### PR TITLE
fix(daemon): apply persisted attributions on startup so live runners regain slugs

### DIFF
--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -461,7 +461,7 @@ func serve(stderr io.Writer) int {
 	// Start socket-based discovery (scans /tmp/gmux-sessions/*.sock)
 	// Discovery also subscribes to each runner's /events SSE for live updates.
 	stopDiscovery := make(chan struct{})
-	go discovery.Watch(sessions, subs, fileMon, pendingResumes, persistDead, 3*time.Second, stopDiscovery)
+	go discovery.Watch(sessions, subs, fileMon, pendingResumes, persistDead, fileMon.ApplyPersistedAttributions, 3*time.Second, stopDiscovery)
 	defer close(stopDiscovery)
 
 	// Session file scanner — discovers resumable sessions from adapter

--- a/services/gmuxd/internal/discovery/discovery.go
+++ b/services/gmuxd/internal/discovery/discovery.go
@@ -48,9 +48,17 @@ type OnDeadFunc func(sess store.Session)
 // Watch periodically scans for Unix sockets and queries their /meta.
 // When a new session is found, it subscribes to the runner's /events SSE
 // for real-time status/meta/exit updates.
-func Watch(sessions *store.Store, subs *Subscriptions, fileMon *FileMonitor, resumes *PendingResumes, onDead OnDeadFunc, interval time.Duration, stop <-chan struct{}) {
+//
+// onFirstScan, if non-nil, runs once after the initial Scan completes.
+// This is the right point to invoke work that depends on live sessions
+// being registered with the FileMonitor (e.g. applying persisted
+// attributions to freshly-rehydrated runners).
+func Watch(sessions *store.Store, subs *Subscriptions, fileMon *FileMonitor, resumes *PendingResumes, onDead OnDeadFunc, onFirstScan func(), interval time.Duration, stop <-chan struct{}) {
 	// Initial scan immediately
 	Scan(sessions, subs, fileMon, resumes, onDead)
+	if onFirstScan != nil {
+		onFirstScan()
+	}
 
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()

--- a/services/gmuxd/internal/discovery/filemon.go
+++ b/services/gmuxd/internal/discovery/filemon.go
@@ -709,6 +709,43 @@ func (fm *FileMonitor) persistAttributionsLocked() {
 	saveAttributions(fm.attributions, fm.sessions)
 }
 
+// ApplyPersistedAttributions walks the loaded attributions map and,
+// for each (filePath, sessionID) entry whose target is currently a
+// monitored live session, propagates the slug and title from the
+// session file into the store.
+//
+// This bridges the daemon-restart gap: attribution decisions persist
+// in attributions.json, but slug/title are runtime fields that live
+// only in the in-memory store. Without this pass, a freshly
+// re-registered runner stays slug-less until the next file event
+// re-triggers syncFileMetadataLocked, which can be a long time for
+// idle sessions.
+//
+// Entries pointing at unknown session IDs are skipped silently;
+// they're either dismissed sessions whose entries haven't been
+// pruned yet, or sessions that haven't re-registered yet (in which
+// case a later NotifyNewSession will trigger sync via the normal
+// file-event path).
+//
+// Must be called after live sessions have been registered with
+// NotifyNewSession (i.e. after the first discovery.Scan pass).
+func (fm *FileMonitor) ApplyPersistedAttributions() {
+	fm.mu.Lock()
+	defer fm.mu.Unlock()
+
+	var applied int
+	for path, sessionID := range fm.attributions {
+		if _, ok := fm.sessions[sessionID]; !ok {
+			continue
+		}
+		fm.syncFileMetadataLocked(sessionID, path)
+		applied++
+	}
+	if applied > 0 {
+		log.Printf("filemon: applied %d persisted attribution(s) at startup", applied)
+	}
+}
+
 // --- Attribution ---
 
 // tryAttributeUnmatched attempts to match candidate files to sessions

--- a/services/gmuxd/internal/discovery/filemon_test.go
+++ b/services/gmuxd/internal/discovery/filemon_test.go
@@ -1220,3 +1220,93 @@ func TestFileMonitor_ScrollbackFetchDoesNotPool(t *testing.T) {
 		t.Fatalf("server saw %d accepts, want %d (each fetch must dial a fresh conn)", got, N)
 	}
 }
+
+// TestApplyPersistedAttributionsPopulatesSlugAfterRestart is the
+// regression guard for the daemon-restart UX gap: a live runner
+// re-registers with empty slug, the persisted attributions map says
+// which JSONL belongs to it, but without an active file event nothing
+// propagates the slug from disk into the store. ApplyPersistedAttributions
+// closes that gap synchronously at startup.
+func TestApplyPersistedAttributionsPopulatesSlugAfterRestart(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now()
+
+	// Codex JSONL with a known first user message — slug derives from it.
+	filePath := filepath.Join(dir, "rollout.jsonl")
+	content := `{"timestamp":"` + now.Format(time.RFC3339Nano) + `","type":"session_meta","payload":{"id":"sess-codex-uuid","timestamp":"` + now.Format(time.RFC3339Nano) + `","cwd":"/tmp"}}
+{"timestamp":"` + now.Format(time.RFC3339Nano) + `","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"fix auth bug"}]}}
+`
+	if err := os.WriteFile(filePath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Live runner: re-registered after daemon restart, slug empty
+	// because the runner's /meta does not know its own slug.
+	s := store.New()
+	s.Upsert(store.Session{
+		ID:        "sess-runner",
+		Cwd:       "/tmp",
+		Kind:      "codex",
+		Alive:     true,
+		StartedAt: now.UTC().Format(time.RFC3339),
+	})
+
+	// FileMonitor pre-seeded with the persisted attribution from the
+	// previous gmuxd run.
+	fm := NewFileMonitorWithAttributions(s, map[string]string{filePath: "sess-runner"})
+	if fm.watcher != nil {
+		fm.watcher.Close()
+		fm.watcher = nil
+	}
+	codex := adapters.NewCodex()
+	fm.sessions["sess-runner"] = &monitoredSession{
+		id:      "sess-runner",
+		cwd:     "/tmp",
+		kind:    "codex",
+		adapter: codex,
+		fileMon: codex,
+		filer:   codex,
+	}
+
+	// Pre-condition: slug not yet populated.
+	pre, _ := s.Get("sess-runner")
+	if pre.Slug != "" {
+		t.Fatalf("test setup: expected empty slug, got %q", pre.Slug)
+	}
+
+	fm.ApplyPersistedAttributions()
+
+	post, _ := s.Get("sess-runner")
+	if post.Slug != "fix-auth-bug" {
+		t.Errorf("Slug after apply: want %q, got %q", "fix-auth-bug", post.Slug)
+	}
+	if post.AdapterTitle != "fix auth bug" {
+		t.Errorf("AdapterTitle after apply: want %q, got %q", "fix auth bug", post.AdapterTitle)
+	}
+}
+
+// TestApplyPersistedAttributionsSkipsUnknownSession ensures stale
+// attribution entries (pointing at sessions that didn't re-register
+// after restart, e.g. dismissed or runner died) don't cause panics
+// or spurious Upserts.
+func TestApplyPersistedAttributionsSkipsUnknownSession(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "orphan.jsonl")
+	if err := os.WriteFile(filePath, []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s := store.New()
+	fm := NewFileMonitorWithAttributions(s, map[string]string{filePath: "sess-gone"})
+	if fm.watcher != nil {
+		fm.watcher.Close()
+		fm.watcher = nil
+	}
+	// Note: no entry in fm.sessions for "sess-gone".
+
+	fm.ApplyPersistedAttributions()
+
+	if got := len(s.List()); got != 0 {
+		t.Errorf("expected empty store, got %d sessions", got)
+	}
+}


### PR DESCRIPTION
## Problem

When gmuxd restarts while runners are still alive, those runners re-register with the new daemon but arrive with `slug=""` (the runner doesn't know its own slug; that derivation is daemon-side from JSONL contents). Until something writes to the runner's adapter session file, fsnotify never fires an event, `processFileEvent` never runs, `syncFileMetadataLocked` never runs, and the live session keeps an empty slug + generic title (`π - cwd`, `Claude Code`, etc.) in the sidebar.

The information needed to fix this is already on disk: `attributions.json` records the JSONL-to-session-ID mapping. We just don't apply it at startup.

User-visible symptom (reported on a real install of v1.5.1 prerelease):

> Live pi sessions all show as `π - juniper`, `π - mg`, etc. instead of their actual conversation titles. Restarting the daemon "broke" attribution.

## Fix

A new method `FileMonitor.ApplyPersistedAttributions` walks `fm.attributions` once and, for each entry whose target session is a currently-monitored live session, calls the existing `syncFileMetadataLocked` to propagate slug+title into the store.

Wired into `discovery.Watch` via a new `onFirstScan` callback parameter so it runs after the synchronous first scan has registered all live runners with the FileMonitor (otherwise `fm.sessions` is empty and the function does nothing).

## What it doesn't do

- **Doesn't re-attribute.** Attribution decisions are taken from the persisted map verbatim. Running scrollback-similarity matching at startup would be expensive (HTTP fetch per session) and unnecessary: the previous gmuxd already did that work.
- **Doesn't touch dead sessions.** Only iterates entries whose `sessionID` is in `fm.sessions`. Dead sessions get their slugs from sessionmeta or the convIndex fallback, not from this path.
- **Doesn't fix misattributions.** If the persisted attribution was wrong before the restart, applying it propagates the same wrong decision. No regression: a real file event would have continued the same misattribution. The fix here is orthogonal.

## Tests

`TestApplyPersistedAttributionsPopulatesSlugAfterRestart` is the regression guard. Verified by temporarily disabling the apply call inside the loop:

```
filemon_test.go:1281: Slug after apply: want "fix-auth-bug", got ""
filemon_test.go:1284: AdapterTitle after apply: want "fix auth bug", got ""
```

`TestApplyPersistedAttributionsSkipsUnknownSession` covers the stale-attribution edge case (entry pointing at a session that didn't re-register, e.g., dismissed since last save) — must not panic, must not Upsert.

## Relationship to #194

Different concern, complementary effect:

- **#194** stops `rehydrateProjects` from creating ghost entries when the same logical session is already represented in the store.
- **This PR** ensures live runners actually get their slugs populated at startup, which is what makes #194's `HasLocalSlug` check actually work for the daemon-restart case (without this, live runners have empty slugs and the slug-match skip is a no-op).

Either can land first; they don't conflict. Together they close the daemon-restart attribution-loss gap that the user reported.
