### PR TITLE
docs: point contributors + agents at the canonical pnpm check commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,11 @@ messages directly. Rules that follow from this:
 
 ## Other rules
 
+- Before pushing, run `pnpm lint && pnpm build && pnpm test` — these are
+  the exact entrypoints CI runs, so green locally means green in CI.
+  `pnpm lint` includes biome with `--error-on-warnings`; bare
+  `moon run :lint` skips biome and will pass while CI fails. Run
+  `pnpm install` first if you haven't — moon does not auto-install deps.
 - Push changes and create pull requests. Don't commit directly to
   `main`.
 - Use `./scripts/install.sh` when asked to install locally.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,10 +41,24 @@ moon run gmux-web:dev     # just vite
 
 ## Tests & linting
 
+Run the same entrypoints CI does — local and CI are kept in sync by
+construction (CI just runs these):
+
 ```bash
-moon run :test    # all tests (Go + JS)
-moon run :lint    # all lint/typecheck
+pnpm lint    # biome + all lint/typecheck (Go vet + tsc)
+pnpm build   # build everything
+pnpm test    # all tests (Go + JS)
 ```
+
+These wrap moon (`moon run :lint` / `:build` / `:test`). Prefer the `pnpm`
+scripts: `pnpm lint` also runs biome with `--error-on-warnings`, which
+bare `moon run :lint` does not — running moon directly will silently skip
+the biome lint that CI enforces.
+
+Note: moon does not manage the JS toolchain or auto-install dependencies.
+Run `pnpm install` first, or tasks fail with "command not found".
+
+To target one project: `moon run gmux-web:test`, `moon run gmuxd:lint`, etc.
 
 ## Project structure
 


### PR DESCRIPTION
Follow-up to #328. After CI moved to running `pnpm lint/build/test`, the docs gave stale/incomplete guidance.

## CONTRIBUTING.md
The "Tests & linting" section told contributors to run `moon run :lint` — but **bare `moon run :lint` skips biome** (biome isn't a moon task; it's wired into the `pnpm lint` script). A contributor following the old instructions would miss exactly the biome `--error-on-warnings` rules CI now enforces. Updated to point at `pnpm lint/build/test` as canonical (== CI), explain why to prefer them over bare moon, and note moon doesn't auto-install JS deps (run `pnpm install` first).

## AGENTS.md
The "Other rules" section said to push + open PRs but gave no pre-push validation guidance. Added: run `pnpm lint && pnpm build && pnpm test` before pushing (the exact CI entrypoints), with the same biome/auto-install caveats — so agents don't push changes that pass a bare moon run but fail CI on biome warnings.