### PR TITLE
feat(web): red pip on the settings gear when references are unresolved

### DIFF
--- a/apps/gmux-web/src/sidebar.tsx
+++ b/apps/gmux-web/src/sidebar.tsx
@@ -15,7 +15,7 @@ import {
   activityMap, projects, connState,
   updateProjects, reorderSessions,
   peerStatusByName, isSessionUnavailable, localPeerNames, sessionDotState,
-  unreadCount, localHostLabel,
+  unreadCount, localHostLabel, unresolvedHosts,
   type DotState,
 } from './store'
 import { HostSuffix } from './host-suffix'
@@ -336,6 +336,9 @@ export function Sidebar({
   // when an additional session enters the waiting state.
   const waitingCount = unreadCount.value
   const waiting = waitingCount > 0
+  // A reference points at a host that's in no roster bucket (renamed /
+  // removed): flag the gear so the user knows where the fix lives. (refs #270)
+  const hasUnresolved = unresolvedHosts.value.length > 0
   const bgArrival = useArrivalPulse(waiting ? 'unread' : 'none', waitingCount)
 
   const totalVisible = foldersVal.reduce(
@@ -366,10 +369,11 @@ export function Sidebar({
           <button
             class="sidebar-settings-btn"
             onClick={onOpenSettings}
-            aria-label="Settings"
-            title="Settings"
+            aria-label={hasUnresolved ? 'Settings (a referenced host needs attention)' : 'Settings'}
+            title={hasUnresolved ? 'A referenced host was not found — open Settings → Hosts' : 'Settings'}
           >
             <IconSettings />
+            {hasUnresolved && <span class="settings-attention-pip" aria-hidden="true" />}
           </button>
         </div>
         <div class="sidebar-scroll">

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -128,6 +128,7 @@ body {
 
 /* Settings gear, pinned opposite the logo in the header. */
 .sidebar-settings-btn {
+  position: relative;
   margin-left: auto;
   display: flex;
   align-items: center;
@@ -145,6 +146,18 @@ body {
 .sidebar-settings-btn:hover {
   color: var(--text);
   background: var(--bg-hover);
+}
+/* Attention pip: a referenced host is unresolved and needs a fix in
+   Settings -> Hosts. (refs #270) */
+.settings-attention-pip {
+  position: absolute;
+  top: 3px;
+  right: 3px;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--status-error, oklch(63% 0.2 25));
+  box-shadow: 0 0 0 2px var(--bg-sidebar, var(--bg));
 }
 
 /* Empty-state launch affordance: when there are no projects yet, the


### PR DESCRIPTION
Slice 6 of #270 — the beacon. Stacked on #275.

When at least one referenced host is unresolved (`unresolvedHosts` non-empty), the sidebar settings gear shows a small red attention pip and its tooltip/aria-label change to *"A referenced host was not found — open Settings → Hosts."* This is what tells the user *where* to go fix the silently-broken reference; it clears on its own once they remap/remove or the host reappears.

Driven entirely by the slice-3 `unresolvedHosts` signal — no new state. Verified in the mock dev server (screenshot in thread). Full suite 436 pass.

This completes the user-facing loop for #270: surfaced in the sidebar (#274) → beacon on the gear (this) → recover in the Hosts tab (#275).