### PR TITLE
docs: relational storage is a non-goal (ADR 0012) + post-#315 cleanup

### DIFF
--- a/UBIQUITOUS_LANGUAGE.md
+++ b/UBIQUITOUS_LANGUAGE.md
@@ -5,7 +5,8 @@
 | Term                | Definition                                                                                                | Aliases to avoid          |
 | ------------------- | --------------------------------------------------------------------------------------------------------- | ------------------------- |
 | **Session**         | The user-facing unit of work in a directory: a terminal pane plus everything we know about it             | Pane, terminal, tab       |
-| **Slug**            | A session's stable, human-readable identity; persistent across runner restarts and resume                 | Name                      |
+| **Conversation**    | An agent's own thread of dialogue (pi/claude/codex's "session"), identified by its on-disk file path. The path (= **Tool ID**) is immutable; the conversation's display name (slug) is mutable. A tool-backed **Session** corresponds to a Conversation; a **Runner** binds to one and may rebind (`/resume`) to another | Agent session, thread     |
+| **Slug**            | A session's mutable, human-readable display name; persistent across runner restarts and resume, but renamable. Not identity (the immutable Tool ID is) | Name                      |
 | **Session ID**      | A specific runner instance's identifier; ephemeral for shell, stable (= tool ID) for pi/claude            | Identifier (alone is too generic) |
 | **Key**             | The single string projects.json uses per session: slug if attributed, session ID otherwise                |                           |
 | **Tool ID**         | An adapter-managed file identifier (e.g. JSONL filename) used as session ID for tool-backed sessions      |                           |
@@ -46,7 +47,7 @@
 
 | Term                     | Definition                                                                                                   | Aliases to avoid              |
 | ------------------------ | ------------------------------------------------------------------------------------------------------------ | ----------------------------- |
-| **Store**                | The daemon's in-memory `store.Store`: the live, authoritative session table                                  | Session table                 |
+| **Store**                | The daemon's in-memory `store.Store`: a **read cache** of live session state, fed by runner `/events` (ADR 0011). The runner owns live state; the store no longer parses files or writes session content                                  | Session table                 |
 | **Sessionmeta**          | Per-session runtime persistence: `<state>/sessions/<id>/meta.json`. SOT for **runtime state** of dead sessions | Session metadata, meta files |
 | **Scrollback**           | Per-session persisted PTY byte stream: `<state>/sessions/<id>/scrollback{,.0}`. SOT for terminal history     | History, log                  |
 | **Projects.json**        | The on-disk SOT for **sidebar membership and ordering** (project rules + ordered key lists)                  | Project state, projects file  |
@@ -59,7 +60,7 @@ The four stores have orthogonal concerns. Mixing them is a smell:
 
 | Store                  | Owns                                                              | Keyed by                          |
 | ---------------------- | ----------------------------------------------------------------- | --------------------------------- |
-| **Store**              | Live runtime state of every session the hub knows about           | Session ID                        |
+| **Store**              | Caches live runtime state (the runner owns it; ADR 0011)          | Session ID                        |
 | **Sessionmeta**        | Persisted runtime state (exit code, status, title, timestamps)    | Session ID                        |
 | **Projects.json**      | Which sessions appear in the sidebar, in what project, what order | Project slug → list of **Key**s   |
 | **Conversations Index**| Cross-reference between IDs and slugs for adapter-backed sessions | (kind, ID) and (kind, slug)       |
@@ -75,7 +76,7 @@ The four stores have orthogonal concerns. Mixing them is a smell:
 | **Restart**           | Like Resume but kills the live runner first; goes through Resume after exit                                            |                                |
 | **Slug-takeover**     | A fresh live session evicting a dead one with the same `(kind, peer, slug)` from the store                              | Slug eviction                  |
 | **Dismiss**           | Explicit user removal: runner killed if alive, store entry removed, sessionmeta + scrollback dropped                    | Delete, close                  |
