### PR TITLE
fix(web): UI polish and dead-code cleanup

### DIFF
--- a/apps/gmux-web/src/home.tsx
+++ b/apps/gmux-web/src/home.tsx
@@ -36,7 +36,11 @@ export function Home() {
             status="connected"
             url={tsUrl}
             details={[
-              healthVal?.version ? `v${healthVal.version}` : undefined,
+              healthVal?.version
+                ? healthVal.update_available
+                  ? `v${healthVal.version} \u2192 v${healthVal.update_available}`
+                  : `v${healthVal.version}`
+                : undefined,
               `${localAlive} active session${localAlive === 1 ? '' : 's'}`,
             ]}
             launchers={localLaunchers}
@@ -78,6 +82,15 @@ export function Home() {
           <button class="home-footer-reload" onClick={() => location.reload()}>
             reload to update
           </button>
+        )}
+        {healthVal?.update_available && (
+          <a
+            class="home-footer-update"
+            href="https://gmux.app/changelog/"
+            target="_blank"
+          >
+            v{healthVal.update_available} available
+          </a>
         )}
       </footer>
     </div>

--- a/apps/gmux-web/src/home.tsx
+++ b/apps/gmux-web/src/home.tsx
@@ -51,11 +51,9 @@ export function Home() {
                 p.version ? `v${p.version}` : undefined,
                 p.status === 'connected'
                   ? `${p.session_count} active session${p.session_count === 1 ? '' : 's'}`
-                  : p.status === 'connecting'
-                    ? 'connecting\u2026'
-                    : p.status === 'offline'
-                      ? 'offline'
-                      : p.last_error ?? 'disconnected',
+                  : p.status === 'offline'
+                    ? 'offline'
+                    : p.last_error ?? 'disconnected',
               ]}
               launchers={p.status === 'connected' ? peerLaunchers(p.name) : []}
               peer={p.name}

--- a/apps/gmux-web/src/sidebar.tsx
+++ b/apps/gmux-web/src/sidebar.tsx
@@ -9,7 +9,7 @@ import { sessionPath } from './routing'
 import { LaunchButton } from './launcher'
 import { useArrivalPulse } from './use-arrival-pulse'
 import {
-  folders, selectedId, currentProjectSlug, health,
+  folders, selectedId, currentProjectSlug,
   activityMap, unmatchedActiveCount, projects, connState,
   updateProjects,
   type DotState,
@@ -197,7 +197,6 @@ export function Sidebar({
   const foldersVal = folders.value
   const selId = selectedId.value
   const curProjectSlug = currentProjectSlug.value
-  const healthVal = health.value
   const unmatchedCount = unmatchedActiveCount.value
   const am = activityMap.value
 

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -1664,6 +1664,17 @@ a.home-host-link:hover {
   color: var(--text);
 }
 
+.home-footer-update {
+  font-size: 11px;
+  color: oklch(85% 0.1 145);
+  text-decoration: none;
+}
+
+.home-footer-update:hover {
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
 
 /* ── Mobile ── */
 

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -39,7 +39,6 @@ code {
   /* Status */
   --status-error: oklch(65% 0.18 25);
   --status-connected: oklch(72% 0.14 145);
-  --status-connecting: oklch(80% 0.14 85);
   --status-disconnected: oklch(65% 0.18 25);
 
   /* Radii */
@@ -121,7 +120,6 @@ body {
 }
 .sidebar-logo:hover {
   color: #fff;
-  background: var(--bg-hover);
   text-shadow: 0 0 6px rgba(255, 255, 255, 0.25);
 }
 
@@ -194,7 +192,8 @@ body {
   transition: opacity 0.1s;
 }
 
-.folder-header:hover .launch-container.folder-launch-btn {
+.folder-header:hover .launch-container.folder-launch-btn,
+.launch-container.folder-launch-btn:has(.loading) {
   opacity: 1;
 }
 
@@ -1520,8 +1519,7 @@ body {
   box-shadow: 0 0 6px color-mix(in oklch, var(--status-connected) 40%, transparent);
 }
 .home-host-status.connecting {
-  background: var(--status-connecting);
-  animation: pulse-connecting 1.5s ease-in-out infinite;
+  background: var(--status-disconnected);
 }
 .home-host-status.disconnected {
   background: var(--status-disconnected);
@@ -2151,8 +2149,7 @@ a.home-host-link:hover {
   background: var(--status-connected);
 }
 .hub-host-dot.connecting {
-  background: var(--status-connecting);
-  animation: pulse-connecting 1.5s ease-in-out infinite;
+  background: var(--status-disconnected);
 }
 .hub-host-dot.disconnected { background: var(--status-disconnected); }
 .hub-host-name {

--- a/apps/gmux-web/src/types.ts
+++ b/apps/gmux-web/src/types.ts
@@ -72,7 +72,7 @@ export interface DiscoveredProject {
 export interface PeerInfo {
   name: string
   url: string
-  status: string // 'connected' | 'connecting' | 'disconnected' | 'offline'
+  status: string // 'connected' | 'connecting' | 'disconnected' | 'offline' (connecting treated as disconnected in UI)
   session_count: number
   last_error?: string
   version?: string


### PR DESCRIPTION
## Small UI fixes and cleanup

Follow-up to PRs #136 (version display redesign) and #135 (runner
version on wire).

### Commits

1. **Polish sidebar logo, spinner visibility, and peer status display**
   - Remove background highlight from sidebar logo hover (keep text glow only)
   - Keep launch spinner visible when user stops hovering a folder row
   - Treat `connecting` peers same as `disconnected` in the UI; the brief
     connecting state during retry caused misleading indicators on offline hosts
   - Remove unused `--status-connecting` CSS variable

2. **Surface update notification and clean up dead sidebar import**
   - Remove unused `health` import and `healthVal` variable from sidebar
     (left behind when the version badge was removed in #136)
   - Surface `update_available` notification which was previously only shown
     in the now-removed sidebar badge: local host card shows
     "v1.2.0 → v1.3.0", footer shows "v1.3.0 available" linking to changelog

All 250 frontend tests pass, clean build.