### PR TITLE
fix(web): preload terminal font before mounting xterm

### DIFF
--- a/apps/gmux-web/src/settings-schema.ts
+++ b/apps/gmux-web/src/settings-schema.ts
@@ -10,7 +10,7 @@
  * validation happens here in the frontend.
  */
 import * as v from 'valibot'
-import type { ITerminalOptions, ITheme } from '@xterm/xterm'
+import type { ITheme } from '@xterm/xterm'
 
 // ── Helpers ──
 
@@ -209,6 +209,14 @@ export const SettingsSchema = v.pipe(
 export type SettingsConfig = v.InferInput<typeof SettingsSchema>
 export type ResolvedSettings = v.InferOutput<typeof SettingsSchema>
 
+/** xterm options after our schema has filled in defaults. Strictly
+ *  narrower than xterm's `ITerminalOptions` (which marks every field
+ *  optional), so consumers can rely on `fontFamily`, `fontSize`, etc.
+ *  being defined. */
+export type ResolvedTerminalOptions =
+  & Omit<ResolvedSettings, 'keybinds' | 'macCommandIsCtrl'>
+  & { theme: ITheme }
+
 // ── Default theme colors ──
 
 export const DEFAULT_THEME_COLORS: ITheme = {
@@ -274,7 +282,7 @@ function warnUnknownKeys(raw: Record<string, unknown>): void {
 export function buildTerminalOptions(
   rawSettings: SettingsConfig | null | undefined,
   rawTheme: ThemeColors | null | undefined,
-): ITerminalOptions {
+): ResolvedTerminalOptions {
   // Warn about unknown keys before parsing (parse strips them).
   if (rawSettings && typeof rawSettings === 'object') {
     warnUnknownKeys(rawSettings as Record<string, unknown>)

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -21,7 +21,7 @@ import { buildProjectFolders, matchSession } from './projects'
 
 import { fetchFrontendConfig, buildTerminalOptions, resolveKeybinds, type ResolvedKeybind } from './config'
 import { MOCK_SESSIONS, MOCK_PROJECTS } from './mock-data/index'
-import type { ITerminalOptions } from '@xterm/xterm'
+import type { ResolvedTerminalOptions } from './settings-schema'
 import type { Session as ProtocolSession } from '@gmux/protocol'
 
 // ── Raw state (sources of truth) ────────────────────────────────────────────
@@ -103,7 +103,7 @@ export const peerAppearance = computed<ReadonlyMap<string, PeerAppearance>>(() =
   return map
 })
 
-export const terminalOptions = signal<ITerminalOptions | null>(null)
+export const terminalOptions = signal<ResolvedTerminalOptions | null>(null)
 export const keybinds = signal<ResolvedKeybind[] | null>(null)
 export const macCommandIsCtrl = signal(false)
 

--- a/apps/gmux-web/src/terminal.tsx
+++ b/apps/gmux-web/src/terminal.tsx
@@ -4,7 +4,7 @@ import { FitAddon } from '@xterm/addon-fit'
 import { ImageAddon } from '@xterm/addon-image'
 import { WebLinksAddon } from '@xterm/addon-web-links'
 import { WebglAddon } from '@xterm/addon-webgl'
-import type { ITerminalOptions } from '@xterm/xterm'
+import type { ResolvedTerminalOptions } from './settings-schema'
 import { attachKeyboardHandler, attachPasteHandler, ctrlSequenceFor, defaultPasteFeedback, handlePasteAction } from './keyboard'
 import { DEFAULT_THEME_COLORS, type ResolvedKeybind } from './config'
 import { attachMobileInputHandler } from './mobile-input'
@@ -194,7 +194,7 @@ export function TerminalView({
   onFocusReady,
 }: {
   session: Session
-  terminalOptions: ITerminalOptions
+  terminalOptions: ResolvedTerminalOptions
   keybinds: ResolvedKeybind[]
   macCommandIsCtrl: boolean
   ctrlArmed: boolean
@@ -217,6 +217,10 @@ export function TerminalView({
   const altArmedRef = useRef(altArmed)
   const termIoRef = useRef<ReturnType<typeof createTerminalIO> | null>(null)
   const termEpochRef = useRef(0)
+
+  // True once the terminal's font is downloaded; gates xterm mount.
+  // See the preload effect below for why this matters.
+  const [fontReady, setFontReady] = useState(false)
 
   const [termLoading, setTermLoading] = useState(true)
   const [wsState, setWsState] = useState<'connecting' | 'open' | 'lost'>('connecting')
@@ -371,9 +375,38 @@ export function TerminalView({
     focusTerminal()
   }, [focusTerminal])
 
+  // Force-fetch the terminal font before mounting xterm.
+  //
+  // xterm picks its cell metrics from the first measurement it takes
+  // inside term.open(). If the woff2 hasn't downloaded yet, that
+  // measurement uses fallback monospace metrics (cell ≈ 18 px). xterm
+  // re-measures internally when the real font arrives a few ms later
+  // (cell ≈ 17 px) and the rendered grid shrinks, but the row count we
+  // derived from the original measurement doesn't get recomputed,
+  // leaving an extra row's worth of unused space at the bottom of the
+  // viewport.
+  //
+  // document.fonts.ready isn't enough: @fontsource only registers the
+  // @font-face declarations, so nothing is in flight at mount and ready
+  // resolves immediately. document.fonts.load(spec) actually triggers
+  // the fetch and resolves once the bytes are in.
+  //
+  // .finally rather than .then so a fetch failure (offline, flaky network,
+  // CSP) still unblocks the gate. xterm falls back to monospace metrics in
+  // that case, which is much better UX than a terminal stuck on the
+  // loading overlay forever.
+  useEffect(() => {
+    let cancelled = false
+    const spec = `${terminalOptions.fontSize}px ${terminalOptions.fontFamily}`
+    document.fonts.load(spec).finally(() => {
+      if (!cancelled) setFontReady(true)
+    })
+    return () => { cancelled = true }
+  }, [terminalOptions.fontFamily, terminalOptions.fontSize])
+
   // Terminal + keyboard setup (stable across session changes).
   useEffect(() => {
-    if (!containerRef.current || USE_MOCK) return
+    if (!containerRef.current || USE_MOCK || !fontReady) return
     disposed.current = false
 
     // Add non-serializable options that can't live in JSON config.
@@ -724,7 +757,7 @@ export function TerminalView({
       termRef.current = null
       termIoRef.current = null
     }
-  }, [onCtrlConsumed, onInputReady])
+  }, [onCtrlConsumed, onInputReady, fontReady])
 
   // WebSocket connection (reconnects when session.id changes).
   useEffect(() => {
@@ -888,7 +921,7 @@ export function TerminalView({
       wsRef.current?.close()
       wsRef.current = null
     }
-  }, [fitAndResize, queueData, queueMany, queueResize, releaseResizeEchoGate, resetResizeEchoGate, session.id])
+  }, [fitAndResize, queueData, queueMany, queueResize, releaseResizeEchoGate, resetResizeEchoGate, session.id, fontReady])
 
   // Pill is purely derived from size mismatch. No "driving" flag: we claim
   // on every fresh session select (first ws.onopen), and fitAndResize sets


### PR DESCRIPTION
On first load the terminal often ends up shorter than the available area, leaving a gap at the bottom on desktop or pushing content below the fold on mobile. The gap is one mobile-bar's worth of pixels (~52 px), which made it look like a layout problem. It isn't.

## Cause

xterm sizes its row count from the first cell measurement (`measureTerminalFit` divides shell height by `term.dimensions.css.cell.height`). That measurement runs as soon as `term.open(container)` is called, which happens before the terminal's font has finished downloading: `@fontsource/fira-code` only registers the `@font-face` declaration eagerly, the actual woff2 isn't fetched until something uses the family. xterm renders, browser starts the fetch, 30-100 ms later the font arrives, xterm internally re-measures (cell height drops 18 to 17 px) and the rendered xterm shrinks. Nothing else triggers our resize pipeline (shell height didn't change), so the row count stays at the fallback-font value and we end up with a row's worth of unused space at the bottom.

Captured in chrome-devtools against the running gmuxd:

```
t=132 rows=41 cellH=18 xtermH=744
t=172 fonts loadingdone -> cellH=17 xtermH=703   (xterm re-measured, fit didn't)
```

## Why `document.fonts.ready` isn't enough

The first thing I tried was awaiting `document.fonts.ready` before opening xterm. Doesn't work: `ready` resolves when the *currently loading* set is empty. At mount, no fonts are in-flight (only declared), so `ready` resolves immediately. The fetch only starts when xterm renders, after our await has unblocked.

## Fix

Use `document.fonts.load(<spec>)` instead. That API explicitly forces the font to download and resolves with the loaded `FontFace[]`. Gate xterm mount on it via a tiny `fontReady` state:

```ts
const [fontReady, setFontReady] = useState(false)

useEffect(() => {
  const spec = `${terminalOptions.fontSize}px ${terminalOptions.fontFamily}`
  document.fonts.load(spec).then(() => setFontReady(true))
}, [terminalOptions.fontFamily, terminalOptions.fontSize])

useEffect(() => {
  if (!fontReady) return
  // ... create Terminal, term.open(...), etc.
}, [..., fontReady])
```

After: xterm's first cell measurement uses the real font metrics, no second-frame resize, no flicker.

```
t=216 terminal mounts  rows=44 cellH=17 xtermH=754   (correct from first frame)
```

The preload runs in parallel with everything else (data fetch, store hydration, WebSocket connect), so the visible delay is negligible: typically already covered by the existing `terminal-loading` overlay.

## Drive-by: tighter `terminalOptions` type

xterm's `ITerminalOptions` marks every field optional, but our schema fills in defaults for `fontSize`/`fontFamily`/etc. Added a `ResolvedTerminalOptions` type (`Omit<ResolvedSettings, 'keybinds' | 'macCommandIsCtrl'> & { theme }`) so consumers don't need defensive `?? '...'` fallbacks at every call site. The store signal and `<TerminalView>` prop both use the narrower type.