### PR TITLE
refactor: references identify by name, node_id as a liveness anchor (ADR 0015)

### DIFF
--- a/apps/gmux-web/src/projects.test.ts
+++ b/apps/gmux-web/src/projects.test.ts
@@ -302,18 +302,16 @@ describe('buildProjectFolders', () => {
     expect(folders[0].missing).toBeUndefined()
   })
 
-  it('buckets a renamed host\'s sessions under a reference resolved by node_id', () => {
-    // The seam with resolveReferences: the reference is stored under the
-    // old name "unraid" but resolveRef maps it to the host's current
-    // name "gmux-hs". The session (stamped with the live name) must land
-    // in the folder, and the folder must carry the live name.
-    const projects: ProjectItem[] = [{ slug: 'apps', peer: 'unraid', node_id: 'node_hs' }]
+  it('buckets a reference\'s sessions by its stored name and stays resolved when present', () => {
+    // `peer` is the runtime key (ADR 0015): sessions stamped with the
+    // same name land in the folder, and the liveness predicate (node_id
+    // present) keeps it resolved.
+    const projects: ProjectItem[] = [{ slug: 'apps', peer: 'gmux-hs', node_id: 'node_hs' }]
     const sessions = [
       makeSession({ id: 's1', cwd: '/mnt/apps', peer: 'gmux-hs', project_slug: 'apps', alive: true }),
     ]
-    const resolveRef = (peer: string, slug: string) =>
-      peer === 'unraid' && slug === 'apps' ? { effectivePeer: 'gmux-hs', resolved: true } : undefined
-    const folders = buildProjectFolders(projects, sessions, undefined, {}, resolveRef)
+    const isPresent = (_peer: string, nodeId?: string) => nodeId === 'node_hs'
+    const folders = buildProjectFolders(projects, sessions, undefined, {}, isPresent)
     expect(folders).toHaveLength(1)
     expect(folders[0].peer).toBe('gmux-hs')
     expect(folders[0].unresolved).toBeUndefined()
@@ -321,13 +319,13 @@ describe('buildProjectFolders', () => {
   })
 
   it('flags an unresolved reference and takes precedence over missing', () => {
-    // resolveRef reports the host is in no roster bucket. Even though we
-    // have no peer_projects entry for it, the folder is flagged
-    // unresolved (host renamed/removed) rather than left as a plain
-    // empty reference — and unresolved is never conflated with missing.
-    const projects: ProjectItem[] = [{ slug: 'apps', peer: 'hs' }]
-    const resolveRef = () => ({ effectivePeer: 'hs', resolved: false })
-    const folders = buildProjectFolders(projects, [], undefined, {}, resolveRef)
+    // The reference's anchor (node_id) is in no roster bucket — host
+    // renamed-away-and-gone or removed. Even with no peer_projects entry,
+    // the folder is flagged unresolved rather than left a plain empty
+    // reference — and unresolved is never conflated with missing.
+    const projects: ProjectItem[] = [{ slug: 'apps', peer: 'hs', node_id: 'node_gone' }]
+    const isPresent = () => false
+    const folders = buildProjectFolders(projects, [], undefined, {}, isPresent)
     expect(folders[0].unresolved).toBe(true)
     expect(folders[0].missing).toBeUndefined()
     expect(folders[0].peer).toBe('hs')

--- a/apps/gmux-web/src/projects.ts
+++ b/apps/gmux-web/src/projects.ts
@@ -333,10 +333,10 @@ export function buildProjectFolders(
   sessions: Session[],
   isLocalPeer?: (peerName: string) => boolean,
   peerProjects?: Record<string, { slug: string; launch_cwd?: string }[]>,
-  // Resolve a reference (by its stored peer+slug) to the live host's
-  // current name and whether it's in the roster at all. When omitted,
-  // references resolve to their stored name (legacy behavior). (refs #270)
-  resolveRef?: (peer: string, slug: string) => { effectivePeer: string; resolved: boolean } | undefined,
+  // Liveness predicate: is a reference's host in the roster? (ADR 0015).
+  // `peer` is a frozen viewer-owned label, so references bucket/label by
+  // it directly; this only sets the unresolved flag. Omitted ⇒ present.
+  isPresent?: (peer: string, nodeId?: string) => boolean,
 ): Folder[] {
   // Bucket every stamped session by `${ownerPeer}::${slug}`.
   // ownerPeer is '' for sessions owned by the viewer (local sessions,
@@ -361,20 +361,12 @@ export function buildProjectFolders(
 
   const folders: Folder[] = []
   for (const project of projects) {
-    const storedPeer = project.peer ?? ''
-    // For references, resolve to the live host's current name (which
-    // may differ from the stored name after a rename) and learn
-    // whether the host is in the roster at all. Owned projects pass
-    // through unchanged.
-    let ownerPeer = storedPeer
-    let unresolved = false
-    if (storedPeer !== '' && resolveRef) {
-      const r = resolveRef(storedPeer, project.slug)
-      if (r) {
-        ownerPeer = r.effectivePeer
-        unresolved = !r.resolved
-      }
-    }
+    // `peer` is the runtime key (viewer-owned, frozen — ADR 0007 §7), so
+    // bucket and label references by it directly. The only roster
+    // question is liveness, which also blocks a reused name from
+    // adopting a stale reference (node_id mismatch).
+    const ownerPeer = project.peer ?? ''
+    const unresolved = ownerPeer !== '' && !!isPresent && !isPresent(ownerPeer, project.node_id)
     const ss = buckets.get(`${ownerPeer}::${project.slug}`) ?? []
     const visible = ss.filter(s => s.alive || s.resumable === true)
     visible.sort(compareFolderSessions)

--- a/apps/gmux-web/src/references.test.ts
+++ b/apps/gmux-web/src/references.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { resolveReferences, removeReferenceItems, removeHostReferenceItems, refKey } from './references'
+import { referencePresence, unresolvedReferences, removeReferenceItems, removeHostReferenceItems } from './references'
 import type { PeerInfo, ProjectItem } from './types'
 
 function peer(name: string, node_id?: string): PeerInfo {
@@ -12,79 +12,82 @@ function owned(slug: string): ProjectItem {
   return { slug, match: [{ path: `/home/${slug}` }] }
 }
 
-describe('resolveReferences', () => {
-  it('resolves a legacy name-only reference and backfills its node_id', () => {
-    const projects = [ref('gmux-hs', 'apps')]
-    const roster = [peer('gmux-hs', 'node_hs')]
-    const { resolution, unresolved, backfills } = resolveReferences(projects, roster)
-    expect(resolution.get(refKey('gmux-hs', 'apps'))).toEqual({ effectivePeer: 'gmux-hs', resolved: true })
-    expect(unresolved).toEqual([])
-    expect(backfills).toEqual([{ slug: 'apps', fromPeer: 'gmux-hs', toPeer: 'gmux-hs', node_id: 'node_hs' }])
+describe('referencePresence', () => {
+  it('matches a reference by node_id (name-reuse-proof)', () => {
+    // node_id is the authority: a different host now holding the same
+    // name must NOT count as present.
+    const present = referencePresence([peer('gmux-hs', 'node_hs')])
+    expect(present('gmux-hs', 'node_hs')).toBe(true)
+    // node_id present under a different roster name: still present
+    expect(present('whatever', 'node_hs')).toBe(true)
+    // anchor gone, a confirmed different node_id holds the name: hijack,
+    // so not present
+    expect(present('gmux-hs', 'node_other')).toBe(false)
   })
 
-  it('resolves by node_id and follows a renamed host (name drift)', () => {
-    // Reference stored "unraid" + node, host now reports "gmux-hs".
-    const projects = [ref('unraid', 'apps', 'node_hs')]
-    const roster = [peer('gmux-hs', 'node_hs')]
-    const { resolution, unresolved, backfills } = resolveReferences(projects, roster)
-    expect(resolution.get(refKey('unraid', 'apps'))).toEqual({ effectivePeer: 'gmux-hs', resolved: true })
-    expect(unresolved).toEqual([])
-    // Backfill follows the rename: update the cached display name.
-    expect(backfills).toEqual([{ slug: 'apps', fromPeer: 'unraid', toPeer: 'gmux-hs', node_id: 'node_hs' }])
+  it('stays present when the named peer has no node_id yet (post-restart)', () => {
+    // After a daemon restart a peer is listed but its node_id isn't
+    // cached until it reconnects. A stamped reference to it must not
+    // flash "host not found" — an unknown node_id is not a confirmed
+    // mismatch.
+    const present = referencePresence([
+      { name: 'gmux-hs', url: 'https://gmux-hs', status: 'connecting', session_count: 0 },
+    ])
+    expect(present('gmux-hs', 'node_hs')).toBe(true)
   })
 
-  it('node_id match needs no backfill when the name is unchanged', () => {
+  it('matches a name-only reference by name', () => {
+    // A reference with no node_id (hand-authored/legacy) falls back to
+    // a plain name membership check.
+    const present = referencePresence([peer('workstation', 'N1')])
+    expect(present('workstation', undefined)).toBe(true)
+    expect(present('elsewhere', undefined)).toBe(false)
+  })
+
+  it('treats an offline-but-known host (no node_id) as present by name', () => {
+    // Offline peers sit in the roster without a cached node_id; a
+    // reference to one is reachable-but-offline, not unresolved.
+    const present = referencePresence([
+      { name: 'bespin', url: 'https://bespin', status: 'offline', session_count: 0 },
+    ])
+    expect(present('bespin', undefined)).toBe(true)
+  })
+
+  it('keeps a stamped reference present while its host is offline', () => {
+    // Once stamped, presence is by node_id. An offline peer still
+    // carries its cached node_id in the roster (peer.go keeps
+    // cachedHealth across disconnects), so a stamped reference to it
+    // stays present (reachable-but-offline) rather than flipping to
+    // unresolved. Guards against a future change that drops node_id
+    // from offline roster entries.
+    const present = referencePresence([
+      { name: 'bespin', url: 'https://bespin', status: 'offline', session_count: 0, node_id: 'N_bespin' },
+    ])
+    expect(present('bespin', 'N_bespin')).toBe(true)
+  })
+})
+
+describe('unresolvedReferences', () => {
+  it('flags a reference whose anchor is in no roster bucket', () => {
+    const projects = [ref('hs', 'apps', 'node_hs'), ref('hs', 'home', 'node_hs')]
+    const roster = [peer('unraid', 'node_other'), peer('ft', 'node_ft')]
+    expect(unresolvedReferences(projects, roster)).toEqual([{ name: 'hs', slugs: ['apps', 'home'] }])
+  })
+
+  it('does not flag a present (node_id-matched) reference', () => {
     const projects = [ref('gmux-hs', 'apps', 'node_hs')]
     const roster = [peer('gmux-hs', 'node_hs')]
-    const { backfills } = resolveReferences(projects, roster)
-    expect(backfills).toEqual([])
-  })
-
-  it('flags a reference whose host is in no roster bucket as unresolved', () => {
-    // The classic broken case: reference points at "hs", live host is
-    // "unraid"/"gmux-hs" — no roster peer named "hs".
-    const projects = [ref('hs', 'apps'), ref('hs', 'home'), ref('hs', 'chezmoi')]
-    const roster = [peer('unraid', 'node_hs'), peer('ft', 'node_ft')]
-    const { resolution, unresolved, backfills } = resolveReferences(projects, roster)
-    expect(resolution.get(refKey('hs', 'apps'))).toEqual({ effectivePeer: 'hs', resolved: false })
-    expect(backfills).toEqual([])
-    expect(unresolved).toEqual([{ name: 'hs', slugs: ['apps', 'home', 'chezmoi'] }])
-  })
-
-  it('treats an offline-but-known host (no node_id) as resolved, not unresolved', () => {
-    // Offline tailnet peers are in the roster without a node_id.
-    const projects = [ref('bespin', 'home')]
-    const roster: PeerInfo[] = [{ name: 'bespin', url: 'https://bespin', status: 'offline', session_count: 0 }]
-    const { resolution, unresolved, backfills } = resolveReferences(projects, roster)
-    expect(resolution.get(refKey('bespin', 'home'))).toEqual({ effectivePeer: 'bespin', resolved: true })
-    expect(unresolved).toEqual([])
-    expect(backfills).toEqual([]) // nothing to stamp; offline peer has no node_id
-  })
-
-  it('falls back to name and refreshes a stale node_id', () => {
-    // node_id was stamped, but that host is gone; another host now has
-    // the referenced name. Resolve by name rather than orphaning, and
-    // backfill the *current* node_id so the stale one doesn't linger
-    // (otherwise every load repeats the failed-id-then-name dance).
-    const projects = [ref('shared', 'proj', 'node_gone')]
-    const roster = [peer('shared', 'node_new')]
-    const { resolution, unresolved, backfills } = resolveReferences(projects, roster)
-    expect(resolution.get(refKey('shared', 'proj'))).toEqual({ effectivePeer: 'shared', resolved: true })
-    expect(unresolved).toEqual([])
-    expect(backfills).toEqual([{ slug: 'proj', fromPeer: 'shared', toPeer: 'shared', node_id: 'node_new' }])
+    expect(unresolvedReferences(projects, roster)).toEqual([])
   })
 
   it('ignores owned projects entirely', () => {
-    const projects = [owned('gmux'), ref('hs', 'apps')]
-    const roster: PeerInfo[] = []
-    const { resolution, unresolved } = resolveReferences(projects, roster)
-    expect(resolution.has(refKey('', 'gmux'))).toBe(false)
-    expect(unresolved).toEqual([{ name: 'hs', slugs: ['apps'] }])
+    const projects = [owned('gmux'), ref('hs', 'apps', 'node_hs')]
+    expect(unresolvedReferences(projects, [])).toEqual([{ name: 'hs', slugs: ['apps'] }])
   })
 
   it('groups multiple unresolved hosts independently', () => {
     const projects = [ref('hs', 'apps'), ref('old-laptop', 'dots'), ref('hs', 'home')]
-    const { unresolved } = resolveReferences(projects, [])
+    const unresolved = unresolvedReferences(projects, [])
     expect(unresolved).toContainEqual({ name: 'hs', slugs: ['apps', 'home'] })
     expect(unresolved).toContainEqual({ name: 'old-laptop', slugs: ['dots'] })
     expect(unresolved).toHaveLength(2)

--- a/apps/gmux-web/src/references.ts
+++ b/apps/gmux-web/src/references.ts
@@ -1,43 +1,15 @@
-// --- Peer reference resolution (refs #270) ---
+// --- Peer reference liveness (ADR 0015) ---
 //
-// A reference item in projects.json points at a project owned by
-// another host. It stores the host's display `peer` name and,
-// optionally, the host's stable opaque `node_id` (ADR 0007). Because
-// ADR 0007 derives a host's name from Tailscale / the OS hostname, that
-// name can change on upgrade — so resolving a reference purely by name
-// breaks silently when a host is renamed.
-//
-// `resolveReferences` is the single source of truth for "which live
-// host (if any) does this reference point at, and under what current
-// name." Every surface — the sidebar folders, the Hosts tab, the
-// settings gear pip — reads off its output so they all agree.
-//
-// Resolution order, per reference:
-//   1. by node_id — if the reference has a node_id and a roster peer
-//      reports the same one, it resolves to that peer's *current* name
-//      (the display name follows the live host across renames).
-//   2. by name — legacy references with no node_id (or whose node_id
-//      matches no live peer) fall back to matching the stored name. A
-//      name match against a peer that has a node_id yields a backfill,
-//      so the reference becomes rename-proof going forward.
-//   3. unresolved — no roster peer matches by id or name. The host
-//      isn't a current peer (manually added or a devcontainer); it may
-//      have been renamed or removed.
+// A reference points at a peer-owned project. Its `peer` name is the
+// runtime key (folder bucketing, peer_projects, URLs, routing) and is a
+// viewer-owned label frozen at first contact (ADR 0007 §7), so it
+// doesn't drift and the viewer renders it directly — no name
+// resolution. The only question left is liveness: is the host in the
+// roster? Answered by node_id when the reference has one (immune to a
+// reused name), else by name. That also blocks a freed-then-reused
+// name from adopting a stale reference.
 
 import type { PeerInfo, ProjectItem } from './types'
-
-/** Composite key for a reference, by its stored (peer, slug). */
-export function refKey(peer: string, slug: string): string {
-  return `${peer}\u0000${slug}`
-}
-
-export interface RefResolution {
-  /** Peer name to bucket sessions under and label the folder with.
-   *  Equals the live host's current name when resolved by node_id. */
-  effectivePeer: string
-  /** True when the reference points at a host in the current roster. */
-  resolved: boolean
-}
 
 /** A referenced host name that matches no roster peer, with the slugs
  *  that point at it. One entry per distinct unresolved name. */
@@ -46,108 +18,63 @@ export interface UnresolvedHost {
   slugs: string[]
 }
 
-/** A projects.json write needed to make a reference rename-proof:
- *  stamp `node_id` (and follow a drifted display name). The writer
- *  finds the item by (fromPeer, slug) and rewrites it to
- *  { peer: toPeer, node_id }. */
-export interface RefBackfill {
-  slug: string
-  fromPeer: string
-  toPeer: string
-  node_id: string
-}
-
-export interface ResolvedReferences {
-  /** Per-reference resolution, keyed by refKey(item.peer, item.slug). */
-  resolution: Map<string, RefResolution>
-  /** Distinct referenced host names not present in the roster. */
-  unresolved: UnresolvedHost[]
-  /** Opportunistic projects.json updates (stamp node_id / follow rename). */
-  backfills: RefBackfill[]
+/**
+ * Predicate: is a reference's host in the roster?
+ *
+ *  - node_id present in the roster → present (the anchor is live).
+ *  - name absent from the roster → not present.
+ *  - name present but the reference's node_id isn't: present *unless* a
+ *    confirmed, different node_id holds that name. A roster peer with no
+ *    node_id yet (e.g. not reconnected after a daemon restart) is not a
+ *    confirmed mismatch, so we stay present rather than flashing
+ *    "host not found"; a different node_id *is* name reuse, so we don't.
+ */
+export function referencePresence(
+  roster: readonly PeerInfo[],
+): (peer: string, nodeId?: string) => boolean {
+  const liveNodeIds = new Set<string>()
+  const nodeIdByName = new Map<string, string>() // '' = in roster, node_id unknown
+  for (const p of roster) {
+    if (p.node_id) liveNodeIds.add(p.node_id)
+    nodeIdByName.set(p.name, p.node_id ?? '')
+  }
+  return (peer, nodeId) => {
+    if (nodeId && liveNodeIds.has(nodeId)) return true
+    const named = nodeIdByName.get(peer)
+    if (named === undefined) return false // name not in roster
+    if (!nodeId) return true // name-only reference: name match suffices
+    return named === '' // present unless a different node_id owns the name
+  }
 }
 
 /**
- * Resolve every reference item in `projects` against the live peer
- * `roster`. Owned items (no `peer`) are ignored. Pure: no I/O, no
- * signals — callers feed it the current projects + peers and act on
- * the result.
+ * Distinct referenced hosts absent from the roster, with the slugs
+ * pointing at each. Drives the Hosts-tab "Referenced but not found"
+ * group and the gear pip.
  */
-export function resolveReferences(
+export function unresolvedReferences(
   projects: readonly ProjectItem[],
   roster: readonly PeerInfo[],
-): ResolvedReferences {
-  const byNodeId = new Map<string, PeerInfo>()
-  const byName = new Map<string, PeerInfo>()
-  for (const p of roster) {
-    // Last-write-wins if two roster entries report the same node_id
-    // (the duplicate-entry case — see the discovery-dedup follow-up).
-    // Resolution stays correct (both names are the same physical node),
-    // but which display name a reference resolves to then depends on
-    // roster order. Deduping the roster upstream removes the ambiguity.
-    if (p.node_id) byNodeId.set(p.node_id, p)
-    byName.set(p.name, p)
-  }
-
-  const resolution = new Map<string, RefResolution>()
-  const unresolvedMap = new Map<string, string[]>()
-  const backfills: RefBackfill[] = []
-
+): UnresolvedHost[] {
+  const present = referencePresence(roster)
+  const byName = new Map<string, string[]>()
   for (const item of projects) {
     if (!item.peer) continue // owned project, not a reference
-    const key = refKey(item.peer, item.slug)
-
-    // 1. node_id anchor: the durable identity. The live host's current
-    //    name wins, so a renamed host stays linked.
-    if (item.node_id) {
-      const live = byNodeId.get(item.node_id)
-      if (live) {
-        resolution.set(key, { effectivePeer: live.name, resolved: true })
-        if (live.name !== item.peer) {
-          // Host was renamed; follow it and refresh the cached name.
-          backfills.push({ slug: item.slug, fromPeer: item.peer, toPeer: live.name, node_id: item.node_id })
-        }
-        continue
-      }
-      // node_id set but no live peer reports it (host not currently a
-      // peer, or gone) — fall through to a name match.
-    }
-
-    // 2. name match: legacy references, or a reference whose stored
-    //    node_id matched no live peer (host gone / replaced). When the
-    //    matched peer's node_id differs from what's stored — covering
-    //    both the never-stamped and the stale cases — record a backfill
-    //    so the (deferred) backfill writer can refresh projects.json.
-    //    Resolution is already correct here; until that writer lands the
-    //    refreshed id isn't persisted, so the id-then-name fallback
-    //    recurs harmlessly on each load.
-    const named = byName.get(item.peer)
-    if (named) {
-      resolution.set(key, { effectivePeer: item.peer, resolved: true })
-      if (named.node_id && named.node_id !== item.node_id) {
-        backfills.push({ slug: item.slug, fromPeer: item.peer, toPeer: item.peer, node_id: named.node_id })
-      }
-      continue
-    }
-
-    // 3. unresolved: no live host matches. Keep the dangling name for
-    //    the folder label; the surface flags it.
-    resolution.set(key, { effectivePeer: item.peer, resolved: false })
-    const slugs = unresolvedMap.get(item.peer) ?? []
+    if (present(item.peer, item.node_id)) continue
+    const slugs = byName.get(item.peer) ?? []
     slugs.push(item.slug)
-    unresolvedMap.set(item.peer, slugs)
+    byName.set(item.peer, slugs)
   }
-
-  const unresolved: UnresolvedHost[] = []
-  for (const [name, slugs] of unresolvedMap) unresolved.push({ name, slugs })
-
-  return { resolution, unresolved, backfills }
+  const out: UnresolvedHost[] = []
+  for (const [name, slugs] of byName) out.push({ name, slugs })
+  return out
 }
 
 /**
  * Remove the references `(peer, slug)` for `slug` in `slugs`. Pure:
- * returns a new items array. Like the remap above, scoping to the
- * surfaced unresolved `slugs` is what prevents deleting a same-named
- * reference that's actually resolving correctly via node_id. (refs #270)
+ * returns a new items array. Scoping to the surfaced unresolved `slugs`
+ * is what prevents deleting a same-named reference that is actually
+ * present via its node_id anchor (ADR 0015).
  */
 export function removeReferenceItems(
   items: readonly ProjectItem[],

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -19,7 +19,7 @@ import type { View } from './routing'
 import { resolveViewFromPath, viewToPath } from './routing'
 import { navigateWithReload } from './version-watch'
 import { buildProjectFolders, discoverProjects } from './projects'
-import { resolveReferences, removeReferenceItems, removeHostReferenceItems, refKey, type UnresolvedHost } from './references'
+import { referencePresence, unresolvedReferences, removeReferenceItems, removeHostReferenceItems, type UnresolvedHost } from './references'
 
 import { fetchFrontendConfig, buildTerminalOptions, resolveKeybinds, type ResolvedKeybind } from './config'
 import { MOCK_SESSIONS, MOCK_PROJECTS, MOCK_PEERS, MOCK_HEALTH } from './mock-data/index'
@@ -516,19 +516,11 @@ export const localPeerNames = computed<ReadonlySet<string>>(() => {
   return set
 })
 
-/** Project folders for the sidebar, built from projects + sessions. */
-/** Reference resolution against the live roster: maps each reference
- *  to the host's current name (rename-proof via node_id) or flags it
- *  unresolved. Single source of truth for folders, the Hosts tab, and
- *  the gear pip. (refs #270) */
-export const resolvedReferences = computed(() =>
-  resolveReferences(projects.value, peers.value),
-)
-
-/** Distinct referenced host names that match no roster peer. Drives
- *  the Hosts-tab "Referenced but not found" group and the gear pip. */
+/** Distinct referenced host names absent from the roster. Drives the
+ *  Hosts-tab "Referenced but not found" group and the gear pip — a
+ *  node_id/name membership check against the roster (ADR 0015). */
 export const unresolvedHosts = computed<UnresolvedHost[]>(
-  () => resolvedReferences.value.unresolved,
+  () => unresolvedReferences(projects.value, peers.value),
 )
 
 /** Build sidebar folders from an arbitrary session list. Shared by the
@@ -541,7 +533,7 @@ function foldersFrom(ss: Session[]): Folder[] {
     ss,
     (name) => localPeerNames.value.has(name),
     _rawWorld.value.peerProjects,
-    (peer, slug) => resolvedReferences.value.resolution.get(refKey(peer, slug)),
+    referencePresence(peers.value),
   )
 }
 

--- a/apps/gmux-web/src/types.ts
+++ b/apps/gmux-web/src/types.ts
@@ -132,10 +132,11 @@ export interface ProjectItem {
   /** Set when this item is a reference to a peer-owned project. */
   peer?: string
   /**
-   * Stable opaque identity (ADR 0007) of the referenced peer, used to
-   * resolve the reference even after the peer is renamed. Set only on
-   * references; opportunistically backfilled once the peer is
-   * reachable. Absent on legacy references and owned projects.
+   * Referenced peer's stable opaque identity (ADR 0007). `peer` (the
+   * display name) is the runtime key the viewer renders and routes by;
+   * node_id is only the liveness anchor (see referencePresence),
+   * keeping a reference matched to the right host across re-adds and
+   * name reuse. Set only on references; absent on owned projects.
    */
   node_id?: string
   /** Owned-project match rules. Empty/absent for references. */

--- a/docs/adr/0015-reference-resolution-name-key-nodeid-plumbing.md
+++ b/docs/adr/0015-reference-resolution-name-key-nodeid-plumbing.md
@@ -1,0 +1,99 @@
+# ADR 0015: References identify by name; node_id is a liveness anchor
+
+**Status:** Proposed
+**Date:** 2026-06-23
+**Related:** ADR 0005 (references), ADR 0007 (host identity)
+**Supersedes:** the ad-hoc reference resolver from refs #270
+**Target:** gmux 2.0
+
+## Context
+
+A *reference* (ADR 0005) is a `projects.json` entry `{slug, peer}`
+pointing at a peer-owned project. ADR 0007 made the peer **name** a
+viewer-owned label and added a stable opaque **`node_id`**.
+
+refs #270 stored `node_id` on references and **resolved them by node_id
+at read time** in the viewer, to survive renames. That was both
+over-built and broken:
+
+- A peer's name is **frozen at first contact**: `peerstore.AddOrGet`
+  updates URL/token/node_id on a node_id match but never the name
+  (ADR 0007 §7), and a peer is re-probed only on an explicit "Connect
+  to host", not on reconnect. Peer sessions, namespaced IDs,
+  `peer_projects`, URLs and references all use that one frozen name. So
+  names don't drift, and the resolver's node_id→current-name step was a
+  no-op identity in every real case.
+- It still computed name-refresh writes (`backfills`) that **nothing
+  applied** — dead code that hid the fact the read-time re-resolution
+  was load-bearing only because the writer was never built.
+- It pushed node_id into the viewer's folder/hub matching layer — the
+  one place ADR 0007 keeps it out of — and the hub matched raw names,
+  disagreeing with folder-building.
+
+## Decision
+
+**Name is the key; node_id is a liveness anchor.** A reference's `peer`
+name is the runtime key (bucketing, `peer_projects`, URLs, routing) — a
+viewer-owned label that doesn't drift — so the viewer renders it
+directly and does **no** name resolution.
+
+The only residual "resolution" is a one-bit liveness check — *is the
+reference's host in the roster?* — computed in the viewer
+(`referencePresence` / `unresolvedReferences`): present if its node_id
+is live, else if its name is in the roster and no *different* node_id
+holds that name (so a reused name can't adopt a stale reference, while a
+not-yet-reconnected peer after a restart doesn't flash unresolved).
+
+It drives the unresolved flag and gates session bucketing. The inputs
+(reference node_id + roster node_ids) are already in `snapshot.world`;
+no new wire field.
+
+Deleted: `resolveReferences`, `effectivePeer`, the dead `backfills`,
+the `resolveRef` callback into `buildProjectFolders`, and the hub's
+separate name matching. `buildProjectFolders` takes an `isPresent`
+predicate instead.
+
+node_id is stamped at creation (`addPeerReference`), when the peer is
+known. Name-only references (hand-authored or legacy) match by name and
+gain nothing from a node_id, so none is required.
+
+**No daemon machinery:** because names don't drift, there is nothing to
+reconcile (contrast Alternative B).
+
+## Consequences
+
+- One namespace (the frozen name) everywhere; the hub's folder lookup
+  and its `project` lookup agree by construction.
+- No `projects.json` migration: the `{slug, peer, node_id?}` shape is
+  unchanged.
+- More correct against name reuse than #270: a stale node_id whose old
+  name is taken by a different host is flagged unresolved, not silently
+  hijacked.
+- Cheaper renders: the per-`(projects, peers)` resolver `computed` is
+  gone.
+- A renamed peer keeps its first-contact label until removed and
+  re-added. Accepted: names are viewer-owned (ADR 0007 §7).
+
+## Alternatives considered
+
+**A. Keep node_id in the URL / matching layer.** Rejected — everything
+at runtime keys on name; node_id-keying references forces a
+node_id→name projection at every use-site, the concern ADR 0007 §4
+avoids.
+
+**B. Make peer renames propagate.** Refresh a peer's stored name from
+its live identity on reconnect (a `peerstore` change), then have the
+daemon rewrite reference names to follow. This would make node_id
+genuinely load-bearing on references, and is the right design *if* we
+decide self-renames should surface. Out of scope for 2.0; names stay
+viewer-owned for now.
+
+**C. node_id-anchored storage + opaque `projects.json` + Projects UI.**
+Rejected, and not a planned direction: it costs a hard Projects-UI
+dependency and makes the file non-hand-authorable, for no real gain
+over a frozen-name label. Recorded only as an option should those
+trade-offs change.
+
+**D. Apply refs #270's `backfills` in the viewer.** Rejected: races
+across viewers and keeps the read-time resolver — and moot anyway,
+since names don't drift.

--- a/services/gmuxd/internal/projects/projects.go
+++ b/services/gmuxd/internal/projects/projects.go
@@ -60,11 +60,11 @@ type Item struct {
 	Peer     string      `json:"peer,omitempty"`
 	Match    []MatchRule `json:"match,omitempty"`
 	Sessions []string    `json:"sessions,omitempty"`
-	// NodeID anchors a reference on the peer's stable opaque identity
-	// (ADR 0007) so it survives the peer being renamed: the viewer
-	// resolves the reference by NodeID first, falling back to Peer
-	// (the display name). Set only on references; opportunistically
-	// backfilled once the referenced peer is reachable (refs #270).
+	// NodeID is the referenced peer's stable opaque identity (ADR 0007).
+	// Peer (the display name) is the runtime key; NodeID is only the
+	// viewer's liveness anchor (ADR 0015): it keeps a reference matching
+	// the right host across re-adds and stops a reused name from matching
+	// the wrong one. Set only on references; stamped at creation.
 	NodeID string `json:"node_id,omitempty"`
 }
 

--- a/services/gmuxd/internal/projects/projects_test.go
+++ b/services/gmuxd/internal/projects/projects_test.go
@@ -1408,7 +1408,7 @@ func TestValidateRejectsReferenceWithMatchRules(t *testing.T) {
 }
 
 // A reference's node_id anchor must survive a Save/Load round-trip so
-// the viewer can resolve renamed peers (refs #270).
+// the daemon can follow a renamed peer across restarts (ADR 0015).
 func TestReferenceNodeIDRoundTrips(t *testing.T) {
 	dir := t.TempDir()
 	orig := &State{Items: []Item{


### PR DESCRIPTION
Implements **ADR 0015** (first commit). Supersedes the un-ADR'd reference resolver from refs #270.

## Problem
A *reference* (`{slug, peer}`) points at a peer-owned project. refs #270 stored `node_id` on references and **resolved them by node_id at read time** in the viewer, to survive renames. Investigating it showed the premise doesn't hold here:

- A peer's **name is frozen at first contact** — `peerstore.AddOrGet` updates URL/token/node_id on a node_id match but **never the name** (ADR 0007 §7), and re-probe happens only on explicit "Connect to host", not reconnect. Peer sessions, namespaced IDs, `peer_projects`, URLs and references all use that one frozen name. So names don't drift, and the resolver's node_id→current-name step was a **no-op identity** in every real case.
- It computed name-refresh writes (`backfills`) that **nothing applied** — dead code hiding that the read-time re-resolution only "worked" because the writer was never built.
- It pushed node_id into the viewer's folder/hub matching layer — the one place ADR 0007 keeps it out of — and the hub matched raw names, disagreeing with folder-building.

## Decision (ADR 0015)
**Name is the runtime key; node_id is a liveness anchor.** A reference's `peer` name is a viewer-owned label that doesn't drift, so the viewer renders it directly and does **no** name resolution. The only residual is a one-bit liveness check — *is the host in the roster?* — by node_id when present (immune to a reused name), else by name.

## Changes (viewer only)
- Deleted `resolveReferences`, `effectivePeer`, the dead `backfills`/`RefBackfill`/`RefResolution`, the `resolveRef` callback into `buildProjectFolders`, and the now-dead `refKey`.
- Added `referencePresence` / `unresolvedReferences` (node_id membership against the roster already on the wire — no new field). Presence is conflict-aware: live by node_id, else by name unless a *different* node_id holds that name — so a reused name can't adopt a stale reference, while a not-yet-reconnected peer after a daemon restart doesn't flash "host not found". The bit also gates session bucketing.
- `buildProjectFolders` takes an `isPresent` predicate; references bucket/label by their stored name.
- `store.ts` drops the `resolvedReferences` computed.

## Notes
- **No daemon machinery.** An earlier draft reconciled reference names on the daemon (rename-follow); verification showed names don't drift in this architecture, so that was speculative and is not included. If we ever want peer self-renames to surface, that's a separate `peerstore` change (ADR 0015 Alternative B), and the reconcile would become justified then.
- **No `projects.json` migration** — the `{slug, peer, node_id?}` shape is unchanged. node_id stays stamped at creation (`addPeerReference`) as the liveness anchor; name-only references (hand-authored/legacy) match by name. Hand-authoring stays supported (no Projects UI required for 2.0).
- **More correct than #270** against name reuse: a stale node_id whose old name is taken by a different host is flagged unresolved, not silently hijacked.
- One namespace (the frozen name) everywhere, so the project-hub folder lookup and `project` lookup agree by construction.

## Tests
- `referencePresence` — node_id match, name-reuse hijack rejection, post-restart not-yet-reconnected (stays present), name fallback, offline-known, and offline-*stamped* (documents the `peer.go` cached-node_id-across-disconnect dependency); `unresolvedReferences` grouping/owned-ignored.
- `buildProjectFolders` reference bucketing + unresolved/missing precedence.
- `pnpm test` 521 passed, `pnpm lint` clean; full `go test ./...` green.