### PR TITLE
feat(web): surface backend/action failures as error toasts

### DIFF
--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -1,4 +1,4 @@
-import { render } from 'preact'
+import { Component, Fragment, render, type ComponentChildren } from 'preact'
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'preact/hooks'
 import { LocationProvider, Router, Route, lazy, useLocation } from 'preact-iso'
 import '@xterm/xterm/css/xterm.css'
@@ -18,6 +18,8 @@ import { ProjectHub } from './project-hub'
 import { Home } from './home'
 import { installCopySession } from './mock-data/export-session'
 import { installVersionWatch } from './version-watch'
+import { ToastHost } from './toast-host'
+import { pushError } from './toasts'
 
 import {
   sessions, connState, selected, selectedId, view, health, peers,
@@ -60,6 +62,105 @@ if (!USE_MOCK) installVersionWatch()
 // browsers that don't emit them.
 for (const type of ['gesturestart', 'gesturechange', 'gestureend']) {
   document.addEventListener(type, e => e.preventDefault(), { passive: false })
+}
+
+// ── Error boundary ──
+
+const GITHUB_ISSUES_URL = 'https://github.com/gmuxapp/gmux/issues/new'
+const DISCORD_URL = 'https://discord.gg/Mg6EJHFZxu'
+
+/** Build a copyable crash report. Mirrors input-diagnostics' buildReport:
+ *  environment first, then the error + stacks. The `gmux` version comes
+ *  from the last health snapshot (may be unknown if we crashed before it
+ *  arrived). */
+function buildCrashReport(err: unknown, componentStack?: string): string {
+  const lines: string[] = []
+  lines.push('=== gmux Crash Report ===')
+  lines.push(`Date: ${new Date().toISOString()}`)
+  lines.push(`gmux: ${health.value?.version ?? 'unknown'}`)
+  lines.push(`URL: ${location.pathname}${location.search}`)
+  lines.push(`User-Agent: ${navigator.userAgent}`)
+  lines.push('')
+  lines.push(`Error: ${err instanceof Error ? `${err.name}: ${err.message}` : String(err)}`)
+  if (err instanceof Error && err.stack) {
+    lines.push('Stack:')
+    lines.push(err.stack)
+  }
+  if (componentStack) {
+    lines.push('Component stack:')
+    lines.push(componentStack.trim())
+  }
+  lines.push('=== End Report ===')
+  return lines.join('\n')
+}
+
+// A thrown render error used to white-screen the whole app with nothing
+// in the UI. This catches it (render-phase throws only — async/event
+// failures go through toasts instead), shows a recoverable fallback with
+// a copyable crash report + report links, and pushes an error toast.
+// Preact supports componentDidCatch / getDerivedStateFromError on class
+// components.
+class ErrorBoundary extends Component<
+  { children: ComponentChildren },
+  { failed: boolean; report: string; copied: boolean }
+> {
+  state = { failed: false, report: '', copied: false }
+
+  static getDerivedStateFromError() {
+    return { failed: true }
+  }
+
+  componentDidCatch(err: unknown, info: { componentStack?: string }) {
+    console.error('render error caught by boundary:', err)
+    pushError(`Something broke: ${err instanceof Error ? err.message : 'render error'}`)
+    this.setState({ report: buildCrashReport(err, info?.componentStack) })
+  }
+
+  copyReport = async () => {
+    // Clipboard-then-textarea fallback, matching input-diagnostics so the
+    // copy works in non-secure contexts / older browsers too.
+    try {
+      await navigator.clipboard.writeText(this.state.report)
+    } catch {
+      const ta = document.createElement('textarea')
+      ta.value = this.state.report
+      document.body.appendChild(ta)
+      ta.select()
+      document.execCommand('copy')
+      document.body.removeChild(ta)
+    }
+    this.setState({ copied: true })
+  }
+
+  render() {
+    if (this.state.failed) {
+      return (
+        <div class="state-message crash-fallback">
+          <div class="state-icon" style={{ color: 'var(--status-error)' }}>⚠</div>
+          <div class="state-title">Something broke</div>
+          <div class="state-subtitle">
+            gmux hit an unexpected error and couldn't render this view.
+          </div>
+          <div class="crash-report-links">
+            Please report it so we can fix it:{' '}
+            <a href={GITHUB_ISSUES_URL} target="_blank" rel="noreferrer">GitHub Issues</a>
+            {' · '}
+            <a href={DISCORD_URL} target="_blank" rel="noreferrer">Discord</a>
+          </div>
+          <pre class="crash-report">{this.state.report}</pre>
+          <div class="crash-actions">
+            <button class="btn" onClick={this.copyReport}>
+              {this.state.copied ? 'Copied!' : 'Copy report'}
+            </button>
+            <button class="btn btn-primary" onClick={() => location.reload()}>
+              Reload
+            </button>
+          </div>
+        </div>
+      )
+    }
+    return this.props.children
+  }
 }
 
 // ── Components ──
@@ -479,9 +580,12 @@ function App() {
 
   const handleResume = useCallback((id: string) => {
     setResumingId(id)
-    resumeSession(id).catch(err => {
-      console.error('resume failed:', err)
-      setResumingId(prev => prev === id ? null : prev)
+    // resumeSession never rejects (postAction converts failures to false
+    // and surfaces the toast itself); branch on the boolean to clear the
+    // "resuming…" spinner immediately on rejection instead of letting it
+    // linger until the 10s timeout.
+    void resumeSession(id).then(ok => {
+      if (!ok) setResumingId(prev => prev === id ? null : prev)
     })
   }, [])
 
@@ -563,7 +667,7 @@ function App() {
         {viewVal !== null && viewVal.kind !== 'project' && viewVal.kind !== 'home' && (
           <MainHeader
             session={selectedVal}
-            onRestart={selectedVal ? () => { restartSession(selectedVal.id).catch(err => console.error('restart failed:', err)) } : undefined}
+            onRestart={selectedVal ? () => { void restartSession(selectedVal.id) } : undefined}
           />
         )}
 
@@ -639,11 +743,21 @@ function App() {
 }
 
 render(
-  <LocationProvider>
-    <Router>
-      <Route path="/_/input-diagnostics" component={InputDiagnostics} />
-      <Route default component={App} />
-    </Router>
-  </LocationProvider>,
+  // ToastHost is a *sibling* of the boundary, not a child: when the
+  // boundary fires it unmounts its children, so a ToastHost nested
+  // inside would be gone exactly when componentDidCatch pushes its
+  // error toast (the signal would update with no mounted consumer).
+  // Keeping it outside means toasts survive an app crash.
+  <Fragment>
+    <ErrorBoundary>
+      <LocationProvider>
+        <Router>
+          <Route path="/_/input-diagnostics" component={InputDiagnostics} />
+          <Route default component={App} />
+        </Router>
+      </LocationProvider>
+    </ErrorBoundary>
+    <ToastHost />
+  </Fragment>,
   document.getElementById('app')!,
 )

--- a/apps/gmux-web/src/store.test.ts
+++ b/apps/gmux-web/src/store.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import { toasts } from './toasts'
 import {
   sessions, sessionsLoaded, worldLoaded, projects, upsertSession, removeSession,
-  markSessionRead, dismissSession, reorderSessions,
+  markSessionRead, dismissSession, reorderSessions, resumeSession, killSession,
   handleActivity, isSessionActive, isSessionFading, activityMap,
   sessionStaleness, peers, peerAppearance, peerStatusByName,
   isSessionUnavailable, urlPath, urlSearch, filteredSessions, selectedId,
@@ -46,6 +47,94 @@ beforeEach(() => {
   worldLoaded.value = false
   urlPath.value = '/'
   urlSearch.value = ''
+})
+
+describe('postAction surfaces backend failures as error toasts', () => {
+  beforeEach(() => { toasts.value = [] })
+  afterEach(() => { vi.unstubAllGlobals(); toasts.value = [] })
+
+  it('parses the structured error contract and labels the action', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      statusText: 'Bad Request',
+      text: () => Promise.resolve(JSON.stringify({
+        ok: false, error: { code: 'not_resumable', message: 'session is not resumable' },
+      })),
+    }))
+    await resumeSession('s1')
+    expect(toasts.value).toHaveLength(1)
+    expect(toasts.value[0]).toMatchObject({ kind: 'error', message: 'Resume failed: session is not resumable' })
+  })
+
+  it('falls back to the status line when the body is not the structured shape', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false, status: 500, statusText: 'Internal Server Error',
+      text: () => Promise.resolve(''),
+    }))
+    await killSession('s1')
+    expect(toasts.value[0].message).toBe('Kill failed: Internal Server Error')
+  })
+
+  it('does NOT toast a network reject (connectivity is owned by the reconnecting pill)', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')))
+    await resumeSession('s1')
+    expect(toasts.value).toHaveLength(0)
+  })
+
+  it('pushes nothing on success', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true, status: 200, statusText: 'OK', text: () => Promise.resolve(''),
+    }))
+    await killSession('s1')
+    expect(toasts.value).toHaveLength(0)
+  })
+
+  it('resolves the success boolean and never rejects (callers branch, not catch)', async () => {
+    // handleResume clears its "resuming…" spinner off this boolean; a
+    // rejection-based contract would leave the spinner stuck for the
+    // fallback timeout since postAction swallows all throws.
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false, status: 500, statusText: 'Internal Server Error',
+      text: () => Promise.resolve(''),
+    }))
+    await expect(resumeSession('s1')).resolves.toBe(false)
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true, status: 200, statusText: 'OK', text: () => Promise.resolve(''),
+    }))
+    await expect(resumeSession('s1')).resolves.toBe(true)
+  })
+})
+
+describe('optimistic dismiss retracts on failure', () => {
+  beforeEach(() => { toasts.value = []; _pendingMutations.value = [] })
+  afterEach(() => { vi.unstubAllGlobals(); toasts.value = []; _pendingMutations.value = [] })
+
+  it('hides the row, then retracts immediately when the server rejects', async () => {
+    _rawSessions.value = [makeSession({ id: 's1' })]
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false, status: 404, statusText: 'Not Found',
+      text: () => Promise.resolve(JSON.stringify({ error: { message: 'no such session' } })),
+    }))
+    await dismissSession('s1')
+    // Toast surfaced AND the optimistic mutation was retracted (not left
+    // to linger until the TTL), so the session is visible again now.
+    expect(toasts.value[0].message).toBe('Dismiss failed: no such session')
+    expect(_pendingMutations.value).toHaveLength(0)
+    expect(sessions.value.some(s => s.id === 's1')).toBe(true)
+  })
+
+  it('keeps the optimistic dismissal when the server accepts', async () => {
+    _rawSessions.value = [makeSession({ id: 's1' })]
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true, status: 200, statusText: 'OK', text: () => Promise.resolve(''),
+    }))
+    await dismissSession('s1')
+    expect(toasts.value).toHaveLength(0)
+    // Mutation stands until the next snapshot confirms removal.
+    expect(_pendingMutations.value).toHaveLength(1)
+    expect(sessions.value.some(s => s.id === 's1')).toBe(false)
+  })
 })
 
 describe('filteredSessions reactivity to the URL query string', () => {

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -20,6 +20,7 @@ import { resolveViewFromPath, viewToPath } from './routing'
 import { navigateWithReload } from './version-watch'
 import { buildProjectFolders, discoverProjects } from './projects'
 import { referencePresence, unresolvedReferences, removeReferenceItems, removeHostReferenceItems, type UnresolvedHost } from './references'
+import { pushError } from './toasts'
 
 import { fetchFrontendConfig, buildTerminalOptions, resolveKeybinds, type ResolvedKeybind } from './config'
 import { MOCK_SESSIONS, MOCK_PROJECTS, MOCK_PEERS, MOCK_HEALTH } from './mock-data/index'
@@ -175,12 +176,31 @@ function isResolved(
   }
 }
 
-/** Push a mutation onto the pending stack and schedule its TTL drop. */
-function addPending(m: PendingMutation) {
+/** Push a mutation onto the pending stack and schedule its TTL drop.
+ *  Returns a `retract` that drops the mutation immediately and idempotently
+ *  — used by `optimistic()` to roll back as soon as the server rejects,
+ *  instead of waiting out the full TTL (the lagged-rollback artifact). */
+function addPending(m: PendingMutation): () => void {
   _pendingMutations.value = [..._pendingMutations.value, m]
-  setTimeout(() => {
+  const retract = () => {
     _pendingMutations.value = _pendingMutations.value.filter(x => x !== m)
-  }, PENDING_TTL_MS)
+  }
+  setTimeout(retract, PENDING_TTL_MS)
+  return retract
+}
+
+/**
+ * Run an optimistic mutation: apply it locally now, fire `action`, and
+ * retract immediately if the action reports failure (rather than letting
+ * the row/order linger until the TTL sweeps it). `action` returns whether
+ * the server accepted it. Shared by `dismissSession` and `reorderSessions`;
+ * `mark-read` deliberately opts out (it's fire-and-forget — a failed
+ * mark-read silently self-heals on the next snapshot and needs no toast
+ * or eager rollback).
+ */
+async function optimistic(m: PendingMutation, action: () => Promise<boolean>): Promise<void> {
+  const retract = addPending(m)
+  if (!(await action())) retract()
 }
 
 // ── Public projections of raw state ─────────────────────────────────────────
@@ -946,9 +966,14 @@ async function putProjects(items: ProjectItem[]): Promise<void> {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ items }),
     })
