### PR TITLE
test(e2e): isolate test daemon from operator environment and enable in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,49 @@ jobs:
         env:
           GOWORK: ${{ github.workspace }}/go.work
 
+  e2e:
+    name: E2E (Playwright)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: "22"
+
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: "1.26"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Build gmux + frontend
+        run: ./scripts/build.sh
+        env:
+          GOWORK: ${{ github.workspace }}/go.work
+
+      - name: Run e2e tests
+        run: pnpm test:e2e
+        env:
+          E2E_SKIP_BUILD: "1"
+
+      - name: Upload Playwright artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: playwright-results
+          path: |
+            test-results/
+            playwright-report/
+          retention-days: 7
+
   release-scripts:
     name: Release scripts (version.sh tests)
     runs-on: ubuntu-latest

--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -332,6 +332,19 @@ function App() {
   const loc = useLocation()
   useEffect(() => {
     setNavigate((url, replace) => loc.route(url, replace))
+    // Test-only navigation hook: routes to a session by ID. Used by
+    // e2e/helpers.ts to drive the app from a known session ID, since
+    // the post-refactor home page no longer auto-selects.
+    //
+    // Returns true if the session was found in the store (and so
+    // navigation was attempted), false if sessions/projects haven't
+    // loaded yet (caller should retry).
+    ;(window as any).__gmuxNavigateToSession = (sessionId: string): boolean => {
+      const sess = sessions.value.find(s => s.id === sessionId)
+      if (!sess) return false
+      navigateToSession(sessionId, true)
+      return true
+    }
   }, [loc])
 
   // Sync preact-iso's URL to the store signal on every navigation.

--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -1,0 +1,68 @@
+# e2e harness
+
+Playwright suite that drives a real `gmuxd` + `gmux` against a real
+chromium. CI runs it on every PR via the `E2E (Playwright)` job in
+`.github/workflows/ci.yml`. Locally: `pnpm test:e2e`.
+
+## Isolation contract
+
+The harness must produce a daemon whose state is fully derived from
+this directory's setup, with no leakage from the operator's
+environment. Three paths can leak and have to stay plugged:
+
+1. **Socket discovery.** Sockets live in `$GMUX_SOCKET_DIR` (default
+   `/tmp/gmux-sessions`). `gmuxd start` re-execs to daemonize and
+   strips every `GMUX_*` env var on the way, so a `start`-launched
+   daemon falls back to the operator's `/tmp/gmux-sessions`.
+   **Fix:** spawn `gmuxd run` directly from `global-setup.ts`. Keeps
+   the env intact and gives us a real PID for teardown. Don't switch
+   back to `start` without first solving the env-strip.
+
+2. **Adapter session-file scanning.** The pi/claude/codex/shell
+   adapters resolve their session roots via `os.UserHomeDir()`, so a
+   real `$HOME` makes them index every conversation the operator
+   has on disk. **Fix:** override `HOME` to a fresh dir under
+   `tmpDir`.
+
+3. **Devcontainer discovery.** Reads the host's docker socket and
+   would enumerate operator containers. **Fix:** seed
+   `[discovery] devcontainers = false` in `host.toml`. Tailscale is
+   off by default but pinned explicitly in the same file so a
+   future default flip doesn't silently re-enable it for tests.
+
+`tests/harness.spec.ts` asserts the socket-discovery contract
+directly (one alive session, no peers, expected cwd). It does **not**
+catch HOME regressions: the symptom there (operator pi/claude
+conversations entering the index) doesn't currently surface in a
+public API in a way the harness can probe. HOME isolation is
+defense-in-depth for future tests that spawn agents like `pi` or
+`claude` (which would otherwise read the operator's real
+`~/.pi/agent/` etc.); audit it manually when touching this setup.
+
+## Test hooks on `window`
+
+Two hooks are exposed by the app for the harness; both are
+intentionally global because Playwright drives the page from the
+outside:
+
+- `__gmuxTerm` — the live xterm instance, exposed for assertions on
+  rows/cols/scroll state.
+- `__gmuxNavigateToSession(id)` — routes to a session by ID via the
+  store's `navigateToSession`. Returns `false` until the store has
+  loaded sessions and projects; the helper polls until it returns
+  `true`. Needed because the home page no longer auto-selects.
+
+Hooks should never gate or change product behavior. If a hook ever
+needs to do more than read state or call an existing public API,
+that's a sign the production API is missing something; fix the API
+instead of growing the hook.
+
+## Adding tests
+
+- Reach for `gotoTestSession(page)` to navigate. It handles auth,
+  store warm-up, navigation, and waits for the terminal.
+- Use `__gmuxTerm` for assertions about terminal state. Don't poke
+  at xterm internals without a hook; add one and document it here.
+- The test session is `bash -c 'echo READY; while true; do sleep 60; done'`
+  with `cwd=$tmpDir/workspace`. Don't depend on anything more
+  specific than that without changing the harness.

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,4 +1,4 @@
-import { spawn, execSync, type ChildProcess } from 'child_process'
+import { spawn, execSync } from 'child_process'
 import * as fs from 'fs'
 import * as net from 'net'
 import * as os from 'os'
@@ -37,22 +37,31 @@ async function waitForHealth(port: number, token: string, timeoutMs = 15_000): P
   throw new Error(`gmuxd did not become healthy on port ${port} within ${timeoutMs}ms`)
 }
 
