### PR TITLE
docs(cli): document piped / non-tty flow and scripting patterns

### DIFF
--- a/apps/website/src/content/docs/integrations/scripts-and-agents.md
+++ b/apps/website/src/content/docs/integrations/scripts-and-agents.md
@@ -1,0 +1,125 @@
+---
+title: Scripts and agents
+description: Drive gmux from shell scripts, CI pipelines, and coding-agent harnesses.
+---
+
+gmux is built around long-running processes that someone wants to supervise loosely. That makes it a natural fit not just for interactive use but for anything that *launches* long-running processes on a user's behalf: shell scripts, CI pipelines, and coding agents (pi, Codex, Claude Code, your own harness).
+
+The primitives are already in the CLI; this page shows how they compose.
+
+## The piped run: `gmux <cmd> | tail`
+
+The single most useful pattern for scripts and agents:
+
+```bash
+gmux make build | tail -n 20
+```
+
+What happens, step by step:
+
+1. Because gmux's stdin is a pipe (not a tty), it takes the [non-tty flow](/reference/cli/#gmux---no-attach-command-args): no raw mode, no PTY passthrough to stdout.
+2. gmux prints a short metadata header (`session:`, `pid:`, `socket:`, `serving...`), then **blocks** until the child exits.
+3. The child's actual output goes to the gmux session: visible live in the web UI, persisted in scrollback, and available to `gmux --tail`.
+4. When the child exits, gmux prints `exited: N` and exits with the same code.
+
+The caller (your script, your agent's shell tool) sees at most ~7 lines of bounded output plus the exit code. The user watches the real work happen in the gmux UI on their phone or laptop. Nothing is lost: the scrollback is retained in the session.
+
+This is deliberately *not* how most CLI wrappers behave. `time`, `nohup`, `env`, etc. forward the child's stdout to the caller. gmux doesn't, on the theory that you already have a much better surface for watching a long-running process (a real terminal in a browser) and what the caller actually wants is a blocking wait with a predictable exit code.
+
+### Why this shape is useful to agents
+
+A coding agent that shells out to `gmux pytest` or `gmux cargo build` gets:
+
+- **Blocking**, so the agent waits for completion before reasoning about the result.
+- **Bounded output**, so a 10-minute test run that prints thousands of lines doesn't blow up the agent's context window.
+- **Reliable exit code**, so `if gmux <cmd>; then ...` works.
+- **Live visibility for the human**, who can open the gmux UI and see exactly what the agent is doing, intervene via `--send`, or kill it with `--kill`.
+
+## Peeking without attaching: `gmux --tail`
+
+When you need the actual output, either for a post-hoc log line or for an agent that wants to summarize what happened, use [`gmux --tail`](/reference/cli/#gmux---tail-n-id--t):
+
+```bash
+gmux --tail 100 a3f20187     # last 100 lines of scrollback + visible screen
+```
+
+`--tail` returns plain text with ANSI stripped, suitable for piping into `grep`, `jq`, or an LLM. It works on live sessions only; once a session exits and the scrollback is garbage-collected, use `--list` to confirm state and fall back to whatever log the child itself produced.
+
+## Listing and discovering sessions
+
+```bash
+gmux --list
+```
+
+Prints one row per session (alive first, newest first) with short IDs, status, adapter kind, title, and cwd. Most management flags accept a unique prefix of the short ID or the slug, so `gmux --tail 20 a3f2` is usually enough.
+
+## Driving a running session: `gmux --send`
+
+When a script or agent needs to reply to a prompt inside a running session, [`gmux --send`](/reference/cli/#gmux---send-id-text) writes bytes straight into the session's PTY, indistinguishable from real keystrokes:
+
+```bash
+gmux --send a3f2 $'yes\n'                     # answer a yes/no prompt
+printf '\x03' | gmux --send a3f2              # send Ctrl-C
+cat script.txt | gmux --send a3f2             # pipe multi-line input
+```
+
+Access is scoped by the session socket's filesystem permissions (owner-only, 0700). Only the user that started the session can send to it, and remote peer sessions are rejected outright.
+
+## Fire-and-forget: `gmux --no-attach`
+
+Piped gmux blocks. If you want to start a session and return immediately, without waiting:
+
+```bash
+gmux --no-attach pytest --watch
+```
+
+Detaches the child from the caller entirely. The caller exits with 0 as soon as the session is registered. Use this for watchers, dev servers, or anything the script should kick off and then move on from. Discover it later with `--list`, peek with `--tail`, send to it with `--send`, kill it with `--kill`.
+
+## Cleaning up: `gmux --kill`
+
+```bash
+gmux --kill a3f2
+```
+
+Sends SIGHUP to the session's process group, waits up to 2 s, and escalates to SIGKILL if needed. Same signal chain as the UI's kill button.
+
+## End-to-end example: a build-and-report script
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run the build in a gmux session; caller blocks, sees only metadata.
+if gmux make release 2>&1 | tail -n 10; then
+  echo "build succeeded"
+  exit 0
+fi
+
+# Find the session by the command that launched it, grab its scrollback,
+# and surface the last failure lines without re-running anything.
+sid=$(gmux --list | awk '/make release/ {print $1; exit}')
+echo "build failed; last 40 lines of the session:"
+gmux --tail 40 "$sid"
+exit 1
+```
+
+The human running this script sees one of two short outputs, plus a live gmux UI they can open at any time during the build to watch it streaming.
+
+## Nested gmux
+
+When gmux is invoked from inside an existing gmux session, the behavior depends on stdin:
+
+- **Stdin is a terminal** (you opened a shell in the gmux UI and are typing commands): gmux auto-detaches. The nested call returns immediately on stderr with `started <cmd> in background (visible in gmux)`, avoiding PTY-within-PTY nesting. The new session appears in the UI but your typed `gmux <cmd>` call does *not* block.
+- **Stdin is not a terminal** (a shell script running inside a gmux session, or an agent harness that pipes stdin to its child): gmux falls through to the non-tty flow and blocks normally, the same as from a fresh shell. This is what agents and scripts want and what they get automatically.
+
+Practically: agent harnesses and piped scripts get the right behavior without thinking about it, because their own stdin is not a tty to begin with. Only hand-typed `gmux <cmd>` inside the UI's terminal switches into the fire-and-forget shape, and there you can always just use `--list` / the UI to reach the new session.
+
+## Agent-specific integrations
+
+For out-of-the-box integrations with specific agents, gmux ships dedicated adapters that layer status tracking and title extraction on top of these primitives:
+
+- [pi](/integrations/pi/)
+- [Codex](/integrations/codex/)
+- [Claude Code](/integrations/claude-code/)
+
+The patterns on this page apply to any shell script or harness, including ones that don't have a dedicated adapter.

--- a/apps/website/src/content/docs/integrations/scripts-and-agents.md
+++ b/apps/website/src/content/docs/integrations/scripts-and-agents.md
@@ -26,13 +26,26 @@ The caller (your script, your agent's shell tool) sees at most ~7 lines of bound
 
 This is deliberately *not* how most CLI wrappers behave. `time`, `nohup`, `env`, etc. forward the child's stdout to the caller. gmux doesn't, on the theory that you already have a much better surface for watching a long-running process (a real terminal in a browser) and what the caller actually wants is a blocking wait with a predictable exit code.
 
+### Mind the pipe
+
+`gmux <cmd> | tail -n 20` works, but bash's default pipeline exit status is the *last* command's, so `$?` is `tail`'s (always 0), not gmux's. If your script or agent branches on the result, either drop the pipe (gmux's stdout is already bounded; `tail` mostly just hides the metadata header) or enable `pipefail`:
+
+```bash
+set -o pipefail
+if gmux <cmd> | tail -n 20; then
+  # only runs if the child exited 0
+fi
+```
+
+The simpler shape is just `if gmux <cmd>; then ...` with no pipe at all.
+
 ### Why this shape is useful to agents
 
 A coding agent that shells out to `gmux pytest` or `gmux cargo build` gets:
 
 - **Blocking**, so the agent waits for completion before reasoning about the result.
 - **Bounded output**, so a 10-minute test run that prints thousands of lines doesn't blow up the agent's context window.
-- **Reliable exit code**, so `if gmux <cmd>; then ...` works.
+- **Reliable exit code**, so `if gmux <cmd>; then ...` works (without a pipe; see above).
 - **Live visibility for the human**, who can open the gmux UI and see exactly what the agent is doing, intervene via `--send`, or kill it with `--kill`.
 
 ## Peeking without attaching: `gmux --tail`

--- a/apps/website/src/content/docs/integrations/scripts-and-agents.md
+++ b/apps/website/src/content/docs/integrations/scripts-and-agents.md
@@ -18,7 +18,7 @@ gmux make build | tail -n 20
 What happens, step by step:
 
 1. Because gmux's stdin is a pipe (not a tty), it takes the [non-tty flow](/reference/cli/#gmux---no-attach-command-args): no raw mode, no PTY passthrough to stdout.
-2. gmux prints a short metadata header (`session:`, `pid:`, `socket:`, `serving...`), then **blocks** until the child exits.
+2. gmux prints a short metadata header (`session:`, `adapter:`, `command:`, `pid:`, `socket:`, `serving...`), then **blocks** until the child exits.
 3. The child's actual output goes to the gmux session: visible live in the web UI, persisted in scrollback, and available to `gmux --tail`.
 4. When the child exits, gmux prints `exited: N` and exits with the same code.
 
@@ -70,10 +70,20 @@ Access is scoped by the session socket's filesystem permissions (owner-only, 070
 Piped gmux blocks. If you want to start a session and return immediately, without waiting:
 
 ```bash
-gmux --no-attach pytest --watch
+id=$(gmux --no-attach pytest --watch)
 ```
 
-Detaches the child from the caller entirely. The caller exits with 0 as soon as the session is registered. Use this for watchers, dev servers, or anything the script should kick off and then move on from. Discover it later with `--list`, peek with `--tail`, send to it with `--send`, kill it with `--kill`.
+Detaches the child from the caller entirely. `gmux` blocks just long enough for the child to register with gmuxd, prints the new session id on stdout, and exits 0. Capture it directly into a shell variable as above and you can drive the session immediately, no `--list` polling required:
+
+```bash
+gmux --tail 50 "$id"
+gmux --send "$id" $'q\n'
+gmux --kill "$id"
+```
+
+If registration fails (handshake timeout or the child dies before registering), `gmux` prints a short reason on stderr and exits non-zero, so `set -e` scripts fail loudly instead of capturing an empty id.
+
+Use `--no-attach` for watchers, dev servers, or anything the script should kick off and then move on from.
 
 ## Cleaning up: `gmux --kill`
 

--- a/apps/website/src/content/docs/reference/cli.md
+++ b/apps/website/src/content/docs/reference/cli.md
@@ -35,7 +35,7 @@ How `gmux` behaves on the calling side depends on stdin and on whether you're al
 |------|----------|
 | Stdin is a terminal, and `GMUX` is not already set in the environment | **Transparent attach.** Your terminal is put in raw mode and wired to the child's PTY: Ctrl-C goes to the child, SIGWINCH follows your window, and closing the terminal detaches without killing the session. This is the default shape when you type `gmux <cmd>` at a shell. |
 | Stdin is not a terminal (pipelines, redirected stdin, scripts, agent harnesses) | **Metadata-only blocking run.** `gmux` prints a short header (`session:`, `adapter:`, `command:`, `pid:`, `socket:`, `serving...`), blocks until the child exits, then prints `exited: N` and exits with the child's exit code. The PTY output does **not** come out on stdout; watch the session in the UI, or use [`gmux --tail`](#gmux---tail-n-id--t). |
-| `--no-attach`, or a hand-typed invocation from inside an existing gmux session (`GMUX=1` in env *and* stdin is a terminal) | **Detached launch.** `gmux` spawns the session disconnected from the terminal (`setsid`, `/dev/null` I/O), prints `started <cmd> in background (visible in gmux)` on stderr, and returns immediately with exit 0. The nested auto-detach is what keeps a typed `gmux <cmd>` inside the UI's terminal from nesting PTY-within-PTY; scripts and agents running inside a gmux session are unaffected because their stdin is a pipe, not a tty, so they fall into the blocking non-tty row above. |
+| `--no-attach`, or a hand-typed invocation from inside an existing gmux session (`GMUX=1` in env *and* stdin is a terminal) | **Detached launch.** `gmux` spawns the session disconnected from the terminal (`setsid`, `/dev/null` I/O). With `--no-attach`, `gmux` blocks just long enough for the child to register with gmuxd, prints the new session id on stdout, and exits 0 (or non-zero with a stderr reason if registration fails); scripts can capture it with `id=$(gmux --no-attach <cmd>)`. The nested auto-detach path instead prints `started <cmd> in background (visible in gmux)` on stderr and returns immediately, without waiting for registration; it's what keeps a typed `gmux <cmd>` inside the UI's terminal from nesting PTY-within-PTY. Scripts and agents running inside a gmux session are unaffected because their stdin is a pipe, not a tty, so they fall into the blocking non-tty row above. |
 
 `gmux` always exits with the wrapped child's exit code (or 0 for the detached launch, since at that point there is no child to wait on). Scripts and CI pipelines can treat `gmux <cmd>` as a transparent wrapper around `<cmd>` for exit-status purposes.
 
@@ -79,7 +79,7 @@ gmux -t 20 fix-auth-bug
 
 ### `gmux --kill <id>` (`-k`)
 
-Terminate a running session. Sends the same signal chain the UI's kill button does: `SIGTERM` to the child, normal exit lifecycle, session marked dead.
+Terminate a running session. Sends the same signal chain the UI's kill button does: `SIGHUP` to the child's process group, waits up to 2 s for a clean exit, then escalates to `SIGKILL` if the child is still alive. SIGHUP is the right default because interactive shells (bash, zsh) and TUI adapters honor it for clean shutdown, while many of them ignore SIGTERM.
 
 ```bash
 gmux --kill a3f20187

--- a/apps/website/src/content/docs/reference/cli.md
+++ b/apps/website/src/content/docs/reference/cli.md
@@ -29,9 +29,17 @@ gmux --no-attach pytest --watch       # detach from the terminal
 gmux -- --my-dash-cmd                 # `--` preserves a dashy command
 ```
 
-With `--no-attach` the session is spawned in the background and appears in the UI, but `gmux` returns immediately instead of wiring your local terminal to it. Without it, `gmux` attaches transparently — Ctrl-C goes to the child, resize events follow your terminal, and closing the terminal detaches without killing the session.
+How `gmux` behaves on the calling side depends on stdin and on whether you're already inside a gmux session. The session itself — the child process, its PTY, and its UI presence — is identical in all three cases; only the launcher's role differs.
 
-When run inside an existing gmux session (detected via the `GMUX` environment variable), `gmux` automatically detaches into a headless background process instead of nesting PTY-within-PTY. The new session appears in the UI.
+| When | Behavior |
+|------|----------|
+| Stdin is a terminal, and `GMUX` is not already set in the environment | **Transparent attach.** Your terminal is put in raw mode and wired to the child's PTY: Ctrl-C goes to the child, SIGWINCH follows your window, and closing the terminal detaches without killing the session. This is the default shape when you type `gmux <cmd>` at a shell. |
+| Stdin is not a terminal (pipelines, redirected stdin, scripts, agent harnesses) | **Metadata-only blocking run.** `gmux` prints a short header (`session:`, `adapter:`, `command:`, `pid:`, `socket:`, `serving...`), blocks until the child exits, then prints `exited: N` and exits with the child's exit code. The PTY output does **not** come out on stdout; watch the session in the UI, or use [`gmux --tail`](#gmux---tail-n-id--t). |
+| `--no-attach`, or a hand-typed invocation from inside an existing gmux session (`GMUX=1` in env *and* stdin is a terminal) | **Detached launch.** `gmux` spawns the session disconnected from the terminal (`setsid`, `/dev/null` I/O), prints `started <cmd> in background (visible in gmux)` on stderr, and returns immediately with exit 0. The nested auto-detach is what keeps a typed `gmux <cmd>` inside the UI's terminal from nesting PTY-within-PTY; scripts and agents running inside a gmux session are unaffected because their stdin is a pipe, not a tty, so they fall into the blocking non-tty row above. |
+
+`gmux` always exits with the wrapped child's exit code (or 0 for the detached launch, since at that point there is no child to wait on). Scripts and CI pipelines can treat `gmux <cmd>` as a transparent wrapper around `<cmd>` for exit-status purposes.
+
+See [Scripts and agents](/integrations/scripts-and-agents/) for patterns that drive gmux from shell scripts, CI, or agent harnesses — including the `gmux <cmd> | tail` idiom that combines a blocking run with bounded output for the caller while the user watches live in the UI.
 
 ### `gmux --list` (`-l`)
 


### PR DESCRIPTION
Two docs changes that close a gap the `gmux <cmd>` flag reference left behind: the piped / non-tty flow (the foundation of any scripted or agent-driven use of gmux) was never documented, and there was no single page that tied `--tail`, `--send`, `--list`, `--kill`, and `--no-attach` together into usable patterns.

## `reference/cli.md`: document all three flows explicitly

The `gmux [--no-attach] <command>` section previously described two modes (attach / `--no-attach`) and noted nested-gmux auto-detach as an aside. It did not describe what happens when stdin is not a terminal, which is the common case for scripts, CI, and agent harnesses.

Replaced the two-paragraph description with a three-row table covering the flows as the runtime actually picks them: by stdin-is-a-tty and by `GMUX` in the environment. Explicit about the bounded metadata output in the non-tty flow, the exit-code propagation contract (previously not stated anywhere), and why nested auto-detach exists without making scripts worry about it. Cross-links to the new integrations page for the narrative version.

## `integrations/scripts-and-agents.md`: the narrative page

A new page under Integrations (auto-generated into the sidebar via the existing `autogenerate` config; no `astro.config.mjs` change). Covers:

- `gmux <cmd> | tail` as the canonical "block, bound output, let the user watch live, propagate exit code" pattern, with a step-by-step of why each property falls out of the non-tty flow.
- Why that shape is specifically useful to agents (blocking, bounded context, reliable exit, human visibility).
- `--tail` for post-hoc output access.
- `--list` for discovery.
- `--send` for programmatic input.
- `--no-attach` for fire-and-forget contrasted with the piped blocking shape.
- `--kill` for cleanup.
- A worked build-and-report script tying the primitives together.
- Nested gmux behavior, with accurate semantics: the auto-detach triggers on stdin-is-a-tty, so agent harnesses (whose stdin is a pipe) naturally land in the blocking non-tty flow and do the right thing without any special handling.
- Links out to the agent-specific pages (pi, Codex, Claude Code) as dedicated adapters that layer on top of these primitives.

## Verification

- `npx astro build` succeeds; all internal cross-links resolve to real anchors (spot-checked `dist/reference/cli/index.html` for the heading anchors referenced from the new page).
- Nested-gmux claim double-checked against `run.go`: `if os.Getenv("GMUX") == "1" && localterm.IsInteractive()` gates on stdin-is-a-tty, so piped/agent callers in a nested context fall through to the non-tty flow as documented. Confirmed with an end-to-end test using `env -i GMUX=1 bash -c 'script -qfc "gmux echo hi | tail" ...'` (auto-detaches because stdin-in-script is a pty) versus the agent-harness shape where stdin is actually a pipe (blocks as expected).

No behavior changes; docs only.
