### PR TITLE
fix: dismissed sessions no longer reappear after scanner cycle

### DIFF
--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -359,6 +359,7 @@ export function killSession(sessionId: string): Promise<void> {
 }
 
 export function dismissSession(sessionId: string): Promise<void> {
+  removeSession(sessionId)
   return postAction(`/v1/sessions/${sessionId}/dismiss`)
 }
 

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -1138,6 +1138,8 @@ func serve(stderr io.Writer) int {
 			}
 			// Remove session from its project's sessions array.
 			projectMgr.DismissSession(sessionID, sess.ResumeKey)
+			// Mark as dismissed so the file scanner doesn't re-create it.
+			sessions.Dismiss(sessionID)
 			// Remove from store — broadcasts session-remove to all clients.
 			sessions.Remove(sessionID)
 			if subs != nil {

--- a/services/gmuxd/internal/sessionfiles/scanner.go
+++ b/services/gmuxd/internal/sessionfiles/scanner.go
@@ -105,6 +105,11 @@ func (sc *Scanner) Scan() {
 				continue
 			}
 
+			// Skip sessions the user explicitly dismissed.
+			if sc.store.IsDismissed("file-" + info.ID[:8]) {
+				continue
+			}
+
 			if hasResume && !resumer.CanResume(path) {
 				continue
 			}

--- a/services/gmuxd/internal/sessionfiles/scanner_test.go
+++ b/services/gmuxd/internal/sessionfiles/scanner_test.go
@@ -131,6 +131,67 @@ func TestScanRediscoversAfterRemove(t *testing.T) {
 	}
 }
 
+func TestScanSkipsDismissedSessions(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	sessID := "aaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	writePiSession(t, tmpHome, "/tmp/project", sessID, "hello")
+
+	s := newTestStore()
+	sc := New(s)
+	sc.Scan()
+
+	if len(s.List()) != 1 {
+		t.Fatal("expected 1 session from initial scan")
+	}
+	fileID := s.List()[0].ID // "file-aaaa-bbb"
+
+	// Dismiss + remove (as the dismiss handler does).
+	s.Dismiss(fileID)
+	s.Remove(fileID)
+	if len(s.List()) != 0 {
+		t.Fatal("expected 0 sessions after dismiss")
+	}
+
+	// Rescan: dismissed session should NOT come back.
+	sc.Scan()
+	if len(s.List()) != 0 {
+		t.Errorf("expected 0 sessions after rescan (dismissed), got %d", len(s.List()))
+	}
+}
+
+func TestDismissedSessionReappearsAfterResume(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	sessID := "aaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	writePiSession(t, tmpHome, "/tmp/project", sessID, "hello")
+
+	s := newTestStore()
+	sc := New(s)
+	sc.Scan()
+
+	fileID := s.List()[0].ID
+
+	// Dismiss + remove.
+	s.Dismiss(fileID)
+	s.Remove(fileID)
+
+	// Simulate a resume: the tool re-launches and discovery registers
+	// a live session with the same ID.
+	s.Upsert(store.Session{ID: fileID, Alive: true, Kind: "pi", Cwd: "/tmp/project"})
+
+	// The live session clears the dismissed flag. After it exits and
+	// is removed, the scanner should rediscover it.
+	s.Remove(fileID)
+	sc.Scan()
+
+	if len(s.List()) != 1 {
+		t.Errorf("expected 1 session after resume+exit+rescan, got %d", len(s.List()))
+	}
+}
+
 func TestScanUsesFileHeaderCwd(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)

--- a/services/gmuxd/internal/store/store.go
+++ b/services/gmuxd/internal/store/store.go
@@ -124,12 +124,18 @@ type Store struct {
 	sessions       map[string]Session
 	subscribers    map[*subscriber]struct{}
 	commandTitlers map[string]func([]string) string
+
+	// dismissed tracks session IDs that were explicitly dismissed by the
+	// user. The file scanner checks this to avoid re-creating sessions
+	// from files that are still on disk. In-memory only; resets on restart.
+	dismissed map[string]bool
 }
 
 func New() *Store {
 	return &Store{
 		sessions:    make(map[string]Session),
 		subscribers: make(map[*subscriber]struct{}),
+		dismissed:   make(map[string]bool),
 	}
 }
 
@@ -187,6 +193,11 @@ func (s *Store) Upsert(sess Session) {
 	if !skip {
 		s.ensureUniqueResumeKey(&sess)
 		s.sessions[sess.ID] = sess
+		// A live session clears any dismissed flag so that if it later
+		// exits the file scanner can rediscover it as resumable.
+		if sess.Alive {
+			delete(s.dismissed, sess.ID)
+		}
 	}
 	s.mu.Unlock()
 
@@ -326,6 +337,24 @@ func (s *Store) Remove(id string) bool {
 		})
 	}
 	return ok
+}
+
+// Dismiss marks a session ID as explicitly dismissed by the user.
+// Dismissed IDs are checked by the file scanner to prevent re-creation
+// from session files still on disk. Clearing the dismissed flag happens
+// automatically when the same ID is re-inserted via Upsert (e.g. the
+// user resumes the session from the tool's own TUI).
+func (s *Store) Dismiss(id string) {
+	s.mu.Lock()
+	s.dismissed[id] = true
+	s.mu.Unlock()
+}
+
+// IsDismissed reports whether a session ID was explicitly dismissed.
+func (s *Store) IsDismissed(id string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.dismissed[id]
 }
 
 // RemoveByPeer removes all sessions belonging to a peer and broadcasts


### PR DESCRIPTION
The file scanner runs every 30s and re-creates resumable entries from session files on disk. When a user dismissed a session, it was removed from the in-memory store but the file remained, so the scanner would resurrect it on the next cycle.

Fix: `Store.Dismiss(id)` marks a session as explicitly dismissed. The scanner checks `IsDismissed` before upserting file-scanned entries. The flag is cleared when a live session with the same ID is upserted (e.g. the user resumes it from the tool), so the normal lifecycle is preserved.

The dismissed set is in-memory only and resets on daemon restart, which matches user expectations: a restart is a fresh start, and sessions that were dismissed before would need re-dismissal anyway if the user still wants them gone.