### PR TITLE
fix(web): make the settings body scrollable on short/mobile viewports

### DIFF
--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -989,6 +989,12 @@ body {
 .settings-main {
   flex: 1;
   min-width: 0;
+  /* Without this, the auto min-height of a flex item keeps this column
+     from shrinking below its content, so the .modal-body scroller grows
+     to its full content height and overflows the (capped) panel instead
+     of scrolling. Bites on short/mobile viewports where the panel's
+     max-height is well below the content. */
+  min-height: 0;
   display: flex;
   flex-direction: column;
 }


### PR DESCRIPTION
## Problem
On mobile (and any short viewport), the **Settings** modal couldn't scroll — anything past the fold was unreachable. With the panel correctly capped to `var(--app-height) - 64px`, the inner `.modal-body` scroller instead expanded to its **full content height** and overflowed the panel, where `.settings-modal { overflow: hidden }` clipped it.

## Cause
`.settings-main` is a flex column holding the `.modal-body` scroller, but it was missing `min-height: 0`. A flex item's default `min-height: auto` refuses to shrink below its content, so the column (and the `flex: 1` body inside it) grew to fit all content rather than constraining the body to the available height and letting it scroll. It bit hardest on short viewports, where the panel's `max-height` sits well below the content.

## Fix
Add `min-height: 0` to `.settings-main` — the standard nested-flex-scroll fix.

## Verification
Reproduced and confirmed fixed via DevTools layout measurements across viewport heights:

| viewport | before | after |
|---|---|---|
| 390×360 | body 881px tall, clipped, `scrolls:false` | body 247px, `scrolls:true`, reaches bottom |
| 390×600 | clipped, `scrolls:false` | `scrolls:true` |

- Both tabs (Hosts + Projects) scroll on a short viewport.
- Desktop (1100×800) unchanged: fixed 538px panel, body still scrolls when content exceeds it.
- 458 web tests pass; `tsc` clean.

This is a pre-existing structural bug in the settings modal (independent of #282; that PR's extra host-status rows just made overflow more likely).