### PR TITLE
docs: correct scrollback size and architecture description

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ graph LR
 
 **`gmuxd`** runs once per machine (auto-started by `gmux`). It discovers sessions via their Unix sockets, caches their state, proxies WebSocket connections, and pushes real-time updates to the browser via SSE. It's stateless — restart it anytime, it rebuilds from what's running.
 
-**`gmux-web`** is the browser UI. The sidebar groups sessions by working directory, with status dots that pulse when something needs attention. The terminal is xterm.js — the same battle-tested terminal emulator that powers VS Code's integrated terminal — with synchronized output for flicker-free session switching and 128KB of scrollback that replays instantly on reconnect.
+**`gmux-web`** is the browser UI. The sidebar groups sessions by working directory, with status dots that pulse when something needs attention. The terminal is xterm.js — the same battle-tested terminal emulator that powers VS Code's integrated terminal — with synchronized output for flicker-free session switching and ~1 MiB of persisted scrollback that replays instantly on reconnect.
 
 ## What you see
 
@@ -86,7 +86,7 @@ Sessions are grouped into **folders** by working directory. Each folder heading 
 ### Sessions
 - **Launch anything** — `gmux <command>` wraps any process in a managed session
 - **Full terminal** — xterm.js with WebSocket transport, the same terminal emulator as VS Code
-- **128KB scrollback** — replays instantly on reconnect, no lost context
+- **~1 MiB persisted scrollback** — replays instantly on reconnect, survives runner exit, no lost context
 - **Flicker-free switching** — DEC 2026 synchronized output renders session swaps in a single frame
 - **Session lifecycle** — live status, exit codes, kill from the UI
 - **Reconnecting** — tab away, come back, the terminal is right where you left it

