### PR TITLE
fix(web): match line content as the strongest scroll-restore anchor

### DIFF
--- a/apps/gmux-web/src/terminal-io.test.ts
+++ b/apps/gmux-web/src/terminal-io.test.ts
@@ -47,6 +47,10 @@ function makeScrollHarness(opts: { scrollbackLimit: number; rows: number }) {
 
   const scrollToLineCalls: number[] = []
   const scrollToBottomCalls: number[] = [] // tracks call count
+  // Per-line content for anchor-matching tests. y → visible text. Lines
+  // not in the map return null from getLine() (the production accessor
+  // also returns null for empty / trivial lines).
+  const lineContent = new Map<number, string>()
 
   const scroll: ScrollAccessor = {
     getState: () => ({ viewportY, baseY }),
@@ -57,6 +61,9 @@ function makeScrollHarness(opts: { scrollbackLimit: number; rows: number }) {
     scrollToBottom() {
       scrollToBottomCalls.push(baseY)
       viewportY = baseY
+    },
+    getLine(y: number): string | null {
+      return lineContent.get(y) ?? null
     },
   }
 
@@ -135,6 +142,12 @@ function makeScrollHarness(opts: { scrollbackLimit: number; rows: number }) {
       totalLines = rows
       baseY = 0
       viewportY = 0
+      lineContent.clear()
+    },
+
+    /** Set the visible text of the buffer line at `y`. */
+    setLine(y: number, text: string) {
+      lineContent.set(y, text)
     },
 
     /**
@@ -457,6 +470,110 @@ describe('scroll preservation across BSU/ESU', () => {
     // No wipe happened, just growth. The user was implicitly at bottom
     // (viewportY=0=baseY=0 pre-BSU), so the wasAtBottom branch fires.
     expect(h.viewportY).toBe(h.baseY)
+    h.cleanup()
+  })
+
+  it('after scrollback wipe, jumps to the line whose content matches the user\'s anchor', () => {
+    // The user is reading a recognizable line ("ERROR: cannot find
+    // foo"). The agent emits a wipe + redraw, the same line reappears
+    // in the new buffer at a different position. Anchor-match wins
+    // over distance restoration.
+    const h = makeScrollHarness({ scrollbackLimit: 5000, rows: 40 })
+    h.io.reset(1)
+    h.addLines(200)
+    h.userScrollTo(150)
+    h.setLine(150, 'ERROR: cannot find foo')
+    expect(h.baseY - h.viewportY).toBe(50)
+
+    h.io.enqueue(wrapBSU('redraw'), 1)
+    h.clearScrollback()
+    h.addLines(80)
+    // Same line lands at a different y after the redraw.
+    h.setLine(60, 'ERROR: cannot find foo')
+    h.flushOne(0)
+    h.flushRAF()
+
+    // Anchor matched at y=60: scroll there, no bottom snap.
+    expect(h.scrollToLineCalls).toContain(60)
+    expect(h.scrollToBottomCalls.length).toBe(0)
+    expect(h.viewportY).toBe(60)
+    h.cleanup()
+  })
+
+  it('after scrollback wipe with multiple anchor matches, picks the one closest to prevDistanceFromBottom', () => {
+    // The anchor line appears three times in the redraw. The match
+    // closest to the user's pre-wipe distance from the bottom (5)
+    // wins. The winning y is deliberately chosen so it differs from
+    // the distance-fallback position (baseY - prevDistance = 15),
+    // so a regression that disables anchor matching is caught here.
+    const h = makeScrollHarness({ scrollbackLimit: 5000, rows: 40 })
+    h.io.reset(1)
+    h.addLines(50)
+    h.userScrollTo(45)         // distance = 5
+    h.setLine(45, 'session ready')
+    expect(h.baseY - h.viewportY).toBe(5)
+
+    h.io.enqueue(wrapBSU('redraw'), 1)
+    h.clearScrollback()
+    h.addLines(20)             // new baseY=20
+    h.setLine(12, 'session ready')  // distance: 8, |8-5|=3
+    h.setLine(16, 'session ready')  // distance: 4, |4-5|=1 ← winner
+    h.setLine(18, 'session ready')  // distance: 2, |2-5|=3
+    h.flushOne(0)
+    h.flushRAF()
+
+    // y=16 is the closest match. Distance fallback would have given
+    // y=15, so this assertion is sensitive to anchor matching being
+    // active rather than coincidentally matching the fallback.
+    expect(h.scrollToLineCalls).toContain(16)
+    expect(h.viewportY).toBe(16)
+    h.cleanup()
+  })
+
+  it('after scrollback wipe, falls back to distance restoration when anchor is null', () => {
+    // The user was on a trivial line so getLine returned null and
+    // savedScroll.prevAnchorLine is null. We fall through to the
+    // distance restoration path.
+    const h = makeScrollHarness({ scrollbackLimit: 5000, rows: 40 })
+    h.io.reset(1)
+    h.addLines(50)
+    h.userScrollTo(47)         // distance = 3
+    // Deliberately NOT calling setLine: getLine returns null (the
+    // production accessor's filter for trivial lines).
+
+    h.io.enqueue(wrapBSU('redraw'), 1)
+    h.clearScrollback()
+    h.addLines(20)             // new baseY=20
+    h.setLine(17, 'unrelated content')  // present but won't match anything
+    h.flushOne(0)
+    h.flushRAF()
+
+    // No anchor captured → distance fallback: 20 - 3 = 17.
+    expect(h.scrollToLineCalls).toContain(17)
+    expect(h.viewportY).toBe(17)
+    h.cleanup()
+  })
+
+  it('after scrollback wipe, falls back to distance when anchor does not match anywhere', () => {
+    // The agent's redraw doesn't include the user's pre-wipe content
+    // (eg pi's status-bar-only redraw vs the user reading prior
+    // conversation output). Distance restoration takes over.
+    const h = makeScrollHarness({ scrollbackLimit: 5000, rows: 40 })
+    h.io.reset(1)
+    h.addLines(50)
+    h.userScrollTo(47)         // distance = 3
+    h.setLine(47, 'previous turn output line')
+
+    h.io.enqueue(wrapBSU('redraw'), 1)
+    h.clearScrollback()
+    h.addLines(20)             // new baseY=20
+    h.setLine(10, 'pi status bar version 0.70.2')  // wholly different
+    h.flushOne(0)
+    h.flushRAF()
+
+    // No match → distance fallback: 20 - 3 = 17.
+    expect(h.scrollToLineCalls).toContain(17)
+    expect(h.viewportY).toBe(17)
     h.cleanup()
   })
 

--- a/apps/gmux-web/src/terminal-io.ts
+++ b/apps/gmux-web/src/terminal-io.ts
@@ -18,6 +18,14 @@ export interface ScrollAccessor {
   getState(): { viewportY: number; baseY: number }
   scrollToLine(line: number): void
   scrollToBottom(): void
+  /**
+   * Read the visible text of the buffer line at `y` (post-trim, no ANSI
+   * codes). Returns null if the line doesn't exist or is too trivial to
+   * use as a scroll-restore anchor. "Too trivial" deliberately filters
+   * out empty / whitespace-only / very short lines so a wipe-and-redraw
+   * doesn't snap the user to the first stretch of separators it finds.
+   */
+  getLine(y: number): string | null
 }
 
 interface QueueItem {
@@ -55,20 +63,29 @@ export function createTerminalIO(term: TerminalWriter, scroll?: ScrollAccessor):
   let pendingResize: (TerminalSize & { epoch: number }) | null = null
 
   // Scroll preservation across BSU/ESU blocks.
-  // wasAtBottom, prevBaseY, prevDistanceFromBottom are saved at BSU time;
-  // the post-parse viewportY is captured later at ESU write-callback time,
-  // after xterm has adjusted viewportY for any scrollback evictions.
+  // wasAtBottom, prevBaseY, prevDistanceFromBottom, prevAnchorLine are
+  // saved at BSU time; the post-parse viewportY is captured later at ESU
+  // write-callback time, after xterm has adjusted viewportY for any
+  // scrollback evictions.
   //
-  // prevBaseY detects scrollback wipes (eg `\x1b[3J`): when baseY shrinks
-  // across the BSU/ESU block, the user's pre-BSU line is gone, so the
-  // post-parse viewportY (typically 0 after a wipe) is a meaningless
-  // anchor. prevDistanceFromBottom lets us re-anchor relative to the new
-  // bottom instead, preserving the user's intent ("I was reading N lines
-  // above the latest content").
+  // The wipe branch (baseY shrinks across BSU/ESU, eg via `\x1b[3J`)
+  // tries three anchors in order, falling through on each miss:
+  //
+  //   1. prevAnchorLine — the visible text the user was reading. If the
+  //      redraw still contains that line we know exactly where the user
+  //      wants to be. Multiple matches are tiebroken by closeness to
+  //      prevDistanceFromBottom, so common lines (eg "✓ done") still
+  //      land somewhere reasonable.
+  //   2. prevDistanceFromBottom — if the new buffer has room, restore
+  //      the user's pre-wipe distance from the bottom. Loses the
+  //      identity of the line they were reading but keeps their intent
+  //      ("N lines above the latest content").
+  //   3. scrollToBottom — nothing else is meaningful.
   let savedScroll: {
     wasAtBottom: boolean
     prevBaseY: number
     prevDistanceFromBottom: number
+    prevAnchorLine: string | null
   } | null = null
   let restoreRAF: number | null = null
 
@@ -93,16 +110,25 @@ export function createTerminalIO(term: TerminalWriter, scroll?: ScrollAccessor):
       const { viewportY, baseY } = scroll.getState()
       const distance = Math.max(0, baseY - viewportY)
       if (forceScrollToBottom) {
-        savedScroll = { wasAtBottom: true, prevBaseY: baseY, prevDistanceFromBottom: 0 }
+        savedScroll = {
+          wasAtBottom: true,
+          prevBaseY: baseY,
+          prevDistanceFromBottom: 0,
+          prevAnchorLine: null,
+        }
         forceScrollToBottom = false
       } else {
         // Strict equality: only consider the user "at bottom" if the
         // viewport is exactly at the end. A loose threshold (e.g. <= 3)
         // would fight the user's scroll intent during rapid TUI redraws.
+        const wasAtBottom = viewportY >= baseY
         savedScroll = {
-          wasAtBottom: viewportY >= baseY,
+          wasAtBottom,
           prevBaseY: baseY,
           prevDistanceFromBottom: distance,
+          // Only capture the anchor when scrolled up: at-bottom always
+          // wants scrollToBottom and never reaches the search.
+          prevAnchorLine: wasAtBottom ? null : scroll.getLine(viewportY),
         }
       }
     }
@@ -146,19 +172,19 @@ export function createTerminalIO(term: TerminalWriter, scroll?: ScrollAccessor):
         // Scrollback shrank during the BSU/ESU block. The dominant cause
         // is `\x1b[3J` (clear scrollback), which agents like pi emit at
         // end-of-turn redraws and which resets ybase/ydisp to 0. The
-        // user's pre-BSU line no longer exists; adjustedY points at the
-        // top of a freshly-rebuilt buffer, which is the "jump to top" bug.
-        // Eviction within a full scrollback never reaches this branch
-        // because it leaves baseY at the cap.
+        // user's pre-BSU line is gone from xterm's perspective; adjustedY
+        // points at the top of a freshly-rebuilt buffer, which is the
+        // "jump to top" bug. Eviction within a full scrollback never
+        // reaches this branch because it leaves baseY at the cap.
         //
-        // We don't know the user's pre-BSU position relative to the top
-        // of the buffer in any meaningful sense, but we do know it
-        // relative to the bottom: prevDistanceFromBottom. If the new
-        // buffer is large enough to anchor against, restore that
-        // distance, preserving the user's intent ("keep me N lines above
-        // the latest content"). If it's not, snap to bottom; nothing
-        // else is meaningful.
-        if (snap.prevDistanceFromBottom <= baseY) {
+        // We try three anchors in order, falling through on each miss
+        // (rationale on the savedScroll declaration above).
+        const anchorY = snap.prevAnchorLine !== null
+          ? findAnchorMatch(scroll, snap.prevAnchorLine, baseY, snap.prevDistanceFromBottom)
+          : null
+        if (anchorY !== null) {
+          scroll.scrollToLine(anchorY)
+        } else if (snap.prevDistanceFromBottom <= baseY) {
           scroll.scrollToLine(baseY - snap.prevDistanceFromBottom)
         } else {
           scroll.scrollToBottom()
@@ -252,4 +278,34 @@ export function createTerminalIO(term: TerminalWriter, scroll?: ScrollAccessor):
       return writeInFlight || queue.length > 0 || (!!pendingResize && pendingResize.epoch === currentEpoch)
     },
   }
+}
+
+/**
+ * Search the buffer for a line whose visible text equals `anchor`. If
+ * one or more matches exist, return the y position whose distance from
+ * the bottom (`baseY - y`) is closest to `prevDistanceFromBottom`. Ties
+ * resolve to the first match in scrollback order. Returns null if no
+ * line matches.
+ *
+ * Search range is `[0, baseY]` — the scrollback area `scrollToLine`
+ * can target. Visible-only lines (y > baseY) are skipped: they aren't
+ * a valid scroll target.
+ */
+function findAnchorMatch(
+  scroll: ScrollAccessor,
+  anchor: string,
+  baseY: number,
+  prevDistanceFromBottom: number,
+): number | null {
+  let best: number | null = null
+  let bestDiff = Number.POSITIVE_INFINITY
+  for (let y = 0; y <= baseY; y++) {
+    if (scroll.getLine(y) !== anchor) continue
+    const diff = Math.abs((baseY - y) - prevDistanceFromBottom)
+    if (diff < bestDiff) {
+      best = y
+      bestDiff = diff
+    }
+  }
+  return best
 }

