### PR TITLE
fix(cli): preserve all wrapped-command output in local terminal attach

### DIFF
--- a/cli/gmux/cmd/gmux/attach.go
+++ b/cli/gmux/cmd/gmux/attach.go
@@ -81,6 +81,7 @@ func cmdAttach(ref string) int {
 		return 1
 	}
 	defer attach.Detach()
+	attach.Start()
 
 	// Send an initial resize so the PTY adopts our viewport. Without
 	// this the child TUI might keep the previous attach's dimensions.

--- a/cli/gmux/cmd/gmux/run.go
+++ b/cli/gmux/cmd/gmux/run.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/gmuxapp/gmux/cli/gmux/internal/binhash"
 	"github.com/gmuxapp/gmux/cli/gmux/internal/localterm"
@@ -19,6 +20,15 @@ import (
 	"github.com/gmuxapp/gmux/packages/adapter/adapters"
 	"github.com/gmuxapp/gmux/packages/workspace"
 )
+
+// ptyDrainTimeout bounds the wait for the PTY to fully flush after the
+// child exits. A well-behaved child has its PTY slave closed by the
+// kernel as soon as it exits, so EOF on ptmx arrives almost immediately
+// and this timeout is never approached in practice. The ceiling only
+// matters when a grandchild is still holding the slave open: we'd
+// rather restore the user's terminal promptly than wait forever on a
+// background writer.
+const ptyDrainTimeout = 250 * time.Millisecond
 
 // runSession launches a new managed session for the given command.
 //
@@ -120,15 +130,48 @@ func runSession(args []string, attach bool) {
 		ptyCfg.Rows = rows
 	}
 
+	// In interactive mode, build the local terminal attach before
+	// starting the PTY server so LocalOut is wired from the very first
+	// read. Otherwise a fast-exiting command could have its entire
+	// output flushed before SetLocalOutput is called and be silently
+	// dropped on the floor.
+	//
+	// The PTYWriter and ResizeFn closures read `srv` by reference; the
+	// variable is assigned by the ptyserver.New call below, and
+	// attach.Start() — which is what actually starts the goroutines
+	// that invoke these closures — is deferred until after that point.
+	var (
+		srv      *ptyserver.Server
+		localTty *localterm.Attach
+	)
+	if interactive {
+		lt, err := localterm.New(localterm.Config{
+			PTYWriter: ptyWriterFunc(func(p []byte) (int, error) {
+				return srv.WritePTY(p)
+			}),
+			ResizeFn: func(cols, rows uint16) { srv.Resize(cols, rows) },
+		})
+		if err != nil {
+			log.Fatalf("failed to attach terminal: %v", err)
+		}
+		localTty = lt
+		ptyCfg.LocalOut = localTty
+	}
+
 	if !interactive {
 		fmt.Printf("session:  %s\n", sessionID)
 		fmt.Printf("adapter:  %s\n", a.Name())
 		fmt.Printf("command:  %s\n", strings.Join(args, " "))
 	}
 
-	// Start PTY server
-	srv, err := ptyserver.New(ptyCfg)
+	// Start PTY server. Reuses the outer `err` declared by os.Getwd above.
+	srv, err = ptyserver.New(ptyCfg)
 	if err != nil {
+		if localTty != nil {
+			// Restore cooked mode before fataling out; otherwise the
+			// user's terminal is left in raw mode on the shell prompt.
+			localTty.Detach()
+		}
 		log.Fatalf("failed to start: %v", err)
 	}
 
