### PR TITLE
fix(daemon): stop leaking unix-socket FDs in discovery loop

### DIFF
--- a/services/gmuxd/internal/discovery/discovery.go
+++ b/services/gmuxd/internal/discovery/discovery.go
@@ -242,16 +242,7 @@ func Register(sessions *store.Store, subs *Subscriptions, fileMon *FileMonitor, 
 
 // queryMeta connects to a runner's Unix socket and fetches GET /meta.
 func queryMeta(socketPath string) (*store.Session, error) {
-	client := &http.Client{
-		Transport: &http.Transport{
-			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
-				return net.DialTimeout("unix", socketPath, 2*time.Second)
-			},
-		},
-		Timeout: 3 * time.Second,
-	}
-
-	resp, err := client.Get("http://localhost/meta")
+	resp, err := runnerRequest(context.Background(), socketPath, http.MethodGet, "/meta", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -275,19 +266,11 @@ func queryMeta(socketPath string) (*store.Session, error) {
 	return &sess, nil
 }
 
-// KillSession sends POST /kill to a runner's Unix socket, asking it to
-// SIGTERM its child process. The runner's normal exit lifecycle handles the rest.
+// KillSession sends POST /kill to a runner's Unix socket, asking it
+// to SIGTERM its child process. The runner's normal exit lifecycle
+// handles the rest.
 func KillSession(socketPath string) error {
-	client := &http.Client{
-		Transport: &http.Transport{
-			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
-				return net.DialTimeout("unix", socketPath, 2*time.Second)
-			},
-		},
-		Timeout: 3 * time.Second,
-	}
-
-	resp, err := client.Post("http://localhost/kill", "", nil)
+	resp, err := runnerRequest(context.Background(), socketPath, http.MethodPost, "/kill", nil)
 	if err != nil {
 		return err
 	}

--- a/services/gmuxd/internal/discovery/filemon.go
+++ b/services/gmuxd/internal/discovery/filemon.go
@@ -28,7 +28,6 @@ import (
 	"io"
 	"io/fs"
 	"log"
-	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -962,16 +961,8 @@ func fetchScrollbackText(socketPath string) string {
 	if socketPath == "" {
 		return ""
 	}
-	client := &http.Client{
-		Transport: &http.Transport{
-			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
-				return net.DialTimeout("unix", socketPath, 2*time.Second)
-			},
-		},
-		Timeout: 3 * time.Second,
-	}
 
-	resp, err := client.Get("http://localhost/scrollback/text")
+	resp, err := runnerRequest(context.Background(), socketPath, http.MethodGet, "/scrollback/text", nil)
 	if err != nil {
 		return ""
 	}

--- a/services/gmuxd/internal/discovery/filemon_test.go
+++ b/services/gmuxd/internal/discovery/filemon_test.go
@@ -1,6 +1,7 @@
 package discovery
 
 import (
+	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
@@ -1182,5 +1183,40 @@ func TestCodexFullLifecycle(t *testing.T) {
 	sess, _ = s.Get("sess-codex")
 	if sess.Status != nil {
 		t.Fatalf("expected idle after turn_cancelled, got %+v", sess.Status)
+	}
+}
+
+// TestFileMonitor_ScrollbackFetchDoesNotPool is the integration
+// regression for #197 against the production fetchScrollbackText
+// path. It asserts the property that prevents the leak under load:
+// each attribution-tick fetch closes its server-side connection
+// when the response body is closed, instead of leaving the conn
+// idle in a pool that gets orphaned when the session is torn down.
+//
+// If a future change re-introduced connection pooling (e.g., by
+// reverting to a per-session client without proper Close on
+// teardown), the server would observe a non-zero open-conn count
+// after each fetch — the failure mode that exhausted RLIMIT_NOFILE
+// on the production daemon.
+func TestFileMonitor_ScrollbackFetchDoesNotPool(t *testing.T) {
+	srv := startUnixServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("scrollback content"))
+	}))
+	defer srv.cleanup()
+
+	const N = 5
+	for i := 0; i < N; i++ {
+		got := fetchScrollbackText(srv.socketPath)
+		if got != "scrollback content" {
+			t.Fatalf("fetch[%d] = %q, want %q", i, got, "scrollback content")
+		}
+		// Every fetch must close cleanly: req.Close=true means the
+		// server sees the conn drop before the next iteration.
+		// A pooling regression would leave open at 1 (or growing).
+		srv.waitOpen(t, 0)
+	}
+	if got := srv.accepts.Load(); got != N {
+		t.Fatalf("server saw %d accepts, want %d (each fetch must dial a fresh conn)", got, N)
 	}
 }

