### PR TITLE
feat(gmuxd): expose peer node_id on the peer roster

### DIFF
--- a/apps/gmux-web/src/types.ts
+++ b/apps/gmux-web/src/types.ts
@@ -172,6 +172,13 @@ export interface PeerInfo {
    * POST /v1/peers). Absent on older daemons.
    */
   source?: 'tailscale' | 'devcontainer' | 'manual'
+  /**
+   * The peer's stable opaque identity (ADR 0007), reported by its
+   * /v1/health. References anchor on this so they survive the peer
+   * being renamed. Absent for offline peers we've never probed and
+   * for pre-ADR-0007 daemons.
+   */
+  node_id?: string
 }
 
 /**

--- a/services/gmuxd/internal/peering/manager.go
+++ b/services/gmuxd/internal/peering/manager.go
@@ -237,6 +237,7 @@ func (m *Manager) PeerStatus() []PeerInfo {
 			info.Version = h.Version
 			info.DefaultLauncher = h.DefaultLauncher
 			info.Launchers = h.Launchers
+			info.NodeID = h.NodeID
 		}
 		infos = append(infos, info)
 	}

--- a/services/gmuxd/internal/peering/peering.go
+++ b/services/gmuxd/internal/peering/peering.go
@@ -84,6 +84,10 @@ type SpokeHealth struct {
 	Version         string        `json:"version"`
 	DefaultLauncher string        `json:"default_launcher"`
 	Launchers       []LauncherDef `json:"launchers"`
+	// NodeID is the spoke's stable opaque identity (ADR 0007). The
+	// viewer anchors peer references on it so they survive the host
+	// being renamed. Empty when talking to a pre-ADR-0007 daemon.
+	NodeID string `json:"node_id"`
 }
 
 // SpokeProject is the minimal projection of a peer's project that
@@ -119,6 +123,11 @@ type PeerInfo struct {
 	// or "manual" (peers.json / POST /v1/peers). Used by the UI to group
 	// hosts; empty for the synthesized self row.
 	Source string `json:"source,omitempty"`
+	// NodeID is the peer's stable opaque identity (ADR 0007), reported
+	// by its /v1/health. The viewer anchors references on it so they
+	// survive the peer being renamed. Empty for offline peers we've
+	// never probed and for pre-ADR-0007 daemons.
+	NodeID string `json:"node_id,omitempty"`
 }
 
 // NamespaceID returns a store-key for a remote session: "originalID@peerName".

--- a/services/gmuxd/internal/peering/peering_test.go
+++ b/services/gmuxd/internal/peering/peering_test.go
@@ -876,7 +876,7 @@ func TestPeerStatus_IncludesHealthData(t *testing.T) {
 
 	spoke2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`{"ok":true,"data":{"version":"0.7.9","default_launcher":"pi","launchers":[{"id":"shell"},{"id":"pi"}]}}`))
+		w.Write([]byte(`{"ok":true,"data":{"version":"0.7.9","default_launcher":"pi","node_id":"node_ws","launchers":[{"id":"shell"},{"id":"pi"}]}}`))
 	}))
 	defer spoke2.Close()
 
@@ -908,6 +908,11 @@ func TestPeerStatus_IncludesHealthData(t *testing.T) {
 	}
 	if ws.Version != "0.7.9" {
 		t.Errorf("version = %q, want %q", ws.Version, "0.7.9")
+	}
+	// node_id flows from the spoke's health to the roster so the viewer
+	// can anchor references on it (refs #270).
+	if ws.NodeID != "node_ws" {
+		t.Errorf("node_id = %q, want %q", ws.NodeID, "node_ws")
 	}
 	if ws.DefaultLauncher != "pi" {
 		t.Errorf("default_launcher = %q, want %q", ws.DefaultLauncher, "pi")


### PR DESCRIPTION
Slice 1 of #270 (rename-proof peer references).

Surfaces each peer's stable opaque `node_id` (ADR 0007) on the peer roster so the viewer can anchor references on it instead of the display name:

- `SpokeHealth` now parses `node_id` from a spoke's `/v1/health`.
- `PeerInfo.NodeID` is populated in `PeerStatus()` from the cached health (omitted for offline/never-probed peers and pre-ADR-0007 daemons).
- Frontend `PeerInfo` type gains `node_id?`.

No behavior change yet — this is the foundation the resolver (slice 3) builds on.

**Test:** `TestPeerStatus_IncludesHealthData` extended to assert `node_id` flows from the spoke health to the roster (prior art for the pattern; mirrors the existing version/launcher assertions).