### PR TITLE
feat(cli): send input to a running session with --send

### DIFF
--- a/apps/website/src/content/docs/reference/cli.md
+++ b/apps/website/src/content/docs/reference/cli.md
@@ -77,6 +77,20 @@ Terminate a running session. Sends the same signal chain the UI's kill button do
 gmux --kill a3f20187
 ```
 
+### `gmux --send <id> [text]`
+
+Inject input into a running session, as if the bytes had been typed at the terminal. When `text` is given inline it is sent verbatim — no trailing newline is added, so you use shell `$'...\n'` (or pipe stdin) to submit:
+
+```bash
+gmux --send a3f20187 $'describe yourself\n'
+echo 'describe yourself' | gmux --send a3f20187   # equivalent
+printf '\x03' | gmux --send a3f20187              # send Ctrl-C
+```
+
+When `text` is omitted, gmux reads from stdin until EOF and sends whatever it sees (capped at 1 MiB). Stdin mode is the natural shape for piping, and avoids shell-escaping headaches for multi-line input.
+
+**Access control.** `--send` is powerful — anything you send lands in the session's PTY, and the child has no way to distinguish it from keyboard input. Access is gated by filesystem permissions on the session's Unix socket (owner-only, `0700`), which means only the user that started the session can send to it. Other users on the same machine cannot connect to the socket at all. For the same reason, `--send` is local-only: cross-machine sending would need an explicit authorization model that doesn't exist yet.
+
 ## gmuxd
 
 The daemon. Manages sessions, serves the web UI, and optionally provides Tailscale remote access.

--- a/cli/gmux/cmd/gmux/actions.go
+++ b/cli/gmux/cmd/gmux/actions.go
@@ -280,6 +280,87 @@ func cmdTail(ref string, n int) int {
 	return 0
 }
 
+// cmdSend implements `gmux --send <id> [text]`.
+//
+// Sends bytes to the session's PTY as if they had been typed at the
+// terminal. When text is provided inline it is sent verbatim (callers
+// who want a trailing newline must include it explicitly, e.g. via
+// `$'hello\n'`). When text is omitted, stdin is read until EOF; this
+// is the natural shape for piping: `echo hello | gmux --send abc`.
+//
+// Access control is delegated to the session socket's file permissions
+// (owner-only, 0o700): if you can connect to the socket you already
+// own the process and could do worse things without going through us.
+// For the same reason we don't support sending to remote peer sessions
+// — doing that safely would require a per-peer authorization model
+// that doesn't exist yet.
+func cmdSend(ref string, text *string) int {
+	sess, err := resolveSession(ref)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "gmux:", err)
+		return 1
+	}
+	if sess.SocketPath == "" {
+		switch {
+		case sess.Peer != "":
+			fmt.Fprintf(os.Stderr, "gmux: --send is only supported for local sessions (%s is on peer %q)\n",
+				shortID(sess.ID), sess.Peer)
+		case !sess.Alive:
+			fmt.Fprintf(os.Stderr, "gmux: session %s is not running\n", shortID(sess.ID))
+		default:
+			fmt.Fprintf(os.Stderr, "gmux: session %s has no socket path\n", shortID(sess.ID))
+		}
+		return 1
+	}
+	if !sess.Alive {
+		fmt.Fprintf(os.Stderr, "gmux: session %s is not running\n", shortID(sess.ID))
+		return 1
+	}
+
+	var body io.Reader
+	if text != nil {
+		body = strings.NewReader(*text)
+	} else {
+		body = io.LimitReader(os.Stdin, maxSendBytes)
+	}
+
+	client := sessionSocketClient(sess.SocketPath)
+	// When reading from stdin, the request body may be paced by the
+	// user or another process; the default 5s client timeout would cut
+	// off legitimately slow inputs. Since the socket is local and the
+	// handler just writes to the PTY, it's fine to let the call run
+	// for as long as stdin keeps producing bytes.
+	client.Timeout = 0
+	req, err := http.NewRequest(http.MethodPost, "http://session/input", body)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "gmux:", err)
+		return 1
+	}
+	req.Header.Set("Content-Type", "application/octet-stream")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "gmux:", err)
+		return 1
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		msg, _ := io.ReadAll(resp.Body)
+		if resp.StatusCode == http.StatusNotFound {
+			fmt.Fprintln(os.Stderr, "gmux: this session's runner is too old for --send (restart it to upgrade)")
+			return 1
+		}
+		fmt.Fprintf(os.Stderr, "gmux: send failed: %s: %s\n", resp.Status, strings.TrimSpace(string(msg)))
+		return 1
+	}
+	return 0
+}
+
+// maxSendBytes caps the number of bytes read from stdin for a single
+// --send invocation. Matches the runner's maxInputBytes so we fail
+// fast on the client side rather than letting the server truncate us.
+const maxSendBytes = 1 << 20 // 1 MiB
+
 // sessionSocketClient builds an HTTP client that dials a session's
 // Unix socket directly. The host portion of URLs passed through this
 // client is ignored — we use "session" by convention.

--- a/cli/gmux/cmd/gmux/cli.go
+++ b/cli/gmux/cmd/gmux/cli.go
@@ -17,6 +17,7 @@ const (
 	modeAttach             // reattach to an existing session
 	modeTail               // dump recent output from a session
 	modeKill               // terminate a session
+	modeSend               // inject input into a running session
 	modeHelp               // print usage and exit
 )
 
@@ -29,6 +30,7 @@ type flags struct {
 	list     bool
 	attach   bool
 	kill     bool
+	send     bool
 	tail     int // >=0 when set (flag default is -1)
 	help     bool
 }
@@ -53,6 +55,7 @@ func parseCLI(args []string) (mode, *flags, []string, error) {
 	fs.BoolVar(&f.attach, "a", false, "reattach to an existing session (short)")
 	fs.BoolVar(&f.kill, "kill", false, "kill a running session")
 	fs.BoolVar(&f.kill, "k", false, "kill a running session (short)")
+	fs.BoolVar(&f.send, "send", false, "send input to a running session")
 	fs.IntVar(&f.tail, "tail", -1, "dump the last N lines of a session")
 	fs.IntVar(&f.tail, "t", -1, "dump the last N lines of a session (short)")
 	fs.BoolVar(&f.help, "help", false, "show help")
@@ -78,14 +81,17 @@ func parseCLI(args []string) (mode, *flags, []string, error) {
 	if f.kill {
 		actions++
 	}
+	if f.send {
+		actions++
+	}
 	if f.tail >= 0 {
 		actions++
 	}
 	if actions > 1 {
-		return modeHelp, nil, nil, errors.New("--list, --attach, --tail, --kill are mutually exclusive")
+		return modeHelp, nil, nil, errors.New("--list, --attach, --tail, --kill, --send are mutually exclusive")
 	}
 
-	// Management actions take a single session id (except --list).
+	// Management actions take a single session id (except --list and --send).
 	switch {
 	case f.list:
 		if len(rest) > 0 {
@@ -111,6 +117,16 @@ func parseCLI(args []string) (mode, *flags, []string, error) {
 			return modeHelp, nil, nil, errors.New("--no-attach has no effect with --kill")
 		}
 		return modeKill, f, rest, nil
+	case f.send:
+		// --send takes a session id and either an inline text arg or
+		// stdin (when no text is given).
+		if len(rest) < 1 || len(rest) > 2 {
+			return modeHelp, nil, nil, errors.New("--send takes a session id and optional text (stdin is used if no text is given)")
+		}
+		if f.noAttach {
+			return modeHelp, nil, nil, errors.New("--no-attach has no effect with --send")
+		}
+		return modeSend, f, rest, nil
 	case f.tail >= 0:
 		if len(rest) != 1 {
 			return modeHelp, nil, nil, errors.New("--tail requires a session id")
@@ -149,6 +165,7 @@ Session management:
   gmux --attach <id>                reattach to an existing session
   gmux --tail <N> <id>              print the last N lines of a session
   gmux --kill <id>                  terminate a session
+  gmux --send <id> [text]           send text (or stdin) to a session
 
 Flags before the command apply to gmux itself. Once the first positional
 argument is seen, everything after is the command to run, verbatim.

--- a/cli/gmux/cmd/gmux/cli_test.go
+++ b/cli/gmux/cmd/gmux/cli_test.go
@@ -87,6 +87,18 @@ func TestParseCLI(t *testing.T) {
 				}
 			},
 		},
+		{
+			name:     "--send with inline text",
+			args:     []string{"--send", "sess-abcd", "hello"},
+			wantMode: modeSend,
+			wantRest: []string{"sess-abcd", "hello"},
+		},
+		{
+			name:     "--send without text reads stdin",
+			args:     []string{"--send", "sess-abcd"},
+			wantMode: modeSend,
+			wantRest: []string{"sess-abcd"},
+		},
 	}
 
 	for _, tc := range tests {
@@ -116,17 +128,21 @@ func TestParseCLI(t *testing.T) {
 // free to improve), only that an error is returned in each case.
 func TestParseCLIErrors(t *testing.T) {
 	invalid := [][]string{
-		{"--list", "extra"},              // --list takes no args
-		{"--attach"},                     // --attach needs an id
-		{"--attach", "a", "b"},           // --attach takes exactly one id
-		{"--kill"},                       // --kill needs an id
-		{"--tail", "100"},                // --tail needs an id
-		{"--tail", "0", "sess-a"},        // --tail needs a positive count
-		{"--list", "--attach", "sess-a"}, // mutually exclusive actions
-		{"--kill", "--attach", "sess-a"}, // mutually exclusive actions
-		{"--no-attach"},                  // --no-attach needs a command
-		{"--no-attach", "--list"},        // --no-attach doesn't make sense with --list
+		{"--list", "extra"},                      // --list takes no args
+		{"--attach"},                             // --attach needs an id
+		{"--attach", "a", "b"},                   // --attach takes exactly one id
+		{"--kill"},                               // --kill needs an id
+		{"--tail", "100"},                        // --tail needs an id
+		{"--tail", "0", "sess-a"},                // --tail needs a positive count
+		{"--send"},                               // --send needs an id
+		{"--send", "a", "b", "c"},                // --send takes at most two args
+		{"--list", "--attach", "sess-a"},         // mutually exclusive actions
+		{"--kill", "--attach", "sess-a"},         // mutually exclusive actions
+		{"--send", "--kill", "sess-a"},           // mutually exclusive actions
+		{"--no-attach"},                          // --no-attach needs a command
+		{"--no-attach", "--list"},                // --no-attach doesn't make sense with --list
 		{"--no-attach", "--attach", "sess-a"},
+		{"--no-attach", "--send", "sess-a", "x"}, // --no-attach doesn't make sense with --send
 	}
 
 	for _, args := range invalid {

--- a/cli/gmux/cmd/gmux/main.go
+++ b/cli/gmux/cmd/gmux/main.go
@@ -45,6 +45,12 @@ func main() {
 		os.Exit(cmdTail(rest[0], f.tail))
 	case modeAttach:
 		os.Exit(cmdAttach(rest[0]))
+	case modeSend:
+		var text *string
+		if len(rest) == 2 {
+			text = &rest[1]
+		}
+		os.Exit(cmdSend(rest[0], text))
 	}
 }
 

--- a/cli/gmux/internal/ptyserver/ptyserver.go
+++ b/cli/gmux/internal/ptyserver/ptyserver.go
@@ -339,6 +339,7 @@ func (s *Server) serve() {
 	mux.HandleFunc("GET /meta", s.handleMeta)
 	mux.HandleFunc("GET /scrollback/text", s.handleScrollbackText)
 	mux.HandleFunc("GET /scrollback/tail", s.handleScrollbackTail)
+	mux.HandleFunc("POST /input", s.handleInput)
 	mux.HandleFunc("PUT /status", s.handlePutStatus)
 	mux.HandleFunc("PUT /slug", s.handlePutSlug)
 	mux.HandleFunc("GET /events", s.handleEvents)
@@ -462,6 +463,35 @@ func plainLine(line uv.Line) string {
 		}
 	}
 	return strings.TrimRight(sb.String(), " ")
+}
+
+// maxInputBytes caps the size of a single POST /input request body.
+// The socket is owner-only, so this isn't a trust boundary — it just
+// keeps a well-meaning `gmux --send` invocation from accidentally
+// exhausting memory if someone pipes a huge file into it.
+const maxInputBytes = 1 << 20 // 1 MiB
+
+// handleInput writes the request body straight to the child PTY, as if
+// the bytes had been typed at the terminal. Backs `gmux --send`.
+//
+// Access control is delegated to the Unix socket's file permissions
+// (owner-only, 0o700): anyone who can connect() to this socket already
+// owns the session and could do arbitrary worse things to it.
+func (s *Server) handleInput(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxInputBytes))
+	if err != nil {
+		http.Error(w, "read error", http.StatusBadRequest)
+		return
+	}
+	if len(body) == 0 {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	if _, err := s.ptmx.Write(body); err != nil {
+		http.Error(w, "write pty: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func (s *Server) handlePutStatus(w http.ResponseWriter, r *http.Request) {

--- a/cli/gmux/internal/ptyserver/ptyserver_test.go
+++ b/cli/gmux/internal/ptyserver/ptyserver_test.go
@@ -230,6 +230,117 @@ done:
 	<-srv.Done()
 }
 
+// TestInputEndpoint covers `POST /input` — the HTTP shortcut used by
+// `gmux --send`. The contract is simple: bytes in the body reach the
+// child's stdin as if typed. We exercise that by having the child
+// read a line and echo it back; if the POST path works, the echo
+// appears in the WS stream.
+//
+// This doubles as a regression test for the access-control model: the
+// endpoint is on the session's owner-only Unix socket, and the fact
+// that the test can hit it at all means we correctly didn't add any
+// auth wrapper that would break local callers.
+func TestInputEndpoint(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "test.sock")
+
+	srv, err := New(Config{
+		Command:    []string{"bash", "-c", "read line; echo got:$line"},
+		Cwd:        "/tmp",
+		SocketPath: sockPath,
+	})
+	if err != nil {
+		t.Fatalf("new server: %v", err)
+	}
+	defer srv.Shutdown()
+
+	// Give the child a moment to issue its read() syscall before we
+	// deliver bytes. Without this the bytes arrive before the read
+	// is posted and get dropped by the tty canonical mode buffer on
+	// some kernels.
+	time.Sleep(100 * time.Millisecond)
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				return net.Dial("unix", sockPath)
+			},
+		},
+		Timeout: 2 * time.Second,
+	}
+
+	resp, err := client.Post("http://session/input", "application/octet-stream",
+		bytes.NewReader([]byte("hello\n")))
+	if err != nil {
+		t.Fatalf("post /input: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", resp.StatusCode)
+	}
+
+	// Observe the child's echo via a WS attach. We intentionally don't
+	// mix channels — posting via HTTP and observing via WS — because
+	// that's also what `gmux --send` does (POST) while another client
+	// (the web UI or `gmux --attach`) reads (WS).
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	conn, _, err := websocket.Dial(ctx, "ws://localhost/", &websocket.DialOptions{
+		HTTPClient: client,
+	})
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close(websocket.StatusNormalClosure, "")
+
+	var got []byte
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		_, data, err := conn.Read(ctx)
+		if err != nil {
+			break
+		}
+		got = append(got, data...)
+		if contains(got, "got:hello") {
+			return
+		}
+	}
+	t.Errorf("expected 'got:hello' in output, got: %q", string(got))
+}
+
+// TestInputEndpointEmpty covers the degenerate case: POSTing nothing
+// must succeed without writing anything to the PTY. Matters because a
+// user piping an empty file into `gmux --send` should be a no-op,
+// not a 500.
+func TestInputEndpointEmpty(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "test.sock")
+	srv, err := New(Config{
+		Command:    []string{"bash", "-c", "sleep 1"},
+		Cwd:        "/tmp",
+		SocketPath: sockPath,
+	})
+	if err != nil {
+		t.Fatalf("new server: %v", err)
+	}
+	defer srv.Shutdown()
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				return net.Dial("unix", sockPath)
+			},
+		},
+		Timeout: time.Second,
+	}
+	resp, err := client.Post("http://session/input", "application/octet-stream", bytes.NewReader(nil))
+	if err != nil {
+		t.Fatalf("post /input: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Errorf("status = %d, want 204", resp.StatusCode)
+	}
+}
+
 func TestPTYServerCleanup(t *testing.T) {
 	sockPath := filepath.Join(t.TempDir(), "test.sock")
 


### PR DESCRIPTION
Adds `gmux --send <id> [text]` for injecting keystrokes/text into a running session's PTY. Useful for scripted interaction with agent sessions ("type this prompt", "press enter", "send Ctrl-C") from outside the web UI.

## Shape

```bash
gmux --send a3f20187 $'describe yourself\n'    # inline, shell handles escapes
echo 'describe yourself' | gmux --send a3f2    # stdin mode
printf '\x03' | gmux --send a3f2               # send Ctrl-C
```

- Inline text is sent verbatim, no auto-newline (callers include `\n` explicitly via `$'...\n'` or a pipe).
- Without an inline arg, gmux reads stdin until EOF (capped at 1 MiB).
- Session references follow the same rules as other management flags: full ID, short form shown by `--list`, full slug, or a unique prefix of any of these.

## Security model

`--send` is powerful — bytes land in the session's PTY indistinguishable from real keyboard input. Access is delegated to the session socket's filesystem permissions (`0700`, owner-only, created via `syscall.Umask(0o077)` when the runner starts). That means:

- Only the user who started the session can `connect()` to the socket. Other local users get `EACCES` from the kernel.
- The server-side handler has **no auth wrapper** — it can't — and that's fine: if you can reach the socket you already own the child process and could do worse things directly.
- Remote peer sessions are rejected outright. Cross-machine sending would need an explicit per-peer authorization model that doesn't exist yet; silently proxying through gmuxd would be genuinely dangerous. Clear error: "is only supported for local sessions (X is on peer Y)".

The 1 MiB server-side `LimitReader` on `/input` is not a trust boundary, just ergonomics — a bounded-size failure mode if someone pipes a huge file through by accident.

## Implementation

- **`POST /input` on the session's Unix socket.** New handler on the ptyserver: read up to 1 MiB from the body, write it straight to the PTY master, return 204. Same socket and access-control regime as the existing `POST /kill`, `PUT /status`, and `GET /scrollback/*` endpoints.
- **CLI flag + dispatch.** `--send` joins the management action set (mutually exclusive with `--list/--attach/--tail/--kill`). Accepts 1 or 2 positionals.
- **Client timeout disabled.** The shared `sessionSocketClient` has a 5s timeout for quick GETs (`--tail`); `--send` explicitly clears it because stdin can be legitimately slow.

## Tests

- `TestInputEndpoint` — end-to-end round-trip: child runs `read line; echo got:$line`, `POST /input` with body `hello\n`, then connect via WS and assert `got:hello` appears in the output. Demonstrates that the endpoint (a) reaches the child's stdin, (b) is accessible without any auth layer (which would break local callers), (c) integrates cleanly with the existing WS attach path used by the UI.
- `TestInputEndpointEmpty` — posting an empty body returns 204, not 500. Matters because a user piping an empty file into `gmux --send` should be a silent no-op.
- `TestParseCLI` / `TestParseCLIErrors` — two new happy-path cases (inline text, stdin) and four new validation cases (missing id, too many args, mutual-exclusion with `--kill`, mutual-exclusion with `--no-attach`).

## Docs

`reference/cli.md` gets a new section explaining the shapes, three usage examples (inline, pipe, Ctrl-C via `printf`), and a short "Access control" paragraph that makes the local-only scope explicit instead of leaving it as a surprise.