### PR TITLE
fix(gmuxd): warn instead of fail on removed ADR 0007 config keys

### DIFF
--- a/apps/website/src/content/docs/reference/host-toml.md
+++ b/apps/website/src/content/docs/reference/host-toml.md
@@ -69,9 +69,9 @@ The config file is strictly validated at startup. gmuxd refuses to start if:
 - **`port` is out of range** (must be 1–65535)
 - **TOML syntax is invalid**
 
-Two keys were **removed** and are now rejected with a migration hint (ADR 0007):
+This is intentional. Silent fallback to defaults is dangerous for security settings. See [Security](/security) for the reasoning.
+
+Two keys were **removed** in ADR 0007 and are now **ignored with a deprecation warning** (rather than failing startup), so upgrading a host that still has an old config doesn't brick the daemon. Remove them to silence the warning:
 
 - **`tailscale.hostname`** — the node name now comes from Tailscale / the OS hostname.
 - **`[[peers]]`** — manual peers are runtime state; add them via *Connect to host* (stored in `peers.json`).
-
-This is intentional. Silent fallback to defaults is dangerous for security settings. See [Security](/security) for the reasoning.

--- a/services/gmuxd/internal/config/config.go
+++ b/services/gmuxd/internal/config/config.go
@@ -9,6 +9,7 @@ package config
 
 import (
 	"fmt"
+	"log"
 	"net"
 	"os"
 	"path/filepath"
@@ -111,21 +112,32 @@ func Load() (Config, error) {
 		return Config{}, fmt.Errorf("config: parsing %s: %w", path, err)
 	}
 
-	// Reject unknown keys — a typo like "alow" instead of "allow" would
-	// silently result in an empty allow list, which is a security issue.
+	// Keys removed in ADR 0007 are tolerated with a deprecation warning
+	// rather than a hard failure, so upgrading a host that still has an
+	// old config doesn't brick the daemon — it just ignores them. Any
+	// other unknown key is still rejected: a typo like "alow" instead of
+	// "allow" would silently produce an empty allow list (a security
+	// issue), so those must fail loudly.
 	if undecoded := md.Undecoded(); len(undecoded) > 0 {
-		keys := make([]string, len(undecoded))
-		for i, k := range undecoded {
-			keys[i] = k.String()
-			// Targeted migration hints for keys removed in ADR 0007.
-			if keys[i] == "tailscale.hostname" {
-				return Config{}, fmt.Errorf("config: %s: tailscale.hostname is no longer supported (ADR 0007); remove it — the node name is now derived from the OS hostname and owned by tailscale", path)
-			}
-			if keys[i] == "peers" {
-				return Config{}, fmt.Errorf("config: %s: [[peers]] is no longer supported (ADR 0007); add peers at runtime via \"Connect to host\" in Settings (stored in peers.json)", path)
+		var unknown []string
+		warnedPeers := false
+		for _, k := range undecoded {
+			key := k.String()
+			switch {
+			case key == "tailscale.hostname":
+				log.Printf("config: %s: ignoring deprecated tailscale.hostname (removed in ADR 0007); the node name is now derived from the OS hostname and owned by tailscale. Remove it to silence this warning.", path)
+			case key == "peers" || strings.HasPrefix(key, "peers."):
+				if !warnedPeers {
+					log.Printf("config: %s: ignoring deprecated [[peers]] (removed in ADR 0007); add peers at runtime via \"Connect to host\" in Settings (stored in peers.json). Remove it to silence this warning.", path)
+					warnedPeers = true
+				}
+			default:
+				unknown = append(unknown, key)
 			}
 		}
-		return Config{}, fmt.Errorf("config: unknown keys in %s: %s", path, strings.Join(keys, ", "))
+		if len(unknown) > 0 {
+			return Config{}, fmt.Errorf("config: unknown keys in %s: %s", path, strings.Join(unknown, ", "))
+		}
 	}
 
 	// Normalize allow list: trim whitespace, remove empty entries.

--- a/services/gmuxd/internal/config/config_test.go
+++ b/services/gmuxd/internal/config/config_test.go
@@ -88,39 +88,65 @@ alow = ["user@github"]
 	}
 }
 
-func TestLoadRejectsRemovedTailscaleHostname(t *testing.T) {
+// Removed ADR 0007 keys must not brick a daemon on upgrade: they are
+// ignored with a deprecation warning, and the rest of the config still
+// loads normally.
+func TestLoadIgnoresRemovedTailscaleHostname(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	writeConfig(t, dir, `
+port = 8123
+[tailscale]
+enabled = true
+hostname = "project-a"
+`)
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("deprecated tailscale.hostname should be ignored, got error: %v", err)
+	}
+	if cfg.Port != 8123 || !cfg.Tailscale.Enabled {
+		t.Errorf("rest of config should still load, got %+v", cfg)
+	}
+}
+
+func TestLoadIgnoresRemovedPeers(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	writeConfig(t, dir, `
+port = 8124
+[[peers]]
+name = "server"
+url = "https://gmux-server.ts.net"
+`)
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("deprecated [[peers]] should be ignored, got error: %v", err)
+	}
+	if cfg.Port != 8124 {
+		t.Errorf("rest of config should still load, got port %d", cfg.Port)
+	}
+}
+
+// A genuinely unknown key (e.g. a typo) must still fail loudly, even
+// when it appears alongside a tolerated deprecated key.
+func TestLoadRejectsRemovedKeyMixedWithTypo(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", dir)
 	writeConfig(t, dir, `
 [tailscale]
 enabled = true
 hostname = "project-a"
+alow = ["user@github"]
 `)
 
 	_, err := Load()
 	if err == nil {
-		t.Fatal("expected error for removed key tailscale.hostname")
+		t.Fatal("expected error for unknown key 'alow' even alongside a deprecated key")
 	}
-	if !strings.Contains(err.Error(), "tailscale.hostname is no longer supported") {
-		t.Errorf("error = %q, want migration hint for tailscale.hostname", err)
-	}
-}
-
-func TestLoadRejectsRemovedPeers(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("XDG_CONFIG_HOME", dir)
-	writeConfig(t, dir, `
-[[peers]]
-name = "server"
-url = "https://gmux-server.ts.net"
-`)
-
-	_, err := Load()
-	if err == nil {
-		t.Fatal("expected error for removed [[peers]] config")
-	}
-	if !strings.Contains(err.Error(), "[[peers]] is no longer supported") {
-		t.Errorf("error = %q, want migration hint for [[peers]]", err)
+	if !strings.Contains(err.Error(), "unknown keys") || strings.Contains(err.Error(), "hostname") {
+		t.Errorf("error = %q, want unknown-keys error mentioning only the typo", err)
 	}
 }
 


### PR DESCRIPTION
## Problem

Upgrading a host whose `host.toml` still contained `tailscale.hostname` or `[[peers]]` (both removed in ADR 0007 / #265) made gmuxd exit with a `FATAL` config error on startup, bricking the daemon until the file was hand-edited. Hit in the wild upgrading a real host — its tsnet node silently went offline and the cause (`tailscale.hostname is no longer supported`) was only visible in the daemon log.

## Change

Tolerate the two removed keys with a logged **deprecation warning** and ignore them, so the rest of the config still loads and the daemon starts. Genuinely unknown keys (e.g. a typo like `alow` for `allow`) still **fail loudly** — silently defaulting a security setting like the `allow` list is dangerous, which was the original rationale for strict validation.

```
config: /root/.config/gmux/host.toml: ignoring deprecated tailscale.hostname (removed in ADR 0007); the node name is now derived from the OS hostname and owned by tailscale. Remove it to silence this warning.
```

## Tests

- `TestLoadIgnoresRemovedTailscaleHostname` / `TestLoadIgnoresRemovedPeers` — key ignored, rest of config still loads.
- `TestLoadRejectsRemovedKeyMixedWithTypo` — a typo alongside a deprecated key still errors (and the error names only the typo).
- Existing `TestLoadRejectsUnknownKeys` unchanged.

Docs (`host-toml.md`) updated to describe the keys as ignored-with-warning rather than rejected.