### PR TITLE
refactor(adapter): introduce SessionRegistrar and SessionFinalizer lifecycle hooks

### DIFF
--- a/packages/adapter/adapters/shell.go
+++ b/packages/adapter/adapters/shell.go
@@ -29,11 +29,24 @@ func AllAdapters() []adapter.Adapter {
 	return result
 }
 
+// FindByKind returns the adapter with the given name, or nil if not found.
+// Includes the shell fallback adapter.
+func FindByKind(kind string) adapter.Adapter {
+	for _, a := range AllAdapters() {
+		if a.Name() == kind {
+			return a
+		}
+	}
+	return nil
+}
+
 // Compile-time interface checks.
 var (
-	_ adapter.SessionFiler = (*Shell)(nil)
-	_ adapter.Resumer      = (*Shell)(nil)
-	_ adapter.CommandTitler = (*Shell)(nil)
+	_ adapter.SessionFiler    = (*Shell)(nil)
+	_ adapter.Resumer         = (*Shell)(nil)
+	_ adapter.CommandTitler   = (*Shell)(nil)
+	_ adapter.SessionRegistrar = (*Shell)(nil)
+	_ adapter.SessionFinalizer = (*Shell)(nil)
 )
 
 // Shell is the fallback adapter. It matches all commands and parses
@@ -148,9 +161,32 @@ func (g *Shell) CanResume(path string) bool {
 	return err == nil
 }
 
