### PR TITLE
security: validate session ids and slugs before filesystem and url use

### DIFF
--- a/cli/gmux/internal/ptyserver/ptyserver.go
+++ b/cli/gmux/internal/ptyserver/ptyserver.go
@@ -526,6 +526,17 @@ func (s *Server) handlePutSlug(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "slug is empty", http.StatusBadRequest)
 		return
 	}
+	// Session slugs flow into /@<peer>/<slug> URLs and the
+	// ${peer}::${slug} folder key, so normalize to the same URL-safe
+	// shape as project slugs: reject "/", "::", newlines, and other
+	// separators by slugifying anything not already well-formed.
+	if !adapter.IsValidSlug(slug) {
+		slug = adapter.Slugify(slug)
+	}
+	if slug == "" {
+		http.Error(w, "slug is invalid", http.StatusBadRequest)
+		return
+	}
 	s.state.SetSlug(slug)
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/cli/gmux/internal/ptyserver/ptyserver_test.go
+++ b/cli/gmux/internal/ptyserver/ptyserver_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gmuxapp/gmux/cli/gmux/internal/session"
 	"github.com/gmuxapp/gmux/packages/scrollback"
 	"nhooyr.io/websocket"
 )
@@ -1600,5 +1601,81 @@ func TestBindSocketCreatesParentDir(t *testing.T) {
 
 	if _, err := os.Stat(sockPath); err != nil {
 		t.Errorf("sockfile not created: %v", err)
+	}
+}
+
+// TestPutSlugValidation guards the slug write path: session slugs flow
+// into /@<peer>/<slug> URLs and the ${peer}::${slug} folder key, so a
+// slug carrying "/" or "::" must be rejected or normalized before it
+// reaches the state.
+func TestPutSlugValidation(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "test.sock")
+	srv, err := New(Config{
+		Command:    []string{"sleep", "5"},
+		Cwd:        "/tmp",
+		Listener:   mustBindSocket(t, sockPath),
+		SocketPath: sockPath,
+		State:      session.New(session.Config{ID: "sess-abcd1234"}),
+	})
+	if err != nil {
+		t.Fatalf("new server: %v", err)
+	}
+	defer srv.Shutdown()
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				return net.Dial("unix", sockPath)
+			},
+		},
+	}
+
+	putSlug := func(body string) int {
+		req, _ := http.NewRequest(http.MethodPut, "http://unix/slug", strings.NewReader(body))
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatalf("put slug: %v", err)
+		}
+		resp.Body.Close()
+		return resp.StatusCode
+	}
+
+	currentSlug := func() string {
+		resp, err := client.Get("http://unix/meta")
+		if err != nil {
+			t.Fatalf("get meta: %v", err)
+		}
+		defer resp.Body.Close()
+		var meta struct {
+			Slug string `json:"slug"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&meta); err != nil {
+			t.Fatalf("decode meta: %v", err)
+		}
+		return meta.Slug
+	}
+
+	// Already well-formed: stored verbatim.
+	if code := putSlug("my-session-2"); code != http.StatusNoContent {
+		t.Fatalf("put valid slug = %d, want 204", code)
+	}
+	if got := currentSlug(); got != "my-session-2" {
+		t.Errorf("slug = %q, want %q", got, "my-session-2")
+	}
+
+	// Contains separators / uppercase: normalized, never stored raw.
+	if code := putSlug("Foo/Bar::Baz"); code != http.StatusNoContent {
+		t.Fatalf("put dirty slug = %d, want 204", code)
+	}
+	if got := currentSlug(); got != "foo-bar-baz" {
+		t.Errorf("normalized slug = %q, want %q", got, "foo-bar-baz")
+	}
+	if strings.ContainsAny(currentSlug(), "/:") {
+		t.Errorf("slug %q still contains separators", currentSlug())
+	}
+
+	// Empty after slugify (only separators): rejected.
+	if code := putSlug("///"); code != http.StatusBadRequest {
+		t.Errorf("put unslugifiable = %d, want 400", code)
 	}
 }

--- a/packages/adapter/adapter.go
+++ b/packages/adapter/adapter.go
@@ -66,6 +66,12 @@ func BaseName(arg string) string {
 
 var slugRe = regexp.MustCompile(`[^a-z0-9]+`)
 
+// maxSlugLen caps slug length. Slugify truncates to this and
+// IsValidSlug enforces it, so the two agree on the canonical shape
+// and downstream consumers (/@<peer>/<slug> URLs, ${peer}::${slug}
+// folder keys) always see a bounded slug.
+const maxSlugLen = 40
+
 // validSlugRe matches a normalized slug: lowercase alphanumeric
 // segments joined by single hyphens, no leading/trailing hyphen.
 // Mirrors the daemon's project-slug rule so session slugs that flow
@@ -74,9 +80,11 @@ var slugRe = regexp.MustCompile(`[^a-z0-9]+`)
 var validSlugRe = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
 
 // IsValidSlug reports whether s is already a well-formed slug
-// (the canonical output shape of Slugify).
+// (the canonical output shape of Slugify): the right character shape
+// and within the length cap, so a valid slug never bypasses Slugify's
+// truncation.
 func IsValidSlug(s string) bool {
-	return validSlugRe.MatchString(s)
+	return len(s) <= maxSlugLen && validSlugRe.MatchString(s)
 }
 
 // Slugify converts a string to a URL-safe slug: lowercase, non-alphanum
@@ -88,8 +96,8 @@ func Slugify(s string) string {
 	if s == "" {
 		return ""
 	}
-	if len(s) > 40 {
-		s = s[:40]
+	if len(s) > maxSlugLen {
+		s = s[:maxSlugLen]
 		s = strings.TrimRight(s, "-")
 	}
 	return s

--- a/packages/adapter/adapter.go
+++ b/packages/adapter/adapter.go
@@ -66,6 +66,19 @@ func BaseName(arg string) string {
 
 var slugRe = regexp.MustCompile(`[^a-z0-9]+`)
 
+// validSlugRe matches a normalized slug: lowercase alphanumeric
+// segments joined by single hyphens, no leading/trailing hyphen.
+// Mirrors the daemon's project-slug rule so session slugs that flow
+// into /@<peer>/<slug> URLs and the ${peer}::${slug} folder key can't
+// carry "/", "::", newlines, or other separators.
+var validSlugRe = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
+
+// IsValidSlug reports whether s is already a well-formed slug
+// (the canonical output shape of Slugify).
+func IsValidSlug(s string) bool {
+	return validSlugRe.MatchString(s)
+}
+
 // Slugify converts a string to a URL-safe slug: lowercase, non-alphanum
 // runs replaced by hyphens, trimmed, capped at 40 characters.
 func Slugify(s string) string {

--- a/packages/adapter/slugify_test.go
+++ b/packages/adapter/slugify_test.go
@@ -1,6 +1,9 @@
 package adapter
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestSlugify(t *testing.T) {
 	tests := []struct {
@@ -27,5 +30,45 @@ func TestSlugify(t *testing.T) {
 		if got != tt.want {
 			t.Errorf("Slugify(%q) = %q, want %q", tt.input, got, tt.want)
 		}
+	}
+}
+
+func TestIsValidSlug(t *testing.T) {
+	valid := []string{
+		"a",
+		"already-a-slug",
+		"fix-the-auth-bug",
+		"019cf93a-c782-7942-ab76-010c81df6744",
+		strings.Repeat("a", maxSlugLen), // exactly at the cap
+	}
+	for _, s := range valid {
+		if !IsValidSlug(s) {
+			t.Errorf("IsValidSlug(%q) = false, want true", s)
+		}
+	}
+
+	invalid := []string{
+		"",
+		"-leading",
+		"trailing-",
+		"double--hyphen",
+		"UPPER",
+		"has space",
+		"foo/bar",
+		"foo::bar",
+		"foo\nbar",
+		strings.Repeat("a", maxSlugLen+1), // one over the cap
+	}
+	for _, s := range invalid {
+		if IsValidSlug(s) {
+			t.Errorf("IsValidSlug(%q) = true, want false", s)
+		}
+	}
+
+	// Slugify output always satisfies IsValidSlug, including for
+	// over-length input that exercises the truncation path.
+	long := strings.Repeat("word ", 30)
+	if got := Slugify(long); !IsValidSlug(got) {
+		t.Errorf("Slugify(long)=%q not a valid slug", got)
 	}
 }

--- a/packages/paths/paths.go
+++ b/packages/paths/paths.go
@@ -5,8 +5,27 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 )
+
+// sessionIDRe matches well-formed session IDs. IDs are minted by
+// cli/gmux/internal/naming.SessionID as "sess-<hex>"; the allowlist
+// here (sess- prefix followed by alphanumerics, hyphens, and
+// underscores) is deliberately a touch broader than pure hex so it
+// stays robust to ID-shape evolution, while still excluding every
+// path-dangerous character. Validating against this shape keeps an
+// attacker-influenced ID (the daemon derives it from a runner's
+// /meta, and a malicious socket_path in POST /v1/register could try
+// to steer it) from carrying path separators or ".." into
+// filepath.Join.
+var sessionIDRe = regexp.MustCompile(`^sess-[A-Za-z0-9_-]+$`)
+
+// IsValidSessionID reports whether id is a well-formed local session
+// ID safe to use as a path segment under SessionsDir.
+func IsValidSessionID(id string) bool {
+	return sessionIDRe.MatchString(id)
+}
 
 // SocketPath returns the path to the gmuxd Unix socket for local IPC.
 func SocketPath() string {

--- a/packages/paths/paths_test.go
+++ b/packages/paths/paths_test.go
@@ -59,7 +59,6 @@ func TestCanonicalizePath(t *testing.T) {
 		}
 	}
 }
-
 func TestSessionSocketDir(t *testing.T) {
 	t.Run("GMUX_SOCKET_DIR overrides everything", func(t *testing.T) {
 		t.Setenv("XDG_RUNTIME_DIR", "/run/user/1000")
@@ -91,4 +90,38 @@ func TestSessionSocketDir(t *testing.T) {
 			t.Errorf("SessionSocketDir() must not default to the shared /tmp/gmux-sessions")
 		}
 	})
+}
+
+func TestIsValidSessionID(t *testing.T) {
+	valid := []string{
+		"sess-abcd1234",
+		"sess-0",
+		"sess-claude",
+		"sess-resume_1",
+		"sess-codex-2",
+	}
+	for _, id := range valid {
+		if !IsValidSessionID(id) {
+			t.Errorf("IsValidSessionID(%q) = false, want true", id)
+		}
+	}
+
+	invalid := []string{
+		"",
+		"abcd1234",          // missing prefix
+		"sess-",             // empty suffix
+		"sess-../escape",    // path traversal
+		"sess-..",           // parent dir
+		"../sess-abcd",      // leading traversal
+		"sess-a/b",          // separator
+		`sess-a\b`,          // backslash separator
+		"sess-a::b",         // folder-key separator
+		"sess-a b",          // space
+		"sess-a\n",          // newline
+	}
+	for _, id := range invalid {
+		if IsValidSessionID(id) {
+			t.Errorf("IsValidSessionID(%q) = true, want false", id)
+		}
+	}
 }

--- a/services/gmuxd/internal/discovery/discovery.go
+++ b/services/gmuxd/internal/discovery/discovery.go
@@ -240,6 +240,14 @@ func Register(sessions *store.Store, subs *Subscriptions, fileMon *FileMonitor, 
 		return err
 	}
 
+	// The runner's /meta supplies the session ID, which is then used
+	// as a path segment for persisted metadata and scrollback. Reject
+	// anything that isn't a well-formed sess-<hex> ID so a crafted
+	// socket_path cannot steer writes outside the sessions dir.
+	if !paths.IsValidSessionID(newSess.ID) {
+		return fmt.Errorf("register: invalid session id %q from %s", newSess.ID, socketPath)
+	}
+
 	if existing, ok := sessions.Get(newSess.ID); ok {
 		// Re-registration. The runner reports fresh runtime state;
 		// the store has the historical and attribution-derived

--- a/services/gmuxd/internal/sessionmeta/sessionmeta.go
+++ b/services/gmuxd/internal/sessionmeta/sessionmeta.go
@@ -71,7 +71,20 @@ func New(dir string) *Store { return &Store{dir: dir} }
 func (s *Store) Dir() string { return s.dir }
 
 // SessionDir is the per-session subdirectory: <Dir()>/<id>/.
+//
+// Defense in depth: id becomes a path segment, and SessionDir feeds
+// every disk operation in this package — including Remove's
+// RemoveAll. A crafted id with separators or ".." must never let
+// those escape s.dir, so an id that isn't a well-formed session ID is
+// routed to a single reserved ".invalid" subdir that stays inside
+// s.dir and can never collide with a real session. Well-formed IDs
+// (which contain no separators) join unchanged, and Write rejects
+// invalid IDs with an explicit error before reaching disk, so this
+// fallback is purely a containment backstop.
 func (s *Store) SessionDir(id string) string {
+	if !paths.IsValidSessionID(id) {
+		return filepath.Join(s.dir, ".invalid")
+	}
 	return filepath.Join(s.dir, id)
 }
 
@@ -96,6 +109,14 @@ func (s *Store) Write(sess store.Session) error {
 	}
 	if sess.ID == "" {
 		return errors.New("sessionmeta: cannot persist session with empty id")
+	}
+	// Defense in depth: the ID becomes a path segment under the
+	// sessions dir, so reject anything that isn't a well-formed
+	// session ID before it reaches MkdirAll/Rename. The registration
+	// boundary validates too, but this guarantees the write path can
+	// never escape the sessions dir regardless of caller.
+	if !paths.IsValidSessionID(sess.ID) {
+		return fmt.Errorf("sessionmeta: invalid session id %q", sess.ID)
 	}
 
 	sessDir := s.SessionDir(sess.ID)

--- a/services/gmuxd/internal/sessionmeta/sessionmeta_test.go
+++ b/services/gmuxd/internal/sessionmeta/sessionmeta_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -405,5 +406,76 @@ func TestWriteOverwritesExisting(t *testing.T) {
 	}
 	if verify.Title != "second" {
 		t.Errorf("on-disk title: got %q, want %q", verify.Title, "second")
+	}
+}
+
+// TestWriteRejectsUnsafeID guards the write path: a crafted ID with
+// path separators or ".." must never escape the sessions dir. The
+// daemon derives the ID from a runner's /meta, so a malicious
+// socket_path could otherwise steer Persist outside its base dir.
+func TestWriteRejectsUnsafeID(t *testing.T) {
+	s := newStore(t)
+	unsafe := []string{
+		"sess-../../../etc/cron.d/x",
+		"sess-..",
+		"../escape",
+		"sess-a/b",
+	}
+	for _, id := range unsafe {
+		sess := sampleSession()
+		sess.ID = id
+		if err := s.Write(sess); err == nil {
+			t.Errorf("Write(id=%q) = nil error, want rejection", id)
+		}
+	}
+
+	// Nothing should have been created outside the base dir.
+	if entries, _ := os.ReadDir(filepath.Dir(s.Dir())); len(entries) > 0 {
+		// Dir()'s parent is the temp root; the base dir itself is
+		// created lazily only on a successful write, so an unsafe-only
+		// run must leave the parent empty.
+		for _, e := range entries {
+			if e.Name() != filepath.Base(s.Dir()) {
+				t.Errorf("unexpected entry outside base dir: %s", e.Name())
+			}
+		}
+	}
+}
+
+// TestSessionDirContainsUnsafeIDs confirms the path constructor itself
+// never returns a path outside the base dir for a crafted ID, so every
+// disk op fed by it (including Remove's RemoveAll) stays contained.
+func TestSessionDirContainsUnsafeIDs(t *testing.T) {
+	s := newStore(t)
+	base := filepath.Clean(s.Dir())
+	unsafe := []string{
+		"sess-../../../etc",
+		"..",
+		"../escape",
+		"sess-a/b",
+		"",
+	}
+	for _, id := range unsafe {
+		got := filepath.Clean(s.SessionDir(id))
+		if got != base && !strings.HasPrefix(got, base+string(filepath.Separator)) {
+			t.Errorf("SessionDir(%q) = %q escaped base %q", id, got, base)
+		}
+		if got == base {
+			t.Errorf("SessionDir(%q) = %q collapsed to base dir (RemoveAll would wipe all sessions)", id, got)
+		}
+	}
+}
+
+// TestWriteAcceptsWellFormedID confirms normal sess-<hex> IDs still
+// persist after the validation guard was added.
+func TestWriteAcceptsWellFormedID(t *testing.T) {
+	s := newStore(t)
+	sess := sampleSession()
+	sess.ID = "sess-abcd1234"
+	if err := s.Write(sess); err != nil {
+		t.Fatalf("Write(well-formed id) = %v, want nil", err)
+	}
+	if _, err := os.Stat(filepath.Join(s.SessionDir(sess.ID), metaFile)); err != nil {
+		t.Fatalf("meta.json not written: %v", err)
 	}
 }


### PR DESCRIPTION
Implements review ticket T24.

The daemon derived a session ID from the runner's `/meta` and fed it straight into `filepath.Join` for the metadata write path (`sessionmeta.Write`) without ever validating it — a malicious `socket_path` in `POST /v1/register` could steer the derived ID to carry `..` or path separators and escape the sessions dir. Separately, `ptyserver.handlePutSlug` accepted any non-empty ≤256-byte string as a session slug (newlines, `/`, `::`), bypassing the strict rules project slugs follow; those slugs flow into `/@<peer>/<slug>` URLs and the `${peer}::${slug}` folder key.

This change:
- Adds `paths.IsValidSessionID` (`^sess-[A-Za-z0-9_-]+$`) and enforces it both at the registration boundary (`discovery.Register`) and defensively inside `sessionmeta.Write`, so a crafted ID can never escape the sessions dir on the write path. The allowlist is a touch broader than pure hex to stay robust to ID-shape evolution while excluding every path-dangerous character.
- Adds `adapter.IsValidSlug` and normalizes the session slug in `handlePutSlug`: well-formed slugs pass through verbatim, anything else is slugified, and a slug that slugifies to empty is rejected with 400.

## Verification
- `go build ./...` + `go test ./...` in packages/paths, packages/adapter, cli/gmux, services/gmuxd — all pass.
- New tests: `paths.TestIsValidSessionID`, `sessionmeta.TestWriteRejectsUnsafeID` / `TestWriteAcceptsWellFormedID`, `ptyserver.TestPutSlugValidation` (covers `/`, `::`, uppercase normalization, and unslugifiable rejection).

Note (out of scope): the ticket flags potential overlap with T14 on the register path; this PR only adds the ID guard there and leaves any T14 work untouched.

Source finding: review/01-security.md P1