### PR TITLE
feat(web): improve mobile toolbar with dedicated arrow keys and shift

### DIFF
--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -193,30 +193,35 @@ function MobileTerminalBar({
   ctrlArmed,
   altArmed,
   shiftArmed,
+  metaArmed,
   onMenu,
   onSend,
   onPaste,
   onToggleCtrl,
   onToggleAlt,
   onToggleShift,
+  onToggleMeta,
   onFocusTerminal,
 }: {
   canSend: boolean
   ctrlArmed: boolean
   altArmed: boolean
   shiftArmed: boolean
+  metaArmed: boolean
   onMenu: () => void
   onSend: (data: string) => void
   onPaste: () => void
   onToggleCtrl: () => void
   onToggleAlt: () => void
   onToggleShift: () => void
+  onToggleMeta: () => void
   onFocusTerminal: () => void
 }) {
   // Read signals directly; no props needed for these.
   const bgActivity: DotState = backgroundActivity.value
   const unread = unreadCount.value
   const arrival = useArrivalPulse(bgActivity, unread)
+  const hostOs = health.value?.os
 
   const keepFocus = (ev: Event) => ev.preventDefault()
   const tap = (seq: string) => { onSend(seq); onFocusTerminal() }
@@ -277,15 +282,17 @@ function MobileTerminalBar({
         >
           ctrl
         </button>
-        <button
-          class={`mobile-bottom-action ${showCtrl ? 'armed' : ''}`}
-          disabled={!canSend}
-          onClick={() => { if (holdWordMode) { clearHold(); } else { onToggleCtrl(); } onFocusTerminal() }}
-          title={showCtrl ? '⌘ armed for next typed key' : 'Arm ⌘ for next typed key'}
-          aria-pressed={showCtrl}
-        >
-          ⌘
-        </button>
+        {hostOs && hostOs !== 'windows' && !macCommandIsCtrl.value && (
+          <button
+            class={`mobile-bottom-action ${metaArmed ? 'armed' : ''}`}
+            disabled={!canSend}
+            onClick={() => { onToggleMeta(); onFocusTerminal() }}
+            title={metaArmed ? (hostOs === 'darwin' ? '⌘' : 'Meta') + ' armed for next typed key' : 'Arm ' + (hostOs === 'darwin' ? '⌘' : 'Meta') + ' for next typed key'}
+            aria-pressed={metaArmed}
+          >
+            {hostOs === 'darwin' ? '⌘' : 'meta'}
+          </button>
+        )}
         <button
           class={`mobile-bottom-action ${altArmed ? 'armed' : ''}`}
           disabled={!canSend}
@@ -369,6 +376,7 @@ function App() {
   const [ctrlArmed, setCtrlArmed] = useState(false)
   const [altArmed, setAltArmed] = useState(false)
   const [shiftArmed, setShiftArmed] = useState(false)
+  const [metaArmed, setMetaArmed] = useState(false)
 
   const terminalInputRef = useRef<((data: string) => void) | null>(null)
   const terminalFocusRef = useRef<(() => void) | null>(null)
@@ -408,6 +416,7 @@ function App() {
     setCtrlArmed(false)
     setAltArmed(false)
     setShiftArmed(false)
+    setMetaArmed(false)
     requestAnimationFrame(() => terminalFocusRef.current?.())
   }, [selId])
 
@@ -433,7 +442,7 @@ function App() {
 
   // Clear modifiers when terminal isn't attachable.
   useEffect(() => {
-    if (!canAttach) { setCtrlArmed(false); setAltArmed(false); setShiftArmed(false) }
+    if (!canAttach) { setCtrlArmed(false); setAltArmed(false); setShiftArmed(false); setMetaArmed(false) }
   }, [canAttach])
 
   // ── Terminal callbacks ──
@@ -470,6 +479,11 @@ function App() {
     setShiftArmed(armed => !armed)
   }, [canAttach])
   const handleShiftConsumed = useCallback(() => { setShiftArmed(false) }, [])
+  const handleToggleMeta = useCallback(() => {
+    if (!canAttach) return
+    setMetaArmed(armed => !armed)
+  }, [canAttach])
+  const handleMetaConsumed = useCallback(() => { setMetaArmed(false) }, [])
 
   return (
     <div class="app-layout">
@@ -530,6 +544,8 @@ function App() {
             onAltConsumed={handleAltConsumed}
             shiftArmed={shiftArmed}
             onShiftConsumed={handleShiftConsumed}
+            metaArmed={metaArmed}
+            onMetaConsumed={handleMetaConsumed}
             onInputReady={handleTerminalInputReady}
             onPasteReady={handleTerminalPasteReady}
             onFocusReady={handleTerminalFocusReady}
@@ -547,12 +563,14 @@ function App() {
           ctrlArmed={ctrlArmed}
           altArmed={altArmed}
           shiftArmed={shiftArmed}
+          metaArmed={metaArmed}
           onMenu={() => setSidebarOpen(true)}
           onSend={handleMobileInput}
           onPaste={handleMobilePaste}
           onToggleCtrl={handleToggleCtrl}
           onToggleAlt={handleToggleAlt}
           onToggleShift={handleToggleShift}
+          onToggleMeta={handleToggleMeta}
           onFocusTerminal={handleFocusTerminal}
         />
       </div>

--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -192,21 +192,25 @@ function MobileTerminalBar({
   canSend,
   ctrlArmed,
   altArmed,
+  shiftArmed,
   onMenu,
   onSend,
   onPaste,
   onToggleCtrl,
   onToggleAlt,
+  onToggleShift,
   onFocusTerminal,
 }: {
   canSend: boolean
   ctrlArmed: boolean
   altArmed: boolean
+  shiftArmed: boolean
   onMenu: () => void
   onSend: (data: string) => void
   onPaste: () => void
   onToggleCtrl: () => void
   onToggleAlt: () => void
+  onToggleShift: () => void
   onFocusTerminal: () => void
 }) {
   // Read signals directly; no props needed for these.
@@ -262,14 +266,8 @@ function MobileTerminalBar({
       </button>
       <div class="mobile-bottom-sep" />
       <div class="mobile-terminal-actions" role="toolbar" aria-label="Terminal keys" onMouseDown={keepFocus}>
-        {(ctrlArmed || altArmed)
-          ? <button class="mobile-bottom-action" disabled={!canSend} onClick={() => tap('\x1b[A')} title="Up arrow"><IconUp /></button>
-          : <button class="mobile-bottom-action" disabled={!canSend} onClick={() => tap('\x1b')} title="Escape">esc</button>
-        }
-        {(ctrlArmed || altArmed)
-          ? <button class="mobile-bottom-action" disabled={!canSend} onClick={() => tap('\x1b[B')} title="Down arrow"><IconDown /></button>
-          : <button class="mobile-bottom-action" disabled={!canSend} onClick={() => tap('\t')} title="Tab">tab</button>
-        }
+        <button class="mobile-bottom-action" disabled={!canSend} onClick={() => tap('\x1b')} title="Escape">esc</button>
+        <button class="mobile-bottom-action" disabled={!canSend} onClick={() => tap('\t')} title="Tab">tab</button>
         <button
           class={`mobile-bottom-action ${showCtrl ? 'armed' : ''}`}
           disabled={!canSend}
@@ -288,6 +286,17 @@ function MobileTerminalBar({
         >
           alt
         </button>
+        <button
+          class={`mobile-bottom-action ${shiftArmed ? 'armed' : ''}`}
+          disabled={!canSend}
+          onClick={() => { onToggleShift(); onFocusTerminal() }}
+          title={shiftArmed ? 'Shift armed for next typed key' : 'Arm Shift for next typed key'}
+          aria-pressed={shiftArmed}
+        >
+          shift
+        </button>
+        <button class="mobile-bottom-action" disabled={!canSend} onClick={() => tap('\x1b[A')} title="Up arrow"><IconUp /></button>
+        <button class="mobile-bottom-action" disabled={!canSend} onClick={() => tap('\x1b[B')} title="Down arrow"><IconDown /></button>
         {([
           { seq: '\x1b[D', wordSeq: '\x1b[1;5D', title: 'Left arrow',  wordTitle: 'Word left',  Icon: IconLeft,  WordIcon: IconWordLeft  },
           { seq: '\x1b[C', wordSeq: '\x1b[1;5C', title: 'Right arrow', wordTitle: 'Word right', Icon: IconRight, WordIcon: IconWordRight },
@@ -304,11 +313,12 @@ function MobileTerminalBar({
             {showCtrl ? <WordIcon /> : <Icon />}
           </button>
         ))}
-        {ctrlArmed
-          ? <button class="mobile-bottom-action" disabled={!canSend} onClick={() => { onPaste(); onFocusTerminal() }} title="Paste from clipboard"><IconPaste /></button>
-          : <button class="mobile-bottom-action send-btn" disabled={!canSend} onClick={() => tap('\r')} title="Send"><IconSend /></button>
-        }
       </div>
+      <div class="mobile-bottom-sep" />
+      {ctrlArmed
+        ? <button class="mobile-bottom-action" disabled={!canSend} onClick={() => { onPaste(); onFocusTerminal() }} title="Paste from clipboard" onMouseDown={keepFocus}><IconPaste /></button>
+        : <button class="mobile-bottom-action send-btn" disabled={!canSend} onClick={() => tap('\r')} title="Send" onMouseDown={keepFocus}><IconSend /></button>
+      }
     </div>
   )
 }
@@ -349,6 +359,7 @@ function App() {
   const [manageProjectsOpen, setManageProjectsOpen] = useState(false)
   const [ctrlArmed, setCtrlArmed] = useState(false)
   const [altArmed, setAltArmed] = useState(false)
+  const [shiftArmed, setShiftArmed] = useState(false)
 
   const terminalInputRef = useRef<((data: string) => void) | null>(null)
   const terminalFocusRef = useRef<(() => void) | null>(null)
@@ -387,6 +398,7 @@ function App() {
     setResumingId(null)
     setCtrlArmed(false)
     setAltArmed(false)
+    setShiftArmed(false)
     requestAnimationFrame(() => terminalFocusRef.current?.())
   }, [selId])
 
@@ -412,7 +424,7 @@ function App() {
 
   // Clear modifiers when terminal isn't attachable.
   useEffect(() => {
-    if (!canAttach) { setCtrlArmed(false); setAltArmed(false) }
+    if (!canAttach) { setCtrlArmed(false); setAltArmed(false); setShiftArmed(false) }
   }, [canAttach])
 
   // ── Terminal callbacks ──
@@ -444,6 +456,11 @@ function App() {
     setAltArmed(armed => !armed)
   }, [canAttach])
   const handleAltConsumed = useCallback(() => { setAltArmed(false) }, [])
+  const handleToggleShift = useCallback(() => {
+    if (!canAttach) return
+    setShiftArmed(armed => !armed)
+  }, [canAttach])
+  const handleShiftConsumed = useCallback(() => { setShiftArmed(false) }, [])
 
   return (
     <div class="app-layout">
@@ -502,6 +519,8 @@ function App() {
             onCtrlConsumed={handleCtrlConsumed}
             altArmed={altArmed}
             onAltConsumed={handleAltConsumed}
+            shiftArmed={shiftArmed}
+            onShiftConsumed={handleShiftConsumed}
             onInputReady={handleTerminalInputReady}
             onPasteReady={handleTerminalPasteReady}
             onFocusReady={handleTerminalFocusReady}
@@ -518,11 +537,13 @@ function App() {
           canSend={canAttach}
           ctrlArmed={ctrlArmed}
           altArmed={altArmed}
+          shiftArmed={shiftArmed}
           onMenu={() => setSidebarOpen(true)}
           onSend={handleMobileInput}
           onPaste={handleMobilePaste}
           onToggleCtrl={handleToggleCtrl}
           onToggleAlt={handleToggleAlt}
+          onToggleShift={handleToggleShift}
           onFocusTerminal={handleFocusTerminal}
         />
       </div>

--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -278,6 +278,15 @@ function MobileTerminalBar({
           ctrl
         </button>
         <button
+          class={`mobile-bottom-action ${showCtrl ? 'armed' : ''}`}
+          disabled={!canSend}
+          onClick={() => { if (holdWordMode) { clearHold(); } else { onToggleCtrl(); } onFocusTerminal() }}
+          title={showCtrl ? '⌘ armed for next typed key' : 'Arm ⌘ for next typed key'}
+          aria-pressed={showCtrl}
+        >
+          ⌘
+        </button>
+        <button
           class={`mobile-bottom-action ${altArmed ? 'armed' : ''}`}
           disabled={!canSend}
           onClick={() => { onToggleAlt(); onFocusTerminal() }}

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -41,6 +41,7 @@ export const defaultLauncher = signal<string>('shell')
 export interface HealthData {
   version: string
   hostname?: string
+  os?: string
   tailscale_url?: string
   update_available?: string
   /** SHA-256 of the gmux runner binary on disk. Compared against

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -1770,6 +1770,13 @@ a.home-host-link:hover {
     gap: 6px;
     min-width: 0;
     flex: 1;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+  }
+
+  .mobile-terminal-actions::-webkit-scrollbar {
+    display: none;
   }
 
   .mobile-bottom-action {
@@ -1837,8 +1844,7 @@ a.home-host-link:hover {
   }
 
   .mobile-terminal-actions .mobile-bottom-action {
-    flex: 1 1 0;
-    min-width: 0;
+    flex: 0 0 auto;
   }
 
   .mobile-bottom-action:active {

--- a/apps/gmux-web/src/terminal.tsx
+++ b/apps/gmux-web/src/terminal.tsx
@@ -191,6 +191,8 @@ export function TerminalView({
   onAltConsumed,
   shiftArmed,
   onShiftConsumed,
+  metaArmed,
+  onMetaConsumed,
   onInputReady,
   onPasteReady,
   onFocusReady,
@@ -205,6 +207,8 @@ export function TerminalView({
   onAltConsumed: () => void
   shiftArmed: boolean
   onShiftConsumed: () => void
+  metaArmed: boolean
+  onMetaConsumed: () => void
   onInputReady?: (send: ((data: string) => void) | null) => void
   onPasteReady?: (paste: ((text: string) => void) | null) => void
   onFocusReady?: (focus: (() => void) | null) => void
@@ -220,6 +224,7 @@ export function TerminalView({
   const ctrlArmedRef = useRef(ctrlArmed)
   const altArmedRef = useRef(altArmed)
   const shiftArmedRef = useRef(shiftArmed)
+  const metaArmedRef = useRef(metaArmed)
   const termIoRef = useRef<ReturnType<typeof createTerminalIO> | null>(null)
   const termEpochRef = useRef(0)
 
@@ -251,6 +256,7 @@ export function TerminalView({
   ctrlArmedRef.current = ctrlArmed
   altArmedRef.current = altArmed
   shiftArmedRef.current = shiftArmed
+  metaArmedRef.current = metaArmed
 
   const queueResize = useCallback((size: TerminalSize) => {
     termIoRef.current?.requestResize(size, termEpochRef.current)
@@ -423,6 +429,22 @@ export function TerminalView({
     }
 
     const sendInput = (data: string) => {
+      if (metaArmedRef.current && data.length === 1) {
+        metaArmedRef.current = false
+        onMetaConsumed()
+        // Synthesize a keyboard event with metaKey so the existing
+        // keyboard handler (keybinds, macCommandIsCtrl) processes it.
+        const ta = term.textarea
+        if (ta) {
+          for (const type of ['keydown', 'keypress', 'keyup'] as const) {
+            ta.dispatchEvent(new KeyboardEvent(type, {
+              key: data, code: `Key${data.toUpperCase()}`,
+              metaKey: true, bubbles: true, cancelable: true,
+            }))
+          }
+        }
+        return
+      }
       if (ctrlArmedRef.current) {
         const ctrlData = ctrlSequenceFor(data)
         if (ctrlData) {

--- a/apps/gmux-web/src/terminal.tsx
+++ b/apps/gmux-web/src/terminal.tsx
@@ -189,6 +189,8 @@ export function TerminalView({
   onCtrlConsumed,
   altArmed,
   onAltConsumed,
+  shiftArmed,
+  onShiftConsumed,
   onInputReady,
   onPasteReady,
   onFocusReady,
@@ -201,6 +203,8 @@ export function TerminalView({
   onCtrlConsumed: () => void
   altArmed: boolean
   onAltConsumed: () => void
+  shiftArmed: boolean
+  onShiftConsumed: () => void
   onInputReady?: (send: ((data: string) => void) | null) => void
   onPasteReady?: (paste: ((text: string) => void) | null) => void
   onFocusReady?: (focus: (() => void) | null) => void
@@ -215,6 +219,7 @@ export function TerminalView({
   const sessionRef = useRef(session)
   const ctrlArmedRef = useRef(ctrlArmed)
   const altArmedRef = useRef(altArmed)
+  const shiftArmedRef = useRef(shiftArmed)
   const termIoRef = useRef<ReturnType<typeof createTerminalIO> | null>(null)
   const termEpochRef = useRef(0)
 
@@ -245,6 +250,7 @@ export function TerminalView({
   sessionRef.current = session
   ctrlArmedRef.current = ctrlArmed
   altArmedRef.current = altArmed
+  shiftArmedRef.current = shiftArmed
 
   const queueResize = useCallback((size: TerminalSize) => {
     termIoRef.current?.requestResize(size, termEpochRef.current)
@@ -430,6 +436,17 @@ export function TerminalView({
         altArmedRef.current = false
         onAltConsumed()
         sendRawInput('\x1b' + data)
+        return
+      }
+      if (shiftArmedRef.current) {
+        shiftArmedRef.current = false
+        onShiftConsumed()
+        // Uppercase single printable chars; leave control sequences alone.
+        if (data.length === 1 && data >= 'a' && data <= 'z') {
+          sendRawInput(data.toUpperCase())
+        } else {
+          sendRawInput(data)
+        }
         return
       }
       sendRawInput(data)
@@ -692,7 +709,7 @@ export function TerminalView({
       termRef.current = null
       termIoRef.current = null
     }
-  }, [onCtrlConsumed, onInputReady])
+  }, [onCtrlConsumed, onShiftConsumed, onInputReady])
 
   // WebSocket connection (reconnects when session.id changes).
   useEffect(() => {

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"syscall"
@@ -581,6 +582,7 @@ func serve(stderr io.Writer) int {
 			"version": version,
 			"node_id": "node-local",
 			"status":  "ready",
+			"os":      runtime.GOOS,
 		}
 		if h, err := os.Hostname(); err == nil {
 			data["hostname"] = h


### PR DESCRIPTION
## Summary
- Add always-visible **up/down arrow** buttons (no longer hidden behind ctrl/alt toggle)
- Add **shift** modifier button for uppercase letters and shift+key combos
- **Pin** hamburger menu (left) and send button (right); make middle buttons **horizontally scrollable** for small screens
- Move send/paste button outside the scrollable area so it's always reachable

Closes #163

## Test plan
- [ ] Open web UI on a phone or with touch device emulation
- [ ] Verify all buttons visible: esc, tab, ctrl, alt, shift, ↑, ↓, ←, →
- [ ] Scroll the middle button row left/right on a narrow screen
- [ ] Tap shift, then type a letter — verify uppercase is sent
- [ ] Verify hamburger and send buttons stay pinned at edges
- [ ] Verify ctrl+paste and hold-to-repeat on arrows still work