### PR TITLE
refactor: remove vestigial Status.label; derive status display in frontend

### DIFF
--- a/apps/gmux-web/src/home-partition.test.ts
+++ b/apps/gmux-web/src/home-partition.test.ts
@@ -45,7 +45,7 @@ describe('partitionForHome', () => {
       // session lands in; that's covered by other tests.
       const s = makeSession({
         id: 's1', cwd: '/x', alive: true,
-        status: { label: 'failed', working: false, error: true },
+        status: { working: false, error: true },
       })
       const { needsAttention } = partitionForHome([s], NOW)
       expect(needsAttention).toEqual([])
@@ -54,7 +54,7 @@ describe('partitionForHome', () => {
     it('puts alive+working sessions in running', () => {
       const s = makeSession({
         id: 's1', cwd: '/x', alive: true,
-        status: { label: 'building', working: true, error: false },
+        status: { working: true, error: false },
       })
       const { needsAttention, running } = partitionForHome([s], NOW)
       expect(needsAttention).toEqual([])
@@ -84,7 +84,7 @@ describe('partitionForHome', () => {
   })
 
   describe('sort order', () => {
-    const working = { label: 'x', working: true, error: false }
+    const working = { working: true, error: false }
 
     it('sorts each section newest-first by last_activity_at', () => {
       const a = makeSession({ id: 'a', cwd: '/x', alive: true, status: working, last_activity_at: stamp(-10_000) })
@@ -188,7 +188,7 @@ describe('partitionForHome', () => {
     })
 
     it('returns no buckets when every session is working or unread', () => {
-      const working = { label: 'x', working: true, error: false }
+      const working = { working: true, error: false }
       const sessions = [
         makeSession({ id: 'a', cwd: '/x', alive: true, status: working }),
         makeSession({ id: 'b', cwd: '/x', alive: true, unread: true }),
@@ -214,7 +214,7 @@ describe('partitionForProject', () => {
       id: 'ancient',
       cwd: '/x',
       alive: true,
-      status: { label: '', working: false, error: false },
+      status: { working: false, error: false },
       last_activity_at: weekAgo,
     })
     const { rest } = partitionForProject([s])
@@ -248,7 +248,7 @@ describe('partitionForProject', () => {
     const att = makeSession({ id: 'att', cwd: '/x', alive: true, unread: true })
     const run = makeSession({
       id: 'run', cwd: '/x', alive: true,
-      status: { label: 'building', working: true, error: false },
+      status: { working: true, error: false },
     })
     const idle = makeSession({ id: 'idle', cwd: '/x', alive: true })
     const { needsAttention, running, rest } = partitionForProject([att, run, idle])

--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -91,13 +91,13 @@ function MainHeader({ session, onRestart }: {
         </div>
       </div>
       <div class="main-header-right">
-        {session.status?.label && (
-          <div class={`main-header-status ${session.status.error ? 'error' : session.status.working ? 'working' : ''}`}>
+        {(session.status?.working || session.status?.error) && (
+          <div class={`main-header-status ${session.status.error ? 'error' : 'working'}`}>
             <span
-              class={`session-dot ${session.status.error ? 'error' : session.status.working ? 'working' : 'idle'}`}
+              class={`session-dot ${session.status.error ? 'error' : 'working'}`}
               style={{ width: 5, height: 5 }}
             />
-            {session.status.label}
+            {session.status.error ? 'Error' : 'Working…'}
           </div>
         )}
         <SessionMenu session={session} onRestart={onRestart} />

--- a/apps/gmux-web/src/mock-data/export-session.ts
+++ b/apps/gmux-web/src/mock-data/export-session.ts
@@ -234,7 +234,8 @@ function generateFile(session: Session, terminal: string, cursorX: number, curso
   lines.push(`  title: ${JSON.stringify(session.title)},`)
   lines.push(`  subtitle: ${JSON.stringify(session.subtitle)},`)
   if (session.status) {
-    lines.push(`  status: { label: ${JSON.stringify(session.status.label)}, working: ${session.status.working} },`)
+    const errorPart = session.status.error ? ', error: true' : ''
+    lines.push(`  status: { working: ${session.status.working}${errorPart} },`)
   } else {
     lines.push(`  status: null,`)
   }

--- a/apps/gmux-web/src/mock-data/sessions/claude-design-landing.ts
+++ b/apps/gmux-web/src/mock-data/sessions/claude-design-landing.ts
@@ -22,7 +22,7 @@ export default {
   exited_at: null,
   title: 'design landing page',
   subtitle: '',
-  status: { label: '', working: false },
+  status: { working: false },
   unread: true,
   socket_path: '/tmp/gmux-sessions/sess-claude-01.sock',
   peer: 'laptop',

--- a/apps/gmux-web/src/mock-data/sessions/codex-migrate.ts
+++ b/apps/gmux-web/src/mock-data/sessions/codex-migrate.ts
@@ -22,7 +22,7 @@ export default {
   exited_at: null,
   title: 'migrate to convex',
   subtitle: '',
-  status: { label: '', working: false },
+  status: { working: false },
   unread: false,
   socket_path: '/tmp/gmux-sessions/mock.sock',
   peer: 'server',

--- a/apps/gmux-web/src/mock-data/sessions/codex-refactor-adapters.ts
+++ b/apps/gmux-web/src/mock-data/sessions/codex-refactor-adapters.ts
@@ -30,7 +30,7 @@ export default {
   exited_at: null,
   title: "refactor adapters",
   subtitle: "",
-  status: { label: "", working: true },
+  status: { working: true },
   unread: false,
   socket_path: '/tmp/gmux-sessions/sess-4ab4995b.sock',
   peer: 'laptop',

--- a/apps/gmux-web/src/mock-data/sessions/pi-autoresearch.ts
+++ b/apps/gmux-web/src/mock-data/sessions/pi-autoresearch.ts
@@ -22,7 +22,7 @@ export default {
   exited_at: null,
   title: 'autoresearch benchmark',
   subtitle: '',
-  status: { label: '', working: true },
+  status: { working: true },
   unread: false,
   socket_path: '/tmp/gmux-sessions/mock.sock',
   peer: 'server',

--- a/apps/gmux-web/src/mock-data/sessions/pi-fix-scrollback.ts
+++ b/apps/gmux-web/src/mock-data/sessions/pi-fix-scrollback.ts
@@ -22,7 +22,7 @@ export default {
   exited_at: null,
   title: 'fix scrollback',
   subtitle: '',
-  status: { label: '', working: false },
+  status: { working: false },
   unread: false,
   socket_path: '/tmp/gmux-sessions/mock.sock',
   peer: 'devcontainer',

--- a/apps/gmux-web/src/mock-data/sessions/shell-openclaw-configure.ts
+++ b/apps/gmux-web/src/mock-data/sessions/shell-openclaw-configure.ts
@@ -19,7 +19,7 @@ export default {
   exited_at: null,
   title: 'openclaw configure',
   subtitle: '',
-  status: { label: '', working: false },
+  status: { working: false },
   unread: false,
   socket_path: '/tmp/gmux-sessions/mock.sock',
   peer: 'server',

--- a/apps/gmux-web/src/mock-data/sessions/shell-openclaw-logs.ts
+++ b/apps/gmux-web/src/mock-data/sessions/shell-openclaw-logs.ts
@@ -19,7 +19,7 @@ export default {
   exited_at: null,
   title: 'logs',
   subtitle: '',
-  status: { label: '', working: false },
+  status: { working: false },
   unread: false,
   socket_path: '/tmp/gmux-sessions/mock.sock',
   peer: 'server/container',

--- a/apps/gmux-web/src/session-row.tsx
+++ b/apps/gmux-web/src/session-row.tsx
@@ -93,11 +93,12 @@ export function SessionRow({
   // that haven't transitioned yet (matches the dashboard sort).
   const age = formatAge(session.last_activity_at ?? session.created_at, Date.now())
 
-  // Status label / exit code: surface whichever the session actually
-  // exposes. Dead sessions get a synthetic "exited (N)" if no label
-  // is set, so the row never goes silent about why a session is dead.
-  const statusText = session.status?.label
-    ?? (!session.alive && session.exit_code != null ? `exited (${session.exit_code})` : null)
+  // Exit code: dead sessions surface "exited (N)" so the row never goes
+  // silent about why a session is dead. Live status (working/error) is
+  // conveyed by the dot, not text.
+  const statusText = !session.alive && session.exit_code != null
+    ? `exited (${session.exit_code})`
+    : null
 
   const cls = [
     'session-row',

--- a/apps/gmux-web/src/sidebar.tsx
+++ b/apps/gmux-web/src/sidebar.tsx
@@ -173,12 +173,9 @@ function SessionItem({
         <div class="session-title-row">
           <span class="session-title">{session.title}</span>
         </div>
-        {(session.status?.label || duplicateOpen) && (
+        {duplicateOpen && (
           <div class="session-meta">
-            {session.status?.label && <span class="session-status-label">{session.status.label}</span>}
-            {duplicateOpen && (
-              <span class="session-dup-warning" title="This conversation is open in more than one tab">⚠ open elsewhere</span>
-            )}
+            <span class="session-dup-warning" title="This conversation is open in more than one tab">⚠ open elsewhere</span>
           </div>
         )}
       </div>

--- a/apps/gmux-web/src/store.test.ts
+++ b/apps/gmux-web/src/store.test.ts
@@ -281,11 +281,10 @@ describe('markSessionRead', () => {
   it('clears error flag from status', () => {
     _rawSessions.value = [makeSession({
       id: 'sess-1',
-      status: { label: 'failed', working: false, error: true },
+      status: { working: false, error: true },
     })]
     markSessionRead('sess-1')
     expect(sessions.value[0].status?.error).toBe(false)
-    expect(sessions.value[0].status?.label).toBe('failed')
   })
 
   it('does not touch other sessions', () => {
@@ -771,14 +770,13 @@ describe('pending mutations overlay', () => {
 
     it('mark-read clears unread and status.error on the targeted session', () => {
       const sess = [
-        makeSession({ id: 'a', unread: true, status: { label: 'oops', working: false, error: true } }),
+        makeSession({ id: 'a', unread: true, status: { working: false, error: true } }),
         makeSession({ id: 'b', unread: true }),
       ]
       const m: PendingMutation = { kind: 'mark-read', id: 'a', at: 0 }
       const out = applyPending(sess, [], [m])
       expect(out.sessions[0].unread).toBe(false)
       expect(out.sessions[0].status?.error).toBe(false)
-      expect(out.sessions[0].status?.label).toBe('oops')
       // Untouched session keeps its flags.
       expect(out.sessions[1].unread).toBe(true)
     })

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -688,10 +688,6 @@ body {
   font-weight: 700;
   line-height: 1cap;
 }
-.session-status-label {
-  color: var(--text-secondary);
-}
-
 @keyframes subtle-pulse {
   0%, 100% { opacity: 1; }
   50% { opacity: 0.35; }

--- a/apps/gmux-web/src/types.ts
+++ b/apps/gmux-web/src/types.ts
@@ -3,7 +3,6 @@
 // Pure interfaces for the frontend data model. No logic, no imports.
 
 export interface SessionStatus {
-  label: string
   working: boolean
   error?: boolean
 }

--- a/apps/website/src/content/docs/develop/session-schema.md
+++ b/apps/website/src/content/docs/develop/session-schema.md
@@ -243,4 +243,4 @@ Note the differences: `shell_title`, `adapter_title`, and `binary_hash` are abse
 - **Cost/tokens** — same
 - **Git branch / PR status** — could be a future Status extension, not core
 - **Conversation history** — belongs to the application, not the multiplexer
-- **Progress bar** — deferred; `Status.label` like `"3/10 tests"` is sufficient
+- **Progress bar** — deferred; Status carries only `working`/`error` booleans today

--- a/apps/website/src/content/docs/develop/state-management.md
+++ b/apps/website/src/content/docs/develop/state-management.md
@@ -129,16 +129,17 @@ The terminal renders when `selected.alive && selected.socket_path` is true. This
 - Alive but no socket yet: impossible — `Register()` always sets both `alive` and `socket_path` atomically
 - Alive with socket: terminal connects via WebSocket proxy
 
-## Status labels
+## Status
 
-Status is **null by default**. A label should only be set when it carries information the user can't already see from the session's visual state.
+Status carries only granular booleans (`working`, `error`) and is **null by default**. It describes *live* state; display text is the frontend's concern, derived from these plus `exit_code`.
 
 | State | What the UI shows | Status field |
 |---|---|---|
 | Alive, idle | Steady dot | `null` |
-| Alive, working | Pulsing dot | `{ working: true }` (no label) |
-| Dead, clean exit | Dimmed row | `null` |
-| Dead, non-zero exit | Dimmed row + label | `{ label: "exited (1)" }` |
+| Alive, working | Pulsing dot + header "Working…" | `{ working: true }` |
+| Alive, error | Red dot + header "Error" | `{ working: false, error: true }` |
+| Dead, clean exit | Dimmed row, "Session ended" | `null` |
+| Dead, non-zero exit | Dimmed row, "exited (N)" from `exit_code` | `null` |
 | Resumable | Normal row, clickable | `null` |
 
-Don't set labels like "completed", "idle", or "working" — they repeat what the dot and alive/dead state already communicate. Labels are for genuinely informative states like `"exited (1)"` or `"tests: 3 failed"`.
+Exit text (`exited (N)` / `Session ended`) is derived in the frontend from `exit_code`, not carried in Status. On exit the daemon sets Status to `null`.

--- a/apps/website/src/content/docs/using-the-ui.md
+++ b/apps/website/src/content/docs/using-the-ui.md
@@ -101,7 +101,7 @@ If a project has no sessions yet, the hub shows the project's configured path wi
 
 ## The terminal
 
-Click a session to attach. You get a full interactive terminal powered by [xterm.js](https://xtermjs.org/). Colors, cursor positioning, mouse support, and images all work. The header bar shows the session title, status label, and a working indicator.
+Click a session to attach. You get a full interactive terminal powered by [xterm.js](https://xtermjs.org/). Colors, cursor positioning, mouse support, and images all work. The header bar shows the session title and, while an agent is busy, a working/error status indicator.
 
 ## Launching sessions
 

--- a/cli/gmux/internal/session/state_test.go
+++ b/cli/gmux/internal/session/state_test.go
@@ -95,10 +95,10 @@ func TestSetExited(t *testing.T) {
 
 func TestSetStatus(t *testing.T) {
 	s := New(Config{ID: "s", Command: []string{"echo"}, Kind: "generic"})
-	s.SetStatus(&adapter.Status{Label: "thinking", Working: true})
+	s.SetStatus(&adapter.Status{Working: true, Error: true})
 
-	if s.Status == nil || s.Status.Label != "thinking" {
-		t.Fatalf("expected 'thinking', got %v", s.Status)
+	if s.Status == nil || !s.Status.Working || !s.Status.Error {
+		t.Fatalf("expected working+error, got %v", s.Status)
 	}
 }
 
@@ -134,7 +134,7 @@ func TestSubscribeEvents(t *testing.T) {
 	ch := s.Subscribe()
 	defer s.Unsubscribe(ch)
 
-	s.SetStatus(&adapter.Status{Label: "test"})
+	s.SetStatus(&adapter.Status{Working: true})
 
 	evt := <-ch
 	if evt.Type != "status" {

--- a/packages/adapter/adapter.go
+++ b/packages/adapter/adapter.go
@@ -10,10 +10,11 @@ import (
 )
 
 // Status represents an application-reported status for the sidebar.
+// It carries only granular booleans; any display text is the
+// frontend's concern, derived from these plus exit_code.
 type Status struct {
-	Label   string `json:"label"`           // display text ("working", "3/5 passed")
-	Working bool   `json:"working"`         // true while adapter is busy (spinner, building)
-	Error   bool   `json:"error,omitempty"` // true when the adapter hit a retryable error (red dot)
+	Working bool `json:"working"`         // true while adapter is busy (spinner, building)
+	Error   bool `json:"error,omitempty"` // true when the adapter hit a retryable error (red dot)
 }
 
 // Adapter teaches gmux how to work with a specific child process.

--- a/packages/protocol/src/index.test.ts
+++ b/packages/protocol/src/index.test.ts
@@ -14,7 +14,7 @@ describe('protocol schemas', () => {
       alive: true,
       pid: 12345,
       title: 'test session',
-      status: { label: 'thinking', working: true },
+      status: { working: true },
       terminal_cols: 120,
       terminal_rows: 40,
     })
@@ -22,7 +22,6 @@ describe('protocol schemas', () => {
     expect(result.id).toBe('sess-1')
     expect(result.alive).toBe(true)
     expect(result.status?.working).toBe(true)
-    expect(result.status?.label).toBe('thinking')
     expect(result.terminal_cols).toBe(120)
     expect(result.terminal_rows).toBe(40)
   })
@@ -47,7 +46,7 @@ describe('protocol schemas', () => {
         id: 'sess-1',
         kind: 'pi',
         alive: true,
-        status: { label: 'running', working: true },
+        status: { working: true },
       },
     })
 
@@ -67,7 +66,7 @@ describe('protocol schemas', () => {
 
   it('builds typed success envelopes', () => {
     const Schema = successEnvelope(SessionStatusSchema)
-    const parsed = Schema.parse({ ok: true, data: { label: 'test', working: false } })
-    expect(parsed.data.label).toBe('test')
+    const parsed = Schema.parse({ ok: true, data: { working: false } })
+    expect(parsed.data.working).toBe(false)
   })
 })

--- a/packages/protocol/src/session.ts
+++ b/packages/protocol/src/session.ts
@@ -3,7 +3,6 @@ import { z } from 'zod'
 // Schema v2 — matches gmuxd's API response (GET /v1/sessions, session-upsert SSE)
 
 export const SessionStatusSchema = z.object({
-  label: z.string(),
   working: z.boolean(),
   error: z.boolean().optional().default(false),
 }).nullable()

--- a/services/gmuxd/cmd/gmuxd/rehydrate_test.go
+++ b/services/gmuxd/cmd/gmuxd/rehydrate_test.go
@@ -34,7 +34,7 @@ func TestRehydrateProjects_PreservesSessionmetaState(t *testing.T) {
 		Alive:      false,
 		ExitCode:   &exitCode,
 		ExitedAt:   exitedAt,
-		Status:     &store.Status{Label: "exited (42)", Error: true},
+		Status:     &store.Status{Error: true},
 		ShellTitle: "bash -c echo hi; exit 42",
 		CreatedAt:  "2024-01-01T11:00:00Z",
 	}
@@ -74,7 +74,7 @@ func TestRehydrateProjects_PreservesSessionmetaState(t *testing.T) {
 	if got.ExitedAt != exitedAt {
 		t.Errorf("ExitedAt lost: got %q, want %q", got.ExitedAt, exitedAt)
 	}
-	if got.Status == nil || got.Status.Label != "exited (42)" {
+	if got.Status == nil || !got.Status.Error {
 		t.Errorf("Status lost: got %+v", got.Status)
 	}
 	if got.Title != "bash -c echo hi; exit 42" {

--- a/services/gmuxd/internal/discovery/subscribe.go
+++ b/services/gmuxd/internal/discovery/subscribe.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
-	"fmt"
 	"log"
 	"net"
 	"net/http"
@@ -284,11 +283,10 @@ func (sub *Subscriptions) handleEvent(sessionID, socketPath, eventType string, d
 			resumed = sub.OnExit(&sess)
 		}
 		if !resumed {
-			if exit.ExitCode == 0 {
-				sess.Status = nil // clean exit, no label needed
-			} else {
-				sess.Status = &store.Status{Label: fmt.Sprintf("exited (%d)", exit.ExitCode)}
-			}
+			// Status carries only live working/error state; on exit it's
+			// meaningless. The frontend derives any "exited (N)" text from
+			// exit_code, so just clear it.
+			sess.Status = nil
 		}
 		if !sub.store.Update(sessionID, func(current *store.Session) {
 			*current = sess

--- a/services/gmuxd/internal/notify/notify.go
+++ b/services/gmuxd/internal/notify/notify.go
@@ -164,11 +164,7 @@ func (r *Router) handleEvent(ev store.Event) {
 
 	// Transition: unread flipped on
 	if !prev.Unread && cur.Unread {
-		body := "New output"
-		if sess.Status != nil && sess.Status.Label != "" {
-			body = sess.Status.Label
-		}
-		r.scheduleNotification(sess.ID, "unread", sess.Title, body)
+		r.scheduleNotification(sess.ID, "unread", sess.Title, "New output")
 	}
 }
 

--- a/services/gmuxd/internal/notify/notify_test.go
+++ b/services/gmuxd/internal/notify/notify_test.go
@@ -70,9 +70,9 @@ func (e *testEnv) addClient(id, deviceType string) {
 func (e *testEnv) upsertSession(id string, working, unread, alive bool) {
 	var status *store.Status
 	if working {
-		status = &store.Status{Label: "working", Working: true}
+		status = &store.Status{Working: true}
 	} else {
-		status = &store.Status{Label: "idle", Working: false}
+		status = &store.Status{Working: false}
 	}
 	e.store.Upsert(store.Session{
 		ID:        id,

--- a/services/gmuxd/internal/sessionmeta/sessionmeta_test.go
+++ b/services/gmuxd/internal/sessionmeta/sessionmeta_test.go
@@ -91,7 +91,7 @@ func TestRoundTripFullSession(t *testing.T) {
 		ExitedAt:      "2026-04-26T10:05:00Z",
 		Title:         "my title",
 		Subtitle:      "my subtitle",
-		Status:        &store.Status{Label: "working", Working: true, Error: false},
+		Status:        &store.Status{Working: true, Error: false},
 		Unread:        true,
 		Resumable:     true,
 		SocketPath:    "/tmp/gmux-sessions/sess-full.sock",

--- a/services/gmuxd/internal/store/store.go
+++ b/services/gmuxd/internal/store/store.go
@@ -48,8 +48,8 @@ type Session struct {
 	//   - status.error: false → true  (status went into error)
 	//
 	// Not bumped on: new session creation (the first follow-up
-	// transition does it), title/cwd/slug/stamp changes, status
-	// label-only updates, sessionmeta rehydrate at startup.
+	// transition does it), title/cwd/slug/stamp changes, no-op status
+	// updates, sessionmeta rehydrate at startup.
 	//
 	// Peer sessions arrive over the wire with this already set by
 	// the owning daemon; UpsertRemote preserves it as-received.
@@ -160,11 +160,11 @@ func (s Session) MarshalJSON() ([]byte, error) {
 	})
 }
 
-// Status is the application-reported status.
+// Status is the application-reported status. Carries only granular
+// booleans; display text is derived in the frontend.
 type Status struct {
-	Label   string `json:"label"`
-	Working bool   `json:"working"`
-	Error   bool   `json:"error,omitempty"`
+	Working bool `json:"working"`
+	Error   bool `json:"error,omitempty"`
 }
 
 type Event struct {

--- a/services/gmuxd/internal/store/store_test.go
+++ b/services/gmuxd/internal/store/store_test.go
@@ -1056,7 +1056,7 @@ func fullyPopulatedSession() Session {
 		ExitedAt:       "2026-01-01T00:00:02Z",
 		Title:          "t",
 		Subtitle:       "s",
-		Status:         &Status{Label: "l", Working: true, Error: true},
+		Status:         &Status{Working: true, Error: true},
 		Unread:         true,
 		LastActivityAt: "2026-01-01T00:00:03Z",
 		Resumable:      true,
@@ -1367,7 +1367,7 @@ func TestLastActivityAt_BumpOnTransitions(t *testing.T) {
 }
 
 // TestLastActivityAt_NoBumpOnNoise pins that benign updates do not
-// bump: title changes, slug changes, cwd changes, status label-only
+// bump: title changes, slug changes, cwd changes, no-op status
 // changes. Without this, the recency list would jitter on every
 // adapter title refresh.
 func TestLastActivityAt_NoBumpOnNoise(t *testing.T) {
@@ -1378,7 +1378,7 @@ func TestLastActivityAt_NoBumpOnNoise(t *testing.T) {
 		{"title", func(s *Session) { s.AdapterTitle = "renamed" }},
 		{"slug", func(s *Session) { s.Slug = "new-slug" }},
 		{"cwd", func(s *Session) { s.Cwd = "/tmp/elsewhere" }},
-		{"status-label", func(s *Session) { s.Status = &Status{Label: "running"} }},
+		{"status-noop", func(s *Session) { s.Status = &Status{} }},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1497,8 +1497,8 @@ func TestLastActivityAt_UpsertNoBumpPreservesStamp(t *testing.T) {
 // before fn runs sidesteps the alias entirely.
 func TestLastActivityAt_PointerAliasingDoesNotHideTransition(t *testing.T) {
 	s := New()
-	// Seed with a Status pointer present (label only, not working).
-	s.Upsert(Session{ID: "s1", Kind: "pi", Alive: true, Status: &Status{Label: "idle"}})
+	// Seed with a non-working Status pointer present.
+	s.Upsert(Session{ID: "s1", Kind: "pi", Alive: true, Status: &Status{}})
 
 	// Mutator writes Working=true through the existing Status pointer
 	// rather than allocating a new Status. This is the alias-risk


### PR DESCRIPTION
## What

\`Status.label\` was synthesized in exactly one place — gmuxd's \`exited (N)\` on a non-zero exit — and never written by any adapter or agent hook. Every reachable render was either dead or duplicable:

- The header pill was **label-gated**, so it never showed for live sessions (the runner only ever sends \`working\`/\`error\` booleans, never a label).
- The sidebar/row already derive \`exited (N)\` from \`exit_code\`.
- \`notify.go\`'s label fallback was effectively dead (the only label is set on a dead session; the unread transition fires on a live turn-complete with no label) → always \`"New output"\`.

So the field carried no information that isn't already available from \`working\`/\`error\` + \`exit_code\`.

## Change

- Drop \`label\` from \`Status\` across the stack: \`packages/adapter\`, gmuxd \`store\`, \`packages/protocol\` schema, web \`types.ts\`.
- On exit, gmuxd sets \`Status = nil\` (was \`{label: "exited (N)"}\`). The frontend derives all exit text from \`exit_code\` (ReplayView bottom bar + sidebar fallback, both already did).
- Header pill now derives from the booleans: shows **Working…** / **Error** while an agent is busy, nothing when idle — turning a no-op into a useful live-status indicator.
- \`notify.go\` always uses \`"New output"\` for the unread body.
- Docs updated (state-management, session-schema, using-the-ui).

## Status contract now

\`Status\` carries only \`working\`/\`error\` (live state). Display text is the frontend's concern; exit text comes from \`exit_code\`. On exit, \`Status\` is \`null\`.

## Tested

- Go: \`go test ./...\` green in \`packages/adapter\`, \`services/gmuxd\`, \`cli/gmux\`; \`go vet\` clean.
- Web: 521 tests pass; \`tsc --noEmit\` clean; \`vite build\` ok; \`biome lint --error-on-warnings\` clean.
- Protocol: schema tests pass.