-async function waitForSession(port: number, token: string, timeoutMs = 15_000): Promise<string> {
+/**
+ * Wait for *our* test session to appear, matching by cwd.
+ *
+ * The daemon-isolation work in this same setup means there should
+ * only ever be one alive session here. Matching by cwd is still the
+ * right contract though: it asserts we got the session we spawned,
+ * not whatever else might surface, so an isolation regression fails
+ * loudly here instead of one of the spec files.
+ */
+async function waitForSession(port: number, token: string, expectCwd: string, timeoutMs = 15_000): Promise<string> {
   const start = Date.now()
   const headers = { Authorization: `Bearer ${token}` }
   while (Date.now() - start < timeoutMs) {
     try {
       const resp = await fetch(`http://127.0.0.1:${port}/v1/sessions`, { headers })
-      const body = await resp.json() as { data: Array<{ id: string; alive: boolean }> }
-      const alive = body.data.filter(s => s.alive)
-      if (alive.length > 0) return alive[0].id
+      const body = await resp.json() as { data: Array<{ id: string; alive: boolean; cwd?: string }> }
+      const match = body.data.find(s => s.alive && s.cwd === expectCwd)
+      if (match) return match.id
     } catch { /* retry */ }
     await new Promise(r => setTimeout(r, 200))
   }
-  throw new Error(`No alive session found on port ${port} within ${timeoutMs}ms`)
+  throw new Error(`No alive session with cwd=${expectCwd} found on port ${port} within ${timeoutMs}ms`)
 }
 
-export default async function globalSetup(config: FullConfig) {
+export default async function globalSetup(_config: FullConfig) {
   // Build frontend + Go binaries so the embedded assets are always in sync
   // with the current source.  Runs unconditionally — both Vite and `go build`
   // are incremental, so a no-op rebuild finishes in seconds.
@@ -68,25 +77,73 @@ export default async function globalSetup(config: FullConfig) {
   const socketDir = path.join(tmpDir, 'sockets')
   const configDir = path.join(tmpDir, 'config')
   const stateDir = path.join(tmpDir, 'state')
+  // Workspace dir for the test session's cwd, so it matches the seeded
+  // project rule below. Without a matching project, the test session
+  // can't be reached via URL.
+  const workspaceDir = path.join(tmpDir, 'workspace')
   fs.mkdirSync(socketDir)
   fs.mkdirSync(configDir)
   fs.mkdirSync(stateDir)
+  fs.mkdirSync(workspaceDir)
 
-  // Write host.toml with the allocated port so gmuxd binds there instead of
-  // its default 8790 (which may be in use by a dev instance on the host).
+  // Seed projects.json with a single project rule matching workspaceDir.
+  // The test session is spawned with cwd=workspaceDir below, so it'll
+  // be matched into this project and reachable at /test-project/shell/...
+  // navigateToSession (called from the test helper) needs the session
+  // to belong to *some* project to compute a URL.
+  //
+  // Path layout matches paths.StateDir(): $XDG_STATE_HOME/gmux/.
+  const gmuxStateDir = path.join(stateDir, 'gmux')
+  fs.mkdirSync(gmuxStateDir, { recursive: true })
+  fs.writeFileSync(
+    path.join(gmuxStateDir, 'projects.json'),
+    JSON.stringify({
+      version: 2,
+      items: [
+        { slug: 'test-project', match: [{ path: workspaceDir }] },
+      ],
+    }),
+  )
+
+  // Write host.toml with:
+  //  - the allocated port (so gmuxd doesn't fight a dev instance on 8790)
+  //  - devcontainer discovery disabled (so the test daemon doesn't
+  //    enumerate the operator's running docker containers via the
+  //    host's docker socket; that's the last non-HOME, non-socketdir
+  //    path that can leak the operator's environment into the test).
+  //  - tailscale stays off by default; mention it explicitly so a
+  //    future default change doesn't silently re-enable it for tests.
   fs.mkdirSync(path.join(configDir, 'gmux'))
   fs.writeFileSync(
     path.join(configDir, 'gmux', 'host.toml'),
-    `port = ${port}\n`,
+    [
+      `port = ${port}`,
+      ``,
+      `[discovery]`,
+      `devcontainers = false`,
+      `tailscale = false`,
+      ``,
+      `[tailscale]`,
+      `enabled = false`,
+      ``,
+    ].join('\n'),
   )
 
   // Seed a known auth token so tests can authenticate without scraping the
   // generated token file. Must be >= 64 hex chars (authtoken.validateFormat).
   const testToken = 'e2e'.padEnd(64, '0')
 
+  // Isolation: a fake HOME under tmpDir prevents gmuxd's adapters
+  // (pi, claude, codex, shell) from discovering the operator's real
+  // session files via os.UserHomeDir(). Without this, the test
+  // gmuxd's session list contains every pi/claude/codex conversation
+  // the operator has on their machine. With it, gmuxd starts blank.
+  const fakeHome = path.join(tmpDir, 'home')
+  fs.mkdirSync(fakeHome)
+
   const env: Record<string, string> = {
     PATH: process.env.PATH || '',
-    HOME: process.env.HOME || '',
+    HOME: fakeHome,
     TERM: 'xterm-256color',
     GMUX_SOCKET_DIR: socketDir,
     GMUXD_TOKEN: testToken,
@@ -96,8 +153,19 @@ export default async function globalSetup(config: FullConfig) {
 
   const pids: number[] = []
 
-  // Start gmuxd
-  const gmuxd = spawn(GMUXD, ['start'], {
+  // Start gmuxd in foreground mode (`run`, not `start`).
+  //
+  // `gmuxd start` daemonizes by re-execing itself, and on the way
+  // strips every GMUX_* env var ("so the daemon doesn't inherit
+  // session identity"). That's correct for production, but it means
+  // GMUX_SOCKET_DIR and GMUXD_TOKEN never reach the actual daemon
+  // process; the test gmuxd would then read /tmp/gmux-sessions and
+  // surface the operator's real sessions as its own.
+  //
+  // `gmuxd run` doesn't strip the env, and we already detach the
+  // process ourselves, so we get the foreground process tree we need
+  // for both isolation and clean teardown by PID.
+  const gmuxd = spawn(GMUXD, ['run'], {
     env,
     stdio: ['ignore', 'pipe', 'pipe'],
     detached: true,
@@ -113,9 +181,11 @@ export default async function globalSetup(config: FullConfig) {
 
   await waitForHealth(port, testToken)
 
-  // Start a test shell session (non-interactive — no local terminal attach)
+  // Start a test shell session (non-interactive — no local terminal attach).
+  // cwd=workspaceDir so the session is matched into the seeded project.
   const gmux = spawn(GMUX, ['bash', '-c', 'echo READY; while true; do sleep 60; done'], {
     env,
+    cwd: workspaceDir,
     stdio: ['ignore', 'pipe', 'pipe'],
     detached: true,
   })
@@ -125,8 +195,10 @@ export default async function globalSetup(config: FullConfig) {
     if (process.env.DEBUG) process.stderr.write(`[gmux] ${d}`)
   })
 
-  // Wait for the session to appear in gmuxd
-  const sessionId = await waitForSession(port, testToken)
+  // Wait for the session to appear in gmuxd. Matched by cwd so we get
+  // exactly the session we just spawned (see comment on waitForSession
+  // for why this assertion still earns its keep after isolation).
+  const sessionId = await waitForSession(port, testToken, workspaceDir)
 
   // Save state for teardown and for test config
   fs.writeFileSync(STATE_FILE, JSON.stringify({

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -36,14 +36,33 @@ export async function isPillVisible(page: Page): Promise<boolean> {
 }
 
 /**
- * Wait for a session's terminal to be visible. The app auto-selects the
- * first alive session on load, so we don't need to click anything. If
- * auto-select hasn't kicked in (e.g. no sessions yet), the wait will time
- * out and the caller will see a clear failure.
+ * Navigate to the test session and wait for the terminal to be visible.
+ *
+ * The home page no longer auto-selects a session, so we drive
+ * navigation via the test-only `__gmuxNavigateToSession(id)` hook
+ * installed by main.tsx. The session ID is set by global-setup and
+ * exposed via GMUX_TEST_SESSION_ID.
  */
-export async function selectFirstSession(page: Page): Promise<void> {
+export async function gotoTestSession(page: Page): Promise<void> {
+  const sessionId = process.env.GMUX_TEST_SESSION_ID
+  if (!sessionId) throw new Error('GMUX_TEST_SESSION_ID not set; global-setup did not run')
+
+  // Wait for the store to load sessions/projects, then drive
+  // navigation. The hook returns false until the session appears in
+  // the store.
+  await page.waitForFunction((id) => {
+    const navigate = (window as any).__gmuxNavigateToSession
+    if (typeof navigate !== 'function') return false
+    return navigate(id) === true
+  }, sessionId, { timeout: 10_000 })
+
+  // Confirm navigation actually changed the URL before waiting for
+  // the terminal. If something redirects us back to /, fail loudly
+  // here. The slug `test-project` is seeded by global-setup.
+  await page.waitForURL(/\/test-project\/shell\//, { timeout: 5_000 })
+
   await page.locator('.xterm').waitFor({ state: 'visible', timeout: 5_000 })
-  // Give the WS connection time to establish and replay scrollback
+  // Give the WS connection time to establish and replay scrollback.
   await page.waitForTimeout(1500)
 }
 

--- a/e2e/tests/harness.spec.ts
+++ b/e2e/tests/harness.spec.ts
@@ -1,0 +1,63 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Asserts the harness's isolation contract directly. See
+ * `e2e/AGENTS.md` for the three leak paths these checks defend.
+ *
+ * If any of these fail, the rest of the suite is untrustworthy: a
+ * test that reads "the first alive session" or counts sidebar
+ * entries is silently coupled to whatever the operator happens to
+ * have running. Catching that here surfaces it as one named failure
+ * instead of a smear of unrelated flakes.
+ */
+test.describe('harness isolation', () => {
+  // No openApp/login here — these checks talk to the daemon
+  // directly. Auth is via the bearer token global-setup writes.
+  const port = () => process.env.GMUXD_TEST_PORT
+  const token = () => process.env.GMUX_TEST_TOKEN
+  const sessionId = () => process.env.GMUX_TEST_SESSION_ID
+  const headers = () => ({ Authorization: `Bearer ${token()}` })
+
+  test('daemon sees exactly one alive session and no peers', async () => {
+    const resp = await fetch(`http://127.0.0.1:${port()}/v1/health`, { headers: headers() })
+    expect(resp.ok).toBe(true)
+    const body = await resp.json() as {
+      data: {
+        sessions: { local_alive: number; remote_alive: number; dead: number }
+      }
+      // Peers may live at the top level or under data depending on
+      // the endpoint shape; we'll fetch /v1/peers separately for
+      // an authoritative answer.
+    }
+
+    expect(body.data.sessions.local_alive).toBe(1)
+    expect(body.data.sessions.remote_alive).toBe(0)
+
+    const peersResp = await fetch(`http://127.0.0.1:${port()}/v1/peers`, { headers: headers() })
+    if (peersResp.ok) {
+      const peers = await peersResp.json() as { data?: unknown[] }
+      // Peers payload is an array; empty means no remote hosts
+      // discovered. If the daemon ever auto-enables peer discovery
+      // by default, this fires.
+      expect(peers.data ?? []).toEqual([])
+    }
+  })
+
+  test('the alive session is the one we spawned', async () => {
+    const resp = await fetch(`http://127.0.0.1:${port()}/v1/sessions`, { headers: headers() })
+    expect(resp.ok).toBe(true)
+    const body = await resp.json() as {
+      data: Array<{ id: string; alive: boolean; cwd: string; kind: string }>
+    }
+    const alive = body.data.filter(s => s.alive)
+    expect(alive).toHaveLength(1)
+
+    const ours = alive[0]
+    expect(ours.id).toBe(sessionId())
+    expect(ours.kind).toBe('shell')
+    // The session was spawned with cwd=$tmpDir/workspace; we don't
+    // pin the exact path (it's per-run) but it must end in
+    // /workspace and live under the OS temp dir.
+    expect(ours.cwd).toMatch(/\/workspace$/)
+  })
+})

--- a/e2e/tests/terminal-connect.spec.ts
+++ b/e2e/tests/terminal-connect.spec.ts
@@ -1,10 +1,10 @@
 import { test, expect } from '@playwright/test'
-import { getTermState, openApp, selectFirstSession } from '../helpers'
+import { getTermState, openApp, gotoTestSession } from '../helpers'
 
 test.describe('terminal connection', () => {
   test('connects to session and renders terminal', async ({ page }) => {
     await openApp(page)
-    await selectFirstSession(page)
+    await gotoTestSession(page)
 
     // Terminal should exist and have dimensions
     const state = await getTermState(page)
@@ -17,7 +17,7 @@ test.describe('terminal connection', () => {
 
   test('terminal displays session output', async ({ page }) => {
     await openApp(page)
-    await selectFirstSession(page)
+    await gotoTestSession(page)
 
     // The test session runs `echo READY` — check that the terminal has content.
     // We can't easily read xterm's rendered content, but we can check that

--- a/e2e/tests/terminal-paste.spec.ts
+++ b/e2e/tests/terminal-paste.spec.ts
@@ -11,7 +11,7 @@
  * are inside the container and are never reached when stopPropagation() fires.
  */
 import { test, expect, type Page } from '@playwright/test'
-import { openApp, selectFirstSession } from '../helpers'
+import { openApp, gotoTestSession } from '../helpers'
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -73,7 +73,7 @@ test.describe('terminal paste', () => {
     })
 
     await openApp(page)
-    await selectFirstSession(page)
+    await gotoTestSession(page)
 
     // Discard any data sent during session setup (resize etc. are strings and
     // filtered out, but binary data like initial input isn't expected here).

--- a/e2e/tests/terminal-resize.spec.ts
+++ b/e2e/tests/terminal-resize.spec.ts
@@ -1,17 +1,17 @@
 import { test, expect } from '@playwright/test'
-import { getTermState, isPillVisible, openApp, selectFirstSession } from '../helpers'
+import { getTermState, isPillVisible, openApp, gotoTestSession } from '../helpers'
 
 test.describe('terminal resize', () => {
   test.beforeEach(async ({ page }) => {
     await openApp(page)
-    await selectFirstSession(page)
+    await gotoTestSession(page)
   })
 
   // NOTE: tests that need addInitScript before page load go outside this
   // describe block (below) so they can control navigation order.
 
   test('selecting a session claims: terminal fits viewport, no pill', async ({ page }) => {
-    // After selectFirstSession the browser has claimed ownership. Terminal
+    // After gotoTestSession the browser has claimed ownership. Terminal
     // should have a sensible size and the pill should be hidden.
     const state = await getTermState(page)
     expect(state.termCols).toBeGreaterThan(0)
@@ -48,7 +48,7 @@ test.describe('terminal resize', () => {
     await page.goto('about:blank')
     await page.setViewportSize({ width: 1400, height: 900 })
     await openApp(page)
-    await selectFirstSession(page)
+    await gotoTestSession(page)
 
     const large = await getTermState(page)
     expect(large.termCols!).toBeGreaterThan(small.termCols!)
@@ -84,7 +84,7 @@ test.describe('terminal resize — reconnect', () => {
     })
 
     await openApp(page)
-    await selectFirstSession(page)
+    await gotoTestSession(page)
 
     // Initial claim should have sent at least one resize.
     const initialCount = await page.evaluate(

--- a/e2e/tests/z-terminal-disconnect.spec.ts
+++ b/e2e/tests/z-terminal-disconnect.spec.ts
@@ -1,10 +1,10 @@
 import { test, expect } from '@playwright/test'
-import { openApp, selectFirstSession } from '../helpers'
+import { openApp, gotoTestSession } from '../helpers'
 
 test.describe('connection lost', () => {
   test('shows disconnected pill when backend stops', async ({ page }) => {
     await openApp(page)
-    await selectFirstSession(page)
+    await gotoTestSession(page)
 
     // Verify we're connected — no disconnected pill
     const pill = page.locator('.terminal-disconnected-pill')


### PR DESCRIPTION
## Why

The Playwright e2e suite was not running in CI and could not be
enabled safely: when run on a developer machine that already had a
real `gmuxd` instance and live agent sessions, the test daemon
discovered the operator's sessions and surfaced them as its own.
Tests that asserted on session counts or picked "the first alive
session" silently coupled to whatever the operator happened to
have open.

This PR plugs the leak paths so the test daemon starts truly empty,
asserts that contract with a focused harness spec, wires up the
routing the post-home-page-refactor app needs, and adds an
`E2E (Playwright)` job to `.github/workflows/ci.yml`.

## What was leaking, and the fix

| Leak path | Fix |
| --- | --- |
| `gmuxd start` re-execs to daemonize and strips every `GMUX_*` env var, so `GMUX_SOCKET_DIR` and `GMUXD_TOKEN` never reached the actual daemon process; it then read `/tmp/gmux-sessions` (the operator's socket dir). | Use `gmuxd run` in the e2e harness so the env survives. As a bonus, the captured PID is now the running daemon, which is why the previously-broken `z-terminal-disconnect.spec.ts` flips green here. |
| The pi/claude/codex/shell adapters resolve session roots via `os.UserHomeDir()`, so the conversation index scanned `~/.pi/agent/`, `~/.claude/`, etc. | Override `HOME` to a fresh dir under `tmpDir`. |
| Devcontainer discovery uses the host docker socket and would enumerate the operator's running containers. | Disable it (and pin tailscale off explicitly) in the seeded `host.toml`. |

After all three: `local_alive: 1`, `peers: []`. The test daemon
sees exactly one session: the one we spawned.

## Harness contract test

`e2e/tests/harness.spec.ts` asserts isolation directly: one alive
session, no peers, the alive session is the one we spawned (matched
by ID, kind, and `cwd` shape). Verified by mutation: temporarily
swapping `gmuxd run` back to `gmuxd start` makes the harness spec
fail with `Expected length: 1, Received length: 7` (the operator's
sessions plus ours), so the test catches the dominant regression
loud and clear instead of letting it bleed into unrelated specs.

HOME isolation is defense-in-depth (its symptoms don't currently
surface in a public API); that limit is documented in `e2e/AGENTS.md`
and called out in the harness spec docstring so a future change
can revisit it intentionally.

## Routing plumbing

The home-page refactor removed auto-select-first-session, so the
helper that drove the suite (`selectFirstSession`) had nothing to
drive. Three small changes:

- Seed `projects.json` at `$XDG_STATE_HOME/gmux/projects.json` with
  a rule matching the test session's `cwd`, so the session is
  reachable via URL.
- Expose a test-only `window.__gmuxNavigateToSession(id)` hook that
  calls the store's public `navigateToSession`. (An earlier draft
  bypassed the store via `loc.route` directly under a "stale closure"
  theory; verifying that theory empirically falsified it once
  isolation was fixed, so the hook now uses the public API.)
- Rename the helper to `gotoTestSession`. The old name was a lie
  post-refactor.

`waitForSession` matches by `cwd` rather than "first alive" so an
isolation regression fails the harness spec rather than silently
picking up a leaked session.

## CI

New job runs on every push/PR:

- `actions/setup-node@v6` + `pnpm/action-setup@v5` + `actions/setup-go@v6`
- `pnpm install --frozen-lockfile`
- `pnpm exec playwright install --with-deps chromium`
- `./scripts/build.sh` (web embed + Go binaries)
- `pnpm test:e2e` with `E2E_SKIP_BUILD=1`
- On failure, uploads `test-results/` and `playwright-report/` as a
  7-day artifact.

15-minute timeout. Suite runs in ~40 s locally, took 2m45s on the
first CI run, so plenty of headroom.

## Documentation

Adds `e2e/AGENTS.md` describing the isolation contract, the test
hooks on `window`, and conventions for adding new specs. The next
person to touch this directory should read it first.

## Test plan

- [x] `./scripts/build.sh && pnpm test:e2e` → 17/17 green locally
- [x] Mutation test: with `gmuxd start`, `harness.spec.ts` fails (verified)
- [x] `pnpm exec vitest run` → 262/262 green
- [x] `pnpm exec tsc --noEmit` in `apps/gmux-web` → clean
- [x] No zombie `gmuxd` processes left after the suite (foreground `run` + clean teardown)

## Out of scope

The `__gmuxInject` hook and the `terminal-scroll.spec.ts` cases for
the live-output-jumps-to-top scrollback bug are deliberately not
in this PR. They build on this foundation and will land separately
once it's merged.