### PR TITLE
fix(web): consume xterm fork with android gboard composition fix

### DIFF
--- a/apps/gmux-web/package.json
+++ b/apps/gmux-web/package.json
@@ -19,10 +19,10 @@
     "@preact/signals": "^2.9.0",
     "@trpc/client": "^11.6.0",
     "@xterm/addon-fit": "0.12.0-beta.195",
-    "@xterm/addon-image": "github:mgabor3141/xterm.js#fix/image-addon-hidpi&path:addons/addon-image",
+    "@xterm/addon-image": "github:gmuxapp/xterm.js#fix/image-addon-hidpi&path:addons/addon-image",
     "@xterm/addon-web-links": "0.13.0-beta.195",
     "@xterm/addon-webgl": "0.20.0-beta.194",
-    "@xterm/xterm": "6.1.0-beta.195",
+    "@xterm/xterm": "github:gmuxapp/xterm.js#v6.1.0-beta.195-gmux.1",
     "preact": "^10.26.4",
     "preact-iso": "^2.11.1",
     "valibot": "^1.3.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,19 +49,19 @@ importers:
         version: 11.12.0(@trpc/server@11.12.0(typescript@5.9.3))(typescript@5.9.3)
       '@xterm/addon-fit':
         specifier: 0.12.0-beta.195
-        version: 0.12.0-beta.195(@xterm/xterm@6.1.0-beta.195)
+        version: 0.12.0-beta.195(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/c9d24e0c4453b057315c0bcdfd04249a956880a1)
       '@xterm/addon-image':
-        specifier: github:mgabor3141/xterm.js#fix/image-addon-hidpi&path:addons/addon-image
-        version: https://codeload.github.com/mgabor3141/xterm.js/tar.gz/da8c3baed8c5f7c93dc9b8db9508d1b83f0536dc#path:addons/addon-image
+        specifier: github:gmuxapp/xterm.js#fix/image-addon-hidpi&path:addons/addon-image
+        version: https://codeload.github.com/gmuxapp/xterm.js/tar.gz/da8c3baed8c5f7c93dc9b8db9508d1b83f0536dc#path:addons/addon-image
       '@xterm/addon-web-links':
         specifier: 0.13.0-beta.195
-        version: 0.13.0-beta.195(@xterm/xterm@6.1.0-beta.195)
+        version: 0.13.0-beta.195(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/c9d24e0c4453b057315c0bcdfd04249a956880a1)
       '@xterm/addon-webgl':
         specifier: 0.20.0-beta.194
-        version: 0.20.0-beta.194(@xterm/xterm@6.1.0-beta.195)
+        version: 0.20.0-beta.194(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/c9d24e0c4453b057315c0bcdfd04249a956880a1)
       '@xterm/xterm':
-        specifier: 6.1.0-beta.195
-        version: 6.1.0-beta.195
+        specifier: github:gmuxapp/xterm.js#v6.1.0-beta.195-gmux.1
+        version: https://codeload.github.com/gmuxapp/xterm.js/tar.gz/c9d24e0c4453b057315c0bcdfd04249a956880a1
       preact:
         specifier: ^10.26.4
         version: 10.29.0
@@ -1363,25 +1363,29 @@ packages:
 
   '@xterm/addon-fit@0.12.0-beta.195':
     resolution: {integrity: sha512-Ihc+azRK3HFB2NVBEoWRkEUGYVxoojK2X4Jx6YxiRKdAu6bYzDTzTImE/0EDOjjz2AUUqddRwCUdSbz2/WvYfA==}
+    version: 0.12.0-beta.195
     peerDependencies:
       '@xterm/xterm': ^6.1.0-beta.195
 
