### PR TITLE
fix(web): bake real version into frontend during release builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,7 +2,13 @@ version: 2
 
 before:
   hooks:
-    - bash -c 'cd apps/gmux-web && npx vite build'
+    # VERSION must be passed explicitly: vite reads it from process.env
+    # at build time and bakes it into the bundle as __GMUX_VERSION__.
+    # Without this the frontend always reports 'dev' even on tagged
+    # releases, while gmuxd reports the real version, which makes the
+    # home page footer permanently show "Frontend vdev / reload to
+    # update" because the two never match.
+    - bash -c 'cd apps/gmux-web && VERSION={{ .Version }} npx vite build'
     - bash -c 'rm -rf services/gmuxd/cmd/gmuxd/web/assets services/gmuxd/cmd/gmuxd/web/favicon.svg services/gmuxd/cmd/gmuxd/web/manifest.json && cp -r apps/gmux-web/dist/* services/gmuxd/cmd/gmuxd/web/'
 
 builds:

--- a/apps/gmux-web/vite.config.ts
+++ b/apps/gmux-web/vite.config.ts
@@ -6,6 +6,13 @@ const gmuxdPort = process.env.VITE_DEV_PROXY_PORT || '8790'
 export default defineConfig({
   plugins: [preact()],
   define: {
+    // Baked into the bundle as a literal at build time. Read by
+    // home.tsx to render the footer and to compare against the daemon's
+    // /v1/health version: a mismatch surfaces the "reload to update"
+    // prompt. Release builds MUST pass VERSION (see .goreleaser.yml's
+    // before-hook); without it both backend and frontend default to
+    // 'dev', which is fine for local dev but would silently break the
+    // version-mismatch UX on releases.
     __GMUX_VERSION__: JSON.stringify(process.env.VERSION || 'dev'),
   },
   server: {


### PR DESCRIPTION
## Problem

The home page footer permanently shows:

> Frontend vdev
> reload to update

…even on tagged releases, no matter how many times you reload.

## Root cause

`apps/gmux-web/src/home.tsx` decides whether to show the prompt with `healthVal.version !== __GMUX_VERSION__`. The two values come from independent build steps:

- `healthVal.version`: served by `gmuxd /v1/health`, sourced from `main.version` set via `-X main.version={{ .Version }}` at link time. Tracks the real release tag.
- `__GMUX_VERSION__`: baked into the JS bundle at vite build time from `process.env.VERSION || 'dev'` in `apps/gmux-web/vite.config.ts`.

In `.goreleaser.yml` the `before.hooks` step ran:

```yaml
- bash -c 'cd apps/gmux-web && npx vite build'
```

with no `VERSION` in its environment. Goreleaser only template-substitutes `{{ .Version }}` inside its own templated fields like `ldflags`; it doesn't inject the version into hook commands automatically and doesn't expose it as an env var. So vite always fell back to `'dev'`.

Result: every release shipped a frontend stamped `dev` while the daemon reported the real version. The mismatch check fired forever; no amount of reloading could clear it.

## Fix

Pass `VERSION` explicitly to the vite hook via goreleaser template substitution:

```yaml
- bash -c 'cd apps/gmux-web && VERSION={{ .Version }} npx vite build'
```

Verified locally: with `VERSION=9.9.9-test npx vite build`, the literal `9.9.9-test` appears at the two `home.tsx` references inside `dist/assets/index-*.js`. Without `VERSION`, the same locations contain `"dev"`.

## Other build paths (no change needed)

- **`scripts/install.sh` / `scripts/build.sh`** already work: when invoked without `VERSION`, both backend and frontend default to `'dev'` and match (no banner). When invoked as `VERSION=x.y.z ./scripts/install.sh`, the env propagates from the parent shell to both vite and the go ldflags equally.
- **`.github/workflows/pr-build.yml`** uses `goreleaser release --snapshot --clean`, which goes through the same `before.hooks` and now picks up the snapshot version.
- **Local `vite` dev server** (`scripts/dev-server.sh`): no `VERSION`, both default to `'dev'`, match.

## Documentation

Added a comment in `vite.config.ts` next to the `__GMUX_VERSION__` define so future maintainers know:
1. that this literal feeds the home page's version-mismatch UX, and
2. that release builds must pass `VERSION` (with a pointer to `.goreleaser.yml`).

Also added a `# VERSION must be passed explicitly…` block comment in `.goreleaser.yml` explaining why the env var is required.

## Why no automated test

The bug is a one-line config plumbing issue. A CI assertion (e.g. grep the snapshot bundle for the version string) would be disproportionate guardrail for a config file that's rarely touched. The two cross-referencing comments document the contract clearly enough; a future change that breaks it would surface immediately as the same observable banner on the home page.