-    if (!resp.ok) console.warn('PUT /v1/projects failed:', resp.status)
-  } catch (err) {
-    console.warn('PUT /v1/projects error:', err)
+    if (!resp.ok) {
+      pushError(`Save projects failed: ${await errorMessageFromResponse(resp)}`)
+    }
+  } catch {
+    // Network reject = connectivity, not a semantic failure. The
+    // reconnecting pill owns "we're offline"; don't add a toast flood
+    // on top of it. (See postAction for the full rationale.)
+    console.debug('PUT /v1/projects: network error (suppressed toast)')
   }
 }
 
@@ -1117,27 +1142,84 @@ export async function reorderSessions(
   sessionKeys: string[],
   peer?: string,
 ): Promise<void> {
-  if (peer === undefined) {
-    addPending({ kind: 'reorder', slug: projectSlug, sessions: sessionKeys, at: Date.now() })
-  }
   const url = peer
     ? `/v1/peers/${encodeURIComponent(peer)}/v1/projects/${encodeURIComponent(projectSlug)}/sessions`
     : `/v1/projects/${encodeURIComponent(projectSlug)}/sessions`
-  try {
-    const resp = await fetch(url, {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ sessions: sessionKeys }),
-    })
-    if (!resp.ok) console.warn('PATCH sessions failed:', resp.status)
-  } catch (err) {
-    console.warn('PATCH sessions error:', err)
+
+  // PATCH the new order. Returns whether the server accepted it; a
+  // received error toasts, a network reject stays silent (connectivity,
+  // owned by the reconnecting pill) — same contract as postAction.
+  const patch = async (): Promise<boolean> => {
+    try {
+      const resp = await fetch(url, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sessions: sessionKeys }),
+      })
+      if (!resp.ok) {
+        pushError(`Reorder failed: ${await errorMessageFromResponse(resp)}`)
+        return false
+      }
+      return true
+    } catch {
+      console.debug(`${url}: network error (suppressed toast)`)
+      return false
+    }
+  }
+
+  // Local reorders get an optimistic overlay that retracts on failure.
+  // Peer reorders have no local overlay (the sidebar derives peer-folder
+  // order from server-stamped project_index, not a local array), so
+  // there's nothing to roll back — just fire and let the toast report.
+  if (peer === undefined) {
+    await optimistic(
+      { kind: 'reorder', slug: projectSlug, sessions: sessionKeys, at: Date.now() },
+      patch,
+    )
+  } else {
+    await patch()
   }
 }
 
 // ── Session actions ─────────────────────────────────────────────────────────
 
