### PR TITLE
feat(web): hosts tab in settings (read-only roster: self + peers)

### DIFF
--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -369,10 +369,15 @@ function App() {
   // Open pushes a history entry (back closes); close replaces so the
   // collapsed entry doesn't reopen on a subsequent back.
   const settingsOpen = loc.query.settings !== undefined
-  const openSettings = useCallback((tab = 'projects') => {
+  const settingsTab = loc.query.settings ?? 'projects'
+  const openSettings = useCallback((tab = 'projects', replace = false) => {
     const params = new URLSearchParams(location.search)
+    // Replace (don't push) when the requested tab is already active,
+    // so clicking the always-visible gear while the modal is open
+    // doesn't stack a duplicate history entry that Back has to clear.
+    const alreadyActive = params.get('settings') === tab
     params.set('settings', tab)
-    loc.route(`${loc.path}?${params.toString()}`)
+    loc.route(`${loc.path}?${params.toString()}`, replace || alreadyActive)
   }, [loc])
   const closeSettings = useCallback(() => {
     const params = new URLSearchParams(location.search)
@@ -496,7 +501,9 @@ function App() {
 
       <SettingsModal
         open={settingsOpen}
+        tab={settingsTab}
         onClose={closeSettings}
+        onSelectTab={(t) => openSettings(t, true)}
       />
 
       <div class="main-panel">

--- a/apps/gmux-web/src/mock-data/index.ts
+++ b/apps/gmux-web/src/mock-data/index.ts
@@ -3,7 +3,8 @@
  * Active with ?mock query param or VITE_MOCK=1.
  */
 
-import type { ProjectItem } from '../types'
+import type { ProjectItem, PeerInfo } from '../types'
+import type { HealthData } from '../store'
 import type { MockSession } from './types'
 
 import codexRefactorAdapters from './sessions/codex-refactor-adapters'
@@ -24,6 +25,23 @@ export const MOCK_SESSIONS: MockSession[] = [
   shellOpenclawConfigure,
   shellOpenclawLogs,
 ]
+
+/** Mock peers (host roster). Covers connected, a Local devcontainer,
+ *  and a disconnected host carrying a last_error so the Hosts tab
+ *  exercises every row state. */
+export const MOCK_PEERS: PeerInfo[] = [
+  { name: 'laptop', url: 'https://laptop.tail-scale.ts.net', status: 'connected', session_count: 2, version: '1.2.0' },
+  { name: 'server', url: 'https://server.tail-scale.ts.net', status: 'connected', session_count: 4, version: '1.1.9' },
+  { name: 'devcontainer', url: 'https://devcontainer.tail-scale.ts.net', status: 'connected', session_count: 1, version: '1.2.0', local: true },
+  { name: 'bespin', url: 'https://bespin.tail-scale.ts.net', status: 'disconnected', session_count: 0, last_error: 'dial tcp 100.84.12.9:443: connect: connection refused' },
+]
+
+/** Mock daemon health for the local host. */
+export const MOCK_HEALTH: HealthData = {
+  version: '1.2.0',
+  hostname: 'workstation',
+  peers: MOCK_PEERS,
+}
 
 /** Session ID → mock session (for terminal content + cursor lookup). */
 export const MOCK_BY_ID: Record<string, MockSession> = Object.fromEntries(

--- a/apps/gmux-web/src/settings.tsx
+++ b/apps/gmux-web/src/settings.tsx
@@ -19,10 +19,13 @@ import {
   projects, discovered, peerProjects, peerStatusByName,
   addProject, addPeerReference, folders, updateProjects,
   removeProject, removePeerReference, localHostLabel,
+  health, peers, sessions,
 } from './store'
 import { PeerLabel } from './peer-label'
 import { HostSuffix } from './host-suffix'
 import type { ProjectItem, DiscoveredProject, MatchRule, Folder } from './types'
+
+type SettingsTab = 'projects' | 'hosts'
 
 // ── Rule description ──
 
@@ -57,11 +60,18 @@ function describeRule(rule: MatchRule): RuleDescription {
 
 export function SettingsModal({
   open,
+  tab,
   onClose,
+  onSelectTab,
 }: {
   open: boolean
+  tab: string
   onClose: () => void
+  onSelectTab: (tab: SettingsTab) => void
 }) {
+  // Normalize the raw `?settings` value: anything that isn't 'hosts'
+  // falls back to the projects tab (covers bare `?settings`).
+  const activeTab: SettingsTab = tab === 'hosts' ? 'hosts' : 'projects'
   const [discoveredQuery, setDiscoveredQuery] = useState('')
   const [pathDraft, setPathDraft] = useState('')
   const [pathError, setPathError] = useState('')
@@ -166,19 +176,39 @@ export function SettingsModal({
     <div class="modal-backdrop" ref={backdropRef} onClick={handleBackdropClick}>
       <div class="modal-panel manage-projects-modal">
         <div class="modal-header">
-          <div class="modal-title">Add project</div>
+          <div class="settings-tabs" role="tablist">
+            <button
+              class={`settings-tab${activeTab === 'projects' ? ' active' : ''}`}
+              role="tab"
+              aria-selected={activeTab === 'projects'}
+              onClick={() => onSelectTab('projects')}
+            >Projects</button>
+            <button
+              class={`settings-tab${activeTab === 'hosts' ? ' active' : ''}`}
+              role="tab"
+              aria-selected={activeTab === 'hosts'}
+              onClick={() => onSelectTab('hosts')}
+            >Hosts</button>
+          </div>
           <div class="modal-header-actions">
-            <a
-              class="mp-docs-link"
-              href="https://gmux.app/reference/projects-json/#match-rules"
-              target="_blank"
-              rel="noopener"
-              title="How match rules work"
-            >?</a>
+            {activeTab === 'projects' && (
+              <a
+                class="mp-docs-link"
+                href="https://gmux.app/reference/projects-json/#match-rules"
+                target="_blank"
+                rel="noopener"
+                title="How match rules work"
+              >?</a>
+            )}
             <button class="modal-close" onClick={onClose}>&times;</button>
           </div>
         </div>
 
+        {activeTab === 'hosts' ? (
+          <div class="modal-body">
+            <HostsTab />
+          </div>
+        ) : (
         <div class="modal-body">
           {/* ── Configured projects (manage: reorder + remove) ── */}
           <ConfiguredProjectsSection configured={configured} />
@@ -251,7 +281,86 @@ export function SettingsModal({
             )}
           </section>
         </div>
+        )}
       </div>
+    </div>
+  )
+}
+
+// ── Hosts tab (read-only roster) ──
+
+/** Read-only roster of every host gmux knows about: the local host
+ *  ("this host", synthesized from health), then the tailnet-discovered
+ *  and configured peers. Reachability is already conveyed by the
+ *  sidebar pill colors; this surface is the dig — version, session
+ *  count, and the last error behind an unreachable host. */
+function HostsTab() {
+  const h = health.value
+  const peersVal = peers.value
+  // Local session count: sessions not stamped with a peer. Mirrors
+  // PeerInfo.session_count for the synthesized self row.
+  const localCount = sessions.value.filter(s => !s.peer).length
+
+  return (
+    <section class="mp-section">
+      <div class="mp-section-label">Hosts</div>
+      <div class="host-list">
+        <HostRow
+          self
+          name={h?.hostname ?? 'this host'}
+          status="connected"
+          sessionCount={localCount}
+          version={h?.version}
+        />
+        {peersVal.map(p => (
+          <HostRow
+            key={p.name}
+            name={p.name}
+            status={p.status}
+            sessionCount={p.session_count}
+            version={p.version}
+            lastError={p.last_error}
+            local={p.local}
+          />
+        ))}
+      </div>
+    </section>
+  )
+}
+
+function HostRow({
+  name, self, status, sessionCount, version, lastError, local,
+}: {
+  name: string
+  self?: boolean
+  status: string
+  sessionCount: number
+  version?: string
+  lastError?: string
+  local?: boolean
+}) {
+  const connected = status === 'connected'
+  return (
+    <div class="host-row">
+      <div class="host-row-main">
+        <span class={`host-status-dot${connected ? ' connected' : ''}`} aria-hidden="true" />
+        {self
+          ? <span class="host-self-tag">this host</span>
+          : <PeerLabel name={name} />}
+        <span class="host-name">
+          {name}
+          {local && <span class="host-local-tag">local</span>}
+        </span>
+        <div class="host-meta">
+          <span class="host-status-label">{status}</span>
+          <span class="host-sep">·</span>
+          <span>{sessionCount} session{sessionCount === 1 ? '' : 's'}</span>
+          {version && <><span class="host-sep">·</span><span>v{version}</span></>}
+        </div>
+      </div>
+      {!connected && lastError && (
+        <div class="host-error">{lastError}</div>
+      )}
     </div>
   )
 }

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -21,7 +21,7 @@ import { navigateWithReload } from './version-watch'
 import { buildProjectFolders, discoverProjects } from './projects'
 
 import { fetchFrontendConfig, buildTerminalOptions, resolveKeybinds, type ResolvedKeybind } from './config'
-import { MOCK_SESSIONS, MOCK_PROJECTS } from './mock-data/index'
+import { MOCK_SESSIONS, MOCK_PROJECTS, MOCK_PEERS, MOCK_HEALTH } from './mock-data/index'
 import type { ResolvedTerminalOptions } from './settings-schema'
 import type { Session as ProtocolSession } from '@gmux/protocol'
 
@@ -1016,7 +1016,7 @@ export function initStore(): () => void {
       ? MOCK_SESSIONS.map(s => s.peer === localHost ? { ...s, peer: undefined } : s)
       : [...MOCK_SESSIONS]
     batch(() => {
-      _setRawWorld({ projects: MOCK_PROJECTS })
+      _setRawWorld({ projects: MOCK_PROJECTS, peers: MOCK_PEERS, health: MOCK_HEALTH })
       _rawSessions.value = mockSessions
       sessionsLoaded.value = true
       connState.value = 'connected'

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -902,6 +902,109 @@ body {
   color: var(--text);
 }
 
+/* Settings tab bar (Projects / Hosts). */
+.settings-tabs {
+  display: flex;
+  gap: 4px;
+}
+.settings-tab {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-size: 14px;
+  font-weight: 600;
+  padding: 4px 8px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: color 0.1s, background 0.1s;
+}
+.settings-tab:hover {
+  color: var(--text);
+  background: var(--bg-hover);
+}
+.settings-tab.active {
+  color: var(--text);
+  background: var(--bg-active);
+}
+
+/* Hosts roster (read-only). */
+.host-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.host-row {
+  padding: 8px;
+  border-radius: 6px;
+}
+.host-row-main {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.host-status-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--status-disconnected);
+  flex-shrink: 0;
+}
+.host-status-dot.connected {
+  background: var(--status-connected);
+}
+.host-self-tag {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+  background: var(--bg-active);
+  padding: 2px 6px;
+  border-radius: 4px;
+  flex-shrink: 0;
+}
+.host-name {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+.host-local-tag {
+  font-size: 11px;
+  font-weight: 400;
+  color: var(--text-muted);
+  margin-left: 6px;
+}
+.host-meta {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--text-muted);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+.host-status-label {
+  text-transform: capitalize;
+}
+.host-sep {
+  opacity: 0.5;
+}
+.host-error {
+  margin-top: 4px;
+  margin-left: 15px;
+  font-size: 12px;
+  color: var(--status-disconnected);
+  font-family: var(--mono, monospace);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .modal-close {
   width: 28px;
   height: 28px;


### PR DESCRIPTION
Closes #251.

> Stacked on #254 (`feat/settings-projects-tab`) → #253 → #248. Review/merge bottom-up; rebased onto `main` once parents land. Diff is the tab bar + Hosts roster + mock fixtures.

## Summary

Third slice of the home/settings restructure (#251): add a **Hosts tab** to Settings — the read-only "dig" companion to the at-a-glance host status the sidebar pills already give.

## Changes

- **Tab bar** (Projects / Hosts) in the settings modal header, replacing the static "Add project" title. The active tab is driven by the `?settings` value; `?settings=hosts` deep-links straight to the roster. Tab switches use `route(..., replace)` so Back closes the modal rather than cycling tabs. Bare `?settings` / unknown values normalize to Projects.
- **Hosts roster** (read-only): the local host pinned at top as **"this host"** (synthesized from `health`: hostname, version, local session count), then the tailnet-discovered + configured peers. Each row: status dot + `PeerLabel` chip (self gets the "this host" tag) + name (+ "local" tag for Local peers), with `status · N sessions · vX` meta. A host's **`last_error` renders inline below the row when it isn't connected**.
- **Mock fixtures**: `MOCK_PEERS` + `MOCK_HEALTH` added to mock mode so the Hosts tab (and the existing peer/host-suffix/version-footer surfaces) are exercisable in the `?mock=1` playground. Covers connected, a Local devcontainer, and a disconnected host with a `last_error`.

## Testing
- 424 web tests pass; lint/build clean.
- Verified in mock mode: `?settings=hosts` opens the roster (self + 4 peers, dots/versions/counts, bespin showing its disconnect error); switching Projects↔Hosts updates the param and preserves `mock=1`.

## Notes
- The roster is read-only; editable host attributes (alias/mute/etc.) are a deliberate later phase.
