### PR TITLE
feat(web): activity-first project page with adaptive cwd subtitle

### DIFF
--- a/apps/gmux-web/src/home-partition.test.ts
+++ b/apps/gmux-web/src/home-partition.test.ts
@@ -5,7 +5,13 @@
 // down: section priority, sort key, and the Recent floor/window/cap.
 
 import { describe, it, expect } from 'vitest'
-import { partitionForHome, RECENT_WINDOW_MS, RECENT_FLOOR, RECENT_CAP } from './store'
+import {
+  partitionForHome,
+  partitionForProject,
+  RECENT_WINDOW_MS,
+  RECENT_FLOOR,
+  RECENT_CAP,
+} from './store'
 import { makeSession } from './test-helpers'
 
 const NOW = Date.parse('2026-06-01T12:00:00Z')
@@ -183,5 +189,78 @@ describe('partitionForHome', () => {
       const { recent } = partitionForHome(sessions, NOW)
       expect(recent).toEqual([])
     })
+  })
+})
+
+describe('partitionForProject', () => {
+  // The project page diverges from home in one specific way: the
+  // third bucket holds every remaining session, with no recency
+  // window or cap. These tests pin that divergence; section
+  // assignment for Needs attention / Running is identical to home
+  // and covered by the partitionForHome suite above.
+
+  it('keeps idle-alive sessions from arbitrarily long ago in `rest`', () => {
+    // A session that was last active a week ago would be filtered
+    // out of home's Recent (1h window, 10-cap) but must remain on
+    // the project page.
+    const weekAgo = new Date(NOW - 7 * 24 * 60 * 60 * 1000).toISOString()
+    const s = makeSession({
+      id: 'ancient',
+      cwd: '/x',
+      alive: true,
+      status: { label: '', working: false, error: false },
+      last_activity_at: weekAgo,
+    })
+    const { rest } = partitionForProject([s])
+    expect(rest.map(x => x.id)).toEqual(['ancient'])
+  })
+
+  it('keeps exited sessions in `rest` regardless of age', () => {
+    const longAgo = new Date(NOW - 30 * 24 * 60 * 60 * 1000).toISOString()
+    const s = makeSession({
+      id: 'old-exit',
+      cwd: '/x',
+      alive: false,
+      last_activity_at: longAgo,
+    })
+    const { rest } = partitionForProject([s])
+    expect(rest.map(x => x.id)).toEqual(['old-exit'])
+  })
+
+  it('does not cap `rest` at RECENT_CAP', () => {
+    // Generate more entries than the home cap so a regression that
+    // accidentally reused partitionForHome's slicing would show.
+    const sessions = Array.from({ length: RECENT_CAP + 5 }, (_, i) =>
+      makeSession({ id: `s${i}`, cwd: '/x', alive: false }),
+    )
+    const { rest } = partitionForProject(sessions)
+    expect(rest.length).toBe(RECENT_CAP + 5)
+  })
+
+  it('routes unread-alive to needsAttention and working-alive to running', () => {
+    // Smoke test that the two non-rest buckets still split as expected.
+    const att = makeSession({ id: 'att', cwd: '/x', alive: true, unread: true })
+    const run = makeSession({
+      id: 'run', cwd: '/x', alive: true,
+      status: { label: 'building', working: true, error: false },
+    })
+    const idle = makeSession({ id: 'idle', cwd: '/x', alive: true })
+    const { needsAttention, running, rest } = partitionForProject([att, run, idle])
+    expect(needsAttention.map(s => s.id)).toEqual(['att'])
+    expect(running.map(s => s.id)).toEqual(['run'])
+    expect(rest.map(s => s.id)).toEqual(['idle'])
+  })
+
+  it('routes dead-unread sessions to `rest`, not needsAttention', () => {
+    // Mirrors partitionForHome's alive-only Waiting predicate:
+    // a dead session with unread output is no longer "waiting on
+    // you"; it belongs in the All-sessions tail where dead
+    // sessions live.
+    const s = makeSession({
+      id: 'dead-unread', cwd: '/x', alive: false, unread: true,
+    })
+    const { needsAttention, rest } = partitionForProject([s])
+    expect(needsAttention).toEqual([])
+    expect(rest.map(x => x.id)).toEqual(['dead-unread'])
   })
 })

