### PR TITLE
fix(web): preserve session selection when slug changes

### DIFF
--- a/apps/gmux-web/src/store.test.ts
+++ b/apps/gmux-web/src/store.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
-import { sessions, upsertSession, removeSession, markSessionRead, handleActivity, isSessionActive, isSessionFading, activityMap, sessionStaleness, peers, peerAppearance } from './store'
+import { sessions, sessionsLoaded, projects, upsertSession, removeSession, markSessionRead, handleActivity, isSessionActive, isSessionFading, activityMap, sessionStaleness, peers, peerAppearance, urlPath, selectedId } from './store'
 import type { Session } from './types'
+import type { ProjectItem } from './types'
 
 function makeSession(overrides: Partial<Session> & { id: string }): Session {
   return {
@@ -27,6 +28,9 @@ function makeSession(overrides: Partial<Session> & { id: string }): Session {
 // Reset signal state between tests.
 beforeEach(() => {
   sessions.value = []
+  projects.value = []
+  sessionsLoaded.value = false
+  urlPath.value = '/'
 })
 
 describe('upsertSession', () => {
@@ -63,6 +67,54 @@ describe('upsertSession', () => {
     expect(sessions.value).toHaveLength(2)
     expect(sessions.value[0].title).toBe('updated')
     expect(sessions.value[1].title).toBe('second')
+  })
+
+  it('rewrites URL when selected session slug changes', () => {
+    const testProjects: ProjectItem[] = [
+      { slug: 'myproject', match: [{ path: '/dev/project' }] },
+    ]
+    projects.value = testProjects
+    sessionsLoaded.value = true
+    sessions.value = [
+      makeSession({ id: 'sess-1', cwd: '/dev/project', kind: 'pi', slug: 'fix-auth' }),
+    ]
+    // Simulate the session being selected via URL.
+    urlPath.value = '/myproject/pi/fix-auth'
+    expect(selectedId.value).toBe('sess-1')
+
+    // SSE upserts with a new slug (e.g., /new changed the active file).
+    upsertSession({
+      id: 'sess-1', alive: true, cwd: '/dev/project', kind: 'pi',
+      slug: 'refactor-login', command: ['pi'], title: 'pi',
+    } as any)
+
+    // URL should be atomically rewritten; session stays selected.
+    expect(urlPath.value).toBe('/myproject/pi/refactor-login')
+    expect(selectedId.value).toBe('sess-1')
+  })
+
+  it('does not rewrite URL when a non-selected session slug changes', () => {
+    const testProjects: ProjectItem[] = [
+      { slug: 'myproject', match: [{ path: '/dev/project' }] },
+    ]
+    projects.value = testProjects
+    sessionsLoaded.value = true
+    sessions.value = [
+      makeSession({ id: 'sess-1', cwd: '/dev/project', kind: 'pi', slug: 'fix-auth' }),
+      makeSession({ id: 'sess-2', cwd: '/dev/project', kind: 'pi', slug: 'old-slug' }),
+    ]
+    urlPath.value = '/myproject/pi/fix-auth'
+    expect(selectedId.value).toBe('sess-1')
+
+    // sess-2's slug changes, but it's not the selected session.
+    upsertSession({
+      id: 'sess-2', alive: true, cwd: '/dev/project', kind: 'pi',
+      slug: 'new-slug', command: ['pi'], title: 'pi',
+    } as any)
+
+    // URL should be unchanged.
+    expect(urlPath.value).toBe('/myproject/pi/fix-auth')
+    expect(selectedId.value).toBe('sess-1')
   })
 })
 

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -300,8 +300,32 @@ export function upsertSession(raw: ProtocolSession): boolean {
   const prev = sessions.value
   const idx = prev.findIndex(s => s.id === updated.id)
   if (idx >= 0) {
+    const old = prev[idx]
     const next = [...prev]
     next[idx] = updated
+
+    // When the currently-selected session changes slug, update the URL
+    // atomically with the session data. Without batch(), the view
+    // computed would see the new sessions (slug changed) but the old
+    // URL (still has the old slug), fail to resolve, and briefly
+    // deselect the session.
+    if (old.slug !== updated.slug && selectedId.value === updated.id) {
+      const project = matchSession(updated, projects.value)
+      if (project) {
+        const newUrl = sessionPath(project.slug, updated)
+        batch(() => {
+          sessions.value = next
+          urlPath.value = newUrl
+        })
+        // Sync the browser URL bar. navigate() calls preact-iso's
+        // loc.route which would also set urlPath via the
+        // useLayoutEffect in App, but we already set it above
+        // inside the batch for atomicity.
+        navigate(newUrl, true)
+        return isNew
+      }
+    }
+
     sessions.value = next
   } else {
     isNew = true


### PR DESCRIPTION
## Problem

When a session's slug changed (from `/new` creating a new session file, or the first user message arriving after attribution), the URL still contained the old slug. The view resolver couldn't match the old slug to the session, so `resolveViewFromPath` fell back to the project hub view, deselecting the session.

## Fix

In `upsertSession`, detect when the currently-selected session's slug changes and use `batch()` to atomically update both `sessions` and `urlPath`. This ensures the `view` computed never sees an inconsistent state (new session data + old URL).

`navigate()` is called after the batch to sync the browser URL bar via preact-iso.

## Tests

- **slug change on selected session rewrites URL atomically**: verifies `urlPath` updates and `selectedId` stays the same
- **slug change on non-selected session does not affect URL**: verifies no side effects on other sessions
- All 262 frontend tests pass