### PR TITLE
feat: auto-create project when launching into unmatched directory

### DIFF
--- a/.changesets/launch-auto-add-project.md
+++ b/.changesets/launch-auto-add-project.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+- **Auto-create projects for launched sessions.** When you launch a session from the home screen and it doesn't match any configured project, a project is automatically created from the session's metadata (remote URL, workspace root, or cwd). Works for both local and peer launches.

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -45,6 +45,51 @@ import (
 // version is set at build time via -ldflags "-X main.version=..."
 var version = "dev"
 
+// recentLaunches tracks sessions started via /v1/launch so we can
+// auto-create projects for them if they don't match an existing one.
+// Entries expire after 30 seconds.
+type launchTracker struct {
+	mu    sync.Mutex
+	peers map[string]time.Time // peer name → launch time
+	local []time.Time          // local launch timestamps
+}
+
+func (lt *launchTracker) recordLocal()          { lt.mu.Lock(); lt.local = append(lt.local, time.Now()); lt.mu.Unlock() }
+func (lt *launchTracker) recordPeer(peer string) { lt.mu.Lock(); lt.peers[peer] = time.Now(); lt.mu.Unlock() }
+
+// claimLocal returns true if a local launch was recorded within the last 30s.
+func (lt *launchTracker) claimLocal() bool {
+	lt.mu.Lock()
+	defer lt.mu.Unlock()
+	now := time.Now()
+	// Prune expired, claim newest valid.
+	valid := lt.local[:0]
+	claimed := false
+	for _, t := range lt.local {
+		if now.Sub(t) >= 30*time.Second {
+			continue // expired
+		}
+		if !claimed {
+			claimed = true // consume one
+			continue
+		}
+		valid = append(valid, t)
+	}
+	lt.local = valid
+	return claimed
+}
+
+// claimPeer returns true if a launch on the given peer was recorded within the last 30s.
+func (lt *launchTracker) claimPeer(peer string) bool {
+	lt.mu.Lock()
+	defer lt.mu.Unlock()
+	if t, ok := lt.peers[peer]; ok && time.Since(t) < 30*time.Second {
+		delete(lt.peers, peer)
+		return true
+	}
+	return false
+}
+
 type LaunchConfig struct {
 	DefaultLauncher string             `json:"default_launcher"`
 	Launchers       []adapter.Launcher `json:"launchers"`
@@ -463,6 +508,9 @@ func serve(stderr io.Writer) int {
 	}
 	go scanner.Run(30*time.Second, stopScanner)
 
+	// Track recently launched sessions for project auto-creation.
+	launches := &launchTracker{peers: make(map[string]time.Time)}
+
 	// Auto-assign sessions to projects when they appear or get a ResumeKey.
 	sessionEvents, unsubSessionEvents := sessions.Subscribe()
 	defer unsubSessionEvents()
@@ -478,14 +526,27 @@ func serve(stderr io.Writer) int {
 			if !s.Alive {
 				continue
 			}
-			projectMgr.AutoAssignSession(projects.SessionInfo{
+			info := projects.SessionInfo{
 				ID:            s.ID,
 				Cwd:           s.Cwd,
 				WorkspaceRoot: s.WorkspaceRoot,
 				Remotes:       s.Remotes,
 				Alive:         s.Alive,
 				ResumeKey:     s.ResumeKey,
-			})
+			}
+			if slug := projectMgr.AutoAssignSession(info); slug != "" {
+				continue
+			}
+			// No project matched. If this was an explicit launch, auto-create.
+			if s.Peer == "" {
+				if launches.claimLocal() {
+					projectMgr.EnsureProjectForSession(info)
+				}
+			} else {
+				if launches.claimPeer(s.Peer) {
+					projectMgr.EnsureProjectForSession(info)
+				}
+			}
 		}
 	}()
 
@@ -806,6 +867,10 @@ func serve(stderr io.Writer) int {
 				return
 			}
 			if peer := peerManager.GetPeer(req.Peer); peer != nil {
+				// Record before forwarding: the peer's SSE event may arrive
+				// before ForwardLaunch returns. 30s TTL limits false matches
+				// if the forward fails.
+				launches.recordPeer(req.Peer)
 				r.Body = io.NopCloser(bytes.NewReader(body))
 				peer.ForwardLaunch(w, r)
 				return
@@ -857,6 +922,7 @@ func serve(stderr io.Writer) int {
 			return
 		}
 
+		launches.recordLocal()
 		log.Printf("launch: started gmux pid=%d cwd=%s cmd=%v", pid, cwd, req.Command)
 		writeJSON(w, map[string]any{
 			"ok":   true,

--- a/services/gmuxd/internal/projects/manager.go
+++ b/services/gmuxd/internal/projects/manager.go
@@ -135,6 +135,78 @@ func (m *Manager) AutoAssignAllAlive(sessions []SessionInfo) {
 	}
 }
 
+// EnsureProjectForSession creates a project for a session that doesn't match
+// any existing project. Used when a session is explicitly launched (via /v1/launch)
+// and would otherwise be orphaned. Returns the new project slug, or "" if a
+// matching project already exists.
+func (m *Manager) EnsureProjectForSession(info SessionInfo) string {
+	var created string
+	err := m.Update(func(state *State) bool {
+		key := SessionKey(info.ID, info.ResumeKey)
+
+		// Already assigned?
+		if state.FindSessionProject(key) != "" {
+			return false
+		}
+
+		// Already matches a project?
+		if state.Match(info.Cwd, info.WorkspaceRoot, info.Remotes) != nil {
+			return false
+		}
+
+		// Derive project metadata from the session.
+		// Prefer the "origin" remote; fall back to any other.
+		var remote string
+		if url, ok := info.Remotes["origin"]; ok {
+			remote = NormalizeRemote(url)
+		} else {
+			for _, url := range info.Remotes {
+				remote = NormalizeRemote(url)
+				break
+			}
+		}
+
+		path := info.WorkspaceRoot
+		if path == "" {
+			path = info.Cwd
+		}
+		if path == "" {
+			return false
+		}
+
+		var slug string
+		if remote != "" {
+			slug = SlugFromRemote(remote)
+		} else {
+			slug = SlugFromPath(path)
+		}
+		slug = UniqueSlug(slug, state.Items)
+
+		item := Item{
+			Slug:     slug,
+			Remote:   remote,
+			Paths:    []string{NormalizePath(path)},
+			Sessions: []string{key},
+		}
+		state.Items = append(state.Items, item)
+
+		if err := state.Validate(); err != nil {
+			log.Printf("projects: auto-create validation error: %v", err)
+			// Roll back the append.
+			state.Items = state.Items[:len(state.Items)-1]
+			return false
+		}
+
+		created = slug
+		log.Printf("projects: auto-created project %q for session %s (path=%s)", slug, info.ID, path)
+		return true
+	})
+	if err != nil {
+		log.Printf("projects: auto-create error: %v", err)
+	}
+	return created
+}
+
 // CleanupSessions removes orphaned entries from all project session arrays.
 // An entry is orphaned if its key doesn't appear in the known set. Call this
 // after the initial session scan so the store has the full picture.

--- a/services/gmuxd/internal/projects/projects_test.go
+++ b/services/gmuxd/internal/projects/projects_test.go
@@ -897,3 +897,92 @@ func TestManagerAutoAssignAllAlive(t *testing.T) {
 		t.Errorf("yapp sessions: expected [s2], got %v", state.Items[1].Sessions)
 	}
 }
+
+func TestEnsureProjectForSession(t *testing.T) {
+	t.Run("skips sessions that match existing project", func(t *testing.T) {
+		dir := t.TempDir()
+		mgr := NewManager(dir)
+		mgr.Update(func(s *State) bool {
+			s.Items = []Item{{Slug: "gmux", Paths: []string{"/dev/gmux"}}}
+			return true
+		})
+
+		slug := mgr.EnsureProjectForSession(SessionInfo{
+			ID: "s1", Cwd: "/dev/gmux/src", Alive: true,
+		})
+		if slug != "" {
+			t.Errorf("expected no creation for matching session, got %q", slug)
+		}
+	})
+
+	t.Run("creates project from remote and workspace_root", func(t *testing.T) {
+		dir := t.TempDir()
+		mgr := NewManager(dir)
+
+		slug := mgr.EnsureProjectForSession(SessionInfo{
+			ID: "s1", Cwd: "/home/mg", WorkspaceRoot: "/home/mg/dev/myapp",
+			Remotes: map[string]string{"origin": "github.com/me/myapp.git"}, Alive: true,
+		})
+		if slug != "myapp" {
+			t.Fatalf("expected slug 'myapp', got %q", slug)
+		}
+
+		state, _ := mgr.Load()
+		item := state.Items[0]
+		if item.Remote != "github.com/me/myapp" {
+			t.Errorf("remote: got %q", item.Remote)
+		}
+		if item.Paths[0] != "/home/mg/dev/myapp" {
+			t.Errorf("path: got %q", item.Paths[0])
+		}
+		if len(item.Sessions) != 1 || item.Sessions[0] != "s1" {
+			t.Errorf("sessions: got %v", item.Sessions)
+		}
+	})
+
+	t.Run("prefers origin remote for slug", func(t *testing.T) {
+		dir := t.TempDir()
+		mgr := NewManager(dir)
+
+		slug := mgr.EnsureProjectForSession(SessionInfo{
+			ID: "s1", Cwd: "/dev/x",
+			Remotes: map[string]string{
+				"upstream": "github.com/other/upstream-name.git",
+				"origin":   "github.com/me/my-fork.git",
+			}, Alive: true,
+		})
+		if slug != "my-fork" {
+			t.Errorf("expected 'my-fork', got %q", slug)
+		}
+	})
+
+	t.Run("second session in same dir reuses project", func(t *testing.T) {
+		dir := t.TempDir()
+		mgr := NewManager(dir)
+
+		mgr.EnsureProjectForSession(SessionInfo{
+			ID: "s1", Cwd: "/home/mg", Alive: true,
+		})
+		slug := mgr.EnsureProjectForSession(SessionInfo{
+			ID: "s2", Cwd: "/home/mg", Alive: true,
+		})
+		if slug != "" {
+			t.Errorf("expected no creation (Match hits existing), got %q", slug)
+		}
+	})
+
+	t.Run("duplicate slug gets suffixed", func(t *testing.T) {
+		dir := t.TempDir()
+		mgr := NewManager(dir)
+
+		mgr.EnsureProjectForSession(SessionInfo{
+			ID: "s1", Cwd: "/a/myapp", Alive: true,
+		})
+		slug := mgr.EnsureProjectForSession(SessionInfo{
+			ID: "s2", Cwd: "/b/myapp", Alive: true,
+		})
+		if slug != "myapp-2" {
+			t.Errorf("expected 'myapp-2', got %q", slug)
+		}
+	})
+}


### PR DESCRIPTION
When you launch a session from the home screen (local or on a peer) and the resulting session doesn't match any configured project, a project is automatically created from the session's metadata.

## How it works

`/v1/launch` records the launch in a `launchTracker` (30s TTL). When the session registers and `AutoAssignSession` finds no match, the handler checks whether a recent launch was recorded. If so, `EnsureProjectForSession` creates a project using:

- **Slug**: derived from the origin remote URL, or the path basename
- **Remote**: normalized origin remote (enables cross-machine matching)
- **Path**: workspace_root (preferred) or cwd
- **Sessions**: the new session is immediately added

Only explicitly launched sessions trigger creation. Organic discovery (existing processes, peer sync on first connect) does not.

## Changes

- `projects.Manager.EnsureProjectForSession`: creates a project from session metadata if no match exists. Prefers `origin` remote for slug derivation. Validates before saving, rolls back on failure.
- `launchTracker` in main.go: tracks local launch timestamps and per-peer launch times. `claimLocal`/`claimPeer` consume entries (one-shot), prune expired entries.
- 5 subtests covering: skip on match, create from remote+workspace_root, origin preference, same-dir dedup, slug collision suffixing