### PR TITLE
fix(daemon): preserve session state and prevent duplicates across restart

### DIFF
--- a/UBIQUITOUS_LANGUAGE.md
+++ b/UBIQUITOUS_LANGUAGE.md
@@ -1,0 +1,121 @@
+# Ubiquitous Language
+
+## Session identity
+
+| Term                | Definition                                                                                                | Aliases to avoid          |
+| ------------------- | --------------------------------------------------------------------------------------------------------- | ------------------------- |
+| **Session**         | The user-facing unit of work in a directory: a terminal pane plus everything we know about it             | Pane, terminal, tab       |
+| **Slug**            | A session's stable, human-readable identity; persistent across runner restarts and resume                 | Name                      |
+| **Session ID**      | A specific runner instance's identifier; ephemeral for shell, stable (= tool ID) for pi/claude            | Identifier (alone is too generic) |
+| **Key**             | The single string projects.json uses per session: slug if attributed, session ID otherwise                |                           |
+| **Tool ID**         | An adapter-managed file identifier (e.g. JSONL filename) used as session ID for tool-backed sessions      |                           |
+
+## Session lifecycle
+
+| Term                    | Definition                                                                                          | Aliases to avoid       |
+| ----------------------- | --------------------------------------------------------------------------------------------------- | ---------------------- |
+| **Alive**               | Has a live runner whose Unix socket is reachable                                                    | Running, active        |
+| **Dead**                | No live runner; record exists in the store and possibly on disk                                     | Stopped, exited        |
+| **Resumable**           | Dead session whose `Command` is set so a new runner can be spawned from it                          | Restartable            |
+| **Pre-attribution**     | Transient phase for tool-backed sessions before their adapter file appears: has ID, no slug yet     | Ephemeral, unattributed |
+| **Attributed**          | Tool-backed session whose adapter file exists, giving it a real slug                                | Named                  |
+| **Fast-exit**           | A runner whose child finished before gmuxd's `queryMeta` reaches it; lands in the store as Alive=false directly, never as Alive=true | Quick-exit |
+
+## Components
+
+| Term            | Definition                                                                                       | Aliases to avoid            |
+| --------------- | ------------------------------------------------------------------------------------------------ | --------------------------- |
+| **Runner**      | A `gmux` process holding a child PTY and serving WS / scrollback over a per-session Unix socket  | gmux process, child         |
+| **Daemon**      | The single per-host `gmuxd` process; central registry, broker, and proxy                         | Server, gmuxd (in prose)    |
+| **Broker**      | The daemon's role serving readonly state (today: scrollback) sourced from disk for dead sessions | Replay server               |
+| **Adapter**     | A plugin (pi, claude, shell, ...) that resolves commands, derives slugs, and may write tool files | Plugin, kind                |
+| **Frontend**    | The web UI consuming `/v1/events` SSE and `/ws/<id>` WebSockets                                  | Client (overloaded), web    |
+
+## Peering
+
+| Term            | Definition                                                                                                  | Aliases to avoid           |
+| --------------- | ----------------------------------------------------------------------------------------------------------- | -------------------------- |
+| **Hub**         | The local daemon a frontend is connected to; proxies and aggregates                                         | Master                     |
+| **Spoke**       | A remote daemon whose sessions are forwarded through a hub                                                  | Slave, child daemon        |
+| **Peer**        | A connection from a hub to another daemon                                                                   |                            |
+| **Local peer**  | A peer where `PeerConfig.Local = true` — currently only Docker devcontainers; sessions count as "owned"      | Devcontainer (the *connection*, not the *machine*) |
+| **Network peer**| A non-Local peer (Tailscale or manual); its sessions are excluded from the hub's `/v1/events` stream         | Remote peer                |
+
+## Persistence stores
+
+| Term                     | Definition                                                                                                   | Aliases to avoid              |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------ | ----------------------------- |
+| **Store**                | The daemon's in-memory `store.Store`: the live, authoritative session table                                  | Session table                 |
+| **Sessionmeta**          | Per-session runtime persistence: `<state>/sessions/<id>/meta.json`. SOT for **runtime state** of dead sessions | Session metadata, meta files |
+| **Scrollback**           | Per-session persisted PTY byte stream: `<state>/sessions/<id>/scrollback{,.0}`. SOT for terminal history     | History, log                  |
+| **Projects.json**        | The on-disk SOT for **sidebar membership and ordering** (project rules + ordered key lists)                  | Project state, projects file  |
+| **Conversations Index**  | In-memory id↔slug map rebuilt on startup by scanning **adapter state files**; serves URL resolution & search | Conv index, conversations DB  |
+| **Adapter state files**  | Per-adapter on-disk records the conversations index reads (shell `<cwd>/<id>.json`, pi/claude JSONLs, ...)    | Session files                 |
+
+## State separation
+
+The four stores have orthogonal concerns. Mixing them is a smell:
+
+| Store                  | Owns                                                              | Keyed by                          |
+| ---------------------- | ----------------------------------------------------------------- | --------------------------------- |
+| **Store**              | Live runtime state of every session the hub knows about           | Session ID                        |
+| **Sessionmeta**        | Persisted runtime state (exit code, status, title, timestamps)    | Session ID                        |
+| **Projects.json**      | Which sessions appear in the sidebar, in what project, what order | Project slug → list of **Key**s   |
+| **Conversations Index**| Cross-reference between IDs and slugs for adapter-backed sessions | (kind, ID) and (kind, slug)       |
+
+## Lifecycle events
+
+| Term                  | Definition                                                                                                            | Aliases to avoid               |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------- | ------------------------------ |
+| **Register**          | Runner POSTs to `/v1/register`; daemon queries the runner's `/meta` and Upserts the session                            | Announce                       |
+| **Deregister**        | Runner POSTs to `/v1/deregister` on shutdown; daemon unsubscribes (does **not** remove)                                | Unregister                     |
+| **Resume**            | User-initiated: spawn a new runner with the dead session's resume `Command`, merge new runner onto the existing ID      | Restart (overloaded — see below) |
+| **Resume merge**      | The internal step inside `Register` where a pending resume's existing ID swallows the fresh runner's ID                | Reattach                       |
+| **Restart**           | Like Resume but kills the live runner first; goes through Resume after exit                                            |                                |
+| **Slug-takeover**     | A fresh live session evicting a dead one with the same `(kind, peer, slug)` from the store                              | Slug eviction                  |
+| **Dismiss**           | Explicit user removal: runner killed if alive, store entry removed, sessionmeta + scrollback dropped                    | Delete, close                  |
+| **Sweep**             | Daemon startup operation: read every `meta.json` and Upsert as `Alive=false` so dead sessions reappear in the sidebar   | Restore                        |
+| **Attribution**       | The pre-attribution → attributed transition for tool-backed sessions when their adapter file appears                    | Naming                         |
+
+## Relationships
+
+- A **Session** has exactly one **Slug** (after Attribution) and one **Session ID**.
+- A **Slug** is identity; a **Session ID** is instance. Over time a single **Slug** in a project may host multiple **Session IDs** (e.g., dismiss, then re-run in the same cwd).
+- **Projects.json** stores **Keys**, never `(id, slug)` pairs: the **Key** is the slug if attributed, the ID otherwise.
+- **Sessionmeta** is keyed by **Session ID** and is the SOT for runtime fields. **Projects.json** is keyed by project slug and is the SOT for sidebar membership.
+- A **Local peer** owns its sessions (counted as local for SSE forwarding); a **Network peer** does not.
+- The **Broker** reads from **Scrollback** files and the **Store**; it never writes either.
+
+## Example dialogue
+
+> **Dev:** "User dismisses a session, then runs `gmux bash` in the same cwd. New session, same slug. What happens?"
+
+> **Domain expert:** "It's a fresh **Session** with a new **Session ID** but the same **Slug** — same cwd, same derivation. The **Store** does **Slug-takeover**: evicts the old dead one if it's still around, inserts the new live one. **Projects.json** doesn't notice — its **Key** for that slot is the slug, which is unchanged."
+
+> **Dev:** "So the **Sessionmeta** for the old session — does that get dropped?"
+
+> **Domain expert:** "Yes. **Slug-takeover** broadcasts `session-remove` for the evicted ID, the cleanup goroutine catches it and removes that ID's **Sessionmeta** directory. The new session writes its own meta on first `Alive=false` landing."
+
+> **Dev:** "What if it's a pi session that's still **Pre-attribution** when it hits the project?"
+
+> **Domain expert:** "Then `AutoAssignSession` puts the **Session ID** in **Projects.json** as the **Key**. Once the JSONL appears and the session becomes **Attributed**, it gets a real **Slug**, and the projects code rewrites that array entry in place — same slot, ID swapped for slug."
+
+> **Dev:** "So the **Conversations Index** matters here for resolving URLs to dead pi sessions, but not for the sidebar?"
+
+> **Domain expert:** "Right. **Sessionmeta** is what makes dead sessions reappear in the sidebar after a daemon restart. The **Conversations Index** exists for things like `/v1/conversations/{kind}/{slug}` URL lookup and future search. They live in different concerns; conflating them is what made the old rehydration path overwrite runtime state."
+
+## Flagged ambiguities
+
+- **"Session"** is used colloquially for the in-memory record, the runner process, the user's mental model, and the on-disk meta.json. Prefer **Session** for the conceptual entity, **Runner** for the process, **Sessionmeta** for the on-disk record, **Store entry** for the in-memory record.
+
+- **"Slug"** appears in two scopes: **Project slug** (a project's identifier in projects.json) and **session Slug** (a session's identity). When ambiguous, qualify: "project slug" vs "session slug".
+
+- **"Restart"** has been used both for the explicit `restart` action (kill + resume) and informally for "resume". Prefer **Restart** only for the kill-then-resume operation; **Resume** for spawning a runner from a dead session.
+
+- **"State"** has been overloaded across **Store** (in-memory), **Sessionmeta** (per-session runtime fields on disk), **adapter state files** (per-adapter on-disk records), and the runtime Alive/Dead/Resumable. Always qualify which one.
+
+- **"Identity"**: in this codebase, **Slug** is identity, **Session ID** is instance. Treat them as distinct columns even though `SessionKey` coalesces them for projects.json's purposes.
+
+- **"Local"** has two meanings: the local *machine* (where this gmuxd runs), and a **Local peer** (`PeerConfig.Local = true`, currently devcontainers only). Prefer **Local peer** for the latter to avoid collision with "the local daemon".
+
+- **"Broker"** was introduced for the scrollback endpoint. Reserve it for read-only daemon endpoints serving disk-backed state for dead sessions; not a synonym for the daemon as a whole.

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -533,34 +533,12 @@ func serve(stderr io.Writer) int {
 	}
 	projectMgr.SeedIfEmpty()
 
