### PR TITLE
fix(web): guard mobile-input handler with pointer:coarse check

### DIFF
--- a/apps/gmux-web/src/mobile-input.test.ts
+++ b/apps/gmux-web/src/mobile-input.test.ts
@@ -1,5 +1,24 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { attachMobileInputHandler } from './mobile-input'
+
+// Mock window.matchMedia to simulate a touch-primary device.
+// The handler guards on (pointer: coarse) and is a no-op on desktop.
+const matchMediaMock = vi.fn().mockImplementation((query: string) => ({
+  matches: query === '(pointer: coarse)',
+  media: query,
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn(),
+  addListener: vi.fn(),
+  removeListener: vi.fn(),
+  onchange: null,
+  dispatchEvent: vi.fn(),
+}))
+
+// Vitest runs in Node (no DOM); provide minimal window stub.
+if (typeof globalThis.window === 'undefined') {
+  (globalThis as any).window = globalThis
+}
+Object.defineProperty(window, 'matchMedia', { value: matchMediaMock, writable: true, configurable: true })
 
 // ── Test helpers ──
 
@@ -446,5 +465,53 @@ describe('attachMobileInputHandler', () => {
   it('returns noop when terminal has no textarea', () => {
     const d = attachMobileInputHandler({ textarea: null } as any, container as any, send)
     d() // should not throw
+  })
+
+  it('is a no-op on desktop (pointer: fine)', () => {
+    dispose()
+
+    // Temporarily override matchMedia to report a fine pointer (desktop).
+    matchMediaMock.mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      onchange: null,
+      dispatchEvent: vi.fn(),
+    }))
+
+    const desktopSent: string[] = []
+    const desktopDispose = attachMobileInputHandler(
+      { textarea } as any,
+      container as any,
+      (data) => { desktopSent.push(data) },
+    )
+
+    // Set up a non-collapsed selection (xterm internal state on desktop)
+    textarea.value = 'old content from previous input'
+    textarea.selectionStart = 0
+    textarea.selectionEnd = 30
+
+    // Insert text with non-collapsed selection: on mobile this would
+    // trigger the iOS replacement path, on desktop it must be ignored.
+    simulateInput(textarea, container, 'insertText', ' ')
+
+    expect(desktopSent).toEqual([])
+
+    desktopDispose()
+
+    // Restore touch mock for other tests.
+    matchMediaMock.mockImplementation((query: string) => ({
+      matches: query === '(pointer: coarse)',
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      onchange: null,
+      dispatchEvent: vi.fn(),
+    }))
   })
 })

--- a/apps/gmux-web/src/mobile-input.ts
+++ b/apps/gmux-web/src/mobile-input.ts
@@ -88,6 +88,16 @@ export function attachMobileInputHandler(
   const textarea = term.textarea
   if (!textarea) return () => {}
 
+  // Autocorrect / word-replacement is a mobile-keyboard concern (iOS,
+  // Android). On desktop, xterm.js manages the textarea selection
+  // internally and may leave non-collapsed ranges that our handler would
+  // misinterpret as autocorrect replacements, sending spurious backspaces.
+  // Track the pointer type dynamically so tablet-mode switches are handled.
+  const pointerQuery = window.matchMedia('(pointer: coarse)')
+  let isTouchPrimary = pointerQuery.matches
+  const onPointerChange = () => { isTouchPrimary = pointerQuery.matches }
+  pointerQuery.addEventListener('change', onPointerChange)
+
   let pending: PendingReplacement | null = null
   let trackedDeletion: TrackedDeletion | null = null
 
@@ -109,6 +119,8 @@ export function attachMobileInputHandler(
 
   // Phase 1: detect replacement and send backspaces.
   const onBeforeInput = (ev: InputEvent) => {
+    if (!isTouchPrimary) return
+
     // Snapshot and clear tracked deletion at the top; only the
     // deleteContentBackward branch may re-set it below.
     const deletion = trackedDeletion
@@ -180,6 +192,7 @@ export function attachMobileInputHandler(
   container.addEventListener('input', onInput, { capture: true })
 
   return () => {
+    pointerQuery.removeEventListener('change', onPointerChange)
     textarea.removeEventListener('beforeinput', onBeforeInput, { capture: true })
     container.removeEventListener('input', onInput, { capture: true })
   }


### PR DESCRIPTION
On desktop, xterm.js can leave non-collapsed selections in its hidden textarea. The mobile autocorrect handler misread these as iOS-style replacements, sending backspaces that erased unrelated terminal content.

**Root cause**: `attachMobileInputHandler` listens for `beforeinput` on all devices. On desktop, xterm.js manages its textarea selection internally and may leave `selectionStart != selectionEnd` spanning old content. When a normal keystroke fires `beforeinput`, the handler saw the non-collapsed selection and treated it as an autocorrect replacement, sending `\x7f` × textarea.length backspaces followed by the single typed character.

**Fix**: Guard `onBeforeInput` with a `(pointer: coarse)` media query. Autocorrect is purely a mobile keyboard concern (iOS/Android). The check is evaluated dynamically via a `change` listener on the MediaQueryList so tablet-mode switches are handled.

**Symptom**: typing "> " in a pi session erased ">" and triggered a full TUI redraw. Diagnosed via a temporary debug capture module that logged annotated escape sequences on the terminal I/O hot path.