### PR TITLE
feat: image and binary clipboard paste into sessions

### DIFF
--- a/apps/gmux-web/src/clipboard-upload.test.ts
+++ b/apps/gmux-web/src/clipboard-upload.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  MAX_CLIPBOARD_BYTES,
+  firstBinaryType,
+  uploadClipboardBlob,
+  type UploadResult,
+} from './clipboard-upload'
+
+describe('firstBinaryType', () => {
+  it('returns the first non-text MIME', () => {
+    expect(firstBinaryType(['text/plain', 'image/png', 'text/html'])).toBe('image/png')
+  })
+
+  it('returns null when only text MIMEs are present', () => {
+    expect(firstBinaryType(['text/plain', 'text/html', 'text/uri-list'])).toBe(null)
+  })
+
+  it('returns null on empty input', () => {
+    expect(firstBinaryType([])).toBe(null)
+  })
+
+  it('treats image/svg+xml as binary even though it is structurally textual', () => {
+    // An SVG copied from a graphics app is the user's intended payload;
+    // upload preserves intent. Same reasoning as image/png: prefer binary
+    // when binary is present.
+    expect(firstBinaryType(['text/plain', 'image/svg+xml'])).toBe('image/svg+xml')
+  })
+
+  it('preserves order: first non-text wins', () => {
+    expect(firstBinaryType(['image/png', 'image/jpeg'])).toBe('image/png')
+    expect(firstBinaryType(['image/jpeg', 'image/png'])).toBe('image/jpeg')
+  })
+})
+
+describe('uploadClipboardBlob', () => {
+  const originalFetch = globalThis.fetch
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  function makeBlob(size: number, type = 'image/png'): Blob {
+    return new Blob([new Uint8Array(size)], { type })
+  }
+
+  it('rejects oversized blobs without calling fetch', async () => {
+    const fetchSpy = vi.fn()
+    globalThis.fetch = fetchSpy as unknown as typeof fetch
+
+    const blob = makeBlob(MAX_CLIPBOARD_BYTES + 1)
+    const result = await uploadClipboardBlob(blob, 'sess-1')
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toBe('too_large')
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('POSTs to the session-scoped endpoint with the blob MIME and bytes', async () => {
+    let captured: { url: string; init: RequestInit } | null = null
+    globalThis.fetch = (async (url: string, init: RequestInit) => {
+      captured = { url, init }
+      return new Response(
+        JSON.stringify({ ok: true, data: { path: '/tmp/paste-1.png' } }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      )
+    }) as unknown as typeof fetch
+
+    const blob = makeBlob(64, 'image/png')
+    const result = await uploadClipboardBlob(blob, 'sess-1')
+
+    expect(result).toEqual<UploadResult>({ ok: true, path: '/tmp/paste-1.png' })
+    expect(captured!.url).toBe('/v1/sessions/sess-1/clipboard')
+    expect(captured!.init.method).toBe('POST')
+    const headers = new Headers(captured!.init.headers)
+    expect(headers.get('Content-Type')).toBe('image/png')
+    expect(captured!.init.body).toBe(blob)
+  })
+
+  it('maps server error JSON to a recognizable error string', async () => {
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({ ok: false, error: { code: 'too_large', message: 'too big' } }),
+        { status: 413, headers: { 'Content-Type': 'application/json' } },
+      )) as unknown as typeof fetch
+
+    const result = await uploadClipboardBlob(makeBlob(64), 'sess-1')
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toBe('too_large')
+  })
+
+  it('falls back to a generic error when the response has no error code', async () => {
+    globalThis.fetch = (async () =>
+      new Response('upstream exploded', { status: 500 })) as unknown as typeof fetch
+
+    const result = await uploadClipboardBlob(makeBlob(64), 'sess-1')
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toBe('server_error')
+  })
+
+  it('reports network failure distinctly from server errors', async () => {
+    globalThis.fetch = (async () => {
+      throw new TypeError('Failed to fetch')
+    }) as unknown as typeof fetch
+
+    const result = await uploadClipboardBlob(makeBlob(64), 'sess-1')
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toBe('network')
+  })
+
+  it('URL-encodes the session id', async () => {
+    let capturedURL = ''
+    globalThis.fetch = (async (url: string) => {
+      capturedURL = url
+      return new Response(JSON.stringify({ ok: true, data: { path: '/tmp/paste-1.png' } }))
+    }) as unknown as typeof fetch
+
+    await uploadClipboardBlob(makeBlob(64), 'has spaces/and/slashes')
+    expect(capturedURL).toBe('/v1/sessions/has%20spaces%2Fand%2Fslashes/clipboard')
+  })
+})

--- a/apps/gmux-web/src/clipboard-upload.ts
+++ b/apps/gmux-web/src/clipboard-upload.ts
@@ -1,0 +1,125 @@
+/**
+ * Clipboard binary upload helper.
+ *
+ * Materializes a non-text clipboard payload as a file on the gmuxd
+ * that owns the session, returning the absolute path the caller should
+ * type into the PTY. Owns: web-side size cap, MIME header, error
+ * categorization. Does not own: clipboard inspection, blob extraction,
+ * permission prompting, path injection — those belong to the call
+ * sites in keyboard.ts.
+ *
+ * Mirrors the daemon-side cap in services/gmuxd/cmd/gmuxd/clipboard.go
+ * (MaxClipboardBytes). Web-side enforcement avoids uploading bytes
+ * that will be rejected; server-side enforcement is the safety floor.
+ */
+
+export const MAX_CLIPBOARD_BYTES = 10 * 1024 * 1024
+
+export type UploadResult =
+  | { ok: true; path: string }
+  | { ok: false; error: UploadError }
+
+/**
+ * Categorical error codes for upload failures. The values are stable
+ * identifiers callers can switch on for toast copy; they are deliberately
+ * not user-facing strings.
+ */
+export type UploadError =
+  | 'too_large'
+  | 'network'
+  | 'server_error'
+  | 'empty_body'
+  | string // server-supplied codes (e.g. 'write_failed')
+
+/**
+ * Returns the first MIME from `types` that is not `text/*`, or null if
+ * the clipboard offers only text representations. Captures the
+ * "binary intent wins over text fallback" rule from the design doc:
+ * a clipboard with both an image and an alt-text representation is
+ * treated as image paste.
+ */
+export function firstBinaryType(types: readonly string[]): string | null {
+  for (const t of types) {
+    if (!t.startsWith('text/')) return t
+  }
+  return null
+}
+
+/**
+ * POST a clipboard binary payload to the session's clipboard endpoint
+ * and return the materialized path.
+ *
+ * Errors are returned as UploadResult rather than thrown: every code
+ * path produces a value the caller can inspect to decide between
+ * "type the path" and "show a toast".
+ */
+export async function uploadClipboardBlob(
+  blob: Blob,
+  sessionId: string,
+): Promise<UploadResult> {
+  if (blob.size > MAX_CLIPBOARD_BYTES) {
+    return { ok: false, error: 'too_large' }
+  }
+
+  const url = `/v1/sessions/${encodeURIComponent(sessionId)}/clipboard`
+
+  let resp: Response
+  try {
+    resp = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': blob.type || 'application/octet-stream' },
+      body: blob,
+    })
+  } catch {
+    return { ok: false, error: 'network' }
+  }
+
+  // Try to parse the body regardless of status: success bodies carry
+  // the path, error bodies carry the code. A non-JSON body from
+  // either a 2xx or non-2xx response means the daemon broke its
+  // contract; we collapse both to 'server_error'.
+  let parsed: unknown = null
+  try {
+    parsed = await resp.json()
+  } catch {
+    return { ok: false, error: 'server_error' }
+  }
+
+  if (resp.ok && isOkPayload(parsed)) {
+    return { ok: true, path: parsed.data.path }
+  }
+
+  if (isErrorPayload(parsed)) {
+    return { ok: false, error: parsed.error.code || 'server_error' }
+  }
+
+  return { ok: false, error: 'server_error' }
+}
+
+interface OkPayload {
+  ok: true
+  data: { path: string }
+}
+
+interface ErrorPayload {
+  ok: false
+  error: { code: string; message?: string }
+}
+
+function isOkPayload(v: unknown): v is OkPayload {
+  if (typeof v !== 'object' || v === null) return false
+  const r = v as Record<string, unknown>
+  if (r.ok !== true) return false
+  const data = r.data
+  if (typeof data !== 'object' || data === null) return false
+  return typeof (data as Record<string, unknown>).path === 'string'
+}
+
+function isErrorPayload(v: unknown): v is ErrorPayload {
+  if (typeof v !== 'object' || v === null) return false
+  const r = v as Record<string, unknown>
+  if (r.ok !== false) return false
+  const err = r.error
+  if (typeof err !== 'object' || err === null) return false
+  return typeof (err as Record<string, unknown>).code === 'string'
+}

