### PR TITLE
fix(daemon): re-poll session store during restart so a dropped exit event doesn't time out

### DIFF
--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -1576,9 +1576,13 @@ func serve(stderr io.Writer) int {
 					writeError(w, http.StatusInternalServerError, "kill_failed", err.Error())
 					return
 				}
-				exited, ok := waitForSessionExit(sessions, evCh, sessionID, 5*time.Second, 500*time.Millisecond)
-				if !ok {
-					writeError(w, http.StatusGatewayTimeout, "kill_timeout", "session did not exit in time")
+				exited, err := waitForSessionExit(sessions, evCh, sessionID, 5*time.Second, 500*time.Millisecond)
+				if errors.Is(err, errExitWaitRemoved) {
+					writeError(w, http.StatusConflict, "session_removed", err.Error())
+					return
+				}
+				if err != nil {
+					writeError(w, http.StatusGatewayTimeout, "kill_timeout", err.Error())
 					return
 				}
 				sess = exited

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -1576,23 +1576,12 @@ func serve(stderr io.Writer) int {
 					writeError(w, http.StatusInternalServerError, "kill_failed", err.Error())
 					return
 				}
-				deadline := time.After(5 * time.Second)
-				ready := false
-				for !ready {
-					select {
-					case <-deadline:
-						writeError(w, http.StatusGatewayTimeout, "kill_timeout", "session did not exit in time")
-						return
-					case ev := <-evCh:
-						if ev.ID != sessionID || ev.Session == nil {
-							continue
-						}
-						if !ev.Session.Alive && len(ev.Session.Command) > 0 {
-							sess = *ev.Session
-							ready = true
-						}
-					}
+				exited, ok := waitForSessionExit(sessions, evCh, sessionID, 5*time.Second, 500*time.Millisecond)
+				if !ok {
+					writeError(w, http.StatusGatewayTimeout, "kill_timeout", "session did not exit in time")
+					return
 				}
+				sess = exited
 				// /kill releases the canonical socket path before
 				// responding 204, so by the time KillSession returned
 				// (above) the path was already free. The replacement

--- a/services/gmuxd/cmd/gmuxd/wait.go
+++ b/services/gmuxd/cmd/gmuxd/wait.go
@@ -140,6 +140,48 @@ func handleWait(w http.ResponseWriter, r *http.Request, sessions *store.Store, s
 	}
 }
 
+// waitForSessionExit blocks until the session identified by sessionID
+// has transitioned to its resumable exit state (Alive == false with a
+// non-empty resume Command), the overall timeout elapses, or the event
+// channel closes. It returns the exited session snapshot and true on
+// success, or a zero session and false on timeout.
+//
+// Callers subscribe BEFORE triggering the kill and pass the resulting
+// channel here so the exit upsert can't be missed between subscribe and
+// kill. store.broadcast drops events when a subscriber's 64-slot buffer
+// is full, so under an event burst the exit upsert we're waiting on can
+// be dropped. Mirroring handleWait, we re-poll the store every tick so a
+// dropped event delays the result by at most one tick instead of
+// timing out with a spurious kill_timeout.
+func waitForSessionExit(sessions *store.Store, evCh <-chan store.Event, sessionID string, timeout, tick time.Duration) (store.Session, bool) {
+	exited := func(s store.Session) bool { return !s.Alive && len(s.Command) > 0 }
+
+	deadline := time.After(timeout)
+	ticker := time.NewTicker(tick)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-deadline:
+			return store.Session{}, false
+		case ev, ok := <-evCh:
+			if !ok {
+				return store.Session{}, false
+			}
+			if ev.ID != sessionID || ev.Session == nil {
+				continue
+			}
+			if exited(*ev.Session) {
+				return *ev.Session, true
+			}
+		case <-ticker.C:
+			if cur, ok := sessions.Get(sessionID); ok && exited(cur) {
+				return cur, true
+			}
+		}
+	}
+}
+
 // terminalReason inspects a session and reports whether --wait should
 // return now and with what reason. Centralised so the initial-snapshot
 // check, the per-event check, and the periodic re-poll stay in sync.

--- a/services/gmuxd/cmd/gmuxd/wait.go
+++ b/services/gmuxd/cmd/gmuxd/wait.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"net/http"
 	"strconv"
 	"time"
