### PR TITLE
feat(codex): authoritative session state via codex hooks

### DIFF
--- a/cli/gmux/cmd/gmux/cli.go
+++ b/cli/gmux/cmd/gmux/cli.go
@@ -27,6 +27,7 @@ const (
 	modeAuth                 // gmux auth
 	modeRemote               // gmux remote
 	modeDumpEnv              // (internal) gmux __dump-env
+	modeCodexHook            // (internal) gmux __codex-hook <Event>
 )
 
 // command is the fully-parsed CLI invocation. One struct for every
@@ -66,6 +67,9 @@ type command struct {
 
 	// daemon
 	daemonSub string // start|stop|restart|status|log-path
+
+	// codex hook (internal __codex-hook)
+	codexHookEvent string // the codex hook event name (SessionStart, ...)
 }
 
 // reservedVerbs is the closed top-level namespace (ADR 0009). Growth
@@ -172,6 +176,11 @@ func parseCLI(args []string) (*command, error) {
 		return parseInternalRun(rest)
 	case "__dump-env":
 		return &command{mode: modeDumpEnv}, nil
+	case "__codex-hook":
+		if len(rest) != 1 {
+			return nil, errors.New("__codex-hook requires exactly one event name")
+		}
+		return &command{mode: modeCodexHook, codexHookEvent: rest[0]}, nil
 	}
 
 	// Error-only migration shim (ADR 0009): recognize removed forms and

--- a/cli/gmux/cmd/gmux/cli.go
+++ b/cli/gmux/cmd/gmux/cli.go
@@ -12,22 +12,22 @@ import (
 type mode int
 
 const (
-	modeHelp     mode = iota // print usage and exit
-	modeVersion              // print version and exit
-	modeOpen                 // open the web UI
-	modeRun                  // run a command in a new session (gmux -- <cmd>)
-	modeList                 // gmux ls
-	modeAttach               // gmux attach <id>
-	modeTail                 // gmux tail <id>
-	modeKill                 // gmux kill <id>
-	modeSend                 // gmux send <id> <text> [keys...]
-	modeSendKeys             // gmux send-keys -t <id> ... (tmux-compat)
-	modeWait                 // gmux wait <id>
-	modeDaemon               // gmux daemon <start|stop|restart|status|log-path>
-	modeAuth                 // gmux auth
-	modeRemote               // gmux remote
-	modeDumpEnv              // (internal) gmux __dump-env
-	modeCodexHook            // (internal) gmux __codex-hook <Event>
+	modeHelp      mode = iota // print usage and exit
+	modeVersion               // print version and exit
+	modeOpen                  // open the web UI
+	modeRun                   // run a command in a new session (gmux -- <cmd>)
+	modeList                  // gmux ls
+	modeAttach                // gmux attach <id>
+	modeTail                  // gmux tail <id>
+	modeKill                  // gmux kill <id>
+	modeSend                  // gmux send <id> <text> [keys...]
+	modeSendKeys              // gmux send-keys -t <id> ... (tmux-compat)
+	modeWait                  // gmux wait <id>
+	modeDaemon                // gmux daemon <start|stop|restart|status|log-path>
+	modeAuth                  // gmux auth
+	modeRemote                // gmux remote
+	modeDumpEnv               // (internal) gmux __dump-env
+	modeCodexHook             // (internal) gmux __codex-hook <Event>
 )
 
 // command is the fully-parsed CLI invocation. One struct for every

--- a/cli/gmux/cmd/gmux/codexhook.go
+++ b/cli/gmux/cmd/gmux/codexhook.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/gmuxapp/gmux/packages/adapter/adapters"
+)
+
+// codexHook implements the hidden `gmux __codex-hook <Event>` subcommand that
+// codex invokes as a command hook (injected per-launch by the codex adapter
+// via `-c hooks.<Event>=...` config overrides). codex writes the event payload
+// as JSON to this
+// process's stdin; we translate it to the tool-neutral /hook/event protocol
+// (docs/runner-hook-protocol.md) and POST it to the runner socket named by
+// GMUX_SESSION_SOCK.
+//
+// It is fire-and-forget and must never break codex: it always exits 0 and
+// always prints "{}" on stdout (the minimal valid JSON the codex Stop hook
+// requires). When GMUX_SESSION_SOCK is unset the codex run was not launched by
+// gmux, so the hook is a no-op — this is why the globally-installed hook is
+// safe for plain `codex` invocations outside gmux.
+func codexHook(eventName string) int {
+	// Always read stdin (codex pipes the event JSON in and may block on the
+	// write if we don't drain it), bounded so a pathological payload can't
+	// exhaust memory.
+	input, _ := io.ReadAll(io.LimitReader(os.Stdin, 1<<20))
+
+	if sock := os.Getenv("GMUX_SESSION_SOCK"); sock != "" {
+		for _, body := range adapters.CodexHookBodies(eventName, input) {
+			postCodexHookEvent(sock, body)
+		}
+	}
+
+	fmt.Println("{}")
+	return 0
+}
+
+// postCodexHookEvent POSTs one event body to the runner's /hook/event over the
+// Unix socket. Best-effort with a short timeout; transport errors are swallowed
+// so the hook never surfaces a failure into codex.
+func postCodexHookEvent(sockPath string, body []byte) {
+	client := &http.Client{
+		Timeout: 2 * time.Second,
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				return net.Dial("unix", sockPath)
+			},
+		},
+	}
+	resp, err := client.Post("http://unix/hook/event", "application/json", bytes.NewReader(body))
+	if err != nil {
+		return
+	}
+	resp.Body.Close()
+}

--- a/cli/gmux/cmd/gmux/codexhook.go
+++ b/cli/gmux/cmd/gmux/codexhook.go
@@ -27,19 +27,27 @@ import (
 // gmux, so the hook is a no-op — this is why the globally-installed hook is
 // safe for plain `codex` invocations outside gmux.
 func codexHook(eventName string) int {
-	// Always read stdin (codex pipes the event JSON in and may block on the
-	// write if we don't drain it), bounded so a pathological payload can't
-	// exhaust memory.
-	input, _ := io.ReadAll(io.LimitReader(os.Stdin, 1<<20))
+	runCodexHook(eventName, os.Stdin, os.Stdout, os.Getenv("GMUX_SESSION_SOCK"))
+	return 0
+}
 
-	if sock := os.Getenv("GMUX_SESSION_SOCK"); sock != "" {
+// runCodexHook is the testable core of the subcommand. sock is the runner
+// socket (GMUX_SESSION_SOCK); when empty the codex run was not launched by gmux
+// and the hook is a pure no-op apart from emitting the obligatory "{}" — this is
+// what keeps the per-launch-injected hook inert for plain `codex` invocations.
+func runCodexHook(eventName string, in io.Reader, out io.Writer, sock string) {
+	// Always drain stdin (codex pipes the event JSON in and can block on the
+	// write if we don't read it), bounded so a pathological payload can't
+	// exhaust memory.
+	input, _ := io.ReadAll(io.LimitReader(in, 1<<20))
+
+	if sock != "" {
 		for _, body := range adapters.CodexHookBodies(eventName, input) {
 			postCodexHookEvent(sock, body)
 		}
 	}
 
-	fmt.Println("{}")
-	return 0
+	fmt.Fprintln(out, "{}")
 }
 
 // postCodexHookEvent POSTs one event body to the runner's /hook/event over the

--- a/cli/gmux/cmd/gmux/codexhook_test.go
+++ b/cli/gmux/cmd/gmux/codexhook_test.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"bytes"
 	"io"
 	"net"
 	"net/http"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -64,6 +66,78 @@ func TestPostCodexHookEvent(t *testing.T) {
 		select {
 		case <-deadline:
 			t.Fatalf("runner did not receive event; path=%q body=%q", p, body)
+		case <-time.After(20 * time.Millisecond):
+		}
+	}
+}
+
+// codexHookSink starts a unix-socket HTTP server that records the bodies POSTed
+// to /hook/event, and returns its socket path plus an accessor for the bodies.
+func codexHookSink(t *testing.T) (sockPath string, bodies func() []string) {
+	t.Helper()
+	sockPath = filepath.Join(t.TempDir(), "runner.sock")
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var mu sync.Mutex
+	var got []string
+	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		got = append(got, r.URL.Path+" "+string(b))
+		mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	})}
+	go srv.Serve(ln)
+	t.Cleanup(func() { srv.Close(); ln.Close() })
+	return sockPath, func() []string {
+		mu.Lock()
+		defer mu.Unlock()
+		return append([]string(nil), got...)
+	}
+}
+
+// TestRunCodexHookInertWithoutSocket pins the security-relevant property: with
+// no GMUX_SESSION_SOCK (a plain `codex` run, not launched by gmux) the injected
+// hook posts nothing and still emits the obligatory "{}" so codex is unaffected.
+func TestRunCodexHookInertWithoutSocket(t *testing.T) {
+	sock, bodies := codexHookSink(t)
+	var out bytes.Buffer
+	in := strings.NewReader(`{"hook_event_name":"UserPromptSubmit","session_id":"x"}`)
+
+	runCodexHook("UserPromptSubmit", in, &out, "") // empty sock
+
+	if strings.TrimSpace(out.String()) != "{}" {
+		t.Errorf("stdout = %q, want \"{}\"", out.String())
+	}
+	// Give any (erroneous) post a moment to land, then assert none did.
+	time.Sleep(50 * time.Millisecond)
+	if n := len(bodies()); n != 0 {
+		t.Errorf("posted %d events with no socket; want 0 (sink %s)", n, sock)
+	}
+}
+
+// TestRunCodexHookPostsTurnStart drives the happy path: a UserPromptSubmit with
+// a live socket posts exactly the turn-start event and emits "{}".
+func TestRunCodexHookPostsTurnStart(t *testing.T) {
+	sock, bodies := codexHookSink(t)
+	var out bytes.Buffer
+
+	runCodexHook("UserPromptSubmit", strings.NewReader("{}"), &out, sock)
+
+	if strings.TrimSpace(out.String()) != "{}" {
+		t.Errorf("stdout = %q, want \"{}\"", out.String())
+	}
+	deadline := time.After(2 * time.Second)
+	for {
+		b := bodies()
+		if len(b) == 1 && b[0] == `/hook/event {"op":"turn","phase":"start"}` {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("did not receive turn-start; got %v", b)
 		case <-time.After(20 * time.Millisecond):
 		}
 	}

--- a/cli/gmux/cmd/gmux/codexhook_test.go
+++ b/cli/gmux/cmd/gmux/codexhook_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"io"
+	"net"
+	"net/http"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestParseCodexHookCLI(t *testing.T) {
+	cmd, err := parseCLI([]string{"__codex-hook", "SessionStart"})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cmd.mode != modeCodexHook || cmd.codexHookEvent != "SessionStart" {
+		t.Errorf("got mode=%v event=%q", cmd.mode, cmd.codexHookEvent)
+	}
+
+	if _, err := parseCLI([]string{"__codex-hook"}); err == nil {
+		t.Error("expected error for missing event name")
+	}
+	if _, err := parseCLI([]string{"__codex-hook", "a", "b"}); err == nil {
+		t.Error("expected error for too many args")
+	}
+}
+
+func TestPostCodexHookEvent(t *testing.T) {
+	dir := t.TempDir()
+	sockPath := filepath.Join(dir, "runner.sock")
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	var (
+		mu   sync.Mutex
+		got  []byte
+		path string
+	)
+	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		path = r.URL.Path
+		got, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusNoContent)
+	})}
+	go srv.Serve(ln)
+	defer srv.Close()
+
+	postCodexHookEvent(sockPath, []byte(`{"op":"turn","phase":"start"}`))
+
+	deadline := time.After(2 * time.Second)
+	for {
+		mu.Lock()
+		body, p := string(got), path
+		mu.Unlock()
+		if body == `{"op":"turn","phase":"start"}` && p == "/hook/event" {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("runner did not receive event; path=%q body=%q", p, body)
+		case <-time.After(20 * time.Millisecond):
+		}
+	}
+}
+
+// TestPostCodexHookEventNoListener proves the post is best-effort: a dead
+// socket path must not panic or hang (the hook never breaks codex).
+func TestPostCodexHookEventNoListener(t *testing.T) {
+	done := make(chan struct{})
+	go func() {
+		postCodexHookEvent(filepath.Join(t.TempDir(), "absent.sock"), []byte(`{}`))
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("postCodexHookEvent hung on a dead socket")
+	}
+}

