### PR TITLE
feat(web): rework the mobile terminal — toolbar, keyboard, resize, copy & paste

### DIFF
--- a/apps/gmux-web/index.html
+++ b/apps/gmux-web/index.html
@@ -2,7 +2,13 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
+    <!-- interactive-widget=resizes-visual: when the soft keyboard opens, shrink
+         only the visual viewport and keep the layout viewport (innerHeight) full.
+         Load-bearing for keyboard detection (innerHeight - visualViewport.height)
+         on Chrome >=108; iOS Safari already behaves this way. We deliberately do
+         NOT use the Chromium-only VirtualKeyboard API (it requires overlay mode);
+         see the detection comment in src/main.tsx. -->
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover, interactive-widget=resizes-visual" />
     <meta name="theme-color" content="#0a0e13" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="manifest" href="/manifest.json" />

--- a/apps/gmux-web/src/link-action-sheet.tsx
+++ b/apps/gmux-web/src/link-action-sheet.tsx
@@ -1,53 +1,27 @@
 /**
  * Action sheet for long-pressing a link in the terminal.
  *
- * Centered modal (reuses the settings-modal backdrop conventions)
- * rather than anchored to the touch point: consistent placement, no
- * clamp/flip math, and the link itself stays visible. Shows the
- * resolved target URI — for OSC 8 hyperlinks the buffer only paints a
- * label, so this is the one place a user can inspect the real target
- * before opening it.
+ * Centered modal (via the shared {@link SheetBackdrop} — portaled,
+ * keyboard-aware, click-dismissed) rather than anchored to the touch
+ * point: consistent placement, no clamp/flip math, and the link itself
+ * stays visible. Shows the resolved target URI — for OSC 8 hyperlinks the
+ * buffer only paints a label, so this is the one place a user can inspect
+ * the real target before opening it.
  *
  * The sheet holds a snapshot ({@link LinkInfo}) taken at press time;
  * it never reads live buffer state, so terminal output scrolling the
  * link away can't make it lie, and there's no reason to auto-dismiss.
  */
-import { useEffect, useRef, useState } from 'preact/hooks'
 import type { LinkInfo } from './terminal-link'
+import { CopyButton, SheetBackdrop, SheetButton } from './sheet'
 
 export interface LinkActionSheetProps {
   link: LinkInfo
   onClose: () => void
 }
 
