### PR TITLE
feat(web): replay scrollback for dead sessions

### DIFF
--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -5,6 +5,7 @@ import '@xterm/xterm/css/xterm.css'
 import './styles.css'
 
 import { TerminalView } from './terminal'
+import { ReplayView } from './replay-view'
 import { useArrivalPulse } from './use-arrival-pulse'
 import { Sidebar } from './sidebar'
 import type { DotState } from './store'
@@ -517,9 +518,17 @@ function App() {
             onPasteReady={handleTerminalPasteReady}
             onFocusReady={handleTerminalFocusReady}
           />
+        ) : selectedVal && !selectedVal.alive && termOpts && !USE_MOCK ? (
+          <ReplayView
+            session={selectedVal}
+            terminalOptions={termOpts}
+            onResume={handleResume}
+            onDismiss={handleCloseSession}
+            resuming={resumingId === selectedVal.id}
+          />
         ) : selectedVal ? (
           <div class="state-message">
-            <div class="state-subtitle">{selectedVal.alive ? 'Connecting…' : 'Session ended'}</div>
+            <div class="state-subtitle">Connecting…</div>
           </div>
         ) : (
           <Home />

--- a/apps/gmux-web/src/project-hub.tsx
+++ b/apps/gmux-web/src/project-hub.tsx
@@ -150,12 +150,6 @@ function SessionCard({
     <a
       class="session-card"
       href={href}
-      onClick={(e) => {
-        if (sleeping) {
-          e.preventDefault()
-          onResume(session.id)
-        }
-      }}
     >
       <span class={`session-card-dot ${dotClass}`} />
       <span class="session-card-name">{name}</span>

--- a/apps/gmux-web/src/replay-fetch.test.ts
+++ b/apps/gmux-web/src/replay-fetch.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test, vi } from 'vitest'
+import { fetchScrollback } from './replay-fetch'
+
+function ok(body: BodyInit, init?: ResponseInit): Response {
+  return new Response(body, { status: 200, ...init })
+}
+
+describe('fetchScrollback', () => {
+  test('200 with bytes returns kind=bytes with the response body', async () => {
+    const payload = new Uint8Array([0x68, 0x69, 0x0d, 0x0a]) // "hi\r\n"
+    const fakeFetch = vi.fn().mockResolvedValue(ok(payload))
+
+    const result = await fetchScrollback('sess-abc', fakeFetch)
+
+    expect(fakeFetch).toHaveBeenCalledWith('/v1/sessions/sess-abc/scrollback')
+    expect(result).toEqual({ kind: 'bytes', bytes: payload })
+  })
+
+  test('200 with empty body returns kind=empty', async () => {
+    const fakeFetch = vi.fn().mockResolvedValue(ok(new Uint8Array(0)))
+
+    const result = await fetchScrollback('sess-empty', fakeFetch)
+
+    expect(result).toEqual({ kind: 'empty' })
+  })
+
+  test('404 returns kind=not-found', async () => {
+    const fakeFetch = vi.fn().mockResolvedValue(new Response('not found', { status: 404 }))
+
+    const result = await fetchScrollback('sess-missing', fakeFetch)
+
+    expect(result).toEqual({ kind: 'not-found' })
+  })
+
+  test('5xx returns kind=error with status and message', async () => {
+    const fakeFetch = vi.fn().mockResolvedValue(new Response('boom', { status: 500, statusText: 'Internal Server Error' }))
+
+    const result = await fetchScrollback('sess-bad', fakeFetch)
+
+    expect(result).toEqual({ kind: 'error', status: 500, message: 'Internal Server Error' })
+  })
+
+  test('network failure returns kind=error with status 0', async () => {
+    const fakeFetch = vi.fn().mockRejectedValue(new Error('connection refused'))
+
+    const result = await fetchScrollback('sess-x', fakeFetch)
+
+    expect(result).toEqual({ kind: 'error', status: 0, message: 'connection refused' })
+  })
+
+  test('peer-owned session id is URL-encoded', async () => {
+    const fakeFetch = vi.fn().mockResolvedValue(ok(new Uint8Array(0)))
+
+    await fetchScrollback('sess-abc@hs', fakeFetch)
+
+    // @ would otherwise be unsafe in some HTTP routers; verify the call site
+    // round-trips through encodeURIComponent.
+    expect(fakeFetch).toHaveBeenCalledWith('/v1/sessions/sess-abc%40hs/scrollback')
+  })
+})

--- a/apps/gmux-web/src/replay-fetch.ts
+++ b/apps/gmux-web/src/replay-fetch.ts
@@ -1,0 +1,49 @@
+// Fetches persisted scrollback for a (typically dead) session from the
+// gmuxd broker endpoint at GET /v1/sessions/<id>/scrollback.
+//
+// Response semantics (see services/gmuxd/cmd/gmuxd/scrollback.go):
+//   200 + bytes  →  raw PTY scrollback (octet-stream)
+//   200 + empty  →  session is known but no scrollback was captured
+//                   (e.g. died before scrollback persistence shipped,
+//                    or fast-exited before any output)
+//   404          →  session unknown to this gmuxd
+//   5xx          →  server-side I/O error
+//
+// Peer-owned sessions are forwarded transparently by the hub, so callers
+// don't need to special-case `id@peer`.
+
+export type ScrollbackResult =
+  | { kind: 'bytes'; bytes: Uint8Array }
+  | { kind: 'empty' }
+  | { kind: 'not-found' }
+  | { kind: 'error'; status: number; message: string }
+
+/** Inject-friendly fetcher; defaults to global fetch. */
+export type FetchFn = (input: RequestInfo, init?: RequestInit) => Promise<Response>
+
+export async function fetchScrollback(
+  sessionId: string,
+  fetchImpl: FetchFn = fetch,
+): Promise<ScrollbackResult> {
+  const url = `/v1/sessions/${encodeURIComponent(sessionId)}/scrollback`
+
+  let resp: Response
+  try {
+    resp = await fetchImpl(url)
+  } catch (e) {
+    return { kind: 'error', status: 0, message: e instanceof Error ? e.message : String(e) }
+  }
+
+  if (resp.status === 404) {
+    return { kind: 'not-found' }
+  }
+  if (!resp.ok) {
+    return { kind: 'error', status: resp.status, message: resp.statusText || 'request failed' }
+  }
+
+  const buf = await resp.arrayBuffer()
+  if (buf.byteLength === 0) {
+    return { kind: "empty" }
+  }
+  return { kind: 'bytes', bytes: new Uint8Array(buf) }
+}

--- a/apps/gmux-web/src/replay-view.tsx
+++ b/apps/gmux-web/src/replay-view.tsx
@@ -1,0 +1,170 @@
+import { useEffect, useRef, useState } from 'preact/hooks'
+import { Terminal } from '@xterm/xterm'
+import { FitAddon } from '@xterm/addon-fit'
+import { ImageAddon } from '@xterm/addon-image'
+import { WebLinksAddon } from '@xterm/addon-web-links'
+import { WebglAddon } from '@xterm/addon-webgl'
+import type { ITerminalOptions } from '@xterm/xterm'
+import type { Session } from './types'
+import { fetchScrollback, type ScrollbackResult } from './replay-fetch'
+
+// gmuxd caps scrollback at 1 MiB × 2 files (~2 MiB max). xterm's default
+// scrollback line cap (1000) would silently truncate most of that for
+// text-heavy sessions; bump it for replay so the user can scroll the full
+// captured history.
+const REPLAY_SCROLLBACK_LINES = 10000
+
+function loadPreferredRenderer(term: Terminal) {
+  try { term.loadAddon(new WebglAddon()) } catch { /* DOM fallback */ }
+}
+
+type ReplayState =
+  | { kind: 'loading' }
+  | ScrollbackResult
+
+/**
+ * Read-only xterm view that replays a dead session's persisted scrollback
+ * from the gmuxd broker. No WebSocket, no input, no resize messages: this
+ * is purely a viewer for bytes that already happened.
+ *
+ * The terminal is recreated when `session.id` changes (matching the
+ * sidebar-click model). Live sessions go through TerminalView instead;
+ * see main.tsx for the routing.
+ *
+ * The action bar at the bottom carries the lifecycle controls that
+ * previously lived as auto-trigger-on-click in the sidebar: Resume
+ * (if the adapter is resumable) and Dismiss. Promoting them out of an
+ * implicit click means clicking a dead session navigates to its
+ * scrollback first, and any state-changing action is a deliberate
+ * second click.
+ */
+export function ReplayView({
+  session,
+  terminalOptions,
+  onResume,
+  onDismiss,
+  resuming,
+}: {
+  session: Session
+  terminalOptions: ITerminalOptions
+  onResume?: (id: string) => void
+  onDismiss?: (session: Session) => void
+  resuming?: boolean
+}) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [state, setState] = useState<ReplayState>({ kind: 'loading' })
+
+  useEffect(() => {
+    if (!containerRef.current) return
+
+    const term = new Terminal({
+      ...terminalOptions,
+      scrollback: REPLAY_SCROLLBACK_LINES,
+      disableStdin: true,
+      cursorBlink: false,
+      cursorInactiveStyle: 'none',
+      linkHandler: {
+        activate(_event, text) {
+          window.open(text, '_blank', 'noopener')
+        },
+      },
+    })
+    const fit = new FitAddon()
+    term.loadAddon(fit)
+    term.loadAddon(new ImageAddon())
+    term.loadAddon(new WebLinksAddon())
+    term.open(containerRef.current)
+    loadPreferredRenderer(term)
+    fit.fit()
+
+    // OSC 52 (set clipboard) suppression: the captured bytes may contain
+    // OSC 52 sequences emitted by the *original* live session; replaying
+    // them would silently overwrite the operator's clipboard. Swallow.
+    term.parser.registerOscHandler(52, () => true)
+
+    // Expose for e2e tests (matches TerminalView's window.__gmuxTerm).
+    ;(window as any).__gmuxTerm = term
+
+    setState({ kind: 'loading' })
+
+    let cancelled = false
+    fetchScrollback(session.id).then((result) => {
+      if (cancelled) return
+      setState(result)
+      if (result.kind === 'bytes') {
+        term.write(result.bytes, () => {
+          // Wait for the write callback so xterm has actually parsed the
+          // bytes before we ask it to scroll; otherwise scrollToBottom
+          // pins us at row 0 because the buffer is still empty.
+          term.scrollToBottom()
+        })
+      }
+    })
+
+    const onResize = () => fit.fit()
+    window.addEventListener('resize', onResize)
+
+    return () => {
+      cancelled = true
+      window.removeEventListener('resize', onResize)
+      if ((window as any).__gmuxTerm === term) (window as any).__gmuxTerm = null
+      term.dispose()
+    }
+  }, [session.id])
+
+  const exitLabel = session.exit_code != null
+    ? `Session ended (exit ${session.exit_code})`
+    : 'Session ended'
+
+  return (
+    <div class="replay-root">
+      <div class="terminal-shell">
+        <div ref={containerRef} class="terminal-container" />
+        {state.kind === 'loading' && (
+          <div class="terminal-loading">
+            Loading scrollback…
+          </div>
+        )}
+        {state.kind === 'empty' && (
+          <div class="terminal-loading">
+            No scrollback was captured for this session.
+          </div>
+        )}
+        {state.kind === 'not-found' && (
+          <div class="terminal-loading">
+            This session is no longer known to gmuxd.
+          </div>
+        )}
+        {state.kind === 'error' && (
+          <div class="terminal-loading">
+            Couldn't load scrollback (HTTP {state.status}: {state.message}).
+          </div>
+        )}
+      </div>
+      <div class="replay-actions">
+        <span class="replay-status">{exitLabel}</span>
+        <div class="replay-buttons">
+          {session.resumable && onResume && (
+            <button
+              type="button"
+              class="btn btn-primary"
+              disabled={!!resuming}
+              onClick={() => onResume(session.id)}
+            >
+              {resuming ? 'Resuming…' : 'Resume'}
+            </button>
+          )}
+          {onDismiss && (
+            <button
+              type="button"
+              class="btn"
+              onClick={() => onDismiss(session)}
+            >
+              Dismiss
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/gmux-web/src/sidebar.tsx
+++ b/apps/gmux-web/src/sidebar.tsx
@@ -118,12 +118,8 @@ function SessionItem({
       class={cls}
       href={href}
       draggable={canDrag && !!onDragStart}
-      onClick={(e) => {
+      onClick={() => {
         onClick?.()
-        if (sleeping) {
-          e.preventDefault()
-          onResume?.(session.id)
-        }
       }}
       onAuxClick={(e) => { if (e.button === 1 && onClose) { e.preventDefault(); onClose() } }}
       onDragStart={(e) => {

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -1919,6 +1919,47 @@ a.home-host-link:hover {
   border-color: oklch(78% 0.1 195);
 }
 
+.btn:disabled,
+.btn-primary:disabled {
+  opacity: 0.6;
+  cursor: progress;
+}
+
+/* Replay (read-only dead session) layout: terminal area fills remaining
+   vertical space, action bar pinned beneath. The action bar carries the
+   resume/dismiss buttons that the sidebar used to auto-trigger on click. */
+.replay-root {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.replay-root > .terminal-shell {
+  flex: 1;
+  min-height: 0;
+}
+
+.replay-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 16px;
+  background: var(--bg-surface);
+  border-top: 1px solid var(--border);
+}
+
+.replay-status {
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+.replay-buttons {
+  display: flex;
+  gap: 8px;
+}
+
 /* ── Reduced motion ── */
 @media (prefers-reduced-motion: reduce) {
   .session-dot-indicator.arriving,


### PR DESCRIPTION
## What

Clicking a dead session in the sidebar now shows a read-only terminal populated with that session's persisted scrollback, instead of the previous "Session ended" placeholder. This is the user-visible payoff of #185 (sessionmeta) and #193 (scrollback persistence + broker).

Live sessions still go through `TerminalView` exactly as before; only the dead-session arm of `main.tsx`'s selection switch changes.

## How

- New `apps/gmux-web/src/replay-fetch.ts`: typed wrapper around `GET /v1/sessions/<id>/scrollback`, returning `{ kind: 'bytes' | 'empty' | 'not-found' | 'error' }`. URL-encodes the session ID so peer-owned (`@peer`) IDs round-trip correctly.
- New `apps/gmux-web/src/replay-view.tsx` (~125 lines): mounts a fresh xterm on `session.id` change, fetches scrollback once, writes the bytes, scrolls to bottom. No WebSocket, no input handlers, no resize messages, no mobile bar wiring. OSC 52 (set clipboard) sequences in the captured bytes are suppressed so replaying can't silently overwrite the operator's clipboard. xterm's `scrollback` line cap is bumped from the default 1000 to 10000 to actually fit gmuxd's ~2 MiB persistence window.
- `main.tsx`: adds one ternary arm above the existing fallback. Dead-session path: `selectedVal && !alive && termOpts && !USE_MOCK → <ReplayView />`. Mock mode unchanged (mock sessions are all alive); the previous `'Session ended'` placeholder is now only reached for live sessions whose socket isn't ready yet, so its label simplifies to `'Connecting…'`.

## What's deliberately not in this PR

- **No "session ended" banner inside the replay view.** The sidebar already distinguishes alive/dead; the main header still renders `MainHeader` with its existing restart action via the session menu. Adding chrome inside the terminal area felt like premature decoration; can iterate from real use.
- **No streaming.** The broker is GET with `Content-Length`; one `arrayBuffer()` is enough for the 2 MiB max payload.
- **No `gmux --tail` change.** That was listed as optional in the lifecycle plan; orthogonal to the web piece.

## Tests

`apps/gmux-web/src/replay-fetch.test.ts`: 6 unit tests for the network helper. Verified the assertions bite by perturbing the production code (200/empty case returned `bytes` instead of `empty` ➝ test failed as expected, then restored).

The component itself is intentionally thin: it composes xterm + the tested fetch helper. Component-level rendering tests would require a DOM-test setup that doesn't yet exist in this repo. Manual install verification + the existing E2E harness give better signal here than a contrived component unit test.

## Manual verification

Will install the prerelease and verify on real dead sessions before merging. Plan:
1. `gmuxd restart`, click a dead pi/claude session in the sidebar, expect to see its actual scrollback in a read-only terminal that scrolls to the latest output.
2. Click a pre-S3 dead session (the ones surfaced by the convIndex fallback), expect the inline "No scrollback was captured" notice.
3. Resize the window while viewing replay, expect xterm to reflow without errors.
4. Switch between dead sessions, expect each to fetch its own scrollback and not bleed bytes from the previous one.
