### PR TITLE
fix(web): mobile toolbar respects armed ctrl/alt modifiers

### DIFF
--- a/apps/gmux-web/src/keyboard.test.ts
+++ b/apps/gmux-web/src/keyboard.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { ctrlSequenceFor, formatPasteText, pickBinaryDataTransferItem } from './keyboard'
+import { applyArmedModifiers, ctrlSequenceFor, formatPasteText, pickBinaryDataTransferItem } from './keyboard'
 
 // Build an array-like stand-in for DataTransferItemList. Vitest runs in
 // node by default, where the real DOM type isn't available; a plain
@@ -127,5 +127,64 @@ describe('ctrlSequenceFor', () => {
     expect(ctrlSequenceFor('ab')).toBeNull()
     expect(ctrlSequenceFor('1')).toBeNull()
     expect(ctrlSequenceFor('')).toBeNull()
+  })
+})
+
+describe('applyArmedModifiers', () => {
+  it('passes data through unchanged when nothing is armed', () => {
+    expect(applyArmedModifiers('a', false, false))
+      .toEqual({ seq: 'a', ctrlApplied: false, altApplied: false })
+    expect(applyArmedModifiers('\r', false, false))
+      .toEqual({ seq: '\r', ctrlApplied: false, altApplied: false })
+  })
+
+  it('applies ctrl to single characters via control codes', () => {
+    expect(applyArmedModifiers('c', true, false))
+      .toEqual({ seq: '\x03', ctrlApplied: true, altApplied: false })
+  })
+
+  it('applies alt to single characters via ESC prefix', () => {
+    expect(applyArmedModifiers('b', false, true))
+      .toEqual({ seq: '\x1bb', ctrlApplied: false, altApplied: true })
+  })
+
+  it('combines ctrl+alt on lowercase characters (ESC + control code)', () => {
+    expect(applyArmedModifiers('c', true, true))
+      .toEqual({ seq: '\x1b\x03', ctrlApplied: true, altApplied: true })
+  })
+
+  it('folds alt into the CSI-u modifier for uppercase ctrl combos', () => {
+    // ctrl only: shift+ctrl = 6 (matches ctrlSequenceFor)
+    expect(applyArmedModifiers('A', true, false).seq).toBe('\x1b[97;6u')
+    // ctrl+alt: shift+alt+ctrl = 8
+    expect(applyArmedModifiers('A', true, true).seq).toBe('\x1b[97;8u')
+  })
+
+  it('leaves ctrl armed when the payload has no ctrl encoding', () => {
+    expect(applyArmedModifiers('1', true, false))
+      .toEqual({ seq: '1', ctrlApplied: false, altApplied: false })
+  })
+
+  it('injects modifier params into CSI cursor-key sequences', () => {
+    expect(applyArmedModifiers('\x1b[D', true, false).seq).toBe('\x1b[1;5D')  // ctrl+left = word-left
+    expect(applyArmedModifiers('\x1b[C', false, true).seq).toBe('\x1b[1;3C')  // alt+right
+    expect(applyArmedModifiers('\x1b[A', true, true).seq).toBe('\x1b[1;7A')   // ctrl+alt+up
+  })
+
+  it('encodes alt+enter as ESC CR', () => {
+    expect(applyArmedModifiers('\r', false, true))
+      .toEqual({ seq: '\x1b\r', ctrlApplied: false, altApplied: true })
+  })
+
+  it('encodes ctrl+enter / ctrl+tab / ctrl+esc as CSI-u (no legacy encoding exists)', () => {
+    expect(applyArmedModifiers('\r', true, false).seq).toBe('\x1b[13;5u')
+    expect(applyArmedModifiers('\t', true, false).seq).toBe('\x1b[9;5u')
+    expect(applyArmedModifiers('\x1b', true, false).seq).toBe('\x1b[27;5u')
+    expect(applyArmedModifiers('\r', true, true).seq).toBe('\x1b[13;7u')
+  })
+
+  it('ESC-prefixes alt for keys without special handling', () => {
+    expect(applyArmedModifiers('\t', false, true).seq).toBe('\x1b\t')
+    expect(applyArmedModifiers('\n', false, true).seq).toBe('\x1b\n')
   })
 })

