### PR TITLE
perf(daemon): cache session file stats so unchanged conversations aren't re-parsed every scan

### DIFF
--- a/services/gmuxd/internal/conversations/index.go
+++ b/services/gmuxd/internal/conversations/index.go
@@ -43,6 +43,21 @@ type Index struct {
 	// byToolID maps "kind/toolID" → slug for reverse lookup
 	// (e.g., finding a conversation's slug from its tool UUID).
 	byToolID map[string]string
+	// fileStat caches (mtime, size) per file path so Scan() can skip
+	// re-parsing session files that haven't changed since the last
+	// scan. Pi/Claude/Codex session JSONL files can grow to tens of
+	// MB; without this cache, periodic rescans read and re-parse the
+	// entire session corpus every interval.
+	fileStat map[string]fileStat
+}
+
+// fileStat snapshots a file's mtime and size at index time. Two
+// snapshots compare equal iff the file is byte-identical to the last
+// indexed version (modulo mtime/size collisions, which are negligible
+// for append-only JSONL files).
+type fileStat struct {
+	modTimeUnixNano int64
+	size            int64
 }
 
 // New creates an empty index.
@@ -50,6 +65,7 @@ func New() *Index {
 	return &Index{
 		byKey:    make(map[string]Info),
 		byToolID: make(map[string]string),
+		fileStat: make(map[string]fileStat),
 	}
 }
 
@@ -173,6 +189,23 @@ func (idx *Index) Scan() {
 		}
 
 		for _, path := range allFiles {
+			stat, err := os.Stat(path)
+			if err != nil {
+				continue
+			}
+			snap := fileStat{
+				modTimeUnixNano: stat.ModTime().UnixNano(),
+				size:            stat.Size(),
+			}
+			if idx.unchanged(path, snap) {
+				continue
+			}
+			// Record the snapshot before the parse-and-filter chain so
+			// that even files we skip (parse errors, missing cwd, not
+			// resumable) don't get re-read on every scan. Any future
+			// change bumps mtime or size, which invalidates the cache.
+			idx.recordStat(path, snap)
+
 			fileInfo, err := sf.ParseSessionFile(path)
 			if err != nil {
 				continue
@@ -209,6 +242,26 @@ func (idx *Index) Scan() {
 			idx.Upsert(info)
 		}
 	}
+}
+
+// unchanged reports whether path was indexed previously with the same
+// mtime/size. Callers use this to skip re-parsing session files that
+// haven't been touched since the last scan.
+func (idx *Index) unchanged(path string, snap fileStat) bool {
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
+	cached, ok := idx.fileStat[path]
+	return ok && cached == snap
+}
+
+// recordStat memoizes the file's mtime/size so subsequent scans can
+// short-circuit. Stored regardless of whether parsing or filtering
+// succeeded: any future change to the file bumps mtime or size and
+// invalidates the cache.
+func (idx *Index) recordStat(path string, snap fileStat) {
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
+	idx.fileStat[path] = snap
 }
 
 // ScanFile indexes a single conversation file. Called by filemon when
@@ -251,7 +304,14 @@ func (idx *Index) ScanFile(a adapter.Adapter, path string) string {
 		ResumeCommand: cmd,
 		Created:       fileInfo.Created,
 	}
-	return idx.Upsert(info)
+	slug = idx.Upsert(info)
+	if stat, err := os.Stat(path); err == nil {
+		idx.recordStat(path, fileStat{
+			modTimeUnixNano: stat.ModTime().UnixNano(),
+			size:            stat.Size(),
+		})
+	}
+	return slug
 }
 
 // Remove deletes a conversation from the index by tool ID.
@@ -264,8 +324,14 @@ func (idx *Index) Remove(kind, toolID string) bool {
 	if !ok {
 		return false
 	}
+	ik := indexKey(kind, slug)
+	if info, ok := idx.byKey[ik]; ok && info.FilePath != "" {
+		// Drop the cached stat so a recreated file at the same path
+		// is re-parsed on the next scan.
+		delete(idx.fileStat, info.FilePath)
+	}
 	delete(idx.byToolID, tk)
-	delete(idx.byKey, indexKey(kind, slug))
+	delete(idx.byKey, ik)
 	return true
 }
 

--- a/services/gmuxd/internal/conversations/index_test.go
+++ b/services/gmuxd/internal/conversations/index_test.go
@@ -1,6 +1,8 @@
 package conversations
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -214,4 +216,87 @@ func TestAll(t *testing.T) {
 	}
 }
 