-// WriteStateFile creates a shell state file for a session. Called by gmuxd
-// when a shell session is first discovered (on register). The file allows
-// the session scanner to rediscover the session after a gmuxd restart.
+// --- SessionRegistrar ---
+
+// OnRegister writes a shell state file so gmuxd can rediscover the session
+// after a restart, and returns the initial slug derived from the cwd.
+func (g *Shell) OnRegister(id, cwd string, command []string) (adapter.RegistrationInfo, error) {
+	_, err := WriteShellStateFile(id, cwd, command)
+	if err != nil {
+		return adapter.RegistrationInfo{}, err
+	}
+	slug := adapter.Slugify(filepath.Base(paths.NormalizePath(cwd)))
+	if slug == "" {
+		slug = "shell"
+	}
+	return adapter.RegistrationInfo{Slug: slug}, nil
+}
+
+// --- SessionFinalizer ---
+
+// OnDismiss removes the shell state file when a session is dismissed.
+func (g *Shell) OnDismiss(id, cwd string) {
+	RemoveShellStateFile(id, cwd)
+}
+
+// WriteShellStateFile creates a shell state file for a session. Called by
+// OnRegister. The file allows the session scanner to rediscover the session
+// after a gmuxd restart.
 func WriteShellStateFile(sessionID, cwd string, command []string) (string, error) {
 	sh := NewShell()
 	dir := sh.SessionDir(cwd)

--- a/packages/adapter/adapters/shell_test.go
+++ b/packages/adapter/adapters/shell_test.go
@@ -19,6 +19,12 @@ func TestShellImplementsInterfaces(t *testing.T) {
 	if _, ok := s.(adapter.CommandTitler); !ok {
 		t.Fatal("Shell should implement CommandTitler")
 	}
+	if _, ok := s.(adapter.SessionRegistrar); !ok {
+		t.Fatal("Shell should implement SessionRegistrar")
+	}
+	if _, ok := s.(adapter.SessionFinalizer); !ok {
+		t.Fatal("Shell should implement SessionFinalizer")
+	}
 }
 
 func TestShellWriteAndParseStateFile(t *testing.T) {
@@ -133,5 +139,65 @@ func TestAllAdaptersIncludesShell(t *testing.T) {
 	}
 	if !found {
 		t.Error("AllAdapters() should include the shell adapter")
+	}
+}
+
+func TestFindByKind(t *testing.T) {
+	// Shell is the fallback — not in All — so FindByKind is the only way
+	// to look it up by name without a match call.
+	shell := FindByKind("shell")
+	if shell == nil {
+		t.Fatal("FindByKind(\"shell\") returned nil")
+	}
+	if shell.Name() != "shell" {
+		t.Errorf("got adapter name %q, want \"shell\"", shell.Name())
+	}
+
+	// Unknown kind should return nil.
+	if got := FindByKind("nonexistent"); got != nil {
+		t.Errorf("FindByKind(\"nonexistent\") = %v, want nil", got)
+	}
+}
+
+func TestShellOnRegister(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", tmp)
+
+	sh := NewShell()
+	info, err := sh.OnRegister("sess-reg1", "/home/user/dev/myproject", []string{"bash"})
+	if err != nil {
+		t.Fatalf("OnRegister: %v", err)
+	}
+
+	// State file should exist so the session can be rediscovered after restart.
+	statePath := filepath.Join(sh.SessionDir("/home/user/dev/myproject"), "sess-reg1.json")
+	if _, err := os.Stat(statePath); err != nil {
+		t.Fatalf("state file not created at %s: %v", statePath, err)
+	}
+
+	// Slug should be derived from the cwd basename.
+	if info.Slug != "myproject" {
+		t.Errorf("Slug = %q, want \"myproject\"", info.Slug)
+	}
+}
+
+func TestShellOnDismiss(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", tmp)
+
+	sh := NewShell()
+	// Register creates the state file.
+	if _, err := sh.OnRegister("sess-dis1", "/home/user/dev/proj", []string{"zsh"}); err != nil {
+		t.Fatalf("OnRegister: %v", err)
+	}
+	statePath := filepath.Join(sh.SessionDir("/home/user/dev/proj"), "sess-dis1.json")
+	if _, err := os.Stat(statePath); err != nil {
+		t.Fatalf("state file should exist before dismiss: %v", err)
+	}
+
+	// Dismiss removes it.
+	sh.OnDismiss("sess-dis1", "/home/user/dev/proj")
+	if _, err := os.Stat(statePath); !os.IsNotExist(err) {
+		t.Error("state file should be gone after OnDismiss")
 	}
 }

--- a/packages/adapter/capabilities.go
+++ b/packages/adapter/capabilities.go
@@ -104,6 +104,27 @@ type CommandTitler interface {
 	CommandTitle(command []string) string
 }
 
+// RegistrationInfo holds initial session metadata returned by SessionRegistrar.
+type RegistrationInfo struct {
+	// Slug is the human-readable session identifier to assign at registration.
+	// Empty means the daemon should derive one itself.
+	Slug string
+}
+
+// SessionRegistrar is optionally implemented by adapters that need to perform
+// work when gmuxd registers a new session (e.g. writing a state file for
+// restart recovery). Returns initial metadata like the session slug.
+// A non-nil error is logged by gmuxd but does not abort registration.
+type SessionRegistrar interface {
+	OnRegister(id, cwd string, command []string) (RegistrationInfo, error)
+}
+
+// SessionFinalizer is optionally implemented by adapters that need cleanup
+// when a session is dismissed from gmuxd (e.g. removing a state file).
+type SessionFinalizer interface {
+	OnDismiss(id, cwd string)
+}
+
 // Resumer is implemented by adapters whose sessions can be resumed
 // after the process exits.
 type Resumer interface {

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -1291,9 +1291,11 @@ func serve(stderr io.Writer) int {
 					log.Printf("dismiss: %s: runner kill failed: %v", sessionID, err)
 				}
 			}
-			// Clean up shell state file before removing from store.
-			if sess.Kind == "shell" {
-				adapters.RemoveShellStateFile(sessionID, projects.NormalizePath(sess.Cwd))
+			// Let the adapter perform any cleanup (e.g. removing a state file).
+			if a := adapters.FindByKind(sess.Kind); a != nil {
+				if fin, ok := a.(adapter.SessionFinalizer); ok {
+					fin.OnDismiss(sessionID, projects.NormalizePath(sess.Cwd))
+				}
 			}
 			// Remove session from its project's sessions array.
 			projectMgr.DismissSession(sessionID, sess.Slug)

--- a/services/gmuxd/internal/discovery/discovery.go
+++ b/services/gmuxd/internal/discovery/discovery.go
@@ -210,18 +210,17 @@ func Register(sessions *store.Store, subs *Subscriptions, fileMon *FileMonitor, 
 		}
 	}
 
-	// Write shell state file so the session scanner can rediscover
-	// shell sessions after a gmuxd restart.
-	if newSess.Kind == "shell" {
-		path, err := adapters.WriteShellStateFile(newSess.ID, newSess.Cwd, newSess.Command)
-		if err != nil {
-			log.Printf("register: failed to write shell state file for %s: %v", newSess.ID, err)
-		} else {
-			newSess.Slug = adapter.Slugify(filepath.Base(newSess.Cwd))
-			if newSess.Slug == "" {
-				newSess.Slug = "shell"
+	// Let the adapter perform any registration work (e.g. writing a
+	// state file for restart recovery) and provide initial metadata.
+	if a := adapters.FindByKind(newSess.Kind); a != nil {
+		if reg, ok := a.(adapter.SessionRegistrar); ok {
+			info, err := reg.OnRegister(newSess.ID, newSess.Cwd, newSess.Command)
+			if err != nil {
+				log.Printf("register: %s adapter OnRegister failed for %s: %v", newSess.Kind, newSess.ID, err)
+			} else if info.Slug != "" {
+				newSess.Slug = info.Slug
+				log.Printf("register: %s registered session %s (slug=%s)", newSess.Kind, newSess.ID, info.Slug)
 			}
-			log.Printf("register: wrote shell state file %s", path)
 		}
 	}
 

--- a/services/gmuxd/internal/discovery/filemon.go
+++ b/services/gmuxd/internal/discovery/filemon.go
@@ -986,6 +986,10 @@ func isUnderRoot(dir, root string) bool {
 
 // --- Adapter/file helpers ---
 
+// findAdapter looks up an adapter by kind among the non-fallback adapters
+// (i.e. all adapters except shell). This is intentional: shell sessions do
+// not use the file-monitoring pipeline (shell has no FileMonitor). Use
+// adapters.FindByKind when the shell fallback must be included.
 func findAdapter(kind string) adapter.Adapter {
 	for _, a := range adapters.All {
 		if a.Name() == kind {


### PR DESCRIPTION
Closes #187 (partial — first commit of a two-part change)

## What

Removes the two `if kind == "shell"` hardcodes from the daemon by introducing two new optional adapter interfaces:

- **`SessionRegistrar.OnRegister(id, cwd, command) (RegistrationInfo, error)`** — called when gmuxd registers a new session. Returns initial metadata (currently just `Slug`). Errors are logged but don't abort registration.
- **`SessionFinalizer.OnDismiss(id, cwd)`** — called when a session is dismissed. For cleanup.

`Shell` implements both. `OnRegister` writes the state file (for restart recovery) and derives the slug from the cwd basename. `OnDismiss` removes the state file.

Also adds `adapters.FindByKind` — a package-level lookup by adapter name that includes the shell fallback, unlike the internal `findAdapter` in filemon which intentionally excludes shell from the file-monitoring pipeline (documented with a comment).

## Why

All shell-specific lifecycle logic now lives in `shell.go`. The daemon dispatches through the interface without knowing anything about what the adapter does. Any future adapter that needs registration/cleanup work can opt in by implementing these interfaces.

## Tests

- `TestShellOnRegister`: verifies state file creation and slug derivation via the interface
- `TestShellOnDismiss`: verifies state file removal via the interface
- `TestFindByKind`: verifies shell fallback is found (shell is not in `adapters.All`)
- Updated `TestShellImplementsInterfaces` to assert the two new interfaces