### PR TITLE
feat(cli): print session id for --no-attach with deterministic handshake

### DIFF
--- a/cli/gmux/cmd/gmux/daemon.go
+++ b/cli/gmux/cmd/gmux/daemon.go
@@ -143,7 +143,12 @@ func gmuxdHealthy(timeout time.Duration) bool {
 	return resp.StatusCode == http.StatusOK
 }
 
-func registerWithGmuxd(sessionID, socketPath string) {
+// registerWithGmuxd posts the session's registration to gmuxd and
+// returns true once gmuxd accepts it. Retries a handful of times to
+// cover the case where gmuxd is still starting up. Returns false if
+// every attempt fails: callers that care about registration outcome
+// (e.g. the --no-attach handshake) treat false as "give up".
+func registerWithGmuxd(sessionID, socketPath string) bool {
 	baseURL := gmuxdBaseURL()
 
 	payload, _ := json.Marshal(map[string]string{
@@ -163,9 +168,10 @@ func registerWithGmuxd(sessionID, socketPath string) {
 		}
 		resp.Body.Close()
 		if resp.StatusCode == 200 {
-			return
+			return true
 		}
 	}
+	return false
 }
 
 func deregisterFromGmuxd(sessionID string) {

--- a/cli/gmux/cmd/gmux/handshake.go
+++ b/cli/gmux/cmd/gmux/handshake.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Handshake protocol used by spawnDetached's --no-attach path so the
+// parent process can return a deterministic session id to its caller
+// (typically a script doing id=$(gmux --no-attach foo)) without
+// polling /v1/sessions or guessing.
+//
+// Wire:
+//   - Parent: os.Pipe(); attach write end as cmd.ExtraFiles[0] so the
+//     child sees it as fd 3; set GMUX_HANDSHAKE_FD=3 in the child env;
+//     cmd.Start; close parent's copy of the write end; readHandshake
+//     on the read end with a 5s deadline.
+//   - Child: after registerWithGmuxd, call handshakeAck. On registered
+//     success it writes "<session-id>\n" to fd 3 and closes the fd;
+//     on registered failure it closes without writing — the parent
+//     sees EOF with zero bytes and surfaces a clean error.
+//
+// Failure modes the parent disambiguates:
+//   - io.EOF                     → child exited before acking
+//   - os.ErrDeadlineExceeded     → child wedged between register and ack
+//   - "empty session id…"        → child wrote only whitespace
+//
+// After dispatching the ack, handshakeAck unsets GMUX_HANDSHAKE_FD so
+// the (now-closed) fd doesn't get re-interpreted by any nested fork
+// the runner spawns later (the user's command, or a `gmux` invoked
+// from within it).
+const handshakeFDEnv = "GMUX_HANDSHAKE_FD"
+
+// handshakeAck signals registration outcome to the parent process via
+// the file descriptor named in GMUX_HANDSHAKE_FD. No-op when the env
+// var is unset (the common case: this gmux wasn't spawned with a
+// handshake parent).
+//
+// Errors are swallowed: a malformed env var, a stale fd, or a write
+// failure leaves the parent's read returning EOF, which is already
+// the failure signal. The child continues running regardless, because
+// the session itself is independent of whether the parent ever
+// learns about it.
+func handshakeAck(sessionID string, registered bool) {
+	f := openHandshakeFD()
+	if f == nil {
+		return
+	}
+	// Clear the env var so the (about-to-be-closed) fd isn't
+	// re-interpreted by any process the runner forks later. The
+	// runner forwards os.Environ to user commands, and a nested
+	// `gmux` would otherwise call handshakeAck against a fd that
+	// in its own fd table is either closed or pointing at
+	// something unrelated.
+	_ = os.Unsetenv(handshakeFDEnv)
+	handshakeAckFD(f, sessionID, registered)
+}
+
+// handshakeAckFD is the fd-driven core of the ack: writes the
+// outcome to f and closes it. Split out from handshakeAck so tests
+// can exercise the IO contract without the env-lookup glue, which
+// avoids the fd-aliasing footgun that comes from os.NewFile-ing a
+// fd a test still owns through a different *os.File.
+func handshakeAckFD(f *os.File, sessionID string, registered bool) {
+	defer f.Close()
+	if registered {
+		fmt.Fprintln(f, sessionID)
+	}
+}
+
+// openHandshakeFD returns a *os.File wrapping GMUX_HANDSHAKE_FD, or
+// nil if the env var is unset, malformed, or names one of fds 0-2
+// (which are stdin/stdout/stderr and never a valid handshake
+// channel).
+func openHandshakeFD() *os.File {
+	fdStr := os.Getenv(handshakeFDEnv)
+	if fdStr == "" {
+		return nil
+	}
+	fd, err := strconv.Atoi(fdStr)
+	if err != nil || fd < 3 {
+		return nil
+	}
+	return os.NewFile(uintptr(fd), "gmux-handshake")
+}
+
+// readHandshake blocks on r until the child writes its session id
+// followed by a newline (success), closes its end without writing
+// (failure → io.EOF), or the deadline fires
+// (os.ErrDeadlineExceeded). Returns the trimmed session id on
+// success.
+//
+// Strict framing: the protocol mandates "<id>\n" written atomically.
+// Any read error is treated as failure, even if partial bytes
+// arrived. This protects against a script consuming a half-written
+// id from a child that crashed mid-write.
+func readHandshake(r *os.File, timeout time.Duration) (string, error) {
+	if err := r.SetReadDeadline(time.Now().Add(timeout)); err != nil {
+		return "", err
+	}
+	line, err := bufio.NewReader(r).ReadString('\n')
+	if err != nil {
+		return "", err
+	}
+	id := strings.TrimSpace(line)
+	if id == "" {
+		return "", errors.New("empty session id from child")
+	}
+	return id, nil
+}

--- a/cli/gmux/cmd/gmux/handshake_test.go
+++ b/cli/gmux/cmd/gmux/handshake_test.go
@@ -1,0 +1,268 @@
+package main
+
+import (
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// pipePair is a small helper: returns (r, w) from os.Pipe and
+// registers a cleanup that closes whatever's still open.
+func pipePair(t *testing.T) (*os.File, *os.File) {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = r.Close()
+		_ = w.Close()
+	})
+	return r, w
+}
+
+// ── handshakeAckFD: the IO contract, no env, no fd aliasing ──
+
+func TestHandshakeAckFD_WritesSessionIDOnSuccess(t *testing.T) {
+	r, w := pipePair(t)
+	handshakeAckFD(w, "abc-123", true)
+
+	data, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if got, want := string(data), "abc-123\n"; got != want {
+		t.Fatalf("bytes: got %q, want %q", got, want)
+	}
+}
+
+func TestHandshakeAckFD_ClosesWithoutWritingOnFailure(t *testing.T) {
+	r, w := pipePair(t)
+	handshakeAckFD(w, "abc-123", false)
+
+	data, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if len(data) != 0 {
+		t.Fatalf("expected zero bytes on failed ack, got %q", data)
+	}
+}
+
+// TestHandshakeAckFD_ClosesFDOnSuccess pairs with the failure case to
+// pin down the lifetime contract: regardless of outcome, the fd is
+// closed by the time handshakeAckFD returns. Verified by reading until
+// EOF on the matching read end and observing it terminates.
+func TestHandshakeAckFD_ClosesFDOnSuccess(t *testing.T) {
+	r, w := pipePair(t)
+	handshakeAckFD(w, "abc-123", true)
+
+	// If w were still open, ReadAll would block forever. The fact
+	// that it returns is itself the assertion; data check is
+	// belt-and-braces.
+	data, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(data) != "abc-123\n" {
+		t.Fatalf("bytes: got %q, want %q", data, "abc-123\n")
+	}
+}
+
+// ── openHandshakeFD / handshakeAck: env-lookup + dispatch glue ──
+
+func TestOpenHandshakeFD_NilWhenEnvUnset(t *testing.T) {
+	t.Setenv(handshakeFDEnv, "")
+	if f := openHandshakeFD(); f != nil {
+		t.Fatalf("expected nil with empty env, got %+v", f)
+	}
+}
+
+func TestOpenHandshakeFD_NilForInvalidEnv(t *testing.T) {
+	for _, v := range []string{"not-a-number", "0", "1", "2", "-1"} {
+		t.Run(v, func(t *testing.T) {
+			t.Setenv(handshakeFDEnv, v)
+			if f := openHandshakeFD(); f != nil {
+				t.Fatalf("expected nil for %q, got %+v", v, f)
+			}
+		})
+	}
+}
+
+// TestHandshakeAck_UnsetsEnvAfterDispatch is the regression test for
+// the env-leak fix: after handshakeAck runs once, GMUX_HANDSHAKE_FD
+// must be unset so a fork inheriting os.Environ doesn't try to write
+// to the (now-closed) fd.
+func TestHandshakeAck_UnsetsEnvAfterDispatch(t *testing.T) {
+	_, w := pipePair(t)
+	t.Setenv(handshakeFDEnv, strconv.Itoa(int(w.Fd())))
+
+	handshakeAck("sess-xyz", true)
+
+	if v := os.Getenv(handshakeFDEnv); v != "" {
+		t.Fatalf("env not cleared after ack: got %q", v)
+	}
+}
+
+// TestHandshakeAck_SecondCallIsNoOp follows from
+// UnsetsEnvAfterDispatch: a second call within the same process
+// finds an empty env and writes nothing. Captures the property from
+// the consumer's perspective (one ack per pipe).
+func TestHandshakeAck_SecondCallIsNoOp(t *testing.T) {
+	r, w := pipePair(t)
+	t.Setenv(handshakeFDEnv, strconv.Itoa(int(w.Fd())))
+
+	handshakeAck("first-id", true)
+	handshakeAck("second-id", true) // would re-write if env still set
+
+	data, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if got, want := string(data), "first-id\n"; got != want {
+		t.Fatalf("bytes: got %q, want %q (second call should be no-op)", got, want)
+	}
+}
+
+// TestHandshakeAck_NoOpWithoutEnv pins down the common-case fast
+// path: handshakeAck returns immediately when the env var is absent,
+// touching no fds. Asserted by the absence of side effects: the test
+// should run cleanly with no goroutines blocked.
+func TestHandshakeAck_NoOpWithoutEnv(t *testing.T) {
+	t.Setenv(handshakeFDEnv, "")
+	handshakeAck("abc", true)
+	handshakeAck("abc", false)
+}
+
+// ── readHandshake: parent-side framing ──
+
+func TestReadHandshake_RoundTripWithHandshakeAckFD(t *testing.T) {
+	r, w := pipePair(t)
+	go handshakeAckFD(w, "sess-xyz", true)
+
+	id, err := readHandshake(r, 2*time.Second)
+	if err != nil {
+		t.Fatalf("readHandshake: %v", err)
+	}
+	if id != "sess-xyz" {
+		t.Fatalf("id: got %q, want %q", id, "sess-xyz")
+	}
+}
+
+func TestReadHandshake_ChildFailedReturnsEOF(t *testing.T) {
+	r, w := pipePair(t)
+	handshakeAckFD(w, "ignored", false) // close-without-write
+
+	_, err := readHandshake(r, 2*time.Second)
+	if !errors.Is(err, io.EOF) {
+		t.Fatalf("err: got %v, want io.EOF", err)
+	}
+}
+
+func TestReadHandshake_TimeoutWhenChildHangs(t *testing.T) {
+	r, _ := pipePair(t) // w held open by cleanup, never written to
+
+	start := time.Now()
+	_, err := readHandshake(r, 50*time.Millisecond)
+	elapsed := time.Since(start)
+	if !errors.Is(err, os.ErrDeadlineExceeded) {
+		t.Fatalf("err: got %v, want os.ErrDeadlineExceeded", err)
+	}
+	if elapsed < 50*time.Millisecond {
+		t.Fatalf("deadline fired too early: %v", elapsed)
+	}
+}
+
+func TestReadHandshake_EmptyLineRejected(t *testing.T) {
+	r, w := pipePair(t)
+	go func() {
+		_, _ = w.Write([]byte("\n"))
+		_ = w.Close()
+	}()
+
+	_, err := readHandshake(r, 2*time.Second)
+	if err == nil {
+		t.Fatalf("expected error for empty id, got nil")
+	}
+}
+
+// TestReadHandshake_PartialWriteRejected is the strict-framing
+// regression: a child that writes "sess-abc" (no newline) and dies
+// must NOT result in the parent reporting "sess-abc" as a valid id.
+// The protocol is "<id>\n" written atomically; partial bytes are a
+// failure.
+func TestReadHandshake_PartialWriteRejected(t *testing.T) {
+	r, w := pipePair(t)
+	go func() {
+		_, _ = w.Write([]byte("sess-abc")) // no newline
+		_ = w.Close()
+	}()
+
+	_, err := readHandshake(r, 2*time.Second)
+	if err == nil {
+		t.Fatalf("expected error for partial write, got nil")
+	}
+	if !errors.Is(err, io.EOF) {
+		t.Fatalf("err: got %v, want io.EOF (bufio surfaces EOF when delim missing)", err)
+	}
+}
+
+// ── End-to-end: real subprocess + cmd.ExtraFiles ──
+//
+// The in-process tests above can't catch bugs in the actual cross-
+// process plumbing: ExtraFiles ↔ fd-3 mapping, env inheritance,
+// setsid + ExtraFiles compatibility. This test re-execs the test
+// binary with the same env+fd layout that spawnDetached uses in
+// production, has the child call handshakeAck, and verifies the
+// parent reads the id back through readHandshake. A failure here
+// flags a regression in any of those production-only mechanics.
+//
+// The child branch is the if-block at the top of the function:
+// when the test binary is re-executed with GMUX_HANDSHAKE_TEST_CHILD=1,
+// it pretends to be a runner that just finished a successful
+// register, calls handshakeAck, and exits.
+func TestPipeHandshakeRoundTripViaSubprocess(t *testing.T) {
+	const childIDEnv = "GMUX_HANDSHAKE_TEST_CHILD"
+	const expectedID = "sess-fromchild"
+
+	if os.Getenv(childIDEnv) == "1" {
+		handshakeAck(expectedID, true)
+		os.Exit(0)
+	}
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	defer r.Close()
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestPipeHandshakeRoundTripViaSubprocess$", "-test.v")
+	cmd.Env = append(os.Environ(),
+		childIDEnv+"=1",
+		handshakeFDEnv+"=3",
+	)
+	cmd.ExtraFiles = []*os.File{w}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start child: %v", err)
+	}
+	// Parent's copy of the write end must close so EOF on read
+	// means "child failed". Same pattern as production.
+	if err := w.Close(); err != nil {
+		t.Fatalf("close parent write end: %v", err)
+	}
+
+	id, readErr := readHandshake(r, 5*time.Second)
+	if waitErr := cmd.Wait(); waitErr != nil {
+		t.Fatalf("child exited non-zero: %v", waitErr)
+	}
+	if readErr != nil {
+		t.Fatalf("readHandshake: %v", readErr)
+	}
+	if id != expectedID {
+		t.Fatalf("id: got %q, want %q", id, expectedID)
+	}
+}

--- a/cli/gmux/cmd/gmux/run.go
+++ b/cli/gmux/cmd/gmux/run.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"errors"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"os/exec"
@@ -20,6 +22,13 @@ import (
 	"github.com/gmuxapp/gmux/packages/adapter/adapters"
 	"github.com/gmuxapp/gmux/packages/workspace"
 )
+
+// handshakeTimeout bounds how long the parent end of spawnDetached
+// waits for the child to finish registering with gmuxd. The child's
+// registerWithGmuxd loops up to 5 times with 500ms backoff, so the
+// realistic worst case is ~2.5s plus child startup. 5s is a
+// comfortable ceiling: any longer and something is genuinely wrong.
+const handshakeTimeout = 5 * time.Second
 
 // ptyDrainTimeout bounds the wait for the PTY to fully flush after the
 // child exits. A well-behaved child has its PTY slave closed by the
@@ -44,15 +53,16 @@ func runSession(args []string, attach bool) {
 	// detached process registers with gmuxd and the session appears in the
 	// gmux UI. The original process returns immediately to the parent shell.
 	if os.Getenv("GMUX") == "1" && localterm.IsInteractive() {
-		spawnDetached(args, "started "+strings.Join(args, " ")+" in background (visible in gmux)")
+		spawnDetached(args, "started "+strings.Join(args, " ")+" in background (visible in gmux)", false)
 		return
 	}
 
-	// Explicit --no-attach: spawn detached and return immediately, whether
-	// or not we're inside another gmux session. The session registers with
-	// gmuxd on its own.
+	// Explicit --no-attach: spawn detached, wait for the child to finish
+	// registering with gmuxd, then print the session id on stdout so the
+	// caller (typically a script) can capture it for --tail / --dismiss
+	// without polling.
 	if !attach {
-		spawnDetached(args, "started "+strings.Join(args, " ")+" in background (visible in gmux)")
+		spawnDetached(args, "", true)
 		return
 	}
 
@@ -184,9 +194,19 @@ func runSession(args []string, attach bool) {
 		fmt.Println("serving...")
 	}
 
-	// Auto-start gmuxd if not running (one-shot, never retried), then register.
+	// Auto-start gmuxd if not running (one-shot, never retried), then
+	// register. The goroutine signals regDone when the registration
+	// HTTP call has completed (succeeded or exhausted retries) and the
+	// handshake — if any — has been delivered to the parent. We block
+	// on regDone before exit so a fast-exiting command (echo, true,
+	// false) can't lose the registration race.
 	ensureGmuxd()
-	go registerWithGmuxd(sessionID, sockPath)
+	regDone := make(chan struct{})
+	go func() {
+		defer close(regDone)
+		ok := registerWithGmuxd(sessionID, sockPath)
+		handshakeAck(sessionID, ok)
+	}()
 
 	if interactive {
 		// Transparent mode: the local tty was built above and wired as
@@ -248,6 +268,15 @@ func runSession(args []string, attach bool) {
 	exitCode := srv.ExitCode()
 	state.SetExited(exitCode)
 
+	// Wait for the register/handshake goroutine to finish before we
+	// touch deregister or exit. Otherwise a fast-exiting command
+	// races with its own registration: the child can deregister
+	// (no-op, not registered yet), then the register arrives, then
+	// the child exits, leaving a stale registered session.
+	//
+	// Bounded by registerWithGmuxd's retry budget (≤2.5s).
+	<-regDone
+
 	// Deregister from gmuxd (best-effort)
 	deregisterFromGmuxd(sessionID)
 
@@ -258,10 +287,23 @@ func runSession(args []string, attach bool) {
 }
 
 // spawnDetached re-execs gmux with the given args as a setsid'd
-// background process, disconnected from the current terminal. Used for
-// both --no-attach and nested-gmux scenarios: the child registers with
-// gmuxd and appears in the UI; the parent returns immediately.
-func spawnDetached(args []string, msg string) {
+// background process, disconnected from the current terminal. Used
+// for both --no-attach and nested-gmux scenarios: the child registers
+// with gmuxd and appears in the UI.
+//
+// When waitForRegistration is true, the parent blocks until the child
+// either acknowledges registration via the handshake pipe or fails;
+// on success it prints the session id on stdout, on failure it exits
+// non-zero with a stderr error. This is the --no-attach path: scripts
+// capture the id with id=$(gmux --no-attach foo) and use it
+// immediately, without polling.
+//
+// When waitForRegistration is false, the parent prints msg on stderr
+// and returns immediately. This is the nested-gmux path: an
+// interactive user runs `gmux foo` from a shell already inside a
+// gmux session and sees the message at their prompt; the session
+// shows up in the UI when it registers.
+func spawnDetached(args []string, msg string, waitForRegistration bool) {
 	self, err := os.Executable()
 	if err != nil {
 		log.Fatalf("cannot find own binary: %v", err)
@@ -281,12 +323,58 @@ func spawnDetached(args []string, msg string) {
 	cmd.Stdin = devNull
 	cmd.Stdout = devNull
 	cmd.Stderr = devNull
+
+	var handshakeRead, handshakeWrite *os.File
+	if waitForRegistration {
+		var err error
+		handshakeRead, handshakeWrite, err = os.Pipe()
+		if err != nil {
+			log.Fatalf("failed to create handshake pipe: %v", err)
+		}
+		// Parent reads, child writes. cmd.ExtraFiles[0] becomes fd 3
+		// in the child; GMUX_HANDSHAKE_FD tells the child which fd to
+		// write to.
+		cmd.ExtraFiles = []*os.File{handshakeWrite}
+		cmd.Env = append(os.Environ(), handshakeFDEnv+"=3")
+	}
+
 	if err := cmd.Start(); err != nil {
 		log.Fatalf("failed to start background session: %v", err)
 	}
 	cmd.Process.Release()
-	if msg != "" {
-		fmt.Fprintln(os.Stderr, msg)
+
+	if !waitForRegistration {
+		if msg != "" {
+			fmt.Fprintln(os.Stderr, msg)
+		}
+		return
+	}
+
+	// Close the parent's copy of the write end. The only writer is
+	// now the child; if it dies without writing, our read returns
+	// EOF with zero bytes — the unambiguous "child failed" signal.
+	_ = handshakeWrite.Close()
+	defer handshakeRead.Close()
+
+	id, err := readHandshake(handshakeRead, handshakeTimeout)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to start background session: %s\n", explainHandshakeFailure(err))
+		os.Exit(1)
+	}
+	fmt.Println(id)
+}
+
+// explainHandshakeFailure converts a readHandshake error into a
+// short human-readable reason for the stderr message a script
+// developer sees when --no-attach can't return a session id.
+func explainHandshakeFailure(err error) string {
+	switch {
+	case errors.Is(err, os.ErrDeadlineExceeded):
+		return fmt.Sprintf("registration timed out after %s", handshakeTimeout)
+	case errors.Is(err, io.EOF):
+		return "child process exited before registering"
+	default:
+		return err.Error()
 	}
 }
 


### PR DESCRIPTION
Closes part of the work that was in #172 (now closed). Smaller, focused replacement.

## What

Make `gmux --no-attach <cmd>` print the session id on stdout deterministically, so scripts can capture and use it immediately:

```sh
id=$(gmux --no-attach pytest --watch)
gmux --tail "$id"   # works without polling, no race
```

## How

A `pipe(2)` handshake between the parent (the `gmux` process the user invoked) and the detached child (the actual session runner). All wire details, lifetime, and error semantics are documented in one block at the top of `cli/gmux/cmd/gmux/handshake.go`.

- Parent creates an `os.Pipe()`, attaches the write end as `cmd.ExtraFiles[0]` (becomes fd 3 in the child), sets `GMUX_HANDSHAKE_FD=3` in the child env, then `cmd.Start()`.
- Parent closes its copy of the write end and blocks on `readHandshake` with a 5s deadline.
- Child runs `registerWithGmuxd` synchronously; on success writes `"<session-id>\n"` to fd 3 and closes; on failure closes without writing.
- Parent reads the line and prints the trimmed id on stdout.

Strict framing: any non-nil read error (EOF, deadline, anything) is a failure regardless of whether partial bytes arrived. The protocol mandates `"<id>\n"` written atomically; a child that crashes mid-write must not produce a half-id on the parent's stdout.

After dispatching the ack, the child unsets `GMUX_HANDSHAKE_FD`. Without this, the runner's environment would still carry the var, and any nested `gmux` the user's command spawns would call `handshakeAck` against a fd that in its own fd table is closed or unrelated.

## Race fix

For fast-exit commands (`echo`, `true`, `false`), the previous `go registerWithGmuxd(...)` could lose the registration race: the main goroutine reached `os.Exit` before the register goroutine even started. The child died, kernel closed its end of the pipe, parent saw EOF.

This PR adds a `regDone` channel closed by the register/handshake goroutine, and the main goroutine blocks on it before `deregisterFromGmuxd` and `os.Exit`. Bounded by `registerWithGmuxd`'s own retry budget (≤2.5 s). As a side effect, this also fixes the pre-existing race in non-handshake paths where a fast-exit command's register/deregister could arrive at gmuxd out of order.

## Failure diagnostics

The parent's stderr message distinguishes the three failure modes a script developer hits:

- `"child process exited before registering"` — read returned `io.EOF` with zero bytes
- `"registration timed out after 5s"` — `readHandshake`'s deadline fired (child wedged)
- raw error otherwise — covers empty/malformed-line cases

## Nested-gmux path unchanged

Running `gmux foo` inside an interactive gmux session still prints `started ... in background (visible in gmux)` on stderr and returns immediately. No handshake plumbing, no stdout output. Only `--no-attach` triggers the new path.

## Tests

`cli/gmux/cmd/gmux/handshake_test.go` covers three layers:

**`handshakeAckFD` (the IO core, no env, no fd aliasing):**
- Writes `"<id>\n"` on success.
- Closes the fd without writing on failure.
- Closes the fd in both cases (verified by ReadAll terminating).

**`openHandshakeFD` / `handshakeAck` (env-lookup glue):**
- Returns nil for unset env, malformed values, and fds 0–2.
- Unsets `GMUX_HANDSHAKE_FD` after dispatch (regression test for the env-leak fix).
- Second call within the same process is a no-op (follows from the unset).
- Common-case fast path: returns immediately when env is absent.

**`readHandshake` (parent-side framing):**
- Round-trip with `handshakeAckFD` (in-process).
- Returns `io.EOF` when child closes without writing.
- Returns `os.ErrDeadlineExceeded` when child hangs.
- Rejects empty-line writes.
- Rejects partial writes ("`sess-abc`" no newline) — strict framing regression test.

**End-to-end subprocess (the only test exercising real `cmd.ExtraFiles` + fd-3 plumbing):**
- `TestPipeHandshakeRoundTripViaSubprocess` re-execs the test binary with the same env+fd layout `spawnDetached` uses in production, has the child call `handshakeAck`, and verifies the parent reads the id back. Catches regressions in fd numbering, env inheritance, and `setsid + ExtraFiles` compatibility that the in-process tests can't see.

End-to-end smoke also verified locally with a real gmuxd: fast-exit (echo, returns id with valid session in `/v1/sessions`) and long-running (sleep, returns id in 32 ms with `alive=true`) both work.

## Replaces #172

PR #172 took a different approach: parent generates the session id, passes it to the child via env, polls `/v1/sessions` to detect registration, and persisted post-exit scrollback to a `<socket>.tail` file with a CLI-side disk-fallback chain.

The new approach is a tighter slice:

- **Replaces:** polling → pipe handshake (deterministic, no race, no env-forced ids).
- **Drops:** `persistTail` / `tailPersistTimeout` / `Server.TailPersisted()` / `.tail` file write / CLI disk-fallback chain. Post-exit `--tail` is deferred to a separate PR that brokers scrollback through gmuxd from a structured state-dir, which gives us readonly web views and reboot-survival as side effects.
- **Drops:** `envForceSessionID` / `nextSessionID` / `isValidSessionID`. Child generates the id as today; the env var is unnecessary.
