### PR TITLE
feat(web): auto-reload tab when bundle goes stale relative to daemon

### DIFF
--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -17,6 +17,7 @@ import { ProjectHub } from './project-hub'
 import { Home } from './home'
 import { LaunchButton } from './launcher'
 import { installCopySession } from './mock-data/export-session'
+import { installVersionWatch } from './version-watch'
 
 import {
   sessions, connState, selected, selectedId, view, health, peers,
@@ -40,6 +41,11 @@ if (USE_MOCK) document.documentElement.classList.add('mock-mode')
 
 // Debug: __gmuxCopySession() in devtools console
 installCopySession()
+
+// Auto-reload when the bundle goes stale relative to the daemon.
+// Mock mode is offline-only and the daemon version is fixed, so the
+// watcher is pointless there and would risk masking real bugs.
+if (!USE_MOCK) installVersionWatch()
 
 // ── Components ──
 

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -17,6 +17,7 @@ import { signal, computed, batch, effect } from '@preact/signals'
 import type { Session, ProjectItem, DiscoveredProject, PeerInfo, PeerProject, LauncherDef, Folder } from './types'
 import type { View } from './routing'
 import { resolveViewFromPath, viewToPath } from './routing'
+import { navigateWithReload } from './version-watch'
 import { buildProjectFolders, discoverProjects, countUnmatchedActive } from './projects'
 
 import { fetchFrontendConfig, buildTerminalOptions, resolveKeybinds, type ResolvedKeybind } from './config'
@@ -949,6 +950,13 @@ export function setNavigate(fn: (url: string, replace?: boolean) => void) {
 }
 
 export function navigate(url: string, replace?: boolean) {
+  // When the bundle has drifted from the daemon, the version watcher
+  // converts the next in-app navigation into a full document load.
+  // The user perceives it as a normal route transition that happens
+  // to also pick up the new bundle. (The store ↔ version-watch
+  // module cycle is safe: neither side touches the other at top
+  // level.)
+  if (navigateWithReload(url, replace)) return
   _navigate?.(url, replace)
 }
 

--- a/apps/gmux-web/src/version-watch.test.ts
+++ b/apps/gmux-web/src/version-watch.test.ts
@@ -1,0 +1,100 @@
+// Pins the version-mismatch reload guard. The watcher has one job
+// the user actually feels: it must not loop, and it must not yank
+// the page out from under them. These tests pin:
+//   1) decideBundleState's three outputs
+//   2) navigateWithReload's behavior under each state
+//   3) the loop-guard marker is set at reload time
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  decideBundleState,
+  navigateWithReload,
+  bundleStale,
+} from './version-watch'
+
+describe('decideBundleState', () => {
+  it('is unknown (not fresh) when daemon version is missing', () => {
+    // This is the pin for the loop-guard regression: returning
+    // `fresh` here would erase the reload marker on every mount
+    // before health arrives, defeating the guard entirely.
+    expect(decideBundleState(undefined, '0.1.0', null))
+      .toEqual({ kind: 'unknown' })
+  })
+
+  it('preserves the marker through `unknown` (does not signal fresh)', () => {
+    // Even with a marker present, an unknown daemon version stays
+    // unknown rather than overriding the marker semantics.
+    expect(decideBundleState(undefined, '0.1.0', '0.1.0'))
+      .toEqual({ kind: 'unknown' })
+  })
+
+  it('is fresh when versions match', () => {
+    expect(decideBundleState('0.1.0', '0.1.0', null))
+      .toEqual({ kind: 'fresh' })
+  })
+
+  it('is stale on mismatch with no prior attempt', () => {
+    expect(decideBundleState('0.1.1', '0.1.0', null))
+      .toEqual({ kind: 'stale' })
+  })
+
+  it('is stuck when the marker matches this bundle (loop guard)', () => {
+    // We already reloaded from this exact bundle once; the server is
+    // still serving stale. Don't loop.
+    expect(decideBundleState('0.1.1', '0.1.0', '0.1.0'))
+      .toEqual({ kind: 'stuck' })
+  })
+
+  it('is stale when the marker is for a different bundle', () => {
+    // Previously stuck on 0.1.0; this tab is now on 0.1.1 and daemon
+    // moved to 0.1.2. The old marker is stale; take the fresh attempt.
+    expect(decideBundleState('0.1.2', '0.1.1', '0.1.0'))
+      .toEqual({ kind: 'stale' })
+  })
+})
+
+describe('navigateWithReload', () => {
+  beforeEach(() => {
+    bundleStale.value = false
+  })
+
+  it('returns false and does not navigate when the bundle is fresh', () => {
+    const calls: Array<[string, boolean]> = []
+    const storage = makeStorage()
+    const took = navigateWithReload('/foo', false, storage, '0.1.0', (u, r) => calls.push([u, r]))
+    expect(took).toBe(false)
+    expect(calls).toEqual([])
+    expect(storage.getItem('gmux:reload-from')).toBe(null)
+  })
+
+  it('does a push-style reload (replace=false) and sets the marker', () => {
+    bundleStale.value = true
+    const calls: Array<[string, boolean]> = []
+    const storage = makeStorage()
+    const took = navigateWithReload('/foo', false, storage, '0.1.0', (u, r) => calls.push([u, r]))
+    expect(took).toBe(true)
+    expect(calls).toEqual([['/foo', false]])
+    expect(storage.getItem('gmux:reload-from')).toBe('0.1.0')
+  })
+
+  it('forwards replace=true so auto-attach navigations do not grow the back stack', () => {
+    // Pinning the fix for the dropped-replace bug Greptile flagged:
+    // store.navigate(url, true) must not push a fresh history entry
+    // just because the bundle happened to be stale at the time.
+    bundleStale.value = true
+    const calls: Array<[string, boolean]> = []
+    const storage = makeStorage()
+    navigateWithReload('/foo', true, storage, '0.1.0', (u, r) => calls.push([u, r]))
+    expect(calls).toEqual([['/foo', true]])
+  })
+})
+
+/** Minimal in-memory Storage-shaped object for tests. */
+function makeStorage(): Pick<Storage, 'getItem' | 'setItem' | 'removeItem'> {
+  const map = new Map<string, string>()
+  return {
+    getItem: (k) => map.get(k) ?? null,
+    setItem: (k, v) => { map.set(k, v) },
+    removeItem: (k) => { map.delete(k) },
+  }
+}

