### PR TITLE
ci: prototype — let moon manage the JS toolchain + auto-install deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
           # head and makes `moon run` fail with git exit 128.
           fetch-depth: 0
 
+      # Go isn't moon-managed (the Go projects shell out to `go` directly),
+      # so it still needs its own setup + cache.
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: "1.26"
@@ -38,23 +40,24 @@ jobs:
             **/go.sum
             go.work.sum
 
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+      # proto + moon, with the toolchain (~/.proto) cached. Node + pnpm are
+      # provisioned by moon at the versions pinned in .prototools; the first
+      # `moon run` of a JS task auto-installs deps (InstallDependencies),
+      # so there's no setup-node / pnpm/action-setup / `pnpm install` step.
+      - uses: moonrepo/setup-toolchain@261c62cb5b0f580c7be7c8cd0f023a2e96756095 # v0.6.4
         with:
-          node-version: "22"
+          auto-install: true
 
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+      # moon auto-installs JS deps and provisions the toolchain.
+      - name: Lint, build, test
+        run: moon run :lint :build :test
 
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Lint
-        run: pnpm lint
-
-      - name: Build
-        run: pnpm build
-
-      - name: Test
-        run: pnpm test
+      # biome lives outside moon (repo-wide, not a per-project task); run it
+      # after a moon task so deps are present. Matches the root `lint` script.
+      # (Open question if we adopt this: make biome a moon task so the whole
+      # pipeline is one `moon run` and `pnpm lint` == CI still holds.)
+      - name: Biome
+        run: pnpm exec biome lint --error-on-warnings .
 
   e2e:
     name: E2E (Playwright)

--- a/.moon/toolchains.yml
+++ b/.moon/toolchains.yml
@@ -1,0 +1,23 @@
+# Toolchain management (moon v2). With this file present, moon provisions
+# Node + pnpm itself (via proto) at the versions pinned in .prototools, and
+# runs an InstallDependencies action before any task when the lockfile or
+# manifest changed — so `pnpm install` is no longer a manual prerequisite,
+# and dev/CI/prod all run identical tooling.
+#
+# moon v2 splits the old monolithic `node` platform into three independent
+# toolchains that must each be enabled: the `javascript` toolchain (told
+# which package manager to use), the `node` runtime, and the `pnpm` package
+# manager. Versions are inherited from .prototools (single source of truth).
+
+# JavaScript ecosystem — selects the package manager.
+javascript:
+  packageManager: 'pnpm'
+  # Don't rewrite pnpm-lock.yaml on every install: the default dedupe
+  # reorders the lockfile and adds churn we don't want in diffs/CI.
+  dedupeOnLockfileChange: false
+
+# Node.js runtime (version from .prototools).
+node: {}
+
+# pnpm package manager (version from .prototools).
+pnpm: {}

--- a/.prototools
+++ b/.prototools
@@ -1,0 +1,5 @@
+# Pinned tool versions, resolved by proto (and moon's toolchain).
+# Single source of truth for Node + pnpm across dev and CI.
+node = "22"
+pnpm = "10.32.1"
+moon = "2.0.4"


### PR DESCRIPTION
**Draft / exploratory** — answering "could moon manage the JS toolchain?" Yes. Pushed so CI shows the real behavior + timing. Not for merge as-is.

## What this does
- `.moon/toolchains.yml` — moon v2 split the old monolithic `node` platform into three independent toolchains, so all three are enabled: `javascript` (selects pnpm), `node`, `pnpm`. (v2 also renamed the file `toolchain.yml` → `toolchains.yml`.)
- `.prototools` — pins `node`/`pnpm`/`moon` versions as the single source of truth.
- `ci.yml` — drops `setup-node` + `pnpm/action-setup` + `pnpm install`, replaced by `moonrepo/setup-toolchain` (installs proto+moon, caches `~/.proto`) and a direct `moon run :lint :build :test`.

## Verified locally
- `moon setup` provisions proto + Node 22 + pnpm 10.32.1.
- Removing `node_modules` and running a moon task **auto-reinstalls** — the action graph gained `SetupToolchain(node/pnpm)` + `InstallDependencies(javascript)`, which were absent before.
- Full `build` + `test` pass under moon-managed Node 22.

## Tradeoffs surfaced (why this is a draft, not a merge)
1. **Lockfile churn.** The `javascript` toolchain's default `dedupeOnLockfileChange` rewrites `pnpm-lock.yaml` on install. Disabled it here; worth knowing it's on by default.
2. **Bootstrap chicken-and-egg.** moon was a pnpm devDep; if you `rm -rf node_modules` the `moon` binary goes with it. The toolchain approach wants moon installed standalone (via `setup-toolchain` / proto), which is what the CI change does — but it's a real shift in how you bootstrap.
3. **biome sits outside moon.** `pnpm lint` runs biome *before* `moon run`, so it needs deps pre-installed; with moon-managed install I had to call moon directly and run biome as its own CI step. This breaks the tidy `pnpm lint` == CI property from #328. Cleanest fix if adopted: **make biome a moon task** so the whole pipeline is one `moon run`.
4. **Go is unaffected** — the Go projects shell out to `go` directly (`language: bash`), so they still need `setup-go`. moon only manages the JS side here.
5. **Supersedes the docs note** in #330 ("moon does not auto-install") if adopted.

## Recommendation
Genuinely nice for determinism (pinned Node/pnpm everywhere) and removing the manual `pnpm install`. But it's a real infra decision with the tradeoffs above — wants its own ADR + a decision on biome-as-moon-task before it's more than a prototype.