### PR TITLE
fix(web): only report navigation success once project loaded

### DIFF
--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -336,14 +336,12 @@ function App() {
     // e2e/helpers.ts to drive the app from a known session ID, since
     // the post-refactor home page no longer auto-selects.
     //
-    // Returns true if the session was found in the store (and so
-    // navigation was attempted), false if sessions/projects haven't
-    // loaded yet (caller should retry).
+    // Returns true only when navigation was actually dispatched.
+    // Returns false until both the session and its project have
+    // loaded, so callers (and waitForURL) can rely on the URL having
+    // changed once this returns true.
     ;(window as any).__gmuxNavigateToSession = (sessionId: string): boolean => {
-      const sess = sessions.value.find(s => s.id === sessionId)
-      if (!sess) return false
-      navigateToSession(sessionId, true)
-      return true
+      return navigateToSession(sessionId, true)
     }
   }, [loc])
 

--- a/apps/gmux-web/src/store.test.ts
+++ b/apps/gmux-web/src/store.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
-import { sessions, sessionsLoaded, projects, upsertSession, removeSession, markSessionRead, handleActivity, isSessionActive, isSessionFading, activityMap, sessionStaleness, peers, peerAppearance, urlPath, selectedId } from './store'
+import { sessions, sessionsLoaded, projects, upsertSession, removeSession, markSessionRead, handleActivity, isSessionActive, isSessionFading, activityMap, sessionStaleness, peers, peerAppearance, urlPath, selectedId, navigateToSession, setNavigate } from './store'
 import type { Session } from './types'
 import type { ProjectItem } from './types'
 
@@ -280,6 +280,48 @@ describe('sessionStaleness', () => {
       { runner_version: '1.1.0' },
       { version: '1.2.0' },
     )).toBe('version')