@@ -145,17 +188,10 @@ func runSession(args []string, attach bool) {
 	go registerWithGmuxd(sessionID, sockPath)
 
 	if interactive {
-		// Transparent mode: attach local terminal to the PTY
-		attach, err := localterm.New(localterm.Config{
-			PTYWriter: ptyWriterFunc(func(p []byte) (int, error) {
-				return srv.WritePTY(p)
-			}),
-			ResizeFn: srv.Resize,
-		})
-		if err != nil {
-			log.Fatalf("failed to attach terminal: %v", err)
-		}
-		srv.SetLocalOutput(attach)
+		// Transparent mode: the local tty was built above and wired as
+		// ptyCfg.LocalOut; now that srv exists, kick off the stdin/winch
+		// relay goroutines that call back into srv.
+		localTty.Start()
 
 		// In interactive mode:
 		// - SIGHUP → detach local terminal, keep session running
@@ -166,9 +202,17 @@ func runSession(args []string, attach bool) {
 
 		select {
 		case <-srv.Done():
-			// Child exited — detach and exit
-			attach.Detach()
-		case <-attach.Done():
+			// Child exited. Wait (briefly, bounded) for the final PTY
+			// flush so trailing output reaches the user's terminal
+			// before we detach and restore cooked mode — otherwise the
+			// coalesce buffer's last chunk can land on an already-
+			// detached Attach and be silently dropped.
+			select {
+			case <-srv.PTYDone():
+			case <-time.After(ptyDrainTimeout):
+			}
+			localTty.Detach()
+		case <-localTty.Done():
 			// Local terminal gone (stdin closed) — session continues headless
 			srv.SetLocalOutput(nil)
 			// Wait for child to exit (session persists, accessible via web UI)
@@ -176,13 +220,13 @@ func runSession(args []string, attach bool) {
 		case sig := <-sigCh:
 			if sig == syscall.SIGHUP {
 				// Terminal closed — detach, keep session alive
-				attach.Detach()
+				localTty.Detach()
 				srv.SetLocalOutput(nil)
 				// Continue running headless until child exits
 				<-srv.Done()
 			} else {
 				// SIGINT/SIGTERM — clean shutdown
-				attach.Detach()
+				localTty.Detach()
 				srv.Shutdown()
 			}
 		}

--- a/cli/gmux/internal/localterm/localterm.go
+++ b/cli/gmux/internal/localterm/localterm.go
@@ -58,7 +58,14 @@ type Config struct {
 }
 
 // New creates a local terminal attachment. It puts the terminal in raw
-// mode and starts relaying I/O. Call Detach() to restore the terminal.
+// mode and enables focus reporting, but does NOT begin relaying I/O yet.
+// Call Start() after the PTY writer and resize function are safe to
+// invoke, and Detach() to restore the terminal.
+//
+// Splitting construction from I/O startup lets callers set up a PTY
+// server that already knows about this Attach (as its LocalOut) before
+// any PTY bytes are read, so fast-exiting commands don't race the
+// attach wiring and lose their output.
 func New(cfg Config) (*Attach, error) {
 	stdin := os.Stdin
 	stdout := os.Stdout
@@ -83,10 +90,15 @@ func New(cfg Config) (*Attach, error) {
 	// that point, even if a browser client resized the PTY earlier).
 	stdout.WriteString("\x1b[?1004h")
 
+	return a, nil
+}
+
+// Start begins relaying stdin→PTY and handling SIGWINCH. Call once,
+// after New, when the configured PTYWriter and ResizeFn are ready to
+// be invoked.
+func (a *Attach) Start() {
 	go a.readStdin()
 	go a.handleWinch()
-
-	return a, nil
 }
 
 // Write sends PTY output to the local terminal's stdout.

--- a/cli/gmux/internal/ptyserver/ptyserver.go
+++ b/cli/gmux/internal/ptyserver/ptyserver.go
@@ -146,6 +146,12 @@ type Config struct {
 	Rows       uint16
 	Adapter    adapter.Adapter
 	State      *session.State
+	// LocalOut, if non-nil, receives a copy of every PTY output chunk
+	// from the moment the server starts reading. Set this at construction
+	// time (rather than calling SetLocalOutput after New) when you need
+	// to guarantee that fast-exiting commands can't race the wiring and
+	// have their output dropped on the floor.
+	LocalOut io.Writer
 }
 
 // New creates and starts a PTY server.
@@ -206,6 +212,7 @@ func New(cfg Config) (*Server, error) {
 		adapter:    cfg.Adapter,
 		state:      cfg.State,
 		clients:    make(map[*wsClient]struct{}),
+		localOut:   cfg.LocalOut, // wired before readPTY starts so early output is never lost
 		ptyCols:    cfg.Cols,
 		ptyRows:    cfg.Rows,
 		done:       make(chan struct{}),
@@ -278,8 +285,20 @@ func (s *Server) SocketPath() string {
 }
 
 // Done returns a channel that is closed when the child process exits.
+// Note: when Done closes, the PTY readout may still have buffered
+// output that hasn't been flushed to LocalOut / WS clients yet. Wait
+// on PTYDone() as well if you need to see the child's final bytes.
 func (s *Server) Done() <-chan struct{} {
 	return s.done
+}
+
+// PTYDone returns a channel that is closed after the PTY has been fully
+// drained, meaning all output the child ever produced has been flushed
+// through LocalOut and to every WS client. Always closes strictly after
+// Done(). Callers that want to detach a local terminal without dropping
+// the child's trailing output should wait on this before detaching.
+func (s *Server) PTYDone() <-chan struct{} {
+	return s.ptyDone
 }
 
 // ExitCode returns the child process exit code (only valid after Done).
@@ -295,6 +314,12 @@ func (s *Server) ExitCode() int {
 
 // SetLocalOutput sets a writer that receives a copy of all PTY output.
 // Used for transparent local terminal attach. Pass nil to detach.
+//
+// For the initial wiring, prefer Config.LocalOut: calling this after
+// New leaves a race window in which a fast-exiting child's output can
+// be flushed before the writer is attached and be silently dropped.
+// SetLocalOutput is the right tool for *changing* the sink mid-session
+// (e.g. detaching when stdin closes), not for the first attach.
 func (s *Server) SetLocalOutput(w io.Writer) {
 	s.mu.Lock()
 	detaching := s.localOut != nil && w == nil

--- a/cli/gmux/internal/ptyserver/ptyserver_test.go
+++ b/cli/gmux/internal/ptyserver/ptyserver_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -1168,4 +1169,103 @@ func countOccurrences(s, sub string) int {
 		}
 	}
 	return n
+}
+
+// syncBuffer is a bytes.Buffer safe for concurrent Write and reads.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// TestConfigLocalOutReceivesFastExitOutput verifies that a writer
+// supplied via Config.LocalOut is wired before the PTY server starts
+// reading, so a command that exits before any caller could have
+// plausibly called SetLocalOutput still has its output delivered.
+//
+// Regression test for the race where `gmux echo hi` in a real terminal
+// dropped "hi" because SetLocalOutput was called after readPTY had
+// already flushed the (then nil) local output.
+func TestConfigLocalOutReceivesFastExitOutput(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "test.sock")
+	var out syncBuffer
+
+	srv, err := New(Config{
+		Command:    []string{"bash", "-c", "echo fast-exit-marker"},
+		Cwd:        "/tmp",
+		SocketPath: sockPath,
+		LocalOut:   &out,
+	})
+	if err != nil {
+		t.Fatalf("new server: %v", err)
+	}
+	defer srv.Shutdown()
+
+	select {
+	case <-srv.Done():
+	case <-time.After(3 * time.Second):
+		t.Fatal("child did not exit")
+	}
+	select {
+	case <-srv.PTYDone():
+	case <-time.After(2 * time.Second):
+		t.Fatal("PTYDone never closed")
+	}
+
+	if !strings.Contains(out.String(), "fast-exit-marker") {
+		t.Errorf("expected LocalOut to contain 'fast-exit-marker', got %q", out.String())
+	}
+}
+
+// TestPTYDoneClosesAfterFinalFlush verifies that PTYDone closes strictly
+// after every byte the child produced has been delivered to LocalOut.
+// If PTYDone closed before the final flush, callers that wait on it
+// before detaching a local terminal would still lose the trailing bytes.
+//
+// Regression test for the race where output produced immediately before
+// the child exited was swallowed because Done() fired, the caller
+// detached, and the final readPTY flush arrived at a detached sink.
+func TestPTYDoneClosesAfterFinalFlush(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "test.sock")
+	var out syncBuffer
+
+	// The sleep before the final echo defeats the coalesce timer: the
+	// "END-OF-OUTPUT" bytes arrive right before the child exits, so they
+	// must survive the Done()-to-ptyDone drain to reach LocalOut.
+	srv, err := New(Config{
+		Command:    []string{"bash", "-c", "sleep 0.3; echo END-OF-OUTPUT"},
+		Cwd:        "/tmp",
+		SocketPath: sockPath,
+		LocalOut:   &out,
+	})
+	if err != nil {
+		t.Fatalf("new server: %v", err)
+	}
+	defer srv.Shutdown()
+
+	select {
+	case <-srv.Done():
+	case <-time.After(3 * time.Second):
+		t.Fatal("child did not exit")
+	}
+	select {
+	case <-srv.PTYDone():
+	case <-time.After(2 * time.Second):
+		t.Fatal("PTYDone never closed after child exit")
+	}
+
+	if !strings.Contains(out.String(), "END-OF-OUTPUT") {
+		t.Errorf("expected LocalOut to contain 'END-OF-OUTPUT' by the time PTYDone closes, got %q", out.String())
+	}
 }


### PR DESCRIPTION
Fixes two races in the `gmux <cmd>` interactive attach path that caused
the local terminal to silently miss output the child wrote. Both were
regressions from the abduco→native-ptyserver rewrite: abduco ran the
child's PTY as the user's actual terminal, so there were no "wire up
stdout later" or "detach before drain" windows to race against.

## Repro (before)

In any real terminal outside an existing gmux session:

```bash
# Race 1 — fast-exiting command: "hi" never reaches the terminal
gmux echo hi
# (no output)

# Race 2 — trailing write right before exit: "final" never reaches the terminal
gmux bash -c 'sleep 0.3; echo final'
# (no output)
```

Scripted repro with `script -qfc` confirms only `\x1b[?1004h` / `\x1b[?1004l`
(focus-reporting on/off from `localterm.New` and `Detach`) reach stdout;
the bytes in between are dropped.

## Root causes

### Race 1: `localOut` is nil during the first `readPTY` flush

`runSession` used to do:

```go
srv, _ := ptyserver.New(ptyCfg)       // readPTY goroutine starts immediately
state.SetRunning(srv.Pid())
ensureGmuxd()                         // cold-start latency lives here
go registerWithGmuxd(...)

if interactive {
    attach, _ := localterm.New(...)
    srv.SetLocalOutput(attach)        // only NOW does local stdout get wired
}
```

`readPTY`'s flush reads `s.localOut` under `s.mu`; a flush between `ptyserver.New`
and `SetLocalOutput` sees `nil` and the bytes go to the virtual screen + WS
clients only, never to the user's terminal. For `echo hi` (child exits in
microseconds) that's every flush.

### Race 2: `Done()` fires before the final PTY drain

`ptyserver.waitChild`:

```go
s.err = s.cmd.Wait()
close(s.done)       // (1) unblocks <-srv.Done()
<-s.ptyDone         // (2) but only later waits for readPTY to flush
```

`runSession`:

```go
case <-srv.Done():
    attach.Detach()   // flips a.detached = true
```

`localterm.Attach.Write` swallows silently once detached. Any bytes flushed by
`readPTY` after `close(s.done)` and before `close(s.ptyDone)` land on an
already-detached sink and vanish. 8 ms of coalesce buffer plus the final-EOF
drain is enough to lose a trailing line.

## Fix

### Race 1 — wire `LocalOut` at construction time

- New `ptyserver.Config.LocalOut io.Writer`, assigned to `s.localOut` before
  the `readPTY` goroutine is launched. The `go` statement synchronizes-with
  the goroutine body, so the first flush is guaranteed to see the caller's
  writer.
- `localterm.New` is split into `New` (construct struct, enter raw mode,
  emit focus-reporting SGR) and `Start` (kick off the `readStdin` /
  `handleWinch` goroutines). This lets `runSession` build the `Attach`
  *before* `ptyserver.New` and pass it in as `ptyCfg.LocalOut`; the closures
  captured by `Attach` forward-reference `srv`, and `attach.Start()` is
  deferred until after `srv` is assigned, so the closures are never invoked
  with a nil server.

### Race 2 — wait for the PTY to drain before detaching

- New `ptyserver.Server.PTYDone()` exposes the existing internal `ptyDone`
  channel, which closes strictly after the final `readPTY` flush.
- In the interactive branch, `<-srv.Done()` is now followed by
  `<-srv.PTYDone()` (bounded by `ptyDrainTimeout = 250 ms` so a grandchild
  still holding the PTY slave can't hang the user's terminal in raw mode).
  The final flush lands in `localOut` before `attach.Detach()` flips
  `detached = true`.

`SetLocalOutput` remains the right tool for *changing* the sink mid-session
(detach on SIGHUP / stdin EOF); its docstring now points new callers at
`Config.LocalOut` for the initial wiring.

## Tests

- `TestConfigLocalOutReceivesFastExitOutput` — runs `echo fast-exit-marker`
  with `Config.LocalOut` set to a `syncBuffer`, waits for `Done` + `PTYDone`,
  asserts the buffer contains the marker. Verified to fail without the
  `s.localOut = cfg.LocalOut` wiring (i.e. it catches race 1).
- `TestPTYDoneClosesAfterFinalFlush` — runs `sleep 0.3; echo END-OF-OUTPUT`
  so the trailing write arrives right before exit, asserts the buffer
  contains `END-OF-OUTPUT` by the time `PTYDone` closes. Codifies the
  invariant `runSession` relies on for the race 2 fix.
- Existing ptyserver and localterm tests still pass; the localterm test
  suite constructs `Attach` directly and drives `readStdin` manually, so
  the `New`/`Start` split is transparent to it.

## Manual verification

```bash
gmux echo hi                             # now prints "hi"
gmux bash -c 'sleep 0.3; echo final'    # now prints "final"
gmux cmd | tail                          # piped/agent path unchanged: 7 lines of metadata, exit code propagates
```
