### PR TITLE
feat(web): resolve peer references by node_id with name fallback

### DIFF
--- a/apps/gmux-web/src/projects.ts
+++ b/apps/gmux-web/src/projects.ts
@@ -330,6 +330,10 @@ export function buildProjectFolders(
   sessions: Session[],
   isLocalPeer?: (peerName: string) => boolean,
   peerProjects?: Record<string, { slug: string; launch_cwd?: string }[]>,
+  // Resolve a reference (by its stored peer+slug) to the live host's
+  // current name and whether it's in the roster at all. When omitted,
+  // references resolve to their stored name (legacy behavior). (refs #270)
+  resolveRef?: (peer: string, slug: string) => { effectivePeer: string; resolved: boolean } | undefined,
 ): Folder[] {
   // Bucket every stamped session by `${ownerPeer}::${slug}`.
   // ownerPeer is '' for sessions owned by the viewer (local sessions,
@@ -354,7 +358,20 @@ export function buildProjectFolders(
 
   const folders: Folder[] = []
   for (const project of projects) {
-    const ownerPeer = project.peer ?? ''
+    const storedPeer = project.peer ?? ''
+    // For references, resolve to the live host's current name (which
+    // may differ from the stored name after a rename) and learn
+    // whether the host is in the roster at all. Owned projects pass
+    // through unchanged.
+    let ownerPeer = storedPeer
+    let unresolved = false
+    if (storedPeer !== '' && resolveRef) {
+      const r = resolveRef(storedPeer, project.slug)
+      if (r) {
+        ownerPeer = r.effectivePeer
+        unresolved = !r.resolved
+      }
+    }
     const ss = buckets.get(`${ownerPeer}::${project.slug}`) ?? []
     const visible = ss.filter(s => s.alive || s.resumable === true)
     visible.sort(compareFolderSessions)
@@ -368,6 +385,10 @@ export function buildProjectFolders(
     let missing = false
     if (ownerPeer === '') {
       launchCwd = project.match?.find(r => r.path)?.path
+    } else if (unresolved) {
+      // No live host matches this reference; don't probe peer_projects
+      // for a slug under a name that isn't connected. The unresolved
+      // flag carries the state.
     } else if (peerProjects) {
       const peerEntry = peerProjects[ownerPeer]
       if (peerEntry) {
@@ -388,6 +409,7 @@ export function buildProjectFolders(
       peer: ownerPeer || undefined,
       launchCwd,
       missing: missing || undefined,
+      unresolved: unresolved || undefined,
       sessions: visible,
     })
   }

--- a/apps/gmux-web/src/references.test.ts
+++ b/apps/gmux-web/src/references.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest'
+import { resolveReferences, refKey } from './references'
+import type { PeerInfo, ProjectItem } from './types'
+
+function peer(name: string, node_id?: string): PeerInfo {
+  return { name, url: `https://${name}`, status: 'connected', session_count: 0, node_id }
+}
+function ref(peer: string, slug: string, node_id?: string): ProjectItem {
+  return { slug, peer, node_id }
+}
+function owned(slug: string): ProjectItem {
+  return { slug, match: [{ path: `/home/${slug}` }] }
+}
+
+describe('resolveReferences', () => {
+  it('resolves a legacy name-only reference and backfills its node_id', () => {
+    const projects = [ref('gmux-hs', 'apps')]
+    const roster = [peer('gmux-hs', 'node_hs')]
+    const { resolution, unresolved, backfills } = resolveReferences(projects, roster)
+    expect(resolution.get(refKey('gmux-hs', 'apps'))).toEqual({ effectivePeer: 'gmux-hs', resolved: true })
+    expect(unresolved).toEqual([])
+    expect(backfills).toEqual([{ slug: 'apps', fromPeer: 'gmux-hs', toPeer: 'gmux-hs', node_id: 'node_hs' }])
+  })
+
+  it('resolves by node_id and follows a renamed host (name drift)', () => {
+    // Reference stored "unraid" + node, host now reports "gmux-hs".
+    const projects = [ref('unraid', 'apps', 'node_hs')]
+    const roster = [peer('gmux-hs', 'node_hs')]
+    const { resolution, unresolved, backfills } = resolveReferences(projects, roster)
+    expect(resolution.get(refKey('unraid', 'apps'))).toEqual({ effectivePeer: 'gmux-hs', resolved: true })
+    expect(unresolved).toEqual([])
+    // Backfill follows the rename: update the cached display name.
+    expect(backfills).toEqual([{ slug: 'apps', fromPeer: 'unraid', toPeer: 'gmux-hs', node_id: 'node_hs' }])
+  })
+
+  it('node_id match needs no backfill when the name is unchanged', () => {
+    const projects = [ref('gmux-hs', 'apps', 'node_hs')]
+    const roster = [peer('gmux-hs', 'node_hs')]
+    const { backfills } = resolveReferences(projects, roster)
+    expect(backfills).toEqual([])
+  })
+
+  it('flags a reference whose host is in no roster bucket as unresolved', () => {
+    // The classic broken case: reference points at "hs", live host is
+    // "unraid"/"gmux-hs" — no roster peer named "hs".
+    const projects = [ref('hs', 'apps'), ref('hs', 'home'), ref('hs', 'chezmoi')]
+    const roster = [peer('unraid', 'node_hs'), peer('ft', 'node_ft')]
+    const { resolution, unresolved, backfills } = resolveReferences(projects, roster)
+    expect(resolution.get(refKey('hs', 'apps'))).toEqual({ effectivePeer: 'hs', resolved: false })
+    expect(backfills).toEqual([])
+    expect(unresolved).toEqual([{ name: 'hs', slugs: ['apps', 'home', 'chezmoi'] }])
+  })
+
+  it('treats an offline-but-known host (no node_id) as resolved, not unresolved', () => {
+    // Offline tailnet peers are in the roster without a node_id.
+    const projects = [ref('bespin', 'home')]
+    const roster: PeerInfo[] = [{ name: 'bespin', url: 'https://bespin', status: 'offline', session_count: 0 }]
+    const { resolution, unresolved, backfills } = resolveReferences(projects, roster)
+    expect(resolution.get(refKey('bespin', 'home'))).toEqual({ effectivePeer: 'bespin', resolved: true })
+    expect(unresolved).toEqual([])
+    expect(backfills).toEqual([]) // nothing to stamp; offline peer has no node_id
+  })
+
+  it('falls back to name and refreshes a stale node_id', () => {
+    // node_id was stamped, but that host is gone; another host now has
+    // the referenced name. Resolve by name rather than orphaning, and
+    // backfill the *current* node_id so the stale one doesn't linger
+    // (otherwise every load repeats the failed-id-then-name dance).
+    const projects = [ref('shared', 'proj', 'node_gone')]
+    const roster = [peer('shared', 'node_new')]
+    const { resolution, unresolved, backfills } = resolveReferences(projects, roster)
+    expect(resolution.get(refKey('shared', 'proj'))).toEqual({ effectivePeer: 'shared', resolved: true })
+    expect(unresolved).toEqual([])
+    expect(backfills).toEqual([{ slug: 'proj', fromPeer: 'shared', toPeer: 'shared', node_id: 'node_new' }])
+  })
+
+  it('ignores owned projects entirely', () => {
+    const projects = [owned('gmux'), ref('hs', 'apps')]
+    const roster: PeerInfo[] = []
+    const { resolution, unresolved } = resolveReferences(projects, roster)
+    expect(resolution.has(refKey('', 'gmux'))).toBe(false)
+    expect(unresolved).toEqual([{ name: 'hs', slugs: ['apps'] }])
+  })
+
+  it('groups multiple unresolved hosts independently', () => {
+    const projects = [ref('hs', 'apps'), ref('old-laptop', 'dots'), ref('hs', 'home')]
+    const { unresolved } = resolveReferences(projects, [])
+    expect(unresolved).toContainEqual({ name: 'hs', slugs: ['apps', 'home'] })
+    expect(unresolved).toContainEqual({ name: 'old-laptop', slugs: ['dots'] })
+    expect(unresolved).toHaveLength(2)
+  })
+})

--- a/apps/gmux-web/src/references.ts
+++ b/apps/gmux-web/src/references.ts
@@ -1,0 +1,137 @@
+// --- Peer reference resolution (refs #270) ---
+//
+// A reference item in projects.json points at a project owned by
+// another host. It stores the host's display `peer` name and,
+// optionally, the host's stable opaque `node_id` (ADR 0007). Because
+// ADR 0007 derives a host's name from Tailscale / the OS hostname, that
+// name can change on upgrade — so resolving a reference purely by name
+// breaks silently when a host is renamed.
+//
+// `resolveReferences` is the single source of truth for "which live
+// host (if any) does this reference point at, and under what current
+// name." Every surface — the sidebar folders, the Hosts tab, the
+// settings gear pip — reads off its output so they all agree.
+//
+// Resolution order, per reference:
+//   1. by node_id — if the reference has a node_id and a roster peer
+//      reports the same one, it resolves to that peer's *current* name
+//      (the display name follows the live host across renames).
+//   2. by name — legacy references with no node_id (or whose node_id
+//      matches no live peer) fall back to matching the stored name. A
+//      name match against a peer that has a node_id yields a backfill,
+//      so the reference becomes rename-proof going forward.
+//   3. unresolved — no roster peer matches by id or name. The host
+//      isn't on the tailnet (online or offline), manually added, or a
+//      devcontainer; it may have been renamed or removed.
+
+import type { PeerInfo, ProjectItem } from './types'
+
+/** Composite key for a reference, by its stored (peer, slug). */
+export function refKey(peer: string, slug: string): string {
+  return `${peer}\u0000${slug}`
+}
+
+export interface RefResolution {
+  /** Peer name to bucket sessions under and label the folder with.
+   *  Equals the live host's current name when resolved by node_id. */
+  effectivePeer: string
+  /** True when the reference points at a host in the current roster. */
+  resolved: boolean
+}
+
+/** A referenced host name that matches no roster peer, with the slugs
+ *  that point at it. One entry per distinct unresolved name. */
+export interface UnresolvedHost {
+  name: string
+  slugs: string[]
+}
+
+/** A projects.json write needed to make a reference rename-proof:
+ *  stamp `node_id` (and follow a drifted display name). The writer
+ *  finds the item by (fromPeer, slug) and rewrites it to
+ *  { peer: toPeer, node_id }. */
+export interface RefBackfill {
+  slug: string
+  fromPeer: string
+  toPeer: string
+  node_id: string
+}
+
+export interface ResolvedReferences {
+  /** Per-reference resolution, keyed by refKey(item.peer, item.slug). */
+  resolution: Map<string, RefResolution>
+  /** Distinct referenced host names not present in the roster. */
+  unresolved: UnresolvedHost[]
+  /** Opportunistic projects.json updates (stamp node_id / follow rename). */
+  backfills: RefBackfill[]
+}
+
+/**
+ * Resolve every reference item in `projects` against the live peer
+ * `roster`. Owned items (no `peer`) are ignored. Pure: no I/O, no
+ * signals — callers feed it the current projects + peers and act on
+ * the result.
+ */
+export function resolveReferences(
+  projects: readonly ProjectItem[],
+  roster: readonly PeerInfo[],
+): ResolvedReferences {
+  const byNodeId = new Map<string, PeerInfo>()
+  const byName = new Map<string, PeerInfo>()
+  for (const p of roster) {
+    if (p.node_id) byNodeId.set(p.node_id, p)
+    byName.set(p.name, p)
+  }
+
+  const resolution = new Map<string, RefResolution>()
+  const unresolvedMap = new Map<string, string[]>()
+  const backfills: RefBackfill[] = []
+
+  for (const item of projects) {
+    if (!item.peer) continue // owned project, not a reference
+    const key = refKey(item.peer, item.slug)
+
+    // 1. node_id anchor: the durable identity. The live host's current
+    //    name wins, so a renamed host stays linked.
+    if (item.node_id) {
+      const live = byNodeId.get(item.node_id)
+      if (live) {
+        resolution.set(key, { effectivePeer: live.name, resolved: true })
+        if (live.name !== item.peer) {
+          // Host was renamed; follow it and refresh the cached name.
+          backfills.push({ slug: item.slug, fromPeer: item.peer, toPeer: live.name, node_id: item.node_id })
+        }
+        continue
+      }
+      // node_id set but no live peer reports it (host offline and never
+      // re-probed, or gone) — fall through to a name match.
+    }
+
+    // 2. name match: legacy references, or a reference whose stored
+    //    node_id matched no live peer (host gone / replaced). Stamp the
+    //    matched peer's node_id whenever it differs from what's stored
+    //    — covering both the never-stamped case and refreshing a stale
+    //    node_id — so the reference is (re)made rename-proof rather than
+    //    repeating the failed-id-then-name dance on every load.
+    const named = byName.get(item.peer)
+    if (named) {
+      resolution.set(key, { effectivePeer: item.peer, resolved: true })
+      if (named.node_id && named.node_id !== item.node_id) {
+        backfills.push({ slug: item.slug, fromPeer: item.peer, toPeer: item.peer, node_id: named.node_id })
+      }
+      continue
+    }
+
+    // 3. unresolved: no live host matches. Keep the dangling name for
+    //    the folder label; the surface flags it.
+    resolution.set(key, { effectivePeer: item.peer, resolved: false })
+    const slugs = unresolvedMap.get(item.peer) ?? []
+    slugs.push(item.slug)
+    unresolvedMap.set(item.peer, slugs)
+  }
+
+  const unresolved: UnresolvedHost[] = []
+  for (const [name, slugs] of unresolvedMap) unresolved.push({ name, slugs })
+
+  return { resolution, unresolved, backfills }
+}

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -19,6 +19,7 @@ import type { View } from './routing'
 import { resolveViewFromPath, viewToPath } from './routing'
 import { navigateWithReload } from './version-watch'
 import { buildProjectFolders, discoverProjects } from './projects'
+import { resolveReferences, refKey, type UnresolvedHost } from './references'
 
 import { fetchFrontendConfig, buildTerminalOptions, resolveKeybinds, type ResolvedKeybind } from './config'
 import { MOCK_SESSIONS, MOCK_PROJECTS, MOCK_PEERS, MOCK_HEALTH } from './mock-data/index'
@@ -408,12 +409,27 @@ export const localPeerNames = computed<ReadonlySet<string>>(() => {
 })
 
 /** Project folders for the sidebar, built from projects + sessions. */
+/** Reference resolution against the live roster: maps each reference
+ *  to the host's current name (rename-proof via node_id) or flags it
+ *  unresolved. Single source of truth for folders, the Hosts tab, and
+ *  the gear pip. (refs #270) */
+export const resolvedReferences = computed(() =>
+  resolveReferences(projects.value, peers.value),
+)
+
+/** Distinct referenced host names that match no roster peer. Drives
+ *  the Hosts-tab "Referenced but not found" group and the gear pip. */
+export const unresolvedHosts = computed<UnresolvedHost[]>(
+  () => resolvedReferences.value.unresolved,
+)
+
 export const folders = computed(() =>
   buildProjectFolders(
     projects.value,
     filteredSessions.value,
     (name) => localPeerNames.value.has(name),
     _rawWorld.value.peerProjects,
+    (peer, slug) => resolvedReferences.value.resolution.get(refKey(peer, slug)),
   ),
 )
 

--- a/apps/gmux-web/src/types.ts
+++ b/apps/gmux-web/src/types.ts
@@ -87,6 +87,15 @@ export interface Folder {
    * by the PeerLabel offline state).
    */
   missing?: boolean
+  /**
+   * True when this folder is a reference whose peer name matches no
+   * host in the current roster (not on the tailnet online/offline, not
+   * manually added, not a devcontainer). The host may have been
+   * renamed or removed; the sidebar flags it and the Hosts tab offers
+   * a remap/remove. Distinct from `missing` (peer connected, slug
+   * gone) and from a disconnected-but-known peer. (refs #270)
+   */
+  unresolved?: boolean
   sessions: Session[]
 }
 


### PR DESCRIPTION
Slice 3 of #270 (rename-proof peer references) — the keystone. Stacked on #272.

Adds `resolveReferences(projects, roster)`, the single source of truth for "which live host does this reference point at, and under what current name." Every surface (sidebar folders, upcoming Hosts-tab group, gear pip) reads off it.

**Resolution order, per reference:**
1. **by node_id** — reference's `node_id` matches a roster peer → resolves to that peer's *current* name (display name follows the host across renames).
2. **by name** — legacy references with no node_id fall back to name match; a match against a peer that has a node_id yields a **backfill** (so it becomes rename-proof going forward).
3. **unresolved** — no roster peer matches by id or name (host renamed/removed). Grouped per host name with the slugs pointing at it.

`buildProjectFolders` now buckets a reference under its **resolved** name (so a renamed host's sessions link to an old-named reference once node_id-anchored) and flags `Folder.unresolved` when the host is in no roster bucket. Offline-but-known tailnet hosts resolve normally (not unresolved).

This slice is **visually inert** — it computes resolution + the `unresolvedHosts` signal and flags folders; the sidebar/Hosts-tab/pip that consume it land in slices 4–6. Backfill *writes* are computed here but applied in a later slice.

**Tests:** `references.test.ts` — 8 table-driven cases: legacy name match + backfill, node_id match following a rename, no-op backfill when name unchanged, the classic unresolved case (`hs`), offline-known host resolves, stale-node_id name fallback, owned-project ignored, multi-host grouping. Full suite 434 pass.