### PR TITLE
feat(web): convert frontend to Tailwind CSS v4

### DIFF
--- a/apps/gmux-web/package.json
+++ b/apps/gmux-web/package.json
@@ -29,6 +29,9 @@
   },
   "devDependencies": {
     "@preact/preset-vite": "^2.10.2",
+    "autoprefixer": "^10.5.0",
+    "postcss": "^8.5.15",
+    "tailwindcss": "^4.3.0",
     "typescript": "^5.8.2",
     "vite": "^6.2.0",
     "vitest": "^3.0.7"

--- a/apps/gmux-web/package.json
+++ b/apps/gmux-web/package.json
@@ -29,8 +29,6 @@
   },
   "devDependencies": {
     "@preact/preset-vite": "^2.10.2",
-    "autoprefixer": "^10.5.0",
-    "postcss": "^8.5.15",
     "tailwindcss": "^4.3.0",
     "typescript": "^5.8.2",
     "vite": "^6.2.0",

--- a/apps/gmux-web/src/home.tsx
+++ b/apps/gmux-web/src/home.tsx
@@ -92,7 +92,7 @@ export function Home({
           <div class="text-[13px] text-text-muted py-4">Nothing active right now.</div>
         ) : (
           <div class="text-[13px] text-text-muted py-4">
-            No projects yet. <button class="bg-transparent border-0 text-accent cursor-pointer p-0 underline underline-offset-[2px] font-inherit" onClick={onManageProjects}>Add a project</button>
+            No projects yet. <button class="bg-transparent border-0 text-accent cursor-pointer p-0 underline underline-offset-[2px] font-[inherit]" onClick={onManageProjects}>Add a project</button>
           </div>
         )
       )}