--- a/services/gmuxd/internal/discovery/runnerhttp.go
+++ b/services/gmuxd/internal/discovery/runnerhttp.go
@@ -26,7 +26,6 @@ import (
 	"io"
 	"net"
 	"net/http"
-	"sync"
 	"time"
 )
 
@@ -35,48 +34,26 @@ import (
 // seconds means the runner is wedged or gone.
 const runnerDialTimeout = 2 * time.Second
 
-// runnerRequestTimeout bounds end-to-end request time. Matches the
+// runnerRequestTimeout bounds end-to-end request time, including
+// connect, redirects, and reading the response body. Matches the
 // historical timeout the per-call clients used.
 const runnerRequestTimeout = 3 * time.Second
-
-// newUnixTransport returns an *http.Transport that dials socketPath
-// for every connection regardless of the request URL's host. The
-// transport is single-use; req.Close on the request guarantees the
-// connection closes with the response, so the transport has no
-// idle pool to manage and is safe to discard.
-func newUnixTransport(socketPath string) *http.Transport {
-	return &http.Transport{
-		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
-			d := net.Dialer{Timeout: runnerDialTimeout}
-			return d.DialContext(ctx, "unix", socketPath)
-		},
-	}
-}
 
 // runnerRequest issues a single HTTP request to the runner at
 // socketPath and returns the response. The request is marked
 // Close=true so the connection closes with the response body
 // rather than being pooled.
 //
+// urlPath is the path portion only (e.g. "/meta"); the host is
+// fixed because the transport dials socketPath unconditionally.
 // The caller is responsible for closing resp.Body. ctx bounds the
-// total request lifetime; the runner timeout (3 s) is nested under
-// it, so a caller with a tighter ctx still wins. body may be nil
-// for parameterless GET / POST.
-//
-// Use any host placeholder in the URL; the transport ignores it.
+// request lifetime; the runner timeout (3 s) is applied via
+// http.Client.Timeout, which composes with a tighter caller ctx
+// (earlier deadline wins) and cancels its internal timer when the
+// body is closed. body may be nil for parameterless GET / POST.
 func runnerRequest(ctx context.Context, socketPath, method, urlPath string, body io.Reader) (*http.Response, error) {
-	// Nest the runner timeout under the caller's context. The
-	// effective deadline is the earlier of the two.
-	// http.NewRequestWithContext panics on a nil ctx, matching
-	// stdlib convention for the programmer-error case.
-	ctx, cancel := context.WithTimeout(ctx, runnerRequestTimeout)
-	// We can't defer cancel: the response body must outlive this
-	// function, and cancel needs to fire when the body is closed
-	// (wired below via cancelOnCloseBody).
-
 	req, err := http.NewRequestWithContext(ctx, method, "http://unix"+urlPath, body)
 	if err != nil {
-		cancel()
 		return nil, err
 	}
 	// Mark the connection for closure after the response. With
@@ -84,30 +61,14 @@ func runnerRequest(ctx context.Context, socketPath, method, urlPath string, body
 	// body is closed, instead of returning it to the idle pool.
 	req.Close = true
 
-	tr := newUnixTransport(socketPath)
-	client := &http.Client{Transport: tr}
-	resp, err := client.Do(req)
-	if err != nil {
-		cancel()
-		return nil, err
+	client := &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				d := net.Dialer{Timeout: runnerDialTimeout}
+				return d.DialContext(ctx, "unix", socketPath)
+			},
+		},
+		Timeout: runnerRequestTimeout,
 	}
