### PR TITLE
fix(daemon): disable websocket compression on remote-session proxy

### DIFF
--- a/services/gmuxd/internal/apiclient/client.go
+++ b/services/gmuxd/internal/apiclient/client.go
@@ -354,12 +354,19 @@ func (c *Client) DialWS(ctx context.Context, sessionID string) (*websocket.Conn,
 // sessionID is the ORIGINAL (unnamespaced) session ID on the spoke,
 // not the namespaced wire ID. Callers strip the suffix first.
 func (c *Client) ProxyWS(w http.ResponseWriter, r *http.Request, sessionID string) {
-	// CompressionContextTakeover compresses the browser-facing hop
-	// (terminal output is highly repetitive); the hub->spoke hop is
-	// left uncompressed. Safari falls back to uncompressed. See #242.
+	// No permessage-deflate on the browser-facing hop, matching the
+	// local-session proxy (wsproxy.go). #242 enabled compression here
+	// to shrink the on-connect scrollback replay, but it triggers a
+	// mobile-browser reconnect storm: the browser negotiates deflate,
+	// can't decode gmuxd's frames, and drops the socket after the
+	// first large frame (the replay); the frontend reconnects and
+	// re-ships the replay, which costs far more than compression ever
+	// saved. Same browsers and same hop type as the local proxy, so
+	// the policy must match — leaving it on here was a latent storm
+	// bug on remote/peer sessions. The library defaults
+	// CompressionMode to CompressionDisabled; we keep it that way.
 	clientConn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
 		InsecureSkipVerify: true,
-		CompressionMode:    websocket.CompressionContextTakeover,
 	})
 	if err != nil {
 		log.Printf("apiclient ProxyWS: accept: %v", err)

--- a/services/gmuxd/internal/apiclient/client_test.go
+++ b/services/gmuxd/internal/apiclient/client_test.go
@@ -1,9 +1,13 @@
 package apiclient
 
 import (
+	"bufio"
 	"context"
+	"crypto/rand"
+	"encoding/base64"
 	"encoding/json"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -639,6 +643,67 @@ func TestProxyWS_ClientDisconnectClosesSpoke(t *testing.T) {
 	}
 }
 
+
+// TestProxyWS_NoCompressionNegotiated is the T18 regression test:
+// the remote/peer proxy must not negotiate permessage-deflate, the
+// same policy the local-session proxy (wsproxy.go) enforces. #242
+// found that compression triggers a mobile-browser reconnect storm;
+// leaving it enabled on this path was a latent bug. We assert the
+// handshake response omits permessage-deflate even when the browser
+// offers it.
+func TestProxyWS_NoCompressionNegotiated(t *testing.T) {
+	spokeServer := wsEchoServer(t, nil, "")
+	defer spokeServer.Close()
+
+	c := New(spokeServer.URL)
+	hub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.ProxyWS(w, r, "sess")
+	}))
+	defer hub.Close()
+
+	// Perform a raw WebSocket upgrade handshake, offering
+	// permessage-deflate, and inspect the response headers directly.
+	addr := strings.TrimPrefix(hub.URL, "http://")
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	keyBytes := make([]byte, 16)
+	if _, err := rand.Read(keyBytes); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	key := base64.StdEncoding.EncodeToString(keyBytes)
+
+	req := "GET /ws/sess HTTP/1.1\r\n" +
+		"Host: " + addr + "\r\n" +
+		"Upgrade: websocket\r\n" +
+		"Connection: Upgrade\r\n" +
+		"Sec-WebSocket-Version: 13\r\n" +
+		"Sec-WebSocket-Key: " + key + "\r\n" +
+		"Sec-WebSocket-Extensions: permessage-deflate; client_max_window_bits\r\n" +
+		"\r\n"
+	if err := conn.SetDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		t.Fatalf("set deadline: %v", err)
+	}
+	if _, err := conn.Write([]byte(req)); err != nil {
+		t.Fatalf("write handshake: %v", err)
+	}
+
+	resp, err := http.ReadResponse(bufio.NewReader(conn), &http.Request{Method: http.MethodGet})
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusSwitchingProtocols {
+		t.Fatalf("status = %d, want 101", resp.StatusCode)
+	}
+	if ext := resp.Header.Get("Sec-WebSocket-Extensions"); strings.Contains(ext, "permessage-deflate") {
+		t.Errorf("Sec-WebSocket-Extensions = %q, want no permessage-deflate (T18: must match local proxy)", ext)
+	}
+}
 
 // TestForwardAction_PreservesQueryString locks in the contract that
 // action endpoints with query parameters (e.g. /scrollback?tail=N)

--- a/services/gmuxd/internal/wsproxy/wsproxy.go
+++ b/services/gmuxd/internal/wsproxy/wsproxy.go
@@ -75,8 +75,10 @@ func (p *Proxy) Handler() http.HandlerFunc {
 		// per drop (the runner's shrinkForReconnect). Neither deflate
 		// mode fixed it; only no compression does. The storm re-ships the
 		// replay far more than compression ever saved, so this is the
-		// right call for every client. Revisit #242's bandwidth goal
-		// another way (e.g. bounding replay size) if it proves necessary.
+		// right call for every client. The remote/peer proxy
+		// (apiclient.ProxyWS) disables it for the same reason — same
+		// browsers, same hop type. Revisit #242's bandwidth goal another
+		// way (e.g. bounding replay size) if it proves necessary.
 		clientConn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
 			InsecureSkipVerify: true,
 		})


### PR DESCRIPTION
Implements review ticket T18.

The two browser-facing WebSocket proxies made opposite permessage-deflate decisions: the local-session proxy (`wsproxy.go`) disabled compression with a thorough #242 comment explaining it triggers a mobile-browser reconnect storm (the browser negotiates deflate, can't decode gmuxd's frames, drops the socket after the first large frame, and the frontend re-ships the scrollback replay on every reconnect — costing far more than compression saves), while the remote/peer proxy (`apiclient.ProxyWS`) still enabled `CompressionContextTakeover`. Same browsers, same hop type, so leaving compression on the peer path was a latent reconnect-storm bug. This change disables compression on the apiclient path to match the local proxy, and aligns the comments on both sides so they reference each other.

## Verification
- Added `TestProxyWS_NoCompressionNegotiated` which performs a raw WebSocket handshake offering `permessage-deflate` and asserts the response does not negotiate it. Confirmed it fails when compression is re-enabled and passes after the fix.
- `cd services/gmuxd && go build ./... && go test -count=1 ./internal/apiclient/ ./internal/wsproxy/` — all pass.

Source finding: E1