### PR TITLE
feat(web): drag-to-reorder sessions in the sidebar

### DIFF
--- a/apps/gmux-web/src/projects.test.ts
+++ b/apps/gmux-web/src/projects.test.ts
@@ -208,6 +208,46 @@ describe('buildProjectFolders', () => {
     const folders = buildProjectFolders(projects, sessions)
     expect(folders[0].sessions).toHaveLength(0)
   })
+
+  it('sorts sessions by their position in the sessions array', () => {
+    const projects: ProjectItem[] = [
+      { slug: 'proj', match: [{ path: '/dev/proj' }], sessions: ['c', 'a', 'b'] },
+    ]
+    const sessions = [
+      makeSession({ id: 'a', cwd: '/dev/proj', alive: true }),
+      makeSession({ id: 'b', cwd: '/dev/proj', alive: true }),
+      makeSession({ id: 'c', cwd: '/dev/proj', alive: true }),
+    ]
+    const folders = buildProjectFolders(projects, sessions)
+    expect(folders[0].sessions.map(s => s.id)).toEqual(['c', 'a', 'b'])
+  })
+
+  it('sorts sessions by slug when the array uses slugs', () => {
+    const projects: ProjectItem[] = [
+      { slug: 'proj', match: [{ path: '/dev/proj' }], sessions: ['gamma', 'alpha'] },
+    ]
+    const sessions = [
+      makeSession({ id: 'sess-1', cwd: '/dev/proj', alive: true, slug: 'alpha' }),
+      makeSession({ id: 'sess-2', cwd: '/dev/proj', alive: true, slug: 'gamma' }),
+    ]
+    const folders = buildProjectFolders(projects, sessions)
+    expect(folders[0].sessions.map(s => s.slug)).toEqual(['gamma', 'alpha'])
+  })
+
+  it('puts sessions not in the array at the end', () => {
+    const projects: ProjectItem[] = [
+      { slug: 'proj', match: [{ path: '/dev/proj' }], sessions: ['b'] },
+    ]
+    const sessions = [
+      makeSession({ id: 'a', cwd: '/dev/proj', alive: true, created_at: '2025-01-01T00:00:00Z' }),
+      makeSession({ id: 'b', cwd: '/dev/proj', alive: true, created_at: '2025-01-02T00:00:00Z' }),
+      makeSession({ id: 'c', cwd: '/dev/proj', alive: true, created_at: '2025-01-03T00:00:00Z' }),
+    ]
+    const folders = buildProjectFolders(projects, sessions)
+    const ids = folders[0].sessions.map(s => s.id)
+    // 'b' is in the array so it comes first; 'a' and 'c' are not, sorted by creation time
+    expect(ids).toEqual(['b', 'a', 'c'])
+  })
 })
 
 describe('isSessionVisibleInProject', () => {

--- a/apps/gmux-web/src/projects.ts
+++ b/apps/gmux-web/src/projects.ts
@@ -142,8 +142,17 @@ export function buildProjectFolders(
       path: project.slug,
       launchCwd: project.match.find(r => r.path)?.path,
       sessions: matched.sort((a, b) => {
-        if (a.cwd !== b.cwd) return a.cwd < b.cwd ? -1 : 1
-        return new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+        // The sessions array is the canonical order. Sessions not yet
+        // in the array (just spawned, auto-assign pending) go at the
+        // end sorted by creation time.
+        const keys = project.sessions ?? []
+        const keyOf = (s: Session) => s.slug || s.id
+        const ai = keys.indexOf(keyOf(a))
+        const bi = keys.indexOf(keyOf(b))
+        if (ai !== -1 && bi !== -1) return ai - bi
+        if (ai !== -1) return -1
+        if (bi !== -1) return 1
+        return new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
       }),
     })
   }

--- a/apps/gmux-web/src/sidebar.tsx
+++ b/apps/gmux-web/src/sidebar.tsx
@@ -5,17 +5,18 @@
  * callbacks and the mobile open/close toggle are passed as props.
  */
 
+import { useState, useCallback } from 'preact/hooks'
 import { sessionPath } from './routing'
 import { LaunchButton } from './launcher'
 import { useArrivalPulse } from './use-arrival-pulse'
 import {
   folders, selectedId, currentProjectSlug,
   activityMap, unmatchedActiveCount, projects, connState,
-  updateProjects,
+  updateProjects, reorderSessions,
   type DotState,
 } from './store'
 import { PeerLabel } from './peer-label'
