### PR TITLE
fix: project sidebar polish (stamps, dismiss, peer scoping, manage UX)

### DIFF
--- a/UBIQUITOUS_LANGUAGE.md
+++ b/UBIQUITOUS_LANGUAGE.md
@@ -74,7 +74,7 @@ The four stores have orthogonal concerns. Mixing them is a smell:
 | **Restart**           | Like Resume but kills the live runner first; goes through Resume after exit                                            |                                |
 | **Slug-takeover**     | A fresh live session evicting a dead one with the same `(kind, peer, slug)` from the store                              | Slug eviction                  |
 | **Dismiss**           | Explicit user removal: runner killed if alive, store entry removed, sessionmeta + scrollback dropped                    | Delete, close                  |
-| **Sweep**             | Daemon startup operation: read every `meta.json` and Upsert as `Alive=false` so dead sessions reappear in the sidebar   | Restore                        |
+| **Sweep**             | Daemon startup operation: read every `meta.json` and Upsert as `Alive=false`; sessions appear in the sidebar only if `projects.json` still contains their key | Restore                        |
 | **Attribution**       | The pre-attribution → attributed transition for tool-backed sessions when their adapter file appears                    | Naming                         |
 
 ## Relationships
@@ -102,7 +102,7 @@ The four stores have orthogonal concerns. Mixing them is a smell:
 
 > **Dev:** "So the **Conversations Index** matters here for resolving URLs to dead pi sessions, but not for the sidebar?"
 
-> **Domain expert:** "Right. **Sessionmeta** is what makes dead sessions reappear in the sidebar after a daemon restart. The **Conversations Index** exists for things like `/v1/conversations/{kind}/{slug}` URL lookup and future search. They live in different concerns; conflating them is what made the old rehydration path overwrite runtime state."
+> **Domain expert:** "Right. **Sessionmeta** makes dead session runtime state survive a daemon restart. **Projects.json** decides whether that dead session is still sidebar-visible. The **Conversations Index** exists for things like `/v1/conversations/{kind}/{slug}` URL lookup and future search. They live in different concerns; conflating them is what made the old rehydration path overwrite runtime state."
 
 ## Flagged ambiguities
 