--- a/cli/gmux/cmd/gmux/main.go
+++ b/cli/gmux/cmd/gmux/main.go
@@ -60,6 +60,8 @@ func main() {
 		os.Exit(execGmuxd("remote"))
 	case modeDumpEnv:
 		os.Exit(dumpEnv())
+	case modeCodexHook:
+		os.Exit(codexHook(cmd.codexHookEvent))
 	}
 }
 

--- a/cli/gmux/internal/ptyserver/extension_test.go
+++ b/cli/gmux/internal/ptyserver/extension_test.go
@@ -227,6 +227,51 @@ func TestTurnEventDrivesState(t *testing.T) {
 	}
 }
 
+// TestSessionSlugPrefersExplicitSlug pins, through the real /hook/event
+// handler, that an explicit slug in a session event wins over Slugify(id) — the
+// codex path reports a title-derived slug because its session id is a UUID that
+// slugifies badly — while a session event with only an id still slugifies the
+// id (pi's behavior, unchanged).
+func TestSessionSlugPrefersExplicitSlug(t *testing.T) {
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("node not available")
+	}
+	check := func(name, body, wantSlug string) {
+		t.Helper()
+		dir := t.TempDir()
+		sockPath := filepath.Join(dir, "test.sock")
+		st := session.New(session.Config{ID: "s1", Kind: "codex", SocketPath: sockPath})
+		srv, err := New(Config{
+			Command:    []string{node, "-e", "setTimeout(()=>{},2000)"},
+			Cwd:        dir,
+			Listener:   mustBindSocket(t, sockPath),
+			SocketPath: sockPath,
+			Adapter:    adapters.NewCodex(),
+			State:      st,
+		})
+		if err != nil {
+			t.Fatalf("%s: new server: %v", name, err)
+		}
+		defer srv.Shutdown()
+		postSessionEvent(t, sockPath, body)
+		deadline := time.After(2 * time.Second)
+		for st.SlugSnapshot() != wantSlug {
+			select {
+			case <-deadline:
+				t.Fatalf("%s: slug = %q, want %q", name, st.SlugSnapshot(), wantSlug)
+			case <-time.After(20 * time.Millisecond):
+			}
+		}
+	}
+	check("explicit-slug",
+		`{"op":"session","path":"/x.jsonl","id":"019cfb54-dead-beef","slug":"fix the auth bug"}`,
+		"fix-the-auth-bug")
+	check("id-fallback",
+		`{"op":"session","path":"/y.jsonl","id":"my-chat"}`,
+		"my-chat")
+}
+
 // TestApplyTurnEnd pins the outcome→sidebar-state policy directly (no node).
 func TestApplyTurnEnd(t *testing.T) {
 	cases := []struct {

--- a/cli/gmux/internal/ptyserver/ptyserver.go
+++ b/cli/gmux/internal/ptyserver/ptyserver.go
@@ -259,20 +259,35 @@ func New(cfg Config) (*Server, error) {
 	cmd.Dir = cfg.Cwd
 	cmd.Env = buildChildEnv(os.Environ(), cfg.Env, cfg.Version)
 
-	// Inject the gmux session hook for adapters with a native extension API. It
-	// reports session/title/status authoritatively over POST /hook/event (ADR
-	// 0011; tool-neutral protocol in docs/runner-hook-protocol.md). pi is the
-	// first implementer.
-	//
-	// NOTE: extPath is always the embedded pi extension today. A future non-pi
-	// SessionExtender needs its own materialized hook; making extPath
-	// adapter-supplied is deferred (touches the adapter API).
-	if ext, ok := cfg.Adapter.(adapter.SessionExtender); ok {
-		if agentHookDisabled() {
+	// Inject the gmux session hook for adapters with a native extension/hook
+	// API: it reports session/title/status authoritatively over POST
+	// /hook/event (ADR 0011; tool-neutral protocol in
+	// docs/runner-hook-protocol.md). Two seams by how the agent loads hooks:
+	// SessionExtender splices a loader flag (pi: -e <materialized ext>);
+	// SessionHookCommand injects a command hook via the agent's config-override
+	// flags with the gmux binary as the hook program (codex: -c hooks.X=...).
+	// Both are ephemeral, scoped to this launch, and no-op without
+	// GMUX_SESSION_SOCK. GMUX_NO_AGENT_HOOK opts out.
+	if agentHookDisabled() {
+		_, isExt := cfg.Adapter.(adapter.SessionExtender)
+		_, isHC := cfg.Adapter.(adapter.SessionHookCommand)
+		if isExt || isHC {
 			log.Printf("ptyserver: GMUX_NO_AGENT_HOOK set; launching %s without the gmux hook (no hook-driven title/status/attribution)", cfg.Adapter.Name())
-		} else if extPath, err := agentext.Path(); err != nil {
-			log.Printf("ptyserver: agent extension unavailable: %v", err)
+		}
+	} else if ext, ok := cfg.Adapter.(adapter.SessionExtender); ok {
+		// Argv injection (pi): splice the gmux extension into the launch argv.
+		if extPath, err := agentext.Path(); err != nil {
 		} else if extended := ext.ExtendCommand(cmd.Args, extPath); len(extended) > len(cmd.Args) {
+			cmd.Args = extended
+			cmd.Env = append(cmd.Env, "GMUX_SESSION_SOCK="+cfg.SocketPath)
+		}
+	} else if hc, ok := cfg.Adapter.(adapter.SessionHookCommand); ok {
+		// Config injection (codex): inject a command hook on the launch argv via
+		// the agent's config-override flags. The hook program is the gmux binary
+		// itself (`gmux __codex-hook <Event>`), so the runner passes its own path.
+		if self, err := os.Executable(); err != nil {
+			log.Printf("ptyserver: cannot resolve gmux binary for %s hook: %v", cfg.Adapter.Name(), err)
+		} else if extended, ok := hc.HookCommand(cmd.Args, self); ok {
 			cmd.Args = extended
 			cmd.Env = append(cmd.Env, "GMUX_SESSION_SOCK="+cfg.SocketPath)
 		}
@@ -511,6 +526,7 @@ type hookEvent struct {
 	Pid  int    `json:"pid"`
 
 	ID      string `json:"id,omitempty"`
+	Slug    string `json:"slug,omitempty"` // explicit URL-safe slug; preferred over Slugify(ID)
 	Name    string `json:"name,omitempty"`
 	Reason  string `json:"reason,omitempty"`
 	Title   string `json:"title,omitempty"`
@@ -541,7 +557,12 @@ func (s *Server) handleHookEvent(w http.ResponseWriter, r *http.Request) {
 		if ev.Name != "" {
 			s.state.SetAdapterTitle(ev.Name)
 		}
-		if ev.ID != "" {
+		// Slug source, in order of preference: an explicit slug the agent
+		// reports (e.g. codex, whose session id is a UUID that slugifies badly,
+		// sends a title-derived slug), else the identity to slugify.
+		if ev.Slug != "" {
+			s.state.SetSlug(adapter.Slugify(ev.Slug))
+		} else if ev.ID != "" {
 			s.state.SetSlug(adapter.Slugify(ev.ID))
 		}
 	case "turn":

--- a/cli/gmux/internal/session/state.go
+++ b/cli/gmux/internal/session/state.go
@@ -230,6 +230,13 @@ func (s *State) SessionFileSnapshot() string {
 	return s.SessionFile
 }
 
+// SlugSnapshot returns the current URL-safe slug under lock.
+func (s *State) SlugSnapshot() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.Slug
+}
+
 // StatusSnapshot returns a copy of the current status (nil if unset), safe to
 // read from another goroutine while the runner concurrently updates state.
 func (s *State) StatusSnapshot() *adapter.Status {

--- a/docs/adr/0013-codex-authoritative-state-via-hooks.md
+++ b/docs/adr/0013-codex-authoritative-state-via-hooks.md
@@ -1,0 +1,137 @@
+# ADR 0013: codex reports session state authoritatively via codex hooks
+
+**Status:** Accepted
+**Date:** 2026-06-21
+**Related:** ADR 0011 (runner-owned session state), `docs/runner-hook-protocol.md`
+
+## Context
+
+ADR 0011 made live session state runner-owned and pushed by an **agent hook**:
+pi loads the gmux extension via `pi -e <ext>` and POSTs authoritative
+session/turn facts to the runner socket. It explicitly noted codex as the
+holdout — *"codex remains daemon-parsed via the file-watch fallback until it
+grows a comparable hook (its own Rust process can't load a node/bun
+extension)"* — leaving the daemon's metadata attribution + file-watch
+(`filemon.go`, `FileAttributor`) as the last per-adapter inference path.
+
+That premise no longer holds. **Codex has grown a first-class command-hook
+system** (`codex-rs/hooks`): 10 lifecycle events, each able to run an external
+**command** that receives the event as JSON on stdin. `SessionStart`,
+`UserPromptSubmit`, and `Stop` carry `session_id`, `transcript_path`, `cwd`, and
+`source` — everything needed to attribute the held conversation file and drive
+turn status, the same facts pi reports. (Verified against the codex source, and
+against two shipping integrations, cmux and ghostex, which use the same pattern.)
+
+## Decision
+
+Make codex authoritative via its hooks, reusing the tool-neutral `/hook/event`
+protocol unchanged. Concretely:
+
+1. **New injection seam: `adapter.SessionHookCommand`.** Unlike pi's argv splice
+   (`SessionExtender`), codex loads hooks from its **config**, not a loader
+   flag. But codex accepts hook definitions via per-invocation `-c` config
+   overrides (a `SessionFlags` config layer): `hooks` is a real `ConfigToml`
+   field, and `-c key=value` parses the value as a full TOML value (inline
+   arrays/tables allowed). So the runner injects, **per launch**, on the codex
+   argv:
+   `-c 'hooks.SessionStart=[{hooks=[{type="command",command="gmux __codex-hook SessionStart",timeout=5}]}]'`
+   (and likewise for UserPromptSubmit/Stop), plus the trust-bypass flag, and
+   sets `GMUX_SESSION_SOCK`. This is **ephemeral and scoped to the gmux-launched
+   process — it does not touch the user's `~/.codex`**, matching pi's `-e`.
+   (Earlier drafts installed a hook into `~/.codex/hooks.json`, as cmux/ghostex
+   do; the `-c` path is strictly less invasive and was chosen instead.)
+
+2. **The hook program is the gmux binary itself** (`gmux __codex-hook <Event>`,
+   a hidden subcommand). codex pipes its event JSON to stdin; gmux translates it
+   to `/hook/event` bodies and POSTs them to the runner socket. It is
+   fire-and-forget, always exits 0, and **no-ops unless `GMUX_SESSION_SOCK` is
+   set** — so the globally-installed hook is inert for plain `codex` runs
+   outside gmux.
+
+3. **Title/slug come from the transcript.** codex events carry no title, and its
+   `session_id` is a UUID that slugifies into an unreadable URL. The hook parses
+   the transcript's first user prompt (reusing `ParseSessionFile`) and reports a
+   human title plus an explicit title-derived **`slug`** — a small, tool-neutral
+   addition to the protocol (the runner prefers an explicit `slug` over
+   `Slugify(id)`; pi is unchanged).
+
+4. **Trust scoped to our own hooks via injected `trusted_hash`.** A CLI-injected
+   hook is non-managed and therefore `Untrusted`, which codex silently skips.
+   The blunt instrument, `--dangerously-bypass-hook-trust`, is a **process-global
+   flag**: codex applies it to every non-managed hook source (the user's own
+   hooks, installed plugins, and project `.codex/` hooks in already-trusted
+   directories), collapsing codex's per-hook trust layer for the whole
+   invocation. **Rejected.** Instead gmux injects, alongside the hook
+   definitions, a `-c hooks.state={...}` override carrying the exact per-hook
+   `trusted_hash` codex computes (`version_for_toml` = sha256 of the canonical,
+   sorted-key JSON of the normalized hook identity), keyed by codex's hook_key
+   (`/<session-flags>/config.toml:<event>:0:0`). codex reads hook trust state
+   from the SessionFlags layer, so **only gmux's own three benign reporting
+   hooks become Trusted; every other hook keeps codex's full trust gating.**
+   `GMUX_NO_AGENT_HOOK` disables the whole path.
+
+   This reproduces a codex *internal* (the hash + key formats), not a stable
+   contract, so it can drift across codex releases. The failure mode is safe by
+   construction: a mismatched hash/key leaves our hook `Untrusted` → skipped →
+   daemon attribution takes over. It degrades; it never broadens trust. A Go
+   test pins the canonical-JSON form so our side can't drift silently.
+
+   Note codex's *directory* trust is a separate, earlier gate: project `.codex/`
+   config layers are loaded-but-disabled in untrusted directories and never
+   reach hook discovery, so this scheme cannot cause a hook from an untrusted
+   repo to run regardless.
+
+5. **Version-gated, fallback retained.** The hook integration is gated on codex
+   **≥ 0.135.0** (hooks documented and stable; the hook config/trust shapes we
+   depend on are present). Below the floor — or if `codex --version` can't be
+   read — gmux launches codex unmodified and the daemon's existing metadata
+   attribution + `ParseNewLines` stay in charge. The `-c hooks…` overrides would
+   make an older codex reject the launch, so the gate is load-bearing, not
+   cosmetic. The codex adapter keeps `FileAttributor`/`FileMonitor` for exactly
+   this reason.
+
+## Consequences
+
+- On codex ≥ 0.135, attribution and status are push-based and exact, like pi:
+  the hook reports the held file even for a cache-served resume, and the daemon
+  suppresses its file parse for hook-attributed sessions (the existing
+  `AttributeFromHook` path, adapter-independent).
+- The daemon's metadata-attribution engine (`filemon.go` fallback,
+  `FileAttributor`) is **no longer codex's only path** — but it is still
+  required for older codex. It can be removed only once a hooks-capable codex is
+  the supported floor. This ADR records that as the explicit precondition for
+  the deferred `filemon-simplify` work; this PR does not touch it.
+- gmux does **not** write to the user's codex config. The hook exists only for
+  the duration of a gmux-launched codex process (injected via `-c`); plain
+  `codex` runs are completely unaffected, and there is nothing to clean up or
+  uninstall.
+- Caveat: a `-c hooks.SessionStart=…` override sits in the `SessionFlags` config
+  layer, which takes precedence over the user's `config.toml` inline
+  `[hooks].SessionStart`. Hooks the user defines in a separate `hooks.json` load
+  via a different discovery source and still run; only a user's *inline
+  config.toml* SessionStart/UserPromptSubmit/Stop hooks could be shadowed, and
+  only during gmux-launched codex. Merging the user's inline hooks into the
+  override is possible but reintroduces config reading; deferred as unnecessary.
+
+## Alternatives considered
+
+- **`--dangerously-bypass-hook-trust`.** Simple and robust to codex version
+  changes, but process-global: it un-gates the user's, plugins', and
+  already-trusted projects' hooks for the whole invocation, collapsing codex's
+  per-hook trust defense. Rejected — see decision 4. (The chosen `trusted_hash`
+  approach is the "scope it to our hook" alternative, accepting the hash
+  fragility precisely because it fails safe.)
+- **Managed hooks via `requirements.toml`** (`is_managed` ⇒ always trusted, no
+  hash). The robust "automation" path, but `requirements.toml` is an
+  admin/MDM-flavored, system-scoped mechanism, and managed hooks can't be
+  expressed as an ephemeral per-launch `-c` override. Left as a possible future
+  hardening.
+- **Installing a hook into `~/.codex/hooks.json`** (the cmux/ghostex approach).
+  Works, and preserves the user's other hooks via a merge, but is a global,
+  persistent mutation of the user's config that outlives the gmux session.
+  Rejected in favour of ephemeral `-c` injection.
+- **`CODEX_HOME` redirection to a gmux-managed config layer.** Would avoid
+  touching the user's `~/.codex`, but `CODEX_HOME` *replaces* rather than layers
+  — it would orphan the user's sessions, auth, and history. Rejected.
+- **The older `notify` program** (`agent-turn-complete` only). Too coarse: no
+  session-bind event, no transcript path. Superseded by hooks.

--- a/docs/adr/0013-codex-authoritative-state-via-hooks.md
+++ b/docs/adr/0013-codex-authoritative-state-via-hooks.md
@@ -96,6 +96,11 @@ protocol unchanged. Concretely:
   the hook reports the held file even for a cache-served resume, and the daemon
   suppresses its file parse for hook-attributed sessions (the existing
   `AttributeFromHook` path, adapter-independent).
+- Turn-end status is coarser than pi's. Codex's `Stop` hook input carries no
+  outcome field (`stop.command.input.schema.json`: 9 fields, none about how the
+  turn ended), so the hook always reports `completed` — a user interrupt or
+  error exit shows as completed+unread, not idle/error. Revisit if codex adds an
+  outcome-bearing Stop field.
 - The daemon's metadata-attribution engine (`filemon.go` fallback,
   `FileAttributor`) is **no longer codex's only path** — but it is still
   required for older codex. It can be removed only once a hooks-capable codex is

--- a/docs/runner-hook-protocol.md
+++ b/docs/runner-hook-protocol.md
@@ -79,9 +79,20 @@ but `/events` replay.
 
 ## Implementing for a new agent
 
-1. **Load the hook** via the injection seam matching how the agent loads
-   extensions — `adapter.SessionExtender.ExtendCommand` splices a loader flag
-   into the argv (pi: `-e <path>`). Both seams are ephemeral and scoped to the
-   gmux-launched process; the injected hook no-ops without `GMUX_SESSION_SOCK`.
+1. **Load the hook** via the seam matching how the agent loads extensions
+   (below). Both are ephemeral, scoped to the launch, and no-op without
+   `GMUX_SESSION_SOCK`.
 2. Report a `session` event on every bind.
 3. Report `turn` start/end, normalizing to the outcome vocabulary.
+
+### Injection seams
+
+- **`SessionExtender`** (pi): the runner materializes the embedded pi extension
+  and splices `pi -e <path>` into the argv.
+- **`SessionHookCommand`** (codex): the runner injects a `gmux __codex-hook`
+  command hook via the agent's config-override flags (`-c hooks.<Event>=...`),
+  with the gmux binary itself as the hook program. It also carries the per-hook
+  `trusted_hash` codex computes so only gmux's own hooks are trusted (never the
+  global `--dangerously-bypass-hook-trust`). Version-gated; older codex falls
+  back to daemon metadata attribution, and a hash mismatch degrades to the same
+  fallback rather than broadening trust.

--- a/packages/adapter/adapters/codex.go
+++ b/packages/adapter/adapters/codex.go
@@ -1,6 +1,7 @@
 package adapters
 
 import (
+	"bufio"
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
@@ -485,13 +486,10 @@ func CodexHookBodies(eventName string, input []byte) [][]byte {
 		b, _ := json.Marshal(map[string]string{"op": "turn", "phase": "start"})
 		return [][]byte{b}
 	case "Stop":
-		// outcome is hardcoded "completed": codex's Stop payload carries no
-		// exit-reason field (only session_id/turn_id/cwd/transcript_path/
-		// last_assistant_message/stop_hook_active), so the hook can't tell a clean
-		// completion from a user interrupt or error exit. A user abort therefore
-		// shows as completed+unread rather than idle — the daemon's FileMonitor
-		// fallback (turn_cancelled → idle) is more precise, but the hook has no
-		// equivalent signal. Revisit if codex adds an outcome-bearing Stop field.
+		// outcome hardcoded "completed": codex's Stop payload has no exit-reason
+		// field, so the hook can't distinguish a clean completion from an
+		// interrupt/error (a user abort shows as completed+unread). Revisit if
+		// codex adds an outcome-bearing Stop field.
 		turn, _ := json.Marshal(map[string]string{
 			"op": "turn", "phase": "end", "outcome": "completed",
 		})
@@ -530,12 +528,57 @@ func codexSessionBody(input []byte) ([]byte, bool) {
 		body["reason"] = in.Source
 	}
 	// Derive a human title + slug from the transcript's first user prompt.
-	if info, err := (&Codex{}).ParseSessionFile(in.TranscriptPath); err == nil && info.Title != "" && info.Title != "(new)" {
-		body["name"] = info.Title
-		body["slug"] = info.Slug
+	if title := codexHookTitle(in.TranscriptPath); title != "" {
+		body["name"] = title
+		body["slug"] = adapter.Slugify(title)
 	}
 	b, _ := json.Marshal(body)
 	return b, true
+}
+
+// codexHookTitle returns a codex session's display title — the first non-system
+// user prompt, truncated — or "" if the transcript has none yet.
+//
+// Unlike ParseSessionFile it early-exits at the first user message instead of
+// reading the whole file. This matters because the hook derives the title on
+// every turn-end (codex blocks on the Stop hook), the title never changes after
+// the first prompt, and the transcript grows each turn: a full re-parse would be
+// O(file) per turn, O(n²) over a session. The first prompt sits near the top, so
+// this stays effectively O(1).
+func codexHookTitle(path string) string {
+	f, err := os.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+
+	sc := bufio.NewScanner(f)
+	// codex transcript lines (tool output, assistant messages) can be large;
+	// raise the line cap well above bufio's 64KiB default.
+	sc.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
+	for sc.Scan() {
+		line := sc.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var entry struct {
+			Type    string `json:"type"`
+			Payload struct {
+				Type    string          `json:"type"`
+				Role    string          `json:"role"`
+				Content json.RawMessage `json:"content"`
+			} `json:"payload"`
+		}
+		if json.Unmarshal(line, &entry) != nil {
+			continue
+		}
+		if entry.Type == "response_item" && entry.Payload.Role == "user" && entry.Payload.Type == "message" {
+			if text := extractCodexUserText(entry.Payload.Content); text != "" {
+				return truncateTitle(text, 80)
+			}
+		}
+	}
+	return ""
 }
 
 // --- FileAttributor ---

--- a/packages/adapter/adapters/codex.go
+++ b/packages/adapter/adapters/codex.go
@@ -1,11 +1,17 @@
 package adapters
 
 import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gmuxapp/gmux/packages/adapter"
@@ -18,6 +24,7 @@ var (
 	_ adapter.SessionFileLister  = (*Codex)(nil)
 	_ adapter.FileMonitor        = (*Codex)(nil)
 	_ adapter.FileAttributor     = (*Codex)(nil)
+	_ adapter.SessionHookCommand = (*Codex)(nil)
 	_ adapter.Resumer            = (*Codex)(nil)
 )
 
@@ -27,8 +34,19 @@ func init() {
 
 // Codex is the adapter for OpenAI Codex CLI.
 // Sessions are JSONL files in ~/.codex/sessions/YYYY/MM/DD/.
-// Status is driven by event_msg lines in the session file (FileMonitor).
-type Codex struct{}
+//
+// Live session state is reported authoritatively by the gmux codex hook
+// (SessionHookCommand; see HookCommand + CodexHookBodies): gmux injects the
+// hook per-launch via codex's `-c hooks.<Event>=...` config overrides, so the
+// hook runs `gmux __codex-hook <Event>` and POSTs to the runner socket on every
+// SessionStart/UserPromptSubmit/Stop — ephemeral, with no mutation of the
+// user's ~/.codex. When codex is too old to support hooks, nothing is injected
+// and the daemon's metadata attribution + FileMonitor parsing
+// (FileAttributor/ParseNewLines) remain the fallback.
+type Codex struct {
+	hooksOnce sync.Once
+	hooksOK   bool
+}
 
 func NewCodex() *Codex { return &Codex{} }
 
@@ -164,8 +182,8 @@ func (c *Codex) ParseSessionFile(path string) (*adapter.SessionFileInfo, error) 
 		var entry struct {
 			Type    string `json:"type"`
 			Payload struct {
-				Type    string `json:"type"`
-				Role    string `json:"role"`
+				Type    string          `json:"type"`
+				Role    string          `json:"role"`
 				Content json.RawMessage `json:"content"`
 			} `json:"payload"`
 		}
@@ -268,6 +286,258 @@ func (c *Codex) ParseNewLines(lines []string, _ string) []adapter.Event {
 	return events
 }
 
+// --- SessionHookCommand ---
+
+// codexMinHookVersion is the floor codex version for the gmux hook integration.
+// By v0.135 codex's command-hook system is documented and stable, and the hook
+// config + per-hook trust-state shapes we depend on (`-c hooks.<Event>=...` and
+// `hooks.state.<key>.trusted_hash`) are present. Below this we inject nothing
+// (an older codex would reject the -c hooks overrides, breaking launch); the
+// daemon's metadata attribution stays in charge instead.
+const codexMinHookVersion = "0.135.0"
+
+// codexHookEvents are the codex hook events the gmux hook subscribes to, mapped
+// onto the tool-neutral /hook/event protocol in CodexHookBodies:
+//
+//	SessionStart     → op "session" (bind: transcript_path + title/slug)
+//	UserPromptSubmit → op "turn" phase "start"
+//	Stop             → op "session" (title refresh) + op "turn" phase "end"
+var codexHookEvents = []string{"SessionStart", "UserPromptSubmit", "Stop"}
+
+// codexSessionFlagsSource is the synthetic source path codex assigns to hooks
+// defined via `-c` overrides (the SessionFlags config layer): codex builds it as
+// AbsolutePathBuf::resolve_path_against_base("<session-flags>/config.toml", "/"),
+// which displays as this on POSIX. It is the `key_source` half of the per-hook
+// trust-state key, so we must reproduce it byte-for-byte (see codexHookTrustKey).
+const codexSessionFlagsSource = "/<session-flags>/config.toml"
+
+// hooksSupported reports whether the installed codex is recent enough for the
+// hook integration. Memoized: `codex --version` is cheap (Rust) but the runner
+// calls HookCommand on every launch.
+func (c *Codex) hooksSupported() bool {
+	c.hooksOnce.Do(func() {
+		out, err := exec.Command("codex", "--version").Output()
+		if err != nil {
+			return
+		}
+		if v := parseCodexVersion(string(out)); v != nil {
+			c.hooksOK = !semverLess(v, mustParseSemver(codexMinHookVersion))
+		}
+	})
+	return c.hooksOK
+}
+
+// HookCommand injects the gmux codex hook per-launch via `-c` config overrides
+// (a SessionFlags config layer) — ephemeral, like pi's `-e`, with no mutation of
+// the user's ~/.codex. Returns ok=false (args unchanged) when codex is too old
+// to support hooks.
+func (c *Codex) HookCommand(args []string, selfBin string) ([]string, bool) {
+	if !c.hooksSupported() {
+		return args, false
+	}
+	out := codexHookArgs(args, selfBin)
+	return out, len(out) > len(args)
+}
+
+// codexHookArgs splices, right after the codex binary token (which may not be
+// args[0], e.g. `env codex`), one `-c hooks.<Event>=...` override per subscribed
+// event plus a single `-c hooks.state=...` that pre-trusts *only those* hooks.
+//
+// Trust is scoped deliberately: a CLI-injected hook is non-managed and therefore
+// Untrusted, which codex silently skips. Rather than --dangerously-bypass-hook-
+// trust (a process-global flag that would un-gate the user's, plugins', and
+// already-trusted projects' hooks too), we inject the exact per-hook
+// `trusted_hash` codex computes, so only gmux's own benign reporting hooks are
+// trusted and codex's trust model is preserved for everything else. If our hash
+// ever fails to match (e.g. a codex internal change), the hook is simply
+// Untrusted → skipped → the daemon's metadata attribution takes over. It
+// degrades; it never broadens trust.
+//
+// Returns args unchanged if no codex binary token is found.
+func codexHookArgs(args []string, selfBin string) []string {
+	i := codexBinaryIndex(args)
+	if i < 0 {
+		return args
+	}
+	injected := make([]string, 0, 2*len(codexHookEvents)+2)
+	stateEntries := make([]string, 0, len(codexHookEvents))
+	for _, event := range codexHookEvents {
+		inner := codexHookCommand(selfBin, event)
+		label := codexEventLabel(event)
+		injected = append(injected, "-c", fmt.Sprintf(
+			`hooks.%s=[{hooks=[{type="command",command=%s,timeout=5}]}]`,
+			event, tomlString(inner)))
+		stateEntries = append(stateEntries, fmt.Sprintf("%s={trusted_hash=%s}",
+			tomlString(codexHookTrustKey(label)), tomlString(codexHookTrustedHash(inner, label))))
+	}
+	injected = append(injected, "-c", "hooks.state={"+strings.Join(stateEntries, ",")+"}")
+	out := make([]string, 0, len(args)+len(injected))
+	out = append(out, args[:i+1]...)
+	out = append(out, injected...)
+	return append(out, args[i+1:]...)
+}
+
+// codexHookCommand is the shell command codex runs for an event hook (via
+// `sh -lc`): the gmux binary (shell-quoted) relaying that event. This exact
+// string is both the hook's `command` and the input to its trust hash.
+func codexHookCommand(selfBin, event string) string {
+	return shellQuote(selfBin) + " __codex-hook " + event
+}
+
+// codexEventLabel maps a codex hook event name to the snake_case label codex
+// uses in hook keys (hook_event_key_label).
+func codexEventLabel(event string) string {
+	switch event {
+	case "SessionStart":
+		return "session_start"
+	case "UserPromptSubmit":
+		return "user_prompt_submit"
+	case "Stop":
+		return "stop"
+	default:
+		return strings.ToLower(event)
+	}
+}
+
+// codexHookTrustKey reproduces codex's per-hook trust-state key for a hook the
+// gmux launcher injects via `-c`: `{key_source}:{event_label}:{group}:{handler}`
+// (hook_key). Our hook is the sole matcher group (0) with a single handler (0)
+// in the SessionFlags layer.
+func codexHookTrustKey(eventLabel string) string {
+	return codexSessionFlagsSource + ":" + eventLabel + ":0:0"
+}
+
+// codexHookTrustedHash reproduces codex's `version_for_toml` over the normalized
+// hook identity (discovery.command_hook_hash): sha256, hex, "sha256:"-prefixed,
+// of the canonical (sorted-key, compact, no HTML escaping) JSON of
+//
+//	{event_name, hooks:[{type:"command", command, timeout:5, async:false}]}
+//
+// matcher is None for our events (matcher_pattern_for_event), and the other
+// Option fields are None, so the toml→json value omits them. command is the
+// pre-env-substitution command (we inject no env, so it is exactly `command`).
+func codexHookTrustedHash(command, eventLabel string) string {
+	identity := map[string]any{
+		"event_name": eventLabel,
+		"hooks": []any{map[string]any{
+			"type":    "command",
+			"command": command,
+			"timeout": 5,
+			"async":   false,
+		}},
+	}
+	// Match serde_json: keys sorted (Go sorts map keys), compact, and NOT
+	// HTML-escaped. json.Encoder appends a newline, which serde_json::to_vec
+	// does not — trim it before hashing.
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	_ = enc.Encode(identity)
+	sum := sha256.Sum256(bytes.TrimRight(buf.Bytes(), "\n"))
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+// codexBinaryIndex returns the index of the codex binary token in args (before
+// any `--`), or -1. Mirrors piBinaryIndex: the binary may not be args[0]
+// (e.g. `env codex`, `npx codex`).
+func codexBinaryIndex(args []string) int {
+	for i, arg := range args {
+		if arg == "--" {
+			return -1
+		}
+		if filepath.Base(arg) == "codex" {
+			return i
+		}
+	}
+	return -1
+}
+
+// tomlString renders s as a TOML basic string (double-quoted), escaping
+// backslashes and double quotes.
+func tomlString(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `"`, `\"`)
+	return `"` + s + `"`
+}
+
+// shellQuote single-quotes s for a POSIX shell (codex runs hook commands via
+// `sh -lc "<command>"`). Embedded single quotes are escaped as '\”.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// CodexHookBodies translates a codex hook invocation into zero or more
+// tool-neutral gmux /hook/event bodies (posted in order by `gmux __codex-hook`).
+// eventName is the codex hook event; input is the JSON codex wrote to the hook's
+// stdin (its SessionStart/Stop input carries session_id, transcript_path, cwd).
+//
+// codex has no title/slug field of its own, so this derives them by parsing the
+// transcript's first user prompt (reusing ParseSessionFile) and reports them as
+// the session title + an explicit slug — codex's session_id is a UUID that would
+// slugify into an unreadable URL.
+func CodexHookBodies(eventName string, input []byte) [][]byte {
+	switch eventName {
+	case "SessionStart":
+		if b, ok := codexSessionBody(input); ok {
+			return [][]byte{b}
+		}
+	case "UserPromptSubmit":
+		b, _ := json.Marshal(map[string]string{"op": "turn", "phase": "start"})
+		return [][]byte{b}
+	case "Stop":
+		// outcome is hardcoded "completed": codex's Stop payload carries no
+		// exit-reason field (only session_id/turn_id/cwd/transcript_path/
+		// last_assistant_message/stop_hook_active), so the hook can't tell a clean
+		// completion from a user interrupt or error exit. A user abort therefore
+		// shows as completed+unread rather than idle — the daemon's FileMonitor
+		// fallback (turn_cancelled → idle) is more precise, but the hook has no
+		// equivalent signal. Revisit if codex adds an outcome-bearing Stop field.
+		turn, _ := json.Marshal(map[string]string{
+			"op": "turn", "phase": "end", "outcome": "completed",
+		})
+		if b, ok := codexSessionBody(input); ok {
+			return [][]byte{b, turn} // refresh title/slug, then end the turn
+		}
+		return [][]byte{turn}
+	}
+	return nil
+}
+
+// codexSessionBody builds an op "session" body from a codex hook payload. Returns
+// ok=false when there is no transcript path yet (a brand-new session before its
+// file is written) — nothing to attribute.
+func codexSessionBody(input []byte) ([]byte, bool) {
+	var in struct {
+		SessionID      string `json:"session_id"`
+		TranscriptPath string `json:"transcript_path"`
+		Cwd            string `json:"cwd"`
+		Source         string `json:"source"`
+	}
+	if err := json.Unmarshal(input, &in); err != nil || in.TranscriptPath == "" {
+		return nil, false
+	}
+	body := map[string]any{
+		"op":   "session",
+		"path": in.TranscriptPath,
+	}
+	if in.SessionID != "" {
+		body["id"] = in.SessionID
+	}
+	if in.Cwd != "" {
+		body["cwd"] = in.Cwd
+	}
+	if in.Source != "" {
+		body["reason"] = in.Source
+	}
+	// Derive a human title + slug from the transcript's first user prompt.
+	if info, err := (&Codex{}).ParseSessionFile(in.TranscriptPath); err == nil && info.Title != "" && info.Title != "(new)" {
+		body["name"] = info.Title
+		body["slug"] = info.Slug
+	}
+	b, _ := json.Marshal(body)
+	return b, true
+}
+
 // --- FileAttributor ---
 
 // AttributeFile matches a file to a session using the file's session_meta
@@ -281,13 +551,77 @@ func (c *Codex) AttributeFile(filePath string, candidates []adapter.FileCandidat
 	return attributeByMetadata(info, candidates)
 }
 
+// --- semver (codex --version gating) ---
+
+// parseCodexVersion extracts the first dotted numeric version from `codex
+// --version` output (e.g. "codex-cli 0.142.0\n" → [0 142 0]). Pre-release/build
+// suffixes ("-alpha.9") are ignored. Returns nil if no version is found.
+func parseCodexVersion(s string) []int {
+	for _, tok := range strings.Fields(s) {
+		// Trim a leading 'v' and any pre-release/build suffix.
+		tok = strings.TrimPrefix(tok, "v")
+		if i := strings.IndexAny(tok, "-+"); i >= 0 {
+			tok = tok[:i]
+		}
+		if v := parseSemver(tok); v != nil {
+			return v
+		}
+	}
+	return nil
+}
+
+// parseSemver parses "MAJOR.MINOR.PATCH" (missing components default to 0).
+// Returns nil if the first component isn't numeric.
+func parseSemver(s string) []int {
+	parts := strings.Split(s, ".")
+	if len(parts) == 0 {
+		return nil
+	}
+	out := make([]int, 3)
+	for i := 0; i < 3 && i < len(parts); i++ {
+		n, err := strconv.Atoi(parts[i])
+		if err != nil {
+			if i == 0 {
+				return nil
+			}
+			break
+		}
+		out[i] = n
+	}
+	return out
+}
+
+func mustParseSemver(s string) []int {
+	v := parseSemver(s)
+	if v == nil {
+		panic("invalid semver constant: " + s)
+	}
+	return v
+}
+
+// semverLess reports whether a < b (component-wise, major.minor.patch).
+func semverLess(a, b []int) bool {
+	for i := 0; i < 3; i++ {
+		av, bv := 0, 0
+		if i < len(a) {
+			av = a[i]
+		}
+		if i < len(b) {
+			bv = b[i]
+		}
+		if av != bv {
+			return av < bv
+		}
+	}
+	return false
+}
+
 // --- Resumer ---
 
 // ResumeCommand returns the command to resume a Codex session.
 func (c *Codex) ResumeCommand(info *adapter.SessionFileInfo) []string {
 	return []string{"codex", "resume", info.ID}
 }
-
 
 // CanResume checks if a session file has user messages worth resuming.
 func (c *Codex) CanResume(path string) bool {

--- a/packages/adapter/adapters/codex_hook_test.go
+++ b/packages/adapter/adapters/codex_hook_test.go
@@ -1,0 +1,347 @@
+package adapters
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+)
+
+func TestParseCodexVersion(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []int
+	}{
+		{"codex-cli 0.142.0\n", []int{0, 142, 0}},
+		{"codex 0.135.0", []int{0, 135, 0}},
+		{"0.142.0-alpha.9", []int{0, 142, 0}},
+		{"codex v1.2.3", []int{1, 2, 3}},
+		{"codex 0.13", []int{0, 13, 0}},
+		{"no version here", nil},
+		{"", nil},
+	}
+	for _, c := range cases {
+		got := parseCodexVersion(c.in)
+		if !reflect.DeepEqual(got, c.want) {
+			t.Errorf("parseCodexVersion(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestSemverLess(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want bool
+	}{
+		{"0.134.0", "0.135.0", true},
+		{"0.135.0", "0.135.0", false},
+		{"0.135.1", "0.135.0", false},
+		{"0.135.0", "0.134.9", false},
+		{"0.142.0", "0.135.0", false},
+		{"1.0.0", "0.135.0", false},
+	}
+	for _, c := range cases {
+		got := semverLess(mustParseSemver(c.a), mustParseSemver(c.b))
+		if got != c.want {
+			t.Errorf("semverLess(%s,%s) = %v, want %v", c.a, c.b, got, c.want)
+		}
+	}
+}
+
+func TestCodexHookBodies_SessionStart(t *testing.T) {
+	dir := t.TempDir()
+	transcript := filepath.Join(dir, "rollout-2026-06-20-abc.jsonl")
+	writeCodexTranscript(t, transcript, "Fix the auth bug")
+
+	input := mustJSON(t, map[string]any{
+		"hook_event_name": "SessionStart",
+		"session_id":      "019cfb54-dead-beef-cafe-000000000001",
+		"transcript_path": transcript,
+		"cwd":             "/proj",
+		"source":          "startup",
+	})
+	bodies := CodexHookBodies("SessionStart", input)
+	if len(bodies) != 1 {
+		t.Fatalf("want 1 body, got %d", len(bodies))
+	}
+	var ev map[string]any
+	mustUnmarshal(t, bodies[0], &ev)
+	if ev["op"] != "session" || ev["path"] != transcript {
+		t.Fatalf("bad session body: %v", ev)
+	}
+	// codex's UUID session_id must not become the slug; a title-derived slug is.
+	if ev["slug"] == nil || strings.Contains(ev["slug"].(string), "019cfb54") {
+		t.Errorf("slug should be title-derived, got %v", ev["slug"])
+	}
+	if ev["name"] != "Fix the auth bug" {
+		t.Errorf("name = %v, want title from first user prompt", ev["name"])
+	}
+}
+
+func TestCodexHookBodies_NewSessionNoTranscript(t *testing.T) {
+	// A brand-new session whose transcript path is empty: nothing to attribute.
+	input := mustJSON(t, map[string]any{
+		"hook_event_name": "SessionStart",
+		"session_id":      "abc",
+		"transcript_path": "",
+		"source":          "startup",
+	})
+	if bodies := CodexHookBodies("SessionStart", input); len(bodies) != 0 {
+		t.Fatalf("want no bodies for empty transcript, got %v", bodies)
+	}
+}
+
+func TestCodexHookBodies_TurnLifecycle(t *testing.T) {
+	start := CodexHookBodies("UserPromptSubmit", []byte(`{}`))
+	if len(start) != 1 {
+		t.Fatalf("UserPromptSubmit: want 1 body, got %d", len(start))
+	}
+	var s map[string]string
+	mustUnmarshal(t, start[0], &s)
+	if s["op"] != "turn" || s["phase"] != "start" {
+		t.Errorf("UserPromptSubmit body = %v", s)
+	}
+
+	// Stop with no transcript still ends the turn (completed).
+	stop := CodexHookBodies("Stop", []byte(`{}`))
+	if len(stop) != 1 {
+		t.Fatalf("Stop(no transcript): want 1 body, got %d", len(stop))
+	}
+	var e map[string]string
+	mustUnmarshal(t, stop[0], &e)
+	if e["op"] != "turn" || e["phase"] != "end" || e["outcome"] != "completed" {
+		t.Errorf("Stop body = %v", e)
+	}
+}
+
+func TestCodexHookBodies_StopRefreshesTitle(t *testing.T) {
+	dir := t.TempDir()
+	transcript := filepath.Join(dir, "rollout.jsonl")
+	writeCodexTranscript(t, transcript, "Add retries to the client")
+
+	input := mustJSON(t, map[string]any{
+		"hook_event_name": "Stop",
+		"session_id":      "uuid",
+		"transcript_path": transcript,
+	})
+	bodies := CodexHookBodies("Stop", input)
+	if len(bodies) != 2 {
+		t.Fatalf("Stop with transcript: want session+turn (2 bodies), got %d", len(bodies))
+	}
+	var sess map[string]any
+	mustUnmarshal(t, bodies[0], &sess)
+	if sess["op"] != "session" || sess["name"] != "Add retries to the client" {
+		t.Errorf("first Stop body should refresh session title: %v", sess)
+	}
+	var turn map[string]string
+	mustUnmarshal(t, bodies[1], &turn)
+	if turn["phase"] != "end" {
+		t.Errorf("second Stop body should end the turn: %v", turn)
+	}
+}
+
+func TestCodexHookBodies_UnknownEvent(t *testing.T) {
+	if bodies := CodexHookBodies("PreToolUse", []byte(`{}`)); bodies != nil {
+		t.Errorf("unknown event should yield no bodies, got %v", bodies)
+	}
+}
+
+func TestCodexHookArgs(t *testing.T) {
+	const bin = "/usr/local/bin/gmux"
+	out := codexHookArgs([]string{"codex", "resume", "abc"}, bin)
+
+	// No global trust bypass flag is ever added.
+	for _, a := range out {
+		if strings.Contains(a, "bypass-hook-trust") {
+			t.Fatalf("must not use the global trust-bypass flag: %v", out)
+		}
+	}
+	// Binary token stays put; original tail preserved at the end.
+	if out[0] != "codex" {
+		t.Fatalf("binary token moved: %v", out)
+	}
+	if out[len(out)-2] != "resume" || out[len(out)-1] != "abc" {
+		t.Errorf("original args not preserved at tail: %v", out)
+	}
+	// One -c hook override per subscribed event, each carrying the binary + event.
+	for _, event := range codexHookEvents {
+		found := false
+		for i := 0; i < len(out)-1; i++ {
+			if out[i] == "-c" && strings.HasPrefix(out[i+1], "hooks."+event+"=") &&
+				strings.Contains(out[i+1], "__codex-hook "+event) {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("missing -c override for event %s in %v", event, out)
+		}
+	}
+	// Exactly one -c hooks.state override pre-trusting our hooks.
+	stateCount := 0
+	for i := 0; i < len(out)-1; i++ {
+		if out[i] == "-c" && strings.HasPrefix(out[i+1], "hooks.state=") {
+			stateCount++
+			for _, event := range codexHookEvents {
+				if !strings.Contains(out[i+1], codexHookTrustKey(codexEventLabel(event))) {
+					t.Errorf("hooks.state missing trust key for %s: %s", event, out[i+1])
+				}
+			}
+		}
+	}
+	if stateCount != 1 {
+		t.Errorf("want exactly 1 hooks.state override, got %d in %v", stateCount, out)
+	}
+
+	// Binary not at args[0] (e.g. `env codex`): injection goes after the binary.
+	out = codexHookArgs([]string{"env", "codex"}, bin)
+	if out[0] != "env" || out[1] != "codex" || out[2] != "-c" {
+		t.Errorf("env codex: injection misplaced: %v", out)
+	}
+
+	// No codex binary token: unchanged.
+	orig := []string{"bash", "-c", "echo hi"}
+	if got := codexHookArgs(orig, bin); !reflect.DeepEqual(got, orig) {
+		t.Errorf("non-codex args mutated: %v", got)
+	}
+}
+
+// TestCodexHookOverrideIsValidTOML proves the injected `-c` values parse the way
+// codex parses them: the hook-definition override deserializes into codex's
+// MatcherGroup shape, and the hooks.state override deserializes into the
+// per-hook trust map keyed exactly as codex's hook_key would compute it.
+func TestCodexHookOverrideIsValidTOML(t *testing.T) {
+	// A path with a space + an apostrophe, to exercise shell + TOML escaping.
+	const bin = "/home/a b/it's/gmux"
+	out := codexHookArgs([]string{"codex"}, bin)
+
+	values := map[string]string{} // key path -> raw TOML value
+	for i := 0; i < len(out)-1; i++ {
+		if out[i] == "-c" {
+			k, v, _ := strings.Cut(out[i+1], "=")
+			values[k] = v
+		}
+	}
+
+	// Hook definition for SessionStart.
+	def, ok := values["hooks.SessionStart"]
+	if !ok {
+		t.Fatal("no hooks.SessionStart override injected")
+	}
+	var defDoc struct {
+		V []struct {
+			Hooks []struct {
+				Type    string `toml:"type"`
+				Command string `toml:"command"`
+				Timeout int    `toml:"timeout"`
+			} `toml:"hooks"`
+		} `toml:"v"`
+	}
+	if _, err := toml.Decode("v = "+def, &defDoc); err != nil {
+		t.Fatalf("codex would reject hooks.SessionStart value %q: %v", def, err)
+	}
+	if len(defDoc.V) != 1 || len(defDoc.V[0].Hooks) != 1 {
+		t.Fatalf("unexpected MatcherGroup shape: %+v", defDoc)
+	}
+	h := defDoc.V[0].Hooks[0]
+	if h.Type != "command" || h.Timeout != 5 {
+		t.Errorf("handler = %+v, want type=command timeout=5", h)
+	}
+	if !strings.Contains(h.Command, "__codex-hook SessionStart") ||
+		!strings.Contains(h.Command, `'/home/a b/it'\''s/gmux'`) {
+		t.Errorf("decoded command = %q", h.Command)
+	}
+
+	// Trust state: must parse into HookStateToml keyed exactly by hook_key, and
+	// the decoded command's trusted_hash must equal what codexHookTrustedHash
+	// produced for that same command.
+	state, ok := values["hooks.state"]
+	if !ok {
+		t.Fatal("no hooks.state override injected")
+	}
+	var stateDoc struct {
+		V map[string]struct {
+			TrustedHash string `toml:"trusted_hash"`
+		} `toml:"v"`
+	}
+	if _, err := toml.Decode("v = "+state, &stateDoc); err != nil {
+		t.Fatalf("codex would reject hooks.state value %q: %v", state, err)
+	}
+	wantKey := codexHookTrustKey("session_start")
+	entry, ok := stateDoc.V[wantKey]
+	if !ok {
+		t.Fatalf("hooks.state missing key %q; have %v", wantKey, stateDoc.V)
+	}
+	if entry.TrustedHash != codexHookTrustedHash(h.Command, "session_start") {
+		t.Errorf("trusted_hash %q does not match the injected hook command", entry.TrustedHash)
+	}
+}
+
+// TestCodexHookTrustedHash pins the canonical-JSON form codex hashes
+// (version_for_toml): sorted keys, compact, no HTML escaping, no trailing
+// newline. If this drifts, our hook is merely untrusted (skipped) — codex falls
+// back to daemon attribution — but this guards the Go side from silent change.
+func TestCodexHookTrustedHash(t *testing.T) {
+	const cmd = `'/usr/local/bin/gmux' __codex-hook SessionStart`
+	canonical := `{"event_name":"session_start","hooks":[{"async":false,"command":"` +
+		cmd + `","timeout":5,"type":"command"}]}`
+	sum := sha256.Sum256([]byte(canonical))
+	want := "sha256:" + hex.EncodeToString(sum[:])
+	if got := codexHookTrustedHash(cmd, "session_start"); got != want {
+		t.Errorf("codexHookTrustedHash = %s, want %s (canonical %q)", got, want, canonical)
+	}
+}
+
+func TestShellQuote(t *testing.T) {
+	cases := map[string]string{
+		"/usr/local/bin/gmux":   "'/usr/local/bin/gmux'",
+		"/path/with space/gmux": "'/path/with space/gmux'",
+		"/it's/weird/gmux":      `'/it'\''s/weird/gmux'`,
+	}
+	for in, want := range cases {
+		if got := shellQuote(in); got != want {
+			t.Errorf("shellQuote(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// --- helpers ---
+
+func writeCodexTranscript(t *testing.T, path, firstUserText string) {
+	t.Helper()
+	meta := `{"type":"session_meta","payload":{"id":"uuid","timestamp":"2026-06-20T10:00:00Z","cwd":"/proj"}}`
+	msg := mustJSON(t, map[string]any{
+		"type": "response_item",
+		"payload": map[string]any{
+			"type": "message",
+			"role": "user",
+			"content": []any{
+				map[string]any{"type": "input_text", "text": firstUserText},
+			},
+		},
+	})
+	if err := os.WriteFile(path, []byte(meta+"\n"+string(msg)+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mustJSON(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+func mustUnmarshal(t *testing.T, data []byte, v any) {
+	t.Helper()
+	if err := json.Unmarshal(data, v); err != nil {
+		t.Fatalf("unmarshal %s: %v", data, err)
+	}
+}

--- a/packages/adapter/capabilities.go
+++ b/packages/adapter/capabilities.go
@@ -119,27 +119,11 @@ type SessionExtender interface {
 	ExtendCommand(args []string, extPath string) []string
 }
 
-// SessionHookCommand marks adapters whose agent reports session state via a
-// hook injected per-launch on the argv, where the hook *program* is the gmux
-// binary itself (the agent runs `gmux __<agent>-hook <event>`). Contrast
-// SessionExtender, whose hook is a separate materialized extension file loaded
-// with a flag like `pi -e <path>`.
-//
-// codex is the first implementer: codex loads command hooks from its config,
-// and crucially accepts hook definitions via per-invocation `-c` config
-// overrides (a SessionFlags config layer), so gmux can inject
-// `-c hooks.SessionStart=...` etc. on the launch argv without touching the
-// user's global ~/.codex — ephemeral and scoped to the gmux-launched process,
-// just like pi's `-e`. The injected hook runs `gmux __codex-hook <Event>` and
-// POSTs authoritative session/turn events to the runner socket; it no-ops
-// unless the runner-set GMUX_SESSION_SOCK is present. The wire protocol is the
-// same tool-neutral /hook/event contract as pi (docs/runner-hook-protocol.md).
-//
-// A CLI-injected hook is untrusted and codex would otherwise silently skip it,
-// so the injection also carries the exact per-hook `trusted_hash` codex computes
-// (scoping trust to only gmux's own hooks, never a global bypass). The path is
-// gated on a codex version that supports hooks; older codex falls back to the
-// daemon's metadata attribution unchanged.
+// SessionHookCommand marks adapters whose agent runs the gmux binary itself as
+// a command hook (`gmux __<agent>-hook <event>`), injected per-launch on the
+// argv via the agent's config-override flags. Contrast SessionExtender, whose
+// hook is a separate materialized extension file. codex is the first
+// implementer; see ADR 0013 and docs/runner-hook-protocol.md.
 type SessionHookCommand interface {
 	// HookCommand returns args with the flags spliced in that (a) define a gmux
 	// hook which relays session events to the runner socket and (b) let it run.

--- a/packages/adapter/capabilities.go
+++ b/packages/adapter/capabilities.go
@@ -119,6 +119,37 @@ type SessionExtender interface {
 	ExtendCommand(args []string, extPath string) []string
 }
 
+// SessionHookCommand marks adapters whose agent reports session state via a
+// hook injected per-launch on the argv, where the hook *program* is the gmux
+// binary itself (the agent runs `gmux __<agent>-hook <event>`). Contrast
+// SessionExtender, whose hook is a separate materialized extension file loaded
+// with a flag like `pi -e <path>`.
+//
+// codex is the first implementer: codex loads command hooks from its config,
+// and crucially accepts hook definitions via per-invocation `-c` config
+// overrides (a SessionFlags config layer), so gmux can inject
+// `-c hooks.SessionStart=...` etc. on the launch argv without touching the
+// user's global ~/.codex — ephemeral and scoped to the gmux-launched process,
+// just like pi's `-e`. The injected hook runs `gmux __codex-hook <Event>` and
+// POSTs authoritative session/turn events to the runner socket; it no-ops
+// unless the runner-set GMUX_SESSION_SOCK is present. The wire protocol is the
+// same tool-neutral /hook/event contract as pi (docs/runner-hook-protocol.md).
+//
+// A CLI-injected hook is untrusted and codex would otherwise silently skip it,
+// so the injection also carries the exact per-hook `trusted_hash` codex computes
+// (scoping trust to only gmux's own hooks, never a global bypass). The path is
+// gated on a codex version that supports hooks; older codex falls back to the
+// daemon's metadata attribution unchanged.
+type SessionHookCommand interface {
+	// HookCommand returns args with the flags spliced in that (a) define a gmux
+	// hook which relays session events to the runner socket and (b) let it run.
+	// selfBin is the absolute path of the gmux binary the hook invokes. The
+	// binary token may not be args[0] (e.g. `env codex`). Returns ok=false (and
+	// args unchanged) when the agent version doesn't support hooks, so the
+	// runner launches unmodified and the daemon's fallback attribution applies.
+	HookCommand(args []string, selfBin string) (out []string, ok bool)
+}
+
 // PassthroughDetector marks adapters that recognize invocations which are NOT
 // interactive sessions — one-shot subcommands like `pi update` or `pi list`.
 // gmux execs these directly (inheriting the tty, returning their exit code)

--- a/packages/adapter/go.mod
+++ b/packages/adapter/go.mod
@@ -2,9 +2,9 @@ module github.com/gmuxapp/gmux/packages/adapter
 
 go 1.26.1
 
-require golang.org/x/sys v0.42.0
-
 require (
-	github.com/gmuxapp/gmux/packages/paths v0.0.0-20260407104454-8824700c4612 // indirect
-	nhooyr.io/websocket v1.8.17 // indirect
+	github.com/BurntSushi/toml v1.6.0
+	github.com/gmuxapp/gmux/packages/paths v0.0.0-20260407104454-8824700c4612
+	golang.org/x/sys v0.42.0
+	nhooyr.io/websocket v1.8.17
 )

--- a/packages/adapter/go.sum
+++ b/packages/adapter/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
+github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/gmuxapp/gmux/packages/paths v0.0.0-20260407104454-8824700c4612 h1:vCzKJq/1ILsIep08LhaNlTWpNt3wnkmI60u1OA+8Jvg=
 github.com/gmuxapp/gmux/packages/paths v0.0.0-20260407104454-8824700c4612/go.mod h1:USC5rSsXTjloXV9kuxUlhYUT9YHxCFm/HGMcXhotWEA=
 golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=


### PR DESCRIPTION
**Stacked on #318** (tool-neutral hook protocol). Review/merge that first; the base retargets to `main` once #318 lands.

## What

Makes codex authoritative like pi — it reports its held conversation file + turn status over the same tool-neutral `/hook/event` protocol — instead of relying on the daemon's metadata-fallback attribution. Resolves ADR 0011's holdout: codex has grown a comparable hook (verified in codex source; pattern cross-checked against cmux/ghostex).

## How — ephemeral, per-launch CLI injection (no `~/.codex` mutation)

codex loads hooks from config, but **accepts hook definitions via per-invocation `-c` config overrides** (a `SessionFlags` layer): `hooks` is a real `ConfigToml` field and `-c key=value` parses the value as full TOML. So gmux injects on the codex argv:

```
codex \
  -c 'hooks.SessionStart=[{hooks=[{type="command",command="gmux __codex-hook SessionStart",timeout=5}]}]' \
  -c 'hooks.UserPromptSubmit=...' -c 'hooks.Stop=...' \
  -c 'hooks.state={"/<session-flags>/config.toml:session_start:0:0"={trusted_hash="sha256:…"}, …}'
```

Ephemeral and scoped to the gmux-launched process — **does not touch the user's `~/.codex`**, like pi's `-e`.

- **New seam `adapter.SessionHookCommand`** — like pi's argv splice, but the hook *program* is the gmux binary. `HookCommand(args, selfBin) (out, ok)`.
- **Hook program `gmux __codex-hook <Event>`** (hidden subcommand): reads codex's event JSON on stdin, translates to `/hook/event`, POSTs fire-and-forget, **no-ops unless `GMUX_SESSION_SOCK` is set** (inert for plain `codex`).
- **Events:** `SessionStart`→session bind, `UserPromptSubmit`→turn start, `Stop`→title refresh + turn end. Title/slug from the transcript's first user prompt (early-exit read); reports an explicit **title-derived slug** (new protocol field) since codex's `session_id` is a UUID.
- **Version-gated on codex ≥ 0.135.0**; below the floor (or if `codex --version` is unreadable) gmux launches codex unmodified and the daemon's metadata attribution + `FileMonitor` remain the fallback.

## Trust — scoped to our hooks only (no global bypass)

A CLI-injected hook is non-managed → `Untrusted`, which codex silently skips. **We deliberately do NOT use `--dangerously-bypass-hook-trust`**: that flag is *process-global* — codex applies it to every non-managed hook source (the user's own hooks, installed plugins, and project `.codex/` hooks in already-trusted directories), collapsing codex's per-hook trust layer for the whole invocation.

Instead gmux injects the exact per-hook `trusted_hash` codex itself computes (`version_for_toml` = sha256 of canonical sorted-key JSON of the normalized hook identity), keyed by codex's `hook_key`, via `-c hooks.state={…}`. codex reads hook trust state from the `SessionFlags` layer (`hook_states_from_stack`), so **only gmux's own three benign reporting hooks become Trusted; every other hook keeps codex's full trust gating.** (codex's separate *directory*-trust gate already prevents hooks from untrusted repos loading at all.)

This reproduces codex internals (hash + key formats), not a stable contract, so it can drift across codex releases. **The failure mode is safe by construction:** a mismatch leaves our hook `Untrusted` → skipped → daemon attribution takes over. It degrades; it never broadens trust.

## Not in scope

- `filemon.go` / the daemon fallback engine is untouched — still required for older codex; deletable only once a hooks-capable codex is the supported floor (ADR 0013). The paused `filemon-simplify` branch is left alone.

## Caveat

A `-c hooks.SessionStart=…` override sits in the `SessionFlags` layer, which outranks the user's *inline* `config.toml` SessionStart hooks (their separate `hooks.json` hooks still run). So a user's inline-config SessionStart/UserPromptSubmit/Stop hooks could be shadowed during gmux-launched codex only. Documented in ADR 0013.

## Docs

- `docs/adr/0013-…` (decision incl. the trust-scoping analysis + alternatives) and `docs/runner-hook-protocol.md` (the `slug` field + `SessionHookCommand` seam).

## Tests & verification

Unit tests cover: event translation; `codex --version` parsing + semver gate; the `-c` argv injection (incl. `env codex` / non-codex / no global bypass flag); **TOML-validity of every injected `-c` value through a real TOML parser**, with the `hooks.state` key asserted to equal codex's `hook_key` and its `trusted_hash` matching the injected hook; **the `trusted_hash` canonical-JSON form** (pinned); the subcommand's security-relevant **inert-without-`GMUX_SESSION_SOCK`** no-op and its happy path over a real socket; the explicit-slug runner path through the real handler. Green in all three modules; pi unchanged.

**Verification boundary (honest):** the codex-facing formats (hook config shape, `hook_key`, `version_for_toml`) are derived by reading the codex Rust source and pinned by the tests above, but are **not** integration-tested against a live codex ≥ 0.135 (not available in this env). This is exactly why the trust scheme is built to **fail safe** — any drift degrades to daemon attribution rather than misbehaving.