-	resp.Body = &cancelOnCloseBody{ReadCloser: resp.Body, cancel: cancel}
-	return resp, nil
-}
-
-// cancelOnCloseBody calls cancel() exactly once when the underlying
-// body is closed, releasing the timeout context's resources.
-// sync.Once gives both idempotency and race-detector safety in case
-// a caller's defer-Close pattern composes with another Close call
-// from a different goroutine.
-type cancelOnCloseBody struct {
-	io.ReadCloser
-	cancel context.CancelFunc
-	once   sync.Once
-}
-
-func (b *cancelOnCloseBody) Close() error {
-	err := b.ReadCloser.Close()
-	b.once.Do(b.cancel)
-	return err
+	return client.Do(req)
 }

--- a/services/gmuxd/internal/discovery/runnerhttp.go
+++ b/services/gmuxd/internal/discovery/runnerhttp.go
@@ -1,6 +1,8 @@
-// Package discovery — runner HTTP-over-unix-socket helper.
+package discovery
+
+// runnerhttp.go — HTTP-over-AF_UNIX helper for talking to runners.
 //
-// gmuxd talks to each runner over a per-session AF_UNIX socket using
+// gmuxd talks to each runner over a per-session Unix socket using
 // HTTP. Every call site here is short: a single request and
 // response, then done. AF_UNIX dials cost ~10 µs of kernel work
 // (no network round-trip to amortize), so connection pooling earns
@@ -13,13 +15,12 @@
 // idle pool, so a per-call transport has nothing to leak when it
 // goes out of scope.
 //
