### PR TITLE
feat(release): polish discord announcements and hide release-scoped commits from changelog

### DIFF
--- a/.github/workflows/scripts/notify-discord.sh
+++ b/.github/workflows/scripts/notify-discord.sh
@@ -28,9 +28,23 @@ fi
 # RELEASE_NOTES.md has the highlights prose above a `<!-- highlights-end -->`
 # marker, then the generated bullet list. The marker is invisible in
 # rendered markdown; we stop reading at it.
-summary=$(sed '/<!-- highlights-end -->/,$d' RELEASE_NOTES.md)
-# Trim trailing blank lines.
-summary=$(echo "$summary" | sed -e :a -e '/^\n*$/{$d;N;ba}')
+#
+# When the prose is empty (a release without curated highlights), fall
+# back to the bullet list below the marker so Discord still sees what
+# changed. An empty announcement with only a changelog link is worse
+# than a slightly verbose one: most subscribers just want to know if
+# there's anything they care about without having to click through.
+# Strip leading and trailing blank lines so the rendered message
+# doesn't get extra vertical whitespace from sloppy input or from
+# the blank line that sits right after the highlights-end marker.
+trim_blank() { sed -e :a -e '/^\n*$/{$d;N;ba}'; }
+
+summary=$(sed '/<!-- highlights-end -->/,$d' RELEASE_NOTES.md | trim_blank)
+if [[ -z "${summary//[[:space:]]/}" ]]; then
+  # Skip the marker line itself; everything after it is the auto-generated
+  # bullet list (### Features, ### Fixes, etc.).
+  summary=$(sed -n '/<!-- highlights-end -->/,$p' RELEASE_NOTES.md | tail -n +2 | trim_blank)
+fi
 
 # ── Determine bump type ──
 

--- a/.github/workflows/scripts/notify-discord.sh
+++ b/.github/workflows/scripts/notify-discord.sh
@@ -37,13 +37,13 @@ fi
 # Strip leading and trailing blank lines so the rendered message
 # doesn't get extra vertical whitespace from sloppy input or from
 # the blank line that sits right after the highlights-end marker.
-trim_blank() { sed -e :a -e '/^\n*$/{$d;N;ba}'; }
+trim_blanks() { sed -e '/./,$!d' -e :a -e '/^\n*$/{$d;N;ba}'; }
 
-summary=$(sed '/<!-- highlights-end -->/,$d' RELEASE_NOTES.md | trim_blank)
+summary=$(sed '/<!-- highlights-end -->/,$d' RELEASE_NOTES.md | trim_blanks)
 if [[ -z "${summary//[[:space:]]/}" ]]; then
   # Skip the marker line itself; everything after it is the auto-generated
   # bullet list (### Features, ### Fixes, etc.).
-  summary=$(sed -n '/<!-- highlights-end -->/,$p' RELEASE_NOTES.md | tail -n +2 | trim_blank)
+  summary=$(sed -n '/<!-- highlights-end -->/,$p' RELEASE_NOTES.md | tail -n +2 | trim_blanks)
 fi
 
 # ── Determine bump type ──

--- a/.github/workflows/scripts/notify_discord_test.sh
+++ b/.github/workflows/scripts/notify_discord_test.sh
@@ -53,6 +53,12 @@ assert_contains() {
   fi
 }
 
