### PR TITLE
fix: suppress spurious activity and unread signals

### DIFF
--- a/cli/gmux/internal/ptyserver/ptyserver.go
+++ b/cli/gmux/internal/ptyserver/ptyserver.go
@@ -114,6 +114,7 @@ type Server struct {
 	ptyRows        uint16    // last applied PTY rows (guarded by mu)
 	cursorHidden   bool      // tracks DECTCEM via callback (guarded by mu)
 	screenPending  []byte    // raw PTY data not yet fed to screen (guarded by mu)
+	lastClientLeft time.Time // when the last WS client disconnected (guarded by mu)
 
 	done    chan struct{} // closed when child exits
 	ptyDone chan struct{} // closed when readPTY finishes draining
@@ -535,6 +536,7 @@ func (s *Server) handleWS(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.clients[client] = struct{}{}
+	s.lastClientLeft = time.Time{} // reset: we have an active viewer
 	s.mu.Unlock()
 
 	// Client connected — they'll see the scrollback, so clear unread
@@ -546,6 +548,9 @@ func (s *Server) handleWS(w http.ResponseWriter, r *http.Request) {
 		s.mu.Lock()
 		delete(s.clients, client)
 		noClients := len(s.clients) == 0 && s.localOut == nil
+		if len(s.clients) == 0 {
+			s.lastClientLeft = time.Now()
+		}
 		s.mu.Unlock()
 
 		// When the last viewer disconnects, shrink the PTY by 1 column.
@@ -694,6 +699,11 @@ func (s *Server) resize(msg ResizeMsg) {
 	}
 }
 
+// activityGrace is the time after the last WS client disconnects before
+// activity events are emitted. Suppresses false positives during session
+// switching when the old session briefly has zero clients.
+const activityGrace = 500 * time.Millisecond
+
 // coalesceMaxBytes is the maximum accumulated data before forcing a flush,
 // even if the coalesce timer hasn't fired yet. Keeps latency bounded.
 const coalesceMaxBytes = 32 * 1024
@@ -744,10 +754,16 @@ func (s *Server) readPTY() {
 			clients = append(clients, c)
 		}
 		hasRemoteClients := len(clients) > 0
+		lastLeft := s.lastClientLeft
 		s.mu.Unlock()
 
+		// Emit activity only when no client is viewing and the grace
+		// period has elapsed. The grace period suppresses false positives
+		// during session switching (brief disconnect window).
 		if !hasRemoteClients && s.state != nil {
-			s.state.EmitActivity()
+			if lastLeft.IsZero() || time.Since(lastLeft) > activityGrace {
+				s.state.EmitActivity()
+			}
 		}
 
 		if localOut != nil {

--- a/services/gmuxd/internal/discovery/filemon.go
+++ b/services/gmuxd/internal/discovery/filemon.go
@@ -436,8 +436,9 @@ func (fm *FileMonitor) handleFileChange(path string) {
 		return
 	}
 
-	lines := fm.readNewLines(path, ms.readAll)
-	if ms.readAll {
+	readAll := ms.readAll
+	lines := fm.readNewLines(path, readAll)
+	if readAll {
 		ms.readAll = false
 	}
 	if len(lines) == 0 {
@@ -481,7 +482,9 @@ func (fm *FileMonitor) handleFileChange(path string) {
 					}
 				}
 			}
-			if evt.Unread != nil {
+			// Skip unread events from full-file re-reads (e.g. session
+			// restart). Historical assistant turns are not new output.
+			if evt.Unread != nil && !readAll {
 				sess.Unread = *evt.Unread
 			}
 		}

--- a/services/gmuxd/internal/discovery/filemon_test.go
+++ b/services/gmuxd/internal/discovery/filemon_test.go
@@ -452,6 +452,41 @@ func TestPiExhaustedErrorRecovery(t *testing.T) {
 	}
 }
 
+func TestReadAllSuppressesUnread(t *testing.T) {
+	fm, s, dir := setupPiFileMonitor(t)
+	path := filepath.Join(dir, "test.jsonl")
+
+	// Write a complete conversation to the file (simulating pre-existing content).
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.WriteString(`{"type":"session","id":"test-123","cwd":"/home/user/dev/project","timestamp":"2026-03-19T10:00:00Z"}` + "\n")
+	f.WriteString(`{"type":"message","id":"u1","message":{"role":"user","content":[{"type":"text","text":"fix bug"}]}}` + "\n")
+	f.WriteString(`{"type":"message","id":"a1","message":{"role":"assistant","stopReason":"stop","content":[{"type":"text","text":"Done."}]}}` + "\n")
+	f.Close()
+
+	// Mark readAll to simulate session restart (full file re-read).
+	fm.sessions["sess-pi"].readAll = true
+	fm.attributions[path] = "sess-pi"
+	fm.handleFileChange(path)
+
+	sess, _ := s.Get("sess-pi")
+	if sess.Unread {
+		t.Fatal("readAll parse should not set unread from historical assistant turns")
+	}
+
+	// Subsequent incremental writes should still set unread normally.
+	simulateFileWrite(t, fm, "sess-pi", path,
+		`{"type":"message","id":"u2","message":{"role":"user","content":[{"type":"text","text":"more work"}]}}`,
+		`{"type":"message","id":"a2","message":{"role":"assistant","stopReason":"stop","content":[{"type":"text","text":"Also done."}]}}`,
+	)
+	sess, _ = s.Get("sess-pi")
+	if !sess.Unread {
+		t.Fatal("incremental writes should still set unread")
+	}
+}
+
 func TestAttributionStickiness(t *testing.T) {
 	s := store.New()
 	fm := NewFileMonitor(s)


### PR DESCRIPTION
## Problem

Two false-positive issues with session state indicators:

1. **All adapter sessions marked unread on restart.** When a session restarts, the file monitor re-reads the entire conversation file (`readAll: true`). The adapter's `ParseNewLines` processes historical assistant turns and emits `Unread: true` for each completed turn, marking the session as unread even though no new output was produced.

2. **Activity dot flashes on session switch.** When switching from session A to B, there is a brief window where A has zero WebSocket clients. Any PTY output during that window (shell prompt byte, SIGWINCH echo) triggers `EmitActivity()`, showing a gray activity circle for a session that was just idle.

## Fix

**Bug 1:** Gate `Unread` event application on `!readAll` in `filemon.handleFileChange`. Historical assistant turns from full-file re-reads are suppressed; incremental writes still set unread normally.

**Bug 2:** Track `lastClientLeft` timestamp on the PTY server. Activity events are only emitted after a 500ms grace period following the last client disconnect. Sessions that have never had a client (genuinely unattended) still emit immediately (`lastClientLeft.IsZero()`).

## Commits

- `fix: suppress false activity signals during session switching`
- `fix: skip unread flag from full-file re-reads on session restart`

## Tests

- `TestReadAllSuppressesUnread`: verifies readAll suppresses unread, incremental writes still set it