### PR TITLE
fix(web): hide session close buttons in mock mode (dangling comma)

### DIFF
--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -577,8 +577,17 @@ body {
   color: var(--text);
 }
 
-/* Mock mode (landing page screenshots): hide per-session close buttons */
+/* Mock mode (landing page screenshots): hide per-session close
+ * buttons. Previously chained to the .session-dragging rule below
+ * via a stray comma, so mock mode left them at opacity 0.4 instead
+ * of hiding them. Both the compact sidebar item (.session-close-btn)
+ * and the wide dashboard row (.session-row-close) need hiding so
+ * neither variant leaks into screenshots. */
 .mock-mode .session-close-btn,
+.mock-mode .session-row-close {
+  display: none;
+}
+
 /* Session drag-to-reorder */
 .session-item.session-dragging {
   opacity: 0.4;


### PR DESCRIPTION
## Summary

Tiny CSS fix. The mock-mode close-button rule had a stray trailing comma that chained it to the unrelated `.session-item.session-dragging` rule below:

```css
.mock-mode .session-close-btn,
/* Session drag-to-reorder */
.session-item.session-dragging {
  opacity: 0.4;
}
```

So in mock mode (landing-page screenshots), session close buttons rendered at `opacity: 0.4` instead of being hidden. Splits the rule into two and uses `display: none` for the mock-mode case, which matches the comment's stated intent.

Predates the activity-first stack; Greptile flagged it during the #232 re-review. Standalone PR because it has nothing to do with the dashboard rewrite.
