### PR TITLE
fix(web): blip counts only sidebar sessions, not discovered

### DIFF
--- a/apps/gmux-web/src/store.test.ts
+++ b/apps/gmux-web/src/store.test.ts
@@ -7,7 +7,7 @@ import {
   isSessionUnavailable, urlPath, urlSearch, filteredSessions, selectedId,
   navigateToSession, setNavigate,
   applyPending, _rawSessions, _rawWorld, _setRawWorld, _pendingMutations,
-  toUISession, localHostLabel, parseConnectURL,
+  toUISession, localHostLabel, parseConnectURL, unreadCount,
 } from './store'
 import type { PendingMutation } from './store'
 import type { Session } from './types'
@@ -565,6 +565,52 @@ describe('raw signal projections', () => {
     // projects survived; peers cleared.
     expect(projects.value).toHaveLength(1)
     expect(peers.value).toHaveLength(0)
+  })
+})
+
+describe('unreadCount (sidebar-only attention blip)', () => {
+  beforeEach(() => {
+    _rawSessions.value = []
+    _setRawWorld({ projects: [{ slug: 'proj', match: [{ path: '/work' }] }], peers: [] })
+    sessionsLoaded.value = true
+    urlPath.value = '/'
+  })
+
+  it('excludes discovered (unstamped) sessions even when alive + unread', () => {
+    _rawSessions.value = [
+      makeSession({ id: 'disc', cwd: '/work', alive: true, unread: true }), // no project_slug
+    ]
+    expect(unreadCount.value).toBe(0)
+  })
+
+  it('counts alive + unread sessions stamped into a folder', () => {
+    _rawSessions.value = [
+      makeSession({ id: 'a', cwd: '/work', alive: true, unread: true, project_slug: 'proj' }),
+      makeSession({ id: 'b', cwd: '/work', alive: true, unread: false, project_slug: 'proj' }),
+      makeSession({ id: 'c', cwd: '/work', alive: false, unread: true, project_slug: 'proj' }),
+    ]
+    expect(unreadCount.value).toBe(1)
+  })
+
+  it('excludes the currently-selected session', () => {
+    _rawSessions.value = [
+      makeSession({ id: 'a', cwd: '/work', kind: 'shell', slug: 'aa', alive: true, unread: true, project_slug: 'proj' }),
+      makeSession({ id: 'b', cwd: '/work', kind: 'shell', slug: 'bb', alive: true, unread: true, project_slug: 'proj' }),
+    ]
+    expect(unreadCount.value).toBe(2)
+    urlPath.value = '/proj/shell/aa'
+    expect(selectedId.value).toBe('a')
+    expect(unreadCount.value).toBe(1)
+  })
+
+  it('ignores the ?project=/?cwd= view filter (global signal)', () => {
+    _rawSessions.value = [
+      makeSession({ id: 'a', cwd: '/work', alive: true, unread: true, project_slug: 'proj' }),
+    ]
+    // A cwd filter that excludes the unread session from the visible
+    // sidebar must not zero out the global blip.
+    urlSearch.value = '?cwd=/elsewhere'
+    expect(unreadCount.value).toBe(1)
   })
 })
 

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -432,15 +432,21 @@ export const unresolvedHosts = computed<UnresolvedHost[]>(
   () => resolvedReferences.value.unresolved,
 )
 
-export const folders = computed(() =>
-  buildProjectFolders(
+/** Build sidebar folders from an arbitrary session list. Shared by the
+ *  visible `folders` (filtered by URL params) and the unfiltered folder
+ *  set behind `unreadCount` (a global signal that must ignore the
+ *  ?project=/?cwd= view filter). */
+function foldersFrom(ss: Session[]): Folder[] {
+  return buildProjectFolders(
     projects.value,
-    filteredSessions.value,
+    ss,
     (name) => localPeerNames.value.has(name),
     _rawWorld.value.peerProjects,
     (peer, slug) => resolvedReferences.value.resolution.get(refKey(peer, slug)),
-  ),
-)
+  )
+}
+
+export const folders = computed(() => foldersFrom(filteredSessions.value))
 
 /**
  * Local host's display name, but only when the shown folders span more
@@ -524,10 +530,30 @@ export const backgroundActivity = computed((): DotState => {
   return 'none'
 })
 
-/** Count of unread sessions (excluding selected). */
-export const unreadCount = computed(() =>
-  sessions.value.filter(s => s.id !== selectedId.value && s.alive && s.unread).length,
-)
+/** Count of unread sessions (excluding selected).
+ *
+ * Folder-derived rather than read off the raw `sessions` set, so the
+ * attention blip counts only sessions stamped into a project in
+ * projects.json (owned project or resolved reference) — discovered
+ * (unstamped/unreferenced) sessions render nowhere in the sidebar and
+ * must not ping for attention. `buildProjectFolders` buckets each
+ * session into at most one folder, so summing across folders needs no
+ * dedup.
+ *
+ * Built from the *unfiltered* session set (`foldersFrom(sessions)`),
+ * not the visible `folders` (which honor the ?project=/?cwd= view
+ * filter). The blip is a global signal: an unread session in another
+ * project must still count while the user browses a filtered view. */
+export const unreadCount = computed(() => {
+  const sel = selectedId.value
+  let n = 0
+  for (const f of foldersFrom(sessions.value)) {
+    for (const s of f.sessions) {
+      if (s.id !== sel && s.alive && s.unread) n++
+    }
+  }
+  return n
+})
 
 // ── Home dashboard partitioning ─────────────────────────────────────────────
 //


### PR DESCRIPTION
## What

The waiting-attention blip (gmux logo + mobile hamburger badge) counted **discovered** sessions — unstamped/unreferenced sessions that render nowhere in the sidebar. A session you've never adopted into a project would ping you for attention.

## Fix

`unreadCount` read the raw `sessions` set. It now derives from `folders`, which `buildProjectFolders` builds one-to-one from `projects.json` items — so "session is in some folder" == "session is in the sidebar" (owned project or resolved reference). Each session buckets into at most one folder, so summing alive+unread across folders needs no dedup. The selected-session exclusion and the `alive` requirement are preserved.

Both consumers (sidebar logo blip `sidebar.tsx`, mobile hamburger badge `main.tsx`) read the single `unreadCount` signal, so this fixes both.

## Tests

Added a `unreadCount` describe block in `store.test.ts`:
- discovered (unstamped) alive+unread session is excluded
- alive+unread session stamped into a folder is counted (dead/read excluded)
- currently-selected session is excluded

Full web suite (483 tests) + `tsc --noEmit` green.