### PR TITLE
fix(gmuxd): disable permessage-deflate on the browser PTY WebSocket (mobile reconnect storm)

### DIFF
--- a/services/gmuxd/internal/wsproxy/wsproxy.go
+++ b/services/gmuxd/internal/wsproxy/wsproxy.go
@@ -64,18 +64,21 @@ func (p *Proxy) Handler() http.HandlerFunc {
 			return
 		}
 
-		// Accept browser WebSocket.
-		//
-		// CompressionContextTakeover: terminal output is highly
-		// repetitive, so permessage-deflate cuts the on-wire size of
-		// scrollback replay and full redraws substantially. Only the
-		// browser-facing hop is compressed; the backend hop is a local
-		// Unix socket where compression would be pure CPU cost. Safari
-		// does not implement permessage-deflate and silently falls back
-		// to uncompressed. See issue #242.
+		// Accept browser WebSocket. No permessage-deflate: the library
+		// defaults CompressionMode to CompressionDisabled, and we keep it
+		// that way. Compression (tried in #242 to shrink the on-connect
+		// scrollback replay) breaks at least one mobile browser, which
+		// negotiates deflate but can't decode gmuxd's frames and drops
+		// the socket right after the first large frame (the replay). The
+		// frontend reconnects, re-ships the replay, the browser drops
+		// again — a reconnect storm that also narrows the PTY one column
+		// per drop (the runner's shrinkForReconnect). Neither deflate
+		// mode fixed it; only no compression does. The storm re-ships the
+		// replay far more than compression ever saved, so this is the
+		// right call for every client. Revisit #242's bandwidth goal
+		// another way (e.g. bounding replay size) if it proves necessary.
 		clientConn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
 			InsecureSkipVerify: true,
-			CompressionMode:    websocket.CompressionContextTakeover,
 		})
 		if err != nil {
 			log.Printf("wsproxy: accept: %v", err)


### PR DESCRIPTION
Removes permessage-deflate from the browser-facing PTY WebSocket (added in #242). It was causing a reconnect storm on mobile.

## Symptom

On mobile the terminal flashed "Connection lost, reconnecting…" roughly twice a second, the screen narrowed by one column each time, and only one keystroke landed per cycle. Desktop was unaffected.

## Root cause

The affected mobile browser *negotiates* permessage-deflate but cannot correctly decode gmuxd's compressed frames, so it drops the socket right after the first large frame — the on-connect scrollback replay. The frontend reconnects (500 ms backoff), re-ships the same replay, the browser drops again: a storm. Each disconnect also narrows the PTY by one column via the runner's `shrinkForReconnect`, which is the visible shrink.

There is **no mobile/desktop branching** in the code — the proxy accepts every client identically. The only difference was browser behaviour: desktop browsers decode deflate fine; the affected mobile one does not.

## How it was isolated

- Daemon log showed the storm only in mobile-test bursts, never during desktop use.
- A Go WebSocket client holding the *same compressed stream* stayed connected for 25 s — so the **daemon never closes the connection**; the browser does.
- Stepping the mode (context-takeover → per-message `NoContextTakeover` → off) showed only **fully off** stops it, confirmed live on the real device.

## Fix

Drop the `CompressionMode` field entirely. `nhooyr.io/websocket` defaults `AcceptOptions.CompressionMode` to `CompressionDisabled` (it's the zero value), so this is the simplest possible form and applies to every client.

The storm re-shipped the replay far more than compression ever saved, so disabling is strictly better — for mobile and desktop alike.

## Follow-up

#242's original goal (small on-connect replay to save mobile data / avoid OOM on reconnect) is now unaddressed. If it matters, revisit it a safer way — e.g. bounding replay size — rather than wire compression that some clients cannot decode.

Verified live on the affected phone: storm gone, typing and resize normal.