### PR TITLE
fix(cli): rename GMUX_VERSION child env var to GMUX_RUNNER_VERSION

### DIFF
--- a/apps/website/src/content/docs/develop/adapter-architecture.md
+++ b/apps/website/src/content/docs/develop/adapter-architecture.md
@@ -239,7 +239,7 @@ Every child launched by `gmux` gets a small protocol for detecting gmux and repo
 | `GMUX_SOCKET` | Unix socket path for callbacks to the runner |
 | `GMUX_SESSION_ID` | Unique session identifier |
 | `GMUX_ADAPTER` | Name of the matched adapter |
-| `GMUX_VERSION` | Protocol/version marker |
+| `GMUX_RUNNER_VERSION` | Version of the gmux runner hosting the session |
 
 Most tools ignore these. gmux-aware tools, wrappers, or hooks can use them to integrate directly.
 

--- a/apps/website/src/content/docs/develop/writing-adapters.md
+++ b/apps/website/src/content/docs/develop/writing-adapters.md
@@ -97,7 +97,7 @@ type Adapter interface {
 
 **`Match(cmd)`** receives the full command array and decides whether this adapter should handle it. Match on `filepath.Base(arg)` so full paths and wrappers work. Stop scanning at `"--"`.
 
-**`Env(ctx)`** returns extra environment variables for the child. The runner already sets `GMUX`, `GMUX_SOCKET`, `GMUX_SESSION_ID`, `GMUX_ADAPTER`, and `GMUX_VERSION`. Most adapters return `nil`.
+**`Env(ctx)`** returns extra environment variables for the child. The runner already sets `GMUX`, `GMUX_SOCKET`, `GMUX_SESSION_ID`, `GMUX_ADAPTER`, and `GMUX_RUNNER_VERSION`. Most adapters return `nil`.
 
 **`Monitor(output)`** receives raw PTY bytes on every read. Return a `*Status` when something meaningful happens, `nil` otherwise. This runs frequently, so keep it cheap.
 

--- a/apps/website/src/content/docs/reference/environment.md
+++ b/apps/website/src/content/docs/reference/environment.md
@@ -81,6 +81,6 @@ These are available inside every session launched by `gmux`. Use them to detect 
 | `GMUX_SOCKET` | Unix socket path for callbacks to the session runner. | `/tmp/gmux-sessions/sess-abc123.sock` |
 | `GMUX_SESSION_ID` | Unique session identifier. | `sess-abc123` |
 | `GMUX_ADAPTER` | Name of the matched adapter. | `pi`, `shell` |
-| `GMUX_VERSION` | gmux protocol version. | `0.4.0` |
+| `GMUX_RUNNER_VERSION` | Version of the gmux runner hosting the session. | `0.4.0` |
 
 See [Adapter Architecture](/develop/adapter-architecture) for how to use the child-to-runner API.

--- a/cli/gmux/cmd/gmux/main.go
+++ b/cli/gmux/cmd/gmux/main.go
@@ -165,7 +165,7 @@ func main() {
 		"GMUX_SOCKET=" + sockPath,
 		"GMUX_SESSION_ID=" + sessionID,
 		"GMUX_ADAPTER=" + a.Name(),
-		"GMUX_VERSION=" + version,
+		"GMUX_RUNNER_VERSION=" + version,
 	}
 	env = append(env, adapterEnv...)
 


### PR DESCRIPTION
\`GMUX_VERSION\` is set on every child process gmux spawns, but it collides with the install script convention where users set \`GMUX_VERSION=vX.Y.Z\` to pin a specific release. Running the installer from inside a gmux pane would silently install the already-running version instead of latest.

Rename to \`GMUX_RUNNER_VERSION\`, which is more precise (it's the version of the runner the pane is hosted in) and avoids the conflict. No code reads this variable back -- it's purely informational for shell scripts inside sessions.