### PR TITLE
fix(ci): resolve PR numbers for rebase-merged commits in changelog

### DIFF
--- a/.github/workflows/scripts/version.sh
+++ b/.github/workflows/scripts/version.sh
@@ -94,20 +94,64 @@ fi
 
 new_version=$(echo "$context" | jq -r '.[0].version')
 
-# ── Generate changelog section ──
+# ── Enrich commits with PR links ──
 #
-# Produces:
-#   ## vX.Y.Z
+# GitHub does not append "(#N)" to commit subjects for rebase merges
+# (only squash merges get that). We use the GitHub API to resolve each
+# commit's PR number and inject markdown links into the raw_message
+# before rendering.
 #
-#   ### Features
-#   - foo ([#N](https://github.com/gmuxapp/gmux/pull/N))
+# Steps:
+#   1. For each commit SHA in the context, query /commits/{sha}/pulls
+#   2. Append ([#N](url)) to the subject line of raw_message
+#   3. Render from the enriched context via --from-context
 #
-#   ### Fixes
-#   - bar ([#N](https://github.com/gmuxapp/gmux/pull/N))
-#
-#   ---
+# Commits that already carry a PR reference (squash merges) are skipped.
 
-section=$(git-cliff --unreleased --bump)
+enrich_context() {
+  local ctx_file="$1"
+  local out_file="$2"
+
+  if [[ -z "${GITHUB_TOKEN:-}" ]] || ! command -v gh >/dev/null 2>&1; then
+    cp "$ctx_file" "$out_file"
+    return
+  fi
+
+  local map_file
+  map_file=$(mktemp)
+  echo "{}" > "$map_file"
+
+  while IFS= read -r sha; do
+    local pr
+    pr=$(gh api "repos/gmuxapp/gmux/commits/$sha/pulls" --jq '.[0].number // empty' 2>/dev/null || true)
+    if [[ -n "$pr" ]]; then
+      jq --arg sha "$sha" --arg pr "$pr" '. + {($sha): ($pr | tonumber)}' "$map_file" > "${map_file}.tmp"
+      mv "${map_file}.tmp" "$map_file"
+    fi
+  done < <(jq -r '.[0].commits[].id' "$ctx_file")
+
+  jq --slurpfile prmap "$map_file" '
+    .[0].commits = [.[0].commits[] |
+      . as $c |
+      ($prmap[0][$c.id] // null) as $pr |
+      ($c.raw_message | split("\n")[0]) as $subject |
+      if $pr != null and ($subject | test("\\(#[0-9]+\\)|\\(\\[#[0-9]+\\]") | not) then
+        (.raw_message | split("\n")) as $lines |
+        .raw_message = ([$lines[0] + " ([#\($pr)](https://github.com/gmuxapp/gmux/pull/\($pr)))"] + $lines[1:] | join("\n"))
+      else .
+      end
+    ]
+  ' "$ctx_file" > "$out_file"
+
+  rm -f "$map_file"
+}
+
+ctx_input=$(mktemp)
+ctx_enriched=$(mktemp)
+echo "$context" > "$ctx_input"
+enrich_context "$ctx_input" "$ctx_enriched"
+section=$(git-cliff --from-context "$ctx_enriched")
+rm -f "$ctx_input" "$ctx_enriched"
 
 # ── Helper: strip leading and trailing blank lines ──
 

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -31,6 +31,8 @@ jobs:
 
       - name: Check for releasable commits
         id: version
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           output=$(bash .github/workflows/scripts/version.sh)
           version=$(echo "$output" | head -1 | awk '{print $1}')

--- a/cliff.toml
+++ b/cliff.toml
@@ -5,8 +5,9 @@
 # so that new releases look identical to historical ones.
 #
 # Used by .github/workflows/scripts/version.sh, which parses the JSON
-# context for release-gating logic and reuses the rendered section for
-# the changelog insertion. Manual previews:
+# context for release-gating logic, enriches commits with PR links via
+# the GitHub API, and renders the final section via --from-context.
+# Manual previews (without PR enrichment):
 #
 #   git-cliff --unreleased --bump              # print the next release section
 #   git-cliff --unreleased --bump --context    # same, as JSON
@@ -58,9 +59,11 @@ protect_breaking_commits = true
 split_commits = false
 
 commit_preprocessors = [
-  # Turn trailing "(#125)" into a markdown link to the PR.
-  # Multiline mode (?m) so $ matches end of the subject line, not end of
-  # the whole commit message (which would include body lines).
+  # Turn trailing "(#125)" into a markdown link to the PR. This handles
+  # commits that already carry the suffix (squash merges) during the
+  # --context pass. For rebase merges (which lack the suffix), version.sh
+  # resolves PR numbers via the GitHub API and injects full markdown
+  # links into the context before rendering with --from-context.
   { pattern = "(?m)\\s*\\(#([0-9]+)\\)$", replace = " ([#${1}](https://github.com/gmuxapp/gmux/pull/${1}))" },
 ]
 


### PR DESCRIPTION
GitHub does not append `(#N)` to commit subjects for rebase merges (only squash merges). The cliff.toml preprocessor that converts `(#N)` into markdown links was therefore only producing links for the rare squash-merged commit.

This adds a PR enrichment step to `version.sh` that:

1. Gets the commit context JSON from git-cliff (`--context`)
2. For each commit SHA, queries `gh api commits/{sha}/pulls` to resolve the PR number
3. Injects the full markdown link into `raw_message` (subject line only)
4. Renders the final changelog via `git-cliff --from-context`

Commits that already carry a PR reference (squash merges) are detected and skipped. Gracefully degrades when `GITHUB_TOKEN` or `gh` CLI is unavailable (warning + fallback to unenriched output).

Before: ~3 of 32 changelog bullets had PR links
After: all 32 bullets have PR links