### PR TITLE
fix(web): keep scroll position across pi/TUI scrollback wipes

### DIFF
--- a/apps/gmux-web/src/terminal-io.test.ts
+++ b/apps/gmux-web/src/terminal-io.test.ts
@@ -392,27 +392,50 @@ describe('scroll preservation across BSU/ESU', () => {
     h.cleanup()
   })
 
-  it('snaps to bottom when scrollback is wiped (\\x1b[3J) inside BSU/ESU and user was scrolled up', () => {
-    // The pi end-of-turn shape that the e2e fixture exercises: user is
-    // reading earlier output, agent emits a BSU + clear-scrollback +
-    // redraw + ESU. Scrollback shrinks underneath the user; their
-    // pre-BSU line is gone, so the only meaningful restore is bottom.
+  it('after scrollback wipe, restores user\'s distance from bottom when new buffer is large enough', () => {
+    // The user was reading 3 lines above the latest content (eg the
+    // last line of pi's previous turn). Pi ends a turn with
+    // \x1b[3J + redraw, scrollback gets rebuilt to ~15 lines. The
+    // user's pre-BSU absolute line is gone, but their *intent* ("keep
+    // me 3 lines above the newest content") is preserved.
     const h = makeScrollHarness({ scrollbackLimit: 5000, rows: 40 })
     h.io.reset(1)
-    h.addLines(200)            // baseY=200, plenty of scrollback
-    h.userScrollTo(100)        // user reading the middle
-    expect(h.viewportY).toBe(100)
-    expect(h.baseY).toBe(200)
+    h.addLines(200)            // baseY=200
+    h.userScrollTo(197)        // 3 lines above the bottom
+    expect(h.baseY - h.viewportY).toBe(3)
 
     h.io.enqueue(wrapBSU('redraw'), 1)
-    // Inside the BSU/ESU: agent emits \x1b[3J then redraws ~15 lines.
     h.clearScrollback()
-    h.addLines(15)
-    h.flushOne(0)              // ESU write callback
-    h.flushRAF()               // restore rAF
+    h.addLines(15)             // new baseY=15, plenty of room for distance=3
+    h.flushOne(0)
+    h.flushRAF()
+
+    // Distance preserved: viewportY == baseY - 3.
+    expect(h.scrollToLineCalls).toContain(h.baseY - 3)
+    expect(h.scrollToBottomCalls.length).toBe(0)
+    expect(h.baseY - h.viewportY).toBe(3)
+    h.cleanup()
+  })
+
+  it('after scrollback wipe, snaps to bottom when distance exceeds new buffer', () => {
+    // The pi end-of-turn shape from the e2e fixture: user was reading
+    // far back in scrollback (100 lines above the bottom), the new
+    // buffer is only ~15 lines, so the user's intent has nowhere to
+    // anchor. Snap to bottom: nothing else is meaningful.
+    const h = makeScrollHarness({ scrollbackLimit: 5000, rows: 40 })
+    h.io.reset(1)
+    h.addLines(200)
+    h.userScrollTo(100)        // 100 lines above the bottom
+    expect(h.baseY - h.viewportY).toBe(100)
+
+    h.io.enqueue(wrapBSU('redraw'), 1)
+    h.clearScrollback()
+    h.addLines(15)             // new baseY=15, distance(100) > baseY
+    h.flushOne(0)
+    h.flushRAF()
 
     // Pre-fix bug: scrollToLine(min(adjustedY=0, baseY=15)) = 0 (top).
-    // Post-fix: prevBaseY=200 > baseY=15 → scrollToBottom.
+    // Post-fix: prevDistanceFromBottom (100) > new baseY (15) → bottom.
     expect(h.scrollToBottomCalls.length).toBeGreaterThan(0)
     expect(h.viewportY).toBe(h.baseY)
     h.cleanup()

--- a/apps/gmux-web/src/terminal-io.test.ts
+++ b/apps/gmux-web/src/terminal-io.test.ts
@@ -47,9 +47,13 @@ function makeScrollHarness(opts: { scrollbackLimit: number; rows: number }) {
 
   const scrollToLineCalls: number[] = []
   const scrollToBottomCalls: number[] = [] // tracks call count
+  // Per-line content for anchor-matching tests. y → visible text. Lines
+  // not in the map return null from getLine() (the production accessor
+  // also returns null for empty / trivial lines).
+  const lineContent = new Map<number, string>()
 
   const scroll: ScrollAccessor = {
-    getState: () => ({ viewportY, baseY }),
+    getState: () => ({ viewportY, baseY, rows }),
     scrollToLine(line: number) {
       scrollToLineCalls.push(line)
       viewportY = Math.max(0, Math.min(line, baseY))
@@ -57,6 +61,9 @@ function makeScrollHarness(opts: { scrollbackLimit: number; rows: number }) {
     scrollToBottom() {
       scrollToBottomCalls.push(baseY)
       viewportY = baseY
+    },
+    getLine(y: number): string | null {
+      return lineContent.get(y) ?? null
     },
   }
 
@@ -135,6 +142,12 @@ function makeScrollHarness(opts: { scrollbackLimit: number; rows: number }) {
       totalLines = rows
       baseY = 0
       viewportY = 0
+      lineContent.clear()
+    },
+
+    /** Set the visible text of the buffer line at `y`. */
+    setLine(y: number, text: string) {
+      lineContent.set(y, text)
     },
 
     /**
@@ -457,6 +470,183 @@ describe('scroll preservation across BSU/ESU', () => {
     // No wipe happened, just growth. The user was implicitly at bottom
     // (viewportY=0=baseY=0 pre-BSU), so the wasAtBottom branch fires.
     expect(h.viewportY).toBe(h.baseY)
+    h.cleanup()
+  })
+
+  it('after scrollback wipe, jumps to the line whose content matches the user\'s anchor', () => {
+    // The user is reading a recognizable line ("ERROR: cannot find
+    // foo"). The agent emits a wipe + redraw, the same line reappears
+    // in the new buffer at a different position. Anchor-match wins
+    // over distance restoration.
+    const h = makeScrollHarness({ scrollbackLimit: 5000, rows: 40 })
+    h.io.reset(1)
+    h.addLines(200)
+    h.userScrollTo(150)
+    h.setLine(150, 'ERROR: cannot find foo')
+    expect(h.baseY - h.viewportY).toBe(50)
+
+    h.io.enqueue(wrapBSU('redraw'), 1)
+    h.clearScrollback()
+    h.addLines(80)
+    // Same line lands at a different y after the redraw.
+    h.setLine(60, 'ERROR: cannot find foo')
+    h.flushOne(0)
+    h.flushRAF()
+
+    // Anchor matched at y=60: scroll there, no bottom snap.
+    expect(h.scrollToLineCalls).toContain(60)
+    expect(h.scrollToBottomCalls.length).toBe(0)
+    expect(h.viewportY).toBe(60)
+    h.cleanup()
+  })
+
+  it('after scrollback wipe with multiple anchor matches, picks the one closest to prevDistanceFromBottom', () => {
+    // The anchor line appears three times in the redraw. The match
+    // closest to the user's pre-wipe distance from the bottom (5)
+    // wins. The winning y is deliberately chosen so it differs from
+    // the distance-fallback position (baseY - prevDistance = 15),
+    // so a regression that disables anchor matching is caught here.
+    const h = makeScrollHarness({ scrollbackLimit: 5000, rows: 40 })
+    h.io.reset(1)
+    h.addLines(50)
+    h.userScrollTo(45)         // distance = 5
+    h.setLine(45, 'session ready')
+    expect(h.baseY - h.viewportY).toBe(5)
+
+    h.io.enqueue(wrapBSU('redraw'), 1)
+    h.clearScrollback()
+    h.addLines(20)             // new baseY=20
+    h.setLine(12, 'session ready')  // distance: 8, |8-5|=3
+    h.setLine(16, 'session ready')  // distance: 4, |4-5|=1 ← winner
+    h.setLine(18, 'session ready')  // distance: 2, |2-5|=3
+    h.flushOne(0)
+    h.flushRAF()
+
+    // y=16 is the closest match. Distance fallback would have given
+    // y=15, so this assertion is sensitive to anchor matching being
+    // active rather than coincidentally matching the fallback.
+    expect(h.scrollToLineCalls).toContain(16)
+    expect(h.viewportY).toBe(16)
+    h.cleanup()
+  })
+
+  it('after scrollback wipe, falls back to distance restoration when anchor is null', () => {
+    // The user was on a trivial line so getLine returned null and
+    // savedScroll.prevAnchorLine is null. We fall through to the
+    // distance restoration path.
+    const h = makeScrollHarness({ scrollbackLimit: 5000, rows: 40 })
+    h.io.reset(1)
+    h.addLines(50)
+    h.userScrollTo(47)         // distance = 3
+    // Deliberately NOT calling setLine: getLine returns null (the
+    // production accessor's filter for trivial lines).
+
+    h.io.enqueue(wrapBSU('redraw'), 1)
+    h.clearScrollback()
+    h.addLines(20)             // new baseY=20
+    h.setLine(17, 'unrelated content')  // present but won't match anything
+    h.flushOne(0)
+    h.flushRAF()
+
+    // No anchor captured → distance fallback: 20 - 3 = 17.
+    expect(h.scrollToLineCalls).toContain(17)
+    expect(h.viewportY).toBe(17)
+    h.cleanup()
+  })
+
+  it('after scrollback wipe, anchor in visible region snaps to bottom with the anchor still in view', () => {
+    // Mid-distance scenario: the user was scrolled up just a few
+    // lines, reading streaming output. After the wipe their anchor
+    // line ends up in the visible region of the new buffer, not
+    // scrollback. `scrollToLine` clamps to baseY, so the best we
+    // can do is `scrollToBottom` and let the anchor sit somewhere
+    // in the visible region rather than disappearing entirely or
+    // landing the user at distance restoration's chosen y where
+    // the anchor may be off-screen.
+    //
+    // Concretely: pre-wipe distance = 5. Post-wipe baseY = 5 with
+    // the anchor placed at y = 20 (visible region [5, 44]). With
+    // the search bounded to [0, baseY] (the previous behavior),
+    // anchor matching would miss and distance restoration would
+    // land the user at viewportY = 0. With the search extended to
+    // the full buffer, we land at viewportY = baseY = 5, with the
+    // anchor visible at offset 15 of the viewport. The two
+    // viewportY values differ, so this test catches a regression
+    // that re-narrows the search range.
+    const h = makeScrollHarness({ scrollbackLimit: 5000, rows: 40 })
+    h.io.reset(1)
+    h.addLines(50)
+    h.userScrollTo(45)         // distance = 5
+    h.setLine(45, 'streaming-target')
+    expect(h.baseY - h.viewportY).toBe(5)
+
+    h.io.enqueue(wrapBSU('redraw'), 1)
+    h.clearScrollback()
+    h.addLines(5)              // new baseY=5; total = baseY+rows = 45
+    h.setLine(20, 'streaming-target')  // y=20 in visible region [5, 44]
+    h.flushOne(0)
+    h.flushRAF()
+
+    // Visible-region match → restoreY = min(20, 5) = 5 (= at-bottom).
+    expect(h.scrollToLineCalls).toContain(5)
+    expect(h.viewportY).toBe(5)
+    h.cleanup()
+  })
+
+  it('after scrollback wipe with both scrollback and visible matches, picks by closeness to prevDistanceFromBottom', () => {
+    // Anchor appears in both regions. The user's pre-wipe distance
+    // (1) is close to the visible match's restore-distance (0,
+    // since visible matches force scrollToBottom) and far from the
+    // scrollback match's restore-distance (13). Tiebreaker picks
+    // the visible match.
+    //
+    // Without the full-buffer search, the visible match would never
+    // be considered, the scrollback match would win by default,
+    // and viewportY would land at 2 instead of baseY (= 15). The
+    // two outcomes differ, so this catches a regression that
+    // re-narrows the search range.
+    const h = makeScrollHarness({ scrollbackLimit: 5000, rows: 40 })
+    h.io.reset(1)
+    h.addLines(50)
+    h.userScrollTo(49)         // distance = 1 (just barely scrolled up)
+    h.setLine(49, 'shared-line')
+    expect(h.baseY - h.viewportY).toBe(1)
+
+    h.io.enqueue(wrapBSU('redraw'), 1)
+    h.clearScrollback()
+    h.addLines(15)             // new baseY=15; visible region [15, 54]
+    h.setLine(2, 'shared-line')   // scrollback: restoreY=2,  restoreDistance=13, diff=12
+    h.setLine(30, 'shared-line')  // visible:    restoreY=15, restoreDistance=0,  diff=1
+    h.flushOne(0)
+    h.flushRAF()
+
+    // Visible match wins because its restore-distance is closer to
+    // the pre-wipe distance.
+    expect(h.scrollToLineCalls).toContain(15)
+    expect(h.viewportY).toBe(15)
+    h.cleanup()
+  })
+
+  it('after scrollback wipe, falls back to distance when anchor does not match anywhere', () => {
+    // The agent's redraw doesn't include the user's pre-wipe content
+    // (eg pi's status-bar-only redraw vs the user reading prior
+    // conversation output). Distance restoration takes over.
+    const h = makeScrollHarness({ scrollbackLimit: 5000, rows: 40 })
+    h.io.reset(1)
+    h.addLines(50)
+    h.userScrollTo(47)         // distance = 3
+    h.setLine(47, 'previous turn output line')
+
+    h.io.enqueue(wrapBSU('redraw'), 1)
+    h.clearScrollback()
+    h.addLines(20)             // new baseY=20
+    h.setLine(10, 'pi status bar version 0.70.2')  // wholly different
+    h.flushOne(0)
+    h.flushRAF()
+
+    // No match → distance fallback: 20 - 3 = 17.
+    expect(h.scrollToLineCalls).toContain(17)
+    expect(h.viewportY).toBe(17)
     h.cleanup()
   })
 

--- a/apps/gmux-web/src/terminal-io.ts
+++ b/apps/gmux-web/src/terminal-io.ts
@@ -15,9 +15,25 @@ export interface TerminalSize {
  * position across synchronized output (BSU/ESU) blocks.
  */
 export interface ScrollAccessor {
-  getState(): { viewportY: number; baseY: number }
+  /**
+   * `viewportY` is the buffer row at the top of the visible region;
+   * `baseY` is the largest valid `viewportY` (ie at-bottom). The total
+   * buffer occupies `[0, baseY + rows)` so that `getLine(y)` is
+   * meaningful across that whole range — anchor matching needs to
+   * search the visible region too, not just scrollback, since a line
+   * we saw pre-wipe can land in either area post-wipe.
+   */
+  getState(): { viewportY: number; baseY: number; rows: number }
   scrollToLine(line: number): void
   scrollToBottom(): void
+  /**
+   * Read the visible text of the buffer line at `y` (post-trim, no ANSI
+   * codes). Returns null if the line doesn't exist or is too trivial to
+   * use as a scroll-restore anchor. "Too trivial" deliberately filters
+   * out empty / whitespace-only / very short lines so a wipe-and-redraw
+   * doesn't snap the user to the first stretch of separators it finds.
+   */
+  getLine(y: number): string | null
 }
 
 interface QueueItem {
@@ -55,20 +71,29 @@ export function createTerminalIO(term: TerminalWriter, scroll?: ScrollAccessor):
   let pendingResize: (TerminalSize & { epoch: number }) | null = null
 
   // Scroll preservation across BSU/ESU blocks.
-  // wasAtBottom, prevBaseY, prevDistanceFromBottom are saved at BSU time;
-  // the post-parse viewportY is captured later at ESU write-callback time,
-  // after xterm has adjusted viewportY for any scrollback evictions.
+  // wasAtBottom, prevBaseY, prevDistanceFromBottom, prevAnchorLine are
+  // saved at BSU time; the post-parse viewportY is captured later at ESU
+  // write-callback time, after xterm has adjusted viewportY for any
+  // scrollback evictions.
   //
-  // prevBaseY detects scrollback wipes (eg `\x1b[3J`): when baseY shrinks
-  // across the BSU/ESU block, the user's pre-BSU line is gone, so the
-  // post-parse viewportY (typically 0 after a wipe) is a meaningless
-  // anchor. prevDistanceFromBottom lets us re-anchor relative to the new
-  // bottom instead, preserving the user's intent ("I was reading N lines
-  // above the latest content").
+  // The wipe branch (baseY shrinks across BSU/ESU, eg via `\x1b[3J`)
+  // tries three anchors in order, falling through on each miss:
+  //
+  //   1. prevAnchorLine — the visible text the user was reading. If the
+  //      redraw still contains that line we know exactly where the user
+  //      wants to be. Multiple matches are tiebroken by closeness to
+  //      prevDistanceFromBottom, so common lines (eg "✓ done") still
+  //      land somewhere reasonable.
+  //   2. prevDistanceFromBottom — if the new buffer has room, restore
+  //      the user's pre-wipe distance from the bottom. Loses the
+  //      identity of the line they were reading but keeps their intent
+  //      ("N lines above the latest content").
+  //   3. scrollToBottom — nothing else is meaningful.
   let savedScroll: {
     wasAtBottom: boolean
     prevBaseY: number
     prevDistanceFromBottom: number
+    prevAnchorLine: string | null
   } | null = null
   let restoreRAF: number | null = null
 
@@ -93,16 +118,25 @@ export function createTerminalIO(term: TerminalWriter, scroll?: ScrollAccessor):
       const { viewportY, baseY } = scroll.getState()
       const distance = Math.max(0, baseY - viewportY)
       if (forceScrollToBottom) {
-        savedScroll = { wasAtBottom: true, prevBaseY: baseY, prevDistanceFromBottom: 0 }
+        savedScroll = {
+          wasAtBottom: true,
+          prevBaseY: baseY,
+          prevDistanceFromBottom: 0,
+          prevAnchorLine: null,
+        }
         forceScrollToBottom = false
       } else {
         // Strict equality: only consider the user "at bottom" if the
         // viewport is exactly at the end. A loose threshold (e.g. <= 3)
         // would fight the user's scroll intent during rapid TUI redraws.
+        const wasAtBottom = viewportY >= baseY
         savedScroll = {
-          wasAtBottom: viewportY >= baseY,
+          wasAtBottom,
           prevBaseY: baseY,
           prevDistanceFromBottom: distance,
+          // Only capture the anchor when scrolled up: at-bottom always
+          // wants scrollToBottom and never reaches the search.
+          prevAnchorLine: wasAtBottom ? null : scroll.getLine(viewportY),
         }
       }
     }
@@ -137,7 +171,7 @@ export function createTerminalIO(term: TerminalWriter, scroll?: ScrollAccessor):
 
     restoreRAF = requestAnimationFrame(() => {
       restoreRAF = null
-      const { viewportY, baseY } = scroll.getState()
+      const { viewportY, baseY, rows } = scroll.getState()
       if (snap.wasAtBottom || viewportY >= baseY) {
         // Was at bottom before BSU, or user/code scrolled to bottom during
         // the BSU block — stay there.
@@ -146,19 +180,19 @@ export function createTerminalIO(term: TerminalWriter, scroll?: ScrollAccessor):
         // Scrollback shrank during the BSU/ESU block. The dominant cause
         // is `\x1b[3J` (clear scrollback), which agents like pi emit at
         // end-of-turn redraws and which resets ybase/ydisp to 0. The
-        // user's pre-BSU line no longer exists; adjustedY points at the
-        // top of a freshly-rebuilt buffer, which is the "jump to top" bug.
-        // Eviction within a full scrollback never reaches this branch
-        // because it leaves baseY at the cap.
+        // user's pre-BSU line is gone from xterm's perspective; adjustedY
+        // points at the top of a freshly-rebuilt buffer, which is the
+        // "jump to top" bug. Eviction within a full scrollback never
+        // reaches this branch because it leaves baseY at the cap.
         //
-        // We don't know the user's pre-BSU position relative to the top
-        // of the buffer in any meaningful sense, but we do know it
-        // relative to the bottom: prevDistanceFromBottom. If the new
-        // buffer is large enough to anchor against, restore that
-        // distance, preserving the user's intent ("keep me N lines above
-        // the latest content"). If it's not, snap to bottom; nothing
-        // else is meaningful.
-        if (snap.prevDistanceFromBottom <= baseY) {
+        // We try three anchors in order, falling through on each miss
+        // (rationale on the savedScroll declaration above).
+        const anchorY = snap.prevAnchorLine !== null
+          ? findAnchorMatch(scroll, snap.prevAnchorLine, baseY, rows, snap.prevDistanceFromBottom)
+          : null
+        if (anchorY !== null) {
+          scroll.scrollToLine(anchorY)
+        } else if (snap.prevDistanceFromBottom <= baseY) {
           scroll.scrollToLine(baseY - snap.prevDistanceFromBottom)
         } else {
           scroll.scrollToBottom()
@@ -252,4 +286,52 @@ export function createTerminalIO(term: TerminalWriter, scroll?: ScrollAccessor):
       return writeInFlight || queue.length > 0 || (!!pendingResize && pendingResize.epoch === currentEpoch)
     },
   }
+}
+
+/**
+ * Find the best post-wipe scroll target whose line content matches the
+ * pre-wipe anchor.
+ *
+ * Searches the **whole buffer**, not just `[0, baseY]`. A match at
+ * `y > baseY` lives in the visible region, so we can't position the
+ * viewport's top there directly (`scrollToLine` clamps to `baseY`),
+ * but `scrollToBottom` keeps the line in the viewport at offset
+ * `y - baseY`, which is the user's anchor visibly preserved.
+ *
+ * The restore target for a match at `y` is therefore `min(y, baseY)`:
+ *
+ *   - scrollback match (`y <= baseY`): anchor lands at the top of the
+ *     viewport, exactly where the user had it.
+ *   - visible-region match (`y > baseY`): viewport snaps to the bottom
+ *     and the anchor sits somewhere inside the visible region, still
+ *     readable.
+ *
+ * Tiebreak by closeness to the pre-wipe `distanceFromBottom`. Multiple
+ * visible-region matches all collapse to the same target (`baseY`)
+ * with the same restore-distance (`0`); among scrollback matches we
+ * prefer the one whose `baseY - y` is closest to the captured
+ * distance, so the user's relative scroll position is preserved when
+ * possible.
+ */
+function findAnchorMatch(
+  scroll: ScrollAccessor,
+  anchor: string,
+  baseY: number,
+  rows: number,
+  prevDistanceFromBottom: number,
+): number | null {
+  let best: number | null = null
+  let bestDiff = Number.POSITIVE_INFINITY
+  const totalLines = baseY + rows
+  for (let y = 0; y < totalLines; y++) {
+    if (scroll.getLine(y) !== anchor) continue
+    const restoreY = Math.min(y, baseY)
+    const restoreDistance = baseY - restoreY
+    const diff = Math.abs(restoreDistance - prevDistanceFromBottom)
+    if (diff < bestDiff) {
+      best = restoreY
+      bestDiff = diff
+    }
+  }
+  return best
 }

--- a/apps/gmux-web/src/terminal-io.ts
+++ b/apps/gmux-web/src/terminal-io.ts
@@ -55,13 +55,21 @@ export function createTerminalIO(term: TerminalWriter, scroll?: ScrollAccessor):
   let pendingResize: (TerminalSize & { epoch: number }) | null = null
 
   // Scroll preservation across BSU/ESU blocks.
-  // wasAtBottom and prevBaseY are saved at BSU time; the actual viewportY
-  // is captured later, at ESU write-callback time, after xterm has
-  // processed the data and adjusted viewportY for any scrollback evictions.
-  // prevBaseY exists to detect scrollback wipes (eg \x1b[3J): if baseY
-  // shrinks across a BSU/ESU block, the user's pre-BSU line is gone and
-  // we must snap to bottom rather than restoring to a stale position.
-  let savedScroll: { wasAtBottom: boolean; prevBaseY: number } | null = null
+  // wasAtBottom, prevBaseY, prevDistanceFromBottom are saved at BSU time;
+  // the post-parse viewportY is captured later at ESU write-callback time,
+  // after xterm has adjusted viewportY for any scrollback evictions.
+  //
+  // prevBaseY detects scrollback wipes (eg `\x1b[3J`): when baseY shrinks
+  // across the BSU/ESU block, the user's pre-BSU line is gone, so the
+  // post-parse viewportY (typically 0 after a wipe) is a meaningless
+  // anchor. prevDistanceFromBottom lets us re-anchor relative to the new
+  // bottom instead, preserving the user's intent ("I was reading N lines
+  // above the latest content").
+  let savedScroll: {
+    wasAtBottom: boolean
+    prevBaseY: number
+    prevDistanceFromBottom: number
+  } | null = null
   let restoreRAF: number | null = null
 
   // When true, the next BSU/ESU block will scroll to bottom unconditionally
@@ -83,14 +91,19 @@ export function createTerminalIO(term: TerminalWriter, scroll?: ScrollAccessor):
     if (!scroll || savedScroll) return // already saved, or no accessor
     if (startsWith(data, BSU) || containsSequence(data, BSU)) {
       const { viewportY, baseY } = scroll.getState()
+      const distance = Math.max(0, baseY - viewportY)
       if (forceScrollToBottom) {
-        savedScroll = { wasAtBottom: true, prevBaseY: baseY }
+        savedScroll = { wasAtBottom: true, prevBaseY: baseY, prevDistanceFromBottom: 0 }
         forceScrollToBottom = false
       } else {
         // Strict equality: only consider the user "at bottom" if the
         // viewport is exactly at the end. A loose threshold (e.g. <= 3)
         // would fight the user's scroll intent during rapid TUI redraws.
-        savedScroll = { wasAtBottom: viewportY >= baseY, prevBaseY: baseY }
+        savedScroll = {
+          wasAtBottom: viewportY >= baseY,
+          prevBaseY: baseY,
+          prevDistanceFromBottom: distance,
+        }
       }
     }
   }
@@ -133,13 +146,23 @@ export function createTerminalIO(term: TerminalWriter, scroll?: ScrollAccessor):
         // Scrollback shrank during the BSU/ESU block. The dominant cause
         // is `\x1b[3J` (clear scrollback), which agents like pi emit at
         // end-of-turn redraws and which resets ybase/ydisp to 0. The
-        // user's pre-BSU line no longer exists, so adjustedY would point
-        // at (or near) the top of a freshly-rebuilt buffer; restoring
-        // there is the long-standing "jump to top" bug. Eviction within a
-        // full scrollback never reaches this branch because it leaves
-        // baseY at the cap. Snap to bottom: it's the only position that's
-        // meaningful after the buffer is reset.
-        scroll.scrollToBottom()
+        // user's pre-BSU line no longer exists; adjustedY points at the
+        // top of a freshly-rebuilt buffer, which is the "jump to top" bug.
+        // Eviction within a full scrollback never reaches this branch
+        // because it leaves baseY at the cap.
+        //
+        // We don't know the user's pre-BSU position relative to the top
+        // of the buffer in any meaningful sense, but we do know it
+        // relative to the bottom: prevDistanceFromBottom. If the new
+        // buffer is large enough to anchor against, restore that
+        // distance, preserving the user's intent ("keep me N lines above
+        // the latest content"). If it's not, snap to bottom; nothing
+        // else is meaningful.
+        if (snap.prevDistanceFromBottom <= baseY) {
+          scroll.scrollToLine(baseY - snap.prevDistanceFromBottom)
+        } else {
+          scroll.scrollToBottom()
+        }
       } else {
         // User was scrolled up — restore the post-parse position, clamped
         // to the current buffer range. We use adjustedY (captured after xterm

--- a/apps/gmux-web/src/terminal.tsx
+++ b/apps/gmux-web/src/terminal.tsx
@@ -401,10 +401,21 @@ export function TerminalView({
     termIoRef.current = createTerminalIO(term, {
       getState() {
         const buf = term.buffer.active
-        return { viewportY: buf.viewportY, baseY: buf.baseY }
+        return { viewportY: buf.viewportY, baseY: buf.baseY, rows: term.rows }
       },
       scrollToLine(line: number) { term.scrollToLine(line) },
       scrollToBottom() { term.scrollToBottom() },
+      getLine(y: number): string | null {
+        const line = term.buffer.active.getLine(y)
+        if (!line) return null
+        const text = line.translateToString(true)
+        // Filter trivial anchors so a wipe-and-redraw doesn't snap the
+        // user to the first stretch of separators or whitespace it
+        // finds. Four visible chars is enough to be distinctive without
+        // excluding short but meaningful lines ("DONE", "PASS", etc.).
+        if (text.trim().length < 4) return null
+        return text
+      },
     })
     ;(window as any).__gmuxTerm = term
     // Test-only inject hook: pumps bytes through the same path as ws.onmessage

--- a/e2e/tests/terminal-scroll.spec.ts
+++ b/e2e/tests/terminal-scroll.spec.ts
@@ -440,4 +440,52 @@ test.describe('terminal scrollback (jump-to-top bug)', () => {
       expect(after.viewportY).toBeGreaterThan(0)
     }
   })
+
+  /**
+   * Real pi replay while the user is scrolled up *just a few lines*,
+   * reading the most recent output of pi's previous turn. A single
+   * end-of-turn-shaped frame fires with no streaming in between, so
+   * the new buffer is large enough to anchor the user's pre-wipe
+   * distance against. Contract: viewport lands at the same distance
+   * from the new bottom rather than being yanked all the way down.
+   *
+   * Synthetic rather than fixture-driven on purpose: pi's real turn
+   * grows scrollback while the user holds their scroll, so by the
+   * time the wipe fires the user's distance from bottom has drifted.
+   * That's a property of long-streaming agents and is correctly
+   * handled by the same code path (distance-too-large → bottom snap)
+   * already covered by the fixture test above. The contract this
+   * test pins down — "preserve distance when there is room" — needs
+   * a controlled scenario.
+   */
+  test('user scrolled up by a few lines: BSU + clear-scrollback + redraw preserves distance from bottom', async ({ page }) => {
+    await seedScrollback(page, 200)
+    await scrollToBottom(page)
+    const baseline = await getScroll(page)
+    expect(baseline.baseY).toBeGreaterThan(20)
+
+    const distance = 3
+    const target = baseline.baseY - distance
+    await page.evaluate((line) => (window as any).__gmuxTerm.scrollToLine(line), target)
+    const beforeBurst = await getScroll(page)
+    expect(beforeBurst.baseY - beforeBurst.viewportY).toBe(distance)
+
+    // Single frame: BSU, clear-scrollback, then a redraw big enough
+    // that the new baseY > distance.
+    const redraw = Array.from({ length: 80 }, (_, i) => `redraw-${i}`).join('\r\n') + '\r\n'
+    await inject(page, BSU + '\x1b[2J\x1b[H\x1b[3J' + redraw + ESU)
+    await settle(page)
+
+    const after = await getScroll(page)
+    console.log('[wipe-small-scroll]',
+      'viewportY=', after.viewportY,
+      'baseY=', after.baseY,
+      'distance=', after.baseY - after.viewportY)
+
+    // The new buffer must have room for the captured distance, else
+    // this test is silently exercising the bottom-snap fallback.
+    expect(after.baseY).toBeGreaterThanOrEqual(distance)
+    // Contract: the user's distance from the bottom is preserved.
+    expect(after.baseY - after.viewportY).toBe(distance)
+  })
 })

--- a/e2e/tests/terminal-scroll.spec.ts
+++ b/e2e/tests/terminal-scroll.spec.ts
@@ -305,7 +305,7 @@ test.describe('terminal scrollback (jump-to-top bug)', () => {
    * the original boundaries so BSU/ESU detection in terminal-io sees
    * what production WS framing actually produces.
    */
-  async function replayPiFixture(page: Page): Promise<void> {
+  async function replayPiFixture(page: Page, range?: { from?: number; to?: number }): Promise<void> {
     const fixtureDir = join(__dirname, '..', 'fixtures')
     const bytes = readFileSync(join(fixtureDir, 'pi-turn.bin'))
     const chunks = JSON.parse(
@@ -313,7 +313,9 @@ test.describe('terminal scrollback (jump-to-top bug)', () => {
     ) as Array<{ offset: number; len: number }>
     expect(bytes.indexOf(Buffer.from('\x1b[3J'))).toBeGreaterThan(0)
 
-    for (const c of chunks) {
+    const from = range?.from ?? 0
+    const to = range?.to ?? chunks.length
+    for (const c of chunks.slice(from, to)) {
       const encoded = bytes.subarray(c.offset, c.offset + c.len).toString('base64')
       await page.evaluate((data) => {
         const inj = (window as any).__gmuxInject as ((b: string) => void) | null
@@ -328,6 +330,9 @@ test.describe('terminal scrollback (jump-to-top bug)', () => {
       new Promise(r => requestAnimationFrame(() =>
         requestAnimationFrame(() => r(null)))))
   }
+
+  /** Index of the first chunk that contains pi's `\x1b[3J` wipe. */
+  const PI_WIPE_CHUNK = 98
 
   /**
    * Real pi end-of-turn replay.
@@ -487,5 +492,220 @@ test.describe('terminal scrollback (jump-to-top bug)', () => {
     expect(after.baseY).toBeGreaterThanOrEqual(distance)
     // Contract: the user's distance from the bottom is preserved.
     expect(after.baseY - after.viewportY).toBe(distance)
+  })
+
+  /**
+   * The user is reading a recognizable line in scrollback when the
+   * agent emits a wipe + redraw whose new buffer still contains that
+   * exact line at a different position. We jump to the new position
+   * of the same content rather than restoring the user's pre-wipe
+   * distance from the bottom: the line they were reading is the most
+   * meaningful anchor we have.
+   *
+   * This shape covers TUIs that refresh their display with much of
+   * the same content (log viewers, file browsers, code editors with
+   * gutter redraws). Pi specifically benefits when the user is
+   * reading content that pi's end-of-turn redraw places back into
+   * scrollback (eg the version banner); see the pi-fixture variant
+   * of this test below for that case.
+   */
+  test('user scrolled up to a recognizable line: BSU + clear-scrollback + redraw containing that line jumps to it', async ({ page }) => {
+    // Pin the terminal size so the post-redraw layout is
+    // deterministic: 80 redraw lines with rows=40 means baseY=40
+    // (lines 0..39 in scrollback, 40..79 visible).
+    await page.evaluate(() => (window as any).__gmuxTerm.resize(120, 40))
+    await settle(page)
+
+    await seedScrollback(page, 200)
+    await scrollToBottom(page)
+    const baseline = await getScroll(page)
+    expect(baseline.baseY).toBeGreaterThan(20)
+
+    // Scroll up by a known distance, then read the actual line text
+    // there. Reading rather than predicting keeps the test robust to
+    // banner rows / trailing newlines from seedScrollback; the
+    // contract under test is content matching, not seed numbering.
+    const distance = 10
+    const targetY = baseline.baseY - distance
+    await page.evaluate((line) => (window as any).__gmuxTerm.scrollToLine(line), targetY)
+    const beforeBurst = await getScroll(page)
+    expect(beforeBurst.viewportY).toBe(targetY)
+    const targetText = await page.evaluate((y) => {
+      const term = (window as any).__gmuxTerm
+      const line = term.buffer.active.getLine(y)
+      return line ? line.translateToString(true) : null
+    }, targetY)
+    expect(targetText).toMatch(/^seed-line-\d{4}$/)
+
+    // 80 lines of redraw with `targetText` placed at index 20: lands
+    // in scrollback at y=20 once the visible rows fill (lines 40..79
+    // become visible, 0..39 scrollback). Distance restoration would
+    // land at baseY-distance = 40-10 = 30; anchor match should land
+    // at 20. The two must differ for this test to be meaningful, so
+    // the resize above is load-bearing.
+    const redrawLines = Array.from({ length: 80 }, (_, i) =>
+      i === 20 ? targetText : `redraw-line-${i}`)
+    const redraw = redrawLines.join('\r\n') + '\r\n'
+    await inject(page, BSU + '\x1b[2J\x1b[H\x1b[3J' + redraw + ESU)
+    await settle(page)
+
+    const after = await getScroll(page)
+    const landedText = await page.evaluate((y) => {
+      const term = (window as any).__gmuxTerm
+      const line = term.buffer.active.getLine(y)
+      return line ? line.translateToString(true) : null
+    }, after.viewportY)
+    console.log('[anchor-match]',
+      'viewportY=', after.viewportY,
+      'baseY=', after.baseY,
+      'landedOn=', landedText)
+
+    // The viewport top is sitting on the line whose content matches
+    // the user's pre-wipe anchor (y=20), not the distance fallback
+    // position (y=30).
+    expect(landedText).toBe(targetText)
+    expect(after.viewportY).toBe(20)
+  })
+
+  /**
+   * The anchor lives in the visible region of the post-wipe buffer
+   * rather than scrollback. `scrollToLine` clamps to `baseY`, so we
+   * can't put the anchor at the viewport's top, but `scrollToBottom`
+   * keeps it in the viewport at offset `matchY - baseY`. This is the
+   * mid-distance case for general TUIs that refresh by repainting a
+   * fixed-position UI: the line you were reading reappears in roughly
+   * the same on-screen location.
+   *
+   * The visible-region match must be measurably better than the
+   * distance-restoration fallback for the test to be meaningful, so
+   * we deliberately position the anchor where distance restoration
+   * would scroll past it.
+   */
+  test('user scrolled up: anchor in post-wipe visible region keeps it in view', async ({ page }) => {
+    await page.evaluate(() => (window as any).__gmuxTerm.resize(120, 40))
+    await settle(page)
+
+    await seedScrollback(page, 200)
+    await scrollToBottom(page)
+    const baseline = await getScroll(page)
+    expect(baseline.baseY).toBeGreaterThan(20)
+
+    const distance = 5
+    const targetY = baseline.baseY - distance
+    await page.evaluate((line) => (window as any).__gmuxTerm.scrollToLine(line), targetY)
+    const targetText = await page.evaluate((y) => {
+      const term = (window as any).__gmuxTerm
+      const line = term.buffer.active.getLine(y)
+      return line ? line.translateToString(true) : null
+    }, targetY)
+    expect(targetText).toMatch(/^seed-line-\d{4}$/)
+
+    // 45-line redraw: rows=40, so baseY=5 and visible region is
+    // [5, 44]. Anchor placed at row 40 (deep in visible). Distance
+    // restoration would scrollToLine(baseY - distance) = scrollToLine(0),
+    // visible region [0, 39], anchor at 40 falls off the bottom of
+    // the viewport. Anchor matching with full-buffer search finds
+    // the line at y=40 and snaps to baseY=5, putting anchor at
+    // visible offset 35 (still readable, near the bottom).
+    const redrawLines = Array.from({ length: 45 }, (_, i) =>
+      i === 40 ? targetText : `redraw-line-${i}`)
+    const redraw = redrawLines.join('\r\n') + '\r\n'
+    await inject(page, BSU + '\x1b[2J\x1b[H\x1b[3J' + redraw + ESU)
+    await settle(page)
+
+    const after = await getScroll(page)
+    console.log('[anchor-visible]',
+      'viewportY=', after.viewportY,
+      'baseY=', after.baseY,
+      'distance=', distance)
+
+    // Visible-region match → viewportY = baseY (at-bottom). With
+    // search bounded to [0, baseY] this would be viewportY = 0.
+    expect(after.viewportY).toBe(after.baseY)
+
+    // Sanity: the anchor really is somewhere in the viewport. Walk
+    // visible rows looking for the target text.
+    const anchorVisible = await page.evaluate(({ vy, rows, target }) => {
+      const term = (window as any).__gmuxTerm
+      for (let y = vy; y < vy + rows; y++) {
+        const line = term.buffer.active.getLine(y)
+        if (line && line.translateToString(true) === target) return { y, offset: y - vy }
+      }
+      return null
+    }, { vy: after.viewportY, rows: 40, target: targetText })
+    expect(anchorVisible, 'anchor must be visible in the post-wipe viewport').not.toBeNull()
+  })
+
+  /**
+   * Pi-fixture variant of the anchor-match contract. Pi's end-of-turn
+   * redraw is a full-screen rewrite (~53 lines: version/model banner,
+   * keybind hints, the user prompt, all 30 fruit names, the status
+   * bar). When the user is scrolled up reading content that pi's
+   * redraw places back into scrollback, anchor matching restores them
+   * to that same line.
+   *
+   * Concretely: pre-wipe, the version-banner line sits at y=2 in the
+   * buffer (distance ~22 from the bottom). With baseline #176
+   * (distance restoration), distance > new baseY and we'd snap to the
+   * bottom. With anchor matching, we find the same line in the
+   * rebuilt scrollback and jump directly there.
+   */
+  test('pi-fixture: user reading the version banner stays on it across the wipe', async ({ page }) => {
+    await page.evaluate(() => (window as any).__gmuxTerm.resize(120, 40))
+    await settle(page)
+
+    // Replay everything before pi's wipe so the buffer is in its
+    // realistic pre-wipe shape (banner near the top, fruits in the
+    // middle, a streaming "Working..." indicator near the bottom).
+    await replayPiFixture(page, { to: PI_WIPE_CHUNK })
+
+    // Find the version-banner line by content rather than fixed y:
+    // chunks may emit slightly different layouts as pi evolves, but
+    // the banner string is stable.
+    const found = await page.evaluate(() => {
+      const term = (window as any).__gmuxTerm
+      const buf = term.buffer.active
+      const total = buf.baseY + term.rows
+      for (let y = 0; y < buf.baseY; y++) {
+        const line = buf.getLine(y)
+        const text = line ? line.translateToString(true) : ''
+        if (text.includes('v0.70.2  anthropic')) return { y, text, baseY: buf.baseY, total }
+      }
+      return null
+    })
+    expect(found, 'pre-wipe version banner not found in scrollback').not.toBeNull()
+    const { y: targetY, text: anchorText, baseY: preWipeBaseY } = found!
+
+    // Confirm this is a case the distance fallback could NOT have
+    // rescued: pre-wipe distance is bigger than what fits in the
+    // post-wipe scrollback, so without anchor matching we'd snap to
+    // the bottom.
+    const preWipeDistance = preWipeBaseY - targetY
+    expect(preWipeDistance).toBeGreaterThan(15)
+
+    await page.evaluate((line) => (window as any).__gmuxTerm.scrollToLine(line), targetY)
+    const beforeBurst = await getScroll(page)
+    expect(beforeBurst.viewportY).toBe(targetY)
+
+    // Replay the wipe + redraw + ESU.
+    await replayPiFixture(page, { from: PI_WIPE_CHUNK })
+
+    const after = await getScroll(page)
+    const landedText = await page.evaluate((y) => {
+      const term = (window as any).__gmuxTerm
+      const line = term.buffer.active.getLine(y)
+      return line ? line.translateToString(true) : null
+    }, after.viewportY)
+    console.log('[pi-anchor-match]',
+      'preWipeY=', targetY,
+      'preWipeDistance=', preWipeDistance,
+      'postWipeViewportY=', after.viewportY,
+      'postWipeBaseY=', after.baseY,
+      'landedText=', landedText?.slice(0, 60))
+
+    // Contract: viewport sits on a line whose content matches the
+    // pre-wipe anchor. The exact y depends on pi's redraw layout (we
+    // don't pin it), but the line text is stable.
+    expect(landedText).toBe(anchorText)
   })
 })


### PR DESCRIPTION
## Why

When pi (or any agent) finishes a turn it emits the canonical
"clear visible + cursor home + clear scrollback" sequence inside
a `BSU…ESU` block:

```
\x1b[?2026h\x1b[2J\x1b[H\x1b[3J  …redraw…  \x1b[?2026l
```

The `\x1b[3J` resets xterm's `ybase`/`ydisp` to 0 mid-block, and
the existing BSU/ESU restore logic then asks `scrollToLine(min(adjustedY=0, baseY=N))` for some `N>0`, parking the
viewport at the top.

User-visible: scroll up to read something, pi finishes, screen
yanks to the top. Reproduces deterministically with the captured
fixture in `e2e/fixtures/pi-turn.bin`.

## What's in this PR

Two atomic commits (rebase-merge → both land on `main` as
separate changelog bullets):

1. **`fix(web): restore distance from bottom when agent clears scrollback`** — detect a wipe (`baseY` shrinks across BSU/ESU)
   and restore the user's pre-wipe distance from the bottom
   instead of snapping to it.
2. **`fix(web): match line content as the strongest scroll-restore anchor`** — additionally capture the visible text of
   the line under the user at BSU time, scan the **whole** rebuilt
   buffer for that text, and restore there. Falls through to (1),
   then to bottom-snap.

The wipe branch in `maybeRestoreScroll`, end to end:

```ts
const anchorY = snap.prevAnchorLine !== null
  ? findAnchorMatch(scroll, snap.prevAnchorLine, baseY, rows, snap.prevDistanceFromBottom)
  : null
if (anchorY !== null)               scroll.scrollToLine(anchorY)         // (2)
else if (snap.prevDistanceFromBottom <= baseY)
                                    scroll.scrollToLine(baseY - snap.prevDistanceFromBottom)  // (1)
else                                scroll.scrollToBottom()              // last resort
```

`baseY < prevBaseY` is the wipe trigger: in steady-state
operation xterm's scrollback eviction leaves `baseY` pinned at
the cap, so this branch only fires on real `\x1b[3J` events.

## Search range: full buffer, not just scrollback

A match in the **visible region** (`y > baseY`) can't be the
viewport top (`scrollToLine` clamps to `baseY`), but
`scrollToBottom` keeps the line in view at offset `y - baseY`.
So `findAnchorMatch` searches `[0, baseY + rows)` and uses
`min(matchY, baseY)` as the restore target:

- `matchY ≤ baseY` (scrollback): anchor lands at viewport top,
  exactly where the user had it.
- `matchY > baseY` (visible): viewport snaps to bottom and the
  anchor sits inside the visible region, still readable.

Multiple matches collapse onto a single tiebreaker — closeness
of the resulting restore-distance to the captured pre-wipe
distance. Visible matches all collapse to the same target
(`baseY`, restore-distance 0); among scrollback matches the y
closest to `baseY - prevDistance` wins. The two regions compete
on equal terms: a small pre-wipe distance can prefer a visible
match over a faraway scrollback match.

## Pi specifically

Pi's wipe block is **13.4 kB containing 53 newlines** — a full
screen rewrite (version banner, keybind hints, the user prompt,
all 30 streamed fruit names, status bar). Outcomes by where the
user was scrolled:

- **At-bottom** (most common): unchanged, `wasAtBottom`
  short-circuits to `scrollToBottom()`.
- **Reading the version banner / keybind hints (large distance,
  anchor in post-wipe scrollback)**: anchor matches at low y, the
  user lands exactly there. The pi-fixture e2e test exercises
  this (pre-wipe distance 22, post-wipe `baseY` 15: distance
  alone could not have rescued).
- **Mid-distance, watching streaming output (anchor in post-wipe
  visible region)**: anchor matches in the visible region, we
  `scrollToBottom` and the line stays in view. Without the
  full-buffer search, this would fall through to distance
  restoration which scrolls the line off the viewport.
- **Tiny distance, top-of-viewport is blank** (eg pi's whitespace
  rows): trivial-anchor filter rejects the capture, falls
  through to distance restoration.

## Tests

**Unit** (`apps/gmux-web/src/terminal-io.test.ts`, +6 cases):

- Distance preserved when new `baseY` is large enough; snap to
  bottom when distance > new `baseY`; baseY-grows-from-zero
  doesn't trigger the wipe branch (commit 1).
- Single-anchor match (commit 2).
- Multi-anchor tiebreaker — winning match `y=16` deliberately
  differs from the distance fallback `y=15` so a regression that
  disables anchor matching is caught.
- **Visible-region match** — pre-wipe distance 5, post-wipe
  `baseY=5` with anchor at `y=20`. Mutation-sensitive: re-narrowing
  the search to `[0, baseY]` puts the user at `viewportY=0`
  instead of `viewportY=baseY`.
- **Mixed-region tiebreaker** — both regions match; pre-wipe
  distance 1 makes the visible match's restore-distance (0) win
  over the scrollback match's restore-distance (13).
- Null-anchor and missed-anchor both fall through to distance.

**E2E** (`e2e/tests/terminal-scroll.spec.ts`, +3 cases):

- Synthetic scrollback match: terminal pinned to 120x40 so the
  anchor-target y (=20) and distance-fallback y (=30) provably
  differ.
- **Synthetic visible-region match**: 45-line redraw on a
  rows=40 terminal, anchor at y=40 (visible). Asserts
  `viewportY === baseY` and walks the visible rows to confirm the
  anchor line is in the viewport.
- **Pi-fixture: user reading the version banner stays on it
  across the wipe** — replay chunks 0–97 of the real pi capture,
  scroll to the version banner (y=2, distance=22), replay the
  wipe + redraw chunks. Post-wipe `baseY=15`, distance fallback
  could not have rescued; anchor match lands the user at y=1
  with the same banner text.

The original `real pi end-of-turn does not jump to top` fixture
test continues to pass: when the user is deep in seeded
scrollback (no overlap with pi's redraw content), anchor matching
falls through and distance/bottom-snap takes over without
regressing the bug fix.

## Mutation tests

- Replace the wipe branch with `scrollToBottom()` ⇒ fixture-based
  e2e test from commit 1 fails (viewportY=baseY instead of
  preserving distance).
- Disable anchor matching (`const anchorY: number | null = null`)
  ⇒ 4 unit tests + 3 e2e tests fail (single-match, tiebreaker,
  visible-match, mixed-tiebreaker, synthetic scrollback e2e,
  visible-region e2e, pi-fixture e2e).
- Re-narrow search to `[0, baseY]` ⇒ 2 unit tests + 1 e2e test
  fail (visible-region unit, mixed tiebreaker unit, visible-region
  e2e). Other tests still pass since they exercise scrollback
  matches.

## Test plan

- [x] `pnpm exec vitest run` → 271/271
- [x] `pnpm test:e2e` → 31/31
- [x] `pnpm exec tsc --noEmit` clean
- [x] Fixture sanity: `\x1b[3J` is at offset 69408, inside BSU at
  69393 / ESU at 82833, redraw block has 53 newlines (full screen
  rewrite), not just status bar.
- [x] Mutation tests above.

## Limitations (deliberately not addressed)

- **Wrapping**. If a logical line wraps to a different number of
  buffer lines after the redraw, `translateToString` returns the
  partial buffer line and the match fails. We fall through to
  distance, no regression vs commit 1. Could be addressed with
  `isWrapped`-aware merging if real reports warrant it.
- **`\x1b[3J` outside BSU/ESU**. Detection currently lives only
  on the `maybeRestoreScroll` path; an unwrapped `\x1b[3J` would
  not trigger restoration. No real-world reproducer for this
  shape yet.