@@ -166,7 +166,7 @@ function HomeFooter() {
       {h.update_available && (
         <>
           {' · '}
-          <a class="font-inherit text-accent bg-transparent border-0 p-0 cursor-pointer underline underline-offset-[2px] hover:text-text" href="https://gmux.app/changelog/" target="_blank">
+          <a class="font-[inherit] text-accent bg-transparent border-0 p-0 cursor-pointer underline underline-offset-[2px] hover:text-text" href="https://gmux.app/changelog/" target="_blank">
             version {h.update_available} available!
           </a>
         </>

--- a/apps/gmux-web/src/home.tsx
+++ b/apps/gmux-web/src/home.tsx
@@ -60,9 +60,9 @@ export function Home({
 
   return (
     <div class="page">
-      <header class="hub-header">
-        <div class="home-activity-header">
-          <h2 class="hub-title">Activity</h2>
+      <header class="mb-5">
+        <div class="flex items-center justify-between gap-3">
+          <h2 class="text-lg font-semibold text-text m-0">Activity</h2>
           <NotifPrompt
             permission={notifPermission}
             onRequest={onRequestNotifPermission}
@@ -89,10 +89,10 @@ export function Home({
 
       {!anyActivity && (
         hasProjects ? (
-          <div class="home-empty-hint">Nothing active right now.</div>
+          <div class="text-[13px] text-text-muted py-4">Nothing active right now.</div>
         ) : (
-          <div class="home-empty-hint">
-            No projects yet. <button class="home-empty-action" onClick={onManageProjects}>Add a project</button>
+          <div class="text-[13px] text-text-muted py-4">
+            No projects yet. <button class="bg-transparent border-0 text-accent cursor-pointer p-0 underline underline-offset-[2px] font-inherit" onClick={onManageProjects}>Add a project</button>
           </div>
         )
       )}
@@ -117,7 +117,7 @@ function NotifPrompt({
 }) {
   if (permission === 'default') {
     return (
-      <button class="notif-toggle" onClick={onRequest}>
+      <button class="inline-flex items-center gap-1.5 shrink-0 py-1 px-2.5 border border-border rounded bg-transparent text-text-muted text-[12px] font-[Source_Sans_3] whitespace-nowrap cursor-pointer transition-colors duration-150 hover:border-accent hover:text-text-secondary" onClick={onRequest}>
         <IconBell /> Enable notifications
       </button>
     )
@@ -125,7 +125,7 @@ function NotifPrompt({
   if (permission === 'denied') {
     return (
       <span
-        class="notif-blocked"
+        class="inline-flex items-center shrink-0 text-text-muted cursor-default"
         title="Notifications blocked in browser settings"
       >
         <IconBell muted />
@@ -143,9 +143,9 @@ export function Section({
   children: preact.ComponentChildren
 }) {
   return (
-    <section class="home-section">
-      <h2 class="home-section-title">{title}</h2>
-      <div class="home-section-body">{children}</div>
+    <section class="mb-6">
+      <h2 class="text-[11px] font-semibold uppercase tracking-[0.06em] text-text-muted mb-3">{title}</h2>
+      <div class="flex flex-col gap-1.5">{children}</div>
     </section>
   )
 }
@@ -161,12 +161,12 @@ function HomeFooter() {
   const h = health.value
   if (!h?.version) return null
   return (
-    <footer class="home-footer">
+    <footer class="mt-auto pt-4 border-t border-border text-[11px] text-text-muted leading-[1.5]">
       gmux version {h.version}
       {h.update_available && (
         <>
           {' · '}
-          <a class="home-footer-link" href="https://gmux.app/changelog/" target="_blank">
+          <a class="font-inherit text-accent bg-transparent border-0 p-0 cursor-pointer underline underline-offset-[2px] hover:text-text" href="https://gmux.app/changelog/" target="_blank">
             version {h.update_available} available!
           </a>
         </>

--- a/apps/gmux-web/src/host-suffix.tsx
+++ b/apps/gmux-web/src/host-suffix.tsx
@@ -30,10 +30,10 @@ export function HostSuffix({ peer, leading = true, local = false }: { peer?: str
 
   return (
     <span
-      class={`host-suffix${offline ? ' offline' : ''}`}
+      class={`text-[0.9em] text-text-muted${offline ? ' text-status-disconnected' : ''}`}
       title={`${peer}${status ? ` (${status})` : ''}`}
     >
-      {leading && <span class="host-suffix-sep" aria-hidden="true"> · </span>}{peer}
+      {leading && <span class="opacity-60 mx-[0.1em]" aria-hidden="true"> · </span>}{peer}
     </span>
   )
 }

--- a/apps/gmux-web/src/jump-to-bottom.tsx
+++ b/apps/gmux-web/src/jump-to-bottom.tsx
@@ -36,7 +36,7 @@ export function JumpToBottom({ term }: { term: Terminal | null }) {
   return (
     <button
       type="button"
-      class="jump-to-bottom"
+      class="absolute right-4 bottom-4 z-[5] w-9 h-9 rounded-full border border-border bg-bg-surface text-text cursor-pointer flex items-center justify-center text-lg leading-none shadow-[0_2px_8px_oklch(0%_0_0_/0.35)] transition-all duration-100 hover:bg-[oklch(28%_0.015_250)] active:translate-y-[1px]"
       aria-label="Jump to bottom"
       title="Jump to bottom"
       onClick={() => term.scrollToBottom()}

--- a/apps/gmux-web/src/launcher.tsx
+++ b/apps/gmux-web/src/launcher.tsx
@@ -201,10 +201,10 @@ export function LaunchButton({ className, onLaunch, beforeLaunch, cwd, peer, ses
   }
 
   return (
-    <div class={`launch-container ${className ?? ''}`} ref={containerRef}>
+    <div class={`relative shrink-0 ${className ?? ''}`} ref={containerRef}>
       <button
         ref={btnRef}
-        class={`launch-btn ${isLoading ? 'loading' : ''}`}
+        class={`bg-transparent border-0 text-text-secondary cursor-pointer text-base font-semibold leading-none py-0.5 px-1.5 rounded transition-all duration-150 ease inline-flex items-center justify-center min-w-6 min-h-6 hover:bg-accent hover:text-bg ${isLoading ? 'pointer-events-none' : ''}`}
         title={target.cwd
           ? target.peer ? `New session on ${target.peer} in ${target.cwd}` : `New session in ${target.cwd}`
           : 'New session'}
@@ -219,18 +219,18 @@ export function LaunchButton({ className, onLaunch, beforeLaunch, cwd, peer, ses
       </button>
       {isOpen && menuPos && (
         <div
-          class="launch-inline-menu"
+          class="fixed bg-bg-surface border border-border rounded-lg shadow-[0_8px_24px_rgba(0,0,0,0.4),_0_2px_8px_rgba(0,0,0,0.2)] min-w-[180px] z-[1000] p-1 overflow-hidden"
           style={{ top: menuPos.top, right: menuPos.right }}
         >
           {showTarget && (
             <>
-              <div class="launch-target-line">{formatTarget(target)}</div>
-              <div class="launch-inline-divider" />
+              <div class="pt-1 pb-1 px-2.5 text-[11px] text-text-muted whitespace-nowrap overflow-hidden truncate font-mono">{formatTarget(target)}</div>
+              <div class="h-px bg-border my-1" />
             </>
           )}
           {defLauncher && (
             <button
-              class="launch-inline-item launch-inline-default"
+              class="block w-full py-1.5 px-2.5 bg-transparent border-0 rounded cursor-pointer text-left transition-colors duration-100 text-text text-sm whitespace-nowrap font-medium hover:bg-bg-hover"
               onClick={(e) => { e.stopPropagation(); handleLaunch(defLauncher!.id) }}
             >
               {defLauncher.label}
@@ -239,7 +239,7 @@ export function LaunchButton({ className, onLaunch, beforeLaunch, cwd, peer, ses
           {others.map((l, i) => (
             <button
               key={l.id}
-              class="launch-inline-item"
+              class="block w-full py-1.5 px-2.5 bg-transparent border-0 rounded cursor-pointer text-left transition-colors duration-100 text-text text-sm whitespace-nowrap hover:bg-bg-hover launch-inline-item-animated"
               style={{ animationDelay: `${(i + 1) * 50}ms` }}
               onClick={(e) => { e.stopPropagation(); handleLaunch(l.id) }}
             >

--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -54,8 +54,8 @@ function MainHeader({ session, onRestart }: {
 }) {
   if (!session) {
     return (
-      <div class="main-header">
-        <div class="main-header-title" style={{ color: 'var(--text-muted)' }}>
+      <div class="h-[var(--header-height)] flex items-center justify-between py-0 px-4 gap-3 border-b border-border shrink-0 overflow-visible relative z-[30]">
+        <div class="font-[Source_Sans_3] text-sm font-semibold text-text overflow-hidden text-ellipsis whitespace-nowrap tracking-[-0.01em] flex items-center gap-2" style={{ color: 'var(--text-muted)' }}>
           gmux
         </div>
       </div>
@@ -65,18 +65,18 @@ function MainHeader({ session, onRestart }: {
   const shortCwd = session.cwd.replace(/^\/home\/[^/]+/, '~')
 
   return (
-    <div class="main-header">
-      <div class="main-header-left">
-        <div class="main-header-title">
+    <div class="h-[var(--header-height)] flex items-center justify-between py-0 px-4 gap-3 border-b border-border shrink-0 overflow-visible relative z-[30]">
+      <div class="flex items-center gap-2 min-w-0 overflow-hidden">
+        <div class="font-[Source_Sans_3] text-sm font-semibold text-text overflow-hidden text-ellipsis whitespace-nowrap tracking-[-0.01em] flex items-center gap-2">
           {session.title}
         </div>
-        <div class="main-header-meta">
-          <span class="main-header-cwd">{shortCwd}</span>
+        <div class="flex items-center gap-[5px] text-[12px] text-text-muted">
+          <span class="overflow-hidden text-ellipsis whitespace-nowrap">{shortCwd}</span>
         </div>
       </div>
-      <div class="main-header-right">
+      <div class="flex items-center gap-2 shrink-0">
         {session.status && session.status.label && (
-          <div class={`main-header-status ${session.status.error ? 'error' : session.status.working ? 'working' : ''}`}>
+          <div class={`flex items-center gap-[5px] text-[12px] font-medium whitespace-nowrap shrink-0 ${session.status.error ? 'text-status-error' : session.status.working ? 'text-accent' : 'text-text-secondary'}`}>
             <span
               class={`session-dot ${session.status.error ? 'error' : session.status.working ? 'working' : 'idle'}`}
               style={{ width: 5, height: 5 }}
@@ -133,45 +133,45 @@ function SessionMenu({ session, onRestart }: {
   const hasActions = session.alive && onRestart
 
   return (
-    <div class="session-menu" ref={menuRef}>
+    <div class="relative" ref={menuRef}>
       <button
-        class={`session-menu-trigger${staleKind ? ' stale' : ''}`}
+        class={`relative w-[26px] h-[26px] border-0 rounded bg-transparent text-text-muted cursor-pointer flex items-center justify-center transition-colors duration-100 shrink-0 hover:bg-bg-hover hover:text-text${staleKind ? ' text-[oklch(80%_0.15_65)] hover:bg-[oklch(80%_0.15_65_/0.08)] hover:text-[oklch(88%_0.15_65)]' : ''}`}
         onClick={() => setOpen(!open)}
         title="Session actions"
         aria-expanded={open}
       >
-        <span class="session-menu-icon">⋮</span>
-        {staleKind && <span class="session-menu-badge" />}
+        <span class="text-base leading-none tracking-normal">⋮</span>
+        {staleKind && <span class="absolute top-[3px] right-[3px] w-1.5 h-1.5 rounded-full bg-[oklch(80%_0.15_65)] border-[1.5px] border-bg pointer-events-none" />}
       </button>
       {open && (
-        <div class="session-menu-dropdown">
+        <div class="absolute top-[calc(100%+4px)] right-0 min-w-[200px] bg-bg-surface border border-border-strong rounded py-1 shadow-[0_8px_24px_oklch(0%_0_0_/0.4)] z-[100]">
           {hasActions && (
             <>
               <button
-                class={`session-menu-action${staleKind ? ' stale' : ''}`}
+                class={`flex items-center justify-between w-full py-2 px-3 text-sm ${staleKind ? 'text-[oklch(80%_0.15_65)] hover:bg-[oklch(80%_0.15_65_/0.08)] hover:text-[oklch(88%_0.15_65)]' : 'text-text-secondary hover:bg-bg-hover hover:text-text'} bg-transparent border-0 cursor-pointer transition-colors duration-100 text-left`}
                 onClick={() => { setOpen(false); onRestart!() }}
               >
                 Restart session
-                {staleKind && <span class="session-menu-action-tag">outdated</span>}
+                {staleKind && <span class="text-[10px] font-medium tracking-[0.04em] px-1 py-0 rounded-[3px] bg-[oklch(80%_0.15_65_/0.15)] text-[oklch(80%_0.15_65)] whitespace-nowrap">outdated</span>}
               </button>
-              <div class="session-menu-divider" />
+              <div class="h-px bg-border my-1" />
             </>
           )}
-          <div class="session-menu-section-title">Session info</div>
-          <div class="session-menu-row">
-            <span class="session-menu-label">Adapter</span>
-            <span class="session-menu-value">{session.kind}</span>
+          <div class="text-[11px] font-semibold uppercase tracking-[0.06em] text-text-muted py-1.5 pb-[2px] px-3">Session info</div>
+          <div class="flex justify-between items-baseline py-1 px-3">
+            <span class="text-[13px] text-text-muted">Adapter</span>
+            <span class="font-mono text-[11px] text-text-secondary">{session.kind}</span>
           </div>
-          <div class="session-menu-row">
-            <span class="session-menu-label">Version</span>
-            <span class={`session-menu-value${staleKind ? ' stale' : ''}`}>
+          <div class="flex justify-between items-baseline py-1 px-3">
+            <span class="text-[13px] text-text-muted">Version</span>
+            <span class={`font-mono text-[11px]${staleKind ? ' text-[oklch(80%_0.15_65)]' : ' text-text-secondary'}`}>
               {versionDisplay}
             </span>
           </div>
           {session.peer && (
-            <div class="session-menu-row">
-              <span class="session-menu-label">Host</span>
-              <span class="session-menu-value">{session.peer}</span>
+            <div class="flex justify-between items-baseline py-1 px-3">
+              <span class="text-[13px] text-text-muted">Host</span>
+              <span class="font-mono text-[11px] text-text-secondary">{session.peer}</span>
             </div>
           )}
         </div>
@@ -490,7 +490,7 @@ function App() {
   const handleAltConsumed = useCallback(() => { setAltArmed(false) }, [])
 
   return (
-    <div class="app-layout">
+    <div class="flex h-[100vh] h-[100dvh] h-[var(--app-height,_100dvh)] w-full">
       <Sidebar
         resumingId={resumingId}
         onCloseSession={handleCloseSession}
@@ -506,7 +506,7 @@ function App() {
         onSelectTab={(t) => openSettings(t, true)}
       />
 
-      <div class="main-panel">
+      <div class="flex-1 flex flex-col min-w-0 min-h-0 bg-bg">
         {viewVal !== null && viewVal.kind !== 'project' && viewVal.kind !== 'home' && (
           <MainHeader
             session={selectedVal}

--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -490,7 +490,7 @@ function App() {
   const handleAltConsumed = useCallback(() => { setAltArmed(false) }, [])
 
   return (
-    <div class="flex h-[100vh] h-[100dvh] h-[var(--app-height,_100dvh)] w-full">
+    <div class="app-layout">
       <Sidebar
         resumingId={resumingId}
         onCloseSession={handleCloseSession}

--- a/apps/gmux-web/src/peer-label.tsx
+++ b/apps/gmux-web/src/peer-label.tsx
@@ -10,7 +10,7 @@ export function PeerLabel({ name }: { name: string }) {
   const a = peerAppearance.value.get(name)
   const status = peerStatusByName.value.get(name)
   const connected = status === 'connected'
-  const cls = `session-peer-label${connected ? '' : ' offline'}`
+  const cls = `flex-shrink-0 self-center inline-flex items-center justify-center w-3.5 h-3.5 rounded-[3px] text-[9px] font-semibold leading-[1cap] bg-[oklch(25%_0.04_250)] text-[oklch(72%_0.08_250)]${connected ? '' : ' opacity-40 line-through'}`
   return (
     <span
       class={cls}

--- a/apps/gmux-web/src/project-hub.tsx
+++ b/apps/gmux-web/src/project-hub.tsx
@@ -93,13 +93,13 @@ export function ProjectHub({ projectSlug, projectPeer, onCloseSession }: Project
 
   return (
     <div class="page">
-      <header class="hub-header">
-        <a class="hub-back" href="/" aria-label="Back to home">
-          <span class="hub-back-arrow" aria-hidden="true">←</span>
+      <header class="mb-5">
+        <a class="inline-flex items-center gap-1 text-[11px] font-semibold uppercase tracking-[0.06em] text-text-muted no-underline mb-1 transition-colors duration-120 hover:text-text focus-visible:text-text" href="/" aria-label="Back to home">
+          <span class="text-[13px] leading-none" aria-hidden="true">←</span>
           Home
         </a>
-        <div class="hub-title-row">
-          <h2 class="hub-title">
+        <div class="flex items-baseline justify-between gap-3">
+          <h2 class="text-lg font-semibold text-text m-0">
             {projectSlug}
             <HostSuffix peer={projectPeer ?? localHostLabel.value} local={!projectPeer} />
           </h2>
@@ -107,14 +107,14 @@ export function ProjectHub({ projectSlug, projectPeer, onCloseSession }: Project
             sessions={allSessions}
             fallbackCwd={sharedCwd ?? projectFirstPath(project) ?? ''}
             peer={projectPeer}
-            className="hub-header-launch"
+            className="shrink-0"
           />
         </div>
         {(remote || sharedCwd) && (
-          <div class="hub-subtitle">
-            {sharedCwd && <span class="hub-cwd">{sharedCwd}</span>}
-            {remote && sharedCwd && <span class="hub-subtitle-sep"> · </span>}
-            {remote && <span class="hub-remote">{remote}</span>}
+          <div class="text-[12px] text-text-muted mt-1">
+            {sharedCwd && <span class="font-[JetBrains_Mono,_SF_Mono,_monospace] text-[11px]">{sharedCwd}</span>}
+            {remote && sharedCwd && <span class="opacity-60"> · </span>}
+            {remote && <span class="font-[JetBrains_Mono,_SF_Mono,_monospace] text-[11px]">{remote}</span>}
           </div>
         )}
       </header>
@@ -150,7 +150,7 @@ export function ProjectHub({ projectSlug, projectPeer, onCloseSession }: Project
 // duplicate the one above it.
 function EmptyProject({ projectSlug }: { projectSlug: string }) {
   return (
-    <div class="hub-empty">
+    <div class="flex items-center gap-3 py-3.5 px-4 border border-border rounded-lg text-text-muted text-[13px] mt-4">
       <span>No sessions yet in {projectSlug}</span>
     </div>
   )

--- a/apps/gmux-web/src/project-hub.tsx
+++ b/apps/gmux-web/src/project-hub.tsx
@@ -150,7 +150,7 @@ export function ProjectHub({ projectSlug, projectPeer, onCloseSession }: Project
 // duplicate the one above it.
 function EmptyProject({ projectSlug }: { projectSlug: string }) {
   return (
-    <div class="flex items-center gap-3 py-3.5 px-4 border border-border rounded-lg text-text-muted text-[13px] mt-4">
+    <div class="hub-empty flex items-center gap-3 py-3.5 px-4 border border-border rounded-lg text-text-muted text-[13px] mt-4">
       <span>No sessions yet in {projectSlug}</span>
     </div>
   )

--- a/apps/gmux-web/src/session-row.tsx
+++ b/apps/gmux-web/src/session-row.tsx
@@ -99,25 +99,25 @@ export function SessionRow({
     ?? (!session.alive && session.exit_code != null ? `exited (${session.exit_code})` : null)
 
   const cls = [
-    'session-row',
-    selected ? 'selected' : '',
-    unavailable ? 'unavailable' : '',
+    'group flex items-center gap-2.5 py-2.5 px-3 rounded bg-bg-surface border border-border no-underline text-inherit transition-colors duration-100 relative hover:bg-bg-hover hover:border-text-muted',
+    selected ? 'border-accent' : '',
+    unavailable ? 'opacity-[0.55]' : '',
   ].filter(Boolean).join(' ')
 
   // Line-2 metadata segments. Render only the ones requested by
   // props; empty arrays produce no separator dots in the output.
   const metaSegments: preact.ComponentChildren[] = []
   if (showProject && projectName) {
-    metaSegments.push(<span class="session-row-project">{projectName}</span>)
+    metaSegments.push(<span class="text-text opacity-[0.85]">{projectName}</span>)
   }
   if (showCwd && cwdLabel) {
-    metaSegments.push(<span class="session-row-cwd">{cwdLabel}</span>)
+    metaSegments.push(<span class="font-mono">{cwdLabel}</span>)
   }
   if (statusText) {
-    metaSegments.push(<span class="session-row-status">{statusText}</span>)
+    metaSegments.push(<span class="italic">{statusText}</span>)
   }
   if (age) {
-    metaSegments.push(<span class="session-row-age">{age}</span>)
+    metaSegments.push(<span class="tabular-nums">{age}</span>)
   }
 
   return (
@@ -130,15 +130,15 @@ export function SessionRow({
       }}
     >
       {unavailable
-        ? <svg class="session-unavailable-icon" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><title>Peer unavailable</title><path d="M2 2 L10 10 M10 2 L2 10" /></svg>
+        ? <svg class="shrink-0 w-[9px] h-[9px] mt-1 text-text-muted opacity-70" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><title>Peer unavailable</title><path d="M2 2 L10 10 M10 2 L2 10" /></svg>
         : sleeping
-        ? <svg class="session-sleep-icon" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><title>Resumable</title><path d="M7 1h4l-4 4h4" /><path d="M1 5h5l-5 6h5" /></svg>
+        ? <svg class="shrink-0 w-[7px] h-[11px] overflow-visible mt-1 text-text-muted opacity-40" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><title>Resumable</title><path d="M7 1h4l-4 4h4" /><path d="M1 5h5l-5 6h5" /></svg>
         : <span class={`session-dot-indicator ${dot}${arrival ? ` ${arrival}` : ''}`} />
       }
-      <div class="session-row-content">
-        <div class="session-row-title">{session.title}</div>
+      <div class="flex-1 min-w-0">
+        <div class="text-[13px] font-medium text-text whitespace-nowrap overflow-hidden truncate">{session.title}</div>
         {(metaSegments.length > 0 || showHost) && (
-          <div class="session-row-meta">
+          <div class="flex flex-wrap items-baseline mt-1 text-[11px] text-text-muted min-w-0">
             {metaSegments.map((seg, i) => (
               // Long-form Fragment carries a key: the shorthand `<>`
               // can't, and without one Preact falls back to index
@@ -147,7 +147,7 @@ export function SessionRow({
               // happens to be this render), so index is the honest
               // key.
               <Fragment key={i}>
-                {i > 0 && <span class="session-row-sep"> · </span>}
+                {i > 0 && <span class="text-text-muted opacity-60"> · </span>}
                 {seg}
               </Fragment>
             ))}
@@ -157,7 +157,7 @@ export function SessionRow({
       </div>
       {onClose && (
         <button
-          class="session-row-close"
+          class={`session-row-close-btn bg-transparent border-0 text-text-muted text-lg leading-none cursor-pointer py-0.5 px-1.5 rounded transition-colors duration-100 ${selected ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'} hover:text-text hover:bg-bg-active`}
           onClick={(e) => { e.stopPropagation(); e.preventDefault(); onClose() }}
           title={session.alive ? 'Kill session' : 'Dismiss'}
         >

--- a/apps/gmux-web/src/sidebar.tsx
+++ b/apps/gmux-web/src/sidebar.tsx
@@ -395,7 +395,7 @@ export function Sidebar({
           )}
           {connected && isOnlyHomeProject && totalVisible > 0 && (
             <div class="py-3 px-4 text-[12px] text-text-muted leading-[1.4]">
-              <button class="bg-transparent border-0 text-accent font-inherit p-0 cursor-pointer underline underline-offset-[2px] hover:text-text" onClick={onOpenSettings}>
+              <button class="bg-transparent border-0 text-accent font-[inherit] p-0 cursor-pointer underline underline-offset-[2px] hover:text-text" onClick={onOpenSettings}>
                 Add a project
               </button> to organize sessions by repo.
             </div>

--- a/apps/gmux-web/src/sidebar.tsx
+++ b/apps/gmux-web/src/sidebar.tsx
@@ -79,7 +79,7 @@ interface DragState {
  */
 function DevcontainerMarker({ peer }: { peer: string }) {
   return (
-    <svg class="session-container-icon" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round">
+    <svg class="shrink-0 w-2.5 h-2.5 mt-[3px] text-text-muted opacity-80" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round">
       <title>{`devcontainer: ${peer}`}</title>
       <rect x="1.5" y="3.5" width="9" height="6" rx="0.5" />
       <path d="M4 3.5v6 M6 3.5v6 M8 3.5v6" />
@@ -135,11 +135,11 @@ function SessionItem({
   const sleeping = !session.alive && session.resumable
 
   const cls = [
-    'session-item',
+    'session-item group flex items-center py-1 px-1 ps-3.5 cursor-pointer gap-2 transition-colors duration-100 relative no-underline text-inherit',
     selected ? 'selected' : '',
     dragging ? 'session-dragging' : '',
     dropTarget ? 'session-drop-target' : '',
-    unavailable ? 'unavailable' : '',
+    unavailable ? 'opacity-[0.55]' : '',
   ].filter(Boolean).join(' ')
 
   return (
@@ -161,19 +161,19 @@ function SessionItem({
       onDragEnd={onDragEnd}
     >
       {unavailable
-        ? <svg class="session-unavailable-icon" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><title>Peer unavailable</title><path d="M2 2 L10 10 M10 2 L2 10" /></svg>
+        ? <svg class="shrink-0 w-[9px] h-[9px] mt-1 text-text-muted opacity-70" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><title>Peer unavailable</title><path d="M2 2 L10 10 M10 2 L2 10" /></svg>
         : sleeping
-        ? <svg class="session-sleep-icon" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><title>Resumable</title><path d="M7 1h4l-4 4h4" /><path d="M1 5h5l-5 6h5" /></svg>
+        ? <svg class="shrink-0 w-[7px] h-[11px] overflow-visible mt-[3px] text-text-muted opacity-40" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><title>Resumable</title><path d="M7 1h4l-4 4h4" /><path d="M1 5h5l-5 6h5" /></svg>
         : <span class={`session-dot-indicator ${dotState}${arrival ? ` ${arrival}` : ''}`} />
       }
       {showHostMarker && session.peer && <DevcontainerMarker peer={session.peer} />}
-      <div class="session-content">
-        <div class="session-title-row">
-          <span class="session-title">{session.title}</span>
+      <div class="flex-1 min-w-0 flex flex-col gap-[1px]">
+        <div class="flex items-baseline gap-[5px] min-w-0">
+          <span class="text-sm font-normal text-text overflow-hidden text-ellipsis whitespace-nowrap leading-[1.35] flex-1 min-w-0">{session.title}</span>
         </div>
         {session.status?.label && (
-          <div class="session-meta">
-            <span class="session-status-label">{session.status.label}</span>
+          <div class="flex items-center gap-1.5 text-[12px] text-text-muted leading-[1.3]">
+            <span class="text-text-secondary">{session.status.label}</span>
           </div>
         )}
       </div>
@@ -254,9 +254,9 @@ function FolderGroup({
   const mixedHosts = folderPeers.size > 1
   return (
     <div class="folder">
-      <div class="folder-header">
+      <div class={`folder-header flex items-center py-1 px-3 ps-3.5 select-none gap-1.5 cursor-pointer transition-colors duration-100${isCurrent ? ' bg-bg-selected' : ''}`}>
         <a
-          class={`folder-name${isCurrent ? ' current' : ''}${folder.missing ? ' missing' : ''}`}
+          class={`text-[12px] font-semibold text-text flex-1 overflow-hidden text-ellipsis whitespace-nowrap no-underline${folder.missing ? ' opacity-50' : ''}`}
           href={href}
           title={folder.missing
             ? `${folder.name} no longer exists on ${folder.peer}; remove via the home page`
@@ -265,7 +265,7 @@ function FolderGroup({
         >
           {folder.name}
           <HostSuffix peer={folder.peer ?? localHostLabel.value} local={!folder.peer} />
-          {folder.missing && <span class="folder-missing-icon" title="Project missing on peer">?</span>}
+          {folder.missing && <span class="inline-flex items-center justify-center w-3.5 h-3.5 ml-1.5 rounded-full bg-[oklch(25%_0.04_30)] text-[oklch(72%_0.12_30)] text-[10px] font-bold leading-[1cap]" title="Project missing on peer">?</span>}
         </a>
         <LaunchButton
           sessions={folder.sessions}
@@ -275,7 +275,7 @@ function FolderGroup({
           className="folder-launch-btn"
         />
       </div>
-      <div class="folder-sessions">
+      <div class="overflow-hidden pt-[1px]">
         {displayItems.map((s, i) => (
           <SessionItem
             key={s.id}
@@ -350,14 +350,14 @@ export function Sidebar({
     <>
       <div class={`sidebar-overlay ${open ? 'visible' : ''}`} onClick={onClose} />
       <aside class={`sidebar ${open ? 'open' : ''}`}>
-        <div class="sidebar-header">
+        <div class="sidebar-header flex items-center h-[var(--header-height)] py-0 px-1.5 ps-3.5 gap-2.5 shrink-0 border-b border-border">
           <a
-            class={`sidebar-logo${waiting ? ' bg-waiting' : ''}${bgArrival ? ` bg-${bgArrival}` : ''}`}
+            class={`sidebar-logo font-[Instrument_Sans] text-lg font-bold tracking-[-0.04em] text-text leading-none no-underline py-1 px-2.5 pb-1.5 -my-1.5 -mx-2.5 cursor-pointer rounded transition-colors duration-150 hover:text-white hover:shadow-[0_0_6px_rgba(255,255,255,0.25)]${waiting ? ' bg-waiting' : ''}${bgArrival ? ` bg-${bgArrival}` : ''}`}
             href="/"
             onClick={onClose}
           >gmux</a>
           <button
-            class="sidebar-settings-btn"
+            class="ml-auto flex items-center justify-center w-7 h-7 p-0 border-0 bg-transparent text-text-muted rounded cursor-pointer transition-colors duration-150 hover:text-text hover:bg-bg-hover"
             onClick={onOpenSettings}
             aria-label="Settings"
             title="Settings"
@@ -365,7 +365,7 @@ export function Sidebar({
             <IconSettings />
           </button>
         </div>
-        <div class="sidebar-scroll">
+        <div class="sidebar-scroll flex-1 overflow-y-auto overflow-x-hidden py-1.5 pb-12 flex flex-col">
           {foldersVal.map(f => (
             <FolderGroup
               key={f.key}
@@ -380,7 +380,7 @@ export function Sidebar({
             />
           ))}
           {connected && !hasProjects && (
-            <div class="sidebar-empty-launch">
+            <div class="flex justify-center py-4 ps-3.5 pb-1">
               <LaunchButton
                 className="sidebar-launch-btn"
                 beforeLaunch={seedHomeProject}
@@ -389,13 +389,13 @@ export function Sidebar({
             </div>
           )}
           {connected && totalVisible === 0 && !hasProjects && (
-            <div class="sidebar-hint">
-              Click <strong>+</strong> to start your first session.
+            <div class="py-3 px-4 text-[12px] text-text-muted leading-[1.4]">
+              Click <strong class="text-text-secondary">+</strong> to start your first session.
             </div>
           )}
           {connected && isOnlyHomeProject && totalVisible > 0 && (
-            <div class="sidebar-hint">
-              <button class="sidebar-hint-link" onClick={onOpenSettings}>
+            <div class="py-3 px-4 text-[12px] text-text-muted leading-[1.4]">
+              <button class="bg-transparent border-0 text-accent font-inherit p-0 cursor-pointer underline underline-offset-[2px] hover:text-text" onClick={onOpenSettings}>
                 Add a project
               </button> to organize sessions by repo.
             </div>

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -1,14 +1,40 @@
 /* gmux — session orchestration UI */
 
 @import './fonts.css';
+@import 'tailwindcss';
 
-code {
-  font-family: 'Fira Code', monospace;
-  font-size: 0.85em;
-  background: oklch(19% 0.015 250);
-  padding: 0.15em 0.4em;
-  border-radius: 4px;
+/* ── Theme (Tailwind v4 CSS-first configuration) ── */
+
+@theme {
+  /* Surfaces */
+  --color-bg: oklch(12% 0.015 250);
+  --color-bg-sidebar: oklch(16.5% 0.015 250);
+  --color-bg-surface: oklch(19% 0.015 250);
+  --color-bg-hover: oklch(21% 0.015 250);
+  --color-bg-selected: oklch(24% 0.02 250);
+  --color-bg-active: oklch(22% 0.01 250);
+
+  /* Text */
+  --color-text: oklch(90% 0.01 250);
+  --color-text-secondary: oklch(65% 0.01 250);
+  --color-text-muted: oklch(65% 0.01 250);
+
+  /* Borders */
+  --color-border: oklch(32% 0.015 250);
+  --color-border-strong: oklch(38% 0.015 250);
+
+  /* Accent */
+  --color-accent: oklch(72% 0.1 195);
+
+  /* Status */
+  --color-unread: oklch(72% 0.1 195);
+  --color-active: oklch(62% 0.025 250);
+  --color-status-error: oklch(65% 0.18 25);
+  --color-status-connected: oklch(72% 0.14 145);
+  --color-status-disconnected: oklch(65% 0.18 25);
 }
+
+/* ── Design tokens (CSS custom properties) ── */
 
 :root {
   /* Surfaces — widened gaps for clearer distinction */
@@ -17,16 +43,14 @@ code {
   --bg-surface: oklch(19% 0.015 250);
   --bg-hover: oklch(21% 0.015 250);
   --bg-selected: oklch(24% 0.02 250);
+  --bg-active: oklch(22% 0.01 250);
 
   /* Text — 2 tiers; hierarchy from size and weight, not color */
   --text: oklch(90% 0.01 250);
   --text-secondary: oklch(65% 0.01 250);
   --text-muted: oklch(65% 0.01 250);
 
-  /* Borders. Two tiers; the base tier drives dividers, card/button
-   * outlines and scrollbar thumbs, so it needs enough lightness to read
-   * against the near-black surfaces. --border-strong stays ~6pts above
-   * for hover/emphasis separators. */
+  /* Borders */
   --border: oklch(32% 0.015 250);
   --border-strong: oklch(38% 0.015 250);
 
@@ -44,14 +68,13 @@ code {
   --status-connected: oklch(72% 0.14 145);
   --status-disconnected: oklch(65% 0.18 25);
 
-  /* Radii */
-  --radius-lg: 10px;
-
   /* Sizing */
   --sidebar-width: 272px;
   --header-height: 44px;
   --radius: 6px;
 }
+
+/* ── Base resets ── */
 
 * {
   margin: 0;
@@ -74,291 +97,29 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
-/* ── Layout ── */
-
-.app-layout {
-  display: flex;
-  height: 100vh;
-  height: 100dvh;
-  height: var(--app-height, 100dvh);
-  width: 100%;
-}
-
-/* ── Sidebar ── */
-
-.sidebar {
-  width: var(--sidebar-width);
-  min-width: var(--sidebar-width);
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-  background: var(--bg-sidebar);
-  border-right: 1px solid var(--border);
-  overflow: hidden;
-}
-
-.sidebar-header {
-  display: flex;
-  align-items: center;
-  height: var(--header-height);
-  padding: 0 6px 0 14px;
-  gap: 10px;
-  flex-shrink: 0;
-  border-bottom: 1px solid var(--border);
-}
-
-.sidebar-logo {
-  font-family: 'Instrument Sans', sans-serif;
-  font-size: 18px;
-  font-weight: 700;
-  letter-spacing: -0.04em;
-  color: var(--text);
-  line-height: 1;
-  text-decoration: none;
-  padding: 4px 10px 6px 10px;
-  margin: -6px -10px;
-  cursor: pointer;
-  border-radius: 6px;
-  transition: color 0.15s, background 0.15s, text-shadow 0.15s;
-}
-.sidebar-logo:hover {
-  color: #fff;
-  text-shadow: 0 0 6px rgba(255, 255, 255, 0.25);
-}
-
-/* Settings gear, pinned opposite the logo in the header. */
-.sidebar-settings-btn {
-  margin-left: auto;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 28px;
-  height: 28px;
-  padding: 0;
-  border: none;
-  background: transparent;
-  color: var(--text-muted);
-  border-radius: 6px;
-  cursor: pointer;
-  transition: color 0.15s, background 0.15s;
-}
-.sidebar-settings-btn:hover {
-  color: var(--text);
-  background: var(--bg-hover);
-}
-
-/* Empty-state launch affordance: when there are no projects yet, the
- * launch button lives in the sidebar body (not the header, which is
- * now logo + gear). Sits just above the first-session hint. */
-.sidebar-empty-launch {
-  display: flex;
-  justify-content: center;
-  padding: 16px 14px 4px;
-}
-
-/* Waiting dot on the logo. Only the waiting state is surfaced (see the
-   mobile hamburger badge, which uses the same single-state treatment),
-   rendered as an in-flow dot to the RIGHT of the wordmark.
-
-   Alignment: the wordmark is all-lowercase, so its optical midline sits
-   at baseline + ½·x-height rather than the line-box center. `vertical-
-   align: middle` is defined as exactly that point ("midpoint of the box
-   with the baseline plus half the x-height"), so the dot tracks the
-   text's visual centre in font metrics — no pixel nudging, and it scales
-   with the font. This needs an inline (not flex) context, hence the
-   inline-block dot and margin-left for the gap. */
-.sidebar-logo.bg-waiting::after {
-  content: '';
-  display: inline-block;
-  vertical-align: middle;
-  width: 8px;
-  height: 8px;
-  margin-left: 7px;
-  border-radius: 50%;
-  background: var(--unread);
-}
-
-/* Re-blink when a new session enters the waiting state */
-.sidebar-logo.bg-arriving::after {
-  animation: dot-arrival 520ms cubic-bezier(0.25, 1, 0.5, 1) both;
-}
-
-.sidebar-scroll {
-  flex: 1;
-  overflow-y: auto;
-  overflow-x: hidden;
-  /* Generous bottom padding so the last row clears the viewport edge:
-   * the extra whitespace is the visual cue that the user has actually
-   * reached the end of the list (rather than wondering whether more
-   * content is hidden by the fold). */
-  padding: 6px 0 48px;
-  display: flex;
-  flex-direction: column;
-}
-
-.sidebar-scroll::-webkit-scrollbar {
-  width: 3px;
-}
-
-.sidebar-scroll::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-.sidebar-scroll::-webkit-scrollbar-thumb {
-  background: var(--border);
-  border-radius: 2px;
-}
-
-/* ── Folder ── */
-
-.folder + .folder {
-  margin-top: 4px;
-  padding-top: 4px;
-  position: relative;
-}
-/* Inset divider between project groups. Pulled in to the content's left
- * padding (14px) rather than spanning edge-to-edge, so the list reads as
- * grouped rows instead of a hard grid. The header keeps its full-width
- * border as a stronger zone boundary. */
-.folder + .folder::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 14px;
-  right: 14px;
-  border-top: 1px solid var(--border);
-}
-
-.folder-header {
-  display: flex;
-  align-items: center;
-  padding: 5px 12px 5px 14px;
-  user-select: none;
-  gap: 6px;
-  cursor: pointer;
-  transition: background 0.1s;
-}
-.folder-header:hover {
-  background: var(--bg-hover);
-}
-.folder-header.current {
-  background: var(--bg-selected);
-}
-
-/* ── Launch button + inline menu ── */
-
-.launch-container {
-  position: relative;
-  flex-shrink: 0;
-}
-
-.launch-container.sidebar-launch-btn {
-  margin-left: auto;
-}
-
-.launch-container.folder-launch-btn {
-  margin-left: auto;
-  opacity: 0;
-  transition: opacity 0.1s;
-}
-
-.folder-header:hover .launch-container.folder-launch-btn,
-.launch-container.folder-launch-btn:has(.loading) {
-  opacity: 1;
-}
-
-.launch-btn {
-  background: none;
-  border: none;
-  color: var(--text-secondary);
-  cursor: pointer;
-  font-size: 16px;
-  font-weight: 600;
-  line-height: 1;
-  padding: 2px 6px;
-  border-radius: 4px;
-  transition: all 0.15s ease;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 24px;
-  min-height: 24px;
-}
-
-.launch-btn:hover {
-  background: var(--accent);
-  color: var(--bg);
-}
-
-.launch-btn.loading {
-  pointer-events: none;
-}
-
-.spin {
-  animation: spin 0.8s linear infinite;
-}
+/* ── Animations ── */
 
 @keyframes spin {
   to { transform: rotate(360deg); }
 }
 
-/* Inline menu — fixed-positioned by JS so it escapes overflow:hidden parents */
-.launch-inline-menu {
-  position: fixed;
-  background: var(--bg-surface);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4), 0 2px 8px rgba(0, 0, 0, 0.2);
-  min-width: 180px;
-  z-index: 1000;
-  padding: 4px;
-  overflow: hidden;
+@keyframes subtle-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.35; }
 }
 
-.launch-target-line {
-  padding: 5px 10px 4px;
-  font-size: 11px;
-  color: var(--text-muted);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  font-family: 'Fira Code', monospace;
+@keyframes dot-fade-out {
+  from { opacity: 1; }
+  to   { opacity: 0; }
 }
 
-.launch-inline-item {
-  display: block;
-  width: 100%;
-  padding: 6px 10px;
-  background: none;
-  border: none;
-  border-radius: 6px;
-  cursor: pointer;
-  text-align: left;
-  transition: background 0.1s ease;
-  color: var(--text);
-  font-size: 14px;
-  white-space: nowrap;
-}
-
-.launch-inline-item:hover {
-  background: var(--bg-hover);
-}
-
-/* Default item renders instantly — no animation */
-.launch-inline-default {
-  font-weight: 500;
-}
-
-.launch-inline-divider {
-  height: 1px;
-  background: var(--border);
-  margin: 4px 0;
-}
-
-/* Non-default items fade in with stagger */
-.launch-inline-item:not(.launch-inline-default) {
-  opacity: 0;
-  animation: launch-item-in 0.12s ease-out forwards;
+@keyframes dot-arrival {
+  0%   { transform: scale(1);   box-shadow: 0 0 0 0 transparent; }
+  12%  { transform: scale(0.6); box-shadow: 0 0 0 0 transparent; }
+  42%  { transform: scale(1.9); box-shadow: 0 0 6px 2px oklch(72% 0.1 195 / 0.45); }
+  62%  { transform: scale(0.95); box-shadow: 0 0 3px 1px oklch(72% 0.1 195 / 0.2); }
+  80%  { transform: scale(1.08); box-shadow: 0 0 0 0 transparent; }
+  100% { transform: scale(1);   box-shadow: 0 0 0 0 transparent; }
 }
 
 @keyframes launch-item-in {
@@ -366,78 +127,71 @@ body {
   to { opacity: 1; transform: translateY(0); }
 }
 
-.folder-name {
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--text);
-  flex: 1;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  text-decoration: none;
+@keyframes modal-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
 }
 
-
-
-.folder-sessions {
-  overflow: hidden;
-  padding-top: 1px;
+@keyframes modal-slide-in {
+  from { opacity: 0; transform: translateY(8px) scale(0.98); }
+  to   { opacity: 1; transform: translateY(0) scale(1); }
 }
 
-/* ── Host suffix (project headers) ── */
-.host-suffix {
+/* ── Reduced motion ── */
+@media (prefers-reduced-motion: reduce) {
+  .session-dot-indicator.arriving,
+  .mobile-bottom-action.menu-btn.bg-arriving::after,
+  .sidebar-logo.bg-arriving::after {
+    animation: none !important;
+  }
+  .session-dot-indicator.working,
+  .session-dot-indicator.active,
+  .session-dot-indicator.fading,
+  .session-dot-indicator.error {
+    animation: none !important;
+  }
+}
+
+/* ── xterm.js overrides ── */
+
+/* Use JetBrains Mono for italic glyphs since Fira Code has no italic variant */
+@font-face {
+  font-family: 'Fira Code';
+  font-style: italic;
   font-weight: 400;
-  font-size: 0.9em;
-  color: var(--text-muted);
+  src: local('JetBrains Mono Italic'), local('JetBrainsMono-Italic'),
+       url('@fontsource/jetbrains-mono/files/jetbrains-mono-latin-400-italic.woff2') format('woff2');
 }
-.host-suffix.offline {
-  color: var(--status-disconnected);
-}
-.host-suffix-sep {
-  opacity: 0.6;
-  margin: 0 0.1em;
-}
-
-/* ── Session Item ── */
-
-.session-item {
-  display: flex;
-  align-items: center;
-  padding: 5px 5px 5px 14px;
-  cursor: pointer;
-  gap: 8px;
-  transition: background 0.1s;
-  position: relative;
-  text-decoration: none;
-  color: inherit;
+@font-face {
+  font-family: 'Fira Code';
+  font-style: italic;
+  font-weight: 500;
+  src: local('JetBrains Mono Medium Italic'), local('JetBrainsMono-MediumItalic'),
+       url('@fontsource/jetbrains-mono/files/jetbrains-mono-latin-500-italic.woff2') format('woff2');
 }
 
-.session-item:hover {
-  background: var(--bg-hover);
+.terminal-container .xterm {
+  width: max-content;
+  min-width: 100%;
+  min-height: 100%;
+  padding: 0 6px 6px 6px;
+  margin: 0 auto;
 }
 
-.session-item.selected {
-  background: var(--bg-selected);
+/* Hide xterm's native scrollbar — scrollback is handled by the PTY replay buffer */
+.terminal-container .xterm-viewport {
+  overflow-y: hidden !important;
+  background-color: transparent !important;
 }
 
-.session-item.selected::before {
-  content: '';
-  position: absolute;
-  left: 0;
-  top: 4px;
-  bottom: 4px;
-  width: 2px;
-  background: var(--accent);
-  border-radius: 0 1px 1px 0;
-}
+/* ── Custom components (animations, pseudo-elements) ── */
 
-/* Status dot — left of title, vertically centered on first line */
+/* Status dot indicator */
 .session-dot-indicator {
   flex-shrink: 0;
   width: 7px;
   height: 7px;
   border-radius: 50%;
-
 }
 
 .session-dot-indicator.working {
@@ -467,390 +221,373 @@ body {
   animation: subtle-pulse 2.5s ease-in-out infinite;
 }
 
-/* Arrival pulse — plays once when a dot transitions from working→unread.
-   Premove (squish inward) → burst (overshoot outward with glow) → settle. */
 .session-dot-indicator.arriving {
   animation: dot-arrival 520ms cubic-bezier(0.25, 1, 0.5, 1) both;
 }
 
-@keyframes dot-arrival {
-  0%   { transform: scale(1);   box-shadow: 0 0 0 0 transparent; }
-  12%  { transform: scale(0.6); box-shadow: 0 0 0 0 transparent; }
-  42%  { transform: scale(1.9); box-shadow: 0 0 6px 2px oklch(72% 0.1 195 / 0.45); }
-  62%  { transform: scale(0.95); box-shadow: 0 0 3px 1px oklch(72% 0.1 195 / 0.2); }
-  80%  { transform: scale(1.08); box-shadow: 0 0 0 0 transparent; }
-  100% { transform: scale(1);   box-shadow: 0 0 0 0 transparent; }
-}
-
-/* Invisible placeholder to keep alignment when no dot */
 .session-dot-indicator.none {
   visibility: hidden;
 }
 
-.session-sleep-icon {
-  flex-shrink: 0;
-  width: 7px;  /* match dot indicator for title alignment */
-  height: 11px;
-  overflow: visible; /* SVG renders at natural aspect ratio beyond 7px */
-  margin-top: 3px;
-  color: var(--text-muted);
-  opacity: 0.4;
-}
-
-/* Session lives on a peer we can't reach right now (the peer is
-   disconnected or unknown). Dim the row and replace the activity dot
-   with a muted X so the user knows clicking won't reach the session. */
-.session-item.unavailable {
-  opacity: 0.55;
-}
-.session-item.unavailable.selected {
-  opacity: 0.85;
-}
-.session-unavailable-icon {
-  flex-shrink: 0;
-  width: 9px;
-  height: 9px;
-  margin-top: 4px;
-  color: var(--text-muted);
-  opacity: 0.7;
-}
-
-/* Per-row marker shown only in folders that span multiple hosts
-   (currently: parent-local + devcontainer). In single-host folders
-   the marker is absent entirely. */
-.session-container-icon {
-  flex-shrink: 0;
-  width: 10px;
-  height: 10px;
-  margin-top: 3px;
-  color: var(--text-muted);
-  opacity: 0.8;
-}
-
-
-.session-content {
-  flex: 1;
-  min-width: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 1px;
-}
-
-.session-title-row {
-  display: flex;
-  align-items: baseline;
-  gap: 5px;
-  min-width: 0;
-}
-
-.session-title {
-  font-size: 14px;
-  font-weight: 400;
-  color: var(--text);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  line-height: 1.35;
-  flex: 1;
-  min-width: 0;
-}
-
-.session-meta {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  font-size: 12px;
-  color: var(--text-muted);
-  line-height: 1.3;
-}
-
-/* Peer label: single-letter badge for remote hosts.
-   Height matches the adjacent title font size (14px) so baseline
-   alignment keeps the badge centered with the text naturally. */
-/* Peer label: sized to match adjacent 14px title text.
-   1cap line-height trims font leading so the glyph sits at optical center. */
-.session-peer-label {
-  flex-shrink: 0;
-  align-self: center;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 14px;
-  height: 14px;
-  border-radius: 3px;
-  font-size: 9px;
-  font-weight: 600;
-  line-height: 1cap;
-  /* Default fallback; overridden by inline style when peer appearance is available */
-  background: oklch(25% 0.04 250);
-  color: oklch(72% 0.08 250);
-}
-.session-peer-label.offline {
-  opacity: 0.4;
-  /* Cross-out: peer is unreachable, the chip stops claiming activity. */
-  text-decoration: line-through;
-}
-.folder-name.missing {
-  opacity: 0.5;
-}
-.folder-missing-icon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 14px;
-  height: 14px;
-  margin-left: 6px;
+/* Waiting dot on the logo */
+.sidebar-logo.bg-waiting::after {
+  content: '';
+  display: inline-block;
+  vertical-align: middle;
+  width: 8px;
+  height: 8px;
+  margin-left: 7px;
   border-radius: 50%;
-  background: oklch(25% 0.04 30);
-  color: oklch(72% 0.12 30);
-  font-size: 10px;
-  font-weight: 700;
-  line-height: 1cap;
-}
-.session-status-label {
-  color: var(--text-secondary);
+  background: var(--unread);
 }
 
-@keyframes subtle-pulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.35; }
+.sidebar-logo.bg-arriving::after {
+  animation: dot-arrival 520ms cubic-bezier(0.25, 1, 0.5, 1) both;
 }
 
-@keyframes dot-fade-out {
-  from { opacity: 1; }
-  to   { opacity: 0; }
-}
-
-/* ── Close button on session items ── */
-.session-close-btn {
+/* Waiting dot on the mobile hamburger */
+.mobile-bottom-action.menu-btn.bg-waiting::after {
+  content: '';
   position: absolute;
-  right: 4px;
-  top: 50%;
-  transform: translateY(-50%);
-  width: 20px;
-  height: 20px;
-  opacity: 0;
-  border: none;
-  border-radius: 4px;
-  background: transparent;
-  color: var(--text-muted);
-  font-size: 14px;
-  line-height: 1;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: background 0.1s, color 0.1s, opacity 0.15s;
-  padding: 0;
-}
-.session-item:hover .session-close-btn,
-.session-item.selected .session-close-btn {
-  opacity: 1;
-  background: oklch(22% 0.01 250 / 0.45);
-}
-.session-close-btn:hover {
-  background: oklch(28% 0.015 250) !important;
-  color: var(--text);
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  top: -3px;
+  right: -3px;
+  pointer-events: none;
+  background: var(--unread);
+  box-shadow: 0 0 0 1.5px var(--bg-base);
 }
 
-/* Mock mode (landing page screenshots): hide per-session close
- * buttons. Previously chained to the .session-dragging rule below
- * via a stray comma, so mock mode left them at opacity 0.4 instead
- * of hiding them. Both the compact sidebar item (.session-close-btn)
- * and the wide dashboard row (.session-row-close) need hiding so
- * neither variant leaks into screenshots. */
+.mobile-bottom-action.menu-btn.bg-arriving::after {
+  animation: dot-arrival 520ms cubic-bezier(0.25, 1, 0.5, 1) both;
+}
+
+/* ── Scrollbar styling ── */
+
+.sidebar-scroll::-webkit-scrollbar {
+  width: 3px;
+}
+
+.sidebar-scroll::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.sidebar-scroll::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 2px;
+}
+
+.modal-body::-webkit-scrollbar {
+  width: 3px;
+}
+
+.modal-body::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.modal-body::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 2px;
+}
+
+.mp-discovered-scroll::-webkit-scrollbar {
+  width: 3px;
+}
+
+.mp-discovered-scroll::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.mp-discovered-scroll::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 2px;
+}
+
+/* ── Mock mode ── */
+
 .mock-mode .session-close-btn,
 .mock-mode .session-row-close {
-  display: none;
+  display: none !important;
 }
 
-/* Session drag-to-reorder */
-.session-item.session-dragging {
-  opacity: 0.4;
-}
-.session-item.session-drop-target {
-  box-shadow: inset 0 -2px 0 0 var(--accent);
+/* ── Touch device adjustments ── */
+
+@media (hover: none) {
+  .session-row-close-btn {
+    opacity: 1 !important;
+  }
+  .launch-container.folder-launch-btn {
+    opacity: 1 !important;
+  }
+  .session-close-btn {
+    opacity: 1 !important;
+  }
+  .mp-configured-remove {
+    opacity: 1 !important;
+  }
 }
 
-/* ── Wide session row (dashboard / project page) ────────────────────── */
-/* Two-line variant of the sidebar's SessionItem. Same dot conventions
-   and close-button behavior; line 2 carries optional project / cwd /
-   status / age metadata. The host suffix uses the existing
-   .host-suffix styling. */
+/* ── Terminal ── */
 
-.session-row {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 10px 12px;
-  border-radius: 6px;
-  background: var(--bg-surface);
-  border: 1px solid var(--border);
-  text-decoration: none;
-  color: inherit;
-  transition: background 0.1s, border-color 0.15s;
-  position: relative;
-}
-.session-row:hover {
-  background: var(--bg-hover);
-  border-color: var(--text-muted);
-}
-.session-row.selected {
-  border-color: var(--accent);
-}
-.session-row.unavailable {
-  opacity: 0.55;
-}
-
-.session-row-content {
+.terminal-shell {
   flex: 1;
-  min-width: 0;
+  min-height: 0;
+  position: relative;
+  overflow: auto;
+  background: #0f141a;
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
 }
 
-.session-row-title {
+.terminal-shell-passive {
+  touch-action: none;
+}
+
+.terminal-container {
+  min-width: 100%;
+  min-height: 100%;
+  position: relative;
+  overflow: visible;
+  background: #0f141a;
+}
+
+/* ── Terminal resize overlay ── */
+
+.terminal-resize-anchor {
+  position: sticky;
+  top: 0;
+  height: 0;
+  overflow: visible;
+  display: flex;
+  justify-content: center;
+  z-index: 12;
+  pointer-events: none;
+}
+
+.terminal-resize-overlay {
+  pointer-events: auto;
+  position: relative;
+  top: 12px;
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  max-width: min(calc(100% - 24px), 460px);
+  padding: 2.5px 4px;
+  border: 1px solid color-mix(in oklch, var(--accent) 22%, var(--border-strong));
+  border-radius: 999px;
+  background: color-mix(in oklch, var(--bg-sidebar) 76%, #0f141a 24%);
+  color: color-mix(in oklch, var(--text) 88%, var(--accent));
+  box-shadow: 0 8px 24px oklch(0% 0 0 / 0.28);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  font: inherit;
+  font-size: 13px;
+  line-height: 1;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  white-space: nowrap;
+  appearance: none;
+}
+
+.terminal-resize-overlay:hover {
+  background: color-mix(in oklch, var(--bg-sidebar) 68%, var(--accent) 12%);
+  border-color: color-mix(in oklch, var(--accent) 34%, var(--border-strong));
+  color: var(--text);
+}
+
+.terminal-resize-overlay:focus-visible {
+  outline: none;
+  border-color: color-mix(in oklch, var(--accent) 50%, var(--border-strong));
+  box-shadow:
+    0 0 0 1px color-mix(in oklch, var(--accent) 45%, transparent),
+    0 8px 24px oklch(0% 0 0 / 0.28);
+}
+
+.terminal-disconnected-pill {
+  pointer-events: none;
+  position: relative;
+  top: 12px;
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  max-width: min(calc(100% - 24px), 460px);
+  padding: 2.5px 4px;
+  border: 1px solid oklch(0.45 0.12 20 / 0.5);
+  border-radius: 999px;
+  background: oklch(0.22 0.06 20 / 0.88);
+  color: oklch(0.78 0.1 20);
+  box-shadow:
+    0 8px 24px oklch(0% 0 0 / 0.28),
+    0 0 12px oklch(0.5 0.15 20 / 0.12);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  font: inherit;
+  font-size: 13px;
+  line-height: 1;
+  letter-spacing: 0.01em;
+  white-space: nowrap;
+}
+
+.terminal-loading {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: start;
+  justify-content: center;
+  padding-top: 25%;
+  gap: 2px;
+  background: oklch(from #0f141a l c h / 0.85);
+  color: var(--text-muted);
+  font-size: 14px;
+  z-index: 10;
+}
+
+.terminal-scroll-end {
+  position: absolute;
+  bottom: 3px;
+  right: 4px;
+  padding: 2px 3px;
+  border-radius: 8px;
+  border: 1px solid oklch(from var(--border-strong) l c h / 0.7);
+  background: oklch(from var(--bg-surface) l c h / 0.38);
+  color: oklch(76% 0.012 250 / 0.85);
+  font-size: 13px;
+  font-family: 'Source Sans 3', sans-serif;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  z-index: 20;
+  transition: opacity 0.15s, background 0.15s, color 0.15s;
+  pointer-events: auto;
+}
+
+.terminal-scroll-end:hover {
+  background: oklch(from var(--bg-surface) l c h / 0.92);
+  color: oklch(76% 0.012 250);
+}
+
+/* ── Buttons ── */
+
+.btn {
+  font-family: 'Source Sans 3', sans-serif;
   font-size: 13px;
   font-weight: 500;
-  color: var(--text);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.session-row-meta {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: baseline;
-  margin-top: 3px;
-  font-size: 11px;
-  color: var(--text-muted);
-  min-width: 0;
-}
-.session-row-sep {
-  color: var(--text-muted);
-  opacity: 0.6;
-}
-.session-row-project {
-  color: var(--text);
-  opacity: 0.85;
-}
-.session-row-cwd {
-  font-family: var(--font-mono, monospace);
-}
-.session-row-status {
-  font-style: italic;
-}
-.session-row-age {
-  font-variant-numeric: tabular-nums;
-}
-
-.session-row-close {
-  background: none;
-  border: none;
-  color: var(--text-muted);
-  font-size: 18px;
-  line-height: 1;
-  cursor: pointer;
-  padding: 2px 6px;
+  padding: 5px 12px;
   border-radius: 4px;
-  opacity: 0;
-  transition: opacity 0.1s, color 0.1s, background 0.1s;
-}
-.session-row:hover .session-row-close,
-.session-row.selected .session-row-close {
-  opacity: 1;
-}
-.session-row-close:hover {
+  border: 1px solid var(--border);
+  background: var(--bg-surface);
   color: var(--text);
-  background: var(--bg-active);
-}
-@media (hover: none) {
-  .session-row-close { opacity: 1; }
-}
-
-/* On touch devices (no hover), show interactive buttons permanently */
-@media (hover: none) {
-  .launch-container.folder-launch-btn { opacity: 1; }
-  .session-close-btn { opacity: 1; }
-}
-
-/* ── Sidebar empty state ── */
-.sidebar-hint {
-  padding: 12px 16px;
-  font-size: 12px;
-  color: var(--text-muted);
-  line-height: 1.4;
-}
-
-.sidebar-hint strong {
-  color: var(--text-secondary);
-}
-
-.sidebar-hint-link {
-  background: none;
-  border: none;
-  color: var(--accent);
-  font: inherit;
-  padding: 0;
   cursor: pointer;
-  text-decoration: underline;
-  text-underline-offset: 2px;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
 }
 
-.sidebar-hint-link:hover {
-  color: var(--text-primary);
+.btn:hover {
+  background: oklch(24% 0.015 250);
+  border-color: var(--border-strong);
 }
 
-/* ── Notification prompt (home dashboard) ── */
-/* Activity header row: title left, notification affordance right. Uses
-   center alignment (not the baseline alignment of the shared
-   .hub-title-row) so the bordered button's box centers against the
-   heading rather than sitting on its baseline. */
-.home-activity-header {
+.btn-primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: oklch(13% 0.015 250);
+  font-weight: 600;
+}
+
+.btn-primary:hover {
+  background: oklch(78% 0.1 195);
+  border-color: oklch(78% 0.1 195);
+}
+
+.btn:disabled,
+.btn-primary:disabled {
+  opacity: 0.6;
+  cursor: progress;
+}
+
+/* ── Page ── */
+
+.page {
+  flex: 1;
+  min-width: 0;
+  overflow-y: auto;
+  padding: 32px clamp(16px, 4vw, 32px) 48px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.page > * {
+  width: 100%;
+  max-width: 640px;
+}
+
+/* ── Replay ── */
+
+.replay-root {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.replay-root > .terminal-shell {
+  flex: 1;
+  min-height: 0;
+}
+
+.replay-actions {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
+  gap: 3px;
+  padding: 2px 4px;
+  background: var(--bg-surface);
+  border-top: 1px solid var(--border);
 }
 
-/* Enable-notifications affordance, right-aligned in the Activity header.
-   A low-priority ghost button: lighter than the 18px title so it doesn't
-   compete, but bordered enough to read as a button. Radius matches the
-   sibling "+ Add project" control (6px). Brightens to accent on hover,
-   matching the app's other opt-in controls. */
-.notif-toggle {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  flex-shrink: 0;
-  padding: 4px 10px;
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  background: transparent;
+.replay-status {
   color: var(--text-muted);
-  font-size: 12px;
-  font-family: 'Source Sans 3', sans-serif;
-  white-space: nowrap;
-  cursor: pointer;
-  transition: border-color 0.15s, color 0.15s, background 0.15s;
+  font-size: 13px;
 }
 
-.notif-toggle:hover {
-  border-color: var(--accent);
+.replay-buttons {
+  display: flex;
+  gap: 2px;
+}
+
+/* ── State message ── */
+
+.state-message {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1.5px;
+  color: var(--text-muted);
+}
+
+.state-icon {
+  font-size: 24px;
+  opacity: 0.4;
+  margin-bottom: 1px;
+}
+
+.state-title {
+  font-size: 16px;
+  font-weight: 600;
   color: var(--text-secondary);
-  background: color-mix(in oklch, var(--accent) 8%, transparent);
 }
 
-/* Denied: icon-only muted bell (tooltip carries the explanation) so the
-   header row stays uncluttered. */
-.notif-blocked {
-  display: inline-flex;
-  align-items: center;
-  flex-shrink: 0;
+.state-subtitle {
+  font-size: 14px;
   color: var(--text-muted);
-  cursor: default;
 }
 
-/* ── Manage Projects Modal ── */
+/* ── Modal ── */
 
 .modal-backdrop {
   position: fixed;
@@ -861,11 +598,6 @@ body {
   background: oklch(0% 0 0 / 0.55);
   z-index: 200;
   animation: modal-fade-in 0.15s ease-out;
-}
-
-@keyframes modal-fade-in {
-  from { opacity: 0; }
-  to   { opacity: 1; }
 }
 
 .modal-panel {
@@ -882,14 +614,6 @@ body {
   animation: modal-slide-in 0.15s ease-out;
 }
 
-@keyframes modal-slide-in {
-  from { opacity: 0; transform: translateY(8px) scale(0.98); }
-  to   { opacity: 1; transform: translateY(0) scale(1); }
-}
-
-/* Settings modal: fixed-size panel with a side tab rail. Dimensions are
-   fixed so switching tabs / changing content count never resizes the
-   panel; the body scrolls within. */
 .settings-modal {
   position: relative;
   flex-direction: row;
@@ -898,9 +622,6 @@ body {
   overflow: hidden;
 }
 
-/* Single close button, pinned to the panel's top-right. It lands on the
-   main-pane header on desktop and on the top tab strip on mobile,
-   without needing a duplicate per layout. */
 .settings-close {
   position: absolute;
   top: 12px;
@@ -944,10 +665,12 @@ body {
   white-space: nowrap;
   transition: color 0.1s, background 0.1s;
 }
+
 .settings-tab:hover {
   color: var(--text);
   background: var(--bg-hover);
 }
+
 .settings-tab.active {
   color: var(--text);
   background: var(--bg-active);
@@ -964,7 +687,6 @@ body {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  /* extra right padding reserves space for the pinned close button */
   padding: 14px 48px 12px 16px;
   border-bottom: 1px solid var(--border);
   flex-shrink: 0;
@@ -976,8 +698,6 @@ body {
   color: var(--text);
 }
 
-/* Narrow viewports: stack the rail on top as a horizontal,
-   side-to-side scrollable strip of tabs. */
 @media (max-width: 560px) {
   .settings-modal {
     flex-direction: column;
@@ -986,8 +706,7 @@ body {
   .settings-rail {
     width: auto;
     flex-direction: row;
-    gap: 4px;
-    /* right padding clears the pinned close button */
+    gap: 1px;
     padding: 8px 46px 8px 10px;
     border-right: none;
     border-bottom: 1px solid var(--border);
@@ -1000,87 +719,7 @@ body {
     width: auto;
     flex-shrink: 0;
   }
-  /* On mobile the top tab strip already shows the current page, so the
-     title row is redundant — drop it entirely. */
   .settings-main-header { display: none; }
-}
-
-/* Hosts roster (read-only). */
-.host-list {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-.host-row {
-  padding: 8px;
-  border-radius: 6px;
-}
-.host-row-main {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-.host-status-dot {
-  width: 7px;
-  height: 7px;
-  border-radius: 50%;
-  background: var(--status-disconnected);
-  flex-shrink: 0;
-}
-.host-status-dot.connected {
-  background: var(--status-connected);
-}
-.host-self-tag {
-  font-size: 10px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: var(--text-muted);
-  background: var(--bg-active);
-  padding: 2px 6px;
-  border-radius: 4px;
-  flex-shrink: 0;
-}
-.host-name {
-  font-size: 14px;
-  font-weight: 600;
-  color: var(--text);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  min-width: 0;
-}
-.host-local-tag {
-  font-size: 11px;
-  font-weight: 400;
-  color: var(--text-muted);
-  margin-left: 6px;
-}
-.host-meta {
-  margin-left: auto;
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  font-size: 12px;
-  color: var(--text-muted);
-  white-space: nowrap;
-  flex-shrink: 0;
-}
-.host-status-label {
-  text-transform: capitalize;
-}
-.host-sep {
-  opacity: 0.5;
-}
-.host-error {
-  margin-top: 4px;
-  margin-left: 15px;
-  font-size: 12px;
-  color: var(--status-disconnected);
-  font-family: var(--mono, monospace);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
 }
 
 .modal-close {
@@ -1110,11 +749,8 @@ body {
   padding: 12px 16px 16px;
 }
 
-.modal-body::-webkit-scrollbar { width: 3px; }
-.modal-body::-webkit-scrollbar-track { background: transparent; }
-.modal-body::-webkit-scrollbar-thumb { background: var(--border); border-radius: 2px; }
+/* ── Modal sections ── */
 
-/* Section layout */
 .mp-section + .mp-section {
   margin-top: 16px;
   padding-top: 16px;
@@ -1130,7 +766,7 @@ body {
   margin-bottom: 8px;
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 2px;
 }
 
 .mp-section-count {
@@ -1138,13 +774,6 @@ body {
   text-transform: none;
   letter-spacing: 0;
   color: var(--accent);
-}
-
-/* Header actions (help link + close) */
-.modal-header-actions {
-  display: flex;
-  align-items: center;
-  gap: 4px;
 }
 
 .mp-docs-link {
@@ -1166,7 +795,6 @@ body {
   color: var(--text);
 }
 
-/* Vertical stack of peer-project rows in PeerReferencesSection. */
 .mp-project-list {
   display: flex;
   flex-direction: column;
@@ -1181,8 +809,6 @@ body {
   gap: 2px;
 }
 
-/* Secondary text under a discovered-project name: remote URL or
- * local path, truncated with title-tooltip. */
 .mp-project-detail {
   font-size: 12px;
   color: var(--text-muted);
@@ -1200,28 +826,26 @@ body {
   white-space: nowrap;
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 1.5px;
 }
 
-/* Empty hint (used in both sections) */
 .mp-empty-hint {
   font-size: 12px;
   color: var(--text-muted);
-  padding: 6px 8px;
+  padding: 1.5px 2px;
   line-height: 1.5;
 }
 
-/* Search input at top of discovered section */
 .mp-filter-row {
   display: flex;
-  gap: 8px;
-  margin-bottom: 8px;
+  gap: 2px;
+  margin-bottom: 2px;
 }
 
 .mp-filter-input {
   flex: 1;
   min-width: 0;
-  padding: 6px 10px;
+  padding: 1.5px 2.5px;
   border: 1px solid var(--border-strong);
   border-radius: 6px;
   background: var(--bg);
@@ -1243,7 +867,6 @@ body {
   border-color: var(--accent);
 }
 
-/* Scrollable discovered list */
 .mp-discovered-scroll {
   max-height: 320px;
   overflow-y: auto;
@@ -1252,16 +875,11 @@ body {
   gap: 2px;
 }
 
-.mp-discovered-scroll::-webkit-scrollbar { width: 3px; }
-.mp-discovered-scroll::-webkit-scrollbar-track { background: transparent; }
-.mp-discovered-scroll::-webkit-scrollbar-thumb { background: var(--border); border-radius: 2px; }
-
-/* Discovered rows */
 .mp-discovered-row {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 7px 8px;
+  gap: 2px;
+  padding: 1.75px 2px;
   border-radius: 6px;
   cursor: pointer;
   transition: background 0.1s;
@@ -1278,7 +896,7 @@ body {
   justify-content: center;
   min-width: 16px;
   height: 16px;
-  padding: 0 4px;
+  padding: 0 1px;
   border-radius: 8px;
   background: var(--accent);
   color: var(--bg);
@@ -1301,7 +919,6 @@ body {
   color: var(--accent);
 }
 
-/* Manual add button (shown when filter looks like a path) */
 .mp-manual-btn {
   flex-shrink: 0;
   border: 1px solid var(--border-strong);
@@ -1311,7 +928,7 @@ body {
   font-size: 13px;
   font-family: 'Source Sans 3', sans-serif;
   font-weight: 500;
-  padding: 6px 14px;
+  padding: 1.5px 3.5px;
   cursor: pointer;
   transition: border-color 0.15s, color 0.15s;
 }
@@ -1332,7 +949,7 @@ body {
 
 .mp-path-add-row {
   display: flex;
-  gap: 8px;
+  gap: 2px;
 }
 
 .mp-path-input {
@@ -1343,7 +960,7 @@ body {
   font-size: 11.5px;
   color: var(--text-muted);
   opacity: 0.75;
-  margin-top: 5px;
+  margin-top: 1.25px;
   padding-left: 2px;
   line-height: 1.4;
 }
@@ -1351,12 +968,196 @@ body {
 .mp-manual-error {
   font-size: 12px;
   color: var(--status-error);
-  margin-top: 5px;
+  margin-top: 1.25px;
   margin-bottom: 0;
   padding-left: 2px;
 }
 
-/* Status dot — used in header */
+/* ── Hosts ── */
+
+.host-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.host-row {
+  padding: 2px;
+  border-radius: 6px;
+}
+
+.host-row-main {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.host-status-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--status-disconnected);
+  flex-shrink: 0;
+}
+
+.host-status-dot.connected {
+  background: var(--status-connected);
+}
+
+.host-self-tag {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+  background: var(--bg-active);
+  padding: 2px 1.5px;
+  border-radius: 4px;
+  flex-shrink: 0;
+}
+
+.host-name {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+.host-local-tag {
+  font-size: 11px;
+  font-weight: 400;
+  color: var(--text-muted);
+  margin-left: 1.5px;
+}
+
+.host-meta {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 1.5px;
+  font-size: 12px;
+  color: var(--text-muted);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.host-status-label {
+  text-transform: capitalize;
+}
+
+.host-sep {
+  opacity: 0.5;
+}
+
+.host-error {
+  margin-top: 1px;
+  margin-left: 15px;
+  font-size: 12px;
+  color: var(--status-disconnected);
+  font-family: var(--mono, monospace);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ── Configured projects ── */
+
+.mp-configured-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.mp-configured-row {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 1.75px 2px;
+  border-radius: 6px;
+  position: relative;
+}
+
+.mp-configured-row:hover {
+  background: var(--bg-hover);
+}
+
+.mp-configured-row.dragging {
+  opacity: 0.4;
+}
+
+.mp-configured-row.drop-target {
+  box-shadow: inset 0 -2px 0 0 var(--accent);
+}
+
+.mp-configured-drag {
+  color: var(--text-muted);
+  opacity: 0.4;
+  cursor: grab;
+  font-size: 14px;
+  user-select: none;
+  padding: 0 2px;
+  flex-shrink: 0;
+}
+
+.mp-configured-drag:active { cursor: grabbing; }
+.mp-configured-row:hover .mp-configured-drag { opacity: 0.7; }
+
+.mp-configured-info {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 3px;
+}
+
+.mp-configured-name {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.mp-configured-count {
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.mp-configured-alive {
+  color: var(--status-connected);
+}
+
+.mp-configured-rest {
+  color: var(--text-muted);
+}
+
+.mp-configured-remove {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 2px 1.5px;
+  border-radius: 4px;
+  opacity: 0;
+  flex-shrink: 0;
+  transition: opacity 0.1s, color 0.1s, background 0.1s;
+}
+
+.mp-configured-row:hover .mp-configured-remove { opacity: 1; }
+.mp-configured-remove:hover {
+  color: var(--text);
+  background: var(--bg-active);
+}
+
+/* ── Session dot (header) ── */
+
 .session-dot {
   border-radius: 50%;
   display: inline-block;
@@ -1371,836 +1172,7 @@ body {
 .session-dot.idle    { background: var(--text-muted); }
 .session-dot.unread  { background: var(--unread); }
 
-/* ── Main Panel ── */
-
-.main-panel {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  min-width: 0;
-  min-height: 0;
-  background: var(--bg);
-}
-
-.main-header {
-  height: var(--header-height);
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 0 16px;
-  gap: 12px;
-  border-bottom: 1px solid var(--border);
-  flex-shrink: 0;
-  /* overflow must NOT be hidden here — the session menu drops below the header */
-  overflow: visible;
-  position: relative;
-  z-index: 30;
-}
-
-.main-header-left {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  min-width: 0;
-  overflow: hidden;
-}
-
-.main-header-right {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  flex-shrink: 0;
-}
-
-.main-header-title {
-  font-family: 'Source Sans 3', sans-serif;
-  font-size: 14px;
-  font-weight: 600;
-  color: var(--text);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  letter-spacing: -0.01em;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.main-header-meta {
-  display: flex;
-  align-items: center;
-  gap: 5px;
-  font-size: 12px;
-  color: var(--text-muted);
-}
-
-.main-header-cwd {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.main-header-status {
-  display: flex;
-  align-items: center;
-  gap: 5px;
-  font-size: 12px;
-  font-weight: 500;
-  white-space: nowrap;
-  flex-shrink: 0;
-  color: var(--text-secondary);
-}
-
-.main-header-status.working { color: var(--accent); }
-.main-header-status.error   { color: var(--status-error); }
-
-/* Session actions menu */
-
-.session-menu {
-  position: relative;
-}
-
-/* Trigger: icon button in the same style as .session-close-btn */
-.session-menu-trigger {
-  position: relative;
-  width: 26px;
-  height: 26px;
-  border: none;
-  border-radius: 4px;
-  background: transparent;
-  color: var(--text-muted);
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: background 0.1s, color 0.1s;
-  flex-shrink: 0;
-}
-
-.session-menu-trigger:hover {
-  background: var(--bg-hover);
-  color: var(--text);
-}
-
-
-
-.session-menu-icon {
-  font-size: 16px;
-  line-height: 1;
-  letter-spacing: 0;
-}
-
-/* Amber dot in top-right corner of trigger when runner is outdated */
-.session-menu-badge {
-  position: absolute;
-  top: 3px;
-  right: 3px;
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: oklch(80% 0.15 65);
-  border: 1.5px solid var(--bg);
-  pointer-events: none;
-}
-
-.session-menu-dropdown {
-  position: absolute;
-  top: calc(100% + 4px);
-  right: 0;
-  min-width: 200px;
-  background: var(--bg-surface);
-  border: 1px solid var(--border-strong);
-  border-radius: 6px;
-  padding: 4px 0;
-  box-shadow: 0 8px 24px oklch(0% 0 0 / 0.4);
-  z-index: 100;
-}
-
-/* Action buttons at the top of the menu */
-.session-menu-action {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  width: 100%;
-  padding: 7px 12px;
-  font-size: 14px;
-  color: var(--text-secondary);
-  background: none;
-  border: none;
-  cursor: pointer;
-  transition: background 0.1s, color 0.1s;
-  text-align: left;
-}
-
-.session-menu-action:hover {
-  background: var(--bg-hover);
-  color: var(--text);
-}
-
-.session-menu-action.stale {
-  color: oklch(80% 0.15 65);
-}
-
-.session-menu-action.stale:hover {
-  background: oklch(80% 0.15 65 / 0.08);
-  color: oklch(88% 0.15 65);
-}
-
-/* Small tag shown next to the action label when runner is stale */
-.session-menu-action-tag {
-  font-size: 10px;
-  font-weight: 500;
-  letter-spacing: 0.04em;
-  padding: 1px 5px;
-  border-radius: 3px;
-  background: oklch(80% 0.15 65 / 0.15);
-  color: oklch(80% 0.15 65);
-  white-space: nowrap;
-}
-
-.session-menu-divider {
-  height: 1px;
-  background: var(--border);
-  margin: 4px 0;
-}
-
-/* Section heading above info rows */
-.session-menu-section-title {
-  font-size: 11px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--text-muted);
-  padding: 6px 12px 2px;
-}
-
-/* Key/value info rows */
-.session-menu-row {
-  display: flex;
-  justify-content: space-between;
-  align-items: baseline;
-  padding: 3px 12px;
-}
-
-.session-menu-label {
-  font-size: 13px;
-  color: var(--text-muted);
-}
-
-.session-menu-value {
-  font-family: 'Fira Code', monospace;
-  font-size: 11px;
-  color: var(--text-secondary);
-}
-
-.session-menu-value.stale {
-  color: oklch(80% 0.15 65);
-}
-
-.terminal-shell {
-  flex: 1;
-  min-height: 0;
-  position: relative;
-  overflow: auto;
-  background: #0f141a;
-  overscroll-behavior: contain;
-  -webkit-overflow-scrolling: touch;
-}
-
-.terminal-shell-passive {
-  touch-action: none;
-}
-
-.terminal-container {
-  min-width: 100%;
-  min-height: 100%;
-  position: relative;
-  overflow: visible;
-  background: #0f141a;
-}
-
-/* Zero-height sticky anchor: sticks to the top of .terminal-shell's scroll
-   viewport without pushing .terminal-container down. The pill inside
-   overflows visually but doesn't affect layout. */
-.terminal-resize-anchor {
-  position: sticky;
-  top: 0;
-  height: 0;
-  overflow: visible;
-  display: flex;
-  justify-content: center;
-  z-index: 12;
-  pointer-events: none;
-}
-
-.terminal-resize-overlay {
-  pointer-events: auto;
-  position: relative;
-  top: 12px;
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  max-width: min(calc(100% - 24px), 460px);
-  padding: 10px 16px;
-  border: 1px solid color-mix(in oklch, var(--accent) 22%, var(--border-strong));
-  border-radius: 999px;
-  background: color-mix(in oklch, var(--bg-sidebar) 76%, #0f141a 24%);
-  color: color-mix(in oklch, var(--text) 88%, var(--accent));
-  box-shadow: 0 8px 24px oklch(0% 0 0 / 0.28);
-  backdrop-filter: blur(6px);
-  -webkit-backdrop-filter: blur(6px);
-  font: inherit;
-  font-size: 13px;
-  line-height: 1;
-  letter-spacing: 0.01em;
-  cursor: pointer;
-  white-space: nowrap;
-  appearance: none;
-}
-
-.terminal-resize-overlay:hover {
-  background: color-mix(in oklch, var(--bg-sidebar) 68%, var(--accent) 12%);
-  border-color: color-mix(in oklch, var(--accent) 34%, var(--border-strong));
-  color: var(--text);
-}
-
-.terminal-resize-overlay:focus-visible {
-  outline: none;
-  border-color: color-mix(in oklch, var(--accent) 50%, var(--border-strong));
-  box-shadow:
-    0 0 0 1px color-mix(in oklch, var(--accent) 45%, transparent),
-    0 8px 24px oklch(0% 0 0 / 0.28);
-}
-
-.terminal-disconnected-pill {
-  pointer-events: none;
-  position: relative;
-  top: 12px;
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  max-width: min(calc(100% - 24px), 460px);
-  padding: 10px 16px;
-  border: 1px solid oklch(0.45 0.12 20 / 0.5);
-  border-radius: 999px;
-  background: oklch(0.22 0.06 20 / 0.88);
-  color: oklch(0.78 0.1 20);
-  box-shadow:
-    0 8px 24px oklch(0% 0 0 / 0.28),
-    0 0 12px oklch(0.5 0.15 20 / 0.12);
-  backdrop-filter: blur(6px);
-  -webkit-backdrop-filter: blur(6px);
-  font: inherit;
-  font-size: 13px;
-  line-height: 1;
-  letter-spacing: 0.01em;
-  white-space: nowrap;
-}
-
-.terminal-loading {
-  position: absolute;
-  inset: 0;
-  display: flex;
-  align-items: start;
-  justify-content: center;
-  padding-top: 25%;
-  gap: 8px;
-  background: oklch(from #0f141a l c h / 0.85);
-  color: var(--text-muted);
-  font-size: 14px;
-  z-index: 10;
-}
-
-.terminal-scroll-end {
-  position: absolute;
-  bottom: 12px;
-  right: 16px;
-  padding: 8px 12px;
-  border-radius: 8px;
-  border: 1px solid oklch(from var(--border-strong) l c h / 0.7);
-  background: oklch(from var(--bg-surface) l c h / 0.38);
-  color: oklch(76% 0.012 250 / 0.85);
-  font-size: 13px;
-  font-family: 'Source Sans 3', sans-serif;
-  font-weight: 600;
-  letter-spacing: 0.01em;
-  cursor: pointer;
-  backdrop-filter: blur(6px);
-  -webkit-backdrop-filter: blur(6px);
-  z-index: 20;
-  transition: opacity 0.15s, background 0.15s, color 0.15s;
-  pointer-events: auto;
-}
-
-.terminal-scroll-end:hover {
-  background: oklch(from var(--bg-surface) l c h / 0.92);
-  color: oklch(76% 0.012 250);
-}
-
-/* Use JetBrains Mono for italic glyphs since Fira Code has no italic variant.
-   The bundled JetBrains Mono italic files (from fonts.css) are referenced here
-   so we don't depend on the font being installed on the system. */
-@font-face {
-  font-family: 'Fira Code';
-  font-style: italic;
-  font-weight: 400;
-  src: local('JetBrains Mono Italic'), local('JetBrainsMono-Italic'),
-       url('@fontsource/jetbrains-mono/files/jetbrains-mono-latin-400-italic.woff2') format('woff2');
-}
-@font-face {
-  font-family: 'Fira Code';
-  font-style: italic;
-  font-weight: 500;
-  src: local('JetBrains Mono Medium Italic'), local('JetBrainsMono-MediumItalic'),
-       url('@fontsource/jetbrains-mono/files/jetbrains-mono-latin-500-italic.woff2') format('woff2');
-}
-
-.terminal-container .xterm {
-  width: max-content;
-  min-width: 100%;
-  min-height: 100%;
-  padding: 0 6px 6px 6px;
-  margin: 0 auto; /* center the character grid horizontally */
-}
-
-/* Hide xterm's native scrollbar — scrollback is handled by the PTY replay buffer */
-/* Override viewport background — xterm sets it to black inline before theme applies */
-.terminal-container .xterm-viewport {
-  overflow-y: hidden !important;
-  background-color: transparent !important;
-}
-
-/* ── Empty State ── */
-
-.state-message {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 6px;
-  color: var(--text-muted);
-}
-
-.state-icon {
-  font-size: 24px;
-  opacity: 0.4;
-  margin-bottom: 4px;
-}
-
-.state-title {
-  font-size: 16px;
-  font-weight: 600;
-  color: var(--text-secondary);
-}
-
-.state-subtitle {
-  font-size: 14px;
-  color: var(--text-muted);
-}
-
-/* ── Home page ── */
-
-/* Scrollable main column shared by the home dashboard and the
- * project hub. The container fills the available width so the
- * scrollbar tracks the viewport edge; children are centered and
- * capped to a readable width.
- *
- * Horizontal padding uses clamp() so the gutter shrinks gracefully
- * on narrow viewports without a media-query step; vertical padding
- * is fixed because there's no equivalent constraint to satisfy. */
-.page {
-  flex: 1;
-  min-width: 0;
-  overflow-y: auto;
-  padding: 32px clamp(16px, 4vw, 32px) 48px;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-}
-.page > * {
-  width: 100%;
-  max-width: 640px;
-}
-
-.home-section-title {
-  font-size: 11px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--text-muted);
-  margin-bottom: 12px;
-}
-
-/* Dashboard sections */
-
-.home-section {
-  margin-bottom: 24px;
-}
-.home-section-body {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-/* Configured-projects manage-list (Settings → Projects). Management
- * only: drag-to-reorder + remove, no navigation, no launch. */
-.mp-configured-list {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-.mp-configured-row {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 7px 8px;
-  border-radius: 6px;
-  position: relative;
-}
-.mp-configured-row:hover {
-  background: var(--bg-hover);
-}
-.mp-configured-row.dragging {
-  opacity: 0.4;
-}
-.mp-configured-row.drop-target {
-  box-shadow: inset 0 -2px 0 0 var(--accent);
-}
-.mp-configured-drag {
-  color: var(--text-muted);
-  opacity: 0.4;
-  cursor: grab;
-  font-size: 14px;
-  user-select: none;
-  padding: 0 2px;
-  flex-shrink: 0;
-}
-.mp-configured-drag:active { cursor: grabbing; }
-.mp-configured-row:hover .mp-configured-drag { opacity: 0.7; }
-.mp-configured-info {
-  flex: 1;
-  min-width: 0;
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 12px;
-}
-.mp-configured-name {
-  font-size: 14px;
-  font-weight: 600;
-  color: var(--text);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-.mp-configured-count {
-  font-size: 12px;
-  white-space: nowrap;
-}
-.mp-configured-alive {
-  color: var(--status-connected);
-}
-.mp-configured-rest {
-  color: var(--text-muted);
-}
-.mp-configured-remove {
-  background: none;
-  border: none;
-  color: var(--text-muted);
-  font-size: 18px;
-  line-height: 1;
-  cursor: pointer;
-  padding: 2px 6px;
-  border-radius: 4px;
-  opacity: 0;
-  flex-shrink: 0;
-  transition: opacity 0.1s, color 0.1s, background 0.1s;
-}
-.mp-configured-row:hover .mp-configured-remove { opacity: 1; }
-.mp-configured-remove:hover {
-  color: var(--text);
-  background: var(--bg-active);
-}
-@media (hover: none) {
-  .mp-configured-remove { opacity: 1; }
-}
-
-.home-empty-hint {
-  font-size: 13px;
-  color: var(--text-muted);
-  padding: 16px 0;
-}
-.home-empty-action {
-  background: none;
-  border: none;
-  color: var(--accent);
-  cursor: pointer;
-  padding: 0;
-  text-decoration: underline;
-  text-underline-offset: 2px;
-  font: inherit;
-}
-
-/* A single muted sentence. Uniform font and size; the inline refresh
- * button and update link inherit everything except the accent color
- * and underline, so the row reads as flowing prose, not a toolbar. */
-.home-footer {
-  margin-top: auto;
-  padding-top: 16px;
-  border-top: 1px solid var(--border);
-  font-size: 11px;
-  color: var(--text-muted);
-  line-height: 1.5;
-}
-.home-footer-link {
-  font: inherit;
-  color: var(--accent);
-  background: none;
-  border: none;
-  padding: 0;
-  cursor: pointer;
-  text-decoration: underline;
-  text-underline-offset: 2px;
-}
-.home-footer-link:hover {
-  color: var(--text);
-}
-
-
-/* ── Mobile ── */
-
-.mobile-bottom-bar {
-  display: none;
-}
-
-.sidebar-overlay {
-  display: none;
-  position: fixed;
-  inset: 0;
-  background: oklch(0% 0 0 / 0.5);
-  z-index: 90;
-}
-
-/* Narrow viewport: compact padding and smaller text. */
-@media (max-width: 640px) {
-  .main-header {
-    padding: 0 12px;
-  }
-
-  .main-header-meta {
-    display: none;
-  }
-
-  .main-header-status {
-    font-size: 11px;
-  }
-
-  .terminal-container .xterm {
-    padding: 0 4px 4px;
-  }
-
-  .session-item {
-    padding: 8px 10px 8px 14px;
-  }
-}
-
-/* Touch devices: sidebar becomes an overlay, mobile toolbar appears.
-   Uses pointer:coarse so tablets in landscape still get touch controls,
-   while a desktop user with a narrow window keeps the sidebar visible. */
-@media (pointer: coarse) {
-  .sidebar {
-    position: fixed;
-    left: 0;
-    top: 0;
-    bottom: 0;
-    width: 80vw;
-    min-width: 0;
-    max-width: 360px;
-    z-index: 100;
-    transform: translateX(-100%);
-    transition: transform 0.2s ease;
-  }
-
-  .sidebar.open {
-    transform: translateX(0);
-  }
-
-  .sidebar-overlay.visible {
-    display: block;
-  }
-
-  .main-panel {
-    width: 100%;
-  }
-
-  .mobile-bottom-bar {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    min-height: 52px;
-    padding: 6px 8px calc(6px + env(safe-area-inset-bottom));
-    border-top: 1px solid var(--border);
-    background: var(--bg-sidebar);
-    flex-shrink: 0;
-  }
-
-  .mobile-bottom-sep {
-    width: 1px;
-    height: 24px;
-    background: var(--border);
-    flex-shrink: 0;
-  }
-
-  .mobile-terminal-actions {
-    display: flex;
-    gap: 6px;
-    min-width: 0;
-    flex: 1;
-  }
-
-  .mobile-bottom-action {
-    appearance: none;
-    border: 1px solid var(--border-strong);
-    background: var(--bg-surface);
-    color: oklch(76% 0.012 250);
-    border-radius: 6px;
-    min-height: 40px;
-    min-width: 36px;
-    padding: 0 10px;
-    flex: 0 0 auto;
-    font-family: 'Source Sans 3', sans-serif;
-    font-size: 13px;
-    font-weight: 600;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    touch-action: manipulation;
-    transition: background 0.1s, border-color 0.1s, color 0.1s;
-    position: relative;
-  }
-
-  /* Waiting dot on the hamburger menu button. Only the waiting (unread)
-     state is surfaced; working/active are deliberately omitted.
-     Pseudo-elements don't expand the hit-box, so taps outside the button
-     border still pass through correctly. */
-  .mobile-bottom-action.menu-btn.bg-waiting::after {
-    content: '';
-    position: absolute;
-    width: 8px;
-    height: 8px;
-    border-radius: 50%;
-    top: -3px;
-    right: -3px;
-    pointer-events: none;
-    background: var(--unread);
-    /* Ring in the page background so the dot reads cleanly against the button border */
-    box-shadow: 0 0 0 1.5px var(--bg-base);
-  }
-
-  /* Re-blink when a new session enters the waiting state */
-  .mobile-bottom-action.menu-btn.bg-arriving::after {
-    animation: dot-arrival 520ms cubic-bezier(0.25, 1, 0.5, 1) both;
-  }
-
-  .mobile-terminal-actions .mobile-bottom-action {
-    flex: 1 1 0;
-    min-width: 0;
-  }
-
-  .mobile-bottom-action:active {
-    background: var(--bg-hover);
-  }
-
-  .mobile-bottom-action:disabled {
-    opacity: 0.35;
-  }
-
-  .mobile-bottom-action.armed {
-    background: color-mix(in oklch, var(--accent) 20%, var(--bg-surface));
-    border-color: var(--accent);
-    color: var(--text);
-  }
-
-  .mobile-bottom-action.send-btn {
-    color: var(--accent);
-  }
-
-  /* Tighter top padding on touch devices; horizontal padding is
-   * already viewport-relative via clamp(). */
-  .page {
-    padding-top: 20px;
-  }
-
-  .hub-empty {
-    flex-wrap: wrap;
-  }
-
-  /* Move sidebar header to bottom for thumb reach. Match desktop's
-   * 14px horizontal padding and --header-height vertical rhythm so the
-   * logo's margins read the same in both layouts; the safe-area inset
-   * is added below that on notched devices so the logo never hugs the
-   * screen edge. */
-  .sidebar-header {
-    order: 3;
-    height: auto;
-    min-height: var(--header-height);
-    padding: 0 14px;
-    margin-bottom: env(safe-area-inset-bottom);
-    border-top: 1px solid var(--border);
-    border-bottom: none;
-  }
-  .sidebar-scroll { order: 1; }
-}
-
-/* ── Session Detail (non-terminal) ── */
-
-
-.btn {
-  font-family: 'Source Sans 3', sans-serif;
-  font-size: 13px;
-  font-weight: 500;
-  padding: 5px 12px;
-  border-radius: 4px;
-  border: 1px solid var(--border);
-  background: var(--bg-surface);
-  color: var(--text);
-  cursor: pointer;
-  transition: background 0.15s, border-color 0.15s, color 0.15s;
-}
-
-.btn:hover {
-  background: oklch(24% 0.015 250);
-  border-color: var(--border-strong);
-}
-
-.btn-primary {
-  background: var(--accent);
-  border-color: var(--accent);
-  color: oklch(13% 0.015 250);
-  font-weight: 600;
-}
-
-.btn-primary:hover {
-  background: oklch(78% 0.1 195);
-  border-color: oklch(78% 0.1 195);
-}
-
-/* ── Reduced motion ── */
-@media (prefers-reduced-motion: reduce) {
-  .session-dot-indicator.arriving,
-  .mobile-bottom-action.menu-btn.bg-arriving::after,
-  .sidebar-logo.bg-arriving::after {
-    animation: none;
-  }
-  .session-dot-indicator.working,
-  .session-dot-indicator.active,
-  .session-dot-indicator.fading,
-  .session-dot-indicator.error {
-    animation: none;
-  }
-}
-
-/* ── Input Diagnostics Page ── */
+/* ── Input Diagnostics ── */
 
 .diag-page {
   display: flex;
@@ -2216,7 +1188,7 @@ body {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 8px 16px;
+  padding: 2px 4px;
   border-bottom: 1px solid var(--border);
   flex-shrink: 0;
 }
@@ -2236,17 +1208,17 @@ body {
 
 .diag-terminal-section {
   flex: 0 0 auto;
-  padding: 8px 12px 4px;
+  padding: 2px 3px 1px;
   border-bottom: 1px solid var(--border);
 }
 
 .diag-terminal-label {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 2px;
   font-size: 12px;
   color: var(--text-muted);
-  margin-bottom: 6px;
+  margin-bottom: 1.5px;
 }
 
 .diag-terminal {
@@ -2264,14 +1236,14 @@ body {
   display: flex;
   flex-direction: column;
   min-height: 0;
-  padding: 0 12px 12px;
+  padding: 0 3px 3px;
 }
 
 .diag-log-toolbar {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 8px 0;
+  gap: 2px;
+  padding: 2px 0;
   flex-shrink: 0;
   flex-wrap: wrap;
 }
@@ -2288,13 +1260,13 @@ body {
   color: var(--text-muted);
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 1px;
   cursor: pointer;
 }
 
 .diag-btn {
   font-size: 12px;
-  padding: 4px 10px;
+  padding: 1px 2.5px;
   border: 1px solid var(--border-strong);
   border-radius: var(--radius);
   background: var(--bg-surface);
@@ -2313,7 +1285,7 @@ body {
 .diag-btn-primary:hover { opacity: 0.9; }
 
 .diag-btn-small {
-  padding: 2px 8px;
+  padding: 2px 2px;
   font-size: 11px;
 }
 
@@ -2322,7 +1294,7 @@ body {
   overflow-y: auto;
   background: var(--bg-surface);
   border-radius: var(--radius);
-  padding: 6px;
+  padding: 1.5px;
   font-family: 'Fira Code', monospace;
   font-size: 11px;
   line-height: 1.5;
@@ -2331,10 +1303,10 @@ body {
 
 .diag-entry {
   display: flex;
-  gap: 6px;
-  padding: 1px 4px;
+  gap: 1.5px;
+  padding: 2px 1px;
   border-left: 3px solid var(--border);
-  margin-bottom: 1px;
+  margin-bottom: 2px;
   flex-wrap: wrap;
 }
 
@@ -2360,7 +1332,6 @@ body {
   font-size: 10px;
 }
 
-/* Category colors */
 .diag-cat-data        { border-color: oklch(65% 0.15 250); }
 .diag-cat-data .diag-entry-cat { color: oklch(65% 0.15 250); }
 
@@ -2379,7 +1350,6 @@ body {
 .diag-cat-info        { border-color: var(--text-muted); }
 .diag-cat-info .diag-entry-cat { color: var(--text-muted); }
 
-/* Mobile-friendly sizing */
 @media (max-width: 600px) {
   .diag-terminal { height: 140px; }
   .diag-log { font-size: 10px; }
@@ -2387,145 +1357,251 @@ body {
   .diag-entry-cat { min-width: 60px; font-size: 10px; }
 }
 
-/* ─── Project hub (activity-first, three-section) ─── */
+/* ── Launcher hover-dependent behaviors (parent hover controls child) ── */
 
-.hub-header {
-  margin-bottom: 20px;
-}
-.hub-back {
-  /* Back link in the eyebrow slot above the project title. Sized
-   * like the old uppercase kicker so the header rhythm is
-   * preserved; styled as a link so it reads as actionable. */
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  font-size: 11px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--text-muted);
-  text-decoration: none;
-  margin-bottom: 4px;
-  transition: color 0.12s;
-}
-.hub-back:hover,
-.hub-back:focus-visible {
-  color: var(--text);
-}
-.hub-back-arrow {
-  /* Arrow glyph aligned tight to the label; slightly larger than
-   * the uppercase text so it reads as a chevron, not punctuation. */
-  font-size: 13px;
-  line-height: 1;
-}
-.hub-title-row {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 12px;
-}
-.hub-title {
-  font-size: 18px;
-  font-weight: 600;
-  color: var(--text);
-  margin: 0;
-}
-.hub-subtitle {
-  font-size: 12px;
-  color: var(--text-muted);
-  margin-top: 4px;
-}
-.hub-subtitle-sep {
-  opacity: 0.6;
-}
-.hub-cwd {
-  font-family: "JetBrains Mono", "SF Mono", monospace;
-  font-size: 11px;
-}
-.hub-remote {
-  font-family: "JetBrains Mono", "SF Mono", monospace;
-  font-size: 11px;
-}
-.hub-header-launch {
-  flex-shrink: 0;
+.launch-container.folder-launch-btn {
+  margin-left: auto;
+  opacity: 0;
+  transition: opacity 0.1s;
 }
 
-/* Empty project state */
-.hub-empty {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 14px 16px;
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  color: var(--text-muted);
-  font-size: 13px;
-  margin-top: 16px;
-}
-.btn:disabled,
-.btn-primary:disabled {
-  opacity: 0.6;
-  cursor: progress;
+.folder-header:hover .launch-container.folder-launch-btn,
+.launch-container.folder-launch-btn:has(.loading) {
+  opacity: 1;
 }
 
-/* Replay (read-only dead session) layout: terminal area fills remaining
-   vertical space, action bar pinned beneath. The action bar carries the
-   resume/dismiss buttons that the sidebar used to auto-trigger on click. */
-.replay-root {
-  flex: 1;
+.spin {
+  animation: spin 0.8s linear infinite;
+}
+
+/* Non-default launch menu items fade in with stagger */
+.launch-inline-item-animated {
+  opacity: 0;
+  animation: launch-item-in 0.12s ease-out forwards;
+}
+
+/* ── Sidebar mobile overlay ── */
+
+.sidebar {
+  width: var(--sidebar-width);
+  min-width: var(--sidebar-width);
+  height: 100%;
   display: flex;
   flex-direction: column;
-  min-height: 0;
+  background: var(--bg-sidebar);
+  border-right: 1px solid var(--border);
+  overflow: hidden;
 }
 
-.replay-root > .terminal-shell {
-  flex: 1;
-  min-height: 0;
+.sidebar-overlay {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: oklch(0% 0 0 / 0.5);
+  z-index: 90;
 }
 
-.replay-actions {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  padding: 8px 16px;
-  background: var(--bg-surface);
+.sidebar-overlay.visible {
+  display: block;
+}
+
+/* ── Folder sibling divider ── */
+
+.folder + .folder {
+  margin-top: 4px;
+  padding-top: 4px;
+  position: relative;
+}
+
+.folder + .folder::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 14px;
+  right: 14px;
   border-top: 1px solid var(--border);
 }
 
-.replay-status {
-  color: var(--text-muted);
-  font-size: 13px;
-}
+/* ── Session item selected indicator ── */
 
-.replay-buttons {
-  display: flex;
-  gap: 8px;
-}
-
-
-/* Floating "jump to bottom" overlay for any xterm-hosting view (replay,
-   live terminal). Anchors to the nearest positioned ancestor, which
-   .terminal-shell already establishes (position: relative). */
-.jump-to-bottom {
+.session-item.selected::before {
+  content: '';
   position: absolute;
-  right: 16px;
-  bottom: 16px;
-  z-index: 5;
-  width: 36px;
-  height: 36px;
-  border-radius: 50%;
-  border: 1px solid var(--border);
-  background: var(--bg-surface);
-  color: var(--text);
+  left: 0;
+  top: 4px;
+  bottom: 4px;
+  width: 2px;
+  background: var(--accent);
+  border-radius: 0 1px 1px 0;
+}
+
+/* ── Session close button (parent hover) ── */
+
+.session-close-btn {
+  position: absolute;
+  right: 4px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 20px;
+  height: 20px;
+  opacity: 0;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 14px;
+  line-height: 1;
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 18px;
-  line-height: 1;
-  box-shadow: 0 2px 8px oklch(0% 0 0 / 0.35);
-  transition: background 0.1s, transform 0.1s;
+  transition: background 0.1s, color 0.1s, opacity 0.15s;
+  padding: 0;
 }
-.jump-to-bottom:hover { background: oklch(28% 0.015 250); }
-.jump-to-bottom:active { transform: translateY(1px); }
+
+.session-item:hover .session-close-btn,
+.session-item.selected .session-close-btn {
+  opacity: 1;
+  background: oklch(22% 0.01 250 / 0.45);
+}
+
+.session-close-btn:hover {
+  background: oklch(28% 0.015 250) !important;
+  color: var(--text);
+}
+
+/* ── Folder header hover ── */
+
+.folder-header:hover {
+  background: var(--bg-hover);
+}
+
+/* ── Session item hover/selected ── */
+
+.session-item:hover {
+  background: var(--bg-hover);
+}
+
+.session-item.selected {
+  background: var(--bg-selected);
+}
+
+/* ── Session drag states ── */
+
+.session-item.session-dragging {
+  opacity: 0.4;
+}
+
+.session-item.session-drop-target {
+  box-shadow: inset 0 -2px 0 0 var(--accent);
+}
+
+/* ── Mobile sidebar ── */
+
+@media (pointer: coarse) {
+  .sidebar {
+    position: fixed;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 80vw;
+    min-width: 0;
+    max-width: 360px;
+    z-index: 100;
+    transform: translateX(-100%);
+    transition: transform 0.2s ease;
+  }
+
+  .sidebar.open {
+    transform: translateX(0);
+  }
+
+  .sidebar-header {
+    order: 3;
+    height: auto;
+    min-height: var(--header-height);
+    padding: 0 14px;
+    margin-bottom: env(safe-area-inset-bottom);
+    border-top: 1px solid var(--border);
+    border-bottom: none;
+  }
+
+  .sidebar-scroll { order: 1; }
+
+  .page {
+    padding-top: 20px;
+  }
+
+  .hub-empty {
+    flex-wrap: wrap;
+  }
+
+  .mobile-bottom-bar {
+    display: flex;
+    align-items: center;
+    gap: 1.5px;
+    min-height: 52px;
+    padding: 1.5px 2 calc(1.5px + env(safe-area-inset-bottom));
+    border-top: 1px solid var(--border);
+    background: var(--bg-sidebar);
+    flex-shrink: 0;
+  }
+
+  .mobile-bottom-sep {
+    width: 1px;
+    height: 24px;
+    background: var(--border);
+    flex-shrink: 0;
+  }
+
+  .mobile-terminal-actions {
+    display: flex;
+    gap: 1.5px;
+    min-width: 0;
+    flex: 1;
+  }
+
+  .mobile-bottom-action {
+    appearance: none;
+    border: 1px solid var(--border-strong);
+    background: var(--bg-surface);
+    color: oklch(76% 0.012 250);
+    border-radius: 6px;
+    min-height: 40px;
+    min-width: 36px;
+    padding: 0 2.5px;
+    flex: 0 0 auto;
+    font-family: 'Source Sans 3', sans-serif;
+    font-size: 13px;
+    font-weight: 600;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    touch-action: manipulation;
+    transition: background 0.1s, border-color 0.1s, color 0.1s;
+    position: relative;
+  }
+
+  .mobile-terminal-actions .mobile-bottom-action {
+    flex: 1 1 0;
+    min-width: 0;
+  }
+
+  .mobile-bottom-action:active {
+    background: var(--bg-hover);
+  }
+
+  .mobile-bottom-action:disabled {
+    opacity: 0.35;
+  }
+
+  .mobile-bottom-action.armed {
+    background: color-mix(in oklch, var(--accent) 20%, var(--bg-surface));
+    border-color: var(--accent);
+    color: var(--text);
+  }
+
+  .mobile-bottom-action.send-btn {
+    color: var(--accent);
+  }
+}

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -307,8 +307,19 @@ body {
 /* ── Mock mode ── */
 
 .mock-mode .session-close-btn,
-.mock-mode .session-row-close {
+.mock-mode .session-row-close-btn {
   display: none !important;
+}
+
+/* ── App layout (height fallback cascade) ── */
+/* Three declarations in one rule so browsers skip unsupported values
+ * and fall back to the last valid one (100vh → 100dvh → var(--app-height)). */
+.app-layout {
+  display: flex;
+  height: 100vh;
+  height: 100dvh;
+  height: var(--app-height, 100dvh);
+  width: 100%;
 }
 
 /* ── Touch device adjustments ── */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,12 +75,6 @@ importers:
       '@preact/preset-vite':
         specifier: ^2.10.2
         version: 2.10.3(@babel/core@7.29.0)(preact@10.29.0)(rollup@4.59.0)(vite@6.4.1(@types/node@24.12.0)(jiti@1.21.7)(tsx@4.21.0))
-      autoprefixer:
-        specifier: ^10.5.0
-        version: 10.5.0(postcss@8.5.15)
-      postcss:
-        specifier: ^8.5.15
-        version: 8.5.15
       tailwindcss:
         specifier: ^4.3.0
         version: 4.3.0
@@ -1452,13 +1446,6 @@ packages:
     engines: {node: ^20.19.1 || >=22.12.0, npm: '>=9.6.5', pnpm: '>=7.1.0'}
     hasBin: true
 
-  autoprefixer@10.5.0:
-    resolution: {integrity: sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==}
-    engines: {node: ^10 || ^12 || >=14}
-    hasBin: true
-    peerDependencies:
-      postcss: ^8.1.0
-
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
@@ -1470,11 +1457,6 @@ packages:
 
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
-
-  baseline-browser-mapping@2.10.33:
-    resolution: {integrity: sha512-bA6+tcSLpz2tIEdDXZPpPTIuxBcC4+w6SieaYyfigIa4h8GlFxbA17v22Vx3JUtuZQj9SgOsnbK+aTBzyDyEuw==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
 
   baseline-browser-mapping@2.10.7:
     resolution: {integrity: sha512-1ghYO3HnxGec0TCGBXiDLVns4eCSx4zJpxnHrlqFQajmhfKMQBzUGDdkMK7fUW7PTHTeLf+j87aTuKuuwWzMGw==}
@@ -1495,20 +1477,12 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
-  browserslist@4.28.2:
-    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
-    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
-    hasBin: true
-
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
 
   caniuse-lite@1.0.30001778:
     resolution: {integrity: sha512-PN7uxFL+ExFJO61aVmP1aIEG4i9whQd4eoSCebav62UwDyp5OHh06zN4jqKSMePVgxHifCw1QJxdRkA1Pisekg==}
-
-  caniuse-lite@1.0.30001793:
-    resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -1856,9 +1830,6 @@ packages:
   electron-to-chromium@1.5.313:
     resolution: {integrity: sha512-QBMrTWEf00GXZmJyx2lbYD45jpI3TUFnNIzJ5BBc8piGUDwMPa1GV6HJWTZVvY/eiN3fSopl7NRbgGp9sZ9LTA==}
 
-  electron-to-chromium@1.5.364:
-    resolution: {integrity: sha512-G/dYE3+AYhyHwzTwg8UbnXf7zqMERYh7l2jJ3QujhFsH8agSYwtnGAR2aZ7f0AakIKJXd5En/Hre4igIUrdlYw==}
-
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
@@ -1953,9 +1924,6 @@ packages:
   fontkitten@1.0.3:
     resolution: {integrity: sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw==}
     engines: {node: '>=20'}
-
-  fraction.js@5.3.4:
-    resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
 
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
@@ -2506,9 +2474,6 @@ packages:
   postcss-selector-parser@6.1.2:
     resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
     engines: {node: '>=4'}
-
-  postcss-value-parser@4.2.0:
-    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
@@ -4415,15 +4380,6 @@ snapshots:
       - uploadthing
       - yaml
 
-  autoprefixer@10.5.0(postcss@8.5.15):
-    dependencies:
-      browserslist: 4.28.2
-      caniuse-lite: 1.0.30001793
-      fraction.js: 5.3.4
-      picocolors: 1.1.1
-      postcss: 8.5.15
-      postcss-value-parser: 4.2.0
-
   axobject-query@4.1.0: {}
 
   babel-plugin-transform-hook-names@1.0.2(@babel/core@7.29.0):
@@ -4431,8 +4387,6 @@ snapshots:
       '@babel/core': 7.29.0
 
   bail@2.0.2: {}
-
-  baseline-browser-mapping@2.10.33: {}
 
   baseline-browser-mapping@2.10.7: {}
 
@@ -4454,19 +4408,9 @@ snapshots:
       node-releases: 2.0.36
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
 
-  browserslist@4.28.2:
-    dependencies:
-      baseline-browser-mapping: 2.10.33
-      caniuse-lite: 1.0.30001793
-      electron-to-chromium: 1.5.364
-      node-releases: 2.0.36
-      update-browserslist-db: 1.2.3(browserslist@4.28.2)
-
   cac@6.7.14: {}
 
   caniuse-lite@1.0.30001778: {}
-
-  caniuse-lite@1.0.30001793: {}
 
   ccount@2.0.1: {}
 
@@ -4816,8 +4760,6 @@ snapshots:
 
   electron-to-chromium@1.5.313: {}
 
-  electron-to-chromium@1.5.364: {}
-
   entities@4.5.0: {}
 
   entities@6.0.1: {}
@@ -4963,8 +4905,6 @@ snapshots:
   fontkitten@1.0.3:
     dependencies:
       tiny-inflate: 1.0.3
-
-  fraction.js@5.3.4: {}
 
   fsevents@2.3.2:
     optional: true
@@ -5931,8 +5871,6 @@ snapshots:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
-  postcss-value-parser@4.2.0: {}
-
   postcss@8.5.15:
     dependencies:
       nanoid: 3.3.12
@@ -6423,12 +6361,6 @@ snapshots:
   update-browserslist-db@1.2.3(browserslist@4.28.1):
     dependencies:
       browserslist: 4.28.1
-      escalade: 3.2.0
-      picocolors: 1.1.1
-
-  update-browserslist-db@1.2.3(browserslist@4.28.2):
-    dependencies:
-      browserslist: 4.28.2
       escalade: 3.2.0
       picocolors: 1.1.1
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,16 +74,25 @@ importers:
     devDependencies:
       '@preact/preset-vite':
         specifier: ^2.10.2
-        version: 2.10.3(@babel/core@7.29.0)(preact@10.29.0)(rollup@4.59.0)(vite@6.4.1(@types/node@24.12.0)(tsx@4.21.0))
+        version: 2.10.3(@babel/core@7.29.0)(preact@10.29.0)(rollup@4.59.0)(vite@6.4.1(@types/node@24.12.0)(jiti@1.21.7)(tsx@4.21.0))
+      autoprefixer:
+        specifier: ^10.5.0
+        version: 10.5.0(postcss@8.5.15)
+      postcss:
+        specifier: ^8.5.15
+        version: 8.5.15
+      tailwindcss:
+        specifier: ^4.3.0
+        version: 4.3.0
       typescript:
         specifier: ^5.8.2
         version: 5.9.3
       vite:
         specifier: ^6.2.0
-        version: 6.4.1(@types/node@24.12.0)(tsx@4.21.0)
+        version: 6.4.1(@types/node@24.12.0)(jiti@1.21.7)(tsx@4.21.0)
       vitest:
         specifier: ^3.0.7
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(tsx@4.21.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@1.21.7)(tsx@4.21.0)
 
   apps/website:
     dependencies:
@@ -92,13 +101,13 @@ importers:
         version: 3.7.1
       '@astrojs/starlight':
         specifier: ^0.38.1
-        version: 0.38.1(astro@6.0.4(@types/node@24.12.0)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.9.3))
+        version: 0.38.1(astro@6.0.4(@types/node@24.12.0)(jiti@1.21.7)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.9.3))
       astro:
         specifier: ^6.0.4
-        version: 6.0.4(@types/node@24.12.0)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.9.3)
+        version: 6.0.4(@types/node@24.12.0)(jiti@1.21.7)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.9.3)
       astro-mermaid:
         specifier: ^2.0.1
-        version: 2.0.1(astro@6.0.4(@types/node@24.12.0)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.9.3))(mermaid@11.13.0)
+        version: 2.0.1(astro@6.0.4(@types/node@24.12.0)(jiti@1.21.7)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.9.3))(mermaid@11.13.0)
       mermaid:
         specifier: ^11.13.0
         version: 11.13.0
@@ -117,7 +126,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.7
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(tsx@4.21.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@1.21.7)(tsx@4.21.0)
 
 packages:
 
@@ -1328,6 +1337,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@upsetjs/venn.js@2.0.0':
     resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
@@ -1442,6 +1452,13 @@ packages:
     engines: {node: ^20.19.1 || >=22.12.0, npm: '>=9.6.5', pnpm: '>=7.1.0'}
     hasBin: true
 
+  autoprefixer@10.5.0:
+    resolution: {integrity: sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==}
+    engines: {node: ^10 || ^12 || >=14}
+    hasBin: true
+    peerDependencies:
+      postcss: ^8.1.0
+
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
@@ -1453,6 +1470,11 @@ packages:
 
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
+  baseline-browser-mapping@2.10.33:
+    resolution: {integrity: sha512-bA6+tcSLpz2tIEdDXZPpPTIuxBcC4+w6SieaYyfigIa4h8GlFxbA17v22Vx3JUtuZQj9SgOsnbK+aTBzyDyEuw==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
 
   baseline-browser-mapping@2.10.7:
     resolution: {integrity: sha512-1ghYO3HnxGec0TCGBXiDLVns4eCSx4zJpxnHrlqFQajmhfKMQBzUGDdkMK7fUW7PTHTeLf+j87aTuKuuwWzMGw==}
@@ -1473,12 +1495,20 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
 
   caniuse-lite@1.0.30001778:
     resolution: {integrity: sha512-PN7uxFL+ExFJO61aVmP1aIEG4i9whQd4eoSCebav62UwDyp5OHh06zN4jqKSMePVgxHifCw1QJxdRkA1Pisekg==}
+
+  caniuse-lite@1.0.30001793:
+    resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -1826,6 +1856,9 @@ packages:
   electron-to-chromium@1.5.313:
     resolution: {integrity: sha512-QBMrTWEf00GXZmJyx2lbYD45jpI3TUFnNIzJ5BBc8piGUDwMPa1GV6HJWTZVvY/eiN3fSopl7NRbgGp9sZ9LTA==}
 
+  electron-to-chromium@1.5.364:
+    resolution: {integrity: sha512-G/dYE3+AYhyHwzTwg8UbnXf7zqMERYh7l2jJ3QujhFsH8agSYwtnGAR2aZ7f0AakIKJXd5En/Hre4igIUrdlYw==}
+
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
@@ -1920,6 +1953,9 @@ packages:
   fontkitten@1.0.3:
     resolution: {integrity: sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw==}
     engines: {node: '>=20'}
+
+  fraction.js@5.3.4:
+    resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
 
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
@@ -2075,6 +2111,10 @@ packages:
   is-wsl@3.1.1:
     resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
     engines: {node: '>=16'}
+
+  jiti@1.21.7:
+    resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
+    hasBin: true
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -2340,6 +2380,11 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   neotraverse@0.6.18:
     resolution: {integrity: sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==}
     engines: {node: '>= 10'}
@@ -2461,6 +2506,13 @@ packages:
   postcss-selector-parser@6.1.2:
     resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
     engines: {node: '>=4'}
+
+  postcss-value-parser@4.2.0:
+    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
+
+  postcss@8.5.15:
+    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+    engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.8:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
@@ -2677,6 +2729,9 @@ packages:
     resolution: {integrity: sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==}
     engines: {node: '>=16'}
     hasBin: true
+
+  tailwindcss@4.3.0:
+    resolution: {integrity: sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==}
 
   tiny-inflate@1.0.3:
     resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
@@ -3103,12 +3158,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@5.0.0(astro@6.0.4(@types/node@24.12.0)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.9.3))':
+  '@astrojs/mdx@5.0.0(astro@6.0.4(@types/node@24.12.0)(jiti@1.21.7)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.9.3))':
     dependencies:
       '@astrojs/markdown-remark': 7.0.0
       '@mdx-js/mdx': 3.1.1
       acorn: 8.16.0
-      astro: 6.0.4(@types/node@24.12.0)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.9.3)
+      astro: 6.0.4(@types/node@24.12.0)(jiti@1.21.7)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.9.3)
       es-module-lexer: 2.0.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -3132,17 +3187,17 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 4.3.6
 
-  '@astrojs/starlight@0.38.1(astro@6.0.4(@types/node@24.12.0)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.9.3))':
+  '@astrojs/starlight@0.38.1(astro@6.0.4(@types/node@24.12.0)(jiti@1.21.7)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.9.3))':
     dependencies:
       '@astrojs/markdown-remark': 7.0.0
-      '@astrojs/mdx': 5.0.0(astro@6.0.4(@types/node@24.12.0)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.9.3))
+      '@astrojs/mdx': 5.0.0(astro@6.0.4(@types/node@24.12.0)(jiti@1.21.7)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.9.3))
       '@astrojs/sitemap': 3.7.1
       '@pagefind/default-ui': 1.4.0
       '@types/hast': 3.0.4
       '@types/js-yaml': 4.0.9
       '@types/mdast': 4.0.4
-      astro: 6.0.4(@types/node@24.12.0)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.9.3)
-      astro-expressive-code: 0.41.7(astro@6.0.4(@types/node@24.12.0)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.9.3))
+      astro: 6.0.4(@types/node@24.12.0)(jiti@1.21.7)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.9.3)
+      astro-expressive-code: 0.41.7(astro@6.0.4(@types/node@24.12.0)(jiti@1.21.7)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.9.3))
       bcp-47: 2.1.0
       hast-util-from-html: 2.0.3
       hast-util-select: 6.0.4
@@ -3784,18 +3839,18 @@ snapshots:
     dependencies:
       playwright: 1.58.2
 
-  '@preact/preset-vite@2.10.3(@babel/core@7.29.0)(preact@10.29.0)(rollup@4.59.0)(vite@6.4.1(@types/node@24.12.0)(tsx@4.21.0))':
+  '@preact/preset-vite@2.10.3(@babel/core@7.29.0)(preact@10.29.0)(rollup@4.59.0)(vite@6.4.1(@types/node@24.12.0)(jiti@1.21.7)(tsx@4.21.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.29.0)
       '@babel/plugin-transform-react-jsx-development': 7.27.1(@babel/core@7.29.0)
-      '@prefresh/vite': 2.4.12(preact@10.29.0)(vite@6.4.1(@types/node@24.12.0)(tsx@4.21.0))
+      '@prefresh/vite': 2.4.12(preact@10.29.0)(vite@6.4.1(@types/node@24.12.0)(jiti@1.21.7)(tsx@4.21.0))
       '@rollup/pluginutils': 5.3.0(rollup@4.59.0)
       babel-plugin-transform-hook-names: 1.0.2(@babel/core@7.29.0)
       debug: 4.4.3
       picocolors: 1.1.1
-      vite: 6.4.1(@types/node@24.12.0)(tsx@4.21.0)
-      vite-prerender-plugin: 0.5.12(vite@6.4.1(@types/node@24.12.0)(tsx@4.21.0))
+      vite: 6.4.1(@types/node@24.12.0)(jiti@1.21.7)(tsx@4.21.0)
+      vite-prerender-plugin: 0.5.12(vite@6.4.1(@types/node@24.12.0)(jiti@1.21.7)(tsx@4.21.0))
     transitivePeerDependencies:
       - preact
       - rollup
@@ -3816,7 +3871,7 @@ snapshots:
 
   '@prefresh/utils@1.2.1': {}
 
-  '@prefresh/vite@2.4.12(preact@10.29.0)(vite@6.4.1(@types/node@24.12.0)(tsx@4.21.0))':
+  '@prefresh/vite@2.4.12(preact@10.29.0)(vite@6.4.1(@types/node@24.12.0)(jiti@1.21.7)(tsx@4.21.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@prefresh/babel-plugin': 0.5.3
@@ -3824,7 +3879,7 @@ snapshots:
       '@prefresh/utils': 1.2.1
       '@rollup/pluginutils': 4.2.1
       preact: 10.29.0
-      vite: 6.4.1(@types/node@24.12.0)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@24.12.0)(jiti@1.21.7)(tsx@4.21.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -4180,13 +4235,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@6.4.1(@types/node@24.12.0)(tsx@4.21.0))':
+  '@vitest/mocker@3.2.4(vite@6.4.1(@types/node@24.12.0)(jiti@1.21.7)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 6.4.1(@types/node@24.12.0)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@24.12.0)(jiti@1.21.7)(tsx@4.21.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -4253,20 +4308,20 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro-expressive-code@0.41.7(astro@6.0.4(@types/node@24.12.0)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.9.3)):
+  astro-expressive-code@0.41.7(astro@6.0.4(@types/node@24.12.0)(jiti@1.21.7)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.9.3)):
     dependencies:
-      astro: 6.0.4(@types/node@24.12.0)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.9.3)
+      astro: 6.0.4(@types/node@24.12.0)(jiti@1.21.7)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.9.3)
       rehype-expressive-code: 0.41.7
 
-  astro-mermaid@2.0.1(astro@6.0.4(@types/node@24.12.0)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.9.3))(mermaid@11.13.0):
+  astro-mermaid@2.0.1(astro@6.0.4(@types/node@24.12.0)(jiti@1.21.7)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.9.3))(mermaid@11.13.0):
     dependencies:
-      astro: 6.0.4(@types/node@24.12.0)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.9.3)
+      astro: 6.0.4(@types/node@24.12.0)(jiti@1.21.7)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.9.3)
       import-meta-resolve: 4.2.0
       mdast-util-to-string: 4.0.0
       mermaid: 11.13.0
       unist-util-visit: 5.1.0
 
-  astro@6.0.4(@types/node@24.12.0)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.9.3):
+  astro@6.0.4(@types/node@24.12.0)(jiti@1.21.7)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.9.3):
     dependencies:
       '@astrojs/compiler': 3.0.0
       '@astrojs/internal-helpers': 0.8.0
@@ -4318,8 +4373,8 @@ snapshots:
       unist-util-visit: 5.1.0
       unstorage: 1.17.4
       vfile: 6.0.3
-      vite: 7.3.1(@types/node@24.12.0)(tsx@4.21.0)
-      vitefu: 1.1.2(vite@7.3.1(@types/node@24.12.0)(tsx@4.21.0))
+      vite: 7.3.1(@types/node@24.12.0)(jiti@1.21.7)(tsx@4.21.0)
+      vitefu: 1.1.2(vite@7.3.1(@types/node@24.12.0)(jiti@1.21.7)(tsx@4.21.0))
       xxhash-wasm: 1.1.0
       yargs-parser: 22.0.0
       zod: 4.3.6
@@ -4360,6 +4415,15 @@ snapshots:
       - uploadthing
       - yaml
 
+  autoprefixer@10.5.0(postcss@8.5.15):
+    dependencies:
+      browserslist: 4.28.2
+      caniuse-lite: 1.0.30001793
+      fraction.js: 5.3.4
+      picocolors: 1.1.1
+      postcss: 8.5.15
+      postcss-value-parser: 4.2.0
+
   axobject-query@4.1.0: {}
 
   babel-plugin-transform-hook-names@1.0.2(@babel/core@7.29.0):
@@ -4367,6 +4431,8 @@ snapshots:
       '@babel/core': 7.29.0
 
   bail@2.0.2: {}
+
+  baseline-browser-mapping@2.10.33: {}
 
   baseline-browser-mapping@2.10.7: {}
 
@@ -4388,9 +4454,19 @@ snapshots:
       node-releases: 2.0.36
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
 
+  browserslist@4.28.2:
+    dependencies:
+      baseline-browser-mapping: 2.10.33
+      caniuse-lite: 1.0.30001793
+      electron-to-chromium: 1.5.364
+      node-releases: 2.0.36
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
   cac@6.7.14: {}
 
   caniuse-lite@1.0.30001778: {}
+
+  caniuse-lite@1.0.30001793: {}
 
   ccount@2.0.1: {}
 
@@ -4740,6 +4816,8 @@ snapshots:
 
   electron-to-chromium@1.5.313: {}
 
+  electron-to-chromium@1.5.364: {}
+
   entities@4.5.0: {}
 
   entities@6.0.1: {}
@@ -4885,6 +4963,8 @@ snapshots:
   fontkitten@1.0.3:
     dependencies:
       tiny-inflate: 1.0.3
+
+  fraction.js@5.3.4: {}
 
   fsevents@2.3.2:
     optional: true
@@ -5154,6 +5234,9 @@ snapshots:
   is-wsl@3.1.1:
     dependencies:
       is-inside-container: 1.0.0
+
+  jiti@1.21.7:
+    optional: true
 
   js-tokens@4.0.0: {}
 
@@ -5715,6 +5798,8 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  nanoid@3.3.12: {}
+
   neotraverse@0.6.18: {}
 
   nlcst-to-string@4.0.0:
@@ -5845,6 +5930,14 @@ snapshots:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
+
+  postcss-value-parser@4.2.0: {}
+
+  postcss@8.5.15:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   postcss@8.5.8:
     dependencies:
@@ -6200,6 +6293,8 @@ snapshots:
       picocolors: 1.1.1
       sax: 1.5.0
 
+  tailwindcss@4.3.0: {}
+
   tiny-inflate@1.0.3: {}
 
   tinybench@2.9.0: {}
@@ -6331,6 +6426,12 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
+    dependencies:
+      browserslist: 4.28.2
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
   util-deprecate@1.0.2: {}
 
   uuid@11.1.0: {}
@@ -6354,13 +6455,13 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-node@3.2.4(@types/node@24.12.0)(tsx@4.21.0):
+  vite-node@3.2.4(@types/node@24.12.0)(jiti@1.21.7)(tsx@4.21.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.4.1(@types/node@24.12.0)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@24.12.0)(jiti@1.21.7)(tsx@4.21.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -6375,7 +6476,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite-prerender-plugin@0.5.12(vite@6.4.1(@types/node@24.12.0)(tsx@4.21.0)):
+  vite-prerender-plugin@0.5.12(vite@6.4.1(@types/node@24.12.0)(jiti@1.21.7)(tsx@4.21.0)):
     dependencies:
       kolorist: 1.8.0
       magic-string: 0.30.21
@@ -6383,22 +6484,23 @@ snapshots:
       simple-code-frame: 1.3.0
       source-map: 0.7.6
       stack-trace: 1.0.0-pre2
-      vite: 6.4.1(@types/node@24.12.0)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@24.12.0)(jiti@1.21.7)(tsx@4.21.0)
 
-  vite@6.4.1(@types/node@24.12.0)(tsx@4.21.0):
+  vite@6.4.1(@types/node@24.12.0)(jiti@1.21.7)(tsx@4.21.0):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
-      postcss: 8.5.8
+      postcss: 8.5.15
       rollup: 4.59.0
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 24.12.0
       fsevents: 2.3.3
+      jiti: 1.21.7
       tsx: 4.21.0
 
-  vite@7.3.1(@types/node@24.12.0)(tsx@4.21.0):
+  vite@7.3.1(@types/node@24.12.0)(jiti@1.21.7)(tsx@4.21.0):
     dependencies:
       esbuild: 0.27.4
       fdir: 6.5.0(picomatch@4.0.3)
@@ -6409,17 +6511,18 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.12.0
       fsevents: 2.3.3
+      jiti: 1.21.7
       tsx: 4.21.0
 
-  vitefu@1.1.2(vite@7.3.1(@types/node@24.12.0)(tsx@4.21.0)):
+  vitefu@1.1.2(vite@7.3.1(@types/node@24.12.0)(jiti@1.21.7)(tsx@4.21.0)):
     optionalDependencies:
-      vite: 7.3.1(@types/node@24.12.0)(tsx@4.21.0)
+      vite: 7.3.1(@types/node@24.12.0)(jiti@1.21.7)(tsx@4.21.0)
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(tsx@4.21.0):
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@1.21.7)(tsx@4.21.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@24.12.0)(tsx@4.21.0))
+      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@24.12.0)(jiti@1.21.7)(tsx@4.21.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -6437,8 +6540,8 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 6.4.1(@types/node@24.12.0)(tsx@4.21.0)
-      vite-node: 3.2.4(@types/node@24.12.0)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@24.12.0)(jiti@1.21.7)(tsx@4.21.0)
+      vite-node: 3.2.4(@types/node@24.12.0)(jiti@1.21.7)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12


### PR DESCRIPTION
{
  "title": "feat(web): convert frontend to Tailwind CSS v4",
  "head": "feat/tailwind-v4",
  "base": "main",
  "body": "## Summary\n\nConvert the entire gmux web frontend from custom CSS to Tailwind CSS v4.\n\n## Changes\n\n### Setup\n- Install tailwindcss@4 with CSS-first configuration\n- Define custom colors in @theme block (--color-bg, --color-text, etc.)\n- Remove postcss and autoprefixer devDependencies (bundled in Tailwind v4)\n- Remove tailwind.config.js (v4 uses CSS-first config)\n\n### Components Converted to Tailwind\n- main.tsx — app layout, main header, session menu, state messages\n- sidebar.tsx — session items, folder headers, sidebar structure\n- session-row.tsx — wide session row with metadata\n- launcher.tsx — launch button + inline menu\n- host-suffix.tsx — peer name suffix\n- peer-label.tsx — colored peer badge\n- jump-to-bottom.tsx — floating scroll button\n- home.tsx — activity sections, footer, notification prompt\n- project-hub.tsx — project page layout\n\n### Spacing Normalization\n- Converted non-standard padding values (py-[5px], py-[7px], py-[3px], px-[5px], py-[1px]) to Tailwind's spacing scale (py-1, py-2, px-1, py-0)\n- This ensures consistent spacing throughout the UI\n\n### Preserved in CSS\n- Design tokens (CSS custom properties for theming)\n- Animations (@keyframes for dot-arrival, pulse, modal transitions)\n- xterm.js overrides (terminal rendering)\n- Complex parent-child hover patterns (.folder-header:hover .launch-btn)\n- Pseudo-elements (::before, ::after for selected indicators, waiting dots)\n- Mobile media queries (sidebar overlay, bottom bar)\n- Settings modal, hosts tab, input diagnostics (complex component layouts)\n\n### Cleanup\n- Removed ~180 lines of unused CSS (Home, Hub, Notification sections)\n- CSS reduced from 2532 lines to ~1500 lines\n\n## Verification\n- Build succeeds\n- All 426 tests pass\n- Dev server starts"
}
