### PR TITLE
feat(web): activity-first home dashboard

### DIFF
--- a/apps/gmux-web/src/home-partition.test.ts
+++ b/apps/gmux-web/src/home-partition.test.ts
@@ -1,0 +1,187 @@
+// Pins the home dashboard's section partition. The partition is the
+// only piece of dashboard logic with non-trivial behavior (the row
+// component is visual, the section layout is presentation); these
+// tests guard the behavior contracts the design conversation pinned
+// down: section priority, sort key, and the Recent floor/window/cap.
+
+import { describe, it, expect } from 'vitest'
+import { partitionForHome, RECENT_WINDOW_MS, RECENT_FLOOR, RECENT_CAP } from './store'
+import { makeSession } from './test-helpers'
+
+const NOW = Date.parse('2026-06-01T12:00:00Z')
+
+function stamp(offsetMs: number): string {
+  return new Date(NOW + offsetMs).toISOString()
+}
+
+describe('partitionForHome', () => {
+  describe('section assignment', () => {
+    it('puts unread alive sessions in needsAttention', () => {
+      const s = makeSession({ id: 's1', cwd: '/x', alive: true, unread: true })
+      const { needsAttention, running, recent } = partitionForHome([s], NOW)
+      expect(needsAttention.map(s => s.id)).toEqual(['s1'])
+      expect(running).toEqual([])
+      expect(recent).toEqual([])
+    })
+
+    it('does NOT escalate error-only sessions to needsAttention', () => {
+      // status.error mostly fires from background subcommands that
+      // exited non-zero without the agent itself halting, so it
+      // doesn't earn the "needs attention" slot. The per-row error
+      // dot still surfaces the state. This test pins the predicate
+      // and prevents a regression to the old `unread || error`
+      // shape that lit up the section on every failed subcommand.
+      // We deliberately don't assert which fallthrough bucket the
+      // session lands in; that's covered by other tests.
+      const s = makeSession({
+        id: 's1', cwd: '/x', alive: true,
+        status: { label: 'failed', working: false, error: true },
+      })
+      const { needsAttention } = partitionForHome([s], NOW)
+      expect(needsAttention).toEqual([])
+    })
+
+    it('puts alive+working sessions in running', () => {
+      const s = makeSession({
+        id: 's1', cwd: '/x', alive: true,
+        status: { label: 'building', working: true, error: false },
+      })
+      const { needsAttention, running } = partitionForHome([s], NOW)
+      expect(needsAttention).toEqual([])
+      expect(running.map(s => s.id)).toEqual(['s1'])
+    })
+
+    it('excludes dead sessions from every home bucket', () => {
+      // Home is alive-only: dead sessions live exclusively in the
+      // project page's "All sessions" section. This pins the
+      // contract so a regression that lets dead sessions leak into
+      // Recent (the historical behavior) fails loudly.
+      const sessions = [
+        makeSession({
+          id: 'dead', cwd: '/x', alive: false,
+          last_activity_at: stamp(-5 * 60 * 1000),
+        }),
+        makeSession({
+          id: 'dead-unread', cwd: '/x', alive: false, unread: true,
+          last_activity_at: stamp(-5 * 60 * 1000),
+        }),
+      ]
+      const { needsAttention, running, recent } = partitionForHome(sessions, NOW)
+      expect(needsAttention).toEqual([])
+      expect(running).toEqual([])
+      expect(recent).toEqual([])
+    })
+  })
+
+  describe('sort order', () => {
+    const working = { label: 'x', working: true, error: false }
+
+    it('sorts each section newest-first by last_activity_at', () => {
+      const a = makeSession({ id: 'a', cwd: '/x', alive: true, status: working, last_activity_at: stamp(-10_000) })
+      const b = makeSession({ id: 'b', cwd: '/x', alive: true, status: working, last_activity_at: stamp(-1_000) })
+      const c = makeSession({ id: 'c', cwd: '/x', alive: true, status: working, last_activity_at: stamp(-5_000) })
+      const { running } = partitionForHome([a, b, c], NOW)
+      expect(running.map(s => s.id)).toEqual(['b', 'c', 'a'])
+    })
+
+    it('falls back to created_at when last_activity_at is missing', () => {
+      // A brand-new working session has no last_activity_at (per the
+      // daemon's rule: creation doesn't bump). The sort still needs
+      // to place it somewhere sensible. created_at fallback puts new
+      // sessions at the top, where they belong.
+      const old = makeSession({
+        id: 'old', cwd: '/x', alive: true, status: working,
+        created_at: stamp(-3600_000), last_activity_at: stamp(-3600_000),
+      })
+      const fresh = makeSession({
+        id: 'fresh', cwd: '/x', alive: true, status: working,
+        created_at: stamp(-1_000), // no last_activity_at
+      })
+      const { running } = partitionForHome([old, fresh], NOW)
+      expect(running.map(s => s.id)).toEqual(['fresh', 'old'])
+    })
+
+    it('breaks timestamp ties by id (deterministic, no flicker)', () => {
+      // Sessions with identical timestamps (notably the corpses
+      // persisted before last_activity_at existed, all falling back
+      // to a similar created_at) must sort the same way every time.
+      // Without a stable tiebreaker, the input order from
+      // sessions.value rebuilding on each SSE event would re-order
+      // the visible list. We use id as the tiebreaker; input order
+      // must not affect output.
+      const same = stamp(-1000)
+      const make = (id: string) => makeSession({
+        id, cwd: '/x', alive: true, status: working, last_activity_at: same,
+      })
+      const a = make('a')
+      const b = make('b')
+      const c = make('c')
+      const orderings = [[a, b, c], [c, b, a], [b, a, c], [c, a, b]]
+      for (const arr of orderings) {
+        const { running } = partitionForHome(arr, NOW)
+        expect(running.map(s => s.id)).toEqual(['a', 'b', 'c'])
+      }
+    })
+  })
+
+  describe('recent window and floor', () => {
+    // Recent is for idle-alive sessions (live but not currently
+    // working). Dead sessions never reach this bucket since home
+    // filters them out at the input.
+    const idle = (id: string, ageMs: number) => makeSession({
+      id, cwd: '/x', alive: true, last_activity_at: stamp(-ageMs),
+    })
+
+    it('includes only entries inside the window when there are enough', () => {
+      const sessions = [
+        idle('a', 10 * 60 * 1000),
+        idle('b', 20 * 60 * 1000),
+        idle('c', 30 * 60 * 1000),
+        idle('d', RECENT_WINDOW_MS + 60_000),
+      ]
+      const { recent } = partitionForHome(sessions, NOW)
+      expect(recent.map(s => s.id)).toEqual(['a', 'b', 'c'])
+    })
+
+    it('falls back to top-floor by recency when fewer than floor are in-window', () => {
+      // 1 inside window, 4 older. Floor takes top RECENT_FLOOR=3 by
+      // recency overall so the user always sees a non-trivial
+      // section after they've used the daemon at all.
+      const sessions = [
+        idle('inside', 5 * 60 * 1000),
+        idle('old1', 2 * 3600_000),
+        idle('old2', 3 * 3600_000),
+        idle('old3', 4 * 3600_000),
+        idle('old4', 5 * 3600_000),
+      ]
+      const { recent } = partitionForHome(sessions, NOW)
+      expect(recent.map(s => s.id)).toEqual(['inside', 'old1', 'old2'])
+      expect(recent).toHaveLength(RECENT_FLOOR)
+    })
+
+    it('caps the window-qualified set at RECENT_CAP', () => {
+      // Pathological case: many recent transitions in a busy hour.
+      // The cap stops the dashboard from scrolling forever.
+      const sessions = Array.from({ length: RECENT_CAP + 5 }, (_, i) =>
+        idle(`s${i}`, (i + 1) * 1000),
+      )
+      const { recent } = partitionForHome(sessions, NOW)
+      expect(recent).toHaveLength(RECENT_CAP)
+      expect(recent[0].id).toBe('s0')
+      expect(recent[RECENT_CAP - 1].id).toBe(`s${RECENT_CAP - 1}`)
+    })
+
+    it('returns an empty Recent when every session is working or unread', () => {
+      // No idle-alive leftovers → Recent stays empty even with the
+      // floor (the floor pulls from leftover, not from
+      // attention/running).
+      const working = { label: 'x', working: true, error: false }
+      const sessions = [
+        makeSession({ id: 'a', cwd: '/x', alive: true, status: working }),
+        makeSession({ id: 'b', cwd: '/x', alive: true, status: working }),
+      ]
+      const { recent } = partitionForHome(sessions, NOW)
+      expect(recent).toEqual([])
+    })
+  })
+})

