### PR TITLE
feat(web): settings modal shell + gear button (deep-linkable via ?settings)

### DIFF
--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -11,7 +11,7 @@ import { Sidebar } from './sidebar'
 import { usePresence } from './use-presence'
 
 import type { Session } from './types'
-import { ManageProjectsModal } from './manage-projects'
+import { SettingsModal } from './settings'
 import { ProjectHub } from './project-hub'
 import { Home } from './home'
 import { LaunchButton } from './launcher'
@@ -362,12 +362,30 @@ function App() {
     urlPath.value = loc.path
   }, [loc.path])
 
+  // Settings modal is driven by the `?settings` query param rather than
+  // local state, so it's deep-linkable and shareable. It's read off the
+  // query (not the path), leaving the path-derived `view` untouched —
+  // opening settings over a live session keeps the terminal mounted.
+  // Open pushes a history entry (back closes); close replaces so the
+  // collapsed entry doesn't reopen on a subsequent back.
+  const settingsOpen = loc.query.settings !== undefined
+  const openSettings = useCallback((tab = 'projects') => {
+    const params = new URLSearchParams(location.search)
+    params.set('settings', tab)
+    loc.route(`${loc.path}?${params.toString()}`)
+  }, [loc])
+  const closeSettings = useCallback(() => {
+    const params = new URLSearchParams(location.search)
+    params.delete('settings')
+    const qs = params.toString()
+    loc.route(qs ? `${loc.path}?${qs}` : loc.path, true)
+  }, [loc])
+
   // Initialize the store (SSE, data fetching, effects).
   useEffect(() => initStore(), [])
 
   // ── Local UI state (not shared, belongs to App) ──
   const [sidebarOpen, setSidebarOpen] = useState(false)
-  const [manageProjectsOpen, setManageProjectsOpen] = useState(false)
   const [ctrlArmed, setCtrlArmed] = useState(false)
   const [altArmed, setAltArmed] = useState(false)
 
