### PR TITLE
feat(daemon): drop periodic conversations index scan in favor of watcher

### DIFF
--- a/RELEASE_HIGHLIGHTS.md
+++ b/RELEASE_HIGHLIGHTS.md
@@ -18,3 +18,9 @@ Example:
     `projects.json` replaces separate `remote` and `paths` fields with a
     unified `match` array.
 -->
+
+The daemon no longer rescans every adapter session file every 30
+seconds. Conversation discovery is now driven directly by filesystem
+events, so an idle gmuxd does no periodic work. Heavy users with
+many large pi/claude/codex sessions will see CPU drop from steady
+background burn to effectively zero when nothing is happening.

--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -39,6 +39,33 @@ defense-in-depth for future tests that spawn agents like `pi` or
 `claude` (which would otherwise read the operator's real
 `~/.pi/agent/` etc.); audit it manually when touching this setup.
 
+## Adapter-session fixtures
+
+`fixtures.ts` knows how to write minimally valid JSONL session files
+for pi/claude/codex into `$GMUX_TEST_HOME` (set by global-setup). Two
+specs use it:
+
+- `tests/conversation-fixtures.spec.ts` is a drift-detector. It
+  pre-seeds one fixture per adapter via global-setup *before* gmuxd
+  starts, then asserts each is reachable through `/v1/conversations/`
+  once bootstrap completes. If a Go parser grows a new required
+  field and the TS fixture lags, this spec fails first with a clear
+  signal pointing at fixture validity, before anything else.
+- `tests/conversation-discovery.spec.ts` exercises the watcher path:
+  writes JSONL files at test time and asserts the index reflects
+  them within 2s. Tight timeout intentionally: watcher-driven
+  discovery is sub-second; longer would mask regression to a
+  periodic scan. The harness's only alive session is `shell`, so
+  these tests implicitly verify always-on root watches — if root
+  watches were ever re-gated on a live session of the same kind,
+  the discovery tests would time out.
+
+When adding a test that needs a session file on disk, prefer
+`writeFakeSession` over hand-crafted JSONL. Each call needs a unique
+synthetic `cwd` so encoded paths and slugs don't collide between
+tests; `uniqueFixture(kind, label)` in the discovery spec is a good
+pattern.
+
 ## Test hooks on `window`
 
 Two hooks are exposed by the app for the harness; both are
@@ -57,6 +84,20 @@ needs to do more than read state or call an existing public API,
 that's a sign the production API is missing something; fix the API
 instead of growing the hook.
 
+## API helpers
+
+`helpers.ts` exposes two helpers for tests that talk to the daemon
+directly (without a browser context):
+
+- `apiGet<T>(urlPath)` — bearer-auth wrapper around `fetch` against
+  `127.0.0.1:${GMUXD_TEST_PORT}`. Returns `{ status, body }`. Body is
+  parsed JSON or undefined for non-JSON responses (404 etc.).
+- `pollUntil(fn, opts)` — polls until `fn` returns truthy or the
+  default 2s ceiling elapses. Use for assertions that wait on async
+  work ("file written, index updated, API reflects it"). Tight
+  default timeout is intentional: a longer wait masks regressions
+  that re-introduce polling somewhere in the stack.
+
 ## Adding tests
 
 - Reach for `gotoTestSession(page)` to navigate. It handles auth,
@@ -66,3 +107,6 @@ instead of growing the hook.
 - The test session is `bash -c 'echo READY; while true; do sleep 60; done'`
   with `cwd=$tmpDir/workspace`. Don't depend on anything more
   specific than that without changing the harness.
