### PR TITLE
feat(web): redesign version display and session info

### DIFF
--- a/apps/gmux-web/src/env.d.ts
+++ b/apps/gmux-web/src/env.d.ts
@@ -1,0 +1,2 @@
+/** Build-time version injected by Vite define. Matches the VERSION env var used by Go ldflags. */
+declare const __GMUX_VERSION__: string

--- a/apps/gmux-web/src/home.tsx
+++ b/apps/gmux-web/src/home.tsx
@@ -48,6 +48,7 @@ export function Home() {
               status={p.status}
               url={p.url}
               details={[
+                p.version ? `v${p.version}` : undefined,
                 p.status === 'connected'
                   ? `${p.session_count} active session${p.session_count === 1 ? '' : 's'}`
                   : p.status === 'connecting'
@@ -72,6 +73,15 @@ export function Home() {
           </div>
         </section>
       )}
+
+      <footer class="home-footer">
+        <span class="home-footer-version">Frontend v{__GMUX_VERSION__}</span>
+        {healthVal?.version && healthVal.version !== __GMUX_VERSION__ && (
+          <button class="home-footer-reload" onClick={() => location.reload()}>
+            reload to update
+          </button>
+        )}
+      </footer>
     </div>
   )
 }

--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -46,8 +46,6 @@ function MainHeader({ session, onRestart }: {
   session: Session | null
   onRestart?: () => void
 }) {
-  const healthVal = health.value
-
   if (!session) {
     return (
       <div class="main-header">
@@ -59,7 +57,6 @@ function MainHeader({ session, onRestart }: {
   }
 
   const shortCwd = session.cwd.replace(/^\/home\/[^/]+/, '~')
-  const staleKind = sessionStaleness(session, healthVal)
 
   return (
     <div class="main-header">
@@ -81,28 +78,85 @@ function MainHeader({ session, onRestart }: {
             {session.status.label}
           </div>
         )}
-        {staleKind && (
-          <button
-            class="stale-badge"
-            title={staleKind === 'hash'
-              ? `Dev build mismatch: ${session.binary_hash?.slice(0, 8)} vs ${healthVal?.runner_hash?.slice(0, 8)}. Click to restart.`
-              : `Runner v${session.runner_version} outdated (daemon v${healthVal?.version}). Click to restart.`
-            }
-            onClick={onRestart}
-          >
-            {staleKind === 'hash'
-              ? session.binary_hash?.slice(0, 8)
-              : 'outdated'
-            }
-          </button>
-        )}
-        {session.peer && (
-          <div class="main-header-kind" title="Host">{session.peer}</div>
-        )}
-        {session.kind && session.kind !== 'shell' && (
-          <div class="main-header-kind" title="Adapter">{session.kind}</div>
-        )}
+        <SessionInfoMenu session={session} onRestart={onRestart} />
       </div>
+    </div>
+  )
+}
+
+function SessionInfoMenu({ session, onRestart }: {
+  session: Session
+  onRestart?: () => void
+}) {
+  const [open, setOpen] = useState(false)
+  const menuRef = useRef<HTMLDivElement>(null)
+  const healthVal = health.value
+  const staleKind = sessionStaleness(session, healthVal)
+
+  // Close on outside click or Escape.
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setOpen(false) }
+    const onClick = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) setOpen(false)
+    }
+    document.addEventListener('keydown', onKey)
+    document.addEventListener('mousedown', onClick)
+    return () => {
+      document.removeEventListener('keydown', onKey)
+      document.removeEventListener('mousedown', onClick)
+    }
+  }, [open])
+
+  const versionDisplay = session.runner_version
+    ? `v${session.runner_version}`
+    : session.binary_hash
+      ? session.binary_hash.slice(0, 8)
+      : 'unknown'
+
+  const label = session.kind !== 'shell' ? session.kind : 'shell'
+
+  return (
+    <div class="session-info" ref={menuRef}>
+      <button
+        class={`session-info-trigger${staleKind ? ' stale' : ''}`}
+        onClick={() => setOpen(!open)}
+        title={staleKind ? 'Runner outdated' : label}
+      >
+        {label}
+        {staleKind && <span class="session-info-dot" />}
+      </button>
+      {open && (
+        <div class="session-info-menu">
+          <div class="session-info-row">
+            <span class="session-info-label">runner</span>
+            <span class="session-info-value">{label}</span>
+          </div>
+          <div class="session-info-row">
+            <span class="session-info-label">version</span>
+            <span class={`session-info-value${staleKind ? ' stale' : ''}`}>
+              {versionDisplay}
+            </span>
+          </div>
+          {session.peer && (
+            <div class="session-info-row">
+              <span class="session-info-label">host</span>
+              <span class="session-info-value">{session.peer}</span>
+            </div>
+          )}
+          {session.alive && onRestart && (
+            <>
+              <div class="session-info-divider" />
+              <button
+                class={`session-info-action${staleKind ? ' stale' : ''}`}
+                onClick={() => { setOpen(false); onRestart() }}
+              >
+                restart session
+              </button>
+            </>
+          )}
+        </div>
+      )}
     </div>
   )
 }

