### PR TITLE
fix(daemon): reconcile alive runners after daemon restart

### DIFF
--- a/services/gmuxd/internal/discovery/discovery.go
+++ b/services/gmuxd/internal/discovery/discovery.go
@@ -123,12 +123,23 @@ func Scan(sessions *store.Store, subs *Subscriptions, fileMon *FileMonitor, onDe
 			continue
 		}
 		sockPath := filepath.Join(dir, entry.Name())
-		if t, ok := tracked[sockPath]; ok && t.alive && subs != nil && subs.IsActive(t.id) {
+		if t, ok := tracked[sockPath]; ok && t.alive && subs.IsActive(t.id) {
 			continue // already current — runner is alive and we're streaming /events
 		}
 		if err := Register(sessions, subs, fileMon, sockPath, onDead); err != nil {
 			// Only remove sockets old enough to be genuinely stale.
-			// A brand-new socket may not be listening yet (runner still starting).
+			// Two ways Register can land here:
+			//
+			//   - Brand-new socket file not listening yet (runner is
+			//     still starting, has bind()'d but not yet accept()'d).
+			//   - Tracked-but-dead session whose .sock file lingered
+			//     past the runner's exit; queryMeta times out. Pre-fix
+			//     these were skipped entirely; the new predicate lets
+			//     them fall through, so cleanup actually fires.
+			//
+			// The 10s ModTime threshold is generous for the first case
+			// (a runner takes milliseconds to listen) and irrelevant
+			// for the second (the file is hours / days old).
 			if info, serr := entry.Info(); serr == nil && time.Since(info.ModTime()) > 10*time.Second {
 				os.Remove(sockPath)
 			}

--- a/services/gmuxd/internal/discovery/discovery.go
+++ b/services/gmuxd/internal/discovery/discovery.go
@@ -88,11 +88,31 @@ func Scan(sessions *store.Store, subs *Subscriptions, fileMon *FileMonitor, onDe
 		return
 	}
 
-	// Build set of sockets already tracked by a store session.
-	trackedSockets := make(map[string]bool)
+	// Index existing store entries by SocketPath so Phase 1 can
+	// distinguish "already current" sockets from ones that need a
+	// fresh Register call.
+	//
+	// Sweep() at daemon startup populates the store with persisted
+	// sessions marked Alive=false; if their runners survived the
+	// daemon restart, the comment on Sweep promises "discovery.Register
+	// will upsert it with Alive=true shortly after". That contract
+	// only holds if Phase 1 actually calls Register for tracked-but-
+	// dead sockets, so the skip predicate below trusts a tracked entry
+	// only when it is both Alive AND has a live subscription. Anything
+	// less (Alive=false post-Sweep; Alive=true but subscription dropped
+	// during a transient blip) falls through to Register, whose
+	// documented re-registration branch merges fresh runtime state
+	// (alive, pid, socket, status, runner version, terminal size, …)
+	// onto the existing record while preserving the historical fields
+	// (slug, created_at, attribution title/subtitle, workspace).
+	type trackedState struct {
+		id    string
+		alive bool
+	}
+	tracked := make(map[string]trackedState)
 	for _, s := range sessions.List() {
 		if s.SocketPath != "" {
-			trackedSockets[s.SocketPath] = true
+			tracked[s.SocketPath] = trackedState{id: s.ID, alive: s.Alive}
 		}
 	}
 
@@ -103,8 +123,8 @@ func Scan(sessions *store.Store, subs *Subscriptions, fileMon *FileMonitor, onDe
 			continue
 		}
 		sockPath := filepath.Join(dir, entry.Name())
-		if trackedSockets[sockPath] {
-			continue // already tracked
+		if t, ok := tracked[sockPath]; ok && t.alive && subs != nil && subs.IsActive(t.id) {
+			continue // already current — runner is alive and we're streaming /events
 		}
 		if err := Register(sessions, subs, fileMon, sockPath, onDead); err != nil {
 			// Only remove sockets old enough to be genuinely stale.

--- a/services/gmuxd/internal/discovery/discovery_test.go
+++ b/services/gmuxd/internal/discovery/discovery_test.go
@@ -5,7 +5,9 @@ import (
 	"net"
 	"net/http"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/store"
 )
@@ -130,17 +132,32 @@ func TestScanSkipsTrackedAliveSubscribedSession(t *testing.T) {
 	const id = "sess-already-current"
 	sockPath := filepath.Join(sockDir, id+".sock")
 
-	// Fake runner counts /meta calls. If Phase 1 skips correctly,
-	// the count stays at zero across a Scan tick.
-	var metaCalls int
+	// Hold /events open so the subscription goroutine stays
+	// connected for the duration of the test. Without this the
+	// goroutine races with Scan: Subscribe stamps active[id]
+	// synchronously, but a fast dial + 404 could clear the entry
+	// before Scan reads IsActive, flipping the test from
+	// "skip-thrash" to "reconcile-drop" and giving a misleading
+	// failure when CI is slow.
+	hold := make(chan struct{})
+	t.Cleanup(func() { close(hold) })
+	var metaCalls atomic.Int64
 	ln, err := net.Listen("unix", sockPath)
 	if err != nil {
 		t.Fatalf("listen %s: %v", sockPath, err)
 	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/meta", func(w http.ResponseWriter, r *http.Request) {
-		metaCalls++
+		metaCalls.Add(1)
 		_ = json.NewEncoder(w).Encode(store.Session{ID: id, Kind: "shell", Alive: true})
+	})
+	mux.HandleFunc("/events", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.(http.Flusher).Flush()
+		select {
+		case <-r.Context().Done():
+		case <-hold:
+		}
 	})
 	srv := &http.Server{Handler: mux}
 	done := make(chan struct{})
@@ -155,18 +172,104 @@ func TestScanSkipsTrackedAliveSubscribedSession(t *testing.T) {
 		SocketPath: sockPath,
 	})
 
-	// Forge an active subscription entry without actually opening
-	// /events: Subscribe stamps active[id] synchronously, so
-	// IsActive will return true even though the goroutine will
-	// fail and exit shortly after (we don't care about its
-	// lifetime here, only about Scan's behavior in the moment).
 	subs := NewSubscriptions(sessions)
 	subs.Subscribe(id, sockPath)
 	t.Cleanup(func() { subs.UnsubscribeAll() })
 
+	// Settle: give the subscription goroutine time to dial and
+	// reach the held /events handler. IsActive is true the moment
+	// Subscribe returns (synchronous map insert), but pinning the
+	// SSE connection's lifecycle to the test's hold channel
+	// removes any window where the goroutine could fail-and-exit
+	// between Subscribe and Scan and silently turn this into a
+	// different test.
+	time.Sleep(50 * time.Millisecond)
+	if !subs.IsActive(id) {
+		t.Fatal("subscription dropped before Scan could read IsActive")
+	}
+	if n := metaCalls.Load(); n != 0 {
+		t.Fatalf("unexpected /meta traffic before Scan: metaCalls=%d", n)
+	}
+
 	Scan(sessions, subs, nil, nil)
 
-	if metaCalls != 0 {
-		t.Errorf("/meta called %d times during Scan; want 0 — Phase 1 must skip tracked-alive-subscribed sockets", metaCalls)
+	if n := metaCalls.Load(); n != 0 {
+		t.Errorf("/meta called %d times during Scan; want 0 — Phase 1 must skip tracked-alive-subscribed sockets", n)
 	}
 }
+
+// TestScanReregistersOnTransientSubscriptionDrop pins the
+// self-healing path for the case where a session's SSE
+// subscription dropped (network blip, runner /events handler
+// returned early, daemon-side scanner read error) but the runner
+// itself is still alive on its socket.
+//
+// runSubscription has no built-in reconnect: when the SSE stream
+// ends, the goroutine clears active[id] and the store retains
+// Alive=true with no consumer of runner /events. Phase 2's
+// "// subscription will reconnect" comment is aspirational —
+// nothing in the old code actually reconnects. The new Phase 1
+// predicate inherits the reconnection role: tracked && alive &&
+// !IsActive falls through to Register, which calls Subscribe and
+// restores the stream.
+//
+// Without this behavior, a session whose subscription dropped
+// silently loses live status/meta/exit events until the runner
+// dies or the daemon restarts.
+func TestScanReregistersOnTransientSubscriptionDrop(t *testing.T) {
+	sockDir := t.TempDir()
+	t.Setenv("GMUX_SOCKET_DIR", sockDir)
+
+	const id = "sess-blipped"
+	sockPath := filepath.Join(sockDir, id+".sock")
+
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen %s: %v", sockPath, err)
+	}
+	var metaCalls atomic.Int64
+	mux := http.NewServeMux()
+	mux.HandleFunc("/meta", func(w http.ResponseWriter, r *http.Request) {
+		metaCalls.Add(1)
+		_ = json.NewEncoder(w).Encode(store.Session{ID: id, Kind: "shell", Alive: true, Pid: 99})
+	})
+	mux.HandleFunc("/events", func(w http.ResponseWriter, r *http.Request) {
+		// Close immediately so the daemon-side subscription drops.
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.(http.Flusher).Flush()
+	})
+	srv := &http.Server{Handler: mux}
+	done := make(chan struct{})
+	go func() { _ = srv.Serve(ln); close(done) }()
+	t.Cleanup(func() { _ = srv.Close(); <-done })
+
+	sessions := store.New()
+	sessions.Upsert(store.Session{
+		ID:         id,
+		Kind:       "shell",
+		Alive:      true,
+		SocketPath: sockPath,
+	})
+
+	subs := NewSubscriptions(sessions)
+	t.Cleanup(func() { subs.UnsubscribeAll() })
+
+	// Scan must call Register exactly once during the dropped
+	// window, which dials /meta once and Subscribes once.
+	// Re-subscription is the load-bearing effect; the /meta call
+	// is the observable side effect we can count on.
+	Scan(sessions, subs, nil, nil)
+
+	if n := metaCalls.Load(); n != 1 {
+		t.Errorf("/meta called %d times; want 1 (Phase 1 must reconcile alive-but-unsubscribed sessions via Register)", n)
+	}
+	got, _ := sessions.Get(id)
+	if !got.Alive {
+		t.Errorf("Alive = false after reconcile, want true")
+	}
+	if got.Pid != 99 {
+		t.Errorf("Pid = %d, want 99 (re-registration must refresh runtime fields)", got.Pid)
+	}
+}
+
+

--- a/services/gmuxd/internal/discovery/discovery_test.go
+++ b/services/gmuxd/internal/discovery/discovery_test.go
@@ -1,0 +1,172 @@
+package discovery
+
+import (
+	"encoding/json"
+	"net"
+	"net/http"
+	"path/filepath"
+	"testing"
+
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/store"
+)
+
+// TestScanReregistersDeadButAliveRunnerAfterDaemonRestart pins the
+// dead→alive reconciliation contract that Sweep's docstring promises:
+// "callers (gmuxd at startup) Upsert them so the sidebar shows
+// previously-seen sessions before any live runners register … if a
+// live runner is still listening, discovery.Register will upsert it
+// with Alive=true shortly after."
+//
+// The scenario:
+//
+//  1. A previous gmuxd persisted session sess-survivor and exited.
+//  2. The runner stayed up; its socket is still bound and serving.
+//  3. The new gmuxd loads sess-survivor via Sweep → store now has
+//     Alive=false, SocketPath set, plus historical/attribution
+//     fields (slug, created_at, ...) we must not lose.
+//  4. The first Scan() tick must see the live socket, call Register,
+//     and flip Alive=true while preserving the historical fields.
+//
+// Before the fix, Phase 1's skip predicate ("already tracked")
+// short-circuited Register for any path the store already knew —
+// regardless of alive state — so the session sat as resumable in
+// the sidebar even though the runner was healthy, and clicking
+// resume hit the collision-fallback in run.go (orphan duplicate
+// session). The new predicate skips only when the existing entry
+// is genuinely current (Alive AND IsActive), letting Sweep-loaded
+// entries fall through to Register's documented re-registration
+// branch.
+func TestScanReregistersDeadButAliveRunnerAfterDaemonRestart(t *testing.T) {
+	// Place the socket inside a dir we control and point Scan at it.
+	sockDir := t.TempDir()
+	t.Setenv("GMUX_SOCKET_DIR", sockDir)
+
+	const id = "sess-survivor"
+	sockPath := filepath.Join(sockDir, id+".sock")
+
+	const createdAt = "2026-01-02T03:04:05Z"
+
+	// Fake runner: /meta reports the session as alive; /events returns
+	// 404 so the subscription goroutine exits quickly (we don't assert
+	// on SSE behavior here, only on the Scan→Register→Upsert seam).
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen %s: %v", sockPath, err)
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/meta", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(store.Session{
+			ID:    id,
+			Kind:  "shell",
+			Cwd:   "/home/user/proj",
+			Alive: true,
+			Pid:   12345,
+			// Empty Slug here mirrors what an adapter-less /meta would
+			// return; the post-attribution slug in the store must win.
+		})
+	})
+	srv := &http.Server{Handler: mux}
+	done := make(chan struct{})
+	go func() { _ = srv.Serve(ln); close(done) }()
+	t.Cleanup(func() { _ = srv.Close(); <-done })
+
+	// Seed the store as Sweep would: same id and SocketPath, Alive
+	// false, with the historical / attribution fields that the new
+	// daemon would not otherwise know.
+	sessions := store.New()
+	sessions.Upsert(store.Session{
+		ID:           id,
+		Kind:         "shell",
+		Cwd:          "/home/user/proj",
+		SocketPath:   sockPath,
+		Alive:        false,
+		Slug:         "post-attribution-name",
+		CreatedAt:    createdAt,
+		AdapterTitle: "Project Hub",
+		Subtitle:     "main",
+	})
+
+	subs := NewSubscriptions(sessions)
+	t.Cleanup(func() { subs.UnsubscribeAll() })
+
+	Scan(sessions, subs, nil, nil)
+
+	got, ok := sessions.Get(id)
+	if !ok {
+		t.Fatalf("session %s missing from store after Scan", id)
+	}
+	if !got.Alive {
+		t.Errorf("Alive = false, want true (Scan must re-register a surviving runner)")
+	}
+	if got.Pid != 12345 {
+		t.Errorf("Pid = %d, want 12345 (runtime fields must update from /meta)", got.Pid)
+	}
+	// Historical / attribution fields must survive the re-registration.
+	if got.Slug != "post-attribution-name" {
+		t.Errorf("Slug = %q, want %q (persisted slug must survive)", got.Slug, "post-attribution-name")
+	}
+	if got.CreatedAt != createdAt {
+		t.Errorf("CreatedAt = %q, want %q (creation time must survive)", got.CreatedAt, createdAt)
+	}
+	if got.AdapterTitle != "Project Hub" {
+		t.Errorf("AdapterTitle = %q, want %q (attribution must survive)", got.AdapterTitle, "Project Hub")
+	}
+	if got.Subtitle != "main" {
+		t.Errorf("Subtitle = %q, want %q (attribution must survive)", got.Subtitle, "main")
+	}
+}
+
+// TestScanSkipsTrackedAliveSubscribedSession is the negative case
+// guarding against a flapping or thrashing predicate: a session
+// already tracked, alive, and currently subscribed must NOT be
+// re-Registered on every Scan tick. Re-Registering would
+// needlessly dial /meta, churn subscriptions (Subscribe replaces
+// any active entry by design), and risk overwriting in-flight
+// runtime state with whatever /meta happens to report.
+func TestScanSkipsTrackedAliveSubscribedSession(t *testing.T) {
+	sockDir := t.TempDir()
+	t.Setenv("GMUX_SOCKET_DIR", sockDir)
+
+	const id = "sess-already-current"
+	sockPath := filepath.Join(sockDir, id+".sock")
+
+	// Fake runner counts /meta calls. If Phase 1 skips correctly,
+	// the count stays at zero across a Scan tick.
+	var metaCalls int
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen %s: %v", sockPath, err)
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/meta", func(w http.ResponseWriter, r *http.Request) {
+		metaCalls++
+		_ = json.NewEncoder(w).Encode(store.Session{ID: id, Kind: "shell", Alive: true})
+	})
+	srv := &http.Server{Handler: mux}
+	done := make(chan struct{})
+	go func() { _ = srv.Serve(ln); close(done) }()
+	t.Cleanup(func() { _ = srv.Close(); <-done })
+
+	sessions := store.New()
+	sessions.Upsert(store.Session{
+		ID:         id,
+		Kind:       "shell",
+		Alive:      true,
+		SocketPath: sockPath,
+	})
+
+	// Forge an active subscription entry without actually opening
+	// /events: Subscribe stamps active[id] synchronously, so
+	// IsActive will return true even though the goroutine will
+	// fail and exit shortly after (we don't care about its
+	// lifetime here, only about Scan's behavior in the moment).
+	subs := NewSubscriptions(sessions)
+	subs.Subscribe(id, sockPath)
+	t.Cleanup(func() { subs.UnsubscribeAll() })
+
+	Scan(sessions, subs, nil, nil)
+
+	if metaCalls != 0 {
+		t.Errorf("/meta called %d times during Scan; want 0 — Phase 1 must skip tracked-alive-subscribed sockets", metaCalls)
+	}
+}


