### PR TITLE
feat: persist session scrollback for dead-session replay

### DIFF
--- a/cli/gmux/cmd/gmux/run.go
+++ b/cli/gmux/cmd/gmux/run.go
@@ -20,6 +20,8 @@ import (
 	"github.com/gmuxapp/gmux/cli/gmux/internal/session"
 	"github.com/gmuxapp/gmux/packages/adapter"
 	"github.com/gmuxapp/gmux/packages/adapter/adapters"
+	"github.com/gmuxapp/gmux/packages/paths"
+	"github.com/gmuxapp/gmux/packages/scrollback"
 	"github.com/gmuxapp/gmux/packages/workspace"
 )
 
@@ -122,6 +124,16 @@ func runSession(args []string, attach bool) {
 
 	interactive := localterm.IsInteractive()
 
+	// Open the persistent scrollback sink for this runner. Best-
+	// effort: a failure to open (disk full, permission denied)
+	// just leaves the sink off, the runner serves live data
+	// normally, and dead-session replay won't have anything to
+	// show. The active file lives at
+	// $XDG_STATE_HOME/gmux/sessions/<id>/scrollback, in the same
+	// per-session directory gmuxd's sessionmeta package writes
+	// meta.json into.
+	scrollbackPath := filepath.Join(paths.SessionDir(sessionID), scrollback.ActiveName)
+
 	// Determine initial PTY size — use terminal size if interactive
 	ptyCfg := ptyserver.Config{
 		Command:    args,
@@ -131,6 +143,15 @@ func runSession(args []string, attach bool) {
 		Adapter:    a,
 		State:      state,
 		Version:    version,
+	}
+	// Conditional assignment: a typed nil *scrollback.Writer
+	// stored in ptyCfg.Scrollback (an io.WriteCloser) would
+	// satisfy != nil checks downstream and panic on the first
+	// Write. Only assign on successful Open.
+	if sw, err := scrollback.Open(scrollbackPath); err != nil {
+		log.Printf("scrollback: %v (continuing without persistence)", err)
+	} else {
+		ptyCfg.Scrollback = sw
 	}
 	// Always try to inherit terminal dimensions from the parent.
 	// Even non-interactive launches (background, piped) benefit from

--- a/cli/gmux/internal/ptyserver/ptyserver.go
+++ b/cli/gmux/internal/ptyserver/ptyserver.go
@@ -110,12 +110,13 @@ type Server struct {
 
 	mu             sync.Mutex
 	clients        map[*wsClient]struct{}
-	localOut       io.Writer // optional local terminal output sink
-	ptyCols        uint16    // last applied PTY cols (guarded by mu)
-	ptyRows        uint16    // last applied PTY rows (guarded by mu)
-	cursorHidden   bool      // tracks DECTCEM via callback (guarded by mu)
-	screenPending  []byte    // raw PTY data not yet fed to screen (guarded by mu)
-	lastClientLeft time.Time // when the last WS client disconnected (guarded by mu)
+	localOut       io.Writer       // optional local terminal output sink
+	scrollback     io.WriteCloser  // optional persistent scrollback sink (closed in waitChild)
+	ptyCols        uint16          // last applied PTY cols (guarded by mu)
+	ptyRows        uint16          // last applied PTY rows (guarded by mu)
+	cursorHidden   bool            // tracks DECTCEM via callback (guarded by mu)
+	screenPending  []byte          // raw PTY data not yet fed to screen (guarded by mu)
+	lastClientLeft time.Time       // when the last WS client disconnected (guarded by mu)
 
 	done    chan struct{} // closed when child exits
 	ptyDone chan struct{} // closed when readPTY finishes draining
@@ -155,6 +156,13 @@ type Config struct {
 	// to guarantee that fast-exiting commands can't race the wiring and
 	// have their output dropped on the floor.
 	LocalOut io.Writer
+	// Scrollback, if non-nil, receives a copy of every PTY output
+	// chunk for persistence to disk. Wired the same way as LocalOut
+	// so fast-exiting commands can't lose output. The server takes
+	// ownership: Close is called once after the final PTY drain in
+	// waitChild, so callers must not Close it themselves and must
+	// not pass a writer they need to keep using.
+	Scrollback io.WriteCloser
 }
 
 // New creates and starts a PTY server.
@@ -205,7 +213,8 @@ func New(cfg Config) (*Server, error) {
 		adapter:    cfg.Adapter,
 		state:      cfg.State,
 		clients:    make(map[*wsClient]struct{}),
-		localOut:   cfg.LocalOut, // wired before readPTY starts so early output is never lost
+		localOut:   cfg.LocalOut,   // wired before readPTY starts so early output is never lost
+		scrollback: cfg.Scrollback, // same: wired pre-readPTY so fast-exit output is never lost
 		ptyCols:    cfg.Cols,
 		ptyRows:    cfg.Rows,
 		done:       make(chan struct{}),
@@ -899,6 +908,11 @@ func (s *Server) readPTY() {
 		if localOut != nil {
 			localOut.Write(data)
 		}
+		if s.scrollback != nil {
+			// Best-effort: scrollback Write contract is no-error,
+			// IO failures are sticky and surfaced via Close.
+			s.scrollback.Write(data)
+		}
 
 		for _, c := range clients {
 			if err := c.write(websocket.MessageBinary, data); err != nil {
@@ -972,6 +986,17 @@ func (s *Server) waitChild() {
 	// still hold the child's final output when we close the WebSocket,
 	// causing data loss.
 	<-s.ptyDone
+
+	// Now that the final flush has run, close the persistent
+	// scrollback sink. Any IO error from the lifetime of the
+	// writer surfaces here — we log but don't fail, since the
+	// child has already exited and the scrollback is best-effort.
+	if s.scrollback != nil {
+		if err := s.scrollback.Close(); err != nil {
+			log.Printf("ptyserver: scrollback close: %v", err)
+		}
+		s.scrollback = nil
+	}
 
 	s.mu.Lock()
 	for c := range s.clients {

--- a/cli/gmux/internal/ptyserver/ptyserver_test.go
+++ b/cli/gmux/internal/ptyserver/ptyserver_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gmuxapp/gmux/packages/scrollback"
 	"nhooyr.io/websocket"
 )
 
@@ -339,6 +340,85 @@ func TestInputEndpointEmpty(t *testing.T) {
 	resp.Body.Close()
 	if resp.StatusCode != http.StatusNoContent {
 		t.Errorf("status = %d, want 204", resp.StatusCode)
+	}
+}
+
+// TestPTYServerScrollbackPersistence verifies the runner-side
+// half of the dead-session replay contract: PTY output is teed to
+// the configured Scrollback sink, and the sink is closed AFTER the
+// final PTY drain so fast-exiting commands' last bytes land on
+// disk. A regression in either flush() or waitChild's close
+// ordering surfaces here as missing bytes in the file.
+func TestPTYServerScrollbackPersistence(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "test.sock")
+	scrollbackPath := filepath.Join(t.TempDir(), "persist", scrollback.ActiveName)
+
+	sink, err := scrollback.Open(scrollbackPath)
+	if err != nil {
+		t.Fatalf("scrollback.Open: %v", err)
+	}
+
+	srv, err := New(Config{
+		Command:    []string{"bash", "-c", "echo SCROLLBACK-MARKER-XYZ"},
+		Cwd:        "/tmp",
+		SocketPath: sockPath,
+		Scrollback: sink,
+	})
+	if err != nil {
+		t.Fatalf("new server: %v", err)
+	}
+	defer srv.Shutdown()
+
+	// Wait for child exit and the post-drain close to run.
+	select {
+	case <-srv.Done():
+	case <-time.After(3 * time.Second):
+		t.Fatal("child did not exit in time")
+	}
+	select {
+	case <-srv.PTYDone():
+	case <-time.After(time.Second):
+		t.Fatal("PTY did not drain in time")
+	}
+	// PTYDone closing implies waitChild has progressed past
+	// <-s.ptyDone, which is where the scrollback Close runs. Give
+	// it a moment to land before reading.
+	time.Sleep(50 * time.Millisecond)
+
+	data, err := os.ReadFile(scrollbackPath)
+	if err != nil {
+		t.Fatalf("read scrollback: %v", err)
+	}
+	if !bytes.Contains(data, []byte("SCROLLBACK-MARKER-XYZ")) {
+		t.Errorf("scrollback missing child output.\ngot: %q", data)
+	}
+}
+
+// TestPTYServerScrollbackNotConfigured verifies the runner serves
+// live data normally when no scrollback sink is configured. This
+// is the fallback path when scrollback.Open fails (disk full,
+// permission denied) and run.go leaves Config.Scrollback unset.
+func TestPTYServerScrollbackNotConfigured(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "test.sock")
+
+	srv, err := New(Config{
+		Command:    []string{"bash", "-c", "echo no-scrollback-here"},
+		Cwd:        "/tmp",
+		SocketPath: sockPath,
+		// Scrollback intentionally nil.
+	})
+	if err != nil {
+		t.Fatalf("new server: %v", err)
+	}
+	defer srv.Shutdown()
+
+	select {
+	case <-srv.Done():
+	case <-time.After(3 * time.Second):
+		t.Fatal("child did not exit in time")
+	}
+	if srv.ExitCode() != 0 {
+		t.Errorf("unexpected exit code %d", srv.ExitCode())
 	}
 }
 

--- a/go.work
+++ b/go.work
@@ -4,6 +4,7 @@ use (
 	./cli/gmux
 	./packages/adapter
 	./packages/paths
+	./packages/scrollback
 	./packages/workspace
 	./services/gmuxd
 	./tests/e2e

--- a/packages/paths/paths.go
+++ b/packages/paths/paths.go
@@ -21,6 +21,23 @@ func StateDir() string {
 	return filepath.Join(home, ".local", "state", "gmux")
 }
 
+// SessionsDir returns the directory under StateDir that holds
+// per-session subdirectories (meta.json, scrollback). Both the
+// runner (writing scrollback) and gmuxd (writing meta.json,
+// reading scrollback) derive their target paths from this so the
+// on-disk contract has a single source of truth.
+func SessionsDir() string {
+	return filepath.Join(StateDir(), "sessions")
+}
+
+// SessionDir returns the per-session subdirectory for id under
+// SessionsDir. The directory holds meta.json (written by gmuxd's
+// sessionmeta package) and scrollback / scrollback.0 (written by
+// the runner's scrollback package).
+func SessionDir(id string) string {
+	return filepath.Join(SessionsDir(), id)
+}
+
 // NormalizePath expands a stored path to its absolute form for use in
 // filesystem operations. Expands ~ prefix to $HOME and calls filepath.Clean.
 func NormalizePath(p string) string {

--- a/packages/scrollback/go.mod
+++ b/packages/scrollback/go.mod
@@ -1,0 +1,3 @@
+module github.com/gmuxapp/gmux/packages/scrollback
+
+go 1.26.1

--- a/packages/scrollback/scrollback.go
+++ b/packages/scrollback/scrollback.go
@@ -1,0 +1,222 @@
+// Package scrollback persists a session's raw PTY output stream so a
+// dead session can still serve its terminal history.
+//
+// File layout under the per-session state dir
+// ($XDG_STATE_HOME/gmux/sessions/<id>/):
+//
+//	scrollback     append-only active file, capped at MaxBytes
+//	scrollback.0   previous active file (rotated; overwritten on each rotation)
+//
+// When a Write would push the active file past MaxBytes, the active
+// file is renamed onto scrollback.0 (atomically, on the same fs) and
+// a fresh active file is opened. Total on-disk usage per session is
+// therefore bounded at 2 * MaxBytes.
+//
+// Format: raw PTY bytes, exactly as the child process emitted them.
+// No framing, no encoding. xterm.js consumes them by feeding chunks
+// straight to Terminal.write().
+//
+// This package is the single source of truth for the on-disk
+// contract: the runner imports the Writer half, gmuxd imports the
+// Reader half.
+package scrollback
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+const (
+	// ActiveName is the basename of the active scrollback file, the
+	// one currently being appended to.
+	ActiveName = "scrollback"
+
+	// PreviousName is the basename of the rotated previous file. It
+	// is overwritten on each rotation; only the most recent rotation
+	// is preserved.
+	PreviousName = "scrollback.0"
+
+	// MaxBytes is the soft cap at which the active file is rotated.
+	// 1 MiB comfortably exceeds xterm's default 5000-line buffer
+	// (~400 KiB at 80 cols) so Resume sessions get a full replay,
+	// while keeping per-session disk usage bounded at 2 MiB.
+	MaxBytes int64 = 1 << 20
+
+	// dirMode and fileMode mirror sessionmeta's modes so the
+	// per-session directory stays owner-only.
+	dirMode  = 0o700
+	fileMode = 0o600
+)
+
+// Writer appends raw PTY bytes to the active scrollback file with
+// size-based rotation. Safe for concurrent calls; rotation is atomic
+// (rename(2)) and never loses data already written to the rotated
+// file.
+//
+// IO failures are sticky: once any write or rotation errors out, the
+// Writer enters a failed state and subsequent Writes are silently
+// dropped (returning len(p), nil so callers don't have to special-case
+// scrollback failures in their hot path). The first error is
+// preserved and surfaced by Close.
+type Writer struct {
+	mu      sync.Mutex
+	path    string
+	max     int64
+	f       *os.File
+	written int64
+	failErr error
+	closed  bool
+}
+
+// Open creates or opens the active scrollback file at path. The
+// parent directory is created with mode 0o700 if missing.
+//
+// An existing active file is truncated: scrollback's unit is the
+// runner, not the session. A resumed session is a fresh runner
+// with empty in-memory vt state, so its persisted scrollback
+// starts fresh too. The persisted history of the previous
+// (dead) runner is therefore overwritten on resume; users who
+// want to keep that history should peek before resuming.
+func Open(path string) (*Writer, error) {
+	if err := os.MkdirAll(filepath.Dir(path), dirMode); err != nil {
+		return nil, fmt.Errorf("scrollback: mkdir %s: %w", filepath.Dir(path), err)
+	}
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, fileMode)
+	if err != nil {
+		return nil, fmt.Errorf("scrollback: open %s: %w", path, err)
+	}
+	return &Writer{path: path, max: MaxBytes, f: f}, nil
+}
+
+// Write appends p to the active file, rotating first if the write
+// would exceed the cap. Returns len(p), nil even on IO failure: the
+// scrollback is best-effort, and callers in the PTY hot path
+// shouldn't have to handle disk-full as a fatal condition. Use
+// Close's return value to detect persisted IO errors.
+func (w *Writer) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.closed || w.failErr != nil || len(p) == 0 {
+		return len(p), nil
+	}
+
+	if w.written+int64(len(p)) > w.max {
+		if err := w.rotateLocked(); err != nil {
+			w.failErr = err
+			return len(p), nil
+		}
+	}
+
+	n, err := w.f.Write(p)
+	w.written += int64(n)
+	if err != nil {
+		w.failErr = fmt.Errorf("scrollback: write: %w", err)
+	}
+	return len(p), nil
+}
+
+// rotateLocked closes the active file, renames it onto PreviousName
+// (atomic on the same filesystem), and opens a fresh active file.
+// Caller holds w.mu.
+func (w *Writer) rotateLocked() error {
+	if err := w.f.Close(); err != nil {
+		return fmt.Errorf("scrollback: close before rotate: %w", err)
+	}
+	prev := filepath.Join(filepath.Dir(w.path), PreviousName)
+	if err := os.Rename(w.path, prev); err != nil {
+		return fmt.Errorf("scrollback: rotate %s -> %s: %w", w.path, prev, err)
+	}
+	f, err := os.OpenFile(w.path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, fileMode)
+	if err != nil {
+		return fmt.Errorf("scrollback: reopen %s: %w", w.path, err)
+	}
+	w.f = f
+	w.written = 0
+	return nil
+}
+
+// Close flushes and closes the active file. Idempotent. Returns the
+// first IO error observed across all writes/rotations, or nil if
+// every operation succeeded.
+func (w *Writer) Close() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.closed {
+		return w.failErr
+	}
+	w.closed = true
+	if err := w.f.Close(); err != nil && w.failErr == nil {
+		w.failErr = fmt.Errorf("scrollback: close: %w", err)
+	}
+	w.f = nil
+	return w.failErr
+}
+
+// OpenReader returns an io.ReadCloser over the persisted scrollback
+// for the session whose per-session dir is dir. The reader emits the
+// previous file (if it exists) followed by the active file (if it
+// exists) so bytes appear in chronological order.
+//
+// Returns os.ErrNotExist when neither file is present.
+//
+// Concurrency caveat: a Writer rotating between this function's
+// open(prev) and open(active) syscalls can leave the reader with a
+// stale prev fd plus a fresh-empty active fd, missing the chunk
+// that just rotated into the new prev. The race window is small
+// (one rename(2) call) and the loss is bounded at MaxBytes.
+// Scrollback is best-effort by design; callers that need exact
+// snapshots should coordinate with the writer out-of-band.
+func OpenReader(dir string) (io.ReadCloser, error) {
+	prev := filepath.Join(dir, PreviousName)
+	active := filepath.Join(dir, ActiveName)
+
+	var files []*os.File
+	for _, p := range []string{prev, active} {
+		f, err := os.Open(p)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			// Close anything already opened before bailing.
+			for _, opened := range files {
+				_ = opened.Close()
+			}
+			return nil, fmt.Errorf("scrollback: open %s: %w", p, err)
+		}
+		files = append(files, f)
+	}
+	if len(files) == 0 {
+		return nil, os.ErrNotExist
+	}
+
+	readers := make([]io.Reader, len(files))
+	closers := make([]io.Closer, len(files))
+	for i, f := range files {
+		readers[i] = f
+		closers[i] = f
+	}
+	return &multiReadCloser{r: io.MultiReader(readers...), closers: closers}, nil
+}
+
+type multiReadCloser struct {
+	r       io.Reader
+	closers []io.Closer
+}
+
+func (m *multiReadCloser) Read(p []byte) (int, error) { return m.r.Read(p) }
+
+func (m *multiReadCloser) Close() error {
+	var first error
+	for _, c := range m.closers {
+		if err := c.Close(); err != nil && first == nil {
+			first = err
+		}
+	}
+	return first
+}

--- a/packages/scrollback/scrollback_test.go
+++ b/packages/scrollback/scrollback_test.go
@@ -1,0 +1,407 @@
+package scrollback
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func writerForTest(t *testing.T) (*Writer, string) {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "deeper", ActiveName)
+	w, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = w.Close() })
+	return w, path
+}
+
+// readBack returns the bytes a fresh Reader over the given dir
+// would emit. Test helper.
+func readBack(t *testing.T, dir string) []byte {
+	t.Helper()
+	r, err := OpenReader(dir)
+	if err != nil {
+		t.Fatalf("OpenReader: %v", err)
+	}
+	defer r.Close()
+	b, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	return b
+}
+
+// TestWriteRoundTrip is the central correctness claim of the
+// package: bytes Written are returned by a Reader in the same
+// order. Pin everything else against this.
+func TestWriteRoundTrip(t *testing.T) {
+	w, path := writerForTest(t)
+
+	chunks := [][]byte{
+		[]byte("hello "),
+		[]byte("world\n"),
+		[]byte("\x1b[31mred\x1b[0m\n"),
+	}
+	var want []byte
+	for _, c := range chunks {
+		if _, err := w.Write(c); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+		want = append(want, c...)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	got := readBack(t, filepath.Dir(path))
+	if !bytes.Equal(got, want) {
+		t.Fatalf("round-trip mismatch.\nwant: %q\ngot:  %q", want, got)
+	}
+}
+
+// TestRotationAtCap verifies the contract that a Write crossing the
+// cap rotates first: the previous file holds everything written
+// before the rotation, the active file holds the post-rotation
+// chunk. Reader concatenation produces the full byte stream.
+func TestRotationAtCap(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ActiveName)
+	w, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	w.max = 100 // shrink for tests; production uses MaxBytes
+
+	pre := bytes.Repeat([]byte("A"), 90)
+	post := bytes.Repeat([]byte("B"), 30) // pre+post=120 > 100, triggers rotation
+
+	if _, err := w.Write(pre); err != nil {
+		t.Fatalf("Write pre: %v", err)
+	}
+	if _, err := w.Write(post); err != nil {
+		t.Fatalf("Write post: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	prevBytes, err := os.ReadFile(filepath.Join(dir, PreviousName))
+	if err != nil {
+		t.Fatalf("read previous: %v", err)
+	}
+	if !bytes.Equal(prevBytes, pre) {
+		t.Errorf("previous file: want %q, got %q", pre, prevBytes)
+	}
+	activeBytes, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read active: %v", err)
+	}
+	if !bytes.Equal(activeBytes, post) {
+		t.Errorf("active file: want %q, got %q", post, activeBytes)
+	}
+
+	if got := readBack(t, dir); !bytes.Equal(got, append(pre, post...)) {
+		t.Errorf("reader concatenation: want %q, got %q", append(pre, post...), got)
+	}
+}
+
+// TestMultipleRotationsKeepOnlyLastTwoSlices is the bound on disk
+// usage: across many rotations, only the most recent rotated
+// previous + active are kept. Older slices are dropped. Without
+// this, a long-running session would accumulate unbounded history.
+func TestMultipleRotationsKeepOnlyLastTwoSlices(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ActiveName)
+	w, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	w.max = 50
+
+	// Write enough to trigger 3 rotations: A's, then B's, then C's,
+	// then D's. After this, prev should hold C's, active should
+	// hold D's. A and B should be lost.
+	slices := [][]byte{
+		bytes.Repeat([]byte("A"), 40),
+		bytes.Repeat([]byte("B"), 40), // rotates, prev=A
+		bytes.Repeat([]byte("C"), 40), // rotates, prev=B (overwrites A)
+		bytes.Repeat([]byte("D"), 40), // rotates, prev=C (overwrites B)
+	}
+	for _, s := range slices {
+		if _, err := w.Write(s); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	got := readBack(t, dir)
+	want := append(slices[2], slices[3]...) // C + D
+	if !bytes.Equal(got, want) {
+		t.Errorf("after 3 rotations: want %q, got %q", want, got)
+	}
+}
+
+// TestWriteAfterCloseIsNoOp documents that Close is the terminal
+// state; further Writes don't error (matches the best-effort
+// contract from the hot path) but they also don't reopen the file.
+func TestWriteAfterCloseIsNoOp(t *testing.T) {
+	w, path := writerForTest(t)
+	if _, err := w.Write([]byte("before")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	n, err := w.Write([]byte("after"))
+	if err != nil {
+		t.Errorf("Write after Close: want nil err, got %v", err)
+	}
+	if n != len("after") {
+		t.Errorf("Write after Close: want n=%d (best-effort), got %d", len("after"), n)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(got) != "before" {
+		t.Errorf("file should hold pre-close bytes only: got %q", got)
+	}
+}
+
+// TestCloseIdempotent: gmuxd, run.go, and ptyserver could each call
+// Close on shutdown paths. Idempotence is the contract.
+func TestCloseIdempotent(t *testing.T) {
+	w, _ := writerForTest(t)
+	if err := w.Close(); err != nil {
+		t.Fatalf("first Close: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Errorf("second Close: want nil, got %v", err)
+	}
+}
+
+// TestOpenTruncatesExisting locks down the truncate-on-Open
+// contract. A re-opened active file starts fresh; the previous
+// runner's tail is overwritten. This is the design choice that
+// keeps "scrollback is per-runner" honest.
+func TestOpenTruncatesExisting(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ActiveName)
+	if err := os.WriteFile(path, []byte("stale data from previous runner"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	w, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if _, err := w.Write([]byte("fresh")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(got) != "fresh" {
+		t.Errorf("active should hold only post-Open bytes: got %q", got)
+	}
+}
+
+// TestOpenCreatesParentDir verifies the runner doesn't have to
+// create the per-session dir before opening the writer.
+// sessionmeta might create it later via Write; the writer is the
+// first to need it.
+func TestOpenCreatesParentDir(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "a", "b", "c")
+	path := filepath.Join(dir, ActiveName)
+	w, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer w.Close()
+
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("Stat parent: %v", err)
+	}
+	if mode := info.Mode().Perm(); mode != dirMode {
+		t.Errorf("parent dir mode: want %o, got %o", dirMode, mode)
+	}
+}
+
+// TestFileMode verifies the file ends up owner-only on disk. We
+// persist raw terminal output that may include sensitive command
+// substitutions, paths, prompts containing API keys, etc.
+func TestFileMode(t *testing.T) {
+	w, path := writerForTest(t)
+	if _, err := w.Write([]byte("x")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if mode := info.Mode().Perm(); mode != fileMode {
+		t.Errorf("file mode: want %o, got %o", fileMode, mode)
+	}
+}
+
+// TestWriteIsConcurrencySafe drives parallel writes through the
+// Writer to assert the mutex actually serializes them. Failure mode
+// without the mutex: torn writes interleave bytes from different
+// goroutines, byte counts diverge from input.
+func TestWriteIsConcurrencySafe(t *testing.T) {
+	w, _ := writerForTest(t)
+
+	const goroutines = 8
+	const writesPerGoroutine = 50
+	const chunkLen = 64
+
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		marker := byte('A' + g)
+		go func() {
+			defer wg.Done()
+			chunk := bytes.Repeat([]byte{marker}, chunkLen)
+			for i := 0; i < writesPerGoroutine; i++ {
+				if _, err := w.Write(chunk); err != nil {
+					t.Errorf("Write: %v", err)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// Total bytes should be exactly goroutines * writesPerGoroutine * chunkLen.
+	got := readBack(t, filepath.Dir(w.path))
+	want := goroutines * writesPerGoroutine * chunkLen
+	if len(got) != want {
+		t.Errorf("total bytes: want %d, got %d", want, len(got))
+	}
+	// And no chunk should have been split: every run of identical
+	// bytes should be a multiple of chunkLen. (Technically the
+	// scheduler could interleave at chunk boundaries, but never
+	// within a single Write call.)
+	checkChunkBoundaries(t, got, chunkLen)
+}
+
+func checkChunkBoundaries(t *testing.T, got []byte, chunkLen int) {
+	t.Helper()
+	i := 0
+	for i < len(got) {
+		c := got[i]
+		j := i
+		for j < len(got) && got[j] == c {
+			j++
+		}
+		if (j-i)%chunkLen != 0 {
+			t.Errorf("torn write at offset %d: %d consecutive %q bytes (not a multiple of %d)",
+				i, j-i, c, chunkLen)
+			return
+		}
+		i = j
+	}
+}
+
+// TestOpenReaderMissing returns the os.ErrNotExist sentinel so
+// gmuxd's broker handler can map it to a clean 404.
+func TestOpenReaderMissing(t *testing.T) {
+	dir := t.TempDir()
+	_, err := OpenReader(dir)
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("missing scrollback: want os.ErrNotExist, got %v", err)
+	}
+}
+
+// TestOpenReaderActiveOnly: a fresh runner that hasn't rotated yet.
+// Reader returns just the active file.
+func TestOpenReaderActiveOnly(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ActiveName), []byte("active"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	got := readBack(t, dir)
+	if string(got) != "active" {
+		t.Errorf("want %q, got %q", "active", got)
+	}
+}
+
+// TestOpenReaderPreviousOnly: a runner that rotated and then died
+// before writing anything to the new active file. Reader should
+// still return previous.
+func TestOpenReaderPreviousOnly(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, PreviousName), []byte("prev"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	got := readBack(t, dir)
+	if string(got) != "prev" {
+		t.Errorf("want %q, got %q", "prev", got)
+	}
+}
+
+// TestReaderEmitsPreviousBeforeActive nails the chronological
+// ordering. Without it, a replayed session would render its
+// rotation history out of order and the cursor would land in the
+// wrong place.
+func TestReaderEmitsPreviousBeforeActive(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ActiveName), []byte("LATER"), 0o600); err != nil {
+		t.Fatalf("seed active: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, PreviousName), []byte("EARLIER"), 0o600); err != nil {
+		t.Fatalf("seed previous: %v", err)
+	}
+	got := string(readBack(t, dir))
+	if got != "EARLIERLATER" {
+		t.Errorf("want %q, got %q", "EARLIERLATER", got)
+	}
+}
+
+// TestReaderCloseClosesAllUnderlying verifies the multiReadCloser
+// Close fans out: leaks here would surface as ENOSPC under heavy
+// session churn on machines with low fd limits.
+func TestReaderCloseClosesAllUnderlying(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{ActiveName, PreviousName} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("x"), 0o600); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+	r, err := OpenReader(dir)
+	if err != nil {
+		t.Fatalf("OpenReader: %v", err)
+	}
+	if err := r.Close(); err != nil {
+		t.Errorf("Close: %v", err)
+	}
+	// Second Close must not panic; underlying *os.File returns
+	// "file already closed", multiReadCloser surfaces the first.
+	err = r.Close()
+	if err != nil && !strings.Contains(err.Error(), "already closed") {
+		t.Errorf("second Close: want either nil or 'already closed' err, got %v", err)
+	}
+}

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -1240,6 +1240,9 @@ func serve(stderr io.Writer) int {
 			})
 			writeJSON(w, map[string]any{"ok": true, "data": map[string]any{}})
 
+		case "scrollback":
+			scrollbackBrokerHandler(w, r, sessionID, sessions, metaStore.SessionDir)
+
 		case "clipboard":
 			// Materialize a clipboard binary payload as a file in this
 			// gmuxd's os.TempDir() and return the absolute path. For

--- a/services/gmuxd/cmd/gmuxd/scrollback.go
+++ b/services/gmuxd/cmd/gmuxd/scrollback.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"errors"
+	"io"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/gmuxapp/gmux/packages/scrollback"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/store"
+)
+
+// scrollbackBrokerHandler streams a session's persisted PTY scrollback
+// (previous file followed by active file, chronological order) as raw
+// bytes. It's the readonly counterpart to the runner's tee in
+// ptyserver: dead sessions whose runner socket is gone can still
+// serve their terminal history.
+//
+// Status code semantics:
+//
+//   - 405 if the method isn't GET. Scrollback is read-only; writes
+//     happen exclusively through the runner.
+//   - 404 if the session ID isn't in the store. The session existing
+//     in the store is the authorization gate: peer sessions get
+//     forwarded to the owning gmuxd before reaching this handler.
+//   - 200 with an empty body when the session is known but no
+//     scrollback files exist. This is the "fresh session, runner
+//     hasn't produced output yet" case (or a session whose runner
+//     exited without writing anything). Distinguishing it from 404
+//     means the frontend never has to retry on a known session.
+//   - 500 on any other IO error reading the scrollback dir; the
+//     log line carries the underlying cause.
+//
+// dirFor maps a session ID to its per-session directory. In
+// production this is sessionmeta.Store.SessionDir; tests inject a
+// closure pointing at a temp dir.
+func scrollbackBrokerHandler(
+	w http.ResponseWriter,
+	r *http.Request,
+	sessionID string,
+	sessions *store.Store,
+	dirFor func(string) string,
+) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "bad_request", "method not allowed")
+		return
+	}
+	if _, ok := sessions.Get(sessionID); !ok {
+		writeError(w, http.StatusNotFound, "not_found", "session not found")
+		return
+	}
+
+	rc, err := scrollback.OpenReader(dirFor(sessionID))
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		log.Printf("scrollback: %s: %v", sessionID, err)
+		writeError(w, http.StatusInternalServerError, "internal", "scrollback unavailable")
+		return
+	}
+
+	// From here on the response status is 200. Set headers before any
+	// io.Copy; the empty-body case (rc == nil) still sends them so the
+	// frontend can distinguish a known-empty session from a 404.
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.Header().Set("Cache-Control", "no-store")
+
+	if rc == nil {
+		return
+	}
+	defer rc.Close()
+
+	// A mid-stream client disconnect (e.g. user closed the tab)
+	// surfaces as a Copy error and is not actionable; nothing to log.
+	_, _ = io.Copy(w, rc)
+}