-	// Populate the store with dead/resumable sessions from projects.
-	// For each session slug in each project, look up the conversations
-	// index to get file metadata and create a store entry. This replaces
-	// the old file scanner's role of creating file-* store entries:
-	// only sessions tracked by a project appear, not every file on disk.
+	// Populate the store with project-tracked sessions that don't have
+	// a sessionmeta record. The sessionmeta sweep above is the SOT for
+	// runtime fields; this only fills in the pre-S2 fallback path. See
+	// rehydrateProjects for the identity-model rationale.
 	if state, err := projectMgr.Load(); err == nil {
-		for _, item := range state.Items {
-			for _, key := range item.Sessions {
-				info, ok := convIndex.LookupBySlug(key)
-				if !ok {
-					// Slug not in conversations index (file may have
-					// been deleted, or key is an ephemeral session ID).
-					// Leave it; cleanup below removes orphaned entries.
-					continue
-				}
-				sess := store.Session{
-					ID:           info.ToolID,
-					CreatedAt:    info.Created.UTC().Format(time.RFC3339),
-					Command:      info.ResumeCommand,
-					Cwd:          info.Cwd,
-					Kind:         info.Kind,
-					Alive:        false,
-					AdapterTitle: info.Title,
-					Slug:         info.Slug,
-				}
-				sessions.Upsert(sess)
-			}
-		}
+		rehydrateProjects(sessions, convIndex, state)
 	}
 
 	// After store is populated, clean up orphaned project entries

