### PR TITLE
docs: document tool-neutral authoritative hook protocol + guard test

### DIFF
--- a/cli/gmux/internal/ptyserver/ptyserver.go
+++ b/cli/gmux/internal/ptyserver/ptyserver.go
@@ -259,10 +259,14 @@ func New(cfg Config) (*Server, error) {
 	cmd.Dir = cfg.Cwd
 	cmd.Env = buildChildEnv(os.Environ(), cfg.Env, cfg.Version)
 
-	// For adapters with a native extension API (pi), inject the gmux session
-	// extension. It reports the active session, title, and status
-	// authoritatively over the runner socket (POST /hook/event) on every bind
-	// and agent-loop transition (ADR 0011) — no fs inference, no scrollback.
+	// Inject the gmux session hook for adapters with a native extension API. It
+	// reports session/title/status authoritatively over POST /hook/event (ADR
+	// 0011; tool-neutral protocol in docs/runner-hook-protocol.md). pi is the
+	// first implementer.
+	//
+	// NOTE: extPath is always the embedded pi extension today. A future non-pi
+	// SessionExtender needs its own materialized hook; making extPath
+	// adapter-supplied is deferred (touches the adapter API).
 	if ext, ok := cfg.Adapter.(adapter.SessionExtender); ok {
 		if agentHookDisabled() {
 			log.Printf("ptyserver: GMUX_NO_AGENT_HOOK set; launching %s without the gmux hook (no hook-driven title/status/attribution)", cfg.Adapter.Name())
@@ -487,17 +491,20 @@ const maxInputBytes = 1 << 20 // 1 MiB
 // Access control is delegated to the Unix socket's file permissions
 // (owner-only, 0o700): anyone who can connect() to this socket already
 // owns the session and could do arbitrary worse things to it.
-// hookEvent is the payload the agent extension (pi-ext.mjs) posts to
-// POST /hook/event. The agent reports facts about itself; the runner maps
-// them to sidebar state:
+// hookEvent is the tool-neutral payload an agent's gmux hook posts to
+// POST /hook/event. Any agent can target this endpoint; the runner makes no
+// per-adapter assumptions. The agent reports facts about itself; the runner
+// maps them to sidebar state:
 //
 //	op "session"          — the bound conversation file, id, name (on bind)
 //	op "turn" phase start — the agent loop began (→ working)
 //	op "turn" phase end   — the loop ended with Outcome + title
 //
 // Outcome is a stable, agent-agnostic vocabulary ("completed" | "aborted" |
-// "error"); each agent's extension normalizes its own terminal state into it,
-// and the runner owns what each means for the sidebar (see applyTurnEnd).
+// "error"); each agent's hook normalizes its own terminal state into it, and
+// the runner owns what each means for the sidebar (see applyTurnEnd). The full
+// wire contract is documented in docs/runner-hook-protocol.md. pi's hook
+// (pi-ext.mjs) is the reference implementation.
 type hookEvent struct {
 	Op   string `json:"op"`
 	Path string `json:"path"`
@@ -511,10 +518,13 @@ type hookEvent struct {
 	Outcome string `json:"outcome,omitempty"` // "completed" | "aborted" | "error"
 }
 
-// handleHookEvent applies the authoritative session state the agent's
-// extension reports (pi-ext.mjs): the bound conversation file + title + slug
-// on every bind, and busy/idle/unread/error on every agent-loop transition.
-// There is no inference — the agent tells us exactly what it holds and does.
+// handleHookEvent applies the authoritative session state an agent's gmux hook
+// reports: the bound conversation file + title + slug on every bind, and
+// busy/idle/unread/error on every agent-loop transition. There is no
+// inference and no per-adapter branching — the agent tells us exactly what it
+// holds and does, and the runner relays those facts (ADR 0011). State written
+// here (SetSessionFile et al.) is a relay snapshot for /events replay, not
+// derived or sticky.
 func (s *Server) handleHookEvent(w http.ResponseWriter, r *http.Request) {
 	var ev hookEvent
 	if err := json.NewDecoder(io.LimitReader(r.Body, 512*1024)).Decode(&ev); err != nil {
@@ -523,7 +533,7 @@ func (s *Server) handleHookEvent(w http.ResponseWriter, r *http.Request) {
 	}
 	switch ev.Op {
 	case "session":
-		// Authoritative bind (pi's session_start): the file the
+		// Authoritative bind (e.g. pi's session_start): the file the
 		// agent holds, named and slugged.
 		if ev.Path != "" {
 			s.state.SetSessionFile(ev.Path)

--- a/docs/runner-hook-protocol.md
+++ b/docs/runner-hook-protocol.md
@@ -1,0 +1,87 @@
+# Runner hook protocol: tool-neutral authoritative session events
+
+**Status:** Stable · **Related:** ADR 0011, `cli/gmux/internal/ptyserver`
+
+The contract an agent implements to report its session state to the gmux runner
+authoritatively. Tool-neutral: the runner makes no per-adapter assumptions in
+`handleHookEvent`. pi's extension (`agentext/pi-ext.mjs`) is the reference; the
+protocol is not pi-specific.
+
+Per ADR 0011, live state is runner-owned. An agent reports its own facts (held
+file, turn phase) rather than the daemon inferring them from fs scans/scrollback
+— and a hook even catches a cache-served `/resume` that reads no file. The
+runner only **relays** these facts; the one bit of state it keeps is a snapshot
+replayed to `/events` (so a restarted daemon re-learns attribution), never used
+to guess.
+
+## Transport
+
+- Runner exports `GMUX_SESSION_SOCK` (its Unix socket) to the agent env.
+- Agent POSTs JSON to `POST /hook/event`, **fire-and-forget**: a failed POST
+  must never surface into the agent; the next event re-establishes truth.
+- Socket is owner-only (0o700).
+
+## Event schema
+
+One JSON object per event, discriminated by `op`. Unknown ops/values are ignored
+(forward-compatible); zero-value fields are no-ops.
+
+```jsonc
+// op "session" — authoritative bind. Sent on startup and on every rebind
+// (switch/new/resume/fork).
+{
+  "op":     "session",
+  "path":   "/abs/path/to/conversation-file",  // required
+  "id":     "session-id",                       // optional; slugified for the URL if no slug
+  "slug":   "human-title",                      // optional; explicit URL-safe slug, preferred over id
+  "name":   "human title",                      // optional; sets the adapter title
+  "cwd":    "/project/dir",                      // optional; accepted, not yet applied
+  "reason": "startup|new|resume|fork|activity"  // optional; informational
+}
+
+// op "turn" — agent loop boundary.
+{ "op": "turn", "phase": "start" }                            // → working
+{ "op": "turn", "phase": "end", "outcome": "completed",       // see vocabulary
+  "title": "human title" }                                    // optional
+```
+
+### Field reference
+
+| Field     | Op       | Meaning |
+|-----------|----------|---------|
+| `path`    | session  | Absolute path of the held conversation file. |
+| `id`      | session  | Session identity; slugified into the URL when no `slug`. |
+| `slug`    | session  | Explicit URL-safe slug; preferred over `id` (e.g. codex's UUID slugifies badly). |
+| `name`    | session  | Display title at bind time. |
+| `cwd`     | session  | Project dir. Accepted for forward-compat but not applied — the runner knows the launch cwd. |
+| `reason`  | session  | Why the bind happened; informational. |
+| `phase`   | turn     | `"start"` or `"end"`. |
+| `outcome` | turn end | Normalized terminal state — see below. |
+| `title`   | turn end | Display title at turn end. |
+
+### Outcome vocabulary
+
+Stable and agent-agnostic; each hook normalizes its native state into one. The
+outcome→sidebar mapping is gmux policy in the runner (`applyTurnEnd`), not the
+agent's concern.
+
+| Outcome     | Meaning                          | Sidebar              |
+|-------------|----------------------------------|----------------------|
+| `completed` | Agent finished its own turn.     | idle + **unread**    |
+| `aborted`   | User interrupted (Esc).          | idle                 |
+| `error`     | Agent gave up.                   | idle + **error**     |
+
+## The runner does NOT, for hooked sessions
+
+Parse the conversation file, infer status from PTY/scrollback, apply per-adapter
+heuristics in `handleHookEvent`, or use the `session_file` snapshot for anything
+but `/events` replay.
+
+## Implementing for a new agent
+
+1. **Load the hook** via the injection seam matching how the agent loads
+   extensions — `adapter.SessionExtender.ExtendCommand` splices a loader flag
+   into the argv (pi: `-e <path>`). Both seams are ephemeral and scoped to the
+   gmux-launched process; the injected hook no-ops without `GMUX_SESSION_SOCK`.
+2. Report a `session` event on every bind.
+3. Report `turn` start/end, normalizing to the outcome vocabulary.


### PR DESCRIPTION
## What

Makes the runner's authoritative hook-event channel an explicitly **tool-neutral, stateless** capability with a documented contract, per ADR 0011.

After reading the current code, the event protocol (`POST /hook/event` → `hookEvent` → `handleHookEvent` → `applyTurnEnd`, plus `/events` replay) is **already** tool-neutral and stateless: no per-adapter branching, no inference, no caching beyond the replay snapshot. The vocabulary (`op` session/turn, `outcome` completed/aborted/error) is agent-agnostic. So this PR makes that implicit property explicit rather than manufacturing churn.

## Changes

- **`docs/runner-hook-protocol.md`** — formal wire contract any agent can target: transport (`GMUX_SESSION_SOCK`), the session/turn event schema, the agent-agnostic outcome vocabulary, and what the runner explicitly does *not* do (no parsing/inference/per-adapter heuristics).
- **Tool-neutral comments** in `ptyserver.go`: reframed from "pi-ext.mjs is the source" to "any agent hook; pi is the reference implementation".
- **`TestHookEventIsToolNeutral`** — guard test proving the handler drives state identically with a non-`SessionExtender` adapter (codex) attached, so pi-specific assumptions can't creep into the handler.
- **Tracking note** for the one genuine coupling: `agentext.Path()` materializes only `pi-ext.mjs` and the runner injects it for *any* `SessionExtender`. The wire protocol is neutral, but this *injection* step isn't yet. Fixing it (adapter-supplied extension path) touches the adapter API + codex and is deferred — out of scope here.

## Not in scope

- No codex adapter changes.
- No changes to the daemon's `filemon.go` fallback engine or the `filemon-simplify` branch.

## Behavior

No behavior change for pi. `go build ./... && go test ./...` green in both `cli/gmux` and `services/gmuxd`.