### PR TITLE
feat(cli)!: verb-first gmux 2.0 CLI

### DIFF
--- a/apps/website/src/content/docs/adapters.md
+++ b/apps/website/src/content/docs/adapters.md
@@ -19,11 +19,11 @@ Without an adapter, gmux still tracks whether the process is alive — but with 
 You don't configure adapters. gmux recognizes tools by their command name:
 
 ```bash
-gmux claude        # → claude adapter
-gmux codex         # → codex adapter
-gmux pi            # → pi adapter
-gmux bash          # → shell adapter (fallback)
-gmux make build    # → shell adapter (fallback)
+gmux -- claude       # → claude adapter
+gmux -- codex        # → codex adapter
+gmux -- pi           # → pi adapter
+gmux -- bash         # → shell adapter (fallback)
+gmux -- make build   # → shell adapter (fallback)
 ```
 
 If no specific adapter matches, the **shell** adapter handles it.

--- a/apps/website/src/content/docs/architecture.md
+++ b/apps/website/src/content/docs/architecture.md
@@ -54,9 +54,9 @@ Peer daemons use these packages to talk to other gmuxd instances. There are no p
 %%{init: {'theme': 'dark'}}%%
 graph LR
     subgraph runners ["gmux (one per session)"]
-        r1["gmux pi"]
-        r2["gmux pytest"]
-        r3["gmux make build"]
+        r1["gmux -- pi"]
+        r2["gmux -- pytest"]
+        r3["gmux -- make build"]
     end
 
     d["gmuxd"]

--- a/apps/website/src/content/docs/configuration.md
+++ b/apps/website/src/content/docs/configuration.md
@@ -11,7 +11,7 @@ gmux works out of the box with no configuration. Everything is customizable thro
 | `settings.jsonc` | Terminal options, keybinds, UI preferences | [settings.jsonc →](/reference/settings/) |
 | `theme.jsonc` | Terminal color palette (Windows Terminal theme compatible) | [theme.jsonc →](/reference/theme/) |
 
-All files are optional. Create or edit them manually. The only exception is `gmuxd remote`, which can add `[tailscale]` to `host.toml` with your confirmation.
+All files are optional. Create or edit them manually. The only exception is `gmux remote`, which can add `[tailscale]` to `host.toml` with your confirmation.
 
 Settings and theme changes take effect on browser refresh (no daemon restart needed). Host config changes require restarting gmuxd.
 

--- a/apps/website/src/content/docs/devcontainers.md
+++ b/apps/website/src/content/docs/devcontainers.md
@@ -90,6 +90,6 @@ If you're running a container without host-side gmux (e.g. a remote server), add
 }
 ```
 
-Then open the forwarded port and authenticate with `docker exec <container> gmuxd auth`.
+Then open the forwarded port and authenticate with `docker exec <container> gmux auth`.
 
 For standalone Docker deployments without devcontainers, see [Running in Docker](/running-in-docker).

--- a/apps/website/src/content/docs/getting-started.mdx
+++ b/apps/website/src/content/docs/getting-started.mdx
@@ -28,13 +28,13 @@ Or download both binaries (`gmuxd` + `gmux`) from [GitHub Releases](https://gith
 ## Run
 
 ```bash
-gmux pi              # launch a coding agent
-gmux pytest --watch  # or any command
+gmux -- pi              # launch a coding agent
+gmux -- pytest --watch  # or any command
 
-gmux                 # open the dashboard
+gmux open               # open the dashboard
 ```
 
-`gmux` auto-starts the daemon (`gmuxd`) on first run. Running `gmux` with no arguments opens the dashboard in a dedicated browser window (Chrome/Chromium `--app` mode when available, otherwise your default browser).
+Running a command uses the `--` separator: everything after it is your command, verbatim. `gmux` auto-starts the daemon (`gmuxd`) on first run. `gmux open` launches the dashboard in a dedicated browser window (Chrome/Chromium app mode when available, otherwise your default browser); bare `gmux` prints help. If you run commands often, `alias gm='gmux --'` lets you type `gm pi`.
 
 The first time, the sidebar will be empty. Click **Add project** to pick which project directories appear. Once added, sessions in those directories show up automatically. Click a session to attach a live terminal.
 

--- a/apps/website/src/content/docs/integrations/claude-code.md
+++ b/apps/website/src/content/docs/integrations/claude-code.md
@@ -47,10 +47,10 @@ Claude Code appears in the launch menu only when the `claude` binary is on `PATH
 The runtime matching works with direct invocation, full paths, and wrappers:
 
 ```bash
-gmux claude                          # ✓ matched
-gmux /usr/bin/claude                 # ✓ matched
-gmux env claude                      # ✓ matched
-gmux echo "not claude"            # ✗ not matched
+gmux -- claude                       # ✓ matched
+gmux -- /usr/bin/claude              # ✓ matched
+gmux -- env claude                   # ✓ matched
+gmux -- echo "not claude"            # ✗ not matched
 ```
 
 If detection fails, override it:

--- a/apps/website/src/content/docs/integrations/codex.md
+++ b/apps/website/src/content/docs/integrations/codex.md
@@ -40,10 +40,10 @@ Codex appears in the launch menu only when the `codex` binary is on `PATH`. `gmu
 - **Runtime matching** in `gmux`: scan the launched command for a `codex` binary name
 
 ```bash
-gmux codex                           # ✓ matched
-gmux codex "Fix the auth bug"        # ✓ matched
-gmux /usr/bin/codex                  # ✓ matched
-gmux echo "not codex"             # ✗ not matched
+gmux -- codex                        # ✓ matched
+gmux -- codex "Fix the auth bug"     # ✓ matched
+gmux -- /usr/bin/codex               # ✓ matched
+gmux -- echo "not codex"             # ✗ not matched
 ```
 
 If detection fails, override it:

--- a/apps/website/src/content/docs/integrations/pi.md
+++ b/apps/website/src/content/docs/integrations/pi.md
@@ -46,10 +46,10 @@ There are two separate pi checks:
 The runtime matching works with direct invocation, full paths, `npx`, `nix run`, and other wrappers:
 
 ```bash
-gmux pi                              # ✓ matched
-gmux /home/user/.local/bin/pi        # ✓ matched
-gmux npx pi                          # ✓ matched
-gmux echo "not pi"                # ✗ not matched
+gmux -- pi                           # ✓ matched
+gmux -- /home/user/.local/bin/pi     # ✓ matched
+gmux -- npx pi                       # ✓ matched
+gmux -- echo "not pi"                # ✗ not matched
 ```
 
 If detection fails (e.g., an unusual wrapper), override it:

--- a/apps/website/src/content/docs/integrations/scripts-and-agents.md
+++ b/apps/website/src/content/docs/integrations/scripts-and-agents.md
@@ -73,16 +73,9 @@ gmux wait <id>
 gmux tail <id> -n 200          # extract the final answer
 ```
 
-The idle signal is the same `Status.Working` flag the UI's spinner consumes, so `wait` returns the moment the agent emits its closing message. Exit codes: `0` idle/matched, `2` the session died first, `3` `--timeout N` elapsed.
+The idle signal is the same `Status.Working` flag the UI's spinner consumes, so `wait` returns the moment the agent emits its closing message. Exit codes: `0` idle, `2` the session died first, `3` `--timeout N` elapsed.
 
-`wait` with no condition is for agent sessions (`claude`, `codex`, `pi`); shell sessions have no working signal. For those, either run them through the blocking piped flow (`gmux -- make build < /dev/null`) or wait for expected output:
-
-```bash
-gmux wait <id> --for-text '__DONE__' --timeout 120   # fixed substring
-gmux wait <id> --for-regex '^\$ $' --timeout 30        # or a regex
-```
-
-`--for-text` / `--for-regex` poll the session's output and replace the old "loop over `tail` and `grep`" pattern.
+`wait` is for agent sessions (`claude`, `codex`, `pi`); shell sessions have no working signal and are rejected with a clear error. To wait for a shell command, run it through the blocking piped flow above (`gmux -- make build < /dev/null`) — that's exactly the shape `gmux -- <cmd>` already provides. (Waiting on arbitrary output — "until this text appears" — is planned as a server-side `wait` condition, [#313](https://github.com/gmuxapp/gmux/issues/313).)
 
 ## Reading output
 

--- a/apps/website/src/content/docs/integrations/scripts-and-agents.md
+++ b/apps/website/src/content/docs/integrations/scripts-and-agents.md
@@ -5,7 +5,7 @@ sidebar:
   order: 0
 ---
 
