### PR TITLE
feat(gmuxd): PTY WebSocket keepalive + compression (mobile data, #241/#242)

### DIFF
--- a/services/gmuxd/internal/apiclient/client.go
+++ b/services/gmuxd/internal/apiclient/client.go
@@ -354,8 +354,12 @@ func (c *Client) DialWS(ctx context.Context, sessionID string) (*websocket.Conn,
 // sessionID is the ORIGINAL (unnamespaced) session ID on the spoke,
 // not the namespaced wire ID. Callers strip the suffix first.
 func (c *Client) ProxyWS(w http.ResponseWriter, r *http.Request, sessionID string) {
+	// CompressionContextTakeover compresses the browser-facing hop
+	// (terminal output is highly repetitive); the hub->spoke hop is
+	// left uncompressed. Safari falls back to uncompressed. See #242.
 	clientConn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
 		InsecureSkipVerify: true,
+		CompressionMode:    websocket.CompressionContextTakeover,
 	})
 	if err != nil {
 		log.Printf("apiclient ProxyWS: accept: %v", err)

--- a/services/gmuxd/internal/apiclient/client.go
+++ b/services/gmuxd/internal/apiclient/client.go
@@ -31,6 +31,7 @@ import (
 	"nhooyr.io/websocket"
 
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/sseclient"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/wskeepalive"
 )
 
 // Read limits for ProxyWS. These match the values wsproxy.go uses
@@ -385,7 +386,16 @@ func (c *Client) pipeWS(parent context.Context, clientConn, spokeConn *websocket
 	defer cancel()
 
 	var wg sync.WaitGroup
-	wg.Add(2)
+	wg.Add(3)
+
+	// Keepalive on the browser-facing hop, mirroring the local-session
+	// proxy. Runs alongside the client read loop below (which delivers
+	// the pongs) and cancels the pipe if the phone drops off. See #241.
+	go func() {
+		defer wg.Done()
+		wskeepalive.Run(ctx, clientConn,
+			wskeepalive.DefaultInterval, wskeepalive.DefaultTimeout, cancel)
+	}()
 
 	// Spoke → Client (terminal output + resize events).
 	go func() {

--- a/services/gmuxd/internal/wskeepalive/wskeepalive.go
+++ b/services/gmuxd/internal/wskeepalive/wskeepalive.go
@@ -1,0 +1,76 @@
+// Package wskeepalive provides a WebSocket ping loop that keeps an
+// otherwise-idle connection alive across NAT timeouts and promptly
+// detects a dead peer.
+//
+// Why this exists: the PTY data plane (browser ↔ gmuxd) carries no
+// application traffic while a terminal sits idle. Cellular carriers
+// drop idle TCP flows behind their NAT after as little as 30–60s.
+// Without a keepalive the browser only discovers the dead connection
+// on its next write, then reconnects and the server re-ships the full
+// multi-megabyte scrollback replay — a reconnect storm that burns
+// mobile data and can OOM the mobile browser. A small periodic ping
+// keeps the flow warm and surfaces a genuinely dead peer within one
+// interval. See issue #241.
+package wskeepalive
+
+import (
+	"context"
+	"time"
+
+	"nhooyr.io/websocket"
+)
+
+const (
+	// DefaultInterval is how often we ping an idle connection. Chosen
+	// below the ~30s low end of carrier NAT idle timeouts so the flow
+	// never goes quiet long enough to be reaped.
+	DefaultInterval = 20 * time.Second
+	// DefaultTimeout bounds how long we wait for a pong before treating
+	// the peer as dead.
+	DefaultTimeout = 10 * time.Second
+)
+
+// Pinger is the subset of *websocket.Conn this package needs. It exists
+// so the loop can be unit-tested without a real socket.
+type Pinger interface {
+	Ping(ctx context.Context) error
+}
+
+// Run pings conn every interval until ctx is cancelled or a ping fails
+// to be answered within timeout, whichever comes first. On a failed
+// ping it invokes onDead once and returns; the caller wires onDead to
+// its connection-teardown (e.g. cancelling the proxy context) so the
+// read/write goroutines unwind.
+//
+// Run MUST execute concurrently with a reader on the same connection:
+// websocket.Conn.Ping waits for the pong to be read by a Reader call,
+// so a connection with no active read loop would block every ping
+// until timeout and be falsely declared dead. Both PTY proxy paths
+// satisfy this — they always have a client→backend read loop running.
+func Run(ctx context.Context, conn Pinger, interval, timeout time.Duration, onDead func()) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			pingCtx, cancel := context.WithTimeout(ctx, timeout)
+			err := conn.Ping(pingCtx)
+			cancel()
+			if err != nil {
+				// Distinguish a dead peer from normal shutdown: if the
+				// parent ctx is already done, the error is just the
+				// teardown racing the ping — not a NAT drop.
+				if ctx.Err() != nil {
+					return
+				}
+				onDead()
+				return
+			}
+		}
+	}
+}
+
+// Ensure *websocket.Conn satisfies Pinger at compile time.
+var _ Pinger = (*websocket.Conn)(nil)

--- a/services/gmuxd/internal/wskeepalive/wskeepalive_test.go
+++ b/services/gmuxd/internal/wskeepalive/wskeepalive_test.go
@@ -1,0 +1,139 @@
+package wskeepalive
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// fakePinger records ping calls and can either return immediately with a
+// scripted error or block until its context is done (to simulate a ping
+// that is in flight when cancellation arrives). It signals each ping on
+// the buffered `pinged` channel so tests can synchronize deterministically
+// instead of sleeping.
+type fakePinger struct {
+	calls  atomic.Int32
+	err    atomic.Pointer[error]
+	block  atomic.Bool
+	pinged chan struct{}
+}
+
+func newFakePinger() *fakePinger {
+	return &fakePinger{pinged: make(chan struct{}, 1)}
+}
+
+func (f *fakePinger) Ping(ctx context.Context) error {
+	f.calls.Add(1)
+	select {
+	case f.pinged <- struct{}{}: // best-effort signal; never blocks the loop
+	default:
+	}
+	if f.block.Load() {
+		<-ctx.Done() // mimic a ping waiting for a pong until cancelled
+		return ctx.Err()
+	}
+	if e := f.err.Load(); e != nil {
+		return *e
+	}
+	return nil
+}
+
+func (f *fakePinger) setErr(err error) { f.err.Store(&err) }
+
+// waitForPing blocks until at least one ping has happened, or fails the
+// test. Deterministic alternative to sleeping for "some pings to occur".
+func (f *fakePinger) waitForPing(t *testing.T) {
+	t.Helper()
+	select {
+	case <-f.pinged:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for first ping")
+	}
+}
+
+func TestRun_PingsUntilContextCancelled(t *testing.T) {
+	p := newFakePinger()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var deadCalled atomic.Bool
+	done := make(chan struct{})
+	go func() {
+		Run(ctx, p, time.Millisecond, 50*time.Millisecond, func() { deadCalled.Store(true) })
+		close(done)
+	}()
+
+	// Deterministically wait for a real ping rather than sleeping.
+	p.waitForPing(t)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after context cancel")
+	}
+
+	if p.calls.Load() == 0 {
+		t.Fatal("expected at least one ping while running")
+	}
+	if deadCalled.Load() {
+		t.Fatal("onDead must not fire on a healthy connection")
+	}
+}
+
+func TestRun_FailedPingTriggersOnDead(t *testing.T) {
+	p := newFakePinger()
+	p.setErr(errors.New("pong timeout"))
+
+	var deadCalled atomic.Bool
+	done := make(chan struct{})
+	go func() {
+		Run(context.Background(), p, time.Millisecond, 50*time.Millisecond, func() { deadCalled.Store(true) })
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after a failed ping")
+	}
+	if !deadCalled.Load() {
+		t.Fatal("onDead should fire when a ping fails on a live context")
+	}
+}
+
+// TestRun_InFlightPingCancelledIsNotDead exercises the real race the
+// shutdown guard protects against: a ping is *in flight* (blocked waiting
+// for a pong) when another goroutine cancels the parent context. The ping
+// then fails with a context error — but because it's teardown, not a NAT
+// drop, onDead must NOT fire.
+func TestRun_InFlightPingCancelledIsNotDead(t *testing.T) {
+	p := newFakePinger()
+	p.block.Store(true) // Ping blocks until its ctx is cancelled
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var deadCalled atomic.Bool
+	done := make(chan struct{})
+	go func() {
+		// Generous per-ping timeout so the failure is caused by our
+		// cancel below, not by the timeout firing first.
+		Run(ctx, p, time.Millisecond, 5*time.Second, func() { deadCalled.Store(true) })
+		close(done)
+	}()
+
+	// Wait until a ping is actually in flight (blocked), then cancel
+	// concurrently so the cancellation interrupts the blocked Ping.
+	p.waitForPing(t)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after concurrent cancel of an in-flight ping")
+	}
+	if deadCalled.Load() {
+		t.Fatal("onDead must not fire when an in-flight ping is interrupted by shutdown")
+	}
+}