--- a/apps/gmux-web/src/terminal.tsx
+++ b/apps/gmux-web/src/terminal.tsx
@@ -156,8 +156,9 @@ function focusTerminalInput(term: Terminal | null): void {
  *
  * Architecture: one Terminal lives for the app lifetime. Switching sessions
  * closes the old WS, clears the terminal, and opens a new WS. The runner's
- * 128KB scrollback ring buffer replays on connect, so history is preserved
- * without keeping per-session xterm instances alive.
+ * persisted scrollback (an on-disk append-only file that rotates at ~1 MiB,
+ * not a ring buffer) replays on connect, so history is preserved without
+ * keeping per-session xterm instances alive.
  *
  * Resize model: selecting a session claims ownership — the first WS connect
  * resizes the PTY to fit this browser's viewport. While driving, viewport

--- a/apps/website/src/content/docs/architecture.md
+++ b/apps/website/src/content/docs/architecture.md
@@ -11,7 +11,7 @@ One per session. It:
 
 - Launches the child process under a PTY
 - Owns the live session state (title, status, working flag)
-- Maintains a scrollback ring buffer for session replay on reconnect
+- Persists PTY output to an on-disk scrollback file for session replay on reconnect
 - Exposes the session on a Unix socket (metadata, events, terminal attach)
 - Runs adapter logic over child output
 
@@ -77,7 +77,11 @@ Each `gmux` runner exposes its session on a Unix socket. `gmuxd` discovers these
 
 ## Scrollback replay
 
-Each runner maintains a 128KB ring buffer that captures PTY output. When a browser connects or switches sessions, the runner sends the buffered content so the terminal shows the session's current state immediately. Screen clears reset the buffer, and TUI frame boundaries are detected so replay starts at a clean frame.
+Two distinct mechanisms back replay, and they should not be conflated:
+
+- **On-connect emulator snapshot** — the runner keeps a virtual terminal (line-bounded, ~2000 lines via `SetScrollbackSize`) of the live session. When a browser connects or switches sessions, the runner sends this snapshot so the terminal shows the session's current state immediately. Screen clears reset the emulator, and TUI frame boundaries are detected so replay starts at a clean frame. This snapshot lives only while the runner is alive.
+
+- **Persisted on-disk scrollback** — the runner also appends raw PTY bytes to an on-disk scrollback file (`packages/scrollback`). This is **not a ring buffer**: it's an append-only active file that rotates when it exceeds `MaxBytes` (1 MiB). On rotation the active file is renamed to `scrollback.0` and a fresh active file is opened, so total on-disk usage is bounded at `2 * MaxBytes` (2 MiB). Because it lives on disk, this scrollback survives runner exit and serves post-mortem replay for dead sessions.
 
 ## API surface
 

--- a/services/gmuxd/internal/wsproxy/wsproxy.go
+++ b/services/gmuxd/internal/wsproxy/wsproxy.go
@@ -105,7 +105,6 @@ func (p *Proxy) Handler() http.HandlerFunc {
 		p.addConn(sessionID, clientConn)
 		log.Printf("wsproxy: proxying %s via %s", sessionID, sockPath)
 
-		// Read limits must exceed the scrollback buffer size (128KB)
 		// Client sends keyboard input + resize messages (small).
 		clientConn.SetReadLimit(256 * 1024)
 		// Backend sends terminal snapshots on connect which can be large


### PR DESCRIPTION
Implements review ticket T07.

The docs and code comments repeatedly described the persisted scrollback as a "128KB ring buffer". Both are wrong: the real cap is `packages/scrollback`'s `MaxBytes = 1 << 20` (1 MiB = 1048576 bytes), with on-disk usage bounded at `2 * MaxBytes` (2 MiB), and the design is an append-only active file with rotation (`scrollback` → `scrollback.0`), not a ring buffer. The docs also conflated the in-RAM on-connect emulator snapshot (line-bounded, `maxScrollback = 2000` lines via `SetScrollbackSize`, runner-lifetime only) with the persisted on-disk scrollback (byte-bounded, survives runner exit). This PR corrects the size figure, replaces "ring buffer" with an accurate rotation description, and distinguishes the two replay mechanisms in architecture.md. **Prose/comments only; zero behavior change.**

## Files changed (exactly the ticket's named sites)
- `README.md` (2 sites) — prose
- `apps/website/src/content/docs/architecture.md` (2 sites) — prose
- `services/gmuxd/internal/wsproxy/wsproxy.go` (1 line, comment removal)
- `apps/gmux-web/src/terminal.tsx` (JSDoc only)

`jj diff --stat`: 4 files, +11/-7. The wsproxy change is a single stale comment-line deletion; `SetReadLimit` values are untouched.

## Verification
- `grep -rn 128KB / '128 KB' / 'ring buffer'` across the four ticket files: clean except the two intentional "not a ring buffer" clarifications.
- Corrected number matches code: `1 << 20 = 1048576 = 1 MiB`, on-disk cap `2 * MaxBytes = 2 MiB` (`packages/scrollback/scrollback.go`).
- Emulator-snapshot vs persisted-scrollback distinction matches code: `cli/gmux/internal/ptyserver/ptyserver.go` `maxScrollback = 2000` + `SetScrollbackSize`; `packages/scrollback` append-only rotation.
- `cd services/gmuxd && go build ./...` passes. `go test ./...`: all pass except `internal/notify` `TestFinishedPreferredOverUnread`, which is a pre-existing flake unrelated to this change (passes 3/3 in isolation; this PR touches neither that package nor any behavior).

## Adjacent findings (OUT of this ticket's scope — not fixed here, per workflow)
A repo-wide grep shows stale "128KB" / "ring buffer" wording in files NOT listed in T07. Flagging for a follow-up ticket:
- `apps/website/src/content/docs/develop/terminal-data-pipeline.mdx` — actively describes a current "128KB ring buffer" / "fixed-size circular buffer". This looks genuinely outdated (the changelog notes the ring buffer was replaced by a virtual terminal emulator) and likely warrants its own rewrite.
- `docs/adr/0004-session-stream-and-live-dead-view.md` and `apps/website/src/content/docs/changelog.mdx` — contain "128 KiB ring buffer" references, but these are **historical records** and should NOT be retro-edited.
- `apps/website/src/content/docs/planned/session-persistence.md`, mock-data, and test comments also mention ring buffer; out of scope.

Source finding: D1, D2, D3, C2