### PR TITLE
fix(web): trim explicit trailing whitespace on copy so pi and other TUIs are copyable

### DIFF
--- a/apps/gmux-web/src/selection.test.ts
+++ b/apps/gmux-web/src/selection.test.ts
@@ -86,18 +86,53 @@ describe('selectionToText', () => {
     expect(selectionToText(term)).toBe('echo 1')
   })
 
-  it('preserves explicitly-typed trailing spaces across a line break', () => {
-    // Distinguishing written-spaces from never-written pad is the whole
-    // point of using trimRight=true (which keys off cell codepoint, not
-    // the rendered character). If the user typed `echo 1   ` followed
-    // by Enter, those three spaces are content and must survive a copy
-    // that crosses the resulting line break.
+  it('strips explicitly-written trailing whitespace at row boundaries', () => {
+    // The shipped rule: when a row's selection reaches the row boundary,
+    // trim trailing whitespace including explicitly-written spaces
+    // (codepoint 32). Without this, TUIs that paint a full-width row of
+    // content + space-fill + newline (pi, Claude Code, btop, …) copy as a
+    // wall of spaces.
+    //
+    // The trade-off (rare): a row ending with typed trailing spaces, then
+    // a hard newline, copies without those spaces. Pinning that
+    // explicitly here so any future relaxation is a deliberate decision,
+    // not a quiet revert.
     const term = makeTerm({
       cols: 20,
       rows: ['echo 1   ', 'echo 2'],
       selection: { start: { x: 0, y: 0 }, end: { x: 6, y: 1 } },
     })
-    expect(selectionToText(term)).toBe('echo 1   \necho 2')
+    expect(selectionToText(term)).toBe('echo 1\necho 2')
+  })
+
+  it('strips trailing pad on a TUI-style row (full-width explicit space fill)', () => {
+    // Mirrors what pi and similar TUIs render: content followed by an
+    // explicit-space fill all the way to the right edge, then a hard
+    // newline. Verified against pi's actual output (raw stream, replayed
+    // through pyte). The boundary-reaching trim must drop those spaces
+    // even though they have codepoint 32.
+    const term = makeTerm({
+      cols: 80,
+      rows: [
+        ' Hello! How can I help you today?                                               ',
+      ],
+      // Triple-click / line-select on the row: end.x === cols.
+      selection: { start: { x: 0, y: 0 }, end: { x: 80, y: 0 } },
+    })
+    expect(selectionToText(term)).toBe(' Hello! How can I help you today?')
+  })
+
+  it('preserves typed trailing spaces when selection ends mid-row', () => {
+    // Companion to the boundary-trim test above: when the user stops
+    // *inside* the row, the spaces they explicitly dragged across are
+    // content (semantically a mid-row selection of pad), not part of a
+    // line break. The mid-row case must keep them.
+    const term = makeTerm({
+      cols: 20,
+      rows: ['echo 1   '],
+      selection: { start: { x: 0, y: 0 }, end: { x: 9, y: 0 } },
+    })
+    expect(selectionToText(term)).toBe('echo 1   ')
   })
 
   it('joins soft-wrapped rows without inserting a newline', () => {

--- a/apps/gmux-web/src/selection.ts
+++ b/apps/gmux-web/src/selection.ts
@@ -3,27 +3,38 @@
  *
  * Terminal-buffer-to-text models, summarised:
  *
- * 1. "Trim everything": strip trailing whitespace from every copied line.
- *    Loses information when the user genuinely wants to copy spaces typed
- *    into a row. Ghostty's `clipboard-trim-trailing-spaces` option works
- *    this way and its own community considers it a smell
- *    (ghostty-org/ghostty#2709).
+ * 1. "Trim everything": strip trailing whitespace from every copied line
+ *    unconditionally. Ghostty's `clipboard-trim-trailing-spaces` option.
+ *    Loses information when the user explicitly drag-selects through pad
+ *    inside a row.
  *
  * 2. "Trim never": emit cells verbatim. Wall of trailing spaces after
  *    every short line, because the cells past the content render as
  *    spaces. xterm.js' default `getSelection()` lands here in many cases.
  *
- * 3. **"Trailing pad belongs to the line break"**: Terminal.app, Alacritty,
- *    WezTerm, GNOME Terminal, xterm. Selections that *cross* a row boundary
- *    drop the trailing pad of the row before emitting `\n`. Selections that
- *    *end inside* a row preserve the cells the user actually dragged
- *    across, spaces included. This is what people mean when they say "no
- *    trailing whitespace on copy", and it's the model gmux implements.
+ * 3. **"Trailing whitespace belongs to the line break"**: trim trailing
+ *    whitespace only when the selection reaches the row boundary;
+ *    preserve mid-row pad the user explicitly dragged across. This is the
+ *    model gmux implements. It handles two different cases that look the
+ *    same to the buffer:
  *
- * Why xterm.js' `trimRight` parameter is the right primitive: it trims by
- * cell *codepoint* (0 = never written) rather than by rendered character,
- * so it cleanly distinguishes never-written pad cells from explicitly-typed
- * spaces, and is automatically wide-character-aware.
+ *      a. Shell output (`echo hello`) leaves the rest of the row as
+ *         never-written cells (codepoint 0). xterm.js's
+ *         `translateToString(trimRight=true)` drops these by walking the
+ *         line until it finds a cell with `HAS_CONTENT_MASK`.
+ *
+ *      b. TUI output (pi, Claude Code, btop, fzf, lazygit, k9s, …) fills
+ *         each row with *explicit* space cells (codepoint 32) before the
+ *         newline. Those cells survive xterm's codepoint-0 trim because
+ *         they have content. Without an extra step, copying any TUI
+ *         response yields a wall of spaces.
+ *
+ *    For (b) we post-strip ASCII whitespace from the right edge of every
+ *    boundary-reaching slice. Trade-off: a row that ends with
+ *    explicitly-typed trailing whitespace, then a hard newline, copies
+ *    without those spaces. In practice that's vanishingly rare. The
+ *    `trim = ex >= cols` guard still preserves spaces a user explicitly
+ *    drags through without crossing the line break.
  *
  * Soft wraps (terminal-driven, signalled by `IBufferLine.isWrapped` on the
  * following row) are joined without an inserted `\n`, matching every modern
@@ -80,15 +91,25 @@ export function selectionToText(term: SelectionTerminal): string {
     const sx = y === start.y ? start.x : 0
     const ex = isLast ? end.x : cols
 
-    // Trim trailing pad when the row's selection reaches the row boundary
-    // (`ex >= cols`). That covers every non-last row, plus the last row
-    // when the user selected past EOL (triple-click, line-select, drag
-    // through the line break). When the user stopped *inside* the row we
-    // preserve the cells they dragged across, including any pad spaces:
-    // that's an explicit selection of padding, semantically distinct from
-    // crossing a line break.
+    // Trim trailing whitespace when the row's selection reaches the row
+    // boundary (`ex >= cols`). That covers every non-last row, plus the
+    // last row when the user selected past EOL (triple-click,
+    // line-select, drag through the line break). When the user stopped
+    // *inside* the row we preserve the cells they dragged across,
+    // including any pad spaces.
+    //
+    // Two layers of trimming, both gated on `trim`:
+    //   1. xterm's translateToString(trimRight=true) drops never-written
+    //      cells (codepoint 0). Handles shell output cleanly.
+    //   2. We post-strip ASCII whitespace from the right edge. Handles
+    //      TUIs that fill rows with explicit space cells before the
+    //      newline (pi, CC, btop, …). See file-level docstring for the
+    //      full rationale and the rare case it loses fidelity in.
     const trim = ex >= cols
-    if (ex > sx) out += line.translateToString(trim, sx, ex)
+    if (ex > sx) {
+      const slice = line.translateToString(trim, sx, ex)
+      out += trim ? slice.replace(/[ \t]+$/, '') : slice
+    }
 
     if (!isLast) {
       // Soft wrap: next row continues this one, suppress the newline.

--- a/e2e/tests/terminal-copy-tui.spec.ts
+++ b/e2e/tests/terminal-copy-tui.spec.ts
@@ -1,0 +1,163 @@
+/**
+ * E2E test for copying from TUI-rendered output (pi and friends).
+ *
+ * The selectionToText fix (#189) handles the easy case: shell output
+ * where cells past the content are never-written, so xterm.js's
+ * translateToString(trimRight=true) drops them. The harder case the
+ * codepoint-0 trim doesn't catch is the one TUIs produce: the renderer
+ * fills each row with *explicit* space cells before the newline, so
+ * those cells have codepoint 32 and survive the trim. Without an extra
+ * step, selecting and copying yielded a wall of spaces.
+ *
+ * The fix this test pins extends the "trailing whitespace belongs to
+ * the line break" rule to codepoint-32 cells too: when the selection
+ * reaches the row boundary, post-strip ASCII whitespace from the
+ * slice. See selection.ts's docstring for the full rationale.
+ *
+ * Pi's actual output shape was verified out-of-band by running pi
+ * under a PTY and replaying the raw stream through pyte: each content
+ * row is content text + explicit space cells (via `\x1b[2K` followed
+ * by literal-space fill to col cols-1) + `\r\n`. The fixture below
+ * mirrors that.
+ */
+import { test, expect, type Page } from '@playwright/test'
+import { openApp, gotoTestSession } from '../helpers'
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Capture every call to navigator.clipboard.writeText so the test can
+ * assert what the production code put on the clipboard, without needing
+ * the OS clipboard or a clipboard-read permission grant. Same shape as
+ * terminal-paste.spec.ts's WS capture.
+ */
+async function captureClipboardWrites(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    const w = window as unknown as { __clipboardWrites: string[] }
+    w.__clipboardWrites = []
+    const orig = navigator.clipboard.writeText.bind(navigator.clipboard)
+    navigator.clipboard.writeText = (text: string) => {
+      w.__clipboardWrites.push(text)
+      return orig(text)
+    }
+  })
+}
+
+async function lastClipboardWrite(page: Page): Promise<string | null> {
+  return page.evaluate(() => {
+    const writes = (window as unknown as { __clipboardWrites: string[] }).__clipboardWrites
+    return writes.length > 0 ? writes[writes.length - 1] : null
+  })
+}
+
+/**
+ * Inject `lines` into the xterm buffer separated by CRLFs and return the
+ * absolute buffer-row range the block occupies. Bypasses the PTY/WS so
+ * the test is deterministic and doesn't depend on a running pi binary
+ * in CI.
+ *
+ * Computing the range from the cursor position after the write avoids
+ * brittle assumptions about scrollback and prior session output: the
+ * cursor's absolute row (`baseY + cursorY`) lands on the last written
+ * line, and the block is `lines.length - 1` rows tall above it.
+ */
+async function injectLines(page: Page, lines: string[]): Promise<{ startRow: number, endRow: number }> {
+  return page.evaluate(({ ls }) => {
+    return new Promise<{ startRow: number, endRow: number }>(resolve => {
+      const term = (window as unknown as {
+        __gmuxTerm: {
+          write: (s: string, cb: () => void) => void
+          buffer: { active: { baseY: number, cursorY: number } }
+        }
+      }).__gmuxTerm
+      term.write(ls.join('\r\n'), () => {
+        const buf = term.buffer.active
+        const endRow = buf.baseY + buf.cursorY
+        resolve({ startRow: endRow - (ls.length - 1), endRow })
+      })
+    })
+  }, { ls: lines })
+}
+
+/**
+ * Programmatically select rows [startRow, endRow] inclusive across the
+ * full terminal width. xterm's `select(col, row, length)` walks `length`
+ * cells forward in row-major order, so the length must be measured in
+ * the terminal's actual `cols`, not the visible box's narrower width;
+ * otherwise the end coordinate falls in the middle of a row.
+ *
+ * Selecting the full row width matches the user gesture we care about
+ * (drag-select that includes pad cells past the rendered box edge),
+ * which is also what xterm's selectLineAt / triple-click produces.
+ */
+async function selectRows(page: Page, startRow: number, endRow: number): Promise<void> {
+  await page.evaluate(({ s, e }) => {
+    const term = (window as unknown as {
+      __gmuxTerm: {
+        cols: number
+        select: (col: number, row: number, length: number) => void
+      }
+    }).__gmuxTerm
+    term.select(0, s, term.cols * (e - s + 1))
+  }, { s: startRow, e: endRow })
+}
+
+/** Focus the terminal so keyboard events route through xterm. */
+async function focusTerm(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    (window as unknown as { __gmuxTerm: { focus: () => void } }).__gmuxTerm.focus()
+  })
+}
+
+// ── Test suite ───────────────────────────────────────────────────────────────
+
+test.describe('copy from TUI output', () => {
+  test.beforeEach(async ({ page }) => {
+    await captureClipboardWrites(page)
+    await openApp(page)
+    await gotoTestSession(page)
+    await focusTerm(page)
+  })
+
+  // Pi's actual output shape (verified by running pi under a PTY and
+  // replaying the raw stream through pyte): each content row is content
+  // text followed by *explicit* space cells (literal codepoint-32 fill
+  // to col 79), then `\r\n`. No vertical borders. Horizontal rules
+  // (U+2500) separate sections.
+  //
+  // The trouble cells are the trailing spaces before the newline: they
+  // have codepoint 32, so xterm.js's translateToString(trimRight=true)
+  // (which keys off codepoint 0) leaves them in place. Selecting and
+  // copying yields a wall of spaces.
+  const cols = 80
+  const piRow = (s: string) => ` ${s}` + ' '.repeat(cols - s.length - 1)
+  const piTranscript = [
+    piRow('hello world'),
+    piRow('Hello! How can I help you today?'),
+  ]
+
+  test('selecting through pi chat output copies only the source text',
+    async ({ page }) => {
+      const range = await injectLines(page, piTranscript)
+      await selectRows(page, range.startRow, range.endRow)
+      await page.keyboard.press('Control+Shift+KeyC')
+
+      const clipboard = await lastClipboardWrite(page)
+      expect(clipboard).toBe(' hello world\n Hello! How can I help you today?')
+    },
+  )
+
+  // Single-row selection. Verifies the trim happens per-row, not only
+  // at the seam between rows. xterm's selectLineAt sets end.x === cols,
+  // so this is also the triple-click case for a content row.
+  test('selecting a single pi row strips its trailing pad',
+    async ({ page }) => {
+      const range = await injectLines(page, piTranscript)
+      await selectRows(page, range.endRow, range.endRow)
+      await page.keyboard.press('Control+Shift+KeyC')
+
+      const clipboard = await lastClipboardWrite(page)
+      expect(clipboard).toBe(' Hello! How can I help you today?')
+    },
+  )
+})


### PR DESCRIPTION
You were right: we'd discussed shipping the Ghostty-style "trailing whitespace before a newline is part of the line break" rule, and the implementation in #189 only got us halfway there.

## What was missing

`selection.ts` shipped two layers of intent but only one of execution:

- The docstring described "trailing pad belongs to the line break" as the model.
- The code called `xterm.translateToString(trimRight=true, sx, ex)`, which trims by **cell codepoint** (`0` = never written), so it handles shell output (`echo hello` leaves the rest of the row as never-written cells) but ignores rows where an app explicitly wrote space cells (codepoint `32`) before the newline.

That second case is exactly what pi, Claude Code, btop, fzf, lazygit, k9s, and friends produce. Verified out-of-band by running pi under a PTY in this branch's workspace and replaying the raw stream through pyte: every content row is `\x1b[2K` + content + literal-space fill to col `cols-1` + `\r\n`. No vertical borders, no never-written cells past content. The codepoint-0 trim has nothing to trim, so copying yielded a wall of spaces.

## The fix

One line, in the existing function:

```ts
const trim = ex >= cols
if (ex > sx) {
  const slice = line.translateToString(trim, sx, ex)
  out += trim ? slice.replace(/[ \t]+$/, '') : slice
}
```

When the row's selection reaches the row boundary, post-strip ASCII trailing whitespace from the slice. The mid-row preservation guard (`trim = ex >= cols`) is unchanged, so a user who drag-selects through pad without crossing the line break still gets the spaces they dragged across.

This is the same shape as Ghostty's `clipboard-trim-trailing-spaces`, scoped to boundary-reaching rows so the mid-row case stays honest.

## Trade-off pinned in tests

A row ending with typed trailing whitespace, then a hard newline, copies without those spaces. The previous test for that case (which asserted preservation) is updated to assert the new behavior, with a comment explaining why the trade-off is a deliberate choice and not a quiet revert. Pinning it explicitly so any future relaxation is intentional.

## Tests

- **Unit (`selection.test.ts`):** existing "preserves explicitly-typed trailing spaces across a line break" rewritten to assert the new contract; new "strips trailing pad on a TUI-style row (full-width explicit space fill)" using the exact shape pi produces; new "preserves typed trailing spaces when selection ends mid-row" pinning the mid-row guard. 305 vitest pass (was 297).
- **E2E (`terminal-copy-tui.spec.ts`):** injects pi-shaped output via `term.write()` directly into the xterm buffer (deterministic, no PTY/WS dependency), drives a real `Ctrl+Shift+C` through the keyboard, captures the production code's `navigator.clipboard.writeText` call, asserts the captured value contains only the source text. Two cases: full transcript (multi-row) and single-row (triple-click / line-select). Both fail without the fix and pass with it; verified locally by toggling the implementation.

Closes the regression the user reported when they tried to copy from pi after #189 landed.