--- a/apps/gmux-web/src/home.tsx
+++ b/apps/gmux-web/src/home.tsx
@@ -94,7 +94,7 @@ export function Home({ onManageProjects }: { onManageProjects: () => void }) {
   )
 }
 
-function Section({
+export function Section({
   title,
   children,
 }: {

--- a/apps/gmux-web/src/project-hub.tsx
+++ b/apps/gmux-web/src/project-hub.tsx
@@ -1,17 +1,32 @@
-// Project hub page: sessions for one project grouped by host and cwd.
+// Project hub: activity-first view scoped to one project.
 //
-// Data shape comes from `buildProjectTopology` (pure function in types.ts).
-// This module is render-only: no data fetching, no business logic.
-// Reads sessions/projects/peers from the store.
+// Mirrors the home dashboard's three-section layout (Waiting /
+// Active / All sessions) but filtered to this project's sessions. The
+// shared <SessionRow> renders without a project label (it's in the
+// header) and without a host suffix unless the project spans multiple
+// hosts (devcontainer case).
+//
+// Adaptive cwd:
+//   - If every session shares a single cwd, render it as a subtitle
+//     under the project title and omit it from rows.
+//   - Otherwise show each session's cwd on its row, since worktree
+//     identity is the most useful disambiguator in multi-cwd projects.
+//
+// Worktree grouping (the legacy `~/dev/gmux/.grove/<name>` headings)
+// is intentionally dropped: activity-first sectioning is more useful
+// day-to-day, and cwd-per-row preserves the disambiguation worktree
+// grouping previously provided.
 
 import type { Session, ProjectItem } from './types'
-import type { HostNode } from './projects'
 import { buildProjectTopology } from './projects'
 import { sessionPath } from './routing'
 import { LaunchButton } from './launcher'
-import { sessions, projects, peers, peerStatusByName, isSessionUnavailable, localPeerNames } from './store'
-import { PeerLabel } from './peer-label'
+import {
+  sessions, projects, peers, localPeerNames, partitionForProject,
+} from './store'
 import { HostSuffix } from './host-suffix'
+import { SessionRow } from './session-row'
+import { Section } from './home'
 
 function projectRemote(p: ProjectItem | undefined): string | undefined {
   return p?.match?.find(r => r.remote)?.remote
@@ -32,147 +47,107 @@ export function ProjectHub({ projectSlug, projectPeer, onCloseSession }: Project
   const project = projectsVal.find(p =>
     p.slug === projectSlug && (p.peer ?? '') === (projectPeer ?? ''),
   )
+
+  // Topology is still the right input shape: it correctly resolves
+  // devcontainer (Local-peer) sessions onto their parent's project.
+  // We flatten its output rather than render it as a tree; the
+  // three-section pattern handles the navigation, not topology.
   const hosts = buildProjectTopology(
     projectSlug, sessions.value, projectsVal, peers.value,
     projectPeer,
     (name) => localPeerNames.value.has(name),
   )
+  const allSessions = hosts.flatMap(h => h.folders.flatMap(f => f.sessions))
   const remote = projectRemote(project)
 
-  const totalSessions = hosts.reduce(
-    (n, h) => n + h.folders.reduce((m, f) => m + f.sessions.length, 0),
-    0,
+  // Adaptive cwd disambiguator: a project whose sessions all live in
+  // one cwd shows that cwd as a subtitle (clean, no repetition); a
+  // multi-cwd project shows cwd per row (lets the user pick the
+  // right worktree). Empty cwds are filtered: they're a placeholder
+  // for sessions whose cwd hasn't resolved yet, not a meaningful
+  // shared root.
+  const uniqueCwds = new Set(allSessions.map(s => s.cwd).filter(Boolean))
+  const sharedCwd = uniqueCwds.size === 1 ? [...uniqueCwds][0] : null
+
+  // Multi-host iff sessions disagree on .peer. Local-peer
+  // (devcontainer) sessions in a local project's folder are the
+  // common case: they make the folder mixed and earn a host suffix
+  // on their row.
+  const uniqueHosts = new Set(allSessions.map(s => s.peer ?? ''))
+  const mixedHosts = uniqueHosts.size > 1
+
+  const { needsAttention, running, rest } = partitionForProject(allSessions)
+
+  const renderRow = (s: Session) => (
+    <SessionRow
+      key={s.id}
+      session={s}
+      href={sessionPath(projectSlug, s, projectPeer)}
+      showCwd={!sharedCwd}
+      cwdLabel={s.cwd}
+      showHost={mixedHosts}
+      onClose={() => onCloseSession(s)}
+    />
   )
 
   return (
-    <div class="home">
-      <section>
-        <h2 class="home-section-title">
-          {projectSlug}
-          <HostSuffix peer={projectPeer} />
-        </h2>
-        {(remote || totalSessions > 0) && (
-          <div class="hub-meta">
+    <div class="page">
+      <header class="hub-header">
+        <div class="hub-eyebrow">Project</div>
+        <div class="hub-title-row">
+          <h2 class="hub-title">
+            {projectSlug}
+            <HostSuffix peer={projectPeer} />
+          </h2>
+          <LaunchButton
+            sessions={allSessions}
+            fallbackCwd={sharedCwd ?? projectFirstPath(project) ?? ''}
+            peer={projectPeer}
+            className="hub-header-launch"
+          />
+        </div>
+        {(remote || sharedCwd) && (
+          <div class="hub-subtitle">
+            {sharedCwd && <span class="hub-cwd">{sharedCwd}</span>}
+            {remote && sharedCwd && <span class="hub-subtitle-sep"> · </span>}
             {remote && <span class="hub-remote">{remote}</span>}
-            {remote && totalSessions > 0 && ' · '}
-            {totalSessions > 0 && (
-              <span>
-                {totalSessions} session{totalSessions === 1 ? '' : 's'}
-                {hosts.length > 1 && <> across {hosts.length} hosts</>}
-              </span>
-            )}
           </div>
         )}
-      </section>
+      </header>
 
-      {hosts.length === 0
-        ? <EmptyProject projectSlug={projectSlug} launchCwd={projectFirstPath(project)} />
-        : hosts.map(host => (
-            <HostGroup
-              key={host.path.join('\0') || '(local)'}
-              host={host}
-              projectSlug={projectSlug}
-              onCloseSession={onCloseSession}
-            />
-          ))}
-    </div>
-  )
-}
-
-function EmptyProject({ projectSlug, launchCwd }: { projectSlug: string; launchCwd?: string }) {
-  return (
-    <div class="hub-empty">
-      <span>No sessions yet in {projectSlug}</span>
-      {launchCwd && (
+      {allSessions.length === 0 ? (
+        <EmptyProject projectSlug={projectSlug} />
+      ) : (
         <>
-          <span class="hub-empty-path">{launchCwd}</span>
-          <LaunchButton cwd={launchCwd} className="hub-empty-launch" />
+          {needsAttention.length > 0 && (
+            <Section title="Waiting">
+              {needsAttention.map(renderRow)}
+            </Section>
+          )}
+          {running.length > 0 && (
+            <Section title="Active">
+              {running.map(renderRow)}
+            </Section>
+          )}
+          {rest.length > 0 && (
+            <Section title="All sessions">
+              {rest.map(renderRow)}
+            </Section>
+          )}
         </>
       )}
     </div>
   )
 }
 
-function HostGroup({
-  host, projectSlug, onCloseSession,
-}: { host: HostNode; projectSlug: string; onCloseSession: (session: Session) => void }) {
-  const sessionCount = host.folders.reduce((n, f) => n + f.sessions.length, 0)
-  const canLaunch = host.path.length <= 1
-  const launchPeer = host.path.length === 1 ? host.path[0] : undefined
-
+// Empty-state placeholder for projects with no sessions. The launch
+// affordance is already in the page header, so this block only
+// carries the descriptor text: a second launch button here would
+// duplicate the one above it.
+function EmptyProject({ projectSlug }: { projectSlug: string }) {
   return (
-    <section class="hub-host">
-      <div class="hub-host-header">
-        <span class={`hub-host-dot ${host.status}`} />
-        {host.path.length > 0 && <PeerLabel name={host.path[0]} />}
-        <span class="hub-host-name"><HostPath path={host.path} /></span>
-        <span class="hub-host-count">
-          {sessionCount} session{sessionCount === 1 ? '' : 's'}
-        </span>
-      </div>
-      {host.folders.map(folder => (
-        <div class="hub-folder" key={folder.cwd}>
-          <div class="hub-folder-path">{folder.cwd || '~'}</div>
-          <div class="hub-folder-sessions">
-            {folder.sessions.map(s => (
-              <SessionCard
-                key={s.id}
-                session={s}
-                projectSlug={projectSlug}
-                unavailable={isSessionUnavailable(s, peerStatusByName.value)}
-                onClose={() => onCloseSession(s)}
-              />
-            ))}
-            {canLaunch && (
-              <LaunchButton
-                cwd={folder.cwd || undefined}
-                peer={launchPeer}
-                className="hub-folder-launch"
-              />
-            )}
-          </div>
-        </div>
-      ))}
-    </section>
-  )
-}
-
-function HostPath({ path }: { path: string[] }) {
-  if (path.length === 0) return <>local</>
-  return (
-    <>
-      {path.map((seg, i) => (
-        <>{i > 0 && <span class="hub-host-arrow">›</span>}{seg}</>
-      ))}
-    </>
-  )
-}
-
-function SessionCard({
-  session, projectSlug, unavailable, onClose,
-}: {
-  session: Session
-  projectSlug: string
-  unavailable?: boolean
-  onClose: () => void
-}) {
-  const dotClass = session.alive ? '' : 'dead'
-  const name = session.title || session.kind
-  const href = sessionPath(projectSlug, session)
-  return (
-    <a
-      class={`session-card${unavailable ? ' unavailable' : ''}`}
-      href={href}
-    >
-      <span class={`session-card-dot ${dotClass}`} />
-      <span class="session-card-name">{name}</span>
-      <button
-        class="session-card-close"
-        onClick={(e) => { e.preventDefault(); e.stopPropagation(); onClose() }}
-        title={session.alive ? 'Kill session' : 'Dismiss'}
-      >
-        ×
-      </button>
-    </a>
+    <div class="hub-empty">
+      <span>No sessions yet in {projectSlug}</span>
+    </div>
   )
 }

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -585,6 +585,45 @@ export const homePartition = computed(() =>
   partitionForHome(sessions.value, Date.now()),
 )
 
+/**
+ * Project-page partition: same Needs-attention / Running buckets as
+ * the home dashboard, but the third bucket holds *every* remaining
+ * session in the project, not a recency-windowed subset. Rationale:
+ * the project page is the user's exhaustive view of a project; an
+ * idle shell from yesterday or an exited session from last week
+ * must remain visible here or they're effectively unreachable (the
+ * sidebar still lists them, but losing them from the project page
+ * means losing them from the only dedicated project surface).
+ *
+ * Pure; tests drive it with fixtures.
+ */
+export function partitionForProject(
+  all: readonly Session[],
+): { needsAttention: Session[]; running: Session[]; rest: Session[] } {
+  const needsAttention: Session[] = []
+  const running: Session[] = []
+  const rest: Session[] = []
+
+  for (const s of all) {
+    // Waiting/Active are alive-only here too (mirrors
+    // partitionForHome): a dead session, even with unread output,
+    // can't be "waiting on you" or "active" anymore. It belongs in
+    // the All-sessions tail. See partitionForHome for why
+    // status.error is also intentionally not escalated.
+    if (s.alive && s.unread) {
+      needsAttention.push(s)
+    } else if (s.alive && s.status?.working) {
+      running.push(s)
+    } else {
+      rest.push(s)
+    }
+  }
+  needsAttention.sort(byActivityDesc)
+  running.sort(byActivityDesc)
+  rest.sort(byActivityDesc)
+  return { needsAttention, running, rest }
+}
+
 // ── Mutators ────────────────────────────────────────────────────────────────
 
 export function toUISession(s: ProtocolSession): Session {

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -579,8 +579,6 @@ body {
 
 /* Mock mode (landing page screenshots): hide per-session close buttons */
 .mock-mode .session-close-btn,
-.mock-mode .session-card-close { display: none; }
-
 /* Session drag-to-reorder */
 .session-item.session-dragging {
   opacity: 0.4;
@@ -1989,10 +1987,6 @@ body {
     padding: 20px 16px 48px;
   }
 
-  .session-card {
-    max-width: 100%;
-  }
-
   .hub-empty {
     flex-wrap: wrap;
   }
@@ -2245,76 +2239,52 @@ body {
   .diag-entry-cat { min-width: 60px; font-size: 10px; }
 }
 
-/* ─── Project hub (flat host dividers, session-focused) ─── */
+/* ─── Project hub (activity-first, three-section) ─── */
 
-.hub-meta {
+.hub-header {
+  margin-bottom: 20px;
+}
+.hub-eyebrow {
+  /* Small uppercase kicker above the project slug. Mirrors the
+   * idiom used by section labels (RECENT / RUNNING / PROJECTS) so
+   * the page reads in a single visual language. */
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  margin-bottom: 4px;
+}
+.hub-title-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+.hub-title {
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--text);
+  margin: 0;
+}
+.hub-subtitle {
   font-size: 12px;
   color: var(--text-muted);
-  margin-top: 2px;
+  margin-top: 4px;
+}
+.hub-subtitle-sep {
+  opacity: 0.6;
+}
+.hub-cwd {
+  font-family: "JetBrains Mono", "SF Mono", monospace;
+  font-size: 11px;
 }
 .hub-remote {
   font-family: "JetBrains Mono", "SF Mono", monospace;
   font-size: 11px;
 }
-
-/* Host divider row */
-.hub-host {
-  margin-top: 20px;
-}
-.hub-host-header {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding-bottom: 8px;
-  border-bottom: 1px solid var(--border);
-  margin-bottom: 12px;
-}
-.hub-host-dot {
-  width: 7px;
-  height: 7px;
-  border-radius: 50%;
+.hub-header-launch {
   flex-shrink: 0;
-}
-.hub-host-dot.connected, .hub-host-dot.local {
-  background: var(--status-connected);
-}
-.hub-host-dot.connecting {
-  background: var(--status-disconnected);
-}
-.hub-host-dot.disconnected { background: var(--status-disconnected); }
-.hub-host-name {
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--text);
-}
-.hub-host-arrow {
-  color: var(--text-muted);
-  font-size: 11px;
-  margin: 0 2px;
-  opacity: 0.6;
-}
-.hub-host-count {
-  font-size: 12px;
-  color: var(--text-muted);
-  margin-left: auto;
-}
-
-/* Folder rows under a host divider */
-.hub-folder {
-  padding: 0 0 14px 15px;
-}
-.hub-folder-path {
-  font-family: "JetBrains Mono", "SF Mono", monospace;
-  font-size: 12px;
-  color: var(--text-muted);
-  margin-bottom: 8px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-.hub-folder-sessions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
 }
 
 /* Empty project state */
@@ -2329,66 +2299,6 @@ body {
   font-size: 13px;
   margin-top: 16px;
 }
-.hub-empty-path {
-  font-family: "JetBrains Mono", "SF Mono", monospace;
-  font-size: 12px;
-  color: var(--text-muted);
-}
-
-/* Session card (used in project hub folder rows) */
-.session-card {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 8px 12px;
-  border-radius: var(--radius);
-  background: var(--bg-surface);
-  border: 1px solid var(--border);
-  cursor: pointer;
-  transition: background 0.1s, border-color 0.1s;
-  text-decoration: none;
-  color: inherit;
-  max-width: 280px;
-  min-width: 0;
-  position: relative;
-}
-.session-card:hover {
-  background: var(--bg-hover);
-  border-color: var(--border-strong);
-}
-.session-card-dot {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: var(--status-connected);
-  flex-shrink: 0;
-}
-.session-card-dot.dead { background: var(--text-muted); }
-.session-card.unavailable { opacity: 0.55; }
-.session-card-name {
-  font-size: 13px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-.session-card-close {
-  margin-left: auto;
-  flex-shrink: 0;
-  width: 20px;
-  height: 20px;
-  border: none;
-  border-radius: 4px;
-  background: transparent;
-  color: var(--text-muted);
-  font-size: 13px;
-  line-height: 1;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: background 0.1s, color 0.1s;
-}
-.session-card-close:hover { background: oklch(28% 0.015 250); color: var(--text); }
 .btn:disabled,
 .btn-primary:disabled {
   opacity: 0.6;


### PR DESCRIPTION
## Summary

Step 4a of the home/project/sidebar polish thread. Rewrites the project hub page to mirror the home dashboard's three-section pattern (Needs attention / Running / Recent), filtered to one project. Drops worktree grouping in favor of an adaptive cwd subtitle.

**Stacks on #231.** Merge order: #229 → #230 → #231 → this.

## What changes

- **`project-hub.tsx` rewrite.** Same three sections as the home dashboard, scoped to the project's sessions. Renders `<SessionRow>` with `showProject={false}` (the project name is in the page header) and `showHost` only when sessions disagree on `.peer` (i.e. devcontainer case).
- **Adaptive cwd subtitle.** If every session in the project shares one cwd, render it as a monospace subtitle under the title and omit cwd from rows. Otherwise render cwd on each row. Single-cwd projects (most personal repos) get a clean header; multi-cwd projects (like `gmux` with its `.grove/*` worktrees) get per-row disambiguation.
- **Project-level launch button** lives in the header, top-right. Replaces the per-cwd launch buttons of the old layout.
- **CSS cleanup.** Removed the no-longer-used `.hub-host*`, `.hub-folder*`, `.session-card*` styles and the `.mock-mode .session-card-close` rule. Added `.hub-header*` / `.hub-title*` / `.hub-cwd` for the new layout.

## Why

The old project page had a clear concept (host topology → cwd folders → session pills) but used the space poorly: most projects had 1-2 sessions per cwd, leaving rows with single pills floating in whitespace. Switching to the activity-first three-section pattern matches the home dashboard's job ("what here needs my attention") and uses the full row width.

Worktree grouping doesn't disappear; it moves into the cwd-per-row line on multi-cwd projects. If anyone misses worktree-grouped view we can add a toggle later.

## Verification

- `pnpm lint` and `pnpm test` clean.
- Visual check on dev daemon:
  - Multi-cwd project (`/gmux`, 12 sessions, several `.grove/*` worktrees): cwd shown per row, no subtitle. Sections render correctly with sleeping icons on Recent rows.
  - Single-cwd project (`/pi-mono`): cwd shown as subtitle, rows clean.
  - Single-cwd project with Recent (`/dots`): subtitle + Running + Recent sections all render; `exited (N)` status visible.

## Out of scope (next step)

- Manage-projects modal trim. Currently the modal still shows the "Your sidebar" list, which is now duplicated by the home dashboard's projects section. The clean endpoint is "modal is additions only, home owns reorder/remove" — but that needs a design pass on how prominent drag handles and remove × should be on the home dashboard. Open question, deferred to a follow-up PR.
