### PR TITLE
fix(web): unique keys for discovered project rows

### DIFF
--- a/apps/gmux-web/src/settings.tsx
+++ b/apps/gmux-web/src/settings.tsx
@@ -241,10 +241,10 @@ export function SettingsModal({
 
             <div class="mp-discovered-scroll">
               {activeDiscovered.length > 0 && activeDiscovered.map(d => (
-                <DiscoveredRow key={d.suggested_slug} project={d} onAdd={handleAdd} />
+                <DiscoveredRow key={discoveredKey(d)} project={d} onAdd={handleAdd} />
               ))}
               {inactiveDiscovered.length > 0 && inactiveDiscovered.map(d => (
-                <DiscoveredRow key={d.suggested_slug} project={d} onAdd={handleAdd} />
+                <DiscoveredRow key={discoveredKey(d)} project={d} onAdd={handleAdd} />
               ))}
               {filteredDiscovered.length === 0 && lowerDiscoveredQuery && (
                 <div class="mp-empty-hint">
@@ -582,4 +582,12 @@ function PeerReferencesSection({ configured }: { configured: ProjectItem[] }) {
 
 function shortenPath(p: string): string {
   return p.replace(/^\/home\/[^/]+/, '~')
+}
+
+/** Stable, collision-free key for a discovered row. suggested_slug
+ *  alone collides when two hosts — or two repos on one host — suggest
+ *  the same name; the owning peer plus the repo's remote/path
+ *  disambiguates. */
+function discoveredKey(d: DiscoveredProject): string {
+  return `${d.peer ?? ''}::${d.remote ?? d.paths[0] ?? d.suggested_slug}`
 }


### PR DESCRIPTION
The discovered-projects list in Settings keyed each row on `suggested_slug` alone. When two hosts (or two repos on one host) suggest the same slug — e.g. several peers each exposing `my-project` — the keys collide, and Preact logs *"two or more children with the same key attribute"* and can mis-render rows.

Key on the row's actual identity instead: the owning peer plus the repo's remote (or first path), falling back to the slug. Extracted as a small `discoveredKey(d)` helper used by both the active and inactive maps.

## Verification
- `tsc --noEmit` clean; 426 web tests pass.
- Mock dev server (which exposes several same-slug discovered entries across peers) no longer logs the duplicate-key warning.