### PR TITLE
ci(release): build PRs at head sha and surface commit info in the install comment

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -26,7 +26,43 @@ jobs:
     env:
       PR: ${{ inputs.pr_number || github.event.number }}
     steps:
+      # Resolve the PR head SHA explicitly so checkout pins to a commit
+      # a user can browse, not the synthetic refs/pull/N/merge ref that
+      # github computes for pull_request events. With rebase-merge as the
+      # project's merge policy, the head SHA is what lands on main, so
+      # the artifact's embedded version matches what'll be released.
+      - name: Resolve PR head
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -eu
+          sha=$(gh api "repos/${{ github.repository }}/pulls/${PR}" --jq .head.sha)
+          echo "sha=${sha}" >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ steps.pr.outputs.sha }}
+          # Full history so goreleaser's snapshot version_template can
+          # call git-describe and produce e.g. 1.5.1-snapshot-<short>
+          # instead of falling back to 0.0.0-snapshot-<short>.
+          fetch-depth: 0
+
+      - name: Capture build commit info
+        id: commit
+        run: |
+          set -eu
+          short=$(git rev-parse --short=7 HEAD)
+          # Subject only (no body) so the install comment stays one line.
+          # Truncate with an ellipsis at 100 chars to avoid runaway titles.
+          subject=$(git log -1 --format='%s' HEAD)
+          if [ ${#subject} -gt 100 ]; then
+            subject="${subject:0:97}…"
+          fi
+          {
+            echo "short=${short}"
+            echo "subject=${subject}"
+          } >> "$GITHUB_OUTPUT"
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
@@ -60,12 +96,16 @@ jobs:
         continue-on-error: true # read-only token on fork PRs
         env:
           GH_TOKEN: ${{ github.token }}
+          HEAD_SHORT: ${{ steps.commit.outputs.short }}
+          HEAD_SUBJECT: ${{ steps.commit.outputs.subject }}
         run: |
+          set -eu
           body="<!-- gmux-pr-build -->
           ### Try this PR
           \`\`\`sh
           curl -sSfL https://gmux.app/install-pr.sh | sh -s -- ${PR}
           \`\`\`
+          Built from [\`${HEAD_SHORT}\`](https://github.com/${{ github.repository }}/pull/${PR}/commits/${HEAD_SHORT}) — ${HEAD_SUBJECT}
           <sub>Requires [GitHub CLI](https://cli.github.com/) with auth. Artifacts expire after 7 days.</sub>"
 
           # Update existing comment or create a new one

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,15 @@
 version: 2
 
+# Snapshot builds (PRs, local dev) get a version that is traceable to a
+# real commit on the source branch. Format: <next-patch>-snapshot-<short>.
+# With fetch-depth: 0 in CI, .Version is git-describe-derived (e.g. 1.5.0)
+# so incpatch yields 1.5.1; without tags it falls back to 0.0.0.
+# .ShortCommit reflects whatever ref was checked out — pr-build.yml pins
+# this to the PR head SHA so the version maps directly to a commit a user
+# can browse.
+snapshot:
+  version_template: '{{ incpatch .Version }}-snapshot-{{ .ShortCommit }}'
+
 before:
   hooks:
     # VERSION must be passed explicitly: vite reads it from process.env


### PR DESCRIPTION
## Problem

Two issues with the current PR build pipeline that surfaced while testing #194:

1. **Version stamps point at unbrowsable SHAs.** Binaries built for PRs report a version like `0.0.0-SNAPSHOT-73c9cab`. The hash is the synthetic `refs/pull/N/merge` SHA that GitHub computes — not on any branch, not in `git log`, not on the PR's commit list. Users can't tell which version of a PR they have installed.

2. **The install comment doesn't say what's actually in the build.** When you re-push to a PR while a previous build is still uploading, you can `curl | sh` and silently get the older artifact. Without commit info in the comment, you only learn this after install when you read the version string and have to dig to figure out where it came from.

## Fix

### `.goreleaser.yml`: explicit snapshot template

```yaml
snapshot:
  version_template: '{{ incpatch .Version }}-snapshot-{{ .ShortCommit }}'
```

Format becomes `<next-patch>-snapshot-<short>`, e.g. `1.5.1-snapshot-7d9e1ef8`. Verified locally with `goreleaser release --snapshot`:

```
• building snapshot...                           version=1.4.1-snapshot-dc451798
• archiving                                      name=dist/gmux_1.4.1-snapshot-dc451798_linux_amd64.tar.gz
```

The short SHA is `.ShortCommit` of whatever ref was checked out, which (after the workflow change below) is the PR head — a real commit a user can browse.

### `.github/workflows/pr-build.yml`: pin checkout to PR head

Two coupled changes:

- A new `Resolve PR head` step queries the GitHub API for `pulls/${PR}.head.sha` and exposes it as a step output. Works for both `pull_request` events and the `workflow_dispatch` rebuild path used by release PRs.
- `actions/checkout` now passes `ref: ${{ steps.pr.outputs.sha }}` and `fetch-depth: 0`. The first makes the checked-out HEAD a real commit (matching what'll land on `main` under rebase-merge, per AGENTS.md); the second gives goreleaser visibility into tags so `incpatch .Version` doesn't fall back to `0.0.1`.

Other workflows (`ci.yml`, `pages.yml`) intentionally keep the default merge-commit behavior — they test the integration, not the artifact's identity.

### Install comment now includes commit info

```
### Try this PR
```sh
curl -sSfL https://gmux.app/install-pr.sh | sh -s -- 194
```
Built from [`7d9e1ef`](https://github.com/gmuxapp/gmux/pull/194/commits/7d9e1ef) — fix(daemon): preserve session state and prevent duplicates across restart
```

The short SHA links to the commit's PR-context view. The subject is taken from `git log -1 --format='%s' HEAD`, truncated to 100 chars with `…` if longer (so a runaway commit message doesn't blow up the comment line).

## Scope

- Only changes `pr-build.yml` and `.goreleaser.yml`. CI (`ci.yml`), release (`release.yml`), and pages workflows untouched.
- No code changes; no tests; the change manifests on the next PR build to fire.
- Hidden from the user-facing changelog per the `release` scope convention in AGENTS.md.

## Self-test

Local `goreleaser release --snapshot --clean` confirms:

- Tarball: `gmux_1.4.1-snapshot-dc451798_linux_amd64.tar.gz`
- Binary embeds: `1.4.1-snapshot-dc451798` (verified via `strings dist/.../gmuxd | grep snapshot`)

The workflow's gh-API-then-checkout-by-sha pattern is the same shape used by GoReleaser's own [official examples](https://goreleaser.com/ci/actions/) for PR builds, so no surprises there.
