### PR TITLE
feat(gmuxd): gate devcontainer discovery on the local_folder label (ADR 0007 §3)

### DIFF
--- a/services/gmuxd/internal/devcontainers/watcher.go
+++ b/services/gmuxd/internal/devcontainers/watcher.go
@@ -348,10 +348,20 @@ func dockerSocketPath() string {
 	return "/var/run/docker.sock"
 }
 
-// isGmuxContainer returns true if a container is running gmuxd via the
-// devcontainer feature. Detection: GMUXD_LISTEN env var is set by the
-// feature's containerEnv.
+// isGmuxContainer returns true if a container is a discoverable gmux
+// devcontainer. It must (1) run gmuxd via the devcontainer feature —
+// detected by the GMUXD_LISTEN env var set in the feature's
+// containerEnv — and (2) carry the `devcontainer.local_folder` label
+// (ADR 0007 §3).
+//
+// Gating on the label means discovery only ever names a peer after its
+// host folder (deriveName), never after the ephemeral container ID:
+// a label-less container is simply not discovered, so the ID fallback
+// can't churn the peer name on every container recreation.
 func isGmuxContainer(c container) bool {
+	if _, ok := c.Labels["devcontainer.local_folder"]; !ok {
+		return false
+	}
 	for _, e := range c.Env {
 		if strings.HasPrefix(e, "GMUXD_LISTEN=") {
 			return true

--- a/services/gmuxd/internal/devcontainers/watcher_test.go
+++ b/services/gmuxd/internal/devcontainers/watcher_test.go
@@ -727,19 +727,24 @@ func TestDockerSocketPath(t *testing.T) {
 }
 
 func TestIsGmuxContainer(t *testing.T) {
+	// Discovery requires BOTH the GMUXD_LISTEN env var and the
+	// devcontainer.local_folder label (ADR 0007 §3).
+	withLabel := map[string]string{"devcontainer.local_folder": "/home/user/proj"}
 	tests := []struct {
-		name string
-		env  []string
-		want bool
+		name   string
+		env    []string
+		labels map[string]string
+		want   bool
 	}{
-		{"with GMUXD_LISTEN", []string{"PATH=/bin", "GMUXD_LISTEN=0.0.0.0"}, true},
-		{"without GMUXD_LISTEN", []string{"PATH=/bin", "REDIS_PORT=6379"}, false},
-		{"empty env", nil, false},
-		{"partial match", []string{"GMUXD_LISTEN_OTHER=x"}, false},
+		{"env + label", []string{"PATH=/bin", "GMUXD_LISTEN=0.0.0.0"}, withLabel, true},
+		{"env but no label", []string{"PATH=/bin", "GMUXD_LISTEN=0.0.0.0"}, nil, false},
+		{"label but no GMUXD_LISTEN", []string{"PATH=/bin", "REDIS_PORT=6379"}, withLabel, false},
+		{"empty env, with label", nil, withLabel, false},
+		{"partial env match, with label", []string{"GMUXD_LISTEN_OTHER=x"}, withLabel, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := container{Env: tt.env}
+			c := container{Env: tt.env, Labels: tt.labels}
 			if got := isGmuxContainer(c); got != tt.want {
 				t.Errorf("isGmuxContainer = %v, want %v", got, tt.want)
 			}


### PR DESCRIPTION
Implements ADR 0007 §3: devcontainer autodiscovery now requires the `devcontainer.local_folder` label in addition to the `GMUXD_LISTEN` env marker.

## Change
- `isGmuxContainer` returns false for any container lacking the `devcontainer.local_folder` label.

## Why
`deriveName` falls back to the container ID when a container has neither the folder label nor a usable name — that ID churns on every container recreation, producing unstable peer names/URLs. Gating discovery on the label means a discovered container *always* has a stable, folder-derived name; a label-less container is simply not discovered, so the ID fallback can never fire. The churn becomes impossible by construction rather than patched.

Behavior change: hand-rolled `docker run` gmuxd containers without the label stop being auto-discovered. This is intended for 2.0 — properly-launched devcontainers (VS Code Dev Containers / `devcontainer` CLI) always set the label.

## Verification
- `TestIsGmuxContainer` updated to require both env + label (covers env-but-no-label, label-but-no-env, etc.).
- Full `go test ./...` (26 pkgs) pass.

Stacked on the identity-resolve PR.