### PR TITLE
feat(daemon): persist session metadata across gmuxd restarts

### DIFF
--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/presence"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/sessionfiles"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/sleep"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/sessionmeta"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/store"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/tsauth"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/tsdiscovery"
@@ -385,6 +386,44 @@ func serve(stderr io.Writer) int {
 
 	sessions := store.New()
 
+	// sessionmeta persists per-session records so dead sessions
+	// survive a gmuxd restart. Sweep on startup repopulates the
+	// store with everything we knew about previously; the OnDead
+	// hook below persists every Alive=false landing; Dismiss /
+	// Resume merge / slug takeover drop the corresponding directory.
+	// See sessionmeta package doc for the full lifecycle.
+	metaStore := sessionmeta.New(sessionmeta.DefaultDir())
+	if loaded, err := metaStore.Sweep(); err != nil {
+		log.Printf("sessionmeta: sweep failed: %v", err)
+	} else {
+		for _, sess := range loaded {
+			sessions.Upsert(sess)
+		}
+		if n := len(loaded); n > 0 {
+			log.Printf("sessionmeta: restored %d session(s) from %s", n, metaStore.Dir())
+		}
+	}
+	persistDead := func(sess store.Session) {
+		if err := metaStore.Write(sess); err != nil {
+			log.Printf("sessionmeta: write %s: %v", sess.ID, err)
+		}
+	}
+	forgetMeta := func(id string) {
+		if err := metaStore.Remove(id); err != nil {
+			log.Printf("sessionmeta: remove %s: %v", id, err)
+		}
+	}
+
+	// Drive the persister's removal loop off store events so every
+	// session-remove (dismiss, slug takeover, peer disconnect, etc.)
+	// drops the matching meta dir. The explicit forgetMeta call in
+	// the dismiss handler is redundant but cheap; resume merge does
+	// NOT broadcast session-remove (it's an Alive=false→true Upsert)
+	// so its forgetMeta call is the only thing that cleans up there.
+	metaEvents, cancelMetaEvents := sessions.Subscribe()
+	defer cancelMetaEvents()
+	go metaStore.WatchRemovals(metaEvents)
+
 	// Build command titlers from adapters that implement CommandTitler.
 	commandTitlers := make(map[string]func([]string) string)
 	for _, a := range adapters.AllAdapters() {
@@ -396,6 +435,7 @@ func serve(stderr io.Writer) int {
 	sessions.SetCommandTitlers(commandTitlers)
 
 	subs := discovery.NewSubscriptions(sessions)
+	subs.OnDead = persistDead
 	pendingResumes := discovery.NewPendingResumes()
 	var resumeMu sync.Mutex
 
@@ -420,7 +460,7 @@ func serve(stderr io.Writer) int {
 	// Start socket-based discovery (scans /tmp/gmux-sessions/*.sock)
 	// Discovery also subscribes to each runner's /events SSE for live updates.
 	stopDiscovery := make(chan struct{})
-	go discovery.Watch(sessions, subs, fileMon, pendingResumes, 3*time.Second, stopDiscovery)
+	go discovery.Watch(sessions, subs, fileMon, pendingResumes, persistDead, 3*time.Second, stopDiscovery)
 	defer close(stopDiscovery)
 
 	// Session file scanner — discovers resumable sessions from adapter
@@ -883,7 +923,7 @@ func serve(stderr io.Writer) int {
 		}
 
 		log.Printf("register: %s at %s", req.SessionID, req.SocketPath)
-		if err := discovery.Register(sessions, subs, fileMon, req.SocketPath, pendingResumes); err != nil {
+		if err := discovery.Register(sessions, subs, fileMon, req.SocketPath, pendingResumes, persistDead, forgetMeta); err != nil {
 			log.Printf("register: failed to query meta for %s: %v", req.SessionID, err)
 			writeError(w, http.StatusBadGateway, "runner_unreachable", err.Error())
 			return
@@ -1198,6 +1238,7 @@ func serve(stderr io.Writer) int {
 						}
 					}
 					sessions.Upsert(sess)
+					persistDead(sess)
 					subs.Unsubscribe(sessionID)
 					if fileMon != nil {
 						fileMon.NotifySessionDied(sessionID)
@@ -1242,8 +1283,11 @@ func serve(stderr io.Writer) int {
 			}
 			// Remove session from its project's sessions array.
 			projectMgr.DismissSession(sessionID, sess.Slug)
-			// Remove from store — broadcasts session-remove to all clients.
+			// Remove from store — broadcasts session-remove to all clients
+			// (which the cleanup goroutine catches to drop meta), then
+			// also drop meta synchronously to defeat any subscriber lag.
 			sessions.Remove(sessionID)
+			forgetMeta(sessionID)
 			if subs != nil {
 				subs.Unsubscribe(sessionID)
 			}

--- a/services/gmuxd/internal/discovery/discovery.go
+++ b/services/gmuxd/internal/discovery/discovery.go
@@ -32,12 +32,25 @@ func socketDir() string {
 	return "/tmp/gmux-sessions"
 }
 
+// OnDeadFunc is invoked after a session has just landed as Alive=false
+// in the store, with the post-Upsert snapshot. nil is allowed.
+//
+// Three call sites fire it:
+//
+//   - Scan's socket-gone phase, when a previously-alive session's
+//     runner is no longer reachable.
+//   - Register's fresh-upsert path, when the runner's /meta already
+//     reports alive=false (fast-exit commands like `echo` whose
+//     runner finishes before queryMeta arrives).
+//   - Subscriptions.OnDead, after the SSE exit handler upserts.
+type OnDeadFunc func(sess store.Session)
+
 // Watch periodically scans for Unix sockets and queries their /meta.
 // When a new session is found, it subscribes to the runner's /events SSE
 // for real-time status/meta/exit updates.
-func Watch(sessions *store.Store, subs *Subscriptions, fileMon *FileMonitor, resumes *PendingResumes, interval time.Duration, stop <-chan struct{}) {
+func Watch(sessions *store.Store, subs *Subscriptions, fileMon *FileMonitor, resumes *PendingResumes, onDead OnDeadFunc, interval time.Duration, stop <-chan struct{}) {
 	// Initial scan immediately
-	Scan(sessions, subs, fileMon, resumes)
+	Scan(sessions, subs, fileMon, resumes, onDead)
 
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
@@ -48,7 +61,7 @@ func Watch(sessions *store.Store, subs *Subscriptions, fileMon *FileMonitor, res
 			subs.UnsubscribeAll()
 			return
 		case <-ticker.C:
-			Scan(sessions, subs, fileMon, resumes)
+			Scan(sessions, subs, fileMon, resumes, onDead)
 		}
 	}
 }
@@ -56,7 +69,7 @@ func Watch(sessions *store.Store, subs *Subscriptions, fileMon *FileMonitor, res
 // Scan finds all .sock files and queries each runner's /meta endpoint.
 // Reachable sockets → upsert session + subscribe to /events.
 // Unreachable → remove + cleanup + unsubscribe.
-func Scan(sessions *store.Store, subs *Subscriptions, fileMon *FileMonitor, resumes *PendingResumes) {
+func Scan(sessions *store.Store, subs *Subscriptions, fileMon *FileMonitor, resumes *PendingResumes, onDead OnDeadFunc) {
 	dir := socketDir()
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -84,7 +97,7 @@ func Scan(sessions *store.Store, subs *Subscriptions, fileMon *FileMonitor, resu
 		if trackedSockets[sockPath] {
 			continue // already tracked
 		}
-		if err := Register(sessions, subs, fileMon, sockPath, resumes); err != nil {
+		if err := Register(sessions, subs, fileMon, sockPath, resumes, onDead, nil); err != nil {
 			// Only remove sockets old enough to be genuinely stale.
 			// A brand-new socket may not be listening yet (runner still starting).
 			if info, serr := entry.Info(); serr == nil && time.Since(info.ModTime()) > 10*time.Second {
@@ -114,6 +127,9 @@ func Scan(sessions *store.Store, subs *Subscriptions, fileMon *FileMonitor, resu
 			}
 		}
 		sessions.Upsert(s)
+		if onDead != nil {
+			onDead(s)
+		}
 		if subs != nil {
 			subs.Unsubscribe(s.ID)
 		}
@@ -135,11 +151,23 @@ func probeSocket(socketPath string) bool {
 	return true
 }
 
+// OnResumeMergedFunc fires when Register absorbs a fresh registration
+// into an existing dead session record (the pendingResume path).
+// gmuxd uses it to drop the persisted meta.json now that the session
+// is alive again. nil is allowed.
+type OnResumeMergedFunc func(existingID string)
+
 // Register handles a registration request from gmux-run.
 // Immediately queries the runner's /meta, adds to store, and subscribes to /events.
 // If there's a pending resume matching this session's cwd+kind, the existing
-// store entry is updated in-place rather than creating a new one.
-func Register(sessions *store.Store, subs *Subscriptions, fileMon *FileMonitor, socketPath string, resumes *PendingResumes) error {
+// store entry is updated in-place rather than creating a new one;
+// onResumeMerged then fires with the existing session's id.
+//
+// Fast-exiting commands (echo, true) often die before queryMeta arrives,
+// so the /meta payload reports alive=false. In that case Register is the
+// session's only landing point in the store, and onDead fires after the
+// Upsert so the record is persisted to disk.
+func Register(sessions *store.Store, subs *Subscriptions, fileMon *FileMonitor, socketPath string, resumes *PendingResumes, onDead OnDeadFunc, onResumeMerged OnResumeMergedFunc) error {
 	newSess, err := queryMeta(socketPath)
 	if err != nil {
 		return err
@@ -173,6 +201,9 @@ func Register(sessions *store.Store, subs *Subscriptions, fileMon *FileMonitor, 
 						subs.Unsubscribe(newSess.ID)
 					}
 				}
+				if onResumeMerged != nil {
+					onResumeMerged(existingID)
+				}
 				log.Printf("register: merged resumed session %s ← %s", existingID, newSess.ID)
 				return nil
 			}
@@ -195,6 +226,11 @@ func Register(sessions *store.Store, subs *Subscriptions, fileMon *FileMonitor, 
 	}
 
 	sessions.Upsert(*newSess)
+	if !newSess.Alive && newSess.Peer == "" && onDead != nil {
+		// /meta arrived after the runner already exited; the session
+		// will never appear in any /events stream we subscribe to.
+		onDead(*newSess)
+	}
 	if subs != nil {
 		subs.Subscribe(newSess.ID, socketPath)
 	}

--- a/services/gmuxd/internal/discovery/subscribe.go
+++ b/services/gmuxd/internal/discovery/subscribe.go
@@ -25,6 +25,15 @@ type Subscriptions struct {
 	// Returns true if the session was transitioned to resumable
 	// (caller should not set exit status).
 	OnExit func(sess *store.Session) bool
+	// OnDead fires after the store Upsert that records an exit
+	// event. The session passed is the post-Upsert snapshot,
+	// including any Title / Resumable derivation the store applied
+	// and any mutations the OnExit hook made before it.
+	//
+	// Used by gmuxd to persist the session record so it survives a
+	// restart. See discovery.OnDeadFunc for the parallel hook on
+	// the Scan and Register paths.
+	OnDead func(sess store.Session)
 }
 
 func NewSubscriptions(s *store.Store) *Subscriptions {
@@ -237,6 +246,9 @@ func (sub *Subscriptions) handleEvent(sessionID, socketPath, eventType string, d
 			}
 		}
 		sub.store.Upsert(sess)
+		if sub.OnDead != nil {
+			sub.OnDead(sess)
+		}
 
 	case "activity":
 		// Transient signal: terminal produced output with no attached clients.

--- a/services/gmuxd/internal/sessionmeta/sessionmeta.go
+++ b/services/gmuxd/internal/sessionmeta/sessionmeta.go
@@ -1,0 +1,246 @@
+// Package sessionmeta persists per-session metadata to disk so dead
+// sessions survive a gmuxd restart and so future scrollback artifacts
+// (S3) live alongside their owning session's record.
+//
+// gmuxd writes a meta.json file under
+// $XDG_STATE_HOME/gmux/sessions/<id>/ every time a locally-owned
+// session lands as Alive=false in the store. That covers the
+// obvious Alive=true→false transitions (SSE exit, socket-gone,
+// kill-unreachable) plus the less-obvious case of fast-exiting
+// commands whose runner finishes before gmuxd's queryMeta arrives:
+// the runner's /meta then reports alive=false directly, so the
+// session lands as dead via Register's fresh-upsert path without
+// any transition.
+//
+// On startup, Sweep loads each meta.json back into the store as
+// Alive=false so previously-seen sessions remain visible in the
+// sidebar across restarts. On Dismiss / Resume merge / slug
+// takeover, the per-session directory is removed.
+//
+// Peer-owned sessions are excluded: the hub re-receives them from
+// the spoke on reconnect, so persisting on the hub would create
+// duplicate ghosts. Write is a no-op for sess.Peer != "".
+//
+// The package writes with mode 0o600 inside a 0o700 parent so
+// scrollback (added in S3) and any future per-session secrets stay
+// readable only by the gmux user.
+package sessionmeta
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/gmuxapp/gmux/packages/paths"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/store"
+)
+
+const (
+	metaFile       = "meta.json"
+	scrollbackFile = "scrollback" // owned by the runner; sweep recognizes it as non-orphan
+	dirMode        = 0o700
+	fileMode       = 0o600
+)
+
+// DefaultDir is the production state-dir for session metadata.
+// $XDG_STATE_HOME/gmux/sessions, derived from paths.StateDir().
+func DefaultDir() string {
+	return filepath.Join(paths.StateDir(), "sessions")
+}
+
+// Store binds a base directory to the file-IO operations. One Store
+// is constructed at gmuxd startup with DefaultDir(); tests construct
+// their own with a temp dir.
+type Store struct {
+	dir string
+}
+
+// New returns a Store rooted at dir. The directory is created lazily
+// on first Write; no IO happens at construction.
+func New(dir string) *Store { return &Store{dir: dir} }
+
+// Dir is the base directory under which per-session subdirectories
+// live. Exposed for tests and for diagnostic logging.
+func (s *Store) Dir() string { return s.dir }
+
+// SessionDir is the per-session subdirectory: <Dir()>/<id>/.
+func (s *Store) SessionDir(id string) string {
+	return filepath.Join(s.dir, id)
+}
+
+// persistedSession aliases store.Session to bypass the API
+// MarshalJSON method, which strips internal fields like ShellTitle
+// and AdapterTitle. The default reflection-based marshaller
+// respects the json tags on the original struct — including the
+// ones for those internal fields — so no manual mirroring is
+// needed and adding a new field to store.Session automatically
+// flows into persistence.
+type persistedSession store.Session
+
+// Write atomically persists s to <dir>/<s.ID>/meta.json. Skips
+// peer-owned sessions: the hub doesn't authoritatively own those
+// records and re-receives them from the spoke on reconnect.
+//
+// Atomic via temp file + rename. The temp file is created in the
+// same directory so rename(2) is on the same filesystem.
+func (s *Store) Write(sess store.Session) error {
+	if sess.Peer != "" {
+		return nil // not ours to persist
+	}
+	if sess.ID == "" {
+		return errors.New("sessionmeta: cannot persist session with empty id")
+	}
+
+	sessDir := s.SessionDir(sess.ID)
+	if err := os.MkdirAll(sessDir, dirMode); err != nil {
+		return fmt.Errorf("sessionmeta: mkdir %s: %w", sessDir, err)
+	}
+
+	data, err := json.MarshalIndent(persistedSession(sess), "", "  ")
+	if err != nil {
+		return fmt.Errorf("sessionmeta: marshal %s: %w", sess.ID, err)
+	}
+
+	final := filepath.Join(sessDir, metaFile)
+	tmp, err := os.CreateTemp(sessDir, metaFile+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("sessionmeta: create tmp: %w", err)
+	}
+	tmpPath := tmp.Name()
+	cleanupTmp := func() { _ = os.Remove(tmpPath) }
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		cleanupTmp()
+		return fmt.Errorf("sessionmeta: write tmp: %w", err)
+	}
+	if err := tmp.Chmod(fileMode); err != nil {
+		_ = tmp.Close()
+		cleanupTmp()
+		return fmt.Errorf("sessionmeta: chmod tmp: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		cleanupTmp()
+		return fmt.Errorf("sessionmeta: close tmp: %w", err)
+	}
+	if err := os.Rename(tmpPath, final); err != nil {
+		cleanupTmp()
+		return fmt.Errorf("sessionmeta: rename %s → %s: %w", tmpPath, final, err)
+	}
+	return nil
+}
+
+// Read returns the persisted session for id, or (zero, error) if
+// the directory or meta.json is missing or unparseable.
+func (s *Store) Read(id string) (store.Session, error) {
+	path := filepath.Join(s.SessionDir(id), metaFile)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return store.Session{}, err
+	}
+	var ps persistedSession
+	if err := json.Unmarshal(data, &ps); err != nil {
+		return store.Session{}, fmt.Errorf("sessionmeta: parse %s: %w", path, err)
+	}
+	return store.Session(ps), nil
+}
+
+// Remove deletes the entire per-session directory. Idempotent: a
+// missing directory is not an error. Used for dismiss and for the
+// resume-merge cleanup, where the dead session's record is replaced
+// by a fresh live registration.
+func (s *Store) Remove(id string) error {
+	if id == "" {
+		return nil
+	}
+	sessDir := s.SessionDir(id)
+	if err := os.RemoveAll(sessDir); err != nil {
+		return fmt.Errorf("sessionmeta: remove %s: %w", sessDir, err)
+	}
+	return nil
+}
+
+// WatchRemovals consumes events until the channel closes, removing
+// the on-disk record for every session-remove event. Wired at
+// gmuxd startup against store.Subscribe so the persister cleans up
+// after every store removal, not just the dismiss / resume-merge
+// paths that have explicit Remove calls.
+//
+// Catches the slug-takeover case: when a fresh live session
+// shadows a dead one with the same (kind, peer, slug), the store
+// silently evicts the dead record and broadcasts session-remove.
+// Without this loop those orphan meta.json files accumulate — the
+// next Sweep would re-load them and the next slug collision would
+// re-orphan, indefinitely.
+//
+// Errors from Remove are logged; failure to clean up one entry
+// doesn't stop the loop. Returns when the events channel closes
+// (i.e., when the store subscription is cancelled at shutdown).
+func (s *Store) WatchRemovals(events <-chan store.Event) {
+	for ev := range events {
+		if ev.Type != "session-remove" {
+			continue
+		}
+		if err := s.Remove(ev.ID); err != nil {
+			log.Printf("sessionmeta: cleanup remove %s: %v", ev.ID, err)
+		}
+	}
+}
+
+// Sweep loads every persisted session from disk. Each is returned
+// with Alive=false; callers (gmuxd at startup) Upsert them so the
+// sidebar shows previously-seen sessions before any live runners
+// register.
+//
+// Cleanup performed during the sweep:
+//   - directories with no meta.json (orphan scrollback or empty
+//     dirs) are logged and removed
+//   - directories whose meta.json fails to parse are logged and
+//     left in place (operator may want to inspect)
+//   - non-directory entries under the base dir are ignored
+//
+// Returns nil error when the base dir doesn't exist (clean install).
+func (s *Store) Sweep() ([]store.Session, error) {
+	entries, err := os.ReadDir(s.dir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("sessionmeta: read %s: %w", s.dir, err)
+	}
+
+	var loaded []store.Session
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		id := e.Name()
+		sessDir := s.SessionDir(id)
+		metaPath := filepath.Join(sessDir, metaFile)
+
+		if _, err := os.Stat(metaPath); err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				log.Printf("sessionmeta: orphan dir %s (no %s); removing", sessDir, metaFile)
+				_ = os.RemoveAll(sessDir)
+				continue
+			}
+			log.Printf("sessionmeta: stat %s: %v; skipping", metaPath, err)
+			continue
+		}
+
+		sess, err := s.Read(id)
+		if err != nil {
+			log.Printf("sessionmeta: read %s: %v; skipping", metaPath, err)
+			continue
+		}
+		// Sweep loads dead sessions only; if a live runner is still
+		// listening, discovery.Register will upsert it with Alive=true
+		// shortly after.
+		sess.Alive = false
+		loaded = append(loaded, sess)
+	}
+	return loaded, nil
+}

--- a/services/gmuxd/internal/sessionmeta/sessionmeta_test.go
+++ b/services/gmuxd/internal/sessionmeta/sessionmeta_test.go
@@ -1,0 +1,406 @@
+package sessionmeta
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/store"
+)
+
+func newStore(t *testing.T) *Store {
+	t.Helper()
+	return New(t.TempDir())
+}
+
+func sampleSession() store.Session {
+	exit := 42
+	return store.Session{
+		ID:           "sess-test123",
+		Kind:         "shell",
+		Command:      []string{"bash", "-l"},
+		Cwd:          "/home/u/proj",
+		Alive:        false,
+		ExitCode:     &exit,
+		StartedAt:    "2026-04-26T10:00:00Z",
+		ExitedAt:     "2026-04-26T10:05:00Z",
+		Title:        "proj",
+		ShellTitle:   "shell-title-internal",
+		AdapterTitle: "adapter-title-internal",
+		Slug:         "proj",
+	}
+}
+
+// TestRoundTripPreservesInternalFields is the central correctness
+// claim of this package: persisted sessions come back with the
+// internal Title-precedence fields (ShellTitle, AdapterTitle) intact.
+// Without this, a restored session loses its title resolution and
+// shows up as the bare Kind ("shell") instead of "proj".
+func TestRoundTripPreservesInternalFields(t *testing.T) {
+	s := newStore(t)
+	in := sampleSession()
+
+	if err := s.Write(in); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	out, err := s.Read(in.ID)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+
+	if out.ShellTitle != in.ShellTitle {
+		t.Errorf("ShellTitle: got %q, want %q", out.ShellTitle, in.ShellTitle)
+	}
+	if out.AdapterTitle != in.AdapterTitle {
+		t.Errorf("AdapterTitle: got %q, want %q", out.AdapterTitle, in.AdapterTitle)
+	}
+	if out.ExitCode == nil || *out.ExitCode != *in.ExitCode {
+		t.Errorf("ExitCode: got %v, want %v", out.ExitCode, in.ExitCode)
+	}
+	if out.Cwd != in.Cwd || out.Title != in.Title || out.Slug != in.Slug {
+		t.Errorf("scalars mismatch: got %+v, want %+v", out, in)
+	}
+}
+
+// TestRoundTripFullSession is the regression test for "someone added
+// a field to store.Session without a json tag." By using
+// reflect.DeepEqual against a fully-populated Session we don't have
+// to enumerate field names: any silently-dropped field surfaces as
+// a diff at this assertion. The persistedSession alias is supposed
+// to make this guarantee automatic, but only if every field carries
+// a json tag.
+func TestRoundTripFullSession(t *testing.T) {
+	s := newStore(t)
+	exit := 7
+	in := store.Session{
+		ID:            "sess-full",
+		CreatedAt:     "2026-04-26T10:00:00Z",
+		Command:       []string{"bash", "-c", "echo hi"},
+		Cwd:           "~/work",
+		Kind:          "shell",
+		WorkspaceRoot: "~/work/repo",
+		Remotes:       map[string]string{"origin": "github.com/me/repo"},
+		Alive:         false,
+		Pid:           12345,
+		ExitCode:      &exit,
+		StartedAt:     "2026-04-26T10:00:01Z",
+		ExitedAt:      "2026-04-26T10:05:00Z",
+		Title:         "my title",
+		Subtitle:      "my subtitle",
+		Status:        &store.Status{Label: "working", Working: true, Error: false},
+		Unread:        true,
+		Resumable:     true,
+		SocketPath:    "/tmp/gmux-sessions/sess-full.sock",
+		TerminalCols:  120,
+		TerminalRows:  40,
+		Slug:          "my-slug",
+		RunnerVersion: "v1.4.0",
+		BinaryHash:    "abc123",
+		ShellTitle:    "shell-title",
+		AdapterTitle:  "adapter-title",
+	}
+
+	if err := s.Write(in); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	out, err := s.Read(in.ID)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+
+	if !reflect.DeepEqual(in, out) {
+		t.Fatalf("round-trip diverged.\nin:  %+v\nout: %+v", in, out)
+	}
+}
+
+// TestWriteAtomicNoTempLeftover pins down the rename-not-copy
+// invariant: after a successful Write, no .tmp-* file lingers in
+// the session directory. Without this, a partial-Write crash could
+// leave files that would confuse Sweep on next startup.
+func TestWriteAtomicNoTempLeftover(t *testing.T) {
+	s := newStore(t)
+	if err := s.Write(sampleSession()); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	entries, err := os.ReadDir(s.SessionDir("sess-test123"))
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	for _, e := range entries {
+		if e.Name() != metaFile {
+			t.Errorf("unexpected file in session dir: %q", e.Name())
+		}
+	}
+}
+
+func TestWriteSkipsPeerSessions(t *testing.T) {
+	s := newStore(t)
+	sess := sampleSession()
+	sess.Peer = "remote-host"
+	if err := s.Write(sess); err != nil {
+		t.Fatalf("Write returned error for peer session: %v", err)
+	}
+	if _, err := os.Stat(s.SessionDir(sess.ID)); !os.IsNotExist(err) {
+		t.Fatalf("peer session should not have been persisted; got err=%v", err)
+	}
+}
+
+func TestWriteRejectsEmptyID(t *testing.T) {
+	s := newStore(t)
+	sess := sampleSession()
+	sess.ID = ""
+	if err := s.Write(sess); err == nil {
+		t.Fatalf("expected error for empty id, got nil")
+	}
+}
+
+func TestWriteFilePermissions(t *testing.T) {
+	s := newStore(t)
+	if err := s.Write(sampleSession()); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	info, err := os.Stat(filepath.Join(s.SessionDir("sess-test123"), metaFile))
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if got := info.Mode().Perm(); got != fileMode {
+		t.Errorf("file mode: got %o, want %o", got, fileMode)
+	}
+	dirInfo, err := os.Stat(s.SessionDir("sess-test123"))
+	if err != nil {
+		t.Fatalf("Stat dir: %v", err)
+	}
+	if got := dirInfo.Mode().Perm(); got != dirMode {
+		t.Errorf("dir mode: got %o, want %o", got, dirMode)
+	}
+}
+
+func TestRemoveIsIdempotent(t *testing.T) {
+	s := newStore(t)
+	if err := s.Write(sampleSession()); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := s.Remove("sess-test123"); err != nil {
+		t.Fatalf("first Remove: %v", err)
+	}
+	if err := s.Remove("sess-test123"); err != nil {
+		t.Fatalf("second Remove (must be idempotent): %v", err)
+	}
+	if err := s.Remove("sess-never-existed"); err != nil {
+		t.Fatalf("Remove of non-existent: %v", err)
+	}
+}
+
+func TestSweepLoadsAllSessionsAsAliveFalse(t *testing.T) {
+	s := newStore(t)
+	a := sampleSession()
+	a.ID = "sess-aaa"
+	b := sampleSession()
+	b.ID = "sess-bbb"
+	b.Alive = true // Sweep must downgrade — we only persist after death
+
+	for _, sess := range []store.Session{a, b} {
+		if err := s.Write(sess); err != nil {
+			t.Fatalf("Write %s: %v", sess.ID, err)
+		}
+	}
+
+	loaded, err := s.Sweep()
+	if err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	if len(loaded) != 2 {
+		t.Fatalf("loaded %d sessions, want 2: %+v", len(loaded), loaded)
+	}
+	for _, sess := range loaded {
+		if sess.Alive {
+			t.Errorf("Sweep returned Alive=true for %s; should always be false", sess.ID)
+		}
+	}
+}
+
+func TestSweepRemovesOrphanDirs(t *testing.T) {
+	s := newStore(t)
+	// Orphan: dir exists with a scrollback-like file but no meta.json.
+	orphan := s.SessionDir("sess-orphan")
+	if err := os.MkdirAll(orphan, dirMode); err != nil {
+		t.Fatalf("mkdir orphan: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(orphan, scrollbackFile), []byte("xyz"), fileMode); err != nil {
+		t.Fatalf("write orphan scrollback: %v", err)
+	}
+
+	if _, err := s.Sweep(); err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	if _, err := os.Stat(orphan); !os.IsNotExist(err) {
+		t.Fatalf("orphan dir should have been removed; got err=%v", err)
+	}
+}
+
+func TestSweepKeepsValidSessionsAlongsideOrphan(t *testing.T) {
+	s := newStore(t)
+
+	good := sampleSession()
+	if err := s.Write(good); err != nil {
+		t.Fatalf("Write good: %v", err)
+	}
+	orphan := s.SessionDir("sess-orphan")
+	if err := os.MkdirAll(orphan, dirMode); err != nil {
+		t.Fatalf("mkdir orphan: %v", err)
+	}
+
+	loaded, err := s.Sweep()
+	if err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	if len(loaded) != 1 || loaded[0].ID != good.ID {
+		t.Fatalf("Sweep should return just the good session; got %+v", loaded)
+	}
+	if _, err := os.Stat(filepath.Join(s.SessionDir(good.ID), metaFile)); err != nil {
+		t.Errorf("good session was disturbed: %v", err)
+	}
+	if _, err := os.Stat(orphan); !os.IsNotExist(err) {
+		t.Errorf("orphan should have been swept: err=%v", err)
+	}
+}
+
+// TestSweepSkipsUnparseableMeta verifies that a corrupted meta.json
+// doesn't take down the whole sweep. Recovery posture: log, skip,
+// keep going. Operator can inspect manually if curious.
+func TestSweepSkipsUnparseableMeta(t *testing.T) {
+	s := newStore(t)
+	bad := s.SessionDir("sess-bad")
+	if err := os.MkdirAll(bad, dirMode); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(bad, metaFile), []byte("not json"), fileMode); err != nil {
+		t.Fatalf("write bad meta: %v", err)
+	}
+	good := sampleSession()
+	if err := s.Write(good); err != nil {
+		t.Fatalf("Write good: %v", err)
+	}
+
+	loaded, err := s.Sweep()
+	if err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	if len(loaded) != 1 || loaded[0].ID != good.ID {
+		t.Fatalf("Sweep should return only the good session: %+v", loaded)
+	}
+	// Bad dir is intentionally left in place for inspection.
+	if _, err := os.Stat(bad); err != nil {
+		t.Errorf("bad dir should be left alone: %v", err)
+	}
+}
+
+func TestSweepReturnsEmptyForMissingDir(t *testing.T) {
+	s := New(filepath.Join(t.TempDir(), "does-not-exist"))
+	loaded, err := s.Sweep()
+	if err != nil {
+		t.Fatalf("Sweep on missing dir should not error: %v", err)
+	}
+	if len(loaded) != 0 {
+		t.Fatalf("expected zero sessions, got %d", len(loaded))
+	}
+}
+
+// TestWatchRemovalsRemovesOnSessionRemoveEvent verifies the cleanup
+// loop's contract end to end: a session-remove event drops the
+// on-disk record; events of other types do not; the loop terminates
+// cleanly when the channel closes.
+//
+// This is the catch-all for slug-takeover orphans (and any other
+// store removal not paired with an explicit Remove call). A
+// regression here would silently leak per-session directories.
+func TestWatchRemovalsRemovesOnSessionRemoveEvent(t *testing.T) {
+	s := newStore(t)
+	target := sampleSession()
+	target.ID = "sess-target"
+	survivor := sampleSession()
+	survivor.ID = "sess-survivor"
+
+	for _, sess := range []store.Session{target, survivor} {
+		if err := s.Write(sess); err != nil {
+			t.Fatalf("Write %s: %v", sess.ID, err)
+		}
+	}
+
+	events := make(chan store.Event, 4)
+	done := make(chan struct{})
+	go func() {
+		s.WatchRemovals(events)
+		close(done)
+	}()
+
+	// Non-removal events must not touch the disk.
+	events <- store.Event{Type: "session-upsert", ID: target.ID}
+	events <- store.Event{Type: "session-activity", ID: target.ID}
+
+	// Removal of target should drop its dir.
+	events <- store.Event{Type: "session-remove", ID: target.ID}
+
+	// Removal of an ID we never persisted is a no-op (peer sessions,
+	// sessions removed before any Alive=false upsert).
+	events <- store.Event{Type: "session-remove", ID: "sess-never-existed"}
+
+	// Closing the channel must terminate the loop.
+	close(events)
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("WatchRemovals did not return after channel close")
+	}
+
+	if _, err := os.Stat(s.SessionDir(target.ID)); !os.IsNotExist(err) {
+		t.Errorf("target dir should have been removed; err=%v", err)
+	}
+	if _, err := os.Stat(s.SessionDir(survivor.ID)); err != nil {
+		t.Errorf("survivor dir should be untouched: %v", err)
+	}
+}
+
+// TestWriteOverwritesExisting verifies the "every Alive=true→false
+// transition rewrites meta.json" contract from the lifecycle plan.
+// Subsequent Writes for the same id replace the previous file
+// (e.g., an exit code arriving via a late SSE event after the
+// socket-gone path already persisted a no-exit-code stub).
+func TestWriteOverwritesExisting(t *testing.T) {
+	s := newStore(t)
+	first := sampleSession()
+	first.Title = "first"
+	if err := s.Write(first); err != nil {
+		t.Fatalf("first Write: %v", err)
+	}
+
+	second := sampleSession()
+	second.Title = "second"
+	if err := s.Write(second); err != nil {
+		t.Fatalf("second Write: %v", err)
+	}
+
+	out, err := s.Read(first.ID)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if out.Title != "second" {
+		t.Errorf("title: got %q, want %q (second Write should have overwritten)", out.Title, "second")
+	}
+
+	// Sanity: meta.json contains exactly the second payload.
+	raw, err := os.ReadFile(filepath.Join(s.SessionDir(first.ID), metaFile))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	var verify persistedSession
+	if err := json.Unmarshal(raw, &verify); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if verify.Title != "second" {
+		t.Errorf("on-disk title: got %q, want %q", verify.Title, "second")
+	}
+}


### PR DESCRIPTION
Second slice of the session-lifecycle work (after #184).

## What

Dead sessions disappear on gmuxd restart today. This change persists per-session metadata to disk on every `Alive=false` transition (or registration that lands as `Alive=false`), and rehydrates the store on startup. Result: a session that exited five minutes ago, before a `gmuxd restart`, still shows up in the sidebar with its title, command, exit code, and timestamps.

## How

`services/gmuxd/internal/sessionmeta` is a small package with a `Store` bound to a base directory. Five operations: `Write`, `Read`, `Remove`, `Sweep`, plus a `DefaultDir` helper. Files live at `$XDG_STATE_HOME/gmux/sessions/<id>/meta.json`, mode `0o600` inside a `0o700` parent. Atomic writes via `CreateTemp` + `Chmod` + `Rename` in the same directory.

The persisted JSON uses a `persistedSession` type alias for `store.Session` so it bypasses the API `MarshalJSON` method (which strips internal fields). The default reflection marshaller respects every json tag on the original struct, so internal Title-precedence fields like `ShellTitle` and `AdapterTitle` round-trip without a manual mirror struct. Add a field to `store.Session` and persistence picks it up automatically.

### Wiring

gmuxd calls `metaStore.Write` at every site that lands a local session as `Alive=false` in the store:

- `discovery/subscribe.go` — SSE exit handler, after the Upsert. New `Subscriptions.OnDead` callback.
- `discovery/discovery.go` — `Scan`'s socket-gone phase, and `Register`'s fresh-upsert path when the runner's `/meta` already reports `alive=false` (fast-exit commands like `echo` whose runner finishes before `queryMeta` arrives — the runner appears in the store directly as dead, never transitions there). New `OnDeadFunc` parameter on `Watch` / `Scan` / `Register`.
- `cmd/gmuxd/main.go` — kill-unreachable fallback. Direct call.

`metaStore.Remove` fires on:

- Explicit `dismiss` handler.
- `Register`'s resume-merge path, via a new `OnResumeMergedFunc` callback (the existing record is about to flip back to `Alive=true`, so its meta is no longer authoritative).
- A goroutine running `metaStore.WatchRemovals(events)` against `store.Subscribe()` that drops meta on every `session-remove` event. Catches paths the explicit calls miss, most importantly slug-takeover: when a fresh live session shadows a dead one with the same `(kind, peer, slug)`, the store silently kicks the dead one out and broadcasts `session-remove`. Without this, the dead one's meta lingers as an orphan that the next `Sweep` would re-load and the next slug collision would re-orphan, indefinitely.

### Sweep behavior on startup

Reads each subdirectory under the base dir, unmarshals `meta.json`, upserts as `Alive=false`. Sites of cleanup during the sweep:

- Subdirectory with no `meta.json` (orphan scrollback dir, future-proofing for S3 where the runner writes scrollback alongside): logged and `os.RemoveAll`'d.
- `meta.json` that fails to parse: logged and **left in place** (operator may want to inspect; the cost of a stuck dead-session sidebar entry is lower than silently destroying the only forensic trail).
- Missing base dir: clean install, no error.

### Peer sessions

`Write` is a no-op when `sess.Peer != ""`. The hub re-receives peer sessions from the spoke on reconnect; persisting on the hub would create duplicate ghosts. The cleanup goroutine still calls `Remove` for peer session IDs but that's an idempotent no-op (no file was ever written).

## Tests

`services/gmuxd/internal/sessionmeta/sessionmeta_test.go` covers the IO surface against a `t.TempDir`:

- Round-trip preserves internal Title-precedence fields (`ShellTitle`, `AdapterTitle`) — the central correctness claim. Without this, restored sessions show the bare `Kind` instead of the resolved title.
- Full-session round-trip with `reflect.DeepEqual` against a populated `store.Session`. Catches the regression "someone added a field without a json tag": the `persistedSession` alias makes the round-trip work automatically, but only for fields that have a json tag.
- `Write` is atomic: no `.tmp-*` left behind after success. Pins down the rename-not-copy invariant so a partial-write crash can't leave files that confuse the next `Sweep`.
- `Write` is a no-op for peer sessions; rejects empty IDs.
- File mode is `0o600`, dir mode `0o700`.
- `Remove` is idempotent (removing twice or removing non-existent doesn't error).
- `Sweep` returns dead sessions, downgrades any persisted `Alive=true` to `false`, removes orphan dirs, leaves an unparseable `meta.json` in place, returns empty for missing dir.
- `Write` overwrites: a second write replaces the on-disk payload.
- `WatchRemovals` end-to-end: `session-remove` events drop the on-disk record, non-removal events don't, removals of unknown IDs are no-op, the loop terminates cleanly when the channel closes.

End-to-end smoke test verified locally for the six lifecycle paths:

1. Fast-exit `gmux --no-attach echo hi`: meta written via Register's fresh-upsert path.
2. Slug collision: a fresh live session with the same `(kind, peer, slug)` causes the store to evict the dead one. Cleanup goroutine drops the orphan meta.
3. Longer-lived session exit (SSE handler path): meta written.
4. `dismiss`: meta removed synchronously plus catches via cleanup goroutine.
5. `kill -9` the runner: 3-second `Scan` detects socket gone, persists meta.
6. Daemon restart: only the non-dismissed survivor is restored; the dismissed one stays gone.

## Deferred

- **Sweep doesn't auto-prune by age.** Per the lifecycle plan: rely on explicit dismiss; revisit once the deferred sidebar UX work lands.
- **Spoke-side persistence.** Same architecture but on the spoke. Until both sides have it, peer-owned dead sessions still vanish on the hub when the spoke restarts. Tracked separately.
- **Devcontainer parity.** Same as spoke: depends on devcontainer-side runner having the persistence hook.

## Stack

Builds on #184 (now merged). Next slice (S3) adds runner-side scrollback flush + gmuxd readonly broker, which uses this same per-session directory.
