### PR TITLE
feat: 2.0 upgrade migration and explicit host auth status

### DIFF
--- a/apps/gmux-web/src/host-status.test.ts
+++ b/apps/gmux-web/src/host-status.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { hostStatus } from './host-status'
+
+describe('hostStatus', () => {
+  it('connected → Online', () => {
+    expect(hostStatus('connected')).toEqual({ kind: 'online', label: 'Online' })
+  })
+
+  it('connecting → Connecting…', () => {
+    expect(hostStatus('connecting')).toEqual({ kind: 'connecting', label: 'Connecting…' })
+  })
+
+  it('disconnected + auth error → Auth needed (carries detail)', () => {
+    expect(hostStatus('disconnected', 'authentication failed')).toEqual({
+      kind: 'auth', label: 'Auth needed', detail: 'authentication failed',
+    })
+  })
+
+  it('disconnected + connection error → Offline (carries detail)', () => {
+    expect(hostStatus('disconnected', 'connection refused')).toEqual({
+      kind: 'offline', label: 'Offline', detail: 'connection refused',
+    })
+  })
+
+  it('disconnected with no error → Offline', () => {
+    expect(hostStatus('disconnected')).toEqual({ kind: 'offline', label: 'Offline' })
+  })
+
+  it('a TLS/cert failure is offline, not mislabeled as not-gmux', () => {
+    expect(hostStatus('disconnected', 'TLS certificate error').kind).toBe('offline')
+  })
+})

--- a/apps/gmux-web/src/host-status.ts
+++ b/apps/gmux-web/src/host-status.ts
@@ -1,0 +1,35 @@
+/** Display status for a host row, derived from its connection state.
+ *
+ *  The peering layer reports only connected / connecting / disconnected
+ *  plus a categorized error string (e.g. "authentication failed",
+ *  "connection refused"). We fold those into the buckets a user actually
+ *  reasons about:
+ *
+ *    - online      — connected and authenticated
+ *    - connecting  — handshake in progress
+ *    - auth        — reachable but the token is missing or wrong
+ *    - offline     — unreachable (refused / timed out / no such host / TLS)
+ *
+ *  "Reachable but not gmux" is intentionally not its own bucket: at the
+ *  transport level a closed port is indistinguishable from a host that's
+ *  down, and a wrong server gives no reliable positive signal, so it
+ *  falls under offline with the raw error shown as detail.
+ */
+export type HostStatusKind = 'online' | 'connecting' | 'auth' | 'offline'
+
+export interface HostStatus {
+  kind: HostStatusKind
+  label: string
+  /** The raw categorized error, surfaced under the row when present. */
+  detail?: string
+}
+
+export function hostStatus(status: string, lastError?: string): HostStatus {
+  if (status === 'connected') return { kind: 'online', label: 'Online' }
+  if (status === 'connecting') return { kind: 'connecting', label: 'Connecting…' }
+  const e = (lastError ?? '').toLowerCase()
+  if (e.includes('auth')) {
+    return { kind: 'auth', label: 'Auth needed', detail: lastError }
+  }
+  return { kind: 'offline', label: 'Offline', detail: lastError }
+}

--- a/apps/gmux-web/src/mock-data/index.ts
+++ b/apps/gmux-web/src/mock-data/index.ts
@@ -26,16 +26,17 @@ export const MOCK_SESSIONS: MockSession[] = [
   shellOpenclawLogs,
 ]
 
-/** Mock peers (host roster). Covers all three Hosts-tab groups
- *  (tailnet-discovered, devcontainer, manual), a connected and a
- *  disconnected row, and a manual host carrying a last_error so the
- *  grouping and every row state are exercised. */
+/** Mock peers (host roster). Exercises the Hosts-tab groups
+ *  (devcontainer, manual) and every row state: online, offline (a
+ *  connection error), and auth-needed (drives the amber "Add token"
+ *  affordance). */
 export const MOCK_PEERS: PeerInfo[] = [
   { name: 'laptop', url: 'https://laptop.tail-scale.ts.net', status: 'connected', session_count: 2, version: '1.2.0', source: 'manual' },
   { name: 'server', url: 'https://server.tail-scale.ts.net', status: 'connected', session_count: 4, version: '1.1.9', source: 'manual' },
   { name: 'devcontainer', url: 'https://devcontainer.tail-scale.ts.net', status: 'connected', session_count: 1, version: '1.2.0', local: true, source: 'devcontainer' },
   { name: 'konyvtar', url: 'https://gmux.tail95157a.ts.net', status: 'connected', session_count: 1, version: '1.2.0', source: 'manual' },
   { name: 'bespin', url: 'https://bespin.tail-scale.ts.net', status: 'disconnected', session_count: 0, last_error: 'dial tcp 100.84.12.9:443: connect: connection refused', source: 'manual' },
+  { name: 'cloud-city', url: 'https://cloud-city.tail-scale.ts.net', status: 'disconnected', session_count: 0, last_error: 'authentication failed', source: 'manual' },
 ]
 
 /** Mock daemon health for the local host. */

--- a/apps/gmux-web/src/references.test.ts
+++ b/apps/gmux-web/src/references.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { resolveReferences, remapReferenceItems, removeReferenceItems, removeHostReferenceItems, refKey } from './references'
+import { resolveReferences, removeReferenceItems, removeHostReferenceItems, refKey } from './references'
 import type { PeerInfo, ProjectItem } from './types'
 
 function peer(name: string, node_id?: string): PeerInfo {
@@ -88,57 +88,6 @@ describe('resolveReferences', () => {
     expect(unresolved).toContainEqual({ name: 'hs', slugs: ['apps', 'home'] })
     expect(unresolved).toContainEqual({ name: 'old-laptop', slugs: ['dots'] })
     expect(unresolved).toHaveLength(2)
-  })
-})
-
-describe('remapReferenceItems', () => {
-  it('repoints the named references from one host to another and stamps node_id', () => {
-    const items = [owned('gmux'), ref('hs', 'apps'), ref('hs', 'home'), ref('ft', 'dots')]
-    const next = remapReferenceItems(items, 'hs', ['apps', 'home'], 'gmux-hs', 'node_hs')
-    expect(next).toEqual([
-      owned('gmux'),
-      { slug: 'apps', peer: 'gmux-hs', node_id: 'node_hs' },
-      { slug: 'home', peer: 'gmux-hs', node_id: 'node_hs' },
-      ref('ft', 'dots'), // untouched
-    ])
-  })
-
-  it('does not touch a same-named reference outside the slug scope', () => {
-    // Data-loss guard: during a rename transition a stored name can be
-    // shared by an unresolved reference (in scope) and one already
-    // resolving via node_id (out of scope). Only the scoped slug moves.
-    const items = [
-      ref('hs', 'apps', 'node_hs'), // resolves via node_id; NOT in scope
-      ref('hs', 'legacy'),          // unresolved; in scope
-    ]
-    const next = remapReferenceItems(items, 'hs', ['legacy'], 'gmux-hs', 'node_hs')
-    expect(next).toEqual([
-      ref('hs', 'apps', 'node_hs'),
-      { slug: 'legacy', peer: 'gmux-hs', node_id: 'node_hs' },
-    ])
-  })
-
-  it('is a no-op when fromPeer equals toPeer (never wipes references)', () => {
-    const items = [ref('hs', 'apps', 'node_hs'), ref('hs', 'home', 'node_hs'), owned('gmux')]
-    expect(remapReferenceItems(items, 'hs', ['apps', 'home'], 'hs', 'node_hs')).toEqual(items)
-  })
-
-  it('clears a stale node_id when the remap target has no node_id', () => {
-    const items = [ref('hs', 'apps', 'stale_node'), ref('hs', 'home', 'stale_node')]
-    const next = remapReferenceItems(items, 'hs', ['apps', 'home'], 'gmux-hs', undefined)
-    expect(next).toEqual([
-      { slug: 'apps', peer: 'gmux-hs', node_id: undefined },
-      { slug: 'home', peer: 'gmux-hs', node_id: undefined },
-    ])
-  })
-
-  it('drops a remapped reference whose slug the target already has', () => {
-    const items = [ref('gmux-hs', 'apps', 'node_hs'), ref('hs', 'apps'), ref('hs', 'home')]
-    const next = remapReferenceItems(items, 'hs', ['apps', 'home'], 'gmux-hs', 'node_hs')
-    expect(next).toEqual([
-      ref('gmux-hs', 'apps', 'node_hs'),
-      { slug: 'home', peer: 'gmux-hs', node_id: 'node_hs' },
-    ])
   })
 })
 

