### PR TITLE
feat: replace stale bool with runner_version and binary_hash

### DIFF
--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -18,7 +18,7 @@ import { LaunchButton } from './launcher'
 import { installCopySession } from './mock-data/export-session'
 
 import {
-  sessions, connState, selected, selectedId, view,
+  sessions, connState, selected, selectedId, view, health,
   terminalOptions, keybinds, macCommandIsCtrl,
   backgroundActivity, unreadCount,
   urlPath,
@@ -41,10 +41,32 @@ installCopySession()
 
 // ── Components ──
 
+/**
+ * Derive staleness from version and hash fields.
+ *
+ * A session is stale when:
+ *   - runner_version differs from the daemon version (normal production case), OR
+ *   - versions match (both "dev") but binary_hash differs from runner_hash
+ *     (dev-mode: same version string, different builds)
+ *
+ * Returns null when the runner predates version tracking (graceful degradation).
+ */
+function sessionStaleness(
+  session: Session,
+  h: { version: string; runner_hash?: string } | null,
+): 'version' | 'hash' | null {
+  if (!h || !session.runner_version) return null
+  if (session.runner_version !== h.version) return 'version'
+  if (session.binary_hash && h.runner_hash && session.binary_hash !== h.runner_hash) return 'hash'
+  return null
+}
+
 function MainHeader({ session, onRestart }: {
   session: Session | null
   onRestart?: () => void
 }) {
+  const healthVal = health.value
+
   if (!session) {
     return (
       <div class="main-header">
@@ -56,6 +78,7 @@ function MainHeader({ session, onRestart }: {
   }
 
   const shortCwd = session.cwd.replace(/^\/home\/[^/]+/, '~')
+  const staleKind = sessionStaleness(session, healthVal)
 
   return (
     <div class="main-header">
@@ -77,9 +100,19 @@ function MainHeader({ session, onRestart }: {
             {session.status.label}
           </div>
         )}
-        {session.stale && (
-          <button class="stale-badge" title="Click to restart this session with the latest build" onClick={onRestart}>
-            outdated
+        {staleKind && (
+          <button
+            class="stale-badge"
+            title={staleKind === 'hash'
+              ? `Dev build mismatch (${session.binary_hash?.slice(0, 8)} vs ${healthVal?.runner_hash?.slice(0, 8)}) — click to restart`
+              : `Runner v${session.runner_version} outdated (daemon v${healthVal?.version}) — click to restart`
+            }
+            onClick={onRestart}
+          >
+            {staleKind === 'hash'
+              ? session.binary_hash?.slice(0, 8)
+              : 'outdated'
+            }
           </button>
         )}
         {session.peer && (

--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -24,6 +24,7 @@ import {
   urlPath,
   initStore, setNavigate, navigateToSession,
   dismissSession, resumeSession, restartSession,
+  sessionStaleness,
 } from './store'
 
 // Lazy-loaded routes (code-split, not bundled with the main app)
@@ -40,26 +41,6 @@ if (USE_MOCK) document.documentElement.classList.add('mock-mode')
 installCopySession()
 
 // ── Components ──
-
-/**
- * Derive staleness from version and hash fields.
- *
- * A session is stale when:
- *   - runner_version differs from the daemon version (normal production case), OR
- *   - versions match (both "dev") but binary_hash differs from runner_hash
- *     (dev-mode: same version string, different builds)
- *
- * Returns null when the runner predates version tracking (graceful degradation).
- */
-function sessionStaleness(
-  session: Session,
-  h: { version: string; runner_hash?: string } | null,
-): 'version' | 'hash' | null {
-  if (!h || !session.runner_version) return null
-  if (session.runner_version !== h.version) return 'version'
-  if (session.binary_hash && h.runner_hash && session.binary_hash !== h.runner_hash) return 'hash'
-  return null
-}
 
 function MainHeader({ session, onRestart }: {
   session: Session | null
@@ -104,8 +85,8 @@ function MainHeader({ session, onRestart }: {
           <button
             class="stale-badge"
             title={staleKind === 'hash'
-              ? `Dev build mismatch (${session.binary_hash?.slice(0, 8)} vs ${healthVal?.runner_hash?.slice(0, 8)}) — click to restart`
-              : `Runner v${session.runner_version} outdated (daemon v${healthVal?.version}) — click to restart`
+              ? `Dev build mismatch: ${session.binary_hash?.slice(0, 8)} vs ${healthVal?.runner_hash?.slice(0, 8)}. Click to restart.`
+              : `Runner v${session.runner_version} outdated (daemon v${healthVal?.version}). Click to restart.`
             }
             onClick={onRestart}
           >

--- a/apps/gmux-web/src/mock-data/export-session.ts
+++ b/apps/gmux-web/src/mock-data/export-session.ts
@@ -238,7 +238,8 @@ function generateFile(session: Session, terminal: string, cursorX: number, curso
   }
   lines.push(`  unread: ${session.unread},`)
   lines.push(`  socket_path: '/tmp/gmux-sessions/${session.id}.sock',`)
-  if (session.stale) lines.push(`  stale: true,`)
+  if (session.runner_version) lines.push(`  runner_version: ${JSON.stringify(session.runner_version)},`)
+  if (session.binary_hash) lines.push(`  binary_hash: ${JSON.stringify(session.binary_hash)},`)
   lines.push(`  cursorX: ${cursorX},`)
   lines.push(`  cursorY: ${cursorY},`)
   lines.push(`  terminal: ${body},`)

--- a/apps/gmux-web/src/store.test.ts
+++ b/apps/gmux-web/src/store.test.ts
@@ -19,7 +19,7 @@ function makeSession(overrides: Partial<Session> & { id: string }): Session {
     unread: false,
     resumable: false,
     socket_path: '/tmp/s.sock',
-    stale: false,
+    runner_version: undefined,
     ...overrides,
   }
 }

--- a/apps/gmux-web/src/store.test.ts
+++ b/apps/gmux-web/src/store.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
-import { sessions, upsertSession, removeSession, markSessionRead, handleActivity, isSessionActive, isSessionFading, activityMap } from './store'
+import { sessions, upsertSession, removeSession, markSessionRead, handleActivity, isSessionActive, isSessionFading, activityMap, sessionStaleness } from './store'
 import type { Session } from './types'
 
 function makeSession(overrides: Partial<Session> & { id: string }): Session {
@@ -157,5 +157,60 @@ describe('activity tracking', () => {
     handleActivity('sess-1')     // reset
     vi.advanceTimersByTime(2000) // 2s since reset, still active
     expect(isSessionActive('sess-1')).toBe(true)
+  })
+})
+
+describe('sessionStaleness', () => {
+  const h = { version: '1.2.0', runner_hash: 'aabbccdd1122' }
+
+  it('returns null when health is null (not yet loaded)', () => {
+    expect(sessionStaleness({ runner_version: '1.1.0' }, null)).toBeNull()
+  })
+
+  it('returns null when runner_version is absent (pre-version runner)', () => {
+    expect(sessionStaleness({}, h)).toBeNull()
+    expect(sessionStaleness({ binary_hash: 'aabbccdd1122' }, h)).toBeNull()
+  })
+
+  it("returns 'version' when runner version differs from daemon version", () => {
+    expect(sessionStaleness({ runner_version: '1.1.0' }, h)).toBe('version')
+    expect(sessionStaleness({ runner_version: '0.9.0' }, h)).toBe('version')
+  })
+
+  it('returns null when runner and daemon versions match and no hash info', () => {
+    expect(sessionStaleness({ runner_version: '1.2.0' }, { version: '1.2.0' })).toBeNull()
+  })
+
+  it('returns null when versions and hashes both match', () => {
+    expect(sessionStaleness(
+      { runner_version: '1.2.0', binary_hash: 'aabbccdd1122' }, h,
+    )).toBeNull()
+  })
+
+  it("returns 'hash' when versions match but hashes differ (dev-mode drift)", () => {
+    expect(sessionStaleness(
+      { runner_version: '1.2.0', binary_hash: 'deadbeef9999' }, h,
+    )).toBe('hash')
+  })
+
+  it("returns 'version' not 'hash' when both differ (version takes priority)", () => {
+    expect(sessionStaleness(
+      { runner_version: '1.1.0', binary_hash: 'deadbeef9999' }, h,
+    )).toBe('version')
+  })
+
+  it("returns null for 'dev'/'dev' version match with no hash available", () => {
+    // Common in dev: both report "dev", hash unknown on health side
+    expect(sessionStaleness(
+      { runner_version: 'dev', binary_hash: 'aabbcc' },
+      { version: 'dev' },
+    )).toBeNull()
+  })
+
+  it("returns 'hash' for 'dev'/'dev' version match with differing hashes", () => {
+    expect(sessionStaleness(
+      { runner_version: 'dev', binary_hash: 'deadbeef' },
+      { version: 'dev', runner_hash: 'aabbccdd' },
+    )).toBe('hash')
   })
 })

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -43,6 +43,9 @@ export interface HealthData {
   hostname?: string
   tailscale_url?: string
   update_available?: string
+  /** SHA-256 of the gmux runner binary on disk. Compared against
+   * session.binary_hash to detect dev-mode hash drift. */
+  runner_hash?: string
   default_launcher?: string
   launchers?: LauncherDef[]
   peers?: PeerInfo[]
@@ -213,7 +216,8 @@ export function toUISession(s: ProtocolSession): Session {
     terminal_cols: s.terminal_cols ?? undefined,
     terminal_rows: s.terminal_rows ?? undefined,
     slug: s.slug ?? undefined,
-    stale: s.stale ?? false,
+    runner_version: s.runner_version ?? undefined,
+    binary_hash: s.binary_hash ?? undefined,
     peer: s.peer ?? undefined,
   }
 }

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -222,6 +222,26 @@ export function toUISession(s: ProtocolSession): Session {
   }
 }
 
+/**
+ * Derive staleness from a session's build-identity fields.
+ *
+ * Returns:
+ *   'version' - runner_version differs from the daemon version (production mismatch)
+ *   'hash'    - versions match but binary_hash differs from health.runner_hash
+ *               (dev-mode: both sides report "dev" but from different builds)
+ *   null      - current, or insufficient data to determine (graceful degradation
+ *               for runners that predate version tracking)
+ */
+export function sessionStaleness(
+  session: Pick<Session, 'runner_version' | 'binary_hash'>,
+  h: Pick<HealthData, 'version' | 'runner_hash'> | null,
+): 'version' | 'hash' | null {
+  if (!h || !session.runner_version) return null
+  if (session.runner_version !== h.version) return 'version'
+  if (session.binary_hash && h.runner_hash && session.binary_hash !== h.runner_hash) return 'hash'
+  return null
+}
+
 /** Upsert a session from SSE. Returns true if the session was new. */
 export function upsertSession(raw: ProtocolSession): boolean {
   const updated = toUISession(raw)

--- a/apps/gmux-web/src/types.ts
+++ b/apps/gmux-web/src/types.ts
@@ -32,7 +32,10 @@ export interface Session {
   terminal_cols?: number
   terminal_rows?: number
   slug?: string
-  stale?: boolean
+  /** Version string of the gmux runner binary that owns this session. */
+  runner_version?: string
+  /** SHA-256 of the gmux runner binary (first 8 chars useful for display). */
+  binary_hash?: string
 }
 
 export interface Folder {

--- a/cli/gmux/cmd/gmux/main.go
+++ b/cli/gmux/cmd/gmux/main.go
@@ -156,6 +156,7 @@ func main() {
 		Remotes:       remotes,
 		SocketPath:    sockPath,
 		BinaryHash:    binhash.Self(),
+		RunnerVersion: version,
 	})
 
 	// Common env vars — set for every child, per ADR-0005

--- a/cli/gmux/internal/session/state.go
+++ b/cli/gmux/internal/session/state.go
@@ -52,7 +52,8 @@ type State struct {
 	SocketPath string `json:"socket_path"`
 
 	// Build identity
-	BinaryHash string `json:"binary_hash,omitempty"`
+	BinaryHash    string `json:"binary_hash,omitempty"`
+	RunnerVersion string `json:"runner_version,omitempty"`
 
 	// SSE subscribers (not serialized)
 	subs []chan Event
@@ -75,6 +76,7 @@ type Config struct {
 	Kind          string
 	SocketPath    string
 	BinaryHash    string
+	RunnerVersion string
 	WorkspaceRoot string
 	Remotes       map[string]string
 }
@@ -91,6 +93,7 @@ func New(cfg Config) *State {
 		Remotes:       cfg.Remotes,
 		SocketPath:    cfg.SocketPath,
 		BinaryHash:    cfg.BinaryHash,
+		RunnerVersion: cfg.RunnerVersion,
 		Alive:         false,
 	}
 }

--- a/packages/protocol/src/session.ts
+++ b/packages/protocol/src/session.ts
@@ -31,8 +31,8 @@ export const SessionSchema = z.object({
   terminal_cols: z.number().int().positive().optional(),
   terminal_rows: z.number().int().positive().optional(),
   slug: z.string().optional(),
-
-  stale: z.boolean().optional().default(false),
+  runner_version: z.string().optional(),
+  binary_hash: z.string().optional(),
 })
 
 export const AttachResponseSchema = z.object({

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -624,6 +624,14 @@ func serve(stderr io.Writer) int {
 			"dead":         dead,
 		}
 
+		// runner_hash is the sha256 of the gmux runner binary on disk.
+		// The frontend uses this (alongside runner_version on sessions)
+		// to detect dev-mode builds where both sides report "dev" but
+		// were compiled from different commits.
+		if discovery.ExpectedRunnerHash != "" {
+			data["runner_hash"] = discovery.ExpectedRunnerHash
+		}
+
 		// Launchers: what adapters can be launched on this host.
 		data["default_launcher"] = launchConfig.DefaultLauncher
 		data["launchers"] = launchConfig.Launchers

--- a/services/gmuxd/internal/discovery/discovery.go
+++ b/services/gmuxd/internal/discovery/discovery.go
@@ -21,8 +21,8 @@ import (
 )
 
 // ExpectedRunnerHash is the sha256 hash of the gmux binary that gmuxd
-// would launch for new sessions. Set by main at startup. Sessions whose
-// binary_hash differs are marked stale.
+// would launch for new sessions. Set by main at startup. Exposed via
+// /v1/health as runner_hash so the frontend can detect dev-mode hash drift.
 var ExpectedRunnerHash string
 
 func socketDir() string {
@@ -30,15 +30,6 @@ func socketDir() string {
 		return d
 	}
 	return "/tmp/gmux-sessions"
-}
-
-// markStale sets sess.Stale based on whether its BinaryHash matches the expected runner hash.
-func markStale(sess *store.Session) {
-	if ExpectedRunnerHash == "" || sess.BinaryHash == "" {
-		// Can't determine — don't mark stale (graceful degradation for old runners)
-		return
-	}
-	sess.Stale = sess.BinaryHash != ExpectedRunnerHash
 }
 
 // Watch periodically scans for Unix sockets and queries their /meta.
@@ -153,7 +144,6 @@ func Register(sessions *store.Store, subs *Subscriptions, fileMon *FileMonitor, 
 	if err != nil {
 		return err
 	}
-	markStale(newSess)
 
 	// Check if this is a resumed session.
 	if resumes != nil {
@@ -167,7 +157,7 @@ func Register(sessions *store.Store, subs *Subscriptions, fileMon *FileMonitor, 
 				existing.StartedAt = newSess.StartedAt
 				existing.Status = newSess.Status
 				existing.BinaryHash = newSess.BinaryHash
-				existing.Stale = newSess.Stale
+				existing.RunnerVersion = newSess.RunnerVersion
 				sessions.Upsert(existing)
 				if subs != nil {
 					subs.Subscribe(existingID, socketPath)

--- a/services/gmuxd/internal/store/store.go
+++ b/services/gmuxd/internal/store/store.go
@@ -38,13 +38,22 @@ type Session struct {
 	SocketPath    string            `json:"socket_path,omitempty"`
 	TerminalCols  uint16            `json:"terminal_cols,omitempty"`
 	TerminalRows  uint16            `json:"terminal_rows,omitempty"`
-	Stale         bool              `json:"stale,omitempty"`
-
 	// Slug is a human-readable stable identifier derived from the
 	// adapter's session file slug. Used for URL routing (the frontend
 	// falls back to id[:8] when empty) and for matching dead sessions
 	// to project membership arrays. Unique within (kind, peer).
 	Slug string `json:"slug,omitempty"`
+
+	// RunnerVersion is the version string of the gmux runner binary that
+	// launched this session. Set by the runner at startup. The frontend
+	// derives staleness by comparing this to the daemon's own version
+	// (and BinaryHash when both sides report the same version string).
+	RunnerVersion string `json:"runner_version,omitempty"`
+
+	// BinaryHash is the sha256 of the gmux runner binary that launched
+	// this session. The frontend compares it against the daemon's
+	// runner_hash (from /v1/health) to detect dev-mode hash drift.
+	BinaryHash string `json:"binary_hash,omitempty"`
 
 	// ── Internal fields (excluded from API via MarshalJSON) ──
 
@@ -52,14 +61,10 @@ type Session struct {
 	// on every Upsert/Update.
 	ShellTitle   string `json:"shell_title,omitempty"`
 	AdapterTitle string `json:"adapter_title,omitempty"`
-
-	// BinaryHash is the sha256 of the gmux binary that owns this session.
-	// The derived Stale bool (API-visible) is what the frontend needs.
-	BinaryHash string `json:"binary_hash,omitempty"`
 }
 
 // MarshalJSON serializes a Session for the frontend API, excluding internal
-// fields whose derived outputs are already exposed (e.g. Stale from BinaryHash).
+// fields (ShellTitle, AdapterTitle) that are resolved into Title before sending.
 func (s Session) MarshalJSON() ([]byte, error) {
 	type wire struct {
 		ID            string            `json:"id"`
@@ -83,8 +88,9 @@ func (s Session) MarshalJSON() ([]byte, error) {
 		SocketPath    string            `json:"socket_path,omitempty"`
 		TerminalCols  uint16            `json:"terminal_cols,omitempty"`
 		TerminalRows  uint16            `json:"terminal_rows,omitempty"`
-		Stale         bool              `json:"stale,omitempty"`
 		Slug          string            `json:"slug,omitempty"`
+		RunnerVersion string            `json:"runner_version,omitempty"`
+		BinaryHash    string            `json:"binary_hash,omitempty"`
 	}
 	return json.Marshal(wire{
 		ID: s.ID, Peer: s.Peer, CreatedAt: s.CreatedAt, Command: s.Command,
@@ -94,8 +100,8 @@ func (s Session) MarshalJSON() ([]byte, error) {
 		Title: s.Title, Subtitle: s.Subtitle, Status: s.Status,
 		Unread: s.Unread, Resumable: s.Resumable,
 		SocketPath: s.SocketPath, TerminalCols: s.TerminalCols,
-		TerminalRows: s.TerminalRows, Stale: s.Stale,
-		Slug: s.Slug,
+		TerminalRows: s.TerminalRows, Slug: s.Slug,
+		RunnerVersion: s.RunnerVersion, BinaryHash: s.BinaryHash,
 	})
 }
 

--- a/services/gmuxd/internal/store/store_test.go
+++ b/services/gmuxd/internal/store/store_test.go
@@ -778,3 +778,45 @@ func TestUpsertRemote_BroadcastsEvent(t *testing.T) {
 
 
 
+func TestSessionMarshalJSON_WireFormat(t *testing.T) {
+	s := Session{
+		ID:            "sess-abc",
+		Kind:          "pi",
+		Alive:         true,
+		RunnerVersion: "1.2.0",
+		BinaryHash:    "aabbccdd",
+		ShellTitle:    "internal-only",
+		AdapterTitle:  "internal-only",
+		Slug:          "my-slug",
+	}
+	b, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	// Fields that must appear on the wire.
+	if got := m["runner_version"]; got != "1.2.0" {
+		t.Errorf("runner_version = %v, want 1.2.0", got)
+	}
+	if got := m["binary_hash"]; got != "aabbccdd" {
+		t.Errorf("binary_hash = %v, want aabbccdd", got)
+	}
+	if got := m["slug"]; got != "my-slug" {
+		t.Errorf("slug = %v, want my-slug", got)
+	}
+
+	// Internal fields must not appear on the wire.
+	if _, ok := m["shell_title"]; ok {
+		t.Error("shell_title must not appear in wire JSON")
+	}
+	if _, ok := m["adapter_title"]; ok {
+		t.Error("adapter_title must not appear in wire JSON")
+	}
+	if _, ok := m["stale"]; ok {
+		t.Error("stale was removed; must not appear in wire JSON")
+	}
+}


### PR DESCRIPTION
Sessions now carry two build-identity fields on the wire instead of a derived `stale` bool.

## What changes

### `runner_version` (string)

The `gmux` runner version string (ldflags-injected). Compared against `health.version` to detect outdated runners in production: if a session was started by an older build of the runner, the UI shows an "outdated" badge.

### `binary_hash` (string, sha256)

The sha256 of the `gmux` runner binary. `/v1/health` gains a matching `runner_hash` field (hash of the runner binary gmuxd sees on disk). The frontend compares these to detect dev-mode drift: when both sides report `"dev"` as the version but were compiled from different commits, the badge shows the 8-char hash prefix.

### Staleness derivation moves to the frontend

`markStale` and the `Stale` field are deleted from the backend. The frontend `sessionStaleness()` function (now exported from `store.ts`) returns:
- `"version"` - runner version differs from daemon version
- `"hash"` - versions match but hashes differ (dev drift)
- `null` - current, or runner predates version tracking (graceful degradation)

`ExpectedRunnerHash` stays in discovery, now used only to populate `health.runner_hash`.

## Files changed

**Runner** (`cli/gmux`): `State` and `Config` gain `RunnerVersion`; written at session creation alongside existing `BinaryHash`.

**gmuxd store**: `Session` gains `RunnerVersion`, promotes `BinaryHash` to the wire; drops `Stale`.

**gmuxd discovery**: `markStale` deleted; `ExpectedRunnerHash` kept for the health endpoint.

**gmuxd health endpoint**: adds `runner_hash`.

**Protocol** (`packages/protocol`): `stale: boolean` replaced by `runner_version?: string` + `binary_hash?: string`.

**Frontend**: `sessionStaleness()` exported from `store.ts`. `HealthData` gains `runner_hash`. Header badge tooltip shows version numbers or hash prefix depending on which mismatch was detected.

## Tests

- 9 frontend unit tests for `sessionStaleness` covering all cases: null health, pre-version runners, version mismatch, hash drift, both-match, dev/dev variants
- `TestSessionMarshalJSON_WireFormat` in Go: asserts `runner_version` and `binary_hash` appear on wire; `stale`, `shell_title`, `adapter_title` do not