### PR TITLE
feat(gmuxd)!: host identity, naming & peer URLs (ADR 0007)

### DIFF
--- a/apps/gmux-web/src/mock-data/index.ts
+++ b/apps/gmux-web/src/mock-data/index.ts
@@ -26,14 +26,16 @@ export const MOCK_SESSIONS: MockSession[] = [
   shellOpenclawLogs,
 ]
 
-/** Mock peers (host roster). Covers connected, a Local devcontainer,
- *  and a disconnected host carrying a last_error so the Hosts tab
- *  exercises every row state. */
+/** Mock peers (host roster). Covers all three Hosts-tab groups
+ *  (tailnet-discovered, devcontainer, manual), a connected and a
+ *  disconnected row, and a manual host carrying a last_error so the
+ *  grouping and every row state are exercised. */
 export const MOCK_PEERS: PeerInfo[] = [
-  { name: 'laptop', url: 'https://laptop.tail-scale.ts.net', status: 'connected', session_count: 2, version: '1.2.0' },
-  { name: 'server', url: 'https://server.tail-scale.ts.net', status: 'connected', session_count: 4, version: '1.1.9' },
-  { name: 'devcontainer', url: 'https://devcontainer.tail-scale.ts.net', status: 'connected', session_count: 1, version: '1.2.0', local: true },
-  { name: 'bespin', url: 'https://bespin.tail-scale.ts.net', status: 'disconnected', session_count: 0, last_error: 'dial tcp 100.84.12.9:443: connect: connection refused' },
+  { name: 'laptop', url: 'https://laptop.tail-scale.ts.net', status: 'connected', session_count: 2, version: '1.2.0', source: 'tailscale' },
+  { name: 'server', url: 'https://server.tail-scale.ts.net', status: 'connected', session_count: 4, version: '1.1.9', source: 'tailscale' },
+  { name: 'devcontainer', url: 'https://devcontainer.tail-scale.ts.net', status: 'connected', session_count: 1, version: '1.2.0', local: true, source: 'devcontainer' },
+  { name: 'konyvtar', url: 'https://gmux.tail95157a.ts.net', status: 'connected', session_count: 1, version: '1.2.0', source: 'manual' },
+  { name: 'bespin', url: 'https://bespin.tail-scale.ts.net', status: 'disconnected', session_count: 0, last_error: 'dial tcp 100.84.12.9:443: connect: connection refused', source: 'manual' },
 ]
 
 /** Mock daemon health for the local host. */

--- a/apps/gmux-web/src/settings.tsx
+++ b/apps/gmux-web/src/settings.tsx
@@ -19,7 +19,7 @@ import {
   projects, discovered, peerProjects, peerStatusByName,
   addProject, addPeerReference, folders, updateProjects,
   removeProject, removePeerReference, localHostLabel,
-  health, peers, sessions,
+  health, peers, sessions, connectHost, disconnectHost,
 } from './store'
 import { PeerLabel } from './peer-label'
 import { HostSuffix } from './host-suffix'
