### PR TITLE
feat(claude): authoritative session/status via Claude Code hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ cli/gmux/gmux
 test-results/
 tests/pi-adapter/pi-adapter
 gmux gmuxd
+
+# Agent handoff/scratch docs
+.memory/

--- a/cli/gmux/cmd/gmux/claudehook.go
+++ b/cli/gmux/cmd/gmux/claudehook.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/gmuxapp/gmux/packages/adapter/adapters"
+)
+
+// claudeHook implements the hidden `gmux __claude-hook` subcommand that Claude
+// Code invokes as a command hook (injected per-launch by the claude adapter's
+// HookCommand via `--settings`). Claude writes the event payload as JSON to
+// stdin (carrying hook_event_name); we translate it to the tool-neutral
+// /hook/event protocol (docs/runner-hook-protocol.md) and POST it to the runner
+// socket named by GMUX_SESSION_SOCK.
+//
+// Fire-and-forget and always exits 0: a hook must never block or fail Claude.
+// When GMUX_SESSION_SOCK is unset the run was not launched by gmux, so the hook
+// is a no-op. It writes nothing to stdout — Claude folds a hook's stdout into
+// the model context for some events (UserPromptSubmit), so emitting anything
+// would pollute the conversation.
+func claudeHook() int {
+	runClaudeHook(os.Stdin, os.Getenv("GMUX_SESSION_SOCK"))
+	return 0
+}
+
+// runClaudeHook is the testable core. sock is the runner socket
+// (GMUX_SESSION_SOCK); when empty the hook only drains stdin and returns.
+func runClaudeHook(in io.Reader, sock string) {
+	// Drain stdin (Claude pipes the event JSON and can block on the write if we
+	// don't read it), bounded so a pathological payload can't exhaust memory.
+	input, _ := io.ReadAll(io.LimitReader(in, 1<<20))
+	if sock == "" {
+		return
+	}
+	for _, body := range adapters.ClaudeHookBodies(input) {
+		postClaudeHookEvent(sock, body)
+	}
+}
+
+// postClaudeHookEvent POSTs one event body to the runner's /hook/event over the
+// Unix socket. Best-effort with a short timeout; transport errors are swallowed
+// so the hook never surfaces a failure into Claude.
+func postClaudeHookEvent(sock string, body []byte) {
+	client := &http.Client{
+		Timeout: 2 * time.Second,
+		Transport: &http.Transport{
+			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+				return net.Dial("unix", sock)
+			},
+		},
+	}
+	resp, err := client.Post("http://unix/hook/event", "application/json", bytes.NewReader(body))
+	if err != nil {
+		return
+	}
+	resp.Body.Close()
+}

--- a/cli/gmux/cmd/gmux/claudehook_test.go
+++ b/cli/gmux/cmd/gmux/claudehook_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestParseClaudeHookCLI(t *testing.T) {
+	cmd, err := parseCLI([]string{"__claude-hook"})
+	if err != nil || cmd.mode != modeClaudeHook {
+		t.Fatalf("want modeClaudeHook, got %+v err=%v", cmd, err)
+	}
+}
+
+func TestRunClaudeHookInertWithoutSocket(t *testing.T) {
+	// No socket: must drain stdin and return without panicking.
+	runClaudeHook(strings.NewReader(`{"hook_event_name":"UserPromptSubmit"}`), "")
+}
+
+func TestRunClaudeHookPosts(t *testing.T) {
+	sock := filepath.Join(t.TempDir(), "s.sock")
+	ln, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	var mu sync.Mutex
+	var paths []string
+	done := make(chan struct{})
+	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		paths = append(paths, r.URL.Path)
+		mu.Unlock()
+		w.WriteHeader(200)
+	})}
+	go func() { srv.Serve(ln); close(done) }()
+	defer srv.Close()
+
+	runClaudeHook(strings.NewReader(`{"hook_event_name":"UserPromptSubmit"}`), sock)
+	time.Sleep(50 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(paths) != 1 || paths[0] != "/hook/event" {
+		t.Fatalf("want one POST to /hook/event, got %v", paths)
+	}
+}
+
+func TestClaudeHookExitsZero(t *testing.T) {
+	// Redirect stdin to empty so claudeHook doesn't block; it must exit 0 and
+	// (implicitly) write nothing to stdout.
+	old := os.Stdin
+	r, _, _ := os.Pipe()
+	os.Stdin = r
+	defer func() { os.Stdin = old; r.Close() }()
+	r.Close() // EOF immediately
+	if code := claudeHook(); code != 0 {
+		t.Fatalf("claudeHook must exit 0, got %d", code)
+	}
+}