--- a/services/gmuxd/cmd/gmuxd/rehydrate.go
+++ b/services/gmuxd/cmd/gmuxd/rehydrate.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"log"
+	"time"
+
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/conversations"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/projects"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/store"
+)
+
+// rehydrateProjects ensures every key listed in projects.json appears
+// in the session store, so the sidebar shows project-tracked sessions
+// after a daemon restart.
+//
+// Identity model: projects.json is the SOT for sidebar membership and
+// ordering; sessionmeta is the SOT for per-session runtime fields.
+// The two stores have orthogonal concerns. This function honours that
+// split: it only fabricates a Session record when neither the
+// sessionmeta sweep nor any other path has put a session in the
+// store for this slot.
+//
+// Two skip checks, in priority order:
+//
+//  1. Same instance ID present (sessions.Get(info.ToolID)). This is
+//     the steady-state for shell sessions, where the runner ID and
+//     the conversations-index ToolID are the same string.
+//
+//  2. Same (kind, slug) present (sessions.HasLocalSlug). This is
+//     critical for tool-backed adapters (pi, claude, codex) where
+//     the conversations index uses the adapter's own UUID (e.g. the
+//     JSONL filename) as ToolID, while sessionmeta keys by the
+//     runner-generated session ID. Without this check, a single
+//     pi/claude session restored from sessionmeta would gain a
+//     parallel ghost entry from convIndex, surfacing as a duplicate
+//     in the sidebar until slug-takeover at next attribution.
+//
+// The convIndex fallback exists only for the migration window where
+// pre-S2 sessions referenced in projects.json have no sessionmeta
+// record yet. The aggregated log surfaces lingering use so that
+// decision can be informed.
+func rehydrateProjects(sessions *store.Store, convIndex *conversations.Index, state *projects.State) {
+	var fallbacks int
+	for _, item := range state.Items {
+		for _, key := range item.Sessions {
+			info, ok := convIndex.LookupBySlug(key)
+			if !ok {
+				// Either an ephemeral pre-attribution session ID
+				// (already loaded by sessionmeta keyed by ID) or a
+				// stale entry whose adapter file is gone. The
+				// orphan-cleanup pass below removes the latter.
+				continue
+			}
+			if _, exists := sessions.Get(info.ToolID); exists {
+				continue
+			}
+			if sessions.HasLocalSlug(info.Kind, info.Slug) {
+				continue
+			}
+			fallbacks++
+			sessions.Upsert(store.Session{
+				ID:           info.ToolID,
+				CreatedAt:    info.Created.UTC().Format(time.RFC3339),
+				Command:      info.ResumeCommand,
+				Cwd:          info.Cwd,
+				Kind:         info.Kind,
+				Alive:        false,
+				AdapterTitle: info.Title,
+				Slug:         info.Slug,
+			})
+		}
+	}
+	if fallbacks > 0 {
+		// Aggregated: a 50-session pre-S2 install would otherwise
+		// emit 50 lines on every startup. The count is what we use
+		// to gauge when this fallback path can be retired.
+		log.Printf("rehydrate: %d session(s) restored from convIndex (no sessionmeta record)", fallbacks)
+	}
+}

