### PR TITLE
fix: hub-and-spoke peering prevents duplicate sessions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,10 @@ Prioritize verifiable, correct behavior above all else. If something has lots of
 
 Never add new state without justification. Before adding a field, ask: who owns it, who updates it, and can it be derived from existing state instead? Prefer derivation over storage. New state creates maintenance burden, sync bugs, and lifecycle complexity.
 
+## Peering model
+
+Hub-and-spoke: each node's SSE stream only includes sessions it **owns** (local + devcontainer). Network peer sessions are excluded. `PeerConfig.Local` distinguishes the two: only the Docker watcher sets it. Tailscale-discovered and manual peers are not Local.
+
 ## Other rules
 
 - Push changes and create pull requests

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -1271,9 +1271,44 @@ func serve(stderr io.Writer) int {
 			return
 		}
 
-		// Send current state as upserts
+		// isOwned reports whether a session belongs to this node.
+		// Local sessions (Peer=="") and devcontainer sessions (Local
+		// peer) are owned; network peer sessions are not forwarded.
+		isOwned := func(s *store.Session) bool {
+			if s.Peer == "" {
+				return true
+			}
+			return peerManager != nil && peerManager.IsLocalPeer(s.Peer)
+		}
+
+		// isOwnedEvent checks a store event. Session-upsert carries
+		// the full session; remove/activity only have the ID, so we
+		// extract the peer from the namespaced ID. Non-session events
+		// (projects-update, peer-status) are always forwarded.
+		isOwnedEvent := func(ev store.Event) bool {
+			switch ev.Type {
+			case "session-upsert":
+				if ev.Session == nil {
+					return true
+				}
+				return isOwned(ev.Session)
+			case "session-remove", "session-activity":
+				_, peerName := peering.ParseID(ev.ID)
+				if peerName == "" {
+					return true // local
+				}
+				return peerManager != nil && peerManager.IsLocalPeer(peerName)
+			default:
+				return true
+			}
+		}
+
+		// Send current state as upserts (owned sessions only).
 		for _, sess := range sessions.List() {
 			s := sess
+			if !isOwned(&s) {
+				continue
+			}
 			sendSSE(w, "session-upsert", store.Event{
 				Type:    "session-upsert",
 				ID:      s.ID,
@@ -1282,7 +1317,7 @@ func serve(stderr io.Writer) int {
 		}
 		flusher.Flush()
 
-		// Stream updates
+		// Stream updates (owned events only).
 		ch, cancel := sessions.Subscribe()
 		defer cancel()
 
@@ -1294,6 +1329,9 @@ func serve(stderr io.Writer) int {
 			case ev, open := <-ch:
 				if !open {
 					return
+				}
+				if !isOwnedEvent(ev) {
+					continue
 				}
 				sendSSE(w, ev.Type, ev)
 				flusher.Flush()

--- a/services/gmuxd/internal/config/config.go
+++ b/services/gmuxd/internal/config/config.go
@@ -55,6 +55,12 @@ type PeerConfig struct {
 	// TokenCommand is a shell command whose stdout is the bearer token.
 	// Executed via "sh -c" with a 10-second timeout.
 	TokenCommand string `toml:"token_command"`
+
+	// Local marks peers whose sessions this node owns (e.g. devcontainers
+	// on the local Docker daemon). Their sessions are included in the
+	// outgoing SSE stream; network peer sessions are not. Set
+	// programmatically by the devcontainer watcher.
+	Local bool
 }
 
 // DiscoveryConfig controls automatic peer discovery.

--- a/services/gmuxd/internal/devcontainers/watcher.go
+++ b/services/gmuxd/internal/devcontainers/watcher.go
@@ -234,6 +234,7 @@ func (w *Watcher) scan(ctx context.Context) {
 			Name:  name,
 			URL:   url,
 			Token: r.token,
+			Local: true,
 		}
 		log.Printf("devcontainers: discovered %s (container %s, %s)", name, short(r.c.ID), url)
 		w.mgr.AddPeer(cfg)

--- a/services/gmuxd/internal/peering/manager.go
+++ b/services/gmuxd/internal/peering/manager.go
@@ -69,6 +69,15 @@ func (m *Manager) isKnownOrigin(name string) bool {
 	return ok
 }
 
+// IsLocalPeer reports whether name is a local peer (e.g. a devcontainer)
+// whose sessions this node owns and should include in its SSE stream.
+func (m *Manager) IsLocalPeer(name string) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	mp, ok := m.peers[name]
+	return ok && mp.peer.Config.Local
+}
+
 // Start begins background goroutines that connect to each peer.
 func (m *Manager) Start() {
 	ctx, cancel := context.WithCancel(context.Background())

--- a/services/gmuxd/internal/peering/peering.go
+++ b/services/gmuxd/internal/peering/peering.go
@@ -1,12 +1,23 @@
 // Package peering manages connections to remote gmuxd instances (spokes).
 //
-// A hub gmuxd subscribes to each spoke's GET /v1/events SSE stream,
+// Each gmuxd subscribes to its peers' GET /v1/events SSE streams and
 // transforms remote sessions into the local store with namespaced IDs
-// (originalID@peerName), and tracks connection state per peer.
+// (originalID@peerName). Actions and WebSocket connections are routed
+// back to the owning spoke by splitting on the last "@".
 //
-// Remote session IDs use the convention "originalID@peerName". The hub
-// splits on the last "@" to route actions and WebSocket connections back
-// to the owning spoke.
+// # Hub-and-spoke session ownership
+//
+// Each node's SSE stream only includes sessions it owns: local sessions
+// and sessions from Local peers (devcontainers connected via the Docker
+// daemon). Network peer sessions are excluded from the outgoing stream.
+// This prevents duplication when multiple peers aggregate each other.
+// A Tailscale-connected container is independently reachable by every
+// node on the tailnet, so it is not Local and its sessions are not
+// forwarded. A Docker-only devcontainer is only reachable through its
+// host, so it is Local and its sessions are forwarded.
+//
+// As a secondary defense, the receiver drops forwarded sessions whose
+// origin peer is already a direct subscription (matched by name).
 package peering
 
 import (
@@ -70,4 +81,3 @@ func ParseID(namespacedID string) (originalID, peerName string) {
 	}
 	return namespacedID[:i], namespacedID[i+1:]
 }
-

--- a/services/gmuxd/internal/peering/peering_test.go
+++ b/services/gmuxd/internal/peering/peering_test.go
@@ -596,6 +596,28 @@ func TestManager_RemoveNonexistentIsNoop(t *testing.T) {
 	mgr.RemovePeer("nonexistent")
 }
 
+func TestManager_IsLocalPeer(t *testing.T) {
+	st := store.New()
+	mgr := NewManager(nil, st, "test-host")
+	mgr.Start()
+	defer mgr.Stop()
+
+	// Network peer.
+	mgr.AddPeer(config.PeerConfig{Name: "server", URL: "http://10.0.0.5:8790", Token: "t"})
+	// Local peer (devcontainer).
+	mgr.AddPeer(config.PeerConfig{Name: "container-abc", URL: "http://172.17.0.2:8790", Token: "t", Local: true})
+
+	if mgr.IsLocalPeer("server") {
+		t.Error("network peer should not be local")
+	}
+	if !mgr.IsLocalPeer("container-abc") {
+		t.Error("devcontainer peer should be local")
+	}
+	if mgr.IsLocalPeer("unknown") {
+		t.Error("unknown peer should not be local")
+	}
+}
+
 func TestPeerFetchConfig(t *testing.T) {
 	// Spoke returns a launch config.
 	spoke := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1043,7 +1065,6 @@ func TestForwardingFilter_UnknownPeerSessionKept(t *testing.T) {
 
 	mgr.Stop()
 }
-
 
 func TestOnSleep_ReconnectsAndResyncs(t *testing.T) {
 	st := store.New()


### PR DESCRIPTION
## Problem

When peers aggregate each other's sessions (a Tailscale container and its host both on the tailnet), each re-serves the other's data. A consumer connecting to both gets every session twice.

**Before:** 44 duplicate sessions between `dev` and `hs` peers.

## Root cause

Every node's SSE stream included all sessions in its store, including those forwarded from network peers. Two peers subscribing to each other created a mirror.

## Fix: hub-and-spoke SSE output

The `/v1/events` SSE stream now only includes sessions this node **owns**:
- Local sessions (`Peer == ""`)
- Devcontainer sessions (`PeerConfig.Local == true`)

Network peer sessions are excluded. Each node serves what it owns; the consumer aggregates from all spokes directly.

The key insight: a peer discovered via **Tailscale** is independently reachable by every node on the tailnet, so its sessions should not be forwarded. A peer discovered via the **Docker watcher** (devcontainer) has no Tailscale identity and is only reachable through its host, so its sessions should be forwarded. `PeerConfig.Local` encodes exactly this: only the devcontainer watcher sets it to `true`.

This ensures each host appears at most once as a peer to any consumer, eliminating duplication structurally rather than filtering it after the fact.

**After:** 0 duplicates. `dev`: 39 sessions. `hs`: 5 sessions.

## Changes

- `config.PeerConfig.Local` field (`toml:"-"`, set programmatically)
- `devcontainers/watcher.go`: sets `Local: true` on discovered containers
- `peering/manager.go`: `IsLocalPeer()` method
- `peering/peering.go`: updated package doc for hub-and-spoke model
- `cmd/gmuxd/main.go`: SSE handler filters with `isOwned`/`isOwnedEvent`

## Test

- `TestManager_IsLocalPeer`: network peer returns false, devcontainer peer returns true, unknown returns false