+// TestScan_SkipsUnchangedFiles verifies that Scan() does not re-parse
+// session files whose (mtime, size) match the last indexed snapshot.
+// Without this cache, Scan re-reads every JSONL session file every
+// interval, which on real systems with hundreds of MB of pi/claude/
+// codex history pegs a CPU core.
+//
+// Strategy: index a real pi session file, then mutate the in-memory
+// Info via Upsert (a sentinel marker). A re-Scan of the unchanged
+// file must keep the sentinel (cache hit, no re-parse). Bumping the
+// file's mtime must invalidate the cache and overwrite the sentinel.
+func TestScan_SkipsUnchangedFiles(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home) // claude/codex roots resolve under HOME
+	t.Setenv("PI_CODING_AGENT_DIR", filepath.Join(home, ".pi", "agent"))
+
+	cwd := t.TempDir()
+	piDir := filepath.Join(home, ".pi", "agent", "sessions", "--"+cwdEncode(cwd)+"--")
+	if err := os.MkdirAll(piDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sessionFile := filepath.Join(piDir, "sess.jsonl")
+	content := `{"type":"session","version":3,"id":"abc-123","timestamp":"2026-03-15T10:00:00Z","cwd":"` + cwd + `"}` + "\n" +
+		`{"type":"message","id":"u1","timestamp":"2026-03-15T10:01:00Z","message":{"role":"user","content":[{"type":"text","text":"original title"}]}}` + "\n"
+	if err := os.WriteFile(sessionFile, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	idx := New()
+	idx.Scan()
+
+	info, ok := idx.Lookup("pi", "original-title")
+	if !ok {
+		t.Fatalf("expected initial scan to index session file; got entries: %v", idx.All())
+	}
+
+	// Stamp a sentinel via Upsert. If the next Scan re-parses the file,
+	// the sentinel is overwritten with the on-disk title.
+	info.Title = "SENTINEL"
+	idx.Upsert(info)
+
+	idx.Scan()
+
+	after, _ := idx.Lookup("pi", "original-title")
+	if after.Title != "SENTINEL" {
+		t.Errorf("expected unchanged file to be skipped (title still SENTINEL), got %q", after.Title)
+	}
+
+	// Bump mtime; cache must invalidate and re-parse, overwriting the
+	// sentinel with the on-disk title.
+	future := time.Now().Add(time.Minute)
+	if err := os.Chtimes(sessionFile, future, future); err != nil {
+		t.Fatal(err)
+	}
+
+	idx.Scan()
+
+	after, _ = idx.Lookup("pi", "original-title")
+	if after.Title == "SENTINEL" {
+		t.Errorf("expected mtime change to invalidate cache and re-parse; sentinel still present")
+	}
+	if after.Title != "original title" {
+		t.Errorf("expected re-parsed title %q, got %q", "original title", after.Title)
+	}
+}
+
+// cwdEncode mirrors pi's filesystem encoding (strip leading /, replace
+// remaining / with -). Duplicating it here avoids a test dependency on
+// the adapters package's unexported helpers.
+func cwdEncode(cwd string) string {
+	s := cwd
+	if len(s) > 0 && s[0] == '/' {
+		s = s[1:]
+	}
+	out := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		if s[i] == '/' {
+			out = append(out, '-')
+		} else {
+			out = append(out, s[i])
+		}
+	}
+	return string(out)
+}
 


### PR DESCRIPTION
## Why

User reported steady-state ~90% CPU in gmuxd 1.2.0 with **0 alive sessions** and 32 known session dirs. The hot path is `convIndex.Scan()`, which runs every 30s in `gmuxd/cmd/gmuxd/main.go` and calls each adapter's `ParseSessionFile` (a full `os.ReadFile` + per-line `json.Unmarshal`) on every `.jsonl` under each adapter's session root.

Pi sessions accumulate: a single conversation file can grow to tens of MB (the source already calls this out in `extractPiText`). On my own dev machine (~380 MB across 490 pi/claude/codex files) a single `Scan()` already takes **4.6 seconds**. On a user with more or larger files, scans easily run longer than the 30s ticker interval, leaving the goroutine pinned to a core.

## What

Add a `(mtime, size)` snapshot per file path, taken before `ParseSessionFile`. If the snapshot matches the previous indexed value, skip the parse entirely. The snapshot is recorded for **every** file we visit (even ones we skip due to parse errors, missing cwd, or non-resumable content) so we don't re-pay parse cost on every interval just to drop the file again. Any future write bumps mtime or size, which invalidates the cache and re-parses.

## Numbers

Same dataset (490 files, ~380 MB), four sequential scans:

```
Scan #1: 4.63s, indexed 490 files
Scan #2: 2.76ms
Scan #3: 2.80ms
Scan #4: 2.56ms
```

~1700x speedup on the steady-state path. The first scan still pays full cost (correct: cold cache).

## State discipline

Per AGENTS.md, the new `fileStat` map is justified: it can't be derived from `byKey`/`byToolID` because we need a path-keyed lookup before parsing, and the avoided work (full reads of multi-MB JSONL) is exactly what was burning CPU. `Remove()` drops the corresponding cache entry so a recreated file at the same path is re-parsed.

## Testing

`TestScan_SkipsUnchangedFiles` verifies the behavior end-to-end: index a real pi session file, stamp a sentinel via `Upsert`, re-`Scan`, and assert the sentinel survives (cache hit). Then `os.Chtimes` to bump mtime and assert the next `Scan` overwrites the sentinel with the on-disk title (cache miss). I also confirmed the test fails when the cache check is forcibly disabled.