### PR TITLE
fix(web): pin xterm fork to immutable tag and fix peer-dep version

### DIFF
--- a/apps/gmux-web/package.json
+++ b/apps/gmux-web/package.json
@@ -19,10 +19,10 @@
     "@preact/signals": "^2.9.0",
     "@trpc/client": "^11.6.0",
     "@xterm/addon-fit": "0.12.0-beta.195",
-    "@xterm/addon-image": "github:gmuxapp/xterm.js#fix/image-addon-hidpi&path:addons/addon-image",
+    "@xterm/addon-image": "github:gmuxapp/xterm.js#v6.1.0-beta.195-gmux.2&path:addons/addon-image",
     "@xterm/addon-web-links": "0.13.0-beta.195",
     "@xterm/addon-webgl": "0.20.0-beta.194",
-    "@xterm/xterm": "github:gmuxapp/xterm.js#v6.1.0-beta.195-gmux.1",
+    "@xterm/xterm": "github:gmuxapp/xterm.js#v6.1.0-beta.195-gmux.2",
     "preact": "^10.26.4",
     "preact-iso": "^2.11.1",
     "valibot": "^1.3.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,19 +49,19 @@ importers:
         version: 11.12.0(@trpc/server@11.12.0(typescript@5.9.3))(typescript@5.9.3)
       '@xterm/addon-fit':
         specifier: 0.12.0-beta.195
-        version: 0.12.0-beta.195(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/c9d24e0c4453b057315c0bcdfd04249a956880a1)
+        version: 0.12.0-beta.195(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed)
       '@xterm/addon-image':
-        specifier: github:gmuxapp/xterm.js#fix/image-addon-hidpi&path:addons/addon-image
-        version: https://codeload.github.com/gmuxapp/xterm.js/tar.gz/da8c3baed8c5f7c93dc9b8db9508d1b83f0536dc#path:addons/addon-image
+        specifier: github:gmuxapp/xterm.js#v6.1.0-beta.195-gmux.2&path:addons/addon-image
+        version: https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed#path:addons/addon-image
       '@xterm/addon-web-links':
         specifier: 0.13.0-beta.195
-        version: 0.13.0-beta.195(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/c9d24e0c4453b057315c0bcdfd04249a956880a1)
+        version: 0.13.0-beta.195(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed)
       '@xterm/addon-webgl':
         specifier: 0.20.0-beta.194
-        version: 0.20.0-beta.194(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/c9d24e0c4453b057315c0bcdfd04249a956880a1)
+        version: 0.20.0-beta.194(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed)
       '@xterm/xterm':
-        specifier: github:gmuxapp/xterm.js#v6.1.0-beta.195-gmux.1
-        version: https://codeload.github.com/gmuxapp/xterm.js/tar.gz/c9d24e0c4453b057315c0bcdfd04249a956880a1
+        specifier: github:gmuxapp/xterm.js#v6.1.0-beta.195-gmux.2
+        version: https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed
       preact:
         specifier: ^10.26.4
         version: 10.29.0
@@ -1367,8 +1367,8 @@ packages:
     peerDependencies:
       '@xterm/xterm': ^6.1.0-beta.195
 
