### PR TITLE
feat(release): always include changelog bullets in discord announcement

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -70,7 +70,7 @@ To edit prose for an upcoming release: open the `release/next` PR and edit the b
 
 1. The `tag` job extracts the version from the PR title (`release: v1.2.0`), creates and pushes the git tag, and dispatches the release build. Because `changelog.mdx` is already on `main` (it's part of the merged release commit), there's no separate changelog write here.
 2. The `release` job extracts the latest entry from `changelog.mdx` and passes it to GoReleaser via `--release-notes` (binaries + GitHub Release + Homebrew tap).
-3. `notify-discord.sh` reads the same latest entry from `changelog.mdx`, splits prose from bullets at the first `### ` heading, and posts to Discord. Empty prose falls back to the bullet list so subscribers always see what changed.
+3. `notify-discord.sh` reads the same latest entry from `changelog.mdx` and posts the whole entry (curated prose plus auto-generated bullets) to Discord, so subscribers always see what changed without clicking through.
 4. `pages.yml` deploys the docs site.
 
 ## Branch protection
@@ -144,7 +144,7 @@ Workflow scripts live in `.github/workflows/scripts/`, colocated with the workfl
 |--------|---------|---------|
 | `version.sh` | `regen.yml` | Compute next version via git-cliff, write changelog.mdx, write `.github/release-target`, render PR body. Also handles `--extract-prose` (parses prose out of a PR body on stdin) for the workflow's read-existing-prose step. |
 | `extract-release-notes.sh` | `release.yml`, `notify-discord.sh` | Extract the body of the latest `changelog.mdx` entry (no heading, no trailing `---`). Single source of truth for what GoReleaser and the Discord post see. |
-| `notify-discord.sh` | `release.yml` | Send release notification to Discord webhook (reads prose from the latest `changelog.mdx` entry via `extract-release-notes.sh`) |
+| `notify-discord.sh` | `release.yml` | Send release notification to Discord webhook (posts the latest `changelog.mdx` entry, fetched via `extract-release-notes.sh`) |
 | `version_test.sh` | `ci.yml`, manual | End-to-end tests for `version.sh` using scratch git repos |
 | `notify_discord_test.sh` | `ci.yml`, manual | Tests for `notify-discord.sh` |
 | `extract_release_notes_test.sh` | `ci.yml`, manual | Tests for `extract-release-notes.sh` |

--- a/.github/workflows/scripts/notify-discord.sh
+++ b/.github/workflows/scripts/notify-discord.sh
@@ -25,32 +25,19 @@ fi
 
 # ── Extract summary ──
 #
-# `extract-release-notes.sh` returns the body of the latest entry
-# (no heading, no trailing `---`). We split it at the first `### `
-# group heading to get prose vs bullets. Horizontal rules inside
-# prose survive: the trailing `---` we already stripped is the
-# per-entry separator, not a user-written rule.
-#
-# When prose is empty (a release without curated highlights), fall
-# back to the bullet list so Discord still sees what changed. An
-# empty announcement with only a changelog link is worse than a
-# slightly verbose one: most subscribers just want to know if there's
-# anything they care about without having to click through.
+# `extract-release-notes.sh` returns the body of the latest entry:
+# curated prose (if any) followed by the auto-generated `### ` group
+# headings and their bullets, no per-entry trailing `---`. We send it
+# as-is so Discord subscribers always see both the framing and the
+# detail without clicking through. When prose is empty the message
+# degrades naturally to bullets only.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CHANGELOG="${CHANGELOG:-apps/website/src/content/docs/changelog.mdx}"
 
 trim_blanks() { sed -e '/./,$!d' -e :a -e '/^\n*$/{$d;N;ba}'; }
 
-body=$(bash "$SCRIPT_DIR/extract-release-notes.sh" "$CHANGELOG")
-
-prose=$(echo "$body" | awk '/^### / { exit } { print }' | trim_blanks)
-bullets=$(echo "$body" | awk '/^### / { f = 1 } f { print }' | trim_blanks)
-
-summary="$prose"
-if [[ -z "${summary//[[:space:]]/}" ]]; then
-  summary="$bullets"
-fi
+summary=$(bash "$SCRIPT_DIR/extract-release-notes.sh" "$CHANGELOG" | trim_blanks)
 
 # ── Determine bump type ──
 

--- a/.github/workflows/scripts/notify_discord_test.sh
+++ b/.github/workflows/scripts/notify_discord_test.sh
@@ -8,8 +8,9 @@
 #   3. Stays under Discord's 2000-char limit, preferring a paragraph
 #      break to a hard byte cut.
 #   4. Always carries the changelog link, even when truncated.
-#   5. Reads release prose from the latest entry of changelog.mdx,
-#      falling back to the bullet list when prose is empty.
+#   5. Always includes the latest changelog entry (curated prose plus
+#      the auto-generated bullet groups) in the message body, so
+#      subscribers don't need to click through.
 #
 # Tests use DRY_RUN=1 to capture the payload as JSON and assert on its
 # structure (roles list, flags) rather than on the rendered string
@@ -166,15 +167,15 @@ echo "Embed suppression:"
   assert_eq "flags=4" "4" "$flags"
 )
 
