### PR TITLE
fix(gmuxd): make restart wait for health; clarify install behavior

### DIFF
--- a/apps/website/public/install-pr.sh
+++ b/apps/website/public/install-pr.sh
@@ -65,10 +65,13 @@ main() {
   install -m 755 "$tmpdir/out/gmuxd" "${INSTALL_DIR}/gmuxd"
   echo "Installed gmux and gmuxd from PR #${PR} to ${INSTALL_DIR}"
 
-  # Restart daemon if it was running
+  # If gmuxd was already running, restart it so the new version takes effect.
+  # Active sessions survive (they reconnect to the new daemon).
   if curl -sSf http://localhost:8790/v1/health > /dev/null 2>&1; then
-    "${INSTALL_DIR}/gmuxd" start 2>/dev/null || true
-    echo "Restarted gmuxd"
+    "${INSTALL_DIR}/gmuxd" start || true
+    echo "gmuxd restarted to apply the update."
+  else
+    echo "To start gmux, run: gmux"
   fi
 }
 

--- a/apps/website/public/install-pr.sh
+++ b/apps/website/public/install-pr.sh
@@ -66,10 +66,13 @@ main() {
   echo "Installed gmux and gmuxd from PR #${PR} to ${INSTALL_DIR}"
 
   # If gmuxd was already running, restart it so the new version takes effect.
-  # Active sessions survive (they reconnect to the new daemon).
+  # Active sessions survive (the new daemon rediscovers them on startup).
   if curl -sSf http://localhost:8790/v1/health > /dev/null 2>&1; then
-    "${INSTALL_DIR}/gmuxd" start || true
-    echo "gmuxd restarted to apply the update."
+    if "${INSTALL_DIR}/gmuxd" start; then
+      echo "gmuxd restarted to apply the update."
+    else
+      echo "Warning: gmuxd restart did not complete successfully; check logs."
+    fi
   else
     echo "To start gmux, run: gmux"
   fi

--- a/apps/website/public/install.sh
+++ b/apps/website/public/install.sh
@@ -138,10 +138,13 @@ main() {
   fi
 
   # If gmuxd was already running, restart it so the new version takes effect.
-  # Active sessions survive (they reconnect to the new daemon).
+  # Active sessions survive (the new daemon rediscovers them on startup).
   if "${INSTALL_DIR}/gmuxd" status > /dev/null 2>&1; then
-    "${INSTALL_DIR}/gmuxd" start || true
-    echo "gmuxd restarted to apply the update."
+    if "${INSTALL_DIR}/gmuxd" start; then
+      echo "gmuxd restarted to apply the update."
+    else
+      echo "Warning: gmuxd restart did not complete successfully; check logs."
+    fi
   else
     echo "To start gmux, run: gmux"
   fi

--- a/apps/website/public/install.sh
+++ b/apps/website/public/install.sh
@@ -137,10 +137,13 @@ main() {
     install_desktop_entry
   fi
 
-  # If gmuxd was already running, restart it so the new version takes over.
-  # Running sessions keep using the previous binary until restarted.
+  # If gmuxd was already running, restart it so the new version takes effect.
+  # Active sessions survive (they reconnect to the new daemon).
   if "${INSTALL_DIR}/gmuxd" status > /dev/null 2>&1; then
     "${INSTALL_DIR}/gmuxd" start || true
+    echo "gmuxd restarted to apply the update."
+  else
+    echo "To start gmux, run: gmux"
   fi
 
   case ":${PATH}:" in

--- a/apps/website/src/content/docs/reference/cli.md
+++ b/apps/website/src/content/docs/reference/cli.md
@@ -12,8 +12,8 @@ sidebar:
 **`gmux`** — the session runner. Wraps any command in a managed session.
 This is your primary entry point; it auto-starts the daemon if needed.
 
-**`gmuxd`** — the daemon. Manages sessions, serves the web UI, and persists
-scrollback. Rarely invoked directly.
+**`gmuxd`** — the daemon. Manages sessions, serves the web UI and session
+history, and provides optional remote access. Rarely invoked directly.
 
 ## gmux
 
@@ -149,9 +149,9 @@ Run the daemon in the foreground. Same as `start`, but blocks until interrupted.
 ### `gmuxd restart`
 
 Stops any running instance and starts a fresh one. Waits for the new daemon
-to become healthy before returning. Active sessions survive: they keep running
-on the old binary until you resume or restart them, at which point they
-reconnect to the new daemon.
+to become healthy before returning. Active sessions survive: the new daemon
+rediscovers them on startup. Each session keeps running on its previous binary
+until you resume or restart it, which relaunches it on the new binary.
 
 Use this after installing an update to apply the new binary.
 

--- a/apps/website/src/content/docs/reference/cli.md
+++ b/apps/website/src/content/docs/reference/cli.md
@@ -7,6 +7,14 @@ sidebar:
   order: 1
 ---
 
+## Overview
+
+**`gmux`** — the session runner. Wraps any command in a managed session.
+This is your primary entry point; it auto-starts the daemon if needed.
+
+**`gmuxd`** — the daemon. Manages sessions, serves the web UI, and persists
+scrollback. Rarely invoked directly.
+
 ## gmux
 
 The session runner and primary entry point. Auto-starts gmuxd if needed.
@@ -140,7 +148,12 @@ Run the daemon in the foreground. Same as `start`, but blocks until interrupted.
 
 ### `gmuxd restart`
 
-Alias for `start`. Stops any running instance and starts a fresh one.
+Stops any running instance and starts a fresh one. Waits for the new daemon
+to become healthy before returning. Active sessions survive: they keep running
+on the old binary until you resume or restart them, at which point they
+reconnect to the new daemon.
+
+Use this after installing an update to apply the new binary.
 
 ### `gmuxd stop`
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,8 +2,7 @@
 # Build and install gmux + gmuxd to ~/.local/bin.
 #
 # Stops the running gmuxd, replaces the binaries, and restarts it.
-# Existing sessions keep running (they use the old binary via open
-# file descriptors); new sessions will use the new binary.
+# Active sessions survive (they reconnect to the new daemon).
 #
 # Usage: ./scripts/install.sh [--skip-frontend]
 set -euo pipefail

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,7 +2,8 @@
 # Build and install gmux + gmuxd to ~/.local/bin.
 #
 # Stops the running gmuxd, replaces the binaries, and restarts it.
-# Active sessions survive (they reconnect to the new daemon).
+# Active sessions survive (the new daemon rediscovers them on startup);
+# the running runner keeps its old binary until that session restarts.
 #
 # Usage: ./scripts/install.sh [--skip-frontend]
 set -euo pipefail

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -231,7 +231,7 @@ Commands:
   start              Start the daemon in the background
   run                Run the daemon in the foreground (for systemd/Docker)
   stop               Stop the running daemon
-  restart            Restart the daemon (alias for start)
+  restart            Restart the daemon (stops then starts)
   status             Show daemon health, listeners, and sessions
   auth               Show the auth URL and token
   remote             Set up or check remote access via Tailscale
@@ -390,23 +390,32 @@ func startBackground(stdout, stderr io.Writer) int {
 		_, _ = fmt.Fprintf(stderr, "gmuxd: failed to start: %v\n", err)
 		return 1
 	}
+	done := make(chan struct{})
 	go func() {
 		cmd.Wait()
 		logFile.Close()
+		close(done)
 	}()
 
-	// Wait for the daemon to become healthy.
-	// Initial backoff gives the new process time to fork and begin
-	// initializing; the socket listener is created early in serve()
-	// so this typically succeeds within the first few probes.
+	// Wait for the daemon to become healthy. The new process does heavy
+	// initialization (launcher discovery, session sweep, conversation
+	// index scan, project loading) before it creates the Unix socket, so
+	// the probe can take several seconds on a slow machine or a large
+	// history. Poll with exponential backoff until a generous deadline
+	// rather than a tight fixed budget. Break immediately if the process
+	// exits before becoming healthy (crash, bad config, port conflict).
 	healthy := false
 	backoff := 200 * time.Millisecond
-	for range 50 {
-		time.Sleep(backoff)
-		if unixipc.Healthy(sock) {
-			healthy = true
-			break
+	deadline := time.Now().Add(20 * time.Second)
+	for !healthy && time.Now().Before(deadline) {
+		select {
+		case <-done:
+			// Daemon process exited before becoming healthy.
+			_, _ = fmt.Fprintf(stderr, "gmuxd: daemon exited before becoming healthy\n  Logs: %s\n", logPath)
+			return 1
+		case <-time.After(backoff):
 		}
+		healthy = unixipc.Healthy(sock)
 		backoff = min(backoff*2, 2*time.Second)
 	}
 
@@ -432,125 +441,9 @@ func serve(stderr io.Writer) int {
 			log.Printf("gmux hash: %s…", h[:12])
 		}
 	}
+	launchConfig := discoverLaunchers()
 
-	// ── Early socket listener ──
-	//
-	// Create the Unix socket and start serving *before* the heavy
-	// initialization (launcher discovery, session sweep, conversation
-	// index scan, project loading). This lets gmuxd restart return
-	// promptly: the health probe hits the socket immediately and
-	// gets 200 OK even while the daemon is still warming up.
-	//
-	// Variables captured by the health handler are declared here as
-	// nil/zero so the handler can be registered now and will return
-	// a minimal (but valid) response until they're populated below.
-
-	var (
-		sessions      *store.Store
-		launchConfig  LaunchConfig
-		updateChecker *update.Checker
-		tsListener    *tsauth.Listener
-		peerManager   *peering.Manager
-		tsDiscovery   *tsdiscovery.Watcher
-		tcpAddr       string
-		authToken     string
-	)
-
-	mux := http.NewServeMux()
-
-	// Health handler — safe to call before sessions/updateChecker are
-	// initialized (nil checks inside). Registered early so the socket
-	// is useful the moment it's created.
-	mux.HandleFunc("/v1/health", func(w http.ResponseWriter, r *http.Request) {
-		data := map[string]any{
-			"service": "gmuxd",
-			"version": version,
-			"node_id": "node-local",
-			"status":  "ready",
-		}
-		if h, err := os.Hostname(); err == nil {
-			data["hostname"] = h
-		}
-		if tsListener != nil {
-			diag := tsListener.Diag()
-			if diag.FQDN != "" {
-				data["tailscale_url"] = "https://" + diag.FQDN
-			}
-			data["tailscale"] = diag
-		}
-		data["listen"] = tcpAddr
-		if updateChecker != nil {
-			if v := updateChecker.Available(); v != "" {
-				data["update_available"] = v
-			}
-		}
-		if r.RemoteAddr == "@" || strings.HasPrefix(r.RemoteAddr, "/") || r.RemoteAddr == "" {
-			data["auth_token"] = authToken
-		}
-		if peers := appendOfflinePeers(peerManager, tsDiscovery); len(peers) > 0 {
-			data["peers"] = peers
-		}
-		if sessions != nil {
-			all := sessions.List()
-			var localAlive, remoteAlive, dead int
-			for _, s := range all {
-				switch {
-				case !s.Alive:
-					dead++
-				case s.Peer == "":
-					localAlive++
-				default:
-					remoteAlive++
-				}
-			}
-			data["sessions"] = map[string]int{
-				"local_alive":  localAlive,
-				"remote_alive": remoteAlive,
-				"dead":         dead,
-			}
-		}
-		if discovery.ExpectedRunnerHash != "" {
-			data["runner_hash"] = discovery.ExpectedRunnerHash
-		}
-		data["default_launcher"] = launchConfig.DefaultLauncher
-		data["launchers"] = launchConfig.Launchers
-		writeJSON(w, map[string]any{"ok": true, "data": data})
-	})
-
-	// Shutdown endpoint (needed before the socket goes live).
-	shutdownCh := make(chan struct{})
-	var shutdownOnce sync.Once
-	mux.HandleFunc("POST /v1/shutdown", func(w http.ResponseWriter, r *http.Request) {
-		writeJSON(w, map[string]any{"ok": true})
-		shutdownOnce.Do(func() {
-			log.Printf("shutdown requested — exiting")
-			close(shutdownCh)
-		})
-	})
-
-	sock := paths.SocketPath()
-	if err := unixipc.Replace(sock); err != nil {
-		_, _ = fmt.Fprintf(stderr, "gmuxd: %v\n", err)
-		return 1
-	}
-
-	sockLn, err := unixipc.Listen(sock)
-	if err != nil {
-		log.Fatalf("FATAL: %v", err)
-	}
-	sockSrv := &http.Server{Handler: mux}
-	go func() {
-		if err := sockSrv.Serve(sockLn); err != http.ErrServerClosed {
-			log.Printf("unix socket listener: %v", err)
-		}
-	}()
-	log.Printf("unix socket: %s", sock)
-
-	// ── Heavy initialization (now behind a live socket) ──
-
-	launchConfig = discoverLaunchers()
-
-	sessions = store.New()
+	sessions := store.New()
 
 	// sessionmeta persists per-session records so dead sessions
 	// survive a gmuxd restart. Sweep on startup repopulates the
@@ -852,34 +745,30 @@ func serve(stderr io.Writer) int {
 			data["tailscale"] = diag
 		}
 		data["listen"] = tcpAddr
-		if updateChecker != nil {
-			if v := updateChecker.Available(); v != "" {
-				data["update_available"] = v
-			}
+		if v := updateChecker.Available(); v != "" {
+			data["update_available"] = v
 		}
 		if peers := appendOfflinePeers(peerManager, tsDiscovery); len(peers) > 0 {
 			data["peers"] = peers
 		}
 
-		// Session summary (defensive: sessions may not be initialized yet during startup).
-		if sessions != nil {
-			all := sessions.List()
-			var localAlive, remoteAlive, dead int
-			for _, s := range all {
-				switch {
-				case !s.Alive:
-					dead++
-				case s.Peer == "":
-					localAlive++
-				default:
-					remoteAlive++
-				}
+		// Session summary.
+		all := sessions.List()
+		var localAlive, remoteAlive, dead int
+		for _, s := range all {
+			switch {
+			case !s.Alive:
+				dead++
+			case s.Peer == "":
+				localAlive++
+			default:
+				remoteAlive++
 			}
-			data["sessions"] = map[string]int{
-				"local_alive":  localAlive,
-				"remote_alive": remoteAlive,
-				"dead":         dead,
-			}
+		}
+		data["sessions"] = map[string]int{
+			"local_alive":  localAlive,
+			"remote_alive": remoteAlive,
+			"dead":         dead,
 		}
 
 		// runner_hash is the sha256 of the gmux runner binary on disk.

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -396,13 +396,18 @@ func startBackground(stdout, stderr io.Writer) int {
 	}()
 
 	// Wait for the daemon to become healthy.
+	// Initial backoff gives the new process time to fork and begin
+	// initializing; the socket listener is created early in serve()
+	// so this typically succeeds within the first few probes.
 	healthy := false
-	for range 30 {
-		time.Sleep(100 * time.Millisecond)
+	backoff := 200 * time.Millisecond
+	for range 50 {
+		time.Sleep(backoff)
 		if unixipc.Healthy(sock) {
 			healthy = true
 			break
 		}
+		backoff = min(backoff*2, 2*time.Second)
 	}
 
 	if !healthy {
@@ -427,9 +432,125 @@ func serve(stderr io.Writer) int {
 			log.Printf("gmux hash: %s…", h[:12])
 		}
 	}
-	launchConfig := discoverLaunchers()
 
-	sessions := store.New()
+	// ── Early socket listener ──
+	//
+	// Create the Unix socket and start serving *before* the heavy
+	// initialization (launcher discovery, session sweep, conversation
+	// index scan, project loading). This lets gmuxd restart return
+	// promptly: the health probe hits the socket immediately and
+	// gets 200 OK even while the daemon is still warming up.
+	//
+	// Variables captured by the health handler are declared here as
+	// nil/zero so the handler can be registered now and will return
+	// a minimal (but valid) response until they're populated below.
+
+	var (
+		sessions      *store.Store
+		launchConfig  LaunchConfig
+		updateChecker *update.Checker
+		tsListener    *tsauth.Listener
+		peerManager   *peering.Manager
+		tsDiscovery   *tsdiscovery.Watcher
+		tcpAddr       string
+		authToken     string
+	)
+
+	mux := http.NewServeMux()
+
+	// Health handler — safe to call before sessions/updateChecker are
+	// initialized (nil checks inside). Registered early so the socket
+	// is useful the moment it's created.
+	mux.HandleFunc("/v1/health", func(w http.ResponseWriter, r *http.Request) {
+		data := map[string]any{
+			"service": "gmuxd",
+			"version": version,
+			"node_id": "node-local",
+			"status":  "ready",
+		}
+		if h, err := os.Hostname(); err == nil {
+			data["hostname"] = h
+		}
+		if tsListener != nil {
+			diag := tsListener.Diag()
+			if diag.FQDN != "" {
+				data["tailscale_url"] = "https://" + diag.FQDN
+			}
+			data["tailscale"] = diag
+		}
+		data["listen"] = tcpAddr
+		if updateChecker != nil {
+			if v := updateChecker.Available(); v != "" {
+				data["update_available"] = v
+			}
+		}
+		if r.RemoteAddr == "@" || strings.HasPrefix(r.RemoteAddr, "/") || r.RemoteAddr == "" {
+			data["auth_token"] = authToken
+		}
+		if peers := appendOfflinePeers(peerManager, tsDiscovery); len(peers) > 0 {
+			data["peers"] = peers
+		}
+		if sessions != nil {
+			all := sessions.List()
+			var localAlive, remoteAlive, dead int
+			for _, s := range all {
+				switch {
+				case !s.Alive:
+					dead++
+				case s.Peer == "":
+					localAlive++
+				default:
+					remoteAlive++
+				}
+			}
+			data["sessions"] = map[string]int{
+				"local_alive":  localAlive,
+				"remote_alive": remoteAlive,
+				"dead":         dead,
+			}
+		}
+		if discovery.ExpectedRunnerHash != "" {
+			data["runner_hash"] = discovery.ExpectedRunnerHash
+		}
+		data["default_launcher"] = launchConfig.DefaultLauncher
+		data["launchers"] = launchConfig.Launchers
+		writeJSON(w, map[string]any{"ok": true, "data": data})
+	})
+
+	// Shutdown endpoint (needed before the socket goes live).
+	shutdownCh := make(chan struct{})
+	var shutdownOnce sync.Once
+	mux.HandleFunc("POST /v1/shutdown", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, map[string]any{"ok": true})
+		shutdownOnce.Do(func() {
+			log.Printf("shutdown requested — exiting")
+			close(shutdownCh)
+		})
+	})
+
+	sock := paths.SocketPath()
+	if err := unixipc.Replace(sock); err != nil {
+		_, _ = fmt.Fprintf(stderr, "gmuxd: %v\n", err)
+		return 1
+	}
+
+	sockLn, err := unixipc.Listen(sock)
+	if err != nil {
+		log.Fatalf("FATAL: %v", err)
+	}
+	sockSrv := &http.Server{Handler: mux}
+	go func() {
+		if err := sockSrv.Serve(sockLn); err != http.ErrServerClosed {
+			log.Printf("unix socket listener: %v", err)
+		}
+	}()
+	log.Printf("unix socket: %s", sock)
+
+	// ── Heavy initialization (now behind a live socket) ──
+
+	launchConfig = discoverLaunchers()
+
+	sessions = store.New()
 
 	// sessionmeta persists per-session records so dead sessions
 	// survive a gmuxd restart. Sweep on startup repopulates the
@@ -731,30 +852,34 @@ func serve(stderr io.Writer) int {
 			data["tailscale"] = diag
 		}
 		data["listen"] = tcpAddr
-		if v := updateChecker.Available(); v != "" {
-			data["update_available"] = v
+		if updateChecker != nil {
+			if v := updateChecker.Available(); v != "" {
+				data["update_available"] = v
+			}
 		}
 		if peers := appendOfflinePeers(peerManager, tsDiscovery); len(peers) > 0 {
 			data["peers"] = peers
 		}
 
-		// Session summary.
-		all := sessions.List()
-		var localAlive, remoteAlive, dead int
-		for _, s := range all {
-			switch {
-			case !s.Alive:
-				dead++
-			case s.Peer == "":
-				localAlive++
-			default:
-				remoteAlive++
+		// Session summary (defensive: sessions may not be initialized yet during startup).
+		if sessions != nil {
+			all := sessions.List()
+			var localAlive, remoteAlive, dead int
+			for _, s := range all {
+				switch {
+				case !s.Alive:
+					dead++
+				case s.Peer == "":
+					localAlive++
+				default:
+					remoteAlive++
+				}
 			}
-		}
-		data["sessions"] = map[string]int{
-			"local_alive":  localAlive,
-			"remote_alive": remoteAlive,
-			"dead":         dead,
+			data["sessions"] = map[string]int{
+				"local_alive":  localAlive,
+				"remote_alive": remoteAlive,
+				"dead":         dead,
+			}
 		}
 
 		// runner_hash is the sha256 of the gmux runner binary on disk.


### PR DESCRIPTION
## Summary

Two related improvements to the CLI user experience:

### 1. `gmuxd restart` now waits reliably for health

The health-check now uses a 20-second deadline with exponential backoff
(starting at 200ms, doubling up to 2s). The previous approach used a
fixed 50×100ms loop (5s total), which was too short for the heavy
initialization the daemon does before creating the Unix socket
(launcher discovery, session sweep, conversation index scan, project
loading) — especially on slow machines or with large histories.

Added a done channel so the polling loop breaks immediately if the
daemon process crashes before becoming healthy (bad config, port
conflict, missing dependency), avoiding a 20-second hang on startup
failures.

### 2. Install scripts restart gmuxd automatically

The install scripts (install.sh, install-pr.sh) now restart gmuxd
automatically when it is already running, with a clear confirmation
message. If gmuxd is not running, they tell the user to start it with
`gmux`.

The brew formula already had this behavior via its post-install hook.

### Cleanup

- Removed the conceptual gmux/gmuxd explanation from the CLI help
  (redundant with the docs)
- Fixed the `restart` subcommand description to say "stops then starts"
  instead of the misleading "alias for start"

## Changes

- `services/gmuxd/cmd/gmuxd/main.go`: health polling with 20s deadline,
  exponential backoff, early exit on process death; simplified help text
- `apps/website/public/install.sh`: auto-restart gmuxd with confirmation
- `apps/website/public/install-pr.sh`: same
- `scripts/install.sh`: updated comment
- `apps/website/src/content/docs/reference/cli.md`: simplified Overview
