### PR TITLE
feat(web): show unavailable projects in the settings modal

### DIFF
--- a/apps/gmux-web/src/mock-data/index.ts
+++ b/apps/gmux-web/src/mock-data/index.ts
@@ -73,6 +73,9 @@ export const MOCK_PROJECTS: ProjectItem[] = [
   },
   // A resolved reference to a roster peer (server).
   { slug: 'api', peer: 'server' },
+  // A reference to a roster host that is currently disconnected
+  // (bespin) — surfaces as an offline/unavailable project.
+  { slug: 'telemetry', peer: 'bespin' },
   // An unresolved reference: 'old-tower' is in no roster bucket, so it
   // surfaces as a host-not-found state in the sidebar and Hosts tab.
   { slug: 'legacy-app', peer: 'old-tower' },

--- a/apps/gmux-web/src/projects.test.ts
+++ b/apps/gmux-web/src/projects.test.ts
@@ -14,6 +14,7 @@ import {
   mostCommonRemote,
   discoverProjects,
   countUnmatchedActive,
+  projectAvailability,
 } from './projects'
 import { makeSession } from './test-helpers'
 
@@ -1002,5 +1003,42 @@ describe('countUnmatchedActive', () => {
 
   it('returns 0 when there are no sessions', () => {
     expect(countUnmatchedActive([], [])).toBe(0)
+  })
+})
+
+describe('projectAvailability', () => {
+  const connected = new Map([['server', 'connected'], ['bespin', 'disconnected']])
+
+  it('reports owned (local) projects as ok regardless of peer roster', () => {
+    expect(projectAvailability({ peer: undefined }, new Map())).toBe('ok')
+  })
+
+  it('reports a reference to a connected host as ok', () => {
+    expect(projectAvailability({ peer: 'server' }, connected)).toBe('ok')
+  })
+
+  it('reports a reference to a roster host that is not connected as offline', () => {
+    expect(projectAvailability({ peer: 'bespin' }, connected)).toBe('offline')
+  })
+
+  it('reports a reference to a host absent from the roster as offline', () => {
+    // peer set but not in the status map at all (e.g. removed peer that
+    // still resolved by name moments ago) is treated as not reachable.
+    expect(projectAvailability({ peer: 'ghost' }, connected)).toBe('offline')
+  })
+
+  it('reports an unresolved reference as unresolved', () => {
+    expect(projectAvailability({ peer: 'old-tower', unresolved: true }, connected)).toBe('unresolved')
+  })
+
+  it('reports a connected host missing the slug as missing', () => {
+    expect(projectAvailability({ peer: 'server', missing: true }, connected)).toBe('missing')
+  })
+
+  it('prefers unresolved over offline when both could apply', () => {
+    // A stored name that is both unresolved and (coincidentally) a
+    // disconnected roster entry surfaces as unresolved — the actionable
+    // state — not offline.
+    expect(projectAvailability({ peer: 'bespin', unresolved: true }, connected)).toBe('unresolved')
   })
 })