-# ── Test: empty prose falls back to the bullet list ──
+# ── Test: bullets always reach Discord, with or without curated prose ──
 #
-# A patch release with no curated prose should still tell Discord
-# subscribers what changed. Sending only the changelog link forces
-# every subscriber to click through to find out if the release is
-# relevant; echoing the auto-generated bullets answers that inline.
+# Subscribers should never have to click through just to find out if a
+# release is relevant; echoing the auto-generated bullets answers that
+# inline. With curated prose, the prose sits above the bullets so
+# readers get framing plus detail.
 
 echo ""
-echo "Empty prose falls back to bullets:"
+echo "Bullets always included (no prose):"
 (
   tmp=$(mktemp -d); trap 'rm -rf "$tmp"' EXIT
   make_repo "$tmp" v1.5.3 v1.5.4
@@ -198,13 +199,13 @@ EOF
   assert_not_contains "no triple-newline gap"    $'\n\n\n'                 "$content"
 )
 
-# ── Test: prose present suppresses the bullet fallback ──
+# ── Test: prose and bullets both reach Discord when prose is present ──
 #
-# Otherwise we'd double up: curated prose + raw bullets. The Discord
-# message becomes verbose and the link footer feels redundant.
+# Curated prose sets the framing; bullets fill in the detail. We send
+# both so the message stands on its own.
 
 echo ""
-echo "Prose present suppresses bullet fallback:"
+echo "Bullets always included (with prose):"
 (
   tmp=$(mktemp -d); trap 'rm -rf "$tmp"' EXIT
   make_repo "$tmp" v1.5.3 v1.5.4
@@ -224,8 +225,8 @@ Hand-written highlight paragraph.
 EOF
 
   content=$(run_notify "$tmp" v1.5.4 | jq -r '.content')
-  assert_contains     "prose reaches Discord"          "Hand-written highlight"  "$content"
-  assert_not_contains "bullets do not duplicate prose" "stop leaking goroutines" "$content"
+  assert_contains "prose reaches Discord" "Hand-written highlight"  "$content"
+  assert_contains "bullets reach Discord" "stop leaking goroutines" "$content"
 )
 
 # ── Test: a literal `---` inside prose survives the prose/bullet split ──
@@ -258,9 +259,9 @@ Theme B summary.
 EOF
 
   content=$(run_notify "$tmp" v1.5.4 | jq -r '.content')
-  assert_contains     "first half of prose survives"  "Theme A summary" "$content"
-  assert_contains     "second half of prose survives" "Theme B summary" "$content"
-  assert_not_contains "bullets did not leak"          "something"       "$content"
+  assert_contains "first half of prose survives"  "Theme A summary" "$content"
+  assert_contains "second half of prose survives" "Theme B summary" "$content"
+  assert_contains "bullets reach Discord"         "something"       "$content"
 )
 
 # ── Test: trailing `---` separator does not leak into the summary ──


### PR DESCRIPTION
Subscribers should always see what changed inline, not just clickthrough to the changelog. Drop the prose-or-bullets split in `notify-discord.sh` and post the whole latest `changelog.mdx` entry: curated prose followed by the auto-generated `### ` group bullets.

When prose is empty the message degrades naturally to bullets only (same as before); when prose is present, bullets now also follow it instead of being suppressed.

## Changes

- **`notify-discord.sh`**: drop the prose/bullets awk split and the empty-prose fallback. The summary is now whatever `extract-release-notes.sh` returns, with leading/trailing blanks trimmed.
- **`notify_discord_test.sh`**: existing "prose present suppresses bullet fallback" test flipped to "both prose and bullets reach Discord". The horizontal-rule test now asserts that bullets follow the prose instead of being filtered out.
- **`.github/workflows/README.md`**: doc updated.