### PR TITLE
ci: run PR workflows on non-main targeting PRs too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
 
 permissions:
   contents: read

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -2,7 +2,6 @@ name: PR Build
 
 on:
   pull_request:
-    branches: [main]
   workflow_dispatch:
     inputs:
       pr_number:


### PR DESCRIPTION
Remove the `branches: [main]` filter from the `pull_request` triggers in `ci.yml` and `pr-build.yml`.

This lets stacked PRs (e.g. feature B targeting feature A) get the same test suite as PRs targeting `main`. The `pr-title.yml` workflow already had no branch filter and runs on all PRs.