-// This package exists because three call sites previously
-// open-coded the same &http.Transport{DialContext: unix-dial}
-// closure and discarded the transport after each request. Closing
-// the response body returned the connection to the abandoned
-// transport's idle pool instead of closing the FD; on a busy
-// daemon this exhausted RLIMIT_NOFILE within hours. See #197.
-package discovery
+// This file exists because three call sites previously open-coded
+// the same &http.Transport{DialContext: unix-dial} closure and
+// discarded the transport after each request. Closing the response
+// body returned the connection to the abandoned transport's idle
+// pool instead of closing the FD; on a busy daemon this exhausted
+// RLIMIT_NOFILE within hours. See #197.
 
 import (
 	"context"

--- a/services/gmuxd/internal/discovery/runnerhttp.go
+++ b/services/gmuxd/internal/discovery/runnerhttp.go
@@ -1,0 +1,113 @@
+// Package discovery — runner HTTP-over-unix-socket helper.
+//
+// gmuxd talks to each runner over a per-session AF_UNIX socket using
+// HTTP. Every call site here is short: a single request and
+// response, then done. AF_UNIX dials cost ~10 µs of kernel work
+// (no network round-trip to amortize), so connection pooling earns
+// almost nothing while introducing a lifecycle (idle pool, drain,
+// orphan-conn races) that has to be reasoned about and tested.
+//
+// One helper, runnerRequest. Each call dials, requests, closes.
+// req.Close = true tells the transport to close the underlying FD
+// when the response body is closed instead of returning it to the
+// idle pool, so a per-call transport has nothing to leak when it
+// goes out of scope.
+//
+// This package exists because three call sites previously
+// open-coded the same &http.Transport{DialContext: unix-dial}
+// closure and discarded the transport after each request. Closing
+// the response body returned the connection to the abandoned
+// transport's idle pool instead of closing the FD; on a busy
+// daemon this exhausted RLIMIT_NOFILE within hours. See #197.
+package discovery
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// runnerDialTimeout bounds the time spent connecting to a runner's
+// Unix socket. The socket is local, so any wait beyond a couple of
+// seconds means the runner is wedged or gone.
+const runnerDialTimeout = 2 * time.Second
+
+// runnerRequestTimeout bounds end-to-end request time. Matches the
+// historical timeout the per-call clients used.
+const runnerRequestTimeout = 3 * time.Second
+
+// newUnixTransport returns an *http.Transport that dials socketPath
+// for every connection regardless of the request URL's host. The
+// transport is single-use; req.Close on the request guarantees the
+// connection closes with the response, so the transport has no
+// idle pool to manage and is safe to discard.
+func newUnixTransport(socketPath string) *http.Transport {
+	return &http.Transport{
+		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			d := net.Dialer{Timeout: runnerDialTimeout}
+			return d.DialContext(ctx, "unix", socketPath)
+		},
+	}
+}
+
+// runnerRequest issues a single HTTP request to the runner at
+// socketPath and returns the response. The request is marked
+// Close=true so the connection closes with the response body
+// rather than being pooled.
+//
+// The caller is responsible for closing resp.Body. ctx bounds the
+// total request lifetime; the runner timeout (3 s) is nested under
+// it, so a caller with a tighter ctx still wins. body may be nil
+// for parameterless GET / POST.
+//
+// Use any host placeholder in the URL; the transport ignores it.
+func runnerRequest(ctx context.Context, socketPath, method, urlPath string, body io.Reader) (*http.Response, error) {
+	// Nest the runner timeout under the caller's context. The
+	// effective deadline is the earlier of the two.
+	// http.NewRequestWithContext panics on a nil ctx, matching
+	// stdlib convention for the programmer-error case.
+	ctx, cancel := context.WithTimeout(ctx, runnerRequestTimeout)
+	// We can't defer cancel: the response body must outlive this
+	// function, and cancel needs to fire when the body is closed
+	// (wired below via cancelOnCloseBody).
+
+	req, err := http.NewRequestWithContext(ctx, method, "http://unix"+urlPath, body)
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+	// Mark the connection for closure after the response. With
+	// this set, the transport closes the underlying FD when the
+	// body is closed, instead of returning it to the idle pool.
+	req.Close = true
+
+	tr := newUnixTransport(socketPath)
+	client := &http.Client{Transport: tr}
+	resp, err := client.Do(req)
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+	resp.Body = &cancelOnCloseBody{ReadCloser: resp.Body, cancel: cancel}
+	return resp, nil
+}
+
+// cancelOnCloseBody calls cancel() exactly once when the underlying
+// body is closed, releasing the timeout context's resources.
+// sync.Once gives both idempotency and race-detector safety in case
+// a caller's defer-Close pattern composes with another Close call
+// from a different goroutine.
+type cancelOnCloseBody struct {
+	io.ReadCloser
+	cancel context.CancelFunc
+	once   sync.Once
+}
+
+func (b *cancelOnCloseBody) Close() error {
+	err := b.ReadCloser.Close()
+	b.once.Do(b.cancel)
+	return err
+}