-| **Sweep**             | Daemon startup operation: read every `meta.json` and Upsert as `Alive=false`; sessions appear in the sidebar only if `projects.json` still contains their key | Restore                        |
+| **Sweep**             | Daemon startup operation: read every `meta.json` and Upsert as `Alive=false`, so previously-seen dead sessions reappear. Whether each then renders depends on project membership and match rules — `State.Discovered()` also surfaces unfiled sessions, so visibility is not strictly gated by `projects.json` | Restore                        |
 | **Attribution**       | Binding a tool-backed session to its adapter session file. **Primary:** authoritative, reported by the **Agent-hook** (pi names the held file directly, including cache-served `/resume` rebinds). **Fallback:** metadata matching (cwd + start time) for agents with no hook (codex). See ADR 0011 | Naming                         |
 
 ## Relationships

--- a/docs/adr/0011-runner-owned-session-state.md
+++ b/docs/adr/0011-runner-owned-session-state.md
@@ -95,7 +95,7 @@ and the **daemon is a read cache plus a raw file-event source**.
    updates its own file," eliminating the clear-other-files logic in
    `AttributeFromHook`.
 
-This realises ADR 0009's "identity is adapter-owned; shells aren't special":
+This realises the principle that identity is adapter-owned and shells aren't special:
 once the adapter owns state and identity in the runner, the daemon stops
 making per-adapter decisions entirely.
 