+- For tests that exercise daemon behavior without a browser (HTTP
+  endpoints, watcher paths), drop into `apiGet` + `pollUntil`. No
+  need to touch a `Page` if nothing in the UI changes.

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -73,12 +73,17 @@ function claudeFile(home: string, spec: FixtureSpec): string {
 
 function codexFile(home: string, spec: FixtureSpec): string {
   const root = path.join(home, '.codex', 'sessions')
-  // Codex is date-nested by file creation time; use today's date so
-  // ListSessionFiles finds it. Date format mirrors Go's time.Format.
+  // Codex is date-nested by file creation time. Path layout is
+  // YYYY/MM/DD/. Bootstrap uses ListSessionFiles which walks the
+  // entire tree (date-agnostic), so any reasonable date works for
+  // the smoke spec. Use *local* time to match Go's codex.SessionDir,
+  // which calls time.Now() (local) — keeps the fixture path
+  // identical to whatever a real codex session would create today
+  // on the same machine.
   const now = new Date()
-  const yyyy = String(now.getUTCFullYear())
-  const mm = String(now.getUTCMonth() + 1).padStart(2, '0')
-  const dd = String(now.getUTCDate()).padStart(2, '0')
+  const yyyy = String(now.getFullYear())
+  const mm = String(now.getMonth() + 1).padStart(2, '0')
+  const dd = String(now.getDate()).padStart(2, '0')
   return path.join(root, yyyy, mm, dd, `${spec.toolID}.jsonl`)
 }
 

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -1,0 +1,201 @@
+/**
+ * Adapter session-file fixtures used by both global-setup (pre-seeded
+ * before gmuxd starts, so the bootstrap scan picks them up) and by
+ * test specs (written at test time to exercise the watcher path).
+ *
+ * Each fixture is a minimally valid JSONL document for its adapter.
+ * The shapes here mirror the contracts in `packages/adapter/adapters/*.go`:
+ * if those parsers grow new required fields, the smoke spec is the
+ * first place to fail and the failure points at fixture drift.
+ *
+ * Path encoding mirrors each adapter's `SessionDir(cwd)` exactly. We
+ * intentionally don't import any Go logic; the fixtures stand on their
+ * own and the smoke spec round-trips them through the real parsers via
+ * the public API.
+ */
+import * as fs from 'fs'
+import * as path from 'path'
+
+export type AdapterKind = 'pi' | 'claude' | 'codex'
+
+export interface FixtureSpec {
+  kind: AdapterKind
+  /** Synthetic cwd for path encoding; must be unique within a test run. */
+  cwd: string
+  /** Session ID / UUID, used as filename. */
+  toolID: string
+  /**
+   * Human-readable title. Drives slug derivation. Use clean
+   * lowercase-with-spaces text so the slug is predictable.
+   */
+  title: string
+}
+
+export interface FixtureResult {
+  /** Absolute path the JSONL was written to. */
+  filePath: string
+  /** Slug `convIndex` will assign (matches Go `adapter.Slugify(title)`). */
+  expectedSlug: string
+}
+
+/**
+ * Mirror of Go's `adapter.Slugify`: lowercase, non-alphanumeric runs
+ * become `-`, trim leading/trailing `-`, cap at 40 chars.
+ */
+export function slugify(s: string): string {
+  let out = s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '')
+  if (out.length > 40) {
+    out = out.slice(0, 40).replace(/-+$/, '')
+  }
+  return out
+}
+
+/** Pi: strip leading `/`, replace remaining `/` with `-`, wrap in `--`. */
+function encodePiCwd(cwd: string): string {
+  const stripped = cwd.replace(/^\/+/, '')
+  return `--${stripped.replace(/\//g, '-')}--`
+}
+
+/** Claude: replace `/` and `.` with `-`. */
+function encodeClaudeCwd(cwd: string): string {
+  return cwd.replace(/[/.]/g, '-')
+}
+
+function piFile(home: string, spec: FixtureSpec): string {
+  const root = path.join(home, '.pi', 'agent', 'sessions')
+  return path.join(root, encodePiCwd(spec.cwd), `${spec.toolID}.jsonl`)
+}
+
+function claudeFile(home: string, spec: FixtureSpec): string {
+  const root = path.join(home, '.claude', 'projects')
+  return path.join(root, encodeClaudeCwd(spec.cwd), `${spec.toolID}.jsonl`)
+}
+
+function codexFile(home: string, spec: FixtureSpec): string {
+  const root = path.join(home, '.codex', 'sessions')
+  // Codex is date-nested by file creation time; use today's date so
+  // ListSessionFiles finds it. Date format mirrors Go's time.Format.
+  const now = new Date()
+  const yyyy = String(now.getUTCFullYear())
+  const mm = String(now.getUTCMonth() + 1).padStart(2, '0')
+  const dd = String(now.getUTCDate()).padStart(2, '0')
+  return path.join(root, yyyy, mm, dd, `${spec.toolID}.jsonl`)
+}
+
+function piContent(spec: FixtureSpec): string {
+  const ts = new Date().toISOString()
+  // Header line + session_info (sets title directly) + a user message
+  // (so `MessageCount > 0` and the conversation passes `CanResume`).
+  const header = JSON.stringify({
+    type: 'session',
+    id: spec.toolID,
+    cwd: spec.cwd,
+    timestamp: ts,
+  })
+  const sessionInfo = JSON.stringify({
+    type: 'session_info',
+    name: spec.title,
+  })
+  const userMsg = JSON.stringify({
+    type: 'message',
+    message: { role: 'user', content: [{ type: 'text', text: spec.title }] },
+  })
+  return header + '\n' + sessionInfo + '\n' + userMsg + '\n'
+}
+
+function claudeContent(spec: FixtureSpec): string {
+  const ts = new Date().toISOString()
+  // Claude's title priority is `custom-title` > first user message;
+  // we use a user message so the title round-trip is observable.
+  const userLine = JSON.stringify({
+    type: 'user',
+    sessionId: spec.toolID,
+    cwd: spec.cwd,
+    timestamp: ts,
+    message: { role: 'user', content: spec.title },
+  })
+  return userLine + '\n'
+}
+
+function codexContent(spec: FixtureSpec): string {
+  const ts = new Date().toISOString()
+  // session_meta line + a user response_item so the title comes from
+  // first-user-text (codex has no custom-title mechanism).
+  const meta = JSON.stringify({
+    type: 'session_meta',
+    payload: { id: spec.toolID, timestamp: ts, cwd: spec.cwd },
+  })
+  const userMsg = JSON.stringify({
+    type: 'response_item',
+    payload: {
+      type: 'message',
+      role: 'user',
+      content: [{ type: 'input_text', text: spec.title }],
+    },
+  })
+  return meta + '\n' + userMsg + '\n'
+}
+
+/** Write a JSONL session file under `home` for the given fixture. */
+export function writeFakeSession(home: string, spec: FixtureSpec): FixtureResult {
+  let filePath: string
+  let content: string
+  switch (spec.kind) {
+    case 'pi':
+      filePath = piFile(home, spec)
+      content = piContent(spec)
+      break
+    case 'claude':
+      filePath = claudeFile(home, spec)
+      content = claudeContent(spec)
+      break
+    case 'codex':
+      filePath = codexFile(home, spec)
+      content = codexContent(spec)
+      break
+  }
+  fs.mkdirSync(path.dirname(filePath), { recursive: true })
+  fs.writeFileSync(filePath, content)
+  return {
+    filePath,
+    expectedSlug: slugify(spec.title),
+  }
+}
+
+/**
+ * Append a line to a JSONL session file. Used by tests that want to
+ * exercise re-parse on Write events (e.g. claude `custom-title` after
+ * initial index).
+ */
+export function appendToSession(filePath: string, jsonLine: object): void {
+  fs.appendFileSync(filePath, JSON.stringify(jsonLine) + '\n')
+}
+
+/**
+ * Pre-seeded smoke fixtures, written by global-setup before gmuxd
+ * starts. Each tests the bootstrap scan path through a real parser.
+ *
+ * These slugs and toolIDs are referenced from the smoke spec, so the
+ * spec asserts the same fixtures global-setup wrote without
+ * re-deriving them.
+ */
+export const SMOKE_FIXTURES: FixtureSpec[] = [
+  {
+    kind: 'pi',
+    cwd: '/var/gmux-e2e/smoke-pi',
+    toolID: '00000000-0000-0000-0000-0000000000a1',
+    title: 'pi smoke fixture',
+  },
+  {
+    kind: 'claude',
+    cwd: '/var/gmux-e2e/smoke-claude',
+    toolID: '00000000-0000-0000-0000-0000000000a2',
+    title: 'claude smoke fixture',
+  },
+  {
+    kind: 'codex',
+    cwd: '/var/gmux-e2e/smoke-codex',
+    toolID: '00000000-0000-0000-0000-0000000000a3',
+    title: 'codex smoke fixture',
+  },
+]

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -13,8 +13,8 @@
  * own and the smoke spec round-trips them through the real parsers via
  * the public API.
  */
