### PR TITLE
fix(peering): handle disconnection instead of preventing it

### DIFF
--- a/services/gmuxd/internal/apiclient/client.go
+++ b/services/gmuxd/internal/apiclient/client.go
@@ -57,9 +57,10 @@ const httpActionTimeout = 10 * time.Second
 // Client is an authenticated HTTP + WebSocket client pointed at one
 // gmuxd instance (the "spoke" from the hub's perspective).
 type Client struct {
-	baseURL   string
-	token     string
-	transport http.RoundTripper
+	baseURL          string
+	token            string
+	transport        http.RoundTripper
+	streamIdleTimeout time.Duration
 
 	// httpClient is a long-lived client with no Timeout so SSE
 	// subscriptions can run indefinitely. Short-lived REST calls use
@@ -81,6 +82,13 @@ func WithBearerToken(token string) Option {
 // calls. Used by tailscale-discovered peers to route through tsnet.
 func WithTransport(t http.RoundTripper) Option {
 	return func(c *Client) { c.transport = t }
+}
+
+// WithStreamIdleTimeout configures the SSE idle timeout passed to
+// sseclient.WithIdleTimeout on Events(). A zero value (the default)
+// means no idle detection.
+func WithStreamIdleTimeout(d time.Duration) Option {
+	return func(c *Client) { c.streamIdleTimeout = d }
 }
 
 // New creates a Client pointed at baseURL (e.g. "http://host:8790").
@@ -113,6 +121,9 @@ func (c *Client) Events() *sseclient.Client {
 	opts := []sseclient.Option{sseclient.WithBearerToken(c.token)}
 	if c.transport != nil {
 		opts = append(opts, sseclient.WithTransport(c.transport))
+	}
+	if c.streamIdleTimeout > 0 {
+		opts = append(opts, sseclient.WithIdleTimeout(c.streamIdleTimeout))
 	}
 	return sseclient.New(c.baseURL+"/v1/events", opts...)
 }

--- a/services/gmuxd/internal/peering/manager.go
+++ b/services/gmuxd/internal/peering/manager.go
@@ -12,13 +12,14 @@ import (
 
 // Manager orchestrates connections to all configured spoke peers.
 type Manager struct {
-	mu       sync.RWMutex
-	peers    map[string]*managedPeer
-	store    *store.Store
-	selfName string // this machine's hostname, for self-echo detection
-	baseCtx  context.Context
-	cancel   context.CancelFunc
-	wg       sync.WaitGroup
+	mu          sync.RWMutex
+	peers       map[string]*managedPeer
+	store       *store.Store
+	selfName    string // this machine's hostname, for self-echo detection
+	defaultOpts []PeerOption
+	baseCtx     context.Context
+	cancel      context.CancelFunc
+	wg          sync.WaitGroup
 }
 
 type managedPeer struct {
@@ -33,15 +34,16 @@ type managedPeer struct {
 // selfName is the local machine's hostname, used to detect (and drop)
 // sessions that are our own data echoed back through a mutual peer
 // subscription.
-func NewManager(configs []config.PeerConfig, st *store.Store, selfName string) *Manager {
+func NewManager(configs []config.PeerConfig, st *store.Store, selfName string, opts ...PeerOption) *Manager {
 	m := &Manager{
-		peers:    make(map[string]*managedPeer, len(configs)),
-		store:    st,
-		selfName: selfName,
+		peers:       make(map[string]*managedPeer, len(configs)),
+		store:       st,
+		selfName:    selfName,
+		defaultOpts: opts,
 	}
 
 	for _, cfg := range configs {
-		p := newPeer(cfg, st, m.onStatus)
+		p := newPeer(cfg, st, m.onStatus, opts...)
 		p.isKnownOrigin = m.isKnownOrigin
 		m.peers[cfg.Name] = &managedPeer{peer: p}
 	}
@@ -152,7 +154,8 @@ func (m *Manager) AddPeer(cfg config.PeerConfig, opts ...PeerOption) {
 		return
 	}
 
-	p := newPeer(cfg, m.store, m.onStatus, opts...)
+	allOpts := append(m.defaultOpts, opts...)
+	p := newPeer(cfg, m.store, m.onStatus, allOpts...)
 	p.isKnownOrigin = m.isKnownOrigin
 	mp := &managedPeer{peer: p}
 	m.peers[cfg.Name] = mp

--- a/services/gmuxd/internal/peering/peer.go
+++ b/services/gmuxd/internal/peering/peer.go
@@ -17,6 +17,13 @@ import (
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/store"
 )
 
+// defaultStreamIdleTimeout is the maximum time the SSE stream can be
+// silent before we assume the connection is dead and reconnect. 60s
+// is conservative: real events flow every few seconds on an active
+// spoke, and on an idle spoke the reconnect is invisible (sessions
+// stay in the store, the initial dump produces no-op upserts).
+const defaultStreamIdleTimeout = 60 * time.Second
+
 // Peer manages the connection to a single remote gmuxd instance.
 //
 // Protocol primitives (SSE decode, HTTP forwarding, WS proxying) live
@@ -46,6 +53,10 @@ type Peer struct {
 	// nil means use the default transport. Set via WithTransport for
 	// tailscale-discovered peers that route through tsnet.
 	transport http.RoundTripper
+
+	// streamIdleTimeout overrides the default SSE idle timeout.
+	// Zero means use defaultStreamIdleTimeout.
+	streamIdleTimeout time.Duration
 }
 
 func newPeer(cfg config.PeerConfig, st *store.Store, onStatus func(string, Status), opts ...PeerOption) *Peer {
@@ -64,6 +75,12 @@ func newPeer(cfg config.PeerConfig, st *store.Store, onStatus func(string, Statu
 	if p.transport != nil {
 		apiOpts = append(apiOpts, apiclient.WithTransport(p.transport))
 	}
+	// Idle timeout: detect silent network drops on the SSE stream.
+	idleTimeout := defaultStreamIdleTimeout
+	if p.streamIdleTimeout > 0 {
+		idleTimeout = p.streamIdleTimeout
+	}
+	apiOpts = append(apiOpts, apiclient.WithStreamIdleTimeout(idleTimeout))
 	p.api = apiclient.New(cfg.URL, apiOpts...)
 	return p
 }
@@ -164,20 +181,22 @@ func (p *Peer) run(ctx context.Context) {
 		wasConnected := false
 		err := p.subscribe(ctx, func() { wasConnected = true })
 
-		// Clean up spoke sessions from store on disconnect.
-		removed := p.store.RemoveByPeer(p.Config.Name)
-		if len(removed) > 0 {
-			log.Printf("peering: %s: removed %d sessions on disconnect", p.Config.Name, len(removed))
-		}
+		// Sessions stay in the store across reconnects. The spoke's
+		// initial dump on the next successful connect will upsert
+		// current state; anything the spoke no longer reports stays
+		// as stale-but-visible until the user dismisses it.
+		// RemoveByPeer only runs on intentional peer removal (see
+		// Manager.removePeer).
 
 		if err != nil && ctx.Err() == nil {
 			p.mu.Lock()
 			p.lastError = categorizeError(err)
 			p.mu.Unlock()
 		}
-		p.mu.Lock()
-		p.cachedConfig = nil
-		p.mu.Unlock()
+		// Keep cachedConfig across reconnects: the spoke's config
+		// doesn't change because our connection dropped, and clearing
+		// it would make /v1/config return empty for this peer during
+		// the brief reconnect window.
 		p.setStatus(StatusDisconnected)
 
 		if ctx.Err() != nil {
@@ -236,6 +255,8 @@ func (p *Peer) subscribe(ctx context.Context, onConnected func()) error {
 		return fmt.Errorf("stream ended")
 	case errors.Is(err, sseclient.ErrStreamEnded):
 		return fmt.Errorf("stream ended")
+	case errors.Is(err, sseclient.ErrStreamIdle):
+		return fmt.Errorf("no data received")
 	case errors.Is(err, sseclient.ErrUnauthorized):
 		return fmt.Errorf("auth failed: %w", err)
 	default:
@@ -344,6 +365,8 @@ func categorizeError(err error) string {
 	case strings.Contains(s, "certificate"),
 		strings.Contains(s, "x509"):
 		return "TLS certificate error"
+	case strings.Contains(s, "no data received"):
+		return "no data received"
 	case strings.Contains(s, "stream ended"):
 		return "connection lost"
 	default:

--- a/services/gmuxd/internal/peering/peer_error_test.go
+++ b/services/gmuxd/internal/peering/peer_error_test.go
@@ -17,6 +17,7 @@ func TestCategorizeError(t *testing.T) {
 		{"connect: dial tcp 10.0.0.1:443: i/o timeout", "connection timed out"},
 		{"connect: tls: failed to verify certificate", "TLS certificate error"},
 		{"connect: x509: certificate signed by unknown authority", "TLS certificate error"},
+		{"no data received", "no data received"},
 		{"stream ended", "connection lost"},
 		{"read: unexpected EOF", "connection failed"},
 	}

--- a/services/gmuxd/internal/peering/peering.go
+++ b/services/gmuxd/internal/peering/peering.go
@@ -23,6 +23,7 @@ package peering
 import (
 	"net/http"
 	"strings"
+	"time"
 )
 
 // PeerOption configures a Peer at creation time.
@@ -35,6 +36,15 @@ type PeerOption func(*Peer)
 func WithTransport(rt http.RoundTripper) PeerOption {
 	return func(p *Peer) {
 		p.transport = rt
+	}
+}
+
+// WithStreamIdleTimeout overrides the default SSE idle timeout for
+// this peer. Intended for tests that need fast idle detection without
+// waiting 60 seconds.
+func WithStreamIdleTimeout(d time.Duration) PeerOption {
+	return func(p *Peer) {
+		p.streamIdleTimeout = d
 	}
 }
 

--- a/services/gmuxd/internal/peering/peering_test.go
+++ b/services/gmuxd/internal/peering/peering_test.go
@@ -786,7 +786,7 @@ func TestManagerPeerConfigs_SkipsDisconnected(t *testing.T) {
 	}
 }
 
-func TestCachedConfig_ClearedOnDisconnect(t *testing.T) {
+func TestCachedConfig_PersistsAcrossDisconnect(t *testing.T) {
 	spoke := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.Write([]byte(`{"ok":true,"data":{"launchers":[]}}`))
@@ -807,12 +807,12 @@ func TestCachedConfig_ClearedOnDisconnect(t *testing.T) {
 		t.Fatal("expected non-nil cache after fetch")
 	}
 
-	// Cleared when we simulate disconnect (same as the run loop does).
-	p.mu.Lock()
-	p.cachedConfig = nil
-	p.mu.Unlock()
-	if p.CachedConfig() != nil {
-		t.Fatal("expected nil cache after disconnect")
+	// Cache survives a status transition to disconnected. The spoke's
+	// config doesn't change because our connection dropped, so keeping
+	// the cache avoids a gap in /v1/config responses during reconnect.
+	p.setStatus(StatusDisconnected)
+	if p.CachedConfig() == nil {
+		t.Fatal("expected cache to persist across disconnect")
 	}
 }
 
@@ -1094,19 +1094,62 @@ func TestOnSleep_ReconnectsAndResyncs(t *testing.T) {
 	// Trigger sleep recovery.
 	mgr.OnSleep()
 
-	// Wait for reconnection and resync.
+	// Wait for reconnection: sess-1 arrives in the fresh dump.
 	waitForSessions(t, st, "remote", 1)
 
-	// sess-2 should be gone (RemoveByPeer cleared it, initial dump
-	// only re-added sess-1).
-	if s, ok := st.Get("sess-2@remote"); ok && s.Alive {
-		t.Error("sess-2@remote should not be alive after OnSleep resync")
-	}
-
-	// sess-1 should still be alive.
+	// sess-1 should be alive (refreshed by the new dump).
 	if s, ok := st.Get("sess-1@remote"); !ok || !s.Alive {
 		t.Error("sess-1@remote should be alive after OnSleep resync")
 	}
 
+	// sess-2 stays in the store (stale but visible). Sessions persist
+	// across reconnects; only intentional peer removal or user dismiss
+	// deletes them. The spoke's dump didn't include sess-2, so it
+	// retains its last-known state.
+	if _, ok := st.Get("sess-2@remote"); !ok {
+		t.Error("sess-2@remote should still exist (sessions persist across reconnects)")
+	}
+
 	mgr.Stop()
+}
+
+// TestDisconnect_SessionsPersist verifies that a network disconnect does
+// not remove remote sessions from the store. Sessions stay visible so the
+// user's sidebar is stable across transient connection drops.
+func TestDisconnect_SessionsPersist(t *testing.T) {
+	st := store.New()
+	sessions := []store.Session{
+		{ID: "sess-1", Kind: "pi", Alive: true, Title: "important work"},
+		{ID: "sess-2", Kind: "codex", Alive: true, Title: "background task"},
+	}
+
+	// spokeServer sends sessions then closes, simulating a disconnect.
+	sk := spokeServer(t, "", sessions)
+	cfg := config.PeerConfig{Name: "server", URL: sk.URL}
+
+	// Short idle timeout so the test doesn't wait 60s for the default.
+	mgr := NewManager([]config.PeerConfig{cfg}, st, "test-host",
+		WithStreamIdleTimeout(200*time.Millisecond))
+	mgr.Start()
+	waitForSessions(t, st, "server", 2)
+
+	// Spoke closes the SSE stream (simulates disconnect).
+	// Wait for the idle timeout to fire + reconnect attempt to start.
+	sk.Close()
+	time.Sleep(500 * time.Millisecond)
+
+	// Both sessions must still be in the store.
+	if _, ok := st.Get("sess-1@server"); !ok {
+		t.Error("sess-1@server should persist after disconnect")
+	}
+	if _, ok := st.Get("sess-2@server"); !ok {
+		t.Error("sess-2@server should persist after disconnect")
+	}
+
+	mgr.Stop()
+
+	// After intentional Stop, sessions ARE removed (Manager.removePeer).
+	if _, ok := st.Get("sess-1@server"); ok {
+		t.Error("sess-1@server should be removed after Stop")
+	}
 }

--- a/services/gmuxd/internal/sseclient/client.go
+++ b/services/gmuxd/internal/sseclient/client.go
@@ -22,8 +22,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
+	"time"
 )
 
 // Default buffer size for SSE event decoding. Matches the size used
@@ -40,6 +42,13 @@ var ErrStreamEnded = errors.New("sse stream ended")
 // with HTTP 401 or 403. Callers typically do not retry this.
 var ErrUnauthorized = errors.New("sse unauthorized")
 
+// ErrStreamIdle is returned by Subscribe when the server sent no data
+// within the configured idle timeout. This covers silent network
+// drops (NAT rebind, Tailscale tunnel hiccup, mobile suspend) where
+// the TCP socket stays open but no bytes flow. Callers treat this
+// like any other disconnect and reconnect.
+var ErrStreamIdle = errors.New("sse stream idle")
+
 // Event is a decoded SSE event. Data is the raw bytes from one or
 // more "data:" lines, concatenated with newlines (per the spec).
 // Callers parse Data according to their own schema.
@@ -54,10 +63,11 @@ type Event struct {
 // URL (e.g. after a reconnect) but not safe for concurrent Subscribe
 // calls from multiple goroutines.
 type Client struct {
-	url       string
-	headers   http.Header
-	transport http.RoundTripper
-	bufSize   int
+	url         string
+	headers     http.Header
+	transport   http.RoundTripper
+	bufSize     int
+	idleTimeout time.Duration
 }
 
 // Option configures a Client.
@@ -99,6 +109,65 @@ func WithBufferSize(n int) Option {
 			c.bufSize = n
 		}
 	}
+}
+
+// WithIdleTimeout configures how long Subscribe waits for any data
+// before returning ErrStreamIdle. The deadline resets on every line
+// received (events, comments, partial frames). A zero or negative
+// value disables idle detection (the default).
+//
+// This is a detection mechanism, not a prevention mechanism: it does
+// not send anything to the server. It simply surfaces silent network
+// drops faster than TCP's default retransmit timeout (which can be
+// minutes or hours on idle connections).
+func WithIdleTimeout(d time.Duration) Option {
+	return func(c *Client) {
+		c.idleTimeout = d
+	}
+}
+
+// idleAwareBody wraps an io.ReadCloser so that reads fail when the
+// idle context is cancelled. Without this, bufio.Scanner.Scan would
+// block forever on a TCP socket that never sends data, because
+// context cancellation alone doesn't interrupt a blocking read on
+// an http.Response.Body.
+type idleAwareBody struct {
+	body io.ReadCloser
+	ctx  context.Context
+}
+
+func (b *idleAwareBody) Read(p []byte) (int, error) {
+	// Fast path: check context before blocking.
+	if err := b.ctx.Err(); err != nil {
+		return 0, err
+	}
+	// Read with a background poll on context. We use a goroutine + select
+	// so the idle timer can unblock a stuck Read. The goroutine exits
+	// when the Read completes OR when the context fires (in which case
+	// closing the body unblocks the Read).
+	type result struct {
+		n   int
+		err error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		n, err := b.body.Read(p)
+		ch <- result{n, err}
+	}()
+	select {
+	case r := <-ch:
+		return r.n, r.err
+	case <-b.ctx.Done():
+		// Close the body to unblock the goroutine's Read.
+		b.body.Close()
+		// Wait for it to finish so we don't leak.
+		<-ch
+		return 0, b.ctx.Err()
+	}
+}
+
+func (b *idleAwareBody) Close() error {
+	return b.body.Close()
 }
 
 // New creates a Client pointed at url.
@@ -172,7 +241,33 @@ func (c *Client) Subscribe(ctx context.Context, connected func(), handler func(E
 		connected()
 	}
 
-	scanner := bufio.NewScanner(resp.Body)
+	// Idle timeout: wrap the caller's context with a resettable timer.
+	// When the timer fires it cancels only the inner context, causing
+	// scanner.Scan to fail on the next read. We distinguish this from
+	// a caller-initiated cancel by checking ctx.Err() == nil.
+	idleCtx := ctx
+	idleCancel := func() {} // noop when no idle timeout
+	var idleTimer *time.Timer
+	if c.idleTimeout > 0 {
+		var cancel context.CancelFunc
+		idleCtx, cancel = context.WithCancel(ctx)
+		idleCancel = cancel
+		idleTimer = time.AfterFunc(c.idleTimeout, cancel)
+	}
+	defer idleCancel()
+	if idleTimer != nil {
+		defer idleTimer.Stop()
+	}
+
+	// The HTTP request was made with the caller's ctx, but we need the
+	// idle-aware context to cancel the body read. Attach it by piping
+	// through a context-aware reader.
+	body := resp.Body
+	if idleTimer != nil {
+		body = &idleAwareBody{body: resp.Body, ctx: idleCtx}
+	}
+
+	scanner := bufio.NewScanner(body)
 	// bufio.Scanner uses max(initial cap, configured max) as the real
 	// limit, so the initial cap must not exceed bufSize or the max is
 	// a no-op for small bufSize values.
@@ -184,6 +279,9 @@ func (c *Client) Subscribe(ctx context.Context, connected func(), handler func(E
 
 	var currentEvent string
 	for scanner.Scan() {
+		if idleTimer != nil {
+			idleTimer.Reset(c.idleTimeout)
+		}
 		if err := ctx.Err(); err != nil {
 			return err
 		}
@@ -218,13 +316,22 @@ func (c *Client) Subscribe(ctx context.Context, connected func(), handler func(E
 	}
 
 	if err := scanner.Err(); err != nil {
-		// ctx.Err() takes priority: if the caller cancelled, surface
-		// that directly rather than the ambient "context canceled"
-		// wrapped in a read error.
+		// Caller cancel takes priority over any ambient errors.
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return ctxErr
 		}
+		// Idle timeout: the inner context was cancelled but the
+		// caller's context is still live.
+		if idleCtx.Err() != nil && ctx.Err() == nil {
+			return ErrStreamIdle
+		}
 		return fmt.Errorf("sse read: %w", err)
+	}
+
+	// Clean EOF: check idle timeout even if scanner didn't error
+	// (the body might have been closed by the idle timer).
+	if idleCtx.Err() != nil && ctx.Err() == nil {
+		return ErrStreamIdle
 	}
 
 	return ErrStreamEnded

--- a/services/gmuxd/internal/sseclient/client_test.go
+++ b/services/gmuxd/internal/sseclient/client_test.go
@@ -423,6 +423,143 @@ func TestSubscribe_RequestURLInvalid(t *testing.T) {
 	}
 }
 
+// ── Idle timeout ──────────────────────────────────────────────────
+
+func TestSubscribe_IdleTimeout_SilentServer(t *testing.T) {
+	// Server accepts the connection, sends headers, then goes silent.
+	// Subscribe should return ErrStreamIdle after the idle timeout.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(200)
+		w.(http.Flusher).Flush()
+		// Block until client disconnects.
+		<-r.Context().Done()
+	}))
+	defer ts.Close()
+
+	c := New(ts.URL, WithIdleTimeout(100*time.Millisecond))
+	var connected bool
+	err := c.Subscribe(context.Background(),
+		func() { connected = true },
+		func(Event) { t.Error("unexpected event") },
+	)
+	if !connected {
+		t.Error("connected callback should have fired")
+	}
+	if !errors.Is(err, ErrStreamIdle) {
+		t.Errorf("err = %v, want ErrStreamIdle", err)
+	}
+}
+
+func TestSubscribe_IdleTimeout_ActiveServerResets(t *testing.T) {
+	// Server sends events faster than the idle timeout. The timeout
+	// should never fire.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(200)
+		f := w.(http.Flusher)
+		for i := 0; i < 5; i++ {
+			fmt.Fprintf(w, "event: ping\ndata: %d\n\n", i)
+			f.Flush()
+			time.Sleep(50 * time.Millisecond)
+		}
+	}))
+	defer ts.Close()
+
+	c := New(ts.URL, WithIdleTimeout(200*time.Millisecond))
+	var count int
+	err := c.Subscribe(context.Background(), nil, func(ev Event) {
+		count++
+	})
+	// Server closes stream cleanly after 5 events.
+	if !errors.Is(err, ErrStreamEnded) {
+		t.Errorf("err = %v, want ErrStreamEnded", err)
+	}
+	if count != 5 {
+		t.Errorf("got %d events, want 5", count)
+	}
+}
+
+func TestSubscribe_IdleTimeout_CallerCancelTakesPriority(t *testing.T) {
+	// If the caller cancels before the idle timeout, the error should
+	// be context.Canceled, not ErrStreamIdle.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(200)
+		w.(http.Flusher).Flush()
+		<-r.Context().Done()
+	}))
+	defer ts.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel quickly, well before the 5s idle timeout.
+	time.AfterFunc(50*time.Millisecond, cancel)
+
+	c := New(ts.URL, WithIdleTimeout(5*time.Second))
+	err := c.Subscribe(ctx, nil, func(Event) {})
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("err = %v, want context.Canceled", err)
+	}
+}
+
+func TestSubscribe_IdleTimeout_CommentResetsDeadline(t *testing.T) {
+	// Server sends comment lines (keepalives). Even though they don't
+	// produce events, they should reset the idle timer because they
+	// prove the connection is alive.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(200)
+		f := w.(http.Flusher)
+		// Send comments every 50ms for 300ms, then one real event, then close.
+		for i := 0; i < 6; i++ {
+			fmt.Fprintln(w, ": keepalive")
+			f.Flush()
+			time.Sleep(50 * time.Millisecond)
+		}
+		fmt.Fprintln(w, "event: done")
+		fmt.Fprintln(w, "data: ok")
+		fmt.Fprintln(w)
+		f.Flush()
+	}))
+	defer ts.Close()
+
+	// Idle timeout is 150ms; the 50ms comment interval keeps it alive
+	// for 300ms total, then the real event arrives.
+	c := New(ts.URL, WithIdleTimeout(150*time.Millisecond))
+	var got []string
+	err := c.Subscribe(context.Background(), nil, func(ev Event) {
+		got = append(got, ev.Type)
+	})
+	if !errors.Is(err, ErrStreamEnded) {
+		t.Errorf("err = %v, want ErrStreamEnded", err)
+	}
+	if len(got) != 1 || got[0] != "done" {
+		t.Errorf("events = %v, want [done]", got)
+	}
+}
+
+func TestSubscribe_NoIdleTimeout_InfiniteByDefault(t *testing.T) {
+	// Without WithIdleTimeout, the client should block until the
+	// server closes or the caller cancels. Here we cancel after 50ms
+	// to prove no spurious ErrStreamIdle.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(200)
+		w.(http.Flusher).Flush()
+		<-r.Context().Done()
+	}))
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	c := New(ts.URL) // no idle timeout
+	err := c.Subscribe(ctx, nil, func(Event) {})
+	if errors.Is(err, ErrStreamIdle) {
+		t.Error("got ErrStreamIdle without idle timeout configured")
+	}
+}
+
 func TestSubscribe_ServerReturns500(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "boom", http.StatusInternalServerError)


