### PR TITLE
ci: dedup checks through moon + cache Go build for PR snapshots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,30 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  js:
-    name: JS (lint, build, test)
+  checks:
+    name: Lint, build, test
     runs-on: ubuntu-latest
+    # One source of truth: run the same pnpm entrypoints developers run
+    # locally. The actual commands live once in moon.yml (moon discovers
+    # projects from the workspace globs), so CI can't drift from local.
+    # `pnpm lint` = biome (--error-on-warnings, matching the root script)
+    # + `moon run :lint`; build/test fan out the same way.
+    env:
+      GOWORK: ${{ github.workspace }}/go.work
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          # moon's VCS layer needs the default branch ref to compute a
+          # touched-files baseline; a shallow checkout has only the PR
+          # head and makes `moon run` fail with git exit 128.
+          fetch-depth: 0
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: "1.26"
+          cache-dependency-path: |
+            **/go.sum
+            go.work.sum
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
@@ -28,65 +47,14 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Lint (Biome)
-        # biome lint (not `biome ci`): the repo enables only the linter;
-        # formatter and import-sort assists are intentionally off, and
-        # `biome ci` would also run those. Match the root `lint` script.
-        # --error-on-warnings: biome.json configures several rules at "warn"
-        # (noEmptyBlockStatements, noUnusedVariables, noUnusedImports); without
-        # this flag they'd surface locally but silently pass CI.
-        run: pnpm exec biome lint --error-on-warnings .
-
-      - name: Build protocol
-        run: cd packages/protocol && pnpm exec tsc -p tsconfig.json
-
-      - name: Lint protocol
-        run: cd packages/protocol && pnpm exec tsc --noEmit
-
-      - name: Test protocol
-        run: cd packages/protocol && pnpm exec vitest run --passWithNoTests
-
-      - name: Lint web
-        run: cd apps/gmux-web && pnpm exec tsc --noEmit
-
-      - name: Test web
-        run: cd apps/gmux-web && pnpm exec vitest run --passWithNoTests
-
-      - name: Build web
-        run: cd apps/gmux-web && pnpm exec vite build
-
-  go:
-    name: Go (lint, build, test)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
-        with:
-          go-version: "1.26"
-
-      - name: Vet
-        run: |
-          go vet ./cli/gmux/...
-          go vet ./packages/adapter/...
-          go vet ./services/gmuxd/...
-        env:
-          GOWORK: ${{ github.workspace }}/go.work
+      - name: Lint
+        run: pnpm lint
 
       - name: Build
-        run: |
-          go build ./cli/gmux/...
-          go build ./services/gmuxd/...
-        env:
-          GOWORK: ${{ github.workspace }}/go.work
+        run: pnpm build
 
       - name: Test
-        run: |
-          go test ./cli/gmux/...
-          go test ./packages/adapter/...
-          go test ./services/gmuxd/...
-        env:
-          GOWORK: ${{ github.workspace }}/go.work
+        run: pnpm test
 
   e2e:
     name: E2E (Playwright)

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -66,6 +66,24 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: "1.26"
+          # We manage the Go caches explicitly below (the go.work workspace
+          # has no root go.sum, so setup-go's default cache no-ops anyway).
+          cache: false
+
+      # Persist GOCACHE + the module cache so incremental PR pushes don't
+      # recompile the std lib for all four cross-compile targets from
+      # scratch. Key on go.sum + Go sources; restore-keys fall back to the
+      # nearest prior cache on a miss.
+      - name: Cache Go build + modules
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-gobuild-${{ hashFiles('**/go.sum', 'go.work.sum') }}-${{ hashFiles('**/*.go') }}
+          restore-keys: |
+            ${{ runner.os }}-gobuild-${{ hashFiles('**/go.sum', 'go.work.sum') }}-
+            ${{ runner.os }}-gobuild-
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev": "./scripts/dev-kill.sh && moon run :dev",
     "test": "moon run :test",
     "test:e2e": "npx playwright test --config e2e/playwright.config.ts",
-    "lint": "biome lint . && moon run :lint",
+    "lint": "biome lint --error-on-warnings . && moon run :lint",
     "check": "moon check :build :test",
     "graph": "moon project-graph"
   },


### PR DESCRIPTION
Infra PR (stacked under #326). Two commits.

## 1. Run checks through moon — kill the local/CI drift
CI hand-rolled every lint/build/test command inline in `ci.yml`, duplicating the task definitions in the various `moon.yml` files. They had already drifted: CI ran `biome lint --error-on-warnings` while the local `lint` script ran plain `biome lint`, so warning-level rules (`noUnusedVariables`, `noUnusedImports`, `noEmptyBlockStatements`) **passed locally and failed CI**.

- Collapse the `js` + `go` jobs into one `checks` job that runs the same pnpm entrypoints developers run locally: `pnpm lint` / `pnpm build` / `pnpm test`.
- Command bodies now live in exactly one place (`moon.yml`); moon discovers projects from the workspace globs, so there's **no folder map to maintain** — add a project and CI picks it up.
- Sync the root `lint` script to `biome lint --error-on-warnings` so local == CI by construction.

Verified locally: `pnpm lint` / `build` / `test` all green through moon.

## 2. Cache the Go build for PR snapshot builds
The PR snapshot build (`pr-build.yml`) was a **flat ~227s regardless of change size** — 87% of the job. Measured breakdown of a recent run:
```
227s  Build with GoReleaser (snapshot)
  8s  setup-go
  5s  pnpm install
```
goreleaser cross-compiles **8 binaries** (2 × {linux,darwin} × {amd64,arm64}) and the Go build cache was **cold every run**, so it recompiled the std lib for all four targets plus every package each time. `setup-go`'s default caching no-ops here because the `go.work` workspace has no root `go.sum`.

- Cache `GOCACHE` + the module cache explicitly, keyed on `go.sum` + Go sources, with restore-keys for partial hits, so incremental pushes reuse compiled packages and the per-target std lib.
- `cache: false` on setup-go so the two mechanisms don't fight over the same dirs.

Expected: ~227s → ~30–60s for incremental changes once the cache is warm. (Larger runner / trimming the PR platform matrix remain available follow-ups if cold-cache runs still hurt — deliberately not done here.)