@@ -471,14 +489,14 @@ function App() {
       <Sidebar
         resumingId={resumingId}
         onCloseSession={handleCloseSession}
-        onManageProjects={() => { setSidebarOpen(false); setManageProjectsOpen(true) }}
+        onOpenSettings={() => { setSidebarOpen(false); openSettings() }}
         open={sidebarOpen}
         onClose={() => setSidebarOpen(false)}
       />
 
-      <ManageProjectsModal
-        open={manageProjectsOpen}
-        onClose={() => setManageProjectsOpen(false)}
+      <SettingsModal
+        open={settingsOpen}
+        onClose={closeSettings}
       />
 
       <div class="main-panel">
@@ -537,7 +555,7 @@ function App() {
           </div>
         ) : (
           <Home
-            onManageProjects={() => setManageProjectsOpen(true)}
+            onManageProjects={() => openSettings()}
             notifPermission={notifPermission}
             onRequestNotifPermission={requestNotifPermission}
           />

--- a/apps/gmux-web/src/settings.tsx
+++ b/apps/gmux-web/src/settings.tsx
@@ -1,15 +1,18 @@
-// "Add project" modal.
+// Settings modal.
 //
-// Three addition flows:
+// Deep-linkable via the `?settings` query param (see main.tsx): it
+// layers over the current view without changing the path-derived
+// `view`, so the background — including a live session — stays mounted.
+//
+// For now the modal hosts only project configuration via three
+// addition flows:
 //   1. Peer references (subscribe to a project owned by another host)
 //   2. Discovered (claim a repo on disk that isn't a project yet)
 //   3. Manual local path
 //
-// Display, reorder, and removal of *configured* projects all live on
-// the home dashboard now: the modal is intentionally additions-only,
-// so the user has one place to discover-and-add and another to
-// arrange-and-curate. The exported component name keeps the older
-// `ManageProjectsModal` identifier for now; callers update later.
+// A tab bar (Projects / Hosts) and the configured-project manage-list
+// land in later slices; today the modal is additions-only and
+// reorder/removal still live on the home dashboard.
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks'
 import {
@@ -48,9 +51,9 @@ function describeRule(rule: MatchRule): RuleDescription {
   return { label: '(empty rule)', qualifier: '' }
 }
 
-// ── ManageProjectsModal ──
+// ── SettingsModal ──
 
-export function ManageProjectsModal({
+export function SettingsModal({
   open,
   onClose,
 }: {

--- a/apps/gmux-web/src/sidebar.tsx
+++ b/apps/gmux-web/src/sidebar.tsx
@@ -41,6 +41,14 @@ export const IconBell = ({ muted }: { muted?: boolean }) => (
   </svg>
 )
 
+export const IconSettings = () => (
+  <svg viewBox="0 0 16 16" width="15" height="15" {...bellStroke}>
+    <path d="M2 4.5h7M12 4.5h2M2 11.5h2M7 11.5h7"/>
+    <circle cx="10.5" cy="4.5" r="1.7"/>
+    <circle cx="5.5" cy="11.5" r="1.7"/>
+  </svg>
+)
+
 // ── Drag helpers ──
 
 /** True on devices with a pointer (mouse/trackpad). Touch-only devices
@@ -295,13 +303,13 @@ function FolderGroup({
 export function Sidebar({
   resumingId,
   onCloseSession,
-  onManageProjects,
+  onOpenSettings,
   open,
   onClose,
 }: {
   resumingId: string | null
   onCloseSession: (session: Session) => void
-  onManageProjects: () => void
+  onOpenSettings: () => void
   open: boolean
   onClose: () => void
 }) {
@@ -348,13 +356,14 @@ export function Sidebar({
             href="/"
             onClick={onClose}
           >gmux</a>
-          {connected && !hasProjects && (
-            <LaunchButton
-              className="sidebar-launch-btn"
-              beforeLaunch={seedHomeProject}
-              onLaunch={onClose}
-            />
-          )}
+          <button
+            class="sidebar-settings-btn"
+            onClick={onOpenSettings}
+            aria-label="Settings"
+            title="Settings"
+          >
+            <IconSettings />
+          </button>
         </div>
         <div class="sidebar-scroll">
           {foldersVal.map(f => (
@@ -370,6 +379,15 @@ export function Sidebar({
               onClick={onClose}
             />
           ))}
+          {connected && !hasProjects && (
+            <div class="sidebar-empty-launch">
+              <LaunchButton
+                className="sidebar-launch-btn"
+                beforeLaunch={seedHomeProject}
+                onLaunch={onClose}
+              />
+            </div>
+          )}
           {connected && totalVisible === 0 && !hasProjects && (
             <div class="sidebar-hint">
               Click <strong>+</strong> to start your first session.
@@ -377,7 +395,7 @@ export function Sidebar({
           )}
           {connected && isOnlyHomeProject && totalVisible > 0 && (
             <div class="sidebar-hint">
-              <button class="sidebar-hint-link" onClick={onManageProjects}>
+              <button class="sidebar-hint-link" onClick={onOpenSettings}>
                 Add a project
               </button> to organize sessions by repo.
             </div>

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -126,6 +126,36 @@ body {
   text-shadow: 0 0 6px rgba(255, 255, 255, 0.25);
 }
 
+/* Settings gear, pinned opposite the logo in the header. */
+.sidebar-settings-btn {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  border-radius: 6px;
+  cursor: pointer;
+  transition: color 0.15s, background 0.15s;
+}
+.sidebar-settings-btn:hover {
+  color: var(--text);
+  background: var(--bg-hover);
+}
+
+/* Empty-state launch affordance: when there are no projects yet, the
+ * launch button lives in the sidebar body (not the header, which is
+ * now logo + gear). Sits just above the first-session hint. */
+.sidebar-empty-launch {
+  display: flex;
+  justify-content: center;
+  padding: 16px 14px 4px;
+}
+
 /* Waiting dot on the logo. Only the waiting state is surfaced (see the
    mobile hamburger badge, which uses the same single-state treatment),
    rendered as an in-flow dot to the RIGHT of the wordmark.


### PR DESCRIPTION
Closes #249.

> Stacked on #248 (`feat/local-host-multihost`) — review/merge that first; this targets that branch and will be rebased onto `main` once #248 lands. The diff below is settings-shell only.

## Summary

First slice of the home/settings restructure (#249): introduce a **deep-linkable Settings modal** and a **gear button**, replacing the standalone "Manage projects" modal. Shell + entry point only — the modal's *content* is unchanged (still today's add/discovery UI); the tab bar and the configured-project manage-list arrive in later slices (#250/#251).

## Changes

- **`manage-projects.tsx` → `settings.tsx`**, export `ManageProjectsModal` → `SettingsModal`. Content/behavior otherwise unchanged.
- **URL-driven open state**: settings is encoded as a `?settings` query param read from `loc.query`, *not* the path. The path-derived `view` is untouched, so opening settings over a live session keeps the terminal/websocket mounted. Open pushes a history entry (back closes); close replaces. Open/close preserve any other query params (only `settings` is touched).
- **Gear button** in the sidebar header opposite the logo, on desktop and mobile (within the drawer); `aria-label`/`title` "Settings". New `IconSettings` (sliders glyph).
- **Empty-state launch button relocated** out of the header into the sidebar body (`.sidebar-empty-launch`), so the header is just logo + gear when you have no projects.
- Sidebar `onManageProjects` prop → `onOpenSettings`; the "Add a project" hint link and the gear both open settings.

## Testing
- 424 web tests pass; lint/build clean.
- Verified via mock mode: gear opens `?settings=projects` over the preserved home view; deep-linking `?settings=projects` opens directly; close strips the param; unrelated query params survive open/close.