--- a/apps/gmux-web/src/references.ts
+++ b/apps/gmux-web/src/references.ts
@@ -144,51 +144,6 @@ export function resolveReferences(
 }
 
 /**
- * Rewrite the references `(fromPeer, slug)` for `slug` in `slugs` to
- * point at `toPeer`, stamping the target's `nodeId`. Pure: returns a
- * new items array; the caller persists it.
- *
- * Scoping to `slugs` (the *unresolved* slugs the UI surfaced for this
- * host) is critical: a stored peer name can be shared by both an
- * unresolved reference and one that already resolves correctly via
- * node_id during a rename transition. Matching by name alone would
- * silently move the working reference too. Only the named slugs are
- * touched. (refs #270)
- *
- * A reference whose slug `toPeer` already references is dropped (the
- * target wins) so the result has no duplicate (peer, slug). The
- * remapped reference takes the target's `nodeId` verbatim — if the
- * target has none (offline/legacy peer), the node_id is *cleared*,
- * never left pointing at the old host's id (which would let the old
- * host silently re-claim the reference if it reappeared).
- */
-export function remapReferenceItems(
-  items: readonly ProjectItem[],
-  fromPeer: string,
-  slugs: readonly string[],
-  toPeer: string,
-  nodeId?: string,
-): ProjectItem[] {
-  // No-op remap (same source and target): without this guard every
-  // matching item would collide with itself in targetSlugs below and be
-  // dropped, silently wiping the references. Not reachable from the UI
-  // (you remap an unresolved host to a *different* live one) but a
-  // footgun for any future caller.
-  if (fromPeer === toPeer) return items.slice()
-  const scope = new Set(slugs)
-  const targetSlugs = new Set(
-    items.filter(p => p.peer === toPeer).map(p => p.slug),
-  )
-  const next: ProjectItem[] = []
-  for (const it of items) {
-    if (it.peer !== fromPeer || !scope.has(it.slug)) { next.push(it); continue }
-    if (targetSlugs.has(it.slug)) continue // target already references this slug
-    next.push({ ...it, peer: toPeer, node_id: nodeId })
-  }
-  return next
-}
-
-/**
  * Remove the references `(peer, slug)` for `slug` in `slugs`. Pure:
  * returns a new items array. Like the remap above, scoping to the
  * surfaced unresolved `slugs` is what prevents deleting a same-named

--- a/apps/gmux-web/src/settings.tsx
+++ b/apps/gmux-web/src/settings.tsx
@@ -23,6 +23,7 @@ import {
   unresolvedHosts, removeReferences,
 } from './store'
 import { HostSuffix } from './host-suffix'
+import { hostStatus } from './host-status'
 import type { ProjectItem, DiscoveredProject, MatchRule, Folder, PeerInfo } from './types'
 import type { UnresolvedHost } from './references'
 
@@ -334,6 +335,16 @@ function HostsTab() {
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState('')
   const [notice, setNotice] = useState('')
+  const tokenInputRef = useRef<HTMLInputElement>(null)
+
+  // "Add token" on an auth-needed host: pre-fill the connect form with
+  // its URL and focus the token field. Connecting re-runs POST /v1/peers,
+  // which upserts the token onto the existing record (matched by URL).
+  const handleAddToken = useCallback((peerUrl: string) => {
+    setUrl(peerUrl); setToken(''); setError('')
+    setNotice("Paste this host's token and press Connect.")
+    requestAnimationFrame(() => tokenInputRef.current?.focus())
+  }, [])
 
   const handleConnect = useCallback(async () => {
     const u = url.trim()
@@ -409,6 +420,7 @@ function HostsTab() {
                   // Only manual peers can be disconnected; tailscale and
                   // devcontainer peers are managed automatically.
                   onRemove={g.key === 'manual' ? () => handleRemove(p.name, p.node_id) : undefined}
+                  onAddToken={g.key === 'manual' ? () => handleAddToken(p.url) : undefined}
                 />
               ))}
             </div>
@@ -443,6 +455,7 @@ function HostsTab() {
           </button>
         </div>
         <input
+          ref={tokenInputRef}
           class="mp-filter-input mp-host-token"
           type="password"
           placeholder="Token (only if the URL has none)"
@@ -498,7 +511,7 @@ function UnresolvedHostRow({ host }: { host: UnresolvedHost }) {
 }
 
 function HostRow({
-  name, self, status, sessionCount, version, lastError, local, onRemove,
+  name, self, status, sessionCount, version, lastError, local, onRemove, onAddToken,
 }: {
   name: string
   self?: boolean
@@ -508,33 +521,41 @@ function HostRow({
   lastError?: string
   local?: boolean
   onRemove?: () => void
+  onAddToken?: () => void
 }) {
-  const connected = status === 'connected'
+  const st = hostStatus(status, lastError)
   return (
     <div class="host-row">
       <div class="host-row-main">
-        <span class={`host-status-dot${connected ? ' connected' : ''}`} aria-hidden="true" />
+        <span class={`host-status-dot ${st.kind}`} aria-hidden="true" />
         {self && <span class="host-self-tag">this host</span>}
         <span class="host-name">
           {name}
           {local && <span class="host-local-tag">local</span>}
         </span>
         <div class="host-meta">
-          <span class="host-status-label">{status}</span>
+          <span class={`host-status-label ${st.kind}`}>{st.label}</span>
           <span class="host-sep">·</span>
           <span>{sessionCount} session{sessionCount === 1 ? '' : 's'}</span>
           {version && <><span class="host-sep">·</span><span>v{version}</span></>}
         </div>
+        {st.kind === 'auth' && onAddToken && (
+          <button
+            class="host-add-token"
+            title="Supply this host's access token"
+            onClick={(e) => { e.preventDefault(); e.stopPropagation(); onAddToken() }}
+          >Add token</button>
+        )}
         {onRemove && (
           <button
             class="host-remove"
-            title="Disconnect host"
+            title="Remove host"
             onClick={(e) => { e.preventDefault(); e.stopPropagation(); onRemove() }}
           >×</button>
         )}
       </div>
-      {!connected && lastError && (
-        <div class="host-error">{lastError}</div>
+      {st.kind === 'offline' && st.detail && (
+        <div class="host-error">{st.detail}</div>
       )}
     </div>
   )

--- a/apps/gmux-web/src/settings.tsx
+++ b/apps/gmux-web/src/settings.tsx
@@ -20,7 +20,7 @@ import {
   addProject, addPeerReference, folders, updateProjects,
   removeProject, removePeerReference, localHostLabel,
   health, peers, sessions, connectHost, removeHost, parseConnectURL,
-  unresolvedHosts, remapReferences, removeReferences,
+  unresolvedHosts, removeReferences,
 } from './store'
 import { HostSuffix } from './host-suffix'
 import type { ProjectItem, DiscoveredProject, MatchRule, Folder, PeerInfo } from './types'
@@ -367,11 +367,11 @@ function HostsTab() {
         <section class="mp-section">
           <div class="mp-section-label">Referenced but not found</div>
           <div class="mp-path-hint" style="margin-bottom:8px">
-            These projects reference a host that isn't in your roster. If it's a host you still have, re-add it under <strong>Connect to host</strong> below and its references will resolve again automatically. Otherwise, remap them to a current host or remove them.
+            These projects reference a host that isn't in your roster. If it's a host you still have, re-add it under <strong>Connect to host</strong> below and its references will resolve again automatically. Otherwise, remove them.
           </div>
           <div class="host-list">
             {unresolvedHosts.value.map(u => (
-              <UnresolvedHostRow key={u.name} host={u} targets={peersVal} />
+              <UnresolvedHostRow key={u.name} host={u} />
             ))}
           </div>
         </section>
@@ -466,28 +466,9 @@ function HostsTab() {
  *  (renamed or removed). Offers a one-click remap onto a roster host
  *  — stamping the target's node_id so it survives future renames —
  *  and a remove that drops all its references. (refs #270) */