@@ -140,11 +141,21 @@ func handleWait(w http.ResponseWriter, r *http.Request, sessions *store.Store, s
 	}
 }
 
+// Sentinel results for waitForSessionExit. Distinct errors let the
+// restart handler report an honest status: a session that vanished
+// mid-restart is a conflict with a concurrent dismiss/prune, not a
+// kill that timed out.
+var (
+	errExitWaitTimeout = errors.New("session did not exit in time")
+	errExitWaitRemoved = errors.New("session removed while waiting for exit")
+)
+
 // waitForSessionExit blocks until the session identified by sessionID
-// has transitioned to its resumable exit state (Alive == false with a
-// non-empty resume Command), the overall timeout elapses, or the event
-// channel closes. It returns the exited session snapshot and true on
-// success, or a zero session and false on timeout.
+// has transitioned to its resumable exit state (Resumable, i.e.
+// Alive == false with a non-empty resume Command — the store stamps
+// this on every write), the overall timeout elapses, or the session
+// disappears from the store. On success it returns the exited session
+// snapshot; otherwise errExitWaitTimeout or errExitWaitRemoved.
 //
 // Callers subscribe BEFORE triggering the kill and pass the resulting
 // channel here so the exit upsert can't be missed between subscribe and
@@ -152,10 +163,11 @@ func handleWait(w http.ResponseWriter, r *http.Request, sessions *store.Store, s
 // is full, so under an event burst the exit upsert we're waiting on can
 // be dropped. Mirroring handleWait, we re-poll the store every tick so a
 // dropped event delays the result by at most one tick instead of
-// timing out with a spurious kill_timeout.
-func waitForSessionExit(sessions *store.Store, evCh <-chan store.Event, sessionID string, timeout, tick time.Duration) (store.Session, bool) {
-	exited := func(s store.Session) bool { return !s.Alive && len(s.Command) > 0 }
-
+// timing out with a spurious kill_timeout — and, also like handleWait,
+// we fail fast when the session is removed (UI dismiss, retention
+// prune) rather than hanging out the full deadline for a session that
+// can never become resumable.
+func waitForSessionExit(sessions *store.Store, evCh <-chan store.Event, sessionID string, timeout, tick time.Duration) (store.Session, error) {
 	deadline := time.After(timeout)
 	ticker := time.NewTicker(tick)
 	defer ticker.Stop()
@@ -163,20 +175,31 @@ func waitForSessionExit(sessions *store.Store, evCh <-chan store.Event, sessionI
 	for {
 		select {
 		case <-deadline:
-			return store.Session{}, false
+			return store.Session{}, errExitWaitTimeout
 		case ev, ok := <-evCh:
 			if !ok {
-				return store.Session{}, false
+				return store.Session{}, errExitWaitTimeout
 			}
-			if ev.ID != sessionID || ev.Session == nil {
+			if ev.ID != sessionID {
 				continue
 			}
-			if exited(*ev.Session) {
-				return *ev.Session, true
+			if ev.Session == nil {
+				// session-remove for our id: the store dropped the
+				// session (a remove is never followed by a transient
+				// re-upsert of the same id; shadow eviction only
+				// removes other ids).
+				return store.Session{}, errExitWaitRemoved
+			}
+			if ev.Session.Resumable {
+				return *ev.Session, nil
 			}
 		case <-ticker.C:
-			if cur, ok := sessions.Get(sessionID); ok && exited(cur) {
-				return cur, true
+			cur, ok := sessions.Get(sessionID)
+			if !ok {
+				return store.Session{}, errExitWaitRemoved
+			}
+			if cur.Resumable {
+				return cur, nil
 			}
 		}
 	}

--- a/services/gmuxd/cmd/gmuxd/wait_test.go
+++ b/services/gmuxd/cmd/gmuxd/wait_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -398,12 +399,64 @@ func TestWaitForSessionExitRepollsDroppedEvent(t *testing.T) {
 	// can only learn about it via the re-poll ticker.
 	st.Upsert(store.Session{ID: id, Kind: "shell", Alive: false, Command: []string{"bash"}})
 
-	exited, ok := waitForSessionExit(st, evCh, id, 2*time.Second, 20*time.Millisecond)
-	if !ok {
-		t.Fatal("waitForSessionExit timed out despite the store holding the exit state")
+	exited, err := waitForSessionExit(st, evCh, id, 2*time.Second, 20*time.Millisecond)
+	if err != nil {
+		t.Fatalf("waitForSessionExit failed despite the store holding the exit state: %v", err)
 	}
-	if exited.Alive || len(exited.Command) == 0 {
+	if !exited.Resumable {
 		t.Fatalf("returned session not in resumable exit state: %+v", exited)
+	}
+}
+
+// TestWaitForSessionExitReturnsOnEvent covers the primary path: the
+// exit upsert arrives on the subscriber channel (no drop), so the
+// helper must return the event's snapshot without waiting for a tick.
+// The generous tick makes the test fail loudly if the event path ever
+// regresses into relying on the re-poll fallback.
+func TestWaitForSessionExitReturnsOnEvent(t *testing.T) {
+	st := store.New()
+	const id = "sess-event"
+	st.Upsert(store.Session{ID: id, Kind: "shell", Alive: true})
+
+	evCh, unsub := st.Subscribe()
+	defer unsub()
+
+	st.Upsert(store.Session{ID: id, Kind: "shell", Alive: false, Command: []string{"bash"}})
+
+	start := time.Now()
+	exited, err := waitForSessionExit(st, evCh, id, 2*time.Second, time.Minute)
+	if err != nil {
+		t.Fatalf("waitForSessionExit failed on the event path: %v", err)
+	}
+	if !exited.Resumable {
+		t.Fatalf("returned session not in resumable exit state: %+v", exited)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("event path took %v; should return immediately without a tick", elapsed)
+	}
+}
+
+// TestWaitForSessionExitFailsFastOnRemove verifies that a session
+// dropped from the store mid-wait (UI dismiss, retention prune) makes
+// the helper return errExitWaitRemoved promptly instead of hanging
+// for the full deadline and masquerading as a kill timeout.
+func TestWaitForSessionExitFailsFastOnRemove(t *testing.T) {
+	st := store.New()
+	const id = "sess-dismissed"
+	st.Upsert(store.Session{ID: id, Kind: "shell", Alive: true})
+
+	evCh, unsub := st.Subscribe()
+	defer unsub()
+
+	st.Remove(id)
+
+	start := time.Now()
+	_, err := waitForSessionExit(st, evCh, id, 5*time.Second, 10*time.Millisecond)
+	if !errors.Is(err, errExitWaitRemoved) {
+		t.Fatalf("expected errExitWaitRemoved, got %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("removal took %v to surface; must fail fast, not ride out the deadline", elapsed)
 	}
 }
 
@@ -418,7 +471,7 @@ func TestWaitForSessionExitTimesOut(t *testing.T) {
 	evCh, unsub := st.Subscribe()
 	defer unsub()
 
-	if _, ok := waitForSessionExit(st, evCh, id, 50*time.Millisecond, 10*time.Millisecond); ok {
-		t.Fatal("waitForSessionExit reported success for a session that never exited")
+	if _, err := waitForSessionExit(st, evCh, id, 50*time.Millisecond, 10*time.Millisecond); !errors.Is(err, errExitWaitTimeout) {
+		t.Fatalf("expected errExitWaitTimeout for a session that never exited, got %v", err)
 	}
 }

--- a/services/gmuxd/cmd/gmuxd/wait_test.go
+++ b/services/gmuxd/cmd/gmuxd/wait_test.go
@@ -371,3 +371,54 @@ func postWait(t *testing.T, srv *httptest.Server, id string) (*http.Response, ma
 	}
 	return resp, body
 }
+
+// TestWaitForSessionExitRepollsDroppedEvent verifies that the restart
+// handler's exit-wait helper recovers when the broadcast bus drops the
+// exit upsert because the subscriber's buffer is saturated. The helper
+// must fall back to its re-poll ticker and return the exited session
+// rather than timing out with a spurious kill_timeout. Regression guard
+// for review ticket T19.
+func TestWaitForSessionExitRepollsDroppedEvent(t *testing.T) {
+	st := store.New()
+	const id = "sess-restart"
+	st.Upsert(store.Session{ID: id, Kind: "shell", Alive: true})
+
+	// Subscribe BEFORE the kill, exactly as the restart handler does.
+	evCh, unsub := st.Subscribe()
+	defer unsub()
+
+	// Saturate the 64-slot subscriber buffer so any further broadcast —
+	// including the exit upsert below — is dropped on the floor.
+	for i := 0; i < 128; i++ {
+		st.Broadcast(store.Event{Type: "session-activity", ID: "other"})
+	}
+
+	// The exit upsert: session goes dead but keeps a resume Command.
+	// Its broadcast is dropped because the buffer is full, so the helper
+	// can only learn about it via the re-poll ticker.
+	st.Upsert(store.Session{ID: id, Kind: "shell", Alive: false, Command: []string{"bash"}})
+
+	exited, ok := waitForSessionExit(st, evCh, id, 2*time.Second, 20*time.Millisecond)
+	if !ok {
+		t.Fatal("waitForSessionExit timed out despite the store holding the exit state")
+	}
+	if exited.Alive || len(exited.Command) == 0 {
+		t.Fatalf("returned session not in resumable exit state: %+v", exited)
+	}
+}
+
+// TestWaitForSessionExitTimesOut confirms the 5 s overall deadline still
+// fires when the session never reaches its exit state, so the re-poll
+// fallback doesn't mask a genuine kill failure.
+func TestWaitForSessionExitTimesOut(t *testing.T) {
+	st := store.New()
+	const id = "sess-stuck"
+	st.Upsert(store.Session{ID: id, Kind: "shell", Alive: true})
+
+	evCh, unsub := st.Subscribe()
+	defer unsub()
+
+	if _, ok := waitForSessionExit(st, evCh, id, 50*time.Millisecond, 10*time.Millisecond); ok {
+		t.Fatal("waitForSessionExit reported success for a session that never exited")
+	}
+}


### PR DESCRIPTION
Implements review ticket T19 (rebased onto current main; extended with a review follow-up).

The `restart` handler subscribes to the session event bus, kills the runner, then waits up to 5 s for the session to become resumable. Because `store.broadcast` silently drops events when a subscriber's 64-slot buffer is full, an event burst could drop the exit upsert and produce a spurious `504 kill_timeout` even though the kill succeeded. `handleWait` already defends against this with a 500 ms re-poll ticker; `restart` did not.

This change mirrors that defense fully:

- **Re-poll fallback**: the wait loop re-checks `sessions.Get(sessionID)` every 500 ms, so a dropped exit event delays restart by at most one tick instead of timing out. Extracted into a `waitForSessionExit` helper (wait.go) to make it unit-testable; the 5 s overall deadline is preserved.
- **Fast-fail on session removal** (review follow-up): if the session is removed mid-restart (UI dismiss, retention prune), the helper returns `errExitWaitRemoved` immediately — mapped to `409 session_removed` — instead of hanging out the full deadline and reporting a misleading `kill_timeout`. Safe because a `session-remove` for an id is never followed by a transient re-upsert of that id (shadow eviction only removes *other* ids).
- **Single source of truth for "resumable"**: the helper checks the store-stamped `Session.Resumable` field instead of duplicating the `!Alive && len(Command) > 0` predicate.

## Verification
- `cd services/gmuxd && go build ./... && go test ./...` — all packages pass; `waitForSessionExit` tests also pass under `-race`.
- Tests in `cmd/gmuxd/wait_test.go`:
  - `TestWaitForSessionExitRepollsDroppedEvent` — saturates the subscriber buffer so the exit upsert is dropped, asserts the helper still returns the exited session via the re-poll fallback.
  - `TestWaitForSessionExitReturnsOnEvent` — primary path: the exit upsert arrives on the channel and the helper returns without waiting for a tick.
  - `TestWaitForSessionExitFailsFastOnRemove` — session removed mid-wait surfaces `errExitWaitRemoved` promptly, not a deadline timeout.
  - `TestWaitForSessionExitTimesOut` — the overall deadline still fires when the session never exits.
- Reconfirmed the gap exists on current main before rebasing: a verbatim copy of the pre-PR inline loop times out when the exit broadcast is dropped, while the store already holds the exit state.

Source finding: E2