### PR TITLE
feat(cli): printable session id for --no-attach, post-exit --tail, and race-free handoff

### DIFF
--- a/apps/website/src/content/docs/reference/cli.md
+++ b/apps/website/src/content/docs/reference/cli.md
@@ -74,7 +74,9 @@ gmux --tail 100 a3f20187
 gmux -t 20 fix-auth-bug
 ```
 
-`--tail` currently only works for sessions owned by the local node; remote peer sessions are rejected with a clear error.
+`--tail` works on both live and exited sessions. Live sessions are read from the runner's in-memory scrollback; exited sessions fall back to a plain-text file the runner flushed next to the session socket on exit (`<socket>.tail`, owner-only). The fallback exists so a build or test run that has already finished is still inspectable without re-executing it.
+
+`--tail` only works for sessions owned by the local node; remote peer sessions are rejected with a clear error.
 
 ### `gmux --kill <id>` (`-k`)
 

--- a/apps/website/src/content/docs/reference/cli.md
+++ b/apps/website/src/content/docs/reference/cli.md
@@ -33,6 +33,13 @@ With `--no-attach` the session is spawned in the background and appears in the U
 
 When run inside an existing gmux session (detected via the `GMUX` environment variable), `gmux` automatically detaches into a headless background process instead of nesting PTY-within-PTY. The new session appears in the UI.
 
+Both detaching paths (explicit `--no-attach` and the nested-gmux auto-background) print the new session's short ID to **stdout** and the "started ... in background" confirmation to stderr. Scripts can capture just the ID:
+
+```bash
+id=$(gmux --no-attach pytest --watch)
+gmux --tail 100 "$id"
+```
+
 ### `gmux --list` (`-l`)
 
 List known sessions, alive first, newest first.

--- a/cli/gmux/cmd/gmux/actions.go
+++ b/cli/gmux/cmd/gmux/actions.go
@@ -246,38 +246,109 @@ func cmdTail(ref string, n int) int {
 		case sess.Peer != "":
 			fmt.Fprintf(os.Stderr, "gmux: --tail is only supported for local sessions (%s is on peer %q)\n",
 				shortID(sess.ID), sess.Peer)
-		case !sess.Alive:
-			fmt.Fprintf(os.Stderr, "gmux: session %s is not running\n", shortID(sess.ID))
 		default:
 			fmt.Fprintf(os.Stderr, "gmux: session %s has no socket path\n", shortID(sess.ID))
 		}
 		return 1
 	}
 
-	client := sessionSocketClient(sess.SocketPath)
+	// Live path: try the session's socket first. For alive sessions
+	// this is the authoritative source, and for just-exited sessions
+	// the socket may still be serving briefly.
+	if body, ok := fetchLiveTail(sess.SocketPath, n); ok {
+		os.Stdout.Write(body)
+		return 0
+	}
+
+	// Disk fallback: ptyserver flushes the scrollback to
+	// <socket>.tail on exit, so we can still show it for dead sessions.
+	// This is what makes `gmux --tail` useful for post-hoc peeking at a
+	// build or test run that has already finished.
+	body, err := readPersistedTail(sess.SocketPath, n)
+	if err == nil {
+		os.Stdout.Write(body)
+		return 0
+	}
+	if os.IsNotExist(err) {
+		if sess.Alive {
+			fmt.Fprintf(os.Stderr, "gmux: session %s is unreachable (socket refused, no persisted tail on disk)\n", shortID(sess.ID))
+		} else {
+			fmt.Fprintf(os.Stderr, "gmux: session %s has no persisted tail (started by an older runner, or tail file was removed)\n", shortID(sess.ID))
+		}
+		return 1
+	}
+	fmt.Fprintln(os.Stderr, "gmux:", err)
+	return 1
+}
+
+// fetchLiveTail pulls the last n lines from the session's live socket.
+// Returns (body, true) on success, (nil, false) on any error that
+// looks like "session is gone" (dial refused, connection reset) so the
+// caller can fall back to disk. Non-gone errors (e.g. a 5xx from a
+// live runner) are also reported as ok=false but logged; callers that
+// want the detail should run with GMUX_DEBUG.
+func fetchLiveTail(socketPath string, n int) ([]byte, bool) {
+	client := sessionSocketClient(socketPath)
 	url := fmt.Sprintf("http://session/scrollback/tail?n=%d", n)
 	resp, err := client.Get(url)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "gmux:", err)
-		return 1
+		return nil, false
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		// Older runners may not have the tail endpoint yet; give a
-		// specific hint instead of a bare 404.
-		if resp.StatusCode == http.StatusNotFound {
-			fmt.Fprintln(os.Stderr, "gmux: this session's runner is too old for --tail (restart it to upgrade)")
-			return 1
+		// 404 from an old runner: prefer the disk fallback silently,
+		// let it decide whether to print the "too old" hint.
+		return nil, false
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return nil, false
+	}
+	return body, true
+}
+
+// readPersistedTail returns the last n plain-text lines of the
+// scrollback file written by ptyserver when the session exited.
+// The file path is derived from the session's socket path; see
+// ptyserver.persistTail for the writer side.
+func readPersistedTail(socketPath string, n int) ([]byte, error) {
+	data, err := os.ReadFile(socketPath + ".tail")
+	if err != nil {
+		return nil, err
+	}
+	return lastNLines(data, n), nil
+}
+
+// lastNLines returns the last n newline-separated lines of buf,
+// preserving any trailing newline. When buf has fewer than n lines the
+// whole buffer is returned. A buf without a trailing newline is still
+// treated as ending with a line, so content from a truncated write
+// isn't silently dropped.
+//
+// Implementation: walk backwards counting newline boundaries. With a
+// trailing newline, seeing n+1 newlines from the end means buf[i+1:]
+// starts at the n-th line from the end. Without one, the final
+// unterminated line itself is the first line-from-end, so n newlines
+// is enough.
+func lastNLines(buf []byte, n int) []byte {
+	if n <= 0 || len(buf) == 0 {
+		return nil
+	}
+	end := len(buf)
+	target := n + 1
+	if buf[end-1] != '\n' {
+		target = n
+	}
+	count := 0
+	for i := end - 1; i >= 0; i-- {
+		if buf[i] == '\n' {
+			count++
+			if count == target {
+				return buf[i+1:]
+			}
 		}
-		fmt.Fprintf(os.Stderr, "gmux: tail failed: %s: %s\n", resp.Status, strings.TrimSpace(string(body)))
-		return 1
 	}
-	if _, err := io.Copy(os.Stdout, resp.Body); err != nil && !errors.Is(err, io.EOF) {
-		fmt.Fprintln(os.Stderr, "gmux:", err)
-		return 1
-	}
-	return 0
+	return buf
 }
 
 // cmdSend implements `gmux --send <id> [text]`.

--- a/cli/gmux/cmd/gmux/actions_test.go
+++ b/cli/gmux/cmd/gmux/actions_test.go
@@ -1,9 +1,114 @@
 package main
 
 import (
+	"bytes"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
+
+// TestReadPersistedTail covers the on-disk fallback `gmux --tail` uses
+// when the session's socket has gone away. ptyserver writes the full
+// scrollback as plain text to <socketPath>.tail on exit; the CLI picks
+// up the last N lines from that file so users can still peek at a
+// finished make-build or pytest run without re-executing it.
+func TestReadPersistedTail(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "sess-deadbeef.sock")
+	tailPath := sockPath + ".tail"
+
+	// 12 lines of known content, one per row.
+	var content bytes.Buffer
+	for i := 1; i <= 12; i++ {
+		content.WriteString("line-" + twoDigit(i) + "\n")
+	}
+	if err := os.WriteFile(tailPath, content.Bytes(), 0o600); err != nil {
+		t.Fatalf("write tail file: %v", err)
+	}
+
+	got, err := readPersistedTail(sockPath, 3)
+	if err != nil {
+		t.Fatalf("readPersistedTail: %v", err)
+	}
+	want := "line-10\nline-11\nline-12\n"
+	if string(got) != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestReadPersistedTail_RequestMoreThanAvailable returns everything
+// when the caller asks for more lines than the file has. Matches how
+// the live /scrollback/tail endpoint behaves, so a caller script gets
+// consistent output regardless of whether the session is still alive.
+func TestReadPersistedTail_RequestMoreThanAvailable(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "sess-cafef00d.sock")
+	tailPath := sockPath + ".tail"
+
+	if err := os.WriteFile(tailPath, []byte("only\ntwo\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	got, err := readPersistedTail(sockPath, 100)
+	if err != nil {
+		t.Fatalf("readPersistedTail: %v", err)
+	}
+	if string(got) != "only\ntwo\n" {
+		t.Errorf("got %q, want %q", got, "only\ntwo\n")
+	}
+}
+
+// TestReadPersistedTail_MissingFile returns a distinguishable error
+// (os.IsNotExist true) so the caller can tell "nothing persisted"
+// apart from "disk corruption".
+func TestReadPersistedTail_MissingFile(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "sess-nope.sock")
+
+	_, err := readPersistedTail(sockPath, 10)
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+	if !os.IsNotExist(err) {
+		t.Errorf("err = %v, want an os.IsNotExist error", err)
+	}
+}
+
+// TestLastNLines covers the byte-walk tail extractor. The one case
+// most likely to be wrong in a hand-rolled implementation is input
+// without a trailing newline: the "last line" still exists and must
+// be counted, otherwise a truncated write silently drops content from
+// the tail.
+func TestLastNLines(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		n    int
+		want string
+	}{
+		{"empty", "", 5, ""},
+		{"n=0", "a\nb\n", 0, ""},
+		{"fewer lines than requested", "only\ntwo\n", 10, "only\ntwo\n"},
+		{"exact tail with trailing newline", "a\nb\nc\n", 2, "b\nc\n"},
+		{"tail without trailing newline", "a\nb\nc", 2, "b\nc"},
+		{"single unterminated line", "solo", 1, "solo"},
+		{"single unterminated line, ask for more", "solo", 5, "solo"},
+		{"two lines no trailing, n=1", "a\nb", 1, "b"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := string(lastNLines([]byte(tc.in), tc.n))
+			if got != tc.want {
+				t.Errorf("lastNLines(%q, %d) = %q, want %q", tc.in, tc.n, got, tc.want)
+			}
+		})
+	}
+}
+
+func twoDigit(n int) string {
+	if n < 10 {
+		return "0" + string(rune('0'+n))
+	}
+	return string(rune('0'+n/10)) + string(rune('0'+n%10))
+}
 
 // TestMatchSession covers the reference-resolution rules the CLI
 // documents: short form (as shown by --list), full ID, slug, and

--- a/cli/gmux/cmd/gmux/main_test.go
+++ b/cli/gmux/cmd/gmux/main_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 )
@@ -15,6 +16,16 @@ import (
 // Returns the state dir (for t.Setenv) and a cleanup func.
 func startTestSocketDaemon(t *testing.T, ver string) (stateDir string, cleanup func()) {
 	t.Helper()
+	stateDir, _, cleanup = startTestSocketDaemonWithSessions(t, ver, nil)
+	return stateDir, cleanup
+}
+
+// startTestSocketDaemonWithSessions behaves like startTestSocketDaemon
+// but also serves /v1/sessions from a slice the caller can mutate
+// concurrently. Returns a pointer to the slice (guarded by its own
+// mutex — use the returned addSession helper to append).
+func startTestSocketDaemonWithSessions(t *testing.T, ver string, initial []cliSession) (stateDir string, addSession func(cliSession), cleanup func()) {
+	t.Helper()
 	stateDir = t.TempDir()
 	sockDir := filepath.Join(stateDir, "gmux")
 	os.MkdirAll(sockDir, 0o700)
@@ -22,6 +33,16 @@ func startTestSocketDaemon(t *testing.T, ver string) (stateDir string, cleanup f
 	ln, err := net.Listen("unix", sockPath)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	var (
+		mu       sync.Mutex
+		sessions = append([]cliSession(nil), initial...)
+	)
+	addSession = func(s cliSession) {
+		mu.Lock()
+		defer mu.Unlock()
+		sessions = append(sessions, s)
 	}
 
 	mux := http.NewServeMux()
@@ -36,11 +57,18 @@ func startTestSocketDaemon(t *testing.T, ver string) (stateDir string, cleanup f
 			},
 		})
 	})
+	mux.HandleFunc("/v1/sessions", func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		snapshot := append([]cliSession(nil), sessions...)
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"ok": true, "data": snapshot})
+	})
 	srv := &http.Server{Handler: mux}
 	go srv.Serve(ln)
 	time.Sleep(50 * time.Millisecond)
 
-	return stateDir, func() {
+	return stateDir, addSession, func() {
 		srv.Close()
 		os.Remove(sockPath)
 	}

--- a/cli/gmux/cmd/gmux/run.go
+++ b/cli/gmux/cmd/gmux/run.go
@@ -237,7 +237,11 @@ func runSession(args []string, attach bool) {
 
 	// Auto-start gmuxd if not running (one-shot, never retried), then register.
 	ensureGmuxd()
-	go registerWithGmuxd(sessionID, sockPath)
+	regDone := make(chan struct{})
+	go func() {
+		registerWithGmuxd(sessionID, sockPath)
+		close(regDone)
+	}()
 
 	if interactive {
 		// Transparent mode: the local tty was built above and wired as
@@ -305,8 +309,43 @@ func runSession(args []string, attach bool) {
 	if !interactive {
 		fmt.Printf("exited:   %d\n", exitCode)
 	}
+
+	// Wait for the scrollback tail file to finish writing before we exit.
+	// waitChild runs persistTail *after* Done() fires (so Done() keeps its
+	// "child exited" meaning for the interactive attach path), which means
+	// os.Exit could otherwise cut the write off mid-flight and leave the
+	// disk fallback for `gmux --tail` silently empty. The timeout bounds
+	// any pathological I/O stall; the common-case wait is under a
+	// millisecond.
+	select {
+	case <-srv.TailPersisted():
+	case <-time.After(tailPersistTimeout):
+	}
+
+	// Wait for gmuxd registration to complete before we exit. For
+	// ultra-fast commands (think `gmux echo hi`) the child can finish
+	// before the register goroutine above has even posted to
+	// /v1/register, leaving the session invisible to --list / --tail /
+	// --send. Blocking on regDone here ensures the session record
+	// survives the runner's lifetime.
+	select {
+	case <-regDone:
+	case <-time.After(registerExitTimeout):
+	}
 	os.Exit(exitCode)
 }
+
+// registerExitTimeout bounds how long the runner waits for its own
+// registration goroutine to finish before exiting. Sized to exceed
+// registerWithGmuxd's full retry budget (5 attempts x 500 ms backoff),
+// so we never abandon a registration that's still making progress.
+const registerExitTimeout = 3 * time.Second
+
+// tailPersistTimeout bounds how long runSession waits for the scrollback
+// tail file to be written after the child exits. The write is a few KB
+// to a local tmpfs in practice, so anything approaching this ceiling
+// means disk I/O is pathologically slow and we'd rather exit than hang.
+const tailPersistTimeout = 500 * time.Millisecond
 
 // spawnDetached re-execs gmux with the given args as a setsid'd
 // background process, disconnected from the current terminal. Used for
@@ -351,8 +390,55 @@ func spawnDetached(args []string, msg string) {
 		log.Fatalf("failed to start background session: %v", err)
 	}
 	cmd.Process.Release()
+
+	// Wait briefly for the child to register with gmuxd so a caller can
+	// use the printed id immediately:
+	//
+	//	id=$(gmux --no-attach cmd); gmux --tail "$id"
+	//
+	// Without this, the caller races the child's async registration
+	// flow (socket bind → /v1/register → gmuxd /meta query → store)
+	// and gets "no session matches <id>" for fast-exiting commands.
+	// On timeout we still announce: the id is valid, just not
+	// ready-yet; the caller's next call will succeed once gmuxd
+	// catches up.
+	waitForRegistration(sessionID, registrationTimeout)
 	announceDetached(os.Stdout, os.Stderr, sessionID, msg)
 }
+
+// registrationTimeout bounds the wait for a detached session to appear
+// in gmuxd's session list. Sized for the common case (fork + bind +
+// register ≈ tens of milliseconds) plus headroom for a cold-start
+// gmuxd (≤ 1s on a warm disk).
+const registrationTimeout = 2 * time.Second
+
+// waitForRegistration polls gmuxd for sessionID until it appears or
+// the timeout elapses. Returns true on success, false on timeout. The
+// timeout path isn't fatal: the caller still announces the id, just
+// without the ordering guarantee that an immediate follow-up command
+// will find the session.
+func waitForRegistration(sessionID string, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for {
+		if sessions, err := fetchSessions(); err == nil {
+			for _, s := range sessions {
+				if s.ID == sessionID {
+					return true
+				}
+			}
+		}
+		if time.Now().After(deadline) {
+			return false
+		}
+		time.Sleep(registrationPollInterval)
+	}
+}
+
+// registrationPollInterval is the gap between /v1/sessions polls while
+// waiting for a just-spawned child to register. Small enough that
+// typical registrations (tens of ms) aren't amplified by poll slack,
+// large enough that we don't spin on gmuxd.
+const registrationPollInterval = 25 * time.Millisecond
 
 // announceDetached writes the new session's short id to stdout and the
 // free-form human message (if any) to stderr. Split onto two streams so

--- a/cli/gmux/cmd/gmux/run.go
+++ b/cli/gmux/cmd/gmux/run.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"os/exec"
@@ -20,6 +21,57 @@ import (
 	"github.com/gmuxapp/gmux/packages/adapter/adapters"
 	"github.com/gmuxapp/gmux/packages/workspace"
 )
+
+// envForceSessionID carries a pre-generated session ID from a
+// detaching parent (spawnDetached) to its re-execed child. This lets
+// the parent announce the ID on stdout before the child exists yet, so
+// `id=$(gmux --no-attach cmd)` works. It is intentionally undocumented
+// for end users: the only legitimate setter is gmux itself.
+//
+// The child reads and immediately clears it (see nextSessionID) so a
+// grandchild session launched later doesn't silently adopt the parent's
+// id and collide in gmuxd's session store.
+const envForceSessionID = "GMUX_RUNNER_FORCE_SESSION_ID"
+
+// nextSessionID returns the session ID to use for this runner. When
+// envForceSessionID holds a well-formed id (sess-<hex>), it is adopted
+// and the env var is cleared. Otherwise a fresh id is generated. The
+// env var is cleared even on a malformed value so a bad entry doesn't
+// survive into child processes.
+func nextSessionID() string {
+	forced, ok := os.LookupEnv(envForceSessionID)
+	if ok {
+		os.Unsetenv(envForceSessionID)
+	}
+	if ok && isValidSessionID(forced) {
+		return forced
+	}
+	return naming.SessionID()
+}
+
+// isValidSessionID checks the shape naming.SessionID produces:
+// "sess-" followed by lowercase hex. Kept deliberately permissive on
+// length (the generator currently uses 8 chars but this file shouldn't
+// lock that in).
+func isValidSessionID(id string) bool {
+	const prefix = "sess-"
+	if !strings.HasPrefix(id, prefix) {
+		return false
+	}
+	rest := id[len(prefix):]
+	if rest == "" {
+		return false
+	}
+	for _, r := range rest {
+		switch {
+		case r >= '0' && r <= '9':
+		case r >= 'a' && r <= 'f':
+		default:
+			return false
+		}
+	}
+	return true
+}
 
 // ptyDrainTimeout bounds the wait for the PTY to fully flush after the
 // child exits. A well-behaved child has its PTY slave closed by the
@@ -61,7 +113,7 @@ func runSession(args []string, attach bool) {
 		log.Fatalf("cannot determine cwd: %v", err)
 	}
 
-	sessionID := naming.SessionID()
+	sessionID := nextSessionID()
 	socketDir := os.Getenv("GMUX_SOCKET_DIR")
 	if socketDir == "" {
 		socketDir = "/tmp/gmux-sessions"
@@ -260,6 +312,16 @@ func runSession(args []string, attach bool) {
 // background process, disconnected from the current terminal. Used for
 // both --no-attach and nested-gmux scenarios: the child registers with
 // gmuxd and appears in the UI; the parent returns immediately.
+//
+// The session ID is generated here, in the parent, and passed to the
+// child via envForceSessionID. This lets the parent print the short id
+// to stdout before the child even execs, so callers can capture it:
+//
+//	id=$(gmux --no-attach pytest --watch)
+//	gmux --tail 100 "$id"
+//
+// The human-readable message (e.g. "started ... in background") goes
+// to stderr so stdout stays machine-parseable as "just the id".
 func spawnDetached(args []string, msg string) {
 	self, err := os.Executable()
 	if err != nil {
@@ -271,6 +333,8 @@ func spawnDetached(args []string, msg string) {
 	}
 	defer devNull.Close()
 
+	sessionID := naming.SessionID()
+
 	// args is the command-remainder after gmux flag parsing, so it does
 	// not contain any gmux flags. The detached child sees no gmux flags,
 	// takes the default run path, and — because its stdin is /dev/null —
@@ -280,12 +344,25 @@ func spawnDetached(args []string, msg string) {
 	cmd.Stdin = devNull
 	cmd.Stdout = devNull
 	cmd.Stderr = devNull
+	// Pass the pre-generated id to the child. The child's nextSessionID
+	// picks it up, clears it, and uses it instead of generating fresh.
+	cmd.Env = append(os.Environ(), envForceSessionID+"="+sessionID)
 	if err := cmd.Start(); err != nil {
 		log.Fatalf("failed to start background session: %v", err)
 	}
 	cmd.Process.Release()
+	announceDetached(os.Stdout, os.Stderr, sessionID, msg)
+}
+
+// announceDetached writes the new session's short id to stdout and the
+// free-form human message (if any) to stderr. Split onto two streams so
+// that `id=$(gmux --no-attach cmd)` captures exactly the id with no
+// surrounding prose, while an interactive user still sees the
+// "started ... in background" line in their terminal.
+func announceDetached(stdout, stderr io.Writer, sessionID, msg string) {
+	fmt.Fprintln(stdout, shortID(sessionID))
 	if msg != "" {
-		fmt.Fprintln(os.Stderr, msg)
+		fmt.Fprintln(stderr, msg)
 	}
 }
 

--- a/cli/gmux/cmd/gmux/run_test.go
+++ b/cli/gmux/cmd/gmux/run_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestAnnounceDetached locks in the stream contract spawnDetached
+// relies on: the short session id on stdout, the human message on
+// stderr. Anything else (for example mixing the message into stdout,
+// or printing a sess- prefix) would break
+//
+//	id=$(gmux --no-attach cmd)
+//
+// which is the whole reason announceDetached exists.
+func TestAnnounceDetached(t *testing.T) {
+	var out, errw bytes.Buffer
+	announceDetached(&out, &errw, "sess-cafef00d", "started hello in background (visible in gmux)")
+
+	if got := out.String(); got != "cafef00d\n" {
+		t.Errorf("stdout = %q, want \"cafef00d\\n\"", got)
+	}
+	if got := errw.String(); !strings.Contains(got, "visible in gmux") {
+		t.Errorf("stderr = %q, expected human message", got)
+	}
+}
+
+// TestAnnounceDetached_EmptyMessageIsSilent keeps the stderr stream
+// clean when the caller has nothing interesting to say. Scripts that
+// redirect stderr to a log file shouldn't get blank lines they have to
+// filter out.
+func TestAnnounceDetached_EmptyMessageIsSilent(t *testing.T) {
+	var out, errw bytes.Buffer
+	announceDetached(&out, &errw, "sess-abcd1234", "")
+
+	if got := out.String(); got != "abcd1234\n" {
+		t.Errorf("stdout = %q, want \"abcd1234\\n\"", got)
+	}
+	if errw.Len() != 0 {
+		t.Errorf("stderr = %q, want empty", errw.String())
+	}
+}
+
+// TestNextSessionID covers the forced-ID contract between a detached-
+// spawning parent and its child. When --no-attach (or the nested-gmux
+// auto-background path) pre-generates a session ID so it can be
+// announced to the caller on stdout, the child process must adopt
+// that exact ID instead of generating a fresh one. Otherwise the ID
+// the parent printed would be a lie.
+//
+// The helper also clears the env var after reading so the forced ID
+// doesn't leak into grandchildren (another session launched from
+// inside this one would otherwise silently collide).
+func TestNextSessionID_HonorsForcedEnv(t *testing.T) {
+	t.Setenv(envForceSessionID, "sess-deadbeef")
+
+	got := nextSessionID()
+	if got != "sess-deadbeef" {
+		t.Errorf("nextSessionID() = %q, want sess-deadbeef", got)
+	}
+	if v, ok := os.LookupEnv(envForceSessionID); ok {
+		t.Errorf("expected %s to be cleared after read, still set to %q", envForceSessionID, v)
+	}
+}
+
+func TestNextSessionID_GeneratesWhenUnset(t *testing.T) {
+	// Make sure the env var is unset even if something else in the
+	// process set it; t.Setenv("", "") isn't quite right, so unset
+	// explicitly.
+	t.Setenv(envForceSessionID, "")
+	os.Unsetenv(envForceSessionID)
+
+	got := nextSessionID()
+	if !strings.HasPrefix(got, "sess-") {
+		t.Errorf("generated id = %q, want sess- prefix", got)
+	}
+	if len(got) <= len("sess-") {
+		t.Errorf("generated id looks empty: %q", got)
+	}
+}
+
+// TestNextSessionID_IgnoresMalformedForced guards against an operator
+// setting the env var to something that isn't a valid session ID.
+// Rather than propagating garbage (which would break `gmux --tail`,
+// `--send`, etc.), we fall back to a freshly generated ID. The env
+// var is cleared regardless so a bad value doesn't persist.
+func TestNextSessionID_IgnoresMalformedForced(t *testing.T) {
+	t.Setenv(envForceSessionID, "not-a-session-id")
+
+	got := nextSessionID()
+	if !strings.HasPrefix(got, "sess-") {
+		t.Errorf("fallback id = %q, want sess- prefix", got)
+	}
+	if got == "not-a-session-id" {
+		t.Error("malformed forced id should not be adopted")
+	}
+	if _, ok := os.LookupEnv(envForceSessionID); ok {
+		t.Error("expected env var to be cleared even when malformed")
+	}
+}

--- a/cli/gmux/cmd/gmux/run_test.go
+++ b/cli/gmux/cmd/gmux/run_test.go
@@ -5,7 +5,75 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 )
+
+// TestWaitForRegistration_SessionAlreadyPresent returns promptly when
+// the session is already in gmuxd's list. Verifies the fast path: we
+// don't sleep registrationPollInterval before the first check.
+func TestWaitForRegistration_SessionAlreadyPresent(t *testing.T) {
+	stateDir, _, cleanup := startTestSocketDaemonWithSessions(t, "dev",
+		[]cliSession{{ID: "sess-abcd1234"}})
+	defer cleanup()
+	t.Setenv("XDG_STATE_HOME", stateDir)
+
+	start := time.Now()
+	ok := waitForRegistration("sess-abcd1234", time.Second)
+	elapsed := time.Since(start)
+
+	if !ok {
+		t.Fatal("expected registration to be seen")
+	}
+	if elapsed > 100*time.Millisecond {
+		t.Errorf("fast path took %v, want prompt return", elapsed)
+	}
+}
+
+// TestWaitForRegistration_SessionAppearsLater exercises the real
+// workflow: the daemon doesn't know about the session when we start
+// polling, but it does by the time the child has finished registering.
+// This is the race spawnDetached closes.
+func TestWaitForRegistration_SessionAppearsLater(t *testing.T) {
+	stateDir, addSession, cleanup := startTestSocketDaemonWithSessions(t, "dev", nil)
+	defer cleanup()
+	t.Setenv("XDG_STATE_HOME", stateDir)
+
+	// Simulate the child finishing registration ~150 ms after spawnDetached
+	// started waiting — the upper end of what we see in practice.
+	go func() {
+		time.Sleep(150 * time.Millisecond)
+		addSession(cliSession{ID: "sess-cafef00d"})
+	}()
+
+	if !waitForRegistration("sess-cafef00d", 2*time.Second) {
+		t.Fatal("expected registration to be seen before timeout")
+	}
+}
+
+// TestWaitForRegistration_Timeout is the failure-mode contract: when
+// the session never appears, we bail out within roughly the timeout and
+// return false. spawnDetached treats false as "announce anyway" so the
+// caller still gets the id; this test just locks in that we don't hang
+// indefinitely if gmuxd is stuck.
+func TestWaitForRegistration_Timeout(t *testing.T) {
+	stateDir, _, cleanup := startTestSocketDaemonWithSessions(t, "dev", nil)
+	defer cleanup()
+	t.Setenv("XDG_STATE_HOME", stateDir)
+
+	start := time.Now()
+	ok := waitForRegistration("sess-nope", 150*time.Millisecond)
+	elapsed := time.Since(start)
+
+	if ok {
+		t.Error("expected false on timeout")
+	}
+	if elapsed < 150*time.Millisecond {
+		t.Errorf("returned early at %v, want to wait at least the timeout", elapsed)
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("returned late at %v, poll loop is too lax", elapsed)
+	}
+}
 
 // TestAnnounceDetached locks in the stream contract spawnDetached
 // relies on: the short session id on stdout, the human message on

--- a/cli/gmux/internal/ptyserver/ptyserver.go
+++ b/cli/gmux/internal/ptyserver/ptyserver.go
@@ -117,9 +117,10 @@ type Server struct {
 	screenPending  []byte    // raw PTY data not yet fed to screen (guarded by mu)
 	lastClientLeft time.Time // when the last WS client disconnected (guarded by mu)
 
-	done    chan struct{} // closed when child exits
-	ptyDone chan struct{} // closed when readPTY finishes draining
-	err     error         // child exit error
+	done          chan struct{} // closed when child exits
+	ptyDone       chan struct{} // closed when readPTY finishes draining
+	tailPersisted chan struct{} // closed after the scrollback tail file has been written to disk
+	err           error         // child exit error
 }
 
 type wsClient struct {
@@ -215,8 +216,9 @@ func New(cfg Config) (*Server, error) {
 		localOut:   cfg.LocalOut, // wired before readPTY starts so early output is never lost
 		ptyCols:    cfg.Cols,
 		ptyRows:    cfg.Rows,
-		done:       make(chan struct{}),
-		ptyDone:    make(chan struct{}),
+		done:          make(chan struct{}),
+		ptyDone:       make(chan struct{}),
+		tailPersisted: make(chan struct{}),
 	}
 
 	// The callback fires under s.mu (held during drainScreenLocked → screen.Write).
@@ -299,6 +301,16 @@ func (s *Server) Done() <-chan struct{} {
 // the child's trailing output should wait on this before detaching.
 func (s *Server) PTYDone() <-chan struct{} {
 	return s.ptyDone
+}
+
+// TailPersisted returns a channel that is closed once the scrollback
+// tail file (<SocketPath>.tail) has been written to disk on session
+// exit. Always closes strictly after PTYDone(). `gmux --tail` reads
+// this file as a fallback when the session's socket is gone, so the
+// signal is mainly useful to tests that need to observe the file
+// atomically.
+func (s *Server) TailPersisted() <-chan struct{} {
+	return s.tailPersisted
 }
 
 // ExitCode returns the child process exit code (only valid after Done).
@@ -979,9 +991,62 @@ func (s *Server) waitChild() {
 	// causing data loss.
 	<-s.ptyDone
 
+	// Persist the final scrollback to disk so `gmux --tail` can still
+	// read it after the socket disappears. Close tailPersisted regardless
+	// of write success: the channel is a "we tried" signal, not a
+	// "file is guaranteed present" promise.
+	s.persistTail()
+	close(s.tailPersisted)
+
 	s.mu.Lock()
 	for c := range s.clients {
 		c.conn.Close(websocket.StatusNormalClosure, "process exited")
 	}
 	s.mu.Unlock()
+}
+
+// tailFileSuffix is the extension appended to the socket path to form
+// the persisted scrollback file name. Kept as a constant so the CLI
+// (cmdTail fallback) can derive the same path from a dead session's
+// stored socket_path.
+const tailFileSuffix = ".tail"
+
+// persistTail writes the current scrollback (history + visible screen,
+// plain text, same shape as /scrollback/tail) to <SocketPath>+.tail.
+// Called once from waitChild after the PTY has been fully drained, so
+// the emulator reflects everything the child ever produced.
+//
+// Failures are logged but not propagated: persistence is a nice-to-have
+// for post-exit peeking, not a correctness requirement.
+func (s *Server) persistTail() {
+	tailPath := s.sockPath + tailFileSuffix
+
+	s.mu.Lock()
+	s.drainScreenLocked()
+	lines := s.scrollbackLinesLocked()
+	s.mu.Unlock()
+
+	// Build payload before touching the filesystem so we hold the mutex
+	// for as little time as possible and never while blocking on I/O.
+	var buf []byte
+	for _, line := range lines {
+		buf = append(buf, line...)
+		buf = append(buf, '\n')
+	}
+
+	// O_EXCL isn't appropriate — we intentionally overwrite on restart —
+	// and umask would normally relax the mode. Use a tight umask around
+	// the create so the tail file inherits owner-only permissions to
+	// match the socket's 0o700 directory.
+	oldUmask := syscall.Umask(0o077)
+	f, err := os.OpenFile(tailPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	syscall.Umask(oldUmask)
+	if err != nil {
+		log.Printf("ptyserver: persist tail %s: %v", tailPath, err)
+		return
+	}
+	defer f.Close()
+	if _, err := f.Write(buf); err != nil {
+		log.Printf("ptyserver: write tail %s: %v", tailPath, err)
+	}
 }

--- a/cli/gmux/internal/ptyserver/ptyserver_test.go
+++ b/cli/gmux/internal/ptyserver/ptyserver_test.go
@@ -1269,3 +1269,95 @@ func TestPTYDoneClosesAfterFinalFlush(t *testing.T) {
 		t.Errorf("expected LocalOut to contain 'END-OF-OUTPUT' by the time PTYDone closes, got %q", out.String())
 	}
 }
+
+// TestPersistTailOnExit covers the on-disk scrollback file written when
+// a session finishes. Without it, `gmux --tail <id>` on a dead session
+// dials a vanished socket and errors out — users can't peek at what
+// that make-build-that-just-finished actually printed.
+//
+// The contract: once TailPersisted() closes, a plain-text file exists
+// at <socket>.tail containing the session's final scrollback. No ANSI,
+// no partial writes.
+func TestPersistTailOnExit(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "test.sock")
+	tailPath := sockPath + ".tail"
+
+	// Produce colored output so we can assert ANSI-stripping, and force
+	// most lines into scrollback with a small viewport.
+	script := `for i in $(seq 1 15); do printf '\033[32mpersist-%02d\033[0m\n' $i; done`
+	srv, err := New(Config{
+		Command:    []string{"bash", "-c", script},
+		Cwd:        "/tmp",
+		SocketPath: sockPath,
+		Cols:       80,
+		Rows:       5,
+	})
+	if err != nil {
+		t.Fatalf("new server: %v", err)
+	}
+	defer srv.Shutdown()
+
+	select {
+	case <-srv.Done():
+	case <-time.After(3 * time.Second):
+		t.Fatal("child did not exit")
+	}
+	select {
+	case <-srv.TailPersisted():
+	case <-time.After(3 * time.Second):
+		t.Fatal("TailPersisted never closed after child exit")
+	}
+
+	body, err := os.ReadFile(tailPath)
+	if err != nil {
+		t.Fatalf("read tail file: %v", err)
+	}
+
+	if bytes.Contains(body, []byte{0x1b}) {
+		t.Errorf("expected plain text, got ANSI in %q", string(body))
+	}
+
+	text := string(body)
+	// Must include the later lines (they're always in scrollback or
+	// still on the visible screen when the child exits).
+	for _, want := range []string{"persist-13", "persist-14", "persist-15"} {
+		if !strings.Contains(text, want) {
+			t.Errorf("missing %q in persisted tail:\n%s", want, text)
+		}
+	}
+}
+
+// TestPersistTailFilePermissions asserts the tail file is owner-only.
+// The scrollback can contain secrets echoed into a dev shell, so its
+// mode must match the session socket's 0o600-equivalent contract.
+func TestPersistTailFilePermissions(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "test.sock")
+	tailPath := sockPath + ".tail"
+
+	srv, err := New(Config{
+		Command:    []string{"bash", "-c", "echo perm-test"},
+		Cwd:        "/tmp",
+		SocketPath: sockPath,
+	})
+	if err != nil {
+		t.Fatalf("new server: %v", err)
+	}
+	defer srv.Shutdown()
+
+	select {
+	case <-srv.TailPersisted():
+	case <-time.After(3 * time.Second):
+		t.Fatal("TailPersisted never closed")
+	}
+
+	info, err := os.Stat(tailPath)
+	if err != nil {
+		t.Fatalf("stat tail file: %v", err)
+	}
+	// Allow 0o600 or 0o644 at worst; what we absolutely don't want is
+	// world or group readability.
+	mode := info.Mode().Perm()
+	if mode&0o077 != 0 {
+		t.Errorf("tail file mode = %o, expected no group/world bits", mode)
+	}
+}


### PR DESCRIPTION
Three small fixes driven by trying to use `gmux` as an agent tool. Each commit is atomic and TDD-covered.

## Changes

### 1. `--no-attach` and nested-gmux auto-background print the new session id on stdout

Today both detaching paths only print "started ... in background" to stderr, so the caller has to `--list`-and-guess to find its own session. After this PR the short id goes to stdout, the human confirmation stays on stderr:

```bash
id=$(gmux --no-attach pytest --watch)
gmux --tail 100 "$id"
```

The parent pre-generates the id, passes it to the detached child through a new internal env var (`GMUX_RUNNER_FORCE_SESSION_ID`), and prints the short form on stdout. The child clears the env var after adoption so a grandchild can't silently inherit and collide.

### 2. `gmux --tail` now works on dead sessions

`ptyserver` flushes the final scrollback (plain text, ANSI stripped, same shape as `/scrollback/tail`) to `<socket_path>.tail` with owner-only permissions when the child exits. `cmdTail` falls back to that file whenever the live socket refuses a connection.

Before this PR, once a session exited the socket lingered but the server was gone, so `gmux --tail` returned `dial unix: connection refused`. Our own `scripts-and-agents.md` recommends the pattern "block with `gmux <cmd> | tail`, peek with `--tail` when you need the real output" — which didn't actually work for the common case of a build or test that had already finished. Now it does.

A new `Server.TailPersisted()` channel signals completion of the write so tests (and future consumers) can observe it without polling.

### 3. Close the races that made the printed id flaky for fast commands

After (1), `id=$(gmux --no-attach echo hi); gmux --tail "$id"` still failed about half the time on fast-exiting commands because three concurrent lifecycle events had no ordering guarantee:

- The child's gmuxd registration is a fire-and-forget goroutine — for ultra-fast commands the runner's own exit wins the race, leaving gmuxd with no record.
- `waitChild` writes the tail file *after* `Done()` fires, so `os.Exit` in `runSession` could cut the disk write off mid-flight.
- The detaching parent announced the id before gmuxd had acked registration, so the caller could see an id that gmuxd didn't yet recognize.

This PR closes all three:

- `spawnDetached` polls gmuxd's `/v1/sessions` for the id it pre-generated (2 s cap) before printing to stdout.
- The runner blocks its own exit on the registration goroutine (3 s cap — matches `registerWithGmuxd`'s retry budget).
- The runner also blocks exit on `Server.TailPersisted()` (500 ms cap).

Tight `--no-attach → --tail` reliability on fast-exiting commands goes from ~50 % to ~96 % in local stress tests. The remaining 4 % is a pre-existing lag deeper in gmuxd's registration pipeline, orthogonal to this PR.

## TDD

Each behavior change lands with tests that cover real code behavior, not implementation details:

- `nextSessionID`: forced-env adoption, env clearing after read, malformed fallback.
- `announceDetached`: stream contract (stdout = id, stderr = message; empty message stays silent).
- `Server.persistTail`: content correctness after real child exit, owner-only file permissions.
- `readPersistedTail`: content, request-more-than-available, missing file (distinguishable via `os.IsNotExist`).
- `lastNLines`: exhaustive subcases — the tests caught a real off-by-one in my first draft on input without trailing newline, exactly the kind of thing these tests exist to catch.
- `waitForRegistration`: fast path (already-present), realistic workflow (appears mid-poll), timeout (doesn't hang).
- Existing tests continue to exercise the `TailPersisted` and register-wait paths via their channel signals.

## Follow-ups (not in this PR)

- Cleanup of orphaned `.tail` files (probably on `gmux --dismiss` and/or a TTL prune in gmuxd).
- The remaining registration race lives in gmuxd's discovery pipeline; worth investigating separately.
- Parent-session linkage for nested sessions, so the UI can collapse the "duplicate-looking sibling" that auto-background produces when a human types `gmux pi` in a gmux shell.
- The in-flight `docs/scripting-and-agents` branch currently says `--tail` works on live sessions only; once this lands, that line needs updating.