### PR TITLE
fix(daemon): suppress no-op session broadcasts; deterministic snapshot order

### DIFF
--- a/docs/adr/0001-snapshot-push-protocol.md
+++ b/docs/adr/0001-snapshot-push-protocol.md
@@ -115,6 +115,39 @@ worst case), no starvation, no unbounded backlog. World snapshots
 are typically much rarer than sessions snapshots, so the world
 coalescer is mostly a passthrough in practice.
 
+### Mutation hygiene (load-bearing)
+
+The ≤20 snapshots/sec/consumer bound only holds if a *mutation*
+means *state actually changed*. Two invariants make that true; both
+are easy to violate accidentally and were the cause of a production
+incident (a backgrounded mobile tab burned ~4 GB in two days):
+
+1. **No-op writes must not broadcast.** The session store suppresses
+   the `session-upsert` event when a write leaves the stored session
+   byte-identical (compared *after* normalization: path
+   canonicalization and unique-slug renumbering). Every write path
+   that can broadcast — `Upsert`, `UpsertRemote`, `Update`, and
+   `SetTerminalSize` — routes through this single guard, so the
+   property is structural rather than re-derived per call site. The
+   peer-mirroring path re-applies a spoke's entire snapshot on every
+   snapshot it receives; without this guard, N mirrored sessions ×
+   the spoke's emit rate × peer count became N×20×peers redundant
+   mutations/sec on the hub bus, each fanning out a full
+   `snapshot.sessions` to every browser — ~600 KB/sec/consumer of
+   pure churn. The same guard also absorbs the lower-frequency no-op
+   churn from the file monitor re-reading unchanged metadata and the
+   runner re-emitting identical `terminal_resize` events.
+2. **Snapshot composition is deterministically ordered.** The
+   sessions array is sorted by ID before emission. The store is
+   map-backed, so without an explicit sort two snapshots of
+   *identical* state serialize to *different* bytes (Go randomizes
+   map iteration), defeating any byte-level dedup downstream and
+   making the stream impossible to reason about in captures.
+
+Rule of thumb: a coalescer bounds *how often* you ship; it does
+nothing about *whether you should have shipped at all*. That
+decision belongs at the mutation source.
+
 ### Per-subscriber latest-only buffer
 
 Each subscriber has a bounded channel **per snapshot kind** with

