### PR TITLE
refactor(gmuxd): validate centrally in Manager.Update; surface conflicts to callers

### DIFF
--- a/services/gmuxd/internal/projects/addproject_test.go
+++ b/services/gmuxd/internal/projects/addproject_test.go
@@ -5,6 +5,63 @@ import (
 	"testing"
 )
 
+// Update is the single validation chokepoint: when fn commits (returns
+// true) but leaves the state invalid, nothing must be saved and the
+// caller must receive a *ValidationError. Previously Update never
+// validated, so an invalid mutation was persisted (or, for callers that
+// validated by hand and returned false, silently reported as success).
+func TestManagerUpdate_InvalidStateRejected(t *testing.T) {
+	dir := t.TempDir()
+	m := NewManager(dir)
+
+	// Seed a valid project.
+	if err := m.Update(func(s *State) bool {
+		s.Items = []Item{{Slug: "gmux", Match: []MatchRule{{Path: "/dev/gmux"}}}}
+		return true
+	}); err != nil {
+		t.Fatalf("seed Update: %v", err)
+	}
+
+	broadcasts := 0
+	m.Broadcast = func(*State) { broadcasts++ }
+
+	// A committing mutation that produces a duplicate slug must be
+	// rejected and must not save or broadcast.
+	err := m.Update(func(s *State) bool {
+		s.Items = append(s.Items, Item{Slug: "gmux", Match: []MatchRule{{Path: "/dev/other"}}})
+		return true
+	})
+	if err == nil {
+		t.Fatal("Update accepted invalid state, want *ValidationError")
+	}
+	var verr *ValidationError
+	if !errors.As(err, &verr) {
+		t.Fatalf("error type = %T (%v), want *ValidationError", err, err)
+	}
+	if broadcasts != 0 {
+		t.Errorf("broadcast fired on rejected update: %d", broadcasts)
+	}
+
+	// Nothing must have been persisted beyond the seed project.
+	s, err := m.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(s.Items) != 1 || s.Items[0].Slug != "gmux" {
+		t.Fatalf("persisted items = %#v, want only the seed 'gmux'", s.Items)
+	}
+}
+
+// An aborted update (fn returns false) is still a nil error, distinct
+// from a validation failure.
+func TestManagerUpdate_AbortIsNotError(t *testing.T) {
+	dir := t.TempDir()
+	m := NewManager(dir)
+	if err := m.Update(func(s *State) bool { return false }); err != nil {
+		t.Fatalf("aborted Update returned error: %v", err)
+	}
+}
+
 func TestManagerAddProject_Success(t *testing.T) {
 	dir := t.TempDir()
 	m := NewManager(dir)

--- a/services/gmuxd/internal/projects/manager.go
+++ b/services/gmuxd/internal/projects/manager.go
@@ -1,6 +1,7 @@
 package projects
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"sync"
@@ -71,33 +72,41 @@ func (m *Manager) SeedIfEmpty() {
 // item (with its final, possibly deduplicated slug) is returned.
 //
 // This exists so the caller can tell "created" from "rejected": a bare
-// Update cannot, because its fn returning false (abort) and returning
-// true (saved) both surface as a nil error. Reporting success on an
-// aborted add let clients pin references to projects that were never
-// created (see the dangling peer-reference bug).
+// Update returning false (abort) and returning true with invalid state
+// would both surface as a nil error if Update did not validate.
+// Reporting success on an aborted add let clients pin references to
+// projects that were never created (see the dangling peer-reference
+// bug). Update now validates centrally, so AddProject just contextualises
+// the resulting *ValidationError with the requested slug.
 func (m *Manager) AddProject(baseSlug string, rules []MatchRule) (Item, error) {
 	var created Item
-	var valErr error
 	err := m.Update(func(s *State) bool {
 		created = Item{Slug: UniqueSlug(baseSlug, s.Items), Match: rules}
 		s.Items = append(s.Items, created)
-		if err := s.Validate(); err != nil {
-			valErr = err
-			return false
-		}
 		return true
 	})
 	if err != nil {
+		var verr *ValidationError
+		if errors.As(err, &verr) {
+			return Item{}, &ValidationError{Err: fmt.Errorf("project %q: %w", baseSlug, verr.Err)}
+		}
 		return Item{}, err
-	}
-	if valErr != nil {
-		return Item{}, &ValidationError{Err: fmt.Errorf("project %q: %w", baseSlug, valErr)}
 	}
 	return created, nil
 }
 
-// Update atomically loads state, calls fn to modify it, validates, and saves.
-// If fn returns false, the update is aborted (no save, no broadcast).
+// Update atomically loads state, calls fn to modify it, validates, and
+// saves. If fn returns false, the update is aborted (no save, no
+// broadcast, nil error).
+//
+// Validation is the single chokepoint here, not in each caller: when fn
+// returns true but leaves the state invalid, Update saves nothing and
+// returns a *ValidationError. This makes a silently-discarded mutation
+// impossible — every caller now sees a non-nil error instead of a
+// success that persisted nothing. User-initiated callers (HTTP handlers)
+// map it to a 4xx; background/reconcile callers log and drop it (their
+// mutations only add/remove session keys, which Validate never rejects,
+// so in practice they never hit this path).
 func (m *Manager) Update(fn func(s *State) bool) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -109,6 +118,10 @@ func (m *Manager) Update(fn func(s *State) bool) error {
 
 	if !fn(state) {
 		return nil // aborted by fn
+	}
+
+	if err := state.Validate(); err != nil {
+		return &ValidationError{Err: err}
 	}
 
 	if err := state.Save(m.stateDir); err != nil {


### PR DESCRIPTION
## Summary
Closes the rest of the class of bug fixed for the add path in #303.

**Root cause:** `projects.Manager.Update` never called `Validate` at all — it loaded, ran `fn`, and saved whatever `fn` produced. `AddProject` worked around this by hand-validating inside its closure and returning `false` on failure, which is exactly why a rejected add was indistinguishable from a real abort (both surfaced as `nil`).

## Audit result
Every `Update` caller was classified. `State.Validate` only inspects slugs / node_id / match rules / paths — **it never examines `Sessions[]`** — so the session-array mutators (`AutoAssignSession`, `AutoAssignAll`, `PruneNamespacedKeys`, `CleanupSessions`, `DismissSession`, `SeedIfEmpty`) cannot produce invalid state. The PUT handler pre-validates its incoming payload (400); the PATCH reorder handler only shuffles an existing sessions array and signals "not found" via a separate flag. **The add path genuinely was the only victim** — but centralising validation closes the gap for any future committing caller.

## Changes
- `Update` now validates after `fn` commits: invalid state → `*ValidationError`, nothing saved, no broadcast. Single, unskippable chokepoint.
- `AddProject` drops its hand-rolled validate and re-wraps the central `*ValidationError` with the requested slug. The add HTTP handler keeps mapping it to 409.
- PUT `/v1/projects` and PATCH `/v1/projects/{slug}/sessions` are left unchanged: PUT pre-validates the payload (a malformed full-state replace is a 400, not a conflict), and reorder can't produce invalid state, so neither can surface a `ValidationError` today. No dead 409 branches added.

## Tests
- `TestManagerUpdate_InvalidStateRejected` — a committing duplicate-slug mutation is rejected, not saved, not broadcast.
- `TestManagerUpdate_AbortIsNotError` — `fn`→false stays a nil error.
- Existing add-path tests still pass.
- `go test ./services/gmuxd/...` green, `go vet` clean.