--- a/apps/gmux-web/src/manage-projects.tsx
+++ b/apps/gmux-web/src/manage-projects.tsx
@@ -55,8 +55,9 @@ export function ManageProjectsModal({
   open: boolean
   onClose: () => void
 }) {
-  const [filter, setFilter] = useState('')
-  const [manualError, setManualError] = useState('')
+  const [discoveredQuery, setDiscoveredQuery] = useState('')
+  const [pathDraft, setPathDraft] = useState('')
+  const [pathError, setPathError] = useState('')
   const [drag, setDrag] = useState<DragState | null>(null)
   const backdropRef = useRef<HTMLDivElement>(null)
 
@@ -68,9 +69,13 @@ export function ManageProjectsModal({
     return () => document.removeEventListener('keydown', handler)
   }, [open, onClose])
 
-  // Reset filter when opening
+  // Reset form state when opening
   useEffect(() => {
-    if (open) { setFilter(''); setManualError('') }
+    if (open) {
+      setDiscoveredQuery('')
+      setPathDraft('')
+      setPathError('')
+    }
   }, [open])
 
   // Close on backdrop click
@@ -82,22 +87,19 @@ export function ManageProjectsModal({
   const discoveredVal = discovered.value
 
   // Filter discovered by the search term.
-  const lowerFilter = filter.toLowerCase().trim()
+  const lowerDiscoveredQuery = discoveredQuery.toLowerCase().trim()
   const filteredDiscovered = useMemo(() => {
-    if (!lowerFilter) return discoveredVal
+    if (!lowerDiscoveredQuery) return discoveredVal
     return discoveredVal.filter(d =>
-      d.suggested_slug.toLowerCase().includes(lowerFilter)
-      || d.paths.some(p => p.toLowerCase().includes(lowerFilter))
-      || (d.remote && d.remote.toLowerCase().includes(lowerFilter)),
+      d.suggested_slug.toLowerCase().includes(lowerDiscoveredQuery)
+      || d.paths.some(p => p.toLowerCase().includes(lowerDiscoveredQuery))
+      || (d.remote && d.remote.toLowerCase().includes(lowerDiscoveredQuery)),
     )
-  }, [discoveredVal, lowerFilter])
+  }, [discoveredVal, lowerDiscoveredQuery])
 
   // Split filtered discovered: active first, then inactive.
   const activeDiscovered = filteredDiscovered.filter(d => d.active_count > 0)
   const inactiveDiscovered = filteredDiscovered.filter(d => d.active_count === 0)
-
-  // Detect if filter looks like a path (for the add-by-path affordance).
-  const filterIsPath = filter.trim().startsWith('/') || filter.trim().startsWith('~/')
 
   // ── Reorder handlers ──
 
@@ -156,21 +158,29 @@ export function ManageProjectsModal({
 
   // ── Manual add by path ──
 
-  const handleManualAdd = useCallback(() => {
-    const path = filter.trim()
-    if (!path) return
-    if (!path.startsWith('/') && !path.startsWith('~/')) {
-      setManualError('Path must be absolute (start with / or ~/)')
+  const handleManualAdd = useCallback(async () => {
+    const path = pathDraft.trim()
+    if (!path) {
+      setPathError('Enter an absolute local path.')
       return
     }
-    setManualError('')
-    addProject({ paths: [path] })
-    setFilter('')
-  }, [filter])
+    if (!path.startsWith('/') && !path.startsWith('~/')) {
+      setPathError('Path must be absolute, starting with / or ~/.')
+      return
+    }
 
-  const handleFilterKeyDown = useCallback((e: KeyboardEvent) => {
-    if (e.key === 'Enter' && filterIsPath) handleManualAdd()
-  }, [filterIsPath, handleManualAdd])
+    setPathError('')
+    try {
+      await addProject({ paths: [path] })
+      setPathDraft('')
+    } catch {
+      setPathError('Could not add that local path.')
+    }
+  }, [pathDraft])
+
+  const handlePathKeyDown = useCallback((e: KeyboardEvent) => {
+    if (e.key === 'Enter') handleManualAdd()
+  }, [handleManualAdd])
 
   if (!open) return null
 
@@ -219,7 +229,7 @@ export function ManageProjectsModal({
               </div>
             ) : (
               <div class="mp-empty-hint">
-                No projects yet. Add one from the list below, or type a path.
+                No projects yet. Add a discovered project below, or add a local path.
               </div>
             )}
           </section>
@@ -241,19 +251,12 @@ export function ManageProjectsModal({
             <div class="mp-filter-row">
               <input
                 class="mp-filter-input"
-                type="text"
-                placeholder="Filter or enter a path to add..."
-                value={filter}
-                onInput={(e) => { setFilter((e.target as HTMLInputElement).value); setManualError('') }}
-                onKeyDown={handleFilterKeyDown}
+                type="search"
+                placeholder="Search discovered projects..."
+                value={discoveredQuery}
+                onInput={(e) => { setDiscoveredQuery((e.target as HTMLInputElement).value) }}
               />
-              {filterIsPath && (
-                <button class="mp-manual-btn" onClick={handleManualAdd}>
-                  Add
-                </button>
-              )}
             </div>
-            {manualError && <div class="mp-manual-error">{manualError}</div>}
 
             <div class="mp-discovered-scroll">
               {activeDiscovered.length > 0 && activeDiscovered.map(d => (
@@ -262,18 +265,41 @@ export function ManageProjectsModal({
               {inactiveDiscovered.length > 0 && inactiveDiscovered.map(d => (
                 <DiscoveredRow key={d.suggested_slug} project={d} onAdd={handleAdd} />
               ))}
-              {filteredDiscovered.length === 0 && lowerFilter && !filterIsPath && (
+              {filteredDiscovered.length === 0 && lowerDiscoveredQuery && (
                 <div class="mp-empty-hint">
-                  No matches. Try a different search, or enter a path to add manually.
+                  No discovered projects match that search.
                 </div>
               )}
-              {filteredDiscovered.length === 0 && !lowerFilter && (
+              {filteredDiscovered.length === 0 && !lowerDiscoveredQuery && (
                 <div class="mp-empty-hint">
-                  No unmatched sessions. Launch some sessions and they'll appear here
-                  if they don't match a project.
+                  No unmatched sessions. Launch sessions outside your configured projects
+                  and they will appear here.
                 </div>
               )}
             </div>
+          </section>
+
+          {/* ── Manual local path add ── */}
+          <section class="mp-section mp-path-add-section">
+            <div class="mp-section-label">Add local path</div>
+            <div class="mp-path-add-row">
+              <input
+                class="mp-filter-input mp-path-input"
+                type="text"
+                placeholder="/home/me/dev/project"
+                value={pathDraft}
+                onInput={(e) => { setPathDraft((e.target as HTMLInputElement).value); setPathError('') }}
+                onKeyDown={handlePathKeyDown}
+              />
+              <button class="mp-manual-btn" onClick={handleManualAdd} disabled={pathDraft.trim() === ''}>
+                Add
+              </button>
+            </div>
+            {pathError ? (
+              <div class="mp-manual-error">{pathError}</div>
+            ) : (
+              <div class="mp-path-hint">Adds a local project by absolute path. Remote hosts are not affected.</div>
+            )}
           </section>
         </div>
       </div>

--- a/apps/gmux-web/src/store.test.ts
+++ b/apps/gmux-web/src/store.test.ts
@@ -7,6 +7,7 @@ import {
   isSessionUnavailable, urlPath, selectedId,
   navigateToSession, setNavigate,
   applyPending, _rawSessions, _rawWorld, _setRawWorld, _pendingMutations,
+  toUISession,
 } from './store'
 import type { PendingMutation } from './store'
 import type { Session } from './types'
@@ -41,6 +42,51 @@ beforeEach(() => {
   _pendingMutations.value = []
   sessionsLoaded.value = false
   urlPath.value = '/'
+})
+
+// Pin the protocol-to-UI translation for stamp fields. Stamps are
+// the sole authority for sidebar bucketing under the references
+// model; if toUISession silently drops them (as it did between PR
+// #191 landing and this fix), every session becomes invisible
+// regardless of project configuration.
+describe('toUISession project stamp passthrough', () => {
+  it('preserves project_slug and project_index from the wire', () => {
+    const ui = toUISession({
+      id: 'sess-1', alive: true,
+      project_slug: 'gmux', project_index: 3,
+    } as any)
+    expect(ui.project_slug).toBe('gmux')
+    expect(ui.project_index).toBe(3)
+  })
+
+  it('preserves project_index: 0 (falsy but valid first position)', () => {
+    // 0 is the most common value (first session in a project) and is
+    // falsy in JS. Guards against future ||-coercion regressions on
+    // this field.
+    const ui = toUISession({
+      id: 'sess-1', alive: true,
+      project_slug: 'gmux', project_index: 0,
+    } as any)
+    expect(ui.project_index).toBe(0)
+  })
+
+  it('leaves stamps undefined when the wire omits them', () => {
+    const ui = toUISession({
+      id: 'sess-1', alive: true,
+    } as any)
+    expect(ui.project_slug).toBeUndefined()
+  })
+
+  it('treats empty-string project_slug as unstamped', () => {
+    // Go's omitempty drops empty strings, but legacy / dev paths may
+    // emit them. buildProjectFolders treats an empty stamp the same
+    // as no stamp; normalize at the boundary so consumers never
+    // see the difference.
+    const ui = toUISession({
+      id: 'sess-1', alive: true, project_slug: '',
+    } as any)
+    expect(ui.project_slug).toBeUndefined()
+  })
 })
 
 describe('upsertSession', () => {

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -486,6 +486,12 @@ export function toUISession(s: ProtocolSession): Session {
     runner_version: s.runner_version ?? undefined,
     binary_hash: s.binary_hash ?? undefined,
     peer: s.peer ?? undefined,
+    // Stamps from the session's origin host. Drive sidebar bucketing
+    // under the references model: a session that arrives without
+    // these is invisible (no folder claims it), so this passthrough
+    // is load-bearing rather than incidental.
+    project_slug: s.project_slug || undefined,
+    project_index: s.project_index,
   }
 }
 

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -943,7 +943,7 @@ body {
   line-height: 1.5;
 }
 
-/* Filter/add input at top of discovered section */
+/* Search input at top of discovered section */
 .mp-filter-row {
   display: flex;
   gap: 8px;
@@ -1048,16 +1048,43 @@ body {
   transition: border-color 0.15s, color 0.15s;
 }
 
-.mp-manual-btn:hover {
+.mp-manual-btn:hover:not(:disabled) {
   border-color: var(--accent);
   color: var(--accent);
+}
+
+.mp-manual-btn:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
+.mp-path-add-section {
+  padding-bottom: 2px;
+}
+
+.mp-path-add-row {
+  display: flex;
+  gap: 8px;
+}
+
+.mp-path-input {
+  font-size: 11.5px;
+}
+
+.mp-path-hint {
+  font-size: 11.5px;
+  color: var(--text-muted);
+  opacity: 0.75;
+  margin-top: 5px;
+  padding-left: 2px;
+  line-height: 1.4;
 }
 
 .mp-manual-error {
   font-size: 12px;
   color: var(--status-error);
-  margin-top: -4px;
-  margin-bottom: 4px;
+  margin-top: 5px;
+  margin-bottom: 0;
   padding-left: 2px;
 }
 

--- a/apps/website/src/content/docs/reference/projects-json.md
+++ b/apps/website/src/content/docs/reference/projects-json.md
@@ -95,15 +95,9 @@ By default, path rules match subdirectories. Set `exact: true` to match only the
 
 This matches sessions started from `$HOME` itself, but not `~/dev/gmux` or any other subdirectory. The default "home" project uses this to avoid catching every session.
 
-### Host scoping
+### Host ownership
 
-Rules can be restricted to sessions from specific [peer hosts](/multi-machine):
-
-```json
-{ "path": "/data/ml", "hosts": ["gpu-server"] }
-```
-
-This rule only applies to sessions running on the peer named `gpu-server`. Local sessions and sessions from other peers are not affected. Rules without `hosts` match sessions from any host.
+Match rules are local to the host that owns the project. Network peer projects are represented as reference items with `peer`; their match rules and session order live in that peer's own `projects.json`. The old `hosts` match-rule field is ignored by current gmuxd versions and is dropped the next time the file is saved.
 
 ## Match precedence
 

--- a/apps/website/src/content/docs/using-the-ui.md
+++ b/apps/website/src/content/docs/using-the-ui.md
@@ -58,7 +58,7 @@ Each session has a dot on the left edge:
 
 Agent sessions (pi, Claude, Codex) only trigger the blue unread dot when the assistant completes a turn, not on every line of output.
 
-Hover over a session to reveal the **×** button. For live sessions this kills the process; if the adapter supports resume, the session moves to the **Resume previous** drawer at the bottom of the sidebar. Exited sessions that aren't resumable can be dismissed with ×.
+Hover over a session to reveal the **×** button. This dismisses the session: live runners are killed, the sidebar/project membership is removed, and persisted runtime metadata is dropped so the session does not come back as resumable. Use **Resume** from a dead session view only when you want to continue it.
 
 ## Project hub
 
@@ -81,7 +81,7 @@ Within each host, sessions are grouped by their working directory. Each folder r
 
 ### Session cards
 
-Each card shows a status dot and the session title. Click a card to attach to that session's terminal. The **×** button kills alive sessions or dismisses dead ones.
+Each card shows a status dot and the session title. Click a card to attach to that session's terminal. The **×** button dismisses the session, killing it first if it is still alive.
 
 ### Empty projects
 

--- a/docs/adr/0005-references-and-local-peer-exception.md
+++ b/docs/adr/0005-references-and-local-peer-exception.md
@@ -133,15 +133,16 @@ sessions.Reconcile(func(s store.Session) (string, int) {
 })
 ```
 
-### Resumable sessions get stamped
+### Resumable sessions preserve existing membership only
 
-Auto-assign (per-event and startup-sweep) covers alive *and*
-resumable sessions, not just alive. Without this, a session that
-dies before the per-event subscriber processes it (fast-exiting
-commands, attribution-stage crashes) would never enter
-`Sessions[]`, never get a stamp, and stay invisible in the sidebar
-after a daemon restart. This was a direct consequence of stamps
-becoming the sole authority for sidebar visibility.
+Auto-assign (per-event and startup-sweep) covers live sessions only.
+Dead/resumable runtime state lives in sessionmeta, while sidebar
+membership lives in `projects.json`. If `Sessions[]` already contains
+a dead session's key, reconcile can still stamp it and keep it visible;
+if dismiss removed the key, a late exit event or startup sweep must not
+add it back as resumable. This keeps stamps as the sole authority for
+rendering without letting runtime discovery override explicit sidebar
+membership.
 
 ## Consequences
 

--- a/packages/protocol/src/session.ts
+++ b/packages/protocol/src/session.ts
@@ -33,6 +33,12 @@ export const SessionSchema = z.object({
   slug: z.string().optional(),
   runner_version: z.string().optional(),
   binary_hash: z.string().optional(),
+  // Project assignment stamps populated by the session's origin host.
+  // Drive sidebar bucketing (ADR 0002): a session is rendered under
+  // (peer, project_slug) iff project_slug is non-empty. project_index
+  // is the session's authoritative position inside that project.
+  project_slug: z.string().optional(),
+  project_index: z.number().int().nonnegative().optional(),
 })
 
 export const AttachResponseSchema = z.object({

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -24,20 +24,20 @@ import (
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/authtoken"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/binhash"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/clipfile"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/coalesce"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/config"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/conversations"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/devcontainers"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/discovery"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/netauth"
-	"github.com/gmuxapp/gmux/services/gmuxd/internal/coalesce"
-	"github.com/gmuxapp/gmux/services/gmuxd/internal/conversations"
-	"github.com/gmuxapp/gmux/services/gmuxd/internal/peering"
-	"github.com/gmuxapp/gmux/services/gmuxd/internal/projects"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/notify"
-	"github.com/gmuxapp/gmux/services/gmuxd/internal/snapshot"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/peering"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/presence"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/projects"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/sessionfiles"
-	"github.com/gmuxapp/gmux/services/gmuxd/internal/sleep"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/sessionmeta"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/sleep"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/snapshot"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/store"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/tsauth"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/tsdiscovery"
@@ -225,8 +225,6 @@ Tip:
   More help: https://gmux.app
 `, version)
 }
-
-
 
 func run(args []string, stdout, stderr io.Writer) int {
 	if len(args) == 0 {
@@ -596,12 +594,10 @@ func serve(stderr io.Writer) int {
 	// rehydrateProjects for the identity-model rationale.
 	if state, err := projectMgr.Load(); err == nil {
 		rehydrateProjects(sessions, convIndex, state)
-		// Sweep resumable sessions into project.sessions[] arrays.
-		// The auto-assign subscriber only fires on session-upsert events,
-		// which arrive after this point; without this pass, a dead-but-
-		// resumable session loaded from sessionmeta would never be added
-		// to its matching project and would be invisible in the sidebar
-		// (the visibility filter requires a stamp).
+		// Sweep live sessions into project.sessions[] arrays. Dead/resumable
+		// sessions loaded from sessionmeta are stamped only when projects.json
+		// already contains their key; dismiss removes that membership, and a
+		// late exit/resume-command upsert must not recreate it.
 		projectMgr.AutoAssignAll(buildSessionInfos(sessions, func(name string) bool { return peerManager != nil && peerManager.IsLocalPeer(name) }))
 		// Stamp ProjectSlug / ProjectIndex on the just-rehydrated sessions
 		// (and on any sessions previously loaded via sessionmeta.Sweep)
@@ -644,12 +640,10 @@ func serve(stderr io.Writer) int {
 				continue
 			}
 			s := ev.Session
-			// Auto-assign live and resumable sessions. A dead session
-			// with a resume command is just as worth stamping as a live
-			// one; the user can still resume it, and without this stamp
-			// the session would be invisible in the sidebar after a
-			// daemon restart.
-			if !s.Alive && !s.Resumable {
+			// Auto-assign live sessions only. Dead/resumable runtime state
+			// belongs to sessionmeta; sidebar membership belongs to projects.json.
+			// If dismiss removed the key, a late exit upsert must not add it back.
+			if !s.Alive {
 				continue
 			}
 			projectMgr.AutoAssignSession(projects.SessionInfo{
@@ -759,7 +753,6 @@ func serve(stderr io.Writer) int {
 			},
 		})
 	})
-
 
 	// Frontend config (read from disk on each request so users can edit
 	// and refresh without restarting gmuxd).
@@ -2359,5 +2352,3 @@ func writeError(w http.ResponseWriter, status int, code, message string) {
 		"error": map[string]any{"code": code, "message": message},
 	})
 }
-
-

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -2103,6 +2103,9 @@ func composePeerProjects(mgr *peering.Manager) map[string][]peering.SpokeProject
 	}
 	out := make(map[string][]peering.SpokeProject, len(infos))
 	for _, info := range infos {
+		if info.Local {
+			continue
+		}
 		p := mgr.GetPeer(info.Name)
 		if p == nil {
 			continue

--- a/services/gmuxd/cmd/gmuxd/main_test.go
+++ b/services/gmuxd/cmd/gmuxd/main_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -12,6 +13,8 @@ import (
 	"time"
 
 	"github.com/gmuxapp/gmux/packages/adapter"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/config"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/peering"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/store"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/unixipc"
 )
@@ -25,7 +28,7 @@ func (a discoverTestAdapter) Name() string                      { return a.name 
 func (a discoverTestAdapter) Discover() bool                    { return a.available }
 func (a discoverTestAdapter) Match(_ []string) bool             { return false }
 func (a discoverTestAdapter) Env(_ adapter.EnvContext) []string { return nil }
-func (a discoverTestAdapter) Monitor(_ []byte) *adapter.Event { return nil }
+func (a discoverTestAdapter) Monitor(_ []byte) *adapter.Event   { return nil }
 func (a discoverTestAdapter) Launchers() []adapter.Launcher {
 	return []adapter.Launcher{{ID: a.name, Label: a.name}}
 }
@@ -471,6 +474,70 @@ func TestSnapshotPumpRoute(t *testing.T) {
 					tc.eventType, gotSessions, gotWorld, tc.wantSessions, tc.wantWorld)
 			}
 		})
+	}
+}
+
+func TestComposePeerProjectsSkipsLocalPeers(t *testing.T) {
+	spoke := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/events":
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = w.Write([]byte("event: snapshot.sessions\ndata: {\"sessions\":[]}\n\n"))
+			if f, ok := w.(http.Flusher); ok {
+				f.Flush()
+			}
+			<-r.Context().Done()
+		case "/v1/health":
+			_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "data": map[string]any{"version": "test"}})
+		case "/v1/projects":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"ok": true,
+				"data": map[string]any{
+					"configured": []map[string]any{{
+						"slug":  "gmux",
+						"match": []map[string]any{{"path": "/work/gmux"}},
+					}},
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer spoke.Close()
+
+	mgr := peering.NewManager([]config.PeerConfig{
+		{Name: "tower", URL: spoke.URL},
+		{Name: "devcontainer", URL: spoke.URL, Local: true},
+	}, store.New(), "test-host")
+	mgr.Start()
+	defer mgr.Stop()
+
+	waitForCachedProjects := func(name string) {
+		t.Helper()
+		deadline := time.Now().Add(2 * time.Second)
+		for time.Now().Before(deadline) {
+			if p := mgr.GetPeer(name); p != nil {
+				if _, ok := p.CachedProjects(); ok {
+					return
+				}
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+		t.Fatalf("timed out waiting for %s project cache", name)
+	}
+	waitForCachedProjects("tower")
+	waitForCachedProjects("devcontainer")
+
+	got := composePeerProjects(mgr)
+	if _, ok := got["devcontainer"]; ok {
+		t.Fatalf("composePeerProjects included Local peer: %#v", got)
+	}
+	projects, ok := got["tower"]
+	if !ok {
+		t.Fatalf("composePeerProjects missing network peer: %#v", got)
+	}
+	if len(projects) != 1 || projects[0].Slug != "gmux" || projects[0].LaunchCwd != "/work/gmux" {
+		t.Fatalf("tower projects = %#v, want gmux with launch cwd", projects)
 	}
 }
 

--- a/services/gmuxd/internal/discovery/subscribe.go
+++ b/services/gmuxd/internal/discovery/subscribe.go
@@ -266,7 +266,9 @@ func (sub *Subscriptions) handleEvent(sessionID, socketPath, eventType string, d
 			log.Printf("subscribe: %s: bad exit event: %v", sessionID, err)
 			return
 		}
-		// Read the session for the OnExit hook which needs the full session.
+		// Read the session for the OnExit hook, then write it back only if
+		// it still exists. A dismissed session has already been removed, so
+		// a late runner exit event must not re-upsert it as dead/resumable.
 		sess, ok := sub.store.Get(sessionID)
 		if !ok {
 			return
@@ -275,20 +277,24 @@ func (sub *Subscriptions) handleEvent(sessionID, socketPath, eventType string, d
 		sess.ExitCode = &exit.ExitCode
 		sess.ExitedAt = time.Now().UTC().Format(time.RFC3339)
 		// Let the OnExit hook set the resume command before upsert.
-		// If it returns true, the session transitioned to resumable —
-		// don't overwrite with exit status.
+		// If it returns true, the session transitioned to resumable,
+		// so don't overwrite with exit status.
 		resumed := false
 		if sub.OnExit != nil {
 			resumed = sub.OnExit(&sess)
 		}
 		if !resumed {
 			if exit.ExitCode == 0 {
-				sess.Status = nil // clean exit — no label needed
+				sess.Status = nil // clean exit, no label needed
 			} else {
 				sess.Status = &store.Status{Label: fmt.Sprintf("exited (%d)", exit.ExitCode)}
 			}
 		}
-		sub.store.Upsert(sess)
+		if !sub.store.Update(sessionID, func(current *store.Session) {
+			*current = sess
+		}) {
+			return
+		}
 		if sub.OnDead != nil {
 			sub.OnDead(sess)
 		}

--- a/services/gmuxd/internal/discovery/subscribe_test.go
+++ b/services/gmuxd/internal/discovery/subscribe_test.go
@@ -187,3 +187,51 @@ func TestSubscribeOldDeferDoesNotEvictNewEntry(t *testing.T) {
 		t.Error("Unsubscribe failed to clear the second subscription's entry")
 	}
 }
+
+func TestExitEventDoesNotResurrectDismissedSession(t *testing.T) {
+	const id = "sess-dismissed-exit-race"
+	sessions := store.New()
+	sessions.Upsert(store.Session{
+		ID:      id,
+		Kind:    "shell",
+		Alive:   true,
+		Command: []string{"bash"},
+	})
+
+	subs := NewSubscriptions(sessions)
+	onExitStarted := make(chan struct{})
+	allowOnExit := make(chan struct{})
+	subs.OnExit = func(sess *store.Session) bool {
+		close(onExitStarted)
+		<-allowOnExit
+		sess.Command = []string{"bash", "-l"}
+		return true
+	}
+
+	exitDone := make(chan struct{})
+	go func() {
+		subs.handleEvent(id, "", "exit", []byte(`{"exit_code":0}`))
+		close(exitDone)
+	}()
+
+	select {
+	case <-onExitStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("OnExit hook was not called")
+	}
+
+	// Dismiss while exit handling is deriving the resume command. The final
+	// write must notice that the session is gone instead of recreating it.
+	sessions.Remove(id)
+	close(allowOnExit)
+
+	select {
+	case <-exitDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("exit handling did not complete")
+	}
+
+	if got, ok := sessions.Get(id); ok {
+		t.Fatalf("dismissed session was resurrected by late exit event: %+v", got)
+	}
+}

--- a/services/gmuxd/internal/projects/manager.go
+++ b/services/gmuxd/internal/projects/manager.go
@@ -77,11 +77,15 @@ func (m *Manager) Update(fn func(s *State) bool) error {
 	return nil
 }
 
-// AutoAssignSession checks if a session matches a project and adds it
+// AutoAssignSession checks if a live session matches a project and adds it
 // to that project's sessions list. Returns the project slug if assigned.
 // This is called when:
 //   - A new session is discovered (Register)
 //   - A session gets a Slug (file attribution)
+//
+// Dead/resumable sessions are not auto-assigned. projects.json is the
+// source of truth for sidebar membership; if dismiss removed a session key,
+// a late exit/resume-command upsert must not add it back.
 //
 // Network-peer sessions (info.Host set, info.LocalHost false) are never
 // written to the local projects.json: project membership for them is
@@ -90,7 +94,7 @@ func (m *Manager) Update(fn func(s *State) bool) error {
 // owns their assignment per the ADR 0002 amendment, so they flow
 // through here like local sessions.
 func (m *Manager) AutoAssignSession(info SessionInfo) string {
-	if info.Host != "" && !info.LocalHost {
+	if !info.Alive || (info.Host != "" && !info.LocalHost) {
 		return ""
 	}
 	var assigned string
@@ -140,14 +144,15 @@ func (m *Manager) AutoAssignSession(info SessionInfo) string {
 	return assigned
 }
 
-// AutoAssignAll iterates all sessions and adds alive-or-resumable
-// ones to their matching projects in a single atomic update. Called
-// after adding a project so that existing sessions populate the array
-// immediately rather than waiting for the next session-upsert event,
-// and at startup so resumable sessions loaded from sessionmeta get
-// stamped before the first snapshot goes out (otherwise dead-but-
-// resumable sessions miss the auto-assign hook, which only fires on
-// session-upsert events for live sessions).
+// AutoAssignAll iterates all live sessions and adds them to their matching
+// projects in a single atomic update. Called after adding a project so that
+// existing live sessions populate the array immediately rather than waiting
+// for the next session-upsert event.
+//
+// Dead/resumable sessions are skipped: sessionmeta owns their runtime state,
+// but projects.json owns sidebar membership. If a key is already present in
+// projects.json, reconciliation can still stamp the dead session; auto-assign
+// just must not create new membership for dead sessions.
 //
 // Network-peer sessions are skipped; Local-peer sessions flow through
 // because the parent owns their assignment. See AutoAssignSession.
@@ -155,7 +160,7 @@ func (m *Manager) AutoAssignAll(sessions []SessionInfo) {
 	err := m.Update(func(state *State) bool {
 		changed := false
 		for _, info := range sessions {
-			if !info.Alive && !info.Resumable {
+			if !info.Alive {
 				continue
 			}
 			if info.Host != "" && !info.LocalHost {

--- a/services/gmuxd/internal/projects/projects.go
+++ b/services/gmuxd/internal/projects/projects.go
@@ -1,8 +1,8 @@
 // Package projects manages the user-curated project list that controls
 // which sessions appear in the sidebar.
 //
-// Each project has a list of match rules (remote URLs, filesystem paths,
-// optionally scoped to specific hosts). A session matches a project if
+// Each owned project has a list of match rules (remote URLs or filesystem
+// paths). A session matches a project if
 // any rule matches. First matching project in list order wins; among
 // path rules, longest prefix wins. State is persisted to
 // projects.json in the state directory.

--- a/services/gmuxd/internal/projects/projects_test.go
+++ b/services/gmuxd/internal/projects/projects_test.go
@@ -800,7 +800,7 @@ func TestManagerAutoAssign(t *testing.T) {
 	slug := mgr.AutoAssignSession(SessionInfo{
 		ID: "sess-1", Cwd: "/dev/gmux/src", WorkspaceRoot: "/dev/gmux",
 		Remotes: map[string]string{"origin": "github.com/gmuxapp/gmux"},
-		Alive: true,
+		Alive:   true,
 	})
 	if slug != "gmux" {
 		t.Errorf("expected 'gmux', got %q", slug)
@@ -905,6 +905,30 @@ func TestManagerUnmatchedNotAutoAssigned(t *testing.T) {
 	}
 }
 
+func TestManagerDeadResumableNotAutoAssigned(t *testing.T) {
+	dir := t.TempDir()
+	mgr := NewManager(dir)
+
+	mgr.Update(func(s *State) bool {
+		s.Items = []Item{
+			{Slug: "gmux", Match: []MatchRule{{Path: "/dev/gmux"}}},
+		}
+		return true
+	})
+
+	assigned := mgr.AutoAssignSession(SessionInfo{
+		ID: "sess-1", Cwd: "/dev/gmux", Alive: false, Resumable: true, Slug: "fix-sidebar",
+	})
+	if assigned != "" {
+		t.Fatalf("dead/resumable session should not be auto-assigned, got %q", assigned)
+	}
+
+	state, _ := mgr.Load()
+	if len(state.Items[0].Sessions) != 0 {
+		t.Fatalf("dead/resumable session was added back to sidebar membership: %v", state.Items[0].Sessions)
+	}
+}
+
 // --- UnmatchedActiveCount ---
 
 func TestUnmatchedActiveCount(t *testing.T) {
@@ -912,11 +936,11 @@ func TestUnmatchedActiveCount(t *testing.T) {
 		{Slug: "gmux", Match: []MatchRule{{Path: "/dev/gmux"}}, Sessions: []string{"s1"}},
 	}}
 	sessions := []SessionInfo{
-		{ID: "s1", Cwd: "/dev/gmux", Alive: true},       // matched + in array
+		{ID: "s1", Cwd: "/dev/gmux", Alive: true},        // matched + in array
 		{ID: "s2", Cwd: "/dev/gmux", Alive: true},        // matched but not in array
-		{ID: "s3", Cwd: "/somewhere/else", Alive: true},   // unmatched + alive
-		{ID: "s4", Cwd: "/somewhere/else", Alive: false},  // unmatched + dead
-		{ID: "s5", Cwd: "/another/place", Alive: true},    // unmatched + alive
+		{ID: "s3", Cwd: "/somewhere/else", Alive: true},  // unmatched + alive
+		{ID: "s4", Cwd: "/somewhere/else", Alive: false}, // unmatched + dead
+		{ID: "s5", Cwd: "/another/place", Alive: true},   // unmatched + alive
 	}
 	count := s.UnmatchedActiveCount(sessions)
 	// s3 and s5 are unmatched+alive. s2 matches gmux (not counted). s4 is dead.
@@ -1050,16 +1074,16 @@ func TestManagerAutoAssignAll(t *testing.T) {
 	sessions := []SessionInfo{
 		{ID: "s1", Cwd: "/dev/gmux/src", Alive: true},
 		{ID: "s2", Cwd: "/dev/yapp", Alive: true},
-		{ID: "s3", Cwd: "/dev/gmux", Alive: false, Resumable: true}, // dead+resumable: included
+		{ID: "s3", Cwd: "/dev/gmux", Alive: false, Resumable: true}, // dead+resumable: skipped
 		{ID: "s4", Cwd: "/dev/gmux", Alive: false},                  // dead, no resume: skipped
-		{ID: "s5", Cwd: "/other", Alive: true},                       // unmatched: skipped
+		{ID: "s5", Cwd: "/other", Alive: true},                      // unmatched: skipped
 	}
 
 	mgr.AutoAssignAll(sessions)
 
 	state, _ := mgr.Load()
-	if len(state.Items[0].Sessions) != 2 || state.Items[0].Sessions[0] != "s1" || state.Items[0].Sessions[1] != "s3" {
-		t.Errorf("gmux sessions: expected [s1 s3], got %v", state.Items[0].Sessions)
+	if len(state.Items[0].Sessions) != 1 || state.Items[0].Sessions[0] != "s1" {
+		t.Errorf("gmux sessions: expected [s1], got %v", state.Items[0].Sessions)
 	}
 	if len(state.Items[1].Sessions) != 1 || state.Items[1].Sessions[0] != "s2" {
 		t.Errorf("yapp sessions: expected [s2], got %v", state.Items[1].Sessions)
@@ -1118,7 +1142,6 @@ func TestManagerAutoAssignAllSkipsPeerOwnedSessions(t *testing.T) {
 		t.Errorf("expected only local-1 assigned, got %v", state.Items[0].Sessions)
 	}
 }
-
 
 func TestNormalizePathExpandsTilde(t *testing.T) {
 	home, err := os.UserHomeDir()
@@ -1377,10 +1400,10 @@ func TestPruneNamespacedKeys(t *testing.T) {
 				Slug:  "proj",
 				Match: []MatchRule{{Path: "/x"}},
 				Sessions: []string{
-					"sess-a@container",  // should be pruned
-					"sess-b@container",  // should be pruned
-					"sess-c@develop",    // not @container; kept
-					"sess-d",            // local id; kept
+					"sess-a@container",   // should be pruned
+					"sess-b@container",   // should be pruned
+					"sess-c@develop",     // not @container; kept
+					"sess-d",             // local id; kept
 					"claude-attribution", // slug; kept (survives container restart)
 				},
 			},


### PR DESCRIPTION
## Summary

Polish follow-ups for the projects-polish stack (#227). Four atomic fixes:

1. `fix(web): wire project stamps through the protocol→UI translation` — the original PR. Sessions were invisible in the sidebar because `project_slug` / `project_index` were dropped at the protocol→UI boundary.
2. `fix(daemon): prevent dismissed sessions from resurfacing as resumable` — dismissed sessions could reappear as dead/resumable due to a race with the runner exit event, and through the auto-assign path treating dead/resumable sessions like alive ones for sidebar membership.
3. `fix(peering): omit local peers from peer project ownership` — local peers (devcontainers) were leaking into the "peer projects" composition; their assignments belong to the parent under ADR 0002.
4. `fix(web): separate project search from manual path add` — the discovered-projects search field was overloaded with "type a path to add it manually". Split into a search box and a dedicated "Add local path" footer.

## Problem (#2, the meaty one)

The user reported: clicking the **×** button on a sidebar item, the session reappeared as dead/resumable. Per `UBIQUITOUS_LANGUAGE.md` and ADR 0002, **Dismiss** means "kill if alive, remove from store, sessionmeta, and projects.json"; the session must not come back.

Two resurrection paths existed:

- **Store-level race.** The runner's exit event for the killed PTY was handled by `subscribe.handleEvent("exit")`, which read the session, ran the `OnExit` hook to derive the resume command, then **unconditionally `store.Upsert`d** the result. If dismiss removed the session between the Get and the Upsert, Upsert re-created it as `Alive=false, Resumable=true`.
- **Projects-level path.** The session-upsert subscriber and the startup sweep both called `projectMgr.AutoAssignSession` for **alive OR resumable** sessions. So even ignoring the race, any time a dead/resumable session went through an upsert (sessionmeta sweep, late exit, attribution), auto-assign added it back to `projects.json` — overriding the user's dismiss intent.

The mental model that fell out of the docs:

- `sessionmeta` is the SOT for **dead session runtime state**.
- `projects.json` is the SOT for **sidebar membership**.
- A dead/resumable session is sidebar-visible only if its key is still in `projects.json`.
- Auto-discovery / auto-assign creates sidebar membership for **live** sessions only.

## Fix (#2)

- `subscribe.handleEvent("exit")` now writes via a conditional `store.Update`. If dismiss removed the session first, `Update` returns false and we return without re-creating.
- `projects.Manager.AutoAssignSession` and `AutoAssignAll` skip sessions that are not `Alive`. Existing project membership is preserved (sessions in `projects.json` stay there; reconcile still stamps them); auto-assign no longer creates new membership for dead sessions.
- Updated `UBIQUITOUS_LANGUAGE.md`, the website docs, and ADR 0005 to reflect the corrected model.

## Tests

- `TestExitEventDoesNotResurrectDismissedSession` (subscribe): pins the dismiss-during-exit race using a blocking `OnExit` hook and a real store.
- `TestManagerDeadResumableNotAutoAssigned` (projects): pins that a dead/resumable session is not added to `projects.json`.
- `TestManagerAutoAssignAll` (projects, updated): the startup sweep no longer adds dead/resumable sessions.
- `TestComposePeerProjectsSkipsLocalPeers` (cmd/gmuxd): pins #3 against a real httptest spoke.
- `toUISession project stamp passthrough` (web, store.test.ts): covers #1, including `project_index: 0` (falsy but valid first position).

## Verification

Installed locally (`./scripts/install.sh`), dismissed the previously-resurrecting session `sess-48b3d783` (slug `what-application-can-i-use-to-remap-my-k`), confirmed it stayed gone in `/v1/sessions`, `sessionmeta` directory, and `projects.json` after several seconds.
