### PR TITLE
fix: terminal resize/scrollbar feedback loop; standardize scrollbars

### DIFF
--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -59,6 +59,40 @@ code {
   box-sizing: border-box;
 }
 
+/* ── Scrollbars ──
+ *
+ * One scrollbar style for the whole app, derived from the sidebar's slim
+ * thumb but a touch wider and brighter so it's easier to spot and grab.
+ *
+ * Two mechanisms on purpose: Chromium 121+ and Firefox honor the standard
+ * scrollbar-width/scrollbar-color properties (and then ignore the
+ * ::-webkit-scrollbar pseudos entirely); Safari only understands the
+ * webkit pseudos. Each browser picks the one it supports.
+ *
+ * Keeping the thumb thin also keeps the layout cost of classic
+ * (non-overlay) scrollbars small wherever they take up space. */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: var(--border-strong) transparent;
+}
+*::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+*::-webkit-scrollbar-track {
+  background: transparent;
+}
+*::-webkit-scrollbar-thumb {
+  background: var(--border-strong);
+  border-radius: 3px;
+}
+*::-webkit-scrollbar-thumb:hover {
+  background: oklch(46% 0.015 250);
+}
+*::-webkit-scrollbar-corner {
+  background: transparent;
+}
+
 html, body, #app {
   height: 100%;
   overflow: hidden;
@@ -207,19 +241,6 @@ body {
   padding: 6px 0 48px;
   display: flex;
   flex-direction: column;
-}
-
-.sidebar-scroll::-webkit-scrollbar {
-  width: 3px;
-}
-
-.sidebar-scroll::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-.sidebar-scroll::-webkit-scrollbar-thumb {
-  background: var(--border);
-  border-radius: 2px;
 }
 
 /* ── Folder ── */
@@ -1272,9 +1293,6 @@ body {
   padding: 12px 16px 16px;
 }
 
-.modal-body::-webkit-scrollbar { width: 3px; }
-.modal-body::-webkit-scrollbar-track { background: transparent; }
-.modal-body::-webkit-scrollbar-thumb { background: var(--border); border-radius: 2px; }
 
 /* Section layout */
 .mp-section + .mp-section {
@@ -1414,9 +1432,6 @@ body {
   gap: 2px;
 }
 
-.mp-discovered-scroll::-webkit-scrollbar { width: 3px; }
-.mp-discovered-scroll::-webkit-scrollbar-track { background: transparent; }
-.mp-discovered-scroll::-webkit-scrollbar-thumb { background: var(--border); border-radius: 2px; }
 
 /* Discovered rows */
 .mp-discovered-row {

--- a/apps/gmux-web/src/terminal.tsx
+++ b/apps/gmux-web/src/terminal.tsx
@@ -55,12 +55,21 @@ function measureTerminalFit(
   const padX = parseFloat(style.paddingLeft) + parseFloat(style.paddingRight)
   const padY = parseFloat(style.paddingTop) + parseFloat(style.paddingBottom)
 
-  // Measure the shell, the stable flex-allocated viewport.
-  const availW = shellEl.clientWidth - padX - reserveWidth
-  const availH = shellEl.clientHeight - padY
+  // Measure the shell, the stable flex-allocated viewport. Use offsetWidth/
+  // offsetHeight, NOT clientWidth/clientHeight: the shell is the scroll
+  // container (overflow: auto), so client* shrinks when a scrollbar appears.
+  // Measuring client* creates a feedback loop — e.g. after a DPR change
+  // (moving the window between monitors) the grid can overflow by 1px,
+  // a scrollbar appears, client* shrinks, we refit smaller, the scrollbar
+  // disappears, client* grows, we refit bigger, the grid overflows again,
+  // forever. offset* is the border-box and ignores scrollbars, so the
+  // measurement is a fixed point regardless of transient overflow.
+  // (.terminal-shell has no border/padding, so offset* == the viewport.)
+  const availW = shellEl.offsetWidth - padX - reserveWidth
+  const availH = shellEl.offsetHeight - padY
 
   let cols = Math.max(2, Math.floor(availW / dims.css.cell.width))
-  const rows = Math.max(1, Math.floor(availH / dims.css.cell.height))
+  let rows = Math.max(1, Math.floor(availH / dims.css.cell.height))
 
   // Guard against 1px overflow: xterm computes screen width as
   // Math.round(device.cell.width * cols / dpr). Because css.cell.width is
@@ -72,6 +81,13 @@ function measureTerminalFit(
   if (dims.device.cell.width > 0) {
     const predictedWidth = Math.round(dims.device.cell.width * cols / dpr)
     if (predictedWidth > availW && cols > 2) cols--
+  }
+  // Same guard vertically: row height rounding across device/css pixels can
+  // overflow by 1px at fractional DPRs (the monitor-move case), which is
+  // exactly what seeds the scrollbar flicker described above.
+  if (dims.device.cell.height > 0) {
+    const predictedHeight = Math.round(dims.device.cell.height * rows / dpr)
+    if (predictedHeight > availH && rows > 1) rows--
   }
 
   return { cols, rows }
@@ -87,9 +103,11 @@ export function getProposedTerminalSize(fit: FitAddon | null): TerminalSize | nu
 
 function getResizeSignalPixels(host: HTMLElement | null, vv: VisualViewport | null): { width: number; height: number } {
   if (host) {
+    // offset* not client*: must match measureTerminalFit so scrollbar
+    // appearance/disappearance doesn't register as a size change.
     return {
-      width: host.clientWidth,
-      height: host.clientHeight,
+      width: host.offsetWidth,
+      height: host.offsetHeight,
     }
   }
 


### PR DESCRIPTION
## Problem

Moving the browser window between monitors (DPR change) could send the terminal into an endless oscillation: scrollbar appears → terminal shrinks → scrollbar disappears → terminal grows → scrollbar appears → …

## Root cause

`measureTerminalFit` read `clientWidth/clientHeight` of `.terminal-shell` — the scroll container itself. Classic scrollbars take layout space, so `client*` shrinks the moment one appears. A DPR change makes the xterm grid overflow by ~1px via device↔css pixel rounding, which triggers the scrollbar and closes the feedback loop with the ResizeObserver-driven refit.

## Fix

- Measure `offsetWidth/offsetHeight` instead (border-box, scrollbar-independent), making the fit measurement a fixed point regardless of transient overflow.
- Add a 1px row-height rounding guard mirroring the existing column guard, killing the seed of the overflow at fractional DPRs.
- Key resize-signal dedupe off offset sizes too so scrollbar flicker never registers as a size change.

## Standardized scrollbars

One app-wide scrollbar style based on the sidebar's slim thumb, tweaked for visibility: 6px wide, `--border-strong` thumb, transparent track, brighter on hover. Standard `scrollbar-width`/`scrollbar-color` for Chromium 121+/Firefox plus `::-webkit-scrollbar` pseudos for Safari. Removes the per-component overrides (`.sidebar-scroll`, `.modal-body`, `.mp-discovered-scroll`).

## Testing

- Typecheck + all 466 unit tests pass.
- Manual sanity check recommended for the actual monitor-move scenario (DPR transitions aren't simulated in tests).