### PR TITLE
feat(gmuxd): persist node_id anchor on peer references

### DIFF
--- a/apps/gmux-web/src/types.ts
+++ b/apps/gmux-web/src/types.ts
@@ -116,6 +116,13 @@ export interface ProjectItem {
   slug: string
   /** Set when this item is a reference to a peer-owned project. */
   peer?: string
+  /**
+   * Stable opaque identity (ADR 0007) of the referenced peer, used to
+   * resolve the reference even after the peer is renamed. Set only on
+   * references; opportunistically backfilled once the peer is
+   * reachable. Absent on legacy references and owned projects.
+   */
+  node_id?: string
   /** Owned-project match rules. Empty/absent for references. */
   match?: MatchRule[]
   /** Server-managed ordering. Absent for references. */

--- a/services/gmuxd/internal/projects/projects.go
+++ b/services/gmuxd/internal/projects/projects.go
@@ -59,6 +59,12 @@ type Item struct {
 	Peer     string      `json:"peer,omitempty"`
 	Match    []MatchRule `json:"match,omitempty"`
 	Sessions []string    `json:"sessions,omitempty"`
+	// NodeID anchors a reference on the peer's stable opaque identity
+	// (ADR 0007) so it survives the peer being renamed: the viewer
+	// resolves the reference by NodeID first, falling back to Peer
+	// (the display name). Set only on references; opportunistically
+	// backfilled once the referenced peer is reachable (refs #270).
+	NodeID string `json:"node_id,omitempty"`
 }
 
 // IsReference reports whether this item is a reference to a peer-owned
@@ -162,6 +168,12 @@ func (s *State) Validate() error {
 			return fmt.Errorf("duplicate slug %q", item.Slug)
 		}
 		slugs[key] = true
+
+		// node_id is a reference anchor; it's meaningless on an owned
+		// project (the viewer owns it, so there's no peer to anchor to).
+		if item.NodeID != "" && !item.IsReference() {
+			return fmt.Errorf("item %q: node_id is only valid on references", item.Slug)
+		}
 
 		if item.IsReference() {
 			// References carry no rules or sessions of their own.

--- a/services/gmuxd/internal/projects/projects_test.go
+++ b/services/gmuxd/internal/projects/projects_test.go
@@ -1362,6 +1362,46 @@ func TestValidateRejectsReferenceWithMatchRules(t *testing.T) {
 	}
 }
 
+// A reference's node_id anchor must survive a Save/Load round-trip so
+// the viewer can resolve renamed peers (refs #270).
+func TestReferenceNodeIDRoundTrips(t *testing.T) {
+	dir := t.TempDir()
+	orig := &State{Items: []Item{
+		{Slug: "apps", Peer: "gmux-hs", NodeID: "node_abc"},
+	}}
+	if err := orig.Save(dir); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(loaded.Items) != 1 || loaded.Items[0].NodeID != "node_abc" || loaded.Items[0].Peer != "gmux-hs" {
+		t.Errorf("reference did not round-trip: %+v", loaded.Items)
+	}
+}
+
+func TestValidateRejectsNodeIDOnOwnedProject(t *testing.T) {
+	s := State{Items: []Item{
+		{Slug: "gmux", Match: []MatchRule{{Path: "/x"}}, NodeID: "node_abc"},
+	}}
+	if err := s.Validate(); err == nil {
+		t.Error("expected validation error for node_id on an owned project")
+	}
+}
+
+// The positive counterpart: a reference *with* a node_id is valid — it's
+// the rename-proof anchor — so Validate must accept it. Guards against a
+// future change that mistakenly rejects node_id on references too.
+func TestValidateAcceptsNodeIDOnReference(t *testing.T) {
+	s := State{Items: []Item{
+		{Slug: "apps", Peer: "gmux-hs", NodeID: "node_abc"},
+	}}
+	if err := s.Validate(); err != nil {
+		t.Errorf("node_id on a reference should be valid, got: %v", err)
+	}
+}
+
 func TestValidateAllowsSameSlugAsOwnedAndReference(t *testing.T) {
 	s := State{Items: []Item{
 		{Slug: "gmux", Match: []MatchRule{{Path: "/x"}}},


### PR DESCRIPTION
Slice 2 of #270 (rename-proof peer references). Stacked on #271.

Lets a reference item in `projects.json` carry an optional `node_id` — the stable opaque identity (ADR 0007) of the peer it points to — so the viewer can resolve it even after the peer is renamed:

- `projects.Item` gains `node_id` (`omitempty`); it round-trips through GET/PUT `/v1/projects` for free (handlers serialize the full struct, no projection).
- Validation rejects `node_id` on an owned project (it's only meaningful as a reference anchor).
- Frontend `ProjectItem` type gains `node_id?`.

No resolution behavior yet — that's slice 3. This just makes the anchor durable on disk.

**Tests:** `TestReferenceNodeIDRoundTrips` (Save/Load preserves the anchor) and `TestValidateRejectsNodeIDOnOwnedProject`.