### PR TITLE
feat(web): cross-host indicators — host suffix + devcontainer marker

### DIFF
--- a/apps/gmux-web/src/home.tsx
+++ b/apps/gmux-web/src/home.tsx
@@ -1,72 +1,16 @@
-// Home page: host status, project overview, quick-launch per host.
+// Home page: projects overview.
 // Reads shared data from the store (signals).
 
-import { useState } from 'preact/hooks'
-import { health, peers, folders, sessions, launchers as launchersSignal, defaultLauncher as defaultLauncherSignal, launchSession } from './store'
-import { PeerLabel } from './peer-label'
-import type { Folder, LauncherDef } from './types'
-import { launchersForPeer } from './launcher'
-
-/** Strip protocol and trailing slash for display: "https://foo.bar/" → "foo.bar" */
-function displayHost(url: string): string {
-  return url.replace(/^https?:\/\//, '').replace(/\/+$/, '')
-}
+import { health, folders } from './store'
+import { HostSuffix } from './host-suffix'
+import type { Folder } from './types'
 
 export function Home() {
   const healthVal = health.value
-  const peersVal = peers.value
   const foldersVal = folders.value
-  const sessionsVal = sessions.value
-  const localAlive = sessionsVal.filter(s => !s.peer && s.alive).length
-  const hostname = healthVal?.hostname ?? 'local'
-  const tsUrl = healthVal?.tailscale_url
-
-  const localLaunchers = launchersSignal.value
-  const localDefault = defaultLauncherSignal.value
-  const peerLaunchers = (peer: string) =>
-    launchersForPeer(localLaunchers, localDefault, peersVal, peer).launchers
 
   return (
     <div class="home">
-      {/* ── Hosts ── */}
-      <section class="home-hosts">
-        <h2 class="home-section-title">Hosts</h2>
-        <div class="home-host-grid">
-          <HostCard
-            name={hostname}
-            status="connected"
-            url={tsUrl}
-            details={[
-              healthVal?.version
-                ? healthVal.update_available
-                  ? `v${healthVal.version} \u2192 v${healthVal.update_available}`
-                  : `v${healthVal.version}`
-                : undefined,
-              `${localAlive} active session${localAlive === 1 ? '' : 's'}`,
-            ]}
-            launchers={localLaunchers}
-          />
-          {peersVal.map(p => (
-            <HostCard
-              key={p.name}
-              name={p.name}
-              status={p.status}
-              url={p.url}
-              details={[
-                p.version ? `v${p.version}` : undefined,
-                p.status === 'connected'
-                  ? `${p.session_count} active session${p.session_count === 1 ? '' : 's'}`
-                  : p.status === 'offline'
-                    ? 'offline'
-                    : p.last_error ?? 'disconnected',
-              ]}
-              launchers={p.status === 'connected' ? peerLaunchers(p.name) : []}
-              peer={p.name}
-            />
-          ))}
-        </div>
-      </section>
-
       {/* ── Projects ── */}
       {foldersVal.length > 0 && (
         <section class="home-projects">
@@ -105,8 +49,8 @@ function ProjectCard({ folder: f }: { folder: Folder }) {
   return (
     <a class="home-project-card" href={href}>
       <div class="home-project-name">
-        {f.peer && <PeerLabel name={f.peer} />}
         {f.name}
+        <HostSuffix peer={f.peer} />
       </div>
       <div class="home-project-count">
         {alive > 0 && <span class="home-project-alive">{alive} alive</span>}
@@ -118,55 +62,3 @@ function ProjectCard({ folder: f }: { folder: Folder }) {
   )
 }
 
-function HostCard({
-  name, status, url, details, launchers, peer,
-}: {
-  name: string
-  status: string
-  url?: string
-  details: (string | undefined)[]
-  launchers: LauncherDef[]
-  peer?: string
-}) {
-  const [launching, setLaunching] = useState<string | null>(null)
-  const linked = status === 'connected' && url
-
-  const handleLaunch = (id: string) => {
-    setLaunching(id)
-    launchSession(id, peer ? { peer } : undefined).finally(() => setLaunching(null))
-  }
-
-  return (
-    <div class="home-host-card">
-      <div class="home-host-top">
-        <span class={`home-host-status ${status}`} />
-        {peer && <PeerLabel name={name} />}
-        <span class="home-host-name">{name}</span>
-      </div>
-      <div class="home-host-details">
-        {url && (
-          linked
-            ? <a class="home-host-detail home-host-link" href={url} target="_blank" rel="noopener">{displayHost(url)}</a>
-            : <div class="home-host-detail">{displayHost(url)}</div>
-        )}
-        {details.filter(Boolean).map((d, i) => (
-          <div key={i} class="home-host-detail">{d}</div>
-        ))}
-      </div>
-      {launchers.length > 0 && (
-        <div class="home-host-launchers">
-          {launchers.map(l => (
-            <button
-              key={l.id}
-              class={`home-launch-btn${launching === l.id ? ' launching' : ''}${!l.available ? ' unavailable' : ''}`}
-              onClick={() => handleLaunch(l.id)}
-              disabled={launching !== null || !l.available}
-            >
-              {l.label}
-            </button>
-          ))}
-        </div>
-      )}
-    </div>
-  )
-}

--- a/apps/gmux-web/src/host-suffix.tsx
+++ b/apps/gmux-web/src/host-suffix.tsx
@@ -1,40 +1,32 @@
 /** Textual " · host" suffix for project headers.
  *
- * Replaces the single-letter PeerLabel pill on project-level UI
- * (sidebar folder headers, home project cards, project page h2).
- * The session-row PeerLabel stays where it is until the unified
- * row component lands.
+ * Renders the peer's name in muted body text after a project name
+ * on the sidebar folder header, home project card, and project page
+ * h2. Turns the disconnect color when the peer is unreachable.
  *
- * Visual: muted body text appended after a project name. Turns
- * the disconnect color when the peer is unreachable. Tooltip
- * shows the resolved status.
- *
- * `peer` carries the folder.peer for peer-owned projects. Omit it
- * for locally-owned projects, where the suffix reads the daemon's
- * hostname and never shows an offline state (the viewer is always
- * reachable from itself).
+ * Locally-owned projects (peer omitted) render nothing: the viewer
+ * is on that host, so naming it is noise. The suffix exists to flag
+ * cross-host ownership; absence of the suffix means "here".
  */
 
-import { health, peerStatusByName } from './store'
+import { peerStatusByName } from './store'
 
 export function HostSuffix({ peer }: { peer?: string }) {
-  const name = peer ?? health.value?.hostname
-  if (!name) return null
+  if (!peer) return null
 
-  // Local projects: always show as connected. Peer projects:
-  // 'connected' or unknown reads as normal; anything else
-  // ('connecting', 'disconnected', 'offline') reads as red.
+  // 'connected' or unknown (undefined) reads as normal; anything
+  // else ('connecting', 'disconnected', 'offline') reads as red.
   // Treating unknown as connected avoids a brief offline flash on
-  // first SSE arrival, before peers[] populates.
-  const status = peer ? peerStatusByName.value.get(peer) : 'connected'
+  // first SSE arrival before peers[] populates.
+  const status = peerStatusByName.value.get(peer)
   const offline = status !== undefined && status !== 'connected'
 
   return (
     <span
       class={`host-suffix${offline ? ' offline' : ''}`}
-      title={peer ? `${peer}${status ? ` (${status})` : ''}` : name}
+      title={`${peer}${status ? ` (${status})` : ''}`}
     >
-      <span class="host-suffix-sep" aria-hidden="true"> · </span>{name}
+      <span class="host-suffix-sep" aria-hidden="true"> · </span>{peer}
     </span>
   )
 }

--- a/apps/gmux-web/src/host-suffix.tsx
+++ b/apps/gmux-web/src/host-suffix.tsx
@@ -1,0 +1,40 @@
+/** Textual " · host" suffix for project headers.
+ *
+ * Replaces the single-letter PeerLabel pill on project-level UI
+ * (sidebar folder headers, home project cards, project page h2).
+ * The session-row PeerLabel stays where it is until the unified
+ * row component lands.
+ *
+ * Visual: muted body text appended after a project name. Turns
+ * the disconnect color when the peer is unreachable. Tooltip
+ * shows the resolved status.
+ *
+ * `peer` carries the folder.peer for peer-owned projects. Omit it
+ * for locally-owned projects, where the suffix reads the daemon's
+ * hostname and never shows an offline state (the viewer is always
+ * reachable from itself).
+ */
+
+import { health, peerStatusByName } from './store'
+
+export function HostSuffix({ peer }: { peer?: string }) {
+  const name = peer ?? health.value?.hostname
+  if (!name) return null
+
+  // Local projects: always show as connected. Peer projects:
+  // 'connected' or unknown reads as normal; anything else
+  // ('connecting', 'disconnected', 'offline') reads as red.
+  // Treating unknown as connected avoids a brief offline flash on
+  // first SSE arrival, before peers[] populates.
+  const status = peer ? peerStatusByName.value.get(peer) : 'connected'
+  const offline = status !== undefined && status !== 'connected'
+
+  return (
+    <span
+      class={`host-suffix${offline ? ' offline' : ''}`}
+      title={peer ? `${peer}${status ? ` (${status})` : ''}` : name}
+    >
+      <span class="host-suffix-sep" aria-hidden="true"> · </span>{name}
+    </span>
+  )
+}

--- a/apps/gmux-web/src/project-hub.tsx
+++ b/apps/gmux-web/src/project-hub.tsx
@@ -11,6 +11,7 @@ import { sessionPath } from './routing'
 import { LaunchButton } from './launcher'
 import { sessions, projects, peers, peerStatusByName, isSessionUnavailable, localPeerNames } from './store'
 import { PeerLabel } from './peer-label'
+import { HostSuffix } from './host-suffix'
 
 function projectRemote(p: ProjectItem | undefined): string | undefined {
   return p?.match?.find(r => r.remote)?.remote
@@ -46,7 +47,10 @@ export function ProjectHub({ projectSlug, projectPeer, onCloseSession }: Project
   return (
     <div class="home">
       <section>
-        <h2 class="home-section-title">{projectSlug}</h2>
+        <h2 class="home-section-title">
+          {projectSlug}
+          <HostSuffix peer={projectPeer} />
+        </h2>
         {(remote || totalSessions > 0) && (
           <div class="hub-meta">
             {remote && <span class="hub-remote">{remote}</span>}

--- a/apps/gmux-web/src/projects.test.ts
+++ b/apps/gmux-web/src/projects.test.ts
@@ -336,6 +336,34 @@ describe('buildProjectFolders', () => {
     expect(folders[0].sessions.map(s => s.id)).toEqual(['a@tower', 'b@tower', 'c@tower'])
   })
 
+  it('non-Local peer sessions never land in a locally-owned folder', () => {
+    // Pinned for the sidebar mixed-host marker (sidebar.tsx,
+    // DevcontainerMarker): inside a folder with peer===undefined,
+    // any session whose .peer is set must be a Local peer
+    // (devcontainer). The marker leans on this invariant to render
+    // a container icon unconditionally rather than re-classifying
+    // peers at render time. If bucketing ever folds non-Local peer
+    // sessions into a local folder, this test fires and the marker
+    // needs to be revisited.
+    const projects: ProjectItem[] = [
+      { slug: 'gmux', match: [{ path: '/dev/gmux' }] },
+    ]
+    const sessions = [
+      makeSession({ id: 's-local', cwd: '/dev/gmux', alive: true,
+                    project_slug: 'gmux', project_index: 0 }),
+      makeSession({ id: 's-tower@tower', cwd: '/x', alive: true,
+                    peer: 'tower', project_slug: 'gmux', project_index: 1 }),
+    ]
+    // Crucial: 'tower' is *not* a Local peer. The hint must be
+    // honest about this; an incorrect Local claim would land the
+    // session here legitimately.
+    const isLocal = (name: string) => name !== 'tower'
+    const folders = buildProjectFolders(projects, sessions, isLocal)
+    expect(folders).toHaveLength(1)
+    expect(folders[0].peer).toBeUndefined()
+    expect(folders[0].sessions.map(s => s.id)).toEqual(['s-local'])
+  })
+
   it('ignores stamped peer sessions when no reference exists for them', () => {
     // Under the references model, peer-stamped sessions only appear
     // if the viewer added a reference. No emergent peer folders.

--- a/apps/gmux-web/src/sidebar.tsx
+++ b/apps/gmux-web/src/sidebar.tsx
@@ -17,7 +17,6 @@ import {
   peerStatusByName, isSessionUnavailable, localPeerNames,
   type DotState,
 } from './store'
-import { PeerLabel } from './peer-label'
 import { HostSuffix } from './host-suffix'
 import type { Session, Folder } from './types'
 
@@ -66,6 +65,29 @@ interface DragState {
 
 // ── Components ──
 
+/** Per-row host marker for sessions inside a folder that spans
+ *  multiple hosts. Two flavors:
+ *  - Local peer (devcontainer): small container icon. The letter
+ *    pill never told anyone "this runs in a container"; the icon
+ *    does. The peer name is in the tooltip.
+ *  - Network peer in a mixed folder (rare in practice, since peer
+ *    references make folders single-host): falls back to the peer
+ *    name as muted text, so the information is still legible.
+ */
+function SessionHostMarker({ peer }: { peer: string }) {
+  const isContainer = localPeerNames.value.has(peer)
+  if (isContainer) {
+    return (
+      <svg class="session-container-icon" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round">
+        <title>{`devcontainer: ${peer}`}</title>
+        <rect x="1.5" y="3.5" width="9" height="6" rx="0.5" />
+        <path d="M4 3.5v6 M6 3.5v6 M8 3.5v6" />
+      </svg>
+    )
+  }
+  return <span class="session-host-text" title={peer}>{peer}</span>
+}
+
 function reorder<T>(arr: T[], from: number, to: number): T[] {
   const next = [...arr]
   const [item] = next.splice(from, 1)
@@ -82,6 +104,7 @@ function SessionItem({
   dragging,
   dropTarget,
   unavailable,
+  showHostMarker,
   onClose,
   onClick,
   onDragStart,
@@ -97,6 +120,8 @@ function SessionItem({
   dropTarget?: boolean
   /** Session lives on a peer we can't reach right now. */
   unavailable?: boolean
+  /** Folder spans multiple hosts; render this session's host marker. */
+  showHostMarker?: boolean
   onClose?: () => void
   /** Extra side-effects on click (e.g. close mobile sidebar). */
   onClick?: () => void
@@ -142,7 +167,7 @@ function SessionItem({
         ? <svg class="session-sleep-icon" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><title>Resumable</title><path d="M7 1h4l-4 4h4" /><path d="M1 5h5l-5 6h5" /></svg>
         : <span class={`session-dot-indicator ${dotState}${arrival ? ` ${arrival}` : ''}`} />
       }
-      {session.peer && <PeerLabel name={session.peer} />}
+      {showHostMarker && session.peer && <SessionHostMarker peer={session.peer} />}
       <div class="session-content">
         <div class="session-title-row">
           <span class="session-title">{session.title}</span>
@@ -221,6 +246,13 @@ function FolderGroup({
   const displayItems = drag ? reorder(visible, drag.from, drag.over) : visible
   const isCurrent = currentKey === folder.key
   const href = folder.peer ? `/@${folder.peer}/${folder.slug}` : `/${folder.slug}`
+  // Folder spans multiple hosts iff its sessions don't all share the
+  // same .peer value. In practice this is the devcontainer case: a
+  // local project's folder containing both parent-local sessions
+  // (peer=undefined) and Local-peer container sessions. When all
+  // sessions agree, per-row markers are noise.
+  const folderPeers = new Set(visible.map(s => s.peer ?? ''))
+  const mixedHosts = folderPeers.size > 1
   return (
     <div class="folder">
       <div class="folder-header">
@@ -254,6 +286,7 @@ function FolderGroup({
             resuming={resumingId === s.id}
             dotState={sessionDotState(s, am)}
             unavailable={isSessionUnavailable(s, peerStatus)}
+            showHostMarker={mixedHosts}
             dragging={drag !== null && s.id === visible[drag.from]?.id}
             dropTarget={drag !== null && drag.over === i && drag.from !== i}
             onClose={() => onCloseSession(s)}

--- a/apps/gmux-web/src/sidebar.tsx
+++ b/apps/gmux-web/src/sidebar.tsx
@@ -18,6 +18,7 @@ import {
   type DotState,
 } from './store'
 import { PeerLabel } from './peer-label'
+import { HostSuffix } from './host-suffix'
 import type { Session, Folder } from './types'
 
 // ── Types ──
@@ -231,8 +232,8 @@ function FolderGroup({
             : `Open ${folder.name} hub`}
           onClick={onClick}
         >
-          {folder.peer && <PeerLabel name={folder.peer} />}
           {folder.name}
+          <HostSuffix peer={folder.peer} />
           {folder.missing && <span class="folder-missing-icon" title="Project missing on peer">?</span>}
         </a>
         <LaunchButton

--- a/apps/gmux-web/src/sidebar.tsx
+++ b/apps/gmux-web/src/sidebar.tsx
@@ -65,27 +65,26 @@ interface DragState {
 
 // ── Components ──
 
-/** Per-row host marker for sessions inside a folder that spans
- *  multiple hosts. Two flavors:
- *  - Local peer (devcontainer): small container icon. The letter
- *    pill never told anyone "this runs in a container"; the icon
- *    does. The peer name is in the tooltip.
- *  - Network peer in a mixed folder (rare in practice, since peer
- *    references make folders single-host): falls back to the peer
- *    name as muted text, so the information is still legible.
+/** Container icon for a devcontainer session inside a mixed-host
+ *  folder. Replaces the per-row PeerLabel pill (which didn't tell
+ *  anyone "this runs in a container" anyway).
+ *
+ *  Reachability is guaranteed by the `buildProjectFolders`
+ *  bucketing: any session with `.peer` set inside a folder where
+ *  `folder.peer === undefined` is a Local peer (parent-owned
+ *  devcontainer). Pinned by `projects.test.ts`
+ *  ("non-Local peer sessions never land in a locally-owned
+ *  folder"). Peer-owned folders are single-host by construction,
+ *  so showHostMarker never fires there.
  */
-function SessionHostMarker({ peer }: { peer: string }) {
-  const isContainer = localPeerNames.value.has(peer)
-  if (isContainer) {
-    return (
-      <svg class="session-container-icon" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round">
-        <title>{`devcontainer: ${peer}`}</title>
-        <rect x="1.5" y="3.5" width="9" height="6" rx="0.5" />
-        <path d="M4 3.5v6 M6 3.5v6 M8 3.5v6" />
-      </svg>
-    )
-  }
-  return <span class="session-host-text" title={peer}>{peer}</span>
+function DevcontainerMarker({ peer }: { peer: string }) {
+  return (
+    <svg class="session-container-icon" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round">
+      <title>{`devcontainer: ${peer}`}</title>
+      <rect x="1.5" y="3.5" width="9" height="6" rx="0.5" />
+      <path d="M4 3.5v6 M6 3.5v6 M8 3.5v6" />
+    </svg>
+  )
 }
 
 function reorder<T>(arr: T[], from: number, to: number): T[] {
@@ -167,7 +166,7 @@ function SessionItem({
         ? <svg class="session-sleep-icon" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><title>Resumable</title><path d="M7 1h4l-4 4h4" /><path d="M1 5h5l-5 6h5" /></svg>
         : <span class={`session-dot-indicator ${dotState}${arrival ? ` ${arrival}` : ''}`} />
       }
-      {showHostMarker && session.peer && <SessionHostMarker peer={session.peer} />}
+      {showHostMarker && session.peer && <DevcontainerMarker peer={session.peer} />}
       <div class="session-content">
         <div class="session-title-row">
           <span class="session-title">{session.title}</span>

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -450,12 +450,7 @@ body {
   color: var(--text-muted);
   opacity: 0.8;
 }
-.session-host-text {
-  flex-shrink: 0;
-  font-size: 10px;
-  color: var(--text-muted);
-  align-self: center;
-}
+
 
 .session-content {
   flex: 1;

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -439,6 +439,24 @@ body {
   opacity: 0.7;
 }
 
+/* Per-row marker shown only in folders that span multiple hosts
+   (currently: parent-local + devcontainer). In single-host folders
+   the marker is absent entirely. */
+.session-container-icon {
+  flex-shrink: 0;
+  width: 10px;
+  height: 10px;
+  margin-top: 3px;
+  color: var(--text-muted);
+  opacity: 0.8;
+}
+.session-host-text {
+  flex-shrink: 0;
+  font-size: 10px;
+  color: var(--text-muted);
+  align-self: center;
+}
+
 .session-content {
   flex: 1;
   min-width: 0;

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -308,6 +308,20 @@ body {
   padding-top: 1px;
 }
 
+/* ── Host suffix (project headers) ── */
+.host-suffix {
+  font-weight: 400;
+  font-size: 0.9em;
+  color: var(--text-muted);
+}
+.host-suffix.offline {
+  color: var(--status-disconnected);
+}
+.host-suffix-sep {
+  opacity: 0.6;
+  margin: 0 0.1em;
+}
+
 /* ── Session Item ── */
 
 .session-item {
@@ -1552,88 +1566,6 @@ body {
   margin-bottom: 12px;
 }
 
-/* Host cards */
-
-.home-host-grid {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  margin-bottom: 32px;
-}
-
-.home-host-card {
-  background: var(--bg-surface);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 12px 14px;
-}
-
-.home-host-top {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.home-host-name {
-  font-size: 14px;
-  font-weight: 600;
-  color: var(--text);
-}
-
-.home-host-status {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  flex-shrink: 0;
-}
-.home-host-status.connected, .home-host-status.local {
-  background: var(--status-connected);
-  box-shadow: 0 0 6px color-mix(in oklch, var(--status-connected) 40%, transparent);
-}
-.home-host-status.connecting {
-  background: var(--status-disconnected);
-}
-.home-host-status.disconnected {
-  background: var(--status-disconnected);
-}
-.home-host-status.offline {
-  background: var(--text-muted);
-}
-
-.home-host-card:has(.home-host-status.offline) {
-  opacity: 0.5;
-}
-
-.home-host-details {
-  display: flex;
-  gap: 12px;
-  margin-top: 6px;
-  padding-left: 16px;
-}
-
-.home-host-detail {
-  font-size: 12px;
-  color: var(--text-secondary);
-}
-
-a.home-host-link {
-  text-decoration: none;
-  color: var(--text-secondary);
-  transition: color 0.15s;
-}
-a.home-host-link:hover {
-  color: var(--text);
-}
-
-.home-host-launchers {
-  display: flex;
-  gap: 6px;
-  flex-wrap: wrap;
-  margin-top: 10px;
-  padding-top: 10px;
-  border-top: 1px solid var(--border);
-}
-
 /* Project cards */
 
 .home-project-grid {
@@ -1674,37 +1606,6 @@ a.home-host-link:hover {
 
 .home-project-rest {
   color: var(--text-muted);
-}
-
-/* Host-card launch buttons */
-
-.home-launch-btn {
-  padding: 4px 14px;
-  background: var(--bg-hover);
-  border: 1px solid var(--border);
-  border-radius: 5px;
-  color: var(--text);
-  font-family: 'Source Sans 3', sans-serif;
-  font-size: 12px;
-  font-weight: 500;
-  cursor: pointer;
-  transition: background 0.15s, border-color 0.15s;
-}
-.home-launch-btn:hover {
-  background: var(--bg-selected);
-  border-color: var(--text-muted);
-}
-.home-launch-btn:disabled {
-  opacity: 0.5;
-  cursor: default;
-}
-.home-launch-btn.launching {
-  opacity: 0.5;
-  pointer-events: none;
-}
-.home-launch-btn.unavailable {
-  color: var(--text-muted);
-  opacity: 0.4;
 }
 
 .home-footer {


### PR DESCRIPTION
> Stacked on **#229** (`feat/last-activity-at`). Review/merge that one first.

Step 2 of the home/project/sidebar polish thread. Tightens the cross-host visual language across the sidebar, home page, and project page; removes the dedicated HOSTS section.

## The model

- A project is owned by exactly one host (post #228). The host is therefore a project-level fact, not a session-level fact.
- The single exception: a parent's local project can contain devcontainer sessions (Local peers re-stamped under the parent's local folder per ADR 0002). That's the only realistic mixed-host case.
- "Local" (the viewer's own host) is the implicit default. We surface info only when the project is *elsewhere*, or when a folder *spans* hosts.

## What changes

| Surface | Before | After |
|---|---|---|
| Sidebar project header | `[Y] gmux` (letter pill) | `gmux` (local) / `gmux · tower` (peer-owned) |
| Sidebar session row | `[Y] session-title` per row | nothing (single-host folders) / container icon (devcontainer in mixed folder) |
| Home page header section | Full HOSTS card list with versions, addresses, adapter chips, per-host launchers | *(removed)* |
| Home project card | `[Y] gmux` | `gmux` / `gmux · tower` |
| Project page h2 | `GMUX` | `GMUX` / `GMUX · TOWER` |
| Disconnected peer | dimmed letter pill | red suffix / red marker |
| Manage-projects modal | (still uses `<PeerLabel>`) | unchanged; rewritten in a later step |
| Project page inner `<HostGroup>` | (still uses `<PeerLabel>`) | unchanged; collapsed in a later step |

Net effect on a single-host setup: zero host noise anywhere. On a multi-host setup: peer projects are clearly tagged, and the disconnect state is louder than the previous dimmed pill.

## Commits

1. **`feat(web): replace peer-pill with textual ·host suffix on project headers; remove HOSTS section`** — new `<HostSuffix>` component (muted body text, red on disconnect); wired into sidebar / home card / project h2. Deletes `<HostCard>` + ~75 lines of CSS.
2. **`feat(web): hide host suffix on locally-owned projects`** — `<HostSuffix>` returns null when `peer` is undefined. The viewer is on that host; naming it is noise.
3. **`feat(web): show container icon on devcontainer sessions in mixed-host folders`** — `<FolderGroup>` computes `mixedHosts` from its visible sessions' `.peer` values; passes the flag to `<SessionItem>`. New `<DevcontainerMarker>` SVG renders only for sessions where the marker is needed. Drops the per-row `<PeerLabel>` from the sidebar entirely.
4. **`refactor(web): drop dead non-Local fallback in mixed-host marker; pin bucketing invariant`** — `buildProjectFolders` guarantees that any session with `.peer` set inside a `folder.peer === undefined` folder is a Local peer (devcontainer). The marker was originally written with a defensive "non-Local peer" fallback that the bucketing makes unreachable. Dropped, with a new `projects.test.ts` test that pins the bucketing invariant. If someone later changes bucketing to fold non-Local peer sessions into local folders, the test fires and the rendering code gets a heads-up.

## Tests

- `non-Local peer sessions never land in a locally-owned folder` (projects.test.ts): pins the invariant the `<DevcontainerMarker>` leans on.
- All existing tests pass (395 web; daemon untouched in this PR).

## Verification

- Local dev daemon (4 owned local projects, no peers): sidebar / home / project pages all render with zero host suffixes / markers. Verified visually.
- Multi-host case rests on the model + the new invariant test. The container icon path was not exercised live (dev daemon has no Local peers); if you spin one up that's the first thing to eye-check.

## Out of scope, scheduled

- Wide `<SessionRow>` component (step 3) — where the `last_activity_at` from #229 starts getting used.
- Home as a 3-section dashboard (step 3).
- Project page rewrite with adaptive cwd subtitle (step 4).
- Manage-projects modal rework (step 4).
