### PR TITLE
feat(web): surface unresolved peer references in the sidebar

### DIFF
--- a/apps/gmux-web/src/mock-data/index.ts
+++ b/apps/gmux-web/src/mock-data/index.ts
@@ -70,4 +70,9 @@ export const MOCK_PROJECTS: ProjectItem[] = [
       { path: '~/dev/openclaw' },
     ],
   },
+  // A resolved reference to a roster peer (server).
+  { slug: 'api', peer: 'server' },
+  // An unresolved reference: 'old-tower' is in no roster bucket, so it
+  // surfaces as a host-not-found state in the sidebar and Hosts tab.
+  { slug: 'legacy-app', peer: 'old-tower' },
 ]

--- a/apps/gmux-web/src/sidebar.tsx
+++ b/apps/gmux-web/src/sidebar.tsx
@@ -256,9 +256,11 @@ function FolderGroup({
     <div class="folder">
       <div class="folder-header">
         <a
-          class={`folder-name${isCurrent ? ' current' : ''}${folder.missing ? ' missing' : ''}`}
+          class={`folder-name${isCurrent ? ' current' : ''}${folder.missing ? ' missing' : ''}${folder.unresolved ? ' unresolved' : ''}`}
           href={href}
-          title={folder.missing
+          title={folder.unresolved
+            ? `Host “${folder.peer}” isn't on your tailnet or manually added — it may have been renamed or removed. Open Settings → Hosts to remap or remove it.`
+            : folder.missing
             ? `${folder.name} no longer exists on ${folder.peer}; remove via the home page`
             : `Open ${folder.name} hub`}
           onClick={onClick}
@@ -266,14 +268,19 @@ function FolderGroup({
           {folder.name}
           <HostSuffix peer={folder.peer ?? localHostLabel.value} local={!folder.peer} />
           {folder.missing && <span class="folder-missing-icon" title="Project missing on peer">?</span>}
+          {folder.unresolved && (
+            <span class="folder-unresolved-icon" title="Host not found — fix in Settings → Hosts">!</span>
+          )}
         </a>
-        <LaunchButton
-          sessions={folder.sessions}
-          selectedId={selId}
-          fallbackCwd={folder.launchCwd ?? ''}
-          peer={folder.peer}
-          className="folder-launch-btn"
-        />
+        {!folder.unresolved && (
+          <LaunchButton
+            sessions={folder.sessions}
+            selectedId={selId}
+            fallbackCwd={folder.launchCwd ?? ''}
+            peer={folder.peer}
+            className="folder-launch-btn"
+          />
+        )}
       </div>
       <div class="folder-sessions">
         {displayItems.map((s, i) => (

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -593,6 +593,26 @@ body {
 .folder-name.missing {
   opacity: 0.5;
 }
+/* Unresolved reference: the host this reference points at isn't in the
+   roster (renamed/removed). Muted like `missing`, but with a warning
+   pip directing the user to Settings -> Hosts to remap or remove. */
+.folder-name.unresolved {
+  opacity: 0.5;
+}
+.folder-unresolved-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  margin-left: 6px;
+  border-radius: 50%;
+  background: oklch(28% 0.06 75);
+  color: oklch(80% 0.14 75);
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1cap;
+}
 .folder-missing-icon {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
Slice 4 of #270. Stacked on #273.

An unresolved reference (its host matches no roster peer — renamed or removed) no longer looks like an empty-but-healthy project. The folder now renders muted with an amber `!` pip and a tooltip: *"Host '…' isn't on your tailnet or manually added — it may have been renamed or removed. Open Settings → Hosts to remap or remove it."* The launch `+` is suppressed (you can't launch into a host that isn't there).

Distinct from the existing `missing` state (peer connected, slug gone → grey `?`) and from a disconnected-but-known peer.

Mock data gains a resolved reference (`api@server`) and an unresolved one (`legacy-app@old-tower`) for visual coverage; verified in the mock dev server (screenshot in thread). Full suite 434 pass.