--- a/docs/adr/0012-defer-relational-storage-migration.md
+++ b/docs/adr/0012-defer-relational-storage-migration.md
@@ -1,0 +1,125 @@
+# ADR 0012: Relational (SQLite) storage is a non-goal
+
+**Status:** Accepted
+**Date:** 2026-06-16
+**Related:** ADR 0002 (project ownership; share-nothing peering), ADR 0010 /
+ADR 0011 (authoritative attribution + runner-owned state)
+
+## Context
+
+An earlier exploration ("attribution is the foundation"; the sidebar is
+conversation-keyed) parked a larger idea: move dead-session snapshots and
+project **membership** out of the JSON files into an embedded relational
+store (SQLite), keyed by a stable identity, so that membership integrity,
+atomic updates, and retention-by-query come for free. The motivating bugs
+were: sessions disappearing on relaunch, dismissed sessions reappearing,
+and renamed sessions sorting to the bottom.
+
+That exploration deferred the decision until attribution was solid.
+Attribution is now solid (ADR 0010 → 0011): the agent-hook makes
+attribution authoritative and **runner-owned**, the daemon `store.Store`
+is a single-writer **read cache**, and `attributions.json` was retired.
+This ADR records the resulting decision on the storage migration itself.
+
+### What persists after ADR 0011
+
+| File | Holds | |
+| --- | --- | --- |
+| `meta.json` (sessionmeta) | dead-session snapshots, dir-per-id | live |
+| `projects.json` | project definitions **+ membership** (Key arrays) | live, versioned (v3) |
+| `peers.json` | peering config | live |
+| ~~`attributions.json`~~ | — | retired by #315 |
+| live session state | — | no longer persisted (runner-owned, re-announced) |
+
+The single-writer read-cache model already dissolved the "two writers /
+drift between stores" problem that was half the original case for a
+relational store. The remaining `SessionKey` (slug-or-id) membership and
+the startup `CleanupSessions` are unchanged, but #315's instant,
+authoritative attribution removed the *timing* that triggered the
+reorder-to-bottom race for hooked agents.
+
+## Decision
+
+**Do not migrate to a relational store.** Relational storage is a
+non-goal for v2.0 and the foreseeable future; do not block the v2.0
+breaking window on it. Revisit only if a genuinely relational feature
+appears (see "No warranted trigger identified" below).
+
+### Rationale
+
+1. **The motivating bugs are already fixed** by ADR 0010/0011
+   (authoritative attribution) — not by storage. A migration now would
+   buy structural tidiness, not bug fixes.
+2. **The migration is not actually gated by the v2.0 breaking window.**
+   Persisted state is purely local: peering is share-nothing (ADR 0002),
+   so a storage change has **zero wire/peer-protocol impact**. On-disk
+   format changes are already routine via the `projects.json` versioned
+   migration framework, and an importer makes "migrate later" as cheap as
+   "migrate now." Keeping `projects.json` for definitions and scrollback
+   as files means nothing user-facing breaks either. There is no
+   second-breaking-window penalty for waiting.
+3. **The cost is real:** a net-new pure-Go SQLite dependency (cgo is out —
+   gmux cross-compiles), rewriting the membership half of `projects`
+   (~756 LOC) and `sessionmeta` (~271 LOC) plus their tests (~2000 LOC), a
+   new schema + migration framework, a one-time importer, and full
+   re-validation of core sidebar-persistence/retention/rehydrate state
+   (bugs here mean lost or misplaced sessions).
+
+### No warranted trigger identified
+
+There is no concrete feature on the horizon that justifies a relational
+store. Relational storage stays a **non-goal** unless a genuinely
+relational feature materializes (e.g. cross-entity history/analytics that
+needs joins and ranking over primary state). The bar to revisit is high
+and specific; "it would be tidier" does not clear it.
+
+**Fulltext search is explicitly *not* such a trigger.** A search index is
+*derived*, not authoritative — the conversation transcripts are the SOT
+on disk, so any index is rebuildable at will. That removes the only thing
+a relational store offers over the rest of this design (durability and
+integrity of *primary* state): a derived index needs no schema,
+migration, importer, or drift reconciliation. Search is also one user's
+history queried interactively (low QPS), which fits an **in-memory**
+inverted index — an extension of the existing in-memory conversations
+index, not a new substrate. If startup re-index cost or RAM ever strains
+at large corpora, the in-memory-first answers are a serialized index
+cache (persist the index, not the data; rebuild opportunistically) and
+bounding what is indexed (recent-N / retention-aligned) — both far
+lighter than adopting SQLite.
+
+### Cleanup-hardening finding
+
+The earlier exploration floated "harden `CleanupSessions` to resolve keys
+against persisted meta, not just the live store." On inspection this was
+already effectively true — `CleanupSessions` runs **once** at startup,
+after `Sweep` has loaded dead sessions into the store, so a key is pruned
+only when neither live nor persisted. No behavioural change is warranted.
+The only change made is a small **ordering-robustness refactor**: `known`
+is now built explicitly as `persisted-on-disk ∪ live store` (captured from
+the sweep result) rather than relying on the incidental fact that swept
+dead sessions are still in the store at cleanup time. See
+`services/gmuxd/cmd/gmuxd/main.go` (`persistedKeys`).
+
+## Consequences
+
+- v2.0 ships on the current JSON stores (`projects.json` + `meta.json`),
+  which is sufficient now that attribution is authoritative.
+- Fulltext search, when built, is an in-memory derived index (optionally
+  with a serialized cache) — not a reason to adopt SQLite.
+- A relational store would remain importer-friendly and wire-neutral if a
+  qualifying relational feature ever appears, so nothing is foreclosed.
+- No new dependency, no core-state rewrite, no migration risk taken on for
+  gains that are currently cosmetic.
+
+## Alternatives considered
+
+- **Do the migration in v2.0 because "it's the breaking window."**
+  Rejected: the premise is false — it's an importer-friendly local change
+  with no wire impact, so there is no now-or-never pressure.
+- **Do it for the structural integrity benefits (FK membership, atomic
+  updates).** Real but cosmetic post-#315; not worth the rewrite/risk on
+  core state until a feature needs the queries.
+- **Adopt SQLite to back fulltext search.** Rejected: a search index is
+  derived and rebuildable from the on-disk transcripts, so it gains
+  nothing from relational durability/integrity; an in-memory inverted
+  index (with an optional serialized cache) serves it more simply.

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -456,11 +456,23 @@ func serve(stderr io.Writer) int {
 	// Resume merge / slug takeover drop the corresponding directory.
 	// See sessionmeta package doc for the full lifecycle.
 	metaStore := sessionmeta.New(sessionmeta.DefaultDir())
+	// persistedKeys records the id and slug of every session sessionmeta
+	// holds on disk at startup (the post-retention sweep survivors). The
+	// startup CleanupSessions unions this with the live store so a project
+	// membership key is pruned only when it is neither live nor persisted.
+	// Capturing it here rather than re-deriving it from the store at
+	// cleanup time keeps the guard correct regardless of whether the swept
+	// dead sessions are still populated in the store by then.
+	persistedKeys := make(map[string]bool)
 	if loaded, err := metaStore.Sweep(); err != nil {
 		log.Printf("sessionmeta: sweep failed: %v", err)
 	} else {
 		for _, sess := range loaded {
 			sessions.Upsert(sess)
+			persistedKeys[sess.ID] = true
+			if sess.Slug != "" {
+				persistedKeys[sess.Slug] = true
+			}
 		}
 		if n := len(loaded); n > 0 {
 			log.Printf("sessionmeta: restored %d session(s) from %s", n, metaStore.Dir())
@@ -691,10 +703,14 @@ func serve(stderr io.Writer) int {
 		reconcileProjectStamps(state)
 	}
 
-	// After store is populated, clean up orphaned project entries
-	// (slugs that no longer resolve to a store session).
+	// After the store is populated, clean up orphaned project entries
+	// (keys that resolve to neither a live session nor a persisted one).
+	// known = persisted-on-disk ∪ live store; see persistedKeys above.
 	scanner.OnFirstScan = func() {
-		known := make(map[string]bool)
+		known := make(map[string]bool, len(persistedKeys))
+		for k := range persistedKeys {
+			known[k] = true
+		}
 		for _, s := range sessions.List() {
 			known[s.ID] = true
 			if s.Slug != "" {


### PR DESCRIPTION
Follow-up cleanup after the attribution work (#315 / ADR 0010/0011). Docs + one small startup hardening; no behavioural change to attribution.

## ADR 0012 — relational (SQLite) storage is a non-goal
Records the decision not to migrate sessions/membership to a relational store:
- The bugs that motivated it (sessions disappearing on relaunch, dismissed sessions reappearing, renamed sessions sorting to the bottom) were attribution races, **already fixed** by authoritative attribution (ADR 0010/0011) — not storage.
- Not gated by the v2.0 breaking window: peering is share-nothing, so it has zero wire impact, and on-disk format is already versioned + importer-friendly. No now-or-never pressure.
- The one plausible trigger — **fulltext search** — is explicitly *not* a reason to adopt SQLite: a search index is *derived* and rebuildable from the on-disk transcripts, so it gains nothing from relational durability; it fits an in-memory inverted index instead.

## `CleanupSessions` ordering-robustness refactor
`CleanupSessions` runs once at startup after `Sweep` loads dead sessions into the store, so a project membership key is pruned only when neither live nor persisted. That protection was *incidental* — it relied on swept dead sessions still being in the store at cleanup time. Now `known` is built explicitly as `persisted-on-disk ∪ live store` (captured from the sweep result), so the guard survives any future reordering of startup steps. No user-visible change.

## UBIQUITOUS_LANGUAGE alignment with post-#315 model
- **Store** reframed from "live, authoritative session table" → **read cache fed by runner `/events`** (runner owns live state, per ADR 0011).
- Added **Conversation** as a first-class term (agent's own thread, immutable Tool ID, mutable slug); clarified **Slug** is a mutable display name, not identity.
- Dropped the inaccurate **Sweep** claim that sidebar visibility is gated by `projects.json` (`State.Discovered()` surfaces unfiled sessions regardless).
- Fixed a dangling `ADR 0009` citation in merged ADR 0011 (it resolved to the unrelated verb-first-CLI ADR) — reworded to state the adapter-owned-identity principle inline.

## Testing
- `go build ./...`, `go vet ./cmd/gmuxd/`, and `go test ./internal/projects/ ./internal/sessionmeta/` all green.