### PR TITLE
feat(web): recover unresolved references from the Hosts tab (remap/remove)

### DIFF
--- a/apps/gmux-web/src/references.test.ts
+++ b/apps/gmux-web/src/references.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { resolveReferences, refKey } from './references'
+import { resolveReferences, remapReferenceItems, refKey } from './references'
 import type { PeerInfo, ProjectItem } from './types'
 
 function peer(name: string, node_id?: string): PeerInfo {
@@ -88,5 +88,42 @@ describe('resolveReferences', () => {
     expect(unresolved).toContainEqual({ name: 'hs', slugs: ['apps', 'home'] })
     expect(unresolved).toContainEqual({ name: 'old-laptop', slugs: ['dots'] })
     expect(unresolved).toHaveLength(2)
+  })
+})
+
+describe('remapReferenceItems', () => {
+  it('repoints all references from one host to another and stamps node_id', () => {
+    const items = [owned('gmux'), ref('hs', 'apps'), ref('hs', 'home'), ref('ft', 'dots')]
+    const next = remapReferenceItems(items, 'hs', 'gmux-hs', 'node_hs')
+    expect(next).toEqual([
+      owned('gmux'),
+      { slug: 'apps', peer: 'gmux-hs', node_id: 'node_hs' },
+      { slug: 'home', peer: 'gmux-hs', node_id: 'node_hs' },
+      ref('ft', 'dots'), // untouched
+    ])
+  })
+
+  it('clears a stale node_id when the remap target has no node_id', () => {
+    // Source references carry a stale node_id from the original host;
+    // the target (offline/legacy) has none. The stale id must be
+    // cleared, not preserved — keeping it would let the old host
+    // silently re-claim the reference if it came back.
+    const items = [ref('hs', 'apps', 'stale_node'), ref('hs', 'home', 'stale_node')]
+    const next = remapReferenceItems(items, 'hs', 'gmux-hs', undefined)
+    expect(next).toEqual([
+      { slug: 'apps', peer: 'gmux-hs', node_id: undefined },
+      { slug: 'home', peer: 'gmux-hs', node_id: undefined },
+    ])
+  })
+
+  it('drops a remapped reference whose slug the target already has', () => {
+    const items = [ref('gmux-hs', 'apps', 'node_hs'), ref('hs', 'apps'), ref('hs', 'home')]
+    const next = remapReferenceItems(items, 'hs', 'gmux-hs', 'node_hs')
+    // hs/apps collides with the existing gmux-hs/apps and is dropped;
+    // hs/home is remapped.
+    expect(next).toEqual([
+      ref('gmux-hs', 'apps', 'node_hs'),
+      { slug: 'home', peer: 'gmux-hs', node_id: 'node_hs' },
+    ])
   })
 })

--- a/apps/gmux-web/src/references.ts
+++ b/apps/gmux-web/src/references.ts
@@ -135,3 +135,34 @@ export function resolveReferences(
 
   return { resolution, unresolved, backfills }
 }
+
+/**
+ * Rewrite every reference pointing at `fromPeer` to point at `toPeer`,
+ * stamping the target's `nodeId` so it survives future renames. Pure:
+ * returns a new items array; the caller persists it. A reference whose
+ * slug `toPeer` already references is dropped (the target wins) so the
+ * result has no duplicate (peer, slug). Used to recover references
+ * orphaned by a host rename. (refs #270)
+ *
+ * The remapped reference takes the target's `nodeId` verbatim — if the
+ * target has none (offline/legacy peer), the reference's node_id is
+ * *cleared*, never left pointing at the old host's id (which would let
+ * the old host silently re-claim the reference if it reappeared).
+ */
+export function remapReferenceItems(
+  items: readonly ProjectItem[],
+  fromPeer: string,
+  toPeer: string,
+  nodeId?: string,
+): ProjectItem[] {
+  const targetSlugs = new Set(
+    items.filter(p => p.peer === toPeer).map(p => p.slug),
+  )
+  const next: ProjectItem[] = []
+  for (const it of items) {
+    if (it.peer !== fromPeer) { next.push(it); continue }
+    if (targetSlugs.has(it.slug)) continue // target already references this slug
+    next.push({ ...it, peer: toPeer, node_id: nodeId })
+  }
+  return next
+}

