### PR TITLE
feat(env): source a fresh login environment when launching sessions

### DIFF
--- a/apps/website/src/content/docs/reference/environment.md
+++ b/apps/website/src/content/docs/reference/environment.md
@@ -84,3 +84,13 @@ These are available inside every session launched by `gmux`. Use them to detect 
 | `GMUX_RUNNER_VERSION` | Version of the gmux runner hosting the session. | `0.4.0` |
 
 See [Adapter Architecture](/develop/adapter-architecture) for how to use the child-to-runner API.
+
+## How a session's environment is sourced
+
+When the daemon starts, resumes, or **restarts** a session (the launch buttons in the UI), it sources a fresh environment from an interactive login shell — roughly `$SHELL -l -i` run in the session's working directory — and hands that to the session. This means edits to your `~/.zshrc` / `~/.bashrc` / `~/.profile` (and per-directory hooks like `direnv`) take effect on the next launch or restart, **without** needing a `gmuxd restart`. Clicking **Restart session** behaves like opening a fresh terminal.
+
+The captured environment is merged onto the daemon's own environment, so session/desktop variables that your dotfiles never set — `DISPLAY`, `SSH_AUTH_SOCK`, `XDG_RUNTIME_DIR`, and similar — are preserved. (One consequence of the merge: a variable you *remove* from your dotfiles may linger until the daemon itself is restarted.)
+
+If `$SHELL` is unset (typical for systemd- or Docker-managed daemons), this step is skipped and the session inherits the daemon's environment unchanged. The same fallback applies if the login shell fails or takes longer than 5 seconds. Sessions you start directly from a terminal (`gmux <cmd>`) always use that terminal's live environment.
+
+See [ADR 0006](https://github.com/gmuxapp/gmux/blob/main/docs/adr/0006-fresh-login-env-on-launch.md) for the full rationale.

--- a/cli/gmux/cmd/gmux/cli.go
+++ b/cli/gmux/cmd/gmux/cli.go
@@ -19,6 +19,7 @@ const (
 	modeKill               // terminate a session
 	modeSend               // inject input into a running session
 	modeWait               // block until session reaches idle / dies
+	modeDumpEnv            // (daemon-internal) write os.Environ() to fd 3 and exit
 	modeHelp               // print usage and exit
 )
 
@@ -48,6 +49,7 @@ type flags struct {
 	resumeID    string // --resume-id=<id>: reuse this session id
 	initialCols int    // --initial-cols=N: pre-size PTY
 	initialRows int    // --initial-rows=N: pre-size PTY
+	dumpEnv     bool   // --dump-env: write os.Environ() NUL-delimited to fd 3, then exit
 }
 
 // parseCLI parses argv (without program name) and decides which mode to
@@ -83,6 +85,7 @@ func parseCLI(args []string) (mode, *flags, []string, error) {
 	fs.StringVar(&f.resumeID, "resume-id", "", "(daemon-internal) reuse this session id instead of generating a fresh one")
 	fs.IntVar(&f.initialCols, "initial-cols", 0, "(daemon-internal) pre-size the PTY width")
 	fs.IntVar(&f.initialRows, "initial-rows", 0, "(daemon-internal) pre-size the PTY height")
+	fs.BoolVar(&f.dumpEnv, "dump-env", false, "(daemon-internal) write the environment to fd 3 and exit")
 
 	if err := fs.Parse(args); err != nil {
 		return modeHelp, nil, nil, err
@@ -91,6 +94,15 @@ func parseCLI(args []string) (mode, *flags, []string, error) {
 
 	if f.help {
 		return modeHelp, f, rest, nil
+	}
+
+	// --dump-env is the env-capture probe gmuxd runs inside a login
+	// shell (see ADR 0006). It short-circuits every other mode: no
+	// command, no management action, just dump and exit. Checked here,
+	// before management/run dispatch, so it can never be mistaken for a
+	// command to exec.
+	if f.dumpEnv {
+		return modeDumpEnv, f, nil, nil
 	}
 
 	// In management modes there is no wrapped command, only a bounded

--- a/cli/gmux/cmd/gmux/daemon.go
+++ b/cli/gmux/cmd/gmux/daemon.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/gmuxapp/gmux/packages/paths"
+	"github.com/gmuxapp/gmux/packages/sessionenv"
 )
 
 // ensureGmuxd checks if gmuxd is reachable and starts it if not.
@@ -96,6 +97,15 @@ func startGmuxd(gmuxdBin string, args []string) bool {
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
 	cmd.Stdout = nil
 	cmd.Stderr = logFile
+	// Strip gmux session-identity vars. ensureGmuxd often fires from a
+	// process already inside a session (e.g. a nested `gmux foo`), whose
+	// env carries GMUX_SESSION_ID/GMUX_SOCKET/GMUX_ADAPTER for *that*
+	// session. Without this the auto-started daemon would inherit them
+	// and stamp the stale identity onto every session it later launches.
+	// GMUX_SOCKET_DIR is preserved so the daemon scans the same socket
+	// directory as the runner that triggered the auto-start. See
+	// packages/sessionenv.
+	cmd.Env = sessionenv.Strip(os.Environ())
 	if err := cmd.Start(); err != nil {
 		log.Printf("warning: could not start gmuxd: %v", err)
 		if logFile != nil {

--- a/cli/gmux/cmd/gmux/dumpenv.go
+++ b/cli/gmux/cmd/gmux/dumpenv.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"io"
+	"log"
+	"os"
+)
+
+// dumpEnvFD is the file descriptor gmuxd hands to the `gmux --dump-env`
+// probe (via cmd.ExtraFiles[0], which the child sees as fd 3). Writing
+// the environment to a dedicated fd — rather than stdout — keeps the
+// payload clean of any banner/prompt noise a login shell's rc files
+// print to stdout/stderr. See ADR 0006.
+const dumpEnvFD = 3
+
+// dumpEnv writes os.Environ() to fd 3 as NUL-terminated entries, then
+// exits. It is the inner command of gmuxd's env-capture probe
+//
+//	$SHELL -l -i -c '<gmux> --dump-env'
+//
+// The login shell sources the user's dotfiles, so the environment we
+// observe here is the freshly-sourced one gmuxd wants to launch the
+// session with. NUL termination is used (not newlines) because exported
+// shell functions in bash carry literal newlines in their values.
+//
+// On any write failure we return non-zero; gmuxd treats a short/empty
+// read as a failed capture and falls back to its own environment, so a
+// partial dump never silently corrupts a session's env.
+func dumpEnv() int {
+	f := os.NewFile(dumpEnvFD, "gmux-dump-env")
+	if f == nil {
+		log.Printf("--dump-env: fd %d not available", dumpEnvFD)
+		return 1
+	}
+	defer f.Close()
+
+	if err := writeNulEnv(f, os.Environ()); err != nil {
+		log.Printf("--dump-env: write fd %d: %v", dumpEnvFD, err)
+		return 1
+	}
+	return 0
+}
+
+// writeNulEnv writes each env entry to w followed by a NUL byte. Split
+// out from dumpEnv so the wire format can be unit-tested without an
+// actual fd 3.
+func writeNulEnv(w io.Writer, env []string) error {
+	buf := make([]byte, 0, 8192)
+	for _, e := range env {
+		buf = append(buf, e...)
+		buf = append(buf, 0)
+	}
+	_, err := w.Write(buf)
+	return err
+}

--- a/cli/gmux/cmd/gmux/dumpenv_test.go
+++ b/cli/gmux/cmd/gmux/dumpenv_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestParseCLIDumpEnv(t *testing.T) {
+	m, f, rest, err := parseCLI([]string{"--dump-env"})
+	if err != nil {
+		t.Fatalf("parseCLI(--dump-env) error: %v", err)
+	}
+	if m != modeDumpEnv {
+		t.Errorf("mode = %v, want modeDumpEnv", m)
+	}
+	if !f.dumpEnv {
+		t.Errorf("f.dumpEnv = false, want true")
+	}
+	if len(rest) != 0 {
+		t.Errorf("rest = %v, want empty", rest)
+	}
+}
+
+func TestWriteNulEnv(t *testing.T) {
+	var buf bytes.Buffer
+	// A value with an embedded newline (as bash exports functions) must
+	// survive: that's the reason for NUL delimiting over newlines.
+	env := []string{"A=1", "B=two\nlines", "C="}
+	if err := writeNulEnv(&buf, env); err != nil {
+		t.Fatalf("writeNulEnv: %v", err)
+	}
+	want := "A=1\x00B=two\nlines\x00C=\x00"
+	if buf.String() != want {
+		t.Errorf("writeNulEnv = %q, want %q", buf.String(), want)
+	}
+}

--- a/cli/gmux/cmd/gmux/main.go
+++ b/cli/gmux/cmd/gmux/main.go
@@ -57,6 +57,8 @@ func main() {
 		os.Exit(cmdSend(rest[0], text, f.noSubmit, f.host))
 	case modeWait:
 		os.Exit(cmdWait(rest[0], f.waitTimeout))
+	case modeDumpEnv:
+		os.Exit(dumpEnv())
 	}
 }
 

--- a/docs/adr/0006-fresh-login-env-on-launch.md
+++ b/docs/adr/0006-fresh-login-env-on-launch.md
@@ -1,0 +1,289 @@
+# ADR 0006: Daemon-spawned sessions source a fresh login environment
+
+**Status:** Accepted
+**Date:** 2026-05-29
+**Related:** ADR 0003 (daemon-initiated resume / restart passes Session.ID), ADR 0005 (CLI routes through gmuxd)
+
+## Context
+
+Every managed session's environment is, today, a frozen copy of the
+daemon's environment captured once at daemon startup. The chain:
+
+1. `gmuxd` captures `os.Environ()` when its process starts. The
+   daemon is long-lived — typically auto-started by the first
+   `gmux` invocation (`ensureGmuxd`), inheriting that terminal's
+   env, and then never restarted for days.
+2. `launchGmux` forks every runner — for `/v1/launch`,
+   `/v1/resume`, **and `/v1/restart`** — with
+   `cmd.Env = sessionenv.Strip(os.Environ())`, i.e. the daemon's
+   frozen env minus session-identity vars (see the env-leak fix
+   that introduced `packages/sessionenv`).
+3. The runner builds its child's env via
+   `buildChildEnv(os.Environ(), ...)` — its own env, inherited from
+   the daemon — overlaying per-session `GMUX_*`, adapter, and
+   terminal-capability vars.
+
+The net effect: a session's environment is whatever the daemon's
+environment was at daemon-start time, possibly many days and many
+dotfile edits ago.
+
+This produces a confusing, recurring symptom:
+
+- A user edits `~/.zshrc` / `~/.bashrc` / `~/.profile` (adds a
+  `PATH` entry, a tool shim, an `export`), then **clicks "Restart
+  session"** expecting the session to pick it up. It doesn't. The
+  restarted runner inherits the same frozen daemon env.
+- Worse, the obvious remedy — `gmuxd restart` — only refreshes the
+  env if run from a *pristine* login shell. Run from a terminal
+  *inside* a gmux session (the common case when living in the
+  tool), it re-freezes the already-stale session env, because that
+  shell carries the daemon's frozen env to begin with.
+
+The root cause is that the env is *captured once and frozen*, with
+no path that re-sources the user's actual login environment. The
+"Restart session" button is the sharpest edge: its whole purpose is
+to give the user a clean slate, but it silently reuses the stale
+env.
+
+## Decision
+
+`launchGmux` **sources a fresh interactive-login shell environment
+at launch time** and hands that to the runner, instead of the
+daemon's frozen `os.Environ()`. This applies to all three
+daemon-initiated spawn paths (launch, resume, restart) since all go
+through `launchGmux`. Terminal-initiated paths (`gmux foo`,
+`--no-attach`, nested gmux via `spawnDetached`) are unchanged: they
+already re-exec from the user's *live* terminal env, which is fresh
+by definition.
+
+### Source: an interactive login shell
+
+```
+$SHELL -l -i -c '<gmuxBin> --dump-env'
+```
+
+- **Login (`-l`)** reads `~/.profile` / `~/.zprofile` /
+  `~/.bash_profile`.
+- **Interactive (`-i`)** reads `~/.zshrc` / `~/.bashrc` — where
+  most users actually put `PATH`, `export`s, and tool shims
+  (nvm, mise, pyenv, …). Login-only would still look stale to most
+  users.
+
+Together this matches "what a freshly-opened terminal sees", which
+is the mental model the Restart button should satisfy.
+
+### Extraction: self-exec dumper over fd 3
+
+A hidden `gmux --dump-env` mode writes `os.Environ()` as
+NUL-delimited entries to **file descriptor 3** — a pipe the daemon
+passes via `cmd.ExtraFiles[0]`. The shell's rc-file banners,
+MOTDs, prompts, and `direnv` notices all go to stdout/stderr and
+never touch fd 3, so there is nothing to frame, mark, or parse out
+of noise.
+
+```go
+// daemon side (sketch)
+pr, pw, _ := os.Pipe()
+cmd := exec.CommandContext(ctx, shell, "-l", "-i", "-c", shellQuote(gmuxBin)+" --dump-env")
+cmd.Dir = cwd                 // session launch cwd (see below)
+cmd.Stdin = devNull
+cmd.Stdout, cmd.Stderr = nil, nil
+cmd.ExtraFiles = []*os.File{pw}            // → fd 3 in the child
+cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+// start, close parent's pw copy, read pr to EOF, parse NUL, wait
+```
+
+```go
+// gmux --dump-env (sketch)
+f := os.NewFile(3, "env")
+for _, e := range os.Environ() {
+    f.WriteString(e)
+    f.Write([]byte{0})
+}
+f.Close()
+```
+
+This reuses the established `spawnDetached` handshake-fd pattern
+(daemon passes a pipe as `cmd.ExtraFiles[0]`/fd 3). `--dump-env` is
+a daemon-internal flag, matching the `--resume-id` /
+`--initial-cols` convention from ADR 0003 — greppable in `ps`,
+tagged daemon-internal in `--help`, and dispatched before the run
+path so it is never mistaken for a command to exec.
+
+The one assumption is that fd 3 survives through
+`$SHELL -l -i -c '<gmux> --dump-env'`. This is standard POSIX
+behavior (the shell execs the command with inherited fds ≥ 3). If
+it ever doesn't, the read returns empty and we hit the fallback.
+
+### Merge, not from-scratch
+
+The capture shell **inherits the daemon's environment** as its
+starting point (no `env -i`), then layers rc-file changes on top.
+The result is `daemon-env ∪ rc-file-changes`:
+
+- Session/PAM-provided vars the dotfiles never set survive —
+  `DISPLAY`, `SSH_AUTH_SOCK`, `XDG_RUNTIME_DIR`,
+  `DBUS_SESSION_BUS_ADDRESS`. A from-scratch capture would lose
+  these and break GUI apps, ssh-agent, and the runtime socket dir.
+- Fresh `PATH` / exports / tool shims from `.zshrc` apply on top.
+
+Accepted tradeoff: a variable *removed* from dotfiles still lingers
+(rc files add/override but don't un-set what they no longer
+mention). This matches how a freshly-opened terminal behaves (it
+too inherits the session env) and is low-impact compared to losing
+the session vars.
+
+This also means **zero protocol change**: `launchGmux` sets
+`cmd.Env = sessionenv.Strip(captureLoginEnv(cwd))`; the runner's
+`os.Environ()` becomes that, and `buildChildEnv` still overlays the
+per-session `GMUX_*` / adapter / terminal vars. `sessionenv.Strip`
+is still applied so any session-identity vars that leaked into the
+captured env are dropped, while `GMUX_SOCKET_DIR` (config) is
+preserved.
+
+### Working directory: the session's launch cwd
+
+The capture runs in the session's launch cwd, so per-directory env
+hooks (`direnv`/`.envrc`, `mise`) that the user has intentionally
+set up are honored. Users who have such hooks accept the extra
+startup cost; `direnv`'s "blocked" notices land on stderr and are
+discarded.
+
+### Robustness: synchronous, bounded, fail-safe
+
+- **Synchronous** inside `launchGmux` / the HTTP handler. Launch,
+  resume, and restart are deliberate, infrequent user actions;
+  the `/v1/restart` handler already blocks up to 5s waiting for the
+  old runner to die, so multi-second handler latency is not new.
+- **5s hard timeout**, injectable for tests. Generous enough that
+  legitimately-slow shells (nvm/mise) complete rather than falsely
+  timing out into stale env.
+- **Process-group kill** on timeout: the shell runs in its own
+  process group (`Setpgid`), and expiry sends `SIGKILL` to the
+  group (`syscall.Kill(-pid, SIGKILL)`) so rc-spawned children
+  cannot be orphaned or hold the read open. Same pattern as
+  `ptyserver.handleKill`.
+- stdin ← `/dev/null`, stderr discarded.
+
+### Fallback: degrade to today's behavior
+
+Any failure falls back to `sessionenv.Strip(os.Environ())` — the
+daemon's current env, i.e. exactly today's behavior — with a
+warning logged. Two invariants:
+
+1. **Never produce a worse env than today.** A failed refresh must
+   never break a launch or strip vars the session would otherwise
+   have.
+2. **Never block forever.** The timeout + process-group kill bound
+   the wait.
+
+Trigger conditions for fallback: `$SHELL` unset (typical for
+systemd/Docker daemons, where a login shell is meaningless — we
+skip rather than guess `/bin/sh -l -i`); `gmuxBin` unresolved;
+shell exits non-zero; empty/short read; timeout.
+
+### Always-on, gated by `$SHELL`
+
+No config toggle. `$SHELL`-unset already skips capture, covering
+headless deployments; for interactive users this is the desired
+default. A toggle is cheap to add later if a real need surfaces;
+pre-adding it is speculative config surface.
+
+## Consequences
+
+### Positive
+
+- **Restart actually refreshes the environment.** The button's
+  purpose — a clean slate — is satisfied: a restarted session sees
+  current dotfiles, like a freshly-opened terminal.
+- **No daemon restart required** to pick up env changes for new or
+  restarted sessions.
+- **No new persistent state, no protocol change.** The fresh env
+  threads through the existing `cmd.Env` → runner `os.Environ()` →
+  `buildChildEnv` chain.
+- **Headless deployments unaffected.** `$SHELL`-unset skips capture
+  and inherits the daemon env unchanged, as before.
+
+### Negative
+
+- **Per-launch shell-startup cost.** Every daemon-initiated launch
+  now forks an interactive-login shell (typically 100–500ms, up to
+  1–2s for heavy rc setups). Accepted: these are infrequent,
+  deliberate actions, and caching was explicitly rejected as
+  reintroducing the staleness class of bug.
+- **Removed dotfile vars linger.** The merge model keeps the
+  daemon's stale copy of a var the user deleted from their
+  dotfiles. Rare; matches freshly-opened-terminal semantics.
+- **Interactive rc files run on launch.** Anything a user's
+  `.zshrc` does unconditionally (slow plugin managers, network
+  calls) runs per launch and counts against the 5s budget; on
+  timeout the launch falls back to stale env.
+- **`exec` in rc bypasses the dumper.** A `.zshrc` that
+  `exec`s another program replaces the shell before
+  `gmux --dump-env` runs; fd 3 never gets written and we fall
+  back. Acceptable edge case.
+
+### Breaking
+
+None. Behavior changes only for daemon-spawned sessions, and only
+to give them a fresher (superset-on-merge) environment. Headless
+daemons (`$SHELL` unset) are byte-for-byte unchanged. No schema,
+HTTP, or SSE surface changes.
+
+## Alternatives considered
+
+### A. Status quo: freeze the daemon env at startup
+
+Rejected — it is the bug. The env is captured once and never
+re-sourced; the Restart button and `gmuxd restart`-from-inside-a-
+session both fail to refresh it.
+
+### B. Cache the captured env (memoize, invalidate on some signal)
+
+Rejected. Caching reintroduces exactly the staleness class we are
+fixing, plus an invalidation policy to get wrong. Launch/resume/
+restart are infrequent enough that a fresh capture each time is
+affordable, and "fresh every time" is the only model with no
+hidden drift.
+
+### C. Login-only shell (`-l`, no `-i`)
+
+Rejected as the primary mode. It misses `~/.zshrc` / `~/.bashrc`,
+where most users' env actually lives, so it would still look stale
+to most users.
+
+### D. From-scratch capture (`env -i $SHELL -l -i`)
+
+Rejected. Truly fresh, but loses session/PAM vars
+(`DISPLAY`, `SSH_AUTH_SOCK`, `XDG_RUNTIME_DIR`, …), breaking GUI
+apps, ssh-agent, and the runtime socket dir. Merge keeps these
+while still applying dotfile changes.
+
+### E. Parse `env` output on stdout with a random marker
+
+Rejected in favor of the fd-3 dumper. Stdout is shared with
+rc-file noise, so it needs marker framing; and portable
+NUL-delimited dumping is awkward (`env -0` is GNU-only, and bash
+exports *functions* as newline-containing env vars, so
+newline-delimited parsing is unsafe). The fd-3 dumper sidesteps
+both: a private channel, our own NUL format, no marker.
+
+### F. A gmux-specific env file (`~/.config/gmux/env`)
+
+Rejected as the primary mechanism. It is a second place to manage
+env and would not reflect ordinary dotfile edits — the exact thing
+users expect Restart to honor. Could be added later as an
+*additive* layer for power users.
+
+### G. Config toggle / opt-out from day one
+
+Deferred. `$SHELL`-unset already covers headless deployments, and
+the behavior is the right default for interactive users. A toggle
+(or a `GMUX_NO_REFRESH_ENV` escape hatch) is cheap to add if a real
+need surfaces; pre-adding it is speculative surface.
+
+### H. Capture in a neutral cwd ($HOME / daemon cwd)
+
+Rejected. Capturing in the session's launch cwd honors intentional
+per-directory hooks (`direnv`/`mise`); a neutral cwd would ignore
+them. Users with such hooks accept the cost.

--- a/go.work
+++ b/go.work
@@ -5,6 +5,7 @@ use (
 	./packages/adapter
 	./packages/paths
 	./packages/scrollback
+	./packages/sessionenv
 	./packages/workspace
 	./services/gmuxd
 	./tests/e2e

--- a/packages/sessionenv/go.mod
+++ b/packages/sessionenv/go.mod
@@ -1,0 +1,3 @@
+module github.com/gmuxapp/gmux/packages/sessionenv
+
+go 1.26

--- a/packages/sessionenv/sessionenv.go
+++ b/packages/sessionenv/sessionenv.go
@@ -1,0 +1,54 @@
+// Package sessionenv filters gmux session-identity environment
+// variables out of a process environment before it is handed to a
+// child that must not inherit the parent session's identity.
+//
+// Every gmux session is stamped with a set of GMUX_* variables that
+// describe *that specific session* — its socket, id, adapter, runner
+// version (see the runner's common-env block in cli/gmux). When a
+// process that already lives inside a session spawns the daemon — or
+// when the daemon launches/restarts a runner — those identity vars
+// must be stripped, or the child would masquerade as the parent
+// session: a daemon auto-started from inside a session would otherwise
+// carry GMUX_SESSION_ID/GMUX_SOCKET/GMUX_ADAPTER and stamp them onto
+// every future session it launches. See the investigation in the
+// "stale/leaked session env" work.
+package sessionenv
+
+import "strings"
+
+// preserve lists GMUX_-prefixed variables that are *configuration*,
+// not session identity, and must survive Strip. GMUX_SOCKET_DIR tells
+// both the daemon (discovery scan) and the runner (where to bind its
+// socket) which directory session sockets live in; stripping it would
+// make an auto-started daemon scan a different directory than the
+// runner that triggered the auto-start, so they could never find each
+// other.
+var preserve = map[string]bool{
+	"GMUX_SOCKET_DIR": true,
+}
+
+// Strip returns env with gmux session-identity variables removed: the
+// bare GMUX marker and every GMUX_* variable except the configuration
+// vars in preserve. GMUXD_* daemon config is untouched (it does not
+// match the GMUX_ prefix — the character after GMUX is 'D', not '_').
+//
+// Used by every site that spawns a process which must not inherit the
+// caller's session identity: the daemon launching/restarting runners,
+// the daemon self-restart, and gmux auto-starting the daemon.
+func Strip(env []string) []string {
+	out := make([]string, 0, len(env))
+	for _, e := range env {
+		key := e
+		if i := strings.IndexByte(e, '='); i >= 0 {
+			key = e[:i]
+		}
+		if key == "GMUX" {
+			continue
+		}
+		if strings.HasPrefix(key, "GMUX_") && !preserve[key] {
+			continue
+		}
+		out = append(out, e)
+	}
+	return out
+}

--- a/packages/sessionenv/sessionenv_test.go
+++ b/packages/sessionenv/sessionenv_test.go
@@ -1,0 +1,54 @@
+package sessionenv
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestStrip(t *testing.T) {
+	in := []string{
+		"PATH=/usr/bin",
+		"GMUX=1",
+		"GMUX_SOCKET=/tmp/gmux-sessions/sess-abc.sock",
+		"GMUX_SESSION_ID=sess-abc",
+		"GMUX_ADAPTER=pi",
+		"GMUX_RUNNER_VERSION=dev",
+		"GMUX_RESUME_ID=sess-abc",
+		"GMUX_HANDSHAKE_FD=3",
+		"GMUX_SOCKET_DIR=/tmp/custom",
+		"GMUXD_LISTEN=0.0.0.0",
+		"GMUXD_TOKEN=secret",
+		"HOME=/home/me",
+	}
+	want := []string{
+		"PATH=/usr/bin",
+		"GMUX_SOCKET_DIR=/tmp/custom",
+		"GMUXD_LISTEN=0.0.0.0",
+		"GMUXD_TOKEN=secret",
+		"HOME=/home/me",
+	}
+	got := Strip(in)
+	if !slices.Equal(got, want) {
+		t.Errorf("Strip()\n got: %v\nwant: %v", got, want)
+	}
+}
+
+// A bare GMUX with no '=' (malformed but possible) is still treated as
+// the identity marker and stripped.
+func TestStripBareKeyNoValue(t *testing.T) {
+	got := Strip([]string{"GMUX", "GMUX_SOCKET", "KEEP=1"})
+	want := []string{"KEEP=1"}
+	if !slices.Equal(got, want) {
+		t.Errorf("Strip()\n got: %v\nwant: %v", got, want)
+	}
+}
+
+// GMUXD_* must never be mistaken for a GMUX_ session var: the prefix
+// check keys on "GMUX_" and "GMUXD_..." does not match it.
+func TestStripPreservesDaemonConfig(t *testing.T) {
+	got := Strip([]string{"GMUXD_DEV_PROXY=http://x", "GMUX_SESSION_ID=s"})
+	want := []string{"GMUXD_DEV_PROXY=http://x"}
+	if !slices.Equal(got, want) {
+		t.Errorf("Strip()\n got: %v\nwant: %v", got, want)
+	}
+}

--- a/services/gmuxd/cmd/gmuxd/loginenv.go
+++ b/services/gmuxd/cmd/gmuxd/loginenv.go
@@ -1,0 +1,197 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+// loginEnvTimeout bounds how long captureLoginEnv waits for the probe
+// shell to source the user's dotfiles and dump its environment. Heavy
+// rc setups (nvm, mise, conda, prompt frameworks) can take a second or
+// two; 5s is generous enough that a slow-but-valid shell completes
+// rather than falsely timing out into the stale-env fallback. A hung
+// rc file is bounded by the process-group kill on expiry.
+const loginEnvTimeout = 5 * time.Second
+
+// captureLoginEnv returns a freshly-sourced login environment for a
+// session about to be launched in cwd, by running
+//
+//	$SHELL -l -i -c '<gmuxBin> --dump-env'
+//
+// in that cwd and reading the NUL-delimited environment the probe
+// writes to fd 3. The interactive login shell sources the user's
+// profile *and* rc files (~/.zshrc / ~/.bashrc), so dotfile changes —
+// and the Restart button — take effect without a daemon restart. The
+// probe shell inherits the daemon's environment as its base, so this is
+// a merge (daemon env ∪ rc-file changes), preserving session/PAM vars
+// like DISPLAY and SSH_AUTH_SOCK. See ADR 0006.
+//
+// On any failure (shell unset, probe binary unresolved, non-zero exit,
+// empty read, timeout) it falls back to os.Environ() and logs a
+// warning, so a failed refresh never produces a worse environment than
+// today nor blocks a launch indefinitely. Callers still run the result
+// through sessionenv.Strip.
+func captureLoginEnv(gmuxBin, cwd string) []string {
+	return captureLoginEnvTimeout(gmuxBin, cwd, loginEnvTimeout)
+}
+
+// captureLoginEnvTimeout is captureLoginEnv with an injectable timeout
+// for tests.
+func captureLoginEnvTimeout(gmuxBin, cwd string, timeout time.Duration) []string {
+	shell := os.Getenv("SHELL")
+	if shell == "" {
+		// No login shell to source (typical for systemd/Docker
+		// daemons). Skip rather than guess /bin/sh -l -i, which could
+		// hang or surprise. Inherit the daemon env unchanged — exactly
+		// today's behavior.
+		return os.Environ()
+	}
+	if gmuxBin == "" {
+		log.Printf("loginenv: gmux binary unresolved; using daemon env")
+		return os.Environ()
+	}
+
+	env, err := runLoginEnvProbe(shell, gmuxBin, cwd, timeout)
+	if err != nil {
+		log.Printf("loginenv: capture via %s failed (%v); using daemon env", shell, err)
+		return os.Environ()
+	}
+	if len(env) == 0 {
+		log.Printf("loginenv: capture via %s produced no variables; using daemon env", shell)
+		return os.Environ()
+	}
+	return env
+}
+
+// runLoginEnvProbe runs the probe shell and returns the parsed
+// environment, or an error. The probe's stdout/stderr are discarded
+// (rc-file banners land there); only fd 3 carries the payload.
+func runLoginEnvProbe(shell, gmuxBin, cwd string, timeout time.Duration) ([]string, error) {
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		return nil, fmt.Errorf("pipe: %w", err)
+	}
+	defer pr.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	// -l (login) sources the profile files; -i (interactive) sources
+	// ~/.zshrc / ~/.bashrc, where most users' PATH/exports/tool-shims
+	// live. shellQuote guards a gmuxBin path containing spaces.
+	cmd := exec.CommandContext(ctx, shell, "-l", "-i", "-c", shellQuote(gmuxBin)+" --dump-env")
+	cmd.Dir = cwd
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = nil, nil, nil
+	cmd.ExtraFiles = []*os.File{pw} // child sees this as fd 3
+	// Own process group so a timeout kill reaches rc-spawned children
+	// too, and so a child holding the pipe open can't wedge the read.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	// On ctx timeout, kill the whole process group (negative pid), not
+	// just the direct shell. An rc-spawned descendant (e.g. a lingering
+	// `sleep`) would otherwise keep the fd-3 pipe open and wedge the
+	// read below forever. Matches ptyserver.handleKill's group signal.
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	}
+
+	if err := cmd.Start(); err != nil {
+		pw.Close()
+		return nil, fmt.Errorf("start %s: %w", shell, err)
+	}
+	// The child owns the write end now; close the parent's copy so the
+	// read below sees EOF once the child exits.
+	pw.Close()
+
+	// Read concurrently with Wait so a child that writes a lot can't
+	// deadlock against a full pipe while we block in Wait.
+	type readResult struct {
+		data []byte
+		err  error
+	}
+	readCh := make(chan readResult, 1)
+	go func() {
+		data, err := io.ReadAll(pr)
+		readCh <- readResult{data, err}
+	}()
+
+	waitErr := cmd.Wait()
+
+	// Wait for the reader, but don't trust it to finish just because the
+	// shell exited. A process the rc files spawned in the background
+	// (e.g. a daemon started with `&`) can inherit fd 3 and keep the
+	// pipe's write end open after the shell is gone, so io.ReadAll never
+	// sees EOF. By this point cmd.Wait has returned, so Go's context
+	// watcher has stopped and cmd.Cancel will not fire again — we must
+	// bail out ourselves: close the read end to unblock io.ReadAll and
+	// signal the lingering process group (still reachable by pgid while
+	// a member is alive).
+	var rr readResult
+	select {
+	case rr = <-readCh:
+	case <-ctx.Done():
+		pr.Close()
+		if cmd.Process != nil {
+			_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		}
+		<-readCh // io.ReadAll returns now that pr is closed; don't leak it
+		return nil, fmt.Errorf("timed out after %s", timeout)
+	}
+
+	if ctx.Err() == context.DeadlineExceeded {
+		return nil, fmt.Errorf("timed out after %s", timeout)
+	}
+	if rr.err != nil {
+		return nil, fmt.Errorf("read fd 3: %w", rr.err)
+	}
+	if waitErr != nil {
+		return nil, fmt.Errorf("%s exited: %w", shell, waitErr)
+	}
+	return parseNulEnv(rr.data), nil
+}
+
+// parseNulEnv splits a NUL-delimited environment dump into KEY=VALUE
+// entries. A trailing NUL (the dumper terminates every entry) yields no
+// empty final element; any empty segments are skipped defensively.
+func parseNulEnv(data []byte) []string {
+	if len(data) == 0 {
+		return nil
+	}
+	parts := bytes.Split(data, []byte{0})
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if len(p) == 0 {
+			continue
+		}
+		out = append(out, string(p))
+	}
+	return out
+}
+
+// shellQuote wraps s in single quotes for safe inclusion in a `sh -c`
+// command string, escaping any embedded single quotes. Sufficient for
+// the one value we interpolate (the resolved gmux binary path).
+func shellQuote(s string) string {
+	return "'" + escapeSingleQuotes(s) + "'"
+}
+
+func escapeSingleQuotes(s string) string {
+	out := make([]byte, 0, len(s)+2)
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\'' {
+			out = append(out, '\'', '\\', '\'', '\'')
+			continue
+		}
+		out = append(out, s[i])
+	}
+	return string(out)
+}

--- a/services/gmuxd/cmd/gmuxd/loginenv_test.go
+++ b/services/gmuxd/cmd/gmuxd/loginenv_test.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+	"time"
+)
+
+// writeFakeShell writes an executable script to a temp dir and returns
+// its path. The script stands in for $SHELL: gmuxd invokes it as
+// `shell -l -i -c '<gmuxBin> --dump-env'`, but the fake ignores its
+// args and runs body, which can write the env payload to fd 3 (>&3),
+// sleep, or exit non-zero to exercise each path.
+func writeFakeShell(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "fakeshell")
+	script := "#!/bin/sh\n" + body + "\n"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake shell: %v", err)
+	}
+	return path
+}
+
+func TestCaptureLoginEnv_FakeShellPayload(t *testing.T) {
+	shell := writeFakeShell(t, `printf 'A=1\0B=two\nlines\0C=\0' >&3`)
+	t.Setenv("SHELL", shell)
+
+	got := captureLoginEnvTimeout("/bin/true", t.TempDir(), 5*time.Second)
+	want := []string{"A=1", "B=two\nlines", "C="}
+	if !slices.Equal(got, want) {
+		t.Errorf("captureLoginEnv = %v, want %v", got, want)
+	}
+}
+
+// Banner noise on stdout/stderr must not corrupt the payload — only
+// fd 3 is read.
+func TestCaptureLoginEnv_IgnoresStdoutNoise(t *testing.T) {
+	shell := writeFakeShell(t, "echo banner-on-stdout\necho moo >&2\nprintf 'X=9\\0' >&3")
+	t.Setenv("SHELL", shell)
+
+	got := captureLoginEnvTimeout("/bin/true", t.TempDir(), 5*time.Second)
+	if !slices.Equal(got, []string{"X=9"}) {
+		t.Errorf("captureLoginEnv = %v, want [X=9]", got)
+	}
+}
+
+func TestCaptureLoginEnv_ShellUnset(t *testing.T) {
+	t.Setenv("SHELL", "")
+	got := captureLoginEnvTimeout("/bin/true", t.TempDir(), 5*time.Second)
+	if !slices.Equal(got, os.Environ()) {
+		t.Errorf("SHELL-unset should fall back to os.Environ()")
+	}
+}
+
+func TestCaptureLoginEnv_NoBinary(t *testing.T) {
+	t.Setenv("SHELL", writeFakeShell(t, "printf 'A=1\\0' >&3"))
+	got := captureLoginEnvTimeout("", t.TempDir(), 5*time.Second)
+	if !slices.Equal(got, os.Environ()) {
+		t.Errorf("empty gmuxBin should fall back to os.Environ()")
+	}
+}
+
+func TestCaptureLoginEnv_NonZeroExit(t *testing.T) {
+	// Exits non-zero without writing fd 3.
+	shell := writeFakeShell(t, "exit 7")
+	t.Setenv("SHELL", shell)
+	got := captureLoginEnvTimeout("/bin/true", t.TempDir(), 5*time.Second)
+	if !slices.Equal(got, os.Environ()) {
+		t.Errorf("non-zero exit should fall back to os.Environ()")
+	}
+}
+
+func TestCaptureLoginEnv_EmptyDump(t *testing.T) {
+	// Exits 0 but writes nothing — treated as a failed capture.
+	shell := writeFakeShell(t, "true")
+	t.Setenv("SHELL", shell)
+	got := captureLoginEnvTimeout("/bin/true", t.TempDir(), 5*time.Second)
+	if !slices.Equal(got, os.Environ()) {
+		t.Errorf("empty dump should fall back to os.Environ()")
+	}
+}
+
+func TestCaptureLoginEnv_Timeout(t *testing.T) {
+	// Holds fd 3 open and sleeps past the timeout. The capture must
+	// return promptly via fallback rather than blocking for the sleep.
+	shell := writeFakeShell(t, "sleep 30")
+	t.Setenv("SHELL", shell)
+
+	start := time.Now()
+	got := captureLoginEnvTimeout("/bin/true", t.TempDir(), 200*time.Millisecond)
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Errorf("capture took %s, expected to abort near the 200ms timeout", elapsed)
+	}
+	if !slices.Equal(got, os.Environ()) {
+		t.Errorf("timeout should fall back to os.Environ()")
+	}
+}
+
+// A process the rc files spawn in the background can inherit fd 3 and
+// keep the pipe open after the shell exits, so io.ReadAll never sees
+// EOF. The capture must still return near the timeout (via fallback)
+// rather than blocking on the lingering background process.
+func TestCaptureLoginEnv_BackgroundHoldsFD3(t *testing.T) {
+	shell := writeFakeShell(t, "printf 'A=1\\0' >&3\nsleep 30 &\nexit 0")
+	t.Setenv("SHELL", shell)
+
+	start := time.Now()
+	got := captureLoginEnvTimeout("/bin/true", t.TempDir(), 300*time.Millisecond)
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Errorf("capture took %s; expected to abort near the 300ms timeout", elapsed)
+	}
+	if !slices.Equal(got, os.Environ()) {
+		t.Errorf("background-held fd 3 should fall back to os.Environ()")
+	}
+}
+
+func TestParseNulEnv(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"empty", "", nil},
+		{"trailing nul", "A=1\x00B=2\x00", []string{"A=1", "B=2"}},
+		{"no trailing nul", "A=1\x00B=2", []string{"A=1", "B=2"}},
+		{"skips empty segments", "A=1\x00\x00B=2\x00", []string{"A=1", "B=2"}},
+		{"newline value", "A=x\ny\x00", []string{"A=x\ny"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := parseNulEnv([]byte(c.in))
+			if !slices.Equal(got, c.want) {
+				t.Errorf("parseNulEnv(%q) = %v, want %v", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func TestShellQuote(t *testing.T) {
+	cases := map[string]string{
+		"/usr/bin/gmux":          "'/usr/bin/gmux'",
+		"/path with spaces/gmux": "'/path with spaces/gmux'",
+		"/weird/o'brien/gmux":    `'/weird/o'\''brien/gmux'`,
+	}
+	for in, want := range cases {
+		if got := shellQuote(in); got != want {
+			t.Errorf("shellQuote(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -152,9 +152,8 @@ func launcherStates(ls []adapter.Launcher) []string {
 	return states
 }
 
-// launchGmux starts a detached gmux process with the given command and cwd.
-// Returns the PID on success.
 // launchGmux forks a gmux runner with the given command and cwd.
+// Returns the PID on success.
 //
 // resumeID, when non-empty, is passed via --resume-id so the
 // runner uses the daemon-supplied id instead of generating a fresh
@@ -184,12 +183,15 @@ func launchGmux(gmuxBin string, command []string, cwd, resumeID string, initialC
 	cmd.Stderr = nil
 	cmd.Stdin = nil
 
-	// Strip gmux session-identity vars so child processes don't inherit
-	// the parent session's identity. Without this, a gmuxd started
-	// inside a gmux session (e.g. dogfooding during dev) would leak
-	// GMUX_ADAPTER, GMUX_SOCKET, GMUX_SESSION_ID, etc. into every
-	// launched session. See packages/sessionenv.
-	cmd.Env = sessionenv.Strip(os.Environ())
+	// Source a fresh interactive-login environment for the session
+	// (see ADR 0006), so dotfile changes and the Restart button take
+	// effect without a daemon restart. Falls back to the daemon's own
+	// env when no login shell is available (headless daemons) or the
+	// probe fails. Strip gmux session-identity vars either way so child
+	// processes don't inherit a parent session's identity (a leaked
+	// GMUX_SESSION_ID/GMUX_SOCKET/GMUX_ADAPTER would otherwise be
+	// stamped onto every launched session). See packages/sessionenv.
+	cmd.Env = sessionenv.Strip(captureLoginEnv(gmuxBin, cwd))
 
 	if err := cmd.Start(); err != nil {
 		return 0, err

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gmuxapp/gmux/packages/adapter"
 	"github.com/gmuxapp/gmux/packages/adapter/adapters"
 	"github.com/gmuxapp/gmux/packages/paths"
+	"github.com/gmuxapp/gmux/packages/sessionenv"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/authtoken"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/binhash"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/clipfile"
@@ -153,17 +154,6 @@ func launcherStates(ls []adapter.Launcher) []string {
 
 // launchGmux starts a detached gmux process with the given command and cwd.
 // Returns the PID on success.
-// filterEnvPrefix returns env with any variable starting with prefix removed.
-func filterEnvPrefix(env []string, prefix string) []string {
-	result := make([]string, 0, len(env))
-	for _, e := range env {
-		if !strings.HasPrefix(e, prefix) {
-			result = append(result, e)
-		}
-	}
-	return result
-}
-
 // launchGmux forks a gmux runner with the given command and cwd.
 //
 // resumeID, when non-empty, is passed via --resume-id so the
@@ -194,12 +184,12 @@ func launchGmux(gmuxBin string, command []string, cwd, resumeID string, initialC
 	cmd.Stderr = nil
 	cmd.Stdin = nil
 
-	// Strip all GMUX_* session vars so child processes don't inherit
+	// Strip gmux session-identity vars so child processes don't inherit
 	// the parent session's identity. Without this, a gmuxd started
 	// inside a gmux session (e.g. dogfooding during dev) would leak
 	// GMUX_ADAPTER, GMUX_SOCKET, GMUX_SESSION_ID, etc. into every
-	// launched session.
-	cmd.Env = filterEnvPrefix(os.Environ(), "GMUX_")
+	// launched session. See packages/sessionenv.
+	cmd.Env = sessionenv.Strip(os.Environ())
 
 	if err := cmd.Start(); err != nil {
 		return 0, err
@@ -386,8 +376,9 @@ func startBackground(stdout, stderr io.Writer) int {
 	cmd.Stdout = nil
 	cmd.Stderr = logFile
 	cmd.Stdin = nil
-	// Strip GMUX_* env vars so the daemon doesn't inherit session identity.
-	cmd.Env = filterEnvPrefix(os.Environ(), "GMUX_")
+	// Strip gmux session-identity vars so the daemon doesn't inherit
+	// session identity. See packages/sessionenv.
+	cmd.Env = sessionenv.Strip(os.Environ())
 
 	if err := cmd.Start(); err != nil {
 		logFile.Close()

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -72,7 +72,7 @@ func TestEndToEnd(t *testing.T) {
 	gmuxdCtx, gmuxdCancel := context.WithCancel(context.Background())
 	defer gmuxdCancel()
 
-	gmuxdCmd := exec.CommandContext(gmuxdCtx, gmuxdBin)
+	gmuxdCmd := exec.CommandContext(gmuxdCtx, gmuxdBin, "run")
 	gmuxdCmd.Env = append(os.Environ(),
 		fmt.Sprintf("XDG_CONFIG_HOME=%s", configDir),
 		fmt.Sprintf("XDG_STATE_HOME=%s", stateDir),

--- a/tests/e2e/loginenv_test.go
+++ b/tests/e2e/loginenv_test.go
@@ -1,0 +1,145 @@
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestFreshLoginEnvOnLaunch proves the ADR-0006 behavior end-to-end:
+// the daemon sources a fresh login environment when it launches and
+// restarts sessions, so an edit to the user's "dotfile" is reflected on
+// the next launch/restart without restarting the daemon.
+func TestFreshLoginEnvOnLaunch(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode")
+	}
+
+	repoRoot := findRepoRoot(t)
+
+	// Build gmuxd and gmux into the SAME directory so the daemon's
+	// resolveGmux() finds gmux as a sibling and can run the
+	// `gmux --dump-env` probe.
+	binDir := t.TempDir()
+	buildInto(t, repoRoot, "services/gmuxd/cmd/gmuxd", filepath.Join(binDir, "gmuxd"))
+	buildInto(t, repoRoot, "cli/gmux/cmd/gmux", filepath.Join(binDir, "gmux"))
+	gmuxdBin := filepath.Join(binDir, "gmuxd")
+
+	socketDir := t.TempDir()
+	stateDir := t.TempDir()
+	configDir := t.TempDir()
+	cfgDir := filepath.Join(configDir, "gmux")
+	os.MkdirAll(cfgDir, 0o755)
+	port := freePort(t)
+	os.WriteFile(filepath.Join(cfgDir, "host.toml"),
+		[]byte(fmt.Sprintf("port = %d\n", port)), 0o644)
+	gmuxdSock := filepath.Join(stateDir, "gmux", "gmuxd.sock")
+
+	// Fake $SHELL: sources a sentinel "dotfile", then runs the -c
+	// command (gmux --dump-env). Editing the dotfile between launches
+	// simulates the user editing ~/.zshrc.
+	dotfile := filepath.Join(t.TempDir(), "dotfile")
+	os.WriteFile(dotfile, []byte("export SENTINEL=before-edit\n"), 0o644)
+	fakeShell := filepath.Join(t.TempDir(), "fakeshell")
+	os.WriteFile(fakeShell, []byte(
+		"#!/bin/sh\n. "+dotfile+" 2>/dev/null\nshift 3\nexec sh -c \"$1\"\n"), 0o755)
+
+	outFile := filepath.Join(t.TempDir(), "sentinel.out")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	gmuxd := exec.CommandContext(ctx, gmuxdBin, "run")
+	home := t.TempDir()
+	gmuxd.Env = append(os.Environ(),
+		"HOME="+home,
+		"XDG_CONFIG_HOME="+configDir,
+		"XDG_STATE_HOME="+stateDir,
+		"GMUX_SOCKET_DIR="+socketDir,
+		"SHELL="+fakeShell,
+	)
+	gmuxd.Stdout, gmuxd.Stderr = os.Stdout, os.Stderr
+	if err := gmuxd.Start(); err != nil {
+		t.Fatalf("start gmuxd: %v", err)
+	}
+	defer gmuxd.Process.Kill()
+	waitForSocket(t, gmuxdSock, 20*time.Second)
+
+	launch := func() {
+		t.Helper()
+		os.Remove(outFile)
+		body := fmt.Sprintf(`{"command":["sh","-c","echo SENTINEL=$SENTINEL > %s; sleep 300"],"cwd":%q}`,
+			outFile, repoRoot)
+		client := unixHTTPClient(gmuxdSock)
+		resp, err := client.Post("http://localhost/v1/launch", "application/json", strings.NewReader(body))
+		if err != nil {
+			t.Fatalf("POST /v1/launch: %v", err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != 200 {
+			t.Fatalf("POST /v1/launch: status %d", resp.StatusCode)
+		}
+	}
+
+	waitForSentinel := func(want string) {
+		t.Helper()
+		deadline := time.Now().Add(10 * time.Second)
+		var last string
+		for time.Now().Before(deadline) {
+			if b, err := os.ReadFile(outFile); err == nil {
+				last = strings.TrimSpace(string(b))
+				if last == "SENTINEL="+want {
+					return
+				}
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+		t.Fatalf("sentinel = %q, want SENTINEL=%s", last, want)
+	}
+
+	// 1) Initial launch sees the original dotfile value.
+	launch()
+	waitForSentinel("before-edit")
+
+	// 2) Edit the dotfile (no daemon restart), then Restart the session.
+	os.WriteFile(dotfile, []byte("export SENTINEL=after-edit\n"), 0o644)
+
+	var sid string
+	for _, s := range listSessions(t, gmuxdSock) {
+		if s.Alive {
+			sid = s.ID
+			break
+		}
+	}
+	if sid == "" {
+		t.Fatal("no alive session to restart")
+	}
+
+	client := unixHTTPClient(gmuxdSock)
+	resp, err := client.Post("http://localhost/v1/sessions/"+sid+"/restart", "application/json", bytes.NewReader(nil))
+	if err != nil {
+		t.Fatalf("POST restart: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("POST restart: status %d", resp.StatusCode)
+	}
+
+	// The restarted session must reflect the edited dotfile.
+	waitForSentinel("after-edit")
+}
+
+func buildInto(t *testing.T, repoRoot, pkg, out string) {
+	t.Helper()
+	cmd := exec.Command("go", "build", "-o", out, "./"+pkg)
+	cmd.Dir = repoRoot
+	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("build %s: %v", pkg, err)
+	}
+}


### PR DESCRIPTION
## Problem

Sessions launched by gmuxd inherit the daemon's environment, which is **frozen at daemon startup** (typically when `gmux` first auto-started it). The result:

- Editing `~/.zshrc`/`~/.profile` then clicking **Restart session** never picks up the change — the restarted runner reuses the same stale env.
- Even `gmuxd restart` only helps when run from a *pristine* login shell. Run from a terminal *inside* a gmux session (the common case), it re-freezes the already-stale env.

While investigating I also found two env **leaks**: the `gmux`→`gmuxd` auto-start path stripped nothing (so a daemon auto-started from inside a session inherited `GMUX_SESSION_ID`/`GMUX_SOCKET`/`GMUX_ADAPTER` and stamped them onto every future session), and the bare `GMUX=1` marker slipped through the existing `GMUX_`-prefix filter everywhere.

## Changes

Two commits:

**1. `fix(env)`: stop leaking session identity into spawned daemons**
New `packages/sessionenv.Strip` removes bare `GMUX` + all `GMUX_*` identity vars, while preserving `GMUX_SOCKET_DIR` (config — daemon and runner must agree on the socket dir) and `GMUXD_*`. Applied at all three spawn sites (`launchGmux`, `startBackground`, `startGmuxd`).

**2. `feat(env)`: source a fresh login environment when launching sessions**
`launchGmux` now sources a fresh **interactive-login** environment — `$SHELL -l -i`, run in the session's cwd — via a hidden `gmux --dump-env` probe that writes `os.Environ()` NUL-delimited to **fd 3** (keeps the payload clean of rc-file banner noise; NUL handles bash function exports with embedded newlines).

- **Merge** semantics: the probe inherits the daemon env and layers dotfiles on top, so `DISPLAY`/`SSH_AUTH_SOCK`/`XDG_RUNTIME_DIR` survive while `.zshrc` changes apply. Still run through `sessionenv.Strip`.
- **Robust:** synchronous, 5s timeout, **process-group kill** on expiry (via `cmd.Cancel`). Any failure (`$SHELL` unset → headless daemons, probe error, timeout) falls back to today's behavior — never a worse env, never blocks forever.
- **Scope:** daemon-initiated launch/resume/restart only. Terminal-initiated `gmux <cmd>` is unchanged (already fresh).

Design rationale and alternatives are captured in **ADR 0006**.

## Verification

- Unit tests: `sessionenv.Strip`; capture/fallback/timeout/NUL-parse/shell-quote.
- **e2e** (`TestFreshLoginEnvOnLaunch`): proves a dotfile edit reaches a **restarted** session with no daemon restart.
- Manually reproduced before/after.

## Notes

- Drive-by: `TestEndToEnd` invoked `gmuxd` without the `run` subcommand (pre-existing breakage) — fixed.
- Changelog is auto-generated from conventional commits, so it's left to the release workflow.