--- a/services/gmuxd/cmd/gmuxd/rehydrate_test.go
+++ b/services/gmuxd/cmd/gmuxd/rehydrate_test.go
@@ -1,0 +1,203 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/conversations"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/projects"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/store"
+)
+
+// TestRehydrateProjects_PreservesSessionmetaState is the regression
+// guard for the bug where the projects.json rehydration loop
+// clobbered runtime fields populated by the sessionmeta sweep.
+//
+// Reproduce: a session with rich runtime state (exit code, status,
+// resolved title, exited-at timestamp) is loaded into the store first
+// (mimicking sessionmeta.Sweep). projects.json lists the same session
+// by slug. After rehydrateProjects runs, all runtime fields must
+// remain intact.
+func TestRehydrateProjects_PreservesSessionmetaState(t *testing.T) {
+	sessions := store.New()
+
+	// Sessionmeta.Sweep equivalent: full runtime state. ShellTitle
+	// (set from runtime OSC sequences) is the field a real shell
+	// session carries; resolveTitle promotes it to Title on Upsert.
+	exitCode := 42
+	exitedAt := "2024-01-01T12:00:00Z"
+	loaded := store.Session{
+		ID:         "tool-abc",
+		Slug:       "fix-auth",
+		Kind:       "shell",
+		Cwd:        "/home/me/proj",
+		Alive:      false,
+		ExitCode:   &exitCode,
+		ExitedAt:   exitedAt,
+		Status:     &store.Status{Label: "exited (42)", Error: true},
+		ShellTitle: "bash -c echo hi; exit 42",
+		CreatedAt:  "2024-01-01T11:00:00Z",
+	}
+	sessions.Upsert(loaded)
+
+	// convIndex carries the sparse, AdapterTitle-only view that comes
+	// from scanning adapter state files. Pre-fix, this would feed
+	// into Upsert via projects rehydration, take precedence over the
+	// already-loaded ShellTitle (AdapterTitle > ShellTitle), and
+	// clobber Title to the generic kind label.
+	idx := conversations.New()
+	idx.Upsert(conversations.Info{
+		ToolID:  "tool-abc",
+		Slug:    "fix-auth",
+		Kind:    "shell",
+		Title:   "shell", // becomes AdapterTitle on rehydrate
+		Cwd:     "/home/me/proj",
+		Created: time.Date(2024, 1, 1, 11, 0, 0, 0, time.UTC),
+	})
+
+	state := &projects.State{
+		Items: []projects.Item{{
+			Slug:     "proj",
+			Sessions: []string{"fix-auth"},
+		}},
+	}
+
+	rehydrateProjects(sessions, idx, state)
+
+	got, ok := sessions.Get("tool-abc")
+	if !ok {
+		t.Fatal("session disappeared from store")
+	}
+	if got.ExitCode == nil || *got.ExitCode != 42 {
+		t.Errorf("ExitCode lost: got %v, want 42", got.ExitCode)
+	}
+	if got.ExitedAt != exitedAt {
+		t.Errorf("ExitedAt lost: got %q, want %q", got.ExitedAt, exitedAt)
+	}
+	if got.Status == nil || got.Status.Label != "exited (42)" {
+		t.Errorf("Status lost: got %+v", got.Status)
+	}
+	if got.Title != "bash -c echo hi; exit 42" {
+		t.Errorf("Title clobbered: got %q, want runtime title", got.Title)
+	}
+}
+
+// TestRehydrateProjects_PreventsDuplicateForToolBackedAdapter is the
+// regression guard for the pi/claude/codex case where sessionmeta
+// and convIndex use different identifiers for the same logical
+// session: sessionmeta keys by the runner's session ID (assigned at
+// runner spawn), the conversations index keys by the adapter's own
+// UUID (e.g. JSONL filename header). Without the slug-based skip,
+// the sweep loads under one ID and the projects rehydration adds a
+// parallel ghost entry under the other, surfacing as a duplicate in
+// the sidebar.
+func TestRehydrateProjects_PreventsDuplicateForToolBackedAdapter(t *testing.T) {
+	sessions := store.New()
+
+	// Sessionmeta-loaded entry: keyed by runner session ID.
+	sessions.Upsert(store.Session{
+		ID:    "sess-runner-A",
+		Slug:  "fix-auth",
+		Kind:  "pi",
+		Cwd:   "/work",
+		Alive: false,
+	})
+
+	// convIndex entry: same logical session, but ToolID is the JSONL
+	// UUID, which is a different string from the runner ID.
+	idx := conversations.New()
+	idx.Upsert(conversations.Info{
+		ToolID:  "jsonl-uuid-XYZ",
+		Slug:    "fix-auth",
+		Kind:    "pi",
+		Title:   "(new)",
+		Cwd:     "/work",
+		Created: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+	})
+
+	state := &projects.State{
+		Items: []projects.Item{{
+			Slug:     "proj",
+			Sessions: []string{"fix-auth"},
+		}},
+	}
+
+	rehydrateProjects(sessions, idx, state)
+
+	if got := len(sessions.List()); got != 1 {
+		t.Fatalf("want 1 session after rehydrate, got %d (duplicate ghost not skipped)", got)
+	}
+	if _, ok := sessions.Get("sess-runner-A"); !ok {
+		t.Error("runner-keyed entry from sessionmeta was lost")
+	}
+	if _, ok := sessions.Get("jsonl-uuid-XYZ"); ok {
+		t.Error("convIndex ghost entry was created despite slug match")
+	}
+}
+
+// TestRehydrateProjects_FallbackForMissingSessionmeta covers the
+// pre-S2 migration path: a session is in projects.json + convIndex
+// but has no sessionmeta record. Without rehydration it would not
+// appear in the sidebar.
+func TestRehydrateProjects_FallbackForMissingSessionmeta(t *testing.T) {
+	sessions := store.New()
+
+	idx := conversations.New()
+	idx.Upsert(conversations.Info{
+		ToolID:        "tool-old",
+		Slug:          "legacy",
+		Kind:          "shell",
+		Title:         "shell",
+		Cwd:           "/home/me/legacy",
+		Created:       time.Date(2023, 6, 1, 0, 0, 0, 0, time.UTC),
+		ResumeCommand: []string{"bash"},
+	})
+
+	state := &projects.State{
+		Items: []projects.Item{{
+			Slug:     "proj",
+			Sessions: []string{"legacy"},
+		}},
+	}
+
+	rehydrateProjects(sessions, idx, state)
+
+	got, ok := sessions.Get("tool-old")
+	if !ok {
+		t.Fatal("fallback rehydration did not populate store")
+	}
+	if got.Slug != "legacy" {
+		t.Errorf("Slug = %q, want %q", got.Slug, "legacy")
+	}
+	if got.Cwd != "/home/me/legacy" {
+		t.Errorf("Cwd = %q, want /home/me/legacy", got.Cwd)
+	}
+	if got.Alive {
+		t.Error("rehydrated session must land as Alive=false")
+	}
+	if !got.Resumable {
+		t.Error("session with ResumeCommand should be marked Resumable")
+	}
+}
+
+// TestRehydrateProjects_SkipsUnknownKey covers the case where
+// projects.json references a key that resolves nowhere: neither
+// sessionmeta nor convIndex knows about it. The function must leave
+// the store untouched and not panic.
+func TestRehydrateProjects_SkipsUnknownKey(t *testing.T) {
+	sessions := store.New()
+	idx := conversations.New()
+
+	state := &projects.State{
+		Items: []projects.Item{{
+			Slug:     "proj",
+			Sessions: []string{"orphan-key"},
+		}},
+	}
+
+	rehydrateProjects(sessions, idx, state)
+
+	if got := sessions.List(); len(got) != 0 {
+		t.Errorf("expected empty store, got %d sessions", len(got))
+	}
+}