--- a/apps/gmux-web/src/terminal.tsx
+++ b/apps/gmux-web/src/terminal.tsx
@@ -405,6 +405,17 @@ export function TerminalView({
       },
       scrollToLine(line: number) { term.scrollToLine(line) },
       scrollToBottom() { term.scrollToBottom() },
+      getLine(y: number): string | null {
+        const line = term.buffer.active.getLine(y)
+        if (!line) return null
+        const text = line.translateToString(true)
+        // Filter trivial anchors so a wipe-and-redraw doesn't snap the
+        // user to the first stretch of separators or whitespace it
+        // finds. Four visible chars is enough to be distinctive without
+        // excluding short but meaningful lines ("DONE", "PASS", etc.).
+        if (text.trim().length < 4) return null
+        return text
+      },
     })
     ;(window as any).__gmuxTerm = term
     // Test-only inject hook: pumps bytes through the same path as ws.onmessage

--- a/e2e/tests/terminal-scroll.spec.ts
+++ b/e2e/tests/terminal-scroll.spec.ts
@@ -488,4 +488,77 @@ test.describe('terminal scrollback (jump-to-top bug)', () => {
     // Contract: the user's distance from the bottom is preserved.
     expect(after.baseY - after.viewportY).toBe(distance)
   })
+
+  /**
+   * The user is reading a recognizable line in scrollback when the
+   * agent emits a wipe + redraw whose new buffer still contains that
+   * exact line at a different position. We jump to the new position
+   * of the same content rather than restoring the user's pre-wipe
+   * distance from the bottom: the line they were reading is the most
+   * meaningful anchor we have.
+   *
+   * This is the case general TUIs (log viewers, code editors, file
+   * browsers) hit when they refresh their display: the visible
+   * content is largely the same, just rebuilt. (Pi specifically
+   * doesn't benefit because its end-of-turn redraw is a status bar,
+   * not the conversation content; that case still falls through to
+   * distance restoration, covered by the previous test.)
+   */
+  test('user scrolled up to a recognizable line: BSU + clear-scrollback + redraw containing that line jumps to it', async ({ page }) => {
+    // Pin the terminal size so the post-redraw layout is
+    // deterministic: 80 redraw lines with rows=40 means baseY=40
+    // (lines 0..39 in scrollback, 40..79 visible).
+    await page.evaluate(() => (window as any).__gmuxTerm.resize(120, 40))
+    await settle(page)
+
+    await seedScrollback(page, 200)
+    await scrollToBottom(page)
+    const baseline = await getScroll(page)
+    expect(baseline.baseY).toBeGreaterThan(20)
+
+    // Scroll up by a known distance, then read the actual line text
+    // there. Reading rather than predicting keeps the test robust to
+    // banner rows / trailing newlines from seedScrollback; the
+    // contract under test is content matching, not seed numbering.
+    const distance = 10
+    const targetY = baseline.baseY - distance
+    await page.evaluate((line) => (window as any).__gmuxTerm.scrollToLine(line), targetY)
+    const beforeBurst = await getScroll(page)
+    expect(beforeBurst.viewportY).toBe(targetY)
+    const targetText = await page.evaluate((y) => {
+      const term = (window as any).__gmuxTerm
+      const line = term.buffer.active.getLine(y)
+      return line ? line.translateToString(true) : null
+    }, targetY)
+    expect(targetText).toMatch(/^seed-line-\d{4}$/)
+
+    // 80 lines of redraw with `targetText` placed at index 20: lands
+    // in scrollback at y=20 once the visible rows fill (lines 40..79
+    // become visible, 0..39 scrollback). Distance restoration would
+    // land at baseY-distance = 40-10 = 30; anchor match should land
+    // at 20. The two must differ for this test to be meaningful, so
+    // the resize above is load-bearing.
+    const redrawLines = Array.from({ length: 80 }, (_, i) =>
+      i === 20 ? targetText : `redraw-line-${i}`)
+    const redraw = redrawLines.join('\r\n') + '\r\n'
+    await inject(page, BSU + '\x1b[2J\x1b[H\x1b[3J' + redraw + ESU)
+    await settle(page)
+
+    const after = await getScroll(page)
+    const landedText = await page.evaluate((y) => {
+      const term = (window as any).__gmuxTerm
+      const line = term.buffer.active.getLine(y)
+      return line ? line.translateToString(true) : null
+    }, after.viewportY)
+    console.log('[anchor-match]',
+      'viewportY=', after.viewportY,
+      'baseY=', after.baseY,
+      'landedOn=', landedText)
+
+    // The viewport top is sitting on the line whose content matches
+    // the user's pre-wipe anchor (y=20), not the distance fallback
+    // position (y=30).
+    expect(landedText).toBe(targetText)
+    expect(after.viewportY).toBe(20)
+  })
 })