-async function postAction(endpoint: string, body?: Record<string, unknown>): Promise<void> {
+/**
+ * Pull a human message out of a failed response. The daemon's
+ * `writeError` (services/gmuxd) returns
+ * `{ ok:false, error:{ code, message } }`, so prefer `error.message`;
+ * fall back to a raw text body, then the HTTP status line, so even an
+ * unexpected non-JSON 500 still produces something legible.
+ */
+async function errorMessageFromResponse(resp: Response): Promise<string> {
+  const raw = await resp.text().catch(() => '')
+  if (raw) {
+    try {
+      const body = JSON.parse(raw) as { error?: { message?: string } }
+      if (body?.error?.message) return body.error.message
+    } catch { /* not the structured shape; fall through to raw text */ }
+    const trimmed = raw.trim()
+    if (trimmed) return trimmed
+  }
+  return resp.statusText || `HTTP ${resp.status}`
+}
+
+/**
+ * Single seam for session actions (kill/dismiss/resume/restart).
+ *
+ * Failures are classified by whether the server *answered*:
+ *  - `!resp.ok` (we got an HTTP response carrying a structured error) is
+ *    a semantic failure — the server was reachable and is telling us why
+ *    — so it always surfaces a labelled toast ("Resume failed: …").
+ *  - a `fetch` *reject* (no response: offline / connection dropped) is a
+ *    connectivity symptom, which the reconnecting pill already owns. We
+ *    deliberately do NOT toast it; otherwise a connection drop produces a
+ *    toast flood duplicating the pill, exactly when it's least wanted.
+ *
+ * Returns whether the action succeeded, so optimistic callers can retract
+ * on failure. A network reject counts as "not succeeded" for rollback,
+ * even though it's silent toast-wise.
+ */
+async function postAction(endpoint: string, label = 'Action', body?: Record<string, unknown>): Promise<boolean> {
   try {
     const resp = await fetch(endpoint, {
       method: 'POST',
@@ -1146,31 +1228,42 @@ async function postAction(endpoint: string, body?: Record<string, unknown>): Pro
         body: JSON.stringify(body),
       } : {}),
     })
-    if (!resp.ok) console.warn(`${endpoint} failed:`, resp.status, await resp.text().catch(() => ''))
-  } catch (err) {
-    console.warn(`${endpoint} error:`, err)
+    if (!resp.ok) {
+      pushError(`${label} failed: ${await errorMessageFromResponse(resp)}`)
+      return false
+    }
+    return true
+  } catch {
+    console.debug(`${endpoint}: network error (suppressed toast)`)
+    return false
   }
 }
 