--- a/apps/gmux-web/src/keyboard.test.ts
+++ b/apps/gmux-web/src/keyboard.test.ts
@@ -1,5 +1,60 @@
 import { describe, it, expect } from 'vitest'
-import { ctrlSequenceFor, formatPasteText } from './keyboard'
+import { ctrlSequenceFor, formatPasteText, pickBinaryDataTransferItem } from './keyboard'
+
+// Build an array-like stand-in for DataTransferItemList. Vitest runs in
+// node by default, where the real DOM type isn't available; a plain
+// indexed object with .length matches what the function actually reads.
+function makeItems(
+  entries: ReadonlyArray<{ kind: 'string' | 'file'; type: string }>,
+): DataTransferItemList {
+  const list: Record<string | number, unknown> = { length: entries.length }
+  entries.forEach((e, i) => {
+    list[i] = { ...e, getAsFile: () => null, getAsString: () => undefined }
+  })
+  return list as unknown as DataTransferItemList
+}
+
+describe('pickBinaryDataTransferItem', () => {
+  it('returns the first file with a non-text MIME', () => {
+    const items = makeItems([
+      { kind: 'string', type: 'text/plain' },
+      { kind: 'file', type: 'image/png' },
+      { kind: 'file', type: 'image/jpeg' },
+    ])
+    expect(pickBinaryDataTransferItem(items)?.type).toBe('image/png')
+  })
+
+  it('skips kind=string even when the MIME is non-text', () => {
+    // A 'string' item's getAsFile() returns null; uploading it would
+    // produce a confusing failure-toast race. The kind check is what
+    // prevents that.
+    const items = makeItems([{ kind: 'string', type: 'application/json' }])
+    expect(pickBinaryDataTransferItem(items)).toBe(null)
+  })
+
+  it('skips kind=file when the MIME is text/*', () => {
+    // Some browsers expose dragged .txt files as kind='file' with type
+    // 'text/plain'. We treat those as text and let the existing text
+    // paste path handle them, not the binary upload path.
+    const items = makeItems([{ kind: 'file', type: 'text/plain' }])
+    expect(pickBinaryDataTransferItem(items)).toBe(null)
+  })
+
+  it('returns null on empty list', () => {
+    expect(pickBinaryDataTransferItem(makeItems([]))).toBe(null)
+  })
+
+  it('returns the first qualifying file even when later items are also binary', () => {
+    // Order matters: the function must not pick "the most preferred"
+    // image type, just the first qualifying one. Browsers are responsible
+    // for ordering the representations sensibly.
+    const items = makeItems([
+      { kind: 'file', type: 'image/jpeg' },
+      { kind: 'file', type: 'image/png' },
+    ])
+    expect(pickBinaryDataTransferItem(items)?.type).toBe('image/jpeg')
+  })
+})
 
 describe('formatPasteText', () => {
   // ── Bracketed paste mode ──────────────────────────────────────────────────

--- a/apps/gmux-web/src/keyboard.ts
+++ b/apps/gmux-web/src/keyboard.ts
@@ -17,6 +17,11 @@ import {
   keyComboToSequence,
   type ResolvedKeybind,
 } from './config'
+import {
+  firstBinaryType,
+  uploadClipboardBlob,
+  type UploadResult,
+} from './clipboard-upload'
 
 type SendFn = (data: string) => void
 
@@ -46,12 +51,72 @@ function isTouchDevice(): boolean {
  * API. Non-keyboard paste (right-click, middle-click, mobile paste button)
  * is handled separately by attachPasteHandler via the DOM paste event.
  */
+/**
+ * Optional feedback channel for clipboard upload outcomes. Callers can
+ * route this to a toast surface; the default is a `console` fallback so
+ * silent failures aren't possible. Kept as a callback to keep keyboard.ts
+ * neutral about the UI surface.
+ */
+export type PasteFeedback = (kind: 'info' | 'error', message: string) => void
+
+/**
+ * Default paste-feedback sink: routes errors to console.warn and info
+ * messages to console.log under a `[paste]` tag. Exported so callers
+ * that don't have their own toast UI yet can opt into the same console
+ * shape used by `attachKeyboardHandler` and `attachPasteHandler`.
+ */
+export const defaultPasteFeedback: PasteFeedback = (kind, message) => {
+  if (kind === 'error') console.warn('[paste]', message)
+  else console.log('[paste]', message)
+}
+
+/**
+ * Bind clipboard upload outcome to keyboard.ts call sites. Returns the
+ * input bytes to type into the PTY on success, or null on failure (after
+ * surfacing the error via feedback).
+ */
+async function uploadAndFormatPath(
+  blob: Blob,
+  sessionId: string,
+  bracketedPasteMode: boolean,
+  feedback: PasteFeedback,
+): Promise<string | null> {
+  const result: UploadResult = await uploadClipboardBlob(blob, sessionId)
+  if (!result.ok) {
+    feedback('error', pasteErrorMessage(result.error))
+    return null
+  }
+  feedback('info', `Pasted to ${result.path}`)
+  return formatPasteText(result.path, bracketedPasteMode)
+}
+
+function pasteErrorMessage(code: string): string {
+  switch (code) {
+    case 'too_large':
+      return 'Clipboard item too large (limit 10MB)'
+    case 'network':
+      return 'Paste failed: gmuxd unreachable'
+    case 'empty_body':
+      return 'Clipboard item is empty'
+    case 'not_found':
+      return 'Paste failed: session not found'
+    case 'write_failed':
+      return 'Paste failed: could not write file'
+    case 'server_error':
+      return 'Paste failed: server error'
+    default:
+      return `Paste failed: ${code}`
+  }
+}
+
 export function attachKeyboardHandler(
   term: Terminal,
   send: SendFn,
   sendRaw: SendFn,
   keybinds: ResolvedKeybind[],
   macCommandIsCtrl = false,
+  sessionId = '',
+  onPasteFeedback: PasteFeedback = defaultPasteFeedback,
 ): void {
   term.attachCustomKeyEventHandler((ev: KeyboardEvent) => {
     // Mobile Enter → newline (not submit).
@@ -84,7 +149,7 @@ export function attachKeyboardHandler(
 
       for (const kb of keybinds) {
         if (!eventMatchesKeybind(virtualMods, kb)) continue
-        const handled = executeAction(kb, term, send, sendRaw)
+        const handled = executeAction(kb, term, send, sendRaw, sessionId, onPasteFeedback)
         if (handled) { ev.preventDefault(); return false }
       }
 
@@ -102,7 +167,7 @@ export function attachKeyboardHandler(
       // For shift+enter we need to block all event types (keydown, keypress,
       // keyup) to prevent the Kitty keyboard protocol sequence from leaking.
       if (kb.baseKey === 'enter' && kb.shift) {
-        if (ev.type === 'keydown') executeAction(kb, term, send, sendRaw)
+        if (ev.type === 'keydown') executeAction(kb, term, send, sendRaw, sessionId, onPasteFeedback)
         ev.preventDefault()
         return false
       }
@@ -110,7 +175,7 @@ export function attachKeyboardHandler(
       // For other bindings, only act on keydown.
       if (ev.type !== 'keydown') return true
 
-      const handled = executeAction(kb, term, send, sendRaw)
+      const handled = executeAction(kb, term, send, sendRaw, sessionId, onPasteFeedback)
       if (handled) {
         // Prevent browser default (e.g. Cmd+Left navigating back on Mac).
         // xterm.js does not call preventDefault when the custom handler
@@ -137,6 +202,8 @@ function executeAction(
   term: Terminal,
   send: SendFn,
   sendRaw: SendFn,
+  sessionId: string,
+  onPasteFeedback: PasteFeedback,
 ): boolean {
   switch (kb.action) {
     case 'sendText':
@@ -172,17 +239,19 @@ function executeAction(
     }
 
     case 'paste': {
-      // Read from the Clipboard API and send to the PTY. Uses sendRaw to
-      // bypass mobile ctrl/alt arm logic (same as the DOM paste handler).
-      // Requires clipboard-read permission in a secure context with a user
-      // gesture (keydown qualifies). Falls back with a console warning if
-      // the browser denies access.
-      navigator.clipboard.readText().then(text => {
-        if (text) {
-          sendRaw(formatPasteText(text, term.modes.bracketedPasteMode))
-        }
-      }).catch((err) => {
-        console.warn('Paste failed: clipboard access denied.', err)
+      // Inspect the clipboard for binary content first; binary always
+      // wins over text (see PRD). Falls back to readText() when only
+      // text/* representations are present, preserving prior behavior.
+      // Both branches use sendRaw to bypass mobile ctrl/alt arm logic.
+      //
+      // Requires clipboard-read permission in a secure context. The
+      // keydown counts as a user gesture. Permission denial is reported
+      // via onPasteFeedback so users see why nothing happened.
+      void handlePasteAction({
+        sessionId,
+        bracketedPasteMode: term.modes.bracketedPasteMode,
+        feedback: onPasteFeedback,
+        emit: sendRaw,
       })
       return true
     }
@@ -276,27 +345,146 @@ export function formatPasteText(text: string, bracketedPasteMode: boolean): stri
  * - We need to own the bracketed-paste / newline conversion ourselves so it is
  *   always correct regardless of what mobile modifier state is active.
  *
- * `send` should be sendRawInput (not sendInput) so that paste is never
- * transformed by the ctrl/alt modifier logic.
+ * The `sendRaw` parameter must be sendRawInput (not sendInput) so that
+ * paste is never transformed by the ctrl/alt modifier logic. The name
+ * encodes the contract: the keybind paste action takes the same care
+ * (see executeAction's `case 'paste'`).
  *
  * Returns a cleanup function.
  */
 export function attachPasteHandler(
   term: Terminal,
   container: HTMLElement,
-  send: SendFn,
+  sendRaw: SendFn,
+  sessionId = '',
+  onPasteFeedback: PasteFeedback = defaultPasteFeedback,
 ): () => void {
   const handler = (ev: ClipboardEvent) => {
-    const text = ev.clipboardData?.getData('text/plain') ?? ''
+    const data = ev.clipboardData
+    if (!data) return
+
+    // Binary takes precedence: scan items for the first non-text MIME
+    // and route to the upload helper. Pull the Blob synchronously
+    // before the event handler returns; clipboardData becomes invalid
+    // after.
+    const binaryItem = pickBinaryDataTransferItem(data.items)
+    if (binaryItem) {
+      const blob = binaryItem.getAsFile()
+      ev.stopPropagation()
+      ev.preventDefault()
+      if (!blob) {
+        onPasteFeedback('error', 'Paste failed: could not read clipboard item')
+        return
+      }
+      if (!sessionId) {
+        onPasteFeedback('error', 'Paste failed: no session bound')
+        return
+      }
+      void uploadAndFormatPath(blob, sessionId, term.modes.bracketedPasteMode, onPasteFeedback)
+        .then(out => { if (out !== null) sendRaw(out) })
+      return
+    }
+
+    const text = data.getData('text/plain') ?? ''
     if (!text) return
 
     // Stop the event before it reaches xterm's textarea listener.
     ev.stopPropagation()
     ev.preventDefault()
 
-    send(formatPasteText(text, term.modes.bracketedPasteMode))
+    sendRaw(formatPasteText(text, term.modes.bracketedPasteMode))
   }
 
   container.addEventListener('paste', handler, { capture: true })
   return () => container.removeEventListener('paste', handler, { capture: true })
+}
+
+/**
+ * Walk a DataTransferItemList and return the first item whose kind is
+ * 'file' and whose MIME is not text/*. Returns null if no such item
+ * exists or the list is empty.
+ *
+ * Two predicates, both load-bearing:
+ *  - `kind === 'file'` excludes 'string' items (their getAsFile() is
+ *    always null and their bytes live in getAsString()'s callback).
+ *  - non-text/* implements the "binary intent wins" rule: a clipboard
+ *    with both an image and its alt-text representation surfaces the
+ *    image.
+ *
+ * Exported for testability; the rule is small but the cost of getting
+ * it subtly wrong (e.g. uploading a string-kind item that returns null
+ * from getAsFile) is a confusing failure-toast race.
+ */
+export function pickBinaryDataTransferItem(items: DataTransferItemList): DataTransferItem | null {
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i]
+    if (item.kind === 'file' && !item.type.startsWith('text/')) return item
+  }
+  return null
+}
+
+/**
+ * Read the system clipboard via the Clipboard API and route binary
+ * payloads to the upload helper, falling back to text extracted from
+ * the same clipboard items (no second clipboard read). Mirrors the
+ * DOM paste handler's shape so both entry points behave identically.
+ *
+ * `navigator.clipboard.read()` is missing on a few browsers (Firefox
+ * default config, older Safari) and may throw on text-only clipboards
+ * in some Chromium builds. Both cases fall back to `readText()`.
+ *
+ * Exported so the mobile toolbar paste button can reuse the exact same
+ * inspect-and-route logic as the keybind path. Without this, the mobile
+ * button would be text-only.
+ */
+export async function handlePasteAction(args: {
+  sessionId: string
+  bracketedPasteMode: boolean
+  feedback: PasteFeedback
+  emit: SendFn
+}): Promise<void> {
+  const { sessionId, bracketedPasteMode, feedback, emit } = args
+  const reader = navigator.clipboard
+
+  if (typeof reader?.read === 'function') {
+    let items: ClipboardItems | null = null
+    try {
+      items = await reader.read()
+    } catch {
+      // read() unavailable in this state; fall through to readText().
+    }
+    if (items !== null) {
+      // Binary intent wins.
+      for (const item of items) {
+        const binMime = firstBinaryType(item.types)
+        if (!binMime) continue
+        const blob = await item.getType(binMime)
+        if (!sessionId) {
+          feedback('error', 'Paste failed: no session bound')
+          return
+        }
+        const out = await uploadAndFormatPath(blob, sessionId, bracketedPasteMode, feedback)
+        if (out !== null) emit(out)
+        return
+      }
+      // No binary; extract text from the items we already have so we
+      // don't trigger a second clipboard permission prompt.
+      for (const item of items) {
+        if (!item.types.includes('text/plain')) continue
+        const blob = await item.getType('text/plain')
+        const text = await blob.text()
+        if (text) emit(formatPasteText(text, bracketedPasteMode))
+        return
+      }
+      return // clipboard had only types we don't handle
+    }
+  }
+
+  try {
+    const text = await reader.readText()
+    if (text) emit(formatPasteText(text, bracketedPasteMode))
+  } catch (err) {
+    feedback('error', 'Paste failed: clipboard access denied')
+    console.warn('Paste failed: clipboard access denied.', err)
+  }
 }

--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -365,7 +365,7 @@ function App() {
 
   const terminalInputRef = useRef<((data: string) => void) | null>(null)
   const terminalFocusRef = useRef<(() => void) | null>(null)
-  const terminalPasteRef = useRef<((text: string) => void) | null>(null)
+  const terminalPasteRef = useRef<(() => void) | null>(null)
 
   // Read signals.
   const viewVal = view.value
@@ -438,14 +438,14 @@ function App() {
   }, [])
   const handleFocusTerminal = useCallback(() => { terminalFocusRef.current?.() }, [])
   const handleMobileInput = useCallback((data: string) => { terminalInputRef.current?.(data) }, [])
-  const handleTerminalPasteReady = useCallback((paste: ((text: string) => void) | null) => {
+  const handleTerminalPasteReady = useCallback((paste: (() => void) | null) => {
     terminalPasteRef.current = paste
   }, [])
-  const handleMobilePaste = useCallback(async () => {
-    try {
-      const text = await navigator.clipboard.readText()
-      if (text) terminalPasteRef.current?.(text)
-    } catch { /* clipboard denied */ }
+  // The trigger encapsulates clipboard read, binary detection, upload,
+  // and PTY emission. Mobile and desktop now share one paste code path,
+  // so binary clipboard items work from the toolbar button too.
+  const handleMobilePaste = useCallback(() => {
+    terminalPasteRef.current?.()
   }, [])
   const handleToggleCtrl = useCallback(() => {
     if (!canAttach) return

--- a/apps/gmux-web/src/terminal.tsx
+++ b/apps/gmux-web/src/terminal.tsx
@@ -5,7 +5,7 @@ import { ImageAddon } from '@xterm/addon-image'
 import { WebLinksAddon } from '@xterm/addon-web-links'
 import { WebglAddon } from '@xterm/addon-webgl'
 import type { ITerminalOptions } from '@xterm/xterm'
-import { attachKeyboardHandler, attachPasteHandler, ctrlSequenceFor, formatPasteText } from './keyboard'
+import { attachKeyboardHandler, attachPasteHandler, ctrlSequenceFor, defaultPasteFeedback, handlePasteAction } from './keyboard'
 import { DEFAULT_THEME_COLORS, type ResolvedKeybind } from './config'
 import { attachMobileInputHandler } from './mobile-input'
 import { createReplayBuffer } from './replay'
@@ -202,7 +202,7 @@ export function TerminalView({
   altArmed: boolean
   onAltConsumed: () => void
   onInputReady?: (send: ((data: string) => void) | null) => void
-  onPasteReady?: (paste: ((text: string) => void) | null) => void
+  onPasteReady?: (paste: (() => void) | null) => void
   onFocusReady?: (focus: (() => void) | null) => void
 }) {
   const shellRef = useRef<HTMLDivElement>(null)
@@ -457,14 +457,24 @@ export function TerminalView({
     }
 
     onInputReady?.(sendRawInput)
-    onPasteReady?.((text: string) => {
-      sendRawInput(formatPasteText(text, term.modes.bracketedPasteMode))
+    // The paste trigger reads bracketedPasteMode and the clipboard fresh
+    // on every invocation: bracketed mode flips at runtime as TUIs come
+    // and go, and the clipboard contents are obviously volatile. Sharing
+    // handlePasteAction with the keybind path means the mobile toolbar
+    // button gets binary-paste support without divergent code.
+    onPasteReady?.(() => {
+      void handlePasteAction({
+        sessionId: session.id,
+        bracketedPasteMode: term.modes.bracketedPasteMode,
+        feedback: defaultPasteFeedback,
+        emit: sendRawInput,
+      })
     })
     onFocusReady?.(() => focusTerminalInput(term))
 
     const dataDisposable = term.onData((data) => sendInput(data))
-    attachKeyboardHandler(term, sendInput, sendRawInput, keybinds, macCommandIsCtrl)
-    const disposePasteHandler = attachPasteHandler(term, containerRef.current!, sendRawInput)
+    attachKeyboardHandler(term, sendInput, sendRawInput, keybinds, macCommandIsCtrl, session.id)
+    const disposePasteHandler = attachPasteHandler(term, containerRef.current!, sendRawInput, session.id)
     const disposeMobileHandler = attachMobileInputHandler(term, containerRef.current!, sendRawInput)
 
     // OSC 52 clipboard: applications (e.g. pi /copy) write

--- a/services/gmuxd/cmd/gmuxd/clipboard.go
+++ b/services/gmuxd/cmd/gmuxd/clipboard.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"errors"
+	"io"
+	"net/http"
+
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/clipfile"
+)
+
+// MaxClipboardBytes caps the request body for clipboard uploads.
+// Mirrored on the gmux-web side for immediate UX feedback; this is the
+// safety floor enforced server-side regardless of client.
+//
+// Sized to comfortably fit screenshots and short video clips (typical
+// PNG screenshot is well under 5MB), while flagging accidents like
+// pasting a forgotten copied video early instead of after a long
+// upload. Raise on demand; raising is non-breaking.
+const MaxClipboardBytes = 10 * 1024 * 1024
+
+// clipboardHandler returns an http.Handler that materializes the
+// request body as a file via writer and responds with the absolute
+// path. Caller is responsible for routing (path parsing, peer
+// forwarding, session lookup) and for not invoking this for sessions
+// that aren't owned locally.
+func clipboardHandler(writer clipfile.Writer) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			writeError(w, http.StatusMethodNotAllowed, "bad_request", "method not allowed")
+			return
+		}
+
+		// Cap body before reading. http.MaxBytesReader returns an error
+		// of type *http.MaxBytesError once the limit is exceeded; we
+		// distinguish "too large" from generic read failures so the
+		// client gets an actionable error.
+		r.Body = http.MaxBytesReader(w, r.Body, MaxClipboardBytes)
+		payload, err := io.ReadAll(r.Body)
+		if err != nil {
+			var maxErr *http.MaxBytesError
+			if errors.As(err, &maxErr) {
+				writeError(w, http.StatusRequestEntityTooLarge, "too_large",
+					"clipboard payload exceeds 10MB limit")
+				return
+			}
+			writeError(w, http.StatusBadRequest, "read_failed", err.Error())
+			return
+		}
+		if len(payload) == 0 {
+			writeError(w, http.StatusBadRequest, "empty_body",
+				"clipboard payload is empty")
+			return
+		}
+
+		path, err := writer.Write(payload, r.Header.Get("Content-Type"))
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "write_failed", err.Error())
+			return
+		}
+
+		writeJSON(w, map[string]any{
+			"ok":   true,
+			"data": map[string]any{"path": path},
+		})
+	})
+}

--- a/services/gmuxd/cmd/gmuxd/clipboard_test.go
+++ b/services/gmuxd/cmd/gmuxd/clipboard_test.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/clipfile"
+)
+
+// roundTrip exercises the clipboard handler with a real LocalWriter
+// rooted at t.TempDir() and returns the HTTP response plus the parsed
+// JSON body.
+func roundTrip(t *testing.T, dir string, method string, contentType string, body []byte) (*http.Response, map[string]any) {
+	t.Helper()
+	w := clipfile.NewLocalWriter(dir)
+	h := clipboardHandler(w)
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+
+	req, err := http.NewRequest(method, srv.URL, bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	t.Cleanup(func() { resp.Body.Close() })
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	var parsed map[string]any
+	if len(respBody) > 0 {
+		if err := json.Unmarshal(respBody, &parsed); err != nil {
+			t.Fatalf("unmarshal %q: %v", respBody, err)
+		}
+	}
+	return resp, parsed
+}
+
+func TestClipboardHandler_HappyPath(t *testing.T) {
+	dir := t.TempDir()
+	payload := []byte{0x89, 'P', 'N', 'G', 0x0d, 0x0a, 0x1a, 0x0a, 'x', 'y', 'z'}
+	resp, parsed := roundTrip(t, dir, http.MethodPost, "image/png", payload)
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	data, ok := parsed["data"].(map[string]any)
+	if !ok {
+		t.Fatalf("no data in response: %v", parsed)
+	}
+	pathStr, _ := data["path"].(string)
+	if filepath.Base(pathStr) != "paste-1.png" {
+		t.Errorf("path basename = %q, want paste-1.png", filepath.Base(pathStr))
+	}
+	got, err := os.ReadFile(pathStr)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Errorf("file contents differ from posted bytes")
+	}
+}
+
+func TestClipboardHandler_RejectsNonPOST(t *testing.T) {
+	dir := t.TempDir()
+	resp, _ := roundTrip(t, dir, http.MethodGet, "image/png", nil)
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Errorf("GET status = %d, want 405", resp.StatusCode)
+	}
+}
+
+func TestClipboardHandler_EnforcesSizeCap(t *testing.T) {
+	dir := t.TempDir()
+	// Just over the 10MB limit.
+	oversized := bytes.Repeat([]byte{0xff}, MaxClipboardBytes+1)
+	resp, parsed := roundTrip(t, dir, http.MethodPost, "image/png", oversized)
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		t.Errorf("status = %d, want 413", resp.StatusCode)
+	}
+	if parsed["ok"] != false {
+		t.Errorf("ok field = %v, want false", parsed["ok"])
+	}
+	// No file should have been written.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "paste-") {
+			t.Errorf("oversized request left file %q on disk", e.Name())
+		}
+	}
+}
+
+func TestClipboardHandler_DefaultsContentTypeToBin(t *testing.T) {
+	dir := t.TempDir()
+	resp, parsed := roundTrip(t, dir, http.MethodPost, "", []byte("opaque"))
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	data := parsed["data"].(map[string]any)
+	pathStr := data["path"].(string)
+	if !strings.HasSuffix(pathStr, ".bin") {
+		t.Errorf("path = %q, want .bin extension for unspecified Content-Type", pathStr)
+	}
+}
+
+func TestClipboardHandler_RejectsEmptyBody(t *testing.T) {
+	dir := t.TempDir()
+	resp, parsed := roundTrip(t, dir, http.MethodPost, "image/png", nil)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", resp.StatusCode)
+	}
+	if parsed["ok"] != false {
+		t.Errorf("ok = %v, want false", parsed["ok"])
+	}
+	// No file written.
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "paste-") {
+			t.Errorf("empty request left file %q on disk", e.Name())
+		}
+	}
+}

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gmuxapp/gmux/packages/paths"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/authtoken"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/binhash"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/clipfile"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/config"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/devcontainers"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/discovery"
@@ -1260,6 +1261,19 @@ func serve(stderr io.Writer) int {
 				}
 			})
 			writeJSON(w, map[string]any{"ok": true, "data": map[string]any{}})
+
+		case "clipboard":
+			// Materialize a clipboard binary payload as a file in this
+			// gmuxd's os.TempDir() and return the absolute path. For
+			// devcontainer/peer sessions, the request was already
+			// forwarded above to the gmuxd that owns the session, so
+			// reaching this branch always means "write locally". The
+			// session must exist; we don't otherwise need fields from it.
+			if _, ok := sessions.Get(sessionID); !ok {
+				writeError(w, http.StatusNotFound, "not_found", "session not found")
+				return
+			}
+			clipboardHandler(clipfile.NewLocalWriter(os.TempDir())).ServeHTTP(w, r)
 
 		case "dismiss":
 			if r.Method != http.MethodPost {

--- a/services/gmuxd/internal/clipfile/clipfile.go
+++ b/services/gmuxd/internal/clipfile/clipfile.go
@@ -1,0 +1,181 @@
+// Package clipfile materializes clipboard binary payloads to files on
+// the local filesystem so a TUI running in a gmux session can read them
+// by path. Image paste in gmux-web POSTs bytes to the gmuxd that owns
+// the session; that gmuxd uses a Writer to land the bytes in its own
+// os.TempDir() and returns the absolute path. The path is then typed
+// into the PTY as if the user had typed it.
+//
+// Devcontainer and network-peer sessions are handled by the existing
+// peer-forwarding HTTP layer: the request is forwarded to the gmuxd
+// running inside the container or on the peer machine, and that gmuxd
+// uses its own Writer against its own os.TempDir(). There is no
+// container- or peer-aware code in this package.
+package clipfile
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+// Writer materializes clipboard bytes to a file and returns the
+// absolute path the caller should type into the PTY.
+type Writer interface {
+	Write(payload []byte, mime string) (path string, err error)
+}
+
+// LocalWriter writes into a fixed directory (typically os.TempDir()).
+// Files are named paste-N.<ext> with N the next free positive integer
+// for the recognized paste-* filename pattern in the directory.
+// Concurrent writers race-safely via O_CREAT|O_EXCL retry.
+type LocalWriter struct {
+	dir string
+}
+
+// NewLocalWriter returns a Writer rooted at dir.
+func NewLocalWriter(dir string) *LocalWriter {
+	return &LocalWriter{dir: dir}
+}
+
+// pasteFilenameRe matches paste-<positive int>.<non-empty ext> with no
+// path separators. Defining this once and reusing it for both
+// recognition and parsing avoids inconsistency between scan and
+// write.
+var pasteFilenameRe = regexp.MustCompile(`^paste-([1-9][0-9]*)\.([A-Za-z0-9]+)$`)
+
+func isPasteFilename(name string) bool {
+	return pasteFilenameRe.MatchString(name)
+}
+
+// pasteFilenameN returns the integer N from paste-N.<ext>, or 0 if name
+// doesn't match the pattern.
+func pasteFilenameN(name string) int {
+	m := pasteFilenameRe.FindStringSubmatch(name)
+	if m == nil {
+		return 0
+	}
+	n, err := strconv.Atoi(m[1])
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
+// extForMIME maps a Content-Type to a file extension. Unknown MIMEs
+// fall back to "bin"; an empty MIME is treated the same as unknown.
+//
+// The list covers what a real browser clipboard typically carries:
+//   - PNG/JPEG: every screenshot tool's default
+//   - HEIC/HEIF: iPhone screenshot syncing through iCloud paste
+//   - WebP/AVIF: modern web image copies
+//   - GIF/BMP/TIFF: older tooling, Preview's TIFF export
+//   - SVG: graphics apps copy as image/svg+xml
+//   - PDF: Preview "copy page as PDF"
+//   - MP4: short video clips
+func extForMIME(mime string) string {
+	// Strip parameters (e.g. "image/png; charset=binary").
+	if i := strings.IndexByte(mime, ';'); i >= 0 {
+		mime = mime[:i]
+	}
+	mime = strings.TrimSpace(strings.ToLower(mime))
+	switch mime {
+	case "image/png":
+		return "png"
+	case "image/jpeg", "image/jpg":
+		return "jpg"
+	case "image/gif":
+		return "gif"
+	case "image/webp":
+		return "webp"
+	case "image/avif":
+		return "avif"
+	case "image/heic":
+		return "heic"
+	case "image/heif":
+		return "heif"
+	case "image/bmp":
+		return "bmp"
+	case "image/tiff":
+		return "tiff"
+	case "image/svg+xml":
+		return "svg"
+	case "application/pdf":
+		return "pdf"
+	case "video/mp4":
+		return "mp4"
+	default:
+		return "bin"
+	}
+}
+
+// Write materializes payload into dir as paste-N.<ext>, picking N
+// atomically via O_CREAT|O_EXCL retry. Returns the absolute path.
+func (w *LocalWriter) Write(payload []byte, mime string) (string, error) {
+	if err := os.MkdirAll(w.dir, 0o755); err != nil {
+		return "", fmt.Errorf("clipfile: ensure dir: %w", err)
+	}
+	ext := extForMIME(mime)
+
+	start, err := w.nextN()
+	if err != nil {
+		return "", err
+	}
+
+	// Bounded retry: if every candidate up to start+maxRetry collides,
+	// something is very wrong (another process spamming pastes faster
+	// than we can scan). Surface as an error rather than spinning.
+	const maxRetry = 1024
+	for i := 0; i < maxRetry; i++ {
+		n := start + i
+		name := fmt.Sprintf("paste-%d.%s", n, ext)
+		path := filepath.Join(w.dir, name)
+		f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
+		if err != nil {
+			if errors.Is(err, os.ErrExist) || errors.Is(err, syscall.EEXIST) {
+				continue
+			}
+			return "", fmt.Errorf("clipfile: create %s: %w", name, err)
+		}
+		if _, werr := f.Write(payload); werr != nil {
+			_ = f.Close()
+			_ = os.Remove(path)
+			return "", fmt.Errorf("clipfile: write %s: %w", name, werr)
+		}
+		if cerr := f.Close(); cerr != nil {
+			return "", fmt.Errorf("clipfile: close %s: %w", name, cerr)
+		}
+		abs, aerr := filepath.Abs(path)
+		if aerr != nil {
+			return "", fmt.Errorf("clipfile: abs %s: %w", name, aerr)
+		}
+		return abs, nil
+	}
+	return "", fmt.Errorf("clipfile: too many collisions starting from paste-%d", start)
+}
+
+// nextN returns the integer to try first: max recognized N in dir, plus 1.
+// Empty dir returns 1.
+func (w *LocalWriter) nextN() (int, error) {
+	entries, err := os.ReadDir(w.dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 1, nil
+		}
+		return 0, fmt.Errorf("clipfile: read dir: %w", err)
+	}
+	max := 0
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if n := pasteFilenameN(e.Name()); n > max {
+			max = n
+		}
+	}
+	return max + 1, nil
+}

--- a/services/gmuxd/internal/clipfile/clipfile_test.go
+++ b/services/gmuxd/internal/clipfile/clipfile_test.go
@@ -1,0 +1,253 @@
+package clipfile
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// pngBytes returns a minimal valid PNG signature plus a few payload bytes.
+// Real PNG decoding isn't required; we only verify byte-for-byte storage.
+func pngBytes() []byte {
+	return []byte{0x89, 'P', 'N', 'G', 0x0d, 0x0a, 0x1a, 0x0a, 0x01, 0x02, 0x03}
+}
+
+// TestLocalWriter_FirstWriteIsPaste1 is the tracer bullet: a single write
+// into an empty tmpdir produces paste-1.png with the exact bytes we passed.
+func TestLocalWriter_FirstWriteIsPaste1(t *testing.T) {
+	dir := t.TempDir()
+	w := NewLocalWriter(dir)
+
+	payload := pngBytes()
+	path, err := w.Write(payload, "image/png")
+	if err != nil {
+		t.Fatalf("Write returned error: %v", err)
+	}
+
+	wantName := "paste-1.png"
+	if filepath.Base(path) != wantName {
+		t.Errorf("filename = %q, want %q", filepath.Base(path), wantName)
+	}
+	if filepath.Dir(path) != dir {
+		t.Errorf("dir = %q, want %q", filepath.Dir(path), dir)
+	}
+	if !filepath.IsAbs(path) {
+		t.Errorf("path = %q, want absolute", path)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Errorf("file contents = %v, want %v", got, payload)
+	}
+}
+
+// Sanity check on filename predicate so later tests can rely on it without
+// duplicating the regex.
+func TestPasteFilenameRecognition(t *testing.T) {
+	cases := map[string]bool{
+		"paste-1.png":      true,
+		"paste-42.jpg":     true,
+		"paste-9999.webp":  true,
+		"paste-1.bin":      true,
+		"paste-0.png":      false, // we start at 1
+		"paste-.png":       false,
+		"paste-1.":         false,
+		"paste-1":          false,
+		"paste-abc.png":    false,
+		"otherpaste-1.png": false,
+		"paste-1.png.bak":  false,
+	}
+	for name, want := range cases {
+		if got := isPasteFilename(name); got != want {
+			t.Errorf("isPasteFilename(%q) = %v, want %v", name, got, want)
+		}
+	}
+	// Defensive: ensure we don't accidentally match a path that has separators.
+	if isPasteFilename(strings.Join([]string{"sub", "paste-1.png"}, string(filepath.Separator))) {
+		t.Errorf("isPasteFilename should reject paths with separators")
+	}
+}
+
+// Sequential writes increment N. Independent of MIME (mixing pngs and
+// jpegs still picks the next-free integer regardless of extension).
+func TestLocalWriter_SequentialWritesIncrementN(t *testing.T) {
+	dir := t.TempDir()
+	w := NewLocalWriter(dir)
+
+	cases := []struct {
+		mime string
+		want string
+	}{
+		{"image/png", "paste-1.png"},
+		{"image/jpeg", "paste-2.jpg"},
+		{"image/png", "paste-3.png"},
+		{"image/webp", "paste-4.webp"},
+		{"application/pdf", "paste-5.pdf"},
+	}
+	for _, c := range cases {
+		path, err := w.Write([]byte("x"), c.mime)
+		if err != nil {
+			t.Fatalf("Write(%s): %v", c.mime, err)
+		}
+		if got := filepath.Base(path); got != c.want {
+			t.Errorf("Write(%s) = %q, want %q", c.mime, got, c.want)
+		}
+	}
+}
+
+// Unrelated files in the dir don't influence numbering. Subdirectories,
+// non-paste files, malformed paste-* names, and paste-0 are all ignored.
+func TestLocalWriter_IgnoresUnrelatedEntries(t *testing.T) {
+	dir := t.TempDir()
+	// Pre-populate with noise that must not affect numbering.
+	noise := []string{
+		"README.md",
+		"paste-0.png",      // 0 isn't a valid N
+		"paste-abc.png",    // non-numeric
+		"paste-1.png.bak",  // suffix after ext
+		"otherpaste-9.png", // wrong prefix
+		"paste-1",          // no extension
+	}
+	for _, n := range noise {
+		if err := os.WriteFile(filepath.Join(dir, n), []byte("noise"), 0o644); err != nil {
+			t.Fatalf("prep %s: %v", n, err)
+		}
+	}
+	if err := os.Mkdir(filepath.Join(dir, "paste-99.png"), 0o755); err != nil {
+		t.Fatalf("prep dir: %v", err)
+	}
+
+	w := NewLocalWriter(dir)
+	path, err := w.Write([]byte("x"), "image/png")
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if got := filepath.Base(path); got != "paste-1.png" {
+		t.Errorf("Write = %q, want paste-1.png", got)
+	}
+}
+
+// Recognized paste-* files anchor the counter regardless of extension.
+func TestLocalWriter_AnchorsOnExistingMaxN(t *testing.T) {
+	dir := t.TempDir()
+	// Existing paste-3.jpg means next write picks paste-4 even though
+	// the new MIME is png.
+	if err := os.WriteFile(filepath.Join(dir, "paste-3.jpg"), []byte("old"), 0o644); err != nil {
+		t.Fatalf("prep: %v", err)
+	}
+	w := NewLocalWriter(dir)
+	path, err := w.Write([]byte("new"), "image/png")
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if got := filepath.Base(path); got != "paste-4.png" {
+		t.Errorf("Write = %q, want paste-4.png", got)
+	}
+}
+
+// Concurrent writers across many goroutines must produce distinct
+// paths and must not overwrite each other. This is the regression net
+// for the O_EXCL retry loop.
+func TestLocalWriter_ConcurrentWritesAreDistinct(t *testing.T) {
+	dir := t.TempDir()
+	w := NewLocalWriter(dir)
+
+	const n = 50
+	paths := make([]string, n)
+	errs := make([]error, n)
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func(i int) {
+			defer wg.Done()
+			payload := []byte(fmt.Sprintf("payload-%d", i))
+			path, err := w.Write(payload, "image/png")
+			paths[i] = path
+			errs[i] = err
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("Write[%d]: %v", i, err)
+		}
+	}
+
+	// All paths must be distinct.
+	seen := make(map[string]int, n)
+	for i, p := range paths {
+		if prev, ok := seen[p]; ok {
+			t.Errorf("path collision: i=%d and i=%d both got %q", prev, i, p)
+		}
+		seen[p] = i
+	}
+
+	// Each file must contain the payload of the goroutine that claimed
+	// it: no overwrites or torn writes.
+	for i, p := range paths {
+		got, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatalf("ReadFile %s: %v", p, err)
+		}
+		want := fmt.Sprintf("payload-%d", i)
+		if !bytes.Equal(got, []byte(want)) {
+			t.Errorf("%s = %q, want %q", p, got, want)
+		}
+	}
+
+	// Numbers should be exactly 1..n with no gaps. Gaps would suggest
+	// the retry loop is skipping or the scan is racy in a way we'd want
+	// to know about.
+	nums := make([]int, 0, n)
+	for _, p := range paths {
+		nums = append(nums, pasteFilenameN(filepath.Base(p)))
+	}
+	sort.Ints(nums)
+	for i, num := range nums {
+		if num != i+1 {
+			t.Errorf("after sort, nums[%d] = %d, want %d (full sequence: %v)", i, num, i+1, nums)
+			break
+		}
+	}
+}
+
+// MIME-to-extension mapping covers every entry the documentation
+// promises and falls back to "bin" for anything else. Tolerates
+// case and parameter variations the way Content-Type headers vary
+// in the wild.
+func TestExtForMIME(t *testing.T) {
+	cases := map[string]string{
+		"image/png":              "png",
+		"image/jpeg":             "jpg",
+		"image/jpg":              "jpg", // non-standard but seen in the wild
+		"image/gif":              "gif",
+		"image/webp":             "webp",
+		"image/avif":             "avif",
+		"image/heic":             "heic",
+		"image/heif":             "heif",
+		"image/bmp":              "bmp",
+		"image/tiff":             "tiff",
+		"image/svg+xml":          "svg",
+		"application/pdf":        "pdf",
+		"video/mp4":              "mp4",
+		"application/zip":        "bin", // truly unknown falls back
+		"audio/mpeg":             "bin",
+		"":                       "bin",
+		"  IMAGE/PNG  ":          "png", // case + whitespace tolerance
+		"image/png; charset=foo": "png", // params stripped
+	}
+	for mime, want := range cases {
+		if got := extForMIME(mime); got != want {
+			t.Errorf("extForMIME(%q) = %q, want %q", mime, got, want)
+		}
+	}
+}


### PR DESCRIPTION
Implements image (and any non-text binary) paste into gmux sessions per the design in #85.

When the user pastes a clipboard item that isn't pure text, gmux-web POSTs the bytes to the gmuxd that owns the session, that gmuxd materializes them as `paste-N.<ext>` in its `os.TempDir()`, and gmux-web types the absolute path into the PTY through the existing `formatPasteText` machinery. CC, pi, or anything else that accepts file paths handles it from there. No app-specific glue, no display server on the daemon, no protocol dependence on the running TUI.

## What's in this PR

**Daemon (`feat(daemon)`)**

- New `internal/clipfile/` package: deep `Writer` interface plus `LocalWriter` impl. Picks the next-free `paste-N.<ext>` via `O_CREAT|O_EXCL` retry against the dir, so concurrent pastes from multiple sessions never overwrite each other. MIME → ext map covers `image/{png,jpeg,gif,webp,avif,heic,heif,bmp,tiff,svg+xml}`, `application/pdf`, `video/mp4`, with `bin` fallback for everything else.
- New endpoint: `POST /v1/sessions/{id}/clipboard`. Body cap of 10MB enforced via `http.MaxBytesReader`; oversized requests get `413 too_large`. Empty bodies get `400 empty_body`. Returns `{ ok: true, data: { path } }` on success.
- Devcontainer and network-peer sessions Just Work via the existing `peer.Forward()` machinery: the request is forwarded to the gmuxd that owns the session (running inside the container or on the peer machine), which writes to its own `os.TempDir()`. No `docker exec`, no path translation, no second writer impl. Simpler than the PRD's draft devcontainer story.

**Web (`feat(web)`)**

- New `clipboard-upload.ts` deep helper: `uploadClipboardBlob(blob, sessionId)` returns `{ ok, path } | { ok: false, error }`. Handles MIME header, size cap, error categorization. Pure logic + `fetch`; trivially mockable.
- All three paste paths route through one exported `handlePasteAction`:
  - the **keybind** (Ctrl+V / Cmd+V) via the keymap's `paste` action
  - the **DOM paste event** (right-click, browser Edit menu, native long-press paste on mobile) via `attachPasteHandler`
  - the **mobile toolbar paste button** via the parameterless `onPasteReady` bridge in `terminal.tsx` (changed from a string-typed bridge so the button is no longer text-only)
- Each path inspects the clipboard for non-`text/*` items first, routes through the upload helper if found, then types the returned path via existing `formatPasteText` + `sendRaw`. Text-only clipboards keep the existing behavior verbatim. Optional `PasteFeedback` callback surfaces success and error toast copy; defaults to `defaultPasteFeedback` (exported) which writes to `console` so failures aren't silent.
- The keybind path reads the clipboard once via `Clipboard.read()` and extracts text from the same items when there's no binary, avoiding a redundant `readText()` call (and the second permission prompt some browsers fire for it).
- `pickBinaryDataTransferItem` is exported so its rule (`kind === 'file'` AND non-`text/*` MIME) is unit-tested in isolation; both predicates are load-bearing and a regression in either would cause confusing failure-toast races.

## Tests

- **`clipfile.LocalWriter`** (Go): 6 tests including a 50-goroutine concurrent-write race regression net (asserts distinct paths, no torn writes, contiguous numbering 1..50). Race-clean across `-count=3 -race`.
- **HTTP handler** (Go): 5 `httptest`-driven tests covering happy path, method rejection, size cap, empty body, content-type → ext mapping (verified with a real `LocalWriter` over `t.TempDir()`).
- **`extForMIME`** (Go): table-driven coverage of every documented MIME plus case/whitespace/parameter tolerance and unknown fallback.
- **`clipboard-upload.ts`** (vitest): 11 cases covering MIME picking, web-side size cap (no `fetch` call), success path, error JSON mapping, network failure, session id encoding.
- **`pickBinaryDataTransferItem`** (vitest): 5 cases covering both predicates of the rule, order preservation, and empty input.
- **`keyboard.ts` paste shim** and the new mobile bridge: deliberately skipped per the PRD; the helpers they delegate to are covered by the unit tests above and the bridge is a single function call.

287 frontend tests pass (was 281). All daemon tests pass without `-race`; with `-race` everything I added stays clean across `-count=3`. The pre-existing `internal/notify` race is unrelated.

## Out of scope

- OSC 5522 / Kitty clipboard protocol responder. Independent follow-up; will compose with this without conflict.
- A real in-page toast UI; current feedback is `console`. Adding a toast component is a follow-up that just routes the existing `PasteFeedback` callback.
- `text/uri-list` (Finder paths) special-casing.

## Coexistence with #189

PR #189 (trailing-whitespace fix on copy) also touches `keyboard.ts`. The two PRs touch different parts of the file (copy actions vs paste actions / new `attachPasteHandler` signature) but share the file, so whichever lands second will be a trivial rebase. Both can land in either order.

Closes #85.
