### PR TITLE
feat: add gmux skill, improve gmux CLI for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,15 @@
 
 Prioritize verifiable, correct behavior above all else. If something has lots of race conditions or other edgecases that are difficult to test and reason about, it is likely the wrong approach. If a library does something more reliably than what we can achieve, it is worth considering.
 
+## CLI conventions
+
+Run mode (`gmux <cmd> [args...]`) uses POSIX runner flag parsing (same as `env`, `nohup`, `time`, `screen`): flag parsing stops at the first positional argument so flags after the command go to the child, not gmux. Management modes (`--list`, `--attach`, `--kill`, `--send`, `--wait`, `--tail`) accept flags in any order since they have no wrapped command.
+
+Practical consequences for docs and examples:
+
+- `gmux --no-attach pi "prompt"`, never `gmux pi "prompt" --no-attach`. In run mode the latter passes `--no-attach` to pi, which doesn't recognize it.
+- Agents started via `gmux <agent> "prompt"` stay running by default; `gmux <cmd> < /dev/null` blocks until the child exits, so it hangs forever for interactive agents. Use `--no-attach` to spawn detached, or the agent's print-and-exit mode (`pi -p`, `claude -p`, `codex exec`).
+
 ## State discipline
 
 Never add new state without justification. Before adding a field, ask: who owns it, who updates it, and can it be derived from existing state instead? Prefer derivation over storage. New state creates maintenance burden, sync bugs, and lifecycle complexity.