--- a/apps/gmux-web/src/sidebar.tsx
+++ b/apps/gmux-web/src/sidebar.tsx
@@ -227,20 +227,6 @@ export function Sidebar({
             href="/"
             onClick={onClose}
           >gmux</a>
-          {healthVal?.version ? (
-            <a
-              class={`sidebar-badge${healthVal.update_available ? ' sidebar-badge-update' : ''}`}
-              href="https://gmux.app/changelog/"
-              target="_blank"
-              title={healthVal.update_available
-                ? 'Update available - safe to update while sessions are running'
-                : `gmux ${healthVal.version}`}
-            >
-              {healthVal.update_available
-                ? <>{healthVal.version} &rarr; {healthVal.update_available}</>
-                : healthVal.version}
-            </a>
-          ) : null}
           {connected && !hasProjects && (
             <LaunchButton
               className="sidebar-launch-btn"

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -1600,6 +1600,35 @@ a.home-host-link:hover {
   opacity: 0.4;
 }
 
+.home-footer {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 32px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border);
+}
+
+.home-footer-version {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.home-footer-reload {
+  font-size: 11px;
+  color: var(--accent);
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.home-footer-reload:hover {
+  color: var(--text);
+}
+
 
 /* ── Mobile ── */
 

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -125,38 +125,6 @@ body {
   text-shadow: 0 0 6px rgba(255, 255, 255, 0.25);
 }
 
-.sidebar-badge {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 18px;
-  padding: 0 6px;
-  border-radius: 999px;
-  background: oklch(22% 0.015 250);
-  color: var(--text-secondary);
-  font-size: 11px;
-  font-weight: 500;
-  line-height: 1;
-  letter-spacing: 0.01em;
-  text-decoration: none;
-  transform: translateY(2px);
-}
-
-.sidebar-badge:hover {
-  color: var(--text-primary);
-}
-
-.sidebar-badge-update {
-  background: oklch(30% 0.08 145);
-  color: oklch(85% 0.1 145);
-  text-decoration: none;
-  cursor: pointer;
-}
-
-.sidebar-badge-update:hover {
-  background: oklch(35% 0.1 145);
-}
-
 .sidebar-scroll {
   flex: 1;
   overflow-y: auto;
@@ -1116,29 +1084,6 @@ body {
   gap: 8px;
 }
 
-.stale-badge {
-  font-family: 'Fira Code', monospace;
-  font-size: 10px;
-  font-weight: 500;
-  color: oklch(75% 0.15 65);
-  background: oklch(75% 0.15 65 / 0.12);
-  border: 1px solid oklch(75% 0.15 65 / 0.25);
-  padding: 1px 6px;
-  border-radius: 3px;
-  letter-spacing: 0.02em;
-  white-space: nowrap;
-  flex-shrink: 0;
-  cursor: pointer;
-  transition: background 0.15s, border-color 0.15s;
-}
-.stale-badge:hover {
-  background: oklch(75% 0.15 65 / 0.22);
-  border-color: oklch(75% 0.15 65 / 0.4);
-}
-.stale-badge:active {
-  background: oklch(75% 0.15 65 / 0.3);
-}
-
 .main-header-meta {
   display: flex;
   align-items: center;
@@ -1157,10 +1102,6 @@ body {
   opacity: 0.4;
 }
 
-.main-header-kind {
-  opacity: 0.7;
-}
-
 .main-header-status {
   display: flex;
   align-items: center;
@@ -1175,17 +1116,113 @@ body {
 .main-header-status.working { color: var(--accent); }
 .main-header-status.error   { color: var(--status-error); }
 
-.main-header-kind {
+/* Session info menu (replaces standalone adapter + outdated badges) */
+
+.session-info {
+  position: relative;
+}
+
+.session-info-trigger {
   font-family: 'Fira Code', monospace;
   font-size: 11px;
   font-weight: 500;
   color: var(--text-muted);
   background: var(--bg-surface);
+  border: 1px solid transparent;
   padding: 2px 8px;
   border-radius: 3px;
   white-space: nowrap;
-  flex-shrink: 0;
+  cursor: pointer;
   letter-spacing: 0.01em;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.session-info-trigger:hover {
+  color: var(--text-secondary);
+  border-color: var(--border);
+}
+
+.session-info-trigger.stale {
+  color: oklch(75% 0.15 65);
+}
+
+.session-info-dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: oklch(75% 0.15 65);
+  flex-shrink: 0;
+}
+
+.session-info-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  min-width: 180px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 8px 0;
+  box-shadow: 0 4px 16px oklch(0% 0 0 / 0.3);
+  z-index: 50;
+}
+
+.session-info-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 4px 12px;
+  font-size: 12px;
+}
+
+.session-info-label {
+  color: var(--text-muted);
+}
+
+.session-info-value {
+  font-family: 'Fira Code', monospace;
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+
+.session-info-value.stale {
+  color: oklch(75% 0.15 65);
+}
+
+.session-info-divider {
+  height: 1px;
+  background: var(--border);
+  margin: 6px 0;
+}
+
+.session-info-action {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 5px 12px;
+  font-size: 12px;
+  color: var(--text-secondary);
+  background: none;
+  border: none;
+  cursor: pointer;
+  transition: background 0.1s, color 0.1s;
+}
+
+.session-info-action:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+
+.session-info-action.stale {
+  color: oklch(75% 0.15 65);
+}
+
+.session-info-action.stale:hover {
+  background: oklch(75% 0.15 65 / 0.12);
+  color: oklch(85% 0.15 65);
 }
 
 .terminal-shell {
@@ -1656,10 +1693,6 @@ a.home-host-link:hover {
 
   .main-header-status {
     font-size: 11px;
-  }
-
-  .main-header-kind {
-    font-size: 10px;
   }
 
   .terminal-container .xterm {

--- a/apps/gmux-web/vite.config.ts
+++ b/apps/gmux-web/vite.config.ts
@@ -5,6 +5,9 @@ const gmuxdPort = process.env.VITE_DEV_PROXY_PORT || '8790'
 
 export default defineConfig({
   plugins: [preact()],
+  define: {
+    __GMUX_VERSION__: JSON.stringify(process.env.VERSION || 'dev'),
+  },
   server: {
     allowedHosts: true,
     proxy: {


### PR DESCRIPTION
## Version display redesign

Moves version information to where it is useful and replaces the
cluttered session header badges with a clean info menu.

### Commits

1. **Move version display from sidebar to home page**
   - Remove version badge from sidebar header (just "gmux" logo now)
   - Peer host cards now show their version (using `PeerInfo.version`
     from PR #132)
   - Footer shows frontend build version; "reload to update" link
     appears when it differs from the daemon version
   - Build-time version injected via Vite `define` from `VERSION` env
     var (same source as Go ldflags)

2. **Replace adapter and outdated badges with session info menu**
   - Single compact trigger button shows adapter name (e.g., "pi")
   - Warning dot appears when runner is outdated
   - Popover menu shows: runner kind, version (colored if stale), host
     (if remote), restart action (highlighted if outdated)
   - Delete unused CSS: `sidebar-badge`, `stale-badge`,
     `main-header-kind` (all replaced by `session-info-*` classes)

### Net effect
- Sidebar header is cleaner (no version clutter)
- Home page shows version for every host at a glance
- Session header collapses 3 separate badges into one interactive menu
- Frontend can detect when it is out of date with the backend

All 250 tests pass, clean build.