### PR TITLE
fix(web): redesign session menu, fix remote staleness, delete dead CSS

### DIFF
--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -18,7 +18,7 @@ import { LaunchButton } from './launcher'
 import { installCopySession } from './mock-data/export-session'
 
 import {
-  sessions, connState, selected, selectedId, view, health,
+  sessions, connState, selected, selectedId, view, health, peers,
   terminalOptions, keybinds, macCommandIsCtrl,
   backgroundActivity, unreadCount,
   urlPath,
@@ -91,7 +91,14 @@ function SessionMenu({ session, onRestart }: {
   const [open, setOpen] = useState(false)
   const menuRef = useRef<HTMLDivElement>(null)
   const healthVal = health.value
-  const staleKind = sessionStaleness(session, healthVal)
+
+  // For remote sessions, compare against the peer's version (not the local
+  // daemon's). Peers don't expose runner_hash, so only version comparison
+  // is possible for remote sessions.
+  const compareTarget = session.peer
+    ? { version: peers.value.find(p => p.name === session.peer)?.version ?? '' }
+    : healthVal
+  const staleKind = sessionStaleness(session, compareTarget)
 
   // Close on outside click or Escape.
   useEffect(() => {
@@ -114,45 +121,49 @@ function SessionMenu({ session, onRestart }: {
       ? session.binary_hash.slice(0, 8)
       : 'unknown'
 
+  const hasActions = session.alive && onRestart
+
   return (
     <div class="session-menu" ref={menuRef}>
       <button
         class={`session-menu-trigger${staleKind ? ' stale' : ''}`}
         onClick={() => setOpen(!open)}
-        title={staleKind ? 'Runner outdated; click to restart' : 'Session'}
+        title="Session actions"
+        aria-expanded={open}
       >
-        {session.kind}
-        {staleKind && <span class="session-menu-dot" />}
+        <span class="session-menu-icon">⋮</span>
+        {staleKind && <span class="session-menu-badge" />}
       </button>
       {open && (
         <div class="session-menu-dropdown">
+          {hasActions && (
+            <>
+              <button
+                class={`session-menu-action${staleKind ? ' stale' : ''}`}
+                onClick={() => { setOpen(false); onRestart!() }}
+              >
+                Restart session
+                {staleKind && <span class="session-menu-action-tag">outdated</span>}
+              </button>
+              <div class="session-menu-divider" />
+            </>
+          )}
           <div class="session-menu-section-title">Session info</div>
           <div class="session-menu-row">
-            <span class="session-menu-label">adapter</span>
+            <span class="session-menu-label">Adapter</span>
             <span class="session-menu-value">{session.kind}</span>
           </div>
           <div class="session-menu-row">
-            <span class="session-menu-label">version</span>
+            <span class="session-menu-label">Version</span>
             <span class={`session-menu-value${staleKind ? ' stale' : ''}`}>
               {versionDisplay}
             </span>
           </div>
           {session.peer && (
             <div class="session-menu-row">
-              <span class="session-menu-label">host</span>
+              <span class="session-menu-label">Host</span>
               <span class="session-menu-value">{session.peer}</span>
             </div>
-          )}
-          {session.alive && onRestart && (
-            <>
-              <div class="session-menu-divider" />
-              <button
-                class={`session-menu-action${staleKind ? ' stale' : ''}`}
-                onClick={() => { setOpen(false); onRestart() }}
-              >
-                restart session
-              </button>
-            </>
           )}
         </div>
       )}

--- a/apps/gmux-web/src/store.test.ts
+++ b/apps/gmux-web/src/store.test.ts
@@ -213,4 +213,20 @@ describe('sessionStaleness', () => {
       { version: 'dev', runner_hash: 'aabbccdd' },
     )).toBe('hash')
   })
+
+  it('returns null when compared against peer with matching version (no hash)', () => {
+    // Remote sessions are compared against their peer version, which has
+    // no runner_hash. Hash drift should not trigger a false positive.
+    expect(sessionStaleness(
+      { runner_version: '1.2.0', binary_hash: 'deadbeef9999' },
+      { version: '1.2.0' },
+    )).toBeNull()
+  })
+
+  it("returns 'version' when compared against peer with different version", () => {
+    expect(sessionStaleness(
+      { runner_version: '1.1.0' },
+      { version: '1.2.0' },
+    )).toBe('version')
+  })
 })

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -132,12 +132,6 @@ body {
   flex-direction: column;
 }
 
-/* Pushes folder content to the bottom of the scroll area.
-   Collapses to zero when content overflows, so scrolling works normally. */
-.sidebar-spacer {
-  flex: 1;
-}
-
 .sidebar-scroll::-webkit-scrollbar {
   width: 3px;
 }
@@ -1101,10 +1095,6 @@ body {
   white-space: nowrap;
 }
 
-.main-header-sep {
-  opacity: 0.4;
-}
-
 .main-header-status {
   display: flex;
   align-items: center;
@@ -1125,79 +1115,132 @@ body {
   position: relative;
 }
 
+/* Trigger: icon button in the same style as .session-close-btn */
 .session-menu-trigger {
-  font-family: 'Fira Code', monospace;
-  font-size: 11px;
-  font-weight: 500;
-  color: var(--text-secondary);
-  background: var(--bg-surface);
-  border: 1px solid var(--border);
-  padding: 3px 8px;
+  position: relative;
+  width: 26px;
+  height: 26px;
+  border: none;
   border-radius: 4px;
-  white-space: nowrap;
+  background: transparent;
+  color: var(--text-muted);
   cursor: pointer;
-  letter-spacing: 0.01em;
   display: flex;
   align-items: center;
-  gap: 5px;
-  transition: background 0.1s, border-color 0.1s, color 0.1s;
+  justify-content: center;
+  transition: background 0.1s, color 0.1s;
+  flex-shrink: 0;
 }
 
 .session-menu-trigger:hover {
   background: var(--bg-hover);
-  border-color: var(--border-strong);
   color: var(--text);
 }
 
 .session-menu-trigger.stale {
-  border-color: oklch(75% 0.15 65 / 0.5);
-  color: oklch(75% 0.15 65);
+  color: oklch(80% 0.15 65);
 }
 
-.session-menu-trigger.stale:hover {
-  border-color: oklch(75% 0.15 65 / 0.8);
-  background: oklch(75% 0.15 65 / 0.08);
+.session-menu-icon {
+  font-size: 16px;
+  line-height: 1;
+  letter-spacing: 0;
 }
 
-.session-menu-dot {
-  width: 5px;
-  height: 5px;
+/* Amber dot in top-right corner of trigger when runner is outdated */
+.session-menu-badge {
+  position: absolute;
+  top: 3px;
+  right: 3px;
+  width: 6px;
+  height: 6px;
   border-radius: 50%;
-  background: oklch(75% 0.15 65);
-  flex-shrink: 0;
+  background: oklch(80% 0.15 65);
+  border: 1.5px solid var(--bg);
+  pointer-events: none;
 }
 
 .session-menu-dropdown {
   position: absolute;
-  top: calc(100% + 6px);
+  top: calc(100% + 4px);
   right: 0;
   min-width: 200px;
   background: var(--bg-surface);
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-strong);
   border-radius: 6px;
-  padding: 6px 0;
+  padding: 4px 0;
   box-shadow: 0 8px 24px oklch(0% 0 0 / 0.4);
   z-index: 100;
 }
 
-.session-menu-section-title {
+/* Action buttons at the top of the menu */
+.session-menu-action {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 7px 12px;
+  font-size: 14px;
+  color: var(--text-secondary);
+  background: none;
+  border: none;
+  cursor: pointer;
+  transition: background 0.1s, color 0.1s;
+  text-align: left;
+}
+
+.session-menu-action:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+
+.session-menu-action.stale {
+  color: oklch(80% 0.15 65);
+}
+
+.session-menu-action.stale:hover {
+  background: oklch(80% 0.15 65 / 0.08);
+  color: oklch(88% 0.15 65);
+}
+
+/* Small tag shown next to the action label when runner is stale */
+.session-menu-action-tag {
   font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  padding: 1px 5px;
+  border-radius: 3px;
+  background: oklch(80% 0.15 65 / 0.15);
+  color: oklch(80% 0.15 65);
+  white-space: nowrap;
+}
+
+.session-menu-divider {
+  height: 1px;
+  background: var(--border);
+  margin: 4px 0;
+}
+
+/* Section heading above info rows */
+.session-menu-section-title {
+  font-size: 11px;
   font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.07em;
+  letter-spacing: 0.06em;
   color: var(--text-muted);
   padding: 6px 12px 2px;
 }
 
+/* Key/value info rows */
 .session-menu-row {
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  align-items: baseline;
   padding: 3px 12px;
-  font-size: 12px;
 }
 
 .session-menu-label {
+  font-size: 13px;
   color: var(--text-muted);
 }
 
@@ -1208,40 +1251,7 @@ body {
 }
 
 .session-menu-value.stale {
-  color: oklch(75% 0.15 65);
-}
-
-.session-menu-divider {
-  height: 1px;
-  background: var(--border);
-  margin: 4px 0;
-}
-
-.session-menu-action {
-  display: block;
-  width: 100%;
-  text-align: left;
-  padding: 6px 12px;
-  font-size: 12px;
-  color: var(--text-secondary);
-  background: none;
-  border: none;
-  cursor: pointer;
-  transition: background 0.1s, color 0.1s;
-}
-
-.session-menu-action:hover {
-  background: var(--bg-hover);
-  color: var(--text);
-}
-
-.session-menu-action.stale {
-  color: oklch(75% 0.15 65);
-}
-
-.session-menu-action.stale:hover {
-  background: oklch(75% 0.15 65 / 0.1);
-  color: oklch(85% 0.15 65);
+  color: oklch(80% 0.15 65);
 }
 
 .terminal-shell {
@@ -1256,18 +1266,6 @@ body {
 
 .terminal-shell-passive {
   touch-action: none;
-}
-
-.terminal-screenshot {
-  display: flex;
-  align-items: flex-start;
-  justify-content: center;
-}
-
-.terminal-screenshot img {
-  max-width: 100%;
-  max-height: 100%;
-  object-fit: contain;
 }
 
 .terminal-container {
@@ -1394,19 +1392,6 @@ body {
 .terminal-scroll-end:hover {
   background: oklch(from var(--bg-surface) l c h / 0.92);
   color: oklch(76% 0.012 250);
-}
-
-.terminal-loading-dot {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: var(--accent);
-  animation: pulse-dot 1.5s ease-in-out infinite;
-}
-
-@keyframes pulse-dot {
-  0%, 100% { opacity: 0.3; }
-  50% { opacity: 1; }
 }
 
 /* Use JetBrains Mono for italic glyphs since Fira Code has no italic variant.
@@ -1932,17 +1917,6 @@ a.home-host-link:hover {
 .btn-primary:hover {
   background: oklch(78% 0.1 195);
   border-color: oklch(78% 0.1 195);
-}
-
-.btn-danger {
-  color: var(--status-error);
-  border-color: oklch(30% 0.06 25);
-}
-
-.btn-danger:hover {
-  background: oklch(22% 0.04 25);
-  border-color: var(--status-error);
-  color: oklch(72% 0.2 25);
 }
 
 /* ── Reduced motion ── */


### PR DESCRIPTION
Follow-up to PRs #136 and #137.

### Session menu redesign
- Trigger is a compact ⋮ icon button instead of showing the adapter name
- Amber dot badge appears in the corner when the runner is outdated
- Actions first (restart with "outdated" tag), then session info section
  (adapter, version, host) below a heading
- Typography matches the rest of the app: 14px actions, 13px labels,
  11px monospace values, 11px/600/uppercase section titles
- z-index fix: menu no longer renders behind the terminal

### Remote staleness fix
`sessionStaleness` was always compared against the local daemon. A
remote session on a spoke at v1.1.0 would incorrectly show as outdated
if the hub was v1.2.0. Now remote sessions compare against their peer
version. Hash drift detection stays local-only (peers do not expose
`runner_hash`).

### Dead CSS cleanup
Deleted 5 orphaned classes that accumulated over recent refactors:
`sidebar-spacer`, `main-header-sep`, `btn-danger`,
`terminal-loading-dot` + `@keyframes pulse-dot`,
`terminal-screenshot`.

253 tests pass, clean build.