--- a/services/gmuxd/internal/store/store.go
+++ b/services/gmuxd/internal/store/store.go
@@ -163,6 +163,25 @@ func (s *Store) Get(id string) (Session, bool) {
 	return sess, ok
 }
 
+// HasLocalSlug reports whether the store already contains a local
+// (non-peer) session with the given (kind, slug). Slug is identity
+// for sidebar purposes (see UBIQUITOUS_LANGUAGE.md), so this is the
+// right check when deciding whether a project-tracked session is
+// already represented, regardless of which instance ID it carries.
+func (s *Store) HasLocalSlug(kind, slug string) bool {
+	if slug == "" {
+		return false
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, sess := range s.sessions {
+		if sess.Peer == "" && sess.Kind == kind && sess.Slug == slug {
+			return true
+		}
+	}
+	return false
+}
+
 // resolveTitle picks the best title: adapter > shell > command fallback.
 func (s *Store) resolveTitle(sess Session) string {
 	if sess.AdapterTitle != "" {


### PR DESCRIPTION
## Problem

After a daemon restart, project-tracked sessions experienced two distinct symptoms:

1. **For shell sessions**: runtime fields like `Title`, `Status`, `ExitCode`, `ExitedAt` were silently overwritten. Titles in particular degraded from runtime-resolved values like `"bash -c echo hi; exit 42"` to generic adapter labels like `"shell"`.

2. **For tool-backed sessions (pi, claude, codex)**: each logical session showed up twice in the sidebar, once with the runner's session ID and once with the adapter's UUID. Reported by a user testing S2 in the wild.

## Cause

Two startup paths in `services/gmuxd/cmd/gmuxd/main.go` populated the session store:

1. `metaStore.Sweep()` (~L397, added by S2): rich per-session record reconstructed from `sessionmeta/<id>/meta.json`. Keyed by the runner's session ID.
2. `projectMgr.Load()` loop (~L541, predates S2): for every key in `projects.json.Sessions`, looked up the conversations index and called `sessions.Upsert(sparseSession)` with `{ID: info.ToolID, Slug, Kind, Cwd, ...}`.

`store.Upsert` is replace-not-merge. The two paths interact differently per adapter:

- **Shell**: `info.ToolID` is the same string as the runner's session ID (the shell adapter writes `<state>/shell-sessions/<cwd>/<runner-id>.json`, parsed back into `Info.ToolID`). So the second loop's Upsert had the same key, replacing the rich sessionmeta record with a sparse one. Title-degradation symptom.
- **Pi/Claude/Codex**: `info.ToolID` is the adapter's own UUID (e.g., the JSONL filename's header.id field). This is a different string from the runner's session ID. So the second loop's Upsert had a different key, creating a parallel ghost entry. Duplicate-session symptom.

S1/S2 didn't introduce the projects-loop rehydration; it predates them. But S2 made the problem visible because it became the system's first record-keeping path that didn't agree with convIndex on the choice of identifier.

## Fix

Extract the projects-loop body into `rehydrateProjects` with two skip checks, in priority order:

```go
if _, exists := sessions.Get(info.ToolID); exists {
    continue // shell case: runner ID and convIndex ToolID are the same
}
if sessions.HasLocalSlug(info.Kind, info.Slug) {
    continue // tool-backed case: same logical session under a different ID
}
```

The `HasLocalSlug` helper is the single new method on `store.Store`. Slug is identity for sidebar purposes (per `UBIQUITOUS_LANGUAGE.md`, added in this PR), so checking by `(kind, slug)` is the right scope: it matches `resolveDuplicateSlugsLocked`'s rules and excludes peer-owned sessions, which the sweep doesn't load anyway.

The convIndex fallback after both checks is preserved for the migration window: pre-S2 sessions referenced in `projects.json` whose only on-disk trace is the adapter state file. The aggregated startup log (`rehydrate: N session(s) restored from convIndex (no sessionmeta record)`) surfaces lingering use so this path can be retired in a future release once the count converges to zero.

## Identity model

`UBIQUITOUS_LANGUAGE.md` (added here) makes the separation explicit:

- `projects.json` is the SOT for **sidebar membership and ordering**. Keys are slugs.
- `sessionmeta` is the SOT for **per-session runtime fields**. Keyed by the runner's session ID.
- `conversations index` serves URL resolution and pre-S2 rehydration fallback. Keyed by adapter ToolID, which is per-adapter (runner ID for shell, JSONL UUID for pi/claude/codex).

The four stores have orthogonal concerns; the bug class was rehydration paths conflating two of them. Doc clarifies the model and flags ambiguous terminology.

## Tests

`TestRehydrateProjects_PreservesSessionmetaState` is the regression guard for symptom 1 (shell title-degradation). Verified by temporarily disabling the ID-match skip:

```
rehydrate_test.go:72: ExitCode lost: got <nil>, want 42
rehydrate_test.go:75: ExitedAt lost: got "", want "2024-01-01T12:00:00Z"
rehydrate_test.go:78: Status lost: got <nil>
rehydrate_test.go:81: Title clobbered: got "shell", want runtime title
```

`TestRehydrateProjects_PreventsDuplicateForToolBackedAdapter` is the regression guard for symptom 2 (pi/claude duplicates). Verified by temporarily disabling the slug-match skip:

```
rehydrate_test.go:128: want 1 session after rehydrate, got 2 (duplicate ghost not skipped)
```

Two more tests cover the migration fallback (sessionmeta missing, convIndex present) and the orphan-key path (neither store has the key).

## Scope and follow-ups

- No data-format changes. `projects.json.Sessions []string` stays as-is. The single-column **Key** model (slug-or-id) is correct, encoded by the existing `SessionKey` coalesce; the joint `(id, slug)` ref idea was considered and rejected.
- Migration fallback: keep one release; revisit dropping when the rehydrate count log converges to zero across user reports.
- Independent of #193 (scrollback persistence), can land in either order.
