### PR TITLE
fix(web): open links reliably on mobile by hit-testing taps against the buffer

### DIFF
--- a/apps/gmux-web/src/terminal-link.test.ts
+++ b/apps/gmux-web/src/terminal-link.test.ts
@@ -1,0 +1,94 @@
+import { beforeAll, describe, expect, test } from 'vitest'
+import type { Terminal } from '@xterm/xterm'
+import { openLinkAtPoint } from './terminal-link'
+
+// Node has Event/EventTarget but not MouseEvent; polyfill enough for
+// the synthetic handshake the module dispatches.
+beforeAll(() => {
+  if (typeof globalThis.MouseEvent === 'undefined') {
+    class MouseEventPolyfill extends Event {
+      clientX: number
+      clientY: number
+      button: number
+      buttons: number
+      constructor(type: string, init: MouseEventInit = {}) {
+        super(type, init)
+        this.clientX = init.clientX ?? 0
+        this.clientY = init.clientY ?? 0
+        this.button = init.button ?? 0
+        this.buttons = init.buttons ?? 0
+      }
+    }
+    // @ts-expect-error assigning polyfill into the global scope
+    globalThis.MouseEvent = MouseEventPolyfill
+  }
+})
+
+interface FakeTermOptions {
+  /** Called on mousemove; return a truthy link to simulate resolution. */
+  resolveLink?: () => unknown
+  withScreen?: boolean
+  withLinkifier?: boolean
+}
+
+function makeFakeTerm(opts: FakeTermOptions = {}) {
+  const { resolveLink, withScreen = true, withLinkifier = true } = opts
+  const screen = new EventTarget()
+  const received: { type: string, clientX: number, clientY: number }[] = []
+  const linkifier: { currentLink?: unknown } = {}
+
+  for (const type of ['mousemove', 'mousedown', 'mouseup']) {
+    screen.addEventListener(type, ev => {
+      const me = ev as MouseEvent
+      received.push({ type: ev.type, clientX: me.clientX, clientY: me.clientY })
+      if (ev.type === 'mousemove' && resolveLink) {
+        linkifier.currentLink = resolveLink()
+      }
+    })
+  }
+
+  const term = {
+    element: withScreen
+      ? { querySelector: (sel: string) => (sel === '.xterm-screen' ? screen : null) }
+      : null,
+    _core: withLinkifier ? { linkifier } : {},
+  } as unknown as Terminal
+
+  return { term, received }
+}
+
+describe('openLinkAtPoint', () => {
+  test('activates a resolved link with the full handshake, in order', () => {
+    const { term, received } = makeFakeTerm({ resolveLink: () => ({ link: {} }) })
+
+    expect(openLinkAtPoint(term, 42, 17)).toBe(true)
+    expect(received.map(e => e.type)).toEqual(['mousemove', 'mousedown', 'mouseup'])
+    // All events target the tap coordinates so the Linkifier's position
+    // checks (resolve, press, release) all hit the same cell.
+    for (const ev of received) {
+      expect(ev.clientX).toBe(42)
+      expect(ev.clientY).toBe(17)
+    }
+  })
+
+  test('stops after hover when no link resolves (no synthetic click side effects)', () => {
+    const { term, received } = makeFakeTerm({ resolveLink: () => undefined })
+
+    expect(openLinkAtPoint(term, 5, 5)).toBe(false)
+    expect(received.map(e => e.type)).toEqual(['mousemove'])
+  })
+
+  test('returns false when the screen element is missing', () => {
+    const { term, received } = makeFakeTerm({ withScreen: false })
+
+    expect(openLinkAtPoint(term, 5, 5)).toBe(false)
+    expect(received).toEqual([])
+  })
+
+  test('returns false when the internal linkifier is unavailable', () => {
+    const { term, received } = makeFakeTerm({ withLinkifier: false })
+
+    expect(openLinkAtPoint(term, 5, 5)).toBe(false)
+    expect(received).toEqual([])
+  })
+})