-`gmux` was designed so that the same binary works whether you're attaching to a session by hand or driving sessions from a script. This page covers the scripted shape: how to start sessions non-interactively, how to send input and wait for output, and how to compose the primitives into agent-orchestration patterns.
+`gmux` is designed so the same binary works whether you attach to a session by hand or drive sessions from a script. This page covers the scripted shape: starting sessions non-interactively, sending input, waiting for output, and composing these into agent-orchestration patterns.
 
 :::tip[Driving gmux from an agent?]
 Install the [gmux skill](https://github.com/gmuxapp/gmux/blob/main/skills/gmux/SKILL.md) so your agent picks up these patterns automatically:
@@ -19,109 +19,117 @@ The skill follows the [agentskills.io](https://agentskills.io/) standard and wor
 
 ## The piped flow
 
-The most useful primitive for scripting is `gmux <cmd>` with stdin redirected away from a terminal:
+The most useful primitive for scripting is `gmux -- <cmd>` with stdin redirected away from a terminal:
 
 ```bash
-gmux make build < /dev/null
-gmux pi -p "summarize this PR" < /dev/null
+gmux -- make build < /dev/null
+gmux -- pi -p "summarize this PR" < /dev/null
 ```
 
-The `-p` (print) flag tells `pi` to process the prompt and exit instead of staying interactive. Other agents have similar one-shot modes (`claude -p`, `codex exec`); without one, the agent stays running and `gmux <cmd>` blocks indefinitely. For multi-turn orchestration, see the [parallel orchestration](#parallel-orchestration) section below: spawn with `--no-attach`, then drive with `--send` / `--wait`.
+Running a command always uses the explicit `--` separator — there is no bare `gmux <cmd>` shorthand. The `-p` (print) flag tells `pi` to process the prompt and exit instead of staying interactive; other agents have similar one-shot modes (`claude -p`, `codex exec`). Without one, the agent stays running and the call blocks indefinitely — for multi-turn work, spawn detached and drive it instead (see [parallel orchestration](#parallel-orchestration)).
 
-When stdin is not a TTY, `gmux <cmd>`:
+When stdin is not a TTY, `gmux -- <cmd>`:
 
 - **Blocks** until the child exits.
 - **Streams bounded metadata** to stdout (session id, kind, exit status), not the full PTY output. Your script's logs stay readable.
-- **Exits with the child's exit code**, so `gmux make build < /dev/null && deploy.sh` works.
+- **Exits with the child's exit code**, so `gmux -- make build < /dev/null && deploy.sh` works.
 - **Keeps the session in the UI** for the duration: a human can watch it live in the browser without affecting the script.
 
-This is the shape every other line on this page builds on. It works the same in CI, in cron jobs, in agent harnesses (whose stdin is a pipe by default), and in any scripted invocation.
+This is the shape every other line on this page builds on. It works the same in CI, cron jobs, and agent harnesses (whose stdin is a pipe by default).
+
+## Spawning detached
+
+To start a session and drive it later, spawn it detached with `-d`. It returns immediately and prints the session id:
+
+```bash
+id=$(gmux -d -- pi "build the feature")
+```
+
+Capture that id and pass it to `send`, `wait`, `tail`, and `kill`.
 
 ## Sending input
 
-Use [`--send`](/reference/cli/#gmux---send---no-submit-id-text) to push input into an already-running session, as if the bytes had been typed at the keyboard. By default `--send` submits the input (appends the carriage return that signals Enter), so the canonical shape is just:
+`gmux send <id> [text] [keys]` pushes input into a running session, as if typed at the keyboard. Text is sent literally; trailing key names (`Enter`, `C-c`, …) are sent as keys. **Submission is explicit** — add a trailing `Enter` to dispatch a line:
 
 ```bash
-gmux --send <id> < prompt.txt
-gmux --send <id> 'shorter inline message'
+gmux send <id> 'shorter inline message' Enter
+gmux send <id> Enter < prompt.txt          # pipe a file, then submit
+gmux send <id> C-c                          # interrupt, no Enter
 ```
 
-Use `--no-submit` for the rare case where you want to pre-fill the input box without dispatching, e.g. agent-assisted human authoring or sending a control character without an extra Enter:
+When no text is given and stdin is a pipe, gmux reads stdin until EOF (capped at 1 MiB). `send` is gated by Unix-socket file permissions (owner-only); see the [CLI reference](/reference/cli/) for the access-control story.
+
+## Waiting
+
+`gmux wait <id>` blocks until an agent session finishes its current turn — the primitive that turns sequential orchestration into one line per step:
 
 ```bash
-printf '\x03' | gmux --send --no-submit <id>   # Ctrl-C, no extra Enter
-gmux --send --no-submit <id> 'draft '          # leave "draft " in the input
+gmux send <id> Enter < step-1.txt
+gmux wait <id>
+
+gmux send <id> Enter < step-2.txt
+gmux wait <id>
+
+gmux tail <id> -n 200          # extract the final answer
 ```
 
-`--send` is local-only and gated by Unix-socket file permissions (owner-only `0700`); see the CLI reference for the access-control story.
+The idle signal is the same `Status.Working` flag the UI's spinner consumes, so `wait` returns the moment the agent emits its closing message. Exit codes: `0` idle/matched, `2` the session died first, `3` `--timeout N` elapsed.
 
-## Waiting for the turn to finish
-
-`gmux --wait <id>` blocks until an agent session has finished its current turn. It's the primitive that turns sequential orchestration into a one-line-per-step pattern:
+`wait` with no condition is for agent sessions (`claude`, `codex`, `pi`); shell sessions have no working signal. For those, either run them through the blocking piped flow (`gmux -- make build < /dev/null`) or wait for expected output:
 
 ```bash
-gmux --send <id> < step-1.txt
-gmux --wait <id>
-
-gmux --send <id> < step-2.txt
-gmux --wait <id>
-
-# extract the final answer
-gmux --tail 200 <id>
+gmux wait <id> --for-text '__DONE__' --timeout 120   # fixed substring
+gmux wait <id> --for-regex '^\$ $' --timeout 30        # or a regex
 ```
 
-The idle signal is the same `Status.Working` flag the UI's spinner consumes, so `--wait` returns the moment the agent emits its closing message for the turn. If the session dies first, `--wait` exits 2; if you set `--timeout N` and N seconds pass, it exits 3. Idle is exit 0.
-
-`--wait` is for agent sessions (`claude`, `codex`, `pi`); shell sessions don't emit a working signal and are rejected with a clear error. To wait for a shell command to finish, run it through the piped flow above instead — the blocking shape is exactly what `gmux make build < /dev/null` already provides.
+`--for-text` / `--for-regex` poll the session's output and replace the old "loop over `tail` and `grep`" pattern.
 
 ## Reading output
 
-`gmux --tail N <id>` dumps the last N lines of a session's output as plain text (ANSI stripped). Pair it with `--wait` to capture the agent's final answer:
+`gmux tail <id>` prints recent output as plain text (ANSI stripped; `-n N` for line count, default 100). Pair it with `wait` to capture an agent's final answer:
 
 ```bash
-gmux --send <id> < ship-prompt.txt
-gmux --wait --timeout 600 <id>
-url=$(gmux --tail 50 <id> | grep -oE 'https://github\.com/[^ ]+/pull/[0-9]+' | tail -1)
+gmux send <id> Enter < ship-prompt.txt
+gmux wait <id> --timeout 600
+url=$(gmux tail <id> -n 50 | grep -oE 'https://github\.com/[^ ]+/pull/[0-9]+' | tail -1)
 echo "$url"
 ```
-
-`--tail` is local-only today.
 
 ## Discovery and cleanup
 
 ```bash
-gmux --list                  # all sessions, alive first, newest first
-gmux --kill <id>             # SIGTERM the runner, normal exit lifecycle
+gmux ls            # all local sessions, alive first, newest first
+gmux ls --json     # machine-readable, for parsing in scripts
+gmux kill <id>     # SIGTERM the runner, normal exit lifecycle
 ```
 
-`--list` accepts ID prefixes, full session IDs, or slugs anywhere a session is named, so the eight-character short form it prints can be passed straight back to `--kill`, `--send`, `--tail`, or `--wait`.
+Every verb accepts id prefixes, full session ids, or slugs, so the eight-character short form `ls` prints passes straight back to `kill`, `send`, `tail`, or `wait`.
 
 ## Parallel orchestration
 
-Spawn N agents in parallel, then wait for each in turn. Sequential waiting finishes when the slowest agent finishes — same wall-clock as backgrounding the `--wait` calls, but exit codes are per-session and the loop reads as a straight line:
+Spawn N agents in parallel, then wait for each in turn. Sequential waiting finishes when the slowest agent does — same wall-clock as backgrounding the `wait` calls, but exit codes are per-session and the loop reads as a straight line:
 
 ```bash
 ids=()
 for ticket in fa-48 fa-49 fa-52; do
-  prompt="Implement $ticket. Return when you're done."
-  ids+=( "$(gmux --no-attach pi "$prompt")" )
+  ids+=( "$(gmux -d -- pi "Implement $ticket. Return when you're done.")" )
 done
 
 for id in "${ids[@]}"; do
-  gmux --wait --timeout 600 "$id" || echo "$id did not finish cleanly: $?"
+  gmux wait "$id" --timeout 600 || echo "$id did not finish cleanly: $?"
 done
 
 for id in "${ids[@]}"; do
   echo "=== $id ==="
-  gmux --tail 100 "$id"
+  gmux tail "$id" -n 100
 done
 ```
 
-The agents run concurrently because `gmux --no-attach pi <prompt>` returns as soon as the session registers (and `--no-attach` prints just the session id, no grep needed); the wait loop just gates the harvest step on every agent reaching idle. Background `&` + `wait` is only useful when you want to dispatch the next step as soon as **any** agent finishes (rare for orchestration, where you usually want all of them done before you act).
+The agents run concurrently because `gmux -d -- pi <prompt>` returns as soon as the session registers and prints just the session id (no grep needed); the wait loop gates the harvest step on every agent reaching idle.
 
 ## Nested gmux
 
-When `gmux <cmd>` is run inside an existing gmux session (detected via the `GMUX=1` env var), gmux auto-detaches into a headless background process so you don't end up with a PTY-within-PTY. Importantly, the auto-detach only triggers when stdin is a TTY: agent harnesses whose stdin is a pipe land in the piped / non-tty flow described above and behave normally, blocking with bounded output. You don't need to special-case nested invocations in your scripts.
+When `gmux -- <cmd>` runs inside an existing gmux session (detected via the `GMUX=1` env var), gmux auto-detaches into a headless background process so you don't get a PTY-within-PTY. The auto-detach only triggers when stdin is a TTY: agent harnesses whose stdin is a pipe land in the piped flow above and behave normally. You don't need to special-case nested invocations.
 
 ## Agent-specific integrations
 

--- a/apps/website/src/content/docs/multi-machine.md
+++ b/apps/website/src/content/docs/multi-machine.md
@@ -20,7 +20,7 @@ Spokes need zero configuration changes. The hub authenticates with each spoke's 
 
 gmux does **not** auto-connect machines on your tailnet. Being on the same tailnet lets a machine *reach* another, but connecting still requires that host's bearer token, exactly like any other peer ([ADR 0008](https://github.com/gmuxapp/gmux/blob/main/docs/adr/0008-peer-authentication-via-token.md)). This keeps a single compromised node (say, a container running an untrusted agent) from driving every other machine on the tailnet.
 
-To add a tailnet machine, run `gmuxd auth` on it and copy the **connect URL** it prints:
+To add a tailnet machine, run `gmux auth` on it and copy the **connect URL** it prints:
 
 ```
 To add this host from another gmux machine, paste this into "Connect to host":
@@ -43,7 +43,7 @@ The host gmuxd detects the container via Docker events, reads the auth token, an
 
 ## Connecting to a host manually
 
-Open **Settings → Hosts → Connect to host**. Paste the connect URL from `gmuxd auth` (it splits into the URL and token fields automatically), or enter the host's URL (e.g. `https://gmux-server.your-tailnet.ts.net`) and its token separately. A token is required for every host, tailnet or not.
+Open **Settings → Hosts → Connect to host**. Paste the connect URL from `gmux auth` (it splits into the URL and token fields automatically), or enter the host's URL (e.g. `https://gmux-server.your-tailnet.ts.net`) and its token separately. A token is required for every host, tailnet or not.
 
 gmux probes the host, adopts the name it reports about itself (no name to assign), and saves the connection to `peers.json` in the state directory. If a different host already uses that name, gmux suffixes it (`server-2`) for you. The hub connects immediately and reconnects with exponential backoff on failure; every peer uses the same token-authenticated protocol.
 
@@ -65,7 +65,7 @@ Removing a host clears the references that pointed at it, so a deliberate remova
 
 ## Upgrading from a version with tailnet autodiscovery
 
-Earlier versions auto-discovered gmux machines on your tailnet. [ADR 0008](https://github.com/gmuxapp/gmux/blob/main/docs/adr/0008-peer-authentication-via-token.md) removed that, so on first start the daemon migrates the hosts **you had projects on** into the roster as **Auth needed** (it imports the old discovery cache, then deletes it). Click **Add token** on each in **Settings → Hosts** and paste its token (`gmuxd auth` on that host) to bring it online. Machines you never pinned a project on aren't carried over — add them with **Connect to host** if you want them. `projects.json` is backed up to `projects.json.bak` before any schema migration.
+Earlier versions auto-discovered gmux machines on your tailnet. [ADR 0008](https://github.com/gmuxapp/gmux/blob/main/docs/adr/0008-peer-authentication-via-token.md) removed that, so on first start the daemon migrates the hosts **you had projects on** into the roster as **Auth needed** (it imports the old discovery cache, then deletes it). Click **Add token** on each in **Settings → Hosts** and paste its token (`gmux auth` on that host) to bring it online. Machines you never pinned a project on aren't carried over — add them with **Connect to host** if you want them. `projects.json` is backed up to `projects.json.bak` before any schema migration.
 
 ## Session namespacing
 

--- a/apps/website/src/content/docs/reference/cli.md
+++ b/apps/website/src/content/docs/reference/cli.md
@@ -109,8 +109,8 @@ gmux tail -n 500 a3f20187     # last 500 lines
 gmux tail --raw a3f20187      # keep ANSI escapes (-e also works)
 ```
 
-It's a snapshot, not a stream — to block until specific output appears, use
-`gmux wait --for-text` below.
+It's a snapshot, not a stream — to watch a session live, attach to it or open
+it in the browser.
 
 ### `gmux send <id> [text] [Key...]`
 
@@ -143,28 +143,29 @@ gmuxd's authenticated proxy.
 
 ### `gmux wait <id>`
 
-Block until the session is done with what you're waiting for.
+Block until an **agent** session finishes its current turn (its spinner stops),
+optionally bounded by `--timeout N`.
 
 ```bash
-gmux wait a3f20187                              # until the agent finishes its turn
-gmux wait a3f20187 --for-text DONE --timeout 60 # until "DONE" appears, or 60s
-gmux wait a3f20187 --for-regex '^\$ ' --timeout 30
+gmux send a3f20187 'do the thing' Enter
+gmux wait a3f20187
+gmux wait a3f20187 --timeout 600   # or fail after 600s
 ```
 
-With no condition, `wait` blocks until an **agent** session goes idle (its
-spinner stops) or the session exits. Plain shell sessions have no idle signal,
-so for those either run them with the blocking piped form (`gmux -- make
-build`) or wait for expected output with `--for-text` / `--for-regex`, which
-poll the session's output and replace the old `tail | grep` loop.
+The idle signal is the same `Status.Working` flag the UI's spinner consumes,
+so `wait` returns the moment the agent emits its closing message. Exit codes
+(so scripts can branch on the outcome):
 
-Exit codes (so scripts can branch on the outcome):
+- `0` — the agent reached idle
+- `2` — the session exited before becoming idle
+- `3` — `--timeout` elapsed
 
-- `0` — matched / agent reached idle
-- `2` — the session exited before the condition was met
-- `3` — `--timeout` elapsed (the current tail is printed to stderr to help diagnose)
-
-`--for-text`/`--for-regex` are matched client-side for now;
-the idle wait is local-only (peer support is pending).
+Plain **shell** sessions have no idle signal and are rejected with a clear
+error; to wait for a shell command, run it through the blocking piped form
+(`gmux -- make build < /dev/null`) instead. Idle wait is local-only for now
+(peer support is pending). Waiting on arbitrary output ("until this text
+appears") is planned as a server-side `wait` condition
+([#313](https://github.com/gmuxapp/gmux/issues/313)).
 
 ### `gmux kill <id>`
 

--- a/apps/website/src/content/docs/reference/cli.md
+++ b/apps/website/src/content/docs/reference/cli.md
@@ -9,35 +9,39 @@ sidebar:
 
 ## Overview
 
-**`gmux`** — the session runner. Wraps any command in a managed session.
-This is your primary entry point; it auto-starts the daemon if needed.
+**`gmux`** — the command you use. It runs commands in managed sessions and
+drives them (list, attach, tail, send, wait, kill), plus daemon control and
+pairing. It auto-starts the daemon when needed.
 
-**`gmuxd`** — the daemon. Manages sessions, serves the web UI and session
-history, and provides optional remote access. Rarely invoked directly.
+**`gmuxd`** — the daemon process. Serves the web UI, session history, and
+optional remote access. You rarely invoke it directly; `gmux` starts it for
+you, and `gmux daemon …` controls it.
 
-## gmux
+`gmux` is verb-first: `gmux <verb> [args]`. Running a command is the one form
+that isn't a verb — it uses an explicit `--` separator so gmux never has to
+guess where its flags end and your command begins.
 
-The session runner and primary entry point. Auto-starts gmuxd if needed.
+## Running a command
 
-`gmux` has no subcommands. Flags before the command apply to gmux itself; once the first positional argument is seen, everything after it is the command to run, verbatim, including its own flags. Use `--` to disambiguate when the command starts with a dash.
+### `gmux -- <command> [args...]`
 
-### `gmux`
-
-Open the gmux UI in a browser. Starts gmuxd if it is not already running. Prefers Chrome/Chromium in `--app` mode for a standalone window; falls back to the default browser.
-
-### `gmux [--no-attach] <command> [args...]`
-
-Run a command inside a gmux session. The session registers with gmuxd and appears in the web UI.
+Run a command inside a gmux session. Everything after `--` is your command,
+verbatim — including its own flags. The session registers with gmuxd and
+appears in the web UI.
 
 ```bash
-gmux bash
-gmux python3 main.py
-gmux pi "build the feature"
-gmux --no-attach pytest --watch       # detach from the terminal
-gmux -- --my-dash-cmd                 # `--` preserves a dashy command
+gmux -- bash
+gmux -- python3 main.py
+gmux -- pi "build the feature"
+gmux -- pytest --watch        # --watch belongs to pytest, not gmux
 ```
 
-Which behavior `gmux <cmd>` exhibits depends on whether stdin is a terminal and whether you're already inside a gmux session:
+There's no bare shorthand: `gmux pytest` is an "unknown command" error (gmux
+suggests the `gmux -- pytest` form). If you run commands constantly,
+`alias gm='gmux --'` gives you `gm pytest` back.
+
+Behavior depends on whether stdin is a terminal and whether you're already
+inside a gmux session:
 
 | Stdin              | Inside `GMUX=1`? | Behavior                                                                                                |
 | ------------------ | ---------------- | ------------------------------------------------------------------------------------------------------- |
@@ -45,126 +49,170 @@ Which behavior `gmux <cmd>` exhibits depends on whether stdin is a terminal and 
 | TTY                | yes              | Auto-detach: spawn the session in the background and return immediately, so PTYs don't nest.            |
 | Pipe / file / null | either           | Block, stream bounded metadata to stdout, exit with the child's exit code. The session keeps running for the UI to attach to. |
 
-The pipe / file / null row is the canonical shape for scripts and agent harnesses: you get a blocking call, bounded stdout (no full PTY noise leaks into your script's logs), and reliable exit-code propagation. `--no-attach` forces the auto-detach behavior even from a terminal.
+The pipe/file/null row is the canonical shape for scripts and agent harnesses:
+a blocking call, bounded stdout (no full PTY noise in your logs), and reliable
+exit-code propagation — so `if gmux -- pytest -q; then …` works.
 
-See [Scripts and agents](/integrations/scripts-and-agents/) for the narrative version, including a worked build-and-report example.
+See [Scripts and agents](/integrations/scripts-and-agents/) for the narrative
+version with a worked build-and-report example.
 
-### `gmux --list` (`-l`)
+### `gmux -d -- <command> [args...]`
 
-List known sessions, alive first, newest first.
+Detached run. Spawns the session in the background and prints its session id on
+stdout, so a script can capture it (`id=$(gmux -d -- pi "…")`) and drive it
+without polling. `-d` must come before `--`.
+
+## Managing sessions
+
+Sessions are **local by default**: a bare id only ever matches a session on
+this machine, so you can't accidentally act on another host. To target a peer,
+suffix the id with `@<peer>` (see `gmux ls --all`). IDs are the 8-character
+short form the UI shows; verbs also accept a unique id prefix, the full id, or
+the session's slug.
+
+### `gmux ls`
+
+List sessions, alive first, newest first. Local only unless `--all`.
 
 ```
-$ gmux --list
+$ gmux ls
 ID        STATUS  KIND   TITLE
 a3f20187  alive   pi     fix auth bug  (/home/mg/dev/myapp)
 be14b052  alive   shell  bash          (/home/mg/dev/gmux)
 7d3304e9  dead    shell  make build    (/home/mg/dev/myapp)
 ```
 
-The ID column shows the 8-character short form the web UI uses; most management flags accept unique ID prefixes, the full session ID, or the session's slug.
+- `--all` — include sessions from every connected peer (adds a peer column).
+- `--json` — emit a JSON array instead of the table, for scripts and agents.
 
-### `gmux --attach <id>` (`-a`)
+### `gmux attach <id>`
 
-Reattach your local terminal to an existing session. The session's scrollback is replayed on connect, SIGWINCH is forwarded, and closing the terminal detaches without killing the session — identical to how `gmux <cmd>` itself behaves.
-
-```bash
-gmux --attach a3f20187
-gmux -a fix-auth-bug        # slug also works
-```
-
-Attach requires an interactive terminal. Remote peer sessions are supported transparently — gmuxd proxies the WebSocket to the owning node.
-
-### `gmux --tail <N> <id>` (`-t`)
-
-Print the last `N` lines of a session's output as plain text (scrollback plus the currently visible screen, ANSI stripped). Useful for peeking at a background session without attaching to it.
+Reattach your local terminal to a session. Scrollback is replayed on connect,
+SIGWINCH is forwarded, and closing the terminal detaches without killing the
+session. Requires an interactive terminal. Peer sessions work transparently —
+gmuxd proxies the WebSocket to the owning host.
 
 ```bash
-gmux --tail 100 a3f20187
-gmux -t 20 fix-auth-bug
+gmux attach a3f20187
+gmux attach fix-auth-bug      # slug also works
+gmux attach a3f20187@desktop  # a session on a peer
 ```
 
-`--tail` currently only works for sessions owned by the local node; remote peer sessions are rejected with a clear error.
+### `gmux tail <id>`
 
-### `gmux --kill <id>` (`-k`)
-
-Terminate a running session. Sends the same signal chain the UI's kill button does: `SIGTERM` to the child, normal exit lifecycle, session marked dead.
+Print recent output as plain text. ANSI escapes are stripped by default so the
+output is grep-friendly.
 
 ```bash
-gmux --kill a3f20187
+gmux tail a3f20187            # last 100 lines (default)
+gmux tail -n 500 a3f20187     # last 500 lines
+gmux tail --raw a3f20187      # keep ANSI escapes (-e also works)
 ```
 
-### `gmux --send [--no-submit] <id> [text]`
+It's a snapshot, not a stream — to block until specific output appears, use
+`gmux wait --for-text` below.
 
-Inject input into a running session, as if the bytes had been typed at the terminal, and submit it. By default `--send` appends a carriage return after the payload so the agent or shell processes it as a complete line; `--no-submit` suppresses that for the rare flow where you want to pre-fill the input box without dispatching it.
+### `gmux send <id> [text] [Key...]`
+
+Inject input into a running session as if typed at the keyboard. The text is
+sent literally; any trailing arguments that name keys (`Enter`, `C-c`,
+`Escape`, `Up`, …) are sent as those keys. **Submission is explicit** — add a
+trailing `Enter` to dispatch a line; omit it to leave the input unsent.
 
 ```bash
-gmux --send a3f20187 'describe yourself'           # submits
-gmux --send a3f20187 < prompt.txt                  # submits stdin
-echo 'describe yourself' | gmux --send a3f20187    # equivalent
-printf '\x03' | gmux --send --no-submit a3f20187   # send Ctrl-C without an extra Enter
-gmux --send --no-submit a3f20187 'draft '          # leave "draft " in the input box
+gmux send a3f20187 'describe yourself' Enter   # type and submit
+gmux send a3f20187 'half a thought'            # type, leave it unsent
+gmux send a3f20187 C-c                          # interrupt (Ctrl-C)
+gmux send a3f20187 Escape                       # send Escape
+echo "$body" | gmux send a3f20187 Enter         # pipe stdin, then submit
 ```
 
-When `text` is omitted, gmux reads from stdin until EOF and sends whatever it sees (capped at 1 MiB). Stdin mode is the natural shape for piping multi-line input from files or heredocs.
+When no text is given and stdin is a pipe, gmux reads stdin until EOF (capped
+at 1 MiB) and sends it — the natural shape for files and heredocs. Include a
+trailing `Enter` to submit piped input.
 
-**Access control.** `--send` is powerful — anything you send lands in the session's PTY, and the child has no way to distinguish it from keyboard input. Access is gated by filesystem permissions on the session's Unix socket (owner-only, `0700`), which means only the user that started the session can send to it. Other users on the same machine cannot connect to the socket at all. For the same reason, `--send` is local-only: cross-machine sending would need an explicit authorization model that doesn't exist yet.
+For verbatim tmux compatibility there's also `gmux send-keys -t <id> <keys...>`
+(all arguments are key names by default; `-l` sends them as literal text).
+Use plain `send` for everyday use; `send-keys` only when porting tmux commands.
 
-### `gmux --wait [--timeout N] <id>`
+**Access control.** `send` is powerful — anything you send lands in the
+session's PTY, indistinguishable from keyboard input. Access is gated by
+filesystem permissions on the session's Unix socket (owner-only), so only the
+user who started a session can send to it. Peer sessions are reached through
+gmuxd's authenticated proxy.
 
-Block until the agent in the session has finished its turn. Returns 0 when the agent reaches an idle state (the spinner stops), 2 if the session dies before becoming idle, and 3 if the optional `--timeout` elapses first.
+### `gmux wait <id>`
+
+Block until the session is done with what you're waiting for.
 
 ```bash
-gmux --send a3f20187 < prompt.txt
-gmux --wait a3f20187
-gmux --tail 50 a3f20187 > result.log
+gmux wait a3f20187                              # until the agent finishes its turn
+gmux wait a3f20187 --for-text DONE --timeout 60 # until "DONE" appears, or 60s
+gmux wait a3f20187 --for-regex '^\$ ' --timeout 30
 ```
 
-The idle signal is the same `Status.Working` flag the UI's spinner consumes: each agent adapter (claude, codex, pi) flips it false once its agent has emitted its final message for the turn. Wait returns immediately if the agent is already idle when called (so composition with `--send` is reliable when the agent races ahead between the two CLI hops).
+With no condition, `wait` blocks until an **agent** session goes idle (its
+spinner stops) or the session exits. Plain shell sessions have no idle signal,
+so for those either run them with the blocking piped form (`gmux -- make
+build`) or wait for expected output with `--for-text` / `--for-regex`, which
+poll the session's output and replace the old `tail | grep` loop.
 
-Shell sessions don't emit an idle signal and are rejected with a clear error rather than returning a misleading idle. To wait for a shell command to finish, run it directly via the piped flow above or compose with `timeout`.
+Exit codes (so scripts can branch on the outcome):
 
-Local sessions only; remote peer sessions are rejected until peer subscriptions stream `Status` events back to the hub.
+- `0` — matched / agent reached idle
+- `2` — the session exited before the condition was met
+- `3` — `--timeout` elapsed (the current tail is printed to stderr to help diagnose)
 
-## gmuxd
+`--for-text`/`--for-regex` are matched client-side for now;
+the idle wait is local-only (peer support is pending).
 
-The daemon. Manages sessions, serves the web UI, and optionally provides Tailscale remote access.
+### `gmux kill <id>`
 
-### `gmuxd start`
+Terminate a running session: `SIGTERM` to the child, normal exit lifecycle,
+session marked dead — the same path as the UI's kill button.
 
-Start the daemon in the background. If an existing instance is running, it is stopped first (the old version is printed for confirmation). Logs to `~/.local/state/gmux/gmuxd.log`. Prints the PID on success.
+```bash
+gmux kill a3f20187
+```
+
+## UI, pairing, and the daemon
+
+### `gmux open`
+
+Open the gmux UI in a browser, starting gmuxd if needed. Prefers Chrome/Chromium
+in app mode for a standalone window; falls back to the default browser. (Bare
+`gmux` with no arguments prints help — use `gmux open` to launch the UI.)
+
+### `gmux auth`
+
+Print this host's login URL and token, plus a connect URL and QR code for
+pairing another machine. This reveals a secret — run it deliberately, not as a
+status check.
+
+### `gmux remote`
+
+Set up or check Tailscale remote access. Walks you through enabling it the
+first time, then reports connection status on later runs. See
+[Remote Access](/remote-access/). (Shows connection *state* only; it never
+prints the token — use `gmux auth` for that.)
+
+### `gmux daemon <command>`
+
+Control the daemon process. This is the canonical front for daemon lifecycle;
+the underlying `gmuxd` binary keeps the same verbs for service managers.
+
+```bash
+gmux daemon status     # health, session counts, peer status
+gmux daemon start      # start in the background (replaces a running instance)
+gmux daemon stop       # stop the running daemon
+gmux daemon restart    # restart; active sessions survive and are rediscovered
+gmux daemon log-path   # print the log file path (for scripting)
+```
+
+`gmux daemon status` example:
 
 ```
-$ gmuxd start
-gmuxd: stopping existing daemon (1.0.0)...
-gmuxd: running (pid 12345)
-  Logs: /home/user/.local/state/gmux/gmuxd.log
-```
-
-Reads [`host.toml`](/reference/host-toml/) for configuration. Binds to `127.0.0.1` on the configured port (default 8790) and creates a Unix socket for local IPC.
-
-### `gmuxd run`
-
-Run the daemon in the foreground. Same as `start`, but blocks until interrupted. Use this for systemd services, Docker containers, or debugging.
-
-### `gmuxd restart`
-
-Stops any running instance and starts a fresh one. Waits for the new daemon
-to become healthy before returning. Active sessions survive: the new daemon
-rediscovers them on startup. Each session keeps running on its previous binary
-until you resume or restart it, which relaunches it on the new binary.
-
-Use this after installing an update to apply the new binary.
-
-### `gmuxd stop`
-
-Stop the running daemon via the Unix socket.
-
-### `gmuxd status`
-
-Show daemon health, session counts, and peer status.
-
-```
-gmuxd 1.0.0 (ready)
+gmuxd 2.0.0 (ready)
   tcp:    127.0.0.1:8790
   socket: /home/user/.local/state/gmux/gmuxd.sock
   remote: https://gmux.tailnet.ts.net
@@ -172,55 +220,29 @@ gmuxd 1.0.0 (ready)
 Sessions: 3 alive (2 local, 1 remote), 12 dead (15 total)
 
 Peers:
-  • desktop (1 session)
-    https://gmux-desktop.tailnet.ts.net
-  ○ gmux-server (offline)
-    https://gmux-server.tailnet.ts.net
-  ✗ manual-peer (connection refused)
-    https://peer.example.com
+  • desktop (1 session)        https://gmux-desktop.tailnet.ts.net
+  ○ gmux-server (offline)      https://gmux-server.tailnet.ts.net
+  ✗ manual-peer (refused)      https://peer.example.com
 ```
 
-Show the TCP listen address, auth token, and ready-to-open URLs. Useful for connecting from another device, and for pairing another gmux machine.
+### `gmux version` · `gmux help`
 
-```
-Listen:     127.0.0.1:8790
-Auth token: abc123...
+Print the version, or the usage summary. `gmux help` accepts a trailing verb
+name (it prints the full usage either way).
 
-Open this URL to authenticate in a browser on this machine:
-  http://127.0.0.1:8790/auth/login?token=abc123...
+## gmuxd
 
-To add this host from another gmux machine, paste this into "Connect to host":
-  https://gmux-host.your-tailnet.ts.net/auth/login?token=abc123...
-
-Or scan to open gmux on a device on your tailnet:
-  [inline QR code]
-```
-
-The second URL appears only when Tailscale is enabled. It is the **connect URL** for pairing: paste it into **Settings → Hosts → Connect to host** on another machine and it splits into the host URL and token, or scan the inline QR from a phone on your tailnet to open gmux authenticated. A token is required for every host — tailnet reachability alone does not authorize ([ADR 0008](https://github.com/gmuxapp/gmux/blob/main/docs/adr/0008-peer-authentication-via-token.md)).
-
-### `gmuxd remote`
-
-Set up or check Tailscale remote access.
-
-If Tailscale is not yet configured, explains what remote access is, asks for confirmation, enables it in `host.toml`, restarts the daemon, and waits for Tailscale to connect. The command guides you through the entire process interactively.
-
-If already enabled, polls the daemon until Tailscale reaches a known state, then shows the connection status. It only reports HTTPS/MagicDNS problems after confirming the connection is established, so you never see false warnings from a daemon that is still starting.
-
-See [Remote Access](/remote-access/) for the full guide.
-
-### `gmuxd log-path`
-
-Print the daemon log file path with no extra output, suitable for scripting.
+The daemon process. You normally start and control it through `gmux` (which
+auto-starts it) and `gmux daemon …`. Invoke `gmuxd` directly only when a service
+manager needs to own the process:
 
 ```bash
-tail -f $(gmuxd log-path)
-cat $(gmuxd log-path) | grep tsauth
+gmuxd          # run in the foreground (for systemd, Docker, debugging)
+gmuxd run      # same thing, explicit
 ```
 
-### `gmuxd version`
-
-Print the version string.
-
-### `gmuxd help`
-
-Show the usage summary.
+Foreground `gmuxd` reads [`host.toml`](/reference/host-toml/), binds
+`127.0.0.1` on the configured port (default 8790), and creates a Unix socket
+for local IPC. For background start/stop/status/restart and the log path, use
+`gmux daemon …` above. `gmuxd --help` lists the binary's own verbs and points
+back to the `gmux daemon` equivalents.

--- a/apps/website/src/content/docs/reference/environment.md
+++ b/apps/website/src/content/docs/reference/environment.md
@@ -87,10 +87,10 @@ See [Adapter Architecture](/develop/adapter-architecture) for how to use the chi
 
 ## How a session's environment is sourced
 
-When the daemon starts, resumes, or **restarts** a session (the launch buttons in the UI), it sources a fresh environment from an interactive login shell — roughly `$SHELL -l -i` run in the session's working directory — and hands that to the session. This means edits to your `~/.zshrc` / `~/.bashrc` / `~/.profile` (and per-directory hooks like `direnv`) take effect on the next launch or restart, **without** needing a `gmuxd restart`. Clicking **Restart session** behaves like opening a fresh terminal.
+When the daemon starts, resumes, or **restarts** a session (the launch buttons in the UI), it sources a fresh environment from an interactive login shell — roughly `$SHELL -l -i` run in the session's working directory — and hands that to the session. This means edits to your `~/.zshrc` / `~/.bashrc` / `~/.profile` (and per-directory hooks like `direnv`) take effect on the next launch or restart, **without** needing a `gmux daemon restart`. Clicking **Restart session** behaves like opening a fresh terminal.
 
 The captured environment is merged onto the daemon's own environment, so session/desktop variables that your dotfiles never set — `DISPLAY`, `SSH_AUTH_SOCK`, `XDG_RUNTIME_DIR`, and similar — are preserved. (One consequence of the merge: a variable you *remove* from your dotfiles may linger until the daemon itself is restarted.)
 
-If `$SHELL` is unset (typical for systemd- or Docker-managed daemons), this step is skipped and the session inherits the daemon's environment unchanged. The same fallback applies if the login shell fails or takes longer than 5 seconds. Sessions you start directly from a terminal (`gmux <cmd>`) always use that terminal's live environment.
+If `$SHELL` is unset (typical for systemd- or Docker-managed daemons), this step is skipped and the session inherits the daemon's environment unchanged. The same fallback applies if the login shell fails or takes longer than 5 seconds. Sessions you start directly from a terminal (`gmux -- <cmd>`) always use that terminal's live environment.
 
 See [ADR 0006](https://github.com/gmuxapp/gmux/blob/main/docs/adr/0006-fresh-login-env-on-launch.md) for the full rationale.

--- a/apps/website/src/content/docs/reference/file-paths.md
+++ b/apps/website/src/content/docs/reference/file-paths.md
@@ -7,7 +7,7 @@ sidebar:
 
 ## Config files
 
-Created by the user. gmux does not write to these, except that `gmuxd remote` can add `[tailscale]` to `host.toml` with your confirmation.
+Created by the user. gmux does not write to these, except that `gmux remote` can add `[tailscale]` to `host.toml` with your confirmation.
 
 | Path | Purpose | Reference |
 |------|---------|-----------|
@@ -28,7 +28,7 @@ Created by gmuxd. Lives under `~/.local/state/gmux` (or `$XDG_STATE_HOME/gmux`).
 | `~/.local/state/gmux/projects.json` | User-curated project list (sidebar grouping, ordering) |
 | `~/.local/state/gmux/projects.json.bak` | Snapshot of `projects.json` taken before a schema migration rewrites it (notably the 2.0 upgrade) |
 | `~/.local/state/gmux/peers.json` | Hosts you connected to via **Connect to host** — URL, token, and node id (0600; it carries a token) |
-| `~/.local/state/gmux/gmuxd.log` | Daemon log (when started via `gmuxd start`) |
+| `~/.local/state/gmux/gmuxd.log` | Daemon log (when started via `gmux daemon start`) |
 | `~/.local/state/gmux/tsnet/` | Tailscale state directory (when remote access is enabled) |
 
 ## Session sockets
@@ -51,4 +51,4 @@ Override the directory with `GMUX_SOCKET_DIR`.
 
 | Path | Purpose |
 |------|---------|
-| `~/.local/state/gmux/gmuxd.log` | Daemon log when started via `gmuxd start` or auto-started by `gmux` |
+| `~/.local/state/gmux/gmuxd.log` | Daemon log when started via `gmux daemon start` or auto-started by `gmux` |

--- a/apps/website/src/content/docs/reference/host-toml.md
+++ b/apps/website/src/content/docs/reference/host-toml.md
@@ -7,7 +7,7 @@ tableOfContents:
 
 `~/.config/gmux/host.toml` (or `$XDG_CONFIG_HOME/gmux/host.toml`)
 
-Daemon behavior. gmuxd reads this file once at startup. Create or edit it manually. The only command that modifies this file is `gmuxd remote`, which can add the `[tailscale]` section with your confirmation. If the file does not exist, safe defaults are used. Changes require restarting gmuxd.
+Daemon behavior. gmuxd reads this file once at startup. Create or edit it manually. The only command that modifies this file is `gmux remote`, which can add the `[tailscale]` section with your confirmation. If the file does not exist, safe defaults are used. Changes require restarting gmuxd.
 
 ## Example
 
@@ -35,7 +35,7 @@ To seed a specific name at first registration — e.g. when running several daem
 
 ## Connecting to other hosts
 
-There is **no `[[peers]]` config**. Add a host you want to aggregate sessions from at runtime via **Settings → Hosts → Connect to host** (paste the connect URL from `gmuxd auth`, or enter the host's URL and token). A token is required for every host, tailnet or not ([ADR 0008](https://github.com/gmuxapp/gmux/blob/main/docs/adr/0008-peer-authentication-via-token.md)). Connected hosts are saved to `peers.json` in the state directory, and the peer's name is taken from the host itself — you don't assign one.
+There is **no `[[peers]]` config**. Add a host you want to aggregate sessions from at runtime via **Settings → Hosts → Connect to host** (paste the connect URL from `gmux auth`, or enter the host's URL and token). A token is required for every host, tailnet or not ([ADR 0008](https://github.com/gmuxapp/gmux/blob/main/docs/adr/0008-peer-authentication-via-token.md)). Connected hosts are saved to `peers.json` in the state directory, and the peer's name is taken from the host itself — you don't assign one.
 
 ## Fields
 

--- a/apps/website/src/content/docs/remote-access.md
+++ b/apps/website/src/content/docs/remote-access.md
@@ -11,7 +11,7 @@ By default, gmux only listens on localhost. To access it from another device, yo
 
 ## Setup
 
-The fastest path: run `gmuxd remote` and follow the prompts. It handles configuration, walks you through Tailscale registration, and verifies the result. You can run it again at any time to check the status.
+The fastest path: run `gmux remote` and follow the prompts. It handles configuration, walks you through Tailscale registration, and verifies the result. You can run it again at any time to check the status.
 
 The steps below cover the same process in detail.
 
@@ -32,12 +32,12 @@ In the [Tailscale admin console](https://login.tailscale.com/admin/dns):
 1. Enable **MagicDNS** so devices can find each other by name.
 2. Enable **HTTPS Certificates** so Tailscale can issue valid TLS certificates for `*.ts.net` hostnames.
 
-Both are required. You can verify they're enabled by running `gmuxd remote` after setup.
+Both are required. You can verify they're enabled by running `gmux remote` after setup.
 
 ### 3. Enable and register
 
 ```bash
-gmuxd remote
+gmux remote
 ```
 
 This walks you through the process interactively: it explains what remote access does, asks for confirmation, enables Tailscale in `~/.config/gmux/host.toml`, restarts the daemon, and waits for Tailscale to connect.
@@ -57,13 +57,13 @@ Connecting to Tailscale...
 To complete setup, log in to Tailscale:
   https://login.tailscale.com/a/...
 
-After logging in, run `gmuxd remote` again to check the connection.
+After logging in, run `gmux remote` again to check the connection.
 ```
 
-Visit the URL to approve the device. gmux registers as its own device in your tailnet, separate from the machine's Tailscale. After login, run `gmuxd remote` again:
+Visit the URL to approve the device. gmux registers as its own device in your tailnet, separate from the machine's Tailscale. After login, run `gmux remote` again:
 
 ```
-$ gmuxd remote
+$ gmux remote
 Connecting to Tailscale...
   local:  http://127.0.0.1:8790
   remote: https://gmux.your-tailnet.ts.net
@@ -86,7 +86,7 @@ Each machine joins the tailnet under `gmux-<its-hostname>`, derived from the OS 
 
 ### 4. Connect
 
-On your other device, open `https://gmux.your-tailnet.ts.net`. The connection is HTTPS with a valid certificate. You'll be asked for the host's access token (run `gmuxd auth` on the host to get it, or scan its QR/connect URL) — being on the tailnet lets you *reach* the host, but the token is what authorizes you ([ADR 0008](https://github.com/gmuxapp/gmux/blob/main/docs/adr/0008-peer-authentication-via-token.md)).
+On your other device, open `https://gmux.your-tailnet.ts.net`. The connection is HTTPS with a valid certificate. You'll be asked for the host's access token (run `gmux auth` on the host to get it, or scan its QR/connect URL) — being on the tailnet lets you *reach* the host, but the token is what authorizes you ([ADR 0008](https://github.com/gmuxapp/gmux/blob/main/docs/adr/0008-peer-authentication-via-token.md)).
 
 :::note
 The Tailscale listener is independent from the localhost listener. Local access (`127.0.0.1:8790`) always works, so you can't lock yourself out by misconfiguring Tailscale.
@@ -106,20 +106,20 @@ enabled = true
 allow = ["your-work-account@github"]
 ```
 
-Then restart: `gmuxd restart`.
+Then restart: `gmux daemon restart`.
 
 If the other account is on a **different tailnet**, you also need to share the gmux device via the [Machines](https://login.tailscale.com/admin/machines) page (⋯ → Share). The device is then accessible at `gmux.owner-tailnet.ts.net` (using the owner's tailnet name).
 
 ## Troubleshooting
 
-Run `gmuxd remote` to diagnose most issues. It checks whether the daemon is running, whether the device is registered, and whether HTTPS and MagicDNS are enabled.
+Run `gmux remote` to diagnose most issues. It checks whether the daemon is running, whether the device is registered, and whether HTTPS and MagicDNS are enabled.
 
-**`ERR_NAME_NOT_RESOLVED` in the browser**: the device isn't registered, or MagicDNS is disabled. Run `gmuxd remote` to check.
+**`ERR_NAME_NOT_RESOLVED` in the browser**: the device isn't registered, or MagicDNS is disabled. Run `gmux remote` to check.
 
-**gmux doesn't appear in the Tailscale dashboard**: gmux registers as its own device, not through the machine's Tailscale. Check the daemon log for the login URL: `cat $(gmuxd log-path) | grep tsauth`. You can also run `gmuxd run` in foreground mode to see the URL directly.
+**gmux doesn't appear in the Tailscale dashboard**: gmux registers as its own device, not through the machine's Tailscale. Check the daemon log for the login URL: `cat $(gmux daemon log-path) | grep tsauth`. You can also run `gmuxd run` in foreground mode to see the URL directly.
 
 **Certificate warning**: HTTPS certificates aren't enabled in your tailnet. Enable them in your [Tailscale DNS settings](https://login.tailscale.com/admin/dns), then restart gmuxd.
 
-**Certificate error when accessing a shared machine**: Tailscale issues certificates for the **active tailnet DNS name** only. If the owner renamed their tailnet after issuing certificates, the guest may see a mismatch. Check that the active name in [DNS settings](https://login.tailscale.com/admin/dns) matches what `gmuxd remote` shows.
+**Certificate error when accessing a shared machine**: Tailscale issues certificates for the **active tailnet DNS name** only. If the owner renamed their tailnet after issuing certificates, the guest may see a mismatch. Check that the active name in [DNS settings](https://login.tailscale.com/admin/dns) matches what `gmux remote` shows.
 
 **Can't reach from a specific device**: make sure Tailscale is installed, signed in, and connected on that device.

--- a/apps/website/src/content/docs/security.md
+++ b/apps/website/src/content/docs/security.md
@@ -84,7 +84,7 @@ The file remains the primary storage. Environment variables are inherited by chi
 
 The [`examples/`](https://github.com/gmuxapp/gmux/tree/main/examples) directory has ready-to-run Docker Compose setups showing how to handle auth in common deployment scenarios: [Tailscale](/running-in-docker/#tailscale-recommended), [WireGuard](/running-in-docker/#wireguard), and [Traefik with OIDC](/running-in-docker/#reverse-proxy-with-oidc-traefik--pocketid).
 
-**For easy access from other devices**, use [Tailscale remote access](/remote-access). It gives you HTTPS with automatic certificates and cryptographic identity verification; access still requires the host's token (run `gmuxd auth` to get its connect URL).
+**For easy access from other devices**, use [Tailscale remote access](/remote-access). It gives you HTTPS with automatic certificates and cryptographic identity verification; access still requires the host's token (run `gmux auth` to get its connect URL).
 
 ## Config validation
 

--- a/apps/website/src/content/docs/troubleshooting.md
+++ b/apps/website/src/content/docs/troubleshooting.md
@@ -10,7 +10,7 @@ description: Common problems and how to fix them.
 **Check the log:**
 
 ```bash
-cat $(gmuxd log-path)
+cat $(gmux daemon log-path)
 ```
 
 Common causes:
@@ -25,13 +25,13 @@ Common causes:
 gmuxd run
 ```
 
-This runs the daemon in the foreground so you can see errors directly. Use `gmuxd start` for normal background operation.
+This runs the daemon in the foreground so you can see errors directly. Use `gmux daemon start` for normal background operation.
 
 ## Sessions don't appear in the sidebar
 
 - **No project configured.** gmux discovers session groups but doesn't add them to the sidebar automatically. Click **Add project** in the empty state, or the **Manage projects** button. Unmatched sessions show a badge count on the manage button.
 - **Session exited immediately.** If the command exits before gmuxd discovers it, it won't appear. Check if the command works when run directly (outside of `gmux`).
-- **Different daemon.** If you have multiple gmux installs (e.g. Homebrew and a dev build), `gmux` and `gmuxd` might not be talking to the same instance. Run `gmuxd status` to check which binary is running.
+- **Different daemon.** If you have multiple gmux installs (e.g. Homebrew and a dev build), `gmux` and `gmuxd` might not be talking to the same instance. Run `gmux daemon status` to check which binary is running.
 
 ## "outdated" badge on a session
 
@@ -69,4 +69,4 @@ After updating, the old daemon is replaced automatically:
 - **`curl | sh` installer**: restarts the daemon if it was running
 - **Manual installs**: the next `gmux` invocation detects the version mismatch and replaces the daemon
 
-To force a restart manually: `gmuxd restart` (or just `gmuxd start`, which replaces any running instance).
+To force a restart manually: `gmux daemon restart` (or just `gmux daemon start`, which replaces any running instance).

--- a/apps/website/src/content/docs/using-the-ui.md
+++ b/apps/website/src/content/docs/using-the-ui.md
@@ -3,7 +3,7 @@ title: Using the UI
 description: What you see in gmux and how to work with it.
 ---
 
-Running `gmux` with no arguments opens the dashboard in a dedicated browser window. You can also navigate to **[localhost:8790](http://localhost:8790)** directly; the first time you'll need to authenticate by visiting the login URL from `gmuxd auth`.
+Running `gmux open` opens the dashboard in a dedicated browser window. You can also navigate to **[localhost:8790](http://localhost:8790)** directly; the first time you'll need to authenticate by visiting the login URL from `gmux auth`.
 
 ## The sidebar
 
@@ -40,7 +40,7 @@ In **Settings → Hosts**, each host shows an explicit status:
 
 Removing a host also clears the project references that pointed at it, so it leaves nothing behind under **Referenced but not found**.
 
-**Upgrading to 2.0:** hosts you had projects on — that earlier versions auto-discovered on your tailnet — are migrated into the roster as **Auth needed**. Click **Add token** on each and paste its token (run `gmuxd auth` on that host) to bring it back online. Other tailnet machines aren't carried over; re-add them with **Connect to host** if you want them. Your `projects.json` is backed up to `projects.json.bak` before the upgrade rewrites it.
+**Upgrading to 2.0:** hosts you had projects on — that earlier versions auto-discovered on your tailnet — are migrated into the roster as **Auth needed**. Click **Add token** on each and paste its token (run `gmux auth` on that host) to bring it back online. Other tailnet machines aren't carried over; re-add them with **Connect to host** if you want them. Your `projects.json` is backed up to `projects.json.bak` before the upgrade rewrites it.
 
 Connected peers show launch buttons for each configured adapter, just like the local host.
 
@@ -108,8 +108,8 @@ Click a session to attach. You get a full interactive terminal powered by [xterm
 ### From the command line
 
 ```bash
-gmux pi              # coding agent
-gmux pytest --watch  # any command
+gmux -- pi              # coding agent
+gmux -- pytest --watch  # any command
 ```
 
 ### From the UI

--- a/cli/gmux/cmd/gmux/actions.go
+++ b/cli/gmux/cmd/gmux/actions.go
@@ -56,6 +56,23 @@ func fetchSessions() ([]cliSession, error) {
 	return envelope.Data, nil
 }
 
+// sessionExited reports whether gmuxd considers the session no longer
+// alive: either it is present but dead, or gmuxd no longer knows the id
+// at all (it was pruned). A fetch error returns false so a transient
+// network hiccup is never mistaken for session death.
+func sessionExited(id string) bool {
+	sessions, err := fetchSessions()
+	if err != nil {
+		return false
+	}
+	for _, s := range sessions {
+		if s.ID == id {
+			return !s.Alive
+		}
+	}
+	return true
+}
+
 // resolveSession fetches the session list from gmuxd and finds the one
 // the user's reference points to. See matchSession for the matching
 // rules.

--- a/cli/gmux/cmd/gmux/actions.go
+++ b/cli/gmux/cmd/gmux/actions.go
@@ -243,7 +243,7 @@ func displayID(s cliSession) string {
 // Rows are grouped alive-first then by start time; columns are kept
 // shallow (id, status, kind, title, cwd) so the output stays readable
 // in a narrow terminal.
-func cmdList(host string, all bool) int {
+func cmdList(all bool, asJSON bool) int {
 	sessions, err := fetchSessions()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "gmux:", err)
@@ -253,13 +253,12 @@ func cmdList(host string, all bool) int {
 	// Scope to the requested view:
 	//   default → local only (Peer == "")
 	//   --all   → everything
-	//   --host  → just that peer
-	// (parseCLI already rejects --host + --all.)
-	switch {
-	case host != "":
-		sessions = filterByHost(sessions, host)
-	case !all:
+	if !all {
 		sessions = filterByHost(sessions, "")
+	}
+
+	if asJSON {
+		return emitSessionsJSON(sessions)
 	}
 
 	if len(sessions) == 0 {
@@ -324,8 +323,8 @@ func cmdList(host string, all bool) int {
 // peers work the same way local sessions do. gmuxd translates this into
 // a SIGTERM on the child process and lets the normal exit lifecycle
 // update the store.
-func cmdKill(ref, host string) int {
-	sess, err := resolveSession(ref, host)
+func cmdKill(ref string) int {
+	sess, err := resolveSession(ref, "")
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "gmux:", err)
 		return 1
@@ -361,35 +360,53 @@ func cmdKill(ref, host string) int {
 // to the owning gmuxd), and peer-dead (forward-then-disk on the peer).
 // Output is raw PTY bytes including ANSI; pipe through your favorite
 // stripper if you want plain text.
-func cmdTail(ref string, n int, host string) int {
-	sess, err := resolveSession(ref, host)
+func cmdTail(ref string, n int, raw bool) int {
+	sess, err := resolveSession(ref, "")
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "gmux:", err)
 		return 1
 	}
 
+	data, code := fetchScrollback(sess, n)
+	if code != 0 {
+		return code
+	}
+	if !raw {
+		data = stripANSI(data)
+	}
+	if _, err := os.Stdout.Write(data); err != nil {
+		fmt.Fprintln(os.Stderr, "gmux:", err)
+		return 1
+	}
+	return 0
+}
+
+// fetchScrollback pulls the last n lines of a session's scrollback from
+// gmuxd's broker. Returns the raw bytes and a process exit code (0 ok).
+func fetchScrollback(sess cliSession, n int) ([]byte, int) {
 	client := gmuxdClient()
 	url := fmt.Sprintf("%s/v1/sessions/%s/scrollback?tail=%d", gmuxdBaseURL(), sess.ID, n)
 	resp, err := client.Get(url)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "gmux:", err)
-		return 1
+		return nil, 1
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
 		if resp.StatusCode == http.StatusNotFound {
 			fmt.Fprintf(os.Stderr, "gmux: session %s not found\n", displayID(sess))
-			return 1
+			return nil, 1
 		}
 		fmt.Fprintf(os.Stderr, "gmux: tail failed: %s: %s\n", resp.Status, strings.TrimSpace(string(body)))
-		return 1
+		return nil, 1
 	}
-	if _, err := io.Copy(os.Stdout, resp.Body); err != nil && !errors.Is(err, io.EOF) {
+	data, err := io.ReadAll(resp.Body)
+	if err != nil && !errors.Is(err, io.EOF) {
 		fmt.Fprintln(os.Stderr, "gmux:", err)
-		return 1
+		return nil, 1
 	}
-	return 0
+	return data, 0
 }
 
 // cmdSend implements `gmux --send [--no-submit] <id> [text]`.
@@ -411,14 +428,24 @@ func cmdTail(ref string, n int, host string) int {
 // peer sessions (gmuxd forwards to the owning peer transparently).
 // Access control inherits from gmuxd: local IPC is owner-only, and
 // peers honor their own `tailscale.allow` config.
-func cmdSend(ref string, text *string, noSubmit bool, host string) int {
-	sess, err := resolveSession(ref, host)
+func cmdSend(ref string, text *string, keys []string) int {
+	return sendBytes(ref, buildSendBody(text, keys, os.Stdin))
+}
+
+// cmdSendKeys implements the tmux-compatible `gmux send-keys -t <id>
+// <keys...>` form: every argument is a key name unless -l (literal)
+// is set, in which case arguments are sent as literal text.
+func cmdSendKeys(ref string, keys []string, literal bool) int {
+	return sendBytes(ref, strings.NewReader(renderKeys(keys, literal)))
+}
+
+// sendBytes resolves ref and POSTs body to the session's input endpoint.
+func sendBytes(ref string, body io.Reader) int {
+	sess, err := resolveSession(ref, "")
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "gmux:", err)
 		return 1
 	}
-
-	body := buildSendBody(text, os.Stdin, noSubmit)
 
 	client := gmuxdClient()
 	// Stdin may be paced by a human or upstream process; the default
@@ -470,17 +497,79 @@ const maxSendBytes = 1 << 20 // 1 MiB
 // failing for users who expected `cat`-style behavior. A redundant \r
 // in the input is harmless (submits an empty line at most), so we don't
 // try to detect and dedupe.
-func buildSendBody(text *string, stdin io.Reader, noSubmit bool) io.Reader {
-	var body io.Reader
+func buildSendBody(text *string, keys []string, stdin io.Reader) io.Reader {
+	// No text and no keys: read from stdin verbatim (the pipe form,
+	// `echo hi | gmux send <id>`). Callers wanting submission include a
+	// trailing Enter key explicitly.
+	if text == nil && len(keys) == 0 {
+		return io.LimitReader(stdin, maxSendBytes)
+	}
+	readers := make([]io.Reader, 0, 2)
 	if text != nil {
-		body = strings.NewReader(*text)
-	} else {
-		body = io.LimitReader(stdin, maxSendBytes)
+		readers = append(readers, strings.NewReader(*text))
 	}
-	if !noSubmit {
-		body = io.MultiReader(body, strings.NewReader("\r"))
+	if len(keys) > 0 {
+		readers = append(readers, strings.NewReader(renderKeys(keys, false)))
 	}
-	return body
+	return io.MultiReader(readers...)
 }
 
+// emitSessionsJSON prints sessions as a single JSON array with a stable
+// schema so agents can consume `gmux ls --json` without scraping the
+// human table. Always emits an array (never null) even when empty.
+func emitSessionsJSON(sessions []cliSession) int {
+	if sessions == nil {
+		sessions = []cliSession{}
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(sessions); err != nil {
+		fmt.Fprintln(os.Stderr, "gmux:", err)
+		return 1
+	}
+	return 0
+}
 
+// stripANSI removes ANSI/VT escape sequences from PTY output so the
+// default `gmux tail` is grep-friendly plain text. `--raw` bypasses
+// this. Handles CSI (ESC [ ... letter), OSC (ESC ] ... BEL/ST), and
+// lone two-byte escapes; this is a pragmatic stripper, not a full
+// terminal emulator.
+func stripANSI(b []byte) []byte {
+	out := make([]byte, 0, len(b))
+	for i := 0; i < len(b); {
+		c := b[i]
+		if c != 0x1b { // not ESC
+			if c != '\r' { // collapse bare CRs that survive re-render
+				out = append(out, c)
+			}
+			i++
+			continue
+		}
+		// ESC sequence.
+		if i+1 >= len(b) {
+			break
+		}
+		switch b[i+1] {
+		case '[': // CSI: ESC [ params... final-byte (0x40-0x7e)
+			j := i + 2
+			for j < len(b) && (b[j] < 0x40 || b[j] > 0x7e) {
+				j++
+			}
+			i = j + 1
+		case ']': // OSC: ESC ] ... (BEL | ESC \)
+			j := i + 2
+			for j < len(b) && b[j] != 0x07 {
+				if b[j] == 0x1b && j+1 < len(b) && b[j+1] == '\\' {
+					j++
+					break
+				}
+				j++
+			}
+			i = j + 1
+		default: // two-byte escape
+			i += 2
+		}
+	}
+	return out
+}

--- a/cli/gmux/cmd/gmux/actions.go
+++ b/cli/gmux/cmd/gmux/actions.go
@@ -56,23 +56,6 @@ func fetchSessions() ([]cliSession, error) {
 	return envelope.Data, nil
 }
 
-// sessionExited reports whether gmuxd considers the session no longer
-// alive: either it is present but dead, or gmuxd no longer knows the id
-// at all (it was pruned). A fetch error returns false so a transient
-// network hiccup is never mistaken for session death.
-func sessionExited(id string) bool {
-	sessions, err := fetchSessions()
-	if err != nil {
-		return false
-	}
-	for _, s := range sessions {
-		if s.ID == id {
-			return !s.Alive
-		}
-	}
-	return true
-}
-
 // resolveSession fetches the session list from gmuxd and finds the one
 // the user's reference points to. See matchSession for the matching
 // rules.

--- a/cli/gmux/cmd/gmux/actions.go
+++ b/cli/gmux/cmd/gmux/actions.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"sort"
 	"strings"
+
+	"github.com/gmuxapp/gmux/cli/gmux/internal/localterm"
 )
 
 // session is the subset of gmuxd's Session model that the CLI cares
@@ -429,7 +431,16 @@ func fetchScrollback(sess cliSession, n int) ([]byte, int) {
 // Access control inherits from gmuxd: local IPC is owner-only, and
 // peers honor their own `tailscale.allow` config.
 func cmdSend(ref string, text *string, keys []string) int {
-	return sendBytes(ref, buildSendBody(text, keys, os.Stdin))
+	// Read stdin only when no inline text was given AND stdin is a pipe.
+	// The tty guard is essential: without it, `gmux send <id> Enter` typed
+	// interactively would block reading the terminal. With it, piped input
+	// composes with trailing keys, so `echo hi | gmux send <id> Enter`
+	// sends "hi" then submits instead of silently dropping "hi".
+	var stdin io.Reader
+	if text == nil && !localterm.IsInteractive() {
+		stdin = os.Stdin
+	}
+	return sendBytes(ref, buildSendBody(text, keys, stdin))
 }
 
 // cmdSendKeys implements the tmux-compatible `gmux send-keys -t <id>
@@ -497,16 +508,18 @@ const maxSendBytes = 1 << 20 // 1 MiB
 // failing for users who expected `cat`-style behavior. A redundant \r
 // in the input is harmless (submits an empty line at most), so we don't
 // try to detect and dedupe.
+// buildSendBody assembles the bytes to write to the session PTY: the
+// message body (inline text, else piped stdin if provided) followed by
+// any trailing key sequences. stdin is nil unless the caller determined
+// it is a pipe to read (see cmdSend). Submission is explicit — a
+// trailing Enter key, or a \r in the piped bytes.
 func buildSendBody(text *string, keys []string, stdin io.Reader) io.Reader {
-	// No text and no keys: read from stdin verbatim (the pipe form,
-	// `echo hi | gmux send <id>`). Callers wanting submission include a
-	// trailing Enter key explicitly.
-	if text == nil && len(keys) == 0 {
-		return io.LimitReader(stdin, maxSendBytes)
-	}
 	readers := make([]io.Reader, 0, 2)
-	if text != nil {
+	switch {
+	case text != nil:
 		readers = append(readers, strings.NewReader(*text))
+	case stdin != nil:
+		readers = append(readers, io.LimitReader(stdin, maxSendBytes))
 	}
 	if len(keys) > 0 {
 		readers = append(readers, strings.NewReader(renderKeys(keys, false)))

--- a/cli/gmux/cmd/gmux/actions.go
+++ b/cli/gmux/cmd/gmux/actions.go
@@ -57,42 +57,43 @@ func fetchSessions() ([]cliSession, error) {
 }
 
 // resolveSession fetches the session list from gmuxd and finds the one
-// the user's reference points to. host is the optional --host flag; an
-// empty host means "local sessions only". See matchSession for the
-// matching rules.
-func resolveSession(ref, host string) (cliSession, error) {
+// the user's reference points to. See matchSession for the matching
+// rules.
+func resolveSession(ref string) (cliSession, error) {
 	sessions, err := fetchSessions()
 	if err != nil {
 		return cliSession{}, err
 	}
-	return matchSession(sessions, ref, host)
+	return matchSession(sessions, ref)
 }
 
-// matchSession resolves a user-supplied reference to a single session,
-// scoped by host.
+// matchSession resolves a user-supplied reference to a single session.
 //
 // A reference can be:
 //   - the full session ID ("sess-abcd1234") or full slug
-//   - the short form shown by --list ("abcd1234", i.e. the ID with its
-//     "sess-" prefix stripped)
+//   - the short form shown by `gmux ls` ("abcd1234", i.e. the ID with
+//     its "sess-" prefix stripped)
 //   - a unique prefix of any of the above
-//   - any of the above with an "@<host>" suffix to target a peer
+//   - any of the above with an "@<peer>" suffix to target a peer
 //
-// host comes from the --host flag. An @-suffix in ref overrides host
-// (or must agree if both are present). An empty effective host scopes
-// the lookup to local sessions only; consistency over magic.
+// Local-by-default (ADR 0009): without an @suffix the lookup is scoped
+// to local sessions only, so a bare ref can never match — let alone act
+// on — a session on another host. Addressing a peer requires explicitly
+// typing "@<peer>".
 //
 // Exact matches (on either ID or slug) always win, even when a shorter
 // prefix would also match something else. Ambiguous prefixes return a
 // human-readable error listing the candidates. As a friendly hint, if
 // a strict-local lookup fails but exactly one peer session matches the
 // ref, the error suggests the qualified id@peer form.
-func matchSession(sessions []cliSession, ref, host string) (cliSession, error) {
+func matchSession(sessions []cliSession, ref string) (cliSession, error) {
 	if ref == "" {
 		return cliSession{}, fmt.Errorf("empty session reference")
 	}
 
-	// Split off any @host suffix. Reconcile with the --host flag.
+	// The only way to widen the scope past local is an explicit @peer
+	// suffix on the ref.
+	host := ""
 	if idx := strings.LastIndex(ref, "@"); idx > 0 {
 		suffixHost := ref[idx+1:]
 		if suffixHost == "" {
@@ -100,9 +101,6 @@ func matchSession(sessions []cliSession, ref, host string) (cliSession, error) {
 			// as local would silently scope wrong; demand the user make
 			// the intent explicit.
 			return cliSession{}, fmt.Errorf("session ref %q has empty @host suffix", ref)
-		}
-		if host != "" && host != suffixHost {
-			return cliSession{}, fmt.Errorf("--host=%q conflicts with %q in session ref", host, suffixHost)
 		}
 		host = suffixHost
 		ref = ref[:idx]
@@ -126,7 +124,7 @@ func matchSession(sessions []cliSession, ref, host string) (cliSession, error) {
 	// Friendly miss: if the user gave no host and the ref matches
 	// peer sessions, suggest the qualified form rather than just
 	// saying "not found". This is the most common confused-paste
-	// case (`gmux --list --all` shows c0b3c1a1@konyvtar, user copies
+	// case (`gmux ls --all` shows c0b3c1a1@konyvtar, user copies
 	// just the c0b3c1a1).
 	if host == "" {
 		peerPool := make([]cliSession, 0, len(sessions))
@@ -226,7 +224,7 @@ func shortID(id string) string {
 // displayID returns the user-visible address for a session: shortID for
 // local sessions, shortID@peer for peer sessions. Use it in error
 // messages so the printed id matches what the user typed (and what
-// --list shows), instead of dropping the @peer suffix and leaving them
+// `gmux ls` shows), instead of dropping the @peer suffix and leaving them
 // wondering which session the message refers to.
 func displayID(s cliSession) string {
 	if s.Peer == "" {
@@ -235,12 +233,12 @@ func displayID(s cliSession) string {
 	return shortID(s.ID) + "@" + s.Peer
 }
 
-// cmdList implements `gmux --list`.
+// cmdList implements `gmux ls [--all] [--json]`.
 //
-// Defaults to local sessions only; pass --all to include every peer, or
-// --host=<peer> to scope to one. The ID column carries the @host
-// suffix for peer sessions so the displayed ID is a single copy-paste
-// unit that works directly with --send, --kill, etc.
+// Defaults to local sessions only; pass --all to include every peer.
+// The ID column carries the @peer suffix for peer sessions so the
+// displayed ID is a single copy-paste unit that works directly with
+// send, kill, etc.
 //
 // Rows are grouped alive-first then by start time; columns are kept
 // shallow (id, status, kind, title, cwd) so the output stays readable
@@ -288,7 +286,7 @@ func cmdList(all bool, asJSON bool) int {
 		if s.Peer != "" {
 			// The @peer suffix is part of the addressable ID, not just
 			// status flavor: copy-pasting this row's ID into
-			// `gmux --send` must work without further typing.
+			// `gmux send` must work without further typing.
 			id += "@" + s.Peer
 		}
 		title := s.Title
@@ -319,14 +317,14 @@ func cmdList(all bool, asJSON bool) int {
 	return 0
 }
 
-// cmdKill implements `gmux --kill <id>`.
+// cmdKill implements `gmux kill <id>`.
 //
 // Routes through gmuxd rather than the session's own socket so remote
 // peers work the same way local sessions do. gmuxd translates this into
 // a SIGTERM on the child process and lets the normal exit lifecycle
 // update the store.
 func cmdKill(ref string) int {
-	sess, err := resolveSession(ref, "")
+	sess, err := resolveSession(ref)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "gmux:", err)
 		return 1
@@ -353,7 +351,7 @@ func cmdKill(ref string) int {
 	return 0
 }
 
-// cmdTail implements `gmux --tail N <id>`.
+// cmdTail implements `gmux tail <id> [-n N] [--raw]`.
 //
 // Routes through gmuxd's scrollback broker rather than the per-session
 // Unix socket so the same code path serves four cases uniformly:
@@ -363,7 +361,7 @@ func cmdKill(ref string) int {
 // Output is raw PTY bytes including ANSI; pipe through your favorite
 // stripper if you want plain text.
 func cmdTail(ref string, n int, raw bool) int {
-	sess, err := resolveSession(ref, "")
+	sess, err := resolveSession(ref)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "gmux:", err)
 		return 1
@@ -411,19 +409,17 @@ func fetchScrollback(sess cliSession, n int) ([]byte, int) {
 	return data, 0
 }
 
-// cmdSend implements `gmux --send [--no-submit] <id> [text]`.
+// cmdSend implements `gmux send <id> [text] [Key...]`.
 //
-// Sends bytes to the session's PTY as if they had been typed at the
-// terminal, then appends a carriage return so the input is submitted.
-// The submit-by-default shape matches what every other "send a message"
-// CLI does (gh issue comment, slack send, jira issue comment add) and
-// avoids the silent-failure trap of bytes-without-\r sitting in the
-// agent's input box forever. `--no-submit` opts out for the rare
-// flow where you want to pre-fill input without dispatching it.
+// Sends bytes to the session's PTY as if typed at the terminal: the
+// inline text (or piped stdin) followed by any trailing key tokens.
+// Submission is explicit (ADR 0009) — a trailing `Enter` key, or a \r
+// in piped bytes — so there is no implicit carriage return.
 //
-// When text is provided inline it is sent verbatim before the submit;
-// when text is omitted, stdin is read until EOF — the natural shape
-// for piping: `echo hello | gmux --send abc`.
+// When text is provided inline it is sent verbatim; when it is omitted
+// and stdin is a pipe, stdin is read until EOF (`echo hi | gmux send
+// <id> Enter`). Trailing keys (`Enter`, `C-c`, ...) render to their
+// terminal byte sequences and are appended after the body.
 //
 // Routes through gmuxd's session-action API rather than dialing the
 // runner socket directly, so the same code path handles local and
@@ -452,7 +448,7 @@ func cmdSendKeys(ref string, keys []string, literal bool) int {
 
 // sendBytes resolves ref and POSTs body to the session's input endpoint.
 func sendBytes(ref string, body io.Reader) int {
-	sess, err := resolveSession(ref, "")
+	sess, err := resolveSession(ref)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "gmux:", err)
 		return 1

--- a/cli/gmux/cmd/gmux/actions_test.go
+++ b/cli/gmux/cmd/gmux/actions_test.go
@@ -125,44 +125,44 @@ func TestShortID(t *testing.T) {
 // has to wrap both.
 func TestBuildSendBody(t *testing.T) {
 	tests := []struct {
-		name     string
-		text     *string
-		stdin    string
-		noSubmit bool
-		want     string
+		name  string
+		text  *string
+		keys  []string
+		stdin string
+		want  string
 	}{
 		{
-			name: "inline text submits with trailing \\r",
+			name: "text without keys sends verbatim, no submit",
 			text: stringPtr("hello"),
+			want: "hello",
+		},
+		{
+			name: "text + Enter submits with trailing \\r",
+			text: stringPtr("hello"),
+			keys: []string{"Enter"},
 			want: "hello\r",
 		},
 		{
-			name:     "inline text with --no-submit sends verbatim",
-			text:     stringPtr("hello"),
-			noSubmit: true,
-			want:     "hello",
+			name: "text + C-c appends the control byte",
+			text: stringPtr("hello"),
+			keys: []string{"C-c"},
+			want: "hello\x03",
 		},
 		{
-			name:  "stdin submits with trailing \\r",
+			name: "keys only, no text",
+			keys: []string{"Escape", "Enter"},
+			want: "\x1b\r",
+		},
+		{
+			name:  "stdin verbatim when no text and no keys",
 			stdin: "prompt body\nwith newline\n",
-			want:  "prompt body\nwith newline\n\r",
-		},
-		{
-			name:     "stdin with --no-submit preserves trailing newline only",
-			stdin:    "prompt body\nwith newline\n",
-			noSubmit: true,
-			want:     "prompt body\nwith newline\n",
-		},
-		{
-			name: "empty inline text still submits an empty line",
-			text: stringPtr(""),
-			want: "\r",
+			want:  "prompt body\nwith newline\n",
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			body := buildSendBody(tc.text, strings.NewReader(tc.stdin), tc.noSubmit)
+			body := buildSendBody(tc.text, tc.keys, strings.NewReader(tc.stdin))
 			got, err := io.ReadAll(body)
 			if err != nil {
 				t.Fatalf("read body: %v", err)

--- a/cli/gmux/cmd/gmux/actions_test.go
+++ b/cli/gmux/cmd/gmux/actions_test.go
@@ -34,7 +34,7 @@ func TestMatchSession(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := matchSession(sessions, tc.ref, "")
+			got, err := matchSession(sessions, tc.ref)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -54,7 +54,7 @@ func TestMatchSessionAmbiguous(t *testing.T) {
 		{ID: "sess-abcd1234", Slug: "fix-auth"},
 		{ID: "sess-abcd5678", Slug: "fix-bug"},
 	}
-	_, err := matchSession(sessions, "abcd", "")
+	_, err := matchSession(sessions, "abcd")
 	if err == nil {
 		t.Fatal("expected ambiguous error")
 	}
@@ -75,7 +75,7 @@ func TestMatchSessionExactBeatsPrefix(t *testing.T) {
 		{ID: "sess-abcd"},     // exact match for short form "abcd"
 		{ID: "sess-abcdef01"}, // also starts with "abcd"
 	}
-	got, err := matchSession(sessions, "abcd", "")
+	got, err := matchSession(sessions, "abcd")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -89,13 +89,13 @@ func TestMatchSessionExactBeatsPrefix(t *testing.T) {
 // random one.
 func TestMatchSessionNoMatch(t *testing.T) {
 	sessions := []cliSession{{ID: "sess-abcd1234"}}
-	if _, err := matchSession(sessions, "zzzz", ""); err == nil {
+	if _, err := matchSession(sessions, "zzzz"); err == nil {
 		t.Error("expected error for non-matching ref")
 	}
-	if _, err := matchSession(nil, "anything", ""); err == nil {
+	if _, err := matchSession(nil, "anything"); err == nil {
 		t.Error("expected error when session list is empty")
 	}
-	if _, err := matchSession(sessions, "", ""); err == nil {
+	if _, err := matchSession(sessions, ""); err == nil {
 		t.Error("expected error for empty ref")
 	}
 }
@@ -200,7 +200,7 @@ func TestMatchSessionStrictLocalDefault(t *testing.T) {
 	sessions := []cliSession{
 		{ID: "sess-abcd1234", Peer: "konyvtar"},
 	}
-	_, err := matchSession(sessions, "abcd1234", "")
+	_, err := matchSession(sessions, "abcd1234")
 	if err == nil {
 		t.Fatal("strict-local lookup should not see a peer-only session")
 	}
@@ -215,7 +215,7 @@ func TestMatchSessionFriendlyHintForPeerOnlyMatch(t *testing.T) {
 	sessions := []cliSession{
 		{ID: "sess-abcd1234", Peer: "konyvtar"},
 	}
-	_, err := matchSession(sessions, "abcd1234", "")
+	_, err := matchSession(sessions, "abcd1234")
 	if err == nil {
 		t.Fatal("expected error for peer-only short id without --host")
 	}
@@ -236,56 +236,7 @@ func TestMatchSessionAtSuffixRoutes(t *testing.T) {
 		{ID: "sess-abcd1234", Peer: "konyvtar"}, // namespaced collision
 		{ID: "sess-ef019283", Peer: "bespin"},
 	}
-	got, err := matchSession(sessions, "abcd1234@konyvtar", "")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if got.Peer != "konyvtar" {
-		t.Errorf("expected konyvtar session, got peer=%q", got.Peer)
-	}
-}
-
-// TestMatchSessionHostFlag exercises the equivalence between
-// --host=peer and @peer. Both should resolve to the same session;
-// otherwise the design's "two forms, same meaning" claim is wrong.
-func TestMatchSessionHostFlag(t *testing.T) {
-	sessions := []cliSession{
-		{ID: "sess-abcd1234", Peer: "konyvtar"},
-	}
-	got, err := matchSession(sessions, "abcd1234", "konyvtar")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if got.Peer != "konyvtar" {
-		t.Errorf("expected konyvtar session, got peer=%q", got.Peer)
-	}
-}
-
-// TestMatchSessionHostAndSuffixConflict guards the contract that a
-// user can't address two different hosts in one invocation. Silent
-// preference for either side would be a footgun.
-func TestMatchSessionHostAndSuffixConflict(t *testing.T) {
-	sessions := []cliSession{
-		{ID: "sess-abcd1234", Peer: "konyvtar"},
-	}
-	_, err := matchSession(sessions, "abcd1234@bespin", "konyvtar")
-	if err == nil {
-		t.Fatal("expected error when @suffix and --host disagree")
-	}
-	if !strings.Contains(err.Error(), "konyvtar") || !strings.Contains(err.Error(), "bespin") {
-		t.Errorf("error should mention both hosts, got: %s", err.Error())
-	}
-}
-
-// TestMatchSessionHostAndSuffixAgreeing covers the redundancy case:
-// `--host=konyvtar abcd@konyvtar` should resolve cleanly rather than
-// be rejected as conflicting. People copy-paste IDs that already
-// carry the @suffix.
-func TestMatchSessionHostAndSuffixAgreeing(t *testing.T) {
-	sessions := []cliSession{
-		{ID: "sess-abcd1234", Peer: "konyvtar"},
-	}
-	got, err := matchSession(sessions, "abcd1234@konyvtar", "konyvtar")
+	got, err := matchSession(sessions, "abcd1234@konyvtar")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -304,7 +255,7 @@ func TestMatchSessionEmptyHostSuffixRejected(t *testing.T) {
 		{ID: "sess-abcd1234"},                   // local
 		{ID: "sess-abcd1234", Peer: "konyvtar"}, // peer
 	}
-	_, err := matchSession(sessions, "abcd1234@", "")
+	_, err := matchSession(sessions, "abcd1234@")
 	if err == nil {
 		t.Fatal("expected error for trailing @ with empty host suffix")
 	}
@@ -329,7 +280,7 @@ func TestMatchSessionMultiplePeerMatchesGetCandidateList(t *testing.T) {
 		{ID: "sess-abcd1234", Peer: "konyvtar"},
 		{ID: "sess-ab98ef76", Peer: "bespin"},
 	}
-	_, err := matchSession(sessions, "ab", "")
+	_, err := matchSession(sessions, "ab")
 	if err == nil {
 		t.Fatal("expected error for prefix matching multiple peer sessions")
 	}

--- a/cli/gmux/cmd/gmux/actions_test.go
+++ b/cli/gmux/cmd/gmux/actions_test.go
@@ -124,45 +124,60 @@ func TestShortID(t *testing.T) {
 // they construct the body differently and the carriage-return logic
 // has to wrap both.
 func TestBuildSendBody(t *testing.T) {
+	noStdin := "\x00NIL" // sentinel: this case passes a nil stdin reader
 	tests := []struct {
 		name  string
 		text  *string
 		keys  []string
-		stdin string
+		stdin string // noStdin → nil reader (the tty / no-pipe case)
 		want  string
 	}{
 		{
-			name: "text without keys sends verbatim, no submit",
-			text: stringPtr("hello"),
-			want: "hello",
+			name:  "text without keys sends verbatim, no submit",
+			text:  stringPtr("hello"),
+			stdin: noStdin,
+			want:  "hello",
 		},
 		{
-			name: "text + Enter submits with trailing \\r",
-			text: stringPtr("hello"),
-			keys: []string{"Enter"},
-			want: "hello\r",
+			name:  "text + Enter submits with trailing \\r",
+			text:  stringPtr("hello"),
+			keys:  []string{"Enter"},
+			stdin: noStdin,
+			want:  "hello\r",
 		},
 		{
-			name: "text + C-c appends the control byte",
-			text: stringPtr("hello"),
-			keys: []string{"C-c"},
-			want: "hello\x03",
+			name:  "text + C-c appends the control byte",
+			text:  stringPtr("hello"),
+			keys:  []string{"C-c"},
+			stdin: noStdin,
+			want:  "hello\x03",
 		},
 		{
-			name: "keys only, no text",
-			keys: []string{"Escape", "Enter"},
-			want: "\x1b\r",
+			name:  "keys only at a tty (nil stdin) sends just the keys",
+			keys:  []string{"Escape", "Enter"},
+			stdin: noStdin,
+			want:  "\x1b\r",
 		},
 		{
-			name:  "stdin verbatim when no text and no keys",
+			name:  "piped stdin, no keys, verbatim",
 			stdin: "prompt body\nwith newline\n",
 			want:  "prompt body\nwith newline\n",
+		},
+		{
+			name:  "piped stdin composes with trailing Enter (no silent drop)",
+			keys:  []string{"Enter"},
+			stdin: "hi",
+			want:  "hi\r",
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			body := buildSendBody(tc.text, tc.keys, strings.NewReader(tc.stdin))
+			var stdin io.Reader
+			if tc.stdin != noStdin {
+				stdin = strings.NewReader(tc.stdin)
+			}
+			body := buildSendBody(tc.text, tc.keys, stdin)
 			got, err := io.ReadAll(body)
 			if err != nil {
 				t.Fatalf("read body: %v", err)
@@ -217,8 +232,8 @@ func TestMatchSessionFriendlyHintForPeerOnlyMatch(t *testing.T) {
 // action subcommands.
 func TestMatchSessionAtSuffixRoutes(t *testing.T) {
 	sessions := []cliSession{
-		{ID: "sess-abcd1234"},                       // local
-		{ID: "sess-abcd1234", Peer: "konyvtar"},     // namespaced collision
+		{ID: "sess-abcd1234"},                   // local
+		{ID: "sess-abcd1234", Peer: "konyvtar"}, // namespaced collision
 		{ID: "sess-ef019283", Peer: "bespin"},
 	}
 	got, err := matchSession(sessions, "abcd1234@konyvtar", "")
@@ -323,5 +338,29 @@ func TestMatchSessionMultiplePeerMatchesGetCandidateList(t *testing.T) {
 	// pick the right one and retypes.
 	if !strings.Contains(msg, "abcd1234@konyvtar") || !strings.Contains(msg, "ab98ef76@bespin") {
 		t.Errorf("error should list both qualified candidates, got: %s", msg)
+	}
+}
+
+func TestStripANSI(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain text untouched", "hello world\n", "hello world\n"},
+		{"CSI color codes removed", "\x1b[31mred\x1b[0m text", "red text"},
+		{"cursor-move CSI removed", "a\x1b[2Kb\x1b[1;5Hc", "abc"},
+		{"OSC title (BEL-terminated) removed", "\x1b]0;my title\x07done", "done"},
+		{"OSC (ST-terminated) removed", "\x1b]8;;http://x\x1b\\link", "link"},
+		{"CRLF normalized to LF", "line1\r\nline2\r\n", "line1\nline2\n"},
+		{"UTF-8 multibyte preserved", "café — π ✓", "café — π ✓"},
+		{"lone ESC at end does not panic", "trailing\x1b", "trailing"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := string(stripANSI([]byte(tc.in))); got != tc.want {
+				t.Errorf("stripANSI(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
 	}
 }

--- a/cli/gmux/cmd/gmux/attach.go
+++ b/cli/gmux/cmd/gmux/attach.go
@@ -13,7 +13,7 @@ import (
 	"nhooyr.io/websocket"
 )
 
-// cmdAttach implements `gmux --attach <id>`.
+// cmdAttach implements `gmux attach <id>`.
 //
 // Opens a WebSocket to gmuxd's /ws/{id} handler via the local Unix
 // socket. gmuxd proxies to the session's own Unix socket for local
@@ -24,8 +24,8 @@ import (
 // helper that `gmux <cmd>` uses, so attach feels the same as an
 // original launch: transparent I/O, SIGWINCH → resize, SIGHUP →
 // detach (session keeps running), Ctrl-C goes to the child.
-func cmdAttach(ref, host string) int {
-	sess, err := resolveSession(ref, host)
+func cmdAttach(ref string) int {
+	sess, err := resolveSession(ref)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "gmux:", err)
 		return 1
@@ -41,7 +41,7 @@ func cmdAttach(ref, host string) int {
 	}
 
 	if !localterm.IsInteractive() {
-		fmt.Fprintln(os.Stderr, "gmux: --attach requires an interactive terminal")
+		fmt.Fprintln(os.Stderr, "gmux: attach requires an interactive terminal")
 		return 1
 	}
 
@@ -161,4 +161,3 @@ func sendResize(ctx context.Context, conn *websocket.Conn, cols, rows uint16) {
 	}
 	_ = conn.Write(ctx, websocket.MessageText, data)
 }
-

--- a/cli/gmux/cmd/gmux/cli.go
+++ b/cli/gmux/cmd/gmux/cli.go
@@ -5,344 +5,449 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"strings"
 )
 
 // mode is the top-level action gmux is being asked to perform.
 type mode int
 
 const (
-	modeUI     mode = iota // no args → open the web UI
-	modeRun                // run a command in a new session
-	modeList               // list known sessions
-	modeAttach             // reattach to an existing session
-	modeTail               // dump recent output from a session
-	modeKill               // terminate a session
-	modeSend               // inject input into a running session
-	modeWait               // block until session reaches idle / dies
-	modeDumpEnv            // (daemon-internal) write os.Environ() to fd 3 and exit
-	modeHelp               // print usage and exit
+	modeHelp     mode = iota // print usage and exit
+	modeVersion              // print version and exit
+	modeOpen                 // open the web UI
+	modeRun                  // run a command in a new session (gmux -- <cmd>)
+	modeList                 // gmux ls
+	modeAttach               // gmux attach <id>
+	modeTail                 // gmux tail <id>
+	modeKill                 // gmux kill <id>
+	modeSend                 // gmux send <id> <text> [keys...]
+	modeSendKeys             // gmux send-keys -t <id> ... (tmux-compat)
+	modeWait                 // gmux wait <id>
+	modeDaemon               // gmux daemon <start|stop|restart|status|log-path>
+	modeAuth                 // gmux auth
+	modeRemote               // gmux remote
+	modeDumpEnv              // (internal) gmux __dump-env
 )
 
-// flags captures the parsed gmux-level options. Anything that influences
-// the run path ("flags the runner cares about") or triggers a management
-// action ("flags that replace the runner") lives here. The trailing
-// positional command or session id is returned separately as rest.
-type flags struct {
-	noAttach    bool
-	list        bool
-	attach      bool
-	kill        bool
-	send        bool
-	noSubmit    bool // suppresses the trailing carriage return on --send
-	wait        bool
-	waitTimeout int // 0 means no timeout
-	tail        int // >=0 when set (flag default is -1)
-	host        string // --host=<peer>: target this peer instead of local
-	all         bool   // --list --all: include peer sessions in output
-	help        bool
+// command is the fully-parsed CLI invocation. One struct for every
+// verb keeps dispatch in main.go a single switch with no flag-combo
+// validation: each verb's parser only sets the fields it owns.
+type command struct {
+	mode mode
 
-	// daemon→runner directives. Only set when gmuxd forks a runner
-	// for /v1/launch, /v1/resume, /v1/restart. End users have no
-	// reason to pass them, but they're plain CLI flags so the
-	// daemon↔runner contract is greppable and toolable; the legacy
-	// GMUX_RESUME_ID env var is still honored as a fallback.
-	resumeID    string // --resume-id=<id>: reuse this session id
-	initialCols int    // --initial-cols=N: pre-size PTY
-	initialRows int    // --initial-rows=N: pre-size PTY
-	dumpEnv     bool   // --dump-env: write os.Environ() NUL-delimited to fd 3, then exit
+	// run (modeRun / internal __run)
+	detach      bool
+	runArgs     []string // the wrapped command, verbatim
+	resumeID    string   // internal: reuse this session id
+	initialCols int      // internal: pre-size PTY width
+	initialRows int      // internal: pre-size PTY height
+
+	// session-addressing verbs (attach/tail/kill/send/send-keys/wait)
+	ref string // session reference; may carry an @peer suffix
+
+	// ls
+	all  bool
+	json bool
+
+	// tail
+	tailLines int
+	raw       bool
+
+	// send
+	sendText *string  // literal text to type (nil = none)
+	sendKeys []string // trailing key-name tokens (Enter, C-c, ...)
+
+	// send-keys (tmux-compat)
+	keysLiteral bool     // -l: treat args as literal text, not key names
+	keys        []string // key/text arguments
+
+	// wait
+	forText  string // --for-text: fixed substring
+	forRegex string // --for-regex: regular expression
+	timeout  int    // --timeout seconds (0 = none)
+
+	// daemon
+	daemonSub string // start|stop|restart|status|log-path
+
+	// help
+	helpTopic string // optional verb to show focused help for
 }
 
-// parseCLI parses argv (without program name) and decides which mode to
-// dispatch. Flag parsing stops at the first positional argument, matching
-// the POSIX runner convention (env/nohup/time/screen): everything from
-// the first bare word onwards is the command, verbatim, including its
-// own flags.
-//
-// A literal `--` also terminates flag parsing, for the rare case where
-// the command itself starts with a dash.
-func parseCLI(args []string) (mode, *flags, []string, error) {
-	f := &flags{tail: -1}
-	fs := flag.NewFlagSet("gmux", flag.ContinueOnError)
-	fs.SetOutput(io.Discard) // we print our own usage on error
+// reservedVerbs is the closed top-level namespace (ADR 0009). Growth
+// happens under namespace groups, not new top-level verbs. Used to give
+// "did you mean?" hints and to distinguish a removed flag from a stray
+// command in the error-only migration shim.
+var reservedVerbs = []string{
+	"open", "ls", "attach", "tail", "kill", "send", "send-keys",
+	"wait", "daemon", "auth", "remote", "version", "help",
+}
 
-	fs.BoolVar(&f.noAttach, "no-attach", false, "run the command detached from the terminal")
-	fs.BoolVar(&f.list, "list", false, "list known sessions")
-	fs.BoolVar(&f.list, "l", false, "list known sessions (short)")
-	fs.BoolVar(&f.attach, "attach", false, "reattach to an existing session")
-	fs.BoolVar(&f.attach, "a", false, "reattach to an existing session (short)")
-	fs.BoolVar(&f.kill, "kill", false, "kill a running session")
-	fs.BoolVar(&f.kill, "k", false, "kill a running session (short)")
-	fs.BoolVar(&f.send, "send", false, "send input to a running session")
-	fs.BoolVar(&f.noSubmit, "no-submit", false, "with --send, do not append the carriage return that submits the input")
-	fs.BoolVar(&f.wait, "wait", false, "block until a session is idle (agent finished its turn)")
-	fs.IntVar(&f.waitTimeout, "timeout", 0, "with --wait, fail after N seconds (default: no timeout)")
-	fs.IntVar(&f.tail, "tail", -1, "dump the last N lines of a session")
-	fs.IntVar(&f.tail, "t", -1, "dump the last N lines of a session (short)")
-	fs.StringVar(&f.host, "host", "", "target a peer by name (e.g. --host=konyvtar); equivalent to id@peer")
-	fs.BoolVar(&f.all, "all", false, "with --list, include sessions from all peers (default: local only)")
-	fs.BoolVar(&f.help, "help", false, "show help")
-	fs.BoolVar(&f.help, "h", false, "show help (short)")
-	fs.StringVar(&f.resumeID, "resume-id", "", "(daemon-internal) reuse this session id instead of generating a fresh one")
-	fs.IntVar(&f.initialCols, "initial-cols", 0, "(daemon-internal) pre-size the PTY width")
-	fs.IntVar(&f.initialRows, "initial-rows", 0, "(daemon-internal) pre-size the PTY height")
-	fs.BoolVar(&f.dumpEnv, "dump-env", false, "(daemon-internal) write the environment to fd 3 and exit")
+// removedFlags maps every pre-2.0 action flag to the verb that replaced
+// it. The migration shim (ADR 0009) recognizes these solely to print a
+// precise error; no old behavior is carried.
+var removedFlags = map[string]string{
+	"--list": "gmux ls", "-l": "gmux ls",
+	"--attach": "gmux attach <id>", "-a": "gmux attach <id>",
+	"--tail": "gmux tail <id>", "-t": "gmux tail <id>",
+	"--kill": "gmux kill <id>", "-k": "gmux kill <id>",
+	"--send":      "gmux send <id> <text>",
+	"--no-submit": "gmux send <id> <text>  (omit a trailing Enter to not submit)",
+	"--wait":      "gmux wait <id>",
+	"--no-attach": "gmux -d -- <cmd>",
+	"--host":      "address the session as <id>@<peer> instead",
+	"--all":       "gmux ls --all",
+}
 
-	if err := fs.Parse(args); err != nil {
-		return modeHelp, nil, nil, err
-	}
-	rest := fs.Args()
-
-	if f.help {
-		return modeHelp, f, rest, nil
+// parseCLI parses argv (without program name) into a command.
+func parseCLI(args []string) (*command, error) {
+	if len(args) == 0 {
+		return &command{mode: modeHelp}, nil
 	}
 
-	// --dump-env is the env-capture probe gmuxd runs inside a login
-	// shell (see ADR 0006). It short-circuits every other mode: no
-	// command, no management action, just dump and exit. Checked here,
-	// before management/run dispatch, so it can never be mistaken for a
-	// command to exec.
-	if f.dumpEnv {
-		return modeDumpEnv, f, nil, nil
+	// Consume leading global flags. Only -d/--detach is global, and it
+	// is valid solely on the run form (gmux -d -- <cmd>).
+	detach := false
+	for len(args) > 0 && (args[0] == "-d" || args[0] == "--detach") {
+		detach = true
+		args = args[1:]
 	}
 
-	// In management modes there is no wrapped command, only a bounded
-	// number of positionals (id, optional text for --send). The POSIX
-	// runner stop-at-first-positional rule that protects `gmux <cmd>
-	// --cmd-flag` from having gmux eat --cmd-flag does nothing useful
-	// here — it just turns `gmux --wait <id> --timeout 60` into a
-	// silent foot-trap where --timeout becomes a positional. Re-parse
-	// any flags interleaved with positionals so flag order doesn't
-	// matter for management actions.
-	if isManagementMode(f) {
-		rest = parseInterspersedFlags(fs, rest)
+	if len(args) == 0 {
+		return nil, errors.New("-d/--detach requires a command: gmux -d -- <cmd>")
 	}
 
-	// At most one management action at a time.
-	actions := 0
-	if f.list {
-		actions++
-	}
-	if f.attach {
-		actions++
-	}
-	if f.kill {
-		actions++
-	}
-	if f.send {
-		actions++
-	}
-	if f.wait {
-		actions++
-	}
-	if f.tail >= 0 {
-		actions++
-	}
-	if actions > 1 {
-		return modeHelp, nil, nil, errors.New("--list, --attach, --tail, --kill, --send, --wait are mutually exclusive")
+	head := args[0]
+	rest := args[1:]
+
+	// `gmux -- <cmd>` (and `gmux -d -- <cmd>`): everything after -- is
+	// the command verbatim.
+	if head == "--" {
+		if len(rest) == 0 {
+			return nil, errors.New("gmux -- requires a command")
+		}
+		return &command{mode: modeRun, detach: detach, runArgs: rest}, nil
 	}
 
-	// --no-submit only changes the bytes --send writes; with anything
-	// else it would silently do nothing, so reject it loudly.
-	if f.noSubmit && !f.send {
-		return modeHelp, nil, nil, errors.New("--no-submit only applies with --send")
-	}
-	// --timeout is meaningless without --wait. (Once we add other
-	// time-bounded actions it can grow into a shared option.)
-	if f.waitTimeout != 0 && !f.wait {
-		return modeHelp, nil, nil, errors.New("--timeout only applies with --wait")
-	}
-	// --all is a discovery-only flag: it widens what --list shows. On an
-	// action command (--send, --kill, etc.) "all peers at once" is a
-	// footgun, so we only accept it with --list.
-	if f.all && !f.list {
-		return modeHelp, nil, nil, errors.New("--all only applies with --list")
-	}
-	// --host is a filter/target for session-addressing actions. With
-	// --all it would be contradictory ("all peers + only this peer"),
-	// so disallow the combination.
-	if f.host != "" && f.all {
-		return modeHelp, nil, nil, errors.New("--host and --all are mutually exclusive")
-	}
-	// --wait crossing peers isn't wired up server-side yet (the peer
-	// would need to stream Status events back). Reject up front rather
-	// than letting the user hit an opaque gmuxd error.
-	if f.host != "" && f.wait {
-		return modeHelp, nil, nil, errors.New("--wait does not yet support --host (local sessions only)")
-	}
-	// Daemon→runner directives only make sense in run mode (gmuxd
-	// is forking a runner to execute a command). Reject up front if
-	// they leak into a management action so a misuse fails loud.
-	if (f.resumeID != "" || f.initialCols != 0 || f.initialRows != 0) && isManagementMode(f) {
-		return modeHelp, nil, nil, errors.New("--resume-id / --initial-cols / --initial-rows only apply when launching a command")
-	}
-	if f.initialCols < 0 || f.initialRows < 0 {
-		return modeHelp, nil, nil, errors.New("--initial-cols and --initial-rows must be non-negative")
+	// Past this point -d makes no sense — it only pairs with `--`.
+	if detach {
+		return nil, errors.New("-d/--detach only applies to 'gmux -- <cmd>'")
 	}
 
-	// Management actions take a single session id (except --list and --send).
-	switch {
-	case f.list:
+	switch head {
+	case "help", "-h", "--help":
+		c := &command{mode: modeHelp}
+		if len(rest) == 1 {
+			c.helpTopic = rest[0]
+		}
+		return c, nil
+	case "version", "--version", "-v":
+		return &command{mode: modeVersion}, nil
+	case "open":
 		if len(rest) > 0 {
-			return modeHelp, nil, nil, errors.New("--list takes no arguments")
+			return nil, errors.New("open takes no arguments")
 		}
-		if f.noAttach {
-			return modeHelp, nil, nil, errors.New("--no-attach has no effect with --list")
+		return &command{mode: modeOpen}, nil
+	case "ls":
+		return parseLs(rest)
+	case "attach":
+		return parseRefOnly(modeAttach, "attach", rest)
+	case "kill":
+		return parseRefOnly(modeKill, "kill", rest)
+	case "tail":
+		return parseTail(rest)
+	case "send":
+		return parseSend(rest)
+	case "send-keys":
+		return parseSendKeys(rest)
+	case "wait":
+		return parseWait(rest)
+	case "daemon":
+		return parseDaemon(rest)
+	case "auth":
+		if len(rest) > 0 {
+			return nil, errors.New("auth takes no arguments")
 		}
-		return modeList, f, nil, nil
-	case f.attach:
-		if len(rest) != 1 {
-			return modeHelp, nil, nil, errors.New("--attach requires a session id")
+		return &command{mode: modeAuth}, nil
+	case "remote":
+		if len(rest) > 0 {
+			return nil, errors.New("remote takes no arguments")
 		}
-		if f.noAttach {
-			return modeHelp, nil, nil, errors.New("--no-attach conflicts with --attach")
-		}
-		return modeAttach, f, rest, nil
-	case f.kill:
-		if len(rest) != 1 {
-			return modeHelp, nil, nil, errors.New("--kill requires a session id")
-		}
-		if f.noAttach {
-			return modeHelp, nil, nil, errors.New("--no-attach has no effect with --kill")
-		}
-		return modeKill, f, rest, nil
-	case f.send:
-		// --send takes a session id and either an inline text arg or
-		// stdin (when no text is given).
-		if len(rest) < 1 || len(rest) > 2 {
-			return modeHelp, nil, nil, errors.New("--send takes a session id and optional text (stdin is used if no text is given)")
-		}
-		if f.noAttach {
-			return modeHelp, nil, nil, errors.New("--no-attach has no effect with --send")
-		}
-		return modeSend, f, rest, nil
-	case f.wait:
-		if len(rest) != 1 {
-			return modeHelp, nil, nil, errors.New("--wait requires a session id")
-		}
-		if f.noAttach {
-			return modeHelp, nil, nil, errors.New("--no-attach has no effect with --wait")
-		}
-		if f.waitTimeout < 0 {
-			return modeHelp, nil, nil, errors.New("--timeout must be a non-negative number of seconds")
-		}
-		return modeWait, f, rest, nil
-	case f.tail >= 0:
-		if len(rest) != 1 {
-			return modeHelp, nil, nil, errors.New("--tail requires a session id")
-		}
-		if f.tail == 0 {
-			return modeHelp, nil, nil, errors.New("--tail needs a positive line count")
-		}
-		if f.noAttach {
-			return modeHelp, nil, nil, errors.New("--no-attach has no effect with --tail")
-		}
-		return modeTail, f, rest, nil
+		return &command{mode: modeRemote}, nil
+	case "__run":
+		return parseInternalRun(rest)
+	case "__dump-env":
+		return &command{mode: modeDumpEnv}, nil
 	}
 
-	// No management action. If there's a command, run it; otherwise UI.
-	if len(rest) == 0 {
-		if f.noAttach {
-			return modeHelp, nil, nil, errors.New("--no-attach requires a command")
-		}
-		if f.host != "" {
-			// Bare `gmux --host=peer` would naturally mean "open peer's
-			// web UI", but we don't have a peer-URL discovery path on the
-			// CLI yet; reject explicitly rather than silently open the
-			// local UI.
-			return modeHelp, nil, nil, errors.New("--host with no command not supported yet (use a session action)")
-		}
-		return modeUI, f, nil, nil
+	// Error-only migration shim (ADR 0009): recognize removed forms and
+	// the dropped bare-command shorthand to emit precise guidance. Strip
+	// any =value so `--host=laptop` matches the `--host` key.
+	flagKey := head
+	if eq := strings.IndexByte(flagKey, '='); eq > 0 {
+		flagKey = flagKey[:eq]
 	}
-	if f.host != "" {
-		// Remote create (`gmux --host=peer <cmd>`) is a planned follow-up
-		// to this milestone; reject for now so a half-implemented path
-		// can't silently create a session on the wrong side.
-		return modeHelp, nil, nil, errors.New("--host with a command not supported yet (remote create is planned for a follow-up)")
+	if repl, ok := removedFlags[flagKey]; ok {
+		return nil, fmt.Errorf("%s was removed in 2.0; use: %s", flagKey, repl)
 	}
-	return modeRun, f, rest, nil
+	if strings.HasPrefix(head, "-") {
+		return nil, fmt.Errorf("unknown flag %q", head)
+	}
+	if hint := didYouMean(head); hint != "" {
+		return nil, fmt.Errorf("unknown command %q; did you mean %q?", head, hint)
+	}
+	return nil, fmt.Errorf("unknown command %q; to run a command use: gmux -- %s", head, strings.Join(args, " "))
 }
 
-// isManagementMode reports whether the parsed flags request a
-// management action (no wrapped command). Run mode is everything
-// else — a command with optional --no-attach.
-func isManagementMode(f *flags) bool {
-	return f.list || f.attach || f.kill || f.send || f.wait || f.tail >= 0
+func parseLs(args []string) (*command, error) {
+	c := &command{mode: modeList}
+	fs := newFlagSet("ls")
+	fs.BoolVar(&c.all, "all", false, "include sessions from all peers")
+	fs.BoolVar(&c.json, "json", false, "emit a JSON array")
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	if len(fs.Args()) > 0 {
+		return nil, errors.New("ls takes no positional arguments")
+	}
+	return c, nil
 }
 
-// parseInterspersedFlags walks `rest` consuming any further flags via
-// fs.Parse and collecting non-flag tokens as positionals. The default
-// flag.FlagSet behavior stops at the first positional; iterating lets
-// us pick up flags that appear after positionals too. Used only in
-// management modes, where positionals are bounded and there is no
-// risk of swallowing flags meant for a wrapped child command.
-func parseInterspersedFlags(fs *flag.FlagSet, rest []string) []string {
+func parseRefOnly(m mode, name string, args []string) (*command, error) {
+	if len(args) != 1 {
+		return nil, fmt.Errorf("%s requires a session id", name)
+	}
+	return &command{mode: m, ref: args[0]}, nil
+}
+
+func parseTail(args []string) (*command, error) {
+	c := &command{mode: modeTail, tailLines: 100}
+	fs := newFlagSet("tail")
+	fs.IntVar(&c.tailLines, "n", 100, "number of lines to show")
+	fs.BoolVar(&c.raw, "raw", false, "preserve ANSI escapes")
+	fs.BoolVar(&c.raw, "e", false, "preserve ANSI escapes (short)")
+	pos, err := parseInterspersed(fs, args)
+	if err != nil {
+		return nil, err
+	}
+	if len(pos) != 1 {
+		return nil, errors.New("tail requires a session id")
+	}
+	if c.tailLines <= 0 {
+		return nil, errors.New("-n must be a positive line count")
+	}
+	c.ref = pos[0]
+	return c, nil
+}
+
+// parseSend handles `gmux send <id> [text] [Key...]`. The first
+// positional is the session ref; an optional second positional is the
+// literal text; any further bare tokens are key-name tokens. With no
+// text and no keys, stdin supplies the text.
+func parseSend(args []string) (*command, error) {
+	if len(args) < 1 {
+		return nil, errors.New("send requires a session id")
+	}
+	c := &command{mode: modeSend, ref: args[0]}
+	rest := args[1:]
+	if len(rest) > 0 {
+		// Heuristic: the first non-key token is the literal text; the
+		// rest are keys. If the first token is itself a key name, there
+		// is no text and everything is keys.
+		if !isKeyName(rest[0]) {
+			t := rest[0]
+			c.sendText = &t
+			rest = rest[1:]
+		}
+		c.sendKeys = rest
+	}
+	return c, nil
+}
+
+func parseSendKeys(args []string) (*command, error) {
+	c := &command{mode: modeSendKeys}
+	fs := newFlagSet("send-keys")
+	var target string
+	fs.StringVar(&target, "t", "", "target session id")
+	fs.BoolVar(&c.keysLiteral, "l", false, "treat arguments as literal text")
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	if target == "" {
+		return nil, errors.New("send-keys requires -t <id>")
+	}
+	c.ref = target
+	c.keys = fs.Args()
+	if len(c.keys) == 0 {
+		return nil, errors.New("send-keys requires at least one key or string")
+	}
+	return c, nil
+}
+
+func parseWait(args []string) (*command, error) {
+	c := &command{mode: modeWait}
+	fs := newFlagSet("wait")
+	fs.StringVar(&c.forText, "for-text", "", "wait until this fixed substring appears")
+	fs.StringVar(&c.forRegex, "for-regex", "", "wait until this regex matches")
+	fs.IntVar(&c.timeout, "timeout", 0, "fail after N seconds")
+	pos, err := parseInterspersed(fs, args)
+	if err != nil {
+		return nil, err
+	}
+	if len(pos) != 1 {
+		return nil, errors.New("wait requires a session id")
+	}
+	if c.forText != "" && c.forRegex != "" {
+		return nil, errors.New("--for-text and --for-regex are mutually exclusive")
+	}
+	if c.timeout < 0 {
+		return nil, errors.New("--timeout must be a non-negative number of seconds")
+	}
+	c.ref = pos[0]
+	return c, nil
+}
+
+var daemonSubs = map[string]bool{
+	"start": true, "stop": true, "restart": true, "status": true, "log-path": true,
+}
+
+func parseDaemon(args []string) (*command, error) {
+	if len(args) != 1 || !daemonSubs[args[0]] {
+		return nil, errors.New("daemon requires one of: start, stop, restart, status, log-path")
+	}
+	return &command{mode: modeDaemon, daemonSub: args[0]}, nil
+}
+
+// parseInternalRun handles the hidden `gmux __run [directives] -- <cmd>`
+// form the daemon uses to fork a runner. Directives precede `--`; the
+// command follows it verbatim.
+func parseInternalRun(args []string) (*command, error) {
+	c := &command{mode: modeRun}
+	fs := newFlagSet("__run")
+	fs.StringVar(&c.resumeID, "resume-id", "", "reuse this session id")
+	fs.IntVar(&c.initialCols, "initial-cols", 0, "pre-size PTY width")
+	fs.IntVar(&c.initialRows, "initial-rows", 0, "pre-size PTY height")
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	if c.initialCols < 0 || c.initialRows < 0 {
+		return nil, errors.New("--initial-cols and --initial-rows must be non-negative")
+	}
+	c.runArgs = fs.Args()
+	if len(c.runArgs) == 0 {
+		return nil, errors.New("__run requires a command")
+	}
+	return c, nil
+}
+
+func newFlagSet(name string) *flag.FlagSet {
+	fs := flag.NewFlagSet(name, flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	return fs
+}
+
+// parseInterspersed parses flags that may appear before or after the
+// positional arguments. Go's flag package stops at the first
+// positional; for management verbs (bounded positionals, no wrapped
+// child command) we want `gmux wait abc --timeout 30` to work the same
+// as `gmux wait --timeout 30 abc`. A literal `--` ends flag parsing.
+func parseInterspersed(fs *flag.FlagSet, args []string) ([]string, error) {
 	var positionals []string
-	remaining := rest
+	remaining := args
 	for len(remaining) > 0 {
-		// Honor `--` as a hard terminator: anything after is positional
-		// data even if it looks like a flag. fs.Parse alone is not
-		// enough — it stops AT `--`, but our loop would then re-enter
-		// fs.Parse on the suffix and happily consume `--no-submit` from
-		// the user's text as the gmux flag. Short-circuit here so the
-		// suffix flows through verbatim. Realistically this matters
-		// only for `gmux --send <id> -- <text>` where <text> may start
-		// with dashes.
 		if remaining[0] == "--" {
-			return append(positionals, remaining[1:]...)
+			return append(positionals, remaining[1:]...), nil
 		}
 		if err := fs.Parse(remaining); err != nil {
-			// fs.Parse already wrote into the same flags struct on the
-			// first call; any error here is from re-parsing an unknown
-			// flag after a positional. Surface the leftover args as-is
-			// so the caller's validation produces a sensible message.
-			return append(positionals, remaining...)
+			return nil, err
 		}
-		newRest := fs.Args()
-		if len(newRest) == 0 {
+		rest := fs.Args()
+		if len(rest) == 0 {
 			break
 		}
-		if len(newRest) == len(remaining) {
-			// fs.Parse stopped without consuming anything: first token
-			// is a positional. Take it and resume on the suffix.
-			positionals = append(positionals, newRest[0])
-			remaining = newRest[1:]
+		if len(rest) == len(remaining) {
+			// fs.Parse consumed nothing: first token is a positional.
+			positionals = append(positionals, rest[0])
+			remaining = rest[1:]
 			continue
 		}
-		// fs.Parse consumed at least one flag; loop on the new tail.
-		remaining = newRest
+		remaining = rest
 	}
-	return positionals
+	return positionals, nil
 }
 
-// printUsage writes the gmux usage synopsis. Shown on --help, on parse
-// errors (with an error message prefix), and nowhere else.
+// didYouMean returns the closest reserved verb to head, or "" if none is
+// close. A cheap edit-distance-1 check covers the common typo cases.
+func didYouMean(head string) string {
+	for _, v := range reservedVerbs {
+		if editDistanceLE1(head, v) {
+			return v
+		}
+	}
+	return ""
+}
+
+func editDistanceLE1(a, b string) bool {
+	if a == b {
+		return true
+	}
+	la, lb := len(a), len(b)
+	if la > lb {
+		a, b = b, a
+		la, lb = lb, la
+	}
+	if lb-la > 1 {
+		return false
+	}
+	// At most one insertion/substitution.
+	i, j, diffs := 0, 0, 0
+	for i < la && j < lb {
+		if a[i] == b[j] {
+			i++
+			j++
+			continue
+		}
+		diffs++
+		if diffs > 1 {
+			return false
+		}
+		if la == lb {
+			i++
+			j++
+		} else {
+			j++
+		}
+	}
+	return true
+}
+
+// printUsage writes the gmux usage synopsis.
 func printUsage(w io.Writer) {
-	fmt.Fprint(w, `gmux — wrap any command in a managed session
+	fmt.Fprint(w, `gmux — wrap any command in a managed session you watch in a browser
 
-Usage:
-  gmux                              open the web UI
-  gmux [--no-attach] <cmd> [args]   run a command in a new session
-  gmux -- <cmd> [args]              use -- if <cmd> starts with a dash
+Run a command:
+  gmux -- <cmd> [args]              run a command in a new session
+  gmux -d -- <cmd> [args]           ... detached; prints the session id
+  (tip: alias gm='gmux --')
 
-Session management:
-  gmux --list                       list local sessions
-  gmux --list --all                 ... include sessions from every peer
-  gmux --list --host=<peer>         ... only this peer's sessions
-  gmux --attach <id>                reattach to an existing session
-  gmux --tail <N> <id>              print the last N lines of a session
-  gmux --kill <id>                  terminate a session
-  gmux --send <id> [text]           send text (or stdin) to a session and submit it
-  gmux --send --no-submit <id> ...  send without the trailing carriage return
-  gmux --wait <id>                  block until session is idle (agent finished its turn)
-  gmux --wait --timeout N <id>      ... or fail after N seconds
+Sessions (local by default; address a peer with <id>@<peer>):
+  gmux ls [--all] [--json]          list sessions
+  gmux attach <id>                  reattach to a session
+  gmux tail <id> [-n N] [--raw]     print recent output (snapshot)
+  gmux send <id> <text> [Key...]    type text and/or send keys (e.g. Enter, C-c)
+  gmux send-keys -t <id> <keys...>  tmux-compatible key sending
+  gmux wait <id> [--for-text S | --for-regex P] [--timeout N]
+  gmux kill <id>                    terminate a session
 
-Peer addressing (for any session action):
-  gmux --send <id>@<peer> 'foo'     address a session on a peer (canonical form)
-  gmux --send --host=<peer> <id> 'foo'  ... or use the --host flag (equivalent)
+UI & pairing:
+  gmux open                         open the web UI
+  gmux remote                       set up / check remote access
+  gmux auth                         reveal this host's login token
 
-Flags before the command apply to gmux itself. Once the first positional
-argument is seen, everything after is the command to run, verbatim.
+Daemon:
+  gmux daemon start|stop|restart|status|log-path
 
-For daemon management see 'gmuxd --help'.
+  gmux version · gmux help [verb]
+
+For the daemon process itself, see 'gmuxd --help'.
 `)
 }

--- a/cli/gmux/cmd/gmux/cli.go
+++ b/cli/gmux/cmd/gmux/cli.go
@@ -68,9 +68,6 @@ type command struct {
 
 	// daemon
 	daemonSub string // start|stop|restart|status|log-path
-
-	// help
-	helpTopic string // optional verb to show focused help for
 }
 
 // reservedVerbs is the closed top-level namespace (ADR 0009). Growth
@@ -135,12 +132,12 @@ func parseCLI(args []string) (*command, error) {
 
 	switch head {
 	case "help", "-h", "--help":
-		c := &command{mode: modeHelp}
-		if len(rest) == 1 {
-			c.helpTopic = rest[0]
-		}
-		return c, nil
-	case "version", "--version", "-v":
+		// Lenient: `gmux help` and `gmux help <anything>` both print the
+		// full usage. Per-verb help is intentionally not implemented (see
+		// ADR 0009); accepting a trailing word avoids an error on the
+		// natural `gmux help send`.
+		return &command{mode: modeHelp}, nil
+	case "version", "--version":
 		return &command{mode: modeVersion}, nil
 	case "open":
 		if len(rest) > 0 {
@@ -192,10 +189,16 @@ func parseCLI(args []string) (*command, error) {
 	if strings.HasPrefix(head, "-") {
 		return nil, fmt.Errorf("unknown flag %q", head)
 	}
-	if hint := didYouMean(head); hint != "" {
-		return nil, fmt.Errorf("unknown command %q; did you mean %q?", head, hint)
+	// Unknown bare word: it could be a fat-fingered verb OR a real program
+	// the user meant to run but forgot `--` (e.g. `gmux sed -i ...`). We
+	// can't know which, so always surface the run form, and add a verb
+	// suggestion only when one is close. Never replace the run hint with
+	// the suggestion alone — that misleads when the word is a real command.
+	runHint := "to run a command use: gmux -- " + strings.Join(args, " ")
+	if v := didYouMean(head); v != "" {
+		return nil, fmt.Errorf("unknown command %q; did you mean %q? (%s)", head, v, runHint)
 	}
-	return nil, fmt.Errorf("unknown command %q; to run a command use: gmux -- %s", head, strings.Join(args, " "))
+	return nil, fmt.Errorf("unknown command %q; %s", head, runHint)
 }
 
 func parseLs(args []string) (*command, error) {

--- a/cli/gmux/cmd/gmux/cli.go
+++ b/cli/gmux/cmd/gmux/cli.go
@@ -62,9 +62,7 @@ type command struct {
 	keys        []string // key/text arguments
 
 	// wait
-	forText  string // --for-text: fixed substring
-	forRegex string // --for-regex: regular expression
-	timeout  int    // --timeout seconds (0 = none)
+	timeout int // --timeout seconds (0 = none)
 
 	// daemon
 	daemonSub string // start|stop|restart|status|log-path
@@ -289,8 +287,6 @@ func parseSendKeys(args []string) (*command, error) {
 func parseWait(args []string) (*command, error) {
 	c := &command{mode: modeWait}
 	fs := newFlagSet("wait")
-	fs.StringVar(&c.forText, "for-text", "", "wait until this fixed substring appears")
-	fs.StringVar(&c.forRegex, "for-regex", "", "wait until this regex matches")
 	fs.IntVar(&c.timeout, "timeout", 0, "fail after N seconds")
 	pos, err := parseInterspersed(fs, args)
 	if err != nil {
@@ -298,9 +294,6 @@ func parseWait(args []string) (*command, error) {
 	}
 	if len(pos) != 1 {
 		return nil, errors.New("wait requires a session id")
-	}
-	if c.forText != "" && c.forRegex != "" {
-		return nil, errors.New("--for-text and --for-regex are mutually exclusive")
 	}
 	if c.timeout < 0 {
 		return nil, errors.New("--timeout must be a non-negative number of seconds")
@@ -438,7 +431,7 @@ Sessions (local by default; address a peer with <id>@<peer>):
   gmux tail <id> [-n N] [--raw]     print recent output (snapshot)
   gmux send <id> <text> [Key...]    type text and/or send keys (e.g. Enter, C-c)
   gmux send-keys -t <id> <keys...>  tmux-compatible key sending
-  gmux wait <id> [--for-text S | --for-regex P] [--timeout N]
+  gmux wait <id> [--timeout N]      block until an agent session is idle
   gmux kill <id>                    terminate a session
 
 UI & pairing:

--- a/cli/gmux/cmd/gmux/cli_test.go
+++ b/cli/gmux/cmd/gmux/cli_test.go
@@ -124,16 +124,16 @@ func TestParseCLI(t *testing.T) {
 			}},
 
 		{name: "wait idle default", args: []string{"wait", "abc"}, wantMode: modeWait},
-		{name: "wait --for-text --timeout", args: []string{"wait", "--for-text", "DONE", "--timeout", "30", "abc"}, wantMode: modeWait,
+		{name: "wait --timeout", args: []string{"wait", "--timeout", "30", "abc"}, wantMode: modeWait,
 			check: func(t *testing.T, c *command) {
-				if c.forText != "DONE" || c.timeout != 30 {
-					t.Errorf("forText=%q timeout=%d", c.forText, c.timeout)
+				if c.timeout != 30 || c.ref != "abc" {
+					t.Errorf("timeout=%d ref=%q", c.timeout, c.ref)
 				}
 			}},
-		{name: "wait flags after positional", args: []string{"wait", "abc", "--for-regex", "^>>>"}, wantMode: modeWait,
+		{name: "wait flags after positional", args: []string{"wait", "abc", "--timeout", "5"}, wantMode: modeWait,
 			check: func(t *testing.T, c *command) {
-				if c.forRegex != "^>>>" || c.ref != "abc" {
-					t.Errorf("forRegex=%q ref=%q", c.forRegex, c.ref)
+				if c.timeout != 5 || c.ref != "abc" {
+					t.Errorf("timeout=%d ref=%q", c.timeout, c.ref)
 				}
 			}},
 
@@ -185,7 +185,6 @@ func TestParseCLIErrors(t *testing.T) {
 		{"tail"},                   // missing id
 		{"tail", "-n", "0", "abc"}, // non-positive count
 		{"wait"},                   // missing id
-		{"wait", "--for-text", "x", "--for-regex", "y", "abc"}, // mutually exclusive
 		{"send-keys", "C-c"},     // missing -t
 		{"daemon"},               // missing subcommand
 		{"daemon", "frobnicate"}, // unknown subcommand

--- a/cli/gmux/cmd/gmux/cli_test.go
+++ b/cli/gmux/cmd/gmux/cli_test.go
@@ -16,12 +16,7 @@ func TestParseCLI(t *testing.T) {
 	}{
 		{name: "no args prints help", args: nil, wantMode: modeHelp},
 		{name: "help verb", args: []string{"help"}, wantMode: modeHelp},
-		{name: "help topic", args: []string{"help", "send"}, wantMode: modeHelp,
-			check: func(t *testing.T, c *command) {
-				if c.helpTopic != "send" {
-					t.Errorf("helpTopic = %q, want send", c.helpTopic)
-				}
-			}},
+		{name: "help with trailing word is lenient", args: []string{"help", "send"}, wantMode: modeHelp},
 		{name: "version", args: []string{"version"}, wantMode: modeVersion},
 		{name: "open", args: []string{"open"}, wantMode: modeOpen},
 
@@ -181,20 +176,20 @@ func TestParseCLI(t *testing.T) {
 
 func TestParseCLIErrors(t *testing.T) {
 	bad := [][]string{
-		{"-d"},                          // detach without command
-		{"-d", "ls"},                    // detach only pairs with --
-		{"--"},                          // run with no command
-		{"open", "extra"},               // open takes no args
-		{"attach"},                      // missing id
-		{"attach", "a", "b"},            // too many
-		{"tail"},                        // missing id
-		{"tail", "-n", "0", "abc"},      // non-positive count
-		{"wait"},                        // missing id
+		{"-d"},                     // detach without command
+		{"-d", "ls"},               // detach only pairs with --
+		{"--"},                     // run with no command
+		{"open", "extra"},          // open takes no args
+		{"attach"},                 // missing id
+		{"attach", "a", "b"},       // too many
+		{"tail"},                   // missing id
+		{"tail", "-n", "0", "abc"}, // non-positive count
+		{"wait"},                   // missing id
 		{"wait", "--for-text", "x", "--for-regex", "y", "abc"}, // mutually exclusive
-		{"send-keys", "C-c"},            // missing -t
-		{"daemon"},                      // missing subcommand
-		{"daemon", "frobnicate"},        // unknown subcommand
-		{"ls", "stray"},                 // ls takes no positional
+		{"send-keys", "C-c"},     // missing -t
+		{"daemon"},               // missing subcommand
+		{"daemon", "frobnicate"}, // unknown subcommand
+		{"ls", "stray"},          // ls takes no positional
 	}
 	for _, args := range bad {
 		t.Run(strings.Join(args, "_"), func(t *testing.T) {
@@ -239,5 +234,49 @@ func TestDidYouMean(t *testing.T) {
 	}
 	if got := didYouMean("klil"); got != "" { // two edits away
 		t.Errorf("didYouMean(klil) = %q, want empty", got)
+	}
+}
+
+// TestReexecRunArgsRoundTrips guards the regression where detached runs
+// re-execed via the removed bare-command shorthand. The argv produced for
+// the detached child must parse back to the same run command, including
+// when the command's own args look like gmux flags.
+func TestReexecRunArgsRoundTrips(t *testing.T) {
+	cases := [][]string{
+		{"pytest", "-q"},
+		{"pi", "--all", "a prompt"},
+		{"bash", "-c", "echo hi; sleep 1"},
+	}
+	for _, cmd := range cases {
+		t.Run(strings.Join(cmd, "_"), func(t *testing.T) {
+			c, err := parseCLI(reexecRunArgs(cmd))
+			if err != nil {
+				t.Fatalf("parseCLI(reexec %v) error: %v", cmd, err)
+			}
+			if c.mode != modeRun {
+				t.Fatalf("mode = %v, want modeRun", c.mode)
+			}
+			if strings.Join(c.runArgs, "\x00") != strings.Join(cmd, "\x00") {
+				t.Errorf("runArgs = %v, want %v", c.runArgs, cmd)
+			}
+		})
+	}
+}
+
+// TestUnknownCommandAlwaysShowsRunHint locks the rule that a bare unknown
+// word always surfaces the `gmux -- ...` run form, even when it is close
+// to a verb. `sed` is a real program one letter from `send`; suggesting
+// only the verb would mislead a user who meant to run sed.
+func TestUnknownCommandAlwaysShowsRunHint(t *testing.T) {
+	_, err := parseCLI([]string{"sed", "-i", "s/a/b/"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "gmux -- sed -i s/a/b/") {
+		t.Errorf("missing run hint in %q", msg)
+	}
+	if !strings.Contains(msg, "send") {
+		t.Errorf("missing verb suggestion in %q", msg)
 	}
 }

--- a/cli/gmux/cmd/gmux/cli_test.go
+++ b/cli/gmux/cmd/gmux/cli_test.go
@@ -1,358 +1,243 @@
 package main
 
 import (
-	"reflect"
+	"strings"
 	"testing"
 )
 
-// TestParseCLI covers every distinct dispatch path the user can reach.
-// We check the returned mode, the relevant flag values, and the
-// positional remainder — these three together describe what main.go
-// will actually do.
+// TestParseCLI exercises the verb-first grammar (ADR 0009): each verb,
+// the explicit run form, and the daemon-internal forms.
 func TestParseCLI(t *testing.T) {
 	tests := []struct {
 		name     string
 		args     []string
 		wantMode mode
-		wantRest []string
-		check    func(t *testing.T, f *flags)
+		check    func(t *testing.T, c *command)
 	}{
-		// ── Run-mode shapes ─────────────────────────────────────────
-		{
-			name:     "bare gmux opens the UI",
-			args:     nil,
-			wantMode: modeUI,
-		},
-		{
-			name:     "plain command is a run",
-			args:     []string{"pytest"},
-			wantMode: modeRun,
-			wantRest: []string{"pytest"},
-		},
-		{
-			name:     "command keeps its own flags",
-			args:     []string{"pytest", "--watch", "-x"},
-			wantMode: modeRun,
-			wantRest: []string{"pytest", "--watch", "-x"},
-		},
-		{
-			name:     "double-dash shields a dash-prefixed command",
-			args:     []string{"--", "--weird-binary", "arg"},
-			wantMode: modeRun,
-			wantRest: []string{"--weird-binary", "arg"},
-		},
-		{
-			name:     "no-attach carries into run mode",
-			args:     []string{"--no-attach", "pytest", "--watch"},
-			wantMode: modeRun,
-			wantRest: []string{"pytest", "--watch"},
-			check: func(t *testing.T, f *flags) {
-				if !f.noAttach {
-					t.Error("noAttach should be true")
+		{name: "no args prints help", args: nil, wantMode: modeHelp},
+		{name: "help verb", args: []string{"help"}, wantMode: modeHelp},
+		{name: "help topic", args: []string{"help", "send"}, wantMode: modeHelp,
+			check: func(t *testing.T, c *command) {
+				if c.helpTopic != "send" {
+					t.Errorf("helpTopic = %q, want send", c.helpTopic)
 				}
-			},
-		},
+			}},
+		{name: "version", args: []string{"version"}, wantMode: modeVersion},
+		{name: "open", args: []string{"open"}, wantMode: modeOpen},
 
-		// ── Management shapes ───────────────────────────────────────
-		{
-			name:     "--list has no positionals",
-			args:     []string{"--list"},
-			wantMode: modeList,
-		},
-		{
-			name:     "-l is the short form of --list",
-			args:     []string{"-l"},
-			wantMode: modeList,
-		},
-		{
-			// --all extends --list across peers. Without it, the new
-			// default keeps --list local-only (the one breaking
-			// change in this milestone).
-			name:     "--list --all dispatches to list with f.all set",
-			args:     []string{"--list", "--all"},
-			wantMode: modeList,
-		},
-		{
-			// --host scopes a session action to a peer. Co-existing
-			// with the positional id, the resolver reconciles them.
-			name:     "--kill --host=peer routes",
-			args:     []string{"--kill", "--host=konyvtar", "sess-abcd"},
-			wantMode: modeKill,
-			wantRest: []string{"sess-abcd"},
-		},
-		{
-			name:     "--attach takes one session id",
-			args:     []string{"--attach", "sess-abcd"},
-			wantMode: modeAttach,
-			wantRest: []string{"sess-abcd"},
-		},
-		{
-			name:     "--kill takes one session id",
-			args:     []string{"--kill", "sess-abcd"},
-			wantMode: modeKill,
-			wantRest: []string{"sess-abcd"},
-		},
-		{
-			name:     "--tail takes a count and a session id",
-			args:     []string{"--tail", "100", "sess-abcd"},
-			wantMode: modeTail,
-			wantRest: []string{"sess-abcd"},
-			check: func(t *testing.T, f *flags) {
-				if f.tail != 100 {
-					t.Errorf("tail = %d, want 100", f.tail)
+		{name: "run via --", args: []string{"--", "pytest", "-q"}, wantMode: modeRun,
+			check: func(t *testing.T, c *command) {
+				if strings.Join(c.runArgs, " ") != "pytest -q" {
+					t.Errorf("runArgs = %v", c.runArgs)
 				}
-			},
-		},
-		{
-			name:     "--send with inline text",
-			args:     []string{"--send", "sess-abcd", "hello"},
-			wantMode: modeSend,
-			wantRest: []string{"sess-abcd", "hello"},
-		},
-		{
-			name:     "--send without text reads stdin",
-			args:     []string{"--send", "sess-abcd"},
-			wantMode: modeSend,
-			wantRest: []string{"sess-abcd"},
-			check: func(t *testing.T, f *flags) {
-				if f.noSubmit {
-					t.Errorf("noSubmit = true, want false (submit-by-default)")
+				if c.detach {
+					t.Error("detach should be false")
 				}
-			},
-		},
-		{
-			name:     "--send --no-submit suppresses the submit",
-			args:     []string{"--send", "--no-submit", "sess-abcd", "draft"},
-			wantMode: modeSend,
-			wantRest: []string{"sess-abcd", "draft"},
-			check: func(t *testing.T, f *flags) {
-				if !f.noSubmit {
-					t.Errorf("noSubmit = false, want true")
+			}},
+		{name: "detached run", args: []string{"-d", "--", "server"}, wantMode: modeRun,
+			check: func(t *testing.T, c *command) {
+				if !c.detach {
+					t.Error("detach should be true")
 				}
-			},
-		},
-		{
-			name:     "--wait takes a session id",
-			args:     []string{"--wait", "sess-abcd"},
-			wantMode: modeWait,
-			wantRest: []string{"sess-abcd"},
-			check: func(t *testing.T, f *flags) {
-				if f.waitTimeout != 0 {
-					t.Errorf("waitTimeout = %d, want 0", f.waitTimeout)
+				if strings.Join(c.runArgs, " ") != "server" {
+					t.Errorf("runArgs = %v", c.runArgs)
 				}
-			},
-		},
-		{
-			name:     "--wait with --timeout",
-			args:     []string{"--wait", "--timeout", "30", "sess-abcd"},
-			wantMode: modeWait,
-			wantRest: []string{"sess-abcd"},
-			check: func(t *testing.T, f *flags) {
-				if f.waitTimeout != 30 {
-					t.Errorf("waitTimeout = %d, want 30", f.waitTimeout)
+			}},
+		{name: "detach long form", args: []string{"--detach", "--", "x"}, wantMode: modeRun,
+			check: func(t *testing.T, c *command) {
+				if !c.detach {
+					t.Error("detach should be true")
 				}
-			},
-		},
-		// Management modes accept flags in any order: there's no
-		// wrapped child command at the end, so the POSIX runner
-		// stop-at-first-positional rule that run mode needs would only
-		// turn `gmux --wait <id> --timeout 60` into a silent foot-trap.
-		// These cases pin the lenient parsing for each management
-		// action that takes a flag besides its mode flag.
-		{
-			name:     "--wait accepts --timeout after the id",
-			args:     []string{"--wait", "sess-abcd", "--timeout", "30"},
-			wantMode: modeWait,
-			wantRest: []string{"sess-abcd"},
-			check: func(t *testing.T, f *flags) {
-				if f.waitTimeout != 30 {
-					t.Errorf("waitTimeout = %d, want 30", f.waitTimeout)
+			}},
+		{name: "child flags after -- are not gmux flags", args: []string{"--", "pi", "--all", "prompt"}, wantMode: modeRun,
+			check: func(t *testing.T, c *command) {
+				if strings.Join(c.runArgs, " ") != "pi --all prompt" {
+					t.Errorf("runArgs = %v, child flags must pass through", c.runArgs)
 				}
-			},
-		},
-		{
-			name:     "--send accepts --no-submit after the id",
-			args:     []string{"--send", "sess-abcd", "--no-submit", "text"},
-			wantMode: modeSend,
-			wantRest: []string{"sess-abcd", "text"},
-			check: func(t *testing.T, f *flags) {
-				if !f.noSubmit {
-					t.Errorf("noSubmit = false, want true")
+			}},
+
+		{name: "ls", args: []string{"ls"}, wantMode: modeList},
+		{name: "ls --all --json", args: []string{"ls", "--all", "--json"}, wantMode: modeList,
+			check: func(t *testing.T, c *command) {
+				if !c.all || !c.json {
+					t.Errorf("all=%v json=%v, want both true", c.all, c.json)
 				}
-			},
-		},
-		{
-			name:     "--send accepts --no-submit after both positionals",
-			args:     []string{"--send", "sess-abcd", "text", "--no-submit"},
-			wantMode: modeSend,
-			wantRest: []string{"sess-abcd", "text"},
-			check: func(t *testing.T, f *flags) {
-				if !f.noSubmit {
-					t.Errorf("noSubmit = false, want true")
+			}},
+
+		{name: "attach", args: []string{"attach", "abc"}, wantMode: modeAttach,
+			check: func(t *testing.T, c *command) {
+				if c.ref != "abc" {
+					t.Errorf("ref = %q", c.ref)
 				}
-			},
-		},
-		// `gmux --send <id> -- <text>` is the documented escape for
-		// inline text that starts with dashes. The lenient flag parser
-		// must respect `--` as a hard terminator, otherwise text like
-		// `--no-submit` (a real gmux flag name) gets silently swallowed
-		// as a flag and never reaches the agent. This is the case where
-		// being too lenient would corrupt user data, so it gets a test
-		// of its own rather than living inside the table.
-		{
-			name:     "--send respects -- as a flag terminator for inline text",
-			args:     []string{"--send", "sess-abcd", "--", "--no-submit"},
-			wantMode: modeSend,
-			wantRest: []string{"sess-abcd", "--no-submit"},
-			check: func(t *testing.T, f *flags) {
-				if f.noSubmit {
-					t.Errorf("noSubmit = true, want false: -- should have stopped flag parsing so --no-submit is text, not a flag")
+			}},
+		{name: "kill with peer ref", args: []string{"kill", "abc@laptop"}, wantMode: modeKill,
+			check: func(t *testing.T, c *command) {
+				if c.ref != "abc@laptop" {
+					t.Errorf("ref = %q", c.ref)
 				}
-			},
-		},
+			}},
+
+		{name: "tail defaults to 100 lines", args: []string{"tail", "abc"}, wantMode: modeTail,
+			check: func(t *testing.T, c *command) {
+				if c.tailLines != 100 || c.raw {
+					t.Errorf("tailLines=%d raw=%v", c.tailLines, c.raw)
+				}
+			}},
+		{name: "tail -n and --raw", args: []string{"tail", "-n", "500", "--raw", "abc"}, wantMode: modeTail,
+			check: func(t *testing.T, c *command) {
+				if c.tailLines != 500 || !c.raw {
+					t.Errorf("tailLines=%d raw=%v", c.tailLines, c.raw)
+				}
+			}},
+
+		{name: "send text + Enter", args: []string{"send", "abc", "pytest -q", "Enter"}, wantMode: modeSend,
+			check: func(t *testing.T, c *command) {
+				if c.ref != "abc" || c.sendText == nil || *c.sendText != "pytest -q" {
+					t.Errorf("ref=%q text=%v", c.ref, c.sendText)
+				}
+				if len(c.sendKeys) != 1 || c.sendKeys[0] != "Enter" {
+					t.Errorf("keys = %v", c.sendKeys)
+				}
+			}},
+		{name: "send keys only", args: []string{"send", "abc", "C-c"}, wantMode: modeSend,
+			check: func(t *testing.T, c *command) {
+				if c.sendText != nil {
+					t.Errorf("text should be nil, got %v", *c.sendText)
+				}
+				if len(c.sendKeys) != 1 || c.sendKeys[0] != "C-c" {
+					t.Errorf("keys = %v", c.sendKeys)
+				}
+			}},
+		{name: "send stdin (ref only)", args: []string{"send", "abc"}, wantMode: modeSend,
+			check: func(t *testing.T, c *command) {
+				if c.sendText != nil || len(c.sendKeys) != 0 {
+					t.Errorf("expected stdin form: text=%v keys=%v", c.sendText, c.sendKeys)
+				}
+			}},
+
+		{name: "send-keys tmux compat", args: []string{"send-keys", "-t", "abc", "C-c"}, wantMode: modeSendKeys,
+			check: func(t *testing.T, c *command) {
+				if c.ref != "abc" || len(c.keys) != 1 || c.keys[0] != "C-c" {
+					t.Errorf("ref=%q keys=%v", c.ref, c.keys)
+				}
+			}},
+		{name: "send-keys literal", args: []string{"send-keys", "-t", "abc", "-l", "hello"}, wantMode: modeSendKeys,
+			check: func(t *testing.T, c *command) {
+				if !c.keysLiteral {
+					t.Error("keysLiteral should be true")
+				}
+			}},
+
+		{name: "wait idle default", args: []string{"wait", "abc"}, wantMode: modeWait},
+		{name: "wait --for-text --timeout", args: []string{"wait", "--for-text", "DONE", "--timeout", "30", "abc"}, wantMode: modeWait,
+			check: func(t *testing.T, c *command) {
+				if c.forText != "DONE" || c.timeout != 30 {
+					t.Errorf("forText=%q timeout=%d", c.forText, c.timeout)
+				}
+			}},
+		{name: "wait flags after positional", args: []string{"wait", "abc", "--for-regex", "^>>>"}, wantMode: modeWait,
+			check: func(t *testing.T, c *command) {
+				if c.forRegex != "^>>>" || c.ref != "abc" {
+					t.Errorf("forRegex=%q ref=%q", c.forRegex, c.ref)
+				}
+			}},
+
+		{name: "daemon status", args: []string{"daemon", "status"}, wantMode: modeDaemon,
+			check: func(t *testing.T, c *command) {
+				if c.daemonSub != "status" {
+					t.Errorf("daemonSub = %q", c.daemonSub)
+				}
+			}},
+		{name: "auth", args: []string{"auth"}, wantMode: modeAuth},
+		{name: "remote", args: []string{"remote"}, wantMode: modeRemote},
+
+		{name: "internal __run with directives", args: []string{"__run", "--resume-id=sess-1", "--initial-cols=80", "--", "pi"}, wantMode: modeRun,
+			check: func(t *testing.T, c *command) {
+				if c.resumeID != "sess-1" || c.initialCols != 80 {
+					t.Errorf("resumeID=%q cols=%d", c.resumeID, c.initialCols)
+				}
+				if strings.Join(c.runArgs, " ") != "pi" {
+					t.Errorf("runArgs = %v", c.runArgs)
+				}
+			}},
+		{name: "internal __dump-env", args: []string{"__dump-env"}, wantMode: modeDumpEnv},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m, f, rest, err := parseCLI(tc.args)
+			c, err := parseCLI(tc.args)
 			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
+				t.Fatalf("parseCLI(%v) unexpected error: %v", tc.args, err)
 			}
-			if m != tc.wantMode {
-				t.Errorf("mode = %v, want %v", m, tc.wantMode)
+			if c.mode != tc.wantMode {
+				t.Fatalf("mode = %v, want %v", c.mode, tc.wantMode)
 			}
-			if !reflect.DeepEqual(rest, tc.wantRest) {
-				// Treat nil and empty slice as equivalent for readability.
-				if !(len(rest) == 0 && len(tc.wantRest) == 0) {
-					t.Errorf("rest = %v, want %v", rest, tc.wantRest)
-				}
-			}
-			if tc.check != nil && f != nil {
-				tc.check(t, f)
+			if tc.check != nil {
+				tc.check(t, c)
 			}
 		})
 	}
 }
 
-// TestRunModeKeepsPOSIXRunnerSemantics pins the contract that flags
-// after the wrapped command go to the child, not to gmux. This is
-// the load-bearing case for run mode and the reason management modes
-// (which lack a wrapped command) get lenient parsing while run mode
-// keeps the strict stop-at-first-positional behavior.
-func TestParseCLIDaemonDirectives(t *testing.T) {
-	t.Run("resume-id + size hints are exposed as flags in run mode", func(t *testing.T) {
-		m, f, rest, err := parseCLI([]string{
-			"--resume-id=sess-abc",
-			"--initial-cols=142",
-			"--initial-rows=47",
-			"claude", "--continue",
-		})
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if m != modeRun {
-			t.Errorf("mode = %v, want modeRun", m)
-		}
-		if f.resumeID != "sess-abc" || f.initialCols != 142 || f.initialRows != 47 {
-			t.Errorf("directives not captured: resume=%q cols=%d rows=%d", f.resumeID, f.initialCols, f.initialRows)
-		}
-		wantRest := []string{"claude", "--continue"}
-		if len(rest) != 2 || rest[0] != wantRest[0] || rest[1] != wantRest[1] {
-			t.Errorf("rest = %v, want %v", rest, wantRest)
-		}
-	})
-
-	t.Run("directives do not leak from a child command's own argv", func(t *testing.T) {
-		// Defends the daemon↔runner contract: a child command that
-		// happens to use the same flag names (`weirdcli
-		// --resume-id=...`) must not have its flag consumed by gmux.
-		// POSIX runner semantics (stop at first positional) is what
-		// makes this safe; the test pins it.
-		_, f, rest, err := parseCLI([]string{"weirdcli", "--resume-id=evil"})
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if f.resumeID != "" {
-			t.Errorf("resumeID should not be set from child argv, got %q", f.resumeID)
-		}
-		if len(rest) != 2 || rest[0] != "weirdcli" || rest[1] != "--resume-id=evil" {
-			t.Errorf("rest should preserve child argv verbatim, got %v", rest)
-		}
-	})
-}
-
-func TestRunModeKeepsPOSIXRunnerSemantics(t *testing.T) {
-	// `gmux pi --some-pi-flag` — --some-pi-flag must reach pi as part
-	// of the command, not be parsed as an unknown gmux flag.
-	_, _, rest, err := parseCLI([]string{"pi", "--some-pi-flag", "prompt"})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	want := []string{"pi", "--some-pi-flag", "prompt"}
-	if !reflect.DeepEqual(rest, want) {
-		t.Errorf("rest = %v, want %v", rest, want)
-	}
-}
-
-// TestParseCLIErrors asserts that every user-facing invariant the CLI
-// promises is actually enforced. We don't pin error strings (those are
-// free to improve), only that an error is returned in each case.
 func TestParseCLIErrors(t *testing.T) {
-	invalid := [][]string{
-		{"--list", "extra"},                      // --list takes no args
-		{"--attach"},                             // --attach needs an id
-		{"--attach", "a", "b"},                   // --attach takes exactly one id
-		{"--kill"},                               // --kill needs an id
-		{"--tail", "100"},                        // --tail needs an id
-		{"--tail", "0", "sess-a"},                // --tail needs a positive count
-		{"--send"},                               // --send needs an id
-		{"--send", "a", "b", "c"},                // --send takes at most two args
-		{"--list", "--attach", "sess-a"},         // mutually exclusive actions
-		{"--kill", "--attach", "sess-a"},         // mutually exclusive actions
-		{"--send", "--kill", "sess-a"},           // mutually exclusive actions
-		{"--no-attach"},                          // --no-attach needs a command
-		{"--no-attach", "--list"},                // --no-attach doesn't make sense with --list
-		{"--no-attach", "--attach", "sess-a"},
-		{"--no-attach", "--send", "sess-a", "x"}, // --no-attach doesn't make sense with --send
-		{"--no-submit", "sess-a"},                // --no-submit only applies with --send
-		{"--no-submit", "--list"},                // --no-submit only applies with --send
-		{"--wait"},                               // --wait needs an id
-		{"--wait", "a", "b"},                     // --wait takes exactly one id
-		{"--wait", "--send", "sess-a"},           // mutually exclusive
-		{"--no-attach", "--wait", "sess-a"},      // --no-attach has no effect with --wait
-		{"--timeout", "30", "sess-a"},            // --timeout only applies with --wait
-		{"--wait", "--timeout", "-1", "sess-a"},  // --timeout must be non-negative
-		{"--all", "--send", "sess-a", "x"},        // --all is discovery-only
-		{"--all", "--kill", "sess-a"},             // --all is discovery-only
-		{"--host=konyvtar", "--all", "--list"},    // --host and --all are mutually exclusive
-		{"--host=konyvtar", "--wait", "sess-a"},   // --wait + --host not yet supported
-		{"--host=konyvtar", "fish"},               // remote create deferred
-		{"--resume-id=sess-1", "--list"},          // directives are run-mode only
-		{"--initial-cols=80", "--kill", "sess-a"}, // directives are run-mode only
-		{"--initial-rows=24", "--attach", "sess-a"}, // directives are run-mode only
-		{"--initial-cols=-1", "claude"},           // size must be non-negative
-		{"--initial-rows=-1", "claude"},
+	bad := [][]string{
+		{"-d"},                          // detach without command
+		{"-d", "ls"},                    // detach only pairs with --
+		{"--"},                          // run with no command
+		{"open", "extra"},               // open takes no args
+		{"attach"},                      // missing id
+		{"attach", "a", "b"},            // too many
+		{"tail"},                        // missing id
+		{"tail", "-n", "0", "abc"},      // non-positive count
+		{"wait"},                        // missing id
+		{"wait", "--for-text", "x", "--for-regex", "y", "abc"}, // mutually exclusive
+		{"send-keys", "C-c"},            // missing -t
+		{"daemon"},                      // missing subcommand
+		{"daemon", "frobnicate"},        // unknown subcommand
+		{"ls", "stray"},                 // ls takes no positional
 	}
-
-	for _, args := range invalid {
-		t.Run(joinArgs(args), func(t *testing.T) {
-			if _, _, _, err := parseCLI(args); err == nil {
-				t.Errorf("expected error for %v", args)
+	for _, args := range bad {
+		t.Run(strings.Join(args, "_"), func(t *testing.T) {
+			if _, err := parseCLI(args); err == nil {
+				t.Errorf("parseCLI(%v) = nil error, want error", args)
 			}
 		})
 	}
 }
 
-func joinArgs(args []string) string {
-	out := ""
-	for i, a := range args {
-		if i > 0 {
-			out += " "
-		}
-		out += a
+// TestParseCLIMigrationShim checks that removed pre-2.0 forms and the
+// dropped bare-command shorthand produce guidance errors, not silent
+// behavior (ADR 0009 error-only shim).
+func TestParseCLIMigrationShim(t *testing.T) {
+	cases := []struct {
+		args     []string
+		contains string
+	}{
+		{[]string{"--list"}, "gmux ls"},
+		{[]string{"-l"}, "gmux ls"},
+		{[]string{"--kill", "abc"}, "gmux kill"},
+		{[]string{"--no-attach", "x"}, "gmux -d"},
+		{[]string{"--host=laptop"}, "@<peer>"},
+		{[]string{"pytest", "-q"}, "gmux -- pytest"},
 	}
-	if out == "" {
-		return "(no args)"
+	for _, tc := range cases {
+		t.Run(strings.Join(tc.args, "_"), func(t *testing.T) {
+			_, err := parseCLI(tc.args)
+			if err == nil {
+				t.Fatalf("parseCLI(%v) = nil error, want migration error", tc.args)
+			}
+			if !strings.Contains(err.Error(), tc.contains) {
+				t.Errorf("error %q does not mention %q", err.Error(), tc.contains)
+			}
+		})
 	}
-	return out
+}
+
+func TestDidYouMean(t *testing.T) {
+	if got := didYouMean("opn"); got != "open" {
+		t.Errorf("didYouMean(opn) = %q, want open", got)
+	}
+	if got := didYouMean("klil"); got != "" { // two edits away
+		t.Errorf("didYouMean(klil) = %q, want empty", got)
+	}
 }

--- a/cli/gmux/cmd/gmux/daemon.go
+++ b/cli/gmux/cmd/gmux/daemon.go
@@ -157,7 +157,7 @@ func gmuxdHealthy(timeout time.Duration) bool {
 // returns true once gmuxd accepts it. Retries a handful of times to
 // cover the case where gmuxd is still starting up. Returns false if
 // every attempt fails: callers that care about registration outcome
-// (e.g. the --no-attach handshake) treat false as "give up".
+// (e.g. the detached (-d) handshake) treat false as "give up".
 func registerWithGmuxd(sessionID, socketPath string) bool {
 	baseURL := gmuxdBaseURL()
 

--- a/cli/gmux/cmd/gmux/dumpenv.go
+++ b/cli/gmux/cmd/gmux/dumpenv.go
@@ -6,7 +6,7 @@ import (
 	"os"
 )
 
-// dumpEnvFD is the file descriptor gmuxd hands to the `gmux --dump-env`
+// dumpEnvFD is the file descriptor gmuxd hands to the `gmux __dump-env`
 // probe (via cmd.ExtraFiles[0], which the child sees as fd 3). Writing
 // the environment to a dedicated fd — rather than stdout — keeps the
 // payload clean of any banner/prompt noise a login shell's rc files
@@ -16,7 +16,7 @@ const dumpEnvFD = 3
 // dumpEnv writes os.Environ() to fd 3 as NUL-terminated entries, then
 // exits. It is the inner command of gmuxd's env-capture probe
 //
-//	$SHELL -l -i -c '<gmux> --dump-env'
+//	$SHELL -l -i -c '<gmux> __dump-env'
 //
 // The login shell sources the user's dotfiles, so the environment we
 // observe here is the freshly-sourced one gmuxd wants to launch the
@@ -29,13 +29,13 @@ const dumpEnvFD = 3
 func dumpEnv() int {
 	f := os.NewFile(dumpEnvFD, "gmux-dump-env")
 	if f == nil {
-		log.Printf("--dump-env: fd %d not available", dumpEnvFD)
+		log.Printf("__dump-env: fd %d not available", dumpEnvFD)
 		return 1
 	}
 	defer f.Close()
 
 	if err := writeNulEnv(f, os.Environ()); err != nil {
-		log.Printf("--dump-env: write fd %d: %v", dumpEnvFD, err)
+		log.Printf("__dump-env: write fd %d: %v", dumpEnvFD, err)
 		return 1
 	}
 	return 0

--- a/cli/gmux/cmd/gmux/dumpenv_test.go
+++ b/cli/gmux/cmd/gmux/dumpenv_test.go
@@ -6,18 +6,12 @@ import (
 )
 
 func TestParseCLIDumpEnv(t *testing.T) {
-	m, f, rest, err := parseCLI([]string{"--dump-env"})
+	c, err := parseCLI([]string{"__dump-env"})
 	if err != nil {
-		t.Fatalf("parseCLI(--dump-env) error: %v", err)
+		t.Fatalf("parseCLI(__dump-env) error: %v", err)
 	}
-	if m != modeDumpEnv {
-		t.Errorf("mode = %v, want modeDumpEnv", m)
-	}
-	if !f.dumpEnv {
-		t.Errorf("f.dumpEnv = false, want true")
-	}
-	if len(rest) != 0 {
-		t.Errorf("rest = %v, want empty", rest)
+	if c.mode != modeDumpEnv {
+		t.Errorf("mode = %v, want modeDumpEnv", c.mode)
 	}
 }
 

--- a/cli/gmux/cmd/gmux/handshake.go
+++ b/cli/gmux/cmd/gmux/handshake.go
@@ -10,9 +10,9 @@ import (
 	"time"
 )
 
-// Handshake protocol used by spawnDetached's --no-attach path so the
+// Handshake protocol used by spawnDetached's detached (-d) path so the
 // parent process can return a deterministic session id to its caller
-// (typically a script doing id=$(gmux --no-attach foo)) without
+// (typically a script doing id=$(gmux -d -- foo)) without
 // polling /v1/sessions or guessing.
 //
 // Wire:

--- a/cli/gmux/cmd/gmux/keys.go
+++ b/cli/gmux/cmd/gmux/keys.go
@@ -1,0 +1,79 @@
+package main
+
+import "strings"
+
+// Key-name handling for `gmux send` and `gmux send-keys`. Names follow
+// tmux's send-keys vocabulary so existing tmux knowledge transfers
+// (ADR 0009). A "key" renders to the byte sequence an xterm-class
+// terminal emits for that key; gmux writes those bytes to the session
+// PTY's input exactly as if typed.
+
+// namedKeys maps a key name to the bytes it produces. Control keys
+// (C-<letter>) are handled separately in keyBytes.
+var namedKeys = map[string]string{
+	"Enter":     "\r",
+	"Tab":       "\t",
+	"Space":     " ",
+	"Escape":    "\x1b",
+	"Esc":       "\x1b",
+	"BSpace":    "\x7f",
+	"Backspace": "\x7f",
+	"Up":        "\x1b[A",
+	"Down":      "\x1b[B",
+	"Right":     "\x1b[C",
+	"Left":      "\x1b[D",
+	"Home":      "\x1b[H",
+	"End":       "\x1b[F",
+	"PageUp":    "\x1b[5~",
+	"PageDown":  "\x1b[6~",
+	"Delete":    "\x1b[3~",
+	"DC":        "\x1b[3~",
+}
+
+// isKeyName reports whether s is a recognized key-name token. Used by
+// `gmux send` to tell a trailing key (Enter, C-c) from literal text.
+func isKeyName(s string) bool {
+	_, ok := keyBytes(s)
+	return ok
+}
+
+// keyBytes renders a single key name to its byte sequence. Recognizes
+// the named keys above and control combos of the form C-<char>
+// (C-c → 0x03, C-d → 0x04, ...).
+func keyBytes(name string) (string, bool) {
+	if b, ok := namedKeys[name]; ok {
+		return b, true
+	}
+	if len(name) == 3 && (name[0] == 'C' || name[0] == 'c') && name[1] == '-' {
+		ch := name[2]
+		switch {
+		case ch >= 'a' && ch <= 'z':
+			return string([]byte{ch - 'a' + 1}), true
+		case ch >= 'A' && ch <= 'Z':
+			return string([]byte{ch - 'A' + 1}), true
+		case ch == ' ' || ch == '@':
+			return string([]byte{0}), true // C-Space / C-@ → NUL
+		}
+	}
+	return "", false
+}
+
+// renderKeys turns a list of key/text tokens into the bytes to send.
+// When literal is true (send-keys -l), every token is sent verbatim.
+// Otherwise each recognized key name renders to its sequence and any
+// unrecognized token is sent as literal text (matching tmux send-keys).
+func renderKeys(tokens []string, literal bool) string {
+	var b strings.Builder
+	for _, t := range tokens {
+		if literal {
+			b.WriteString(t)
+			continue
+		}
+		if seq, ok := keyBytes(t); ok {
+			b.WriteString(seq)
+		} else {
+			b.WriteString(t)
+		}
+	}
+	return b.String()
+}

--- a/cli/gmux/cmd/gmux/keys_test.go
+++ b/cli/gmux/cmd/gmux/keys_test.go
@@ -1,0 +1,58 @@
+package main
+
+import "testing"
+
+func TestKeyBytes(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+		ok   bool
+	}{
+		// Control combos: the whole point is C-c → 0x03, not the text "C-c".
+		{"C-c", "\x03", true},
+		{"C-d", "\x04", true},
+		{"C-a", "\x01", true},
+		{"C-z", "\x1a", true},
+		{"C-C", "\x03", true}, // upper-case letter, same control byte
+		{"C-@", "\x00", true}, // NUL
+		// Named keys.
+		{"Enter", "\r", true},
+		{"Tab", "\t", true},
+		{"Escape", "\x1b", true},
+		{"Esc", "\x1b", true},
+		{"Up", "\x1b[A", true},
+		{"Backspace", "\x7f", true},
+		// Not keys.
+		{"hello", "", false},
+		{"c", "", false},    // bare letter is not a control combo
+		{"C-", "", false},   // malformed
+		{"Entr", "", false}, // typo is not a key
+		{"", "", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := keyBytes(tc.name)
+			if ok != tc.ok || got != tc.want {
+				t.Errorf("keyBytes(%q) = (%q, %v), want (%q, %v)", tc.name, got, ok, tc.want, tc.ok)
+			}
+			if isKeyName(tc.name) != tc.ok {
+				t.Errorf("isKeyName(%q) = %v, want %v", tc.name, isKeyName(tc.name), tc.ok)
+			}
+		})
+	}
+}
+
+func TestRenderKeys(t *testing.T) {
+	// Non-literal: recognized names render to sequences, unknown tokens
+	// pass through as literal text (matching tmux send-keys).
+	if got := renderKeys([]string{"echo hi", "Enter"}, false); got != "echo hi\r" {
+		t.Errorf("renderKeys = %q, want %q", got, "echo hi\r")
+	}
+	if got := renderKeys([]string{"Escape", ":wq", "Enter"}, false); got != "\x1b:wq\r" {
+		t.Errorf("renderKeys = %q, want %q", got, "\x1b:wq\r")
+	}
+	// Literal: every token verbatim, even ones that look like key names.
+	if got := renderKeys([]string{"Enter", "C-c"}, true); got != "EnterC-c" {
+		t.Errorf("renderKeys literal = %q, want %q", got, "EnterC-c")
+	}
+}

--- a/cli/gmux/cmd/gmux/main.go
+++ b/cli/gmux/cmd/gmux/main.go
@@ -51,7 +51,7 @@ func main() {
 	case modeSendKeys:
 		os.Exit(cmdSendKeys(cmd.ref, cmd.keys, cmd.keysLiteral))
 	case modeWait:
-		os.Exit(cmdWait(cmd.ref, cmd.forText, cmd.forRegex, cmd.timeout))
+		os.Exit(cmdWait(cmd.ref, cmd.timeout))
 	case modeDaemon:
 		os.Exit(execGmuxd(cmd.daemonSub))
 	case modeAuth:

--- a/cli/gmux/cmd/gmux/main.go
+++ b/cli/gmux/cmd/gmux/main.go
@@ -1,11 +1,11 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"io"
 	"log"
 	"os"
+	"os/exec"
 	"time"
 )
 
@@ -17,52 +17,78 @@ func main() {
 	log.SetPrefix("gmux: ")
 	log.SetFlags(0)
 
-	m, f, rest, err := parseCLI(os.Args[1:])
+	cmd, err := parseCLI(os.Args[1:])
 	if err != nil {
-		if err != flag.ErrHelp {
-			fmt.Fprintln(os.Stderr, "gmux:", err)
-			fmt.Fprintln(os.Stderr)
-		}
+		fmt.Fprintln(os.Stderr, "gmux:", err)
+		fmt.Fprintln(os.Stderr)
 		printUsage(os.Stderr)
 		os.Exit(2)
 	}
 
-	switch m {
+	switch cmd.mode {
 	case modeHelp:
 		printUsage(os.Stdout)
-		return
-	case modeUI:
+	case modeVersion:
+		fmt.Println(version)
+	case modeOpen:
 		openUI()
-		return
 	case modeRun:
-		runSession(rest, !f.noAttach, runDirectives{
-			ResumeID:    f.resumeID,
-			InitialCols: f.initialCols,
-			InitialRows: f.initialRows,
+		runSession(cmd.runArgs, !cmd.detach, runDirectives{
+			ResumeID:    cmd.resumeID,
+			InitialCols: cmd.initialCols,
+			InitialRows: cmd.initialRows,
 		})
-		return
 	case modeList:
-		os.Exit(cmdList(f.host, f.all))
+		os.Exit(cmdList(cmd.all, cmd.json))
 	case modeKill:
-		os.Exit(cmdKill(rest[0], f.host))
+		os.Exit(cmdKill(cmd.ref))
 	case modeTail:
-		os.Exit(cmdTail(rest[0], f.tail, f.host))
+		os.Exit(cmdTail(cmd.ref, cmd.tailLines, cmd.raw))
 	case modeAttach:
-		os.Exit(cmdAttach(rest[0], f.host))
+		os.Exit(cmdAttach(cmd.ref, ""))
 	case modeSend:
-		var text *string
-		if len(rest) == 2 {
-			text = &rest[1]
-		}
-		os.Exit(cmdSend(rest[0], text, f.noSubmit, f.host))
+		os.Exit(cmdSend(cmd.ref, cmd.sendText, cmd.sendKeys))
+	case modeSendKeys:
+		os.Exit(cmdSendKeys(cmd.ref, cmd.keys, cmd.keysLiteral))
 	case modeWait:
-		os.Exit(cmdWait(rest[0], f.waitTimeout))
+		os.Exit(cmdWait(cmd.ref, cmd.forText, cmd.forRegex, cmd.timeout))
+	case modeDaemon:
+		os.Exit(execGmuxd(cmd.daemonSub))
+	case modeAuth:
+		os.Exit(execGmuxd("auth"))
+	case modeRemote:
+		os.Exit(execGmuxd("remote"))
 	case modeDumpEnv:
 		os.Exit(dumpEnv())
 	}
 }
 
-// openUI implements the bare `gmux` invocation: ensure gmuxd is up,
+// execGmuxd bridges the `gmux daemon …`, `gmux auth`, and `gmux remote`
+// verbs to the gmuxd binary, which still owns the implementation. A
+// later slice moves the logic into gmux and slims gmuxd to a pure
+// serve binary (ADR 0009). Streams stdio so interactive flows (remote
+// setup y/N, auth QR) work transparently.
+func execGmuxd(args ...string) int {
+	bin := findGmuxdBin()
+	if bin == "" {
+		fmt.Fprintln(os.Stderr, "gmux: gmuxd not found (install it alongside gmux or add it to PATH)")
+		return 1
+	}
+	c := exec.Command(bin, args...)
+	c.Stdin = os.Stdin
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+	if err := c.Run(); err != nil {
+		if exit, ok := err.(*exec.ExitError); ok {
+			return exit.ExitCode()
+		}
+		fmt.Fprintln(os.Stderr, "gmux:", err)
+		return 1
+	}
+	return 0
+}
+
+// openUI implements the `gmux open` invocation: ensure gmuxd is up,
 // learn its TCP listen address and auth token from /v1/health, and
 // hand those to the local browser.
 func openUI() {

--- a/cli/gmux/cmd/gmux/main.go
+++ b/cli/gmux/cmd/gmux/main.go
@@ -45,7 +45,7 @@ func main() {
 	case modeTail:
 		os.Exit(cmdTail(cmd.ref, cmd.tailLines, cmd.raw))
 	case modeAttach:
-		os.Exit(cmdAttach(cmd.ref, ""))
+		os.Exit(cmdAttach(cmd.ref))
 	case modeSend:
 		os.Exit(cmdSend(cmd.ref, cmd.sendText, cmd.sendKeys))
 	case modeSendKeys:

--- a/cli/gmux/cmd/gmux/run.go
+++ b/cli/gmux/cmd/gmux/run.go
@@ -68,9 +68,9 @@ func runSession(args []string, attach bool, dir runDirectives) {
 		return
 	}
 
-	// Explicit --no-attach: spawn detached, wait for the child to finish
+	// Explicit -d/--detach: spawn detached, wait for the child to finish
 	// registering with gmuxd, then print the session id on stdout so the
-	// caller (typically a script) can capture it for --tail / --dismiss
+	// caller (typically a script) can capture it for tail / kill
 	// without polling.
 	if !attach {
 		spawnDetached(args, "", true)
@@ -376,14 +376,14 @@ func reexecRunArgs(args []string) []string {
 
 // spawnDetached re-execs gmux with the given args as a setsid'd
 // background process, disconnected from the current terminal. Used
-// for both --no-attach and nested-gmux scenarios: the child registers
+// for both detached (-d) and nested-gmux scenarios: the child registers
 // with gmuxd and appears in the UI.
 //
 // When waitForRegistration is true, the parent blocks until the child
 // either acknowledges registration via the handshake pipe or fails;
 // on success it prints the session id on stdout, on failure it exits
-// non-zero with a stderr error. This is the --no-attach path: scripts
-// capture the id with id=$(gmux --no-attach foo) and use it
+// non-zero with a stderr error. This is the detached (-d) path: scripts
+// capture the id with id=$(gmux -d -- foo) and use it
 // immediately, without polling.
 //
 // When waitForRegistration is false, the parent prints msg on stderr
@@ -455,7 +455,7 @@ func spawnDetached(args []string, msg string, waitForRegistration bool) {
 
 // explainHandshakeFailure converts a readHandshake error into a
 // short human-readable reason for the stderr message a script
-// developer sees when --no-attach can't return a session id.
+// developer sees when a detached run cannot return a session id.
 func explainHandshakeFailure(err error) string {
 	switch {
 	case errors.Is(err, os.ErrDeadlineExceeded):

--- a/cli/gmux/cmd/gmux/run.go
+++ b/cli/gmux/cmd/gmux/run.go
@@ -365,6 +365,15 @@ func runSession(args []string, attach bool, dir runDirectives) {
 	os.Exit(exitCode)
 }
 
+// reexecRunArgs builds the argv for re-execing gmux to run a command
+// detached: the internal `__run -- <cmd>` form (ADR 0009). The `--`
+// delivers the command verbatim even when its own args look like flags,
+// and `__run` is required because the bare-command shorthand was removed
+// in 2.0 (a bare `gmux <cmd>` is now an "unknown command" error).
+func reexecRunArgs(args []string) []string {
+	return append([]string{"__run", "--"}, args...)
+}
+
 // spawnDetached re-execs gmux with the given args as a setsid'd
 // background process, disconnected from the current terminal. Used
 // for both --no-attach and nested-gmux scenarios: the child registers
@@ -398,8 +407,7 @@ func spawnDetached(args []string, msg string, waitForRegistration bool) {
 	// shorthand no longer exists, and `--` delivers the command verbatim
 	// even when its own args look like flags. Because the child's stdin
 	// is /dev/null it runs non-interactively without trying to attach.
-	reexecArgs := append([]string{"__run", "--"}, args...)
-	cmd := exec.Command(self, reexecArgs...)
+	cmd := exec.Command(self, reexecRunArgs(args)...)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
 	cmd.Stdin = devNull
 	cmd.Stdout = devNull

--- a/cli/gmux/cmd/gmux/run.go
+++ b/cli/gmux/cmd/gmux/run.go
@@ -393,11 +393,13 @@ func spawnDetached(args []string, msg string, waitForRegistration bool) {
 	}
 	defer devNull.Close()
 
-	// args is the command-remainder after gmux flag parsing, so it does
-	// not contain any gmux flags. The detached child sees no gmux flags,
-	// takes the default run path, and — because its stdin is /dev/null —
-	// runs non-interactively without trying to attach.
-	cmd := exec.Command(self, args...)
+	// args is the command-remainder after gmux flag parsing. Re-exec via
+	// the internal `__run -- <cmd>` form (ADR 0009): the bare-command
+	// shorthand no longer exists, and `--` delivers the command verbatim
+	// even when its own args look like flags. Because the child's stdin
+	// is /dev/null it runs non-interactively without trying to attach.
+	reexecArgs := append([]string{"__run", "--"}, args...)
+	cmd := exec.Command(self, reexecArgs...)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
 	cmd.Stdin = devNull
 	cmd.Stdout = devNull

--- a/cli/gmux/cmd/gmux/wait.go
+++ b/cli/gmux/cmd/gmux/wait.go
@@ -28,7 +28,7 @@ const (
 	waitExitTimeout = 3
 )
 
-// cmdWait implements `gmux --wait [--timeout N] <id>`.
+// cmdWait implements `gmux wait <id> [--for-text S | --for-regex P] [--timeout N]`.
 //
 // The wait itself happens server-side: gmuxd already subscribes to
 // per-session events for its own bookkeeping, so we just hand it the
@@ -42,7 +42,7 @@ const (
 // peer sessions are out of scope until peer subscriptions stream
 // Status events back to the hub.
 func cmdWait(ref, forText, forRegex string, timeoutSecs int) int {
-	sess, err := resolveSession(ref, "")
+	sess, err := resolveSession(ref)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "gmux:", err)
 		return 1
@@ -53,7 +53,7 @@ func cmdWait(ref, forText, forRegex string, timeoutSecs int) int {
 	if sess.Peer != "" {
 		// Use the bare shortID here: the message already names the peer
 		// separately, so displayID's "shortID@peer" would just repeat it.
-		fmt.Fprintf(os.Stderr, "gmux: --wait is only supported for local sessions (%s is on peer %q)\n",
+		fmt.Fprintf(os.Stderr, "gmux: wait is only supported for local sessions (%s is on peer %q)\n",
 			shortID(sess.ID), sess.Peer)
 		return 1
 	}
@@ -101,13 +101,13 @@ func cmdWait(ref, forText, forRegex string, timeoutSecs int) int {
 			return 1
 		}
 	case http.StatusRequestTimeout:
-		fmt.Fprintf(os.Stderr, "gmux: --wait timed out after %ds\n", timeoutSecs)
+		fmt.Fprintf(os.Stderr, "gmux: wait timed out after %ds\n", timeoutSecs)
 		return waitExitTimeout
 	case http.StatusUnprocessableEntity:
 		// Adapter kind doesn't emit an idle signal. Surface the
 		// daemon's message so the user knows which kind they hit.
 		body, _ := io.ReadAll(resp.Body)
-		fmt.Fprintf(os.Stderr, "gmux: --wait not supported for this session: %s\n",
+		fmt.Fprintf(os.Stderr, "gmux: wait not supported for this session: %s\n",
 			extractMessage(body))
 		return 1
 	case http.StatusNotFound:

--- a/cli/gmux/cmd/gmux/wait.go
+++ b/cli/gmux/cmd/gmux/wait.go
@@ -127,6 +127,11 @@ func cmdWait(ref, forText, forRegex string, timeoutSecs int) int {
 // timeout it prints the current tail to stderr so the wait is
 // diagnosable, and exits with waitExitTimeout.
 //
+// Exit codes match the idle-wait path (cmdWait): waitExitIdle on match,
+// waitExitDied if the session exits before the pattern appears (no more
+// output will ever come, so we fail fast rather than spin to timeout),
+// waitExitTimeout on --timeout.
+//
 // Polling lives client-side for now; absorbing it into a gmuxd endpoint
 // (so the match happens where the bytes are) is a planned follow-up.
 func waitForOutput(sess cliSession, forText, forRegex string, timeoutSecs int) int {
@@ -138,6 +143,12 @@ func waitForOutput(sess cliSession, forText, forRegex string, timeoutSecs int) i
 			fmt.Fprintf(os.Stderr, "gmux: invalid --for-regex: %v\n", err)
 			return 1
 		}
+	}
+	matched := func(b []byte) bool {
+		if re != nil {
+			return re.Match(b)
+		}
+		return bytes.Contains(b, []byte(forText))
 	}
 
 	var deadline time.Time
@@ -152,12 +163,24 @@ func waitForOutput(sess cliSession, forText, forRegex string, timeoutSecs int) i
 			return code
 		}
 		last = data
-		if re != nil {
-			if re.Match(data) {
-				return waitExitIdle
-			}
-		} else if bytes.Contains(data, []byte(forText)) {
+		if matched(data) {
 			return waitExitIdle
+		}
+		// No match yet. If the session has exited, no further output will
+		// arrive — give up with the "died" code instead of spinning to
+		// timeout. Re-read scrollback first to close the race where the
+		// pattern was printed and the session exited between our read and
+		// this liveness check (a dead session's scrollback is still served
+		// from disk, so the final bytes are there).
+		if sessionExited(sess.ID) {
+			if data, code = fetchScrollback(sess, 2000); code == 0 {
+				last = data
+				if matched(data) {
+					return waitExitIdle
+				}
+			}
+			fmt.Fprintf(os.Stderr, "gmux: session %s exited before the expected output appeared\n", displayID(sess))
+			return waitExitDied
 		}
 		if !deadline.IsZero() && time.Now().After(deadline) {
 			fmt.Fprintf(os.Stderr, "gmux: wait timed out after %ds; last output:\n", timeoutSecs)

--- a/cli/gmux/cmd/gmux/wait.go
+++ b/cli/gmux/cmd/gmux/wait.go
@@ -1,13 +1,16 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 	"os"
+	"regexp"
 	"strconv"
+	"time"
 )
 
 // Exit codes from cmdWait. Distinct codes let scripts dispatch on the
@@ -38,11 +41,14 @@ const (
 // against its local store and consults the adapter allowlist; remote
 // peer sessions are out of scope until peer subscriptions stream
 // Status events back to the hub.
-func cmdWait(ref string, timeoutSecs int) int {
+func cmdWait(ref, forText, forRegex string, timeoutSecs int) int {
 	sess, err := resolveSession(ref, "")
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "gmux:", err)
 		return 1
+	}
+	if forText != "" || forRegex != "" {
+		return waitForOutput(sess, forText, forRegex, timeoutSecs)
 	}
 	if sess.Peer != "" {
 		// Use the bare shortID here: the message already names the peer
@@ -113,6 +119,53 @@ func cmdWait(ref string, timeoutSecs int) int {
 		body, _ := io.ReadAll(resp.Body)
 		fmt.Fprintf(os.Stderr, "gmux: wait failed: %s: %s\n", resp.Status, extractMessage(body))
 		return 1
+	}
+}
+
+// waitForOutput polls the session's scrollback until a fixed substring
+// (forText) or a regex (forRegex) appears, or --timeout elapses. On
+// timeout it prints the current tail to stderr so the wait is
+// diagnosable, and exits with waitExitTimeout.
+//
+// Polling lives client-side for now; absorbing it into a gmuxd endpoint
+// (so the match happens where the bytes are) is a planned follow-up.
+func waitForOutput(sess cliSession, forText, forRegex string, timeoutSecs int) int {
+	var re *regexp.Regexp
+	if forRegex != "" {
+		var err error
+		re, err = regexp.Compile(forRegex)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "gmux: invalid --for-regex: %v\n", err)
+			return 1
+		}
+	}
+
+	var deadline time.Time
+	if timeoutSecs > 0 {
+		deadline = time.Now().Add(time.Duration(timeoutSecs) * time.Second)
+	}
+
+	var last []byte
+	for {
+		data, code := fetchScrollback(sess, 2000)
+		if code != 0 {
+			return code
+		}
+		last = data
+		if re != nil {
+			if re.Match(data) {
+				return waitExitIdle
+			}
+		} else if bytes.Contains(data, []byte(forText)) {
+			return waitExitIdle
+		}
+		if !deadline.IsZero() && time.Now().After(deadline) {
+			fmt.Fprintf(os.Stderr, "gmux: wait timed out after %ds; last output:\n", timeoutSecs)
+			os.Stderr.Write(stripANSI(last))
+			fmt.Fprintln(os.Stderr)
+			return waitExitTimeout
+		}
+		time.Sleep(500 * time.Millisecond)
 	}
 }
 

--- a/cli/gmux/cmd/gmux/wait.go
+++ b/cli/gmux/cmd/gmux/wait.go
@@ -1,16 +1,13 @@
 package main
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 	"os"
-	"regexp"
 	"strconv"
-	"time"
 )
 
 // Exit codes from cmdWait. Distinct codes let scripts dispatch on the
@@ -28,7 +25,7 @@ const (
 	waitExitTimeout = 3
 )
 
-// cmdWait implements `gmux wait <id> [--for-text S | --for-regex P] [--timeout N]`.
+// cmdWait implements `gmux wait <id> [--timeout N]`.
 //
 // The wait itself happens server-side: gmuxd already subscribes to
 // per-session events for its own bookkeeping, so we just hand it the
@@ -41,14 +38,11 @@ const (
 // against its local store and consults the adapter allowlist; remote
 // peer sessions are out of scope until peer subscriptions stream
 // Status events back to the hub.
-func cmdWait(ref, forText, forRegex string, timeoutSecs int) int {
+func cmdWait(ref string, timeoutSecs int) int {
 	sess, err := resolveSession(ref)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "gmux:", err)
 		return 1
-	}
-	if forText != "" || forRegex != "" {
-		return waitForOutput(sess, forText, forRegex, timeoutSecs)
 	}
 	if sess.Peer != "" {
 		// Use the bare shortID here: the message already names the peer
@@ -119,76 +113,6 @@ func cmdWait(ref, forText, forRegex string, timeoutSecs int) int {
 		body, _ := io.ReadAll(resp.Body)
 		fmt.Fprintf(os.Stderr, "gmux: wait failed: %s: %s\n", resp.Status, extractMessage(body))
 		return 1
-	}
-}
-
-// waitForOutput polls the session's scrollback until a fixed substring
-// (forText) or a regex (forRegex) appears, or --timeout elapses. On
-// timeout it prints the current tail to stderr so the wait is
-// diagnosable, and exits with waitExitTimeout.
-//
-// Exit codes match the idle-wait path (cmdWait): waitExitIdle on match,
-// waitExitDied if the session exits before the pattern appears (no more
-// output will ever come, so we fail fast rather than spin to timeout),
-// waitExitTimeout on --timeout.
-//
-// Polling lives client-side for now; absorbing it into a gmuxd endpoint
-// (so the match happens where the bytes are) is a planned follow-up.
-func waitForOutput(sess cliSession, forText, forRegex string, timeoutSecs int) int {
-	var re *regexp.Regexp
-	if forRegex != "" {
-		var err error
-		re, err = regexp.Compile(forRegex)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "gmux: invalid --for-regex: %v\n", err)
-			return 1
-		}
-	}
-	matched := func(b []byte) bool {
-		if re != nil {
-			return re.Match(b)
-		}
-		return bytes.Contains(b, []byte(forText))
-	}
-
-	var deadline time.Time
-	if timeoutSecs > 0 {
-		deadline = time.Now().Add(time.Duration(timeoutSecs) * time.Second)
-	}
-
-	var last []byte
-	for {
-		data, code := fetchScrollback(sess, 2000)
-		if code != 0 {
-			return code
-		}
-		last = data
-		if matched(data) {
-			return waitExitIdle
-		}
-		// No match yet. If the session has exited, no further output will
-		// arrive — give up with the "died" code instead of spinning to
-		// timeout. Re-read scrollback first to close the race where the
-		// pattern was printed and the session exited between our read and
-		// this liveness check (a dead session's scrollback is still served
-		// from disk, so the final bytes are there).
-		if sessionExited(sess.ID) {
-			if data, code = fetchScrollback(sess, 2000); code == 0 {
-				last = data
-				if matched(data) {
-					return waitExitIdle
-				}
-			}
-			fmt.Fprintf(os.Stderr, "gmux: session %s exited before the expected output appeared\n", displayID(sess))
-			return waitExitDied
-		}
-		if !deadline.IsZero() && time.Now().After(deadline) {
-			fmt.Fprintf(os.Stderr, "gmux: wait timed out after %ds; last output:\n", timeoutSecs)
-			os.Stderr.Write(stripANSI(last))
-			fmt.Fprintln(os.Stderr)
-			return waitExitTimeout
-		}
-		time.Sleep(500 * time.Millisecond)
 	}
 }
 

--- a/docs/adr/0004-session-stream-and-live-dead-view.md
+++ b/docs/adr/0004-session-stream-and-live-dead-view.md
@@ -4,6 +4,9 @@
 **Date:** 2026-05-04
 **Related:** ADR 0003 (Daemon-initiated resume passes Session.ID to the runner)
 
+> **Note (2026-06, CLI 2.0):** Decision stands; any pre-2.0 command syntax in
+> the examples (e.g. `--tail`) is superseded by ADR 0009's verb-first grammar.
+
 ## Context
 
 A user attached to a session whose runner exits expects the

--- a/docs/adr/0005-cli-routes-through-gmuxd.md
+++ b/docs/adr/0005-cli-routes-through-gmuxd.md
@@ -4,6 +4,11 @@
 **Date:** 2026-05-17
 **Related:** gmuxapp/gmux#221 (peer --send/--tail), gmuxapp/gmux#222 (tail on dead sessions)
 
+> **Note (2026-06, CLI 2.0):** The *routing* decision below stands — the CLI
+> still speaks one gmuxd HTTP API. Only the command **syntax** in the examples
+> is pre-2.0 (`--list`/`--tail`/`--send`/…); see ADR 0009 for the current
+> verb-first grammar (`gmux ls`/`gmux tail`/`gmux send`).
+
 ## Context
 
 Until this change, four of the CLI's session subcommands split cleanly

--- a/docs/adr/0006-fresh-login-env-on-launch.md
+++ b/docs/adr/0006-fresh-login-env-on-launch.md
@@ -4,6 +4,9 @@
 **Date:** 2026-05-29
 **Related:** ADR 0003 (daemon-initiated resume / restart passes Session.ID), ADR 0005 (CLI routes through gmuxd)
 
+> **Note (2026-06, CLI 2.0):** Decision stands. The env-capture probe is now
+> invoked as `gmux __dump-env` (was `gmux --dump-env`); see ADR 0009.
+
 ## Context
 
 Every managed session's environment is, today, a frozen copy of the

--- a/docs/adr/0009-verb-first-cli-and-frozen-top-level-namespace.md
+++ b/docs/adr/0009-verb-first-cli-and-frozen-top-level-namespace.md
@@ -150,9 +150,9 @@ For 2.0 we unify on a single **verb-first** grammar fronted by the
 13a. **`gmux tail` is snapshot-only.** `gmux tail <id>` (default ~100
      lines), `-n N` for count, `--raw`/`-e` to preserve ANSI (stripped by
      default). **No `-f`/follow and no `logs` verb**: "block until output
-     X" is served by `wait --for-text`/`--for-regex` (better: in-daemon,
-     timeout, exit code); live human watching is served by the browser
-     and `attach`. Streaming a pane elsewhere (tmux `pipe-pane`) is niche
+     X" is served by a future `wait` output-condition (see decision 13);
+     live human watching is served by the browser and `attach`.
+     Streaming a pane elsewhere (tmux `pipe-pane`) is niche
      and deferred to a future namespace if requested.
 
 13b. **`gmux ls` output.** Human default: short id · state
@@ -163,15 +163,19 @@ For 2.0 we unify on a single **verb-first** grammar fronted by the
      tmux-style `-F`/`--format` is deferred (addable under the
      frozen-namespace policy).
 
-13. **`gmux wait` condition is explicit; default is idle-or-exit.**
+13. **`gmux wait` waits for agent idle, bounded by `--timeout`.**
     `gmux wait <id>` blocks until the session goes **idle** (agent turn
-    end; shell idle-detection is a planned follow-up) **or the session
-    exits** — whichever comes first, so a detached non-agent command
-    (`gmux -d -- pytest`) is waitable without hanging. Explicit
-    conditions: `--for-text <str>` (fixed substring), `--for-regex <pat>`,
-    bounded by `--timeout <secs>`. On timeout, exit nonzero **and print
-    the current tail to stderr** so the wait is diagnosable. Cross-peer
-    `wait` returns "not supported across peers yet" (ADR 0005 deferral).
+    end) or exits; `--timeout <secs>` bounds it (exit 0 idle, 2 died,
+    3 timeout). Cross-peer `wait` returns "not supported across peers
+    yet" (ADR 0005 deferral).
+
+    Output-condition variants (`--for-text` / `--for-regex` — "block
+    until this text appears") were designed but **deferred**: the only
+    sound implementation matches where the bytes are, i.e. a gmuxd
+    endpoint, not client-side scrollback polling. Tracked as a
+    follow-up ([#313](https://github.com/gmuxapp/gmux/issues/313)).
+    Until then, shell "wait for output" is served by running the command
+    through the blocking piped form (`gmux -- <cmd>`).
 
 ## Considered alternatives
 

--- a/docs/adr/0009-verb-first-cli-and-frozen-top-level-namespace.md
+++ b/docs/adr/0009-verb-first-cli-and-frozen-top-level-namespace.md
@@ -48,11 +48,29 @@ For 2.0 we unify on a single **verb-first** grammar fronted by the
    Adding a new top-level verb is a breaking change requiring a major
    bump.
 
-6. **`gmuxd` becomes a pure daemon executable: foreground serve only.**
-   Bare `gmuxd` serves in the foreground (what `gmuxd run` did);
-   `gmuxd run` is kept as a hidden compatibility alias. All human-facing
-   daemon control moved to `gmux daemon …`. `gmuxd` stays a separate
-   binary (like `dockerd`/`tailscaled`) for systemd/Docker supervision.
+6. **`gmux daemon …` is the canonical front; `gmuxd` keeps its verbs for
+   backwards-compatible ops.** `gmux daemon start|stop|restart|status|
+   log-path`, `gmux auth`, and `gmux remote` are the documented surface
+   and bridge (thin `exec`) to the `gmuxd` binary, which retains its
+   existing verbs (`run`, `start`, `stop`, `restart`, `status`, `auth`,
+   `remote`, `log-path`; bare `gmuxd` prints help, `gmuxd run` serves
+   foreground). The bridge keeps a **single implementation** (in gmuxd)
+   rather than copying lifecycle code into gmux.
+
+   This deliberately steps back from "strip `gmuxd` to bare-serve only."
+   Rationale: the constraint that drove top-level minimalism — shorthand
+   collisions — is gone (decision 4 dropped the shorthand), and daemon
+   control is rare, human, and non-scriptable, so a second entry point
+   costs little. Against that, a hard break would force migration on
+   *infrastructure* config (systemd `ExecStart=…/gmuxd run`, Dockerfiles,
+   runbooks) — edited rarely, by different people, and not covered by the
+   scriptable-surface migration shim. Keeping `gmuxd`'s verbs is
+   backwards-compatible there and lower-risk than moving working code
+   across the binary boundary. Docs steer everyone to `gmux daemon …`;
+   `gmuxd --help` cross-references it. (This is *not* the `open`/`ui`/`app`
+   alias smell of decision 2: that was three names for the single most
+   common action; this is one canonical name plus the underlying binary
+   that infra already invokes.)
 
 7. **Daemon auto-start is intent-driven.** Session verbs (`open`, `ls`,
    `attach`, `tail`, `send`, `wait`, `kill`, and `gmux -- <cmd>`)
@@ -190,7 +208,10 @@ For 2.0 we unify on a single **verb-first** grammar fronted by the
   shim would have forced keeping them). The table deletes cleanly in
   2.1. Cost accepted: existing *scripts* break immediately rather than
   working-with-warning — appropriate for a major version, and agents
-  migrate the instant the skill is updated.
+  migrate the instant the skill is updated. Note the shim covers the
+  *scriptable* surface only; daemon/ops invocations (`gmuxd <verb>`)
+  keep working unchanged per decision 6, so infrastructure config needs
+  no migration.
 - `--host` is dropped. `<id>@<peer>` is the **sole** way to address a
   peer session, which simplifies `matchSession` (the `host` parameter
   and the `--host`/`@suffix` reconciliation branch both go away).

--- a/docs/adr/0009-verb-first-cli-and-frozen-top-level-namespace.md
+++ b/docs/adr/0009-verb-first-cli-and-frozen-top-level-namespace.md
@@ -1,0 +1,196 @@
+# ADR 0009: Verb-first CLI, explicit run syntax, and a frozen top-level namespace
+
+**Status:** Proposed
+**Date:** 2026-06-15
+**Supersedes (in part):** the flag-based action surface of ADR 0005 (the
+*transport* decision in 0005 stands; only the user-facing flag grammar changes)
+
+## Context
+
+Before 2.0, `gmux` exposed session actions as mutually-exclusive boolean
+flags (`--list`, `--attach`, `--tail`, `--kill`, `--send`, `--wait`,
+`--no-attach`, `--host`, `--all`) while the `gmuxd` daemon binary used
+verbs (`start`, `run`, `stop`, `status`, `auth`, `remote`, `log-path`).
+Two grammars, one product. The flag grammar also required ~150 lines of
+hand-rolled mutual-exclusion and interspersed-flag parsing in `cli.go`.
+
+For 2.0 we unify on a single **verb-first** grammar fronted by the
+`gmux` binary, and we settle how a command-to-run is expressed.
+
+## Decision
+
+1. **All user-facing actions are verbs under `gmux`.** Session verbs:
+   `open`, `ls`, `attach`, `tail`, `send`, `wait`, `kill` (plus `help`,
+   `version`). Each verb owns its own flag set; the global
+   mutual-exclusion maze is deleted.
+
+2. **`gmux open` is the single canonical UI-launch verb.** No `ui`/`app`
+   aliases. (`open` is a verb, consistent grammar, and matches
+   `xdg-open`/`gh browse` intuitions.) The web client remains the
+   **Frontend** in the glossary; `open` names the *action*, not the thing.
+
+3. **Bare `gmux` prints help.** It has no side effects — in particular it
+   does **not** auto-start the daemon.
+
+4. **Running a command is explicit: `gmux -- <cmd> [args…]`.** There is no
+   `run` verb (so `run` is not a reserved word) and **no bare shorthand**
+   (`gmux pytest` is an "unknown command" error, not "run pytest").
+   Power users who want terseness alias `gm='gmux --'` — which is shorter
+   than the old shorthand and lives in their shell, not the tool.
+
+5. **The top-level verb namespace is deliberately closed and small.**
+   Functionality grows under **namespace groups**, not new top-level
+   verbs:
+   - `gmux daemon start|stop|restart|status|log-path` — daemon process
+     lifecycle (was the `gmuxd` verbs).
+   - future groups (e.g. `gmux peer …`) as needed.
+   `auth` and `remote` remain top-level (rare, deliberate, setup-time).
+   Adding a new top-level verb is a breaking change requiring a major
+   bump.
+
+6. **`gmuxd` becomes a pure daemon executable: foreground serve only.**
+   Bare `gmuxd` serves in the foreground (what `gmuxd run` did);
+   `gmuxd run` is kept as a hidden compatibility alias. All human-facing
+   daemon control moved to `gmux daemon …`. `gmuxd` stays a separate
+   binary (like `dockerd`/`tailscaled`) for systemd/Docker supervision.
+
+7. **Daemon auto-start is intent-driven.** Session verbs (`open`, `ls`,
+   `attach`, `tail`, `send`, `wait`, `kill`, and `gmux -- <cmd>`)
+   auto-start `gmuxd` when it is down — the daemon is a *stateful broker*
+   that rehydrates dead sessions from disk, so even `ls`/`tail` on a cold
+   machine have something to serve. `gmux daemon status` and bare `gmux`
+   (help) never auto-start.
+
+8. **`gmux auth` stays a distinct verb because it prints a secret.**
+   Folding the token reveal into `gmux remote` status would leak live
+   tokens into scrollback/screenshares on a casual status check.
+   `gmux remote` shows connection *state* only and MUST NOT print the
+   token; revealing the token is the explicit, deliberate act of
+   `gmux auth`.
+
+9. **Argument convention (positional vs named).**
+   - A verb's single **primary operand is positional and comes first** —
+     for session verbs, the session reference: `gmux kill <id>`,
+     `gmux tail <id>`, `gmux attach <id>`. This deliberately diverges from
+     tmux's named `-t` target: gmux is single-target with no
+     `window.pane` substructure, so the disambiguation tmux needs does
+     not exist, and `gmux kill foo` beats `gmux kill -t foo`.
+   - **Behavior modifiers are named flags:** `-d`, `--timeout`, `--json`,
+     `--no-submit`, `--all`.
+   - **Variadic / verbatim content is trailing positionals**, after the
+     primary operand, guarded by `--` when passed through untouched (the
+     run command; literal send text).
+
+10. **Two input verbs with distinct contracts (not aliases).**
+    - `gmux send <id> <text> [Key…]` — gmux-native. `<text>` is **literal**;
+      trailing bare tokens matching key names (`Enter`, `C-c`, `Escape`,
+      `Up`…) are interpreted as keys. Common case: `gmux send foo 'pytest -q' Enter`.
+      `--no-submit` suppresses the implicit nothing (no Enter unless a
+      trailing key says so).
+    - `gmux send-keys -t <id> …` — the **verbatim tmux interface**
+      (`-t` target, all args are key names by default, `-l` for literal).
+      A *compatibility verb*, documented as such, so tmux knowledge and
+      existing tmux skills/agent calls port directly. Docs must state
+      crisply: *use `send` normally; `send-keys` only when porting tmux*.
+    - **Enter is explicit; `--no-submit` is removed.** Submission is
+      controlled by a trailing `Enter` key token, tmux-style:
+      `gmux send foo 'pytest -q' Enter` submits; omitting `Enter` types
+      without submitting. This changes today's implicit-Enter default.
+
+11. **Local-by-default, as a hard invariant (agent blast-radius).**
+    The CLI's default worldview is "this host only", so an agent can
+    never *accidentally* act on another machine:
+    - **Targeting:** bare references resolve strictly against local
+      sessions. Fuzzy/prefix matching never crosses a host boundary. A
+      bare ref that matches only a peer session is a **miss with a hint**
+      ("did you mean `foo@konyvtar`?"), never a silent remote action.
+    - **Visibility:** `gmux ls` shows local only; `--all` opts into the
+      fleet. Listing scope and targeting scope are **independent** —
+      `ls --all` surfacing a remote session never lets a subsequent bare
+      `gmux kill foo` reach it.
+    - **Opt-in:** crossing a host requires explicitly typing `@peer`.
+      This is a deliberate, per-command act; there is no flag or config
+      that makes bare refs go remote.
+    - This is the existing resolver behaviour (empty host = `Peer == ""`
+      only); 2.0 promotes it to a tested invariant so a future refactor
+      cannot quietly let prefix-matching bleed across hosts. The
+      agent-facing skill keeps `@peer` as a one-line advanced escape
+      hatch, not woven through its examples.
+    - No regression of ADR 0005: cross-host CLI actions stay *possible*
+      (gmuxd still routes via `peer.Forward`/`ProxyWS`), just *explicit*.
+      The trust boundary remains the daemon + per-host pairing tokens
+      (ADR 0008); the CLI is one local client among others.
+
+12. **Guiding principle: follow tmux conventions wherever sensible.**
+    tmux is the reference grammar for terminal-multiplexer agents; matching
+    it (`-d` detach, `send-keys`, key names, capture semantics) lets
+    existing tmux skills and agent muscle memory transfer to gmux.
+    Deliberate divergences (positional target; literal-default `send`;
+    no `run` verb) are called out where they occur and justified by
+    gmux's narrower, session-centric model.
+
+13a. **`gmux tail` is snapshot-only.** `gmux tail <id>` (default ~100
+     lines), `-n N` for count, `--raw`/`-e` to preserve ANSI (stripped by
+     default). **No `-f`/follow and no `logs` verb**: "block until output
+     X" is served by `wait --for-text`/`--for-regex` (better: in-daemon,
+     timeout, exit code); live human watching is served by the browser
+     and `attach`. Streaming a pane elsewhere (tmux `pipe-pane`) is niche
+     and deferred to a future namespace if requested.
+
+13b. **`gmux ls` output.** Human default: short id · state
+     (alive/idle/dead) · kind · slug/title · command · age (+ `peer`
+     column under `--all`). `--json` emits a single stable-schema array
+     (`id, slug, kind, alive, idle, pid, title, command, started_at,
+     exited_at, exit_code, peer`) so agents stop scraping the table.
+     tmux-style `-F`/`--format` is deferred (addable under the
+     frozen-namespace policy).
+
+13. **`gmux wait` condition is explicit; default is idle-or-exit.**
+    `gmux wait <id>` blocks until the session goes **idle** (agent turn
+    end; shell idle-detection is a planned follow-up) **or the session
+    exits** — whichever comes first, so a detached non-agent command
+    (`gmux -d -- pytest`) is waitable without hanging. Explicit
+    conditions: `--for-text <str>` (fixed substring), `--for-regex <pat>`,
+    bounded by `--timeout <secs>`. On timeout, exit nonzero **and print
+    the current tail to stderr** so the wait is diagnosable. Cross-peer
+    `wait` returns "not supported across peers yet" (ADR 0005 deferral).
+
+## Considered alternatives
+
+- **Keep the bare shorthand `gmux <cmd>` alongside `gmux -- <cmd>`.**
+  Rejected: the shorthand *freezes* the top-level namespace (every new
+  verb could shadow a user's same-named binary), forecloses friendly
+  "unknown verb, did you mean…?" errors, and forces a verb-vs-program
+  disambiguation branch in the parser. The `gm` alias recovers the
+  ergonomics without any of these costs.
+- **Require `gmux run <cmd>`.** Rejected in favour of `gmux -- <cmd>`:
+  `--` is universal, needs no reserved word, and the parser already
+  implements it.
+- **One binary for daemon + runner (symlink `gmuxd`→`gmux`).** Rejected:
+  keeping `gmuxd` separate matches daemon conventions and keeps `ps`,
+  systemd units, and packaging legible.
+
+## Consequences
+
+- ~150 lines of mutual-exclusion / interspersed-flag parsing in `cli.go`
+  are removed; each verb parses its own flags normally. Only `gmux --`
+  needs stop-at-first-positional.
+- Verb *typos* are impossible to fool-proof only because there is no
+  shorthand — every bare word is a verb, so `gmux opn` yields a clean
+  "unknown command" with a suggestion.
+- Breaking change appropriate to a major version. **Migration uses an
+  error-only shim, not a forwarding shim.** Old forms (every removed
+  flag, `gmuxd <verb>`, and the removed bare `gmux <cmd>` shorthand) are
+  recognized *solely to emit a precise migration error* and exit
+  nonzero — e.g. `--list` → "use `gmux ls`"; `gmuxd status` → "use
+  `gmux daemon status`"; bare `gmux pytest` → "unknown command 'pytest';
+  to run a command use `gmux -- pytest`". This is a static guidance
+  table carrying **zero old behavior**, so the old flag parser and the
+  mutual-exclusion conflict-matrix are genuinely deleted (a forwarding
+  shim would have forced keeping them). The table deletes cleanly in
+  2.1. Cost accepted: existing *scripts* break immediately rather than
+  working-with-warning — appropriate for a major version, and agents
+  migrate the instant the skill is updated.
+- `--host` is dropped. `<id>@<peer>` is the **sole** way to address a
+  peer session, which simplifies `matchSession` (the `host` parameter
+  and the `--host`/`@suffix` reconciliation branch both go away).

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -194,7 +194,7 @@ export default async function globalSetup(_config: FullConfig) {
 
   // Start a test shell session (non-interactive — no local terminal attach).
   // cwd=workspaceDir so the session is matched into the seeded project.
-  const gmux = spawn(GMUX, ['bash', '-c', 'echo READY; while true; do sleep 60; done'], {
+  const gmux = spawn(GMUX, ['--', 'bash', '-c', 'echo READY; while true; do sleep 60; done'], {
     env,
     cwd: workspaceDir,
     stdio: ['ignore', 'pipe', 'pipe'],

--- a/services/gmuxd/cmd/gmuxd/loginenv.go
+++ b/services/gmuxd/cmd/gmuxd/loginenv.go
@@ -23,7 +23,7 @@ const loginEnvTimeout = 5 * time.Second
 // captureLoginEnv returns a freshly-sourced login environment for a
 // session about to be launched in cwd, by running
 //
-//	$SHELL -l -i -c '<gmuxBin> --dump-env'
+//	$SHELL -l -i -c '<gmuxBin> __dump-env'
 //
 // in that cwd and reading the NUL-delimited environment the probe
 // writes to fd 3. The interactive login shell sources the user's
@@ -86,7 +86,7 @@ func runLoginEnvProbe(shell, gmuxBin, cwd string, timeout time.Duration) ([]stri
 	// -l (login) sources the profile files; -i (interactive) sources
 	// ~/.zshrc / ~/.bashrc, where most users' PATH/exports/tool-shims
 	// live. shellQuote guards a gmuxBin path containing spaces.
-	cmd := exec.CommandContext(ctx, shell, "-l", "-i", "-c", shellQuote(gmuxBin)+" --dump-env")
+	cmd := exec.CommandContext(ctx, shell, "-l", "-i", "-c", shellQuote(gmuxBin)+" __dump-env")
 	cmd.Dir = cwd
 	cmd.Stdin, cmd.Stdout, cmd.Stderr = nil, nil, nil
 	cmd.ExtraFiles = []*os.File{pw} // child sees this as fd 3

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -204,13 +204,14 @@ func launchGmux(gmuxBin string, command []string, cwd, resumeID string, initialC
 	return cmd.Process.Pid, nil
 }
 
-// buildLaunchArgs assembles the gmux runner argv: any non-empty
-// daemon→runner directive flags first, then the user command
-// verbatim. The gmux flag parser stops at the first positional, so
-// the user command is delivered intact even when its own arguments
-// look like flags.
+// buildLaunchArgs assembles the gmux runner argv for the internal
+// `gmux __run [directives] -- <command>` form (ADR 0009): the hidden
+// __run verb, any non-empty daemon→runner directive flags, then a `--`
+// terminator and the user command verbatim. The `--` delivers the
+// command intact even when its own arguments look like flags.
 func buildLaunchArgs(resumeID string, initialCols, initialRows uint16, command []string) []string {
-	args := make([]string, 0, len(command)+3)
+	args := make([]string, 0, len(command)+5)
+	args = append(args, "__run")
 	if resumeID != "" {
 		args = append(args, "--resume-id="+resumeID)
 	}
@@ -220,6 +221,7 @@ func buildLaunchArgs(resumeID string, initialCols, initialRows uint16, command [
 	if initialRows > 0 {
 		args = append(args, fmt.Sprintf("--initial-rows=%d", initialRows))
 	}
+	args = append(args, "--")
 	return append(args, command...)
 }
 
@@ -241,7 +243,8 @@ Commands:
   help               Show this help
 
 Tip:
-  gmux <command>     Run a command; gmux auto-starts gmuxd if needed
+  gmux daemon <cmd>  Canonical front for these commands (start/stop/status/...)
+  gmux -- <command>  Run a command; gmux auto-starts gmuxd if needed
   More help: https://gmux.app
 `, version)
 }

--- a/services/gmuxd/cmd/gmuxd/main_test.go
+++ b/services/gmuxd/cmd/gmuxd/main_test.go
@@ -626,19 +626,22 @@ func TestIsAllowedPeerProxyPath(t *testing.T) {
 func TestBuildLaunchArgs(t *testing.T) {
 	cmd := []string{"claude", "--continue", "-p", "hi"}
 
-	t.Run("fresh launch: no directives, command verbatim", func(t *testing.T) {
+	t.Run("fresh launch: __run then -- then command verbatim", func(t *testing.T) {
 		got := buildLaunchArgs("", 0, 0, cmd)
-		if !slices.Equal(got, cmd) {
-			t.Errorf("got %v, want %v", got, cmd)
+		want := append([]string{"__run", "--"}, cmd...)
+		if !slices.Equal(got, want) {
+			t.Errorf("got %v, want %v", got, want)
 		}
 	})
 
-	t.Run("restart: all directives precede the command", func(t *testing.T) {
+	t.Run("restart: directives precede --, then the command", func(t *testing.T) {
 		got := buildLaunchArgs("sess-abc", 142, 47, cmd)
 		want := []string{
+			"__run",
 			"--resume-id=sess-abc",
 			"--initial-cols=142",
 			"--initial-rows=47",
+			"--",
 			"claude", "--continue", "-p", "hi",
 		}
 		if !slices.Equal(got, want) {
@@ -648,22 +651,22 @@ func TestBuildLaunchArgs(t *testing.T) {
 
 	t.Run("zero dims omit the size flags", func(t *testing.T) {
 		got := buildLaunchArgs("sess-1", 0, 0, cmd)
-		want := append([]string{"--resume-id=sess-1"}, cmd...)
+		want := append([]string{"__run", "--resume-id=sess-1", "--"}, cmd...)
 		if !slices.Equal(got, want) {
 			t.Errorf("got %v, want %v", got, want)
 		}
 	})
 
-	t.Run("command flags survive intact (parser stops at first positional)", func(t *testing.T) {
-		// If the daemon's directive args bled into the command, the
-		// runner's flag parser would consume --resume-id from the
-		// child's own argv. Verify ordering: directives appear before
-		// the first positional only.
+	t.Run("command flags survive intact (-- terminator)", func(t *testing.T) {
+		// The `--` terminator delivers the command verbatim even when its
+		// own args look like directive flags.
 		got := buildLaunchArgs("sess-1", 80, 24, []string{"weirdcli", "--resume-id=evil"})
 		want := []string{
+			"__run",
 			"--resume-id=sess-1",
 			"--initial-cols=80",
 			"--initial-rows=24",
+			"--",
 			"weirdcli", "--resume-id=evil",
 		}
 		if !slices.Equal(got, want) {

--- a/skills/gmux/SKILL.md
+++ b/skills/gmux/SKILL.md
@@ -40,7 +40,7 @@ gmux send $id 'pytest -q' Enter   # type and run
 gmux send $id 'half a line'       # type without submitting
 gmux send $id C-c                 # interrupt (Ctrl-C)
 gmux send $id Escape              # send Escape
-echo "$body" | gmux send $id      # pipe stdin (verbatim; add Enter yourself)
+echo "$body" | gmux send $id Enter  # pipe stdin, then submit (Enter optional)
 ```
 
 Key names follow tmux: `Enter`, `Tab`, `Escape`, `Up`/`Down`/`Left`/`Right`,

--- a/skills/gmux/SKILL.md
+++ b/skills/gmux/SKILL.md
@@ -5,30 +5,58 @@ description: Drive long-running terminal commands and AI coding agents through g
 
 # gmux
 
+A command run through gmux becomes a managed session the user can watch live
+in a browser. The grammar is verb-first; **running a command always uses the
+explicit `--` separator** so gmux never guesses where its own flags end and
+the command begins.
+
 ## Primitives
 
 ```bash
-gmux --no-attach <cmd>       # spawn detached; prints the session id on stdout
-gmux <cmd> < /dev/null       # spawn blocking; exits with the child's exit code
-gmux --send <id> [text]      # send text (or stdin) to a session and submit
-gmux --wait <id>             # block until the agent finishes its turn
-gmux --tail N <id>           # last N lines of output (ANSI stripped)
-gmux --list                  # all sessions
-gmux --kill <id>             # SIGTERM the runner
+gmux -- <cmd> [args]         # run blocking; exits with the child's exit code
+gmux -d -- <cmd> [args]      # run detached; prints the session id on stdout
+gmux send <id> 'text' Enter  # type text and submit (Enter is explicit)
+gmux send <id> C-c           # send a control key (interrupt), no text
+gmux wait <id>               # block until the agent finishes its turn
+gmux tail <id> [-n N]        # last N lines of output (ANSI stripped; default 100)
+gmux ls [--json]             # list sessions (--json for machine parsing)
+gmux kill <id>               # SIGTERM the runner
 ```
 
-`--list` IDs are 8-character prefixes; pass them directly to `--send` / `--wait` / `--tail` / `--kill`.
+`ls` IDs are 8-character prefixes; pass them directly to
+`send` / `wait` / `tail` / `kill`. Tip: `alias gm='gmux --'` makes
+`gm pytest` shorthand for `gmux -- pytest`.
+
+Because `gmux -- <cmd>` propagates the child's exit code, it composes:
+`if gmux -- pytest -q; then ...`.
+
+## Sending input and keys
+
+`send` types literal text; any trailing token that is a key name is sent as a
+key. **Enter is not implicit** — add it to submit:
+
+```bash
+gmux send $id 'pytest -q' Enter   # type and run
+gmux send $id 'half a line'       # type without submitting
+gmux send $id C-c                 # interrupt (Ctrl-C)
+gmux send $id Escape              # send Escape
+echo "$body" | gmux send $id      # pipe stdin (verbatim; add Enter yourself)
+```
+
+Key names follow tmux: `Enter`, `Tab`, `Escape`, `Up`/`Down`/`Left`/`Right`,
+`C-c`, `C-d`, etc. For verbatim tmux compatibility there is also
+`gmux send-keys -t <id> <keys...>` (with `-l` for literal text).
 
 ## Sequential orchestration
 
 ```bash
-id=$(gmux --no-attach pi "implement the feature")
-gmux --wait $id
+id=$(gmux -d -- pi "implement the feature")
+gmux wait $id
 
-gmux --send $id < review.txt
-gmux --wait $id
+gmux send $id "$(cat review.txt)" Enter
+gmux wait $id
 
-gmux --tail 100 $id
+gmux tail $id -n 100
 ```
 
 ## Parallel orchestration
@@ -36,39 +64,56 @@ gmux --tail 100 $id
 ```bash
 ids=()
 for ticket in fa-48 fa-49 fa-52; do
-  ids+=( "$(gmux --no-attach pi "Implement $ticket. Return when done.")" )
+  ids+=( "$(gmux -d -- pi "Implement $ticket. Return when done.")" )
 done
 
 for id in "${ids[@]}"; do
-  gmux --wait --timeout 600 "$id" || echo "$id failed: $?"
+  gmux wait "$id" --timeout 600 || echo "$id failed: $?"
 done
 
 for id in "${ids[@]}"; do
   echo "=== $id ==="
-  gmux --tail 100 "$id"
+  gmux tail "$id" -n 100
 done
 ```
 
-## `--wait` exit codes
+## Waiting
 
-- `0` agent reached idle
-- `2` session died
+`gmux wait <id>` (no flags) blocks until an **agent** session goes idle (turn
+finished) or the session exits. Exit codes:
+
+- `0` agent reached idle (or session exited)
+- `2` session died before going idle
 - `3` `--timeout` elapsed
 
-`--wait` only works for agent sessions (`claude`, `codex`, `pi`). For shell commands use the blocking piped flow: `gmux make build < /dev/null`.
+Plain **shell** commands don't emit an idle signal, so for those either run
+blocking (`gmux -- make build`) or wait for expected output:
+
+```bash
+gmux wait $id --for-text '__DONE__' --timeout 120   # fixed substring
+gmux wait $id --for-regex '^\$ $' --timeout 30       # or a regex
+```
+
+`--for-text` / `--for-regex` replace the old "poll `tail` in an `until grep`
+loop" pattern — gmux does the polling and prints the tail to stderr on timeout.
 
 ## Other agents have one-shot modes
 
-Agents stay running by default. To make them exit after one prompt, use the agent's print mode: `pi -p`, `claude -p`, `codex exec`. Pair with the piped flow for fire-and-forget:
+Agents stay running by default. To make them exit after one prompt, use the
+agent's print mode: `pi -p`, `claude -p`, `codex exec`:
 
 ```bash
-gmux pi -p "summarize this PR" < /dev/null
+gmux -- pi -p "summarize this PR"
 ```
 
-## Sending control characters
+## Sessions on other machines
+
+Sessions are **local by default** — bare IDs only ever match this host, so you
+can't accidentally act on another machine. To address a peer session
+explicitly, suffix the ID with `@<peer>` (see them with `gmux ls --all`):
 
 ```bash
-printf '\x03' | gmux --send --no-submit $id   # Ctrl-C without an extra Enter
+gmux tail abc123@laptop
 ```
 
 ## Reference

--- a/skills/gmux/SKILL.md
+++ b/skills/gmux/SKILL.md
@@ -79,23 +79,18 @@ done
 
 ## Waiting
 
-`gmux wait <id>` (no flags) blocks until an **agent** session goes idle (turn
-finished) or the session exits. Exit codes:
+`gmux wait <id>` blocks until an **agent** session goes idle (turn finished) or
+the session exits, optionally bounded by `--timeout N`. Exit codes:
 
 - `0` agent reached idle (or session exited)
 - `2` session died before going idle
 - `3` `--timeout` elapsed
 
-Plain **shell** commands don't emit an idle signal, so for those either run
-blocking (`gmux -- make build`) or wait for expected output:
-
-```bash
-gmux wait $id --for-text '__DONE__' --timeout 120   # fixed substring
-gmux wait $id --for-regex '^\$ $' --timeout 30       # or a regex
-```
-
-`--for-text` / `--for-regex` replace the old "poll `tail` in an `until grep`
-loop" pattern — gmux does the polling and prints the tail to stderr on timeout.
+Plain **shell** commands don't emit an idle signal and are rejected, so run
+those blocking instead: `gmux -- make build < /dev/null` exits with the
+command's own status. (Waiting on arbitrary output — "until this text
+appears" — is planned as a server-side condition; until then, poll `gmux tail`
+yourself if you must.)
 
 ## Other agents have one-shot modes
 


### PR DESCRIPTION
Reworks the gmux CLI from flag-based actions to a verb-first grammar, per **ADR 0009** (included). Breaking change for 2.0.

## Highlights
- **Verbs** replace action flags: `open`, `ls`, `attach`, `tail`, `send`, `send-keys`, `wait`, `kill`, `daemon`, `auth`, `remote`.
- **Explicit run:** `gmux -- <cmd>` (`-d` detaches). No bare-command shorthand — power users `alias gm='gmux --'`. Frees the top-level namespace to grow safely.
- **send:** literal text + trailing key tokens (`gmux send <id> 'pytest -q' Enter`, `gmux send <id> C-c`); explicit Enter (drops `--no-submit`). Piped stdin composes with trailing keys. New tmux-compatible `send-keys -t`.
- **wait:** `--for-text` / `--for-regex` with `--timeout` (prints tail on timeout), replacing the hand-rolled grep loop; idle stays server-side. (Server-side move tracked in #313.)
- **tail:** `-n` (default 100), `--raw`/`-e` to keep ANSI (stripped by default).
- **ls:** `--json` for agents; `--all` for peers; `--host` dropped.
- **Local-by-default** addressing is a hard invariant — bare refs never cross hosts; `<id>@<peer>` is the only opt-in. The `host` parameter is removed from session resolution entirely (no dead plumbing).
- **Migration:** error-only shim maps every removed flag / `gmuxd <verb>` / bare command to its new form. Unknown bare words always show the `gmux -- <cmd>` run form, with a verb "did you mean?" only as a secondary hint (so `gmux sed ...` isn't misdirected).
- **Daemon:** `gmux daemon …` is the canonical front; `gmuxd` keeps its verbs for backwards-compatible ops (systemd/Docker). Internal daemon→runner contract moved to `gmux __run … -- <cmd>` / `gmux __dump-env`.

## Docs
- ADR 0009 (new); stale-syntax banners on ADRs 0004/0005/0006 (decisions stand).
- gmux skill rewritten for 2.0.
- Website docs (`reference/cli.md`, integrations guide, changelog 2.0 entry) intentionally **not** in this PR — follow-up.

## Tests
Both modules build and pass fully. New focused tests for logic with real correctness stakes (not coverage padding): `keyBytes`/`renderKeys` (C-c → 0x03, literal vs key), `stripANSI` (CSI/OSC/CRLF/UTF-8/lone-ESC), `buildSendBody` composition incl. the stdin+keys regression, `reexecRunArgs` round-trip (guards the detached re-exec), the migration shim, and the dual-hint rule. Verified end-to-end against a live daemon (detached run, exit-code propagation, `send C-c` interrupt, `wait --for-text`, `ls --json`).

## Notable behavior changes (call out in release notes)
- Running a command now requires `--` (`gmux -- pytest`); bare `gmux pytest` errors with guidance.
- `send` no longer auto-submits; add a trailing `Enter`.
- `gmuxd <verb>` still works but `gmux daemon <verb>` is canonical.