### PR TITLE
fix(web): make filteredSessions reactive to the URL query string

### DIFF
--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -22,7 +22,7 @@ import {
   sessions, connState, selected, selectedId, view, health, peers,
   terminalOptions, keybinds, macCommandIsCtrl,
   unreadCount,
-  urlPath,
+  urlPath, urlSearch,
   initStore, setNavigate, navigateToSession,
   dismissSession, resumeSession, restartSession,
   sessionStaleness,
@@ -360,7 +360,11 @@ function App() {
   // computed reacts before the browser renders a stale frame.
   useLayoutEffect(() => {
     urlPath.value = loc.path
-  }, [loc.path])
+    // Derive the query string from loc.url (path+search) so query-only
+    // navigations (?project=, ?cwd=) reactively re-filter sessions.
+    const q = loc.url.indexOf('?')
+    urlSearch.value = q >= 0 ? loc.url.slice(q) : ''
+  }, [loc.url])
 
   // Settings modal is driven by the `?settings` query param rather than
   // local state, so it's deep-linkable and shareable. It's read off the

--- a/apps/gmux-web/src/store.test.ts
+++ b/apps/gmux-web/src/store.test.ts
@@ -4,7 +4,7 @@ import {
   markSessionRead, dismissSession, reorderSessions,
   handleActivity, isSessionActive, isSessionFading, activityMap,
   sessionStaleness, peers, peerAppearance, peerStatusByName,
-  isSessionUnavailable, urlPath, selectedId,
+  isSessionUnavailable, urlPath, urlSearch, filteredSessions, selectedId,
   navigateToSession, setNavigate,
   applyPending, _rawSessions, _rawWorld, _setRawWorld, _pendingMutations,
   toUISession, localHostLabel, parseConnectURL,
@@ -42,6 +42,30 @@ beforeEach(() => {
   _pendingMutations.value = []
   sessionsLoaded.value = false
   urlPath.value = '/'
+  urlSearch.value = ''
+})
+
+describe('filteredSessions reactivity to the URL query string', () => {
+  it('recomputes when urlSearch flips, without an SSE session update', () => {
+    _rawSessions.value = [
+      makeSession({ id: 'a', cwd: '/home/user/projects/alpha' }),
+      makeSession({ id: 'b', cwd: '/home/user/projects/beta' }),
+    ]
+    // No query: all sessions pass through.
+    expect(filteredSessions.value.map(s => s.id)).toEqual(['a', 'b'])
+
+    // Flip only the query signal (no sessions.value change): filter applies.
+    urlSearch.value = '?project=alpha'
+    expect(filteredSessions.value.map(s => s.id)).toEqual(['a'])
+
+    // cwd prefix filter, again query-only.
+    urlSearch.value = '?cwd=/home/user/projects/beta'
+    expect(filteredSessions.value.map(s => s.id)).toEqual(['b'])
+
+    // Clearing the query restores the full list.
+    urlSearch.value = ''
+    expect(filteredSessions.value.map(s => s.id)).toEqual(['a', 'b'])
+  })
 })
 
 // Pin the protocol-to-UI translation for stamp fields. Stamps are

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -325,6 +325,16 @@ export const urlPath = signal(
   typeof location !== 'undefined' ? (location.pathname.replace(/\/+$/, '') || '/') : '/',
 )
 
+/** Current URL query string (including the leading '?'), kept in sync
+ * with preact-iso's location alongside `urlPath`. Tracked as its own
+ * signal so query-only changes (?project=, ?cwd=) reactively recompute
+ * `filteredSessions` and its dependents (folders, view, sidebar)
+ * without waiting for an unrelated SSE session update to nudge
+ * `sessions.value`. */
+export const urlSearch = signal(
+  typeof location !== 'undefined' ? location.search : '',
+)
+
 /**
  * Activity tracking: which sessions recently produced output.
  *
@@ -385,8 +395,7 @@ export function isSessionFading(id: string): boolean {
 
 /** Sessions filtered by URL params (?project=, ?cwd=). */
 export const filteredSessions = computed(() => {
-  const search = typeof location !== 'undefined' ? location.search : ''
-  const params = new URLSearchParams(search)
+  const params = new URLSearchParams(urlSearch.value)
   const project = params.get('project')
   const cwdFilter = params.get('cwd')
   if (!project && !cwdFilter) return sessions.value


### PR DESCRIPTION
Implements review ticket T09.

`filteredSessions` was a `computed` that read `location.search` directly, which is non-reactive: `computed` only re-runs when a *signal* it reads changes, and `urlPath` tracked only `location.pathname`. As a result, in-app `?project=` / `?cwd=` changes did not recompute `filteredSessions` (or its dependents `folders`, `view`, and the sidebar) until an unrelated SSE session update happened to nudge `sessions.value`. This adds a `urlSearch` signal kept in sync with the location alongside `urlPath` (synced in main.tsx's layout effect from `loc.url`), and has `filteredSessions` read it. Query-only navigations now re-filter immediately; bookmarked per-project URLs still work on first load because `urlSearch` is seeded from `location.search`.

## Verification
- `npm test` (apps/gmux-web): 459 passed, including a new store test that flips `urlSearch` and asserts `filteredSessions` recomputes without an SSE update.
- `npm run build`: passed.
- `npm run lint` (tsc --noEmit): passed.

Source finding: review F1