### PR TITLE
fix(pi): first-user-message title in the extension; drop the (new) sentinel

### DIFF
--- a/cli/gmux/internal/agentext/pi-ext.mjs
+++ b/cli/gmux/internal/agentext/pi-ext.mjs
@@ -15,6 +15,13 @@
 //   { op: "session", path, id, name, cwd, reason }      on bind (session_start)
 //   { op: "turn", phase: "start" }                       on agent loop start
 //   { op: "turn", phase: "end", outcome, title }         on agent loop end
+//
+// `name`/`title` is pi's session name when it has one; until pi titles the
+// conversation we fall back to its first user message (truncated), so a working
+// session is identifiable by what it's about rather than a bare cwd. This
+// mirrors what codex/claude hooks already report; per ADR 0015 the translation
+// from pi's events to the gmux protocol lives here, at the typed-access point.
+//
 // outcome is pi's terminal state normalized to a stable vocabulary
 // ("completed" | "aborted" | "error"); the runner owns what each means for the
 // sidebar (e.g. completed → unread). The extension reports pi facts, not gmux
@@ -32,6 +39,11 @@ export default function (pi) {
   const sock = process.env.GMUX_SESSION_SOCK;
   if (!sock) return; // not launched by gmux → no-op
 
+  // First user message of the bound conversation, captured once and used as the
+  // title until pi names the session. Reset on every bind (a switch/resume/fork
+  // is a different conversation whose previous fallback no longer applies).
+  let firstUserTitle = "";
+
   // --- session identity: which conversation pi is bound to ----------------
   // getSessionFile() is the resolved absolute path of the active conversation,
   // or undefined for a brand-new session whose file isn't written yet (the
@@ -48,7 +60,8 @@ export default function (pi) {
       return;
     }
     if (!file) return; // nothing to attribute yet
-    post(sock, { op: "session", path: String(file), id, name, cwd, reason });
+    const title = name || firstUserTitle;
+    post(sock, { op: "session", path: String(file), id, name: title || undefined, cwd, reason });
   }
 
   // session_start is the one authoritative bind event: pi fires it on startup
