### PR TITLE
fix(gmuxd): disable permessage-deflate on the peer-proxy browser WebSocket too (mobile reconnect storm)

### DIFF
--- a/services/gmuxd/internal/apiclient/client.go
+++ b/services/gmuxd/internal/apiclient/client.go
@@ -354,12 +354,18 @@ func (c *Client) DialWS(ctx context.Context, sessionID string) (*websocket.Conn,
 // sessionID is the ORIGINAL (unnamespaced) session ID on the spoke,
 // not the namespaced wire ID. Callers strip the suffix first.
 func (c *Client) ProxyWS(w http.ResponseWriter, r *http.Request, sessionID string) {
-	// CompressionContextTakeover compresses the browser-facing hop
-	// (terminal output is highly repetitive); the hub->spoke hop is
-	// left uncompressed. Safari falls back to uncompressed. See #242.
+	// No permessage-deflate on the browser-facing hop. #242 enabled it
+	// here to shrink the repetitive terminal replay, but at least one
+	// mobile browser negotiates deflate and then mis-decodes gmuxd's
+	// frames, dropping the socket right after the first large frame (the
+	// replay) and triggering a reconnect storm. #279 disabled it on the
+	// local-session hop (wsproxy); a session that lives on a remote host
+	// is proxied through here instead, so this hop must match — otherwise
+	// the storm returns the moment you view a peer's session on mobile.
+	// The hub->spoke hop (DialWS) is uncompressed too. Revisit #242's
+	// bandwidth goal another way (e.g. bounding replay size) if needed.
 	clientConn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
 		InsecureSkipVerify: true,
-		CompressionMode:    websocket.CompressionContextTakeover,
 	})
 	if err != nil {
 		log.Printf("apiclient ProxyWS: accept: %v", err)

--- a/services/gmuxd/internal/apiclient/client_test.go
+++ b/services/gmuxd/internal/apiclient/client_test.go
@@ -639,6 +639,41 @@ func TestProxyWS_ClientDisconnectClosesSpoke(t *testing.T) {
 	}
 }
 
+// TestProxyWS_NoCompressionToBrowser locks in #279's fix for the
+// peer-proxy hop: the browser-facing WebSocket must never negotiate
+// permessage-deflate. At least one mobile browser offers deflate but
+// then mis-decodes gmuxd's frames and drops the socket right after the
+// first large replay frame, producing a reconnect storm. #279 disabled
+// compression on the local-session hop (wsproxy); a session that lives
+// on a remote host is proxied here instead, so this hop must match or
+// the storm comes back when you view a peer's session on mobile.
+func TestProxyWS_NoCompressionToBrowser(t *testing.T) {
+	spoke := wsEchoServer(t, nil, "")
+	defer spoke.Close()
+
+	c := New(spoke.URL)
+	hub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.ProxyWS(w, r, "sess")
+	}))
+	defer hub.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	wsURL := "ws" + strings.TrimPrefix(hub.URL, "http")
+	// Offer permessage-deflate, exactly as the affected mobile browsers do.
+	browser, resp, err := websocket.Dial(ctx, wsURL, &websocket.DialOptions{
+		CompressionMode: websocket.CompressionContextTakeover,
+	})
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer browser.Close(websocket.StatusNormalClosure, "")
+
+	if ext := resp.Header.Get("Sec-WebSocket-Extensions"); strings.Contains(ext, "permessage-deflate") {
+		t.Errorf("server negotiated permessage-deflate (%q); it must stay disabled on the browser-facing peer hop (#279)", ext)
+	}
+}
+
 
 // TestForwardAction_PreservesQueryString locks in the contract that
 // action endpoints with query parameters (e.g. /scrollback?tail=N)


### PR DESCRIPTION
## TL;DR
The mobile reconnect-storm diagnosis was **right** (permessage-deflate breaks the affected mobile browser); the #279 **fix was incomplete**. #279 disabled compression only on the *local-session* hop (`wsproxy`). A session that lives on a **remote host** is proxied through a different browser-facing accept — `apiclient.ProxyWS` — which still enabled `CompressionContextTakeover`. So the storm returns the moment you view a peer's session (e.g. gmux-hs) on mobile.

## Why this is the culprit
The `/ws/{sessionID}` handler forks by ownership:

- **Local session** → `wsProxy.Handler()` → compression **disabled** (#279, `wsproxy.go`).
- **Peer session** → `peer.ProxyWS()` → `apiclient.ProxyWS` → compression **`CompressionContextTakeover`** (untouched by #279).

`git show` confirms #279 (`8770e4d4`) only changed `wsproxy.go`. The hub→spoke dial (`DialWS`) was already uncompressed, so the only place deflate still reached the browser was the peer-proxy accept. Its comment even still claimed "Safari falls back to uncompressed" — the exact assumption #279 disproved (the browser negotiates deflate, then mis-decodes gmuxd's frames and drops after the first large replay frame).

## Fix
Drop `CompressionMode: CompressionContextTakeover` from `apiclient.ProxyWS` so the peer hop matches `wsproxy` (library default = `CompressionDisabled`). Comment rewritten to record the #279 finding and cross-reference it.

## Test (red→green)
New `TestProxyWS_NoCompressionToBrowser`: a browser dials the hub **offering** permessage-deflate (as the affected mobile browsers do) and asserts the handshake response does **not** negotiate it.

- **Before the fix:** fails — `server negotiated permessage-deflate`.
- **After:** passes. Full `apiclient` + Go suites green; installed locally, daemon healthy.

## Note on deployment
This runs on whichever daemon performs the proxy (the one the browser connects to that forwards to the spoke). If you reach gmux-hs through your local daemon, updating the local install is enough; if the browser hits gmux-hs's own daemon and it forwards to a further spoke, gmux-hs needs the new binary too.