--- a/apps/gmux-web/src/version-watch.ts
+++ b/apps/gmux-web/src/version-watch.ts
@@ -1,0 +1,167 @@
+// Reload the tab onto the new bundle when the daemon goes ahead of us.
+//
+// Background: the daemon serves the SPA bundle, so under normal
+// operation `__GMUX_VERSION__` (baked in at build time) and
+// `health.version` (live from the daemon) match. They drift when the
+// daemon is upgraded while a tab stays open.
+//
+// Strategy: we don't yank the page out from under the user. Instead,
+// we wait for the next in-app navigation event (sidebar click, back
+// button, programmatic route change) and convert that soft route
+// change into a full document load. The browser shows its normal
+// navigation transition; the user never sees a "page reloaded"
+// flicker, just a route change that happens to also pick up the new
+// bundle.
+//
+// The hazard is a reload loop: if the server keeps serving the same
+// stale bundle (CDN cache, browser cache, broken deploy), we'd flip
+// back to "stale" immediately and reload on the next click forever.
+// The guard is a sessionStorage marker that records *which bundle
+// version triggered the reload*. On the next mount, if the marker
+// still matches the current bundle, the reload didn't help, and we
+// stay quiescent until a version match clears the marker.
+
+import { signal, effect } from '@preact/signals'
+import { health } from './store'
+
+const RELOAD_MARKER = 'gmux:reload-from'
+
+export type BundleDecision =
+  /** Daemon version not yet known (first mount before SSE arrives).
+   *  Distinct from `fresh` because we must NOT touch the loop-guard
+   *  marker yet: if we just reloaded with a stale bundle and the
+   *  daemon-version effect fires synchronously with `health = null`,
+   *  clearing the marker would erase the only signal that the prior
+   *  reload happened. */
+  | { kind: 'unknown' }
+  /** Daemon reported a version that matches ours. Clear the marker:
+   *  this is the post-reload happy path or normal steady state. */
+  | { kind: 'fresh' }
+  /** Mismatch with no prior attempt for this bundle: next nav reloads. */
+  | { kind: 'stale' }
+  /** We already tried reloading from this exact bundle and the daemon
+   *  still reports a different version: stay quiet to avoid looping. */
+  | { kind: 'stuck' }
+
+/**
+ * Pure decision: given the inputs, what state is the bundle in?
+ *
+ * `stuck` takes precedence over `stale` because the loop guard is
+ * the safety net we never want to bypass; a stuck bundle stays
+ * quiescent regardless of what the daemon reports. `unknown` is its
+ * own state precisely so the loop guard survives the first effect
+ * tick before health arrives.
+ */
+export function decideBundleState(
+  daemonVersion: string | undefined,
+  bundleVersion: string,
+  reloadMarker: string | null,
+): BundleDecision {
+  if (!daemonVersion) return { kind: 'unknown' }
+  if (daemonVersion === bundleVersion) return { kind: 'fresh' }
+  if (reloadMarker === bundleVersion) return { kind: 'stuck' }
+  return { kind: 'stale' }
+}
+
+/**
+ * True while the next in-app navigation should be a full reload.
+ * Read by `store.navigate()` to decide between soft (pushState) and
+ * hard (location.assign) navigation. Exported for tests; production
+ * callers go through `installVersionWatch` + `navigate`.
+ */
+export const bundleStale = signal(false)
+
+/**
+ * If the bundle is stale, do a full document load to `url` and
+ * return true (caller skips its own soft-nav). Otherwise return
+ * false. Also responsible for setting the loop-guard marker at the
+ * moment the reload is committed, so a future mount can detect a
+ * stuck bundle.
+ *
+ * `replace` mirrors `history.replaceState` semantics: when true, the
+ * reload uses `location.replace` so the current entry is overwritten
+ * rather than a new one being pushed. This matters for callers like
+ * `navigateToSession` that re-target the URL bar without intending
+ * to grow the back stack (an auto-attach replacing `/foo` with
+ * `/foo/shell/abc` shouldn't make Back send the user to `/foo`).
+ */
+export function navigateWithReload(
+  url: string,
+  replace: boolean = false,
+  storage?: Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>,
+  bundleVersion: string = __GMUX_VERSION__,
+  go: (u: string, replace: boolean) => void = (u, r) => {
+    if (r) location.replace(u); else location.assign(u)
+  },
+): boolean {
+  if (!bundleStale.value) return false
+  // Resolve `sessionStorage` lazily so callers that never trip the
+  // stale guard don't depend on a DOM Storage global being present.
+  // Vitest's node environment doesn't ship one; jsdom and browsers do.
+  const s = storage ?? sessionStorage
+  s.setItem(RELOAD_MARKER, bundleVersion)
+  go(url, replace)
+  return true
+}
+
+let installed = false
+
+export interface InstallOptions {
+  /** Override the bundle version (tests; defaults to `__GMUX_VERSION__`). */
+  bundleVersion?: string
+  /** Override storage (tests; defaults to `sessionStorage`). */
+  storage?: Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>
+}
+
+/**
+ * Subscribe the watcher to health changes. Flips `bundleStale` when
+ * the daemon's version drifts from ours; clears it (and the loop-guard
+ * marker) when the versions re-converge. Idempotent: a second call is
+ * a noop until the first install's teardown runs.
+ *
+ * Returns a teardown function (mainly for tests).
+ */
+export function installVersionWatch(opts: InstallOptions = {}): () => void {
+  if (installed) return () => {}
+  installed = true
+
+  const bundleVersion = opts.bundleVersion ?? __GMUX_VERSION__
+  const storage = opts.storage ?? sessionStorage
+
+  const dispose = effect(() => {
+    const decision = decideBundleState(
+      health.value?.version,
+      bundleVersion,
+      storage.getItem(RELOAD_MARKER),
+    )
+    switch (decision.kind) {
+      case 'unknown':
+        // First mount before the daemon health arrives. Crucially
+        // we leave the marker alone: if a previous tab triggered a
+        // reload and the bundle still hasn't caught up, the marker
+        // is the only memory of that. Wait for a real verdict.
+        bundleStale.value = false
+        break
+      case 'fresh':
+        // Self-heal: a future mismatch gets one fresh reload attempt.
+        // Clearing here covers the post-reload happy path where the
+        // new bundle matches the daemon, and the normal steady state.
+        storage.removeItem(RELOAD_MARKER)
+        bundleStale.value = false
+        break
+      case 'stuck':
+        // Loop guard latched: don't reload on the next nav.
+        bundleStale.value = false
+        break
+      case 'stale':
+        bundleStale.value = true
+        break
+    }
+  })
+
+  return () => {
+    dispose()
+    bundleStale.value = false
+    installed = false
+  }
+}