@@ -56,7 +69,10 @@ export default function (pi) {
   // the old session), carrying the new file and a reason of
   // startup | new | resume | fork. This is what catches a cache-served
   // /resume-select, where no file is read for an fs probe to observe.
-  pi.on("session_start", (ev, ctx) => reportSession(ev?.reason ?? "start", ctx));
+  pi.on("session_start", (ev, ctx) => {
+    firstUserTitle = ""; // new bind → forget the previous conversation's fallback
+    reportSession(ev?.reason ?? "start", ctx);
+  });
 
   // --- turn lifecycle: drive the sidebar busy/idle without parsing the file -
   // pi's agent loop bounds map onto the sidebar's working/idle; agent_end
@@ -65,12 +81,23 @@ export default function (pi) {
   pi.on("agent_start", () => post(sock, { op: "turn", phase: "start" }));
 
   pi.on("agent_end", (ev, ctx) => {
-    let stopReason;
     const msgs = ev.messages ?? [];
+    let stopReason;
     for (let i = msgs.length - 1; i >= 0; i--) {
       if (msgs[i]?.role === "assistant") {
         stopReason = msgs[i].stopReason;
         break;
+      }
+    }
+    // Capture the first user message once, as the title fallback until pi names
+    // the session. ev.messages on the first turn carries the opening prompt.
+    if (!firstUserTitle) {
+      for (const m of msgs) {
+        const t = extractUserText(m);
+        if (t) {
+          firstUserTitle = truncateTitle(t);
+          break;
+        }
       }
     }
     let name;
@@ -83,10 +110,41 @@ export default function (pi) {
     //   else  → aborted   (user Esc, or any other non-completion)
     const outcome =
       stopReason === "stop" ? "completed" : stopReason === "error" ? "error" : "aborted";
-    post(sock, { op: "turn", phase: "end", outcome, title: name || undefined });
+    const title = name || firstUserTitle;
+    post(sock, { op: "turn", phase: "end", outcome, title: title || undefined });
     // A brand-new session's file exists by now; make sure it's attributed.
     reportSession("activity", ctx);
   });
+}
+
+// extractUserText pulls the text of a pi user message. content is either a
+// plain string or an array of typed blocks; mirrors pi.go's extractFirstUserText.
+function extractUserText(msg) {
+  if (!msg || msg.role !== "user") return "";
+  const c = msg.content;
+  if (typeof c === "string") return c;
+  if (Array.isArray(c)) {
+    for (const b of c) {
+      if (b && b.type === "text" && b.text) return b.text;
+    }
+  }
+  return "";
+}
+
+// truncateTitle collapses whitespace and caps length at a word boundary, with
+// an ellipsis. Mirrors pi.go's truncateTitle (maxLen 80) so the live title and
+// the one ParseSessionFile recovers after a restart agree. Go measures length
+// in UTF-8 bytes, so we operate on bytes too (JS string length is UTF-16 code
+// units, which would diverge for non-ASCII prompts near the boundary).
+function truncateTitle(s) {
+  s = s.replace(/\s+/g, " ").trim();
+  const maxLen = 80;
+  const bytes = Buffer.from(s, "utf8");
+  if (bytes.length <= maxLen) return s;
+  // Go: strings.LastIndex(s[:maxLen], " ") — last space byte within the cap.
+  let cut = bytes.lastIndexOf(0x20, maxLen - 1);
+  if (cut < maxLen / 2) cut = maxLen;
+  return bytes.subarray(0, cut).toString("utf8") + "…";
 }
 
 function post(socketPath, event) {

--- a/docs/adr/0015-hook-translation-at-the-agent-side.md
+++ b/docs/adr/0015-hook-translation-at-the-agent-side.md
@@ -1,0 +1,86 @@
+# ADR 0015: Tool-event translation lives at the agent-side hook, not the runner
+
+**Status:** Accepted
+**Date:** 2026-06-23
+**Related:** ADR 0011 (runner-owned session state), ADR 0013 (codex hooks),
+`docs/runner-hook-protocol.md`
+
+## Context
+
+A recurring question when extending or debugging the hook path: should the
+agent-side hook/extension be a **dumb forwarder** that posts the tool's *raw*
+native events, leaving the gmux adapter (in the runner) to parse them into gmux
+state? On its face that sounds like the cleaner "all tool-specific knowledge in
+the adapter" split, and it reads as the natural end of ADR 0011's "adapter logic
+in one place."
+
+It is the wrong split, and this ADR records why so the question doesn't get
+relitigated.
+
+The three "hooks" are not the same kind of thing:
+
+- **pi** — `agentext/pi-ext.mjs`, **JavaScript**, runs *inside* the pi process
+  with first-class typed access to pi's API (`pi.on("agent_end")`,
+  `ev.messages`, `ctx.sessionManager.getSessionName()`). It reaches the runner
+  as JSON over a unix socket.
+- **codex** — `gmux __codex-hook`, **the gmux Go binary** as a subcommand; codex
+  pipes event JSON to its stdin.
+- **claude** — `claude_hook.go`, **Go, already in the adapter package**.
+
+So for codex and claude the translation is *already* adapter code, in Go,
+sharing the adapter's types. There is nothing to move. The only odd one out is
+pi, and it is JS because pi's extension API is JS — the translation lives at the
+one place with typed access to pi's events.
+
+## Decision
+
+**Translate to gmux's stable hook protocol at the point of typed access to the
+tool's native events; keep the runner tool-neutral.**
+
+- The agent-side hook/extension is the adapter's **agent-side translation
+  surface**, written in whatever language the tool dictates (JS for pi's
+  extension; Go for codex/claude, where it lives in the adapter package).
+- It emits the small, stable `{op:"session"|"turn"}` contract in
+  `docs/runner-hook-protocol.md`. The runner's `handleHookEvent` stays
+  tool-neutral and makes no per-adapter assumptions (ADR 0011).
+- The runner does **not** receive raw tool events and does **not** dispatch them
+  back into per-adapter parsers.
+
+## Rationale
+
+The hook→runner boundary is JSON across a process *and* language boundary
+(JS↔Go for pi). No end-to-end type safety is achievable there regardless of
+where translation sits. The only lever is **how wide** the untyped boundary is:
+
+- **Translate at the source (chosen):** the untyped wire carries gmux's own
+  small, stable protocol. The tool's churny, version-specific internal event
+  shapes stay on the tool's side; the hook absorbs that churn.
+- **Forward raw (rejected):** the untyped wire now carries the tool's *entire
+  internal event model*, and the Go adapter re-parses version-specific shapes it
+  cannot type — widening the untyped surface and coupling the adapter to tool
+  internals.
+
+So translating at the agent side is not a compromise forced by language
+mismatch; it is the design that *minimizes* the untyped blast radius and the
+adapter's coupling to tool internals.
+
+## Consequences
+
+- The extension/hook stays a thin, stable forwarder of a small contract; tool
+  version churn is absorbed where the events are typed, not propagated across
+  the wire into Go.
+- `handleHookEvent` remains tool-neutral — adding an agent means writing its
+  agent-side translator, not branching the runner.
+- pi's title derivation (first user message until pi names the session) belongs
+  in `pi-ext.mjs`, mirroring what the codex/claude Go hooks already do — not in
+  the runner or daemon, and not via raw-event forwarding.
+
+## Alternatives considered
+
+- **Dumb hooks + raw-event forwarding, adapter parses in the runner.** Rejected:
+  widens the untyped boundary to the tool's whole internal event model and
+  couples the Go adapter to tool internals, for no type-safety gain (the
+  boundary is untyped JSON either way). See Rationale.
+- **A shared, generated protocol schema across JS and Go.** Possible future
+  hardening for the `{op}` contract, but the contract is small and stable; not
+  worth the build machinery now.

--- a/docs/runner-hook-protocol.md
+++ b/docs/runner-hook-protocol.md
@@ -14,6 +14,16 @@ runner only **relays** these facts; the one bit of state it keeps is a snapshot
 replayed to `/events` (so a restarted daemon re-learns attribution), never used
 to guess.
 
+**The hook is the adapter's agent-side translation surface** (ADR 0015). It
+translates the tool's *native* events into the `{op}` contract below, in
+whatever language the tool dictates — JS in pi's extension (typed access to
+pi's API), Go for codex/claude (in the adapter package). It does **not** forward
+raw tool events for the runner to parse: translating at the typed-access point
+keeps this wire a small, stable contract instead of the tool's churny internal
+event model, and keeps `handleHookEvent` tool-neutral. So tool-specific logic
+(e.g. pi deriving a first-user-message title until pi names the session) lives
+in the hook, mirroring what codex/claude already do.
+
 ## Transport
 
 - Runner exports `GMUX_SESSION_SOCK` (its Unix socket) to the agent env.

--- a/packages/adapter/adapters/claude.go
+++ b/packages/adapter/adapters/claude.go
@@ -116,7 +116,8 @@ type claudeFirstLine struct {
 
 // ParseSessionFile reads a Claude Code JSONL session file and returns
 // display metadata.
-// Title priority: custom-title line > first user message text > "(new)".
+// Title priority: custom-title line > first user message text > "" (no
+// conversation-derived title yet; callers fall back to cwd/kind).
 func (c *Claude) ParseSessionFile(path string) (*adapter.SessionFileInfo, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -182,7 +183,7 @@ func (c *Claude) ParseSessionFile(path string) (*adapter.SessionFileInfo, error)
 		created, _ := time.Parse(time.RFC3339Nano, header.Timestamp)
 		return &adapter.SessionFileInfo{
 			ID:           header.SessionID,
-			Title:        "(new)",
+			Title:        "", // header only, no messages yet
 			Created:      created,
 			MessageCount: messageCount,
 			FilePath:     path,
@@ -207,7 +208,7 @@ func (c *Claude) ParseSessionFile(path string) (*adapter.SessionFileInfo, error)
 	case firstUserText != "":
 		info.Title = truncateTitle(firstUserText, 80)
 	default:
-		info.Title = "(new)"
+		info.Title = "" // no custom title and no message yet
 	}
 
 	// Slug from the first user message (immutable), not custom-title

--- a/packages/adapter/adapters/claude_hook.go
+++ b/packages/adapter/adapters/claude_hook.go
@@ -255,7 +255,7 @@ func claudeTitleSlug(transcriptPath, sessionTitle string) (title, slug string) {
 		return t, adapter.Slugify(t)
 	}
 	info, err := NewClaude().ParseSessionFile(transcriptPath)
-	if err != nil || info == nil || info.Title == "" || info.Title == "(new)" {
+	if err != nil || info == nil || info.Title == "" {
 		return "", ""
 	}
 	return info.Title, info.Slug

--- a/packages/adapter/adapters/claude_integration_test.go
+++ b/packages/adapter/adapters/claude_integration_test.go
@@ -63,7 +63,7 @@ func TestClaudeTurnAndTitle(t *testing.T) {
 	claudeSendAndWait(t, g, send, sess.ID)
 
 	updated := g.WaitForSession(sess.ID, func(s testutil.Session) bool {
-		return s.Title != "" && s.Title != "claude" && s.Title != "(new)"
+		return s.Title != "" && s.Title != "claude"
 	}, 15*time.Second, "title from first user message")
 	t.Logf("title: %q", updated.Title)
 

--- a/packages/adapter/adapters/claude_test.go
+++ b/packages/adapter/adapters/claude_test.go
@@ -219,8 +219,8 @@ func TestClaudeParseSessionFileQueueOnly(t *testing.T) {
 	if info.ID != "q-123" {
 		t.Errorf("expected id q-123, got %s", info.ID)
 	}
-	if info.Title != "(new)" {
-		t.Errorf("expected '(new)', got %q", info.Title)
+	if info.Title != "" {
+		t.Errorf("expected empty title for a session with no messages, got %q", info.Title)
 	}
 }
 

--- a/packages/adapter/adapters/codex.go
+++ b/packages/adapter/adapters/codex.go
@@ -120,7 +120,8 @@ type codexSessionMeta struct {
 
 // ParseSessionFile reads a Codex JSONL session file and returns display
 // metadata.
-// Title priority: first user prompt text > "(new)".
+// Title priority: first user prompt text > "" (no conversation-derived title
+// yet; callers fall back to cwd/kind).
 func (c *Codex) ParseSessionFile(path string) (*adapter.SessionFileInfo, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -191,7 +192,7 @@ func (c *Codex) ParseSessionFile(path string) (*adapter.SessionFileInfo, error) 
 	case firstUserText != "":
 		info.Title = truncateTitle(firstUserText, 80)
 	default:
-		info.Title = "(new)"
+		info.Title = "" // no message yet
 	}
 
 	info.Slug = adapter.Slugify(info.Title)

--- a/packages/adapter/adapters/codex_integration_test.go
+++ b/packages/adapter/adapters/codex_integration_test.go
@@ -66,7 +66,7 @@ func TestCodexTurnAndTitle(t *testing.T) {
 	codexSendAndWait(t, g, send, sess.ID)
 
 	updated := g.WaitForSession(sess.ID, func(s testutil.Session) bool {
-		return s.Title != "" && s.Title != "codex" && s.Title != "(new)"
+		return s.Title != "" && s.Title != "codex"
 	}, 15*time.Second, "title from first user message")
 	t.Logf("title: %q", updated.Title)
 

--- a/packages/adapter/adapters/codex_test.go
+++ b/packages/adapter/adapters/codex_test.go
@@ -162,8 +162,8 @@ func TestCodexParseSessionFileNoMessages(t *testing.T) {
 		`{"timestamp":"2026-03-17T01:00:00Z","type":"session_meta","payload":{"id":"abc","timestamp":"2026-03-17T01:00:00Z","cwd":"/tmp"}}`,
 	)
 	info, _ := NewCodex().ParseSessionFile(path)
-	if info.Title != "(new)" {
-		t.Errorf("expected '(new)', got %q", info.Title)
+	if info.Title != "" {
+		t.Errorf("expected empty title for a session with no messages, got %q", info.Title)
 	}
 }
 

--- a/packages/adapter/adapters/pi.go
+++ b/packages/adapter/adapters/pi.go
@@ -181,7 +181,8 @@ func (p *Pi) SessionDir(cwd string) string {
 }
 
 // ParseSessionFile reads a pi JSONL session file and returns display metadata.
-// Title priority: session_info.name > first user message > "(new)".
+// Title priority: session_info.name > first user message > "" (no
+// conversation-derived title yet; callers fall back to cwd/kind).
 func (p *Pi) ParseSessionFile(path string) (*adapter.SessionFileInfo, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -251,7 +252,7 @@ func (p *Pi) ParseSessionFile(path string) (*adapter.SessionFileInfo, error) {
 	case firstUserMsg != "":
 		info.Title = truncateTitle(firstUserMsg, 80)
 	default:
-		info.Title = "(new)"
+		info.Title = "" // no name and no message yet
 	}
 
 	info.Slug = adapter.Slugify(info.Title)

--- a/packages/adapter/adapters/pi_integration_test.go
+++ b/packages/adapter/adapters/pi_integration_test.go
@@ -67,7 +67,7 @@ func TestPiTurnAndTitle(t *testing.T) {
 
 	// Title should come from the first user message.
 	updated := g.WaitForSession(sess.ID, func(s testutil.Session) bool {
-		return s.Title != "" && s.Title != "pi" && s.Title != "(new)"
+		return s.Title != "" && s.Title != "pi"
 	}, 15*time.Second, "title from first user message")
 	t.Logf("title=%q slug=%s", updated.Title, updated.Slug)
 }

--- a/packages/adapter/adapters/pi_test.go
+++ b/packages/adapter/adapters/pi_test.go
@@ -264,8 +264,8 @@ func TestParseSessionFileNoMessages(t *testing.T) {
 		`{"type":"session","version":3,"id":"abc","timestamp":"2026-03-15T10:00:00Z","cwd":"/tmp/test"}`,
 	)
 	info, _ := NewPi().ParseSessionFile(path)
-	if info.Title != "(new)" {
-		t.Errorf("expected '(new)', got %q", info.Title)
+	if info.Title != "" {
+		t.Errorf("expected empty title for a session with no messages, got %q", info.Title)
 	}
 }
 

--- a/services/gmuxd/cmd/gmuxd/rehydrate_test.go
+++ b/services/gmuxd/cmd/gmuxd/rehydrate_test.go
@@ -110,7 +110,7 @@ func TestRehydrateProjects_PreventsDuplicateForToolBackedAdapter(t *testing.T) {
 		ToolID:  "jsonl-uuid-XYZ",
 		Slug:    "fix-auth",
 		Kind:    "pi",
-		Title:   "(new)",
+		Title:   "fix auth",
 		Cwd:     "/work",
 		Created: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
 	})


### PR DESCRIPTION
## What

A **live** pi session showed the weak fallback `π - <cwd>` (pi's OSC shell title) until pi generated a conversation name. pi's extension only reported `session_info.name` — empty until titled — whereas the codex/claude hooks already report a first-user-message title. This restores the disambiguating "first user message" title for working pi sessions.

## Changes

- **`pi-ext.mjs`**: capture the first user message (from `agent_end`'s `ev.messages`) and report it, truncated (mirroring `pi.go`'s `truncateTitle`), as the title until pi names the session. Reset on every bind so a switch/resume/fork doesn't carry the previous conversation's fallback. Fixed where the other agents already do it — the agent-side hook.
- **Drop the `"(new)"` sentinel** from `ParseSessionFile` in pi/claude/codex. It was a placeholder conflated with "no title yet" (`claude_hook` already special-cased it next to `""`). `ParseSessionFile` now returns `""` when there's no conversation-derived title; callers fall back to cwd/kind. Slug derivation is unchanged (falls through to the id-based slug).
- **ADR 0015** + a note in `runner-hook-protocol.md`: tool-event translation lives at the agent-side hook (in the tool's language), **not** via raw-event forwarding into the runner — this keeps the hook wire a small, stable contract and `handleHookEvent` tool-neutral. Records the reasoning so the "dumb hooks, smart adapter" question isn't relitigated.

## Testing

- `go test ./packages/adapter/... ./cli/gmux/... ./services/gmuxd/...` — 34 packages green; gofmt clean.
- Updated adapter unit tests + `rehydrate_test` for the empty-title value; dropped now-dead `"(new)"` guards from the integration polls.
- No JS unit harness exists for the extension (validated via e2e + the materialization test); the `extractUserText`/`truncateTitle` helpers mirror the Go equivalents that *are* tested in `pi_test.go`.

## Notes / follow-ups (out of scope here)

- **Just-opened, zero-message** pi sessions still briefly show `π - <cwd>` until the first user message. Removing that π-prefix fallback (drop `ShellTitle` for agent kinds, use a bare cwd basename in `resolveTitle`) is a separate daemon-side change.
- **Sidebar runner icon** (provenance via icon, hidden when homogeneous) — deferred.
- pi's live slug remains id-based (`Slugify(id)`); aligning it with the index's title-derived slug is a possible follow-up.