### PR TITLE
feat: rename-proof peer references — surface & recover unresolved references (ADR 0007 follow-up)

### DIFF
--- a/apps/gmux-web/src/mock-data/index.ts
+++ b/apps/gmux-web/src/mock-data/index.ts
@@ -70,4 +70,9 @@ export const MOCK_PROJECTS: ProjectItem[] = [
       { path: '~/dev/openclaw' },
     ],
   },
+  // A resolved reference to a roster peer (server).
+  { slug: 'api', peer: 'server' },
+  // An unresolved reference: 'old-tower' is in no roster bucket, so it
+  // surfaces as a host-not-found state in the sidebar and Hosts tab.
+  { slug: 'legacy-app', peer: 'old-tower' },
 ]

--- a/apps/gmux-web/src/projects.test.ts
+++ b/apps/gmux-web/src/projects.test.ts
@@ -301,6 +301,37 @@ describe('buildProjectFolders', () => {
     expect(folders[0].missing).toBeUndefined()
   })
 
+  it('buckets a renamed host\'s sessions under a reference resolved by node_id', () => {
+    // The seam with resolveReferences: the reference is stored under the
+    // old name "unraid" but resolveRef maps it to the host's current
+    // name "gmux-hs". The session (stamped with the live name) must land
+    // in the folder, and the folder must carry the live name.
+    const projects: ProjectItem[] = [{ slug: 'apps', peer: 'unraid', node_id: 'node_hs' }]
+    const sessions = [
+      makeSession({ id: 's1', cwd: '/mnt/apps', peer: 'gmux-hs', project_slug: 'apps', alive: true }),
+    ]
+    const resolveRef = (peer: string, slug: string) =>
+      peer === 'unraid' && slug === 'apps' ? { effectivePeer: 'gmux-hs', resolved: true } : undefined
+    const folders = buildProjectFolders(projects, sessions, undefined, {}, resolveRef)
+    expect(folders).toHaveLength(1)
+    expect(folders[0].peer).toBe('gmux-hs')
+    expect(folders[0].unresolved).toBeUndefined()
+    expect(folders[0].sessions.map(s => s.id)).toEqual(['s1'])
+  })
+
+  it('flags an unresolved reference and takes precedence over missing', () => {
+    // resolveRef reports the host is in no roster bucket. Even though we
+    // have no peer_projects entry for it, the folder is flagged
+    // unresolved (host renamed/removed) rather than left as a plain
+    // empty reference — and unresolved is never conflated with missing.
+    const projects: ProjectItem[] = [{ slug: 'apps', peer: 'hs' }]
+    const resolveRef = () => ({ effectivePeer: 'hs', resolved: false })
+    const folders = buildProjectFolders(projects, [], undefined, {}, resolveRef)
+    expect(folders[0].unresolved).toBe(true)
+    expect(folders[0].missing).toBeUndefined()
+    expect(folders[0].peer).toBe('hs')
+  })
+
   it('keeps a local owned project and a same-slug reference as separate folders', () => {
     const projects: ProjectItem[] = [
       { slug: 'gmux', match: [{ path: '/dev/gmux' }] },

--- a/apps/gmux-web/src/projects.ts
+++ b/apps/gmux-web/src/projects.ts
@@ -330,6 +330,10 @@ export function buildProjectFolders(
   sessions: Session[],
   isLocalPeer?: (peerName: string) => boolean,
   peerProjects?: Record<string, { slug: string; launch_cwd?: string }[]>,
+  // Resolve a reference (by its stored peer+slug) to the live host's
+  // current name and whether it's in the roster at all. When omitted,
+  // references resolve to their stored name (legacy behavior). (refs #270)
+  resolveRef?: (peer: string, slug: string) => { effectivePeer: string; resolved: boolean } | undefined,
 ): Folder[] {
   // Bucket every stamped session by `${ownerPeer}::${slug}`.
   // ownerPeer is '' for sessions owned by the viewer (local sessions,
@@ -354,7 +358,20 @@ export function buildProjectFolders(
 
   const folders: Folder[] = []
   for (const project of projects) {
-    const ownerPeer = project.peer ?? ''
+    const storedPeer = project.peer ?? ''
+    // For references, resolve to the live host's current name (which
+    // may differ from the stored name after a rename) and learn
+    // whether the host is in the roster at all. Owned projects pass
+    // through unchanged.
+    let ownerPeer = storedPeer
+    let unresolved = false
+    if (storedPeer !== '' && resolveRef) {
+      const r = resolveRef(storedPeer, project.slug)
+      if (r) {
+        ownerPeer = r.effectivePeer
+        unresolved = !r.resolved
+      }
+    }
     const ss = buckets.get(`${ownerPeer}::${project.slug}`) ?? []
     const visible = ss.filter(s => s.alive || s.resumable === true)
     visible.sort(compareFolderSessions)
@@ -368,6 +385,10 @@ export function buildProjectFolders(
     let missing = false
     if (ownerPeer === '') {
       launchCwd = project.match?.find(r => r.path)?.path
+    } else if (unresolved) {
+      // No live host matches this reference; don't probe peer_projects
+      // for a slug under a name that isn't connected. The unresolved
+      // flag carries the state.
     } else if (peerProjects) {
       const peerEntry = peerProjects[ownerPeer]
       if (peerEntry) {
@@ -388,6 +409,7 @@ export function buildProjectFolders(
       peer: ownerPeer || undefined,
       launchCwd,
       missing: missing || undefined,
+      unresolved: unresolved || undefined,
       sessions: visible,
     })
   }

--- a/apps/gmux-web/src/references.test.ts
+++ b/apps/gmux-web/src/references.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest'
+import { resolveReferences, refKey } from './references'
+import type { PeerInfo, ProjectItem } from './types'
+
+function peer(name: string, node_id?: string): PeerInfo {
+  return { name, url: `https://${name}`, status: 'connected', session_count: 0, node_id }
+}
+function ref(peer: string, slug: string, node_id?: string): ProjectItem {
+  return { slug, peer, node_id }
+}
+function owned(slug: string): ProjectItem {
+  return { slug, match: [{ path: `/home/${slug}` }] }
+}
+
+describe('resolveReferences', () => {
+  it('resolves a legacy name-only reference and backfills its node_id', () => {
+    const projects = [ref('gmux-hs', 'apps')]
+    const roster = [peer('gmux-hs', 'node_hs')]
+    const { resolution, unresolved, backfills } = resolveReferences(projects, roster)
+    expect(resolution.get(refKey('gmux-hs', 'apps'))).toEqual({ effectivePeer: 'gmux-hs', resolved: true })
+    expect(unresolved).toEqual([])
+    expect(backfills).toEqual([{ slug: 'apps', fromPeer: 'gmux-hs', toPeer: 'gmux-hs', node_id: 'node_hs' }])
+  })
+
+  it('resolves by node_id and follows a renamed host (name drift)', () => {
+    // Reference stored "unraid" + node, host now reports "gmux-hs".
+    const projects = [ref('unraid', 'apps', 'node_hs')]
+    const roster = [peer('gmux-hs', 'node_hs')]
+    const { resolution, unresolved, backfills } = resolveReferences(projects, roster)
+    expect(resolution.get(refKey('unraid', 'apps'))).toEqual({ effectivePeer: 'gmux-hs', resolved: true })
+    expect(unresolved).toEqual([])
+    // Backfill follows the rename: update the cached display name.
+    expect(backfills).toEqual([{ slug: 'apps', fromPeer: 'unraid', toPeer: 'gmux-hs', node_id: 'node_hs' }])
+  })
+
+  it('node_id match needs no backfill when the name is unchanged', () => {
+    const projects = [ref('gmux-hs', 'apps', 'node_hs')]
+    const roster = [peer('gmux-hs', 'node_hs')]
+    const { backfills } = resolveReferences(projects, roster)
+    expect(backfills).toEqual([])
+  })
+
+  it('flags a reference whose host is in no roster bucket as unresolved', () => {
+    // The classic broken case: reference points at "hs", live host is
+    // "unraid"/"gmux-hs" — no roster peer named "hs".
+    const projects = [ref('hs', 'apps'), ref('hs', 'home'), ref('hs', 'chezmoi')]
+    const roster = [peer('unraid', 'node_hs'), peer('ft', 'node_ft')]
+    const { resolution, unresolved, backfills } = resolveReferences(projects, roster)
+    expect(resolution.get(refKey('hs', 'apps'))).toEqual({ effectivePeer: 'hs', resolved: false })
+    expect(backfills).toEqual([])
+    expect(unresolved).toEqual([{ name: 'hs', slugs: ['apps', 'home', 'chezmoi'] }])
+  })
+
+  it('treats an offline-but-known host (no node_id) as resolved, not unresolved', () => {
+    // Offline tailnet peers are in the roster without a node_id.
+    const projects = [ref('bespin', 'home')]
+    const roster: PeerInfo[] = [{ name: 'bespin', url: 'https://bespin', status: 'offline', session_count: 0 }]
+    const { resolution, unresolved, backfills } = resolveReferences(projects, roster)
+    expect(resolution.get(refKey('bespin', 'home'))).toEqual({ effectivePeer: 'bespin', resolved: true })
+    expect(unresolved).toEqual([])
+    expect(backfills).toEqual([]) // nothing to stamp; offline peer has no node_id
+  })
+
+  it('falls back to name and refreshes a stale node_id', () => {
+    // node_id was stamped, but that host is gone; another host now has
+    // the referenced name. Resolve by name rather than orphaning, and
+    // backfill the *current* node_id so the stale one doesn't linger
+    // (otherwise every load repeats the failed-id-then-name dance).
+    const projects = [ref('shared', 'proj', 'node_gone')]
+    const roster = [peer('shared', 'node_new')]
+    const { resolution, unresolved, backfills } = resolveReferences(projects, roster)
+    expect(resolution.get(refKey('shared', 'proj'))).toEqual({ effectivePeer: 'shared', resolved: true })
+    expect(unresolved).toEqual([])
+    expect(backfills).toEqual([{ slug: 'proj', fromPeer: 'shared', toPeer: 'shared', node_id: 'node_new' }])
+  })
+
+  it('ignores owned projects entirely', () => {
+    const projects = [owned('gmux'), ref('hs', 'apps')]
+    const roster: PeerInfo[] = []
+    const { resolution, unresolved } = resolveReferences(projects, roster)
+    expect(resolution.has(refKey('', 'gmux'))).toBe(false)
+    expect(unresolved).toEqual([{ name: 'hs', slugs: ['apps'] }])
+  })
+
+  it('groups multiple unresolved hosts independently', () => {
+    const projects = [ref('hs', 'apps'), ref('old-laptop', 'dots'), ref('hs', 'home')]
+    const { unresolved } = resolveReferences(projects, [])
+    expect(unresolved).toContainEqual({ name: 'hs', slugs: ['apps', 'home'] })
+    expect(unresolved).toContainEqual({ name: 'old-laptop', slugs: ['dots'] })
+    expect(unresolved).toHaveLength(2)
+  })
+})

--- a/apps/gmux-web/src/references.test.ts
+++ b/apps/gmux-web/src/references.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { resolveReferences, refKey } from './references'
+import { resolveReferences, remapReferenceItems, refKey } from './references'
 import type { PeerInfo, ProjectItem } from './types'
 
 function peer(name: string, node_id?: string): PeerInfo {
@@ -88,5 +88,42 @@ describe('resolveReferences', () => {
     expect(unresolved).toContainEqual({ name: 'hs', slugs: ['apps', 'home'] })
     expect(unresolved).toContainEqual({ name: 'old-laptop', slugs: ['dots'] })
     expect(unresolved).toHaveLength(2)
+  })
+})
+
+describe('remapReferenceItems', () => {
+  it('repoints all references from one host to another and stamps node_id', () => {
+    const items = [owned('gmux'), ref('hs', 'apps'), ref('hs', 'home'), ref('ft', 'dots')]
+    const next = remapReferenceItems(items, 'hs', 'gmux-hs', 'node_hs')
+    expect(next).toEqual([
+      owned('gmux'),
+      { slug: 'apps', peer: 'gmux-hs', node_id: 'node_hs' },
+      { slug: 'home', peer: 'gmux-hs', node_id: 'node_hs' },
+      ref('ft', 'dots'), // untouched
+    ])
+  })
+
+  it('clears a stale node_id when the remap target has no node_id', () => {
+    // Source references carry a stale node_id from the original host;
+    // the target (offline/legacy) has none. The stale id must be
+    // cleared, not preserved — keeping it would let the old host
+    // silently re-claim the reference if it came back.
+    const items = [ref('hs', 'apps', 'stale_node'), ref('hs', 'home', 'stale_node')]
+    const next = remapReferenceItems(items, 'hs', 'gmux-hs', undefined)
+    expect(next).toEqual([
+      { slug: 'apps', peer: 'gmux-hs', node_id: undefined },
+      { slug: 'home', peer: 'gmux-hs', node_id: undefined },
+    ])
+  })
+
+  it('drops a remapped reference whose slug the target already has', () => {
+    const items = [ref('gmux-hs', 'apps', 'node_hs'), ref('hs', 'apps'), ref('hs', 'home')]
+    const next = remapReferenceItems(items, 'hs', 'gmux-hs', 'node_hs')
+    // hs/apps collides with the existing gmux-hs/apps and is dropped;
+    // hs/home is remapped.
+    expect(next).toEqual([
+      ref('gmux-hs', 'apps', 'node_hs'),
+      { slug: 'home', peer: 'gmux-hs', node_id: 'node_hs' },
+    ])
   })
 })

--- a/apps/gmux-web/src/references.test.ts
+++ b/apps/gmux-web/src/references.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { resolveReferences, remapReferenceItems, refKey } from './references'
+import { resolveReferences, remapReferenceItems, removeReferenceItems, refKey } from './references'
 import type { PeerInfo, ProjectItem } from './types'
 
 function peer(name: string, node_id?: string): PeerInfo {
@@ -92,9 +92,9 @@ describe('resolveReferences', () => {
 })
 
 describe('remapReferenceItems', () => {
-  it('repoints all references from one host to another and stamps node_id', () => {
+  it('repoints the named references from one host to another and stamps node_id', () => {
     const items = [owned('gmux'), ref('hs', 'apps'), ref('hs', 'home'), ref('ft', 'dots')]
-    const next = remapReferenceItems(items, 'hs', 'gmux-hs', 'node_hs')
+    const next = remapReferenceItems(items, 'hs', ['apps', 'home'], 'gmux-hs', 'node_hs')
     expect(next).toEqual([
       owned('gmux'),
       { slug: 'apps', peer: 'gmux-hs', node_id: 'node_hs' },
@@ -103,13 +103,29 @@ describe('remapReferenceItems', () => {
     ])
   })
 
+  it('does not touch a same-named reference outside the slug scope', () => {
+    // Data-loss guard: during a rename transition a stored name can be
+    // shared by an unresolved reference (in scope) and one already
+    // resolving via node_id (out of scope). Only the scoped slug moves.
+    const items = [
+      ref('hs', 'apps', 'node_hs'), // resolves via node_id; NOT in scope
+      ref('hs', 'legacy'),          // unresolved; in scope
+    ]
+    const next = remapReferenceItems(items, 'hs', ['legacy'], 'gmux-hs', 'node_hs')
+    expect(next).toEqual([
+      ref('hs', 'apps', 'node_hs'),
+      { slug: 'legacy', peer: 'gmux-hs', node_id: 'node_hs' },
+    ])
+  })
+
+  it('is a no-op when fromPeer equals toPeer (never wipes references)', () => {
+    const items = [ref('hs', 'apps', 'node_hs'), ref('hs', 'home', 'node_hs'), owned('gmux')]
+    expect(remapReferenceItems(items, 'hs', ['apps', 'home'], 'hs', 'node_hs')).toEqual(items)
+  })
+
   it('clears a stale node_id when the remap target has no node_id', () => {
-    // Source references carry a stale node_id from the original host;
-    // the target (offline/legacy) has none. The stale id must be
-    // cleared, not preserved — keeping it would let the old host
-    // silently re-claim the reference if it came back.
     const items = [ref('hs', 'apps', 'stale_node'), ref('hs', 'home', 'stale_node')]
-    const next = remapReferenceItems(items, 'hs', 'gmux-hs', undefined)
+    const next = remapReferenceItems(items, 'hs', ['apps', 'home'], 'gmux-hs', undefined)
     expect(next).toEqual([
       { slug: 'apps', peer: 'gmux-hs', node_id: undefined },
       { slug: 'home', peer: 'gmux-hs', node_id: undefined },
@@ -118,12 +134,24 @@ describe('remapReferenceItems', () => {
 
   it('drops a remapped reference whose slug the target already has', () => {
     const items = [ref('gmux-hs', 'apps', 'node_hs'), ref('hs', 'apps'), ref('hs', 'home')]
-    const next = remapReferenceItems(items, 'hs', 'gmux-hs', 'node_hs')
-    // hs/apps collides with the existing gmux-hs/apps and is dropped;
-    // hs/home is remapped.
+    const next = remapReferenceItems(items, 'hs', ['apps', 'home'], 'gmux-hs', 'node_hs')
     expect(next).toEqual([
       ref('gmux-hs', 'apps', 'node_hs'),
       { slug: 'home', peer: 'gmux-hs', node_id: 'node_hs' },
     ])
+  })
+})
+
+describe('removeReferenceItems', () => {
+  it('removes only the named references for the host', () => {
+    const items = [owned('gmux'), ref('hs', 'apps'), ref('hs', 'home'), ref('ft', 'dots')]
+    expect(removeReferenceItems(items, 'hs', ['apps', 'home'])).toEqual([owned('gmux'), ref('ft', 'dots')])
+  })
+
+  it('keeps a same-named reference that resolves via node_id (outside scope)', () => {
+    // The data-loss path Greptile caught: removing the unresolved
+    // "legacy" slug must not delete the working node_id-anchored "apps".
+    const items = [ref('hs', 'apps', 'node_hs'), ref('hs', 'legacy')]
+    expect(removeReferenceItems(items, 'hs', ['legacy'])).toEqual([ref('hs', 'apps', 'node_hs')])
   })
 })

--- a/apps/gmux-web/src/references.ts
+++ b/apps/gmux-web/src/references.ts
@@ -1,0 +1,137 @@
+// --- Peer reference resolution (refs #270) ---
+//
+// A reference item in projects.json points at a project owned by
+// another host. It stores the host's display `peer` name and,
+// optionally, the host's stable opaque `node_id` (ADR 0007). Because
+// ADR 0007 derives a host's name from Tailscale / the OS hostname, that
+// name can change on upgrade — so resolving a reference purely by name
+// breaks silently when a host is renamed.
+//
+// `resolveReferences` is the single source of truth for "which live
+// host (if any) does this reference point at, and under what current
+// name." Every surface — the sidebar folders, the Hosts tab, the
+// settings gear pip — reads off its output so they all agree.
+//
+// Resolution order, per reference:
+//   1. by node_id — if the reference has a node_id and a roster peer
+//      reports the same one, it resolves to that peer's *current* name
+//      (the display name follows the live host across renames).
+//   2. by name — legacy references with no node_id (or whose node_id
+//      matches no live peer) fall back to matching the stored name. A
+//      name match against a peer that has a node_id yields a backfill,
+//      so the reference becomes rename-proof going forward.
+//   3. unresolved — no roster peer matches by id or name. The host
+//      isn't on the tailnet (online or offline), manually added, or a
+//      devcontainer; it may have been renamed or removed.
+
+import type { PeerInfo, ProjectItem } from './types'
+
+/** Composite key for a reference, by its stored (peer, slug). */
+export function refKey(peer: string, slug: string): string {
+  return `${peer}\u0000${slug}`
+}
+
+export interface RefResolution {
+  /** Peer name to bucket sessions under and label the folder with.
+   *  Equals the live host's current name when resolved by node_id. */
+  effectivePeer: string
+  /** True when the reference points at a host in the current roster. */
+  resolved: boolean
+}
+
+/** A referenced host name that matches no roster peer, with the slugs
+ *  that point at it. One entry per distinct unresolved name. */
+export interface UnresolvedHost {
+  name: string
+  slugs: string[]
+}
+
+/** A projects.json write needed to make a reference rename-proof:
+ *  stamp `node_id` (and follow a drifted display name). The writer
+ *  finds the item by (fromPeer, slug) and rewrites it to
+ *  { peer: toPeer, node_id }. */
+export interface RefBackfill {
+  slug: string
+  fromPeer: string
+  toPeer: string
+  node_id: string
+}
+
+export interface ResolvedReferences {
+  /** Per-reference resolution, keyed by refKey(item.peer, item.slug). */
+  resolution: Map<string, RefResolution>
+  /** Distinct referenced host names not present in the roster. */
+  unresolved: UnresolvedHost[]
+  /** Opportunistic projects.json updates (stamp node_id / follow rename). */
+  backfills: RefBackfill[]
+}
+
+/**
+ * Resolve every reference item in `projects` against the live peer
+ * `roster`. Owned items (no `peer`) are ignored. Pure: no I/O, no
+ * signals — callers feed it the current projects + peers and act on
+ * the result.
+ */
+export function resolveReferences(
+  projects: readonly ProjectItem[],
+  roster: readonly PeerInfo[],
+): ResolvedReferences {
+  const byNodeId = new Map<string, PeerInfo>()
+  const byName = new Map<string, PeerInfo>()
+  for (const p of roster) {
+    if (p.node_id) byNodeId.set(p.node_id, p)
+    byName.set(p.name, p)
+  }
+
+  const resolution = new Map<string, RefResolution>()
+  const unresolvedMap = new Map<string, string[]>()
+  const backfills: RefBackfill[] = []
+
+  for (const item of projects) {
+    if (!item.peer) continue // owned project, not a reference
+    const key = refKey(item.peer, item.slug)
+
+    // 1. node_id anchor: the durable identity. The live host's current
+    //    name wins, so a renamed host stays linked.
+    if (item.node_id) {
+      const live = byNodeId.get(item.node_id)
+      if (live) {
+        resolution.set(key, { effectivePeer: live.name, resolved: true })
+        if (live.name !== item.peer) {
+          // Host was renamed; follow it and refresh the cached name.
+          backfills.push({ slug: item.slug, fromPeer: item.peer, toPeer: live.name, node_id: item.node_id })
+        }
+        continue
+      }
+      // node_id set but no live peer reports it (host offline and never
+      // re-probed, or gone) — fall through to a name match.
+    }
+
+    // 2. name match: legacy references, or a reference whose stored
+    //    node_id matched no live peer (host gone / replaced). Stamp the
+    //    matched peer's node_id whenever it differs from what's stored
+    //    — covering both the never-stamped case and refreshing a stale
+    //    node_id — so the reference is (re)made rename-proof rather than
+    //    repeating the failed-id-then-name dance on every load.
+    const named = byName.get(item.peer)
+    if (named) {
+      resolution.set(key, { effectivePeer: item.peer, resolved: true })
+      if (named.node_id && named.node_id !== item.node_id) {
+        backfills.push({ slug: item.slug, fromPeer: item.peer, toPeer: item.peer, node_id: named.node_id })
+      }
+      continue
+    }
+
+    // 3. unresolved: no live host matches. Keep the dangling name for
+    //    the folder label; the surface flags it.
+    resolution.set(key, { effectivePeer: item.peer, resolved: false })
+    const slugs = unresolvedMap.get(item.peer) ?? []
+    slugs.push(item.slug)
+    unresolvedMap.set(item.peer, slugs)
+  }
+
+  const unresolved: UnresolvedHost[] = []
+  for (const [name, slugs] of unresolvedMap) unresolved.push({ name, slugs })
+
+  return { resolution, unresolved, backfills }
+}

--- a/apps/gmux-web/src/references.ts
+++ b/apps/gmux-web/src/references.ts
@@ -135,3 +135,34 @@ export function resolveReferences(
 
   return { resolution, unresolved, backfills }
 }
+
+/**
+ * Rewrite every reference pointing at `fromPeer` to point at `toPeer`,
+ * stamping the target's `nodeId` so it survives future renames. Pure:
+ * returns a new items array; the caller persists it. A reference whose
+ * slug `toPeer` already references is dropped (the target wins) so the
+ * result has no duplicate (peer, slug). Used to recover references
+ * orphaned by a host rename. (refs #270)
+ *
+ * The remapped reference takes the target's `nodeId` verbatim — if the
+ * target has none (offline/legacy peer), the reference's node_id is
+ * *cleared*, never left pointing at the old host's id (which would let
+ * the old host silently re-claim the reference if it reappeared).
+ */
+export function remapReferenceItems(
+  items: readonly ProjectItem[],
+  fromPeer: string,
+  toPeer: string,
+  nodeId?: string,
+): ProjectItem[] {
+  const targetSlugs = new Set(
+    items.filter(p => p.peer === toPeer).map(p => p.slug),
+  )
+  const next: ProjectItem[] = []
+  for (const it of items) {
+    if (it.peer !== fromPeer) { next.push(it); continue }
+    if (targetSlugs.has(it.slug)) continue // target already references this slug
+    next.push({ ...it, peer: toPeer, node_id: nodeId })
+  }
+  return next
+}

--- a/apps/gmux-web/src/references.ts
+++ b/apps/gmux-web/src/references.ts
@@ -79,6 +79,11 @@ export function resolveReferences(
   const byNodeId = new Map<string, PeerInfo>()
   const byName = new Map<string, PeerInfo>()
   for (const p of roster) {
+    // Last-write-wins if two roster entries report the same node_id
+    // (the duplicate-entry case — see the discovery-dedup follow-up).
+    // Resolution stays correct (both names are the same physical node),
+    // but which display name a reference resolves to then depends on
+    // roster order. Deduping the roster upstream removes the ambiguity.
     if (p.node_id) byNodeId.set(p.node_id, p)
     byName.set(p.name, p)
   }
@@ -108,11 +113,13 @@ export function resolveReferences(
     }
 
     // 2. name match: legacy references, or a reference whose stored
-    //    node_id matched no live peer (host gone / replaced). Stamp the
-    //    matched peer's node_id whenever it differs from what's stored
-    //    — covering both the never-stamped case and refreshing a stale
-    //    node_id — so the reference is (re)made rename-proof rather than
-    //    repeating the failed-id-then-name dance on every load.
+    //    node_id matched no live peer (host gone / replaced). When the
+    //    matched peer's node_id differs from what's stored — covering
+    //    both the never-stamped and the stale cases — record a backfill
+    //    so the (deferred) backfill writer can refresh projects.json.
+    //    Resolution is already correct here; until that writer lands the
+    //    refreshed id isn't persisted, so the id-then-name fallback
+    //    recurs harmlessly on each load.
     const named = byName.get(item.peer)
     if (named) {
       resolution.set(key, { effectivePeer: item.peer, resolved: true })
@@ -137,32 +144,61 @@ export function resolveReferences(
 }
 
 /**
- * Rewrite every reference pointing at `fromPeer` to point at `toPeer`,
- * stamping the target's `nodeId` so it survives future renames. Pure:
- * returns a new items array; the caller persists it. A reference whose
- * slug `toPeer` already references is dropped (the target wins) so the
- * result has no duplicate (peer, slug). Used to recover references
- * orphaned by a host rename. (refs #270)
+ * Rewrite the references `(fromPeer, slug)` for `slug` in `slugs` to
+ * point at `toPeer`, stamping the target's `nodeId`. Pure: returns a
+ * new items array; the caller persists it.
  *
- * The remapped reference takes the target's `nodeId` verbatim — if the
- * target has none (offline/legacy peer), the reference's node_id is
- * *cleared*, never left pointing at the old host's id (which would let
- * the old host silently re-claim the reference if it reappeared).
+ * Scoping to `slugs` (the *unresolved* slugs the UI surfaced for this
+ * host) is critical: a stored peer name can be shared by both an
+ * unresolved reference and one that already resolves correctly via
+ * node_id during a rename transition. Matching by name alone would
+ * silently move the working reference too. Only the named slugs are
+ * touched. (refs #270)
+ *
+ * A reference whose slug `toPeer` already references is dropped (the
+ * target wins) so the result has no duplicate (peer, slug). The
+ * remapped reference takes the target's `nodeId` verbatim — if the
+ * target has none (offline/legacy peer), the node_id is *cleared*,
+ * never left pointing at the old host's id (which would let the old
+ * host silently re-claim the reference if it reappeared).
  */
 export function remapReferenceItems(
   items: readonly ProjectItem[],
   fromPeer: string,
+  slugs: readonly string[],
   toPeer: string,
   nodeId?: string,
 ): ProjectItem[] {
+  // No-op remap (same source and target): without this guard every
+  // matching item would collide with itself in targetSlugs below and be
+  // dropped, silently wiping the references. Not reachable from the UI
+  // (you remap an unresolved host to a *different* live one) but a
+  // footgun for any future caller.
+  if (fromPeer === toPeer) return items.slice()
+  const scope = new Set(slugs)
   const targetSlugs = new Set(
     items.filter(p => p.peer === toPeer).map(p => p.slug),
   )
   const next: ProjectItem[] = []
   for (const it of items) {
-    if (it.peer !== fromPeer) { next.push(it); continue }
+    if (it.peer !== fromPeer || !scope.has(it.slug)) { next.push(it); continue }
     if (targetSlugs.has(it.slug)) continue // target already references this slug
     next.push({ ...it, peer: toPeer, node_id: nodeId })
   }
   return next
+}
+
+/**
+ * Remove the references `(peer, slug)` for `slug` in `slugs`. Pure:
+ * returns a new items array. Like the remap above, scoping to the
+ * surfaced unresolved `slugs` is what prevents deleting a same-named
+ * reference that's actually resolving correctly via node_id. (refs #270)
+ */
+export function removeReferenceItems(
+  items: readonly ProjectItem[],
+  peer: string,
+  slugs: readonly string[],
+): ProjectItem[] {
+  const scope = new Set(slugs)
+  return items.filter(p => !(p.peer === peer && scope.has(p.slug)))
 }

--- a/apps/gmux-web/src/settings.tsx
+++ b/apps/gmux-web/src/settings.tsx
@@ -20,9 +20,11 @@ import {
   addProject, addPeerReference, folders, updateProjects,
   removeProject, removePeerReference, localHostLabel,
   health, peers, sessions, connectHost, disconnectHost,
+  unresolvedHosts, remapReferences, removeReferencesForPeer,
 } from './store'
 import { HostSuffix } from './host-suffix'
 import type { ProjectItem, DiscoveredProject, MatchRule, Folder, PeerInfo } from './types'
+import type { UnresolvedHost } from './references'
 
 type SettingsTab = 'projects' | 'hosts'
 
@@ -354,6 +356,21 @@ function HostsTab() {
 
   return (
     <>
+      {/* Surfaced first so a broken reference is the first thing seen. */}
+      {unresolvedHosts.value.length > 0 && (
+        <section class="mp-section">
+          <div class="mp-section-label">Referenced but not found</div>
+          <div class="mp-path-hint" style="margin-bottom:8px">
+            These hosts are referenced by your projects but aren't on your tailnet or manually added. They may have been renamed or removed. Remap each to a current host, or remove its references.
+          </div>
+          <div class="host-list">
+            {unresolvedHosts.value.map(u => (
+              <UnresolvedHostRow key={u.name} host={u} targets={peersVal} />
+            ))}
+          </div>
+        </section>
+      )}
+
       <section class="mp-section">
         <div class="mp-section-label">This host</div>
         <div class="host-list">
@@ -425,6 +442,64 @@ function HostsTab() {
         )}
       </section>
     </>
+  )
+}
+
+/** A host that projects reference but that matches no current peer
+ *  (renamed or removed). Offers a one-click remap onto a roster host
+ *  — stamping the target's node_id so it survives future renames —
+ *  and a remove that drops all its references. (refs #270) */
+function UnresolvedHostRow({ host, targets }: { host: UnresolvedHost; targets: PeerInfo[] }) {
+  const [busy, setBusy] = useState(false)
+  const [err, setErr] = useState('')
+
+  const onRemap = useCallback(async (e: Event) => {
+    const sel = e.target as HTMLSelectElement
+    const toName = sel.value
+    if (!toName) return
+    const target = targets.find(t => t.name === toName)
+    setBusy(true); setErr('')
+    try {
+      await remapReferences(host.name, toName, target?.node_id)
+    } catch (e) {
+      // Reset to the placeholder so re-picking the same target fires
+      // onChange again (otherwise the user must choose a different
+      // option before they can retry).
+      sel.value = ''
+      setErr(e instanceof Error ? e.message : 'Could not remap.')
+    } finally {
+      setBusy(false)
+    }
+  }, [host.name, targets])
+
+  const onRemove = useCallback(async () => {
+    setBusy(true); setErr('')
+    try {
+      await removeReferencesForPeer(host.name)
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : 'Could not remove.')
+    } finally {
+      setBusy(false)
+    }
+  }, [host.name])
+
+  const count = host.slugs.length
+  return (
+    <div class="host-row unresolved">
+      <div class="host-row-main">
+        <span class="host-unresolved-icon" title="Host not found">!</span>
+        <span class="host-name">{host.name}</span>
+        <span class="host-meta">{count} reference{count === 1 ? '' : 's'}: {host.slugs.join(', ')}</span>
+      </div>
+      <div class="host-row-actions">
+        <select class="mp-filter-input host-remap-select" disabled={busy} onChange={onRemap}>
+          <option value="">Remap to…</option>
+          {targets.map(t => <option key={t.name} value={t.name}>{t.name}</option>)}
+        </select>
+        <button class="host-remove" disabled={busy} title="Remove these references" onClick={onRemove}>×</button>
+      </div>
+      {err && <div class="mp-manual-error">{err}</div>}
+    </div>
   )
 }
 

--- a/apps/gmux-web/src/settings.tsx
+++ b/apps/gmux-web/src/settings.tsx
@@ -20,7 +20,7 @@ import {
   addProject, addPeerReference, folders, updateProjects,
   removeProject, removePeerReference, localHostLabel,
   health, peers, sessions, connectHost, disconnectHost,
-  unresolvedHosts, remapReferences, removeReferencesForPeer,
+  unresolvedHosts, remapReferences, removeReferences,
 } from './store'
 import { HostSuffix } from './host-suffix'
 import type { ProjectItem, DiscoveredProject, MatchRule, Folder, PeerInfo } from './types'
@@ -460,7 +460,7 @@ function UnresolvedHostRow({ host, targets }: { host: UnresolvedHost; targets: P
     const target = targets.find(t => t.name === toName)
     setBusy(true); setErr('')
     try {
-      await remapReferences(host.name, toName, target?.node_id)
+      await remapReferences(host.name, host.slugs, toName, target?.node_id)
     } catch (e) {
       // Reset to the placeholder so re-picking the same target fires
       // onChange again (otherwise the user must choose a different
@@ -475,7 +475,7 @@ function UnresolvedHostRow({ host, targets }: { host: UnresolvedHost; targets: P
   const onRemove = useCallback(async () => {
     setBusy(true); setErr('')
     try {
-      await removeReferencesForPeer(host.name)
+      await removeReferences(host.name, host.slugs)
     } catch (e) {
       setErr(e instanceof Error ? e.message : 'Could not remove.')
     } finally {

--- a/apps/gmux-web/src/sidebar.tsx
+++ b/apps/gmux-web/src/sidebar.tsx
@@ -256,9 +256,11 @@ function FolderGroup({
     <div class="folder">
       <div class="folder-header">
         <a
-          class={`folder-name${isCurrent ? ' current' : ''}${folder.missing ? ' missing' : ''}`}
+          class={`folder-name${isCurrent ? ' current' : ''}${folder.missing ? ' missing' : ''}${folder.unresolved ? ' unresolved' : ''}`}
           href={href}
-          title={folder.missing
+          title={folder.unresolved
+            ? `Host “${folder.peer}” isn't on your tailnet or manually added — it may have been renamed or removed. Open Settings → Hosts to remap or remove it.`
+            : folder.missing
             ? `${folder.name} no longer exists on ${folder.peer}; remove via the home page`
             : `Open ${folder.name} hub`}
           onClick={onClick}
@@ -266,14 +268,19 @@ function FolderGroup({
           {folder.name}
           <HostSuffix peer={folder.peer ?? localHostLabel.value} local={!folder.peer} />
           {folder.missing && <span class="folder-missing-icon" title="Project missing on peer">?</span>}
+          {folder.unresolved && (
+            <span class="folder-unresolved-icon" title="Host not found — fix in Settings → Hosts">!</span>
+          )}
         </a>
-        <LaunchButton
-          sessions={folder.sessions}
-          selectedId={selId}
-          fallbackCwd={folder.launchCwd ?? ''}
-          peer={folder.peer}
-          className="folder-launch-btn"
-        />
+        {!folder.unresolved && (
+          <LaunchButton
+            sessions={folder.sessions}
+            selectedId={selId}
+            fallbackCwd={folder.launchCwd ?? ''}
+            peer={folder.peer}
+            className="folder-launch-btn"
+          />
+        )}
       </div>
       <div class="folder-sessions">
         {displayItems.map((s, i) => (

--- a/apps/gmux-web/src/sidebar.tsx
+++ b/apps/gmux-web/src/sidebar.tsx
@@ -15,7 +15,7 @@ import {
   activityMap, projects, connState,
   updateProjects, reorderSessions,
   peerStatusByName, isSessionUnavailable, localPeerNames, sessionDotState,
-  unreadCount, localHostLabel,
+  unreadCount, localHostLabel, unresolvedHosts,
   type DotState,
 } from './store'
 import { HostSuffix } from './host-suffix'
@@ -336,6 +336,9 @@ export function Sidebar({
   // when an additional session enters the waiting state.
   const waitingCount = unreadCount.value
   const waiting = waitingCount > 0
+  // A reference points at a host that's in no roster bucket (renamed /
+  // removed): flag the gear so the user knows where the fix lives. (refs #270)
+  const hasUnresolved = unresolvedHosts.value.length > 0
   const bgArrival = useArrivalPulse(waiting ? 'unread' : 'none', waitingCount)
 
   const totalVisible = foldersVal.reduce(
@@ -366,10 +369,11 @@ export function Sidebar({
           <button
             class="sidebar-settings-btn"
             onClick={onOpenSettings}
-            aria-label="Settings"
-            title="Settings"
+            aria-label={hasUnresolved ? 'Settings (a referenced host needs attention)' : 'Settings'}
+            title={hasUnresolved ? 'A referenced host was not found — open Settings → Hosts' : 'Settings'}
           >
             <IconSettings />
+            {hasUnresolved && <span class="settings-attention-pip" aria-hidden="true" />}
           </button>
         </div>
         <div class="sidebar-scroll">

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -19,7 +19,7 @@ import type { View } from './routing'
 import { resolveViewFromPath, viewToPath } from './routing'
 import { navigateWithReload } from './version-watch'
 import { buildProjectFolders, discoverProjects } from './projects'
-import { resolveReferences, remapReferenceItems, refKey, type UnresolvedHost } from './references'
+import { resolveReferences, remapReferenceItems, removeReferenceItems, refKey, type UnresolvedHost } from './references'
 
 import { fetchFrontendConfig, buildTerminalOptions, resolveKeybinds, type ResolvedKeybind } from './config'
 import { MOCK_SESSIONS, MOCK_PROJECTS, MOCK_PEERS, MOCK_HEALTH } from './mock-data/index'
@@ -933,16 +933,18 @@ export async function removePeerReference(peer: string, slug: string): Promise<v
  *  duplicate. */
 export async function remapReferences(
   fromPeer: string,
+  slugs: readonly string[],
   toPeer: string,
   nodeId?: string,
 ): Promise<void> {
-  await putProjects(remapReferenceItems(projects.value, fromPeer, toPeer, nodeId))
+  await putProjects(remapReferenceItems(projects.value, fromPeer, slugs, toPeer, nodeId))
 }
 
-/** Drop every reference pointing at `peer` (used to clear out an
- *  unresolved host whose references are no longer wanted). */
-export async function removeReferencesForPeer(peer: string): Promise<void> {
-  await putProjects(projects.value.filter(p => p.peer !== peer))
+/** Drop the unresolved references `(peer, slug)` for the given slugs.
+ *  Scoped to the surfaced slugs so a same-named reference that still
+ *  resolves correctly (via node_id) is never deleted. */
+export async function removeReferences(peer: string, slugs: readonly string[]): Promise<void> {
+  await putProjects(removeReferenceItems(projects.value, peer, slugs))
 }
 
 export async function updateProjects(items: ProjectItem[]): Promise<void> {

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -19,7 +19,7 @@ import type { View } from './routing'
 import { resolveViewFromPath, viewToPath } from './routing'
 import { navigateWithReload } from './version-watch'
 import { buildProjectFolders, discoverProjects } from './projects'
-import { resolveReferences, refKey, type UnresolvedHost } from './references'
+import { resolveReferences, remapReferenceItems, refKey, type UnresolvedHost } from './references'
 
 import { fetchFrontendConfig, buildTerminalOptions, resolveKeybinds, type ResolvedKeybind } from './config'
 import { MOCK_SESSIONS, MOCK_PROJECTS, MOCK_PEERS, MOCK_HEALTH } from './mock-data/index'
@@ -920,6 +920,25 @@ export async function disconnectHost(name: string): Promise<void> {
 export async function removePeerReference(peer: string, slug: string): Promise<void> {
   const filtered = projects.value.filter(p => !(p.peer === peer && p.slug === slug))
   await putProjects(filtered)
+}
+
+/** Remap every reference pointing at `fromPeer` onto `toPeer`, stamping
+ *  the target's stable node_id so the reference survives future
+ *  renames. Recovers references orphaned by a host rename (refs #270).
+ *  References whose slug the target already has are dropped to avoid a
+ *  duplicate. */
+export async function remapReferences(
+  fromPeer: string,
+  toPeer: string,
+  nodeId?: string,
+): Promise<void> {
+  await putProjects(remapReferenceItems(projects.value, fromPeer, toPeer, nodeId))
+}
+
+/** Drop every reference pointing at `peer` (used to clear out an
+ *  unresolved host whose references are no longer wanted). */
+export async function removeReferencesForPeer(peer: string): Promise<void> {
+  await putProjects(projects.value.filter(p => p.peer !== peer))
 }
 
 export async function updateProjects(items: ProjectItem[]): Promise<void> {

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -882,7 +882,11 @@ export async function addProject(
 export async function addPeerReference(peer: string, slug: string): Promise<void> {
   const existing = projects.value
   if (existing.some(p => p.peer === peer && p.slug === slug)) return
-  await putProjects([...existing, { peer, slug }])
+  // Stamp the peer's stable node_id at creation (when known) so the
+  // reference is rename-proof from the start: a later rename of the
+  // host follows automatically rather than orphaning it. (refs #270)
+  const node_id = peers.value.find(p => p.name === peer)?.node_id
+  await putProjects([...existing, node_id ? { peer, slug, node_id } : { peer, slug }])
 }
 
 /** Connect to a host (ADR 0007): POST /v1/peers probes the target,

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -19,6 +19,7 @@ import type { View } from './routing'
 import { resolveViewFromPath, viewToPath } from './routing'
 import { navigateWithReload } from './version-watch'
 import { buildProjectFolders, discoverProjects } from './projects'
+import { resolveReferences, refKey, type UnresolvedHost } from './references'
 
 import { fetchFrontendConfig, buildTerminalOptions, resolveKeybinds, type ResolvedKeybind } from './config'
 import { MOCK_SESSIONS, MOCK_PROJECTS, MOCK_PEERS, MOCK_HEALTH } from './mock-data/index'
@@ -408,12 +409,27 @@ export const localPeerNames = computed<ReadonlySet<string>>(() => {
 })
 
 /** Project folders for the sidebar, built from projects + sessions. */
+/** Reference resolution against the live roster: maps each reference
+ *  to the host's current name (rename-proof via node_id) or flags it
+ *  unresolved. Single source of truth for folders, the Hosts tab, and
+ *  the gear pip. (refs #270) */
+export const resolvedReferences = computed(() =>
+  resolveReferences(projects.value, peers.value),
+)
+
+/** Distinct referenced host names that match no roster peer. Drives
+ *  the Hosts-tab "Referenced but not found" group and the gear pip. */
+export const unresolvedHosts = computed<UnresolvedHost[]>(
+  () => resolvedReferences.value.unresolved,
+)
+
 export const folders = computed(() =>
   buildProjectFolders(
     projects.value,
     filteredSessions.value,
     (name) => localPeerNames.value.has(name),
     _rawWorld.value.peerProjects,
+    (peer, slug) => resolvedReferences.value.resolution.get(refKey(peer, slug)),
   ),
 )
 

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -1114,6 +1114,41 @@ body {
   background: var(--bg-hover);
   color: var(--text);
 }
+/* Unresolved host row: referenced but matching no roster peer. (refs #270) */
+.host-row.unresolved {
+  border-left: 2px solid oklch(60% 0.13 75);
+  background: oklch(28% 0.04 75 / 0.18);
+}
+.host-unresolved-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  border-radius: 50%;
+  background: oklch(28% 0.06 75);
+  color: oklch(80% 0.14 75);
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1cap;
+}
+.host-row-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 8px;
+}
+.host-remap-select {
+  max-width: 220px;
+  cursor: pointer;
+}
+/* The remove button is always visible on an unresolved row (no hover
+   reveal): the whole row is a call to action. */
+.host-row-actions .host-remove {
+  opacity: 1;
+  border: 1px solid var(--border);
+}
 .mp-host-token {
   margin-top: 8px;
 }

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -593,6 +593,26 @@ body {
 .folder-name.missing {
   opacity: 0.5;
 }
+/* Unresolved reference: the host this reference points at isn't in the
+   roster (renamed/removed). Muted like `missing`, but with a warning
+   pip directing the user to Settings -> Hosts to remap or remove. */
+.folder-name.unresolved {
+  opacity: 0.5;
+}
+.folder-unresolved-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  margin-left: 6px;
+  border-radius: 50%;
+  background: oklch(28% 0.06 75);
+  color: oklch(80% 0.14 75);
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1cap;
+}
 .folder-missing-icon {
   display: inline-flex;
   align-items: center;

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -128,6 +128,7 @@ body {
 
 /* Settings gear, pinned opposite the logo in the header. */
 .sidebar-settings-btn {
+  position: relative;
   margin-left: auto;
   display: flex;
   align-items: center;
@@ -145,6 +146,18 @@ body {
 .sidebar-settings-btn:hover {
   color: var(--text);
   background: var(--bg-hover);
+}
+/* Attention pip: a referenced host is unresolved and needs a fix in
+   Settings -> Hosts. (refs #270) */
+.settings-attention-pip {
+  position: absolute;
+  top: 3px;
+  right: 3px;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--status-error, oklch(63% 0.2 25));
+  box-shadow: 0 0 0 2px var(--bg-sidebar, var(--bg));
 }
 
 /* Empty-state launch affordance: when there are no projects yet, the

--- a/apps/gmux-web/src/types.ts
+++ b/apps/gmux-web/src/types.ts
@@ -172,6 +172,13 @@ export interface PeerInfo {
    * POST /v1/peers). Absent on older daemons.
    */
   source?: 'tailscale' | 'devcontainer' | 'manual'
+  /**
+   * The peer's stable opaque identity (ADR 0007), reported by its
+   * /v1/health. References anchor on this so they survive the peer
+   * being renamed. Absent for offline peers we've never probed and
+   * for pre-ADR-0007 daemons.
+   */
+  node_id?: string
 }
 
 /**

--- a/apps/gmux-web/src/types.ts
+++ b/apps/gmux-web/src/types.ts
@@ -116,6 +116,13 @@ export interface ProjectItem {
   slug: string
   /** Set when this item is a reference to a peer-owned project. */
   peer?: string
+  /**
+   * Stable opaque identity (ADR 0007) of the referenced peer, used to
+   * resolve the reference even after the peer is renamed. Set only on
+   * references; opportunistically backfilled once the peer is
+   * reachable. Absent on legacy references and owned projects.
+   */
+  node_id?: string
   /** Owned-project match rules. Empty/absent for references. */
   match?: MatchRule[]
   /** Server-managed ordering. Absent for references. */

--- a/apps/gmux-web/src/types.ts
+++ b/apps/gmux-web/src/types.ts
@@ -87,6 +87,15 @@ export interface Folder {
    * by the PeerLabel offline state).
    */
   missing?: boolean
+  /**
+   * True when this folder is a reference whose peer name matches no
+   * host in the current roster (not on the tailnet online/offline, not
+   * manually added, not a devcontainer). The host may have been
+   * renamed or removed; the sidebar flags it and the Hosts tab offers
+   * a remap/remove. Distinct from `missing` (peer connected, slug
+   * gone) and from a disconnected-but-known peer. (refs #270)
+   */
+  unresolved?: boolean
   sessions: Session[]
 }
 

--- a/apps/website/src/content/docs/multi-machine.md
+++ b/apps/website/src/content/docs/multi-machine.md
@@ -51,6 +51,18 @@ gmux probes the host, adopts the name it reports about itself (no name to assign
 
 There is no `[[peers]]` config block (removed in [ADR 0007](https://github.com/gmuxapp/gmux/blob/main/docs/adr/0007-host-identity-and-peer-urls.md)) — peers are runtime state managed from the UI.
 
+## When a referenced host is renamed
+
+A host's name is derived from Tailscale (or its OS hostname), so it can change — for example when you upgrade a machine. A project reference pins another host's project into your sidebar by name, so a rename could silently strip those projects out.
+
+To prevent that, a reference is anchored on the host's stable, opaque node ID, not just its name. References you create from the UI capture that ID immediately, so a later rename is followed automatically and the projects stay put under the new name.
+
+If gmux can't match a reference to any current host — the host was renamed before it was anchored, or removed entirely — the reference is **not** silently dropped:
+
+- The sidebar shows the project muted, with a warning marker.
+- The settings gear gets a small red pip.
+- **Settings → Hosts → Referenced but not found** lists each unmatched host with the projects pointing at it. Pick the host's current name from **Remap to…** to repoint every reference at once (this re-anchors them on the node ID, so the same rename won't break them again), or remove the references if the host is gone for good.
+
 ## Session namespacing
 
 Remote sessions carry their origin in the session ID using `@` separators:

--- a/services/gmuxd/internal/peering/manager.go
+++ b/services/gmuxd/internal/peering/manager.go
@@ -237,6 +237,7 @@ func (m *Manager) PeerStatus() []PeerInfo {
 			info.Version = h.Version
 			info.DefaultLauncher = h.DefaultLauncher
 			info.Launchers = h.Launchers
+			info.NodeID = h.NodeID
 		}
 		infos = append(infos, info)
 	}

--- a/services/gmuxd/internal/peering/peering.go
+++ b/services/gmuxd/internal/peering/peering.go
@@ -84,6 +84,10 @@ type SpokeHealth struct {
 	Version         string        `json:"version"`
 	DefaultLauncher string        `json:"default_launcher"`
 	Launchers       []LauncherDef `json:"launchers"`
+	// NodeID is the spoke's stable opaque identity (ADR 0007). The
+	// viewer anchors peer references on it so they survive the host
+	// being renamed. Empty when talking to a pre-ADR-0007 daemon.
+	NodeID string `json:"node_id"`
 }
 
 // SpokeProject is the minimal projection of a peer's project that
@@ -119,6 +123,11 @@ type PeerInfo struct {
 	// or "manual" (peers.json / POST /v1/peers). Used by the UI to group
 	// hosts; empty for the synthesized self row.
 	Source string `json:"source,omitempty"`
+	// NodeID is the peer's stable opaque identity (ADR 0007), reported
+	// by its /v1/health. The viewer anchors references on it so they
+	// survive the peer being renamed. Empty for offline peers we've
+	// never probed and for pre-ADR-0007 daemons.
+	NodeID string `json:"node_id,omitempty"`
 }
 
 // NamespaceID returns a store-key for a remote session: "originalID@peerName".

--- a/services/gmuxd/internal/peering/peering_test.go
+++ b/services/gmuxd/internal/peering/peering_test.go
@@ -876,7 +876,7 @@ func TestPeerStatus_IncludesHealthData(t *testing.T) {
 
 	spoke2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`{"ok":true,"data":{"version":"0.7.9","default_launcher":"pi","launchers":[{"id":"shell"},{"id":"pi"}]}}`))
+		w.Write([]byte(`{"ok":true,"data":{"version":"0.7.9","default_launcher":"pi","node_id":"node_ws","launchers":[{"id":"shell"},{"id":"pi"}]}}`))
 	}))
 	defer spoke2.Close()
 
@@ -908,6 +908,11 @@ func TestPeerStatus_IncludesHealthData(t *testing.T) {
 	}
 	if ws.Version != "0.7.9" {
 		t.Errorf("version = %q, want %q", ws.Version, "0.7.9")
+	}
+	// node_id flows from the spoke's health to the roster so the viewer
+	// can anchor references on it (refs #270).
+	if ws.NodeID != "node_ws" {
+		t.Errorf("node_id = %q, want %q", ws.NodeID, "node_ws")
 	}
 	if ws.DefaultLauncher != "pi" {
 		t.Errorf("default_launcher = %q, want %q", ws.DefaultLauncher, "pi")

--- a/services/gmuxd/internal/projects/projects.go
+++ b/services/gmuxd/internal/projects/projects.go
@@ -59,6 +59,12 @@ type Item struct {
 	Peer     string      `json:"peer,omitempty"`
 	Match    []MatchRule `json:"match,omitempty"`
 	Sessions []string    `json:"sessions,omitempty"`
+	// NodeID anchors a reference on the peer's stable opaque identity
+	// (ADR 0007) so it survives the peer being renamed: the viewer
+	// resolves the reference by NodeID first, falling back to Peer
+	// (the display name). Set only on references; opportunistically
+	// backfilled once the referenced peer is reachable (refs #270).
+	NodeID string `json:"node_id,omitempty"`
 }
 
 // IsReference reports whether this item is a reference to a peer-owned
@@ -162,6 +168,12 @@ func (s *State) Validate() error {
 			return fmt.Errorf("duplicate slug %q", item.Slug)
 		}
 		slugs[key] = true
+
+		// node_id is a reference anchor; it's meaningless on an owned
+		// project (the viewer owns it, so there's no peer to anchor to).
+		if item.NodeID != "" && !item.IsReference() {
+			return fmt.Errorf("item %q: node_id is only valid on references", item.Slug)
+		}
 
 		if item.IsReference() {
 			// References carry no rules or sessions of their own.

--- a/services/gmuxd/internal/projects/projects_test.go
+++ b/services/gmuxd/internal/projects/projects_test.go
@@ -1362,6 +1362,46 @@ func TestValidateRejectsReferenceWithMatchRules(t *testing.T) {
 	}
 }
 
+// A reference's node_id anchor must survive a Save/Load round-trip so
+// the viewer can resolve renamed peers (refs #270).
+func TestReferenceNodeIDRoundTrips(t *testing.T) {
+	dir := t.TempDir()
+	orig := &State{Items: []Item{
+		{Slug: "apps", Peer: "gmux-hs", NodeID: "node_abc"},
+	}}
+	if err := orig.Save(dir); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(loaded.Items) != 1 || loaded.Items[0].NodeID != "node_abc" || loaded.Items[0].Peer != "gmux-hs" {
+		t.Errorf("reference did not round-trip: %+v", loaded.Items)
+	}
+}
+
+func TestValidateRejectsNodeIDOnOwnedProject(t *testing.T) {
+	s := State{Items: []Item{
+		{Slug: "gmux", Match: []MatchRule{{Path: "/x"}}, NodeID: "node_abc"},
+	}}
+	if err := s.Validate(); err == nil {
+		t.Error("expected validation error for node_id on an owned project")
+	}
+}
+
+// The positive counterpart: a reference *with* a node_id is valid — it's
+// the rename-proof anchor — so Validate must accept it. Guards against a
+// future change that mistakenly rejects node_id on references too.
+func TestValidateAcceptsNodeIDOnReference(t *testing.T) {
+	s := State{Items: []Item{
+		{Slug: "apps", Peer: "gmux-hs", NodeID: "node_abc"},
+	}}
+	if err := s.Validate(); err != nil {
+		t.Errorf("node_id on a reference should be valid, got: %v", err)
+	}
+}
+
 func TestValidateAllowsSameSlugAsOwnedAndReference(t *testing.T) {
 	s := State{Items: []Item{
 		{Slug: "gmux", Match: []MatchRule{{Path: "/x"}}},


### PR DESCRIPTION
Closes #270. Consolidates the reviewed slice stack (#271–#277, all Greptile **5/5**) into one trunk for merge.

## Problem

ADR 0007 (#265) derives a host's name from Tailscale / the OS hostname, so a host can be **renamed on upgrade**. A project reference pins another host's project into the sidebar by name — so a rename silently emptied those folders, with no signal and no recovery path. (Hit live: a box referenced as `hs`, rediscovered as `unraid` → `gmux-hs`.)

## Solution

Anchor references on the stable opaque `node_id` (ADR 0007), surface the unresolved state, and make it recoverable in one click.

- **Resolve by `node_id` first, name fallback** — a renamed host's reference keeps resolving; the display name follows the live host.
- **Surfaced, not silently dropped** — unresolved references render muted in the sidebar (amber `!`, no launch), and the settings gear shows a red attention pip.
- **Recover from Settings → Hosts** — a top-of-tab "Referenced but not found" group lists each unmatched host; **Remap to → [host]** repoints every reference and stamps the target's `node_id` (rename-proof thereafter), or **Remove** drops them. No auto-guessing — always a user choice.
- **Born rename-proof** — references created from the UI capture the peer's `node_id` at creation.

## Slices (each reviewed 5/5)

| | |
|--|--|
| Backend | expose peer `node_id` on the roster (#271); persist `node_id` anchor on references (#272) |
| Core | `resolveReferences` deep module — id-first, name fallback, stale-id refresh, backfills (#273) |
| UI | sidebar surfacing (#274); Hosts-tab remap/remove (#275); gear pip (#276) |
| Polish | creation-time `node_id` stamping, seam tests, docs (#277) |

## Testing

`resolveReferences` / `remapReferenceItems` are pure, table-driven tested (id match w/ rename drift, legacy-name backfill, **stale-id refresh**, unresolved grouping, offline-known resolves, **clear-stale-on-remap**, collision-drop). The `buildProjectFolders` ↔ resolver **seam** is covered (renamed host buckets correctly; unresolved beats `missing`). Backend: peer-status carries `node_id`; reference `node_id` round-trips and validates (accept on reference, reject on owned). Full suite: 439 web tests + 27 Go pkgs, lint clean.

Validated end-to-end on a real renamed host (surfaced → remapped → reconnected).

## Out of scope (follow-ups)

- Opportunistic backfill for *pre-existing* name-only references (auto-writing `projects.json` — own PR).
- Discovery dedup: collapse roster entries that report the same `node_id` (the `gmux-hs` + `unraid` duplicate; also removes a resolver non-determinism under that duplicate).

🤖 Verified by Greptile across the slice stack (all 5/5).