### PR TITLE
feat(web): move project management into Settings; home becomes pure overview

### DIFF
--- a/apps/gmux-web/src/home.tsx
+++ b/apps/gmux-web/src/home.tsx
@@ -1,37 +1,19 @@
-// Home dashboard: activity-first overview of every session, plus the
-// list of configured projects. Replaces the old project-grid-only
-// homepage. Three activity sections (Waiting / Active /
-// Recent) surface what the user likely wants right now without
-// asking them to scan the sidebar; the projects list below is the
-// stable "wherever I'm working from" navigation surface.
+// Home dashboard: activity-first overview of every session. Three
+// activity sections (Waiting / Active / Recent) surface what the user
+// likely wants right now. Project configuration (add / reorder /
+// remove) lives in Settings → Projects; project navigation lives in
+// the sidebar. The home page is purely an overview surface.
 //
 // Section semantics, sort order, and the Recent floor/window/cap
 // live in store.ts:partitionForHome. This file is presentation.
 
-import { useCallback, useState } from 'preact/hooks'
 import {
-  health, folders, homePartition, dismissSession, projects,
-  updateProjects, removeProject, removePeerReference, localHostLabel,
+  health, folders, homePartition, dismissSession,
 } from './store'
-import { HostSuffix } from './host-suffix'
 import { SessionRow } from './session-row'
-import { LaunchButton } from './launcher'
 import { sessionPath } from './routing'
 import { IconBell, type NotifPermission } from './sidebar'