-import * as fs from 'fs'
-import * as path from 'path'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
 
 export type AdapterKind = 'pi' | 'claude' | 'codex'
 

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -4,6 +4,7 @@ import * as net from 'net'
 import * as os from 'os'
 import * as path from 'path'
 import type { FullConfig } from '@playwright/test'
+import { SMOKE_FIXTURES, writeFakeSession } from './fixtures'
 
 const ROOT = path.resolve(__dirname, '..')
 const GMUXD = path.join(ROOT, 'bin', 'gmuxd')
@@ -141,6 +142,16 @@ export default async function globalSetup(_config: FullConfig) {
   const fakeHome = path.join(tmpDir, 'home')
   fs.mkdirSync(fakeHome)
 
+  // Pre-seed smoke fixtures (one valid JSONL per adapter) before
+  // gmuxd starts. The bootstrap scan picks them up and the smoke spec
+  // asserts they're reachable at /v1/conversations/{kind}/{slug}. If a
+  // fixture is invalid for its parser, the smoke spec fails first with
+  // a clear "fixture didn't reach the index" signal, before the
+  // discovery spec's tests run.
+  for (const fixture of SMOKE_FIXTURES) {
+    writeFakeSession(fakeHome, fixture)
+  }
+
   const env: Record<string, string> = {
     PATH: process.env.PATH || '',
     HOME: fakeHome,
@@ -215,4 +226,9 @@ export default async function globalSetup(_config: FullConfig) {
   process.env.GMUXD_TEST_PORT = String(port)
   process.env.GMUX_TEST_SESSION_ID = sessionId
   process.env.GMUX_TEST_TOKEN = testToken
+  // Tests that write into adapter session roots (conversation
+  // discovery, etc.) need to know where the daemon is looking for
+  // session files. fakeHome is the daemon's HOME, so adapters resolve
+  // their roots under it.
+  process.env.GMUX_TEST_HOME = fakeHome
 }

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,5 +1,55 @@
 import type { Page } from '@playwright/test'
 
+/**
+ * Bearer-auth wrapper around `fetch` against the test gmuxd. Returns
+ * the parsed JSON body and the response status; tests assert on both.
+ *
+ * Targeting `127.0.0.1:${GMUXD_TEST_PORT}` directly (not via Playwright's
+ * baseURL) keeps these calls independent of any browser/page context
+ * so they work in `test.beforeAll`, helpers, and global setup teardown.
+ */
+export async function apiGet<T = unknown>(urlPath: string): Promise<{ status: number; body: T }> {
+  const port = process.env.GMUXD_TEST_PORT
+  const token = process.env.GMUX_TEST_TOKEN
+  if (!port) throw new Error('GMUXD_TEST_PORT not set; global-setup did not run')
+  if (!token) throw new Error('GMUX_TEST_TOKEN not set; global-setup did not run')
+  const resp = await fetch(`http://127.0.0.1:${port}${urlPath}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+  // 404 bodies aren't JSON; tolerate that.
+  let body: T = undefined as unknown as T
+  try {
+    body = await resp.json() as T
+  } catch { /* non-JSON, leave body undefined */ }
+  return { status: resp.status, body }
+}
+
+/**
+ * Poll `fn` until it returns a defined, truthy value (or until
+ * `timeoutMs` elapses). Returns the resolved value or throws.
+ *
+ * Use for assertions that depend on async work the daemon does after
+ * a side-effect (e.g. "file written → reachable in API"). Default
+ * 2s ceiling intentionally tight: the watcher path is sub-second, so
+ * a longer wait masks regression to a periodic scan.
+ */
+export async function pollUntil<T>(
+  fn: () => Promise<T | null | undefined | false>,
+  opts: { timeoutMs?: number; intervalMs?: number; description?: string } = {},
+): Promise<T> {
+  const timeoutMs = opts.timeoutMs ?? 2_000
+  const intervalMs = opts.intervalMs ?? 50
+  const description = opts.description ?? 'condition'
+  const start = Date.now()
+  let lastValue: T | null | undefined | false = undefined
+  while (Date.now() - start < timeoutMs) {
+    lastValue = await fn()
+    if (lastValue) return lastValue as T
+    await new Promise(r => setTimeout(r, intervalMs))
+  }
+  throw new Error(`pollUntil: ${description} did not become truthy within ${timeoutMs}ms (last=${JSON.stringify(lastValue)})`)
+}
+
 export interface TermState {
   termCols: number | undefined
   termRows: number | undefined

--- a/e2e/tests/conversation-discovery.spec.ts
+++ b/e2e/tests/conversation-discovery.spec.ts
@@ -1,0 +1,166 @@
+import { test, expect } from '@playwright/test'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { apiGet, pollUntil } from '../helpers'
+import {
+  type AdapterKind,
+  type FixtureSpec,
+  appendToSession,
+  writeFakeSession,
+} from '../fixtures'
+
+/**
+ * Watcher-driven conversation discovery spec.
+ *
+ * Each test creates a fresh adapter session file under the daemon's
+ * fakeHome at runtime (after gmuxd is already up) and asserts that
+ * the public API reflects the change within a tight timeout. The
+ * watcher path should be sub-second; 2s is the ceiling that catches
+ * regression to a periodic scan (which would land on a tick \u22650.5s
+ * away if reintroduced, and likely \u226530s).
+ *
+ * The harness's only alive session is `shell`. Pi, claude, and codex
+ * never have alive sessions in this test daemon. That means tests
+ * 1\u20133 implicitly verify always-on root watches: if the rewrite
+ * regressed to session-gated roots, the pi/claude/codex watches
+ * wouldn't exist, and these tests would time out.
+ */
+
+interface ConvBody {
+  data: { kind: string; title: string; cwd: string; slug: string }
+}
+
+const TEST_HOME = (): string => {
+  const home = process.env.GMUX_TEST_HOME
+  if (!home) throw new Error('GMUX_TEST_HOME not set; global-setup did not run')
+  return home
+}
+
+/** Poll /v1/conversations/{kind}/{slug} until it returns 200, or timeout. */
+async function awaitIndexed(kind: AdapterKind, slug: string, timeoutMs = 2_000): Promise<ConvBody['data']> {
+  return pollUntil(
+    async () => {
+      const { status, body } = await apiGet<ConvBody>(`/v1/conversations/${kind}/${slug}`)
+      if (status !== 200) return null
+      return body.data
+    },
+    { timeoutMs, description: `${kind}/${slug} reachable via API` },
+  )
+}
+
+/** Poll until /v1/conversations/{kind}/{slug} returns 404, or timeout. */
+async function awaitRemoved(kind: AdapterKind, slug: string, timeoutMs = 2_000): Promise<void> {
+  await pollUntil(
+    async () => {
+      const { status } = await apiGet<unknown>(`/v1/conversations/${kind}/${slug}`)
+      return status === 404 ? true : null
+    },
+    { timeoutMs, description: `${kind}/${slug} removed from API` },
+  )
+}
+
+/**
+ * Build a unique fixture for a test. Synthetic cwd embeds the test
+ * name + a random suffix so concurrent tests (or repeat runs) don't
+ * collide on slug/path.
+ */
+function uniqueFixture(kind: AdapterKind, label: string): FixtureSpec {
+  const tag = `${label}-${Math.random().toString(36).slice(2, 10)}`
+  return {
+    kind,
+    cwd: `/var/gmux-e2e/discovery/${tag}`,
+    toolID: `disc-${tag}`,
+    title: `${kind} discovery ${tag}`,
+  }
+}
+
+test.describe('conversation discovery (watcher-driven)', () => {
+  // Track files created in each test for cleanup. Unique slugs make
+  // tests independent regardless, but cleanup keeps the daemon's
+  // index from accumulating cruft over a long test run.
+  const filesCreated: string[] = []
+  test.afterEach(() => {
+    while (filesCreated.length) {
+      const p = filesCreated.pop()!
+      try { fs.unlinkSync(p) } catch { /* already gone */ }
+    }
+  })
+
+  for (const kind of ['pi', 'claude', 'codex'] as const) {
+    test(`${kind}: write session file -> reachable in API within 2s`, async () => {
+      const spec = uniqueFixture(kind, 'create')
+      const { filePath, expectedSlug } = writeFakeSession(TEST_HOME(), spec)
+      filesCreated.push(filePath)
+
+      const result = await awaitIndexed(kind, expectedSlug)
+      expect(result.kind).toBe(kind)
+      expect(result.title).toBe(spec.title)
+      expect(result.cwd).toBe(spec.cwd)
+      expect(result.slug).toBe(expectedSlug)
+    })
+  }
+
+  test('claude: appending custom-title updates API title within 2s', async () => {
+    // Initial fixture: title comes from the user message.
+    const spec = uniqueFixture('claude', 'retitle')
+    const { filePath, expectedSlug } = writeFakeSession(TEST_HOME(), spec)
+    filesCreated.push(filePath)
+
+    // Wait for initial indexing.
+    const initial = await awaitIndexed('claude', expectedSlug)
+    expect(initial.title).toBe(spec.title)
+
+    // Append a `custom-title` line. Claude's parser prefers
+    // custom-title over first-user-message text, so the indexed
+    // title should update on re-parse. The slug stays stable across
+    // updates (Upsert preserves it via byToolID, so existing URLs
+    // don't break) — we query the same slug and expect a new title.
+    const newTitle = 'claude custom retitled'
+    appendToSession(filePath, { type: 'custom-title', customTitle: newTitle })
+
+    await pollUntil(
+      async () => {
+        const { status, body } = await apiGet<ConvBody>(`/v1/conversations/claude/${expectedSlug}`)
+        if (status !== 200) return null
+        return body.data.title === newTitle ? body.data : null
+      },
+      { description: `claude/${expectedSlug} title updated to ${newTitle}` },
+    )
+  })
+
+  test('pi: deleting session file -> 404 within 2s', async () => {
+    const spec = uniqueFixture('pi', 'delete')
+    const { filePath, expectedSlug } = writeFakeSession(TEST_HOME(), spec)
+    // Don't push to filesCreated; the test deletes the file itself.
+
+    await awaitIndexed('pi', expectedSlug)
+
+    // Remove triggers fsnotify Remove -> RemoveByPath.
+    fs.unlinkSync(filePath)
+
+    await awaitRemoved('pi', expectedSlug)
+  })
+
+  test('pi: write into a brand-new cwd subdirectory -> reachable within 2s', async () => {
+    // The synthetic cwd is unique per test; its encoded subdirectory
+    // doesn't exist yet under $HOME/.pi/agent/sessions/. Creating it
+    // exercises the always-on root-watch path:
+    //   1. mkdir of new subdir -> Create event under root
+    //   2. handleNewSubdirLocked adds a watch on the new subdir
+    //   3. write of .jsonl inside -> Create event picked up by the new watch
+    //
+    // If the rewrite regressed to session-gated root watches, step 1
+    // wouldn't fire (root not watched without an alive pi session),
+    // and the test would time out.
+    const spec = uniqueFixture('pi', 'newdir')
+    const { filePath, expectedSlug } = writeFakeSession(TEST_HOME(), spec)
+    filesCreated.push(filePath)
+
+    // Sanity check that we did create a previously-nonexistent subdir.
+    const subdir = path.dirname(filePath)
+    expect(fs.existsSync(subdir)).toBe(true)
+
+    const result = await awaitIndexed('pi', expectedSlug)
+    expect(result.cwd).toBe(spec.cwd)
+  })
+})

--- a/e2e/tests/conversation-fixtures.spec.ts
+++ b/e2e/tests/conversation-fixtures.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from '@playwright/test'
+import { apiGet, pollUntil } from '../helpers'
+import { SMOKE_FIXTURES, slugify } from '../fixtures'
+
+/**
+ * Smoke spec: pre-seeded fixtures (written by global-setup before gmuxd
+ * starts) must be reachable at /v1/conversations/{kind}/{slug} once the
+ * bootstrap scan completes.
+ *
+ * Purpose: detect drift between the TS fixtures in `e2e/fixtures.ts`
+ * and the Go parsers in `packages/adapter/adapters/*.go`. If a parser
+ * grows a new required field and the TS fixture doesn't update, this
+ * spec fails first with a clear signal pointing at fixture validity,
+ * before the discovery spec's tests run.
+ *
+ * The tests assert via the public API only (no introspection). The
+ * polling timeout is generous because we only need the bootstrap scan
+ * to have completed once at startup; in practice it's done before the
+ * first test even runs.
+ */
+test.describe('conversation fixtures (bootstrap scan)', () => {
+  // Each smoke fixture rendered as one parameterized test, so a
+  // failure names the offending kind directly.
+  for (const fixture of SMOKE_FIXTURES) {
+    test(`${fixture.kind}: pre-seeded fixture reachable via API`, async () => {
+      const expectedSlug = slugify(fixture.title)
+      // Bootstrap is one-shot at daemon start, but we still poll: the
+      // first test in the run might race the daemon's `Scan()` call,
+      // and on slow CI the index population can lag startup by tens
+      // of milliseconds.
+      const result = await pollUntil(
+        async () => {
+          const { status, body } = await apiGet<{ data: { kind: string; title: string; cwd: string } }>(
+            `/v1/conversations/${fixture.kind}/${expectedSlug}`,
+          )
+          if (status !== 200) return null
+          return body.data
+        },
+        {
+          timeoutMs: 5_000,
+          description: `fixture ${fixture.kind}/${expectedSlug} reachable via API`,
+        },
+      )
+
+      expect(result.kind).toBe(fixture.kind)
+      expect(result.title).toBe(fixture.title)
+      expect(result.cwd).toBe(fixture.cwd)
+    })
+  }
+})

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -434,9 +434,18 @@ func serve(stderr io.Writer) int {
 
 	// Conversations index — maps (kind, slug) to file metadata for URL
 	// resolution of dead conversations and future fulltext search.
+	// One bootstrap scan at startup; from then on the index is kept
+	// fresh by filemon's fsnotify event handler (SetConvIndex below).
 	convIndex := conversations.New()
 	convIndex.Scan()
 	log.Printf("conversations: indexed %d files", convIndex.Count())
+
+	// Wire filemon to the conversations index and install always-on
+	// watches on every adapter session root. After this, every .jsonl
+	// Create/Write/Remove under any adapter root updates the index
+	// automatically, with no periodic scan involved.
+	fileMon.SetConvIndex(convIndex)
+	fileMon.WatchRoots()
 
 	// Start background update checker
 	updateChecker := update.New(version)
@@ -527,19 +536,12 @@ func serve(stderr io.Writer) int {
 	}
 	go scanner.Run(30*time.Second, stopScanner)
 
-	// Periodic rescan of conversations index so new files are picked up.
-	go func() {
-		ticker := time.NewTicker(30 * time.Second)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-stopScanner:
-				return
-			case <-ticker.C:
-				convIndex.Scan()
-			}
-		}
-	}()
+	// Conversations index updates are watcher-driven via filemon
+	// (see SetConvIndex + WatchRoots above). No periodic rescan: a
+	// healthy fsnotify watch tree plus the startup bootstrap scan
+	// covers steady state. If reports of staleness emerge after
+	// suspend or inotify queue overflow, add an explicit reconcile
+	// hook — don't reintroduce the periodic ticker.
 
 	// Auto-assign sessions to projects when they appear or get a Slug.
 	sessionEvents, unsubSessionEvents := sessions.Subscribe()

--- a/services/gmuxd/internal/conversations/index.go
+++ b/services/gmuxd/internal/conversations/index.go
@@ -269,6 +269,26 @@ func (idx *Index) Remove(kind, toolID string) bool {
 	return true
 }
 
+// RemoveByPath deletes any conversation whose FilePath matches path.
+// Used when filemon observes a deletion event and we don't have the
+// (kind, toolID) handy. Linear walk over the index; that's fine
+// because Remove events are rare (manual `rm`, file rotation) and
+// the index size stays in the hundreds-to-low-thousands range.
+// Returns true if an entry was removed.
+func (idx *Index) RemoveByPath(path string) bool {
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
+	for key, info := range idx.byKey {
+		if info.FilePath != path {
+			continue
+		}
+		delete(idx.byKey, key)
+		delete(idx.byToolID, toolKey(info.Kind, info.ToolID))
+		return true
+	}
+	return false
+}
+
 // SlugExists reports whether a slug is taken within a kind.
 func (idx *Index) SlugExists(kind, slug string) bool {
 	idx.mu.RLock()

--- a/services/gmuxd/internal/conversations/index_test.go
+++ b/services/gmuxd/internal/conversations/index_test.go
@@ -136,6 +136,41 @@ func TestRemove(t *testing.T) {
 	}
 }
 
+func TestRemoveByPath(t *testing.T) {
+	idx := New()
+	idx.Upsert(Info{ToolID: "a", Slug: "one", Kind: "pi", FilePath: "/x/a.jsonl"})
+	idx.Upsert(Info{ToolID: "b", Slug: "two", Kind: "pi", FilePath: "/x/b.jsonl"})
+	idx.Upsert(Info{ToolID: "c", Slug: "three", Kind: "claude", FilePath: "/y/c.jsonl"})
+
+	if !idx.RemoveByPath("/x/b.jsonl") {
+		t.Fatal("expected RemoveByPath to return true for indexed path")
+	}
+	if idx.Count() != 2 {
+		t.Errorf("expected count 2 after remove, got %d", idx.Count())
+	}
+	if _, ok := idx.Lookup("pi", "two"); ok {
+		t.Error("expected miss for removed slug")
+	}
+	// Sibling entries with same kind unaffected.
+	if _, ok := idx.Lookup("pi", "one"); !ok {
+		t.Error("sibling pi entry was incorrectly removed")
+	}
+	// Cross-kind unaffected.
+	if _, ok := idx.Lookup("claude", "three"); !ok {
+		t.Error("cross-kind entry was incorrectly removed")
+	}
+	// Reverse-lookup (byToolID) cleared too: Upserting the same toolID
+	// at a new slug should yield the new slug, not update-in-place at
+	// the old one.
+	slug := idx.Upsert(Info{ToolID: "b", Slug: "different", Kind: "pi", FilePath: "/x/b2.jsonl"})
+	if slug != "different" {
+		t.Errorf("expected fresh slug 'different' (byToolID was cleared), got %q", slug)
+	}
+	if idx.RemoveByPath("/x/nope.jsonl") {
+		t.Error("expected RemoveByPath to return false for unknown path")
+	}
+}
+
 func TestSlugExists(t *testing.T) {
 	idx := New()
 	idx.Upsert(Info{ToolID: "abc", Slug: "fix-auth", Kind: "pi"})

--- a/services/gmuxd/internal/discovery/filemon.go
+++ b/services/gmuxd/internal/discovery/filemon.go
@@ -132,6 +132,13 @@ func (fm *FileMonitor) SetConvIndex(ix *conversations.Index) {
 // fully covered. Idempotent and safe to call once at gmuxd startup
 // before Run begins.
 //
+// We mkdir any missing root because fsnotify can only watch existing
+// directories, and we want to detect when a user starts using an
+// adapter mid-session without forcing a daemon restart. Side effect:
+// gmuxd creates an empty `~/.pi/agent/sessions/` (etc.) for every
+// configured adapter, even ones the user has never used. Acceptable
+// in exchange for not requiring a restart on first use.
+//
 // New subdirectories created later are picked up by handleFSEvent's
 // Create handler, which adds a watch on any subdir created under an
 // already-watched dir.
@@ -139,10 +146,6 @@ func (fm *FileMonitor) WatchRoots() {
 	fm.mu.Lock()
 	defer fm.mu.Unlock()
 	for root := range fm.rootToAdapter {
-		// Create the root if it doesn't exist; otherwise we can't
-		// watch it, and a session of this kind starting later would
-		// also need to mkdir it. fsnotify can only watch existing
-		// dirs.
 		if _, err := os.Stat(root); os.IsNotExist(err) {
 			if err := os.MkdirAll(root, 0o755); err != nil {
 				log.Printf("filemon: mkdir %s: %v", root, err)

--- a/services/gmuxd/internal/discovery/filemon.go
+++ b/services/gmuxd/internal/discovery/filemon.go
@@ -26,6 +26,7 @@ package discovery
 import (
 	"context"
 	"io"
+	"io/fs"
 	"log"
 	"net"
 	"net/http"
@@ -38,6 +39,7 @@ import (
 	"github.com/fsnotify/fsnotify"
 	"github.com/gmuxapp/gmux/packages/adapter"
 	"github.com/gmuxapp/gmux/packages/adapter/adapters"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/conversations"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/store"
 )
 
@@ -46,6 +48,13 @@ type FileMonitor struct {
 	store   *store.Store
 	watcher *fsnotify.Watcher
 	poke    chan struct{} // non-blocking signal to retry attribution
+	index   *conversations.Index // optional; nil in unit tests
+
+	// rootToAdapter maps each adapter's SessionRootDir() to its adapter.
+	// Built once at construction from adapters.AllAdapters() so the
+	// always-on path → adapter resolver works without a live session of
+	// that kind. Read-only after NewFileMonitor returns.
+	rootToAdapter map[string]adapter.Adapter
 
 	mu             sync.Mutex
 	watchedDirs    map[string]bool              // all dirs currently watched (roots + session dirs)
@@ -84,10 +93,21 @@ func NewFileMonitorWithAttributions(s *store.Store, attrs map[string]string) *Fi
 	if attrs == nil {
 		attrs = make(map[string]string)
 	}
+	rootToAdapter := make(map[string]adapter.Adapter)
+	for _, a := range adapters.AllAdapters() {
+		sf, ok := a.(adapter.SessionFiler)
+		if !ok {
+			continue
+		}
+		if root := sf.SessionRootDir(); root != "" {
+			rootToAdapter[root] = a
+		}
+	}
 	return &FileMonitor{
 		store:          s,
 		watcher:        w,
 		poke:           make(chan struct{}, 1),
+		rootToAdapter:  rootToAdapter,
 		watchedDirs:    make(map[string]bool),
 		rootDirs:       make(map[string]bool),
 		sessions:       make(map[string]*monitoredSession),
@@ -95,6 +115,95 @@ func NewFileMonitorWithAttributions(s *store.Store, attrs map[string]string) *Fi
 		activeFiles:    make(map[string]string),
 		fileOffsets:    make(map[string]int64),
 		candidateFiles: make(map[string]bool),
+	}
+}
+
+// SetConvIndex wires the conversations index to receive ScanFile and
+// RemoveByPath calls on .jsonl events. Must be called before Run
+// starts; not safe to swap concurrently. Tests that don't exercise
+// the index can leave it unset (calls become no-ops).
+func (fm *FileMonitor) SetConvIndex(ix *conversations.Index) {
+	fm.index = ix
+}
+
+// WatchRoots installs always-on fsnotify watches for every adapter
+// SessionRootDir() and every existing subdirectory under it. Walks
+// the tree depth-first so codex's date-nested layout (YYYY/MM/DD) is
+// fully covered. Idempotent and safe to call once at gmuxd startup
+// before Run begins.
+//
+// New subdirectories created later are picked up by handleFSEvent's
+// Create handler, which adds a watch on any subdir created under an
+// already-watched dir.
+func (fm *FileMonitor) WatchRoots() {
+	fm.mu.Lock()
+	defer fm.mu.Unlock()
+	for root := range fm.rootToAdapter {
+		// Create the root if it doesn't exist; otherwise we can't
+		// watch it, and a session of this kind starting later would
+		// also need to mkdir it. fsnotify can only watch existing
+		// dirs.
+		if _, err := os.Stat(root); os.IsNotExist(err) {
+			if err := os.MkdirAll(root, 0o755); err != nil {
+				log.Printf("filemon: mkdir %s: %v", root, err)
+				continue
+			}
+		}
+		fm.ensureRootWatchLocked(root)
+		fm.watchTreeLocked(root)
+	}
+}
+
+// watchTreeLocked walks the directory tree under root and adds a
+// watch on every subdirectory. Errors on individual entries are
+// logged but don't abort the walk.
+func (fm *FileMonitor) watchTreeLocked(root string) {
+	filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil // skip unreadable entries
+		}
+		if !d.IsDir() {
+			return nil
+		}
+		if path == root {
+			return nil // already watched as root
+		}
+		fm.addWatchLocked(path)
+		return nil
+	})
+}
+
+// adapterForPath returns the adapter responsible for path by matching
+// its directory against known SessionRootDir prefixes. Returns nil if
+// no adapter claims the path.
+func (fm *FileMonitor) adapterForPath(path string) adapter.Adapter {
+	dir := filepath.Dir(path)
+	for root, a := range fm.rootToAdapter {
+		if isUnderRoot(dir, root) {
+			return a
+		}
+	}
+	return nil
+}
+
+// notifyConvIndex dispatches a .jsonl filesystem event to the
+// conversations index. No-op if the index isn't wired (test mode).
+func (fm *FileMonitor) notifyConvIndex(event fsnotify.Event) {
+	if fm.index == nil {
+		return
+	}
+	if !strings.HasSuffix(event.Name, ".jsonl") {
+		return
+	}
+	switch {
+	case event.Has(fsnotify.Remove), event.Has(fsnotify.Rename):
+		fm.index.RemoveByPath(event.Name)
+	case event.Has(fsnotify.Create), event.Has(fsnotify.Write):
+		a := fm.adapterForPath(event.Name)
+		if a == nil {
+			return
+		}
+		fm.index.ScanFile(a, event.Name)
 	}
 }
 
@@ -134,6 +243,11 @@ func (fm *FileMonitor) Run(stop <-chan struct{}) {
 			if !ok {
 				return
 			}
+			// Errors here are typically inotify queue overflow or
+			// transient EINTR. We log and continue; the index gets
+			// reconciled on the next gmuxd restart via the bootstrap
+			// scan. Add an explicit reconcile hook here if reports
+			// of staleness after overflow start coming in.
 			log.Printf("filemon: watcher error: %v", err)
 
 		case <-fm.poke:
@@ -159,11 +273,15 @@ func (fm *FileMonitor) handleFSEvent(event fsnotify.Event) {
 
 	if event.Has(fsnotify.Create) {
 		// A new entry was created. Could be:
-		// 1. A new session subdirectory in a root dir -> add watch
-		// 2. A new .jsonl file in a session dir -> handle as file change
+		// 1. A new subdirectory under any watched dir -> add watch +
+		//    catch up on .jsonl files that may already exist there.
+		//    We check watchedDirs (not just rootDirs) so codex's
+		//    YYYY/MM/DD nesting is supported: a new month dir under a
+		//    watched year dir gets its own watch.
+		// 2. A new .jsonl file in a watched dir -> handle as file change.
 		fm.mu.Lock()
 		dir := filepath.Dir(name)
-		if fm.rootDirs[dir] {
+		if fm.watchedDirs[dir] {
 			fm.handleNewSubdirLocked(name)
 		}
 		fm.mu.Unlock()
@@ -178,18 +296,50 @@ func (fm *FileMonitor) handleFSEvent(event fsnotify.Event) {
 			fm.handleFileChange(name)
 		}
 	}
+
+	// Conversations index stays in sync with disk for every .jsonl
+	// event, regardless of whether any session is alive. This is the
+	// path that replaces the old 30s periodic Scan.
+	fm.notifyConvIndex(event)
 }
 
-// handleNewSubdirLocked is called when a Create event fires inside a root dir.
-// Any new subdirectory is watched, because the tool may write session files
-// in directories other than SessionDir(cwd) (e.g., grove worktrees, /resume
-// from a different folder).
+// handleNewSubdirLocked is called when a Create event fires inside a
+// watched dir. Any new subdirectory is watched, and we catch up on
+// any .jsonl files that already landed in it before the watch took
+// effect (the `mkdir x && touch x/y.jsonl` race).
 func (fm *FileMonitor) handleNewSubdirLocked(path string) {
 	info, err := os.Stat(path)
 	if err != nil || !info.IsDir() {
 		return
 	}
 	fm.addWatchLocked(path)
+
+	// Catch-up scan: feed any pre-existing .jsonl files through the
+	// conversations index so we don't miss files that landed between
+	// the parent's Create event and our watch being established.
+	// Recursively, since a Create could deliver a deep subtree (e.g.
+	// codex's YYYY/MM/DD created in one mkdir -p call).
+	if fm.index == nil {
+		return
+	}
+	filepath.WalkDir(path, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() {
+			if p != path {
+				fm.addWatchLocked(p)
+			}
+			return nil
+		}
+		if !strings.HasSuffix(p, ".jsonl") {
+			return nil
+		}
+		if a := fm.adapterForPath(p); a != nil {
+			fm.index.ScanFile(a, p)
+		}
+		return nil
+	})
 }
 
 // NotifyNewSession registers a session for file monitoring.

--- a/services/gmuxd/internal/discovery/filemon.go
+++ b/services/gmuxd/internal/discovery/filemon.go
@@ -283,11 +283,20 @@ func (fm *FileMonitor) handleFSEvent(event fsnotify.Event) {
 		//    watched year dir gets its own watch.
 		// 2. A new .jsonl file in a watched dir -> handle as file change.
 		fm.mu.Lock()
+		var catchUp []indexWork
 		dir := filepath.Dir(name)
 		if fm.watchedDirs[dir] {
-			fm.handleNewSubdirLocked(name)
+			catchUp = fm.handleNewSubdirLocked(name)
 		}
 		fm.mu.Unlock()
+
+		// Run catch-up ScanFile calls outside fm.mu. The walk itself
+		// stays locked (it modifies watchedDirs), but the expensive
+		// part (per-file JSONL parse) shouldn't hold up other fm.mu
+		// users like NotifyNewSession during a large catch-up.
+		for _, w := range catchUp {
+			fm.index.ScanFile(w.adapter, w.path)
+		}
 
 		if strings.HasSuffix(name, ".jsonl") {
 			fm.handleFileChange(name)
@@ -306,25 +315,35 @@ func (fm *FileMonitor) handleFSEvent(event fsnotify.Event) {
 	fm.notifyConvIndex(event)
 }
 
+// indexWork is a deferred ScanFile call that handleNewSubdirLocked
+// returns to its caller. Decoupling collection (under fm.mu) from
+// parsing (after release) keeps a large catch-up from blocking other
+// fm.mu users like NotifyNewSession.
+type indexWork struct {
+	adapter adapter.Adapter
+	path    string
+}
+
 // handleNewSubdirLocked is called when a Create event fires inside a
-// watched dir. Any new subdirectory is watched, and we catch up on
-// any .jsonl files that already landed in it before the watch took
-// effect (the `mkdir x && touch x/y.jsonl` race).
-func (fm *FileMonitor) handleNewSubdirLocked(path string) {
+// watched dir. Any new subdirectory is watched, and any pre-existing
+// .jsonl files in it are returned as deferred ScanFile work for the
+// caller to run after releasing fm.mu.
+//
+// Catch-up exists to close the `mkdir x && touch x/y.jsonl` race
+// where a file lands in a fresh subdir between the dir's creation
+// and our watch taking effect. We recurse so a deep subtree created
+// by `mkdir -p YYYY/MM/DD` is fully covered.
+func (fm *FileMonitor) handleNewSubdirLocked(path string) []indexWork {
 	info, err := os.Stat(path)
 	if err != nil || !info.IsDir() {
-		return
+		return nil
 	}
 	fm.addWatchLocked(path)
 
-	// Catch-up scan: feed any pre-existing .jsonl files through the
-	// conversations index so we don't miss files that landed between
-	// the parent's Create event and our watch being established.
-	// Recursively, since a Create could deliver a deep subtree (e.g.
-	// codex's YYYY/MM/DD created in one mkdir -p call).
 	if fm.index == nil {
-		return
+		return nil
 	}
+	var work []indexWork
 	filepath.WalkDir(path, func(p string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return nil
@@ -339,10 +358,11 @@ func (fm *FileMonitor) handleNewSubdirLocked(path string) {
 			return nil
 		}
 		if a := fm.adapterForPath(p); a != nil {
-			fm.index.ScanFile(a, p)
+			work = append(work, indexWork{adapter: a, path: p})
 		}
 		return nil
 	})
+	return work
 }
 
 // NotifyNewSession registers a session for file monitoring.


### PR DESCRIPTION
## Why

User report: gmuxd 1.2.0 sits at ~90% CPU steady state with **zero alive sessions** and 32 session dirs. Tracked it down to `conversations.Index.Scan()` running every 30s and re-reading every adapter `.jsonl` file (pi files reach tens of MB). Once the corpus exceeds ~30s of parse work, the scan never finishes before the next tick, pinning a core indefinitely.

Previous attempt (#173) added a `(mtime, size)` cache. Closed in favor of removing the ticker entirely: with the watcher wired up, idle = zero events = zero CPU. The ticker was masking an architectural duplication where filemon already had fsnotify infrastructure but its wiring to the conversations index had been left dead (`Index.ScanFile` defined, never called).

## What

Five atomic commits:

1. **`test(e2e): add adapter session file helpers and smoke spec`** — `GMUX_TEST_HOME` export, `apiGet` / `pollUntil` / `writeFakeSession` helpers, three smoke tests pre-seeding fixtures so the bootstrap scan picks them up. Drift-detector for fixture-vs-parser compatibility.
2. **`feat(daemon): drop periodic conversations index scan in favor of watcher`** — always-on root watches, `rootToAdapter` map, `Index.ScanFile` wired to fsnotify Create/Write, `Index.RemoveByPath` (linear walk, no new map state) wired to Remove/Rename, catch-up scan in `handleNewSubdirLocked` to close the `mkdir+touch` race, recursive tree walk so codex's `YYYY/MM/DD` nesting is fully covered, 30s ticker deleted, six discovery tests.
3. **`docs(daemon): document watcher-only conversations index in agent-facing docs`** — `e2e/AGENTS.md` notes on the new helpers and specs, `RELEASE_HIGHLIGHTS.md` user-facing prose, comment polish in `filemon.go` calling out the `mkdir` side effect of `WatchRoots`, and `node:` import normalization in `e2e/fixtures.ts`.
4. **`test(e2e): use local time in codex fixture path`** — addresses Greptile review feedback. Codex fixture now uses local time to match Go's `codex.SessionDir` (`time.Now()`); functionally a no-op for tests (bootstrap walks the whole tree, watcher does too) but removes a misleading comment and stylistic divergence.
5. **`perf(daemon): release fm.mu before running catch-up ScanFile`** — addresses Greptile review feedback. `handleNewSubdirLocked` now collects deferred `indexWork` and the caller iterates `ScanFile` after releasing `fm.mu`. The walk still needs the lock (it modifies `watchedDirs`), but the per-file JSONL parse no longer blocks `NotifyNewSession` etc. during a deep catch-up.

## Verification

- `go test ./services/gmuxd/...` clean; `go vet ./...` clean.
- All 36 e2e tests pass (30 existing + 3 smoke + 6 discovery).
- **Regression-catch verified twice**: temporarily disabled `SetConvIndex` + `WatchRoots` on top of both the original rewrite (commit 2) and the post-feedback state (after commit 5). All 6 discovery tests fail in both cases (timeout exhaustion at 2s for tests 1-5, no event ever firing for test 6). Smoke tests still pass because they exercise the bootstrap path.
- Walked through every realistic concurrency scenario (bootstrap vs watcher, NotifyNewSession vs WatchRoots, mid-walk file creation in catch-up scan, codex date-rollover at midnight). Documented the side effect of `WatchRoots` creating empty adapter root directories at startup.

## Design decisions

| | |
|---|---|
| Freshness contract | Call `ScanFile` on every event, no throttle, no first-then-skip. Realistic per-event cost is bounded; idle is zero. |
| State discipline | One new field on `FileMonitor` (`rootToAdapter`, set once at construction). No `byPath` map: `RemoveByPath` does a linear walk over `byKey` (rare event, sub-ms even at 10K entries). |
| Recovery hooks | Skipped (Q_OVERFLOW reconcile, sleep-wake reconcile, `watcher_degraded` health field). Bootstrap scan on daemon restart is the documented recovery. Add later if reports emerge; logs already cover ENOSPC. |
| Lock discipline | Catch-up walks `watchedDirs` modifications under `fm.mu`, but defers per-file `ScanFile` to the caller post-unlock so a large catch-up doesn't block other acquirers. |
| Cross-platform | Linux is CI; macOS is dev-only. fsnotify behaves differently but the bootstrap scan covers both. Called out as a deferred risk. |

## Closes

- The user's 90% CPU report (idle daemon now does no periodic work).
- Incidentally: deleted-file leak in the index (Remove was never wired before; now is).