--- a/services/gmuxd/internal/wsproxy/wsproxy.go
+++ b/services/gmuxd/internal/wsproxy/wsproxy.go
@@ -65,8 +65,17 @@ func (p *Proxy) Handler() http.HandlerFunc {
 		}
 
 		// Accept browser WebSocket.
+		//
+		// CompressionContextTakeover: terminal output is highly
+		// repetitive, so permessage-deflate cuts the on-wire size of
+		// scrollback replay and full redraws substantially. Only the
+		// browser-facing hop is compressed; the backend hop is a local
+		// Unix socket where compression would be pure CPU cost. Safari
+		// does not implement permessage-deflate and silently falls back
+		// to uncompressed. See issue #242.
 		clientConn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
 			InsecureSkipVerify: true,
+			CompressionMode:    websocket.CompressionContextTakeover,
 		})
 		if err != nil {
 			log.Printf("wsproxy: accept: %v", err)

--- a/services/gmuxd/internal/wsproxy/wsproxy.go
+++ b/services/gmuxd/internal/wsproxy/wsproxy.go
@@ -17,6 +17,7 @@ import (
 	"net/http"
 	"sync"
 
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/wskeepalive"
 	"nhooyr.io/websocket"
 )
 
@@ -102,7 +103,7 @@ func (p *Proxy) Handler() http.HandlerFunc {
 		proxyCtx, proxyCancel := context.WithCancel(ctx)
 
 		var wg sync.WaitGroup
-		wg.Add(2)
+		wg.Add(3)
 
 		// Backend → Client (PTY output + terminal_resize events).
 		go func() {
@@ -116,6 +117,17 @@ func (p *Proxy) Handler() http.HandlerFunc {
 			defer wg.Done()
 			defer proxyCancel()
 			p.proxyClientToBackend(proxyCtx, clientConn, backendConn)
+		}()
+
+		// Keepalive on the browser-facing hop: keeps the cellular NAT
+		// flow warm and tears the proxy down promptly if the phone
+		// vanishes. Runs alongside the client read loop above, which is
+		// what delivers the pongs. See issue #241.
+		go func() {
+			defer wg.Done()
+			wskeepalive.Run(proxyCtx, clientConn,
+				wskeepalive.DefaultInterval, wskeepalive.DefaultTimeout,
+				proxyCancel)
 		}()
 
 		wg.Wait()


### PR DESCRIPTION
## Summary

Follow-up to #240, completing the mobile-data investigation. #240 fixed the **SSE** half (peer-snapshot amplification). This PR hardens the **PTY data plane** (browser ↔ gmuxd WebSocket) — the other half of the mobile-data burn and the prime suspect for the mobile-browser crashes.

Closes #241, closes #242. Two atomic commits.

## #241 — Keepalive ping on the browser-facing PTY WebSocket

The PTY WS carries no traffic while a terminal sits idle. Cellular carriers drop idle TCP flows behind their NAT after as little as 30–60s. Without a keepalive the browser only notices on its next write, reconnects, and the server re-ships the **full scrollback replay** (476 KB measured for one small session; multi-MB for large scrollback). On a flaky link this becomes a reconnect storm that burns data and can OOM the mobile browser.

- Adds a periodic ping (20s interval / 10s pong timeout) on the browser-facing hop of **both** proxy paths: `wsproxy.Handler` (local sessions) and `apiclient.pipeWS` (remote/peer sessions).
- New `internal/wskeepalive` package centralizes the interval/timeout/teardown semantics so the two paths can't drift, and makes the loop unit-testable.
- `websocket.Conn.Ping` requires a concurrent reader to receive the pong; both proxy paths always run a client read loop (asserted in a test that mirrors the real topology).
- No frontend change: browsers auto-reply to ping frames with pongs at the protocol level.

## #242 — permessage-deflate on the browser-facing PTY WebSocket

- Enables `CompressionContextTakeover` on the browser-facing accept in both proxy paths. Terminal replay/redraws are highly repetitive; context-takeover keeps the deflate window across frames for the best ratio.
- Only the browser-facing hop is compressed; the local Unix-socket backend hop and the hub→spoke hop don't benefit and would just burn CPU.
- **Caveat:** Safari does not implement permessage-deflate, so iOS/Safari clients fall back to plaintext (graceful). Compression helps Chrome/Firefox/Android/desktop; **#241 (keepalive) is the iOS-relevant half** of this workstream.

## Scope notes

- The runner-side `ptyserver.go` is intentionally untouched: its hop to gmuxd is a local Unix socket (no NAT, no wire).
- Compression + keepalive are independent (different concerns, independently revertable) → two commits.

## Testing

`go test ./services/gmuxd/...` passes (incl. `-race`). The existing `apiclient` ProxyWS tests (real WebSocket over httptest, large-snapshot + disconnect cases) exercise the combined keepalive path.

New tests:
- `wskeepalive.TestRun_PingsUntilContextCancelled`, `TestRun_FailedPingTriggersOnDead`, `TestRun_ShutdownRaceDoesNotReportDead`.

Verified end-to-end against the real `nhooyr.io/websocket` v1.8.17:
- A client offering `permessage-deflate` negotiates `Sec-WebSocket-Extensions: permessage-deflate`; a ~1 MB repetitive payload round-trips intact.
- Keepalive pings stay healthy with a concurrent reader (real proxy topology); `onDead` does not false-fire.

## Remaining follow-ups (tracked)
- #224 drop protocol-1 SSE/bulk-GET surface
- #243 SSE half-dead socket detection
- #244 peering reconnect backoff
