### PR TITLE
feat(web): long-press a terminal link on mobile to copy or open it

### DIFF
--- a/apps/gmux-web/index.html
+++ b/apps/gmux-web/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
     <meta name="theme-color" content="#0a0e13" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="manifest" href="/manifest.json" />

--- a/apps/gmux-web/src/link-action-sheet.tsx
+++ b/apps/gmux-web/src/link-action-sheet.tsx
@@ -1,0 +1,99 @@
+/**
+ * Action sheet for long-pressing a link in the terminal.
+ *
+ * Centered modal (reuses the settings-modal backdrop conventions)
+ * rather than anchored to the touch point: consistent placement, no
+ * clamp/flip math, and the link itself stays visible. Shows the
+ * resolved target URI — for OSC 8 hyperlinks the buffer only paints a
+ * label, so this is the one place a user can inspect the real target
+ * before opening it.
+ *
+ * The sheet holds a snapshot ({@link LinkInfo}) taken at press time;
+ * it never reads live buffer state, so terminal output scrolling the
+ * link away can't make it lie, and there's no reason to auto-dismiss.
+ */
+import { useEffect, useRef, useState } from 'preact/hooks'
+import type { LinkInfo } from './terminal-link'
+
+export interface LinkActionSheetProps {
+  link: LinkInfo
+  onClose: () => void
+}
+
+type CopyState = 'idle' | 'copied' | 'failed'
+
+const COPY_CLOSE_DELAY_MS = 600
+
+export function LinkActionSheet({ link, onClose }: LinkActionSheetProps) {
+  const [copyState, setCopyState] = useState<CopyState>('idle')
+  const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const showLabel = link.label !== link.uri
+
+  // Don't let the post-copy auto-close fire after the sheet is already
+  // gone (e.g. dismissed via the backdrop within the delay window).
+  useEffect(() => () => {
+    if (closeTimer.current !== null) clearTimeout(closeTimer.current)
+  }, [])
+
+  const handleCopy = () => {
+    if (!navigator.clipboard) {
+      setCopyState('failed')
+      return
+    }
+    navigator.clipboard.writeText(link.uri).then(
+      () => {
+        setCopyState('copied')
+        closeTimer.current = setTimeout(onClose, COPY_CLOSE_DELAY_MS)
+      },
+      () => setCopyState('failed'),
+    )
+  }
+
+  const handleOpen = () => {
+    window.open(link.uri, '_blank', 'noopener,noreferrer')
+    onClose()
+  }
+
+  return (
+    // Activate on pointerup, not click. The sheet opens mid-touch (the
+    // 500ms hold fires while the finger is down on the terminal), so a
+    // quick tap right after the long-press release gets coalesced with
+    // it by iOS's gesture recognizer, which suppresses the synthesized
+    // click — on whatever element it lands, regardless of touch-action
+    // (that's decided by the element the gesture *started* on, the
+    // terminal). pointerup fires on release reliably and bypasses click
+    // synthesis entirely, while still being a release gesture (not
+    // press-to-activate). The recognizer is touch-gated, so the sheet
+    // only exists on touch devices; no keyboard-activation path to lose.
+    <div
+      class="modal-backdrop link-sheet-backdrop"
+      onPointerUp={ev => {
+        ev.stopPropagation()
+        if (ev.target === ev.currentTarget) onClose()
+      }}
+    >
+      <div class="modal-panel link-sheet" role="menu" aria-label="Link actions">
+        <div class="link-sheet-preview">
+          {showLabel && <div class="link-sheet-label">{link.label}</div>}
+          <div class="link-sheet-uri">{link.uri}</div>
+        </div>
+        <button
+          type="button"
+          class="link-sheet-action"
+          role="menuitem"
+          onPointerUp={ev => { ev.stopPropagation(); handleCopy() }}
+        >
+          {copyState === 'idle' ? 'Copy URL' : copyState === 'copied' ? 'Copied ✓' : 'Copy failed'}
+        </button>
+        <button
+          type="button"
+          class="link-sheet-action"
+          role="menuitem"
+          onPointerUp={ev => { ev.stopPropagation(); handleOpen() }}
+        >
+          Open
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/apps/gmux-web/src/long-press.test.ts
+++ b/apps/gmux-web/src/long-press.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { createLongPressRecognizer, LONG_PRESS_MS } from './long-press'
+
+describe('createLongPressRecognizer', () => {
+  beforeEach(() => { vi.useFakeTimers() })
+  afterEach(() => { vi.useRealTimers() })
+
+  test('fires after the hold duration with the start coordinates', () => {
+    const onLongPress = vi.fn()
+    const rec = createLongPressRecognizer(onLongPress)
+
+    rec.start(10, 20)
+    vi.advanceTimersByTime(LONG_PRESS_MS - 1)
+    expect(onLongPress).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(1)
+    expect(onLongPress).toHaveBeenCalledWith(10, 20)
+    expect(rec.end()).toBe(true)
+  })
+
+  test('end() before the timer fires is a tap', () => {
+    const onLongPress = vi.fn()
+    const rec = createLongPressRecognizer(onLongPress)
+
+    rec.start(0, 0)
+    vi.advanceTimersByTime(100)
+    expect(rec.end()).toBe(false)
+    // Timer was disarmed; nothing fires later.
+    vi.runAllTimers()
+    expect(onLongPress).not.toHaveBeenCalled()
+  })
+
+  test('cancel() disarms a pending press', () => {
+    const onLongPress = vi.fn()
+    const rec = createLongPressRecognizer(onLongPress)
+
+    rec.start(0, 0)
+    rec.cancel()
+    vi.runAllTimers()
+    expect(onLongPress).not.toHaveBeenCalled()
+    expect(rec.end()).toBe(false)
+  })
+
+  test('a fired press stays fired through cancel()', () => {
+    const rec = createLongPressRecognizer(() => { /* noop */ })
+
+    rec.start(0, 0)
+    vi.runAllTimers()
+    rec.cancel() // finger moved after the sheet opened
+    expect(rec.end()).toBe(true)
+  })
+
+  test('end() resets state for the next press', () => {
+    const rec = createLongPressRecognizer(() => { /* noop */ })
+
+    rec.start(0, 0)
+    vi.runAllTimers()
+    expect(rec.end()).toBe(true)
+    expect(rec.end()).toBe(false)
+  })
+
+  test('start() resets a prior fired press and re-arms', () => {
+    const onLongPress = vi.fn()
+    const rec = createLongPressRecognizer(onLongPress)
+
+    rec.start(0, 0)
+    vi.runAllTimers()
+    rec.start(5, 5) // new touch before end() — e.g. touchcancel path
+    expect(rec.end()).toBe(false)
+    expect(onLongPress).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/gmux-web/src/long-press.ts
+++ b/apps/gmux-web/src/long-press.ts
@@ -1,0 +1,69 @@
+/**
+ * Long-press recognizer for the terminal's touch handler.
+ *
+ * Pure timer state machine: the caller feeds it touch lifecycle calls
+ * and decides what a long-press *does* via the callback. Movement
+ * cancellation is deliberately not handled here — the touch handler in
+ * terminal.tsx already tracks a move threshold for tap-vs-pan
+ * discrimination, and a second threshold would drift from it. The
+ * caller calls `cancel()` when its own threshold trips.
+ *
+ * A long-press is a distinct intent from a tap: once the timer fires,
+ * `end()` reports it so the caller suppresses its tap behavior
+ * (link-open / keyboard toggle) — even when the callback found nothing
+ * actionable under the finger. Holding the terminal for half a second
+ * should never pop the keyboard. `cancel()` only disarms a *pending*
+ * timer; a fired press stays fired until `end()`/`start()` reset it,
+ * so finger movement after an action sheet opened can't resurrect the
+ * tap. Future consumers (copy-paragraph) extend the callback, not this
+ * state machine.
+ */
+
+export interface LongPressRecognizer {
+  /** Arm the timer for a new touch at (x, y). Resets prior state. */
+  start(x: number, y: number): void
+  /** Disarm a pending timer (finger moved, second finger, …). A press
+   * that already fired stays fired. */
+  cancel(): void
+  /** Touch ended: returns true if the long-press fired (caller should
+   * suppress its tap behavior). Resets. */
+  end(): boolean
+}
+
+export const LONG_PRESS_MS = 500
+
+export function createLongPressRecognizer(
+  onLongPress: (x: number, y: number) => void,
+  holdMs: number = LONG_PRESS_MS,
+): LongPressRecognizer {
+  let timer: ReturnType<typeof setTimeout> | null = null
+  let fired = false
+
+  const disarm = () => {
+    if (timer !== null) {
+      clearTimeout(timer)
+      timer = null
+    }
+  }
+
+  return {
+    start(x, y) {
+      disarm()
+      fired = false
+      timer = setTimeout(() => {
+        timer = null
+        fired = true
+        onLongPress(x, y)
+      }, holdMs)
+    },
+    cancel() {
+      disarm()
+    },
+    end() {
+      disarm()
+      const wasFired = fired
+      fired = false
+      return wasFired
+    },
+  }
+}

--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -47,6 +47,15 @@ installCopySession()
 // watcher is pointless there and would risk masking real bugs.
 if (!USE_MOCK) installVersionWatch()
 
+// Disable pinch-to-zoom app-wide. This is a terminal, not a document;
+// page zoom only breaks the layout. iOS Safari ignores user-scalable=no
+// and touch-action for *page* pinch, so the only reliable lever is
+// preventing the non-standard gesture events it fires. Harmless on
+// browsers that don't emit them.
+for (const type of ['gesturestart', 'gesturechange', 'gestureend']) {
+  document.addEventListener(type, e => e.preventDefault(), { passive: false })
+}
+
 // ── Components ──
 
 function MainHeader({ session, onRestart }: {

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -97,6 +97,14 @@ html, body, #app {
   height: 100%;
   overflow: hidden;
   overscroll-behavior: none;
+  /* This is a terminal, not a document. `manipulation` drops
+     double-tap-to-zoom and the tap delay/suppression it causes —
+     notably taps landing right after a long-press release. (Pinch-zoom
+     is killed separately in JS via gesturestart; iOS Safari honors
+     neither touch-action nor user-scalable=no for page pinch.)
+     Elements needing stricter handling (e.g. .terminal-shell-passive)
+     override locally. */
+  touch-action: manipulation;
 }
 
 body {
@@ -2719,3 +2727,54 @@ body {
 }
 .jump-to-bottom:hover { background: oklch(28% 0.015 250); }
 .jump-to-bottom:active { transform: translateY(1px); }
+
+/* ── Link action sheet (long-press a link on touch devices) ────────
+   Reuses the modal backdrop/panel conventions; the panel is a narrow
+   menu rather than a dialog. The preview intentionally shows the full
+   URI (word-broken, scrollable past ~6 lines) — for OSC 8 hyperlinks
+   this is the only place the real target is visible before opening. */
+.link-sheet {
+  width: 320px;
+  padding: 6px;
+  gap: 2px;
+}
+
+.link-sheet-preview {
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 4px;
+}
+
+.link-sheet-label {
+  color: var(--text);
+  font-size: 13px;
+  margin-bottom: 4px;
+  word-break: break-all;
+}
+
+.link-sheet-uri {
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-family: var(--font-mono, monospace);
+  word-break: break-all;
+  max-height: 108px;
+  overflow-y: auto;
+}
+
+.link-sheet-action {
+  appearance: none;
+  border: none;
+  background: transparent;
+  color: var(--text);
+  text-align: left;
+  font-size: 14px;
+  font-family: inherit;
+  padding: 12px 12px;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.link-sheet-action:hover,
+.link-sheet-action:active {
+  background: var(--bg-hover);
+}

--- a/apps/gmux-web/src/terminal-link.test.ts
+++ b/apps/gmux-web/src/terminal-link.test.ts
@@ -1,6 +1,6 @@
 import { beforeAll, describe, expect, test } from 'vitest'
 import type { Terminal } from '@xterm/xterm'
-import { openLinkAtPoint } from './terminal-link'
+import { linkAtPoint, openLinkAtPoint } from './terminal-link'
 
 // Node has Event/EventTarget but not MouseEvent; polyfill enough for
 // the synthetic handshake the module dispatches.
@@ -24,25 +24,34 @@ beforeAll(() => {
   }
 })
 
+interface InternalLinkShape {
+  text: string
+  range: { start: { x: number, y: number }, end: { x: number, y: number } }
+}
+
 interface FakeTermOptions {
-  /** Called on mousemove; return a truthy link to simulate resolution. */
-  resolveLink?: () => unknown
+  /** Called on mousemove; return a link to simulate resolution. */
+  resolveLink?: () => InternalLinkShape | undefined
+  /** 1-based absolute buffer rows as strings (row 1 first). */
+  bufferRows?: string[]
+  cols?: number
   withScreen?: boolean
   withLinkifier?: boolean
 }
 
 function makeFakeTerm(opts: FakeTermOptions = {}) {
-  const { resolveLink, withScreen = true, withLinkifier = true } = opts
+  const { resolveLink, bufferRows = [], cols = 80, withScreen = true, withLinkifier = true } = opts
   const screen = new EventTarget()
   const received: { type: string, clientX: number, clientY: number }[] = []
-  const linkifier: { currentLink?: unknown } = {}
+  const linkifier: { currentLink?: { link: InternalLinkShape } } = {}
 
   for (const type of ['mousemove', 'mousedown', 'mouseup']) {
     screen.addEventListener(type, ev => {
       const me = ev as MouseEvent
       received.push({ type: ev.type, clientX: me.clientX, clientY: me.clientY })
       if (ev.type === 'mousemove' && resolveLink) {
-        linkifier.currentLink = resolveLink()
+        const link = resolveLink()
+        linkifier.currentLink = link ? { link } : undefined
       }
     })
   }
@@ -51,6 +60,19 @@ function makeFakeTerm(opts: FakeTermOptions = {}) {
     element: withScreen
       ? { querySelector: (sel: string) => (sel === '.xterm-screen' ? screen : null) }
       : null,
+    cols,
+    buffer: {
+      active: {
+        getLine: (y: number) => {
+          const text = bufferRows[y]
+          if (text === undefined) return undefined
+          return {
+            translateToString: (_trim: boolean, fromCol: number, toCol: number) =>
+              text.padEnd(cols).slice(fromCol, toCol),
+          }
+        },
+      },
+    },
     _core: withLinkifier ? { linkifier } : {},
   } as unknown as Terminal
 
@@ -58,8 +80,13 @@ function makeFakeTerm(opts: FakeTermOptions = {}) {
 }
 
 describe('openLinkAtPoint', () => {
+  const link = (): InternalLinkShape => ({
+    text: 'https://example.com',
+    range: { start: { x: 1, y: 1 }, end: { x: 19, y: 1 } },
+  })
+
   test('activates a resolved link with the full handshake, in order', () => {
-    const { term, received } = makeFakeTerm({ resolveLink: () => ({ link: {} }) })
+    const { term, received } = makeFakeTerm({ resolveLink: link })
 
     expect(openLinkAtPoint(term, 42, 17)).toBe(true)
     expect(received.map(e => e.type)).toEqual(['mousemove', 'mousedown', 'mouseup'])
@@ -90,5 +117,84 @@ describe('openLinkAtPoint', () => {
 
     expect(openLinkAtPoint(term, 5, 5)).toBe(false)
     expect(received).toEqual([])
+  })
+})
+
+describe('linkAtPoint', () => {
+  test('never activates: only the hover is dispatched', () => {
+    const { term, received } = makeFakeTerm({
+      resolveLink: () => ({
+        text: 'https://example.com',
+        range: { start: { x: 1, y: 2 }, end: { x: 19, y: 2 } },
+      }),
+      // bufferRows[1] is buffer row y=2 (getLine is 0-based)
+      bufferRows: ['', 'https://example.com rest of line'],
+    })
+
+    expect(linkAtPoint(term, 1, 1)).not.toBeNull()
+    expect(received.map(e => e.type)).toEqual(['mousemove'])
+  })
+
+  test('plain URL: label equals uri', () => {
+    const { term } = makeFakeTerm({
+      resolveLink: () => ({
+        text: 'https://example.com',
+        // cols 5..23 on row 1 (1-based inclusive)
+        range: { start: { x: 5, y: 1 }, end: { x: 23, y: 1 } },
+      }),
+      bufferRows: ['see https://example.com for details'],
+    })
+
+    expect(linkAtPoint(term, 1, 1)).toEqual({
+      uri: 'https://example.com',
+      label: 'https://example.com',
+    })
+  })
+
+  test('OSC 8 link: label is the visible text, uri the hidden target', () => {
+    const { term } = makeFakeTerm({
+      resolveLink: () => ({
+        text: 'https://evil.example/payload',
+        range: { start: { x: 1, y: 1 }, end: { x: 10, y: 1 } },
+      }),
+      bufferRows: ['Click here to continue'],
+    })
+
+    expect(linkAtPoint(term, 1, 1)).toEqual({
+      uri: 'https://evil.example/payload',
+      label: 'Click here',
+    })
+  })
+
+  test('label spans wrapped rows', () => {
+    const cols = 10
+    const { term } = makeFakeTerm({
+      cols,
+      resolveLink: () => ({
+        text: 'https://a.io/xyz',
+        // starts at col 5 of row 1, ends at col 10 of row 2
+        range: { start: { x: 5, y: 1 }, end: { x: 10, y: 2 } },
+      }),
+      bufferRows: ['see https:', '//a.io/xyz'],
+    })
+
+    expect(linkAtPoint(term, 1, 1)?.label).toBe('https://a.io/xyz')
+  })
+
+  test('falls back to uri when a range row is missing from the buffer', () => {
+    const { term } = makeFakeTerm({
+      resolveLink: () => ({
+        text: 'https://example.com',
+        range: { start: { x: 1, y: 99 }, end: { x: 19, y: 99 } },
+      }),
+      bufferRows: ['only one row'],
+    })
+
+    expect(linkAtPoint(term, 1, 1)?.label).toBe('https://example.com')
+  })
+
+  test('returns null when nothing resolves', () => {
+    const { term } = makeFakeTerm({ resolveLink: () => undefined })
+    expect(linkAtPoint(term, 1, 1)).toBeNull()
   })
 })

--- a/apps/gmux-web/src/terminal-link.ts
+++ b/apps/gmux-web/src/terminal-link.ts
@@ -36,28 +36,48 @@
  */
 import type { Terminal } from '@xterm/xterm'
 
-/** Internal Linkifier surface we rely on (stable in our pinned fork). */
-interface CoreWithLinkifier {
-  _core?: { linkifier?: { currentLink?: unknown } }
+/**
+ * Internal Linkifier surface we rely on (stable in our pinned fork).
+ * The range is 1-based; y is an absolute buffer row (scrollback
+ * included). `text` is the link's URI for both built-in providers:
+ * WebLinksAddon stores the regex match, OscLinkProvider stores the
+ * OSC 8 URI (not the visible label).
+ */
+interface InternalLink {
+  text: string
+  range: {
+    start: { x: number, y: number }
+    end: { x: number, y: number }
+  }
 }
 
-/**
- * If a link is under (clientX, clientY), activate it via the Linkifier
- * and return true. Returns false (with no side effects beyond a hover)
- * when there is no link, the renderer hasn't measured yet, or the
- * internal linkifier is unavailable.
- *
- * The mousedown/mouseup pair is only dispatched when a link was
- * resolved, and all events are non-bubbling, so the handshake never
- * reaches selection handling, PTY mouse reporting, or the focus-
- * grabbing MouseService handler on the outer element.
- */
-export function openLinkAtPoint(term: Terminal, clientX: number, clientY: number): boolean {
+interface CoreWithLinkifier {
+  _core?: { linkifier?: { currentLink?: { link: InternalLink } } }
+}
+
+/** A link resolved under a touch point. */
+export interface LinkInfo {
+  /** The target URI (what activation would open). */
+  uri: string
+  /** The text painted in the terminal for this link. Equals `uri` for
+   * plain-text URLs; differs for OSC 8 hyperlinks, where the buffer
+   * shows a label and the URI is hidden — surfacing both lets the user
+   * inspect the real target before opening. */
+  label: string
+}
+
+interface ResolvedLink {
+  screen: Element
+  init: MouseEventInit
+  link: InternalLink
+}
+
+function resolveLinkAtPoint(term: Terminal, clientX: number, clientY: number): ResolvedLink | null {
   const screen = term.element?.querySelector('.xterm-screen')
-  if (!screen) return false
+  if (!screen) return null
 
   const linkifier = (term as unknown as CoreWithLinkifier)._core?.linkifier
-  if (!linkifier) return false
+  if (!linkifier) return null
 
   // Non-bubbling on purpose: the Linkifier listens on the screen
   // element itself, so it receives these regardless (events always
@@ -68,13 +88,54 @@ export function openLinkAtPoint(term: Terminal, clientX: number, clientY: number
   // reporting.
   const init: MouseEventInit = { bubbles: false, clientX, clientY }
 
-  // Step 1: hover. Link providers reply synchronously, so currentLink
-  // is settled by the time dispatchEvent returns.
+  // Hover step of the handshake. Link providers reply synchronously,
+  // so currentLink is settled by the time dispatchEvent returns.
   screen.dispatchEvent(new MouseEvent('mousemove', init))
-  if (!linkifier.currentLink) return false
+  const link = linkifier.currentLink?.link
+  if (!link) return null
 
-  // Steps 2+3: press and release at the same point → Linkifier calls
+  return { screen, init, link }
+}
+
+/** Read the text the link's range covers in the buffer (its visible
+ * label). Falls back to the URI if any row is unavailable. */
+function labelForLink(term: Terminal, link: InternalLink): string {
+  const { start, end } = link.range
+  let label = ''
+  for (let y = start.y; y <= end.y; y++) {
+    const line = term.buffer.active.getLine(y - 1)
+    if (!line) return link.text
+    const fromCol = y === start.y ? start.x - 1 : 0
+    const toCol = y === end.y ? end.x : term.cols
+    label += line.translateToString(false, fromCol, toCol)
+  }
+  return label
+}
+
+/**
+ * Query-only: resolve the link under (clientX, clientY) without
+ * activating it. Side effects are limited to a synthetic hover.
+ * Returns null when there is no link, the renderer hasn't measured
+ * yet, or the internal linkifier is unavailable.
+ */
+export function linkAtPoint(term: Terminal, clientX: number, clientY: number): LinkInfo | null {
+  const resolved = resolveLinkAtPoint(term, clientX, clientY)
+  if (!resolved) return null
+  return { uri: resolved.link.text, label: labelForLink(term, resolved.link) }
+}
+
+/**
+ * If a link is under (clientX, clientY), activate it via the Linkifier
+ * and return true. The mousedown/mouseup pair is only dispatched when
+ * a link was resolved, so plain taps inject nothing.
+ */
+export function openLinkAtPoint(term: Terminal, clientX: number, clientY: number): boolean {
+  const resolved = resolveLinkAtPoint(term, clientX, clientY)
+  if (!resolved) return false
+
+  // Press and release at the same point → Linkifier calls
   // link.activate() (WebLinksAddon's handler or the OSC 8 handler).
+  const { screen, init } = resolved
   screen.dispatchEvent(new MouseEvent('mousedown', { ...init, button: 0, buttons: 1 }))
   screen.dispatchEvent(new MouseEvent('mouseup', { ...init, button: 0 }))
   return true

--- a/apps/gmux-web/src/terminal.tsx
+++ b/apps/gmux-web/src/terminal.tsx
@@ -10,7 +10,9 @@ import { DEFAULT_THEME_COLORS, type ResolvedKeybind } from './config'
 import { attachMobileInputHandler } from './mobile-input'
 import { createReplayBuffer } from './replay'
 import { createTerminalIO, type TerminalSize } from './terminal-io'
-import { openLinkAtPoint } from './terminal-link'
+import { linkAtPoint, type LinkInfo, openLinkAtPoint } from './terminal-link'
+import { createLongPressRecognizer } from './long-press'
+import { LinkActionSheet } from './link-action-sheet'
 import { decideViewportResize, sameSize } from './terminal-resize'
 import { MOCK_BY_ID } from './mock-data/index'
 import type { Session } from './types'
@@ -238,6 +240,7 @@ export function TerminalView({
   const [wsState, setWsState] = useState<'connecting' | 'open' | 'lost'>('connecting')
   const [viewportSize, setViewportSize] = useState<TerminalSize | null>(null)
   const [scrolledUp, setScrolledUp] = useState(false)
+  const [linkSheet, setLinkSheet] = useState<LinkInfo | null>(null)
   const SCROLL_THRESHOLD = 3 // rows above bottom before showing the button
   // Track the last PTY size we know about so we can derive the pill.
   const [ptySize, setPtySize] = useState<TerminalSize | null>(null)
@@ -545,8 +548,21 @@ export function TerminalView({
     window.addEventListener('keydown', handleGlobalKeydown, true)
 
     const shell = shellRef.current
+    // Overlays (the link action sheet) render inside the shell; their
+    // touches must not arm tap/pan/long-press handling.
     const isInteractiveTarget = (target: EventTarget | null) => target instanceof HTMLElement
-      && !!target.closest('button, input, textarea, select, a, label, [role="button"]')
+      && !!target.closest('button, input, textarea, select, a, label, [role="button"], .modal-backdrop')
+
+    // Long-press on a link → action sheet (copy / open / inspect the
+    // real target of OSC 8 hyperlinks). A ≥500ms hold is a distinct
+    // intent from a tap: even when nothing is under the finger, the
+    // release must not open a link or toggle the keyboard.
+    const longPress = createLongPressRecognizer((x, y) => {
+      const link = linkAtPoint(term, x, y)
+      if (!link) return
+      try { navigator.vibrate?.(10) } catch { /* unsupported */ }
+      setLinkSheet(link)
+    })
     const touchPanState = {
       active: false,
       moved: false,
@@ -558,6 +574,7 @@ export function TerminalView({
 
     const handleTouchStartCapture = (ev: TouchEvent) => {
       if (ev.touches.length !== 1 || isInteractiveTarget(ev.target)) {
+        longPress.cancel()
         touchPanState.active = false
         touchPanState.moved = false
         return
@@ -578,6 +595,7 @@ export function TerminalView({
       touchPanState.startY = ev.touches[0].clientY
       touchPanState.startScrollLeft = host.scrollLeft
       touchPanState.startScrollTop = host.scrollTop
+      longPress.start(touchPanState.startX, touchPanState.startY)
     }
 
     const handleTouchMoveCapture = (ev: TouchEvent) => {
@@ -591,6 +609,7 @@ export function TerminalView({
       const deltaY = touch.clientY - touchPanState.startY
       if (Math.abs(deltaX) > 6 || Math.abs(deltaY) > 6) {
         touchPanState.moved = true
+        longPress.cancel()
       }
 
       // If viewport matches PTY (in sync), no overflow to pan — let xterm
@@ -610,6 +629,15 @@ export function TerminalView({
     }
 
     const handleTouchEndCapture = (ev: TouchEvent) => {
+      // A fired long-press owns this touch: suppress tap behavior and
+      // the browser's synthesized cascade.
+      if (longPress.end()) {
+        ev.preventDefault()
+        touchPanState.active = false
+        touchPanState.moved = false
+        return
+      }
+
       if (touchPanState.active && !touchPanState.moved) {
         // Tap on a link opens it by driving xterm's Linkifier with a
         // synthetic mousemove/mousedown/mouseup handshake (see
@@ -645,6 +673,7 @@ export function TerminalView({
     }
 
     const clearTouchPan = () => {
+      longPress.end() // full reset: discard pending and fired state
       touchPanState.active = false
       touchPanState.moved = false
     }
@@ -740,6 +769,7 @@ export function TerminalView({
       if (resizeTimer !== null) clearTimeout(resizeTimer)
       if (resizeFrame !== null) cancelAnimationFrame(resizeFrame)
       if (refocusTimer !== null) clearTimeout(refocusTimer)
+      longPress.cancel()
       disposed.current = true
       window.removeEventListener('keydown', handleGlobalKeydown, true)
       window.removeEventListener('resize', onViewportResize)
@@ -994,6 +1024,9 @@ export function TerminalView({
         >
           End ↓
         </button>
+      )}
+      {linkSheet && (
+        <LinkActionSheet link={linkSheet} onClose={() => setLinkSheet(null)} />
       )}
     </div>
   )


### PR DESCRIPTION
Follow-up to #301. Long-pressing a link in the terminal on a touch device opens a centered action sheet with the resolved target, **Copy URL**, and **Open**.

## Design (from the discussion)

- **Generic long-press recognizer** (`long-press.ts`): pure timer state machine wired into the existing touch handler; movement-cancel delegates to the handler's existing 6px tap-vs-pan threshold so there's a single threshold. A ≥500ms hold is a distinct intent: the release never opens a link or toggles the keyboard, even when nothing is under the finger. This is the hook the future "copy paragraph" long-press plugs into.
- **Query-only link resolution** (`terminal-link.ts` refactor): `linkAtPoint` dispatches just the hover step of the Linkifier handshake and reads `currentLink` — no activation. `openLinkAtPoint` (tap path) builds on it. WebLinksAddon/OscLinkProvider remain the single source of truth.
- **OSC 8 inspection**: `link.text` is the URI for both providers; the visible label is read from the link's buffer range. When they differ (OSC 8), the sheet shows both — the only way on mobile to see the real target before opening, since there's no hover status. xterm already rejects non-http(s) OSC 8 URIs.
- **Sheet** (`link-action-sheet.tsx`): preact, reuses the `modal-backdrop`/`modal-panel` conventions, center-center. Copy flips the button to "Copied ✓" and auto-closes (~600ms); failure shows "Copy failed" and stays. Backdrop tap dismisses (excluded from the shell's touch/click handling). Holds a snapshot taken at press time, so it stays open and truthful while output scrolls.

## Testing

- Recognizer: 7 unit tests (fake timers) — fire/cancel/end lifecycle, fired-stays-fired through movement, reset semantics
- `linkAtPoint`: label extraction (plain URL, OSC 8 label≠URI, wrapped rows, missing-row fallback), query-only dispatch assertions
- Full suite passes (492), tsc + biome clean
- Device verification pending (iOS): long-press link → sheet; copy; open; long-press plain text → no keyboard; tap unchanged