--- a/apps/gmux-web/src/projects.ts
+++ b/apps/gmux-web/src/projects.ts
@@ -418,6 +418,38 @@ export function buildProjectFolders(
 }
 
 /**
+ * Why a project's host can't be reached right now, or `'ok'` when it
+ * can. Lets management surfaces (the settings modal) mirror the
+ * sidebar's muted/marked treatment of unavailable projects from one
+ * place.
+ *
+ *   - `'ok'`         — owned (local) project, or a reference whose host
+ *                      is connected and still reports the slug.
+ *   - `'unresolved'` — reference whose host is in no roster bucket
+ *                      (renamed/removed); fix under Settings -> Hosts.
+ *   - `'missing'`    — reference whose host is connected but no longer
+ *                      reports the slug (project removed upstream).
+ *   - `'offline'`    — reference whose host is in the roster but not
+ *                      connected right now.
+ *
+ * Precedence matches the order above: an unresolved or dangling
+ * reference is reported as such even when its (stored) name also
+ * happens to be a disconnected peer.
+ */
+export type ProjectAvailability = 'ok' | 'unresolved' | 'missing' | 'offline'
+
+export function projectAvailability(
+  folder: Pick<Folder, 'peer' | 'missing' | 'unresolved'>,
+  peerStatusByName: ReadonlyMap<string, string>,
+): ProjectAvailability {
+  if (!folder.peer) return 'ok' // owned/local: always reachable
+  if (folder.unresolved) return 'unresolved'
+  if (folder.missing) return 'missing'
+  if (peerStatusByName.get(folder.peer) !== 'connected') return 'offline'
+  return 'ok'
+}
+
+/**
  * Sort key for a session inside a folder.
  *
  * Stamps are now the sole authority for both folder membership and

--- a/apps/gmux-web/src/settings.tsx
+++ b/apps/gmux-web/src/settings.tsx
@@ -24,6 +24,7 @@ import {
 } from './store'
 import { HostSuffix } from './host-suffix'
 import { hostStatus } from './host-status'
+import { projectAvailability } from './projects'
 import type { ProjectItem, DiscoveredProject, MatchRule, Folder, PeerInfo } from './types'
 import type { UnresolvedHost } from './references'
 
@@ -657,9 +658,13 @@ function ConfiguredProjectRow({
   const alive = f.sessions.filter(s => s.alive).length
   const resumable = f.sessions.filter(s => !s.alive && s.resumable).length
   const isReference = !!project.peer
+  // Mirror the sidebar: a reference whose host is unresolved, dangling,
+  // or offline reads as unavailable here too — muted row + a marker
+  // sharing the sidebar's pip vocabulary.
+  const availability = projectAvailability(f, peerStatusByName.value)
   return (
     <div
-      class={`mp-configured-row${dragging ? ' dragging' : ''}${dropTarget ? ' drop-target' : ''}`}
+      class={`mp-configured-row${availability !== 'ok' ? ' unavailable' : ''}${dragging ? ' dragging' : ''}${dropTarget ? ' drop-target' : ''}`}
       draggable
       onDragStart={(e) => {
         e.dataTransfer!.effectAllowed = 'move'
@@ -679,6 +684,15 @@ function ConfiguredProjectRow({
         <span class="mp-configured-name">
           {f.name}
           <HostSuffix peer={f.peer ?? localHostLabel.value} local={!f.peer} />
+          {availability === 'unresolved' && (
+            <span class="folder-unresolved-icon" title="Host not found — fix in Settings → Hosts">!</span>
+          )}
+          {availability === 'missing' && (
+            <span class="folder-missing-icon" title="Project missing on host">?</span>
+          )}
+          {availability === 'offline' && (
+            <span class="folder-offline-icon" title="Host offline">×</span>
+          )}
         </span>
         <span class="mp-configured-count">
           {alive > 0 && <span class="mp-configured-alive">{alive} alive</span>}

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -640,6 +640,23 @@ body {
   font-weight: 700;
   line-height: 1cap;
 }
+/* Offline reference: the host is in the roster but not connected right
+   now. Neutral grey — it's a transient "down, comes back" state, not a
+   "fix me" warning like unresolved/missing. */
+.folder-offline-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  margin-left: 6px;
+  border-radius: 50%;
+  background: oklch(30% 0 0);
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1cap;
+}
 .session-status-label {
   color: var(--text-secondary);
 }
@@ -2016,6 +2033,13 @@ body {
 }
 .mp-configured-row.drop-target {
   box-shadow: inset 0 -2px 0 0 var(--accent);
+}
+/* Unavailable reference (unresolved / missing / offline host): dim the
+   name + count like the sidebar dims unreachable folders, while leaving
+   the drag handle and remove control at full strength so the row stays
+   manageable. */
+.mp-configured-row.unavailable .mp-configured-info {
+  opacity: 0.55;
 }
 .mp-configured-drag {
   color: var(--text-muted);


### PR DESCRIPTION
## Problem
In the sidebar, a project whose host can't be reached is visually flagged — the folder is muted and carries a marker (`!` host-not-found, `?` missing). But the **Settings → Projects → Your projects** list rendered every reference identically, so a project pointing at a renamed, removed, or offline host looked perfectly healthy there. The management surface hid exactly the state you'd open it to fix.

## Change
Mirror the sidebar's treatment in the configured-projects list. Each reference row now derives its availability and, when unreachable, mutes the name/count and shows a marker sharing the sidebar's pip vocabulary:

| state | marker | meaning |
|---|---|---|
| **unresolved** | amber `!` | host is in no roster bucket (renamed/removed) — fix under Settings → Hosts |
| **missing** | red `?` | host is connected but no longer reports the slug (project removed upstream) |
| **offline** | grey `×` | host is in the roster but not connected right now (transient) |

Owned (local) projects are always available.

## Implementation
- New pure helper `projectAvailability(folder, peerStatusByName)` in `projects.ts` returning `'ok' | 'unresolved' | 'missing' | 'offline'`, with documented precedence (an unresolved/dangling reference wins over a coincidental offline name). `unresolved`/`missing` come straight off the `Folder` (already computed centrally for the sidebar); `offline` is derived from peer status.
- `ConfiguredProjectRow` consumes it: `.unavailable` row modifier dims `.mp-configured-info` (drag handle + remove stay full-strength so the row is still manageable), plus the marker after the host suffix.
- New `.folder-offline-icon` (neutral grey pip) alongside the existing unresolved/missing pips.
- Mock gains a reference to the disconnected `bespin` host so the offline state is demonstrable.

## Tests / verification
- 7 new `projectAvailability` unit tests (owned, connected, offline, absent-from-roster, unresolved, missing, unresolved-beats-offline precedence). 465 web tests pass; `tsc` clean.
- Verified in the mock UI (production build + `vite preview`): `telemetry · bespin` shows the grey `×` muted, `legacy-app · old-tower` shows the amber `!` muted, healthy references unchanged.