### PR TITLE
fix(web): break suggested_slug ties on path in discoverProjects sort

### DIFF
--- a/apps/gmux-web/src/projects.test.ts
+++ b/apps/gmux-web/src/projects.test.ts
@@ -843,6 +843,26 @@ describe('discoverProjects', () => {
     ]
     expect(discoverProjects(sessions, [])).toEqual([])
   })
+
+  it('breaks suggested_slug ties on path for stable order across snapshots', () => {
+    // Two unrelated sessions whose cwd basenames collide on
+    // slugFromPath both produce suggested_slug = "api". With only
+    // active_count, session_count, suggested_slug as sort keys the
+    // pair would tie; the sort then falls through to the byDir Map's
+    // insertion order, which mirrors the input sessions array.
+    //
+    // In the manage-projects modal that input order is set by
+    // snapshot.sessions, whose Go-map iteration is randomized, so
+    // every snapshot re-emit would visually flip the rows. The
+    // paths[0] tiebreak pins them.
+    const a = makeSession({ id: 'sa', cwd: '/home/me/api', alive: true })
+    const b = makeSession({ id: 'sb', cwd: '/srv/api', alive: true })
+
+    for (const input of [[a, b], [b, a]]) {
+      const out = discoverProjects(input, [])
+      expect(out.map(d => d.paths[0])).toEqual(['/home/me/api', '/srv/api'])
+    }
+  })
 })
 
 describe('countUnmatchedActive', () => {

--- a/apps/gmux-web/src/projects.ts
+++ b/apps/gmux-web/src/projects.ts
@@ -203,11 +203,25 @@ export function discoverProjects(
     result.push(dp)
   }
 
-  // Active first, then most sessions, then alphabetically.
+  // Active first, then most sessions, then alphabetically by
+  // suggested_slug, then by the directory path that originated this
+  // discovered project.
+  //
+  // The final paths[0] tiebreak matters: two sessions whose cwds have
+  // the same basename (e.g. `/home/me/api` and `/srv/api`) bucket
+  // into distinct discovered projects but produce identical
+  // suggested_slug values via slugFromPath. Without it, the sort falls
+  // through to the input order, which is the byDir Map's insertion
+  // order, which mirrors the (Go-map-randomized) snapshot.sessions
+  // order — so the two rows flip on every snapshot re-emit. paths[0]
+  // is unique per discovered project because it is the very key used
+  // to build the bucket.
   result.sort((a, b) => {
     if (a.active_count !== b.active_count) return b.active_count - a.active_count
     if (a.session_count !== b.session_count) return b.session_count - a.session_count
-    return a.suggested_slug < b.suggested_slug ? -1 : a.suggested_slug > b.suggested_slug ? 1 : 0
+    const slugCmp = a.suggested_slug.localeCompare(b.suggested_slug)
+    if (slugCmp !== 0) return slugCmp
+    return a.paths[0].localeCompare(b.paths[0])
   })
   return result
 }


### PR DESCRIPTION
## Bug

In the **Manage projects** modal, two rows in the Discovered list
would visually swap places when a v1 spoke was sending session
updates. Reproduced reliably with a bespin peer (still on the v1
daemon) and two checkouts whose paths share a basename
(`~/dev/api` locally and `/srv/api` on bespin both slugify to
`api`).

## Root cause

Third instance of the same shape of bug fixed for the sidebar and
project hub in #191's follow-up commits: a sort function ties on a
non-unique key and falls through to **input order**, which on this
code path is the `byDir` Map's insertion order, which mirrors the
`snapshot.sessions` array, which the daemon composes from a
randomized Go-map iteration.

`slugFromPath` returns the basename slug. Two sessions whose cwds
end in the same component produce two distinct discovered projects
with identical `suggested_slug`. The `active_count` /
`session_count` tiebreakers don't break the tie when both rows have
the same counts.

The "every frame" feel comes from the chain
`v1-spoke session-upsert → hub mirror → snapshot.sessions →
_rawSessions ref change → discovered recompute → tied rows flip`,
up to the 50ms coalescer floor (≈20 flips/sec under steady spoke
activity).

## Fix

Tiebreak on `paths[0]`. It is the `byDir` bucket key by
construction, so it is unique per discovered project. Sort is now
fully deterministic regardless of input order.

## Test

`discoverProjects > breaks suggested_slug ties on path for stable
order across snapshots` constructs the same two-session input in
both orderings and asserts the output matches in either case.