### PR TITLE
fix(web): preserve scroll distance from bottom across pi end-of-turn redraws

### DIFF
--- a/apps/gmux-web/src/replay.ts
+++ b/apps/gmux-web/src/replay.ts
@@ -19,6 +19,17 @@ export const BSU = new Uint8Array([0x1b, 0x5b, 0x3f, 0x32, 0x30, 0x32, 0x36, 0x6
 /** End Synchronized Update: CSI ? 2026 l */
 export const ESU = new Uint8Array([0x1b, 0x5b, 0x3f, 0x32, 0x30, 0x32, 0x36, 0x6c])
 
+/**
+ * Erase Saved Lines (clear scrollback): CSI 3 J.
+ *
+ * Resets xterm's `ybase` and `ydisp` to 0 mid-frame, breaking the
+ * line-tracking invariant that the BSU/ESU restore path relies on. Its
+ * presence inside a synchronized-output block is the signal to fall back
+ * to distance-from-bottom restoration instead of trusting the post-parse
+ * `viewportY`. Pi emits this as part of its end-of-turn redraw shape.
+ */
+export const CSI_3J = new Uint8Array([0x1b, 0x5b, 0x33, 0x4a])
+
 export type FlushCallback = (chunks: Uint8Array[]) => void
 
 export type ReplayState = 'waiting' | 'buffering' | 'done'

--- a/apps/gmux-web/src/terminal-io.test.ts
+++ b/apps/gmux-web/src/terminal-io.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import { createTerminalIO, type ScrollAccessor } from './terminal-io'
-import { BSU, ESU } from './replay'
+import { BSU, CSI_3J, ESU } from './replay'
 
 function makeHarness() {
   const writes: Array<string> = []
@@ -214,6 +214,18 @@ function wrapBSU(payload: string): Uint8Array {
   return result
 }
 
+/** Wrap payload in BSU + \x1b[3J + ESU markers (pi-style redraw). */
+function wrapBSUWithClear(payload: string): Uint8Array {
+  const payloadBytes = enc(payload)
+  const result = new Uint8Array(BSU.length + CSI_3J.length + payloadBytes.length + ESU.length)
+  let offset = 0
+  result.set(BSU, offset); offset += BSU.length
+  result.set(CSI_3J, offset); offset += CSI_3J.length
+  result.set(payloadBytes, offset); offset += payloadBytes.length
+  result.set(ESU, offset)
+  return result
+}
+
 describe('createTerminalIO', () => {
   it('serializes writes one at a time', () => {
     const h = makeHarness()
@@ -417,7 +429,7 @@ describe('scroll preservation across BSU/ESU', () => {
     h.userScrollTo(197)        // 3 lines above the bottom
     expect(h.baseY - h.viewportY).toBe(3)
 
-    h.io.enqueue(wrapBSU('redraw'), 1)
+    h.io.enqueue(wrapBSUWithClear('redraw'), 1)
     h.clearScrollback()
     h.addLines(15)             // new baseY=15, plenty of room for distance=3
     h.flushOne(0)
@@ -441,7 +453,7 @@ describe('scroll preservation across BSU/ESU', () => {
     h.userScrollTo(100)        // 100 lines above the bottom
     expect(h.baseY - h.viewportY).toBe(100)
 
-    h.io.enqueue(wrapBSU('redraw'), 1)
+    h.io.enqueue(wrapBSUWithClear('redraw'), 1)
     h.clearScrollback()
     h.addLines(15)             // new baseY=15, distance(100) > baseY
     h.flushOne(0)
@@ -485,7 +497,7 @@ describe('scroll preservation across BSU/ESU', () => {
     h.setLine(150, 'ERROR: cannot find foo')
     expect(h.baseY - h.viewportY).toBe(50)
 
-    h.io.enqueue(wrapBSU('redraw'), 1)
+    h.io.enqueue(wrapBSUWithClear('redraw'), 1)
     h.clearScrollback()
     h.addLines(80)
     // Same line lands at a different y after the redraw.
@@ -513,7 +525,7 @@ describe('scroll preservation across BSU/ESU', () => {
     h.setLine(45, 'session ready')
     expect(h.baseY - h.viewportY).toBe(5)
 
-    h.io.enqueue(wrapBSU('redraw'), 1)
+    h.io.enqueue(wrapBSUWithClear('redraw'), 1)
     h.clearScrollback()
     h.addLines(20)             // new baseY=20
     h.setLine(12, 'session ready')  // distance: 8, |8-5|=3
@@ -541,7 +553,7 @@ describe('scroll preservation across BSU/ESU', () => {
     // Deliberately NOT calling setLine: getLine returns null (the
     // production accessor's filter for trivial lines).
 
-    h.io.enqueue(wrapBSU('redraw'), 1)
+    h.io.enqueue(wrapBSUWithClear('redraw'), 1)
     h.clearScrollback()
     h.addLines(20)             // new baseY=20
     h.setLine(17, 'unrelated content')  // present but won't match anything
@@ -580,7 +592,7 @@ describe('scroll preservation across BSU/ESU', () => {
     h.setLine(45, 'streaming-target')
     expect(h.baseY - h.viewportY).toBe(5)
 
-    h.io.enqueue(wrapBSU('redraw'), 1)
+    h.io.enqueue(wrapBSUWithClear('redraw'), 1)
     h.clearScrollback()
     h.addLines(5)              // new baseY=5; total = baseY+rows = 45
     h.setLine(20, 'streaming-target')  // y=20 in visible region [5, 44]
@@ -612,7 +624,7 @@ describe('scroll preservation across BSU/ESU', () => {
     h.setLine(49, 'shared-line')
     expect(h.baseY - h.viewportY).toBe(1)
 
-    h.io.enqueue(wrapBSU('redraw'), 1)
+    h.io.enqueue(wrapBSUWithClear('redraw'), 1)
     h.clearScrollback()
     h.addLines(15)             // new baseY=15; visible region [15, 54]
     h.setLine(2, 'shared-line')   // scrollback: restoreY=2,  restoreDistance=13, diff=12
@@ -637,7 +649,7 @@ describe('scroll preservation across BSU/ESU', () => {
     h.userScrollTo(47)         // distance = 3
     h.setLine(47, 'previous turn output line')
 
-    h.io.enqueue(wrapBSU('redraw'), 1)
+    h.io.enqueue(wrapBSUWithClear('redraw'), 1)
     h.clearScrollback()
     h.addLines(20)             // new baseY=20
     h.setLine(10, 'pi status bar version 0.70.2')  // wholly different
@@ -647,6 +659,105 @@ describe('scroll preservation across BSU/ESU', () => {
     // No match → distance fallback: 20 - 3 = 17.
     expect(h.scrollToLineCalls).toContain(17)
     expect(h.viewportY).toBe(17)
+    h.cleanup()
+  })
+
+  it('after \\x1b[3J + redraw growing baseY past prevBaseY, restores distance from bottom (not adjustedY)', () => {
+    // Discriminator regression test. The pre-fix code used a
+    // `baseY < prevBaseY` heuristic to detect buffer-reset frames; it
+    // missed redraws that grow baseY past its pre-frame value, falling
+    // through to the else branch (line-based restore via adjustedY).
+    //
+    // The crucial assumption modeled here — verified end-to-end by
+    // the matching e2e test in `e2e/tests/terminal-scroll.spec.ts`
+    // ("BSU + clear-scrollback + redraw growing baseY") — is that
+    // real xterm's `viewportY` post-parse is 0 when `\x1b[3J` resets
+    // `ydisp` mid-frame and `isUserScrolling` is true. The harness
+    // simulates that here with `userScrollTo(0)` after `addLines`.
+    //
+    // What this test pins: given a frame whose bytes contain \x1b[3J
+    // and a post-parse adjustedY of 0, the restore lands
+    // `prevDistanceFromBottom` rows above the new bottom, NOT at
+    // `min(adjustedY, baseY) = 0`.
+    const h = makeScrollHarness({ scrollbackLimit: 5000, rows: 40 })
+    h.io.reset(1)
+    h.addLines(100)            // prevBaseY = 100
+    h.userScrollTo(97)         // distance = 3
+
+    h.io.enqueue(wrapBSUWithClear('redraw'), 1)
+    h.clearScrollback()        // \x1b[3J: ydisp=0, ybase=0
+    h.addLines(200)            // long redraw: new baseY = 160 (> prevBaseY)
+    h.userScrollTo(0)          // model adjustedY = 0 (broken line tracking)
+    expect(h.baseY).toBeGreaterThan(100)
+    h.flushOne(0)
+    h.flushRAF()
+
+    // Distance preserved: 3 rows above the new bottom.
+    expect(h.viewportY).toBe(h.baseY - 3)
+    h.cleanup()
+  })
+
+  it('after non-redraw streaming (no \\x1b[3J), honors xterm\'s eviction-tracked viewportY', () => {
+    // Plain shell / `tail -f` semantics: the user is reading a specific
+    // line. New lines stream in below; eviction kicks in; xterm decrements
+    // ydisp to keep the same line visible. The BSU/ESU restore path must
+    // honor xterm's adjustedY here, NOT pull the user toward the bottom.
+    //
+    // This pins the requirement that distance-from-bottom is *only* used
+    // when \x1b[3J is present in the chunk; without it, line-based restore
+    // wins.
+    const h = makeScrollHarness({ scrollbackLimit: 100, rows: 25 })
+    h.io.reset(1)
+    h.addLines(100)            // at capacity, baseY=100
+    h.userScrollTo(97)         // distance = 3, reading a specific line
+
+    h.io.enqueue(wrapBSU('streaming output'), 1)
+    // 10 lines stream in: full overflow, baseY stays 100, xterm decrements
+    // viewportY by 10 to 87 to keep the same content visible.
+    h.flushOne(10)
+    h.flushRAF()
+
+    // Line-based restore: viewportY = adjustedY = 87. Distance from bottom
+    // grew from 3 to 13, which is what xterm-style eviction tracking gives.
+    // A distance-based restore would have put viewportY at 97 (still 3
+    // from bottom), losing the user's line. We don't want that here.
+    expect(h.viewportY).toBe(87)
+    h.cleanup()
+  })
+
+  it('detects \\x1b[3J across split BSU / 3J / ESU chunks', () => {
+    // Pi can split a redraw across multiple WS frames: BSU in one
+    // chunk, \x1b[3J + payload in another, ESU in a third. The
+    // discriminator must OR-accumulate \x1b[3J presence across every
+    // chunk while savedScroll is set, otherwise the restore falls
+    // back to line-based and we get the same "jump to middle" bug.
+    const h = makeScrollHarness({ scrollbackLimit: 5000, rows: 40 })
+    h.io.reset(1)
+    h.addLines(100)
+    h.userScrollTo(97)         // distance = 3
+
+    // Chunk A: just BSU.
+    h.io.enqueue(new Uint8Array([...BSU]), 1)
+    h.flushOne(0)
+
+    // Chunk B: \x1b[3J + redraw payload (no ESU yet). The clear
+    // happens here, simulated by mutating harness state.
+    const clearChunk = new Uint8Array([...CSI_3J, ...enc('redraw')])
+    h.io.enqueue(clearChunk, 1)
+    h.clearScrollback()
+    h.addLines(200)            // grow baseY past prevBaseY
+    h.userScrollTo(0)          // xterm pinned ydisp at 0
+    h.flushOne(0)
+
+    // Chunk C: just ESU.
+    h.io.enqueue(new Uint8Array([...ESU]), 1)
+    h.flushOne(0)
+    h.flushRAF()
+
+    // Distance-based restore: 3 rows above the new bottom. Without
+    // the OR-accumulation, this would land at 0 (line-based on the
+    // pinned adjustedY).
+    expect(h.viewportY).toBe(h.baseY - 3)
     h.cleanup()
   })
 

--- a/apps/gmux-web/src/terminal-io.ts
+++ b/apps/gmux-web/src/terminal-io.ts
@@ -1,4 +1,4 @@
-import { BSU, ESU, containsSequence, startsWith } from './replay'
+import { BSU, CSI_3J, ESU, containsSequence, startsWith } from './replay'
 
 export interface TerminalWriter {
   write(data: string | Uint8Array, callback?: () => void): void
@@ -71,13 +71,14 @@ export function createTerminalIO(term: TerminalWriter, scroll?: ScrollAccessor):
   let pendingResize: (TerminalSize & { epoch: number }) | null = null
 
   // Scroll preservation across BSU/ESU blocks.
-  // wasAtBottom, prevBaseY, prevDistanceFromBottom, prevAnchorLine are
-  // saved at BSU time; the post-parse viewportY is captured later at ESU
+  // wasAtBottom, prevDistanceFromBottom, prevAnchorLine are saved at BSU
+  // time; the post-parse viewportY is captured later at ESU
   // write-callback time, after xterm has adjusted viewportY for any
   // scrollback evictions.
   //
-  // The wipe branch (baseY shrinks across BSU/ESU, eg via `\x1b[3J`)
-  // tries three anchors in order, falling through on each miss:
+  // The buffer-reset branch (block contains `\x1b[3J`, ie pi-style end-
+  // of-turn redraw) tries three anchors in order, falling through on
+  // each miss:
   //
   //   1. prevAnchorLine — the visible text the user was reading. If the
   //      redraw still contains that line we know exactly where the user
@@ -85,16 +86,28 @@ export function createTerminalIO(term: TerminalWriter, scroll?: ScrollAccessor):
   //      prevDistanceFromBottom, so common lines (eg "✓ done") still
   //      land somewhere reasonable.
   //   2. prevDistanceFromBottom — if the new buffer has room, restore
-  //      the user's pre-wipe distance from the bottom. Loses the
+  //      the user's pre-redraw distance from the bottom. Loses the
   //      identity of the line they were reading but keeps their intent
   //      ("N lines above the latest content").
   //   3. scrollToBottom — nothing else is meaningful.
+  //
+  // Why byte-presence of \x1b[3J rather than a baseY-shrink heuristic:
+  // \x1b[3J resets ydisp/ybase to 0 mid-frame, breaking the line-
+  // tracking invariant that the else branch's adjustedY relies on. A
+  // shrinking baseY is one symptom but not the only one: pi can also
+  // emit \x1b[3J followed by a long redraw that grows baseY past its
+  // pre-frame value, in which case adjustedY is still corrupt (pinned at
+  // 0 because isUserScrolling stays true through the synchronized
+  // block). Detecting the cause directly catches both shapes.
   let savedScroll: {
     wasAtBottom: boolean
-    prevBaseY: number
     prevDistanceFromBottom: number
     prevAnchorLine: string | null
   } | null = null
+  // OR-accumulated across every chunk while savedScroll is set: BSU
+  // chunk, intermediate chunks, and the ESU chunk. Cleared alongside
+  // savedScroll. Only meaningful when savedScroll is non-null.
+  let bufferReset = false
   let restoreRAF: number | null = null
 
   // When true, the next BSU/ESU block will scroll to bottom unconditionally
@@ -120,7 +133,6 @@ export function createTerminalIO(term: TerminalWriter, scroll?: ScrollAccessor):
       if (forceScrollToBottom) {
         savedScroll = {
           wasAtBottom: true,
-          prevBaseY: baseY,
           prevDistanceFromBottom: 0,
           prevAnchorLine: null,
         }
@@ -132,7 +144,6 @@ export function createTerminalIO(term: TerminalWriter, scroll?: ScrollAccessor):
         const wasAtBottom = viewportY >= baseY
         savedScroll = {
           wasAtBottom,
-          prevBaseY: baseY,
           prevDistanceFromBottom: distance,
           // Only capture the anchor when scrolled up: at-bottom always
           // wants scrollToBottom and never reaches the search.
@@ -140,6 +151,18 @@ export function createTerminalIO(term: TerminalWriter, scroll?: ScrollAccessor):
         }
       }
     }
+  }
+
+  /**
+   * OR-accumulate `\x1b[3J` presence across every chunk while a BSU/ESU
+   * block is open. Called for every pumped chunk; covers the BSU chunk
+   * itself (common: pi sends BSU + 3J + redraw + ESU all in one frame),
+   * intermediate chunks, and the ESU chunk. Cleared alongside
+   * `savedScroll` in `maybeRestoreScroll` and `reset`.
+   */
+  const maybeMarkBufferReset = (data: Uint8Array): void => {
+    if (!savedScroll || bufferReset) return
+    if (containsSequence(data, CSI_3J)) bufferReset = true
   }
 
   /**
@@ -159,7 +182,9 @@ export function createTerminalIO(term: TerminalWriter, scroll?: ScrollAccessor):
     if (!containsSequence(data, ESU)) return
 
     const snap = savedScroll
+    const wasBufferReset = bufferReset
     savedScroll = null
+    bufferReset = false
 
     // Capture the adjusted viewportY now, after xterm has processed the
     // data (including any scrollback evictions) but before the deferred
@@ -176,14 +201,10 @@ export function createTerminalIO(term: TerminalWriter, scroll?: ScrollAccessor):
         // Was at bottom before BSU, or user/code scrolled to bottom during
         // the BSU block — stay there.
         scroll.scrollToBottom()
-      } else if (baseY < snap.prevBaseY) {
-        // Scrollback shrank during the BSU/ESU block. The dominant cause
-        // is `\x1b[3J` (clear scrollback), which agents like pi emit at
-        // end-of-turn redraws and which resets ybase/ydisp to 0. The
-        // user's pre-BSU line is gone from xterm's perspective; adjustedY
-        // points at the top of a freshly-rebuilt buffer, which is the
-        // "jump to top" bug. Eviction within a full scrollback never
-        // reaches this branch because it leaves baseY at the cap.
+      } else if (wasBufferReset) {
+        // The block contained `\x1b[3J`. xterm reset ybase/ydisp to 0
+        // mid-parse, so adjustedY is unreliable: it can point at the top
+        // of a rebuilt buffer regardless of where the user actually was.
         //
         // We try three anchors in order, falling through on each miss
         // (rationale on the savedScroll declaration above).
@@ -198,10 +219,12 @@ export function createTerminalIO(term: TerminalWriter, scroll?: ScrollAccessor):
           scroll.scrollToBottom()
         }
       } else {
-        // User was scrolled up — restore the post-parse position, clamped
-        // to the current buffer range. We use adjustedY (captured after xterm
-        // processed the data) rather than a pre-BSU snapshot, so scrollback
-        // evictions are already accounted for.
+        // User was scrolled up and the block was a plain streaming
+        // update (no \x1b[3J). Restore the post-parse position, clamped
+        // to the current buffer range. adjustedY (captured after xterm
+        // processed the data) already accounts for scrollback evictions,
+        // so the user's specific line stays visible — what `tail -f`
+        // and other append-only streams need.
         scroll.scrollToLine(Math.min(adjustedY, baseY))
       }
       // Flush any resize that was deferred while the BSU/ESU block or
@@ -218,6 +241,7 @@ export function createTerminalIO(term: TerminalWriter, scroll?: ScrollAccessor):
     if (next) {
       writeInFlight = true
       maybeSaveScroll(next.data)
+      maybeMarkBufferReset(next.data)
       term.write(next.data, () => {
         maybeRestoreScroll(next.data)
         writeInFlight = false
@@ -250,6 +274,7 @@ export function createTerminalIO(term: TerminalWriter, scroll?: ScrollAccessor):
       writeInFlight = false
       pendingResize = null
       savedScroll = null
+      bufferReset = false
       forceScrollToBottom = false
       if (restoreRAF !== null) {
         cancelAnimationFrame(restoreRAF)

--- a/e2e/tests/terminal-scroll.spec.ts
+++ b/e2e/tests/terminal-scroll.spec.ts
@@ -708,4 +708,78 @@ test.describe('terminal scrollback (jump-to-top bug)', () => {
     // don't pin it), but the line text is stable.
     expect(landedText).toBe(anchorText)
   })
+
+  /**
+   * Synthetic redraw whose post-wipe `baseY` ends up LARGER than the
+   * pre-wipe value. The earlier baseY-shrink heuristic missed this
+   * shape — it only fired the buffer-reset branch when scrollback
+   * shrank during the frame. Anything that grew baseY past prevBaseY
+   * fell through to the line-based else branch, which trusted xterm's
+   * post-parse `viewportY`.
+   *
+   * The bug: when the user is scrolled up, xterm keeps `isUserScrolling`
+   * true through the synchronized block. `\x1b[3J` resets `ydisp` to
+   * 0 mid-parse; the long redraw appends lines but `ydisp` does not
+   * follow. Post-parse `viewportY = 0`. The else branch ran
+   * `scrollToLine(min(0, baseY)) = 0` and the user landed at the top
+   * of the rerendered conversation. Verified end-to-end: this test
+   * fails on the pre-fix code with `viewportY=0, distance=baseY`
+   * (see PR #203 for the on-`main` CI run that produced exactly
+   * that diagnostic).
+   *
+   * Trigger condition is just "user not at bottom when the frame
+   * arrives"; no preceding wheel-scroll is required. Live
+   * observations confirmed the bug fires on a passive viewer too.
+   *
+   * Contract pinned here: byte-presence of `\x1b[3J` in the BSU/ESU
+   * block triggers distance-from-bottom restoration regardless of
+   * which side of `prevBaseY` the rebuilt buffer ends up on.
+   */
+  test('user scrolled up: BSU + clear-scrollback + redraw growing baseY past prevBaseY preserves distance', async ({ page }) => {
+    await page.evaluate(() => (window as any).__gmuxTerm.resize(120, 40))
+    await settle(page)
+
+    // Modest seed so the redraw can grow baseY past it. With rows=40
+    // and 100 seed lines, prevBaseY ≈ 60.
+    await seedScrollback(page, 100)
+    await scrollToBottom(page)
+    const baseline = await getScroll(page)
+    expect(baseline.baseY).toBeGreaterThan(40)
+
+    // Small distance: the bug fires whenever the user is not at
+    // bottom; the magnitude doesn't matter, but a small distance
+    // makes the failure mode (viewportY=0, distance=baseY) visually
+    // dramatic in the assertion message.
+    const distance = 3
+    const target = baseline.baseY - distance
+    await page.evaluate((line) => (window as any).__gmuxTerm.scrollToLine(line), target)
+    const beforeBurst = await getScroll(page)
+    expect(beforeBurst.baseY - beforeBurst.viewportY).toBe(distance)
+    const prevBaseY = beforeBurst.baseY
+
+    // 250-line redraw: post-wipe baseY ≈ 210, comfortably larger
+    // than prevBaseY ≈ 60. The two values must differ for the test
+    // to exercise the regressed code path: with baseY' < prevBaseY
+    // the old heuristic would have caught it.
+    const redraw = Array.from({ length: 250 }, (_, i) =>
+      `redraw-line-${String(i).padStart(4, '0')}`).join('\r\n') + '\r\n'
+    await inject(page, BSU + '\x1b[2J\x1b[H\x1b[3J' + redraw + ESU)
+    await settle(page)
+
+    const after = await getScroll(page)
+    console.log('[grown-baseY]',
+      'prevBaseY=', prevBaseY,
+      'postBaseY=', after.baseY,
+      'viewportY=', after.viewportY,
+      'distance=', after.baseY - after.viewportY)
+
+    // The shape we're testing: post-wipe baseY grew past pre-wipe.
+    // If the redraw didn't actually grow baseY (eg pi changed its
+    // layout), the test is silently exercising the shrink branch.
+    expect(after.baseY).toBeGreaterThan(prevBaseY)
+    // The bug shape: viewportY === 0 with baseY > 0. The fix:
+    // distance from bottom is preserved.
+    expect(after.viewportY).toBeGreaterThan(0)
+    expect(after.baseY - after.viewportY).toBe(distance)
+  })
 })


### PR DESCRIPTION
## The reported bug

> Sometimes I scroll up from the bottom in a session that I haven't touched in a while and I jump to the middle of the conversation on the first scroll action.

Always while pi was actively outputting, with the user scrolled up at the moment a frame arrives. A live observation later confirmed the bug also fires with **no user interaction** \u2014 just a pi frame landing while the user is already scrolled up. So the precondition is simply "user not at bottom when pi emits a redraw frame", not "user just scrolled".

## Diagnosis

The BSU/ESU scroll-restore path in `apps/gmux-web/src/terminal-io.ts` had two branches:

- **Wipe branch** (`baseY < prevBaseY`): used distance-from-bottom restore. Designed for pi's end-of-turn frames that emit `\\x1b[3J` followed by a small redraw, shrinking scrollback.
- **Else branch**: trusted xterm's post-parse `viewportY` as `adjustedY`, then `scrollToLine(min(adjustedY, baseY))`.

The `baseY < prevBaseY` heuristic was a *symptom* of buffer reset, not the *cause*. Pi can also emit `\\x1b[3J` + a long redraw that grows `baseY` past its pre-frame value (long thread, conversation rerendered top-down). When the user is scrolled up, `isUserScrolling` stays true through the synchronized block; `\\x1b[3J` resets `ydisp` to 0 mid-parse and the redraw's appended lines don't pull `ydisp` along. Post-parse `adjustedY = 0`. The else branch ran `scrollToLine(0)`. The user landed at the top of the rerendered buffer \u2014 which, because pi rerenders the conversation chronologically, the user perceives as being yanked into the middle (or beginning) of the conversation history.

## Verification

Probe PR #203 ran the new e2e test from this PR against `main` alone. It failed with:

```
[grown-baseY] prevBaseY=66 postBaseY=211 viewportY=0 distance=211
```

Confirming all three claims above: xterm pins `ydisp=0`, `baseY` grew past `prevBaseY` so the old heuristic missed, and the else branch produced `viewportY=0`. All other e2e tests on `main` passed. The fix in this PR makes the test pass.

## Fix

Replace the indirect `baseY < prevBaseY` discriminator with the direct cause: byte-presence of `\\x1b[3J` (`CSI_3J`) anywhere in the BSU/ESU block, OR-accumulated across split chunks via `maybeMarkBufferReset()`.

- **Buffer-reset frames** (any `\\x1b[3J`): anchor \u2192 distance \u2192 bottom restoration runs regardless of which side of `prevBaseY` the rebuilt buffer ends up on.
- **Plain streaming output** (no `\\x1b[3J`, eg `tail -f`): line-based restore stays. Eviction tracking continues to keep the user's specific line visible \u2014 the right behavior for append-only logs.

Drops the now-redundant `prevBaseY` field from `savedScroll`. Adds `bufferReset` boolean lifecycle-coupled to `savedScroll`. Net state count unchanged.

## Tests

Unit tests (`apps/gmux-web/src/terminal-io.test.ts`):

1. **Pi-style redraw with grown baseY**: pins the discriminator behavior at the algorithm level. Models xterm's pinned `ydisp` via the harness.
2. **`tail -f` streaming**: pins line-based restore for non-`\\x1b[3J` frames so a future "always distance-from-bottom" regression fails loudly.
3. **Split BSU / 3J / ESU chunks**: pins the OR-accumulation contract.
4. Existing wipe-branch tests updated to put `\\x1b[3J` in the bytes.

E2E (`e2e/tests/terminal-scroll.spec.ts`, second commit):

5. **Real-xterm grown-baseY**: 100-line seed + 250-line redraw with `\\x1b[3J` so post-wipe `baseY > prevBaseY`. This is the test that failed on `main` in the probe.

## Considered but rejected

- **Always use distance-from-bottom**: simpler, but yanks `tail -f` users toward the bottom as new lines stream in even though their line is still in the buffer.
- **Anchor-line presence check** (`getLine(adjustedY) === prevAnchorLine`): more general but indirect. Byte-presence is more direct and easier to reason about.
- **Dual signal** (`\\x1b[3J` byte OR `baseY < prevBaseY`): would catch hypothetical reset codes other than `\\x1b[3J`. None of those are realistic inside a synchronized output block in practice; rejected for simplicity.