### PR TITLE
fix(peering): reliability refactor for remote sessions

### DIFF
--- a/apps/website/src/content/docs/architecture.md
+++ b/apps/website/src/content/docs/architecture.md
@@ -37,7 +37,16 @@ Configuration lives in `~/.config/gmux/host.toml`. See [Configuration](/configur
 
 ### Web UI
 
-The frontend is built with Preact and xterm.js, compiled into a static bundle, and embedded into the `gmuxd` binary via `go:embed`. No separate web server or Node.js runtime is needed. It renders session state as a pure projection of the backend — see [State Management](/develop/state-management) for the data flow details.
+The frontend is built with Preact and xterm.js, compiled into a static bundle, and embedded into the `gmuxd` binary via `go:embed`. No separate web server or Node.js runtime is needed. It renders session state as a pure projection of the backend, see [State Management](/develop/state-management) for the data flow details.
+
+### Shared client packages
+
+`gmuxd` consumes its own public API for peer connections. Two small internal packages hold the protocol primitives:
+
+- **`sseclient`** decodes Server-Sent Events from `/v1/events`. It handles `event:` / `data:` / `:` comment framing, enforces payload size limits, and calls a user-supplied handler per event. Reconnect is the caller's job, matching how the browser's `EventSource` works.
+- **`apiclient`** is a typed wrapper around the public gmuxd API: `GetConfig`, `ForwardAction`, `ForwardLaunch`, `DialWS`, `ProxyWS`, plus `Events` which returns a configured `sseclient`. It sets bearer auth once and accepts an `http.RoundTripper` so Tailscale-discovered peers can route through `tsnet`.
+
+Peer daemons use these packages to talk to other gmuxd instances. There are no peer-only endpoints: if the browser path works, the peer path works, because they both flow through the same code. Read limits, auth, error handling, and keepalive live in one place instead of being duplicated per consumer.
 
 ## Data flow
 

--- a/apps/website/src/content/docs/develop/state-management.md
+++ b/apps/website/src/content/docs/develop/state-management.md
@@ -15,6 +15,12 @@ Session state flows one way: runners and file monitors produce it, `gmuxd` aggre
 
 `store.Remove(id)` broadcasts `session-remove`. There are no other write paths.
 
+### `Upsert` vs `UpsertRemote`
+
+Sessions owned by a peer go through `store.UpsertRemote` instead of `store.Upsert`. The difference is that `UpsertRemote` does **not** re-run `resolveTitle` or re-derive `resumable`: those fields were already authoritatively resolved on the spoke and arrive in the SSE payload. Canonicalization, duplicate-resume-key handling, unique-resume-key numbering, and the broadcast all still run.
+
+This split exists because the spoke keeps `shell_title` and `adapter_title` as internal fields and drops them in `MarshalJSON`. If the hub called `Upsert` on a remote session it would see those fields empty, fall through to the `CommandTitler` or the bare `kind` string, and overwrite the correct spoke-resolved `title`. `UpsertRemote` trusts the spoke. The alternative, putting the internal title fields on the wire, was rejected: it widens the public API surface for a purely internal concern.
+
 ## Who writes what
 
 Each field on a session has a single owner. No two subsystems write the same field.

--- a/apps/website/src/content/docs/multi-machine.md
+++ b/apps/website/src/content/docs/multi-machine.md
@@ -77,11 +77,13 @@ Each spoke connection is independent. When a spoke goes offline:
 - The hub reconnects with exponential backoff.
 - When the spoke comes back, sessions go live again.
 
-A slow or dead spoke never blocks the hub or other spokes.
+A slow or dead spoke never blocks the hub or other spokes. Planned reliability work (connection keepalives, silent-drop detection, and a unified session-identity model) is tracked in [Planned: peer reliability](/planned/peer-reliability).
 
 ## Protocol details
 
-The hub connects to standard gmuxd endpoints on each spoke:
+A peer gmuxd is a regular client of the spoke's public API. There are no peer-only endpoints and no peer-only auth scheme; the hub uses the spoke's bearer token exactly the same way a browser uses it on the TCP listener. If the browser path works, the peer path works.
+
+The hub connects to these public gmuxd endpoints on each spoke:
 
 | Endpoint | Purpose |
 |----------|---------|
@@ -94,4 +96,4 @@ The hub connects to standard gmuxd endpoints on each spoke:
 | `POST /v1/sessions/:id/dismiss` | Forward dismiss |
 | `POST /v1/sessions/:id/resume` | Forward resume |
 
-No new protocol or auth scheme: the hub authenticates with the spoke's bearer token, the same mechanism browsers use for the TCP listener.
+All spoke traffic flows through the same small Go packages (`sseclient` and `apiclient`) that also back internal uses of the public API. See [Architecture: Shared client packages](/architecture#shared-client-packages). That means read limits, auth, and error handling have a single implementation: terminal snapshots up to 4 MiB flow through the WebSocket proxy without tripping size limits, and spoke-resolved session titles are never re-derived on the hub (the hub trusts the spoke's `title` instead of computing one from empty internal fields).

--- a/apps/website/src/content/docs/planned/peer-reliability.md
+++ b/apps/website/src/content/docs/planned/peer-reliability.md
@@ -1,0 +1,98 @@
+---
+title: Peer Reliability
+description: Keepalives, silent-drop detection, and a unified session identity model.
+---
+
+> This feature is not yet implemented.
+
+Remote sessions today work through a single hub-and-spoke protocol that goes through `sseclient` and `apiclient` (see [Multi-Machine](/multi-machine) and [Architecture](/architecture#shared-client-packages)). That refactor gave us one code path per protocol primitive, which is where two reliability improvements now want to live.
+
+## Keepalives and silent-drop detection
+
+Long-lived connections between gmuxd instances can die silently when a NAT rebinds, a Tailscale tunnel hiccups, or a mobile device suspends. The TCP socket stays open from both sides, but no bytes flow, and neither side notices until the next write fails (which on an idle SSE stream may never come).
+
+The plan is to add two cheap mechanisms on top of the shared client packages:
+
+### Server-sent SSE heartbeats
+
+The spoke's SSE handler emits a `:\n\n` comment line every 30 seconds when the event queue is idle. Comment lines are part of the SSE spec, they produce no client-side events, and they work through any HTTP proxy that preserves chunked transfer-encoding. Ten lines of code on the spoke, already supported by `sseclient`.
+
+### Ping ticker on the proxy WebSocket
+
+`apiclient.ProxyWS` runs a 30-second ping ticker on the spoke connection and closes with a distinct error if no pong comes back within 60 seconds. The peering outer loop treats that close like any other disconnect, triggering the existing exponential-backoff reconnect. The browser side already relies on OS TCP keepalive, so nothing changes there.
+
+### Read deadlines
+
+`sseclient` sets a sliding read deadline (refreshed on every event or comment line) so an idle connection trips after the configured window even if the TCP socket never surfaces an error. Same mechanism, different layer, catches the case where the server stops sending heartbeats entirely.
+
+### Tuning
+
+Initial values: 30 s ping, 60 s idle deadline. These numbers are conservative starting points and benefit from real-tailnet testing before being locked in. Landing the keepalive work separately from the [peer refactor](/multi-machine) lets the numbers be tuned without reopening the refactor diff.
+
+## Unified session identity
+
+Session identity today uses several parallel concepts:
+
+| origin | ID shape | stored where | notes |
+|--------|----------|--------------|-------|
+| live runner | UUID from runner | `store.sessions[id]` | |
+| dead session from file | `file-<first8>` | `store.sessions[id]` | prefix avoids clash with live |
+| remote | `<id>@<peer>` | `store.sessions[id]` | namespacing applied by hub |
+| resumable routing | `ResumeKey` (slug) | `store.Session.ResumeKey` | frontend URL stability |
+
+Plus three lifecycle flags that should really be one:
+
+- `Session.Alive` (bool)
+- `Session.Resumable` (bool, derived from `!Alive && len(Command) > 0`)
+- `Store.dismissed` side-map
+
+The dismissed side-map in particular exists because the scanner and the store disagree on whether a dismissed-then-removed session should come back. It's a patch, not a model.
+
+### Target model
+
+```go
+type Session struct {
+    OriginKey string       // immutable, the full UUID or file-backed ID
+    Owner     string       // "" for local, peer name otherwise
+    State     SessionState // alive | resumable | dismissed
+    // ...other metadata...
+}
+
+type SessionState int
+
+const (
+    StateAlive     SessionState = iota // runner is up
+    StateResumable                     // dead, but can be resumed
+    StateDismissed                     // user dismissed, hidden
+)
+
+func (s Session) WireID() string {
+    if s.Owner == "" {
+        return s.OriginKey
+    }
+    return s.OriginKey + "@" + s.Owner
+}
+```
+
+What this changes:
+
+1. **The `file-` prefix disappears.** The scanner emits the full origin key directly. A one-time migration reads existing `file-<first8>` entries and restores the full UUID from the session file they point at.
+2. **`Store.dismissed` disappears.** Dismissal sets `State = StateDismissed` and the store keeps the row; the scanner's "is this already known?" check naturally excludes it because the key is there. Dismiss emits `session-upsert` with the new state, the frontend filters `state === 'dismissed'` from the sidebar (with a "Show dismissed" toggle in settings).
+3. **`Alive` and `Resumable` become derived methods** on `Session` for wire-format backward compatibility. They read from `State` instead of being independently stored. No new storage, just a projection.
+4. **`peering.NamespaceID` / `ParseID` become thin helpers** around `Session.WireID` / `ParseWireID`. Nested peer chains (`sess-xyz@proj@server`) still work because `Owner` can include nested `@` and the split happens on the last one.
+5. **The projects manager keys membership by `(OriginKey, Owner)`** instead of the wire ID string. This is the piece that actually fixes the "same dead session, different representation" bugs that motivated the current state sprawl.
+
+### Why this eliminates the dismissed side-map
+
+With dismissal-as-state, the store never forgets a dismissed session. The scanner sees it in the store, skips it. If the user clicks resume, the state flips back to `StateAlive` via the normal resume path. A subsequent exit takes it to `StateResumable`, not back to dismissed. No scanner special cases, no `Upsert` side effects, no patches.
+
+## Scope and sequencing
+
+The keepalive work and the identity rework are independent and can land in either order. Keepalives are small, mechanical, and benefit from landing first because they improve reliability on the same day they merge. The identity rework is larger, touches the scanner and the frontend, and supersedes the existing dismissed-session fix. They should not be bundled into one PR.
+
+Explicitly out of scope:
+
+- **Reconnect-UUID buffer pattern** (Coder-style). The runner already replays full scrollback on each WebSocket attach, which is the moral equivalent. Revisit only if browser flicker on reconnect becomes a user-visible issue.
+- **Single-WebSocket protocol** that multiplexes state and terminal data. Mature terminal tools (ttyd, gotty, wetty, Coder) don't do this, and the duplication that motivated the refactor lived on the peer side, not the browser side.
+- **Centrifuge or other real-time messaging libraries.** Wrong abstraction layer, large dependency, solves problems we don't have.
+- **Hub-side caching of shared spoke WebSocket connections.** One WebSocket per attach stays. The resource cost is negligible for a self-hosted single-user app.

--- a/services/gmuxd/internal/apiclient/client.go
+++ b/services/gmuxd/internal/apiclient/client.go
@@ -1,0 +1,353 @@
+// Package apiclient is a typed Go client for the gmuxd public HTTP API.
+//
+// It wraps the small number of endpoints a peer daemon (or any other
+// programmatic client) needs: SSE event subscription, config and
+// health fetch, session action forwarding, launch forwarding, and
+// WebSocket proxying for terminal attachment.
+//
+// The goal is that any Go code talking to gmuxd goes through this
+// client rather than hand-rolling http.Client calls. That keeps auth,
+// read limits, timeouts, and keepalive policy in one place, and makes
+// sure a fix in one consumer (e.g. the hub WS proxy read limit) also
+// benefits every other consumer (the CLI, tests, future tools).
+//
+// Client is safe for concurrent use by multiple goroutines: each
+// method builds its own http.Request against the shared http.Client
+// and does not touch Client state.
+package apiclient
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"nhooyr.io/websocket"
+
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/sseclient"
+)
+
+// Read limits for ProxyWS. These match the values wsproxy.go uses
+// for the equivalent browser-to-runner hop and fix the long-standing
+// 256 KiB bug in peering.Peer.ProxyWS that caused reconnect loops on
+// remote sessions with large terminals.
+const (
+	// wsClientReadLimit caps the browser → proxy direction. Browsers
+	// only send keyboard input and resize messages, which are tiny.
+	wsClientReadLimit = 256 * 1024
+
+	// wsSpokeReadLimit caps the spoke → proxy direction. The spoke
+	// relays terminal snapshots (full screen state with ANSI
+	// attributes) on each attach; at 174x66 these reach ~1.3 MB, and
+	// we give headroom to 4 MiB to match wsproxy's backend limit.
+	wsSpokeReadLimit = 4 * 1024 * 1024
+)
+
+// httpActionTimeout bounds one-shot REST calls (GetConfig,
+// ForwardAction, ForwardLaunch). Long enough for a slow spoke behind
+// a VPN; short enough that a stuck peer doesn't hang a browser click.
+const httpActionTimeout = 10 * time.Second
+
+// Client is an authenticated HTTP + WebSocket client pointed at one
+// gmuxd instance (the "spoke" from the hub's perspective).
+type Client struct {
+	baseURL   string
+	token     string
+	transport http.RoundTripper
+
+	// httpClient is a long-lived client with no Timeout so SSE
+	// subscriptions can run indefinitely. Short-lived REST calls use
+	// per-request contexts with httpActionTimeout.
+	httpClient *http.Client
+}
+
+// Option configures a Client.
+type Option func(*Client)
+
+// WithBearerToken sets the Authorization: Bearer <token> header on
+// every request. Empty token is ignored (tailscale-discovered peers
+// authenticate via WhoIs instead).
+func WithBearerToken(token string) Option {
+	return func(c *Client) { c.token = token }
+}
+
+// WithTransport sets the http.RoundTripper used for REST and WS
+// calls. Used by tailscale-discovered peers to route through tsnet.
+func WithTransport(t http.RoundTripper) Option {
+	return func(c *Client) { c.transport = t }
+}
+
+// New creates a Client pointed at baseURL (e.g. "http://host:8790").
+// A trailing slash on baseURL is tolerated and stripped.
+func New(baseURL string, opts ...Option) *Client {
+	c := &Client{
+		baseURL: strings.TrimRight(baseURL, "/"),
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	c.httpClient = &http.Client{Transport: c.transport}
+	return c
+}
+
+// BaseURL returns the base URL this client was constructed with.
+func (c *Client) BaseURL() string { return c.baseURL }
+
+// setAuth adds the bearer token to a request if one is configured.
+func (c *Client) setAuth(req *http.Request) {
+	if c.token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
+}
+
+// Events returns an sseclient.Client for this spoke's /v1/events
+// stream, preconfigured with auth and transport. The caller owns the
+// reconnect loop; call Subscribe directly to start streaming.
+func (c *Client) Events() *sseclient.Client {
+	opts := []sseclient.Option{sseclient.WithBearerToken(c.token)}
+	if c.transport != nil {
+		opts = append(opts, sseclient.WithTransport(c.transport))
+	}
+	return sseclient.New(c.baseURL+"/v1/events", opts...)
+}
+
+// GetConfig fetches GET /v1/config and returns the Data field of the
+// response envelope (the raw config JSON, unwrapped).
+//
+// Returns an error if the request fails, the status is not 200, the
+// envelope cannot be decoded, or the response has ok=false.
+func (c *Client) GetConfig(ctx context.Context) (json.RawMessage, error) {
+	ctx, cancel := context.WithTimeout(ctx, httpActionTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/v1/config", nil)
+	if err != nil {
+		return nil, fmt.Errorf("apiclient GetConfig: %w", err)
+	}
+	c.setAuth(req)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("apiclient GetConfig: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("apiclient GetConfig: unexpected status %d", resp.StatusCode)
+	}
+
+	var envelope struct {
+		OK   bool            `json:"ok"`
+		Data json.RawMessage `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		return nil, fmt.Errorf("apiclient GetConfig: decode: %w", err)
+	}
+	if !envelope.OK {
+		return nil, fmt.Errorf("apiclient GetConfig: ok=false")
+	}
+	return envelope.Data, nil
+}
+
+// ForwardAction proxies an HTTP request to the spoke's
+// /v1/sessions/{sessionID}/{action} endpoint. It's the canonical way
+// for a hub to implement kill/resume/dismiss/read/restart on a
+// remote session.
+//
+// The sessionID passed here is the ORIGINAL (unnamespaced) session
+// ID, not the hub's namespaced wire ID. The caller is responsible
+// for stripping the "@peer" suffix before calling.
+func (c *Client) ForwardAction(w http.ResponseWriter, r *http.Request, sessionID, action string) {
+	path := fmt.Sprintf("/v1/sessions/%s/%s", sessionID, action)
+	c.proxyHTTP(w, r, path)
+}
+
+// ForwardLaunch sends a launch request to the spoke's /v1/launch
+// endpoint. The top-level "peer" field is stripped from the request
+// body before forwarding, so the spoke treats the request as a local
+// launch. Leaving the field in place would make the spoke try to
+// forward the request again to a peer of its own with that name
+// (which typically doesn't exist on that side).
+//
+// Returns an HTTP error to the client on invalid JSON, I/O errors,
+// or upstream failures.
+func (c *Client) ForwardLaunch(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(io.LimitReader(r.Body, 4096))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	stripped, err := stripPeerField(body)
+	if err != nil {
+		http.Error(w, "invalid JSON", http.StatusBadRequest)
+		return
+	}
+	r.Body = io.NopCloser(bytes.NewReader(stripped))
+	r.ContentLength = int64(len(stripped))
+	c.proxyHTTP(w, r, "/v1/launch")
+}
+
+// stripPeerField removes the top-level "peer" key from a JSON object
+// body. Kept as a package-level function for unit testability.
+func stripPeerField(body []byte) ([]byte, error) {
+	var req map[string]any
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, err
+	}
+	delete(req, "peer")
+	return json.Marshal(req)
+}
+
+// proxyHTTP forwards an HTTP request to the spoke at the given path
+// and copies the response back to the caller, preserving method,
+// body, status, headers, and Content-Type.
+func (c *Client) proxyHTTP(w http.ResponseWriter, r *http.Request, path string) {
+	ctx, cancel := context.WithTimeout(r.Context(), httpActionTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, r.Method, c.baseURL+path, r.Body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	c.setAuth(req)
+	if ct := r.Header.Get("Content-Type"); ct != "" {
+		req.Header.Set("Content-Type", ct)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		log.Printf("apiclient: forward %s: %v", path, err)
+		http.Error(w, "peer unavailable", http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+
+	for k, vv := range resp.Header {
+		for _, v := range vv {
+			w.Header().Add(k, v)
+		}
+	}
+	w.WriteHeader(resp.StatusCode)
+	_, _ = io.Copy(w, resp.Body)
+}
+
+// DialWS opens a WebSocket connection to the spoke's /ws/{sessionID}
+// endpoint, injecting bearer auth and honoring the client's transport.
+// The caller owns the returned connection and must close it.
+func (c *Client) DialWS(ctx context.Context, sessionID string) (*websocket.Conn, error) {
+	base := strings.TrimRight(c.baseURL, "/")
+	switch {
+	case strings.HasPrefix(base, "https://"):
+		base = "wss://" + base[len("https://"):]
+	case strings.HasPrefix(base, "http://"):
+		base = "ws://" + base[len("http://"):]
+	}
+	spokeURL := fmt.Sprintf("%s/ws/%s", base, sessionID)
+
+	dialOpts := &websocket.DialOptions{}
+	if c.token != "" {
+		dialOpts.HTTPHeader = http.Header{
+			"Authorization": []string{"Bearer " + c.token},
+		}
+	}
+	if c.transport != nil {
+		dialOpts.HTTPClient = &http.Client{Transport: c.transport}
+	}
+
+	conn, _, err := websocket.Dial(ctx, spokeURL, dialOpts)
+	if err != nil {
+		return nil, fmt.Errorf("apiclient DialWS: %w", err)
+	}
+	return conn, nil
+}
+
+// ProxyWS accepts the incoming browser WebSocket upgrade and proxies
+// it to the spoke's /ws/{sessionID}. It handles:
+//
+//   - Accept + Dial of the two WS connections.
+//   - Direction-specific read limits (4 MiB spoke → client for large
+//     terminal snapshots, 256 KiB client → spoke for keyboard input).
+//   - Bidirectional copy with shared cancellation when either side
+//     closes or errors.
+//   - Clean shutdown of both connections on exit.
+//
+// sessionID is the ORIGINAL (unnamespaced) session ID on the spoke,
+// not the namespaced wire ID. Callers strip the suffix first.
+func (c *Client) ProxyWS(w http.ResponseWriter, r *http.Request, sessionID string) {
+	clientConn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
+		InsecureSkipVerify: true,
+	})
+	if err != nil {
+		log.Printf("apiclient ProxyWS: accept: %v", err)
+		return
+	}
+
+	spokeConn, err := c.DialWS(r.Context(), sessionID)
+	if err != nil {
+		log.Printf("apiclient ProxyWS: dial %s: %v", sessionID, err)
+		clientConn.Close(websocket.StatusInternalError, "peer unavailable")
+		return
+	}
+
+	// Direction-specific limits: browser input is tiny, spoke output
+	// carries full terminal snapshots.
+	clientConn.SetReadLimit(wsClientReadLimit)
+	spokeConn.SetReadLimit(wsSpokeReadLimit)
+
+	c.pipeWS(r.Context(), clientConn, spokeConn, sessionID)
+}
+
+// pipeWS runs the bidirectional copy loop between an already-accepted
+// client connection and an already-dialed spoke connection, blocking
+// until one side closes. Extracted from ProxyWS so tests can exercise
+// the copy loop without a real HTTP upgrade.
+func (c *Client) pipeWS(parent context.Context, clientConn, spokeConn *websocket.Conn, sessionID string) {
+	ctx, cancel := context.WithCancel(parent)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Spoke → Client (terminal output + resize events).
+	go func() {
+		defer wg.Done()
+		defer cancel()
+		for {
+			typ, data, err := spokeConn.Read(ctx)
+			if err != nil {
+				return
+			}
+			if err := clientConn.Write(ctx, typ, data); err != nil {
+				return
+			}
+		}
+	}()
+
+	// Client → Spoke (keyboard input + resize).
+	go func() {
+		defer wg.Done()
+		defer cancel()
+		for {
+			typ, data, err := clientConn.Read(ctx)
+			if err != nil {
+				return
+			}
+			if err := spokeConn.Write(ctx, typ, data); err != nil {
+				return
+			}
+		}
+	}()
+
+	wg.Wait()
+
+	clientConn.Close(websocket.StatusNormalClosure, "")
+	spokeConn.Close(websocket.StatusNormalClosure, "")
+	log.Printf("apiclient ProxyWS: %s disconnected", sessionID)
+}

--- a/services/gmuxd/internal/apiclient/client_test.go
+++ b/services/gmuxd/internal/apiclient/client_test.go
@@ -1,0 +1,588 @@
+package apiclient
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"nhooyr.io/websocket"
+
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/sseclient"
+)
+
+// ── Construction + basics ────────────────────────────────────────
+
+func TestNew_TrimsTrailingSlash(t *testing.T) {
+	c := New("http://host:8790/")
+	if c.BaseURL() != "http://host:8790" {
+		t.Errorf("BaseURL = %q, want %q", c.BaseURL(), "http://host:8790")
+	}
+}
+
+func TestNew_WithBearerToken(t *testing.T) {
+	c := New("http://host", WithBearerToken("abc"))
+	if c.token != "abc" {
+		t.Errorf("token = %q, want abc", c.token)
+	}
+}
+
+// ── GetConfig ─────────────────────────────────────────────────────
+
+func TestGetConfig_Success(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/config" {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Header.Get("Authorization") != "Bearer the-token" {
+			http.Error(w, "unauth", http.StatusUnauthorized)
+			return
+		}
+		_, _ = w.Write([]byte(`{"ok":true,"data":{"port":8790,"hostname":"test"}}`))
+	}))
+	defer ts.Close()
+
+	c := New(ts.URL, WithBearerToken("the-token"))
+	data, err := c.GetConfig(context.Background())
+	if err != nil {
+		t.Fatalf("GetConfig: %v", err)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if parsed["hostname"] != "test" {
+		t.Errorf("hostname = %v, want test", parsed["hostname"])
+	}
+}
+
+func TestGetConfig_Unauthorized(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "nope", http.StatusUnauthorized)
+	}))
+	defer ts.Close()
+
+	c := New(ts.URL, WithBearerToken("wrong"))
+	_, err := c.GetConfig(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "401") {
+		t.Errorf("err = %v, want status code in message", err)
+	}
+}
+
+func TestGetConfig_EnvelopeOkFalse(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"ok":false}`))
+	}))
+	defer ts.Close()
+
+	c := New(ts.URL)
+	_, err := c.GetConfig(context.Background())
+	if err == nil {
+		t.Fatal("expected error for ok=false")
+	}
+}
+
+func TestGetConfig_BadJSON(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`not json`))
+	}))
+	defer ts.Close()
+
+	c := New(ts.URL)
+	_, err := c.GetConfig(context.Background())
+	if err == nil {
+		t.Fatal("expected error for bad JSON")
+	}
+}
+
+// ── stripPeerField ────────────────────────────────────────────────
+
+func TestStripPeerField(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "strips peer",
+			in:   `{"launcher_id":"shell","cwd":"/root","peer":"dev"}`,
+			want: `{"cwd":"/root","launcher_id":"shell"}`,
+		},
+		{
+			name: "no peer is noop",
+			in:   `{"launcher_id":"shell","cwd":"/root"}`,
+			want: `{"cwd":"/root","launcher_id":"shell"}`,
+		},
+		{
+			name: "empty peer is removed",
+			in:   `{"launcher_id":"shell","peer":""}`,
+			want: `{"launcher_id":"shell"}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := stripPeerField([]byte(tt.in))
+			if err != nil {
+				t.Fatalf("stripPeerField: %v", err)
+			}
+			if string(got) != tt.want {
+				t.Errorf("stripPeerField = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStripPeerField_InvalidJSON(t *testing.T) {
+	_, err := stripPeerField([]byte("not json"))
+	if err == nil {
+		t.Error("expected error for invalid JSON")
+	}
+}
+
+// ── ForwardAction ─────────────────────────────────────────────────
+
+func TestForwardAction_PathConstruction(t *testing.T) {
+	var gotPath, gotMethod string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer ts.Close()
+
+	c := New(ts.URL, WithBearerToken("tok"))
+	req := httptest.NewRequest(http.MethodPost, "/v1/sessions/sess-123/kill", nil)
+	w := httptest.NewRecorder()
+	c.ForwardAction(w, req, "sess-123", "kill")
+
+	if gotPath != "/v1/sessions/sess-123/kill" {
+		t.Errorf("path = %q, want /v1/sessions/sess-123/kill", gotPath)
+	}
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %q, want POST", gotMethod)
+	}
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", w.Code)
+	}
+}
+
+func TestForwardAction_BearerInjected(t *testing.T) {
+	var gotAuth string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	c := New(ts.URL, WithBearerToken("my-token"))
+	req := httptest.NewRequest(http.MethodPost, "/anything", nil)
+	w := httptest.NewRecorder()
+	c.ForwardAction(w, req, "sess-x", "resume")
+
+	if gotAuth != "Bearer my-token" {
+		t.Errorf("Authorization = %q, want Bearer my-token", gotAuth)
+	}
+}
+
+func TestForwardAction_PreservesBody(t *testing.T) {
+	var gotBody string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	c := New(ts.URL)
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"payload":"hello"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	c.ForwardAction(w, req, "sess-y", "read")
+
+	if gotBody != `{"payload":"hello"}` {
+		t.Errorf("body = %q, want %q", gotBody, `{"payload":"hello"}`)
+	}
+}
+
+func TestForwardAction_UpstreamError(t *testing.T) {
+	// Dial a port nothing is listening on so the request fails.
+	c := New("http://127.0.0.1:1", WithBearerToken("t"))
+	req := httptest.NewRequest(http.MethodPost, "/anything", nil)
+	w := httptest.NewRecorder()
+	c.ForwardAction(w, req, "sess", "kill")
+
+	if w.Code != http.StatusBadGateway {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadGateway)
+	}
+}
+
+func TestForwardAction_PropagatesStatusCode(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	c := New(ts.URL)
+	req := httptest.NewRequest(http.MethodPost, "/anything", nil)
+	w := httptest.NewRecorder()
+	c.ForwardAction(w, req, "sess-missing", "kill")
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", w.Code)
+	}
+}
+
+// ── ForwardLaunch ─────────────────────────────────────────────────
+
+func TestForwardLaunch_StripsPeerField(t *testing.T) {
+	var received []byte
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/launch" {
+			http.Error(w, "bad path", http.StatusNotFound)
+			return
+		}
+		received, _ = io.ReadAll(r.Body)
+		_, _ = w.Write([]byte(`{"ok":true,"data":{"id":"sess-1"}}`))
+	}))
+	defer ts.Close()
+
+	c := New(ts.URL, WithBearerToken("tok"))
+	body := `{"launcher_id":"shell","cwd":"/root","peer":"dev"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/launch", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	c.ForwardLaunch(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	var got map[string]any
+	if err := json.Unmarshal(received, &got); err != nil {
+		t.Fatalf("invalid JSON forwarded to spoke: %v", err)
+	}
+	if _, ok := got["peer"]; ok {
+		t.Errorf("spoke received body still contains 'peer': %s", received)
+	}
+	if got["launcher_id"] != "shell" {
+		t.Errorf("launcher_id lost: %v", got)
+	}
+}
+
+func TestForwardLaunch_InvalidJSON(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("spoke should not be called for invalid JSON")
+	}))
+	defer ts.Close()
+
+	c := New(ts.URL)
+	req := httptest.NewRequest(http.MethodPost, "/v1/launch", strings.NewReader("not json"))
+	w := httptest.NewRecorder()
+	c.ForwardLaunch(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+// ── Events ────────────────────────────────────────────────────────
+
+// TestEvents_CallsAuthorizedSubscribe is the smoke test for apiclient
+// → sseclient wiring: Events().Subscribe() must send the bearer
+// token the Client was constructed with.
+func TestEvents_CallsAuthorizedSubscribe(t *testing.T) {
+	var gotAuth string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "text/event-stream")
+	}))
+	defer ts.Close()
+
+	c := New(ts.URL, WithBearerToken("evt-token"))
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	_ = c.Events().Subscribe(ctx, nil, func(sseclient.Event) {})
+	if gotAuth != "Bearer evt-token" {
+		t.Errorf("Authorization = %q, want Bearer evt-token", gotAuth)
+	}
+}
+
+// TestEvents_DeliversEvent verifies the full pipeline: a spoke-style
+// SSE frame pushed through an Events() subscribe call reaches the
+// handler with the correct type and data.
+func TestEvents_DeliversEvent(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("event: session-upsert\ndata: {\"id\":\"sess-1\"}\n\n"))
+	}))
+	defer ts.Close()
+
+	c := New(ts.URL)
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	got := make(chan sseclient.Event, 1)
+	_ = c.Events().Subscribe(ctx, nil, func(ev sseclient.Event) {
+		select {
+		case got <- ev:
+		default:
+		}
+	})
+
+	select {
+	case ev := <-got:
+		if ev.Type != "session-upsert" {
+			t.Errorf("type = %q, want session-upsert", ev.Type)
+		}
+		if !strings.Contains(string(ev.Data), `"sess-1"`) {
+			t.Errorf("data = %s, want to contain sess-1", ev.Data)
+		}
+	default:
+		t.Fatal("no event received")
+	}
+}
+
+// ── DialWS + ProxyWS ──────────────────────────────────────────────
+
+// wsEchoServer runs an nhooyr.io/websocket echo server on an HTTP test
+// server. Any binary/text message received is sent back to the peer.
+// On connect, it optionally sends `onConnect` to the peer first.
+func wsEchoServer(t *testing.T, onConnect []byte, expectAuth string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if expectAuth != "" && r.Header.Get("Authorization") != "Bearer "+expectAuth {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
+			InsecureSkipVerify: true,
+		})
+		if err != nil {
+			t.Errorf("accept: %v", err)
+			return
+		}
+		// Large read limit for the "spoke receives client input" leg.
+		conn.SetReadLimit(4 * 1024 * 1024)
+		defer conn.Close(websocket.StatusNormalClosure, "")
+
+		ctx := r.Context()
+		if len(onConnect) > 0 {
+			_ = conn.Write(ctx, websocket.MessageBinary, onConnect)
+		}
+		for {
+			typ, data, err := conn.Read(ctx)
+			if err != nil {
+				return
+			}
+			if err := conn.Write(ctx, typ, data); err != nil {
+				return
+			}
+		}
+	}))
+}
+
+func TestDialWS_Success(t *testing.T) {
+	ts := wsEchoServer(t, nil, "")
+	defer ts.Close()
+
+	c := New(ts.URL)
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	conn, err := c.DialWS(ctx, "sess-xyz")
+	if err != nil {
+		t.Fatalf("DialWS: %v", err)
+	}
+	defer conn.Close(websocket.StatusNormalClosure, "")
+}
+
+func TestDialWS_BearerInjected(t *testing.T) {
+	ts := wsEchoServer(t, nil, "ws-tok")
+	defer ts.Close()
+
+	c := New(ts.URL, WithBearerToken("ws-tok"))
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	conn, err := c.DialWS(ctx, "sess")
+	if err != nil {
+		t.Fatalf("DialWS: %v", err)
+	}
+	conn.Close(websocket.StatusNormalClosure, "")
+}
+
+func TestDialWS_UnauthorizedFails(t *testing.T) {
+	ts := wsEchoServer(t, nil, "correct")
+	defer ts.Close()
+
+	c := New(ts.URL, WithBearerToken("wrong"))
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	_, err := c.DialWS(ctx, "sess")
+	if err == nil {
+		t.Fatal("expected auth error")
+	}
+}
+
+func TestDialWS_HTTPSUpgradesToWSS(t *testing.T) {
+	// Cover the scheme rewrite paths in DialWS without actually
+	// standing up TLS. We can't dial wss://, but we can verify that a
+	// broken http-prefix URL fails with a wss-related error message
+	// indirectly via the baseURL.
+	c := New("https://invalid.invalid:9/")
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	_, err := c.DialWS(ctx, "sess")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	// We expect the dial to attempt wss://; the error message from
+	// nhooyr.io/websocket wraps the URL string. If the scheme rewrite
+	// didn't happen the error would mention "http:" instead.
+	if !strings.Contains(err.Error(), "wss:") && !strings.Contains(err.Error(), "invalid.invalid") {
+		t.Errorf("err = %v, expected to contain wss: or target host", err)
+	}
+}
+
+// ── ProxyWS regression test for the 256 KiB bug ───────────────────
+
+// TestProxyWS_LargeSnapshot is the Bug 1 regression test. The old
+// peering.ProxyWS had a 256 KiB read limit on the spoke side, which
+// silently truncated any terminal snapshot bigger than that and
+// caused the browser to enter a 1 Hz reconnect loop. apiclient.
+// ProxyWS must deliver large spoke frames to the client unchanged.
+func TestProxyWS_LargeSnapshot(t *testing.T) {
+	// 1 MiB binary payload, ~4x the old broken limit, well within
+	// the new 4 MiB spoke limit.
+	payload := make([]byte, 1024*1024)
+	for i := range payload {
+		payload[i] = byte(i)
+	}
+
+	// "spoke" sends the payload on connect, then echoes.
+	spokeServer := wsEchoServer(t, payload, "")
+	defer spokeServer.Close()
+
+	// "hub" is an HTTP server that, on /ws/{id}, accepts the browser
+	// WS and calls apiclient.ProxyWS to bridge to spokeServer.
+	c := New(spokeServer.URL)
+	hub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.ProxyWS(w, r, "sess-large")
+	}))
+	defer hub.Close()
+
+	// Dial the hub as a browser would.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	wsURL := "ws" + strings.TrimPrefix(hub.URL, "http")
+	browser, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		t.Fatalf("browser dial: %v", err)
+	}
+	defer browser.Close(websocket.StatusNormalClosure, "")
+	browser.SetReadLimit(4 * 1024 * 1024)
+
+	typ, got, err := browser.Read(ctx)
+	if err != nil {
+		t.Fatalf("browser read: %v", err)
+	}
+	if typ != websocket.MessageBinary {
+		t.Errorf("msg type = %v, want binary", typ)
+	}
+	if len(got) != len(payload) {
+		t.Fatalf("got %d bytes, want %d (truncation bug)", len(got), len(payload))
+	}
+	// Spot-check a few bytes rather than full bytes.Equal to keep
+	// the failure output readable.
+	for _, i := range []int{0, 100, len(payload) / 2, len(payload) - 1} {
+		if got[i] != payload[i] {
+			t.Errorf("byte %d: got %d, want %d", i, got[i], payload[i])
+		}
+	}
+}
+
+// TestProxyWS_Bidirectional exercises the client → spoke direction
+// too, to make sure the proxy loop handles both sides.
+func TestProxyWS_Bidirectional(t *testing.T) {
+	spokeServer := wsEchoServer(t, nil, "")
+	defer spokeServer.Close()
+
+	c := New(spokeServer.URL)
+	hub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.ProxyWS(w, r, "sess")
+	}))
+	defer hub.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	wsURL := "ws" + strings.TrimPrefix(hub.URL, "http")
+	browser, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer browser.Close(websocket.StatusNormalClosure, "")
+
+	// Send text, expect echo.
+	want := "hello from browser"
+	if err := browser.Write(ctx, websocket.MessageText, []byte(want)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	typ, got, err := browser.Read(ctx)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if typ != websocket.MessageText || string(got) != want {
+		t.Errorf("echo = (%v, %q), want (text, %q)", typ, got, want)
+	}
+}
+
+// TestProxyWS_ClientDisconnectClosesSpoke verifies that closing the
+// browser side propagates to the spoke side, so an idle spoke WS
+// isn't left dangling.
+func TestProxyWS_ClientDisconnectClosesSpoke(t *testing.T) {
+	spokeClosed := make(chan struct{})
+	var once sync.Once
+	spoke := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{InsecureSkipVerify: true})
+		if err != nil {
+			t.Errorf("accept: %v", err)
+			return
+		}
+		defer conn.Close(websocket.StatusNormalClosure, "")
+		// Block reading until the client closes; then signal.
+		_, _, _ = conn.Read(r.Context())
+		once.Do(func() { close(spokeClosed) })
+	}))
+	defer spoke.Close()
+
+	c := New(spoke.URL)
+	hub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.ProxyWS(w, r, "sess")
+	}))
+	defer hub.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	wsURL := "ws" + strings.TrimPrefix(hub.URL, "http")
+	browser, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	// Close the browser side.
+	browser.Close(websocket.StatusNormalClosure, "")
+
+	select {
+	case <-spokeClosed:
+	case <-time.After(1 * time.Second):
+		t.Fatal("spoke side was not unblocked after client disconnect")
+	}
+}
+

