### PR TITLE
security: move per-session sockets off shared /tmp to a per-user dir

### DIFF
--- a/cli/gmux/cmd/gmux/run.go
+++ b/cli/gmux/cmd/gmux/run.go
@@ -102,10 +102,7 @@ func runSession(args []string, attach bool, dir runDirectives) {
 	if sessionID == "" {
 		sessionID = naming.SessionID()
 	}
-	socketDir := os.Getenv("GMUX_SOCKET_DIR")
-	if socketDir == "" {
-		socketDir = "/tmp/gmux-sessions"
-	}
+	socketDir := paths.SessionSocketDir()
 	sockPath := filepath.Join(socketDir, sessionID+".sock")
 
 	// Bind the socket BEFORE any sessionID-dependent setup

--- a/packages/paths/paths.go
+++ b/packages/paths/paths.go
@@ -2,6 +2,7 @@
 package paths
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -10,6 +11,31 @@ import (
 // SocketPath returns the path to the gmuxd Unix socket for local IPC.
 func SocketPath() string {
 	return filepath.Join(StateDir(), "gmuxd.sock")
+}
+
+// SessionSocketDir returns the directory that holds per-session Unix
+// sockets. Both the runner (which binds the sockets) and gmuxd (which
+// scans them for discovery) resolve it here so they always agree on a
+// single location.
+//
+// The GMUX_SOCKET_DIR env var overrides everything; it is used by tests
+// and devcontainers and is passed through to the daemon so both ends
+// scan the same place. Otherwise the default is per-user so that two OS
+// users on the same host never collide on one world-shared directory
+// (whoever creates it first owns it 0700, locking everyone else out):
+//
+//   - $XDG_RUNTIME_DIR/gmux/sessions when XDG_RUNTIME_DIR is set (the
+//     standard per-user, 0700, tmpfs-backed runtime dir on Linux), else
+//   - a per-uid subdirectory of the system temp dir, e.g.
+//     /tmp/gmux-sessions-1000.
+func SessionSocketDir() string {
+	if d := os.Getenv("GMUX_SOCKET_DIR"); d != "" {
+		return d
+	}
+	if rt := os.Getenv("XDG_RUNTIME_DIR"); rt != "" {
+		return filepath.Join(rt, "gmux", "sessions")
+	}
+	return filepath.Join(os.TempDir(), fmt.Sprintf("gmux-sessions-%d", os.Getuid()))
 }
 
 // StateDir returns the gmux state directory (~/.local/state/gmux).

--- a/packages/paths/paths_test.go
+++ b/packages/paths/paths_test.go
@@ -1,7 +1,9 @@
 package paths
 
 import (
+	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -56,4 +58,37 @@ func TestCanonicalizePath(t *testing.T) {
 			t.Errorf("CanonicalizePath(%q) = %q, want %q", tt.input, got, tt.want)
 		}
 	}
+}
+
+func TestSessionSocketDir(t *testing.T) {
+	t.Run("GMUX_SOCKET_DIR overrides everything", func(t *testing.T) {
+		t.Setenv("XDG_RUNTIME_DIR", "/run/user/1000")
+		t.Setenv("GMUX_SOCKET_DIR", "/tmp/custom-sockets")
+		if got := SessionSocketDir(); got != "/tmp/custom-sockets" {
+			t.Errorf("SessionSocketDir() = %q, want %q", got, "/tmp/custom-sockets")
+		}
+	})
+
+	t.Run("falls back to XDG_RUNTIME_DIR", func(t *testing.T) {
+		t.Setenv("GMUX_SOCKET_DIR", "")
+		t.Setenv("XDG_RUNTIME_DIR", "/run/user/1000")
+		want := "/run/user/1000/gmux/sessions"
+		if got := SessionSocketDir(); got != want {
+			t.Errorf("SessionSocketDir() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("per-uid temp dir when no XDG_RUNTIME_DIR", func(t *testing.T) {
+		t.Setenv("GMUX_SOCKET_DIR", "")
+		t.Setenv("XDG_RUNTIME_DIR", "")
+		got := SessionSocketDir()
+		want := filepath.Join(os.TempDir(), fmt.Sprintf("gmux-sessions-%d", os.Getuid()))
+		if got != want {
+			t.Errorf("SessionSocketDir() = %q, want %q", got, want)
+		}
+		// Must not be the old world-shared path.
+		if got == "/tmp/gmux-sessions" {
+			t.Errorf("SessionSocketDir() must not default to the shared /tmp/gmux-sessions")
+		}
+	})
 }

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -518,7 +518,7 @@ func serve(stderr io.Writer) int {
 	go fileMon.Run(stopFileMon)
 	defer close(stopFileMon)
 
-	// Start socket-based discovery (scans /tmp/gmux-sessions/*.sock)
+	// Start socket-based discovery (scans paths.SessionSocketDir() for *.sock)
 	// Discovery also subscribes to each runner's /events SSE for live updates.
 	stopDiscovery := make(chan struct{})
 	go discovery.Watch(sessions, subs, fileMon, persistDead, fileMon.ApplyPersistedAttributions, 3*time.Second, stopDiscovery)

--- a/services/gmuxd/internal/discovery/discovery.go
+++ b/services/gmuxd/internal/discovery/discovery.go
@@ -1,6 +1,7 @@
-// Package discovery scans /tmp/gmux-sessions/*.sock for live gmux-run
-// instances and queries their GET /meta endpoint to populate the store.
-// Replaces the old file-polling approach from /tmp/gmux-meta/.
+// Package discovery scans the per-session socket directory (see
+// paths.SessionSocketDir) for live gmux-run instances and queries their
+// GET /meta endpoint to populate the store. Replaces the old
+// file-polling approach.
 package discovery
 
 import (
@@ -18,6 +19,7 @@ import (
 
 	"github.com/gmuxapp/gmux/packages/adapter"
 	"github.com/gmuxapp/gmux/packages/adapter/adapters"
+	"github.com/gmuxapp/gmux/packages/paths"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/store"
 )
 
@@ -27,10 +29,7 @@ import (
 var ExpectedRunnerHash string
 
 func socketDir() string {
-	if d := os.Getenv("GMUX_SOCKET_DIR"); d != "" {
-		return d
-	}
-	return "/tmp/gmux-sessions"
+	return paths.SessionSocketDir()
 }
 
 // OnDeadFunc is invoked after a session has just landed as Alive=false


### PR DESCRIPTION
Implements review ticket T05.

Per-session Unix sockets defaulted to the world-shared, predictable `/tmp/gmux-sessions`. On a multi-user host the first user to create the directory owns it 0700, locking every other user's runner out (cross-user DoS / squatting), even though every other gmux artifact already lives under a per-user state dir. This moves the default to a per-user location: `$XDG_RUNTIME_DIR/gmux/sessions` when set, otherwise a per-uid subdir of the system temp dir (e.g. `/tmp/gmux-sessions-1000`). The resolution lives in the shared `packages/paths` (`SessionSocketDir()`), so the runner (`cli/gmux`) and the daemon's discovery scan (`services/gmuxd`) derive the identical directory from one source of truth. The `GMUX_SOCKET_DIR` override is preserved unchanged, so tests and devcontainer discovery are unaffected. The runner already creates the dir 0700 via `ptyserver.BindSocket`.

## Why runner and daemon still agree
The daemon is auto-started by the runner and inherits its environment; `sessionenv.Strip` only removes `GMUX_*` identity vars, so both `GMUX_SOCKET_DIR` (preserved explicitly) and `XDG_RUNTIME_DIR` (non-GMUX) pass through. Same env + same uid ⇒ identical `SessionSocketDir()` in all three branches (override / XDG / per-uid temp).

## Verification
- `packages/paths`: `go build ./... && go test ./...` — pass. New `TestSessionSocketDir` covers all three branches and asserts the default is never the shared `/tmp/gmux-sessions`.
- `cli/gmux`: `go build ./... && go test ./...` — pass.
- `services/gmuxd`: `go build ./... && go test ./...` — pass (full suite incl. discovery).
- Grepped both sides: runner (`run.go`) and daemon (`discovery.go`) both resolve via `paths.SessionSocketDir()`; no hardcoded `/tmp/gmux-sessions` default remains in non-test code.
- Discovery tests and `filemon_test` set `GMUX_SOCKET_DIR` explicitly, so the override path (and devcontainer discovery, which relies on it) is exercised and unaffected. Remaining `/tmp/gmux-sessions` literals in tests are arbitrary `SocketPath` fixtures, not default-resolution dependencies — no test update needed.

## Adjacent findings (out of scope, not fixed)
- The dead `cli/gmux/internal/metadata` package still hardcodes `/tmp/gmux-meta` (`MetaDir`). It has no callers and is slated for deletion in T13, so I left it untouched.
- Docs still cite the old default: `apps/website/src/content/docs/reference/environment.md` (GMUX_SOCKET_DIR default column), `file-paths.md`, `architecture.md`, `session-schema.md`. Worth a docs follow-up.

Source finding: review S7