--- a/apps/gmux-web/src/terminal-link.ts
+++ b/apps/gmux-web/src/terminal-link.ts
@@ -1,0 +1,81 @@
+/**
+ * Open the link under a touch point by driving xterm's Linkifier with a
+ * synthetic mouse-event sequence.
+ *
+ * Why this exists: xterm activates links via a 3-step handshake on the
+ * screen element — `mousemove` resolves the link under the pointer into
+ * `Linkifier._currentLink` (link providers reply synchronously),
+ * `mousedown` snapshots it, and `mouseup` activates it if both match.
+ * On mobile, the browser-synthesized cascade after touchend is supposed
+ * to provide these events, but it's unreliable:
+ *
+ * - iOS cancels the rest of the cascade if the DOM changes during
+ *   mouseover/mousemove (the "content change rule"). Our tap handler
+ *   focuses the hidden textarea, which mutates styles and opens the
+ *   keyboard — so on iOS the cascade always died and links never worked.
+ * - The keyboard-open viewport resize triggers a terminal resize, and
+ *   the Linkifier clears its current link on resize, racing whatever
+ *   events do arrive (the Android flakiness).
+ *
+ * Instead, the tap handler calls preventDefault() on touchend (which
+ * per spec suppresses the browser's synthesized cascade entirely) and
+ * we dispatch the handshake ourselves, synchronously, before any
+ * focus/keyboard/resize can interfere. WebLinksAddon stays the single
+ * source of truth for link detection (same regex as desktop), and
+ * OSC 8 hyperlinks work too since OscLinkProvider is also registered.
+ *
+ * Considered and rejected: expressing the keyboard toggle as a
+ * lowest-priority catch-all link provider, so the Linkifier's priority
+ * resolution would pick "real link" vs "toggle keyboard" itself. Link
+ * providers answer "what's at this cell", not "what should a tap do":
+ * they aren't modality-aware (desktop clicks would activate the
+ * catch-all too), it would require dispatching mousedown/mouseup on
+ * every tap (feeding selection and PTY mouse reporting on plain taps),
+ * and tap-vs-pan-vs-long-press discrimination lives in the touch
+ * handler regardless. The tap decision stays a flat branch there.
+ */
+import type { Terminal } from '@xterm/xterm'
+
+/** Internal Linkifier surface we rely on (stable in our pinned fork). */
+interface CoreWithLinkifier {
+  _core?: { linkifier?: { currentLink?: unknown } }
+}
+
+/**
+ * If a link is under (clientX, clientY), activate it via the Linkifier
+ * and return true. Returns false (with no side effects beyond a hover)
+ * when there is no link, the renderer hasn't measured yet, or the
+ * internal linkifier is unavailable.
+ *
+ * The mousedown/mouseup pair is only dispatched when a link was
+ * resolved, and all events are non-bubbling, so the handshake never
+ * reaches selection handling, PTY mouse reporting, or the focus-
+ * grabbing MouseService handler on the outer element.
+ */
+export function openLinkAtPoint(term: Terminal, clientX: number, clientY: number): boolean {
+  const screen = term.element?.querySelector('.xterm-screen')
+  if (!screen) return false
+
+  const linkifier = (term as unknown as CoreWithLinkifier)._core?.linkifier
+  if (!linkifier) return false
+
+  // Non-bubbling on purpose: the Linkifier listens on the screen
+  // element itself, so it receives these regardless (events always
+  // fire on their target), while listeners on ancestors never see
+  // them. That keeps the handshake invisible to xterm's MouseService
+  // (whose element-level mousedown handler calls focus(), which would
+  // open the on-screen keyboard), selection handling, and PTY mouse
+  // reporting.
+  const init: MouseEventInit = { bubbles: false, clientX, clientY }
+
+  // Step 1: hover. Link providers reply synchronously, so currentLink
+  // is settled by the time dispatchEvent returns.
+  screen.dispatchEvent(new MouseEvent('mousemove', init))
+  if (!linkifier.currentLink) return false
+
+  // Steps 2+3: press and release at the same point → Linkifier calls
+  // link.activate() (WebLinksAddon's handler or the OSC 8 handler).
+  screen.dispatchEvent(new MouseEvent('mousedown', { ...init, button: 0, buttons: 1 }))
+  screen.dispatchEvent(new MouseEvent('mouseup', { ...init, button: 0 }))
+  return true
+}

--- a/apps/gmux-web/src/terminal.tsx
+++ b/apps/gmux-web/src/terminal.tsx
@@ -10,6 +10,7 @@ import { DEFAULT_THEME_COLORS, type ResolvedKeybind } from './config'
 import { attachMobileInputHandler } from './mobile-input'
 import { createReplayBuffer } from './replay'
 import { createTerminalIO, type TerminalSize } from './terminal-io'
+import { openLinkAtPoint } from './terminal-link'
 import { decideViewportResize, sameSize } from './terminal-resize'
 import { MOCK_BY_ID } from './mock-data/index'
 import type { Session } from './types'
