### PR TITLE
feat(daemon): prune dead sessions past retention limits on startup

### DIFF
--- a/packages/paths/paths.go
+++ b/packages/paths/paths.go
@@ -79,6 +79,12 @@ func SessionsDir() string {
 // SessionsDir. The directory holds meta.json (written by gmuxd's
 // sessionmeta package) and scrollback / scrollback.0 (written by
 // the runner's scrollback package).
+//
+// gmuxd bounds the growth of this directory with a retention policy
+// applied at startup (see services/gmuxd/internal/sessionmeta): dead
+// sessions older than 30 days are removed, and only the newest 200 dead
+// sessions are kept. Override via GMUX_SESSION_RETENTION_DAYS and
+// GMUX_SESSION_RETENTION_MAX (0 disables a limit).
 func SessionDir(id string) string {
 	return filepath.Join(SessionsDir(), id)
 }

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -452,7 +452,7 @@ func serve(stderr io.Writer) int {
 	// hook below persists every Alive=false landing; Dismiss /
 	// Resume merge / slug takeover drop the corresponding directory.
 	// See sessionmeta package doc for the full lifecycle.
-	metaStore := sessionmeta.New(sessionmeta.DefaultDir())
+	metaStore := sessionmeta.New(sessionmeta.DefaultDir(), sessionmeta.WithRetention(sessionmeta.DefaultRetention()))
 	if loaded, err := metaStore.Sweep(); err != nil {
 		log.Printf("sessionmeta: sweep failed: %v", err)
 	} else {

--- a/services/gmuxd/internal/sessionmeta/sessionmeta.go
+++ b/services/gmuxd/internal/sessionmeta/sessionmeta.go
@@ -17,6 +17,13 @@
 // sidebar across restarts. On Dismiss / Resume merge / slug
 // takeover, the per-session directory is removed.
 //
+// Sweep also enforces a retention policy on dead-but-not-dismissed
+// sessions so the state dir doesn't grow without bound: corpses older
+// than 30 days are aged out, and only the newest 200 dead sessions are
+// kept (LRU by exit time). Both limits are configurable via the
+// GMUX_SESSION_RETENTION_DAYS and GMUX_SESSION_RETENTION_MAX environment
+// variables (0 disables a limit). See RetentionPolicy and Sweep.
+//
 // Peer-owned sessions are excluded: the hub re-receives them from
 // the spoke on reconnect, so persisting on the hub would create
 // duplicate ghosts. Write is a no-op for sess.Peer != "".
@@ -33,6 +40,9 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"sort"
+	"strconv"
+	"time"
 
 	"github.com/gmuxapp/gmux/packages/paths"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/store"
@@ -43,6 +53,69 @@ const (
 	dirMode  = 0o700
 	fileMode = 0o600
 )
+
+// Retention defaults bound the disk footprint of dead-but-not-dismissed
+// sessions. Each dead session keeps a meta.json plus up to ~2 MiB of
+// rotated scrollback under $XDG_STATE_HOME/gmux/sessions/<id>/; without a
+// cap these accumulate forever for users who never dismiss. The Sweep at
+// startup applies the policy: corpses older than MaxAge are aged out, and
+// once that's done only the newest MaxCount dead sessions are kept (LRU by
+// effective timestamp). Live sessions are never on the chopping block here
+// because Sweep only loads Alive=false records, and any still-running
+// runner re-registers as alive immediately afterwards.
+//
+// Resumable sessions get no special exemption, and that is safe:
+// store.Upsert derives Resumable = !Alive && len(Command) > 0, so it is
+// a UI affordance offering to re-run a dead session's command, not a
+// handle on a live OS process. A resumable corpse has no backing
+// process to orphan; pruning a 30-day-old one only retires a stale
+// "resume" button, and the command itself was never the artifact we
+// promised to keep forever. Recently-dead resumables stay because they
+// are the newest by timestamp and well within MaxAge.
+const (
+	DefaultMaxAge   = 30 * 24 * time.Hour
+	DefaultMaxCount = 200
+)
+
+// Environment variables that override the retention defaults at startup.
+// Both accept a non-negative integer; 0 disables that limit (unbounded).
+const (
+	envRetentionDays  = "GMUX_SESSION_RETENTION_DAYS"
+	envRetentionCount = "GMUX_SESSION_RETENTION_MAX"
+)
+
+// RetentionPolicy bounds how many dead-session directories survive a
+// Sweep. A zero value for either field disables that limit.
+type RetentionPolicy struct {
+	// MaxAge ages out dead sessions whose effective timestamp is older
+	// than now-MaxAge. Zero means no age limit.
+	MaxAge time.Duration
+	// MaxCount keeps only the newest MaxCount dead sessions (by
+	// effective timestamp) after age-out. Zero means no count limit.
+	MaxCount int
+}
+
+// DefaultRetention returns the built-in policy, with the
+// GMUX_SESSION_RETENTION_DAYS / GMUX_SESSION_RETENTION_MAX environment
+// overrides applied when set to a valid non-negative integer.
+func DefaultRetention() RetentionPolicy {
+	p := RetentionPolicy{MaxAge: DefaultMaxAge, MaxCount: DefaultMaxCount}
+	if v := os.Getenv(envRetentionDays); v != "" {
+		if days, err := strconv.Atoi(v); err == nil && days >= 0 {
+			p.MaxAge = time.Duration(days) * 24 * time.Hour
+		} else {
+			log.Printf("sessionmeta: ignoring invalid %s=%q", envRetentionDays, v)
+		}
+	}
+	if v := os.Getenv(envRetentionCount); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			p.MaxCount = n
+		} else {
+			log.Printf("sessionmeta: ignoring invalid %s=%q", envRetentionCount, v)
+		}
+	}
+	return p
+}
 
 // Per-session directories may also contain scrollback files written
 // by the runner (see packages/scrollback). sessionmeta does not
@@ -59,12 +132,37 @@ func DefaultDir() string {
 // is constructed at gmuxd startup with DefaultDir(); tests construct
 // their own with a temp dir.
 type Store struct {
-	dir string
+	dir       string
+	retention RetentionPolicy
+	// now is the clock used by Sweep's retention pass. Overridable in
+	// tests via WithClock; defaults to time.Now.
+	now func() time.Time
+}
+
+// Option configures a Store at construction.
+type Option func(*Store)
+
+// WithRetention sets the dead-session retention policy applied during
+// Sweep. Without it, Sweep performs no age/count pruning.
+func WithRetention(p RetentionPolicy) Option {
+	return func(s *Store) { s.retention = p }
+}
+
+// WithClock overrides the clock used by Sweep's retention pass. Tests
+// inject a fixed clock to make age-out deterministic.
+func WithClock(now func() time.Time) Option {
+	return func(s *Store) { s.now = now }
 }
 
 // New returns a Store rooted at dir. The directory is created lazily
 // on first Write; no IO happens at construction.
-func New(dir string) *Store { return &Store{dir: dir} }
+func New(dir string, opts ...Option) *Store {
+	s := &Store{dir: dir, now: time.Now}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
+}
 
 // Dir is the base directory under which per-session subdirectories
 // live. Exposed for tests and for diagnostic logging.
@@ -227,6 +325,11 @@ func (s *Store) WatchRemovals(events <-chan store.Event) {
 //     left in place (operator may want to inspect)
 //   - non-directory entries under the base dir are ignored
 //
+// After loading, the retention policy (if any) prunes dead-session
+// directories: corpses older than MaxAge are aged out, then only the
+// newest MaxCount survive (LRU by effective timestamp). Pruned sessions
+// are not returned. See RetentionPolicy.
+//
 // Returns nil error when the base dir doesn't exist (clean install).
 func (s *Store) Sweep() ([]store.Session, error) {
 	entries, err := os.ReadDir(s.dir)
@@ -267,5 +370,78 @@ func (s *Store) Sweep() ([]store.Session, error) {
 		sess.Alive = false
 		loaded = append(loaded, sess)
 	}
-	return loaded, nil
+	return s.prune(loaded), nil
+}
+
+// effectiveTime returns the timestamp used to rank a dead session for
+// retention: ExitedAt (when it died) is preferred, falling back to
+// LastActivityAt then CreatedAt. The bool is false when none parse, in
+// which case the session is treated conservatively (never aged out,
+// kept as if newest) so an undatable record is never evicted.
+func effectiveTime(sess store.Session) (time.Time, bool) {
+	for _, ts := range []string{sess.ExitedAt, sess.LastActivityAt, sess.CreatedAt} {
+		if ts == "" {
+			continue
+		}
+		if t, err := time.Parse(time.RFC3339, ts); err == nil {
+			return t, true
+		}
+	}
+	return time.Time{}, false
+}
+
+// prune applies the retention policy to the freshly-loaded dead
+// sessions, removing the on-disk directories of the losers and
+// returning the survivors. Age-out runs first, then the count cap on
+// what remains. A no-op when the policy disables both limits.
+func (s *Store) prune(loaded []store.Session) []store.Session {
+	if s.retention.MaxAge <= 0 && s.retention.MaxCount <= 0 {
+		return loaded
+	}
+	now := time.Now
+	if s.now != nil {
+		now = s.now
+	}
+
+	survivors := loaded[:0:0]
+	if s.retention.MaxAge > 0 {
+		cutoff := now().Add(-s.retention.MaxAge)
+		for _, sess := range loaded {
+			t, ok := effectiveTime(sess)
+			if ok && t.Before(cutoff) {
+				s.evict(sess.ID, "age")
+				continue
+			}
+			survivors = append(survivors, sess)
+		}
+	} else {
+		survivors = append(survivors, loaded...)
+	}
+
+	if s.retention.MaxCount > 0 && len(survivors) > s.retention.MaxCount {
+		// Sort newest-first; undatable records sort as newest so they
+		// survive the count cap. Stable so equal timestamps keep their
+		// readdir order.
+		sort.SliceStable(survivors, func(i, j int) bool {
+			ti, oki := effectiveTime(survivors[i])
+			tj, okj := effectiveTime(survivors[j])
+			if oki != okj {
+				return !oki // undatable (newest) before datable
+			}
+			return ti.After(tj)
+		})
+		for _, sess := range survivors[s.retention.MaxCount:] {
+			s.evict(sess.ID, "count")
+		}
+		survivors = survivors[:s.retention.MaxCount]
+	}
+	return survivors
+}
+
+// evict removes a pruned session's directory and logs the reason.
+func (s *Store) evict(id, reason string) {
+	log.Printf("sessionmeta: pruning dead session %s (retention: %s)", id, reason)
+	if err := s.Remove(id); err != nil {
+		log.Printf("sessionmeta: prune remove %s: %v", id, err)
+	}
 }

--- a/services/gmuxd/internal/sessionmeta/sessionmeta.go
+++ b/services/gmuxd/internal/sessionmeta/sessionmeta.go
@@ -101,7 +101,12 @@ type RetentionPolicy struct {
 func DefaultRetention() RetentionPolicy {
 	p := RetentionPolicy{MaxAge: DefaultMaxAge, MaxCount: DefaultMaxCount}
 	if v := os.Getenv(envRetentionDays); v != "" {
-		if days, err := strconv.Atoi(v); err == nil && days >= 0 {
+		// Cap at the largest day count that still fits in a
+		// time.Duration (int64 ns) once multiplied by 24h, so a huge
+		// value can't overflow to a negative duration that prune would
+		// silently treat as "no age limit".
+		const maxSafeDays = int(^uint(0)>>1) / int(24*time.Hour) // ~106 751 on 64-bit
+		if days, err := strconv.Atoi(v); err == nil && days >= 0 && days <= maxSafeDays {
 			p.MaxAge = time.Duration(days) * 24 * time.Hour
 		} else {
 			log.Printf("sessionmeta: ignoring invalid %s=%q", envRetentionDays, v)

--- a/services/gmuxd/internal/sessionmeta/sessionmeta_test.go
+++ b/services/gmuxd/internal/sessionmeta/sessionmeta_test.go
@@ -479,3 +479,138 @@ func TestWriteAcceptsWellFormedID(t *testing.T) {
 		t.Fatalf("meta.json not written: %v", err)
 	}
 }
+
+// --- Retention policy (T22) ---------------------------------------
+
+// writeDead persists a dead session with the given id and ExitedAt so
+// retention tests can stage aged corpses on disk.
+func writeDead(t *testing.T, s *Store, id, exitedAt string) {
+	t.Helper()
+	sess := store.Session{ID: id, Kind: "shell", Alive: false, ExitedAt: exitedAt}
+	if err := s.Write(sess); err != nil {
+		t.Fatalf("Write %s: %v", id, err)
+	}
+}
+
+func loadedIDs(sessions []store.Session) map[string]bool {
+	m := make(map[string]bool, len(sessions))
+	for _, s := range sessions {
+		m[s.ID] = true
+	}
+	return m
+}
+
+// TestSweepAgesOutOldSessions pins the age limit: corpses older than
+// MaxAge are removed from disk and excluded from the loaded set, while
+// recently-dead sessions are preserved.
+func TestSweepAgesOutOldSessions(t *testing.T) {
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	s := New(t.TempDir(),
+		WithRetention(RetentionPolicy{MaxAge: 7 * 24 * time.Hour}),
+		WithClock(func() time.Time { return now }))
+
+	writeDead(t, s, "sess-old", now.Add(-30*24*time.Hour).Format(time.RFC3339))
+	writeDead(t, s, "sess-fresh", now.Add(-1*time.Hour).Format(time.RFC3339))
+
+	loaded, err := s.Sweep()
+	if err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	ids := loadedIDs(loaded)
+	if ids["sess-old"] {
+		t.Error("old session should have been aged out")
+	}
+	if !ids["sess-fresh"] {
+		t.Error("fresh session should be preserved")
+	}
+	if _, err := os.Stat(s.SessionDir("sess-old")); !os.IsNotExist(err) {
+		t.Errorf("old dir should be removed; err=%v", err)
+	}
+	if _, err := os.Stat(s.SessionDir("sess-fresh")); err != nil {
+		t.Errorf("fresh dir should remain: %v", err)
+	}
+}
+
+// TestSweepCountCapKeepsNewest pins the count limit: only the newest
+// MaxCount dead sessions survive, ranked by ExitedAt.
+func TestSweepCountCapKeepsNewest(t *testing.T) {
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	s := New(t.TempDir(),
+		WithRetention(RetentionPolicy{MaxCount: 2}),
+		WithClock(func() time.Time { return now }))
+
+	writeDead(t, s, "sess-oldest", now.Add(-3*time.Hour).Format(time.RFC3339))
+	writeDead(t, s, "sess-middle", now.Add(-2*time.Hour).Format(time.RFC3339))
+	writeDead(t, s, "sess-newest", now.Add(-1*time.Hour).Format(time.RFC3339))
+
+	loaded, err := s.Sweep()
+	if err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	ids := loadedIDs(loaded)
+	if len(loaded) != 2 || !ids["sess-newest"] || !ids["sess-middle"] {
+		t.Errorf("expected newest+middle kept, got %v", ids)
+	}
+	if _, err := os.Stat(s.SessionDir("sess-oldest")); !os.IsNotExist(err) {
+		t.Errorf("oldest dir should be removed; err=%v", err)
+	}
+}
+
+// TestSweepNoPolicyKeepsEverything pins that the default New (no
+// retention option) does not prune, preserving prior behavior.
+func TestSweepNoPolicyKeepsEverything(t *testing.T) {
+	s := New(t.TempDir())
+	writeDead(t, s, "sess-a", "2000-01-01T00:00:00Z") // ancient
+	writeDead(t, s, "sess-b", "2000-01-02T00:00:00Z")
+
+	loaded, err := s.Sweep()
+	if err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	if len(loaded) != 2 {
+		t.Errorf("expected both sessions kept without a policy, got %d", len(loaded))
+	}
+}
+
+// TestSweepUndatableSurvives pins the conservative rule: a record with
+// no parseable timestamp is never aged out and is treated as newest for
+// the count cap, so it is never evicted unexpectedly.
+func TestSweepUndatableSurvives(t *testing.T) {
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	s := New(t.TempDir(),
+		WithRetention(RetentionPolicy{MaxAge: time.Hour, MaxCount: 1}),
+		WithClock(func() time.Time { return now }))
+
+	writeDead(t, s, "sess-dated", now.Add(-10*time.Hour).Format(time.RFC3339)) // ages out
+	writeDead(t, s, "sess-undated", "")                                        // no timestamp
+
+	loaded, err := s.Sweep()
+	if err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	ids := loadedIDs(loaded)
+	if !ids["sess-undated"] {
+		t.Error("undatable session must survive retention")
+	}
+	if ids["sess-dated"] {
+		t.Error("dated stale session should have been aged out")
+	}
+}
+
+// TestDefaultRetentionEnvOverride pins the env-var overrides.
+func TestDefaultRetentionEnvOverride(t *testing.T) {
+	t.Setenv(envRetentionDays, "5")
+	t.Setenv(envRetentionCount, "10")
+	p := DefaultRetention()
+	if p.MaxAge != 5*24*time.Hour {
+		t.Errorf("MaxAge: got %v, want 5d", p.MaxAge)
+	}
+	if p.MaxCount != 10 {
+		t.Errorf("MaxCount: got %d, want 10", p.MaxCount)
+	}
+
+	t.Setenv(envRetentionDays, "0")
+	if got := DefaultRetention().MaxAge; got != 0 {
+		t.Errorf("MaxAge with days=0 should disable age limit, got %v", got)
+	}
+}

--- a/services/gmuxd/internal/sessionmeta/sessionmeta_test.go
+++ b/services/gmuxd/internal/sessionmeta/sessionmeta_test.go
@@ -613,4 +613,12 @@ func TestDefaultRetentionEnvOverride(t *testing.T) {
 	if got := DefaultRetention().MaxAge; got != 0 {
 		t.Errorf("MaxAge with days=0 should disable age limit, got %v", got)
 	}
+
+	// A day count that would overflow time.Duration when multiplied by
+	// 24h is rejected and falls back to the default rather than wrapping
+	// to a negative duration.
+	t.Setenv(envRetentionDays, "100000000000")
+	if got := DefaultRetention().MaxAge; got != DefaultMaxAge {
+		t.Errorf("MaxAge with overflowing days should fall back to default %v, got %v", DefaultMaxAge, got)
+	}
 }


### PR DESCRIPTION
Implements review ticket T22.

Dead-but-not-dismissed sessions previously persisted forever — each keeps a meta.json plus up to ~2 MiB of rotated scrollback under `~/.local/state/gmux/sessions/<id>/`, removed only on explicit dismiss or orphan-sweep. For heavy users who never dismiss, the state dir grew unbounded. This adds a retention policy applied during the startup `Sweep`: dead-session corpses older than `MaxAge` are aged out, then only the newest `MaxCount` survive (LRU by effective timestamp — ExitedAt, falling back to LastActivityAt then CreatedAt). Defaults are 30 days / 200 sessions, overridable via `GMUX_SESSION_RETENTION_DAYS` and `GMUX_SESSION_RETENTION_MAX` (0 disables a limit).

Safety rules: `Sweep` only loads `Alive=false` records, and any still-running runner re-registers as alive immediately afterwards, so live sessions are never on the chopping block. Records with no parseable timestamp are treated conservatively — never aged out and ranked as newest for the count cap — so they are never evicted unexpectedly. The clock is injectable (`WithClock`) for deterministic tests; the policy is injected via `WithRetention`, and `New` without options preserves the prior no-prune behavior.

## Verification
- `cd services/gmuxd && go build ./...` — passes
- `go test ./...` — all packages pass, including new sessionmeta retention tests (age-out, count cap, no-policy, undatable-survives, env override)

Source finding: L1