### PR TITLE
feat(web): home, sidebar & settings overhaul

### DIFF
--- a/apps/gmux-web/src/home-partition.test.ts
+++ b/apps/gmux-web/src/home-partition.test.ts
@@ -2,19 +2,23 @@
 // only piece of dashboard logic with non-trivial behavior (the row
 // component is visual, the section layout is presentation); these
 // tests guard the behavior contracts the design conversation pinned
-// down: section priority, sort key, and the Recent floor/window/cap.
+// down: section priority, sort key, and the recency-bucket boundaries.
 
 import { describe, it, expect } from 'vitest'
 import {
   partitionForHome,
   partitionForProject,
-  RECENT_WINDOW_MS,
-  RECENT_FLOOR,
-  RECENT_CAP,
 } from './store'
 import { makeSession } from './test-helpers'
 
-const NOW = Date.parse('2026-06-01T12:00:00Z')
+// Constructed from LOCAL date parts (not a UTC string) so the
+// calendar-day bucket boundaries — which partitionForHome computes in
+// local time — line up deterministically regardless of the test
+// runner's timezone. Noon leaves a comfortable 12h gap to local
+// midnight, keeping the "earlier today" / "yesterday" splits crisp.
+const NOW = new Date(2026, 5, 1, 12, 0, 0).getTime()
+const HOUR = 60 * 60 * 1000
+const DAY = 24 * HOUR
 
 function stamp(offsetMs: number): string {
   return new Date(NOW + offsetMs).toISOString()
@@ -24,10 +28,10 @@ describe('partitionForHome', () => {
   describe('section assignment', () => {
     it('puts unread alive sessions in needsAttention', () => {
       const s = makeSession({ id: 's1', cwd: '/x', alive: true, unread: true })
-      const { needsAttention, running, recent } = partitionForHome([s], NOW)
+      const { needsAttention, running, buckets } = partitionForHome([s], NOW)
       expect(needsAttention.map(s => s.id)).toEqual(['s1'])
       expect(running).toEqual([])
-      expect(recent).toEqual([])
+      expect(buckets).toEqual([])
     })
 
     it('does NOT escalate error-only sessions to needsAttention', () => {
@@ -61,7 +65,7 @@ describe('partitionForHome', () => {
       // Home is alive-only: dead sessions live exclusively in the
       // project page's "All sessions" section. This pins the
       // contract so a regression that lets dead sessions leak into
-      // Recent (the historical behavior) fails loudly.
+      // a recency bucket (the historical behavior) fails loudly.
       const sessions = [
         makeSession({
           id: 'dead', cwd: '/x', alive: false,
@@ -72,10 +76,10 @@ describe('partitionForHome', () => {
           last_activity_at: stamp(-5 * 60 * 1000),
         }),
       ]
-      const { needsAttention, running, recent } = partitionForHome(sessions, NOW)
+      const { needsAttention, running, buckets } = partitionForHome(sessions, NOW)
       expect(needsAttention).toEqual([])
       expect(running).toEqual([])
-      expect(recent).toEqual([])
+      expect(buckets).toEqual([])
     })
   })
 
@@ -130,64 +134,67 @@ describe('partitionForHome', () => {
     })
   })
 
-  describe('recent window and floor', () => {
-    // Recent is for idle-alive sessions (live but not currently
-    // working). Dead sessions never reach this bucket since home
+  describe('recency buckets', () => {
+    // Buckets hold idle-alive sessions (live but not currently
+    // working/unread). Dead sessions never reach them since home
     // filters them out at the input.
     const idle = (id: string, ageMs: number) => makeSession({
       id, cwd: '/x', alive: true, last_activity_at: stamp(-ageMs),
     })
 
-    it('includes only entries inside the window when there are enough', () => {
+    it('groups idle-alive sessions into the four recency buckets', () => {
       const sessions = [
-        idle('a', 10 * 60 * 1000),
-        idle('b', 20 * 60 * 1000),
-        idle('c', 30 * 60 * 1000),
-        idle('d', RECENT_WINDOW_MS + 60_000),
+        idle('h', 30 * 60 * 1000), // 30m ago  → Last hour
+        idle('t', 3 * HOUR),       // 09:00     → Earlier today
+        idle('y', 15 * HOUR),      // prev 21:00 → Yesterday
+        idle('w', 3 * DAY),        // 3 days     → Earlier this week
       ]
-      const { recent } = partitionForHome(sessions, NOW)
-      expect(recent.map(s => s.id)).toEqual(['a', 'b', 'c'])
+      const { buckets } = partitionForHome(sessions, NOW)
+      expect(buckets.map(b => b.label)).toEqual([
+        'Last hour', 'Earlier today', 'Yesterday', 'Earlier this week',
+      ])
+      expect(buckets.map(b => b.sessions.map(s => s.id))).toEqual([
+        ['h'], ['t'], ['y'], ['w'],
+      ])
     })
 
-    it('falls back to top-floor by recency when fewer than floor are in-window', () => {
-      // 1 inside window, 4 older. Floor takes top RECENT_FLOOR=3 by
-      // recency overall so the user always sees a non-trivial
-      // section after they've used the daemon at all.
-      const sessions = [
-        idle('inside', 5 * 60 * 1000),
-        idle('old1', 2 * 3600_000),
-        idle('old2', 3 * 3600_000),
-        idle('old3', 4 * 3600_000),
-        idle('old4', 5 * 3600_000),
-      ]
-      const { recent } = partitionForHome(sessions, NOW)
-      expect(recent.map(s => s.id)).toEqual(['inside', 'old1', 'old2'])
-      expect(recent).toHaveLength(RECENT_FLOOR)
+    it('prioritizes the rolling Last hour window over the calendar day', () => {
+      // A session 40m ago is "Last hour" even though it is also part
+      // of "today". The rolling window wins.
+      const { buckets } = partitionForHome([idle('a', 40 * 60 * 1000)], NOW)
+      expect(buckets).toHaveLength(1)
+      expect(buckets[0].label).toBe('Last hour')
     })
 
-    it('caps the window-qualified set at RECENT_CAP', () => {
-      // Pathological case: many recent transitions in a busy hour.
-      // The cap stops the dashboard from scrolling forever.
-      const sessions = Array.from({ length: RECENT_CAP + 5 }, (_, i) =>
-        idle(`s${i}`, (i + 1) * 1000),
+    it('drops sessions older than a week', () => {
+      const { buckets } = partitionForHome([idle('ancient', 8 * DAY)], NOW)
+      expect(buckets).toEqual([])
+    })
+
+    it('omits empty buckets', () => {
+      // Only an earlier-this-week session present: the three newer
+      // buckets don't render at all.
+      const { buckets } = partitionForHome([idle('w', 3 * DAY)], NOW)
+      expect(buckets.map(b => b.label)).toEqual(['Earlier this week'])
+    })
+
+    it('sorts newest-first within a bucket', () => {
+      const { buckets } = partitionForHome(
+        [idle('older', 50 * 60 * 1000), idle('newer', 10 * 60 * 1000)],
+        NOW,
       )
-      const { recent } = partitionForHome(sessions, NOW)
-      expect(recent).toHaveLength(RECENT_CAP)
-      expect(recent[0].id).toBe('s0')
-      expect(recent[RECENT_CAP - 1].id).toBe(`s${RECENT_CAP - 1}`)
+      expect(buckets).toHaveLength(1)
+      expect(buckets[0].sessions.map(s => s.id)).toEqual(['newer', 'older'])
     })
 
-    it('returns an empty Recent when every session is working or unread', () => {
-      // No idle-alive leftovers → Recent stays empty even with the
-      // floor (the floor pulls from leftover, not from
-      // attention/running).
+    it('returns no buckets when every session is working or unread', () => {
       const working = { label: 'x', working: true, error: false }
       const sessions = [
         makeSession({ id: 'a', cwd: '/x', alive: true, status: working }),
-        makeSession({ id: 'b', cwd: '/x', alive: true, status: working }),
+        makeSession({ id: 'b', cwd: '/x', alive: true, unread: true }),
       ]
-      const { recent } = partitionForHome(sessions, NOW)
-      expect(recent).toEqual([])
+      const { buckets } = partitionForHome(sessions, NOW)
+      expect(buckets).toEqual([])
     })
   })
 })
@@ -200,10 +207,9 @@ describe('partitionForProject', () => {
   // and covered by the partitionForHome suite above.
 
   it('keeps idle-alive sessions from arbitrarily long ago in `rest`', () => {
-    // A session that was last active a week ago would be filtered
-    // out of home's Recent (1h window, 10-cap) but must remain on
-    // the project page.
-    const weekAgo = new Date(NOW - 7 * 24 * 60 * 60 * 1000).toISOString()
+    // A session last active a week ago would be dropped from home's
+    // recency buckets (>7 days) but must remain on the project page.
+    const weekAgo = new Date(NOW - 7 * DAY).toISOString()
     const s = makeSession({
       id: 'ancient',
       cwd: '/x',
@@ -216,7 +222,7 @@ describe('partitionForProject', () => {
   })
 
   it('keeps exited sessions in `rest` regardless of age', () => {
-    const longAgo = new Date(NOW - 30 * 24 * 60 * 60 * 1000).toISOString()
+    const longAgo = new Date(NOW - 30 * DAY).toISOString()
     const s = makeSession({
       id: 'old-exit',
       cwd: '/x',
@@ -227,14 +233,14 @@ describe('partitionForProject', () => {
     expect(rest.map(x => x.id)).toEqual(['old-exit'])
   })
 
-  it('does not cap `rest` at RECENT_CAP', () => {
-    // Generate more entries than the home cap so a regression that
-    // accidentally reused partitionForHome's slicing would show.
-    const sessions = Array.from({ length: RECENT_CAP + 5 }, (_, i) =>
+  it('does not cap or window `rest`', () => {
+    // Generate a large set so a regression that accidentally reused
+    // home's bucketing/dropping would show up as a shorter list.
+    const sessions = Array.from({ length: 15 }, (_, i) =>
       makeSession({ id: `s${i}`, cwd: '/x', alive: false }),
     )
     const { rest } = partitionForProject(sessions)
-    expect(rest.length).toBe(RECENT_CAP + 5)
+    expect(rest.length).toBe(15)
   })
 
   it('routes unread-alive to needsAttention and working-alive to running', () => {

--- a/apps/gmux-web/src/home.tsx
+++ b/apps/gmux-web/src/home.tsx
@@ -1,37 +1,19 @@
-// Home dashboard: activity-first overview of every session, plus the
-// list of configured projects. Replaces the old project-grid-only
-// homepage. Three activity sections (Waiting / Active /
-// Recent) surface what the user likely wants right now without
-// asking them to scan the sidebar; the projects list below is the
-// stable "wherever I'm working from" navigation surface.
+// Home dashboard: activity-first overview of every session. Three
+// activity sections (Waiting / Active / Recent) surface what the user
+// likely wants right now. Project configuration (add / reorder /
+// remove) lives in Settings → Projects; project navigation lives in
+// the sidebar. The home page is purely an overview surface.
 //
 // Section semantics, sort order, and the Recent floor/window/cap
 // live in store.ts:partitionForHome. This file is presentation.
 
-import { useCallback, useState } from 'preact/hooks'
 import {
-  health, folders, homePartition, dismissSession, projects,
-  updateProjects, removeProject, removePeerReference, localHostLabel,
+  health, folders, homePartition, dismissSession,
 } from './store'
-import { HostSuffix } from './host-suffix'
 import { SessionRow } from './session-row'
-import { LaunchButton } from './launcher'
 import { sessionPath } from './routing'
 import { IconBell, type NotifPermission } from './sidebar'
-import type { Folder, Session, ProjectItem } from './types'
-
-/** Drag-to-reorder transient state. `from` is the index lifted off,
- *  `over` is the current insertion target. Set to null when nothing
- *  is being dragged. Lives in the component, not the store: it's
- *  view-only and reset on every mouse-up. */
-interface DragState { from: number; over: number }
-
-function reorder<T>(arr: readonly T[], from: number, to: number): T[] {
-  const out = [...arr]
-  const [moved] = out.splice(from, 1)
-  out.splice(to, 0, moved)
-  return out
-}
+import type { Folder, Session } from './types'
 
 export function Home({
   onManageProjects,
@@ -42,38 +24,9 @@ export function Home({
   notifPermission: NotifPermission
   onRequestNotifPermission: () => void
 }) {
-  const healthVal = health.value
   const foldersVal = folders.value
-  const projectsVal = projects.value
+  const hasProjects = folders.value.length > 0
   const { needsAttention, running, recent } = homePartition.value
-
-  // Drag-to-reorder state for the Projects list. `configured` is the
-  // authoritative order; `dragItems` is the visual order during drag
-  // (commit on drop via updateProjects). Folder index maps 1:1 to
-  // projects.value index because buildProjectFolders preserves
-  // projects.json order.
-  const [drag, setDrag] = useState<DragState | null>(null)
-  const dragItems = drag ? reorder(projectsVal, drag.from, drag.over) : projectsVal
-
-  const handleDragStart = useCallback((i: number) => setDrag({ from: i, over: i }), [])
-  const handleDragOver = useCallback((i: number) => {
-    setDrag(prev => prev ? { ...prev, over: i } : null)
-  }, [])
-  const handleDragEnd = useCallback(() => {
-    // Commit the reorder before clearing drag state. State-setter
-    // updaters must stay pure (Preact may invoke them more than
-    // once in strict / dev modes), so the side effect lives outside
-    // the updater.
-    if (drag && drag.from !== drag.over) {
-      updateProjects(reorder(projectsVal, drag.from, drag.over))
-    }
-    setDrag(null)
-  }, [drag, projectsVal])
-
-  const handleRemove = useCallback((p: ProjectItem) => {
-    if (p.peer) removePeerReference(p.peer, p.slug)
-    else removeProject(p.slug)
-  }, [])
 
   // Cheap session→folder lookup: the SessionRow needs a project name
   // and the folder's owning peer to build a correct href. Building a
@@ -134,42 +87,15 @@ export function Home({
         </Section>
       )}
 
-      <section class="home-projects-section">
-        <h2 class="home-section-title">Projects</h2>
-        {projectsVal.length > 0 ? (
-          <div class="home-projects-list">
-            {dragItems.map((p, i) => {
-              // Match each project to its rendered folder (which
-              // carries display-friendly fields like name and counts).
-              // Folder key is `${peer ?? ''}::${slug}`; we match on that.
-              const folderKey = `${p.peer ?? ''}::${p.slug}`
-              const folder = foldersVal.find(f => f.key === folderKey)
-              if (!folder) return null
-              return (
-                <ProjectRow
-                  key={folderKey}
-                  folder={folder}
-                  project={p}
-                  index={i}
-                  dragging={drag !== null && drag.from === projectsVal.indexOf(p)}
-                  dropTarget={drag !== null && drag.over === i && drag.from !== i}
-                  onDragStart={handleDragStart}
-                  onDragOver={handleDragOver}
-                  onDragEnd={handleDragEnd}
-                  onRemove={handleRemove}
-                />
-              )
-            })}
-          </div>
-        ) : !anyActivity ? (
+      {!anyActivity && (
+        hasProjects ? (
+          <div class="home-empty-hint">Nothing active right now.</div>
+        ) : (
           <div class="home-empty-hint">
             No projects yet. <button class="home-empty-action" onClick={onManageProjects}>Add a project</button>
           </div>
-        ) : null}
-        <button class="home-add-project" onClick={onManageProjects}>
-          + Add project
-        </button>
-      </section>
+        )
+      )}
 
       <HomeFooter />
     </div>
@@ -221,81 +147,6 @@ export function Section({
       <h2 class="home-section-title">{title}</h2>
       <div class="home-section-body">{children}</div>
     </section>
-  )
-}
-
-function ProjectRow({
-  folder: f, project, index,
-  dragging, dropTarget,
-  onDragStart, onDragOver, onDragEnd, onRemove,
-}: {
-  folder: Folder
-  project: ProjectItem
-  index: number
-  dragging: boolean
-  dropTarget: boolean
-  onDragStart: (i: number) => void
-  onDragOver: (i: number) => void
-  onDragEnd: () => void
-  onRemove: (project: ProjectItem) => void
-}) {
-  // Counts mirror the legacy ProjectCard: "N alive" is the running
-  // count, "N resumable" is dead-but-resurrectable. Empty projects
-  // get a muted "no sessions" hint so the row isn't visually mute.
-  const alive = f.sessions.filter(s => s.alive).length
-  const resumable = f.sessions.filter(s => !s.alive && s.resumable).length
-  const href = f.peer ? `/@${f.peer}/${f.slug}` : `/${f.slug}`
-  const isReference = !!project.peer
-  return (
-    <div
-      class={`home-project-row${dragging ? ' dragging' : ''}${dropTarget ? ' drop-target' : ''}`}
-      draggable
-      onDragStart={(e) => {
-        e.dataTransfer!.effectAllowed = 'move'
-        e.dataTransfer!.setData('text/plain', '')
-        onDragStart(index)
-      }}
-      onDragOver={(e) => {
-        e.preventDefault()
-        e.dataTransfer!.dropEffect = 'move'
-        onDragOver(index)
-      }}
-      // `onDrop` only consumes the event so the browser doesn't try
-      // to navigate or search; the actual commit happens in
-      // `onDragEnd`, which fires for both successful drops and
-      // cancellations (Esc, release outside). Wiring both to the
-      // same handler doubled the PUT /v1/projects call on every
-      // successful drag.
-      onDrop={(e) => { e.preventDefault() }}
-      onDragEnd={onDragEnd}
-    >
-      <span class="home-project-drag" title="Drag to reorder" aria-hidden="true">⠿</span>
-      <a class="home-project-link" href={href}>
-        <div class="home-project-name">
-          {f.name}
-          <HostSuffix peer={f.peer ?? localHostLabel.value} local={!f.peer} />
-        </div>
-        <div class="home-project-count">
-          {alive > 0 && <span class="home-project-alive">{alive} alive</span>}
-          {alive > 0 && resumable > 0 && <span class="home-project-rest"> · </span>}
-          {resumable > 0 && <span class="home-project-rest">{resumable} resumable</span>}
-          {alive === 0 && resumable === 0 && <span class="home-project-rest">no sessions</span>}
-        </div>
-      </a>
-      <LaunchButton
-        sessions={f.sessions}
-        fallbackCwd={f.launchCwd ?? ''}
-        peer={f.peer}
-        className="home-project-launch"
-      />
-      <button
-        class="home-project-remove"
-        onClick={(e) => { e.preventDefault(); e.stopPropagation(); onRemove(project) }}
-        title={isReference ? 'Remove reference' : 'Remove project'}
-      >
-        ×
-      </button>
-    </div>
   )
 }
 

--- a/apps/gmux-web/src/home.tsx
+++ b/apps/gmux-web/src/home.tsx
@@ -108,7 +108,13 @@ export function Home({
   return (
     <div class="page">
       <header class="hub-header">
-        <h2 class="hub-title">Activity</h2>
+        <div class="home-activity-header">
+          <h2 class="hub-title">Activity</h2>
+          <NotifPrompt
+            permission={notifPermission}
+            onRequest={onRequestNotifPermission}
+          />
+        </div>
       </header>
       {needsAttention.length > 0 && (
         <Section title="Waiting">
@@ -165,21 +171,17 @@ export function Home({
         </button>
       </section>
 
-      <NotifPrompt
-        permission={notifPermission}
-        onRequest={onRequestNotifPermission}
-      />
-
       <HomeFooter />
     </div>
   )
 }
 
-/** Notification opt-in surface on the home dashboard.
- *  - 'default' : show the prompt button.
- *  - 'denied'  : show a muted banner pointing at browser settings.
- *  - 'granted' / 'unavailable' : render nothing (no opt-in needed,
- *    and a permission we cannot request is not actionable). */
+/** Notification opt-in affordance, right-aligned in the Activity header.
+ *  - 'default' : ghost pill inviting opt-in.
+ *  - 'denied'  : icon-only muted bell with a tooltip pointing at browser
+ *    settings (kept compact so it never crowds the header row).
+ *  - 'granted' / 'unavailable' : render nothing (no opt-in needed, and a
+ *    permission we cannot request is not actionable). */
 function NotifPrompt({
   permission,
   onRequest,
@@ -189,20 +191,19 @@ function NotifPrompt({
 }) {
   if (permission === 'default') {
     return (
-      <div class="home-notif">
-        <button class="notif-btn" onClick={onRequest}>
-          <IconBell /> Enable notifications
-        </button>
-      </div>
+      <button class="notif-toggle" onClick={onRequest}>
+        <IconBell /> Enable notifications
+      </button>
     )
   }
   if (permission === 'denied') {
     return (
-      <div class="home-notif">
-        <div class="notif-denied">
-          <IconBell muted /> Notifications blocked in browser settings
-        </div>
-      </div>
+      <span
+        class="notif-blocked"
+        title="Notifications blocked in browser settings"
+      >
+        <IconBell muted />
+      </span>
     )
   }
   return null

--- a/apps/gmux-web/src/home.tsx
+++ b/apps/gmux-web/src/home.tsx
@@ -11,7 +11,7 @@
 import { useCallback, useState } from 'preact/hooks'
 import {
   health, folders, homePartition, dismissSession, projects,
-  updateProjects, removeProject, removePeerReference,
+  updateProjects, removeProject, removePeerReference, localHostLabel,
 } from './store'
 import { HostSuffix } from './host-suffix'
 import { SessionRow } from './session-row'
@@ -273,7 +273,7 @@ function ProjectRow({
       <a class="home-project-link" href={href}>
         <div class="home-project-name">
           {f.name}
-          <HostSuffix peer={f.peer} />
+          <HostSuffix peer={f.peer ?? localHostLabel.value} local={!f.peer} />
         </div>
         <div class="home-project-count">
           {alive > 0 && <span class="home-project-alive">{alive} alive</span>}

--- a/apps/gmux-web/src/home.tsx
+++ b/apps/gmux-web/src/home.tsx
@@ -4,7 +4,7 @@
 // remove) lives in Settings → Projects; project navigation lives in
 // the sidebar. The home page is purely an overview surface.
 //
-// Section semantics, sort order, and the Recent floor/window/cap
+// Section semantics, sort order, and the recency-bucket boundaries
 // live in store.ts:partitionForHome. This file is presentation.
 
 import {
@@ -26,7 +26,7 @@ export function Home({
 }) {
   const foldersVal = folders.value
   const hasProjects = folders.value.length > 0
-  const { needsAttention, running, recent } = homePartition.value
+  const { needsAttention, running, buckets } = homePartition.value
 
   // Cheap session→folder lookup: the SessionRow needs a project name
   // and the folder's owning peer to build a correct href. Building a
@@ -56,7 +56,7 @@ export function Home({
     )
   }
 
-  const anyActivity = needsAttention.length + running.length + recent.length > 0
+  const anyActivity = needsAttention.length > 0 || running.length > 0 || buckets.length > 0
 
   return (
     <div class="page">
@@ -81,11 +81,11 @@ export function Home({
         </Section>
       )}
 
-      {recent.length > 0 && (
-        <Section title="Recent">
-          {recent.map(renderRow)}
+      {buckets.map(b => (
+        <Section key={b.label} title={b.label}>
+          {b.sessions.map(renderRow)}
         </Section>
-      )}
+      ))}
 
       {!anyActivity && (
         hasProjects ? (

--- a/apps/gmux-web/src/host-suffix.tsx
+++ b/apps/gmux-web/src/host-suffix.tsx
@@ -7,19 +7,26 @@
  * Locally-owned projects (peer omitted) render nothing: the viewer
  * is on that host, so naming it is noise. The suffix exists to flag
  * cross-host ownership; absence of the suffix means "here".
+ *
+ * `local` marks the name as the viewer's own host (used when a
+ * multi-host setup labels local project headers too). The local host
+ * is always reachable and is never in `peerStatusByName`, so we skip
+ * the peer-status lookup entirely — otherwise a remote peer that
+ * happens to share the local hostname would tint local headers red.
  */
 
 import { peerStatusByName } from './store'
 
-export function HostSuffix({ peer, leading = true }: { peer?: string; leading?: boolean }) {
+export function HostSuffix({ peer, leading = true, local = false }: { peer?: string; leading?: boolean; local?: boolean }) {
   if (!peer) return null
 
   // 'connected' or unknown (undefined) reads as normal; anything
   // else ('connecting', 'disconnected', 'offline') reads as red.
   // Treating unknown as connected avoids a brief offline flash on
-  // first SSE arrival before peers[] populates.
-  const status = peerStatusByName.value.get(peer)
-  const offline = status !== undefined && status !== 'connected'
+  // first SSE arrival before peers[] populates. The local host is
+  // always "us" — never offline, never status-looked-up.
+  const status = local ? undefined : peerStatusByName.value.get(peer)
+  const offline = !local && status !== undefined && status !== 'connected'
 
   return (
     <span

--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -8,7 +8,6 @@ import { ReplayView } from './replay-view'
 import { TerminalView } from './terminal'
 import { useArrivalPulse } from './use-arrival-pulse'
 import { Sidebar } from './sidebar'
-import type { DotState } from './store'
 import { usePresence } from './use-presence'
 
 import type { Session } from './types'
@@ -22,7 +21,7 @@ import { installVersionWatch } from './version-watch'
 import {
   sessions, connState, selected, selectedId, view, health, peers,
   terminalOptions, keybinds, macCommandIsCtrl,
-  backgroundActivity, unreadCount,
+  unreadCount,
   urlPath,
   initStore, setNavigate, navigateToSession,
   dismissSession, resumeSession, restartSession,
@@ -216,10 +215,14 @@ function MobileTerminalBar({
   onToggleAlt: () => void
   onFocusTerminal: () => void
 }) {
-  // Read signals directly; no props needed for these.
-  const bgActivity: DotState = backgroundActivity.value
-  const unread = unreadCount.value
-  const arrival = useArrivalPulse(bgActivity, unread)
+  // Read signals directly; no props needed for these. The hamburger
+  // badge surfaces only the waiting (unread) state — working/active are
+  // deliberately omitted. unreadCount excludes the selected session and
+  // its value re-fires the arrival pulse when another session starts
+  // waiting.
+  const waitingCount = unreadCount.value
+  const waiting = waitingCount > 0
+  const arrival = useArrivalPulse(waiting ? 'unread' : 'none', waitingCount)
 
   const keepFocus = (ev: Event) => ev.preventDefault()
   const tap = (seq: string) => { onSend(seq); onFocusTerminal() }
@@ -261,7 +264,7 @@ function MobileTerminalBar({
   return (
     <div class="mobile-bottom-bar" aria-label="Mobile terminal controls">
       <button
-        class={`mobile-bottom-action menu-btn${bgActivity !== 'none' ? ` bg-${bgActivity}` : ''}${arrival ? ` bg-${arrival}` : ''}`}
+        class={`mobile-bottom-action menu-btn${waiting ? ' bg-waiting' : ''}${arrival ? ` bg-${arrival}` : ''}`}
         onClick={onMenu}
         title="Open sessions"
       >

--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -369,10 +369,15 @@ function App() {
   // Open pushes a history entry (back closes); close replaces so the
   // collapsed entry doesn't reopen on a subsequent back.
   const settingsOpen = loc.query.settings !== undefined
-  const openSettings = useCallback((tab = 'projects') => {
+  const settingsTab = loc.query.settings ?? 'projects'
+  const openSettings = useCallback((tab = 'projects', replace = false) => {
     const params = new URLSearchParams(location.search)
+    // Replace (don't push) when the requested tab is already active,
+    // so clicking the always-visible gear while the modal is open
+    // doesn't stack a duplicate history entry that Back has to clear.
+    const alreadyActive = params.get('settings') === tab
     params.set('settings', tab)
-    loc.route(`${loc.path}?${params.toString()}`)
+    loc.route(`${loc.path}?${params.toString()}`, replace || alreadyActive)
   }, [loc])
   const closeSettings = useCallback(() => {
     const params = new URLSearchParams(location.search)
@@ -496,7 +501,9 @@ function App() {
 
       <SettingsModal
         open={settingsOpen}
+        tab={settingsTab}
         onClose={closeSettings}
+        onSelectTab={(t) => openSettings(t, true)}
       />
 
       <div class="main-panel">

--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -11,7 +11,7 @@ import { Sidebar } from './sidebar'
 import { usePresence } from './use-presence'
 
 import type { Session } from './types'
-import { ManageProjectsModal } from './manage-projects'
+import { SettingsModal } from './settings'
 import { ProjectHub } from './project-hub'
 import { Home } from './home'
 import { LaunchButton } from './launcher'
@@ -362,12 +362,30 @@ function App() {
     urlPath.value = loc.path
   }, [loc.path])
 
+  // Settings modal is driven by the `?settings` query param rather than
+  // local state, so it's deep-linkable and shareable. It's read off the
+  // query (not the path), leaving the path-derived `view` untouched —
+  // opening settings over a live session keeps the terminal mounted.
+  // Open pushes a history entry (back closes); close replaces so the
+  // collapsed entry doesn't reopen on a subsequent back.
+  const settingsOpen = loc.query.settings !== undefined
+  const openSettings = useCallback((tab = 'projects') => {
+    const params = new URLSearchParams(location.search)
+    params.set('settings', tab)
+    loc.route(`${loc.path}?${params.toString()}`)
+  }, [loc])
+  const closeSettings = useCallback(() => {
+    const params = new URLSearchParams(location.search)
+    params.delete('settings')
+    const qs = params.toString()
+    loc.route(qs ? `${loc.path}?${qs}` : loc.path, true)
+  }, [loc])
+
   // Initialize the store (SSE, data fetching, effects).
   useEffect(() => initStore(), [])
 
   // ── Local UI state (not shared, belongs to App) ──
   const [sidebarOpen, setSidebarOpen] = useState(false)
-  const [manageProjectsOpen, setManageProjectsOpen] = useState(false)
   const [ctrlArmed, setCtrlArmed] = useState(false)
   const [altArmed, setAltArmed] = useState(false)
 
@@ -471,14 +489,14 @@ function App() {
       <Sidebar
         resumingId={resumingId}
         onCloseSession={handleCloseSession}
-        onManageProjects={() => { setSidebarOpen(false); setManageProjectsOpen(true) }}
+        onOpenSettings={() => { setSidebarOpen(false); openSettings() }}
         open={sidebarOpen}
         onClose={() => setSidebarOpen(false)}
       />
 
-      <ManageProjectsModal
-        open={manageProjectsOpen}
-        onClose={() => setManageProjectsOpen(false)}
+      <SettingsModal
+        open={settingsOpen}
+        onClose={closeSettings}
       />
 
       <div class="main-panel">
@@ -537,7 +555,7 @@ function App() {
           </div>
         ) : (
           <Home
-            onManageProjects={() => setManageProjectsOpen(true)}
+            onManageProjects={() => openSettings()}
             notifPermission={notifPermission}
             onRequestNotifPermission={requestNotifPermission}
           />

--- a/apps/gmux-web/src/mock-data/index.ts
+++ b/apps/gmux-web/src/mock-data/index.ts
@@ -3,7 +3,8 @@
  * Active with ?mock query param or VITE_MOCK=1.
  */
 
-import type { ProjectItem } from '../types'
+import type { ProjectItem, PeerInfo } from '../types'
+import type { HealthData } from '../store'
 import type { MockSession } from './types'
 
 import codexRefactorAdapters from './sessions/codex-refactor-adapters'
@@ -24,6 +25,23 @@ export const MOCK_SESSIONS: MockSession[] = [
   shellOpenclawConfigure,
   shellOpenclawLogs,
 ]
+
+/** Mock peers (host roster). Covers connected, a Local devcontainer,
+ *  and a disconnected host carrying a last_error so the Hosts tab
+ *  exercises every row state. */
+export const MOCK_PEERS: PeerInfo[] = [
+  { name: 'laptop', url: 'https://laptop.tail-scale.ts.net', status: 'connected', session_count: 2, version: '1.2.0' },
+  { name: 'server', url: 'https://server.tail-scale.ts.net', status: 'connected', session_count: 4, version: '1.1.9' },
+  { name: 'devcontainer', url: 'https://devcontainer.tail-scale.ts.net', status: 'connected', session_count: 1, version: '1.2.0', local: true },
+  { name: 'bespin', url: 'https://bespin.tail-scale.ts.net', status: 'disconnected', session_count: 0, last_error: 'dial tcp 100.84.12.9:443: connect: connection refused' },
+]
+
+/** Mock daemon health for the local host. */
+export const MOCK_HEALTH: HealthData = {
+  version: '1.2.0',
+  hostname: 'workstation',
+  peers: MOCK_PEERS,
+}
 
 /** Session ID → mock session (for terminal content + cursor lookup). */
 export const MOCK_BY_ID: Record<string, MockSession> = Object.fromEntries(

--- a/apps/gmux-web/src/project-hub.tsx
+++ b/apps/gmux-web/src/project-hub.tsx
@@ -23,6 +23,7 @@ import { sessionPath } from './routing'
 import { LaunchButton } from './launcher'
 import {
   sessions, projects, peers, localPeerNames, partitionForProject,
+  localHostLabel,
 } from './store'
 import { HostSuffix } from './host-suffix'
 import { SessionRow } from './session-row'
@@ -100,7 +101,7 @@ export function ProjectHub({ projectSlug, projectPeer, onCloseSession }: Project
         <div class="hub-title-row">
           <h2 class="hub-title">
             {projectSlug}
-            <HostSuffix peer={projectPeer} />
+            <HostSuffix peer={projectPeer ?? localHostLabel.value} local={!projectPeer} />
           </h2>
           <LaunchButton
             sessions={allSessions}

--- a/apps/gmux-web/src/settings.tsx
+++ b/apps/gmux-web/src/settings.tsx
@@ -19,10 +19,13 @@ import {
   projects, discovered, peerProjects, peerStatusByName,
   addProject, addPeerReference, folders, updateProjects,
   removeProject, removePeerReference, localHostLabel,
+  health, peers, sessions,
 } from './store'
 import { PeerLabel } from './peer-label'
 import { HostSuffix } from './host-suffix'
 import type { ProjectItem, DiscoveredProject, MatchRule, Folder } from './types'
+
+type SettingsTab = 'projects' | 'hosts'
 
 // ── Rule description ──
 
@@ -57,11 +60,18 @@ function describeRule(rule: MatchRule): RuleDescription {
 
 export function SettingsModal({
   open,
+  tab,
   onClose,
+  onSelectTab,
 }: {
   open: boolean
+  tab: string
   onClose: () => void
+  onSelectTab: (tab: SettingsTab) => void
 }) {
+  // Normalize the raw `?settings` value: anything that isn't 'hosts'
+  // falls back to the projects tab (covers bare `?settings`).
+  const activeTab: SettingsTab = tab === 'hosts' ? 'hosts' : 'projects'
   const [discoveredQuery, setDiscoveredQuery] = useState('')
   const [pathDraft, setPathDraft] = useState('')
   const [pathError, setPathError] = useState('')
@@ -166,19 +176,39 @@ export function SettingsModal({
     <div class="modal-backdrop" ref={backdropRef} onClick={handleBackdropClick}>
       <div class="modal-panel manage-projects-modal">
         <div class="modal-header">
-          <div class="modal-title">Add project</div>
+          <div class="settings-tabs" role="tablist">
+            <button
+              class={`settings-tab${activeTab === 'projects' ? ' active' : ''}`}
+              role="tab"
+              aria-selected={activeTab === 'projects'}
+              onClick={() => onSelectTab('projects')}
+            >Projects</button>
+            <button
+              class={`settings-tab${activeTab === 'hosts' ? ' active' : ''}`}
+              role="tab"
+              aria-selected={activeTab === 'hosts'}
+              onClick={() => onSelectTab('hosts')}
+            >Hosts</button>
+          </div>
           <div class="modal-header-actions">
-            <a
-              class="mp-docs-link"
-              href="https://gmux.app/reference/projects-json/#match-rules"
-              target="_blank"
-              rel="noopener"
-              title="How match rules work"
-            >?</a>
+            {activeTab === 'projects' && (
+              <a
+                class="mp-docs-link"
+                href="https://gmux.app/reference/projects-json/#match-rules"
+                target="_blank"
+                rel="noopener"
+                title="How match rules work"
+              >?</a>
+            )}
             <button class="modal-close" onClick={onClose}>&times;</button>
           </div>
         </div>
 
+        {activeTab === 'hosts' ? (
+          <div class="modal-body">
+            <HostsTab />
+          </div>
+        ) : (
         <div class="modal-body">
           {/* ── Configured projects (manage: reorder + remove) ── */}
           <ConfiguredProjectsSection configured={configured} />
@@ -251,7 +281,86 @@ export function SettingsModal({
             )}
           </section>
         </div>
+        )}
       </div>
+    </div>
+  )
+}
+
+// ── Hosts tab (read-only roster) ──
+
+/** Read-only roster of every host gmux knows about: the local host
+ *  ("this host", synthesized from health), then the tailnet-discovered
+ *  and configured peers. Reachability is already conveyed by the
+ *  sidebar pill colors; this surface is the dig — version, session
+ *  count, and the last error behind an unreachable host. */
+function HostsTab() {
+  const h = health.value
+  const peersVal = peers.value
+  // Local session count: sessions not stamped with a peer. Mirrors
+  // PeerInfo.session_count for the synthesized self row.
+  const localCount = sessions.value.filter(s => !s.peer).length
+
+  return (
+    <section class="mp-section">
+      <div class="mp-section-label">Hosts</div>
+      <div class="host-list">
+        <HostRow
+          self
+          name={h?.hostname ?? 'this host'}
+          status="connected"
+          sessionCount={localCount}
+          version={h?.version}
+        />
+        {peersVal.map(p => (
+          <HostRow
+            key={p.name}
+            name={p.name}
+            status={p.status}
+            sessionCount={p.session_count}
+            version={p.version}
+            lastError={p.last_error}
+            local={p.local}
+          />
+        ))}
+      </div>
+    </section>
+  )
+}
+
+function HostRow({
+  name, self, status, sessionCount, version, lastError, local,
+}: {
+  name: string
+  self?: boolean
+  status: string
+  sessionCount: number
+  version?: string
+  lastError?: string
+  local?: boolean
+}) {
+  const connected = status === 'connected'
+  return (
+    <div class="host-row">
+      <div class="host-row-main">
+        <span class={`host-status-dot${connected ? ' connected' : ''}`} aria-hidden="true" />
+        {self
+          ? <span class="host-self-tag">this host</span>
+          : <PeerLabel name={name} />}
+        <span class="host-name">
+          {name}
+          {local && <span class="host-local-tag">local</span>}
+        </span>
+        <div class="host-meta">
+          <span class="host-status-label">{status}</span>
+          <span class="host-sep">·</span>
+          <span>{sessionCount} session{sessionCount === 1 ? '' : 's'}</span>
+          {version && <><span class="host-sep">·</span><span>v{version}</span></>}
+        </div>
+      </div>
+      {!connected && lastError && (
+        <div class="host-error">{lastError}</div>
+      )}
     </div>
   )
 }

--- a/apps/gmux-web/src/settings.tsx
+++ b/apps/gmux-web/src/settings.tsx
@@ -174,23 +174,27 @@ export function SettingsModal({
 
   return (
     <div class="modal-backdrop" ref={backdropRef} onClick={handleBackdropClick}>
-      <div class="modal-panel manage-projects-modal">
-        <div class="modal-header">
-          <div class="settings-tabs" role="tablist">
-            <button
-              class={`settings-tab${activeTab === 'projects' ? ' active' : ''}`}
-              role="tab"
-              aria-selected={activeTab === 'projects'}
-              onClick={() => onSelectTab('projects')}
-            >Projects</button>
-            <button
-              class={`settings-tab${activeTab === 'hosts' ? ' active' : ''}`}
-              role="tab"
-              aria-selected={activeTab === 'hosts'}
-              onClick={() => onSelectTab('hosts')}
-            >Hosts</button>
-          </div>
-          <div class="modal-header-actions">
+      <div class="modal-panel settings-modal">
+        <button class="modal-close settings-close" onClick={onClose}>&times;</button>
+        <nav class="settings-rail" role="tablist">
+          <div class="settings-rail-title">Settings</div>
+          <button
+            class={`settings-tab${activeTab === 'projects' ? ' active' : ''}`}
+            role="tab"
+            aria-selected={activeTab === 'projects'}
+            onClick={() => onSelectTab('projects')}
+          >Projects</button>
+          <button
+            class={`settings-tab${activeTab === 'hosts' ? ' active' : ''}`}
+            role="tab"
+            aria-selected={activeTab === 'hosts'}
+            onClick={() => onSelectTab('hosts')}
+          >Hosts</button>
+        </nav>
+
+        <div class="settings-main">
+          <div class="settings-main-header">
+            <span class="settings-main-title">{activeTab === 'hosts' ? 'Hosts' : 'Projects'}</span>
             {activeTab === 'projects' && (
               <a
                 class="mp-docs-link"
@@ -200,9 +204,7 @@ export function SettingsModal({
                 title="How match rules work"
               >?</a>
             )}
-            <button class="modal-close" onClick={onClose}>&times;</button>
           </div>
-        </div>
 
         {activeTab === 'hosts' ? (
           <div class="modal-body">
@@ -282,6 +284,7 @@ export function SettingsModal({
           </section>
         </div>
         )}
+        </div>
       </div>
     </div>
   )

--- a/apps/gmux-web/src/settings.tsx
+++ b/apps/gmux-web/src/settings.tsx
@@ -1,15 +1,18 @@
-// "Add project" modal.
+// Settings modal.
 //
-// Three addition flows:
+// Deep-linkable via the `?settings` query param (see main.tsx): it
+// layers over the current view without changing the path-derived
+// `view`, so the background — including a live session — stays mounted.
+//
+// For now the modal hosts only project configuration via three
+// addition flows:
 //   1. Peer references (subscribe to a project owned by another host)
 //   2. Discovered (claim a repo on disk that isn't a project yet)
 //   3. Manual local path
 //
-// Display, reorder, and removal of *configured* projects all live on
-// the home dashboard now: the modal is intentionally additions-only,
-// so the user has one place to discover-and-add and another to
-// arrange-and-curate. The exported component name keeps the older
-// `ManageProjectsModal` identifier for now; callers update later.
+// A tab bar (Projects / Hosts) and the configured-project manage-list
+// land in later slices; today the modal is additions-only and
+// reorder/removal still live on the home dashboard.
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks'
 import {
@@ -48,9 +51,9 @@ function describeRule(rule: MatchRule): RuleDescription {
   return { label: '(empty rule)', qualifier: '' }
 }
 
-// ── ManageProjectsModal ──
+// ── SettingsModal ──
 
-export function ManageProjectsModal({
+export function SettingsModal({
   open,
   onClose,
 }: {

--- a/apps/gmux-web/src/settings.tsx
+++ b/apps/gmux-web/src/settings.tsx
@@ -17,10 +17,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks'
 import {
   projects, discovered, peerProjects, peerStatusByName,
-  addProject, addPeerReference,
+  addProject, addPeerReference, folders, updateProjects,
+  removeProject, removePeerReference, localHostLabel,
 } from './store'
 import { PeerLabel } from './peer-label'
-import type { ProjectItem, DiscoveredProject, MatchRule } from './types'
+import { HostSuffix } from './host-suffix'
+import type { ProjectItem, DiscoveredProject, MatchRule, Folder } from './types'
 
 // ── Rule description ──
 
@@ -178,6 +180,9 @@ export function SettingsModal({
         </div>
 
         <div class="modal-body">
+          {/* ── Configured projects (manage: reorder + remove) ── */}
+          <ConfiguredProjectsSection configured={configured} />
+
           {/* ── References to peer-owned projects ── */}
           <PeerReferencesSection configured={configured} />
 
@@ -247,6 +252,140 @@ export function SettingsModal({
           </section>
         </div>
       </div>
+    </div>
+  )
+}
+
+// ── Configured projects (manage-list) ──
+
+/** Drag-to-reorder transient state. `from` is the index lifted off,
+ *  `over` is the current insertion target. */
+interface DragState { from: number; over: number }
+
+function reorder<T>(arr: readonly T[], from: number, to: number): T[] {
+  const out = [...arr]
+  const [moved] = out.splice(from, 1)
+  out.splice(to, 0, moved)
+  return out
+}
+
+/** The unified "Your projects" list at the top of the Projects tab:
+ *  every configured project (local + peer references) in sidebar order,
+ *  management-only — drag-to-reorder and remove, no navigation, no
+ *  launch. This is the single ordering that drives the sidebar; the
+ *  list maps 1:1 to projects.json items[] (which buildProjectFolders
+ *  preserves). Reference rows are distinguished by a leading colored
+ *  PeerLabel chip. */
+function ConfiguredProjectsSection({ configured }: { configured: ProjectItem[] }) {
+  const foldersVal = folders.value
+  const [drag, setDrag] = useState<DragState | null>(null)
+  const dragItems = drag ? reorder(configured, drag.from, drag.over) : configured
+
+  const handleDragStart = useCallback((i: number) => setDrag({ from: i, over: i }), [])
+  const handleDragOver = useCallback((i: number) => {
+    setDrag(prev => prev ? { ...prev, over: i } : null)
+  }, [])
+  const handleDragEnd = useCallback(() => {
+    // Commit before clearing. State-setter updaters must stay pure
+    // (Preact may invoke them more than once), so the side effect
+    // lives outside the updater.
+    if (drag && drag.from !== drag.over) {
+      updateProjects(reorder(configured, drag.from, drag.over))
+    }
+    setDrag(null)
+  }, [drag, configured])
+
+  const handleRemove = useCallback((p: ProjectItem) => {
+    if (p.peer) removePeerReference(p.peer, p.slug)
+    else removeProject(p.slug)
+  }, [])
+
+  if (configured.length === 0) return null
+
+  return (
+    <section class="mp-section">
+      <div class="mp-section-label">Your projects</div>
+      <div class="mp-configured-list">
+        {dragItems.map((p, i) => {
+          const folderKey = `${p.peer ?? ''}::${p.slug}`
+          const folder = foldersVal.find(f => f.key === folderKey)
+          if (!folder) return null
+          return (
+            <ConfiguredProjectRow
+              key={folderKey}
+              folder={folder}
+              project={p}
+              index={i}
+              dragging={drag !== null && drag.from === configured.indexOf(p)}
+              dropTarget={drag !== null && drag.over === i && drag.from !== i}
+              onDragStart={handleDragStart}
+              onDragOver={handleDragOver}
+              onDragEnd={handleDragEnd}
+              onRemove={handleRemove}
+            />
+          )
+        })}
+      </div>
+    </section>
+  )
+}
+
+function ConfiguredProjectRow({
+  folder: f, project, index,
+  dragging, dropTarget,
+  onDragStart, onDragOver, onDragEnd, onRemove,
+}: {
+  folder: Folder
+  project: ProjectItem
+  index: number
+  dragging: boolean
+  dropTarget: boolean
+  onDragStart: (i: number) => void
+  onDragOver: (i: number) => void
+  onDragEnd: () => void
+  onRemove: (project: ProjectItem) => void
+}) {
+  const alive = f.sessions.filter(s => s.alive).length
+  const resumable = f.sessions.filter(s => !s.alive && s.resumable).length
+  const isReference = !!project.peer
+  return (
+    <div
+      class={`mp-configured-row${dragging ? ' dragging' : ''}${dropTarget ? ' drop-target' : ''}`}
+      draggable
+      onDragStart={(e) => {
+        e.dataTransfer!.effectAllowed = 'move'
+        e.dataTransfer!.setData('text/plain', '')
+        onDragStart(index)
+      }}
+      onDragOver={(e) => {
+        e.preventDefault()
+        e.dataTransfer!.dropEffect = 'move'
+        onDragOver(index)
+      }}
+      onDrop={(e) => { e.preventDefault() }}
+      onDragEnd={onDragEnd}
+    >
+      <span class="mp-configured-drag" title="Drag to reorder" aria-hidden="true">⠿</span>
+      {isReference && <PeerLabel name={project.peer!} />}
+      <div class="mp-configured-info">
+        <span class="mp-configured-name">
+          {f.name}
+          <HostSuffix peer={f.peer ?? localHostLabel.value} local={!f.peer} />
+        </span>
+        <span class="mp-configured-count">
+          {alive > 0 && <span class="mp-configured-alive">{alive} alive</span>}
+          {alive > 0 && resumable > 0 && <span class="mp-configured-rest"> · </span>}
+          {resumable > 0 && <span class="mp-configured-rest">{resumable} resumable</span>}
+          {alive === 0 && resumable === 0 && <span class="mp-configured-rest">no sessions</span>}
+        </span>
+      </div>
+      <button
+        class="mp-configured-remove"
+        onClick={(e) => { e.preventDefault(); e.stopPropagation(); onRemove(project) }}
+        title={isReference ? 'Remove reference' : 'Remove project'}
+      >
+        ×
+      </button>
     </div>
   )
 }

--- a/apps/gmux-web/src/sidebar.tsx
+++ b/apps/gmux-web/src/sidebar.tsx
@@ -41,6 +41,14 @@ export const IconBell = ({ muted }: { muted?: boolean }) => (
   </svg>
 )
 
+export const IconSettings = () => (
+  <svg viewBox="0 0 16 16" width="15" height="15" {...bellStroke}>
+    <path d="M2 4.5h7M12 4.5h2M2 11.5h2M7 11.5h7"/>
+    <circle cx="10.5" cy="4.5" r="1.7"/>
+    <circle cx="5.5" cy="11.5" r="1.7"/>
+  </svg>
+)
+
 // ── Drag helpers ──
 
 /** True on devices with a pointer (mouse/trackpad). Touch-only devices
@@ -295,13 +303,13 @@ function FolderGroup({
 export function Sidebar({
   resumingId,
   onCloseSession,
-  onManageProjects,
+  onOpenSettings,
   open,
   onClose,
 }: {
   resumingId: string | null
   onCloseSession: (session: Session) => void
-  onManageProjects: () => void
+  onOpenSettings: () => void
   open: boolean
   onClose: () => void
 }) {
@@ -348,13 +356,14 @@ export function Sidebar({
             href="/"
             onClick={onClose}
           >gmux</a>
-          {connected && !hasProjects && (
-            <LaunchButton
-              className="sidebar-launch-btn"
-              beforeLaunch={seedHomeProject}
-              onLaunch={onClose}
-            />
-          )}
+          <button
+            class="sidebar-settings-btn"
+            onClick={onOpenSettings}
+            aria-label="Settings"
+            title="Settings"
+          >
+            <IconSettings />
+          </button>
         </div>
         <div class="sidebar-scroll">
           {foldersVal.map(f => (
@@ -370,6 +379,15 @@ export function Sidebar({
               onClick={onClose}
             />
           ))}
+          {connected && !hasProjects && (
+            <div class="sidebar-empty-launch">
+              <LaunchButton
+                className="sidebar-launch-btn"
+                beforeLaunch={seedHomeProject}
+                onLaunch={onClose}
+              />
+            </div>
+          )}
           {connected && totalVisible === 0 && !hasProjects && (
             <div class="sidebar-hint">
               Click <strong>+</strong> to start your first session.
@@ -377,7 +395,7 @@ export function Sidebar({
           )}
           {connected && isOnlyHomeProject && totalVisible > 0 && (
             <div class="sidebar-hint">
-              <button class="sidebar-hint-link" onClick={onManageProjects}>
+              <button class="sidebar-hint-link" onClick={onOpenSettings}>
                 Add a project
               </button> to organize sessions by repo.
             </div>

--- a/apps/gmux-web/src/sidebar.tsx
+++ b/apps/gmux-web/src/sidebar.tsx
@@ -15,6 +15,7 @@ import {
   activityMap, projects, connState,
   updateProjects, reorderSessions,
   peerStatusByName, isSessionUnavailable, localPeerNames, sessionDotState,
+  unreadCount,
   type DotState,
 } from './store'
 import { HostSuffix } from './host-suffix'
@@ -312,6 +313,16 @@ export function Sidebar({
   const am = activityMap.value
   const peerStatus = peerStatusByName.value
 
+  // Waiting indicator on the logo: mirrors the mobile hamburger badge so
+  // the always-visible brand mark doubles as a "a session elsewhere is
+  // waiting on you" cue. Only the waiting (unread) state is surfaced —
+  // working/active are deliberately omitted. unreadCount excludes the
+  // selected session (see store.ts); its value also drives the re-blink
+  // when an additional session enters the waiting state.
+  const waitingCount = unreadCount.value
+  const waiting = waitingCount > 0
+  const bgArrival = useArrivalPulse(waiting ? 'unread' : 'none', waitingCount)
+
   const totalVisible = foldersVal.reduce(
     (n, f) => n + f.sessions.filter(s => s.alive || s.resumable).length, 0,
   )
@@ -333,7 +344,7 @@ export function Sidebar({
       <aside class={`sidebar ${open ? 'open' : ''}`}>
         <div class="sidebar-header">
           <a
-            class="sidebar-logo"
+            class={`sidebar-logo${waiting ? ' bg-waiting' : ''}${bgArrival ? ` bg-${bgArrival}` : ''}`}
             href="/"
             onClick={onClose}
           >gmux</a>

--- a/apps/gmux-web/src/sidebar.tsx
+++ b/apps/gmux-web/src/sidebar.tsx
@@ -15,7 +15,7 @@ import {
   activityMap, projects, connState,
   updateProjects, reorderSessions,
   peerStatusByName, isSessionUnavailable, localPeerNames, sessionDotState,
-  unreadCount,
+  unreadCount, localHostLabel,
   type DotState,
 } from './store'
 import { HostSuffix } from './host-suffix'
@@ -256,7 +256,7 @@ function FolderGroup({
           onClick={onClick}
         >
           {folder.name}
-          <HostSuffix peer={folder.peer} />
+          <HostSuffix peer={folder.peer ?? localHostLabel.value} local={!folder.peer} />
           {folder.missing && <span class="folder-missing-icon" title="Project missing on peer">?</span>}
         </a>
         <LaunchButton

--- a/apps/gmux-web/src/store.test.ts
+++ b/apps/gmux-web/src/store.test.ts
@@ -7,7 +7,7 @@ import {
   isSessionUnavailable, urlPath, selectedId,
   navigateToSession, setNavigate,
   applyPending, _rawSessions, _rawWorld, _setRawWorld, _pendingMutations,
-  toUISession,
+  toUISession, localHostLabel,
 } from './store'
 import type { PendingMutation } from './store'
 import type { Session } from './types'
@@ -541,6 +541,54 @@ describe('raw signal projections', () => {
     // projects survived; peers cleared.
     expect(projects.value).toHaveLength(1)
     expect(peers.value).toHaveLength(0)
+  })
+})
+
+describe('localHostLabel', () => {
+  beforeEach(() => {
+    _rawSessions.value = []
+    _setRawWorld({ projects: [], peers: [], health: null })
+  })
+
+  it('is undefined when every folder is local (single host)', () => {
+    _setRawWorld({
+      health: { version: 'dev', hostname: 'workstation' },
+      projects: [
+        { slug: 'a', match: [{ path: '/a' }] },
+        { slug: 'b', match: [{ path: '/b' }] },
+      ],
+    })
+    expect(localHostLabel.value).toBeUndefined()
+  })
+
+  it('yields the local hostname once a peer reference adds a second host', () => {
+    _setRawWorld({
+      health: { version: 'dev', hostname: 'workstation' },
+      projects: [
+        { slug: 'a', match: [{ path: '/a' }] },
+        { slug: 'b', peer: 'unraid' },
+      ],
+    })
+    expect(localHostLabel.value).toBe('workstation')
+  })
+
+  it('is undefined in multi-host mode when the daemon has not reported a hostname', () => {
+    _setRawWorld({
+      health: { version: 'dev' },
+      projects: [
+        { slug: 'a', match: [{ path: '/a' }] },
+        { slug: 'b', peer: 'unraid' },
+      ],
+    })
+    expect(localHostLabel.value).toBeUndefined()
+  })
+
+  it('is undefined when only peer references exist but all share one host', () => {
+    _setRawWorld({
+      health: { version: 'dev', hostname: 'workstation' },
+      projects: [{ slug: 'b', peer: 'unraid' }],
+    })
+    expect(localHostLabel.value).toBeUndefined()
   })
 })
 

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -21,7 +21,7 @@ import { navigateWithReload } from './version-watch'
 import { buildProjectFolders, discoverProjects } from './projects'
 
 import { fetchFrontendConfig, buildTerminalOptions, resolveKeybinds, type ResolvedKeybind } from './config'
-import { MOCK_SESSIONS, MOCK_PROJECTS } from './mock-data/index'
+import { MOCK_SESSIONS, MOCK_PROJECTS, MOCK_PEERS, MOCK_HEALTH } from './mock-data/index'
 import type { ResolvedTerminalOptions } from './settings-schema'
 import type { Session as ProtocolSession } from '@gmux/protocol'
 
@@ -1016,7 +1016,7 @@ export function initStore(): () => void {
       ? MOCK_SESSIONS.map(s => s.peer === localHost ? { ...s, peer: undefined } : s)
       : [...MOCK_SESSIONS]
     batch(() => {
-      _setRawWorld({ projects: MOCK_PROJECTS })
+      _setRawWorld({ projects: MOCK_PROJECTS, peers: MOCK_PEERS, health: MOCK_HEALTH })
       _rawSessions.value = mockSessions
       sessionsLoaded.value = true
       connState.value = 'connected'

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -418,6 +418,34 @@ export const folders = computed(() =>
 )
 
 /**
+ * Local host's display name, but only when the shown folders span more
+ * than one host.
+ *
+ * Normally locally-owned project headers render no host suffix (the
+ * viewer is on that host, so naming it is noise). Once projects from
+ * more than one host are present, though, the local host becomes just
+ * one host among several, and labelling every header — local included —
+ * is clearer than leaving the local ones ambiguously bare. This yields
+ * the name to fall back to in that case, or `undefined` when there's a
+ * single host (or the daemon hasn't reported its hostname yet).
+ */
+export const localHostLabel = computed<string | undefined>(() => {
+  const local = health.value?.hostname
+  // Count distinct hosts among the shown folders. Local folders
+  // (peer === undefined) are tracked separately from named peers
+  // rather than via a '' sentinel, so a (misconfigured) peer named
+  // '' can't masquerade as local and skew the threshold.
+  const peerHosts = new Set<string>()
+  let hasLocal = false
+  for (const f of folders.value) {
+    if (f.peer === undefined) hasLocal = true
+    else peerHosts.add(f.peer)
+  }
+  const hostCount = peerHosts.size + (hasLocal ? 1 : 0)
+  return hostCount > 1 ? local : undefined
+})
+
+/**
  * Current view, derived from the URL + data.
  *
  * Returns null until sessions have loaded at least once. This prevents

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -513,18 +513,21 @@ export const unreadCount = computed(() =>
 // have not transitioned yet, so a brand-new idle session shows at
 // the top of Running and an old quiet one drops to the bottom).
 //
-// Recent surfaces idle-alive sessions worth glancing back at:
-// shells at a prompt that were recently doing something, or
-// adapter sessions between turns. Dead sessions are NOT included
-// (they live on the project page). Shape: entries whose
-// last_activity_at falls within RECENT_WINDOW_MS, plus enough
-// additional entries by recency to reach a floor of RECENT_FLOOR,
-// capped at RECENT_CAP. Without the floor the section vanishes
-// after a quiet hour; without the cap it grows unbounded on busy
-// daemons.
-export const RECENT_WINDOW_MS = 60 * 60 * 1000
-export const RECENT_FLOOR = 3
-export const RECENT_CAP = 10
+// The idle-alive remainder is grouped into recency buckets (Last
+// hour / Earlier today / Yesterday / Earlier this week) rather than a
+// single capped list. Buckets give structure so the section can grow
+// without truncation; anything older than a week drops off home (find
+// it via the project page or search). Dead sessions are NOT included
+// (they live on the project page).
+export const RECENT_WINDOW_DAYS = 7
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+const MS_PER_HOUR = 60 * 60 * 1000
+
+/** One recency bucket on the home dashboard. */
+export interface RecentBucket {
+  label: string
+  sessions: Session[]
+}
 
 function activityTimeMs(s: Session): number {
   // last_activity_at is canonical when present (daemon-stamped on
@@ -549,10 +552,11 @@ function byActivityDesc(a: Session, b: Session): number {
 }
 
 /**
- * Pure partition of a session list into the three dashboard sections.
- * Exported so tests can drive it with fixtures and `now` injected
- * (real wall-clock time would otherwise make the Recent floor/window
- * untestable).
+ * Pure partition of a session list into the dashboard sections:
+ * Waiting (unread), Active (working), and recency buckets for the
+ * idle-alive remainder. Exported so tests can drive it with fixtures
+ * and `now` injected (real wall-clock time would otherwise make the
+ * day boundaries untestable).
  *
  * Alive-only: dead sessions never appear on the home dashboard.
  * They live exclusively in the project page's "All sessions"
@@ -563,7 +567,7 @@ function byActivityDesc(a: Session, b: Session): number {
 export function partitionForHome(
   all: readonly Session[],
   now: number,
-): { needsAttention: Session[]; running: Session[]; recent: Session[] } {
+): { needsAttention: Session[]; running: Session[]; buckets: RecentBucket[] } {
   const needsAttention: Session[] = []
   const running: Session[] = []
   const leftover: Session[] = []
@@ -582,9 +586,7 @@ export function partitionForHome(
     } else if (s.status?.working) {
       running.push(s)
     } else {
-      // Idle-alive: not unread, not working. Falls to Recent if
-      // its last_activity_at is within the window (or via the
-      // floor when the daemon is quiet).
+      // Idle-alive: not unread, not working. Bucketed by recency below.
       leftover.push(s)
     }
   }
@@ -592,19 +594,42 @@ export function partitionForHome(
   running.sort(byActivityDesc)
   leftover.sort(byActivityDesc)
 
-  // Recent: leftover (idle-alive) entries whose timestamp is
-  // within the window, or top-N by recency if fewer than the
-  // floor qualify.
-  const withinWindow = leftover.filter(s => {
-    const t = activityTimeMs(s)
-    return t > 0 && now - t < RECENT_WINDOW_MS
-  })
-  const recent = (withinWindow.length >= RECENT_FLOOR
-    ? withinWindow
-    : leftover.slice(0, RECENT_FLOOR)
-  ).slice(0, RECENT_CAP)
+  // Recency buckets. "Last hour" is a rolling 60-minute window and
+  // takes priority; "Earlier today" / "Yesterday" use local-midnight
+  // calendar boundaries (so an 11pm session reads as "yesterday", not
+  // "20 hours ago"); "Earlier this week" is the rolling 2–7 day tail.
+  // Sessions older than a week (or without a parseable timestamp) are
+  // omitted from home.
+  const d = new Date(now)
+  const todayMidnight = new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime()
+  // Let the Date constructor normalize the day rollover so the
+  // boundary stays correct across DST transitions (a subtraction of
+  // a fixed 24h would drift by an hour on spring-forward / fall-back).
+  const yesterdayMidnight = new Date(d.getFullYear(), d.getMonth(), d.getDate() - 1).getTime()
+  const hourAgo = now - MS_PER_HOUR
+  const weekAgo = now - RECENT_WINDOW_DAYS * MS_PER_DAY
 
-  return { needsAttention, running, recent }
+  const lastHour: Session[] = []
+  const earlierToday: Session[] = []
+  const yesterday: Session[] = []
+  const earlierWeek: Session[] = []
+  for (const s of leftover) {
+    const t = activityTimeMs(s)
+    if (t <= 0) continue
+    if (t >= hourAgo) lastHour.push(s)
+    else if (t >= todayMidnight) earlierToday.push(s)
+    else if (t >= yesterdayMidnight) yesterday.push(s)
+    else if (t >= weekAgo) earlierWeek.push(s)
+  }
+
+  const buckets: RecentBucket[] = [
+    { label: 'Last hour', sessions: lastHour },
+    { label: 'Earlier today', sessions: earlierToday },
+    { label: 'Yesterday', sessions: yesterday },
+    { label: 'Earlier this week', sessions: earlierWeek },
+  ].filter(b => b.sessions.length > 0)
+
+  return { needsAttention, running, buckets }
 }
 
 export const homePartition = computed(() =>

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -756,42 +756,53 @@ body {
 }
 
 /* ── Notification prompt (home dashboard) ── */
-.home-notif {
-  /* Sits between the projects list and the footer as a low-priority
-   * opt-in. Width comes from the shared `.page > *` rule so the
-   * prompt aligns with the other home content blocks. */
-  margin: 16px 0 8px;
-}
-
-.notif-btn {
+/* Activity header row: title left, notification affordance right. Uses
+   center alignment (not the baseline alignment of the shared
+   .hub-title-row) so the bordered button's box centers against the
+   heading rather than sitting on its baseline. */
+.home-activity-header {
   display: flex;
   align-items: center;
-  gap: 7px;
-  width: 100%;
-  padding: 6px 10px;
-  border: 1px dashed var(--border);
+  justify-content: space-between;
+  gap: 12px;
+}
+
+/* Enable-notifications affordance, right-aligned in the Activity header.
+   A low-priority ghost button: lighter than the 18px title so it doesn't
+   compete, but bordered enough to read as a button. Radius matches the
+   sibling "+ Add project" control (6px). Brightens to accent on hover,
+   matching the app's other opt-in controls. */
+.notif-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+  padding: 4px 10px;
+  border: 1px solid var(--border);
   border-radius: 6px;
   background: transparent;
   color: var(--text-muted);
-  font-size: 13px;
+  font-size: 12px;
   font-family: 'Source Sans 3', sans-serif;
+  white-space: nowrap;
   cursor: pointer;
-  text-align: left;
-  transition: border-color 0.15s, color 0.15s;
+  transition: border-color 0.15s, color 0.15s, background 0.15s;
 }
 
-.notif-btn:hover {
+.notif-toggle:hover {
   border-color: var(--accent);
   color: var(--text-secondary);
+  background: color-mix(in oklch, var(--accent) 8%, transparent);
 }
 
-.notif-denied {
-  display: flex;
+/* Denied: icon-only muted bell (tooltip carries the explanation) so the
+   header row stays uncluttered. */
+.notif-blocked {
+  display: inline-flex;
   align-items: center;
-  gap: 7px;
-  padding: 5px 10px;
+  flex-shrink: 0;
   color: var(--text-muted);
-  font-size: 12px;
+  cursor: default;
 }
 
 /* ── Manage Projects Modal ── */

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -887,35 +887,61 @@ body {
   to   { opacity: 1; transform: translateY(0) scale(1); }
 }
 
-.modal-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 14px 16px 12px;
-  border-bottom: 1px solid var(--border);
+/* Settings modal: fixed-size panel with a side tab rail. Dimensions are
+   fixed so switching tabs / changing content count never resizes the
+   panel; the body scrolls within. */
+.settings-modal {
+  position: relative;
+  flex-direction: row;
+  width: 640px;
+  height: 540px;
+  overflow: hidden;
+}
+
+/* Single close button, pinned to the panel's top-right. It lands on the
+   main-pane header on desktop and on the top tab strip on mobile,
+   without needing a duplicate per layout. */
+.settings-close {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  z-index: 2;
+}
+
+.settings-rail {
   flex-shrink: 0;
-}
-
-.modal-title {
-  font-size: 15px;
-  font-weight: 600;
-  color: var(--text);
-}
-
-/* Settings tab bar (Projects / Hosts). */
-.settings-tabs {
+  width: 156px;
   display: flex;
-  gap: 4px;
+  flex-direction: column;
+  gap: 2px;
+  padding: 14px 10px;
+  border-right: 1px solid var(--border);
+  background: oklch(0% 0 0 / 0.12);
 }
+
+.settings-rail-title {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  padding: 0 8px;
+  margin-bottom: 8px;
+}
+
 .settings-tab {
+  display: block;
+  width: 100%;
+  text-align: left;
   background: none;
   border: none;
   color: var(--text-muted);
   font-size: 14px;
   font-weight: 600;
-  padding: 4px 8px;
+  padding: 7px 8px;
   border-radius: 6px;
   cursor: pointer;
+  white-space: nowrap;
   transition: color 0.1s, background 0.1s;
 }
 .settings-tab:hover {
@@ -925,6 +951,58 @@ body {
 .settings-tab.active {
   color: var(--text);
   background: var(--bg-active);
+}
+
+.settings-main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.settings-main-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  /* extra right padding reserves space for the pinned close button */
+  padding: 14px 48px 12px 16px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.settings-main-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+/* Narrow viewports: stack the rail on top as a horizontal,
+   side-to-side scrollable strip of tabs. */
+@media (max-width: 560px) {
+  .settings-modal {
+    flex-direction: column;
+    width: 480px;
+  }
+  .settings-rail {
+    width: auto;
+    flex-direction: row;
+    gap: 4px;
+    /* right padding clears the pinned close button */
+    padding: 8px 46px 8px 10px;
+    border-right: none;
+    border-bottom: 1px solid var(--border);
+    overflow-x: auto;
+    scrollbar-width: none;
+  }
+  .settings-rail::-webkit-scrollbar { display: none; }
+  .settings-rail-title { display: none; }
+  .settings-tab {
+    width: auto;
+    flex-shrink: 0;
+  }
+  /* On mobile the top tab strip already shows the current page, so the
+     title row is redundant — drop it entirely. */
+  .settings-main-header { display: none; }
 }
 
 /* Hosts roster (read-only). */

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -1875,14 +1875,11 @@ body {
     position: relative;
   }
 
-  /* Background-activity dot on the hamburger menu button.
+  /* Waiting dot on the hamburger menu button. Only the waiting (unread)
+     state is surfaced; working/active are deliberately omitted.
      Pseudo-elements don't expand the hit-box, so taps outside the button
      border still pass through correctly. */
-  .mobile-bottom-action.menu-btn.bg-working::after,
-  .mobile-bottom-action.menu-btn.bg-active::after,
-  .mobile-bottom-action.menu-btn.bg-fading::after,
-  .mobile-bottom-action.menu-btn.bg-error::after,
-  .mobile-bottom-action.menu-btn.bg-unread::after {
+  .mobile-bottom-action.menu-btn.bg-waiting::after {
     content: '';
     position: absolute;
     width: 8px;
@@ -1891,29 +1888,12 @@ body {
     top: -3px;
     right: -3px;
     pointer-events: none;
+    background: var(--unread);
     /* Ring in the page background so the dot reads cleanly against the button border */
     box-shadow: 0 0 0 1.5px var(--bg-base);
   }
-  .mobile-bottom-action.menu-btn.bg-working::after {
-    background: transparent;
-    border: 1.5px solid var(--accent);
-    box-sizing: border-box;
-  }
-  .mobile-bottom-action.menu-btn.bg-active::after {
-    background: transparent;
-    border: 1.5px solid var(--active);
-    box-sizing: border-box;
-  }
-  .mobile-bottom-action.menu-btn.bg-fading::after {
-    background: transparent;
-    border: 1.5px solid var(--active);
-    box-sizing: border-box;
-    animation: dot-fade-out 800ms ease-out forwards;
-  }
-  .mobile-bottom-action.menu-btn.bg-error::after   { background: var(--status-error); }
-  .mobile-bottom-action.menu-btn.bg-unread::after   { background: var(--unread); }
 
-  /* Arrival pulse on the hamburger badge — reuses the same keyframes timing */
+  /* Re-blink when a new session enters the waiting state */
   .mobile-bottom-action.menu-btn.bg-arriving::after {
     animation: dot-arrival 520ms cubic-bezier(0.25, 1, 0.5, 1) both;
   }
@@ -2004,7 +1984,8 @@ body {
 /* ── Reduced motion ── */
 @media (prefers-reduced-motion: reduce) {
   .session-dot-indicator.arriving,
-  .mobile-bottom-action.menu-btn.bg-arriving::after {
+  .mobile-bottom-action.menu-btn.bg-arriving::after,
+  .sidebar-logo.bg-arriving::after {
     animation: none;
   }
   .session-dot-indicator.working,

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -127,7 +127,11 @@ body {
   flex: 1;
   overflow-y: auto;
   overflow-x: hidden;
-  padding: 6px 0;
+  /* Generous bottom padding so the last row clears the viewport edge:
+   * the extra whitespace is the visual cue that the user has actually
+   * reached the end of the list (rather than wondering whether more
+   * content is hidden by the fold). */
+  padding: 6px 0 48px;
   display: flex;
   flex-direction: column;
 }

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -23,9 +23,12 @@ code {
   --text-secondary: oklch(65% 0.01 250);
   --text-muted: oklch(65% 0.01 250);
 
-  /* Borders */
-  --border: oklch(22% 0.015 250);
-  --border-strong: oklch(28% 0.015 250);
+  /* Borders. Two tiers; the base tier drives dividers, card/button
+   * outlines and scrollbar thumbs, so it needs enough lightness to read
+   * against the near-black surfaces. --border-strong stays ~6pts above
+   * for hover/emphasis separators. */
+  --border: oklch(32% 0.015 250);
+  --border-strong: oklch(38% 0.015 250);
 
   /* Accent — used for selection bars, buttons, links */
   --accent: oklch(72% 0.1 195);

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -98,7 +98,7 @@ body {
   display: flex;
   align-items: center;
   height: var(--header-height);
-  padding: 0 12px 0 14px;
+  padding: 0 14px;
   gap: 10px;
   flex-shrink: 0;
   border-bottom: 1px solid var(--border);
@@ -1924,13 +1924,17 @@ body {
     flex-wrap: wrap;
   }
 
-  /* Move sidebar header to bottom for thumb reach */
+  /* Move sidebar header to bottom for thumb reach. Match desktop's
+   * 14px horizontal padding and --header-height vertical rhythm so the
+   * logo's margins read the same in both layouts; the safe-area inset
+   * is added below that on notched devices so the logo never hugs the
+   * screen edge. */
   .sidebar-header {
     order: 3;
     height: auto;
     min-height: var(--header-height);
     padding: 0 14px;
-    padding-bottom: env(safe-area-inset-bottom);
+    margin-bottom: env(safe-area-inset-bottom);
     border-top: 1px solid var(--border);
     border-bottom: none;
   }

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -1661,34 +1661,31 @@ body {
   flex-direction: column;
   gap: 6px;
 }
-/* Projects list */
-
-.home-projects-section {
-  margin-bottom: 16px;
-}
-.home-projects-list {
+/* Configured-projects manage-list (Settings → Projects). Management
+ * only: drag-to-reorder + remove, no navigation, no launch. */
+.mp-configured-list {
   display: flex;
   flex-direction: column;
-  gap: 4px;
-  margin-bottom: 8px;
+  gap: 2px;
 }
-.home-project-row {
+.mp-configured-row {
   display: flex;
   align-items: center;
   gap: 8px;
+  padding: 7px 8px;
   border-radius: 6px;
   position: relative;
 }
-.home-project-row.dragging {
+.mp-configured-row:hover {
+  background: var(--bg-hover);
+}
+.mp-configured-row.dragging {
   opacity: 0.4;
 }
-.home-project-row.drop-target {
+.mp-configured-row.drop-target {
   box-shadow: inset 0 -2px 0 0 var(--accent);
 }
-.home-project-drag {
-  /* Always-visible drag affordance: muted enough to disappear when
-     scanning, present enough that the rows announce themselves as
-     reorderable. Touch users would otherwise have no signal. */
+.mp-configured-drag {
   color: var(--text-muted);
   opacity: 0.4;
   cursor: grab;
@@ -1697,26 +1694,35 @@ body {
   padding: 0 2px;
   flex-shrink: 0;
 }
-.home-project-drag:active { cursor: grabbing; }
-.home-project-row:hover .home-project-drag { opacity: 0.7; }
-.home-project-link {
+.mp-configured-drag:active { cursor: grabbing; }
+.mp-configured-row:hover .mp-configured-drag { opacity: 0.7; }
+.mp-configured-info {
   flex: 1;
   min-width: 0;
   display: flex;
   align-items: baseline;
   justify-content: space-between;
   gap: 12px;
-  padding: 8px 12px;
-  border-radius: 6px;
-  text-decoration: none;
-  color: inherit;
-  transition: background 0.1s;
 }
-.home-project-link:hover {
-  background: var(--bg-hover);
+.mp-configured-name {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
-
-.home-project-remove {
+.mp-configured-count {
+  font-size: 12px;
+  white-space: nowrap;
+}
+.mp-configured-alive {
+  color: var(--status-connected);
+}
+.mp-configured-rest {
+  color: var(--text-muted);
+}
+.mp-configured-remove {
   background: none;
   border: none;
   color: var(--text-muted);
@@ -1729,52 +1735,13 @@ body {
   flex-shrink: 0;
   transition: opacity 0.1s, color 0.1s, background 0.1s;
 }
-.home-project-row:hover .home-project-remove { opacity: 1; }
-.home-project-remove:hover {
+.mp-configured-row:hover .mp-configured-remove { opacity: 1; }
+.mp-configured-remove:hover {
   color: var(--text);
   background: var(--bg-active);
 }
 @media (hover: none) {
-  .home-project-remove { opacity: 1; }
-}
-.home-project-name {
-  font-size: 14px;
-  font-weight: 600;
-  color: var(--text);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-.home-project-count {
-  font-size: 12px;
-  white-space: nowrap;
-}
-.home-project-alive {
-  color: var(--status-connected);
-}
-.home-project-rest {
-  color: var(--text-muted);
-}
-.home-project-launch {
-  flex-shrink: 0;
-}
-
-.home-add-project {
-  background: none;
-  border: 1px dashed var(--border);
-  border-radius: 6px;
-  color: var(--text-muted);
-  font-size: 12px;
-  padding: 8px 12px;
-  cursor: pointer;
-  width: 100%;
-  text-align: left;
-  transition: border-color 0.1s, color 0.1s, background 0.1s;
-}
-.home-add-project:hover {
-  border-color: var(--text-muted);
-  color: var(--text);
-  background: var(--bg-hover);
+  .mp-configured-remove { opacity: 1; }
 }
 
 .home-empty-hint {

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -101,7 +101,7 @@ body {
   display: flex;
   align-items: center;
   height: var(--header-height);
-  padding: 0 14px;
+  padding: 0 6px 0 14px;
   gap: 10px;
   flex-shrink: 0;
   border-bottom: 1px solid var(--border);
@@ -115,7 +115,7 @@ body {
   color: var(--text);
   line-height: 1;
   text-decoration: none;
-  padding: 6px 10px;
+  padding: 4px 10px 6px 10px;
   margin: -6px -10px;
   cursor: pointer;
   border-radius: 6px;

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -126,6 +126,36 @@ body {
   text-shadow: 0 0 6px rgba(255, 255, 255, 0.25);
 }
 
+/* Settings gear, pinned opposite the logo in the header. */
+.sidebar-settings-btn {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  border-radius: 6px;
+  cursor: pointer;
+  transition: color 0.15s, background 0.15s;
+}
+.sidebar-settings-btn:hover {
+  color: var(--text);
+  background: var(--bg-hover);
+}
+
+/* Empty-state launch affordance: when there are no projects yet, the
+ * launch button lives in the sidebar body (not the header, which is
+ * now logo + gear). Sits just above the first-session hint. */
+.sidebar-empty-launch {
+  display: flex;
+  justify-content: center;
+  padding: 16px 14px 4px;
+}
+
 /* Waiting dot on the logo. Only the waiting state is surfaced (see the
    mobile hamburger badge, which uses the same single-state treatment),
    rendered as an in-flow dot to the RIGHT of the wordmark.

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -123,6 +123,33 @@ body {
   text-shadow: 0 0 6px rgba(255, 255, 255, 0.25);
 }
 
+/* Waiting dot on the logo. Only the waiting state is surfaced (see the
+   mobile hamburger badge, which uses the same single-state treatment),
+   rendered as an in-flow dot to the RIGHT of the wordmark.
+
+   Alignment: the wordmark is all-lowercase, so its optical midline sits
+   at baseline + ½·x-height rather than the line-box center. `vertical-
+   align: middle` is defined as exactly that point ("midpoint of the box
+   with the baseline plus half the x-height"), so the dot tracks the
+   text's visual centre in font metrics — no pixel nudging, and it scales
+   with the font. This needs an inline (not flex) context, hence the
+   inline-block dot and margin-left for the gap. */
+.sidebar-logo.bg-waiting::after {
+  content: '';
+  display: inline-block;
+  vertical-align: middle;
+  width: 8px;
+  height: 8px;
+  margin-left: 7px;
+  border-radius: 50%;
+  background: var(--unread);
+}
+
+/* Re-blink when a new session enters the waiting state */
+.sidebar-logo.bg-arriving::after {
+  animation: dot-arrival 520ms cubic-bezier(0.25, 1, 0.5, 1) both;
+}
+
 .sidebar-scroll {
   flex: 1;
   overflow-y: auto;

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -184,6 +184,18 @@ body {
 .folder + .folder {
   margin-top: 4px;
   padding-top: 4px;
+  position: relative;
+}
+/* Inset divider between project groups. Pulled in to the content's left
+ * padding (14px) rather than spanning edge-to-edge, so the list reads as
+ * grouped rows instead of a hard grid. The header keeps its full-width
+ * border as a stronger zone boundary. */
+.folder + .folder::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 14px;
+  right: 14px;
   border-top: 1px solid var(--border);
 }
 

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -902,6 +902,109 @@ body {
   color: var(--text);
 }
 
+/* Settings tab bar (Projects / Hosts). */
+.settings-tabs {
+  display: flex;
+  gap: 4px;
+}
+.settings-tab {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-size: 14px;
+  font-weight: 600;
+  padding: 4px 8px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: color 0.1s, background 0.1s;
+}
+.settings-tab:hover {
+  color: var(--text);
+  background: var(--bg-hover);
+}
+.settings-tab.active {
+  color: var(--text);
+  background: var(--bg-active);
+}
+
+/* Hosts roster (read-only). */
+.host-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.host-row {
+  padding: 8px;
+  border-radius: 6px;
+}
+.host-row-main {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.host-status-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--status-disconnected);
+  flex-shrink: 0;
+}
+.host-status-dot.connected {
+  background: var(--status-connected);
+}
+.host-self-tag {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+  background: var(--bg-active);
+  padding: 2px 6px;
+  border-radius: 4px;
+  flex-shrink: 0;
+}
+.host-name {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+.host-local-tag {
+  font-size: 11px;
+  font-weight: 400;
+  color: var(--text-muted);
+  margin-left: 6px;
+}
+.host-meta {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--text-muted);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+.host-status-label {
+  text-transform: capitalize;
+}
+.host-sep {
+  opacity: 0.5;
+}
+.host-error {
+  margin-top: 4px;
+  margin-left: 15px;
+  font-size: 12px;
+  color: var(--status-disconnected);
+  font-family: var(--mono, monospace);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .modal-close {
   width: 28px;
   height: 28px;


### PR DESCRIPTION
Restructures the web UI around an activity-first home, a cleaner sidebar, and a deep-linkable Settings modal that absorbs all project/host management.

## Home — pure activity overview
- Home is now a read-only activity feed; project management moved out entirely.
- **Waiting** and **Active** sections pinned at the top (alive sessions only).
- Older sessions group into recency buckets: **Last hour** (rolling 60m), **Earlier today**, **Yesterday**, **Earlier this week** (≤7d); empty buckets and >7d are hidden.
- Contextual empty states: first-run shows an "Add a project" CTA into Settings; otherwise a quiet "Nothing active right now."
- The enable-notifications prompt moved into the Activity header as a ghost pill.

## Sidebar
- Waiting indicator on the logo; the mobile hamburger badge reflects only the waiting state.
- Project headers show the local host label when configured projects span more than one host.
- Inset inter-folder dividers (reduces the grid feel); raised border-token lightness for clearer dividers/outlines; bottom padding for an end-of-scroll affordance; aligned logo margins across desktop/mobile and tuned logo/header padding.
- New gear button opens Settings.

## Settings — deep-linkable modal
- Layered over the current view via the `?settings=projects` / `?settings=hosts` query param, so the background (including a live session + its websocket) stays mounted.
- **Projects tab**: unified configured-project list (local + peer references) in sidebar order with drag-to-reorder and remove, plus discovered projects, peer references from other hosts, and manual local-path add.
- **Hosts tab**: read-only roster — this host (synthesized from health) pinned on top, then peers with status, session count, version, and inline last-error when unreachable.
- **Fixed-size panel with a side tab rail**: dimensions stay constant regardless of tab/content (body scrolls); on narrow viewports the rail collapses to a horizontal, side-to-side scrollable strip and the title row is dropped (the strip shows the current page; close pins to the strip).

## Notes
- Greptile's review comments (host-suffix local handling, the `''` peer sentinel, duplicate history push on re-open, `.host-name` ellipsis, DST-safe yesterday boundary) are addressed in the relevant commits.
- All web tests pass (426); `tsc` clean; verified visually via the mock dev server at wide and narrow widths.