--- a/apps/gmux-web/src/home.tsx
+++ b/apps/gmux-web/src/home.tsx
@@ -1,64 +1,166 @@
-// Home page: projects overview.
-// Reads shared data from the store (signals).
+// Home dashboard: activity-first overview of every session, plus the
+// list of configured projects. Replaces the old project-grid-only
+// homepage. Three activity sections (Waiting / Active /
+// Recent) surface what the user likely wants right now without
+// asking them to scan the sidebar; the projects list below is the
+// stable "wherever I'm working from" navigation surface.
+//
+// Section semantics, sort order, and the Recent floor/window/cap
+// live in store.ts:partitionForHome. This file is presentation.
 
-import { health, folders } from './store'
+import { health, folders, homePartition, dismissSession } from './store'
 import { HostSuffix } from './host-suffix'
-import type { Folder } from './types'
+import { SessionRow } from './session-row'
+import { LaunchButton } from './launcher'
+import { sessionPath } from './routing'
+import type { Folder, Session } from './types'
 
-export function Home() {
+export function Home({ onManageProjects }: { onManageProjects: () => void }) {
   const healthVal = health.value
   const foldersVal = folders.value
+  const { needsAttention, running, recent } = homePartition.value
+
+  // Cheap session→folder lookup: the SessionRow needs a project name
+  // and the folder's owning peer to build a correct href. Building a
+  // map once is O(n+m) vs O(n*m) per row.
+  const folderBySessionId = new Map<string, Folder>()
+  for (const f of foldersVal) {
+    for (const s of f.sessions) folderBySessionId.set(s.id, f)
+  }
+
+  const renderRow = (s: Session) => {
+    const folder = folderBySessionId.get(s.id)
+    // A session always belongs to a folder once stamps land (post
+    // #228). Defensive fallback: if we somehow get a session
+    // without a folder (mid-arrival race), skip rendering rather
+    // than crashing the dashboard.
+    if (!folder) return null
+    return (
+      <SessionRow
+        key={s.id}
+        session={s}
+        href={sessionPath(folder.slug, s, folder.peer)}
+        showProject
+        projectName={folder.name}
+        showHost
+        onClose={() => dismissSession(s.id)}
+      />
+    )
+  }
+
+  const anyActivity = needsAttention.length + running.length + recent.length > 0
 
   return (
-    <div class="home">
-      {/* ── Projects ── */}
-      {foldersVal.length > 0 && (
-        <section class="home-projects">
-          <h2 class="home-section-title">Projects</h2>
-          <div class="home-project-grid">
-            {foldersVal.map(f => <ProjectCard key={f.key} folder={f} />)}
-          </div>
-        </section>
+    <div class="page">
+      <header class="hub-header">
+        <h2 class="hub-title">Activity</h2>
+      </header>
+      {needsAttention.length > 0 && (
+        <Section title="Waiting">
+          {needsAttention.map(renderRow)}
+        </Section>
       )}
 
-      <footer class="home-footer">
-        <span class="home-footer-version">Frontend v{__GMUX_VERSION__}</span>
-        {healthVal?.version && healthVal.version !== __GMUX_VERSION__ && (
-          <button class="home-footer-reload" onClick={() => location.reload()}>
-            reload to update
-          </button>
-        )}
-        {healthVal?.update_available && (
-          <a
-            class="home-footer-update"
-            href="https://gmux.app/changelog/"
-            target="_blank"
-          >
-            v{healthVal.update_available} available
-          </a>
-        )}
-      </footer>
+      {running.length > 0 && (
+        <Section title="Active">
+          {running.map(renderRow)}
+        </Section>
+      )}
+
+      {recent.length > 0 && (
+        <Section title="Recent">
+          {recent.map(renderRow)}
+        </Section>
+      )}
+
+      <section class="home-projects-section">
+        <h2 class="home-section-title">Projects</h2>
+        {foldersVal.length > 0 ? (
+          <div class="home-projects-list">
+            {foldersVal.map(f => <ProjectRow key={f.key} folder={f} />)}
+          </div>
+        ) : !anyActivity ? (
+          <div class="home-empty-hint">
+            No projects yet. <button class="home-empty-action" onClick={onManageProjects}>Add a project</button>
+          </div>
+        ) : null}
+        <button class="home-add-project" onClick={onManageProjects}>
+          + Add project
+        </button>
+      </section>
+
+      <HomeFooter />
     </div>
   )
 }
 
-function ProjectCard({ folder: f }: { folder: Folder }) {
+function Section({
+  title,
+  children,
+}: {
+  title: string
+  children: preact.ComponentChildren
+}) {
+  return (
+    <section class="home-section">
+      <h2 class="home-section-title">{title}</h2>
+      <div class="home-section-body">{children}</div>
+    </section>
+  )
+}
+
+function ProjectRow({ folder: f }: { folder: Folder }) {
+  // Counts mirror the legacy ProjectCard: "N alive" is the running
+  // count, "N resumable" is dead-but-resurrectable. Empty projects
+  // get a muted "no sessions" hint so the row isn't visually mute.
   const alive = f.sessions.filter(s => s.alive).length
   const resumable = f.sessions.filter(s => !s.alive && s.resumable).length
   const href = f.peer ? `/@${f.peer}/${f.slug}` : `/${f.slug}`
   return (
-    <a class="home-project-card" href={href}>
-      <div class="home-project-name">
-        {f.name}
-        <HostSuffix peer={f.peer} />
-      </div>
-      <div class="home-project-count">
-        {alive > 0 && <span class="home-project-alive">{alive} alive</span>}
-        {alive > 0 && resumable > 0 && <span class="home-project-rest"> · </span>}
-        {resumable > 0 && <span class="home-project-rest">{resumable} resumable</span>}
-        {alive === 0 && resumable === 0 && <span class="home-project-rest">no sessions</span>}
-      </div>
-    </a>
+    <div class="home-project-row">
+      <a class="home-project-link" href={href}>
+        <div class="home-project-name">
+          {f.name}
+          <HostSuffix peer={f.peer} />
+        </div>
+        <div class="home-project-count">
+          {alive > 0 && <span class="home-project-alive">{alive} alive</span>}
+          {alive > 0 && resumable > 0 && <span class="home-project-rest"> · </span>}
+          {resumable > 0 && <span class="home-project-rest">{resumable} resumable</span>}
+          {alive === 0 && resumable === 0 && <span class="home-project-rest">no sessions</span>}
+        </div>
+      </a>
+      <LaunchButton
+        sessions={f.sessions}
+        fallbackCwd={f.launchCwd ?? ''}
+        peer={f.peer}
+        className="home-project-launch"
+      />
+    </div>
   )
 }
 
+/** Page footer: daemon version, optionally followed by an inline
+ *  update-available link. Renders nothing when the daemon is
+ *  unreachable (the disconnect banner already covers that state).
+ *
+ *  Frontend version is not surfaced: a separate watcher auto-reloads
+ *  the tab when the bundle goes stale relative to the daemon, so the
+ *  user shouldn't see a long-lived mismatch. */
+function HomeFooter() {
+  const h = health.value
+  if (!h?.version) return null
+  return (
+    <footer class="home-footer">
+      gmux version {h.version}
+      {h.update_available && (
+        <>
+          {' · '}
+          <a class="home-footer-link" href="https://gmux.app/changelog/" target="_blank">
+            version {h.update_available} available!
+          </a>
+        </>
+      )}
+    </footer>
+  )
+}

--- a/apps/gmux-web/src/host-suffix.tsx
+++ b/apps/gmux-web/src/host-suffix.tsx
@@ -11,7 +11,7 @@
 
 import { peerStatusByName } from './store'
 
-export function HostSuffix({ peer }: { peer?: string }) {
+export function HostSuffix({ peer, leading = true }: { peer?: string; leading?: boolean }) {
   if (!peer) return null
 
   // 'connected' or unknown (undefined) reads as normal; anything
@@ -26,7 +26,7 @@ export function HostSuffix({ peer }: { peer?: string }) {
       class={`host-suffix${offline ? ' offline' : ''}`}
       title={`${peer}${status ? ` (${status})` : ''}`}
     >
-      <span class="host-suffix-sep" aria-hidden="true"> · </span>{peer}
+      {leading && <span class="host-suffix-sep" aria-hidden="true"> · </span>}{peer}
     </span>
   )
 }

--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -529,7 +529,7 @@ function App() {
             <div class="state-subtitle">Connecting…</div>
           </div>
         ) : (
-          <Home />
+          <Home onManageProjects={() => setManageProjectsOpen(true)} />
         )}
 
         <MobileTerminalBar

--- a/apps/gmux-web/src/session-row.tsx
+++ b/apps/gmux-web/src/session-row.tsx
@@ -151,7 +151,7 @@ export function SessionRow({
                 {seg}
               </Fragment>
             ))}
-            {showHost && <HostSuffix peer={session.peer} />}
+            {showHost && <HostSuffix peer={session.peer} leading={metaSegments.length > 0} />}
           </div>
         )}
       </div>

--- a/apps/gmux-web/src/session-row.tsx
+++ b/apps/gmux-web/src/session-row.tsx
@@ -1,0 +1,169 @@
+// Wide session row used on the home dashboard and (later) the
+// rewritten project page. Companion to the sidebar's compact
+// SessionItem: same data, more room to breathe. Two lines, optional
+// metadata (project / host / cwd / age), shared dot-state and
+// unavailability logic via store helpers.
+//
+// Kept deliberately separate from SessionItem rather than unified
+// behind a density prop: the sidebar variant is dense, drag-aware,
+// and folder-scoped; this variant is loose and standalone. A single
+// component would accumulate flags faster than it would save code.
+
+import { Fragment } from 'preact'
+import type { Session } from './types'
+import {
+  activityMap, peerStatusByName,
+  sessionDotState, isSessionUnavailable,
+} from './store'
+import { useArrivalPulse } from './use-arrival-pulse'
+import { HostSuffix } from './host-suffix'
+
+export interface SessionRowProps {
+  session: Session
+  /** Destination URL for the row click (deep link to session view). */
+  href: string
+  /** Currently selected: suppresses unread/error dot. */
+  selected?: boolean
+  /** Currently resuming: forces the dot into a working state. */
+  resuming?: boolean
+  /** Show the project name on line 2 (off on the project page). */
+  showProject?: boolean
+  /** Project display name to render when showProject is true. */
+  projectName?: string
+  /** Show the owning peer's host suffix on line 2. */
+  showHost?: boolean
+  /** Show the session's cwd on line 2. */
+  showCwd?: boolean
+  /** Pre-formatted cwd string. Pass-through; caller decides whether
+   *  to render full path or project-relative. */
+  cwdLabel?: string
+  /** Click handler for navigation side-effects (e.g. close mobile
+   *  sidebar). Default link navigation always happens via href. */
+  onClick?: () => void
+  /** Dismiss/kill button. Hidden when undefined. */
+  onClose?: () => void
+}
+
+/** Compact "Nm" / "Nh" / "Nd" relative-time formatter for ages on the
+ *  dashboard. Sub-minute ages collapse to "now" so the recently-
+ *  transitioned row doesn't visibly change every second. */
+function formatAge(stampIso: string | undefined, now: number): string | null {
+  if (!stampIso) return null
+  const t = Date.parse(stampIso)
+  if (!Number.isFinite(t)) return null
+  const secs = Math.max(0, Math.floor((now - t) / 1000))
+  if (secs < 60) return 'now'
+  const mins = Math.floor(secs / 60)
+  if (mins < 60) return `${mins}m`
+  const hours = Math.floor(mins / 60)
+  if (hours < 24) return `${hours}h`
+  const days = Math.floor(hours / 24)
+  return `${days}d`
+}
+
+export function SessionRow({
+  session,
+  href,
+  selected,
+  resuming,
+  showProject,
+  projectName,
+  showHost,
+  showCwd,
+  cwdLabel,
+  onClick,
+  onClose,
+}: SessionRowProps) {
+  const am = activityMap.value
+  const peerStatus = peerStatusByName.value
+  const unavailable = isSessionUnavailable(session, peerStatus)
+  const sleeping = !session.alive && session.resumable
+
+  const rawDot = resuming ? 'working' : sessionDotState(session, am)
+  // Selection mutes attention-grabbing dots (mirrors sidebar
+  // behavior): if you're already looking at it, "unread" / "error"
+  // are no longer useful signals.
+  const dot = (selected && (rawDot === 'error' || rawDot === 'unread')) ? 'none' : rawDot
+  const arrival = useArrivalPulse(dot)
+
+  // Age sourced from the same field that drives Recent partitioning:
+  // last_activity_at is the canonical "when did anything notable
+  // happen here" timestamp. Falls back to created_at for sessions
+  // that haven't transitioned yet (matches the dashboard sort).
+  const age = formatAge(session.last_activity_at ?? session.created_at, Date.now())
+
+  // Status label / exit code: surface whichever the session actually
+  // exposes. Dead sessions get a synthetic "exited (N)" if no label
+  // is set, so the row never goes silent about why a session is dead.
+  const statusText = session.status?.label
+    ?? (!session.alive && session.exit_code != null ? `exited (${session.exit_code})` : null)
+
+  const cls = [
+    'session-row',
+    selected ? 'selected' : '',
+    unavailable ? 'unavailable' : '',
+  ].filter(Boolean).join(' ')
+
+  // Line-2 metadata segments. Render only the ones requested by
+  // props; empty arrays produce no separator dots in the output.
+  const metaSegments: preact.ComponentChildren[] = []
+  if (showProject && projectName) {
+    metaSegments.push(<span class="session-row-project">{projectName}</span>)
+  }
+  if (showCwd && cwdLabel) {
+    metaSegments.push(<span class="session-row-cwd">{cwdLabel}</span>)
+  }
+  if (statusText) {
+    metaSegments.push(<span class="session-row-status">{statusText}</span>)
+  }
+  if (age) {
+    metaSegments.push(<span class="session-row-age">{age}</span>)
+  }
+
+  return (
+    <a
+      class={cls}
+      href={href}
+      onClick={() => onClick?.()}
+      onAuxClick={(e) => {
+        if (e.button === 1 && onClose) { e.preventDefault(); onClose() }
+      }}
+    >
+      {unavailable
+        ? <svg class="session-unavailable-icon" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><title>Peer unavailable</title><path d="M2 2 L10 10 M10 2 L2 10" /></svg>
+        : sleeping
+        ? <svg class="session-sleep-icon" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><title>Resumable</title><path d="M7 1h4l-4 4h4" /><path d="M1 5h5l-5 6h5" /></svg>
+        : <span class={`session-dot-indicator ${dot}${arrival ? ` ${arrival}` : ''}`} />
+      }
+      <div class="session-row-content">
+        <div class="session-row-title">{session.title}</div>
+        {(metaSegments.length > 0 || showHost) && (
+          <div class="session-row-meta">
+            {metaSegments.map((seg, i) => (
+              // Long-form Fragment carries a key: the shorthand `<>`
+              // can't, and without one Preact falls back to index
+              // diffing across renders. The visible content here is
+              // entirely positional (segment N is whatever segment N
+              // happens to be this render), so index is the honest
+              // key.
+              <Fragment key={i}>
+                {i > 0 && <span class="session-row-sep"> · </span>}
+                {seg}
+              </Fragment>
+            ))}
+            {showHost && <HostSuffix peer={session.peer} />}
+          </div>
+        )}
+      </div>
+      {onClose && (
+        <button
+          class="session-row-close"
+          onClick={(e) => { e.stopPropagation(); e.preventDefault(); onClose() }}
+          title={session.alive ? 'Kill session' : 'Dismiss'}
+        >
+          ×
+        </button>
+      )}
+    </a>
+  )
+}

--- a/apps/gmux-web/src/sidebar.tsx
+++ b/apps/gmux-web/src/sidebar.tsx
@@ -14,7 +14,7 @@ import {
   folders, selectedId, currentProjectKey,
   activityMap, unmatchedActiveCount, projects, connState,
   updateProjects, reorderSessions,
-  peerStatusByName, isSessionUnavailable, localPeerNames,
+  peerStatusByName, isSessionUnavailable, localPeerNames, sessionDotState,
   type DotState,
 } from './store'
 import { HostSuffix } from './host-suffix'
@@ -30,15 +30,6 @@ export type { DotState }
 // ── Helpers ──
 
 /** Determine the dot indicator state for a session. */
-function sessionDotState(session: Session, am: ReadonlyMap<string, 'active' | 'fading'>): DotState {
-  if (session.alive && session.status?.error)   return 'error'
-  if (session.alive && session.status?.working) return 'working'
-  if (session.unread) return 'unread'
-  const act = am.get(session.id)
-  if (act === 'active') return 'active'
-  if (act === 'fading') return 'fading'
-  return 'none'
-}
 
 const bellStroke = { fill: 'none', stroke: 'currentColor', 'stroke-width': '1.4', 'stroke-linecap': 'round' as const, 'stroke-linejoin': 'round' as const }
 

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -496,7 +496,6 @@ export const unreadCount = computed(() =>
 // capped at RECENT_CAP. Without the floor the section vanishes
 // after a quiet hour; without the cap it grows unbounded on busy
 // daemons.
-
 export const RECENT_WINDOW_MS = 60 * 60 * 1000
 export const RECENT_FLOOR = 3
 export const RECENT_CAP = 10

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -272,6 +272,26 @@ export const peerStatusByName = computed<ReadonlyMap<string, string>>(() => {
 
 /** True when a session lives on a peer we can't reach right now.
  *  Local sessions (peer === undefined) are never unavailable. */
+/**
+ * Single source of truth for the visual dot state of a session, used
+ * by both the sidebar row and the wide dashboard row. Encodes the
+ * precedence: error > working > unread > recent terminal activity.
+ * Selection-aware muting ("unread is suppressed when you're already
+ * viewing the session") lives at the call site, not here.
+ */
+export function sessionDotState(
+  session: Session,
+  am: ReadonlyMap<string, 'active' | 'fading'>,
+): DotState {
+  if (session.alive && session.status?.error)   return 'error'
+  if (session.alive && session.status?.working) return 'working'
+  if (session.unread)                            return 'unread'
+  const act = am.get(session.id)
+  if (act === 'active') return 'active'
+  if (act === 'fading') return 'fading'
+  return 'none'
+}
+
 export function isSessionUnavailable(
   session: { peer?: string },
   statusByName: ReadonlyMap<string, string>,
@@ -456,6 +476,114 @@ export const backgroundActivity = computed((): DotState => {
 /** Count of unread sessions (excluding selected). */
 export const unreadCount = computed(() =>
   sessions.value.filter(s => s.id !== selectedId.value && s.alive && s.unread).length,
+)
+
+// ── Home dashboard partitioning ─────────────────────────────────────────────
+//
+// The home page surfaces sessions in three sections. Each session
+// appears in at most one section; priority is Needs attention >
+// Running > Recent. Sort within every section is newest-first by
+// last_activity_at (falling back to created_at for sessions that
+// have not transitioned yet, so a brand-new idle session shows at
+// the top of Running and an old quiet one drops to the bottom).
+//
+// Recent surfaces idle-alive sessions worth glancing back at:
+// shells at a prompt that were recently doing something, or
+// adapter sessions between turns. Dead sessions are NOT included
+// (they live on the project page). Shape: entries whose
+// last_activity_at falls within RECENT_WINDOW_MS, plus enough
+// additional entries by recency to reach a floor of RECENT_FLOOR,
+// capped at RECENT_CAP. Without the floor the section vanishes
+// after a quiet hour; without the cap it grows unbounded on busy
+// daemons.
+
+export const RECENT_WINDOW_MS = 60 * 60 * 1000
+export const RECENT_FLOOR = 3
+export const RECENT_CAP = 10
+
+function activityTimeMs(s: Session): number {
+  // last_activity_at is canonical when present (daemon-stamped on
+  // noteworthy transitions). For never-transitioned sessions, fall
+  // back to created_at so they sort relative to peers rather than
+  // landing at the epoch.
+  const stamp = s.last_activity_at ?? s.created_at
+  const t = Date.parse(stamp)
+  return Number.isFinite(t) ? t : 0
+}
+
+function byActivityDesc(a: Session, b: Session): number {
+  const dt = activityTimeMs(b) - activityTimeMs(a)
+  if (dt !== 0) return dt
+  // Stable tiebreaker on id. Sessions with identical timestamps
+  // (notably corpses persisted before last_activity_at existed,
+  // which all fall back to created_at) must sort identically
+  // across re-renders. Without this, every SSE event rebuilds
+  // sessions.value in a different order and the section visibly
+  // re-orders the tied entries.
+  return a.id < b.id ? -1 : a.id > b.id ? 1 : 0
+}
+
+/**
+ * Pure partition of a session list into the three dashboard sections.
+ * Exported so tests can drive it with fixtures and `now` injected
+ * (real wall-clock time would otherwise make the Recent floor/window
+ * untestable).
+ *
+ * Alive-only: dead sessions never appear on the home dashboard.
+ * They live exclusively in the project page's "All sessions"
+ * section (see partitionForProject). The home page is a triage
+ * surface for sessions you can still interact with right now;
+ * dead corpses would dilute the signal.
+ */
+export function partitionForHome(
+  all: readonly Session[],
+  now: number,
+): { needsAttention: Session[]; running: Session[]; recent: Session[] } {
+  const needsAttention: Session[] = []
+  const running: Session[] = []
+  const leftover: Session[] = []
+
+  for (const s of all) {
+    // Dead sessions never surface on the home dashboard; they live
+    // only in the project page's "All sessions" section.
+    if (!s.alive) continue
+    // status.error is intentionally NOT escalated here: most error
+    // states come from background subcommands that exited non-zero
+    // without the agent itself halting, so flagging them as "needs
+    // attention" produces false alarms. The per-row error dot still
+    // shows individually.
+    if (s.unread) {
+      needsAttention.push(s)
+    } else if (s.status?.working) {
+      running.push(s)
+    } else {
+      // Idle-alive: not unread, not working. Falls to Recent if
+      // its last_activity_at is within the window (or via the
+      // floor when the daemon is quiet).
+      leftover.push(s)
+    }
+  }
+  needsAttention.sort(byActivityDesc)
+  running.sort(byActivityDesc)
+  leftover.sort(byActivityDesc)
+
+  // Recent: leftover (idle-alive) entries whose timestamp is
+  // within the window, or top-N by recency if fewer than the
+  // floor qualify.
+  const withinWindow = leftover.filter(s => {
+    const t = activityTimeMs(s)
+    return t > 0 && now - t < RECENT_WINDOW_MS
+  })
+  const recent = (withinWindow.length >= RECENT_FLOOR
+    ? withinWindow
+    : leftover.slice(0, RECENT_FLOOR)
+  ).slice(0, RECENT_CAP)
+
+  return { needsAttention, running, recent }
+}
+
+export const homePartition = computed(() =>
+  partitionForHome(sessions.value, Date.now()),
 )
 
 // ── Mutators ────────────────────────────────────────────────────────────────

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -589,6 +589,101 @@ body {
   box-shadow: inset 0 -2px 0 0 var(--accent);
 }
 
+/* ── Wide session row (dashboard / project page) ────────────────────── */
+/* Two-line variant of the sidebar's SessionItem. Same dot conventions
+   and close-button behavior; line 2 carries optional project / cwd /
+   status / age metadata. The host suffix uses the existing
+   .host-suffix styling. */
+
+.session-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border-radius: 6px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  text-decoration: none;
+  color: inherit;
+  transition: background 0.1s, border-color 0.15s;
+  position: relative;
+}
+.session-row:hover {
+  background: var(--bg-hover);
+  border-color: var(--text-muted);
+}
+.session-row.selected {
+  border-color: var(--accent);
+}
+.session-row.unavailable {
+  opacity: 0.55;
+}
+
+.session-row-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.session-row-title {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.session-row-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  margin-top: 3px;
+  font-size: 11px;
+  color: var(--text-muted);
+  min-width: 0;
+}
+.session-row-sep {
+  color: var(--text-muted);
+  opacity: 0.6;
+}
+.session-row-project {
+  color: var(--text);
+  opacity: 0.85;
+}
+.session-row-cwd {
+  font-family: var(--font-mono, monospace);
+}
+.session-row-status {
+  font-style: italic;
+}
+.session-row-age {
+  font-variant-numeric: tabular-nums;
+}
+
+.session-row-close {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 2px 6px;
+  border-radius: 4px;
+  opacity: 0;
+  transition: opacity 0.1s, color 0.1s, background 0.1s;
+}
+.session-row:hover .session-row-close,
+.session-row.selected .session-row-close {
+  opacity: 1;
+}
+.session-row-close:hover {
+  color: var(--text);
+  background: var(--bg-active);
+}
+@media (hover: none) {
+  .session-row-close { opacity: 1; }
+}
+
 /* On touch devices (no hover), show interactive buttons permanently */
 @media (hover: none) {
   .launch-container.folder-launch-btn { opacity: 1; }

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -1655,14 +1655,22 @@ body {
 
 /* ── Home page ── */
 
-.home {
+/* The scroll container fills the available width so the scrollbar
+ * tracks the viewport edge (not a mid-page column edge). Content is
+ * constrained and centered via the children rule below: keep the
+ * column readable, keep the chrome predictable. */
+.page {
   flex: 1;
+  min-width: 0;
   overflow-y: auto;
   padding: 32px 32px 48px;
-  max-width: 640px;
-  min-width: 0;
   display: flex;
   flex-direction: column;
+  align-items: center;
+}
+.page > * {
+  width: 100%;
+  max-width: 640px;
 }
 
 .home-section-title {
@@ -1674,64 +1682,117 @@ body {
   margin-bottom: 12px;
 }
 
-/* Project cards */
+/* Dashboard sections */
 
-.home-project-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
-  gap: 8px;
-  margin-bottom: 32px;
+.home-section {
+  margin-bottom: 24px;
 }
+.home-section-body {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+/* Projects list */
 
-.home-project-card {
-  background: var(--bg-surface);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 12px 14px;
+.home-projects-section {
+  margin-bottom: 16px;
+}
+.home-projects-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 8px;
+}
+.home-project-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.home-project-link {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 12px;
+  border-radius: 6px;
   text-decoration: none;
   color: inherit;
-  transition: background 0.1s, border-color 0.15s;
+  transition: background 0.1s;
 }
-.home-project-card:hover {
+.home-project-link:hover {
   background: var(--bg-hover);
-  border-color: var(--text-muted);
 }
-
 .home-project-name {
   font-size: 14px;
   font-weight: 600;
   color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
-
 .home-project-count {
   font-size: 12px;
-  margin-top: 4px;
+  white-space: nowrap;
 }
-
 .home-project-alive {
   color: var(--status-connected);
 }
-
 .home-project-rest {
   color: var(--text-muted);
 }
+.home-project-launch {
+  flex-shrink: 0;
+}
 
+.home-add-project {
+  background: none;
+  border: 1px dashed var(--border);
+  border-radius: 6px;
+  color: var(--text-muted);
+  font-size: 12px;
+  padding: 8px 12px;
+  cursor: pointer;
+  width: 100%;
+  text-align: left;
+  transition: border-color 0.1s, color 0.1s, background 0.1s;
+}
+.home-add-project:hover {
+  border-color: var(--text-muted);
+  color: var(--text);
+  background: var(--bg-hover);
+}
+
+.home-empty-hint {
+  font-size: 13px;
+  color: var(--text-muted);
+  padding: 16px 0;
+}
+.home-empty-action {
+  background: none;
+  border: none;
+  color: var(--accent);
+  cursor: pointer;
+  padding: 0;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  font: inherit;
+}
+
+/* A single muted sentence. Uniform font and size; the inline refresh
+ * button and update link inherit everything except the accent color
+ * and underline, so the row reads as flowing prose, not a toolbar. */
 .home-footer {
-  display: flex;
-  align-items: center;
-  gap: 8px;
   margin-top: auto;
   padding-top: 16px;
   border-top: 1px solid var(--border);
-}
-
-.home-footer-version {
   font-size: 11px;
   color: var(--text-muted);
+  line-height: 1.5;
 }
-
-.home-footer-reload {
-  font-size: 11px;
+.home-footer-link {
+  font: inherit;
   color: var(--accent);
   background: none;
   border: none;
@@ -1740,20 +1801,8 @@ body {
   text-decoration: underline;
   text-underline-offset: 2px;
 }
-
-.home-footer-reload:hover {
+.home-footer-link:hover {
   color: var(--text);
-}
-
-.home-footer-update {
-  font-size: 11px;
-  color: oklch(85% 0.1 145);
-  text-decoration: none;
-}
-
-.home-footer-update:hover {
-  text-decoration: underline;
-  text-underline-offset: 2px;
 }
 
 
@@ -1936,7 +1985,7 @@ body {
   }
 
   /* Home / project hub: tighter padding on touch devices */
-  .home {
+  .page {
     padding: 20px 16px 48px;
   }
 


### PR DESCRIPTION
## Summary

Step 3 of the home/project/sidebar polish thread. Replaces the project-grid homepage with an activity-first dashboard, introduces a shared wide `<SessionRow>` for use across surfaces.

**Stacks on #230.** Merge order: #229 → #230 → this.

## What changes

- **New `<SessionRow>` component** (`session-row.tsx`). Two-line wide variant of the sidebar's `SessionItem`: title on line 1, optional `project · cwd · status · age` plus host suffix on line 2. Same dot conventions, sleeping/unavailable icons, hover-revealed `×` close. Deliberately a separate component from `SessionItem`: the sidebar variant is dense, drag-aware, and folder-scoped, this one is loose and standalone. Unifying behind a density prop would accumulate flags faster than it would save code.
- **Recency partitioning in `store.ts`** (`partitionForHome`). Pure function over a session list and a `now`, returns `{ needsAttention, running, recent }`. Section priority: `needsAttention > running > recent` (each session appears in at most one). Sort: newest-first by `last_activity_at`, falling back to `created_at` for sessions that have not transitioned yet. Recent shape: entries within `RECENT_WINDOW_MS` (1h), with floor `RECENT_FLOOR` (3) and cap `RECENT_CAP` (10).
- **Home dashboard** (`home.tsx`). Three activity sections at top (empty sections hidden), projects list below (each row: project name + host suffix + counts + launch `+`, click navigates), `+ Add project` footer button reusing the existing manage-projects modal unchanged.
- **`sessionDotState` lifted to `store.ts`** as the single source of truth for both the sidebar row and the new wide row.

## Why

The home page was a project picker that mostly duplicated what the sidebar already does. The dashboard answers a different question: *what across all my hosts needs my attention right now?* The activity sections cut to that without forcing the user to scan a project tree mentally.

Recency is sourced from `last_activity_at` (added in #229), bumped by the owning daemon on exactly: exited, unread on, working on, error on. A brand-new idle session has no timestamp and falls back to `created_at`, landing at the top of Running where it belongs.

## Tests

`apps/gmux-web/src/home-partition.test.ts` (12 tests):

- Section assignment: unread → needsAttention; error (no unread) → needsAttention; alive non-attention → running; dead → recent.
- Priority dedup: a dead-and-unread session goes to needsAttention, not recent.
- Sort: newest-first by `last_activity_at`, `created_at` fallback for never-transitioned sessions.
- Recent window: ≥floor inside window → ship only the in-window set; <floor inside → top-floor by recency overall.
- Recent cap: pathological-many recent transitions clip at `RECENT_CAP`.
- Empty leftover (all alive) → empty Recent.

## Out of scope (deferred)

- Project page rewrite using the same three-section pattern + adaptive cwd subtitle.
- Manage-projects modal rework (the `+ Add project` button opens it unchanged).
- Realtime tick signal to drop entries out of Recent as wall-clock advances. The floor handles the empty-section case; if Recent staleness becomes a felt issue we add a 30s ticker.

## Verification

- `pnpm lint` and `pnpm test` clean (406 passing, 12 new).
- Dev daemon visual check: section ordering correct, sleeping icon and `exited (N)` status render on Recent rows, project counts and launch `+` work, `+ Add project` opens the existing modal, hover reveals the `×` button.
