### PR TITLE
feat(cli): manage sessions with --no-attach, --list, --attach, --tail, --kill

### DIFF
--- a/apps/website/src/content/docs/reference/cli.md
+++ b/apps/website/src/content/docs/reference/cli.md
@@ -11,11 +11,13 @@ sidebar:
 
 The session runner and primary entry point. Auto-starts gmuxd if needed.
 
+`gmux` has no subcommands. Flags before the command apply to gmux itself; once the first positional argument is seen, everything after it is the command to run, verbatim, including its own flags. Use `--` to disambiguate when the command starts with a dash.
+
 ### `gmux`
 
 Open the gmux UI in a browser. Starts gmuxd if it is not already running. Prefers Chrome/Chromium in `--app` mode for a standalone window; falls back to the default browser.
 
-### `gmux <command> [args...]`
+### `gmux [--no-attach] <command> [args...]`
 
 Run a command inside a gmux session. The session registers with gmuxd and appears in the web UI.
 
@@ -23,9 +25,57 @@ Run a command inside a gmux session. The session registers with gmuxd and appear
 gmux bash
 gmux python3 main.py
 gmux pi "build the feature"
+gmux --no-attach pytest --watch       # detach from the terminal
+gmux -- --my-dash-cmd                 # `--` preserves a dashy command
 ```
 
+With `--no-attach` the session is spawned in the background and appears in the UI, but `gmux` returns immediately instead of wiring your local terminal to it. Without it, `gmux` attaches transparently — Ctrl-C goes to the child, resize events follow your terminal, and closing the terminal detaches without killing the session.
+
 When run inside an existing gmux session (detected via the `GMUX` environment variable), `gmux` automatically detaches into a headless background process instead of nesting PTY-within-PTY. The new session appears in the UI.
+
+### `gmux --list` (`-l`)
+
+List known sessions, alive first, newest first.
+
+```
+$ gmux --list
+ID        STATUS  KIND   TITLE
+a3f20187  alive   pi     fix auth bug  (/home/mg/dev/myapp)
+be14b052  alive   shell  bash          (/home/mg/dev/gmux)
+7d3304e9  dead    shell  make build    (/home/mg/dev/myapp)
+```
+
+The ID column shows the 8-character short form the web UI uses; most management flags accept unique ID prefixes, the full session ID, or the session's slug.
+
+### `gmux --attach <id>` (`-a`)
+
+Reattach your local terminal to an existing session. The session's scrollback is replayed on connect, SIGWINCH is forwarded, and closing the terminal detaches without killing the session — identical to how `gmux <cmd>` itself behaves.
+
+```bash
+gmux --attach a3f20187
+gmux -a fix-auth-bug        # slug also works
+```
+
+Attach requires an interactive terminal. Remote peer sessions are supported transparently — gmuxd proxies the WebSocket to the owning node.
+
+### `gmux --tail <N> <id>` (`-t`)
+
+Print the last `N` lines of a session's output as plain text (scrollback plus the currently visible screen, ANSI stripped). Useful for peeking at a background session without attaching to it.
+
+```bash
+gmux --tail 100 a3f20187
+gmux -t 20 fix-auth-bug
+```
+
+`--tail` currently only works for sessions owned by the local node; remote peer sessions are rejected with a clear error.
+
+### `gmux --kill <id>` (`-k`)
+
+Terminate a running session. Sends the same signal chain the UI's kill button does: `SIGTERM` to the child, normal exit lifecycle, session marked dead.
+
+```bash
+gmux --kill a3f20187
+```
 
 ## gmuxd
 

--- a/cli/gmux/cmd/gmux/actions.go
+++ b/cli/gmux/cmd/gmux/actions.go
@@ -1,0 +1,296 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"sort"
+	"strings"
+	"time"
+)
+
+// session is the subset of gmuxd's Session model that the CLI cares
+// about. Defined locally to avoid pulling in the gmuxd store package.
+type cliSession struct {
+	ID         string `json:"id"`
+	Peer       string `json:"peer,omitempty"`
+	Cwd        string `json:"cwd,omitempty"`
+	Kind       string `json:"kind"`
+	Alive      bool   `json:"alive"`
+	Pid        int    `json:"pid,omitempty"`
+	Title      string `json:"title,omitempty"`
+	Slug       string `json:"slug,omitempty"`
+	SocketPath string `json:"socket_path,omitempty"`
+	Command    []string `json:"command,omitempty"`
+	StartedAt  string `json:"started_at,omitempty"`
+	ExitedAt   string `json:"exited_at,omitempty"`
+	ExitCode   *int   `json:"exit_code,omitempty"`
+}
+
+// fetchSessions queries gmuxd for the full session list. Starts gmuxd
+// if it's not already running so management commands work on a cold
+// machine, the same way `gmux <cmd>` does.
+func fetchSessions() ([]cliSession, error) {
+	ensureGmuxd()
+	client := gmuxdClient()
+	resp, err := client.Get(gmuxdBaseURL() + "/v1/sessions")
+	if err != nil {
+		return nil, fmt.Errorf("contact gmuxd: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("gmuxd returned %s", resp.Status)
+	}
+
+	var envelope struct {
+		OK   bool         `json:"ok"`
+		Data []cliSession `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		return nil, fmt.Errorf("decode sessions: %w", err)
+	}
+	return envelope.Data, nil
+}
+
+// resolveSession fetches the session list from gmuxd and finds the one
+// the user's reference points to. See matchSession for the matching rules.
+func resolveSession(ref string) (cliSession, error) {
+	sessions, err := fetchSessions()
+	if err != nil {
+		return cliSession{}, err
+	}
+	return matchSession(sessions, ref)
+}
+
+// matchSession resolves a user-supplied reference to a single session.
+//
+// A reference can be:
+//   - the full session ID ("sess-abcd1234") or full slug
+//   - the short form shown by --list ("abcd1234", i.e. the ID with its
+//     "sess-" prefix stripped)
+//   - a unique prefix of any of the above
+//
+// Exact matches (on either ID or slug) always win, even when a shorter
+// prefix would also match something else. Ambiguous prefixes return a
+// human-readable error listing the candidates.
+func matchSession(sessions []cliSession, ref string) (cliSession, error) {
+	if ref == "" {
+		return cliSession{}, fmt.Errorf("empty session reference")
+	}
+
+	// Pass 1: exact matches take precedence, so "abcd" never accidentally
+	// resolves to a prefix when a session is literally named "abcd".
+	for _, s := range sessions {
+		if s.ID == ref || s.Slug == ref || shortID(s.ID) == ref {
+			return s, nil
+		}
+	}
+
+	// Pass 2: unique prefix match. We also match against the short form
+	// so "abcd" (a prefix of the short id shown by --list) resolves
+	// as users expect, not only "sess-abcd...".
+	var matches []cliSession
+	for _, s := range sessions {
+		switch {
+		case strings.HasPrefix(s.ID, ref),
+			strings.HasPrefix(shortID(s.ID), ref),
+			s.Slug != "" && strings.HasPrefix(s.Slug, ref):
+			matches = append(matches, s)
+		}
+	}
+
+	switch len(matches) {
+	case 0:
+		return cliSession{}, fmt.Errorf("no session matches %q", ref)
+	case 1:
+		return matches[0], nil
+	default:
+		var ids []string
+		for _, m := range matches {
+			ids = append(ids, shortID(m.ID))
+		}
+		return cliSession{}, fmt.Errorf("ambiguous session %q matches: %s", ref, strings.Join(ids, ", "))
+	}
+}
+
+// shortID returns the 8-char display form of a session id, matching
+// what the web UI uses.
+func shortID(id string) string {
+	const prefix = "sess-"
+	trimmed := strings.TrimPrefix(id, prefix)
+	if len(trimmed) > 8 {
+		trimmed = trimmed[:8]
+	}
+	return trimmed
+}
+
+// cmdList implements `gmux --list`.
+//
+// Prints one row per session, grouped alive-first then by start time.
+// The columns are kept intentionally shallow (id, status, kind, title,
+// cwd) so the output stays readable in a narrow terminal; anyone who
+// wants richer data can open the UI.
+func cmdList() int {
+	sessions, err := fetchSessions()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "gmux:", err)
+		return 1
+	}
+
+	if len(sessions) == 0 {
+		fmt.Println("no sessions")
+		return 0
+	}
+
+	// Alive first; within each group, newest first.
+	sort.SliceStable(sessions, func(i, j int) bool {
+		if sessions[i].Alive != sessions[j].Alive {
+			return sessions[i].Alive
+		}
+		return sessions[i].StartedAt > sessions[j].StartedAt
+	})
+
+	// Measure columns.
+	idW, statusW, kindW := len("ID"), len("STATUS"), len("KIND")
+	rows := make([][5]string, 0, len(sessions))
+	for _, s := range sessions {
+		status := "dead"
+		if s.Alive {
+			status = "alive"
+		}
+		if s.Peer != "" {
+			status += "@" + s.Peer
+		}
+		title := s.Title
+		if title == "" {
+			title = strings.Join(s.Command, " ")
+		}
+		row := [5]string{shortID(s.ID), status, s.Kind, title, s.Cwd}
+		rows = append(rows, row)
+		if n := len(row[0]); n > idW {
+			idW = n
+		}
+		if n := len(row[1]); n > statusW {
+			statusW = n
+		}
+		if n := len(row[2]); n > kindW {
+			kindW = n
+		}
+	}
+
+	fmt.Printf("%-*s  %-*s  %-*s  %s\n", idW, "ID", statusW, "STATUS", kindW, "KIND", "TITLE")
+	for _, r := range rows {
+		line := fmt.Sprintf("%-*s  %-*s  %-*s  %s", idW, r[0], statusW, r[1], kindW, r[2], r[3])
+		if r[4] != "" {
+			line += "  (" + r[4] + ")"
+		}
+		fmt.Println(line)
+	}
+	return 0
+}
+
+// cmdKill implements `gmux --kill <id>`.
+//
+// Routes through gmuxd rather than the session's own socket so remote
+// peers work the same way local sessions do. gmuxd translates this into
+// a SIGTERM on the child process and lets the normal exit lifecycle
+// update the store.
+func cmdKill(ref string) int {
+	sess, err := resolveSession(ref)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "gmux:", err)
+		return 1
+	}
+	if !sess.Alive {
+		fmt.Fprintf(os.Stderr, "gmux: session %s is already not running\n", shortID(sess.ID))
+		return 1
+	}
+
+	client := gmuxdClient()
+	url := gmuxdBaseURL() + "/v1/sessions/" + sess.ID + "/kill"
+	resp, err := client.Post(url, "application/json", strings.NewReader("{}"))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "gmux:", err)
+		return 1
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		fmt.Fprintf(os.Stderr, "gmux: kill failed: %s: %s\n", resp.Status, strings.TrimSpace(string(body)))
+		return 1
+	}
+	fmt.Printf("killed %s\n", shortID(sess.ID))
+	return 0
+}
+
+// cmdTail implements `gmux --tail N <id>`.
+//
+// Reads from the session's own Unix socket (/scrollback/tail) rather
+// than going through gmuxd: the socket path is already in the gmuxd
+// session record, and this keeps the scrollback data off the daemon
+// path. Remote peer sessions (no local socket_path) are rejected with
+// a clear error rather than silently falling back to something lossy.
+func cmdTail(ref string, n int) int {
+	sess, err := resolveSession(ref)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "gmux:", err)
+		return 1
+	}
+	if sess.SocketPath == "" {
+		switch {
+		case sess.Peer != "":
+			fmt.Fprintf(os.Stderr, "gmux: --tail is only supported for local sessions (%s is on peer %q)\n",
+				shortID(sess.ID), sess.Peer)
+		case !sess.Alive:
+			fmt.Fprintf(os.Stderr, "gmux: session %s is not running\n", shortID(sess.ID))
+		default:
+			fmt.Fprintf(os.Stderr, "gmux: session %s has no socket path\n", shortID(sess.ID))
+		}
+		return 1
+	}
+
+	client := sessionSocketClient(sess.SocketPath)
+	url := fmt.Sprintf("http://session/scrollback/tail?n=%d", n)
+	resp, err := client.Get(url)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "gmux:", err)
+		return 1
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		// Older runners may not have the tail endpoint yet; give a
+		// specific hint instead of a bare 404.
+		if resp.StatusCode == http.StatusNotFound {
+			fmt.Fprintln(os.Stderr, "gmux: this session's runner is too old for --tail (restart it to upgrade)")
+			return 1
+		}
+		fmt.Fprintf(os.Stderr, "gmux: tail failed: %s: %s\n", resp.Status, strings.TrimSpace(string(body)))
+		return 1
+	}
+	if _, err := io.Copy(os.Stdout, resp.Body); err != nil && !errors.Is(err, io.EOF) {
+		fmt.Fprintln(os.Stderr, "gmux:", err)
+		return 1
+	}
+	return 0
+}
+
+// sessionSocketClient builds an HTTP client that dials a session's
+// Unix socket directly. The host portion of URLs passed through this
+// client is ignored — we use "session" by convention.
+func sessionSocketClient(sockPath string) *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				var d net.Dialer
+				return d.DialContext(ctx, "unix", sockPath)
+			},
+		},
+		Timeout: 5 * time.Second,
+	}
+}

