### PR TITLE
chore: add v1.0.0 bump changeset

### DIFF
--- a/.changesets/semver-1.0.md
+++ b/.changesets/semver-1.0.md
@@ -1,0 +1,6 @@
+---
+bump: major
+---
+
+- **gmux 1.0.** Semver starts here. No functional changes; this changeset
+  exists solely to bump the version to v1.0.0.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,16 @@ jobs:
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           GOWORK: ${{ github.workspace }}/go.work
 
+      - name: Notify Discord
+        env:
+          WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          ROLE_BREAKING: ${{ vars.DISCORD_ROLE_BREAKING }}
+          ROLE_FEATURE: ${{ vars.DISCORD_ROLE_FEATURE }}
+          ROLE_PATCH: ${{ vars.DISCORD_ROLE_PATCH }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: bash scripts/notify-discord.sh
+
   deploy-docs:
     needs: release
     uses: ./.github/workflows/pages.yml

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -28,11 +28,24 @@ jobs:
       - name: Consume changesets
         if: steps.check.outputs.count != '0'
         id: version
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
         run: |
           output=$(bash scripts/version.sh)
           version=$(echo "$output" | head -1 | awk '{print $1}')
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "$output"
+
+      - name: Prepare PR body
+        if: steps.check.outputs.count != '0'
+        id: body
+        run: |
+          {
+            echo "notes<<NOTES_EOF"
+            cat RELEASE_NOTES.md
+            echo "NOTES_EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Create release PR
         if: steps.check.outputs.count != '0'
@@ -42,10 +55,13 @@ jobs:
           commit-message: "release: ${{ steps.version.outputs.version }}"
           title: "release: ${{ steps.version.outputs.version }}"
           body: |
-            Consuming pending changesets for **${{ steps.version.outputs.version }}**.
+            Release **${{ steps.version.outputs.version }}**.
 
-            Review the changelog entry, edit if needed, then merge.
             Merging creates the `${{ steps.version.outputs.version }}` tag and triggers the release build.
+
+            ---
+
+            ${{ steps.body.outputs.notes }}
           branch: release/next
           delete-branch: true
 
@@ -54,16 +70,23 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          cat <<EOF | gh pr edit "${{ steps.create-pr.outputs.pull-request-number }}" --body-file -
-          Consuming pending changesets for **${{ steps.version.outputs.version }}**.
+          version="${{ steps.version.outputs.version }}"
+          pr_num="${{ steps.create-pr.outputs.pull-request-number }}"
+          notes=$(cat RELEASE_NOTES.md)
 
-          Review the changelog entry, edit if needed, then merge.
-          Merging creates the \`${{ steps.version.outputs.version }}\` tag and triggers the release build.
+          cat <<EOF | gh pr edit "$pr_num" --body-file -
+          Release **${version}**.
+
+          Merging creates the \`${version}\` tag and triggers the release build.
 
           ### Try this prerelease
           \`\`\`sh
-          curl -sSfL https://gmux.app/install-pr.sh | sh -s -- ${{ steps.create-pr.outputs.pull-request-number }}
+          curl -sSfL https://gmux.app/install-pr.sh | sh -s -- ${pr_num}
           \`\`\`
+
+          ---
+
+          ${notes}
           EOF
 
   # When the release PR itself merges (deleting changeset files), this

--- a/scripts/notify-discord.sh
+++ b/scripts/notify-discord.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Send a Discord release notification via webhook.
+#
+# Expects these environment variables:
+#   WEBHOOK_URL    - Discord webhook URL (skips silently if empty)
+#   VERSION        - Release version tag (e.g. v0.9.0)
+#   ROLE_BREAKING  - Discord role ID for breaking changes
+#   ROLE_FEATURE   - Discord role ID for feature releases
+#   ROLE_PATCH     - Discord role ID for patch releases
+set -euo pipefail
+
+if [[ -z "${WEBHOOK_URL:-}" ]]; then
+  echo "DISCORD_WEBHOOK_URL not set, skipping notification"
+  exit 0
+fi
+
+: "${VERSION:?}"
+: "${ROLE_BREAKING:?}"
+: "${ROLE_FEATURE:?}"
+: "${ROLE_PATCH:?}"
+
+# ── Extract summary ──
+
+# RELEASE_NOTES.md has the summary above a --- separator, then the PR list.
+summary=$(sed '/^---$/,$d' RELEASE_NOTES.md)
+# Trim trailing blank lines.
+summary=$(echo "$summary" | sed -e :a -e '/^\n*$/{$d;N;ba}')
+
+# ── Determine bump type ──
+
+prev_tag=$(git tag -l 'v*' | sort -V | grep -B1 "^${VERSION}$" | head -1)
+cur_major=$(echo "$VERSION" | sed 's/^v//' | cut -d. -f1)
+cur_minor=$(echo "$VERSION" | sed 's/^v//' | cut -d. -f2)
+prev_major=$(echo "$prev_tag" | sed 's/^v//' | cut -d. -f1)
+prev_minor=$(echo "$prev_tag" | sed 's/^v//' | cut -d. -f2)
+
+if [[ "$cur_major" != "$prev_major" ]]; then
+  role_id="$ROLE_BREAKING"
+elif [[ "$cur_minor" != "$prev_minor" ]]; then
+  role_id="$ROLE_FEATURE"
+else
+  role_id="$ROLE_PATCH"
+fi
+
+# ── Send ──
+
+header="<@&${role_id}>
+## gmux ${VERSION}"
+footer="[See the changelog for details.](https://gmux.app/changelog)"
+overhead=$(( ${#header} + ${#footer} + 4 ))
+
+# Condense the summary if the full message would exceed Discord's 2000 char limit.
+if [[ $(( ${#summary} + overhead )) -gt 2000 ]]; then
+  max_chars=$(( 2000 - overhead ))
+  echo "Summary too long for Discord ($(( ${#summary} + overhead )) chars), condensing..."
+  summary=$(echo "$summary" | "$(dirname "$0")/summarize.sh" --condense "$max_chars")
+fi
+
+message="${header}
+
+${summary}
+
+${footer}"
+
+# Hard truncation as a last resort.
+if [[ ${#message} -gt 2000 ]]; then
+  message="${message:0:1997}..."
+fi
+
+payload=$(jq -n \
+  --arg content "$message" \
+  --arg role_id "$role_id" \
+  '{
+    content: $content,
+    allowed_mentions: { roles: [$role_id] }
+  }')
+
+curl -sf -H "Content-Type: application/json" -d "$payload" "$WEBHOOK_URL"
+echo "Discord notification sent for ${VERSION}"

--- a/scripts/summarize.sh
+++ b/scripts/summarize.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Generate or condense a release summary using OpenRouter's best free model.
+#
+# Usage:
+#   scripts/summarize.sh <version>              < notes.txt   # summarize
+#   scripts/summarize.sh --condense <max_chars> < summary.txt # condense
+#
+# Falls back to a placeholder (or truncation for --condense) if the API is
+# unavailable or OPENROUTER_API_KEY is not set.
+set -euo pipefail
+
+condense=false
+if [[ "${1:-}" == "--condense" ]]; then
+  condense=true
+  max_chars="${2:?Usage: summarize.sh --condense <max_chars>}"
+else
+  version="${1:?Usage: summarize.sh <version>}"
+fi
+
+input=$(cat)
+
+if [[ -z "${OPENROUTER_API_KEY:-}" ]]; then
+  if $condense; then
+    echo "${input:0:$max_chars}"
+  else
+    echo "_No summary available._"
+  fi
+  exit 0
+fi
+
+# ── Pick model ──
+
+# First free model in OpenRouter's default ordering (correlates with
+# popularity) with a reasonable context window.
+model=$(curl -sf 'https://openrouter.ai/api/v1/models' | jq -r '
+  [.data[]
+    | select(.id | endswith(":free"))
+    | select(.context_length >= 32000)
+  ] | .[0].id')
+
+if [[ -z "$model" || "$model" == "null" ]]; then
+  echo "Could not select a model." >&2
+  if $condense; then
+    echo "${input:0:$max_chars}"
+  else
+    echo "_No summary available._"
+  fi
+  exit 0
+fi
+
+echo "Using model: $model" >&2
+
+# ── Build prompt ──
+
+if $condense; then
+  prompt="Condense the following release summary to ${max_chars} characters \
+or fewer. Preserve the section structure (**Breaking changes**, **Features**, \
+**Fixes**). Keep the high-level picture and key migration actions; cut \
+implementation details and specific flag/env var names. Do not add anything \
+new. Output only the condensed summary.
+
+${input}"
+  max_tokens=500
+else
+  prompt="gmux is an open-source terminal multiplexer with a web UI. Below \
+is the content for a release. Each entry has a user-facing changelog note \
+followed by the PR description for context. Summarize them into a Discord \
+message for the project's community server.
+
+Base the summary on the changelog notes, not the PR implementation details. \
+The PR descriptions are background context to help you understand the change, \
+not content to surface to users.
+
+Be direct, technical, and accurate. Assume readers are developers who use \
+the tool daily. No hype, no filler, no calls to action.
+
+Group by change type, skipping empty sections: breaking changes first, then \
+features, then fixes. Multiple entries may be part of the same effort; cover \
+them once. A link to the full changelog follows the summary, so focus on the \
+highlights rather than being exhaustive.
+
+Use Discord markdown. Use - for bullet points. Do not include a title, \
+heading, or links.
+
+Changelog for ${version}:
+${input}"
+  max_tokens=800
+fi
+
+# ── Call API with retries ──
+
+for attempt in 1 2 3; do
+  response=$(curl -s https://openrouter.ai/api/v1/chat/completions \
+    -H "Authorization: Bearer $OPENROUTER_API_KEY" \
+    -H "Content-Type: application/json" \
+    -d "$(jq -n \
+      --arg model "$model" \
+      --arg prompt "$prompt" \
+      --argjson max_tokens "$max_tokens" \
+      '{
+        model: $model,
+        messages: [{role: "user", content: $prompt}],
+        max_tokens: $max_tokens
+      }')")
+
+  result=$(echo "$response" | jq -r '.choices[0].message.content // empty')
+  if [[ -n "$result" ]]; then
+    echo "$result"
+    exit 0
+  fi
+
+  echo "Attempt $attempt failed, retrying in $((attempt * 2))s..." >&2
+  sleep $((attempt * 2))
+done
+
+echo "Summary generation failed after 3 attempts." >&2
+if $condense; then
+  echo "${input:0:$max_chars}"
+else
+  echo "_No summary available._"
+fi

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -82,21 +82,19 @@ case "$bump" in
 esac
 new_version="$major.$minor.$patch_v"
 
-# ── Collect changelog entries ──
+# ── Map changesets to PRs ──
 
 # Derive the GitHub repo URL for PR links.
 remote_url=$(git remote get-url origin 2>/dev/null || true)
 repo_url=$(echo "$remote_url" | sed -E 's|\.git$||; s|^git@github\.com:|https://github.com/|')
 
-# Extract body (everything after the second ---) from each changeset.
-# Each entry becomes a bullet point with a PR link appended.
-entries=""
+declare -A pr_bumps       # pr_num -> highest bump level (major > minor > patch)
+declare -A pr_changelogs  # pr_num -> concatenated changeset bodies
+
 for f in "${changesets[@]}"; do
+  file_bump=$(awk '/^---$/{n++; next} n==1 && /^bump:/{print $2}' "$f" | tr -d '[:space:]')
   body=$(awk '/^---$/{n++; next} n>=2{print}' "$f")
   body=$(echo "$body" | sed '/./,$!d' | sed -e :a -e '/^\n*$/{$d;N;ba}')
-  if [[ "$body" != "- "* ]]; then
-    body="- $body"
-  fi
 
   # Find the PR that introduced this changeset (from merge commit message).
   pr_num=""
@@ -104,14 +102,72 @@ for f in "${changesets[@]}"; do
   if [[ "$commit_msg" =~ \(#([0-9]+)\) ]]; then
     pr_num="${BASH_REMATCH[1]}"
   fi
-  if [[ -n "$pr_num" && -n "$repo_url" ]]; then
-    body+=" ([#${pr_num}](${repo_url}/pull/${pr_num}))"
+
+  # Track highest bump per PR.
+  if [[ -n "$pr_num" ]]; then
+    existing="${pr_bumps[$pr_num]:-}"
+    case "$file_bump" in
+      major) pr_bumps[$pr_num]="major" ;;
+      minor) [[ "$existing" != "major" ]] && pr_bumps[$pr_num]="minor" ;;
+      patch) [[ -z "$existing" ]] && pr_bumps[$pr_num]="patch" ;;
+    esac
+    pr_changelogs[$pr_num]+="$body"$'\n'
+  fi
+done
+
+# ── Fetch PR content and build list ──
+
+declare -A pr_titles
+llm_input=""
+breaking_items=()
+feature_items=()
+fix_items=()
+
+for pr_num in $(echo "${!pr_bumps[@]}" | tr ' ' '\n' | sort -n); do
+  pr_json=$(gh pr view "$pr_num" --json title,body 2>/dev/null || echo '{}')
+  pr_title=$(echo "$pr_json" | jq -r '.title // "#'"$pr_num"'"')
+  pr_body=$(echo "$pr_json" | jq -r '.body // ""')
+  pr_titles[$pr_num]="$pr_title"
+
+  llm_input+="## ${pr_title} (#${pr_num})"$'\n\n'
+  llm_input+="### Changelog note"$'\n'
+  llm_input+="${pr_changelogs[$pr_num]:-}"$'\n\n'
+  if [[ -n "$pr_body" ]]; then
+    llm_input+="### PR description"$'\n'
+    llm_input+="${pr_body}"$'\n\n'
   fi
 
-  entries+="$body"$'\n'
+  item="- ${pr_title} ([#${pr_num}](${repo_url}/pull/${pr_num}))"
+  case "${pr_bumps[$pr_num]}" in
+    major) breaking_items+=("$item") ;;
+    minor) feature_items+=("$item") ;;
+    patch) fix_items+=("$item") ;;
+  esac
 done
-# Remove trailing newlines
-entries=$(echo "$entries" | sed -e :a -e '/^\n*$/{$d;N;ba}')
+
+# ── Summarize ──
+
+summary=$(echo "$llm_input" | "$ROOT/scripts/summarize.sh" "v$new_version")
+
+# ── Build grouped PR list ──
+
+pr_list=""
+if [[ ${#breaking_items[@]} -gt 0 ]]; then
+  pr_list+="### Breaking"$'\n'
+  for item in "${breaking_items[@]}"; do pr_list+="$item"$'\n'; done
+  pr_list+=$'\n'
+fi
+if [[ ${#feature_items[@]} -gt 0 ]]; then
+  pr_list+="### Features"$'\n'
+  for item in "${feature_items[@]}"; do pr_list+="$item"$'\n'; done
+  pr_list+=$'\n'
+fi
+if [[ ${#fix_items[@]} -gt 0 ]]; then
+  pr_list+="### Fixes"$'\n'
+  for item in "${fix_items[@]}"; do pr_list+="$item"$'\n'; done
+  pr_list+=$'\n'
+fi
+pr_list=$(echo "$pr_list" | sed -e :a -e '/^\n*$/{$d;N;ba}')
 
 # ── Output ──
 
@@ -119,16 +175,26 @@ echo "v$new_version ($bump)"
 
 if $DRY_RUN; then
   echo ""
-  echo "$entries"
+  echo "$summary"
+  echo ""
+  echo "---"
+  echo ""
+  echo "$pr_list"
   exit 0
 fi
 
 # ── Write release notes file ──
 #
 # GoReleaser uses this via --release-notes to populate the GitHub Release body.
-# Kept at a fixed path so .goreleaser.yml doesn't need to change per release.
+# The --- separator lets scripts/notify-discord.sh extract just the summary.
 
-echo "$entries" > "$ROOT/RELEASE_NOTES.md"
+cat > "$ROOT/RELEASE_NOTES.md" <<EOF
+${summary}
+
+---
+
+${pr_list}
+EOF
 
 # ── Update changelog.mdx ──
 #
@@ -137,7 +203,9 @@ echo "$entries" > "$ROOT/RELEASE_NOTES.md"
 
 new_section="## v${new_version}
 
-${entries}
+${summary}
+
+${pr_list}
 
 ---"
 


### PR DESCRIPTION
Dummy changeset to bump the version to v1.0.0. No functional changes.

This is the last changeset. Merge after PR #52 lands. The version workflow will create a release PR for v1.0.0, which ships the pending changes (remote grouping, unix socket IPC) as the first semver release.