--- a/apps/gmux-web/src/settings.tsx
+++ b/apps/gmux-web/src/settings.tsx
@@ -20,9 +20,11 @@ import {
   addProject, addPeerReference, folders, updateProjects,
   removeProject, removePeerReference, localHostLabel,
   health, peers, sessions, connectHost, disconnectHost,
+  unresolvedHosts, remapReferences, removeReferencesForPeer,
 } from './store'
 import { HostSuffix } from './host-suffix'
 import type { ProjectItem, DiscoveredProject, MatchRule, Folder, PeerInfo } from './types'
+import type { UnresolvedHost } from './references'
 
 type SettingsTab = 'projects' | 'hosts'
 
@@ -354,6 +356,21 @@ function HostsTab() {
 
   return (
     <>
+      {/* Surfaced first so a broken reference is the first thing seen. */}
+      {unresolvedHosts.value.length > 0 && (
+        <section class="mp-section">
+          <div class="mp-section-label">Referenced but not found</div>
+          <div class="mp-path-hint" style="margin-bottom:8px">
+            These hosts are referenced by your projects but aren't on your tailnet or manually added. They may have been renamed or removed. Remap each to a current host, or remove its references.
+          </div>
+          <div class="host-list">
+            {unresolvedHosts.value.map(u => (
+              <UnresolvedHostRow key={u.name} host={u} targets={peersVal} />
+            ))}
+          </div>
+        </section>
+      )}
+
       <section class="mp-section">
         <div class="mp-section-label">This host</div>
         <div class="host-list">
@@ -425,6 +442,64 @@ function HostsTab() {
         )}
       </section>
     </>
+  )
+}
+
+/** A host that projects reference but that matches no current peer
+ *  (renamed or removed). Offers a one-click remap onto a roster host
+ *  — stamping the target's node_id so it survives future renames —
+ *  and a remove that drops all its references. (refs #270) */
+function UnresolvedHostRow({ host, targets }: { host: UnresolvedHost; targets: PeerInfo[] }) {
+  const [busy, setBusy] = useState(false)
+  const [err, setErr] = useState('')
+
+  const onRemap = useCallback(async (e: Event) => {
+    const sel = e.target as HTMLSelectElement
+    const toName = sel.value
+    if (!toName) return
+    const target = targets.find(t => t.name === toName)
+    setBusy(true); setErr('')
+    try {
+      await remapReferences(host.name, toName, target?.node_id)
+    } catch (e) {
+      // Reset to the placeholder so re-picking the same target fires
+      // onChange again (otherwise the user must choose a different
+      // option before they can retry).
+      sel.value = ''
+      setErr(e instanceof Error ? e.message : 'Could not remap.')
+    } finally {
+      setBusy(false)
+    }
+  }, [host.name, targets])
+
+  const onRemove = useCallback(async () => {
+    setBusy(true); setErr('')
+    try {
+      await removeReferencesForPeer(host.name)
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : 'Could not remove.')
+    } finally {
+      setBusy(false)
+    }
+  }, [host.name])
+
+  const count = host.slugs.length
+  return (
+    <div class="host-row unresolved">
+      <div class="host-row-main">
+        <span class="host-unresolved-icon" title="Host not found">!</span>
+        <span class="host-name">{host.name}</span>
+        <span class="host-meta">{count} reference{count === 1 ? '' : 's'}: {host.slugs.join(', ')}</span>
+      </div>
+      <div class="host-row-actions">
+        <select class="mp-filter-input host-remap-select" disabled={busy} onChange={onRemap}>
+          <option value="">Remap to…</option>
+          {targets.map(t => <option key={t.name} value={t.name}>{t.name}</option>)}
+        </select>
+        <button class="host-remove" disabled={busy} title="Remove these references" onClick={onRemove}>×</button>
+      </div>
+      {err && <div class="mp-manual-error">{err}</div>}
+    </div>
   )
 }
 

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -19,7 +19,7 @@ import type { View } from './routing'
 import { resolveViewFromPath, viewToPath } from './routing'
 import { navigateWithReload } from './version-watch'
 import { buildProjectFolders, discoverProjects } from './projects'