-  '@xterm/addon-image@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/da8c3baed8c5f7c93dc9b8db9508d1b83f0536dc#path:addons/addon-image':
-    resolution: {path: addons/addon-image, tarball: https://codeload.github.com/gmuxapp/xterm.js/tar.gz/da8c3baed8c5f7c93dc9b8db9508d1b83f0536dc}
+  '@xterm/addon-image@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed#path:addons/addon-image':
+    resolution: {path: addons/addon-image, tarball: https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed}
     version: 0.9.0
 
   '@xterm/addon-web-links@0.13.0-beta.195':
@@ -1383,9 +1383,9 @@ packages:
     peerDependencies:
       '@xterm/xterm': ^6.1.0-beta.195
 
-  '@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/c9d24e0c4453b057315c0bcdfd04249a956880a1':
-    resolution: {tarball: https://codeload.github.com/gmuxapp/xterm.js/tar.gz/c9d24e0c4453b057315c0bcdfd04249a956880a1}
-    version: 6.0.0
+  '@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed':
+    resolution: {tarball: https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed}
+    version: 6.1.0-beta.195
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -4214,21 +4214,21 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
-  '@xterm/addon-fit@0.12.0-beta.195(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/c9d24e0c4453b057315c0bcdfd04249a956880a1)':
+  '@xterm/addon-fit@0.12.0-beta.195(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed)':
     dependencies:
-      '@xterm/xterm': https://codeload.github.com/gmuxapp/xterm.js/tar.gz/c9d24e0c4453b057315c0bcdfd04249a956880a1
+      '@xterm/xterm': https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed
 
-  '@xterm/addon-image@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/da8c3baed8c5f7c93dc9b8db9508d1b83f0536dc#path:addons/addon-image': {}
+  '@xterm/addon-image@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed#path:addons/addon-image': {}
 
-  '@xterm/addon-web-links@0.13.0-beta.195(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/c9d24e0c4453b057315c0bcdfd04249a956880a1)':
+  '@xterm/addon-web-links@0.13.0-beta.195(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed)':
     dependencies:
-      '@xterm/xterm': https://codeload.github.com/gmuxapp/xterm.js/tar.gz/c9d24e0c4453b057315c0bcdfd04249a956880a1
+      '@xterm/xterm': https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed
 
-  '@xterm/addon-webgl@0.20.0-beta.194(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/c9d24e0c4453b057315c0bcdfd04249a956880a1)':
+  '@xterm/addon-webgl@0.20.0-beta.194(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed)':
     dependencies:
-      '@xterm/xterm': https://codeload.github.com/gmuxapp/xterm.js/tar.gz/c9d24e0c4453b057315c0bcdfd04249a956880a1
+      '@xterm/xterm': https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed
 
-  '@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/c9d24e0c4453b057315c0bcdfd04249a956880a1': {}
+  '@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed': {}
 
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:


### PR DESCRIPTION
Follow-up to #213, addressing Greptile review feedback.

## Changes in the fork (gmuxapp/xterm.js)

New tag [`v6.1.0-beta.195-gmux.2`](https://github.com/gmuxapp/xterm.js/tree/v6.1.0-beta.195-gmux.2) folds together:
1. The original Gboard composition fix (`6a011cf4`).
2. The addon-image HiDPI fix, cherry-picked from the standalone `fix/image-addon-hidpi-pr` branch (`0bec8e56`).
3. Version bump in the fork's `package.json` from `6.0.0` → `6.1.0-beta.195` (`4cab6d38`), so the `^6.1.0-beta.195` peer dependency declared by the npm-published addons (`addon-fit`, `addon-web-links`, `addon-webgl`) resolves cleanly. Previously pnpm was matching by URL identity; `pnpm install --strict-peer-dependencies` would have errored.
4. Re-built `lib/` artifacts for both core and addon-image (`a8d82b58`).

## Changes in this PR

`apps/gmux-web/package.json` now pins both packages to the same tag:
```
"@xterm/addon-image": "github:gmuxapp/xterm.js#v6.1.0-beta.195-gmux.2&path:addons/addon-image",
"@xterm/xterm":       "github:gmuxapp/xterm.js#v6.1.0-beta.195-gmux.2"
```

Previously addon-image was pinned to a branch ref (`fix/image-addon-hidpi`), which would silently follow whatever HEAD that branch points to on a fresh install without the lockfile. Tags are immutable.

## Verification

- `pnpm install --strict-peer-dependencies` succeeds.
- All 312 web unit tests pass.
- Both @xterm/xterm and @xterm/addon-image lockfile entries resolve to the same commit hash (the tagged commit), confirming a single source of truth.