### PR DESCRIPTION
## Why

[#176](https://github.com/gmuxapp/gmux/pull/176) preserves the
user's distance from the bottom across a scrollback wipe. That's
strictly better than snapping to the bottom, but it still throws
away one piece of state we have right at BSU time: the actual
text of the line under the user.

Follow-up suggestion from review: capture that line content as a
marker, and after the wipe, scan the rebuilt buffer for it. If we
find it, jump there directly. If multiple lines match (a common
"ok" or " ✓ Done"), tiebreak by closeness to the captured
distance from bottom.

## Stacked on top of #176

This PR sits on `fix/scrollback-preserve-distance` (#176), not
`main`. Once #176 lands, GitHub will rebase this onto `main`
automatically. Until then, review the diff against
`fix/scrollback-preserve-distance` to see only the anchor-matching
delta.

## Change

`ScrollAccessor` gains a `getLine(y)` method, implemented in the
production accessor by `term.buffer.active.getLine(y).translateToString(true)`.
The implementation filters trivial anchors (empty, whitespace-only,
< 4 visible chars) and returns `null` for them: separators, blank
lines, and short status markers match too many candidate lines to
be useful as anchors.

`savedScroll` gains `prevAnchorLine: string | null`, captured at
BSU time only when the user is scrolled up. The wipe branch tries
three anchors in order, falling through on each miss:

1. **Anchor match** — scan `[0, baseY]` for a line whose
   `translateToString` equals `prevAnchorLine`. Multiple matches
   are tiebroken by `|baseY - y - prevDistanceFromBottom|`. Search
   range is the scrollback area `scrollToLine` can target;
   visible-only lines aren't valid scroll targets so we skip them.
2. **Distance restoration** (already in #176).
3. **Bottom snap** (already in #176).

```ts
const anchorY = snap.prevAnchorLine !== null
  ? findAnchorMatch(scroll, snap.prevAnchorLine, baseY, snap.prevDistanceFromBottom)
  : null
if (anchorY !== null) {
  scroll.scrollToLine(anchorY)
} else if (snap.prevDistanceFromBottom <= baseY) {
  scroll.scrollToLine(baseY - snap.prevDistanceFromBottom)
} else {
  scroll.scrollToBottom()
}
```

## Who actually benefits

General TUIs that refresh their display with substantially the
same content: log viewers (`tail -f` reload), file browsers,
code editors with gutter redraws, package managers showing
identical install summaries.

**Not pi specifically**: pi's `\x1b[3J` redraw at end-of-turn
emits only the status bar, not the conversation content the user
was reading. That case still falls through to distance
restoration, exactly as in #176, and is covered by the
`user scrolled up: real pi end-of-turn does not jump to top`
fixture test.

## Tests

**Unit** (`terminal-io.test.ts`, +4 cases):

- single-anchor match: jumps to the rebuilt line
- multi-anchor tiebreaker: deliberately positioned so the
  winning match (y=16) differs from the distance fallback (y=15);
  this is what makes the test sensitive to the anchor branch
  being active rather than coincidentally matching the fallback
- null anchor: getLine returned null (trivial line) ⇒ falls
  through to distance restoration
- anchor-not-in-redraw: line under user not present in new
  buffer ⇒ falls through to distance restoration

The harness gains a `setLine(y, text)` method and a per-y content
map cleared on `clearScrollback()`.

**E2E** (`terminal-scroll.spec.ts`, +1 case): seed 200 lines,
scroll up 10, inject a single `BSU + \x1b[2J \x1b[H \x1b[3J + 80
redraw lines + ESU` frame containing the same seeded line at a
new position. Terminal is pinned to 120x40 so the anchor target
(y=20) and the distance fallback (y=30) provably differ; the
viewport must land on y=20 with content equal to the captured
anchor.

## Mutation tests

Disabled the anchor branch (`const anchorY: number | null = null`)
and confirmed:

- `terminal-io.test.ts`: 2 failures (single-match + tiebreaker)
- `terminal-scroll.spec.ts`: 1 failure (anchor-match e2e)

Restoring the branch turns all green.

## Test plan

- [x] `pnpm exec vitest run` → 269/269 (was 265, +4 anchor cases)
- [x] `pnpm test:e2e` → 29/29 (was 28, +1 anchor case)
- [x] `pnpm exec tsc --noEmit` clean
- [x] Mutation: disable anchor branch ⇒ 3 tests fail; restore ⇒ green

## Limitations (deliberately not addressed)

- **Wrapping**. If the same logical line wraps differently after
  the redraw (eg different terminal width), `translateToString`
  returns the partial buffer line and the match fails. We fall
  through to distance restoration, no regression vs #176. Could
  be addressed with `isWrapped`-aware merging if real reports
  warrant it.
- **Single-line marker**. A short anchor line might match a
  similar-but-not-identical line elsewhere. The trivial-anchor
  filter (4 visible chars) and the distance tiebreaker keep this
  fairly contained in practice.