### PR TITLE
fix(web): handle Android autocorrect in mobile input handler

### DIFF
--- a/apps/gmux-web/src/mobile-input.test.ts
+++ b/apps/gmux-web/src/mobile-input.test.ts
@@ -104,6 +104,40 @@ function simulateInput(
   return { stoppedBeforeXterm: immediateStopped }
 }
 
+/**
+ * Simulate Android autocorrect: deleteContentBackward with non-collapsed
+ * selection, immediately followed by insertText with collapsed selection.
+ *
+ * Returns whether the insertText's input event was stopped before xterm.
+ */
+function simulateAndroidAutocorrect(
+  textarea: ReturnType<typeof createFakeTextarea>,
+  container: ReturnType<typeof createFakeContainer>,
+  data: string,
+): { stoppedBeforeXterm: boolean } {
+  // Phase 1a: beforeinput deleteContentBackward
+  textarea.dispatch('beforeinput', {
+    inputType: 'deleteContentBackward',
+    data: null,
+    dataTransfer: null,
+  })
+
+  // Browser applies the deletion
+  const delStart = textarea.selectionStart
+  const delEnd = textarea.selectionEnd
+  textarea.value = textarea.value.substring(0, delStart) + textarea.value.substring(delEnd)
+  textarea.selectionStart = textarea.selectionEnd = delStart
+
+  // Phase 1b: input deleteContentBackward (container capture → textarea)
+  const delResult = container.dispatch('input', { inputType: 'deleteContentBackward', data: null })
+  if (!delResult.immediateStopped) {
+    textarea.dispatch('input', { inputType: 'deleteContentBackward', data: null })
+  }
+
+  // Phase 2: the insertText half
+  return simulateInput(textarea, container, 'insertText', data)
+}
+
 // ── Tests ──
 
 describe('attachMobileInputHandler', () => {
@@ -247,6 +281,129 @@ describe('attachMobileInputHandler', () => {
     expect(sent).toBe('\x7f'.repeat(4) + 'test')
   })
 
+  // ── Android autocorrect (deleteContentBackward + insertText) ──
+
+  it('handles Android autocorrect at end of line', () => {
+    // Trace from real Android device (Chrome 146, GBoard):
+    // User typed "lets", keyboard corrects to "let's "
+    //   deleteContentBackward selStart=36 selEnd=37 (deletes "s")
+    //   insertText data="'s " selStart=36 selEnd=36
+    textarea.value = 'hello , let\'s autocorrect thists lets'
+    textarea.selectionStart = 36
+    textarea.selectionEnd = 37
+
+    const { stoppedBeforeXterm } = simulateAndroidAutocorrect(textarea, container, "'s ")
+
+    expect(stoppedBeforeXterm).toBe(true)
+    // 1 backspace (erase from deleteStart=36 to end=37) + replacement + no suffix
+    expect(sent).toBe('\x7f' + "'s ")
+    // Textarea reset to pre-autocorrect value to neutralize _handleAnyTextareaChanges
+    expect(textarea.value).toBe('hello , let\'s autocorrect thists lets')
+  })
+
+  it('handles Android autocorrect in the middle of text', () => {
+    // "helo world" → correct "helo" to "hello"
+    // delete "lo" (positions 2-4), insert "llo"
+    textarea.value = 'helo world'
+    textarea.selectionStart = 2
+    textarea.selectionEnd = 4
+
+    const { stoppedBeforeXterm } = simulateAndroidAutocorrect(textarea, container, 'llo')
+
+    expect(stoppedBeforeXterm).toBe(true)
+    // 8 backspaces (erase from deleteStart=2 to end=10: "lo world")
+    // then replacement "llo" + suffix " world"
+    expect(sent).toBe('\x7f'.repeat(8) + 'llo world')
+    // Textarea reset to pre-autocorrect value
+    expect(textarea.value).toBe('helo world')
+  })
+
+  it('does not treat collapsed backspace + typing as autocorrect', () => {
+    // Non-collapsed delete sets tracking
+    textarea.value = 'hello world'
+    textarea.selectionStart = 5
+    textarea.selectionEnd = 8
+    textarea.dispatch('beforeinput', {
+      inputType: 'deleteContentBackward',
+      data: null,
+      dataTransfer: null,
+    })
+
+    // Collapsed delete (normal backspace) should clear the stale tracking
+    textarea.value = 'helloorld'
+    textarea.selectionStart = 5
+    textarea.selectionEnd = 5
+    textarea.dispatch('beforeinput', {
+      inputType: 'deleteContentBackward',
+      data: null,
+      dataTransfer: null,
+    })
+
+    // This insertText should pass through as a normal append, not autocorrect
+    textarea.value = 'hellorld'
+    textarea.selectionStart = 4
+    textarea.selectionEnd = 4
+
+    const { stoppedBeforeXterm } = simulateInput(textarea, container, 'insertText', 'o')
+
+    expect(sent).toBe('')
+    expect(stoppedBeforeXterm).toBe(false)
+  })
+
+  it('clears tracked deletion when a non-text event intervenes', () => {
+    textarea.value = 'hello'
+    textarea.selectionStart = 3
+    textarea.selectionEnd = 5
+
+    // deleteContentBackward with non-collapsed selection
+    textarea.dispatch('beforeinput', {
+      inputType: 'deleteContentBackward',
+      data: null,
+      dataTransfer: null,
+    })
+
+    // An unrelated event type intervenes, clearing the tracked deletion
+    textarea.dispatch('beforeinput', {
+      inputType: 'insertCompositionText',
+      data: null,
+      dataTransfer: null,
+    })
+
+    // The following insertText should be treated as a normal append
+    textarea.value = 'hel'
+    textarea.selectionStart = 3
+    textarea.selectionEnd = 3
+
+    const { stoppedBeforeXterm } = simulateInput(textarea, container, 'insertText', 'p')
+
+    expect(sent).toBe('')
+    expect(stoppedBeforeXterm).toBe(false)
+  })
+
+  it('handles successive Android autocorrects independently', () => {
+    // First autocorrect: "teh" → "the"
+    textarea.value = 'teh wrld'
+    textarea.selectionStart = 0
+    textarea.selectionEnd = 3
+
+    let r = simulateAndroidAutocorrect(textarea, container, 'the')
+    expect(r.stoppedBeforeXterm).toBe(true)
+    expect(sent).toBe('\x7f'.repeat(8) + 'the wrld')
+    expect(textarea.value).toBe('teh wrld') // reset
+
+    sent = ''
+
+    // Second autocorrect: "wrld" → "world" (on the reset textarea)
+    textarea.value = 'the wrld'
+    textarea.selectionStart = 4
+    textarea.selectionEnd = 8
+
+    r = simulateAndroidAutocorrect(textarea, container, 'world')
+    expect(r.stoppedBeforeXterm).toBe(true)
+    expect(sent).toBe('\x7f'.repeat(4) + 'world')
+    expect(textarea.value).toBe('the wrld') // reset
+  })
+
   // ── Edge cases ──
 
   it('ignores replacement with empty text', () => {
@@ -260,12 +417,12 @@ describe('attachMobileInputHandler', () => {
     expect(stoppedBeforeXterm).toBe(false)
   })
 
-  it('ignores non-text input types', () => {
+  it('ignores unhandled input types', () => {
     textarea.value = 'hello'
     textarea.selectionStart = 0
     textarea.selectionEnd = 5
 
-    const { stoppedBeforeXterm } = simulateInput(textarea, container, 'deleteContentBackward', '')
+    const { stoppedBeforeXterm } = simulateInput(textarea, container, 'insertLineBreak', '')
 
     expect(sent).toBe('')
     expect(stoppedBeforeXterm).toBe(false)

--- a/apps/gmux-web/src/mobile-input.ts
+++ b/apps/gmux-web/src/mobile-input.ts
@@ -2,27 +2,40 @@
  * Mobile keyboard input fixes for xterm.js.
  *
  * Problem: mobile keyboards (iOS autocorrect, dictation, predictive text)
- * replace words in xterm's hidden textarea rather than appending. The
- * replacement is signaled by a non-collapsed selection (selectionStart <
- * selectionEnd) in a beforeinput event. xterm.js doesn't distinguish
- * replacements from appends: its _inputEvent handler sends the full ev.data
- * for every insertText event, so each replacement re-sends the entire text
- * that was already on screen, causing cascading duplication.
+ * replace words in xterm's hidden textarea rather than appending. xterm.js
+ * doesn't distinguish replacements from appends, so each replacement
+ * re-sends text that was already on screen, causing cascading duplication.
  *
- * iOS Safari fires these replacements as inputType='insertText' (not
- * 'insertReplacementText'), so we must handle both.
+ * The replacement signal differs by platform:
+ *
+ *   iOS Safari: a single insertText (or insertReplacementText) with a
+ *   non-collapsed selection (selectionStart < selectionEnd).
+ *
+ *   Android Chrome: a deleteContentBackward with non-collapsed selection,
+ *   immediately followed by an insertText with collapsed selection. Same
+ *   logical operation, split into two DOM events.
  *
  * Fix: two-phase interception.
  *
- *   beforeinput (textarea, capture): when we detect a replacement (selStart <
- *   selEnd), send backspaces to erase from the replacement start to the end
- *   of the textarea (everything that was already sent to the PTY). Save the
- *   replacement text and any suffix for phase two.
+ *   beforeinput (textarea, capture): detect the replacement signal (iOS:
+ *   non-collapsed selection on insertText; Android: deleteContentBackward
+ *   with non-collapsed selection, carried forward to the next insertText).
+ *   Send backspaces to erase from the replacement start to the end of the
+ *   textarea.
  *
  *   input (container, capture): fires before xterm's handler on the textarea
  *   because capture goes parent-first. We stopImmediatePropagation() to
  *   prevent xterm from also sending ev.data, then send the replacement text
  *   plus the preserved suffix ourselves.
+ *
+ * Android has an additional complication: keydown events with keyCode 229
+ * trigger xterm's CompositionHelper._handleAnyTextareaChanges, which uses
+ * String.replace(oldValue, '') to diff the textarea. This works for pure
+ * appends but produces garbage when the keyboard modifies the middle of the
+ * string (the old value isn't a substring of the new value, so replace()
+ * returns the entire textarea). We neutralize this by resetting
+ * textarea.value to its pre-autocorrect state after sending the correct
+ * data, so the deferred diff sees no change.
  *
  * This approach never calls preventDefault(), so it works regardless of
  * whether the browser considers beforeinput cancelable for the given
@@ -42,6 +55,17 @@ type SendFn = (data: string) => void
 interface PendingReplacement {
   newText: string
   suffix: string
+  /** When set, reset textarea.value after sending to neutralize xterm's
+   *  _handleAnyTextareaChanges deferred diff (Android keyCode-229 path). */
+  resetValue?: string
+}
+
+/** Tracks a deleteContentBackward with non-collapsed selection so the
+ *  immediately following insertText can be recognized as a replacement. */
+interface TrackedDeletion {
+  preDeleteValue: string
+  deleteStart: number
+  deleteEnd: number
 }
 
 /**
@@ -65,17 +89,56 @@ export function attachMobileInputHandler(
   if (!textarea) return () => {}
 
   let pending: PendingReplacement | null = null
+  let trackedDeletion: TrackedDeletion | null = null
 
   // Phase 1: detect replacement and send backspaces.
   const onBeforeInput = (ev: InputEvent) => {
-    if (ev.inputType !== 'insertText' && ev.inputType !== 'insertReplacementText') return
+    // Android autocorrect: the keyboard splits word corrections into
+    // deleteContentBackward (non-collapsed) + insertText (collapsed).
+    // Track the deletion so we can combine it with the following insert.
+    if (ev.inputType === 'deleteContentBackward') {
+      const start = textarea.selectionStart ?? 0
+      const end = textarea.selectionEnd ?? start
+      // Non-collapsed: potential Android autocorrect start. Track it.
+      // Collapsed: normal backspace. Clear any stale tracking.
+      trackedDeletion = start < end
+        ? { preDeleteValue: textarea.value, deleteStart: start, deleteEnd: end }
+        : null
+      return
+    }
+
+    if (ev.inputType !== 'insertText' && ev.inputType !== 'insertReplacementText') {
+      trackedDeletion = null
+      return
+    }
 
     const start = textarea.selectionStart ?? 0
     const end = textarea.selectionEnd ?? start
 
+    // Android autocorrect phase 2: insertText immediately after a tracked
+    // deletion completes the replacement pair.
+    if (trackedDeletion && start === end) {
+      const newText = ev.data ?? ev.dataTransfer?.getData('text/plain') ?? ''
+      if (!newText) { trackedDeletion = null; return }
+
+      const { preDeleteValue, deleteStart, deleteEnd } = trackedDeletion
+      trackedDeletion = null
+
+      const suffix = preDeleteValue.substring(deleteEnd)
+      const charsToErase = preDeleteValue.length - deleteStart
+
+      send('\x7f'.repeat(charsToErase))
+      pending = { newText, suffix, resetValue: preDeleteValue }
+      return
+    }
+
+    trackedDeletion = null
+
     // Collapsed selection = normal append, let xterm handle it.
     if (start === end) return
 
+    // iOS replacement: a single insertText/insertReplacementText with
+    // non-collapsed selection.
     const newText = ev.data ?? ev.dataTransfer?.getData('text/plain') ?? ''
     if (!newText) return
 
@@ -96,13 +159,22 @@ export function attachMobileInputHandler(
   // xterm's capture-phase handler on the textarea itself.
   const onInput = (ev: Event) => {
     if (!pending) return
-    const { newText, suffix } = pending
+    const { newText, suffix, resetValue } = pending
     pending = null
 
     // Prevent xterm's _inputEvent from also sending ev.data.
     ev.stopImmediatePropagation()
 
     send(newText + suffix)
+
+    // Android: reset textarea to the pre-autocorrect value. xterm's
+    // CompositionHelper._handleAnyTextareaChanges (triggered by keydown 229)
+    // captured this same value as oldValue and will diff against it in a
+    // deferred setTimeout(0). By restoring it, the diff sees no change.
+    if (resetValue !== undefined) {
+      textarea.value = resetValue
+      textarea.selectionStart = textarea.selectionEnd = resetValue.length
+    }
   }
 
   textarea.addEventListener('beforeinput', onBeforeInput, { capture: true })


### PR DESCRIPTION
## Problem

Android keyboard autocorrect causes the entire textarea content to be sent as input, duplicating everything the user has already typed.

### Root cause

Android Chrome splits autocorrect word replacements into two DOM events:
1. `deleteContentBackward` with a non-collapsed selection (deletes part of the word)
2. `insertText` with a collapsed selection (inserts the correction)

Our `mobile-input.ts` handler only recognized the iOS pattern (a single `insertText` with non-collapsed selection), so the Android pair passed through unhandled. xterm.js's `CompositionHelper._handleAnyTextareaChanges` then ran its deferred diff using `String.replace(oldValue, '')`, which fails when the middle of the string changed (the old value is no longer a substring of the new value), causing it to send the entire accumulated textarea as input.

### Fix

Recognize the Android two-event pattern by tracking `deleteContentBackward` events that have a non-collapsed selection, then combining with the immediately following `insertText` into the same replacement logic already used for iOS.

After handling the replacement, reset `textarea.value` to its pre-autocorrect state. This neutralizes xterm.js's broken `_handleAnyTextareaChanges` diff: it captured the same value as `oldValue` during `keydown`, so when its `setTimeout(0)` fires it sees no change.

### Trace

Diagnosed from a real Android device trace (Chrome 146 on Android 10). The critical event:

```
deleteContentBackward  selStart=36 selEnd=37  textarea="...lets"  (37 chars)
insertText data="'s "   selStart=36 selEnd=36  textarea="...let"   (36 chars)
onData: hello , let's autocorrect thists let's   (39 chars = entire textarea!)
```