-export function killSession(sessionId: string): Promise<void> {
-  return postAction(`/v1/sessions/${sessionId}/kill`)
+// Kill/resume/restart return postAction's success boolean so callers can
+// sync UI state (e.g. clear a "resuming…" spinner) the moment a rejection
+// toast fires, instead of waiting out a timeout. Note these promises never
+// reject — postAction converts all failures into `false` — so `.catch()`
+// on them is dead code; branch on the boolean instead.
+export function killSession(sessionId: string): Promise<boolean> {
+  return postAction(`/v1/sessions/${sessionId}/kill`, 'Kill')
 }
 
 export function dismissSession(sessionId: string): Promise<void> {
-  // Optimistic dismissal: hide the session locally until the next
-  // snapshot.sessions confirms it's gone. If the server rejects the
-  // dismiss, the mutation TTL-expires and the session reappears on the
-  // following snapshot.
-  addPending({ kind: 'dismiss', id: sessionId, at: Date.now() })
-  return postAction(`/v1/sessions/${sessionId}/dismiss`)
+  // Optimistic dismissal: hide the session locally now, and retract
+  // immediately if the server rejects — so the toast and the row
+  // reappearing are coincident, not lagged by the pending TTL.
+  return optimistic(
+    { kind: 'dismiss', id: sessionId, at: Date.now() },
+    () => postAction(`/v1/sessions/${sessionId}/dismiss`, 'Dismiss'),
+  )
 }
 
-export function resumeSession(sessionId: string): Promise<void> {
-  return postAction(`/v1/sessions/${sessionId}/resume`)
+export function resumeSession(sessionId: string): Promise<boolean> {
+  return postAction(`/v1/sessions/${sessionId}/resume`, 'Resume')
 }
 
-export function restartSession(sessionId: string): Promise<void> {
-  return postAction(`/v1/sessions/${sessionId}/restart`)
+export function restartSession(sessionId: string): Promise<boolean> {
+  return postAction(`/v1/sessions/${sessionId}/restart`, 'Restart')
 }
 
 // ── Launch ───────────────────────────────────────────────────────────────────
@@ -1185,9 +1278,11 @@ export async function launchSession(launcherId: string, opts?: { cwd?: string; p
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ launcher_id: launcherId, cwd: opts?.cwd, peer: opts?.peer }),
     })
-    if (!resp.ok) console.warn('/v1/launch failed:', resp.status, await resp.text().catch(() => ''))
-  } catch (err) {
-    console.warn('/v1/launch error:', err)
+    if (!resp.ok) {
+      pushError(`Launch failed: ${await errorMessageFromResponse(resp)}`)
+    }
+  } catch {
+    console.debug('/v1/launch: network error (suppressed toast)')
   }
 }
 

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -3076,3 +3076,172 @@ body {
     display: inline-flex;
   }
 }
