### PR TITLE
feat(web): tidy home/project navigation; fix terminal color bleed and replay width

### DIFF
--- a/apps/gmux-web/src/home.tsx
+++ b/apps/gmux-web/src/home.tsx
@@ -17,6 +17,7 @@ import { HostSuffix } from './host-suffix'
 import { SessionRow } from './session-row'
 import { LaunchButton } from './launcher'
 import { sessionPath } from './routing'
+import { IconBell, type NotifPermission } from './sidebar'
 import type { Folder, Session, ProjectItem } from './types'
 
 /** Drag-to-reorder transient state. `from` is the index lifted off,
@@ -32,7 +33,15 @@ function reorder<T>(arr: readonly T[], from: number, to: number): T[] {
   return out
 }
 
-export function Home({ onManageProjects }: { onManageProjects: () => void }) {
+export function Home({
+  onManageProjects,
+  notifPermission,
+  onRequestNotifPermission,
+}: {
+  onManageProjects: () => void
+  notifPermission: NotifPermission
+  onRequestNotifPermission: () => void
+}) {
   const healthVal = health.value
   const foldersVal = folders.value
   const projectsVal = projects.value
@@ -156,9 +165,47 @@ export function Home({ onManageProjects }: { onManageProjects: () => void }) {
         </button>
       </section>
 
+      <NotifPrompt
+        permission={notifPermission}
+        onRequest={onRequestNotifPermission}
+      />
+
       <HomeFooter />
     </div>
   )
+}
+
+/** Notification opt-in surface on the home dashboard.
+ *  - 'default' : show the prompt button.
+ *  - 'denied'  : show a muted banner pointing at browser settings.
+ *  - 'granted' / 'unavailable' : render nothing (no opt-in needed,
+ *    and a permission we cannot request is not actionable). */
+function NotifPrompt({
+  permission,
+  onRequest,
+}: {
+  permission: NotifPermission
+  onRequest: () => void
+}) {
+  if (permission === 'default') {
+    return (
+      <div class="home-notif">
+        <button class="notif-btn" onClick={onRequest}>
+          <IconBell /> Enable notifications
+        </button>
+      </div>
+    )
+  }
+  if (permission === 'denied') {
+    return (
+      <div class="home-notif">
+        <div class="notif-denied">
+          <IconBell muted /> Notifications blocked in browser settings
+        </div>
+      </div>
+    )
+  }
+  return null
 }
 
 export function Section({

--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -471,8 +471,6 @@ function App() {
         onManageProjects={() => { setSidebarOpen(false); setManageProjectsOpen(true) }}
         open={sidebarOpen}
         onClose={() => setSidebarOpen(false)}
-        notifPermission={notifPermission}
-        onRequestNotifPermission={requestNotifPermission}
       />
 
       <ManageProjectsModal
@@ -535,7 +533,11 @@ function App() {
             <div class="state-subtitle">Connecting…</div>
           </div>
         ) : (
-          <Home onManageProjects={() => setManageProjectsOpen(true)} />
+          <Home
+            onManageProjects={() => setManageProjectsOpen(true)}
+            notifPermission={notifPermission}
+            onRequestNotifPermission={requestNotifPermission}
+          />
         )}
 
         <MobileTerminalBar

--- a/apps/gmux-web/src/project-hub.tsx
+++ b/apps/gmux-web/src/project-hub.tsx
@@ -93,7 +93,10 @@ export function ProjectHub({ projectSlug, projectPeer, onCloseSession }: Project
   return (
     <div class="page">
       <header class="hub-header">
-        <div class="hub-eyebrow">Project</div>
+        <a class="hub-back" href="/" aria-label="Back to home">
+          <span class="hub-back-arrow" aria-hidden="true">←</span>
+          Home
+        </a>
         <div class="hub-title-row">
           <h2 class="hub-title">
             {projectSlug}

--- a/apps/gmux-web/src/replay-view.tsx
+++ b/apps/gmux-web/src/replay-view.tsx
@@ -78,8 +78,21 @@ export function ReplayView({
   useEffect(() => {
     if (!containerRef.current) return
 
+    // Scrollback was recorded at a specific column width. Re-flowing it
+    // to a different width would corrupt cursor positioning, box-drawing
+    // alignment, and any output that assumed the original geometry, so
+    // we pin cols to the recorded value and rely on `.terminal-shell`'s
+    // `overflow: auto` to allow horizontal scrolling when the viewport
+    // is narrower than the recording. Rows still fit vertically so the
+    // scrollback fills the available height without leaving an empty
+    // strip below.
+    const recordedCols = session.terminal_cols ?? 80
+    const recordedRows = session.terminal_rows ?? 24
+
     const term = new Terminal({
       ...terminalOptions,
+      cols: recordedCols,
+      rows: recordedRows,
       scrollback: REPLAY_SCROLLBACK_LINES,
       disableStdin: true,
       cursorBlink: false,
@@ -96,7 +109,18 @@ export function ReplayView({
     term.loadAddon(new WebLinksAddon())
     term.open(containerRef.current)
     loadPreferredRenderer(term)
-    fit.fit()
+    // Vertical-only fit: use FitAddon's proposal for rows, but keep cols
+    // pinned to the recording. FitAddon already knows the cell metrics
+    // and shell-padding accounting; reusing it for the row dimension is
+    // simpler than duplicating that logic here.
+    const fitRows = () => {
+      const proposed = fit.proposeDimensions()
+      if (!proposed || !Number.isFinite(proposed.rows) || proposed.rows < 1) return
+      if (term.cols !== recordedCols || term.rows !== proposed.rows) {
+        term.resize(recordedCols, proposed.rows)
+      }
+    }
+    fitRows()
     setTerm(term)
 
     // OSC 52 (set clipboard) suppression: the captured bytes may contain
@@ -129,7 +153,7 @@ export function ReplayView({
       }
     })
 
-    const onResize = () => fit.fit()
+    const onResize = () => fitRows()
     window.addEventListener('resize', onResize)
 
     return () => {

--- a/apps/gmux-web/src/sidebar.tsx
+++ b/apps/gmux-web/src/sidebar.tsx
@@ -297,16 +297,12 @@ export function Sidebar({
   onManageProjects,
   open,
   onClose,
-  notifPermission,
-  onRequestNotifPermission,
 }: {
   resumingId: string | null
   onCloseSession: (session: Session) => void
   onManageProjects: () => void
   open: boolean
   onClose: () => void
-  notifPermission: NotifPermission
-  onRequestNotifPermission: () => void
 }) {
   // Read signals; component re-renders only when these values change.
   const foldersVal = folders.value
@@ -373,18 +369,6 @@ export function Sidebar({
               <button class="sidebar-hint-link" onClick={onManageProjects}>
                 Add a project
               </button> to organize sessions by repo.
-            </div>
-          )}
-        </div>
-        <div class="sidebar-footer">
-          {notifPermission === 'default' && (
-            <button class="notif-btn" onClick={onRequestNotifPermission}>
-              <IconBell /> Enable notifications
-            </button>
-          )}
-          {notifPermission === 'denied' && (
-            <div class="notif-denied">
-              <IconBell muted /> Notifications blocked in browser settings
             </div>
           )}
         </div>

--- a/apps/gmux-web/src/sidebar.tsx
+++ b/apps/gmux-web/src/sidebar.tsx
@@ -12,7 +12,7 @@ import { LaunchButton } from './launcher'
 import { useArrivalPulse } from './use-arrival-pulse'
 import {
   folders, selectedId, currentProjectKey,
-  activityMap, unmatchedActiveCount, projects, connState,
+  activityMap, projects, connState,
   updateProjects, reorderSessions,
   peerStatusByName, isSessionUnavailable, localPeerNames, sessionDotState,
   type DotState,
@@ -313,7 +313,6 @@ export function Sidebar({
   const projectsVal = projects.value
   const selId = selectedId.value
   const curKey = currentProjectKey.value
-  const unmatchedCount = unmatchedActiveCount.value
   const am = activityMap.value
   const peerStatus = peerStatusByName.value
 
@@ -378,12 +377,6 @@ export function Sidebar({
           )}
         </div>
         <div class="sidebar-footer">
-          <button class="manage-projects-btn" onClick={onManageProjects}>
-            + Add project
-            {unmatchedCount > 0 && (
-              <span class="manage-projects-badge">{unmatchedCount}</span>
-            )}
-          </button>
           {notifPermission === 'default' && (
             <button class="notif-btn" onClick={onRequestNotifPermission}>
               <IconBell /> Enable notifications

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -18,7 +18,7 @@ import type { Session, ProjectItem, DiscoveredProject, PeerInfo, PeerProject, La
 import type { View } from './routing'
 import { resolveViewFromPath, viewToPath } from './routing'
 import { navigateWithReload } from './version-watch'
-import { buildProjectFolders, discoverProjects, countUnmatchedActive } from './projects'
+import { buildProjectFolders, discoverProjects } from './projects'
 
 import { fetchFrontendConfig, buildTerminalOptions, resolveKeybinds, type ResolvedKeybind } from './config'
 import { MOCK_SESSIONS, MOCK_PROJECTS } from './mock-data/index'
@@ -212,14 +212,11 @@ effect(() => {
 export const sessionsLoaded = signal(false)
 export const connState = signal<'connecting' | 'connected' | 'error'>('connecting')
 
-// Per ADR 0001: Discovered and UnmatchedActiveCount are per-viewer
-// projections, not server-pushed state. They derive from the same
-// public sessions/projects projections everyone else uses.
+// Per ADR 0001: Discovered is a per-viewer projection, not
+// server-pushed state. It derives from the same public
+// sessions/projects projections everyone else uses.
 export const discovered = computed<DiscoveredProject[]>(
   () => discoverProjects(sessions.value, projects.value, peerStatusByName.value),
-)
-export const unmatchedActiveCount = computed<number>(
-  () => countUnmatchedActive(sessions.value, projects.value, peerStatusByName.value),
 )
 
 // ── Peer appearance: unique prefix + deterministic color ─────────────────────

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -731,43 +731,6 @@ body {
   border-top: 1px solid var(--border);
 }
 
-.manage-projects-btn {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  width: 100%;
-  padding: 6px 10px;
-  border: none;
-  border-radius: 6px;
-  background: transparent;
-  color: var(--text-muted);
-  font-size: 13px;
-  font-family: 'Source Sans 3', sans-serif;
-  cursor: pointer;
-  transition: color 0.15s, background 0.15s;
-}
-
-.manage-projects-btn:hover {
-  color: var(--text-secondary);
-  background: var(--bg-hover);
-}
-
-.manage-projects-badge {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 18px;
-  height: 18px;
-  padding: 0 5px;
-  border-radius: 9px;
-  background: var(--accent);
-  color: var(--bg);
-  font-size: 11px;
-  font-weight: 600;
-  line-height: 1;
-}
-
 .notif-btn {
   display: flex;
   align-items: center;

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -724,11 +724,12 @@ body {
   color: var(--text-primary);
 }
 
-/* ── Sidebar footer ── */
-.sidebar-footer {
-  flex-shrink: 0;
-  padding: 8px 12px;
-  border-top: 1px solid var(--border);
+/* ── Notification prompt (home dashboard) ── */
+.home-notif {
+  /* Sits between the projects list and the footer as a low-priority
+   * opt-in. Width comes from the shared `.page > *` rule so the
+   * prompt aligns with the other home content blocks. */
+  margin: 16px 0 8px;
 }
 
 .notif-btn {
@@ -736,7 +737,6 @@ body {
   align-items: center;
   gap: 7px;
   width: 100%;
-  margin-top: 6px;
   padding: 6px 10px;
   border: 1px dashed var(--border);
   border-radius: 6px;
@@ -758,7 +758,6 @@ body {
   display: flex;
   align-items: center;
   gap: 7px;
-  margin-top: 6px;
   padding: 5px 10px;
   color: var(--text-muted);
   font-size: 12px;
@@ -1932,7 +1931,6 @@ body {
     border-bottom: none;
   }
   .sidebar-scroll { order: 1; }
-  .sidebar-footer { order: 2; }
 }
 
 /* ── Session Detail (non-terminal) ── */

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -2211,16 +2211,31 @@ body {
 .hub-header {
   margin-bottom: 20px;
 }
-.hub-eyebrow {
-  /* Small uppercase kicker above the project slug. Mirrors the
-   * idiom used by section labels (RECENT / RUNNING / PROJECTS) so
-   * the page reads in a single visual language. */
+.hub-back {
+  /* Back link in the eyebrow slot above the project title. Sized
+   * like the old uppercase kicker so the header rhythm is
+   * preserved; styled as a link so it reads as actionable. */
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
   font-size: 11px;
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.06em;
   color: var(--text-muted);
+  text-decoration: none;
   margin-bottom: 4px;
+  transition: color 0.12s;
+}
+.hub-back:hover,
+.hub-back:focus-visible {
+  color: var(--text);
+}
+.hub-back-arrow {
+  /* Arrow glyph aligned tight to the label; slightly larger than
+   * the uppercase text so it reads as a chevron, not punctuation. */
+  font-size: 13px;
+  line-height: 1;
 }
 .hub-title-row {
   display: flex;

--- a/apps/gmux-web/src/terminal.tsx
+++ b/apps/gmux-web/src/terminal.tsx
@@ -774,6 +774,13 @@ export function TerminalView({
     termEpochRef.current = epoch
     termIoRef.current.reset(epoch)
 
+    // Full RIS on the xterm instance so SGR colors, modes, cursor state, and
+    // scroll regions from the previous session don't bleed into the next one.
+    // Without this, switching away from a colorful TUI (btop, htop) leaves
+    // its trailing bg/fg attributes active until the new session emits an SGR
+    // of its own, painting plain-text output in btop's last color.
+    termRef.current.reset()
+
     // Reset sizes so stale values from a previous session can't trigger a
     // spurious pill while the loading overlay is visible (before ws.onopen).
     resetResizeEchoGate()


### PR DESCRIPTION
A set of related UI tweaks plus two terminal-rendering bug fixes.

## Navigation tidy

- **Project page → back-to-home link.** The static `Project` eyebrow on the project hub header is replaced with a `← Home` link. The eyebrow conveyed nothing the page title didn't already; reusing the slot for navigation keeps the visual rhythm and adds a real affordance. Plain anchor so middle-click / right-click / keyboard / screen-reader all work.
- **Sidebar → home owns "+ Add project".** The add-project footer button is removed from the sidebar. Home already has the affordance; two entry points just split attention. The unused `unmatchedActiveCount` signal goes with it (no consumers).
- **Sidebar → home owns "Enable notifications".** The permission prompt moves from a cramped sidebar footer to a proper home-page block, where it has room to explain what notifications gate on and what `default` / `denied` / `granted` / `unavailable` mean. Sidebar `notifPermission` / `onRequestNotifPermission` props dropped; routing happens once at the top.

## Terminal fixes

- **Reset xterm on session switch.** Switching from a TUI session (btop, htop, vim) into a plain shell would carry the previous session's SGR state — colors, cursor mode, scroll regions — into the new buffer, most visibly as a tinted prompt. The xterm `Terminal` instance is intentionally reused across switches (creation is expensive), so the WS-reconnect path now calls `term.reset()` (RIS) right after the terminal-io epoch reset. RIS clears buffer, SGR, modes, cursor, scroll regions, character sets, and alt-buffer state — covers every bleed vector, not just colors.
- **Replay renders at recorded width.** The replay view used `FitAddon.fit()`, which re-flows scrollback to the current viewport width. Recordings made at a different width came out with corrupted cursor positions and broken box-drawing. The replay view now pins `cols` to `session.terminal_cols` (falling back to 80) and only fits rows; horizontal scroll appears when the viewport is narrower than the recording, courtesy of the existing `overflow: auto` on `.terminal-shell`.

## Verification

Mock-mode walkthrough plus live install:
- Back link renders in the eyebrow slot, hover brightens, click goes to `/`.
- Sidebar no longer has the add-project footer; "+ Add project" on home is the single entry point.
- Notification prompt renders on home as a regular page block in each of the four permission states.
- After exiting btop in one session and switching to a plain shell, the prompt renders in default colors immediately — no tinted bleed.
- Replay of a session recorded at 200×50 in a 120-column window shows horizontal scroll, rows fit vertically, no re-flow.