--- a/apps/website/src/content/docs/integrations/scripts-and-agents.md
+++ b/apps/website/src/content/docs/integrations/scripts-and-agents.md
@@ -1,0 +1,132 @@
+---
+title: Scripts and agents
+description: Drive gmux sessions from shell scripts, CI, and agent harnesses.
+sidebar:
+  order: 0
+---
+
+`gmux` was designed so that the same binary works whether you're attaching to a session by hand or driving sessions from a script. This page covers the scripted shape: how to start sessions non-interactively, how to send input and wait for output, and how to compose the primitives into agent-orchestration patterns.
+
+:::tip[Driving gmux from an agent?]
+Install the [gmux skill](https://github.com/gmuxapp/gmux/blob/main/skills/gmux/SKILL.md) so your agent picks up these patterns automatically:
+
+```sh
+npx skills add gmuxapp/gmux
+```
+
+The skill follows the [agentskills.io](https://agentskills.io/) standard and works with Claude Code, Codex, Cursor, Copilot, Gemini CLI, OpenCode, and 50+ other agents. Or drop the `SKILL.md` into your agent's skills directory by hand if you prefer not to install the CLI.
+:::
+
+## The piped flow
+
+The most useful primitive for scripting is `gmux <cmd>` with stdin redirected away from a terminal:
+
+```bash
+gmux make build < /dev/null
+gmux pi -p "summarize this PR" < /dev/null
+```
+
+The `-p` (print) flag tells `pi` to process the prompt and exit instead of staying interactive. Other agents have similar one-shot modes (`claude -p`, `codex exec`); without one, the agent stays running and `gmux <cmd>` blocks indefinitely. For multi-turn orchestration, see the [parallel orchestration](#parallel-orchestration) section below: spawn with `--no-attach`, then drive with `--send` / `--wait`.
+
+When stdin is not a TTY, `gmux <cmd>`:
+
+- **Blocks** until the child exits.
+- **Streams bounded metadata** to stdout (session id, kind, exit status), not the full PTY output. Your script's logs stay readable.
+- **Exits with the child's exit code**, so `gmux make build < /dev/null && deploy.sh` works.
+- **Keeps the session in the UI** for the duration: a human can watch it live in the browser without affecting the script.
+
+This is the shape every other line on this page builds on. It works the same in CI, in cron jobs, in agent harnesses (whose stdin is a pipe by default), and in any scripted invocation.
+
+## Sending input
+
+Use [`--send`](/reference/cli/#gmux---send---no-submit-id-text) to push input into an already-running session, as if the bytes had been typed at the keyboard. By default `--send` submits the input (appends the carriage return that signals Enter), so the canonical shape is just:
+
+```bash
+gmux --send <id> < prompt.txt
+gmux --send <id> 'shorter inline message'
+```
+
+Use `--no-submit` for the rare case where you want to pre-fill the input box without dispatching, e.g. agent-assisted human authoring or sending a control character without an extra Enter:
+
+```bash
+printf '\x03' | gmux --send --no-submit <id>   # Ctrl-C, no extra Enter
+gmux --send --no-submit <id> 'draft '          # leave "draft " in the input
+```
+
+`--send` is local-only and gated by Unix-socket file permissions (owner-only `0700`); see the CLI reference for the access-control story.
+
+## Waiting for the turn to finish
+
+`gmux --wait <id>` blocks until an agent session has finished its current turn. It's the primitive that turns sequential orchestration into a one-line-per-step pattern:
+
+```bash
+gmux --send <id> < step-1.txt
+gmux --wait <id>
+
+gmux --send <id> < step-2.txt
+gmux --wait <id>
+
+# extract the final answer
+gmux --tail 200 <id>
+```
+
+The idle signal is the same `Status.Working` flag the UI's spinner consumes, so `--wait` returns the moment the agent emits its closing message for the turn. If the session dies first, `--wait` exits 2; if you set `--timeout N` and N seconds pass, it exits 3. Idle is exit 0.
+
+`--wait` is for agent sessions (`claude`, `codex`, `pi`); shell sessions don't emit a working signal and are rejected with a clear error. To wait for a shell command to finish, run it through the piped flow above instead — the blocking shape is exactly what `gmux make build < /dev/null` already provides.
+
+## Reading output
+
+`gmux --tail N <id>` dumps the last N lines of a session's output as plain text (ANSI stripped). Pair it with `--wait` to capture the agent's final answer:
+
+```bash
+gmux --send <id> < ship-prompt.txt
+gmux --wait --timeout 600 <id>
+url=$(gmux --tail 50 <id> | grep -oE 'https://github\.com/[^ ]+/pull/[0-9]+' | tail -1)
+echo "$url"
+```
+
+`--tail` is local-only today.
+
+## Discovery and cleanup
+
+```bash
+gmux --list                  # all sessions, alive first, newest first
+gmux --kill <id>             # SIGTERM the runner, normal exit lifecycle
+```
+
+`--list` accepts ID prefixes, full session IDs, or slugs anywhere a session is named, so the eight-character short form it prints can be passed straight back to `--kill`, `--send`, `--tail`, or `--wait`.
+
+## Parallel orchestration
+
+Spawn N agents in parallel, then wait for each in turn. Sequential waiting finishes when the slowest agent finishes — same wall-clock as backgrounding the `--wait` calls, but exit codes are per-session and the loop reads as a straight line:
+
+```bash
+ids=()
+for ticket in fa-48 fa-49 fa-52; do
+  prompt="Implement $ticket. Return when you're done."
+  ids+=( "$(gmux --no-attach pi "$prompt")" )
+done
+
+for id in "${ids[@]}"; do
+  gmux --wait --timeout 600 "$id" || echo "$id did not finish cleanly: $?"
+done
+
+for id in "${ids[@]}"; do
+  echo "=== $id ==="
+  gmux --tail 100 "$id"
+done
+```
+
+The agents run concurrently because `gmux --no-attach pi <prompt>` returns as soon as the session registers (and `--no-attach` prints just the session id, no grep needed); the wait loop just gates the harvest step on every agent reaching idle. Background `&` + `wait` is only useful when you want to dispatch the next step as soon as **any** agent finishes (rare for orchestration, where you usually want all of them done before you act).
+
+## Nested gmux
+
+When `gmux <cmd>` is run inside an existing gmux session (detected via the `GMUX=1` env var), gmux auto-detaches into a headless background process so you don't end up with a PTY-within-PTY. Importantly, the auto-detach only triggers when stdin is a TTY: agent harnesses whose stdin is a pipe land in the piped / non-tty flow described above and behave normally, blocking with bounded output. You don't need to special-case nested invocations in your scripts.
+
+## Agent-specific integrations
+
+Each adapter has its own status and resumption story. See:
+
+- [pi](/integrations/pi/)
+- [Codex](/integrations/codex/)
+- [Claude Code](/integrations/claude-code/)

--- a/apps/website/src/content/docs/reference/cli.md
+++ b/apps/website/src/content/docs/reference/cli.md
@@ -29,9 +29,17 @@ gmux --no-attach pytest --watch       # detach from the terminal
 gmux -- --my-dash-cmd                 # `--` preserves a dashy command
 ```
 
-With `--no-attach` the session is spawned in the background and appears in the UI, but `gmux` returns immediately instead of wiring your local terminal to it. Without it, `gmux` attaches transparently — Ctrl-C goes to the child, resize events follow your terminal, and closing the terminal detaches without killing the session.
+Which behavior `gmux <cmd>` exhibits depends on whether stdin is a terminal and whether you're already inside a gmux session:
 
-When run inside an existing gmux session (detected via the `GMUX` environment variable), `gmux` automatically detaches into a headless background process instead of nesting PTY-within-PTY. The new session appears in the UI.
+| Stdin              | Inside `GMUX=1`? | Behavior                                                                                                |
+| ------------------ | ---------------- | ------------------------------------------------------------------------------------------------------- |
+| TTY                | no               | Attach: wire your terminal to the child PTY, forward Ctrl-C and resize, detach when the terminal closes. |
+| TTY                | yes              | Auto-detach: spawn the session in the background and return immediately, so PTYs don't nest.            |
+| Pipe / file / null | either           | Block, stream bounded metadata to stdout, exit with the child's exit code. The session keeps running for the UI to attach to. |
+
+The pipe / file / null row is the canonical shape for scripts and agent harnesses: you get a blocking call, bounded stdout (no full PTY noise leaks into your script's logs), and reliable exit-code propagation. `--no-attach` forces the auto-detach behavior even from a terminal.
+
+See [Scripts and agents](/integrations/scripts-and-agents/) for the narrative version, including a worked build-and-report example.
 
 ### `gmux --list` (`-l`)
 
@@ -77,19 +85,37 @@ Terminate a running session. Sends the same signal chain the UI's kill button do
 gmux --kill a3f20187
 ```
 
-### `gmux --send <id> [text]`
+### `gmux --send [--no-submit] <id> [text]`
 
-Inject input into a running session, as if the bytes had been typed at the terminal. When `text` is given inline it is sent verbatim — no trailing newline is added, so you use shell `$'...\n'` (or pipe stdin) to submit:
+Inject input into a running session, as if the bytes had been typed at the terminal, and submit it. By default `--send` appends a carriage return after the payload so the agent or shell processes it as a complete line; `--no-submit` suppresses that for the rare flow where you want to pre-fill the input box without dispatching it.
 
 ```bash
-gmux --send a3f20187 $'describe yourself\n'
-echo 'describe yourself' | gmux --send a3f20187   # equivalent
-printf '\x03' | gmux --send a3f20187              # send Ctrl-C
+gmux --send a3f20187 'describe yourself'           # submits
+gmux --send a3f20187 < prompt.txt                  # submits stdin
+echo 'describe yourself' | gmux --send a3f20187    # equivalent
+printf '\x03' | gmux --send --no-submit a3f20187   # send Ctrl-C without an extra Enter
+gmux --send --no-submit a3f20187 'draft '          # leave "draft " in the input box
 ```
 
-When `text` is omitted, gmux reads from stdin until EOF and sends whatever it sees (capped at 1 MiB). Stdin mode is the natural shape for piping, and avoids shell-escaping headaches for multi-line input.
+When `text` is omitted, gmux reads from stdin until EOF and sends whatever it sees (capped at 1 MiB). Stdin mode is the natural shape for piping multi-line input from files or heredocs.
 
 **Access control.** `--send` is powerful — anything you send lands in the session's PTY, and the child has no way to distinguish it from keyboard input. Access is gated by filesystem permissions on the session's Unix socket (owner-only, `0700`), which means only the user that started the session can send to it. Other users on the same machine cannot connect to the socket at all. For the same reason, `--send` is local-only: cross-machine sending would need an explicit authorization model that doesn't exist yet.
+
+### `gmux --wait [--timeout N] <id>`
+
+Block until the agent in the session has finished its turn. Returns 0 when the agent reaches an idle state (the spinner stops), 2 if the session dies before becoming idle, and 3 if the optional `--timeout` elapses first.
+
+```bash
+gmux --send a3f20187 < prompt.txt
+gmux --wait a3f20187
+gmux --tail 50 a3f20187 > result.log
+```
+
+The idle signal is the same `Status.Working` flag the UI's spinner consumes: each agent adapter (claude, codex, pi) flips it false once its agent has emitted its final message for the turn. Wait returns immediately if the agent is already idle when called (so composition with `--send` is reliable when the agent races ahead between the two CLI hops).
+
+Shell sessions don't emit an idle signal and are rejected with a clear error rather than returning a misleading idle. To wait for a shell command to finish, run it directly via the piped flow above or compose with `timeout`.
+
+Local sessions only; remote peer sessions are rejected until peer subscriptions stream `Status` events back to the hub.
 
 ## gmuxd
 

--- a/cli/gmux/cmd/gmux/actions.go
+++ b/cli/gmux/cmd/gmux/actions.go
@@ -280,13 +280,19 @@ func cmdTail(ref string, n int) int {
 	return 0
 }
 
-// cmdSend implements `gmux --send <id> [text]`.
+// cmdSend implements `gmux --send [--no-submit] <id> [text]`.
 //
 // Sends bytes to the session's PTY as if they had been typed at the
-// terminal. When text is provided inline it is sent verbatim (callers
-// who want a trailing newline must include it explicitly, e.g. via
-// `$'hello\n'`). When text is omitted, stdin is read until EOF; this
-// is the natural shape for piping: `echo hello | gmux --send abc`.
+// terminal, then appends a carriage return so the input is submitted.
+// The submit-by-default shape matches what every other "send a message"
+// CLI does (gh issue comment, slack send, jira issue comment add) and
+// avoids the silent-failure trap of bytes-without-\r sitting in the
+// agent's input box forever. `--no-submit` opts out for the rare
+// flow where you want to pre-fill input without dispatching it.
+//
+// When text is provided inline it is sent verbatim before the submit;
+// when text is omitted, stdin is read until EOF — the natural shape
+// for piping: `echo hello | gmux --send abc`.
 //
 // Access control is delegated to the session socket's file permissions
 // (owner-only, 0o700): if you can connect to the socket you already
@@ -294,7 +300,7 @@ func cmdTail(ref string, n int) int {
 // For the same reason we don't support sending to remote peer sessions
 // — doing that safely would require a per-peer authorization model
 // that doesn't exist yet.
-func cmdSend(ref string, text *string) int {
+func cmdSend(ref string, text *string, noSubmit bool) int {
 	sess, err := resolveSession(ref)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "gmux:", err)
@@ -317,12 +323,7 @@ func cmdSend(ref string, text *string) int {
 		return 1
 	}
 
-	var body io.Reader
-	if text != nil {
-		body = strings.NewReader(*text)
-	} else {
-		body = io.LimitReader(os.Stdin, maxSendBytes)
-	}
+	body := buildSendBody(text, os.Stdin, noSubmit)
 
 	client := sessionSocketClient(sess.SocketPath)
 	// When reading from stdin, the request body may be paced by the
@@ -360,6 +361,29 @@ func cmdSend(ref string, text *string) int {
 // --send invocation. Matches the runner's maxInputBytes so we fail
 // fast on the client side rather than letting the server truncate us.
 const maxSendBytes = 1 << 20 // 1 MiB
+
+// buildSendBody assembles the bytes that --send writes to the session's
+// PTY input. When text is non-nil it is sent verbatim; otherwise stdin
+// is read up to maxSendBytes. Unless noSubmit is set, a trailing \r is
+// appended — that's what xterm sends for Enter and what every PTY
+// (agent or shell) treats as "submit this line." \n alone is not
+// enough: most agents see it as a literal newline and keep buffering,
+// which is how `gmux --send <id> < prompt.txt` ended up silently
+// failing for users who expected `cat`-style behavior. A redundant \r
+// in the input is harmless (submits an empty line at most), so we don't
+// try to detect and dedupe.
+func buildSendBody(text *string, stdin io.Reader, noSubmit bool) io.Reader {
+	var body io.Reader
+	if text != nil {
+		body = strings.NewReader(*text)
+	} else {
+		body = io.LimitReader(stdin, maxSendBytes)
+	}
+	if !noSubmit {
+		body = io.MultiReader(body, strings.NewReader("\r"))
+	}
+	return body
+}
 
 // sessionSocketClient builds an HTTP client that dials a session's
 // Unix socket directly. The host portion of URLs passed through this

--- a/cli/gmux/cmd/gmux/actions_test.go
+++ b/cli/gmux/cmd/gmux/actions_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"io"
 	"strings"
 	"testing"
 )
@@ -115,3 +116,62 @@ func TestShortID(t *testing.T) {
 		}
 	}
 }
+
+// TestBuildSendBody pins the wire-level contract of --send: by default
+// the bytes written to the PTY end with the carriage return that
+// submits the input, and --no-submit suppresses exactly that byte and
+// nothing else. Both inline-text and stdin paths are covered because
+// they construct the body differently and the carriage-return logic
+// has to wrap both.
+func TestBuildSendBody(t *testing.T) {
+	tests := []struct {
+		name     string
+		text     *string
+		stdin    string
+		noSubmit bool
+		want     string
+	}{
+		{
+			name: "inline text submits with trailing \\r",
+			text: stringPtr("hello"),
+			want: "hello\r",
+		},
+		{
+			name:     "inline text with --no-submit sends verbatim",
+			text:     stringPtr("hello"),
+			noSubmit: true,
+			want:     "hello",
+		},
+		{
+			name:  "stdin submits with trailing \\r",
+			stdin: "prompt body\nwith newline\n",
+			want:  "prompt body\nwith newline\n\r",
+		},
+		{
+			name:     "stdin with --no-submit preserves trailing newline only",
+			stdin:    "prompt body\nwith newline\n",
+			noSubmit: true,
+			want:     "prompt body\nwith newline\n",
+		},
+		{
+			name: "empty inline text still submits an empty line",
+			text: stringPtr(""),
+			want: "\r",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			body := buildSendBody(tc.text, strings.NewReader(tc.stdin), tc.noSubmit)
+			got, err := io.ReadAll(body)
+			if err != nil {
+				t.Fatalf("read body: %v", err)
+			}
+			if string(got) != tc.want {
+				t.Errorf("body = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func stringPtr(s string) *string { return &s }

--- a/cli/gmux/cmd/gmux/cli.go
+++ b/cli/gmux/cmd/gmux/cli.go
@@ -31,7 +31,8 @@ type flags struct {
 	attach   bool
 	kill     bool
 	send     bool
-	tail     int // >=0 when set (flag default is -1)
+	noSubmit bool // suppresses the trailing carriage return on --send
+	tail     int  // >=0 when set (flag default is -1)
 	help     bool
 }
 
@@ -56,6 +57,7 @@ func parseCLI(args []string) (mode, *flags, []string, error) {
 	fs.BoolVar(&f.kill, "kill", false, "kill a running session")
 	fs.BoolVar(&f.kill, "k", false, "kill a running session (short)")
 	fs.BoolVar(&f.send, "send", false, "send input to a running session")
+	fs.BoolVar(&f.noSubmit, "no-submit", false, "with --send, do not append the carriage return that submits the input")
 	fs.IntVar(&f.tail, "tail", -1, "dump the last N lines of a session")
 	fs.IntVar(&f.tail, "t", -1, "dump the last N lines of a session (short)")
 	fs.BoolVar(&f.help, "help", false, "show help")
@@ -89,6 +91,12 @@ func parseCLI(args []string) (mode, *flags, []string, error) {
 	}
 	if actions > 1 {
 		return modeHelp, nil, nil, errors.New("--list, --attach, --tail, --kill, --send are mutually exclusive")
+	}
+
+	// --no-submit only changes the bytes --send writes; with anything
+	// else it would silently do nothing, so reject it loudly.
+	if f.noSubmit && !f.send {
+		return modeHelp, nil, nil, errors.New("--no-submit only applies with --send")
 	}
 
 	// Management actions take a single session id (except --list and --send).
@@ -165,7 +173,8 @@ Session management:
   gmux --attach <id>                reattach to an existing session
   gmux --tail <N> <id>              print the last N lines of a session
   gmux --kill <id>                  terminate a session
-  gmux --send <id> [text]           send text (or stdin) to a session
+  gmux --send <id> [text]           send text (or stdin) to a session and submit it
+  gmux --send --no-submit <id> ...  send without the trailing carriage return
 
 Flags before the command apply to gmux itself. Once the first positional
 argument is seen, everything after is the command to run, verbatim.

--- a/cli/gmux/cmd/gmux/cli.go
+++ b/cli/gmux/cmd/gmux/cli.go
@@ -77,6 +77,18 @@ func parseCLI(args []string) (mode, *flags, []string, error) {
 		return modeHelp, f, rest, nil
 	}
 
+	// In management modes there is no wrapped command, only a bounded
+	// number of positionals (id, optional text for --send). The POSIX
+	// runner stop-at-first-positional rule that protects `gmux <cmd>
+	// --cmd-flag` from having gmux eat --cmd-flag does nothing useful
+	// here — it just turns `gmux --wait <id> --timeout 60` into a
+	// silent foot-trap where --timeout becomes a positional. Re-parse
+	// any flags interleaved with positionals so flag order doesn't
+	// matter for management actions.
+	if isManagementMode(f) {
+		rest = parseInterspersedFlags(fs, rest)
+	}
+
 	// At most one management action at a time.
 	actions := 0
 	if f.list {
@@ -180,6 +192,47 @@ func parseCLI(args []string) (mode, *flags, []string, error) {
 		return modeUI, f, nil, nil
 	}
 	return modeRun, f, rest, nil
+}
+
+// isManagementMode reports whether the parsed flags request a
+// management action (no wrapped command). Run mode is everything
+// else — a command with optional --no-attach.
+func isManagementMode(f *flags) bool {
+	return f.list || f.attach || f.kill || f.send || f.wait || f.tail >= 0
+}
+
+// parseInterspersedFlags walks `rest` consuming any further flags via
+// fs.Parse and collecting non-flag tokens as positionals. The default
+// flag.FlagSet behavior stops at the first positional; iterating lets
+// us pick up flags that appear after positionals too. Used only in
+// management modes, where positionals are bounded and there is no
+// risk of swallowing flags meant for a wrapped child command.
+func parseInterspersedFlags(fs *flag.FlagSet, rest []string) []string {
+	var positionals []string
+	remaining := rest
+	for len(remaining) > 0 {
+		if err := fs.Parse(remaining); err != nil {
+			// fs.Parse already wrote into the same flags struct on the
+			// first call; any error here is from re-parsing an unknown
+			// flag after a positional. Surface the leftover args as-is
+			// so the caller's validation produces a sensible message.
+			return append(positionals, remaining...)
+		}
+		newRest := fs.Args()
+		if len(newRest) == 0 {
+			break
+		}
+		if len(newRest) == len(remaining) {
+			// fs.Parse stopped without consuming anything: first token
+			// is a positional. Take it and resume on the suffix.
+			positionals = append(positionals, newRest[0])
+			remaining = newRest[1:]
+			continue
+		}
+		// fs.Parse consumed at least one flag; loop on the new tail.
+		remaining = newRest
+	}
+	return positionals
 }
 
 // printUsage writes the gmux usage synopsis. Shown on --help, on parse

--- a/cli/gmux/cmd/gmux/cli.go
+++ b/cli/gmux/cmd/gmux/cli.go
@@ -18,6 +18,7 @@ const (
 	modeTail               // dump recent output from a session
 	modeKill               // terminate a session
 	modeSend               // inject input into a running session
+	modeWait               // block until session reaches idle / dies
 	modeHelp               // print usage and exit
 )
 
@@ -26,14 +27,16 @@ const (
 // action ("flags that replace the runner") lives here. The trailing
 // positional command or session id is returned separately as rest.
 type flags struct {
-	noAttach bool
-	list     bool
-	attach   bool
-	kill     bool
-	send     bool
-	noSubmit bool // suppresses the trailing carriage return on --send
-	tail     int  // >=0 when set (flag default is -1)
-	help     bool
+	noAttach    bool
+	list        bool
+	attach      bool
+	kill        bool
+	send        bool
+	noSubmit    bool // suppresses the trailing carriage return on --send
+	wait        bool
+	waitTimeout int // 0 means no timeout
+	tail        int // >=0 when set (flag default is -1)
+	help        bool
 }
 
 // parseCLI parses argv (without program name) and decides which mode to
@@ -58,6 +61,8 @@ func parseCLI(args []string) (mode, *flags, []string, error) {
 	fs.BoolVar(&f.kill, "k", false, "kill a running session (short)")
 	fs.BoolVar(&f.send, "send", false, "send input to a running session")
 	fs.BoolVar(&f.noSubmit, "no-submit", false, "with --send, do not append the carriage return that submits the input")
+	fs.BoolVar(&f.wait, "wait", false, "block until a session is idle (agent finished its turn)")
+	fs.IntVar(&f.waitTimeout, "timeout", 0, "with --wait, fail after N seconds (default: no timeout)")
 	fs.IntVar(&f.tail, "tail", -1, "dump the last N lines of a session")
 	fs.IntVar(&f.tail, "t", -1, "dump the last N lines of a session (short)")
 	fs.BoolVar(&f.help, "help", false, "show help")
@@ -86,17 +91,25 @@ func parseCLI(args []string) (mode, *flags, []string, error) {
 	if f.send {
 		actions++
 	}
+	if f.wait {
+		actions++
+	}
 	if f.tail >= 0 {
 		actions++
 	}
 	if actions > 1 {
-		return modeHelp, nil, nil, errors.New("--list, --attach, --tail, --kill, --send are mutually exclusive")
+		return modeHelp, nil, nil, errors.New("--list, --attach, --tail, --kill, --send, --wait are mutually exclusive")
 	}
 
 	// --no-submit only changes the bytes --send writes; with anything
 	// else it would silently do nothing, so reject it loudly.
 	if f.noSubmit && !f.send {
 		return modeHelp, nil, nil, errors.New("--no-submit only applies with --send")
+	}
+	// --timeout is meaningless without --wait. (Once we add other
+	// time-bounded actions it can grow into a shared option.)
+	if f.waitTimeout != 0 && !f.wait {
+		return modeHelp, nil, nil, errors.New("--timeout only applies with --wait")
 	}
 
 	// Management actions take a single session id (except --list and --send).
@@ -135,6 +148,17 @@ func parseCLI(args []string) (mode, *flags, []string, error) {
 			return modeHelp, nil, nil, errors.New("--no-attach has no effect with --send")
 		}
 		return modeSend, f, rest, nil
+	case f.wait:
+		if len(rest) != 1 {
+			return modeHelp, nil, nil, errors.New("--wait requires a session id")
+		}
+		if f.noAttach {
+			return modeHelp, nil, nil, errors.New("--no-attach has no effect with --wait")
+		}
+		if f.waitTimeout < 0 {
+			return modeHelp, nil, nil, errors.New("--timeout must be a non-negative number of seconds")
+		}
+		return modeWait, f, rest, nil
 	case f.tail >= 0:
 		if len(rest) != 1 {
 			return modeHelp, nil, nil, errors.New("--tail requires a session id")
@@ -175,6 +199,8 @@ Session management:
   gmux --kill <id>                  terminate a session
   gmux --send <id> [text]           send text (or stdin) to a session and submit it
   gmux --send --no-submit <id> ...  send without the trailing carriage return
+  gmux --wait <id>                  block until session is idle (agent finished its turn)
+  gmux --wait --timeout N <id>      ... or fail after N seconds
 
 Flags before the command apply to gmux itself. Once the first positional
 argument is seen, everything after is the command to run, verbatim.

--- a/cli/gmux/cmd/gmux/cli_test.go
+++ b/cli/gmux/cmd/gmux/cli_test.go
@@ -115,6 +115,28 @@ func TestParseCLI(t *testing.T) {
 				}
 			},
 		},
+		{
+			name:     "--wait takes a session id",
+			args:     []string{"--wait", "sess-abcd"},
+			wantMode: modeWait,
+			wantRest: []string{"sess-abcd"},
+			check: func(t *testing.T, f *flags) {
+				if f.waitTimeout != 0 {
+					t.Errorf("waitTimeout = %d, want 0", f.waitTimeout)
+				}
+			},
+		},
+		{
+			name:     "--wait with --timeout",
+			args:     []string{"--wait", "--timeout", "30", "sess-abcd"},
+			wantMode: modeWait,
+			wantRest: []string{"sess-abcd"},
+			check: func(t *testing.T, f *flags) {
+				if f.waitTimeout != 30 {
+					t.Errorf("waitTimeout = %d, want 30", f.waitTimeout)
+				}
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -161,6 +183,12 @@ func TestParseCLIErrors(t *testing.T) {
 		{"--no-attach", "--send", "sess-a", "x"}, // --no-attach doesn't make sense with --send
 		{"--no-submit", "sess-a"},                // --no-submit only applies with --send
 		{"--no-submit", "--list"},                // --no-submit only applies with --send
+		{"--wait"},                               // --wait needs an id
+		{"--wait", "a", "b"},                     // --wait takes exactly one id
+		{"--wait", "--send", "sess-a"},           // mutually exclusive
+		{"--no-attach", "--wait", "sess-a"},      // --no-attach has no effect with --wait
+		{"--timeout", "30", "sess-a"},            // --timeout only applies with --wait
+		{"--wait", "--timeout", "-1", "sess-a"},  // --timeout must be non-negative
 	}
 
 	for _, args := range invalid {

--- a/cli/gmux/cmd/gmux/cli_test.go
+++ b/cli/gmux/cmd/gmux/cli_test.go
@@ -98,6 +98,22 @@ func TestParseCLI(t *testing.T) {
 			args:     []string{"--send", "sess-abcd"},
 			wantMode: modeSend,
 			wantRest: []string{"sess-abcd"},
+			check: func(t *testing.T, f *flags) {
+				if f.noSubmit {
+					t.Errorf("noSubmit = true, want false (submit-by-default)")
+				}
+			},
+		},
+		{
+			name:     "--send --no-submit suppresses the submit",
+			args:     []string{"--send", "--no-submit", "sess-abcd", "draft"},
+			wantMode: modeSend,
+			wantRest: []string{"sess-abcd", "draft"},
+			check: func(t *testing.T, f *flags) {
+				if !f.noSubmit {
+					t.Errorf("noSubmit = false, want true")
+				}
+			},
 		},
 	}
 
@@ -143,6 +159,8 @@ func TestParseCLIErrors(t *testing.T) {
 		{"--no-attach", "--list"},                // --no-attach doesn't make sense with --list
 		{"--no-attach", "--attach", "sess-a"},
 		{"--no-attach", "--send", "sess-a", "x"}, // --no-attach doesn't make sense with --send
+		{"--no-submit", "sess-a"},                // --no-submit only applies with --send
+		{"--no-submit", "--list"},                // --no-submit only applies with --send
 	}
 
 	for _, args := range invalid {

--- a/cli/gmux/cmd/gmux/cli_test.go
+++ b/cli/gmux/cmd/gmux/cli_test.go
@@ -137,6 +137,45 @@ func TestParseCLI(t *testing.T) {
 				}
 			},
 		},
+		// Management modes accept flags in any order: there's no
+		// wrapped child command at the end, so the POSIX runner
+		// stop-at-first-positional rule that run mode needs would only
+		// turn `gmux --wait <id> --timeout 60` into a silent foot-trap.
+		// These cases pin the lenient parsing for each management
+		// action that takes a flag besides its mode flag.
+		{
+			name:     "--wait accepts --timeout after the id",
+			args:     []string{"--wait", "sess-abcd", "--timeout", "30"},
+			wantMode: modeWait,
+			wantRest: []string{"sess-abcd"},
+			check: func(t *testing.T, f *flags) {
+				if f.waitTimeout != 30 {
+					t.Errorf("waitTimeout = %d, want 30", f.waitTimeout)
+				}
+			},
+		},
+		{
+			name:     "--send accepts --no-submit after the id",
+			args:     []string{"--send", "sess-abcd", "--no-submit", "text"},
+			wantMode: modeSend,
+			wantRest: []string{"sess-abcd", "text"},
+			check: func(t *testing.T, f *flags) {
+				if !f.noSubmit {
+					t.Errorf("noSubmit = false, want true")
+				}
+			},
+		},
+		{
+			name:     "--send accepts --no-submit after both positionals",
+			args:     []string{"--send", "sess-abcd", "text", "--no-submit"},
+			wantMode: modeSend,
+			wantRest: []string{"sess-abcd", "text"},
+			check: func(t *testing.T, f *flags) {
+				if !f.noSubmit {
+					t.Errorf("noSubmit = false, want true")
+				}
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -158,6 +197,24 @@ func TestParseCLI(t *testing.T) {
 				tc.check(t, f)
 			}
 		})
+	}
+}
+
+// TestRunModeKeepsPOSIXRunnerSemantics pins the contract that flags
+// after the wrapped command go to the child, not to gmux. This is
+// the load-bearing case for run mode and the reason management modes
+// (which lack a wrapped command) get lenient parsing while run mode
+// keeps the strict stop-at-first-positional behavior.
+func TestRunModeKeepsPOSIXRunnerSemantics(t *testing.T) {
+	// `gmux pi --some-pi-flag` — --some-pi-flag must reach pi as part
+	// of the command, not be parsed as an unknown gmux flag.
+	_, _, rest, err := parseCLI([]string{"pi", "--some-pi-flag", "prompt"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"pi", "--some-pi-flag", "prompt"}
+	if !reflect.DeepEqual(rest, want) {
+		t.Errorf("rest = %v, want %v", rest, want)
 	}
 }
 

--- a/cli/gmux/cmd/gmux/main.go
+++ b/cli/gmux/cmd/gmux/main.go
@@ -51,6 +51,8 @@ func main() {
 			text = &rest[1]
 		}
 		os.Exit(cmdSend(rest[0], text, f.noSubmit))
+	case modeWait:
+		os.Exit(cmdWait(rest[0], f.waitTimeout))
 	}
 }
 

--- a/cli/gmux/cmd/gmux/main.go
+++ b/cli/gmux/cmd/gmux/main.go
@@ -50,7 +50,7 @@ func main() {
 		if len(rest) == 2 {
 			text = &rest[1]
 		}
-		os.Exit(cmdSend(rest[0], text))
+		os.Exit(cmdSend(rest[0], text, f.noSubmit))
 	}
 }
 

--- a/cli/gmux/cmd/gmux/wait.go
+++ b/cli/gmux/cmd/gmux/wait.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+)
+
+// Exit codes from cmdWait. Distinct codes let scripts dispatch on the
+// reason a wait ended without parsing strings.
+//
+//   - waitExitIdle (0): session reached a Working == false state
+//   - waitExitDied (2): session crashed or was killed before going idle
+//   - waitExitTimeout (3): --timeout elapsed
+//
+// Any other usage / network error returns 1, matching the rest of the
+// CLI.
+const (
+	waitExitIdle    = 0
+	waitExitDied    = 2
+	waitExitTimeout = 3
+)
+
+// cmdWait implements `gmux --wait [--timeout N] <id>`.
+//
+// The wait itself happens server-side: gmuxd already subscribes to
+// per-session events for its own bookkeeping, so we just hand it the
+// session id and block on the HTTP response. That keeps the CLI free
+// of SSE-parsing logic and ensures the idle-detection rules (which
+// adapter kinds emit Status.Working, what counts as "died") live in
+// one place.
+//
+// Local sessions only: the daemon's wait handler resolves the session
+// against its local store and consults the adapter allowlist; remote
+// peer sessions are out of scope until peer subscriptions stream
+// Status events back to the hub.
+func cmdWait(ref string, timeoutSecs int) int {
+	sess, err := resolveSession(ref)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "gmux:", err)
+		return 1
+	}
+	if sess.Peer != "" {
+		fmt.Fprintf(os.Stderr, "gmux: --wait is only supported for local sessions (%s is on peer %q)\n",
+			shortID(sess.ID), sess.Peer)
+		return 1
+	}
+
+	endpoint := gmuxdBaseURL() + "/v1/sessions/" + url.PathEscape(sess.ID) + "/wait"
+	if timeoutSecs > 0 {
+		endpoint += "?timeout=" + strconv.Itoa(timeoutSecs)
+	}
+
+	client := gmuxdClient()
+	// The default 5s client timeout would cut off any wait that
+	// outlasts a turn on a slow agent. With no client-side timeout
+	// the only deadline is the optional server-side --timeout.
+	client.Timeout = 0
+
+	resp, err := client.Post(endpoint, "application/json", nil)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "gmux:", err)
+		return 1
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		// Body is { ok: true, data: { reason: "idle" | "died" } }
+		var env struct {
+			Data struct {
+				Reason string `json:"reason"`
+			} `json:"data"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+			fmt.Fprintln(os.Stderr, "gmux: decode wait response:", err)
+			return 1
+		}
+		switch env.Data.Reason {
+		case "idle":
+			return waitExitIdle
+		case "died":
+			fmt.Fprintf(os.Stderr, "gmux: session %s died before becoming idle\n", shortID(sess.ID))
+			return waitExitDied
+		default:
+			fmt.Fprintf(os.Stderr, "gmux: unexpected wait reason %q\n", env.Data.Reason)
+			return 1
+		}
+	case http.StatusRequestTimeout:
+		fmt.Fprintf(os.Stderr, "gmux: --wait timed out after %ds\n", timeoutSecs)
+		return waitExitTimeout
+	case http.StatusUnprocessableEntity:
+		// Adapter kind doesn't emit an idle signal. Surface the
+		// daemon's message so the user knows which kind they hit.
+		body, _ := io.ReadAll(resp.Body)
+		fmt.Fprintf(os.Stderr, "gmux: --wait not supported for this session: %s\n",
+			extractMessage(body))
+		return 1
+	case http.StatusNotFound:
+		// Distinct from "no idle signal": means the session id is
+		// unknown to gmuxd entirely.
+		fmt.Fprintf(os.Stderr, "gmux: session %s not found\n", shortID(sess.ID))
+		return 1
+	default:
+		body, _ := io.ReadAll(resp.Body)
+		fmt.Fprintf(os.Stderr, "gmux: wait failed: %s: %s\n", resp.Status, extractMessage(body))
+		return 1
+	}
+}
+
+// extractMessage pulls the .error.message field out of gmuxd's
+// standard error envelope, falling back to the raw body if the
+// shape doesn't match.
+func extractMessage(body []byte) string {
+	var env struct {
+		Error struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(body, &env); err == nil && env.Error.Message != "" {
+		return env.Error.Message
+	}
+	return string(body)
+}

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -1318,6 +1318,9 @@ func serve(stderr io.Writer) int {
 			}
 			writeJSON(w, map[string]any{"ok": true, "data": map[string]any{}})
 
+		case "wait":
+			handleWait(w, r, sessions, sessionID)
+
 		default:
 			http.NotFound(w, r)
 		}

--- a/services/gmuxd/cmd/gmuxd/wait.go
+++ b/services/gmuxd/cmd/gmuxd/wait.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/store"
+)
+
+// handleWait implements POST /v1/sessions/{id}/wait?timeout=N. It blocks
+// until the session is idle (Status.Working == false), the session
+// dies, the optional timeout elapses, or the client disconnects.
+//
+// The single signal we wait on is the per-session Status.Working flag
+// the adapters emit. That's a precise, debounced signal: each adapter
+// flips it false once its agent has finished its turn (claude /
+// codex / pi all emit a Working transition). Falling back to "no
+// output bytes for N seconds" would race ad-hoc against tool-call
+// progress prints; the explicit Working flag is what we already use
+// in the UI's idle indicator and is the right thing to consume here.
+//
+// Sessions whose adapter doesn't emit Working (notably the shell
+// adapter) are rejected with 422 rather than silently returning
+// "idle" immediately, which would foot-trap the obvious composition
+// `gmux make build && gmux --wait <id>` into doing nothing.
+//
+// Reasons returned in the response body:
+//
+//   - "idle": session reached Status.Working == false
+//   - "died": session.Alive flipped to false before becoming idle
+//
+// HTTP status codes:
+//
+//   - 200 with {reason}: terminal state reached (caller maps to its
+//     own exit code)
+//   - 408 Request Timeout: --timeout deadline elapsed
+//   - 422: session kind has no idle signal
+//   - 404: session not found
+func handleWait(w http.ResponseWriter, r *http.Request, sessions *store.Store, sessionID string) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "bad_request", "method not allowed")
+		return
+	}
+
+	sess, ok := sessions.Get(sessionID)
+	if !ok {
+		writeError(w, http.StatusNotFound, "not_found", "session not found")
+		return
+	}
+	if !kindEmitsIdleSignal(sess.Kind) {
+		writeError(w, http.StatusUnprocessableEntity, "no_idle_signal",
+			"session kind "+sess.Kind+" does not emit an idle signal; --wait is only supported for agent sessions")
+		return
+	}
+
+	var deadline <-chan time.Time
+	if ts := r.URL.Query().Get("timeout"); ts != "" {
+		secs, err := strconv.Atoi(ts)
+		if err != nil || secs <= 0 {
+			writeError(w, http.StatusBadRequest, "bad_request", "timeout must be a positive integer of seconds")
+			return
+		}
+		deadline = time.After(time.Duration(secs) * time.Second)
+	}
+
+	// Subscribe BEFORE re-reading current state. If we read first then
+	// subscribed, an event between the read and the subscribe would be
+	// lost and we'd block forever waiting for a transition that already
+	// happened.
+	evCh, unsub := sessions.Subscribe()
+	defer unsub()
+
+	// Already in a terminal state? Return without waiting for a
+	// transition. Callers like `--send-wait` (composition) want
+	// `--wait` to be a no-op when the agent is already idle.
+	if cur, ok := sessions.Get(sessionID); ok {
+		if reason, done := terminalReason(cur); done {
+			writeJSON(w, map[string]any{"ok": true, "data": map[string]any{"reason": reason}})
+			return
+		}
+	}
+
+	// Subscriber channels are buffered (64 slots) and broadcast() drops
+	// events when the buffer is full. Under heavy load (e.g. parallel
+	// orchestration with many agents emitting status events) the
+	// critical Working→false transition for our session could
+	// theoretically be among the dropped events. Re-snapshot every
+	// poll interval so a missed event delays the response by at most
+	// one tick instead of hanging forever.
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-r.Context().Done():
+			// Client disconnected; nothing to write.
+			return
+		case <-deadline:
+			writeError(w, http.StatusRequestTimeout, "timeout", "session did not become idle within timeout")
+			return
+		case ev := <-evCh:
+			if ev.ID != sessionID || ev.Session == nil {
+				continue
+			}
+			if reason, done := terminalReason(*ev.Session); done {
+				writeJSON(w, map[string]any{"ok": true, "data": map[string]any{"reason": reason}})
+				return
+			}
+		case <-ticker.C:
+			if cur, ok := sessions.Get(sessionID); ok {
+				if reason, done := terminalReason(cur); done {
+					writeJSON(w, map[string]any{"ok": true, "data": map[string]any{"reason": reason}})
+					return
+				}
+			}
+		}
+	}
+}
+
+// terminalReason inspects a session and reports whether --wait should
+// return now and with what reason. Centralised so the initial-snapshot
+// check, the per-event check, and the periodic re-poll stay in sync.
+//
+// A nil Status means the adapter hasn't emitted any status yet — the
+// session has been registered in the store but the runner's first
+// /events frame hasn't reached us. Treating that as idle would
+// foot-trap `gmux pi <prompt> --no-attach && gmux --wait $id`: --wait
+// would race the runner's first Working:true event and return
+// immediately without the agent having processed anything. Wait
+// instead for the adapter to assert a real state.
+func terminalReason(s store.Session) (string, bool) {
+	if !s.Alive {
+		return "died", true
+	}
+	if s.Status != nil && !s.Status.Working {
+		return "idle", true
+	}
+	return "", false
+}
+
+// kindEmitsIdleSignal reports whether sessions of the given adapter
+// kind ever transition Status.Working — i.e. whether --wait can
+// observe a meaningful idle event for them. Currently the agent
+// adapters (claude, codex, pi) all emit Working; the shell adapter
+// doesn't. Kept as an explicit allowlist so adding a new agent
+// adapter requires a deliberate update here, and so unknown kinds
+// (peer sessions whose adapter we don't know about, future adapters)
+// fail loudly instead of silently degrading to "always idle."
+func kindEmitsIdleSignal(kind string) bool {
+	switch kind {
+	case "claude", "codex", "pi":
+		return true
+	}
+	return false
+}

--- a/services/gmuxd/cmd/gmuxd/wait_test.go
+++ b/services/gmuxd/cmd/gmuxd/wait_test.go
@@ -1,0 +1,336 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/store"
+)
+
+// waitTestServer wires handleWait against a real store.Store at the
+// path the production dispatcher serves it from. Tests then drive
+// store.Upsert to simulate Working transitions and observe the
+// daemon's response. The store is the load-bearing dependency here:
+// faking it would only test the test, since the whole point of
+// handleWait is to consume real session-event broadcasts.
+func waitTestServer(t *testing.T) (*httptest.Server, *store.Store) {
+	t.Helper()
+	st := store.New()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/sessions/", func(w http.ResponseWriter, r *http.Request) {
+		parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
+		if len(parts) != 4 || parts[3] != "wait" {
+			http.NotFound(w, r)
+			return
+		}
+		handleWait(w, r, st, parts[2])
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv, st
+}
+
+func waitURL(srv *httptest.Server, id string) string {
+	return srv.URL + "/v1/sessions/" + id + "/wait"
+}
+
+// TestWaitReturnsImmediatelyWhenAlreadyIdle pins the contract that
+// `gmux --wait` is a no-op when the agent has already finished its
+// turn before the wait call lands. This is the common case for
+// composition (`gmux --send X && gmux --wait X` after the agent
+// races ahead between the two CLI calls), and the no-op-when-idle
+// behavior is what makes that composition reliable.
+func TestWaitReturnsImmediatelyWhenAlreadyIdle(t *testing.T) {
+	srv, st := waitTestServer(t)
+	st.Upsert(store.Session{
+		ID:     "sess-idle",
+		Kind:   "claude",
+		Alive:  true,
+		Status: &store.Status{Working: false},
+	})
+
+	start := time.Now()
+	resp, body := postWait(t, srv, "sess-idle")
+	elapsed := time.Since(start)
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if got := body["data"].(map[string]any)["reason"]; got != "idle" {
+		t.Errorf("reason = %v, want idle", got)
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("returned in %v, want immediate", elapsed)
+	}
+}
+
+// TestWaitBlocksUntilWorkingFlipsFalse is the headline behavior: a
+// session that's currently busy should block --wait, and unblock it
+// the moment the adapter emits Working: false. Drives the store
+// asynchronously so the test exercises the subscription path rather
+// than the initial-snapshot fast path.
+func TestWaitBlocksUntilWorkingFlipsFalse(t *testing.T) {
+	srv, st := waitTestServer(t)
+	st.Upsert(store.Session{
+		ID:     "sess-busy",
+		Kind:   "pi",
+		Alive:  true,
+		Status: &store.Status{Working: true},
+	})
+
+	done := make(chan struct{})
+	var resp *http.Response
+	var body map[string]any
+	go func() {
+		resp, body = postWait(t, srv, "sess-busy")
+		close(done)
+	}()
+
+	// Give the goroutine time to land in the Subscribe + select loop;
+	// any short, finite delay is fine because the test fails by
+	// timeout, not by sleeping too short.
+	time.Sleep(50 * time.Millisecond)
+	select {
+	case <-done:
+		t.Fatal("--wait returned before the Working flag flipped")
+	default:
+	}
+
+	st.Upsert(store.Session{
+		ID:     "sess-busy",
+		Kind:   "pi",
+		Alive:  true,
+		Status: &store.Status{Working: false},
+	})
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("--wait did not return after Working flipped to false")
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if got := body["data"].(map[string]any)["reason"]; got != "idle" {
+		t.Errorf("reason = %v, want idle", got)
+	}
+}
+
+// TestWaitReturnsDiedWhenSessionDies covers the failure mode where a
+// session crashes or is killed mid-turn. The caller's intent is "wait
+// for this turn to finish"; if the agent dies first we surface that
+// with reason=died so the CLI can map it to a non-zero exit code.
+func TestWaitReturnsDiedWhenSessionDies(t *testing.T) {
+	srv, st := waitTestServer(t)
+	st.Upsert(store.Session{
+		ID:     "sess-busy",
+		Kind:   "claude",
+		Alive:  true,
+		Status: &store.Status{Working: true},
+	})
+
+	done := make(chan struct{})
+	var body map[string]any
+	go func() {
+		_, body = postWait(t, srv, "sess-busy")
+		close(done)
+	}()
+	time.Sleep(50 * time.Millisecond)
+
+	// Death signal: Alive flips to false. Status.Working may still be
+	// true at the point of death (adapter never got to emit a final
+	// flip) — that's exactly the case the "died" reason is for.
+	st.Upsert(store.Session{
+		ID:     "sess-busy",
+		Kind:   "claude",
+		Alive:  false,
+		Status: &store.Status{Working: true},
+	})
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("--wait did not return after session died")
+	}
+
+	if got := body["data"].(map[string]any)["reason"]; got != "died" {
+		t.Errorf("reason = %v, want died", got)
+	}
+}
+
+// TestWaitTimesOut verifies the timeout escape hatch returns a
+// distinct HTTP status (408) so the CLI can tell timeout apart from
+// idle and from died.
+func TestWaitTimesOut(t *testing.T) {
+	srv, st := waitTestServer(t)
+	st.Upsert(store.Session{
+		ID:     "sess-stuck",
+		Kind:   "codex",
+		Alive:  true,
+		Status: &store.Status{Working: true},
+	})
+
+	// 1-second timeout; production callers compose with `timeout`
+	// for sub-second values, but the endpoint accepts integer seconds.
+	req, _ := http.NewRequest(http.MethodPost, waitURL(srv, "sess-stuck")+"?timeout=1", nil)
+	start := time.Now()
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	elapsed := time.Since(start)
+
+	if resp.StatusCode != http.StatusRequestTimeout {
+		t.Fatalf("status = %d, want 408", resp.StatusCode)
+	}
+	if elapsed < 900*time.Millisecond || elapsed > 2*time.Second {
+		t.Errorf("elapsed = %v, want ~1s", elapsed)
+	}
+}
+
+// TestWaitRejectsShellSessions pins the allowlist: shell sessions
+// don't emit Working transitions, so `gmux --wait` against them
+// would return immediately with reason=idle and silently do the
+// wrong thing for `gmux make build && gmux --wait <id>`-style
+// composition. 422 surfaces the limitation explicitly.
+func TestWaitRejectsShellSessions(t *testing.T) {
+	srv, st := waitTestServer(t)
+	st.Upsert(store.Session{
+		ID:    "sess-shell",
+		Kind:  "shell",
+		Alive: true,
+	})
+
+	resp, _ := postWait(t, srv, "sess-shell")
+	if resp.StatusCode != http.StatusUnprocessableEntity {
+		t.Errorf("status = %d, want 422", resp.StatusCode)
+	}
+}
+
+// TestWaitDoesNotTreatNilStatusAsIdle pins the contract that a
+// freshly-spawned agent (registered in the store but not yet emitting
+// status events) is not mistaken for an already-idle session. Without
+// this guard, `gmux pi <prompt> --no-attach && gmux --wait $id` would
+// race the runner's first Working:true event and return immediately.
+func TestWaitDoesNotTreatNilStatusAsIdle(t *testing.T) {
+	srv, st := waitTestServer(t)
+	st.Upsert(store.Session{
+		ID:     "sess-fresh",
+		Kind:   "pi",
+		Alive:  true,
+		Status: nil, // hasn't emitted its first status yet
+	})
+
+	done := make(chan struct{})
+	var body map[string]any
+	go func() {
+		_, body = postWait(t, srv, "sess-fresh")
+		close(done)
+	}()
+
+	// Should not return on its own — nil Status means "not started yet,"
+	// not "idle." Wait long enough that the 500ms re-poll runs at least
+	// once: if the implementation treats nil as idle anywhere (initial
+	// snapshot, event handler, or ticker) the test catches it.
+	select {
+	case <-done:
+		t.Fatal("--wait returned for nil-status session before any transition")
+	case <-time.After(700 * time.Millisecond):
+	}
+
+	st.Upsert(store.Session{
+		ID:     "sess-fresh",
+		Kind:   "pi",
+		Alive:  true,
+		Status: &store.Status{Working: false},
+	})
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("--wait did not return after Status appeared")
+	}
+	if got := body["data"].(map[string]any)["reason"]; got != "idle" {
+		t.Errorf("reason = %v, want idle", got)
+	}
+}
+
+// TestWaitUnderHighEventLoad asserts --wait still completes correctly
+// when the subscription channel is under heavy traffic from unrelated
+// sessions. store.broadcast uses a non-blocking send into a 64-slot
+// buffered channel, so events for our session can theoretically be
+// dropped if other sessions outpace handleWait's drain. handleWait
+// guards against this with a periodic re-snapshot of the session
+// state; this test exercises the high-throughput path and verifies
+// the response is correct regardless of which path (subscription or
+// re-snapshot) caught the transition.
+func TestWaitUnderHighEventLoad(t *testing.T) {
+	srv, st := waitTestServer(t)
+	st.Upsert(store.Session{
+		ID:     "sess-drop",
+		Kind:   "claude",
+		Alive:  true,
+		Status: &store.Status{Working: true},
+	})
+
+	done := make(chan struct{})
+	var body map[string]any
+	go func() {
+		_, body = postWait(t, srv, "sess-drop")
+		close(done)
+	}()
+	time.Sleep(50 * time.Millisecond)
+
+	for i := 0; i < 500; i++ {
+		st.Upsert(store.Session{ID: "sess-noise", Kind: "claude", Alive: true, Status: &store.Status{Working: true}})
+	}
+	st.Upsert(store.Session{
+		ID:     "sess-drop",
+		Kind:   "claude",
+		Alive:  true,
+		Status: &store.Status{Working: false},
+	})
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("--wait did not return under high event load")
+	}
+	if got := body["data"].(map[string]any)["reason"]; got != "idle" {
+		t.Errorf("reason = %v, want idle", got)
+	}
+}
+
+// TestWaitNotFound keeps the "missing session" case from being
+// confused with "session is busy forever."
+func TestWaitNotFound(t *testing.T) {
+	srv, _ := waitTestServer(t)
+	resp, _ := postWait(t, srv, "sess-nope")
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", resp.StatusCode)
+	}
+}
+
+func postWait(t *testing.T, srv *httptest.Server, id string) (*http.Response, map[string]any) {
+	t.Helper()
+	resp, err := http.Post(waitURL(srv, id), "", nil)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	t.Cleanup(func() { resp.Body.Close() })
+	raw, _ := io.ReadAll(resp.Body)
+	var body map[string]any
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &body); err != nil {
+			t.Fatalf("unmarshal %q: %v", raw, err)
+		}
+	}
+	return resp, body
+}

--- a/skills/gmux/SKILL.md
+++ b/skills/gmux/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: gmux
+description: Drive long-running terminal commands and AI coding agents through gmux sessions. Use when the user asks to run a command in the background, send input to a running session, wait for an agent's turn to finish, orchestrate multiple agents in parallel, or capture output from a tmux/screen-style session.
+---
+
+# gmux
+
+## Primitives
+
+```bash
+gmux --no-attach <cmd>       # spawn detached; prints the session id on stdout
+gmux <cmd> < /dev/null       # spawn blocking; exits with the child's exit code
+gmux --send <id> [text]      # send text (or stdin) to a session and submit
+gmux --wait <id>             # block until the agent finishes its turn
+gmux --tail N <id>           # last N lines of output (ANSI stripped)
+gmux --list                  # all sessions
+gmux --kill <id>             # SIGTERM the runner
+```
+
+`--list` IDs are 8-character prefixes; pass them directly to `--send` / `--wait` / `--tail` / `--kill`.
+
+## Sequential orchestration
+
+```bash
+id=$(gmux --no-attach pi "implement the feature")
+gmux --wait $id
+
+gmux --send $id < review.txt
+gmux --wait $id
+
+gmux --tail 100 $id
+```
+
+## Parallel orchestration
+
+```bash
+ids=()
+for ticket in fa-48 fa-49 fa-52; do
+  ids+=( "$(gmux --no-attach pi "Implement $ticket. Return when done.")" )
+done
+
+for id in "${ids[@]}"; do
+  gmux --wait --timeout 600 "$id" || echo "$id failed: $?"
+done
+
+for id in "${ids[@]}"; do
+  echo "=== $id ==="
+  gmux --tail 100 "$id"
+done
+```
+
+## `--wait` exit codes
+
+- `0` agent reached idle
+- `2` session died
+- `3` `--timeout` elapsed
+
+`--wait` only works for agent sessions (`claude`, `codex`, `pi`). For shell commands use the blocking piped flow: `gmux make build < /dev/null`.
+
+## Other agents have one-shot modes
+
+Agents stay running by default. To make them exit after one prompt, use the agent's print mode: `pi -p`, `claude -p`, `codex exec`. Pair with the piped flow for fire-and-forget:
+
+```bash
+gmux pi -p "summarize this PR" < /dev/null
+```
+
+## Sending control characters
+
+```bash
+printf '\x03' | gmux --send --no-submit $id   # Ctrl-C without an extra Enter
+```
+
+## Reference
+
+- <https://gmux.app/reference/cli/>
+- <https://gmux.app/integrations/scripts-and-agents/>


### PR DESCRIPTION
Closes #171.

Three CLI changes that turn scripted / agent-driven gmux from "works if you know the shell trivia" into a first-class workflow, plus the docs and skill that make the pattern discoverable.

## Headline behavior

### `--send` submits by default

Sending a prompt to an agent used to require manually appending a carriage return:

```sh
{ cat prompt.txt; printf '\r'; } | gmux --send <id>
```

Without it, bytes landed in the agent's input box but nothing got dispatched. Heredocs, `cat`, and editor saves all produce `\n`; agents expect `\r` for submit. The failure mode was silent (no error, no output, agent just sits there) and the workaround required three pieces of shell trivia (brace-grouped subshells, `printf`, the `\r` vs `\n` distinction) for what is conceptually one operation: send a message.

`--send` now appends `\r` after the payload by default. `--no-submit` opts out for the rare flow where you want to pre-fill the input box without dispatching it. Matches what every other "send a message" CLI does (`gh issue comment`, `slack send`, `jira issue comment add`).

Backwards compatible for callers that already sent `\r`: a redundant `\r` submits an empty line at most.

### `--wait` blocks until idle

`gmux --wait <id>` blocks until the agent has finished its turn, replacing the previous `sleep + tail + parse` workaround for scripted orchestration. Pairs with `--send` for the canonical sequential-step shape:

```sh
gmux --send <id> < prompt.txt
gmux --wait <id>
gmux --tail 50 <id>
```

Optional `--timeout N` caps the wait at N seconds. No default timeout: shell `timeout` handles caps when callers want one, and a non-zero default would surprise long-running orchestration loops.

The wait runs server-side at `POST /v1/sessions/{id}/wait` so the idle-detection rules (which adapter kinds emit `Status.Working`, what counts as "died") live in one place. The CLI maps the daemon's response to distinct exit codes:

- 0: agent reached idle (`Status.Working == false`)
- 2: session died before becoming idle
- 3: `--timeout` elapsed
- 1: usage / network / other errors

Shell sessions don't emit a working signal and are rejected with 422 (`no_idle_signal`) rather than silently returning idle, which would foot-trap the obvious composition `gmux make build && gmux --wait <id>` into doing nothing. To wait for a shell command to finish, use the existing piped flow: `gmux make build < /dev/null && deploy.sh`.

## Docs (the original #171 scope)

- **`reference/cli.md`** updated: replaces the two-paragraph attach / `--no-attach` description with a three-row table mapping stdin (TTY vs pipe) and `GMUX` env state to the actual runtime behavior. The piped / non-tty row was previously undocumented even though it is the foundation of every script and agent harness that uses gmux. The exit-code propagation contract was never stated anywhere; now it is.
- **`integrations/scripts-and-agents.md`** new: the narrative companion. Canonical `gmux <cmd> < /dev/null` shape, `--send` / `--wait` / `--tail` worked together, parallel-agent orchestration recipe, nested-gmux behavior with the actual stdin-is-a-tty gate so agent harnesses know they don't need special-casing.
- **`reference/cli.md`** `--send` and `--wait` sections updated for the new flags and exit-code contract.

## Skill

`skills/gmux/SKILL.md` follows the [agentskills.io](https://agentskills.io/) specification, so users can install it via:

```sh
gh skill install gmuxapp/gmux gmux                    # any host
gh skill install gmuxapp/gmux gmux --agent claude-code
gh skill install gmuxapp/gmux gmux --agent codex
```

Lives in this repo rather than a separate one so the skill version tracks the gmux release that introduced its primitives — `gh skill install` resolves to the latest tagged release for free, and the skill is never out of sync with the CLI flags it documents.

The skill is deliberately concise: agents are smart enough to extrapolate from the four primitives (`<cmd> < /dev/null`, `--send`, `--wait`, `--tail`) and the worked composition patterns. The triggering description front-loads the use cases ("background command", "send input to a session", "wait for an agent's turn", "orchestrate multiple agents in parallel") so implicit invocation matches naturally when the user describes their problem rather than the tool.

## Verification

- New tests, all verified to fail when their corresponding fix is reverted:
  - `TestBuildSendBody` — pins the wire-level `--send` contract: by default the bytes end with `\r`, `--no-submit` suppresses exactly that byte, both inline-text and stdin paths covered.
  - `TestParseCLI` / `TestParseCLIErrors` — extends the existing parser tests with `--no-submit`, `--wait`, `--timeout` invariants and the mutual-exclusion / requires-`--send` / requires-`--wait` rules.
  - `TestWaitReturnsImmediatelyWhenAlreadyIdle` — `gmux --send X && gmux --wait X` works when the agent races ahead between the two CLI hops.
  - `TestWaitBlocksUntilWorkingFlipsFalse` — the headline behavior: drives the store asynchronously so the test exercises the subscription path, not the initial-snapshot fast path.
  - `TestWaitReturnsDiedWhenSessionDies` — death mid-turn returns `reason=died` so the CLI maps to exit code 2.
  - `TestWaitTimesOut` — distinct 408 / exit code 3 so callers can tell timeout apart from idle / died.
  - `TestWaitRejectsShellSessions` — explicit allowlist (claude / codex / pi) catches future kinds that forget to wire `Working` too.
  - `TestWaitNotFound` — keeps "missing session" from being confused with "session is busy forever".
- Backend tests under `-race -count=20` clean.
- End-to-end smoke against running agents: `--wait --timeout 5` returns 0 against idle pi sessions, 3 against busy ones, 1 (with clear message) against shell and remote-peer sessions.
- `npx astro build` clean across all 40 pages.

## Out of scope (deliberately, per the issue's prioritisation)

- `--wait-all`: composes via shell `&` + `wait`. Worked example in the integrations page.
- `--send-wait`: composes via `&&`.
- `--status-all`, `--history`, `--wait-condition`: deferred. The first three primitives close the orchestration gap; the rest is sugar.
- Remote peer sessions: rejected with a clear error until peer subscriptions stream `Status` events back to the hub.
