### PR TITLE
test: deflake TestPTYServerSpinnerPreservesContent

### DIFF
--- a/cli/gmux/internal/ptyserver/ptyserver_test.go
+++ b/cli/gmux/internal/ptyserver/ptyserver_test.go
@@ -805,10 +805,7 @@ func TestPTYServerSpinnerPreservesContent(t *testing.T) {
 	}
 	defer srv.Shutdown()
 
-	// Wait for the spinner loop and completion marker.
-	time.Sleep(500 * time.Millisecond)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
 	conn, _, err := websocket.Dial(ctx, "ws://localhost/", &websocket.DialOptions{
@@ -825,11 +822,16 @@ func TestPTYServerSpinnerPreservesContent(t *testing.T) {
 	}
 	defer conn.Close(websocket.StatusNormalClosure, "")
 
+	// Read frames (snapshot first, then live data) until the marker
+	// arrives or the overall deadline expires. We must NOT abort on a
+	// per-read gap: under load the child can stall arbitrarily long
+	// between the spinner loop and the marker, and a short per-read
+	// timeout would give up before the (correctly delivered) marker
+	// shows up. The marker is never dropped from replay; the only
+	// question is whether we waited long enough to read it.
 	var got []byte
-	for i := 0; i < 10; i++ {
-		readCtx, readCancel := context.WithTimeout(ctx, 500*time.Millisecond)
-		_, data, err := conn.Read(readCtx)
-		readCancel()
+	for {
+		_, data, err := conn.Read(ctx)
 		if err != nil {
 			break
 		}


### PR DESCRIPTION
## Problem

`TestPTYServerSpinnerPreservesContent` flaked in CI ("never saw spinner-done marker in replay", PR #319 run 27904012287, passed on plain re-run).

## Root cause: test-sync bug, **not** a replay/ring-buffer bug

The `spinner-done` marker is never dropped from replay. The old read loop used a per-read 500ms timeout and `break` on the first timeout. The server takes the replay snapshot and registers the client under the same `s.mu`, so there is no snapshot/live gap — the marker always arrives, either in the snapshot or as a later live frame (the child emits it then `sleep 3`). Under CI load the child's 500-iteration spinner loop hasn't finished by the fixed `time.Sleep(500ms)`, so the marker comes as a live frame. If the child stalls >500ms between the spinner loop and the marker (CPU contention), the per-read timeout fires and `break` gives up *before* the marker arrives.

Verified by injecting a controlled stall before the marker: reproduces 5/5 with the old loop, passes 5/5 with the fix.

## Fix

Drop the fixed pre-sleep; read against a single bounded deadline (10s) and loop until the marker arrives or the deadline expires. Never abort on a per-read gap. Bounded so it fails cleanly rather than hanging; robust against arbitrary inter-frame stalls. Also drops a flat 500ms/run, so the test is much faster.

## Out of scope
`-race` surfaces an unrelated pre-existing data race in the `vt.Emulator` DSR-drain goroutine vs `Close()`; left for a separate change.