--- a/services/gmuxd/cmd/gmuxd/scrollback_test.go
+++ b/services/gmuxd/cmd/gmuxd/scrollback_test.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gmuxapp/gmux/packages/scrollback"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/store"
+)
+
+// brokerFixture wires up a real store + a temp dir keyed by session
+// ID, then returns a closure that runs requests against the handler
+// the same way the dispatcher does at runtime.
+type brokerFixture struct {
+	sessions *store.Store
+	rootDir  string
+	dirFor   func(string) string
+}
+
+func newBrokerFixture(t *testing.T) *brokerFixture {
+	t.Helper()
+	root := t.TempDir()
+	return &brokerFixture{
+		sessions: store.New(),
+		rootDir:  root,
+		dirFor:   func(id string) string { return filepath.Join(root, id) },
+	}
+}
+
+func (f *brokerFixture) addSession(t *testing.T, id string) {
+	t.Helper()
+	f.sessions.Upsert(store.Session{ID: id, Kind: "shell", Alive: true})
+}
+
+func (f *brokerFixture) writeScrollback(t *testing.T, id, body string) {
+	t.Helper()
+	dir := f.dirFor(id)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, scrollback.ActiveName), []byte(body), 0o600); err != nil {
+		t.Fatalf("write active: %v", err)
+	}
+}
+
+func (f *brokerFixture) do(method, sessionID string) *http.Response {
+	req := httptest.NewRequest(method, "/v1/sessions/"+sessionID+"/scrollback", nil)
+	rec := httptest.NewRecorder()
+	scrollbackBrokerHandler(rec, req, sessionID, f.sessions, f.dirFor)
+	return rec.Result()
+}
+
+// TestBrokerStreamsScrollbackBytes is the central correctness claim:
+// when a session has a scrollback file, GET returns it byte-for-byte.
+// Without this, dead-session replay would diverge from what the
+// runner actually emitted.
+func TestBrokerStreamsScrollbackBytes(t *testing.T) {
+	f := newBrokerFixture(t)
+	f.addSession(t, "sess-1")
+
+	want := "hello\x1b[31mred\x1b[0m\nworld\n"
+	f.writeScrollback(t, "sess-1", want)
+
+	resp := f.do(http.MethodGet, "sess-1")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: want 200, got %d", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Content-Type"); got != "application/octet-stream" {
+		t.Errorf("Content-Type: want application/octet-stream, got %q", got)
+	}
+	if got := resp.Header.Get("Cache-Control"); got != "no-store" {
+		t.Errorf("Cache-Control: want no-store, got %q", got)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if string(body) != want {
+		t.Errorf("body: want %q, got %q", want, body)
+	}
+}
+
+// TestBrokerKnownSessionEmptyScrollbackReturns200 nails the design
+// decision to NOT 404 when the session is known but has no
+// scrollback yet. A frontend polling on attach would otherwise have
+// to retry on 404 / treat 404 as transient, which is gnarly. With
+// 200-empty, the polling logic is just "stream until eof, append".
+func TestBrokerKnownSessionEmptyScrollbackReturns200(t *testing.T) {
+	f := newBrokerFixture(t)
+	f.addSession(t, "sess-fresh")
+	// Note: no writeScrollback call. Session is in store, no files
+	// on disk.
+
+	resp := f.do(http.MethodGet, "sess-fresh")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: want 200, got %d", resp.StatusCode)
+	}
+	// Headers must still match the success case so a frontend can
+	// rely on Content-Type/Cache-Control regardless of body length.
+	if got := resp.Header.Get("Content-Type"); got != "application/octet-stream" {
+		t.Errorf("Content-Type on empty body: want application/octet-stream, got %q", got)
+	}
+	if got := resp.Header.Get("Cache-Control"); got != "no-store" {
+		t.Errorf("Cache-Control on empty body: want no-store, got %q", got)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if len(body) != 0 {
+		t.Errorf("body: want empty, got %q", body)
+	}
+}
+
+// TestBrokerUnknownSession404 distinguishes "session never existed"
+// from "session known, no scrollback yet" (200 above). The frontend
+// uses 404 to drop the session from its UI; conflating them would
+// hide real sessions during the milliseconds before scrollback
+// shows up on disk.
+func TestBrokerUnknownSession404(t *testing.T) {
+	f := newBrokerFixture(t)
+	// No session added.
+
+	resp := f.do(http.MethodGet, "sess-ghost")
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("status: want 404, got %d", resp.StatusCode)
+	}
+}
+
+// TestBrokerRejectsNonGet locks down readonly semantics. POST /
+// PUT / DELETE on this endpoint should never succeed; the runner
+// is the only writer.
+func TestBrokerRejectsNonGet(t *testing.T) {
+	f := newBrokerFixture(t)
+	f.addSession(t, "sess-1")
+	f.writeScrollback(t, "sess-1", "data")
+
+	for _, method := range []string{http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodPatch} {
+		resp := f.do(method, "sess-1")
+		if resp.StatusCode != http.StatusMethodNotAllowed {
+			t.Errorf("%s: want 405, got %d", method, resp.StatusCode)
+		}
+	}
+}
+
+// TestBrokerConcatenatesPreviousAndActive verifies the rotation
+// contract surfaces correctly through the broker: previous file
+// bytes precede active file bytes. A regression here would replay
+// rotated history out of order, putting the cursor in the wrong
+// place and corrupting the visible scrollback.
+func TestBrokerConcatenatesPreviousAndActive(t *testing.T) {
+	f := newBrokerFixture(t)
+	f.addSession(t, "sess-1")
+
+	dir := f.dirFor("sess-1")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, scrollback.PreviousName), []byte("EARLIER\n"), 0o600); err != nil {
+		t.Fatalf("write previous: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, scrollback.ActiveName), []byte("LATER\n"), 0o600); err != nil {
+		t.Fatalf("write active: %v", err)
+	}
+
+	resp := f.do(http.MethodGet, "sess-1")
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "EARLIER\nLATER\n" {
+		t.Errorf("ordering: want %q, got %q", "EARLIER\nLATER\n", body)
+	}
+}