-type CopyState = 'idle' | 'copied' | 'failed'
-
-const COPY_CLOSE_DELAY_MS = 600
-
 export function LinkActionSheet({ link, onClose }: LinkActionSheetProps) {
-  const [copyState, setCopyState] = useState<CopyState>('idle')
-  const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const showLabel = link.label !== link.uri
-
-  // Don't let the post-copy auto-close fire after the sheet is already
-  // gone (e.g. dismissed via the backdrop within the delay window).
-  useEffect(() => () => {
-    if (closeTimer.current !== null) clearTimeout(closeTimer.current)
-  }, [])
-
-  const handleCopy = () => {
-    if (!navigator.clipboard) {
-      setCopyState('failed')
-      return
-    }
-    navigator.clipboard.writeText(link.uri).then(
-      () => {
-        setCopyState('copied')
-        closeTimer.current = setTimeout(onClose, COPY_CLOSE_DELAY_MS)
-      },
-      () => setCopyState('failed'),
-    )
-  }
 
   const handleOpen = () => {
     window.open(link.uri, '_blank', 'noopener,noreferrer')
@@ -55,45 +29,17 @@ export function LinkActionSheet({ link, onClose }: LinkActionSheetProps) {
   }
 
   return (
-    // Activate on pointerup, not click. The sheet opens mid-touch (the
-    // 500ms hold fires while the finger is down on the terminal), so a
-    // quick tap right after the long-press release gets coalesced with
-    // it by iOS's gesture recognizer, which suppresses the synthesized
-    // click — on whatever element it lands, regardless of touch-action
-    // (that's decided by the element the gesture *started* on, the
-    // terminal). pointerup fires on release reliably and bypasses click
-    // synthesis entirely, while still being a release gesture (not
-    // press-to-activate). The recognizer is touch-gated, so the sheet
-    // only exists on touch devices; no keyboard-activation path to lose.
-    <div
-      class="modal-backdrop link-sheet-backdrop"
-      onPointerUp={ev => {
-        ev.stopPropagation()
-        if (ev.target === ev.currentTarget) onClose()
-      }}
-    >
-      <div class="modal-panel link-sheet" role="menu" aria-label="Link actions">
+    <SheetBackdrop onClose={onClose}>
+      <div class="modal-panel link-sheet" role="dialog" aria-label="Link actions">
         <div class="link-sheet-preview">
           {showLabel && <div class="link-sheet-label">{link.label}</div>}
           <div class="link-sheet-uri">{link.uri}</div>
         </div>
-        <button
-          type="button"
-          class="link-sheet-action"
-          role="menuitem"
-          onPointerUp={ev => { ev.stopPropagation(); handleCopy() }}
-        >
-          {copyState === 'idle' ? 'Copy URL' : copyState === 'copied' ? 'Copied ✓' : 'Copy failed'}
-        </button>
-        <button
-          type="button"
-          class="link-sheet-action"
-          role="menuitem"
-          onPointerUp={ev => { ev.stopPropagation(); handleOpen() }}
-        >
-          Open
-        </button>
+        <div class="link-sheet-actions">
+          <CopyButton label="Copy URL" text={link.uri} />
+          <SheetButton primary onActivate={handleOpen}>Open</SheetButton>
+        </div>
       </div>
-    </div>
+    </SheetBackdrop>
   )
 }

--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -37,9 +37,17 @@ const InputDiagnostics = lazy(() => import('./input-diagnostics'))
 const USE_MOCK = import.meta.env.VITE_MOCK === '1' || location.search.includes('mock')
 
 /** Visual-viewport occlusion (px) above which the on-screen keyboard is
- * considered open. Low enough to trip early in the slide-up animation,
- * well above sub-pixel/URL-bar noise. */
+ * considered open. Low enough to trip early in the slide-up animation and
+ * above sub-pixel/URL-bar noise, yet above a hardware-keyboard accessory
+ * bar (~44px on iPad) so that doesn't read as a soft keyboard. */
 const KEYBOARD_PRESENCE_PX = 60
+
+// On touch devices, focusing the terminal's hidden textarea pops the
+// on-screen keyboard. So auto-focus (session select, terminal mount) is
+// gated to non-touch — the keyboard opens only when the user taps the
+// terminal. Toolbar keys send via the raw input channel and never focus.
+const isTouchDevice = (): boolean =>
+  window.matchMedia?.('(pointer: coarse)').matches || navigator.maxTouchPoints > 0
 
 // Mock mode: hide close buttons and other interactive chrome via CSS.
 if (USE_MOCK) document.documentElement.classList.add('mock-mode')
@@ -207,7 +215,6 @@ const IconRight = () => <svg viewBox="0 0 14 14" width="16" height="16" {...S}><
 const IconWordLeft  = () => <svg viewBox="0 0 18 14" width="20" height="16" {...S}><line x1="3.5" y1="3" x2="3.5" y2="11"/><path d="M13 7H6m0 0 3-3M6 7l3 3"/></svg>
 const IconWordRight = () => <svg viewBox="0 0 18 14" width="20" height="16" {...S}><line x1="14.5" y1="3" x2="14.5" y2="11"/><path d="M5 7h7m0 0-3-3m3 3-3 3"/></svg>
 const IconSend = () => <svg viewBox="0 0 14 14" width="16" height="16" fill="currentColor" stroke="none"><path d="M3 2.5l8 4.5-8 4.5V8.5L7.5 7 3 5.5z"/></svg>
-const IconPaste = () => <svg viewBox="0 0 14 14" width="16" height="16" {...S}><rect x="3" y="3" width="8" height="9" rx="1"/><path d="M5.5 3V2.5a1.5 1.5 0 0 1 3 0V3"/><path d="M7 7v3m0 0-1.5-1.5M7 10l1.5-1.5"/></svg>
 
 function MobileTerminalBar({
   canSend,
@@ -215,24 +222,20 @@ function MobileTerminalBar({
   altArmed,
   onMenu,
   onSend,
-  onPaste,
   onToggleCtrl,
   onToggleAlt,
   onCtrlConsumed,
   onAltConsumed,
-  onFocusTerminal,
 }: {
   canSend: boolean
   ctrlArmed: boolean
   altArmed: boolean
   onMenu: () => void
   onSend: (data: string) => void
-  onPaste: () => void
   onToggleCtrl: () => void
   onToggleAlt: () => void
   onCtrlConsumed: () => void
   onAltConsumed: () => void
-  onFocusTerminal: () => void
 }) {
   // Read signals directly; no props needed for these. The hamburger
   // badge surfaces only the waiting (unread) state — working/active are
@@ -243,120 +246,79 @@ function MobileTerminalBar({
   const waiting = waitingCount > 0
   const arrival = useArrivalPulse(waiting ? 'unread' : 'none', waitingCount)
 
+  // Don't steal focus from the terminal: a control tap leaves the
+  // keyboard exactly as it is (open or closed). Bytes reach the PTY via
+  // the raw input channel (onSend), independent of DOM focus, so every
+  // key works with the keyboard closed without ever opening it — which
+  // is the whole point of arrows/esc being reachable while navigating.
   const keepFocus = (ev: Event) => ev.preventDefault()
-  const tap = (seq: string) => { onSend(seq); onFocusTerminal() }
 
-  // Modifier-aware tap: the toolbar sends through the raw input channel
-  // (bypassing the arm logic in sendInput), so armed ctrl/alt must be
-  // applied here. Consumes whichever arms were actually encoded.
-  // Used by keys where an armed modifier should combine (send, ←/→);
-  // NOT used by the ↑/↓ layer buttons, whose entire purpose is plain
-  // arrow access while a modifier is armed.
-  const tapKey = (seq: string, ctrl = ctrlArmed, alt = altArmed): string => {
-    const r = applyArmedModifiers(seq, ctrl, alt)
+  // Modifier-aware send: the toolbar writes through the raw input
+  // channel (bypassing the arm logic in sendInput), so armed ctrl/alt
+  // are encoded here. Consumes whichever arms were actually applied.
+  // ctrl+esc / ctrl+↑ / alt+esc all encode correctly via CSI-u.
+  const sendKey = (seq: string) => {
+    const r = applyArmedModifiers(seq, ctrlArmed, altArmed)
     if (r.ctrlApplied && ctrlArmed) onCtrlConsumed()
     if (r.altApplied) onAltConsumed()
-    tap(r.seq)
-    return r.seq
+    onSend(r.seq)
   }
 
-  const [holdWordMode, setHoldWordMode] = useState(false)
-  const holdTimer1   = useRef<ReturnType<typeof setTimeout>  | null>(null)
-  const holdTimer2   = useRef<ReturnType<typeof setTimeout>  | null>(null)
-  const holdInterval = useRef<ReturnType<typeof setInterval> | null>(null)
-  const holdGen      = useRef(0)
-
-  const clearHold = () => {
-    holdGen.current++
-    if (holdTimer1.current)   { clearTimeout(holdTimer1.current);   holdTimer1.current   = null }
-    if (holdTimer2.current)   { clearTimeout(holdTimer2.current);   holdTimer2.current   = null }
-    if (holdInterval.current) { clearInterval(holdInterval.current); holdInterval.current = null }
-    setHoldWordMode(false)
+  // Word-jump is intrinsically ctrl+arrow. Force ctrl on so it works
+  // regardless of armed state, fold in an armed alt (→ ctrl+alt+arrow),
+  // and consume both arms so neither leaks to the next key.
+  const sendWord = (arrow: string) => {
+    const r = applyArmedModifiers(arrow, true, altArmed)
+    if (ctrlArmed) onCtrlConsumed()
+    if (r.altApplied) onAltConsumed()
+    onSend(r.seq)
   }
 
-  useEffect(() => () => clearHold(), [])
-
-  const startArrowHold = (arrowSeq: string, wordSeq: string) => {
-    const gen = holdGen.current
-    holdTimer1.current = setTimeout(() => {
-      if (holdGen.current !== gen) return
-      holdInterval.current = setInterval(() => tap(arrowSeq), 50)
-      holdTimer2.current = setTimeout(() => {
-        if (holdGen.current !== gen) return
-        clearInterval(holdInterval.current!)
-        holdInterval.current = null
-        setHoldWordMode(true)
-        tap(wordSeq)
-        holdInterval.current = setInterval(() => tap(wordSeq), 180)
-      }, 700)
-    }, 400)
-  }
-
-  const showCtrl = ctrlArmed || holdWordMode
+  // Static two-row grid, identical whether the keyboard is open or
+  // closed (no relabeling, no reflow). ☰ and send are double-height
+  // bookends; the inner 5×2 grid holds the keys with ↑/↓ stacked into a
+  // center D-pad column (← ↓ → across the bottom, word-jumps tucked into
+  // the top corners). ctrl/alt only arm + highlight — they never change
+  // another key's meaning.
+  const armedClass = (armed: boolean) => `mobile-bottom-action${armed ? ' armed' : ''}`
 
   return (
-    <div class="mobile-bottom-bar" aria-label="Mobile terminal controls">
+    <div class="mobile-bottom-bar" aria-label="Mobile terminal controls" onMouseDown={keepFocus}>
       <button
         class={`mobile-bottom-action menu-btn${waiting ? ' bg-waiting' : ''}${arrival ? ` bg-${arrival}` : ''}`}
-        onClick={onMenu}
+        onClick={() => {
+          // Dismiss the on-screen keyboard when opening the menu. keepFocus
+          // holds focus on the textarea through pointerdown, so it's still
+          // the active element here; blurring it slides the keyboard away.
+          (document.activeElement as HTMLElement | null)?.blur()
+          onMenu()
+        }}
         title="Open sessions"
       >
         ☰
       </button>
-      <div class="mobile-bottom-sep" />
-      <div class="mobile-terminal-actions" role="toolbar" aria-label="Terminal keys" onMouseDown={keepFocus}>
-        {(ctrlArmed || altArmed)
-          ? <button class="mobile-bottom-action" disabled={!canSend} onClick={() => tap('\x1b[A')} title="Up arrow"><IconUp /></button>
-          : <button class="mobile-bottom-action" disabled={!canSend} onClick={() => tap('\x1b')} title="Escape">esc</button>
-        }
-        {(ctrlArmed || altArmed)
-          ? <button class="mobile-bottom-action" disabled={!canSend} onClick={() => tap('\x1b[B')} title="Down arrow"><IconDown /></button>
-          : <button class="mobile-bottom-action" disabled={!canSend} onClick={() => tap('\t')} title="Tab">tab</button>
-        }
-        <button
-          class={`mobile-bottom-action ${showCtrl ? 'armed' : ''}`}
-          disabled={!canSend}
-          onClick={() => { if (holdWordMode) { clearHold(); } else { onToggleCtrl(); } onFocusTerminal() }}
-          title={showCtrl ? 'Ctrl armed for next typed key' : 'Arm Ctrl for next typed key'}
-          aria-pressed={showCtrl}
-        >
-          ctrl
-        </button>
-        <button
-          class={`mobile-bottom-action ${altArmed ? 'armed' : ''}`}
-          disabled={!canSend}
-          onClick={() => { onToggleAlt(); onFocusTerminal() }}
-          title={altArmed ? 'Alt armed for next typed key' : 'Arm Alt for next typed key'}
-          aria-pressed={altArmed}
-        >
-          alt
-        </button>
-        {([
-          { seq: '\x1b[D', wordSeq: '\x1b[1;5D', title: 'Left arrow',  wordTitle: 'Word left',  Icon: IconLeft,  WordIcon: IconWordLeft  },
-          { seq: '\x1b[C', wordSeq: '\x1b[1;5C', title: 'Right arrow', wordTitle: 'Word right', Icon: IconRight, WordIcon: IconWordRight },
-        ] as const).map(({ seq, wordSeq, title, wordTitle, Icon, WordIcon }) => (
-          <button
-            class="mobile-bottom-action"
-            disabled={!canSend}
-            onPointerDown={e => { e.currentTarget.setPointerCapture(e.pointerId); e.preventDefault(); const s = tapKey(seq, showCtrl, altArmed); startArrowHold(s, wordSeq) }}
-            onPointerUp={clearHold}
-            onPointerCancel={clearHold}
-            onContextMenu={e => e.preventDefault()}
-            title={showCtrl ? wordTitle : `${title} (hold to repeat)`}
-          >
-            {showCtrl ? <WordIcon /> : <Icon />}
-          </button>
-        ))}
-        {ctrlArmed
-          ? <button class="mobile-bottom-action" disabled={!canSend} onClick={() => { onPaste(); onFocusTerminal() }} title="Paste from clipboard"><IconPaste /></button>
-          : <button
-              class="mobile-bottom-action send-btn"
-              disabled={!canSend}
-              onClick={() => tapKey('\r')}
-              title={altArmed ? 'Send Alt+Enter' : 'Send'}
-            ><IconSend /></button>
-        }
+
+      <div class="mobile-key-grid" role="toolbar" aria-label="Terminal keys">
+        {/* Row 1 */}
+        <button class="mobile-bottom-action" disabled={!canSend} onClick={() => sendKey('\x1b')} title="Escape">esc</button>
+        <button class={armedClass(altArmed)} disabled={!canSend} aria-pressed={altArmed} onClick={onToggleAlt} title={altArmed ? 'Alt armed for next key' : 'Arm Alt'}>alt</button>
+        <button class="mobile-bottom-action" disabled={!canSend} onClick={() => sendWord('\x1b[D')} title="Word left"><IconWordLeft /></button>
+        <button class="mobile-bottom-action" disabled={!canSend} onClick={() => sendKey('\x1b[A')} title="Up arrow"><IconUp /></button>
+        <button class="mobile-bottom-action" disabled={!canSend} onClick={() => sendWord('\x1b[C')} title="Word right"><IconWordRight /></button>
+        {/* Row 2 */}
+        <button class="mobile-bottom-action" disabled={!canSend} onClick={() => sendKey('\t')} title="Tab">tab</button>
+        <button class={armedClass(ctrlArmed)} disabled={!canSend} aria-pressed={ctrlArmed} onClick={onToggleCtrl} title={ctrlArmed ? 'Ctrl armed for next key' : 'Arm Ctrl'}>ctrl</button>
+        <button class="mobile-bottom-action" disabled={!canSend} onClick={() => sendKey('\x1b[D')} title="Left arrow"><IconLeft /></button>
+        <button class="mobile-bottom-action" disabled={!canSend} onClick={() => sendKey('\x1b[B')} title="Down arrow"><IconDown /></button>
+        <button class="mobile-bottom-action" disabled={!canSend} onClick={() => sendKey('\x1b[C')} title="Right arrow"><IconRight /></button>
       </div>
+
+      <button
+        class="mobile-bottom-action send-btn"
+        disabled={!canSend}
+        onClick={() => sendKey('\r')}
+        title={altArmed ? 'Send Alt+Enter' : 'Send'}
+      ><IconSend /></button>
     </div>
   )
 }
@@ -371,18 +333,39 @@ function App() {
   useEffect(() => {
     const vv = window.visualViewport
     if (!vv) return
-    // On touch, the on-screen keyboard shrinks the visual viewport without
-    // shrinking the layout viewport (window.innerHeight) on iOS, so their
-    // difference is the occluded height. The URL bar moves both together,
-    // so it doesn't register — letting a small threshold detect the
-    // keyboard early in its slide. Detected via the viewport, not textarea
-    // focus, which lies (the resize path re-focuses after the keyboard
-    // closes). CSS decides whether a collapse actually applies.
-    const isTouchDevice = window.matchMedia('(pointer: coarse)').matches
-      || navigator.maxTouchPoints > 0
+    // Keyboard presence = occluded height = layout viewport (innerHeight)
+    // minus visual viewport (vv.height). This is only meaningful because
+    // the keyboard shrinks the *visual* viewport while the *layout*
+    // viewport stays full — which holds on:
+    //   - iOS Safari: always (it ignores interactive-widget but already
+    //     behaves this way).
+    //   - Chrome/Android >=108: because index.html sets the viewport meta
+    //     interactive-widget=resizes-visual. That meta is load-bearing
+    //     here; without it Chrome's default (resizes-content) shrinks the
+    //     layout viewport too, and the difference collapses to ~0.
+    // Browsers that ignore the meta and resize the layout viewport read
+    // ~0 and so never flip keyboardOpen — a deliberate fail-safe: the
+    // header just doesn't collapse, nothing breaks. (We don't support
+    // pre-108 Android beyond that.)
+    //
+    // Deliberately not the VirtualKeyboard API (navigator.virtualKeyboard):
+    // it's Chromium-only (no iOS Safari — our primary target — and no
+    // Firefox), and its boundingRect/geometrychange only report anything
+    // once overlaysContent=true, which stops the browser resizing the
+    // viewport and makes the keyboard overlay content instead. That would
+    // invert this entire vv-resize model for no gain: we need a boolean,
+    // not pixel geometry, and the continuous resize is already free here.
+    //
+    // The URL bar moves both viewports together, so it nets out and
+    // doesn't trip the threshold. Detected via the viewport, never
+    // textarea focus, which lies: the textarea can stay focused while the
+    // keyboard is dismissed (hardware keyboard, swipe-to-hide), and
+    // focus/blur don't track the keyboard's slide. CSS decides whether a
+    // collapse actually applies.
+    const touch = isTouchDevice()
     const update = () => {
       document.documentElement.style.setProperty('--app-height', `${vv.height}px`)
-      if (isTouchDevice) {
+      if (touch) {
         keyboardOpen.value = window.innerHeight - vv.height > KEYBOARD_PRESENCE_PX
       }
     }
@@ -488,7 +471,8 @@ function App() {
     setResumingId(null)
     setCtrlArmed(false)
     setAltArmed(false)
-    requestAnimationFrame(() => terminalFocusRef.current?.())
+    // Don't auto-open the keyboard on touch when switching sessions.
+    if (!isTouchDevice()) requestAnimationFrame(() => terminalFocusRef.current?.())
   }, [selId])
 
   // When a resumed session comes alive, navigate to it.
@@ -522,18 +506,18 @@ function App() {
   }, [])
   const handleTerminalFocusReady = useCallback((focus: (() => void) | null) => {
     terminalFocusRef.current = focus
-    focus?.()
+    // Auto-focus on mount only off-touch; on touch this would pop the
+    // on-screen keyboard the moment a session opens (surprising).
+    if (!isTouchDevice()) focus?.()
   }, [])
-  const handleFocusTerminal = useCallback(() => { terminalFocusRef.current?.() }, [])
   const handleMobileInput = useCallback((data: string) => { terminalInputRef.current?.(data) }, [])
+  // Paste capability is wired up (TerminalView reports its trigger here)
+  // but currently has no UI affordance on mobile: the toolbar paste
+  // button was removed in favor of a forthcoming long-press-to-paste on
+  // the terminal, which will call terminalPasteRef. Desktop paste still
+  // goes through the keyboard handler.
   const handleTerminalPasteReady = useCallback((paste: (() => void) | null) => {
     terminalPasteRef.current = paste
-  }, [])
-  // The trigger encapsulates clipboard read, binary detection, upload,
-  // and PTY emission. Mobile and desktop now share one paste code path,
-  // so binary clipboard items work from the toolbar button too.
-  const handleMobilePaste = useCallback(() => {
-    terminalPasteRef.current?.()
   }, [])
   const handleToggleCtrl = useCallback(() => {
     if (!canAttach) return
@@ -631,12 +615,10 @@ function App() {
           altArmed={altArmed}
           onMenu={() => setSidebarOpen(true)}
           onSend={handleMobileInput}
-          onPaste={handleMobilePaste}
           onToggleCtrl={handleToggleCtrl}
           onToggleAlt={handleToggleAlt}
           onCtrlConsumed={handleCtrlConsumed}
           onAltConsumed={handleAltConsumed}
-          onFocusTerminal={handleFocusTerminal}
         />
       </div>
     </div>

--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -23,7 +23,7 @@ import { installVersionWatch } from './version-watch'
 import {
   sessions, connState, selected, selectedId, view, health, peers,
   terminalOptions, keybinds, macCommandIsCtrl,
-  unreadCount, keyboardOpen,
+  unreadCount, keyboardOpen, terminalScrolledUp, terminalScrollToBottom,
   urlPath, urlSearch,
   initStore, setNavigate, navigateToSession,
   dismissSession, resumeSession, restartSession,
@@ -209,6 +209,7 @@ const IconRight = () => <svg viewBox="0 0 14 14" width="16" height="16" {...S}><
 const IconWordLeft  = () => <svg viewBox="0 0 18 14" width="20" height="16" {...S}><line x1="3.5" y1="3" x2="3.5" y2="11"/><path d="M13 7H6m0 0 3-3M6 7l3 3"/></svg>
 const IconWordRight = () => <svg viewBox="0 0 18 14" width="20" height="16" {...S}><line x1="14.5" y1="3" x2="14.5" y2="11"/><path d="M5 7h7m0 0-3-3m3 3-3 3"/></svg>
 const IconSend = () => <svg viewBox="0 0 14 14" width="16" height="16" fill="currentColor" stroke="none"><path d="M3 2.5l8 4.5-8 4.5V8.5L7.5 7 3 5.5z"/></svg>
+const IconEnd = () => <svg viewBox="0 0 14 14" width="16" height="16" {...S}><path d="M7 2v7m0 0-3-3m3 3 3-3"/><path d="M3.5 12h7"/></svg>
 
 // Press-and-hold auto-repeat for the navigation keys: fire once on press,
 // then after a short delay repeat until release. Arrows repeat briskly;
@@ -305,18 +306,18 @@ function MobileTerminalBar({
   // Arrows and word-jumps key-repeat on hold; the rest fire once per tap.
   const repeat = useAutoRepeat()
 
-  // Static two-row grid, identical whether the keyboard is open or
-  // closed (no relabeling, no reflow). ☰ and send are double-height
-  // bookends; the inner 5×2 grid holds the keys with ↑/↓ stacked into a
-  // center D-pad column (← ↓ → across the bottom, word-jumps tucked into
-  // the top corners). ctrl/alt only arm + highlight — they never change
-  // another key's meaning.
+  // The bar is a CSS grid laid out via named areas (.mk-* → grid-area), so the
+  // DOM order below is only tab/reading order — the visual arrangement lives
+  // in styles.css. Narrow phones get a 7×2 grid (empty top-left corner;
+  // scroll-end or empty top-right). Wider viewports (landscape / tablets)
+  // collapse to a single row, and the widest step folds the word-jumps back
+  // in. Keys never relabel; ctrl/alt only arm + highlight.
   const armedClass = (armed: boolean) => `mobile-bottom-action${armed ? ' armed' : ''}`
 
   return (
-    <div class="mobile-bottom-bar" aria-label="Mobile terminal controls" onMouseDown={keepFocus}>
+    <div class="mobile-bottom-bar" role="toolbar" aria-label="Terminal keys" onMouseDown={keepFocus}>
       <button
-        class={`mobile-bottom-action menu-btn${waiting ? ' bg-waiting' : ''}${arrival ? ` bg-${arrival}` : ''}`}
+        class={`mobile-bottom-action menu-btn mk-menu${waiting ? ' bg-waiting' : ''}${arrival ? ` bg-${arrival}` : ''}`}
         onClick={() => {
           // Dismiss the on-screen keyboard when opening the menu. keepFocus
           // holds focus on the textarea through pointerdown, so it's still
@@ -325,31 +326,21 @@ function MobileTerminalBar({
           onMenu()
         }}
         title="Open sessions"
-      >
-        ☰
-      </button>
-
-      <div class="mobile-key-grid" role="toolbar" aria-label="Terminal keys">
-        {/* Row 1 */}
-        <button class="mobile-bottom-action" disabled={!canSend} onClick={() => sendKey('\x1b')} title="Escape">esc</button>
-        <button class="mobile-bottom-action" disabled={!canSend} onClick={() => sendKey('\t')} title="Tab">tab</button>
-        <button class="mobile-bottom-action" disabled={!canSend} {...repeat(() => sendWord('\x1b[D'), WORD_REPEAT_MS)} title="Word left"><IconWordLeft /></button>
-        <button class="mobile-bottom-action" disabled={!canSend} {...repeat(() => sendKey('\x1b[A'), ARROW_REPEAT_MS)} title="Up arrow"><IconUp /></button>
-        <button class="mobile-bottom-action" disabled={!canSend} {...repeat(() => sendWord('\x1b[C'), WORD_REPEAT_MS)} title="Word right"><IconWordRight /></button>
-        {/* Row 2 */}
-        <button class={armedClass(ctrlArmed)} disabled={!canSend} aria-pressed={ctrlArmed} onClick={onToggleCtrl} title={ctrlArmed ? 'Ctrl armed for next key' : 'Arm Ctrl'}>ctrl</button>
-        <button class={armedClass(altArmed)} disabled={!canSend} aria-pressed={altArmed} onClick={onToggleAlt} title={altArmed ? 'Alt armed for next key' : 'Arm Alt'}>alt</button>
-        <button class="mobile-bottom-action" disabled={!canSend} {...repeat(() => sendKey('\x1b[D'), ARROW_REPEAT_MS)} title="Left arrow"><IconLeft /></button>
-        <button class="mobile-bottom-action" disabled={!canSend} {...repeat(() => sendKey('\x1b[B'), ARROW_REPEAT_MS)} title="Down arrow"><IconDown /></button>
-        <button class="mobile-bottom-action" disabled={!canSend} {...repeat(() => sendKey('\x1b[C'), ARROW_REPEAT_MS)} title="Right arrow"><IconRight /></button>
-      </div>
-
-      <button
-        class="mobile-bottom-action send-btn"
-        disabled={!canSend}
-        onClick={() => sendKey('\r')}
-        title={altArmed ? 'Send Alt+Enter' : 'Send'}
-      ><IconSend /></button>
+      ><span class="mkey-face">☰</span></button>
+      <button class="mobile-bottom-action mk-esc" disabled={!canSend} onClick={() => sendKey('\x1b')} title="Escape"><span class="mkey-face">esc</span></button>
+      <button class="mobile-bottom-action mk-tab" disabled={!canSend} onClick={() => sendKey('\t')} title="Tab"><span class="mkey-face">tab</span></button>
+      <button class={`${armedClass(ctrlArmed)} mk-ctrl`} disabled={!canSend} aria-pressed={ctrlArmed} onClick={onToggleCtrl} title={ctrlArmed ? 'Ctrl armed for next key' : 'Arm Ctrl'}><span class="mkey-face">ctrl</span></button>
+      <button class={`${armedClass(altArmed)} mk-alt`} disabled={!canSend} aria-pressed={altArmed} onClick={onToggleAlt} title={altArmed ? 'Alt armed for next key' : 'Arm Alt'}><span class="mkey-face">alt</span></button>
+      <button class="mobile-bottom-action mk-wl" disabled={!canSend} {...repeat(() => sendWord('\x1b[D'), WORD_REPEAT_MS)} title="Word left"><span class="mkey-face"><IconWordLeft /></span></button>
+      <button class="mobile-bottom-action mk-al" disabled={!canSend} {...repeat(() => sendKey('\x1b[D'), ARROW_REPEAT_MS)} title="Left arrow"><span class="mkey-face"><IconLeft /></span></button>
+      <button class="mobile-bottom-action mk-ad" disabled={!canSend} {...repeat(() => sendKey('\x1b[B'), ARROW_REPEAT_MS)} title="Down arrow"><span class="mkey-face"><IconDown /></span></button>
+      <button class="mobile-bottom-action mk-au" disabled={!canSend} {...repeat(() => sendKey('\x1b[A'), ARROW_REPEAT_MS)} title="Up arrow"><span class="mkey-face"><IconUp /></span></button>
+      <button class="mobile-bottom-action mk-ar" disabled={!canSend} {...repeat(() => sendKey('\x1b[C'), ARROW_REPEAT_MS)} title="Right arrow"><span class="mkey-face"><IconRight /></span></button>
+      <button class="mobile-bottom-action mk-wr" disabled={!canSend} {...repeat(() => sendWord('\x1b[C'), WORD_REPEAT_MS)} title="Word right"><span class="mkey-face"><IconWordRight /></span></button>
+      {terminalScrolledUp.value && (
+        <button class="mobile-bottom-action mk-end" onClick={() => terminalScrollToBottom.value?.()} title="Scroll to bottom"><span class="mkey-face"><IconEnd /></span></button>
+      )}
+      <button class="mobile-bottom-action send-btn mk-send" disabled={!canSend} onClick={() => sendKey('\r')} title={altArmed ? 'Send Alt+Enter' : 'Send'}><span class="mkey-face"><IconSend /></span></button>
     </div>
   )
 }
@@ -630,17 +621,19 @@ function App() {
           />
         )}
 
-        <MobileTerminalBar
-          canSend={canAttach}
-          ctrlArmed={ctrlArmed}
-          altArmed={altArmed}
-          onMenu={() => setSidebarOpen(true)}
-          onSend={handleMobileInput}
-          onToggleCtrl={handleToggleCtrl}
-          onToggleAlt={handleToggleAlt}
-          onCtrlConsumed={handleCtrlConsumed}
-          onAltConsumed={handleAltConsumed}
-        />
+        {selectedVal && (canAttach || USE_MOCK) && termOpts && keybindsVal && (
+          <MobileTerminalBar
+            canSend={canAttach}
+            ctrlArmed={ctrlArmed}
+            altArmed={altArmed}
+            onMenu={() => setSidebarOpen(true)}
+            onSend={handleMobileInput}
+            onToggleCtrl={handleToggleCtrl}
+            onToggleAlt={handleToggleAlt}
+            onCtrlConsumed={handleCtrlConsumed}
+            onAltConsumed={handleAltConsumed}
+          />
+        )}
       </div>
     </div>
   )

--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -5,6 +5,7 @@ import '@xterm/xterm/css/xterm.css'
 import './styles.css'
 
 import { applyArmedModifiers } from './keyboard'
+import { isTouchDevice } from './touch'
 import { ReplayView } from './replay-view'
 import { TerminalView } from './terminal'
 import { useArrivalPulse } from './use-arrival-pulse'
@@ -41,13 +42,6 @@ const USE_MOCK = import.meta.env.VITE_MOCK === '1' || location.search.includes('
  * above sub-pixel/URL-bar noise, yet above a hardware-keyboard accessory
  * bar (~44px on iPad) so that doesn't read as a soft keyboard. */
 const KEYBOARD_PRESENCE_PX = 60
-
-// On touch devices, focusing the terminal's hidden textarea pops the
-// on-screen keyboard. So auto-focus (session select, terminal mount) is
-// gated to non-touch — the keyboard opens only when the user taps the
-// terminal. Toolbar keys send via the raw input channel and never focus.
-const isTouchDevice = (): boolean =>
-  window.matchMedia?.('(pointer: coarse)').matches || navigator.maxTouchPoints > 0
 
 // Mock mode: hide close buttons and other interactive chrome via CSS.
 if (USE_MOCK) document.documentElement.classList.add('mock-mode')

--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -210,6 +210,40 @@ const IconWordLeft  = () => <svg viewBox="0 0 18 14" width="20" height="16" {...
 const IconWordRight = () => <svg viewBox="0 0 18 14" width="20" height="16" {...S}><line x1="14.5" y1="3" x2="14.5" y2="11"/><path d="M5 7h7m0 0-3-3m3 3-3 3"/></svg>
 const IconSend = () => <svg viewBox="0 0 14 14" width="16" height="16" fill="currentColor" stroke="none"><path d="M3 2.5l8 4.5-8 4.5V8.5L7.5 7 3 5.5z"/></svg>
 
+// Press-and-hold auto-repeat for the navigation keys: fire once on press,
+// then after a short delay repeat until release. Arrows repeat briskly;
+// word-jumps slower, since each hop covers a whole word and a fast rate
+// would overshoot. (No native key-repeat reaches these on-screen keys.)
+const REPEAT_DELAY_MS = 300
+const ARROW_REPEAT_MS = 70
+const WORD_REPEAT_MS = 250
+
+/** Returns a factory that builds the press-and-hold pointer handlers for a
+ * repeatable key. One timer pair total — only a single key is held at a
+ * time on touch — and any running timer is cleared on unmount. */
+function useAutoRepeat() {
+  const timers = useRef<{ delay?: number; interval?: number }>({})
+  const stop = useCallback(() => {
+    clearTimeout(timers.current.delay)
+    clearInterval(timers.current.interval)
+    timers.current = {}
+  }, [])
+  useEffect(() => stop, [stop])
+  return useCallback((fire: () => void, intervalMs: number) => ({
+    onPointerDown: (ev: Event) => {
+      ev.preventDefault() // act on press; no focus-steal or long-press callout
+      stop()              // defensive: never stack onto a lingering hold
+      fire()
+      timers.current.delay = window.setTimeout(() => {
+        timers.current.interval = window.setInterval(fire, intervalMs)
+      }, REPEAT_DELAY_MS)
+    },
+    onPointerUp: stop,
+    onPointerLeave: stop,
+    onPointerCancel: stop,
+  }), [stop])
+}
+
 function MobileTerminalBar({
   canSend,
   ctrlArmed,
@@ -268,6 +302,9 @@ function MobileTerminalBar({
     onSend(r.seq)
   }
 
+  // Arrows and word-jumps key-repeat on hold; the rest fire once per tap.
+  const repeat = useAutoRepeat()
+
   // Static two-row grid, identical whether the keyboard is open or
   // closed (no relabeling, no reflow). ☰ and send are double-height
   // bookends; the inner 5×2 grid holds the keys with ↑/↓ stacked into a
@@ -295,16 +332,16 @@ function MobileTerminalBar({
       <div class="mobile-key-grid" role="toolbar" aria-label="Terminal keys">
         {/* Row 1 */}
         <button class="mobile-bottom-action" disabled={!canSend} onClick={() => sendKey('\x1b')} title="Escape">esc</button>
-        <button class={armedClass(altArmed)} disabled={!canSend} aria-pressed={altArmed} onClick={onToggleAlt} title={altArmed ? 'Alt armed for next key' : 'Arm Alt'}>alt</button>
-        <button class="mobile-bottom-action" disabled={!canSend} onClick={() => sendWord('\x1b[D')} title="Word left"><IconWordLeft /></button>
-        <button class="mobile-bottom-action" disabled={!canSend} onClick={() => sendKey('\x1b[A')} title="Up arrow"><IconUp /></button>
-        <button class="mobile-bottom-action" disabled={!canSend} onClick={() => sendWord('\x1b[C')} title="Word right"><IconWordRight /></button>
-        {/* Row 2 */}
         <button class="mobile-bottom-action" disabled={!canSend} onClick={() => sendKey('\t')} title="Tab">tab</button>
+        <button class="mobile-bottom-action" disabled={!canSend} {...repeat(() => sendWord('\x1b[D'), WORD_REPEAT_MS)} title="Word left"><IconWordLeft /></button>
+        <button class="mobile-bottom-action" disabled={!canSend} {...repeat(() => sendKey('\x1b[A'), ARROW_REPEAT_MS)} title="Up arrow"><IconUp /></button>
+        <button class="mobile-bottom-action" disabled={!canSend} {...repeat(() => sendWord('\x1b[C'), WORD_REPEAT_MS)} title="Word right"><IconWordRight /></button>
+        {/* Row 2 */}
         <button class={armedClass(ctrlArmed)} disabled={!canSend} aria-pressed={ctrlArmed} onClick={onToggleCtrl} title={ctrlArmed ? 'Ctrl armed for next key' : 'Arm Ctrl'}>ctrl</button>
-        <button class="mobile-bottom-action" disabled={!canSend} onClick={() => sendKey('\x1b[D')} title="Left arrow"><IconLeft /></button>
-        <button class="mobile-bottom-action" disabled={!canSend} onClick={() => sendKey('\x1b[B')} title="Down arrow"><IconDown /></button>
-        <button class="mobile-bottom-action" disabled={!canSend} onClick={() => sendKey('\x1b[C')} title="Right arrow"><IconRight /></button>
+        <button class={armedClass(altArmed)} disabled={!canSend} aria-pressed={altArmed} onClick={onToggleAlt} title={altArmed ? 'Alt armed for next key' : 'Arm Alt'}>alt</button>
+        <button class="mobile-bottom-action" disabled={!canSend} {...repeat(() => sendKey('\x1b[D'), ARROW_REPEAT_MS)} title="Left arrow"><IconLeft /></button>
+        <button class="mobile-bottom-action" disabled={!canSend} {...repeat(() => sendKey('\x1b[B'), ARROW_REPEAT_MS)} title="Down arrow"><IconDown /></button>
+        <button class="mobile-bottom-action" disabled={!canSend} {...repeat(() => sendKey('\x1b[C'), ARROW_REPEAT_MS)} title="Right arrow"><IconRight /></button>
       </div>
 
       <button

--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -436,7 +436,6 @@ function App() {
 
   const terminalInputRef = useRef<((data: string) => void) | null>(null)
   const terminalFocusRef = useRef<(() => void) | null>(null)
-  const terminalPasteRef = useRef<(() => void) | null>(null)
 
   // Read signals.
   const viewVal = view.value
@@ -511,14 +510,6 @@ function App() {
     if (!isTouchDevice()) focus?.()
   }, [])
   const handleMobileInput = useCallback((data: string) => { terminalInputRef.current?.(data) }, [])
-  // Paste capability is wired up (TerminalView reports its trigger here)
-  // but currently has no UI affordance on mobile: the toolbar paste
-  // button was removed in favor of a forthcoming long-press-to-paste on
-  // the terminal, which will call terminalPasteRef. Desktop paste still
-  // goes through the keyboard handler.
-  const handleTerminalPasteReady = useCallback((paste: (() => void) | null) => {
-    terminalPasteRef.current = paste
-  }, [])
   const handleToggleCtrl = useCallback(() => {
     if (!canAttach) return
     setCtrlArmed(armed => !armed)
@@ -587,7 +578,6 @@ function App() {
             altArmed={altArmed}
             onAltConsumed={handleAltConsumed}
             onInputReady={handleTerminalInputReady}
-            onPasteReady={handleTerminalPasteReady}
             onFocusReady={handleTerminalFocusReady}
           />
         ) : selectedVal && !selectedVal.alive && termOpts && !USE_MOCK ? (

--- a/apps/gmux-web/src/sheet.tsx
+++ b/apps/gmux-web/src/sheet.tsx
@@ -1,0 +1,141 @@
+/**
+ * Shared primitives for the terminal long-press sheets (link + text):
+ * {@link SheetBackdrop} and {@link SheetButton}. One place for the portal,
+ * keyboard, dismissal, and button styling all the sheets depend on.
+ *
+ * SheetBackdrop does three things every long-press sheet needs:
+ *
+ * 1. Portaled to <body>. Rendered in place, a sheet is a descendant of
+ *    `.terminal-shell`, whose capture-phase touch handlers (pan + the
+ *    long-press recognizer) then intercept every touch on it — a
+ *    press-hold to select text re-fires long-press instead, and native
+ *    selection never receives the touch. The portal moves the sheet out
+ *    of that subtree so touches reach its content directly, and frees it
+ *    from the shell's stacking context so it paints above the header and
+ *    toolbar.
+ *
+ * 2. Constrained to the visible viewport via `--app-height` (the CSS lives
+ *    on `.action-sheet-backdrop`). With the soft keyboard open the layout
+ *    viewport still spans the full window behind the keyboard, so a plain
+ *    inset:0 backdrop would centre the panel too low (partly occluded).
+ *
+ * 3. Dismiss on click, deferred a macrotask. click fires *after* the
+ *    dismissing touch ends, so unmounting the sheet there can't tear down
+ *    the terminal's iOS momentum-scroll layer mid-gesture. That mid-gesture
+ *    teardown is exactly what killed inertial scrolling — the terminal
+ *    coasts on a GPU layer that iOS drops if the DOM is torn down while the
+ *    touch is live — when these dismissed on pointerup (pointerup fires
+ *    while the touch is still in flight). We briefly used pointerup to
+ *    catch a "quick tap right after the long-press" whose click got
+ *    swallowed — but that swallowing turned out to be Orion-on-iOS
+ *    specific; Safari/WebKit fire the click reliably, so we don't carry
+ *    that workaround. The dismissal still runs through
+ *    {@link dismissAfterGesture} (a setTimeout 0) as cheap insurance that
+ *    the unmount always lands after the touch fully settles. SheetButton,
+ *    by contrast, runs its *action* inline (synchronously): clipboard
+ *    writes/reads and window.open must stay in the gesture task for WebKit
+ *    to honour them (see {@link dismissAfterGesture}). The long-press
+ *    recognizer is touch-gated, so
+ *    the sheets only exist on touch devices; no keyboard-activation path to
+ *    lose.
+ *
+ * Opening a sheet also closes the on-screen keyboard (see effect below).
+ *
+ * The panel (with its role/aria-label) is passed as children.
+ */
+import type { ComponentChildren } from 'preact'
+import { useEffect, useState } from 'preact/hooks'
+import { createPortal } from 'preact/compat'
+
+/**
+ * Defer a sheet's *dismissal* (the DOM unmount) to the next macrotask
+ * rather than running it inline in the click handler. click already fires
+ * after the touch ends, so this is belt-and-suspenders: it guarantees the
+ * sheet's DOM is removed only once the gesture has fully settled, so
+ * removing it can never tear down the terminal's iOS momentum-scroll layer
+ * mid-gesture — the regression we hit when these dismissed on pointerup.
+ * Cheap to keep; see point 3 in the file header.
+ *
+ * Only the *dismissal* is deferred, never the action. Clipboard writes/reads
+ * and window.open must run synchronously inside the click task: WebKit/Safari
+ * ties them to the live user gesture and does not honour the spec's
+ * "transient activation survives a task" model for them, so a setTimeout(0)
+ * gets the write/open rejected or the popup blocked. SheetButton runs its
+ * onActivate inline for that reason.
+ */
+function dismissAfterGesture(fn: () => void): void {
+  setTimeout(fn, 0)
+}
+
+export function SheetBackdrop({ onClose, children }: {
+  onClose: () => void
+  children: ComponentChildren
+}) {
+  // Close the keyboard when a sheet opens by blurring the terminal's
+  // focused hidden textarea. While it holds focus iOS locks selection to
+  // it — you can't select the sheet's text — and draws its insertion caret
+  // over everything; blurring releases both. You don't need the keyboard
+  // to copy/paste, and dropping it gives the sheet more room.
+  useEffect(() => {
+    (document.activeElement as HTMLElement | null)?.blur()
+  }, [])
+
+  return createPortal(
+    <div
+      class="modal-backdrop action-sheet-backdrop"
+      onClick={ev => {
+        ev.stopPropagation()
+        if (ev.target === ev.currentTarget) dismissAfterGesture(onClose)
+      }}
+    >
+      {children}
+    </div>,
+    document.body,
+  )
+}
+
+/** A button inside a sheet. `primary` gives it the accent fill; `quiet`
+ * the de-emphasised treatment for a dismiss (Close) that sits apart from
+ * the real actions. Runs onActivate synchronously on click so gesture-gated
+ * actions (clipboard, window.open) keep their user activation on WebKit —
+ * see {@link dismissAfterGesture}. */
+export function SheetButton({ primary = false, quiet = false, onActivate, children }: {
+  primary?: boolean
+  quiet?: boolean
+  onActivate: () => void
+  children: ComponentChildren
+}) {
+  return (
+    <button
+      type="button"
+      class={`sheet-btn${primary ? ' sheet-btn-primary' : ''}${quiet ? ' sheet-btn-quiet' : ''}`}
+      onClick={ev => { ev.stopPropagation(); onActivate() }}
+    >
+      {children}
+    </button>
+  )
+}
+
+type CopyState = 'idle' | 'copied' | 'failed'
+
+/** A {@link SheetButton} that copies `text` to the clipboard and shows
+ * inline feedback in place of `label`. Deliberately does NOT dismiss: a
+ * copy is often mid-task, and an auto-close timer is an unwinnable guess
+ * (a toast will confirm + close on its own once that lands). Centralises
+ * the copy-with-feedback both the link and text sheets need. */
+export function CopyButton({ label, text }: { label: string; text: string }) {
+  const [state, setState] = useState<CopyState>('idle')
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(text)
+      setState('copied')
+    } catch {
+      setState('failed')
+    }
+  }
+  return (
+    <SheetButton onActivate={copy}>
+      {state === 'idle' ? label : state === 'copied' ? 'Copied ✓' : 'Copy failed'}
+    </SheetButton>
+  )
+}

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -370,10 +370,16 @@ export const macCommandIsCtrl = signal(false)
 
 /**
  * True while the on-screen keyboard is open, detected via visual-viewport
- * occlusion on touch devices (window.innerHeight - visualViewport.height
- * exceeds a threshold). Drives keyboard-aware layout (e.g. collapsing the
- * header on phones to reclaim rows). Set by App's viewport effect; CSS
- * decides whether/when a collapse actually applies.
+ * occlusion on touch devices: layout viewport (window.innerHeight) minus
+ * visual viewport (visualViewport.height) above a threshold. Relies on the
+ * keyboard shrinking only the visual viewport while the layout viewport
+ * stays full — guaranteed on iOS Safari and, via the
+ * interactive-widget=resizes-visual viewport meta, Chrome >=108. Browsers
+ * that resize the layout viewport instead read ~0 and leave this false
+ * (fail-safe: no header collapse). Drives keyboard-aware layout (e.g.
+ * collapsing the header on phones to reclaim rows). Set by App's viewport
+ * effect; CSS decides whether/when a collapse actually applies. See the
+ * detection comment in main.tsx for the full cross-device matrix.
  */
 export const keyboardOpen = signal(false)
 

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -383,6 +383,15 @@ export const macCommandIsCtrl = signal(false)
  */
 export const keyboardOpen = signal(false)
 
+/** True while the terminal viewport is scrolled up from the bottom (past a
+ * small threshold). Lets a scroll-to-end control live outside the terminal
+ * (the mobile toolbar) and stay in sync, without threading state through App. */
+export const terminalScrolledUp = signal(false)
+
+/** Scroll-to-bottom handle for the live terminal, or null when none is
+ * mounted. Set by TerminalView, invoked by the toolbar's end key. */
+export const terminalScrollToBottom = signal<(() => void) | null>(null)
+
 /** Current URL path, kept in sync with preact-iso's location. */
 export const urlPath = signal(
   typeof location !== 'undefined' ? (location.pathname.replace(/\/+$/, '') || '/') : '/',

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -1793,7 +1793,7 @@ body {
   min-height: 0;
   position: relative;
   overflow: auto;
-  background: #0f141a;
+  background: var(--terminal-bg, #0f141a);
   overscroll-behavior: contain;
 }
 
@@ -1806,7 +1806,7 @@ body {
   min-height: 100%;
   position: relative;
   overflow: visible;
-  background: #0f141a;
+  background: var(--terminal-bg, #0f141a);
 }
 
 /* Zero-height sticky anchor: sticks to the top of .terminal-shell's scroll
@@ -2309,13 +2309,13 @@ body {
     background: transparent;
   }
   .terminal-container .xterm-screen {
-    background: #0f141a;
+    background: var(--terminal-bg, #0f141a);
   }
   /* Background-coloured drop shadow on the viewport (the grid's visible
      box), bleeding past its edges to mask the key borders into the terminal
      exactly at the content edge. */
   .terminal-container .xterm-viewport {
-    box-shadow: 0 0 16px 16px #0f141a;
+    box-shadow: 0 0 16px 16px var(--terminal-bg, #0f141a);
   }
 
   /* The floating scroll-to-end pill is desktop-only; on touch the toolbar's

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -2231,29 +2231,36 @@ body {
     width: 100%;
   }
 
+  /* Two-row control bar: ☰ and send are double-height bookends flanking
+     a 5×2 key grid. Same layout regardless of keyboard state. The bar
+     takes real layout height (pushes the terminal up); reclaiming that
+     space via overlay/translucency is a deliberate later iteration. */
   .mobile-bottom-bar {
     display: flex;
-    align-items: center;
+    align-items: stretch;
     gap: 6px;
-    min-height: 52px;
     padding: 6px 8px calc(6px + env(safe-area-inset-bottom));
     border-top: 1px solid var(--border);
     background: var(--bg-sidebar);
     flex-shrink: 0;
   }
 
-  .mobile-bottom-sep {
-    width: 1px;
-    height: 24px;
-    background: var(--border);
-    flex-shrink: 0;
+  /* Bookends: fixed width, normal height, sitting on the bottom row
+     (the top corners above them stay empty). */
+  .mobile-bottom-bar > .mobile-bottom-action {
+    flex: 0 0 auto;
+    width: 52px;
+    height: 40px;
+    align-self: flex-end;
   }
 
-  .mobile-terminal-actions {
-    display: flex;
-    gap: 6px;
+  .mobile-key-grid {
+    flex: 1 1 0;
     min-width: 0;
-    flex: 1;
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    grid-auto-rows: 40px;
+    gap: 6px;
   }
 
   .mobile-bottom-action {
@@ -2263,9 +2270,8 @@ body {
     color: oklch(76% 0.012 250);
     border-radius: 6px;
     min-height: 40px;
-    min-width: 36px;
-    padding: 0 10px;
-    flex: 0 0 auto;
+    min-width: 0;
+    padding: 0 8px;
     font-family: 'Source Sans 3', sans-serif;
     font-size: 13px;
     font-weight: 600;
@@ -2275,6 +2281,12 @@ body {
     touch-action: manipulation;
     transition: background 0.1s, border-color 0.1s, color 0.1s;
     position: relative;
+  }
+
+  /* Grid cells take their height from the grid track, not min-height. */
+  .mobile-key-grid .mobile-bottom-action {
+    min-height: 0;
+    padding: 0 4px;
   }
 
   /* Waiting dot on the hamburger menu button. Only the waiting (unread)
@@ -2298,11 +2310,6 @@ body {
   /* Re-blink when a new session enters the waiting state */
   .mobile-bottom-action.menu-btn.bg-arriving::after {
     animation: dot-arrival 520ms cubic-bezier(0.25, 1, 0.5, 1) both;
-  }
-
-  .mobile-terminal-actions .mobile-bottom-action {
-    flex: 1 1 0;
-    min-width: 0;
   }
 
   .mobile-bottom-action:active {

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -1795,7 +1795,6 @@ body {
   overflow: auto;
   background: #0f141a;
   overscroll-behavior: contain;
-  -webkit-overflow-scrolling: touch;
 }
 
 .terminal-shell-passive {
@@ -2756,6 +2755,50 @@ body {
    menu rather than a dialog. The preview intentionally shows the full
    URI (word-broken, scrollable past ~6 lines) — for OSC 8 hyperlinks
    this is the only place the real target is visible before opening. */
+/* Shared button for the long-press sheets (link + text). Default is a
+   surface-filled button; .sheet-btn-primary gets the accent fill. */
+.sheet-btn {
+  appearance: none;
+  border: 1px solid var(--border-strong);
+  background: var(--bg-surface);
+  color: var(--text);
+  font-family: 'Source Sans 3', sans-serif;
+  font-size: 14px;
+  font-weight: 600;
+  padding: 11px 12px;
+  border-radius: 8px;
+  text-align: center;
+  cursor: pointer;
+  transition: background 0.12s, border-color 0.12s;
+}
+
+.sheet-btn:active {
+  background: var(--bg-hover);
+}
+
+.sheet-btn-primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: oklch(13% 0.015 250);
+}
+
+.sheet-btn-primary:active {
+  background: oklch(66% 0.1 195);
+}
+
+/* Quiet dismiss (Close): set apart from the real actions — no fill, a
+   hairline border (lighter than their --border-strong), muted text — so
+   it reads as a real button but not a third equal choice. */
+.sheet-btn-quiet {
+  background: transparent;
+  border-color: var(--border);
+  color: var(--text-muted);
+}
+
+.sheet-btn-quiet:active {
+  background: var(--bg-hover);
+}
+
 .link-sheet {
   width: 320px;
   padding: 6px;
@@ -2784,20 +2827,66 @@ body {
   overflow-y: auto;
 }
 
-.link-sheet-action {
-  appearance: none;
-  border: none;
-  background: transparent;
-  color: var(--text);
-  text-align: left;
-  font-size: 14px;
-  font-family: inherit;
-  padding: 12px 12px;
-  border-radius: 8px;
-  cursor: pointer;
+.link-sheet-actions {
+  display: flex;
+  gap: 8px;
+  padding: 4px;
 }
 
-.link-sheet-action:hover,
-.link-sheet-action:active {
-  background: var(--bg-hover);
+.link-sheet-actions .sheet-btn {
+  flex: 1;
+}
+
+/* Text-sheet backdrop is constrained to the visible viewport (var set by
+   App's viewport effect), not the layout viewport: with the soft keyboard
+   open the layout viewport still spans the full window behind the
+   keyboard, so a plain inset:0 backdrop would centre the panel too low
+   (partly behind the keyboard). */
+.action-sheet-backdrop {
+  bottom: auto;
+  height: var(--app-height, 100dvh);
+}
+
+/* Text sheet: the terminal buffer as natively-selectable text, scrolled
+   to the long-pressed row, with Paste pinned below. Tall and wide so it
+   reads like a text view rather than a menu. */
+.text-sheet {
+  width: 560px;
+  /* Near full width: a full-width terminal line (13px cells) fits without
+     horizontal scroll at the sheet's 12px font, while wider content still
+     scrolls. Capped height leaves backdrop above/below to tap-dismiss. */
+  max-width: calc(100vw - 12px);
+  height: min(640px, calc(var(--app-height, 100vh) - 120px));
+  padding: 0;
+}
+
+.text-sheet-body {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  padding: 10px 8px;
+}
+
+.text-sheet-pre {
+  margin: 0;
+  font-family: var(--font-mono, monospace);
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--text);
+  white-space: pre;
+  /* The whole point: the app shell sets user-select:none on chrome, so
+     re-enable native selection here. */
+  user-select: text;
+  -webkit-user-select: text;
+}
+
+.text-sheet-footer {
+  border-top: 1px solid var(--border);
+  padding: 8px;
+  display: flex;
+  gap: 8px;
+}
+
+.text-sheet-footer .sheet-btn {
+  flex: 1;
 }

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -2228,45 +2228,112 @@ body {
 
   .main-panel {
     width: 100%;
+    /* Stacking-context root for the key layering: key borders (z:1) <
+       terminal (z:2) < glyphs + feedback (z:3). Also anchors the overlaid
+       control bar. */
+    position: relative;
+    z-index: 0;
   }
 
-  /* Two-row control bar: ☰ and send are double-height bookends flanking
-     a 5×2 key grid. Same layout regardless of keyboard state. The bar
-     takes real layout height (pushes the terminal up); reclaiming that
-     space via overlay/translucency is a deliberate later iteration. */
+  /* Control bar floating over the bottom of the terminal (out of flow,
+     transparent container) so the terminal can slide one rounded-up row in
+     behind the translucent keys instead of stopping short above an opaque
+     strip — see the ceil/reserve path in measureTerminalFit. Keys are placed
+     by named grid-area (.mk-*); the layout (incl. the single-row landscape /
+     tablet steps further down) is purely a matter of redefining the template,
+     never the DOM. */
   .mobile-bottom-bar {
-    display: flex;
-    align-items: stretch;
-    gap: 6px;
-    padding: 6px 8px calc(6px + env(safe-area-inset-bottom));
-    border-top: 1px solid var(--border);
-    background: var(--bg-sidebar);
-    flex-shrink: 0;
-  }
-
-  /* Bookends: fixed width, normal height, sitting on the bottom row
-     (the top corners above them stay empty). */
-  .mobile-bottom-bar > .mobile-bottom-action {
-    flex: 0 0 auto;
-    width: 52px;
-    height: 40px;
-    align-self: flex-end;
-  }
-
-  .mobile-key-grid {
-    flex: 1 1 0;
-    min-width: 0;
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    /* Phones: 7-column × 2-row grid. The empty top-left corner and the
+       scroll-end / empty top-right simply fall out of the template (no
+       placeholder elements needed). */
     display: grid;
-    grid-template-columns: repeat(5, 1fr);
-    grid-auto-rows: 40px;
-    gap: 6px;
+    grid-template-columns: repeat(7, 1fr);
+    grid-template-rows: repeat(2, 40px);
+    grid-template-areas:
+      '.    esc  tab  wl  au  wr  end'
+      'menu ctrl alt  al  ad  ar  send';
+    /* One knob for spacing: the visual gap between keys. Hitboxes bridge it
+       automatically (each .mkey-face extends half of it), so there are no
+       dead gaps between buttons no matter what you set this to. */
+    --key-gap: 5px;
+    gap: var(--key-gap);
+    padding: 0 4px calc(4px + env(safe-area-inset-bottom));
+    background: transparent;
+    /* No z-index: the bar must NOT form a stacking context, so its keys'
+       borders (z:1) and glyphs (z:3) can sit on either side of the
+       terminal (z:2) in .main-panel's context. */
+  }
+
+  /* Key → grid-area map. The same names are reused by every breakpoint, so
+     only the template (above / below) changes between layouts. */
+  .mk-menu { grid-area: menu; }
+  .mk-esc  { grid-area: esc; }
+  .mk-tab  { grid-area: tab; }
+  .mk-ctrl { grid-area: ctrl; }
+  .mk-alt  { grid-area: alt; }
+  .mk-wl   { grid-area: wl; }
+  .mk-wr   { grid-area: wr; }
+  .mk-al   { grid-area: al; }
+  .mk-ad   { grid-area: ad; }
+  .mk-au   { grid-area: au; }
+  .mk-ar   { grid-area: ar; }
+  .mk-end  { grid-area: end; }
+  .mk-send { grid-area: send; }
+
+  /* No bottom padding under the grid: the control bar overlays it, so the
+     reclaimed terminal row can run right to the bottom edge. */
+  .terminal-container .xterm {
+    padding-bottom: 0;
+  }
+
+  /* Middle layer. The shell/container go transparent and the opaque fill
+     moves onto the grid itself (.xterm-screen), so the terminal's painted
+     area ends exactly at the content's bottom edge — wherever the row math
+     lands it. A background-coloured drop shadow extends just below that
+     edge, masking the key borders into the terminal as it overlaps them. */
+  .terminal-shell {
+    z-index: 2;
+    background: transparent;
+    /* No OS text-selection / callout on long-press of the dead strip that
+       slides under the toolbar. Real text selection on touch goes through
+       the long-press text sheet, not native grid selection. */
+    user-select: none;
+    -webkit-user-select: none;
+    -webkit-touch-callout: none;
+  }
+  .terminal-container {
+    background: transparent;
+  }
+  .terminal-container .xterm-screen {
+    background: #0f141a;
+  }
+  /* Background-coloured drop shadow on the viewport (the grid's visible
+     box), bleeding past its edges to mask the key borders into the terminal
+     exactly at the content edge. */
+  .terminal-container .xterm-viewport {
+    box-shadow: 0 0 16px 16px #0f141a;
+  }
+
+  /* The floating scroll-to-end pill is desktop-only; on touch the toolbar's
+     top-right key takes over. */
+  .terminal-scroll-end {
+    display: none;
   }
 
   .mobile-bottom-action {
+    /* Just a layout/hit box. Visuals split across two layers: the border
+       (::before, z:1) sits UNDER the terminal so it's hidden where the
+       terminal overlaps and visible below it; the glyph + feedback
+       (.mkey-face, z:3) sit ON TOP of the terminal, always crisp. The
+       button itself must create no stacking context (no filter/opacity/
+       z-index) or it would trap both layers together. */
     appearance: none;
-    border: 1px solid var(--border-strong);
-    background: var(--bg-surface);
-    color: oklch(76% 0.012 250);
+    border: none;
+    background: transparent;
     border-radius: 6px;
     min-height: 40px;
     min-width: 0;
@@ -2278,12 +2345,61 @@ body {
     align-items: center;
     justify-content: center;
     touch-action: manipulation;
-    transition: background 0.1s, border-color 0.1s, color 0.1s;
+    /* Suppress the OS long-press text-selection / callout on keys held down
+       (e.g. scroll-to-end or an arrow on auto-repeat). */
+    user-select: none;
+    -webkit-user-select: none;
+    -webkit-touch-callout: none;
+    -webkit-tap-highlight-color: transparent;
     position: relative;
   }
 
-  /* Grid cells take their height from the grid track, not min-height. */
-  .mobile-key-grid .mobile-bottom-action {
+  /* Bottom layer: the key border outline. (Background omitted for now —
+     this is where a key fill would go.) */
+  .mobile-bottom-action::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+    border-radius: inherit;
+    border: 1px solid oklch(from var(--border-strong) l c h / 0.65);
+    pointer-events: none;
+  }
+
+  /* Top layer: glyph + press/armed feedback, lifted above the terminal. */
+  .mkey-face {
+    position: absolute;
+    /* Extend the hit area by half the gap on every side so neighbouring
+       faces meet edge-to-edge (the CSS equivalent of hitSlop). The glyph
+       stays centred and the visual border (::before) keeps the cell's
+       true bounds, so only the tappable area grows. */
+    inset: calc(var(--key-gap) / -2);
+    z-index: 3;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: inherit;
+    color: oklch(88% 0.012 250);
+    /* --bg-coloured outline so a glyph stays legible where it overlaps
+       terminal text. Built purely from stacked drop-shadows (not
+       text-stroke) so text and SVG icons get the *same* treatment —
+       text-stroke would only affect the text. More stacks = heavier. */
+    filter:
+      drop-shadow(0 0 0.75px var(--bg))
+      drop-shadow(0 0 0.75px var(--bg))
+      drop-shadow(0 0 0.75px var(--bg))
+      drop-shadow(0 0 0.75px var(--bg))
+      drop-shadow(0 0 0.75px var(--bg));
+    /* Must catch taps: this layer sits above the terminal (z:3), whereas the
+       <button> itself is below it (z:auto, so the border can sit at z:1).
+       With pointer-events:none the tap fell through to the terminal-shell;
+       auto makes this layer the hit target and the event bubbles to the
+       button. (On-device this was masked by iOS touch-target fuzzing.) */
+    pointer-events: auto;
+  }
+
+  /* Cells take their height from the grid track, not min-height. */
+  .mobile-bottom-bar .mobile-bottom-action {
     min-height: 0;
     padding: 0 4px;
   }
@@ -2300,6 +2416,7 @@ body {
     border-radius: 50%;
     top: -3px;
     right: -3px;
+    z-index: 3;
     pointer-events: none;
     background: var(--unread);
     /* Ring in the page background so the dot reads cleanly against the button border */
@@ -2311,21 +2428,42 @@ body {
     animation: dot-arrival 520ms cubic-bezier(0.25, 1, 0.5, 1) both;
   }
 
-  .mobile-bottom-action:active {
-    background: var(--bg-hover);
+  /* Press feedback rides the top layer and snaps in/out (no transition):
+     ring the key in the accent with a soft glow — strong but tasteful. */
+  /* Feedback fill/ring is confined to the cell's true bounds (cancelling
+     the hit area's negative inset) so it never spills into the gap — only
+     the tappable area grew, not the visuals. */
+  .mobile-bottom-action:active .mkey-face::before,
+  .mobile-bottom-action.armed .mkey-face::before {
+    content: '';
+    position: absolute;
+    inset: calc(var(--key-gap) / 2);
+    border-radius: inherit;
+    pointer-events: none;
+  }
+  .mobile-bottom-action:active .mkey-face {
+    color: var(--text);
+  }
+  .mobile-bottom-action:active .mkey-face::before {
+    background: color-mix(in oklch, var(--accent) 18%, transparent);
+    box-shadow:
+      0 0 0 1px var(--accent),
+      0 0 12px 1px oklch(from var(--accent) l c h / 0.55);
   }
 
   .mobile-bottom-action:disabled {
     opacity: 0.35;
   }
 
-  .mobile-bottom-action.armed {
-    background: color-mix(in oklch, var(--accent) 20%, var(--bg-surface));
-    border-color: var(--accent);
+  .mobile-bottom-action.armed .mkey-face {
     color: var(--text);
   }
+  .mobile-bottom-action.armed .mkey-face::before {
+    background: color-mix(in oklch, var(--accent) 20%, transparent);
+    box-shadow: inset 0 0 0 1px var(--accent);
+  }
 
-  .mobile-bottom-action.send-btn {
+  .mobile-bottom-action.send-btn .mkey-face {
     color: var(--accent);
   }
 
@@ -2889,4 +3027,51 @@ body {
 
 .text-sheet-footer .sheet-btn {
   flex: 1;
+}
+
+/* ── Wide control bar: single-row layouts ───────────────────────────────
+   Landscape phones and tablets are wide enough to lay the whole key set in
+   one row, reclaiming a terminal row. Placed after the base coarse block so
+   these win; both thresholds are placeholders to fine-tune. Keys are moved
+   purely by re-stating grid-template-areas (see .mk-* map). */
+
+/* Single row, word-jumps dropped. */
+@media (pointer: coarse) and (min-width: 600px) {
+  .mobile-bottom-bar {
+    grid-template-columns: repeat(10, 1fr);
+    grid-template-rows: 40px;
+    grid-template-areas: 'menu esc tab ctrl alt al ad au ar send';
+  }
+  /* Word-jumps aren't part of the single-row layout. */
+  .mk-wl,
+  .mk-wr {
+    display: none;
+  }
+  /* Scroll-end floats above the top-right of the row instead of taking a
+     column. Unlike the in-row keys (which the terminal slides under), it
+     sits fully above the terminal with its own fill + border at z:3. */
+  .mk-end {
+    position: absolute;
+    grid-area: auto;
+    right: 6px;
+    bottom: calc(100% + 8px);
+    z-index: 3;
+    width: 46px;
+    height: 34px;
+    min-height: 0;
+    border-radius: 8px;
+    background: var(--bg-surface);
+  }
+}
+
+/* Wider still: fold the word-jumps back in, flanking the arrow cluster. */
+@media (pointer: coarse) and (min-width: 820px) {
+  .mobile-bottom-bar {
+    grid-template-columns: repeat(12, 1fr);
+    grid-template-areas: 'menu esc tab ctrl alt wl al ad au ar wr send';
+  }
+  .mk-wl,
+  .mk-wr {
+    display: inline-flex;
+  }
 }

--- a/apps/gmux-web/src/terminal-text-sheet.tsx
+++ b/apps/gmux-web/src/terminal-text-sheet.tsx
@@ -1,0 +1,75 @@
+/**
+ * Long-press text sheet: the whole terminal buffer rendered as plain,
+ * natively-selectable text, scrolled to the row the user pressed, with
+ * the clipboard actions pinned at the bottom.
+ *
+ * The long-press is a "give me my clipboard actions" gesture, so Copy all
+ * and Paste are co-equal peers (neither is the accent), with a quiet Close
+ * set apart. Copy doesn't dismiss — a copy is often not the end of the
+ * task, and an auto-dismiss timer is an unwinnable guess. (A toast will
+ * eventually confirm + close on its own; until then the sheet just stays
+ * open with inline feedback.)
+ *
+ * Why plain text instead of growing xterm's own selection: on touch,
+ * native selection (OS handles, magnifier, the system Copy callout) is
+ * far better than anything we can build over the terminal's canvas — and
+ * text copied this way is same-origin clipboard content, which WebKit
+ * exempts from the iOS paste-confirmation prompt. So Copy and a
+ * promptless Paste both fall out of this one surface.
+ *
+ * Presentational: the caller snapshots the rows and the pressed row at
+ * press time (see readTerminalText / pressedBufferRow), so terminal
+ * output scrolling underneath can't make the sheet lie.
+ *
+ * Portaling, keyboard-aware sizing, click dismiss, and button styling
+ * all live in the shared {@link SheetBackdrop} / {@link SheetButton} — see
+ * there for the touch-isolation and iOS reasoning.
+ */
+import { useLayoutEffect, useRef } from 'preact/hooks'
+import { CopyButton, SheetBackdrop, SheetButton } from './sheet'
+
+export interface TerminalTextSheetProps {
+  /** Buffer rows as plain text, one per visual row. */
+  lines: string[]
+  /** Index into `lines` to centre on (the pressed row). */
+  anchorRow: number
+  onPaste: () => void
+  onClose: () => void
+}
+
+export function TerminalTextSheet({ lines, anchorRow, onPaste, onClose }: TerminalTextSheetProps) {
+  const bodyRef = useRef<HTMLDivElement>(null)
+  const anchorRef = useRef<HTMLSpanElement>(null)
+
+  // Centre the pressed row so the user lands where their finger was.
+  useLayoutEffect(() => {
+    const body = bodyRef.current
+    const anchor = anchorRef.current
+    if (!body || !anchor) return
+    body.scrollTop = anchor.offsetTop - body.clientHeight / 2 + anchor.offsetHeight / 2
+  }, [])
+
+  const before = lines.slice(0, anchorRow)
+  const after = lines.slice(anchorRow + 1)
+
+  return (
+    <SheetBackdrop onClose={onClose}>
+      <div class="modal-panel text-sheet" role="dialog" aria-label="Terminal text">
+        {/* Single text flow (only the anchor line is wrapped, for the
+            scroll target + highlight) so native selection runs clean. */}
+        <div class="text-sheet-body" ref={bodyRef}>
+          <pre class="text-sheet-pre">
+            {before.length > 0 && `${before.join('\n')}\n`}
+            <span ref={anchorRef} class="text-sheet-anchor">{lines[anchorRow] ?? ''}</span>
+            {after.length > 0 && `\n${after.join('\n')}`}
+          </pre>
+        </div>
+        <div class="text-sheet-footer">
+          <SheetButton quiet onActivate={onClose}>Close</SheetButton>
+          <CopyButton label="Copy all" text={lines.join('\n')} />
+          <SheetButton onActivate={() => { onPaste(); onClose() }}>Paste</SheetButton>
+        </div>
+      </div>
+    </SheetBackdrop>
+  )
+}

--- a/apps/gmux-web/src/terminal-text-sheet.tsx
+++ b/apps/gmux-web/src/terminal-text-sheet.tsx
@@ -55,12 +55,12 @@ export function TerminalTextSheet({ lines, anchorRow, onPaste, onClose }: Termin
   return (
     <SheetBackdrop onClose={onClose}>
       <div class="modal-panel text-sheet" role="dialog" aria-label="Terminal text">
-        {/* Single text flow (only the anchor line is wrapped, for the
-            scroll target + highlight) so native selection runs clean. */}
+        {/* Single text flow (only the anchor line is wrapped, as the
+            scroll target) so native selection runs clean. */}
         <div class="text-sheet-body" ref={bodyRef}>
           <pre class="text-sheet-pre">
             {before.length > 0 && `${before.join('\n')}\n`}
-            <span ref={anchorRef} class="text-sheet-anchor">{lines[anchorRow] ?? ''}</span>
+            <span ref={anchorRef}>{lines[anchorRow] ?? ''}</span>
             {after.length > 0 && `\n${after.join('\n')}`}
           </pre>
         </div>

--- a/apps/gmux-web/src/terminal-text.test.ts
+++ b/apps/gmux-web/src/terminal-text.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import { dropTrailingBlankRows, readTerminalText, rowAtClientY, type TextTerminal } from './terminal-text'
+
+/** Fake terminal whose rows are plain strings; translateToString returns
+ * the row verbatim (the real one trims never-written cells — our rows are
+ * already concrete, so we exercise the post-strip and blank-row logic). */
+function fakeTerm(rows: (string | undefined)[]): TextTerminal {
+  return {
+    buffer: {
+      active: {
+        length: rows.length,
+        getLine: y => {
+          const row = rows[y]
+          return row === undefined ? undefined : { translateToString: () => row }
+        },
+      },
+    },
+  }
+}
+
+describe('dropTrailingBlankRows', () => {
+  it('drops only trailing blanks, preserving interior ones', () => {
+    expect(dropTrailingBlankRows(['a', '', 'b', '', ''])).toEqual(['a', '', 'b'])
+  })
+  it('returns empty for an all-blank buffer', () => {
+    expect(dropTrailingBlankRows(['', '', ''])).toEqual([])
+  })
+  it('leaves a buffer with no trailing blanks untouched', () => {
+    expect(dropTrailingBlankRows(['a', 'b'])).toEqual(['a', 'b'])
+  })
+})
+
+describe('readTerminalText', () => {
+  it('strips trailing whitespace from each row and trailing blank rows', () => {
+    const lines = readTerminalText(fakeTerm(['hello   ', 'world\t', '   ', '']))
+    expect(lines).toEqual(['hello', 'world'])
+  })
+  it('preserves interior blank rows and leading whitespace', () => {
+    const lines = readTerminalText(fakeTerm(['  indented', '', 'after', '']))
+    expect(lines).toEqual(['  indented', '', 'after'])
+  })
+  it('treats missing lines as blank', () => {
+    expect(readTerminalText(fakeTerm(['a', undefined, 'b']))).toEqual(['a', '', 'b'])
+  })
+})
+
+describe('rowAtClientY', () => {
+  it('maps a press to viewportY plus the row offset within the screen', () => {
+    expect(rowAtClientY({ clientY: 100, screenTop: 20, cellHeight: 16, viewportY: 50 })).toBe(55)
+  })
+  it('returns the top visible row for a press on the first row', () => {
+    expect(rowAtClientY({ clientY: 24, screenTop: 20, cellHeight: 16, viewportY: 50 })).toBe(50)
+  })
+  it('goes below viewportY for a press above the screen top', () => {
+    expect(rowAtClientY({ clientY: 4, screenTop: 20, cellHeight: 16, viewportY: 50 })).toBe(49)
+  })
+})

--- a/apps/gmux-web/src/terminal-text.ts
+++ b/apps/gmux-web/src/terminal-text.ts
@@ -1,0 +1,81 @@
+/**
+ * Snapshot the terminal buffer as plain text for the long-press text
+ * sheet, where native selection gives real mobile copy.
+ *
+ * The pure pieces (row extraction, blank-row trimming, point→row math)
+ * live here so they can be unit-tested with hand-rolled fakes, mirroring
+ * selection.ts. `pressedBufferRow` is the one DOM-touching wrapper.
+ */
+import type { Terminal } from '@xterm/xterm'
+
+/** Minimal buffer surface needed to read rows as text. Subset of
+ * `@xterm/xterm`'s public API, redeclared locally for testability. */
+export interface TextBufferLine {
+  translateToString(trimRight: boolean, startColumn?: number, endColumn?: number): string
+}
+export interface TextBuffer {
+  readonly length: number
+  getLine(y: number): TextBufferLine | undefined
+}
+export interface TextTerminal {
+  readonly buffer: { readonly active: TextBuffer }
+}
+
+/**
+ * Read the whole buffer (scrollback + viewport) as one trimmed string
+ * per visual row, with trailing blank rows dropped.
+ *
+ * Each row is trimmed on the right two ways, same as selection.ts:
+ * `translateToString(trimRight=true)` drops never-written cells
+ * (codepoint 0, shell output), and the post-strip removes explicit
+ * trailing spaces that TUIs pad rows with (pi, Claude Code, btop, …).
+ * Rows aren't reflowed — one buffer row per line matches what the user
+ * saw on screen and makes the scroll-to-press land exactly.
+ */
+export function readTerminalText(term: TextTerminal): string[] {
+  const buf = term.buffer.active
+  const lines: string[] = []
+  for (let y = 0; y < buf.length; y++) {
+    const line = buf.getLine(y)
+    lines.push(line ? line.translateToString(true).replace(/[ \t]+$/, '') : '')
+  }
+  return dropTrailingBlankRows(lines)
+}
+
+/** Drop empty rows from the end so the sheet doesn't open into a sea of
+ * blank lines. Blank rows between content are preserved. */
+export function dropTrailingBlankRows(lines: string[]): string[] {
+  let end = lines.length
+  while (end > 0 && lines[end - 1] === '') end--
+  return lines.slice(0, end)
+}
+
+/**
+ * Absolute buffer row under a vertical client coordinate. Pure: the
+ * caller supplies the measured screen top, cell height, and the buffer's
+ * current top visible row (`viewportY`). The result indexes the array
+ * from {@link readTerminalText} (clamp it to that array's bounds).
+ */
+export function rowAtClientY(args: {
+  clientY: number
+  screenTop: number
+  cellHeight: number
+  viewportY: number
+}): number {
+  const { clientY, screenTop, cellHeight, viewportY } = args
+  return viewportY + Math.floor((clientY - screenTop) / cellHeight)
+}
+
+/** Resolve the buffer row under a touch's clientY, reading layout from
+ * the live terminal. Returns 0 when dimensions aren't measured yet. */
+export function pressedBufferRow(term: Terminal, clientY: number): number {
+  const screen = term.element?.querySelector('.xterm-screen')
+  const cellHeight = term.dimensions?.css.cell.height
+  if (!screen || !cellHeight) return 0
+  return rowAtClientY({
+    clientY,
+    screenTop: screen.getBoundingClientRect().top,
+    cellHeight,
+    viewportY: term.buffer.active.viewportY,
+  })
+}

--- a/apps/gmux-web/src/terminal.tsx
+++ b/apps/gmux-web/src/terminal.tsx
@@ -8,6 +8,7 @@ import { loadWebglRenderer } from './webgl-renderer'
 import { applyArmedModifiers, attachKeyboardHandler, attachPasteHandler, defaultPasteFeedback, handlePasteAction } from './keyboard'
 import { DEFAULT_THEME_COLORS, type ResolvedKeybind } from './config'
 import { attachMobileInputHandler } from './mobile-input'
+import { isTouchDevice } from './touch'
 import { createReplayBuffer } from './replay'
 import { createTerminalIO, type TerminalSize } from './terminal-io'
 import { linkAtPoint, type LinkInfo, openLinkAtPoint } from './terminal-link'
@@ -125,10 +126,6 @@ function getResizeSignalPixels(host: HTMLElement | null, vv: VisualViewport | nu
 function announceResize(ws: WebSocket | null, dims: TerminalSize): void {
   if (!ws || ws.readyState !== WebSocket.OPEN) return
   ws.send(JSON.stringify({ type: 'resize', cols: dims.cols, rows: dims.rows }))
-}
-
-function isTouchDevice(): boolean {
-  return window.matchMedia('(pointer: coarse)').matches || navigator.maxTouchPoints > 0
 }
 
 function focusTerminalInput(term: Terminal | null): void {

--- a/apps/gmux-web/src/terminal.tsx
+++ b/apps/gmux-web/src/terminal.tsx
@@ -127,6 +127,10 @@ function announceResize(ws: WebSocket | null, dims: TerminalSize): void {
   ws.send(JSON.stringify({ type: 'resize', cols: dims.cols, rows: dims.rows }))
 }
 
+function isTouchDevice(): boolean {
+  return window.matchMedia('(pointer: coarse)').matches || navigator.maxTouchPoints > 0
+}
+
 function focusTerminalInput(term: Terminal | null): void {
   if (!term) return
 
@@ -135,9 +139,7 @@ function focusTerminalInput(term: Terminal | null): void {
   const textarea = term.textarea
   if (!textarea) return
 
-  const isTouchDevice = window.matchMedia('(pointer: coarse)').matches
-    || navigator.maxTouchPoints > 0
-  if (!isTouchDevice) return
+  if (!isTouchDevice()) return
 
   const prev = {
     position: textarea.style.position,
@@ -388,6 +390,10 @@ export function TerminalView({
   }, [])
 
   const handleShellClick = useCallback((ev: MouseEvent) => {
+    // Touch focuses the terminal via the touchend handler (a deliberate
+    // tap opens the keyboard). Ignore synthesized clicks here so a click
+    // falling through from a just-dismissed sheet can't reopen it.
+    if (isTouchDevice()) return
     const target = ev.target
     if (target instanceof HTMLElement && target.closest('button, input, textarea, select, a, label, [role="button"]')) {
       return
@@ -484,10 +490,14 @@ export function TerminalView({
 
     const sendRawInput = (data: string) => {
       const ws = wsRef.current
-      if (ws && ws.readyState === WebSocket.OPEN) {
-        ws.send(new TextEncoder().encode(data))
-        term.focus()
-      }
+      if (!ws || ws.readyState !== WebSocket.OPEN) return
+      // Only re-assert focus if the terminal already had it (keyboard
+      // open). Grabbing focus unconditionally would pop the on-screen
+      // keyboard on every toolbar key, even when it was closed — the
+      // whole point of the toolbar is to work with the keyboard down.
+      const hadFocus = document.activeElement === term.textarea
+      ws.send(new TextEncoder().encode(data))
+      if (hadFocus) term.focus()
     }
 
     const sendInput = (data: string) => {

--- a/apps/gmux-web/src/terminal.tsx
+++ b/apps/gmux-web/src/terminal.tsx
@@ -17,6 +17,7 @@ import { LinkActionSheet } from './link-action-sheet'
 import { TerminalTextSheet } from './terminal-text-sheet'
 import { pressedBufferRow, readTerminalText } from './terminal-text'
 import { decideViewportResize, sameSize } from './terminal-resize'
+import { terminalScrolledUp, terminalScrollToBottom } from './store'
 import { MOCK_BY_ID } from './mock-data/index'
 import type { Session } from './types'
 
@@ -71,11 +72,22 @@ function measureTerminalFit(
   // forever. offset* is the border-box and ignores scrollbars, so the
   // measurement is a fixed point regardless of transient overflow.
   // (.terminal-shell has no border/padding, so offset* == the viewport.)
+  // On mobile the control bar floats over the terminal's bottom (out of
+  // flow, translucent — see styles.css), so the shell fills the full height
+  // behind it. Reserve the bar's height, but round the row count UP: the
+  // terminal then claims one extra row whose bottom sliver tucks behind the
+  // translucent keys, instead of leaving a sub-cell gap above an opaque bar.
+  // Detected here — not at the call sites — so every resize path (initial
+  // fit, keyboard transitions, manual refit) computes identically. The bar's
+  // offsetParent is null when it's display:none (desktop) ⇒ plain floor fit.
+  const bar = document.querySelector<HTMLElement>('.mobile-bottom-bar')
+  const overlayBar = bar?.offsetParent ? bar.offsetHeight : 0
+
   const availW = shellEl.offsetWidth - padX - reserveWidth
-  const availH = shellEl.offsetHeight - padY
+  const availH = shellEl.offsetHeight - padY - overlayBar
 
   let cols = Math.max(2, Math.floor(availW / dims.css.cell.width))
-  let rows = Math.max(1, Math.floor(availH / dims.css.cell.height))
+  let rows = Math.max(1, (overlayBar > 0 ? Math.ceil : Math.floor)(availH / dims.css.cell.height))
 
   // Guard against 1px overflow: xterm computes screen width as
   // Math.round(device.cell.width * cols / dpr). Because css.cell.width is
@@ -91,7 +103,9 @@ function measureTerminalFit(
   // Same guard vertically: row height rounding across device/css pixels can
   // overflow by 1px at fractional DPRs (the monitor-move case), which is
   // exactly what seeds the scrollbar flicker described above.
-  if (dims.device.cell.height > 0) {
+  // (Skipped in overlay-bar mode: the gained row intentionally exceeds
+  // availH, spilling its bottom sliver behind the translucent bar.)
+  if (overlayBar === 0 && dims.device.cell.height > 0) {
     const predictedHeight = Math.round(dims.device.cell.height * rows / dpr)
     if (predictedHeight > availH && rows > 1) rows--
   }
@@ -238,7 +252,6 @@ export function TerminalView({
   const [termLoading, setTermLoading] = useState(true)
   const [wsState, setWsState] = useState<'connecting' | 'open' | 'lost'>('connecting')
   const [viewportSize, setViewportSize] = useState<TerminalSize | null>(null)
-  const [scrolledUp, setScrolledUp] = useState(false)
   const [linkSheet, setLinkSheet] = useState<LinkInfo | null>(null)
   const [textSheet, setTextSheet] = useState<{ lines: string[]; anchorRow: number } | null>(null)
   // The paste trigger lives in the attach effect (it reads bracketed-paste
@@ -386,6 +399,19 @@ export function TerminalView({
     focusTerminalInput(termRef.current)
   }, [])
 
+  // A tap on the shell *outside* the rendered grid (the strip that slides
+  // under the translucent toolbar, including the empty key-row corners)
+  // would let the browser's synthesized mousedown blur the textarea and
+  // dismiss the soft keyboard. Hold focus there by cancelling the default,
+  // mirroring the toolbar's keepFocus. The grid (.xterm) manages its own
+  // focus, so leave those taps untouched. Touch-only: there's no soft
+  // keyboard to protect off-touch, and cancelling mousedown there would
+  // only suppress focus/selection on shell controls for no benefit.
+  const holdShellFocus = useCallback((ev: MouseEvent) => {
+    if (!isTouchDevice()) return
+    if (!(ev.target instanceof Element) || !ev.target.closest('.xterm')) ev.preventDefault()
+  }, [])
+
   const handleShellClick = useCallback((ev: MouseEvent) => {
     // Touch focuses the terminal via the touchend handler (a deliberate
     // tap opens the keyboard). Ignore synthesized clicks here so a click
@@ -505,6 +531,7 @@ export function TerminalView({
     }
 
     onInputReady?.(sendRawInput)
+    terminalScrollToBottom.value = () => term.scrollToBottom()
     // The paste trigger reads bracketedPasteMode and the clipboard fresh
     // on every invocation: bracketed mode flips at runtime as TUIs come
     // and go, and the clipboard contents are obviously volatile. Sharing
@@ -548,7 +575,7 @@ export function TerminalView({
 
     const scrollDisposable = term.onScroll(() => {
       const buf = term.buffer.active
-      setScrolledUp(buf.baseY - buf.viewportY > SCROLL_THRESHOLD)
+      terminalScrolledUp.value = buf.baseY - buf.viewportY > SCROLL_THRESHOLD
     })
 
     const handleGlobalKeydown = (ev: KeyboardEvent) => {
@@ -763,7 +790,8 @@ export function TerminalView({
       osc52Disposable.dispose()
       dataDisposable.dispose()
       scrollDisposable.dispose()
-      setScrolledUp(false)
+      terminalScrolledUp.value = false
+      terminalScrollToBottom.value = null
       if (reconnectTimer.current) clearTimeout(reconnectTimer.current)
       wsRef.current?.close()
       wsRef.current = null
@@ -969,6 +997,7 @@ export function TerminalView({
     <div
       ref={shellRef}
       class={`terminal-shell ${showResizePill ? 'terminal-shell-passive' : ''}`}
+      onMouseDown={holdShellFocus}
       onClick={handleShellClick}
     >
       {showDisconnectedPill && (
@@ -995,7 +1024,7 @@ export function TerminalView({
           Waiting for output…
         </div>
       )}
-      {scrolledUp && (
+      {terminalScrolledUp.value && (
         <button
           type="button"
           class="terminal-scroll-end"

--- a/apps/gmux-web/src/terminal.tsx
+++ b/apps/gmux-web/src/terminal.tsx
@@ -27,11 +27,6 @@ const USE_MOCK = import.meta.env.VITE_MOCK === '1' || location.search.includes('
  */
 export const TERM_THEME = DEFAULT_THEME_COLORS
 
-// ── Keyboard / resize timing (touch) ──
-
-/** Debounce before measuring a height-only viewport change, so an
- * unsettled mid-animation height never drives a resize. */
-const KEYBOARD_RESIZE_DEBOUNCE_MS = 20
 // ── Utilities ──
 
 /**
@@ -660,18 +655,12 @@ export function TerminalView({
         }
 
         focusTerminalInput(term)
-        // Defer the scroll-to-bottom past the focus-driven layout work
-        // (keyboard opening resizes the viewport) and the browser's
-        // synthesized mouse events for this touch, so it lands once on
-        // the settled layout instead of racing them.
-        setTimeout(() => {
-          term.scrollToBottom()
-          const host = shellRef.current
-          if (host) {
-            host.scrollTop = host.scrollHeight
-            host.scrollLeft = 0
-          }
-        }, 0)
+        // No eager scroll-to-bottom here: the keyboard-open viewport
+        // shrink triggers one PTY reflow that already lands at the
+        // bottom. A scrollToBottom here would fire mid-slide (its
+        // setTimeout is deferred by the focus/layout work to ~30% of
+        // the keyboard animation), producing a redundant scroll jump
+        // before the reflow does the same thing again.
       }
       touchPanState.active = false
       touchPanState.moved = false
@@ -688,41 +677,27 @@ export function TerminalView({
     shell?.addEventListener('touchend', handleTouchEndCapture, { capture: true, passive: false })
     shell?.addEventListener('touchcancel', clearTouchPan, true)
 
-    const isTouchDevice = window.matchMedia('(pointer: coarse)').matches
-      || navigator.maxTouchPoints > 0
-
-    // Resize strategy:
-    // - A ResizeObserver on the shell element detects all layout changes:
-    //   initial flex settle, sidebar toggle, window resize, etc.
-    // - Measure on the next animation frame, after browser layout settles.
-    //   In practice width can update before flex heights finish recalculating,
-    //   so measuring synchronously in the resize event can read a stale height.
-    // - After each outbound resize, wait for the matching terminal_resize echo
-    //   before sending the next one. This keeps drag-resize responsive without
-    //   flooding the server with intermediate sizes.
-    // - Height-only viewport changes (soft keyboard slide) get a short debounce
-    //   before that frame measurement, so we skip unstable intermediate heights.
+    // Resize strategy (no debounce — two natural throttles make it
+    // unnecessary, and dropping it lets the soft-keyboard reflow fire in
+    // sync with the layout change instead of ~36ms later):
+    // - A ResizeObserver on the shell + window/visualViewport resize
+    //   events detect every layout change (flex settle, sidebar, soft
+    //   keyboard, rotation).
+    // - Measure on the next animation frame so layout has settled (width
+    //   can update before flex heights finish recalculating).
+    // - Cell quantization: measureTerminalFit floors pixels to cols/rows,
+    //   so sub-character jitter never produces a resize at all.
+    // - Echo gate: only one resize is in flight at a time (send → await the
+    //   server terminal_resize echo → send the latest pending), which
+    //   serializes and coalesces drag-resizes without flooding the PTY.
     const vv = window.visualViewport
 
-    let resizeTimer: ReturnType<typeof setTimeout> | null = null
     let resizeFrame: number | null = null
-    let refocusTimer: ReturnType<typeof setTimeout> | null = null
     let lastViewportPixels = getResizeSignalPixels(shell, vv)
-    let pendingHeightChange = false
 
     const flushViewportResize = () => {
-      resizeTimer = null
       resizeFrame = null
       processViewportResize()
-
-      const shouldRefocus = pendingHeightChange && isTouchDevice
-      pendingHeightChange = false
-      if (!shouldRefocus) return
-
-      // Let iOS finish the keyboard transition before grabbing focus,
-      // otherwise the OS immediately re-blurs the textarea.
-      if (refocusTimer !== null) clearTimeout(refocusTimer)
-      refocusTimer = setTimeout(() => focusTerminalInput(termRef.current), 120)
     }
 
     const scheduleViewportResize = () => {
@@ -741,21 +716,6 @@ export function TerminalView({
       if (!widthChanged && !heightChanged) return
 
       lastViewportPixels = nextViewportPixels
-      pendingHeightChange = pendingHeightChange || heightChanged
-
-      if (resizeTimer !== null) {
-        clearTimeout(resizeTimer)
-        resizeTimer = null
-      }
-
-      // Soft keyboard animations are mostly height-only, so debounce just that
-      // case on touch devices. Desktop resizes go through immediately, even if
-      // only the height changed.
-      if (isTouchDevice && heightChanged && !widthChanged) {
-        resizeTimer = setTimeout(scheduleViewportResize, KEYBOARD_RESIZE_DEBOUNCE_MS)
-        return
-      }
-
       scheduleViewportResize()
     }
 
@@ -771,9 +731,7 @@ export function TerminalView({
 
     return () => {
       shellObserver.disconnect()
-      if (resizeTimer !== null) clearTimeout(resizeTimer)
       if (resizeFrame !== null) cancelAnimationFrame(resizeFrame)
-      if (refocusTimer !== null) clearTimeout(refocusTimer)
       longPress.cancel()
       disposed.current = true
       window.removeEventListener('keydown', handleGlobalKeydown, true)

--- a/apps/gmux-web/src/terminal.tsx
+++ b/apps/gmux-web/src/terminal.tsx
@@ -13,6 +13,8 @@ import { createTerminalIO, type TerminalSize } from './terminal-io'
 import { linkAtPoint, type LinkInfo, openLinkAtPoint } from './terminal-link'
 import { createLongPressRecognizer } from './long-press'
 import { LinkActionSheet } from './link-action-sheet'
+import { TerminalTextSheet } from './terminal-text-sheet'
+import { pressedBufferRow, readTerminalText } from './terminal-text'
 import { decideViewportResize, sameSize } from './terminal-resize'
 import { MOCK_BY_ID } from './mock-data/index'
 import type { Session } from './types'
@@ -204,7 +206,6 @@ export function TerminalView({
   altArmed,
   onAltConsumed,
   onInputReady,
-  onPasteReady,
   onFocusReady,
 }: {
   session: Session
@@ -216,7 +217,6 @@ export function TerminalView({
   altArmed: boolean
   onAltConsumed: () => void
   onInputReady?: (send: ((data: string) => void) | null) => void
-  onPasteReady?: (paste: (() => void) | null) => void
   onFocusReady?: (focus: (() => void) | null) => void
 }) {
   const shellRef = useRef<HTMLDivElement>(null)
@@ -241,6 +241,11 @@ export function TerminalView({
   const [viewportSize, setViewportSize] = useState<TerminalSize | null>(null)
   const [scrolledUp, setScrolledUp] = useState(false)
   const [linkSheet, setLinkSheet] = useState<LinkInfo | null>(null)
+  const [textSheet, setTextSheet] = useState<{ lines: string[]; anchorRow: number } | null>(null)
+  // The paste trigger lives in the attach effect (it reads bracketed-paste
+  // mode + clipboard fresh), so bridge it out to the sheet's Paste button
+  // via a ref.
+  const pasteActionRef = useRef<(() => void) | null>(null)
   const SCROLL_THRESHOLD = 3 // rows above bottom before showing the button
   // Track the last PTY size we know about so we can derive the pill.
   const [ptySize, setPtySize] = useState<TerminalSize | null>(null)
@@ -496,16 +501,16 @@ export function TerminalView({
     // The paste trigger reads bracketedPasteMode and the clipboard fresh
     // on every invocation: bracketed mode flips at runtime as TUIs come
     // and go, and the clipboard contents are obviously volatile. Sharing
-    // handlePasteAction with the keybind path means the mobile toolbar
-    // button gets binary-paste support without divergent code.
-    onPasteReady?.(() => {
+    // handlePasteAction with the keybind path means long-press paste gets
+    // binary-paste support without divergent code.
+    pasteActionRef.current = () => {
       void handlePasteAction({
         sessionId: session.id,
         bracketedPasteMode: term.modes.bracketedPasteMode,
         feedback: defaultPasteFeedback,
         emit: sendRawInput,
       })
-    })
+    }
     onFocusReady?.(() => focusTerminalInput(term))
 
     const dataDisposable = term.onData((data) => sendInput(data))
@@ -559,9 +564,14 @@ export function TerminalView({
     // release must not open a link or toggle the keyboard.
     const longPress = createLongPressRecognizer((x, y) => {
       const link = linkAtPoint(term, x, y)
-      if (!link) return
       try { navigator.vibrate?.(10) } catch { /* unsupported */ }
-      setLinkSheet(link)
+      // On a link: offer open/copy. On empty space: open the text sheet —
+      // the buffer as natively-selectable text, scrolled to the pressed
+      // row, with Paste at the bottom.
+      if (link) { setLinkSheet(link); return }
+      const lines = readTerminalText(term)
+      const anchorRow = Math.max(0, Math.min(pressedBufferRow(term, y), lines.length - 1))
+      setTextSheet({ lines, anchorRow })
     })
     const touchPanState = {
       active: false,
@@ -751,7 +761,7 @@ export function TerminalView({
       wsRef.current?.close()
       wsRef.current = null
       onInputReady?.(null)
-      onPasteReady?.(null)
+      pasteActionRef.current = null
       onFocusReady?.(null)
       if ((window as any).__gmuxTerm === term) (window as any).__gmuxTerm = null
       ;(window as any).__gmuxInject = null
@@ -990,6 +1000,14 @@ export function TerminalView({
       )}
       {linkSheet && (
         <LinkActionSheet link={linkSheet} onClose={() => setLinkSheet(null)} />
+      )}
+      {textSheet && (
+        <TerminalTextSheet
+          lines={textSheet.lines}
+          anchorRow={textSheet.anchorRow}
+          onPaste={() => pasteActionRef.current?.()}
+          onClose={() => setTextSheet(null)}
+        />
       )}
     </div>
   )

--- a/apps/gmux-web/src/terminal.tsx
+++ b/apps/gmux-web/src/terminal.tsx
@@ -424,6 +424,15 @@ export function TerminalView({
     focusTerminal()
   }, [focusTerminal])
 
+  // Mirror the resolved terminal background into CSS (--terminal-bg) so the
+  // overlay fade and the shell/container fills match a themed background
+  // instead of a hard-coded literal. Falls back to the default in CSS when
+  // unset, so behaviour is unchanged for the default theme.
+  useEffect(() => {
+    const bg = terminalOptions.theme.background
+    if (shellRef.current && bg) shellRef.current.style.setProperty('--terminal-bg', bg)
+  }, [terminalOptions.theme.background])
+
   // Force-fetch the terminal font before mounting xterm.
   //
   // xterm picks its cell metrics from the first measurement it takes

--- a/apps/gmux-web/src/touch.ts
+++ b/apps/gmux-web/src/touch.ts
@@ -1,0 +1,14 @@
+/**
+ * True on touch-capable devices — a coarse pointer OR a positive
+ * touch-point count, so it also catches touch screens that report a fine
+ * pointer.
+ *
+ * Used to gate behaviours that would pop or assume the on-screen keyboard
+ * (auto-focus on session select/mount, focus-on-tap). Deliberately broader
+ * than the coarse-pointer-only checks in keyboard.ts / presence.ts, which
+ * must match the `@media (pointer: coarse)` query that drives the mobile
+ * layout.
+ */
+export function isTouchDevice(): boolean {
+  return window.matchMedia?.('(pointer: coarse)').matches || navigator.maxTouchPoints > 0
+}


### PR DESCRIPTION
Reworks the mobile (touch) terminal experience end to end: the key toolbar, on-screen-keyboard behavior, keyboard-driven resize, and a long-press sheet for copying terminal text and pasting. Eight self-contained commits, each builds green.

## `perf(web): resize the terminal in sync with the soft keyboard instead of debouncing`
- Drop the 20ms keyboard-resize debounce and the post-resize refocus. Cell-quantization + the `terminal_resize` echo already throttle, so the PTY now resizes **once, in sync with the keyboard slide** instead of reflowing mid-animation — the source of the visible flicker on iOS.
- Add `interactive-widget=resizes-visual` to the viewport meta so the layout viewport stays full while only the visual viewport shrinks, making `innerHeight − visualViewport.height` keyboard detection work on Chrome ≥108 (iOS Safari already behaves this way).

## `feat(web): redesign the mobile terminal toolbar and on-screen-keyboard behavior`
- **Static two-row key grid** replacing the modal single-row bar: `esc / alt / word-left / ↑ / word-right` over `tab / ctrl / ← / ↓ / →`, with `☰` and `send` as bottom-row bookends. The layout never changes shape between keyboard states.
- **ctrl/alt only arm + highlight** — they no longer relabel other keys. This also closes the previously unreachable `ctrl+esc` / `ctrl+↑` / `alt+esc` combinations (encoded via CSI-u).
- **Keyboard no longer opens unprompted** on touch: the terminal isn't auto-focused on session select, mount, or toolbar taps. Toolbar keys send via the raw input channel, so arrows/esc work with the keyboard closed.
- **☰ dismisses the keyboard** when open.
- Documents the visual-viewport keyboard-open detection (cross-device matrix, the load-bearing meta tag, fail-safe on older browsers) and records why the Chromium-only **VirtualKeyboard API is deliberately not used**.

## `feat(web): long-press the terminal for a copy/paste sheet`
- **Long-press empty terminal space → a text sheet**: the whole buffer (scrollback included) rendered as plain, natively-selectable text, auto-scrolled to the row under your finger. **Long-press a link → a link sheet** (Open / Copy URL, with Open primary).
- Hands selection to the **OS** — real selection handles, magnifier, the system Copy callout — far better than xterm's touch selection over the canvas. Copied text is **same-origin**, which WebKit exempts from the iOS paste-confirmation prompt, so in-gmux copy→paste is **promptless**. Copy and Paste converge on one surface.
- Shared **`SheetBackdrop` / `SheetButton`** primitives (`sheet.tsx`) back both sheets. Text-sheet footer: a quiet **Close** set apart from **co-equal Copy all / Paste** (the long-press is a "give me my clipboard actions" gesture, so neither is primary). Copy shows inline `Copied ✓` and doesn't auto-dismiss.
- **Portaled to `<body>`**: rendered in place the sheet is a child of `.terminal-shell`, whose capture-phase touch handlers re-fire the long-press recognizer on a press-hold and whose stacking mis-centres the panel behind the keyboard — the portal escapes both, and the backdrop is constrained to the visible viewport (`--app-height`). Opening a sheet also **dismisses the keyboard** (blur the focused hidden textarea, which iOS otherwise locks selection to).
- **Dismiss on `click`, not `pointerup`**: `pointerup` fires mid-gesture, and unmounting the sheet while the dismissing touch is still in flight tears down the terminal's iOS momentum-scroll layer — inertial scrolling died until reload. `click` fires after the touch ends, so the unmount is clean (wrapped in `setTimeout(0)` as cheap insurance). _(We briefly used `pointerup` to catch a quick tap whose synthesized `click` got swallowed, but that swallowing was **Orion-on-iOS specific**; Safari/WebKit fire it reliably.)_
- Buffer extraction (`readTerminalText`) and the press-point→row mapping (`rowAtClientY`) are pure, unit-tested helpers in `terminal-text.ts`.

## `fix(web): stop toolbar keys and sheet dismissals from opening the keyboard`
- `sendRawInput` re-focused the terminal after every send, so each toolbar key popped the keyboard — the opposite of the toolbar's intent. Now it only re-asserts focus if the terminal already had it (keyboard open).
- `handleShellClick` focused on click; gate it to non-touch so a synthesized click can't reopen the keyboard (on touch, a deliberate tap focuses via the touchend handler).

## `refactor(web): de-duplicate the touch-device check, drop dead text-sheet styling`
- Lift the identical `isTouchDevice` (coarse pointer OR `maxTouchPoints`) out of `main.tsx`/`terminal.tsx` into a shared `touch.ts`, documented as deliberately broader than the coarse-only checks elsewhere (which must match the mobile-layout `@media` query).
- Drop the `.text-sheet-anchor` class (its highlight CSS was removed earlier; the scroll anchor only needs the ref) and a stale comment.

## `feat(web): auto-repeat the toolbar nav keys on hold, regroup esc/tab/ctrl/alt`
- **Hold-to-repeat** on the navigation keys: arrows repeat at 70ms, word-jumps at 250ms, after a 300ms initial delay; a quick tap still fires exactly once. esc/tab/ctrl/alt/send/☰ stay tap-only. A small `useAutoRepeat` hook owns one timer pair (cleared on release/unmount) and `preventDefault`s so the hold can't steal focus.
- Regroup the top-left of the grid to `esc tab` over `ctrl alt`, so the modifiers sit together.

## `feat(web): float the toolbar over the terminal and collapse it to one row on wide screens`
- **Translucent overlay**: the bar no longer reserves an opaque strip — it floats over the bottom of the terminal, which slides one rounded-up row in behind the keys. Three-layer z-stack within `.main-panel`: key borders **under** the terminal (visible below it, hidden where it overlaps), the terminal itself, then glyphs + press feedback **on top**. A background-coloured drop shadow on the grid masks the borders into the content exactly at its edge.
- **One named-area grid** (bookends included) replaces the flex bar + inner grid, so every layout is a pure `grid-template-areas` swap and DOM order is just tab order. Key **hitboxes bridge the inter-key gaps** — each face extends half of a single `--key-gap` knob — so there are no dead gaps between buttons.
- **Single-row layout on wide viewports** (landscape phones, tablets): `☰ esc tab ctrl alt ← ↓ ↑ → send`, with a wider step that folds the word-jumps back in. Two `min-width` thresholds are the only knobs.
- **Scroll-to-end moves into the toolbar on touch** (top-right cell, or floating above the row in the single-row layouts), driven by shared `terminalScrolledUp` / `terminalScrollToBottom` signals instead of prop-threading; the floating `End` pill becomes desktop-only.
- **Dead-strip fixes**: taps on the shell that slides under the bar (incl. the empty key-row corners) now hold textarea focus instead of dismissing the keyboard, and no longer trigger OS text selection / the long-press callout.

## `fix(web): match the terminal fills and overlay fade to the themed background`
- The shell/container fills and the new overlay edge-fade hard-coded the default terminal background (`#0f141a`), so a user-themed background would show a mismatched fade where the terminal meets the toolbar. Mirror the resolved theme background into a `--terminal-bg` custom property on the shell and reference it from those fills, keeping the literal as the CSS fallback so the default theme is unchanged.

## Testing
- **510 unit tests pass**, `tsc` clean on every commit. Covered: the keyboard encodings the toolbar relies on (`ctrl+esc`, `ctrl+arrows`, `alt+enter`), the resize-gate decision, and the buffer-text extraction / blank-row trim / press-point→row mapping.
- **Device-verified on iOS (Safari + Orion):** single resize per keyboard transition (SIGWINCH watch), no flicker, keyboard stays dismissed after ☰, sheet selection + Paste work above the keyboard, and **inertial momentum scrolling survives** opening/dismissing the sheet. Overlay toolbar + single-row layouts tuned on-device across portrait, landscape, and tablet widths.

## Follow-ups (deliberately deferred)
- fn-layer (home/end, pgup/pgdn) and arrow slide-gestures.


https://github.com/user-attachments/assets/b4d3ea29-92cb-4f60-8d73-d0d08e21d3dc