@@ -304,35 +304,101 @@ function HostsTab() {
   // PeerInfo.session_count for the synthesized self row.
   const localCount = sessions.value.filter(s => !s.peer).length
 
+  const [url, setUrl] = useState('')
+  const [token, setToken] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState('')
+  const [notice, setNotice] = useState('')
+
+  const handleConnect = useCallback(async () => {
+    const u = url.trim()
+    if (!u) { setError('Enter a host URL.'); return }
+    setBusy(true); setError(''); setNotice('')
+    try {
+      const { name, alreadyConnected } = await connectHost(u, token.trim())
+      setNotice(alreadyConnected ? `Already connected to ${name}.` : `Connected to ${name}.`)
+      setUrl(''); setToken('')
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Could not connect.')
+    } finally {
+      setBusy(false)
+    }
+  }, [url, token])
+
+  const handleRemove = useCallback(async (name: string) => {
+    setError(''); setNotice('')
+    try {
+      await disconnectHost(name)
+      setNotice(`Disconnected from ${name}.`)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Could not disconnect.')
+    }
+  }, [])
+
   return (
-    <section class="mp-section">
-      <div class="mp-section-label">Hosts</div>
-      <div class="host-list">
-        <HostRow
-          self
-          name={h?.hostname ?? 'this host'}
-          status="connected"
-          sessionCount={localCount}
-          version={h?.version}
-        />
-        {peersVal.map(p => (
+    <>
+      <section class="mp-section">
+        <div class="mp-section-label">Hosts</div>
+        <div class="host-list">
           <HostRow
-            key={p.name}
-            name={p.name}
-            status={p.status}
-            sessionCount={p.session_count}
-            version={p.version}
-            lastError={p.last_error}
-            local={p.local}
+            self
+            name={h?.hostname ?? 'this host'}
+            status="connected"
+            sessionCount={localCount}
+            version={h?.version}
           />
-        ))}
-      </div>
-    </section>
+          {peersVal.map(p => (
+            <HostRow
+              key={p.name}
+              name={p.name}
+              status={p.status}
+              sessionCount={p.session_count}
+              version={p.version}
+              lastError={p.last_error}
+              local={p.local}
+              onRemove={p.local ? undefined : () => handleRemove(p.name)}
+            />
+          ))}
+        </div>
+      </section>
+
+      <section class="mp-section">
+        <div class="mp-section-label">Connect to host</div>
+        <div class="mp-path-add-row">
+          <input
+            class="mp-filter-input mp-path-input"
+            type="text"
+            placeholder="https://gmux-host.tailnet.ts.net"
+            value={url}
+            onInput={(e) => { setUrl((e.target as HTMLInputElement).value); setError(''); setNotice('') }}
+            onKeyDown={(e) => { if (e.key === 'Enter') handleConnect() }}
+          />
+          <button class="mp-manual-btn" onClick={handleConnect} disabled={busy || url.trim() === ''}>
+            {busy ? 'Connecting…' : 'Connect'}
+          </button>
+        </div>
+        <input
+          class="mp-filter-input mp-host-token"
+          type="password"
+          placeholder="Access token (leave blank on your tailnet)"
+          value={token}
+          onInput={(e) => { setToken((e.target as HTMLInputElement).value) }}
+          onKeyDown={(e) => { if (e.key === 'Enter') handleConnect() }}
+        />
+        {error ? (
+          <div class="mp-manual-error">{error}</div>
+        ) : notice ? (
+          <div class="mp-path-hint">{notice}</div>
+        ) : (
+          <div class="mp-path-hint">Connect to a host you reach by URL. On your tailnet, leave the token blank — it authenticates by identity.</div>
+        )}
+      </section>
+    </>
   )
 }
 
 function HostRow({
-  name, self, status, sessionCount, version, lastError, local,
+  name, self, status, sessionCount, version, lastError, local, onRemove,
 }: {
   name: string
   self?: boolean
@@ -341,6 +407,7 @@ function HostRow({
   version?: string
   lastError?: string
   local?: boolean
+  onRemove?: () => void
 }) {
   const connected = status === 'connected'
   return (
@@ -360,6 +427,13 @@ function HostRow({
           <span>{sessionCount} session{sessionCount === 1 ? '' : 's'}</span>
           {version && <><span class="host-sep">·</span><span>v{version}</span></>}
         </div>
+        {onRemove && (
+          <button
+            class="host-remove"
+            title="Disconnect host"
+            onClick={(e) => { e.preventDefault(); e.stopPropagation(); onRemove() }}
+          >×</button>
+        )}
       </div>
       {!connected && lastError && (
         <div class="host-error">{lastError}</div>

--- a/apps/gmux-web/src/settings.tsx
+++ b/apps/gmux-web/src/settings.tsx
@@ -21,7 +21,6 @@ import {
   removeProject, removePeerReference, localHostLabel,
   health, peers, sessions, connectHost, disconnectHost,
 } from './store'
-import { PeerLabel } from './peer-label'
 import { HostSuffix } from './host-suffix'
 import type { ProjectItem, DiscoveredProject, MatchRule, Folder } from './types'
 
@@ -414,9 +413,7 @@ function HostRow({
     <div class="host-row">
       <div class="host-row-main">
         <span class={`host-status-dot${connected ? ' connected' : ''}`} aria-hidden="true" />
-        {self
-          ? <span class="host-self-tag">this host</span>
-          : <PeerLabel name={name} />}
+        {self && <span class="host-self-tag">this host</span>}
         <span class="host-name">
           {name}
           {local && <span class="host-local-tag">local</span>}
@@ -460,8 +457,8 @@ function reorder<T>(arr: readonly T[], from: number, to: number): T[] {
  *  management-only — drag-to-reorder and remove, no navigation, no
  *  launch. This is the single ordering that drives the sidebar; the
  *  list maps 1:1 to projects.json items[] (which buildProjectFolders
- *  preserves). Reference rows are distinguished by a leading colored
- *  PeerLabel chip. */
+ *  preserves). Reference rows are distinguished by the muted " · host"
+ *  suffix after the project name. */
 function ConfiguredProjectsSection({ configured }: { configured: ProjectItem[] }) {
   const foldersVal = folders.value
   const [drag, setDrag] = useState<DragState | null>(null)
@@ -552,7 +549,6 @@ function ConfiguredProjectRow({
       onDragEnd={onDragEnd}
     >
       <span class="mp-configured-drag" title="Drag to reorder" aria-hidden="true">⠿</span>
-      {isReference && <PeerLabel name={project.peer!} />}
       <div class="mp-configured-info">
         <span class="mp-configured-name">
           {f.name}
@@ -590,10 +586,10 @@ function DiscoveredRow({
 
   return (
     <div class="mp-discovered-row" onClick={() => onAdd(project)}>
-      {project.peer && <PeerLabel name={project.peer} />}
       <div class="mp-project-info">
         <span class="mp-project-name">
           {project.suggested_slug}
+          <HostSuffix peer={project.peer ?? localHostLabel.value} local={!project.peer} />
           {project.active_count > 0 && (
             <span class="mp-active-badge">{project.active_count}</span>
           )}
@@ -640,9 +636,8 @@ function PeerReferencesSection({ configured }: { configured: ProjectItem[] }) {
             class="mp-discovered-row"
             onClick={() => addPeerReference(peer, slug)}
           >
-            <PeerLabel name={peer} />
             <div class="mp-project-info">
-              <span class="mp-project-name">{slug}</span>
+              <span class="mp-project-name">{slug}<HostSuffix peer={peer} /></span>
             </div>
             <span class="mp-add-label">+ Add</span>
           </div>

--- a/apps/gmux-web/src/settings.tsx
+++ b/apps/gmux-web/src/settings.tsx
@@ -22,7 +22,7 @@ import {
   health, peers, sessions, connectHost, disconnectHost,
 } from './store'
 import { HostSuffix } from './host-suffix'
-import type { ProjectItem, DiscoveredProject, MatchRule, Folder } from './types'
+import type { ProjectItem, DiscoveredProject, MatchRule, Folder, PeerInfo } from './types'
 
 type SettingsTab = 'projects' | 'hosts'
 
@@ -291,11 +291,29 @@ export function SettingsModal({
 
 // ── Hosts tab (read-only roster) ──
 
+/** A peer's group in the Hosts tab. Uses the daemon's `source` when
+ *  present; falls back for older daemons that don't send it (a Local
+ *  peer is a devcontainer, anything else is treated as manual). */
+function peerSource(p: PeerInfo): 'tailscale' | 'devcontainer' | 'manual' {
+  if (p.source === 'tailscale' || p.source === 'devcontainer' || p.source === 'manual') {
+    return p.source
+  }
+  return p.local ? 'devcontainer' : 'manual'
+}
+
+/** Host groups, in display order. Each maps to a peerSource() bucket. */
+const HOST_GROUPS = [
+  { key: 'tailscale', label: 'Discovered on your tailnet' },
+  { key: 'devcontainer', label: 'Devcontainers' },
+  { key: 'manual', label: 'Added manually' },
+] as const
+
 /** Read-only roster of every host gmux knows about: the local host
- *  ("this host", synthesized from health), then the tailnet-discovered
- *  and configured peers. Reachability is already conveyed by the
- *  sidebar pill colors; this surface is the dig — version, session
- *  count, and the last error behind an unreachable host. */
+ *  ("this host", synthesized from health) first, then peers grouped by
+ *  how they were added — tailnet-discovered, devcontainers, and
+ *  manually connected. Reachability is already conveyed by the sidebar
+ *  pill colors; this surface is the dig — version, session count, and
+ *  the last error behind an unreachable host. */
 function HostsTab() {
   const h = health.value
   const peersVal = peers.value
@@ -337,7 +355,7 @@ function HostsTab() {
   return (
     <>
       <section class="mp-section">
-        <div class="mp-section-label">Hosts</div>
+        <div class="mp-section-label">This host</div>
         <div class="host-list">
           <HostRow
             self
@@ -346,20 +364,34 @@ function HostsTab() {
             sessionCount={localCount}
             version={h?.version}
           />
-          {peersVal.map(p => (
-            <HostRow
-              key={p.name}
-              name={p.name}
-              status={p.status}
-              sessionCount={p.session_count}
-              version={p.version}
-              lastError={p.last_error}
-              local={p.local}
-              onRemove={p.local ? undefined : () => handleRemove(p.name)}
-            />
-          ))}
         </div>
       </section>
+
+      {HOST_GROUPS.map(g => {
+        const rows = peersVal.filter(p => peerSource(p) === g.key)
+        if (rows.length === 0) return null
+        return (
+          <section class="mp-section" key={g.key}>
+            <div class="mp-section-label">{g.label}</div>
+            <div class="host-list">
+              {rows.map(p => (
+                <HostRow
+                  key={p.name}
+                  name={p.name}
+                  status={p.status}
+                  sessionCount={p.session_count}
+                  version={p.version}
+                  lastError={p.last_error}
+                  local={p.local}
+                  // Only manual peers can be disconnected; tailscale and
+                  // devcontainer peers are managed automatically.
+                  onRemove={g.key === 'manual' ? () => handleRemove(p.name) : undefined}
+                />
+              ))}
+            </div>
+          </section>
+        )
+      })}
 
       <section class="mp-section">
         <div class="mp-section-label">Connect to host</div>

--- a/apps/gmux-web/src/settings.tsx
+++ b/apps/gmux-web/src/settings.tsx
@@ -411,7 +411,7 @@ function HostsTab() {
         <input
           class="mp-filter-input mp-host-token"
           type="password"
-          placeholder="Access token (leave blank on your tailnet)"
+          placeholder="Token (if not using Tailscale)"
           value={token}
           onInput={(e) => { setToken((e.target as HTMLInputElement).value) }}
           onKeyDown={(e) => { if (e.key === 'Enter') handleConnect() }}

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -869,6 +869,37 @@ export async function addPeerReference(peer: string, slug: string): Promise<void
   await putProjects([...existing, { peer, slug }])
 }
 
+/** Connect to a host (ADR 0007): POST /v1/peers probes the target,
+ *  dedups by node_id, and persists it to peers.json. Returns the name
+ *  the peer was stored under (may be suffixed on a collision) and
+ *  whether it was already connected. Throws with the server message. */
+export async function connectHost(
+  url: string,
+  token: string,
+): Promise<{ name: string; alreadyConnected: boolean }> {
+  const resp = await fetch('/v1/peers', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ url, token }),
+  })
+  const body = await resp.json().catch(() => ({})) as {
+    peer?: { name?: string }; already_connected?: boolean; error?: { message?: string }
+  }
+  if (!resp.ok) {
+    throw new Error(body.error?.message || `Could not connect (${resp.status})`)
+  }
+  return { name: body.peer?.name ?? '', alreadyConnected: !!body.already_connected }
+}
+
+/** Disconnect a manually-added host: DELETE /v1/peers/{name}. */
+export async function disconnectHost(name: string): Promise<void> {
+  const resp = await fetch(`/v1/peers/${encodeURIComponent(name)}`, { method: 'DELETE' })
+  if (!resp.ok) {
+    const body = await resp.json().catch(() => ({})) as { error?: { message?: string } }
+    throw new Error(body.error?.message || `Could not disconnect (${resp.status})`)
+  }
+}
+
 /** Remove a reference item from local projects.json. */
 export async function removePeerReference(peer: string, slug: string): Promise<void> {
   const filtered = projects.value.filter(p => !(p.peer === peer && p.slug === slug))

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -1072,6 +1072,32 @@ body {
 .host-sep {
   opacity: 0.5;
 }
+.host-remove {
+  flex-shrink: 0;
+  width: 22px;
+  height: 22px;
+  margin-left: 8px;
+  border: none;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.1s, background 0.1s, color 0.1s;
+}
+.host-row:hover .host-remove {
+  opacity: 1;
+}
+.host-remove:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+.mp-host-token {
+  margin-top: 8px;
+}
+
 .host-error {
   margin-top: 4px;
   margin-left: 15px;

--- a/apps/gmux-web/src/types.ts
+++ b/apps/gmux-web/src/types.ts
@@ -165,6 +165,13 @@ export interface PeerInfo {
    * stamped by the parent and bucket into local sidebar folders.
    */
   local?: boolean
+  /**
+   * How the peer was added — drives the Hosts-tab grouping. One of
+   * 'tailscale' (auto-discovered on the tailnet), 'devcontainer'
+   * (auto-discovered Docker container), or 'manual' (peers.json /
+   * POST /v1/peers). Absent on older daemons.
+   */
+  source?: 'tailscale' | 'devcontainer' | 'manual'
 }
 
 /**

--- a/apps/website/src/content/docs/multi-machine.md
+++ b/apps/website/src/content/docs/multi-machine.md
@@ -43,18 +43,13 @@ Add one line to your `devcontainer.json` and sessions from inside the container 
 
 The host gmuxd detects the container via Docker events, reads the auth token, and connects over the Docker bridge. See the [Devcontainers](/devcontainers) guide for setup, options, and details.
 
-## Manual peers
+## Connecting to a host manually
 
-For machines that aren't on the same tailnet, configure peers explicitly in `~/.config/gmux/host.toml`:
+For machines that aren't auto-discovered (different tailnet, reachable by URL/IP), open **Settings → Hosts → Connect to host** and enter the host's URL, e.g. `https://gmux-server.your-tailnet.ts.net`. Leave the token blank when the host is on your own tailnet (it authenticates by identity); otherwise paste its auth token.
 
-```toml
-[[peers]]
-name = "server"
-url = "https://gmux-server.your-tailnet.ts.net"
-token = "the-spoke-auth-token"
-```
+gmux probes the host, adopts the name it reports about itself (no name to assign), and saves the connection to `peers.json` in the state directory. If a different host already uses that name, gmux suffixes it (`server-2`) for you. The hub connects immediately and reconnects with exponential backoff on failure; manual and auto-discovered peers use the same protocol.
 
-The hub connects on startup and reconnects with exponential backoff on failure. Manual and auto-discovered peers use the same protocol.
+There is no `[[peers]]` config block (removed in [ADR 0007](https://github.com/gmuxapp/gmux/blob/main/docs/adr/0007-host-identity-and-peer-urls.md)) — peers are runtime state managed from the UI.
 
 ## Session namespacing
 

--- a/apps/website/src/content/docs/reference/host-toml.md
+++ b/apps/website/src/content/docs/reference/host-toml.md
@@ -20,20 +20,21 @@ port = 8790
 # See the Remote Access guide for setup.
 [tailscale]
 enabled = false
-hostname = "gmux"       # → gmux.your-tailnet.ts.net
 allow = []               # additional login names (owner is auto-whitelisted)
 
 # Auto-discover peers. All flags default to true.
 [discovery]
 tailscale = true         # discover other gmux instances on the tailnet
 devcontainers = true     # subscribe to Docker events, register gmux containers
-
-# Manual peers (remote gmuxd instances to aggregate sessions from).
-[[peers]]
-name = "server"
-url = "http://10.0.0.5:8790"
-token_file = "~/.config/gmux/tokens/server"
 ```
+
+## Node identity
+
+This host's name — what peers see in their UI and URLs — is **not** configured here. When Tailscale is enabled the name is your Tailscale machine name (owned and kept stable by Tailscale itself); otherwise it is the OS hostname. The first time the daemon joins a tailnet it requests `gmux-<hostname>`, and Tailscale keeps that name across restarts and container recreation. See [ADR 0007](https://github.com/gmuxapp/gmux/blob/main/docs/adr/0007-host-identity-and-peer-urls.md).
+
+## Connecting to other hosts
+
+There is **no `[[peers]]` config**. Add a host you want to aggregate sessions from at runtime via **Settings → Hosts → Connect to host** (enter its URL; leave the token blank on your own tailnet). Connected hosts are saved to `peers.json` in the state directory, and the peer's name is taken from the host itself — you don't assign one. Hosts on the same tailnet are also discovered automatically.
 
 ## Fields
 
@@ -48,7 +49,6 @@ token_file = "~/.config/gmux/tokens/server"
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `enabled` | `boolean` | `false` | Enable Tailscale remote access. |
-| `hostname` | `string` | `"gmux"` | Tailscale machine name (becomes `<hostname>.your-tailnet.ts.net`). Must be non-empty when enabled. Changing this value automatically clears the Tailscale state and re-registers the device under the new name on the next restart. |
 | `allow` | `string[]` | `[]` | Additional Tailscale login names to allow (owner is auto-whitelisted). Each must contain `@`. |
 
 ### `[discovery]`
@@ -56,19 +56,7 @@ token_file = "~/.config/gmux/tokens/server"
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `tailscale` | `boolean` | `true` | Discover other gmux instances on the tailnet via `WatchIPNBus`. Only active when `tailscale.enabled` is also true. |
-| `devcontainers` | `boolean` | `true` | Subscribe to Docker events and register any container with the gmux devcontainer feature as a peer. Skipped if the Docker CLI is not installed. |
-
-### `[[peers]]` (array of tables)
-
-One table per manual peer. Each peer requires `name`, `url`, and exactly one of `token`, `token_file`, `token_command`.
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `name` | `string` | Unique peer identifier. Appears in URLs (`/@name/`) and session IDs. |
-| `url` | `string` | Base URL of the remote gmuxd, e.g. `http://host:8790`. |
-| `token` | `string` | Inline bearer token. Quick but leaks into your dotfiles. |
-| `token_file` | `string` | Path to a file containing the token. Tilde expansion is supported. |
-| `token_command` | `string` | Shell command (via `sh -c`) whose stdout is the token. Use for 1Password / pass / op integrations. 10 second timeout. |
+| `devcontainers` | `boolean` | `true` | Subscribe to Docker events and register any container with the gmux devcontainer feature **and** the `devcontainer.local_folder` label as a peer. Skipped if the Docker CLI is not installed. |
 
 ## Strict validation
 
@@ -76,10 +64,12 @@ The config file is strictly validated at startup. gmuxd refuses to start if:
 
 - **Unknown keys** are present, catching typos like `alow` instead of `allow`
 - **`allow` entries don't contain `@`**, likely not a valid Tailscale login name
-- **`hostname` is empty** when Tailscale is enabled
 - **`port` is out of range** (must be 1–65535)
-- **A `[[peers]]` entry is missing required fields** (`name`, `url`) or specifies more than one token source
-- **Two `[[peers]]` entries share the same `name`**
 - **TOML syntax is invalid**
+
+Two keys were **removed** and are now rejected with a migration hint (ADR 0007):
+
+- **`tailscale.hostname`** — the node name now comes from Tailscale / the OS hostname.
+- **`[[peers]]`** — manual peers are runtime state; add them via *Connect to host* (stored in `peers.json`).
 
 This is intentional. Silent fallback to defaults is dangerous for security settings. See [Security](/security) for the reasoning.

--- a/apps/website/src/content/docs/reference/host-toml.md
+++ b/apps/website/src/content/docs/reference/host-toml.md
@@ -32,7 +32,7 @@ devcontainers = true     # subscribe to Docker events, register gmux containers
 
 This host's name — what peers see in their UI and URLs — is **not** configured here. When Tailscale is enabled the name is your Tailscale machine name (owned and kept stable by Tailscale itself); otherwise it is the OS hostname. The first time the daemon joins a tailnet it requests `gmux-<hostname>`, and Tailscale keeps that name across restarts and container recreation. See [ADR 0007](https://github.com/gmuxapp/gmux/blob/main/docs/adr/0007-host-identity-and-peer-urls.md).
 
-To seed a specific name at first registration — e.g. when running several daemons on one machine — set the `GMUXD_TS_HOSTNAME` environment variable (used verbatim; prefix it with `gmux-` to stay auto-discoverable). It only applies before the node is registered; afterward Tailscale owns the name.
+To seed a specific name at first registration — e.g. when running several daemons on one machine — set the `GMUXD_TS_HOSTNAME` environment variable (used verbatim). It only applies before the node is registered; afterward Tailscale owns the name.
 
 ## Connecting to other hosts
 
@@ -57,7 +57,7 @@ There is **no `[[peers]]` config**. Add a host you want to aggregate sessions fr
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `tailscale` | `boolean` | `true` | Discover other gmux instances on the tailnet via `WatchIPNBus`. Only active when `tailscale.enabled` is also true. |
+| `tailscale` | `boolean` | `true` | Discover other gmux instances on the tailnet via `WatchIPNBus`: every online tailnet device is probed, and any running gmuxd is added — regardless of its name. (The `gmux-`/`gmux` name only affects whether an *offline* peer is surfaced as a known-but-down host.) Only active when `tailscale.enabled` is also true. |
 | `devcontainers` | `boolean` | `true` | Subscribe to Docker events and register any container with the gmux devcontainer feature **and** the `devcontainer.local_folder` label as a peer. Skipped if the Docker CLI is not installed. |
 
 ## Strict validation

--- a/apps/website/src/content/docs/reference/host-toml.md
+++ b/apps/website/src/content/docs/reference/host-toml.md
@@ -32,6 +32,8 @@ devcontainers = true     # subscribe to Docker events, register gmux containers
 
 This host's name — what peers see in their UI and URLs — is **not** configured here. When Tailscale is enabled the name is your Tailscale machine name (owned and kept stable by Tailscale itself); otherwise it is the OS hostname. The first time the daemon joins a tailnet it requests `gmux-<hostname>`, and Tailscale keeps that name across restarts and container recreation. See [ADR 0007](https://github.com/gmuxapp/gmux/blob/main/docs/adr/0007-host-identity-and-peer-urls.md).
 
+To seed a specific name at first registration — e.g. when running several daemons on one machine — set the `GMUXD_TS_HOSTNAME` environment variable (used verbatim; prefix it with `gmux-` to stay auto-discoverable). It only applies before the node is registered; afterward Tailscale owns the name.
+
 ## Connecting to other hosts
 
 There is **no `[[peers]]` config**. Add a host you want to aggregate sessions from at runtime via **Settings → Hosts → Connect to host** (enter its URL; leave the token blank on your own tailnet). Connected hosts are saved to `peers.json` in the state directory, and the peer's name is taken from the host itself — you don't assign one. Hosts on the same tailnet are also discovered automatically.

--- a/apps/website/src/content/docs/remote-access.md
+++ b/apps/website/src/content/docs/remote-access.md
@@ -78,18 +78,10 @@ You can also edit `host.toml` manually instead:
 enabled = true
 ```
 
-See [host.toml reference](/reference/host-toml/) for all fields (hostname, allow list).
+See [host.toml reference](/reference/host-toml/) for all fields (allow list).
 
 :::note[Multiple machines]
-Each machine on the same tailnet needs a unique hostname. Set it in `host.toml`:
-
-```toml
-[tailscale]
-enabled = true
-hostname = "gmux-desktop"
-```
-
-This gives you `https://gmux-desktop.your-tailnet.ts.net`.
+Each machine joins the tailnet under `gmux-<its-hostname>`, derived from the OS hostname on first registration and then owned by Tailscale (it dedups names automatically). To use a specific name, set the machine's name in the Tailscale admin console or rename the host — there is no `hostname` key in `host.toml` (see [ADR 0007](https://github.com/gmuxapp/gmux/blob/main/docs/adr/0007-host-identity-and-peer-urls.md)). A machine named `gmux-desktop` is reachable at `https://gmux-desktop.your-tailnet.ts.net`.
 :::
 
 ### 4. Connect

--- a/apps/website/src/content/docs/running-in-docker.md
+++ b/apps/website/src/content/docs/running-in-docker.md
@@ -21,12 +21,12 @@ mkdir -p data/{workspace,gmux-config,gmux-state}
 cat > data/gmux-config/host.toml << 'EOF'
 [tailscale]
 enabled = true
-hostname = "dev"
 EOF
 
-docker compose up -d --build
+# The container's hostname becomes its Tailscale name (gmux-<hostname>).
+docker compose up -d --build   # compose sets hostname: dev → joins as gmux-dev
 docker logs dev 2>&1 | grep "login.tailscale.com"
-# Visit the URL to register, then open https://dev.your-tailnet.ts.net
+# Visit the URL to register, then open https://gmux-dev.your-tailnet.ts.net
 ```
 
 See [Remote Access](/remote-access/) for Tailscale setup details.
@@ -114,13 +114,19 @@ The overlay mounts for gmux config and state give the container its own Tailscal
 
 ### Multiple projects
 
-Run separate containers for different projects. Each gets its own Tailscale hostname:
+Run separate containers for different projects. Each joins Tailscale as `gmux-<container-hostname>`, so give each container a distinct hostname (compose `hostname:` or `docker run --hostname`):
+
+```yaml
+# docker-compose.yml
+services:
+  project-a:
+    hostname: project-a   # → joins the tailnet as gmux-project-a
+```
 
 ```toml
 # data/project-a/gmux-config/host.toml
 [tailscale]
 enabled = true
-hostname = "project-a"
 ```
 
-To see sessions from all containers in a single dashboard instead, set up [Multi-Machine Sessions](/multi-machine) with one gmuxd as the hub.
+The node name is owned by Tailscale after first registration (it survives container recreation as long as the state mount persists), so there is no `hostname` key in `host.toml`. To see sessions from all containers in a single dashboard instead, set up [Multi-Machine Sessions](/multi-machine) with one gmuxd as the hub.

--- a/docs/adr/0007-host-identity-and-peer-urls.md
+++ b/docs/adr/0007-host-identity-and-peer-urls.md
@@ -1,0 +1,262 @@
+# ADR 0007: Host identity, naming, and peer URLs
+
+**Status:** Proposed
+**Date:** 2026-05-29
+**Related:** ADR 0002 (project ownership from session origin), ADR 0005 (references and the local-peer exception)
+**Target:** gmux 2.0 (breaking; no backwards compatibility)
+
+## Context
+
+A host has no single identity in gmux today — it has **four**, and
+they disagree:
+
+| Source | Where it comes from | Used for |
+|---|---|---|
+| `os.Hostname()` | OS/kernel (the **container ID** under Docker) | `/v1/health` `hostname` field; peering self-echo name; devcontainer name fallback |
+| `tailscale.hostname` (config, default `gmux`) | `host.toml` | tsnet machine name → FQDN; tailnet discovery *filter* (prefix `gmux-*`) |
+| `deriveName()` | devcontainer label → container name → container ID | devcontainer peer name |
+| `PeerConfig.Name` | `host.toml` | manual peer name; URL `@<segment>` |
+
+The non-obvious part: a **tailnet-discovered peer is named by the
+remote's `/v1/health` `hostname` field — i.e. its `os.Hostname()`**,
+not its tailscale hostname. Discovery *filters* on the tailscale
+hostname prefix but *names* the peer by its OS hostname. So
+`tailscale.hostname` and the name shown in the UI / URL are already
+two different things.
+
+This produced the bug that motivated this ADR: a gmuxd running inside
+a container, discovered over **tailscale**, appeared as
+`@ca75413aec31` — the container ID, because that is what
+`os.Hostname()` returns in a container and that is what the health
+field reports. Recreating the container (rebuild / `compose up`
+recreate / `rm`+`run`) mints a new container ID, so the name — and
+every URL that embedded it — changed.
+
+Three ways a peer can be connected today, each naming it differently:
+
+- **Tailscale autodiscovery** (same tailnet) → remote's `os.Hostname()`.
+- **Devcontainer autodiscovery** (local Docker) → `deriveName()`.
+- **Manual `[[peers]]`** in `host.toml` → user-chosen `Name`.
+
+Two hard constraints in the current design:
+
+- **`host.toml` is never written by gmuxd** (documented invariant;
+  the TOML library also loses comments/ordering on round-trip).
+- URL identity is `@<name>`, where `<name>` is whichever of the four
+  sources applies — so URL stability is hostage to the least stable
+  source.
+
+### Goals
+
+1. **One identity per node**, independent of how it is reached.
+2. **URL stability** — a host's URL changes only when the host's
+   identity genuinely changes, never because of *how* a viewer
+   reached it.
+3. **Collision safety** — names are unique within a tailnet but can
+   collide across tailnets or for non-tailscale hosts.
+4. **Human-readable**, short URLs.
+
+## Decision
+
+### 1. One identity function
+
+A single `identity()` value feeds the `/v1/health` `hostname` field,
+the peering self-name, the `localHostLabel`, and the URL key:
+
+```
+identity() = live tailscale name (from tsnet status)   if tailscale enabled
+           = os.Hostname()                              otherwise
+```
+
+There is **no generated name and no gmux-side persistence of the
+name.** The previously-considered "generate `gmux-adjective-noun` and
+write it back to config" approach is dropped (see Alternatives A): the
+two cases are already covered — tailscale owns the name when present,
+and `os.Hostname()` is stable and meaningful on a real machine when it
+is not.
+
+### 2. Tailscale is the authority *and* the state
+
+When tailscale is enabled, the identity is **whatever tsnet settled on
+after the coordination server's uniqueness dedup** (`gmux-foo` →
+`gmux-foo-1`), read live from the listener — not the requested name.
+tsnet persists the node key in its state dir, so the name is sticky
+across daemon restarts *and* container recreation **iff that state dir
+is persisted** (see §4). There is nothing for gmux to reconcile or
+write: we always read the current name.
+
+Consequences for config:
+
+- **Remove `tailscale.hostname`.** The *requested* name is set once
+  during onboarding (`gmuxd remote`), defaulting to `os.Hostname()`.
+- If a user enables tailscale **outside** onboarding (e.g. hand-edits
+  `enabled = true`), the requested name defaults to `os.Hostname()` —
+  we never had the chance to ask, and tailscale will dedup it if
+  needed.
+
+### 3. Devcontainers: discovery gated on the folder label
+
+Devcontainer autodiscovery **requires the `devcontainer.local_folder`
+label**; the name is its basename. No label → not discovered. This
+removes the container-ID fallback in `deriveName()` by construction:
+a container that would have fallen through to the ID is simply not a
+discovered devcontainer.
+
+Note this does **not** fix the motivating bug directly — that was a
+*tailscale*-discovered container, fixed by §2 (it now reports its
+tailscale name, not `os.Hostname()`). §3 closes the separate
+devcontainer-ID-churn path.
+
+### 4. A stable opaque `node_id` for sameness
+
+A 32-byte random `node-id`, generated once and persisted alongside
+`auth-token` in the state dir (same `LoadOrCreate` pattern,
+`0600`), returned in `/v1/health`. It is **never shown and never
+appears in a URL.** Its sole purpose is to answer *"is this the same
+node?"* independent of name, address, or connection method.
+
+Crucially this adds **no new persistence requirement**: a peer's
+`auth-token` and its tailscale node key already must survive on disk
+for any connection to it to be stable. A container that doesn't
+persist its state dir already regenerates its auth token (and so is
+unreachable by existing viewers) — its `node_id` churning with it is
+moot. Co-locating `node_id` with `auth-token` makes "persist this
+directory" the single, already-necessary rule.
+
+### 5. Peers as state, not config (2.0)
+
+Remove `[[peers]]` from `host.toml`. The set of peers becomes
+**state** in `peers.json` (state dir), managed by a **"Connect to
+host"** flow in the Settings UI. The user does **not** assign a name —
+on connect we fetch the peer's `/v1/health` and adopt its
+self-reported identity (§1). The address (URL / FQDN) is stored
+separately as the connection *target*, distinct from the *name*.
+
+gmux thus begins owning a writable state file for the peer list. This
+is distinct from the `host.toml` "never written" invariant, which
+stands for the user-authored config file.
+
+### 6. URL schema: short name, uniform
+
+The URL is `/@<name>/...`, the peer's **short self-name**, for every
+connection method. No method prefix (`@ts-` / `@dev-` / `@peer-`),
+no FQDN in the URL. The FQDN is *address metadata*, not identity.
+
+Within a single tailnet, tailscale guarantees unique hostnames, so the
+common case has zero collisions and fully stable, portable URLs.
+
+### 7. Add-peer flow: dedup first, then collide
+
+On "Connect to host", fetch `/v1/health` → `(node_id, name)`:
+
+1. **Known `node_id`** → already connected. Optionally record the new
+   address as an alternate route. *Not* a collision; never rename.
+2. **New `node_id`, name free** → use the name.
+3. **New `node_id`, name taken** → genuine collision (two distinct
+   hosts, same name). Resolve **viewer-side**: suffix it (`name-2`),
+   persist the alias in `peers.json`, and surface a flag. The user may
+   optionally give the underlying host a clean global name by renaming
+   its tailscale machine or its OS hostname — gmux builds **no remote
+   name-state** of its own.
+
+This directly resolves the "same host added via tailscale *and*
+manually" case: both report the same `node_id`, so step 1 dedupes
+them rather than treating the shared name as a conflict.
+
+### 8. No backwards compatibility
+
+This is a 2.0 break. An unknown or unresolvable `@<name>` redirects to
+home (the user locates the session and re-bookmarks). The removed
+config keys (`tailscale.hostname`, `[[peers]]`) are rejected at load
+with an error pointing to `gmuxd remote` / "Connect to host", rather
+than silently migrated.
+
+## Consequences
+
+### Positive
+
+- **One identity** across health, peering, UI labels, and URLs —
+  derived from a single function with one obvious source per case.
+- **The motivating bug is fixed by construction**: a tailscale host
+  reports its (sticky, deduped) tailscale name, not `os.Hostname()`;
+  devcontainers can't fall through to a container ID.
+- **No name generation, no name writeback, no `host.toml` writes.**
+  tailscale owns the name where present; `os.Hostname()` covers the
+  rest.
+- **Stable, portable, readable URLs** in the common single-tailnet
+  case. Method changes (autodiscovered ↔ manual) never churn a URL.
+- **Robust sameness** via `node_id`, at no new persistence cost.
+
+### Negative
+
+- **`node_id` is new remote state** (one file). Mitigated by
+  co-locating with `auth-token`, which already must persist.
+- **Cross-tailnet / non-tailscale collisions still need a human
+  decision** (viewer-side suffix + flag, or rename the host). We do
+  not auto-globally-resolve these.
+- **Identity churns if a container's state dir is not persisted** —
+  but such a container is already unreachable (auth token churns too),
+  so this is not a regression.
+- **Viewer-side suffixes are viewer-relative** (a suffixed `name-2`
+  may differ from how another viewer names the same host). Accepted:
+  manual peers are inherently viewer-owned config.
+
+### Breaking
+
+- `tailscale.hostname` and `[[peers]]` are removed from `host.toml`.
+- Existing `@<name>` URLs that embedded an `os.Hostname()`/container-ID
+  name (or a manual `Name`) will not resolve and fall back to home.
+- The `/v1/health` `hostname` field changes meaning (now the unified
+  identity) and gains `node_id`.
+
+## Alternatives considered
+
+### A. Generate + persist `gmux-adjective-noun`, reconcile with tailscale
+
+The earlier proposal: generate a human-readable name on first start,
+persist it, and on tailscale connect compare against the tailscale
+name and write back the deduped value. Rejected: tailscale is
+*already* the authority and the durable state for the name, so
+generation + writeback duplicates that machinery and re-adds a
+config/state-write surface. `os.Hostname()` covers the no-tailscale
+case without generation.
+
+### B. Method-prefixed URLs (`@ts-` / `@dev-` / `@peer-`)
+
+Rejected. The connection *method is not a stable property of a host*:
+the same host moved from autodiscovered to manual would change URL
+form, violating Goal 2. It is also viewer-relative (non-portable), and
+it does not even close *within-method* collisions (two manual peers,
+or two foreign tailnets, can still collide within `@peer-`).
+
+### C. FQDN as the URL key
+
+Rejected. Non-tailscale peers have no FQDN, so it cannot be the
+universal key — short-name handling is needed regardless. Using FQDN
+only for manual peers reintroduces the same method dependence as (B),
+and it is verbose in every URL. The FQDN's correct role is the
+connection *address*, stored in `peers.json`.
+
+### D. Remote-settable persisted name without tailscale
+
+The other collision-resolution option: give every node the ability to
+persist a user-set name even without tailscale, and tell the user to
+change it to resolve a conflict. Rejected: for a host the user
+controls, this collapses to "rename the host's tailscale machine name
+or OS hostname," which needs no new gmux machinery; building remote
+name-state re-adds exactly the persistence/generation surface §1–§2
+removed. The viewer-side suffix (§7) covers hosts the user cannot
+touch.
+
+### E. Keep `[[peers]]` in `host.toml`
+
+Rejected for 2.0. File-managed peers cannot cleanly carry viewer-side
+rename aliases (§7) or live connection state, and the "Connect to
+host" UI needs writable state anyway. A user-authored config file is
+the wrong home for runtime-mutable peer state.
+
+### F. Keep naming peers by `os.Hostname()` even under tailscale (status quo)
+
+Rejected — it is the bug. In a container `os.Hostname()` is the
+container ID; on a tailnet it diverges from the name the host is
+actually reachable as.

--- a/examples/docker-tailscale/README.md
+++ b/examples/docker-tailscale/README.md
@@ -9,11 +9,11 @@ container's terminal sessions from any device on your tailnet.
 # 1. Create data directories
 mkdir -p data/{workspace,gmux-config,gmux-state}
 
-# 2. Configure Tailscale (pick a unique hostname)
+# 2. Enable Tailscale. The tailscale name is gmux-<container hostname>
+#    (compose sets `hostname: dev`), so this joins as gmux-dev.
 cat > data/gmux-config/host.toml << 'EOF'
 [tailscale]
 enabled = true
-hostname = "dev"
 EOF
 
 # 3. Build and start
@@ -24,7 +24,7 @@ docker logs dev 2>&1 | grep "login.tailscale.com"
 # Visit the URL to approve the device
 
 # 5. Open in browser
-# https://dev.your-tailnet.ts.net
+# https://gmux-dev.your-tailnet.ts.net
 ```
 
 ## What's included

--- a/examples/docker-tailscale/compose.yaml
+++ b/examples/docker-tailscale/compose.yaml
@@ -2,6 +2,7 @@ services:
   dev:
     build: .
     container_name: dev
+    hostname: dev          # → tailscale name gmux-dev (ADR 0007)
     restart: unless-stopped
     environment:
       - TERM=xterm-256color

--- a/scripts/dev-server.sh
+++ b/scripts/dev-server.sh
@@ -51,8 +51,11 @@ port = $DEV_PORT
 
 [tailscale]
 enabled = true
-hostname = "$DEV_TS_HOSTNAME"
 EOF
+
+# The tailscale name is set via env (ADR 0007: no host.toml hostname key).
+# Each instance needs a distinct name on this shared OS hostname.
+export GMUXD_TS_HOSTNAME="$DEV_TS_HOSTNAME"
 
 # ── Shared env ──
 

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -2023,10 +2023,17 @@ func serve(stderr io.Writer) int {
 	// ── Optional tailscale listener ──
 
 	if cfg.Tailscale.Enabled {
+		// Requested tailscale name for *first* registration (ADR 0007):
+		// GMUXD_TS_HOSTNAME wins verbatim (used by dev-server and any
+		// multi-instance/container setup that needs a distinct name on a
+		// shared OS hostname); otherwise derive "gmux-<os-hostname>".
+		// Once registered, tailscale owns the name and this is ignored.
+		tsSeed := strings.TrimSpace(os.Getenv("GMUXD_TS_HOSTNAME"))
+		if tsSeed == "" {
+			tsSeed = tsauth.SeedFromHostname(hostname)
+		}
 		tsListener = tsauth.Start(tsauth.Config{
-			// Seed the tailscale name from the OS hostname; tsauth derives
-			// "gmux-<slug>" on first registration and keeps it thereafter.
-			Hostname: hostname,
+			Hostname: tsSeed,
 			Allow:    cfg.Tailscale.Allow,
 		}, stateDir, mux)
 		defer tsListener.Shutdown()

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -1954,7 +1954,9 @@ func serve(stderr io.Writer) int {
 
 	if cfg.Tailscale.Enabled {
 		tsListener = tsauth.Start(tsauth.Config{
-			Hostname: cfg.Tailscale.Hostname,
+			// Seed the tailscale name from the OS hostname; tsauth derives
+			// "gmux-<slug>" on first registration and keeps it thereafter.
+			Hostname: hostname,
 			Allow:    cfg.Tailscale.Allow,
 		}, stateDir, mux)
 		defer tsListener.Shutdown()
@@ -1965,7 +1967,7 @@ func serve(stderr io.Writer) int {
 				Manager:        peerManager,
 				StateDir:       stateDir,
 				ManualPeerURLs: tsdiscovery.ManualPeerURLs(cfg.Peers),
-				HostnamePrefix: cfg.Tailscale.Hostname,
+				// HostnamePrefix defaults to "gmux" in tsdiscovery.
 			})
 			tsDiscoveryCtx, tsDiscoveryCancel := context.WithCancel(context.Background())
 			defer tsDiscoveryCancel()

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -1006,6 +1006,70 @@ func serve(stderr io.Writer) int {
 		peer.ForwardPath(w, r, "/"+sub)
 	})
 
+	// POST /v1/peers — connect to a host (ADR 0007 §5,§7). Probes the
+	// target's /v1/health for its node_id + name, dedups by node_id
+	// (already-known host reached again is a no-op, not a duplicate),
+	// resolves any name collision viewer-side, then connects + persists.
+	mux.HandleFunc("POST /v1/peers", func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(io.LimitReader(r.Body, 8192))
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "bad_request", "read error")
+			return
+		}
+		var req struct {
+			URL   string `json:"url"`
+			Token string `json:"token"`
+		}
+		if err := json.Unmarshal(body, &req); err != nil {
+			writeError(w, http.StatusBadRequest, "bad_request", "invalid JSON")
+			return
+		}
+		req.URL = strings.TrimRight(strings.TrimSpace(req.URL), "/")
+		if err := peerstore.ValidateURL(req.URL); err != nil {
+			writeError(w, http.StatusBadRequest, "bad_request", err.Error())
+			return
+		}
+
+		nodeID, name, err := probePeerHealth(r.Context(), req.URL, req.Token)
+		if err != nil {
+			writeError(w, http.StatusBadGateway, "unreachable", fmt.Sprintf("could not reach host: %v", err))
+			return
+		}
+
+		// Same host already known (this peer, or one reached another way):
+		// not a collision — report the existing record.
+		if existing, ok := peerStore.FindByNodeID(nodeID); ok {
+			writeJSON(w, map[string]any{"peer": existing, "already_connected": true})
+			return
+		}
+
+		rec, err := peerStore.Add(peerstore.Record{Name: name, URL: req.URL, Token: req.Token, NodeID: nodeID})
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "bad_request", err.Error())
+			return
+		}
+		peerManager.AddPeer(config.PeerConfig{Name: rec.Name, URL: rec.URL, Token: rec.Token})
+		log.Printf("peering: connected to %s (%s)", rec.Name, rec.URL)
+		writeJSON(w, map[string]any{"peer": rec})
+	})
+
+	// DELETE /v1/peers/{name} — disconnect a manually-added peer.
+	mux.HandleFunc("DELETE /v1/peers/{name}", func(w http.ResponseWriter, r *http.Request) {
+		name := r.PathValue("name")
+		rec, ok, err := peerStore.Remove(name)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "internal", "failed to persist peers")
+			return
+		}
+		if !ok {
+			writeError(w, http.StatusNotFound, "not_found", fmt.Sprintf("peer %q is not a manually-added host", name))
+			return
+		}
+		peerManager.RemovePeer(rec.Name)
+		log.Printf("peering: disconnected from %s", rec.Name)
+		writeJSON(w, map[string]any{"ok": true})
+	})
+
 	// ── Sessions ──
 
 	mux.HandleFunc("GET /v1/sessions", func(w http.ResponseWriter, r *http.Request) {
@@ -1913,29 +1977,30 @@ func serve(stderr io.Writer) int {
 
 	hostname, _ := os.Hostname()
 	manualPeers := peerStore.PeerConfigs()
-	if len(manualPeers) > 0 || cfg.Discovery.Devcontainers || (cfg.Tailscale.Enabled && cfg.Discovery.Tailscale) {
-		peerManager = peering.NewManager(manualPeers, sessions, hostname)
-		// Prune namespaced projects.json keys when a Local peer
-		// (devcontainer) is removed: its `id@<peer>` session keys can
-		// never resolve again and would accumulate dead weight in the
-		// parent's projects.json.
-		peerManager.OnPeerRemoved = func(name string, wasLocal bool) {
-			if wasLocal {
-				projectMgr.PruneNamespacedKeys(name)
-			}
+	// Always create the manager: peers can be added at runtime via
+	// /v1/peers (ADR 0007 §5), so it must exist even when nothing is
+	// configured or discovered at startup.
+	peerManager = peering.NewManager(manualPeers, sessions, hostname)
+	// Prune namespaced projects.json keys when a Local peer
+	// (devcontainer) is removed: its `id@<peer>` session keys can
+	// never resolve again and would accumulate dead weight in the
+	// parent's projects.json.
+	peerManager.OnPeerRemoved = func(name string, wasLocal bool) {
+		if wasLocal {
+			projectMgr.PruneNamespacedKeys(name)
 		}
-		peerManager.Start()
-		if len(manualPeers) > 0 {
-			log.Printf("peering: %d manual peer(s) loaded", len(manualPeers))
-		}
-
-		// Reconnect all peers after system sleep.
-		go func() {
-			for range sleepWatcher.C() {
-				peerManager.OnSleep()
-			}
-		}()
 	}
+	peerManager.Start()
+	if len(manualPeers) > 0 {
+		log.Printf("peering: %d manual peer(s) loaded", len(manualPeers))
+	}
+
+	// Reconnect all peers after system sleep.
+	go func() {
+		for range sleepWatcher.C() {
+			peerManager.OnSleep()
+		}
+	}()
 
 	// ── Devcontainer discovery ──
 
@@ -2335,6 +2400,43 @@ func sendSSE(w http.ResponseWriter, event string, payload any) {
 func writeJSON(w http.ResponseWriter, payload any) {
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(payload)
+}
+
+// probePeerHealth fetches the target's /v1/health and returns its opaque
+// node_id and self-reported name (ADR 0007). The add-peer flow uses the
+// node_id to dedup and adopts the name as the peer's routing identity.
+// Manual peers use the default transport (as [[peers]] did before).
+func probePeerHealth(ctx context.Context, baseURL, token string) (nodeID, name string, err error) {
+	ctx, cancel := context.WithTimeout(ctx, 8*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/v1/health", nil)
+	if err != nil {
+		return "", "", err
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", "", fmt.Errorf("health returned %s", resp.Status)
+	}
+	var env struct {
+		Data struct {
+			NodeID   string `json:"node_id"`
+			Hostname string `json:"hostname"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<16)).Decode(&env); err != nil {
+		return "", "", fmt.Errorf("parsing health: %w", err)
+	}
+	if env.Data.Hostname == "" {
+		return "", "", fmt.Errorf("host did not report a name")
+	}
+	return env.Data.NodeID, env.Data.Hostname, nil
 }
 
 func writeError(w http.ResponseWriter, status int, code, message string) {

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gmuxapp/gmux/packages/paths"
 	"github.com/gmuxapp/gmux/packages/sessionenv"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/authtoken"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/nodeid"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/binhash"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/clipfile"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/coalesce"
@@ -568,6 +569,14 @@ func serve(stderr io.Writer) int {
 	// State directory for persistent files (projects.json, auth-token, etc).
 	stateDir := paths.StateDir()
 
+	// Stable, opaque per-node identity (ADR 0007). Generated once and
+	// persisted alongside the auth token; used for peer dedup, never
+	// shown or routed.
+	nodeID, err := nodeid.LoadOrCreate(stateDir)
+	if err != nil {
+		log.Fatalf("FATAL: %v", err)
+	}
+
 	// peerManager and tsDiscovery are initialized later after config is
 	// loaded. Closures (reconcileProjectStamps, buildSessionInfos call
 	// sites) capture these pointers so handlers work once they're set.
@@ -693,7 +702,7 @@ func serve(stderr io.Writer) int {
 		data := map[string]any{
 			"service": "gmuxd",
 			"version": version,
-			"node_id": "node-local",
+			"node_id": nodeID,
 			"status":  "ready",
 		}
 		if h, err := os.Hostname(); err == nil {

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -1052,7 +1052,7 @@ func serve(stderr io.Writer) int {
 			writeJSON(w, map[string]any{"peer": rec, "already_connected": true})
 			return
 		}
-		peerManager.AddPeer(config.PeerConfig{Name: rec.Name, URL: rec.URL, Token: rec.Token})
+		peerManager.AddPeer(config.PeerConfig{Name: rec.Name, URL: rec.URL, Token: rec.Token, Source: config.SourceManual})
 		log.Printf("peering: connected to %s (%s)", rec.Name, rec.URL)
 		writeJSON(w, map[string]any{"peer": rec})
 	})
@@ -2236,6 +2236,7 @@ func appendOfflinePeers(mgr *peering.Manager, disc *tsdiscovery.Watcher) []peeri
 				Name:   op.Name,
 				URL:    "https://" + op.FQDN,
 				Status: "offline",
+				Source: config.SourceTailscale,
 			})
 		}
 	}

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -1034,7 +1034,7 @@ func serve(stderr io.Writer) int {
 			return
 		}
 
-		nodeID, name, err := probePeerHealth(r.Context(), req.URL, req.Token)
+		peerNodeID, name, err := probePeerHealth(r.Context(), req.URL, req.Token)
 		if err != nil {
 			writeError(w, http.StatusBadGateway, "unreachable", fmt.Sprintf("could not reach host: %v", err))
 			return
@@ -1043,7 +1043,7 @@ func serve(stderr io.Writer) int {
 		// Atomic dedup-or-add: same node_id ⇒ already connected (not a
 		// duplicate); otherwise the probed name is slugified, de-collided,
 		// and persisted under one lock (no check-then-act race).
-		rec, existed, err := peerStore.AddOrGet(peerstore.Record{Name: name, URL: req.URL, Token: req.Token, NodeID: nodeID})
+		rec, existed, err := peerStore.AddOrGet(peerstore.Record{Name: name, URL: req.URL, Token: req.Token, NodeID: peerNodeID})
 		if err != nil {
 			writeError(w, http.StatusBadRequest, "bad_request", err.Error())
 			return
@@ -2441,13 +2441,20 @@ func probePeerHealth(ctx context.Context, baseURL, token string) (nodeID, name s
 		return "", "", fmt.Errorf("health returned %s", resp.Status)
 	}
 	var env struct {
+		OK   bool `json:"ok"`
 		Data struct {
+			Service  string `json:"service"`
 			NodeID   string `json:"node_id"`
 			Hostname string `json:"hostname"`
 		} `json:"data"`
 	}
 	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<16)).Decode(&env); err != nil {
 		return "", "", fmt.Errorf("parsing health: %w", err)
+	}
+	// Confirm it's actually gmuxd (parity with tsdiscovery.probe), so a
+	// stray HTTP endpoint can't be registered as a peer.
+	if !env.OK || env.Data.Service != "gmuxd" {
+		return "", "", fmt.Errorf("host is not running gmux")
 	}
 	if env.Data.Hostname == "" {
 		return "", "", fmt.Errorf("host did not report a name")

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -1024,6 +1024,10 @@ func serve(stderr io.Writer) int {
 			writeError(w, http.StatusBadRequest, "bad_request", "invalid JSON")
 			return
 		}
+		if peerManager == nil {
+			writeError(w, http.StatusServiceUnavailable, "unavailable", "peering is not available")
+			return
+		}
 		req.URL = strings.TrimRight(strings.TrimSpace(req.URL), "/")
 		if err := peerstore.ValidateURL(req.URL); err != nil {
 			writeError(w, http.StatusBadRequest, "bad_request", err.Error())
@@ -1036,16 +1040,16 @@ func serve(stderr io.Writer) int {
 			return
 		}
 
-		// Same host already known (this peer, or one reached another way):
-		// not a collision — report the existing record.
-		if existing, ok := peerStore.FindByNodeID(nodeID); ok {
-			writeJSON(w, map[string]any{"peer": existing, "already_connected": true})
-			return
-		}
-
-		rec, err := peerStore.Add(peerstore.Record{Name: name, URL: req.URL, Token: req.Token, NodeID: nodeID})
+		// Atomic dedup-or-add: same node_id ⇒ already connected (not a
+		// duplicate); otherwise the probed name is slugified, de-collided,
+		// and persisted under one lock (no check-then-act race).
+		rec, existed, err := peerStore.AddOrGet(peerstore.Record{Name: name, URL: req.URL, Token: req.Token, NodeID: nodeID})
 		if err != nil {
 			writeError(w, http.StatusBadRequest, "bad_request", err.Error())
+			return
+		}
+		if existed {
+			writeJSON(w, map[string]any{"peer": rec, "already_connected": true})
 			return
 		}
 		peerManager.AddPeer(config.PeerConfig{Name: rec.Name, URL: rec.URL, Token: rec.Token})
@@ -1055,6 +1059,10 @@ func serve(stderr io.Writer) int {
 
 	// DELETE /v1/peers/{name} — disconnect a manually-added peer.
 	mux.HandleFunc("DELETE /v1/peers/{name}", func(w http.ResponseWriter, r *http.Request) {
+		if peerManager == nil {
+			writeError(w, http.StatusServiceUnavailable, "unavailable", "peering is not available")
+			return
+		}
 		name := r.PathValue("name")
 		rec, ok, err := peerStore.Remove(name)
 		if err != nil {

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/authtoken"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/identity"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/nodeid"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/peerstore"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/binhash"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/clipfile"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/coalesce"
@@ -574,6 +575,13 @@ func serve(stderr io.Writer) int {
 	// persisted alongside the auth token; used for peer dedup, never
 	// shown or routed.
 	nodeID, err := nodeid.LoadOrCreate(stateDir)
+	if err != nil {
+		log.Fatalf("FATAL: %v", err)
+	}
+
+	// Manually-added peers are runtime state (ADR 0007 §5), not config.
+	// Opened early so the /v1/peers add/remove handlers can capture it.
+	peerStore, err := peerstore.Open(stateDir)
 	if err != nil {
 		log.Fatalf("FATAL: %v", err)
 	}
@@ -1820,10 +1828,6 @@ func serve(stderr io.Writer) int {
 	if err != nil {
 		log.Fatalf("FATAL: %v", err)
 	}
-	if err := cfg.ResolveTokens(); err != nil {
-		log.Fatalf("FATAL: %v", err)
-	}
-
 	// ── Resolve TCP listen address and auth token ──
 
 	resolved, err := cfg.ListenAddr()
@@ -1908,8 +1912,9 @@ func serve(stderr io.Writer) int {
 	// ── Peer connections (hub protocol) ──
 
 	hostname, _ := os.Hostname()
-	if len(cfg.Peers) > 0 || cfg.Discovery.Devcontainers || (cfg.Tailscale.Enabled && cfg.Discovery.Tailscale) {
-		peerManager = peering.NewManager(cfg.Peers, sessions, hostname)
+	manualPeers := peerStore.PeerConfigs()
+	if len(manualPeers) > 0 || cfg.Discovery.Devcontainers || (cfg.Tailscale.Enabled && cfg.Discovery.Tailscale) {
+		peerManager = peering.NewManager(manualPeers, sessions, hostname)
 		// Prune namespaced projects.json keys when a Local peer
 		// (devcontainer) is removed: its `id@<peer>` session keys can
 		// never resolve again and would accumulate dead weight in the
@@ -1920,8 +1925,8 @@ func serve(stderr io.Writer) int {
 			}
 		}
 		peerManager.Start()
-		if len(cfg.Peers) > 0 {
-			log.Printf("peering: %d peer(s) configured", len(cfg.Peers))
+		if len(manualPeers) > 0 {
+			log.Printf("peering: %d manual peer(s) loaded", len(manualPeers))
 		}
 
 		// Reconnect all peers after system sleep.
@@ -1966,7 +1971,7 @@ func serve(stderr io.Writer) int {
 			tsDiscovery = tsdiscovery.New(tsdiscovery.Config{
 				Manager:        peerManager,
 				StateDir:       stateDir,
-				ManualPeerURLs: tsdiscovery.ManualPeerURLs(cfg.Peers),
+				ManualPeerURLs: tsdiscovery.ManualPeerURLs(manualPeers),
 				// HostnamePrefix defaults to "gmux" in tsdiscovery.
 			})
 			tsDiscoveryCtx, tsDiscoveryCancel := context.WithCancel(context.Background())

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gmuxapp/gmux/packages/paths"
 	"github.com/gmuxapp/gmux/packages/sessionenv"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/authtoken"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/identity"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/nodeid"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/binhash"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/clipfile"
@@ -705,9 +706,15 @@ func serve(stderr io.Writer) int {
 			"node_id": nodeID,
 			"status":  "ready",
 		}
-		if h, err := os.Hostname(); err == nil {
-			data["hostname"] = h
+		// Node identity (ADR 0007): the live tailscale name when
+		// connected, else the OS hostname. Evaluated per request so it
+		// converges once the tailscale listener becomes ready.
+		osHost, _ := os.Hostname()
+		tsFQDN := ""
+		if tsListener != nil {
+			tsFQDN = tsListener.FQDN()
 		}
+		data["hostname"] = identity.Resolve(tsFQDN, osHost)
 		if tsListener != nil {
 			diag := tsListener.Diag()
 			if diag.FQDN != "" {

--- a/services/gmuxd/cmd/gmuxd/peers_test.go
+++ b/services/gmuxd/cmd/gmuxd/peers_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// probePeerHealth is the contract the add-peer flow relies on: it must
+// reach /v1/health, forward the bearer token, and pull node_id + name
+// out of the {data:{…}} envelope — and fail clearly when the host is
+// unreachable/unauthorized or reports no name.
+func TestProbePeerHealth(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/health" {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Header.Get("Authorization") != "Bearer tok" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		_, _ = w.Write([]byte(`{"data":{"node_id":"node_abc","hostname":"gmux-laptop"}}`))
+	}))
+	defer srv.Close()
+
+	id, name, err := probePeerHealth(context.Background(), srv.URL, "tok")
+	if err != nil {
+		t.Fatalf("probePeerHealth: %v", err)
+	}
+	if id != "node_abc" || name != "gmux-laptop" {
+		t.Fatalf("got (node_id=%q, name=%q), want (node_abc, gmux-laptop)", id, name)
+	}
+}
+
+func TestProbePeerHealth_Unauthorized(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+	if _, _, err := probePeerHealth(context.Background(), srv.URL, ""); err == nil {
+		t.Fatal("expected an error when the probe is unauthorized")
+	}
+}
+
+func TestProbePeerHealth_MissingName(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"node_id":"node_abc"}}`))
+	}))
+	defer srv.Close()
+	// A host that reports no name can't be given a routing identity.
+	if _, _, err := probePeerHealth(context.Background(), srv.URL, ""); err == nil {
+		t.Fatal("expected an error when the host reports no name")
+	}
+}

--- a/services/gmuxd/cmd/gmuxd/peers_test.go
+++ b/services/gmuxd/cmd/gmuxd/peers_test.go
@@ -21,7 +21,7 @@ func TestProbePeerHealth(t *testing.T) {
 			w.WriteHeader(http.StatusUnauthorized)
 			return
 		}
-		_, _ = w.Write([]byte(`{"data":{"node_id":"node_abc","hostname":"gmux-laptop"}}`))
+		_, _ = w.Write([]byte(`{"ok":true,"data":{"service":"gmuxd","node_id":"node_abc","hostname":"gmux-laptop"}}`))
 	}))
 	defer srv.Close()
 
@@ -46,11 +46,23 @@ func TestProbePeerHealth_Unauthorized(t *testing.T) {
 
 func TestProbePeerHealth_MissingName(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte(`{"data":{"node_id":"node_abc"}}`))
+		_, _ = w.Write([]byte(`{"ok":true,"data":{"service":"gmuxd","node_id":"node_abc"}}`))
 	}))
 	defer srv.Close()
 	// A host that reports no name can't be given a routing identity.
 	if _, _, err := probePeerHealth(context.Background(), srv.URL, ""); err == nil {
 		t.Fatal("expected an error when the host reports no name")
+	}
+}
+
+func TestProbePeerHealth_NotGmux(t *testing.T) {
+	// A reachable HTTP endpoint that isn't gmuxd must be rejected, so a
+	// stray URL can't be registered as a peer (parity with discovery).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"ok":true,"data":{"service":"other","hostname":"x"}}`))
+	}))
+	defer srv.Close()
+	if _, _, err := probePeerHealth(context.Background(), srv.URL, ""); err == nil {
+		t.Fatal("expected an error when the host is not running gmux")
 	}
 }

--- a/services/gmuxd/cmd/gmuxd/remote_test.go
+++ b/services/gmuxd/cmd/gmuxd/remote_test.go
@@ -181,9 +181,9 @@ func TestEnableTailscaleConfig_ProducesValidConfig(t *testing.T) {
 	}{
 		{"empty file", ""},
 		{"port only", "port = 9999\n"},
-		{"section disabled", "[tailscale]\nenabled = false\nhostname = \"mybox\"\n"},
-		{"section no enabled", "[tailscale]\nhostname = \"mybox\"\n"},
-		{"no trailing newline", "[tailscale]\nhostname = \"mybox\""},
+		{"section disabled", "[tailscale]\nenabled = false\nallow = [\"alice@github\"]\n"},
+		{"section no enabled", "[tailscale]\nallow = [\"alice@github\"]\n"},
+		{"no trailing newline", "[tailscale]\nallow = [\"alice@github\"]"},
 		{"section header only no newline", "[tailscale]"},
 	}
 	for _, tt := range cases {

--- a/services/gmuxd/internal/config/config.go
+++ b/services/gmuxd/internal/config/config.go
@@ -80,9 +80,9 @@ type TailscaleConfig struct {
 	// Enabled starts a tsnet listener on the tailnet. Default false.
 	Enabled bool `toml:"enabled"`
 
-	// Hostname is the tailscale machine name (e.g. "gmux" -> gmux.tailnet.ts.net).
-	// Default "gmux".
-	Hostname string `toml:"hostname"`
+	// NOTE: there is no `hostname` key (removed in ADR 0007). The node's
+	// tailscale name is derived from the OS hostname on first
+	// registration and then owned/persisted by tailscale itself.
 
 	// Allow is the list of additional tailscale login names permitted to connect
 	// (e.g. "user@github"). The node owner is always auto-whitelisted at runtime.
@@ -116,6 +116,10 @@ func Load() (Config, error) {
 		keys := make([]string, len(undecoded))
 		for i, k := range undecoded {
 			keys[i] = k.String()
+			// Targeted migration hints for keys removed in ADR 0007.
+			if keys[i] == "tailscale.hostname" {
+				return Config{}, fmt.Errorf("config: %s: tailscale.hostname is no longer supported (ADR 0007); remove it — the node name is now derived from the OS hostname and owned by tailscale", path)
+			}
 		}
 		return Config{}, fmt.Errorf("config: unknown keys in %s: %s", path, strings.Join(keys, ", "))
 	}
@@ -153,11 +157,6 @@ func validate(cfg Config) error {
 		if !strings.Contains(entry, "@") {
 			return fmt.Errorf("tailscale.allow entry %q doesn't look like a login name (expected format: user@provider)", entry)
 		}
-	}
-
-	// Tailscale: hostname must be non-empty when enabled.
-	if cfg.Tailscale.Enabled && cfg.Tailscale.Hostname == "" {
-		return fmt.Errorf("tailscale.enabled is true but tailscale.hostname is empty")
 	}
 
 	// Peers: validate each entry.
@@ -262,9 +261,6 @@ func isPrivateOrCGNAT(ip net.IP) bool {
 func defaults() Config {
 	return Config{
 		Port: 8790,
-		Tailscale: TailscaleConfig{
-			Hostname: "gmux",
-		},
 		Discovery: DiscoveryConfig{
 			Devcontainers: true,
 			Tailscale:     true,

--- a/services/gmuxd/internal/config/config.go
+++ b/services/gmuxd/internal/config/config.go
@@ -8,16 +8,11 @@
 package config
 
 import (
-	"context"
 	"fmt"
 	"net"
-	"net/url"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"regexp"
 	"strings"
-	"time"
 
 	"github.com/BurntSushi/toml"
 )
@@ -30,31 +25,25 @@ type Config struct {
 	Tailscale TailscaleConfig `toml:"tailscale"`
 	Discovery DiscoveryConfig `toml:"discovery"`
 
-	// Peers is the list of remote gmuxd instances to aggregate sessions from.
-	Peers []PeerConfig `toml:"peers"`
+	// NOTE: there is no `[[peers]]` array (removed in ADR 0007). Manually
+	// added peers are now runtime state in peers.json (see internal/
+	// peerstore), managed via the "Connect to host" flow.
 }
 
-// PeerConfig describes a remote gmuxd spoke to subscribe to.
+// PeerConfig describes a remote gmuxd spoke to subscribe to. It is no
+// longer loaded from the config file (ADR 0007); the peering manager and
+// peerstore construct it directly.
 type PeerConfig struct {
 	// Name is a URL-safe slug used as the namespace prefix for session IDs
 	// (e.g. sessions become "sess-abc@name") and in URL routing (/@name/).
-	Name string `toml:"name"`
+	Name string
 
 	// URL is the base HTTP URL of the remote gmuxd (e.g. "http://172.17.0.2:8790").
-	URL string `toml:"url"`
+	URL string
 
 	// Token is the bearer token for authenticating with the remote gmuxd.
-	// At most one of Token, TokenFile, or TokenCommand may be set.
-	// Peers on the same tailnet can omit all three (they authenticate
-	// via WhoIs identity instead).
-	Token string `toml:"token"`
-
-	// TokenFile is a path to a file containing the bearer token.
-	TokenFile string `toml:"token_file"`
-
-	// TokenCommand is a shell command whose stdout is the bearer token.
-	// Executed via "sh -c" with a 10-second timeout.
-	TokenCommand string `toml:"token_command"`
+	// Empty for peers that authenticate via tailnet WhoIs identity.
+	Token string
 
 	// Local marks peers whose sessions this node owns (e.g. devcontainers
 	// on the local Docker daemon). Their sessions are included in the
@@ -120,6 +109,9 @@ func Load() (Config, error) {
 			if keys[i] == "tailscale.hostname" {
 				return Config{}, fmt.Errorf("config: %s: tailscale.hostname is no longer supported (ADR 0007); remove it — the node name is now derived from the OS hostname and owned by tailscale", path)
 			}
+			if keys[i] == "peers" {
+				return Config{}, fmt.Errorf("config: %s: [[peers]] is no longer supported (ADR 0007); add peers at runtime via \"Connect to host\" in Settings (stored in peers.json)", path)
+			}
 		}
 		return Config{}, fmt.Errorf("config: unknown keys in %s: %s", path, strings.Join(keys, ", "))
 	}
@@ -141,10 +133,6 @@ func Load() (Config, error) {
 	return cfg, nil
 }
 
-// peerNameRe matches valid peer names: lowercase alphanumeric + hyphens,
-// no leading/trailing hyphens, no consecutive hyphens.
-var peerNameRe = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
-
 func validate(cfg Config) error {
 	// Port range.
 	if cfg.Port < 1 || cfg.Port > 65535 {
@@ -156,51 +144,6 @@ func validate(cfg Config) error {
 	for _, entry := range cfg.Tailscale.Allow {
 		if !strings.Contains(entry, "@") {
 			return fmt.Errorf("tailscale.allow entry %q doesn't look like a login name (expected format: user@provider)", entry)
-		}
-	}
-
-	// Peers: validate each entry.
-	seen := make(map[string]bool, len(cfg.Peers))
-	for i, p := range cfg.Peers {
-		prefix := fmt.Sprintf("peers[%d]", i)
-
-		if p.Name == "" {
-			return fmt.Errorf("%s: name is required", prefix)
-		}
-		if !peerNameRe.MatchString(p.Name) {
-			return fmt.Errorf("%s: name %q must be a lowercase slug (a-z, 0-9, hyphens)", prefix, p.Name)
-		}
-		if seen[p.Name] {
-			return fmt.Errorf("%s: duplicate peer name %q", prefix, p.Name)
-		}
-		seen[p.Name] = true
-
-		if p.URL == "" {
-			return fmt.Errorf("%s (%s): url is required", prefix, p.Name)
-		}
-		u, err := url.Parse(p.URL)
-		if err != nil {
-			return fmt.Errorf("%s (%s): invalid url %q: %w", prefix, p.Name, p.URL, err)
-		}
-		if u.Scheme != "http" && u.Scheme != "https" {
-			return fmt.Errorf("%s (%s): url %q must use http or https scheme", prefix, p.Name, p.URL)
-		}
-		if u.Host == "" {
-			return fmt.Errorf("%s (%s): url %q has no host", prefix, p.Name, p.URL)
-		}
-
-		sources := 0
-		if p.Token != "" {
-			sources++
-		}
-		if p.TokenFile != "" {
-			sources++
-		}
-		if p.TokenCommand != "" {
-			sources++
-		}
-		if sources > 1 {
-			return fmt.Errorf("%s (%s): only one of token, token_file, or token_command may be set", prefix, p.Name)
 		}
 	}
 
@@ -266,64 +209,6 @@ func defaults() Config {
 			Tailscale:     true,
 		},
 	}
-}
-
-// ResolveTokens resolves token_file and token_command references in peer
-// configs, filling the Token field with the actual secret. Called after
-// Load() and before passing configs to the peering manager.
-func (cfg *Config) ResolveTokens() error {
-	for i := range cfg.Peers {
-		if err := cfg.Peers[i].resolveToken(); err != nil {
-			return fmt.Errorf("config: %w", err)
-		}
-	}
-	return nil
-}
-
-func (p *PeerConfig) resolveToken() error {
-	if p.Token != "" {
-		return nil
-	}
-	if p.TokenFile != "" {
-		path := expandHome(p.TokenFile)
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return fmt.Errorf("peer %s: reading token_file: %w", p.Name, err)
-		}
-		token := strings.TrimSpace(string(data))
-		if token == "" {
-			return fmt.Errorf("peer %s: token_file %q is empty", p.Name, p.TokenFile)
-		}
-		p.Token = token
-		return nil
-	}
-	if p.TokenCommand != "" {
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
-		out, err := exec.CommandContext(ctx, "sh", "-c", p.TokenCommand).Output()
-		if err != nil {
-			return fmt.Errorf("peer %s: token_command: %w", p.Name, err)
-		}
-		token := strings.TrimSpace(string(out))
-		if token == "" {
-			return fmt.Errorf("peer %s: token_command produced empty output", p.Name)
-		}
-		p.Token = token
-		return nil
-	}
-	return nil
-}
-
-// expandHome expands a leading ~/ to the user's home directory.
-func expandHome(path string) string {
-	if !strings.HasPrefix(path, "~/") {
-		return path
-	}
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return path
-	}
-	return filepath.Join(home, path[2:])
 }
 
 // ListenAddr returns the effective TCP listen address (host:port).

--- a/services/gmuxd/internal/config/config.go
+++ b/services/gmuxd/internal/config/config.go
@@ -50,7 +50,19 @@ type PeerConfig struct {
 	// outgoing SSE stream; network peer sessions are not. Set
 	// programmatically by the devcontainer watcher.
 	Local bool
+
+	// Source records how the peer was added, for UI grouping only (it
+	// has no effect on connection behavior). One of SourceTailscale,
+	// SourceDevcontainer, or SourceManual.
+	Source string
 }
+
+// Peer sources (see PeerConfig.Source).
+const (
+	SourceTailscale    = "tailscale"    // auto-discovered on the tailnet
+	SourceDevcontainer = "devcontainer" // auto-discovered Docker devcontainer
+	SourceManual       = "manual"       // added via peers.json / POST /v1/peers
+)
 
 // DiscoveryConfig controls automatic peer discovery.
 type DiscoveryConfig struct {

--- a/services/gmuxd/internal/config/config_test.go
+++ b/services/gmuxd/internal/config/config_test.go
@@ -21,9 +21,6 @@ func TestLoadDefaults(t *testing.T) {
 	if cfg.Tailscale.Enabled {
 		t.Error("tailscale should be disabled by default")
 	}
-	if cfg.Tailscale.Hostname != "gmux" {
-		t.Errorf("hostname = %q, want %q", cfg.Tailscale.Hostname, "gmux")
-	}
 	if !cfg.Discovery.Devcontainers {
 		t.Error("discovery.devcontainers should default to true")
 	}
@@ -37,7 +34,6 @@ port = 9999
 
 [tailscale]
 enabled = true
-hostname = "mybox"
 allow = ["alice@github", "bob@github"]
 `)
 
@@ -50,9 +46,6 @@ allow = ["alice@github", "bob@github"]
 	}
 	if !cfg.Tailscale.Enabled {
 		t.Error("tailscale should be enabled")
-	}
-	if cfg.Tailscale.Hostname != "mybox" {
-		t.Errorf("hostname = %q, want %q", cfg.Tailscale.Hostname, "mybox")
 	}
 	if len(cfg.Tailscale.Allow) != 2 {
 		t.Fatalf("allow = %v, want 2 entries", cfg.Tailscale.Allow)
@@ -93,6 +86,24 @@ alow = ["user@github"]
 	}
 	if !strings.Contains(err.Error(), "unknown keys") {
 		t.Errorf("error = %q, want mention of unknown keys", err)
+	}
+}
+
+func TestLoadRejectsRemovedTailscaleHostname(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	writeConfig(t, dir, `
+[tailscale]
+enabled = true
+hostname = "project-a"
+`)
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected error for removed key tailscale.hostname")
+	}
+	if !strings.Contains(err.Error(), "tailscale.hostname is no longer supported") {
+		t.Errorf("error = %q, want migration hint for tailscale.hostname", err)
 	}
 }
 

--- a/services/gmuxd/internal/config/config_test.go
+++ b/services/gmuxd/internal/config/config_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -104,6 +103,24 @@ hostname = "project-a"
 	}
 	if !strings.Contains(err.Error(), "tailscale.hostname is no longer supported") {
 		t.Errorf("error = %q, want migration hint for tailscale.hostname", err)
+	}
+}
+
+func TestLoadRejectsRemovedPeers(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	writeConfig(t, dir, `
+[[peers]]
+name = "server"
+url = "https://gmux-server.ts.net"
+`)
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected error for removed [[peers]] config")
+	}
+	if !strings.Contains(err.Error(), "[[peers]] is no longer supported") {
+		t.Errorf("error = %q, want migration hint for [[peers]]", err)
 	}
 }
 
@@ -241,291 +258,6 @@ func TestListenAddrIPv6(t *testing.T) {
 
 // ── [[peers]] ──
 
-func TestLoadPeers(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("XDG_CONFIG_HOME", dir)
-	writeConfig(t, dir, `
-[[peers]]
-name = "server"
-url = "http://10.0.0.5:8790"
-token = "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
-
-[[peers]]
-name = "dev-box"
-url = "http://172.17.0.2:8790"
-token = "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
-`)
-
-	cfg, err := Load()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(cfg.Peers) != 2 {
-		t.Fatalf("peers = %d, want 2", len(cfg.Peers))
-	}
-	if cfg.Peers[0].Name != "server" {
-		t.Errorf("peers[0].name = %q, want %q", cfg.Peers[0].Name, "server")
-	}
-	if cfg.Peers[1].Name != "dev-box" {
-		t.Errorf("peers[1].name = %q, want %q", cfg.Peers[1].Name, "dev-box")
-	}
-}
-
-func TestLoadPeersRejectsDuplicate(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("XDG_CONFIG_HOME", dir)
-	writeConfig(t, dir, `
-[[peers]]
-name = "server"
-url = "http://10.0.0.5:8790"
-token = "abc"
-
-[[peers]]
-name = "server"
-url = "http://10.0.0.6:8790"
-token = "def"
-`)
-
-	_, err := Load()
-	if err == nil {
-		t.Fatal("expected error for duplicate peer name")
-	}
-	if !strings.Contains(err.Error(), "duplicate") {
-		t.Errorf("error = %q, want mention of duplicate", err)
-	}
-}
-
-func TestLoadPeersRejectsInvalidName(t *testing.T) {
-	tests := []struct {
-		name string
-		want string
-	}{
-		{"", "name is required"},
-		{"Server", "lowercase slug"},
-		{"my_server", "lowercase slug"},
-		{"my@server", "lowercase slug"},
-		{"-leading", "lowercase slug"},
-		{"trailing-", "lowercase slug"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			dir := t.TempDir()
-			t.Setenv("XDG_CONFIG_HOME", dir)
-			writeConfig(t, dir, fmt.Sprintf(`
-[[peers]]
-name = %q
-url = "http://10.0.0.5:8790"
-token = "abc"
-`, tt.name))
-
-			_, err := Load()
-			if err == nil {
-				t.Fatal("expected error")
-			}
-			if !strings.Contains(err.Error(), tt.want) {
-				t.Errorf("error = %q, want mention of %q", err, tt.want)
-			}
-		})
-	}
-}
-
-func TestLoadPeersRejectsMissingURL(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("XDG_CONFIG_HOME", dir)
-	writeConfig(t, dir, `
-[[peers]]
-name = "server"
-token = "abc"
-`)
-
-	_, err := Load()
-	if err == nil {
-		t.Fatal("expected error for missing url")
-	}
-	if !strings.Contains(err.Error(), "url is required") {
-		t.Errorf("error = %q, want mention of url", err)
-	}
-}
-
-func TestLoadPeersAcceptsNoToken(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("XDG_CONFIG_HOME", dir)
-	writeConfig(t, dir, `
-[[peers]]
-name = "server"
-url = "https://mybox.tailnet.ts.net"
-`)
-
-	cfg, err := Load()
-	if err != nil {
-		t.Fatalf("tokenless peer should be accepted (tailscale auth): %v", err)
-	}
-	if cfg.Peers[0].Token != "" {
-		t.Errorf("token = %q, want empty", cfg.Peers[0].Token)
-	}
-}
-
-func TestLoadPeersRejectsMultipleTokenSources(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("XDG_CONFIG_HOME", dir)
-	writeConfig(t, dir, `
-[[peers]]
-name = "server"
-url = "http://10.0.0.5:8790"
-token = "inline"
-token_file = "/path/to/token"
-`)
-
-	_, err := Load()
-	if err == nil {
-		t.Fatal("expected error for multiple token sources")
-	}
-	if !strings.Contains(err.Error(), "only one") {
-		t.Errorf("error = %q, want mention of 'only one'", err)
-	}
-}
-
-func TestLoadPeersTokenFile(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("XDG_CONFIG_HOME", dir)
-	tokenFile := filepath.Join(t.TempDir(), "token")
-	os.WriteFile(tokenFile, []byte("my-secret-token\n"), 0o600)
-
-	writeConfig(t, dir, fmt.Sprintf(`
-[[peers]]
-name = "server"
-url = "http://10.0.0.5:8790"
-token_file = %q
-`, tokenFile))
-
-	cfg, err := Load()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if cfg.Peers[0].TokenFile != tokenFile {
-		t.Errorf("token_file = %q, want %q", cfg.Peers[0].TokenFile, tokenFile)
-	}
-}
-
-func TestLoadPeersTokenCommand(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("XDG_CONFIG_HOME", dir)
-	writeConfig(t, dir, `
-[[peers]]
-name = "server"
-url = "http://10.0.0.5:8790"
-token_command = "echo my-secret"
-`)
-
-	cfg, err := Load()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if cfg.Peers[0].TokenCommand != "echo my-secret" {
-		t.Errorf("token_command = %q, want %q", cfg.Peers[0].TokenCommand, "echo my-secret")
-	}
-}
-
-func TestResolveTokens_Inline(t *testing.T) {
-	cfg := Config{
-		Peers: []PeerConfig{{Name: "s", URL: "http://x:8790", Token: "abc"}},
-	}
-	if err := cfg.ResolveTokens(); err != nil {
-		t.Fatal(err)
-	}
-	if cfg.Peers[0].Token != "abc" {
-		t.Errorf("token = %q, want %q", cfg.Peers[0].Token, "abc")
-	}
-}
-
-func TestResolveTokens_File(t *testing.T) {
-	tokenFile := filepath.Join(t.TempDir(), "token")
-	os.WriteFile(tokenFile, []byte("  file-secret  \n"), 0o600)
-
-	cfg := Config{
-		Peers: []PeerConfig{{Name: "s", URL: "http://x:8790", TokenFile: tokenFile}},
-	}
-	if err := cfg.ResolveTokens(); err != nil {
-		t.Fatal(err)
-	}
-	if cfg.Peers[0].Token != "file-secret" {
-		t.Errorf("token = %q, want %q", cfg.Peers[0].Token, "file-secret")
-	}
-}
-
-func TestResolveTokens_FileExpandsHome(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-
-	// Write a token file at $HOME/.config/gmux/tokens/server
-	dir := filepath.Join(home, ".config", "gmux", "tokens")
-	os.MkdirAll(dir, 0o700)
-	absPath := filepath.Join(dir, "server")
-	os.WriteFile(absPath, []byte("home-secret\n"), 0o600)
-
-	cfg := Config{
-		Peers: []PeerConfig{{
-			Name:      "s",
-			URL:       "http://x:8790",
-			TokenFile: "~/.config/gmux/tokens/server",
-		}},
-	}
-	if err := cfg.ResolveTokens(); err != nil {
-		t.Fatal(err)
-	}
-	if cfg.Peers[0].Token != "home-secret" {
-		t.Errorf("token = %q, want %q", cfg.Peers[0].Token, "home-secret")
-	}
-}
-
-func TestResolveTokens_Command(t *testing.T) {
-	cfg := Config{
-		Peers: []PeerConfig{{Name: "s", URL: "http://x:8790", TokenCommand: "echo cmd-secret"}},
-	}
-	if err := cfg.ResolveTokens(); err != nil {
-		t.Fatal(err)
-	}
-	if cfg.Peers[0].Token != "cmd-secret" {
-		t.Errorf("token = %q, want %q", cfg.Peers[0].Token, "cmd-secret")
-	}
-}
-
-func TestResolveTokens_EmptyFileErrors(t *testing.T) {
-	tokenFile := filepath.Join(t.TempDir(), "token")
-	os.WriteFile(tokenFile, []byte("  \n"), 0o600)
-
-	cfg := Config{
-		Peers: []PeerConfig{{Name: "s", URL: "http://x:8790", TokenFile: tokenFile}},
-	}
-	err := cfg.ResolveTokens()
-	if err == nil {
-		t.Fatal("expected error for empty token file")
-	}
-	if !strings.Contains(err.Error(), "empty") {
-		t.Errorf("error = %q, want mention of empty", err)
-	}
-}
-
-func TestResolveTokens_MissingFileErrors(t *testing.T) {
-	cfg := Config{
-		Peers: []PeerConfig{{Name: "s", URL: "http://x:8790", TokenFile: "/nonexistent/path"}},
-	}
-	err := cfg.ResolveTokens()
-	if err == nil {
-		t.Fatal("expected error for missing token file")
-	}
-}
-
-func TestResolveTokens_FailedCommandErrors(t *testing.T) {
-	cfg := Config{
-		Peers: []PeerConfig{{Name: "s", URL: "http://x:8790", TokenCommand: "false"}},
-	}
-	err := cfg.ResolveTokens()
-	if err == nil {
-		t.Fatal("expected error for failed command")
-	}
-}
-
 func TestLoadDiscoveryDefaults(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", dir)
@@ -554,71 +286,6 @@ devcontainers = false
 	}
 	if cfg.Discovery.Devcontainers {
 		t.Error("discovery.devcontainers should be false when explicitly disabled")
-	}
-}
-
-func TestLoadPeersRejectsInvalidURL(t *testing.T) {
-	tests := []struct {
-		url  string
-		want string
-	}{
-		{"not-a-url", "http or https"},
-		{"ftp://server:8790", "http or https"},
-		{"http://", "no host"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.url, func(t *testing.T) {
-			dir := t.TempDir()
-			t.Setenv("XDG_CONFIG_HOME", dir)
-			writeConfig(t, dir, fmt.Sprintf(`
-[[peers]]
-name = "server"
-url = %q
-token = "abc"
-`, tt.url))
-
-			_, err := Load()
-			if err == nil {
-				t.Fatal("expected error")
-			}
-			if !strings.Contains(err.Error(), tt.want) {
-				t.Errorf("error = %q, want mention of %q", err, tt.want)
-			}
-		})
-	}
-}
-
-func TestLoadPeersAcceptsHTTPAndHTTPS(t *testing.T) {
-	for _, scheme := range []string{"http", "https"} {
-		t.Run(scheme, func(t *testing.T) {
-			dir := t.TempDir()
-			t.Setenv("XDG_CONFIG_HOME", dir)
-			writeConfig(t, dir, fmt.Sprintf(`
-[[peers]]
-name = "server"
-url = "%s://10.0.0.5:8790"
-token = "abc"
-`, scheme))
-
-			_, err := Load()
-			if err != nil {
-				t.Fatalf("scheme %s should be accepted: %v", scheme, err)
-			}
-		})
-	}
-}
-
-func TestLoadNoPeersIsValid(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("XDG_CONFIG_HOME", dir)
-	writeConfig(t, dir, `port = 8790`)
-
-	cfg, err := Load()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(cfg.Peers) != 0 {
-		t.Errorf("peers = %d, want 0", len(cfg.Peers))
 	}
 }
 

--- a/services/gmuxd/internal/devcontainers/watcher.go
+++ b/services/gmuxd/internal/devcontainers/watcher.go
@@ -231,10 +231,11 @@ func (w *Watcher) scan(ctx context.Context) {
 		name := w.uniqueName(deriveName(r.c))
 		url := fmt.Sprintf("http://%s:%d", r.c.IP, gmuxdPort)
 		cfg := config.PeerConfig{
-			Name:  name,
-			URL:   url,
-			Token: r.token,
-			Local: true,
+			Name:   name,
+			URL:    url,
+			Token:  r.token,
+			Local:  true,
+			Source: config.SourceDevcontainer,
 		}
 		log.Printf("devcontainers: discovered %s (container %s, %s)", name, short(r.c.ID), url)
 		w.mgr.AddPeer(cfg)

--- a/services/gmuxd/internal/devcontainers/watcher.go
+++ b/services/gmuxd/internal/devcontainers/watcher.go
@@ -348,10 +348,20 @@ func dockerSocketPath() string {
 	return "/var/run/docker.sock"
 }
 
-// isGmuxContainer returns true if a container is running gmuxd via the
-// devcontainer feature. Detection: GMUXD_LISTEN env var is set by the
-// feature's containerEnv.
+// isGmuxContainer returns true if a container is a discoverable gmux
+// devcontainer. It must (1) run gmuxd via the devcontainer feature —
+// detected by the GMUXD_LISTEN env var set in the feature's
+// containerEnv — and (2) carry the `devcontainer.local_folder` label
+// (ADR 0007 §3).
+//
+// Gating on the label means discovery only ever names a peer after its
+// host folder (deriveName), never after the ephemeral container ID:
+// a label-less container is simply not discovered, so the ID fallback
+// can't churn the peer name on every container recreation.
 func isGmuxContainer(c container) bool {
+	if _, ok := c.Labels["devcontainer.local_folder"]; !ok {
+		return false
+	}
 	for _, e := range c.Env {
 		if strings.HasPrefix(e, "GMUXD_LISTEN=") {
 			return true

--- a/services/gmuxd/internal/devcontainers/watcher_test.go
+++ b/services/gmuxd/internal/devcontainers/watcher_test.go
@@ -727,19 +727,24 @@ func TestDockerSocketPath(t *testing.T) {
 }
 
 func TestIsGmuxContainer(t *testing.T) {
+	// Discovery requires BOTH the GMUXD_LISTEN env var and the
+	// devcontainer.local_folder label (ADR 0007 §3).
+	withLabel := map[string]string{"devcontainer.local_folder": "/home/user/proj"}
 	tests := []struct {
-		name string
-		env  []string
-		want bool
+		name   string
+		env    []string
+		labels map[string]string
+		want   bool
 	}{
-		{"with GMUXD_LISTEN", []string{"PATH=/bin", "GMUXD_LISTEN=0.0.0.0"}, true},
-		{"without GMUXD_LISTEN", []string{"PATH=/bin", "REDIS_PORT=6379"}, false},
-		{"empty env", nil, false},
-		{"partial match", []string{"GMUXD_LISTEN_OTHER=x"}, false},
+		{"env + label", []string{"PATH=/bin", "GMUXD_LISTEN=0.0.0.0"}, withLabel, true},
+		{"env but no label", []string{"PATH=/bin", "GMUXD_LISTEN=0.0.0.0"}, nil, false},
+		{"label but no GMUXD_LISTEN", []string{"PATH=/bin", "REDIS_PORT=6379"}, withLabel, false},
+		{"empty env, with label", nil, withLabel, false},
+		{"partial env match, with label", []string{"GMUXD_LISTEN_OTHER=x"}, withLabel, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := container{Env: tt.env}
+			c := container{Env: tt.env, Labels: tt.labels}
 			if got := isGmuxContainer(c); got != tt.want {
 				t.Errorf("isGmuxContainer = %v, want %v", got, tt.want)
 			}

--- a/services/gmuxd/internal/identity/identity.go
+++ b/services/gmuxd/internal/identity/identity.go
@@ -1,0 +1,30 @@
+// Package identity resolves this node's stable, human-readable name
+// (ADR 0007): the live tailscale hostname when tailscale is connected,
+// otherwise the OS hostname.
+//
+// This single value feeds the /v1/health `hostname` field (and thus how
+// peers name this node in their UI and URLs), so it must be the name the
+// node is actually reachable as — not os.Hostname(), which inside a
+// container is the ephemeral container ID and churns on recreation.
+package identity
+
+import "strings"
+
+// Resolve returns the node identity given the live tailscale FQDN (empty
+// when tailscale is disabled or not yet connected) and the OS hostname.
+//
+// The tailscale name — the first label of the FQDN, e.g. "gmux-laptop"
+// from "gmux-laptop.tailnet.ts.net" — wins when present. Tailscale owns
+// and persists this name (post-dedup) in its node state, so it is sticky
+// across daemon restarts and container recreation. With no tailscale
+// FQDN, the OS hostname is used.
+func Resolve(tailscaleFQDN, osHostname string) string {
+	label := tailscaleFQDN
+	if i := strings.IndexByte(tailscaleFQDN, '.'); i >= 0 {
+		label = tailscaleFQDN[:i]
+	}
+	if label != "" {
+		return label
+	}
+	return osHostname
+}

--- a/services/gmuxd/internal/identity/identity_test.go
+++ b/services/gmuxd/internal/identity/identity_test.go
@@ -1,0 +1,25 @@
+package identity
+
+import "testing"
+
+func TestResolve(t *testing.T) {
+	tests := []struct {
+		name     string
+		fqdn     string
+		osHost   string
+		want     string
+	}{
+		{"tailscale fqdn wins over os hostname", "gmux-laptop.tailnet.ts.net", "ca75413aec31", "gmux-laptop"},
+		{"fqdn without dot used as-is", "gmux-laptop", "host", "gmux-laptop"},
+		{"no fqdn falls back to os hostname", "", "my-server", "my-server"},
+		{"empty both", "", "", ""},
+		{"leading-dot fqdn falls back (no usable label)", ".weird", "host", "host"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Resolve(tt.fqdn, tt.osHost); got != tt.want {
+				t.Fatalf("Resolve(%q, %q) = %q, want %q", tt.fqdn, tt.osHost, got, tt.want)
+			}
+		})
+	}
+}

--- a/services/gmuxd/internal/nodeid/nodeid.go
+++ b/services/gmuxd/internal/nodeid/nodeid.go
@@ -1,0 +1,91 @@
+// Package nodeid manages the stable, opaque per-node identifier gmuxd
+// uses to answer "is this the same node?" across reconnects, address
+// changes, and connection methods — independent of the node's mutable
+// human-readable hostname. See ADR 0007.
+//
+// The id is generated once on first start and persisted to the state
+// directory alongside the auth token, so it survives daemon restarts
+// (and container recreation, when the state directory is on a persisted
+// volume — the same requirement the auth token and the tailscale node
+// key already impose).
+//
+// It is opaque: never shown in the UI and never part of a URL. It is
+// not a secret — the auth token is the credential — but it is generated
+// with crypto/rand so it cannot be cheaply forged to impersonate
+// another node during peer dedup.
+package nodeid
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	// idBytes is the number of random bytes in a generated id (256 bits).
+	// Matches authtoken so both share one generate-and-persist shape;
+	// far more than collision-resistance requires.
+	idBytes = 32
+
+	// prefix tags the id for easy recognition in logs and /v1/health,
+	// mirroring the "sess-" session-id convention.
+	prefix = "node_"
+
+	// fileName is the name of the id file in the state directory.
+	fileName = "node-id"
+)
+
+// LoadOrCreate returns this node's stable id, generating and persisting
+// it on first call.
+//
+//   - file present and valid: return it.
+//   - file absent: generate, persist (0600), return it.
+//   - file present but corrupted: hard error. Silently regenerating
+//     would change the node's identity and split it from peers that
+//     already know it, so we refuse rather than guess.
+func LoadOrCreate(stateDir string) (string, error) {
+	path := filepath.Join(stateDir, fileName)
+
+	data, err := os.ReadFile(path)
+	switch {
+	case err == nil:
+		id := strings.TrimSpace(string(data))
+		if !valid(id) {
+			return "", fmt.Errorf("nodeid: %s is corrupted; remove the file and restart", path)
+		}
+		return id, nil
+	case os.IsNotExist(err):
+		return generate(path)
+	default:
+		return "", fmt.Errorf("nodeid: reading %s: %w", path, err)
+	}
+}
+
+// valid reports whether id is a well-formed node id ("node_" + 64 hex).
+func valid(id string) bool {
+	hexPart, ok := strings.CutPrefix(id, prefix)
+	if !ok || len(hexPart) != idBytes*2 {
+		return false
+	}
+	_, err := hex.DecodeString(hexPart)
+	return err == nil
+}
+
+func generate(path string) (string, error) {
+	b := make([]byte, idBytes)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("nodeid: generating random id: %w", err)
+	}
+	id := prefix + hex.EncodeToString(b)
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return "", fmt.Errorf("nodeid: creating state dir: %w", err)
+	}
+	if err := os.WriteFile(path, []byte(id+"\n"), 0o600); err != nil {
+		return "", fmt.Errorf("nodeid: writing %s: %w", path, err)
+	}
+	return id, nil
+}

--- a/services/gmuxd/internal/nodeid/nodeid_test.go
+++ b/services/gmuxd/internal/nodeid/nodeid_test.go
@@ -1,0 +1,93 @@
+package nodeid
+
+import (
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGeneratesWhenNothingExists(t *testing.T) {
+	dir := t.TempDir()
+
+	id, err := LoadOrCreate(dir)
+	if err != nil {
+		t.Fatalf("LoadOrCreate: %v", err)
+	}
+
+	hexPart, ok := strings.CutPrefix(id, prefix)
+	if !ok {
+		t.Fatalf("id %q missing %q prefix", id, prefix)
+	}
+	if len(hexPart) != idBytes*2 {
+		t.Fatalf("id hex part = %d chars, want %d", len(hexPart), idBytes*2)
+	}
+	if _, err := hex.DecodeString(hexPart); err != nil {
+		t.Fatalf("id hex part not valid hex: %v", err)
+	}
+
+	// File persisted with 0600.
+	info, err := os.Stat(filepath.Join(dir, fileName))
+	if err != nil {
+		t.Fatalf("stat id file: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("id file perm = %o, want 600", perm)
+	}
+}
+
+func TestStableAcrossCalls(t *testing.T) {
+	dir := t.TempDir()
+
+	first, err := LoadOrCreate(dir)
+	if err != nil {
+		t.Fatalf("first LoadOrCreate: %v", err)
+	}
+	second, err := LoadOrCreate(dir)
+	if err != nil {
+		t.Fatalf("second LoadOrCreate: %v", err)
+	}
+	if first != second {
+		t.Fatalf("id changed across calls: %q != %q", first, second)
+	}
+}
+
+func TestDistinctPerStateDir(t *testing.T) {
+	a, err := LoadOrCreate(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := LoadOrCreate(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a == b {
+		t.Fatalf("two fresh node ids collided: %q", a)
+	}
+}
+
+func TestCorruptedFileIsHardError(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, fileName), []byte("not-a-node-id\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadOrCreate(dir); err == nil {
+		t.Fatal("expected error for corrupted id file, got nil")
+	}
+}
+
+func TestReadsExistingValidFile(t *testing.T) {
+	dir := t.TempDir()
+	want := prefix + strings.Repeat("ab", idBytes)
+	if err := os.WriteFile(filepath.Join(dir, fileName), []byte(want+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := LoadOrCreate(dir)
+	if err != nil {
+		t.Fatalf("LoadOrCreate: %v", err)
+	}
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}

--- a/services/gmuxd/internal/peering/manager.go
+++ b/services/gmuxd/internal/peering/manager.go
@@ -231,6 +231,7 @@ func (m *Manager) PeerStatus() []PeerInfo {
 			SessionCount: alive,
 			LastError:    mp.peer.LastError(),
 			Local:        mp.peer.Config.Local,
+			Source:       mp.peer.Config.Source,
 		}
 		if h, ok := mp.peer.CachedHealth(); ok {
 			info.Version = h.Version

--- a/services/gmuxd/internal/peering/peering.go
+++ b/services/gmuxd/internal/peering/peering.go
@@ -114,6 +114,11 @@ type PeerInfo struct {
 	// which then bucket into the parent's local folders. See ADR
 	// 0002 amendment.
 	Local bool `json:"local,omitempty"`
+	// Source records how the peer was added: "tailscale" (auto-discovered
+	// on the tailnet), "devcontainer" (auto-discovered Docker container),
+	// or "manual" (peers.json / POST /v1/peers). Used by the UI to group
+	// hosts; empty for the synthesized self row.
+	Source string `json:"source,omitempty"`
 }
 
 // NamespaceID returns a store-key for a remote session: "originalID@peerName".

--- a/services/gmuxd/internal/peering/peering_test.go
+++ b/services/gmuxd/internal/peering/peering_test.go
@@ -203,6 +203,30 @@ func TestPeerSubscribe_PreservesTitles(t *testing.T) {
 	mgr.Stop()
 }
 
+// PeerStatus must surface how each peer was added (Config.Source) so the
+// UI can group hosts into tailnet / devcontainer / manual sections.
+func TestPeerStatus_CarriesSource(t *testing.T) {
+	mgr := NewManager([]config.PeerConfig{
+		{Name: "ts", URL: "http://a:8790", Source: config.SourceTailscale},
+		{Name: "dc", URL: "http://b:8790", Source: config.SourceDevcontainer, Local: true},
+		{Name: "hand", URL: "http://c:8790", Source: config.SourceManual},
+	}, store.New(), "test-host")
+
+	got := map[string]string{}
+	for _, p := range mgr.PeerStatus() {
+		got[p.Name] = p.Source
+	}
+	for name, want := range map[string]string{
+		"ts":   config.SourceTailscale,
+		"dc":   config.SourceDevcontainer,
+		"hand": config.SourceManual,
+	} {
+		if got[name] != want {
+			t.Errorf("PeerStatus()[%q].Source = %q, want %q", name, got[name], want)
+		}
+	}
+}
+
 func TestPeerSubscribe_InitialSessions(t *testing.T) {
 	st := store.New()
 	sessions := []store.Session{

--- a/services/gmuxd/internal/peerstore/peerstore.go
+++ b/services/gmuxd/internal/peerstore/peerstore.go
@@ -90,6 +90,12 @@ func Open(stateDir string) (*Store, error) {
 		}
 		return nil, fmt.Errorf("peerstore: reading %s: %w", s.path, err)
 	}
+	// An empty file (e.g. a truncated write from an older build that
+	// didn't persist atomically) is treated as an empty store rather
+	// than a fatal parse error, so the daemon can still start.
+	if len(data) == 0 {
+		return s, nil
+	}
 	if err := json.Unmarshal(data, &s.records); err != nil {
 		return nil, fmt.Errorf("peerstore: parsing %s: %w", s.path, err)
 	}
@@ -109,7 +115,7 @@ func (s *Store) PeerConfigs() []config.PeerConfig {
 	defer s.mu.Unlock()
 	out := make([]config.PeerConfig, 0, len(s.records))
 	for _, r := range s.records {
-		out = append(out, config.PeerConfig{Name: r.Name, URL: r.URL, Token: r.Token})
+		out = append(out, config.PeerConfig{Name: r.Name, URL: r.URL, Token: r.Token, Source: config.SourceManual})
 	}
 	return out
 }
@@ -190,8 +196,15 @@ func (s *Store) save() error {
 	if err := os.MkdirAll(filepath.Dir(s.path), 0o700); err != nil {
 		return fmt.Errorf("peerstore: creating state dir: %w", err)
 	}
-	if err := os.WriteFile(s.path, append(data, '\n'), 0o600); err != nil {
-		return fmt.Errorf("peerstore: writing %s: %w", s.path, err)
+	// Write-to-tmp-then-rename so a crash mid-write can never leave a
+	// truncated/0-byte peers.json (rename is atomic; matches
+	// projects.go and discovery/persist.go).
+	tmp := s.path + ".tmp"
+	if err := os.WriteFile(tmp, append(data, '\n'), 0o600); err != nil {
+		return fmt.Errorf("peerstore: writing %s: %w", tmp, err)
+	}
+	if err := os.Rename(tmp, s.path); err != nil {
+		return fmt.Errorf("peerstore: renaming %s: %w", s.path, err)
 	}
 	return nil
 }

--- a/services/gmuxd/internal/peerstore/peerstore.go
+++ b/services/gmuxd/internal/peerstore/peerstore.go
@@ -163,8 +163,16 @@ func (s *Store) Remove(name string) (Record, bool, error) {
 	defer s.mu.Unlock()
 	for i, r := range s.records {
 		if r.Name == name {
-			s.records = append(s.records[:i], s.records[i+1:]...)
+			// Build a fresh slice so the original backing array is left
+			// intact for rollback if the disk write fails (mirrors
+			// AddOrGet — keeps the in-memory store consistent with disk).
+			prev := s.records
+			next := make([]Record, 0, len(prev)-1)
+			next = append(next, prev[:i]...)
+			next = append(next, prev[i+1:]...)
+			s.records = next
 			if err := s.save(); err != nil {
+				s.records = prev
 				return Record{}, false, err
 			}
 			return r, true, nil

--- a/services/gmuxd/internal/peerstore/peerstore.go
+++ b/services/gmuxd/internal/peerstore/peerstore.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"sync"
 
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/config"
@@ -45,8 +46,15 @@ type Record struct {
 	NodeID string `json:"node_id,omitempty"`
 }
 
-// peerNameRe matches valid peer names: lowercase alphanumeric + hyphens.
-var peerNameRe = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
+// nonSlug matches runs of characters that aren't slug-safe.
+var nonSlug = regexp.MustCompile(`[^a-z0-9]+`)
+
+// Slugify lowercases and reduces a host's self-reported name to a
+// URL-safe routing slug (the name appears in `/@name/`). Returns ""
+// when nothing usable remains.
+func Slugify(s string) string {
+	return strings.Trim(nonSlug.ReplaceAllString(strings.ToLower(s), "-"), "-")
+}
 
 // ValidateURL reports whether u is an acceptable peer base URL.
 func ValidateURL(u string) error {
@@ -106,46 +114,46 @@ func (s *Store) PeerConfigs() []config.PeerConfig {
 	return out
 }
 
-// FindByNodeID returns the existing record for a node id, if any. An
-// empty id never matches (a peer that doesn't report a node_id can't be
-// deduplicated and is always treated as new).
-func (s *Store) FindByNodeID(nodeID string) (Record, bool) {
+// AddOrGet atomically connects a host: if a record with the same
+// (non-empty) node_id already exists it is returned with existed=true
+// (the same host reached again is not a duplicate); otherwise the
+// record's name is slugified, de-collided, appended, and persisted.
+//
+// The node_id check and the append happen under one lock, so two
+// concurrent connects to the same host can't both pass the dedup and
+// create duplicates (no check-then-act race).
+func (s *Store) AddOrGet(rec Record) (stored Record, existed bool, err error) {
+	if err := ValidateURL(rec.URL); err != nil {
+		return Record{}, false, err
+	}
+	name := Slugify(rec.Name)
+	if name == "" {
+		return Record{}, false, fmt.Errorf("host name %q has no usable slug characters", rec.Name)
+	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if nodeID == "" {
-		return Record{}, false
-	}
-	for _, r := range s.records {
-		if r.NodeID == nodeID {
-			return r, true
+
+	if rec.NodeID != "" {
+		for _, r := range s.records {
+			if r.NodeID == rec.NodeID {
+				return r, true, nil
+			}
 		}
 	}
-	return Record{}, false
-}
 
-// Add validates and appends a record, resolving any name collision with
-// a different node by suffixing, then persists. Returns the stored
-// record (whose Name may have been suffixed).
-func (s *Store) Add(rec Record) (Record, error) {
-	if err := ValidateURL(rec.URL); err != nil {
-		return Record{}, err
-	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
 	taken := make(map[string]bool, len(s.records))
 	for _, r := range s.records {
 		taken[r.Name] = true
 	}
-	rec.Name = uniqueName(rec.Name, taken)
-	if !peerNameRe.MatchString(rec.Name) {
-		return Record{}, fmt.Errorf("peer name %q must be a lowercase slug", rec.Name)
-	}
+	rec.Name = uniqueName(name, taken)
+
 	s.records = append(s.records, rec)
 	if err := s.save(); err != nil {
 		s.records = s.records[:len(s.records)-1]
-		return Record{}, err
+		return Record{}, false, err
 	}
-	return rec, nil
+	return rec, false, nil
 }
 
 // Remove deletes the record with the given name and persists. Returns

--- a/services/gmuxd/internal/peerstore/peerstore.go
+++ b/services/gmuxd/internal/peerstore/peerstore.go
@@ -1,0 +1,196 @@
+// Package peerstore persists the set of manually-added peers (ADR 0007
+// §5). With `[[peers]]` removed from host.toml, a peer the user connects
+// to via the "Connect to host" flow is durable state, not config: it
+// lives in peers.json in the state directory (0600 — it can carry a
+// bearer token), distinct from the user-authored config file.
+//
+// Auto-discovered peers (tailscale, devcontainers) are NOT stored here;
+// they remain ephemeral/runtime. This file is exactly "the hosts you
+// explicitly connected to".
+//
+// Each record carries the remote's opaque node_id (ADR 0007 §4) so the
+// add flow can recognize a host it already knows — reached via a
+// different address or already auto-discovered — instead of adding a
+// duplicate.
+package peerstore
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sync"
+
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/config"
+)
+
+// fileName is the peers file within the state directory.
+const fileName = "peers.json"
+
+// Record is one manually-added peer.
+type Record struct {
+	// Name is the viewer-facing identity used in routing (/@name/). It is
+	// the remote's self-reported name, suffixed (`name-2`) only on a
+	// genuine collision with a different node.
+	Name string `json:"name"`
+	// URL is the base address used to reach the peer.
+	URL string `json:"url"`
+	// Token is the bearer token, if the peer requires one. Empty for
+	// peers authenticated via tailnet identity.
+	Token string `json:"token,omitempty"`
+	// NodeID is the remote's opaque node id (ADR 0007 §4), used to detect
+	// "same host" regardless of address or connection method.
+	NodeID string `json:"node_id,omitempty"`
+}
+
+// peerNameRe matches valid peer names: lowercase alphanumeric + hyphens.
+var peerNameRe = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
+
+// ValidateURL reports whether u is an acceptable peer base URL.
+func ValidateURL(u string) error {
+	parsed, err := url.Parse(u)
+	if err != nil {
+		return fmt.Errorf("invalid url %q: %w", u, err)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return fmt.Errorf("url %q must use http or https", u)
+	}
+	if parsed.Host == "" {
+		return fmt.Errorf("url %q has no host", u)
+	}
+	return nil
+}
+
+// Store is the in-memory + on-disk set of manual peers. Safe for
+// concurrent use.
+type Store struct {
+	mu      sync.Mutex
+	path    string
+	records []Record
+}
+
+// Open loads peers.json from stateDir, returning an empty store if the
+// file is absent.
+func Open(stateDir string) (*Store, error) {
+	s := &Store{path: filepath.Join(stateDir, fileName)}
+	data, err := os.ReadFile(s.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return s, nil
+		}
+		return nil, fmt.Errorf("peerstore: reading %s: %w", s.path, err)
+	}
+	if err := json.Unmarshal(data, &s.records); err != nil {
+		return nil, fmt.Errorf("peerstore: parsing %s: %w", s.path, err)
+	}
+	return s, nil
+}
+
+// List returns a copy of the current records.
+func (s *Store) List() []Record {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]Record(nil), s.records...)
+}
+
+// PeerConfigs converts the records to peering configs for the manager.
+func (s *Store) PeerConfigs() []config.PeerConfig {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]config.PeerConfig, 0, len(s.records))
+	for _, r := range s.records {
+		out = append(out, config.PeerConfig{Name: r.Name, URL: r.URL, Token: r.Token})
+	}
+	return out
+}
+
+// FindByNodeID returns the existing record for a node id, if any. An
+// empty id never matches (a peer that doesn't report a node_id can't be
+// deduplicated and is always treated as new).
+func (s *Store) FindByNodeID(nodeID string) (Record, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if nodeID == "" {
+		return Record{}, false
+	}
+	for _, r := range s.records {
+		if r.NodeID == nodeID {
+			return r, true
+		}
+	}
+	return Record{}, false
+}
+
+// Add validates and appends a record, resolving any name collision with
+// a different node by suffixing, then persists. Returns the stored
+// record (whose Name may have been suffixed).
+func (s *Store) Add(rec Record) (Record, error) {
+	if err := ValidateURL(rec.URL); err != nil {
+		return Record{}, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	taken := make(map[string]bool, len(s.records))
+	for _, r := range s.records {
+		taken[r.Name] = true
+	}
+	rec.Name = uniqueName(rec.Name, taken)
+	if !peerNameRe.MatchString(rec.Name) {
+		return Record{}, fmt.Errorf("peer name %q must be a lowercase slug", rec.Name)
+	}
+	s.records = append(s.records, rec)
+	if err := s.save(); err != nil {
+		s.records = s.records[:len(s.records)-1]
+		return Record{}, err
+	}
+	return rec, nil
+}
+
+// Remove deletes the record with the given name and persists. Returns
+// the removed record and whether one was found.
+func (s *Store) Remove(name string) (Record, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for i, r := range s.records {
+		if r.Name == name {
+			s.records = append(s.records[:i], s.records[i+1:]...)
+			if err := s.save(); err != nil {
+				return Record{}, false, err
+			}
+			return r, true, nil
+		}
+	}
+	return Record{}, false, nil
+}
+
+// save writes the records to disk (0600). Caller holds s.mu.
+func (s *Store) save() error {
+	data, err := json.MarshalIndent(s.records, "", "  ")
+	if err != nil {
+		return fmt.Errorf("peerstore: encoding: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o700); err != nil {
+		return fmt.Errorf("peerstore: creating state dir: %w", err)
+	}
+	if err := os.WriteFile(s.path, append(data, '\n'), 0o600); err != nil {
+		return fmt.Errorf("peerstore: writing %s: %w", s.path, err)
+	}
+	return nil
+}
+
+// uniqueName returns base if free, else base-2, base-3, … (ADR 0007 §7:
+// a genuine collision between two distinct hosts is resolved viewer-side
+// by suffixing).
+func uniqueName(base string, taken map[string]bool) string {
+	if !taken[base] {
+		return base
+	}
+	for i := 2; ; i++ {
+		candidate := fmt.Sprintf("%s-%d", base, i)
+		if !taken[candidate] {
+			return candidate
+		}
+	}
+}

--- a/services/gmuxd/internal/peerstore/peerstore_test.go
+++ b/services/gmuxd/internal/peerstore/peerstore_test.go
@@ -1,0 +1,98 @@
+package peerstore
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestOpenEmptyWhenAbsent(t *testing.T) {
+	s, err := Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(s.List()) != 0 {
+		t.Fatalf("want empty, got %v", s.List())
+	}
+}
+
+func TestAddPersistsAndReloads(t *testing.T) {
+	dir := t.TempDir()
+	s, _ := Open(dir)
+	if _, err := s.Add(Record{Name: "laptop", URL: "https://gmux-laptop.ts.net", Token: "secret", NodeID: "node_a"}); err != nil {
+		t.Fatal(err)
+	}
+
+	// File is 0600 (carries a token).
+	info, err := os.Stat(filepath.Join(dir, fileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("perm = %o, want 600", info.Mode().Perm())
+	}
+
+	// Reloads identically.
+	s2, _ := Open(dir)
+	recs := s2.List()
+	if len(recs) != 1 || recs[0].Name != "laptop" || recs[0].Token != "secret" || recs[0].NodeID != "node_a" {
+		t.Fatalf("reloaded = %+v", recs)
+	}
+}
+
+func TestAddRejectsBadURL(t *testing.T) {
+	s, _ := Open(t.TempDir())
+	if _, err := s.Add(Record{Name: "x", URL: "ftp://nope"}); err == nil {
+		t.Fatal("expected error for non-http url")
+	}
+}
+
+func TestFindByNodeID(t *testing.T) {
+	s, _ := Open(t.TempDir())
+	s.Add(Record{Name: "a", URL: "http://h:8790", NodeID: "node_x"})
+
+	if _, ok := s.FindByNodeID("node_x"); !ok {
+		t.Fatal("should find by node id")
+	}
+	if _, ok := s.FindByNodeID("node_y"); ok {
+		t.Fatal("should not find unknown node id")
+	}
+	// Empty node id never matches (undedupable peer is always new).
+	if _, ok := s.FindByNodeID(""); ok {
+		t.Fatal("empty node id must not match")
+	}
+}
+
+func TestAddSuffixesNameCollision(t *testing.T) {
+	s, _ := Open(t.TempDir())
+	s.Add(Record{Name: "server", URL: "http://a:8790", NodeID: "node_1"})
+	got, err := s.Add(Record{Name: "server", URL: "http://b:8790", NodeID: "node_2"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Name != "server-2" {
+		t.Fatalf("collision name = %q, want server-2", got.Name)
+	}
+	third, _ := s.Add(Record{Name: "server", URL: "http://c:8790", NodeID: "node_3"})
+	if third.Name != "server-3" {
+		t.Fatalf("third name = %q, want server-3", third.Name)
+	}
+}
+
+func TestRemove(t *testing.T) {
+	dir := t.TempDir()
+	s, _ := Open(dir)
+	s.Add(Record{Name: "gone", URL: "http://h:8790"})
+	rec, ok, err := s.Remove("gone")
+	if err != nil || !ok || rec.Name != "gone" {
+		t.Fatalf("remove = %+v ok=%v err=%v", rec, ok, err)
+	}
+	if _, ok, _ := s.Remove("gone"); ok {
+		t.Fatal("second remove should report not found")
+	}
+	// Persisted empty.
+	s2, _ := Open(dir)
+	if len(s2.List()) != 0 {
+		t.Fatalf("want empty after remove, got %v", s2.List())
+	}
+}

--- a/services/gmuxd/internal/peerstore/peerstore_test.go
+++ b/services/gmuxd/internal/peerstore/peerstore_test.go
@@ -16,10 +16,10 @@ func TestOpenEmptyWhenAbsent(t *testing.T) {
 	}
 }
 
-func TestAddPersistsAndReloads(t *testing.T) {
+func TestAddOrGetPersistsAndReloads(t *testing.T) {
 	dir := t.TempDir()
 	s, _ := Open(dir)
-	if _, err := s.Add(Record{Name: "laptop", URL: "https://gmux-laptop.ts.net", Token: "secret", NodeID: "node_a"}); err != nil {
+	if _, _, err := s.AddOrGet(Record{Name: "laptop", URL: "https://gmux-laptop.ts.net", Token: "secret", NodeID: "node_a"}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -40,49 +40,89 @@ func TestAddPersistsAndReloads(t *testing.T) {
 	}
 }
 
-func TestAddRejectsBadURL(t *testing.T) {
+func TestAddOrGetRejectsBadURL(t *testing.T) {
 	s, _ := Open(t.TempDir())
-	if _, err := s.Add(Record{Name: "x", URL: "ftp://nope"}); err == nil {
+	if _, _, err := s.AddOrGet(Record{Name: "x", URL: "ftp://nope", NodeID: "n"}); err == nil {
 		t.Fatal("expected error for non-http url")
 	}
 }
 
-func TestFindByNodeID(t *testing.T) {
-	s, _ := Open(t.TempDir())
-	s.Add(Record{Name: "a", URL: "http://h:8790", NodeID: "node_x"})
+// Re-adding the same node_id returns the existing record (existed=true)
+// rather than creating a duplicate — and does so under one lock, so it's
+// safe against concurrent connects (no check-then-act race).
+func TestAddOrGetDedupsByNodeID(t *testing.T) {
+	dir := t.TempDir()
+	s, _ := Open(dir)
+	first, _, _ := s.AddOrGet(Record{Name: "laptop", URL: "http://a:8790", NodeID: "node_x"})
 
-	if _, ok := s.FindByNodeID("node_x"); !ok {
-		t.Fatal("should find by node id")
-	}
-	if _, ok := s.FindByNodeID("node_y"); ok {
-		t.Fatal("should not find unknown node id")
-	}
-	// Empty node id never matches (undedupable peer is always new).
-	if _, ok := s.FindByNodeID(""); ok {
-		t.Fatal("empty node id must not match")
-	}
-}
-
-func TestAddSuffixesNameCollision(t *testing.T) {
-	s, _ := Open(t.TempDir())
-	s.Add(Record{Name: "server", URL: "http://a:8790", NodeID: "node_1"})
-	got, err := s.Add(Record{Name: "server", URL: "http://b:8790", NodeID: "node_2"})
+	got, existed, err := s.AddOrGet(Record{Name: "laptop-again", URL: "http://b:8790", NodeID: "node_x"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got.Name != "server-2" {
-		t.Fatalf("collision name = %q, want server-2", got.Name)
+	if !existed {
+		t.Fatal("re-adding same node_id should report existed=true")
 	}
-	third, _ := s.Add(Record{Name: "server", URL: "http://c:8790", NodeID: "node_3"})
-	if third.Name != "server-3" {
-		t.Fatalf("third name = %q, want server-3", third.Name)
+	if got.Name != first.Name || got.URL != "http://a:8790" {
+		t.Fatalf("dedup should return the original record, got %+v", got)
+	}
+	if len(s.List()) != 1 {
+		t.Fatalf("dedup must not append, got %d records", len(s.List()))
+	}
+}
+
+// An empty node_id is undedupable: each add is a distinct host.
+func TestAddOrGetEmptyNodeIDNotDeduped(t *testing.T) {
+	s, _ := Open(t.TempDir())
+	s.AddOrGet(Record{Name: "a", URL: "http://a:8790"})
+	s.AddOrGet(Record{Name: "b", URL: "http://b:8790"})
+	if len(s.List()) != 2 {
+		t.Fatalf("empty node_id must not dedup, got %d", len(s.List()))
+	}
+}
+
+func TestAddOrGetSlugifiesAndSuffixes(t *testing.T) {
+	s, _ := Open(t.TempDir())
+	// Non-slug self-reported name is slugified rather than rejected.
+	got, _, err := s.AddOrGet(Record{Name: "My-Laptop.local", URL: "http://a:8790", NodeID: "n1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Name != "my-laptop-local" {
+		t.Fatalf("slugified name = %q, want my-laptop-local", got.Name)
+	}
+	// A different node reporting a name that slugifies to the same value
+	// is suffixed.
+	got2, _, _ := s.AddOrGet(Record{Name: "my-laptop-local", URL: "http://b:8790", NodeID: "n2"})
+	if got2.Name != "my-laptop-local-2" {
+		t.Fatalf("collision name = %q, want my-laptop-local-2", got2.Name)
+	}
+}
+
+func TestAddOrGetRejectsUnslugifiableName(t *testing.T) {
+	s, _ := Open(t.TempDir())
+	if _, _, err := s.AddOrGet(Record{Name: "...", URL: "http://a:8790", NodeID: "n"}); err == nil {
+		t.Fatal("expected error for a name with no usable slug characters")
+	}
+}
+
+func TestSlugify(t *testing.T) {
+	for _, tt := range []struct{ in, want string }{
+		{"My-Laptop.local", "my-laptop-local"},
+		{"gmux-server", "gmux-server"},
+		{"  Spaces  ", "spaces"},
+		{"...", ""},
+		{"", ""},
+	} {
+		if got := Slugify(tt.in); got != tt.want {
+			t.Errorf("Slugify(%q) = %q, want %q", tt.in, got, tt.want)
+		}
 	}
 }
 
 func TestRemove(t *testing.T) {
 	dir := t.TempDir()
 	s, _ := Open(dir)
-	s.Add(Record{Name: "gone", URL: "http://h:8790"})
+	s.AddOrGet(Record{Name: "gone", URL: "http://h:8790", NodeID: "n"})
 	rec, ok, err := s.Remove("gone")
 	if err != nil || !ok || rec.Name != "gone" {
 		t.Fatalf("remove = %+v ok=%v err=%v", rec, ok, err)
@@ -90,7 +130,6 @@ func TestRemove(t *testing.T) {
 	if _, ok, _ := s.Remove("gone"); ok {
 		t.Fatal("second remove should report not found")
 	}
-	// Persisted empty.
 	s2, _ := Open(dir)
 	if len(s2.List()) != 0 {
 		t.Fatalf("want empty after remove, got %v", s2.List())

--- a/services/gmuxd/internal/peerstore/peerstore_test.go
+++ b/services/gmuxd/internal/peerstore/peerstore_test.go
@@ -127,11 +127,13 @@ func TestRemoveRollsBackOnSaveFailure(t *testing.T) {
 	s, _ := Open(dir)
 	s.AddOrGet(Record{Name: "keep", URL: "http://a:8790", NodeID: "n"})
 
-	// Make peers.json unwritable so save() fails during the next Remove.
-	if err := os.Chmod(s.path, 0o400); err != nil {
+	// Make the state dir unwritable so save() can't create its tmp file
+	// during the next Remove (a read-only file wouldn't block the
+	// atomic rename, but a read-only dir blocks the tmp write).
+	if err := os.Chmod(dir, 0o500); err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { os.Chmod(s.path, 0o600) })
+	t.Cleanup(func() { os.Chmod(dir, 0o700) })
 
 	_, ok, err := s.Remove("keep")
 	if err == nil || ok {
@@ -139,6 +141,22 @@ func TestRemoveRollsBackOnSaveFailure(t *testing.T) {
 	}
 	if recs := s.List(); len(recs) != 1 || recs[0].Name != "keep" {
 		t.Fatalf("record must be rolled back in memory, got %+v", recs)
+	}
+}
+
+// A 0-byte peers.json (e.g. left by a non-atomic write in an older
+// build) must not wedge startup: Open treats it as an empty store.
+func TestOpenToleratesEmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, fileName), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	s, err := Open(dir)
+	if err != nil {
+		t.Fatalf("Open on empty file should succeed, got %v", err)
+	}
+	if len(s.List()) != 0 {
+		t.Fatalf("want empty store, got %v", s.List())
 	}
 }
 

--- a/services/gmuxd/internal/peerstore/peerstore_test.go
+++ b/services/gmuxd/internal/peerstore/peerstore_test.go
@@ -119,6 +119,29 @@ func TestSlugify(t *testing.T) {
 	}
 }
 
+// A failed disk write during Remove must roll back the in-memory slice,
+// so the store stays consistent with disk and a later retry can succeed
+// (rather than leaving the peer gone-from-memory but still on disk).
+func TestRemoveRollsBackOnSaveFailure(t *testing.T) {
+	dir := t.TempDir()
+	s, _ := Open(dir)
+	s.AddOrGet(Record{Name: "keep", URL: "http://a:8790", NodeID: "n"})
+
+	// Make peers.json unwritable so save() fails during the next Remove.
+	if err := os.Chmod(s.path, 0o400); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(s.path, 0o600) })
+
+	_, ok, err := s.Remove("keep")
+	if err == nil || ok {
+		t.Fatalf("expected save failure (ok=%v err=%v)", ok, err)
+	}
+	if recs := s.List(); len(recs) != 1 || recs[0].Name != "keep" {
+		t.Fatalf("record must be rolled back in memory, got %+v", recs)
+	}
+}
+
 func TestRemove(t *testing.T) {
 	dir := t.TempDir()
 	s, _ := Open(dir)

--- a/services/gmuxd/internal/store/store.go
+++ b/services/gmuxd/internal/store/store.go
@@ -18,7 +18,7 @@ type Session struct {
 	ID            string            `json:"id"`
 
 	// Peer identifies which gmuxd instance owns this session.
-	// Empty = local. Non-empty = the peer name from [[peers]] config.
+	// Empty = local. Non-empty = the peer name (manual peer in peers.json, or a discovered peer).
 	Peer string `json:"peer,omitempty"`
 	CreatedAt     string            `json:"created_at,omitempty"`
 	Command       []string          `json:"command,omitempty"`

--- a/services/gmuxd/internal/tsauth/tsauth.go
+++ b/services/gmuxd/internal/tsauth/tsauth.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -95,11 +96,16 @@ func (l *Listener) Diag() DiagStatus {
 // Call Shutdown to stop.
 func Start(cfg Config, stateDir string, handler http.Handler) *Listener {
 	tsnetDir := filepath.Join(stateDir, "tsnet")
-	resetStateIfHostnameChanged(tsnetDir, cfg.Hostname)
+	// cfg.Hostname carries the OS hostname seed; the actual tailscale
+	// name is the previously-registered one (sentinel) if any, else
+	// "gmux-<slug>" derived from it. Tailscale owns the identity after
+	// first registration, so we never wipe state on change (ADR 0007).
+	name := loadOrSeedHostname(tsnetDir, seedName(cfg.Hostname))
+	cfg.Hostname = name
 
-	log.Printf("tsauth: starting with hostname %q", cfg.Hostname)
+	log.Printf("tsauth: starting with hostname %q", name)
 	srv := &tsnet.Server{
-		Hostname: cfg.Hostname,
+		Hostname: name,
 		Dir:      tsnetDir,
 	}
 
@@ -281,48 +287,44 @@ func resolveOwnerLogin(lc *tailscale.LocalClient) (string, error) {
 	}
 }
 
-// hostnameFile is a sentinel that records the hostname last used by tsnet.
-// When the configured hostname changes, we must clear the tsnet state so
-// the node re-registers under the new name. Without this, the Tailscale
-// control plane keeps the old device name from the persisted node keys.
+// hostnameFile records the tailscale name this node registered under.
+// It is the durable seed: once written it is never changed by gmuxd, so
+// the node keeps its tailscale identity across restarts and container
+// recreation (ADR 0007 — tailscale owns the name; we never wipe state).
 const hostnameFile = "hostname"
 
-// resetStateIfHostnameChanged removes the tsnet state directory when the
-// configured hostname differs from the last-used hostname. This forces a
-// clean re-registration with the Tailscale control plane.
-func resetStateIfHostnameChanged(tsnetDir, hostname string) {
+// loadOrSeedHostname returns the tailscale name to register under. If a
+// name was recorded on a previous run it is kept verbatim (no rename, no
+// state wipe); otherwise the seed is adopted and recorded.
+func loadOrSeedHostname(tsnetDir, seed string) string {
 	path := filepath.Join(tsnetDir, hostnameFile)
-	prev, err := os.ReadFile(path)
-	if err == nil && strings.TrimSpace(string(prev)) == hostname {
-		return // hostname unchanged
-	}
-
-	dirExists := false
-	if _, serr := os.Stat(tsnetDir); serr == nil {
-		dirExists = true
-	}
-
-	if err != nil && dirExists {
-		// Sentinel missing but directory exists: upgrade from an older
-		// version that didn't write the sentinel. Adopt the current
-		// hostname without nuking state to avoid forcing re-auth.
-		log.Printf("tsauth: writing hostname sentinel for existing state (hostname %q)", hostname)
-	} else if prev != nil {
-		// Sentinel exists with a different hostname: clear everything.
-		log.Printf("tsauth: hostname changed from %q to %q, clearing tsnet state", strings.TrimSpace(string(prev)), hostname)
-		if err := os.RemoveAll(tsnetDir); err != nil {
-			log.Printf("tsauth: WARNING: failed to clear tsnet state dir: %v", err)
+	if prev, err := os.ReadFile(path); err == nil {
+		if name := strings.TrimSpace(string(prev)); name != "" {
+			return name
 		}
 	}
-
-	// (Re-)create the directory and write the sentinel.
 	if err := os.MkdirAll(tsnetDir, 0o700); err != nil {
 		log.Printf("tsauth: WARNING: failed to create tsnet state dir: %v", err)
-		return
+		return seed
 	}
-	if err := os.WriteFile(path, []byte(hostname+"\n"), 0o600); err != nil {
+	if err := os.WriteFile(path, []byte(seed+"\n"), 0o600); err != nil {
 		log.Printf("tsauth: WARNING: failed to write hostname sentinel: %v", err)
 	}
+	return seed
+}
+
+var slugRe = regexp.MustCompile(`[^a-z0-9]+`)
+
+// seedName derives the first-registration tailscale name from the OS
+// hostname: "gmux-<slug>" so the node is both hostname-derived and
+// matches the tailnet discovery prefix ("gmux-*"). Falls back to "gmux"
+// when the hostname has no usable characters.
+func seedName(osHostname string) string {
+	s := strings.Trim(slugRe.ReplaceAllString(strings.ToLower(osHostname), "-"), "-")
+	if s == "" {
+		return "gmux"
+	}
+	return "gmux-" + s
 }
 
 // addIfMissing appends entry to the list if not already present (case-insensitive).

--- a/services/gmuxd/internal/tsauth/tsauth.go
+++ b/services/gmuxd/internal/tsauth/tsauth.go
@@ -316,8 +316,9 @@ func loadOrSeedHostname(tsnetDir, seed string) string {
 var slugRe = regexp.MustCompile(`[^a-z0-9]+`)
 
 // SeedFromHostname derives the first-registration tailscale name from the
-// OS hostname: "gmux-<slug>" so the node is both hostname-derived and
-// matches the tailnet discovery prefix ("gmux-*"). Falls back to "gmux"
+// OS hostname: "gmux-<slug>". The "gmux-" prefix keeps the node in the
+// "gmux-*" family used for the offline-peers hint (online discovery
+// probes every tailnet device regardless of name). Falls back to "gmux"
 // when the hostname has no usable characters. Callers may bypass this
 // with an explicit name (e.g. the GMUXD_TS_HOSTNAME override).
 func SeedFromHostname(osHostname string) string {

--- a/services/gmuxd/internal/tsauth/tsauth.go
+++ b/services/gmuxd/internal/tsauth/tsauth.go
@@ -96,11 +96,11 @@ func (l *Listener) Diag() DiagStatus {
 // Call Shutdown to stop.
 func Start(cfg Config, stateDir string, handler http.Handler) *Listener {
 	tsnetDir := filepath.Join(stateDir, "tsnet")
-	// cfg.Hostname carries the OS hostname seed; the actual tailscale
-	// name is the previously-registered one (sentinel) if any, else
-	// "gmux-<slug>" derived from it. Tailscale owns the identity after
-	// first registration, so we never wipe state on change (ADR 0007).
-	name := loadOrSeedHostname(tsnetDir, seedName(cfg.Hostname))
+	// cfg.Hostname is the requested name for *first* registration. The
+	// actual name is the previously-registered one (sentinel) if any.
+	// Tailscale owns the identity after first registration, so we never
+	// wipe state on change (ADR 0007).
+	name := loadOrSeedHostname(tsnetDir, cfg.Hostname)
 	cfg.Hostname = name
 
 	log.Printf("tsauth: starting with hostname %q", name)
@@ -315,11 +315,12 @@ func loadOrSeedHostname(tsnetDir, seed string) string {
 
 var slugRe = regexp.MustCompile(`[^a-z0-9]+`)
 
-// seedName derives the first-registration tailscale name from the OS
-// hostname: "gmux-<slug>" so the node is both hostname-derived and
+// SeedFromHostname derives the first-registration tailscale name from the
+// OS hostname: "gmux-<slug>" so the node is both hostname-derived and
 // matches the tailnet discovery prefix ("gmux-*"). Falls back to "gmux"
-// when the hostname has no usable characters.
-func seedName(osHostname string) string {
+// when the hostname has no usable characters. Callers may bypass this
+// with an explicit name (e.g. the GMUXD_TS_HOSTNAME override).
+func SeedFromHostname(osHostname string) string {
 	s := strings.Trim(slugRe.ReplaceAllString(strings.ToLower(osHostname), "-"), "-")
 	if s == "" {
 		return "gmux"

--- a/services/gmuxd/internal/tsauth/tsauth_test.go
+++ b/services/gmuxd/internal/tsauth/tsauth_test.go
@@ -86,7 +86,7 @@ func TestLoadOrSeedHostname_KeepsExistingNeverWipes(t *testing.T) {
 	}
 }
 
-func TestSeedName(t *testing.T) {
+func TestSeedFromHostname(t *testing.T) {
 	tests := []struct{ in, want string }{
 		{"Aquilo", "gmux-aquilo"},
 		{"my.box", "gmux-my-box"},
@@ -95,8 +95,8 @@ func TestSeedName(t *testing.T) {
 		{"---", "gmux"},
 	}
 	for _, tt := range tests {
-		if got := seedName(tt.in); got != tt.want {
-			t.Errorf("seedName(%q) = %q, want %q", tt.in, got, tt.want)
+		if got := SeedFromHostname(tt.in); got != tt.want {
+			t.Errorf("SeedFromHostname(%q) = %q, want %q", tt.in, got, tt.want)
 		}
 	}
 }

--- a/services/gmuxd/internal/tsauth/tsauth_test.go
+++ b/services/gmuxd/internal/tsauth/tsauth_test.go
@@ -42,55 +42,32 @@ func TestIsAllowedEmptyList(t *testing.T) {
 	}
 }
 
-func TestResetStateIfHostnameChanged(t *testing.T) {
+func TestLoadOrSeedHostname_SeedsWhenAbsent(t *testing.T) {
 	dir := t.TempDir()
 	tsnetDir := filepath.Join(dir, "tsnet")
 
-	// First call: no existing state, creates sentinel.
-	resetStateIfHostnameChanged(tsnetDir, "gmux")
+	name := loadOrSeedHostname(tsnetDir, "gmux-aquilo")
+	if name != "gmux-aquilo" {
+		t.Errorf("name = %q, want %q", name, "gmux-aquilo")
+	}
 	got, err := os.ReadFile(filepath.Join(tsnetDir, hostnameFile))
 	if err != nil {
 		t.Fatalf("sentinel not created: %v", err)
 	}
-	if string(got) != "gmux\n" {
-		t.Errorf("sentinel = %q, want %q", got, "gmux\n")
-	}
-
-	// Simulate tsnet creating a state file.
-	statePath := filepath.Join(tsnetDir, "tailscaled.state")
-	if err := os.WriteFile(statePath, []byte("fake-state"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	// Same hostname: state preserved.
-	resetStateIfHostnameChanged(tsnetDir, "gmux")
-	if _, err := os.Stat(statePath); err != nil {
-		t.Errorf("state file should still exist after same-hostname call: %v", err)
-	}
-
-	// Different hostname: state directory wiped and re-created.
-	resetStateIfHostnameChanged(tsnetDir, "gmux-hs")
-	if _, err := os.Stat(statePath); !os.IsNotExist(err) {
-		t.Errorf("state file should be gone after hostname change, got err=%v", err)
-	}
-	got, err = os.ReadFile(filepath.Join(tsnetDir, hostnameFile))
-	if err != nil {
-		t.Fatalf("sentinel not re-created: %v", err)
-	}
-	if string(got) != "gmux-hs\n" {
-		t.Errorf("sentinel = %q, want %q", got, "gmux-hs\n")
+	if string(got) != "gmux-aquilo\n" {
+		t.Errorf("sentinel = %q, want %q", got, "gmux-aquilo\n")
 	}
 }
 
-// Upgrade scenario: existing tsnet state from a version that didn't write
-// the sentinel file. The state must be preserved (not nuked), and the
-// sentinel must be written for future runs.
-func TestResetStateIfHostnameChanged_UpgradePreservesState(t *testing.T) {
+// The recorded name is kept verbatim and tsnet state is never wiped, even
+// when the seed differs — tailscale owns the identity (ADR 0007).
+func TestLoadOrSeedHostname_KeepsExistingNeverWipes(t *testing.T) {
 	dir := t.TempDir()
 	tsnetDir := filepath.Join(dir, "tsnet")
-
-	// Simulate pre-existing tsnet state with no sentinel.
 	if err := os.MkdirAll(tsnetDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tsnetDir, hostnameFile), []byte("project-a\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	statePath := filepath.Join(tsnetDir, "tailscaled.state")
@@ -98,24 +75,29 @@ func TestResetStateIfHostnameChanged_UpgradePreservesState(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	resetStateIfHostnameChanged(tsnetDir, "gmux")
-
-	// State file must survive.
+	// A different seed must NOT rename or wipe.
+	name := loadOrSeedHostname(tsnetDir, "gmux-aquilo")
+	if name != "project-a" {
+		t.Errorf("name = %q, want kept %q", name, "project-a")
+	}
 	data, err := os.ReadFile(statePath)
-	if err != nil {
-		t.Fatalf("state file was deleted during upgrade: %v", err)
+	if err != nil || string(data) != "existing-keys" {
+		t.Fatalf("state file must survive untouched, got %q err=%v", data, err)
 	}
-	if string(data) != "existing-keys" {
-		t.Errorf("state file content changed: %q", data)
-	}
+}
 
-	// Sentinel must now exist.
-	got, err := os.ReadFile(filepath.Join(tsnetDir, hostnameFile))
-	if err != nil {
-		t.Fatalf("sentinel not written: %v", err)
+func TestSeedName(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{"Aquilo", "gmux-aquilo"},
+		{"my.box", "gmux-my-box"},
+		{"ca75413aec31", "gmux-ca75413aec31"},
+		{"", "gmux"},
+		{"---", "gmux"},
 	}
-	if string(got) != "gmux\n" {
-		t.Errorf("sentinel = %q, want %q", got, "gmux\n")
+	for _, tt := range tests {
+		if got := seedName(tt.in); got != tt.want {
+			t.Errorf("seedName(%q) = %q, want %q", tt.in, got, tt.want)
+		}
 	}
 }
 

--- a/services/gmuxd/internal/tsdiscovery/tsdiscovery.go
+++ b/services/gmuxd/internal/tsdiscovery/tsdiscovery.go
@@ -138,8 +138,9 @@ func (w *Watcher) Start() {
 	for _, d := range w.state.Devices {
 		if d.IsGmux && d.PeerName != "" && !w.isManualPeer(d.FQDN) {
 			w.cfg.Manager.AddPeer(config.PeerConfig{
-				Name: d.PeerName,
-				URL:  "https://" + d.FQDN,
+				Name:   d.PeerName,
+				URL:    "https://" + d.FQDN,
+				Source: config.SourceTailscale,
 			}, peering.WithTransport(w.cfg.Transport))
 		}
 	}
@@ -353,8 +354,9 @@ func (w *Watcher) handleOnlinePeer(ctx context.Context, nodeID string, cs peerSn
 		} else {
 			log.Printf("tsdiscovery: discovered %s at %s", peerName, cs.fqdn)
 			w.cfg.Manager.AddPeer(config.PeerConfig{
-				Name: peerName,
-				URL:  "https://" + cs.fqdn,
+				Name:   peerName,
+				URL:    "https://" + cs.fqdn,
+				Source: config.SourceTailscale,
 			}, peering.WithTransport(w.cfg.Transport))
 		}
 	}

--- a/services/gmuxd/internal/tsdiscovery/tsdiscovery.go
+++ b/services/gmuxd/internal/tsdiscovery/tsdiscovery.go
@@ -132,7 +132,7 @@ func (w *Watcher) SetTailscale(lc *tailscale.LocalClient, transport http.RoundTr
 // is not started.
 func (w *Watcher) Start() {
 	// Re-register known gmux peers immediately (without re-probing).
-	// Skip any that are now manually configured (user added a [[peers]]
+	// Skip any that are now manually configured (user added a manual peer in peers.json
 	// entry after the initial discovery).
 	w.mu.Lock()
 	for _, d := range w.state.Devices {


### PR DESCRIPTION
Implements ADR 0007 end-to-end: one stable, transport-independent host identity; manual peers as runtime state; a Connect-to-host UI. **Breaking** — squash-merges as a single breaking-change commit.

10 atomic commits:

1. **`node_id` + ADR doc** (§4) — opaque per-node id (`node_<hex>`, `crypto/rand`, persisted next to `auth-token`), in `/v1/health`, never shown/routed.
2. **identity resolution** (§1–2) — `/v1/health` `hostname` = live tailscale name (first FQDN label) else `os.Hostname()`. Fixes the original `@ca75413aec31` bug (a tailscale container reported its container-ID OS hostname; now reports its tailscale name).
3. **devcontainer label gate** (§3) — discovery requires `devcontainer.local_folder`; the container-ID name fallback can no longer fire.
4. **tailscale name seed** (§2, breaking) — remove `tailscale.hostname`; seed `gmux-<slug(os.Hostname())>` on first registration; **never wipe tsnet state on change** (tailscale owns the name; existing nodes keep their registered name via the sentinel).
5. **peers as state** (§5, breaking) — remove `[[peers]]`; manual peers live in `peers.json` (`0600`) via a new `peerstore`, loaded at startup.
6. **add/remove API + dedup** (§5,§7) — `POST /v1/peers` probes the target's `/v1/health`, dedups by `node_id` against persisted peers, suffixes name collisions (`name-2`), connects + persists; `DELETE /v1/peers/{name}`.
7. **Connect to host UI** (§6) — Settings → Hosts gains a connect form (URL + optional token) and per-row disconnect.
8. **docs** — host.toml reference, multi-machine, remote-access, running-in-docker, docker example.
9. **review pass** — `GMUXD_TS_HOSTNAME` env override for the first-registration name (so multiple daemons on one machine, incl. dev-server and grove worktrees, get distinct tailscale names without a config key); fixes `scripts/dev-server.sh` (was writing the now-rejected `hostname` key); `probePeerHealth` tests; stale-comment cleanups.

§6/§8 routing (short-name `@name`, no method prefix/FQDN, unknown → home) needed **no change** — already conformant.

## Breaking changes
- `tailscale.hostname` and `[[peers]]` are **rejected at startup** with migration hints. Migrate `[[peers]]` → *Connect to host* (peers.json) and drop `hostname`.
- The first-registration tailscale name now comes from the OS hostname (or `GMUXD_TS_HOSTNAME`); existing registered nodes keep their name (sentinel preserved, state never wiped).
- `/v1/health` `hostname` meaning changes (unified identity) and gains `node_id`.
- Old `@<name>` URLs embedding an OS/container-ID name fall back to home.

## Verification (here)
- `go build`/`go vet`/`go test ./...` (27 pkgs) pass — new `nodeid`, `identity`, `peerstore`, and `probePeerHealth` tests; `tsc` clean; 426 web tests.
- **Live (installed):** `/v1/health` reports tailscale name `gmux` + stable `node_id`; sentinel keeps the existing name (no rename); migrated my 3 real peers into `peers.json` — `dev` and `hs` (same tailnet) **connect via the default transport**; `POST /v1/peers` self-probe returns the record, **re-POST returns `already_connected` (node_id dedup verified)**, `DELETE` works; Connect-to-host UI verified in the mock dev server.

## Needs your real-host validation (can't exercise here)
- Cross-host tailscale-name discovery between two upgraded hosts.
- The tailscale rename/no-wipe behavior across the upgrade on a node whose name actually changes (mine stayed `gmux`, so no rename was exercised).

## Known limitations (honest scope)
- **Dedup is by `node_id` against *persisted* (manual) peers** — re-adding a manual peer is deduped. A host that's already *auto-discovered* (not in peers.json) and then added manually becomes a manual peer; the existing `isManualPeer` FQDN-skip stops discovery from double-adding it (no duplicate connection), but this isn't node_id-based. A rare edge — two *different* hosts reporting the same name, one auto-discovered — isn't collision-resolved against the live manager. Follow-up: track peer node_ids in the manager for full cross-source dedup.
- ~~The disconnect (×) shows on all non-local peers~~ **Resolved** (commit 12): the `source` field now lets the Hosts tab show × only on manually-added peers.

Your `host.toml` was migrated locally (`[[peers]]` → `peers.json`, `hostname` dropped) with a `.pre-adr7.bak` backup. Supersedes #262–#264.

10. **Greptile review fixes** — atomic `peerstore.AddOrGet` (node_id dedup + append under one lock, fixing a TOCTOU in the connect handler); the probed name is slugified before use (a host reporting `My-Laptop.local` is accepted as `my-laptop-local` rather than rejected); `peerManager` nil guards on the new handlers. New peerstore tests cover dedup/slugify/collision.

11. **Folds in #259** — replaces the colored `PeerLabel` chips in Settings with the muted " · hostname" suffix (configured/discovered/reference rows and the Hosts roster).
12. **Group hosts by source** — adds a `source` field to `PeerConfig`/`PeerInfo` (`tailscale` / `devcontainer` / `manual`), set at every add-site (peerstore, tailscale discovery incl. offline list, devcontainer watcher, `POST /v1/peers`). The Settings → Hosts tab now renders **This host**, then **Discovered on your tailnet**, **Devcontainers**, and **Added manually** sections. The disconnect (×) now appears **only on manual peers** (resolving the earlier limitation where it showed on auto-discovered peers that can't be removed). `TestPeerStatus_CarriesSource` covers the plumbing.