-  '@xterm/addon-image@https://codeload.github.com/mgabor3141/xterm.js/tar.gz/da8c3baed8c5f7c93dc9b8db9508d1b83f0536dc#path:addons/addon-image':
-    resolution: {path: addons/addon-image, tarball: https://codeload.github.com/mgabor3141/xterm.js/tar.gz/da8c3baed8c5f7c93dc9b8db9508d1b83f0536dc}
+  '@xterm/addon-image@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/da8c3baed8c5f7c93dc9b8db9508d1b83f0536dc#path:addons/addon-image':
+    resolution: {path: addons/addon-image, tarball: https://codeload.github.com/gmuxapp/xterm.js/tar.gz/da8c3baed8c5f7c93dc9b8db9508d1b83f0536dc}
     version: 0.9.0
 
   '@xterm/addon-web-links@0.13.0-beta.195':
     resolution: {integrity: sha512-3x1jjud/TAVCSd3Jn7E9ielvPUwHAqvtqL1AKeH9sD5RKUuNr+Z4B+vhkvR0XF2BAk9af6ErgyygdAMnOL2Rwg==}
+    version: 0.13.0-beta.195
     peerDependencies:
       '@xterm/xterm': ^6.1.0-beta.195
 
   '@xterm/addon-webgl@0.20.0-beta.194':
     resolution: {integrity: sha512-aX4yGkHyoJVmxh3ZVMha7CYdTFu7tuzTJ0ljyXKAVFrdO+Wve4luK8w3wLmxuvqa9LWA9muMx/bGeEWtwD/Nlg==}
+    version: 0.20.0-beta.194
     peerDependencies:
       '@xterm/xterm': ^6.1.0-beta.195
 
-  '@xterm/xterm@6.1.0-beta.195':
-    resolution: {integrity: sha512-lLVfI3T4pX4W4qrbf2Qhdq5Pa00FkOOUz9vlOm6f1r5wel1mUafeJL8zacfsUVdc03MsCKHRyZkLubmDEnabcw==}
+  '@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/c9d24e0c4453b057315c0bcdfd04249a956880a1':
+    resolution: {tarball: https://codeload.github.com/gmuxapp/xterm.js/tar.gz/c9d24e0c4453b057315c0bcdfd04249a956880a1}
+    version: 6.0.0
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -4210,21 +4214,21 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
-  '@xterm/addon-fit@0.12.0-beta.195(@xterm/xterm@6.1.0-beta.195)':
+  '@xterm/addon-fit@0.12.0-beta.195(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/c9d24e0c4453b057315c0bcdfd04249a956880a1)':
     dependencies:
-      '@xterm/xterm': 6.1.0-beta.195
+      '@xterm/xterm': https://codeload.github.com/gmuxapp/xterm.js/tar.gz/c9d24e0c4453b057315c0bcdfd04249a956880a1
 
-  '@xterm/addon-image@https://codeload.github.com/mgabor3141/xterm.js/tar.gz/da8c3baed8c5f7c93dc9b8db9508d1b83f0536dc#path:addons/addon-image': {}
+  '@xterm/addon-image@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/da8c3baed8c5f7c93dc9b8db9508d1b83f0536dc#path:addons/addon-image': {}
 
-  '@xterm/addon-web-links@0.13.0-beta.195(@xterm/xterm@6.1.0-beta.195)':
+  '@xterm/addon-web-links@0.13.0-beta.195(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/c9d24e0c4453b057315c0bcdfd04249a956880a1)':
     dependencies:
-      '@xterm/xterm': 6.1.0-beta.195
+      '@xterm/xterm': https://codeload.github.com/gmuxapp/xterm.js/tar.gz/c9d24e0c4453b057315c0bcdfd04249a956880a1
 
-  '@xterm/addon-webgl@0.20.0-beta.194(@xterm/xterm@6.1.0-beta.195)':
+  '@xterm/addon-webgl@0.20.0-beta.194(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/c9d24e0c4453b057315c0bcdfd04249a956880a1)':
     dependencies:
-      '@xterm/xterm': 6.1.0-beta.195
+      '@xterm/xterm': https://codeload.github.com/gmuxapp/xterm.js/tar.gz/c9d24e0c4453b057315c0bcdfd04249a956880a1
 
-  '@xterm/xterm@6.1.0-beta.195': {}
+  '@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/c9d24e0c4453b057315c0bcdfd04249a956880a1': {}
 
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:


### PR DESCRIPTION
Switch `@xterm/xterm` to [gmuxapp/xterm.js#v6.1.0-beta.195-gmux.1](https://github.com/gmuxapp/xterm.js/tree/v6.1.0-beta.195-gmux.1), which includes a fix for Android Gboard "edit previous word" mode.

## The bug

User trace (Android 10, Chrome 137, Gboard) reported via `/_/input-diagnostics`:

1. User types `input1 input2 input3 ` (terminal echoes 21 chars).
2. User presses backspace. Gboard deletes the trailing space and restarts composition on `input3`.
3. xterm's composition view overlay renders `input3` at the cursor in a slightly different color, so the user sees `input1 input2 input3 input3` and assumes their text was duplicated.
4. As the user keeps backspacing, the composition data shrinks (`input3` → `input` → ... → ``) and so does the textarea, but xterm sends nothing because `_finalizeComposition`'s deferred path computes `value.substring(20, 14) === ''` and silently skips `triggerDataEvent`.
5. After ~21 phantom backspaces (3 sessions × 7 chars), the textarea is empty; further backspaces flow through xterm's keydown path and the deletes finally hit the terminal. The user has pressed backspace ~42 times to delete 21 chars.

## Why a fork

Issue [xtermjs/xterm.js#3600](https://github.com/xtermjs/xterm.js/issues/3600) has been open since 2022-01 with the maintainer marking it low priority. The architectural fix is non-trivial because the obvious workaround (`textarea.value = ''` on compositionend) breaks Korean composition. The two-system arrangement (our `mobile-input.ts` racing xterm's CompositionHelper on the same textarea) was getting fragile. Forking lets us fix it at the source with proper test coverage.

The fork lives at [gmuxapp/xterm.js](https://github.com/gmuxapp/xterm.js) under the org. The fix commit is a candidate for upstreaming via PR.

## Changes in this PR

Just the dependency bump in `apps/gmux-web/package.json` plus the resulting lockfile churn. Both fork URLs (xterm core and addon-image) now point at gmuxapp.

## Tests

- All 312 gmux-web unit tests pass on the new fork.
- The fork itself adds 2 regression tests for the Gboard pattern and continues to pass the existing 8 CJK composition tests (10 total in CompositionHelper.test.ts; 2246 total xterm unit tests).

## Verification

Reproduced the trace on real Android Gboard locally; backspaces now flow to the terminal in lockstep with each keypress, and the composition view overlay clears as expected.