### PR TITLE
feat(web): settings modal — fixed-size panel with side tab rail (responsive)

### DIFF
--- a/apps/gmux-web/src/settings.tsx
+++ b/apps/gmux-web/src/settings.tsx
@@ -174,23 +174,27 @@ export function SettingsModal({
 
   return (
     <div class="modal-backdrop" ref={backdropRef} onClick={handleBackdropClick}>
-      <div class="modal-panel manage-projects-modal">
-        <div class="modal-header">
-          <div class="settings-tabs" role="tablist">
-            <button
-              class={`settings-tab${activeTab === 'projects' ? ' active' : ''}`}
-              role="tab"
-              aria-selected={activeTab === 'projects'}
-              onClick={() => onSelectTab('projects')}
-            >Projects</button>
-            <button
-              class={`settings-tab${activeTab === 'hosts' ? ' active' : ''}`}
-              role="tab"
-              aria-selected={activeTab === 'hosts'}
-              onClick={() => onSelectTab('hosts')}
-            >Hosts</button>
-          </div>
-          <div class="modal-header-actions">
+      <div class="modal-panel settings-modal">
+        <button class="modal-close settings-close" onClick={onClose}>&times;</button>
+        <nav class="settings-rail" role="tablist">
+          <div class="settings-rail-title">Settings</div>
+          <button
+            class={`settings-tab${activeTab === 'projects' ? ' active' : ''}`}
+            role="tab"
+            aria-selected={activeTab === 'projects'}
+            onClick={() => onSelectTab('projects')}
+          >Projects</button>
+          <button
+            class={`settings-tab${activeTab === 'hosts' ? ' active' : ''}`}
+            role="tab"
+            aria-selected={activeTab === 'hosts'}
+            onClick={() => onSelectTab('hosts')}
+          >Hosts</button>
+        </nav>
+
+        <div class="settings-main">
+          <div class="settings-main-header">
+            <span class="settings-main-title">{activeTab === 'hosts' ? 'Hosts' : 'Projects'}</span>
             {activeTab === 'projects' && (
               <a
                 class="mp-docs-link"
@@ -200,9 +204,7 @@ export function SettingsModal({
                 title="How match rules work"
               >?</a>
             )}
-            <button class="modal-close" onClick={onClose}>&times;</button>
           </div>
-        </div>
 
         {activeTab === 'hosts' ? (
           <div class="modal-body">
@@ -282,6 +284,7 @@ export function SettingsModal({
           </section>
         </div>
         )}
+        </div>
       </div>
     </div>
   )

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -887,35 +887,61 @@ body {
   to   { opacity: 1; transform: translateY(0) scale(1); }
 }
 
-.modal-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 14px 16px 12px;
-  border-bottom: 1px solid var(--border);
+/* Settings modal: fixed-size panel with a side tab rail. Dimensions are
+   fixed so switching tabs / changing content count never resizes the
+   panel; the body scrolls within. */
+.settings-modal {
+  position: relative;
+  flex-direction: row;
+  width: 640px;
+  height: 540px;
+  overflow: hidden;
+}
+
+/* Single close button, pinned to the panel's top-right. It lands on the
+   main-pane header on desktop and on the top tab strip on mobile,
+   without needing a duplicate per layout. */
+.settings-close {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  z-index: 2;
+}
+
+.settings-rail {
   flex-shrink: 0;
-}
-
-.modal-title {
-  font-size: 15px;
-  font-weight: 600;
-  color: var(--text);
-}
-
-/* Settings tab bar (Projects / Hosts). */
-.settings-tabs {
+  width: 156px;
   display: flex;
-  gap: 4px;
+  flex-direction: column;
+  gap: 2px;
+  padding: 14px 10px;
+  border-right: 1px solid var(--border);
+  background: oklch(0% 0 0 / 0.12);
 }
+
+.settings-rail-title {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  padding: 0 8px;
+  margin-bottom: 8px;
+}
+
 .settings-tab {
+  display: block;
+  width: 100%;
+  text-align: left;
   background: none;
   border: none;
   color: var(--text-muted);
   font-size: 14px;
   font-weight: 600;
-  padding: 4px 8px;
+  padding: 7px 8px;
   border-radius: 6px;
   cursor: pointer;
+  white-space: nowrap;
   transition: color 0.1s, background 0.1s;
 }
 .settings-tab:hover {
@@ -925,6 +951,58 @@ body {
 .settings-tab.active {
   color: var(--text);
   background: var(--bg-active);
+}
+
+.settings-main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.settings-main-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  /* extra right padding reserves space for the pinned close button */
+  padding: 14px 48px 12px 16px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.settings-main-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+/* Narrow viewports: stack the rail on top as a horizontal,
+   side-to-side scrollable strip of tabs. */
+@media (max-width: 560px) {
+  .settings-modal {
+    flex-direction: column;
+    width: 480px;
+  }
+  .settings-rail {
+    width: auto;
+    flex-direction: row;
+    gap: 4px;
+    /* right padding clears the pinned close button */
+    padding: 8px 46px 8px 10px;
+    border-right: none;
+    border-bottom: 1px solid var(--border);
+    overflow-x: auto;
+    scrollbar-width: none;
+  }
+  .settings-rail::-webkit-scrollbar { display: none; }
+  .settings-rail-title { display: none; }
+  .settings-tab {
+    width: auto;
+    flex-shrink: 0;
+  }
+  /* On mobile the top tab strip already shows the current page, so the
+     title row is redundant — drop it entirely. */
+  .settings-main-header { display: none; }
 }
 
 /* Hosts roster (read-only). */


### PR DESCRIPTION
Reworks the Settings modal so its dimensions stay constant and moves the tab navigation to the side.

## What changed

- **Fixed-size panel.** The modal no longer grows and shrinks with its contents. `.settings-modal` is a fixed 640×540 panel (still capped by the viewport via the inherited `max-width`/`max-height`); the body scrolls inside. Switching between Projects and Hosts — or adding/removing projects — no longer reflows the window.
- **Side tab rail.** Tabs moved from a top bar into a left rail (`.settings-rail`) headed by a "Settings" label, with full-width, left-aligned tab buttons. The main pane gets its own header showing the active tab's title plus the contextual help link (Projects only) and the close button.
- **Responsive.** On narrow viewports (`max-width: 560px`) the rail collapses to the top as a horizontal, side-to-side scrollable strip of tabs; the "Settings" rail title hides. The panel keeps its fixed footprint and the body still scrolls.

## Structure

`.modal-panel.settings-modal` is now a flex row: `.settings-rail` (tablist) + `.settings-main` (`.settings-main-header` + scrollable `.modal-body`). The old `.modal-header` / `.modal-title` / `.settings-tabs` rules are replaced; no other component used them.

## Verification

- `tsc --noEmit` clean; 426 web tests pass.
- Visually checked wide (side rail) and narrow (top strip) at both tabs via the mock dev server: Projects and Hosts render an identical panel footprint despite very different content volumes; help link shows on Projects only.

Stacked on top of #248 (targets `feat/local-host-multihost`).