--- a/services/gmuxd/internal/sessionmeta/sessionmeta.go
+++ b/services/gmuxd/internal/sessionmeta/sessionmeta.go
@@ -39,16 +39,20 @@ import (
 )
 
 const (
-	metaFile       = "meta.json"
-	scrollbackFile = "scrollback" // owned by the runner; sweep recognizes it as non-orphan
-	dirMode        = 0o700
-	fileMode       = 0o600
+	metaFile = "meta.json"
+	dirMode  = 0o700
+	fileMode = 0o600
 )
 
+// Per-session directories may also contain scrollback files written
+// by the runner (see packages/scrollback). sessionmeta does not
+// inspect or own those files — it only manages meta.json — but it
+// removes them as a side effect of Remove (entire dir tree).
+
 // DefaultDir is the production state-dir for session metadata.
-// $XDG_STATE_HOME/gmux/sessions, derived from paths.StateDir().
+// $XDG_STATE_HOME/gmux/sessions, derived from paths.SessionsDir.
 func DefaultDir() string {
-	return filepath.Join(paths.StateDir(), "sessions")
+	return paths.SessionsDir()
 }
 
 // Store binds a base directory to the file-IO operations. One Store

--- a/services/gmuxd/internal/sessionmeta/sessionmeta_test.go
+++ b/services/gmuxd/internal/sessionmeta/sessionmeta_test.go
@@ -224,12 +224,14 @@ func TestSweepLoadsAllSessionsAsAliveFalse(t *testing.T) {
 
 func TestSweepRemovesOrphanDirs(t *testing.T) {
 	s := newStore(t)
-	// Orphan: dir exists with a scrollback-like file but no meta.json.
+	// Orphan: dir exists with non-meta content (a scrollback file
+	// the runner wrote) but no meta.json. Sweep should treat the
+	// whole dir as orphan and clean it up.
 	orphan := s.SessionDir("sess-orphan")
 	if err := os.MkdirAll(orphan, dirMode); err != nil {
 		t.Fatalf("mkdir orphan: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(orphan, scrollbackFile), []byte("xyz"), fileMode); err != nil {
+	if err := os.WriteFile(filepath.Join(orphan, "scrollback"), []byte("xyz"), fileMode); err != nil {
 		t.Fatalf("write orphan scrollback: %v", err)
 	}
 


### PR DESCRIPTION
Third slice of the session-lifecycle work, after #184 (pipe handshake) and #185 (metadata persistence).

## What

Dead sessions get a sidebar entry from #185 but their terminal pane is empty: the runner is gone, its in-memory vt state is gone, and there's nowhere left to read from. This change tees the runner's PTY output to disk and exposes a readonly broker so the history is recoverable after the runner socket disappears.

A `gmux --no-attach echo hi` followed by a `GET /v1/sessions/<id>/scrollback` now returns `hi\r\n`. A long-running session that gets `kill -9`'d still serves everything up to the moment the runner died.

## How

### Shared on-disk contract: `packages/scrollback`

New module with both halves of the protocol so the runner and gmuxd agree on the layout by construction. Two files per session under `$XDG_STATE_HOME/gmux/sessions/<id>/`:

- `scrollback`: append-only active file
- `scrollback.0`: previous active, rotated on size cap

`MaxBytes = 1 MiB` per file, so total per-session disk usage is bounded at 2 MiB. The cap comfortably exceeds xterm's default 5000-line scrollback (~400 KiB at 80 cols) so dead-session replay shows everything the live attach would have shown.

`Writer.Write` is best-effort: IO errors are sticky and silently dropped from the hot path (returning `len(p), nil`); the first error is preserved and surfaced by `Close`. The runner's flush loop doesn't have to handle disk-full as a fatal condition.

`OpenReader` returns an `io.ReadCloser` over the concatenated previous + active files in chronological order, or `os.ErrNotExist` if neither file is present.

Format: raw PTY bytes, exactly as the child emitted them. xterm.js consumes them by feeding chunks straight to `Terminal.write()`, so S5's web-side replay is just stream-and-write.

### Runner: tee into the writer

`ptyserver.Config` gains an `io.WriteCloser` field. The server tees every coalesced PTY chunk to it in `flush()` (after `localOut`, before client writes) and closes it in `waitChild` after `<-s.ptyDone`. Closing post-drain is the critical timing: fast-exiting commands (`echo`, `true`) have their final coalesced chunk delivered before the file is closed, so nothing lands on the floor.

`run.go` opens the writer at `paths.SessionDir(sessionID)/scrollback`, with a typed-nil-interface guard (only assign on successful Open) so a failed Open leaves `Config.Scrollback` nil rather than a non-nil interface wrapping a nil pointer.

### Broker: `GET /v1/sessions/<id>/scrollback`

`scrollbackBrokerHandler` in gmuxd:

- 405 on non-GET (readonly).
- 404 when the session ID isn't in the store.
- **200 with empty body** when the session is known but no scrollback files exist. This is the design call worth flagging: a frontend polling on attach to a fresh session shouldn't have to retry on 404, so we distinguish "session unknown" (404) from "session known, no bytes yet" (200-empty).
- 500 + log on any other IO error.
- Stream `application/octet-stream` + `Cache-Control: no-store` followed by the bytes from `OpenReader`.

Peer-owned scrollback requests are forwarded by the existing peer routing block at the top of the dispatcher, so spoke-side runners' history is reachable from the hub.

### Path layout: `paths.SessionDir`

Single source of truth for the per-session directory, used by:

- `paths.SessionDir(id)` itself (new helper)
- `sessionmeta.DefaultDir` (S2's metadata persistence)
- `run.go`'s scrollback path computation

Eliminates the literal `"sessions"` from being typed in two places, which previously meant a path-layout change had two places to drift.

## Tests

`packages/scrollback/scrollback_test.go` (14 tests):

- Round-trip: bytes Written come back via `OpenReader` in order.
- Rotation at cap: previous file holds pre-rotation data, active holds post-rotation, reader concatenates them.
- Multiple rotations bound on disk usage: across 3 rotations, only the most recent previous + active are kept.
- Write-after-Close, idempotent Close.
- Truncate-on-Open contract (per-runner, not per-session).
- Parent dir auto-creation, file mode `0o600`.
- Concurrency: 8 goroutines writing chunks in parallel, no torn writes (every contiguous run of identical bytes is a multiple of chunk length).
- Reader returns `os.ErrNotExist` for missing dirs (so the broker can map to 404 cleanly), serves active-only / previous-only, emits previous before active, closes all underlying files.

`services/gmuxd/cmd/gmuxd/scrollback_test.go` (5 tests against the broker):

- Streams scrollback bytes verbatim with the right Content-Type / Cache-Control headers.
- Known session with no files returns 200-empty (the design choice gets a regression guard).
- Unknown session returns 404.
- Rejects POST/PUT/DELETE/PATCH (readonly).
- Concatenates previous + active in chronological order.

`cli/gmux/internal/ptyserver/ptyserver_test.go` (2 new tests):

- `TestPTYServerScrollbackPersistence`: a real PTY server with a real `scrollback.Writer`, runs `echo SCROLLBACK-MARKER-XYZ`, asserts the bytes land on disk after `<-srv.PTYDone()`. This is the regression guard for the `flush()` tee + the `waitChild` post-drain Close ordering: a refactor that moves the Close earlier or forgets it entirely surfaces here, not just in E2E.
- `TestPTYServerScrollbackNotConfigured`: PTY server with no `Scrollback` field set runs to completion normally. Locks down the typed-nil-interface guard and the "best-effort" promise.

E2E verified locally for all six lifecycle paths:

1. Fast-exit `echo`: scrollback written + broker serves it.
2. Slug-takeover cleanup (S2 contract): `forgetMeta` removes the entire session dir, scrollback included.
3. SSE-exit path: scrollback closes after final drain, broker serves complete output.
4. Dismiss: dir + meta + scrollback all removed.
5. SIGKILL: scrollback up to the moment of the kill is preserved (no phantom bytes from after the kill).
6. gmuxd restart: scrollback file survives the daemon restart and the broker still serves it post-sweep.
7. Rotation under load (`yes | head -n 30000` ≈ 1.65 MiB output): previous=1.04 MiB, active=608 KiB, broker concatenates, total served = 1.65 MiB (no bytes lost).

## Deferred

- **Append-on-Open** instead of truncate. Today, resuming a session truncates the dead runner's history. The alternative (rotate-on-Open: rename existing active to `.0`, open fresh) would preserve the most recent slice of the dead runner alongside the resumed one. Worth doing once we have UX feedback that resume-loses-history actually bothers people.
- **fsync on rotate**. Today, rotation does close + rename + reopen but no fsync. A power loss between rotation and the next OS flush could leave both files on disk while the actual bytes are still in page cache. For raw terminal output with a 2 MiB cap this seems unimportant; revisit if it ever surfaces.
- **Web-side replay** (S5). The broker is in place; xterm.js wiring is the next slice.
- **Peer-owned scrollback E2E confirmation**. The runner-side persistence and the peer-routing block in the dispatcher are both in place; assuming both ends run a build with this change, the hub serves a peer-owned dead session's scrollback transparently. Not yet exercised end-to-end. Plan is to verify with a devcontainer peer once this lands.

## Stack

Builds on #184 (merged) and #185 (merged). S5 (web tabs) consumes this endpoint to populate xterm on attach to a dead session; it doesn't depend on any further backend work.

