### PR TITLE
fix(daemon): exempt manifest.json from netauth

### DIFF
--- a/services/gmuxd/internal/netauth/netauth.go
+++ b/services/gmuxd/internal/netauth/netauth.go
@@ -42,6 +42,14 @@ func Middleware(token string, next http.Handler) http.Handler {
 			return
 		}
 
+		// The web app manifest must be publicly accessible. Browsers fetch
+		// it without cookies, so auth-gating it returns the login HTML
+		// page which Chrome then fails to parse as JSON.
+		if r.URL.Path == "/manifest.json" {
+			next.ServeHTTP(w, r)
+			return
+		}
+
 		// Shutdown is a local-only operation (available via Unix socket).
 		// Block it entirely on the TCP listener regardless of auth.
 		if r.URL.Path == "/v1/shutdown" {

--- a/services/gmuxd/internal/netauth/netauth_test.go
+++ b/services/gmuxd/internal/netauth/netauth_test.go
@@ -303,6 +303,17 @@ func TestLoginGetWithInvalidURLToken(t *testing.T) {
 	}
 }
 
+func TestManifestAccessibleWithoutAuth(t *testing.T) {
+	h := Middleware(testToken, okHandler())
+	req := httptest.NewRequest("GET", "/manifest.json", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200 (manifest must be publicly accessible)", rr.Code)
+	}
+}
+
 func TestShutdownBlockedOnNetworkListener(t *testing.T) {
 	h := Middleware(testToken, okHandler())
 


### PR DESCRIPTION
## Problem

Chrome reports console errors on every page load:

```
manifest.json:1 Manifest: Line: 1, column: 1, Syntax error.
```

## Root cause

Browsers fetch `<link rel="manifest">` without cookies. The `netauth` middleware sees no auth cookie, classifies it as a browser request, and redirects to `/auth/login`. Chrome follows the redirect, receives the HTML login page, tries to parse it as JSON, and fails at line 1 column 1.

## Fix

Exempt `/manifest.json` from the auth middleware. The manifest contains only the app name, theme color, and display mode, all of which are already visible on the unauthenticated login page.

## Alternatives considered

Adding `crossorigin="use-credentials"` to the manifest `<link>` tag (per MDN guidance) would make the browser send cookies with the manifest fetch. However, that adds complexity for no security benefit since the manifest contains nothing sensitive.