--- a/services/gmuxd/internal/discovery/runnerhttp_test.go
+++ b/services/gmuxd/internal/discovery/runnerhttp_test.go
@@ -1,0 +1,158 @@
+package discovery
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// unixServer wraps an HTTP server on a Unix socket and exposes
+// counters for accepted connections and currently-open connections.
+// `open` lets tests assert that the server saw a clean close (req
+// completed and the connection went away), distinguishing
+// req.Close=true from a pooled-but-discarded conn.
+type unixServer struct {
+	socketPath string
+	accepts    atomic.Int64
+	open       atomic.Int64 // currently-open server-side conns
+	cleanup    func()
+}
+
+func startUnixServer(t *testing.T, h http.Handler) *unixServer {
+	t.Helper()
+	s := &unixServer{socketPath: filepath.Join(t.TempDir(), "test.sock")}
+	ln, err := net.Listen("unix", s.socketPath)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	srv := &http.Server{
+		Handler: h,
+		ConnState: func(_ net.Conn, st http.ConnState) {
+			switch st {
+			case http.StateNew:
+				s.open.Add(1)
+			case http.StateClosed, http.StateHijacked:
+				s.open.Add(-1)
+			}
+		},
+	}
+	counted := &countingListener{Listener: ln, accepts: &s.accepts}
+	done := make(chan struct{})
+	go func() {
+		_ = srv.Serve(counted)
+		close(done)
+	}()
+	s.cleanup = func() {
+		_ = srv.Close()
+		<-done
+	}
+	return s
+}
+
+// waitOpen polls until the server-side open-conn count matches want
+// or the test deadline elapses. Conn-state transitions are async on
+// the server's goroutines, so a tiny settle is needed after the
+// client closes a response body.
+func (s *unixServer) waitOpen(t *testing.T, want int64) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if s.open.Load() == want {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("open conns = %d, want %d (timed out)", s.open.Load(), want)
+}
+
+type countingListener struct {
+	net.Listener
+	accepts *atomic.Int64
+}
+
+func (l *countingListener) Accept() (net.Conn, error) {
+	c, err := l.Listener.Accept()
+	if err == nil {
+		l.accepts.Add(1)
+	}
+	return c, err
+}
+
+// TestRunnerRequest_ClosesConnectionAfterResponse is the central
+// regression for issue #197. It verifies that runnerRequest causes
+// the server to see a clean connection close after each request:
+// req.Close=true means the underlying FD is released when the
+// caller closes the response body, not pooled in an abandoned
+// transport that GC may take ages to reach.
+//
+// If req.Close were dropped, the conn would be pooled in the
+// per-call transport. The server keeps it in StateIdle until its
+// own keep-alive timeout, so this test would observe a non-zero
+// open count after each iteration.
+func TestRunnerRequest_ClosesConnectionAfterResponse(t *testing.T) {
+	var requests atomic.Int64
+	s := startUnixServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer s.cleanup()
+
+	const N = 5
+	for i := 0; i < N; i++ {
+		resp, err := runnerRequest(context.Background(), s.socketPath, http.MethodGet, "/probe", nil)
+		if err != nil {
+			t.Fatalf("runnerRequest[%d]: %v", i, err)
+		}
+		_ = resp.Body.Close()
+		// After closing the body, req.Close=true must have caused
+		// the conn to close on the server side. If the conn were
+		// pooled (idle), open would stay at 1.
+		s.waitOpen(t, 0)
+	}
+
+	if got := requests.Load(); got != N {
+		t.Fatalf("server saw %d requests, want %d", got, N)
+	}
+	if got := s.accepts.Load(); got != N {
+		t.Fatalf("server saw %d accepts, want %d (each call must dial a new conn)", got, N)
+	}
+}
+
+// TestRunnerRequest_HonorsCallerContext verifies that a caller's
+// context cancellation propagates into the in-flight request and
+// short-circuits the runner-side timeout. This matters because the
+// helper nests its own 3-second timeout under the caller's ctx; if
+// the nesting were inverted (or the wrong ctx used), a cancelled
+// caller would still wait the full 3 s.
+func TestRunnerRequest_HonorsCallerContext(t *testing.T) {
+	// Server hangs forever so the only way out is ctx cancellation.
+	hang := make(chan struct{})
+	defer close(hang)
+	s := startUnixServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-hang
+	}))
+	defer s.cleanup()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	_, err := runnerRequest(ctx, s.socketPath, http.MethodGet, "/hang", nil)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected error from cancelled request, got nil")
+	}
+	// The 3-second runner timeout would otherwise dominate. Any
+	// elapsed time well under that proves the caller's ctx won.
+	if elapsed > time.Second {
+		t.Fatalf("request took %v; expected <1s (caller ctx must short-circuit runner timeout)", elapsed)
+	}
+}