--- a/apps/gmux-web/src/keyboard.ts
+++ b/apps/gmux-web/src/keyboard.ts
@@ -267,6 +267,81 @@ function executeAction(
 }
 
 /**
+ * Result of applying armed mobile modifiers to an input payload.
+ *
+ * `ctrlApplied` / `altApplied` tell the caller which arms were actually
+ * encoded into `seq`, so only those get consumed (disarmed). A ctrl arm
+ * stays armed when the payload has no ctrl encoding (e.g. a digit),
+ * matching the long-standing sendInput behavior.
+ */
+export interface ArmedModifierResult {
+  seq: string
+  ctrlApplied: boolean
+  altApplied: boolean
+}
+
+/**
+ * Apply armed ctrl/alt modifiers to an outgoing input payload.
+ *
+ * This is the single source of truth for the mobile "arm a modifier, then
+ * press a key" feature. It understands more than bare characters:
+ *
+ *  - Single characters: ctrl via ctrlSequenceFor (legacy control codes,
+ *    CSI-u for uppercase), alt via ESC prefix, both combined when armed
+ *    together (legacy ESC + control code; CSI-u modifier bits for
+ *    uppercase).
+ *  - CSI cursor keys (arrows, Home, End): modifier parameter injection,
+ *    e.g. \x1b[D + ctrl → \x1b[1;5D (the standard word-left encoding).
+ *  - Enter / Tab / Esc: alt uses the universal ESC prefix. Ctrl has no
+ *    legacy encoding for these (ctrl+enter is byte-identical to enter),
+ *    so CSI-u is emitted — consistent with ctrlSequenceFor's uppercase
+ *    handling. Apps without kitty-protocol support won't see it, but
+ *    nothing else can represent the combo at all.
+ *
+ * The CSI-u modifier parameter is 1 + shift(1) + alt(2) + ctrl(4).
+ */
+export function applyArmedModifiers(
+  data: string,
+  ctrl: boolean,
+  alt: boolean,
+): ArmedModifierResult {
+  const unchanged = { seq: data, ctrlApplied: false, altApplied: false }
+  if (!ctrl && !alt) return unchanged
+  const mod = 1 + (alt ? 2 : 0) + (ctrl ? 4 : 0)
+
+  // CSI cursor-key sequences: inject the modifier parameter.
+  const csi = /^\x1b\[([A-DHF])$/.exec(data)
+  if (csi) return { seq: `\x1b[1;${mod}${csi[1]}`, ctrlApplied: ctrl, altApplied: alt }
+
+  // Enter / Tab / Esc with ctrl involved: CSI-u (no legacy encoding exists).
+  const csiUCode = data === '\r' ? 13 : data === '\t' ? 9 : data === '\x1b' ? 27 : null
+  if (csiUCode !== null && ctrl) {
+    return { seq: `\x1b[${csiUCode};${mod}u`, ctrlApplied: true, altApplied: alt }
+  }
+
+  if (data.length === 1 && ctrl) {
+    // Uppercase: ctrlSequenceFor would emit CSI-u with mod 6 (shift+ctrl);
+    // fold an armed alt into the modifier bits instead of ESC-prefixing.
+    if (data >= 'A' && data <= 'Z') {
+      return {
+        seq: `\x1b[${data.toLowerCase().charCodeAt(0)};${mod + 1}u`,
+        ctrlApplied: true,
+        altApplied: alt,
+      }
+    }
+    const code = ctrlSequenceFor(data)
+    if (code) return { seq: alt ? `\x1b${code}` : code, ctrlApplied: true, altApplied: alt }
+  }
+
+  // Alt fallback: ESC prefix is the universal legacy alt encoding and is
+  // valid for any remaining payload (chars, \r, \t, even whole sequences).
+  if (alt) return { seq: `\x1b${data}`, ctrlApplied: false, altApplied: true }
+
+  // Ctrl armed but no encoding for this payload: leave it armed.
+  return unchanged
+}
+
+/**
  * Translate a single character into its Ctrl+<key> sequence.
  *
  * Lowercase letters produce the traditional ASCII control code (a=\x01).

--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -316,7 +316,15 @@ function MobileTerminalBar({
         ))}
         {ctrlArmed
           ? <button class="mobile-bottom-action" disabled={!canSend} onClick={() => { onPaste(); onFocusTerminal() }} title="Paste from clipboard"><IconPaste /></button>
-          : <button class="mobile-bottom-action send-btn" disabled={!canSend} onClick={() => tap('\r')} title="Send"><IconSend /></button>
+          : <button
+              class="mobile-bottom-action send-btn"
+              disabled={!canSend}
+              // The toolbar sends through the raw input channel (no ctrl/alt
+              // arm transformation), so an armed Alt must be applied here:
+              // prefix ESC (alt+enter) and consume the arm.
+              onClick={() => { if (altArmed) { onToggleAlt(); tap('\x1b\r') } else { tap('\r') } }}
+              title={altArmed ? 'Send Alt+Enter' : 'Send'}
+            ><IconSend /></button>
         }
       </div>
     </div>

--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -4,6 +4,7 @@ import { LocationProvider, Router, Route, lazy, useLocation } from 'preact-iso'
 import '@xterm/xterm/css/xterm.css'
 import './styles.css'
 
+import { applyArmedModifiers } from './keyboard'
 import { ReplayView } from './replay-view'
 import { TerminalView } from './terminal'
 import { useArrivalPulse } from './use-arrival-pulse'
@@ -203,6 +204,8 @@ function MobileTerminalBar({
   onPaste,
   onToggleCtrl,
   onToggleAlt,
+  onCtrlConsumed,
+  onAltConsumed,
   onFocusTerminal,
 }: {
   canSend: boolean
@@ -213,6 +216,8 @@ function MobileTerminalBar({
   onPaste: () => void
   onToggleCtrl: () => void
   onToggleAlt: () => void
+  onCtrlConsumed: () => void
+  onAltConsumed: () => void
   onFocusTerminal: () => void
 }) {
   // Read signals directly; no props needed for these. The hamburger
@@ -226,6 +231,20 @@ function MobileTerminalBar({
 
   const keepFocus = (ev: Event) => ev.preventDefault()
   const tap = (seq: string) => { onSend(seq); onFocusTerminal() }
+
+  // Modifier-aware tap: the toolbar sends through the raw input channel
+  // (bypassing the arm logic in sendInput), so armed ctrl/alt must be
+  // applied here. Consumes whichever arms were actually encoded.
+  // Used by keys where an armed modifier should combine (send, ←/→);
+  // NOT used by the ↑/↓ layer buttons, whose entire purpose is plain
+  // arrow access while a modifier is armed.
+  const tapKey = (seq: string, ctrl = ctrlArmed, alt = altArmed): string => {
+    const r = applyArmedModifiers(seq, ctrl, alt)
+    if (r.ctrlApplied && ctrlArmed) onCtrlConsumed()
+    if (r.altApplied) onAltConsumed()
+    tap(r.seq)
+    return r.seq
+  }
 
   const [holdWordMode, setHoldWordMode] = useState(false)
   const holdTimer1   = useRef<ReturnType<typeof setTimeout>  | null>(null)
@@ -305,7 +324,7 @@ function MobileTerminalBar({
           <button
             class="mobile-bottom-action"
             disabled={!canSend}
-            onPointerDown={e => { e.currentTarget.setPointerCapture(e.pointerId); e.preventDefault(); const s = showCtrl ? wordSeq : seq; tap(s); startArrowHold(s, wordSeq) }}
+            onPointerDown={e => { e.currentTarget.setPointerCapture(e.pointerId); e.preventDefault(); const s = tapKey(seq, showCtrl, altArmed); startArrowHold(s, wordSeq) }}
             onPointerUp={clearHold}
             onPointerCancel={clearHold}
             onContextMenu={e => e.preventDefault()}
@@ -319,10 +338,7 @@ function MobileTerminalBar({
           : <button
               class="mobile-bottom-action send-btn"
               disabled={!canSend}
-              // The toolbar sends through the raw input channel (no ctrl/alt
-              // arm transformation), so an armed Alt must be applied here:
-              // prefix ESC (alt+enter) and consume the arm.
-              onClick={() => { if (altArmed) { onToggleAlt(); tap('\x1b\r') } else { tap('\r') } }}
+              onClick={() => tapKey('\r')}
               title={altArmed ? 'Send Alt+Enter' : 'Send'}
             ><IconSend /></button>
         }
@@ -589,6 +605,8 @@ function App() {
           onPaste={handleMobilePaste}
           onToggleCtrl={handleToggleCtrl}
           onToggleAlt={handleToggleAlt}
+          onCtrlConsumed={handleCtrlConsumed}
+          onAltConsumed={handleAltConsumed}
           onFocusTerminal={handleFocusTerminal}
         />
       </div>

--- a/apps/gmux-web/src/terminal.tsx
+++ b/apps/gmux-web/src/terminal.tsx
@@ -5,7 +5,7 @@ import { ImageAddon } from '@xterm/addon-image'
 import { WebLinksAddon } from '@xterm/addon-web-links'
 import type { ResolvedTerminalOptions } from './settings-schema'
 import { loadWebglRenderer } from './webgl-renderer'
-import { attachKeyboardHandler, attachPasteHandler, ctrlSequenceFor, defaultPasteFeedback, handlePasteAction } from './keyboard'
+import { applyArmedModifiers, attachKeyboardHandler, attachPasteHandler, defaultPasteFeedback, handlePasteAction } from './keyboard'
 import { DEFAULT_THEME_COLORS, type ResolvedKeybind } from './config'
 import { attachMobileInputHandler } from './mobile-input'
 import { createReplayBuffer } from './replay'
@@ -464,22 +464,10 @@ export function TerminalView({
     }
 
     const sendInput = (data: string) => {
-      if (ctrlArmedRef.current) {
-        const ctrlData = ctrlSequenceFor(data)
-        if (ctrlData) {
-          ctrlArmedRef.current = false
-          onCtrlConsumed()
-          sendRawInput(ctrlData)
-          return
-        }
-      }
-      if (altArmedRef.current) {
-        altArmedRef.current = false
-        onAltConsumed()
-        sendRawInput('\x1b' + data)
-        return
-      }
-      sendRawInput(data)
+      const r = applyArmedModifiers(data, ctrlArmedRef.current, altArmedRef.current)
+      if (r.ctrlApplied) { ctrlArmedRef.current = false; onCtrlConsumed() }
+      if (r.altApplied) { altArmedRef.current = false; onAltConsumed() }
+      sendRawInput(r.seq)
     }
 
     onInputReady?.(sendRawInput)


### PR DESCRIPTION
## Problem

On mobile, arming **alt** via the soft toolbar and then tapping **send** sent a bare Enter (`\r`) instead of Alt+Enter. An audit found the same class of bug elsewhere (see below).

## Root cause

The toolbar is wired to `sendRawInput`, which deliberately bypasses the ctrl/alt arm logic in `sendInput` (so esc/arrow escape sequences aren't corrupted by an armed modifier). Toolbar taps therefore ignored armed modifiers entirely.

## Fix

New `applyArmedModifiers` in keyboard.ts — the single source of truth for armed-modifier encoding, shared by typed input (`sendInput`) and the toolbar:

- single chars: legacy ctrl codes / ESC-prefix alt; ctrl+alt now combine instead of leaving alt dangling
- CSI cursor keys: modifier-param injection (`\x1b[D` + ctrl → `\x1b[1;5D`)
- enter/tab/esc: ESC prefix for alt (`\x1b\r` = alt+enter); CSI-u when ctrl is involved, since these combos have **no legacy encoding** (consistent with the existing ctrl+uppercase CSI-u handling)

Bugs fixed:
- armed **alt + send** → now sends `\x1b\r`
- armed **alt + ←/→** → was ignored; alt stayed armed and silently hit the next typed char
- armed **ctrl + ←/→** → bytes were right (word-nav) but the arm was never consumed, so the next typed char became ctrl+char (typing `c` sent SIGINT)

Deliberately unchanged:
- ↑/↓ layer buttons stay plain — their purpose is plain-arrow access while a modifier is armed
- ctrl-armed send slot still shows paste, so ctrl+enter remains unreachable from the bar (it's only representable via CSI-u anyway)

## Testing

- 10 new unit tests for `applyArmedModifiers`
- `tsc --noEmit` clean, all 476 web tests pass