### PR TITLE
fix(web): stabilize peer color assignment and stale indicator

### DIFF
--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -95,8 +95,11 @@ function SessionMenu({ session, onRestart }: {
   // For remote sessions, compare against the peer's version (not the local
   // daemon's). Peers don't expose runner_hash, so only version comparison
   // is possible for remote sessions.
+  const peerVersion = session.peer
+    ? peers.value.find(p => p.name === session.peer)?.version
+    : undefined
   const compareTarget = session.peer
-    ? { version: peers.value.find(p => p.name === session.peer)?.version ?? '' }
+    ? (peerVersion ? { version: peerVersion } : null)
     : healthVal
   const staleKind = sessionStaleness(session, compareTarget)
 

--- a/apps/gmux-web/src/store.test.ts
+++ b/apps/gmux-web/src/store.test.ts
@@ -266,13 +266,17 @@ describe('peerAppearance', () => {
     expect(map.get('development')!.label).toBe('DEVE')
   })
 
-  it('assigns colors sequentially by list order', () => {
+  it('assigns stable colors by name hash, independent of list order', () => {
     peers.value = [
       { name: 'alpha', url: '', status: 'connected', session_count: 0 },
       { name: 'beta', url: '', status: 'connected', session_count: 0 },
     ]
-    const map = peerAppearance.value
-    // First and second peer get different colors (first two palette entries)
-    expect(map.get('alpha')!.color).not.toBe(map.get('beta')!.color)
+    const color1 = peerAppearance.value.get('alpha')!.color
+    // Reverse order: alpha's color should not change
+    peers.value = [
+      { name: 'beta', url: '', status: 'connected', session_count: 0 },
+      { name: 'alpha', url: '', status: 'connected', session_count: 0 },
+    ]
+    expect(peerAppearance.value.get('alpha')!.color).toBe(color1)
   })
 })

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -65,6 +65,13 @@ const PEER_PALETTE: [string, string][] = [
   ['oklch(72% 0.10 340)', 'oklch(25% 0.04 340)'], // rose
 ]
 
+/** Simple string hash (djb2) mapped to palette index. */
+function hashPaletteIndex(s: string): number {
+  let h = 5381
+  for (let i = 0; i < s.length; i++) h = ((h << 5) + h + s.charCodeAt(i)) | 0
+  return (h >>> 0) % PEER_PALETTE.length
+}
+
 /** Shortest unique prefix for each name among a set of names. */
 function uniquePrefixes(names: string[]): Map<string, string> {
   const result = new Map<string, string>()
@@ -89,9 +96,9 @@ export const peerAppearance = computed<ReadonlyMap<string, PeerAppearance>>(() =
   const names = peers.value.map(p => p.name)
   const prefixes = uniquePrefixes(names)
   const map = new Map<string, PeerAppearance>()
-  for (let i = 0; i < names.length; i++) {
-    const [color, bg] = PEER_PALETTE[i % PEER_PALETTE.length]
-    map.set(names[i], { label: prefixes.get(names[i])!, color, bg })
+  for (const name of names) {
+    const [color, bg] = PEER_PALETTE[hashPaletteIndex(name)]
+    map.set(name, { label: prefixes.get(name)!, color, bg })
   }
   return map
 })


### PR DESCRIPTION
Two small fixes for the peer label system:

**Hash-based color assignment** — Peer colors were assigned by list position, which caused colors to shift as peers reconnected and changed order. Now uses djb2 hash of the peer name, so each peer gets a stable color regardless of list ordering.

**False stale indicator for unknown peers** — When a remote session's peer couldn't be found (disconnected, removed), the staleness check compared against an empty version string, causing every orphaned remote session to show as outdated. Now returns null (no indicator) when the peer's version is unavailable.