--- a/cli/gmux/cmd/gmux/cli.go
+++ b/cli/gmux/cmd/gmux/cli.go
@@ -28,6 +28,7 @@ const (
 	modeRemote                // gmux remote
 	modeDumpEnv               // (internal) gmux __dump-env
 	modeCodexHook             // (internal) gmux __codex-hook <Event>
+	modeClaudeHook            // (internal) gmux __claude-hook
 )
 
 // command is the fully-parsed CLI invocation. One struct for every
@@ -181,6 +182,8 @@ func parseCLI(args []string) (*command, error) {
 			return nil, errors.New("__codex-hook requires exactly one event name")
 		}
 		return &command{mode: modeCodexHook, codexHookEvent: rest[0]}, nil
+	case "__claude-hook":
+		return &command{mode: modeClaudeHook}, nil
 	}
 
 	// Error-only migration shim (ADR 0009): recognize removed forms and

--- a/cli/gmux/cmd/gmux/main.go
+++ b/cli/gmux/cmd/gmux/main.go
@@ -62,6 +62,8 @@ func main() {
 		os.Exit(dumpEnv())
 	case modeCodexHook:
 		os.Exit(codexHook(cmd.codexHookEvent))
+	case modeClaudeHook:
+		os.Exit(claudeHook())
 	}
 }
 

--- a/docs/runner-hook-protocol.md
+++ b/docs/runner-hook-protocol.md
@@ -96,3 +96,7 @@ but `/events` replay.
   global `--dangerously-bypass-hook-trust`). Version-gated; older codex falls
   back to daemon metadata attribution, and a hash mismatch degrades to the same
   fallback rather than broadening trust.
+- **`SessionHookCommand`** (claude): Claude Code takes hooks through settings,
+  so the runner splices `--settings <inline-json>` (a `gmux __claude-hook`
+  command hook). That layer merges with the user's settings and hook arrays
+  concatenate, so gmux's hooks add to rather than clobber the user's.