--- a/services/gmuxd/internal/discovery/runnerhttp_test.go
+++ b/services/gmuxd/internal/discovery/runnerhttp_test.go
@@ -124,10 +124,11 @@ func TestRunnerRequest_ClosesConnectionAfterResponse(t *testing.T) {
 
 // TestRunnerRequest_HonorsCallerContext verifies that a caller's
 // context cancellation propagates into the in-flight request and
-// short-circuits the runner-side timeout. This matters because the
-// helper nests its own 3-second timeout under the caller's ctx; if
-// the nesting were inverted (or the wrong ctx used), a cancelled
-// caller would still wait the full 3 s.
+// short-circuits the runner-side timeout. The helper composes the
+// caller's ctx with http.Client.Timeout, so the earlier deadline
+// must win; if ctx weren't threaded through (e.g., a future
+// regression that drops NewRequestWithContext), a cancelled caller
+// would still wait the full 3 s for Client.Timeout.
 func TestRunnerRequest_HonorsCallerContext(t *testing.T) {
 	// Server hangs forever so the only way out is ctx cancellation.
 	hang := make(chan struct{})


### PR DESCRIPTION
Implements the fix described in #197.

## Cause

Three call sites in `services/gmuxd/internal/discovery/` (`queryMeta`, `KillSession`, `fetchScrollbackText`) each constructed a fresh `&http.Transport{DialContext: unix-dial}` per call. `defer resp.Body.Close()` returned the connection to the **transport's own** idle pool instead of closing the FD. The transport then went out of scope; with no remaining reference, `IdleConnTimeout` never reaped, and the FD sat there until GC finalized the conn. On a busy daemon this happened faster than GC kept up: the affected box was sitting at 40960/40960 FDs (~99% sockets to runners) within hours of starting.

## Fix

A single helper `runnerRequest` in a new `runnerhttp.go` replaces all three open-coded closures. Every call dials, requests, closes — `req.Close = true` tells the transport to close the underlying FD with the response body rather than pool it. Caller-provided `ctx` is threaded via `NewRequestWithContext`; the runner-side 3 s ceiling is applied via `http.Client.Timeout`, which composes with the caller's ctx (earlier deadline wins) and cleans up its internal timer when the body is closed.

I considered a per-session pooled `*http.Client` for the hot-path scrollback fetch (`fetchScrollbackText` runs every ~3 s × N sessions). That design was actually shipped in earlier revisions of this PR. It worked, but the keep-alive optimization it bought is amortizing TCP round-trip time, which doesn't exist on AF_UNIX (~10 µs of kernel work per dial). The lifecycle the per-session client introduced — `Close` on session death, idempotency drain on re-registration, `IdleConnTimeout` to bound an orphan-conn race window — was paying real complexity for a benefit that didn't exist on this transport. Once-everywhere makes both race windows impossible by construction.

The reasoning trail is in the PR conversation; the commits reflect the destination, not the journey.

## Commits

1. **`fix(daemon): stop leaking unix-socket FDs in discovery loop`** — the fix itself: `runnerRequest` helper + the three call-site migrations + tests.
2. **`refactor(daemon): defer to http.Client.Timeout instead of hand-rolled body wrapper`** — drops a `cancelOnCloseBody` body wrapper and a manual `WithTimeout` dance once I noticed `http.Client.Timeout` already does both for free (composes with the request's ctx, cancels its internal timer when the body is closed). ~40 fewer lines and one less local concept.
3. **`docs(daemon): demote runnerhttp.go's package doc to a file comment`** — `discovery.go` already carries the canonical `Package discovery` doc; demote this file's commentary so godoc's package overview doesn't read as two unrelated paragraphs.

## Tests

`runnerhttp_test.go` (new):
- `TestRunnerRequest_ClosesConnectionAfterResponse` is the central regression for #197. Tracks server-side `ConnState` transitions and asserts each request reaches `StateClosed` (open count returns to 0) after the caller closes the body. Verified to fail when `req.Close = true` is removed.
- `TestRunnerRequest_HonorsCallerContext` asserts a caller's ctx cancellation short-circuits the runner-side 3 s timeout. Verified to fail (3.01 s elapsed) when `NewRequestWithContext` is replaced with `NewRequest`.

`filemon_test.go` (extended):
- `TestFileMonitor_ScrollbackFetchDoesNotPool` drives the production `fetchScrollbackText` path against a real Unix socket and asserts the same clean-close property end-to-end.

All discovery tests pass under `-race -count=5`.

## Verification on the affected box

After deploying, `ss -xp | grep gmuxd | wc -l` should remain proportional to the number of live sessions (one SSE conn per session) plus a small one-shot working set, not climb monotonically with uptime. The running daemon needs a restart to drop its existing leaked sockets; the fix is preventative, not retroactive.

Fixes #197.