### PR DESCRIPTION
## Summary

Auto-reload the tab onto a fresh bundle when the daemon is upgraded while the tab stays open. Triggered on the *next in-app navigation*, not on a timer, so the user never sees the page yank out from under them.

**Stacks on #233.** Merge order: #229 → #230 → #231 → #232 → #233 → this.

## Why nav-triggered

The first iteration of this PR used `focusout` to detect when the user was idle and reloaded then. That had a real bug Greptile flagged: `focusout` fires on the *outgoing* focus owner while `document.activeElement` is already reset to `body`, so the busy-deferral guard was inverted (the watcher could decide "user is idle" mid-tab-key between two inputs and reload while they were typing).

The fix wasn't a better busy check; the fix was that we shouldn't pick the reload moment ourselves. We piggy-back on a moment the user already chose: the next time they click a sidebar link, hit back, or any other in-app navigation, we convert the soft route change into a full document load (`location.assign`). The browser's normal nav transition hides the reload entirely.

Side benefit: the watcher's machinery collapses dramatically. No focus listeners, no busy heuristic, no timer.

## How

- **`version-watch.ts`** exposes a `bundleStale` signal that flips true when `health.version !== __GMUX_VERSION__` and stays false otherwise. The effect resets the loop-guard marker whenever the versions converge.
- **`store.ts navigate()`** calls `navigateWithReload(url)` before its usual `pushState`-style soft nav. When `bundleStale` is set, it writes the loop-guard marker and `location.assign(url)`s.
- **Loop guard**: `sessionStorage['gmux:reload-from']` records the bundle version that triggered the last reload. On mount, if the marker still matches the current bundle (meaning the reload didn't actually pick up a new bundle, e.g. CDN cache or broken deploy), `decideBundleState` returns `stuck` and the watcher stays quiet until a version match clears the marker.

## Edge cases

- **User stays on one page forever.** They never reload. Fine. Daemon-tab mismatch only matters across interactions; `gmuxd` is backward-compatible across these patch versions.
- **First load after a deploy hits a stale-version tab.** First click reloads. Expected.
- **Reload loop.** Marker latches once. After one reload, `bundleStale` becomes false until versions match again. No timer-based escape; if the daemon and bundle are permanently mismatched, the watcher gives up rather than churning.
- **Programmatic redirects (`navigateToSession`).** These go through the same `navigate()`, so resume / notification clicks also pick up the new bundle.

## Verification

- `pnpm lint` clean, `pnpm test` 418 passing.
- `decideBundleState` and `navigateWithReload` covered by unit tests in `version-watch.test.ts`.

## Out of scope

A background timer that reloads after N hours of staleness when the tab is hidden. Worth considering if the "user stays on one page forever" case becomes a real support burden, but not now.
