### PR TITLE
security(daemon): create clipboard paste files with 0600 permissions

### DIFF
--- a/services/gmuxd/internal/clipfile/clipfile.go
+++ b/services/gmuxd/internal/clipfile/clipfile.go
@@ -33,6 +33,9 @@ type Writer interface {
 // Files are named paste-N.<ext> with N the next free positive integer
 // for the recognized paste-* filename pattern in the directory.
 // Concurrent writers race-safely via O_CREAT|O_EXCL retry.
+//
+// Files are created 0600 so other local users can't read pasted
+// secrets (screenshots/PDFs/videos may carry sensitive data).
 type LocalWriter struct {
 	dir string
 }
@@ -134,7 +137,7 @@ func (w *LocalWriter) Write(payload []byte, mime string) (string, error) {
 		n := start + i
 		name := fmt.Sprintf("paste-%d.%s", n, ext)
 		path := filepath.Join(w.dir, name)
-		f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
+		f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
 		if err != nil {
 			if errors.Is(err, os.ErrExist) || errors.Is(err, syscall.EEXIST) {
 				continue

--- a/services/gmuxd/internal/clipfile/clipfile_test.go
+++ b/services/gmuxd/internal/clipfile/clipfile_test.go
@@ -49,6 +49,26 @@ func TestLocalWriter_FirstWriteIsPaste1(t *testing.T) {
 	}
 }
 
+// New paste files must be 0600 so other local users can't read pasted
+// secrets, while the short paste-N.<ext> path stays in os.TempDir().
+func TestLocalWriter_FilePermissions(t *testing.T) {
+	dir := t.TempDir()
+	w := NewLocalWriter(dir)
+
+	path, err := w.Write(pngBytes(), "image/png")
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat file: %v", err)
+	}
+	if got := fi.Mode().Perm(); got != 0o600 {
+		t.Errorf("file mode = %o, want 0600", got)
+	}
+}
+
 // Sanity check on filename predicate so later tests can rely on it without
 // duplicating the regex.
 func TestPasteFilenameRecognition(t *testing.T) {


### PR DESCRIPTION
Implements review ticket T04 (scoped down — see note below).

`LocalWriter.Write` created `paste-N.<ext>` files with mode `0644` in `os.TempDir()`, so pasted screenshots/PDFs/videos (potential secrets) were readable by every other local user. This changes the create mode to `0600` so only the owner can read them. That single line is the substance of the fix; a focused test (`TestLocalWriter_FilePermissions`) asserts the resulting file is `0600`.

## Deliberately out of scope
The ticket also proposed a per-user `0700` subdirectory and a TTL prune. After review we dropped both:
- **Per-user subdir** would lengthen the path from `/tmp/paste-N.png` to `/tmp/gmux-clip-<uid>/paste-N.png`. Short, predictable paste paths are an intentional ergonomics feature (agents type these), and `0600` already fixes the confidentiality issue — the subdir would only hide filenames, not contents.
- **TTL prune** adds new state (clock + ttl) against AGENTS.md's 'no unjustified state' rule. Temp-file cleanup is left to the environment (reboot / tmpfs / `systemd-tmpfiles`). Note this varies by OS/distro, so if accumulation ever becomes a real problem it can be revisited then.

The `paste-N` numbering contract and the web `clipboard-upload.ts` MIME/size (10MB) contract are unchanged — only the file's permission bits change.

## Verification
```
cd services/gmuxd && go build ./... && go vet ./internal/clipfile/ ./cmd/gmuxd/ && go test ./internal/clipfile/ ./cmd/gmuxd/
```
All pass, including the new permissions test. `cmd/gmuxd/main.go` is unchanged vs main.

Source finding: review/04-security.md S4