### PR TITLE
feat: make project discovery host-authoritative

### DIFF
--- a/apps/gmux-web/src/projects.test.ts
+++ b/apps/gmux-web/src/projects.test.ts
@@ -866,11 +866,14 @@ describe('discoverProjects', () => {
   })
 
   it('sorts by active count, then session count, then alphabetically', () => {
+    // Equal created_at so the recency key ties and the active/session
+    // count keys are what's exercised here.
+    const ts = '2026-01-01T00:00:00Z'
     const sessions = [
-      makeSession({ id: '1', cwd: '/a', alive: false }),
-      makeSession({ id: '2', cwd: '/b', alive: true }),
-      makeSession({ id: '3', cwd: '/c', alive: true }),
-      makeSession({ id: '4', cwd: '/c', alive: false }),
+      makeSession({ id: '1', cwd: '/a', alive: false, created_at: ts }),
+      makeSession({ id: '2', cwd: '/b', alive: true, created_at: ts }),
+      makeSession({ id: '3', cwd: '/c', alive: true, created_at: ts }),
+      makeSession({ id: '4', cwd: '/c', alive: false, created_at: ts }),
     ]
     const out = discoverProjects(sessions, [])
     expect(out.map(d => d.paths[0])).toEqual(['/c', '/b', '/a'])
@@ -908,8 +911,10 @@ describe('discoverProjects', () => {
     // snapshot.sessions, whose Go-map iteration is randomized, so
     // every snapshot re-emit would visually flip the rows. The
     // paths[0] tiebreak pins them.
-    const a = makeSession({ id: 'sa', cwd: '/home/me/api', alive: true })
-    const b = makeSession({ id: 'sb', cwd: '/srv/api', alive: true })
+    // Pin created_at equal so the recency sort key ties and the
+    // path tiebreak is what's under test.
+    const a = makeSession({ id: 'sa', cwd: '/home/me/api', alive: true, created_at: '2026-01-01T00:00:00Z' })
+    const b = makeSession({ id: 'sb', cwd: '/srv/api', alive: true, created_at: '2026-01-01T00:00:00Z' })
 
     for (const input of [[a, b], [b, a]]) {
       const out = discoverProjects(input, [])
@@ -917,18 +922,42 @@ describe('discoverProjects', () => {
     }
   })
 
-  it('excludes sessions from disconnected peers', () => {
-    // A disconnected peer's disclaimed sessions may be stale: the
-    // peer may have grown rules we haven't seen yet. Surfacing them
-    // as discoverable would let the user click + Add against an
-    // unreachable peer and create a dangling reference.
+  it('excludes ALL peer sessions (discovery is host-authoritative)', () => {
+    // Discovery is owned by the originating host (ADR 0002/0005): the
+    // viewer computes discovery only for its own local sessions. Peer
+    // sessions — connected or not — are discovered by their owning
+    // host and relayed verbatim (merged in store.discovered), never
+    // recomputed here.
     const sessions = [
       makeSession({ id: 'a@up', cwd: '/work/a', alive: true, peer: 'up' }),
       makeSession({ id: 'b@down', cwd: '/work/b', alive: true, peer: 'down' }),
+      makeSession({ id: 'local', cwd: '/work/local', alive: true }),
     ]
-    const status = new Map([['up', 'connected'], ['down', 'disconnected']])
-    const out = discoverProjects(sessions, [], status)
-    expect(out.map(d => d.peer)).toEqual(['up'])
+    const out = discoverProjects(sessions, [])
+    expect(out.map(d => d.paths[0])).toEqual(['/work/local'])
+    expect(out.every(d => d.peer === undefined)).toBe(true)
+  })
+
+  it('treats local-peer (devcontainer) sessions as local', () => {
+    // Per ADR 0005 a Local peer's project assignment is owned by the
+    // parent, so its disclaimed sessions flow through the parent's
+    // local discovery rather than the container's own.
+    const sessions = [
+      makeSession({ id: 's@dev', cwd: '/work/dc', alive: true, peer: 'dev' }),
+    ]
+    const out = discoverProjects(sessions, [], (name) => name === 'dev')
+    expect(out).toHaveLength(1)
+    expect(out[0].paths).toEqual(['/work/dc'])
+    expect(out[0].peer).toBeUndefined()
+  })
+
+  it('populates last_active from the most recent session timestamp', () => {
+    const sessions = [
+      makeSession({ id: 'a', cwd: '/work/foo', alive: true, created_at: '2026-01-01T00:00:00Z' }),
+      makeSession({ id: 'b', cwd: '/work/foo', alive: true, created_at: '2026-02-01T00:00:00Z' }),
+    ]
+    const out = discoverProjects(sessions, [])
+    expect(out[0].last_active).toBe('2026-02-01T00:00:00Z')
   })
 })
 

--- a/apps/gmux-web/src/projects.ts
+++ b/apps/gmux-web/src/projects.ts
@@ -165,46 +165,45 @@ export function mostCommonRemote(sessions: Session[]): string {
   return best
 }
 
-/** Group disclaimed sessions into suggested projects, scoped per host.
+/** Discover suggested projects from the viewer's OWN (local) sessions.
  *
- * Each host's discovery is independent: a session is in scope for host X
- * iff (s.peer ?? '') === X and s.project_slug is empty. The viewer no
- * longer adopts peer sessions via its own match rules, so the bucket is
- * exactly "sessions whose origin host hasn't filed them."
+ * Discovery is host-authoritative (ADR 0002/0005): each host runs its
+ * own match rules over its own sessions and decides which are unclaimed.
+ * This function therefore handles local sessions only — peer sessions
+ * are discovered by their owning host and relayed verbatim (merged in
+ * by the `discovered` computed in store.ts).
  *
- * Suggestions from different hosts mix into one returned list, sorted
- * by recency (most-recently-active first). Each carries a `peer` field
- * (absent for local) so the modal can render a host chip and route the
- * "+ Add" action to the right daemon.
+ * A session is in scope iff it is local (`s.peer` empty, or a Local
+ * peer / devcontainer whose project assignment the parent owns — see
+ * ADR 0005), it is disclaimed (`s.project_slug` empty), and it doesn't
+ * match a local owned project (those get stamped imminently by
+ * auto-assign, so surfacing them as discovered would just flicker).
  *
- * Disconnected-peer suggestions are excluded: their disclaimed status
- * could be stale (the peer's projects.json may have grown rules we
- * haven't seen yet), and clicking + Add on one would hit a peer we
- * can't actually reach, producing a confusing failure.
- *
- * Local groups whose disclaimed sessions would still match a local
- * owned project are skipped: the user already has a place for them, and
- * the auto-assign hook will stamp them on next attribution. */
+ * Results carry no `peer` field (they are local). The merge in
+ * store.ts attaches `peer` to the peer-advertised rows. */
 export function discoverProjects(
   sessions: Session[],
   projects: ProjectItem[],
-  peerStatusByName?: ReadonlyMap<string, string>,
+  isLocalPeer?: (peerName: string) => boolean,
 ): DiscoveredProject[] {
   // Bucket by (peer, dir). peer '' is local; dir is workspace_root if
   // set, else cwd. Sessions with no dir are dropped.
   const byKey = new Map<string, { peer: string; dir: string; group: Session[] }>()
   for (const s of sessions) {
     if (s.project_slug) continue // claimed by origin
-    const peer = s.peer ?? ''
-    if (peer === '') {
-      // Local-host discovery still defers to local owned projects:
-      // a session matching a local rule will be stamped imminently by
-      // auto-assign, so don't surface it as discovered.
-      if (matchSession(s, projects)) continue
-    } else if (peerStatusByName && peerStatusByName.get(peer) !== 'connected') {
-      // Unreachable peer: skip. Same logic as countUnmatchedActive.
-      continue
-    }
+    // Discovery is host-authoritative (ADR 0002/0005): this viewer only
+    // discovers its OWN (local) sessions. Peer sessions are discovered
+    // by their owning host and relayed verbatim (see store.discovered).
+    // Local-peer/devcontainer sessions count as local: per ADR 0005
+    // their project assignment is owned by the parent's rules, so they
+    // flow through the parent's local discovery, not the container's.
+    const rawPeer = s.peer ?? ''
+    const peer = rawPeer !== '' && isLocalPeer?.(rawPeer) ? '' : rawPeer
+    if (peer !== '') continue
+    // Local-host discovery still defers to local owned projects: a
+    // session matching a local rule will be stamped imminently by
+    // auto-assign, so don't surface it as discovered.
+    if (matchSession(s, projects)) continue
     const dir = s.workspace_root || s.cwd
     if (!dir) continue
     const key = `${peer}\u0000${dir}`
@@ -221,9 +220,13 @@ export function discoverProjects(
     let suggested = remote ? slugFromRemote(remote) : ''
     if (!suggested) suggested = slugFromPath(dir)
     if (!suggested) suggested = 'project'
+    // Mirror the server-side sessionLastActive: prefer last_activity_at,
+    // fall back to created_at, so local rows sort consistently against
+    // peer-advertised ones.
     let lastActive = ''
     for (const s of group) {
-      if (s.created_at > lastActive) lastActive = s.created_at
+      const t = s.last_activity_at || s.created_at
+      if (t > lastActive) lastActive = t
     }
     const dp: DiscoveredProject = {
       suggested_slug: suggested,

--- a/apps/gmux-web/src/store.test.ts
+++ b/apps/gmux-web/src/store.test.ts
@@ -7,7 +7,7 @@ import {
   isSessionUnavailable, urlPath, urlSearch, filteredSessions, selectedId,
   navigateToSession, setNavigate,
   applyPending, _rawSessions, _rawWorld, _setRawWorld, _pendingMutations,
-  toUISession, localHostLabel, parseConnectURL, unreadCount,
+  toUISession, localHostLabel, parseConnectURL, unreadCount, discovered,
 } from './store'
 import type { PendingMutation } from './store'
 import type { Session } from './types'
@@ -530,6 +530,63 @@ describe('peerStatusByName + isSessionUnavailable', () => {
     // reach the session yet, so render as unavailable.
     const map = new Map([['tower', 'connecting']])
     expect(isSessionUnavailable({ peer: 'tower' }, map)).toBe(true)
+  })
+})
+
+describe('discovered (host-authoritative)', () => {
+  beforeEach(() => {
+    _rawSessions.value = []
+    _setRawWorld({ projects: [], peers: [], peerProjects: {}, peerDiscovered: {} })
+  })
+  afterEach(() => {
+    _rawSessions.value = []
+    _setRawWorld({ projects: [], peers: [], peerProjects: {}, peerDiscovered: {} })
+  })
+
+  it('merges local discovery with a connected peer\'s advertised list', () => {
+    _rawSessions.value = [
+      makeSession({ id: 'local', cwd: '/work/local', alive: true, created_at: '2026-01-01T00:00:00Z' }),
+    ]
+    _setRawWorld({
+      peers: [{ name: 'tower', url: '', status: 'connected', session_count: 0 }],
+      peerDiscovered: {
+        tower: [{
+          suggested_slug: 'apps', remote: 'github.com/mgabor3141/apps',
+          paths: ['/mnt/user/apps'], session_count: 1, active_count: 1,
+          last_active: '2026-02-01T00:00:00Z',
+        }],
+      },
+    })
+    const out = discovered.value
+    expect(out).toHaveLength(2)
+    // Peer row is more recent, so it sorts first.
+    expect(out[0]).toMatchObject({ suggested_slug: 'apps', peer: 'tower' })
+    expect(out[1]).toMatchObject({ paths: ['/work/local'] })
+    expect(out[1].peer).toBeUndefined()
+  })
+
+  it('drops a disconnected peer\'s advertised discovered rows', () => {
+    _setRawWorld({
+      peers: [{ name: 'tower', url: '', status: 'disconnected', session_count: 0 }],
+      peerDiscovered: {
+        tower: [{ suggested_slug: 'apps', paths: ['/mnt/user/apps'], session_count: 1, active_count: 1 }],
+      },
+    })
+    expect(discovered.value).toEqual([])
+  })
+
+  it('does not recompute peer sessions locally', () => {
+    // A peer session present in the snapshot must NOT generate a
+    // discovered row on the viewer side; only the peer's own
+    // advertised list (peerDiscovered) counts.
+    _rawSessions.value = [
+      makeSession({ id: 's@tower', cwd: '/mnt/user/apps', alive: true, peer: 'tower' }),
+    ]
+    _setRawWorld({
+      peers: [{ name: 'tower', url: '', status: 'connected', session_count: 1 }],
+      peerDiscovered: {},
+    })
+    expect(discovered.value).toEqual([])
   })
 })
 

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -67,6 +67,15 @@ export interface RawWorld {
    * without proxying a separate request.
    */
   peerProjects: Record<string, PeerProject[]>
+  /**
+   * Per-peer authoritative discovered list, keyed by peer name.
+   * Discovery is host-authoritative (ADR 0002/0005): each connected
+   * peer advertises the sessions it owns but no project of its own
+   * claims, and the viewer renders these rows verbatim rather than
+   * recomputing peer discovery blind. The viewer's own (local) sessions
+   * are discovered client-side; see the `discovered` computed.
+   */
+  peerDiscovered: Record<string, DiscoveredProject[]>
 }
 
 export const _rawSessions = signal<Session[]>([])
@@ -77,6 +86,7 @@ export const _rawWorld = signal<RawWorld>({
   launchers: [],
   defaultLauncher: 'shell',
   peerProjects: {},
+  peerDiscovered: {},
 })
 
 /** Merge a partial world update into `_rawWorld`. Used by SSE handlers,
@@ -213,12 +223,50 @@ effect(() => {
 export const sessionsLoaded = signal(false)
 export const connState = signal<'connecting' | 'connected' | 'error'>('connecting')
 
-// Per ADR 0001: Discovered is a per-viewer projection, not
-// server-pushed state. It derives from the same public
-// sessions/projects projections everyone else uses.
-export const discovered = computed<DiscoveredProject[]>(
-  () => discoverProjects(sessions.value, projects.value, peerStatusByName.value),
-)
+// Discovered is host-authoritative (ADR 0002/0005): each host runs its
+// own match rules over its own sessions and decides which are
+// unclaimed. So this viewer computes discovery only for its OWN (local)
+// sessions, and merges in each connected peer's self-advertised
+// discovered list verbatim. A peer can therefore never offer (in
+// Discovered) a project it already owns by a rule the viewer can't see.
+//
+// Per ADR 0001's note: "Discovered is a per-viewer projection." That
+// remains true for the viewer's own local sessions (the viewer is their
+// owner); for peer sessions the projection is the peer's own, relayed
+// over the wire.
+export const discovered = computed<DiscoveredProject[]>(() => {
+  const lp = localPeerNames.value
+  const local = discoverProjects(sessions.value, projects.value, (name) => lp.has(name))
+  const statuses = peerStatusByName.value
+  const peerRows: DiscoveredProject[] = []
+  const byPeer = _rawWorld.value.peerDiscovered
+  for (const [peerName, rows] of Object.entries(byPeer)) {
+    // Disconnected peers contribute no rows: their advertised list may
+    // be stale and "+ Add" would hit a host we can't reach.
+    if (statuses.get(peerName) !== 'connected') continue
+    for (const row of rows) {
+      peerRows.push({ ...row, peer: peerName })
+    }
+  }
+  return sortDiscovered([...local, ...peerRows])
+})
+
+/** Sort discovered suggestions by recency, then active count, then
+ *  session count, then suggested_slug, then originating path. Mirrors
+ *  the Go-side Discovered() sort so local and peer-advertised rows
+ *  interleave consistently. */
+function sortDiscovered(rows: DiscoveredProject[]): DiscoveredProject[] {
+  return rows.sort((a, b) => {
+    const ta = a.last_active ?? ''
+    const tb = b.last_active ?? ''
+    if (ta !== tb) return tb < ta ? -1 : 1
+    if (a.active_count !== b.active_count) return b.active_count - a.active_count
+    if (a.session_count !== b.session_count) return b.session_count - a.session_count
+    const slugCmp = a.suggested_slug.localeCompare(b.suggested_slug)
+    if (slugCmp !== 0) return slugCmp
+    return (a.paths[0] ?? '').localeCompare(b.paths[0] ?? '')
+  })
+}
 
 // ── Peer appearance: unique prefix + deterministic color ─────────────────────
 
@@ -1245,6 +1293,7 @@ export function initStore(): () => void {
         launchers?: LauncherDef[]
         default_launcher?: string
         peer_projects?: Record<string, PeerProject[]>
+        peer_discovered?: Record<string, DiscoveredProject[]>
       }
       _setRawWorld({
         projects: env.projects ?? [],
@@ -1253,6 +1302,7 @@ export function initStore(): () => void {
         launchers: env.launchers ?? [],
         defaultLauncher: env.default_launcher ?? 'shell',
         peerProjects: env.peer_projects ?? {},
+        peerDiscovered: env.peer_discovered ?? {},
       })
     } catch (err) {
       console.warn('snapshot.world: bad event', err)

--- a/apps/gmux-web/src/types.ts
+++ b/apps/gmux-web/src/types.ts
@@ -158,8 +158,9 @@ export interface DiscoveredProject {
    */
   peer?: string
   /**
-   * Most-recent created_at among the sessions in this group, as an
-   * RFC3339 string. Used to sort suggestions by recency.
+   * Most-recent last_activity_at (falling back to created_at) among the
+   * sessions in this group, as an RFC3339 string. Used to sort
+   * suggestions by recency.
    */
   last_active?: string
 }

--- a/docs/adr/0001-snapshot-push-protocol.md
+++ b/docs/adr/0001-snapshot-push-protocol.md
@@ -176,6 +176,22 @@ computation to local `computed` derivations; the server keeps them
 on the HTTP `GET /v1/projects` path for CLI compatibility but
 removes them from the SSE path.
 
+**Amendment (host-authoritative discovery).** The "discovered is a
+per-viewer projection" framing is correct only for the viewer's OWN
+(local) sessions, whose owner is the viewer. Discovery is the inverse
+of ownership ("which of MY sessions does no project of mine claim"),
+and per ADR 0002/0005 ownership is host-authoritative — so a PEER's
+discovery belongs to that peer, not the viewer. A viewer recomputing
+peer discovery is rule-blind (it can't see the peer's match rules) and
+would offer a project the peer already owns by a path-vs-remote rule
+mismatch, forking a duplicate slug on "+ Add". The viewer therefore
+computes discovery only for its local sessions and merges in each
+connected peer's self-advertised `discovered` list verbatim, relayed
+through the hub's `snapshot.world.peer_discovered` map (the hub caches
+it from the peer's `GET /v1/projects` response). Local-peer /
+devcontainer sessions flow through the parent's local discovery (ADR
+0005). Disconnected peers contribute no rows.
+
 A `ready` computed gates initial render: `_rawSessions !== null &&
 _rawWorld !== null`. The hydration race the existing
 `sessionsLoaded` gate addresses goes away because each raw signal

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -1843,6 +1843,7 @@ func serve(stderr io.Writer) int {
 				Launchers:       launchConfig.Launchers,
 				DefaultLauncher: launchConfig.DefaultLauncher,
 				PeerProjects:    composePeerProjects(peerManager),
+				PeerDiscovered:  composePeerDiscovered(peerManager),
 			}
 		}
 
@@ -2240,6 +2241,38 @@ func composePeerProjects(mgr *peering.Manager) map[string][]peering.SpokeProject
 	return out
 }
 
+// composePeerDiscovered gathers each connected peer's self-advertised
+// discovered list into a map keyed by peer name. Discovery is
+// host-authoritative (ADR 0002/0005): the viewer renders each peer's
+// own discovered rows verbatim instead of recomputing them blind. Local
+// peers are skipped (their sessions flow through the parent's local
+// discovery). Peers not yet fetched appear with an empty list.
+func composePeerDiscovered(mgr *peering.Manager) map[string][]peering.SpokeDiscovered {
+	if mgr == nil {
+		return nil
+	}
+	infos := mgr.PeerStatus()
+	if len(infos) == 0 {
+		return nil
+	}
+	out := make(map[string][]peering.SpokeDiscovered, len(infos))
+	for _, info := range infos {
+		if info.Local {
+			continue
+		}
+		p := mgr.GetPeer(info.Name)
+		if p == nil {
+			continue
+		}
+		discovered, _ := p.CachedDiscovered()
+		if discovered == nil {
+			discovered = []peering.SpokeDiscovered{}
+		}
+		out[info.Name] = discovered
+	}
+	return out
+}
+
 // currentPeers returns the manager's active peer status list, or nil if
 // there are none. (Offline tailnet-discovery hints were removed with
 // tsdiscovery in ADR 0008.)
@@ -2406,6 +2439,16 @@ func isAllowedPeerProxyPath(method, sub string) bool {
 	return false
 }
 
+// sessionLastActive returns the timestamp used to sort discovered
+// suggestions by recency: the session's last_activity_at, falling back
+// to created_at when no activity has been recorded yet.
+func sessionLastActive(s store.Session) string {
+	if s.LastActivityAt != "" {
+		return s.LastActivityAt
+	}
+	return s.CreatedAt
+}
+
 // buildSessionInfos converts store sessions to project SessionInfo structs.
 func buildSessionInfos(sessions *store.Store, isLocalPeer func(string) bool) []projects.SessionInfo {
 	list := sessions.List()
@@ -2421,6 +2464,7 @@ func buildSessionInfos(sessions *store.Store, isLocalPeer func(string) bool) []p
 			Alive:         s.Alive,
 			Resumable:     s.Resumable,
 			Slug:          s.Slug,
+			LastActive:    sessionLastActive(s),
 		}
 	}
 	return infos

--- a/services/gmuxd/internal/peering/peer.go
+++ b/services/gmuxd/internal/peering/peer.go
@@ -42,6 +42,10 @@ type Peer struct {
 	healthLoaded   bool        // true after first successful health fetch
 	cachedProjects []SpokeProject // peer's projects, refreshed on connect and on projects-update
 	projectsLoaded bool
+	// cachedDiscovered is the spoke's self-advertised discovered list
+	// (host-authoritative; see SpokeDiscovered). Refreshed alongside
+	// cachedProjects in fetchProjects.
+	cachedDiscovered []SpokeDiscovered
 
 	// onStatus is called when connection state changes.
 	onStatus func(name string, status Status)
@@ -156,6 +160,15 @@ func (p *Peer) CachedProjects() ([]SpokeProject, bool) {
 	return p.cachedProjects, p.projectsLoaded
 }
 
+// CachedDiscovered returns the peer's self-advertised discovered list
+// (host-authoritative). The bool tracks the same projectsLoaded flag as
+// CachedProjects: both are populated by the one fetchProjects call.
+func (p *Peer) CachedDiscovered() ([]SpokeDiscovered, bool) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.cachedDiscovered, p.projectsLoaded
+}
+
 // fetchProjects fetches the spoke's project list via GET /v1/projects,
 // projects each Item down to a SpokeProject (slug + launch_cwd hint
 // derived from the first path rule), and caches the result. Called
@@ -175,6 +188,7 @@ func (p *Peer) fetchProjects(ctx context.Context) {
 				Path string `json:"path,omitempty"`
 			} `json:"match"`
 		} `json:"configured"`
+		Discovered []SpokeDiscovered `json:"discovered"`
 	}
 	if err := json.Unmarshal(data, &envelope); err != nil {
 		log.Printf("peering: %s: parse projects: %v", p.Config.Name, err)
@@ -201,8 +215,16 @@ func (p *Peer) fetchProjects(ctx context.Context) {
 		}
 		projects = append(projects, sp)
 	}
+	// The spoke's discovered list is host-authoritative: it ran its
+	// own match rules over its own sessions, so we cache it verbatim
+	// rather than recomputing peer discovery blind (ADR 0002/0005).
+	discovered := envelope.Discovered
+	if discovered == nil {
+		discovered = []SpokeDiscovered{}
+	}
 	p.mu.Lock()
 	p.cachedProjects = projects
+	p.cachedDiscovered = discovered
 	p.projectsLoaded = true
 	p.mu.Unlock()
 	// Signal a status change so the hub's world coalescer re-emits

--- a/services/gmuxd/internal/peering/peering.go
+++ b/services/gmuxd/internal/peering/peering.go
@@ -101,6 +101,23 @@ type SpokeProject struct {
 	LaunchCwd string `json:"launch_cwd,omitempty"`
 }
 
+// SpokeDiscovered is the hub's verbatim copy of a single entry from a
+// spoke's authoritative `discovered` list (GET /v1/projects). Discovery
+// is host-authoritative (ADR 0002/0005): only the owning host runs its
+// own match rules over its own sessions, so the hub re-broadcasts the
+// spoke's self-advertised discovered rows under
+// peer_discovered[<peerName>][] rather than recomputing them blind.
+// The shape mirrors projects.DiscoveredProject (and the TS
+// DiscoveredProject) field-for-field.
+type SpokeDiscovered struct {
+	SuggestedSlug string   `json:"suggested_slug"`
+	Remote        string   `json:"remote,omitempty"`
+	Paths         []string `json:"paths"`
+	SessionCount  int      `json:"session_count"`
+	ActiveCount   int      `json:"active_count"`
+	LastActive    string   `json:"last_active,omitempty"`
+}
+
 // PeerInfo is the public status of a single peer connection.
 type PeerInfo struct {
 	Name            string        `json:"name"`

--- a/services/gmuxd/internal/projects/projects.go
+++ b/services/gmuxd/internal/projects/projects.go
@@ -600,6 +600,12 @@ type SessionInfo struct {
 	Alive     bool
 	Resumable bool // dead but has a resume command persisted
 	Slug      string
+	// LastActive is an RFC3339 timestamp of the session's most recent
+	// noteworthy activity (last_activity_at, falling back to
+	// created_at). Used to sort discovered suggestions by recency so a
+	// peer-advertised discovered row sorts consistently against the
+	// viewer's own local discovery.
+	LastActive string
 }
 
 // matchParamsFromInfo builds MatchParams from a SessionInfo.
@@ -619,6 +625,11 @@ type DiscoveredProject struct {
 	Paths         []string `json:"paths"`
 	SessionCount  int      `json:"session_count"`
 	ActiveCount   int      `json:"active_count"`
+	// LastActive is the most-recent LastActive among the sessions in
+	// this group, as an RFC3339 string. Mirrors the TS
+	// DiscoveredProject.last_active field so peer-advertised rows sort
+	// consistently with the viewer's locally-computed ones.
+	LastActive string `json:"last_active,omitempty"`
 }
 
 // UnmatchedActiveCount returns the number of alive sessions that don't
@@ -668,9 +679,13 @@ func (s *State) Discovered(sessions []SessionInfo) []DiscoveredProject {
 	result := make([]DiscoveredProject, 0, len(byDir))
 	for dir, group := range byDir {
 		active := 0
+		lastActive := ""
 		for _, s := range group {
 			if s.Alive {
 				active++
+			}
+			if s.LastActive > lastActive {
+				lastActive = s.LastActive
 			}
 		}
 
@@ -678,6 +693,7 @@ func (s *State) Discovered(sessions []SessionInfo) []DiscoveredProject {
 			Paths:        []string{dir},
 			SessionCount: len(group),
 			ActiveCount:  active,
+			LastActive:   lastActive,
 		}
 
 		// Extract the most common remote for display and the add request.
@@ -697,15 +713,23 @@ func (s *State) Discovered(sessions []SessionInfo) []DiscoveredProject {
 		result = append(result, dp)
 	}
 
-	// Active sessions first, then most sessions, then alphabetically.
+	// Recency first, then active sessions, then most sessions, then
+	// alphabetically by slug, then by path. Mirrors the TS sort so
+	// peer-advertised rows interleave consistently with local ones.
 	sort.Slice(result, func(i, j int) bool {
+		if result[i].LastActive != result[j].LastActive {
+			return result[i].LastActive > result[j].LastActive
+		}
 		if result[i].ActiveCount != result[j].ActiveCount {
 			return result[i].ActiveCount > result[j].ActiveCount
 		}
 		if result[i].SessionCount != result[j].SessionCount {
 			return result[i].SessionCount > result[j].SessionCount
 		}
-		return result[i].SuggestedSlug < result[j].SuggestedSlug
+		if result[i].SuggestedSlug != result[j].SuggestedSlug {
+			return result[i].SuggestedSlug < result[j].SuggestedSlug
+		}
+		return result[i].Paths[0] < result[j].Paths[0]
 	})
 
 	return result

--- a/services/gmuxd/internal/projects/projects_test.go
+++ b/services/gmuxd/internal/projects/projects_test.go
@@ -614,6 +614,51 @@ func TestDiscoveredAllMatched(t *testing.T) {
 	}
 }
 
+// TestDiscoveredExcludesRemoteOwnedButPathMatched is the exact
+// apps/apps-2 repro: the host owns project `apps` by a PATH rule
+// (/mnt/user/apps), while its sessions also report a github remote.
+// A viewer recomputing discovery by remote would still offer `apps`
+// (it can't see the path rule); the owning host's own Discovered()
+// must not, because Match() claims the session via the path rule.
+func TestDiscoveredExcludesRemoteOwnedButPathMatched(t *testing.T) {
+	s := &State{Items: []Item{
+		{Slug: "apps", Match: []MatchRule{{Path: "/mnt/user/apps"}}},
+	}}
+	sessions := []SessionInfo{
+		{ID: "s1", Cwd: "/mnt/user/apps", WorkspaceRoot: "/mnt/user/apps",
+			Remotes: map[string]string{"origin": "https://github.com/mgabor3141/apps.git"}},
+	}
+	if d := s.Discovered(sessions); d != nil {
+		t.Errorf("owned-by-path session must not be discovered, got %+v", d)
+	}
+}
+
+// TestDiscoveredLastActive verifies the LastActive field is populated
+// from the most-recent session in the group and drives recency sort.
+func TestDiscoveredLastActive(t *testing.T) {
+	s := &State{}
+	sessions := []SessionInfo{
+		{ID: "old", Cwd: "/work/old", LastActive: "2026-01-01T00:00:00Z"},
+		{ID: "newA", Cwd: "/work/new", LastActive: "2026-01-01T00:00:00Z"},
+		{ID: "newB", Cwd: "/work/new", LastActive: "2026-03-01T00:00:00Z"},
+	}
+	d := s.Discovered(sessions)
+	if len(d) != 2 {
+		t.Fatalf("expected 2 groups, got %d", len(d))
+	}
+	// Group /work/new has the most-recent LastActive, so it sorts first
+	// and carries the max timestamp of its sessions.
+	if d[0].Paths[0] != "/work/new" {
+		t.Errorf("expected /work/new first (most recent), got %q", d[0].Paths[0])
+	}
+	if d[0].LastActive != "2026-03-01T00:00:00Z" {
+		t.Errorf("LastActive = %q, want 2026-03-01T00:00:00Z", d[0].LastActive)
+	}
+	if d[1].LastActive != "2026-01-01T00:00:00Z" {
+		t.Errorf("second group LastActive = %q, want 2026-01-01T00:00:00Z", d[1].LastActive)
+	}
+}
+
 // --- Session membership ---
 
 func TestAddSession(t *testing.T) {

--- a/services/gmuxd/internal/snapshot/snapshot.go
+++ b/services/gmuxd/internal/snapshot/snapshot.go
@@ -72,6 +72,17 @@ type WorldPayload struct {
 	// last-active timestamps are derived client-side from stamped
 	// sessions; nothing else needs to ride on this field.
 	PeerProjects any `json:"peer_projects,omitempty"`
+
+	// PeerDiscovered carries each connected peer's self-advertised
+	// discovered list (sessions the peer owns but no project of its own
+	// claims), keyed by peer name. Discovery is host-authoritative
+	// (ADR 0002/0005): the owning host runs its own match rules over
+	// its own sessions, so the viewer renders these rows verbatim
+	// rather than recomputing peer discovery blind (which could offer a
+	// project the peer already owns by a rule the viewer can't see).
+	// Empty for peer consumers and for local peers (whose sessions flow
+	// through the parent's local discovery).
+	PeerDiscovered any `json:"peer_discovered,omitempty"`
 }
 
 // ComposeSessions builds a snapshot.sessions payload from the live


### PR DESCRIPTION
## Problem

Project discovery was computed twice, and the wrong copy won for peer sessions. A host could offer — in the **Discovered** section — a project it **already owns**, and clicking **+ Add** forked a duplicate slug (`apps` → `apps-2`) and pinned a dangling reference.

Repro: `gmux-hs` owns project `apps` by **path** `/mnt/user/apps`. The viewer's Discovered list still showed `apps · gmux-hs` grouped by the github **remote**, because the viewer-side TS recompute is rule-blind for peers — its only "claimed" signal for a peer session is `project_slug`, and it has no access to the peer's match rules. The hub also fetched the peer's authoritative `discovered` list and threw it away.

## Fix

Discovery is now **host-authoritative**, as ADR 0002/0005 already mandate:

> Discovered = (the viewer's locally-computed discovery of its own sessions) ⊕ (each connected peer's self-advertised discovered list, verbatim).

- **gmuxd**: `Peer.fetchProjects` parses + caches the peer's `discovered` array (`CachedDiscovered`); `composePeerDiscovered` relays it in `snapshot.world.peer_discovered`. `DiscoveredProject` gains `last_active` (max session `last_activity_at`, fallback `created_at`) and `Discovered()` now sorts recency-first.
- **web**: `discoverProjects` is local-only (treating local-peer/devcontainer sessions as local per ADR 0005); `store.discovered` merges local rows with each connected peer's advertised list and sorts them with a shared comparator. Disconnected peers contribute nothing.

A peer can therefore never offer a project it already owns by path or remote, so the `apps`/`apps-2` duplicate-Add path is structurally impossible.

## Tests

- Go: the exact repro (remote-owned-but-path-matched excluded) + `last_active` population.
- TS: local-only discovery, local-peer-as-local, merge with a connected peer, drop disconnected peer, no client recompute of peer sessions.

## Notes

This is a breaking-ish protocol/projection change for the 2.0 prerelease. ADR 0001's "discovered is a per-viewer projection" note is amended to record the host-authoritative scoping.