### PR TITLE
fix(web): fix session menu clipping, improve button style, rename to session-menu

### DIFF
--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -78,13 +78,13 @@ function MainHeader({ session, onRestart }: {
             {session.status.label}
           </div>
         )}
-        <SessionInfoMenu session={session} onRestart={onRestart} />
+        <SessionMenu session={session} onRestart={onRestart} />
       </div>
     </div>
   )
 }
 
-function SessionInfoMenu({ session, onRestart }: {
+function SessionMenu({ session, onRestart }: {
   session: Session
   onRestart?: () => void
 }) {
@@ -114,41 +114,40 @@ function SessionInfoMenu({ session, onRestart }: {
       ? session.binary_hash.slice(0, 8)
       : 'unknown'
 
-  const label = session.kind !== 'shell' ? session.kind : 'shell'
-
   return (
-    <div class="session-info" ref={menuRef}>
+    <div class="session-menu" ref={menuRef}>
       <button
-        class={`session-info-trigger${staleKind ? ' stale' : ''}`}
+        class={`session-menu-trigger${staleKind ? ' stale' : ''}`}
         onClick={() => setOpen(!open)}
-        title={staleKind ? 'Runner outdated' : label}
+        title={staleKind ? 'Runner outdated; click to restart' : 'Session'}
       >
-        {label}
-        {staleKind && <span class="session-info-dot" />}
+        {session.kind}
+        {staleKind && <span class="session-menu-dot" />}
       </button>
       {open && (
-        <div class="session-info-menu">
-          <div class="session-info-row">
-            <span class="session-info-label">runner</span>
-            <span class="session-info-value">{label}</span>
+        <div class="session-menu-dropdown">
+          <div class="session-menu-section-title">Session info</div>
+          <div class="session-menu-row">
+            <span class="session-menu-label">adapter</span>
+            <span class="session-menu-value">{session.kind}</span>
           </div>
-          <div class="session-info-row">
-            <span class="session-info-label">version</span>
-            <span class={`session-info-value${staleKind ? ' stale' : ''}`}>
+          <div class="session-menu-row">
+            <span class="session-menu-label">version</span>
+            <span class={`session-menu-value${staleKind ? ' stale' : ''}`}>
               {versionDisplay}
             </span>
           </div>
           {session.peer && (
-            <div class="session-info-row">
-              <span class="session-info-label">host</span>
-              <span class="session-info-value">{session.peer}</span>
+            <div class="session-menu-row">
+              <span class="session-menu-label">host</span>
+              <span class="session-menu-value">{session.peer}</span>
             </div>
           )}
           {session.alive && onRestart && (
             <>
-              <div class="session-info-divider" />
+              <div class="session-menu-divider" />
               <button
-                class={`session-info-action${staleKind ? ' stale' : ''}`}
+                class={`session-menu-action${staleKind ? ' stale' : ''}`}
                 onClick={() => { setOpen(false); onRestart() }}
               >
                 restart session

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -1052,7 +1052,10 @@ body {
   gap: 12px;
   border-bottom: 1px solid var(--border);
   flex-shrink: 0;
-  overflow: hidden;
+  /* overflow must NOT be hidden here — the session menu drops below the header */
+  overflow: visible;
+  position: relative;
+  z-index: 30;
 }
 
 .main-header-left {
@@ -1060,6 +1063,7 @@ body {
   align-items: center;
   gap: 8px;
   min-width: 0;
+  overflow: hidden;
 }
 
 .main-header-right {
@@ -1115,40 +1119,47 @@ body {
 .main-header-status.working { color: var(--accent); }
 .main-header-status.error   { color: var(--status-error); }
 
-/* Session info menu (replaces standalone adapter + outdated badges) */
+/* Session actions menu */
 
-.session-info {
+.session-menu {
   position: relative;
 }
 
-.session-info-trigger {
+.session-menu-trigger {
   font-family: 'Fira Code', monospace;
   font-size: 11px;
   font-weight: 500;
-  color: var(--text-muted);
+  color: var(--text-secondary);
   background: var(--bg-surface);
-  border: 1px solid transparent;
-  padding: 2px 8px;
-  border-radius: 3px;
+  border: 1px solid var(--border);
+  padding: 3px 8px;
+  border-radius: 4px;
   white-space: nowrap;
   cursor: pointer;
   letter-spacing: 0.01em;
   display: flex;
   align-items: center;
   gap: 5px;
-  transition: color 0.15s, border-color 0.15s;
+  transition: background 0.1s, border-color 0.1s, color 0.1s;
 }
 
-.session-info-trigger:hover {
-  color: var(--text-secondary);
-  border-color: var(--border);
+.session-menu-trigger:hover {
+  background: var(--bg-hover);
+  border-color: var(--border-strong);
+  color: var(--text);
 }
 
-.session-info-trigger.stale {
+.session-menu-trigger.stale {
+  border-color: oklch(75% 0.15 65 / 0.5);
   color: oklch(75% 0.15 65);
 }
 
-.session-info-dot {
+.session-menu-trigger.stale:hover {
+  border-color: oklch(75% 0.15 65 / 0.8);
+  background: oklch(75% 0.15 65 / 0.08);
+}
+
+.session-menu-dot {
   width: 5px;
   height: 5px;
   border-radius: 50%;
@@ -1156,52 +1167,61 @@ body {
   flex-shrink: 0;
 }
 
-.session-info-menu {
+.session-menu-dropdown {
   position: absolute;
   top: calc(100% + 6px);
   right: 0;
-  min-width: 180px;
+  min-width: 200px;
   background: var(--bg-surface);
   border: 1px solid var(--border);
   border-radius: 6px;
-  padding: 8px 0;
-  box-shadow: 0 4px 16px oklch(0% 0 0 / 0.3);
-  z-index: 50;
+  padding: 6px 0;
+  box-shadow: 0 8px 24px oklch(0% 0 0 / 0.4);
+  z-index: 100;
 }
 
-.session-info-row {
+.session-menu-section-title {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--text-muted);
+  padding: 6px 12px 2px;
+}
+
+.session-menu-row {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 4px 12px;
+  padding: 3px 12px;
   font-size: 12px;
 }
 
-.session-info-label {
+.session-menu-label {
   color: var(--text-muted);
 }
 
-.session-info-value {
+.session-menu-value {
   font-family: 'Fira Code', monospace;
   font-size: 11px;
   color: var(--text-secondary);
 }
 
-.session-info-value.stale {
+.session-menu-value.stale {
   color: oklch(75% 0.15 65);
 }
 
-.session-info-divider {
+.session-menu-divider {
   height: 1px;
   background: var(--border);
-  margin: 6px 0;
+  margin: 4px 0;
 }
 
-.session-info-action {
+.session-menu-action {
   display: block;
   width: 100%;
   text-align: left;
-  padding: 5px 12px;
+  padding: 6px 12px;
   font-size: 12px;
   color: var(--text-secondary);
   background: none;
@@ -1210,17 +1230,17 @@ body {
   transition: background 0.1s, color 0.1s;
 }
 
-.session-info-action:hover {
+.session-menu-action:hover {
   background: var(--bg-hover);
   color: var(--text);
 }
 
-.session-info-action.stale {
+.session-menu-action.stale {
   color: oklch(75% 0.15 65);
 }
 
-.session-info-action.stale:hover {
-  background: oklch(75% 0.15 65 / 0.12);
+.session-menu-action.stale:hover {
+  background: oklch(75% 0.15 65 / 0.1);
   color: oklch(85% 0.15 65);
 }
 


### PR DESCRIPTION
Fix three issues with the session actions menu introduced in PR #136:

**Clipping / renders behind terminal**
- `.main-header` had `overflow: hidden`, which clipped the absolutely-positioned dropdown to the header bounds
- Moved `overflow: hidden` to `.main-header-left` (the only part that needs ellipsis on long titles)
- Added `position: relative; z-index: 30` to `.main-header` so the dropdown stacks above terminal content (which uses z-index 10/12/20)
- Raised dropdown `z-index` to 100

**Button appearance**
- Trigger now has a visible border at rest, making it look like an actual button rather than a pill badge
- Stale state shows warning-colored border, not just text color change
- Hover state darkens background and strengthens border

**Terminology and structure**
- Renamed all CSS classes from `session-info-*` to `session-menu-*` (the component is an actions menu, not just a tooltip)
- Renamed "runner" label to "adapter" (consistent with the rest of the codebase)
- Added "Session info" section title above the info rows