-import type { Session, Folder } from './types'
+import type { Session, Folder, ProjectItem } from './types'
 
 // ── Types ──
 
@@ -46,7 +47,28 @@ export const IconBell = ({ muted }: { muted?: boolean }) => (
   </svg>
 )
 
+// ── Drag helpers ──
+
+/** True on devices with a pointer (mouse/trackpad). Touch-only devices
+ *  don't support the HTML5 drag API and setting draggable on them
+ *  interferes with scroll. */
+const canDrag = typeof matchMedia !== 'undefined' && matchMedia('(hover: hover)').matches
+
+interface DragState {
+  /** Index of the item being dragged (in the original array). */
+  from: number
+  /** Current visual insertion target. */
+  over: number
+}
+
 // ── Components ──
+
+function reorder<T>(arr: T[], from: number, to: number): T[] {
+  const next = [...arr]
+  const [item] = next.splice(from, 1)
+  next.splice(to, 0, item)
+  return next
+}
 
 function SessionItem({
   session,
@@ -54,19 +76,29 @@ function SessionItem({
   selected,
   resuming,
   dotState: rawDotState,
+  dragging,
+  dropTarget,
   onResume,
   onClose,
   onClick,
+  onDragStart,
+  onDragOver,
+  onDragEnd,
 }: {
   session: Session
   href: string
   selected: boolean
   resuming?: boolean
   dotState: DotState
+  dragging?: boolean
+  dropTarget?: boolean
   onResume?: (id: string) => void
   onClose?: () => void
   /** Extra side-effects on click (e.g. close mobile sidebar). */
   onClick?: () => void
+  onDragStart?: () => void
+  onDragOver?: () => void
+  onDragEnd?: () => void
 }) {
   const effectiveDotState = resuming ? 'working' : rawDotState
   // Nothing is "unread" if you're already looking at it.
@@ -74,10 +106,18 @@ function SessionItem({
   const arrival = useArrivalPulse(dotState)
   const sleeping = !session.alive && session.resumable
 
+  const cls = [
+    'session-item',
+    selected ? 'selected' : '',
+    dragging ? 'session-dragging' : '',
+    dropTarget ? 'session-drop-target' : '',
+  ].filter(Boolean).join(' ')
+
   return (
     <a
-      class={`session-item ${selected ? 'selected' : ''}`}
+      class={cls}
       href={href}
+      draggable={canDrag && !!onDragStart}
       onClick={(e) => {
         onClick?.()
         if (sleeping) {
@@ -86,6 +126,14 @@ function SessionItem({
         }
       }}
       onAuxClick={(e) => { if (e.button === 1 && onClose) { e.preventDefault(); onClose() } }}
+      onDragStart={(e) => {
+        e.dataTransfer!.effectAllowed = 'move'
+        e.dataTransfer!.setData('text/plain', '')
+        onDragStart?.()
+      }}
+      onDragOver={(e) => { e.preventDefault(); e.dataTransfer!.dropEffect = 'move'; onDragOver?.() }}
+      onDrop={(e) => { e.preventDefault(); onDragEnd?.() }}
+      onDragEnd={onDragEnd}
     >
       {sleeping
         ? <svg class="session-sleep-icon" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><title>Resumable</title><path d="M7 1h4l-4 4h4" /><path d="M1 5h5l-5 6h5" /></svg>
@@ -117,6 +165,7 @@ function SessionItem({
 
 function FolderGroup({
   folder,
+  project,
   selId,
   curProjectSlug,
   resumingId,
@@ -126,6 +175,7 @@ function FolderGroup({
   onClick,
 }: {
   folder: Folder
+  project: ProjectItem
   selId: string | null
   curProjectSlug: string | null
   resumingId: string | null
@@ -134,7 +184,32 @@ function FolderGroup({
   onCloseSession: (session: Session) => void
   onClick?: () => void
 }) {
+  const [drag, setDrag] = useState<DragState | null>(null)
+
+  const handleDragStart = useCallback((idx: number) => {
+    setDrag({ from: idx, over: idx })
+  }, [])
+
+  const handleDragOver = useCallback((idx: number) => {
+    setDrag(prev => prev ? { ...prev, over: idx } : null)
+  }, [])
+
+  const handleDragEnd = useCallback((visible: Session[]) => {
+    if (!drag || drag.from === drag.over) {
+      setDrag(null)
+      return
+    }
+    const reordered = reorder(visible, drag.from, drag.over)
+    const visibleKeys = reordered.map(s => s.slug || s.id)
+    // Preserve keys of non-visible sessions (dead, non-resumable) at the end.
+    const visibleSet = new Set(visibleKeys)
+    const hidden = (project.sessions ?? []).filter(k => !visibleSet.has(k))
+    reorderSessions(project.slug, [...visibleKeys, ...hidden])
+    setDrag(null)
+  }, [drag, project])
+
   const visible = folder.sessions.filter(s => s.alive || s.resumable)
+  const displayItems = drag ? reorder(visible, drag.from, drag.over) : visible
   const isCurrent = curProjectSlug === folder.path
   return (
     <div class="folder">
@@ -155,7 +230,7 @@ function FolderGroup({
         />
       </div>
       <div class="folder-sessions">
-        {visible.map(s => (
+        {displayItems.map((s, i) => (
           <SessionItem
             key={s.id}
             session={s}
@@ -163,9 +238,14 @@ function FolderGroup({
             selected={selId === s.id}
             resuming={resumingId === s.id}
             dotState={sessionDotState(s, am)}
+            dragging={drag !== null && s.id === visible[drag.from]?.id}
+            dropTarget={drag !== null && drag.over === i && drag.from !== i}
             onResume={onResume}
             onClose={() => onCloseSession(s)}
             onClick={onClick}
+            onDragStart={() => handleDragStart(i)}
+            onDragOver={() => handleDragOver(i)}
+            onDragEnd={() => handleDragEnd(visible)}
           />
         ))}
       </div>
@@ -194,15 +274,16 @@ export function Sidebar({
 }) {
   // Read signals; component re-renders only when these values change.
   const foldersVal = folders.value
+  const projectsVal = projects.value
   const selId = selectedId.value
   const curProjectSlug = currentProjectSlug.value
   const unmatchedCount = unmatchedActiveCount.value
   const am = activityMap.value
+  const projectBySlug = new Map(projectsVal.map(p => [p.slug, p]))
 
   const totalVisible = foldersVal.reduce(
     (n, f) => n + f.sessions.filter(s => s.alive || s.resumable).length, 0,
   )
-  const projectsVal = projects.value
   const connected = connState.value === 'connected'
   const hasProjects = projectsVal.length > 0
   const isOnlyHomeProject = projectsVal.length === 1
@@ -234,19 +315,24 @@ export function Sidebar({
           )}
         </div>
         <div class="sidebar-scroll">
-          {foldersVal.map(f => (
-            <FolderGroup
-              key={f.path}
-              folder={f}
-              selId={selId}
-              curProjectSlug={curProjectSlug}
-              resumingId={resumingId}
-              am={am}
-              onResume={onResume}
-              onCloseSession={onCloseSession}
-              onClick={onClose}
-            />
-          ))}
+          {foldersVal.map(f => {
+            const proj = projectBySlug.get(f.path)
+            if (!proj) return null
+            return (
+              <FolderGroup
+                key={f.path}
+                folder={f}
+                project={proj}
+                selId={selId}
+                curProjectSlug={curProjectSlug}
+                resumingId={resumingId}
+                am={am}
+                onResume={onResume}
+                onCloseSession={onCloseSession}
+                onClick={onClose}
+              />
+            )
+          })}
           {connected && totalVisible === 0 && !hasProjects && (
             <div class="sidebar-hint">
               Click <strong>+</strong> to start your first session.

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -407,6 +407,29 @@ export async function updateProjects(items: ProjectItem[]): Promise<void> {
   await putProjects(items)
 }
 
+/**
+ * Persist a new session order for a project. The `sessionKeys` array
+ * contains session keys (slug or id) in the desired display order.
+ * Optimistically updates the local signal so the sidebar re-renders
+ * immediately, without waiting for the SSE projects-update round-trip.
+ */
+export async function reorderSessions(projectSlug: string, sessionKeys: string[]): Promise<void> {
+  // Optimistic update.
+  projects.value = projects.value.map(p =>
+    p.slug === projectSlug ? { ...p, sessions: sessionKeys } : p,
+  )
+  try {
+    const resp = await fetch(`/v1/projects/${projectSlug}/sessions`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ sessions: sessionKeys }),
+    })
+    if (!resp.ok) console.warn('PATCH sessions failed:', resp.status)
+  } catch (err) {
+    console.warn('PATCH sessions error:', err)
+  }
+}
+
 // ── Session actions ─────────────────────────────────────────────────────────
 
 async function postAction(endpoint: string, body?: Record<string, unknown>): Promise<void> {

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -480,10 +480,13 @@ body {
 
 /* ── Close button on session items ── */
 .session-close-btn {
-  flex-shrink: 0;
-  width: 0;
+  position: absolute;
+  right: 4px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 20px;
   height: 20px;
-  overflow: hidden;
+  opacity: 0;
   border: none;
   border-radius: 4px;
   background: transparent;
@@ -494,22 +497,30 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: background 0.1s, color 0.1s, width 0.1s;
+  transition: background 0.1s, color 0.1s, opacity 0.15s;
   padding: 0;
 }
 .session-item:hover .session-close-btn,
 .session-item.selected .session-close-btn {
-  width: 20px;
-  padding: 0;
+  opacity: 1;
+  background: oklch(22% 0.01 250 / 0.45);
 }
 .session-close-btn:hover {
-  background: oklch(28% 0.015 250);
+  background: oklch(28% 0.015 250) !important;
   color: var(--text);
 }
 
 /* Mock mode (landing page screenshots): hide per-session close buttons */
 .mock-mode .session-close-btn,
 .mock-mode .session-card-close { display: none; }
+
+/* Session drag-to-reorder */
+.session-item.session-dragging {
+  opacity: 0.4;
+}
+.session-item.session-drop-target {
+  box-shadow: inset 0 -2px 0 0 var(--accent);
+}
 
 /* On touch devices (no hover), show interactive buttons permanently */
 @media (hover: none) {

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -791,6 +791,43 @@ func serve(stderr io.Writer) int {
 		writeJSON(w, map[string]any{"ok": true, "data": item})
 	})
 
+	mux.HandleFunc("PATCH /v1/projects/{slug}/sessions", func(w http.ResponseWriter, r *http.Request) {
+		slug := r.PathValue("slug")
+		body, err := io.ReadAll(io.LimitReader(r.Body, 64*1024))
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "bad_request", "read error")
+			return
+		}
+		var req struct {
+			Sessions []string `json:"sessions"`
+		}
+		if err := json.Unmarshal(body, &req); err != nil {
+			writeError(w, http.StatusBadRequest, "bad_request", "invalid JSON")
+			return
+		}
+		found := false
+		err = projectMgr.Update(func(state *projects.State) bool {
+			for i := range state.Items {
+				if state.Items[i].Slug == slug {
+					state.Items[i].Sessions = req.Sessions
+					found = true
+					return true
+				}
+			}
+			return false
+		})
+		if err != nil {
+			log.Printf("projects: reorder sessions error: %v", err)
+			writeError(w, http.StatusInternalServerError, "internal", "failed to save projects")
+			return
+		}
+		if !found {
+			writeError(w, http.StatusNotFound, "not_found", "project not found")
+			return
+		}
+		writeJSON(w, map[string]any{"ok": true})
+	})
+
 	// ── Sessions ──
 
 	mux.HandleFunc("GET /v1/sessions", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Adds drag-to-reorder for sessions within each project folder in the sidebar. The project's `sessions` array in `projects.json` is the canonical source of display order.

## Changes

**Backend** (`main.go`): New `PATCH /v1/projects/{slug}/sessions` endpoint. Accepts `{"sessions": [...keys]}`, persists the new order atomically, and broadcasts `projects-update` via SSE.

**Sort logic** (`projects.ts`): `buildProjectFolders` now sorts sessions by their position in the project's `sessions` array. Sessions not yet in the array (just spawned, auto-assign pending) appear at the end in creation-time order.

**Store** (`store.ts`): New `reorderSessions(projectSlug, sessionKeys)` with optimistic local signal update, then PATCH to server. The sidebar re-renders immediately without waiting for the SSE round-trip.

**Sidebar** (`sidebar.tsx`): Entire session row is draggable using `effectAllowed = 'move'` to override the browser's default link-drag behavior. `FolderGroup` tracks local `DragState` and renders the optimistic reordered list mid-drag. On drop, the visible session keys are sent in their new order; non-visible keys (dead, non-resumable) are preserved at the tail. Same `{from, over}` + `onDrop`/`onDragEnd` pattern as the project reorder in `manage-projects.tsx`.

**Mobile** (`sidebar.tsx`, `styles.css`): Drag is disabled on touch-only devices (`matchMedia('(hover: hover)')` check) so it doesn't interfere with scrolling. The drag handle is hidden via `@media (hover: none)`.

**Tests** (`projects.test.ts`): Three new tests covering array-order sorting by id, by slug, and untracked sessions falling to the end in creation-time order.