@@ -608,19 +609,28 @@ export function TerminalView({
       ev.stopPropagation()
     }
 
-    const handleTouchEndCapture = () => {
+    const handleTouchEndCapture = (ev: TouchEvent) => {
       if (touchPanState.active && !touchPanState.moved) {
+        // Tap on a link opens it by driving xterm's Linkifier with a
+        // synthetic mousemove/mousedown/mouseup handshake (see
+        // terminal-link.ts for why the browser's own synthesized cascade
+        // is unreliable here, especially on iOS). preventDefault stops
+        // the browser from synthesizing its own cascade for this touch,
+        // so the link can't be activated twice. When a link opens, skip
+        // the keyboard focus/scroll — the tap was navigation, not input
+        // intent.
+        if (openLinkAtPoint(term, touchPanState.startX, touchPanState.startY)) {
+          ev.preventDefault()
+          touchPanState.active = false
+          touchPanState.moved = false
+          return
+        }
+
         focusTerminalInput(term)
-        // Defer scroll so synthesized mouse events (which the browser fires
-        // after touchend returns) reach xterm's Linkifier at the current
-        // scroll position. Without this, scrollToBottom() changes the
-        // viewport before the Linkifier can resolve the link under the tap
-        // coordinates, making link taps a no-op on mobile.
-        //
-        // setTimeout(0) and not rAF: synthesized mouse events fire as part
-        // of the current user interaction, before queued tasks. rAF timing
-        // relative to synthesized events is unspecified and varies by
-        // browser; on some it fires before them, reproducing the bug.
+        // Defer the scroll-to-bottom past the focus-driven layout work
+        // (keyboard opening resizes the viewport) and the browser's
+        // synthesized mouse events for this touch, so it lands once on
+        // the settled layout instead of racing them.
         setTimeout(() => {
           term.scrollToBottom()
           const host = shellRef.current
@@ -641,7 +651,7 @@ export function TerminalView({
 
     shell?.addEventListener('touchstart', handleTouchStartCapture, { capture: true, passive: false })
     shell?.addEventListener('touchmove', handleTouchMoveCapture, { capture: true, passive: false })
-    shell?.addEventListener('touchend', handleTouchEndCapture, true)
+    shell?.addEventListener('touchend', handleTouchEndCapture, { capture: true, passive: false })
     shell?.addEventListener('touchcancel', clearTouchPan, true)
 
     // Resize strategy:


### PR DESCRIPTION
## Problem

Tapping a URL in the terminal never worked on iOS and was flaky on Android.

Root cause: xterm activates links via a 3-event handshake on the screen element — `mousemove` resolves the link into `Linkifier._currentLink` (providers reply synchronously), `mousedown` snapshots it, `mouseup` activates if both match. Mobile browsers synthesize that cascade after `touchend`, but:

- **iOS** cancels the rest of the cascade if the DOM changes during mouseover/mousemove (the "content change rule"). Our tap handler focuses the hidden textarea on touchend → style mutations + keyboard opens → cascade dies. Links could never work.
- The keyboard-open viewport resize triggers a terminal resize, and the Linkifier clears `_currentLink` on resize — racing whatever events do arrive (**the Android flakiness**, only partially mitigated by the `setTimeout(0)` from #44).

## Approach

On a clean tap, `preventDefault()` on the touchend (per spec this suppresses the browser's synthesized cascade entirely) and dispatch the mousemove/mousedown/mouseup handshake ourselves — synchronously, before any focus/keyboard/resize can interfere (`terminal-link.ts`).

- **WebLinksAddon stays the single source of truth** for link detection: identical behavior to desktop, and OSC 8 hyperlinks work too via OscLinkProvider.
- Events are dispatched **non-bubbling** on the screen element: the Linkifier (listening there) receives them, but ancestor listeners never do — keeping the handshake invisible to xterm's MouseService (whose mousedown handler calls `focus()` and would open the on-screen keyboard), selection handling, and PTY mouse reporting.
- mousedown/mouseup only fire when a link actually resolved, so plain taps inject nothing; no link → existing keyboard-toggle behavior, unchanged.
- Stale links are xterm's problem, already solved: the Linkifier clears/re-resolves `currentLink` on `onRenderedViewportChange`.

Considered and rejected (documented in the module header): expressing the keyboard toggle as a catch-all link provider — providers answer "what's at this cell", not "what should a tap do".

## Testing

- Unit tests for the handshake: ordering, coordinates, no-link short-circuit, missing screen/linkifier guards
- Full suite passes, tsc clean
- Device-verified on iOS: tap URL opens it (keyboard stays closed), tap plain text toggles keyboard as before

## Follow-up

Long-press on a URL → copy/open action sheet (prototype on a side branch) slots into the same touch handler.