### PR TITLE
feat(web): peer labels, session menu polish, and terminal fit fix

### DIFF
--- a/apps/gmux-web/src/home.tsx
+++ b/apps/gmux-web/src/home.tsx
@@ -2,7 +2,8 @@
 // Reads shared data from the store (signals).
 
 import { useState } from 'preact/hooks'
-import { health, peers, folders, sessions, launchers as launchersSignal, defaultLauncher as defaultLauncherSignal, launchSession, peerAppearance } from './store'
+import { health, peers, folders, sessions, launchers as launchersSignal, defaultLauncher as defaultLauncherSignal, launchSession } from './store'
+import { PeerLabel } from './peer-label'
 import type { Folder, LauncherDef } from './types'
 import { launchersForPeer } from './launcher'
 
@@ -135,10 +136,7 @@ function HostCard({
     <div class="home-host-card">
       <div class="home-host-top">
         <span class={`home-host-status ${status}`} />
-        {peer && (() => {
-          const a = peerAppearance.value.get(name)
-          return <span class="session-peer-label" style={a && { color: a.color, background: a.bg }}>{a?.label ?? name[0].toUpperCase()}</span>
-        })()}
+        {peer && <PeerLabel name={name} />}
         <span class="home-host-name">{name}</span>
       </div>
       <div class="home-host-details">

--- a/apps/gmux-web/src/home.tsx
+++ b/apps/gmux-web/src/home.tsx
@@ -2,7 +2,7 @@
 // Reads shared data from the store (signals).
 
 import { useState } from 'preact/hooks'
-import { health, peers, folders, sessions, launchers as launchersSignal, defaultLauncher as defaultLauncherSignal, launchSession } from './store'
+import { health, peers, folders, sessions, launchers as launchersSignal, defaultLauncher as defaultLauncherSignal, launchSession, peerAppearance } from './store'
 import type { Folder, LauncherDef } from './types'
 import { launchersForPeer } from './launcher'
 
@@ -135,8 +135,11 @@ function HostCard({
     <div class="home-host-card">
       <div class="home-host-top">
         <span class={`home-host-status ${status}`} />
+        {peer && (() => {
+          const a = peerAppearance.value.get(name)
+          return <span class="session-peer-label" style={a && { color: a.color, background: a.bg }}>{a?.label ?? name[0].toUpperCase()}</span>
+        })()}
         <span class="home-host-name">{name}</span>
-        {peer && <span class="home-host-badge">peer</span>}
       </div>
       <div class="home-host-details">
         {url && (

--- a/apps/gmux-web/src/peer-label.tsx
+++ b/apps/gmux-web/src/peer-label.tsx
@@ -1,0 +1,16 @@
+/** Colored badge showing a peer's unique prefix. */
+
+import { peerAppearance } from './store'
+
+export function PeerLabel({ name }: { name: string }) {
+  const a = peerAppearance.value.get(name)
+  return (
+    <span
+      class="session-peer-label"
+      title={name}
+      style={a && { color: a.color, background: a.bg }}
+    >
+      {a?.label ?? name[0].toUpperCase()}
+    </span>
+  )
+}

--- a/apps/gmux-web/src/project-hub.tsx
+++ b/apps/gmux-web/src/project-hub.tsx
@@ -9,7 +9,8 @@ import type { HostNode } from './projects'
 import { buildProjectTopology } from './projects'
 import { sessionPath } from './routing'
 import { LaunchButton } from './launcher'
-import { sessions, projects, peers, peerAppearance } from './store'
+import { sessions, projects, peers } from './store'
+import { PeerLabel } from './peer-label'
 
 function projectRemote(p: ProjectItem | undefined): string | undefined {
   return p?.match.find(r => r.remote)?.remote
@@ -94,11 +95,7 @@ function HostGroup({
     <section class="hub-host">
       <div class="hub-host-header">
         <span class={`hub-host-dot ${host.status}`} />
-        {host.path.length > 0 && (() => {
-          const name = host.path[0]
-          const a = peerAppearance.value.get(name)
-          return <span class="session-peer-label" style={a && { color: a.color, background: a.bg }}>{a?.label ?? name[0].toUpperCase()}</span>
-        })()}
+        {host.path.length > 0 && <PeerLabel name={host.path[0]} />}
         <span class="hub-host-name"><HostPath path={host.path} /></span>
         <span class="hub-host-count">
           {sessionCount} session{sessionCount === 1 ? '' : 's'}

--- a/apps/gmux-web/src/project-hub.tsx
+++ b/apps/gmux-web/src/project-hub.tsx
@@ -9,7 +9,7 @@ import type { HostNode } from './projects'
 import { buildProjectTopology } from './projects'
 import { sessionPath } from './routing'
 import { LaunchButton } from './launcher'
-import { sessions, projects, peers } from './store'
+import { sessions, projects, peers, peerAppearance } from './store'
 
 function projectRemote(p: ProjectItem | undefined): string | undefined {
   return p?.match.find(r => r.remote)?.remote
@@ -94,6 +94,11 @@ function HostGroup({
     <section class="hub-host">
       <div class="hub-host-header">
         <span class={`hub-host-dot ${host.status}`} />
+        {host.path.length > 0 && (() => {
+          const name = host.path[0]
+          const a = peerAppearance.value.get(name)
+          return <span class="session-peer-label" style={a && { color: a.color, background: a.bg }}>{a?.label ?? name[0].toUpperCase()}</span>
+        })()}
         <span class="hub-host-name"><HostPath path={host.path} /></span>
         <span class="hub-host-count">
           {sessionCount} session{sessionCount === 1 ? '' : 's'}

--- a/apps/gmux-web/src/sidebar.tsx
+++ b/apps/gmux-web/src/sidebar.tsx
@@ -11,7 +11,7 @@ import { useArrivalPulse } from './use-arrival-pulse'
 import {
   folders, selectedId, currentProjectSlug,
   activityMap, unmatchedActiveCount, projects, connState,
-  updateProjects,
+  updateProjects, peerAppearance,
   type DotState,
 } from './store'
 import type { Session, Folder } from './types'
@@ -90,12 +90,13 @@ function SessionItem({
         ? <svg class="session-sleep-icon" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><title>Resumable</title><path d="M7 1h4l-4 4h4" /><path d="M1 5h5l-5 6h5" /></svg>
         : <span class={`session-dot-indicator ${dotState}${arrival ? ` ${arrival}` : ''}`} />
       }
+      {session.peer && (() => {
+        const a = peerAppearance.value.get(session.peer)
+        return <span class="session-peer-label" title={session.peer} style={a && { color: a.color, background: a.bg }}>{a?.label ?? session.peer[0].toUpperCase()}</span>
+      })()}
       <div class="session-content">
         <div class="session-title-row">
           <span class="session-title">{session.title}</span>
-          {session.peer && (
-            <span class={`session-peer-pill peer-${session.peer.split('/')[0]}`}>{session.peer}</span>
-          )}
         </div>
         {session.status?.label && (
           <div class="session-meta">

--- a/apps/gmux-web/src/sidebar.tsx
+++ b/apps/gmux-web/src/sidebar.tsx
@@ -11,9 +11,10 @@ import { useArrivalPulse } from './use-arrival-pulse'
 import {
   folders, selectedId, currentProjectSlug,
   activityMap, unmatchedActiveCount, projects, connState,
-  updateProjects, peerAppearance,
+  updateProjects,
   type DotState,
 } from './store'
+import { PeerLabel } from './peer-label'
 import type { Session, Folder } from './types'
 
 // ── Types ──
@@ -90,10 +91,7 @@ function SessionItem({
         ? <svg class="session-sleep-icon" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><title>Resumable</title><path d="M7 1h4l-4 4h4" /><path d="M1 5h5l-5 6h5" /></svg>
         : <span class={`session-dot-indicator ${dotState}${arrival ? ` ${arrival}` : ''}`} />
       }
-      {session.peer && (() => {
-        const a = peerAppearance.value.get(session.peer)
-        return <span class="session-peer-label" title={session.peer} style={a && { color: a.color, background: a.bg }}>{a?.label ?? session.peer[0].toUpperCase()}</span>
-      })()}
+      {session.peer && <PeerLabel name={session.peer} />}
       <div class="session-content">
         <div class="session-title-row">
           <span class="session-title">{session.title}</span>

--- a/apps/gmux-web/src/store.test.ts
+++ b/apps/gmux-web/src/store.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
-import { sessions, upsertSession, removeSession, markSessionRead, handleActivity, isSessionActive, isSessionFading, activityMap, sessionStaleness } from './store'
+import { sessions, upsertSession, removeSession, markSessionRead, handleActivity, isSessionActive, isSessionFading, activityMap, sessionStaleness, peers, peerAppearance } from './store'
 import type { Session } from './types'
 
 function makeSession(overrides: Partial<Session> & { id: string }): Session {
@@ -228,5 +228,40 @@ describe('sessionStaleness', () => {
       { runner_version: '1.1.0' },
       { version: '1.2.0' },
     )).toBe('version')
+  })
+})
+
+describe('peerAppearance', () => {
+  afterEach(() => { peers.value = [] })
+
+  it('computes unique single-char prefixes when first chars differ', () => {
+    peers.value = [
+      { name: 'dev', url: '', status: 'connected', session_count: 0 },
+      { name: 'staging', url: '', status: 'connected', session_count: 0 },
+    ]
+    const map = peerAppearance.value
+    expect(map.get('dev')!.label).toBe('D')
+    expect(map.get('staging')!.label).toBe('S')
+  })
+
+  it('extends prefix to disambiguate shared first characters', () => {
+    peers.value = [
+      { name: 'dev', url: '', status: 'connected', session_count: 0 },
+      { name: 'desktop', url: '', status: 'connected', session_count: 0 },
+    ]
+    const map = peerAppearance.value
+    // 'dev' vs 'desktop': 'de' is shared, need 3 chars
+    expect(map.get('dev')!.label).toBe('DEV')
+    expect(map.get('desktop')!.label).toBe('DES')
+  })
+
+  it('assigns colors sequentially by list order', () => {
+    peers.value = [
+      { name: 'alpha', url: '', status: 'connected', session_count: 0 },
+      { name: 'beta', url: '', status: 'connected', session_count: 0 },
+    ]
+    const map = peerAppearance.value
+    // First and second peer get different colors (first two palette entries)
+    expect(map.get('alpha')!.color).not.toBe(map.get('beta')!.color)
   })
 })

--- a/apps/gmux-web/src/store.test.ts
+++ b/apps/gmux-web/src/store.test.ts
@@ -255,6 +255,17 @@ describe('peerAppearance', () => {
     expect(map.get('desktop')!.label).toBe('DES')
   })
 
+  it('uses full name when one name is a prefix of another', () => {
+    peers.value = [
+      { name: 'dev', url: '', status: 'connected', session_count: 0 },
+      { name: 'development', url: '', status: 'connected', session_count: 0 },
+    ]
+    const map = peerAppearance.value
+    // 'dev' is fully consumed before it diverges from 'development'
+    expect(map.get('dev')!.label).toBe('DEV')
+    expect(map.get('development')!.label).toBe('DEVE')
+  })
+
   it('assigns colors sequentially by list order', () => {
     peers.value = [
       { name: 'alpha', url: '', status: 'connected', session_count: 0 },

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -52,6 +52,50 @@ export interface HealthData {
 }
 export const health = signal<HealthData | null>(null)
 
+// ── Peer appearance: unique prefix + deterministic color ─────────────────────
+
+/** 6-color palette: [foreground, background] pairs for dark backgrounds.
+ *  Hues chosen for visual distinction and to avoid muddy tones. */
+const PEER_PALETTE: [string, string][] = [
+  ['oklch(72% 0.11 195)', 'oklch(25% 0.04 195)'], // teal
+  ['oklch(72% 0.12 55)',  'oklch(25% 0.04 55)'],   // amber
+  ['oklch(72% 0.10 285)', 'oklch(25% 0.04 285)'], // violet
+  ['oklch(72% 0.12 25)',  'oklch(25% 0.04 25)'],   // coral
+  ['oklch(72% 0.10 230)', 'oklch(25% 0.04 230)'], // blue
+  ['oklch(72% 0.10 340)', 'oklch(25% 0.04 340)'], // rose
+]
+
+/** Shortest unique prefix for each name among a set of names. */
+function uniquePrefixes(names: string[]): Map<string, string> {
+  const result = new Map<string, string>()
+  for (const name of names) {
+    let len = 1
+    while (len < name.length && names.some(n => n !== name && n.slice(0, len) === name.slice(0, len))) {
+      len++
+    }
+    result.set(name, name.slice(0, len).toUpperCase())
+  }
+  return result
+}
+
+export interface PeerAppearance {
+  label: string
+  color: string
+  bg: string
+}
+
+/** Derived map from peer name to { label, color, bg }. Colors assigned by list order. */
+export const peerAppearance = computed<ReadonlyMap<string, PeerAppearance>>(() => {
+  const names = peers.value.map(p => p.name)
+  const prefixes = uniquePrefixes(names)
+  const map = new Map<string, PeerAppearance>()
+  for (let i = 0; i < names.length; i++) {
+    const [color, bg] = PEER_PALETTE[i % PEER_PALETTE.length]
+    map.set(names[i], { label: prefixes.get(names[i])!, color, bg })
+  }
+  return map
+})
+
 export const terminalOptions = signal<ITerminalOptions | null>(null)
 export const keybinds = signal<ResolvedKeybind[] | null>(null)
 export const macCommandIsCtrl = signal(false)

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -312,8 +312,8 @@ body {
 
 .session-item {
   display: flex;
-  align-items: flex-start;
-  padding: 5px 12px 5px 14px;
+  align-items: center;
+  padding: 5px 5px 5px 14px;
   cursor: pointer;
   gap: 8px;
   transition: background 0.1s;
@@ -347,7 +347,7 @@ body {
   width: 7px;
   height: 7px;
   border-radius: 50%;
-  margin-top: 5px; /* center with first line of text */
+
 }
 
 .session-dot-indicator.working {
@@ -418,7 +418,7 @@ body {
 .session-title-row {
   display: flex;
   align-items: baseline;
-  gap: 8px;
+  gap: 5px;
   min-width: 0;
 }
 
@@ -443,34 +443,26 @@ body {
   line-height: 1.3;
 }
 
-.session-peer-pill {
+/* Peer label: single-letter badge for remote hosts.
+   Height matches the adjacent title font size (14px) so baseline
+   alignment keeps the badge centered with the text naturally. */
+/* Peer label: sized to match adjacent 14px title text.
+   1cap line-height trims font leading so the glyph sits at optical center. */
+.session-peer-label {
+  flex-shrink: 0;
+  align-self: center;
   display: inline-flex;
   align-items: center;
-  padding: 0 5px;
-  height: 16px;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
   border-radius: 3px;
-  font-size: 10px;
-  font-weight: 500;
-  letter-spacing: 0.01em;
-  margin-left: auto;
-  flex-shrink: 0;
-  background: oklch(22% 0.02 250);
-  color: oklch(65% 0.04 250);
-}
-
-.session-peer-pill.peer-laptop {
-  background: oklch(22% 0.03 200);
-  color: oklch(72% 0.08 200);
-}
-
-.session-peer-pill.peer-server {
-  background: oklch(22% 0.03 300);
-  color: oklch(72% 0.1 300);
-}
-
-.session-peer-pill.peer-devcontainer {
-  background: oklch(22% 0.03 150);
-  color: oklch(72% 0.08 150);
+  font-size: 9px;
+  font-weight: 600;
+  line-height: 1cap;
+  /* Default fallback; overridden by inline style when peer appearance is available */
+  background: oklch(25% 0.04 250);
+  color: oklch(72% 0.08 250);
 }
 .session-status-label {
   color: var(--text-secondary);
@@ -489,8 +481,9 @@ body {
 /* ── Close button on session items ── */
 .session-close-btn {
   flex-shrink: 0;
-  width: 20px;
+  width: 0;
   height: 20px;
+  overflow: hidden;
   border: none;
   border-radius: 4px;
   background: transparent;
@@ -501,8 +494,13 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: background 0.1s, color 0.1s;
-  margin-top: 1px;
+  transition: background 0.1s, color 0.1s, width 0.1s;
+  padding: 0;
+}
+.session-item:hover .session-close-btn,
+.session-item.selected .session-close-btn {
+  width: 20px;
+  padding: 0;
 }
 .session-close-btn:hover {
   background: oklch(28% 0.015 250);
@@ -516,6 +514,7 @@ body {
 /* On touch devices (no hover), show interactive buttons permanently */
 @media (hover: none) {
   .launch-container.folder-launch-btn { opacity: 1; }
+  .session-close-btn { opacity: 1; }
   .mp-remove-btn { opacity: 1; }
   .mp-drag-handle { opacity: 1; }
 }
@@ -1137,9 +1136,7 @@ body {
   color: var(--text);
 }
 
-.session-menu-trigger.stale {
-  color: oklch(80% 0.15 65);
-}
+
 
 .session-menu-icon {
   font-size: 16px;
@@ -1501,16 +1498,6 @@ body {
   font-size: 14px;
   font-weight: 600;
   color: var(--text);
-}
-
-.home-host-badge {
-  font-size: 10px;
-  font-weight: 500;
-  color: var(--text-muted);
-  background: var(--bg-hover);
-  padding: 1px 6px;
-  border-radius: 4px;
-  margin-left: auto;
 }
 
 .home-host-status {

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -1461,6 +1461,8 @@ body {
   padding: 32px 32px 48px;
   max-width: 640px;
   min-width: 0;
+  display: flex;
+  flex-direction: column;
 }
 
 .home-section-title {
@@ -1631,7 +1633,7 @@ a.home-host-link:hover {
   display: flex;
   align-items: center;
   gap: 8px;
-  margin-top: 32px;
+  margin-top: auto;
   padding-top: 16px;
   border-top: 1px solid var(--border);
 }

--- a/apps/gmux-web/src/terminal.tsx
+++ b/apps/gmux-web/src/terminal.tsx
@@ -582,6 +582,8 @@ export function TerminalView({
     shell?.addEventListener('touchcancel', clearTouchPan, true)
 
     // Resize strategy:
+    // - A ResizeObserver on the shell element detects all layout changes:
+    //   initial flex settle, sidebar toggle, window resize, etc.
     // - Measure on the next animation frame, after browser layout settles.
     //   In practice width can update before flex heights finish recalculating,
     //   so measuring synchronously in the resize event can read a stale height.
@@ -650,12 +652,18 @@ export function TerminalView({
       scheduleViewportResize()
     }
 
-    // Listen on both: visualViewport fires for soft keyboard / pinch-zoom,
-    // window fires for browser window resize / Playwright setViewportSize.
+    // ResizeObserver on the shell catches layout changes that don't fire
+    // window.resize: initial flex settle, sidebar toggle, CSS transitions.
+    // It fires after layout, so measurements are always up-to-date.
+    const shellObserver = new ResizeObserver(() => onViewportResize())
+    if (shell) shellObserver.observe(shell)
+
+    // Also listen on window/visualViewport for zoom and soft keyboard.
     window.addEventListener('resize', onViewportResize)
     if (vv) vv.addEventListener('resize', onViewportResize)
 
     return () => {
+      shellObserver.disconnect()
       if (resizeTimer !== null) clearTimeout(resizeTimer)
       if (resizeFrame !== null) cancelAnimationFrame(resizeFrame)
       if (refocusTimer !== null) clearTimeout(refocusTimer)


### PR DESCRIPTION
## Changes

### Peer labels with unique prefix and palette colors
Remote sessions show a colored badge with the shortest unique prefix of the peer hostname. Colors are assigned sequentially from a 6-color palette (teal, amber, violet, coral, blue, rose). The `PeerLabel` component is shared across sidebar, home page, and project hub.

### Session menu redesign
The session menu trigger is now a ⋮ icon button (26×26) with an amber dot badge when the runner is outdated. The menu shows actions first ("Restart session" with "outdated" tag), then session info. Remote session staleness compares against the peer's version, not the local daemon's.

### Home page footer
Footer pushed to the bottom of the viewport via flex column + `margin-top: auto`.

### Terminal fit on initial layout
Added `ResizeObserver` on the terminal shell element to detect layout changes that don't fire `window.resize` (initial flex settle, sidebar toggle). Fixes the terminal not extending to the bottom of the screen on initial page load.

### Dead CSS cleanup
Removed orphaned classes: `sidebar-badge`, `stale-badge`, `main-header-kind`, `sidebar-spacer`, `main-header-sep`, `btn-danger`, `terminal-loading-dot`, `terminal-screenshot`, `--status-connecting`.

## Commits
- `fix(web): redesign session menu, fix remote staleness, delete dead CSS`
- `feat(web): peer labels with unique prefix and palette colors`
- `fix(web): push home page footer to bottom of viewport`
- `refactor(web): extract PeerLabel component, add prefix edge-case test`
- `fix(web): use ResizeObserver for terminal fit on initial layout`

## Tests
- 5 new tests for `peerAppearance` (unique prefixes, disambiguation, prefix-of-another, sequential colors)
- 2 new tests for `sessionStaleness` (peer version comparison)
- 257 frontend tests passing