### PR TITLE
feat(gmuxd): resolve node identity from live tailscale name (ADR 0007 §1-2)

### DIFF
--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gmuxapp/gmux/packages/paths"
 	"github.com/gmuxapp/gmux/packages/sessionenv"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/authtoken"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/identity"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/nodeid"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/binhash"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/clipfile"
@@ -705,9 +706,15 @@ func serve(stderr io.Writer) int {
 			"node_id": nodeID,
 			"status":  "ready",
 		}
-		if h, err := os.Hostname(); err == nil {
-			data["hostname"] = h
+		// Node identity (ADR 0007): the live tailscale name when
+		// connected, else the OS hostname. Evaluated per request so it
+		// converges once the tailscale listener becomes ready.
+		osHost, _ := os.Hostname()
+		tsFQDN := ""
+		if tsListener != nil {
+			tsFQDN = tsListener.FQDN()
 		}
+		data["hostname"] = identity.Resolve(tsFQDN, osHost)
 		if tsListener != nil {
 			diag := tsListener.Diag()
 			if diag.FQDN != "" {

--- a/services/gmuxd/internal/identity/identity.go
+++ b/services/gmuxd/internal/identity/identity.go
@@ -1,0 +1,30 @@
+// Package identity resolves this node's stable, human-readable name
+// (ADR 0007): the live tailscale hostname when tailscale is connected,
+// otherwise the OS hostname.
+//
+// This single value feeds the /v1/health `hostname` field (and thus how
+// peers name this node in their UI and URLs), so it must be the name the
+// node is actually reachable as — not os.Hostname(), which inside a
+// container is the ephemeral container ID and churns on recreation.
+package identity
+
+import "strings"
+
+// Resolve returns the node identity given the live tailscale FQDN (empty
+// when tailscale is disabled or not yet connected) and the OS hostname.
+//
+// The tailscale name — the first label of the FQDN, e.g. "gmux-laptop"
+// from "gmux-laptop.tailnet.ts.net" — wins when present. Tailscale owns
+// and persists this name (post-dedup) in its node state, so it is sticky
+// across daemon restarts and container recreation. With no tailscale
+// FQDN, the OS hostname is used.
+func Resolve(tailscaleFQDN, osHostname string) string {
+	label := tailscaleFQDN
+	if i := strings.IndexByte(tailscaleFQDN, '.'); i >= 0 {
+		label = tailscaleFQDN[:i]
+	}
+	if label != "" {
+		return label
+	}
+	return osHostname
+}

--- a/services/gmuxd/internal/identity/identity_test.go
+++ b/services/gmuxd/internal/identity/identity_test.go
@@ -1,0 +1,25 @@
+package identity
+
+import "testing"
+
+func TestResolve(t *testing.T) {
+	tests := []struct {
+		name     string
+		fqdn     string
+		osHost   string
+		want     string
+	}{
+		{"tailscale fqdn wins over os hostname", "gmux-laptop.tailnet.ts.net", "ca75413aec31", "gmux-laptop"},
+		{"fqdn without dot used as-is", "gmux-laptop", "host", "gmux-laptop"},
+		{"no fqdn falls back to os hostname", "", "my-server", "my-server"},
+		{"empty both", "", "", ""},
+		{"leading-dot fqdn falls back (no usable label)", ".weird", "host", "host"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Resolve(tt.fqdn, tt.osHost); got != tt.want {
+				t.Fatalf("Resolve(%q, %q) = %q, want %q", tt.fqdn, tt.osHost, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Implements ADR 0007 §1–§2: a single node identity = the **live tailscale name** when connected, else `os.Hostname()`.

## Change
- New `internal/identity` package: `Resolve(tailscaleFQDN, osHostname)` returns the first FQDN label (e.g. `gmux-laptop` from `gmux-laptop.tailnet.ts.net`) when present, else the OS hostname. Empty/degenerate first label falls back.
- `/v1/health` `hostname` field now uses `identity.Resolve(tsListener.FQDN(), os.Hostname())`, evaluated per request so it converges once the tailscale listener becomes ready.

## Why
This is the real fix for the original `@ca75413aec31` bug: a tailscale-connected container was named by its `os.Hostname()` (the ephemeral container ID). It now reports its tailscale name, which tailscale owns and keeps sticky across restarts/recreation. Peers name this node by the health `hostname` field, so this directly stabilizes peer names and URLs.

## Verification
- Unit tests for `Resolve` (fqdn wins / no-dot / fallback / empty / leading-dot).
- `go build`, `go vet`, full `go test ./...` (26 pkgs) pass.
- **Live**: on a tailscale-enabled host, `/v1/health` now reports `hostname: gmux` (the tailscale name) where it previously reported the OS hostname.

Stacked on #262 (ADR + node_id).