### PR DESCRIPTION
## Philosophy

Disconnection is inevitable in a distributed system. Instead of trying to prevent it (keepalives, heartbeats), detect it promptly and recover quickly while keeping the user's sidebar stable.

This PR does three things:

### 1. Sessions persist across reconnects

`peer.run` no longer calls `store.RemoveByPeer` on disconnect. Remote sessions stay in the store with their last-known state. When the spoke reconnects, its initial dump flows through `handleEvent` → `UpsertRemote` and updates whatever changed. Sessions the spoke no longer reports stay as stale-but-visible; Phase D's state-enum model will handle their lifecycle properly.

`RemoveByPeer` still runs on intentional peer removal (`Manager.Stop`, config-driven removal) so sessions get cleaned up when a peer is permanently removed.

Cached config also persists across reconnects: the spoke's config doesn't change because our connection dropped, and clearing it was making `/v1/config` return empty during the brief reconnect window.

**User-visible change:** transient network blips no longer cause remote sessions to vanish and reappear in the sidebar. The host card changes to "disconnected" status but the session rows stay put.

### 2. Idle stream detection via read deadline

New `sseclient.WithIdleTimeout(d)` option. When set, `Subscribe` returns `ErrStreamIdle` if no bytes arrive within the configured window. The deadline resets on every line (events, comments, partial frames).