### PR DESCRIPTION
When gmuxd restarts while a runner is still alive on its socket (systemd resume, gmuxd crash + supervisor relaunch, manual install), the surviving runner is invisible to the new daemon's session list:

- `Sweep` loads the persisted session as `Alive=false` (correctly — alive is in-memory truth, persistence is the post-death record).
- `discovery.Scan`'s Phase 1 then skips the socket file because the store already tracks the path, regardless of whether the tracked entry is alive.
- `discovery.Scan`'s Phase 2 only processes `Alive=true` entries, so there is no dead→alive reconciliation anywhere.

The session sits in the sidebar as resumable. Clicking resume causes the daemon to spawn a fresh runner with `--resume-id`, which collides on `BindSocket` (the original runner still owns it) and falls back to a brand-new id per ADR 0003. Each click leaks an orphan duplicate runner attached to no recognizable session row.

The same root cause shows up as a dismiss-resurrection bug: the user dismisses what looks like a dead session, the store entry disappears, the next Scan tick no longer sees the path as tracked and re-Registers the live runner as a new alive session — the dismissed row pops back.

`Register`'s documented re-registration branch already merges fresh runtime state onto the existing record while preserving slug, created_at, attribution, and workspace fields:

> Re-registration (id already in store). Resume … and daemon-restart-with-surviving-runner both land here.

