### PR TITLE
feat(release): improve release flow (discord roles, highlights SOT, preview, tests)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,6 +109,31 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
         run: bash .github/workflows/scripts/notify-discord.sh
 
+      # The release/next PR carries RELEASE_HIGHLIGHTS.md untouched so
+      # editors can tweak prose right up until merge. Now that the
+      # release has shipped, reset it to the stub on main so the next
+      # cycle starts clean.
+      - name: Clear release highlights on main
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          bash .github/workflows/scripts/version.sh --clear-highlights
+          if git diff --quiet RELEASE_HIGHLIGHTS.md; then
+            echo "RELEASE_HIGHLIGHTS.md already clean, nothing to do"
+            exit 0
+          fi
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add RELEASE_HIGHLIGHTS.md
+          git commit -m "chore: clear release highlights for ${VERSION}"
+          # The checkout at the start of this job is stale by now
+          # (goreleaser, Discord notify, etc. take minutes). Rebase
+          # onto current main so the push fast-forwards even if other
+          # commits landed in the meantime.
+          git pull --rebase origin main
+          git push origin main
+
   deploy-docs:
     needs: release
     if: needs.release.result == 'success'

--- a/.github/workflows/scripts/notify-discord.sh
+++ b/.github/workflows/scripts/notify-discord.sh
@@ -7,6 +7,9 @@
 #   ROLE_BREAKING  - Discord role ID for breaking changes
 #   ROLE_FEATURE   - Discord role ID for feature releases
 #   ROLE_PATCH     - Discord role ID for patch releases
+#   DRY_RUN        - If "1", print the JSON payload to stdout and skip
+#                    the actual webhook call. Used for local debugging
+#                    and tests.
 set -euo pipefail
 trap 'echo "error: ${BASH_SOURCE}:${LINENO}: ${BASH_COMMAND}" >&2' ERR
 
@@ -31,7 +34,12 @@ summary=$(echo "$summary" | sed -e :a -e '/^\n*$/{$d;N;ba}')
 
 # ── Determine bump type ──
 
-prev_tag=$(git tag -l 'v*' | sort -V | grep -B1 "^${VERSION}$" | head -1)
+# Use git's own "nearest tag reachable from VERSION's parent" rather
+# than scanning all tags. The old approach (`git tag -l 'v*' | sort -V
+# | grep -B1 ...`) breaks when tags are pushed out of order or VERSION
+# isn't yet in the local tag list; `git describe` always picks the
+# actual predecessor on the release history.
+prev_tag=$(git describe --tags --abbrev=0 "${VERSION}^" 2>/dev/null || true)
 cur_major=$(echo "$VERSION" | sed 's/^v//' | cut -d. -f1)
 cur_minor=$(echo "$VERSION" | sed 's/^v//' | cut -d. -f2)
 prev_major=$(echo "$prev_tag" | sed 's/^v//' | cut -d. -f1)
@@ -44,7 +52,9 @@ prev_minor=$(echo "$prev_tag" | sed 's/^v//' | cut -d. -f2)
 # This way each role's subscribers see every release that affects them.
 
 role_ids=("$ROLE_PATCH")
-if [[ "$cur_major" != "$prev_major" ]]; then
+if [[ -z "$prev_tag" ]]; then
+  : # No predecessor (first-ever release): patch-only ping, same as the old behavior.
+elif [[ "$cur_major" != "$prev_major" ]]; then
   role_ids+=("$ROLE_FEATURE" "$ROLE_BREAKING")
 elif [[ "$cur_minor" != "$prev_minor" ]]; then
   role_ids+=("$ROLE_FEATURE")
@@ -62,35 +72,47 @@ header="${mentions}
 ## gmux ${VERSION}"
 footer="[See the changelog for details.](https://gmux.app/changelog)"
 
