### PR TITLE
fix(daemon): preserve PTY size across /resume and /restart

### DIFF
--- a/cli/gmux/cmd/gmux/cli.go
+++ b/cli/gmux/cmd/gmux/cli.go
@@ -39,6 +39,15 @@ type flags struct {
 	host        string // --host=<peer>: target this peer instead of local
 	all         bool   // --list --all: include peer sessions in output
 	help        bool
+
+	// daemon→runner directives. Only set when gmuxd forks a runner
+	// for /v1/launch, /v1/resume, /v1/restart. End users have no
+	// reason to pass them, but they're plain CLI flags so the
+	// daemon↔runner contract is greppable and toolable; the legacy
+	// GMUX_RESUME_ID env var is still honored as a fallback.
+	resumeID    string // --resume-id=<id>: reuse this session id
+	initialCols int    // --initial-cols=N: pre-size PTY
+	initialRows int    // --initial-rows=N: pre-size PTY
 }
 
 // parseCLI parses argv (without program name) and decides which mode to
@@ -71,6 +80,9 @@ func parseCLI(args []string) (mode, *flags, []string, error) {
 	fs.BoolVar(&f.all, "all", false, "with --list, include sessions from all peers (default: local only)")
 	fs.BoolVar(&f.help, "help", false, "show help")
 	fs.BoolVar(&f.help, "h", false, "show help (short)")
+	fs.StringVar(&f.resumeID, "resume-id", "", "(daemon-internal) reuse this session id instead of generating a fresh one")
+	fs.IntVar(&f.initialCols, "initial-cols", 0, "(daemon-internal) pre-size the PTY width")
+	fs.IntVar(&f.initialRows, "initial-rows", 0, "(daemon-internal) pre-size the PTY height")
 
 	if err := fs.Parse(args); err != nil {
 		return modeHelp, nil, nil, err
@@ -144,6 +156,15 @@ func parseCLI(args []string) (mode, *flags, []string, error) {
 	// than letting the user hit an opaque gmuxd error.
 	if f.host != "" && f.wait {
 		return modeHelp, nil, nil, errors.New("--wait does not yet support --host (local sessions only)")
+	}
+	// Daemon→runner directives only make sense in run mode (gmuxd
+	// is forking a runner to execute a command). Reject up front if
+	// they leak into a management action so a misuse fails loud.
+	if (f.resumeID != "" || f.initialCols != 0 || f.initialRows != 0) && isManagementMode(f) {
+		return modeHelp, nil, nil, errors.New("--resume-id / --initial-cols / --initial-rows only apply when launching a command")
+	}
+	if f.initialCols < 0 || f.initialRows < 0 {
+		return modeHelp, nil, nil, errors.New("--initial-cols and --initial-rows must be non-negative")
 	}
 
 	// Management actions take a single session id (except --list and --send).

--- a/cli/gmux/cmd/gmux/cli_test.go
+++ b/cli/gmux/cmd/gmux/cli_test.go
@@ -239,6 +239,48 @@ func TestParseCLI(t *testing.T) {
 // the load-bearing case for run mode and the reason management modes
 // (which lack a wrapped command) get lenient parsing while run mode
 // keeps the strict stop-at-first-positional behavior.
+func TestParseCLIDaemonDirectives(t *testing.T) {
+	t.Run("resume-id + size hints are exposed as flags in run mode", func(t *testing.T) {
+		m, f, rest, err := parseCLI([]string{
+			"--resume-id=sess-abc",
+			"--initial-cols=142",
+			"--initial-rows=47",
+			"claude", "--continue",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if m != modeRun {
+			t.Errorf("mode = %v, want modeRun", m)
+		}
+		if f.resumeID != "sess-abc" || f.initialCols != 142 || f.initialRows != 47 {
+			t.Errorf("directives not captured: resume=%q cols=%d rows=%d", f.resumeID, f.initialCols, f.initialRows)
+		}
+		wantRest := []string{"claude", "--continue"}
+		if len(rest) != 2 || rest[0] != wantRest[0] || rest[1] != wantRest[1] {
+			t.Errorf("rest = %v, want %v", rest, wantRest)
+		}
+	})
+
+	t.Run("directives do not leak from a child command's own argv", func(t *testing.T) {
+		// Defends the daemon↔runner contract: a child command that
+		// happens to use the same flag names (`weirdcli
+		// --resume-id=...`) must not have its flag consumed by gmux.
+		// POSIX runner semantics (stop at first positional) is what
+		// makes this safe; the test pins it.
+		_, f, rest, err := parseCLI([]string{"weirdcli", "--resume-id=evil"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if f.resumeID != "" {
+			t.Errorf("resumeID should not be set from child argv, got %q", f.resumeID)
+		}
+		if len(rest) != 2 || rest[0] != "weirdcli" || rest[1] != "--resume-id=evil" {
+			t.Errorf("rest should preserve child argv verbatim, got %v", rest)
+		}
+	})
+}
+
 func TestRunModeKeepsPOSIXRunnerSemantics(t *testing.T) {
 	// `gmux pi --some-pi-flag` — --some-pi-flag must reach pi as part
 	// of the command, not be parsed as an unknown gmux flag.
@@ -285,6 +327,11 @@ func TestParseCLIErrors(t *testing.T) {
 		{"--host=konyvtar", "--all", "--list"},    // --host and --all are mutually exclusive
 		{"--host=konyvtar", "--wait", "sess-a"},   // --wait + --host not yet supported
 		{"--host=konyvtar", "fish"},               // remote create deferred
+		{"--resume-id=sess-1", "--list"},          // directives are run-mode only
+		{"--initial-cols=80", "--kill", "sess-a"}, // directives are run-mode only
+		{"--initial-rows=24", "--attach", "sess-a"}, // directives are run-mode only
+		{"--initial-cols=-1", "claude"},           // size must be non-negative
+		{"--initial-rows=-1", "claude"},
 	}
 
 	for _, args := range invalid {

--- a/cli/gmux/cmd/gmux/main.go
+++ b/cli/gmux/cmd/gmux/main.go
@@ -35,7 +35,11 @@ func main() {
 		openUI()
 		return
 	case modeRun:
-		runSession(rest, !f.noAttach)
+		runSession(rest, !f.noAttach, runDirectives{
+			ResumeID:    f.resumeID,
+			InitialCols: f.initialCols,
+			InitialRows: f.initialRows,
+		})
 		return
 	case modeList:
 		os.Exit(cmdList(f.host, f.all))

--- a/cli/gmux/cmd/gmux/run.go
+++ b/cli/gmux/cmd/gmux/run.go
@@ -41,6 +41,15 @@ const handshakeTimeout = 5 * time.Second
 // background writer.
 const ptyDrainTimeout = 250 * time.Millisecond
 
+// runDirectives carries daemon→runner overrides for a /v1/launch,
+// /v1/resume, or /v1/restart. End-user invocations leave all three
+// fields zero. See the flag declarations in cli.go for semantics.
+type runDirectives struct {
+	ResumeID    string
+	InitialCols int
+	InitialRows int
+}
+
 // runSession launches a new managed session for the given command.
 //
 // When attach is true and stdin is a tty, the local terminal is wired
@@ -48,7 +57,7 @@ const ptyDrainTimeout = 250 * time.Millisecond
 // attach is false, the session is spawned detached from the tty and
 // this call returns immediately once the session is running, leaving
 // the session visible in the gmux UI.
-func runSession(args []string, attach bool) {
+func runSession(args []string, attach bool, dir runDirectives) {
 	// Nested gmux detection: if we're running interactively inside an
 	// existing gmux session, re-exec as a detached headless process instead
 	// of doing PTY passthrough (which would nest PTY-within-PTY). The
@@ -68,26 +77,28 @@ func runSession(args []string, attach bool) {
 		return
 	}
 
+	// Honour the legacy GMUX_RESUME_ID env var when --resume-id
+	// wasn't provided. Older gmuxd builds set it via env; newer
+	// gmuxd sets the flag instead. The env-var path is kept for
+	// rolling-upgrade scenarios (a daemon installed before the
+	// flag existed talking to a newer runner) and will be removed
+	// in a future release.
+	if dir.ResumeID == "" {
+		dir.ResumeID = os.Getenv("GMUX_RESUME_ID")
+	}
+
 	workDir, err := os.Getwd()
 	if err != nil {
 		log.Fatalf("cannot determine cwd: %v", err)
 	}
 
-	// Honour GMUX_RESUME_ID when the daemon passed one in (resume,
-	// restart). The runner uses the daemon-supplied id so the
-	// session keeps its identity across the seam, including its
-	// scrollback directory on disk. See ADR 0003.
-	//
-	// GMUX_RESUME_ID is intentionally distinct from GMUX_SESSION_ID:
-	// the runner sets the latter for its child process (consumed by
-	// adapters / hooks), so a nested `gmux foo` inside an
-	// interactive gmux session inherits GMUX_SESSION_ID from the
-	// parent and would otherwise try to re-bind the parent's id.
-	// The dedicated GMUX_RESUME_ID is only ever set by the daemon
-	// and not propagated to descendants, so the nested case falls
-	// through to a fresh id without depending on the bind-collision
-	// fallback as a safety net.
-	sessionID := os.Getenv("GMUX_RESUME_ID")
+	// --resume-id, when the daemon passed it on /resume or
+	// /restart, makes the runner keep the existing session id
+	// across the seam (including its scrollback directory on
+	// disk; see ADR 0003). Without it we generate a fresh id, so
+	// nested `gmux foo` invocations inside a session don't try to
+	// re-bind the parent's id.
+	sessionID := dir.ResumeID
 	if sessionID == "" {
 		sessionID = naming.SessionID()
 	}
@@ -195,6 +206,20 @@ func runSession(args []string, attach bool) {
 	if cols, rows, err := localterm.TerminalSize(); err == nil {
 		ptyCfg.Cols = cols
 		ptyCfg.Rows = rows
+	}
+	// --initial-cols / --initial-rows, when the daemon passed
+	// them on /resume or /restart, override the local TTY
+	// detection: a detached runner has no TTY to read from, and
+	// the daemon knows the last-attached browser's dimensions
+	// from its store. Without this, the PTY would start at 80x24
+	// and any child process that captures $COLUMNS at startup
+	// (claude, prompt frameworks, etc.) would render at the
+	// default width until the next manual resize.
+	if dir.InitialCols > 0 {
+		ptyCfg.Cols = uint16(dir.InitialCols)
+	}
+	if dir.InitialRows > 0 {
+		ptyCfg.Rows = uint16(dir.InitialRows)
 	}
 
 	// In interactive mode, build the local terminal attach before

--- a/docs/adr/0003-resume-by-id-passthrough.md
+++ b/docs/adr/0003-resume-by-id-passthrough.md
@@ -1,7 +1,8 @@
 # ADR 0003: Daemon-initiated resume passes Session.ID to the runner
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-05-04
+**Revised:** 2026-05-26 (env var → CLI flag)
 **Related:** ADR 0004 (SessionStream and the live↔dead view abstraction)
 
 ## Context
@@ -61,42 +62,47 @@ generates an id it didn't need to.
 ## Decision
 
 The daemon's resume handler **passes the existing Session.ID to the
-forked runner** via a dedicated `GMUX_RESUME_ID` environment
-variable. The runner uses it as its session id instead of
-generating a fresh one.
+forked runner** via a dedicated `--resume-id` CLI flag. The
+runner uses it as its session id instead of generating a fresh
+one.
 
 ```go
 // services/gmuxd/cmd/gmuxd/main.go (resume handler)
-cmd := exec.Command(gmuxBinary, "--", session.Command...)
-cmd.Env = append(filteredEnv, "GMUX_RESUME_ID="+session.ID)
+args := []string{"--resume-id=" + session.ID}
+args = append(args, session.Command...)
+cmd := exec.Command(gmuxBinary, args...)
 ```
 
 ```go
 // cli/gmux/cmd/gmux/run.go
-sessionID := os.Getenv("GMUX_RESUME_ID")
+sessionID := dir.ResumeID // populated from the --resume-id flag
 if sessionID == "" {
     sessionID = naming.SessionID()
 }
 ```
 
-`GMUX_RESUME_ID` is a one-shot directive separate from the
-`GMUX_SESSION_ID` the runner already exports to its child process.
-The two have orthogonal meanings: `GMUX_SESSION_ID` is the
-runner-published "this is my id" (consumed by adapters and hooks);
-`GMUX_RESUME_ID` is the daemon-supplied "adopt this id at
-startup" (consumed only by the runner's own initialisation).
-Distinct names let us prevent nested-gmux invocations from
-accidentally re-binding the parent session's id. The runner does
-not propagate `GMUX_RESUME_ID` into PTY children
-(`buildChildEnv` strips it; `GMUX_SESSION_ID` is intentionally
-kept because adapters and hooks consume it), so a `gmux foo`
-inside an interactive gmux session does not see
-`GMUX_RESUME_ID` at all and falls through to a fresh id. Without
-the strip, the daemon→runner directive would silently propagate
-to every descendant of the runner's PTY child and the
-collision-fallback would catch the inevitable bind clash; the
-dedicated env var name plus the explicit strip means we don't
-rely on that fallback for the nested case.
+The original incarnation of this ADR used a `GMUX_RESUME_ID`
+environment variable for the same purpose. The mechanism moved to
+a CLI flag once the runner grew a real flag parser: `ps` now shows
+the directive directly, the daemon↔runner contract is
+greppable, and the runner doesn't need an env-strip step in
+`buildChildEnv` to keep the directive from leaking into
+grandchildren (POSIX runner semantics in the parser already stop
+at the first positional, so a child command's own argv can't
+collide with the daemon's `--resume-id`). The env var is still
+honoured as a fallback when the flag is absent so a brand-new
+runner paired with an older daemon (rolling upgrade) keeps
+working; it will be removed in a future release.
+
+`--resume-id` is orthogonal to the `GMUX_SESSION_ID` the runner
+exports to its child process. `GMUX_SESSION_ID` is the
+runner-published "this is my id" (consumed by adapters and
+hooks); `--resume-id` is the daemon-supplied "adopt this id at
+startup" (consumed only by the runner's own initialisation). The
+separation prevents nested-gmux invocations from re-binding the
+parent session's id: a `gmux foo` inside an interactive gmux
+session inherits `GMUX_SESSION_ID` but never sees a
+`--resume-id` flag, so it falls through to a fresh id.
 
 ### Register simplifies
 
@@ -371,14 +377,35 @@ discovery event loop with a wait condition. The collision case is
 rare and self-correcting via SSE; deferred until a real user
 report shows the optimistic response causing observable harm.
 
-### E. Pass Session.ID via a CLI flag (`gmux --session-id=R1`) instead
+### E. Pass Session.ID via a CLI flag (`gmux --resume-id=R1`) instead
 of an env var
 
-Rejected. Both work; env var is more contained (no addition to the
-public CLI surface, not user-invokable in normal use). The env var
-name (`GMUX_RESUME_ID`) is dedicated to this directive and
-distinct from the `GMUX_SESSION_ID` the runner exports to its
-child, so there is no aliasing with adapter / hook env.
+Originally rejected (env var was more contained: no addition to
+the public CLI surface, not user-invokable in normal use).
+**Reconsidered and adopted 2026-05-26** once the runner grew a
+real flag parser. The flag form is greppable in `ps`, shows up in
+`--help` (tagged as daemon-internal), validates types (rejects
+negative sizes) without ad-hoc parsing, and doesn't need an
+env-strip step in `buildChildEnv` since POSIX runner semantics
+in the parser already stop at the first positional, so a child
+command's own argv can't collide with the daemon's directives.
+The legacy `GMUX_RESUME_ID` env var is honoured as a fallback for
+the one rolling-upgrade direction that can realistically happen
+in practice: a new runner binary paired with a still-old daemon
+(e.g. the user's host-installed gmux auto-updated faster than a
+containerised gmuxd). The reverse direction (new daemon emitting
+`--resume-id` to an old runner that doesn't know the flag) is
+not guarded; it would break /resume and /restart until the
+runner catches up. This is acceptable because gmux and gmuxd
+ship as a single release and `scripts/install.sh` replaces both
+binaries atomically; an operator who upgrades only the daemon is
+off the supported path. The fallback will be removed in a future
+release.
+
+The same mechanism (`--initial-cols` / `--initial-rows`) carries
+the last-known PTY dimensions through the fork so child processes
+that read `$COLUMNS` at startup don't clamp to 80 between exec
+and the first browser resize.
 
 ### F. Have the runner ask the daemon for an id assignment at startup
 
@@ -398,9 +425,10 @@ implicitly inherits it from the parent shell. If the runner read
 would attempt to re-bind the parent session's id, depending on
 the collision fallback to recover. That works (the user ends up
 with a fresh-id sibling session) but accidentally relies on a
-safety net for the common path. A dedicated `GMUX_RESUME_ID`
-name is set only by the daemon for resume / restart launches and
-is never inherited by descendants, eliminating the false-positive.
+safety net for the common path. The dedicated `--resume-id` flag
+(see alternative E) is set only by the daemon for resume /
+restart launches and never appears in a nested invocation's
+argv, eliminating the false-positive.
 
 ### H. Use the slug as the persistent identity and let Session.ID
 churn

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -166,21 +166,28 @@ func filterEnvPrefix(env []string, prefix string) []string {
 
 // launchGmux forks a gmux runner with the given command and cwd.
 //
-// resumeID, when non-empty, is passed to the runner via
-// GMUX_RESUME_ID so the runner uses the daemon-supplied id
-// instead of generating a fresh one. /v1/launch leaves it empty
-// (fresh sessions get a runner-generated id); /v1/resume and
-// /v1/restart pass the existing session's id so identity (and the
-// scrollback directory on disk) carry across the seam. See
-// ADR 0003.
+// resumeID, when non-empty, is passed via --resume-id so the
+// runner uses the daemon-supplied id instead of generating a fresh
+// one. /v1/launch leaves it empty (fresh sessions get a runner-
+// generated id); /v1/resume and /v1/restart pass the existing
+// session's id so identity (and the scrollback directory on disk)
+// carry across the seam. See ADR 0003.
 //
-// GMUX_RESUME_ID is dedicated to this directive and distinct from
-// the GMUX_SESSION_ID the runner exports to its child process; a
-// nested `gmux foo` inherits GMUX_SESSION_ID from the parent
-// runner but never GMUX_RESUME_ID, so nested invocations always
-// generate a fresh id.
-func launchGmux(gmuxBin string, command []string, cwd, resumeID string) (int, error) {
-	cmd := exec.Command(gmuxBin, command...)
+// initialCols / initialRows, when non-zero, are passed via
+// --initial-cols / --initial-rows so the PTY starts at the right
+// size instead of the 80x24 default. Without this, /resume and
+// /restart momentarily expose the child process to a
+// default-sized terminal between exec and the browser's first
+// resize WS message; programs that read $COLUMNS or query the
+// TTY once at startup (claude, vim, less, prompt frameworks)
+// stay stuck at 80 columns.
+//
+// Directives are delivered as CLI flags so the daemon↔runner
+// contract is greppable and shows up in `ps`. The runner still
+// honours the legacy GMUX_RESUME_ID env var as a fallback for
+// rolling upgrades, but this code path no longer sets it.
+func launchGmux(gmuxBin string, command []string, cwd, resumeID string, initialCols, initialRows uint16) (int, error) {
+	cmd := exec.Command(gmuxBin, buildLaunchArgs(resumeID, initialCols, initialRows, command)...)
 	cmd.Dir = cwd
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
 	cmd.Stdout = nil
@@ -189,18 +196,35 @@ func launchGmux(gmuxBin string, command []string, cwd, resumeID string) (int, er
 
 	// Strip all GMUX_* session vars so child processes don't inherit
 	// the parent session's identity. Without this, a gmuxd started
-	// inside a pi session would leak GMUX_ADAPTER=pi, GMUX_SOCKET,
-	// GMUX_SESSION_ID, etc. into every launched session.
+	// inside a gmux session (e.g. dogfooding during dev) would leak
+	// GMUX_ADAPTER, GMUX_SOCKET, GMUX_SESSION_ID, etc. into every
+	// launched session.
 	cmd.Env = filterEnvPrefix(os.Environ(), "GMUX_")
-	if resumeID != "" {
-		cmd.Env = append(cmd.Env, "GMUX_RESUME_ID="+resumeID)
-	}
 
 	if err := cmd.Start(); err != nil {
 		return 0, err
 	}
 	go cmd.Wait()
 	return cmd.Process.Pid, nil
+}
+
+// buildLaunchArgs assembles the gmux runner argv: any non-empty
+// daemon→runner directive flags first, then the user command
+// verbatim. The gmux flag parser stops at the first positional, so
+// the user command is delivered intact even when its own arguments
+// look like flags.
+func buildLaunchArgs(resumeID string, initialCols, initialRows uint16, command []string) []string {
+	args := make([]string, 0, len(command)+3)
+	if resumeID != "" {
+		args = append(args, "--resume-id="+resumeID)
+	}
+	if initialCols > 0 {
+		args = append(args, fmt.Sprintf("--initial-cols=%d", initialCols))
+	}
+	if initialRows > 0 {
+		args = append(args, fmt.Sprintf("--initial-rows=%d", initialRows))
+	}
+	return append(args, command...)
 }
 
 func printUsage(w io.Writer) {
@@ -1120,7 +1144,17 @@ func serve(stderr io.Writer) int {
 			return
 		}
 
-		pid, err := launchGmux(gmuxBin, req.Command, cwd, "")
+		// Fresh launch: no resume id, no size hint. CLI invocations
+		// (`gmux <cmd>` in a terminal) detect their own TTY size
+		// via localterm.TerminalSize(). Browser-initiated launches
+		// have no TTY and currently no protocol slot for client
+		// dimensions, so the PTY starts at 80x24 until the
+		// browser's first resize WS message arrives. Same race as
+		// /resume and /restart had before the size hints were
+		// added; fixing /launch requires a protocol change to
+		// carry cols/rows in the launch request and is left as a
+		// follow-up.
+		pid, err := launchGmux(gmuxBin, req.Command, cwd, "", 0, 0)
 		if err != nil {
 			log.Printf("launch: failed to start gmux: %v", err)
 			writeError(w, http.StatusInternalServerError, "launch_failed", err.Error())
@@ -1210,12 +1244,15 @@ func serve(stderr io.Writer) int {
 				return
 			}
 
-			// The runner reads GMUX_RESUME_ID and registers under the
+			// The runner receives --resume-id and registers under the
 			// same id, so Register() lands in its re-registration
 			// branch and the session keeps its identity (and its
-			// scrollback directory). See ADR 0003.
+			// scrollback directory). See ADR 0003. The size hints
+			// preserve the last-known PTY dimensions through the
+			// fork; without them claude / vim / prompt frameworks
+			// reading $COLUMNS at startup would clamp to 80.
 			resumeCwd := projects.NormalizePath(sess.Cwd)
-			pid, err := launchGmux(gmuxBin, sess.Command, resumeCwd, sessionID)
+			pid, err := launchGmux(gmuxBin, sess.Command, resumeCwd, sessionID, sess.TerminalCols, sess.TerminalRows)
 			if err != nil {
 				log.Printf("resume: failed to start gmux: %v", err)
 				writeError(w, http.StatusInternalServerError, "launch_failed", err.Error())
@@ -1299,7 +1336,7 @@ func serve(stderr io.Writer) int {
 			// session id; Register's re-registration branch handles
 			// the rest.
 			restartCwd := projects.NormalizePath(sess.Cwd)
-			pid, err := launchGmux(gmuxBin, sess.Command, restartCwd, sessionID)
+			pid, err := launchGmux(gmuxBin, sess.Command, restartCwd, sessionID, sess.TerminalCols, sess.TerminalRows)
 			if err != nil {
 				log.Printf("restart: failed to start gmux: %v", err)
 				writeError(w, http.StatusInternalServerError, "launch_failed", err.Error())

--- a/services/gmuxd/cmd/gmuxd/main_test.go
+++ b/services/gmuxd/cmd/gmuxd/main_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -684,6 +685,55 @@ func TestIsOwnedEvent(t *testing.T) {
 		ev := store.Event{Type: "session-remove", ID: "sess-1@dc"}
 		if got := isOwnedEvent(ev, nil); got != false {
 			t.Errorf("isOwnedEvent with nil isLocalPeer = %v, want false", got)
+		}
+	})
+}
+
+func TestBuildLaunchArgs(t *testing.T) {
+	cmd := []string{"claude", "--continue", "-p", "hi"}
+
+	t.Run("fresh launch: no directives, command verbatim", func(t *testing.T) {
+		got := buildLaunchArgs("", 0, 0, cmd)
+		if !slices.Equal(got, cmd) {
+			t.Errorf("got %v, want %v", got, cmd)
+		}
+	})
+
+	t.Run("restart: all directives precede the command", func(t *testing.T) {
+		got := buildLaunchArgs("sess-abc", 142, 47, cmd)
+		want := []string{
+			"--resume-id=sess-abc",
+			"--initial-cols=142",
+			"--initial-rows=47",
+			"claude", "--continue", "-p", "hi",
+		}
+		if !slices.Equal(got, want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("zero dims omit the size flags", func(t *testing.T) {
+		got := buildLaunchArgs("sess-1", 0, 0, cmd)
+		want := append([]string{"--resume-id=sess-1"}, cmd...)
+		if !slices.Equal(got, want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("command flags survive intact (parser stops at first positional)", func(t *testing.T) {
+		// If the daemon's directive args bled into the command, the
+		// runner's flag parser would consume --resume-id from the
+		// child's own argv. Verify ordering: directives appear before
+		// the first positional only.
+		got := buildLaunchArgs("sess-1", 80, 24, []string{"weirdcli", "--resume-id=evil"})
+		want := []string{
+			"--resume-id=sess-1",
+			"--initial-cols=80",
+			"--initial-rows=24",
+			"weirdcli", "--resume-id=evil",
+		}
+		if !slices.Equal(got, want) {
+			t.Errorf("got %v, want %v", got, want)
 		}
 	})
 }


### PR DESCRIPTION
When gmuxd forks a runner for /v1/resume or /v1/restart, the runner's stdin/stdout are nil, so `localterm.TerminalSize()` fails and the PTY falls back to 80×24. Between exec and the browser's first resize WS message, any program that captures `$COLUMNS` at startup (claude, prompt frameworks, vim, less invoked non-interactively) sticks at 80 columns.

**Fix.** The daemon now passes the last-known `sess.TerminalCols/Rows` to the runner via two new CLI flags, `--initial-cols=N` / `--initial-rows=N`. The runner uses them to override `ptyCfg.Cols/Rows` before `pty.StartWithSize`, so the child sees the right dimensions from its very first `ioctl(TIOCGWINSZ)`. `sess.TerminalCols/Rows` is reliably non-zero whenever the session was ever displayed (it's persisted in `meta.json` and round-trips across daemon restart).

## Also: deprecate `GMUX_RESUME_ID` env var

Replaces it with a `--resume-id=<id>` flag on the same path. The runner still reads the env var as a fallback when the flag is empty, so a brand-new runner paired with a pre-flag-aware daemon (rolling upgrade) still works. The daemon no longer sets it.

Why switch: the runner grew a real flag parser since the ADR was written. The flag form is greppable in `ps`, validates types via the existing parser (rejects negative sizes without ad-hoc code), shows up in `--help` (tagged "daemon-internal"), and doesn't need an env-strip step in `buildChildEnv` to prevent leakage. POSIX runner semantics in the parser (stop at first positional) already protect against a child command's argv colliding with the daemon's directives.

All three flags are rejected in management modes (`--list`, `--attach`, etc.) so misuse fails loud.

## Scope: not fixing /v1/launch in this PR

The same race exists for browser-initiated launches: the launch request from the browser has no protocol slot for client dimensions, so a fresh PTY starts at 80x24 too. Fixing it requires adding `cols/rows` to the launch request and threading them through. CLI launches (`gmux <cmd>` in a terminal) are not affected — they detect their own TTY size via `localterm.TerminalSize()`. The misleading comment in the old `/v1/launch` code path is updated to call out the gap and the follow-up.

## Docs

ADR 0003 is revised: alternative E ("CLI flag instead of env var") was originally rejected as too public-CLI; reconsidered and adopted now that the runner has a real flag parser. Status flipped to Accepted with a "Revised: 2026-05-26 (env var → CLI flag)" line.

## Tests

- `TestBuildLaunchArgs` (daemon): fresh launch is unmodified, restart prepends directives in stable order, zero dims omit size flags, child commands with colliding flag names survive intact.
- `TestParseCLIDaemonDirectives` (runner): flags captured into `flags`, rest contains only the child command verbatim, child argv with same flag names not absorbed.
- `TestParseCLIErrors` (runner): new cases for directives-with-management-mode and negative sizes.