### PR TITLE
fix(web): trim trailing whitespace and pad on terminal copy

### DIFF
--- a/apps/gmux-web/src/keyboard.ts
+++ b/apps/gmux-web/src/keyboard.ts
@@ -22,6 +22,7 @@ import {
   uploadClipboardBlob,
   type UploadResult,
 } from './clipboard-upload'
+import { selectionToText } from './selection'
 
 type SendFn = (data: string) => void
 
@@ -217,7 +218,7 @@ function executeAction(
     }
 
     case 'copyOrInterrupt': {
-      const sel = term.getSelection()
+      const sel = selectionToText(term)
       if (sel) {
         navigator.clipboard.writeText(sel)
         term.clearSelection()
@@ -228,7 +229,7 @@ function executeAction(
     }
 
     case 'copy': {
-      const sel = term.getSelection()
+      const sel = selectionToText(term)
       if (sel) {
         navigator.clipboard.writeText(sel)
         term.clearSelection()

--- a/apps/gmux-web/src/selection.test.ts
+++ b/apps/gmux-web/src/selection.test.ts
@@ -74,7 +74,7 @@ describe('selectionToText', () => {
 
   it('trims pad on triple-click / line select (end.x === cols, single row)', () => {
     // xterm's selectLineAt sets end.x = cols. We must treat that as
-    // "selection reached the row boundary" and drop the pad — otherwise
+    // "selection reached the row boundary" and drop the pad, otherwise
     // every triple-click copies a wall of spaces. Regression test for the
     // bug introduced when first trying the naive "preserve pad on last
     // row" rule.

--- a/apps/gmux-web/src/selection.test.ts
+++ b/apps/gmux-web/src/selection.test.ts
@@ -5,11 +5,17 @@ import {
   type SelectionTerminal,
 } from './selection'
 
-/** Build a fake terminal where each row is a fixed-width string padded with
- * spaces to `cols`. `wrapped` lists the y-indices that are continuations
- * of the row above (i.e. soft-wrapped rows). Selection range is in the same
- * coordinate space the test passes; the algorithm doesn't care whether it's
- * 0- or 1-based as long as inputs are consistent. */
+/**
+ * Build a fake terminal where each row has explicitly-written content
+ * followed by never-written cells (the row's "pad"). The fake's
+ * `translateToString` honors `trimRight` the same way xterm.js does: it
+ * drops trailing never-written cells from the slice, but leaves
+ * explicitly-typed spaces alone. This keeps the tests faithful to the
+ * real cell-codepoint distinction the algorithm relies on.
+ *
+ * Selection coordinates use the same 0-based, half-open-on-x convention
+ * as `Terminal.getSelectionPosition()`.
+ */
 function makeTerm(opts: {
   cols: number
   rows: string[]
@@ -17,12 +23,18 @@ function makeTerm(opts: {
   selection?: { start: { x: number, y: number }, end: { x: number, y: number } }
 }): SelectionTerminal {
   const wrapped = new Set(opts.wrapped ?? [])
-  const lines: SelectionBufferLine[] = opts.rows.map((raw, i) => {
-    const padded = raw.padEnd(opts.cols, ' ').slice(0, opts.cols)
+  const lines: SelectionBufferLine[] = opts.rows.map((written, i) => {
+    const writtenLen = Math.min(written.length, opts.cols)
+    const padded = written.padEnd(opts.cols, ' ').slice(0, opts.cols)
     return {
       isWrapped: wrapped.has(i),
-      translateToString(_trim, start = 0, end = opts.cols) {
-        return padded.slice(start, end)
+      translateToString(trim, start = 0, end = opts.cols) {
+        if (!trim) return padded.slice(start, end)
+        // Mirror xterm.js: trimRight drops never-written cells (those past
+        // `writtenLen`) from the slice's right edge. Written content,
+        // including any trailing typed spaces, is preserved.
+        const cap = Math.min(end, writtenLen)
+        return cap <= start ? '' : padded.slice(start, cap)
       },
     }
   })
@@ -40,7 +52,6 @@ describe('selectionToText', () => {
   })
 
   it('drops trailing pad when selection crosses a line break', () => {
-    // User triple-clicks line 0, drag extends to start of line 1.
     const term = makeTerm({
       cols: 20,
       rows: ['echo 1', 'echo 2'],
@@ -49,9 +60,10 @@ describe('selectionToText', () => {
     expect(selectionToText(term)).toBe('echo 1\n')
   })
 
-  it('preserves trailing spaces when selection ends mid-row inside the pad', () => {
+  it('preserves trailing pad when selection ends inside a row past content', () => {
     // User explicitly drags past EOL but stops before end of row. Those
-    // spaces are part of the selection, not part of the line break.
+    // cells render as spaces and are part of the user's selection, not
+    // part of the line break.
     const term = makeTerm({
       cols: 20,
       rows: ['echo 1'],
@@ -60,8 +72,35 @@ describe('selectionToText', () => {
     expect(selectionToText(term)).toBe('echo 1   ')
   })
 
+  it('trims pad on triple-click / line select (end.x === cols, single row)', () => {
+    // xterm's selectLineAt sets end.x = cols. We must treat that as
+    // "selection reached the row boundary" and drop the pad — otherwise
+    // every triple-click copies a wall of spaces. Regression test for the
+    // bug introduced when first trying the naive "preserve pad on last
+    // row" rule.
+    const term = makeTerm({
+      cols: 20,
+      rows: ['echo 1'],
+      selection: { start: { x: 0, y: 0 }, end: { x: 20, y: 0 } },
+    })
+    expect(selectionToText(term)).toBe('echo 1')
+  })
+
+  it('preserves explicitly-typed trailing spaces across a line break', () => {
+    // Distinguishing written-spaces from never-written pad is the whole
+    // point of using trimRight=true (which keys off cell codepoint, not
+    // the rendered character). If the user typed `echo 1   ` followed
+    // by Enter, those three spaces are content and must survive a copy
+    // that crosses the resulting line break.
+    const term = makeTerm({
+      cols: 20,
+      rows: ['echo 1   ', 'echo 2'],
+      selection: { start: { x: 0, y: 0 }, end: { x: 6, y: 1 } },
+    })
+    expect(selectionToText(term)).toBe('echo 1   \necho 2')
+  })
+
   it('joins soft-wrapped rows without inserting a newline', () => {
-    // Long shell command terminal-wrapped across two rows.
     const term = makeTerm({
       cols: 10,
       rows: ['sudo npm i', 'nstall expr'],
@@ -72,7 +111,7 @@ describe('selectionToText', () => {
     expect(selectionToText(term)).toBe('sudo npm install exp')
   })
 
-  it('keeps blank lines when they are part of the selection', () => {
+  it('keeps blank lines that are part of the selection', () => {
     const term = makeTerm({
       cols: 10,
       rows: ['line a', '', 'line b'],
@@ -88,17 +127,6 @@ describe('selectionToText', () => {
       selection: { start: { x: 6, y: 0 }, end: { x: 7, y: 1 } },
     })
     expect(selectionToText(term)).toBe('world\nfoo bar')
-  })
-
-  it('emits no padding for fully blank intermediate rows', () => {
-    // Three-row selection where the middle row is empty — the trailing
-    // pad of an empty row is the entire row, which must collapse to "".
-    const term = makeTerm({
-      cols: 30,
-      rows: ['top', '', 'bottom'],
-      selection: { start: { x: 0, y: 0 }, end: { x: 6, y: 2 } },
-    })
-    expect(selectionToText(term)).toBe('top\n\nbottom')
   })
 
   it('does not insert a newline after the last selected row', () => {

--- a/apps/gmux-web/src/selection.test.ts
+++ b/apps/gmux-web/src/selection.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest'
+import {
+  selectionToText,
+  type SelectionBufferLine,
+  type SelectionTerminal,
+} from './selection'
+
+/** Build a fake terminal where each row is a fixed-width string padded with
+ * spaces to `cols`. `wrapped` lists the y-indices that are continuations
+ * of the row above (i.e. soft-wrapped rows). Selection range is in the same
+ * coordinate space the test passes; the algorithm doesn't care whether it's
+ * 0- or 1-based as long as inputs are consistent. */
+function makeTerm(opts: {
+  cols: number
+  rows: string[]
+  wrapped?: number[]
+  selection?: { start: { x: number, y: number }, end: { x: number, y: number } }
+}): SelectionTerminal {
+  const wrapped = new Set(opts.wrapped ?? [])
+  const lines: SelectionBufferLine[] = opts.rows.map((raw, i) => {
+    const padded = raw.padEnd(opts.cols, ' ').slice(0, opts.cols)
+    return {
+      isWrapped: wrapped.has(i),
+      translateToString(_trim, start = 0, end = opts.cols) {
+        return padded.slice(start, end)
+      },
+    }
+  })
+  return {
+    cols: opts.cols,
+    buffer: { active: { getLine: y => lines[y] } },
+    getSelectionPosition: () => opts.selection,
+  }
+}
+
+describe('selectionToText', () => {
+  it('returns empty string when nothing is selected', () => {
+    const term = makeTerm({ cols: 10, rows: ['hello'] })
+    expect(selectionToText(term)).toBe('')
+  })
+
+  it('drops trailing pad when selection crosses a line break', () => {
+    // User triple-clicks line 0, drag extends to start of line 1.
+    const term = makeTerm({
+      cols: 20,
+      rows: ['echo 1', 'echo 2'],
+      selection: { start: { x: 0, y: 0 }, end: { x: 0, y: 1 } },
+    })
+    expect(selectionToText(term)).toBe('echo 1\n')
+  })
+
+  it('preserves trailing spaces when selection ends mid-row inside the pad', () => {
+    // User explicitly drags past EOL but stops before end of row. Those
+    // spaces are part of the selection, not part of the line break.
+    const term = makeTerm({
+      cols: 20,
+      rows: ['echo 1'],
+      selection: { start: { x: 0, y: 0 }, end: { x: 9, y: 0 } },
+    })
+    expect(selectionToText(term)).toBe('echo 1   ')
+  })
+
+  it('joins soft-wrapped rows without inserting a newline', () => {
+    // Long shell command terminal-wrapped across two rows.
+    const term = makeTerm({
+      cols: 10,
+      rows: ['sudo npm i', 'nstall expr'],
+      wrapped: [1],
+      selection: { start: { x: 0, y: 0 }, end: { x: 10, y: 1 } },
+    })
+    // Row 1 is "nstall expr" truncated to cols=10 → "nstall exp"
+    expect(selectionToText(term)).toBe('sudo npm install exp')
+  })
+
+  it('keeps blank lines when they are part of the selection', () => {
+    const term = makeTerm({
+      cols: 10,
+      rows: ['line a', '', 'line b'],
+      selection: { start: { x: 0, y: 0 }, end: { x: 6, y: 2 } },
+    })
+    expect(selectionToText(term)).toBe('line a\n\nline b')
+  })
+
+  it('handles a selection that starts mid-row and ends mid-row across rows', () => {
+    const term = makeTerm({
+      cols: 20,
+      rows: ['hello world', 'foo bar baz'],
+      selection: { start: { x: 6, y: 0 }, end: { x: 7, y: 1 } },
+    })
+    expect(selectionToText(term)).toBe('world\nfoo bar')
+  })
+
+  it('emits no padding for fully blank intermediate rows', () => {
+    // Three-row selection where the middle row is empty — the trailing
+    // pad of an empty row is the entire row, which must collapse to "".
+    const term = makeTerm({
+      cols: 30,
+      rows: ['top', '', 'bottom'],
+      selection: { start: { x: 0, y: 0 }, end: { x: 6, y: 2 } },
+    })
+    expect(selectionToText(term)).toBe('top\n\nbottom')
+  })
+
+  it('does not insert a newline after the last selected row', () => {
+    const term = makeTerm({
+      cols: 10,
+      rows: ['only line'],
+      selection: { start: { x: 0, y: 0 }, end: { x: 9, y: 0 } },
+    })
+    expect(selectionToText(term)).toBe('only line')
+  })
+
+  it('drops trailing pad on every non-last row when selection spans many rows', () => {
+    const term = makeTerm({
+      cols: 20,
+      rows: ['a', 'bb', 'ccc'],
+      selection: { start: { x: 0, y: 0 }, end: { x: 3, y: 2 } },
+    })
+    expect(selectionToText(term)).toBe('a\nbb\nccc')
+  })
+})

--- a/apps/gmux-web/src/selection.ts
+++ b/apps/gmux-web/src/selection.ts
@@ -3,17 +3,17 @@
  *
  * Terminal-buffer-to-text models, summarised:
  *
- * 1. "Trim everything" — strip trailing whitespace from every copied line.
+ * 1. "Trim everything": strip trailing whitespace from every copied line.
  *    Loses information when the user genuinely wants to copy spaces typed
  *    into a row. Ghostty's `clipboard-trim-trailing-spaces` option works
  *    this way and its own community considers it a smell
  *    (ghostty-org/ghostty#2709).
  *
- * 2. "Trim never" — emit cells verbatim. Wall of trailing spaces after
+ * 2. "Trim never": emit cells verbatim. Wall of trailing spaces after
  *    every short line, because the cells past the content render as
  *    spaces. xterm.js' default `getSelection()` lands here in many cases.
  *
- * 3. **"Trailing pad belongs to the line break"** — Terminal.app, Alacritty,
+ * 3. **"Trailing pad belongs to the line break"**: Terminal.app, Alacritty,
  *    WezTerm, GNOME Terminal, xterm. Selections that *cross* a row boundary
  *    drop the trailing pad of the row before emitting `\n`. Selections that
  *    *end inside* a row preserve the cells the user actually dragged

--- a/apps/gmux-web/src/selection.ts
+++ b/apps/gmux-web/src/selection.ts
@@ -4,33 +4,48 @@
  * Terminal-buffer-to-text models, summarised:
  *
  * 1. "Trim everything" — strip trailing whitespace from every copied line.
- *    Loses information when the user genuinely wants to copy padding (e.g.
- *    selecting inside a TUI cell). Ghostty's `clipboard-trim-trailing-spaces`
- *    option works this way and its own community considers it a smell
+ *    Loses information when the user genuinely wants to copy spaces typed
+ *    into a row. Ghostty's `clipboard-trim-trailing-spaces` option works
+ *    this way and its own community considers it a smell
  *    (ghostty-org/ghostty#2709).
  *
- * 2. "Trim never" — emit cells verbatim. Wall of trailing spaces after every
- *    short line. xterm.js' default `getSelection()` lands here in many cases.
+ * 2. "Trim never" — emit cells verbatim. Wall of trailing spaces after
+ *    every short line, because the cells past the content render as
+ *    spaces. xterm.js' default `getSelection()` lands here in many cases.
  *
  * 3. **"Trailing pad belongs to the line break"** — Terminal.app, Alacritty,
  *    WezTerm, GNOME Terminal, xterm. Selections that *cross* a row boundary
  *    drop the trailing pad of the row before emitting `\n`. Selections that
- *    *end inside* a row preserve the cells the user actually dragged across,
- *    spaces included. This is what people mean when they say "no trailing
- *    whitespace on copy", and it's the model gmux implements here.
+ *    *end inside* a row preserve the cells the user actually dragged
+ *    across, spaces included. This is what people mean when they say "no
+ *    trailing whitespace on copy", and it's the model gmux implements.
+ *
+ * Why xterm.js' `trimRight` parameter is the right primitive: it trims by
+ * cell *codepoint* (0 = never written) rather than by rendered character,
+ * so it cleanly distinguishes never-written pad cells from explicitly-typed
+ * spaces, and is automatically wide-character-aware.
  *
  * Soft wraps (terminal-driven, signalled by `IBufferLine.isWrapped` on the
  * following row) are joined without an inserted `\n`, matching every modern
  * terminal. TUI-driven wraps (Vim, tmux, Claude Code, pi, …) are
- * indistinguishable from hard newlines in the buffer and therefore copy as
- * separate lines. No terminal can recover those without app cooperation.
+ * indistinguishable from hard newlines in the buffer and copy as separate
+ * lines. No terminal can recover those without app cooperation.
+ *
+ * Coordinate notes (xterm.js 6.x): `getSelectionPosition` returns 0-based
+ * `x` and `y`, where `y` is an absolute buffer row index (compatible with
+ * `buffer.active.getLine`) and `x` is half-open on the right (`x === cols`
+ * means "past last column"). The public typings claim 1-based, but the
+ * runtime behavior is 0-based; verified against the bundled source.
  */
 
-/** Minimal terminal surface needed for selection-to-text. Matches the shape
- * of `@xterm/xterm`'s public API but typed locally so the algorithm can be
+/** Minimal terminal surface needed for selection-to-text. Subset of
+ * `@xterm/xterm`'s public API, redeclared locally so the algorithm can be
  * unit-tested with hand-rolled fakes. */
 export interface SelectionBufferLine {
   readonly isWrapped: boolean
+  /** Slice the line as a string. With `trimRight=true`, never-written
+   * trailing cells inside the slice are dropped (pad stripping). Written
+   * spaces are preserved either way. */
   translateToString(trimRight: boolean, startColumn?: number, endColumn?: number): string
 }
 
@@ -62,23 +77,18 @@ export function selectionToText(term: SelectionTerminal): string {
     if (!line) continue
 
     const isLast = y === end.y
-    const isFirst = y === start.y
-    const sx = isFirst ? start.x : 0
+    const sx = y === start.y ? start.x : 0
     const ex = isLast ? end.x : cols
 
-    // Logical content extent: last non-space column on the row. The cells
-    // beyond this are the row's "trailing pad" and conceptually belong to
-    // the line break, not to the line.
-    const full = line.translateToString(false, 0, cols)
-    let contentEnd = full.length
-    while (contentEnd > 0 && full.charCodeAt(contentEnd - 1) === 0x20) contentEnd--
-
-    // Last selected row: emit cells exactly as the user dragged. If they
-    // dragged into the trailing pad we keep those spaces — that's an
-    // explicit selection of padding, distinct from crossing a line break.
-    // Earlier rows: clip to contentEnd so the pad is dropped before \n.
-    const cutEx = isLast ? ex : Math.min(ex, Math.max(contentEnd, sx))
-    if (cutEx > sx) out += line.translateToString(false, sx, cutEx)
+    // Trim trailing pad when the row's selection reaches the row boundary
+    // (`ex >= cols`). That covers every non-last row, plus the last row
+    // when the user selected past EOL (triple-click, line-select, drag
+    // through the line break). When the user stopped *inside* the row we
+    // preserve the cells they dragged across, including any pad spaces:
+    // that's an explicit selection of padding, semantically distinct from
+    // crossing a line break.
+    const trim = ex >= cols
+    if (ex > sx) out += line.translateToString(trim, sx, ex)
 
     if (!isLast) {
       // Soft wrap: next row continues this one, suppress the newline.

--- a/apps/gmux-web/src/selection.ts
+++ b/apps/gmux-web/src/selection.ts
@@ -1,0 +1,90 @@
+/**
+ * Convert an xterm.js selection to a clipboard string.
+ *
+ * Terminal-buffer-to-text models, summarised:
+ *
+ * 1. "Trim everything" — strip trailing whitespace from every copied line.
+ *    Loses information when the user genuinely wants to copy padding (e.g.
+ *    selecting inside a TUI cell). Ghostty's `clipboard-trim-trailing-spaces`
+ *    option works this way and its own community considers it a smell
+ *    (ghostty-org/ghostty#2709).
+ *
+ * 2. "Trim never" — emit cells verbatim. Wall of trailing spaces after every
+ *    short line. xterm.js' default `getSelection()` lands here in many cases.
+ *
+ * 3. **"Trailing pad belongs to the line break"** — Terminal.app, Alacritty,
+ *    WezTerm, GNOME Terminal, xterm. Selections that *cross* a row boundary
+ *    drop the trailing pad of the row before emitting `\n`. Selections that
+ *    *end inside* a row preserve the cells the user actually dragged across,
+ *    spaces included. This is what people mean when they say "no trailing
+ *    whitespace on copy", and it's the model gmux implements here.
+ *
+ * Soft wraps (terminal-driven, signalled by `IBufferLine.isWrapped` on the
+ * following row) are joined without an inserted `\n`, matching every modern
+ * terminal. TUI-driven wraps (Vim, tmux, Claude Code, pi, …) are
+ * indistinguishable from hard newlines in the buffer and therefore copy as
+ * separate lines. No terminal can recover those without app cooperation.
+ */
+
+/** Minimal terminal surface needed for selection-to-text. Matches the shape
+ * of `@xterm/xterm`'s public API but typed locally so the algorithm can be
+ * unit-tested with hand-rolled fakes. */
+export interface SelectionBufferLine {
+  readonly isWrapped: boolean
+  translateToString(trimRight: boolean, startColumn?: number, endColumn?: number): string
+}
+
+export interface SelectionBuffer {
+  getLine(y: number): SelectionBufferLine | undefined
+}
+
+export interface SelectionTerminal {
+  readonly cols: number
+  readonly buffer: { readonly active: SelectionBuffer }
+  getSelectionPosition(): { start: { x: number, y: number }, end: { x: number, y: number } } | undefined
+}
+
+/**
+ * Render the active selection as a clipboard string using the
+ * trailing-pad-as-line-break model. Returns `''` when there is no selection.
+ */
+export function selectionToText(term: SelectionTerminal): string {
+  const range = term.getSelectionPosition()
+  if (!range) return ''
+
+  const { start, end } = range
+  const buffer = term.buffer.active
+  const cols = term.cols
+
+  let out = ''
+  for (let y = start.y; y <= end.y; y++) {
+    const line = buffer.getLine(y)
+    if (!line) continue
+
+    const isLast = y === end.y
+    const isFirst = y === start.y
+    const sx = isFirst ? start.x : 0
+    const ex = isLast ? end.x : cols
+
+    // Logical content extent: last non-space column on the row. The cells
+    // beyond this are the row's "trailing pad" and conceptually belong to
+    // the line break, not to the line.
+    const full = line.translateToString(false, 0, cols)
+    let contentEnd = full.length
+    while (contentEnd > 0 && full.charCodeAt(contentEnd - 1) === 0x20) contentEnd--
+
+    // Last selected row: emit cells exactly as the user dragged. If they
+    // dragged into the trailing pad we keep those spaces — that's an
+    // explicit selection of padding, distinct from crossing a line break.
+    // Earlier rows: clip to contentEnd so the pad is dropped before \n.
+    const cutEx = isLast ? ex : Math.min(ex, Math.max(contentEnd, sx))
+    if (cutEx > sx) out += line.translateToString(false, sx, cutEx)
+
+    if (!isLast) {
+      // Soft wrap: next row continues this one, suppress the newline.
+      const next = buffer.getLine(y + 1)
+      if (!next?.isWrapped) out += '\n'
+    }
+  }
+  return out
+}


### PR DESCRIPTION
## Problem

Copying text from the terminal includes a significant amount of trailing whitespace. xterm.js's `getSelection()` doesn't consistently trim cells that were never written, and for full-rendered rows it has no way to know which spaces are intentional content vs. row padding.

## Approach

Replace both `term.getSelection()` callers in `keyboard.ts` with a new `selectionToText(term)` that walks the active buffer directly, using the **"trailing pad belongs to the line break"** model used by Terminal.app, Alacritty, WezTerm, GNOME Terminal, and xterm:

- Selections that **cross** a row boundary (or reach `end.x === cols`, e.g. triple-click) drop the trailing pad of the row before emitting `\n`.
- Selections that **end inside** a row preserve the cells the user dragged across, spaces included.
- Soft-wrapped rows (xterm.js's `isWrapped` flag) are joined without an inserted `\n`, matching every modern terminal.

Implementation leans on xterm.js's `translateToString(trimRight=true, ...)`, which trims by cell *codepoint* (`0` = never written) rather than by rendered character. That cleanly distinguishes never-written pad cells from explicitly-typed spaces and is automatically wide-character-aware. The whole algorithm is `trim = ex >= cols`, then one `translateToString(trim, sx, ex)` per row plus the `\n`/soft-wrap decision.

This is deliberately not a config toggle. Ghostty's `clipboard-trim-trailing-spaces` option is considered a smell by its own community ([ghostty-org/ghostty#2709](https://github.com/ghostty-org/ghostty/discussions/2709)) because it conflates two different things; the row-extent model handles both correctly.

## Scope

Fixes the trailing-whitespace pain for shell output and any program that lets the terminal do the wrapping.

**Does not** fix copying from full-screen TUIs (vim, tmux, Claude Code, pi, btop, fzf, …). Those programs draw their own wraps via cursor positioning, so each visual row is a hard newline in the buffer, indistinguishable from a real line break. No terminal recovers source text from a TUI's rendered screen without app cooperation; this is an information-loss problem at the protocol layer (cf. [ghostty-org/ghostty#11215](https://github.com/ghostty-org/ghostty/discussions/11215), [#7962](https://github.com/ghostty-org/ghostty/discussions/7962), [#2780](https://github.com/ghostty-org/ghostty/discussions/2780)).

## Coordinate-system note

`getSelectionPosition()`'s public typings claim 1-based coordinates, but the runtime returns 0-based values directly (verified against the bundled xterm.js source). `start.y`/`end.y` are absolute buffer indices, compatible with `buffer.active.getLine`. The implementation file documents this so future maintainers don't lose an hour to it.

## Tests

`selection.test.ts`, 10 cases. The fake `Terminal` honors `trimRight` the same way xterm.js does (drops never-written cells from the slice's right edge while preserving explicitly-typed spaces), so the tests faithfully exercise the algorithm's real dependency:

- empty selection
- selection crosses a line break → drops pad
- selection ends inside a row past content → preserves pad
- **triple-click / line select (`end.x === cols`, single row)** → trims pad, no `\n` (regression test for first-pass bug)
- **explicitly-typed trailing spaces preserved across a line break** (verifies the codepoint-vs-character distinction)
- soft-wrap rejoin (`isWrapped`) without `\n`
- blank intermediate rows preserved
- mid-row to mid-row across rows
- single-row selection has no trailing `\n`
- multi-row selection with varying content lengths

`selectionToText` is typed against a minimal `SelectionTerminal` interface (subset of `@xterm/xterm`'s `Terminal`) so tests use plain object fakes, no DOM or xterm-headless dependency.