-if [[ -n "$summary" ]]; then
-  message="${header}
-
-${summary}
-
-${footer}"
-else
-  message="${header}
-
-${footer}"
-fi
-
-# Discord's message limit is 2000 chars. Truncate the summary (not the
-# header or footer) so the link always survives.
-if [[ ${#message} -gt 2000 ]]; then
-  overhead=$(( ${#header} + ${#footer} + 6 ))
-  max_summary=$(( 2000 - overhead - 4 ))  # 4 for trailing "...\n"
-  if (( max_summary > 0 )); then
-    summary="${summary:0:max_summary}..."
-    message="${header}
-
-${summary}
-
-${footer}"
+compose_message() {
+  local body=$1
+  if [[ -n "$body" ]]; then
+    printf '%s\n\n%s\n\n%s' "$header" "$body" "$footer"
   else
-    message="${header}
-
-${footer}"
+    printf '%s\n\n%s' "$header" "$footer"
   fi
+}
+
+# Trim a summary so the full message fits in Discord's 2000-char limit.
+# Cuts at the last paragraph break under the limit when possible, then
+# falls back to a sentence break, then a newline, then a hard cut.
+# Returns the trimmed summary (still without ellipsis suffix).
+trim_summary() {
+  local body=$1 max=$2
+  local candidate="${body:0:max}"
+  local marker pos
+  for marker in $'\n\n' '. ' $'\n'; do
+    pos="${candidate%"$marker"*}"
+    # Require at least half the budget so we don't cut at an early
+    # break and throw away most of the prose.
+    if [[ "$pos" != "$candidate" && ${#pos} -gt $(( max / 2 )) ]]; then
+      printf '%s' "${candidate:0:${#pos}}"
+      return
+    fi
+  done
+  printf '%s' "$candidate"
+}
+
+message=$(compose_message "$summary")
+if [[ ${#message} -gt 2000 ]]; then
+  # 6 chars for the two "\n\n" separators between sections,
+  # 4 more for the trailing ellipsis we'll add to the summary.
+  overhead=$(( ${#header} + ${#footer} + 6 ))
+  max_summary=$(( 2000 - overhead - 4 ))
+  if (( max_summary > 0 )); then
+    summary="$(trim_summary "$summary" "$max_summary")…"
+  else
+    summary=""
+  fi
+  message=$(compose_message "$summary")
 fi
 
 # flags: 4 = SUPPRESS_EMBEDS. Stops Discord from generating a link
@@ -103,6 +125,11 @@ payload=$(jq -n \
     flags: 4,
     allowed_mentions: { roles: $role_ids }
   }')
+
+if [[ "${DRY_RUN:-}" == "1" ]]; then
+  printf '%s\n' "$payload"
+  exit 0
+fi
 
 curl -sf -H "Content-Type: application/json" -d "$payload" "$WEBHOOK_URL"
 echo "Discord notification sent for ${VERSION}"

--- a/.github/workflows/scripts/notify-discord.sh
+++ b/.github/workflows/scripts/notify-discord.sh
@@ -37,17 +37,28 @@ cur_minor=$(echo "$VERSION" | sed 's/^v//' | cut -d. -f2)
 prev_major=$(echo "$prev_tag" | sed 's/^v//' | cut -d. -f1)
 prev_minor=$(echo "$prev_tag" | sed 's/^v//' | cut -d. -f2)
 
+# Always ping every role at or below the bump severity:
+#   patch    → patch
+#   feature  → patch + feature
+#   breaking → patch + feature + breaking
+# This way each role's subscribers see every release that affects them.
+
+role_ids=("$ROLE_PATCH")
 if [[ "$cur_major" != "$prev_major" ]]; then
-  role_id="$ROLE_BREAKING"
+  role_ids+=("$ROLE_FEATURE" "$ROLE_BREAKING")
 elif [[ "$cur_minor" != "$prev_minor" ]]; then
-  role_id="$ROLE_FEATURE"
-else
-  role_id="$ROLE_PATCH"
+  role_ids+=("$ROLE_FEATURE")
 fi
+
+mentions=""
+for id in "${role_ids[@]}"; do
+  mentions+="<@&${id}> "
+done
+mentions="${mentions% }"
 
 # ── Send ──
 
-header="<@&${role_id}>
+header="${mentions}
 ## gmux ${VERSION}"
 footer="[See the changelog for details.](https://gmux.app/changelog)"
 
@@ -82,12 +93,15 @@ ${footer}"
   fi
 fi
 
+# flags: 4 = SUPPRESS_EMBEDS. Stops Discord from generating a link
+# preview card for the changelog URL.
 payload=$(jq -n \
   --arg content "$message" \
-  --arg role_id "$role_id" \
+  --argjson role_ids "$(printf '%s\n' "${role_ids[@]}" | jq -R . | jq -s .)" \
   '{
     content: $content,
-    allowed_mentions: { roles: [$role_id] }
+    flags: 4,
+    allowed_mentions: { roles: $role_ids }
   }')
 
 curl -sf -H "Content-Type: application/json" -d "$payload" "$WEBHOOK_URL"

--- a/.github/workflows/scripts/notify_discord_test.sh
+++ b/.github/workflows/scripts/notify_discord_test.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# Tests for notify-discord.sh.
+#
+# notify-discord.sh's job is to build a Discord webhook payload that:
+#
+#   1. Pings every role at or below the bump severity.
+#   2. Suppresses the link-preview embed.
+#   3. Stays under Discord's 2000-char limit, preferring a paragraph
+#      break to a hard byte cut.
+#   4. Always carries the changelog link, even when truncated.
+#
+# Tests use DRY_RUN=1 to capture the payload as JSON and assert on its
+# structure (roles list, flags) rather than on the rendered string
+# representation, which would be brittle.
+set -uo pipefail
+
+REAL_SCRIPT="$(cd "$(dirname "$0")" && pwd)/notify-discord.sh"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "SKIP: jq is required" >&2
+  exit 0
+fi
+
+SCOREBOARD=$(mktemp)
+trap 'rm -f "$SCOREBOARD"' EXIT
+echo "0 0" > "$SCOREBOARD"
+
+bump_score() {
+  read -r pass fail < "$SCOREBOARD"
+  case "$1" in pass) pass=$((pass + 1)) ;; fail) fail=$((fail + 1)) ;; esac
+  echo "$pass $fail" > "$SCOREBOARD"
+}
+
+assert_eq() {
+  if [[ "$2" == "$3" ]]; then echo "  ✓ $1"; bump_score pass
+  else
+    echo "  ✗ $1"
+    echo "    expected: $2"
+    echo "    actual:   $3"
+    bump_score fail
+  fi
+}
+
+assert_le() {
+  if (( $3 <= $2 )); then echo "  ✓ $1 ($3 <= $2)"; bump_score pass
+  else echo "  ✗ $1 ($3 > $2)"; bump_score fail
+  fi
+}
+
+assert_contains() {
+  if [[ "$3" == *"$2"* ]]; then echo "  ✓ $1"; bump_score pass
+  else echo "  ✗ $1"; echo "    expected to contain: $2"; bump_score fail
+  fi
+}
+
+# Lay out a scratch repo with two tags so notify-discord.sh's
+# `git describe --tags --abbrev=0 "${VERSION}^"` finds the predecessor.
+make_repo() {
+  local tmp=$1 prev=$2 version=$3
+  cd "$tmp"
+  git init --quiet --initial-branch=main
+  git config user.email "test@example.com"
+  git config user.name "Test"
+  git -c commit.gpgsign=false commit --allow-empty --quiet -m "first"
+  git tag "$prev"
+  git -c commit.gpgsign=false commit --allow-empty --quiet -m "second"
+  git tag "$version"
+}
+
+run_notify() {
+  local tmp=$1 version=$2
+  (
+    cd "$tmp"
+    DRY_RUN=1 \
+      WEBHOOK_URL="http://fake" \
+      VERSION="$version" \
+      ROLE_BREAKING="BR" \
+      ROLE_FEATURE="FE" \
+      ROLE_PATCH="PA" \
+      bash "$REAL_SCRIPT"
+  )
+}
+
+# ── Test: each bump level pings exactly the roles at or below severity ──
+#
+# Patch must NOT wake up feature/breaking subscribers; major must
+# reach everyone. Asserting on .allowed_mentions.roles (the structured
+# field Discord uses to decide who to ping) instead of the rendered
+# content string avoids breaking on cosmetic text changes.
+
+echo "Bump-level role ping:"
+for case in \
+  "v1.5.3|v1.5.4|PA" \
+  "v1.5.3|v1.6.0|PA,FE" \
+  "v1.5.3|v2.0.0|PA,FE,BR"
+do
+  prev=${case%%|*}; rest=${case#*|}; version=${rest%%|*}; expected=${rest##*|}
+  (
+    tmp=$(mktemp -d); trap 'rm -rf "$tmp"' EXIT
+    make_repo "$tmp" "$prev" "$version"
+    echo "x" > "$tmp/RELEASE_NOTES.md"
+
+    payload=$(run_notify "$tmp" "$version")
+    actual=$(echo "$payload" | jq -r '.allowed_mentions.roles | join(",")')
+    assert_eq "$prev → $version" "$expected" "$actual"
+  )
+done
+
+# ── Test: first-ever release (no predecessor tag) pings patch only ──
+#
+# `git describe ... "${VERSION}^"` fails when there's no prior tag.
+# Without a guard, the empty `prev_major` makes `"X" != ""` true and
+# we'd ping every role on the very first release. Patch-only is the
+# right default and matches the old `grep -B1` behavior.
+
+echo ""
+echo "First-ever release:"
+(
+  tmp=$(mktemp -d); trap 'rm -rf "$tmp"' EXIT
+  cd "$tmp"
+  git init --quiet --initial-branch=main
+  git config user.email "test@example.com"; git config user.name "Test"
+  git -c commit.gpgsign=false commit --allow-empty --quiet -m "first"
+  git tag v0.1.0
+  echo "x" > RELEASE_NOTES.md
+
+  roles=$(run_notify "$tmp" v0.1.0 | jq -r '.allowed_mentions.roles | join(",")')
+  assert_eq "no prior tag → patch only" "PA" "$roles"
+)
+
+# ── Test: payload sets flags=4 (SUPPRESS_EMBEDS) ──
+#
+# Without this Discord generates a preview card for the changelog URL.
+# Asserting on the structured field, not on whether the rendered post
+# happened to suppress it.
+
+echo ""
+echo "Embed suppression:"
+(
+  tmp=$(mktemp -d); trap 'rm -rf "$tmp"' EXIT
+  make_repo "$tmp" v1.5.3 v1.5.4
+  echo "x" > "$tmp/RELEASE_NOTES.md"
+
+  flags=$(run_notify "$tmp" v1.5.4 | jq -r '.flags')
+  assert_eq "flags=4" "4" "$flags"
+)
+
+# ── Test: long summaries truncate at a paragraph break, not in the middle ──
+#
+# Constructs a summary with a clear paragraph break under the 2000-char
+# limit and a long second paragraph that pushes the total over the
+# limit. The cut must land in (or after) paragraph B, leaving paragraph
+# A intact, and the changelog link must survive.
+
+echo ""
+echo "Truncation:"
+(
+  tmp=$(mktemp -d); trap 'rm -rf "$tmp"' EXIT
+  make_repo "$tmp" v1.5.3 v1.5.4
+
+  {
+    for _ in {1..30}; do echo -n "Lorem ipsum dolor sit amet consectetur adipiscing elit. "; done
+    echo; echo
+    for _ in {1..30}; do echo -n "Second paragraph filler text appears here. "; done
+    echo
+    echo "<!-- highlights-end -->"
+  } > "$tmp/RELEASE_NOTES.md"
+
+  content=$(run_notify "$tmp" v1.5.4 | jq -r '.content')
+  assert_le "under Discord's 2000-char limit" 2000 "${#content}"
+  assert_contains "changelog link survives truncation" "gmux.app/changelog" "$content"
+  assert_contains "first paragraph not chopped"        "Lorem ipsum dolor"  "$content"
+)
+
+# ── Summary ──
+
+read -r pass fail < "$SCOREBOARD"
+echo ""
+echo "$pass passed, $fail failed"
+[[ $fail -eq 0 ]]

--- a/.github/workflows/scripts/version.sh
+++ b/.github/workflows/scripts/version.sh
@@ -28,11 +28,16 @@
 #                    `## v…` heading (unless --dry-run)
 #   RELEASE_NOTES.md → highlights + separator + bullets for the
 #                      release PR body (unless --dry-run)
-#   RELEASE_HIGHLIGHTS.md → reset to stub (unless --dry-run)
+#
+# RELEASE_HIGHLIGHTS.md is the single source of truth for prose. It is
+# *not* cleared by this script. The release workflow clears it via
+# `--clear-highlights` after a successful release ships, so it stays
+# editable on the open release PR until the moment of release.
 #
 # Usage:
-#   .github/workflows/scripts/version.sh           # apply changes
-#   .github/workflows/scripts/version.sh --dry-run # preview only, no writes
+#   .github/workflows/scripts/version.sh                    # apply changes
+#   .github/workflows/scripts/version.sh --dry-run          # preview only
+#   .github/workflows/scripts/version.sh --clear-highlights # reset stub only
 set -euo pipefail
 trap 'echo "error: ${BASH_SOURCE}:${LINENO}: ${BASH_COMMAND}" >&2' ERR
 
@@ -41,8 +46,48 @@ CHANGELOG="$ROOT/apps/website/src/content/docs/changelog.mdx"
 HIGHLIGHTS="$ROOT/RELEASE_HIGHLIGHTS.md"
 
 DRY_RUN=false
-if [[ "${1:-}" == "--dry-run" ]]; then
-  DRY_RUN=true
+CLEAR_ONLY=false
+case "${1:-}" in
+  --dry-run) DRY_RUN=true ;;
+  --clear-highlights) CLEAR_ONLY=true ;;
+  "") ;;
+  *) echo "unknown flag: $1" >&2; exit 2 ;;
+esac
+
+clear_highlights() {
+  cat > "$HIGHLIGHTS" <<'STUB'
+<!--
+Optional prose for the next release. Edit this file to add a high-level
+summary, topic paragraphs, or migration notes. Its content is injected
+into the changelog section between the version heading and the grouped
+bullet lists.
+
+This file is the single source of truth for release prose: edit it on
+`main` before merging the PR that ships the noteworthy change, or on
+the `release/next` branch up until the release ships (then run
+`scripts/regen-release-notes.sh` to refresh the generated files).
+
+The release workflow clears this file automatically after a successful
+release. Leave empty for releases that don't need prose; the
+auto-generated bullet list is enough for patch-only releases.
+
+Format: plain markdown. Supports headings, paragraphs, and lists.
+Example:
+
+    Peers now automatically reconnect after system suspend, no restart
+    needed.
+
+    ### Project matching
+    `projects.json` replaces separate `remote` and `paths` fields with a
+    unified `match` array.
+-->
+STUB
+}
+
+if $CLEAR_ONLY; then
+  clear_highlights
+  echo "Cleared $HIGHLIGHTS" >&2
+  exit 0
 fi
 
 # ── Skip release commits ──
@@ -112,23 +157,57 @@ enrich_context() {
   local ctx_file="$1"
   local out_file="$2"
 
+  local have_gh=true
   if [[ -z "${GITHUB_TOKEN:-}" ]] || ! command -v gh >/dev/null 2>&1; then
+    have_gh=false
+  fi
+
+  if ! $have_gh; then
+    # In CI we expect enrichment to work; bail loudly so a bad token
+    # never silently ships a changelog with bare commit subjects.
+    # Locally (and in test runs) we silently fall back so iteration
+    # without `gh` keeps working.
+    if [[ "${CI:-}" == "true" ]]; then
+      echo "error: GITHUB_TOKEN missing or gh not installed in CI; cannot enrich PR links" >&2
+      exit 1
+    fi
     cp "$ctx_file" "$out_file"
     return
   fi
 
+  # Single GraphQL request resolves every commit's associated PR in one
+  # round trip, so a release with N commits costs 1 API call instead of
+  # N. GraphQL aliases must start with a letter, so we prefix each SHA
+  # with `c_`.
+  local shas
+  shas=$(jq -r '.[0].commits[].id' "$ctx_file")
+  if [[ -z "$shas" ]]; then
+    cp "$ctx_file" "$out_file"
+    return
+  fi
+
+  local query='query { repository(owner: "gmuxapp", name: "gmux") {'
+  while IFS= read -r sha; do
+    [[ -z "$sha" ]] && continue
+    query+=" c_${sha}: object(oid: \"${sha}\") { ... on Commit { associatedPullRequests(first: 1) { nodes { number url } } } }"
+  done <<< "$shas"
+  query+=' } }'
+
   local map_file
   map_file=$(mktemp)
-  echo "{}" > "$map_file"
-
-  while IFS= read -r sha; do
-    local pr
-    pr=$(gh api "repos/gmuxapp/gmux/commits/$sha/pulls" --jq '.[0].number // empty' 2>/dev/null || true)
-    if [[ -n "$pr" ]]; then
-      jq --arg sha "$sha" --arg pr "$pr" '. + {($sha): ($pr | tonumber)}' "$map_file" > "${map_file}.tmp"
-      mv "${map_file}.tmp" "$map_file"
-    fi
-  done < <(jq -r '.[0].commits[].id' "$ctx_file")
+  if ! gh api graphql -f query="$query" --jq '
+    .data.repository | to_entries
+    | map(select(.value != null and (.value.associatedPullRequests.nodes | length > 0)))
+    | map({
+        key: (.key | sub("^c_"; "")),
+        value: .value.associatedPullRequests.nodes[0]
+      })
+    | from_entries
+  ' > "$map_file"; then
+    echo "error: GraphQL PR lookup failed" >&2
+    rm -f "$map_file"
+    exit 1
+  fi
 
   jq --slurpfile prmap "$map_file" '
     .[0].commits = [.[0].commits[] |
@@ -137,7 +216,7 @@ enrich_context() {
       ($c.raw_message | split("\n")[0]) as $subject |
       if $pr != null and ($subject | test("\\(#[0-9]+\\)|\\(\\[#[0-9]+\\]") | not) then
         (.raw_message | split("\n")) as $lines |
-        .raw_message = ([$lines[0] + " ([#\($pr)](https://github.com/gmuxapp/gmux/pull/\($pr)))"] + $lines[1:] | join("\n"))
+        .raw_message = ([$lines[0] + " ([#\($pr.number)](\($pr.url)))"] + $lines[1:] | join("\n"))
       else .
       end
     ]
@@ -293,33 +372,8 @@ else
 fi
 mv "$CHANGELOG.tmp" "$CHANGELOG"
 
-# ── Clear RELEASE_HIGHLIGHTS.md ──
-#
-# The release PR includes the cleared state so the next cycle starts
-# fresh. The stub content explains the workflow to future editors.
-
-cat > "$HIGHLIGHTS" <<'STUB'
-<!--
-Optional prose for the next release. Edit this file to add a high-level
-summary, topic paragraphs, or migration notes. When version.sh runs, the
-content is injected into the changelog section between the version
-heading and the grouped bullet lists.
-
-The file is cleared automatically after each release. Leave empty for
-releases that don't need prose (the auto-generated bullet list is
-enough for patch-only releases).
-
-Format: plain markdown. Supports headings, paragraphs, and lists.
-Example:
-
-    Peers now automatically reconnect after system suspend, no restart
-    needed.
-
-    ### Project matching
-    `projects.json` replaces separate `remote` and `paths` fields with a
-    unified `match` array.
--->
-STUB
+# RELEASE_HIGHLIGHTS.md is intentionally NOT cleared here. It stays
+# editable on the release/next branch until the release actually
+# ships; release.yml runs `version.sh --clear-highlights` afterward.
 
 echo "Updated $CHANGELOG" >&2
-echo "Updated $HIGHLIGHTS (cleared)" >&2

--- a/.github/workflows/scripts/version_test.sh
+++ b/.github/workflows/scripts/version_test.sh
@@ -1,19 +1,25 @@
 #!/usr/bin/env bash
-# End-to-end tests for version.sh using a scratch git repository.
+# Tests for version.sh.
 #
-# Most of the versioning logic now lives in git-cliff, so these tests
-# exercise the behaviors that version.sh still owns:
+# The interesting logic lives in git-cliff and cliff.toml; version.sh
+# only owns:
 #
-#   1. Release commit detection (loop prevention)
-#   2. No-op when there are no releasable commits
-#   3. Correct bump level (patch / minor / major)
-#   4. Changelog insertion placement
-#   5. Highlights prepended into changelog.mdx and RELEASE_NOTES.md
-#   6. Highlights file cleared after release
-#   7. RELEASE_NOTES.md format compatible with notify-discord.sh
+#   - Loop-prevention guards (skip release commits, exit when no
+#     releasable commits)
+#   - The bump version that ends up on stdout (single source of truth
+#     for the rest of the release pipeline)
+#   - Orchestration: reading RELEASE_HIGHLIGHTS.md, writing
+#     RELEASE_NOTES.md and changelog.mdx, optional --clear-highlights
+#   - Highlights parsing edge cases (HTML comments, the
+#     <!-- highlights-end --> sentinel, horizontal-rule survival)
+#
+# Tests are organised around those behaviours. A small smoke test
+# pins that cliff.toml still produces every group heading we expect,
+# but we deliberately don't assert section ordering, dates, or other
+# template details that would break on cosmetic git-cliff changes.
+
 set -uo pipefail
 
-# Locate the real version.sh so we can run it against scratch repos.
 REAL_SCRIPT="$(cd "$(dirname "$0")" && pwd)/version.sh"
 REAL_CLIFF_TOML="$(cd "$(dirname "$0")/../../.." && pwd)/cliff.toml"
 
@@ -22,66 +28,49 @@ if ! command -v git-cliff >/dev/null 2>&1; then
   exit 0
 fi
 
-# Use a scoreboard file so counts survive subshells used for test isolation.
 SCOREBOARD=$(mktemp)
 trap 'rm -f "$SCOREBOARD"' EXIT
 echo "0 0" > "$SCOREBOARD"
 
 bump_score() {
-  local which="$1"
   read -r pass fail < "$SCOREBOARD"
-  case "$which" in
-    pass) pass=$((pass + 1)) ;;
-    fail) fail=$((fail + 1)) ;;
-  esac
+  case "$1" in pass) pass=$((pass + 1)) ;; fail) fail=$((fail + 1)) ;; esac
   echo "$pass $fail" > "$SCOREBOARD"
 }
 
 assert_eq() {
-  local label="$1" expected="$2" actual="$3"
-  if [[ "$expected" == "$actual" ]]; then
-    echo "  ✓ $label"
-    bump_score pass
+  if [[ "$2" == "$3" ]]; then echo "  ✓ $1"; bump_score pass
   else
-    echo "  ✗ $label"
-    echo "    expected: $(printf %q "$expected")"
-    echo "    actual:   $(printf %q "$actual")"
+    echo "  ✗ $1"
+    echo "    expected: $(printf %q "$2")"
+    echo "    actual:   $(printf %q "$3")"
     bump_score fail
   fi
 }
 
 assert_contains() {
-  local label="$1" needle="$2" haystack="$3"
-  if [[ "$haystack" == *"$needle"* ]]; then
-    echo "  ✓ $label"
-    bump_score pass
+  if [[ "$3" == *"$2"* ]]; then echo "  ✓ $1"; bump_score pass
   else
-    echo "  ✗ $label"
-    echo "    expected to contain: $needle"
-    echo "    actual: $haystack"
+    echo "  ✗ $1"
+    echo "    expected to contain: $2"
+    echo "    actual (first 200 chars): ${3:0:200}"
     bump_score fail
   fi
 }
 
 assert_not_contains() {
-  local label="$1" needle="$2" haystack="$3"
-  if [[ "$haystack" != *"$needle"* ]]; then
-    echo "  ✓ $label"
-    bump_score pass
+  if [[ "$3" != *"$2"* ]]; then echo "  ✓ $1"; bump_score pass
   else
-    echo "  ✗ $label"
-    echo "    expected NOT to contain: $needle"
-    echo "    actual: $haystack"
+    echo "  ✗ $1"
+    echo "    expected NOT to contain: $2"
     bump_score fail
   fi
 }
 
-# ── Create a throwaway repo mirroring gmux's layout ──
-#
-# The script uses the repo root (three levels up from the script path)
-# to find cliff.toml, apps/website/src/content/docs/changelog.mdx, and
-# RELEASE_HIGHLIGHTS.md. We replicate that layout in a temp directory.
-
+# Lay out a temp repo that mirrors the bits of the gmux tree version.sh
+# touches: cliff.toml at the root, the changelog under apps/website/...,
+# and a stub RELEASE_HIGHLIGHTS.md. Tag v1.0.0 on the initial commit so
+# git-cliff's --bump always has a baseline.
 make_repo() {
   local tmp="$1"
   mkdir -p "$tmp/.github/workflows/scripts"
@@ -89,7 +78,6 @@ make_repo() {
   cp "$REAL_SCRIPT" "$tmp/.github/workflows/scripts/version.sh"
   cp "$REAL_CLIFF_TOML" "$tmp/cliff.toml"
 
-  # Seed changelog with one past release so the insertion path is exercised.
   cat > "$tmp/apps/website/src/content/docs/changelog.mdx" <<'EOF'
 ---
 title: Changelog
@@ -120,443 +108,268 @@ EOF
   )
 }
 
+# Unset CI so version.sh's "fail loudly in CI when GITHUB_TOKEN missing"
+# branch doesn't trip the test runner. Real release runs go through the
+# CI=true path.
 run_script() {
   local tmp="$1" arg="${2:-}"
   (
     cd "$tmp"
-    bash .github/workflows/scripts/version.sh ${arg:+"$arg"} 2>&1
+    CI= bash .github/workflows/scripts/version.sh ${arg:+"$arg"} 2>&1
   )
 }
 
-# ── Test: no releasable commits (only docs/chore/refactor) ──
+# Add an empty commit and return without noise.
+commit() {
+  git -c commit.gpgsign=false commit --allow-empty --quiet -m "$1"
+}
+
+# ── Test: docs / chore alone do not trigger a release ──
+#
+# `releasable_count` filters to Features / Fixes / Breaking / Security.
+# A docs-only push must be a no-op so the workflow doesn't open a PR.
 
 echo "No releasable commits:"
 (
-  tmp=$(mktemp -d)
-  trap 'rm -rf "$tmp"' EXIT
-  make_repo "$tmp"
-  cd "$tmp"
-  git -c commit.gpgsign=false commit --allow-empty --quiet -m "docs: update readme"
-  git -c commit.gpgsign=false commit --allow-empty --quiet -m "chore: bump deps"
+  tmp=$(mktemp -d); trap 'rm -rf "$tmp"' EXIT
+  make_repo "$tmp"; cd "$tmp"
+  commit "docs: update readme"
+  commit "chore: bump deps"
 
   output=$(run_script "$tmp")
-  assert_contains "docs+chore only exits with no release" "No releasable commits" "$output"
-
-  # changelog.mdx should be unchanged
   changelog=$(cat apps/website/src/content/docs/changelog.mdx)
-  assert_not_contains "changelog.mdx unchanged" "## v1.0.1" "$changelog"
+
+  assert_contains "exits with 'no releasable commits'" "No releasable commits" "$output"
+  assert_not_contains "changelog.mdx untouched"        "## v1.0.1"             "$changelog"
 )
 
-# ── Test: release commit detection ──
+# ── Test: HEAD = "release: vX.Y.Z" triggers loop-prevention skip ──
+#
+# Plus the regression that subjects merely *containing* "release/next"
+# (e.g. a fix mentioning the branch name) are NOT treated as release
+# commits.
 
 echo ""
 echo "Release commit detection:"
 (
-  tmp=$(mktemp -d)
-  trap 'rm -rf "$tmp"' EXIT
-  make_repo "$tmp"
-  cd "$tmp"
-  git -c commit.gpgsign=false commit --allow-empty --quiet -m "release: v1.0.1"
+  tmp=$(mktemp -d); trap 'rm -rf "$tmp"' EXIT
+  make_repo "$tmp"; cd "$tmp"
+  commit "release: v1.0.1"
 
   output=$(run_script "$tmp")
-  assert_contains "release: vX.Y.Z triggers skip" "Release commit, skipping" "$output"
+  assert_contains "release: vX.Y.Z is recognised" "Release commit, skipping" "$output"
 )
-
-# ── Test: commits that mention "release/next" in their subject are NOT
-# ── mistaken for release commits. Regression test: a prior loose
-# ── regex `=~ release/next` matched anywhere in the subject line.
-
-echo ""
-echo "Release commit detection does not match substring matches:"
 (
-  tmp=$(mktemp -d)
-  trap 'rm -rf "$tmp"' EXIT
-  make_repo "$tmp"
-  cd "$tmp"
-  git -c commit.gpgsign=false commit --allow-empty --quiet -m "fix: use fixed release/next branch for release PR (#13)"
+  tmp=$(mktemp -d); trap 'rm -rf "$tmp"' EXIT
+  make_repo "$tmp"; cd "$tmp"
+  commit "fix: use fixed release/next branch (#13)"
 
   version=$(run_script "$tmp" --dry-run | head -1)
-  assert_eq "fix that mentions release/next still triggers patch bump" "v1.0.1" "$version"
+  assert_eq "subject containing 'release/next' still bumps" "v1.0.1" "$version"
 )
 
-# ── Test: fix commit triggers patch bump ──
+# ── Test: bump level matches the highest commit type ──
+#
+# version.sh's job is to take git-cliff's bump output and surface it
+# verbatim on stdout. Cover one commit per type, plus the "highest
+# wins" interaction.
 
 echo ""
-echo "Patch bump (fix commit):"
+echo "Bump level:"
+for case in \
+  "fix: small bug (#1)|v1.0.1" \
+  "feat: add thing (#2)|v1.1.0" \
+  "feat!: redesign (#3)|v2.0.0" \
+  "perf: faster boot (#4)|v1.0.1" \
+  "security: redact secrets (#5)|v1.0.1"
+do
+  msg=${case%%|*}; expected=${case##*|}
+  (
+    tmp=$(mktemp -d); trap 'rm -rf "$tmp"' EXIT
+    make_repo "$tmp"; cd "$tmp"
+    commit "$msg"
+    actual=$(run_script "$tmp" --dry-run | head -1)
+    assert_eq "${msg%%:*} → $expected" "$expected" "$actual"
+  )
+done
 (
-  tmp=$(mktemp -d)
-  trap 'rm -rf "$tmp"' EXIT
-  make_repo "$tmp"
-  cd "$tmp"
-  git -c commit.gpgsign=false commit --allow-empty --quiet -m "fix: handle nil pointer (#42)"
+  tmp=$(mktemp -d); trap 'rm -rf "$tmp"' EXIT
+  make_repo "$tmp"; cd "$tmp"
+  commit "fix: small (#1)"
+  commit "feat: bigger (#2)"
+  commit "fix: another (#3)"
+  actual=$(run_script "$tmp" --dry-run | head -1)
+  assert_eq "feat among fixes wins minor bump" "v1.1.0" "$actual"
+)
 
-  version=$(run_script "$tmp" --dry-run | head -1)
-  assert_eq "fix bumps patch" "v1.0.1" "$version"
+# ── Test: cliff.toml smoke test (every expected group heading appears) ──
+#
+# Pin that cliff.toml still routes the four commit types we care about
+# into the four group headings notify-discord.sh and the changelog
+# rely on. We don't assert ordering or per-bullet wording.
+
+echo ""
+echo "cliff.toml renders all expected group headings:"
+(
+  tmp=$(mktemp -d); trap 'rm -rf "$tmp"' EXIT
+  make_repo "$tmp"; cd "$tmp"
+  commit "fix: f (#1)"
+  commit "feat: F (#2)"
+  commit "perf: P (#3)"
+  commit "security: S (#4)"
+  commit "feat!: B (#5)"
 
   run_script "$tmp" >/dev/null
   changelog=$(cat apps/website/src/content/docs/changelog.mdx)
-  assert_contains "new section heading"      "## v1.0.1" "$changelog"
-  assert_contains "fix bullet text"          "handle nil pointer" "$changelog"
-  assert_contains "PR link"                  "[#42](https://github.com/gmuxapp/gmux/pull/42)" "$changelog"
-  assert_contains "Fixes group heading"      "### Fixes" "$changelog"
-  assert_contains "previous version retained" "## v1.0.0" "$changelog"
+
+  assert_contains "Breaking heading" "### Breaking" "$changelog"
+  assert_contains "Security heading" "### Security" "$changelog"
+  assert_contains "Features heading" "### Features" "$changelog"
+  assert_contains "Fixes heading"    "### Fixes"    "$changelog"
 )
 
-# ── Test: feat commit triggers minor bump ──
-
-echo ""
-echo "Minor bump (feat commit):"
-(
-  tmp=$(mktemp -d)
-  trap 'rm -rf "$tmp"' EXIT
-  make_repo "$tmp"
-  cd "$tmp"
-  git -c commit.gpgsign=false commit --allow-empty --quiet -m "feat: add dark mode (#50)"
-
-  version=$(run_script "$tmp" --dry-run | head -1)
-  assert_eq "feat bumps minor" "v1.1.0" "$version"
-)
-
-# ── Test: feat! commit triggers major bump ──
-
-echo ""
-echo "Major bump (breaking change):"
-(
-  tmp=$(mktemp -d)
-  trap 'rm -rf "$tmp"' EXIT
-  make_repo "$tmp"
-  cd "$tmp"
-  git -c commit.gpgsign=false commit --allow-empty --quiet -m "feat!: redesign API (#99)"
-
-  version=$(run_script "$tmp" --dry-run | head -1)
-  assert_eq "feat! bumps major" "v2.0.0" "$version"
-
-  run_script "$tmp" >/dev/null
-  changelog=$(cat apps/website/src/content/docs/changelog.mdx)
-  assert_contains "Breaking section present" "### Breaking" "$changelog"
-)
-
-# ── Test: mixed commits, highest bump wins ──
-
-echo ""
-echo "Mixed commits (highest bump wins):"
-(
-  tmp=$(mktemp -d)
-  trap 'rm -rf "$tmp"' EXIT
-  make_repo "$tmp"
-  cd "$tmp"
-  git -c commit.gpgsign=false commit --allow-empty --quiet -m "fix: small bug (#1)"
-  git -c commit.gpgsign=false commit --allow-empty --quiet -m "feat: big feature (#2)"
-  git -c commit.gpgsign=false commit --allow-empty --quiet -m "fix: another bug (#3)"
-
-  version=$(run_script "$tmp" --dry-run | head -1)
-  assert_eq "fix+feat+fix bumps minor" "v1.1.0" "$version"
-
-  run_script "$tmp" >/dev/null
-  changelog=$(cat apps/website/src/content/docs/changelog.mdx)
-  assert_contains "feature appears" "big feature" "$changelog"
-  assert_contains "fix appears"     "small bug"   "$changelog"
-  assert_contains "other fix"       "another bug" "$changelog"
-)
-
-# ── Test: highlights injected into both files ──
+# ── Test: highlights flow into RELEASE_NOTES.md and changelog.mdx ──
+#
+# This is version.sh's main orchestration responsibility. The
+# <!-- highlights-end --> marker in RELEASE_NOTES.md is what
+# notify-discord.sh keys off to extract the Discord summary; if the
+# marker drifts or the highlights aren't injected, Discord stops
+# announcing prose. The highlights file itself must survive (single
+# source of truth; release.yml clears it post-release).
 
 echo ""
 echo "Highlights integration:"
 (
-  tmp=$(mktemp -d)
-  trap 'rm -rf "$tmp"' EXIT
-  make_repo "$tmp"
-  cd "$tmp"
-  git -c commit.gpgsign=false commit --allow-empty --quiet -m "feat: add dark mode (#50)"
-
+  tmp=$(mktemp -d); trap 'rm -rf "$tmp"' EXIT
+  make_repo "$tmp"; cd "$tmp"
+  commit "feat: dark mode (#50)"
   cat > RELEASE_HIGHLIGHTS.md <<'EOF'
-Major theme overhaul: every panel now supports a dark variant.
-
-### Migration
-Run `gmux migrate-theme` after updating.
+Major theme overhaul.
 EOF
 
   run_script "$tmp" >/dev/null
   changelog=$(cat apps/website/src/content/docs/changelog.mdx)
-  assert_contains "highlights prose in changelog"     "Major theme overhaul" "$changelog"
-  assert_contains "highlights subheading in changelog" "### Migration"        "$changelog"
-
   release_notes=$(cat RELEASE_NOTES.md)
-  assert_contains "highlights in release notes"   "Major theme overhaul"     "$release_notes"
-  assert_contains "marker in release notes"       "<!-- highlights-end -->" "$release_notes"
-  assert_contains "bullets in release notes"      "add dark mode"            "$release_notes"
-
-  # notify-discord.sh extraction: everything before the highlights-end marker.
-  discord_summary=$(sed '/<!-- highlights-end -->/,$d' RELEASE_NOTES.md)
-  assert_contains "Discord gets highlights"         "Major theme overhaul" "$discord_summary"
-  assert_not_contains "Discord does not get bullets" "add dark mode"       "$discord_summary"
-
-  # Highlights file should be cleared (contain only the stub comment)
   highlights_after=$(cat RELEASE_HIGHLIGHTS.md)
-  assert_not_contains "highlights cleared after release" "Major theme overhaul" "$highlights_after"
-  assert_contains "highlights stub retained" "<!--" "$highlights_after"
+
+  assert_contains "highlights reach changelog"      "Major theme overhaul"    "$changelog"
+  assert_contains "highlights reach release notes"  "Major theme overhaul"    "$release_notes"
+  assert_contains "Discord-extraction marker"       "<!-- highlights-end -->" "$release_notes"
+  assert_contains "highlights file preserved"       "Major theme overhaul"    "$highlights_after"
+
+  # The Discord summary is everything BEFORE the marker. Bullets must
+  # not bleed into it (they belong below the marker, and the link
+  # already says "see the changelog").
+  discord=$(sed '/<!-- highlights-end -->/,$d' RELEASE_NOTES.md)
+  assert_not_contains "Discord summary excludes bullets" "dark mode" "$discord"
 )
 
-# ── Test: BREAKING CHANGE: footer triggers major bump and lands in Breaking ──
+# ── Test: --clear-highlights resets the file to a stub ──
 #
-# git-cliff moves the footer out of the body and exposes it separately,
-# so the commit parser must match on `footer =`, not `body =`. This test
-# pins that behavior.
+# Invoked by release.yml after a successful release. Without this
+# mode, RELEASE_HIGHLIGHTS.md would carry the previous release's
+# prose into the next cycle.
 
 echo ""
-echo "BREAKING CHANGE footer:"
+echo "--clear-highlights:"
 (
-  tmp=$(mktemp -d)
-  trap 'rm -rf "$tmp"' EXIT
+  tmp=$(mktemp -d); trap 'rm -rf "$tmp"' EXIT
   make_repo "$tmp"
-  cd "$tmp"
-  git -c commit.gpgsign=false commit --allow-empty --quiet -m "$(printf 'feat: new config format (#60)\n\nBREAKING CHANGE: old config format no longer supported.')"
+  echo "Stale prose from a shipped release." > "$tmp/RELEASE_HIGHLIGHTS.md"
 
-  version=$(run_script "$tmp" --dry-run | head -1)
-  assert_eq "BREAKING CHANGE footer bumps major" "v2.0.0" "$version"
-
-  run_script "$tmp" >/dev/null
-  changelog=$(cat apps/website/src/content/docs/changelog.mdx)
-  assert_contains "Breaking section present"      "### Breaking"      "$changelog"
-  assert_contains "breaking commit under Breaking" "new config format" "$changelog"
-  # The commit must NOT also appear under Features.
-  features_section=$(echo "$changelog" | awk '/^## v2\.0\.0/{found=1; next} found && /^## v/{exit} found && /^### /{section=$0; next} found{print section" | "$0}' | grep -c '### Features | - new config format' || true)
-  assert_eq "breaking commit is NOT duplicated under Features" "0" "$features_section"
+  run_script "$tmp" --clear-highlights >/dev/null
+  highlights_after=$(cat "$tmp/RELEASE_HIGHLIGHTS.md")
+  assert_not_contains "stale prose removed" "Stale prose" "$highlights_after"
 )
 
-# ── Test: perf triggers patch bump and lands in Features ──
-
-echo ""
-echo "Perf commits trigger patch release:"
-(
-  tmp=$(mktemp -d)
-  trap 'rm -rf "$tmp"' EXIT
-  make_repo "$tmp"
-  cd "$tmp"
-  git -c commit.gpgsign=false commit --allow-empty --quiet -m "perf: faster session resume (#70)"
-
-  version=$(run_script "$tmp" --dry-run | head -1)
-  assert_eq "perf bumps patch" "v1.0.1" "$version"
-
-  run_script "$tmp" >/dev/null
-  changelog=$(cat apps/website/src/content/docs/changelog.mdx)
-  assert_contains "perf bullet under Features" "faster session resume" "$changelog"
-  assert_contains "Features section exists"    "### Features"          "$changelog"
-)
-
-# ── Test: changelog insertion preserves prior release sections ──
-#
-# The awk insertion path should place the new section above the first
-# existing `## v` heading without disturbing anything below it.
-
-echo ""
-echo "Changelog insertion preserves prior sections:"
-(
-  tmp=$(mktemp -d)
-  trap 'rm -rf "$tmp"' EXIT
-  make_repo "$tmp"
-  cd "$tmp"
-  git -c commit.gpgsign=false commit --allow-empty --quiet -m "feat: new thing (#80)"
-
-  run_script "$tmp" >/dev/null
-  changelog=$(cat apps/website/src/content/docs/changelog.mdx)
-  assert_contains "prior v1.0.0 heading still present" "## v1.0.0"         "$changelog"
-  assert_contains "prior v1.0.0 bullet still present"  "everything"        "$changelog"
-  assert_contains "new v1.1.0 heading present"         "## v1.1.0 - "      "$changelog"
-
-  # New heading must come before old heading in the file.
-  new_line=$(grep -n '^## v1.1.0' apps/website/src/content/docs/changelog.mdx | head -1 | cut -d: -f1)
-  old_line=$(grep -n '^## v1.0.0' apps/website/src/content/docs/changelog.mdx | head -1 | cut -d: -f1)
-  if [[ -n "$new_line" && -n "$old_line" && "$new_line" -lt "$old_line" ]]; then
-    echo "  ✓ new section inserted above prior section"
-    bump_score pass
-  else
-    echo "  ✗ new section not inserted above prior section (new line: $new_line, old line: $old_line)"
-    bump_score fail
-  fi
-)
-
-# ── Test: scope appears as bold tag in bullets ──
-
-echo ""
-echo "Scope rendering:"
-(
-  tmp=$(mktemp -d)
-  trap 'rm -rf "$tmp"' EXIT
-  make_repo "$tmp"
-  cd "$tmp"
-  git -c commit.gpgsign=false commit --allow-empty --quiet -m "feat(peering): reconnect after system sleep (#30)"
-  git -c commit.gpgsign=false commit --allow-empty --quiet -m "fix(web): overlap on narrow viewports (#31)"
-  git -c commit.gpgsign=false commit --allow-empty --quiet -m "feat: unscoped feature (#32)"
-
-  run_script "$tmp" >/dev/null
-  changelog=$(cat apps/website/src/content/docs/changelog.mdx)
-  assert_contains "scoped feat bullet has bold scope"   "**(peering)** reconnect after system sleep" "$changelog"
-  assert_contains "scoped fix bullet has bold scope"    "**(web)** overlap on narrow viewports"      "$changelog"
-  assert_contains "unscoped bullet has no scope prefix" "- unscoped feature"                         "$changelog"
-  assert_not_contains "unscoped bullet has no empty bold" "- ****"                                   "$changelog"
-)
-
-# ── Test: date appears in version heading ──
-
-echo ""
-echo "Date in heading:"
-(
-  tmp=$(mktemp -d)
-  trap 'rm -rf "$tmp"' EXIT
-  make_repo "$tmp"
-  cd "$tmp"
-  git -c commit.gpgsign=false commit --allow-empty --quiet -m "fix: today bug (#1)"
-
-  run_script "$tmp" >/dev/null
-  changelog=$(cat apps/website/src/content/docs/changelog.mdx)
-  today=$(date -u +%Y-%m-%d)
-  assert_contains "heading includes ISO date" "## v1.0.1 - $today" "$changelog"
-)
-
-# ── Test: security commits get their own section ──
-
-echo ""
-echo "Security section:"
-(
-  tmp=$(mktemp -d)
-  trap 'rm -rf "$tmp"' EXIT
-  make_repo "$tmp"
-  cd "$tmp"
-  git -c commit.gpgsign=false commit --allow-empty --quiet -m "security: redact tokens from logs (#40)"
-
-  version=$(run_script "$tmp" --dry-run | head -1)
-  assert_eq "security bumps patch" "v1.0.1" "$version"
-
-  run_script "$tmp" >/dev/null
-  changelog=$(cat apps/website/src/content/docs/changelog.mdx)
-  assert_contains "Security section heading" "### Security" "$changelog"
-  assert_contains "Security bullet text"     "redact tokens from logs" "$changelog"
-)
-
-# ── Test: security appears before Features in the ordering ──
-
-echo ""
-echo "Security ordering:"
-(
-  tmp=$(mktemp -d)
-  trap 'rm -rf "$tmp"' EXIT
-  make_repo "$tmp"
-  cd "$tmp"
-  git -c commit.gpgsign=false commit --allow-empty --quiet -m "feat: new feature (#1)"
-  git -c commit.gpgsign=false commit --allow-empty --quiet -m "security: patch vulnerability (#2)"
-  git -c commit.gpgsign=false commit --allow-empty --quiet -m "fix: small bug (#3)"
-
-  run_script "$tmp" >/dev/null
-  changelog=$(cat apps/website/src/content/docs/changelog.mdx)
-
-  # Extract group heading order within the new release section.
-  order=$(echo "$changelog" | awk '/^## v1\.1\.0/{found=1; next} found && /^## v/{exit} found && /^### /{print}')
-  expected_order=$(printf '### Security\n### Features\n### Fixes')
-  assert_eq "Security appears before Features and Fixes" "$expected_order" "$order"
-)
-
-# ── Test: inline HTML comments in highlights do not swallow content ──
+# ── Test: highlights HTML-comment stripping ──
 #
 # Regression test for a sed-range bug: `sed '/<!--/,/-->/d'` swallows
-# everything after an inline `<!-- note -->` because sed won't match
-# start and end on the same line. The script uses a stateful awk
-# helper instead.
+# everything after an inline `<!-- note -->` because sed can't match
+# start and end on the same line. version.sh uses a stateful awk
+# helper; pin that it handles both inline and multi-line comments.
 
 echo ""
-echo "Inline HTML comments in highlights:"
+echo "Highlights HTML comments:"
 (
-  tmp=$(mktemp -d)
-  trap 'rm -rf "$tmp"' EXIT
-  make_repo "$tmp"
-  cd "$tmp"
-  git -c commit.gpgsign=false commit --allow-empty --quiet -m "feat: something (#90)"
-
+  tmp=$(mktemp -d); trap 'rm -rf "$tmp"' EXIT
+  make_repo "$tmp"; cd "$tmp"
+  commit "feat: thing (#90)"
   cat > RELEASE_HIGHLIGHTS.md <<'EOF'
 First paragraph.
 
-<!-- inline note from the author -->
+<!-- inline note -->
 
-Second paragraph survives the inline comment.
+Second paragraph.
 
 <!--
-This whole block should be dropped.
+multi-line
+comment
 -->
 
-Third paragraph also survives.
+Third paragraph.
 EOF
 
   run_script "$tmp" >/dev/null
-  changelog=$(cat apps/website/src/content/docs/changelog.mdx)
-  assert_contains "first paragraph present"                      "First paragraph"                        "$changelog"
-  assert_contains "second paragraph survives inline comment"     "Second paragraph survives"             "$changelog"
-  assert_contains "third paragraph survives multi-line comment"  "Third paragraph also survives"         "$changelog"
-  assert_not_contains "inline comment text is stripped"          "inline note from the author"           "$changelog"
-  assert_not_contains "multi-line comment text is stripped"      "This whole block should be dropped"    "$changelog"
-)
-
-# ── Test: empty highlights file produces clean release notes ──
-
-echo ""
-echo "Empty highlights produces clean output:"
-(
-  tmp=$(mktemp -d)
-  trap 'rm -rf "$tmp"' EXIT
-  make_repo "$tmp"
-  cd "$tmp"
-  git -c commit.gpgsign=false commit --allow-empty --quiet -m "fix: tiny bug (#7)"
-
-  # Leave RELEASE_HIGHLIGHTS.md as the default stub (comment only)
-  run_script "$tmp" >/dev/null
-
   release_notes=$(cat RELEASE_NOTES.md)
-  discord_summary=$(sed '/<!-- highlights-end -->/,$d' RELEASE_NOTES.md | awk '
-    { lines[NR] = $0 }
-    END {
-      first = 1
-      while (first <= NR && lines[first] ~ /^[[:space:]]*$/) first++
-      last = NR
-      while (last >= first && lines[last] ~ /^[[:space:]]*$/) last--
-      for (i = first; i <= last; i++) print lines[i]
-    }
-  ')
-  assert_eq "Discord summary empty when no highlights" "" "$discord_summary"
-  assert_contains "release notes has bullets"         "tiny bug" "$release_notes"
+
+  assert_contains "content before inline comment kept"     "First paragraph"  "$release_notes"
+  assert_contains "content after inline comment kept"      "Second paragraph" "$release_notes"
+  assert_contains "content after multi-line comment kept"  "Third paragraph"  "$release_notes"
+  assert_not_contains "inline comment stripped"            "inline note"      "$release_notes"
+  assert_not_contains "multi-line comment stripped"        "multi-line"       "$release_notes"
 )
 
-# ── Test: highlights with literal `---` (horizontal rule) survive ──
+# ── Test: a literal `---` inside highlights survives ──
 #
-# Regression test for the old `---` separator: if a user used a
-# markdown horizontal rule inside their highlights, the old
-# `sed '/^---$/,$d'` would truncate the summary at the first `---`,
-# losing the rest of the prose. With `<!-- highlights-end -->` as the
-# sentinel, user-written `---` lines pass through unchanged.
+# Regression: the old format used `---` as the highlights-end marker,
+# which collided with user-written horizontal rules. The
+# `<!-- highlights-end -->` sentinel fixed it; this pins the fix.
 
 echo ""
-echo "Horizontal rules in highlights pass through:"
+echo "Horizontal rule in highlights survives:"
 (
-  tmp=$(mktemp -d)
-  trap 'rm -rf "$tmp"' EXIT
-  make_repo "$tmp"
-  cd "$tmp"
-  git -c commit.gpgsign=false commit --allow-empty --quiet -m "feat: add thing (#55)"
-
+  tmp=$(mktemp -d); trap 'rm -rf "$tmp"' EXIT
+  make_repo "$tmp"; cd "$tmp"
+  commit "feat: thing (#55)"
   cat > RELEASE_HIGHLIGHTS.md <<'EOF'
-First major theme.
+Theme A.
 
 ---
 
-Second major theme, after a horizontal rule.
+Theme B.
 EOF
 
   run_script "$tmp" >/dev/null
+  discord=$(sed '/<!-- highlights-end -->/,$d' RELEASE_NOTES.md)
 
-  discord_summary=$(sed '/<!-- highlights-end -->/,$d' RELEASE_NOTES.md)
-  assert_contains "first theme present"           "First major theme"         "$discord_summary"
-  assert_contains "horizontal rule preserved"     "---"                        "$discord_summary"
-  assert_contains "second theme after rule present" "Second major theme"       "$discord_summary"
-  assert_not_contains "bullets not in Discord"    "add thing"                 "$discord_summary"
+  assert_contains "content before horizontal rule" "Theme A" "$discord"
+  assert_contains "content after horizontal rule"  "Theme B" "$discord"
+)
+
+# ── Test: new changelog section is inserted ABOVE prior versions ──
+#
+# version.sh owns the awk insertion; if it ever appended at the end
+# instead, the latest release would render at the bottom of the page.
+
+echo ""
+echo "Changelog insertion order:"
+(
+  tmp=$(mktemp -d); trap 'rm -rf "$tmp"' EXIT
+  make_repo "$tmp"; cd "$tmp"
+  commit "feat: new (#80)"
+
+  run_script "$tmp" >/dev/null
+  new_line=$(grep -n '^## v1.1.0' apps/website/src/content/docs/changelog.mdx | head -1 | cut -d: -f1)
+  old_line=$(grep -n '^## v1.0.0' apps/website/src/content/docs/changelog.mdx | head -1 | cut -d: -f1)
+
+  if [[ -n "$new_line" && -n "$old_line" && "$new_line" -lt "$old_line" ]]; then
+    echo "  ✓ new section above prior section (lines $new_line < $old_line)"
+    bump_score pass
+  else
+    echo "  ✗ new section not above prior section (new=$new_line, old=$old_line)"
+    bump_score fail
+  fi
 )
 
 # ── Summary ──

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -97,6 +97,45 @@ jobs:
           ${NOTES}
           EOF
 
+      # Sticky comment showing exactly what will go to Discord and the
+      # GitHub Release. Reviewers can verify wording before merging
+      # without having to expand the PR body or run version.sh locally.
+      - name: Post release preview comment
+        if: steps.version.outputs.version != '' && steps.create-pr.outputs.pull-request-number != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUM: ${{ steps.create-pr.outputs.pull-request-number }}
+          VERSION: ${{ steps.version.outputs.version }}
+          NOTES: ${{ steps.body.outputs.notes }}
+        run: |
+          summary=$(printf '%s\n' "$NOTES" | sed '/<!-- highlights-end -->/,$d' | awk 'NF{p=1} p' | awk '{a[NR]=$0} END{n=NR; while(n>0 && a[n]~/^[[:space:]]*$/) n--; for(i=1;i<=n;i++) print a[i]}')
+          if [[ -z "$summary" ]]; then
+            summary="_(no highlights; only the changelog link will be posted)_"
+          fi
+          quoted=$(printf '%s\n' "$summary" | sed 's/^/> /')
+          marker='<!-- gmux-release-preview -->'
+          {
+            printf '%s\n' "$marker"
+            printf '### Discord announcement preview\n\n'
+            printf 'What `notify-discord.sh` will post when this release ships:\n\n'
+            printf '> ## gmux %s\n>\n' "$VERSION"
+            printf '%s\n' "$quoted"
+            printf '>\n> [See the changelog for details.](https://gmux.app/changelog)\n\n'
+            printf 'To tweak this, edit `RELEASE_HIGHLIGHTS.md` on the `release/next` branch and run `scripts/regen-release-notes.sh` to refresh the generated files.\n'
+          } > /tmp/preview.md
+          existing=$(gh api "repos/$REPO/issues/$PR_NUM/comments" \
+            --jq ".[] | select(.body | startswith(\"$marker\")) | .id" | head -1)
+          if [[ -n "$existing" ]]; then
+            # Build a proper JSON body via jq --rawfile so markdown
+            # content (with quotes, backticks, control chars) is
+            # always escaped correctly.
+            jq -n --rawfile body /tmp/preview.md '{body: $body}' \
+              | gh api -X PATCH "repos/$REPO/issues/comments/$existing" --input -
+          else
+            gh pr comment "$PR_NUM" --body-file /tmp/preview.md
+          fi
+
       - name: Trigger PR build
         if: steps.version.outputs.version != '' && steps.create-pr.outputs.pull-request-number != ''
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,10 +43,19 @@ messages directly. Rules that follow from this:
   `jj squash` / `jj split` / `jj describe` to fix up WIP commits
   locally.
 - **Prose highlights for a release** go in `RELEASE_HIGHLIGHTS.md` at
-  the repo root. Edit it as part of the PR that ships the noteworthy
-  change. The content is injected into the changelog section between
-  the version heading and the grouped bullet lists, and cleared after
-  release.
+  the repo root. It's the single source of truth for release prose:
+  edit it as part of the PR that ships the noteworthy change, or on
+  the open `release/next` branch up until merge. The content is
+  injected into the changelog section between the version heading and
+  the grouped bullet lists. The release workflow clears it
+  automatically after a successful release.
+
+  To tweak prose on an already-open release PR: check out
+  `release/next`, edit `RELEASE_HIGHLIGHTS.md`, run
+  `scripts/regen-release-notes.sh`, then
+  `git push --force-with-lease origin release/next`. The version
+  workflow also posts a sticky preview comment on the PR showing
+  exactly what will go to Discord.
 
 ## Other rules
 

--- a/RELEASE_HIGHLIGHTS.md
+++ b/RELEASE_HIGHLIGHTS.md
@@ -1,12 +1,17 @@
 <!--
 Optional prose for the next release. Edit this file to add a high-level
-summary, topic paragraphs, or migration notes. When version.sh runs, the
-content is injected into the changelog section between the version
-heading and the grouped bullet lists.
+summary, topic paragraphs, or migration notes. Its content is injected
+into the changelog section between the version heading and the grouped
+bullet lists.
 
-The file is cleared automatically after each release. Leave empty for
-releases that don't need prose (the auto-generated bullet list is
-enough for patch-only releases).
+This file is the single source of truth for release prose: edit it on
+`main` before merging the PR that ships the noteworthy change, or on
+the `release/next` branch up until the release ships (then run
+`scripts/regen-release-notes.sh` to refresh the generated files).
+
+The release workflow clears this file automatically after a successful
+release. Leave empty for releases that don't need prose; the
+auto-generated bullet list is enough for patch-only releases.
 
 Format: plain markdown. Supports headings, paragraphs, and lists.
 Example:

--- a/scripts/regen-release-notes.sh
+++ b/scripts/regen-release-notes.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Regenerate RELEASE_NOTES.md and changelog.mdx after editing
+# RELEASE_HIGHLIGHTS.md on the open release/next branch.
+#
+# Use this when you want to tweak release prose after the release PR
+# is already open:
+#
+#   1. Check out release/next.
+#   2. Edit RELEASE_HIGHLIGHTS.md.
+#   3. Run this script.
+#   4. Push (force-push) the branch back up.
+#
+# What it does:
+#
+#   - Saves your current RELEASE_HIGHLIGHTS.md edits.
+#   - Resets the working tree to the parent of the release commit
+#     (undoing the auto-generated changelog.mdx and RELEASE_NOTES.md).
+#   - Restores your highlights edits.
+#   - Re-runs version.sh to regenerate the auto-generated files.
+#   - Re-creates the `release: vX.Y.Z` commit.
+#
+# After it finishes, push with `git push -f origin release/next`.
+
+set -euo pipefail
+trap 'echo "error: ${BASH_SOURCE}:${LINENO}: ${BASH_COMMAND}" >&2' ERR
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+cur_branch=$(git rev-parse --abbrev-ref HEAD)
+if [[ "$cur_branch" != "release/next" ]]; then
+  echo "error: expected to be on 'release/next', got '$cur_branch'" >&2
+  exit 1
+fi
+
+head_subject=$(git log -1 --format='%s')
+version=$(echo "$head_subject" | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' || true)
+if [[ -z "$version" ]]; then
+  echo "error: HEAD is not a release commit (subject: $head_subject)" >&2
+  exit 1
+fi
+
+# Refuse to run if the parent of the release commit is not origin/main.
+# This catches the case where someone runs this script twice in a row
+# (which would reset past main) or where release/next has somehow
+# diverged from peter-evans's expected single-commit-on-top-of-main
+# shape.
+git fetch --quiet origin main
+parent=$(git rev-parse HEAD~1)
+main=$(git rev-parse origin/main)
+if [[ "$parent" != "$main" ]]; then
+  echo "error: HEAD~1 ($parent) is not origin/main ($main)." >&2
+  echo "       release/next should be exactly one commit on top of main." >&2
+  echo "       If you ran this script already, recreate the branch from origin/release/next first." >&2
+  exit 1
+fi
+
+# Refuse to run if there are uncommitted changes other than to
+# RELEASE_HIGHLIGHTS.md. The reset --hard below would silently discard
+# them.
+if ! git diff --quiet HEAD -- ':(exclude)RELEASE_HIGHLIGHTS.md'; then
+  echo "error: uncommitted changes outside RELEASE_HIGHLIGHTS.md would be lost." >&2
+  echo "       commit or stash them first." >&2
+  git diff --stat HEAD -- ':(exclude)RELEASE_HIGHLIGHTS.md' >&2
+  exit 1
+fi
+
+# 1. Save the current highlights (the human-edited source of truth).
+saved=$(mktemp)
+trap 'rm -f "$saved"' EXIT
+cp RELEASE_HIGHLIGHTS.md "$saved"
+
+# 2. Roll back the auto-generated release commit.
+echo "Resetting to $(git rev-parse --short HEAD~1) (parent of release commit)..."
+git reset --hard HEAD~1
+
+# 3. Restore the human-edited highlights on top of the clean tree.
+cp "$saved" RELEASE_HIGHLIGHTS.md
+
+# 4. Regenerate.
+.github/workflows/scripts/version.sh
+
+# 5. Re-create the release commit using the user's local git identity.
+git add -A
+git commit --quiet -m "release: $version"
+
+cat <<EOF
+
+Regenerated release notes for $version.
+
+Push with:
+  git push --force-with-lease origin release/next
+EOF


### PR DESCRIPTION
Two commits stacked on this PR.

## Commit 1: `fix(release): ping all relevant discord roles and suppress link embed`

- Each release now pings every role at or below its severity (patch always pings; feature adds feature; breaking adds feature + breaking).
- Discord message sets `flags: 4` (SUPPRESS_EMBEDS) so the changelog link no longer renders an autogenerated preview card.

## Commit 2: `feat(release): make highlights the source of truth, add preview comment, harden helpers`

Several improvements to the release flow.

### `RELEASE_HIGHLIGHTS.md` is now the single source of truth

Previously, `version.sh` cleared `RELEASE_HIGHLIGHTS.md` while generating the release PR, so once the PR was open the file on `release/next` was already empty. To tweak prose post-PR you had to edit *both* `RELEASE_NOTES.md` and `apps/website/src/content/docs/changelog.mdx` by hand, and they could drift.

Now:

- `version.sh` no longer clears `RELEASE_HIGHLIGHTS.md`. It stays populated on `release/next` until release time.
- A new `version.sh --clear-highlights` mode resets it to a stub.
- `release.yml` invokes that mode after a successful release and pushes a `chore: clear release highlights for vX.Y.Z` commit to `main`. Verified main's branch protection ruleset only blocks `deletion` and `non_fast_forward`, not direct fast-forward pushes.
- New `scripts/regen-release-notes.sh` helper: edit `RELEASE_HIGHLIGHTS.md` on `release/next`, run the script, force-push. It rolls back the auto-generated commit, restores your highlight edits on top of clean state, regenerates, and re-creates the release commit. Includes safeguards: refuses to run if not on `release/next`, if `HEAD~1` isn't `origin/main`, or if there are uncommitted changes outside `RELEASE_HIGHLIGHTS.md`.

### Sticky preview comment on the release PR

`version.yml` now posts (and updates) a single comment showing exactly what `notify-discord.sh` will send when the release ships. Reviewers can verify wording without expanding the PR body or running the script locally. Comment body is built via `jq --rawfile` and POSTed via `--input -` so arbitrary markdown content (quotes, backticks, control chars) round-trips correctly.

### Smarter Discord truncation

`notify-discord.sh` now cuts at the last paragraph break (then sentence break, then newline) under the 2000-char limit, instead of a hard byte cut mid-sentence. Adds an ellipsis (`…`) instead of `...`. The truncation logic is extracted into `trim_summary` and message composition into `compose_message`, removing duplication.

### `git describe` for previous tag

`notify-discord.sh` previously did `git tag -l | sort -V | grep -B1 ...` to find the prior tag, which silently broke if `VERSION` wasn't yet locally known or tags were out of order. Replaced with `git describe --tags --abbrev=0 "${VERSION}^"`, which always picks the actual predecessor on the release ancestry.

### Batched GraphQL PR lookup

`version.sh` previously made one REST call per commit to resolve PR links (`/commits/{sha}/pulls`). On larger releases that's dozens of round trips and silently no-ops without `GITHUB_TOKEN`. Now a single GraphQL query resolves every commit at once, and the script fails loudly when running in CI without auth so we never ship a changelog with bare commit subjects by accident. Falls back silently outside CI so iteration without `gh` keeps working.

### Testability and tests

`notify-discord.sh` gains a `DRY_RUN=1` env var that prints the JSON payload to stdout instead of POSTing. Useful for local debugging and powering a new test file `notify_discord_test.sh` covering:

- Patch / minor / major bumps ping the right roles (and only those).
- `flags: 4` is set so embeds are suppressed.
- Long summaries truncate at a paragraph break under the 2000-char limit, ellipsis is added, footer link survives.
- First-ever release (no predecessor tag) pings patch role only.

`version_test.sh` was updated: replaced the "highlights cleared after release" assertion with one verifying highlights survive PR generation, plus a new test for `--clear-highlights`.

All 36 tests pass locally (`version_test.sh`: 28, `notify_discord_test.sh`: 8). Tests were pruned from initial drafts to focus on behavior the scripts actually own; brittle string-matching against git-cliff templates and Discord rendered text was dropped.

### Docs

- `AGENTS.md` describes the new highlights flow and the `regen-release-notes.sh` workflow.
