### PR TITLE
fix(cli): default TERM to xterm-256color and report real version to children

### DIFF
--- a/cli/gmux/cmd/gmux/run.go
+++ b/cli/gmux/cmd/gmux/run.go
@@ -120,6 +120,7 @@ func runSession(args []string, attach bool) {
 		SocketPath: sockPath,
 		Adapter:    a,
 		State:      state,
+		Version:    version,
 	}
 	// Always try to inherit terminal dimensions from the parent.
 	// Even non-interactive launches (background, piped) benefit from

--- a/cli/gmux/internal/ptyserver/ptyserver.go
+++ b/cli/gmux/internal/ptyserver/ptyserver.go
@@ -146,6 +146,9 @@ type Config struct {
 	Rows       uint16
 	Adapter    adapter.Adapter
 	State      *session.State
+	// Version is reported to children via TERM_PROGRAM_VERSION.
+	// Defaults to "dev" when empty.
+	Version    string
 	// LocalOut, if non-nil, receives a copy of every PTY output chunk
 	// from the moment the server starts reading. Set this at construction
 	// time (rather than calling SetLocalOutput after New) when you need
@@ -168,17 +171,7 @@ func New(cfg Config) (*Server, error) {
 
 	cmd := exec.Command(cfg.Command[0], cfg.Command[1:]...)
 	cmd.Dir = cfg.Cwd
-	cmd.Env = append(os.Environ(), cfg.Env...)
-	// Advertise terminal capabilities to child processes.
-	// Our frontend (xterm.js + image addon) supports kitty graphics, sixel, and iTerm2 images.
-	// Set KITTY_WINDOW_ID so programs that check for kitty graphics support (e.g. pi, viu)
-	// will use it. This is legitimate — our terminal genuinely handles the kitty protocol.
-	cmd.Env = append(cmd.Env,
-		"TERM_PROGRAM=gmux",
-		"TERM_PROGRAM_VERSION=0.1.0",
-		"COLORTERM=truecolor",
-		"KITTY_WINDOW_ID=1",
-	)
+	cmd.Env = buildChildEnv(os.Environ(), cfg.Env, cfg.Version)
 
 	// Start command in a new PTY
 	ptmx, err := pty.StartWithSize(cmd, &pty.Winsize{
@@ -984,4 +977,53 @@ func (s *Server) waitChild() {
 		c.conn.Close(websocket.StatusNormalClosure, "process exited")
 	}
 	s.mu.Unlock()
+}
+
+// buildChildEnv composes the environment passed to PTY children.
+//
+// Layering, in order:
+//  1. parent (typically os.Environ()) — inherits the daemon/user env;
+//  2. caller-supplied extras (cfg.Env from the adapter / runner);
+//  3. terminal capability advertisements that always win, because the
+//     frontend's actual capabilities don't depend on what the parent
+//     thinks: TERM_PROGRAM=gmux, TERM_PROGRAM_VERSION=<version>,
+//     COLORTERM=truecolor, KITTY_WINDOW_ID=1 (xterm.js + image addon
+//     handles kitty graphics, sixel, and iTerm2 images);
+//  4. TERM=xterm-256color, but only if no earlier layer provided one.
+//     When gmuxd is launched from a non-interactive context (systemd
+//     unit, browser-launched shell inheriting the daemon's env) TERM
+//     may be missing, which makes curses programs like lazygit abort
+//     with "terminal entry not found: term not set". Defaulting matches
+//     what the xterm.js frontend actually renders.
+//
+// version falls back to "dev" when empty so TERM_PROGRAM_VERSION is
+// never a bare "=".
+func buildChildEnv(parent, extra []string, version string) []string {
+	if version == "" {
+		version = "dev"
+	}
+	env := make([]string, 0, len(parent)+len(extra)+5)
+	env = append(env, parent...)
+	env = append(env, extra...)
+	env = append(env,
+		"TERM_PROGRAM=gmux",
+		"TERM_PROGRAM_VERSION="+version,
+		"COLORTERM=truecolor",
+		"KITTY_WINDOW_ID=1",
+	)
+	if !hasEnv(env, "TERM") {
+		env = append(env, "TERM=xterm-256color")
+	}
+	return env
+}
+
+// hasEnv reports whether env contains a NAME=... entry for the given name.
+func hasEnv(env []string, name string) bool {
+	prefix := name + "="
+	for _, e := range env {
+		if strings.HasPrefix(e, prefix) {
+			return true
+		}
+	}
+	return false
 }

--- a/cli/gmux/internal/ptyserver/ptyserver_test.go
+++ b/cli/gmux/internal/ptyserver/ptyserver_test.go
@@ -1269,3 +1269,130 @@ func TestPTYDoneClosesAfterFinalFlush(t *testing.T) {
 		t.Errorf("expected LocalOut to contain 'END-OF-OUTPUT' by the time PTYDone closes, got %q", out.String())
 	}
 }
+
+// envValue returns the last value for name in env, or "" if not set.
+// Mirrors POSIX semantics where later entries shadow earlier ones.
+func envValue(env []string, name string) string {
+	prefix := name + "="
+	val := ""
+	for _, e := range env {
+		if strings.HasPrefix(e, prefix) {
+			val = e[len(prefix):]
+		}
+	}
+	return val
+}
+
+// When the parent has no TERM (e.g. gmuxd launched by systemd, then
+// forking a shell into a session) curses programs like lazygit abort
+// with "terminal entry not found: term not set". buildChildEnv must
+// default TERM=xterm-256color so children always have a usable
+// terminfo entry.
+func TestBuildChildEnv_DefaultsTermWhenAbsent(t *testing.T) {
+	parent := []string{"PATH=/usr/bin", "HOME=/home/test"}
+	env := buildChildEnv(parent, nil, "1.2.3")
+
+	if got := envValue(env, "TERM"); got != "xterm-256color" {
+		t.Errorf("TERM = %q, want xterm-256color", got)
+	}
+}
+
+// An existing TERM in the parent must win: we never clobber a real
+// terminal's terminfo entry.
+func TestBuildChildEnv_PreservesParentTerm(t *testing.T) {
+	parent := []string{"TERM=screen-256color"}
+	env := buildChildEnv(parent, nil, "1.2.3")
+
+	if got := envValue(env, "TERM"); got != "screen-256color" {
+		t.Errorf("TERM = %q, want parent value screen-256color", got)
+	}
+}
+
+// Caller-supplied env (e.g. an adapter) can override a parent TERM
+// without ptyserver layering one on top.
+func TestBuildChildEnv_ExtraOverridesParentTerm(t *testing.T) {
+	parent := []string{"TERM=screen-256color"}
+	extra := []string{"TERM=tmux-256color"}
+	env := buildChildEnv(parent, extra, "1.2.3")
+
+	if got := envValue(env, "TERM"); got != "tmux-256color" {
+		t.Errorf("TERM = %q, want extra value tmux-256color", got)
+	}
+}
+
+// Terminal capability advertisements always win over the parent: the
+// frontend's actual capabilities don't depend on what the parent
+// thinks. fastfetch reads TERM_PROGRAM/TERM_PROGRAM_VERSION, so the
+// version must reflect the real build, not whatever the parent had.
+func TestBuildChildEnv_AdvertisesTerminalCapabilities(t *testing.T) {
+	parent := []string{
+		"TERM_PROGRAM=iTerm.app",
+		"TERM_PROGRAM_VERSION=3.4.0",
+		"COLORTERM=",
+	}
+	env := buildChildEnv(parent, nil, "1.2.3")
+
+	if got := envValue(env, "TERM_PROGRAM"); got != "gmux" {
+		t.Errorf("TERM_PROGRAM = %q, want gmux", got)
+	}
+	if got := envValue(env, "TERM_PROGRAM_VERSION"); got != "1.2.3" {
+		t.Errorf("TERM_PROGRAM_VERSION = %q, want 1.2.3", got)
+	}
+	if got := envValue(env, "COLORTERM"); got != "truecolor" {
+		t.Errorf("COLORTERM = %q, want truecolor", got)
+	}
+	if got := envValue(env, "KITTY_WINDOW_ID"); got != "1" {
+		t.Errorf("KITTY_WINDOW_ID = %q, want 1", got)
+	}
+}
+
+// An empty version (e.g. someone forgot to wire the ldflag) must not
+// produce a bare "TERM_PROGRAM_VERSION=" — fall back to "dev" so
+// downstream parsers always see a non-empty value.
+func TestBuildChildEnv_EmptyVersionFallsBackToDev(t *testing.T) {
+	env := buildChildEnv(nil, nil, "")
+
+	if got := envValue(env, "TERM_PROGRAM_VERSION"); got != "dev" {
+		t.Errorf("TERM_PROGRAM_VERSION = %q, want dev", got)
+	}
+}
+
+// End-to-end check that buildChildEnv's output actually reaches a
+// spawned child through cmd.Env. The unit tests above cover composition
+// rules; this guards against regressions in how New wires the env into
+// exec.Command.
+func TestNewSpawnsChildWithComposedEnv(t *testing.T) {
+	// t.Setenv registers cleanup to restore the original TERM after the
+	// test; we then Unsetenv so os.Environ() truly lacks a TERM entry
+	// (TERM="" would still prefix-match buildChildEnv's hasEnv check).
+	t.Setenv("TERM", "")
+	if err := os.Unsetenv("TERM"); err != nil {
+		t.Fatalf("unset TERM: %v", err)
+	}
+	sockPath := filepath.Join(t.TempDir(), "test.sock")
+	var out syncBuffer
+
+	srv, err := New(Config{
+		Command:    []string{"sh", "-c", `printf "TERM=%s|TPV=%s|TP=%s\n" "$TERM" "$TERM_PROGRAM_VERSION" "$TERM_PROGRAM"`},
+		Cwd:        "/tmp",
+		SocketPath: sockPath,
+		LocalOut:   &out,
+		Version:    "9.9.9-test",
+	})
+	if err != nil {
+		t.Fatalf("new server: %v", err)
+	}
+	defer srv.Shutdown()
+
+	select {
+	case <-srv.Done():
+	case <-time.After(3 * time.Second):
+		t.Fatal("child did not exit")
+	}
+	<-srv.PTYDone()
+
+	want := "TERM=xterm-256color|TPV=9.9.9-test|TP=gmux"
+	if !strings.Contains(out.String(), want) {
+		t.Errorf("child env: want substring %q, got: %q", want, out.String())
+	}
+}


### PR DESCRIPTION
Fixes #154.

## Problem

Inside a gmux shell:
```
$ lazygit
terminal entry not found: term not set
```

The daemon (or any non-interactive parent of `gmux run`, e.g. a systemd unit) may have no `TERM` set in its environment. `ptyserver` was building the child env from `os.Environ() + cfg.Env` and passing the empty `TERM` straight through to the shell, breaking every curses-based program.

`gmux lazygit` worked because that path comes from an interactive terminal that already has `TERM`.

## Fix

`ptyserver` now defaults `TERM=xterm-256color` when the resolved env has none, matching what the xterm.js frontend actually renders. Existing `TERM` values, from either the parent or a caller-supplied extra, still win.

## Bonus: real version in `TERM_PROGRAM_VERSION`

`TERM_PROGRAM_VERSION` was hardcoded to `0.1.0`, which is what fastfetch picked up and reported as `Terminal: gmux 0.1.0` regardless of the actual build. `Config` now takes a `Version`, plumbed from `cmd/gmux/main.go`'s ldflags-set `version`, so the value tracks real releases. Empty `Version` falls back to `dev`, matching the binary's own default.

## Refactor

Env composition is extracted to a pure `buildChildEnv(parent, extra, version)` helper. Documented layering (parent → extra → terminal capability advertisements → TERM default) makes precedence obvious, and the logic is now testable without spawning processes.

## Tests

Five fast unit tests on `buildChildEnv` covering: TERM default when absent, parent TERM preserved, extra overrides parent TERM, terminal capability advertisements always win over the parent, empty version falls back to `dev`. Plus one end-to-end test that spawns a child and confirms the composed env actually reaches it through `exec.Command`.