-function UnresolvedHostRow({ host, targets }: { host: UnresolvedHost; targets: PeerInfo[] }) {
+function UnresolvedHostRow({ host }: { host: UnresolvedHost }) {
   const [busy, setBusy] = useState(false)
   const [err, setErr] = useState('')
-
-  const onRemap = useCallback(async (e: Event) => {
-    const sel = e.target as HTMLSelectElement
-    const toName = sel.value
-    if (!toName) return
-    const target = targets.find(t => t.name === toName)
-    setBusy(true); setErr('')
-    try {
-      await remapReferences(host.name, host.slugs, toName, target?.node_id)
-    } catch (e) {
-      // Reset to the placeholder so re-picking the same target fires
-      // onChange again (otherwise the user must choose a different
-      // option before they can retry).
-      sel.value = ''
-      setErr(e instanceof Error ? e.message : 'Could not remap.')
-    } finally {
-      setBusy(false)
-    }
-  }, [host.name, targets])
 
   const onRemove = useCallback(async () => {
     setBusy(true); setErr('')
@@ -509,10 +490,6 @@ function UnresolvedHostRow({ host, targets }: { host: UnresolvedHost; targets: P
         <span class="host-meta">{count} reference{count === 1 ? '' : 's'}: {host.slugs.join(', ')}</span>
       </div>
       <div class="host-row-actions">
-        <select class="mp-filter-input host-remap-select" disabled={busy} onChange={onRemap}>
-          <option value="">Remap to…</option>
-          {targets.map(t => <option key={t.name} value={t.name}>{t.name}</option>)}
-        </select>
         <button class="host-remove-refs" disabled={busy} title="Delete this host's project references" onClick={onRemove}>Remove references</button>
       </div>
       {err && <div class="mp-manual-error">{err}</div>}

--- a/apps/gmux-web/src/settings.tsx
+++ b/apps/gmux-web/src/settings.tsx
@@ -351,8 +351,12 @@ function HostsTab() {
     if (!u) { setError('Enter a host URL.'); return }
     setBusy(true); setError(''); setNotice('')
     try {
-      const { name, alreadyConnected } = await connectHost(u, token.trim())
-      setNotice(alreadyConnected ? `Already connected to ${name}.` : `Connected to ${name}.`)
+      const { name, alreadyConnected, updated } = await connectHost(u, token.trim())
+      setNotice(
+        alreadyConnected ? `Already connected to ${name}.`
+          : updated ? `Reconnected to ${name}.`
+            : `Connected to ${name}.`,
+      )
       setUrl(''); setToken('')
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Could not connect.')

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -913,19 +913,21 @@ export function parseConnectURL(input: string): { url: string; token: string } |
 export async function connectHost(
   url: string,
   token: string,
-): Promise<{ name: string; alreadyConnected: boolean }> {
+): Promise<{ name: string; alreadyConnected: boolean; updated: boolean }> {
   const resp = await fetch('/v1/peers', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ url, token }),
   })
   const body = await resp.json().catch(() => ({})) as {
-    peer?: { name?: string }; already_connected?: boolean; error?: { message?: string }
+    peer?: { name?: string }; already_connected?: boolean; updated?: boolean; error?: { message?: string }
   }
   if (!resp.ok) {
     throw new Error(body.error?.message || `Could not connect (${resp.status})`)
   }
-  return { name: body.peer?.name ?? '', alreadyConnected: !!body.already_connected }
+  // updated: the host was already known and its URL/token were refreshed
+  // (the "Add token" path). alreadyConnected: known with identical creds.
+  return { name: body.peer?.name ?? '', alreadyConnected: !!body.already_connected, updated: !!body.updated }
 }
 
 /** Disconnect a manually-added host: DELETE /v1/peers/{name}. */

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -19,7 +19,7 @@ import type { View } from './routing'
 import { resolveViewFromPath, viewToPath } from './routing'
 import { navigateWithReload } from './version-watch'
 import { buildProjectFolders, discoverProjects } from './projects'
-import { resolveReferences, remapReferenceItems, removeReferenceItems, removeHostReferenceItems, refKey, type UnresolvedHost } from './references'
+import { resolveReferences, removeReferenceItems, removeHostReferenceItems, refKey, type UnresolvedHost } from './references'
 
 import { fetchFrontendConfig, buildTerminalOptions, resolveKeybinds, type ResolvedKeybind } from './config'
 import { MOCK_SESSIONS, MOCK_PROJECTS, MOCK_PEERS, MOCK_HEALTH } from './mock-data/index'
@@ -951,20 +951,6 @@ export async function removeHost(name: string, nodeId?: string): Promise<void> {
 export async function removePeerReference(peer: string, slug: string): Promise<void> {
   const filtered = projects.value.filter(p => !(p.peer === peer && p.slug === slug))
   await putProjects(filtered)
-}
-
-/** Remap every reference pointing at `fromPeer` onto `toPeer`, stamping
- *  the target's stable node_id so the reference survives future
- *  renames. Recovers references orphaned by a host rename (refs #270).
- *  References whose slug the target already has are dropped to avoid a
- *  duplicate. */
-export async function remapReferences(
-  fromPeer: string,
-  slugs: readonly string[],
-  toPeer: string,
-  nodeId?: string,
-): Promise<void> {
-  await putProjects(remapReferenceItems(projects.value, fromPeer, slugs, toPeer, nodeId))
 }
 
 /** Drop the unresolved references `(peer, slug)` for the given slugs.

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -1152,10 +1152,6 @@ body {
   gap: 8px;
   margin-top: 8px;
 }
-.host-remap-select {
-  max-width: 220px;
-  cursor: pointer;
-}
 /* The remove button is always visible on an unresolved row (no hover
    reveal): the whole row is a call to action. */
 .host-row-actions .host-remove {

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -1060,8 +1060,15 @@ body {
   background: var(--status-disconnected);
   flex-shrink: 0;
 }
-.host-status-dot.connected {
+.host-status-dot.online {
   background: var(--status-connected);
+}
+.host-status-dot.connecting,
+.host-status-dot.auth {
+  background: oklch(78% 0.15 75); /* amber: needs attention */
+}
+.host-status-dot.offline {
+  background: oklch(58% 0.012 250); /* muted grey: down, not an error */
 }
 .host-self-tag {
   font-size: 10px;
@@ -1099,8 +1106,30 @@ body {
   white-space: nowrap;
   flex-shrink: 0;
 }
-.host-status-label {
-  text-transform: capitalize;
+.host-status-label.auth {
+  color: oklch(78% 0.15 75);
+}
+.host-status-label.offline {
+  color: var(--text-secondary);
+}
+/* Inline "Add token" on an auth-needed host: pre-fills the connect form. */
+.host-add-token {
+  flex-shrink: 0;
+  margin-left: 8px;
+  border: 1px solid oklch(78% 0.15 75 / 0.5);
+  border-radius: 5px;
+  background: transparent;
+  color: oklch(80% 0.13 75);
+  font-family: 'Source Sans 3', sans-serif;
+  font-size: 12px;
+  font-weight: 500;
+  padding: 3px 9px;
+  cursor: pointer;
+  transition: background 0.12s, border-color 0.12s;
+}
+.host-add-token:hover {
+  background: oklch(78% 0.15 75 / 0.12);
+  border-color: oklch(78% 0.15 75 / 0.8);
 }
 .host-sep {
   opacity: 0.5;
@@ -1186,7 +1215,7 @@ body {
   margin-top: 4px;
   margin-left: 15px;
   font-size: 12px;
-  color: var(--status-disconnected);
+  color: var(--text-secondary);
   font-family: var(--mono, monospace);
   white-space: nowrap;
   overflow: hidden;

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -989,6 +989,12 @@ body {
 .settings-main {
   flex: 1;
   min-width: 0;
+  /* Without this, the auto min-height of a flex item keeps this column
+     from shrinking below its content, so the .modal-body scroller grows
+     to its full content height and overflows the (capped) panel instead
+     of scrolling. Bites on short/mobile viewports where the panel's
+     max-height is well below the content. */
+  min-height: 0;
   display: flex;
   flex-direction: column;
 }

--- a/apps/website/src/content/docs/multi-machine.md
+++ b/apps/website/src/content/docs/multi-machine.md
@@ -55,11 +55,17 @@ A host's name is derived from Tailscale (or its OS hostname), so it can change �
 
 To prevent that, a reference is anchored on the host's stable, opaque node ID, not just its name. References you create from the UI capture that ID immediately, so a later rename is followed automatically and the projects stay put under the new name.
 
-If gmux can't match a reference to any current host — the host was renamed before it was anchored, or removed entirely — the reference is **not** silently dropped:
+If gmux can't match a reference to any current host — it's not in the roster because it was removed, or set up on a previous install — the reference is **not** silently dropped:
 
 - The sidebar shows the project muted, with a warning marker.
 - The settings gear gets a small red pip.
-- **Settings → Hosts → Referenced but not found** lists each unmatched host with the projects pointing at it. Pick the host's current name from **Remap to…** to repoint every reference at once (this re-anchors them on the node ID, so the same rename won't break them again), or remove the references if the host is gone for good.
+- **Settings → Hosts → Referenced but not found** lists each unmatched host with the projects pointing at it. Re-add the host under **Connect to host** (a manual peer's references are anchored on its node ID, so a later rename follows it automatically) and the references resolve again; otherwise remove them.
+
+Removing a host clears the references that pointed at it, so a deliberate removal leaves nothing behind here.
+
+## Upgrading from a version with tailnet autodiscovery
+
+Earlier versions auto-discovered gmux machines on your tailnet. [ADR 0008](https://github.com/gmuxapp/gmux/blob/main/docs/adr/0008-peer-authentication-via-token.md) removed that, so on first start the daemon migrates the hosts **you had projects on** into the roster as **Auth needed** (it imports the old discovery cache, then deletes it). Click **Add token** on each in **Settings → Hosts** and paste its token (`gmuxd auth` on that host) to bring it online. Machines you never pinned a project on aren't carried over — add them with **Connect to host** if you want them. `projects.json` is backed up to `projects.json.bak` before any schema migration.
 
 ## Session namespacing
 

--- a/apps/website/src/content/docs/reference/file-paths.md
+++ b/apps/website/src/content/docs/reference/file-paths.md
@@ -26,6 +26,8 @@ Created by gmuxd. Lives under `~/.local/state/gmux` (or `$XDG_STATE_HOME/gmux`).
 | `~/.local/state/gmux/gmuxd.sock` | Daemon Unix socket (local IPC between gmux CLI and gmuxd) |
 | `~/.local/state/gmux/auth-token` | Bearer token for TCP authentication |
 | `~/.local/state/gmux/projects.json` | User-curated project list (sidebar grouping, ordering) |
+| `~/.local/state/gmux/projects.json.bak` | Snapshot of `projects.json` taken before a schema migration rewrites it (notably the 2.0 upgrade) |
+| `~/.local/state/gmux/peers.json` | Hosts you connected to via **Connect to host** — URL, token, and node id (0600; it carries a token) |
 | `~/.local/state/gmux/gmuxd.log` | Daemon log (when started via `gmuxd start`) |
 | `~/.local/state/gmux/tsnet/` | Tailscale state directory (when remote access is enabled) |
 

--- a/apps/website/src/content/docs/using-the-ui.md
+++ b/apps/website/src/content/docs/using-the-ui.md
@@ -27,7 +27,20 @@ Each machine (local and remote) gets a card with a status indicator, session cou
 | **Pulsing dot** | Connecting to peer |
 | **Red ✗** | Peer disconnected (shows error reason) |
 
-Hosts you add via **Settings → Hosts → Connect to host** persist across restarts and reconnect automatically. A disconnected host keeps its card (with the last error) until you remove it. gmux does not auto-discover tailnet machines — adding one is an explicit, token-authenticated step (see [Multi-Machine](/multi-machine/) and [ADR 0008](https://github.com/gmuxapp/gmux/blob/main/docs/adr/0008-peer-authentication-via-token.md)).
+Hosts you add via **Settings → Hosts → Connect to host** persist across restarts and reconnect automatically. gmux does not auto-discover tailnet machines — adding one is an explicit, token-authenticated step (see [Multi-Machine](/multi-machine/) and [ADR 0008](https://github.com/gmuxapp/gmux/blob/main/docs/adr/0008-peer-authentication-via-token.md)).
+
+In **Settings → Hosts**, each host shows an explicit status:
+
+| Status | Meaning |
+|--------|---------|
+| **Online** | Connected and authenticated |
+| **Connecting…** | Handshake in progress |
+| **Auth needed** | Reachable, but the token is missing or wrong — an **Add token** button pre-fills the connect form so you can supply it |
+| **Offline** | Unreachable right now (shows the connection error); it reconnects on its own when the host comes back |
+
+Removing a host also clears the project references that pointed at it, so it leaves nothing behind under **Referenced but not found**.
+
+**Upgrading to 2.0:** hosts you had projects on — that earlier versions auto-discovered on your tailnet — are migrated into the roster as **Auth needed**. Click **Add token** on each and paste its token (run `gmuxd auth` on that host) to bring it back online. Other tailnet machines aren't carried over; re-add them with **Connect to host** if you want them. Your `projects.json` is backed up to `projects.json.bak` before the upgrade rewrites it.
 
 Connected peers show launch buttons for each configured adapter, just like the local host.
 

--- a/docs/adr/0008-peer-authentication-via-token.md
+++ b/docs/adr/0008-peer-authentication-via-token.md
@@ -1,6 +1,6 @@
 # ADR 0008: Peer authentication via token
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-06-03
 **Related:** ADR 0007 (host identity and peer URLs)
 **Target:** gmux 2.0 (breaking; no backwards compatibility)
@@ -253,14 +253,24 @@ not part of this change.
 
 This is a breaking change appropriate to a major version.
 
-- **Existing 2.0-prerelease auto-discovered peers go dark on upgrade.**
-  They were never persisted (they lived only in the `tsdiscovery`
-  cache, re-added each boot), so the cache file
-  (`tailscale-discovery.json`) is simply removed and each tailnet host
-  is re-added once via Connect-to-host.
+- **Previously auto-discovered peers are migrated into the roster as
+  `Auth needed`.** They were never persisted as peers (they lived only
+  in the `tsdiscovery` cache, re-added each boot), so on the first
+  upgrade start the cache file (`tailscale-discovery.json`) is imported:
+  each cached gmux device **that a project references** becomes a
+  token-less manual peer, then the cache is deleted. Scoping to
+  referenced hosts is deliberate — those are the ones whose references
+  would otherwise orphan; other gmux boxes the tailnet once surfaced are
+  left out rather than filling the roster with `Auth needed` rows, and
+  can be re-added on demand. A migrated host shows as `Auth needed`
+  until the user supplies its token via **Add token** (which upserts the
+  token onto the existing record, matched by URL). `projects.json` is
+  backed up to `projects.json.bak` before any schema migration rewrites
+  it.
 - **Release notes must call this out loudly:** after upgrading, each
-  remote host must be re-added with its connect URL (`gmuxd auth` on
-  the remote, paste into Connect-to-host on the hub).
+  migrated host needs its token supplied once (`gmuxd auth` on the
+  remote, then **Add token** on the hub); hosts that were never
+  auto-discovered are added via Connect-to-host as before.
 - Docs to update: `multi-machine.md`, `remote-access.md`, and the
   `docker-tailscale` example — "on my tailnet" must no longer imply
   "can drive my machines"; pairing is now an explicit per-host token

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -1059,21 +1059,27 @@ func serve(stderr io.Writer) int {
 			return
 		}
 
-		// Atomic dedup-or-add: same node_id ⇒ already connected (not a
-		// duplicate); otherwise the probed name is slugified, de-collided,
-		// and persisted under one lock (no check-then-act race).
-		rec, existed, err := peerStore.AddOrGet(peerstore.Record{Name: name, URL: req.URL, Token: req.Token, NodeID: peerNodeID})
+		// Atomic upsert: a known host (by node_id, else URL) refreshes its
+		// URL/token in place; a new host is slugified, de-collided, and
+		// persisted — all under one lock (no check-then-act race).
+		rec, outcome, err := peerStore.AddOrGet(peerstore.Record{Name: name, URL: req.URL, Token: req.Token, NodeID: peerNodeID})
 		if err != nil {
 			writeError(w, http.StatusBadRequest, "bad_request", err.Error())
 			return
 		}
-		if existed {
+		if outcome == peerstore.Unchanged {
 			writeJSON(w, map[string]any{"peer": rec, "already_connected": true})
 			return
 		}
+		if outcome == peerstore.Updated {
+			// Credentials changed (e.g. a token supplied for a host added
+			// without one). AddPeer is a no-op when the name already exists,
+			// so drop the live peer first to force a reconnect with them.
+			peerManager.RemovePeer(rec.Name)
+		}
 		peerManager.AddPeer(config.PeerConfig{Name: rec.Name, URL: rec.URL, Token: rec.Token, Source: config.SourceManual})
 		log.Printf("peering: connected to %s (%s)", rec.Name, rec.URL)
-		writeJSON(w, map[string]any{"peer": rec})
+		writeJSON(w, map[string]any{"peer": rec, "updated": outcome == peerstore.Updated})
 	})
 
 	// DELETE /v1/peers/{name} — disconnect a manually-added peer.

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -585,12 +585,6 @@ func serve(stderr io.Writer) int {
 	// State directory for persistent files (projects.json, auth-token, etc).
 	stateDir := paths.StateDir()
 
-	// Remove the legacy tailscale-discovery.json cache. Tailscale
-	// autodiscovery was removed in ADR 0008 (token-everywhere made
-	// auto-connect unsafe); nothing reads or writes this file anymore, so
-	// clean it up on first start after the upgrade. Best-effort.
-	_ = os.Remove(filepath.Join(stateDir, "tailscale-discovery.json"))
-
 	// Stable, opaque per-node identity (ADR 0007). Generated once and
 	// persisted alongside the auth token; used for peer dedup, never
 	// shown or routed.
@@ -614,6 +608,29 @@ func serve(stderr io.Writer) int {
 	// Project manager handles concurrent access to projects.json and
 	// auto-assignment of sessions to projects.
 	projectMgr := projects.NewManager(stateDir)
+
+	// One-time upgrade: ADR 0008 removed tailscale autodiscovery, so the
+	// hosts it surfaced automatically would otherwise vanish (orphaning
+	// their project references). Migrate the legacy discovery cache into
+	// the peer store as token-less manual peers — but only the hosts a
+	// project actually references — then delete the cache. The user
+	// supplies each token via "Add token". Best-effort: never blocks
+	// startup.
+	if state, err := projectMgr.Load(); err != nil {
+		log.Printf("peerstore: legacy discovery migration skipped (projects load: %v)", err)
+	} else {
+		referenced := make(map[string]bool)
+		for _, it := range state.Items {
+			if it.Peer != "" {
+				referenced[it.Peer] = true
+			}
+		}
+		if n, err := peerStore.ImportLegacyDiscovery(stateDir, referenced); err != nil {
+			log.Printf("peerstore: legacy discovery migration: %v", err)
+		} else if n > 0 {
+			log.Printf("peerstore: migrated %d referenced host(s) from the legacy autodiscovery cache (supply a token to reconnect)", n)
+		}
+	}
 
 	// reconcileProjectStamps is the single point that updates each
 	// owned session's ProjectSlug / ProjectIndex from the current

--- a/services/gmuxd/internal/peerstore/peerstore.go
+++ b/services/gmuxd/internal/peerstore/peerstore.go
@@ -160,13 +160,21 @@ func (s *Store) AddOrGet(rec Record) (stored Record, outcome AddOutcome, err err
 
 	if i := s.matchIndex(rec); i >= 0 {
 		cur := s.records[i]
-		changed := cur.URL != rec.URL || cur.Token != rec.Token ||
+		// Empty Token/NodeID mean "unknown", not "clear it": only a non-empty
+		// value updates the stored one. This keeps the legacy-discovery
+		// import (token-less) from wiping the token of a host that was also
+		// added manually, and there's no flow that deliberately blanks a
+		// token. URL is always present (validated) so it always updates.
+		changed := cur.URL != rec.URL ||
+			(rec.Token != "" && cur.Token != rec.Token) ||
 			(rec.NodeID != "" && cur.NodeID != rec.NodeID)
 		if !changed {
 			return cur, Unchanged, nil
 		}
 		s.records[i].URL = rec.URL
-		s.records[i].Token = rec.Token
+		if rec.Token != "" {
+			s.records[i].Token = rec.Token
+		}
 		if rec.NodeID != "" {
 			s.records[i].NodeID = rec.NodeID
 		}

--- a/services/gmuxd/internal/peerstore/peerstore.go
+++ b/services/gmuxd/internal/peerstore/peerstore.go
@@ -120,32 +120,61 @@ func (s *Store) PeerConfigs() []config.PeerConfig {
 	return out
 }
 
-// AddOrGet atomically connects a host: if a record with the same
-// (non-empty) node_id already exists it is returned with existed=true
-// (the same host reached again is not a duplicate); otherwise the
-// record's name is slugified, de-collided, appended, and persisted.
+// AddOutcome reports what AddOrGet did to the store.
+type AddOutcome int
+
+const (
+	// Added: a brand-new record was appended.
+	Added AddOutcome = iota
+	// Updated: an existing record matched and its URL/token (and any
+	// newly-learned node_id) were refreshed in place.
+	Updated
+	// Unchanged: an existing record matched and nothing differed.
+	Unchanged
+)
+
+// AddOrGet upserts a host. It matches an existing record by node_id (the
+// durable identity) or, when that misses, by URL — so supplying a token
+// for a host added without one (e.g. one migrated from autodiscovery,
+// whose node_id isn't known until it first authenticates) refreshes that
+// record in place instead of creating a duplicate. On a match it updates
+// the URL, token, and (if newly learned) node_id while keeping the
+// existing display name; otherwise the name is slugified, de-collided,
+// appended, and persisted.
 //
-// The node_id check and the append happen under one lock, so two
-// concurrent connects to the same host can't both pass the dedup and
-// create duplicates (no check-then-act race).
-func (s *Store) AddOrGet(rec Record) (stored Record, existed bool, err error) {
+// Matching and the append happen under one lock, so two concurrent
+// connects to the same host can't both pass the dedup and create
+// duplicates (no check-then-act race).
+func (s *Store) AddOrGet(rec Record) (stored Record, outcome AddOutcome, err error) {
 	if err := ValidateURL(rec.URL); err != nil {
-		return Record{}, false, err
+		return Record{}, Added, err
 	}
 	name := Slugify(rec.Name)
 	if name == "" {
-		return Record{}, false, fmt.Errorf("host name %q has no usable slug characters", rec.Name)
+		return Record{}, Added, fmt.Errorf("host name %q has no usable slug characters", rec.Name)
 	}
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if rec.NodeID != "" {
-		for _, r := range s.records {
-			if r.NodeID == rec.NodeID {
-				return r, true, nil
-			}
+	if i := s.matchIndex(rec); i >= 0 {
+		cur := s.records[i]
+		changed := cur.URL != rec.URL || cur.Token != rec.Token ||
+			(rec.NodeID != "" && cur.NodeID != rec.NodeID)
+		if !changed {
+			return cur, Unchanged, nil
 		}
+		s.records[i].URL = rec.URL
+		s.records[i].Token = rec.Token
+		if rec.NodeID != "" {
+			s.records[i].NodeID = rec.NodeID
+		}
+		updated := s.records[i]
+		if err := s.save(); err != nil {
+			s.records[i] = cur // roll back the in-memory change
+			return Record{}, Added, err
+		}
+		return updated, Updated, nil
 	}
 
 	taken := make(map[string]bool, len(s.records))
@@ -157,9 +186,34 @@ func (s *Store) AddOrGet(rec Record) (stored Record, existed bool, err error) {
 	s.records = append(s.records, rec)
 	if err := s.save(); err != nil {
 		s.records = s.records[:len(s.records)-1]
-		return Record{}, false, err
+		return Record{}, Added, err
 	}
-	return rec, false, nil
+	return rec, Added, nil
+}
+
+// matchIndex returns the index of the record representing the same host
+// as rec — same node_id when known, else same URL — or -1 if none.
+// Caller holds s.mu.
+func (s *Store) matchIndex(rec Record) int {
+	if rec.NodeID != "" {
+		for i, r := range s.records {
+			if r.NodeID == rec.NodeID {
+				return i
+			}
+		}
+	}
+	for i, r := range s.records {
+		if sameURL(r.URL, rec.URL) {
+			return i
+		}
+	}
+	return -1
+}
+
+// sameURL reports whether two peer base URLs address the same host,
+// ignoring a trailing slash and case.
+func sameURL(a, b string) bool {
+	return strings.EqualFold(strings.TrimRight(a, "/"), strings.TrimRight(b, "/"))
 }
 
 // Remove deletes the record with the given name and persists. Returns

--- a/services/gmuxd/internal/peerstore/peerstore.go
+++ b/services/gmuxd/internal/peerstore/peerstore.go
@@ -17,6 +17,7 @@ package peerstore
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -214,6 +215,79 @@ func (s *Store) matchIndex(rec Record) int {
 // ignoring a trailing slash and case.
 func sameURL(a, b string) bool {
 	return strings.EqualFold(strings.TrimRight(a, "/"), strings.TrimRight(b, "/"))
+}
+
+// legacyDiscoveryFile is the pre-2.0 tailscale autodiscovery cache.
+const legacyDiscoveryFile = "tailscale-discovery.json"
+
+// legacyDiscoveryState / legacyDeviceEntry mirror the shape the removed
+// tsdiscovery package (ADR 0008) wrote to tailscale-discovery.json. They
+// exist only to migrate that cache's gmux entries into the peer store on
+// the first upgrade start.
+type legacyDiscoveryState struct {
+	Devices map[string]*legacyDeviceEntry `json:"devices"`
+}
+
+type legacyDeviceEntry struct {
+	FQDN     string `json:"fqdn"`
+	PeerName string `json:"peer_name"`
+	IsGmux   bool   `json:"is_gmux"`
+}
+
+// ImportLegacyDiscovery one-time-migrates the pre-2.0 autodiscovery
+// cache into the peer store: a cached gmux device becomes a manual peer
+// with no token (ADR 0008 removed autodiscovery, so the user
+// re-authenticates each host by supplying its token) — but only if a
+// project references it (its slugified name is in referenced). Those are
+// the hosts whose references would otherwise orphan; other gmux boxes
+// the tailnet once surfaced are left out rather than cluttering the
+// roster with "auth needed" rows, and can be re-added on demand. The
+// cache is removed afterward so the migration runs once regardless of
+// how many hosts matched. Returns the number of hosts newly added; an
+// absent cache is (0, nil).
+func (s *Store) ImportLegacyDiscovery(stateDir string, referenced map[string]bool) (int, error) {
+	path := filepath.Join(stateDir, legacyDiscoveryFile)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("peerstore: reading %s: %w", path, err)
+	}
+
+	var st legacyDiscoveryState
+	if err := json.Unmarshal(data, &st); err != nil {
+		// Unparseable cache: nothing to salvage. Drop it and move on.
+		_ = os.Remove(path)
+		return 0, nil
+	}
+
+	imported := 0
+	for _, d := range st.Devices {
+		if d == nil || !d.IsGmux || d.PeerName == "" || d.FQDN == "" {
+			continue
+		}
+		// Only carry forward hosts a project references; skip gmux boxes
+		// the tailnet surfaced but the user never pinned anything on.
+		if !referenced[Slugify(d.PeerName)] {
+			continue
+		}
+		// No token, no node_id: the host lands as "auth needed" until the
+		// user supplies its token, which upserts this record by URL.
+		_, outcome, err := s.AddOrGet(Record{Name: d.PeerName, URL: "https://" + d.FQDN})
+		if err != nil {
+			log.Printf("peerstore: skipping legacy peer %q: %v", d.PeerName, err)
+			continue
+		}
+		if outcome == Added {
+			imported++
+		}
+	}
+
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		log.Printf("peerstore: could not remove legacy %s: %v", legacyDiscoveryFile, err)
+	}
+	return imported, nil
 }
 
 // Remove deletes the record with the given name and persists. Returns

--- a/services/gmuxd/internal/peerstore/peerstore_test.go
+++ b/services/gmuxd/internal/peerstore/peerstore_test.go
@@ -6,6 +6,88 @@ import (
 	"testing"
 )
 
+func TestImportLegacyDiscovery(t *testing.T) {
+	dir := t.TempDir()
+	cache := `{"devices":{
+		"n1":{"fqdn":"gmux-laptop.angler-map.ts.net","peer_name":"laptop","is_gmux":true},
+		"n2":{"fqdn":"phone.angler-map.ts.net","peer_name":"","is_gmux":false},
+		"n3":{"fqdn":"gmux-server.angler-map.ts.net","peer_name":"server","is_gmux":true}
+	}}`
+	if err := os.WriteFile(filepath.Join(dir, legacyDiscoveryFile), []byte(cache), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	s, _ := Open(dir)
+	// Both gmux devices are referenced by a project; the non-gmux one
+	// can't be (and is filtered by IsGmux anyway).
+	referenced := map[string]bool{"laptop": true, "server": true}
+	n, err := s.ImportLegacyDiscovery(dir, referenced)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 2 {
+		t.Fatalf("imported = %d, want 2 (referenced gmux devices)", n)
+	}
+
+	recs := s.List()
+	if len(recs) != 2 {
+		t.Fatalf("records = %d, want 2", len(recs))
+	}
+	for _, r := range recs {
+		if r.Token != "" || r.NodeID != "" {
+			t.Errorf("migrated peer %q should have no token/node_id, got %+v", r.Name, r)
+		}
+		if r.URL == "" || r.URL[:8] != "https://" {
+			t.Errorf("migrated peer %q should have an https URL, got %q", r.Name, r.URL)
+		}
+	}
+
+	// Cache is removed so the migration runs once.
+	if _, err := os.Stat(filepath.Join(dir, legacyDiscoveryFile)); !os.IsNotExist(err) {
+		t.Fatal("legacy cache should be removed after import")
+	}
+
+	// Re-running is a no-op (cache gone).
+	if n, err := s.ImportLegacyDiscovery(dir, referenced); err != nil || n != 0 {
+		t.Fatalf("second import = (%d, %v), want (0, nil)", n, err)
+	}
+}
+
+// Only hosts a project references are carried forward; an unreferenced
+// gmux device is skipped, but the cache is still removed (migration runs
+// once regardless).
+func TestImportLegacyDiscoverySkipsUnreferenced(t *testing.T) {
+	dir := t.TempDir()
+	cache := `{"devices":{
+		"n1":{"fqdn":"gmux-laptop.ts.net","peer_name":"laptop","is_gmux":true},
+		"n2":{"fqdn":"gmux-spare.ts.net","peer_name":"spare","is_gmux":true}
+	}}`
+	if err := os.WriteFile(filepath.Join(dir, legacyDiscoveryFile), []byte(cache), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	s, _ := Open(dir)
+	n, err := s.ImportLegacyDiscovery(dir, map[string]bool{"laptop": true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Fatalf("imported = %d, want 1 (only the referenced host)", n)
+	}
+	if recs := s.List(); len(recs) != 1 || recs[0].Name != "laptop" {
+		t.Fatalf("want only 'laptop', got %+v", recs)
+	}
+	if _, err := os.Stat(filepath.Join(dir, legacyDiscoveryFile)); !os.IsNotExist(err) {
+		t.Fatal("cache should be removed even when some devices are skipped")
+	}
+}
+
+func TestImportLegacyDiscoveryAbsent(t *testing.T) {
+	s, _ := Open(t.TempDir())
+	if n, err := s.ImportLegacyDiscovery(t.TempDir(), map[string]bool{"x": true}); err != nil || n != 0 {
+		t.Fatalf("absent cache = (%d, %v), want (0, nil)", n, err)
+	}
+}
+
 func TestOpenEmptyWhenAbsent(t *testing.T) {
 	s, err := Open(t.TempDir())
 	if err != nil {

--- a/services/gmuxd/internal/peerstore/peerstore_test.go
+++ b/services/gmuxd/internal/peerstore/peerstore_test.go
@@ -47,36 +47,72 @@ func TestAddOrGetRejectsBadURL(t *testing.T) {
 	}
 }
 
-// Re-adding the same node_id returns the existing record (existed=true)
-// rather than creating a duplicate — and does so under one lock, so it's
-// safe against concurrent connects (no check-then-act race).
+// Re-adding the same node_id matches the existing record (no duplicate)
+// and refreshes its URL/token in place, keeping the display name — under
+// one lock, so it's safe against concurrent connects (no check-then-act
+// race).
 func TestAddOrGetDedupsByNodeID(t *testing.T) {
 	dir := t.TempDir()
 	s, _ := Open(dir)
-	first, _, _ := s.AddOrGet(Record{Name: "laptop", URL: "http://a:8790", NodeID: "node_x"})
+	first, _, _ := s.AddOrGet(Record{Name: "laptop", URL: "http://a:8790", Token: "t1", NodeID: "node_x"})
 
-	got, existed, err := s.AddOrGet(Record{Name: "laptop-again", URL: "http://b:8790", NodeID: "node_x"})
+	got, outcome, err := s.AddOrGet(Record{Name: "laptop-again", URL: "http://b:8790", Token: "t2", NodeID: "node_x"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !existed {
-		t.Fatal("re-adding same node_id should report existed=true")
+	if outcome != Updated {
+		t.Fatalf("re-adding same node_id with new creds should report Updated, got %v", outcome)
 	}
-	if got.Name != first.Name || got.URL != "http://a:8790" {
-		t.Fatalf("dedup should return the original record, got %+v", got)
+	if got.Name != first.Name || got.URL != "http://b:8790" || got.Token != "t2" {
+		t.Fatalf("upsert should keep the name and refresh url/token, got %+v", got)
 	}
 	if len(s.List()) != 1 {
-		t.Fatalf("dedup must not append, got %d records", len(s.List()))
+		t.Fatalf("upsert must not append, got %d records", len(s.List()))
 	}
 }
 
-// An empty node_id is undedupable: each add is a distinct host.
-func TestAddOrGetEmptyNodeIDNotDeduped(t *testing.T) {
+// Re-adding identical creds is a no-op: outcome Unchanged, no rewrite.
+func TestAddOrGetUnchanged(t *testing.T) {
+	s, _ := Open(t.TempDir())
+	s.AddOrGet(Record{Name: "laptop", URL: "http://a:8790", Token: "t", NodeID: "node_x"})
+	_, outcome, err := s.AddOrGet(Record{Name: "laptop", URL: "http://a:8790", Token: "t", NodeID: "node_x"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome != Unchanged {
+		t.Fatalf("identical re-add should report Unchanged, got %v", outcome)
+	}
+}
+
+// A host added without a node_id (e.g. migrated from autodiscovery) is
+// matched by URL on the next connect, so supplying a token updates that
+// record and stamps the now-known node_id instead of duplicating it.
+func TestAddOrGetUpsertsByURLWhenNodeIDUnknown(t *testing.T) {
+	s, _ := Open(t.TempDir())
+	s.AddOrGet(Record{Name: "old-tower", URL: "https://old-tower.ts.net"}) // no token, no node_id
+
+	got, outcome, err := s.AddOrGet(Record{Name: "old-tower", URL: "https://old-tower.ts.net", Token: "secret", NodeID: "node_ot"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome != Updated {
+		t.Fatalf("supplying a token for a URL-matched host should report Updated, got %v", outcome)
+	}
+	if got.Token != "secret" || got.NodeID != "node_ot" {
+		t.Fatalf("upsert should set token and stamp node_id, got %+v", got)
+	}
+	if len(s.List()) != 1 {
+		t.Fatalf("URL match must not append, got %d records", len(s.List()))
+	}
+}
+
+// Distinct URLs with no node_id stay distinct hosts.
+func TestAddOrGetEmptyNodeIDDistinctURLsNotDeduped(t *testing.T) {
 	s, _ := Open(t.TempDir())
 	s.AddOrGet(Record{Name: "a", URL: "http://a:8790"})
 	s.AddOrGet(Record{Name: "b", URL: "http://b:8790"})
 	if len(s.List()) != 2 {
-		t.Fatalf("empty node_id must not dedup, got %d", len(s.List()))
+		t.Fatalf("distinct URLs must not dedup, got %d", len(s.List()))
 	}
 }
 

--- a/services/gmuxd/internal/peerstore/peerstore_test.go
+++ b/services/gmuxd/internal/peerstore/peerstore_test.go
@@ -81,6 +81,31 @@ func TestImportLegacyDiscoverySkipsUnreferenced(t *testing.T) {
 	}
 }
 
+// A host that was both added manually (with a token) and present in the
+// legacy cache must keep its token through the migration — importing it
+// token-less must not knock it back to "auth needed".
+func TestImportLegacyDiscoveryPreservesExistingToken(t *testing.T) {
+	dir := t.TempDir()
+	s, _ := Open(dir)
+	s.AddOrGet(Record{Name: "laptop", URL: "https://gmux-laptop.ts.net", Token: "keep-me", NodeID: "node_l"})
+
+	cache := `{"devices":{"n1":{"fqdn":"gmux-laptop.ts.net","peer_name":"laptop","is_gmux":true}}}`
+	if err := os.WriteFile(filepath.Join(dir, legacyDiscoveryFile), []byte(cache), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	n, err := s.ImportLegacyDiscovery(dir, map[string]bool{"laptop": true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 0 {
+		t.Fatalf("imported = %d, want 0 (host already present)", n)
+	}
+	recs := s.List()
+	if len(recs) != 1 || recs[0].Token != "keep-me" || recs[0].NodeID != "node_l" {
+		t.Fatalf("existing token/node_id must survive a token-less import, got %+v", recs)
+	}
+}
+
 func TestImportLegacyDiscoveryAbsent(t *testing.T) {
 	s, _ := Open(t.TempDir())
 	if n, err := s.ImportLegacyDiscovery(t.TempDir(), map[string]bool{"x": true}); err != nil || n != 0 {
@@ -185,6 +210,23 @@ func TestAddOrGetUpsertsByURLWhenNodeIDUnknown(t *testing.T) {
 	}
 	if len(s.List()) != 1 {
 		t.Fatalf("URL match must not append, got %d records", len(s.List()))
+	}
+}
+
+// URL matching ignores a trailing slash, so re-adding the same host with
+// a "/"-suffixed URL upserts rather than creating a second record.
+func TestAddOrGetUpsertMatchesURLIgnoringTrailingSlash(t *testing.T) {
+	s, _ := Open(t.TempDir())
+	s.AddOrGet(Record{Name: "oldbox", URL: "https://oldbox.ts.net"})
+	_, outcome, err := s.AddOrGet(Record{Name: "oldbox", URL: "https://oldbox.ts.net/", Token: "secret", NodeID: "node_ob"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome != Updated {
+		t.Fatalf("trailing-slash variant should match and update, got %v", outcome)
+	}
+	if len(s.List()) != 1 {
+		t.Fatalf("trailing-slash variant must not append, got %d records", len(s.List()))
 	}
 }
 

--- a/services/gmuxd/internal/projects/migrate_test.go
+++ b/services/gmuxd/internal/projects/migrate_test.go
@@ -165,6 +165,43 @@ func TestV3References(t *testing.T) {
 	}
 }
 
+func TestLoadBacksUpBeforeMigration(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, fileName)
+	bak := path + ".bak"
+
+	// A pre-version (v0/v1) file triggers a real migration → backup.
+	v1 := `{"items":[{"slug":"gmux","remote":"github.com/gmuxapp/gmux","paths":["/home/x/dev/gmux"]}]}`
+	if err := os.WriteFile(path, []byte(v1), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Load(dir); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	got, err := os.ReadFile(bak)
+	if err != nil {
+		t.Fatalf("expected %s to exist: %v", bak, err)
+	}
+	if string(got) != v1 {
+		t.Fatalf("backup should hold the verbatim pre-migration bytes, got %q", got)
+	}
+
+	// A file already at the current version is not backed up again.
+	os.Remove(bak)
+	current := `{"version":` + itoa(currentVersion) + `,"items":[]}`
+	if err := os.WriteFile(path, []byte(current), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Load(dir); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if _, err := os.Stat(bak); !os.IsNotExist(err) {
+		t.Fatal("a current-version file should not be backed up")
+	}
+}
+
+func itoa(n int) string { return fmt.Sprintf("%d", n) }
+
 func TestMigrateRoundtrip(t *testing.T) {
 	// Save state, reload, verify identical.
 	dir := t.TempDir()

--- a/services/gmuxd/internal/projects/projects.go
+++ b/services/gmuxd/internal/projects/projects.go
@@ -11,6 +11,7 @@ package projects
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -94,6 +95,13 @@ func Load(stateDir string) (*State, error) {
 		return nil, fmt.Errorf("projects: reading %s: %w", path, err)
 	}
 
+	// Before a real schema upgrade rewrites the file, snapshot the
+	// pre-migration bytes to projects.json.bak so the change is
+	// recoverable (notably across the 2.0 upgrade). Best-effort.
+	if onDiskVersion(data) < currentVersion {
+		backupFile(path, data)
+	}
+
 	// Run migrations on the raw JSON before unmarshaling into the
 	// current struct layout. This keeps each migration self-contained
 	// and independent of the Go types.
@@ -107,6 +115,29 @@ func Load(stateDir string) (*State, error) {
 		return nil, fmt.Errorf("projects: parsing %s: %w", path, err)
 	}
 	return &s, nil
+}
+
+// onDiskVersion peeks at the schema version of a raw projects.json
+// document. A missing or invalid version field is the original
+// pre-version format (0).
+func onDiskVersion(data []byte) int {
+	var doc struct {
+		Version int `json:"version"`
+	}
+	_ = json.Unmarshal(data, &doc)
+	return doc.Version
+}
+
+// backupFile writes the pre-migration bytes to path+".bak" (0600),
+// overwriting any earlier backup. Best-effort: a failure is logged but
+// never fatal — a missing backup must not stop projects.json loading.
+func backupFile(path string, original []byte) {
+	bak := path + ".bak"
+	if err := os.WriteFile(bak, original, 0o600); err != nil {
+		log.Printf("projects: could not write %s: %v", bak, err)
+		return
+	}
+	log.Printf("projects: backed up pre-migration state to %s", bak)
 }
 
 // Save writes the project state atomically to stateDir/projects.json.


### PR DESCRIPTION
Builds on the merged ADR 0008 (#280). Makes the 2.0 upgrade carry hosts forward instead of dropping them, and gives every host an explicit, actionable status. Flips ADR 0008 to **Accepted**.

## The upgrade story
ADR 0008 removed Tailscale autodiscovery. Previously, that meant auto-discovered hosts simply vanished on upgrade and their project references orphaned. Instead:

- **Migrate the legacy `tailscale-discovery.json` cache into `peers.json`** — but only the gmux hosts **a project actually references** (the ones whose references would otherwise orphan). Other gmux boxes the tailnet once surfaced are left out rather than filling the roster with "Auth needed" rows; they can be re-added on demand. The cache is deleted afterward. Each imported host lands as **Auth needed**; supplying its token brings it online (references keep resolving throughout). A host that was *also* added manually keeps its existing token — the token-less import never clobbers it.
- **Supplying a token reuses the connect flow** (`POST /v1/peers`) — `AddOrGet` is now a real upsert, matching by node_id *or* URL and refreshing URL/token in place (empty fields mean "unknown", never "clear"), then reconnecting the live peer.
- **`projects.json` is backed up to `projects.json.bak`** before any schema migration rewrites it.

## Host status UX
- A host row shows a derived status: **Online / Connecting… / Auth needed / Offline**. Offline reads as "down — comes back" (muted, with the connection error as detail); Auth needed is amber with an **Add token** button that pre-fills the connect form and focuses the token field. Re-supplying a token reports "Reconnected to X."
- "Reachable, not gmux" is intentionally folded into Offline — there's no reliable transport-level signal for it (noted in code).

## Simplification (option B)
- **Dropped reference remap.** With removed hosts now clearing their references and offline hosts staying resolved, the only thing left in "Referenced but not found" is a reference to a host not in the roster — re-adding the host resolves it automatically. The section is now remove-only; the dead `remapReferences`/`remapReferenceItems` helpers and tests are gone.

## Tests / verification
- New: `peerstore` upsert tests (node_id update, URL match incl. trailing-slash, unchanged, **token-not-clobbered**) + legacy-import tests (referenced-only, skip-unreferenced, **preserves existing token**, absent); `projects` backup test; `hostStatus` pure-helper tests. Full Go suite + 458 web tests pass; `tsc` clean.
- Migration verified live: referenced host imported token-less, unreferenced gmux skipped, a manually-added host's token preserved, cache removed, existing peer untouched.
- Add-token flow verified live in the mock UI (pre-fills URL, focuses token).

Docs: `using-the-ui` (status table + Add token + upgrade note), `multi-machine` (remove-only unresolved flow + upgrade section), `file-paths` (`peers.json`, `projects.json.bak`), ADR 0008 migration section + status.

## Also included (folded from #283)
- **Settings modal scrollable on short/mobile viewports** — `.settings-main` was missing `min-height: 0`, so the inner `.modal-body` scroller expanded to its full content height and overflowed the capped panel (clipped by `overflow: hidden`) instead of scrolling. Pre-existing structural bug; this PR's extra host-status rows just made it easier to hit. Verified across viewport heights via DevTools layout measurements (both tabs scroll to the bottom; desktop unchanged).