### PR TITLE
feat(web): collapse the session header while the keyboard is open on phones

### DIFF
--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -22,7 +22,7 @@ import { installVersionWatch } from './version-watch'
 import {
   sessions, connState, selected, selectedId, view, health, peers,
   terminalOptions, keybinds, macCommandIsCtrl,
-  unreadCount,
+  unreadCount, keyboardOpen,
   urlPath, urlSearch,
   initStore, setNavigate, navigateToSession,
   dismissSession, resumeSession, restartSession,
@@ -35,6 +35,11 @@ const InputDiagnostics = lazy(() => import('./input-diagnostics'))
 // ── Config ──
 
 const USE_MOCK = import.meta.env.VITE_MOCK === '1' || location.search.includes('mock')
+
+/** Visual-viewport occlusion (px) above which the on-screen keyboard is
+ * considered open. Low enough to trip early in the slide-up animation,
+ * well above sub-pixel/URL-bar noise. */
+const KEYBOARD_PRESENCE_PX = 60
 
 // Mock mode: hide close buttons and other interactive chrome via CSS.
 if (USE_MOCK) document.documentElement.classList.add('mock-mode')
@@ -75,7 +80,7 @@ function MainHeader({ session, onRestart }: {
   const shortCwd = session.cwd.replace(/^\/home\/[^/]+/, '~')
 
   return (
-    <div class="main-header">
+    <div class={`main-header ${keyboardOpen.value ? 'keyboard-collapsed' : ''}`}>
       <div class="main-header-left">
         <div class="main-header-title">
           {session.title}
@@ -359,12 +364,27 @@ function MobileTerminalBar({
 // ── App ──
 
 function App() {
-  // Visual viewport tracking for keyboard-aware layout.
+  // Visual viewport tracking for keyboard-aware layout. Lives here (not
+  // in TerminalView) because viewport occlusion is an app-global fact:
+  // App never unmounts, so keyboardOpen can't flash on session switch or
+  // navigation, and there's no per-component cleanup to get wrong.
   useEffect(() => {
     const vv = window.visualViewport
     if (!vv) return
+    // On touch, the on-screen keyboard shrinks the visual viewport without
+    // shrinking the layout viewport (window.innerHeight) on iOS, so their
+    // difference is the occluded height. The URL bar moves both together,
+    // so it doesn't register — letting a small threshold detect the
+    // keyboard early in its slide. Detected via the viewport, not textarea
+    // focus, which lies (the resize path re-focuses after the keyboard
+    // closes). CSS decides whether a collapse actually applies.
+    const isTouchDevice = window.matchMedia('(pointer: coarse)').matches
+      || navigator.maxTouchPoints > 0
     const update = () => {
       document.documentElement.style.setProperty('--app-height', `${vv.height}px`)
+      if (isTouchDevice) {
+        keyboardOpen.value = window.innerHeight - vv.height > KEYBOARD_PRESENCE_PX
+      }
     }
     update()
     vv.addEventListener('resize', update)

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -368,6 +368,15 @@ export const terminalOptions = signal<ResolvedTerminalOptions | null>(null)
 export const keybinds = signal<ResolvedKeybind[] | null>(null)
 export const macCommandIsCtrl = signal(false)
 
+/**
+ * True while the on-screen keyboard is open, detected via visual-viewport
+ * occlusion on touch devices (window.innerHeight - visualViewport.height
+ * exceeds a threshold). Drives keyboard-aware layout (e.g. collapsing the
+ * header on phones to reclaim rows). Set by App's viewport effect; CSS
+ * decides whether/when a collapse actually applies.
+ */
+export const keyboardOpen = signal(false)
+
 /** Current URL path, kept in sync with preact-iso's location. */
 export const urlPath = signal(
   typeof location !== 'undefined' ? (location.pathname.replace(/\/+$/, '') || '/') : '/',

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -2350,6 +2350,22 @@ body {
   .sidebar-scroll { order: 1; }
 }
 
+/* Collapse the session header while the on-screen keyboard is open on
+   phone-sized touch screens, reclaiming a row for the terminal. The
+   keyboardOpen signal (set from textarea focus) toggles
+   .keyboard-collapsed; this query gates *when* it actually hides.
+   We gate on width, not height: the iOS keyboard doesn't shrink the
+   layout viewport (what media queries read), so a phone in portrait
+   stays ~800px tall and a max-height gate would never match. Width is
+   the reliable "this is a phone" proxy — reusing the 640px narrow
+   breakpoint — where the keyboard always eats a large share of the
+   screen. Tablets (wider) keep the header. */
+@media (pointer: coarse) and (max-width: 640px) {
+  .main-header.keyboard-collapsed {
+    display: none;
+  }
+}
+
 /* ── Session Detail (non-terminal) ── */
 
 

--- a/apps/gmux-web/src/terminal.tsx
+++ b/apps/gmux-web/src/terminal.tsx
@@ -27,6 +27,11 @@ const USE_MOCK = import.meta.env.VITE_MOCK === '1' || location.search.includes('
  */
 export const TERM_THEME = DEFAULT_THEME_COLORS
 
+// ── Keyboard / resize timing (touch) ──
+
+/** Debounce before measuring a height-only viewport change, so an
+ * unsettled mid-animation height never drives a resize. */
+const KEYBOARD_RESIZE_DEBOUNCE_MS = 20
 // ── Utilities ──
 
 /**
@@ -683,6 +688,9 @@ export function TerminalView({
     shell?.addEventListener('touchend', handleTouchEndCapture, { capture: true, passive: false })
     shell?.addEventListener('touchcancel', clearTouchPan, true)
 
+    const isTouchDevice = window.matchMedia('(pointer: coarse)').matches
+      || navigator.maxTouchPoints > 0
+
     // Resize strategy:
     // - A ResizeObserver on the shell element detects all layout changes:
     //   initial flex settle, sidebar toggle, window resize, etc.
@@ -695,9 +703,6 @@ export function TerminalView({
     // - Height-only viewport changes (soft keyboard slide) get a short debounce
     //   before that frame measurement, so we skip unstable intermediate heights.
     const vv = window.visualViewport
-    const isTouchDevice = window.matchMedia('(pointer: coarse)').matches
-      || navigator.maxTouchPoints > 0
-    const KEYBOARD_RESIZE_DEBOUNCE_MS = 20
 
     let resizeTimer: ReturnType<typeof setTimeout> | null = null
     let resizeFrame: number | null = null


### PR DESCRIPTION
On a phone, the on-screen keyboard already eats half the screen; the session header then costs another row of terminal. This collapses the header while the keyboard is open, reclaiming that row, and restores it when the keyboard closes.

## Detection — visual viewport, not focus

The keyboard is detected from the **visual viewport**, not textarea focus. Focus is a false signal here: the resize path deliberately re-focuses the hidden textarea after the keyboard closes (so iOS doesn't re-blur mid-transition), which would pin the header collapsed forever. Instead, `updateKeyboardPresence` compares `window.innerHeight` (layout viewport, stable on iOS) to `visualViewport.height` (shrinks under the keyboard); the difference is the occluded height. The browser URL bar moves both together so it never registers, letting a small threshold (`KEYBOARD_PRESENCE_PX = 60`) trip early in the keyboard's slide-up animation.

That presence drives a `keyboardOpen` signal (store), which `MainHeader` reflects as a `keyboard-collapsed` class. CSS owns the *when*: `@media (pointer: coarse) and (max-width: 640px)` — width is the reliable "this is a phone" proxy (the iOS layout viewport doesn't shrink with the keyboard, so a height gate would never match in portrait). Tablets keep the header; desktop is untouched.

## Single resize

Hard requirement: the header collapse must not add a second PTY resize on top of the keyboard's. It doesn't — the collapse/expand happens *during* the keyboard's continuous `visualViewport.resize` stream, so the existing 20ms height-only debounce coalesces both into one resize. Verified on-device with a SIGWINCH-echo session: exactly one resize per open and per close, no header flicker.

(An earlier iteration carried hysteresis + a widened "transition" debounce from a focus-based prototype; once detection moved to the viewport that machinery proved unnecessary — removing it was a net simplification *and* made the post-keyboard reflow ~180ms snappier.)

## Testing

- New `keyboardOpen` signal; detection gated on `pointer: coarse`.
- Full suite green (501), tsc + biome clean.
- Device-verified (iOS): header collapses early in the keyboard animation, returns and stays on close, no flicker, single resize each way; toolbar buttons don't disturb it.