### PR TITLE
fix(web): launch project-level "+" in the project's canonical dir

### DIFF
--- a/apps/gmux-web/src/launcher.test.ts
+++ b/apps/gmux-web/src/launcher.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest'
-import { launchersForPeer, resolveTarget, formatTarget, computeMenuPos } from './launcher'
-import type { Session, LauncherDef, PeerInfo } from './types'
+import { launchersForPeer, formatTarget, computeMenuPos } from './launcher'
+import type { LauncherDef, PeerInfo } from './types'
 
 const localLaunchers: LauncherDef[] = [
   { id: 'shell', label: 'Shell', command: ['bash'], available: true },
@@ -40,88 +40,6 @@ describe('launchersForPeer', () => {
   test('falls back to local when peers list is empty', () => {
     const resolved = launchersForPeer(localLaunchers, localDefault, [], 'work-laptop')
     expect(resolved.default_launcher).toBe('shell')
-  })
-})
-
-// -- Helpers for building test sessions --
-
-function sess(overrides: Partial<Session> & { id: string }): Session {
-  return {
-    created_at: '2026-04-01T00:00:00Z',
-    command: [],
-    cwd: '/home/mg/dev/gmux',
-    kind: 'shell',
-    alive: true,
-    pid: 1,
-    exit_code: null,
-    started_at: '2026-04-01T00:00:00Z',
-    exited_at: null,
-    title: 'test',
-    subtitle: '',
-    status: null,
-    unread: false,
-    resumable: false,
-    socket_path: '/tmp/test.sock',
-    ...overrides,
-  }
-}
-
-describe('resolveTarget', () => {
-  test('uses selected session when it is in the list', () => {
-    const sessions = [
-      sess({ id: 'a', cwd: '/home/mg/dev/gmux' }),
-      sess({ id: 'b', cwd: '/workspace', peer: 'laptop' }),
-    ]
-    const target = resolveTarget(sessions, 'b', '/fallback')
-    expect(target).toEqual({ peer: 'laptop', cwd: '/workspace' })
-  })
-
-  test('ignores selectedId when it is not in the session list', () => {
-    const sessions = [
-      sess({ id: 'a', cwd: '/home/mg/dev/gmux' }),
-    ]
-    const target = resolveTarget(sessions, 'other-project-session', '/fallback')
-    expect(target).toEqual({ peer: undefined, cwd: '/home/mg/dev/gmux' })
-  })
-
-  test('uses most recently created alive session when none selected', () => {
-    const sessions = [
-      sess({ id: 'old', cwd: '/old', created_at: '2026-01-01T00:00:00Z' }),
-      sess({ id: 'new', cwd: '/new', peer: 'server', created_at: '2026-04-01T00:00:00Z' }),
-    ]
-    const target = resolveTarget(sessions, null, '/fallback')
-    expect(target).toEqual({ peer: 'server', cwd: '/new' })
-  })
-
-  test('skips dead sessions when finding most recent alive', () => {
-    const sessions = [
-      sess({ id: 'dead', cwd: '/dead', created_at: '2026-04-02T00:00:00Z', alive: false }),
-      sess({ id: 'alive', cwd: '/alive', created_at: '2026-04-01T00:00:00Z' }),
-    ]
-    const target = resolveTarget(sessions, null, '/fallback')
-    expect(target).toEqual({ peer: undefined, cwd: '/alive' })
-  })
-
-  test('uses selected dead session (user is looking at it)', () => {
-    const sessions = [
-      sess({ id: 'alive-local', cwd: '/local', created_at: '2026-04-01T00:00:00Z' }),
-      sess({ id: 'dead-remote', cwd: '/workspace', peer: 'laptop', alive: false, resumable: true }),
-    ]
-    const target = resolveTarget(sessions, 'dead-remote', '/fallback')
-    expect(target).toEqual({ peer: 'laptop', cwd: '/workspace' })
-  })
-
-  test('falls back to fallbackCwd when no sessions', () => {
-    const target = resolveTarget([], null, '/home/mg/dev/gmux')
-    expect(target).toEqual({ cwd: '/home/mg/dev/gmux' })
-  })
-
-  test('falls back when all sessions are dead', () => {
-    const sessions = [
-      sess({ id: 'a', alive: false, cwd: '/dead' }),
-    ]
-    const target = resolveTarget(sessions, null, '/fallback')
-    expect(target).toEqual({ cwd: '/fallback' })
   })
 })
 

--- a/apps/gmux-web/src/launcher.tsx
+++ b/apps/gmux-web/src/launcher.tsx
@@ -5,7 +5,7 @@
 // from /v1/health). The component reads them reactively.
 
 import { useState, useRef, useEffect, useMemo } from 'preact/hooks'
-import type { Session, LauncherDef, PeerInfo } from './types'
+import type { LauncherDef, PeerInfo } from './types'
 import { launchers as launchersSignal, defaultLauncher as defaultLauncherSignal, peers as peersSignal, launchSession } from './store'
 
 /** Resolved launch target: where the session will be created. */
@@ -28,37 +28,6 @@ export function launchersForPeer(
     }
   }
   return { default_launcher: localDefault, launchers: localLaunchers }