--- a/packages/adapter/adapters/claude_hook.go
+++ b/packages/adapter/adapters/claude_hook.go
@@ -211,7 +211,11 @@ func ClaudeHookBodies(input []byte) [][]byte {
 	case "UserPromptSubmit":
 		return [][]byte{turn("start", "")}
 	case "Stop":
-		if b, ok := claudeSessionBody(in.TranscriptPath, in.SessionID, "activity", in.SessionTitle); ok {
+		// Stop fires only on a clean finish — Claude routes interrupts/API errors
+		// elsewhere (StopFailure, which we don't wire) — so "completed" is
+		// accurate here (unlike codex, whose Stop can't tell completion from
+		// abort). An Esc-interrupted turn stays working until the next prompt.
+		if b, ok := claudeSessionBody(in.TranscriptPath, in.SessionID, "", in.SessionTitle); ok {
 			return [][]byte{b, turn("end", "completed")} // refresh title/slug, then end the turn
 		}
 		return [][]byte{turn("end", "completed")}

--- a/packages/adapter/adapters/claude_hook.go
+++ b/packages/adapter/adapters/claude_hook.go
@@ -1,0 +1,258 @@
+package adapters
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/gmuxapp/gmux/packages/adapter"
+)
+
+// Claude reports session state authoritatively via a gmux command hook
+// (SessionHookCommand, ADR 0011/0013). Unlike codex's `-c` config override,
+// Claude Code takes hooks through settings, so we splice `--settings
+// <inline-json>` after the claude binary. Per Claude's docs that is a
+// highest-precedence-but-merged layer whose hook arrays concatenate across
+// sources, so ours add to — never clobber — the user's hooks. The injected
+// hooks run `gmux __claude-hook`, which relays an authoritative event to the
+// runner socket. The metadata FileAttributor stays as the fallback for launches
+// the hook can't cover (e.g. a shell-wrapped argv where injection is lost).
+var _ adapter.SessionHookCommand = (*Claude)(nil)
+
+// HookCommand splices `--settings <inline-json>` in right after the claude
+// binary. Any user `--settings` are folded into ours (deep-merged: arrays
+// concatenate, user scalars win, but a user value can never wipe our hook
+// arrays). Returns ok=false (args unchanged) if the binary isn't found or
+// anything fails, so the runner launches unmodified and the daemon's fallback
+// attribution applies.
+func (c *Claude) HookCommand(args []string, selfBin string) ([]string, bool) {
+	i := claudeBinaryIndex(args)
+	if i < 0 || selfBin == "" {
+		return args, false
+	}
+	tail, userSettings := extractClaudeSettings(args[i+1:])
+	settingsJSON, err := buildClaudeSettings(selfBin, userSettings)
+	if err != nil {
+		return args, false
+	}
+	out := make([]string, 0, len(args)+2)
+	out = append(out, args[:i+1]...)
+	out = append(out, "--settings", settingsJSON)
+	return append(out, tail...), true
+}
+
+// claudeBinaryIndex returns the index of the `claude` binary token in args, or
+// -1 if none appears before a `--` separator.
+func claudeBinaryIndex(args []string) int {
+	for i, arg := range args {
+		if arg == "--" {
+			return -1
+		}
+		if filepath.Base(arg) == "claude" {
+			return i
+		}
+	}
+	return -1
+}
+
+// extractClaudeSettings removes `--settings <value>` / `--settings=<value>`
+// pairs from tokens, returning the filtered tokens and the collected values.
+// Stops at a bare `--` so a positional prompt is never misread as a flag value.
+func extractClaudeSettings(tokens []string) (filtered, values []string) {
+	for i := 0; i < len(tokens); i++ {
+		tok := tokens[i]
+		if tok == "--" {
+			filtered = append(filtered, tokens[i:]...)
+			break
+		}
+		switch {
+		case tok == "--settings":
+			if i+1 < len(tokens) {
+				values = append(values, tokens[i+1])
+				i++
+			}
+		case strings.HasPrefix(tok, "--settings="):
+			values = append(values, strings.TrimPrefix(tok, "--settings="))
+		default:
+			filtered = append(filtered, tok)
+		}
+	}
+	return filtered, values
+}
+
+// buildClaudeSettings returns the inline JSON for `--settings`: gmux's session
+// hooks, with any user-provided settings deep-merged on top.
+func buildClaudeSettings(selfBin string, userSettings []string) (string, error) {
+	var base any = claudeGmuxHooks(selfBin)
+	for _, us := range userSettings {
+		if obj, ok := parseClaudeSettings(us); ok {
+			base = mergeClaudeSettings(base, obj)
+		}
+	}
+	out, err := json.Marshal(base)
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+// claudeGmuxHooks builds the gmux hook config. Each hook runs `gmux
+// __claude-hook`, which reads Claude's payload on stdin and forwards an
+// authoritative event to the runner (see cmd/gmux/claudehook.go). The command
+// is shell-interpreted by Claude, so the binary path is single-quoted.
+//
+//   - SessionStart    → bind held transcript + id + title/slug; fires on
+//     startup AND resume/clear/compact, so it rebinds on /resume.
+//   - UserPromptSubmit → turn start (working).
+//   - Stop             → rebind + turn end completed.
+//   - SessionEnd       → turn end aborted; covers Ctrl+C / exit where Stop
+//     does not fire.
+func claudeGmuxHooks(selfBin string) map[string]any {
+	cmd := shellQuote(selfBin) + " __claude-hook"
+	entry := func(timeout int) []any {
+		return []any{map[string]any{
+			"hooks": []any{map[string]any{
+				"type":    "command",
+				"command": cmd,
+				"timeout": timeout,
+			}},
+		}}
+	}
+	return map[string]any{
+		"hooks": map[string]any{
+			"SessionStart":     entry(10),
+			"UserPromptSubmit": entry(10),
+			"Stop":             entry(10),
+			"SessionEnd":       entry(5),
+		},
+	}
+}
+
+// parseClaudeSettings interprets a user `--settings` value as inline JSON
+// (starts with `{`) or a path to a JSON file.
+func parseClaudeSettings(value string) (map[string]any, bool) {
+	trimmed := strings.TrimSpace(value)
+	var data []byte
+	if strings.HasPrefix(trimmed, "{") {
+		data = []byte(trimmed)
+	} else {
+		b, err := os.ReadFile(trimmed)
+		if err != nil {
+			return nil, false
+		}
+		data = b
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return nil, false
+	}
+	return obj, true
+}
+
+// mergeClaudeSettings deep-merges over onto base. Objects merge recursively;
+// arrays concatenate (user hooks run alongside gmux's); scalars from over win.
+// A container in base is never replaced by a scalar/null in over — so a user
+// `hooks: null` or `hooks: []` cannot wipe gmux's hook arrays.
+func mergeClaudeSettings(base, over any) any {
+	bm, bMap := base.(map[string]any)
+	om, oMap := over.(map[string]any)
+	if bMap && oMap {
+		for k, ov := range om {
+			if bv, ok := bm[k]; ok {
+				bm[k] = mergeClaudeSettings(bv, ov)
+			} else {
+				bm[k] = ov
+			}
+		}
+		return bm
+	}
+	ba, bArr := base.([]any)
+	oa, oArr := over.([]any)
+	if bArr && oArr {
+		return append(ba, oa...)
+	}
+	if (bMap || bArr) && !(oMap || oArr) {
+		return base
+	}
+	return over
+}
+
+// ClaudeHookBodies translates a Claude Code hook payload (JSON on the hook's
+// stdin, carrying hook_event_name) into the runner's tool-neutral /hook/event
+// bodies (docs/runner-hook-protocol.md). Pure apart from reading the transcript
+// for the title, so it is unit-testable. Returns nil for events we don't map.
+func ClaudeHookBodies(input []byte) [][]byte {
+	var in struct {
+		HookEventName  string `json:"hook_event_name"`
+		SessionID      string `json:"session_id"`
+		TranscriptPath string `json:"transcript_path"`
+		Source         string `json:"source"`
+		SessionTitle   string `json:"session_title"`
+	}
+	if err := json.Unmarshal(input, &in); err != nil {
+		return nil
+	}
+
+	turn := func(phase, outcome string) []byte {
+		m := map[string]string{"op": "turn", "phase": phase}
+		if outcome != "" {
+			m["outcome"] = outcome
+		}
+		b, _ := json.Marshal(m)
+		return b
+	}
+
+	switch in.HookEventName {
+	case "SessionStart":
+		if b, ok := claudeSessionBody(in.TranscriptPath, in.SessionID, in.Source, in.SessionTitle); ok {
+			return [][]byte{b}
+		}
+	case "UserPromptSubmit":
+		return [][]byte{turn("start", "")}
+	case "Stop":
+		if b, ok := claudeSessionBody(in.TranscriptPath, in.SessionID, "activity", in.SessionTitle); ok {
+			return [][]byte{b, turn("end", "completed")} // refresh title/slug, then end the turn
+		}
+		return [][]byte{turn("end", "completed")}
+	case "SessionEnd":
+		return [][]byte{turn("end", "aborted")}
+	}
+	return nil
+}
+
+// claudeSessionBody builds the authoritative "session" bind body: the held
+// transcript, id, bind reason, and a human title + explicit slug (Claude's
+// session_id is a UUID that slugifies into an unreadable URL).
+func claudeSessionBody(transcriptPath, sessionID, source, sessionTitle string) ([]byte, bool) {
+	if transcriptPath == "" {
+		return nil, false
+	}
+	body := map[string]any{"op": "session", "path": transcriptPath}
+	if sessionID != "" {
+		body["id"] = sessionID
+	}
+	if source != "" {
+		body["reason"] = source
+	}
+	if title, slug := claudeTitleSlug(transcriptPath, sessionTitle); title != "" {
+		body["name"] = title
+		body["slug"] = slug
+	}
+	b, _ := json.Marshal(body)
+	return b, true
+}
+
+// claudeTitleSlug resolves the title (Claude's own session_title, else the
+// transcript-derived title) and a matching slug. Returns "","" when only a
+// placeholder is available, so the runner keeps any better title it has.
+func claudeTitleSlug(transcriptPath, sessionTitle string) (title, slug string) {
+	if t := strings.TrimSpace(sessionTitle); t != "" {
+		return t, adapter.Slugify(t)
+	}
+	info, err := NewClaude().ParseSessionFile(transcriptPath)
+	if err != nil || info == nil || info.Title == "" || info.Title == "(new)" {
+		return "", ""
+	}
+	return info.Title, info.Slug
+}

--- a/packages/adapter/adapters/claude_hook_test.go
+++ b/packages/adapter/adapters/claude_hook_test.go
@@ -1,0 +1,159 @@
+package adapters
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeClaudeTranscript writes a minimal Claude JSONL whose first user message
+// yields a known title/slug ("Hello world" → "hello-world").
+func writeClaudeTranscript(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "conv.jsonl")
+	line := `{"type":"user","sessionId":"abc","cwd":"/tmp","timestamp":"2026-01-01T00:00:00Z","message":{"role":"user","content":"Hello world"}}`
+	if err := os.WriteFile(path, []byte(line+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func decodeBodies(t *testing.T, bodies [][]byte) []map[string]any {
+	t.Helper()
+	out := make([]map[string]any, len(bodies))
+	for i, b := range bodies {
+		if err := json.Unmarshal(b, &out[i]); err != nil {
+			t.Fatalf("body %d not JSON: %v", i, err)
+		}
+	}
+	return out
+}
+
+func TestClaudeHookBodies_SessionStartBindsWithTitleSlug(t *testing.T) {
+	tr := writeClaudeTranscript(t)
+	in, _ := json.Marshal(map[string]string{
+		"hook_event_name": "SessionStart",
+		"session_id":      "uuid-1",
+		"transcript_path": tr,
+		"source":          "resume",
+	})
+	got := decodeBodies(t, ClaudeHookBodies(in))
+	if len(got) != 1 {
+		t.Fatalf("want 1 body, got %d", len(got))
+	}
+	b := got[0]
+	if b["op"] != "session" || b["path"] != tr || b["id"] != "uuid-1" || b["reason"] != "resume" {
+		t.Fatalf("bind body wrong: %v", b)
+	}
+	if b["name"] != "Hello world" || b["slug"] != "hello-world" {
+		t.Fatalf("want derived title/slug, got name=%v slug=%v", b["name"], b["slug"])
+	}
+}
+
+func TestClaudeHookBodies_SessionTitleWins(t *testing.T) {
+	tr := writeClaudeTranscript(t)
+	in, _ := json.Marshal(map[string]string{
+		"hook_event_name": "SessionStart",
+		"transcript_path": tr,
+		"session_title":   "Custom Title",
+	})
+	b := decodeBodies(t, ClaudeHookBodies(in))[0]
+	if b["name"] != "Custom Title" || b["slug"] != "custom-title" {
+		t.Fatalf("session_title should win: name=%v slug=%v", b["name"], b["slug"])
+	}
+}
+
+func TestClaudeHookBodies_TurnLifecycle(t *testing.T) {
+	start := decodeBodies(t, ClaudeHookBodies([]byte(`{"hook_event_name":"UserPromptSubmit"}`)))
+	if len(start) != 1 || start[0]["op"] != "turn" || start[0]["phase"] != "start" {
+		t.Fatalf("UserPromptSubmit → turn start, got %v", start)
+	}
+	end := decodeBodies(t, ClaudeHookBodies([]byte(`{"hook_event_name":"SessionEnd"}`)))
+	if len(end) != 1 || end[0]["phase"] != "end" || end[0]["outcome"] != "aborted" {
+		t.Fatalf("SessionEnd → turn end aborted, got %v", end)
+	}
+}
+
+func TestClaudeHookBodies_StopRefreshesThenEnds(t *testing.T) {
+	tr := writeClaudeTranscript(t)
+	in, _ := json.Marshal(map[string]string{"hook_event_name": "Stop", "transcript_path": tr})
+	got := decodeBodies(t, ClaudeHookBodies(in))
+	if len(got) != 2 || got[0]["op"] != "session" || got[1]["op"] != "turn" || got[1]["outcome"] != "completed" {
+		t.Fatalf("Stop → [session, turn end completed], got %v", got)
+	}
+}
+
+func TestClaudeHookBodies_UnknownEventNil(t *testing.T) {
+	if got := ClaudeHookBodies([]byte(`{"hook_event_name":"PreToolUse"}`)); got != nil {
+		t.Fatalf("unknown event should map to nil, got %v", got)
+	}
+}
+
+func TestClaudeHookBodies_NoTranscriptNoBind(t *testing.T) {
+	// SessionStart without a transcript path has nothing authoritative to bind.
+	if got := ClaudeHookBodies([]byte(`{"hook_event_name":"SessionStart"}`)); got != nil {
+		t.Fatalf("no transcript → no bind, got %v", got)
+	}
+}
+
+func TestClaudeHookCommand_Splices(t *testing.T) {
+	out, ok := (&Claude{}).HookCommand([]string{"claude", "--model", "opus"}, "/usr/bin/gmux")
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	// --settings is spliced right after the binary, carrying our hooks.
+	if out[0] != "claude" || out[1] != "--settings" {
+		t.Fatalf("want claude --settings ..., got %v", out[:2])
+	}
+	var settings map[string]any
+	if err := json.Unmarshal([]byte(out[2]), &settings); err != nil {
+		t.Fatalf("settings not JSON: %v", err)
+	}
+	hooks, _ := settings["hooks"].(map[string]any)
+	if _, has := hooks["SessionStart"]; !has {
+		t.Fatalf("missing SessionStart hook: %v", settings)
+	}
+	if out[len(out)-2] != "--model" || out[len(out)-1] != "opus" {
+		t.Fatalf("user args dropped: %v", out)
+	}
+}
+
+func TestClaudeHookCommand_NoBinaryNoInject(t *testing.T) {
+	args := []string{"bash", "-c", "echo hi"}
+	out, ok := (&Claude{}).HookCommand(args, "/usr/bin/gmux")
+	if ok {
+		t.Fatalf("no claude binary → ok=false, got %v", out)
+	}
+}
+
+func TestClaudeHookCommand_MergesUserSettings(t *testing.T) {
+	out, ok := (&Claude{}).HookCommand(
+		[]string{"claude", "--settings", `{"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"user"}]}]},"model":"opus"}`},
+		"/usr/bin/gmux",
+	)
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	// Exactly one --settings flag remains (the merged one).
+	n := 0
+	var merged string
+	for i, a := range out {
+		if a == "--settings" {
+			n++
+			merged = out[i+1]
+		}
+	}
+	if n != 1 {
+		t.Fatalf("want exactly one --settings, got %d: %v", n, out)
+	}
+	var s map[string]any
+	json.Unmarshal([]byte(merged), &s)
+	if s["model"] != "opus" {
+		t.Fatalf("user scalar lost: %v", s)
+	}
+	starts, _ := s["hooks"].(map[string]any)["SessionStart"].([]any)
+	if len(starts) != 2 {
+		t.Fatalf("hook arrays should concatenate (gmux + user), got %d: %v", len(starts), s)
+	}
+}

--- a/packages/adapter/adapters/claude_hook_test.go
+++ b/packages/adapter/adapters/claude_hook_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -97,6 +98,30 @@ func TestClaudeHookBodies_NoTranscriptNoBind(t *testing.T) {
 	}
 }
 
+func TestClaudeHookBodies_MalformedNil(t *testing.T) {
+	if got := ClaudeHookBodies([]byte("not json")); got != nil {
+		t.Fatalf("malformed payload → nil, got %v", got)
+	}
+}
+
+func TestClaudeHookBodies_BindsBeforeTranscriptHasContent(t *testing.T) {
+	// SessionStart can fire before the transcript is written. We still bind the
+	// held path + id authoritatively; title/slug are omitted (runner falls back
+	// to the id) and get filled in when Stop re-binds after the first turn.
+	in, _ := json.Marshal(map[string]string{
+		"hook_event_name": "SessionStart",
+		"session_id":      "uuid-2",
+		"transcript_path": filepath.Join(t.TempDir(), "missing.jsonl"),
+	})
+	b := decodeBodies(t, ClaudeHookBodies(in))[0]
+	if b["op"] != "session" || b["id"] != "uuid-2" {
+		t.Fatalf("want authoritative bind, got %v", b)
+	}
+	if _, hasName := b["name"]; hasName {
+		t.Fatalf("no title until transcript has content, got %v", b)
+	}
+}
+
 func TestClaudeHookCommand_Splices(t *testing.T) {
 	out, ok := (&Claude{}).HookCommand([]string{"claude", "--model", "opus"}, "/usr/bin/gmux")
 	if !ok {
@@ -135,7 +160,19 @@ func TestClaudeHookCommand_MergesUserSettings(t *testing.T) {
 	if !ok {
 		t.Fatal("expected ok")
 	}
-	// Exactly one --settings flag remains (the merged one).
+	s := mergedSettings(t, out)
+	if s["model"] != "opus" {
+		t.Fatalf("user scalar lost: %v", s)
+	}
+	if n := sessionStartHookCount(s); n != 2 {
+		t.Fatalf("hook arrays should concatenate (gmux + user), got %d: %v", n, s)
+	}
+}
+
+// mergedSettings asserts exactly one --settings flag survives in out and
+// returns its parsed JSON (the single combined layer Claude honors).
+func mergedSettings(t *testing.T, out []string) map[string]any {
+	t.Helper()
 	n := 0
 	var merged string
 	for i, a := range out {
@@ -148,12 +185,82 @@ func TestClaudeHookCommand_MergesUserSettings(t *testing.T) {
 		t.Fatalf("want exactly one --settings, got %d: %v", n, out)
 	}
 	var s map[string]any
-	json.Unmarshal([]byte(merged), &s)
-	if s["model"] != "opus" {
-		t.Fatalf("user scalar lost: %v", s)
+	if err := json.Unmarshal([]byte(merged), &s); err != nil {
+		t.Fatalf("merged --settings not JSON: %v", err)
 	}
-	starts, _ := s["hooks"].(map[string]any)["SessionStart"].([]any)
-	if len(starts) != 2 {
-		t.Fatalf("hook arrays should concatenate (gmux + user), got %d: %v", len(starts), s)
+	return s
+}
+
+func parseJSON(t *testing.T, s string) map[string]any {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal([]byte(s), &m); err != nil {
+		t.Fatalf("not JSON: %v", err)
+	}
+	return m
+}
+
+func sessionStartHookCount(s map[string]any) int {
+	hooks, _ := s["hooks"].(map[string]any)
+	starts, _ := hooks["SessionStart"].([]any)
+	return len(starts)
+}
+
+func TestClaudeHookCommand_MergesUserSettingsFile(t *testing.T) {
+	// A user --settings given as a *file path* (not inline JSON) must be read
+	// and merged — the branch the greptile "trimmed path" note lived in.
+	userFile := filepath.Join(t.TempDir(), "user.json")
+	if err := os.WriteFile(userFile, []byte(`{"model":"haiku","hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"user"}]}]}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	out, ok := (&Claude{}).HookCommand([]string{"claude", "--settings", userFile}, "/usr/bin/gmux")
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	s := mergedSettings(t, out)
+	if s["model"] != "haiku" {
+		t.Fatalf("settings file not read/merged: %v", s)
+	}
+	if n := sessionStartHookCount(s); n != 2 {
+		t.Fatalf("want gmux + user SessionStart hooks, got %d", n)
+	}
+}
+
+func TestClaudeHookCommand_MergesEqualsForm(t *testing.T) {
+	out, ok := (&Claude{}).HookCommand([]string{"claude", `--settings={"model":"opus"}`}, "/usr/bin/gmux")
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	if s := mergedSettings(t, out); s["model"] != "opus" {
+		t.Fatalf("--settings=<inline> not merged: %v", s)
+	}
+}
+
+func TestClaudeHookCommand_StopsAtDoubleDash(t *testing.T) {
+	// Tokens after `--` are positional and must be passed through verbatim — a
+	// `--settings` there is a prompt, not a flag to extract.
+	out, ok := (&Claude{}).HookCommand([]string{"claude", "--", "--settings", "hi"}, "/usr/bin/gmux")
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	// Our --settings is injected right after the binary; the post-`--` tokens
+	// (which include a literal "--settings hi") survive verbatim as positionals.
+	if out[1] != "--settings" || sessionStartHookCount(parseJSON(t, out[2])) != 1 {
+		t.Fatalf("gmux --settings not injected after binary: %v", out)
+	}
+	if joined := strings.Join(out, " "); !strings.HasSuffix(joined, "-- --settings hi") {
+		t.Fatalf("positional tokens after -- altered: %v", out)
+	}
+}
+
+func TestClaudeHookCommand_UserCannotWipeHooks(t *testing.T) {
+	// A user `hooks: null` must not erase gmux's hooks (our attribution would
+	// silently break). The deep-merge keeps gmux's container over a null.
+	out, ok := (&Claude{}).HookCommand([]string{"claude", "--settings", `{"hooks":null}`}, "/usr/bin/gmux")
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	if n := sessionStartHookCount(mergedSettings(t, out)); n != 1 {
+		t.Fatalf("gmux SessionStart hook must survive hooks:null, got %d", n)
 	}
 }


### PR DESCRIPTION
Makes **claude** report its held transcript + title/status authoritatively via a gmux command hook, on the same tool-neutral `/hook/event` protocol (#318) and `SessionHookCommand` seam (#319, ADR 0013) as codex. The daemon no longer attributes claude by scanning files.

Reworked from the original draft to converge on codex's interface (was abusing `SessionExtender`; now implements `SessionHookCommand`).

## How
- **Injection (`SessionHookCommand.HookCommand`)**: Claude Code takes hooks through settings, not a loader flag, so the adapter splices `--settings <inline-json>` after the `claude` binary. Per Claude's docs that layer merges with the user's settings and hook arrays **concatenate**, so gmux's hooks add to, never clobber, the user's; any user `--settings` (inline or file path) is deep-merged in, and a user `hooks: null` cannot wipe ours. Returns `ok=false` (launch unmodified → daemon fallback) if the binary isn't found.
- **Hook program**: the injected hooks run the hidden `gmux __claude-hook`, which reads Claude's payload (carrying `hook_event_name`) and POSTs an authoritative event. It writes **nothing** to stdout — Claude folds `UserPromptSubmit`/`SessionStart` hook stdout into the model context (confirmed in the hooks docs), so emitting anything would pollute the conversation (differs from codex's `{}`).
- **Events** (`adapters.ClaudeHookBodies`, mirrors `CodexHookBodies`): `SessionStart` binds the transcript with id + an **explicit slug** (claude's session id is a UUID that slugifies badly), fires on resume/clear/compact too; `UserPromptSubmit`→turn start; `Stop`→refresh + turn end completed; `SessionEnd`→turn end aborted.

## Status fidelity
Claude's `Stop` fires **only on a clean finish** (interrupts/API errors route elsewhere — `StopFailure`, which we don't wire), so `completed` is accurate — strictly better than codex, whose `Stop` can't tell completion from abort. An Esc-interrupted turn stays working until the next prompt (documented).

## Fallback
The metadata `FileAttributor` **stays** as the fallback for launches the hook can't cover (shell-wrapped argv where injection is lost) — matching codex. All fallbacks are removed together in the eventual file-monitor teardown, not piecemeal here.

## Commits
1. `feat(claude)` — the hook integration.
2. `refactor(claude)` — review-pass hardening: verified all hook payloads/`--settings` semantics against Claude Code's official docs; dropped a no-op `reason` the runner ignores; documented the fidelity characteristic; added tests for the settings-merge branches (file path, `=`-form, `--` passthrough), the **can't-wipe-gmux-hooks** invariant, malformed-payload, and bind-before-transcript-content degradation.

## Tests
`packages/adapter/adapters/claude_hook_test.go` + `cli/gmux/cmd/gmux/claudehook_test.go`. Full `packages/adapter` and `cli/gmux` (`cmd/gmux`, `ptyserver`) suites + `go vet` green.