### PR TITLE
feat: project ownership polish (references over adoption)

### DIFF
--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -500,6 +500,7 @@ function App() {
         ) : viewVal?.kind === 'project' ? (
           <ProjectHub
             projectSlug={viewVal.projectSlug}
+            projectPeer={viewVal.projectPeer}
             onCloseSession={handleCloseSession}
           />
         ) : selectedVal && (canAttach || USE_MOCK) && termOpts && keybindsVal ? (

--- a/apps/gmux-web/src/manage-projects.tsx
+++ b/apps/gmux-web/src/manage-projects.tsx
@@ -1,5 +1,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks'
-import { projects, discovered, removeProject, addProject, updateProjects } from './store'
+import {
+  projects, discovered, peerProjects, peerStatusByName,
+  removeProject, addProject, updateProjects,
+  addPeerReference, removePeerReference,
+} from './store'
+import { PeerLabel } from './peer-label'
 import type { ProjectItem, DiscoveredProject, MatchRule } from './types'
 
 // ── Rule description ──
@@ -125,7 +130,14 @@ export function ManageProjectsModal({
   // ── Add from discovered ──
 
   const handleAdd = useCallback((d: DiscoveredProject) => {
-    addProject({ remote: d.remote, paths: d.paths })
+    if (d.peer) {
+      // Remote suggestion: create the project on the peer (proxied),
+      // then auto-add a local reference so it appears in the sidebar.
+      addProject({ remote: d.remote, paths: d.paths }, d.peer)
+        .then(() => addPeerReference(d.peer!, d.suggested_slug))
+    } else {
+      addProject({ remote: d.remote, paths: d.paths })
+    }
   }, [])
 
   // ── Manual add by path ──
@@ -169,22 +181,25 @@ export function ManageProjectsModal({
         </div>
 
         <div class="modal-body">
-          {/* ── Configured projects ── */}
+          {/* ── Configured projects (owned + references) ── */}
           <section class="mp-section">
-            <div class="mp-section-label">Your projects</div>
+            <div class="mp-section-label">Your sidebar</div>
             {configured.length > 0 ? (
               <div class="mp-project-list">
                 {dragItems.map((project, i) => (
                   <ProjectRow
-                    key={project.slug}
+                    key={`${project.peer ?? ''}::${project.slug}`}
                     project={project}
                     index={i}
-                    dragging={drag !== null && project.slug === configured[drag.from]?.slug}
+                    dragging={drag !== null && itemKey(project) === itemKey(configured[drag.from])}
                     dropTarget={drag !== null && drag.over === i && drag.from !== i}
                     onDragStart={handleDragStart}
                     onDragOver={handleDragOver}
                     onDragEnd={handleDragEnd}
-                    onRemove={handleRemove}
+                    onRemove={(p) => {
+                      if (p.peer) removePeerReference(p.peer, p.slug)
+                      else handleRemove(p.slug)
+                    }}
                   />
                 ))}
               </div>
@@ -194,6 +209,9 @@ export function ManageProjectsModal({
               </div>
             )}
           </section>
+
+          {/* ── References to peer-owned projects ── */}
+          <PeerReferencesSection configured={configured} />
 
           {/* ── Discovered projects ── */}
           <section class="mp-section">
@@ -268,9 +286,10 @@ function ProjectRow({
   onDragStart: (i: number) => void
   onDragOver: (i: number) => void
   onDragEnd: () => void
-  onRemove: (slug: string) => void
+  onRemove: (project: ProjectItem) => void
 }) {
   const rules = project.match ?? []
+  const isReference = !!project.peer
 
   return (
     <div
@@ -293,10 +312,13 @@ function ProjectRow({
       onDragEnd={onDragEnd}
     >
       <span class="mp-drag-handle" title="Drag to reorder">&#x283F;</span>
+      {project.peer && <PeerLabel name={project.peer} />}
       <div class="mp-project-info">
         <span class="mp-project-name">{project.slug}</span>
         <div class="mp-project-rules">
-          {rules.map((rule, i) => {
+          {isReference ? (
+            <span class="mp-rule mp-rule-qualifier">reference</span>
+          ) : rules.map((rule, i) => {
             const { prefix, label, qualifier } = describeRule(rule)
             const title = [prefix, label, qualifier].filter(Boolean).join(' ')
             return (
@@ -311,8 +333,8 @@ function ProjectRow({
       </div>
       <button
         class="mp-remove-btn"
-        onClick={() => onRemove(project.slug)}
-        title="Remove project"
+        onClick={() => onRemove(project)}
+        title={isReference ? 'Remove reference' : 'Remove project'}
       >
         &times;
       </button>
@@ -332,6 +354,7 @@ function DiscoveredRow({
 
   return (
     <div class="mp-discovered-row" onClick={() => onAdd(project)}>
+      {project.peer && <PeerLabel name={project.peer} />}
       <div class="mp-project-info">
         <span class="mp-project-name">
           {project.suggested_slug}
@@ -344,6 +367,58 @@ function DiscoveredRow({
       <span class="mp-add-label">+ Add</span>
     </div>
   )
+}
+
+/** Lists peer-owned projects that the viewer hasn't referenced yet,
+ *  one section per connected peer. Each row adds a reference via
+ *  addPeerReference; the new folder appears in the sidebar on the
+ *  next render. */
+function PeerReferencesSection({ configured }: { configured: ProjectItem[] }) {
+  const peerProjectsByPeer = peerProjects.value
+  const statuses = peerStatusByName.value
+  const referenced = useMemo(() => {
+    const set = new Set<string>()
+    for (const p of configured) {
+      if (p.peer) set.add(`${p.peer}::${p.slug}`)
+    }
+    return set
+  }, [configured])
+
+  const entries: { peer: string; slug: string }[] = []
+  for (const peer of Object.keys(peerProjectsByPeer).sort()) {
+    if (statuses.get(peer) !== 'connected') continue
+    for (const sp of peerProjectsByPeer[peer]) {
+      if (referenced.has(`${peer}::${sp.slug}`)) continue
+      entries.push({ peer, slug: sp.slug })
+    }
+  }
+
+  if (entries.length === 0) return null
+  return (
+    <section class="mp-section">
+      <div class="mp-section-label">From other hosts</div>
+      <div class="mp-project-list">
+        {entries.map(({ peer, slug }) => (
+          <div
+            key={`${peer}::${slug}`}
+            class="mp-discovered-row"
+            onClick={() => addPeerReference(peer, slug)}
+          >
+            <PeerLabel name={peer} />
+            <div class="mp-project-info">
+              <span class="mp-project-name">{slug}</span>
+            </div>
+            <span class="mp-add-label">+ Add</span>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}
+
+function itemKey(p: ProjectItem | undefined): string {
+  if (!p) return ''
+  return `${p.peer ?? ''}::${p.slug}`
 }
 
 // ── Helpers ──

--- a/apps/gmux-web/src/manage-projects.tsx
+++ b/apps/gmux-web/src/manage-projects.tsx
@@ -8,19 +8,15 @@ import type { ProjectItem, DiscoveredProject, MatchRule } from './types'
 interface RuleDescription {
   prefix?: string   // e.g. "Remote"
   label: string     // monospace part: path or URL
-  qualifier: string // dimmed suffix: "on any host"
+  qualifier: string // dimmed suffix
 }
 
 function describeRule(rule: MatchRule): RuleDescription {
-  const hosts = rule.hosts?.length
-    ? rule.hosts.join(', ')
-    : 'any host'
-
   if (rule.path) {
     const suffix = rule.exact ? ' only' : ''
     return {
       label: `${rule.path}${suffix}`,
-      qualifier: `on ${hosts}`,
+      qualifier: '',
     }
   }
 
@@ -28,7 +24,7 @@ function describeRule(rule: MatchRule): RuleDescription {
     return {
       prefix: 'Remote',
       label: rule.remote,
-      qualifier: `in any directory on ${hosts}`,
+      qualifier: 'in any directory',
     }
   }
 
@@ -274,7 +270,7 @@ function ProjectRow({
   onDragEnd: () => void
   onRemove: (slug: string) => void
 }) {
-  const rules = project.match
+  const rules = project.match ?? []
 
   return (
     <div

--- a/apps/gmux-web/src/manage-projects.tsx
+++ b/apps/gmux-web/src/manage-projects.tsx
@@ -137,9 +137,14 @@ export function ManageProjectsModal({
       // gets a dangling reference (peer refused the add but viewer's
       // projects.json gains a reference to a slug that doesn't exist
       // upstream).
+      //
+      // Use the slug the peer actually assigned, not d.suggested_slug:
+      // the peer's UniqueSlug may have deduplicated on collision
+      // ("api" → "api-2"), in which case referencing the client-side
+      // guess would produce an immediate dangling reference.
       try {
-        await addProject({ remote: d.remote, paths: d.paths }, d.peer)
-        await addPeerReference(d.peer, d.suggested_slug)
+        const created = await addProject({ remote: d.remote, paths: d.paths }, d.peer)
+        await addPeerReference(d.peer, created.slug)
       } catch {
         // addProject already logs the failure; nothing more to do here.
         // Surface in the UI eventually via a toast; out of scope for now.

--- a/apps/gmux-web/src/manage-projects.tsx
+++ b/apps/gmux-web/src/manage-projects.tsx
@@ -129,14 +129,23 @@ export function ManageProjectsModal({
 
   // ── Add from discovered ──
 
-  const handleAdd = useCallback((d: DiscoveredProject) => {
+  const handleAdd = useCallback(async (d: DiscoveredProject) => {
     if (d.peer) {
       // Remote suggestion: create the project on the peer (proxied),
       // then auto-add a local reference so it appears in the sidebar.
-      addProject({ remote: d.remote, paths: d.paths }, d.peer)
-        .then(() => addPeerReference(d.peer!, d.suggested_slug))
+      // Gate the reference on a successful create; otherwise the user
+      // gets a dangling reference (peer refused the add but viewer's
+      // projects.json gains a reference to a slug that doesn't exist
+      // upstream).
+      try {
+        await addProject({ remote: d.remote, paths: d.paths }, d.peer)
+        await addPeerReference(d.peer, d.suggested_slug)
+      } catch {
+        // addProject already logs the failure; nothing more to do here.
+        // Surface in the UI eventually via a toast; out of scope for now.
+      }
     } else {
-      addProject({ remote: d.remote, paths: d.paths })
+      await addProject({ remote: d.remote, paths: d.paths }).catch(() => {})
     }
   }, [])
 

--- a/apps/gmux-web/src/peer-label.tsx
+++ b/apps/gmux-web/src/peer-label.tsx
@@ -1,13 +1,20 @@
-/** Colored badge showing a peer's unique prefix. */
+/** Colored badge showing a peer's unique prefix.
+ *
+ * Status-aware: reads peerStatusByName and dims when the peer is
+ * disconnected. Callers don't need to thread peer status through
+ * because connection state is intrinsic to the chip's meaning. */
 
-import { peerAppearance } from './store'
+import { peerAppearance, peerStatusByName } from './store'
 
 export function PeerLabel({ name }: { name: string }) {
   const a = peerAppearance.value.get(name)
+  const status = peerStatusByName.value.get(name)
+  const connected = status === 'connected'
+  const cls = `session-peer-label${connected ? '' : ' offline'}`
   return (
     <span
-      class="session-peer-label"
-      title={name}
+      class={cls}
+      title={connected ? name : `${name} (${status ?? 'unknown'})`}
       style={a && { color: a.color, background: a.bg }}
     >
       {a?.label ?? name[0].toUpperCase()}

--- a/apps/gmux-web/src/project-hub.tsx
+++ b/apps/gmux-web/src/project-hub.tsx
@@ -9,7 +9,7 @@ import type { HostNode } from './projects'
 import { buildProjectTopology } from './projects'
 import { sessionPath } from './routing'
 import { LaunchButton } from './launcher'
-import { sessions, projects, peers, peerStatusByName, isSessionUnavailable } from './store'
+import { sessions, projects, peers, peerStatusByName, isSessionUnavailable, localPeerNames } from './store'
 import { PeerLabel } from './peer-label'
 
 function projectRemote(p: ProjectItem | undefined): string | undefined {
@@ -22,13 +22,20 @@ function projectFirstPath(p: ProjectItem | undefined): string | undefined {
 
 interface ProjectHubProps {
   projectSlug: string
+  projectPeer?: string
   onCloseSession: (session: Session) => void
 }
 
-export function ProjectHub({ projectSlug, onCloseSession }: ProjectHubProps) {
+export function ProjectHub({ projectSlug, projectPeer, onCloseSession }: ProjectHubProps) {
   const projectsVal = projects.value
-  const project = projectsVal.find(p => p.slug === projectSlug)
-  const hosts = buildProjectTopology(projectSlug, sessions.value, projectsVal, peers.value)
+  const project = projectsVal.find(p =>
+    p.slug === projectSlug && (p.peer ?? '') === (projectPeer ?? ''),
+  )
+  const hosts = buildProjectTopology(
+    projectSlug, sessions.value, projectsVal, peers.value,
+    projectPeer,
+    (name) => localPeerNames.value.has(name),
+  )
   const remote = projectRemote(project)
 
   const totalSessions = hosts.reduce(

--- a/apps/gmux-web/src/project-hub.tsx
+++ b/apps/gmux-web/src/project-hub.tsx
@@ -13,11 +13,11 @@ import { sessions, projects, peers, peerStatusByName, isSessionUnavailable } fro
 import { PeerLabel } from './peer-label'
 
 function projectRemote(p: ProjectItem | undefined): string | undefined {
-  return p?.match.find(r => r.remote)?.remote
+  return p?.match?.find(r => r.remote)?.remote
 }
 
 function projectFirstPath(p: ProjectItem | undefined): string | undefined {
-  return p?.match.find(r => r.path)?.path
+  return p?.match?.find(r => r.path)?.path
 }
 
 interface ProjectHubProps {

--- a/apps/gmux-web/src/projects.test.ts
+++ b/apps/gmux-web/src/projects.test.ts
@@ -259,6 +259,48 @@ describe('buildProjectFolders', () => {
     expect(folders[0].sessions).toEqual([])
   })
 
+  it('derives launchCwd for a reference from peer_projects', () => {
+    // Empty referenced folder still needs a sensible cwd for the
+    // launch button: pull it from peer_projects so the launcher
+    // doesn't fall back to the peer's $HOME.
+    const projects: ProjectItem[] = [
+      { slug: 'gmux', peer: 'tower' },
+    ]
+    const peerProjects = {
+      tower: [{ slug: 'gmux', launch_cwd: '/home/me/dev/gmux' }],
+    }
+    const folders = buildProjectFolders(projects, [], undefined, peerProjects)
+    expect(folders[0].launchCwd).toBe('/home/me/dev/gmux')
+  })
+
+  it('flags a reference as missing when the peer no longer enumerates the slug', () => {
+    // Peer is connected (we have a peer_projects entry for it) but
+    // doesn't list the slug we're referencing: project was removed
+    // upstream. Mark the folder so the UI renders a question-mark
+    // badge prompting the user to remove the reference.
+    const projects: ProjectItem[] = [
+      { slug: 'gmux', peer: 'tower' },
+    ]
+    const peerProjects = {
+      tower: [{ slug: 'something-else' }], // peer reachable, slug gone
+    }
+    const folders = buildProjectFolders(projects, [], undefined, peerProjects)
+    expect(folders[0].missing).toBe(true)
+  })
+
+  it('does not flag a reference as missing when the peer is disconnected', () => {
+    // No peer_projects entry for a peer means we have no enumeration
+    // (disconnected or not yet fetched). Distinguishing missing from
+    // disconnected matters for the UI: disconnected uses the dimmed
+    // PeerLabel, missing uses the ? badge. Conflating them would
+    // nag users when their laptop goes to sleep.
+    const projects: ProjectItem[] = [
+      { slug: 'gmux', peer: 'tower' },
+    ]
+    const folders = buildProjectFolders(projects, [], undefined, {})
+    expect(folders[0].missing).toBeUndefined()
+  })
+
   it('keeps a local owned project and a same-slug reference as separate folders', () => {
     const projects: ProjectItem[] = [
       { slug: 'gmux', match: [{ path: '/dev/gmux' }] },
@@ -457,6 +499,32 @@ describe('reorderKeysForFolder', () => {
       makeSession({ id: 'a@spoke', cwd: '/x', slug: '', peer: 'spoke' }),
     ]
     expect(reorderKeysForFolder(sessions, 'tower')).toEqual([])
+  })
+
+  it('local folder + Local peer: keeps namespaced id (parent owns assignment)', () => {
+    // Container sessions bucket into local folders. The parent's
+    // projects.json keys them by full namespaced id (their identity
+    // from the parent's POV); the reorder PATCH must preserve that
+    // shape, not strip @<peer>, or the merge logic will treat the
+    // session as new and prepend it.
+    const sessions = [
+      makeSession({ id: 'sess-1', cwd: '/x', slug: '' }),
+      makeSession({ id: 'sess-2@container', cwd: '/x', slug: '', peer: 'container' }),
+    ]
+    const isLocal = (n: string) => n === 'container'
+    expect(reorderKeysForFolder(sessions, undefined, isLocal))
+      .toEqual(['sess-1', 'sess-2@container'])
+  })
+
+  it('local folder + Local peer: slug takes precedence over namespaced id', () => {
+    // A container session that's been attribution-resolved (e.g.
+    // claude/codex) keys by slug, not id, in projects.json.
+    const sessions = [
+      makeSession({ id: 'sess-1@container', cwd: '/x', slug: 'claude-fix', peer: 'container' }),
+    ]
+    const isLocal = (n: string) => n === 'container'
+    expect(reorderKeysForFolder(sessions, undefined, isLocal))
+      .toEqual(['claude-fix'])
   })
 })
 
@@ -773,7 +841,7 @@ describe('discoverProjects', () => {
     // Two unrelated sessions whose cwd basenames collide on
     // slugFromPath both produce suggested_slug = "api". With only
     // active_count, session_count, suggested_slug as sort keys the
-    // pair would tie; the sort then falls through to the byDir Map's
+    // pair would tie; the sort then falls through to the byKey Map's
     // insertion order, which mirrors the input sessions array.
     //
     // In the manage-projects modal that input order is set by
@@ -787,6 +855,20 @@ describe('discoverProjects', () => {
       const out = discoverProjects(input, [])
       expect(out.map(d => d.paths[0])).toEqual(['/home/me/api', '/srv/api'])
     }
+  })
+
+  it('excludes sessions from disconnected peers', () => {
+    // A disconnected peer's disclaimed sessions may be stale: the
+    // peer may have grown rules we haven't seen yet. Surfacing them
+    // as discoverable would let the user click + Add against an
+    // unreachable peer and create a dangling reference.
+    const sessions = [
+      makeSession({ id: 'a@up', cwd: '/work/a', alive: true, peer: 'up' }),
+      makeSession({ id: 'b@down', cwd: '/work/b', alive: true, peer: 'down' }),
+    ]
+    const status = new Map([['up', 'connected'], ['down', 'disconnected']])
+    const out = discoverProjects(sessions, [], status)
+    expect(out.map(d => d.peer)).toEqual(['up'])
   })
 })
 

--- a/apps/gmux-web/src/projects.test.ts
+++ b/apps/gmux-web/src/projects.test.ts
@@ -179,11 +179,11 @@ describe('buildProjectFolders', () => {
     expect(folders[0].launchCwd).toBe('/dev/proj')
   })
 
-  it('hides dead sessions that the origin disclaims (not stamped to this folder)', () => {
-    // "old-dead" is dead and disclaimed: nothing claims it. The viewer's
-    // rule matches its cwd, but adopted-disclaimed dead sessions are
-    // not visible — only the viewer's intent put a rule there, and a
-    // dead session can't validate the match.
+  it('drops disclaimed sessions even when their cwd matches a local rule', () => {
+    // Under the references model, viewer match rules don't adopt
+    // sessions client-side. Only stamps put a session in a folder.
+    // A disclaimed session waiting on AutoAssign is invisible until
+    // the daemon stamps it.
     const projects: ProjectItem[] = [
       { slug: 'proj', match: [{ path: '/dev/proj' }] },
     ]
@@ -191,13 +191,10 @@ describe('buildProjectFolders', () => {
       makeSession({ id: 'kept', cwd: '/dev/proj', alive: false, resumable: true,
                     project_slug: 'proj', project_index: 0 }),
       makeSession({ id: 'old-dead', cwd: '/dev/proj', alive: false, resumable: true }),
-      makeSession({ id: 'alive-1', cwd: '/dev/proj', alive: true }),
+      makeSession({ id: 'disclaimed-alive', cwd: '/dev/proj', alive: true }),
     ]
     const folders = buildProjectFolders(projects, sessions)
-    const ids = folders[0].sessions.map(s => s.id)
-    expect(ids).toContain('alive-1')   // alive always renders
-    expect(ids).toContain('kept')      // dead but stamped: claimed, renders
-    expect(ids).not.toContain('old-dead') // dead, disclaimed: hidden
+    expect(folders[0].sessions.map(s => s.id)).toEqual(['kept'])
   })
 
   it('hides dead sessions stamped to a different project than the folder', () => {
@@ -232,104 +229,59 @@ describe('buildProjectFolders', () => {
     expect(folders[0].sessions.map(s => s.id)).toEqual(['c', 'a', 'b'])
   })
 
-  it('puts adopted-disclaimed sessions after stamped ones, ordered by created_at', () => {
-    // Adopted-disclaimed: viewer's rule matched, but origin hasn't
-    // stamped them yet (just-spawned, Reconcile-pending). They should
-    // sit at the end so they don't reshuffle the existing order.
-    const projects: ProjectItem[] = [
-      { slug: 'proj', match: [{ path: '/dev/proj' }] },
-    ]
-    const sessions = [
-      makeSession({ id: 'unstamped-old', cwd: '/dev/proj', alive: true,
-                    created_at: '2025-01-01T00:00:00Z' }),
-      makeSession({ id: 'unstamped-new', cwd: '/dev/proj', alive: true,
-                    created_at: '2025-01-03T00:00:00Z' }),
-      makeSession({ id: 'stamped', cwd: '/dev/proj', alive: true,
-                    project_slug: 'proj', project_index: 0,
-                    created_at: '2025-01-02T00:00:00Z' }),
-    ]
-    const folders = buildProjectFolders(projects, sessions)
-    expect(folders[0].sessions.map(s => s.id)).toEqual([
-      'stamped', 'unstamped-old', 'unstamped-new',
-    ])
-  })
+  // ── References to peer-owned projects ──────────────────────────
 
-  // ── Peer-owned folders (ADR 0002) ──────────────────────────────
-
-  it('renders a stamped peer session under its origin (peer, slug) folder', () => {
+  it('renders a reference folder filled by the peer\'s stamped sessions', () => {
     const projects: ProjectItem[] = [
-      { slug: 'gmux', match: [{ path: '/dev/gmux' }] },
+      { slug: 'gmux', peer: 'tower' },
     ]
     const sessions = [
       makeSession({ id: 's1@tower', cwd: '/elsewhere', alive: true,
                     peer: 'tower', project_slug: 'gmux', project_index: 0 }),
     ]
     const folders = buildProjectFolders(projects, sessions)
-    // Local 'gmux' folder still emits (empty); peer folder follows.
-    const tower = folders.find(f => f.peer === 'tower')!
-    expect(tower).toBeDefined()
-    expect(tower.slug).toBe('gmux')
-    expect(tower.name).toBe('gmux')
-    expect(tower.sessions.map(s => s.id)).toEqual(['s1@tower'])
-    expect(tower.key).toBe('tower::gmux')
+    expect(folders).toHaveLength(1)
+    expect(folders[0].peer).toBe('tower')
+    expect(folders[0].slug).toBe('gmux')
+    expect(folders[0].key).toBe('tower::gmux')
+    expect(folders[0].sessions.map(s => s.id)).toEqual(['s1@tower'])
   })
 
-  it('keeps two same-slug projects on different hosts as separate folders', () => {
+  it('renders an empty referenced folder when the peer has no sessions', () => {
+    // References are first-class: empty folders still render so the
+    // user knows the reference is configured.
     const projects: ProjectItem[] = [
-      { slug: 'gmux', match: [{ path: '/home/me/dev/gmux' }] },
-    ]
-    const sessions = [
-      makeSession({ id: 'local-1', cwd: '/home/me/dev/gmux', alive: true,
-                    project_slug: 'gmux', project_index: 0 }),
-      makeSession({ id: 'tower-1@tower', cwd: '/home/me/dev/gmux', alive: true,
-                    peer: 'tower', project_slug: 'gmux', project_index: 0 }),
-    ]
-    const folders = buildProjectFolders(projects, sessions)
-    const local = folders.find(f => f.peer === undefined && f.slug === 'gmux')!
-    const tower = folders.find(f => f.peer === 'tower')!
-    expect(local.sessions.map(s => s.id)).toEqual(['local-1'])
-    expect(tower.sessions.map(s => s.id)).toEqual(['tower-1@tower'])
-  })
-
-  it('skips empty peer folders (no enumeration on the wire)', () => {
-    // No peer sessions visible → no peer folder, even if a peer is
-    // connected. Empty peer folders would be a viewer fiction.
-    const projects: ProjectItem[] = [
-      { slug: 'gmux', match: [{ path: '/dev/gmux' }] },
+      { slug: 'gmux', peer: 'tower' },
     ]
     const folders = buildProjectFolders(projects, [])
-    expect(folders.filter(f => f.peer !== undefined)).toEqual([])
+    expect(folders).toHaveLength(1)
+    expect(folders[0].peer).toBe('tower')
+    expect(folders[0].sessions).toEqual([])
   })
 
-  it('hides a peer folder once its last visible session goes away', () => {
-    const projects: ProjectItem[] = []
+  it('keeps a local owned project and a same-slug reference as separate folders', () => {
+    const projects: ProjectItem[] = [
+      { slug: 'gmux', match: [{ path: '/dev/gmux' }] },
+      { slug: 'gmux', peer: 'tower' },
+    ]
     const sessions = [
-      // Dead and not resumable: never visible.
-      makeSession({ id: 's1@tower', cwd: '/x', alive: false, resumable: false,
+      makeSession({ id: 'local-1', cwd: '/dev/gmux', alive: true,
+                    project_slug: 'gmux', project_index: 0 }),
+      makeSession({ id: 'tower-1@tower', cwd: '/x', alive: true,
                     peer: 'tower', project_slug: 'gmux', project_index: 0 }),
     ]
     const folders = buildProjectFolders(projects, sessions)
-    expect(folders.filter(f => f.peer === 'tower')).toEqual([])
+    expect(folders).toHaveLength(2)
+    expect(folders[0].peer).toBeUndefined()
+    expect(folders[0].sessions.map(s => s.id)).toEqual(['local-1'])
+    expect(folders[1].peer).toBe('tower')
+    expect(folders[1].sessions.map(s => s.id)).toEqual(['tower-1@tower'])
   })
 
-  it('sorts peer folders by peer name then slug', () => {
-    const projects: ProjectItem[] = []
-    const sessions = [
-      makeSession({ id: 'a@zulu', cwd: '/x', alive: true,
-                    peer: 'zulu', project_slug: 'beta', project_index: 0 }),
-      makeSession({ id: 'b@alpha', cwd: '/x', alive: true,
-                    peer: 'alpha', project_slug: 'gamma', project_index: 0 }),
-      makeSession({ id: 'c@alpha', cwd: '/x', alive: true,
-                    peer: 'alpha', project_slug: 'beta', project_index: 0 }),
+  it('orders sessions in a referenced folder by project_index', () => {
+    const projects: ProjectItem[] = [
+      { slug: 'gmux', peer: 'tower' },
     ]
-    const folders = buildProjectFolders(projects, sessions)
-    expect(folders.map(f => `${f.peer}/${f.slug}`)).toEqual([
-      'alpha/beta', 'alpha/gamma', 'zulu/beta',
-    ])
-  })
-
-  it('orders sessions inside a peer folder by project_index', () => {
-    const projects: ProjectItem[] = []
     const sessions = [
       makeSession({ id: 'b@tower', cwd: '/x', alive: true,
                     peer: 'tower', project_slug: 'gmux', project_index: 1 }),
@@ -339,69 +291,52 @@ describe('buildProjectFolders', () => {
                     peer: 'tower', project_slug: 'gmux', project_index: 2 }),
     ]
     const folders = buildProjectFolders(projects, sessions)
-    const tower = folders.find(f => f.peer === 'tower')!
-    expect(tower.sessions.map(s => s.id)).toEqual(['a@tower', 'b@tower', 'c@tower'])
+    expect(folders[0].sessions.map(s => s.id)).toEqual(['a@tower', 'b@tower', 'c@tower'])
   })
 
-  it('adopts a disclaimed peer session into a local folder via match rules', () => {
-    // Devcontainer-style: peer's projects.json is empty, so all its
-    // sessions disclaim. The viewer's rule for /workspaces/gmux
-    // matches the session's cwd; viewer adopts it into local 'gmux'.
+  it('ignores stamped peer sessions when no reference exists for them', () => {
+    // Under the references model, peer-stamped sessions only appear
+    // if the viewer added a reference. No emergent peer folders.
+    const projects: ProjectItem[] = []
+    const sessions = [
+      makeSession({ id: 's1@tower', cwd: '/x', alive: true,
+                    peer: 'tower', project_slug: 'gmux', project_index: 0 }),
+    ]
+    const folders = buildProjectFolders(projects, sessions)
+    expect(folders).toEqual([])
+  })
+
+  it('routes Local-peer sessions into a local folder (parent owns assignment)', () => {
+    // Devcontainer case: the parent's match rules stamp container
+    // sessions; they should bucket into the parent's local folder,
+    // not a peer folder. The session row still shows the peer chip.
     const projects: ProjectItem[] = [
       { slug: 'gmux', match: [{ path: '/workspaces/gmux' }] },
     ]
     const sessions = [
       makeSession({ id: 's1@dev', cwd: '/workspaces/gmux', alive: true,
-                    peer: 'dev' }), // no project_slug = disclaimed
+                    peer: 'dev', project_slug: 'gmux', project_index: 0 }),
     ]
-    const folders = buildProjectFolders(projects, sessions)
-    const local = folders.find(f => f.slug === 'gmux' && f.peer === undefined)!
-    expect(local.sessions.map(s => s.id)).toEqual(['s1@dev'])
-    // No separate peer folder for an adopted disclaim.
-    expect(folders.filter(f => f.peer === 'dev')).toEqual([])
+    const isLocal = (name: string) => name === 'dev'
+    const folders = buildProjectFolders(projects, sessions, isLocal)
+    expect(folders).toHaveLength(1)
+    expect(folders[0].peer).toBeUndefined()
+    expect(folders[0].sessions.map(s => s.id)).toEqual(['s1@dev'])
   })
 
-  it('drops a disclaimed peer session that no viewer rule adopts', () => {
-    // ADR 0002: unmatched disclaimed sessions appear via
-    // discoverProjects, not in any folder.
+  it('without the local-peer hint, a peer-stamped session misses a non-referenced folder', () => {
+    // Routing depends on the caller telling us which peers are Local.
+    // Without that, a Local-peer session looks like a regular peer
+    // session and falls through (would need a reference to land).
     const projects: ProjectItem[] = [
-      { slug: 'gmux', match: [{ path: '/dev/gmux' }] },
+      { slug: 'gmux', match: [{ path: '/workspaces/gmux' }] },
     ]
     const sessions = [
-      makeSession({ id: 's1@dev', cwd: '/elsewhere', alive: true, peer: 'dev' }),
+      makeSession({ id: 's1@dev', cwd: '/workspaces/gmux', alive: true,
+                    peer: 'dev', project_slug: 'gmux', project_index: 0 }),
     ]
     const folders = buildProjectFolders(projects, sessions)
-    expect(folders.flatMap(f => f.sessions.map(s => s.id))).toEqual([])
-  })
-
-  it('adopted unstamped sessions sharing a created_at sort stably by id', () => {
-    // Regression: bespin (v1 spoke) rehydrates sessions at startup and
-    // stamps them all with the same second-precision RFC3339
-    // created_at. The hub adopts them into a local folder via match
-    // rules; without a deterministic tiebreaker in
-    // compareLocalFolderSessions the sidebar order shuffled on every
-    // snapshot.sessions emit (Go map iteration is randomized).
-    const projects: ProjectItem[] = [
-      { slug: 'gmux', match: [{ path: '/dev/gmux' }] },
-    ]
-    const ts = '2026-05-16T12:00:00Z'
-    const a = makeSession({ id: 'a@bespin', cwd: '/dev/gmux', alive: true, peer: 'bespin', created_at: ts })
-    const b = makeSession({ id: 'b@bespin', cwd: '/dev/gmux', alive: true, peer: 'bespin', created_at: ts })
-    const c = makeSession({ id: 'c@bespin', cwd: '/dev/gmux', alive: true, peer: 'bespin', created_at: ts })
-
-    // Iterate the three possible reorderings the wire might present.
-    // All must produce the same on-screen order.
-    const ordersIn = [
-      [a, b, c],
-      [c, a, b],
-      [b, c, a],
-    ]
-    for (const input of ordersIn) {
-      const folder = buildProjectFolders(projects, input)[0]
-      expect(folder.sessions.map(s => s.id)).toEqual([
-        'a@bespin', 'b@bespin', 'c@bespin',
-      ])
-    }
+    expect(folders[0].sessions).toEqual([])
   })
 })
 
@@ -418,25 +353,31 @@ describe('isSessionVisibleInProject', () => {
     expect(isSessionVisibleInProject(s, project)).toBe(false)
   })
 
-  it('dead resumable sessions show when slug is tracked', () => {
+  it('dead resumable sessions are visible (stamps already gate folder membership)', () => {
+    // Under the references model, buildProjectFolders buckets only
+    // stamped sessions, so by the time isSessionVisibleInProject
+    // runs, the session already belongs in this folder. The check
+    // collapses to alive-or-resumable.
     const s = makeSession({ id: 'sess-x', cwd: '/dev/test', alive: false, resumable: true, slug: 'my-session' })
     expect(isSessionVisibleInProject(s, project)).toBe(true)
   })
 
-  it('dead resumable sessions show when id is tracked', () => {
-    const s = makeSession({ id: 'sess-tracked', cwd: '/dev/test', alive: false, resumable: true })
+  it('ignores project.sessions[] tracking', () => {
+    // The tracked-set check was a holdover from cross-host adoption,
+    // where some sessions arrived in a folder without a stamp. With
+    // stamps as the sole authority, the helper no longer reads it.
+    const s = makeSession({ id: 'sess-orphan', cwd: '/dev/test', alive: false, resumable: true, slug: 'orphan' })
     expect(isSessionVisibleInProject(s, project)).toBe(true)
   })
 
-  it('dead resumable sessions are hidden when not tracked', () => {
-    const s = makeSession({ id: 'sess-orphan', cwd: '/dev/test', alive: false, resumable: true, slug: 'orphan' })
-    expect(isSessionVisibleInProject(s, project)).toBe(false)
-  })
-
-  it('handles projects with no sessions array', () => {
-    const bare: ProjectItem = { slug: 'bare', match: [{ path: '/dev/bare' }] }
-    const s = makeSession({ id: 'sess-x', cwd: '/dev/bare', alive: false, resumable: true })
-    expect(isSessionVisibleInProject(s, bare)).toBe(false)
+  it('handles reference projects (no match[] or sessions[])', () => {
+    const ref: ProjectItem = { slug: 'gmux', peer: 'tower' }
+    const alive = makeSession({ id: 's', cwd: '/x', alive: true })
+    const resumable = makeSession({ id: 'r', cwd: '/x', alive: false, resumable: true })
+    const dead = makeSession({ id: 'd', cwd: '/x', alive: false, resumable: false })
+    expect(isSessionVisibleInProject(alive, ref)).toBe(true)
+    expect(isSessionVisibleInProject(resumable, ref)).toBe(true)
+    expect(isSessionVisibleInProject(dead, ref)).toBe(false)
   })
 })
 
@@ -539,9 +480,12 @@ describe('buildProjectTopology', () => {
 
   it('groups local sessions by cwd', () => {
     const sessions = [
-      makeSession({ id: 'sess-1', cwd: '/home/mg/dev/fluxer', created_at: '2026-01-01T00:00:02Z' }),
-      makeSession({ id: 'sess-2', cwd: '/home/mg/dev/fluxer', created_at: '2026-01-01T00:00:01Z' }),
-      makeSession({ id: 'sess-3', cwd: '/home/mg/dev/fluxer/api' }),
+      makeSession({ id: 'sess-1', cwd: '/home/mg/dev/fluxer', created_at: '2026-01-01T00:00:02Z',
+                    project_slug: 'fluxer', project_index: 0 }),
+      makeSession({ id: 'sess-2', cwd: '/home/mg/dev/fluxer', created_at: '2026-01-01T00:00:01Z',
+                    project_slug: 'fluxer', project_index: 1 }),
+      makeSession({ id: 'sess-3', cwd: '/home/mg/dev/fluxer/api',
+                    project_slug: 'fluxer', project_index: 2 }),
     ]
     const hosts = buildProjectTopology('fluxer', sessions, projects, peers)
     expect(hosts).toHaveLength(1)
@@ -549,37 +493,60 @@ describe('buildProjectTopology', () => {
     expect(hosts[0].status).toBe('local')
     expect(hosts[0].folders).toHaveLength(2)
     expect(hosts[0].folders[0].cwd).toBe('/home/mg/dev/fluxer')
-    expect(hosts[0].folders[0].sessions.map(s => s.id)).toEqual(['sess-1', 'sess-2'])
     expect(hosts[0].folders[1].cwd).toBe('/home/mg/dev/fluxer/api')
   })
 
-  it('separates local and peer sessions', () => {
+  it('collapses Local-peer (devcontainer) sessions into the local host node', () => {
+    // Under the references model, Local-peer sessions are owned by
+    // the parent: their stamps come from the parent's match rules
+    // and they live in the parent's local folder. The hub shows
+    // them under the local host node, with their session id chain
+    // still indicating the container hop in the folder grouping.
     const sessions = [
-      makeSession({ id: 'sess-local', cwd: '/home/mg/dev/fluxer' }),
-      makeSession({ id: 'sess-remote@workstation', cwd: '/home/mg/dev/fluxer', peer: 'workstation' }),
+      makeSession({ id: 's-local', cwd: '/home/mg/dev/fluxer',
+                    project_slug: 'fluxer', project_index: 0 }),
+      makeSession({ id: 's-container@dev', cwd: '/workspaces/fluxer', peer: 'dev',
+                    project_slug: 'fluxer', project_index: 1 }),
     ]
-    const hosts = buildProjectTopology('fluxer', sessions, projects, peers)
-    expect(hosts).toHaveLength(2)
-    // Local first.
+    const isLocal = (name: string) => name === 'dev'
+    const hosts = buildProjectTopology('fluxer', sessions, projects, peers, undefined, isLocal)
+    expect(hosts).toHaveLength(1)
     expect(hosts[0].path).toEqual([])
-    expect(hosts[0].status).toBe('local')
-    // Peer second.
-    expect(hosts[1].path).toEqual(['workstation'])
-    expect(hosts[1].status).toBe('connected')
-    expect(hosts[1].meta).toBe('http://100.64.0.2:8790')
+    // Both sessions land under local; their cwds differ so they
+    // become separate folder groups.
+    const allIds = hosts[0].folders.flatMap(f => f.sessions.map(s => s.id))
+    expect(allIds.sort()).toEqual(['s-container@dev', 's-local'].sort())
+  })
+
+  it('reference hub: shows only the peer\'s stamped sessions', () => {
+    const refProjects: ProjectItem[] = [
+      { slug: 'fluxer', peer: 'workstation' },
+    ]
+    const sessions = [
+      makeSession({ id: 'sess-local', cwd: '/home/mg/dev/fluxer',
+                    project_slug: 'fluxer', project_index: 0 }),
+      makeSession({ id: 'sess-remote@workstation', cwd: '/home/mg/dev/fluxer',
+                    peer: 'workstation',
+                    project_slug: 'fluxer', project_index: 0 }),
+    ]
+    const hosts = buildProjectTopology('fluxer', sessions, refProjects, peers, 'workstation')
+    expect(hosts).toHaveLength(1)
+    expect(hosts[0].path).toEqual(['workstation'])
+    expect(hosts[0].status).toBe('connected')
+    expect(hosts[0].meta).toBe('http://100.64.0.2:8790')
+    expect(hosts[0].folders[0].sessions.map(s => s.id)).toEqual(['sess-remote@workstation'])
   })
 
   it('nested peers form multi-segment paths', () => {
-    const projectsWithRemote: ProjectItem[] = [
-      { slug: 'fluxer', match: [{ remote: 'github.com/mg/fluxer' }, { path: '/home/mg/dev/fluxer' }], sessions: [] },
+    const refProjects: ProjectItem[] = [
+      { slug: 'fluxer', peer: 'workstation' },
     ]
     const sessions = [
-      makeSession({
-        id: 'sess-nested@dev@workstation', cwd: '/workspace/fluxer', peer: 'workstation',
-        remotes: { origin: 'https://github.com/mg/fluxer.git' },
-      }),
+      makeSession({ id: 'sess-nested@dev@workstation', cwd: '/workspace/fluxer',
+                    peer: 'workstation',
+                    project_slug: 'fluxer', project_index: 0 }),
     ]
-    const hosts = buildProjectTopology('fluxer', sessions, projectsWithRemote, peers)
+    const hosts = buildProjectTopology('fluxer', sessions, refProjects, peers, 'workstation')
     expect(hosts).toHaveLength(1)
     expect(hosts[0].path).toEqual(['workstation', 'dev'])
     // Nested inherits root peer status.
@@ -587,56 +554,50 @@ describe('buildProjectTopology', () => {
   })
 
   it('marks unknown peers as disconnected', () => {
-    const sessions = [
-      makeSession({ id: 'sess-a@ghost', cwd: '/home/mg/dev/fluxer', peer: 'ghost' }),
+    const refProjects: ProjectItem[] = [
+      { slug: 'fluxer', peer: 'ghost' },
     ]
-    const hosts = buildProjectTopology('fluxer', sessions, projects, peers)
+    const sessions = [
+      makeSession({ id: 'sess-a@ghost', cwd: '/home/mg/dev/fluxer', peer: 'ghost',
+                    project_slug: 'fluxer', project_index: 0 }),
+    ]
+    const hosts = buildProjectTopology('fluxer', sessions, refProjects, peers, 'ghost')
     expect(hosts).toHaveLength(1)
     expect(hosts[0].status).toBe('disconnected')
     expect(hosts[0].meta).toBe('')
   })
 
   it('reflects peer status from the peers list', () => {
-    const sessions = [
-      makeSession({ id: 'sess-o@offline-box', cwd: '/home/mg/dev/fluxer', peer: 'offline-box' }),
+    const refProjects: ProjectItem[] = [
+      { slug: 'fluxer', peer: 'offline-box' },
     ]
-    const hosts = buildProjectTopology('fluxer', sessions, projects, peers)
+    const sessions = [
+      makeSession({ id: 'sess-o@offline-box', cwd: '/home/mg/dev/fluxer', peer: 'offline-box',
+                    project_slug: 'fluxer', project_index: 0 }),
+    ]
+    const hosts = buildProjectTopology('fluxer', sessions, refProjects, peers, 'offline-box')
     expect(hosts[0].status).toBe('disconnected')
   })
 
-  it('sorts peers alphabetically, local first', () => {
-    const peers2: PeerInfo[] = [
-      { name: 'alpha', url: 'http://a', status: 'connected', session_count: 1 },
-      { name: 'bravo', url: 'http://b', status: 'connected', session_count: 1 },
-    ]
-    const sessions = [
-      makeSession({ id: 's-b@bravo', cwd: '/home/mg/dev/fluxer', peer: 'bravo' }),
-      makeSession({ id: 's-a@alpha', cwd: '/home/mg/dev/fluxer', peer: 'alpha' }),
-      makeSession({ id: 's-local', cwd: '/home/mg/dev/fluxer' }),
-    ]
-    const hosts = buildProjectTopology('fluxer', sessions, projects, peers2)
-    expect(hosts.map(h => h.path.join('/') || '(local)')).toEqual(['(local)', 'alpha', 'bravo'])
-  })
-
   it('sorts sessions within a folder: alive first, then newest-first', () => {
-    const projectsWithDead: ProjectItem[] = [
-      { slug: 'fluxer', match: [{ path: '/home/mg/dev/fluxer' }], sessions: ['dead-old'] },
-    ]
     const sessions = [
       makeSession({
         id: 'dead-old', cwd: '/home/mg/dev/fluxer',
         alive: false, resumable: true, created_at: '2026-01-01T00:00:00Z',
+        project_slug: 'fluxer', project_index: 0,
       }),
       makeSession({
         id: 'alive-old', cwd: '/home/mg/dev/fluxer',
         alive: true, created_at: '2026-01-02T00:00:00Z',
+        project_slug: 'fluxer', project_index: 1,
       }),
       makeSession({
         id: 'alive-new', cwd: '/home/mg/dev/fluxer',
         alive: true, created_at: '2026-01-03T00:00:00Z',
+        project_slug: 'fluxer', project_index: 2,
       }),
     ]
-    const hosts = buildProjectTopology('fluxer', sessions, projectsWithDead, peers)
+    const hosts = buildProjectTopology('fluxer', sessions, projects, peers)
     expect(hosts[0].folders[0].sessions.map(s => s.id)).toEqual([
       'alive-new', 'alive-old', 'dead-old',
     ])
@@ -644,65 +605,29 @@ describe('buildProjectTopology', () => {
 
   it('hides dead non-resumable sessions', () => {
     const sessions = [
-      makeSession({ id: 'alive-1', cwd: '/home/mg/dev/fluxer', alive: true }),
-      makeSession({ id: 'dead-1', cwd: '/home/mg/dev/fluxer', alive: false, resumable: false }),
+      makeSession({ id: 'alive-1', cwd: '/home/mg/dev/fluxer', alive: true,
+                    project_slug: 'fluxer', project_index: 0 }),
+      makeSession({ id: 'dead-1', cwd: '/home/mg/dev/fluxer', alive: false, resumable: false,
+                    project_slug: 'fluxer', project_index: 1 }),
     ]
     const hosts = buildProjectTopology('fluxer', sessions, projects, peers)
     expect(hosts[0].folders[0].sessions.map(s => s.id)).toEqual(['alive-1'])
   })
 
-  it('hides resumable sessions not tracked in project.sessions[]', () => {
-    const sessions = [
-      makeSession({ id: 'alive-1', cwd: '/home/mg/dev/fluxer', alive: true }),
-      makeSession({
-        id: 'orphan', cwd: '/home/mg/dev/fluxer',
-        alive: false, resumable: true,
-      }),
-    ]
-    const hosts = buildProjectTopology('fluxer', sessions, projects, peers)
-    expect(hosts[0].folders[0].sessions.map(s => s.id)).toEqual(['alive-1'])
-  })
-
-  it('filters sessions by project match (ignores unrelated sessions)', () => {
+  it('filters sessions by stamp (ignores unrelated stamps)', () => {
     const projects2: ProjectItem[] = [
-      { slug: 'fluxer', match: [{ path: '/home/mg/dev/fluxer' }], sessions: [] },
-      { slug: 'other', match: [{ path: '/home/mg/dev/other' }], sessions: [] },
+      { slug: 'fluxer', match: [{ path: '/home/mg/dev/fluxer' }] },
+      { slug: 'other', match: [{ path: '/home/mg/dev/other' }] },
     ]
     const sessions = [
-      makeSession({ id: 'f1', cwd: '/home/mg/dev/fluxer' }),
-      makeSession({ id: 'o1', cwd: '/home/mg/dev/other' }),
+      makeSession({ id: 'f1', cwd: '/home/mg/dev/fluxer',
+                    project_slug: 'fluxer', project_index: 0 }),
+      makeSession({ id: 'o1', cwd: '/home/mg/dev/other',
+                    project_slug: 'other', project_index: 0 }),
     ]
     const hosts = buildProjectTopology('fluxer', sessions, projects2, peers)
     expect(hosts).toHaveLength(1)
     expect(hosts[0].folders[0].sessions.map(s => s.id)).toEqual(['f1'])
-  })
-
-  it('sessions sharing a created_at sort stably by id within a cwd group', () => {
-    // Same regression as the sidebar (v1-spoke rehydrate: many
-    // sessions with identical second-precision created_at). The hub
-    // page groups by cwd; within a group, sortHubSessions ties
-    // without an id fallback and the rows flip whenever
-    // snapshot.sessions re-emits with a different Go map order.
-    const ts = '2026-05-16T12:00:00Z'
-    const peerSessions = [
-      makeSession({ id: 'a@bespin', cwd: '/home/mg/dev/fluxer', alive: true, peer: 'bespin', created_at: ts }),
-      makeSession({ id: 'b@bespin', cwd: '/home/mg/dev/fluxer', alive: true, peer: 'bespin', created_at: ts }),
-      makeSession({ id: 'c@bespin', cwd: '/home/mg/dev/fluxer', alive: true, peer: 'bespin', created_at: ts }),
-    ]
-    const bespinPeers: PeerInfo[] = [
-      { name: 'bespin', url: 'http://10.0.0.5:8790', status: 'connected', session_count: 3 },
-    ]
-    for (const input of [
-      [peerSessions[0], peerSessions[1], peerSessions[2]],
-      [peerSessions[2], peerSessions[0], peerSessions[1]],
-      [peerSessions[1], peerSessions[2], peerSessions[0]],
-    ]) {
-      const hosts = buildProjectTopology('fluxer', input, projects, bespinPeers)
-      const bespinHost = hosts.find(h => h.path[0] === 'bespin')!
-      expect(bespinHost.folders[0].sessions.map(s => s.id)).toEqual([
-        'a@bespin', 'b@bespin', 'c@bespin',
-      ])
-    }
   })
 })
 
@@ -866,17 +791,21 @@ describe('discoverProjects', () => {
 })
 
 describe('countUnmatchedActive', () => {
-  it('counts alive sessions outside any project', () => {
+  it('counts alive disclaimed sessions regardless of viewer rule matches', () => {
+    // Under the references model, viewer rules don't adopt anything;
+    // a disclaimed session is unmatched until the owning daemon
+    // stamps it. So 'a' (waiting on local AutoAssign) is counted
+    // alongside 'b' and 'd'.
     const projects: ProjectItem[] = [
       { slug: 'gmux', match: [{ path: '/dev/gmux' }] },
     ]
     const sessions = [
-      makeSession({ id: 'a', cwd: '/dev/gmux/x', alive: true }),  // adopted by viewer rules
-      makeSession({ id: 'b', cwd: '/elsewhere', alive: true }),   // free
-      makeSession({ id: 'c', cwd: '/elsewhere', alive: false }),  // dead, not counted
-      makeSession({ id: 'd', cwd: '/other', alive: true }),       // free
+      makeSession({ id: 'a', cwd: '/dev/gmux/x', alive: true }),
+      makeSession({ id: 'b', cwd: '/elsewhere', alive: true }),
+      makeSession({ id: 'c', cwd: '/elsewhere', alive: false }),
+      makeSession({ id: 'd', cwd: '/other', alive: true }),
     ]
-    expect(countUnmatchedActive(sessions, projects)).toBe(2)
+    expect(countUnmatchedActive(sessions, projects)).toBe(3)
   })
 
   it('excludes claimed sessions (stamped by their origin)', () => {
@@ -910,14 +839,24 @@ describe('countUnmatchedActive', () => {
     expect(countUnmatchedActive(sessions, [])).toBe(1)
   })
 
-  it('does not count a disclaimed peer session adopted by a viewer rule', () => {
-    const projects: ProjectItem[] = [
-      { slug: 'gmux', match: [{ path: '/workspaces/gmux' }] },
-    ]
+  it('counts a connected peer\'s disclaimed sessions', () => {
+    // A connected peer's disclaimed session is unmatched per its own
+    // host; viewer rules no longer adopt it, so it always counts.
     const sessions = [
       makeSession({ id: 's@dev', cwd: '/workspaces/gmux', alive: true, peer: 'dev' }),
     ]
-    expect(countUnmatchedActive(sessions, projects)).toBe(0)
+    const peerStatus = new Map([['dev', 'connected']])
+    expect(countUnmatchedActive(sessions, [], peerStatus)).toBe(1)
+  })
+
+  it('skips disclaimed sessions on disconnected peers', () => {
+    // Don\'t nag the user about an unreachable peer; the count may
+    // be stale.
+    const sessions = [
+      makeSession({ id: 's@tower', cwd: '/x', alive: true, peer: 'tower' }),
+    ]
+    const peerStatus = new Map([['tower', 'disconnected']])
+    expect(countUnmatchedActive(sessions, [], peerStatus)).toBe(0)
   })
 
   it('returns 0 when there are no sessions', () => {

--- a/apps/gmux-web/src/projects.ts
+++ b/apps/gmux-web/src/projects.ts
@@ -33,18 +33,19 @@ function pathUnder(candidate: string | undefined, base: string): boolean {
  * Whether a session should be visible in this project's UI (sidebar
  * folder, project hub page).
  *
- * Alive sessions always show. Dead sessions only appear if they are
- * resumable *and* listed in the project's `sessions` array, which the
- * server maintains as the set of sessions the user has touched in the
- * context of that project. Non-tracked dead sessions stay hidden so
- * the UI doesn't accumulate terminal clutter.
+ * Under the references model, stamps are the sole authority for folder
+ * membership. A session arrives in a folder because its origin host
+ * stamped it; we then just decide whether to render it based on
+ * liveness. Alive and resumable sessions render; dead non-resumable
+ * sessions are hidden (no terminal clutter from one-shot commands).
+ *
+ * The `project` argument is retained for call-site symmetry but the
+ * check no longer reads project.sessions[] — stamps replace that
+ * indirection.
  */
-export function isSessionVisibleInProject(session: Session, project: ProjectItem): boolean {
+export function isSessionVisibleInProject(session: Session, _project: ProjectItem): boolean {
   if (session.alive) return true
-  if (!session.resumable) return false
-  const keys = new Set(project.sessions ?? [])
-  const key = session.slug || session.id
-  return keys.has(key) || keys.has(session.id)
+  return session.resumable === true
 }
 
 /**
@@ -164,38 +165,57 @@ export function mostCommonRemote(sessions: Session[]): string {
   return best
 }
 
-/** Group sessions that aren't claimed by any project, bucketed by
- * directory (workspace_root if set, else cwd). Each bucket becomes one
- * suggested project.
+/** Group disclaimed sessions into suggested projects, scoped per host.
  *
- * Per ADR 0002, claimed sessions (`project_slug != ""`) have a definite
- * home on their origin host; only disclaimed sessions are eligible for
- * discovery, and only those the viewer's own rules don't already adopt.
- * That makes "discovered" exactly the set of sessions the user might
- * reasonably want to file into a new local project. */
+ * Each host's discovery is independent: a session is in scope for host X
+ * iff (s.peer ?? '') === X and s.project_slug is empty. The viewer no
+ * longer adopts peer sessions via its own match rules, so the bucket is
+ * exactly "sessions whose origin host hasn't filed them."
+ *
+ * Suggestions from different hosts mix into one returned list, sorted
+ * by recency (most-recently-active first). Each carries a `peer` field
+ * (absent for local) so the modal can render a host chip and route the
+ * "+ Add" action to the right daemon.
+ *
+ * Local groups whose disclaimed sessions would still match a local
+ * owned project are skipped: the user already has a place for them, and
+ * the auto-assign hook will stamp them on next attribution. */
 export function discoverProjects(
   sessions: Session[],
   projects: ProjectItem[],
 ): DiscoveredProject[] {
-  const byDir = new Map<string, Session[]>()
+  // Bucket by (peer, dir). peer '' is local; dir is workspace_root if
+  // set, else cwd. Sessions with no dir are dropped.
+  const byKey = new Map<string, { peer: string; dir: string; group: Session[] }>()
   for (const s of sessions) {
-    if (s.project_slug) continue            // claimed by origin: not free game
-    if (matchSession(s, projects)) continue  // already adopted by viewer's rules
+    if (s.project_slug) continue // claimed by origin
+    const peer = s.peer ?? ''
+    if (peer === '') {
+      // Local-host discovery still defers to local owned projects:
+      // a session matching a local rule will be stamped imminently by
+      // auto-assign, so don't surface it as discovered.
+      if (matchSession(s, projects)) continue
+    }
     const dir = s.workspace_root || s.cwd
     if (!dir) continue
-    let bucket = byDir.get(dir)
-    if (!bucket) { bucket = []; byDir.set(dir, bucket) }
-    bucket.push(s)
+    const key = `${peer}\u0000${dir}`
+    let bucket = byKey.get(key)
+    if (!bucket) { bucket = { peer, dir, group: [] }; byKey.set(key, bucket) }
+    bucket.group.push(s)
   }
-  if (byDir.size === 0) return []
+  if (byKey.size === 0) return []
 
   const result: DiscoveredProject[] = []
-  for (const [dir, group] of byDir.entries()) {
+  for (const { peer, dir, group } of byKey.values()) {
     const active = group.filter(s => s.alive).length
     const remote = mostCommonRemote(group)
     let suggested = remote ? slugFromRemote(remote) : ''
     if (!suggested) suggested = slugFromPath(dir)
     if (!suggested) suggested = 'project'
+    let lastActive = ''
+    for (const s of group) {
+      if (s.created_at > lastActive) lastActive = s.created_at
+    }
     const dp: DiscoveredProject = {
       suggested_slug: suggested,
       paths: [dir],
@@ -203,23 +223,28 @@ export function discoverProjects(
       active_count: active,
     }
     if (remote) dp.remote = remote
+    if (peer) dp.peer = peer
+    if (lastActive) dp.last_active = lastActive
     result.push(dp)
   }
 
-  // Active first, then most sessions, then alphabetically by
+  // Sort by recency, then active count, then session count, then
   // suggested_slug, then by the directory path that originated this
   // discovered project.
   //
-  // The final paths[0] tiebreak matters: two sessions whose cwds have
-  // the same basename (e.g. `/home/me/api` and `/srv/api`) bucket
-  // into distinct discovered projects but produce identical
-  // suggested_slug values via slugFromPath. Without it, the sort falls
-  // through to the input order, which is the byDir Map's insertion
-  // order, which mirrors the (Go-map-randomized) snapshot.sessions
-  // order — so the two rows flip on every snapshot re-emit. paths[0]
-  // is unique per discovered project because it is the very key used
-  // to build the bucket.
+  // The final paths[0] tiebreak matters: two sessions whose cwds
+  // have the same basename (e.g. `/home/me/api` and `/srv/api`)
+  // bucket into distinct discovered projects but produce identical
+  // suggested_slug values via slugFromPath. Without it, the sort
+  // falls through to the input order, which is the byKey Map's
+  // insertion order, which mirrors the (Go-map-randomized)
+  // snapshot.sessions order — so the two rows flip on every
+  // snapshot re-emit. paths[0] is unique per discovered project
+  // because it is the very key used to build the bucket.
   result.sort((a, b) => {
+    const ta = a.last_active ?? ''
+    const tb = b.last_active ?? ''
+    if (ta !== tb) return tb < ta ? -1 : 1
     if (a.active_count !== b.active_count) return b.active_count - a.active_count
     if (a.session_count !== b.session_count) return b.session_count - a.session_count
     const slugCmp = a.suggested_slug.localeCompare(b.suggested_slug)
@@ -229,22 +254,33 @@ export function discoverProjects(
   return result
 }
 
-/** Number of alive sessions outside any project, in the viewer's view.
- * Drives the "N active sessions outside any project" badge.
+/** Number of alive sessions outside any project, summed across every
+ *  connected host. Drives the "N active sessions outside any project"
+ *  badge.
  *
- * Per ADR 0002, a session is "outside any project" iff its origin
- * disclaims it (`project_slug == ""`) AND the viewer's own match rules
- * don't adopt it. Claimed peer sessions live in the peer's folder;
- * claimed local sessions live in the viewer's folder; neither counts. */
+ *  Under the references model (ADR 0002 + amendment), "outside any
+ *  project" is a per-host property: a session is unmatched iff its
+ *  origin host disclaims it (`project_slug == ""`). Viewer match rules
+ *  no longer adopt peer sessions, so this count is the union of every
+ *  host's disclaimed-alive sessions.
+ *
+ *  Sessions on disconnected peers are excluded: their disclaimed
+ *  status could be stale (peer might have a project rule that adopts
+ *  them once reachable), and badging the user about an unreachable
+ *  peer's discovery is noise. */
 export function countUnmatchedActive(
   sessions: Session[],
-  projects: ProjectItem[],
+  _projects: ProjectItem[],
+  peerStatusByName?: ReadonlyMap<string, string>,
 ): number {
   let count = 0
   for (const s of sessions) {
     if (!s.alive) continue
-    if (s.project_slug) continue           // claimed by origin
-    if (matchSession(s, projects)) continue // adopted by viewer
+    if (s.project_slug) continue // claimed by origin
+    if (s.peer && peerStatusByName) {
+      const status = peerStatusByName.get(s.peer)
+      if (status !== 'connected') continue
+    }
     count++
   }
   return count
@@ -253,136 +289,91 @@ export function countUnmatchedActive(
 // --- Sidebar folders ---
 
 /**
- * Build the sidebar folder list per ADR 0002.
+ * Build the sidebar folder list.
  *
- * Two kinds of folder come out of this:
+ * Each entry in the viewer's `projects` items[] becomes one folder,
+ * in items[] order (user-controlled). Two kinds of entry:
  *
- *   1. **Local folders**: one per entry in the viewer's `projects` list,
- *      in `Items[]` order (user-controlled). Even an empty local folder
- *      renders, so the user always sees their own configuration.
- *   2. **Peer folders**: derived implicitly from `(peer, project_slug)`
- *      pairs that appear on stamped sessions. A peer folder exists iff
- *      at least one visible session carries that pair. Sorted
- *      deterministically by peer name then slug. Two hosts that share
- *      a slug get two distinct folders.
+ *   - **Owned** (`peer` absent): folder is filled by sessions stamped
+ *     with this slug whose peer matches (local sessions for a local
+ *     owner, plus Local-peer sessions whose stamps the parent applies).
+ *   - **Reference** (`peer` set): folder is filled by sessions stamped
+ *     with this slug AND originating from the named peer.
  *
- * Each session is routed to one folder (or none) by the rule:
+ * Sessions route purely by stamps. There is no client-side fallback to
+ * viewer match rules: matching happens only on the owning host. A
+ * session whose origin disclaims it is never adopted by the viewer; it
+ * surfaces via `discoverProjects` / `countUnmatchedActive` only.
  *
- *   - If `s.project_slug != ""` (claimed by origin):
- *       bucket into folder `(s.peer, s.project_slug)`.
- *       Sort key is `s.project_index` (origin's authoritative position).
- *   - Else (disclaimed): run the viewer's `matchSession` against its
- *     own projects. If matched, the session is *adopted* into that
- *     local folder; sort key is `created_at`. If unmatched, the
- *     session is visible only via `discoverProjects` /
- *     `countUnmatchedActive`.
+ * Empty folders still render: the entry is in projects.json by user
+ * intent, the empty state is informative ("No sessions on workstation
+ * right now"), and references in particular need to remain pinned so
+ * the user can launch into them.
  *
- * Visibility filter: alive sessions always render; dead sessions render
- * only when claimed by the folder they'd be in. Disclaimed-adopted dead
- * sessions are hidden (the viewer's intent didn't put them in any array;
- * the rule is the only thread holding them, and a dead session can't
- * acquire new context to validate the match).
+ * Local-peer sessions (devcontainers; `peers[s.peer].local === true`)
+ * are bucketed as if local: their stamps come from the parent's match
+ * rules, and they live in the parent's folder. The peer chip still
+ * renders on the session row so the user knows it's a container
+ * session.
  */
 export function buildProjectFolders(
   projects: ProjectItem[],
   sessions: Session[],
+  isLocalPeer?: (peerName: string) => boolean,
 ): Folder[] {
-  // Bucket every session by `${peer ?? ''}::${slug}`. An empty peer
-  // segment marks a viewer-owned (local) bucket.
+  // Bucket every stamped session by `${ownerPeer}::${slug}`.
+  // ownerPeer is '' for sessions owned by the viewer (local sessions,
+  // and Local-peer sessions whose project ownership lives on the
+  // parent), else the originating peer's name.
   const buckets = new Map<string, Session[]>()
-  const bucket = (peer: string, slug: string, s: Session): void => {
-    const key = `${peer}::${slug}`
+  const bucket = (ownerPeer: string, slug: string, s: Session): void => {
+    const key = `${ownerPeer}::${slug}`
     let arr = buckets.get(key)
     if (!arr) { arr = []; buckets.set(key, arr) }
     arr.push(s)
   }
 
   for (const s of sessions) {
-    if (s.project_slug) {
-      // Claimed by origin. Bucket under (peer, slug); peer may be
-      // empty (local-claimed: viewer is the origin).
-      bucket(s.peer ?? '', s.project_slug, s)
-    } else {
-      // Disclaimed: free-game adoption by the viewer's rules.
-      const matched = matchSession(s, projects)
-      if (matched) bucket('', matched.slug, s)
-      // else: not in any folder; surfaces via discoverProjects.
-    }
+    if (!s.project_slug) continue // unstamped: surfaces via discovery only
+    const sessionPeer = s.peer ?? ''
+    const ownerPeer = sessionPeer && !(isLocalPeer?.(sessionPeer))
+      ? sessionPeer
+      : ''
+    bucket(ownerPeer, s.project_slug, s)
   }
 
   const folders: Folder[] = []
-
-  // 1. Local folders, in viewer's Items[] order. Always emitted, even
-  //    when empty: the user's own configuration is always visible.
   for (const project of projects) {
-    const ss = buckets.get(`::${project.slug}`) ?? []
-    const visible = ss.filter(
-      s => s.alive || (s.resumable === true && s.project_slug === project.slug),
-    )
-    visible.sort(compareLocalFolderSessions)
+    const ownerPeer = project.peer ?? ''
+    const ss = buckets.get(`${ownerPeer}::${project.slug}`) ?? []
+    const visible = ss.filter(s => s.alive || s.resumable === true)
+    visible.sort(compareFolderSessions)
     folders.push({
-      key: project.slug,
+      key: `${ownerPeer}::${project.slug}`,
       slug: project.slug,
       name: project.slug,
+      peer: ownerPeer || undefined,
       launchCwd: project.match?.find(r => r.path)?.path,
       sessions: visible,
     })
   }
 
-  // 2. Peer folders, by (peer, slug). Empty peer folders are skipped
-  //    — nothing on the wire enumerates peer projects, so an empty
-  //    folder would be a viewer fiction.
-  const peerFolders: Folder[] = []
-  for (const [key, ss] of buckets) {
-    if (key.startsWith('::')) continue // local: handled above
-    const sep = key.indexOf('::')
-    const peer = key.slice(0, sep)
-    const slug = key.slice(sep + 2)
-    const visible = ss.filter(s => s.alive || s.resumable === true)
-    if (visible.length === 0) continue
-    visible.sort((a, b) => (a.project_index ?? 0) - (b.project_index ?? 0))
-    peerFolders.push({
-      key,
-      slug,
-      name: slug,
-      peer,
-      sessions: visible,
-    })
-  }
-  peerFolders.sort((a, b) => {
-    const peerCmp = (a.peer ?? '').localeCompare(b.peer ?? '')
-    return peerCmp !== 0 ? peerCmp : a.slug.localeCompare(b.slug)
-  })
-  folders.push(...peerFolders)
-
   return folders
 }
 
 /**
- * Sort key for a session inside a *local* folder.
+ * Sort key for a session inside a folder.
  *
- * Stamped (claimed-local) sessions sort first by `project_index` — the
- * origin's authoritative position, equivalent to the index in
- * `project.sessions[]`. Unstamped sessions (disclaimed-adopted via
- * the viewer's match rules) come after, ordered by creation time so
- * newly-spawned sessions don't reshuffle existing ones.
- *
- * Tiebreak on `id` for unstamped pairs because `created_at` is
- * RFC3339 with second precision on the wire, so sessions launched in
- * the same second tie. Without a stable tiebreaker, the sidebar
- * order would shuffle every time `snapshot.sessions` re-emits with a
- * different Go map-iteration order (most visible when adopting
- * sessions from a v1 spoke whose rehydrated entries all share a
- * second).
+ * Stamps are now the sole authority for both folder membership and
+ * ordering: every session that lands in a folder is stamped, and its
+ * `project_index` reflects the owning host's authoritative position
+ * (the index in projects.json `Sessions[]`). Ties are unlikely (the
+ * server hands out distinct indices) but we fall back to `created_at`
+ * then `id` so the order is deterministic across snapshot re-emits.
  */
-function compareLocalFolderSessions(a: Session, b: Session): number {
-  const aStamped = !!a.project_slug
-  const bStamped = !!b.project_slug
-  if (aStamped && bStamped) {
-    return (a.project_index ?? 0) - (b.project_index ?? 0)
-  }
-  if (aStamped) return -1
-  if (bStamped) return 1
+function compareFolderSessions(a: Session, b: Session): number {
+  const idx = (a.project_index ?? 0) - (b.project_index ?? 0)
+  if (idx !== 0) return idx
   const dt = new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
   if (dt !== 0) return dt
   return a.id.localeCompare(b.id)
@@ -448,10 +439,16 @@ export function parseSessionHostPath(sessionId: string): { originalId: string; p
  *     sending them would add phantom entries on the daemon's next
  *     ReorderSessions merge.
  *
- *  2. Strip the `@<peer>` namespace from slugless ids. A peer-owned
- *     session has `s.id === "orig@peer"` on the wire, but the peer's
- *     projects.json keys by `"orig"`. Slugged sessions key by
- *     `s.slug`, which is never namespaced.
+ *  2. Key sessions appropriately for the owning daemon's projects.json:
+ *     - For references (folder.peer set, not a Local peer): the peer's
+ *       projects.json keys by the original (unnamespaced) id, so we
+ *       strip `@<peer>` from slugless ids before sending.
+ *     - For local folders (folder.peer absent or Local): the parent's
+ *       projects.json keys may include namespaced ids for Local-peer
+ *       sessions, since the parent owns project assignment for them.
+ *       We keep `@<peer>` for those sessions and strip nothing for
+ *       genuinely local sessions.
+ *     Slugged sessions always key by `s.slug`, which is never namespaced.
  *
  * Returns an empty array when no session in the request belongs to
  * the folder owner: caller should skip the PATCH entirely so the
@@ -460,11 +457,30 @@ export function parseSessionHostPath(sessionId: string): { originalId: string; p
 export function reorderKeysForFolder(
   reorderedSessions: Session[],
   folderPeer: string | undefined,
+  isLocalPeer?: (peerName: string) => boolean,
 ): string[] {
-  const ownerPeer = folderPeer ?? ''
+  const isLocalFolder = !folderPeer
   return reorderedSessions
-    .filter(s => (s.peer ?? '') === ownerPeer)
-    .map(s => s.slug || parseSessionHostPath(s.id).originalId)
+    .filter(s => {
+      const sessionPeer = s.peer ?? ''
+      if (isLocalFolder) {
+        // Local folder owns local sessions plus Local-peer sessions.
+        return sessionPeer === '' || !!isLocalPeer?.(sessionPeer)
+      }
+      // Reference folder: only the peer's own sessions belong.
+      return sessionPeer === folderPeer
+    })
+    .map(s => {
+      if (s.slug) return s.slug
+      const sessionPeer = s.peer ?? ''
+      // For Local-peer sessions in a local folder, the parent keys by
+      // the namespaced id since the namespace is part of the session's
+      // identity from the parent's POV.
+      if (isLocalFolder && sessionPeer !== '' && isLocalPeer?.(sessionPeer)) {
+        return s.id
+      }
+      return parseSessionHostPath(s.id).originalId
+    })
 }
 
 /**
@@ -480,25 +496,49 @@ export function buildProjectTopology(
   sessions: Session[],
   projects: ProjectItem[],
   peers: PeerInfo[],
+  projectPeer?: string,
+  isLocalPeer?: (peerName: string) => boolean,
 ): HostNode[] {
-  const project = projects.find(p => p.slug === projectSlug)
+  // Find the matching items[] entry. The hub can be reached at
+  // `/<slug>` (local owned) or `/@<peer>/<slug>` (reference); the
+  // caller passes `projectPeer` for the latter.
+  const ownerPeer = projectPeer ?? ''
+  const project = projects.find(p =>
+    p.slug === projectSlug && (p.peer ?? '') === ownerPeer,
+  )
   if (!project) return []
 
-  // Mirror sidebar visibility: only include sessions the sidebar would
-  // show under this project. Dead non-tracked sessions stay hidden.
-  const projectSessions = sessions.filter(s =>
-    matchSession(s, projects)?.slug === projectSlug
-    && isSessionVisibleInProject(s, project),
-  )
+  // Match the sidebar bucketing: a session belongs in this project's
+  // hub iff its stamp matches AND its effective owner matches the
+  // project's owner. For owned projects, the owner is the viewer
+  // (Local-peer sessions count as owned by the viewer because their
+  // stamps come from the parent's rules). For references, the owner
+  // is the named peer.
+  const projectSessions = sessions.filter(s => {
+    if (s.project_slug !== projectSlug) return false
+    const sessionPeer = s.peer ?? ''
+    const effectiveOwner = sessionPeer && !(isLocalPeer?.(sessionPeer))
+      ? sessionPeer
+      : ''
+    if (effectiveOwner !== ownerPeer) return false
+    return isSessionVisibleInProject(s, project)
+  })
 
-  // Bucket by host path.
+  // Bucket by host path. The session id chain encodes the namespace
+  // hops innermost-first; parseSessionHostPath reverses them so the
+  // path reads root → leaf. We strip any leading Local-peer hop:
+  // those peers are co-tenants of the viewer, so their sessions live
+  // in the viewer's local host node, not a separate peer node.
   const hostBuckets = new Map<string, { path: string[]; sessions: Session[] }>()
   for (const s of projectSessions) {
     const { path } = parseSessionHostPath(s.id)
-    const key = path.join('\0') // NUL-separated because peer names can't contain it
+    const effectivePath = path.length > 0 && isLocalPeer?.(path[0])
+      ? path.slice(1)
+      : path
+    const key = effectivePath.join('\0')
     let bucket = hostBuckets.get(key)
     if (!bucket) {
-      bucket = { path, sessions: [] }
+      bucket = { path: effectivePath, sessions: [] }
       hostBuckets.set(key, bucket)
     }
     bucket.sessions.push(s)

--- a/apps/gmux-web/src/projects.ts
+++ b/apps/gmux-web/src/projects.ts
@@ -67,7 +67,10 @@ export function matchSession(
   let firstRemote: ProjectItem | null = null
 
   for (const project of projects) {
-    for (const rule of project.match) {
+    // References don't carry local match rules; their content is
+    // driven by peer stamps, not viewer-side matching.
+    if (project.peer) continue
+    for (const rule of project.match ?? []) {
       if (rule.remote && session.remotes) {
         const normRule = normalizeRemote(rule.remote)
         for (const url of Object.values(session.remotes)) {
@@ -321,7 +324,7 @@ export function buildProjectFolders(
       key: project.slug,
       slug: project.slug,
       name: project.slug,
-      launchCwd: project.match.find(r => r.path)?.path,
+      launchCwd: project.match?.find(r => r.path)?.path,
       sessions: visible,
     })
   }

--- a/apps/gmux-web/src/projects.ts
+++ b/apps/gmux-web/src/projects.ts
@@ -177,12 +177,18 @@ export function mostCommonRemote(sessions: Session[]): string {
  * (absent for local) so the modal can render a host chip and route the
  * "+ Add" action to the right daemon.
  *
+ * Disconnected-peer suggestions are excluded: their disclaimed status
+ * could be stale (the peer's projects.json may have grown rules we
+ * haven't seen yet), and clicking + Add on one would hit a peer we
+ * can't actually reach, producing a confusing failure.
+ *
  * Local groups whose disclaimed sessions would still match a local
  * owned project are skipped: the user already has a place for them, and
  * the auto-assign hook will stamp them on next attribution. */
 export function discoverProjects(
   sessions: Session[],
   projects: ProjectItem[],
+  peerStatusByName?: ReadonlyMap<string, string>,
 ): DiscoveredProject[] {
   // Bucket by (peer, dir). peer '' is local; dir is workspace_root if
   // set, else cwd. Sessions with no dir are dropped.
@@ -195,6 +201,9 @@ export function discoverProjects(
       // a session matching a local rule will be stamped imminently by
       // auto-assign, so don't surface it as discovered.
       if (matchSession(s, projects)) continue
+    } else if (peerStatusByName && peerStatusByName.get(peer) !== 'connected') {
+      // Unreachable peer: skip. Same logic as countUnmatchedActive.
+      continue
     }
     const dir = s.workspace_root || s.cwd
     if (!dir) continue

--- a/apps/gmux-web/src/projects.ts
+++ b/apps/gmux-web/src/projects.ts
@@ -320,6 +320,7 @@ export function buildProjectFolders(
   projects: ProjectItem[],
   sessions: Session[],
   isLocalPeer?: (peerName: string) => boolean,
+  peerProjects?: Record<string, { slug: string; launch_cwd?: string }[]>,
 ): Folder[] {
   // Bucket every stamped session by `${ownerPeer}::${slug}`.
   // ownerPeer is '' for sessions owned by the viewer (local sessions,
@@ -348,12 +349,36 @@ export function buildProjectFolders(
     const ss = buckets.get(`${ownerPeer}::${project.slug}`) ?? []
     const visible = ss.filter(s => s.alive || s.resumable === true)
     visible.sort(compareFolderSessions)
+    // Owned: derive launchCwd from the project's first path rule.
+    // Reference: pull launchCwd from peer_projects so the launch
+    // button works even when the folder is empty (no session to
+    // borrow cwd from). Also detect dangling references: peer is
+    // enumerated in peer_projects (i.e. connected) but our slug is
+    // not present, meaning the project was removed upstream.
+    let launchCwd: string | undefined
+    let missing = false
+    if (ownerPeer === '') {
+      launchCwd = project.match?.find(r => r.path)?.path
+    } else if (peerProjects) {
+      const peerEntry = peerProjects[ownerPeer]
+      if (peerEntry) {
+        const found = peerEntry.find(p => p.slug === project.slug)
+        if (found) {
+          launchCwd = found.launch_cwd
+        } else {
+          // Peer is connected (we have its enumeration) but doesn't
+          // know this slug anymore: the reference is dangling.
+          missing = true
+        }
+      }
+    }
     folders.push({
       key: `${ownerPeer}::${project.slug}`,
       slug: project.slug,
       name: project.slug,
       peer: ownerPeer || undefined,
-      launchCwd: project.match?.find(r => r.path)?.path,
+      launchCwd,
+      missing: missing || undefined,
       sessions: visible,
     })
   }

--- a/apps/gmux-web/src/sidebar.tsx
+++ b/apps/gmux-web/src/sidebar.tsx
@@ -224,13 +224,16 @@ function FolderGroup({
     <div class="folder">
       <div class="folder-header">
         <a
-          class={`folder-name${isCurrent ? ' current' : ''}`}
+          class={`folder-name${isCurrent ? ' current' : ''}${folder.missing ? ' missing' : ''}`}
           href={href}
-          title={`Open ${folder.name} hub`}
+          title={folder.missing
+            ? `${folder.name} no longer exists on ${folder.peer}; remove via Manage projects`
+            : `Open ${folder.name} hub`}
           onClick={onClick}
         >
           {folder.peer && <PeerLabel name={folder.peer} />}
           {folder.name}
+          {folder.missing && <span class="folder-missing-icon" title="Project missing on peer">?</span>}
         </a>
         <LaunchButton
           sessions={folder.sessions}

--- a/apps/gmux-web/src/sidebar.tsx
+++ b/apps/gmux-web/src/sidebar.tsx
@@ -293,7 +293,7 @@ export function Sidebar({
   const hasProjects = projectsVal.length > 0
   const isOnlyHomeProject = projectsVal.length === 1
     && projectsVal[0].slug === 'home'
-    && projectsVal[0].match.some(r => r.path === '~' && r.exact)
+    && !!projectsVal[0].match?.some(r => r.path === '~' && r.exact)
 
   const seedHomeProject = async () => {
     if (projects.value.length === 0) {

--- a/apps/gmux-web/src/sidebar.tsx
+++ b/apps/gmux-web/src/sidebar.tsx
@@ -14,7 +14,7 @@ import {
   folders, selectedId, currentProjectKey,
   activityMap, unmatchedActiveCount, projects, connState,
   updateProjects, reorderSessions,
-  peerStatusByName, isSessionUnavailable,
+  peerStatusByName, isSessionUnavailable, localPeerNames,
   type DotState,
 } from './store'
 import { PeerLabel } from './peer-label'
@@ -200,12 +200,16 @@ function FolderGroup({
       return
     }
     const reordered = reorder(visible, drag.from, drag.over)
-    // reorderKeysForFolder filters non-owner sessions and strips the
-    // `@<peer>` namespace from slugless ids; see its docstring for
-    // the ADR-0002 corruption modes this prevents. The daemon's
-    // PATCH handler then does a partial-reorder merge that keeps
-    // hidden / dead-resumable entries at the tail.
-    const visibleKeys = reorderKeysForFolder(reordered, folder.peer)
+    // reorderKeysForFolder partitions sessions by the folder owner's
+    // identity and keys them appropriately for the owning daemon's
+    // projects.json (namespaced ids for Local-peer sessions inside a
+    // parent's local folder, plain ids for everything else). See its
+    // docstring for the full routing matrix.
+    const visibleKeys = reorderKeysForFolder(
+      reordered,
+      folder.peer,
+      (name) => localPeerNames.value.has(name),
+    )
     if (visibleKeys.length > 0) {
       reorderSessions(folder.slug, visibleKeys, folder.peer)
     }

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -14,7 +14,7 @@
  */
 
 import { signal, computed, batch, effect } from '@preact/signals'
-import type { Session, ProjectItem, DiscoveredProject, PeerInfo, LauncherDef, Folder } from './types'
+import type { Session, ProjectItem, DiscoveredProject, PeerInfo, PeerProject, LauncherDef, Folder } from './types'
 import type { View } from './routing'
 import { resolveViewFromPath, viewToPath } from './routing'
 import { buildProjectFolders, discoverProjects, countUnmatchedActive } from './projects'
@@ -58,6 +58,13 @@ export interface RawWorld {
   health: HealthData | null
   launchers: LauncherDef[]
   defaultLauncher: string
+  /**
+   * Per-peer projection of each connected peer's owned projects.
+   * Keyed by peer name. Drives the "On other hosts" section of
+   * Manage Projects and lets references render their launch fallback
+   * without proxying a separate request.
+   */
+  peerProjects: Record<string, PeerProject[]>
 }
 
 export const _rawSessions = signal<Session[]>([])
@@ -67,6 +74,7 @@ export const _rawWorld = signal<RawWorld>({
   health: null,
   launchers: [],
   defaultLauncher: 'shell',
+  peerProjects: {},
 })
 
 /** Merge a partial world update into `_rawWorld`. Used by SSE handlers,
@@ -178,6 +186,13 @@ export const peers = computed<PeerInfo[]>(() => _rawWorld.value.peers)
 export const health = computed<HealthData | null>(() => _rawWorld.value.health)
 export const launchers = computed<LauncherDef[]>(() => _rawWorld.value.launchers)
 export const defaultLauncher = computed<string>(() => _rawWorld.value.defaultLauncher)
+
+/** Per-peer projects from the world snapshot. Map from peer name to
+ *  its owned projects (slug + launch_cwd hint). Empty object when no
+ *  peers are connected or none have fetched yet. */
+export const peerProjects = computed<Record<string, PeerProject[]>>(
+  () => _rawWorld.value.peerProjects,
+)
 
 // Auto-clear pending mutations that the wire has acknowledged. Runs on
 // every raw update; uses .peek() to avoid re-triggering itself.
@@ -809,6 +824,7 @@ export function initStore(): () => void {
         health?: HealthData
         launchers?: LauncherDef[]
         default_launcher?: string
+        peer_projects?: Record<string, PeerProject[]>
       }
       _setRawWorld({
         projects: env.projects ?? [],
@@ -816,6 +832,7 @@ export function initStore(): () => void {
         health: env.health ?? null,
         launchers: env.launchers ?? [],
         defaultLauncher: env.default_launcher ?? 'shell',
+        peerProjects: env.peer_projects ?? {},
       })
     } catch (err) {
       console.warn('snapshot.world: bad event', err)

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -395,6 +395,7 @@ export const folders = computed(() =>
     projects.value,
     filteredSessions.value,
     (name) => localPeerNames.value.has(name),
+    _rawWorld.value.peerProjects,
   ),
 )
 
@@ -582,21 +583,48 @@ async function putProjects(items: ProjectItem[]): Promise<void> {
   }
 }
 
+/** Remove an owned project by slug. References (peer + slug) are
+ *  removed via removePeerReference, which keys on the (peer, slug)
+ *  pair to handle same-slug coexistence with owned projects. */
 export async function removeProject(slug: string): Promise<void> {
-  await putProjects(projects.value.filter(p => p.slug !== slug))
+  await putProjects(projects.value.filter(p => p.peer || p.slug !== slug))
 }
 
-export async function addProject(req: { remote?: string; paths: string[] }): Promise<void> {
+export async function addProject(
+  req: { remote?: string; paths: string[] },
+  peer?: string,
+): Promise<void> {
+  // For remote adds, proxy through the hub: /v1/peers/{peer}/v1/projects/add.
+  // The peer applies the change to its own projects.json; we'll receive
+  // the new items[] back via projects-update + fetchProjects.
+  const path = peer
+    ? `/v1/peers/${encodeURIComponent(peer)}/v1/projects/add`
+    : '/v1/projects/add'
   try {
-    const resp = await fetch('/v1/projects/add', {
+    const resp = await fetch(path, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(req),
     })
-    if (!resp.ok) console.warn('POST /v1/projects/add failed:', resp.status)
+    if (!resp.ok) console.warn(`POST ${path} failed:`, resp.status)
   } catch (err) {
-    console.warn('POST /v1/projects/add error:', err)
+    console.warn(`POST ${path} error:`, err)
   }
+}
+
+/** Append a reference item to local projects.json. The reference
+ *  points at a peer-owned project; the peer's projects.json remains
+ *  the source of truth for rules and session order. */
+export async function addPeerReference(peer: string, slug: string): Promise<void> {
+  const existing = projects.value
+  if (existing.some(p => p.peer === peer && p.slug === slug)) return
+  await putProjects([...existing, { peer, slug }])
+}
+
+/** Remove a reference item from local projects.json. */
+export async function removePeerReference(peer: string, slug: string): Promise<void> {
+  const filtered = projects.value.filter(p => !(p.peer === peer && p.slug === slug))
+  await putProjects(filtered)
 }
 
 export async function updateProjects(items: ProjectItem[]): Promise<void> {

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -593,7 +593,7 @@ export async function removeProject(slug: string): Promise<void> {
 export async function addProject(
   req: { remote?: string; paths: string[] },
   peer?: string,
-): Promise<void> {
+): Promise<{ slug: string }> {
   // For remote adds, proxy through the hub: /v1/peers/{peer}/v1/projects/add.
   // The peer applies the change to its own projects.json; we'll receive
   // the new items[] back via projects-update + fetchProjects.
@@ -603,6 +603,12 @@ export async function addProject(
   // avoid the dangling-reference failure mode where the peer rejected
   // the add but the viewer's projects.json still gains a reference
   // pointing at a slug that doesn't exist upstream.
+  //
+  // Returns the actual slug the server assigned. The server may
+  // deduplicate (e.g. "api" → "api-2" on collision), so callers must
+  // not assume the client-suggested slug round-tripped unchanged —
+  // referencing the wrong slug would produce an immediately dangling
+  // reference.
   const path = peer
     ? `/v1/peers/${encodeURIComponent(peer)}/v1/projects/add`
     : '/v1/projects/add'
@@ -622,6 +628,12 @@ export async function addProject(
     console.warn(msg)
     throw new Error(msg)
   }
+  const body = await resp.json() as { ok?: boolean; data?: { slug?: string } }
+  const slug = body.data?.slug
+  if (!slug) {
+    throw new Error(`POST ${path}: missing slug in response`)
+  }
+  return { slug }
 }
 
 /** Append a reference item to local projects.json. The reference

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -215,7 +215,7 @@ export const connState = signal<'connecting' | 'connected' | 'error'>('connectin
 // projections, not server-pushed state. They derive from the same
 // public sessions/projects projections everyone else uses.
 export const discovered = computed<DiscoveredProject[]>(
-  () => discoverProjects(sessions.value, projects.value),
+  () => discoverProjects(sessions.value, projects.value, peerStatusByName.value),
 )
 export const unmatchedActiveCount = computed<number>(
   () => countUnmatchedActive(sessions.value, projects.value, peerStatusByName.value),
@@ -597,18 +597,30 @@ export async function addProject(
   // For remote adds, proxy through the hub: /v1/peers/{peer}/v1/projects/add.
   // The peer applies the change to its own projects.json; we'll receive
   // the new items[] back via projects-update + fetchProjects.
+  //
+  // Throws on non-2xx or network failure. Callers that chain follow-up
+  // work (auto-add a reference after a remote create) rely on this to
+  // avoid the dangling-reference failure mode where the peer rejected
+  // the add but the viewer's projects.json still gains a reference
+  // pointing at a slug that doesn't exist upstream.
   const path = peer
     ? `/v1/peers/${encodeURIComponent(peer)}/v1/projects/add`
     : '/v1/projects/add'
+  let resp: Response
   try {
-    const resp = await fetch(path, {
+    resp = await fetch(path, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(req),
     })
-    if (!resp.ok) console.warn(`POST ${path} failed:`, resp.status)
   } catch (err) {
     console.warn(`POST ${path} error:`, err)
+    throw err
+  }
+  if (!resp.ok) {
+    const msg = `POST ${path} failed: ${resp.status}`
+    console.warn(msg)
+    throw new Error(msg)
   }
 }
 

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -218,7 +218,7 @@ export const discovered = computed<DiscoveredProject[]>(
   () => discoverProjects(sessions.value, projects.value),
 )
 export const unmatchedActiveCount = computed<number>(
-  () => countUnmatchedActive(sessions.value, projects.value),
+  () => countUnmatchedActive(sessions.value, projects.value, peerStatusByName.value),
 )
 
 // ── Peer appearance: unique prefix + deterministic color ─────────────────────
@@ -378,9 +378,24 @@ export const filteredSessions = computed(() => {
   })
 })
 
+/** Set of peer names that are Local (devcontainers, PeerConfig.Local).
+ *  Local peers don't own their own project assignments; their sessions
+ *  are stamped by the parent and bucket into local sidebar folders. */
+export const localPeerNames = computed<ReadonlySet<string>>(() => {
+  const set = new Set<string>()
+  for (const p of peers.value) {
+    if (p.local) set.add(p.name)
+  }
+  return set
+})
+
 /** Project folders for the sidebar, built from projects + sessions. */
 export const folders = computed(() =>
-  buildProjectFolders(projects.value, filteredSessions.value),
+  buildProjectFolders(
+    projects.value,
+    filteredSessions.value,
+    (name) => localPeerNames.value.has(name),
+  ),
 )
 
 /**

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -482,6 +482,28 @@ body {
   background: oklch(25% 0.04 250);
   color: oklch(72% 0.08 250);
 }
+.session-peer-label.offline {
+  opacity: 0.4;
+  /* Cross-out: peer is unreachable, the chip stops claiming activity. */
+  text-decoration: line-through;
+}
+.folder-name.missing {
+  opacity: 0.5;
+}
+.folder-missing-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  margin-left: 6px;
+  border-radius: 50%;
+  background: oklch(25% 0.04 30);
+  color: oklch(72% 0.12 30);
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1cap;
+}
 .session-status-label {
   color: var(--text-secondary);
 }

--- a/apps/gmux-web/src/types.ts
+++ b/apps/gmux-web/src/types.ts
@@ -118,6 +118,18 @@ export interface DiscoveredProject {
   paths: string[]
   session_count: number
   active_count: number
+  /**
+   * Owning host for this suggestion. Absent for local-host discovery;
+   * set to the peer name for sessions disclaimed by a connected peer.
+   * Drives the host chip in the modal and routes "+ Add" to the
+   * correct daemon (proxied if remote).
+   */
+  peer?: string
+  /**
+   * Most-recent created_at among the sessions in this group, as an
+   * RFC3339 string. Used to sort suggestions by recency.
+   */
+  last_active?: string
 }
 
 /** Mirrors /v1/health peers entries. */

--- a/apps/gmux-web/src/types.ts
+++ b/apps/gmux-web/src/types.ts
@@ -107,6 +107,24 @@ export interface PeerInfo {
   version?: string
   default_launcher?: string
   launchers?: LauncherDef[]
+  /**
+   * True when this peer is conceptually an extension of the host (a
+   * devcontainer reachable via PeerConfig.Local = true). Local peers
+   * don't own their own project assignments; their sessions are
+   * stamped by the parent and bucket into local sidebar folders.
+   */
+  local?: boolean
+}
+
+/**
+ * One project owned by a connected peer, projected down to just what
+ * the viewer needs to render a reference (folder header, launch
+ * fallback). Counts and timestamps are derived client-side from
+ * stamped sessions.
+ */
+export interface PeerProject {
+  slug: string
+  launch_cwd?: string
 }
 
 export interface LauncherDef {

--- a/apps/gmux-web/src/types.ts
+++ b/apps/gmux-web/src/types.ts
@@ -79,14 +79,37 @@ export interface Folder {
 export interface MatchRule {
   path?: string
   remote?: string
-  hosts?: string[]
   exact?: boolean // path must match exactly, not as prefix
 }
 
+/**
+ * One entry in the viewer's projects.json items[]. Two shapes share
+ * this type, discriminated by `peer`:
+ *
+ *   - Owned: `slug` + `match[]` (+ `sessions[]` maintained by server)
+ *     A project owned by this host. Match rules drive session
+ *     attribution; `sessions[]` is the ordered list of session keys
+ *     for sidebar order.
+ *   - Reference: `slug` + `peer`
+ *     A pointer to a project owned by a peer. The peer's projects.json
+ *     is the source of truth for match rules and session order; the
+ *     viewer just declares "show this peer's project at this position
+ *     in my sidebar."
+ */
 export interface ProjectItem {
   slug: string
-  match: MatchRule[]
-  sessions?: string[] // managed by server; must be preserved in PUT
+  /** Set when this item is a reference to a peer-owned project. */
+  peer?: string
+  /** Owned-project match rules. Empty/absent for references. */
+  match?: MatchRule[]
+  /** Server-managed ordering. Absent for references. */
+  sessions?: string[]
+}
+
+/** True when an item references a peer-owned project rather than
+ *  defining one locally. */
+export function isReferenceItem(item: ProjectItem): boolean {
+  return !!item.peer
 }
 
 export interface DiscoveredProject {

--- a/apps/gmux-web/src/types.ts
+++ b/apps/gmux-web/src/types.ts
@@ -71,6 +71,14 @@ export interface Folder {
   peer?: string
   /** Filesystem path hint for launching new sessions in this folder. */
   launchCwd?: string
+  /**
+   * True when this folder is a reference whose peer is connected but
+   * no longer reports the named slug in its peer_projects. The folder
+   * is rendered with a missing indicator so the user can remove it
+   * manually. Distinct from a peer simply being disconnected (handled
+   * by the PeerLabel offline state).
+   */
+  missing?: boolean
   sessions: Session[]
 }
 

--- a/docs/adr/0005-references-and-local-peer-exception.md
+++ b/docs/adr/0005-references-and-local-peer-exception.md
@@ -1,0 +1,209 @@
+# ADR 0005: Project references and the Local-peer exception
+
+**Status:** Proposed
+**Date:** 2026-05-22
+**Related:** ADR 0002 (Project ownership from session origin)
+
+## Context
+
+ADR 0002 established that each session's project assignment lives on
+its origin host: `Reconcile` on the owning daemon stamps
+`project_slug` / `project_index` onto the session, and viewers render
+sidebar folders from those stamps. The ADR also kept a fallback
+escape hatch: when an origin disclaims a session (`project_slug ==
+""`), the viewer's own match rules adopt it into the viewer's local
+folders.
+
+Field use has shown the fallback is the dominant source of sidebar
+"magic":
+
+1. **Membership is undiscoverable.** Whether a peer session appears
+   in one of the viewer's folders depends on the peer's
+   `projects.json` (does it claim the session?) and the viewer's
+   match rules (does any of them match the session's cwd / remote?).
+   Neither host's UI shows the user how this question is being
+   answered.
+2. **Behaviour depends on inverse configuration.** If a viewer
+   configures a rule for `~/dev/foo`, that rule will only adopt peer
+   sessions whose `cwd` happens to be exactly that path. In typical
+   devcontainer setups (`/workspaces/foo` inside the container), it
+   won't, and the user sees nothing. In `localWorkspaceFolder`
+   setups, it does, but the user can't tell why.
+3. **There is no preview.** When adding a project, the viewer can't
+   show "here is what would land in this folder" without enumerating
+   sessions across every host the rule might match. The result is
+   either misleading (local-only) or wrong (rule semantics differ
+   from server-side).
+4. **Peer folders are emergent, not configured.** A peer folder
+   appears when stamped sessions arrive and vanishes when the last
+   one closes. The user has no way to pin, hide, or preview one.
+
+The fix is to make the cross-host story explicit instead of
+emergent. This ADR specifies that change.
+
+## Decision
+
+### Each project belongs to exactly one host
+
+Project ownership is **strict per-host**. A session's project
+assignment is determined solely by the rules in its origin's
+`projects.json`. Viewer match rules never adopt sessions from
+elsewhere.
+
+### The viewer's `projects.json` items[] holds two kinds of entry
+
+- **Owned** (existing shape): `{slug, match[], sessions[]}`. The
+  viewer's own project. `match[]` drives session attribution by the
+  viewer's `Reconcile`; `sessions[]` is the ordered session-key
+  list.
+- **Reference** (new): `{slug, peer}`. A pointer to a peer-owned
+  project. The peer's `projects.json` is the source of truth for
+  match rules and session order. The viewer just declares "show
+  this peer's project in my sidebar at this position."
+
+The sidebar order is items[] order, mixing freely. Validation
+enforces exactly one of `{match[] present, peer present}` per
+entry. Owned-and-reference can coexist with the same slug (two
+distinct folders, disambiguated by `(peer, slug)`).
+
+Schema version bumps to 3. v2 → v3 is a pass-through; `MatchRule.Hosts`
+is silently dropped on load (scoping is implicit in ownership now).
+
+### Wire format
+
+`snapshot.world` gains `peer_projects: { [peer]: [{slug, launch_cwd?}] }`
+and `PeerInfo.local: bool`. The hub fetches each peer's `GET
+/v1/projects` on connect and on `projects-update` (now forwarded to
+`?as=peer` consumers too), caches a minimal projection, and
+re-broadcasts it in its own `snapshot.world`. The viewer uses this to
+enumerate references in the Manage Projects modal and to fill
+`launchCwd` for empty referenced folders.
+
+### Hub proxy
+
+The existing `PATCH /v1/peers/{peer}/v1/projects/{slug}/sessions`
+proxy is joined by `POST /v1/peers/{peer}/v1/projects/add`. The
+Manage Projects modal uses the latter to create a project on a peer
+from the Discovered section.
+
+### The Local-peer exception
+
+Devcontainers don't have user-curated `projects.json`. They report
+container-side paths (`/workspaces/foo`) that don't match the host's
+project rules. Asking the user to configure projects inside every
+container — and then reference them from the host — is significant
+friction for the most common gmux usage pattern after plain-local.
+
+A `Local` peer (`PeerConfig.Local = true`, set only by the Docker
+watcher) is conceptually an extension of the parent host:
+
+- Same user, same machine, ephemeral lifecycle.
+- The parent's `Reconcile` runs match rules against Local-peer
+  sessions and writes the resulting slug/index into the session as
+  it flows through the parent's snapshot. The container's own
+  `projects.json`, if any, is ignored from the parent's perspective.
+- Local-peer session keys land in the parent's
+  `projects.json.Items[].Sessions[]` (namespaced ids for slugless
+  sessions; bare slugs for attributed ones). On container removal,
+  `peering.Manager.OnPeerRemoved` fires
+  `projects.Manager.PruneNamespacedKeys(name)` to drop accumulated
+  `@<peer>` keys from owned items.
+- The sidebar buckets Local-peer sessions into the parent's local
+  folder, not a peer folder. The session row still renders the peer
+  chip so the user knows it's a container session.
+
+The exception is **narrow and named**: gated on a single flag, set
+in exactly one place. Network peers remain strict per ADR 0002.
+
+### `Reconcile` becomes caller-driven
+
+`store.Reconcile`'s assignFn is now called for every session; the
+caller decides per-session whether to preserve the existing stamp
+(network peers) or compute a fresh one (local or Local peers). The
+canonical caller in `main.go` encodes this rule:
+
+```go
+sessions.Reconcile(func(s store.Session) (string, int) {
+    if s.Peer != "" && !peerManager.IsLocalPeer(s.Peer) {
+        return s.ProjectSlug, s.ProjectIndex // network peer: preserve
+    }
+    key := projects.SessionKey(s.ID, s.Slug)
+    a := assignments[key]
+    return a.Slug, a.Index
+})
+```
+
+### Resumable sessions get stamped
+
+Auto-assign (per-event and startup-sweep) covers alive *and*
+resumable sessions, not just alive. Without this, a session that
+dies before the per-event subscriber processes it (fast-exiting
+commands, attribution-stage crashes) would never enter
+`Sessions[]`, never get a stamp, and stay invisible in the sidebar
+after a daemon restart. This was a direct consequence of stamps
+becoming the sole authority for sidebar visibility.
+
+## Consequences
+
+### Wins
+
+- Sidebar membership is determined entirely by stamps. One model,
+  one source of truth. No client-side fallback paths.
+- Adding a project gets a meaningful preview: run match rules
+  against the target host's sessions, see exactly what would land.
+- Remote-ness is intrinsic to a project (owned vs reference),
+  visualized via the peer chip on the folder header.
+- Empty references render and pin so users can launch into them,
+  even when the peer is reachable but the project is currently
+  inactive.
+- Peer folders survive across reconnect / sleep cycles (today's
+  emergent peer folders vanish when sessions die).
+
+### Costs
+
+- **Cross-host adoption removed.** Users who previously got
+  devcontainer or v1-spoke sessions adopted into local folders via
+  matching cwds need to either configure a project on the peer
+  (typical case after this ADR) or accept that disclaimed peer
+  sessions surface only via the Manage Projects modal's Discovered
+  section.
+- **Same-repo-on-many-hosts is N folders, not one.** If the user
+  references a peer's `gmux` from N hosts, the sidebar has N
+  folders for the same logical repo. The "all sessions" tab
+  (deferred) addresses the many-tiny-hosts case where the
+  per-host decomposition feels excessive.
+- **`MatchRule.Hosts` is gone.** Anyone who used it (probably
+  nobody) gets a one-time silent migration via the v3 bump; the
+  field is dropped from v2 files on next save.
+
+### Non-goals
+
+- **Path translation.** Devcontainer mounts often map host paths
+  to different in-container paths. The Local-peer exception only
+  partly fixes this: stamps use the parent's rules, which see the
+  parent's paths on the local sessions but the *container's* paths
+  on Local-peer sessions. Path translation (container reports
+  host-equivalent paths in `workspace_root`) is a separate concern,
+  tracked as a follow-up. Git-remote matching covers the common
+  case in the meantime.
+- **All-sessions tab.** Surfacing every session across every host
+  with configurable grouping is a separate epic.
+- **Cross-host project reorder UX.** Each peer-referenced folder's
+  session order is the peer's. The viewer can reorder via PATCH
+  proxy, which is global (every viewer sees the new order). There
+  is intentionally no per-viewer override.
+
+## Implementation notes
+
+- The change is forward-incompatible with v1.x daemons reading v3
+  `projects.json`: older daemons mis-parse reference items. This is
+  acceptable because the relevant feature surface (cross-host
+  ownership, snapshot push, namespaced session keys) was added in
+  the v1.x cycle and isn't expected to round-trip cleanly.
+- Disclaimed sessions on disconnected peers are excluded from the
+  unmatched-active badge. Their disclaimed state may be stale; the
+  count would only nag users about peers they can't act on anyway.
+- Dangling references (peer is connected but reports no such slug)
+  render with a `?` badge. The user removes them manually via
+  Manage Projects. No auto-prune: that's the kind of magic this
+  ADR is moving away from.

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -2304,6 +2304,16 @@ func isAllowedPeerProxyPath(method, sub string) bool {
 		parts[2] != "" && parts[3] == "sessions" {
 		return true
 	}
+	// Create a project on a peer: POST v1/projects/add.
+	// The frontend uses this to add a project on the peer's own
+	// projects.json from the Manage Projects modal (Discovered
+	// section, remote items). The peer applies the add atomically;
+	// the resulting items[] flows back via projects-update.
+	if method == http.MethodPost &&
+		len(parts) == 3 &&
+		parts[0] == "v1" && parts[1] == "projects" && parts[2] == "add" {
+		return true
+	}
 	return false
 }
 

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -658,6 +658,7 @@ func serve(stderr io.Writer) int {
 				WorkspaceRoot: s.WorkspaceRoot,
 				Remotes:       s.Remotes,
 				Host:          s.Peer,
+				LocalHost:     s.Peer != "" && peerManager != nil && peerManager.IsLocalPeer(s.Peer),
 				Alive:         s.Alive,
 				Resumable:     s.Resumable,
 				Slug:          s.Slug,

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -553,6 +553,12 @@ func serve(stderr io.Writer) int {
 	// State directory for persistent files (projects.json, auth-token, etc).
 	stateDir := paths.StateDir()
 
+	// peerManager and tsDiscovery are initialized later after config is
+	// loaded. Closures (reconcileProjectStamps, buildSessionInfos call
+	// sites) capture these pointers so handlers work once they're set.
+	var peerManager *peering.Manager
+	var tsDiscovery *tsdiscovery.Watcher
+
 	// Project manager handles concurrent access to projects.json and
 	// auto-assignment of sessions to projects.
 	projectMgr := projects.NewManager(stateDir)
@@ -565,6 +571,13 @@ func serve(stderr io.Writer) int {
 	reconcileProjectStamps := func(state *projects.State) {
 		assignments := state.AssignmentsByKey()
 		sessions.Reconcile(func(s store.Session) (string, int) {
+			// Network peers own their own project assignments;
+			// preserve whatever stamp arrived on the wire.
+			if s.Peer != "" && (peerManager == nil || !peerManager.IsLocalPeer(s.Peer)) {
+				return s.ProjectSlug, s.ProjectIndex
+			}
+			// Local sessions and Local-peer (devcontainer) sessions:
+			// parent owns assignment, stamp from its projects.json.
 			key := projects.SessionKey(s.ID, s.Slug)
 			a := assignments[key]
 			return a.Slug, a.Index
@@ -589,7 +602,7 @@ func serve(stderr io.Writer) int {
 		// resumable session loaded from sessionmeta would never be added
 		// to its matching project and would be invisible in the sidebar
 		// (the visibility filter requires a stamp).
-		projectMgr.AutoAssignAll(buildSessionInfos(sessions))
+		projectMgr.AutoAssignAll(buildSessionInfos(sessions, func(name string) bool { return peerManager != nil && peerManager.IsLocalPeer(name) }))
 		// Stamp ProjectSlug / ProjectIndex on the just-rehydrated sessions
 		// (and on any sessions previously loaded via sessionmeta.Sweep)
 		// before SSE subscribers can observe. Reload to pick up any
@@ -651,11 +664,6 @@ func serve(stderr io.Writer) int {
 			})
 		}
 	}()
-
-	// peerManager and tsDiscovery are initialized later after config is
-	// loaded. The closures capture the pointers so handlers work once set.
-	var peerManager *peering.Manager
-	var tsDiscovery *tsdiscovery.Watcher
 
 	// ── Health + Capabilities ──
 
@@ -786,7 +794,7 @@ func serve(stderr io.Writer) int {
 			writeError(w, http.StatusInternalServerError, "internal", "failed to load projects")
 			return
 		}
-		sessionInfos := buildSessionInfos(sessions)
+		sessionInfos := buildSessionInfos(sessions, func(name string) bool { return peerManager != nil && peerManager.IsLocalPeer(name) })
 		writeJSON(w, map[string]any{
 			"ok": true,
 			"data": map[string]any{
@@ -890,7 +898,7 @@ func serve(stderr io.Writer) int {
 		// Populate the new project's sessions array with matching live
 		// and resumable sessions immediately, so the frontend sees them
 		// on the first fetch.
-		projectMgr.AutoAssignAll(buildSessionInfos(sessions))
+		projectMgr.AutoAssignAll(buildSessionInfos(sessions, func(name string) bool { return peerManager != nil && peerManager.IsLocalPeer(name) }))
 		writeJSON(w, map[string]any{"ok": true, "data": item})
 	})
 
@@ -1891,6 +1899,15 @@ func serve(stderr io.Writer) int {
 	hostname, _ := os.Hostname()
 	if len(cfg.Peers) > 0 || cfg.Discovery.Devcontainers || (cfg.Tailscale.Enabled && cfg.Discovery.Tailscale) {
 		peerManager = peering.NewManager(cfg.Peers, sessions, hostname)
+		// Prune namespaced projects.json keys when a Local peer
+		// (devcontainer) is removed: its `id@<peer>` session keys can
+		// never resolve again and would accumulate dead weight in the
+		// parent's projects.json.
+		peerManager.OnPeerRemoved = func(name string, wasLocal bool) {
+			if wasLocal {
+				projectMgr.PruneNamespacedKeys(name)
+			}
+		}
 		peerManager.Start()
 		if len(cfg.Peers) > 0 {
 			log.Printf("peering: %d peer(s) configured", len(cfg.Peers))
@@ -2291,7 +2308,7 @@ func isAllowedPeerProxyPath(method, sub string) bool {
 }
 
 // buildSessionInfos converts store sessions to project SessionInfo structs.
-func buildSessionInfos(sessions *store.Store) []projects.SessionInfo {
+func buildSessionInfos(sessions *store.Store, isLocalPeer func(string) bool) []projects.SessionInfo {
 	list := sessions.List()
 	infos := make([]projects.SessionInfo, len(list))
 	for i, s := range list {
@@ -2301,6 +2318,7 @@ func buildSessionInfos(sessions *store.Store) []projects.SessionInfo {
 			WorkspaceRoot: s.WorkspaceRoot,
 			Remotes:       s.Remotes,
 			Host:          s.Peer,
+			LocalHost:     s.Peer != "" && isLocalPeer != nil && isLocalPeer(s.Peer),
 			Alive:         s.Alive,
 			Resumable:     s.Resumable,
 			Slug:          s.Slug,

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -583,9 +583,21 @@ func serve(stderr io.Writer) int {
 	// rehydrateProjects for the identity-model rationale.
 	if state, err := projectMgr.Load(); err == nil {
 		rehydrateProjects(sessions, convIndex, state)
+		// Sweep resumable sessions into project.sessions[] arrays.
+		// The auto-assign subscriber only fires on session-upsert events,
+		// which arrive after this point; without this pass, a dead-but-
+		// resumable session loaded from sessionmeta would never be added
+		// to its matching project and would be invisible in the sidebar
+		// (the visibility filter requires a stamp).
+		projectMgr.AutoAssignAll(buildSessionInfos(sessions))
 		// Stamp ProjectSlug / ProjectIndex on the just-rehydrated sessions
 		// (and on any sessions previously loaded via sessionmeta.Sweep)
-		// before SSE subscribers can observe.
+		// before SSE subscribers can observe. Reload to pick up any
+		// AutoAssignAll mutations; Broadcast also runs reconcile but only
+		// fires when state actually changed.
+		if fresh, err := projectMgr.Load(); err == nil {
+			state = fresh
+		}
 		reconcileProjectStamps(state)
 	}
 
@@ -619,10 +631,12 @@ func serve(stderr io.Writer) int {
 				continue
 			}
 			s := ev.Session
-			// Only auto-assign alive sessions. Dead resumable sessions
-			// stay in the array if already persisted from a previous run,
-			// but we don't bulk-add hundreds of old session files on startup.
-			if !s.Alive {
+			// Auto-assign live and resumable sessions. A dead session
+			// with a resume command is just as worth stamping as a live
+			// one; the user can still resume it, and without this stamp
+			// the session would be invisible in the sidebar after a
+			// daemon restart.
+			if !s.Alive && !s.Resumable {
 				continue
 			}
 			projectMgr.AutoAssignSession(projects.SessionInfo{
@@ -632,7 +646,8 @@ func serve(stderr io.Writer) int {
 				Remotes:       s.Remotes,
 				Host:          s.Peer,
 				Alive:         s.Alive,
-				Slug:     s.Slug,
+				Resumable:     s.Resumable,
+				Slug:          s.Slug,
 			})
 		}
 	}()
@@ -872,9 +887,10 @@ func serve(stderr io.Writer) int {
 			writeError(w, http.StatusInternalServerError, "internal", "failed to save projects")
 			return
 		}
-		// Populate the new project's sessions array with alive matches
-		// immediately, so the frontend sees them on the first fetch.
-		projectMgr.AutoAssignAllAlive(buildSessionInfos(sessions))
+		// Populate the new project's sessions array with matching live
+		// and resumable sessions immediately, so the frontend sees them
+		// on the first fetch.
+		projectMgr.AutoAssignAll(buildSessionInfos(sessions))
 		writeJSON(w, map[string]any{"ok": true, "data": item})
 	})
 
@@ -2247,7 +2263,8 @@ func buildSessionInfos(sessions *store.Store) []projects.SessionInfo {
 			Remotes:       s.Remotes,
 			Host:          s.Peer,
 			Alive:         s.Alive,
-			Slug:     s.Slug,
+			Resumable:     s.Resumable,
+			Slug:          s.Slug,
 		}
 	}
 	return infos

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -1671,6 +1671,7 @@ func serve(stderr io.Writer) int {
 				Health:          health,
 				Launchers:       launchConfig.Launchers,
 				DefaultLauncher: launchConfig.DefaultLauncher,
+				PeerProjects:    composePeerProjects(peerManager),
 			}
 		}
 
@@ -1769,9 +1770,17 @@ func serve(stderr io.Writer) int {
 					}
 					sendSSE(w, ev.Type, ev)
 					flusher.Flush()
-				case "projects-update", "peer-status":
-					// Protocol-1 compat: browser-only. Hubs derive these
-					// from cached /v1/health and their own projects.json.
+				case "projects-update":
+					// Forwarded to peer consumers too: a peer hub uses
+					// this signal to refresh its cached projection of
+					// our projects (surfaced in its snapshot.world as
+					// peer_projects). Without this, peer-owned projects
+					// would only refresh on reconnect.
+					sendSSE(w, ev.Type, ev)
+					flusher.Flush()
+				case "peer-status":
+					// Protocol-1 compat: browser-only. Hubs derive peer
+					// status from their own peer manager.
 					if asPeer {
 						continue
 					}
@@ -2064,6 +2073,36 @@ func runStatus(stdout, stderr io.Writer) int {
 	}
 
 	return 0
+}
+
+// composePeerProjects gathers each connected peer's cached project
+// projection into a map keyed by peer name. Returned as map[string][]
+// SpokeProject; the snapshot.world JSON tag handles the rest.
+//
+// Peers that haven't been fetched yet (or whose fetch failed) appear
+// with an empty list. The viewer still gets the key so it knows the
+// peer is enumerable; the list fills in once the first fetch lands.
+func composePeerProjects(mgr *peering.Manager) map[string][]peering.SpokeProject {
+	if mgr == nil {
+		return nil
+	}
+	infos := mgr.PeerStatus()
+	if len(infos) == 0 {
+		return nil
+	}
+	out := make(map[string][]peering.SpokeProject, len(infos))
+	for _, info := range infos {
+		p := mgr.GetPeer(info.Name)
+		if p == nil {
+			continue
+		}
+		projects, _ := p.CachedProjects()
+		if projects == nil {
+			projects = []peering.SpokeProject{}
+		}
+		out[info.Name] = projects
+	}
+	return out
 }
 
 // appendOfflinePeers merges active peers from the manager with offline

--- a/services/gmuxd/internal/apiclient/client.go
+++ b/services/gmuxd/internal/apiclient/client.go
@@ -169,6 +169,45 @@ func (c *Client) GetHealth(ctx context.Context) (json.RawMessage, error) {
 	return envelope.Data, nil
 }
 
+// GetProjects fetches GET /v1/projects and returns the Data field of
+// the response envelope (the raw projects JSON, unwrapped).
+//
+// Used by the hub to surface peer-owned projects in its own snapshot.world
+// so the viewer can render references to them without proxying a separate
+// request. Refreshed on connect and on projects-update events from the peer.
+func (c *Client) GetProjects(ctx context.Context) (json.RawMessage, error) {
+	ctx, cancel := context.WithTimeout(ctx, httpActionTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/v1/projects", nil)
+	if err != nil {
+		return nil, fmt.Errorf("apiclient GetProjects: %w", err)
+	}
+	c.setAuth(req)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("apiclient GetProjects: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("apiclient GetProjects: unexpected status %d", resp.StatusCode)
+	}
+
+	var envelope struct {
+		OK   bool            `json:"ok"`
+		Data json.RawMessage `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		return nil, fmt.Errorf("apiclient GetProjects: decode: %w", err)
+	}
+	if !envelope.OK {
+		return nil, fmt.Errorf("apiclient GetProjects: ok=false")
+	}
+	return envelope.Data, nil
+}
+
 // ForwardAction proxies an HTTP request to the spoke's
 // /v1/sessions/{sessionID}/{action} endpoint. It's the canonical way
 // for a hub to implement kill/resume/dismiss/read/restart on a

--- a/services/gmuxd/internal/peering/manager.go
+++ b/services/gmuxd/internal/peering/manager.go
@@ -19,6 +19,13 @@ type Manager struct {
 	baseCtx     context.Context
 	cancel      context.CancelFunc
 	wg          sync.WaitGroup
+
+	// OnPeerRemoved fires after RemovePeer has stopped the peer's
+	// goroutine and pruned its sessions from the store. wasLocal
+	// indicates whether the peer was a Local peer (PeerConfig.Local
+	// = true), so callers can prune namespaced projects.json keys
+	// matching this peer name. nil = no-op.
+	OnPeerRemoved func(name string, wasLocal bool)
 }
 
 type managedPeer struct {

--- a/services/gmuxd/internal/peering/manager.go
+++ b/services/gmuxd/internal/peering/manager.go
@@ -217,6 +217,7 @@ func (m *Manager) PeerStatus() []PeerInfo {
 			Status:       mp.peer.Status().String(),
 			SessionCount: alive,
 			LastError:    mp.peer.LastError(),
+			Local:        mp.peer.Config.Local,
 		}
 		if h, ok := mp.peer.CachedHealth(); ok {
 			info.Version = h.Version

--- a/services/gmuxd/internal/peering/manager.go
+++ b/services/gmuxd/internal/peering/manager.go
@@ -169,7 +169,9 @@ func (m *Manager) AddPeer(cfg config.PeerConfig, opts ...PeerOption) {
 }
 
 // RemovePeer stops a peer connection, waits for its goroutine to finish,
-// and removes all its sessions from the store.
+// and removes all its sessions from the store. If OnPeerRemoved is set,
+// it fires after store cleanup so the caller can run additional cleanup
+// (e.g. PruneNamespacedKeys for a destroyed devcontainer).
 func (m *Manager) RemovePeer(name string) {
 	m.mu.Lock()
 	mp, ok := m.peers[name]
@@ -178,6 +180,7 @@ func (m *Manager) RemovePeer(name string) {
 		return
 	}
 	delete(m.peers, name)
+	wasLocal := mp.peer.Config.Local
 	m.mu.Unlock()
 
 	if mp.cancel != nil {
@@ -187,6 +190,9 @@ func (m *Manager) RemovePeer(name string) {
 		<-mp.done
 	}
 	m.store.RemoveByPeer(name)
+	if m.OnPeerRemoved != nil {
+		m.OnPeerRemoved(name, wasLocal)
+	}
 }
 
 // FindPeer looks up the peer that owns a namespaced session ID.

--- a/services/gmuxd/internal/peering/peer.go
+++ b/services/gmuxd/internal/peering/peer.go
@@ -35,11 +35,13 @@ type Peer struct {
 	store  *store.Store
 	api    *apiclient.Client
 
-	mu           sync.RWMutex
-	status       Status
-	lastError    string       // human-readable reason for last disconnect
-	cachedHealth SpokeHealth  // peer's /v1/health data, fetched on connect
-	healthLoaded bool         // true after first successful health fetch
+	mu             sync.RWMutex
+	status         Status
+	lastError      string      // human-readable reason for last disconnect
+	cachedHealth   SpokeHealth // peer's /v1/health data, fetched on connect
+	healthLoaded   bool        // true after first successful health fetch
+	cachedProjects []SpokeProject // peer's projects, refreshed on connect and on projects-update
+	projectsLoaded bool
 
 	// onStatus is called when connection state changes.
 	onStatus func(name string, status Status)
@@ -143,6 +145,74 @@ func (p *Peer) CachedHealth() (SpokeHealth, bool) {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 	return p.cachedHealth, p.healthLoaded
+}
+
+// CachedProjects returns the peer's project list, derived as
+// SpokeProject (slug + launch_cwd hint). Returns false until the
+// first successful fetch.
+func (p *Peer) CachedProjects() ([]SpokeProject, bool) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.cachedProjects, p.projectsLoaded
+}
+
+// fetchProjects fetches the spoke's project list via GET /v1/projects,
+// projects each Item down to a SpokeProject (slug + launch_cwd hint
+// derived from the first path rule), and caches the result. Called
+// once after each successful SSE connection and again whenever the
+// peer broadcasts projects-update.
+func (p *Peer) fetchProjects(ctx context.Context) {
+	data, err := p.api.GetProjects(ctx)
+	if err != nil {
+		log.Printf("peering: %s: fetch projects: %v", p.Config.Name, err)
+		return
+	}
+	var envelope struct {
+		Configured []struct {
+			Slug  string `json:"slug"`
+			Peer  string `json:"peer,omitempty"`
+			Match []struct {
+				Path string `json:"path,omitempty"`
+			} `json:"match"`
+		} `json:"configured"`
+	}
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		log.Printf("peering: %s: parse projects: %v", p.Config.Name, err)
+		return
+	}
+	projects := make([]SpokeProject, 0, len(envelope.Configured))
+	for _, it := range envelope.Configured {
+		if it.Slug == "" {
+			continue
+		}
+		// Skip reference items (peer field set): we don't surface
+		// transitive references in our own snapshot.world. The viewer
+		// sees each peer's owned projects, not what those peers in
+		// turn reference from further upstream.
+		if it.Peer != "" {
+			continue
+		}
+		sp := SpokeProject{Slug: it.Slug}
+		for _, r := range it.Match {
+			if r.Path != "" {
+				sp.LaunchCwd = r.Path
+				break
+			}
+		}
+		projects = append(projects, sp)
+	}
+	p.mu.Lock()
+	p.cachedProjects = projects
+	p.projectsLoaded = true
+	p.mu.Unlock()
+	// Signal a status change so the hub's world coalescer re-emits
+	// snapshot.world with the updated peer_projects entry. Reusing
+	// peer-status keeps the wire surface minimal; the type-name is
+	// a slight overload but the trigger semantics are correct (this
+	// peer's externally-visible state changed).
+	if p.onStatus != nil {
+		p.onStatus(p.Config.Name, p.status)
+	}
 }
 
 // fetchHealth fetches the spoke's /v1/health via apiclient, extracts
@@ -255,6 +325,9 @@ func (p *Peer) subscribe(ctx context.Context, onConnected func()) error {
 			// Fetch the peer's health once per connection so the hub
 			// can serve version and launcher data from cache.
 			p.fetchHealth(ctx)
+			// Also fetch the peer's project list so the hub can surface
+			// references to its projects in its own snapshot.world.
+			p.fetchProjects(ctx)
 		},
 		func(ev sseclient.Event) {
 			p.handleEvent(ev.Type, ev.Data)
@@ -382,11 +455,19 @@ func (p *Peer) handleEvent(eventType string, data []byte) {
 		}
 		p.store.Remove(NamespaceID(ev.ID, p.Config.Name))
 
-	case "snapshot.world", "projects-update", "peer-status":
+	case "projects-update":
+		// v1 spoke signal that its projects.json changed. Refresh
+		// the cached projection so the hub's snapshot.world reflects
+		// the new state. v2 spokes emit snapshot.world which we
+		// don't subscribe to as ?as=peer; for those, we rely on the
+		// per-connect fetch and any future explicit signal.
+		go p.fetchProjects(context.Background())
+
+	case "snapshot.world", "peer-status":
 		// Hub composes its own world view. v2 spokes don't emit
 		// snapshot.world to asPeer subscribers anyway; v1 spokes
-		// emit projects-update / peer-status which we don't care
-		// about (hub state is authoritative for those).
+		// emit peer-status which we don't care about (hub state is
+		// authoritative for those).
 
 	default:
 		// Unknown event types are silently ignored for forward compatibility.

--- a/services/gmuxd/internal/peering/peer.go
+++ b/services/gmuxd/internal/peering/peer.go
@@ -210,6 +210,15 @@ func (p *Peer) fetchProjects(ctx context.Context) {
 	// peer-status keeps the wire surface minimal; the type-name is
 	// a slight overload but the trigger semantics are correct (this
 	// peer's externally-visible state changed).
+	//
+	// Skip the broadcast if the peer's context has been cancelled
+	// (peer torn down mid-fetch). The store cleanup that follows
+	// disconnect would otherwise race against a stale cache update,
+	// and we'd fire a re-compose for a peer the world snapshot no
+	// longer enumerates.
+	if ctx.Err() != nil {
+		return
+	}
 	if p.onStatus != nil {
 		p.onStatus(p.Config.Name, p.status)
 	}
@@ -330,7 +339,7 @@ func (p *Peer) subscribe(ctx context.Context, onConnected func()) error {
 			p.fetchProjects(ctx)
 		},
 		func(ev sseclient.Event) {
-			p.handleEvent(ev.Type, ev.Data)
+			p.handleEvent(ctx, ev.Type, ev.Data)
 		},
 	)
 
@@ -384,7 +393,7 @@ func (p *Peer) isForwardedFromKnownOrigin(id string) bool {
 	return innerPeer != "" && p.isKnownOrigin(innerPeer)
 }
 
-func (p *Peer) handleEvent(eventType string, data []byte) {
+func (p *Peer) handleEvent(ctx context.Context, eventType string, data []byte) {
 	switch eventType {
 	case "snapshot.sessions":
 		// Authoritative replacement: the spoke's view of its owned
@@ -456,12 +465,14 @@ func (p *Peer) handleEvent(eventType string, data []byte) {
 		p.store.Remove(NamespaceID(ev.ID, p.Config.Name))
 
 	case "projects-update":
-		// v1 spoke signal that its projects.json changed. Refresh
-		// the cached projection so the hub's snapshot.world reflects
-		// the new state. v2 spokes emit snapshot.world which we
-		// don't subscribe to as ?as=peer; for those, we rely on the
-		// per-connect fetch and any future explicit signal.
-		go p.fetchProjects(context.Background())
+		// Spoke's projects.json changed. Refresh the cached
+		// projection so the hub's snapshot.world reflects the new
+		// state. Pass the streaming ctx so the fetch is cancelled
+		// if the peer disconnects mid-flight (otherwise a slow
+		// /v1/projects could race past disconnect and fire a
+		// spurious peer-status broadcast via onStatus, triggering
+		// a world re-compose on stale data).
+		go p.fetchProjects(ctx)
 
 	case "snapshot.world", "peer-status":
 		// Hub composes its own world view. v2 spokes don't emit

--- a/services/gmuxd/internal/peering/peering.go
+++ b/services/gmuxd/internal/peering/peering.go
@@ -86,6 +86,17 @@ type SpokeHealth struct {
 	Launchers       []LauncherDef `json:"launchers"`
 }
 
+// SpokeProject is the minimal projection of a peer's project that
+// the hub re-broadcasts in its own snapshot.world under
+// peer_projects[<peerName>][]. Enough for the viewer to render the
+// reference (folder header, launch fallback) without proxying a
+// separate request. Session counts and last-active timestamps are
+// derived client-side from stamped sessions.
+type SpokeProject struct {
+	Slug      string `json:"slug"`
+	LaunchCwd string `json:"launch_cwd,omitempty"`
+}
+
 // PeerInfo is the public status of a single peer connection.
 type PeerInfo struct {
 	Name            string        `json:"name"`
@@ -96,6 +107,13 @@ type PeerInfo struct {
 	Version         string        `json:"version,omitempty"`
 	DefaultLauncher string        `json:"default_launcher,omitempty"`
 	Launchers       []LauncherDef `json:"launchers,omitempty"`
+	// Local is true when this peer is conceptually an extension of
+	// the host (a devcontainer discovered by the Docker watcher,
+	// not a network peer). Local peers don't own their own project
+	// assignments; the parent's match rules stamp their sessions,
+	// which then bucket into the parent's local folders. See ADR
+	// 0002 amendment.
+	Local bool `json:"local,omitempty"`
 }
 
 // NamespaceID returns a store-key for a remote session: "originalID@peerName".

--- a/services/gmuxd/internal/peering/peering_test.go
+++ b/services/gmuxd/internal/peering/peering_test.go
@@ -1,6 +1,7 @@
 package peering
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -437,7 +438,7 @@ func TestHandleEvent_V1CompatPerEvent(t *testing.T) {
 		"id":      "sess-1",
 		"session": rawSession,
 	})
-	p.handleEvent("session-upsert", upsert)
+	p.handleEvent(context.Background(), "session-upsert", upsert)
 
 	sess, ok := st.Get("sess-1@server")
 	if !ok {
@@ -455,7 +456,7 @@ func TestHandleEvent_V1CompatPerEvent(t *testing.T) {
 		"type": "session-remove",
 		"id":   "sess-1",
 	})
-	p.handleEvent("session-remove", remove)
+	p.handleEvent(context.Background(), "session-remove", remove)
 
 	if _, ok := st.Get("sess-1@server"); ok {
 		t.Error("v1 session-remove did not clear the namespaced store entry")
@@ -481,7 +482,7 @@ func TestHandleEvent_V1CompatDropsForwardedFromKnownOrigin(t *testing.T) {
 		"id":      "sess-1@hub-b",
 		"session": rawSession,
 	})
-	p.handleEvent("session-upsert", upsert)
+	p.handleEvent(context.Background(), "session-upsert", upsert)
 
 	if _, ok := st.Get("sess-1@hub-b@hub-a"); ok {
 		t.Error("forwarded-from-known-origin session should be dropped, not mirrored")
@@ -784,6 +785,49 @@ func TestManager_RemovePeer(t *testing.T) {
 	if _, ok := st.Get("s1@dev"); ok {
 		t.Fatal("peer sessions should be cleaned up")
 	}
+}
+
+// The OnPeerRemoved callback is the GC hook that lets the projects
+// manager prune namespaced session keys (`id@<peer>`) when a Local
+// peer (devcontainer) is destroyed. Verify the callback fires with
+// the correct peer name and wasLocal flag for both Local and network
+// peers; the projects-side cleanup relies on the wasLocal branch.
+func TestManager_RemovePeer_FiresOnPeerRemoved(t *testing.T) {
+	type call struct {
+		name    string
+		local   bool
+	}
+
+	run := func(t *testing.T, peerLocal bool) {
+		t.Helper()
+		st := store.New()
+		sk := spokeServer(t, "", nil)
+		mgr := NewManager(nil, st, "test-host")
+		var got []call
+		var mu sync.Mutex
+		mgr.OnPeerRemoved = func(name string, wasLocal bool) {
+			mu.Lock()
+			defer mu.Unlock()
+			got = append(got, call{name, wasLocal})
+		}
+		mgr.Start()
+		defer mgr.Stop()
+
+		mgr.AddPeer(config.PeerConfig{Name: "dev", URL: sk.URL, Token: "", Local: peerLocal})
+		mgr.RemovePeer("dev")
+
+		mu.Lock()
+		defer mu.Unlock()
+		if len(got) != 1 {
+			t.Fatalf("expected 1 callback, got %d", len(got))
+		}
+		if got[0].name != "dev" || got[0].local != peerLocal {
+			t.Errorf("callback got (%q, %v), want (dev, %v)", got[0].name, got[0].local, peerLocal)
+		}
+	}
+
+	t.Run("local peer", func(t *testing.T) { run(t, true) })
+	t.Run("network peer", func(t *testing.T) { run(t, false) })
 }
 
 func TestManager_RemoveNonexistentIsNoop(t *testing.T) {

--- a/services/gmuxd/internal/projects/manager.go
+++ b/services/gmuxd/internal/projects/manager.go
@@ -83,13 +83,14 @@ func (m *Manager) Update(fn func(s *State) bool) error {
 //   - A new session is discovered (Register)
 //   - A session gets a Slug (file attribution)
 //
-// Peer-owned sessions (info.Host != "") are never written to the local
-// projects.json: project membership is owned by the session's origin
-// host (ADR 0002). The viewer learns peer-side project assignment via
-// the session's stamps (ProjectSlug / ProjectIndex), not by mirroring
-// peer state into local config.
+// Network-peer sessions (info.Host set, info.LocalHost false) are never
+// written to the local projects.json: project membership for them is
+// owned by their origin host (ADR 0002). Local-peer sessions
+// (devcontainers, info.LocalHost = true) are an exception: the parent
+// owns their assignment per the ADR 0002 amendment, so they flow
+// through here like local sessions.
 func (m *Manager) AutoAssignSession(info SessionInfo) string {
-	if info.Host != "" {
+	if info.Host != "" && !info.LocalHost {
 		return ""
 	}
 	var assigned string
@@ -148,12 +149,16 @@ func (m *Manager) AutoAssignSession(info SessionInfo) string {
 // resumable sessions miss the auto-assign hook, which only fires on
 // session-upsert events for live sessions).
 //
-// Peer-owned sessions are skipped; see AutoAssignSession.
+// Network-peer sessions are skipped; Local-peer sessions flow through
+// because the parent owns their assignment. See AutoAssignSession.
 func (m *Manager) AutoAssignAll(sessions []SessionInfo) {
 	err := m.Update(func(state *State) bool {
 		changed := false
 		for _, info := range sessions {
-			if (!info.Alive && !info.Resumable) || info.Host != "" {
+			if !info.Alive && !info.Resumable {
+				continue
+			}
+			if info.Host != "" && !info.LocalHost {
 				continue
 			}
 			key := SessionKey(info.ID, info.Slug)
@@ -171,6 +176,40 @@ func (m *Manager) AutoAssignAll(sessions []SessionInfo) {
 	})
 	if err != nil {
 		log.Printf("projects: auto-assign-all error: %v", err)
+	}
+}
+
+// PruneNamespacedKeys removes any session key ending in "@<peerName>"
+// from every project's Sessions[]. Called when a Local peer
+// (devcontainer) is destroyed: its namespaced ids will never resolve
+// again and would accumulate as dead weight in the parent's
+// projects.json. Reference items (peer-owned) are skipped: their
+// content is the peer's business.
+func (m *Manager) PruneNamespacedKeys(peerName string) {
+	if peerName == "" {
+		return
+	}
+	suffix := "@" + peerName
+	err := m.Update(func(state *State) bool {
+		changed := false
+		for i := range state.Items {
+			if state.Items[i].IsReference() {
+				continue
+			}
+			filtered := state.Items[i].Sessions[:0]
+			for _, key := range state.Items[i].Sessions {
+				if len(key) > len(suffix) && key[len(key)-len(suffix):] == suffix {
+					changed = true
+					continue
+				}
+				filtered = append(filtered, key)
+			}
+			state.Items[i].Sessions = filtered
+		}
+		return changed
+	})
+	if err != nil {
+		log.Printf("projects: prune namespaced keys (%s): %v", peerName, err)
 	}
 }
 

--- a/services/gmuxd/internal/projects/manager.go
+++ b/services/gmuxd/internal/projects/manager.go
@@ -139,17 +139,21 @@ func (m *Manager) AutoAssignSession(info SessionInfo) string {
 	return assigned
 }
 
-// AutoAssignAllAlive iterates all sessions and adds alive ones to their
-// matching projects in a single atomic update. Called after adding a
-// project so that existing alive sessions populate the array immediately
-// rather than waiting for the next session-upsert event.
+// AutoAssignAll iterates all sessions and adds alive-or-resumable
+// ones to their matching projects in a single atomic update. Called
+// after adding a project so that existing sessions populate the array
+// immediately rather than waiting for the next session-upsert event,
+// and at startup so resumable sessions loaded from sessionmeta get
+// stamped before the first snapshot goes out (otherwise dead-but-
+// resumable sessions miss the auto-assign hook, which only fires on
+// session-upsert events for live sessions).
 //
 // Peer-owned sessions are skipped; see AutoAssignSession.
-func (m *Manager) AutoAssignAllAlive(sessions []SessionInfo) {
+func (m *Manager) AutoAssignAll(sessions []SessionInfo) {
 	err := m.Update(func(state *State) bool {
 		changed := false
 		for _, info := range sessions {
-			if !info.Alive || info.Host != "" {
+			if (!info.Alive && !info.Resumable) || info.Host != "" {
 				continue
 			}
 			key := SessionKey(info.ID, info.Slug)

--- a/services/gmuxd/internal/projects/migrate.go
+++ b/services/gmuxd/internal/projects/migrate.go
@@ -17,6 +17,10 @@ import (
 //     and "paths" ([]string) as separate top-level fields.
 //   - 2: unified match rules. Items have "match" ([]MatchRule) instead of
 //     separate "remote" and "paths". Paths may use ~ for $HOME.
+//   - 3: items may also be peer references ({slug, peer}). MatchRule.hosts
+//     is dropped (replaced by ownership). v2 → v3 is a pass-through:
+//     existing items remain owned-style; rule.hosts evaporates because
+//     the struct field is gone and the JSON decoder silently drops it.
 func migrateState(data []byte) ([]byte, error) {
 	var doc map[string]any
 	if err := json.Unmarshal(data, &doc); err != nil {
@@ -31,6 +35,11 @@ func migrateState(data []byte) ([]byte, error) {
 	if version < 2 {
 		migrateV1toV2(doc)
 	}
+	// v2 → v3 is structural only: rule.hosts is silently dropped on
+	// load (unknown field), peer references didn't exist before so
+	// nothing to transform. The version bump alone signals "saved by
+	// a v3-aware daemon" so any future migrations downstream see the
+	// right starting point.
 
 	doc["version"] = float64(currentVersion)
 	return json.Marshal(doc)

--- a/services/gmuxd/internal/projects/migrate_test.go
+++ b/services/gmuxd/internal/projects/migrate_test.go
@@ -86,14 +86,20 @@ func TestMigrateV1ToV2(t *testing.T) {
 	}
 }
 
-func TestMigrateV2Noop(t *testing.T) {
-	// Already v2 data should pass through unchanged.
+func TestMigrateV2ToV3(t *testing.T) {
+	// v2 data is structurally compatible with v3: the only schema
+	// difference is the addition of reference items and the removal
+	// of MatchRule.hosts. v2 files load cleanly; the hosts field is
+	// silently dropped because the struct no longer carries it.
 	v2Data := `{
   "version": 2,
   "items": [
     {
       "slug": "gmux",
-      "match": [{"remote": "github.com/gmuxapp/gmux"}, {"path": "~/dev/gmux"}],
+      "match": [
+        {"remote": "github.com/gmuxapp/gmux"},
+        {"path": "~/dev/gmux", "hosts": ["laptop"]}
+      ],
       "sessions": ["hub-protocol"]
     }
   ]
@@ -109,8 +115,8 @@ func TestMigrateV2Noop(t *testing.T) {
 		t.Fatalf("Load: %v", err)
 	}
 
-	if state.Version != 2 {
-		t.Errorf("version = %d", state.Version)
+	if state.Version != currentVersion {
+		t.Errorf("version = %d, want %d", state.Version, currentVersion)
 	}
 	if len(state.Items) != 1 {
 		t.Fatalf("items = %d", len(state.Items))
@@ -123,13 +129,50 @@ func TestMigrateV2Noop(t *testing.T) {
 	}
 }
 
+func TestV3References(t *testing.T) {
+	// Mixed v3 file with an owned project and a reference to a peer's
+	// project. Both shapes load as Item; IsReference distinguishes.
+	v3Data := `{
+  "version": 3,
+  "items": [
+    {"slug": "gmux", "match": [{"path": "~/dev/gmux"}], "sessions": ["s1"]},
+    {"slug": "claude", "peer": "workstation"}
+  ]
+}`
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, fileName), []byte(v3Data), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	state, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(state.Items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(state.Items))
+	}
+	if state.Items[0].IsReference() {
+		t.Error("item 0 should be owned")
+	}
+	if !state.Items[1].IsReference() {
+		t.Error("item 1 should be a reference")
+	}
+	if state.Items[1].Peer != "workstation" {
+		t.Errorf("item 1 peer = %q, want workstation", state.Items[1].Peer)
+	}
+	// Validate accepts the mixed file.
+	if err := state.Validate(); err != nil {
+		t.Errorf("validate mixed v3: %v", err)
+	}
+}
+
 func TestMigrateRoundtrip(t *testing.T) {
-	// Save v2 state, reload, verify identical.
+	// Save state, reload, verify identical.
 	dir := t.TempDir()
 	original := &State{
 		Version: currentVersion,
 		Items: []Item{
 			{Slug: "test", Match: []MatchRule{{Path: "~/projects/test"}}, Sessions: []string{"s1"}},
+			{Slug: "remote", Peer: "workstation"},
 		},
 	}
 	if err := original.Save(dir); err != nil {

--- a/services/gmuxd/internal/projects/projects.go
+++ b/services/gmuxd/internal/projects/projects.go
@@ -544,9 +544,14 @@ type SessionInfo struct {
 	WorkspaceRoot string
 	Remotes       map[string]string
 	Host          string // peer name; empty for local sessions
-	Alive         bool
-	Resumable     bool // dead but has a resume command persisted
-	Slug          string
+	// LocalHost is true when Host is a Local peer (devcontainer): the
+	// session lives on a peer but the parent owns its project
+	// assignment. AutoAssign treats these as local for the purposes
+	// of writing into projects.json.
+	LocalHost bool
+	Alive     bool
+	Resumable bool // dead but has a resume command persisted
+	Slug      string
 }
 
 // matchParamsFromInfo builds MatchParams from a SessionInfo.

--- a/services/gmuxd/internal/projects/projects.go
+++ b/services/gmuxd/internal/projects/projects.go
@@ -24,25 +24,48 @@ const fileName = "projects.json"
 
 // currentVersion is the latest projects.json schema version.
 // See migrateState for the evolution history.
-const currentVersion = 2
+const currentVersion = 3
 
 // MatchRule is a single criterion for matching sessions to a project.
 // Exactly one of Path or Remote should be set.
+//
+// Pre-v3 schemas allowed a Hosts []string field for scoping a rule to
+// specific peers. The field is no longer honoured: in the cross-host
+// project ownership model, scoping is implicit in ownership (each
+// project is owned by exactly one host). v2 files containing the
+// field decode silently because the JSON decoder ignores unknown
+// fields; the field is dropped on next Save.
 type MatchRule struct {
-	Path   string   `json:"path,omitempty"`
-	Remote string   `json:"remote,omitempty"`
-	Hosts  []string `json:"hosts,omitempty"` // empty = any host
-	Exact  bool     `json:"exact,omitempty"` // path must match exactly, not as prefix
+	Path   string `json:"path,omitempty"`
+	Remote string `json:"remote,omitempty"`
+	Exact  bool   `json:"exact,omitempty"` // path must match exactly, not as prefix
 }
 
-// Item is a user-configured project entry.
-// Match contains the rules that determine which sessions belong here.
-// Sessions is an ordered list of session keys (slug or session ID)
-// that controls sidebar order.
+// Item is a single entry in the user's projects.json items[] list. Two
+// shapes share this struct:
+//
+//   - Owned: Slug + Match[] + Sessions[]. This is a project owned by
+//     this host. Match drives session attribution; Sessions[] holds
+//     the ordered list of session keys for sidebar order.
+//   - Reference: Slug + Peer. This is a viewer-side reference to a
+//     project owned by a peer. Match and Sessions are unused: the
+//     peer's projects.json is the source of truth for both. The viewer
+//     just declares "show this peer's project in my sidebar at this
+//     position."
+//
+// Validate enforces exactly one of {Match present, Peer present}.
 type Item struct {
 	Slug     string      `json:"slug"`
-	Match    []MatchRule `json:"match"`
+	Peer     string      `json:"peer,omitempty"`
+	Match    []MatchRule `json:"match,omitempty"`
 	Sessions []string    `json:"sessions,omitempty"`
+}
+
+// IsReference reports whether this item is a reference to a peer-owned
+// project. References have no local match rules; their content is
+// driven entirely by the peer's stamps on the wire.
+func (i *Item) IsReference() bool {
+	return i.Peer != ""
 }
 
 // State holds the ordered list of configured projects.
@@ -124,10 +147,34 @@ func (s *State) Validate() error {
 		if !IsValidSlug(item.Slug) {
 			return fmt.Errorf("item %d: slug %q is not URL-safe", i, item.Slug)
 		}
-		if slugs[item.Slug] {
+		// References use a composite identity (peer+slug); owned
+		// projects use just slug. Detect duplicates within each
+		// kind separately so a local owned "gmux" and a reference
+		// to peer "workstation/gmux" can coexist.
+		key := item.Slug
+		if item.IsReference() {
+			key = item.Peer + "::" + item.Slug
+		}
+		if slugs[key] {
+			if item.IsReference() {
+				return fmt.Errorf("duplicate reference %s/%s", item.Peer, item.Slug)
+			}
 			return fmt.Errorf("duplicate slug %q", item.Slug)
 		}
-		slugs[item.Slug] = true
+		slugs[key] = true
+
+		if item.IsReference() {
+			// References carry no rules or sessions of their own.
+			// A non-empty Match[] would be a user error; reject it
+			// to keep the data shape unambiguous.
+			if len(item.Match) > 0 {
+				return fmt.Errorf("item %q: references cannot carry match rules", item.Slug)
+			}
+			if len(item.Sessions) > 0 {
+				return fmt.Errorf("item %q: references cannot carry sessions", item.Slug)
+			}
+			continue
+		}
 
 		if len(item.Match) == 0 {
 			return fmt.Errorf("item %q: match rules are empty", item.Slug)
@@ -187,11 +234,13 @@ func (s *State) Match(p MatchParams) *Item {
 
 	for i := range s.Items {
 		item := &s.Items[i]
+		// Skip reference items: their content is driven by peer
+		// stamps, not local rules. Match() returns owned projects
+		// only.
+		if item.IsReference() {
+			continue
+		}
 		for _, rule := range item.Match {
-			if !ruleMatchesHost(rule, p.Host) {
-				continue
-			}
-
 			if rule.Remote != "" {
 				normRemote := NormalizeRemote(rule.Remote)
 				for _, url := range p.Remotes {
@@ -228,20 +277,6 @@ func (s *State) Match(p MatchParams) *Item {
 		return bestPath
 	}
 	return firstRemote
-}
-
-// ruleMatchesHost returns true if the rule applies to the given host.
-// Rules without Hosts match any host.
-func ruleMatchesHost(rule MatchRule, host string) bool {
-	if len(rule.Hosts) == 0 {
-		return true
-	}
-	for _, h := range rule.Hosts {
-		if h == host {
-			return true
-		}
-	}
-	return false
 }
 
 // pathUnder returns true if candidate is equal to or a subdirectory of base.

--- a/services/gmuxd/internal/projects/projects.go
+++ b/services/gmuxd/internal/projects/projects.go
@@ -398,10 +398,11 @@ func UniqueSlug(slug string, items []Item) string {
 // --- Session membership ---
 
 // AddSession appends a session key to a project's sessions list if not
-// already present. Returns true if the session was added.
+// already present. Returns true if the session was added. References
+// are skipped: their session order is the peer's responsibility.
 func (s *State) AddSession(slug, key string) bool {
 	for i := range s.Items {
-		if s.Items[i].Slug != slug {
+		if s.Items[i].Slug != slug || s.Items[i].IsReference() {
 			continue
 		}
 		for _, existing := range s.Items[i].Sessions {
@@ -425,10 +426,13 @@ func (s *State) AddSession(slug, key string) bool {
 // via the /v1/peers/{peer}/... proxy: the viewer never sees the full
 // projects.json on the peer, so it can't reconstruct the hidden tail.
 //
-// Returns true if the project was found.
+// Returns true if the project was found. References (peer-owned
+// projects) are skipped: their session order lives on the peer, not
+// in the local file, so the local PATCH endpoint must not touch
+// them even when the slug collides with a local owned project.
 func (s *State) ReorderSessions(slug string, req []string) bool {
 	for i := range s.Items {
-		if s.Items[i].Slug != slug {
+		if s.Items[i].Slug != slug || s.Items[i].IsReference() {
 			continue
 		}
 		inReq := make(map[string]bool, len(req))
@@ -449,10 +453,11 @@ func (s *State) ReorderSessions(slug string, req []string) bool {
 }
 
 // RemoveSession removes a session key from a project's sessions list.
-// Returns true if the session was found and removed.
+// Returns true if the session was found and removed. References are
+// skipped: they carry no sessions[] of their own.
 func (s *State) RemoveSession(slug, key string) bool {
 	for i := range s.Items {
-		if s.Items[i].Slug != slug {
+		if s.Items[i].Slug != slug || s.Items[i].IsReference() {
 			continue
 		}
 		for j, existing := range s.Items[i].Sessions {

--- a/services/gmuxd/internal/projects/projects.go
+++ b/services/gmuxd/internal/projects/projects.go
@@ -510,7 +510,8 @@ type SessionInfo struct {
 	Remotes       map[string]string
 	Host          string // peer name; empty for local sessions
 	Alive         bool
-	Slug     string
+	Resumable     bool // dead but has a resume command persisted
+	Slug          string
 }
 
 // matchParamsFromInfo builds MatchParams from a SessionInfo.

--- a/services/gmuxd/internal/projects/projects_test.go
+++ b/services/gmuxd/internal/projects/projects_test.go
@@ -1288,3 +1288,137 @@ func TestAssignmentsByKey_FirstOccurrenceWinsOnDuplicate(t *testing.T) {
 		t.Errorf("expected first occurrence to win, got %+v", got["shared"])
 	}
 }
+
+// ── References (v3) ─────────────────────────────────────────────────
+
+// When a local owned project and a peer reference share a slug, the
+// session-membership operations must target the owned entry only:
+// references carry no Sessions[] of their own and writing to them
+// would corrupt the file shape and confuse the peer (whose
+// projects.json is the SOT for that slug).
+func TestSessionOpsSkipReferenceWithSameSlug(t *testing.T) {
+	// Reference appears BEFORE the owned entry in items[], so a
+	// naive `Slug == slug` loop would hit it first. The guard in
+	// AddSession/RemoveSession/ReorderSessions must skip it.
+	s := State{Items: []Item{
+		{Slug: "gmux", Peer: "tower"},                    // reference
+		{Slug: "gmux", Match: []MatchRule{{Path: "/x"}}}, // owned
+	}}
+
+	if !s.AddSession("gmux", "sess-1") {
+		t.Fatal("AddSession returned false")
+	}
+	if len(s.Items[0].Sessions) != 0 {
+		t.Errorf("reference contaminated by AddSession: %v", s.Items[0].Sessions)
+	}
+	if !equalStrings(s.Items[1].Sessions, []string{"sess-1"}) {
+		t.Errorf("owned project sessions = %v, want [sess-1]", s.Items[1].Sessions)
+	}
+
+	if !s.ReorderSessions("gmux", []string{"sess-1"}) {
+		t.Fatal("ReorderSessions returned false")
+	}
+	if len(s.Items[0].Sessions) != 0 {
+		t.Errorf("reference contaminated by ReorderSessions: %v", s.Items[0].Sessions)
+	}
+
+	if !s.RemoveSession("gmux", "sess-1") {
+		t.Fatal("RemoveSession returned false")
+	}
+	if len(s.Items[1].Sessions) != 0 {
+		t.Errorf("owned sessions not cleared: %v", s.Items[1].Sessions)
+	}
+}
+
+func TestValidateRejectsReferenceWithMatchRules(t *testing.T) {
+	s := State{Items: []Item{
+		{Slug: "gmux", Peer: "tower", Match: []MatchRule{{Path: "/x"}}},
+	}}
+	if err := s.Validate(); err == nil {
+		t.Error("expected validation error for reference with match rules")
+	}
+}
+
+func TestValidateAllowsSameSlugAsOwnedAndReference(t *testing.T) {
+	s := State{Items: []Item{
+		{Slug: "gmux", Match: []MatchRule{{Path: "/x"}}},
+		{Slug: "gmux", Peer: "tower"},
+	}}
+	if err := s.Validate(); err != nil {
+		t.Errorf("expected mixed owned+reference with same slug to validate, got: %v", err)
+	}
+}
+
+func TestValidateRejectsDuplicateReferences(t *testing.T) {
+	s := State{Items: []Item{
+		{Slug: "gmux", Peer: "tower"},
+		{Slug: "gmux", Peer: "tower"},
+	}}
+	if err := s.Validate(); err == nil {
+		t.Error("expected duplicate reference rejection")
+	}
+}
+
+// PruneNamespacedKeys is the GC hook fired when a Local peer
+// (devcontainer) is removed. It must:
+//   - drop keys whose suffix is exactly "@<peer>"
+//   - leave slug-keyed entries alone (those survive container restarts
+//     because the slug is stable)
+//   - leave references alone (their session order is the peer's, not
+//     ours)
+//   - not be fooled by peer names that are prefixes of other peer names
+//     ("dev" must not match keys ending in "@develop")
+func TestPruneNamespacedKeys(t *testing.T) {
+	dir := t.TempDir()
+	mgr := NewManager(dir)
+	mgr.Update(func(s *State) bool {
+		s.Items = []Item{
+			{
+				Slug:  "proj",
+				Match: []MatchRule{{Path: "/x"}},
+				Sessions: []string{
+					"sess-a@container",  // should be pruned
+					"sess-b@container",  // should be pruned
+					"sess-c@develop",    // not @container; kept
+					"sess-d",            // local id; kept
+					"claude-attribution", // slug; kept (survives container restart)
+				},
+			},
+			{
+				Slug:     "remote",
+				Peer:     "container",
+				Sessions: nil,
+			},
+		}
+		return true
+	})
+
+	mgr.PruneNamespacedKeys("container")
+
+	state, _ := mgr.Load()
+	want := []string{"sess-c@develop", "sess-d", "claude-attribution"}
+	if !equalStrings(state.Items[0].Sessions, want) {
+		t.Errorf("after prune: got %v, want %v", state.Items[0].Sessions, want)
+	}
+	// Reference entry untouched (it had no sessions to begin with;
+	// pin the loop's continue-on-IsReference branch).
+	if len(state.Items[1].Sessions) != 0 {
+		t.Errorf("reference entry mutated: %v", state.Items[1].Sessions)
+	}
+}
+
+func TestPruneNamespacedKeysEmptyPeerNameNoop(t *testing.T) {
+	dir := t.TempDir()
+	mgr := NewManager(dir)
+	mgr.Update(func(s *State) bool {
+		s.Items = []Item{
+			{Slug: "p", Match: []MatchRule{{Path: "/x"}}, Sessions: []string{"a", "b"}},
+		}
+		return true
+	})
+	mgr.PruneNamespacedKeys("")
+	state, _ := mgr.Load()
+	if !equalStrings(state.Items[0].Sessions, []string{"a", "b"}) {
+		t.Errorf("empty peer pruned sessions: %v", state.Items[0].Sessions)
+	}
+}

--- a/services/gmuxd/internal/projects/projects_test.go
+++ b/services/gmuxd/internal/projects/projects_test.go
@@ -1119,37 +1119,6 @@ func TestManagerAutoAssignAllSkipsPeerOwnedSessions(t *testing.T) {
 	}
 }
 
-func TestMatchHostScoping(t *testing.T) {
-	s := &State{Items: []Item{
-		{Slug: "laptop-data", Match: []MatchRule{{Path: "/data/ml", Hosts: []string{"laptop"}}}},
-		{Slug: "gmux", Match: []MatchRule{{Path: "/dev/gmux"}}},
-	}}
-
-	// Local session: host-scoped rule doesn't match (host is "").
-	m := s.Match(MatchParams{Cwd: "/data/ml/experiment"})
-	if m != nil {
-		t.Errorf("local session in /data/ml: expected nil (no unscoped match), got %q", m.Slug)
-	}
-
-	// Session from the scoped host: matches.
-	m = s.Match(MatchParams{Cwd: "/data/ml/experiment", Host: "laptop"})
-	if m == nil || m.Slug != "laptop-data" {
-		t.Errorf("laptop session: expected 'laptop-data', got %v", m)
-	}
-
-	// Session from a different peer: host-scoped rule doesn't apply.
-	m = s.Match(MatchParams{Cwd: "/data/ml/experiment", Host: "server"})
-	if m != nil {
-		t.Errorf("server session in /data/ml: expected nil, got %q", m.Slug)
-	}
-
-	// Unscoped rule matches any host.
-	m = s.Match(MatchParams{Cwd: "/dev/gmux/src", Host: "server"})
-	if m == nil || m.Slug != "gmux" {
-		t.Errorf("server session in /dev/gmux: expected 'gmux', got %v", m)
-	}
-}
-
 
 func TestNormalizePathExpandsTilde(t *testing.T) {
 	home, err := os.UserHomeDir()

--- a/services/gmuxd/internal/projects/projects_test.go
+++ b/services/gmuxd/internal/projects/projects_test.go
@@ -1035,7 +1035,7 @@ func TestManagerCleanupSessionsNoOrphans(t *testing.T) {
 	}
 }
 
-func TestManagerAutoAssignAllAlive(t *testing.T) {
+func TestManagerAutoAssignAll(t *testing.T) {
 	dir := t.TempDir()
 	mgr := NewManager(dir)
 
@@ -1050,15 +1050,16 @@ func TestManagerAutoAssignAllAlive(t *testing.T) {
 	sessions := []SessionInfo{
 		{ID: "s1", Cwd: "/dev/gmux/src", Alive: true},
 		{ID: "s2", Cwd: "/dev/yapp", Alive: true},
-		{ID: "s3", Cwd: "/dev/gmux", Alive: false}, // dead: should be skipped
-		{ID: "s4", Cwd: "/other", Alive: true},      // unmatched: should be skipped
+		{ID: "s3", Cwd: "/dev/gmux", Alive: false, Resumable: true}, // dead+resumable: included
+		{ID: "s4", Cwd: "/dev/gmux", Alive: false},                  // dead, no resume: skipped
+		{ID: "s5", Cwd: "/other", Alive: true},                       // unmatched: skipped
 	}
 
-	mgr.AutoAssignAllAlive(sessions)
+	mgr.AutoAssignAll(sessions)
 
 	state, _ := mgr.Load()
-	if len(state.Items[0].Sessions) != 1 || state.Items[0].Sessions[0] != "s1" {
-		t.Errorf("gmux sessions: expected [s1], got %v", state.Items[0].Sessions)
+	if len(state.Items[0].Sessions) != 2 || state.Items[0].Sessions[0] != "s1" || state.Items[0].Sessions[1] != "s3" {
+		t.Errorf("gmux sessions: expected [s1 s3], got %v", state.Items[0].Sessions)
 	}
 	if len(state.Items[1].Sessions) != 1 || state.Items[1].Sessions[0] != "s2" {
 		t.Errorf("yapp sessions: expected [s2], got %v", state.Items[1].Sessions)
@@ -1094,7 +1095,7 @@ func TestManagerAutoAssignSkipsPeerOwnedSession(t *testing.T) {
 	}
 }
 
-func TestManagerAutoAssignAllAliveSkipsPeerOwnedSessions(t *testing.T) {
+func TestManagerAutoAssignAllSkipsPeerOwnedSessions(t *testing.T) {
 	dir := t.TempDir()
 	mgr := NewManager(dir)
 
@@ -1110,7 +1111,7 @@ func TestManagerAutoAssignAllAliveSkipsPeerOwnedSessions(t *testing.T) {
 		{ID: "peer-1", Cwd: "/dev/gmux", Host: "tower", Alive: true},
 		{ID: "peer-2", Cwd: "/dev/gmux", Host: "laptop", Alive: true},
 	}
-	mgr.AutoAssignAllAlive(sessions)
+	mgr.AutoAssignAll(sessions)
 
 	state, _ := mgr.Load()
 	if len(state.Items[0].Sessions) != 1 || state.Items[0].Sessions[0] != "local-1" {

--- a/services/gmuxd/internal/snapshot/snapshot.go
+++ b/services/gmuxd/internal/snapshot/snapshot.go
@@ -52,6 +52,19 @@ type WorldPayload struct {
 	Health          any `json:"health"`
 	Launchers       any `json:"launchers"`
 	DefaultLauncher any `json:"default_launcher"`
+
+	// PeerProjects enumerates each connected peer's projects so the
+	// viewer can render references (projects owned by other hosts) in
+	// the sidebar and Manage Projects modal without proxying a
+	// separate request. Keyed by peer name. Empty for peer consumers
+	// (they don't render references for hops they can't see anyway).
+	//
+	// Each entry carries the slug plus a launch_cwd hint derived from
+	// the peer's first path rule, so the launch button on an empty
+	// referenced folder has somewhere to land. Session counts and
+	// last-active timestamps are derived client-side from stamped
+	// sessions; nothing else needs to ride on this field.
+	PeerProjects any `json:"peer_projects,omitempty"`
 }
 
 // ComposeSessions builds a snapshot.sessions payload from the live

--- a/services/gmuxd/internal/store/store.go
+++ b/services/gmuxd/internal/store/store.go
@@ -386,26 +386,23 @@ func (s *Store) Remove(id string) bool {
 	return ok
 }
 
-// Reconcile re-derives ProjectSlug and ProjectIndex for every
-// origin-owned session (Peer == "") by calling assignFn for each.
-// assignFn is expected to return ("", 0) for sessions that no
-// project currently claims.
+// Reconcile re-derives ProjectSlug and ProjectIndex for every session
+// by calling assignFn. assignFn is expected to return ("", 0) for
+// sessions that no project currently claims.
+//
+// The caller decides which sessions to claim. Local sessions and
+// Local-peer (devcontainer) sessions both flow through assignFn; the
+// caller is responsible for honouring origin-side stamps for genuine
+// network peers (returning the session's existing stamp unchanged so
+// the assignment doesn't get clobbered by parent rules).
 //
 // In-memory mutation only: no events are broadcast. Subscribers
 // observe the new stamps the next time the session is re-emitted
-// (e.g. via Upsert). Once the snapshot protocol composer lands
-// (commit 10), Reconcile folds into snapshot composition rather
-// than mutating sessions in place.
-//
-// Peer-owned sessions are skipped; their stamps are authoritative
-// from the origin and arrive over the wire.
+// (e.g. via Upsert).
 func (s *Store) Reconcile(assignFn func(Session) (slug string, index int)) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for id, sess := range s.sessions {
-		if sess.Peer != "" {
-			continue
-		}
 		slug, index := assignFn(sess)
 		if sess.ProjectSlug == slug && sess.ProjectIndex == index {
 			continue

--- a/services/gmuxd/internal/store/store_test.go
+++ b/services/gmuxd/internal/store/store_test.go
@@ -848,18 +848,25 @@ func TestReconcile_StampsOwnedSessions(t *testing.T) {
 	}
 }
 
-func TestReconcile_SkipsPeerOwnedSessions(t *testing.T) {
+func TestReconcile_CallerControlsPeerStampPreservation(t *testing.T) {
+	// Reconcile no longer auto-skips peer sessions; the caller decides
+	// per session. The canonical caller (reconcileProjectStamps in
+	// main.go) preserves stamps for network peers and re-stamps Local
+	// peers. This test verifies the contract: assignFn sees every
+	// session and its return value is honoured.
 	s := New()
 	s.UpsertRemote(Session{ID: "p1", Slug: "peer-sess", Kind: "k", Peer: "tower", Alive: true, ProjectSlug: "from-origin", ProjectIndex: 3})
 
 	s.Reconcile(func(sess Session) (string, int) {
-		// Would erroneously overwrite if Reconcile didn't skip peer sessions.
-		return "wrong", 99
+		if sess.Peer != "" {
+			return sess.ProjectSlug, sess.ProjectIndex // network peer: preserve
+		}
+		return "local", 0
 	})
 
 	got, _ := s.Get("p1")
 	if got.ProjectSlug != "from-origin" || got.ProjectIndex != 3 {
-		t.Errorf("peer session stamps overwritten: got slug=%q index=%d, want from-origin/3", got.ProjectSlug, got.ProjectIndex)
+		t.Errorf("peer session stamps lost: got slug=%q index=%d, want from-origin/3", got.ProjectSlug, got.ProjectIndex)
 	}
 }
 


### PR DESCRIPTION
Implements the polish plan in `project-ownership-polish.local.md` and the redesign documented in [ADR 0005](docs/adr/0005-references-and-local-peer-exception.md).

## What changes

Replaces the cross-host *adoption* fallback (where the viewer's local match rules silently pulled in disclaimed peer sessions) with explicit *references* to peer-owned projects. Each project now lives on exactly one host; the viewer chooses which peer projects to surface in its sidebar via reference items in its own `projects.json`. Devcontainers (`PeerConfig.Local`) are the single principled exception: their project ownership lives on the parent, not the container.

Also fixes the post-PR-#191 resumable-disappears bug as a natural consequence of making stamps the sole authority for sidebar membership.

## Commits

1. **fix: stamp resumable sessions so they survive daemon restart** — the auto-assign subscriber now covers dead-but-resumable sessions; startup runs an `AutoAssignAll` pass over rehydrated sessions so they get stamped before the first snapshot.
2. **feat: surface peer-owned projects in `snapshot.world`** — `PeerInfo.local` and a new `peer_projects` map. Hub fetches `GET /v1/projects` per peer on connect, refreshes on `projects-update` (now forwarded to peer consumers too), caches the projection, rebroadcasts in own `snapshot.world`.
3. **feat: `projects.json` v3 with discriminated reference items** — `Item` gains an optional `Peer` field. Validate enforces exactly one of `Match` (owned) or `Peer` (reference). `MatchRule.Hosts` is dropped. v2 → v3 is a pass-through.
4. **feat(web): drop cross-host adoption; sidebar buckets on stamps only** — `buildProjectFolders` is now pure stamp-based; references are first-class folders. Local-peer sessions bucket into local folders. `discoverProjects` is per-host and sorted by recency. `countUnmatchedActive` sums across connected peers.
5. **feat: parent re-stamps Local-peer sessions; GC on container removal** — `reconcileProjectStamps` preserves stamps for network peers but re-stamps Local peers. `SessionInfo` gains `LocalHost`. New `OnPeerRemoved` callback on `peering.Manager` + `PruneNamespacedKeys` in `projects.Manager` GCs `@<peer>` keys when a container is destroyed.
6. **feat(web): manage-projects modal supports references; visual polish** — three-section modal (Your sidebar / From other hosts / Discovered); remote-add proxies through hub; `PeerLabel` becomes status-aware; dangling references render a `?` badge.
7. **fix: harden reference-aware code paths; add ADR 0005** — audit-pass and Greptile-review hardening:
   - per-event `AutoAssign` was missing `LocalHost` (Local peer sessions silently skipped stamping)
   - `RemovePeer` didn't actually invoke `OnPeerRemoved`, leaving `PruneNamespacedKeys` as dead code (real bug — keys accumulated forever)
   - `AddSession`/`RemoveSession`/`ReorderSessions` keyed by slug only; with v3 same-slug coexistence a reference could absorb the op and corrupt state
   - `addProject` swallowed errors, so the remote-add → reference chain created dangling references on failure (now throws; caller awaits before referencing)
   - `discoverProjects` surfaced disconnected-peer sessions, compounding the dangling-reference failure mode; filter matches `countUnmatchedActive`
   - `fetchProjects` on `projects-update` used `context.Background()`, leaking the goroutine past disconnect and firing a spurious `onStatus` on torn-down state; threads the streaming ctx through `handleEvent` and gates `onStatus` on `ctx.Err() == nil`
   - ADR 0005 written documenting the model shift, the Local-peer exception, schema v3, caller-driven `Reconcile`, and explicit costs / non-goals

## Tests

- Go: `go test ./services/gmuxd/... ./cli/gmux/...` green.
- Web: `pnpm test --run` green (387/387).
- New behavioral tests pin: same-slug owned + reference coexistence; reference exclusion from session ops; `PruneNamespacedKeys` suffix match (including prefix-conflict and slug preservation); `OnPeerRemoved` invocation with correct `wasLocal` flag for both Local and network peers; `discoverProjects` skipping disconnected peers; reference `launchCwd` derivation; missing-flag detection distinguished from peer disconnection; and Local-peer namespaced-id preservation in reorder PATCH.