### PR TITLE
feat(web): replay scrollback for dead sessions (stacked on #208)

### DIFF
--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -461,7 +461,6 @@ function App() {
     <div class="app-layout">
       <Sidebar
         resumingId={resumingId}
-        onResume={handleResume}
         onCloseSession={handleCloseSession}
         onManageProjects={() => { setSidebarOpen(false); setManageProjectsOpen(true) }}
         open={sidebarOpen}
@@ -501,7 +500,6 @@ function App() {
         ) : viewVal?.kind === 'project' ? (
           <ProjectHub
             projectSlug={viewVal.projectSlug}
-            onResume={handleResume}
             onCloseSession={handleCloseSession}
           />
         ) : selectedVal && (canAttach || USE_MOCK) && termOpts && keybindsVal ? (

--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -4,6 +4,7 @@ import { LocationProvider, Router, Route, lazy, useLocation } from 'preact-iso'
 import '@xterm/xterm/css/xterm.css'
 import './styles.css'
 
+import { ReplayView } from './replay-view'
 import { TerminalView } from './terminal'
 import { useArrivalPulse } from './use-arrival-pulse'
 import { Sidebar } from './sidebar'
@@ -517,9 +518,17 @@ function App() {
             onPasteReady={handleTerminalPasteReady}
             onFocusReady={handleTerminalFocusReady}
           />
+        ) : selectedVal && !selectedVal.alive && termOpts && !USE_MOCK ? (
+          <ReplayView
+            session={selectedVal}
+            terminalOptions={termOpts}
+            onResume={handleResume}
+            onDismiss={handleCloseSession}
+            resuming={resumingId === selectedVal.id}
+          />
         ) : selectedVal ? (
           <div class="state-message">
-            <div class="state-subtitle">{selectedVal.alive ? 'Connecting…' : 'Session ended'}</div>
+            <div class="state-subtitle">Connecting…</div>
           </div>
         ) : (
           <Home />

--- a/apps/gmux-web/src/project-hub.tsx
+++ b/apps/gmux-web/src/project-hub.tsx
@@ -150,12 +150,6 @@ function SessionCard({
     <a
       class="session-card"
       href={href}
-      onClick={(e) => {
-        if (sleeping) {
-          e.preventDefault()
-          onResume(session.id)
-        }
-      }}
     >
       <span class={`session-card-dot ${dotClass}`} />
       <span class="session-card-name">{name}</span>

--- a/apps/gmux-web/src/project-hub.tsx
+++ b/apps/gmux-web/src/project-hub.tsx
@@ -22,11 +22,10 @@ function projectFirstPath(p: ProjectItem | undefined): string | undefined {
 
 interface ProjectHubProps {
   projectSlug: string
-  onResume: (id: string) => void
   onCloseSession: (session: Session) => void
 }
 
-export function ProjectHub({ projectSlug, onResume, onCloseSession }: ProjectHubProps) {
+export function ProjectHub({ projectSlug, onCloseSession }: ProjectHubProps) {
   const projectsVal = projects.value
   const project = projectsVal.find(p => p.slug === projectSlug)
   const hosts = buildProjectTopology(projectSlug, sessions.value, projectsVal, peers.value)
@@ -62,7 +61,6 @@ export function ProjectHub({ projectSlug, onResume, onCloseSession }: ProjectHub
               key={host.path.join('\0') || '(local)'}
               host={host}
               projectSlug={projectSlug}
-              onResume={onResume}
               onCloseSession={onCloseSession}
             />
           ))}
@@ -85,8 +83,8 @@ function EmptyProject({ projectSlug, launchCwd }: { projectSlug: string; launchC
 }
 
 function HostGroup({
-  host, projectSlug, onResume, onCloseSession,
-}: { host: HostNode; projectSlug: string; onResume: (id: string) => void; onCloseSession: (session: Session) => void }) {
+  host, projectSlug, onCloseSession,
+}: { host: HostNode; projectSlug: string; onCloseSession: (session: Session) => void }) {
   const sessionCount = host.folders.reduce((n, f) => n + f.sessions.length, 0)
   const canLaunch = host.path.length <= 1
   const launchPeer = host.path.length === 1 ? host.path[0] : undefined
@@ -110,7 +108,6 @@ function HostGroup({
                 key={s.id}
                 session={s}
                 projectSlug={projectSlug}
-                onResume={onResume}
                 onClose={() => onCloseSession(s)}
               />
             ))}
@@ -140,10 +137,9 @@ function HostPath({ path }: { path: string[] }) {
 }
 
 function SessionCard({
-  session, projectSlug, onResume, onClose,
-}: { session: Session; projectSlug: string; onResume: (id: string) => void; onClose: () => void }) {
+  session, projectSlug, onClose,
+}: { session: Session; projectSlug: string; onClose: () => void }) {
   const dotClass = session.alive ? '' : 'dead'
-  const sleeping = !session.alive && session.resumable
   const name = session.title || session.kind
   const href = sessionPath(projectSlug, session)
   return (

--- a/apps/gmux-web/src/replay-fetch.test.ts
+++ b/apps/gmux-web/src/replay-fetch.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test, vi } from 'vitest'
+import { fetchScrollback } from './replay-fetch'
+
+function ok(body: BodyInit, init?: ResponseInit): Response {
+  return new Response(body, { status: 200, ...init })
+}
+
+describe('fetchScrollback', () => {
+  test('200 with bytes returns kind=bytes with the response body', async () => {
+    const payload = new Uint8Array([0x68, 0x69, 0x0d, 0x0a]) // "hi\r\n"
+    const fakeFetch = vi.fn().mockResolvedValue(ok(payload))
+
+    const result = await fetchScrollback('sess-abc', fakeFetch)
+
+    expect(fakeFetch).toHaveBeenCalledWith('/v1/sessions/sess-abc/scrollback')
+    expect(result).toEqual({ kind: 'bytes', bytes: payload })
+  })
+
+  test('200 with empty body returns kind=empty', async () => {
+    const fakeFetch = vi.fn().mockResolvedValue(ok(new Uint8Array(0)))
+
+    const result = await fetchScrollback('sess-empty', fakeFetch)
+
+    expect(result).toEqual({ kind: 'empty' })
+  })
+
+  test('404 returns kind=not-found', async () => {
+    const fakeFetch = vi.fn().mockResolvedValue(new Response('not found', { status: 404 }))
+
+    const result = await fetchScrollback('sess-missing', fakeFetch)
+
+    expect(result).toEqual({ kind: 'not-found' })
+  })
+
+  test('5xx returns kind=error with status and message', async () => {
+    const fakeFetch = vi.fn().mockResolvedValue(new Response('boom', { status: 500, statusText: 'Internal Server Error' }))
+
+    const result = await fetchScrollback('sess-bad', fakeFetch)
+
+    expect(result).toEqual({ kind: 'error', status: 500, message: 'Internal Server Error' })
+  })
+
+  test('network failure returns kind=error with status 0', async () => {
+    const fakeFetch = vi.fn().mockRejectedValue(new Error('connection refused'))
+
+    const result = await fetchScrollback('sess-x', fakeFetch)
+
+    expect(result).toEqual({ kind: 'error', status: 0, message: 'connection refused' })
+  })
+
+  test('peer-owned session id is URL-encoded', async () => {
+    const fakeFetch = vi.fn().mockResolvedValue(ok(new Uint8Array(0)))
+
+    await fetchScrollback('sess-abc@hs', fakeFetch)
+
+    // @ would otherwise be unsafe in some HTTP routers; verify the call site
+    // round-trips through encodeURIComponent.
+    expect(fakeFetch).toHaveBeenCalledWith('/v1/sessions/sess-abc%40hs/scrollback')
+  })
+})

--- a/apps/gmux-web/src/replay-fetch.test.ts
+++ b/apps/gmux-web/src/replay-fetch.test.ts
@@ -48,6 +48,25 @@ describe('fetchScrollback', () => {
     expect(result).toEqual({ kind: 'error', status: 0, message: 'connection refused' })
   })
 
+  test('arrayBuffer rejection mid-body returns kind=error instead of throwing', async () => {
+    // Simulate the wire dropping after headers arrive: the
+    // response is a 200 but reading the body rejects.
+    const body = new ReadableStream({
+      start(controller) {
+        controller.error(new Error('aborted'))
+      },
+    })
+    const fakeFetch = vi.fn().mockResolvedValue(new Response(body, { status: 200 }))
+
+    const result = await fetchScrollback('sess-abc', fakeFetch)
+
+    expect(result.kind).toBe('error')
+    if (result.kind === 'error') {
+      expect(result.status).toBe(200)
+      expect(result.message).toContain('aborted')
+    }
+  })
+
   test('peer-owned session id is URL-encoded', async () => {
     const fakeFetch = vi.fn().mockResolvedValue(ok(new Uint8Array(0)))
 

--- a/apps/gmux-web/src/replay-fetch.ts
+++ b/apps/gmux-web/src/replay-fetch.ts
@@ -41,9 +41,18 @@ export async function fetchScrollback(
     return { kind: 'error', status: resp.status, message: resp.statusText || 'request failed' }
   }
 
-  const buf = await resp.arrayBuffer()
+  // Body read can still reject after headers arrive (connection
+  // aborted mid-stream). Without this catch the caller would see
+  // an unhandled rejection and the UI would stall on 'Loading…'
+  // forever.
+  let buf: ArrayBuffer
+  try {
+    buf = await resp.arrayBuffer()
+  } catch (e) {
+    return { kind: 'error', status: resp.status, message: e instanceof Error ? e.message : String(e) }
+  }
   if (buf.byteLength === 0) {
-    return { kind: "empty" }
+    return { kind: 'empty' }
   }
   return { kind: 'bytes', bytes: new Uint8Array(buf) }
 }

--- a/apps/gmux-web/src/replay-fetch.ts
+++ b/apps/gmux-web/src/replay-fetch.ts
@@ -1,0 +1,49 @@
+// Fetches persisted scrollback for a (typically dead) session from the
+// gmuxd broker endpoint at GET /v1/sessions/<id>/scrollback.
+//
+// Response semantics (see services/gmuxd/cmd/gmuxd/scrollback.go):
+//   200 + bytes  →  raw PTY scrollback (octet-stream)
+//   200 + empty  →  session is known but no scrollback was captured
+//                   (e.g. died before scrollback persistence shipped,
+//                    or fast-exited before any output)
+//   404          →  session unknown to this gmuxd
+//   5xx          →  server-side I/O error
+//
+// Peer-owned sessions are forwarded transparently by the hub, so callers
+// don't need to special-case `id@peer`.
+
+export type ScrollbackResult =
+  | { kind: 'bytes'; bytes: Uint8Array }
+  | { kind: 'empty' }
+  | { kind: 'not-found' }
+  | { kind: 'error'; status: number; message: string }
+
+/** Inject-friendly fetcher; defaults to global fetch. */
+export type FetchFn = (input: RequestInfo, init?: RequestInit) => Promise<Response>
+
+export async function fetchScrollback(
+  sessionId: string,
+  fetchImpl: FetchFn = fetch,
+): Promise<ScrollbackResult> {
+  const url = `/v1/sessions/${encodeURIComponent(sessionId)}/scrollback`
+
+  let resp: Response
+  try {
+    resp = await fetchImpl(url)
+  } catch (e) {
+    return { kind: 'error', status: 0, message: e instanceof Error ? e.message : String(e) }
+  }
+
+  if (resp.status === 404) {
+    return { kind: 'not-found' }
+  }
+  if (!resp.ok) {
+    return { kind: 'error', status: resp.status, message: resp.statusText || 'request failed' }
+  }
+
+  const buf = await resp.arrayBuffer()
+  if (buf.byteLength === 0) {
+    return { kind: "empty" }
+  }
+  return { kind: 'bytes', bytes: new Uint8Array(buf) }
+}

--- a/apps/gmux-web/src/replay-view.tsx
+++ b/apps/gmux-web/src/replay-view.tsx
@@ -93,6 +93,12 @@ export function ReplayView({
       setState(result)
       if (result.kind === 'bytes') {
         term.write(result.bytes, () => {
+          // The write callback is async: between term.write and the
+          // callback firing, the effect's cleanup may have run
+          // (component unmount / session.id switch) and disposed
+          // the terminal. Calling scrollToBottom on a disposed
+          // terminal throws.
+          if (cancelled) return
           // Wait for the write callback so xterm has actually parsed the
           // bytes before we ask it to scroll; otherwise scrollToBottom
           // pins us at row 0 because the buffer is still empty.

--- a/apps/gmux-web/src/replay-view.tsx
+++ b/apps/gmux-web/src/replay-view.tsx
@@ -1,0 +1,170 @@
+import { useEffect, useRef, useState } from 'preact/hooks'
+import { Terminal } from '@xterm/xterm'
+import { FitAddon } from '@xterm/addon-fit'
+import { ImageAddon } from '@xterm/addon-image'
+import { WebLinksAddon } from '@xterm/addon-web-links'
+import { WebglAddon } from '@xterm/addon-webgl'
+import type { ITerminalOptions } from '@xterm/xterm'
+import type { Session } from './types'
+import { fetchScrollback, type ScrollbackResult } from './replay-fetch'
+
+// gmuxd caps scrollback at 1 MiB × 2 files (~2 MiB max). xterm's default
+// scrollback line cap (1000) would silently truncate most of that for
+// text-heavy sessions; bump it for replay so the user can scroll the full
+// captured history.
+const REPLAY_SCROLLBACK_LINES = 10000
+
+function loadPreferredRenderer(term: Terminal) {
+  try { term.loadAddon(new WebglAddon()) } catch { /* DOM fallback */ }
+}
+
+type ReplayState =
+  | { kind: 'loading' }
+  | ScrollbackResult
+
+/**
+ * Read-only xterm view that replays a dead session's persisted scrollback
+ * from the gmuxd broker. No WebSocket, no input, no resize messages: this
+ * is purely a viewer for bytes that already happened.
+ *
+ * The terminal is recreated when `session.id` changes (matching the
+ * sidebar-click model). Live sessions go through TerminalView instead;
+ * see main.tsx for the routing.
+ *
+ * The action bar at the bottom carries the lifecycle controls that
+ * previously lived as auto-trigger-on-click in the sidebar: Resume
+ * (if the adapter is resumable) and Dismiss. Promoting them out of an
+ * implicit click means clicking a dead session navigates to its
+ * scrollback first, and any state-changing action is a deliberate
+ * second click.
+ */
+export function ReplayView({
+  session,
+  terminalOptions,
+  onResume,
+  onDismiss,
+  resuming,
+}: {
+  session: Session
+  terminalOptions: ITerminalOptions
+  onResume?: (id: string) => void
+  onDismiss?: (session: Session) => void
+  resuming?: boolean
+}) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [state, setState] = useState<ReplayState>({ kind: 'loading' })
+
+  useEffect(() => {
+    if (!containerRef.current) return
+
+    const term = new Terminal({
+      ...terminalOptions,
+      scrollback: REPLAY_SCROLLBACK_LINES,
+      disableStdin: true,
+      cursorBlink: false,
+      cursorInactiveStyle: 'none',
+      linkHandler: {
+        activate(_event, text) {
+          window.open(text, '_blank', 'noopener')
+        },
+      },
+    })
+    const fit = new FitAddon()
+    term.loadAddon(fit)
+    term.loadAddon(new ImageAddon())
+    term.loadAddon(new WebLinksAddon())
+    term.open(containerRef.current)
+    loadPreferredRenderer(term)
+    fit.fit()
+
+    // OSC 52 (set clipboard) suppression: the captured bytes may contain
+    // OSC 52 sequences emitted by the *original* live session; replaying
+    // them would silently overwrite the operator's clipboard. Swallow.
+    term.parser.registerOscHandler(52, () => true)
+
+    // Expose for e2e tests (matches TerminalView's window.__gmuxTerm).
+    ;(window as any).__gmuxTerm = term
+
+    setState({ kind: 'loading' })
+
+    let cancelled = false
+    fetchScrollback(session.id).then((result) => {
+      if (cancelled) return
+      setState(result)
+      if (result.kind === 'bytes') {
+        term.write(result.bytes, () => {
+          // Wait for the write callback so xterm has actually parsed the
+          // bytes before we ask it to scroll; otherwise scrollToBottom
+          // pins us at row 0 because the buffer is still empty.
+          term.scrollToBottom()
+        })
+      }
+    })
+
+    const onResize = () => fit.fit()
+    window.addEventListener('resize', onResize)
+
+    return () => {
+      cancelled = true
+      window.removeEventListener('resize', onResize)
+      if ((window as any).__gmuxTerm === term) (window as any).__gmuxTerm = null
+      term.dispose()
+    }
+  }, [session.id])
+
+  const exitLabel = session.exit_code != null
+    ? `Session ended (exit ${session.exit_code})`
+    : 'Session ended'
+
+  return (
+    <div class="replay-root">
+      <div class="terminal-shell">
+        <div ref={containerRef} class="terminal-container" />
+        {state.kind === 'loading' && (
+          <div class="terminal-loading">
+            Loading scrollback…
+          </div>
+        )}
+        {state.kind === 'empty' && (
+          <div class="terminal-loading">
+            No scrollback was captured for this session.
+          </div>
+        )}
+        {state.kind === 'not-found' && (
+          <div class="terminal-loading">
+            This session is no longer known to gmuxd.
+          </div>
+        )}
+        {state.kind === 'error' && (
+          <div class="terminal-loading">
+            Couldn't load scrollback (HTTP {state.status}: {state.message}).
+          </div>
+        )}
+      </div>
+      <div class="replay-actions">
+        <span class="replay-status">{exitLabel}</span>
+        <div class="replay-buttons">
+          {session.resumable && onResume && (
+            <button
+              type="button"
+              class="btn btn-primary"
+              disabled={!!resuming}
+              onClick={() => onResume(session.id)}
+            >
+              {resuming ? 'Resuming…' : 'Resume'}
+            </button>
+          )}
+          {onDismiss && (
+            <button
+              type="button"
+              class="btn"
+              onClick={() => onDismiss(session)}
+            >
+              Dismiss
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/gmux-web/src/sidebar.tsx
+++ b/apps/gmux-web/src/sidebar.tsx
@@ -118,12 +118,8 @@ function SessionItem({
       class={cls}
       href={href}
       draggable={canDrag && !!onDragStart}
-      onClick={(e) => {
+      onClick={() => {
         onClick?.()
-        if (sleeping) {
-          e.preventDefault()
-          onResume?.(session.id)
-        }
       }}
       onAuxClick={(e) => { if (e.button === 1 && onClose) { e.preventDefault(); onClose() } }}
       onDragStart={(e) => {

--- a/apps/gmux-web/src/sidebar.tsx
+++ b/apps/gmux-web/src/sidebar.tsx
@@ -78,7 +78,6 @@ function SessionItem({
   dotState: rawDotState,
   dragging,
   dropTarget,
-  onResume,
   onClose,
   onClick,
   onDragStart,
@@ -92,7 +91,6 @@ function SessionItem({
   dotState: DotState
   dragging?: boolean
   dropTarget?: boolean
-  onResume?: (id: string) => void
   onClose?: () => void
   /** Extra side-effects on click (e.g. close mobile sidebar). */
   onClick?: () => void
@@ -166,7 +164,6 @@ function FolderGroup({
   curProjectSlug,
   resumingId,
   am,
-  onResume,
   onCloseSession,
   onClick,
 }: {
@@ -176,7 +173,6 @@ function FolderGroup({
   curProjectSlug: string | null
   resumingId: string | null
   am: ReadonlyMap<string, 'active' | 'fading'>
-  onResume: (id: string) => void
   onCloseSession: (session: Session) => void
   onClick?: () => void
 }) {
@@ -236,7 +232,6 @@ function FolderGroup({
             dotState={sessionDotState(s, am)}
             dragging={drag !== null && s.id === visible[drag.from]?.id}
             dropTarget={drag !== null && drag.over === i && drag.from !== i}
-            onResume={onResume}
             onClose={() => onCloseSession(s)}
             onClick={onClick}
             onDragStart={() => handleDragStart(i)}
@@ -251,7 +246,6 @@ function FolderGroup({
 
 export function Sidebar({
   resumingId,
-  onResume,
   onCloseSession,
   onManageProjects,
   open,
@@ -260,7 +254,6 @@ export function Sidebar({
   onRequestNotifPermission,
 }: {
   resumingId: string | null
-  onResume: (id: string) => void
   onCloseSession: (session: Session) => void
   onManageProjects: () => void
   open: boolean
@@ -323,7 +316,6 @@ export function Sidebar({
                 curProjectSlug={curProjectSlug}
                 resumingId={resumingId}
                 am={am}
-                onResume={onResume}
                 onCloseSession={onCloseSession}
                 onClick={onClose}
               />

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -2263,3 +2263,44 @@ a.home-host-link:hover {
   transition: background 0.1s, color 0.1s;
 }
 .session-card-close:hover { background: oklch(28% 0.015 250); color: var(--text); }
+.btn:disabled,
+.btn-primary:disabled {
+  opacity: 0.6;
+  cursor: progress;
+}
+
+/* Replay (read-only dead session) layout: terminal area fills remaining
+   vertical space, action bar pinned beneath. The action bar carries the
+   resume/dismiss buttons that the sidebar used to auto-trigger on click. */
+.replay-root {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.replay-root > .terminal-shell {
+  flex: 1;
+  min-height: 0;
+}
+
+.replay-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 16px;
+  background: var(--bg-surface);
+  border-top: 1px solid var(--border);
+}
+
+.replay-status {
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+.replay-buttons {
+  display: flex;
+  gap: 8px;
+}
+


### PR DESCRIPTION
**Stacked on #208.** Lifts the visible UX changes from #206 onto the resume-id-passthrough stack so the full resume flow is reachable through the browser.

## What's in here

Two commits.

- **`feat(web): replay scrollback for dead sessions`**
  - **`replay-view.tsx`** (new) — read-only xterm that fetches `/v1/sessions/<id>/scrollback`, replays the captured bytes, and offers Resume / Dismiss in an action bar.
  - **`replay-fetch.ts`** + **`replay-fetch.test.ts`** (new) — small typed wrapper around the broker endpoint with branches for bytes / empty / 404 / error.
  - **`main.tsx`** — routes `selectedVal && !alive` to `ReplayView`; live sessions still go through `TerminalView`.
  - **`sidebar.tsx`** + **`project-hub.tsx`** — drop the auto-resume-on-sidebar-click handler. Selection (navigate to view) and resumption (explicit button) are now separate.
  - **`styles.css`** — replay layout (terminal fills, action bar pinned).

- **`fix(web): guard replay against disposed terminal and aborted response body`** — caught by Greptile review:
  - `term.write`'s callback fires async; between scheduling the write and the callback running, the effect's cleanup may have run (component unmount or `session.id` switch) and disposed the terminal. Guarded with the `cancelled` flag.
  - `arrayBuffer()` sat outside the try/catch in `replay-fetch.ts`; a body-stream abort after headers arrived would reject the `fetchScrollback` promise and the UI would silently stall on "Loading scrollback…". Wrapped in try/catch.
  - Bundles a lint cleanup: dropped `onResume` threading through `Sidebar` / `ProjectHub` (now exclusively driven from `ReplayView`'s button) and the unused `sleeping` const.

## Why stacked instead of just rebasing #206

The id-passthrough work in #208 makes resume actually preserve scrollback at the canonical session directory (the mismatch documented in ADR 0003 is what produced the original "no scrollback was captured" report). Without #208, `ReplayView` would render against a broker that reads from one path while the runner writes to another. Stacking ensures the two ship coherent: the user clicks a dead session, sees its scrollback, clicks Resume, the runner reuses the same id, and the post-resume scrollback continues to be served correctly.

## What this defers

ADR 0004's deeper architecture — `SessionStream`, pooled byte buffers, replacing `TerminalView`'s WS handling, seamless live↔dead transitions — is **not** in this PR. The ADR stays in the repo as the design of record (committed in #208). Rationale: `TerminalView` is 1037 lines of intricate WS / resize / scroll / paste / mobile-input / image-protocol logic; the seamless-flip and image-state-preserving wins are real but quality-of-life, with no specific user-reported bug that's their unique fix. We can pick up 0004 when there's a concrete motivating scenario or a slack moment.

`terminalOptions` deliberately omitted from `ReplayView`'s `useEffect` deps array (Greptile flagged): adding it would cause remount-storms unless the parent memoizes the options object, and there's no concrete need (theme/font preferences don't change while staring at a dead session, and switching unblocks naturally on next session selection).

## Verification

- All 310 frontend tests pass (`vitest run`), including the 7 `replay-fetch.test.ts` cases (one new for the arrayBuffer-rejection branch).
- `tsc --noEmit` clean.
- Backend story (PR #208) verified end-to-end against `sess-93db1e98`: Resume → runner adopts canonical id → 1423 bytes at the canonical scrollback path → broker serves them. With this PR on top, that flow is reachable through the UI.

## Closes

#206 (superseded by this stacked port + the id-passthrough fix it depends on)