-import type { Folder, Session, ProjectItem } from './types'
-
-/** Drag-to-reorder transient state. `from` is the index lifted off,
- *  `over` is the current insertion target. Set to null when nothing
- *  is being dragged. Lives in the component, not the store: it's
- *  view-only and reset on every mouse-up. */
-interface DragState { from: number; over: number }
-
-function reorder<T>(arr: readonly T[], from: number, to: number): T[] {
-  const out = [...arr]
-  const [moved] = out.splice(from, 1)
-  out.splice(to, 0, moved)
-  return out
-}
+import type { Folder, Session } from './types'
 
 export function Home({
   onManageProjects,
@@ -42,38 +24,9 @@ export function Home({
   notifPermission: NotifPermission
   onRequestNotifPermission: () => void
 }) {
-  const healthVal = health.value
   const foldersVal = folders.value
-  const projectsVal = projects.value
+  const hasProjects = folders.value.length > 0
   const { needsAttention, running, recent } = homePartition.value
-
-  // Drag-to-reorder state for the Projects list. `configured` is the
-  // authoritative order; `dragItems` is the visual order during drag
-  // (commit on drop via updateProjects). Folder index maps 1:1 to
-  // projects.value index because buildProjectFolders preserves
-  // projects.json order.
-  const [drag, setDrag] = useState<DragState | null>(null)
-  const dragItems = drag ? reorder(projectsVal, drag.from, drag.over) : projectsVal
-
-  const handleDragStart = useCallback((i: number) => setDrag({ from: i, over: i }), [])
-  const handleDragOver = useCallback((i: number) => {
-    setDrag(prev => prev ? { ...prev, over: i } : null)
-  }, [])
-  const handleDragEnd = useCallback(() => {
-    // Commit the reorder before clearing drag state. State-setter
-    // updaters must stay pure (Preact may invoke them more than
-    // once in strict / dev modes), so the side effect lives outside
-    // the updater.
-    if (drag && drag.from !== drag.over) {
-      updateProjects(reorder(projectsVal, drag.from, drag.over))
-    }
-    setDrag(null)
-  }, [drag, projectsVal])
-
-  const handleRemove = useCallback((p: ProjectItem) => {
-    if (p.peer) removePeerReference(p.peer, p.slug)
-    else removeProject(p.slug)
-  }, [])
 
   // Cheap session→folder lookup: the SessionRow needs a project name
   // and the folder's owning peer to build a correct href. Building a
@@ -134,42 +87,15 @@ export function Home({
         </Section>
       )}
 
-      <section class="home-projects-section">
-        <h2 class="home-section-title">Projects</h2>
-        {projectsVal.length > 0 ? (
-          <div class="home-projects-list">
-            {dragItems.map((p, i) => {
-              // Match each project to its rendered folder (which
-              // carries display-friendly fields like name and counts).
-              // Folder key is `${peer ?? ''}::${slug}`; we match on that.
-              const folderKey = `${p.peer ?? ''}::${p.slug}`
-              const folder = foldersVal.find(f => f.key === folderKey)
-              if (!folder) return null
-              return (
-                <ProjectRow
-                  key={folderKey}
-                  folder={folder}
-                  project={p}
-                  index={i}
-                  dragging={drag !== null && drag.from === projectsVal.indexOf(p)}
-                  dropTarget={drag !== null && drag.over === i && drag.from !== i}
-                  onDragStart={handleDragStart}
-                  onDragOver={handleDragOver}
-                  onDragEnd={handleDragEnd}
-                  onRemove={handleRemove}
-                />
-              )
-            })}
-          </div>
-        ) : !anyActivity ? (
+      {!anyActivity && (
+        hasProjects ? (
+          <div class="home-empty-hint">Nothing active right now.</div>
+        ) : (
           <div class="home-empty-hint">
             No projects yet. <button class="home-empty-action" onClick={onManageProjects}>Add a project</button>
           </div>
-        ) : null}
-        <button class="home-add-project" onClick={onManageProjects}>
-          + Add project
-        </button>
-      </section>
+        )
+      )}
 
       <HomeFooter />
     </div>
@@ -221,81 +147,6 @@ export function Section({
       <h2 class="home-section-title">{title}</h2>
       <div class="home-section-body">{children}</div>
     </section>
-  )
-}
-
-function ProjectRow({
-  folder: f, project, index,
-  dragging, dropTarget,
-  onDragStart, onDragOver, onDragEnd, onRemove,
-}: {
-  folder: Folder
-  project: ProjectItem
-  index: number
-  dragging: boolean
-  dropTarget: boolean
-  onDragStart: (i: number) => void
-  onDragOver: (i: number) => void
-  onDragEnd: () => void
-  onRemove: (project: ProjectItem) => void
-}) {
-  // Counts mirror the legacy ProjectCard: "N alive" is the running
-  // count, "N resumable" is dead-but-resurrectable. Empty projects
-  // get a muted "no sessions" hint so the row isn't visually mute.
-  const alive = f.sessions.filter(s => s.alive).length
-  const resumable = f.sessions.filter(s => !s.alive && s.resumable).length
-  const href = f.peer ? `/@${f.peer}/${f.slug}` : `/${f.slug}`
-  const isReference = !!project.peer
-  return (
-    <div
-      class={`home-project-row${dragging ? ' dragging' : ''}${dropTarget ? ' drop-target' : ''}`}
-      draggable
-      onDragStart={(e) => {
-        e.dataTransfer!.effectAllowed = 'move'
-        e.dataTransfer!.setData('text/plain', '')
-        onDragStart(index)
-      }}
-      onDragOver={(e) => {
-        e.preventDefault()
-        e.dataTransfer!.dropEffect = 'move'
-        onDragOver(index)
-      }}
-      // `onDrop` only consumes the event so the browser doesn't try
-      // to navigate or search; the actual commit happens in
-      // `onDragEnd`, which fires for both successful drops and
-      // cancellations (Esc, release outside). Wiring both to the
-      // same handler doubled the PUT /v1/projects call on every
-      // successful drag.
-      onDrop={(e) => { e.preventDefault() }}
-      onDragEnd={onDragEnd}
-    >
-      <span class="home-project-drag" title="Drag to reorder" aria-hidden="true">⠿</span>
-      <a class="home-project-link" href={href}>
-        <div class="home-project-name">
-          {f.name}
-          <HostSuffix peer={f.peer ?? localHostLabel.value} local={!f.peer} />
-        </div>
-        <div class="home-project-count">
-          {alive > 0 && <span class="home-project-alive">{alive} alive</span>}
-          {alive > 0 && resumable > 0 && <span class="home-project-rest"> · </span>}
-          {resumable > 0 && <span class="home-project-rest">{resumable} resumable</span>}
-          {alive === 0 && resumable === 0 && <span class="home-project-rest">no sessions</span>}
-        </div>
-      </a>
-      <LaunchButton
-        sessions={f.sessions}
-        fallbackCwd={f.launchCwd ?? ''}
-        peer={f.peer}
-        className="home-project-launch"
-      />
-      <button
-        class="home-project-remove"
-        onClick={(e) => { e.preventDefault(); e.stopPropagation(); onRemove(project) }}
-        title={isReference ? 'Remove reference' : 'Remove project'}
-      >
-        ×
-      </button>
-    </div>
   )
 }
 

--- a/apps/gmux-web/src/settings.tsx
+++ b/apps/gmux-web/src/settings.tsx
@@ -17,10 +17,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks'
 import {
   projects, discovered, peerProjects, peerStatusByName,
-  addProject, addPeerReference,
+  addProject, addPeerReference, folders, updateProjects,
+  removeProject, removePeerReference, localHostLabel,
 } from './store'
 import { PeerLabel } from './peer-label'
-import type { ProjectItem, DiscoveredProject, MatchRule } from './types'
+import { HostSuffix } from './host-suffix'
+import type { ProjectItem, DiscoveredProject, MatchRule, Folder } from './types'
 
 // ── Rule description ──
 
@@ -178,6 +180,9 @@ export function SettingsModal({
         </div>
 
         <div class="modal-body">
+          {/* ── Configured projects (manage: reorder + remove) ── */}
+          <ConfiguredProjectsSection configured={configured} />
+
           {/* ── References to peer-owned projects ── */}
           <PeerReferencesSection configured={configured} />
 
@@ -247,6 +252,140 @@ export function SettingsModal({
           </section>
         </div>
       </div>
+    </div>
+  )
+}
+
+// ── Configured projects (manage-list) ──
+
+/** Drag-to-reorder transient state. `from` is the index lifted off,
+ *  `over` is the current insertion target. */
+interface DragState { from: number; over: number }
+
+function reorder<T>(arr: readonly T[], from: number, to: number): T[] {
+  const out = [...arr]
+  const [moved] = out.splice(from, 1)
+  out.splice(to, 0, moved)
+  return out
+}
+
+/** The unified "Your projects" list at the top of the Projects tab:
+ *  every configured project (local + peer references) in sidebar order,
+ *  management-only — drag-to-reorder and remove, no navigation, no
+ *  launch. This is the single ordering that drives the sidebar; the
+ *  list maps 1:1 to projects.json items[] (which buildProjectFolders
+ *  preserves). Reference rows are distinguished by a leading colored
+ *  PeerLabel chip. */
+function ConfiguredProjectsSection({ configured }: { configured: ProjectItem[] }) {
+  const foldersVal = folders.value
+  const [drag, setDrag] = useState<DragState | null>(null)
+  const dragItems = drag ? reorder(configured, drag.from, drag.over) : configured
+
+  const handleDragStart = useCallback((i: number) => setDrag({ from: i, over: i }), [])
+  const handleDragOver = useCallback((i: number) => {
+    setDrag(prev => prev ? { ...prev, over: i } : null)
+  }, [])
+  const handleDragEnd = useCallback(() => {
+    // Commit before clearing. State-setter updaters must stay pure
+    // (Preact may invoke them more than once), so the side effect
+    // lives outside the updater.
+    if (drag && drag.from !== drag.over) {
+      updateProjects(reorder(configured, drag.from, drag.over))
+    }
+    setDrag(null)
+  }, [drag, configured])
+
+  const handleRemove = useCallback((p: ProjectItem) => {
+    if (p.peer) removePeerReference(p.peer, p.slug)
+    else removeProject(p.slug)
+  }, [])
+
+  if (configured.length === 0) return null
+
+  return (
+    <section class="mp-section">
+      <div class="mp-section-label">Your projects</div>
+      <div class="mp-configured-list">
+        {dragItems.map((p, i) => {
+          const folderKey = `${p.peer ?? ''}::${p.slug}`
+          const folder = foldersVal.find(f => f.key === folderKey)
+          if (!folder) return null
+          return (
+            <ConfiguredProjectRow
+              key={folderKey}
+              folder={folder}
+              project={p}
+              index={i}
+              dragging={drag !== null && drag.from === configured.indexOf(p)}
+              dropTarget={drag !== null && drag.over === i && drag.from !== i}
+              onDragStart={handleDragStart}
+              onDragOver={handleDragOver}
+              onDragEnd={handleDragEnd}
+              onRemove={handleRemove}
+            />
+          )
+        })}
+      </div>
+    </section>
+  )
+}
+
+function ConfiguredProjectRow({
+  folder: f, project, index,
+  dragging, dropTarget,
+  onDragStart, onDragOver, onDragEnd, onRemove,
+}: {
+  folder: Folder
+  project: ProjectItem
+  index: number
+  dragging: boolean
+  dropTarget: boolean
+  onDragStart: (i: number) => void
+  onDragOver: (i: number) => void
+  onDragEnd: () => void
+  onRemove: (project: ProjectItem) => void
+}) {
+  const alive = f.sessions.filter(s => s.alive).length
+  const resumable = f.sessions.filter(s => !s.alive && s.resumable).length
+  const isReference = !!project.peer
+  return (
+    <div
+      class={`mp-configured-row${dragging ? ' dragging' : ''}${dropTarget ? ' drop-target' : ''}`}
+      draggable
+      onDragStart={(e) => {
+        e.dataTransfer!.effectAllowed = 'move'
+        e.dataTransfer!.setData('text/plain', '')
+        onDragStart(index)
+      }}
+      onDragOver={(e) => {
+        e.preventDefault()
+        e.dataTransfer!.dropEffect = 'move'
+        onDragOver(index)
+      }}
+      onDrop={(e) => { e.preventDefault() }}
+      onDragEnd={onDragEnd}
+    >
+      <span class="mp-configured-drag" title="Drag to reorder" aria-hidden="true">⠿</span>
+      {isReference && <PeerLabel name={project.peer!} />}
+      <div class="mp-configured-info">
+        <span class="mp-configured-name">
+          {f.name}
+          <HostSuffix peer={f.peer ?? localHostLabel.value} local={!f.peer} />
+        </span>
+        <span class="mp-configured-count">
+          {alive > 0 && <span class="mp-configured-alive">{alive} alive</span>}
+          {alive > 0 && resumable > 0 && <span class="mp-configured-rest"> · </span>}
+          {resumable > 0 && <span class="mp-configured-rest">{resumable} resumable</span>}
+          {alive === 0 && resumable === 0 && <span class="mp-configured-rest">no sessions</span>}
+        </span>
+      </div>
+      <button
+        class="mp-configured-remove"
+        onClick={(e) => { e.preventDefault(); e.stopPropagation(); onRemove(project) }}
+        title={isReference ? 'Remove reference' : 'Remove project'}
+      >
+        ×
+      </button>
     </div>
   )
 }

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -1661,34 +1661,31 @@ body {
   flex-direction: column;
   gap: 6px;
 }
-/* Projects list */
-
-.home-projects-section {
-  margin-bottom: 16px;
-}
-.home-projects-list {
+/* Configured-projects manage-list (Settings → Projects). Management
+ * only: drag-to-reorder + remove, no navigation, no launch. */
+.mp-configured-list {
   display: flex;
   flex-direction: column;
-  gap: 4px;
-  margin-bottom: 8px;
+  gap: 2px;
 }
-.home-project-row {
+.mp-configured-row {
   display: flex;
   align-items: center;
   gap: 8px;
+  padding: 7px 8px;
   border-radius: 6px;
   position: relative;
 }
-.home-project-row.dragging {
+.mp-configured-row:hover {
+  background: var(--bg-hover);
+}
+.mp-configured-row.dragging {
   opacity: 0.4;
 }
-.home-project-row.drop-target {
+.mp-configured-row.drop-target {
   box-shadow: inset 0 -2px 0 0 var(--accent);
 }
-.home-project-drag {
-  /* Always-visible drag affordance: muted enough to disappear when
-     scanning, present enough that the rows announce themselves as
-     reorderable. Touch users would otherwise have no signal. */
+.mp-configured-drag {
   color: var(--text-muted);
   opacity: 0.4;
   cursor: grab;
@@ -1697,26 +1694,35 @@ body {
   padding: 0 2px;
   flex-shrink: 0;
 }
-.home-project-drag:active { cursor: grabbing; }
-.home-project-row:hover .home-project-drag { opacity: 0.7; }
-.home-project-link {
+.mp-configured-drag:active { cursor: grabbing; }
+.mp-configured-row:hover .mp-configured-drag { opacity: 0.7; }
+.mp-configured-info {
   flex: 1;
   min-width: 0;
   display: flex;
   align-items: baseline;
   justify-content: space-between;
   gap: 12px;
-  padding: 8px 12px;
-  border-radius: 6px;
-  text-decoration: none;
-  color: inherit;
-  transition: background 0.1s;
 }
-.home-project-link:hover {
-  background: var(--bg-hover);
+.mp-configured-name {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
-
-.home-project-remove {
+.mp-configured-count {
+  font-size: 12px;
+  white-space: nowrap;
+}
+.mp-configured-alive {
+  color: var(--status-connected);
+}
+.mp-configured-rest {
+  color: var(--text-muted);
+}
+.mp-configured-remove {
   background: none;
   border: none;
   color: var(--text-muted);
@@ -1729,52 +1735,13 @@ body {
   flex-shrink: 0;
   transition: opacity 0.1s, color 0.1s, background 0.1s;
 }
-.home-project-row:hover .home-project-remove { opacity: 1; }
-.home-project-remove:hover {
+.mp-configured-row:hover .mp-configured-remove { opacity: 1; }
+.mp-configured-remove:hover {
   color: var(--text);
   background: var(--bg-active);
 }
 @media (hover: none) {
-  .home-project-remove { opacity: 1; }
-}
-.home-project-name {
-  font-size: 14px;
-  font-weight: 600;
-  color: var(--text);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-.home-project-count {
-  font-size: 12px;
-  white-space: nowrap;
-}
-.home-project-alive {
-  color: var(--status-connected);
-}
-.home-project-rest {
-  color: var(--text-muted);
-}
-.home-project-launch {
-  flex-shrink: 0;
-}
-
-.home-add-project {
-  background: none;
-  border: 1px dashed var(--border);
-  border-radius: 6px;
-  color: var(--text-muted);
-  font-size: 12px;
-  padding: 8px 12px;
-  cursor: pointer;
-  width: 100%;
-  text-align: left;
-  transition: border-color 0.1s, color 0.1s, background 0.1s;
-}
-.home-add-project:hover {
-  border-color: var(--text-muted);
-  color: var(--text);
-  background: var(--bg-hover);
+  .mp-configured-remove { opacity: 1; }
 }
 
 .home-empty-hint {


### PR DESCRIPTION
Closes #250.

> Stacked on #253 (`feat/settings-shell`) → #248. Review/merge the stack bottom-up; this will be rebased onto `main` once the parents land. Diff below is the manage-list + home cleanup only.

## Summary

Second slice of the home/settings restructure (#250): move **project management** into Settings › Projects and make home a pure activity overview.

## Changes

- **Settings › "Your projects" manage-list**: a unified, ordered list of every configured project (local + peer references, matching sidebar order). Management-only — drag-to-reorder (persists via `updateProjects`) and remove (× → `removeProject` / `removePeerReference`). No navigation, no launch button. Sits at the top of the modal, above Discovered / Add-local-path.
- **Reference rows lead with the colored `PeerLabel` chip** (status-aware, dims when the peer is offline); local rows get none. The host suffix and the "Remove reference" tooltip further distinguish them.
- **Home loses its Projects section entirely** (list, reorder, remove, "+ Add project"). The `ProjectRow` component and drag machinery move out of `home.tsx`.
- **Contextual empty state on home**: no projects → "No projects yet. Add a project" CTA that deep-links to `?settings`; projects-exist-but-quiet → "Nothing active right now."
- Dead `.home-project-*` / `.home-add-project` CSS removed; ported to `.mp-configured-*`.

## Testing
- 424 web tests pass; lint/build clean.
- Verified in mock mode: settings shows the manage-list (drag handles + counts + remove) above the add flows; home renders Activity-only with the Projects section gone; `?settings` open preserves other query params (`mock=1`).