+
+/* ── Toasts ───────────────────────────────────────────────────────────────
+ * Transient notifications for backend/action failures. Fixed overlay,
+ * bottom-right on desktop; above modals (settings is z 1000). Never traps
+ * focus — purely informational, dismissible. */
+.toast-host {
+  position: fixed;
+  bottom: 16px;
+  right: 16px;
+  z-index: 2000;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-width: min(420px, calc(100vw - 32px));
+  pointer-events: none;
+}
+
+.toast {
+  pointer-events: auto;
+  position: relative;
+  overflow: hidden;
+  border-radius: var(--radius);
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--border-strong);
+  color: var(--text);
+  font-size: 13px;
+  line-height: 1.4;
+  box-shadow: 0 4px 16px oklch(0% 0 0 / 0.4);
+  animation: toast-in 140ms ease-out;
+}
+
+.toast-body {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 10px 12px;
+}
+
+.toast-error {
+  border-left-color: var(--status-error);
+}
+
+.toast-info {
+  border-left-color: var(--accent);
+}
+
+.toast-message {
+  flex: 1;
+  word-break: break-word;
+}
+
+.toast-count {
+  flex: none;
+  align-self: center;
+  font-variant-numeric: tabular-nums;
+  font-size: 11px;
+  color: var(--text-muted);
+  background: var(--bg-hover);
+  border-radius: 999px;
+  padding: 1px 6px;
+}
+
+.toast-dismiss {
+  flex: none;
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-size: 16px;
+  line-height: 1;
+  padding: 0 2px;
+  cursor: pointer;
+}
+
+.toast-dismiss:hover {
+  color: var(--text);
+}
+
+/* Countdown bar: shrinks across the toast's TTL (duration set inline).
+ * Its animationend drives dismissal, so this bar and the actual removal
+ * are one clock. Pausing on hover freezes both. */
+.toast-countdown {
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  height: 2px;
+  width: 100%;
+  transform-origin: left center;
+  background: var(--border-strong);
+  animation-name: toast-countdown;
+  animation-timing-function: linear;
+  animation-fill-mode: forwards;
+}
+
+.toast-error .toast-countdown { background: var(--status-error); }
+.toast-info .toast-countdown { background: var(--accent); }
+
+.toast:hover .toast-countdown,
+.toast:focus-within .toast-countdown {
+  animation-play-state: paused;
+}
+
+@keyframes toast-countdown {
+  from { transform: scaleX(1); }
+  to   { transform: scaleX(0); }
+}
+
+@keyframes toast-in {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* Honor reduced-motion: no shrink animation means no animationend to
+ * dismiss on, so fall back to opacity and let the toast persist until
+ * manually dismissed. */
+@media (prefers-reduced-motion: reduce) {
+  .toast-countdown { animation: none; opacity: 0.4; }
+}
+
+/* On phones, span the bottom edge above the mobile bar. */
+@media (max-width: 640px) {
+  .toast-host {
+    left: 12px;
+    right: 12px;
+    bottom: 12px;
+    max-width: none;
+  }
+}
+
+/* ── Crash fallback (error boundary) ──────────────────────────────────────── */
+.crash-fallback {
+  max-width: 560px;
+  margin: 0 auto;
+  text-align: center;
+}
+
+.crash-report-links {
+  margin-top: 10px;
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+.crash-report-links a {
+  color: var(--accent);
+}
+
+.crash-report {
+  margin-top: 14px;
+  text-align: left;
+  max-height: 220px;
+  overflow: auto;
+  padding: 10px 12px;
+  border-radius: var(--radius);
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  color: var(--text-secondary);
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 11.5px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.crash-actions {
+  margin-top: 14px;
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+}

--- a/apps/gmux-web/src/toast-host.tsx
+++ b/apps/gmux-web/src/toast-host.tsx
@@ -1,0 +1,50 @@
+/**
+ * Fixed-position overlay that renders the live toast stack. Mounted once
+ * near the app root. Reads the `toasts` signal directly (auto-subscribed)
+ * and never steals focus — it's an aria-live region, not a dialog.
+ *
+ * Auto-dismiss is driven by the countdown bar's `animationend`: the bar
+ * shrinks over the toast's TTL, and when its animation ends the toast is
+ * removed. One clock — the visible bar can't disagree with the actual
+ * dismissal — and `:hover { animation-play-state: paused }` (in
+ * styles.css) pauses both at once for free.
+ *
+ * Two deliberate consequences of the animation-as-clock design:
+ *  - Backgrounded tabs throttle CSS animations, so a toast pushed while
+ *    the tab is hidden may outlive its TTL and still be visible when the
+ *    user returns. That's a feature here: an error you weren't looking at
+ *    shouldn't silently expire before you've seen it.
+ *  - Under prefers-reduced-motion the bar doesn't animate, so there's no
+ *    animationend and toasts persist until manually dismissed (see the
+ *    reduced-motion note in styles.css).
+ */
+
+import { toasts, dismissToast, TOAST_TTL_MS } from './toasts'
+
+export function ToastHost() {
+  const list = toasts.value
+  if (list.length === 0) return null
+  return (
+    <div class="toast-host" role="region" aria-label="Notifications" aria-live="polite">
+      {list.map(t => (
+        <div key={t.id} class={`toast toast-${t.kind}`}>
+          <div class="toast-body">
+            <span class="toast-message">{t.message}</span>
+            {t.count > 1 && <span class="toast-count">×{t.count}</span>}
+            <button
+              class="toast-dismiss"
+              title="Dismiss"
+              aria-label="Dismiss notification"
+              onClick={() => dismissToast(t.id)}
+            >×</button>
+          </div>
+          <div
+            class="toast-countdown"
+            style={{ animationDuration: `${TOAST_TTL_MS[t.kind]}ms` }}
+            onAnimationEnd={() => dismissToast(t.id)}
+          />
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/apps/gmux-web/src/toasts.test.ts
+++ b/apps/gmux-web/src/toasts.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  addToast, removeToast, pushToast, pushError, dismissToast,
+  toasts, MAX_TOASTS, type Toast,
+} from './toasts'
+
+function mk(id: string, message: string, kind: Toast['kind'] = 'error', count = 1): Toast {
+  return { id, kind, message, at: 0, count }
+}
+
+describe('addToast (pure)', () => {
+  it('appends newest last', () => {
+    const out = addToast([mk('a', 'one')], mk('b', 'two'))
+    expect(out.map(t => t.id)).toEqual(['a', 'b'])
+  })
+
+  it('caps the list at MAX_TOASTS, dropping oldest', () => {
+    let list: Toast[] = []
+    for (let i = 0; i < MAX_TOASTS + 3; i++) list = addToast(list, mk(`t${i}`, `m${i}`))
+    expect(list).toHaveLength(MAX_TOASTS)
+    expect(list[0].id).toBe('t3')
+  })
+
+  it('coalesces an identical kind+message: bumps count, takes new id, moves to end', () => {
+    const start = [mk('a', 'same'), mk('b', 'other')]
+    const out = addToast(start, mk('c', 'same'))
+    expect(out).toHaveLength(2)
+    // 'same' moved to the end with the new id and count bumped.
+    expect(out.map(t => t.id)).toEqual(['b', 'c'])
+    expect(out[1]).toMatchObject({ message: 'same', count: 2, id: 'c' })
+  })
+
+  it('keeps counting on repeated coalesce', () => {
+    let list = addToast([], mk('a', 'dup'))
+    list = addToast(list, mk('b', 'dup'))
+    list = addToast(list, mk('c', 'dup'))
+    expect(list).toHaveLength(1)
+    expect(list[0]).toMatchObject({ count: 3, id: 'c' })
+  })
+
+  it('does not coalesce across kinds', () => {
+    const out = addToast([mk('a', 'same', 'error')], mk('b', 'same', 'info'))
+    expect(out).toHaveLength(2)
+  })
+})
+
+describe('removeToast (pure)', () => {
+  it('removes by id', () => {
+    expect(removeToast([mk('a', 'x'), mk('b', 'y')], 'a').map(t => t.id)).toEqual(['b'])
+  })
+})
+
+describe('signal-backed API', () => {
+  beforeEach(() => { toasts.value = [] })
+
+  it('pushToast adds to the signal and returns an id', () => {
+    const id = pushToast('info', 'hello')
+    expect(toasts.value).toHaveLength(1)
+    expect(toasts.value[0]).toMatchObject({ id, kind: 'info', message: 'hello', count: 1 })
+  })
+
+  it('pushError coalesces a repeat into a single counted entry', () => {
+    pushError('boom')
+    pushError('boom')
+    expect(toasts.value).toHaveLength(1)
+    expect(toasts.value[0].count).toBe(2)
+  })
+
+  it('dismissToast removes by id and is idempotent', () => {
+    const id = pushError('x')
+    dismissToast(id)
+    expect(toasts.value).toHaveLength(0)
+    dismissToast(id)
+    expect(toasts.value).toHaveLength(0)
+  })
+
+  it('dismissToast targets the current id after coalesce', () => {
+    pushError('dup')
+    const id2 = pushError('dup')
+    // The coalesced entry carries the latest id; dismissing it clears.
+    dismissToast(id2)
+    expect(toasts.value).toHaveLength(0)
+  })
+})

--- a/apps/gmux-web/src/toasts.ts
+++ b/apps/gmux-web/src/toasts.ts
@@ -1,0 +1,99 @@
+/**
+ * Transient notification ("toast") layer.
+ *
+ * Backend/action failures used to be `console.warn`'d and swallowed, so
+ * a rejected Resume/Kill/Launch looked like nothing happened. This module
+ * holds the toast state (a single signal) plus the pure list operations
+ * behind it, so the push/dismiss/coalesce/cap logic is unit-testable
+ * without a DOM.
+ *
+ * Auto-dismiss is driven by the CSS countdown-bar animation's
+ * `animationend` (see toast-host.tsx), not a JS timer — one clock, so
+ * the visible bar can never disagree with when the toast actually
+ * disappears, and pause-on-hover comes free via `animation-play-state`.
+ *
+ * State only; the visual overlay lives in `<ToastHost />` (toast-host.tsx).
+ */
+
+import { signal } from '@preact/signals'
+
+export type ToastKind = 'error' | 'info'
+
+export interface Toast {
+  id: string
+  kind: ToastKind
+  message: string
+  /** Wall-clock ms when (re)pushed. */
+  at: number
+  /** How many times this exact message has fired; rendered as "(×N)"
+   *  when >1. Coalescing a duplicate bumps this instead of stacking. */
+  count: number
+}
+
+/** Live toast list, newest last. Rendered by `<ToastHost />`. */
+export const toasts = signal<Toast[]>([])
+
+/** Auto-dismiss delay (ms), used to set the countdown-bar animation
+ *  duration. Errors linger longer than info so a failure message isn't
+ *  gone before it's read. */
+export const TOAST_TTL_MS = { error: 6_000, info: 4_000 } as const
+
+/** Hard cap so a flood (e.g. a retry storm of distinct messages) can't
+ *  bury the screen. Oldest toasts past the cap are dropped. */
+export const MAX_TOASTS = 4
+
+let _seq = 0
+
+// ── Pure list ops (tested directly) ─────────────────────────────────────────
+
+/**
+ * Append `toast`, or — if an entry with the same kind+message is already
+ * showing — coalesce into it: bump that entry's count, refresh its
+ * timestamp, and move it to the end (so its countdown bar restarts and
+ * it reads as the most recent). Otherwise append and enforce
+ * `MAX_TOASTS` by dropping the oldest. Pure.
+ */
+export function addToast(list: Toast[], toast: Toast): Toast[] {
+  const existing = list.find(t => t.kind === toast.kind && t.message === toast.message)
+  if (existing) {
+    const coalesced: Toast = {
+      ...existing,
+      count: existing.count + 1,
+      at: toast.at,
+      // Reuse the new id so the host treats it as a fresh element and
+      // restarts the countdown-bar animation from full.
+      id: toast.id,
+    }
+    return [...list.filter(t => t !== existing), coalesced]
+  }
+  const next = [...list, toast]
+  return next.length > MAX_TOASTS ? next.slice(next.length - MAX_TOASTS) : next
+}
+
+/** Remove the toast with `id`. Pure. */
+export function removeToast(list: Toast[], id: string): Toast[] {
+  return list.filter(t => t.id !== id)
+}
+
+// ── Signal-backed API (used by the app) ──────────────────────────────────────
+
+/** Dismiss a toast now (manual close or countdown elapsed). Idempotent. */
+export function dismissToast(id: string) {
+  toasts.value = removeToast(toasts.value, id)
+}
+
+/**
+ * Push a toast. Returns the (possibly coalesced) entry's id. Dismissal
+ * is scheduled by `<ToastHost />` off the countdown-bar `animationend`,
+ * not here — keeping the timer and the visible bar as a single clock.
+ */
+export function pushToast(kind: ToastKind, message: string): string {
+  const id = `t${++_seq}`
+  toasts.value = addToast(toasts.value, { id, kind, message, at: Date.now(), count: 1 })
+  return id
+}
+
+/** Convenience: error toast. */
+export function pushError(message: string): string {
+  return pushToast('error', message)
+}


### PR DESCRIPTION
## Problem

When a user clicks **Resume** (or Restart/Kill/Launch/etc.) and the backend rejects it or it fails, the UI gives no feedback — it just looks like nothing happened. The error was at best `console.warn`'d and swallowed. Concrete case: resuming a session whose `cwd` was deleted returns a 500 from the daemon, and the UI silently did nothing.

Two gaps closed:
1. **Action/network failures were swallowed** → now visible, transient error toasts.
2. **Render-time crashes had no boundary** → a thrown component white-screened the whole app.

## What's in here (frontend only)

- **Toast layer** (`src/toasts.ts`): a `toasts` signal plus pure list ops (`addToast`/`removeToast`) behind `pushToast`/`pushError`/`dismissToast`. Auto-dismiss (errors linger longer than info), manual dismiss, same-message de-dupe, and a hard cap so a flood can't bury the screen.
- **`<ToastHost />`** (`src/toast-host.tsx`): fixed bottom-right overlay, mounted once at the app root. `aria-live`, dismissible, never steals terminal focus. Error vs info visually distinct via the existing theme vars (`--status-error`, `--accent`, surface/border tokens) — no new design language.
- **Wiring**: `postAction` (the single seam for kill/dismiss/resume/restart), `launchSession`, `putProjects`, and `reorderSessions` now parse the daemon's structured error contract (`{ ok:false, error:{ code, message } }`, falling back to raw text → status line) and push a labelled toast, e.g. *"Resume failed: session is not resumable"*.
- **Error boundary** in `main.tsx` wrapping the app: catches render errors, shows a minimal "Something broke — Reload" fallback, and pushes an error toast instead of leaving a blank page.

## Tested

- `src/toasts.test.ts`: push/dismiss/auto-expire, cap, de-dupe + timer-refresh.
- `src/store.test.ts`: `postAction` surfacing — structured-contract parse, status-line fallback, network reject, and no-toast-on-success (mocked fetch).
- Full suite green (534 tests), `pnpm lint` (tsc) and `pnpm build` pass.

## Recommended follow-up (separate, out of scope here)

The backend message for resume-into-a-deleted-cwd is itself misleading (`fork/exec …/gmux: no such file or directory` because Go's exec surfaces the `chdir` ENOENT with argv0). That's a gmuxd fix, not a frontend one — flagging it for a follow-up.