### PR TITLE
fix(gmuxd): reject /v1/projects/add on validation failure instead of reporting phantom success

### DIFF
--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -950,21 +951,18 @@ func serve(stderr io.Writer) int {
 			slug = projects.SlugFromPath(req.Paths[0])
 		}
 
-		var item projects.Item
-		err = projectMgr.Update(func(state *projects.State) bool {
-			slug = projects.UniqueSlug(slug, state.Items)
-			item = projects.Item{
-				Slug:  slug,
-				Match: rules,
-			}
-			state.Items = append(state.Items, item)
-			if err := state.Validate(); err != nil {
-				log.Printf("projects: add validation error: %v", err)
-				return false
-			}
-			return true
-		})
+		// AddProject persists only on a valid result. A *ValidationError
+		// means the add conflicts with existing state (e.g. a duplicate
+		// path) and nothing was saved: report it as a 409 so the client
+		// does not pin a reference to a project that was never created.
+		item, err := projectMgr.AddProject(slug, rules)
 		if err != nil {
+			var verr *projects.ValidationError
+			if errors.As(err, &verr) {
+				log.Printf("projects: add rejected: %v", err)
+				writeError(w, http.StatusConflict, "validation_error", verr.Error())
+				return
+			}
 			log.Printf("projects: add error: %v", err)
 			writeError(w, http.StatusInternalServerError, "internal", "failed to save projects")
 			return

--- a/services/gmuxd/internal/projects/addproject_test.go
+++ b/services/gmuxd/internal/projects/addproject_test.go
@@ -1,0 +1,84 @@
+package projects
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestManagerAddProject_Success(t *testing.T) {
+	dir := t.TempDir()
+	m := NewManager(dir)
+
+	item, err := m.AddProject("apps", []MatchRule{{Path: "/mnt/user/apps"}})
+	if err != nil {
+		t.Fatalf("AddProject: unexpected error: %v", err)
+	}
+	if item.Slug != "apps" {
+		t.Fatalf("slug = %q, want %q", item.Slug, "apps")
+	}
+
+	// The project must actually be persisted.
+	s, err := m.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(s.Items) != 1 || s.Items[0].Slug != "apps" {
+		t.Fatalf("persisted items = %#v, want one 'apps'", s.Items)
+	}
+}
+
+func TestManagerAddProject_UniqueSlug(t *testing.T) {
+	dir := t.TempDir()
+	m := NewManager(dir)
+
+	if _, err := m.AddProject("apps", []MatchRule{{Path: "/mnt/user/apps"}}); err != nil {
+		t.Fatalf("first AddProject: %v", err)
+	}
+	// Different path, same base slug → slug is deduplicated, add succeeds.
+	item, err := m.AddProject("apps", []MatchRule{{Path: "/srv/apps"}})
+	if err != nil {
+		t.Fatalf("second AddProject: %v", err)
+	}
+	if item.Slug != "apps-2" {
+		t.Fatalf("slug = %q, want %q", item.Slug, "apps-2")
+	}
+}
+
+// The regression guard: adding a project whose path duplicates an
+// existing one must be rejected with a *ValidationError AND must not
+// persist anything. Previously the handler reported success on this
+// aborted save, letting clients pin references to a phantom slug.
+func TestManagerAddProject_DuplicatePathRejected(t *testing.T) {
+	dir := t.TempDir()
+	m := NewManager(dir)
+
+	if _, err := m.AddProject("apps", []MatchRule{{Path: "/mnt/user/apps"}}); err != nil {
+		t.Fatalf("seed AddProject: %v", err)
+	}
+
+	// Same path again (e.g. a remote-grouped discovered suggestion that
+	// resolves to an already-owned path) → must be rejected.
+	item, err := m.AddProject("apps", []MatchRule{
+		{Remote: "github.com/acme/apps"},
+		{Path: "/mnt/user/apps"},
+	})
+	if err == nil {
+		t.Fatalf("AddProject succeeded, want rejection (item=%#v)", item)
+	}
+	var verr *ValidationError
+	if !errors.As(err, &verr) {
+		t.Fatalf("error type = %T (%v), want *ValidationError", err, err)
+	}
+	if item.Slug != "" {
+		t.Fatalf("item should be zero on rejection, got %#v", item)
+	}
+
+	// Nothing must have been persisted beyond the seed project.
+	s, err := m.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(s.Items) != 1 || s.Items[0].Slug != "apps" {
+		t.Fatalf("persisted items = %#v, want only the seed 'apps'", s.Items)
+	}
+}

--- a/services/gmuxd/internal/projects/manager.go
+++ b/services/gmuxd/internal/projects/manager.go
@@ -1,9 +1,20 @@
 package projects
 
 import (
+	"fmt"
 	"log"
 	"sync"
 )
+
+// ValidationError wraps a State.Validate failure produced while applying
+// a mutation. Callers (notably the HTTP layer) can detect it with
+// errors.As to map the failure to a 4xx response rather than a 500: the
+// request was well-formed but conflicts with existing state (e.g. a
+// duplicate path), so nothing was persisted.
+type ValidationError struct{ Err error }
+
+func (e *ValidationError) Error() string { return e.Err.Error() }
+func (e *ValidationError) Unwrap() error { return e.Err }
 
 // Manager provides concurrent access to project state and handles
 // auto-assignment of sessions to projects. All mutations go through
@@ -50,6 +61,39 @@ func (m *Manager) SeedIfEmpty() {
 	if err != nil {
 		log.Printf("projects: seed error: %v", err)
 	}
+}
+
+// AddProject appends a new owned project built from the given match
+// rules, assigning a unique slug derived from baseSlug. The mutation is
+// validated before it is persisted: if the resulting state is invalid
+// (e.g. baseSlug's path duplicates an existing project), nothing is
+// saved and a *ValidationError is returned. On success the created
+// item (with its final, possibly deduplicated slug) is returned.
+//
+// This exists so the caller can tell "created" from "rejected": a bare
+// Update cannot, because its fn returning false (abort) and returning
+// true (saved) both surface as a nil error. Reporting success on an
+// aborted add let clients pin references to projects that were never
+// created (see the dangling peer-reference bug).
+func (m *Manager) AddProject(baseSlug string, rules []MatchRule) (Item, error) {
+	var created Item
+	var valErr error
+	err := m.Update(func(s *State) bool {
+		created = Item{Slug: UniqueSlug(baseSlug, s.Items), Match: rules}
+		s.Items = append(s.Items, created)
+		if err := s.Validate(); err != nil {
+			valErr = err
+			return false
+		}
+		return true
+	})
+	if err != nil {
+		return Item{}, err
+	}
+	if valErr != nil {
+		return Item{}, &ValidationError{Err: fmt.Errorf("project %q: %w", baseSlug, valErr)}
+	}
+	return created, nil
 }
 
 // Update atomically loads state, calls fn to modify it, validates, and saves.


### PR DESCRIPTION
## Problem

`POST /v1/projects/add` could report success (`200 {ok:true, data:{slug}}`) while persisting **nothing**, handing the client a slug for a project that was never created.

The handler ran `UniqueSlug` + append + `Validate()` inside a `Manager.Update` closure and returned `false` on validation failure. But `Manager.Update` returns `nil` **both** when its `fn` aborts *and* when it saves:

```go
if !fn(state) { return nil } // aborted
...
return nil                   // saved
```

So the handler couldn't distinguish the two and always wrote `{ok:true, data:item}` with the in-memory (un-saved) item.

Clients trust that response: `addPeerReference(peer, slug)` then pins a reference to a project that doesn't exist on the peer, producing a permanent dangling / "missing" peer-project folder. In the case that surfaced this, a host owned `apps` by path (`/mnt/user/apps`); a remote-grouped *discovered* suggestion for the same repo was offered, and adding it derived slug `apps` → `UniqueSlug` → `apps-2`, failed `Validate()` on the duplicate path, saved nothing — yet returned `apps-2`, which got referenced and could only be cleared by editing `projects.json` by hand.

### Live repro (before)

```
POST /v1/projects/add {"remote":"github.com/…/apps","paths":["/mnt/user/apps"]}
→ HTTP 200  {"ok":true,"data":{"slug":"apps-2","match":[…]}}
owned projects unchanged → nothing was persisted
```

## Fix

Add `projects.Manager.AddProject`, which validates the mutation **before** persisting and returns a typed `*ValidationError` (with nothing saved) when the result is invalid. The handler maps that to `409 validation_error`, so the client can gate the follow-up reference on a genuine create.

### After

```
POST /v1/projects/add {…,"paths":["/mnt/user/apps"]}
→ HTTP 409  validation_error
nothing persisted
```

## Tests

`addproject_test.go` covers success, `UniqueSlug` dedup on a non-conflicting add, and the regression guard: a duplicate-path add is rejected with `*ValidationError` and persists nothing.

## Scope

Standalone fix for the proximate bug (phantom success). The deeper design gap — discovery offering a project already owned via a different rule type (path vs remote), so Add forks `-2` instead of extending the existing project — is intentionally left for a follow-up.