+  })
+})
+
+describe('navigateToSession', () => {
+  // The e2e helper (e2e/helpers.ts) polls a test hook that wraps
+  // navigateToSession and treats its return value as "the URL has
+  // changed". If the contract regresses (e.g. someone makes the
+  // function return void again, or fires navigate() without a project
+  // match), the e2e suite goes flaky in CI under SSE-vs-REST races
+  // between sessions and projects. These tests pin that contract.
+  let navigateMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    navigateMock = vi.fn()
+    setNavigate(navigateMock)
+  })
+  afterEach(() => {
+    setNavigate(() => {})
+  })
+
+  it('returns false and does not navigate when the session is unknown', () => {
+    projects.value = [{ slug: 'p', match: [{ path: '/dev/p' }] }]
+    expect(navigateToSession('ghost')).toBe(false)
+    expect(navigateMock).not.toHaveBeenCalled()
+  })
+
+  it('returns false and does not navigate when projects have not loaded', () => {
+    sessions.value = [makeSession({ id: 'sess-1', cwd: '/dev/p' })]
+    // projects.value left empty: simulates the SSE-vs-REST race where
+    // sessions arrive before projects.
+    expect(navigateToSession('sess-1')).toBe(false)
+    expect(navigateMock).not.toHaveBeenCalled()
+  })
+
+  it('returns true and dispatches the project-prefixed URL once both are loaded', () => {
+    projects.value = [{ slug: 'myproject', match: [{ path: '/dev/p' }] }]
+    sessions.value = [makeSession({ id: 'sess-1', cwd: '/dev/p', kind: 'shell' })]
+    expect(navigateToSession('sess-1', true)).toBe(true)
+    expect(navigateMock).toHaveBeenCalledTimes(1)
+    const [url, replace] = navigateMock.mock.calls[0]
+    expect(url).toMatch(/^\/myproject\/shell\//)
+    expect(replace).toBe(true)
   })
 })
 

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -544,12 +544,16 @@ export function navigate(url: string, replace?: boolean) {
 /**
  * Navigate to a session by ID. Finds the matching project and builds
  * the URL. Used by auto-select, resume, and notification handlers.
+ * Returns true when a URL change was actually dispatched, false when
+ * the session or its project hasn't loaded yet.
  */
-export function navigateToSession(sessionId: string, replace?: boolean) {
+export function navigateToSession(sessionId: string, replace?: boolean): boolean {
   const sess = sessions.value.find(s => s.id === sessionId)
-  if (!sess) return
+  if (!sess) return false
   const project = matchSession(sess, projects.value)
-  if (project) navigate(sessionPath(project.slug, sess), replace)
+  if (!project) return false
+  navigate(sessionPath(project.slug, sess), replace)
+  return true
 }
 
 /**

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -97,19 +97,15 @@ export async function gotoTestSession(page: Page): Promise<void> {
   const sessionId = process.env.GMUX_TEST_SESSION_ID
   if (!sessionId) throw new Error('GMUX_TEST_SESSION_ID not set; global-setup did not run')
 
-  // Wait for the store to load sessions/projects, then drive
-  // navigation. The hook returns false until the session appears in
-  // the store.
+  // Drive navigation via the test hook. It returns true only once
+  // the session and its project are both in the store and the URL
+  // change has been dispatched, so by the time this resolves the
+  // app is on the session route.
   await page.waitForFunction((id) => {
     const navigate = (window as any).__gmuxNavigateToSession
     if (typeof navigate !== 'function') return false
     return navigate(id) === true
   }, sessionId, { timeout: 10_000 })
-
-  // Confirm navigation actually changed the URL before waiting for
-  // the terminal. If something redirects us back to /, fail loudly
-  // here. The slug `test-project` is seeded by global-setup.
-  await page.waitForURL(/\/test-project\/shell\//, { timeout: 5_000 })
 
   await page.locator('.xterm').waitFor({ state: 'visible', timeout: 5_000 })
   // Give the WS connection time to establish and replay scrollback.


### PR DESCRIPTION
## What

Fixes the flaky e2e failure on https://github.com/gmuxapp/gmux/actions/runs/25249439275/job/74039120567:

```
TimeoutError: page.waitForURL: Timeout 5000ms exceeded.
  at gotoTestSession (e2e/helpers.ts:112:14)
```

## Why it flaked

`e2e/helpers.ts` drives navigation via the test-only hook
`window.__gmuxNavigateToSession(id)` and waits until it returns
`true`. The hook used to be:

```ts
;(window as any).__gmuxNavigateToSession = (sessionId: string): boolean => {
  const sess = sessions.value.find(s => s.id === sessionId)
  if (!sess) return false
  navigateToSession(sessionId, true)
  return true
}
```

But `navigateToSession` in `store.ts` silently no-ops when the
matching project hasn't loaded yet:

```ts
export function navigateToSession(sessionId: string, replace?: boolean) {
  const sess = sessions.value.find(s => s.id === sessionId)
  if (!sess) return
  const project = matchSession(sess, projects.value)
  if (project) navigate(sessionPath(project.slug, sess), replace) // ← silent no-op
}
```

Sessions and projects are fetched in parallel from REST, so on a
fresh page either can win. When sessions arrived first (likelier
under CI load, and on the second test in the file since that opens
a fresh context), the hook reported success, the URL never changed,
and the helper's `waitForURL` timed out. The first test in the
same file passed because by then projects had been cached.

## Fix

`navigateToSession` now returns whether it actually dispatched a
URL change, and the test hook propagates that. The e2e helper drops
its now-redundant `waitForURL`, with the hook contract as the single
source of truth that the URL has changed by the time
`waitForFunction` resolves. Other callers (`use-presence.ts`,
resume on mount, auto-select) ignore the return value, so they're
unaffected.

## Test

Added a focused unit test in `store.test.ts` to pin the contract
the e2e helper depends on: returns `false` when the session is
unknown, returns `false` when projects haven't loaded, returns
`true` and dispatches the project-prefixed URL once both are in
place. If the contract regresses (return becomes void, or navigate
fires without a project match), CI catches it before the e2e suite
goes flaky again.

## Verification

```
$ E2E_SKIP_BUILD=1 npx playwright test e2e/tests/terminal-connect.spec.ts
  ✓  1 connects to session and renders terminal (2.2s)
  ✓  2 terminal displays session output (1.7s)
  2 passed (5.8s)

$ npx vitest run
  Test Files  13 passed (13)
       Tests  300 passed (300)
```