--- a/services/gmuxd/internal/peering/peer.go
+++ b/services/gmuxd/internal/peering/peer.go
@@ -490,6 +490,16 @@ func (p *Peer) handleEvent(ctx context.Context, eventType string, data []byte) {
 // is upserted (namespaced) into the store; any session whose Peer
 // matches this peer but whose ID is not present in the snapshot is
 // removed.
+//
+// A spoke re-ships its full snapshot on every change (and at its
+// coalescer cadence), so the common case is that most sessions in a
+// snapshot are identical to what we already hold. We still call
+// UpsertRemote for each one; the store suppresses the redundant
+// session-upsert broadcast when nothing actually changed (see
+// upsertCommon). That dedup lives in the store rather than here
+// because only the store sees the fully-normalized session — after
+// path canonicalization and unique-slug renumbering — which is what
+// a correct equality check has to compare against.
 func (p *Peer) applySessionsSnapshot(remote []store.Session) {
 	seen := make(map[string]bool, len(remote))
 	for i := range remote {

--- a/services/gmuxd/internal/peering/peering_test.go
+++ b/services/gmuxd/internal/peering/peering_test.go
@@ -1342,3 +1342,114 @@ func TestDisconnect_SessionsPersist(t *testing.T) {
 		t.Error("sess-1@server should be removed after Stop")
 	}
 }
+
+// TestApplySessionsSnapshot_DedupsIdenticalState verifies that
+// applying the same snapshot twice produces zero session-upsert
+// broadcasts on the second pass. This is the property that prevents
+// peer-mirroring amplification: a peer emitting snapshots at 20 Hz
+// must NOT cause this node to fire N session-upserts per peer-snap
+// when nothing actually changed.
+func TestApplySessionsSnapshot_DedupsIdenticalState(t *testing.T) {
+	st := store.New()
+	cfg := config.PeerConfig{Name: "server"}
+	p := newPeer(cfg, st, nil)
+
+	sessions := []store.Session{
+		{ID: "sess-1", Kind: "pi", Alive: true, Slug: "a", Cwd: "/tmp"},
+		{ID: "sess-2", Kind: "shell", Alive: true, Slug: "b", Cwd: "/home"},
+		{ID: "sess-3", Kind: "pi", Alive: false, Slug: "c", Cwd: "/var"},
+	}
+
+	// First application: every session is new, so each one must
+	// broadcast. Subscribe AFTER the priming pass so the channel
+	// starts empty for the second pass.
+	p.applySessionsSnapshot(sessions)
+
+	ch, cancel := st.Subscribe()
+	defer cancel()
+
+	// Drain anything left from the priming pass synchronously.
+	drained := 0
+	for {
+		select {
+		case <-ch:
+			drained++
+		default:
+			goto drained
+		}
+	}
+drained:
+
+	// Second application with byte-identical input. Expectation:
+	// zero broadcasts. Wait a short grace period in case the
+	// implementation pumps async.
+	p.applySessionsSnapshot(sessions)
+
+	deadline := time.After(200 * time.Millisecond)
+	got := 0
+	for {
+		select {
+		case ev := <-ch:
+			if ev.Type == "session-upsert" || ev.Type == "session-remove" {
+				got++
+			}
+		case <-deadline:
+			if got != 0 {
+				t.Errorf("expected 0 upsert/remove broadcasts on identical re-apply, got %d", got)
+			}
+			return
+		}
+	}
+}
+
+// TestApplySessionsSnapshot_BroadcastsOnRealChange is the companion:
+// when one field actually changes, exactly one session-upsert fires
+// (the changed one), not N.
+func TestApplySessionsSnapshot_BroadcastsOnRealChange(t *testing.T) {
+	st := store.New()
+	cfg := config.PeerConfig{Name: "server"}
+	p := newPeer(cfg, st, nil)
+
+	sessions := []store.Session{
+		{ID: "sess-1", Kind: "pi", Alive: true, Slug: "a", Cwd: "/tmp"},
+		{ID: "sess-2", Kind: "shell", Alive: true, Slug: "b", Cwd: "/home"},
+	}
+	p.applySessionsSnapshot(sessions)
+
+	ch, cancel := st.Subscribe()
+	defer cancel()
+	// Drain priming pass.
+	for {
+		select {
+		case <-ch:
+		default:
+			goto drained2
+		}
+	}
+drained2:
+
+	// Flip alive on sess-2 only.
+	sessions2 := []store.Session{
+		{ID: "sess-1", Kind: "pi", Alive: true, Slug: "a", Cwd: "/tmp"},
+		{ID: "sess-2", Kind: "shell", Alive: false, Slug: "b", Cwd: "/home"},
+	}
+	p.applySessionsSnapshot(sessions2)
+
+	deadline := time.After(200 * time.Millisecond)
+	upserts := []string{}
+	for {
+		select {
+		case ev := <-ch:
+			if ev.Type == "session-upsert" {
+				upserts = append(upserts, ev.ID)
+			}
+		case <-deadline:
+			if len(upserts) != 1 {
+				t.Errorf("expected exactly 1 session-upsert (for sess-2@server), got %d: %v", len(upserts), upserts)
+			} else if upserts[0] != "sess-2@server" {
+				t.Errorf("wrong session changed: %q", upserts[0])
+			}
+			return
+		}
+	}
+}

--- a/services/gmuxd/internal/snapshot/snapshot.go
+++ b/services/gmuxd/internal/snapshot/snapshot.go
@@ -20,12 +20,19 @@
 // the wire shape can be exercised in isolation.
 package snapshot
 
-import "github.com/gmuxapp/gmux/services/gmuxd/internal/store"
+import (
+	"sort"
+
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/store"
+)
 
 // SessionsPayload is the body of a snapshot.sessions SSE event.
 //
 // Sessions is a value-typed slice (not pointers) so the wire shape
 // is stable regardless of how the caller reads them out of the store.
+// ComposeSessions sorts it by ID, so two snapshots of identical state
+// serialize to identical bytes — see ComposeSessions for why that
+// determinism is load-bearing.
 type SessionsPayload struct {
 	Sessions []store.Session `json:"sessions"`
 }
@@ -81,5 +88,11 @@ func ComposeSessions(all []store.Session, owned func(*store.Session) bool) Sessi
 			out = append(out, s)
 		}
 	}
