### PR TITLE
fix(web): keep session URL on refresh until world snapshot loads

### DIFF
--- a/apps/gmux-web/src/store.test.ts
+++ b/apps/gmux-web/src/store.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
 import {
-  sessions, sessionsLoaded, projects, upsertSession, removeSession,
+  sessions, sessionsLoaded, worldLoaded, projects, upsertSession, removeSession,
   markSessionRead, dismissSession, reorderSessions,
   handleActivity, isSessionActive, isSessionFading, activityMap,
   sessionStaleness, peers, peerAppearance, peerStatusByName,
@@ -8,6 +8,7 @@ import {
   navigateToSession, setNavigate,
   applyPending, _rawSessions, _rawWorld, _setRawWorld, _pendingMutations,
   toUISession, localHostLabel, parseConnectURL, unreadCount, discovered,
+  view,
 } from './store'
 import type { PendingMutation } from './store'
 import type { Session } from './types'
@@ -41,6 +42,7 @@ beforeEach(() => {
   _setRawWorld({ projects: [], peers: [] })
   _pendingMutations.value = []
   sessionsLoaded.value = false
+  worldLoaded.value = false
   urlPath.value = '/'
   urlSearch.value = ''
 })
@@ -171,6 +173,7 @@ describe('upsertSession', () => {
     ]
     _setRawWorld({ projects: testProjects })
     sessionsLoaded.value = true
+    worldLoaded.value = true
     _rawSessions.value = [
       makeSession({ id: 'sess-1', cwd: '/dev/project', kind: 'pi', slug: 'fix-auth' }),
     ]
@@ -195,6 +198,7 @@ describe('upsertSession', () => {
     ]
     _setRawWorld({ projects: testProjects })
     sessionsLoaded.value = true
+    worldLoaded.value = true
     _rawSessions.value = [
       makeSession({ id: 'sess-1', cwd: '/dev/project', kind: 'pi', slug: 'fix-auth' }),
       makeSession({ id: 'sess-2', cwd: '/dev/project', kind: 'pi', slug: 'old-slug' }),
@@ -210,6 +214,37 @@ describe('upsertSession', () => {
 
     // URL should be unchanged.
     expect(urlPath.value).toBe('/myproject/pi/fix-auth')
+    expect(selectedId.value).toBe('sess-1')
+  })
+})
+
+describe('deep-link refresh: snapshot ordering race (#308-adjacent)', () => {
+  // The daemon emits snapshot.sessions *before* snapshot.world on a
+  // fresh SSE subscription (ADR 0001). On a refresh while viewing a
+  // session, the sessions event lands first and flips sessionsLoaded
+  // while projects are still empty. Resolving the local-project URL
+  // against an empty projects list yields `home`, which the URL
+  // normalization effect would then write to the address bar —
+  // bouncing the user off their session. The view must stay `null`
+  // until the world snapshot has also arrived.
+  it('does not resolve a session URL to home before the world loads', () => {
+    urlPath.value = '/myproject/pi/fix-auth'
+    _rawSessions.value = [
+      makeSession({ id: 'sess-1', cwd: '/dev/project', kind: 'pi', slug: 'fix-auth', project_slug: 'myproject' }),
+    ]
+    // Sessions snapshot arrived; world has not (projects still empty).
+    sessionsLoaded.value = true
+    worldLoaded.value = false
+
+    // View must be unresolved — NOT home — so nothing rewrites the URL.
+    expect(view.value).toBeNull()
+    expect(selectedId.value).toBeNull()
+
+    // World snapshot arrives: now the session resolves.
+    _setRawWorld({ projects: [{ slug: 'myproject', match: [{ path: '/dev/project' }] }] })
+    worldLoaded.value = true
+
+    expect(view.value).toEqual({ kind: 'session', sessionId: 'sess-1' })
     expect(selectedId.value).toBe('sess-1')
   })
 })
@@ -630,6 +665,7 @@ describe('unreadCount (sidebar-only attention blip)', () => {
     _rawSessions.value = []
     _setRawWorld({ projects: [{ slug: 'proj', match: [{ path: '/work' }] }], peers: [] })
     sessionsLoaded.value = true
+    worldLoaded.value = true
     urlPath.value = '/'
   })
 

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -221,6 +221,18 @@ effect(() => {
 
 // Local-only UI state (never sourced from the wire).
 export const sessionsLoaded = signal(false)
+/**
+ * Whether the leading-edge `snapshot.world` (projects, peers, health)
+ * has arrived at least once. Tracked separately from `sessionsLoaded`
+ * because the daemon emits `snapshot.sessions` and `snapshot.world` as
+ * two distinct SSE events (sessions first; ADR 0001). On a deep-link
+ * refresh the sessions event lands while `projects` is still empty, and
+ * resolving a local-project URL against an empty projects list yields
+ * `home` — which the URL-normalization effect would then write to the
+ * address bar, dropping the session the user was on. Gating the view on
+ * *both* flags keeps it `null` until a coherent snapshot exists.
+ */
+export const worldLoaded = signal(false)
 export const connState = signal<'connecting' | 'connected' | 'error'>('connecting')
 
 // Discovered is host-authoritative (ADR 0002/0005): each host runs its
@@ -536,13 +548,15 @@ export const localHostLabel = computed<string | undefined>(() => {
 /**
  * Current view, derived from the URL + data.
  *
- * Returns null until sessions have loaded at least once. This prevents
- * the URL normalization effect from overwriting a deep session URL with
- * a fallback before data arrives. After loading, always returns a
- * concrete View (home/project/session).
+ * Returns null until both the sessions and world snapshots have loaded
+ * at least once. This prevents the URL normalization effect from
+ * overwriting a deep session URL with a fallback before data arrives —
+ * in particular before `projects` is populated, when a local-project
+ * URL would otherwise mis-resolve to home. After loading, always
+ * returns a concrete View (home/project/session).
  */
 export const view = computed((): View | null => {
-  if (!sessionsLoaded.value) return null
+  if (!sessionsLoaded.value || !worldLoaded.value) return null
   return resolveViewFromPath(urlPath.value, projects.value, filteredSessions.value)
 })
 
@@ -1223,6 +1237,7 @@ export function initStore(): () => void {
       _setRawWorld({ projects: MOCK_PROJECTS, peers: MOCK_PEERS, health: MOCK_HEALTH })
       _rawSessions.value = mockSessions
       sessionsLoaded.value = true
+      worldLoaded.value = true
       connState.value = 'connected'
       terminalOptions.value = buildTerminalOptions(null, null)
       keybinds.value = resolveKeybinds(null, false)
@@ -1304,14 +1319,17 @@ export function initStore(): () => void {
         peer_projects?: Record<string, PeerProject[]>
         peer_discovered?: Record<string, DiscoveredProject[]>
       }
-      _setRawWorld({
-        projects: env.projects ?? [],
-        peers: env.peers ?? env.health?.peers ?? [],
-        health: env.health ?? null,
-        launchers: env.launchers ?? [],
-        defaultLauncher: env.default_launcher ?? 'shell',
-        peerProjects: env.peer_projects ?? {},
-        peerDiscovered: env.peer_discovered ?? {},
+      batch(() => {
+        _setRawWorld({
+          projects: env.projects ?? [],
+          peers: env.peers ?? env.health?.peers ?? [],
+          health: env.health ?? null,
+          launchers: env.launchers ?? [],
+          defaultLauncher: env.default_launcher ?? 'shell',
+          peerProjects: env.peer_projects ?? {},
+          peerDiscovered: env.peer_discovered ?? {},
+        })
+        worldLoaded.value = true
       })
     } catch (err) {
       console.warn('snapshot.world: bad event', err)
@@ -1329,12 +1347,13 @@ export function initStore(): () => void {
 
   // URL normalization effect: rewrites the URL when the resolved view
   // differs from the current path (e.g., `/:project` resolves to a
-  // specific session). Gated on sessionsLoaded to prevent the race
-  // where projects load first and clobber the URL before sessions arrive.
+  // specific session). `view` is null until both the sessions and
+  // world snapshots have loaded, so the early `v === null` return
+  // already gates this against the load-order race that would
+  // otherwise clobber a deep-link URL before projects arrive.
   const disposeUrlNorm = effect(() => {
     const v = view.value
     if (v === null) return
-    if (!sessionsLoaded.value) return
     const url = viewToPath(v, projects.value, sessions.value)
     if (url && url !== urlPath.value) {
       navigate(url, true)


### PR DESCRIPTION
## Symptom

Refreshing the page while viewing a session bounced you back to **home**: the address bar got rewritten from the session path to `/`.

## Root cause

A **snapshot-ordering race** between the two leading-edge SSE events. The daemon emits `snapshot.sessions` *before* `snapshot.world` on subscribe (ADR 0001):

```go
sendSSE(w, "snapshot.sessions", composeSessions())
if !asPeer { sendSSE(w, "snapshot.world", composeWorld()) }
```

`projects` ride `snapshot.world`; `sessions` ride `snapshot.sessions`. On the client the sessions handler flipped `sessionsLoaded = true` while `projects` was still `[]`. The `view` computed was gated only on `sessionsLoaded`, so for a local-project URL (`/myproject/pi/fix-auth`) `resolveViewFromPath` looked up the project, found nothing, and resolved to `{ kind: 'home' }`. The URL-normalization effect then wrote `viewToPath(home) === '/'` to the address bar. By the time `snapshot.world` arrived, `urlPath` was already `/`, so home stuck.

The existing `sessionsLoaded` gate was meant to prevent exactly this kind of premature URL clobbering, but it only accounted for the *sessions* snapshot — not the separately-delivered *world* snapshot.

## Fix

- Add a `worldLoaded` signal, flipped in the `snapshot.world` SSE handler and mock init.
- Gate the `view` computed **and** the URL-normalization effect on `sessionsLoaded && worldLoaded`, so the view stays `null` until a coherent snapshot (sessions + world) exists and nothing rewrites the URL prematurely.

## Test

Adds a `store.test.ts` regression test ("does not resolve a session URL to home before the world loads") that simulates the sessions-before-world ordering. Verified it **fails** on the old gate and **passes** with the fix.

## Verification

- `pnpm test` — 502 passing (incl. regression)
- `pnpm exec tsc --noEmit` — clean