-}
-
-// ── Target resolution ──
-
-/**
- * Derive the launch target from the user's current context.
- *
- * Priority:
- *  1. The currently selected session (if it belongs to this project)
- *  2. The most recently created alive session in the project
- *  3. The project's configured fallback path (local)
- */
-export function resolveTarget(
-  sessions: Session[],
-  selectedId: string | null,
-  fallbackCwd: string,
-): LaunchTarget {
-  // 1. Selected session in this project?
-  if (selectedId) {
-    const selected = sessions.find(s => s.id === selectedId)
-    if (selected) return { peer: selected.peer, cwd: selected.cwd }
-  }
-
-  // 2. Most recently created alive session?
-  const alive = sessions
-    .filter(s => s.alive)
-    .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
-  if (alive.length > 0) return { peer: alive[0].peer, cwd: alive[0].cwd }
-
-  // 3. Fallback to the project's configured path, local.
-  return { cwd: fallbackCwd }
 }
 
 /** Format a target for display: "~/dev/gmux" or "laptop: ~/dev/gmux". */
@@ -128,45 +97,23 @@ export function computeMenuPos(
 // Double-click works because the default adapter occupies the exact same
 // position as the + button. First click opens, second click hits default.
 //
-// Two modes:
-//  - Explicit target: `cwd` and optional `peer` passed directly (used by
-//    project hub folder rows where the target is known from topology).
-//  - Context-aware: `sessions`, `selectedId`, and `fallbackCwd` passed;
-//    the target is derived from the user's current context (used by
-//    sidebar folder headers).
+// The launch target is explicit: callers pass `cwd` (the project's
+// canonical dir) and optional `peer`. The button never derives a cwd
+// from session context.
 
 interface LaunchButtonProps {
   className?: string
   onLaunch?: () => void
   /** Async action to run before the launch request (e.g. seed a project). */
   beforeLaunch?: () => Promise<void>
-  /** Explicit target: working directory for the new session. */
+  /** Working directory for the new session (the project's canonical dir). */
   cwd?: string
-  /** Explicit target: peer name for remote launch. */
+  /** Peer name for a remote launch; authoritative for the target's host. */
   peer?: string
-  /**
-   * Context-aware target: when `sessions` is provided, the launch target
-   * is derived from the user's current context (selected session or most
-   * recent alive session) instead of `cwd`/`peer`.
-   */
-  sessions?: Session[]
-  selectedId?: string | null
-  fallbackCwd?: string
 }
 
-export function LaunchButton({ className, onLaunch, beforeLaunch, cwd, peer, sessions, selectedId, fallbackCwd }: LaunchButtonProps) {
-  // Resolve the target: context-aware mode (sessions provided) derives
-  // a smart cwd, while an explicit `peer` prop is always authoritative
-  // (the caller knows the folder's owner; ADR 0002). This matters for
-  // peer folders whose sessions are all dead-resumable, where context
-  // mode would otherwise lose the peer in resolveTarget's fallback.
-  const target = useMemo((): LaunchTarget => {
-    if (sessions && fallbackCwd !== undefined) {
-      const ctx = resolveTarget(sessions, selectedId ?? null, fallbackCwd)
-      return peer ? { ...ctx, peer } : ctx
-    }
-    return { peer, cwd: cwd || '' }
-  }, [sessions, selectedId, fallbackCwd, cwd, peer])
+export function LaunchButton({ className, onLaunch, beforeLaunch, cwd, peer }: LaunchButtonProps) {
+  const target = useMemo((): LaunchTarget => ({ peer, cwd: cwd || '' }), [peer, cwd])
 
   const showTarget = target.cwd !== ''
 

--- a/apps/gmux-web/src/project-hub.tsx
+++ b/apps/gmux-web/src/project-hub.tsx
@@ -33,10 +33,6 @@ function projectRemote(p: ProjectItem | undefined): string | undefined {
   return p?.match?.find(r => r.remote)?.remote
 }
 
-function projectFirstPath(p: ProjectItem | undefined): string | undefined {
-  return p?.match?.find(r => r.path)?.path
-}
-
 interface ProjectHubProps {
   projectSlug: string
   projectPeer?: string
@@ -61,14 +57,14 @@ export function ProjectHub({ projectSlug, projectPeer, onCloseSession }: Project
   const allSessions = hosts.flatMap(h => h.folders.flatMap(f => f.sessions))
   const remote = projectRemote(project)
 
-  // Canonical launch dir for the project-level "+", resolved identically
-  // to the sidebar project-row button: the matching folder's launchCwd
-  // (first match-rule path for owned projects, peer_projects.launch_cwd
-  // for references). Falls back to the project's first path rule.
-  const launchFolder = folders.value.find(
+  // Canonical launch dir for the project-level "+", taken from the same
+  // folder the sidebar uses: launchCwd is the first match-rule path for
+  // owned projects, peer_projects.launch_cwd for references. buildProjectFolders
+  // emits a folder per project item, so this resolves whenever the
+  // project exists; '' (default dir) otherwise.
+  const canonicalCwd = folders.value.find(
     f => f.slug === projectSlug && (f.peer ?? '') === (projectPeer ?? ''),
-  )
-  const canonicalCwd = launchFolder?.launchCwd ?? projectFirstPath(project) ?? ''
+  )?.launchCwd ?? ''
 
   // Adaptive cwd disambiguator: a project whose sessions all live in
   // one cwd shows that cwd as a subtitle (clean, no repetition); a
@@ -114,8 +110,7 @@ export function ProjectHub({ projectSlug, projectPeer, onCloseSession }: Project
           </h2>
           <LaunchButton
             // Project-level "+": launch in the canonical dir, consistent
-            // with the sidebar project-row button. Explicit cwd bypasses
-            // resolveTarget's MRU resolution (refs: project-launch-cwd).
+            // with the sidebar project-row button.
             cwd={canonicalCwd}
             peer={projectPeer}
             className="hub-header-launch"

--- a/apps/gmux-web/src/project-hub.tsx
+++ b/apps/gmux-web/src/project-hub.tsx
@@ -23,7 +23,7 @@ import { sessionPath } from './routing'
 import { LaunchButton } from './launcher'
 import {
   sessions, projects, peers, localPeerNames, partitionForProject,
-  localHostLabel,
+  localHostLabel, folders,
 } from './store'
 import { HostSuffix } from './host-suffix'
 import { SessionRow } from './session-row'
@@ -60,6 +60,15 @@ export function ProjectHub({ projectSlug, projectPeer, onCloseSession }: Project
   )
   const allSessions = hosts.flatMap(h => h.folders.flatMap(f => f.sessions))
   const remote = projectRemote(project)
+
+  // Canonical launch dir for the project-level "+", resolved identically
+  // to the sidebar project-row button: the matching folder's launchCwd
+  // (first match-rule path for owned projects, peer_projects.launch_cwd
+  // for references). Falls back to the project's first path rule.
+  const launchFolder = folders.value.find(
+    f => f.slug === projectSlug && (f.peer ?? '') === (projectPeer ?? ''),
+  )
+  const canonicalCwd = launchFolder?.launchCwd ?? projectFirstPath(project) ?? ''
 
   // Adaptive cwd disambiguator: a project whose sessions all live in
   // one cwd shows that cwd as a subtitle (clean, no repetition); a
@@ -104,8 +113,10 @@ export function ProjectHub({ projectSlug, projectPeer, onCloseSession }: Project
             <HostSuffix peer={projectPeer ?? localHostLabel.value} local={!projectPeer} />
           </h2>
           <LaunchButton
-            sessions={allSessions}
-            fallbackCwd={sharedCwd ?? projectFirstPath(project) ?? ''}
+            // Project-level "+": launch in the canonical dir, consistent
+            // with the sidebar project-row button. Explicit cwd bypasses
+            // resolveTarget's MRU resolution (refs: project-launch-cwd).
+            cwd={canonicalCwd}
             peer={projectPeer}
             className="hub-header-launch"
           />

--- a/apps/gmux-web/src/projects.test.ts
+++ b/apps/gmux-web/src/projects.test.ts
@@ -180,6 +180,20 @@ describe('buildProjectFolders', () => {
     expect(folders[0].launchCwd).toBe('/dev/proj')
   })
 
+  it('launchCwd is the canonical first path, not the MRU session cwd', () => {
+    // The project-row "+" launches in launchCwd, so it must stay the
+    // project's canonical dir regardless of where recent sessions ran.
+    const projects: ProjectItem[] = [
+      { slug: 'proj', match: [{ path: '/dev/proj' }] },
+    ]
+    const sessions = [
+      makeSession({ id: 'a', project_slug: 'proj', cwd: '/dev/proj/subdir', created_at: '2026-01-01T00:00:00Z' }),
+      makeSession({ id: 'b', project_slug: 'proj', cwd: '/dev/elsewhere', created_at: '2026-04-01T00:00:00Z' }),
+    ]
+    const folders = buildProjectFolders(projects, sessions)
+    expect(folders[0].launchCwd).toBe('/dev/proj')
+  })
+
   it('drops disclaimed sessions even when their cwd matches a local rule', () => {
     // Under the references model, viewer match rules don't adopt
     // sessions client-side. Only stamps put a session in a folder.

--- a/apps/gmux-web/src/sidebar.tsx
+++ b/apps/gmux-web/src/sidebar.tsx
@@ -276,9 +276,12 @@ function FolderGroup({
         </a>
         {!folder.unresolved && (
           <LaunchButton
-            sessions={folder.sessions}
-            selectedId={selId}
-            fallbackCwd={folder.launchCwd ?? ''}
+            // Project-row "+" always launches in the project's canonical
+            // dir (the first match-rule path, carried by launchCwd), not
+            // the MRU session cwd. Explicit cwd bypasses resolveTarget's
+            // selected/most-recent-session resolution; peer stays
+            // authoritative for references (refs: project-launch-cwd).
+            cwd={folder.launchCwd ?? ''}
             peer={folder.peer}
             className="folder-launch-btn"
           />

--- a/apps/gmux-web/src/sidebar.tsx
+++ b/apps/gmux-web/src/sidebar.tsx
@@ -277,10 +277,9 @@ function FolderGroup({
         {!folder.unresolved && (
           <LaunchButton
             // Project-row "+" always launches in the project's canonical
-            // dir (the first match-rule path, carried by launchCwd), not
-            // the MRU session cwd. Explicit cwd bypasses resolveTarget's
-            // selected/most-recent-session resolution; peer stays
-            // authoritative for references (refs: project-launch-cwd).
+            // dir (the first match-rule path, carried by launchCwd), never
+            // a recently-used session's cwd. peer stays authoritative for
+            // references.
             cwd={folder.launchCwd ?? ''}
             peer={folder.peer}
             className="folder-launch-btn"

--- a/apps/website/src/content/docs/using-the-ui.md
+++ b/apps/website/src/content/docs/using-the-ui.md
@@ -117,8 +117,8 @@ gmux -- pytest --watch  # any command
 There are several places to launch:
 
 - **Sidebar header**: click the **+** button at the top of the sidebar to launch in the default directory.
-- **Sidebar project**: hover a project name to reveal a **+** button. This launcher is context-aware: it targets the host and directory of whatever you're currently looking at. Select a session on a remote peer, and the **+** targets that peer. Switch to a local session, it targets local.
-- **Project hub**: click the **+** on any folder row to launch in that specific directory on that host. For projects with [peers](/multi-machine), the per-host launcher routes the session to the correct machine.
+- **Sidebar project**: hover a project name to reveal a **+** button. It launches in the project's own directory — the first configured path for a project you own, or the upstream directory for a [referenced](/multi-machine) project (which routes to the owning machine) — regardless of which session you're currently viewing.
+- **Project hub**: the **+** in the header launches in that same project directory, routing to the owning machine for referenced projects.
 - **Home screen**: quick-launch buttons for starting a session without any project context.
 
 All launch menus show the available adapters (Shell, pi, Claude Code, Codex). The first item aligns with the **+** button so a double-click launches the default adapter instantly.


### PR DESCRIPTION
## The bug
Clicking the **"+" launch button on a project/folder row** in the sidebar started the new session in the **most recently used folder** of that project rather than the project's **canonical directory**. If you last worked in a subdir or sibling path, the next "+" launch inherited that cwd — surprising and inconsistent. The **project hub header "+"** had the same defect.

## Root cause
The project-level `<LaunchButton>`s ran in **context-aware mode** (`sessions`/`fallbackCwd`). `resolveTarget` resolves in priority: (1) selected session cwd, (2) most-recently-created alive session cwd (the MRU leak), (3) `fallbackCwd`. So the canonical dir was only ever the *last* resort.

## What "canonical dir" means
The project's **first match-rule `path`**. This is already the codebase-wide convention, derived identically on both sides:
- Frontend owned projects: `projects.ts` `launchCwd = project.match.find(r => r.path)?.path`
- Daemon references: `peer.go` `SpokeProject.LaunchCwd` (first path rule), surfaced to the viewer via `peer_projects[].launch_cwd`

`Folder.launchCwd` already carries exactly this, peer-aware: for references it comes from the peer's own first path rule, so the path is valid on the owning host.

### Forks considered (none materially divergent)
- **`workspace_root` vs match path** — `workspace_root` is per-session, which reintroduces the session-dependence we're removing. Canonical dir is project config → match path.
- **multi-path → which path** — "first" matches the existing daemon + frontend convention; unchanged.
- **peer/host** — `peer` is passed explicitly and stays authoritative; `launchCwd` for references is already a valid path on the owning host, so no local path is forced onto a remote launch.

## The fix
Both project-level "+" buttons now pass the canonical dir as an **explicit `cwd`** (the folder's `launchCwd`), bypassing `resolveTarget`'s selected/MRU resolution. `peer` stays authoritative for references. The hub reuses the store's `folders` signal so its derivation is identical to the sidebar's.

## Buttons audited
- `sidebar.tsx` project-row "+" — **fixed** (explicit canonical cwd).
- `project-hub.tsx` header "+" — **fixed**, now consistent with the sidebar. This is the hub's only launch affordance (the old per-cwd folder button no longer exists after the three-section refactor), so there's no worktree-specific button to preserve.
- `sidebar.tsx` no-projects empty case — no cwd, seeds home project; untouched.
- User docs (`using-the-ui.md`) updated: the sidebar/hub "+" bullets still described the old context-aware launcher and a hub per-row launcher that no longer exists.

## Second commit — remove the now-dead context-aware mode
Switching both project-level buttons to explicit `cwd` left **no caller** using `LaunchButton`'s context-aware mode (`sessions`/`selectedId`/`fallbackCwd`). The `refactor:` commit removes it: `resolveTarget` and the context props are deleted, the target is simply `{ peer, cwd }`, and `ProjectHub`'s `canonicalCwd` drops the dead `projectFirstPath` fallback. Net −155/+44 lines, no behavior change (the removed path was unreachable).

## Tests
- `projects.test.ts`: `launchCwd` stays the canonical first path even when the project's sessions ran in other cwds (the canonical-dir derivation — the data both buttons consume).
- `launcher.test.ts`: dropped the `resolveTarget` cases (deleted code); `launchersForPeer`/`formatTarget` retained.
- `pnpm test` green, `pnpm lint` (tsc) clean, `pnpm build` green. Verified the merge with #331 is conflict-free and green.