### PR TITLE
refactor+test+docs: harden and document unresolved-reference recovery

### DIFF
--- a/apps/gmux-web/src/projects.test.ts
+++ b/apps/gmux-web/src/projects.test.ts
@@ -301,6 +301,37 @@ describe('buildProjectFolders', () => {
     expect(folders[0].missing).toBeUndefined()
   })
 
+  it('buckets a renamed host\'s sessions under a reference resolved by node_id', () => {
+    // The seam with resolveReferences: the reference is stored under the
+    // old name "unraid" but resolveRef maps it to the host's current
+    // name "gmux-hs". The session (stamped with the live name) must land
+    // in the folder, and the folder must carry the live name.
+    const projects: ProjectItem[] = [{ slug: 'apps', peer: 'unraid', node_id: 'node_hs' }]
+    const sessions = [
+      makeSession({ id: 's1', cwd: '/mnt/apps', peer: 'gmux-hs', project_slug: 'apps', alive: true }),
+    ]
+    const resolveRef = (peer: string, slug: string) =>
+      peer === 'unraid' && slug === 'apps' ? { effectivePeer: 'gmux-hs', resolved: true } : undefined
+    const folders = buildProjectFolders(projects, sessions, undefined, {}, resolveRef)
+    expect(folders).toHaveLength(1)
+    expect(folders[0].peer).toBe('gmux-hs')
+    expect(folders[0].unresolved).toBeUndefined()
+    expect(folders[0].sessions.map(s => s.id)).toEqual(['s1'])
+  })
+
+  it('flags an unresolved reference and takes precedence over missing', () => {
+    // resolveRef reports the host is in no roster bucket. Even though we
+    // have no peer_projects entry for it, the folder is flagged
+    // unresolved (host renamed/removed) rather than left as a plain
+    // empty reference — and unresolved is never conflated with missing.
+    const projects: ProjectItem[] = [{ slug: 'apps', peer: 'hs' }]
+    const resolveRef = () => ({ effectivePeer: 'hs', resolved: false })
+    const folders = buildProjectFolders(projects, [], undefined, {}, resolveRef)
+    expect(folders[0].unresolved).toBe(true)
+    expect(folders[0].missing).toBeUndefined()
+    expect(folders[0].peer).toBe('hs')
+  })
+
   it('keeps a local owned project and a same-slug reference as separate folders', () => {
     const projects: ProjectItem[] = [
       { slug: 'gmux', match: [{ path: '/dev/gmux' }] },

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -882,7 +882,11 @@ export async function addProject(
 export async function addPeerReference(peer: string, slug: string): Promise<void> {
   const existing = projects.value
   if (existing.some(p => p.peer === peer && p.slug === slug)) return
-  await putProjects([...existing, { peer, slug }])
+  // Stamp the peer's stable node_id at creation (when known) so the
+  // reference is rename-proof from the start: a later rename of the
+  // host follows automatically rather than orphaning it. (refs #270)
+  const node_id = peers.value.find(p => p.name === peer)?.node_id
+  await putProjects([...existing, node_id ? { peer, slug, node_id } : { peer, slug }])
 }
 
 /** Connect to a host (ADR 0007): POST /v1/peers probes the target,

--- a/apps/website/src/content/docs/multi-machine.md
+++ b/apps/website/src/content/docs/multi-machine.md
@@ -51,6 +51,18 @@ gmux probes the host, adopts the name it reports about itself (no name to assign
 
 There is no `[[peers]]` config block (removed in [ADR 0007](https://github.com/gmuxapp/gmux/blob/main/docs/adr/0007-host-identity-and-peer-urls.md)) — peers are runtime state managed from the UI.
 
+## When a referenced host is renamed
+
+A host's name is derived from Tailscale (or its OS hostname), so it can change — for example when you upgrade a machine. A project reference pins another host's project into your sidebar by name, so a rename could silently strip those projects out.
+
+To prevent that, a reference is anchored on the host's stable, opaque node ID, not just its name. References you create from the UI capture that ID immediately, so a later rename is followed automatically and the projects stay put under the new name.
+
+If gmux can't match a reference to any current host — the host was renamed before it was anchored, or removed entirely — the reference is **not** silently dropped:
+
+- The sidebar shows the project muted, with a warning marker.
+- The settings gear gets a small red pip.
+- **Settings → Hosts → Referenced but not found** lists each unmatched host with the projects pointing at it. Pick the host's current name from **Remap to…** to repoint every reference at once (this re-anchors them on the node ID, so the same rename won't break them again), or remove the references if the host is gone for good.
+
 ## Session namespacing
 
 Remote sessions carry their origin in the session ID using `@` separators:


### PR DESCRIPTION
Review pass over the #270 stack (stacked on #276).

**Hardening**
- `addPeerReference` now stamps the peer's stable `node_id` at **creation time** (when the peer is in the roster), so references made from the UI are rename-proof from the start — not only after a remap. (The opportunistic backfill for *pre-existing* name-only references remains a separate follow-up.)

**Tests** (meaningful, not padding — they cover the integration seam the unit tests don't)
- `buildProjectFolders` buckets a **renamed** host's sessions under a reference resolved by `node_id` (folder carries the live name).
- An **unresolved** reference is flagged and takes precedence over the `missing` state.

**Docs**
- `multi-machine.md` gains a "When a referenced host is renamed" section explaining node_id anchoring and the *Settings → Hosts → Referenced but not found* remap/remove recovery.

438 web tests pass.