It just was never being reached. Loosen Phase 1's skip predicate so it only short-circuits when the tracked entry is genuinely current (`Alive` AND subscription `IsActive`); anything less falls through to `Register`. The 10s stale-socket cleanup downstream still handles the case of a tracked-but-dead path that's no longer responsive — and now actually fires for those paths instead of skipping them.

## Bonus: transient subscription drop now self-heals

`runSubscription` has no built-in reconnect: when the SSE stream ends, the goroutine clears `active[id]` and the store retains `Alive=true` with no consumer of runner `/events`. Phase 2's `// subscription will reconnect` comment was aspirational — nothing actually reconnected, so a session whose subscription blipped silently lost live status/meta/exit events until the runner died or the daemon restarted.

The new Phase 1 predicate inherits the reconnection role: `tracked && alive && !IsActive` falls through to `Register`, which calls `Subscribe` and restores the stream. Pinned by `TestScanReregistersOnTransientSubscriptionDrop`.

## Tests

- `TestScanReregistersDeadButAliveRunnerAfterDaemonRestart` pins the full Sweep-then-Scan flow: seeded as `Alive=false` with historical fields (`Slug`, `CreatedAt`, `AdapterTitle`, `Subtitle`), comes out `Alive=true` with all historical fields preserved and runtime fields refreshed from `/meta`.
- `TestScanReregistersOnTransientSubscriptionDrop` pins the dropped-subscription self-heal: an alive-but-unsubscribed session gets re-Registered (and re-Subscribed) on the next Scan tick.
- `TestScanSkipsTrackedAliveSubscribedSession` is the negative-case thrash guard: a current session's `/meta` is not redialed on every Scan tick. Uses a held `/events` handler to remove a CI-flake window where the subscription goroutine could fail-and-exit between `Subscribe` and `Scan`.

5x repeats + race detector clean. Full daemon test suite (23 packages) passes.

## Commits

1. `fix(daemon): reconcile alive runners after daemon restart` — the one-line predicate change + `TestScanReregistersDeadButAliveRunnerAfterDaemonRestart`.
2. `test(daemon): harden discovery reconciliation tests and clarify cleanup comment` — the self-review pass: adds `TestScanReregistersOnTransientSubscriptionDrop`, fixes the CI-flake window in `TestScanSkipsTrackedAliveSubscribedSession`, expands the 10s stale-socket comment to cover both Register-failure paths, drops a defensive `subs != nil` check (asymmetric with Phase 2's contract).