--- a/cli/gmux/cmd/gmux/actions_test.go
+++ b/cli/gmux/cmd/gmux/actions_test.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestMatchSession covers the reference-resolution rules the CLI
+// documents: short form (as shown by --list), full ID, slug, and
+// unique prefixes of any of those. These cases double as the
+// compatibility contract between --list's output and the other
+// management flags — if --list prints "abcd1234", `--kill abcd1234`
+// must resolve it.
+func TestMatchSession(t *testing.T) {
+	sessions := []cliSession{
+		{ID: "sess-abcd1234", Slug: "fix-auth"},
+		{ID: "sess-abcd5678", Slug: "fix-bug"},
+		{ID: "sess-ef019283", Slug: "build-docs"},
+	}
+
+	cases := []struct {
+		name   string
+		ref    string
+		wantID string
+	}{
+		{"full id", "sess-abcd1234", "sess-abcd1234"},
+		{"short form as shown by --list", "abcd1234", "sess-abcd1234"},
+		{"exact slug", "fix-auth", "sess-abcd1234"},
+		{"unique short-form prefix", "ef01", "sess-ef019283"},
+		{"unique slug prefix", "build", "sess-ef019283"},
+		{"unique full-id prefix", "sess-ef", "sess-ef019283"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := matchSession(sessions, tc.ref)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.ID != tc.wantID {
+				t.Errorf("ID = %q, want %q", got.ID, tc.wantID)
+			}
+		})
+	}
+}
+
+// TestMatchSessionAmbiguous asserts that ambiguous prefixes refuse to
+// guess: killing the wrong session because a prefix happened to match
+// two sessions would be actively harmful, much worse than a bad error
+// message.
+func TestMatchSessionAmbiguous(t *testing.T) {
+	sessions := []cliSession{
+		{ID: "sess-abcd1234", Slug: "fix-auth"},
+		{ID: "sess-abcd5678", Slug: "fix-bug"},
+	}
+	_, err := matchSession(sessions, "abcd")
+	if err == nil {
+		t.Fatal("expected ambiguous error")
+	}
+	// Both candidates must appear in the error so the user can
+	// disambiguate by typing more characters.
+	msg := err.Error()
+	if !strings.Contains(msg, "abcd1234") || !strings.Contains(msg, "abcd5678") {
+		t.Errorf("error should list both candidates, got: %s", msg)
+	}
+}
+
+// TestMatchSessionExactBeatsPrefix covers the corner case where the
+// user's ref is itself a valid session short id AND a prefix of
+// another: the exact match must win, otherwise the unambiguous case
+// would report ambiguity.
+func TestMatchSessionExactBeatsPrefix(t *testing.T) {
+	sessions := []cliSession{
+		{ID: "sess-abcd"},     // exact match for short form "abcd"
+		{ID: "sess-abcdef01"}, // also starts with "abcd"
+	}
+	got, err := matchSession(sessions, "abcd")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.ID != "sess-abcd" {
+		t.Errorf("expected exact match to win, got %q", got.ID)
+	}
+}
+
+// TestMatchSessionNoMatch is the "cold cache" path: the user typo'd or
+// pointed at a session from another machine. Error, don't pick a
+// random one.
+func TestMatchSessionNoMatch(t *testing.T) {
+	sessions := []cliSession{{ID: "sess-abcd1234"}}
+	if _, err := matchSession(sessions, "zzzz"); err == nil {
+		t.Error("expected error for non-matching ref")
+	}
+	if _, err := matchSession(nil, "anything"); err == nil {
+		t.Error("expected error when session list is empty")
+	}
+	if _, err := matchSession(sessions, ""); err == nil {
+		t.Error("expected error for empty ref")
+	}
+}
+
+// TestShortID covers the conversion between gmuxd's full session IDs
+// and the display form shown by --list, which is what users type back
+// into --attach / --kill / --tail.
+func TestShortID(t *testing.T) {
+	cases := map[string]string{
+		"sess-abcd1234": "abcd1234", // normal case
+		"sess-ab":       "ab",       // unusually short (shouldn't happen, but don't crash)
+		"abcd1234":      "abcd1234", // already short — idempotent
+		"":              "",         // defensive
+	}
+	for in, want := range cases {
+		if got := shortID(in); got != want {
+			t.Errorf("shortID(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/cli/gmux/cmd/gmux/attach.go
+++ b/cli/gmux/cmd/gmux/attach.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/gmuxapp/gmux/cli/gmux/internal/localterm"
+	"github.com/gmuxapp/gmux/cli/gmux/internal/ptyserver"
+	"nhooyr.io/websocket"
+)
+
+// cmdAttach implements `gmux --attach <id>`.
+//
+// Opens a WebSocket to gmuxd's /ws/{id} handler via the local Unix
+// socket. gmuxd proxies to the session's own Unix socket for local
+// sessions and over the network for peer sessions, so this one code
+// path works regardless of where the session lives.
+//
+// The local terminal is put into raw mode via the same localterm
+// helper that `gmux <cmd>` uses, so attach feels the same as an
+// original launch: transparent I/O, SIGWINCH → resize, SIGHUP →
+// detach (session keeps running), Ctrl-C goes to the child.
+func cmdAttach(ref string) int {
+	sess, err := resolveSession(ref)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "gmux:", err)
+		return 1
+	}
+
+	// A dead session has no backend socket for gmuxd to dial, so the WS
+	// upgrade would fail with a cryptic "backend unavailable". Surface the
+	// real reason up front and point the user at the UI where they can
+	// resume the session if the adapter supports it.
+	if !sess.Alive {
+		fmt.Fprintf(os.Stderr, "gmux: session %s is not running (open the UI to resume)\n", shortID(sess.ID))
+		return 1
+	}
+
+	if !localterm.IsInteractive() {
+		fmt.Fprintln(os.Stderr, "gmux: --attach requires an interactive terminal")
+		return 1
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Dial gmuxd's WS endpoint through its Unix socket. nhooyr's Dial
+	// accepts any HTTPClient, so we reuse the unix-socket transport
+	// that gmuxdClient uses for plain HTTP calls.
+	dialHTTP := gmuxdClient()
+	// A long-lived WS can exceed the default 5s timeout; clear it here.
+	dialHTTP.Timeout = 0
+
+	wsURL := "ws://gmuxd/ws/" + sess.ID
+	conn, _, err := websocket.Dial(ctx, wsURL, &websocket.DialOptions{
+		HTTPClient: dialHTTP,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "gmux: connect %s: %v\n", shortID(sess.ID), err)
+		return 1
+	}
+	defer conn.Close(websocket.StatusNormalClosure, "")
+	// The server may send a scrollback snapshot that exceeds the default
+	// 32KiB read limit (especially for TUIs with lots of state); match
+	// the browser client's limit.
+	conn.SetReadLimit(10 * 1024 * 1024)
+
+	// Wire the local tty to the WS.
+	attach, err := localterm.New(localterm.Config{
+		PTYWriter: wsBinaryWriter{ctx: ctx, conn: conn},
+		ResizeFn: func(cols, rows uint16) {
+			sendResize(ctx, conn, cols, rows)
+		},
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "gmux: attach: %v\n", err)
+		return 1
+	}
+	defer attach.Detach()
+
+	// Send an initial resize so the PTY adopts our viewport. Without
+	// this the child TUI might keep the previous attach's dimensions.
+	if cols, rows, err := localterm.TerminalSize(); err == nil {
+		sendResize(ctx, conn, cols, rows)
+	}
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(sigCh)
+
+	// Reader pump: forward server frames to the terminal. Binary frames
+	// are PTY output; text frames are JSON control messages (we currently
+	// ignore them — the browser client consumes status/title updates via
+	// SSE, not WS).
+	readErr := make(chan error, 1)
+	go func() {
+		for {
+			typ, data, err := conn.Read(ctx)
+			if err != nil {
+				readErr <- err
+				return
+			}
+			if typ == websocket.MessageBinary {
+				attach.Write(data)
+			}
+		}
+	}()
+
+	select {
+	case <-readErr:
+		// Server closed or connection broke. Either the session exited
+		// or gmuxd hung up. Either way, we're done.
+	case <-attach.Done():
+		// Local tty closed (stdin EOF). Detach cleanly; session keeps
+		// running just like gmux <cmd> with SIGHUP.
+	case sig := <-sigCh:
+		if sig == syscall.SIGHUP {
+			// Terminal closed. Detach; session stays alive.
+		} else {
+			// SIGINT/SIGTERM from outside raw mode (shouldn't happen
+			// much because raw mode forwards them to the child via
+			// WS input, but we still drop the WS cleanly).
+		}
+	}
+	return 0
+}
+
+// wsBinaryWriter adapts a WebSocket connection to io.Writer by sending
+// each Write as a binary frame. Used to feed local stdin into the
+// remote PTY.
+type wsBinaryWriter struct {
+	ctx  context.Context
+	conn *websocket.Conn
+}
+
+func (w wsBinaryWriter) Write(p []byte) (int, error) {
+	if err := w.conn.Write(w.ctx, websocket.MessageBinary, p); err != nil {
+		return 0, err
+	}
+	return len(p), nil
+}
+
+// sendResize delivers a resize message over the WS in the same JSON
+// shape the ptyserver accepts. Source "local_tty" distinguishes it
+// from browser resizes in server-side logging.
+func sendResize(ctx context.Context, conn *websocket.Conn, cols, rows uint16) {
+	msg := ptyserver.ResizeMsg{
+		Type:   "resize",
+		Cols:   cols,
+		Rows:   rows,
+		Source: "local_tty",
+	}
+	data, err := json.Marshal(msg)
+	if err != nil {
+		return
+	}
+	_ = conn.Write(ctx, websocket.MessageText, data)
+}
+

--- a/cli/gmux/cmd/gmux/browser.go
+++ b/cli/gmux/cmd/gmux/browser.go
@@ -1,0 +1,212 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"syscall"
+)
+
+// openBrowser opens the gmux UI. Prefers Chrome/Chromium in --app mode
+// for a standalone window; falls back to the default browser.
+func openBrowser(url string) {
+
+	// Strategy: default browser if Chromium-based → app mode, else
+	// any installed Chromium → app mode, else system default.
+	if tryDefaultBrowserAppMode(url) {
+		return
+	}
+	if tryAnyChromiumAppMode(url) {
+		return
+	}
+
+	// Fallback: default browser (normal tab).
+	switch runtime.GOOS {
+	case "darwin":
+		exec.Command("open", url).Start()
+	default:
+		exec.Command("xdg-open", url).Start()
+	}
+}
+
+// tryDefaultBrowserAppMode checks if the user's default browser is
+// Chromium-based and launches it in --app mode.
+func tryDefaultBrowserAppMode(url string) bool {
+	switch runtime.GOOS {
+	case "darwin":
+		bundleID := defaultBrowserBundleID()
+		if binary, ok := macOSChromiumBinary(bundleID); ok {
+			return startDetached(exec.Command(binary, "--app="+url))
+		}
+	default:
+		desktop := defaultDesktopBrowser()
+		if isChromiumDesktop(desktop) {
+			// The default browser is Chromium-based — xdg-open won't pass
+			// --app, but the binary should be on PATH with a known name.
+			return tryAnyChromiumAppMode(url)
+		}
+	}
+	return false
+}
+
+// tryAnyChromiumAppMode finds any installed Chromium-based browser and
+// launches it with --app.
+func tryAnyChromiumAppMode(url string) bool {
+	switch runtime.GOOS {
+	case "darwin":
+		// macOS: Chrome.app doesn't put a binary on $PATH.
+		// Check known .app bundle locations directly.
+		home, _ := os.UserHomeDir()
+		appDirs := []string{"/Applications", filepath.Join(home, "Applications")}
+		for _, app := range []string{"Google Chrome", "Chromium"} {
+			for _, dir := range appDirs {
+				binary := filepath.Join(dir, app+".app", "Contents", "MacOS", app)
+				if _, err := os.Stat(binary); err == nil {
+					if startDetached(exec.Command(binary, "--app="+url)) {
+						return true
+					}
+				}
+			}
+		}
+	default:
+		for _, name := range []string{"google-chrome-stable", "google-chrome", "chromium-browser", "chromium"} {
+			if p, err := exec.LookPath(name); err == nil {
+				if startDetached(exec.Command(p, "--app="+url)) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// startDetached starts a command in a new session so it outlives gmux.
+func startDetached(cmd *exec.Cmd) bool {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	return cmd.Start() == nil
+}
+
+// --- default browser detection ---
+
+// defaultBrowserBundleID returns the macOS bundle ID of the default
+// HTTPS handler (e.g. "com.google.chrome"). Returns "" if Safari is
+// the implicit default or detection fails.
+func defaultBrowserBundleID() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	plistPath := filepath.Join(home,
+		"Library", "Preferences", "com.apple.LaunchServices",
+		"com.apple.launchservices.secure.plist")
+	out, err := exec.Command("plutil", "-convert", "json", "-o", "-", plistPath).Output()
+	if err != nil {
+		return ""
+	}
+	var plist struct {
+		LSHandlers []struct {
+			URLScheme string `json:"LSHandlerURLScheme"`
+			RoleAll   string `json:"LSHandlerRoleAll"`
+		} `json:"LSHandlers"`
+	}
+	if err := json.Unmarshal(out, &plist); err != nil {
+		return ""
+	}
+	for _, h := range plist.LSHandlers {
+		if strings.EqualFold(h.URLScheme, "https") {
+			return h.RoleAll
+		}
+	}
+	return "" // Safari is implicit default
+}
+
+// macOSChromiumBinary maps a bundle ID to its binary path if it's a
+// known Chromium-based browser.
+func macOSChromiumBinary(bundleID string) (string, bool) {
+	// Map bundle IDs → .app names for known Chromium-based browsers.
+	appNames := map[string]string{
+		"com.google.chrome":          "Google Chrome",
+		"org.chromium.chromium":      "Chromium",
+		"company.thebrowser.browser": "Arc",
+		"com.brave.browser":          "Brave Browser",
+		"com.microsoft.edgemac":      "Microsoft Edge",
+	}
+	appName, ok := appNames[strings.ToLower(bundleID)]
+	if !ok {
+		return "", false
+	}
+	home, _ := os.UserHomeDir()
+	for _, dir := range []string{"/Applications", filepath.Join(home, "Applications")} {
+		binary := filepath.Join(dir, appName+".app", "Contents", "MacOS", appName)
+		if _, err := os.Stat(binary); err == nil {
+			return binary, true
+		}
+	}
+	return "", false
+}
+
+// defaultDesktopBrowser returns the .desktop file name of the default
+// web browser on Linux (e.g. "google-chrome.desktop").
+func defaultDesktopBrowser() string {
+	out, err := exec.Command("xdg-settings", "get", "default-web-browser").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// isChromiumDesktop returns true if the .desktop name looks Chromium-based.
+func isChromiumDesktop(desktop string) bool {
+	d := strings.ToLower(desktop)
+	return strings.Contains(d, "chrome") || strings.Contains(d, "chromium")
+}
+
+// upgradeHint returns the appropriate upgrade command based on how gmux was installed.
+func upgradeHint() string {
+	self, err := os.Executable()
+	if err != nil {
+		return "curl -sSfL https://gmux.app/install.sh | sh"
+	}
+	// Resolve symlinks to find the real binary location
+	real, err := filepath.EvalSymlinks(self)
+	if err != nil {
+		real = self
+	}
+	// Check if we're inside a Homebrew prefix
+	if strings.Contains(real, "/Cellar/") || strings.Contains(real, "/homebrew/") {
+		return "brew upgrade gmuxapp/tap/gmux"
+	}
+	return "curl -sSfL https://gmux.app/install.sh | sh"
+}
+
+// maskTailscaleURL masks the tailnet name for privacy.
+// "https://gmux.angler-map.ts.net" → "https://gmux.an******.ts.net"
+func maskTailscaleURL(url string) string {
+	// Find the tailnet part: between first dot after hostname and .ts.net
+	tsNet := ".ts.net"
+	idx := strings.Index(url, tsNet)
+	if idx < 0 {
+		return url
+	}
+	// Find the start of the tailnet name (after "https://gmux.")
+	schemeEnd := strings.Index(url, "://")
+	if schemeEnd < 0 {
+		return url
+	}
+	hostStart := schemeEnd + 3
+	// Find first dot after the hostname prefix
+	dotIdx := strings.Index(url[hostStart:], ".")
+	if dotIdx < 0 {
+		return url
+	}
+	tailnetStart := hostStart + dotIdx + 1
+	tailnetName := url[tailnetStart:idx]
+	if len(tailnetName) <= 2 {
+		return url
+	}
+	masked := tailnetName[:2] + "****"
+	return url[:tailnetStart] + masked + url[idx:]
+}

--- a/cli/gmux/cmd/gmux/cli.go
+++ b/cli/gmux/cmd/gmux/cli.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+)
+
+// mode is the top-level action gmux is being asked to perform.
+type mode int
+
+const (
+	modeUI     mode = iota // no args → open the web UI
+	modeRun                // run a command in a new session
+	modeList               // list known sessions
+	modeAttach             // reattach to an existing session
+	modeTail               // dump recent output from a session
+	modeKill               // terminate a session
+	modeHelp               // print usage and exit
+)
+
+// flags captures the parsed gmux-level options. Anything that influences
+// the run path ("flags the runner cares about") or triggers a management
+// action ("flags that replace the runner") lives here. The trailing
+// positional command or session id is returned separately as rest.
+type flags struct {
+	noAttach bool
+	list     bool
+	attach   bool
+	kill     bool
+	tail     int // >=0 when set (flag default is -1)
+	help     bool
+}
+
+// parseCLI parses argv (without program name) and decides which mode to
+// dispatch. Flag parsing stops at the first positional argument, matching
+// the POSIX runner convention (env/nohup/time/screen): everything from
+// the first bare word onwards is the command, verbatim, including its
+// own flags.
+//
+// A literal `--` also terminates flag parsing, for the rare case where
+// the command itself starts with a dash.
+func parseCLI(args []string) (mode, *flags, []string, error) {
+	f := &flags{tail: -1}
+	fs := flag.NewFlagSet("gmux", flag.ContinueOnError)
+	fs.SetOutput(io.Discard) // we print our own usage on error
+
+	fs.BoolVar(&f.noAttach, "no-attach", false, "run the command detached from the terminal")
+	fs.BoolVar(&f.list, "list", false, "list known sessions")
+	fs.BoolVar(&f.list, "l", false, "list known sessions (short)")
+	fs.BoolVar(&f.attach, "attach", false, "reattach to an existing session")
+	fs.BoolVar(&f.attach, "a", false, "reattach to an existing session (short)")
+	fs.BoolVar(&f.kill, "kill", false, "kill a running session")
+	fs.BoolVar(&f.kill, "k", false, "kill a running session (short)")
+	fs.IntVar(&f.tail, "tail", -1, "dump the last N lines of a session")
+	fs.IntVar(&f.tail, "t", -1, "dump the last N lines of a session (short)")
+	fs.BoolVar(&f.help, "help", false, "show help")
+	fs.BoolVar(&f.help, "h", false, "show help (short)")
+
+	if err := fs.Parse(args); err != nil {
+		return modeHelp, nil, nil, err
+	}
+	rest := fs.Args()
+
+	if f.help {
+		return modeHelp, f, rest, nil
+	}
+
+	// At most one management action at a time.
+	actions := 0
+	if f.list {
+		actions++
+	}
+	if f.attach {
+		actions++
+	}
+	if f.kill {
+		actions++
+	}
+	if f.tail >= 0 {
+		actions++
+	}
+	if actions > 1 {
+		return modeHelp, nil, nil, errors.New("--list, --attach, --tail, --kill are mutually exclusive")
+	}
+
+	// Management actions take a single session id (except --list).
+	switch {
+	case f.list:
+		if len(rest) > 0 {
+			return modeHelp, nil, nil, errors.New("--list takes no arguments")
+		}
+		if f.noAttach {
+			return modeHelp, nil, nil, errors.New("--no-attach has no effect with --list")
+		}
+		return modeList, f, nil, nil
+	case f.attach:
+		if len(rest) != 1 {
+			return modeHelp, nil, nil, errors.New("--attach requires a session id")
+		}
+		if f.noAttach {
+			return modeHelp, nil, nil, errors.New("--no-attach conflicts with --attach")
+		}
+		return modeAttach, f, rest, nil
+	case f.kill:
+		if len(rest) != 1 {
+			return modeHelp, nil, nil, errors.New("--kill requires a session id")
+		}
+		if f.noAttach {
+			return modeHelp, nil, nil, errors.New("--no-attach has no effect with --kill")
+		}
+		return modeKill, f, rest, nil
+	case f.tail >= 0:
+		if len(rest) != 1 {
+			return modeHelp, nil, nil, errors.New("--tail requires a session id")
+		}
+		if f.tail == 0 {
+			return modeHelp, nil, nil, errors.New("--tail needs a positive line count")
+		}
+		if f.noAttach {
+			return modeHelp, nil, nil, errors.New("--no-attach has no effect with --tail")
+		}
+		return modeTail, f, rest, nil
+	}
+
+	// No management action. If there's a command, run it; otherwise UI.
+	if len(rest) == 0 {
+		if f.noAttach {
+			return modeHelp, nil, nil, errors.New("--no-attach requires a command")
+		}
+		return modeUI, f, nil, nil
+	}
+	return modeRun, f, rest, nil
+}
+
+// printUsage writes the gmux usage synopsis. Shown on --help, on parse
+// errors (with an error message prefix), and nowhere else.
+func printUsage(w io.Writer) {
+	fmt.Fprint(w, `gmux — wrap any command in a managed session
+
+Usage:
+  gmux                              open the web UI
+  gmux [--no-attach] <cmd> [args]   run a command in a new session
+  gmux -- <cmd> [args]              use -- if <cmd> starts with a dash
+
+Session management:
+  gmux --list                       list known sessions
+  gmux --attach <id>                reattach to an existing session
+  gmux --tail <N> <id>              print the last N lines of a session
+  gmux --kill <id>                  terminate a session
+
+Flags before the command apply to gmux itself. Once the first positional
+argument is seen, everything after is the command to run, verbatim.
+
+For daemon management see 'gmuxd --help'.
+`)
+}

--- a/cli/gmux/cmd/gmux/cli_test.go
+++ b/cli/gmux/cmd/gmux/cli_test.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestParseCLI covers every distinct dispatch path the user can reach.
+// We check the returned mode, the relevant flag values, and the
+// positional remainder — these three together describe what main.go
+// will actually do.
+func TestParseCLI(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		wantMode mode
+		wantRest []string
+		check    func(t *testing.T, f *flags)
+	}{
+		// ── Run-mode shapes ─────────────────────────────────────────
+		{
+			name:     "bare gmux opens the UI",
+			args:     nil,
+			wantMode: modeUI,
+		},
+		{
+			name:     "plain command is a run",
+			args:     []string{"pytest"},
+			wantMode: modeRun,
+			wantRest: []string{"pytest"},
+		},
+		{
+			name:     "command keeps its own flags",
+			args:     []string{"pytest", "--watch", "-x"},
+			wantMode: modeRun,
+			wantRest: []string{"pytest", "--watch", "-x"},
+		},
+		{
+			name:     "double-dash shields a dash-prefixed command",
+			args:     []string{"--", "--weird-binary", "arg"},
+			wantMode: modeRun,
+			wantRest: []string{"--weird-binary", "arg"},
+		},
+		{
+			name:     "no-attach carries into run mode",
+			args:     []string{"--no-attach", "pytest", "--watch"},
+			wantMode: modeRun,
+			wantRest: []string{"pytest", "--watch"},
+			check: func(t *testing.T, f *flags) {
+				if !f.noAttach {
+					t.Error("noAttach should be true")
+				}
+			},
+		},
+
+		// ── Management shapes ───────────────────────────────────────
+		{
+			name:     "--list has no positionals",
+			args:     []string{"--list"},
+			wantMode: modeList,
+		},
+		{
+			name:     "-l is the short form of --list",
+			args:     []string{"-l"},
+			wantMode: modeList,
+		},
+		{
+			name:     "--attach takes one session id",
+			args:     []string{"--attach", "sess-abcd"},
+			wantMode: modeAttach,
+			wantRest: []string{"sess-abcd"},
+		},
+		{
+			name:     "--kill takes one session id",
+			args:     []string{"--kill", "sess-abcd"},
+			wantMode: modeKill,
+			wantRest: []string{"sess-abcd"},
+		},
+		{
+			name:     "--tail takes a count and a session id",
+			args:     []string{"--tail", "100", "sess-abcd"},
+			wantMode: modeTail,
+			wantRest: []string{"sess-abcd"},
+			check: func(t *testing.T, f *flags) {
+				if f.tail != 100 {
+					t.Errorf("tail = %d, want 100", f.tail)
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m, f, rest, err := parseCLI(tc.args)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if m != tc.wantMode {
+				t.Errorf("mode = %v, want %v", m, tc.wantMode)
+			}
+			if !reflect.DeepEqual(rest, tc.wantRest) {
+				// Treat nil and empty slice as equivalent for readability.
+				if !(len(rest) == 0 && len(tc.wantRest) == 0) {
+					t.Errorf("rest = %v, want %v", rest, tc.wantRest)
+				}
+			}
+			if tc.check != nil && f != nil {
+				tc.check(t, f)
+			}
+		})
+	}
+}
+
+// TestParseCLIErrors asserts that every user-facing invariant the CLI
+// promises is actually enforced. We don't pin error strings (those are
+// free to improve), only that an error is returned in each case.
+func TestParseCLIErrors(t *testing.T) {
+	invalid := [][]string{
+		{"--list", "extra"},              // --list takes no args
+		{"--attach"},                     // --attach needs an id
+		{"--attach", "a", "b"},           // --attach takes exactly one id
+		{"--kill"},                       // --kill needs an id
+		{"--tail", "100"},                // --tail needs an id
+		{"--tail", "0", "sess-a"},        // --tail needs a positive count
+		{"--list", "--attach", "sess-a"}, // mutually exclusive actions
+		{"--kill", "--attach", "sess-a"}, // mutually exclusive actions
+		{"--no-attach"},                  // --no-attach needs a command
+		{"--no-attach", "--list"},        // --no-attach doesn't make sense with --list
+		{"--no-attach", "--attach", "sess-a"},
+	}
+
+	for _, args := range invalid {
+		t.Run(joinArgs(args), func(t *testing.T) {
+			if _, _, _, err := parseCLI(args); err == nil {
+				t.Errorf("expected error for %v", args)
+			}
+		})
+	}
+}
+
+func joinArgs(args []string) string {
+	out := ""
+	for i, a := range args {
+		if i > 0 {
+			out += " "
+		}
+		out += a
+	}
+	if out == "" {
+		return "(no args)"
+	}
+	return out
+}

--- a/cli/gmux/cmd/gmux/daemon.go
+++ b/cli/gmux/cmd/gmux/daemon.go
@@ -1,0 +1,227 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/gmuxapp/gmux/packages/paths"
+)
+
+// ensureGmuxd checks if gmuxd is reachable and starts it if not.
+// If a daemon is running but reports a different version, it is replaced
+// so the child process always talks to a compatible daemon.
+// Called once at startup — if gmuxd dies later, we don't restart it.
+// Returns true if gmuxd was started (or replaced) by this call.
+func ensureGmuxd() bool {
+	if !gmuxdNeedsStart() {
+		return false
+	}
+
+	gmuxdBin := findGmuxdBin()
+	if gmuxdBin == "" {
+		log.Printf("warning: gmuxd not found (install it alongside gmux or add it to PATH)")
+		return false
+	}
+
+	// gmuxd run starts in the foreground; we background it ourselves.
+	return startGmuxd(gmuxdBin, []string{"run"})
+}
+
+// gmuxdNeedsStart checks the running daemon.
+func gmuxdNeedsStart() bool {
+	// "dev" builds never replace — avoids churn during development.
+	if version == "dev" {
+		return !gmuxdHealthy(500 * time.Millisecond)
+	}
+
+	client := gmuxdClient()
+	client.Timeout = 500 * time.Millisecond
+	resp, err := client.Get(gmuxdBaseURL() + "/v1/health")
+	if err != nil {
+		return true // not running
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return true // not healthy
+	}
+
+	var health struct {
+		Data struct {
+			Version string `json:"version"`
+		} `json:"data"`
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if json.Unmarshal(body, &health) != nil {
+		return false // can't parse, leave it alone
+	}
+
+	// Same version: no action needed. Different version: replace.
+	return health.Data.Version != version
+}
+
+// findGmuxdBin locates the gmuxd binary: sibling first, then PATH.
+func findGmuxdBin() string {
+	if self, err := os.Executable(); err == nil {
+		sibling := filepath.Join(filepath.Dir(self), "gmuxd")
+		if _, err := os.Stat(sibling); err == nil {
+			return sibling
+		}
+	}
+	if p, err := exec.LookPath("gmuxd"); err == nil {
+		return p
+	}
+	return ""
+}
+
+// startGmuxd launches gmuxd in the background with the given args.
+func startGmuxd(gmuxdBin string, args []string) bool {
+	// Log gmuxd output to a file so users can diagnose startup failures.
+	logPath := filepath.Join(os.TempDir(), "gmuxd.log")
+	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		logFile = nil
+	}
+
+	cmd := exec.Command(gmuxdBin, args...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	cmd.Stdout = nil
+	cmd.Stderr = logFile
+	if err := cmd.Start(); err != nil {
+		log.Printf("warning: could not start gmuxd: %v", err)
+		if logFile != nil {
+			logFile.Close()
+		}
+		return false
+	}
+	go func() {
+		cmd.Wait()
+		if logFile != nil {
+			logFile.Close()
+		}
+	}()
+
+	return true
+}
+
+// gmuxdClient returns an HTTP client connected to gmuxd via Unix socket.
+func gmuxdClient() *http.Client {
+	sockPath := paths.SocketPath()
+	return &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				return net.DialTimeout("unix", sockPath, 2*time.Second)
+			},
+		},
+		Timeout: 5 * time.Second,
+	}
+}
+
+// gmuxdBaseURL returns the base URL for gmuxd HTTP requests.
+// The host is ignored by the Unix socket transport.
+func gmuxdBaseURL() string {
+	return "http://localhost"
+}
+
+func gmuxdHealthy(timeout time.Duration) bool {
+	client := gmuxdClient()
+	client.Timeout = timeout
+	resp, err := client.Get(gmuxdBaseURL() + "/v1/health")
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode == http.StatusOK
+}
+
+func registerWithGmuxd(sessionID, socketPath string) {
+	baseURL := gmuxdBaseURL()
+
+	payload, _ := json.Marshal(map[string]string{
+		"session_id":  sessionID,
+		"socket_path": socketPath,
+	})
+
+	// Retry a few times — gmux may start before the HTTP server is ready
+	for i := 0; i < 5; i++ {
+		if i > 0 {
+			time.Sleep(500 * time.Millisecond)
+		}
+		client := gmuxdClient()
+		resp, err := client.Post(baseURL+"/v1/register", "application/json", bytes.NewReader(payload))
+		if err != nil {
+			continue
+		}
+		resp.Body.Close()
+		if resp.StatusCode == 200 {
+			return
+		}
+	}
+}
+
+func deregisterFromGmuxd(sessionID string) {
+	baseURL := gmuxdBaseURL()
+
+	payload, _ := json.Marshal(map[string]string{"session_id": sessionID})
+	client := gmuxdClient()
+	resp, err := client.Post(baseURL+"/v1/deregister", "application/json", bytes.NewReader(payload))
+	if err != nil {
+		return
+	}
+	resp.Body.Close()
+}
+
+// parseHealthField extracts a string field from the data object
+// of a /v1/health JSON response.
+func parseHealthField(body []byte, field string) string {
+	var resp struct {
+		Data map[string]json.RawMessage `json:"data"`
+	}
+	if json.Unmarshal(body, &resp) != nil {
+		return ""
+	}
+	raw, ok := resp.Data[field]
+	if !ok {
+		return ""
+	}
+	var val string
+	if json.Unmarshal(raw, &val) != nil {
+		return ""
+	}
+	return val
+}
+
+// parseTailscaleURL extracts the tailscale_url from a /v1/health JSON response.
+func parseTailscaleURL(body []byte) string {
+	var resp struct {
+		Data struct {
+			TailscaleURL string `json:"tailscale_url"`
+		} `json:"data"`
+	}
+	if json.Unmarshal(body, &resp) == nil {
+		return resp.Data.TailscaleURL
+	}
+	return ""
+}
+
+// parseUpdateAvailable extracts update_available from a /v1/health JSON response.
+func parseUpdateAvailable(body []byte) string {
+	var resp struct {
+		Data struct {
+			UpdateAvailable string `json:"update_available"`
+		} `json:"data"`
+	}
+	if json.Unmarshal(body, &resp) == nil {
+		return resp.Data.UpdateAvailable
+	}
+	return ""
+}

--- a/cli/gmux/cmd/gmux/main.go
+++ b/cli/gmux/cmd/gmux/main.go
@@ -1,32 +1,12 @@
 package main
 
 import (
-	"bytes"
-	"context"
-	"encoding/json"
+	"flag"
 	"fmt"
 	"io"
 	"log"
-	"net"
-	"net/http"
 	"os"
-	"os/exec"
-	"os/signal"
-	"path/filepath"
-	"runtime"
-	"strings"
-	"syscall"
 	"time"
-
-	"github.com/gmuxapp/gmux/cli/gmux/internal/binhash"
-	"github.com/gmuxapp/gmux/cli/gmux/internal/localterm"
-	"github.com/gmuxapp/gmux/cli/gmux/internal/naming"
-	"github.com/gmuxapp/gmux/cli/gmux/internal/ptyserver"
-	"github.com/gmuxapp/gmux/cli/gmux/internal/session"
-	"github.com/gmuxapp/gmux/packages/adapter"
-	"github.com/gmuxapp/gmux/packages/adapter/adapters"
-	"github.com/gmuxapp/gmux/packages/workspace"
-	"github.com/gmuxapp/gmux/packages/paths"
 )
 
 // version is set at build time via -ldflags "-X main.version=..."
@@ -37,661 +17,81 @@ func main() {
 	log.SetPrefix("gmux: ")
 	log.SetFlags(0)
 
-	args := os.Args[1:]
-
-	// No args → open the UI in a browser.
-	if len(args) == 0 {
-		ensureGmuxd()
-
-		// Wait for gmuxd to be reachable before opening browser.
-		client := gmuxdClient()
-		baseURL := gmuxdBaseURL()
-		var healthBody []byte
-		ready := false
-		for range 15 {
-			if resp, err := client.Get(baseURL + "/v1/health"); err == nil {
-				body, _ := io.ReadAll(resp.Body)
-				resp.Body.Close()
-				if resp.StatusCode == 200 {
-					healthBody = body
-					ready = true
-					break
-				}
-			}
-			time.Sleep(200 * time.Millisecond)
-		}
-		if !ready {
-			log.Fatalf("gmuxd is not running (check %s/gmuxd.log for errors)", os.TempDir())
-		}
-
-		// Parse health response for TCP address and auth token.
-		listenAddr := parseHealthField(healthBody, "listen")
-		token := parseHealthField(healthBody, "auth_token")
-
-		browserURL := "http://" + listenAddr
-		if token != "" {
-			browserURL = fmt.Sprintf("http://%s/auth/login?token=%s", listenAddr, token)
-		}
-
-		// Print access URLs.
-		fmt.Fprintf(os.Stderr, "  local:  http://%s\n", listenAddr)
-		if tsURL := parseTailscaleURL(healthBody); tsURL != "" {
-			fmt.Fprintf(os.Stderr, "  remote: %s\n", maskTailscaleURL(tsURL))
-		}
-		if updateVer := parseUpdateAvailable(healthBody); updateVer != "" {
-			fmt.Fprintf(os.Stderr, "  update: %s available — %s\n", updateVer, upgradeHint())
-		}
-
-		openBrowser(browserURL)
-		return
-	}
-
-	// Nested gmux detection: if we're running interactively inside an
-	// existing gmux session, re-exec as a detached headless process instead
-	// of doing PTY passthrough (which would nest PTY-within-PTY). The
-	// detached process registers with gmuxd and the session appears in the
-	// gmux UI. The original process returns immediately to the parent shell.
-	if os.Getenv("GMUX") == "1" && localterm.IsInteractive() {
-		self, err := os.Executable()
-		if err != nil {
-			log.Fatalf("cannot find own binary: %v", err)
-		}
-		devNull, err := os.Open(os.DevNull)
-		if err != nil {
-			log.Fatalf("cannot open %s: %v", os.DevNull, err)
-		}
-		defer devNull.Close()
-
-		cmd := exec.Command(self, os.Args[1:]...)
-		cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
-		cmd.Stdin = devNull
-		cmd.Stdout = devNull
-		cmd.Stderr = devNull
-		if err := cmd.Start(); err != nil {
-			log.Fatalf("failed to start background session: %v", err)
-		}
-		cmd.Process.Release()
-		fmt.Fprintf(os.Stderr, "started %s in background (visible in gmux)\n", strings.Join(args, " "))
-		return
-	}
-
-	workDir, err := os.Getwd()
+	m, f, rest, err := parseCLI(os.Args[1:])
 	if err != nil {
-		log.Fatalf("cannot determine cwd: %v", err)
+		if err != flag.ErrHelp {
+			fmt.Fprintln(os.Stderr, "gmux:", err)
+			fmt.Fprintln(os.Stderr)
+		}
+		printUsage(os.Stderr)
+		os.Exit(2)
 	}
 
-	sessionID := naming.SessionID()
-	socketDir := os.Getenv("GMUX_SOCKET_DIR")
-	if socketDir == "" {
-		socketDir = "/tmp/gmux-sessions"
+	switch m {
+	case modeHelp:
+		printUsage(os.Stdout)
+		return
+	case modeUI:
+		openUI()
+		return
+	case modeRun:
+		runSession(rest, !f.noAttach)
+		return
+	case modeList:
+		os.Exit(cmdList())
+	case modeKill:
+		os.Exit(cmdKill(rest[0]))
+	case modeTail:
+		os.Exit(cmdTail(rest[0], f.tail))
+	case modeAttach:
+		os.Exit(cmdAttach(rest[0]))
 	}
-	sockPath := filepath.Join(socketDir, sessionID+".sock")
+}
 
-	// Resolve adapter — registered adapters first, shell fallback
-	registry := adapter.NewRegistry()
-	for _, a := range adapters.All {
-		registry.Register(a)
-	}
-	registry.SetFallback(adapters.DefaultFallback())
-	a := registry.Resolve(args)
-
-	// Get adapter-specific env vars
-	adapterEnv := a.Env(adapter.EnvContext{
-		Cwd:        workDir,
-		SessionID:  sessionID,
-		SocketPath: sockPath,
-	})
-
-	// Detect VCS workspace root and remotes for grouping related sessions.
-	wsRoot := workspace.DetectRoot(workDir)
-	remotes := workspace.DetectRemotes(wsRoot)
-
-	// Create in-memory session state
-	state := session.New(session.Config{
-		ID:            sessionID,
-		Command:       args,
-		Cwd:           workDir,
-		Kind:          a.Name(),
-		WorkspaceRoot: wsRoot,
-		Remotes:       remotes,
-		SocketPath:    sockPath,
-		BinaryHash:    binhash.Self(),
-		RunnerVersion: version,
-	})
-
-	// Common env vars — set for every child, per ADR-0005
-	env := []string{
-		"GMUX=1",
-		"GMUX_SOCKET=" + sockPath,
-		"GMUX_SESSION_ID=" + sessionID,
-		"GMUX_ADAPTER=" + a.Name(),
-		"GMUX_RUNNER_VERSION=" + version,
-	}
-	env = append(env, adapterEnv...)
-
-	interactive := localterm.IsInteractive()
-
-	// Determine initial PTY size — use terminal size if interactive
-	ptyCfg := ptyserver.Config{
-		Command:    args,
-		Cwd:        workDir,
-		Env:        env,
-		SocketPath: sockPath,
-		Adapter:    a,
-		State:      state,
-	}
-	// Always try to inherit terminal dimensions from the parent.
-	// Even non-interactive launches (background, piped) benefit from
-	// a real size: the PTY and virtual terminal start correctly sized
-	// instead of falling back to 80x24.
-	if cols, rows, err := localterm.TerminalSize(); err == nil {
-		ptyCfg.Cols = cols
-		ptyCfg.Rows = rows
-	}
-
-	if !interactive {
-		fmt.Printf("session:  %s\n", sessionID)
-		fmt.Printf("adapter:  %s\n", a.Name())
-		fmt.Printf("command:  %s\n", strings.Join(args, " "))
-	}
-
-	// Start PTY server
-	srv, err := ptyserver.New(ptyCfg)
-	if err != nil {
-		log.Fatalf("failed to start: %v", err)
-	}
-
-	state.SetRunning(srv.Pid())
-
-	if !interactive {
-		fmt.Printf("pid:      %d\n", srv.Pid())
-		fmt.Printf("socket:   %s\n", srv.SocketPath())
-		fmt.Println("serving...")
-	}
-
-	// Auto-start gmuxd if not running (one-shot, never retried), then register.
+// openUI implements the bare `gmux` invocation: ensure gmuxd is up,
+// learn its TCP listen address and auth token from /v1/health, and
+// hand those to the local browser.
+func openUI() {
 	ensureGmuxd()
-	go registerWithGmuxd(sessionID, sockPath)
 
-	if interactive {
-		// Transparent mode: attach local terminal to the PTY
-		attach, err := localterm.New(localterm.Config{
-			PTYWriter: ptyWriterFunc(func(p []byte) (int, error) {
-				return srv.WritePTY(p)
-			}),
-			ResizeFn: srv.Resize,
-		})
-		if err != nil {
-			log.Fatalf("failed to attach terminal: %v", err)
-		}
-		srv.SetLocalOutput(attach)
-
-		// In interactive mode:
-		// - SIGHUP → detach local terminal, keep session running
-		// - SIGINT/SIGTERM are consumed by raw mode and forwarded to child via PTY
-		//   (but we still catch them on gmux in case raw mode is somehow bypassed)
-		sigCh := make(chan os.Signal, 1)
-		signal.Notify(sigCh, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM)
-
-		select {
-		case <-srv.Done():
-			// Child exited — detach and exit
-			attach.Detach()
-		case <-attach.Done():
-			// Local terminal gone (stdin closed) — session continues headless
-			srv.SetLocalOutput(nil)
-			// Wait for child to exit (session persists, accessible via web UI)
-			<-srv.Done()
-		case sig := <-sigCh:
-			if sig == syscall.SIGHUP {
-				// Terminal closed — detach, keep session alive
-				attach.Detach()
-				srv.SetLocalOutput(nil)
-				// Continue running headless until child exits
-				<-srv.Done()
-			} else {
-				// SIGINT/SIGTERM — clean shutdown
-				attach.Detach()
-				srv.Shutdown()
-			}
-		}
-	} else {
-		// Non-interactive: original behavior
-		sigCh := make(chan os.Signal, 1)
-		signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
-
-		select {
-		case <-srv.Done():
-			// Child exited
-		case sig := <-sigCh:
-			fmt.Printf("\nreceived %v, shutting down...\n", sig)
-			srv.Shutdown()
-		}
-	}
-
-	exitCode := srv.ExitCode()
-	state.SetExited(exitCode)
-
-	// Deregister from gmuxd (best-effort)
-	deregisterFromGmuxd(sessionID)
-
-	if !interactive {
-		fmt.Printf("exited:   %d\n", exitCode)
-	}
-	os.Exit(exitCode)
-}
-
-// ensureGmuxd checks if gmuxd is reachable and starts it if not.
-// If a daemon is running but reports a different version, it is replaced
-// so the child process always talks to a compatible daemon.
-// Called once at startup — if gmuxd dies later, we don't restart it.
-// Returns true if gmuxd was started (or replaced) by this call.
-func ensureGmuxd() bool {
-	if !gmuxdNeedsStart() {
-		return false
-	}
-
-	gmuxdBin := findGmuxdBin()
-	if gmuxdBin == "" {
-		log.Printf("warning: gmuxd not found (install it alongside gmux or add it to PATH)")
-		return false
-	}
-
-	// gmuxd run starts in the foreground; we background it ourselves.
-	return startGmuxd(gmuxdBin, []string{"run"})
-}
-
-// gmuxdNeedsStart checks the running daemon.
-func gmuxdNeedsStart() bool {
-	// "dev" builds never replace — avoids churn during development.
-	if version == "dev" {
-		return !gmuxdHealthy(500 * time.Millisecond)
-	}
-
+	// Wait for gmuxd to be reachable before opening browser.
 	client := gmuxdClient()
-	client.Timeout = 500 * time.Millisecond
-	resp, err := client.Get(gmuxdBaseURL() + "/v1/health")
-	if err != nil {
-		return true // not running
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return true // not healthy
-	}
-
-	var health struct {
-		Data struct {
-			Version string `json:"version"`
-		} `json:"data"`
-	}
-	body, _ := io.ReadAll(resp.Body)
-	if json.Unmarshal(body, &health) != nil {
-		return false // can't parse, leave it alone
-	}
-
-	// Same version: no action needed. Different version: replace.
-	return health.Data.Version != version
-}
-
-// findGmuxdBin locates the gmuxd binary: sibling first, then PATH.
-func findGmuxdBin() string {
-	if self, err := os.Executable(); err == nil {
-		sibling := filepath.Join(filepath.Dir(self), "gmuxd")
-		if _, err := os.Stat(sibling); err == nil {
-			return sibling
-		}
-	}
-	if p, err := exec.LookPath("gmuxd"); err == nil {
-		return p
-	}
-	return ""
-}
-
-// startGmuxd launches gmuxd in the background with the given args.
-func startGmuxd(gmuxdBin string, args []string) bool {
-	// Log gmuxd output to a file so users can diagnose startup failures.
-	logPath := filepath.Join(os.TempDir(), "gmuxd.log")
-	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
-	if err != nil {
-		logFile = nil
-	}
-
-	cmd := exec.Command(gmuxdBin, args...)
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
-	cmd.Stdout = nil
-	cmd.Stderr = logFile
-	if err := cmd.Start(); err != nil {
-		log.Printf("warning: could not start gmuxd: %v", err)
-		if logFile != nil {
-			logFile.Close()
-		}
-		return false
-	}
-	go func() {
-		cmd.Wait()
-		if logFile != nil {
-			logFile.Close()
-		}
-	}()
-
-	return true
-}
-
-// gmuxdClient returns an HTTP client connected to gmuxd via Unix socket.
-func gmuxdClient() *http.Client {
-	sockPath := paths.SocketPath()
-	return &http.Client{
-		Transport: &http.Transport{
-			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
-				return net.DialTimeout("unix", sockPath, 2*time.Second)
-			},
-		},
-		Timeout: 5 * time.Second,
-	}
-}
-
-// gmuxdBaseURL returns the base URL for gmuxd HTTP requests.
-// The host is ignored by the Unix socket transport.
-func gmuxdBaseURL() string {
-	return "http://localhost"
-}
-
-func gmuxdHealthy(timeout time.Duration) bool {
-	client := gmuxdClient()
-	client.Timeout = timeout
-	resp, err := client.Get(gmuxdBaseURL() + "/v1/health")
-	if err != nil {
-		return false
-	}
-	defer resp.Body.Close()
-	return resp.StatusCode == http.StatusOK
-}
-
-func registerWithGmuxd(sessionID, socketPath string) {
 	baseURL := gmuxdBaseURL()
-
-	payload, _ := json.Marshal(map[string]string{
-		"session_id":  sessionID,
-		"socket_path": socketPath,
-	})
-
-	// Retry a few times — gmux may start before the HTTP server is ready
-	for i := 0; i < 5; i++ {
-		if i > 0 {
-			time.Sleep(500 * time.Millisecond)
-		}
-		client := gmuxdClient()
-		resp, err := client.Post(baseURL+"/v1/register", "application/json", bytes.NewReader(payload))
-		if err != nil {
-			continue
-		}
-		resp.Body.Close()
-		if resp.StatusCode == 200 {
-			return
-		}
-	}
-}
-
-// ptyWriterFunc is an adapter to use a function as an io.Writer.
-type ptyWriterFunc func([]byte) (int, error)
-
-func (f ptyWriterFunc) Write(p []byte) (int, error) { return f(p) }
-
-// openBrowser opens the gmux UI. Prefers Chrome/Chromium in --app mode
-// for a standalone window; falls back to the default browser.
-func openBrowser(url string) {
-
-	// Strategy: default browser if Chromium-based → app mode, else
-	// any installed Chromium → app mode, else system default.
-	if tryDefaultBrowserAppMode(url) {
-		return
-	}
-	if tryAnyChromiumAppMode(url) {
-		return
-	}
-
-	// Fallback: default browser (normal tab).
-	switch runtime.GOOS {
-	case "darwin":
-		exec.Command("open", url).Start()
-	default:
-		exec.Command("xdg-open", url).Start()
-	}
-}
-
-// tryDefaultBrowserAppMode checks if the user's default browser is
-// Chromium-based and launches it in --app mode.
-func tryDefaultBrowserAppMode(url string) bool {
-	switch runtime.GOOS {
-	case "darwin":
-		bundleID := defaultBrowserBundleID()
-		if binary, ok := macOSChromiumBinary(bundleID); ok {
-			return startDetached(exec.Command(binary, "--app="+url))
-		}
-	default:
-		desktop := defaultDesktopBrowser()
-		if isChromiumDesktop(desktop) {
-			// The default browser is Chromium-based — xdg-open won't pass
-			// --app, but the binary should be on PATH with a known name.
-			return tryAnyChromiumAppMode(url)
-		}
-	}
-	return false
-}
-
-// tryAnyChromiumAppMode finds any installed Chromium-based browser and
-// launches it with --app.
-func tryAnyChromiumAppMode(url string) bool {
-	switch runtime.GOOS {
-	case "darwin":
-		// macOS: Chrome.app doesn't put a binary on $PATH.
-		// Check known .app bundle locations directly.
-		home, _ := os.UserHomeDir()
-		appDirs := []string{"/Applications", filepath.Join(home, "Applications")}
-		for _, app := range []string{"Google Chrome", "Chromium"} {
-			for _, dir := range appDirs {
-				binary := filepath.Join(dir, app+".app", "Contents", "MacOS", app)
-				if _, err := os.Stat(binary); err == nil {
-					if startDetached(exec.Command(binary, "--app="+url)) {
-						return true
-					}
-				}
+	var healthBody []byte
+	ready := false
+	for range 15 {
+		if resp, err := client.Get(baseURL + "/v1/health"); err == nil {
+			body, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			if resp.StatusCode == 200 {
+				healthBody = body
+				ready = true
+				break
 			}
 		}
-	default:
-		for _, name := range []string{"google-chrome-stable", "google-chrome", "chromium-browser", "chromium"} {
-			if p, err := exec.LookPath(name); err == nil {
-				if startDetached(exec.Command(p, "--app="+url)) {
-					return true
-				}
-			}
-		}
+		time.Sleep(200 * time.Millisecond)
 	}
-	return false
-}
+	if !ready {
+		log.Fatalf("gmuxd is not running (check %s/gmuxd.log for errors)", os.TempDir())
+	}
 
-// startDetached starts a command in a new session so it outlives gmux.
-func startDetached(cmd *exec.Cmd) bool {
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
-	return cmd.Start() == nil
-}
+	// Parse health response for TCP address and auth token.
+	listenAddr := parseHealthField(healthBody, "listen")
+	token := parseHealthField(healthBody, "auth_token")
 
-// --- default browser detection ---
+	browserURL := "http://" + listenAddr
+	if token != "" {
+		browserURL = fmt.Sprintf("http://%s/auth/login?token=%s", listenAddr, token)
+	}
 
-// defaultBrowserBundleID returns the macOS bundle ID of the default
-// HTTPS handler (e.g. "com.google.chrome"). Returns "" if Safari is
-// the implicit default or detection fails.
-func defaultBrowserBundleID() string {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return ""
+	// Print access URLs.
+	fmt.Fprintf(os.Stderr, "  local:  http://%s\n", listenAddr)
+	if tsURL := parseTailscaleURL(healthBody); tsURL != "" {
+		fmt.Fprintf(os.Stderr, "  remote: %s\n", maskTailscaleURL(tsURL))
 	}
-	plistPath := filepath.Join(home,
-		"Library", "Preferences", "com.apple.LaunchServices",
-		"com.apple.launchservices.secure.plist")
-	out, err := exec.Command("plutil", "-convert", "json", "-o", "-", plistPath).Output()
-	if err != nil {
-		return ""
+	if updateVer := parseUpdateAvailable(healthBody); updateVer != "" {
+		fmt.Fprintf(os.Stderr, "  update: %s available — %s\n", updateVer, upgradeHint())
 	}
-	var plist struct {
-		LSHandlers []struct {
-			URLScheme string `json:"LSHandlerURLScheme"`
-			RoleAll   string `json:"LSHandlerRoleAll"`
-		} `json:"LSHandlers"`
-	}
-	if err := json.Unmarshal(out, &plist); err != nil {
-		return ""
-	}
-	for _, h := range plist.LSHandlers {
-		if strings.EqualFold(h.URLScheme, "https") {
-			return h.RoleAll
-		}
-	}
-	return "" // Safari is implicit default
-}
 
-// macOSChromiumBinary maps a bundle ID to its binary path if it's a
-// known Chromium-based browser.
-func macOSChromiumBinary(bundleID string) (string, bool) {
-	// Map bundle IDs → .app names for known Chromium-based browsers.
-	appNames := map[string]string{
-		"com.google.chrome":          "Google Chrome",
-		"org.chromium.chromium":      "Chromium",
-		"company.thebrowser.browser": "Arc",
-		"com.brave.browser":          "Brave Browser",
-		"com.microsoft.edgemac":      "Microsoft Edge",
-	}
-	appName, ok := appNames[strings.ToLower(bundleID)]
-	if !ok {
-		return "", false
-	}
-	home, _ := os.UserHomeDir()
-	for _, dir := range []string{"/Applications", filepath.Join(home, "Applications")} {
-		binary := filepath.Join(dir, appName+".app", "Contents", "MacOS", appName)
-		if _, err := os.Stat(binary); err == nil {
-			return binary, true
-		}
-	}
-	return "", false
-}
-
-// defaultDesktopBrowser returns the .desktop file name of the default
-// web browser on Linux (e.g. "google-chrome.desktop").
-func defaultDesktopBrowser() string {
-	out, err := exec.Command("xdg-settings", "get", "default-web-browser").Output()
-	if err != nil {
-		return ""
-	}
-	return strings.TrimSpace(string(out))
-}
-
-// isChromiumDesktop returns true if the .desktop name looks Chromium-based.
-func isChromiumDesktop(desktop string) bool {
-	d := strings.ToLower(desktop)
-	return strings.Contains(d, "chrome") || strings.Contains(d, "chromium")
-}
-
-// parseHealthField extracts a string field from the data object
-// of a /v1/health JSON response.
-func parseHealthField(body []byte, field string) string {
-	var resp struct {
-		Data map[string]json.RawMessage `json:"data"`
-	}
-	if json.Unmarshal(body, &resp) != nil {
-		return ""
-	}
-	raw, ok := resp.Data[field]
-	if !ok {
-		return ""
-	}
-	var val string
-	if json.Unmarshal(raw, &val) != nil {
-		return ""
-	}
-	return val
-}
-
-// parseTailscaleURL extracts the tailscale_url from a /v1/health JSON response.
-func parseTailscaleURL(body []byte) string {
-	var resp struct {
-		Data struct {
-			TailscaleURL string `json:"tailscale_url"`
-		} `json:"data"`
-	}
-	if json.Unmarshal(body, &resp) == nil {
-		return resp.Data.TailscaleURL
-	}
-	return ""
-}
-
-// parseUpdateAvailable extracts update_available from a /v1/health JSON response.
-func parseUpdateAvailable(body []byte) string {
-	var resp struct {
-		Data struct {
-			UpdateAvailable string `json:"update_available"`
-		} `json:"data"`
-	}
-	if json.Unmarshal(body, &resp) == nil {
-		return resp.Data.UpdateAvailable
-	}
-	return ""
-}
-
-// upgradeHint returns the appropriate upgrade command based on how gmux was installed.
-func upgradeHint() string {
-	self, err := os.Executable()
-	if err != nil {
-		return "curl -sSfL https://gmux.app/install.sh | sh"
-	}
-	// Resolve symlinks to find the real binary location
-	real, err := filepath.EvalSymlinks(self)
-	if err != nil {
-		real = self
-	}
-	// Check if we're inside a Homebrew prefix
-	if strings.Contains(real, "/Cellar/") || strings.Contains(real, "/homebrew/") {
-		return "brew upgrade gmuxapp/tap/gmux"
-	}
-	return "curl -sSfL https://gmux.app/install.sh | sh"
-}
-
-// maskTailscaleURL masks the tailnet name for privacy.
-// "https://gmux.angler-map.ts.net" → "https://gmux.an******.ts.net"
-func maskTailscaleURL(url string) string {
-	// Find the tailnet part: between first dot after hostname and .ts.net
-	tsNet := ".ts.net"
-	idx := strings.Index(url, tsNet)
-	if idx < 0 {
-		return url
-	}
-	// Find the start of the tailnet name (after "https://gmux.")
-	schemeEnd := strings.Index(url, "://")
-	if schemeEnd < 0 {
-		return url
-	}
-	hostStart := schemeEnd + 3
-	// Find first dot after the hostname prefix
-	dotIdx := strings.Index(url[hostStart:], ".")
-	if dotIdx < 0 {
-		return url
-	}
-	tailnetStart := hostStart + dotIdx + 1
-	tailnetName := url[tailnetStart:idx]
-	if len(tailnetName) <= 2 {
-		return url
-	}
-	masked := tailnetName[:2] + "****"
-	return url[:tailnetStart] + masked + url[idx:]
-}
-
-func deregisterFromGmuxd(sessionID string) {
-	baseURL := gmuxdBaseURL()
-
-	payload, _ := json.Marshal(map[string]string{"session_id": sessionID})
-	client := gmuxdClient()
-	resp, err := client.Post(baseURL+"/v1/deregister", "application/json", bytes.NewReader(payload))
-	if err != nil {
-		return
-	}
-	resp.Body.Close()
+	openBrowser(browserURL)
 }

--- a/cli/gmux/cmd/gmux/run.go
+++ b/cli/gmux/cmd/gmux/run.go
@@ -1,0 +1,251 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	"github.com/gmuxapp/gmux/cli/gmux/internal/binhash"
+	"github.com/gmuxapp/gmux/cli/gmux/internal/localterm"
+	"github.com/gmuxapp/gmux/cli/gmux/internal/naming"
+	"github.com/gmuxapp/gmux/cli/gmux/internal/ptyserver"
+	"github.com/gmuxapp/gmux/cli/gmux/internal/session"
+	"github.com/gmuxapp/gmux/packages/adapter"
+	"github.com/gmuxapp/gmux/packages/adapter/adapters"
+	"github.com/gmuxapp/gmux/packages/workspace"
+)
+
+// runSession launches a new managed session for the given command.
+//
+// When attach is true and stdin is a tty, the local terminal is wired
+// to the PTY so the command behaves transparently (the default). When
+// attach is false, the session is spawned detached from the tty and
+// this call returns immediately once the session is running, leaving
+// the session visible in the gmux UI.
+func runSession(args []string, attach bool) {
+	// Nested gmux detection: if we're running interactively inside an
+	// existing gmux session, re-exec as a detached headless process instead
+	// of doing PTY passthrough (which would nest PTY-within-PTY). The
+	// detached process registers with gmuxd and the session appears in the
+	// gmux UI. The original process returns immediately to the parent shell.
+	if os.Getenv("GMUX") == "1" && localterm.IsInteractive() {
+		spawnDetached(args, "started "+strings.Join(args, " ")+" in background (visible in gmux)")
+		return
+	}
+
+	// Explicit --no-attach: spawn detached and return immediately, whether
+	// or not we're inside another gmux session. The session registers with
+	// gmuxd on its own.
+	if !attach {
+		spawnDetached(args, "started "+strings.Join(args, " ")+" in background (visible in gmux)")
+		return
+	}
+
+	workDir, err := os.Getwd()
+	if err != nil {
+		log.Fatalf("cannot determine cwd: %v", err)
+	}
+
+	sessionID := naming.SessionID()
+	socketDir := os.Getenv("GMUX_SOCKET_DIR")
+	if socketDir == "" {
+		socketDir = "/tmp/gmux-sessions"
+	}
+	sockPath := filepath.Join(socketDir, sessionID+".sock")
+
+	// Resolve adapter — registered adapters first, shell fallback
+	registry := adapter.NewRegistry()
+	for _, a := range adapters.All {
+		registry.Register(a)
+	}
+	registry.SetFallback(adapters.DefaultFallback())
+	a := registry.Resolve(args)
+
+	// Get adapter-specific env vars
+	adapterEnv := a.Env(adapter.EnvContext{
+		Cwd:        workDir,
+		SessionID:  sessionID,
+		SocketPath: sockPath,
+	})
+
+	// Detect VCS workspace root and remotes for grouping related sessions.
+	wsRoot := workspace.DetectRoot(workDir)
+	remotes := workspace.DetectRemotes(wsRoot)
+
+	// Create in-memory session state
+	state := session.New(session.Config{
+		ID:            sessionID,
+		Command:       args,
+		Cwd:           workDir,
+		Kind:          a.Name(),
+		WorkspaceRoot: wsRoot,
+		Remotes:       remotes,
+		SocketPath:    sockPath,
+		BinaryHash:    binhash.Self(),
+		RunnerVersion: version,
+	})
+
+	// Common env vars — set for every child, per ADR-0005
+	env := []string{
+		"GMUX=1",
+		"GMUX_SOCKET=" + sockPath,
+		"GMUX_SESSION_ID=" + sessionID,
+		"GMUX_ADAPTER=" + a.Name(),
+		"GMUX_RUNNER_VERSION=" + version,
+	}
+	env = append(env, adapterEnv...)
+
+	interactive := localterm.IsInteractive()
+
+	// Determine initial PTY size — use terminal size if interactive
+	ptyCfg := ptyserver.Config{
+		Command:    args,
+		Cwd:        workDir,
+		Env:        env,
+		SocketPath: sockPath,
+		Adapter:    a,
+		State:      state,
+	}
+	// Always try to inherit terminal dimensions from the parent.
+	// Even non-interactive launches (background, piped) benefit from
+	// a real size: the PTY and virtual terminal start correctly sized
+	// instead of falling back to 80x24.
+	if cols, rows, err := localterm.TerminalSize(); err == nil {
+		ptyCfg.Cols = cols
+		ptyCfg.Rows = rows
+	}
+
+	if !interactive {
+		fmt.Printf("session:  %s\n", sessionID)
+		fmt.Printf("adapter:  %s\n", a.Name())
+		fmt.Printf("command:  %s\n", strings.Join(args, " "))
+	}
+
+	// Start PTY server
+	srv, err := ptyserver.New(ptyCfg)
+	if err != nil {
+		log.Fatalf("failed to start: %v", err)
+	}
+
+	state.SetRunning(srv.Pid())
+
+	if !interactive {
+		fmt.Printf("pid:      %d\n", srv.Pid())
+		fmt.Printf("socket:   %s\n", srv.SocketPath())
+		fmt.Println("serving...")
+	}
+
+	// Auto-start gmuxd if not running (one-shot, never retried), then register.
+	ensureGmuxd()
+	go registerWithGmuxd(sessionID, sockPath)
+
+	if interactive {
+		// Transparent mode: attach local terminal to the PTY
+		attach, err := localterm.New(localterm.Config{
+			PTYWriter: ptyWriterFunc(func(p []byte) (int, error) {
+				return srv.WritePTY(p)
+			}),
+			ResizeFn: srv.Resize,
+		})
+		if err != nil {
+			log.Fatalf("failed to attach terminal: %v", err)
+		}
+		srv.SetLocalOutput(attach)
+
+		// In interactive mode:
+		// - SIGHUP → detach local terminal, keep session running
+		// - SIGINT/SIGTERM are consumed by raw mode and forwarded to child via PTY
+		//   (but we still catch them on gmux in case raw mode is somehow bypassed)
+		sigCh := make(chan os.Signal, 1)
+		signal.Notify(sigCh, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM)
+
+		select {
+		case <-srv.Done():
+			// Child exited — detach and exit
+			attach.Detach()
+		case <-attach.Done():
+			// Local terminal gone (stdin closed) — session continues headless
+			srv.SetLocalOutput(nil)
+			// Wait for child to exit (session persists, accessible via web UI)
+			<-srv.Done()
+		case sig := <-sigCh:
+			if sig == syscall.SIGHUP {
+				// Terminal closed — detach, keep session alive
+				attach.Detach()
+				srv.SetLocalOutput(nil)
+				// Continue running headless until child exits
+				<-srv.Done()
+			} else {
+				// SIGINT/SIGTERM — clean shutdown
+				attach.Detach()
+				srv.Shutdown()
+			}
+		}
+	} else {
+		// Non-interactive: original behavior
+		sigCh := make(chan os.Signal, 1)
+		signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+
+		select {
+		case <-srv.Done():
+			// Child exited
+		case sig := <-sigCh:
+			fmt.Printf("\nreceived %v, shutting down...\n", sig)
+			srv.Shutdown()
+		}
+	}
+
+	exitCode := srv.ExitCode()
+	state.SetExited(exitCode)
+
+	// Deregister from gmuxd (best-effort)
+	deregisterFromGmuxd(sessionID)
+
+	if !interactive {
+		fmt.Printf("exited:   %d\n", exitCode)
+	}
+	os.Exit(exitCode)
+}
+
+// spawnDetached re-execs gmux with the given args as a setsid'd
+// background process, disconnected from the current terminal. Used for
+// both --no-attach and nested-gmux scenarios: the child registers with
+// gmuxd and appears in the UI; the parent returns immediately.
+func spawnDetached(args []string, msg string) {
+	self, err := os.Executable()
+	if err != nil {
+		log.Fatalf("cannot find own binary: %v", err)
+	}
+	devNull, err := os.Open(os.DevNull)
+	if err != nil {
+		log.Fatalf("cannot open %s: %v", os.DevNull, err)
+	}
+	defer devNull.Close()
+
+	// args is the command-remainder after gmux flag parsing, so it does
+	// not contain any gmux flags. The detached child sees no gmux flags,
+	// takes the default run path, and — because its stdin is /dev/null —
+	// runs non-interactively without trying to attach.
+	cmd := exec.Command(self, args...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	cmd.Stdin = devNull
+	cmd.Stdout = devNull
+	cmd.Stderr = devNull
+	if err := cmd.Start(); err != nil {
+		log.Fatalf("failed to start background session: %v", err)
+	}
+	cmd.Process.Release()
+	if msg != "" {
+		fmt.Fprintln(os.Stderr, msg)
+	}
+}
+
+// ptyWriterFunc is an adapter to use a function as an io.Writer.
+type ptyWriterFunc func([]byte) (int, error)
+
+func (f ptyWriterFunc) Write(p []byte) (int, error) { return f(p) }

--- a/cli/gmux/internal/ptyserver/ptyserver.go
+++ b/cli/gmux/internal/ptyserver/ptyserver.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -337,6 +338,7 @@ func (s *Server) serve() {
 	// HTTP endpoints (checked first via explicit paths)
 	mux.HandleFunc("GET /meta", s.handleMeta)
 	mux.HandleFunc("GET /scrollback/text", s.handleScrollbackText)
+	mux.HandleFunc("GET /scrollback/tail", s.handleScrollbackTail)
 	mux.HandleFunc("PUT /status", s.handlePutStatus)
 	mux.HandleFunc("PUT /slug", s.handlePutSlug)
 	mux.HandleFunc("GET /events", s.handleEvents)
@@ -381,6 +383,85 @@ func (s *Server) handleScrollbackText(w http.ResponseWriter, r *http.Request) {
 // Caller must hold s.mu.
 func (s *Server) screenText() string {
 	return s.screen.String()
+}
+
+// handleScrollbackTail returns the last N lines of the session's
+// scrollback plus the currently visible screen, as plain text.
+// Intended for `gmux --tail N <id>`: a log-style peek at what's been
+// happening inside a session.
+//
+// N is read from the ?n= query parameter; defaults to 50, capped at
+// maxScrollback + the visible screen height. Trailing blank lines on
+// the visible screen are trimmed so an idle TUI doesn't pad the output
+// with empty rows.
+func (s *Server) handleScrollbackTail(w http.ResponseWriter, r *http.Request) {
+	n := 50
+	if v := r.URL.Query().Get("n"); v != "" {
+		if parsed, err := strconv.Atoi(v); err == nil && parsed > 0 {
+			n = parsed
+		}
+	}
+
+	s.mu.Lock()
+	s.drainScreenLocked()
+	lines := s.scrollbackLinesLocked()
+	s.mu.Unlock()
+
+	if len(lines) > n {
+		lines = lines[len(lines)-n:]
+	}
+
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	for _, line := range lines {
+		w.Write([]byte(line))
+		w.Write([]byte("\n"))
+	}
+}
+
+// scrollbackLinesLocked returns the scrollback history followed by the
+// visible screen as plain-text lines (no ANSI). Trailing blank rows of
+// the visible screen are trimmed. Caller must hold s.mu.
+func (s *Server) scrollbackLinesLocked() []string {
+	var lines []string
+
+	if sb := s.screen.Scrollback(); sb != nil {
+		for _, line := range sb.Lines() {
+			lines = append(lines, plainLine(line))
+		}
+	}
+
+	w, h := s.screen.Width(), s.screen.Height()
+	screenLines := make([]string, h)
+	for y := 0; y < h; y++ {
+		row := make(uv.Line, w)
+		for x := 0; x < w; x++ {
+			if c := s.screen.CellAt(x, y); c != nil {
+				row[x] = *c
+			}
+		}
+		screenLines[y] = plainLine(row)
+	}
+	// Trim trailing empty rows — an idle TUI pads the screen with blanks.
+	end := len(screenLines)
+	for end > 0 && strings.TrimSpace(screenLines[end-1]) == "" {
+		end--
+	}
+	lines = append(lines, screenLines[:end]...)
+	return lines
+}
+
+// plainLine renders a terminal line as plain text (no ANSI styling),
+// right-trimming trailing spaces so short lines don't emit padding.
+func plainLine(line uv.Line) string {
+	var sb strings.Builder
+	for _, c := range line {
+		if c.Content == "" {
+			sb.WriteString(" ")
+		} else {
+			sb.WriteString(c.Content)
+		}
+	}
+	return strings.TrimRight(sb.String(), " ")
 }
 
 func (s *Server) handlePutStatus(w http.ResponseWriter, r *http.Request) {

--- a/cli/gmux/internal/ptyserver/ptyserver_test.go
+++ b/cli/gmux/internal/ptyserver/ptyserver_test.go
@@ -1,9 +1,11 @@
 package ptyserver
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -299,6 +301,74 @@ func TestPTYServerScrollbackReplay(t *testing.T) {
 
 	if !contains(got, "replay-test-output") {
 		t.Errorf("expected scrollback replay to contain 'replay-test-output', got: %q", string(got))
+	}
+}
+
+// TestScrollbackTailEndpoint covers the /scrollback/tail HTTP endpoint
+// used by `gmux --tail N <id>`. It asserts the two properties that
+// users actually rely on: the last N lines are returned in order, and
+// the output is plain text (no ANSI control sequences).
+func TestScrollbackTailEndpoint(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "test.sock")
+
+	// Print 20 distinct, colored lines. The colors matter: if the
+	// endpoint leaks ANSI, our plain-text assertion catches it.
+	script := `for i in $(seq 1 20); do printf '\033[31mline-%02d\033[0m\n' $i; done; sleep 2`
+	srv, err := New(Config{
+		Command:    []string{"bash", "-c", script},
+		Cwd:        "/tmp",
+		SocketPath: sockPath,
+		Cols:       80,
+		Rows:       10, // small viewport forces most lines into scrollback
+	})
+	if err != nil {
+		t.Fatalf("new server: %v", err)
+	}
+	defer srv.Shutdown()
+
+	// Give the child time to emit its 20 lines and the emulator to
+	// process them into scrollback.
+	time.Sleep(500 * time.Millisecond)
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				return net.Dial("unix", sockPath)
+			},
+		},
+		Timeout: 2 * time.Second,
+	}
+
+	// Request the last 5 lines. We expect line-16 .. line-20 in order.
+	resp, err := client.Get("http://session/scrollback/tail?n=5")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	// Plain text: no escape bytes.
+	if bytes.Contains(body, []byte{0x1b}) {
+		t.Errorf("expected plain text, got ANSI: %q", string(body))
+	}
+
+	// Must contain the tail lines and not the earliest ones.
+	got := string(body)
+	for _, want := range []string{"line-16", "line-17", "line-18", "line-19", "line-20"} {
+		if !contains([]byte(got), want) {
+			t.Errorf("missing %q in tail output:\n%s", want, got)
+		}
+	}
+	for _, unwanted := range []string{"line-01", "line-10"} {
+		if contains([]byte(got), unwanted) {
+			t.Errorf("did not expect %q in 5-line tail:\n%s", unwanted, got)
+		}
 	}
 }
 


### PR DESCRIPTION
`gmux` gains session management flags without becoming a subcommand-driven tool. The identity stays "one verb: run" — flags before the command apply to gmux itself; everything after the first positional is the command, verbatim. `--` handles commands that start with a dash.

## New shapes

```
gmux [--no-attach] <cmd> [args]   run a command in a new session
gmux --list                       list known sessions
gmux --attach <id>                reattach to an existing session
gmux --tail <N> <id>              print the last N lines of a session
gmux --kill <id>                  terminate a session
```

Short forms: `-l`, `-a`, `-t`, `-k`. A single `--session`-style selector isn't needed because each action takes its id positionally, same as `screen -r name` / `ssh host`.

## Shape decisions

- **No subcommands.** Adding `gmux tail` would collide with `gmux tail file.log`. Runner-plus-flags is the POSIX convention shared by `env`, `sudo`, `nohup`, `time`, `screen`, `ssh`, `systemd-run` — screen in particular solves the same "run + manage" problem gmux has, using only flags.
- **Management mode vs run mode is implicit.** If any action flag is set, gmux is in management mode and refuses a command. Otherwise, the first positional starts the command and flag parsing stops (stdlib `flag` does this by default). Mutually exclusive action flags are rejected at parse time.
- **`--attach`, `--kill` route through gmuxd** so remote peer sessions work transparently; gmuxd proxies the WS to the owning node. Verified that gmuxd serves `/ws/{id}` on its Unix socket with no auth wrapper (TCP listener is auth-wrapped, Unix socket uses the bare mux).
- **`--tail` talks directly to the session's Unix socket** via a new `GET /scrollback/tail?n=N` endpoint on the ptyserver. Plain-text output (ANSI stripped), scrollback + visible screen, trailing blank rows trimmed. Remote peers are rejected with a clear, case-specific error.
- **`--no-attach` reuses the existing "nested gmux" detached-spawn path**, so a single code path handles both "we're inside another gmux" and "user asked for detach".

## Session references

Any of the following resolves a session, matching what a user would plausibly type:

- The full ID (`sess-abcd1234`) or full slug (`fix-auth`).
- **The short form shown by `--list`** (`abcd1234`) — this was the nonobvious one; without it, copying the first column of `--list` into `--kill` would mysteriously fail to match.
- A unique prefix of any of the above.

Exact matches always beat prefix matches so an unambiguous short id can't be clobbered by a longer one that happens to start with the same characters. Ambiguous prefixes refuse to guess and list the candidates.

Dead sessions are pre-checked before `--attach` so the user sees "session X is not running (open the UI to resume)" instead of a cryptic WebSocket backend-unavailable error.

## Structure

`cli/gmux/cmd/gmux/main.go` used to be one 750-line file holding the entry point, gmuxd plumbing, browser detection, and the session runner. This PR breaks it apart:

- `main.go` — entry point + dispatch + UI mode
- `cli.go` — flag parsing and mode selection (pure function, fully tested)
- `run.go` — runSession + spawnDetached
- `actions.go` — list / kill / tail + session-reference matching
- `attach.go` — WS attach client wired to the existing `localterm`
- `daemon.go` — ensureGmuxd, register/deregister, health parsing
- `browser.go` — Chromium detection + tailnet URL masking

## Tests

- `cli_test.go` — dispatch table covering every valid shape and every user-facing validation (mutually exclusive flags, missing/extra positionals, `--no-attach` without a command, etc.). Asserts modes and flag values, not error strings.
- `actions_test.go` — `matchSession` covers the six shapes a user might type (full id, short form, slug, three kinds of prefix), plus the adversarial cases: ambiguous prefix, exact-beats-prefix, empty ref, empty session list, no match. `shortID` has a small idempotency/defensive table.
- `ptyserver_test.go::TestScrollbackTailEndpoint` — produces 20 colored lines in a 10-row viewport, requests `n=5`, asserts the last 5 arrive in order with no ANSI bytes.

## Docs

`reference/cli.md` updated with the new flags, examples, and the "flags before, command after" rule.

## Compatibility

The one behavior change: gmux now rejects unknown flags before the first positional. In practice this only bites invocations like `gmux --foo bar`, which previously tried to exec a file literally named `--foo` (always failing). Real use (`gmux pytest --watch`, `gmux ./my-script --flag`) is unchanged because the first non-flag positional ends gmux's flag parsing. `--` remains available for the rare case where the command itself starts with a dash.