Implementation: a resettable `time.AfterFunc` cancels an inner context; an `idleAwareBody` wrapper makes the cancel interrupt a blocking `Read` on the HTTP response body. The goroutine in the wrapper is bounded: it exits when Read completes or when body.Close unblocks it, and we always wait for it before returning.

Default is 60 seconds, configurable per-peer via `WithStreamIdleTimeout` (for tests and future config). On an idle spoke this causes a silent reconnect every 60s, which is invisible because sessions stay in the store and the spoke's dump produces no-op upserts.

### 3. No keepalives

Explicitly **not** adding:
- Spoke-side SSE comment heartbeats (`: \n\n`)
- WebSocket ping/pong ticker on `apiclient.ProxyWS`
- `Last-Event-ID` sequencing

These were in the original Phase C plan and have been deliberately cut. The read deadline is a detection mechanism, not a prevention mechanism.

## Commits

```
feat(sseclient): detect idle streams with configurable read deadline
fix(peering): keep remote sessions visible across reconnects
```

## Details found during review

- **`categorizeError` was mapping idle timeouts to "connection failed"**: the `"no data received"` string from `ErrStreamIdle` had no case in the error categorizer and fell through to the generic bucket. Fixed; added test case to the existing `TestCategorizeError` table.
- **`TestCachedConfig_ClearedOnDisconnect` was testing removed behavior**: renamed to `TestCachedConfig_PersistsAcrossDisconnect` and updated assertions to match the new semantics (config survives disconnect).
- **`Manager.AddPeer` was not applying `defaultOpts`**: devcontainer-discovered peers (added via `AddPeer`) would have missed any manager-level options. Fixed by prepending `m.defaultOpts` to the per-peer opts.

## Tests

- 5 new sseclient tests: silent server → `ErrStreamIdle`; active server resets deadline; caller cancel takes priority; comment lines reset deadline; no idle timeout by default
- 1 new peering test: `TestDisconnect_SessionsPersist` (disconnect + verify sessions stay + Stop + verify sessions removed)
- 1 updated test: `TestOnSleep_ReconnectsAndResyncs` (asserts sessions persist instead of asserting removal)
- 1 renamed + updated test: `TestCachedConfig_PersistsAcrossDisconnect`
- 1 new categorizeError case: "no data received" → "no data received"
- All existing tests pass, race detector clean on touched packages