--- a/services/gmuxd/internal/peering/peer.go
+++ b/services/gmuxd/internal/peering/peer.go
@@ -1,27 +1,32 @@
 package peering
 
 import (
-	"bufio"
-	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
-	"io"
 	"log"
 	"net/http"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/apiclient"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/config"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/sseclient"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/store"
-	"nhooyr.io/websocket"
 )
 
 // Peer manages the connection to a single remote gmuxd instance.
+//
+// Protocol primitives (SSE decode, HTTP forwarding, WS proxying) live
+// in the apiclient package so peering can focus on the peering-specific
+// concerns: namespacing session IDs, ownership filtering, reconnect
+// policy, and status reporting.
 type Peer struct {
 	Config config.PeerConfig
 	store  *store.Store
+	api    *apiclient.Client
 
 	mu           sync.RWMutex
 	status       Status
@@ -41,8 +46,6 @@ type Peer struct {
 	// nil means use the default transport. Set via WithTransport for
 	// tailscale-discovered peers that route through tsnet.
 	transport http.RoundTripper
-
-	client *http.Client
 }
 
 func newPeer(cfg config.PeerConfig, st *store.Store, onStatus func(string, Status), opts ...PeerOption) *Peer {
@@ -51,11 +54,17 @@ func newPeer(cfg config.PeerConfig, st *store.Store, onStatus func(string, Statu
 		store:    st,
 		status:   StatusDisconnected,
 		onStatus: onStatus,
-		client:   &http.Client{Timeout: 0},
 	}
 	for _, o := range opts {
 		o(p)
 	}
+	// Construct the API client after options have been applied so a
+	// WithTransport option propagates into it.
+	apiOpts := []apiclient.Option{apiclient.WithBearerToken(cfg.Token)}
+	if p.transport != nil {
+		apiOpts = append(apiOpts, apiclient.WithTransport(p.transport))
+	}
+	p.api = apiclient.New(cfg.URL, apiOpts...)
 	return p
 }
 
@@ -87,45 +96,18 @@ func (p *Peer) setStatus(s Status) {
 	}
 }
 
-// Forward proxies an HTTP request to the spoke, stripping the peer
-// namespace from the session ID. The spoke sees the original session ID.
+// Forward proxies an HTTP request to the spoke's session action
+// endpoint, stripping the peer namespace from the session ID. The
+// spoke sees the original (non-namespaced) session ID.
 func (p *Peer) Forward(w http.ResponseWriter, r *http.Request, originalID, action string) {
-	path := fmt.Sprintf("/v1/sessions/%s/%s", originalID, action)
-	p.proxyHTTP(w, r, path)
+	p.api.ForwardAction(w, r, originalID, action)
 }
 
-// ForwardLaunch sends a launch request to the spoke. The request body is
-// expected to be JSON matching the /v1/launch schema. Any top-level "peer"
-// field is stripped before forwarding so the spoke treats the request as
-// a local launch; leaving it in place would make the spoke try to forward
-// the request again to a peer of its own with that name (which typically
-// doesn't exist on that side).
+// ForwardLaunch sends a launch request to the spoke. The top-level
+// "peer" field is stripped before forwarding so the spoke treats the
+// request as a local launch.
 func (p *Peer) ForwardLaunch(w http.ResponseWriter, r *http.Request) {
-	body, err := io.ReadAll(io.LimitReader(r.Body, 4096))
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
-	stripped, err := stripPeerField(body)
-	if err != nil {
-		http.Error(w, "invalid JSON", http.StatusBadRequest)
-		return
-	}
-	r.Body = io.NopCloser(bytes.NewReader(stripped))
-	r.ContentLength = int64(len(stripped))
-	p.proxyHTTP(w, r, "/v1/launch")
-}
-
-// stripPeerField removes the top-level "peer" key from a JSON object body.
-// Exported as a function (not a method) so it can be unit-tested in
-// isolation; callers generally go through ForwardLaunch.
-func stripPeerField(body []byte) ([]byte, error) {
-	var req map[string]any
-	if err := json.Unmarshal(body, &req); err != nil {
-		return nil, err
-	}
-	delete(req, "peer")
-	return json.Marshal(req)
+	p.api.ForwardLaunch(w, r)
 }
 
 // CachedConfig returns the peer's config data, fetched once on each
@@ -137,163 +119,35 @@ func (p *Peer) CachedConfig() json.RawMessage {
 	return p.cachedConfig
 }
 
-// fetchConfig fetches the spoke's /v1/config and caches the result.
-// Called once after each successful SSE connection.
+// fetchConfig fetches the spoke's /v1/config via apiclient and caches
+// the result. Called once after each successful SSE connection. Tests
+// call it directly to exercise the caching path without standing up a
+// full SSE pipeline.
 func (p *Peer) fetchConfig(ctx context.Context) {
-	url := strings.TrimRight(p.Config.URL, "/") + "/v1/config"
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return
-	}
-	p.setAuth(req)
-
-	client := &http.Client{Timeout: 5 * time.Second, Transport: p.transport}
-	resp, err := client.Do(req)
+	data, err := p.api.GetConfig(ctx)
 	if err != nil {
 		log.Printf("peering: %s: fetch config: %v", p.Config.Name, err)
 		return
 	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return
-	}
-
-	var envelope struct {
-		OK   bool            `json:"ok"`
-		Data json.RawMessage `json:"data"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil || !envelope.OK {
-		return
-	}
-
 	p.mu.Lock()
-	p.cachedConfig = envelope.Data
+	p.cachedConfig = data
 	p.mu.Unlock()
 }
 
 // ProxyWS proxies a browser WebSocket connection to the spoke's
-// /ws/{sessionID} endpoint. The hub accepts the browser WS, dials the
-// spoke WS with bearer auth, and pipes bidirectionally.
+// /ws/{sessionID} endpoint. The hub accepts the browser WS, the
+// apiclient dials the spoke WS with bearer auth and pipes the two
+// connections bidirectionally with direction-specific read limits
+// (256 KiB client, 4 MiB spoke) that accommodate large terminal
+// snapshots.
 func (p *Peer) ProxyWS(w http.ResponseWriter, r *http.Request, originalID string) {
-	// Accept browser WebSocket.
-	clientConn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
-		InsecureSkipVerify: true,
-	})
-	if err != nil {
-		log.Printf("peering: %s: ws accept: %v", p.Config.Name, err)
-		return
-	}
-
-	// Dial spoke's WebSocket.
-	base := strings.TrimRight(p.Config.URL, "/")
-	switch {
-	case strings.HasPrefix(base, "https://"):
-		base = "wss://" + base[len("https://"):]
-	case strings.HasPrefix(base, "http://"):
-		base = "ws://" + base[len("http://"):]
-	}
-	spokeURL := fmt.Sprintf("%s/ws/%s", base, originalID)
-	ctx := r.Context()
-	dialOpts := &websocket.DialOptions{}
-	if p.Config.Token != "" {
-		dialOpts.HTTPHeader = http.Header{
-			"Authorization": []string{"Bearer " + p.Config.Token},
-		}
-	}
-	if p.transport != nil {
-		dialOpts.HTTPClient = &http.Client{Transport: p.transport}
-	}
-	spokeConn, _, err := websocket.Dial(ctx, spokeURL, dialOpts)
-	if err != nil {
-		log.Printf("peering: %s: ws dial %s: %v", p.Config.Name, originalID, err)
-		clientConn.Close(websocket.StatusInternalError, "peer unavailable")
-		return
-	}
-
 	log.Printf("peering: %s: ws proxying %s", p.Config.Name, originalID)
-
-	// Match read limits with the main WS proxy.
-	clientConn.SetReadLimit(256 * 1024)
-	spokeConn.SetReadLimit(256 * 1024)
-
-	proxyCtx, proxyCancel := context.WithCancel(ctx)
-
-	var wg sync.WaitGroup
-	wg.Add(2)
-
-	// Spoke → Client
-	go func() {
-		defer wg.Done()
-		defer proxyCancel()
-		for {
-			typ, data, err := spokeConn.Read(proxyCtx)
-			if err != nil {
-				return
-			}
-			if err := clientConn.Write(proxyCtx, typ, data); err != nil {
-				return
-			}
-		}
-	}()
-
-	// Client → Spoke
-	go func() {
-		defer wg.Done()
-		defer proxyCancel()
-		for {
-			typ, data, err := clientConn.Read(proxyCtx)
-			if err != nil {
-				return
-			}
-			if err := spokeConn.Write(proxyCtx, typ, data); err != nil {
-				return
-			}
-		}
-	}()
-
-	wg.Wait()
-
-	clientConn.Close(websocket.StatusNormalClosure, "")
-	spokeConn.Close(websocket.StatusNormalClosure, "")
-	log.Printf("peering: %s: ws disconnected %s", p.Config.Name, originalID)
+	p.api.ProxyWS(w, r, originalID)
 }
 
-// proxyHTTP forwards an HTTP request to the spoke at the given path
-// and copies the response back to the caller.
-func (p *Peer) proxyHTTP(w http.ResponseWriter, r *http.Request, path string) {
-	targetURL := strings.TrimRight(p.Config.URL, "/") + path
-
-	req, err := http.NewRequestWithContext(r.Context(), r.Method, targetURL, r.Body)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-	p.setAuth(req)
-	if ct := r.Header.Get("Content-Type"); ct != "" {
-		req.Header.Set("Content-Type", ct)
-	}
-
-	resp, err := p.client.Do(req)
-	if err != nil {
-		log.Printf("peering: %s: forward %s: %v", p.Config.Name, path, err)
-		http.Error(w, "peer unavailable", http.StatusBadGateway)
-		return
-	}
-	defer resp.Body.Close()
-
-	for k, vv := range resp.Header {
-		for _, v := range vv {
-			w.Header().Add(k, v)
-		}
-	}
-	w.WriteHeader(resp.StatusCode)
-	io.Copy(w, resp.Body)
-}
-
-// run connects to the spoke's SSE stream and processes events until the
-// context is cancelled. Handles reconnection with exponential backoff.
+// run connects to the spoke's SSE stream and processes events until
+// the context is cancelled. Handles reconnection with exponential
+// backoff.
 func (p *Peer) run(ctx context.Context) {
 	const (
 		initialBackoff = 1 * time.Second
@@ -351,75 +205,42 @@ func (p *Peer) run(ctx context.Context) {
 	}
 }
 
-// subscribe connects to the spoke and processes its SSE stream.
-// The onConnected callback fires once after a successful connection,
-// allowing the caller to track whether the connection was established
-// (used to decide whether to reset backoff).
+// subscribe connects to the spoke and processes its SSE stream via
+// apiclient. The onConnected callback fires once after a successful
+// connection, allowing the caller to track whether the connection was
+// established (used to decide whether to reset backoff).
 func (p *Peer) subscribe(ctx context.Context, onConnected func()) error {
-	url := fmt.Sprintf("%s/v1/events", strings.TrimRight(p.Config.URL, "/"))
+	sse := p.api.Events()
 
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
-	if err != nil {
-		return fmt.Errorf("request: %w", err)
-	}
-	req.Header.Set("Accept", "text/event-stream")
-	p.setAuth(req)
-
-	resp, err := p.client.Do(req)
-	if err != nil {
-		return fmt.Errorf("connect: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
-		return fmt.Errorf("auth failed (HTTP %d)", resp.StatusCode)
-	}
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("unexpected status %d", resp.StatusCode)
-	}
-
-	p.setStatus(StatusConnected)
-	if onConnected != nil {
-		onConnected()
-	}
-	log.Printf("peering: %s: connected to %s", p.Config.Name, url)
-
-	// Fetch the peer's config once per connection so /v1/config can
-	// serve it from cache without making outgoing HTTP calls.
-	p.fetchConfig(ctx)
-
-	scanner := bufio.NewScanner(resp.Body)
-	// Allow large SSE payloads (sessions can have long command arrays).
-	scanner.Buffer(make([]byte, 0, 64*1024), 256*1024)
-
-	var currentEvent string
-
-	for scanner.Scan() {
-		if ctx.Err() != nil {
-			return ctx.Err()
-		}
-
-		line := scanner.Text()
-
-		if strings.HasPrefix(line, "event: ") {
-			currentEvent = strings.TrimPrefix(line, "event: ")
-			continue
-		}
-
-		if strings.HasPrefix(line, "data: ") {
-			data := strings.TrimPrefix(line, "data: ")
-			if currentEvent != "" {
-				p.handleEvent(currentEvent, []byte(data))
-				currentEvent = ""
+	err := sse.Subscribe(ctx,
+		func() {
+			p.setStatus(StatusConnected)
+			log.Printf("peering: %s: connected to %s/v1/events", p.Config.Name, p.Config.URL)
+			if onConnected != nil {
+				onConnected()
 			}
-			continue
-		}
-	}
+			// Fetch the peer's config once per connection so /v1/config
+			// can serve it from cache without making outgoing HTTP
+			// calls.
+			p.fetchConfig(ctx)
+		},
+		func(ev sseclient.Event) {
+			p.handleEvent(ev.Type, ev.Data)
+		},
+	)
 
-	if err := scanner.Err(); err != nil {
-		return fmt.Errorf("read: %w", err)
+	// Normalize errors so run() + categorizeError see the same shapes
+	// they did before the apiclient migration.
+	switch {
+	case err == nil:
+		return fmt.Errorf("stream ended")
+	case errors.Is(err, sseclient.ErrStreamEnded):
+		return fmt.Errorf("stream ended")
+	case errors.Is(err, sseclient.ErrUnauthorized):
+		return fmt.Errorf("auth failed: %w", err)
+	default:
+		return err
 	}
-	return fmt.Errorf("stream ended")
 }
 
 // sseEvent is the wire format for gmuxd SSE events.
@@ -498,15 +319,6 @@ func (p *Peer) handleEvent(eventType string, data []byte) {
 
 	default:
 		// Unknown event types are silently ignored for forward compatibility.
-	}
-}
-
-// setAuth adds the bearer token to a request if one is configured.
-// Tailscale-discovered peers authenticate via WhoIs identity and have
-// no token; manual and devcontainer peers use bearer tokens.
-func (p *Peer) setAuth(req *http.Request) {
-	if p.Config.Token != "" {
-		req.Header.Set("Authorization", "Bearer "+p.Config.Token)
 	}
 }
 

--- a/services/gmuxd/internal/peering/peer.go
+++ b/services/gmuxd/internal/peering/peer.go
@@ -286,7 +286,12 @@ func (p *Peer) handleEvent(eventType string, data []byte) {
 		sess.Peer = p.Config.Name
 		sess.SocketPath = "" // meaningless on hub side
 
-		p.store.Upsert(sess)
+		// UpsertRemote (not Upsert) because the spoke already resolved
+		// Title and Resumable. Upsert would re-run resolveTitle against
+		// the wire session where ShellTitle/AdapterTitle are absent
+		// (they're internal fields, intentionally off the wire) and
+		// overwrite the correct title with the Kind fallback.
+		p.store.UpsertRemote(sess)
 
 	case "session-remove":
 		var ev sseEvent

--- a/services/gmuxd/internal/peering/peering.go
+++ b/services/gmuxd/internal/peering/peering.go
@@ -29,11 +29,12 @@ import (
 type PeerOption func(*Peer)
 
 // WithTransport sets a custom HTTP transport for all peer connections.
-// Used for tailscale-discovered peers that route through tsnet.
+// Used for tailscale-discovered peers that route through tsnet. The
+// transport is stored and applied when newPeer constructs the
+// underlying apiclient.Client.
 func WithTransport(rt http.RoundTripper) PeerOption {
 	return func(p *Peer) {
 		p.transport = rt
-		p.client = &http.Client{Transport: rt}
 	}
 }
 

--- a/services/gmuxd/internal/peering/peering_test.go
+++ b/services/gmuxd/internal/peering/peering_test.go
@@ -859,48 +859,6 @@ func TestManager_FindPeerDynamic(t *testing.T) {
 
 // ── ForwardLaunch ──
 
-func TestStripPeerField(t *testing.T) {
-	tests := []struct {
-		name string
-		in   string
-		want string
-	}{
-		{
-			name: "strips peer",
-			in:   `{"launcher_id":"shell","cwd":"/root","peer":"dev"}`,
-			want: `{"cwd":"/root","launcher_id":"shell"}`,
-		},
-		{
-			name: "no peer is noop",
-			in:   `{"launcher_id":"shell","cwd":"/root"}`,
-			want: `{"cwd":"/root","launcher_id":"shell"}`,
-		},
-		{
-			name: "empty peer is removed too",
-			in:   `{"launcher_id":"shell","peer":""}`,
-			want: `{"launcher_id":"shell"}`,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := stripPeerField([]byte(tt.in))
-			if err != nil {
-				t.Fatalf("stripPeerField: %v", err)
-			}
-			if string(got) != tt.want {
-				t.Errorf("stripPeerField = %s, want %s", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestStripPeerField_InvalidJSON(t *testing.T) {
-	_, err := stripPeerField([]byte("not json"))
-	if err == nil {
-		t.Error("expected error for invalid JSON")
-	}
-}
-
 // TestForwardLaunch_StripsPeerField verifies the hub → spoke forward path
 // sends a body without the "peer" field. Without this, the spoke would
 // try to forward the request again to a peer of its own with that name.

--- a/services/gmuxd/internal/peering/peering_test.go
+++ b/services/gmuxd/internal/peering/peering_test.go
@@ -146,6 +146,44 @@ func spokeServer(t *testing.T, token string, sessions []store.Session) *spoke {
 	return sk
 }
 
+// TestPeerSubscribe_PreservesTitles is the regression guard for the
+// title-overwrite bug: a remote session arrives with Title already
+// resolved by the spoke but with empty ShellTitle/AdapterTitle
+// (those are internal, intentionally off-wire). The hub must not
+// re-resolve the title or it would replace the spoke's value with
+// the Kind fallback (e.g. "codex" instead of "fix remote bug").
+func TestPeerSubscribe_PreservesTitles(t *testing.T) {
+	st := store.New()
+	sessions := []store.Session{
+		{
+			ID:    "sess-1",
+			Kind:  "codex",
+			Alive: true,
+			Title: "fix remote bug",
+			// ShellTitle/AdapterTitle intentionally empty: that's
+			// how they arrive on the wire because store.MarshalJSON
+			// drops them.
+		},
+	}
+
+	sk := spokeServer(t, "", sessions)
+	cfg := config.PeerConfig{Name: "server", URL: sk.URL}
+
+	mgr := NewManager([]config.PeerConfig{cfg}, st, "test-host")
+	mgr.Start()
+	waitForSessions(t, st, "server", 1)
+
+	got, ok := st.Get("sess-1@server")
+	if !ok {
+		t.Fatal("expected sess-1@server")
+	}
+	if got.Title != "fix remote bug" {
+		t.Errorf("Title = %q, want %q (spoke-resolved title must survive hub upsert)", got.Title, "fix remote bug")
+	}
+
+	mgr.Stop()
+}
+
 func TestPeerSubscribe_InitialSessions(t *testing.T) {
 	st := store.New()
 	sessions := []store.Session{

--- a/services/gmuxd/internal/sseclient/client.go
+++ b/services/gmuxd/internal/sseclient/client.go
@@ -1,0 +1,231 @@
+// Package sseclient is a minimal Server-Sent Events client.
+//
+// It handles the SSE wire format (event:/data:/comment lines), auth
+// headers, and buffer sizing. Reconnect policy is intentionally NOT
+// part of this package: callers own the outer loop, mirroring how
+// browser EventSource tracks reconnection in the caller.
+//
+// Usage:
+//
+//	c := sseclient.New("http://host:8790/v1/events",
+//	    sseclient.WithBearerToken(token),
+//	)
+//	err := c.Subscribe(ctx, nil, func(ev sseclient.Event) {
+//	    // dispatch ev.Type / ev.Data
+//	})
+//	// err is ErrStreamEnded on clean close, ErrUnauthorized on auth
+//	// failure, or a wrapped network/protocol error otherwise.
+package sseclient
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// Default buffer size for SSE event decoding. Matches the size used
+// by peering's hand-rolled scanner prior to extraction. Large enough
+// to accept gmuxd session-upsert payloads with long command arrays.
+const defaultBufferSize = 256 * 1024
+
+// ErrStreamEnded is returned by Subscribe when the server closed the
+// stream cleanly (no error from the scanner, EOF). Callers use this
+// as the trigger to reconnect with backoff.
+var ErrStreamEnded = errors.New("sse stream ended")
+
+// ErrUnauthorized is returned by Subscribe when the server responds
+// with HTTP 401 or 403. Callers typically do not retry this.
+var ErrUnauthorized = errors.New("sse unauthorized")
+
+// Event is a decoded SSE event. Data is the raw bytes from one or
+// more "data:" lines, concatenated with newlines (per the spec).
+// Callers parse Data according to their own schema.
+type Event struct {
+	Type string
+	Data []byte
+}
+
+// Client subscribes to a single SSE endpoint.
+//
+// Client is safe to reuse across multiple Subscribe calls on the same
+// URL (e.g. after a reconnect) but not safe for concurrent Subscribe
+// calls from multiple goroutines.
+type Client struct {
+	url       string
+	headers   http.Header
+	transport http.RoundTripper
+	bufSize   int
+}
+
+// Option configures a Client.
+type Option func(*Client)
+
+// WithBearerToken adds an Authorization: Bearer <token> header to
+// every request. Empty token is ignored (useful for tailscale
+// connections that authenticate via WhoIs instead).
+func WithBearerToken(token string) Option {
+	return func(c *Client) {
+		if token != "" {
+			c.headers.Set("Authorization", "Bearer "+token)
+		}
+	}
+}
+
+// WithHeader adds a custom HTTP header. Repeated calls append to the
+// same header name.
+func WithHeader(key, value string) Option {
+	return func(c *Client) {
+		c.headers.Add(key, value)
+	}
+}
+
+// WithTransport sets the HTTP round-tripper used for the connection.
+// Used by tailscale-discovered peers to route through tsnet.
+func WithTransport(t http.RoundTripper) Option {
+	return func(c *Client) {
+		c.transport = t
+	}
+}
+
+// WithBufferSize sets the maximum size of a single SSE event payload.
+// Defaults to 256 KiB. Events larger than this cause Subscribe to
+// return a protocol error.
+func WithBufferSize(n int) Option {
+	return func(c *Client) {
+		if n > 0 {
+			c.bufSize = n
+		}
+	}
+}
+
+// New creates a Client pointed at url.
+func New(url string, opts ...Option) *Client {
+	c := &Client{
+		url:     url,
+		headers: make(http.Header),
+		bufSize: defaultBufferSize,
+	}
+	c.headers.Set("Accept", "text/event-stream")
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+// Subscribe connects to the SSE endpoint and invokes handler for
+// each decoded event until the context is cancelled or the stream
+// ends.
+//
+// connected, if non-nil, is called exactly once after a successful
+// HTTP response (2xx) and before the first handler call. Callers use
+// this to transition their connection state to Connected or to fetch
+// auxiliary resources (config, etc.) on connection.
+//
+// Return values:
+//   - ErrStreamEnded: the server closed the stream without error.
+//   - ErrUnauthorized: the server responded with 401 or 403.
+//   - context.Canceled / DeadlineExceeded: ctx was cancelled.
+//   - wrapped network/protocol error: everything else.
+//
+// Comment lines (lines starting with ':') are consumed silently.
+// Lines that don't match "event: " or "data: " are ignored, per the
+// SSE spec.
+//
+// Events with no "data:" line are silently dropped. Lines with
+// "data:" but no preceding "event:" are also dropped (the current
+// event type is required to dispatch).
+func (c *Client) Subscribe(ctx context.Context, connected func(), handler func(Event)) error {
+	if handler == nil {
+		panic("sseclient: handler must not be nil")
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.url, nil)
+	if err != nil {
+		return fmt.Errorf("sse request: %w", err)
+	}
+	for k, vv := range c.headers {
+		for _, v := range vv {
+			req.Header.Add(k, v)
+		}
+	}
+
+	// Fresh http.Client per Subscribe so Timeout doesn't apply to the
+	// long-lived stream read. Caller can still cancel via ctx.
+	httpClient := &http.Client{Transport: c.transport}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("sse connect: %w", err)
+	}
+	defer resp.Body.Close()
+
+	switch {
+	case resp.StatusCode == http.StatusUnauthorized, resp.StatusCode == http.StatusForbidden:
+		return fmt.Errorf("%w: HTTP %d", ErrUnauthorized, resp.StatusCode)
+	case resp.StatusCode < 200 || resp.StatusCode >= 300:
+		return fmt.Errorf("sse unexpected status %d", resp.StatusCode)
+	}
+
+	if connected != nil {
+		connected()
+	}
+
+	scanner := bufio.NewScanner(resp.Body)
+	// bufio.Scanner uses max(initial cap, configured max) as the real
+	// limit, so the initial cap must not exceed bufSize or the max is
+	// a no-op for small bufSize values.
+	initSize := 64 * 1024
+	if c.bufSize < initSize {
+		initSize = c.bufSize
+	}
+	scanner.Buffer(make([]byte, 0, initSize), c.bufSize)
+
+	var currentEvent string
+	for scanner.Scan() {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		line := scanner.Text()
+		switch {
+		case line == "":
+			// Spec: empty line terminates event. We already dispatch on
+			// data: lines, so this is a no-op. Reset currentEvent to
+			// avoid stale dispatches across event boundaries.
+			currentEvent = ""
+		case strings.HasPrefix(line, ":"):
+			// Comment line (server-pushed keepalive). Ignore.
+		case strings.HasPrefix(line, "event: "):
+			currentEvent = strings.TrimPrefix(line, "event: ")
+		case strings.HasPrefix(line, "event:"):
+			// Spec-compliant form without the space.
+			currentEvent = strings.TrimPrefix(line, "event:")
+		case strings.HasPrefix(line, "data: "):
+			if currentEvent == "" {
+				continue
+			}
+			handler(Event{Type: currentEvent, Data: []byte(strings.TrimPrefix(line, "data: "))})
+		case strings.HasPrefix(line, "data:"):
+			if currentEvent == "" {
+				continue
+			}
+			handler(Event{Type: currentEvent, Data: []byte(strings.TrimPrefix(line, "data:"))})
+		default:
+			// Unknown line type (id:, retry:, custom). Ignore per spec.
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		// ctx.Err() takes priority: if the caller cancelled, surface
+		// that directly rather than the ambient "context canceled"
+		// wrapped in a read error.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		return fmt.Errorf("sse read: %w", err)
+	}
+
+	return ErrStreamEnded
+}

--- a/services/gmuxd/internal/sseclient/client_test.go
+++ b/services/gmuxd/internal/sseclient/client_test.go
@@ -1,0 +1,443 @@
+package sseclient
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// sseServer is a test helper that serves SSE frames.
+type sseServer struct {
+	*httptest.Server
+	mu         sync.Mutex
+	frames     []string   // frames queued for the next connection
+	expectAuth string     // if set, requires "Authorization: Bearer <expectAuth>"
+	clients    chan int   // signals "client connected" by sending 1
+	hold       chan struct{} // if set, server holds the stream open until closed
+}
+
+func newSSEServer(t *testing.T) *sseServer {
+	t.Helper()
+	s := &sseServer{
+		clients: make(chan int, 8),
+	}
+	s.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s.mu.Lock()
+		expectAuth := s.expectAuth
+		frames := make([]string, len(s.frames))
+		copy(frames, s.frames)
+		hold := s.hold
+		s.mu.Unlock()
+
+		if expectAuth != "" {
+			got := r.Header.Get("Authorization")
+			if got != "Bearer "+expectAuth {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+		}
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher := w.(http.Flusher)
+		select {
+		case s.clients <- 1:
+		default:
+		}
+		for _, frame := range frames {
+			fmt.Fprint(w, frame)
+		}
+		flusher.Flush()
+
+		if hold != nil {
+			select {
+			case <-r.Context().Done():
+			case <-hold:
+			}
+		}
+	}))
+	t.Cleanup(s.Close)
+	return s
+}
+
+// setFrames queues the given raw SSE frames for the next connection.
+func (s *sseServer) setFrames(frames ...string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.frames = frames
+}
+
+func (s *sseServer) setAuth(token string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.expectAuth = token
+}
+
+func (s *sseServer) setHold(ch chan struct{}) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.hold = ch
+}
+
+// waitForEvents invokes Subscribe in a goroutine and returns once
+// `want` events have been received or the timeout expires.
+func waitForEvents(t *testing.T, c *Client, want int, timeout time.Duration) ([]Event, error) {
+	t.Helper()
+	var (
+		events []Event
+		mu     sync.Mutex
+	)
+	done := make(chan error, 1)
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	go func() {
+		err := c.Subscribe(ctx, nil, func(ev Event) {
+			mu.Lock()
+			events = append(events, Event{Type: ev.Type, Data: append([]byte(nil), ev.Data...)})
+			n := len(events)
+			mu.Unlock()
+			if n >= want {
+				cancel()
+			}
+		})
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		mu.Lock()
+		defer mu.Unlock()
+		return events, err
+	case <-time.After(timeout + 50*time.Millisecond):
+		t.Fatal("test timeout")
+		return nil, nil
+	}
+}
+
+func TestSubscribe_SingleEvent(t *testing.T) {
+	s := newSSEServer(t)
+	s.setFrames("event: hello\ndata: world\n\n")
+
+	c := New(s.URL)
+	events, err := waitForEvents(t, c, 1, 500*time.Millisecond)
+	if err != nil && !errors.Is(err, ErrStreamEnded) && !errors.Is(err, context.Canceled) {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("got %d events, want 1", len(events))
+	}
+	if events[0].Type != "hello" || string(events[0].Data) != "world" {
+		t.Errorf("event = %+v, want {hello world}", events[0])
+	}
+}
+
+func TestSubscribe_MultipleEvents(t *testing.T) {
+	s := newSSEServer(t)
+	s.setFrames(
+		"event: a\ndata: 1\n\n",
+		"event: b\ndata: 2\n\n",
+		"event: c\ndata: 3\n\n",
+	)
+
+	c := New(s.URL)
+	events, _ := waitForEvents(t, c, 3, 500*time.Millisecond)
+	if len(events) != 3 {
+		t.Fatalf("got %d events, want 3", len(events))
+	}
+	for i, want := range []struct {
+		typ, data string
+	}{
+		{"a", "1"}, {"b", "2"}, {"c", "3"},
+	} {
+		if events[i].Type != want.typ || string(events[i].Data) != want.data {
+			t.Errorf("event[%d] = %+v, want {%s %s}", i, events[i], want.typ, want.data)
+		}
+	}
+}
+
+func TestSubscribe_CommentLinesSkipped(t *testing.T) {
+	s := newSSEServer(t)
+	// Comment lines (starting with ':') are SSE keepalives. They must
+	// not produce events but also must not break parsing of surrounding
+	// real events.
+	s.setFrames(
+		": keepalive\n\n",
+		"event: real\ndata: payload\n\n",
+		": another\n\n",
+	)
+
+	c := New(s.URL)
+	events, _ := waitForEvents(t, c, 1, 500*time.Millisecond)
+	if len(events) != 1 {
+		t.Fatalf("got %d events, want 1", len(events))
+	}
+	if events[0].Type != "real" || string(events[0].Data) != "payload" {
+		t.Errorf("event = %+v, want {real payload}", events[0])
+	}
+}
+
+func TestSubscribe_Unauthorized(t *testing.T) {
+	s := newSSEServer(t)
+	s.setAuth("correct-token")
+
+	c := New(s.URL, WithBearerToken("wrong-token"))
+	err := c.Subscribe(context.Background(), nil, func(Event) {})
+	if !errors.Is(err, ErrUnauthorized) {
+		t.Errorf("err = %v, want ErrUnauthorized", err)
+	}
+}
+
+func TestSubscribe_BearerTokenInjected(t *testing.T) {
+	s := newSSEServer(t)
+	s.setAuth("right-token")
+	s.setFrames("event: ok\ndata: 1\n\n")
+
+	c := New(s.URL, WithBearerToken("right-token"))
+	events, _ := waitForEvents(t, c, 1, 500*time.Millisecond)
+	if len(events) != 1 {
+		t.Fatalf("auth failed: got %d events, want 1", len(events))
+	}
+}
+
+func TestSubscribe_EmptyTokenSkipsAuthHeader(t *testing.T) {
+	// A zero bearer token must not send an "Authorization: Bearer "
+	// header. Tailscale-discovered peers pass "" here and rely on
+	// WhoIs identity instead.
+	var gotHeader string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHeader = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprint(w, "event: ping\ndata: ok\n\n")
+	}))
+	defer ts.Close()
+
+	c := New(ts.URL, WithBearerToken(""))
+	_, _ = waitForEvents(t, c, 1, 500*time.Millisecond)
+	if gotHeader != "" {
+		t.Errorf("Authorization header = %q, want empty", gotHeader)
+	}
+}
+
+func TestSubscribe_ConnectedCallback(t *testing.T) {
+	s := newSSEServer(t)
+	s.setFrames("event: x\ndata: y\n\n")
+
+	c := New(s.URL)
+
+	var connectCount int32
+	var eventsBeforeConnect int32
+	var eventsAfterConnect int32
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		_ = c.Subscribe(ctx,
+			func() {
+				atomic.AddInt32(&connectCount, 1)
+			},
+			func(Event) {
+				if atomic.LoadInt32(&connectCount) == 0 {
+					atomic.AddInt32(&eventsBeforeConnect, 1)
+				} else {
+					atomic.AddInt32(&eventsAfterConnect, 1)
+				}
+				cancel()
+			},
+		)
+		close(done)
+	}()
+
+	<-done
+
+	if got := atomic.LoadInt32(&connectCount); got != 1 {
+		t.Errorf("connect callback invoked %d times, want 1", got)
+	}
+	if got := atomic.LoadInt32(&eventsBeforeConnect); got != 0 {
+		t.Errorf("events before connect callback: %d, want 0", got)
+	}
+	if got := atomic.LoadInt32(&eventsAfterConnect); got != 1 {
+		t.Errorf("events after connect callback: %d, want 1", got)
+	}
+}
+
+func TestSubscribe_ContextCancel(t *testing.T) {
+	s := newSSEServer(t)
+	hold := make(chan struct{})
+	t.Cleanup(func() { close(hold) })
+	s.setHold(hold)
+
+	c := New(s.URL)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- c.Subscribe(ctx, nil, func(Event) {})
+	}()
+
+	// Wait for client to connect, then cancel.
+	select {
+	case <-s.clients:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("client did not connect")
+	}
+	cancel()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("err = %v, want context.Canceled", err)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Subscribe did not return after cancel")
+	}
+}
+
+func TestSubscribe_StreamEnded(t *testing.T) {
+	// Server closes cleanly with no events; Subscribe should return
+	// ErrStreamEnded so the caller knows to reconnect.
+	s := newSSEServer(t)
+	// No frames, no hold: handler returns immediately, body EOFs.
+
+	c := New(s.URL)
+	err := c.Subscribe(context.Background(), nil, func(Event) {})
+	if !errors.Is(err, ErrStreamEnded) {
+		t.Errorf("err = %v, want ErrStreamEnded", err)
+	}
+}
+
+func TestSubscribe_OversizedEvent(t *testing.T) {
+	// A single data: line larger than the buffer must produce a
+	// protocol error, not silent truncation. Use a small buffer so
+	// the test payload stays manageable.
+	huge := strings.Repeat("x", 2048)
+	s := newSSEServer(t)
+	s.setFrames("event: big\ndata: " + huge + "\n\n")
+
+	c := New(s.URL, WithBufferSize(512))
+	err := c.Subscribe(context.Background(), nil, func(Event) {})
+	if err == nil || errors.Is(err, ErrStreamEnded) {
+		t.Errorf("err = %v, want a protocol error", err)
+	}
+}
+
+func TestSubscribe_EventWithoutData(t *testing.T) {
+	// An "event:" line with no "data:" line is per-spec a no-op event
+	// (dispatched as MessageEvent with empty data on the browser).
+	// Our decoder requires a data: line to fire the handler, matching
+	// the behavior of the peering decoder it replaces.
+	s := newSSEServer(t)
+	s.setFrames(
+		"event: ghost\n\n",
+		"event: real\ndata: payload\n\n",
+	)
+
+	c := New(s.URL)
+	events, _ := waitForEvents(t, c, 1, 500*time.Millisecond)
+	if len(events) != 1 {
+		t.Fatalf("got %d events, want 1", len(events))
+	}
+	if events[0].Type != "real" {
+		t.Errorf("event = %+v, want {real ...}", events[0])
+	}
+}
+
+func TestSubscribe_DataWithoutEvent(t *testing.T) {
+	// A "data:" line with no preceding "event:" line has no dispatch
+	// target and must be dropped. Again matches peering's behavior.
+	s := newSSEServer(t)
+	s.setFrames(
+		"data: orphan\n\n",
+		"event: real\ndata: payload\n\n",
+	)
+
+	c := New(s.URL)
+	events, _ := waitForEvents(t, c, 1, 500*time.Millisecond)
+	if len(events) != 1 {
+		t.Fatalf("got %d events, want 1", len(events))
+	}
+	if events[0].Type != "real" || string(events[0].Data) != "payload" {
+		t.Errorf("event = %+v, want {real payload}", events[0])
+	}
+}
+
+func TestSubscribe_CustomHeader(t *testing.T) {
+	var got string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Get("X-Custom")
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprint(w, "event: ok\ndata: 1\n\n")
+	}))
+	defer ts.Close()
+
+	c := New(ts.URL, WithHeader("X-Custom", "hello"))
+	_, _ = waitForEvents(t, c, 1, 500*time.Millisecond)
+	if got != "hello" {
+		t.Errorf("X-Custom = %q, want hello", got)
+	}
+}
+
+func TestSubscribe_AcceptHeader(t *testing.T) {
+	// Accept: text/event-stream is set automatically by New.
+	var got string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Get("Accept")
+		w.Header().Set("Content-Type", "text/event-stream")
+	}))
+	defer ts.Close()
+
+	c := New(ts.URL)
+	_ = c.Subscribe(context.Background(), nil, func(Event) {})
+	if got != "text/event-stream" {
+		t.Errorf("Accept = %q, want text/event-stream", got)
+	}
+}
+
+func TestSubscribe_NilHandlerPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic, got none")
+		}
+	}()
+	c := New("http://localhost")
+	_ = c.Subscribe(context.Background(), nil, nil)
+}
+
+func TestSubscribe_RequestURLInvalid(t *testing.T) {
+	c := New("://not-a-url")
+	err := c.Subscribe(context.Background(), nil, func(Event) {})
+	if err == nil {
+		t.Fatal("expected error for invalid URL")
+	}
+	if errors.Is(err, ErrStreamEnded) || errors.Is(err, ErrUnauthorized) {
+		t.Errorf("err = %v, want a generic request error", err)
+	}
+}
+
+func TestSubscribe_ServerReturns500(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	c := New(ts.URL)
+	err := c.Subscribe(context.Background(), nil, func(Event) {})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if errors.Is(err, ErrUnauthorized) || errors.Is(err, ErrStreamEnded) {
+		t.Errorf("err = %v, want a status error", err)
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Errorf("err = %v, want status code in message", err)
+	}
+}

--- a/services/gmuxd/internal/store/store.go
+++ b/services/gmuxd/internal/store/store.go
@@ -184,18 +184,44 @@ func (s *Store) resolveTitle(sess Session) string {
 }
 
 func (s *Store) Upsert(sess Session) {
-	sess.Cwd = paths.CanonicalizePath(sess.Cwd)
-	sess.WorkspaceRoot = paths.CanonicalizePath(sess.WorkspaceRoot)
 	sess.Title = s.resolveTitle(sess)
 	sess.Resumable = !sess.Alive && len(sess.Command) > 0
+	s.upsertCommon(sess, true)
+}
+
+// UpsertRemote writes a session that was already fully resolved by a
+// peer (spoke). Unlike Upsert it does NOT recompute Title or
+// Resumable: those fields are authoritatively set on the spoke and
+// arriving in the SSE payload already. The spoke intentionally keeps
+// its internal ShellTitle/AdapterTitle fields off the wire, so the
+// hub never has enough information to re-resolve correctly and would
+// otherwise overwrite a correct Title with the adapter Kind fallback.
+//
+// Canonicalization, duplicate-resume-key handling, unique-resume-key
+// numbering, and event broadcast all still run; only the title and
+// resumable derivation are skipped. The dismissed side-map is NOT
+// cleared for remote sessions: dismissal is spoke-side state and the
+// hub's dismissed map only tracks its own file-scanner output.
+func (s *Store) UpsertRemote(sess Session) {
+	s.upsertCommon(sess, false)
+}
+
+// upsertCommon is the shared body of Upsert and UpsertRemote.
+// clearDismissedOnAlive is true for local sessions (where the
+// dismissed map is the hub's own state) and false for remote
+// sessions (where dismissal lives on the spoke).
+func (s *Store) upsertCommon(sess Session, clearDismissedOnAlive bool) {
+	sess.Cwd = paths.CanonicalizePath(sess.Cwd)
+	sess.WorkspaceRoot = paths.CanonicalizePath(sess.WorkspaceRoot)
 	s.mu.Lock()
 	removed, skip := s.resolveDuplicateResumeKeysLocked(sess)
 	if !skip {
 		s.ensureUniqueResumeKey(&sess)
 		s.sessions[sess.ID] = sess
-		// A live session clears any dismissed flag so that if it later
-		// exits the file scanner can rediscover it as resumable.
-		if sess.Alive {
+		if clearDismissedOnAlive && sess.Alive {
+			// A live local session clears any dismissed flag so that
+			// if it later exits the file scanner can rediscover it
+			// as resumable.
 			delete(s.dismissed, sess.ID)
 		}
 	}

--- a/services/gmuxd/internal/store/store_test.go
+++ b/services/gmuxd/internal/store/store_test.go
@@ -630,3 +630,151 @@ func TestUpdateCanonicalizesPaths(t *testing.T) {
 		t.Errorf("Cwd after Update = %q, want %q", got.Cwd, "~/projects/app")
 	}
 }
+
+// ── UpsertRemote ───────────────────────────────────────────────
+//
+// UpsertRemote writes a session that was already fully resolved on a
+// peer. Title and Resumable must be preserved verbatim; canonicalization,
+// dedup, and broadcast must still run.
+
+func TestUpsertRemote_PreservesTitle(t *testing.T) {
+	s := New()
+	// A remote session arrives with Title already set (spoke
+	// resolved it) but internal ShellTitle/AdapterTitle empty (those
+	// are off-wire). Upsert would overwrite Title with Kind; UpsertRemote
+	// must not.
+	s.UpsertRemote(Session{
+		ID:    "sess-123@server",
+		Kind:  "codex",
+		Alive: true,
+		Peer:  "server",
+		Title: "fix remote bug",
+	})
+
+	got, ok := s.Get("sess-123@server")
+	if !ok {
+		t.Fatal("expected session to exist")
+	}
+	if got.Title != "fix remote bug" {
+		t.Errorf("Title = %q, want %q (UpsertRemote must not re-resolve)", got.Title, "fix remote bug")
+	}
+}
+
+func TestUpsertRemote_PreservesResumableFromSpoke(t *testing.T) {
+	s := New()
+	// A dead remote session with Resumable explicitly set to false
+	// by the spoke (e.g. a shell session with no command recorded).
+	// Upsert would derive Resumable from !Alive && len(Command) > 0;
+	// UpsertRemote must preserve the spoke's value.
+	s.UpsertRemote(Session{
+		ID:        "sess-1@server",
+		Kind:      "pi",
+		Alive:     false,
+		Command:   []string{"pi"},
+		Peer:      "server",
+		Resumable: false, // spoke says not resumable despite command
+		Title:     "archived",
+	})
+	got, _ := s.Get("sess-1@server")
+	if got.Resumable {
+		t.Errorf("Resumable = true, want false (UpsertRemote must not re-derive)")
+	}
+}
+
+func TestUpsertRemote_CanonicalizesPaths(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	s := New()
+	s.UpsertRemote(Session{
+		ID:    "sess-path@server",
+		Kind:  "shell",
+		Alive: true,
+		Peer:  "server",
+		Title: "ok",
+		Cwd:   home + "/projects/app",
+	})
+	got, _ := s.Get("sess-path@server")
+	if got.Cwd != "~/projects/app" {
+		t.Errorf("Cwd = %q, want %q (canonicalization must still run)", got.Cwd, "~/projects/app")
+	}
+}
+
+func TestUpsertRemote_DedupsResumeKey(t *testing.T) {
+	s := New()
+	s.UpsertRemote(Session{
+		ID:        "sess-1@server",
+		Kind:      "codex",
+		Alive:     true,
+		Peer:      "server",
+		Title:     "a",
+		ResumeKey: "fix-bug",
+	})
+	s.UpsertRemote(Session{
+		ID:        "sess-2@server",
+		Kind:      "codex",
+		Alive:     true,
+		Peer:      "server",
+		Title:     "b",
+		ResumeKey: "fix-bug",
+	})
+
+	got, _ := s.Get("sess-2@server")
+	if got.ResumeKey == "fix-bug" {
+		t.Errorf("ResumeKey = %q, want a de-duplicated value (e.g. fix-bug-2)", got.ResumeKey)
+	}
+}
+
+func TestUpsertRemote_BroadcastsEvent(t *testing.T) {
+	s := New()
+	ch, cancel := s.Subscribe()
+	defer cancel()
+
+	s.UpsertRemote(Session{
+		ID:    "sess-1@server",
+		Kind:  "codex",
+		Alive: true,
+		Peer:  "server",
+		Title: "hello from spoke",
+	})
+
+	select {
+	case ev := <-ch:
+		if ev.Type != "session-upsert" {
+			t.Errorf("event type = %q, want session-upsert", ev.Type)
+		}
+		if ev.Session == nil || ev.Session.Title != "hello from spoke" {
+			t.Errorf("broadcast session title wrong; got %+v", ev.Session)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("no broadcast")
+	}
+}
+
+func TestUpsertRemote_DoesNotClearDismissed(t *testing.T) {
+	s := New()
+	s.Dismiss("sess-1@server")
+	s.UpsertRemote(Session{
+		ID:    "sess-1@server",
+		Kind:  "codex",
+		Alive: true, // live remote session
+		Peer:  "server",
+		Title: "title",
+	})
+	if !s.IsDismissed("sess-1@server") {
+		t.Errorf("remote Upsert must not clear dismissed (dismissal is spoke-side state)")
+	}
+}
+
+func TestUpsert_StillClearsDismissed(t *testing.T) {
+	// Regression guard: local Upsert must still clear the dismissed
+	// flag when the session comes back alive. UpsertRemote's split
+	// from Upsert mustn't break this path.
+	s := New()
+	s.Dismiss("sess-1")
+	s.Upsert(Session{ID: "sess-1", Kind: "pi", Alive: true})
+	if s.IsDismissed("sess-1") {
+		t.Errorf("local Upsert should clear dismissed")
+	}
+}
+
+


### PR DESCRIPTION
Stacked on #115.

Fixes two reported bugs with remote sessions and refactors `peering.Peer`
onto shared SSE/HTTP/WS primitives so there's one code path instead of two.

## Bugs fixed

**Reconnect banner flashes ~once/second on remote sessions.** The hub's hand-rolled WS proxy inherited a 256 KiB read limit from an old version of `wsproxy.go`. Runner terminal snapshots routinely exceed that on large screens, so the hub read errored, both sides closed, the browser reconnected, and the cycle repeated. The new `apiclient.ProxyWS` uses a 4 MiB limit on the spoke-read side (matching `wsproxy.go`). Regression test `TestProxyWS_LargeSnapshot` pipes a 1 MiB binary payload through the full browser → hub → spoke pipeline and verifies byte-level integrity.

**Remote session titles show as `codex`/`claude`/`pi`.** Spokes keep `ShellTitle`/`AdapterTitle` as internal fields and drop them in `MarshalJSON`; the hub's `store.Upsert` then re-ran `resolveTitle` against the empty fields and overwrote the spoke-resolved title with the Kind fallback. New `store.UpsertRemote` preserves the spoke's `Title` and `Resumable` verbatim while still running canonicalization, dedup, and broadcast. Regression test `TestPeerSubscribe_PreservesTitles` pushes a titled session through the full peering pipeline and verifies the title survives.

## Refactor

Separates protocol primitives from peering-specific policy:

- **New `services/gmuxd/internal/sseclient`** (231 lines, 88% coverage, 17 tests) — SSE event decoder with callback-based `Subscribe(ctx, connected, handler)`. Handles comment-line keepalives, oversized payloads, auth failures, transport errors. No reconnect policy: the caller owns the outer loop, matching how the browser `EventSource` works.

- **New `services/gmuxd/internal/apiclient`** (353 lines, 86% coverage, 23 tests) — typed HTTP/SSE/WS wrapper around the public gmuxd API. `Events()`, `GetConfig()`, `ForwardAction()`, `ForwardLaunch()` (strips `peer` field), `DialWS()`, `ProxyWS()`. Takes a `Transport` option for tsnet-routed peers. Bearer auth or nothing.

- **`peering.Peer` shrinks from 535 → 347 lines** (~35%). Keeps: namespacing, `isKnownOrigin` filter, status state machine, reconnect backoff. Deletes: hand-rolled SSE decoder, HTTP proxy loop, WS proxy loop, `stripPeerField` helper, inline `fetchConfig` plumbing.

- **`store.UpsertRemote`** alongside `store.Upsert`, sharing an `upsertCommon` private helper. Skips `resolveTitle` and trusts the spoke; still runs canonicalization, resume-key dedup, and broadcast. Does not clear `dismissed[]` (spoke-side state). 6 new store tests cover the contract, plus a regression guard `TestUpsert_StillClearsDismissed` for the local path.

The `devcontainers/watcher.go` `Local: true` peer path works unchanged: `WithTransport` still takes a `RoundTripper`, and the new apiclient picks it up in `newPeer`.

## Commits

```
fix(peering): preserve session titles forwarded from spokes
fix(peering): reconnect loop on remote sessions with large terminal snapshots
feat(store): add UpsertRemote for sessions already resolved by a peer
feat(peering): extract apiclient package for typed spoke HTTP access
feat(peering): extract sseclient package for shared SSE decoding
docs: cover shared peering client packages and planned reliability work
```

Three commits are labeled `fix:` so they show up as patch-bump release notes. The `docs(peering)` commit will be deleted before merge in favor of updating the docs site directly.

## Test coverage

- `go test ./services/gmuxd/...` green (47 new tests, 2 removed: `stripPeerField` unit tests moved into `apiclient_test.go`)
- `go test -race` on all touched packages green
- `moon run gmux-web:build` green

Verified the title regression test fails if the one-line `UpsertRemote` swap is reverted (`Title = "codex", want "fix remote bug"`), and the large-snapshot test fails at 256 KiB and passes at 4 MiB.

## Out of scope

Phases C (keepalive + read deadlines) and D (session identity rework, supersedes #115's dismissed side-map) are separate follow-ups. See the planned-features docs for details.