### PR TITLE
feat(daemon): stamp sessions with last_activity_at on noteworthy state transitions

### DIFF
--- a/apps/gmux-web/src/store.test.ts
+++ b/apps/gmux-web/src/store.test.ts
@@ -77,6 +77,22 @@ describe('toUISession project stamp passthrough', () => {
     expect(ui.project_slug).toBeUndefined()
   })
 
+  it('passes last_activity_at through from the wire', () => {
+    // The owning daemon stamps this; the UI uses it for the home
+    // dashboard's Recent section sort. Pure passthrough at the
+    // boundary; no client-side derivation.
+    const ui = toUISession({
+      id: 'sess-1', alive: true,
+      last_activity_at: '2026-01-15T08:00:00Z',
+    } as any)
+    expect(ui.last_activity_at).toBe('2026-01-15T08:00:00Z')
+  })
+
+  it('leaves last_activity_at undefined when the wire omits it', () => {
+    const ui = toUISession({ id: 'sess-1', alive: true } as any)
+    expect(ui.last_activity_at).toBeUndefined()
+  })
+
   it('treats empty-string project_slug as unstamped', () => {
     // Go's omitempty drops empty strings, but legacy / dev paths may
     // emit them. buildProjectFolders treats an empty stamp the same

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -479,6 +479,7 @@ export function toUISession(s: ProtocolSession): Session {
     status: s.status ?? null,
     unread: s.unread ?? false,
     resumable: s.resumable ?? false,
+    last_activity_at: s.last_activity_at ?? undefined,
     socket_path: s.socket_path ?? '',
     terminal_cols: s.terminal_cols ?? undefined,
     terminal_rows: s.terminal_rows ?? undefined,

--- a/apps/gmux-web/src/types.ts
+++ b/apps/gmux-web/src/types.ts
@@ -28,6 +28,14 @@ export interface Session {
   status: SessionStatus | null
   unread: boolean
   resumable?: boolean
+  /**
+   * RFC3339 timestamp of the session's most recent noteworthy state
+   * transition (exited / unread on / working on / error on). Set by
+   * the owning daemon. Drives the home dashboard's "Recent" section
+   * and acts as a stable sort key for activity-ordered views.
+   * Unset for brand-new sessions until their first transition.
+   */
+  last_activity_at?: string
   socket_path: string
   terminal_cols?: number
   terminal_rows?: number

--- a/packages/protocol/src/session.ts
+++ b/packages/protocol/src/session.ts
@@ -27,6 +27,13 @@ export const SessionSchema = z.object({
   status: SessionStatusSchema.optional().nullable(),
   unread: z.boolean().optional().default(false),
   resumable: z.boolean().optional().default(false),
+  // RFC3339 timestamp of the most recent noteworthy state transition
+  // (exited, unread on, working on, error on). Set by the owning
+  // daemon; the UI uses it to populate the "Recent" section on the
+  // home dashboard and as a sort key. Brand-new sessions arrive with
+  // this unset; the first follow-up transition stamps it. See the
+  // store.Session docstring on LastActivityAt for the exact bump set.
+  last_activity_at: z.string().optional(),
   socket_path: z.string().optional(),
   terminal_cols: z.number().int().positive().optional(),
   terminal_rows: z.number().int().positive().optional(),

--- a/services/gmuxd/internal/sessionmeta/sessionmeta_test.go
+++ b/services/gmuxd/internal/sessionmeta/sessionmeta_test.go
@@ -101,6 +101,7 @@ func TestRoundTripFullSession(t *testing.T) {
 		BinaryHash:    "abc123",
 		ShellTitle:    "shell-title",
 		AdapterTitle:  "adapter-title",
+		LastActivityAt: "2026-04-26T10:04:30Z",
 	}
 
 	if err := s.Write(in); err != nil {

--- a/services/gmuxd/internal/store/store.go
+++ b/services/gmuxd/internal/store/store.go
@@ -34,6 +34,25 @@ type Session struct {
 	Subtitle      string            `json:"subtitle,omitempty"`
 	Status        *Status           `json:"status"`
 	Unread        bool              `json:"unread"`
+
+	// LastActivityAt timestamps the most recent noteworthy state
+	// transition for this session, used by the UI to surface
+	// recently-relevant sessions (the home dashboard's "Recent"
+	// section, sort keys, etc.). RFC3339, set by the owning daemon.
+	//
+	// Bumped on (and only on):
+	//   - alive: true → false  (the session exited)
+	//   - unread: false → true  (new output the user hasn't seen)
+	//   - status.working: false → true  (adapter started a task)
+	//   - status.error: false → true  (status went into error)
+	//
+	// Not bumped on: new session creation (the first follow-up
+	// transition does it), title/cwd/slug/stamp changes, status
+	// label-only updates, sessionmeta rehydrate at startup.
+	//
+	// Peer sessions arrive over the wire with this already set by
+	// the owning daemon; UpsertRemote preserves it as-received.
+	LastActivityAt string `json:"last_activity_at,omitempty"`
 	Resumable     bool              `json:"resumable,omitempty"`
 	SocketPath    string            `json:"socket_path,omitempty"`
 	TerminalCols  uint16            `json:"terminal_cols,omitempty"`
@@ -228,7 +247,7 @@ func (s *Store) resolveTitle(sess Session) string {
 func (s *Store) Upsert(sess Session) {
 	sess.Title = s.resolveTitle(sess)
 	sess.Resumable = !sess.Alive && len(sess.Command) > 0
-	s.upsertCommon(sess)
+	s.upsertCommon(sess, true)
 }
 
 // UpsertRemote writes a session that was already fully resolved by a
@@ -243,14 +262,31 @@ func (s *Store) Upsert(sess Session) {
 // numbering, and event broadcast all still run; only the title and
 // resumable derivation are skipped.
 func (s *Store) UpsertRemote(sess Session) {
-	s.upsertCommon(sess)
+	s.upsertCommon(sess, false)
 }
 
 // upsertCommon is the shared body of Upsert and UpsertRemote.
-func (s *Store) upsertCommon(sess Session) {
+// bumpLocally controls whether LastActivityAt is recomputed from
+// the prev→next transition: true for locally-owned sessions, false
+// for peer payloads (where the owning daemon already stamped it).
+func (s *Store) upsertCommon(sess Session, bumpLocally bool) {
 	sess.Cwd = paths.CanonicalizePath(sess.Cwd)
 	sess.WorkspaceRoot = paths.CanonicalizePath(sess.WorkspaceRoot)
 	s.mu.Lock()
+	if bumpLocally {
+		prev, hadPrev := s.sessions[sess.ID]
+		if shouldBumpActivity(prev, hadPrev, sess) {
+			sess.LastActivityAt = nowRFC3339()
+		} else if hadPrev && sess.LastActivityAt == "" {
+			// Preserve the previously stamped timestamp across
+			// no-bump Upserts. Adapters call Upsert with fresh
+			// Session structs built from runner state, which never
+			// includes LastActivityAt; without this carry-forward,
+			// a routine title/cwd refresh would silently zero out
+			// the field and drop the session from Recent.
+			sess.LastActivityAt = prev.LastActivityAt
+		}
+	}
 	removed, skip := s.resolveDuplicateSlugsLocked(sess)
 	if !skip {
 		s.ensureUniqueSlug(&sess)
@@ -277,16 +313,20 @@ func (s *Store) upsertCommon(sess Session) {
 // Returns false if the session doesn't exist.
 func (s *Store) Update(id string, fn func(*Session)) bool {
 	s.mu.Lock()
-	sess, ok := s.sessions[id]
+	prev, ok := s.sessions[id]
 	if !ok {
 		s.mu.Unlock()
 		return false
 	}
+	sess := prev
 	fn(&sess)
 	sess.Cwd = paths.CanonicalizePath(sess.Cwd)
 	sess.WorkspaceRoot = paths.CanonicalizePath(sess.WorkspaceRoot)
 	sess.Title = s.resolveTitle(sess)
 	sess.Resumable = !sess.Alive && len(sess.Command) > 0
+	if shouldBumpActivity(prev, true, sess) {
+		sess.LastActivityAt = nowRFC3339()
+	}
 	removed, skip := s.resolveDuplicateSlugsLocked(sess)
 	if !skip {
 		s.ensureUniqueSlug(&sess)
@@ -511,3 +551,33 @@ func (s *Store) ensureUniqueSlug(sess *Session) {
 	}
 }
 
+
+// shouldBumpActivity reports whether the prev→next session transition
+// is noteworthy enough to refresh LastActivityAt. See the field's
+// docstring for the exact bump set. Brand-new sessions (hadPrev=false)
+// never bump: their first follow-up transition does, which avoids
+// timestamping every sessionmeta-rehydrated dead session at daemon
+// startup.
+func shouldBumpActivity(prev Session, hadPrev bool, next Session) bool {
+	if !hadPrev {
+		return false
+	}
+	if prev.Alive && !next.Alive {
+		return true
+	}
+	if !prev.Unread && next.Unread {
+		return true
+	}
+	if !statusWorking(prev.Status) && statusWorking(next.Status) {
+		return true
+	}
+	if !statusError(prev.Status) && statusError(next.Status) {
+		return true
+	}
+	return false
+}
+
+func statusWorking(s *Status) bool { return s != nil && s.Working }
+func statusError(s *Status) bool   { return s != nil && s.Error }
+
+func nowRFC3339() string { return time.Now().UTC().Format(time.RFC3339) }

--- a/services/gmuxd/internal/store/store.go
+++ b/services/gmuxd/internal/store/store.go
@@ -133,6 +133,7 @@ func (s Session) MarshalJSON() ([]byte, error) {
 		BinaryHash    string            `json:"binary_hash,omitempty"`
 		ProjectSlug   string            `json:"project_slug,omitempty"`
 		ProjectIndex  int               `json:"project_index,omitempty"`
+		LastActivityAt string           `json:"last_activity_at,omitempty"`
 	}
 	return json.Marshal(wire{
 		ID: s.ID, Peer: s.Peer, CreatedAt: s.CreatedAt, Command: s.Command,
@@ -145,6 +146,7 @@ func (s Session) MarshalJSON() ([]byte, error) {
 		TerminalRows: s.TerminalRows, Slug: s.Slug,
 		RunnerVersion: s.RunnerVersion, BinaryHash: s.BinaryHash,
 		ProjectSlug: s.ProjectSlug, ProjectIndex: s.ProjectIndex,
+		LastActivityAt: s.LastActivityAt,
 	})
 }
 
@@ -275,7 +277,7 @@ func (s *Store) upsertCommon(sess Session, bumpLocally bool) {
 	s.mu.Lock()
 	if bumpLocally {
 		prev, hadPrev := s.sessions[sess.ID]
-		if shouldBumpActivity(prev, hadPrev, sess) {
+		if shouldBumpActivity(snapshotActivity(prev), hadPrev, snapshotActivity(sess)) {
 			sess.LastActivityAt = nowRFC3339()
 		} else if hadPrev && sess.LastActivityAt == "" {
 			// Preserve the previously stamped timestamp across
@@ -318,13 +320,14 @@ func (s *Store) Update(id string, fn func(*Session)) bool {
 		s.mu.Unlock()
 		return false
 	}
+	prevSnap := snapshotActivity(prev)
 	sess := prev
 	fn(&sess)
 	sess.Cwd = paths.CanonicalizePath(sess.Cwd)
 	sess.WorkspaceRoot = paths.CanonicalizePath(sess.WorkspaceRoot)
 	sess.Title = s.resolveTitle(sess)
 	sess.Resumable = !sess.Alive && len(sess.Command) > 0
-	if shouldBumpActivity(prev, true, sess) {
+	if shouldBumpActivity(prevSnap, true, snapshotActivity(sess)) {
 		sess.LastActivityAt = nowRFC3339()
 	}
 	removed, skip := s.resolveDuplicateSlugsLocked(sess)
@@ -552,32 +555,52 @@ func (s *Store) ensureUniqueSlug(sess *Session) {
 }
 
 
+// activitySnapshot captures the four scalar bits that determine
+// whether a session transition bumps LastActivityAt. Snapshotting
+// upfront (rather than dereferencing Session.Status during the
+// comparison) is load-bearing: Update callers do `sess := prev`
+// before running their mutator, which shallow-copies the Session
+// but leaves prev.Status and sess.Status pointing at the same
+// Status struct. A mutator that writes through that pointer
+// (e.g. `sess.Status.Working = true`) would silently mutate prev
+// too, hiding the transition from the bump check. Capturing the
+// booleans before fn runs sidesteps the aliasing entirely.
+type activitySnapshot struct {
+	alive, unread, working, errored bool
+}
+
+func snapshotActivity(s Session) activitySnapshot {
+	return activitySnapshot{
+		alive:   s.Alive,
+		unread:  s.Unread,
+		working: s.Status != nil && s.Status.Working,
+		errored: s.Status != nil && s.Status.Error,
+	}
+}
+
 // shouldBumpActivity reports whether the prev→next session transition
 // is noteworthy enough to refresh LastActivityAt. See the field's
 // docstring for the exact bump set. Brand-new sessions (hadPrev=false)
 // never bump: their first follow-up transition does, which avoids
 // timestamping every sessionmeta-rehydrated dead session at daemon
 // startup.
-func shouldBumpActivity(prev Session, hadPrev bool, next Session) bool {
+func shouldBumpActivity(prev activitySnapshot, hadPrev bool, next activitySnapshot) bool {
 	if !hadPrev {
 		return false
 	}
-	if prev.Alive && !next.Alive {
+	if prev.alive && !next.alive {
 		return true
 	}
-	if !prev.Unread && next.Unread {
+	if !prev.unread && next.unread {
 		return true
 	}
-	if !statusWorking(prev.Status) && statusWorking(next.Status) {
+	if !prev.working && next.working {
 		return true
 	}
-	if !statusError(prev.Status) && statusError(next.Status) {
+	if !prev.errored && next.errored {
 		return true
 	}
 	return false
 }
-
-func statusWorking(s *Status) bool { return s != nil && s.Working }
-func statusError(s *Status) bool   { return s != nil && s.Error }
 
 func nowRFC3339() string { return time.Now().UTC().Format(time.RFC3339) }

--- a/services/gmuxd/internal/store/store_test.go
+++ b/services/gmuxd/internal/store/store_test.go
@@ -2,6 +2,8 @@ package store
 
 import (
 	"encoding/json"
+	"reflect"
+	"strings"
 	"testing"
 	"time"
 )
@@ -821,6 +823,161 @@ func TestSessionMarshalJSON_WireFormat(t *testing.T) {
 	}
 }
 
+// internalSessionFields lists struct fields that intentionally do
+// not appear on the wire. The MarshalJSON "wire" struct excludes
+// these; they are kept on Session for internal resolution (Title
+// merging) but never sent to clients. Add a field here if and only
+// if you are deliberately keeping it server-side.
+var internalSessionFields = map[string]struct{}{
+	"ShellTitle":   {},
+	"AdapterTitle": {},
+}
+
+// TestSessionMarshalJSON_AllFieldsAppearOnWire is the gotcha-catcher
+// for "someone added a field to Session with a json tag, but forgot
+// to plumb it through the explicit `wire` struct in MarshalJSON."
+// This is exactly how `last_activity_at` was almost silently dropped
+// during PR #229: the field had a tag on the struct but wasn't
+// enumerated in the wire literal, so it would never have reached
+// any API consumer.
+//
+// The test reflects over every json-tagged field on Session,
+// populates each to a non-zero value, marshals, and asserts the
+// tag's wire name appears in the output. New fields fall into one of
+// two camps: either they belong on the wire (and the wire struct
+// needs an entry, which this test forces) or they're internal (and
+// they need to be added to internalSessionFields with a comment
+// justifying the exclusion). Either way the failure mode is loud,
+// not silent.
+func TestSessionMarshalJSON_AllFieldsAppearOnWire(t *testing.T) {
+	sess := fullyPopulatedSession()
+	b, err := json.Marshal(sess)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	st := reflect.TypeOf(sess)
+	for i := 0; i < st.NumField(); i++ {
+		f := st.Field(i)
+		tag := f.Tag.Get("json")
+		if tag == "" || tag == "-" {
+			continue
+		}
+		wireName := strings.SplitN(tag, ",", 2)[0]
+		_, isInternal := internalSessionFields[f.Name]
+		_, onWire := m[wireName]
+		switch {
+		case isInternal && onWire:
+			t.Errorf("field %s (wire: %s) is listed as internal but appears in MarshalJSON output", f.Name, wireName)
+		case !isInternal && !onWire:
+			t.Errorf("field %s (wire: %s) has a json tag but is missing from MarshalJSON's wire struct; "+
+				"either add it to the wire literal in store.Session.MarshalJSON or add %q to internalSessionFields",
+				f.Name, wireName, f.Name)
+		}
+	}
+}
+
+// fullyPopulatedSession returns a Session with every json-tagged
+// field set to a non-zero value. Used by the all-fields-on-wire
+// test; centralised so adding a new field forces a compile-time
+// touchpoint here too.
+func fullyPopulatedSession() Session {
+	exit := 0
+	return Session{
+		ID:             "sess-full",
+		Peer:           "peer-x",
+		CreatedAt:      "2026-01-01T00:00:00Z",
+		Command:        []string{"bash"},
+		Cwd:            "/tmp/work",
+		Kind:           "pi",
+		WorkspaceRoot:  "/tmp/work",
+		Remotes:        map[string]string{"origin": "github.com/x/y"},
+		Alive:          true,
+		Pid:            42,
+		ExitCode:       &exit,
+		StartedAt:      "2026-01-01T00:00:01Z",
+		ExitedAt:       "2026-01-01T00:00:02Z",
+		Title:          "t",
+		Subtitle:       "s",
+		Status:         &Status{Label: "l", Working: true, Error: true},
+		Unread:         true,
+		LastActivityAt: "2026-01-01T00:00:03Z",
+		Resumable:      true,
+		SocketPath:     "/tmp/sock",
+		TerminalCols:   80,
+		TerminalRows:   24,
+		Slug:           "slug",
+		RunnerVersion:  "v1",
+		BinaryHash:     "hash",
+		ShellTitle:     "shell-internal",
+		AdapterTitle:   "adapter-internal",
+		ProjectSlug:    "proj",
+		ProjectIndex:   3,
+	}
+}
+
+// TestSessionMarshalJSON_LastActivityAt pins that LastActivityAt
+// makes it onto the wire. The Session type has a custom MarshalJSON
+// (an explicit `wire` struct, not the default struct-tag reflection),
+// so adding a field to the struct alone is silently insufficient:
+// the field has to be enumerated in the wire struct and the
+// json.Marshal call. This test exists specifically to catch that
+// class of regression, not to test the std library's JSON encoder.
+func TestSessionMarshalJSON_LastActivityAt(t *testing.T) {
+	ts := "2026-05-23T10:30:00Z"
+	s := Session{ID: "sess-1", Kind: "pi", Alive: true, LastActivityAt: ts}
+	b, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got := m["last_activity_at"]; got != ts {
+		t.Fatalf("last_activity_at on wire = %v, want %q", got, ts)
+	}
+
+	// And: when unset, the field is omitted (omitempty), not sent as
+	// an empty string. Matters because the frontend treats "" and
+	// absent identically today but might diverge later, and empty
+	// strings on RFC3339 fields are a smell.
+	s2 := Session{ID: "sess-2", Kind: "pi", Alive: true}
+	b2, _ := json.Marshal(s2)
+	var m2 map[string]any
+	json.Unmarshal(b2, &m2)
+	if _, present := m2["last_activity_at"]; present {
+		t.Errorf("unset LastActivityAt should be omitted, got %v", m2["last_activity_at"])
+	}
+}
+
+// TestSessionRoundTrip_LastActivityAt pins the peer-payload path:
+// the hub receives a peer session as JSON and json.Unmarshals into
+// store.Session, then UpsertRemote stores it. The default tag-based
+// unmarshal populates LastActivityAt from the wire; this test exists
+// because the symmetry between MarshalJSON (custom) and Unmarshal
+// (default) is the kind of asymmetry that breaks silently when
+// someone adds an UnmarshalJSON later.
+func TestSessionRoundTrip_LastActivityAt(t *testing.T) {
+	ts := "2026-05-23T10:30:00Z"
+	original := Session{ID: "sess-1", Kind: "pi", Alive: true, LastActivityAt: ts}
+	b, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded Session
+	if err := json.Unmarshal(b, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded.LastActivityAt != ts {
+		t.Fatalf("round-trip LastActivityAt = %q, want %q", decoded.LastActivityAt, ts)
+	}
+}
+
 // --- Reconcile (project ownership stamping per ADR 0002) ---
 
 func TestReconcile_StampsOwnedSessions(t *testing.T) {
@@ -1169,6 +1326,40 @@ func TestLastActivityAt_UpsertNoBumpPreservesStamp(t *testing.T) {
 	after, _ := s.Get("s1")
 	if after.LastActivityAt != stamp {
 		t.Fatalf("no-bump Upsert must preserve LastActivityAt (was %q, now %q)", stamp, after.LastActivityAt)
+	}
+}
+
+// TestLastActivityAt_PointerAliasingDoesNotHideTransition is a
+// regression test for a real bug in an earlier draft: Update did
+// `sess := prev` (shallow copy), so prev.Status and sess.Status
+// pointed to the same Status struct. A mutator that wrote through
+// the pointer (e.g. flipped sess.Status.Working from false to true)
+// would silently mutate prev too, hiding the false→true transition
+// from the bump check. This test pins that the bump fires correctly
+// when a mutator constructs a new Status pointer in place of a nil
+// one (the common pattern in subscribe.go), AND would have failed
+// under the previous implementation if the mutator modified the
+// pointer's pointee directly. Snapshotting the activity booleans
+// before fn runs sidesteps the alias entirely.
+func TestLastActivityAt_PointerAliasingDoesNotHideTransition(t *testing.T) {
+	s := New()
+	// Seed with a Status pointer present (label only, not working).
+	s.Upsert(Session{ID: "s1", Kind: "pi", Alive: true, Status: &Status{Label: "idle"}})
+
+	// Mutator writes Working=true through the existing Status pointer
+	// rather than allocating a new Status. This is the alias-risk
+	// shape.
+	ok := s.Update("s1", func(sess *Session) {
+		if sess.Status != nil {
+			sess.Status.Working = true
+		}
+	})
+	if !ok {
+		t.Fatal("update failed")
+	}
+	after, _ := s.Get("s1")
+	if after.LastActivityAt == "" {
+		t.Fatal("working false→true through aliased pointer must still bump LastActivityAt")
 	}
 }
 

--- a/services/gmuxd/internal/store/store_test.go
+++ b/services/gmuxd/internal/store/store_test.go
@@ -1004,3 +1004,190 @@ func TestSession_WireRoundTripPreservesStamps(t *testing.T) {
 		})
 	}
 }
+
+// TestLastActivityAt_NewSessionDoesNotBump pins option (a): brand-new
+// sessions arrive with LastActivityAt unset. This is what keeps
+// sessionmeta rehydrate at daemon startup from timestamping every
+// resumable dead session to "now".
+func TestLastActivityAt_NewSessionDoesNotBump(t *testing.T) {
+	s := New()
+	s.Upsert(Session{ID: "s1", Kind: "pi", Alive: true})
+	got, _ := s.Get("s1")
+	if got.LastActivityAt != "" {
+		t.Fatalf("new session should not bump LastActivityAt, got %q", got.LastActivityAt)
+	}
+}
+
+// TestLastActivityAt_BumpOnTransitions pins the exact set of state
+// transitions that bump: exited, unread on, working on, error on.
+// Each subtest starts from an alive-and-idle baseline and applies
+// one transition.
+func TestLastActivityAt_BumpOnTransitions(t *testing.T) {
+	cases := []struct {
+		name string
+		next func(*Session)
+	}{
+		{"exited", func(s *Session) { s.Alive = false }},
+		{"unread", func(s *Session) { s.Unread = true }},
+		{"working", func(s *Session) { s.Status = &Status{Working: true} }},
+		{"error", func(s *Session) { s.Status = &Status{Error: true} }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := New()
+			s.Upsert(Session{ID: "s1", Kind: "pi", Alive: true})
+			before, _ := s.Get("s1")
+			if before.LastActivityAt != "" {
+				t.Fatalf("baseline should be unset, got %q", before.LastActivityAt)
+			}
+			ok := s.Update("s1", tc.next)
+			if !ok {
+				t.Fatal("update failed")
+			}
+			after, _ := s.Get("s1")
+			if after.LastActivityAt == "" {
+				t.Fatalf("transition %q should bump LastActivityAt", tc.name)
+			}
+			if _, err := time.Parse(time.RFC3339, after.LastActivityAt); err != nil {
+				t.Fatalf("LastActivityAt %q is not RFC3339: %v", after.LastActivityAt, err)
+			}
+		})
+	}
+}
+
+// TestLastActivityAt_NoBumpOnNoise pins that benign updates do not
+// bump: title changes, slug changes, cwd changes, status label-only
+// changes. Without this, the recency list would jitter on every
+// adapter title refresh.
+func TestLastActivityAt_NoBumpOnNoise(t *testing.T) {
+	cases := []struct {
+		name string
+		next func(*Session)
+	}{
+		{"title", func(s *Session) { s.AdapterTitle = "renamed" }},
+		{"slug", func(s *Session) { s.Slug = "new-slug" }},
+		{"cwd", func(s *Session) { s.Cwd = "/tmp/elsewhere" }},
+		{"status-label", func(s *Session) { s.Status = &Status{Label: "running"} }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := New()
+			s.Upsert(Session{ID: "s1", Kind: "pi", Alive: true, AdapterTitle: "orig"})
+			// Pre-seed a LastActivityAt by transitioning to unread.
+			s.Update("s1", func(sess *Session) { sess.Unread = true })
+			seeded, _ := s.Get("s1")
+			stamp := seeded.LastActivityAt
+			if stamp == "" {
+				t.Fatal("expected baseline bump from unread transition")
+			}
+			// Sleep one second so any erroneous bump would produce
+			// a distinct RFC3339 timestamp.
+			time.Sleep(1100 * time.Millisecond)
+			s.Update("s1", tc.next)
+			after, _ := s.Get("s1")
+			if after.LastActivityAt != stamp {
+				t.Fatalf("noise update %q should not bump (was %q, now %q)", tc.name, stamp, after.LastActivityAt)
+			}
+		})
+	}
+}
+
+// TestLastActivityAt_OnlyTransitionEdgeBumps pins that staying in
+// the same noteworthy state does not re-bump on every Update. A
+// session that is unread, gets another Update while still unread,
+// should keep its existing timestamp.
+func TestLastActivityAt_OnlyTransitionEdgeBumps(t *testing.T) {
+	s := New()
+	s.Upsert(Session{ID: "s1", Kind: "pi", Alive: true})
+	s.Update("s1", func(sess *Session) { sess.Unread = true })
+	first, _ := s.Get("s1")
+	time.Sleep(1100 * time.Millisecond)
+	s.Update("s1", func(sess *Session) { sess.AdapterTitle = "still unread" })
+	second, _ := s.Get("s1")
+	if second.LastActivityAt != first.LastActivityAt {
+		t.Fatalf("staying unread should not re-bump (was %q, now %q)", first.LastActivityAt, second.LastActivityAt)
+	}
+}
+
+// TestLastActivityAt_UpsertOnExistingBumps pins that the bump
+// machinery fires on Upsert (not just Update). Adapters call Upsert
+// repeatedly with the same ID as they refresh metadata; when one of
+// those refreshes carries a noteworthy transition (e.g. status going
+// to working), it must stamp LastActivityAt the same way Update does.
+func TestLastActivityAt_UpsertOnExistingBumps(t *testing.T) {
+	cases := []struct {
+		name string
+		mutate func(*Session)
+	}{
+		{"exited", func(s *Session) { s.Alive = false }},
+		{"unread", func(s *Session) { s.Unread = true }},
+		{"working", func(s *Session) { s.Status = &Status{Working: true} }},
+		{"error", func(s *Session) { s.Status = &Status{Error: true} }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := New()
+			baseline := Session{ID: "s1", Kind: "pi", Alive: true}
+			s.Upsert(baseline)
+			before, _ := s.Get("s1")
+			if before.LastActivityAt != "" {
+				t.Fatalf("baseline should be unset, got %q", before.LastActivityAt)
+			}
+			next := baseline
+			tc.mutate(&next)
+			s.Upsert(next)
+			after, _ := s.Get("s1")
+			if after.LastActivityAt == "" {
+				t.Fatalf("Upsert transition %q should bump LastActivityAt", tc.name)
+			}
+			if _, err := time.Parse(time.RFC3339, after.LastActivityAt); err != nil {
+				t.Fatalf("LastActivityAt %q is not RFC3339: %v", after.LastActivityAt, err)
+			}
+		})
+	}
+}
+
+// TestLastActivityAt_UpsertNoBumpPreservesStamp pins that a no-bump
+// Upsert (routine title / cwd / slug refresh from an adapter) does
+// NOT clobber a previously stamped LastActivityAt. Adapters build
+// fresh Session structs from runner state without LastActivityAt;
+// without an explicit carry-forward we'd silently zero the field on
+// every metadata refresh and break Recent ordering.
+func TestLastActivityAt_UpsertNoBumpPreservesStamp(t *testing.T) {
+	s := New()
+	// Seed with a stamped session via a transition.
+	s.Upsert(Session{ID: "s1", Kind: "pi", Alive: true})
+	s.Update("s1", func(sess *Session) { sess.Unread = true })
+	before, _ := s.Get("s1")
+	stamp := before.LastActivityAt
+	if stamp == "" {
+		t.Fatal("baseline transition should have stamped LastActivityAt")
+	}
+	// Routine refresh: same state, only adapter title changed. No
+	// transition fires; LastActivityAt is absent from the payload.
+	s.Upsert(Session{ID: "s1", Kind: "pi", Alive: true, Unread: true, AdapterTitle: "renamed"})
+	after, _ := s.Get("s1")
+	if after.LastActivityAt != stamp {
+		t.Fatalf("no-bump Upsert must preserve LastActivityAt (was %q, now %q)", stamp, after.LastActivityAt)
+	}
+}
+
+// TestLastActivityAt_UpsertRemotePreserves pins that peer payloads
+// (UpsertRemote) carry through LastActivityAt as-received: the
+// owning daemon stamped it, the hub must not recompute.
+func TestLastActivityAt_UpsertRemotePreserves(t *testing.T) {
+	s := New()
+	wired := "2026-01-01T12:00:00Z"
+	s.UpsertRemote(Session{ID: "s1", Kind: "pi", Peer: "remote", Alive: true, LastActivityAt: wired})
+	got, _ := s.Get("s1")
+	if got.LastActivityAt != wired {
+		t.Fatalf("UpsertRemote should preserve LastActivityAt (want %q, got %q)", wired, got.LastActivityAt)
+	}
+	// Even a transition arriving via UpsertRemote must not recompute:
+	// it's the spoke's job to stamp, not ours.
+	s.UpsertRemote(Session{ID: "s1", Kind: "pi", Peer: "remote", Alive: false, LastActivityAt: wired})
+	got2, _ := s.Get("s1")
+	if got2.LastActivityAt != wired {
+		t.Fatalf("UpsertRemote alive→false should preserve peer-supplied timestamp (want %q, got %q)", wired, got2.LastActivityAt)
+	}
+}


### PR DESCRIPTION
## Summary

Adds `last_activity_at` to the Session model: an RFC3339 timestamp set by the owning daemon whenever a session goes through a noteworthy state transition. Frontend will consume this in upcoming PRs to power the home dashboard's "Recent" section and to provide a stable activity sort key across views.

This PR is wire/protocol/store plumbing only; no UI consumer yet.

## What bumps the timestamp

Exactly these prev→next transitions, computed in `shouldBumpActivity`:

- `alive: true → false` (the session exited)
- `unread: false → true` (new output the user hasn't seen)
- `status.working: false → true` (adapter started a task)
- `status.error: false → true` (status went into error)

**Not** bumped on: title/slug/cwd/stamps changes, status label-only updates, brand-new session creation, or sessionmeta rehydrate at daemon startup. Brand-new sessions arrive with the field unset; their first follow-up transition stamps it. This keeps daemon restart from timestamping every resumable-dead session to "now".

## Architecture

- `Upsert` and `Update` invoke the bump check; **`UpsertRemote` does not.** Peer sessions arrive over the SSE forwarding with the stamp already set by the owning daemon (per ADR 0002). The hub forwards as-received; no hub-side observer of peer transitions, no risk of double-stamping.
- The bump check operates on a pre-captured `activitySnapshot` (just the four scalar bits: `alive`, `unread`, `working`, `errored`). This is load-bearing: `Update` does `sess := prev`, a shallow copy that leaves `prev.Status` and `sess.Status` pointing at the same `Status` struct. A mutator that wrote through that pointer (`sess.Status.Working = true`) would silently mutate `prev` too, hiding the transition from the comparison. Snapshotting the booleans before `fn` runs sidesteps the alias entirely.
- Field is on `store.Session` directly, so `sessionmeta`'s existing `persistedSession` type alias picks it up automatically. Resumable sessions retain their last-activity timestamp across daemon restart with no new persistence code.
- Session has a custom `MarshalJSON` (an explicit `wire` struct, not default tag reflection). Adding a field to `Session` with a json tag is **silently insufficient**: it has to be enumerated in the `wire` literal too, or it never reaches any client. A new reflection-based test enforces this contract for every future field.

## Commits

1. **`feat(daemon): stamp sessions with last_activity_at on noteworthy state transitions`** — adds the field, the bump helper, the bump-on-(Upsert|Update) call sites, protocol/Zod wiring, and unit tests for each transition.

2. **`fix(daemon): include last_activity_at in Session wire MarshalJSON; harden bump check against pointer aliasing`** — adds the missing `wire` struct entry, refactors the bump check to operate on a pre-captured `activitySnapshot`, and adds three classes of regression tests: pointer-aliasing safety, wire serialization presence + omitempty, and the all-fields-on-wire reflection test that catches "added a json tag but forgot the wire literal" for any future field.

## Test coverage

- Bump-on-each-transition (exited / unread / working / error).
- No-bump-on-noise (title / slug / cwd / status-label).
- No re-bump while staying in the same state.
- New-session creation does not stamp.
- Peer payloads through `UpsertRemote` preserve the wire-supplied timestamp unchanged, including on alive→false transitions.
- **Pointer aliasing**: a mutator that writes `sess.Status.Working = true` through the existing pointer still bumps. Would have failed under the first draft.
- **Wire serialization**: `last_activity_at` appears on the wire when set, omitted when unset.
- **Wire round-trip**: a session marshaled and unmarshaled preserves the timestamp.
- **All-fields-on-wire (reflection)**: every json-tagged field on `Session` must either appear in `MarshalJSON`'s output or be listed in an explicit `internalSessionFields` exclusion set. New fields fail loudly, with an error message that tells the author exactly which list to update.
- **Sessionmeta round-trip**: the existing `TestRoundTripFullSession` now populates `LastActivityAt`, so a future drop of the json tag would surface as a `reflect.DeepEqual` diff.
- **Frontend boundary**: `toUISession` passes through both the present and absent cases.

## Follow-ups

Subsequent atomic PRs on the same dashboard track:

1. `·host` suffix on project headers + kill the HOSTS section on `/`.
2. Wide `<SessionRow>` component shared by home dashboard and project page.
3. Home `/` as activity-section dashboard (Needs attention / Running / Recent) + projects list + "+ Add project" modal.
4. Project page rewrite using the same three-section pattern + adaptive cwd subtitle.