-import { resolveReferences, refKey, type UnresolvedHost } from './references'
+import { resolveReferences, remapReferenceItems, refKey, type UnresolvedHost } from './references'
 
 import { fetchFrontendConfig, buildTerminalOptions, resolveKeybinds, type ResolvedKeybind } from './config'
 import { MOCK_SESSIONS, MOCK_PROJECTS, MOCK_PEERS, MOCK_HEALTH } from './mock-data/index'
@@ -920,6 +920,25 @@ export async function disconnectHost(name: string): Promise<void> {
 export async function removePeerReference(peer: string, slug: string): Promise<void> {
   const filtered = projects.value.filter(p => !(p.peer === peer && p.slug === slug))
   await putProjects(filtered)
+}
+
+/** Remap every reference pointing at `fromPeer` onto `toPeer`, stamping
+ *  the target's stable node_id so the reference survives future
+ *  renames. Recovers references orphaned by a host rename (refs #270).
+ *  References whose slug the target already has are dropped to avoid a
+ *  duplicate. */
+export async function remapReferences(
+  fromPeer: string,
+  toPeer: string,
+  nodeId?: string,
+): Promise<void> {
+  await putProjects(remapReferenceItems(projects.value, fromPeer, toPeer, nodeId))
+}
+
+/** Drop every reference pointing at `peer` (used to clear out an
+ *  unresolved host whose references are no longer wanted). */
+export async function removeReferencesForPeer(peer: string): Promise<void> {
+  await putProjects(projects.value.filter(p => p.peer !== peer))
 }
 
 export async function updateProjects(items: ProjectItem[]): Promise<void> {

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -1114,6 +1114,41 @@ body {
   background: var(--bg-hover);
   color: var(--text);
 }
+/* Unresolved host row: referenced but matching no roster peer. (refs #270) */
+.host-row.unresolved {
+  border-left: 2px solid oklch(60% 0.13 75);
+  background: oklch(28% 0.04 75 / 0.18);
+}
+.host-unresolved-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  border-radius: 50%;
+  background: oklch(28% 0.06 75);
+  color: oklch(80% 0.14 75);
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1cap;
+}
+.host-row-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 8px;
+}
+.host-remap-select {
+  max-width: 220px;
+  cursor: pointer;
+}
+/* The remove button is always visible on an unresolved row (no hover
+   reveal): the whole row is a call to action. */
+.host-row-actions .host-remove {
+  opacity: 1;
+  border: 1px solid var(--border);
+}
 .mp-host-token {
   margin-top: 8px;
 }


### PR DESCRIPTION
Slice 5 of #270 — the recovery UX. Stacked on #274.

Adds a **"Referenced but not found"** group to Settings → Hosts — shown **at the top of the tab** so a broken reference is the first thing seen. It lists each referenced host name with no matching roster peer (renamed/removed). Each row shows the dangling name, the referencing slugs, and two actions:

- **Remap to → [roster host]** — repoints *every* reference under that name onto the picked host and **stamps the target's node_id**, so the reference survives future renames. (This is the one-click fix for the `hs → gmux-hs` situation: remap `hs` to the live host and `apps`/`home`/`chezmoi` reconnect at once.)
- **× Remove** — drops all references under that name.

No auto-guessing of the target — always a user choice (per the design discussion). The remap transform `remapReferenceItems` is a pure, tested function in `references.ts` (the store action is a thin `putProjects` wrapper over it); a remap whose slug the target already references is dropped to avoid duplicates.

**Tests:** `remapReferenceItems` — repoint-all + node_id stamp, and collision-drop. Full suite passes. Verified in the mock dev server.

Note: the *opportunistic* backfill for pre-existing name-only references is split into its own follow-up PR — auto-writing projects.json deserves focused review. (References created from the UI are stamped with node_id at creation time in the review-pass PR.)