+assert_not_contains() {
+  if [[ "$3" != *"$2"* ]]; then echo "  ✓ $1"; bump_score pass
+  else echo "  ✗ $1"; echo "    expected NOT to contain: $2"; bump_score fail
+  fi
+}
+
 # Lay out a scratch repo with two tags so notify-discord.sh's
 # `git describe --tags --abbrev=0 "${VERSION}^"` finds the predecessor.
 make_repo() {
@@ -143,6 +149,54 @@ echo "Embed suppression:"
 
   flags=$(run_notify "$tmp" v1.5.4 | jq -r '.flags')
   assert_eq "flags=4" "4" "$flags"
+)
+
+# ── Test: empty highlights fall back to the bullet list ──
+#
+# A patch release with no curated prose should still tell Discord
+# subscribers what changed. Sending only the changelog link forces
+# every subscriber to click through to find out if the release is
+# relevant; echoing the auto-generated bullets answers that inline.
+
+echo ""
+echo "Empty highlights falls back to bullets:"
+(
+  tmp=$(mktemp -d); trap 'rm -rf "$tmp"' EXIT
+  make_repo "$tmp" v1.5.3 v1.5.4
+
+  # No prose above the marker; bullet list below.
+  cat > "$tmp/RELEASE_NOTES.md" <<'EOF'
+<!-- highlights-end -->
+
+### Fixes
+- **(daemon)** stop leaking goroutines on shutdown ([#42](https://example/42))
+EOF
+
+  content=$(run_notify "$tmp" v1.5.4 | jq -r '.content')
+  assert_contains "bullet text reaches Discord"  "stop leaking goroutines" "$content"
+  assert_contains "changelog link still present" "gmux.app/changelog"      "$content"
+)
+
+# When highlights ARE present, the bullet list must NOT also be
+# included; otherwise we'd double up (curated prose + raw bullets).
+echo ""
+echo "Highlights present suppresses bullet fallback:"
+(
+  tmp=$(mktemp -d); trap 'rm -rf "$tmp"' EXIT
+  make_repo "$tmp" v1.5.3 v1.5.4
+
+  cat > "$tmp/RELEASE_NOTES.md" <<'EOF'
+Hand-written highlight paragraph.
+
+<!-- highlights-end -->
+
+### Fixes
+- **(daemon)** stop leaking goroutines on shutdown ([#42](https://example/42))
+EOF
+
+  content=$(run_notify "$tmp" v1.5.4 | jq -r '.content')
+  assert_contains     "highlights reach Discord"       "Hand-written highlight"  "$content"
+  assert_not_contains "bullets do not duplicate prose" "stop leaking goroutines" "$content"
 )
 
 # ── Test: long summaries truncate at a paragraph break, not in the middle ──

--- a/.github/workflows/scripts/notify_discord_test.sh
+++ b/.github/workflows/scripts/notify_discord_test.sh
@@ -173,8 +173,12 @@ echo "Empty highlights falls back to bullets:"
 EOF
 
   content=$(run_notify "$tmp" v1.5.4 | jq -r '.content')
-  assert_contains "bullet text reaches Discord"  "stop leaking goroutines" "$content"
-  assert_contains "changelog link still present" "gmux.app/changelog"      "$content"
+  assert_contains     "bullet text reaches Discord"  "stop leaking goroutines" "$content"
+  assert_contains     "changelog link still present" "gmux.app/changelog"      "$content"
+  # The blank line that sits right after `<!-- highlights-end -->` in
+  # RELEASE_NOTES.md must not propagate to Discord, where it would render
+  # as a double-spaced gap between the version heading and the bullets.
+  assert_not_contains "no triple-newline gap"        $'\n\n\n'             "$content"
 )
 
 # When highlights ARE present, the bullet list must NOT also be

--- a/.github/workflows/scripts/version_test.sh
+++ b/.github/workflows/scripts/version_test.sh
@@ -202,6 +202,63 @@ done
   assert_eq "feat among fixes wins minor bump" "v1.1.0" "$actual"
 )
 
+# ── Test: `(release)`-scoped commits are hidden from the changelog ──
+#
+# Anything in the `(release)` scope is internal release-flow plumbing
+# (workflow tweaks, notify-discord polish, cliff.toml itself) and
+# doesn't belong in user-facing release notes. cliff.toml's parser
+# skips them; this test pins both halves of that contract:
+#
+#   - skipped from the changelog when mixed with user-visible commits
+#   - don't count as releasable on their own (no-op release)
+#   - but breaking variants (`!:`) still surface, since users do need
+#     to know about breaking changes to the maintainer-facing flow
+
+echo ""
+echo "(release)-scoped commits skipped from changelog:"
+(
+  tmp=$(mktemp -d); trap 'rm -rf "$tmp"' EXIT
+  make_repo "$tmp"; cd "$tmp"
+  commit "feat: real user feature (#1)"
+  commit "feat(release): internal plumbing (#2)"
+  commit "fix(release): more plumbing (#3)"
+
+  run_script "$tmp" >/dev/null
+  changelog=$(cat apps/website/src/content/docs/changelog.mdx)
+
+  assert_contains     "user-visible feat present" "real user feature" "$changelog"
+  assert_not_contains "feat(release) hidden"      "internal plumbing" "$changelog"
+  assert_not_contains "fix(release) hidden"       "more plumbing"     "$changelog"
+)
+
+echo ""
+echo "(release)-only history is a no-op release:"
+(
+  tmp=$(mktemp -d); trap 'rm -rf "$tmp"' EXIT
+  make_repo "$tmp"; cd "$tmp"
+  commit "feat(release): plumbing only (#1)"
+  commit "fix(release): more plumbing (#2)"
+
+  output=$(run_script "$tmp")
+  assert_contains "exits with 'no releasable commits'" "No releasable commits" "$output"
+)
+
+echo ""
+echo "breaking (release) commit still surfaces:"
+(
+  tmp=$(mktemp -d); trap 'rm -rf "$tmp"' EXIT
+  make_repo "$tmp"; cd "$tmp"
+  commit "feat(release)!: rename WEBHOOK_URL env var (#1)"
+
+  version=$(run_script "$tmp" --dry-run | head -1)
+  assert_eq "breaking release commit bumps major" "v2.0.0" "$version"
+
+  run_script "$tmp" >/dev/null
+  changelog=$(cat apps/website/src/content/docs/changelog.mdx)
+  assert_contains "breaking release commit in Breaking section" "### Breaking"      "$changelog"
+  assert_contains "breaking release commit body present"        "rename WEBHOOK_URL" "$changelog"
+)
+
 # ── Test: cliff.toml smoke test (every expected group heading appears) ──
 #
 # Pin that cliff.toml still routes the four commit types we care about

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,12 @@ messages directly. Rules that follow from this:
   `daemon`, `cli`, `adapter`, `peering`, `devcontainer`, `docs`.
   Example: `feat(peering): reconnect after system sleep`. Scopes show
   up as bold tags in the changelog: `- **(peering)** reconnect after
-  system sleep`.
+  system sleep`. The `release` scope is reserved for release-flow
+  plumbing (workflows, notify-discord, cliff.toml itself) and is
+  hidden from the changelog and bump computation: those changes
+  affect maintainers, not users. Breaking release-scope changes
+  (`feat(release)!:`) still surface so consumers of the release
+  pipeline know to act.
 - **Write commit messages as user-facing changelog bullets.** The text
   after `type: ` becomes the bullet verbatim. Lowercase, no trailing
   period, imperative mood. Good: `fix: prevent recursive config fetch

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,10 @@ messages directly. Rules that follow from this:
   the open `release/next` branch up until merge. The content is
   injected into the changelog section between the version heading and
   the grouped bullet lists. The release workflow clears it
-  automatically after a successful release.
+  automatically after a successful release. Leave it empty for
+  patch-only releases that don't need curated prose; the Discord
+  announcement falls back to the auto-generated bullet list so
+  subscribers can still see what changed without clicking through.
 
   To tweak prose on an already-open release PR: check out
   `release/next`, edit `RELEASE_HIGHLIGHTS.md`, run

--- a/cliff.toml
+++ b/cliff.toml
@@ -70,12 +70,25 @@ commit_preprocessors = [
 # Assign commits to changelog groups. The `<!-- N -->` HTML comments
 # control sort order; striptags removes them before display.
 commit_parsers = [
-  # Breaking changes first, regardless of type. The `!:` variant is
-  # caught by the subject-line regex, the footer form is caught by the
-  # `footer =` rule (git-cliff strips the footer from the body and
-  # exposes it separately, so matching on `body =` would miss it).
+  # Breaking changes first, regardless of type or scope. The `!:`
+  # variant is caught by the subject-line regex, the footer form is
+  # caught by the `footer =` rule (git-cliff strips the footer from
+  # the body and exposes it separately, so matching on `body =`
+  # would miss it). This rule runs before the release-scope skip
+  # below so a hypothetical breaking change to the release flow
+  # still surfaces under the Breaking heading rather than being
+  # silently hidden, even though `protect_breaking_commits` would
+  # also force it through.
   { message = '^[a-z]+(\([^)]+\))?!: ', group = "<!-- 0 -->Breaking" },
   { footer = "^BREAKING[ -]CHANGE",      group = "<!-- 0 -->Breaking" },
+
+  # `(release)`-scoped commits are internal release-flow plumbing
+  # (workflow tweaks, notify-discord polish, cliff.toml itself).
+  # They don't change anything users of gmux see, so they're hidden
+  # from the changelog and don't count toward the bump. Note: in
+  # git-cliff, `scope = "x"` in a parser SETS the scope; matching on
+  # the parsed scope requires the explicit `field`/`pattern` form.
+  { field = "scope", pattern = "^release$", skip = true },
 
   # Security fixes get their own section so they stand out.
   { message = "^security",                group = "<!-- 1 -->Security" },


### PR DESCRIPTION
Three related polish changes to release announcements and the changelog.

## 1. Fall back to the bullet list when highlights are empty

When `RELEASE_HIGHLIGHTS.md` is left empty for a release (the
"patch-only releases don't need prose" path the doc encourages),
`notify-discord.sh` previously sent a Discord post with just a header
and the changelog link. Subscribers had no way to tell what changed
without clicking through.

Now: if the prose above `<!-- highlights-end -->` is empty/whitespace,
fall back to the auto-generated bullet list below the marker. When
prose IS present, the bullets are still suppressed (the curated
paragraph is the canonical summary, and we don't want to double up).

## 2. Trim blank lines on both ends of the summary

The blank line that sits right after the `<!-- highlights-end -->`
marker in `RELEASE_NOTES.md` propagated into the Discord post,
rendering as a double-spaced gap between the version heading and the
bullets. Same risk for highlights files that start with a blank line.
The summary is now stripped of leading and trailing blank lines
before being composed into the message.

## 3. Hide `(release)`-scoped commits from the changelog

Anything in the `(release)` scope is internal release-flow plumbing
(workflows, `notify-discord.sh`, `cliff.toml` itself). Those changes
affect maintainers, not users, so they don't belong in user-facing
release notes and shouldn't trigger a bump on their own.

Implemented as a `cliff.toml` parser rule that skips on
`field = "scope", pattern = "^release$"`. It's placed AFTER the
breaking-change rules so a hypothetical `feat(release)!:` (e.g. an
env-var rename in `notify-discord.sh`) still surfaces under the
Breaking heading. Note: in git-cliff, `scope = "x"` in a parser SETS
the commit's scope; matching the parsed scope requires the explicit
`field`/`pattern` form. The rule is reflexive — this PR's own
commits would be skipped from the next changelog under the new rule.

## Tests

`version_test.sh` (35 passing, +7):

- **Skipped from changelog**: a `feat:` plus `feat(release):` and
  `fix(release):` history. Asserts the user-visible feat is in the
  changelog, the two release-scoped commits are not.
- **No-op release**: a release-scope-only history exits with "No
  releasable commits" and doesn't bump.
- **Breaking still surfaces**: a `feat(release)!:` commit bumps to
  major and lands in the `### Breaking` section.

Mutation-tested: removing the cliff.toml rule causes 3 of those
assertions to fail.

`notify_discord_test.sh` (13 passing, +5):

- **Empty highlights → bullets**: with no prose, asserts bullet text
  reaches Discord and the changelog link survives.
- **No triple-newline gap**: asserts the rendered content has no
  three-consecutive-newlines, pinning the both-ends trim.
- **Highlights present → bullets suppressed**: with prose, asserts
  the bullet body is NOT in the Discord content (no double-up).

## Docs

`AGENTS.md` now mentions the empty-highlights fallback and the
`(release)` scope convention so authors know the conventions for
both.