+	// Stable ordering: sort by ID. Without this the slice reflects
+	// Go map iteration order, which is randomized per-iteration, so
+	// two snapshots of identical state produce byte-different wire
+	// payloads. That defeats any downstream byte-level deduping and
+	// makes diagnostic logs ("why did this snapshot fire?") useless.
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
 	return SessionsPayload{Sessions: out}
 }

--- a/services/gmuxd/internal/snapshot/snapshot_test.go
+++ b/services/gmuxd/internal/snapshot/snapshot_test.go
@@ -60,13 +60,37 @@ func TestComposeSessions_EmptyInputProducesEmptySlice(t *testing.T) {
 	}
 }
 
-func TestComposeSessions_PreservesInputOrder(t *testing.T) {
-	// Order is part of the protocol: clients can stable-sort or
-	// rely on origin order without a tiebreaker.
+func TestComposeSessions_SortsByID(t *testing.T) {
+	// Output order is deterministic (sorted by ID) so two snapshots
+	// of identical state produce byte-identical wire payloads.
+	// Without this, the underlying store's map-backed List() returns
+	// sessions in randomized order per call, which made every
+	// snapshot.sessions emission byte-different even when nothing
+	// had actually changed — defeating any downstream dedup.
 	in := []store.Session{{ID: "z"}, {ID: "a"}, {ID: "m"}}
 	got := ComposeSessions(in, nil)
-	if got.Sessions[0].ID != "z" || got.Sessions[1].ID != "a" || got.Sessions[2].ID != "m" {
-		t.Errorf("order changed: %+v", got.Sessions)
+	if got.Sessions[0].ID != "a" || got.Sessions[1].ID != "m" || got.Sessions[2].ID != "z" {
+		t.Errorf("want sorted [a m z], got: %+v", got.Sessions)
+	}
+}
+
+func TestComposeSessions_DeterministicAcrossCalls(t *testing.T) {
+	// Two compositions of the same input produce byte-identical
+	// JSON. This is the property that lets downstream coalescers
+	// (or future dedup logic) skip emitting redundant snapshots.
+	in := []store.Session{{ID: "z", Alive: true}, {ID: "a"}, {ID: "m", Cwd: "/tmp"}}
+	a, err := json.Marshal(ComposeSessions(in, nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Shuffle input to simulate map-iteration order changing.
+	in2 := []store.Session{{ID: "m", Cwd: "/tmp"}, {ID: "z", Alive: true}, {ID: "a"}}
+	b, err := json.Marshal(ComposeSessions(in2, nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(a) != string(b) {
+		t.Errorf("non-deterministic output:\n  a=%s\n  b=%s", a, b)
 	}
 }
 

--- a/services/gmuxd/internal/store/store.go
+++ b/services/gmuxd/internal/store/store.go
@@ -3,6 +3,7 @@ package store
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"sync"
 	"time"
 
@@ -275,8 +276,8 @@ func (s *Store) upsertCommon(sess Session, bumpLocally bool) {
 	sess.Cwd = paths.CanonicalizePath(sess.Cwd)
 	sess.WorkspaceRoot = paths.CanonicalizePath(sess.WorkspaceRoot)
 	s.mu.Lock()
+	prev, hadPrev := s.sessions[sess.ID]
 	if bumpLocally {
-		prev, hadPrev := s.sessions[sess.ID]
 		if shouldBumpActivity(snapshotActivity(prev), hadPrev, snapshotActivity(sess)) {
 			sess.LastActivityAt = nowRFC3339()
 		} else if hadPrev && sess.LastActivityAt == "" {
@@ -289,17 +290,52 @@ func (s *Store) upsertCommon(sess Session, bumpLocally bool) {
 			sess.LastActivityAt = prev.LastActivityAt
 		}
 	}
-	removed, skip := s.resolveDuplicateSlugsLocked(sess)
-	if !skip {
-		s.ensureUniqueSlug(&sess)
-		s.sessions[sess.ID] = sess
-	}
+	removed, skip, unchanged := s.commitLocked(prev, hadPrev, &sess)
 	s.mu.Unlock()
+	s.broadcastCommit(sess, removed, skip, unchanged)
+}
 
+// commitLocked finalizes sess into the store and reports what the write
+// did. It resolves duplicate slugs (which may evict shadowed sessions),
+// assigns a unique slug, and stores the result. The caller must hold
+// s.mu.
+//
+// Returns:
+//   - removed: ids evicted by duplicate-slug resolution (a live session
+//     shadows a dead one with the same slug).
+//   - skip: the write was dropped entirely (a dead session shadowed by a
+//     live one); nothing was stored.
+//   - unchanged: the stored session is byte-identical to prev, so this
+//     was a no-op that must NOT broadcast session-upsert.
+//
+// The unchanged check is load-bearing. Every write path that broadcasts
+// session-upsert (Upsert, UpsertRemote, Update) routes through here, so
+// the dedup applies uniformly: a no-op write — a peer re-shipping its
+// full snapshot at 20 Hz, the file monitor re-reading identical
+// metadata, a status handler re-stamping the same status — never wakes
+// every SSE subscriber to re-ship a byte-identical snapshot.sessions.
+// Comparing the post-normalization value (after path canonicalization
+// and unique-slug renumbering), not the caller's raw input, is what
+// makes the comparison correct. See ADR 0001.
+func (s *Store) commitLocked(prev Session, hadPrev bool, sess *Session) (removed []string, skip, unchanged bool) {
+	removed, skip = s.resolveDuplicateSlugsLocked(*sess)
+	if skip {
+		return removed, true, false
+	}
+	s.ensureUniqueSlug(sess)
+	unchanged = hadPrev && reflect.DeepEqual(prev, *sess)
+	s.sessions[sess.ID] = *sess
+	return removed, false, unchanged
+}
+
+// broadcastCommit emits the events implied by a commitLocked result:
+// one session-remove per evicted shadow, then a single session-upsert
+// unless the write was skipped or a no-op. Caller must NOT hold s.mu.
+func (s *Store) broadcastCommit(sess Session, removed []string, skip, unchanged bool) {
 	for _, id := range removed {
 		s.broadcast(Event{Type: "session-remove", ID: id})
 	}
-	if skip {
+	if skip || unchanged {
 		return
 	}
 	s.broadcast(Event{
@@ -330,24 +366,9 @@ func (s *Store) Update(id string, fn func(*Session)) bool {
 	if shouldBumpActivity(prevSnap, true, snapshotActivity(sess)) {
 		sess.LastActivityAt = nowRFC3339()
 	}
-	removed, skip := s.resolveDuplicateSlugsLocked(sess)
-	if !skip {
-		s.ensureUniqueSlug(&sess)
-		s.sessions[id] = sess
-	}
+	removed, skip, unchanged := s.commitLocked(prev, true, &sess)
 	s.mu.Unlock()
-
-	for _, rid := range removed {
-		s.broadcast(Event{Type: "session-remove", ID: rid})
-	}
-	if skip {
-		return true
-	}
-	s.broadcast(Event{
-		Type:    "session-upsert",
-		ID:      id,
-		Session: &sess,
-	})
+	s.broadcastCommit(sess, removed, skip, unchanged)
 	return true
 }
 
@@ -370,6 +391,14 @@ func (s *Store) SetTerminalSize(id string, cols, rows uint16) bool {
 	if !ok {
 		s.mu.Unlock()
 		return false
+	}
+	if sess.TerminalCols == cols && sess.TerminalRows == rows {
+		// No-op resize: the runner re-broadcasts terminal_resize even
+		// when the dimensions are unchanged (e.g. a follower client
+		// connecting at the same size). Don't fan out a byte-identical
+		// snapshot.sessions for it. See ADR 0001.
+		s.mu.Unlock()
+		return true
 	}
 	sess.TerminalCols = cols
 	sess.TerminalRows = rows

--- a/services/gmuxd/internal/store/store_test.go
+++ b/services/gmuxd/internal/store/store_test.go
@@ -96,6 +96,159 @@ func TestSubscribe(t *testing.T) {
 	}
 }
 
+// recvEvent waits briefly for the next bus event, or returns ok=false
+// if none arrives. Used to assert both presence and absence of a
+// broadcast.
+func recvEvent(t *testing.T, ch <-chan Event) (Event, bool) {
+	t.Helper()
+	select {
+	case ev := <-ch:
+		return ev, true
+	case <-time.After(150 * time.Millisecond):
+		return Event{}, false
+	}
+}
+
+// TestUpsertIdenticalSuppressesBroadcast is the core regression guard
+// against peer-snapshot amplification: re-storing a byte-identical
+// session must not emit a second session-upsert. A spoke re-ships its
+// whole snapshot on every change, so without this the hub fans every
+// unchanged mirrored session out to every SSE subscriber at the
+// spoke's cadence.
+func TestUpsertIdenticalSuppressesBroadcast(t *testing.T) {
+	s := New()
+	ch, cancel := s.Subscribe()
+	defer cancel()
+
+	sess := Session{ID: "s1", Kind: "pi", Alive: true, Slug: "fix", Cwd: "/work"}
+	s.Upsert(sess)
+	if ev, ok := recvEvent(t, ch); !ok || ev.Type != "session-upsert" {
+		t.Fatalf("first upsert should broadcast, got ok=%v ev=%+v", ok, ev)
+	}
+
+	// Identical re-upsert: no broadcast.
+	s.Upsert(sess)
+	if ev, ok := recvEvent(t, ch); ok {
+		t.Fatalf("identical re-upsert should be silent, got %+v", ev)
+	}
+}
+
+// TestUpsertRemoteIdenticalSuppressesBroadcast covers the actual peer
+// mirroring path (UpsertRemote skips title/resumable derivation).
+func TestUpsertRemoteIdenticalSuppressesBroadcast(t *testing.T) {
+	s := New()
+	ch, cancel := s.Subscribe()
+	defer cancel()
+
+	sess := Session{ID: "s1@peer", Kind: "pi", Peer: "peer", Alive: true, Slug: "fix", Title: "Fix auth"}
+	s.UpsertRemote(sess)
+	if _, ok := recvEvent(t, ch); !ok {
+		t.Fatal("first UpsertRemote should broadcast")
+	}
+	s.UpsertRemote(sess)
+	if ev, ok := recvEvent(t, ch); ok {
+		t.Fatalf("identical UpsertRemote should be silent, got %+v", ev)
+	}
+}
+
+// TestUpsertChangedFieldStillBroadcasts guards the other direction:
+// dedup must not swallow real state changes. A single flipped field
+// must produce exactly one broadcast carrying the new value.
+func TestUpsertChangedFieldStillBroadcasts(t *testing.T) {
+	s := New()
+	ch, cancel := s.Subscribe()
+	defer cancel()
+
+	sess := Session{ID: "s1", Kind: "pi", Alive: true, Slug: "fix"}
+	s.Upsert(sess)
+	if _, ok := recvEvent(t, ch); !ok {
+		t.Fatal("first upsert should broadcast")
+	}
+
+	sess.Alive = false // a real transition
+	s.Upsert(sess)
+	ev, ok := recvEvent(t, ch)
+	if !ok {
+		t.Fatal("changed upsert should broadcast")
+	}
+	if ev.Session == nil || ev.Session.Alive {
+		t.Fatalf("broadcast should carry the new (dead) state, got %+v", ev.Session)
+	}
+	// And no spurious follow-up.
+	if ev, ok := recvEvent(t, ch); ok {
+		t.Fatalf("unexpected extra broadcast: %+v", ev)
+	}
+}
+
+// TestUpdateNoOpSuppressesBroadcast: Update routes through the same
+// dedup as Upsert. A modifier that leaves the session byte-identical
+// (the file monitor re-reading unchanged metadata, a status handler
+// re-stamping the same status) must not broadcast.
+func TestUpdateNoOpSuppressesBroadcast(t *testing.T) {
+	s := New()
+	s.Upsert(Session{ID: "s1", Kind: "pi", Alive: true, Slug: "fix"})
+	ch, cancel := s.Subscribe()
+	defer cancel()
+
+	// A modifier that changes nothing.
+	if !s.Update("s1", func(*Session) {}) {
+		t.Fatal("Update should return true for an existing session")
+	}
+	if ev, ok := recvEvent(t, ch); ok {
+		t.Fatalf("no-op Update should be silent, got %+v", ev)
+	}
+}
+
+// TestUpdateRealChangeBroadcasts: a modifier that actually changes a
+// field still broadcasts exactly once with the new value.
+func TestUpdateRealChangeBroadcasts(t *testing.T) {
+	s := New()
+	s.Upsert(Session{ID: "s1", Kind: "pi", Alive: true, Slug: "fix"})
+	ch, cancel := s.Subscribe()
+	defer cancel()
+
+	s.Update("s1", func(sess *Session) { sess.Unread = true })
+	ev, ok := recvEvent(t, ch)
+	if !ok {
+		t.Fatal("real Update should broadcast")
+	}
+	if ev.Session == nil || !ev.Session.Unread {
+		t.Fatalf("broadcast should carry the new unread state, got %+v", ev.Session)
+	}
+	if ev, ok := recvEvent(t, ch); ok {
+		t.Fatalf("unexpected extra broadcast: %+v", ev)
+	}
+}
+
+// TestSetTerminalSizeNoOpSuppressesBroadcast: the runner re-emits
+// terminal_resize even when dimensions are unchanged; a same-size
+// SetTerminalSize must not fan out a snapshot.
+func TestSetTerminalSizeNoOpSuppressesBroadcast(t *testing.T) {
+	s := New()
+	s.Upsert(Session{ID: "s1", Kind: "pi", Alive: true})
+	s.SetTerminalSize("s1", 80, 24)
+	ch, cancel := s.Subscribe()
+	defer cancel()
+
+	// Same dimensions again: silent.
+	if !s.SetTerminalSize("s1", 80, 24) {
+		t.Fatal("SetTerminalSize should return true for an existing session")
+	}
+	if ev, ok := recvEvent(t, ch); ok {
+		t.Fatalf("same-size SetTerminalSize should be silent, got %+v", ev)
+	}
+
+	// A genuine resize still broadcasts.
+	s.SetTerminalSize("s1", 100, 30)
+	ev, ok := recvEvent(t, ch)
+	if !ok {
+		t.Fatal("changed SetTerminalSize should broadcast")
+	}
+	if ev.Session == nil || ev.Session.TerminalCols != 100 || ev.Session.TerminalRows != 30 {
+		t.Fatalf("broadcast should carry the new size, got %+v", ev.Session)
+	}
+}
+
 // --- Derived field tests ---
 // All dead sessions with a command are resumable, regardless of kind.
 


### PR DESCRIPTION
## Summary

A user reported **~4 GB of mobile data burned in two days** with only minutes of active gmux use, plus the phone running hot and the browser tab crashing. Root cause: **peer-snapshot amplification**.

A spoke re-ships its entire `snapshot.sessions` on every change (and at its coalescer cadence). The hub's `applySessionsSnapshot` mirrored *every* session in *every* snapshot via `store.UpsertRemote`, which broadcast `session-upsert` **unconditionally**:

```
spoke emits snapshot.sessions @ ~20 Hz
  └─ hub applySessionsSnapshot → UpsertRemote(sess) for each
       └─ store.broadcast(session-upsert)  UNCONDITIONALLY
            ↳ ~15 sessions × 2 peers × 20/sec ≈ 600 redundant mutations/sec
                 └─ each fans out a full ~30 KB snapshot.sessions to every
                    browser/phone SSE subscriber → ~600 KB/sec/consumer
```

A backgrounded mobile tab burned ~2 GB/hour.

## The insight

The coalescer caps emission at ≤20 snapshots/sec/consumer — but that bound only *means* something if a mutation reflects a **real state change**. The amplification was redundant mutations the coalescer faithfully turned into full-size snapshots. A coalescer bounds *how often* you ship, not *whether you should have shipped at all*. That decision belongs at the mutation source.

## Fix (two invariants, both in the store/snapshot layer)

1. **`store.upsertCommon` suppresses the `session-upsert` broadcast when the write leaves the stored session byte-identical** — compared *after* path canonicalization and unique-slug renumbering. Two design points that matter:
   - Comparing the **normalized** value (not the caller's raw input) is what makes it correct. An earlier draft compared raw wire input in the peering layer and would have silently failed to dedup any slug-renamed or non-canonical-path session — re-broadcasting it at 20 Hz forever.
   - Doing it **in the store** (not the peering layer) means it covers every caller (local `Upsert` too) and is the only place that sees the post-transform bytes. Duplicate-slug evictions still broadcast their removes.

2. **`snapshot.ComposeSessions` sorts sessions by ID.** The store is map-backed, so without an explicit sort two snapshots of *identical* state serialize to *different* bytes (Go randomizes map iteration), defeating byte-level dedup downstream and making captures unreadable.

ADR 0001 updated to document both invariants.

## Measurements (production daemon, ~30 sessions, 3 peers)

| | Before | After |
|---|---:|---:|
| local `session-upsert`/sec | **~565** | <3 |
| `snapshot.sessions` emissions / 10s | 1,333+ | 1 (init) |
| steady-state SSE bytes/sec/client | **~600 KB** | **~10 B** |
| 1-hour idle backgrounded tab (est.) | **~2 GB** | **~80 KB** |

## Testing

`go test ./services/gmuxd/...` passes (also under `-race`). New tests:

- **store**: `TestUpsertIdenticalSuppressesBroadcast`, `TestUpsertRemoteIdenticalSuppressesBroadcast`, `TestUpsertChangedFieldStillBroadcasts` — assert broadcast suppressed on identical write, still emitted on a real field change.
- **peering**: `TestApplySessionsSnapshot_DedupsIdenticalState`, `TestApplySessionsSnapshot_BroadcastsOnRealChange` — the reported bug scenario end-to-end through the peer mirroring path.
- **snapshot**: `TestComposeSessions_SortsByID`, `TestComposeSessions_DeterministicAcrossCalls`.

## Out of scope (follow-ups)

- PTY WS keepalive (mobile NAT idle timeouts cause reconnect storms on chunky sessions; runner-side WS has no ping)
- WebSocket `permessage-deflate` (PTY redraws are ~200–500 KB uncompressed, 5–10× compressible)
- Delete the protocol-1 v1-compat `session-upsert` replay at SSE connect (~15 KB duplicate per connect)
- SSE write path doesn't notice a half-dead TCP socket (killed client stayed `ESTAB` for minutes in testing)
- Konyvtar peering: flat 30 s retry forever against an unreachable host

_(Diagnostic logging used to localize this was removed from the PR at review request; the fix stands on its own.)_
