### PR TITLE
feat(web): home owns reorder/remove; modal trimmed to additions only

### DIFF
--- a/apps/gmux-web/src/home.tsx
+++ b/apps/gmux-web/src/home.tsx
@@ -8,17 +8,63 @@
 // Section semantics, sort order, and the Recent floor/window/cap
 // live in store.ts:partitionForHome. This file is presentation.
 
-import { health, folders, homePartition, dismissSession } from './store'
+import { useCallback, useState } from 'preact/hooks'
+import {
+  health, folders, homePartition, dismissSession, projects,
+  updateProjects, removeProject, removePeerReference,
+} from './store'
 import { HostSuffix } from './host-suffix'
 import { SessionRow } from './session-row'
 import { LaunchButton } from './launcher'
 import { sessionPath } from './routing'
-import type { Folder, Session } from './types'
+import type { Folder, Session, ProjectItem } from './types'
+
+/** Drag-to-reorder transient state. `from` is the index lifted off,
+ *  `over` is the current insertion target. Set to null when nothing
+ *  is being dragged. Lives in the component, not the store: it's
+ *  view-only and reset on every mouse-up. */
+interface DragState { from: number; over: number }
+
+function reorder<T>(arr: readonly T[], from: number, to: number): T[] {
+  const out = [...arr]
+  const [moved] = out.splice(from, 1)
+  out.splice(to, 0, moved)
+  return out
+}
 
 export function Home({ onManageProjects }: { onManageProjects: () => void }) {
   const healthVal = health.value
   const foldersVal = folders.value
+  const projectsVal = projects.value
   const { needsAttention, running, recent } = homePartition.value
+
+  // Drag-to-reorder state for the Projects list. `configured` is the
+  // authoritative order; `dragItems` is the visual order during drag
+  // (commit on drop via updateProjects). Folder index maps 1:1 to
+  // projects.value index because buildProjectFolders preserves
+  // projects.json order.
+  const [drag, setDrag] = useState<DragState | null>(null)
+  const dragItems = drag ? reorder(projectsVal, drag.from, drag.over) : projectsVal
+
+  const handleDragStart = useCallback((i: number) => setDrag({ from: i, over: i }), [])
+  const handleDragOver = useCallback((i: number) => {
+    setDrag(prev => prev ? { ...prev, over: i } : null)
+  }, [])
+  const handleDragEnd = useCallback(() => {
+    // Commit the reorder before clearing drag state. State-setter
+    // updaters must stay pure (Preact may invoke them more than
+    // once in strict / dev modes), so the side effect lives outside
+    // the updater.
+    if (drag && drag.from !== drag.over) {
+      updateProjects(reorder(projectsVal, drag.from, drag.over))
+    }
+    setDrag(null)
+  }, [drag, projectsVal])
+
+  const handleRemove = useCallback((p: ProjectItem) => {
+    if (p.peer) removePeerReference(p.peer, p.slug)
+    else removeProject(p.slug)
+  }, [])
 
   // Cheap session→folder lookup: the SessionRow needs a project name
   // and the folder's owning peer to build a correct href. Building a
@@ -75,9 +121,30 @@ export function Home({ onManageProjects }: { onManageProjects: () => void }) {
 
       <section class="home-projects-section">
         <h2 class="home-section-title">Projects</h2>
-        {foldersVal.length > 0 ? (
+        {projectsVal.length > 0 ? (
           <div class="home-projects-list">
-            {foldersVal.map(f => <ProjectRow key={f.key} folder={f} />)}
+            {dragItems.map((p, i) => {
+              // Match each project to its rendered folder (which
+              // carries display-friendly fields like name and counts).
+              // Folder key is `${peer ?? ''}::${slug}`; we match on that.
+              const folderKey = `${p.peer ?? ''}::${p.slug}`
+              const folder = foldersVal.find(f => f.key === folderKey)
+              if (!folder) return null
+              return (
+                <ProjectRow
+                  key={folderKey}
+                  folder={folder}
+                  project={p}
+                  index={i}
+                  dragging={drag !== null && drag.from === projectsVal.indexOf(p)}
+                  dropTarget={drag !== null && drag.over === i && drag.from !== i}
+                  onDragStart={handleDragStart}
+                  onDragOver={handleDragOver}
+                  onDragEnd={handleDragEnd}
+                  onRemove={handleRemove}
+                />
+              )
+            })}
           </div>
         ) : !anyActivity ? (
           <div class="home-empty-hint">
@@ -109,15 +176,52 @@ export function Section({
   )
 }
 
-function ProjectRow({ folder: f }: { folder: Folder }) {
+function ProjectRow({
+  folder: f, project, index,
+  dragging, dropTarget,
+  onDragStart, onDragOver, onDragEnd, onRemove,
+}: {
+  folder: Folder
+  project: ProjectItem
+  index: number
+  dragging: boolean
+  dropTarget: boolean
+  onDragStart: (i: number) => void
+  onDragOver: (i: number) => void
+  onDragEnd: () => void
+  onRemove: (project: ProjectItem) => void
+}) {
   // Counts mirror the legacy ProjectCard: "N alive" is the running
   // count, "N resumable" is dead-but-resurrectable. Empty projects
   // get a muted "no sessions" hint so the row isn't visually mute.
   const alive = f.sessions.filter(s => s.alive).length
   const resumable = f.sessions.filter(s => !s.alive && s.resumable).length
   const href = f.peer ? `/@${f.peer}/${f.slug}` : `/${f.slug}`
+  const isReference = !!project.peer
   return (
-    <div class="home-project-row">
+    <div
+      class={`home-project-row${dragging ? ' dragging' : ''}${dropTarget ? ' drop-target' : ''}`}
+      draggable
+      onDragStart={(e) => {
+        e.dataTransfer!.effectAllowed = 'move'
+        e.dataTransfer!.setData('text/plain', '')
+        onDragStart(index)
+      }}
+      onDragOver={(e) => {
+        e.preventDefault()
+        e.dataTransfer!.dropEffect = 'move'
+        onDragOver(index)
+      }}
+      // `onDrop` only consumes the event so the browser doesn't try
+      // to navigate or search; the actual commit happens in
+      // `onDragEnd`, which fires for both successful drops and
+      // cancellations (Esc, release outside). Wiring both to the
+      // same handler doubled the PUT /v1/projects call on every
+      // successful drag.
+      onDrop={(e) => { e.preventDefault() }}
+      onDragEnd={onDragEnd}
+    >
+      <span class="home-project-drag" title="Drag to reorder" aria-hidden="true">⠿</span>
       <a class="home-project-link" href={href}>
         <div class="home-project-name">
           {f.name}
@@ -136,6 +240,13 @@ function ProjectRow({ folder: f }: { folder: Folder }) {
         peer={f.peer}
         className="home-project-launch"
       />
+      <button
+        class="home-project-remove"
+        onClick={(e) => { e.preventDefault(); e.stopPropagation(); onRemove(project) }}
+        title={isReference ? 'Remove reference' : 'Remove project'}
+      >
+        ×
+      </button>
     </div>
   )
 }

--- a/apps/gmux-web/src/manage-projects.tsx
+++ b/apps/gmux-web/src/manage-projects.tsx
@@ -1,8 +1,20 @@
+// "Add project" modal.
+//
+// Three addition flows:
+//   1. Peer references (subscribe to a project owned by another host)
+//   2. Discovered (claim a repo on disk that isn't a project yet)
+//   3. Manual local path
+//
+// Display, reorder, and removal of *configured* projects all live on
+// the home dashboard now: the modal is intentionally additions-only,
+// so the user has one place to discover-and-add and another to
+// arrange-and-curate. The exported component name keeps the older
+// `ManageProjectsModal` identifier for now; callers update later.
+
 import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks'
 import {
   projects, discovered, peerProjects, peerStatusByName,
-  removeProject, addProject, updateProjects,
-  addPeerReference, removePeerReference,
+  addProject, addPeerReference,
 } from './store'
 import { PeerLabel } from './peer-label'
 import type { ProjectItem, DiscoveredProject, MatchRule } from './types'
@@ -36,16 +48,6 @@ function describeRule(rule: MatchRule): RuleDescription {
   return { label: '(empty rule)', qualifier: '' }
 }
 
-// ── Drag-to-reorder ──
-
-/** State tracked during a drag operation. */
-interface DragState {
-  /** Index of the item being dragged. */
-  from: number
-  /** Current insertion target (visual feedback). */
-  over: number
-}
-
 // ── ManageProjectsModal ──
 
 export function ManageProjectsModal({
@@ -58,7 +60,6 @@ export function ManageProjectsModal({
   const [discoveredQuery, setDiscoveredQuery] = useState('')
   const [pathDraft, setPathDraft] = useState('')
   const [pathError, setPathError] = useState('')
-  const [drag, setDrag] = useState<DragState | null>(null)
   const backdropRef = useRef<HTMLDivElement>(null)
 
   // Close on Escape
@@ -100,34 +101,6 @@ export function ManageProjectsModal({
   // Split filtered discovered: active first, then inactive.
   const activeDiscovered = filteredDiscovered.filter(d => d.active_count > 0)
   const inactiveDiscovered = filteredDiscovered.filter(d => d.active_count === 0)
-
-  // ── Reorder handlers ──
-
-  const handleDragStart = useCallback((idx: number) => {
-    setDrag({ from: idx, over: idx })
-  }, [])
-
-  const handleDragOver = useCallback((idx: number) => {
-    setDrag(prev => prev ? { ...prev, over: idx } : null)
-  }, [])
-
-  const handleDragEnd = useCallback(() => {
-    if (!drag || drag.from === drag.over) {
-      setDrag(null)
-      return
-    }
-    const items = [...configured]
-    const [moved] = items.splice(drag.from, 1)
-    items.splice(drag.over, 0, moved)
-    updateProjects(items)
-    setDrag(null)
-  }, [drag, configured])
-
-  // ── Remove handler ──
-
-  const handleRemove = useCallback((slug: string) => {
-    removeProject(slug)
-  }, [])
 
   // ── Add from discovered ──
 
@@ -184,14 +157,11 @@ export function ManageProjectsModal({
 
   if (!open) return null
 
-  // Compute the visual order during drag for CSS.
-  const dragItems = drag ? reorder(configured, drag.from, drag.over) : configured
-
   return (
     <div class="modal-backdrop" ref={backdropRef} onClick={handleBackdropClick}>
       <div class="modal-panel manage-projects-modal">
         <div class="modal-header">
-          <div class="modal-title">Manage projects</div>
+          <div class="modal-title">Add project</div>
           <div class="modal-header-actions">
             <a
               class="mp-docs-link"
@@ -205,35 +175,6 @@ export function ManageProjectsModal({
         </div>
 
         <div class="modal-body">
-          {/* ── Configured projects (owned + references) ── */}
-          <section class="mp-section">
-            <div class="mp-section-label">Your sidebar</div>
-            {configured.length > 0 ? (
-              <div class="mp-project-list">
-                {dragItems.map((project, i) => (
-                  <ProjectRow
-                    key={`${project.peer ?? ''}::${project.slug}`}
-                    project={project}
-                    index={i}
-                    dragging={drag !== null && itemKey(project) === itemKey(configured[drag.from])}
-                    dropTarget={drag !== null && drag.over === i && drag.from !== i}
-                    onDragStart={handleDragStart}
-                    onDragOver={handleDragOver}
-                    onDragEnd={handleDragEnd}
-                    onRemove={(p) => {
-                      if (p.peer) removePeerReference(p.peer, p.slug)
-                      else handleRemove(p.slug)
-                    }}
-                  />
-                ))}
-              </div>
-            ) : (
-              <div class="mp-empty-hint">
-                No projects yet. Add a discovered project below, or add a local path.
-              </div>
-            )}
-          </section>
-
           {/* ── References to peer-owned projects ── */}
           <PeerReferencesSection configured={configured} />
 
@@ -309,79 +250,6 @@ export function ManageProjectsModal({
 
 // ── Sub-components ──
 
-function ProjectRow({
-  project,
-  index,
-  dragging,
-  dropTarget,
-  onDragStart,
-  onDragOver,
-  onDragEnd,
-  onRemove,
-}: {
-  project: ProjectItem
-  index: number
-  dragging: boolean
-  dropTarget: boolean
-  onDragStart: (i: number) => void
-  onDragOver: (i: number) => void
-  onDragEnd: () => void
-  onRemove: (project: ProjectItem) => void
-}) {
-  const rules = project.match ?? []
-  const isReference = !!project.peer
-
-  return (
-    <div
-      class={`mp-project-row${dragging ? ' mp-dragging' : ''}${dropTarget ? ' mp-drop-target' : ''}`}
-      draggable
-      onDragStart={(e) => {
-        e.dataTransfer!.effectAllowed = 'move'
-        e.dataTransfer!.setData('text/plain', '')
-        onDragStart(index)
-      }}
-      onDragOver={(e) => {
-        e.preventDefault()
-        e.dataTransfer!.dropEffect = 'move'
-        onDragOver(index)
-      }}
-      onDrop={(e) => {
-        e.preventDefault()
-        onDragEnd()
-      }}
-      onDragEnd={onDragEnd}
-    >
-      <span class="mp-drag-handle" title="Drag to reorder">&#x283F;</span>
-      {project.peer && <PeerLabel name={project.peer} />}
-      <div class="mp-project-info">
-        <span class="mp-project-name">{project.slug}</span>
-        <div class="mp-project-rules">
-          {isReference ? (
-            <span class="mp-rule mp-rule-qualifier">reference</span>
-          ) : rules.map((rule, i) => {
-            const { prefix, label, qualifier } = describeRule(rule)
-            const title = [prefix, label, qualifier].filter(Boolean).join(' ')
-            return (
-              <span key={i} class="mp-rule" title={title}>
-                {prefix && <span class="mp-rule-qualifier">{prefix} </span>}
-                <span class="mp-rule-label">{label}</span>
-                {qualifier && <span class="mp-rule-qualifier"> {qualifier}</span>}
-              </span>
-            )
-          })}
-        </div>
-      </div>
-      <button
-        class="mp-remove-btn"
-        onClick={() => onRemove(project)}
-        title={isReference ? 'Remove reference' : 'Remove project'}
-      >
-        &times;
-      </button>
-    </div>
-  )
-}
-
 function DiscoveredRow({
   project,
   onAdd,
@@ -456,21 +324,8 @@ function PeerReferencesSection({ configured }: { configured: ProjectItem[] }) {
   )
 }
 
-function itemKey(p: ProjectItem | undefined): string {
-  if (!p) return ''
-  return `${p.peer ?? ''}::${p.slug}`
-}
-
 // ── Helpers ──
 
 function shortenPath(p: string): string {
   return p.replace(/^\/home\/[^/]+/, '~')
-}
-
-/** Reorder an array by moving item at `from` to position `to`. */
-function reorder<T>(arr: T[], from: number, to: number): T[] {
-  const result = [...arr]
-  const [moved] = result.splice(from, 1)
-  result.splice(to, 0, moved)
-  return result
 }

--- a/apps/gmux-web/src/sidebar.tsx
+++ b/apps/gmux-web/src/sidebar.tsx
@@ -250,7 +250,7 @@ function FolderGroup({
           class={`folder-name${isCurrent ? ' current' : ''}${folder.missing ? ' missing' : ''}`}
           href={href}
           title={folder.missing
-            ? `${folder.name} no longer exists on ${folder.peer}; remove via Manage projects`
+            ? `${folder.name} no longer exists on ${folder.peer}; remove via the home page`
             : `Open ${folder.name} hub`}
           onClick={onClick}
         >
@@ -372,14 +372,14 @@ export function Sidebar({
           {connected && isOnlyHomeProject && totalVisible > 0 && (
             <div class="sidebar-hint">
               <button class="sidebar-hint-link" onClick={onManageProjects}>
-                Manage projects
+                Add a project
               </button> to organize sessions by repo.
             </div>
           )}
         </div>
         <div class="sidebar-footer">
           <button class="manage-projects-btn" onClick={onManageProjects}>
-            Manage projects
+            + Add project
             {unmatchedCount > 0 && (
               <span class="manage-projects-badge">{unmatchedCount}</span>
             )}

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -686,8 +686,6 @@ body {
 @media (hover: none) {
   .launch-container.folder-launch-btn { opacity: 1; }
   .session-close-btn { opacity: 1; }
-  .mp-remove-btn { opacity: 1; }
-  .mp-drag-handle { opacity: 1; }
 }
 
 /* ── Sidebar empty state ── */
@@ -929,49 +927,11 @@ body {
   color: var(--text);
 }
 
-/* Configured project rows */
+/* Vertical stack of peer-project rows in PeerReferencesSection. */
 .mp-project-list {
   display: flex;
   flex-direction: column;
   gap: 2px;
-}
-
-.mp-project-row {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 7px 8px;
-  border-radius: 6px;
-  cursor: grab;
-  transition: background 0.1s;
-}
-
-.mp-project-row:hover {
-  background: var(--bg-hover);
-}
-
-.mp-project-row.mp-dragging {
-  opacity: 0.4;
-}
-
-.mp-project-row.mp-drop-target {
-  box-shadow: inset 0 -2px 0 0 var(--accent);
-}
-
-.mp-drag-handle {
-  flex-shrink: 0;
-  width: 16px;
-  text-align: center;
-  color: var(--text-muted);
-  font-size: 11px;
-  letter-spacing: 0.05em;
-  cursor: grab;
-  opacity: 0.35;
-  transition: opacity 0.1s;
-}
-
-.mp-project-row:hover .mp-drag-handle {
-  opacity: 1;
 }
 
 .mp-project-info {
@@ -980,6 +940,16 @@ body {
   display: flex;
   flex-direction: column;
   gap: 2px;
+}
+
+/* Secondary text under a discovered-project name: remote URL or
+ * local path, truncated with title-tooltip. */
+.mp-project-detail {
+  font-size: 12px;
+  color: var(--text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .mp-project-name {
@@ -992,67 +962,6 @@ body {
   display: flex;
   align-items: center;
   gap: 6px;
-}
-
-/* Rule descriptions under project name */
-.mp-project-rules {
-  display: flex;
-  flex-direction: column;
-  gap: 1px;
-}
-
-.mp-rule {
-  font-size: 11.5px;
-  line-height: 1.4;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.mp-rule-label {
-  color: var(--text-muted);
-  font-family: 'Fira Code', monospace;
-  font-size: 11px;
-}
-
-.mp-rule-qualifier {
-  color: var(--text-muted);
-  opacity: 0.6;
-}
-
-.mp-project-detail {
-  font-size: 12px;
-  color: var(--text-muted);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.mp-remove-btn {
-  flex-shrink: 0;
-  width: 24px;
-  height: 24px;
-  border: none;
-  border-radius: 4px;
-  background: transparent;
-  color: var(--text-muted);
-  font-size: 16px;
-  line-height: 1;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  opacity: 0;
-  transition: opacity 0.1s, background 0.1s, color 0.1s;
-}
-
-.mp-project-row:hover .mp-remove-btn {
-  opacity: 1;
-}
-
-.mp-remove-btn:hover {
-  background: oklch(28% 0.015 250);
-  color: var(--status-error);
 }
 
 /* Empty hint (used in both sections) */
@@ -1653,15 +1562,19 @@ body {
 
 /* ── Home page ── */
 
-/* The scroll container fills the available width so the scrollbar
- * tracks the viewport edge (not a mid-page column edge). Content is
- * constrained and centered via the children rule below: keep the
- * column readable, keep the chrome predictable. */
+/* Scrollable main column shared by the home dashboard and the
+ * project hub. The container fills the available width so the
+ * scrollbar tracks the viewport edge; children are centered and
+ * capped to a readable width.
+ *
+ * Horizontal padding uses clamp() so the gutter shrinks gracefully
+ * on narrow viewports without a media-query step; vertical padding
+ * is fixed because there's no equivalent constraint to satisfy. */
 .page {
   flex: 1;
   min-width: 0;
   overflow-y: auto;
-  padding: 32px 32px 48px;
+  padding: 32px clamp(16px, 4vw, 32px) 48px;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -2026,9 +1939,10 @@ body {
     color: var(--accent);
   }
 
-  /* Home / project hub: tighter padding on touch devices */
+  /* Tighter top padding on touch devices; horizontal padding is
+   * already viewport-relative via clamp(). */
   .page {
-    padding: 20px 16px 48px;
+    padding-top: 20px;
   }
 
   .hub-empty {

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -1705,7 +1705,29 @@ body {
   display: flex;
   align-items: center;
   gap: 8px;
+  border-radius: 6px;
+  position: relative;
 }
+.home-project-row.dragging {
+  opacity: 0.4;
+}
+.home-project-row.drop-target {
+  box-shadow: inset 0 -2px 0 0 var(--accent);
+}
+.home-project-drag {
+  /* Always-visible drag affordance: muted enough to disappear when
+     scanning, present enough that the rows announce themselves as
+     reorderable. Touch users would otherwise have no signal. */
+  color: var(--text-muted);
+  opacity: 0.4;
+  cursor: grab;
+  font-size: 14px;
+  user-select: none;
+  padding: 0 2px;
+  flex-shrink: 0;
+}
+.home-project-drag:active { cursor: grabbing; }
+.home-project-row:hover .home-project-drag { opacity: 0.7; }
 .home-project-link {
   flex: 1;
   min-width: 0;
@@ -1721,6 +1743,28 @@ body {
 }
 .home-project-link:hover {
   background: var(--bg-hover);
+}
+
+.home-project-remove {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 2px 6px;
+  border-radius: 4px;
+  opacity: 0;
+  flex-shrink: 0;
+  transition: opacity 0.1s, color 0.1s, background 0.1s;
+}
+.home-project-row:hover .home-project-remove { opacity: 1; }
+.home-project-remove:hover {
+  color: var(--text);
+  background: var(--bg-active);
+}
+@media (hover: none) {
+  .home-project-remove { opacity: 1; }
 }
 .home-project-name {
   font-size: 14px;


### PR DESCRIPTION
## Summary

Step 4b of the home/project/sidebar polish thread. Moves reorder + remove of configured projects to the home dashboard's projects list, then trims the manage-projects modal to additions-only. Closes the loop on the "home subsumes manage-projects" design pinned in the conversation.

**Stacks on #232.** Merge order: #229 → #230 → #231 → #232 → this.

## What changes

**Commit 1: home gets reorder + remove.**

- Drag-to-reorder on the home dashboard's projects list. Always-visible muted drag handle (`⠷` braille glyph at `opacity: 0.4`, brighter on hover) so the list announces itself as reorderable; touch users get the same affordance as mouse users.
- Hover-revealed `×` on each row to remove the project (or its peer reference). Matches the existing pattern on `<SessionRow>`.
- Wires `updateProjects` and `removeProject` / `removePeerReference` directly from the home component.

**Commit 2: modal trim.**

- Removes the "Your sidebar" section, drag state, and `<ProjectRow>` from `manage-projects.tsx`. The modal now contains exactly three addition flows: peer references, discovered, manual path.
- Modal title: "Manage projects" → "Add project".
- Sidebar bottom button: "Manage projects" → "+ Add project".
- Sidebar onboarding hint copy updated to match.
- Dead CSS removed: `.mp-project-list`, `.mp-project-row*`, `.mp-drag-handle`, `.mp-rule*`, `.mp-remove-btn*`, plus their `@media (hover: none)` overrides. `.mp-project-info` / `.mp-project-name` are kept because `<PeerReferencesSection>` still uses them.

## Design notes

The drag-handle visibility question (always-visible muted vs hover-only vs edit-mode toggle) was settled on always-visible per the conversation. Reasoning: it's the only honest signal that the list is reorderable; hidden affordances confuse users and exclude touch devices entirely. The choice of `opacity: 0.4` keeps it from competing with the project name when scanning.

The `×` remove on hover follows the existing dashboard SessionRow pattern, so the two row shapes feel consistent.

The modal rename was the more contentious copy change: "Manage projects" is the older sidebar copy that screenshots and bookmarks might reference. The rename is justified because the modal now does only adding (no longer manages anything else); leaving the old label would mislead users about what's inside.

## Verification

- `pnpm lint` and `pnpm test` clean (406 passing).
- Visual check on dev daemon:
  - Home dashboard projects list shows drag handles + `+` launch + `×` remove on each row.
  - Drag-reorder works (drop target highlight visible on hover during drag).
  - Modal opens from sidebar button and home dashboard footer; shows "Add project" title with only Discovered + Add local path (plus the conditional From-other-hosts when peers have shareable projects).

## Out of scope

Nothing identified. This closes the design conversation's step 4 (project page rewrite + manage-projects consolidation).
