### PR TITLE
feat: snapshot push protocol + cross-host project ownership

### DIFF
--- a/apps/gmux-web/src/home.tsx
+++ b/apps/gmux-web/src/home.tsx
@@ -72,7 +72,7 @@ export function Home() {
         <section class="home-projects">
           <h2 class="home-section-title">Projects</h2>
           <div class="home-project-grid">
-            {foldersVal.map(f => <ProjectCard key={f.path} folder={f} />)}
+            {foldersVal.map(f => <ProjectCard key={f.key} folder={f} />)}
           </div>
         </section>
       )}
@@ -101,9 +101,13 @@ export function Home() {
 function ProjectCard({ folder: f }: { folder: Folder }) {
   const alive = f.sessions.filter(s => s.alive).length
   const resumable = f.sessions.filter(s => !s.alive && s.resumable).length
+  const href = f.peer ? `/@${f.peer}/${f.slug}` : `/${f.slug}`
   return (
-    <a class="home-project-card" href={`/${f.path}`}>
-      <div class="home-project-name">{f.name}</div>
+    <a class="home-project-card" href={href}>
+      <div class="home-project-name">
+        {f.peer && <PeerLabel name={f.peer} />}
+        {f.name}
+      </div>
       <div class="home-project-count">
         {alive > 0 && <span class="home-project-alive">{alive} alive</span>}
         {alive > 0 && resumable > 0 && <span class="home-project-rest"> · </span>}

--- a/apps/gmux-web/src/launcher.tsx
+++ b/apps/gmux-web/src/launcher.tsx
@@ -106,11 +106,15 @@ interface LaunchButtonProps {
 }
 
 export function LaunchButton({ className, onLaunch, beforeLaunch, cwd, peer, sessions, selectedId, fallbackCwd }: LaunchButtonProps) {
-  // Resolve the target: context-aware mode (sessions provided) takes
-  // priority over explicit cwd/peer.
+  // Resolve the target: context-aware mode (sessions provided) derives
+  // a smart cwd, while an explicit `peer` prop is always authoritative
+  // (the caller knows the folder's owner; ADR 0002). This matters for
+  // peer folders whose sessions are all dead-resumable, where context
+  // mode would otherwise lose the peer in resolveTarget's fallback.
   const target = useMemo((): LaunchTarget => {
     if (sessions && fallbackCwd !== undefined) {
-      return resolveTarget(sessions, selectedId ?? null, fallbackCwd)
+      const ctx = resolveTarget(sessions, selectedId ?? null, fallbackCwd)
+      return peer ? { ...ctx, peer } : ctx
     }
     return { peer, cwd: cwd || '' }
   }, [sessions, selectedId, fallbackCwd, cwd, peer])

--- a/apps/gmux-web/src/project-hub.tsx
+++ b/apps/gmux-web/src/project-hub.tsx
@@ -9,7 +9,7 @@ import type { HostNode } from './projects'
 import { buildProjectTopology } from './projects'
 import { sessionPath } from './routing'
 import { LaunchButton } from './launcher'
-import { sessions, projects, peers } from './store'
+import { sessions, projects, peers, peerStatusByName, isSessionUnavailable } from './store'
 import { PeerLabel } from './peer-label'
 
 function projectRemote(p: ProjectItem | undefined): string | undefined {
@@ -108,6 +108,7 @@ function HostGroup({
                 key={s.id}
                 session={s}
                 projectSlug={projectSlug}
+                unavailable={isSessionUnavailable(s, peerStatusByName.value)}
                 onClose={() => onCloseSession(s)}
               />
             ))}
@@ -137,14 +138,19 @@ function HostPath({ path }: { path: string[] }) {
 }
 
 function SessionCard({
-  session, projectSlug, onClose,
-}: { session: Session; projectSlug: string; onClose: () => void }) {
+  session, projectSlug, unavailable, onClose,
+}: {
+  session: Session
+  projectSlug: string
+  unavailable?: boolean
+  onClose: () => void
+}) {
   const dotClass = session.alive ? '' : 'dead'
   const name = session.title || session.kind
   const href = sessionPath(projectSlug, session)
   return (
     <a
-      class="session-card"
+      class={`session-card${unavailable ? ' unavailable' : ''}`}
       href={href}
     >
       <span class={`session-card-dot ${dotClass}`} />

--- a/apps/gmux-web/src/projects.test.ts
+++ b/apps/gmux-web/src/projects.test.ts
@@ -7,6 +7,12 @@ import {
   parseSessionHostPath,
   buildProjectTopology,
   isSessionVisibleInProject,
+  slugify,
+  slugFromRemote,
+  slugFromPath,
+  mostCommonRemote,
+  discoverProjects,
+  countUnmatchedActive,
 } from './projects'
 import { makeSession } from './test-helpers'
 
@@ -161,6 +167,7 @@ describe('buildProjectFolders', () => {
     expect(folders).toHaveLength(1)
     expect(folders[0].name).toBe('empty')
     expect(folders[0].sessions).toHaveLength(0)
+    expect(folders[0].peer).toBeUndefined()
   })
 
   it('sets launchCwd from project paths', () => {
@@ -171,82 +178,199 @@ describe('buildProjectFolders', () => {
     expect(folders[0].launchCwd).toBe('/dev/proj')
   })
 
-  it('excludes dead sessions not in the project sessions array', () => {
+  it('hides dead sessions that the origin disclaims (not stamped to this folder)', () => {
+    // "old-dead" is dead and disclaimed: nothing claims it. The viewer's
+    // rule matches its cwd, but adopted-disclaimed dead sessions are
+    // not visible — only the viewer's intent put a rule there, and a
+    // dead session can't validate the match.
     const projects: ProjectItem[] = [
-      { slug: 'proj', match: [{ path: '/dev/proj' }], sessions: ['kept-id'] },
+      { slug: 'proj', match: [{ path: '/dev/proj' }] },
     ]
     const sessions = [
-      makeSession({ id: 'kept-id', cwd: '/dev/proj', alive: false, resumable: true }),
+      makeSession({ id: 'kept', cwd: '/dev/proj', alive: false, resumable: true,
+                    project_slug: 'proj', project_index: 0 }),
       makeSession({ id: 'old-dead', cwd: '/dev/proj', alive: false, resumable: true }),
       makeSession({ id: 'alive-1', cwd: '/dev/proj', alive: true }),
     ]
     const folders = buildProjectFolders(projects, sessions)
     const ids = folders[0].sessions.map(s => s.id)
-    expect(ids).toContain('alive-1')   // alive: always shown
-    expect(ids).toContain('kept-id')   // dead but in array: shown
-    expect(ids).not.toContain('old-dead') // dead, not in array: hidden
+    expect(ids).toContain('alive-1')   // alive always renders
+    expect(ids).toContain('kept')      // dead but stamped: claimed, renders
+    expect(ids).not.toContain('old-dead') // dead, disclaimed: hidden
   })
 
-  it('matches dead sessions by slug in array', () => {
+  it('hides dead sessions stamped to a different project than the folder', () => {
     const projects: ProjectItem[] = [
-      { slug: 'proj', match: [{ path: '/dev/proj' }], sessions: ['my-resume-key'] },
+      { slug: 'proj', match: [{ path: '/dev/proj' }] },
+      { slug: 'other', match: [{ path: '/elsewhere' }] },
     ]
     const sessions = [
-      makeSession({ id: 'sess-1', cwd: '/dev/proj', alive: false, resumable: true, slug: 'my-resume-key' }),
+      // Dead, stamped to 'other', but its cwd would also rule-match 'proj'.
+      // Stamp wins; it lives in 'other', not 'proj', and being dead-and-
+      // stamped-elsewhere it doesn't render in 'proj' either.
+      makeSession({ id: 'wanderer', cwd: '/dev/proj', alive: false, resumable: true,
+                    project_slug: 'other', project_index: 0 }),
     ]
     const folders = buildProjectFolders(projects, sessions)
-    expect(folders[0].sessions).toHaveLength(1)
+    const proj = folders.find(f => f.slug === 'proj')!
+    const other = folders.find(f => f.slug === 'other')!
+    expect(proj.sessions).toHaveLength(0)
+    expect(other.sessions.map(s => s.id)).toEqual(['wanderer'])
   })
 
-  it('excludes dead sessions whose slug is not in the array', () => {
+  it('sorts stamped local sessions by project_index', () => {
     const projects: ProjectItem[] = [
-      { slug: 'proj', match: [{ path: '/dev/proj' }], sessions: ['other-key'] },
+      { slug: 'proj', match: [{ path: '/dev/proj' }] },
     ]
     const sessions = [
-      makeSession({ id: 'sess-1', cwd: '/dev/proj', alive: false, resumable: true, slug: 'my-resume-key' }),
-    ]
-    const folders = buildProjectFolders(projects, sessions)
-    expect(folders[0].sessions).toHaveLength(0)
-  })
-
-  it('sorts sessions by their position in the sessions array', () => {
-    const projects: ProjectItem[] = [
-      { slug: 'proj', match: [{ path: '/dev/proj' }], sessions: ['c', 'a', 'b'] },
-    ]
-    const sessions = [
-      makeSession({ id: 'a', cwd: '/dev/proj', alive: true }),
-      makeSession({ id: 'b', cwd: '/dev/proj', alive: true }),
-      makeSession({ id: 'c', cwd: '/dev/proj', alive: true }),
+      makeSession({ id: 'a', cwd: '/dev/proj', alive: true, project_slug: 'proj', project_index: 1 }),
+      makeSession({ id: 'b', cwd: '/dev/proj', alive: true, project_slug: 'proj', project_index: 2 }),
+      makeSession({ id: 'c', cwd: '/dev/proj', alive: true, project_slug: 'proj', project_index: 0 }),
     ]
     const folders = buildProjectFolders(projects, sessions)
     expect(folders[0].sessions.map(s => s.id)).toEqual(['c', 'a', 'b'])
   })
 
-  it('sorts sessions by slug when the array uses slugs', () => {
+  it('puts adopted-disclaimed sessions after stamped ones, ordered by created_at', () => {
+    // Adopted-disclaimed: viewer's rule matched, but origin hasn't
+    // stamped them yet (just-spawned, Reconcile-pending). They should
+    // sit at the end so they don't reshuffle the existing order.
     const projects: ProjectItem[] = [
-      { slug: 'proj', match: [{ path: '/dev/proj' }], sessions: ['gamma', 'alpha'] },
+      { slug: 'proj', match: [{ path: '/dev/proj' }] },
     ]
     const sessions = [
-      makeSession({ id: 'sess-1', cwd: '/dev/proj', alive: true, slug: 'alpha' }),
-      makeSession({ id: 'sess-2', cwd: '/dev/proj', alive: true, slug: 'gamma' }),
+      makeSession({ id: 'unstamped-old', cwd: '/dev/proj', alive: true,
+                    created_at: '2025-01-01T00:00:00Z' }),
+      makeSession({ id: 'unstamped-new', cwd: '/dev/proj', alive: true,
+                    created_at: '2025-01-03T00:00:00Z' }),
+      makeSession({ id: 'stamped', cwd: '/dev/proj', alive: true,
+                    project_slug: 'proj', project_index: 0,
+                    created_at: '2025-01-02T00:00:00Z' }),
     ]
     const folders = buildProjectFolders(projects, sessions)
-    expect(folders[0].sessions.map(s => s.slug)).toEqual(['gamma', 'alpha'])
+    expect(folders[0].sessions.map(s => s.id)).toEqual([
+      'stamped', 'unstamped-old', 'unstamped-new',
+    ])
   })
 
-  it('puts sessions not in the array at the end', () => {
+  // ── Peer-owned folders (ADR 0002) ──────────────────────────────
+
+  it('renders a stamped peer session under its origin (peer, slug) folder', () => {
     const projects: ProjectItem[] = [
-      { slug: 'proj', match: [{ path: '/dev/proj' }], sessions: ['b'] },
+      { slug: 'gmux', match: [{ path: '/dev/gmux' }] },
     ]
     const sessions = [
-      makeSession({ id: 'a', cwd: '/dev/proj', alive: true, created_at: '2025-01-01T00:00:00Z' }),
-      makeSession({ id: 'b', cwd: '/dev/proj', alive: true, created_at: '2025-01-02T00:00:00Z' }),
-      makeSession({ id: 'c', cwd: '/dev/proj', alive: true, created_at: '2025-01-03T00:00:00Z' }),
+      makeSession({ id: 's1@tower', cwd: '/elsewhere', alive: true,
+                    peer: 'tower', project_slug: 'gmux', project_index: 0 }),
     ]
     const folders = buildProjectFolders(projects, sessions)
-    const ids = folders[0].sessions.map(s => s.id)
-    // 'b' is in the array so it comes first; 'a' and 'c' are not, sorted by creation time
-    expect(ids).toEqual(['b', 'a', 'c'])
+    // Local 'gmux' folder still emits (empty); peer folder follows.
+    const tower = folders.find(f => f.peer === 'tower')!
+    expect(tower).toBeDefined()
+    expect(tower.slug).toBe('gmux')
+    expect(tower.name).toBe('gmux')
+    expect(tower.sessions.map(s => s.id)).toEqual(['s1@tower'])
+    expect(tower.key).toBe('tower::gmux')
+  })
+
+  it('keeps two same-slug projects on different hosts as separate folders', () => {
+    const projects: ProjectItem[] = [
+      { slug: 'gmux', match: [{ path: '/home/me/dev/gmux' }] },
+    ]
+    const sessions = [
+      makeSession({ id: 'local-1', cwd: '/home/me/dev/gmux', alive: true,
+                    project_slug: 'gmux', project_index: 0 }),
+      makeSession({ id: 'tower-1@tower', cwd: '/home/me/dev/gmux', alive: true,
+                    peer: 'tower', project_slug: 'gmux', project_index: 0 }),
+    ]
+    const folders = buildProjectFolders(projects, sessions)
+    const local = folders.find(f => f.peer === undefined && f.slug === 'gmux')!
+    const tower = folders.find(f => f.peer === 'tower')!
+    expect(local.sessions.map(s => s.id)).toEqual(['local-1'])
+    expect(tower.sessions.map(s => s.id)).toEqual(['tower-1@tower'])
+  })
+
+  it('skips empty peer folders (no enumeration on the wire)', () => {
+    // No peer sessions visible → no peer folder, even if a peer is
+    // connected. Empty peer folders would be a viewer fiction.
+    const projects: ProjectItem[] = [
+      { slug: 'gmux', match: [{ path: '/dev/gmux' }] },
+    ]
+    const folders = buildProjectFolders(projects, [])
+    expect(folders.filter(f => f.peer !== undefined)).toEqual([])
+  })
+
+  it('hides a peer folder once its last visible session goes away', () => {
+    const projects: ProjectItem[] = []
+    const sessions = [
+      // Dead and not resumable: never visible.
+      makeSession({ id: 's1@tower', cwd: '/x', alive: false, resumable: false,
+                    peer: 'tower', project_slug: 'gmux', project_index: 0 }),
+    ]
+    const folders = buildProjectFolders(projects, sessions)
+    expect(folders.filter(f => f.peer === 'tower')).toEqual([])
+  })
+
+  it('sorts peer folders by peer name then slug', () => {
+    const projects: ProjectItem[] = []
+    const sessions = [
+      makeSession({ id: 'a@zulu', cwd: '/x', alive: true,
+                    peer: 'zulu', project_slug: 'beta', project_index: 0 }),
+      makeSession({ id: 'b@alpha', cwd: '/x', alive: true,
+                    peer: 'alpha', project_slug: 'gamma', project_index: 0 }),
+      makeSession({ id: 'c@alpha', cwd: '/x', alive: true,
+                    peer: 'alpha', project_slug: 'beta', project_index: 0 }),
+    ]
+    const folders = buildProjectFolders(projects, sessions)
+    expect(folders.map(f => `${f.peer}/${f.slug}`)).toEqual([
+      'alpha/beta', 'alpha/gamma', 'zulu/beta',
+    ])
+  })
+
+  it('orders sessions inside a peer folder by project_index', () => {
+    const projects: ProjectItem[] = []
+    const sessions = [
+      makeSession({ id: 'b@tower', cwd: '/x', alive: true,
+                    peer: 'tower', project_slug: 'gmux', project_index: 1 }),
+      makeSession({ id: 'a@tower', cwd: '/x', alive: true,
+                    peer: 'tower', project_slug: 'gmux', project_index: 0 }),
+      makeSession({ id: 'c@tower', cwd: '/x', alive: true,
+                    peer: 'tower', project_slug: 'gmux', project_index: 2 }),
+    ]
+    const folders = buildProjectFolders(projects, sessions)
+    const tower = folders.find(f => f.peer === 'tower')!
+    expect(tower.sessions.map(s => s.id)).toEqual(['a@tower', 'b@tower', 'c@tower'])
+  })
+
+  it('adopts a disclaimed peer session into a local folder via match rules', () => {
+    // Devcontainer-style: peer's projects.json is empty, so all its
+    // sessions disclaim. The viewer's rule for /workspaces/gmux
+    // matches the session's cwd; viewer adopts it into local 'gmux'.
+    const projects: ProjectItem[] = [
+      { slug: 'gmux', match: [{ path: '/workspaces/gmux' }] },
+    ]
+    const sessions = [
+      makeSession({ id: 's1@dev', cwd: '/workspaces/gmux', alive: true,
+                    peer: 'dev' }), // no project_slug = disclaimed
+    ]
+    const folders = buildProjectFolders(projects, sessions)
+    const local = folders.find(f => f.slug === 'gmux' && f.peer === undefined)!
+    expect(local.sessions.map(s => s.id)).toEqual(['s1@dev'])
+    // No separate peer folder for an adopted disclaim.
+    expect(folders.filter(f => f.peer === 'dev')).toEqual([])
+  })
+
+  it('drops a disclaimed peer session that no viewer rule adopts', () => {
+    // ADR 0002: unmatched disclaimed sessions appear via
+    // discoverProjects, not in any folder.
+    const projects: ProjectItem[] = [
+      { slug: 'gmux', match: [{ path: '/dev/gmux' }] },
+    ]
+    const sessions = [
+      makeSession({ id: 's1@dev', cwd: '/elsewhere', alive: true, peer: 'dev' }),
+    ]
+    const folders = buildProjectFolders(projects, sessions)
+    expect(folders.flatMap(f => f.sessions.map(s => s.id))).toEqual([])
   })
 })
 
@@ -468,5 +592,204 @@ describe('buildProjectTopology', () => {
     const hosts = buildProjectTopology('fluxer', sessions, projects2, peers)
     expect(hosts).toHaveLength(1)
     expect(hosts[0].folders[0].sessions.map(s => s.id)).toEqual(['f1'])
+  })
+})
+
+describe('slugify', () => {
+  it('lowercases and replaces non-alnum with hyphens', () => {
+    expect(slugify('Hello World')).toBe('hello-world')
+  })
+
+  it('collapses repeated hyphens', () => {
+    expect(slugify('a---b__c')).toBe('a-b-c')
+  })
+
+  it('trims leading and trailing hyphens', () => {
+    expect(slugify('--my-thing--')).toBe('my-thing')
+  })
+
+  it('returns "project" for empty results', () => {
+    expect(slugify('!!!')).toBe('project')
+    expect(slugify('')).toBe('project')
+  })
+})
+
+describe('slugFromRemote', () => {
+  it('uses repo basename of normalized URL', () => {
+    expect(slugFromRemote('git@github.com:gmuxapp/gmux.git')).toBe('gmux')
+    expect(slugFromRemote('https://github.com/Org/My-Repo.git')).toBe('my-repo')
+  })
+})
+
+describe('slugFromPath', () => {
+  it('uses basename', () => {
+    expect(slugFromPath('/dev/gmux')).toBe('gmux')
+    expect(slugFromPath('~/code/My-Project/')).toBe('my-project')
+  })
+})
+
+describe('mostCommonRemote', () => {
+  it('returns the most frequent normalized remote', () => {
+    const sessions = [
+      makeSession({ id: 's1', cwd: '/x', remotes: { origin: 'git@github.com:foo/bar.git' } }),
+      makeSession({ id: 's2', cwd: '/x', remotes: { origin: 'https://github.com/foo/bar' } }),
+      makeSession({ id: 's3', cwd: '/x', remotes: { origin: 'git@github.com:other/repo.git' } }),
+    ]
+    expect(mostCommonRemote(sessions)).toBe('github.com/foo/bar')
+  })
+
+  it('returns empty string when no remotes', () => {
+    expect(mostCommonRemote([makeSession({ id: 's1', cwd: '/x' })])).toBe('')
+  })
+
+  it('breaks ties lexicographically', () => {
+    const sessions = [
+      makeSession({ id: 's1', cwd: '/x', remotes: { origin: 'github.com/zzz/repo' } }),
+      makeSession({ id: 's2', cwd: '/x', remotes: { origin: 'github.com/aaa/repo' } }),
+    ]
+    expect(mostCommonRemote(sessions)).toBe('github.com/aaa/repo')
+  })
+})
+
+describe('discoverProjects', () => {
+  it('groups unmatched sessions by directory', () => {
+    const projects: ProjectItem[] = [
+      { slug: 'gmux', match: [{ path: '/dev/gmux' }] },
+    ]
+    const sessions = [
+      makeSession({ id: 'a', cwd: '/dev/gmux/sub', alive: true }),  // matches gmux
+      makeSession({ id: 'b', cwd: '/work/foo', alive: true }),
+      makeSession({ id: 'c', cwd: '/work/foo', alive: false }),
+      makeSession({ id: 'd', workspace_root: '/work/bar', cwd: '/work/bar/src', alive: true }),
+    ]
+    const out = discoverProjects(sessions, projects)
+    expect(out).toHaveLength(2)
+    const fooBucket = out.find(d => d.paths[0] === '/work/foo')
+    expect(fooBucket).toMatchObject({ session_count: 2, active_count: 1 })
+    const barBucket = out.find(d => d.paths[0] === '/work/bar')
+    expect(barBucket).toMatchObject({ session_count: 1, active_count: 1 })
+  })
+
+  it('skips sessions with no directory at all', () => {
+    expect(discoverProjects([makeSession({ id: 'a', cwd: '' })], [])).toEqual([])
+  })
+
+  it('prefers workspace_root over cwd as bucket key', () => {
+    const sessions = [
+      makeSession({ id: 'a', workspace_root: '/work/repo', cwd: '/work/repo/sub' }),
+      makeSession({ id: 'b', workspace_root: '/work/repo', cwd: '/work/repo/other' }),
+    ]
+    const out = discoverProjects(sessions, [])
+    expect(out).toHaveLength(1)
+    expect(out[0].paths).toEqual(['/work/repo'])
+    expect(out[0].session_count).toBe(2)
+  })
+
+  it('uses remote-derived slug when available', () => {
+    const sessions = [
+      makeSession({ id: 'a', cwd: '/work/foo', remotes: { origin: 'git@github.com:org/cool-repo.git' } }),
+    ]
+    const out = discoverProjects(sessions, [])
+    expect(out[0].suggested_slug).toBe('cool-repo')
+    expect(out[0].remote).toBe('github.com/org/cool-repo')
+  })
+
+  it('falls back to path-derived slug when no remote', () => {
+    const sessions = [makeSession({ id: 'a', cwd: '/work/cool-app' })]
+    const out = discoverProjects(sessions, [])
+    expect(out[0].suggested_slug).toBe('cool-app')
+    expect(out[0].remote).toBeUndefined()
+  })
+
+  it('sorts by active count, then session count, then alphabetically', () => {
+    const sessions = [
+      makeSession({ id: '1', cwd: '/a', alive: false }),
+      makeSession({ id: '2', cwd: '/b', alive: true }),
+      makeSession({ id: '3', cwd: '/c', alive: true }),
+      makeSession({ id: '4', cwd: '/c', alive: false }),
+    ]
+    const out = discoverProjects(sessions, [])
+    expect(out.map(d => d.paths[0])).toEqual(['/c', '/b', '/a'])
+  })
+
+  it('excludes claimed sessions (stamped by their origin)', () => {
+    // A session claimed on its origin has a definite home; only
+    // disclaimed sessions are eligible for discovery.
+    const sessions = [
+      makeSession({ id: 'claimed', cwd: '/work/foo', alive: true,
+                    project_slug: 'foo', project_index: 0 }),
+      makeSession({ id: 'free', cwd: '/work/bar', alive: true }),
+    ]
+    const out = discoverProjects(sessions, [])
+    expect(out).toHaveLength(1)
+    expect(out[0].paths).toEqual(['/work/bar'])
+  })
+
+  it('excludes claimed peer sessions (peer-stamped)', () => {
+    const sessions = [
+      makeSession({ id: 's1@tower', cwd: '/work/foo', alive: true,
+                    peer: 'tower', project_slug: 'gmux', project_index: 0 }),
+    ]
+    expect(discoverProjects(sessions, [])).toEqual([])
+  })
+})
+
+describe('countUnmatchedActive', () => {
+  it('counts alive sessions outside any project', () => {
+    const projects: ProjectItem[] = [
+      { slug: 'gmux', match: [{ path: '/dev/gmux' }] },
+    ]
+    const sessions = [
+      makeSession({ id: 'a', cwd: '/dev/gmux/x', alive: true }),  // adopted by viewer rules
+      makeSession({ id: 'b', cwd: '/elsewhere', alive: true }),   // free
+      makeSession({ id: 'c', cwd: '/elsewhere', alive: false }),  // dead, not counted
+      makeSession({ id: 'd', cwd: '/other', alive: true }),       // free
+    ]
+    expect(countUnmatchedActive(sessions, projects)).toBe(2)
+  })
+
+  it('excludes claimed sessions (stamped by their origin)', () => {
+    // Stamped sessions have a folder; the badge counts only sessions
+    // genuinely outside any project from any host's perspective.
+    const projects: ProjectItem[] = [
+      { slug: 'gmux', match: [{ path: '/dev/gmux' }] },
+    ]
+    const sessions = [
+      makeSession({ id: 'a', cwd: '/elsewhere', alive: true,
+                    project_slug: 'gmux', project_index: 0 }),
+    ]
+    expect(countUnmatchedActive(sessions, projects)).toBe(0)
+  })
+
+  it('excludes claimed peer sessions', () => {
+    // A peer's claimed session lives in the peer's folder; not
+    // "outside any project" from the viewer's perspective.
+    const sessions = [
+      makeSession({ id: 's@tower', cwd: '/elsewhere', alive: true,
+                    peer: 'tower', project_slug: 'gmux', project_index: 0 }),
+    ]
+    expect(countUnmatchedActive(sessions, [])).toBe(0)
+  })
+
+  it('counts a disclaimed peer session that no viewer rule adopts', () => {
+    // Devcontainer disclaim + no viewer rule = genuinely homeless.
+    const sessions = [
+      makeSession({ id: 's@dev', cwd: '/elsewhere', alive: true, peer: 'dev' }),
+    ]
+    expect(countUnmatchedActive(sessions, [])).toBe(1)
+  })
+
+  it('does not count a disclaimed peer session adopted by a viewer rule', () => {
+    const projects: ProjectItem[] = [
+      { slug: 'gmux', match: [{ path: '/workspaces/gmux' }] },
+    ]
+    const sessions = [
+      makeSession({ id: 's@dev', cwd: '/workspaces/gmux', alive: true, peer: 'dev' }),
+    ]
+    expect(countUnmatchedActive(sessions, projects)).toBe(0)
+  })
+
+  it('returns 0 when there are no sessions', () => {
+    expect(countUnmatchedActive([], [])).toBe(0)
   })
 })

--- a/apps/gmux-web/src/projects.test.ts
+++ b/apps/gmux-web/src/projects.test.ts
@@ -373,6 +373,36 @@ describe('buildProjectFolders', () => {
     const folders = buildProjectFolders(projects, sessions)
     expect(folders.flatMap(f => f.sessions.map(s => s.id))).toEqual([])
   })
+
+  it('adopted unstamped sessions sharing a created_at sort stably by id', () => {
+    // Regression: bespin (v1 spoke) rehydrates sessions at startup and
+    // stamps them all with the same second-precision RFC3339
+    // created_at. The hub adopts them into a local folder via match
+    // rules; without a deterministic tiebreaker in
+    // compareLocalFolderSessions the sidebar order shuffled on every
+    // snapshot.sessions emit (Go map iteration is randomized).
+    const projects: ProjectItem[] = [
+      { slug: 'gmux', match: [{ path: '/dev/gmux' }] },
+    ]
+    const ts = '2026-05-16T12:00:00Z'
+    const a = makeSession({ id: 'a@bespin', cwd: '/dev/gmux', alive: true, peer: 'bespin', created_at: ts })
+    const b = makeSession({ id: 'b@bespin', cwd: '/dev/gmux', alive: true, peer: 'bespin', created_at: ts })
+    const c = makeSession({ id: 'c@bespin', cwd: '/dev/gmux', alive: true, peer: 'bespin', created_at: ts })
+
+    // Iterate the three possible reorderings the wire might present.
+    // All must produce the same on-screen order.
+    const ordersIn = [
+      [a, b, c],
+      [c, a, b],
+      [b, c, a],
+    ]
+    for (const input of ordersIn) {
+      const folder = buildProjectFolders(projects, input)[0]
+      expect(folder.sessions.map(s => s.id)).toEqual([
+        'a@bespin', 'b@bespin', 'c@bespin',
+      ])
+    }
+  })
 })
 
 describe('isSessionVisibleInProject', () => {
@@ -645,6 +675,34 @@ describe('buildProjectTopology', () => {
     const hosts = buildProjectTopology('fluxer', sessions, projects2, peers)
     expect(hosts).toHaveLength(1)
     expect(hosts[0].folders[0].sessions.map(s => s.id)).toEqual(['f1'])
+  })
+
+  it('sessions sharing a created_at sort stably by id within a cwd group', () => {
+    // Same regression as the sidebar (v1-spoke rehydrate: many
+    // sessions with identical second-precision created_at). The hub
+    // page groups by cwd; within a group, sortHubSessions ties
+    // without an id fallback and the rows flip whenever
+    // snapshot.sessions re-emits with a different Go map order.
+    const ts = '2026-05-16T12:00:00Z'
+    const peerSessions = [
+      makeSession({ id: 'a@bespin', cwd: '/home/mg/dev/fluxer', alive: true, peer: 'bespin', created_at: ts }),
+      makeSession({ id: 'b@bespin', cwd: '/home/mg/dev/fluxer', alive: true, peer: 'bespin', created_at: ts }),
+      makeSession({ id: 'c@bespin', cwd: '/home/mg/dev/fluxer', alive: true, peer: 'bespin', created_at: ts }),
+    ]
+    const bespinPeers: PeerInfo[] = [
+      { name: 'bespin', url: 'http://10.0.0.5:8790', status: 'connected', session_count: 3 },
+    ]
+    for (const input of [
+      [peerSessions[0], peerSessions[1], peerSessions[2]],
+      [peerSessions[2], peerSessions[0], peerSessions[1]],
+      [peerSessions[1], peerSessions[2], peerSessions[0]],
+    ]) {
+      const hosts = buildProjectTopology('fluxer', input, projects, bespinPeers)
+      const bespinHost = hosts.find(h => h.path[0] === 'bespin')!
+      expect(bespinHost.folders[0].sessions.map(s => s.id)).toEqual([
+        'a@bespin', 'b@bespin', 'c@bespin',
+      ])
+    }
   })
 })
 

--- a/apps/gmux-web/src/projects.test.ts
+++ b/apps/gmux-web/src/projects.test.ts
@@ -5,6 +5,7 @@ import {
   matchSession,
   buildProjectFolders,
   parseSessionHostPath,
+  reorderKeysForFolder,
   buildProjectTopology,
   isSessionVisibleInProject,
   slugify,
@@ -433,6 +434,58 @@ describe('parseSessionHostPath', () => {
     expect(parseSessionHostPath('file-abc-123@peer')).toEqual({
       originalId: 'file-abc-123', path: ['peer'],
     })
+  })
+})
+
+describe('reorderKeysForFolder', () => {
+  // Greptile flagged that the sidebar's drag-end was sending
+  // `s.slug || s.id` to the peer reorder endpoint. For slugless
+  // peer-owned sessions that evaluates to the hub-namespaced id
+  // (`"orig@peer"`), which the peer's ReorderSessions treats as a
+  // new entry and prepends to projects.json. Each drag would
+  // append a phantom key. These cases pin the corruption-prevention
+  // contract.
+
+  it('peer folder: strips @<peer> namespace from slugless ids', () => {
+    const sessions = [
+      makeSession({ id: 'a@tower', cwd: '/x', slug: '', peer: 'tower' }),
+      makeSession({ id: 'b@tower', cwd: '/x', slug: '', peer: 'tower' }),
+    ]
+    // Without stripping, the peer's projects.json would gain phantom
+    // "a@tower" / "b@tower" entries while its real "a" / "b" keys
+    // are pushed to the tail.
+    expect(reorderKeysForFolder(sessions, 'tower')).toEqual(['a', 'b'])
+  })
+
+  it('peer folder: keeps slug as-is for slugged sessions', () => {
+    const sessions = [
+      makeSession({ id: 'a@tower', cwd: '/x', slug: 'fix-auth', peer: 'tower' }),
+      makeSession({ id: 'b@tower', cwd: '/x', slug: 'login-page', peer: 'tower' }),
+    ]
+    expect(reorderKeysForFolder(sessions, 'tower')).toEqual(['fix-auth', 'login-page'])
+  })
+
+  it('local folder: drops adopted peer-owned sessions', () => {
+    // A local folder showing a peer session adopted via match rules:
+    // sending it to the local /v1/projects PATCH would write the
+    // namespaced id into the viewer's own projects.json, polluting
+    // future Reconcile passes.
+    const sessions = [
+      makeSession({ id: 'local-1', cwd: '/x', slug: 'fix-auth' }),
+      makeSession({ id: 'adopted@spoke', cwd: '/x', slug: '', peer: 'spoke' }),
+      makeSession({ id: 'local-2', cwd: '/x', slug: '' }),
+    ]
+    expect(reorderKeysForFolder(sessions, undefined))
+      .toEqual(['fix-auth', 'local-2'])
+  })
+
+  it('returns empty when no session matches the folder owner', () => {
+    // Caller short-circuits on empty: the daemon shouldn't see a
+    // request that boils down to "reorder nothing".
+    const sessions = [
+      makeSession({ id: 'a@spoke', cwd: '/x', slug: '', peer: 'spoke' }),
+    ]
+    expect(reorderKeysForFolder(sessions, 'tower')).toEqual([])
   })
 })
 

--- a/apps/gmux-web/src/projects.ts
+++ b/apps/gmux-web/src/projects.ts
@@ -4,7 +4,7 @@
 // Builds sidebar folders and project hub topology. Pure functions with
 // no side effects or signal dependencies.
 
-import type { Session, Folder, ProjectItem, PeerInfo } from './types'
+import type { Session, Folder, ProjectItem, PeerInfo, DiscoveredProject } from './types'
 
 // --- Remote normalization (mirrors Go NormalizeRemote) ---
 
@@ -93,71 +93,272 @@ export function matchSession(
   return bestPath ?? firstRemote
 }
 
+// --- Slug helpers (mirror Go projects.Slugify, SlugFromRemote, SlugFromPath) ---
+
+/**
+ * Convert a string to a URL-safe slug. Mirrors Go projects.Slugify:
+ * lowercases, maps non-alnum to '-', collapses runs of '-', trims '-'
+ * from both ends. Returns 'project' for empty results.
+ */
+export function slugify(s: string): string {
+  s = s.toLowerCase()
+  let out = ''
+  for (const ch of s) {
+    if ((ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9')) out += ch
+    else out += '-'
+  }
+  while (out.includes('--')) out = out.replaceAll('--', '-')
+  out = out.replace(/^-+|-+$/g, '')
+  return out || 'project'
+}
+
+/** Derive a slug from a git remote URL by slugifying the repo name
+ * (last segment of the normalized URL). */
+export function slugFromRemote(remote: string): string {
+  const norm = normalizeRemote(remote)
+  const parts = norm.split('/')
+  return slugify(parts[parts.length - 1] ?? '')
+}
+
+/** Derive a slug from a filesystem path by slugifying the basename.
+ * Cwd values reaching the frontend are already canonicalized server-side,
+ * so a simple last-segment extraction matches the Go SlugFromPath behaviour. */
+export function slugFromPath(p: string): string {
+  const trimmed = p.replace(/\/+$/, '')
+  const idx = trimmed.lastIndexOf('/')
+  const base = idx >= 0 ? trimmed.slice(idx + 1) : trimmed
+  return slugify(base)
+}
+
+// --- Discovered projects + unmatched active count ---
+//
+// These were previously computed server-side (projects.State.Discovered
+// and UnmatchedActiveCount). Per ADR 0001 they're per-viewer concerns:
+// each frontend computes them from its merged sessions + projects view
+// rather than the server pushing them in the snapshot. Pure functions
+// here; the store wires them up as `computed()` projections.
+
+/** Most frequently appearing normalized remote URL across the given
+ * sessions, or '' if none have remotes. Tie-break: lexicographically
+ * earliest URL wins (matches Go mostCommonRemote). */
+export function mostCommonRemote(sessions: Session[]): string {
+  const counts = new Map<string, number>()
+  for (const s of sessions) {
+    if (!s.remotes) continue
+    for (const url of Object.values(s.remotes)) {
+      const norm = normalizeRemote(url)
+      counts.set(norm, (counts.get(norm) ?? 0) + 1)
+    }
+  }
+  let best = ''
+  let bestN = 0
+  for (const [url, n] of counts.entries()) {
+    if (n > bestN || (n === bestN && url < best)) {
+      best = url
+      bestN = n
+    }
+  }
+  return best
+}
+
+/** Group sessions that aren't claimed by any project, bucketed by
+ * directory (workspace_root if set, else cwd). Each bucket becomes one
+ * suggested project.
+ *
+ * Per ADR 0002, claimed sessions (`project_slug != ""`) have a definite
+ * home on their origin host; only disclaimed sessions are eligible for
+ * discovery, and only those the viewer's own rules don't already adopt.
+ * That makes "discovered" exactly the set of sessions the user might
+ * reasonably want to file into a new local project. */
+export function discoverProjects(
+  sessions: Session[],
+  projects: ProjectItem[],
+): DiscoveredProject[] {
+  const byDir = new Map<string, Session[]>()
+  for (const s of sessions) {
+    if (s.project_slug) continue            // claimed by origin: not free game
+    if (matchSession(s, projects)) continue  // already adopted by viewer's rules
+    const dir = s.workspace_root || s.cwd
+    if (!dir) continue
+    let bucket = byDir.get(dir)
+    if (!bucket) { bucket = []; byDir.set(dir, bucket) }
+    bucket.push(s)
+  }
+  if (byDir.size === 0) return []
+
+  const result: DiscoveredProject[] = []
+  for (const [dir, group] of byDir.entries()) {
+    const active = group.filter(s => s.alive).length
+    const remote = mostCommonRemote(group)
+    let suggested = remote ? slugFromRemote(remote) : ''
+    if (!suggested) suggested = slugFromPath(dir)
+    if (!suggested) suggested = 'project'
+    const dp: DiscoveredProject = {
+      suggested_slug: suggested,
+      paths: [dir],
+      session_count: group.length,
+      active_count: active,
+    }
+    if (remote) dp.remote = remote
+    result.push(dp)
+  }
+
+  // Active first, then most sessions, then alphabetically.
+  result.sort((a, b) => {
+    if (a.active_count !== b.active_count) return b.active_count - a.active_count
+    if (a.session_count !== b.session_count) return b.session_count - a.session_count
+    return a.suggested_slug < b.suggested_slug ? -1 : a.suggested_slug > b.suggested_slug ? 1 : 0
+  })
+  return result
+}
+
+/** Number of alive sessions outside any project, in the viewer's view.
+ * Drives the "N active sessions outside any project" badge.
+ *
+ * Per ADR 0002, a session is "outside any project" iff its origin
+ * disclaims it (`project_slug == ""`) AND the viewer's own match rules
+ * don't adopt it. Claimed peer sessions live in the peer's folder;
+ * claimed local sessions live in the viewer's folder; neither counts. */
+export function countUnmatchedActive(
+  sessions: Session[],
+  projects: ProjectItem[],
+): number {
+  let count = 0
+  for (const s of sessions) {
+    if (!s.alive) continue
+    if (s.project_slug) continue           // claimed by origin
+    if (matchSession(s, projects)) continue // adopted by viewer
+    count++
+  }
+  return count
+}
+
 // --- Sidebar folders ---
 
 /**
- * Build Folder[] from configured projects + live sessions.
- * Each project becomes a folder with its matched sessions.
- * Order follows the project list order (user-controlled).
+ * Build the sidebar folder list per ADR 0002.
+ *
+ * Two kinds of folder come out of this:
+ *
+ *   1. **Local folders**: one per entry in the viewer's `projects` list,
+ *      in `Items[]` order (user-controlled). Even an empty local folder
+ *      renders, so the user always sees their own configuration.
+ *   2. **Peer folders**: derived implicitly from `(peer, project_slug)`
+ *      pairs that appear on stamped sessions. A peer folder exists iff
+ *      at least one visible session carries that pair. Sorted
+ *      deterministically by peer name then slug. Two hosts that share
+ *      a slug get two distinct folders.
+ *
+ * Each session is routed to one folder (or none) by the rule:
+ *
+ *   - If `s.project_slug != ""` (claimed by origin):
+ *       bucket into folder `(s.peer, s.project_slug)`.
+ *       Sort key is `s.project_index` (origin's authoritative position).
+ *   - Else (disclaimed): run the viewer's `matchSession` against its
+ *     own projects. If matched, the session is *adopted* into that
+ *     local folder; sort key is `created_at`. If unmatched, the
+ *     session is visible only via `discoverProjects` /
+ *     `countUnmatchedActive`.
+ *
+ * Visibility filter: alive sessions always render; dead sessions render
+ * only when claimed by the folder they'd be in. Disclaimed-adopted dead
+ * sessions are hidden (the viewer's intent didn't put them in any array;
+ * the rule is the only thread holding them, and a dead session can't
+ * acquire new context to validate the match).
  */
 export function buildProjectFolders(
   projects: ProjectItem[],
   sessions: Session[],
 ): Folder[] {
+  // Bucket every session by `${peer ?? ''}::${slug}`. An empty peer
+  // segment marks a viewer-owned (local) bucket.
   const buckets = new Map<string, Session[]>()
-  for (const project of projects) {
-    buckets.set(project.slug, [])
+  const bucket = (peer: string, slug: string, s: Session): void => {
+    const key = `${peer}::${slug}`
+    let arr = buckets.get(key)
+    if (!arr) { arr = []; buckets.set(key, arr) }
+    arr.push(s)
   }
 
-  // Build a lookup of session keys per project for dead-session filtering.
-  // Alive sessions show by match rules (immediate, no auto-assign lag).
-  // Dead sessions only show if they're in the project's sessions array
-  // (i.e., they were alive while the project existed).
-  const arrayKeys = new Map<string, Set<string>>()
-  for (const project of projects) {
-    arrayKeys.set(project.slug, new Set(project.sessions ?? []))
-  }
-
-  for (const session of sessions) {
-    const matched = matchSession(session, projects)
-    if (!matched || !buckets.has(matched.slug)) continue
-
-    if (session.alive) {
-      buckets.get(matched.slug)!.push(session)
+  for (const s of sessions) {
+    if (s.project_slug) {
+      // Claimed by origin. Bucket under (peer, slug); peer may be
+      // empty (local-claimed: viewer is the origin).
+      bucket(s.peer ?? '', s.project_slug, s)
     } else {
-      // Dead session: only include if it's in the project's sessions array.
-      const keys = arrayKeys.get(matched.slug)!
-      const key = session.slug || session.id
-      if (keys.has(key) || keys.has(session.id)) {
-        buckets.get(matched.slug)!.push(session)
-      }
+      // Disclaimed: free-game adoption by the viewer's rules.
+      const matched = matchSession(s, projects)
+      if (matched) bucket('', matched.slug, s)
+      // else: not in any folder; surfaces via discoverProjects.
     }
   }
 
   const folders: Folder[] = []
+
+  // 1. Local folders, in viewer's Items[] order. Always emitted, even
+  //    when empty: the user's own configuration is always visible.
   for (const project of projects) {
-    const matched = buckets.get(project.slug) || []
+    const ss = buckets.get(`::${project.slug}`) ?? []
+    const visible = ss.filter(
+      s => s.alive || (s.resumable === true && s.project_slug === project.slug),
+    )
+    visible.sort(compareLocalFolderSessions)
     folders.push({
+      key: project.slug,
+      slug: project.slug,
       name: project.slug,
-      path: project.slug,
       launchCwd: project.match.find(r => r.path)?.path,
-      sessions: matched.sort((a, b) => {
-        // The sessions array is the canonical order. Sessions not yet
-        // in the array (just spawned, auto-assign pending) go at the
-        // end sorted by creation time.
-        const keys = project.sessions ?? []
-        const keyOf = (s: Session) => s.slug || s.id
-        const ai = keys.indexOf(keyOf(a))
-        const bi = keys.indexOf(keyOf(b))
-        if (ai !== -1 && bi !== -1) return ai - bi
-        if (ai !== -1) return -1
-        if (bi !== -1) return 1
-        return new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
-      }),
+      sessions: visible,
     })
   }
 
+  // 2. Peer folders, by (peer, slug). Empty peer folders are skipped
+  //    — nothing on the wire enumerates peer projects, so an empty
+  //    folder would be a viewer fiction.
+  const peerFolders: Folder[] = []
+  for (const [key, ss] of buckets) {
+    if (key.startsWith('::')) continue // local: handled above
+    const sep = key.indexOf('::')
+    const peer = key.slice(0, sep)
+    const slug = key.slice(sep + 2)
+    const visible = ss.filter(s => s.alive || s.resumable === true)
+    if (visible.length === 0) continue
+    visible.sort((a, b) => (a.project_index ?? 0) - (b.project_index ?? 0))
+    peerFolders.push({
+      key,
+      slug,
+      name: slug,
+      peer,
+      sessions: visible,
+    })
+  }
+  peerFolders.sort((a, b) => {
+    const peerCmp = (a.peer ?? '').localeCompare(b.peer ?? '')
+    return peerCmp !== 0 ? peerCmp : a.slug.localeCompare(b.slug)
+  })
+  folders.push(...peerFolders)
+
   return folders
+}
+
+/**
+ * Sort key for a session inside a *local* folder.
+ *
+ * Stamped (claimed-local) sessions sort first by `project_index` — the
+ * origin's authoritative position, equivalent to the index in
+ * `project.sessions[]`. Unstamped sessions (disclaimed-adopted via
+ * the viewer's match rules) come after, ordered by creation time so
+ * newly-spawned sessions don't reshuffle existing ones.
+ */
+function compareLocalFolderSessions(a: Session, b: Session): number {
+  const aStamped = !!a.project_slug
+  const bStamped = !!b.project_slug
+  if (aStamped && bStamped) {
+    return (a.project_index ?? 0) - (b.project_index ?? 0)
+  }
+  if (aStamped) return -1
+  if (bStamped) return 1
+  return new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
 }
 
 // --- Project hub topology ---

--- a/apps/gmux-web/src/projects.ts
+++ b/apps/gmux-web/src/projects.ts
@@ -411,6 +411,36 @@ export function parseSessionHostPath(sessionId: string): { originalId: string; p
 }
 
 /**
+ * Build the keys to send to `PATCH /v1/projects/{slug}/sessions` (or
+ * its peer-proxy equivalent) given the order the viewer just dragged
+ * a folder into. Two responsibilities:
+ *
+ *  1. Filter out sessions not owned by the folder's owner. A local
+ *     folder may visually contain peer-owned sessions adopted via
+ *     match rules; those don't live in the local projects.json, and
+ *     sending them would add phantom entries on the daemon's next
+ *     ReorderSessions merge.
+ *
+ *  2. Strip the `@<peer>` namespace from slugless ids. A peer-owned
+ *     session has `s.id === "orig@peer"` on the wire, but the peer's
+ *     projects.json keys by `"orig"`. Slugged sessions key by
+ *     `s.slug`, which is never namespaced.
+ *
+ * Returns an empty array when no session in the request belongs to
+ * the folder owner: caller should skip the PATCH entirely so the
+ * daemon doesn't see an empty reorder.
+ */
+export function reorderKeysForFolder(
+  reorderedSessions: Session[],
+  folderPeer: string | undefined,
+): string[] {
+  const ownerPeer = folderPeer ?? ''
+  return reorderedSessions
+    .filter(s => (s.peer ?? '') === ownerPeer)
+    .map(s => s.slug || parseSessionHostPath(s.id).originalId)
+}
+
+/**
  * Build the host topology for a single project. Sessions that match the
  * project are bucketed by their host path (derived from the session id
  * chain), then by cwd within each host. Used by the project hub page.

--- a/apps/gmux-web/src/projects.ts
+++ b/apps/gmux-web/src/projects.ts
@@ -349,6 +349,14 @@ export function buildProjectFolders(
  * `project.sessions[]`. Unstamped sessions (disclaimed-adopted via
  * the viewer's match rules) come after, ordered by creation time so
  * newly-spawned sessions don't reshuffle existing ones.
+ *
+ * Tiebreak on `id` for unstamped pairs because `created_at` is
+ * RFC3339 with second precision on the wire, so sessions launched in
+ * the same second tie. Without a stable tiebreaker, the sidebar
+ * order would shuffle every time `snapshot.sessions` re-emits with a
+ * different Go map-iteration order (most visible when adopting
+ * sessions from a v1 spoke whose rehydrated entries all share a
+ * second).
  */
 function compareLocalFolderSessions(a: Session, b: Session): number {
   const aStamped = !!a.project_slug
@@ -358,7 +366,9 @@ function compareLocalFolderSessions(a: Session, b: Session): number {
   }
   if (aStamped) return -1
   if (bStamped) return 1
-  return new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+  const dt = new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+  if (dt !== 0) return dt
+  return a.id.localeCompare(b.id)
 }
 
 // --- Project hub topology ---
@@ -522,11 +532,15 @@ function resolveHostStatusAndMeta(
 }
 
 function sortHubSessions(sessions: Session[]): Session[] {
-  // Alive first, then newest-first.
+  // Alive first, then newest-first. Tiebreak on id so sessions that
+  // share a second-precision created_at (e.g. v1-spoke entries
+  // rehydrated together on startup) keep a stable order across
+  // snapshot.sessions re-emits.
   return [...sessions].sort((a, b) => {
     if (a.alive !== b.alive) return a.alive ? -1 : 1
     const ta = new Date(a.created_at || 0).getTime()
     const tb = new Date(b.created_at || 0).getTime()
-    return tb - ta
+    if (ta !== tb) return tb - ta
+    return a.id.localeCompare(b.id)
   })
 }

--- a/apps/gmux-web/src/routing.test.ts
+++ b/apps/gmux-web/src/routing.test.ts
@@ -47,6 +47,21 @@ describe('parseSessionPath', () => {
     })
   })
 
+  it('parses /@<owner>/<project> as a peer-owned project hub', () => {
+    expect(parseSessionPath('/@tower/gmux'))
+      .toEqual({ projectPeer: 'tower', project: 'gmux' })
+  })
+
+  it('parses /@<owner> alone as the peer with no project', () => {
+    expect(parseSessionPath('/@tower'))
+      .toEqual({ projectPeer: 'tower' })
+  })
+
+  it('parses /@<owner>/<project>/<adapter>/<slug> as a peer-project session', () => {
+    expect(parseSessionPath('/@tower/gmux/pi/fix-auth'))
+      .toEqual({ projectPeer: 'tower', project: 'gmux', adapter: 'pi', slug: 'fix-auth' })
+  })
+
   it('does not treat non-@ second segment as host', () => {
     expect(parseSessionPath('/gmux/pi')).toEqual({
       project: 'gmux', adapter: 'pi',
@@ -68,6 +83,26 @@ describe('sessionPath', () => {
   it('includes @peer for remote sessions', () => {
     expect(sessionPath('gmux', { kind: 'pi', slug: 'fix-auth', id: 'abc', peer: 'server' }))
       .toBe('/gmux/@server/pi/fix-auth')
+  })
+
+  it('peer-owned project: leading @owner, no redundant mid-path host', () => {
+    // The session lives on the project's owner, so the mid-path host
+    // segment is redundant and is omitted.
+    expect(sessionPath(
+      'gmux',
+      { id: 'sess-1@tower', kind: 'pi', slug: 'fix-auth', peer: 'tower' },
+      'tower',
+    )).toBe('/@tower/gmux/pi/fix-auth')
+  })
+
+  it('local project + adopted peer session: keeps mid-path @host', () => {
+    // Disclaimed peer session adopted into a local folder. The project
+    // owner is local (no leading @), but the session lives on a peer
+    // (mid-path @<host> needed to disambiguate).
+    expect(sessionPath(
+      'gmux',
+      { id: 'sess-1@dev', kind: 'pi', slug: 'fix-auth', peer: 'dev' },
+    )).toBe('/gmux/@dev/pi/fix-auth')
   })
 
   it('omits @peer for local sessions', () => {
@@ -156,6 +191,37 @@ describe('resolveSessionFromPath', () => {
     )
     expect(id).toBe('sess-abc12345')
   })
+
+  it('resolves a peer-owned project URL via stamps, not viewer rules', () => {
+    // Peer 'tower' has its own 'gmux' project. The viewer also has
+    // a 'gmux' project, but the URL `/@tower/gmux/...` addresses the
+    // peer-owned one; we must trust the stamp, not re-run match.
+    const claimed = makeSession({
+      id: 'sess-t1@tower', cwd: '/elsewhere', kind: 'pi', slug: 'fix-auth',
+      peer: 'tower', project_slug: 'gmux', project_index: 0,
+    })
+    const id = resolveSessionFromPath(
+      { projectPeer: 'tower', project: 'gmux', adapter: 'pi', slug: 'fix-auth' },
+      projects, [claimed],
+    )
+    expect(id).toBe('sess-t1@tower')
+  })
+
+  it('peer-owned project URL ignores local-stamped same-slug sessions', () => {
+    const localGmux = makeSession({
+      id: 'sess-local', cwd: '/dev/gmux', kind: 'pi', slug: 'fix-auth',
+      project_slug: 'gmux', project_index: 0,
+    })
+    const towerGmux = makeSession({
+      id: 'sess-t@tower', cwd: '/elsewhere', kind: 'pi', slug: 'fix-auth',
+      peer: 'tower', project_slug: 'gmux', project_index: 0,
+    })
+    const id = resolveSessionFromPath(
+      { projectPeer: 'tower', project: 'gmux', adapter: 'pi', slug: 'fix-auth' },
+      projects, [localGmux, towerGmux],
+    )
+    expect(id).toBe('sess-t@tower')
+  })
 })
 
 describe('resolveViewFromPath', () => {
@@ -189,6 +255,20 @@ describe('resolveViewFromPath', () => {
     expect(resolveViewFromPath('/gmux', projects, [])).toEqual({
       kind: 'project', projectSlug: 'gmux',
     })
+  })
+
+  it('peer-owned project URL resolves to project view when sessions exist', () => {
+    const peerSession = makeSession({
+      id: 'sess-t@tower', cwd: '/elsewhere', kind: 'pi', slug: 'fix-auth',
+      peer: 'tower', project_slug: 'gmux', project_index: 0,
+    })
+    expect(resolveViewFromPath('/@tower/gmux', projects, [peerSession])).toEqual({
+      kind: 'project', projectSlug: 'gmux', projectPeer: 'tower',
+    })
+  })
+
+  it('peer-owned project URL with no matching sessions resolves to home', () => {
+    expect(resolveViewFromPath('/@tower/gmux', projects, sessions)).toEqual({ kind: 'home' })
   })
 
   it('unknown project resolves to home', () => {
@@ -260,6 +340,35 @@ describe('viewToPath', () => {
   it('session view for unmatched session -> null', () => {
     const orphan = makeSession({ id: 'orphan', cwd: '/nowhere', kind: 'pi' })
     expect(viewToPath({ kind: 'session', sessionId: 'orphan' }, projects, [orphan])).toBeNull()
+  })
+
+  it('peer-owned project hub view -> /@<owner>/<slug>', () => {
+    expect(viewToPath(
+      { kind: 'project', projectSlug: 'gmux', projectPeer: 'tower' },
+      projects, sessions,
+    )).toBe('/@tower/gmux')
+  })
+
+  it('peer-claimed session -> /@<owner>/<slug>/...', () => {
+    const claimed = makeSession({
+      id: 'sess-c@tower', cwd: '/dev/gmux', kind: 'pi', slug: 'on-tower',
+      peer: 'tower', project_slug: 'gmux', project_index: 0,
+    })
+    expect(viewToPath(
+      { kind: 'session', sessionId: 'sess-c@tower' },
+      projects, [claimed],
+    )).toBe('/@tower/gmux/pi/on-tower')
+  })
+
+  it('local-claimed session uses local URL form', () => {
+    const claimed = makeSession({
+      id: 'sess-l', cwd: '/dev/gmux', kind: 'pi', slug: 'local',
+      project_slug: 'gmux', project_index: 0,
+    })
+    expect(viewToPath(
+      { kind: 'session', sessionId: 'sess-l' },
+      projects, [claimed],
+    )).toBe('/gmux/pi/local')
   })
 })
 

--- a/apps/gmux-web/src/routing.ts
+++ b/apps/gmux-web/src/routing.ts
@@ -12,45 +12,78 @@ import { matchSession } from './projects'
  * Parse a URL path into project/host/adapter/slug segments.
  *
  * URL hierarchy:
- *   /<project>/<adapter>/<slug>              (local)
- *   /<project>/@<host>/<adapter>/<slug>       (remote, future)
+ *   /<project>/<adapter>/<slug>                       (local project)
+ *   /<project>/@<host>/<adapter>/<slug>               (local project, peer session adopted)
+ *   /@<owner>/<project>/<adapter>/<slug>              (peer-owned project, ADR 0002)
  *
- * The @-prefix on the second segment distinguishes a remote host
- * from an adapter name.
+ * The leading-`@` segment qualifies *project ownership*: the project
+ * lives on the named peer's host. The mid-path `@<host>` segment
+ * qualifies a *session's host* within a project (used when a viewer
+ * has adopted a disclaimed peer session into a local folder).
  */
 export function parseSessionPath(path: string): {
+  /** Project slug. */
   project?: string
+  /** Project owner peer (when path begins with `/@<owner>/...`). */
+  projectPeer?: string
+  /** Session host within a project (mid-path `@<host>`). */
   host?: string
   adapter?: string
   slug?: string
 } {
   // Strip leading slash and split.
-  const parts = path.replace(/^\//, '').split('/').filter(Boolean)
+  let parts = path.replace(/^\//, '').split('/').filter(Boolean)
   if (parts.length === 0) return {}
   // Skip internal routes.
   if (parts[0] === '_') return {}
-  if (parts.length === 1) return { project: parts[0] }
-  // @-prefixed second segment is a remote host (future: aggregation).
+
+  // Leading @<owner> qualifies project ownership.
+  let projectPeer: string | undefined
+  if (parts[0].startsWith('@')) {
+    projectPeer = parts[0].slice(1)
+    parts = parts.slice(1)
+    if (parts.length === 0) return { projectPeer }
+  }
+
+  if (parts.length === 1) return { projectPeer, project: parts[0] }
+  // @-prefixed second segment is a session host (peer-adopted session).
   if (parts[1].startsWith('@')) {
     const host = parts[1].slice(1)
-    if (parts.length === 2) return { project: parts[0], host }
-    if (parts.length === 3) return { project: parts[0], host, adapter: parts[2] }
-    return { project: parts[0], host, adapter: parts[2], slug: parts[3] }
+    if (parts.length === 2) return { projectPeer, project: parts[0], host }
+    if (parts.length === 3) return { projectPeer, project: parts[0], host, adapter: parts[2] }
+    return { projectPeer, project: parts[0], host, adapter: parts[2], slug: parts[3] }
   }
-  if (parts.length === 2) return { project: parts[0], adapter: parts[1] }
-  return { project: parts[0], adapter: parts[1], slug: parts[2] }
+  if (parts.length === 2) return { projectPeer, project: parts[0], adapter: parts[1] }
+  return { projectPeer, project: parts[0], adapter: parts[1], slug: parts[2] }
 }
 
-/** Build a URL path for a session within a project. */
+/**
+ * Build a URL path for a session within a project.
+ *
+ * `projectPeer` qualifies project ownership: when set, the URL is
+ * peer-prefixed (`/@<owner>/<slug>/...`), reflecting that the project
+ * lives on the named peer (ADR 0002). The session's own host is
+ * encoded by the mid-path `@<host>` segment when it differs from the
+ * project owner (i.e. a disclaimed peer session adopted into a local
+ * folder), and is omitted when project owner and session host match
+ * (since the URL form would be redundant).
+ */
 export function sessionPath(
   projectSlug: string,
   session: { kind: string; slug?: string; id: string; peer?: string },
+  projectPeer?: string,
 ): string {
   const slug = session.slug || session.id.slice(0, 8)
-  if (session.peer) {
-    return `/${projectSlug}/@${session.peer}/${session.kind}/${slug}`
-  }
-  return `/${projectSlug}/${session.kind}/${slug}`
+  const ownerPrefix = projectPeer ? `/@${projectPeer}` : ''
+  // Mid-path session-host segment is needed only when the session
+  // lives on a different host than the project owner.
+  const sessionHost = session.peer && session.peer !== projectPeer ? `/@${session.peer}` : ''
+  return `${ownerPrefix}/${projectSlug}${sessionHost}/${session.kind}/${slug}`
+}
+
+/** Build the URL for a project hub (no session). */
+export function projectPath(slug: string, peer?: string): string {
+  return peer ? `/@${peer}/${slug}` : `/${slug}`
 }
 
 /**
@@ -58,23 +91,48 @@ export function sessionPath(
  * Returns null if no matching session is found.
  */
 export function resolveSessionFromPath(
-  parsed: { project?: string; host?: string; adapter?: string; slug?: string },
+  parsed: { project?: string; projectPeer?: string; host?: string; adapter?: string; slug?: string },
   projects: ProjectItem[],
   sessions: Session[],
 ): string | null {
   if (!parsed.project) return null
-  // Filter by remote host when the URL has an @host segment.
-  const filterPeer = parsed.host ?? undefined
 
-  // Find the project by slug.
-  const project = projects.find(p => p.slug === parsed.project)
-  if (!project) return null
+  // Sessions belonging to the addressed project (ADR 0002):
+  //  - Peer-owned project: stamp matches `(peer, project_slug)`.
+  //  - Local-owned project: stamp matches `("", project_slug)` *or*
+  //    the viewer's match rules adopt a disclaimed session.
+  // The mid-path `@<host>` segment further filters session host
+  // (used when a local folder contains adopted peer sessions).
+  const filterHost = parsed.host
+  const projectSessions = sessions.filter(s => {
+    if (parsed.projectPeer) {
+      // Peer-owned project: trust the stamp.
+      if (s.peer !== parsed.projectPeer) return false
+      if (s.project_slug !== parsed.project) return false
+    } else {
+      // Local project: claimed-local OR disclaimed-adopted.
+      const claimedHere = !s.peer && s.project_slug === parsed.project
+      const adoptedHere = !s.project_slug
+        && matchSession(s, projects)?.slug === parsed.project
+      if (!claimedHere && !adoptedHere) return false
+    }
+    if (filterHost !== undefined && s.peer !== filterHost) return false
+    if (filterHost === undefined && !parsed.projectPeer && s.peer) return false
+    return true
+  })
 
-  // Match sessions to this project, filtering by peer when URL has @host.
-  const projectSessions = sessions.filter(
-    s => matchSession(s, projects)?.slug === parsed.project
-      && (filterPeer === undefined ? !s.peer : s.peer === filterPeer),
-  )
+  // For local projects we still require the project to exist in the
+  // viewer's projects list. Peer-owned projects are valid as long as
+  // they have at least one matching session in view.
+  if (!parsed.projectPeer && !projects.find(p => p.slug === parsed.project)) {
+    return null
+  }
+  if (parsed.projectPeer && projectSessions.length === 0) {
+    return null
+  }
+
+  // Drop the unused `project` const that the original code held; we
+  // already validated existence above and only need the session list.
 
   if (!parsed.adapter) {
     // /:project only - return first alive session, or first session.
@@ -107,12 +165,13 @@ export function resolveSessionFromPath(
  * and drives what the main panel renders.
  *
  *  - `home`: overview / landing (host status, projects, quick-launch)
- *  - `project`: the project hub page for a single project.
+ *  - `project`: the project hub page for a single project. `projectPeer`
+ *    is set for peer-owned projects (ADR 0002); absent for local.
  *  - `session`: a specific terminal session, by id.
  */
 export type View =
   | { kind: 'home' }
-  | { kind: 'project'; projectSlug: string }
+  | { kind: 'project'; projectSlug: string; projectPeer?: string }
   | { kind: 'session'; sessionId: string }
 
 /** Structural equality for views. */
@@ -120,7 +179,10 @@ export function viewsEqual(a: View, b: View): boolean {
   if (a.kind !== b.kind) return false
   switch (a.kind) {
     case 'home': return true
-    case 'project': return a.projectSlug === (b as { projectSlug: string }).projectSlug
+    case 'project': {
+      const bp = b as { projectSlug: string; projectPeer?: string }
+      return a.projectSlug === bp.projectSlug && a.projectPeer === bp.projectPeer
+    }
     case 'session': return a.sessionId === (b as { sessionId: string }).sessionId
   }
 }
@@ -144,18 +206,34 @@ export function resolveViewFromPath(
   const parsed = parseSessionPath(path)
   if (!parsed.project) return { kind: 'home' }
 
-  const project = projects.find(p => p.slug === parsed.project)
-  if (!project) return { kind: 'home' }
+  // Validate that the addressed project exists in the viewer's view.
+  if (parsed.projectPeer) {
+    // Peer-owned: project exists iff at least one session carries the
+    // matching `(peer, slug)` stamp. We don't sync peer projects
+    // separately (ADR 0002); empty peer projects don't render.
+    const hasOne = sessions.some(
+      s => s.peer === parsed.projectPeer && s.project_slug === parsed.project,
+    )
+    if (!hasOne) return { kind: 'home' }
+  } else {
+    if (!projects.find(p => p.slug === parsed.project)) return { kind: 'home' }
+  }
+
+  const projectView: View = {
+    kind: 'project',
+    projectSlug: parsed.project,
+    ...(parsed.projectPeer ? { projectPeer: parsed.projectPeer } : {}),
+  }
 
   // /:project alone goes straight to the project hub.
-  if (!parsed.adapter) return { kind: 'project', projectSlug: project.slug }
+  if (!parsed.adapter) return projectView
 
   // /:project/:adapter[/:slug] resolves to a concrete session when possible.
   const sessionId = resolveSessionFromPath(parsed, projects, sessions)
   if (sessionId) return { kind: 'session', sessionId }
 
   // URL pointed at a session that no longer exists -> fall back to hub.
-  return { kind: 'project', projectSlug: project.slug }
+  return projectView
 }
 
 /**
@@ -172,10 +250,20 @@ export function viewToPath(
     case 'home':
       return '/'
     case 'project':
-      return `/${view.projectSlug}`
+      return projectPath(view.projectSlug, view.projectPeer)
     case 'session': {
       const sess = sessions.find(s => s.id === view.sessionId)
       if (!sess) return null
+      // Peer-owned project (ADR 0002): URL is peer-prefixed; session
+      // lives on the project's owner.
+      if (sess.project_slug && sess.peer) {
+        return sessionPath(sess.project_slug, sess, sess.peer)
+      }
+      // Local-claimed: project owner is the viewer.
+      if (sess.project_slug && !sess.peer) {
+        return sessionPath(sess.project_slug, sess)
+      }
+      // Disclaimed: viewer's match rules decide the local folder.
       const project = matchSession(sess, projects)
       if (!project) return null
       return sessionPath(project.slug, sess)

--- a/apps/gmux-web/src/sidebar.tsx
+++ b/apps/gmux-web/src/sidebar.tsx
@@ -7,6 +7,7 @@
 
 import { useState, useCallback } from 'preact/hooks'
 import { sessionPath } from './routing'
+import { reorderKeysForFolder } from './projects'
 import { LaunchButton } from './launcher'
 import { useArrivalPulse } from './use-arrival-pulse'
 import {
@@ -199,13 +200,15 @@ function FolderGroup({
       return
     }
     const reordered = reorder(visible, drag.from, drag.over)
-    const visibleKeys = reordered.map(s => s.slug || s.id)
-    // We send only the visible keys; the daemon's PATCH handler does
-    // a partial-reorder merge that preserves any keys not in the
-    // request at their existing relative position at the tail. This
-    // lets us reorder peer folders without enumerating the peer's
-    // hidden / dead-resumable entries (which we don't track).
-    reorderSessions(folder.slug, visibleKeys, folder.peer)
+    // reorderKeysForFolder filters non-owner sessions and strips the
+    // `@<peer>` namespace from slugless ids; see its docstring for
+    // the ADR-0002 corruption modes this prevents. The daemon's
+    // PATCH handler then does a partial-reorder merge that keeps
+    // hidden / dead-resumable entries at the tail.
+    const visibleKeys = reorderKeysForFolder(reordered, folder.peer)
+    if (visibleKeys.length > 0) {
+      reorderSessions(folder.slug, visibleKeys, folder.peer)
+    }
     setDrag(null)
   }, [drag, folder.slug, folder.peer])
 

--- a/apps/gmux-web/src/sidebar.tsx
+++ b/apps/gmux-web/src/sidebar.tsx
@@ -10,13 +10,14 @@ import { sessionPath } from './routing'
 import { LaunchButton } from './launcher'
 import { useArrivalPulse } from './use-arrival-pulse'
 import {
-  folders, selectedId, currentProjectSlug,
+  folders, selectedId, currentProjectKey,
   activityMap, unmatchedActiveCount, projects, connState,
   updateProjects, reorderSessions,
+  peerStatusByName, isSessionUnavailable,
   type DotState,
 } from './store'
 import { PeerLabel } from './peer-label'
-import type { Session, Folder, ProjectItem } from './types'
+import type { Session, Folder } from './types'
 
 // ── Types ──
 
@@ -78,6 +79,7 @@ function SessionItem({
   dotState: rawDotState,
   dragging,
   dropTarget,
+  unavailable,
   onClose,
   onClick,
   onDragStart,
@@ -91,6 +93,8 @@ function SessionItem({
   dotState: DotState
   dragging?: boolean
   dropTarget?: boolean
+  /** Session lives on a peer we can't reach right now. */
+  unavailable?: boolean
   onClose?: () => void
   /** Extra side-effects on click (e.g. close mobile sidebar). */
   onClick?: () => void
@@ -109,6 +113,7 @@ function SessionItem({
     selected ? 'selected' : '',
     dragging ? 'session-dragging' : '',
     dropTarget ? 'session-drop-target' : '',
+    unavailable ? 'unavailable' : '',
   ].filter(Boolean).join(' ')
 
   return (
@@ -129,7 +134,9 @@ function SessionItem({
       onDrop={(e) => { e.preventDefault(); onDragEnd?.() }}
       onDragEnd={onDragEnd}
     >
-      {sleeping
+      {unavailable
+        ? <svg class="session-unavailable-icon" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><title>Peer unavailable</title><path d="M2 2 L10 10 M10 2 L2 10" /></svg>
+        : sleeping
         ? <svg class="session-sleep-icon" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><title>Resumable</title><path d="M7 1h4l-4 4h4" /><path d="M1 5h5l-5 6h5" /></svg>
         : <span class={`session-dot-indicator ${dotState}${arrival ? ` ${arrival}` : ''}`} />
       }
@@ -159,20 +166,20 @@ function SessionItem({
 
 function FolderGroup({
   folder,
-  project,
   selId,
-  curProjectSlug,
+  currentKey,
   resumingId,
   am,
+  peerStatus,
   onCloseSession,
   onClick,
 }: {
   folder: Folder
-  project: ProjectItem
   selId: string | null
-  curProjectSlug: string | null
+  currentKey: string | null
   resumingId: string | null
   am: ReadonlyMap<string, 'active' | 'fading'>
+  peerStatus: ReadonlyMap<string, string>
   onCloseSession: (session: Session) => void
   onClick?: () => void
 }) {
@@ -193,31 +200,36 @@ function FolderGroup({
     }
     const reordered = reorder(visible, drag.from, drag.over)
     const visibleKeys = reordered.map(s => s.slug || s.id)
-    // Preserve keys of non-visible sessions (dead, non-resumable) at the end.
-    const visibleSet = new Set(visibleKeys)
-    const hidden = (project.sessions ?? []).filter(k => !visibleSet.has(k))
-    reorderSessions(project.slug, [...visibleKeys, ...hidden])
+    // We send only the visible keys; the daemon's PATCH handler does
+    // a partial-reorder merge that preserves any keys not in the
+    // request at their existing relative position at the tail. This
+    // lets us reorder peer folders without enumerating the peer's
+    // hidden / dead-resumable entries (which we don't track).
+    reorderSessions(folder.slug, visibleKeys, folder.peer)
     setDrag(null)
-  }, [drag, project])
+  }, [drag, folder.slug, folder.peer])
 
   const visible = folder.sessions.filter(s => s.alive || s.resumable)
   const displayItems = drag ? reorder(visible, drag.from, drag.over) : visible
-  const isCurrent = curProjectSlug === folder.path
+  const isCurrent = currentKey === folder.key
+  const href = folder.peer ? `/@${folder.peer}/${folder.slug}` : `/${folder.slug}`
   return (
     <div class="folder">
       <div class="folder-header">
         <a
           class={`folder-name${isCurrent ? ' current' : ''}`}
-          href={`/${folder.path}`}
+          href={href}
           title={`Open ${folder.name} hub`}
           onClick={onClick}
         >
+          {folder.peer && <PeerLabel name={folder.peer} />}
           {folder.name}
         </a>
         <LaunchButton
           sessions={folder.sessions}
           selectedId={selId}
           fallbackCwd={folder.launchCwd ?? ''}
+          peer={folder.peer}
           className="folder-launch-btn"
         />
       </div>
@@ -226,10 +238,11 @@ function FolderGroup({
           <SessionItem
             key={s.id}
             session={s}
-            href={sessionPath(folder.path, s)}
+            href={sessionPath(folder.slug, s, folder.peer)}
             selected={selId === s.id}
             resuming={resumingId === s.id}
             dotState={sessionDotState(s, am)}
+            unavailable={isSessionUnavailable(s, peerStatus)}
             dragging={drag !== null && s.id === visible[drag.from]?.id}
             dropTarget={drag !== null && drag.over === i && drag.from !== i}
             onClose={() => onCloseSession(s)}
@@ -265,10 +278,10 @@ export function Sidebar({
   const foldersVal = folders.value
   const projectsVal = projects.value
   const selId = selectedId.value
-  const curProjectSlug = currentProjectSlug.value
+  const curKey = currentProjectKey.value
   const unmatchedCount = unmatchedActiveCount.value
   const am = activityMap.value
-  const projectBySlug = new Map(projectsVal.map(p => [p.slug, p]))
+  const peerStatus = peerStatusByName.value
 
   const totalVisible = foldersVal.reduce(
     (n, f) => n + f.sessions.filter(s => s.alive || s.resumable).length, 0,
@@ -304,23 +317,19 @@ export function Sidebar({
           )}
         </div>
         <div class="sidebar-scroll">
-          {foldersVal.map(f => {
-            const proj = projectBySlug.get(f.path)
-            if (!proj) return null
-            return (
-              <FolderGroup
-                key={f.path}
-                folder={f}
-                project={proj}
-                selId={selId}
-                curProjectSlug={curProjectSlug}
-                resumingId={resumingId}
-                am={am}
-                onCloseSession={onCloseSession}
-                onClick={onClose}
-              />
-            )
-          })}
+          {foldersVal.map(f => (
+            <FolderGroup
+              key={f.key}
+              folder={f}
+              selId={selId}
+              currentKey={curKey}
+              resumingId={resumingId}
+              am={am}
+              peerStatus={peerStatus}
+              onCloseSession={onCloseSession}
+              onClick={onClose}
+            />
+          ))}
           {connected && totalVisible === 0 && !hasProjects && (
             <div class="sidebar-hint">
               Click <strong>+</strong> to start your first session.

--- a/apps/gmux-web/src/store.test.ts
+++ b/apps/gmux-web/src/store.test.ts
@@ -333,6 +333,25 @@ describe('navigateToSession', () => {
     expect(url).toMatch(/^\/myproject\/shell\//)
     expect(replace).toBe(true)
   })
+
+  it('routes peer-owned sessions through /@<peer>/<slug>/...', () => {
+    // Peer-stamped session: project_slug + peer set, viewer has no
+    // local match rule. Without ADR-0002 awareness this would either
+    // return false (matchSession finds no project) or build a URL
+    // missing the @<peer> prefix, which the e2e helper then can't
+    // round-trip back to a session view.
+    _setRawWorld({ projects: [] })
+    _rawSessions.value = [makeSession({
+      id: 'remote-1',
+      kind: 'shell',
+      slug: 'remote-1-slug',
+      peer: 'workstation',
+      project_slug: 'gmux',
+    })]
+    expect(navigateToSession('remote-1')).toBe(true)
+    const [url] = navigateMock.mock.calls[0]
+    expect(url).toBe('/@workstation/gmux/shell/remote-1-slug')
+  })
 })
 
 describe('peerAppearance', () => {

--- a/apps/gmux-web/src/store.test.ts
+++ b/apps/gmux-web/src/store.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
-import { sessions, sessionsLoaded, projects, upsertSession, removeSession, markSessionRead, handleActivity, isSessionActive, isSessionFading, activityMap, sessionStaleness, peers, peerAppearance, urlPath, selectedId, navigateToSession, setNavigate } from './store'
+import {
+  sessions, sessionsLoaded, projects, upsertSession, removeSession,
+  markSessionRead, dismissSession, reorderSessions,
+  handleActivity, isSessionActive, isSessionFading, activityMap,
+  sessionStaleness, peers, peerAppearance, peerStatusByName,
+  isSessionUnavailable, urlPath, selectedId,
+  navigateToSession, setNavigate,
+  applyPending, _rawSessions, _rawWorld, _setRawWorld, _pendingMutations,
+} from './store'
+import type { PendingMutation } from './store'
 import type { Session } from './types'
 import type { ProjectItem } from './types'
 
@@ -27,8 +36,9 @@ function makeSession(overrides: Partial<Session> & { id: string }): Session {
 
 // Reset signal state between tests.
 beforeEach(() => {
-  sessions.value = []
-  projects.value = []
+  _rawSessions.value = []
+  _setRawWorld({ projects: [], peers: [] })
+  _pendingMutations.value = []
   sessionsLoaded.value = false
   urlPath.value = '/'
 })
@@ -45,7 +55,7 @@ describe('upsertSession', () => {
   })
 
   it('updates an existing session and returns false', () => {
-    sessions.value = [makeSession({ id: 'sess-1', title: 'old' })]
+    _rawSessions.value = [makeSession({ id: 'sess-1', title: 'old' })]
     const isNew = upsertSession({
       id: 'sess-1', alive: true, title: 'new',
       cwd: '/home/user', command: ['/bin/sh'], kind: 'shell',
@@ -56,7 +66,7 @@ describe('upsertSession', () => {
   })
 
   it('preserves other sessions during update', () => {
-    sessions.value = [
+    _rawSessions.value = [
       makeSession({ id: 'sess-1', title: 'first' }),
       makeSession({ id: 'sess-2', title: 'second' }),
     ]
@@ -73,9 +83,9 @@ describe('upsertSession', () => {
     const testProjects: ProjectItem[] = [
       { slug: 'myproject', match: [{ path: '/dev/project' }] },
     ]
-    projects.value = testProjects
+    _setRawWorld({ projects: testProjects })
     sessionsLoaded.value = true
-    sessions.value = [
+    _rawSessions.value = [
       makeSession({ id: 'sess-1', cwd: '/dev/project', kind: 'pi', slug: 'fix-auth' }),
     ]
     // Simulate the session being selected via URL.
@@ -97,9 +107,9 @@ describe('upsertSession', () => {
     const testProjects: ProjectItem[] = [
       { slug: 'myproject', match: [{ path: '/dev/project' }] },
     ]
-    projects.value = testProjects
+    _setRawWorld({ projects: testProjects })
     sessionsLoaded.value = true
-    sessions.value = [
+    _rawSessions.value = [
       makeSession({ id: 'sess-1', cwd: '/dev/project', kind: 'pi', slug: 'fix-auth' }),
       makeSession({ id: 'sess-2', cwd: '/dev/project', kind: 'pi', slug: 'old-slug' }),
     ]
@@ -120,7 +130,7 @@ describe('upsertSession', () => {
 
 describe('removeSession', () => {
   it('removes the session with the given id', () => {
-    sessions.value = [
+    _rawSessions.value = [
       makeSession({ id: 'sess-1' }),
       makeSession({ id: 'sess-2' }),
     ]
@@ -129,7 +139,7 @@ describe('removeSession', () => {
   })
 
   it('is a no-op for unknown ids', () => {
-    sessions.value = [makeSession({ id: 'sess-1' })]
+    _rawSessions.value = [makeSession({ id: 'sess-1' })]
     removeSession('ghost')
     expect(sessions.value).toHaveLength(1)
   })
@@ -141,13 +151,13 @@ describe('markSessionRead', () => {
   afterEach(() => { vi.restoreAllMocks() })
 
   it('clears unread flag on the target session', () => {
-    sessions.value = [makeSession({ id: 'sess-1', unread: true })]
+    _rawSessions.value = [makeSession({ id: 'sess-1', unread: true })]
     markSessionRead('sess-1')
     expect(sessions.value[0].unread).toBe(false)
   })
 
   it('clears error flag from status', () => {
-    sessions.value = [makeSession({
+    _rawSessions.value = [makeSession({
       id: 'sess-1',
       status: { label: 'failed', working: false, error: true },
     })]
@@ -157,7 +167,7 @@ describe('markSessionRead', () => {
   })
 
   it('does not touch other sessions', () => {
-    sessions.value = [
+    _rawSessions.value = [
       makeSession({ id: 'sess-1', unread: true }),
       makeSession({ id: 'sess-2', unread: true }),
     ]
@@ -167,7 +177,7 @@ describe('markSessionRead', () => {
   })
 
   it('posts to the server', () => {
-    sessions.value = [makeSession({ id: 'sess-1', unread: true })]
+    _rawSessions.value = [makeSession({ id: 'sess-1', unread: true })]
     markSessionRead('sess-1')
     expect(fetch).toHaveBeenCalledWith('/v1/sessions/sess-1/read', { method: 'POST' })
   })
@@ -301,22 +311,22 @@ describe('navigateToSession', () => {
   })
 
   it('returns false and does not navigate when the session is unknown', () => {
-    projects.value = [{ slug: 'p', match: [{ path: '/dev/p' }] }]
+    _setRawWorld({ projects: [{ slug: 'p', match: [{ path: '/dev/p' }] }] })
     expect(navigateToSession('ghost')).toBe(false)
     expect(navigateMock).not.toHaveBeenCalled()
   })
 
   it('returns false and does not navigate when projects have not loaded', () => {
-    sessions.value = [makeSession({ id: 'sess-1', cwd: '/dev/p' })]
-    // projects.value left empty: simulates the SSE-vs-REST race where
-    // sessions arrive before projects.
+    _rawSessions.value = [makeSession({ id: 'sess-1', cwd: '/dev/p' })]
+    // projects left empty: simulates the snapshot.sessions-vs-snapshot.world
+    // race where sessions arrive before projects.
     expect(navigateToSession('sess-1')).toBe(false)
     expect(navigateMock).not.toHaveBeenCalled()
   })
 
   it('returns true and dispatches the project-prefixed URL once both are loaded', () => {
-    projects.value = [{ slug: 'myproject', match: [{ path: '/dev/p' }] }]
-    sessions.value = [makeSession({ id: 'sess-1', cwd: '/dev/p', kind: 'shell' })]
+    _setRawWorld({ projects: [{ slug: 'myproject', match: [{ path: '/dev/p' }] }] })
+    _rawSessions.value = [makeSession({ id: 'sess-1', cwd: '/dev/p', kind: 'shell' })]
     expect(navigateToSession('sess-1', true)).toBe(true)
     expect(navigateMock).toHaveBeenCalledTimes(1)
     const [url, replace] = navigateMock.mock.calls[0]
@@ -326,23 +336,23 @@ describe('navigateToSession', () => {
 })
 
 describe('peerAppearance', () => {
-  afterEach(() => { peers.value = [] })
+  afterEach(() => { _setRawWorld({ peers: [] }) })
 
   it('computes unique single-char prefixes when first chars differ', () => {
-    peers.value = [
+    _setRawWorld({ peers: [
       { name: 'dev', url: '', status: 'connected', session_count: 0 },
       { name: 'staging', url: '', status: 'connected', session_count: 0 },
-    ]
+    ] })
     const map = peerAppearance.value
     expect(map.get('dev')!.label).toBe('D')
     expect(map.get('staging')!.label).toBe('S')
   })
 
   it('extends prefix to disambiguate shared first characters', () => {
-    peers.value = [
+    _setRawWorld({ peers: [
       { name: 'dev', url: '', status: 'connected', session_count: 0 },
       { name: 'desktop', url: '', status: 'connected', session_count: 0 },
-    ]
+    ] })
     const map = peerAppearance.value
     // 'dev' vs 'desktop': 'de' is shared, need 3 chars
     expect(map.get('dev')!.label).toBe('DEV')
@@ -350,10 +360,10 @@ describe('peerAppearance', () => {
   })
 
   it('uses full name when one name is a prefix of another', () => {
-    peers.value = [
+    _setRawWorld({ peers: [
       { name: 'dev', url: '', status: 'connected', session_count: 0 },
       { name: 'development', url: '', status: 'connected', session_count: 0 },
-    ]
+    ] })
     const map = peerAppearance.value
     // 'dev' is fully consumed before it diverges from 'development'
     expect(map.get('dev')!.label).toBe('DEV')
@@ -361,16 +371,252 @@ describe('peerAppearance', () => {
   })
 
   it('assigns stable colors by name hash, independent of list order', () => {
-    peers.value = [
+    _setRawWorld({ peers: [
       { name: 'alpha', url: '', status: 'connected', session_count: 0 },
       { name: 'beta', url: '', status: 'connected', session_count: 0 },
-    ]
+    ] })
     const color1 = peerAppearance.value.get('alpha')!.color
     // Reverse order: alpha's color should not change
-    peers.value = [
+    _setRawWorld({ peers: [
       { name: 'beta', url: '', status: 'connected', session_count: 0 },
       { name: 'alpha', url: '', status: 'connected', session_count: 0 },
-    ]
+    ] })
     expect(peerAppearance.value.get('alpha')!.color).toBe(color1)
   })
 })
+
+describe('peerStatusByName + isSessionUnavailable', () => {
+  afterEach(() => { _setRawWorld({ peers: [] }) })
+
+  it('maps each peer name to its current status', () => {
+    _setRawWorld({ peers: [
+      { name: 'tower', url: '', status: 'connected', session_count: 0 },
+      { name: 'laptop', url: '', status: 'disconnected', session_count: 0 },
+    ] })
+    const map = peerStatusByName.value
+    expect(map.get('tower')).toBe('connected')
+    expect(map.get('laptop')).toBe('disconnected')
+  })
+
+  it('flags sessions on disconnected peers as unavailable', () => {
+    const map = new Map([['tower', 'disconnected']])
+    expect(isSessionUnavailable({ peer: 'tower' }, map)).toBe(true)
+  })
+
+  it('treats sessions on connected peers as available', () => {
+    const map = new Map([['tower', 'connected']])
+    expect(isSessionUnavailable({ peer: 'tower' }, map)).toBe(false)
+  })
+
+  it('treats local sessions (no peer) as available', () => {
+    expect(isSessionUnavailable({}, new Map())).toBe(false)
+    expect(isSessionUnavailable({ peer: undefined }, new Map())).toBe(false)
+  })
+
+  it('flags sessions claiming an unknown peer as unavailable', () => {
+    // Peer absent from the world snapshot (e.g. removed from config but still
+    // showing up in lingering snapshot data). Safer to flag than to
+    // pretend the session is reachable.
+    expect(isSessionUnavailable({ peer: 'ghost' }, new Map())).toBe(true)
+  })
+
+  it('treats "connecting" as unavailable', () => {
+    // PeerInfo.status is 'connecting' during reconnect. The user can't
+    // reach the session yet, so render as unavailable.
+    const map = new Map([['tower', 'connecting']])
+    expect(isSessionUnavailable({ peer: 'tower' }, map)).toBe(true)
+  })
+})
+
+describe('raw signal projections', () => {
+  it('exposes _rawSessions through the public sessions computed', () => {
+    _rawSessions.value = [makeSession({ id: 'a', title: 'first' })]
+    expect(sessions.value.map(s => s.id)).toEqual(['a'])
+    _rawSessions.value = [
+      makeSession({ id: 'a' }),
+      makeSession({ id: 'b' }),
+    ]
+    expect(sessions.value.map(s => s.id)).toEqual(['a', 'b'])
+  })
+
+  it('exposes _rawWorld.projects through the public projects computed', () => {
+    const items: ProjectItem[] = [{ slug: 'one', match: [{ path: '/x' }] }]
+    _setRawWorld({ projects: items })
+    expect(projects.value).toBe(items)
+  })
+
+  it('exposes _rawWorld.peers through the public peers computed', () => {
+    _setRawWorld({ peers: [{ name: 'p', url: '', status: 'connected', session_count: 0 }] })
+    expect(peers.value).toHaveLength(1)
+    expect(peers.value[0].name).toBe('p')
+  })
+
+  it('_setRawWorld merges patches without dropping unrelated keys', () => {
+    _setRawWorld({
+      projects: [{ slug: 'a', match: [] }],
+      peers: [{ name: 'p', url: '', status: 'connected', session_count: 0 }],
+    })
+    _setRawWorld({ peers: [] })
+    // projects survived; peers cleared.
+    expect(projects.value).toHaveLength(1)
+    expect(peers.value).toHaveLength(0)
+  })
+})
+
+describe('pending mutations overlay', () => {
+  beforeEach(() => { vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true })) })
+  afterEach(() => { vi.restoreAllMocks() })
+
+  describe('applyPending (pure function)', () => {
+    it('returns raw unchanged when there are no mutations', () => {
+      const sess = [makeSession({ id: 'a' })]
+      const projs: ProjectItem[] = [{ slug: 'p', match: [] }]
+      const out = applyPending(sess, projs, [])
+      expect(out.sessions).toBe(sess)
+      expect(out.projects).toBe(projs)
+    })
+
+    it('mark-read clears unread and status.error on the targeted session', () => {
+      const sess = [
+        makeSession({ id: 'a', unread: true, status: { label: 'oops', working: false, error: true } }),
+        makeSession({ id: 'b', unread: true }),
+      ]
+      const m: PendingMutation = { kind: 'mark-read', id: 'a', at: 0 }
+      const out = applyPending(sess, [], [m])
+      expect(out.sessions[0].unread).toBe(false)
+      expect(out.sessions[0].status?.error).toBe(false)
+      expect(out.sessions[0].status?.label).toBe('oops')
+      // Untouched session keeps its flags.
+      expect(out.sessions[1].unread).toBe(true)
+    })
+
+    it('dismiss removes the targeted session', () => {
+      const sess = [makeSession({ id: 'a' }), makeSession({ id: 'b' })]
+      const out = applyPending(sess, [], [{ kind: 'dismiss', id: 'a', at: 0 }])
+      expect(out.sessions.map(s => s.id)).toEqual(['b'])
+    })
+
+    it('reorder replaces a project sessions array', () => {
+      const projs: ProjectItem[] = [{ slug: 'p', match: [], sessions: ['x', 'y'] }]
+      const out = applyPending([], projs, [{ kind: 'reorder', slug: 'p', sessions: ['y', 'x'], at: 0 }])
+      expect(out.projects[0].sessions).toEqual(['y', 'x'])
+    })
+
+    it('stacks multiple mutations in order', () => {
+      const projs: ProjectItem[] = [{ slug: 'p', match: [], sessions: ['x'] }]
+      const out = applyPending([], projs, [
+        { kind: 'reorder', slug: 'p', sessions: ['a', 'b'], at: 0 },
+        { kind: 'reorder', slug: 'p', sessions: ['b', 'a'], at: 0 },
+      ])
+      expect(out.projects[0].sessions).toEqual(['b', 'a'])
+    })
+  })
+
+  describe('public projections apply pending mutations', () => {
+    it('markSessionRead reflects via the pending overlay (raw is untouched)', () => {
+      _rawSessions.value = [makeSession({ id: 'a', unread: true })]
+      markSessionRead('a')
+      expect(sessions.value[0].unread).toBe(false)
+      // Raw is untouched.
+      expect(_rawSessions.value[0].unread).toBe(true)
+      expect(_pendingMutations.value).toHaveLength(1)
+    })
+
+    it('dismissSession hides the session via overlay without touching raw', () => {
+      _rawSessions.value = [makeSession({ id: 'a' }), makeSession({ id: 'b' })]
+      dismissSession('a')
+      expect(sessions.value.map(s => s.id)).toEqual(['b'])
+      expect(_rawSessions.value.map(s => s.id)).toEqual(['a', 'b'])
+    })
+
+    it('reorderSessions reflects via the projects overlay', () => {
+      _setRawWorld({ projects: [{ slug: 'p', match: [], sessions: ['x', 'y'] }] })
+      reorderSessions('p', ['y', 'x'])
+      expect(projects.value[0].sessions).toEqual(['y', 'x'])
+      // Raw is untouched.
+      expect(_rawWorld.value.projects[0].sessions).toEqual(['x', 'y'])
+    })
+
+    it('reorderSessions for a local project hits /v1/projects/{slug}/sessions', () => {
+      reorderSessions('gmux', ['y', 'x'])
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        '/v1/projects/gmux/sessions',
+        expect.objectContaining({ method: 'PATCH' }),
+      )
+    })
+
+    it('reorderSessions for a peer project routes through the peer proxy', () => {
+      // ADR 0002: a peer's projects.json is owned by the peer; the
+      // viewer asks the peer to reorder via /v1/peers/{peer}/...
+      // rather than writing into its own projects.json.
+      reorderSessions('gmux', ['y', 'x'], 'tower')
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        '/v1/peers/tower/v1/projects/gmux/sessions',
+        expect.objectContaining({ method: 'PATCH' }),
+      )
+    })
+
+    it('peer reorder does not add a local optimistic overlay', () => {
+      // The local pending-mutations overlay is keyed by local project
+      // slug; applying it to a peer reorder would clobber the peer
+      // folder's session order with the viewer's local-projects view.
+      const before = _pendingMutations.value.length
+      reorderSessions('gmux', ['y', 'x'], 'tower')
+      expect(_pendingMutations.value.length).toBe(before)
+    })
+  })
+
+  describe('auto-clear on raw acknowledgement', () => {
+    it('drops a mark-read mutation once raw shows unread=false', () => {
+      _rawSessions.value = [makeSession({ id: 'a', unread: true })]
+      markSessionRead('a')
+      expect(_pendingMutations.value).toHaveLength(1)
+      // Server echoes the cleared state.
+      _rawSessions.value = [makeSession({ id: 'a', unread: false })]
+      expect(_pendingMutations.value).toHaveLength(0)
+    })
+
+    it('drops a dismiss mutation once raw no longer contains the session', () => {
+      _rawSessions.value = [makeSession({ id: 'a' })]
+      dismissSession('a')
+      expect(_pendingMutations.value).toHaveLength(1)
+      _rawSessions.value = []
+      expect(_pendingMutations.value).toHaveLength(0)
+    })
+
+    it('drops a reorder mutation once raw matches the requested order', () => {
+      _setRawWorld({ projects: [{ slug: 'p', match: [], sessions: ['x', 'y'] }] })
+      reorderSessions('p', ['y', 'x'])
+      expect(_pendingMutations.value).toHaveLength(1)
+      _setRawWorld({ projects: [{ slug: 'p', match: [], sessions: ['y', 'x'] }] })
+      expect(_pendingMutations.value).toHaveLength(0)
+    })
+
+    it('keeps a mark-read mutation when raw still shows unread=true', () => {
+      _rawSessions.value = [makeSession({ id: 'a', unread: true })]
+      markSessionRead('a')
+      // Some unrelated raw update arrives.
+      _rawSessions.value = [makeSession({ id: 'a', unread: true, title: 'new' })]
+      expect(_pendingMutations.value).toHaveLength(1)
+      // Public projection still hides the unread flag.
+      expect(sessions.value[0].unread).toBe(false)
+    })
+  })
+
+  describe('TTL expiry', () => {
+    beforeEach(() => { vi.useFakeTimers() })
+    afterEach(() => { vi.useRealTimers() })
+
+    it('drops a mutation after PENDING_TTL_MS even if raw never acknowledges', () => {
+      _rawSessions.value = [makeSession({ id: 'a', unread: true })]
+      markSessionRead('a')
+      expect(_pendingMutations.value).toHaveLength(1)
+      vi.advanceTimersByTime(5_000)
+      expect(_pendingMutations.value).toHaveLength(0)
+      // Public projection now reflects raw again.
+      expect(sessions.value[0].unread).toBe(true)
+    })
+  })
+})
+
+

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -16,8 +16,8 @@
 import { signal, computed, batch, effect } from '@preact/signals'
 import type { Session, ProjectItem, DiscoveredProject, PeerInfo, LauncherDef, Folder } from './types'
 import type { View } from './routing'
-import { resolveViewFromPath, viewToPath, sessionPath } from './routing'
-import { buildProjectFolders, matchSession, discoverProjects, countUnmatchedActive } from './projects'
+import { resolveViewFromPath, viewToPath } from './routing'
+import { buildProjectFolders, discoverProjects, countUnmatchedActive } from './projects'
 
 import { fetchFrontendConfig, buildTerminalOptions, resolveKeybinds, type ResolvedKeybind } from './config'
 import { MOCK_SESSIONS, MOCK_PROJECTS } from './mock-data/index'
@@ -495,9 +495,15 @@ export function upsertSession(raw: ProtocolSession): boolean {
     // URL (still has the old slug), fail to resolve, and briefly
     // deselect the session.
     if (old.slug !== updated.slug && selectedId.value === updated.id) {
-      const project = matchSession(updated, projects.value)
-      if (project) {
-        const newUrl = sessionPath(project.slug, updated)
+      // viewToPath gets the post-update sessions array so it sees the
+      // new slug. Routes peer-owned sessions through `/@<peer>/...`
+      // (ADR 0002) just like every other URL serializer.
+      const newUrl = viewToPath(
+        { kind: 'session', sessionId: updated.id },
+        projects.value,
+        next,
+      )
+      if (newUrl) {
         batch(() => {
           _rawSessions.value = next
           urlPath.value = newUrl
@@ -692,17 +698,20 @@ export function navigate(url: string, replace?: boolean) {
 }
 
 /**
- * Navigate to a session by ID. Finds the matching project and builds
- * the URL. Used by auto-select, resume, and notification handlers.
+ * Navigate to a session by ID. Builds the URL via viewToPath so peer
+ * ownership and disclaimed-but-adopted cases both serialize correctly
+ * (ADR 0002). Used by auto-select, resume, and notification handlers.
  * Returns true when a URL change was actually dispatched, false when
- * the session or its project hasn't loaded yet.
+ * the session or its containing project hasn't loaded yet.
  */
 export function navigateToSession(sessionId: string, replace?: boolean): boolean {
-  const sess = sessions.value.find(s => s.id === sessionId)
-  if (!sess) return false
-  const project = matchSession(sess, projects.value)
-  if (!project) return false
-  navigate(sessionPath(project.slug, sess), replace)
+  const path = viewToPath(
+    { kind: 'session', sessionId },
+    projects.value,
+    sessions.value,
+  )
+  if (!path) return false
+  navigate(path, replace)
   return true
 }
 

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -17,26 +17,14 @@ import { signal, computed, batch, effect } from '@preact/signals'
 import type { Session, ProjectItem, DiscoveredProject, PeerInfo, LauncherDef, Folder } from './types'
 import type { View } from './routing'
 import { resolveViewFromPath, viewToPath, sessionPath } from './routing'
-import { buildProjectFolders, matchSession } from './projects'
+import { buildProjectFolders, matchSession, discoverProjects, countUnmatchedActive } from './projects'
 
 import { fetchFrontendConfig, buildTerminalOptions, resolveKeybinds, type ResolvedKeybind } from './config'
 import { MOCK_SESSIONS, MOCK_PROJECTS } from './mock-data/index'
 import type { ResolvedTerminalOptions } from './settings-schema'
 import type { Session as ProtocolSession } from '@gmux/protocol'
 
-// ── Raw state (sources of truth) ────────────────────────────────────────────
-
-export const sessions = signal<Session[]>([])
-export const sessionsLoaded = signal(false)
-export const connState = signal<'connecting' | 'connected' | 'error'>('connecting')
-
-export const projects = signal<ProjectItem[]>([])
-export const discovered = signal<DiscoveredProject[]>([])
-export const unmatchedActiveCount = signal(0)
-
-export const peers = signal<PeerInfo[]>([])
-export const launchers = signal<LauncherDef[]>([])
-export const defaultLauncher = signal<string>('shell')
+// ── HealthData type (used by both raw signal and consumers) ─────────────────
 
 export interface HealthData {
   version: string
@@ -50,7 +38,173 @@ export interface HealthData {
   launchers?: LauncherDef[]
   peers?: PeerInfo[]
 }
-export const health = signal<HealthData | null>(null)
+
+// ── Raw state (private; ADR 0001) ───────────────────────────────────────────
+//
+// Per ADR 0001 the wire delivers two snapshots: `snapshot.sessions`
+// (just the sessions array) and `snapshot.world` (the bundle of
+// projects + peers + health + launchers). The frontend stores those
+// two payloads verbatim in `_rawSessions` and `_rawWorld`; everything
+// else is a pure projection (computed) on top.
+//
+// The signals are exported with a leading underscore as a soft
+// "private" marker. SSE handlers, bulk-fetch helpers, and the test
+// suite write to them; the rest of the app reads only the public
+// computed projections below.
+
+export interface RawWorld {
+  projects: ProjectItem[]
+  peers: PeerInfo[]
+  health: HealthData | null
+  launchers: LauncherDef[]
+  defaultLauncher: string
+}
+
+export const _rawSessions = signal<Session[]>([])
+export const _rawWorld = signal<RawWorld>({
+  projects: [],
+  peers: [],
+  health: null,
+  launchers: [],
+  defaultLauncher: 'shell',
+})
+
+/** Merge a partial world update into `_rawWorld`. Used by SSE handlers,
+ * bulk-fetch responses, and tests; callers don't have to spread the
+ * whole bundle every time. */
+export function _setRawWorld(patch: Partial<RawWorld>) {
+  _rawWorld.value = { ..._rawWorld.value, ...patch }
+}
+
+// ── Pending mutations (optimistic overlay; ADR 0001) ───────────────────────
+//
+// The wire delivers atomic snapshots that overwrite `_rawSessions` /
+// `_rawWorld` wholesale. Optimistic UI mutations (mark-as-read,
+// dismiss, reorder) need to survive that overwrite until the server
+// echoes them back. We do that by stacking mutations in
+// `_pendingMutations` and replaying them on top of raw in the public
+// projections.
+//
+// Each mutation is auto-cleared two ways:
+//   1. when raw state already reflects the mutation
+//      (`isResolved` returns true), the next raw update sweeps it out;
+//   2. otherwise it expires after `PENDING_TTL_MS`, so a server that
+//      silently drops the request can't pin a stale optimistic value.
+
+export type PendingMutation =
+  | { kind: 'mark-read'; id: string; at: number }
+  | { kind: 'dismiss'; id: string; at: number }
+  | { kind: 'reorder'; slug: string; sessions: string[]; at: number }
+
+export const _pendingMutations = signal<PendingMutation[]>([])
+
+const PENDING_TTL_MS = 5_000
+
+/** Replay pending mutations on top of a raw sessions/projects pair.
+ * Pure; safe to call from `computed`. */
+export function applyPending(
+  rawSessions: Session[],
+  rawProjects: ProjectItem[],
+  pending: PendingMutation[],
+): { sessions: Session[]; projects: ProjectItem[] } {
+  if (pending.length === 0) return { sessions: rawSessions, projects: rawProjects }
+  let sess = rawSessions
+  let projs = rawProjects
+  for (const m of pending) {
+    switch (m.kind) {
+      case 'mark-read':
+        sess = sess.map(s => s.id !== m.id ? s : ({
+          ...s,
+          unread: false,
+          status: s.status?.error ? { ...s.status, error: false } : s.status,
+        }))
+        break
+      case 'dismiss':
+        sess = sess.filter(s => s.id !== m.id)
+        break
+      case 'reorder':
+        projs = projs.map(p => p.slug !== m.slug ? p : ({ ...p, sessions: m.sessions }))
+        break
+    }
+  }
+  return { sessions: sess, projects: projs }
+}
+
+/** True when the raw state already reflects the mutation, so replaying
+ * it would be a no-op. The auto-clear effect uses this to drop
+ * mutations the server has acknowledged. */
+function isResolved(
+  m: PendingMutation,
+  rawSessions: Session[],
+  rawProjects: ProjectItem[],
+): boolean {
+  switch (m.kind) {
+    case 'mark-read': {
+      const s = rawSessions.find(x => x.id === m.id)
+      if (!s) return true
+      return !s.unread && !s.status?.error
+    }
+    case 'dismiss':
+      return !rawSessions.some(s => s.id === m.id)
+    case 'reorder': {
+      const p = rawProjects.find(x => x.slug === m.slug)
+      if (!p) return true
+      const cur = p.sessions ?? []
+      return cur.length === m.sessions.length && cur.every((v, i) => v === m.sessions[i])
+    }
+  }
+}
+
+/** Push a mutation onto the pending stack and schedule its TTL drop. */
+function addPending(m: PendingMutation) {
+  _pendingMutations.value = [..._pendingMutations.value, m]
+  setTimeout(() => {
+    _pendingMutations.value = _pendingMutations.value.filter(x => x !== m)
+  }, PENDING_TTL_MS)
+}
+
+// ── Public projections of raw state ─────────────────────────────────────────
+//
+// Components import these by name; they don't know about `_rawWorld`.
+// Everything is `computed`, so writes go through the raw signals only.
+
+export const sessions = computed<Session[]>(() =>
+  applyPending(_rawSessions.value, _rawWorld.value.projects, _pendingMutations.value).sessions,
+)
+export const projects = computed<ProjectItem[]>(() =>
+  applyPending(_rawSessions.value, _rawWorld.value.projects, _pendingMutations.value).projects,
+)
+export const peers = computed<PeerInfo[]>(() => _rawWorld.value.peers)
+export const health = computed<HealthData | null>(() => _rawWorld.value.health)
+export const launchers = computed<LauncherDef[]>(() => _rawWorld.value.launchers)
+export const defaultLauncher = computed<string>(() => _rawWorld.value.defaultLauncher)
+
+// Auto-clear pending mutations that the wire has acknowledged. Runs on
+// every raw update; uses .peek() to avoid re-triggering itself.
+effect(() => {
+  const rs = _rawSessions.value
+  const rw = _rawWorld.value
+  const pending = _pendingMutations.peek()
+  if (pending.length === 0) return
+  const filtered = pending.filter(m => !isResolved(m, rs, rw.projects))
+  if (filtered.length !== pending.length) {
+    _pendingMutations.value = filtered
+  }
+})
+
+// Local-only UI state (never sourced from the wire).
+export const sessionsLoaded = signal(false)
+export const connState = signal<'connecting' | 'connected' | 'error'>('connecting')
+
+// Per ADR 0001: Discovered and UnmatchedActiveCount are per-viewer
+// projections, not server-pushed state. They derive from the same
+// public sessions/projects projections everyone else uses.
+export const discovered = computed<DiscoveredProject[]>(
+  () => discoverProjects(sessions.value, projects.value),
+)
+export const unmatchedActiveCount = computed<number>(
+  () => countUnmatchedActive(sessions.value, projects.value),
+)
 
 // ── Peer appearance: unique prefix + deterministic color ─────────────────────
 
@@ -89,6 +243,31 @@ export interface PeerAppearance {
   label: string
   color: string
   bg: string
+}
+
+/** Derived map from peer name to status string. Sessions whose peer
+ *  is not 'connected' are unreachable from this viewer right now (the
+ *  peer may still be running them); the sidebar dims them and replaces
+ *  the activity dot with an unavailable indicator. */
+export const peerStatusByName = computed<ReadonlyMap<string, string>>(() => {
+  const map = new Map<string, string>()
+  for (const p of peers.value) map.set(p.name, p.status)
+  return map
+})
+
+/** True when a session lives on a peer we can't reach right now.
+ *  Local sessions (peer === undefined) are never unavailable. */
+export function isSessionUnavailable(
+  session: { peer?: string },
+  statusByName: ReadonlyMap<string, string>,
+): boolean {
+  if (!session.peer) return false
+  // Treat unknown peers as unavailable too: if the session claims a
+  // peer name no longer present in the world snapshot (e.g. peer was
+  // removed from config but still appears in lingering session data),
+  // the safe default is to flag it rather than pretend it's reachable.
+  const status = statusByName.get(session.peer)
+  return status !== 'connected'
 }
 
 /** Derived map from peer name to { label, color, bg }. Colors assigned by list order. */
@@ -217,10 +396,16 @@ export const selected = computed(() => {
   return s
 })
 
-/** Project slug when the view is a project hub. */
-export const currentProjectSlug = computed(() =>
-  view.value?.kind === 'project' ? view.value.projectSlug : null,
-)
+/**
+ * Folder key when the view is a project hub. Matches `Folder.key`
+ * (`${peer ?? ''}::${slug}`) so the sidebar can highlight the active
+ * folder uniformly across local and peer-owned projects (ADR 0002).
+ */
+export const currentProjectKey = computed(() => {
+  const v = view.value
+  if (v?.kind !== 'project') return null
+  return `${v.projectPeer ?? ''}::${v.projectSlug}`
+})
 
 /** Dot state for the mobile hamburger: summarizes background session activity. */
 export type DotState = 'working' | 'error' | 'unread' | 'active' | 'fading' | 'none'
@@ -297,7 +482,7 @@ export function sessionStaleness(
 export function upsertSession(raw: ProtocolSession): boolean {
   const updated = toUISession(raw)
   let isNew = false
-  const prev = sessions.value
+  const prev = _rawSessions.value
   const idx = prev.findIndex(s => s.id === updated.id)
   if (idx >= 0) {
     const old = prev[idx]
@@ -314,7 +499,7 @@ export function upsertSession(raw: ProtocolSession): boolean {
       if (project) {
         const newUrl = sessionPath(project.slug, updated)
         batch(() => {
-          sessions.value = next
+          _rawSessions.value = next
           urlPath.value = newUrl
         })
         // Sync the browser URL bar. navigate() calls preact-iso's
@@ -326,80 +511,24 @@ export function upsertSession(raw: ProtocolSession): boolean {
       }
     }
 
-    sessions.value = next
+    _rawSessions.value = next
   } else {
     isNew = true
-    sessions.value = [...prev, updated]
+    _rawSessions.value = [...prev, updated]
   }
   return isNew
 }
 
 export function removeSession(id: string) {
-  sessions.value = sessions.value.filter(s => s.id !== id)
+  _rawSessions.value = _rawSessions.value.filter(s => s.id !== id)
 }
 
 export function markSessionRead(id: string) {
-  sessions.value = sessions.value.map(s =>
-    s.id === id
-      ? { ...s, unread: false, status: s.status?.error ? { ...s.status, error: false } : s.status }
-      : s,
-  )
+  // Optimistic mark-as-read. The server's next session update overwrites
+  // raw with the authoritative state and `isResolved` clears the
+  // mutation; if the server stays silent the TTL drops it eventually.
+  addPending({ kind: 'mark-read', id, at: Date.now() })
   fetch(`/v1/sessions/${id}/read`, { method: 'POST' }).catch(() => {})
-}
-
-export function setProjects(data: { configured: ProjectItem[]; discovered: DiscoveredProject[]; unmatchedActiveCount: number }) {
-  batch(() => {
-    projects.value = data.configured
-    discovered.value = data.discovered
-    unmatchedActiveCount.value = data.unmatchedActiveCount
-  })
-}
-
-// ── API helpers ─────────────────────────────────────────────────────────────
-
-async function fetchSessions(): Promise<Session[]> {
-  const resp = await fetch('/v1/sessions')
-  const json = await resp.json()
-  const data: ProtocolSession[] = json?.data ?? []
-  return data.map(toUISession)
-}
-
-
-
-export async function fetchProjects(): Promise<void> {
-  try {
-    const resp = await fetch('/v1/projects')
-    const json = await resp.json()
-    if (json.ok && json.data) {
-      setProjects({
-        configured: json.data.configured ?? [],
-        discovered: json.data.discovered ?? [],
-        unmatchedActiveCount: json.data.unmatched_active_count ?? 0,
-      })
-    }
-  } catch (err) {
-    console.warn('Failed to fetch projects:', err)
-  }
-}
-
-function applyHealth(h: HealthData) {
-  batch(() => {
-    health.value = h
-    peers.value = h.peers ?? []
-    launchers.value = h.launchers ?? []
-    defaultLauncher.value = h.default_launcher ?? 'shell'
-  })
-}
-
-async function fetchHealth(): Promise<void> {
-  try {
-    const resp = await fetch('/v1/health')
-    const json = await resp.json()
-    const h: HealthData | null = json.data ?? null
-    if (h) applyHealth(h)
-  } catch {
-    // Health fetch is best-effort; UI works without it.
-  }
 }
 
 // ── Project mutations (used by manage-projects) ─────────────────────────────
@@ -441,16 +570,33 @@ export async function updateProjects(items: ProjectItem[]): Promise<void> {
 /**
  * Persist a new session order for a project. The `sessionKeys` array
  * contains session keys (slug or id) in the desired display order.
- * Optimistically updates the local signal so the sidebar re-renders
- * immediately, without waiting for the SSE projects-update round-trip.
+ *
+ * Local projects (peer === undefined) get an optimistic overlay via
+ * `_pendingMutations` so the sidebar re-renders immediately, before
+ * the snapshot.world round-trip echoes the new order back.
+ *
+ * Peer-owned projects route through the generic peer-write proxy at
+ * `/v1/peers/{peer}/v1/projects/{slug}/sessions` (ADR 0002): the peer
+ * owns its own projects.json and re-stamps each session's
+ * project_index, which arrives over the snapshot stream. We don't
+ * apply a local optimistic overlay for peer reorders because the
+ * sidebar derives peer-folder order from those stamps, not from any
+ * local projects array; the round-trip latency is the cost of
+ * honesty about who owns the data.
  */
-export async function reorderSessions(projectSlug: string, sessionKeys: string[]): Promise<void> {
-  // Optimistic update.
-  projects.value = projects.value.map(p =>
-    p.slug === projectSlug ? { ...p, sessions: sessionKeys } : p,
-  )
+export async function reorderSessions(
+  projectSlug: string,
+  sessionKeys: string[],
+  peer?: string,
+): Promise<void> {
+  if (peer === undefined) {
+    addPending({ kind: 'reorder', slug: projectSlug, sessions: sessionKeys, at: Date.now() })
+  }
+  const url = peer
+    ? `/v1/peers/${encodeURIComponent(peer)}/v1/projects/${encodeURIComponent(projectSlug)}/sessions`
+    : `/v1/projects/${encodeURIComponent(projectSlug)}/sessions`
   try {
-    const resp = await fetch(`/v1/projects/${projectSlug}/sessions`, {
+    const resp = await fetch(url, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ sessions: sessionKeys }),
@@ -483,7 +629,11 @@ export function killSession(sessionId: string): Promise<void> {
 }
 
 export function dismissSession(sessionId: string): Promise<void> {
-  removeSession(sessionId)
+  // Optimistic dismissal: hide the session locally until the next
+  // snapshot.sessions confirms it's gone. If the server rejects the
+  // dismiss, the mutation TTL-expires and the session reappears on the
+  // following snapshot.
+  addPending({ kind: 'dismiss', id: sessionId, at: Date.now() })
   return postAction(`/v1/sessions/${sessionId}/dismiss`)
 }
 
@@ -569,8 +719,8 @@ export function initStore(): () => void {
       ? MOCK_SESSIONS.map(s => s.peer === localHost ? { ...s, peer: undefined } : s)
       : [...MOCK_SESSIONS]
     batch(() => {
-      projects.value = MOCK_PROJECTS
-      sessions.value = mockSessions
+      _setRawWorld({ projects: MOCK_PROJECTS })
+      _rawSessions.value = mockSessions
       sessionsLoaded.value = true
       connState.value = 'connected'
       terminalOptions.value = buildTerminalOptions(null, null)
@@ -583,19 +733,11 @@ export function initStore(): () => void {
     return () => cleanups.forEach(fn => fn())
   }
 
-  // Fetch initial data in parallel.
-  fetchProjects()
-  fetchSessions().then(list => {
-    batch(() => {
-      sessions.value = list
-      sessionsLoaded.value = true
-      connState.value = 'connected'
-    })
-  }).catch(err => {
-    console.error('Failed to fetch sessions:', err)
-    connState.value = 'error'
-  })
-  fetchHealth()
+  // Fetch one-shot per-user config (theme, settings, keybinds) that
+  // doesn't ride the snapshot stream. Everything else — sessions,
+  // projects, peers, health, launchers — arrives as the leading-edge
+  // snapshot.sessions / snapshot.world emitted on SSE subscribe
+  // (ADR 0001).
   fetchFrontendConfig().then(fc => {
     const macCtrl = fc.settings?.macCommandIsCtrl === true
     batch(() => {
@@ -605,52 +747,69 @@ export function initStore(): () => void {
     })
   })
 
-  // SSE subscription.
-  //
-  // The server replays all sessions as upserts on connect. Since we
-  // already fetch via GET /v1/sessions, the initial SSE dump is
-  // redundant. We skip session-upsert events until the bulk fetch
-  // has completed (sessionsLoaded is true). After that, the SSE
-  // stream carries incremental updates.
-  //
-  // On reconnect, the SSE dump IS useful because events may have been
-  // missed. We pair it with a fresh fetchSessions to be safe.
+  // SSE subscription. The server emits a leading-edge snapshot for
+  // both kinds (sessions, world) immediately on subscribe, so we
+  // don't need a bulk-GET prefetch on first load or on reconnect.
+  // Missed deltas don't matter: each snapshot is a full replacement.
   const source = new EventSource('/v1/events')
-  let sseConnected = false
-
-  source.addEventListener('open', () => {
-    if (sseConnected) {
-      // Reconnect: refresh everything to catch missed events.
-      fetchProjects()
-      fetchSessions().then(list => { sessions.value = list }).catch(() => {})
-    }
-    sseConnected = true
+  source.addEventListener('error', () => {
+    // Browser EventSource auto-reconnects; flag the UI as degraded
+    // until the next snapshot arrives. `sessionsLoaded` stays true
+    // once it has flipped, so reconnect doesn't blank the sidebar.
+    if (connState.value === 'connecting') connState.value = 'error'
   })
 
-  source.addEventListener('session-upsert', (e) => {
-    // Skip the initial SSE dump: the bulk GET /v1/sessions fetch is
-    // authoritative for the first load. Processing the dump would
-    // trigger O(n²) array mutations for no benefit.
-    if (!sessionsLoaded.value) return
-
+  // Protocol 2 (ADR 0001). The server pushes two snapshot kinds plus
+  // bare activity. We replace `_rawSessions` and `_rawWorld`
+  // wholesale on each snapshot; the projection layer derives
+  // everything else.
+  source.addEventListener('snapshot.sessions', (e) => {
     try {
-      const envelope = JSON.parse(e.data)
-      const session = envelope.session ?? envelope
-      const isNew = upsertSession(session)
-      if (isNew && consumePendingLaunch()) {
-        navigateToSession(session.id, true)
+      const envelope = JSON.parse(e.data) as { sessions?: ProtocolSession[] }
+      const list = (envelope.sessions ?? []).map(toUISession)
+
+      // Detect newly-arrived IDs vs the previous snapshot so a
+      // pending launch (just-POSTed /v1/launch awaiting an id) can
+      // navigate to its session as soon as the daemon publishes it.
+      // Done before we commit the new array so consumers see the
+      // navigation against the new state.
+      const prevIds = new Set(_rawSessions.value.map(s => s.id))
+      const newIds = list.filter(s => !prevIds.has(s.id)).map(s => s.id)
+
+      batch(() => {
+        _rawSessions.value = list
+        sessionsLoaded.value = true
+        connState.value = 'connected'
+      })
+
+      if (newIds.length > 0 && consumePendingLaunch()) {
+        // Most recent new id wins; with one launch in flight at a
+        // time this is unambiguous.
+        navigateToSession(newIds[newIds.length - 1], true)
       }
     } catch (err) {
-      console.warn('session-upsert: bad event', err)
+      console.warn('snapshot.sessions: bad event', err)
     }
   })
 
-  source.addEventListener('session-remove', (e) => {
+  source.addEventListener('snapshot.world', (e) => {
     try {
-      const { id } = JSON.parse(e.data)
-      removeSession(id)
+      const env = JSON.parse(e.data) as {
+        projects?: ProjectItem[]
+        peers?: PeerInfo[]
+        health?: HealthData
+        launchers?: LauncherDef[]
+        default_launcher?: string
+      }
+      _setRawWorld({
+        projects: env.projects ?? [],
+        peers: env.peers ?? env.health?.peers ?? [],
+        health: env.health ?? null,
+        launchers: env.launchers ?? [],
+        defaultLauncher: env.default_launcher ?? 'shell',
+      })
     } catch (err) {
-      console.warn('session-remove: bad event', err)
+      console.warn('snapshot.world: bad event', err)
     }
   })
 
@@ -659,14 +818,6 @@ export function initStore(): () => void {
       const { id } = JSON.parse(e.data)
       if (id) handleActivity(id)
     } catch { /* ignore */ }
-  })
-
-  source.addEventListener('projects-update', () => {
-    fetchProjects()
-  })
-
-  source.addEventListener('peer-status', () => {
-    fetchHealth()
   })
 
   cleanups.push(() => source.close())

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -407,6 +407,24 @@ body {
   opacity: 0.4;
 }
 
+/* Session lives on a peer we can't reach right now (the peer is
+   disconnected or unknown). Dim the row and replace the activity dot
+   with a muted X so the user knows clicking won't reach the session. */
+.session-item.unavailable {
+  opacity: 0.55;
+}
+.session-item.unavailable.selected {
+  opacity: 0.85;
+}
+.session-unavailable-icon {
+  flex-shrink: 0;
+  width: 9px;
+  height: 9px;
+  margin-top: 4px;
+  color: var(--text-muted);
+  opacity: 0.7;
+}
+
 .session-content {
   flex: 1;
   min-width: 0;
@@ -2239,6 +2257,7 @@ a.home-host-link:hover {
   flex-shrink: 0;
 }
 .session-card-dot.dead { background: var(--text-muted); }
+.session-card.unavailable { opacity: 0.55; }
 .session-card-name {
   font-size: 13px;
   white-space: nowrap;

--- a/apps/gmux-web/src/types.ts
+++ b/apps/gmux-web/src/types.ts
@@ -36,12 +36,41 @@ export interface Session {
   runner_version?: string
   /** SHA-256 of the gmux runner binary (first 8 chars useful for display). */
   binary_hash?: string
+
+  /**
+   * Project assignment stamps from the session's origin host (ADR 0002).
+   * Set as a pair, only by the origin's `Reconcile`:
+   *  - non-empty `project_slug`: the session is *claimed* by the named
+   *    project on its origin; folder = `(peer, project_slug)`,
+   *    sort key = `project_index`.
+   *  - empty / absent: the session is *disclaimed*; viewers fall back
+   *    to their own match rules (free-game adoption).
+   * Index defaults to 0 on decode, which is also a valid first-position
+   * stamp; meaningful only when `project_slug` is non-empty.
+   */
+  project_slug?: string
+  project_index?: number
 }
 
 export interface Folder {
-  name: string       // display name (project slug or derived name)
-  path: string       // project slug (used as key)
-  launchCwd?: string // filesystem path for launching new sessions
+  /**
+   * Stable identity for React keys and selection. Local folders use the
+   * project slug; peer folders use `${peer}::${slug}` to disambiguate
+   * same-named projects on different hosts (ADR 0002).
+   */
+  key: string
+  /** Display name (project slug, possibly colliding across hosts). */
+  name: string
+  /** Project slug (used for URL routing and local projects.json keying). */
+  slug: string
+  /**
+   * Origin host name when this folder is owned by a peer; absent when
+   * owned by the viewer. Drives peer-label rendering and the launch
+   * button's `peer=` argument.
+   */
+  peer?: string
+  /** Filesystem path hint for launching new sessions in this folder. */
+  launchCwd?: string
   sessions: Session[]
 }
 

--- a/apps/website/src/content/docs/architecture.md
+++ b/apps/website/src/content/docs/architecture.md
@@ -85,16 +85,17 @@ Served by `gmuxd` on a Unix socket (local IPC) and a TCP listener (default `127.
 
 | Endpoint | Purpose |
 |---|---|
-| `GET /v1/sessions` | List all sessions |
-| `GET /v1/projects` | Get project configuration |
+| `GET /v1/sessions` | List all sessions (tooling/scripts; the web UI uses SSE snapshots instead) |
 | `PUT /v1/projects` | Replace project list |
 | `POST /v1/projects/add` | Add a discovered project |
+| `PATCH /v1/projects/{slug}/sessions` | Reorder sessions within a project (partial-reorder merge) |
 | `GET /v1/frontend-config` | User settings + theme (from JSONC files) |
 | `POST /v1/launch` | Launch a new session |
 | `POST /v1/sessions/{id}/kill` | Kill a session |
 | `POST /v1/sessions/{id}/dismiss` | Kill + remove |
 | `POST /v1/sessions/{id}/resume` | Resume a resumable session |
-| `GET /v1/events` | SSE stream of session and project changes |
+| `GET /v1/events` | SSE: `snapshot.sessions`, `snapshot.world`, `session-activity` (ADR 0001) |
+| `/v1/peers/{peer}/...` | Forward an allowlisted write to a peer (ADR 0002) |
 | `GET /v1/health` | Daemon health, version, launchers, peer status |
 | `WS /ws/{id}` | Terminal WebSocket proxy |
 | `GET /` | Embedded web UI (SPA) |

--- a/docs/adr/0001-snapshot-push-protocol.md
+++ b/docs/adr/0001-snapshot-push-protocol.md
@@ -1,0 +1,339 @@
+# ADR 0001: Snapshot push protocol
+
+**Status:** Proposed
+**Date:** 2026-04-25
+**Related:** ADR 0002 (Project ownership from session origin)
+
+## Context
+
+Today's gmuxd uses a hybrid push/pull model for state delivery to its
+consumers (browsers and peer gmuxd instances):
+
+- **Hot data via SSE** at `/v1/events`: per-row deltas
+  (`session-upsert`, `session-remove`, `session-activity`) plus
+  trigger-only events (`projects-update`, `peer-status`) whose
+  semantics are "the named resource changed; go re-fetch it."
+- **Initial state via parallel HTTP fetches**: `/v1/sessions`,
+  `/v1/projects`, `/v1/health`, `/v1/frontend-config`.
+
+This shape produces a recurring set of problems:
+
+1. **Hydration races.** The browser fetches multiple resources in
+   parallel; their arrival order is non-deterministic. The frontend
+   carries an explicit `sessionsLoaded` gate to prevent the URL
+   normalization effect from running before sessions arrive and
+   clobbering the path.
+2. **Reconnect requires manual refetches.** On SSE reconnect the
+   client refetches projects and sessions to catch any deltas that
+   happened during the gap, because deltas are not replayed.
+3. **Latent bug with network-peer visibility.** `/v1/events` filters
+   out network-peer sessions to prevent multi-hop forwarding cycles.
+   The same filter applies to browser consumers, so the browser
+   receives initial network-peer sessions via the bulk fetch but no
+   live updates between reconnects.
+4. **Drop-permanence.** A missed `session-remove` leaves a permanent
+   ghost in the receiver's view; the only recovery is a manual
+   refetch. The hybrid protocol has no self-healing property.
+5. **Schema surface.** Seven event types, each with its own payload
+   shape and per-event ordering rules. Maintenance and test cost
+   scale with the number of event types.
+
+## Decision
+
+Replace the hybrid model with a **snapshot push protocol** on
+`/v1/events`. The protocol has three event types, separated by the
+cadence and audience of the data they carry:
+
+1. **`snapshot.sessions`**: the full sessions array. High cadence;
+   driven by every session mutation (create, update, remove, alive
+   flip, project assignment). Subject to coalescing.
+2. **`snapshot.world`**: the bundle of low-frequency, browser-only
+   resources: `projects`, `peers`, `health`, `frontend_config`.
+   Driven by user actions, peer connectivity changes, and settings
+   edits. Subject to coalescing.
+3. **`session-activity`**: small fire-and-forget notification used
+   for UI animations. References a session id; receivers ignore
+   activity for unknown ids. Not coalesced.
+
+Both snapshot types are **full** within their resource scope. Drop
+tolerance is preserved: a missed `snapshot.sessions` is restored by
+the next one, and likewise for `snapshot.world`.
+
+### Why split sessions from world
+
+Sessions and the world bundle have fundamentally different update
+characteristics:
+
+| Property | sessions | world |
+|---|---|---|
+| Cadence | high (terminal activity, peer-driven) | low (user-driven) |
+| Payload size | 10–20 KB typical | 4–6 KB typical |
+| Peer audience | yes (filtered) | no (each node owns its own) |
+| Receiver action | drives sidebar / route logic | settings, project list, peer status |
+
+Bundling them forces the high-cadence stream to drag the
+low-frequency payload along on every emission. Splitting them lets
+each have its own coalescer, its own drop policy, and its own
+filter rule. The world bundle stays bundled internally because all
+its members are individually low-frequency and small; further
+splitting would multiply event types without a corresponding
+benefit.
+
+### Single endpoint with consumer hint
+
+`/v1/events` accepts a `?as=peer|browser` query parameter (default
+`browser`). The hint controls which event types the consumer
+receives:
+
+- `?as=browser`: all three event types. Sessions field includes
+  everything the node can see (own + Local-peer + network-peer
+  sessions). Fixes the latent bug in (3) above.
+- `?as=peer`: only `snapshot.sessions` (filtered to owned sessions
+  only — `Peer == ""` or `peerManager.IsLocalPeer(s.Peer)`) and
+  `session-activity` (filtered to visible sessions). `snapshot.world`
+  is not emitted to peer consumers; peers don't need other peers'
+  projects, peer lists, health, or frontend config.
+
+This preserves today's no-transit-forwarding semantic and is more
+honest about the data model than shipping fields the consumer is
+expected to ignore.
+
+### Server-side coalescing
+
+Each snapshot kind has its own notifier. State mutators call into
+the relevant notifier (or both, for mutations that span both
+domains, e.g., a project change that also updates a session's
+`project_index` stamp).
+
+Each `/v1/events` connection has one goroutine per snapshot kind it
+subscribes to, each with a **trailing-edge throttle** (~50ms): bursts
+of mutations within the window coalesce into one snapshot emitted at
+window end. An idle mutation emits immediately.
+
+Effect: bounded emission rate per kind (≤20 snapshots/sec/consumer
+worst case), no starvation, no unbounded backlog. World snapshots
+are typically much rarer than sessions snapshots, so the world
+coalescer is mostly a passthrough in practice.
+
+### Per-subscriber latest-only buffer
+
+Each subscriber has a bounded channel **per snapshot kind** with
+**latest-only on overflow**: a queued snapshot can be dropped in
+favor of a newer one. Slow consumers receive coalesced updates
+rather than being disconnected. Drops are safe because each
+snapshot is self-contained within its kind.
+
+### Frontend projection layer
+
+The browser store consolidates around three private signals:
+
+- `_rawSessions`: written exactly once per `snapshot.sessions`
+  received.
+- `_rawWorld`: written exactly once per `snapshot.world` received.
+- `_pendingMutations`: optimistic mutations the user has issued but
+  the server has not yet echoed.
+
+Public signals (`sessions`, `projects`, `peers`, `health`,
+`frontendConfig`, `discovered`, `unmatchedActiveCount`, ...) are
+`computed` projections of the appropriate raw signal, with the
+optimistic overlay applied where relevant.
+
+`discovered` and `unmatchedActiveCount` move from server-side
+computation to local `computed` derivations; the server keeps them
+on the HTTP `GET /v1/projects` path for CLI compatibility but
+removes them from the SSE path.
+
+A `ready` computed gates initial render: `_rawSessions !== null &&
+_rawWorld !== null`. The hydration race the existing
+`sessionsLoaded` gate addresses goes away because each raw signal
+has exactly one writer and there are no order dependencies between
+them within their respective domains.
+
+### Optimistic overlay clearance
+
+Each pending mutation targets a specific resource (sessions or
+world.projects, etc.) and carries an `appliesToSnapshot(rawSignal)
+-> boolean` predicate. When a new snapshot arrives that matches the
+mutation's target resource, mutations whose predicate matches are
+removed; remaining mutations stay overlaid. A timeout (~10s) clears
+stuck entries and surfaces a warning. Errors from the action
+endpoint clear the corresponding entry immediately.
+
+### Cross-channel consistency
+
+`snapshot.sessions` and `snapshot.world` arrive on independent
+channels. Brief inconsistencies are possible: a session whose
+`project_slug` references a project that hasn't yet arrived in the
+next world snapshot, or vice versa.
+
+The convergence guarantee handles this: the mutation that produced
+the inconsistency triggers a follow-up snapshot in the lagging
+channel. Receivers tolerate the transient mismatch (e.g., a session
+whose `project_slug` doesn't match any known project falls through
+to disclaimed rendering for one frame).
+
+### Action-ack vs snapshot timing
+
+HTTP action responses and SSE snapshots arrive on independent
+channels. A 200 OK can land before the snapshot reflecting the
+action's effect. The optimistic overlay covers the gap.
+
+## Consequences
+
+### Positive
+
+- **Self-healing per resource.** Drops, missed events, and version
+  skew between receiver and sender all converge on the next
+  snapshot of the affected kind. No class of bug "we lost a remove
+  and now have a permanent ghost."
+- **Reconnect parity.** Initial connect and reconnect are the same
+  handshake; no fork in client logic.
+- **Honest peer protocol.** Peer subscribers receive exactly what
+  they need (sessions + activity), not a bundled payload they're
+  expected to ignore.
+- **Independent cadences.** Sessions stream is decoupled from world
+  edits. A burst of session activity doesn't delay a settings
+  change; a settings change doesn't ride along with every session
+  flip.
+- **Smaller schema.** Three event types instead of seven;
+  maintenance and test surface shrink.
+- **Latent bug fixed.** Browsers receive live updates for
+  network-peer sessions.
+- **Foundation for further consolidation.** Future fields (e.g.,
+  per-session ProjectSlug from ADR 0002) plug into the appropriate
+  snapshot without protocol changes.
+
+### Negative
+
+- **Bandwidth per mutation.** Each state change re-ships the full
+  state of its kind (capped by coalescer). At gmux's intended
+  scale (single user, dozens of sessions, single-digit peers), this
+  is bounded and acceptable; not suitable for thousands of sessions
+  per node.
+- **Receiver responsibility for diff-based actions.** Some receiver
+  logic (e.g., the project-ownership receiver rule from ADR 0002)
+  needs to know what changed between snapshots. The diff is
+  computed per snapshot rather than carried in the event; cost is
+  O(N_sessions) per `snapshot.sessions`.
+- **Cross-channel inconsistency window.** Tiny (single-digit ms)
+  and self-correcting; receivers must be lenient about
+  cross-channel references (e.g., session.project_slug pointing at
+  an unknown slug for one frame).
+
+### Backwards compatibility
+
+Protocol 1 (per-event SSE: `session-upsert`, `session-remove`,
+`projects-update`, `peer-status`) is **kept alongside** protocol 2
+rather than removed. v1.x browsers and hubs continue to work
+against a v2 daemon, and a v2 hub continues to consume sessions
+from a v1.x spoke during a staggered upgrade.
+
+Dispatch on the daemon side:
+
+  - Non-peer subscribers (browsers, v1 hubs that don't send
+    `?as=peer`) receive both `snapshot.sessions` / `snapshot.world`
+    *and* the protocol-1 per-event stream. New consumers attach
+    listeners only for the snapshot events and ignore the per-event
+    chatter; old consumers do the opposite.
+  - Peer subscribers (v2 hubs that send `?as=peer`) receive only
+    `snapshot.sessions` and `session-activity`. Per-event
+    `session-upsert` / `session-remove` are suppressed to avoid
+    double-processing alongside the snapshot.
+
+Dispatch on the hub side: `handleEvent` decodes both
+`snapshot.sessions` and per-event `session-upsert` /
+`session-remove`, applying both idempotently. A v2 spoke sends
+snapshots; a v1 spoke sends per-event; the hub never has to know
+which.
+
+HTTP GET endpoints (`/v1/sessions`, `/v1/projects`, `/v1/health`,
+`/v1/frontend-config`) all remain available. They are no longer the
+v2 browser's hot path; that hydrates from the leading-edge
+`snapshot.sessions` / `snapshot.world`. The endpoints are kept for
+CLI / scripting use and as the v1 browser's bootstrap channel.
+
+The per-event SSE types and the bulk GET endpoints are documented
+as deprecated in v2: they will not gain new fields, but they will
+not be removed in a minor release.
+
+## Alternatives considered
+
+### A. Hybrid: per-row deltas for sessions, full-blob for other resources
+
+Rejected. At gmux's scale, sessions do not churn enough to justify
+per-row complexity. The protocol surface stays at seven event types
+with their associated ordering rules. Per-row deltas reintroduce
+the drop-permanence problem (a missed remove leaves a ghost) for
+the highest-frequency resource.
+
+### B. One unified `snapshot` event with all resources bundled
+
+Rejected. The first sketch of this ADR. Sends every world resource
+on every session mutation. Honest about being a single source of
+truth, but ships fields peer subscribers explicitly don't need
+(other peers' projects/peers/health/config) and couples the
+high-cadence sessions stream to the low-frequency world data on the
+wire. F-3 (the chosen split) gets the same drop-tolerance and
+reconnect parity with cleaner channel separation.
+
+### C. Per-resource SSE endpoints (one connection each)
+
+Rejected. Five concurrent SSE connections per browser, one per peer.
+N reconnect handlers, N times the connection overhead, fragmented
+filter logic. The single endpoint with multiplexed event types
+captures the resource separation without the connection
+multiplication.
+
+### D. Fully per-resource event types (sessions, projects, peers, health, config)
+
+Rejected. Five snapshot kinds in the schema. Most of the splits
+buy nothing: `peers`, `health`, and `config` all change rarely and
+together feel like one logical "world" bundle. Splitting them gives
+five coalescers, five reconnect-state machines, and five filter
+rules, where one bundle suffices. F-3 keeps the split where it
+actually pays — sessions vs world.
+
+### E. Single endpoint, full state to all consumers, receiver-side cycle filter
+
+Rejected. Sending V's full session set to peer Q and letting Q drop
+already-direct-origin sessions enables transitive peering as a side
+effect (Q can see V's peers through V). That is a feature with
+non-trivial routing and trust implications and deserves its own
+design discussion. The `?as=` hint preserves today's
+no-transit-forwarding semantic explicitly.
+
+### F. Two separate endpoints (browser vs peer SSE)
+
+Rejected. The data shape is unified; only the event-type set and
+session filter differ. A single endpoint with a small query param
+is cleaner than two endpoints with duplicated schema and handler
+plumbing.
+
+### G. Feature-flag the new protocol; land incrementally on `main`
+
+Rejected. The chosen design lands both paths atomically in a single
+feature-branch PR (rebase-merged): protocol 2 as the new push
+shape, protocol 1 as the deprecated-but-still-served fallback for
+v1.x peers and tooling. The two paths share state (one store, one
+internal broadcast bus) so there is no risk of them drifting on
+the daemon side; the hub's `handleEvent` switch makes the dispatch
+symmetry explicit on the consumer side. A separate feature flag
+would add a knob we have no use for: every gmuxd should serve
+both shapes.
+
+### H. Snapshot full state on every event, including activity
+
+Rejected. Activity events are high-frequency (one per output burst)
+and tiny (an id). Snapshotting on activity would push bandwidth into
+the tens of KB/sec range during active terminal use for no
+correctness benefit. Keeping `session-activity` as a separate
+notification event is the right size match.
+
+### I. Partial snapshots with "changed fields" hint
+
+Rejected. Drops would lose sub-state for an unbounded period (until
+the next mutation to the dropped field's resource). Recovery would
+require periodic full re-syncs. The drop-tolerance property is the
+single most valuable correctness lever in this design; trading it
+for a 30–50% bandwidth saving on the common case is the wrong
+exchange.

--- a/docs/adr/0002-project-ownership-from-session-origin.md
+++ b/docs/adr/0002-project-ownership-from-session-origin.md
@@ -1,0 +1,498 @@
+# ADR 0002: Project ownership from session origin
+
+**Status:** Proposed
+**Date:** 2026-04-25
+**Related:** ADR 0001 (Snapshot push protocol)
+
+## Context
+
+A gmux project is a user-curated grouping of sessions identified by
+slug, with match rules (paths, git remotes) and an ordered
+`Sessions[]` array that controls sidebar membership and order.
+Project state is per-host, persisted in
+`<state-dir>/projects.json`.
+
+Today, every gmuxd that sees a session decides independently which
+of its own projects (if any) the session belongs to. The local
+auto-assigner runs against every session in the local store,
+including sessions owned by network peers. Symptoms:
+
+1. **The "+" button silently launches on the wrong host.**
+   `LaunchButton` on a folder reads `folder.launchCwd` and POSTs
+   `/v1/launch` without a `peer` field. A folder visually showing
+   five peer-owned sessions still launches a sixth on the local
+   host. Users have no consistent mental model for where a launch
+   lands.
+2. **Mutations don't propagate.** Reordering or dismissing a
+   session from a project is purely local: each host's
+   `projects.json` is independent, and the SSE protocol carries no
+   cross-host project signal. Users editing the sidebar on host A
+   see no effect on host B's view.
+3. **Match rules carry cross-host conceits.** `MatchRule.Hosts`,
+   `NormalizeRemote`, and `~`-path expansion all exist in part to
+   make a single project rule "work" on multiple hosts. The
+   conceit is that `~/dev/foo` on every host is the same project,
+   when it is in fact one filesystem checkout per host.
+4. **Stale peer keys accumulate.** Each local `projects.json`
+   accumulates keys for peer-owned sessions via auto-assignment.
+   These keys stay even after the peer goes away; over time the
+   file becomes cluttered with phantom entries.
+
+### The mental model we're after
+
+A project has **state**: a slug, match rules, an ordered list of
+session keys. State lives somewhere. The cleanest, most honest
+placement is: state lives on the host that curates it, full stop.
+That host is also the one with a working copy of the source, the
+one whose runners produce sessions for the project, and the one
+whose user actually edits `projects.json`.
+
+From that, two consequences fall out:
+
+- **Two hosts that happen to use the slug `gmux` for their
+  respective projects are not the "same project".** They have
+  independent rules, independent membership arrays, and (usually)
+  independent working copies pointing at independent remotes.
+  Merging them in any viewer's sidebar is a per-viewer fiction
+  with no authority for ordering or membership.
+- **A viewer that wants to manipulate a remote project is
+  controlling that project's owner**, not maintaining a local
+  shadow. The viewer's `projects.json` should hold no state about
+  projects it does not own. Mutations cross the wire to the owner;
+  the owner's snapshot reflects the result back to all viewers.
+
+This ADR commits to that model: **a project lives on exactly one
+host; viewers render and steer; they do not co-author.**
+
+### The case for a free-game disclaim
+
+Not every gmuxd is a curator. Devcontainers, CI runners, fresh
+hosts, and short-lived utility nodes produce sessions but never
+have a human curating their `projects.json`. Their natural state
+is empty.
+
+We could introduce an explicit "headless" flag (config or CLI) to
+classify such hosts and gate behaviour. We deliberately don't
+(see Alternative E). Instead, the wire bit `project_slug == ""`
+already encodes the only thing a viewer needs to know: "the
+origin is not claiming this session." An origin with an empty
+`projects.json` disclaims every session by default, which makes
+it emergently "headless" without any new config. A curator host
+that happens to have a one-off shell in `/tmp` produces the same
+disclaim signal for that one session, and that's correct: the
+user told it nothing about that session, so anyone with a
+matching rule is welcome to file it.
+
+Disclaimed sessions are *free game*: viewers run their own match
+rules against them. If a viewer's rules adopt one, the viewer
+adds the key to its own `projects.json` (its intent, its file).
+If nothing adopts, the session falls to the discovered /
+unclaimed UI, exactly like a local orphan. This preserves the
+current zero-config experience for devcontainers and fresh hosts
+while still letting curator hosts keep their own house in order.
+
+## Decision
+
+Project membership for a session is owned by the **origin host**
+(the gmuxd whose runner is executing the session). Each session
+carries its origin's project assignment as part of its wire data.
+Receivers render based on this assignment without re-running their
+own match rules against peer-owned sessions.
+
+When the origin disclaims the session (no matching project, or no
+projects configured at all), receivers fall back to their own match
+rules and treat the session as local-adoptable. This preserves the
+auto-discovery behaviour for the common no-projects-on-peer case
+(devcontainers, fresh hosts) without introducing a separate
+"headless host" classification: an origin with no projects
+disclaims by definition, and the disclaim alone is enough.
+
+### Wire shape
+
+Two new fields on `store.Session`, populated only by the origin and
+only as a pair:
+
+- `project_slug: string` — empty means "origin disclaims this
+  session"; non-empty is the slug of the origin's project that
+  claims it.
+- `project_index: int` — 0-based position in that project's
+  `Sessions[]` array on the origin. Only meaningful when
+  `project_slug != ""`.
+
+These travel with the session in `snapshot.sessions` (per ADR 0001).
+
+### Origin-side stamping (`Reconcile`)
+
+A single `Reconcile()` function on the origin walks
+`projects.json.Items[]` in order; for each `key` in `Sessions[]`
+it stamps the matching `store.Session` with `(slug, index)`. Sessions
+not in any array are stamped `("", 0)`.
+
+`Reconcile()` is the only writer of these two fields on the origin.
+Triggers:
+
+- After every `projectMgr.Update(...)` (any mutation to
+  `projects.json`).
+- After every `sessions.Upsert` / `sessions.Update` for
+  origin-owned sessions (i.e., `Peer == ""`).
+
+For peer-owned sessions, the origin's stamps are received over the
+wire and stored as-is. The local `Reconcile` does not touch them.
+
+### Sidebar rendering rule
+
+```
+for each session s in store:
+  if s.project_slug != "":
+    folder = (s.peer, s.project_slug)         // origin-claimed
+    sort key = (s.peer, s.project_index)
+  else:
+    folder = matchAgainstLocalProjects(s)     // disclaimed: viewer-owned
+    sort key = local Sessions[] array index
+```
+
+Folders displayed:
+
+- **Local owned**, from the viewer's `projects.json.Items[]`. Always
+  shown, even when empty.
+- **Peer owned**, derived from `(peer, slug)` pairs that appear in
+  the visible session set. Shown when at least one session
+  populates the pair. Empty peer projects do not render in v1.
+
+A peer folder is *implicitly* defined by the wire: "at least one
+visible session carries this `(peer, slug)` stamp." The wire
+carries no enumeration of peer projects; viewers don't need one,
+because an empty peer project has nothing to render and nothing
+to sort. This avoids a second piece of state to keep in sync.
+
+### Viewer-side folder ordering (out of scope)
+
+The order of folders *within a single viewer's sidebar* — where
+`[T] gmux` appears among the local folders — is a per-viewer
+view preference, not project state. It is intentionally not
+modelled in this ADR.
+
+For the rendering rule above, a deterministic default is enough:
+local folders first in the viewer's `Items[]` order, then peer
+folders sorted by peer name then by origin's project order. A
+later additive feature can let viewers persist a custom
+`(peer, slug)` ordering in their own local config; that change
+does not touch the wire and does not affect any other host. Its
+state is correctly local, by the same reasoning that puts project
+state on the curator host: a viewer's preferences are about that
+viewer's UI.
+
+### Local auto-assignment
+
+The local auto-assigner runs only for sessions with `Peer == ""`.
+Receivers never write peer-owned session keys to their own
+`Sessions[]` arrays via the claimed path. They may write peer-owned
+keys via the disclaimed-fallback path (the viewer's own match rules
+adopting an origin-disclaimed session).
+
+This contains "peer keys in the local file" to the cases where the
+viewer's own intent has put them there.
+
+### Receiver rule on incoming `snapshot.sessions` (per ADR 0001)
+
+Per session in the new sessions snapshot, compute
+`(prev_claimed, now_claimed)` relative to the previous sessions
+snapshot:
+
+| Transition | Action on viewer |
+|---|---|
+| `false → true` (became claimed) | `RemoveSessionFromAll(key)` from local arrays |
+| `true → false` (became disclaimed) | `AutoAssignSession(s)` (idempotent) |
+| `false → false` (still disclaimed) | `AutoAssignSession(s)` (idempotent; handles late slug attribution) |
+| `true → true` (still claimed, possibly different slug/index) | no array mutation; render reflects new stamps |
+| session removed | `RemoveSessionFromAll(key)` |
+
+### Cross-host actions
+
+- **Per-session actions** (kill, dismiss, attach, resume, restart):
+  unchanged. Already forward to the owner via
+  `peerManager.FindPeer(sessionID)`.
+- **Project-level actions** (reorder a folder's `Sessions[]`):
+  routed via a new generic peer proxy at `/v1/peers/{peer}/...`.
+  The proxy forwards the inner request to the named peer's gmuxd
+  with the auth token. The frontend selects the URL based on
+  whether the folder is local-owned or peer-owned.
+- **Dismiss routing matrix**:
+
+  ```
+  if s.Peer == "":             handle locally (kill if alive; remove from local array)
+  elif s.Alive:                forward to origin (kill)
+  elif s.ProjectSlug != "":    forward to origin (origin removes from its array)
+  else:                        local removal only (viewer's array)
+  ```
+
+### Peer disconnect
+
+When a peer is unreachable, its sessions remain cached in the
+viewer's store with the data from the last received
+`snapshot.sessions`. The sidebar renders them with an "unavailable"
+indicator; the viewer's own `snapshot.world.peers` reflects the
+disconnected status. No cleanup of viewer's `Sessions[]` keys runs
+while the peer is offline.
+
+On reconnect, the peer's first `snapshot.sessions` is authoritative.
+Sessions present in the viewer's prior cache but absent from the
+new sessions snapshot are removed via the receiver rule, which
+cascades through `RemoveSessionFromAll` to clean any local array
+entries that referenced them.
+
+### The "+" button
+
+Each folder has an unambiguous owner: local for own folders,
+the peer for `(peer, slug)` folders. The launch button on a folder
+passes `peer=<owner>` (or omits it for local). The user always
+knows where a new session will run.
+
+## Consequences
+
+### Positive
+
+- **"+" button is unambiguous.** No more silent host-mismatch on
+  launches.
+- **Cross-host reorder, dismiss, and new-session visibility work
+  uniformly.** All routed via "actions go to the owner."
+- **No `projects.json` synchronization across hosts.** Each host
+  retains its own configuration; the sidebar reflects each host's
+  view of the world.
+- **Devcontainer / no-projects-on-peer case is preserved.** The
+  origin disclaims; the viewer adopts via local rules; the user
+  sees the same mixed-folder behaviour as today.
+- **Peer disconnect is honest.** Stale data is visibly stale
+  rather than silently rendered as live.
+- **Match rule complexity has a clear locus.** Rules apply to a
+  host's own sessions and to disclaimed peer sessions on the
+  viewer; they do not pretend to span hosts.
+
+### Negative
+
+- **One-time UX bump.** A session whose origin newly creates a
+  matching project will move out of the viewer's local folder
+  into a `(peer, slug)` folder. Documented in release notes; the
+  new location is more honest than the old.
+- **Empty peer projects don't render on viewers in v1.** A user
+  who creates `gmux` on host B with no sessions yet must launch
+  the first session from B's UI (or use a generic launcher that
+  picks B as the host). Addressable later with a small protocol
+  addition; deferred for v1.
+- **One fiddly action route.** Dismiss of a disclaimed
+  dead-resumable peer session is viewer-local and does not
+  forward to origin (the origin doesn't track it). The four-case
+  table above encodes this; a small unit test set covers it.
+
+### Breaking
+
+Tied to the wire-protocol break in ADR 0001. Not separately
+versioned.
+
+## Alternatives considered
+
+### A. Subscription mechanism
+
+A host can ask peers to track named projects on its behalf, with
+the tracked projects living as hidden entries in the peer's
+`projects.json` (`subscribed_from` field, multi-entry-per-slug,
+explicit lifecycle).
+
+Rejected. The auto-discovery fallback gives us the same benefit
+(peer auto-matches sessions in `~/dev/foo` even when its user has
+no project for them) with one bit (`project_slug` empty) and no
+new state, no new endpoint, no reconciliation.
+
+### B. Synchronize `projects.json` across peers
+
+Treat project state as one shared document with conflict resolution.
+
+Rejected. Requires CRDT or similar machinery; ignores the
+legitimate per-host customization (different hosts may have
+different views of what counts as a project, may want different
+slugs locally, etc.).
+
+### C. Mix sessions across hosts within one project folder, with cross-host drag-reorder
+
+A single `gmux` folder containing local + peer-A + peer-B
+sessions, draggable across hosts.
+
+Rejected. Requires complex ordering policy (whose order wins?
+how do conflicts resolve?), keyspace conversion when forwarding
+mixed reorder PATCHes, UX guards for impossible drops. The "+"
+button location remains ambiguous. Host-scoped folders eliminate
+all of this.
+
+### D. Per-session `ProjectSlug` only, no `ProjectIndex`
+
+Drop position from the wire; receivers sort by an intrinsic
+property (created_at).
+
+Rejected. Defeats reorder propagation entirely. Drag-reorder on
+the origin would not affect viewers' sort. We want the order to
+flow with the rest of the state.
+
+### E. Explicit "headless" config flag
+
+Add `headless = true` (or a CLI `--headless`) to mark hosts that
+produce sessions but never curate projects. Gate the disclaim →
+free-game cascade on this flag, so disclaimed sessions from a
+non-headless host stay strictly under that host's `(peer, ...)`
+in viewers' sidebars rather than being adoptable.
+
+Rejected. The flag would be redundant with information already on
+the wire: a host that doesn't curate projects has an empty
+`projects.json` and so disclaims everything; a host that does
+curate but has a one-off unclaimed session disclaims just that
+one. Both cases want the same viewer behaviour ("if my rules
+match, adopt"), and a single rule covers both. Adding a flag
+would force the user to think about an extra axis of
+configuration without changing any concrete behaviour they care
+about.
+
+A web-server-disable flag (security knob: don't bind a UI on a
+build box) is a reasonable separate setting, but it should not
+affect project semantics.
+
+## Appendix: worked scenarios
+
+These trace the receiver rule end-to-end through the situations
+that motivated this ADR. V is a viewer; O is an origin peer.
+
+### A. New session on origin O; O has a matching project
+
+1. O creates session S. Local auto-assigner adds S's key to
+   `O.gmux.sessions`. `Reconcile` stamps S with
+   `(project_slug="gmux", project_index=N)`.
+2. O emits a snapshot with the stamps.
+3. V receives. Diff vs prior: S is new, claimed. No fallback
+   action needed.
+4. V renders S under `(O, gmux)` at index N.
+
+### B. New session on origin O; O has no matching project
+
+1. O creates session S. Auto-assigner finds no match. S has
+   `project_slug=""`.
+2. O emits a snapshot with empty stamps.
+3. V receives. Diff: S is new, disclaimed. `AutoAssignSession`
+   runs locally. If V's rules match, S's key appends to V's
+   matching project's `Sessions[]`.
+4. V renders S under V's local folder per V's array.
+
+### C. User on O creates a project that retroactively matches existing sessions
+
+1. `projectMgr.Update` adds the project. `AutoAssignAllAlive`
+   walks own sessions, populates the new array. `Reconcile`
+   stamps each affected session.
+2. O emits a snapshot.
+3. V receives. Diff: each affected session transitions
+   `false → true`. V calls `RemoveSessionFromAll(key)` for each.
+4. V re-renders: those sessions move out of V's local folder
+   into `(O, gmux)`.
+
+### D. User on O removes a project (or rule) that previously claimed sessions
+
+1. `projectMgr.Update` removes the project. `Reconcile` clears
+   stamps on affected sessions.
+2. O emits a snapshot.
+3. V receives. Diff: each affected session transitions
+   `true → false`. V calls `AutoAssignSession(s)` for each.
+4. If V's rules match, sessions enter V's local folder.
+   Otherwise they fall to the unmatched / discovered UI.
+
+### E. User on V dismisses a claimed session (origin O, alive)
+
+1. V's gmuxd receives the dismiss action. `peerManager.FindPeer`
+   routes to O.
+2. O kills the runner, removes S from `O.gmux.sessions`, removes
+   S from O's store.
+3. O emits a snapshot. S is absent.
+4. V receives. Diff: S is missing → V calls
+   `RemoveSessionFromAll(key)` (idempotent — wasn't there because
+   origin had claimed it).
+
+### F. User on V dismisses a claimed dead-resumable session (origin O)
+
+1. Forward to O. O's dismiss handler: not alive, no kill.
+   Removes from `O.gmux.sessions`. `Reconcile` clears the stamp.
+2. O emits a snapshot. S is still present (dead-resumable) but
+   `project_slug=""`.
+3. V receives. Diff: S transitions `true → false`.
+   `AutoAssignSession` runs but skips dead sessions; S is not
+   re-adopted.
+4. S has no `project_slug` and is dead-resumable; the rendering
+   rule shows it nowhere. The dismiss intent is preserved.
+
+### G. User on V dismisses a disclaimed peer session
+
+1. V's frontend invokes dismiss for S where `Peer=O` and
+   `project_slug=""`. The four-case route matches: dead
+   disclaimed → local removal only.
+2. V's `projectMgr.RemoveSessionFromAll(key)` clears S from V's
+   own array. No forward to O.
+3. (If S was alive: the alive branch fires first, forwarding to
+   kill at O. Cleanup follows via the next snapshot.)
+
+### H. Reorder of a peer-owned folder
+
+1. V's UI computes new order for `(O, gmux)`. Un-namespaces
+   session ids to O's keyspace.
+2. V's frontend PATCHes
+   `/v1/peers/O/projects/gmux/sessions`. V's gmuxd forwards via
+   the generic peer proxy to O's
+   `PATCH /v1/projects/gmux/sessions`.
+3. O writes the new order. `Reconcile` updates `project_index`
+   on each affected session.
+4. O emits a snapshot. V re-renders.
+
+### I. Reorder of a local mixed folder (own + disclaimed peers)
+
+1. V's UI computes new order. Keys are local-keyspace (slugs or
+   ids).
+2. V's frontend PATCHes V's own
+   `/v1/projects/{slug}/sessions`. V writes its own
+   `projects.json`. No broadcast to peers (this is V's local
+   view of the disclaimed-fallback adoption).
+
+### J. Origin O restarts
+
+1. O's `sessionmeta.Sweep` reloads previously-known dead sessions
+   from disk into the store (`Alive=false`). Live runners that
+   are still listening register shortly after via the discovery
+   scan, upserting with `Alive=true`. Peer-owned records are not
+   persisted, so the store starts empty for those.
+2. O loads `projects.json` and runs an initial `Reconcile` against
+   the now-populated store, stamping every owned session with its
+   `project_slug` / `project_index`.
+3. New SSE subscriptions get a `snapshot.sessions` (and the world
+   snapshot for browser consumers).
+4. V's first `snapshot.sessions` from O after restart serves as the
+   authoritative replay; the receiver rule reconciles V's local
+   arrays. Sessions O previously had but no longer does (e.g., O's
+   meta dir was wiped) are absent and trigger
+   `RemoveSessionFromAll` on V.
+
+### K. Viewer V restarts
+
+1. V loads its own `projects.json`. Has stale entries from prior
+   run (peer keys no longer applicable).
+2. V's session store is empty for peer sessions until subscriptions
+   land.
+3. As each peer's snapshot arrives, the receiver rule applies. Stale
+   peer keys whose sessions are now claimed get removed via
+   `RemoveSessionFromAll`. Stale peer keys whose origin never
+   reconnects sit dormant — they don't render (no resolved store
+   entry) and are addressable via Manage projects.
+
+### L. Peer O disconnects from V
+
+1. V's `peerManager` flips O to disconnected. Cached sessions
+   from O persist in V's store.
+2. V's snapshot to its own browser includes O's sessions with the
+   prior stamps. The browser checks `peers[O].status` and renders
+   them with an "unavailable" indicator.
+3. No cleanup runs while O is disconnected.
+4. On reconnect, O's first snapshot is authoritative. Sessions
+   absent from it trigger `RemoveSessionFromAll`. Sessions present
+   refresh in place. Local `Sessions[]` cleanup follows from the
+   receiver rule.

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -28,10 +28,12 @@ import (
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/devcontainers"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/discovery"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/netauth"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/coalesce"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/conversations"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/peering"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/projects"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/notify"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/snapshot"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/presence"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/sessionfiles"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/sleep"
@@ -548,7 +550,23 @@ func serve(stderr io.Writer) int {
 	// Project manager handles concurrent access to projects.json and
 	// auto-assignment of sessions to projects.
 	projectMgr := projects.NewManager(stateDir)
-	projectMgr.Broadcast = func() {
+
+	// reconcileProjectStamps is the single point that updates each
+	// owned session's ProjectSlug / ProjectIndex from the current
+	// projects.json state. Called after every projectMgr.Update (via
+	// the Broadcast hook below) and once explicitly after the startup
+	// session-seeding loop. See ADR 0002.
+	reconcileProjectStamps := func(state *projects.State) {
+		assignments := state.AssignmentsByKey()
+		sessions.Reconcile(func(s store.Session) (string, int) {
+			key := projects.SessionKey(s.ID, s.Slug)
+			a := assignments[key]
+			return a.Slug, a.Index
+		})
+	}
+
+	projectMgr.Broadcast = func(state *projects.State) {
+		reconcileProjectStamps(state)
 		sessions.Broadcast(store.Event{Type: "projects-update"})
 	}
 	projectMgr.SeedIfEmpty()
@@ -559,6 +577,10 @@ func serve(stderr io.Writer) int {
 	// rehydrateProjects for the identity-model rationale.
 	if state, err := projectMgr.Load(); err == nil {
 		rehydrateProjects(sessions, convIndex, state)
+		// Stamp ProjectSlug / ProjectIndex on the just-rehydrated sessions
+		// (and on any sessions previously loaded via sessionmeta.Sweep)
+		// before SSE subscribers can observe.
+		reconcileProjectStamps(state)
 	}
 
 	// After store is populated, clean up orphaned project entries
@@ -616,7 +638,17 @@ func serve(stderr io.Writer) int {
 
 	// ── Health + Capabilities ──
 
-	mux.HandleFunc("/v1/health", func(w http.ResponseWriter, r *http.Request) {
+	// composeHealth assembles the diagnostic blob shared between
+	// GET /v1/health and the snapshot.world SSE event. It contains
+	// everything the frontend needs to render headers, peer status,
+	// session counts and update banners.
+	//
+	// The auth_token field is intentionally excluded here; the
+	// /v1/health handler injects it only on local Unix-socket
+	// connections. SSE always streams over the authenticated HTTP
+	// path, so leaking the token through snapshot.world would be
+	// a regression.
+	composeHealth := func() map[string]any {
 		data := map[string]any{
 			"service": "gmuxd",
 			"version": version,
@@ -636,11 +668,6 @@ func serve(stderr io.Writer) int {
 		data["listen"] = tcpAddr
 		if v := updateChecker.Available(); v != "" {
 			data["update_available"] = v
-		}
-		// Include auth token only on Unix socket connections (local IPC).
-		// On TCP, the requester already proved they have the token.
-		if r.RemoteAddr == "@" || strings.HasPrefix(r.RemoteAddr, "/") || r.RemoteAddr == "" {
-			data["auth_token"] = authToken
 		}
 		if peers := appendOfflinePeers(peerManager, tsDiscovery); len(peers) > 0 {
 			data["peers"] = peers
@@ -677,6 +704,16 @@ func serve(stderr io.Writer) int {
 		data["default_launcher"] = launchConfig.DefaultLauncher
 		data["launchers"] = launchConfig.Launchers
 
+		return data
+	}
+
+	mux.HandleFunc("/v1/health", func(w http.ResponseWriter, r *http.Request) {
+		data := composeHealth()
+		// Include auth token only on Unix socket connections (local IPC).
+		// On TCP, the requester already proved they have the token.
+		if r.RemoteAddr == "@" || strings.HasPrefix(r.RemoteAddr, "/") || r.RemoteAddr == "" {
+			data["auth_token"] = authToken
+		}
 		writeJSON(w, map[string]any{"ok": true, "data": data})
 	})
 
@@ -715,6 +752,11 @@ func serve(stderr io.Writer) int {
 	})
 
 	// ── Projects ──
+	//
+	// In protocol 2 every reader is also an SSE subscriber and gets the
+	// authoritative project view pushed via snapshot.world (ADR 0001).
+	// GET /v1/projects is retained for v1 clients (old web build, scripts)
+	// and reflects the same state via a one-shot fetch. Deprecated in v2.
 
 	mux.HandleFunc("GET /v1/projects", func(w http.ResponseWriter, r *http.Request) {
 		state, err := projectMgr.Load()
@@ -723,9 +765,7 @@ func serve(stderr io.Writer) int {
 			writeError(w, http.StatusInternalServerError, "internal", "failed to load projects")
 			return
 		}
-
 		sessionInfos := buildSessionInfos(sessions)
-
 		writeJSON(w, map[string]any{
 			"ok": true,
 			"data": map[string]any{
@@ -848,14 +888,8 @@ func serve(stderr io.Writer) int {
 		}
 		found := false
 		err = projectMgr.Update(func(state *projects.State) bool {
-			for i := range state.Items {
-				if state.Items[i].Slug == slug {
-					state.Items[i].Sessions = req.Sessions
-					found = true
-					return true
-				}
-			}
-			return false
+			found = state.ReorderSessions(slug, req.Sessions)
+			return found
 		})
 		if err != nil {
 			log.Printf("projects: reorder sessions error: %v", err)
@@ -867,6 +901,41 @@ func serve(stderr io.Writer) int {
 			return
 		}
 		writeJSON(w, map[string]any{"ok": true})
+	})
+
+	// ── Peer-write proxy ──
+	//
+	// Generic forwarder for state that lives on a peer. The frontend
+	// reaches it via `/v1/peers/{peer}/<rest>`; we forward to the peer
+	// at `/<rest>` (which must already include the leading `/v1/...`).
+	// Per ADR 0002, project membership and ordering are owned by the
+	// session's origin host; the only correct way for the viewer to
+	// reorder a peer's project is to ask the peer to do it.
+	//
+	// The proxy is intentionally narrow: it allowlists writes the
+	// frontend actually issues today (project reorder), so a buggy or
+	// hostile client can't drive arbitrary peer endpoints through us.
+	mux.HandleFunc("/v1/peers/", func(w http.ResponseWriter, r *http.Request) {
+		rest := strings.TrimPrefix(r.URL.Path, "/v1/peers/")
+		name, sub, ok := strings.Cut(rest, "/")
+		if !ok || name == "" || sub == "" {
+			writeError(w, http.StatusNotFound, "not_found", "peer path required")
+			return
+		}
+		if !isAllowedPeerProxyPath(r.Method, sub) {
+			writeError(w, http.StatusForbidden, "forbidden", "peer proxy: method+path not allowed")
+			return
+		}
+		if peerManager == nil {
+			writeError(w, http.StatusBadGateway, "unknown_peer", "no peers configured")
+			return
+		}
+		peer := peerManager.GetPeer(name)
+		if peer == nil {
+			writeError(w, http.StatusBadGateway, "unknown_peer", fmt.Sprintf("peer %q not configured", name))
+			return
+		}
+		peer.ForwardPath(w, r, "/"+sub)
 	})
 
 	// ── Sessions ──
@@ -1436,6 +1505,45 @@ func serve(stderr io.Writer) int {
 		}
 	})
 
+	// ── Snapshot push protocol (ADR 0001) ──
+	//
+	// Two coalesced kinds plus one bare event:
+	//
+	//   snapshot.sessions  trigger: any session state change
+	//   snapshot.world     trigger: projects-update | peer-status
+	//   session-activity   bare: forwarded as-is, lossy, not coalesced
+	//
+	// The coalescers emit `struct{}` triggers; the SSE handler
+	// composes the actual payload at emit time by reading current
+	// state. This avoids snapshotting on every Push (most of which
+	// are coalesced away) and keeps memory bounded under bursts.
+	const snapshotWindow = 50 * time.Millisecond
+	sessionsCoalescer := coalesce.New[struct{}](snapshotWindow)
+	worldCoalescer := coalesce.New[struct{}](snapshotWindow)
+
+	// Pump: a single goroutine watches the broadcast bus and routes
+	// each event type to the right coalescer. session-activity is
+	// not coalesced; it stays on the broadcast bus and SSE handlers
+	// subscribe directly.
+	//
+	// Per-event broadcast types are kept (session-upsert,
+	// session-remove, projects-update, peer-status) because they
+	// remain the canonical signal that *something* changed; protocol
+	// 2 just stops shipping them on the wire.
+	pumpCh, cancelPump := sessions.Subscribe()
+	defer cancelPump()
+	go func() {
+		for ev := range pumpCh {
+			pushSessions, pushWorld := snapshotPumpRoute(ev.Type)
+			if pushSessions {
+				sessionsCoalescer.Push(struct{}{})
+			}
+			if pushWorld {
+				worldCoalescer.Push(struct{}{})
+			}
+		}
+	}()
+
 	// ── SSE Events ──
 
 	mux.HandleFunc("GET /v1/events", func(w http.ResponseWriter, r *http.Request) {
@@ -1449,55 +1557,101 @@ func serve(stderr io.Writer) int {
 			return
 		}
 
-		// isOwned reports whether a session belongs to this node.
-		// Local sessions (Peer=="") and devcontainer sessions (Local
-		// peer) are owned; network peer sessions are not forwarded.
+		// asPeer consumers (?as=peer) get owned sessions only and no
+		// world snapshots. Browser consumers get everything.
+		asPeer := r.URL.Query().Get("as") == "peer"
+
+		// isLocalPeer wraps the manager's check so it tolerates a
+		// nil manager (test harnesses, single-node mode).
+		isLocalPeer := func(name string) bool {
+			return peerManager != nil && peerManager.IsLocalPeer(name)
+		}
+		// isOwned: own sessions (Peer=="") + Local-peer (devcontainer)
+		// sessions belong to this node and ride peer feeds; network
+		// peer sessions don't forward through this node to others.
 		isOwned := func(s *store.Session) bool {
 			if s.Peer == "" {
 				return true
 			}
-			return peerManager != nil && peerManager.IsLocalPeer(s.Peer)
+			return isLocalPeer(s.Peer)
 		}
 
-		// isOwnedEvent checks a store event. Session-upsert carries
-		// the full session; remove/activity only have the ID, so we
-		// extract the peer from the namespaced ID. Non-session events
-		// (projects-update, peer-status) are always forwarded.
-		isOwnedEvent := func(ev store.Event) bool {
-			switch ev.Type {
-			case "session-upsert":
-				if ev.Session == nil {
-					return true
-				}
-				return isOwned(ev.Session)
-			case "session-remove", "session-activity":
-				_, peerName := peering.ParseID(ev.ID)
-				if peerName == "" {
-					return true // local
-				}
-				return peerManager != nil && peerManager.IsLocalPeer(peerName)
-			default:
-				return true
+		// snapshot.sessions filter differs by subscriber kind:
+		//
+		//  - asPeer (?as=peer, another hub): owned only. The peer
+		//    reconciles its view of network-peer sessions directly
+		//    from the originating peers; forwarding them via this
+		//    node would create double delivery and false-origin
+		//    attribution (ADR 0002).
+		//  - browser: every session in the local store, including
+		//    namespaced mirrors of network-peer sessions. ADR 0002
+		//    needs these so peer-owned folders render in the sidebar
+		//    with the origin's chosen order.
+		composeSessions := func() snapshot.SessionsPayload {
+			if asPeer {
+				return snapshot.ComposeSessions(sessions.List(), isOwned)
+			}
+			return snapshot.ComposeSessions(sessions.List(), nil)
+		}
+
+		composeWorld := func() snapshot.WorldPayload {
+			state, err := projectMgr.Load()
+			var items []projects.Item
+			if err == nil {
+				items = state.Items
+			} else {
+				log.Printf("snapshot.world: projects load: %v", err)
+			}
+			health := composeHealth()
+			return snapshot.WorldPayload{
+				Projects:        items,
+				Peers:           appendOfflinePeers(peerManager, tsDiscovery),
+				Health:          health,
+				Launchers:       launchConfig.Launchers,
+				DefaultLauncher: launchConfig.DefaultLauncher,
 			}
 		}
 
-		// Send current state as upserts (owned sessions only).
-		for _, sess := range sessions.List() {
-			s := sess
-			if !isOwned(&s) {
-				continue
+		sessionsSub, cancelSessions := sessionsCoalescer.Subscribe()
+		defer cancelSessions()
+		var worldSub <-chan struct{}
+		var cancelWorld func()
+		if !asPeer {
+			worldSub, cancelWorld = worldCoalescer.Subscribe()
+			defer cancelWorld()
+		}
+
+		// Activity events stay on the bare broadcast bus: lossy,
+		// per-session, no batching. Filter for owned sessions so
+		// peer consumers don't see network-peer activity.
+		activityCh, cancelActivity := sessions.Subscribe()
+		defer cancelActivity()
+
+		// Initial snapshots (leading edge: subscriber is idle).
+		sendSSE(w, "snapshot.sessions", composeSessions())
+		if !asPeer {
+			sendSSE(w, "snapshot.world", composeWorld())
+		}
+
+		// Protocol-1 initial state: emit each owned session as a
+		// session-upsert so v1.x consumers (old browsers, old hubs
+		// without `?as=peer` support) can hydrate without
+		// GET /v1/sessions. Suppressed for new peer subscribers since
+		// they consume snapshot.sessions.
+		if !asPeer {
+			for _, sess := range sessions.List() {
+				s := sess
+				if !isOwned(&s) {
+					continue
+				}
+				sendSSE(w, "session-upsert", store.Event{
+					Type:    "session-upsert",
+					ID:      s.ID,
+					Session: &s,
+				})
 			}
-			sendSSE(w, "session-upsert", store.Event{
-				Type:    "session-upsert",
-				ID:      s.ID,
-				Session: &s,
-			})
 		}
 		flusher.Flush()
-
-		// Stream updates (owned events only).
-		ch, cancel := sessions.Subscribe()
-		defer cancel()
 
 		// Heartbeat: send an SSE comment every 30s to keep the connection
 		// alive through idle periods. Without this, the hub's sseclient
@@ -1513,19 +1667,55 @@ func serve(stderr io.Writer) int {
 			case <-notify:
 				return
 			case <-heartbeat.C:
-				// SSE comment line: resets the client's idle timer
-				// without producing a client-side event.
 				fmt.Fprint(w, ":\n\n")
 				flusher.Flush()
-			case ev, open := <-ch:
+			case _, open := <-sessionsSub:
 				if !open {
 					return
 				}
-				if !isOwnedEvent(ev) {
-					continue
-				}
-				sendSSE(w, ev.Type, ev)
+				sendSSE(w, "snapshot.sessions", composeSessions())
 				flusher.Flush()
+			case _, open := <-worldSub:
+				if !open {
+					return
+				}
+				sendSSE(w, "snapshot.world", composeWorld())
+				flusher.Flush()
+			case ev, open := <-activityCh:
+				if !open {
+					return
+				}
+				switch ev.Type {
+				case "session-activity":
+					// Peer subscribers (?as=peer) get activity for owned
+					// sessions only; browser subscribers see everything so
+					// peer-owned session indicators update.
+					if !shouldForwardActivity(asPeer, ev.ID, isLocalPeer) {
+						continue
+					}
+					sendSSE(w, "session-activity", ev)
+					flusher.Flush()
+				case "session-upsert", "session-remove":
+					// Protocol-1 compat: emit owned-only per-event SSE to
+					// non-asPeer subscribers (browsers and v1 hubs that
+					// don't know about `?as=peer`). v2 hubs subscribe with
+					// `?as=peer` and consume snapshot.sessions exclusively,
+					// so we suppress per-event for them to avoid double
+					// processing.
+					if asPeer || !isOwnedEvent(ev, isLocalPeer) {
+						continue
+					}
+					sendSSE(w, ev.Type, ev)
+					flusher.Flush()
+				case "projects-update", "peer-status":
+					// Protocol-1 compat: browser-only. Hubs derive these
+					// from cached /v1/health and their own projects.json.
+					if asPeer {
+						continue
+					}
+					sendSSE(w, ev.Type, ev)
+					flusher.Flush()
+				}
 			}
 		}
 	})
@@ -1889,6 +2079,114 @@ func runAuth(stdout, stderr io.Writer) int {
 	_, _ = fmt.Fprintf(stdout, "\nOpen this URL to authenticate:\n  %s\n", url)
 
 	return 0
+}
+
+// snapshotPumpRoute decides which protocol-2 coalescers a given
+// internal broadcast event triggers. Returned in (pushSessions,
+// pushWorld) order. Unknown event types fire neither.
+//
+//   - session-upsert / session-remove fire snapshot.sessions only.
+//   - peer-status fires snapshot.world only (peer state lives in
+//     the world bundle, not in the per-session payload).
+//   - projects-update fires both: projects.Manager.Broadcast runs
+//     Reconcile beforehand, which silently re-stamps every owned
+//     session's ProjectSlug / ProjectIndex. Without re-emitting
+//     snapshot.sessions, the UI would keep rendering each session
+//     under its previous project until the next unrelated session
+//     change.
+func snapshotPumpRoute(eventType string) (pushSessions, pushWorld bool) {
+	switch eventType {
+	case "session-upsert", "session-remove":
+		return true, false
+	case "peer-status":
+		return false, true
+	case "projects-update":
+		return true, true
+	}
+	return false, false
+}
+
+// isOwnedEvent reports whether a protocol-1 per-event SSE frame
+// (session-upsert / session-remove) refers to a session this node
+// owns, and therefore should be forwarded to non-asPeer subscribers.
+// Sessions on the local node (Peer == "") and on Local peers
+// (devcontainers reachable via isLocalPeer) are owned; network-peer
+// sessions are not, because non-asPeer hubs sourcing this stream
+// would receive the same upserts directly from those peers.
+//
+// Used only by the SSE handler for v1-compat dispatch; v2 hubs
+// (asPeer=true) consume snapshot.sessions instead and never see
+// these frames.
+//
+// Unknown event types pass through (return true); the caller switches
+// on Type first so this is only a defensive default.
+func isOwnedEvent(ev store.Event, isLocalPeer func(string) bool) bool {
+	ownedPeer := func(peerName string) bool {
+		if peerName == "" {
+			return true
+		}
+		return isLocalPeer != nil && isLocalPeer(peerName)
+	}
+	switch ev.Type {
+	case "session-upsert":
+		if ev.Session == nil {
+			return true
+		}
+		return ownedPeer(ev.Session.Peer)
+	case "session-remove":
+		_, peerName := peering.ParseID(ev.ID)
+		return ownedPeer(peerName)
+	}
+	return true
+}
+
+// shouldForwardActivity decides whether a session-activity event
+// should be sent to a given SSE subscriber.
+//
+//   - asPeer subscribers (?as=peer, i.e. another node's hub) only
+//     receive activity for sessions this node owns (own sessions or
+//     sessions on a Local peer such as a devcontainer). Activity for
+//     network-peer sessions reaches the requesting hub directly from
+//     the origin; forwarding it via this node would create double-
+//     delivery and false-origin attribution.
+//   - Browser subscribers receive every activity event the local
+//     daemon sees, including namespaced activity that hubs have
+//     re-broadcast from network peers — the UI renders all of those
+//     sessions and needs the indicator updates.
+func shouldForwardActivity(asPeer bool, sessionID string, isLocalPeer func(string) bool) bool {
+	if !asPeer {
+		return true
+	}
+	_, peerName := peering.ParseID(sessionID)
+	if peerName == "" {
+		return true
+	}
+	return isLocalPeer != nil && isLocalPeer(peerName)
+}
+
+// isAllowedPeerProxyPath gates the generic /v1/peers/{peer}/...
+// proxy. We deliberately allowlist a small surface, scoped to writes
+// the frontend actually issues for peer-owned state today, rather
+// than blanket-forwarding every method+path. New peer-write features
+// extend this function explicitly.
+//
+// `sub` is the path relative to the peer's API root, with no leading
+// slash (e.g. "v1/projects/gmux/sessions").
+func isAllowedPeerProxyPath(method, sub string) bool {
+	parts := strings.Split(sub, "/")
+	// Project session reorder: PATCH v1/projects/<slug>/sessions.
+	// The frontend uses this to push a new session order into a
+	// peer's projects.json. The peer applies the change atomically
+	// and re-broadcasts the resulting stamps, which we observe over
+	// SSE; no local optimistic mirror is needed because the viewer
+	// doesn't own the projects.json being reordered.
+	if method == http.MethodPatch &&
+		len(parts) == 4 &&
+		parts[0] == "v1" && parts[1] == "projects" &&
+		parts[2] != "" && parts[3] == "sessions" {
+		return true
+	}
+	return false
 }
 
 // buildSessionInfos converts store sessions to project SessionInfo structs.

--- a/services/gmuxd/cmd/gmuxd/main_test.go
+++ b/services/gmuxd/cmd/gmuxd/main_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/gmuxapp/gmux/packages/adapter"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/store"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/unixipc"
 )
 
@@ -432,4 +433,190 @@ func TestRunSubcommandHelp(t *testing.T) {
 			t.Errorf("%s --help: expected %q in output, got %q", tt.cmd, tt.contains, stdout.String())
 		}
 	}
+}
+
+func TestSnapshotPumpRoute(t *testing.T) {
+	cases := []struct {
+		eventType    string
+		wantSessions bool
+		wantWorld    bool
+	}{
+		// Session changes only fire the sessions snapshot.
+		{"session-upsert", true, false},
+		{"session-remove", true, false},
+
+		// Peer status only changes the world bundle.
+		{"peer-status", false, true},
+
+		// projects-update fires both kinds. Regression guard: prior
+		// versions of the pump routed projects-update only to the
+		// world coalescer, leaving session ProjectSlug / ProjectIndex
+		// stamps unflushed after a projects.json edit.
+		{"projects-update", true, true},
+
+		// Activity is delivered separately (bare bus); the pump must
+		// not coalesce it.
+		{"session-activity", false, false},
+
+		// Unknown / future event types are silently ignored.
+		{"", false, false},
+		{"unknown-type", false, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.eventType, func(t *testing.T) {
+			gotSessions, gotWorld := snapshotPumpRoute(tc.eventType)
+			if gotSessions != tc.wantSessions || gotWorld != tc.wantWorld {
+				t.Errorf("snapshotPumpRoute(%q) = (sessions=%v, world=%v), want (sessions=%v, world=%v)",
+					tc.eventType, gotSessions, gotWorld, tc.wantSessions, tc.wantWorld)
+			}
+		})
+	}
+}
+
+func TestShouldForwardActivity(t *testing.T) {
+	// Local peer "dc" is a devcontainer; "hub-b" is a network peer.
+	isLocalPeer := func(name string) bool { return name == "dc" }
+
+	cases := []struct {
+		name      string
+		asPeer    bool
+		sessionID string
+		want      bool
+	}{
+		// Browser sees everything, regardless of namespace.
+		{"browser local session", false, "sess-1", true},
+		{"browser devcontainer session", false, "sess-1@dc", true},
+		{"browser network-peer session", false, "sess-1@hub-b", true},
+
+		// Hub (asPeer) only sees activity for sessions this node owns.
+		{"asPeer local session", true, "sess-1", true},
+		{"asPeer devcontainer session", true, "sess-1@dc", true},
+		{"asPeer network-peer session dropped", true, "sess-1@hub-b", false},
+
+		// Defense: nil isLocalPeer means “no locals”, so any namespaced
+		// id is dropped for asPeer (e.g. peerManager not yet wired).
+		{"asPeer nil isLocalPeer drops namespaced", true, "sess-1@dc", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			lookup := isLocalPeer
+			if tc.name == "asPeer nil isLocalPeer drops namespaced" {
+				lookup = nil
+			}
+			got := shouldForwardActivity(tc.asPeer, tc.sessionID, lookup)
+			if got != tc.want {
+				t.Errorf("shouldForwardActivity(asPeer=%v, %q) = %v, want %v",
+					tc.asPeer, tc.sessionID, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsAllowedPeerProxyPath(t *testing.T) {
+	cases := []struct {
+		name   string
+		method string
+		sub    string
+		want   bool
+	}{
+		// Allowed: project session reorder.
+		{"reorder allowed", http.MethodPatch, "v1/projects/gmux/sessions", true},
+		{"reorder allowed weird slug", http.MethodPatch, "v1/projects/with-dash/sessions", true},
+
+		// Method must be PATCH.
+		{"GET denied", http.MethodGet, "v1/projects/gmux/sessions", false},
+		{"POST denied", http.MethodPost, "v1/projects/gmux/sessions", false},
+		{"DELETE denied", http.MethodDelete, "v1/projects/gmux/sessions", false},
+
+		// Path shape: must be projects/<slug>/sessions.
+		{"reorder root denied", http.MethodPatch, "v1/projects", false},
+		{"reorder add denied", http.MethodPatch, "v1/projects/add", false},
+		{"projects bare denied", http.MethodPatch, "v1/projects/gmux", false},
+		{"sessions endpoint denied", http.MethodPatch, "v1/sessions/sess-1/kill", false},
+		{"unrelated path denied", http.MethodPatch, "v1/health", false},
+
+		// Defense: never allow without the v1/ prefix even if shape matches.
+		{"missing v1 prefix denied", http.MethodPatch, "projects/gmux/sessions", false},
+
+		// Defense: don't accept random suffixes after /sessions.
+		{"trailing path denied", http.MethodPatch, "v1/projects/gmux/sessions/extra", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isAllowedPeerProxyPath(tc.method, tc.sub)
+			if got != tc.want {
+				t.Errorf("isAllowedPeerProxyPath(%q, %q) = %v, want %v",
+					tc.method, tc.sub, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsOwnedEvent(t *testing.T) {
+	// Devcontainers are surfaced as Local peers; "tower" is a network
+	// peer that should NOT be treated as owned by this node.
+	isLocalPeer := func(name string) bool { return name == "dc" }
+
+	cases := []struct {
+		name string
+		ev   store.Event
+		want bool
+	}{
+		// session-upsert ownership comes from the embedded Session's Peer.
+		{
+			name: "upsert local session",
+			ev:   store.Event{Type: "session-upsert", ID: "sess-1", Session: &store.Session{ID: "sess-1"}},
+			want: true,
+		},
+		{
+			name: "upsert devcontainer session",
+			ev:   store.Event{Type: "session-upsert", ID: "sess-1@dc", Session: &store.Session{ID: "sess-1@dc", Peer: "dc"}},
+			want: true,
+		},
+		{
+			name: "upsert network-peer session dropped",
+			ev:   store.Event{Type: "session-upsert", ID: "sess-1@tower", Session: &store.Session{ID: "sess-1@tower", Peer: "tower"}},
+			want: false,
+		},
+		// Defense: a nil Session pointer (shouldn't happen on the wire
+		// today, but cheap to handle): treat as owned rather than drop
+		// silently and lose a removal-pair upsert.
+		{
+			name: "upsert nil session passes through",
+			ev:   store.Event{Type: "session-upsert", ID: "sess-1"},
+			want: true,
+		},
+
+		// session-remove only carries an ID; ownership is inferred from
+		// the namespace suffix on the ID.
+		{name: "remove local id", ev: store.Event{Type: "session-remove", ID: "sess-1"}, want: true},
+		{name: "remove devcontainer id", ev: store.Event{Type: "session-remove", ID: "sess-1@dc"}, want: true},
+		{name: "remove network-peer id dropped", ev: store.Event{Type: "session-remove", ID: "sess-1@tower"}, want: false},
+
+		// Unknown event types pass through (the SSE handler switches on
+		// Type before calling, so this is just a defensive default).
+		{name: "unknown type passes through", ev: store.Event{Type: "something-else", ID: "sess-1@tower"}, want: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isOwnedEvent(tc.ev, isLocalPeer)
+			if got != tc.want {
+				t.Errorf("isOwnedEvent(%+v) = %v, want %v", tc.ev, got, tc.want)
+			}
+		})
+	}
+
+	t.Run("nil isLocalPeer drops any namespaced id", func(t *testing.T) {
+		// Defense: if peerManager isn't wired (early startup, test
+		// harnesses), we can't confirm a peer is Local, so the safe
+		// default for asPeer dispatch is "not owned".
+		ev := store.Event{Type: "session-remove", ID: "sess-1@dc"}
+		if got := isOwnedEvent(ev, nil); got != false {
+			t.Errorf("isOwnedEvent with nil isLocalPeer = %v, want false", got)
+		}
+	})
 }

--- a/services/gmuxd/internal/apiclient/client.go
+++ b/services/gmuxd/internal/apiclient/client.go
@@ -125,7 +125,10 @@ func (c *Client) Events() *sseclient.Client {
 	if c.streamIdleTimeout > 0 {
 		opts = append(opts, sseclient.WithIdleTimeout(c.streamIdleTimeout))
 	}
-	return sseclient.New(c.baseURL+"/v1/events", opts...)
+	// `?as=peer` instructs the spoke to filter to owned sessions and
+	// suppress snapshot.world (ADR 0001). The hub composes its own
+	// world view from local state and union of peer feeds.
+	return sseclient.New(c.baseURL+"/v1/events?as=peer", opts...)
 }
 
 // GetHealth fetches GET /v1/health and returns the Data field of the
@@ -176,6 +179,17 @@ func (c *Client) GetHealth(ctx context.Context) (json.RawMessage, error) {
 // for stripping the "@peer" suffix before calling.
 func (c *Client) ForwardAction(w http.ResponseWriter, r *http.Request, sessionID, action string) {
 	path := fmt.Sprintf("/v1/sessions/%s/%s", sessionID, action)
+	c.proxyHTTP(w, r, path)
+}
+
+// ForwardPath proxies an HTTP request to the spoke at the given
+// absolute path. The path must include the leading slash ("/v1/...").
+// Method, body, status, headers and Content-Type are preserved.
+//
+// Used by the generic peer proxy at /v1/peers/{peer}/... to forward
+// project-management writes (and other host-scoped state) to the
+// session's owning host (ADR 0002).
+func (c *Client) ForwardPath(w http.ResponseWriter, r *http.Request, path string) {
 	c.proxyHTTP(w, r, path)
 }
 

--- a/services/gmuxd/internal/apiclient/client_test.go
+++ b/services/gmuxd/internal/apiclient/client_test.go
@@ -295,6 +295,59 @@ func TestForwardLaunch_InvalidJSON(t *testing.T) {
 	}
 }
 
+// ── ForwardPath ───────────────────────────────────────────────────
+
+func TestForwardPath_PreservesMethodPathAndBody(t *testing.T) {
+	var gotPath, gotMethod string
+	var gotBody []byte
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer ts.Close()
+
+	c := New(ts.URL, WithBearerToken("tok"))
+	req := httptest.NewRequest(http.MethodPatch,
+		"/v1/peers/tower/v1/projects/gmux/sessions",
+		strings.NewReader(`{"sessions":["a","b"]}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	c.ForwardPath(w, req, "/v1/projects/gmux/sessions")
+
+	if gotPath != "/v1/projects/gmux/sessions" {
+		t.Errorf("path = %q, want /v1/projects/gmux/sessions", gotPath)
+	}
+	if gotMethod != http.MethodPatch {
+		t.Errorf("method = %q, want PATCH", gotMethod)
+	}
+	if string(gotBody) != `{"sessions":["a","b"]}` {
+		t.Errorf("body = %q, want session list", string(gotBody))
+	}
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", w.Code)
+	}
+}
+
+func TestForwardPath_PropagatesUpstreamStatus(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "no such project", http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	c := New(ts.URL)
+	req := httptest.NewRequest(http.MethodPatch, "/anything", strings.NewReader(`{}`))
+	w := httptest.NewRecorder()
+	c.ForwardPath(w, req, "/v1/projects/missing/sessions")
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", w.Code)
+	}
+}
+
 // ── Events ────────────────────────────────────────────────────────
 
 // TestEvents_CallsAuthorizedSubscribe is the smoke test for apiclient

--- a/services/gmuxd/internal/coalesce/coalesce.go
+++ b/services/gmuxd/internal/coalesce/coalesce.go
@@ -1,0 +1,187 @@
+// Package coalesce provides a typed trailing-edge coalescer that
+// batches rapid producer updates into at-most-one delivery per
+// window per subscriber, while still letting idle updates through
+// immediately.
+//
+// The shape matches what ADR 0001 calls for: each kind of snapshot
+// (sessions, world) gets one Coalescer; subscribers (the SSE
+// /v1/events handler, peer mirroring) attach their own subscription
+// and receive a "latest only" stream.
+//
+// Semantics for one subscriber:
+//
+//   - Push records the new latest value and pokes the subscriber.
+//   - If no value has been emitted within `window`, the subscriber's
+//     run loop emits immediately (leading-edge while idle).
+//   - Otherwise it waits out the rest of the window then emits the
+//     freshest value, coalescing every push that arrived in between.
+//   - If the subscriber's receive channel is full (buffer 1), the
+//     buffered value is dropped and replaced with the freshest one.
+//     "Latest wins"; the subscriber never sees stale state.
+//
+// The coalescer is safe for concurrent use. Subscribers are
+// independent: a slow receiver only affects its own delivery rate.
+package coalesce
+
+import (
+	"sync"
+	"time"
+)
+
+// Coalescer batches rapid Push() calls into at-most-one trailing-edge
+// emission per window per subscriber. The zero value is not usable;
+// callers must use New.
+type Coalescer[T any] struct {
+	window time.Duration
+
+	mu   sync.Mutex
+	subs []*sub[T]
+}
+
+// New creates a coalescer with the given trailing-edge window. A
+// window of zero disables coalescing (every Push emits immediately
+// to every subscriber).
+func New[T any](window time.Duration) *Coalescer[T] {
+	return &Coalescer[T]{window: window}
+}
+
+// Push records v as the new latest value and notifies every active
+// subscriber. Cheap; safe to call from any goroutine. Push never
+// blocks on subscribers.
+func (c *Coalescer[T]) Push(v T) {
+	c.mu.Lock()
+	subs := append([]*sub[T](nil), c.subs...) // snapshot under lock
+	c.mu.Unlock()
+	for _, s := range subs {
+		s.set(v)
+	}
+}
+
+// Subscribe attaches a fresh subscriber. The returned channel
+// receives coalesced values; callers must invoke cancel exactly once
+// to detach. After cancel, the channel is closed.
+func (c *Coalescer[T]) Subscribe() (<-chan T, func()) {
+	s := &sub[T]{
+		out:  make(chan T, 1),
+		wake: make(chan struct{}, 1),
+		done: make(chan struct{}),
+	}
+	c.mu.Lock()
+	c.subs = append(c.subs, s)
+	c.mu.Unlock()
+
+	go s.run(c.window)
+
+	var once sync.Once
+	cancel := func() {
+		once.Do(func() {
+			close(s.done)
+			c.mu.Lock()
+			for i, x := range c.subs {
+				if x == s {
+					c.subs = append(c.subs[:i], c.subs[i+1:]...)
+					break
+				}
+			}
+			c.mu.Unlock()
+		})
+	}
+	return s.out, cancel
+}
+
+// sub is one subscriber. `latest` + `hasNew` form the "latest only"
+// buffer; `wake` notifies the run goroutine that latest changed;
+// `out` is the receive channel handed to the caller.
+type sub[T any] struct {
+	mu     sync.Mutex
+	latest T
+	hasNew bool
+
+	out  chan T
+	wake chan struct{}
+	done chan struct{}
+}
+
+// set records a new latest value and pokes the run goroutine. Never
+// blocks: the wake channel is single-slot, and a queued wake is
+// equivalent to a fresh one (the goroutine will read latest under
+// its own lock).
+func (s *sub[T]) set(v T) {
+	s.mu.Lock()
+	s.latest = v
+	s.hasNew = true
+	s.mu.Unlock()
+	select {
+	case s.wake <- struct{}{}:
+	default:
+	}
+}
+
+// run is the per-subscriber pump. Single goroutine per subscriber so
+// a slow receiver can't stall the producer or other subscribers.
+func (s *sub[T]) run(window time.Duration) {
+	defer close(s.out)
+
+	var lastEmit time.Time
+	for {
+		select {
+		case <-s.done:
+			return
+		case <-s.wake:
+		}
+
+		// Idle (or zero-window): emit immediately.
+		elapsed := time.Since(lastEmit)
+		if window <= 0 || elapsed >= window {
+			s.emit()
+			lastEmit = time.Now()
+			continue
+		}
+
+		// Trailing-edge wait. Further wakes during the wait don't
+		// reset the timer; they just refresh `latest`, which we'll
+		// pick up when the timer fires.
+		timer := time.NewTimer(window - elapsed)
+		select {
+		case <-s.done:
+			timer.Stop()
+			return
+		case <-timer.C:
+		}
+		s.emit()
+		lastEmit = time.Now()
+	}
+}
+
+// emit copies the buffered latest value to the output channel,
+// dropping any older buffered value first. Returns silently if no
+// new value has accumulated since the last emit (defensive; the run
+// loop only calls emit after a wake).
+func (s *sub[T]) emit() {
+	s.mu.Lock()
+	if !s.hasNew {
+		s.mu.Unlock()
+		return
+	}
+	v := s.latest
+	s.hasNew = false
+	s.mu.Unlock()
+
+	// Latest-wins: if the previous emit hasn't been consumed yet,
+	// drop it and take the newer value.
+	select {
+	case s.out <- v:
+	default:
+		select {
+		case <-s.out:
+		default:
+		}
+		// Buffer is now free (either we drained or another receiver
+		// raced in and drained for us). Try once more; if it still
+		// fails the receiver is reading concurrently, which is fine.
+		select {
+		case s.out <- v:
+		default:
+		}
+	}
+}

--- a/services/gmuxd/internal/coalesce/coalesce_test.go
+++ b/services/gmuxd/internal/coalesce/coalesce_test.go
@@ -1,0 +1,265 @@
+package coalesce
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// recv waits up to timeout for a value on ch. Returns (value, true)
+// on success, (zero, false) on timeout. Test helper, not exported.
+func recv[T any](t *testing.T, ch <-chan T, timeout time.Duration) (T, bool) {
+	t.Helper()
+	select {
+	case v, ok := <-ch:
+		if !ok {
+			var zero T
+			return zero, false
+		}
+		return v, true
+	case <-time.After(timeout):
+		var zero T
+		return zero, false
+	}
+}
+
+// expectNothing asserts that no value arrives within `quiet`.
+func expectNothing[T any](t *testing.T, ch <-chan T, quiet time.Duration) {
+	t.Helper()
+	select {
+	case v, ok := <-ch:
+		if !ok {
+			t.Fatalf("channel closed unexpectedly during quiet window")
+		}
+		t.Fatalf("expected no value within %v, got %v", quiet, v)
+	case <-time.After(quiet):
+	}
+}
+
+func TestIdlePushDeliversImmediately(t *testing.T) {
+	c := New[int](50 * time.Millisecond)
+	ch, cancel := c.Subscribe()
+	defer cancel()
+
+	start := time.Now()
+	c.Push(7)
+	v, ok := recv(t, ch, 25*time.Millisecond)
+	if !ok {
+		t.Fatalf("expected immediate emit, got timeout")
+	}
+	if v != 7 {
+		t.Fatalf("expected 7, got %v", v)
+	}
+	if elapsed := time.Since(start); elapsed > 25*time.Millisecond {
+		t.Fatalf("idle emit took %v, expected <25ms", elapsed)
+	}
+}
+
+func TestBurstCoalescesToTrailingLatest(t *testing.T) {
+	c := New[int](40 * time.Millisecond)
+	ch, cancel := c.Subscribe()
+	defer cancel()
+
+	// First push: leading-edge, immediate.
+	c.Push(1)
+	v, ok := recv(t, ch, 25*time.Millisecond)
+	if !ok || v != 1 {
+		t.Fatalf("leading-edge emit: got %v ok=%v, want 1 true", v, ok)
+	}
+
+	// Burst three more pushes within the window.
+	c.Push(2)
+	c.Push(3)
+	c.Push(4)
+
+	// Nothing should arrive sooner than ~window after the leading emit.
+	expectNothing(t, ch, 20*time.Millisecond)
+
+	// Trailing-edge: a single emission with the latest value (4),
+	// not 2 or 3.
+	v, ok = recv(t, ch, 100*time.Millisecond)
+	if !ok {
+		t.Fatalf("trailing-edge emit: timeout")
+	}
+	if v != 4 {
+		t.Fatalf("expected coalesced trailing emit of latest=4, got %v", v)
+	}
+
+	// And no further emit afterwards.
+	expectNothing(t, ch, 60*time.Millisecond)
+}
+
+func TestSlowReceiverGetsLatestOnly(t *testing.T) {
+	c := New[int](10 * time.Millisecond)
+	ch, cancel := c.Subscribe()
+	defer cancel()
+
+	// Push, don't drain. Run loop emits 1 into the buffer.
+	c.Push(1)
+	// Wait for the goroutine to actually buffer the value.
+	time.Sleep(20 * time.Millisecond)
+
+	// More pushes while the receiver is still slow. Each trailing-
+	// edge emit overwrites the buffered value.
+	for i := 2; i <= 10; i++ {
+		c.Push(i)
+		time.Sleep(15 * time.Millisecond)
+	}
+
+	// Now drain. We should see exactly the latest pushed value (10),
+	// not stale entries.
+	v, ok := recv(t, ch, 50*time.Millisecond)
+	if !ok {
+		t.Fatalf("expected a buffered value, got timeout")
+	}
+	if v != 10 {
+		t.Fatalf("expected latest-wins buffer to hold 10, got %v", v)
+	}
+}
+
+func TestCancelClosesChannel(t *testing.T) {
+	c := New[int](10 * time.Millisecond)
+	ch, cancel := c.Subscribe()
+
+	cancel()
+
+	// Channel should close promptly.
+	select {
+	case _, ok := <-ch:
+		if ok {
+			t.Fatalf("expected closed channel, got value")
+		}
+	case <-time.After(50 * time.Millisecond):
+		t.Fatalf("cancel did not close the channel")
+	}
+}
+
+func TestCancelIsIdempotent(t *testing.T) {
+	c := New[int](10 * time.Millisecond)
+	_, cancel := c.Subscribe()
+	cancel()
+	cancel() // must not panic
+}
+
+func TestPushAfterCancelDoesNotPanic(t *testing.T) {
+	c := New[int](10 * time.Millisecond)
+	_, cancel := c.Subscribe()
+	cancel()
+	// Goroutine has exited; Push must not panic on a removed sub.
+	c.Push(1)
+	c.Push(2)
+}
+
+func TestMultipleSubscribersReceiveIndependently(t *testing.T) {
+	c := New[int](20 * time.Millisecond)
+	ch1, cancel1 := c.Subscribe()
+	defer cancel1()
+	ch2, cancel2 := c.Subscribe()
+	defer cancel2()
+
+	c.Push(42)
+
+	v1, ok1 := recv(t, ch1, 50*time.Millisecond)
+	v2, ok2 := recv(t, ch2, 50*time.Millisecond)
+	if !ok1 || !ok2 {
+		t.Fatalf("expected both subscribers to receive: ok1=%v ok2=%v", ok1, ok2)
+	}
+	if v1 != 42 || v2 != 42 {
+		t.Fatalf("expected both=42, got v1=%v v2=%v", v1, v2)
+	}
+}
+
+func TestSlowSubscriberDoesNotBlockFastOne(t *testing.T) {
+	c := New[int](10 * time.Millisecond)
+	slow, cancelSlow := c.Subscribe()
+	defer cancelSlow()
+	fast, cancelFast := c.Subscribe()
+	defer cancelFast()
+
+	// Don't read from slow. Fast should still get every coalesced emit.
+	_ = slow
+
+	for i := 1; i <= 5; i++ {
+		c.Push(i)
+		v, ok := recv(t, fast, 80*time.Millisecond)
+		if !ok {
+			t.Fatalf("push %d: fast subscriber timed out", i)
+		}
+		if v != i {
+			t.Fatalf("push %d: fast got %v, expected %v", i, v, i)
+		}
+	}
+}
+
+func TestZeroWindowEmitsEveryPushImmediately(t *testing.T) {
+	c := New[int](0)
+	ch, cancel := c.Subscribe()
+	defer cancel()
+
+	// With window=0 we want pass-through. Drain concurrently so the
+	// latest-wins buffer doesn't swallow values.
+	got := make([]int, 0, 5)
+	var mu sync.Mutex
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			v, ok := recv(t, ch, 100*time.Millisecond)
+			if !ok {
+				return
+			}
+			mu.Lock()
+			got = append(got, v)
+			mu.Unlock()
+		}
+	}()
+
+	for i := 1; i <= 5; i++ {
+		c.Push(i)
+		time.Sleep(20 * time.Millisecond) // give the receiver time to drain
+	}
+	cancel()
+	<-done
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(got) != 5 {
+		t.Fatalf("zero-window: expected 5 emits, got %d (%v)", len(got), got)
+	}
+	for i, v := range got {
+		if v != i+1 {
+			t.Fatalf("zero-window: emit %d = %v, want %v", i, v, i+1)
+		}
+	}
+}
+
+func TestNoPushNoEmit(t *testing.T) {
+	c := New[int](10 * time.Millisecond)
+	ch, cancel := c.Subscribe()
+	defer cancel()
+
+	// Without any Push, the channel must stay quiet.
+	expectNothing(t, ch, 50*time.Millisecond)
+}
+
+func TestPushAfterLongIdleEmitsImmediately(t *testing.T) {
+	c := New[int](20 * time.Millisecond)
+	ch, cancel := c.Subscribe()
+	defer cancel()
+
+	c.Push(1)
+	if v, ok := recv(t, ch, 30*time.Millisecond); !ok || v != 1 {
+		t.Fatalf("first push: got %v ok=%v", v, ok)
+	}
+
+	// Long quiet period.
+	time.Sleep(80 * time.Millisecond)
+
+	// Next push should be treated as idle → leading-edge, immediate.
+	start := time.Now()
+	c.Push(2)
+	v, ok := recv(t, ch, 15*time.Millisecond)
+	if !ok || v != 2 {
+		t.Fatalf("post-idle push: got %v ok=%v after %v", v, ok, time.Since(start))
+	}
+}

--- a/services/gmuxd/internal/peering/peer.go
+++ b/services/gmuxd/internal/peering/peer.go
@@ -128,6 +128,15 @@ func (p *Peer) ForwardLaunch(w http.ResponseWriter, r *http.Request) {
 	p.api.ForwardLaunch(w, r)
 }
 
+// ForwardPath proxies an arbitrary HTTP request to the spoke at the
+// given absolute path. Used by the generic peer proxy at
+// /v1/peers/{peer}/... so a hub can mutate state that lives on a
+// spoke (e.g., reorder a peer's projects.json) without the hub
+// having to mirror or re-implement that state locally (ADR 0002).
+func (p *Peer) ForwardPath(w http.ResponseWriter, r *http.Request, path string) {
+	p.api.ForwardPath(w, r, path)
+}
+
 // CachedHealth returns the spoke's cached health data. The second
 // return value is false if health has not been fetched yet.
 func (p *Peer) CachedHealth() (SpokeHealth, bool) {
@@ -268,7 +277,23 @@ func (p *Peer) subscribe(ctx context.Context, onConnected func()) error {
 	}
 }
 
-// sseEvent is the wire format for gmuxd SSE events.
+// sseActivity is the wire format for the bare session-activity event.
+type sseActivity struct {
+	Type string `json:"type"`
+	ID   string `json:"id"`
+}
+
+// sseSnapshotSessions is the wire format for snapshot.sessions.
+type sseSnapshotSessions struct {
+	Sessions []store.Session `json:"sessions"`
+}
+
+// sseEvent is the wire format for protocol-1 per-event SSE
+// (session-upsert / session-remove). Retained so a v2 hub can
+// consume sessions from a v1.x spoke that doesn't emit
+// snapshot.sessions. v2 spokes suppress these for `?as=peer`
+// subscribers, so this path only fires against v1 spokes in
+// steady state.
 type sseEvent struct {
 	Type    string           `json:"type"`
 	ID      string           `json:"id"`
@@ -288,7 +313,39 @@ func (p *Peer) isForwardedFromKnownOrigin(id string) bool {
 
 func (p *Peer) handleEvent(eventType string, data []byte) {
 	switch eventType {
+	case "snapshot.sessions":
+		// Authoritative replacement: the spoke's view of its owned
+		// sessions. We mirror it into the local store namespaced by
+		// peer name and remove any local entries for this peer that
+		// no longer appear (handles dismiss, kill, slug takeover that
+		// happened on the spoke).
+		var payload sseSnapshotSessions
+		if err := json.Unmarshal(data, &payload); err != nil {
+			log.Printf("peering: %s: bad snapshot.sessions: %v", p.Config.Name, err)
+			return
+		}
+		p.applySessionsSnapshot(payload.Sessions)
+
+	case "session-activity":
+		var ev sseActivity
+		if err := json.Unmarshal(data, &ev); err != nil {
+			return
+		}
+		if p.isForwardedFromKnownOrigin(ev.ID) {
+			return
+		}
+		namespacedID := NamespaceID(ev.ID, p.Config.Name)
+		p.store.Broadcast(store.Event{
+			Type: "session-activity",
+			ID:   namespacedID,
+		})
+
 	case "session-upsert":
+		// v1 compat: a v1.x spoke ships sessions one at a time via
+		// session-upsert. A v2 spoke that knows about `?as=peer`
+		// suppresses these in favour of snapshot.sessions. Applying
+		// both from a misconfigured v2 spoke is idempotent: the
+		// upsert produces the same store state the snapshot would.
 		var ev sseEvent
 		if err := json.Unmarshal(data, &ev); err != nil {
 			log.Printf("peering: %s: bad upsert event: %v", p.Config.Name, err)
@@ -305,20 +362,16 @@ func (p *Peer) handleEvent(eventType string, data []byte) {
 			log.Printf("peering: %s: bad session payload: %v", p.Config.Name, err)
 			return
 		}
-
-		// Transform for local store.
 		sess.ID = NamespaceID(ev.ID, p.Config.Name)
 		sess.Peer = p.Config.Name
 		sess.SocketPath = "" // meaningless on hub side
-
 		// UpsertRemote (not Upsert) because the spoke already resolved
-		// Title and Resumable. Upsert would re-run resolveTitle against
-		// the wire session where ShellTitle/AdapterTitle are absent
-		// (they're internal fields, intentionally off the wire) and
-		// overwrite the correct title with the Kind fallback.
+		// Title and Resumable; rerunning resolveTitle here would
+		// clobber the correct title with the Kind fallback.
 		p.store.UpsertRemote(sess)
 
 	case "session-remove":
+		// v1 compat: paired with session-upsert above.
 		var ev sseEvent
 		if err := json.Unmarshal(data, &ev); err != nil {
 			log.Printf("peering: %s: bad remove event: %v", p.Config.Name, err)
@@ -327,28 +380,56 @@ func (p *Peer) handleEvent(eventType string, data []byte) {
 		if p.isForwardedFromKnownOrigin(ev.ID) {
 			return
 		}
-		namespacedID := NamespaceID(ev.ID, p.Config.Name)
-		p.store.Remove(namespacedID)
+		p.store.Remove(NamespaceID(ev.ID, p.Config.Name))
 
-	case "session-activity":
-		var ev sseEvent
-		if err := json.Unmarshal(data, &ev); err != nil {
-			return
-		}
-		if p.isForwardedFromKnownOrigin(ev.ID) {
-			return
-		}
-		namespacedID := NamespaceID(ev.ID, p.Config.Name)
-		p.store.Broadcast(store.Event{
-			Type: "session-activity",
-			ID:   namespacedID,
-		})
-
-	case "projects-update":
-		// Ignore: hub has its own projects.
+	case "snapshot.world", "projects-update", "peer-status":
+		// Hub composes its own world view. v2 spokes don't emit
+		// snapshot.world to asPeer subscribers anyway; v1 spokes
+		// emit projects-update / peer-status which we don't care
+		// about (hub state is authoritative for those).
 
 	default:
 		// Unknown event types are silently ignored for forward compatibility.
+	}
+}
+
+// applySessionsSnapshot reconciles the local store's view of this
+// peer's sessions against the snapshot. Any session in the snapshot
+// is upserted (namespaced) into the store; any session whose Peer
+// matches this peer but whose ID is not present in the snapshot is
+// removed.
+func (p *Peer) applySessionsSnapshot(remote []store.Session) {
+	seen := make(map[string]bool, len(remote))
+	for i := range remote {
+		sess := remote[i]
+		if p.isForwardedFromKnownOrigin(sess.ID) {
+			// A→B→A loop: B is shipping us back a session whose
+			// origin we already reach directly. Skip.
+			continue
+		}
+		namespacedID := NamespaceID(sess.ID, p.Config.Name)
+		seen[namespacedID] = true
+		sess.ID = namespacedID
+		sess.Peer = p.Config.Name
+		sess.SocketPath = "" // meaningless on hub side
+		// UpsertRemote (not Upsert) because the spoke already resolved
+		// Title and Resumable. Upsert would re-run resolveTitle against
+		// the wire session where ShellTitle/AdapterTitle are absent
+		// (they're internal fields, intentionally off the wire) and
+		// overwrite the correct title with the Kind fallback.
+		p.store.UpsertRemote(sess)
+	}
+
+	// Removal pass: anything we still have for this peer that the
+	// snapshot omitted has either been dismissed, killed, or slug-
+	// renamed on the origin side.
+	for _, s := range p.store.List() {
+		if s.Peer != p.Config.Name {
+			continue
+		}
+		if !seen[s.ID] {
+			p.store.Remove(s.ID)
+		}
 	}
 }
 

--- a/services/gmuxd/internal/peering/peering_test.go
+++ b/services/gmuxd/internal/peering/peering_test.go
@@ -80,6 +80,27 @@ func (s *spoke) push(eventType string, payload any) {
 	s.mu.Unlock()
 }
 
+// pushSnapshot emits the current sk.sessions slice as a
+// snapshot.sessions SSE event. This is how the protocol-2 spoke
+// announces both initial state and any subsequent change — there
+// are no per-event session-upsert / session-remove frames.
+func (s *spoke) pushSnapshot() {
+	s.mu.Lock()
+	list := make([]store.Session, len(s.sessions))
+	copy(list, s.sessions)
+	s.mu.Unlock()
+	s.push("snapshot.sessions", map[string]any{"sessions": list})
+}
+
+// setSessions atomically replaces the spoke's sessions and emits
+// the resulting snapshot.
+func (s *spoke) setSessions(list []store.Session) {
+	s.mu.Lock()
+	s.sessions = list
+	s.mu.Unlock()
+	s.pushSnapshot()
+}
+
 // spokeServer creates a test HTTP server that behaves like a gmuxd spoke.
 // It serves GET /v1/events as an SSE stream and GET /v1/sessions.
 func spokeServer(t *testing.T, token string, sessions []store.Session) *spoke {
@@ -103,15 +124,13 @@ func spokeServer(t *testing.T, token string, sessions []store.Session) *spoke {
 			w.Header().Set("Cache-Control", "no-cache")
 			flusher := w.(http.Flusher)
 
-			// Send current sessions as initial upserts.
+			// Initial snapshot.sessions as the protocol-2 spoke does.
 			sk.mu.Lock()
-			for _, s := range sk.sessions {
-				s := s
-				ev := store.Event{Type: "session-upsert", ID: s.ID, Session: &s}
-				data, _ := json.Marshal(ev)
-				fmt.Fprintf(w, "event: session-upsert\ndata: %s\n\n", data)
-			}
+			initial := make([]store.Session, len(sk.sessions))
+			copy(initial, sk.sessions)
 			sk.mu.Unlock()
+			data, _ := json.Marshal(map[string]any{"sessions": initial})
+			fmt.Fprintf(w, "event: snapshot.sessions\ndata: %s\n\n", data)
 			flusher.Flush()
 
 			// Hold connection open and forward pushed events.
@@ -399,6 +418,76 @@ func TestPeerStatusEventBroadcast(t *testing.T) {
 	mgr.Stop()
 }
 
+// TestHandleEvent_V1CompatPerEvent exercises the protocol-1 fallback
+// path in handleEvent: a v1.x spoke (or any spoke not emitting
+// snapshot.sessions, e.g. an upgrade lag) pushes per-session
+// upsert/remove frames. The hub must mirror those into its local
+// store under namespaced ids, even with no snapshot.sessions ever
+// arriving. This is what keeps v2 hubs working against v1 spokes
+// during a staggered upgrade.
+func TestHandleEvent_V1CompatPerEvent(t *testing.T) {
+	st := store.New()
+	p := newPeer(config.PeerConfig{Name: "server"}, st, nil)
+
+	// session-upsert with a Session payload: hub mirrors it as
+	// "sess-1@server" with Peer set.
+	rawSession := json.RawMessage(`{"id":"sess-1","kind":"shell","alive":true,"slug":"fix-auth"}`)
+	upsert, _ := json.Marshal(map[string]any{
+		"type":    "session-upsert",
+		"id":      "sess-1",
+		"session": rawSession,
+	})
+	p.handleEvent("session-upsert", upsert)
+
+	sess, ok := st.Get("sess-1@server")
+	if !ok {
+		t.Fatal("v1 session-upsert did not produce a namespaced store entry")
+	}
+	if sess.Peer != "server" {
+		t.Errorf("sess.Peer = %q, want %q", sess.Peer, "server")
+	}
+	if sess.Slug != "fix-auth" {
+		t.Errorf("sess.Slug = %q, want %q", sess.Slug, "fix-auth")
+	}
+
+	// session-remove against the same namespaced id.
+	remove, _ := json.Marshal(map[string]any{
+		"type": "session-remove",
+		"id":   "sess-1",
+	})
+	p.handleEvent("session-remove", remove)
+
+	if _, ok := st.Get("sess-1@server"); ok {
+		t.Error("v1 session-remove did not clear the namespaced store entry")
+	}
+}
+
+// TestHandleEvent_V1CompatDropsForwardedFromKnownOrigin ensures the
+// per-event path applies the same loop-prevention filter the
+// snapshot path does: if peer A forwards us a session that
+// originated on B (and we already talk to B directly), we drop it
+// rather than mirror it under A's namespace.
+func TestHandleEvent_V1CompatDropsForwardedFromKnownOrigin(t *testing.T) {
+	st := store.New()
+	p := newPeer(config.PeerConfig{Name: "hub-a"}, st, nil)
+	p.isKnownOrigin = func(name string) bool { return name == "hub-b" }
+
+	// session arriving from hub-a but originally owned by hub-b
+	// (id is already namespaced "sess-1@hub-b"). We have a direct
+	// path to hub-b, so this would be a longer-path duplicate.
+	rawSession := json.RawMessage(`{"id":"sess-1@hub-b","kind":"shell","alive":true}`)
+	upsert, _ := json.Marshal(map[string]any{
+		"type":    "session-upsert",
+		"id":      "sess-1@hub-b",
+		"session": rawSession,
+	})
+	p.handleEvent("session-upsert", upsert)
+
+	if _, ok := st.Get("sess-1@hub-b@hub-a"); ok {
+		t.Error("forwarded-from-known-origin session should be dropped, not mirrored")
+	}
+}
+
 func TestPeerSubscribe_SessionRemoveEvent(t *testing.T) {
 	st := store.New()
 	initialSessions := []store.Session{
@@ -415,8 +504,10 @@ func TestPeerSubscribe_SessionRemoveEvent(t *testing.T) {
 	// Wait for initial sessions.
 	waitForSessions(t, st, "server", 2)
 
-	// Push a remove event for sess-1.
-	sk.push("session-remove", store.Event{Type: "session-remove", ID: "sess-1"})
+	// Drop sess-1 from the spoke's snapshot. The hub diffs and removes.
+	sk.setSessions([]store.Session{
+		{ID: "sess-2", Kind: "shell", Alive: true, Slug: "bash"},
+	})
 
 	// Wait for removal.
 	deadline := time.After(2 * time.Second)
@@ -491,10 +582,10 @@ func TestPeerSubscribe_NewSessionViaPush(t *testing.T) {
 
 	waitForSessions(t, st, "server", 1)
 
-	// Push a new session that wasn't in the initial set.
-	newSess := store.Session{ID: "sess-new", Kind: "shell", Alive: true, Slug: "new-one"}
-	sk.push("session-upsert", store.Event{
-		Type: "session-upsert", ID: "sess-new", Session: &newSess,
+	// Add a new session to the spoke and re-emit the snapshot.
+	sk.setSessions([]store.Session{
+		{ID: "sess-1", Kind: "pi", Alive: true, Slug: "initial"},
+		{ID: "sess-new", Kind: "shell", Alive: true, Slug: "new-one"},
 	})
 
 	waitForSessions(t, st, "server", 2)
@@ -511,6 +602,77 @@ func TestPeerSubscribe_NewSessionViaPush(t *testing.T) {
 	}
 
 	mgr.Stop()
+}
+
+func TestPeerSubscribe_ProjectStampsPropagateFromOrigin(t *testing.T) {
+	// The origin stamps ProjectSlug / ProjectIndex on owned sessions
+	// (ADR 0002). Those stamps must round-trip across the SSE wire so
+	// the receiving hub can render (peer, slug) folders without
+	// re-running match rules locally.
+	st := store.New()
+
+	originSess := store.Session{
+		ID:           "sess-1",
+		Kind:         "pi",
+		Alive:        true,
+		Slug:         "fix-auth",
+		ProjectSlug:  "gmux",
+		ProjectIndex: 3,
+	}
+	sk := spokeServer(t, "", []store.Session{originSess})
+
+	cfg := config.PeerConfig{Name: "server", URL: sk.URL, Token: ""}
+	mgr := NewManager([]config.PeerConfig{cfg}, st, "test-host")
+	mgr.Start()
+	defer mgr.Stop()
+
+	waitForSessions(t, st, "server", 1)
+
+	got, ok := st.Get("sess-1@server")
+	if !ok {
+		t.Fatal("expected sess-1@server in store")
+	}
+	if got.ProjectSlug != "gmux" {
+		t.Errorf("ProjectSlug = %q, want %q", got.ProjectSlug, "gmux")
+	}
+	if got.ProjectIndex != 3 {
+		t.Errorf("ProjectIndex = %d, want 3", got.ProjectIndex)
+	}
+}
+
+func TestPeerSubscribe_DisclaimedSessionRoundTripsAsZero(t *testing.T) {
+	// A disclaimed session (origin has no project for it) emits with
+	// no project_slug / project_index on the wire. The receiver
+	// decodes both as zero values, which the receiver-side projection
+	// treats as "fall through to local match rules".
+	st := store.New()
+
+	origin := store.Session{
+		ID:    "sess-1",
+		Kind:  "pi",
+		Alive: true,
+		Slug:  "loose",
+		// ProjectSlug == "", ProjectIndex == 0.
+	}
+	sk := spokeServer(t, "", []store.Session{origin})
+
+	cfg := config.PeerConfig{Name: "server", URL: sk.URL, Token: ""}
+	mgr := NewManager([]config.PeerConfig{cfg}, st, "test-host")
+	mgr.Start()
+	defer mgr.Stop()
+
+	waitForSessions(t, st, "server", 1)
+
+	got, ok := st.Get("sess-1@server")
+	if !ok {
+		t.Fatal("expected sess-1@server in store")
+	}
+	if got.ProjectSlug != "" {
+		t.Errorf("ProjectSlug = %q, want empty", got.ProjectSlug)
+	}
+	if got.ProjectIndex != 0 {
+		t.Errorf("ProjectIndex = %d, want 0", got.ProjectIndex)
+	}
 }
 
 // waitForSessions polls until the store has the expected number of sessions

--- a/services/gmuxd/internal/projects/manager.go
+++ b/services/gmuxd/internal/projects/manager.go
@@ -13,8 +13,12 @@ type Manager struct {
 	stateDir string
 
 	// Broadcast is called after every state mutation that should be
-	// synced to connected clients (via SSE). Set by the caller.
-	Broadcast func()
+	// synced to connected clients (via SSE). The caller receives the
+	// just-saved State so it can derive related state (e.g.,
+	// per-session project stamps via Reconcile) without re-Loading
+	// (which would deadlock against the lock Update is holding).
+	// Set by the caller; nil disables broadcast.
+	Broadcast func(state *State)
 }
 
 func NewManager(stateDir string) *Manager {
@@ -68,7 +72,7 @@ func (m *Manager) Update(fn func(s *State) bool) error {
 	}
 
 	if m.Broadcast != nil {
-		m.Broadcast()
+		m.Broadcast(state)
 	}
 	return nil
 }
@@ -78,7 +82,16 @@ func (m *Manager) Update(fn func(s *State) bool) error {
 // This is called when:
 //   - A new session is discovered (Register)
 //   - A session gets a Slug (file attribution)
+//
+// Peer-owned sessions (info.Host != "") are never written to the local
+// projects.json: project membership is owned by the session's origin
+// host (ADR 0002). The viewer learns peer-side project assignment via
+// the session's stamps (ProjectSlug / ProjectIndex), not by mirroring
+// peer state into local config.
 func (m *Manager) AutoAssignSession(info SessionInfo) string {
+	if info.Host != "" {
+		return ""
+	}
 	var assigned string
 	err := m.Update(func(state *State) bool {
 		key := SessionKey(info.ID, info.Slug)
@@ -130,11 +143,13 @@ func (m *Manager) AutoAssignSession(info SessionInfo) string {
 // matching projects in a single atomic update. Called after adding a
 // project so that existing alive sessions populate the array immediately
 // rather than waiting for the next session-upsert event.
+//
+// Peer-owned sessions are skipped; see AutoAssignSession.
 func (m *Manager) AutoAssignAllAlive(sessions []SessionInfo) {
 	err := m.Update(func(state *State) bool {
 		changed := false
 		for _, info := range sessions {
-			if !info.Alive {
+			if !info.Alive || info.Host != "" {
 				continue
 			}
 			key := SessionKey(info.ID, info.Slug)

--- a/services/gmuxd/internal/projects/projects.go
+++ b/services/gmuxd/internal/projects/projects.go
@@ -380,6 +380,39 @@ func (s *State) AddSession(slug, key string) bool {
 	return false
 }
 
+// ReorderSessions applies a partial-reorder to a project's sessions
+// list: the keys in `req` take their positions (relative to each
+// other) at the start; any existing keys not in `req` keep their
+// relative order at the tail.
+//
+// This lets a viewer reorder what it can see without enumerating
+// dead / hidden entries it doesn't track. Critical for peer reorders
+// via the /v1/peers/{peer}/... proxy: the viewer never sees the full
+// projects.json on the peer, so it can't reconstruct the hidden tail.
+//
+// Returns true if the project was found.
+func (s *State) ReorderSessions(slug string, req []string) bool {
+	for i := range s.Items {
+		if s.Items[i].Slug != slug {
+			continue
+		}
+		inReq := make(map[string]bool, len(req))
+		for _, k := range req {
+			inReq[k] = true
+		}
+		merged := make([]string, 0, len(req)+len(s.Items[i].Sessions))
+		merged = append(merged, req...)
+		for _, k := range s.Items[i].Sessions {
+			if !inReq[k] {
+				merged = append(merged, k)
+			}
+		}
+		s.Items[i].Sessions = merged
+		return true
+	}
+	return false
+}
+
 // RemoveSession removes a session key from a project's sessions list.
 // Returns true if the session was found and removed.
 func (s *State) RemoveSession(slug, key string) bool {
@@ -410,6 +443,38 @@ func (s *State) RemoveSessionFromAll(key string) string {
 		}
 	}
 	return ""
+}
+
+// Assignment is one project's claim on a session: the slug of the
+// owning project and the 0-based index in its Sessions[] array.
+// The zero value (Slug == "", Index == 0) means "no project claims
+// this session" and is what AssignmentsByKey returns by default for
+// keys not found in any project.
+type Assignment struct {
+	Slug  string
+	Index int
+}
+
+// AssignmentsByKey returns a flat map from session key to the
+// project Assignment claiming it. Pure derivation from State; the
+// caller is expected to use the result to stamp sessions (see
+// store.Store.Reconcile).
+//
+// First occurrence wins on duplicate keys: a key appearing in two
+// items would point at the first item's Assignment. This shouldn't
+// happen because dismiss/auto-assign keep entries unique, but the
+// behaviour is at least defined.
+func (s *State) AssignmentsByKey() map[string]Assignment {
+	out := make(map[string]Assignment)
+	for _, item := range s.Items {
+		for i, key := range item.Sessions {
+			if _, exists := out[key]; exists {
+				continue
+			}
+			out[key] = Assignment{Slug: item.Slug, Index: i}
+		}
+	}
+	return out
 }
 
 // FindSessionProject returns the slug of the project containing the given

--- a/services/gmuxd/internal/projects/projects_test.go
+++ b/services/gmuxd/internal/projects/projects_test.go
@@ -652,6 +652,74 @@ func TestRemoveSession(t *testing.T) {
 	}
 }
 
+func TestReorderSessions(t *testing.T) {
+	t.Run("reorder visible keys preserves hidden tail", func(t *testing.T) {
+		// `dead-1` and `dead-2` are dead/resumable entries that the
+		// viewer doesn't show in the sidebar. The viewer reorders
+		// what it sees (req = [c, a, b]) and trusts the daemon to
+		// keep the hidden tail.
+		s := State{Items: []Item{
+			{Slug: "gmux", Sessions: []string{"a", "b", "c", "dead-1", "dead-2"}},
+		}}
+		if !s.ReorderSessions("gmux", []string{"c", "a", "b"}) {
+			t.Fatal("expected ReorderSessions to return true")
+		}
+		want := []string{"c", "a", "b", "dead-1", "dead-2"}
+		if !equalStrings(s.Items[0].Sessions, want) {
+			t.Errorf("got %v, want %v", s.Items[0].Sessions, want)
+		}
+	})
+
+	t.Run("keys not in existing list are appended at request positions", func(t *testing.T) {
+		// New session `z` arrives in the request before the daemon
+		// has stamped it. ReorderSessions accepts it and inserts it
+		// at the requested position.
+		s := State{Items: []Item{
+			{Slug: "gmux", Sessions: []string{"a", "b"}},
+		}}
+		s.ReorderSessions("gmux", []string{"z", "a", "b"})
+		want := []string{"z", "a", "b"}
+		if !equalStrings(s.Items[0].Sessions, want) {
+			t.Errorf("got %v, want %v", s.Items[0].Sessions, want)
+		}
+	})
+
+	t.Run("empty request is a no-op order-wise", func(t *testing.T) {
+		s := State{Items: []Item{
+			{Slug: "gmux", Sessions: []string{"a", "b", "c"}},
+		}}
+		s.ReorderSessions("gmux", []string{})
+		want := []string{"a", "b", "c"}
+		if !equalStrings(s.Items[0].Sessions, want) {
+			t.Errorf("got %v, want %v", s.Items[0].Sessions, want)
+		}
+	})
+
+	t.Run("unknown slug returns false and changes nothing", func(t *testing.T) {
+		s := State{Items: []Item{
+			{Slug: "gmux", Sessions: []string{"a"}},
+		}}
+		if s.ReorderSessions("unknown", []string{"a"}) {
+			t.Error("expected false for unknown slug")
+		}
+		if !equalStrings(s.Items[0].Sessions, []string{"a"}) {
+			t.Errorf("existing project mutated: %v", s.Items[0].Sessions)
+		}
+	})
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
 func TestRemoveSessionFromAll(t *testing.T) {
 	s := State{Items: []Item{
 		{Slug: "gmux", Match: []MatchRule{{Path: "/dev/gmux"}}, Sessions: []string{"a"}},
@@ -902,7 +970,7 @@ func TestManagerBroadcastCalled(t *testing.T) {
 	dir := t.TempDir()
 	mgr := NewManager(dir)
 	called := 0
-	mgr.Broadcast = func() { called++ }
+	mgr.Broadcast = func(*State) { called++ }
 
 	mgr.Update(func(s *State) bool {
 		s.Items = []Item{{Slug: "test", Match: []MatchRule{{Path: "/test"}}}}
@@ -948,7 +1016,7 @@ func TestManagerCleanupSessionsNoOrphans(t *testing.T) {
 	dir := t.TempDir()
 	mgr := NewManager(dir)
 	broadcastCalled := false
-	mgr.Broadcast = func() { broadcastCalled = true }
+	mgr.Broadcast = func(*State) { broadcastCalled = true }
 
 	mgr.Update(func(s *State) bool {
 		s.Items = []Item{
@@ -994,6 +1062,59 @@ func TestManagerAutoAssignAllAlive(t *testing.T) {
 	}
 	if len(state.Items[1].Sessions) != 1 || state.Items[1].Sessions[0] != "s2" {
 		t.Errorf("yapp sessions: expected [s2], got %v", state.Items[1].Sessions)
+	}
+}
+
+// Peer-owned sessions must never enter the local projects.json:
+// project membership is owned by the session's origin host (ADR 0002).
+func TestManagerAutoAssignSkipsPeerOwnedSession(t *testing.T) {
+	dir := t.TempDir()
+	mgr := NewManager(dir)
+
+	mgr.Update(func(s *State) bool {
+		s.Items = []Item{
+			{Slug: "gmux", Match: []MatchRule{{Path: "/dev/gmux"}}},
+		}
+		return true
+	})
+
+	// A session from a peer that *would* match the local rule by cwd:
+	// must be ignored. The peer owns the membership; we trust the
+	// stamp arriving over the wire instead.
+	assigned := mgr.AutoAssignSession(SessionInfo{
+		ID: "sess-tower-1", Cwd: "/dev/gmux", Host: "tower", Alive: true,
+	})
+	if assigned != "" {
+		t.Errorf("expected no assignment for peer session, got %q", assigned)
+	}
+
+	state, _ := mgr.Load()
+	if len(state.Items[0].Sessions) != 0 {
+		t.Errorf("local projects.json should remain empty, got %v", state.Items[0].Sessions)
+	}
+}
+
+func TestManagerAutoAssignAllAliveSkipsPeerOwnedSessions(t *testing.T) {
+	dir := t.TempDir()
+	mgr := NewManager(dir)
+
+	mgr.Update(func(s *State) bool {
+		s.Items = []Item{
+			{Slug: "gmux", Match: []MatchRule{{Path: "/dev/gmux"}}},
+		}
+		return true
+	})
+
+	sessions := []SessionInfo{
+		{ID: "local-1", Cwd: "/dev/gmux", Alive: true},
+		{ID: "peer-1", Cwd: "/dev/gmux", Host: "tower", Alive: true},
+		{ID: "peer-2", Cwd: "/dev/gmux", Host: "laptop", Alive: true},
+	}
+	mgr.AutoAssignAllAlive(sessions)
+
+	state, _ := mgr.Load()
+	if len(state.Items[0].Sessions) != 1 || state.Items[0].Sessions[0] != "local-1" {
+		t.Errorf("expected only local-1 assigned, got %v", state.Items[0].Sessions)
 	}
 }
 
@@ -1150,5 +1271,50 @@ func TestManagerSeedIfEmptySkipsWhenProjectsExist(t *testing.T) {
 	state, _ := mgr.Load()
 	if len(state.Items) != 1 || state.Items[0].Slug != "existing" {
 		t.Errorf("expected existing project unchanged, got %+v", state.Items)
+	}
+}
+
+// --- AssignmentsByKey (per ADR 0002) ---
+
+func TestAssignmentsByKey_FlattensProjectArrays(t *testing.T) {
+	state := &State{Items: []Item{
+		{Slug: "gmux", Sessions: []string{"a", "b", "c"}},
+		{Slug: "yapp", Sessions: []string{"d"}},
+	}}
+
+	got := state.AssignmentsByKey()
+	want := map[string]Assignment{
+		"a": {Slug: "gmux", Index: 0},
+		"b": {Slug: "gmux", Index: 1},
+		"c": {Slug: "gmux", Index: 2},
+		"d": {Slug: "yapp", Index: 0},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d entries, want %d (got=%v)", len(got), len(want), got)
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("key %q: got %+v, want %+v", k, got[k], v)
+		}
+	}
+}
+
+func TestAssignmentsByKey_EmptyForNoProjects(t *testing.T) {
+	state := &State{}
+	if got := state.AssignmentsByKey(); len(got) != 0 {
+		t.Errorf("expected empty map, got %v", got)
+	}
+}
+
+func TestAssignmentsByKey_FirstOccurrenceWinsOnDuplicate(t *testing.T) {
+	// Defensive contract: duplicate keys shouldn't happen but the
+	// behaviour is defined.
+	state := &State{Items: []Item{
+		{Slug: "first", Sessions: []string{"shared"}},
+		{Slug: "second", Sessions: []string{"shared"}},
+	}}
+	got := state.AssignmentsByKey()
+	if got["shared"].Slug != "first" {
+		t.Errorf("expected first occurrence to win, got %+v", got["shared"])
 	}
 }

--- a/services/gmuxd/internal/snapshot/snapshot.go
+++ b/services/gmuxd/internal/snapshot/snapshot.go
@@ -1,0 +1,72 @@
+// Package snapshot composes the wire payloads for the protocol-2
+// SSE stream defined by ADR 0001.
+//
+// The protocol has two snapshot kinds plus one bare event:
+//
+//   - snapshot.sessions  full list of owned sessions (replaces the
+//                        per-event session-upsert / session-remove
+//                        stream of protocol 1).
+//   - snapshot.world     bundle of projects, peers, health, launchers
+//                        (replaces projects-update / peer-status).
+//                        Not sent to peer consumers.
+//   - session-activity   bare {id} ping; lossy, not coalesced.
+//
+// Snapshots are composed lazily at emit time by a per-kind coalescer
+// (see internal/coalesce); this package only knows how to assemble
+// the payload from already-fetched inputs. Callers (the SSE handler
+// in main.go) decide what to read from where and pass it in.
+//
+// This split keeps composition free of locks and HTTP plumbing, so
+// the wire shape can be exercised in isolation.
+package snapshot
+
+import "github.com/gmuxapp/gmux/services/gmuxd/internal/store"
+
+// SessionsPayload is the body of a snapshot.sessions SSE event.
+//
+// Sessions is a value-typed slice (not pointers) so the wire shape
+// is stable regardless of how the caller reads them out of the store.
+type SessionsPayload struct {
+	Sessions []store.Session `json:"sessions"`
+}
+
+// WorldPayload is the body of a snapshot.world SSE event. It bundles
+// every piece of cross-session state the frontend needs into one
+// atomic emission, so the client can replace its `_rawWorld` signal
+// in a single batch (no transient inconsistency between projects and
+// peer status).
+//
+// The fields are typed `any` because their concrete types live in
+// packages this one shouldn't depend on (projects.Item,
+// peering.PeerInfo, peering.LauncherDef, the /v1/health map). The
+// caller marshals them through; SSE clients see normal JSON.
+//
+// Health carries the same shape as GET /v1/health response data:
+// hostname, tailscale, version, peers (offline-merged), session
+// counts, runner_hash, etc. We re-emit it on each snapshot rather
+// than splitting it across fields because it is intentionally an
+// opaque diagnostic blob.
+type WorldPayload struct {
+	Projects        any `json:"projects"`
+	Peers           any `json:"peers"`
+	Health          any `json:"health"`
+	Launchers       any `json:"launchers"`
+	DefaultLauncher any `json:"default_launcher"`
+}
+
+// ComposeSessions builds a snapshot.sessions payload from the live
+// store, keeping only sessions for which `owned` returns true.
+//
+// `owned` mirrors the per-subscriber filter the SSE handler applies
+// for `?as=peer` consumers (own + Local-peer only). For browser
+// consumers it should accept everything.
+func ComposeSessions(all []store.Session, owned func(*store.Session) bool) SessionsPayload {
+	out := make([]store.Session, 0, len(all))
+	for i := range all {
+		s := all[i]
+		if owned == nil || owned(&s) {
+			out = append(out, s)
+		}
+	}
+	return SessionsPayload{Sessions: out}
+}

--- a/services/gmuxd/internal/snapshot/snapshot_test.go
+++ b/services/gmuxd/internal/snapshot/snapshot_test.go
@@ -1,0 +1,94 @@
+package snapshot
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/store"
+)
+
+func TestComposeSessions_NoFilterIncludesAll(t *testing.T) {
+	in := []store.Session{
+		{ID: "a", Peer: ""},
+		{ID: "b", Peer: "tower"},
+		{ID: "c", Peer: "laptop"},
+	}
+	got := ComposeSessions(in, nil)
+	if len(got.Sessions) != 3 {
+		t.Fatalf("len = %d, want 3 (no filter), got %+v", len(got.Sessions), got.Sessions)
+	}
+}
+
+func TestComposeSessions_FilterDropsUnowned(t *testing.T) {
+	in := []store.Session{
+		{ID: "local-1", Peer: ""},
+		{ID: "tower-1", Peer: "tower"},
+		{ID: "laptop-1", Peer: "laptop"},
+	}
+	// Owned = local + tower; laptop is a network peer being filtered out.
+	owned := func(s *store.Session) bool {
+		return s.Peer == "" || s.Peer == "tower"
+	}
+	got := ComposeSessions(in, owned)
+	ids := make([]string, len(got.Sessions))
+	for i, s := range got.Sessions {
+		ids[i] = s.ID
+	}
+	want := map[string]bool{"local-1": true, "tower-1": true}
+	if len(ids) != len(want) {
+		t.Fatalf("ids = %v, want %v", ids, want)
+	}
+	for _, id := range ids {
+		if !want[id] {
+			t.Errorf("unexpected id %q in payload", id)
+		}
+	}
+}
+
+func TestComposeSessions_EmptyInputProducesEmptySlice(t *testing.T) {
+	got := ComposeSessions(nil, nil)
+	if got.Sessions == nil {
+		t.Fatal("Sessions slice should be non-nil for stable JSON")
+	}
+	if len(got.Sessions) != 0 {
+		t.Errorf("len = %d, want 0", len(got.Sessions))
+	}
+	// Marshals to [] not null, so the frontend can blindly Array.from it.
+	b, _ := json.Marshal(got)
+	if string(b) != `{"sessions":[]}` {
+		t.Errorf("json = %s, want {\"sessions\":[]}", b)
+	}
+}
+
+func TestComposeSessions_PreservesInputOrder(t *testing.T) {
+	// Order is part of the protocol: clients can stable-sort or
+	// rely on origin order without a tiebreaker.
+	in := []store.Session{{ID: "z"}, {ID: "a"}, {ID: "m"}}
+	got := ComposeSessions(in, nil)
+	if got.Sessions[0].ID != "z" || got.Sessions[1].ID != "a" || got.Sessions[2].ID != "m" {
+		t.Errorf("order changed: %+v", got.Sessions)
+	}
+}
+
+func TestWorldPayload_MarshalsAllFields(t *testing.T) {
+	p := WorldPayload{
+		Projects:        []map[string]any{{"slug": "gmux"}},
+		Peers:           []map[string]any{{"name": "tower", "status": "connected"}},
+		Health:          map[string]any{"hostname": "node-a"},
+		Launchers:       []map[string]any{{"id": "shell"}},
+		DefaultLauncher: "shell",
+	}
+	b, err := json.Marshal(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatal(err)
+	}
+	for _, k := range []string{"projects", "peers", "health", "launchers", "default_launcher"} {
+		if _, ok := got[k]; !ok {
+			t.Errorf("missing key %q in %s", k, b)
+		}
+	}
+}

--- a/services/gmuxd/internal/store/store.go
+++ b/services/gmuxd/internal/store/store.go
@@ -61,6 +61,27 @@ type Session struct {
 	// on every Upsert/Update.
 	ShellTitle   string `json:"shell_title,omitempty"`
 	AdapterTitle string `json:"adapter_title,omitempty"`
+
+	// Project assignment stamps populated by the project Reconcile
+	// step on the origin host. ProjectSlug is the slug of the project
+	// whose Sessions[] array currently contains this session's key;
+	// ProjectIndex is the 0-based position. Empty slug means the
+	// origin disclaims the session, leaving viewers free to fall
+	// through to their own match rules. See ADR 0002.
+	//
+	// These ride the wire so peers (and the browser) can render
+	// (peer, slug) folders without re-running match rules locally.
+	// Both use omitempty: ProjectSlug is meaningful only when set;
+	// ProjectIndex defaults to 0 on decode, which is also a valid
+	// first-position stamp, so the omit is safe round-trip.
+	//
+	// They are also persisted by sessionmeta (which uses default
+	// reflection marshaling). That's a benign redundancy: the
+	// startup flow always runs Reconcile after loading projects.json
+	// and before any SSE subscriber attaches, so persisted stamps
+	// can never be observed stale.
+	ProjectSlug  string `json:"project_slug,omitempty"`
+	ProjectIndex int    `json:"project_index,omitempty"`
 }
 
 // MarshalJSON serializes a Session for the frontend API, excluding internal
@@ -91,6 +112,8 @@ func (s Session) MarshalJSON() ([]byte, error) {
 		Slug          string            `json:"slug,omitempty"`
 		RunnerVersion string            `json:"runner_version,omitempty"`
 		BinaryHash    string            `json:"binary_hash,omitempty"`
+		ProjectSlug   string            `json:"project_slug,omitempty"`
+		ProjectIndex  int               `json:"project_index,omitempty"`
 	}
 	return json.Marshal(wire{
 		ID: s.ID, Peer: s.Peer, CreatedAt: s.CreatedAt, Command: s.Command,
@@ -102,6 +125,7 @@ func (s Session) MarshalJSON() ([]byte, error) {
 		SocketPath: s.SocketPath, TerminalCols: s.TerminalCols,
 		TerminalRows: s.TerminalRows, Slug: s.Slug,
 		RunnerVersion: s.RunnerVersion, BinaryHash: s.BinaryHash,
+		ProjectSlug: s.ProjectSlug, ProjectIndex: s.ProjectIndex,
 	})
 }
 
@@ -360,6 +384,36 @@ func (s *Store) Remove(id string) bool {
 		})
 	}
 	return ok
+}
+
+// Reconcile re-derives ProjectSlug and ProjectIndex for every
+// origin-owned session (Peer == "") by calling assignFn for each.
+// assignFn is expected to return ("", 0) for sessions that no
+// project currently claims.
+//
+// In-memory mutation only: no events are broadcast. Subscribers
+// observe the new stamps the next time the session is re-emitted
+// (e.g. via Upsert). Once the snapshot protocol composer lands
+// (commit 10), Reconcile folds into snapshot composition rather
+// than mutating sessions in place.
+//
+// Peer-owned sessions are skipped; their stamps are authoritative
+// from the origin and arrive over the wire.
+func (s *Store) Reconcile(assignFn func(Session) (slug string, index int)) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for id, sess := range s.sessions {
+		if sess.Peer != "" {
+			continue
+		}
+		slug, index := assignFn(sess)
+		if sess.ProjectSlug == slug && sess.ProjectIndex == index {
+			continue
+		}
+		sess.ProjectSlug = slug
+		sess.ProjectIndex = index
+		s.sessions[id] = sess
+	}
 }
 
 // RemoveByPeer removes all sessions belonging to a peer and broadcasts

--- a/services/gmuxd/internal/store/store_test.go
+++ b/services/gmuxd/internal/store/store_test.go
@@ -820,3 +820,180 @@ func TestSessionMarshalJSON_WireFormat(t *testing.T) {
 		t.Error("stale was removed; must not appear in wire JSON")
 	}
 }
+
+// --- Reconcile (project ownership stamping per ADR 0002) ---
+
+func TestReconcile_StampsOwnedSessions(t *testing.T) {
+	s := New()
+	s.Upsert(Session{ID: "a", Slug: "alpha", Kind: "k", Alive: true})
+	s.Upsert(Session{ID: "b", Slug: "beta", Kind: "k", Alive: true})
+
+	s.Reconcile(func(sess Session) (string, int) {
+		switch sess.Slug {
+		case "alpha":
+			return "gmux", 0
+		case "beta":
+			return "gmux", 1
+		}
+		return "", 0
+	})
+
+	got, _ := s.Get("a")
+	if got.ProjectSlug != "gmux" || got.ProjectIndex != 0 {
+		t.Errorf("a: got slug=%q index=%d, want gmux/0", got.ProjectSlug, got.ProjectIndex)
+	}
+	got, _ = s.Get("b")
+	if got.ProjectSlug != "gmux" || got.ProjectIndex != 1 {
+		t.Errorf("b: got slug=%q index=%d, want gmux/1", got.ProjectSlug, got.ProjectIndex)
+	}
+}
+
+func TestReconcile_SkipsPeerOwnedSessions(t *testing.T) {
+	s := New()
+	s.UpsertRemote(Session{ID: "p1", Slug: "peer-sess", Kind: "k", Peer: "tower", Alive: true, ProjectSlug: "from-origin", ProjectIndex: 3})
+
+	s.Reconcile(func(sess Session) (string, int) {
+		// Would erroneously overwrite if Reconcile didn't skip peer sessions.
+		return "wrong", 99
+	})
+
+	got, _ := s.Get("p1")
+	if got.ProjectSlug != "from-origin" || got.ProjectIndex != 3 {
+		t.Errorf("peer session stamps overwritten: got slug=%q index=%d, want from-origin/3", got.ProjectSlug, got.ProjectIndex)
+	}
+}
+
+func TestReconcile_DoesNotBroadcast(t *testing.T) {
+	// Reconcile is intentionally silent until the snapshot protocol
+	// commit makes the stamps wire-visible. Verify the contract.
+	s := New()
+	ch, cancel := s.Subscribe()
+	defer cancel()
+	s.Upsert(Session{ID: "a", Slug: "alpha", Kind: "k", Alive: true})
+	// Drain the upsert event from setup.
+	<-ch
+
+	done := make(chan struct{})
+	go func() {
+		s.Reconcile(func(sess Session) (string, int) {
+			return "gmux", 0
+		})
+		close(done)
+	}()
+	<-done
+
+	select {
+	case ev := <-ch:
+		t.Fatalf("Reconcile broadcast unexpectedly: %+v", ev)
+	default:
+	}
+}
+
+func TestReconcile_NoOpWhenStampsUnchanged(t *testing.T) {
+	s := New()
+	s.Upsert(Session{ID: "a", Slug: "alpha", Kind: "k", Alive: true})
+
+	calls := 0
+	assignFn := func(sess Session) (string, int) {
+		calls++
+		return "", 0
+	}
+	s.Reconcile(assignFn)
+	first := calls
+	s.Reconcile(assignFn)
+	if calls-first != 1 {
+		t.Errorf("expected one assignFn call on second Reconcile, got %d", calls-first)
+	}
+
+	got, _ := s.Get("a")
+	if got.ProjectSlug != "" || got.ProjectIndex != 0 {
+		t.Errorf("disclaimed stamps drifted: slug=%q index=%d", got.ProjectSlug, got.ProjectIndex)
+	}
+}
+
+func TestSession_MarshalEmitsProjectStamps(t *testing.T) {
+	sess := Session{
+		ID:           "a",
+		Kind:         "k",
+		Alive:        true,
+		ProjectSlug:  "gmux",
+		ProjectIndex: 4,
+	}
+	b, err := json.Marshal(sess)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got, _ := m["project_slug"].(string); got != "gmux" {
+		t.Errorf("project_slug on wire: got %v, want %q", m["project_slug"], "gmux")
+	}
+	// Numbers decode as float64 in untyped maps.
+	if got, _ := m["project_index"].(float64); got != 4 {
+		t.Errorf("project_index on wire: got %v, want 4", m["project_index"])
+	}
+}
+
+func TestSession_MarshalOmitsDisclaimedStamps(t *testing.T) {
+	// A disclaimed session (no project match) leaves slug="" and
+	// index=0. Both fields use omitempty so neither appears on the
+	// wire; viewers fall through to their own match rules.
+	sess := Session{ID: "a", Kind: "k", Alive: true}
+	b, err := json.Marshal(sess)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, ok := m["project_slug"]; ok {
+		t.Error("project_slug should be omitted when empty")
+	}
+	if _, ok := m["project_index"]; ok {
+		t.Error("project_index should be omitted when zero alongside empty slug")
+	}
+}
+
+func TestSession_WireRoundTripPreservesStamps(t *testing.T) {
+	// What an origin emits, a peer mirror unmarshals back into a
+	// store.Session. The stamps must round-trip so the receiver can
+	// render (peer, slug) folders without re-deriving project
+	// membership.
+	cases := []struct {
+		name  string
+		slug  string
+		index int
+	}{
+		{"first-in-array", "gmux", 0},
+		{"middle", "gmux", 2},
+		{"disclaimed", "", 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			orig := Session{
+				ID:           "a",
+				Kind:         "k",
+				Alive:        true,
+				ProjectSlug:  tc.slug,
+				ProjectIndex: tc.index,
+			}
+			b, err := json.Marshal(orig)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			var got Session
+			if err := json.Unmarshal(b, &got); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if got.ProjectSlug != tc.slug {
+				t.Errorf("slug round-trip: got %q want %q", got.ProjectSlug, tc.slug)
+			}
+			if got.ProjectIndex != tc.index {
+				t.Errorf("index round-trip: got %d want %d", got.ProjectIndex, tc.index)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Five commits, rebase-merged: two ADRs, one squashed implementation
commit, and two follow-up bug fixes from post-rebase audit.

Adds protocol 2 (snapshot push) and per-host project ownership to
gmuxd, **keeping the v1 wire surface alongside as deprecated**.
v1.x browsers, v1.x hubs, and scripts hitting the bulk GET
endpoints continue to work against a v2 daemon; a v2 hub continues
to consume sessions from a v1.x spoke through a staggered upgrade.
Releases as a normal `feat` (minor bump); not a breaking change.

> **Note on commit shape.** The branch originally landed as 17 atomic
> commits and was rebase-tracking `main` over several weeks. After
> `main` absorbed two parallel features (the live↔dead view ADRs that
> reshape `sidebar.tsx` / `project-hub.tsx` to remove `onResume`, and
> the new `rehydrateProjects` startup path), every commit on this
> branch became conflicted because the same regions were edited from
> both sides at every step. Resolving in place would have produced
> half-broken intermediate commits with embedded conflict markers.
> Squashed to a single `feat` instead, with the user-facing story
> unchanged. The two ADRs are kept as separate commits because the
> spec is worth preserving as a self-contained reading.

## What changes for users

- **Multi-host project ownership.** Each host owns its own
  `projects.json`. Sessions arriving from a peer are stamped with the
  peer's project assignment and rendered under that peer's folder, in
  the order the peer arranged it. Disclaimed sessions fall through to
  the viewer's match rules. Drag-reorder on a peer-owned folder
  routes through `/v1/peers/{peer}/...` so the peer applies the
  change to its own `projects.json` and re-broadcasts the result.
- **`@<peer>` in URLs.** Peer-owned project hubs are
  `/@<peer>/<slug>`; adopted-from-peer sessions inside local folders
  keep an `@<host>` mid-path segment. Local sessions on local folders
  have no `@` segment.
- **"Unavailable" indicator.** Sessions whose peer is disconnected,
  reconnecting, or unknown render dimmed with a muted X icon (sidebar
  and project-hub).
- **Snapshot-push protocol.** SSE gains `snapshot.sessions` /
  `snapshot.world` events; the v2 web UI hydrates from those rather
  than polling `/v1/sessions`, `/v1/projects`, `/v1/health` on load
  or reconnect. Reconnect is a single round-trip.

## Backwards compatibility

Per ADR 0001's "Backwards compatibility" section:

- **Wire**: `session-upsert`, `session-remove`, `projects-update`,
  `peer-status` continue to be emitted to non-asPeer subscribers
  (v1 browsers, v1 hubs that don't send `?as=peer`). v2 consumers
  attach listeners only for the new snapshot events and ignore the
  per-event chatter. The v2 hub's `handleEvent` decodes both
  per-event and snapshot frames idempotently, so it works against
  v1 and v2 spokes.
- **HTTP**: `GET /v1/projects` is restored; `GET /v1/sessions` and
  `GET /v1/health` were never removed. All three are documented as
  deprecated in v2: no new fields, but will not be removed in a
  minor release.
- **Asymmetric semantics for `?as=peer` subscribers**: v2 hubs
  using `?as=peer` get `snapshot.sessions` (+ filtered activity)
  only; the v1 per-event stream is suppressed for them to avoid
  double-processing alongside the snapshot.

Additive-only frontend changes:

- New session fields `project_slug` / `project_index`. Old clients
  ignore unknown fields.
- New URL path shape `/@<peer>/<slug>/...` and adopted-peer
  `@<host>` segments. Reachable only when v2 web is served.

## Commits

| # | Type | Subject |
|---|------|---------|
| 1 | docs(adr) | capture snapshot push protocol decision |
| 2 | docs(adr) | capture project ownership from session origin decision |
| 3 | feat | snapshot push protocol and cross-host project ownership |
| 4 | fix(web) | route navigateToSession through viewToPath for peer-owned URLs |
| 5 | fix(web) | strip peer namespace and drop adopted-peer keys on folder reorder |

The squashed commit walks through the implementation in the same
logical chunks the original 17 commits used:

- Snapshot push protocol (ADR 0001): pump routing, lazy compose,
  health factoring, asPeer activity gating, peering reconciliation,
  protocol-1 dispatch coexistence, frontend consumer.
- Cross-host project ownership (ADR 0002): origin-stamped
  ProjectSlug / ProjectIndex, Reconcile pivot, peer-write proxy
  with allowlist, partial-reorder PATCH, frontend folder identity
  refactor.
- Unavailable indicator: pure helper + dim/muted-X UX.
- Frontend signal layout: `_rawSessions` + `_rawWorld` +
  `_pendingMutations` overlay.

## Post-rebase audit & follow-up fixes

**Commit 4 — peer-owned `navigateToSession`.** The helper was
building URLs via `matchSession` + `sessionPath`, ignoring peer
ownership. For a peer-owned session it would either short-circuit
(no local match rule) or omit the `/@<peer>` prefix. Routed both
that helper and the in-place slug-rename URL update through
`viewToPath`, which already understands ADR-0002 ownership.

**Commit 5 — namespace-stripping on folder reorder.** Greptile's
review caught that `s.slug || s.id` for a slugless peer-owned
session evaluates to the hub-namespaced id (`"orig@peer"`), which
the peer's `ReorderSessions` treats as a brand-new key and prepends
to its `projects.json`. Same shape of bug locally for adopted-peer
rows. Extracted `reorderKeysForFolder(sessions, folder.peer)` as a
pure helper that filters to owner-owned sessions and strips the
`@<peer>` chain from slugless ids.

## Verification

- `pnpm --filter @gmux/web test` — 384 tests passing
- `cd services/gmuxd && go test -race ./...` — green except for one
  pre-existing data race in `internal/notify` (unrelated to this
  branch; reproduces on `main`, surfaces only under `-race`)
- `pnpm --filter @gmux/web exec tsc --noEmit` — clean
- `pnpm install --frozen-lockfile` — clean

## Notable correctness fixes folded into commit 3

- **Activity for peer-owned sessions silently dropped.** Browser
  subscribers were running the same activity filter as `?as=peer`
  consumers, which discards namespaced ids. Without the fix, the UI
  never animates activity dots on peer-owned sessions in v2.
  `shouldForwardActivity(asPeer, id, isLocalPeer)` gates on
  `asPeer`.

- **Browser `snapshot.sessions` excluded peer-mirrored sessions.**
  `composeSessions` unconditionally applied the `isOwned` filter,
  so the v2 browser would never see peer-owned sessions and the
  ADR-0002 peer folders wouldn't render. Now `asPeer` keeps the
  filter; browser passes `nil` (full store).

- **Stale `ProjectIndex` after every `projects.json` edit.**
  `projects.Manager.Broadcast` runs `Reconcile` to re-stamp every
  owned session's `ProjectSlug` / `ProjectIndex`, then fires
  `projects-update`. Routing that to the world coalescer alone left
  `snapshot.sessions` un-emitted, so the UI kept rendering each
  session under its previous project. `snapshotPumpRoute(eventType)`
  returns `(pushSessions, pushWorld)`; `projects-update` fires both.

- **Rehydrated sessions un-stamped on first snapshot.**
  `reconcileProjectStamps(state)` now runs immediately after
  `rehydrateProjects(...)` on startup so the first SSE subscriber
  sees stamps without needing a separate projects-update.

## Release prose

`RELEASE_HIGHLIGHTS.md` no longer exists on `main` (release prose
is now driven from the `release/next` PR body between
`<!-- prose-start -->` / `<!-- prose-end -->` markers). Prose for
this release will go onto that PR when it opens.