### PR TITLE
feat(gmuxd): bound session state dir — scrollback as cache, meta mirrors conversation existence

### DIFF
--- a/docs/adr/0016-session-retention-scrollback-as-cache.md
+++ b/docs/adr/0016-session-retention-scrollback-as-cache.md
@@ -1,0 +1,100 @@
+# ADR 0016: dead-session retention — scrollback is a cache, meta mirrors conversation existence
+
+**Status:** Accepted
+**Date:** 2026-06-23
+**Related:** ADR 0011 (runner-owned session state), ADR 0014 (adapter-owned conversation sources)
+
+## Context
+
+Each dead, never-dismissed session leaves a directory under
+`$XDG_STATE_HOME/gmux/sessions/<id>/`:
+
+- `meta.json` (~1 KB) — written by `sessionmeta` on every `Alive=false`
+  landing. Powers the sidebar entry and the resume affordance, and survives a
+  daemon restart.
+- `scrollback` + `scrollback.0` — written *live* by the runner
+  (`packages/scrollback`), capped at `2 × MaxBytes` ≈ **2 MiB per session**.
+
+After ADR 0014 retired the daemon's file monitor, this directory was the sole
+remaining unbounded-growth surface: a user who never dismisses accumulates one
+dir per dead session forever. The big artifact is scrollback; meta is tiny and
+is the thing that makes a session resumable and visible.
+
+## Decision
+
+Two tiers, with different lifetimes for the two artifacts.
+
+### 1. Scrollback is a cache (aggregate byte cap)
+
+`PruneScrollback` sums scrollback bytes across all dead sessions and, when the
+total exceeds `ScrollbackCacheBytes` (`GMUX_SCROLLBACK_CACHE_MB`, default
+**256 MiB**), deletes scrollback files **oldest-first** (by newest scrollback
+mtime) until back under the cap. `meta.json` is **kept** — the session stays in
+the sidebar and resumable; replay simply has no terminal history. That is the
+accepted tradeoff: scrollback is reconstructible-by-rerun context, not a
+durable record.
+
+**Liveness guard.** The runner writes scrollback live into the same dir, so a
+live session's scrollback must never be evicted. The store is the authority on
+liveness; the prune skips any session ID the store reports `Alive`. At startup
+this runs only from discovery's first-scan hook, *after* live runners have
+re-registered as alive.
+
+**When it runs.** At startup (first-scan hook) and, throttled to ≥12 h since
+the last run, when a session is **dismissed**. No background timer: a periodic
+tick would cause disk churn at moments unrelated to anything the user did.
+Dismiss is a natural, user-initiated moment; startup covers restarts. The
+throttle is tracked by the mtime of a `.scrollback-prune-stamp` marker.
+
+### 2. `meta.json` mirrors conversation existence
+
+A dead session's *whole* entry is retired only when its backing conversation
+file disappears. The conversations index (ADR 0014) already observes file
+removals via adapter sources; `RemoveByPath` now fires a callback, and gmuxd
+retires the dead session(s) whose `SessionFile` matches (skipping any alive or
+peer-owned session — the mapping is N:1). `sessions.Remove` broadcasts
+`session-remove`, which the existing `WatchRemovals` loop catches to drop the
+dir.
+
+The index only observes removals while gmuxd runs, so a file deleted *while the
+daemon is down* would otherwise leave an orphan entry. A **startup reconcile**
+closes that gap: after the first discovery scan (live runners flagged), gmuxd
+asks each owning adapter, via the `ConversationProber` capability, whether its
+dead sessions' conversation files are gone. The adapter distinguishes a genuine
+deletion from *unreachable storage* (unmounted home, tool never installed) —
+this is adapter-owned because only the adapter knows which directory anchors
+"storage is present" for its layout. The shared `ConversationGoneAtRoot` helper
+implements the common rule: a file absent under a present `SessionRootDir` is
+deleted; an absent/unreadable root, or any non-`NotExist` stat error, is
+undeterminable and never retires. Only a confident "gone" retires the entry.
+
+**Conversation-less corpses** (shells, and anything that never reported a
+`session_file`) have no conversation whose removal could retire them, so they
+fall back to a whole-dir age/count cap at startup `Sweep`:
+`GMUX_SESSION_RETENTION_DAYS` (default 30) and `GMUX_SESSION_RETENTION_MAX`
+(default 200, LRU by exit time). Sessions *with* a conversation file are exempt
+from this cap — their lifecycle is the conversation's.
+
+## Consequences
+
+- Agent session, conversation file present: meta + sidebar entry persist
+  ~indefinitely (cheap); scrollback reclaimed under space pressure.
+- Agent session, conversation file deleted while running: index notices → entry
+  retires.
+- Agent session, conversation file deleted while gmuxd was down: startup
+  reconcile retires it on next launch (when the adapter confirms deletion).
+- Shell corpse: aged/counted out.
+- Bound holds across restarts (startup prune) and within a long run (dismiss).
+  A daemon that never restarts and whose user never dismisses is the one gap;
+  judged acceptable, since that user isn't generating new dead sessions either.
+- All knobs accept a non-negative integer; `0` disables that limit.
+
+## Known limitation
+
+- Reconcile relies on `SessionRootDir` presence as the storage-availability
+  anchor. If a tool's root sits on local disk but an individual conversation
+  lives on a *separate* mount that's down, a missing file under a present root
+  would read as deleted. This is exotic — these tools keep all conversations
+  under one tree below `$HOME` — and the cost is one retired (~1 KB) entry, so
+  we accept it. An adapter with such a layout can implement `ConversationGone`
+  with finer logic (e.g. sibling-file probing) instead of the shared helper.

--- a/packages/adapter/adapters/claude.go
+++ b/packages/adapter/adapters/claude.go
@@ -18,6 +18,7 @@ import (
 // Compile-time interface checks.
 var (
 	_ adapter.ConversationSource = (*Claude)(nil)
+	_ adapter.ConversationProber = (*Claude)(nil)
 	_ adapter.Launchable         = (*Claude)(nil)
 	_ adapter.SessionFiler       = (*Claude)(nil)
 	_ adapter.Resumer            = (*Claude)(nil)
@@ -80,6 +81,13 @@ func (c *Claude) SessionRootDir() string {
 		return ""
 	}
 	return filepath.Join(home, ".claude", "projects")
+}
+
+// ConversationGone anchors deletion detection on SessionRootDir
+// (~/.claude/projects): if that tree is present, a missing transcript
+// was deleted; if it's absent, the storage is unavailable.
+func (c *Claude) ConversationGone(path string) (gone bool, ok bool) {
+	return adapter.ConversationGoneAtRoot(path, c.SessionRootDir())
 }
 
 // encodeClaudeCwd encodes a working directory into Claude Code's directory

--- a/packages/adapter/adapters/codex.go
+++ b/packages/adapter/adapters/codex.go
@@ -23,6 +23,7 @@ import (
 // Compile-time interface checks.
 var (
 	_ adapter.ConversationSource = (*Codex)(nil)
+	_ adapter.ConversationProber = (*Codex)(nil)
 	_ adapter.Launchable         = (*Codex)(nil)
 	_ adapter.SessionFiler       = (*Codex)(nil)
 	_ adapter.SessionHookCommand = (*Codex)(nil)
@@ -97,6 +98,14 @@ func (c *Codex) SessionRootDir() string {
 		return ""
 	}
 	return filepath.Join(home, ".codex", "sessions")
+}
+
+// ConversationGone anchors deletion detection on SessionRootDir
+// (~/.codex/sessions). The date-nested YYYY/MM/DD subtree may be
+// cleaned up around a deleted transcript, so the stable root — not the
+// file's immediate parent — is the right availability anchor.
+func (c *Codex) ConversationGone(path string) (gone bool, ok bool) {
+	return adapter.ConversationGoneAtRoot(path, c.SessionRootDir())
 }
 
 // SessionDir returns today's date-nested directory where Codex writes new

--- a/packages/adapter/adapters/pi.go
+++ b/packages/adapter/adapters/pi.go
@@ -17,6 +17,7 @@ import (
 // Compile-time interface checks.
 var (
 	_ adapter.ConversationSource  = (*Pi)(nil)
+	_ adapter.ConversationProber  = (*Pi)(nil)
 	_ adapter.Launchable          = (*Pi)(nil)
 	_ adapter.SessionFiler        = (*Pi)(nil)
 	_ adapter.Resumer             = (*Pi)(nil)
@@ -164,6 +165,14 @@ func (p *Pi) SessionRootDir() string {
 		return ""
 	}
 	return filepath.Join(home, ".pi", "agent", "sessions")
+}
+
+// ConversationGone anchors deletion detection on SessionRootDir
+// (PI_CODING_AGENT_DIR/sessions or ~/.pi/agent/sessions): present root
+// means a missing session file was deleted; absent root means the
+// storage is unavailable.
+func (p *Pi) ConversationGone(path string) (gone bool, ok bool) {
+	return adapter.ConversationGoneAtRoot(path, p.SessionRootDir())
 }
 
 // SessionDir returns pi's session directory for a given cwd.

--- a/packages/adapter/adapters/pi_test.go
+++ b/packages/adapter/adapters/pi_test.go
@@ -385,3 +385,36 @@ func TestPiExtendCommand(t *testing.T) {
 		})
 	}
 }
+
+// TestPiConversationGone verifies the adapter anchors deletion detection
+// on its own SessionRootDir: a missing file under a live root reads as
+// deleted, while a missing root (unreachable storage) is undeterminable.
+func TestPiConversationGone(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("PI_CODING_AGENT_DIR", dir)
+	p := NewPi()
+	root := p.SessionRootDir() // <dir>/sessions
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// File deleted, storage present → gone.
+	if gone, ok := p.ConversationGone(filepath.Join(root, "x", "conv.jsonl")); !gone || !ok {
+		t.Errorf("deleted-under-live-root: got (gone=%v ok=%v), want (true true)", gone, ok)
+	}
+
+	// File present → not gone.
+	live := filepath.Join(root, "live.jsonl")
+	if err := os.WriteFile(live, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if gone, ok := p.ConversationGone(live); gone || !ok {
+		t.Errorf("present: got (gone=%v ok=%v), want (false true)", gone, ok)
+	}
+
+	// Storage root absent → undeterminable, never a false deletion.
+	t.Setenv("PI_CODING_AGENT_DIR", filepath.Join(dir, "unmounted"))
+	if gone, ok := p.ConversationGone(filepath.Join(dir, "unmounted", "sessions", "c.jsonl")); gone || ok {
+		t.Errorf("absent-root: got (gone=%v ok=%v), want (false false)", gone, ok)
+	}
+}

--- a/packages/adapter/capabilities.go
+++ b/packages/adapter/capabilities.go
@@ -80,6 +80,29 @@ type ConversationSource interface {
 	WatchConversations(ctx context.Context, sink ConversationSink) error
 }
 
+// ConversationProber is implemented by SessionFiler adapters that can
+// tell a *deleted* conversation file apart from one whose storage is
+// merely *unavailable* (unmounted home, a tool dir that doesn't exist
+// yet). The startup retention reconcile (services/gmuxd) uses it to
+// retire dead sessions whose backing conversation is genuinely gone
+// without nuking entries when the tool's on-disk layout simply isn't
+// reachable.
+//
+// The distinction is adapter-owned because only the adapter knows which
+// directory anchors "storage is present" for its layout — e.g. the
+// per-cwd project dir under ~/.claude/projects vs codex's date-nested
+// ~/.codex/sessions/YYYY/MM/DD. The shared ConversationGoneAtRoot helper
+// implements the common root-anchored rule; adapters with quirkier
+// layouts may answer differently.
+type ConversationProber interface {
+	// ConversationGone reports whether the conversation file at path was
+	// deleted. ok=false means the answer is undeterminable (storage
+	// unavailable), in which case the caller MUST NOT treat the
+	// conversation as gone. When the file is present, returns
+	// (false, true).
+	ConversationGone(path string) (gone bool, ok bool)
+}
+
 // SessionExtender marks adapters whose agent exposes a native extension/hook
 // API that can report the active session authoritatively — the strongest
 // signal, catching even a cache-served /resume-select that leaves no fs

--- a/packages/adapter/conversation.go
+++ b/packages/adapter/conversation.go
@@ -1,0 +1,37 @@
+package adapter
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+)
+
+// ConversationGoneAtRoot is the standard ConversationProber rule for
+// adapters whose storage root directory's presence indicates the tool's
+// conversation storage is reachable. It distinguishes a deleted file
+// from unreachable storage:
+//
+//   - path present                          → (false, true)  not gone
+//   - path absent, root is a readable dir    → (true,  true)  deleted
+//   - path absent, root absent/unreadable    → (false, false) undeterminable
+//   - any non-NotExist stat error on path    → (false, false) undeterminable
+//
+// root is the adapter's layout anchor (e.g. SessionRootDir). It lives
+// under the same storage as path, so an unmounted home or a tool that
+// was never installed makes root absent too — yielding ok=false rather
+// than a false "deleted". Empty path or root is undeterminable.
+func ConversationGoneAtRoot(path, root string) (gone bool, ok bool) {
+	if path == "" || root == "" {
+		return false, false
+	}
+	if _, err := os.Stat(path); err == nil {
+		return false, true // present
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return false, false // can't tell (permission/IO error)
+	}
+	// path is absent: is the storage anchor present and a directory?
+	if fi, err := os.Stat(root); err == nil && fi.IsDir() {
+		return true, true // storage reachable, file gone → deleted
+	}
+	return false, false // storage unavailable → undeterminable
+}

--- a/packages/adapter/conversation_test.go
+++ b/packages/adapter/conversation_test.go
@@ -1,0 +1,56 @@
+package adapter
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestConversationGoneAtRoot(t *testing.T) {
+	root := t.TempDir()
+	present := filepath.Join(root, "conv.jsonl")
+	if err := os.WriteFile(present, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	missing := filepath.Join(root, "deleted.jsonl")
+
+	t.Run("present file is not gone", func(t *testing.T) {
+		gone, ok := ConversationGoneAtRoot(present, root)
+		if gone || !ok {
+			t.Errorf("present: got (gone=%v ok=%v), want (false true)", gone, ok)
+		}
+	})
+
+	t.Run("missing file with live root is deleted", func(t *testing.T) {
+		gone, ok := ConversationGoneAtRoot(missing, root)
+		if !gone || !ok {
+			t.Errorf("deleted: got (gone=%v ok=%v), want (true true)", gone, ok)
+		}
+	})
+
+	t.Run("missing file with absent root is undeterminable", func(t *testing.T) {
+		// Storage anchor doesn't exist (e.g. unmounted home): must NOT
+		// claim deletion.
+		absentRoot := filepath.Join(root, "nope", "sessions")
+		gone, ok := ConversationGoneAtRoot(filepath.Join(absentRoot, "c.jsonl"), absentRoot)
+		if gone || ok {
+			t.Errorf("absent root: got (gone=%v ok=%v), want (false false)", gone, ok)
+		}
+	})
+
+	t.Run("root that is a file (not dir) is undeterminable", func(t *testing.T) {
+		gone, ok := ConversationGoneAtRoot(missing, present) // present is a file
+		if gone || ok {
+			t.Errorf("file-as-root: got (gone=%v ok=%v), want (false false)", gone, ok)
+		}
+	})
+
+	t.Run("empty args are undeterminable", func(t *testing.T) {
+		if g, ok := ConversationGoneAtRoot("", root); g || ok {
+			t.Errorf("empty path: want (false false), got (%v %v)", g, ok)
+		}
+		if g, ok := ConversationGoneAtRoot(present, ""); g || ok {
+			t.Errorf("empty root: want (false false), got (%v %v)", g, ok)
+		}
+	})
+}

--- a/packages/paths/paths.go
+++ b/packages/paths/paths.go
@@ -79,6 +79,14 @@ func SessionsDir() string {
 // SessionsDir. The directory holds meta.json (written by gmuxd's
 // sessionmeta package) and scrollback / scrollback.0 (written by
 // the runner's scrollback package).
+//
+// gmuxd bounds the growth of these artifacts (see ADR 0016 and
+// services/gmuxd/internal/sessionmeta): scrollback is treated as a
+// cache capped at an aggregate byte budget (GMUX_SCROLLBACK_CACHE_MB,
+// default 256), evicted oldest-first while meta.json survives; a dead
+// session's whole entry is retired when its conversation file
+// disappears, and conversation-less corpses fall back to an age/count
+// cap (GMUX_SESSION_RETENTION_DAYS / GMUX_SESSION_RETENTION_MAX).
 func SessionDir(id string) string {
 	return filepath.Join(SessionsDir(), id)
 }

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -455,7 +455,7 @@ func serve(stderr io.Writer) int {
 	// hook below persists every Alive=false landing; Dismiss /
 	// Resume merge / slug takeover drop the corresponding directory.
 	// See sessionmeta package doc for the full lifecycle.
-	metaStore := sessionmeta.New(sessionmeta.DefaultDir())
+	metaStore := sessionmeta.New(sessionmeta.DefaultDir(), sessionmeta.WithRetention(sessionmeta.DefaultRetention()))
 	// persistedKeys records the id and slug of every session sessionmeta
 	// holds on disk at startup (the post-retention sweep survivors). The
 	// startup CleanupSessions unions this with the live store so a project
@@ -486,6 +486,48 @@ func serve(stderr io.Writer) int {
 	forgetMeta := func(id string) {
 		if err := metaStore.Remove(id); err != nil {
 			log.Printf("sessionmeta: remove %s: %v", id, err)
+		}
+	}
+	// aliveSessionIDs snapshots which locally-owned sessions have a live
+	// runner. Scrollback pruning consults it so a runner's open
+	// scrollback file is never deleted out from under it (the runner
+	// writes scrollback live into the same session dir).
+	aliveSessionIDs := func() map[string]bool {
+		alive := map[string]bool{}
+		for _, s := range sessions.List() {
+			if s.Alive {
+				alive[s.ID] = true
+			}
+		}
+		return alive
+	}
+	// scrollbackCacheInterval throttles the dismiss-triggered scrollback
+	// prune: a long-running daemon reclaims cache at a natural moment
+	// (a dismiss) at most this often, with no background timer. Startup
+	// runs an unthrottled prune via discovery's first-scan hook below.
+	const scrollbackCacheInterval = 12 * time.Hour
+
+	// Retire the dead session(s) backed by a conversation file when that
+	// file disappears: the conversations index reports the removal, and
+	// meta.json mirrors conversation existence (ADR 0016). The store
+	// applies the alive/peer/N:1 guards; its session-remove broadcast is
+	// what WatchRemovals turns into a meta-dir delete.
+	convRetireMeta := func(path string) { sessions.RemoveDeadBySessionFile(path) }
+
+	// retireDeleted closes the gap the runtime index signal can't cover:
+	// a conversation file deleted while gmuxd was *down* emits no removal
+	// event. Run from discovery's first-scan hook (live runners flagged),
+	// it asks each owning adapter whether its dead sessions' files are
+	// gone. See reconcileDeletedConversations for the safety gate.
+	convProbe := func(kind, path string) (gone, known bool) {
+		if p, ok := adapters.FindByKind(kind).(adapter.ConversationProber); ok {
+			return p.ConversationGone(path)
+		}
+		return false, false
+	}
+	retireDeleted := func(path string) {
+		if ids := sessions.RemoveDeadBySessionFile(path); len(ids) > 0 {
+			log.Printf("sessionmeta: retired %d dead session(s) for deleted conversation %s", len(ids), path)
 		}
 	}
 
@@ -529,7 +571,13 @@ func serve(stderr io.Writer) int {
 	// Start socket-based discovery (scans paths.SessionSocketDir() for *.sock)
 	// Discovery also subscribes to each runner's /events SSE for live updates.
 	stopDiscovery := make(chan struct{})
-	go discovery.Watch(sessions, subs, persistDead, nil, 3*time.Second, stopDiscovery)
+	// onFirstScan fires after the initial socket scan has registered live
+	// runners as Alive, so the startup scrollback prune can safely skip
+	// their open files. Runs unthrottled and refreshes the prune stamp.
+	go discovery.Watch(sessions, subs, persistDead, func() {
+		reconcileDeletedConversations(sessions.List(), convProbe, retireDeleted)
+		metaStore.PruneScrollback(aliveSessionIDs())
+	}, 3*time.Second, stopDiscovery)
 	defer close(stopDiscovery)
 
 	// Session file scanner — discovers resumable sessions from adapter
@@ -546,6 +594,7 @@ func serve(stderr io.Writer) int {
 	// adapter's ConversationSource supplies a snapshot at startup and
 	// incremental updates thereafter; the daemon owns no file monitor.
 	convIndex := conversations.New()
+	convIndex.SetOnRemoveByPath(convRetireMeta)
 	convIndex.Snapshot()
 	log.Printf("conversations: indexed %d files", convIndex.Count())
 
@@ -1618,6 +1667,10 @@ func serve(stderr io.Writer) int {
 			if subs != nil {
 				subs.Unsubscribe(sessionID)
 			}
+			// Reclaim scrollback cache at this natural moment, throttled
+			// so frequent dismisses don't re-walk the dir each time.
+			// Async: dismiss shouldn't block on disk eviction.
+			go metaStore.MaybePruneScrollback(aliveSessionIDs(), scrollbackCacheInterval)
 			writeJSON(w, map[string]any{"ok": true, "data": map[string]any{}})
 
 		case "wait":

--- a/services/gmuxd/cmd/gmuxd/retention.go
+++ b/services/gmuxd/cmd/gmuxd/retention.go
@@ -1,0 +1,36 @@
+package main
+
+import "github.com/gmuxapp/gmux/services/gmuxd/internal/store"
+
+// reconcileDeletedConversations is the startup counterpart to the
+// runtime conversations-index removal callback: it retires dead,
+// locally-owned sessions whose backing conversation file an adapter
+// confidently reports deleted. It covers the gap the index can't —
+// a conversation file removed while gmuxd was down emits no event.
+//
+// probe answers "is this kind's conversation file at path gone?" as
+// (gone, known). Retirement happens only on (known && gone): when the
+// adapter can't tell (known=false, e.g. its storage root is unreachable
+// because home isn't mounted), the entry is kept. That gate is the
+// whole point — it must never retire on undeterminable storage — so it
+// lives in one tested place rather than inline at the call site.
+//
+// Each distinct conversation file is probed once (the file→session
+// mapping is N:1); retire is expected to drop every dead session for
+// that path. Alive, peer-owned, and file-less sessions are skipped.
+func reconcileDeletedConversations(
+	list []store.Session,
+	probe func(kind, sessionFile string) (gone, known bool),
+	retire func(sessionFile string),
+) {
+	seen := map[string]bool{}
+	for _, sess := range list {
+		if sess.Alive || sess.Peer != "" || sess.SessionFile == "" || seen[sess.SessionFile] {
+			continue
+		}
+		seen[sess.SessionFile] = true
+		if gone, known := probe(sess.Kind, sess.SessionFile); known && gone {
+			retire(sess.SessionFile)
+		}
+	}
+}

--- a/services/gmuxd/cmd/gmuxd/retention_test.go
+++ b/services/gmuxd/cmd/gmuxd/retention_test.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/store"
+)
+
+// TestReconcileDeletedConversations_SafetyGate is the core regression
+// guard: a session is retired only when the adapter is *confident* the
+// file is gone (known && gone). An undeterminable answer (known=false,
+// e.g. storage unreachable) must never retire — that's the whole reason
+// the reconcile asks an adapter instead of stat'ing the file directly.
+func TestReconcileDeletedConversations_SafetyGate(t *testing.T) {
+	list := []store.Session{
+		{ID: "deleted", Kind: "claude", SessionFile: "/c/deleted.jsonl"},
+		{ID: "present", Kind: "claude", SessionFile: "/c/present.jsonl"},
+		{ID: "unreachable", Kind: "codex", SessionFile: "/x/unreachable.jsonl"},
+	}
+	probe := func(kind, path string) (gone, known bool) {
+		switch path {
+		case "/c/deleted.jsonl":
+			return true, true // confidently deleted
+		case "/c/present.jsonl":
+			return false, true // file still there
+		case "/x/unreachable.jsonl":
+			return true, false // storage unreachable — undeterminable
+		}
+		return false, false
+	}
+
+	var retired []string
+	reconcileDeletedConversations(list, probe, func(p string) { retired = append(retired, p) })
+
+	if !reflect.DeepEqual(retired, []string{"/c/deleted.jsonl"}) {
+		t.Fatalf("only the confidently-deleted file should retire, got %v", retired)
+	}
+}
+
+// TestReconcileDeletedConversations_Skips pins that alive, peer-owned,
+// and file-less sessions are never probed or retired.
+func TestReconcileDeletedConversations_Skips(t *testing.T) {
+	list := []store.Session{
+		{ID: "alive", Kind: "claude", SessionFile: "/c/a.jsonl", Alive: true},
+		{ID: "peer", Kind: "claude", SessionFile: "/c/b.jsonl", Peer: "box2"},
+		{ID: "nofile", Kind: "claude", SessionFile: ""},
+	}
+	var probed, retired []string
+	reconcileDeletedConversations(list,
+		func(_, path string) (bool, bool) { probed = append(probed, path); return true, true },
+		func(p string) { retired = append(retired, p) })
+
+	if len(probed) != 0 {
+		t.Errorf("alive/peer/file-less sessions must not be probed, probed %v", probed)
+	}
+	if len(retired) != 0 {
+		t.Errorf("nothing should be retired, retired %v", retired)
+	}
+}
+
+// TestReconcileDeletedConversations_DedupsPaths pins that an N:1
+// conversation (several dead sessions sharing one file) is probed and
+// retired once — retire is expected to drop all matching sessions.
+func TestReconcileDeletedConversations_DedupsPaths(t *testing.T) {
+	const shared = "/c/shared.jsonl"
+	list := []store.Session{
+		{ID: "d1", Kind: "claude", SessionFile: shared},
+		{ID: "d2", Kind: "claude", SessionFile: shared},
+		{ID: "d3", Kind: "claude", SessionFile: shared},
+	}
+	var probed, retired []string
+	reconcileDeletedConversations(list,
+		func(_, path string) (bool, bool) { probed = append(probed, path); return true, true },
+		func(p string) { retired = append(retired, p) })
+
+	if !reflect.DeepEqual(probed, []string{shared}) {
+		t.Errorf("shared path should be probed once, got %v", probed)
+	}
+	if !reflect.DeepEqual(retired, []string{shared}) {
+		t.Errorf("shared path should be retired once, got %v", retired)
+	}
+}
+
+// TestReconcileDeletedConversations_NoProberKind pins that a kind whose
+// adapter can't probe (probe returns known=false) is left alone — this
+// is how the real convProbe reports a missing/incapable adapter.
+func TestReconcileDeletedConversations_NoProberKind(t *testing.T) {
+	list := []store.Session{{ID: "s", Kind: "shell", SessionFile: "/s/x"}}
+	var retired []string
+	reconcileDeletedConversations(list,
+		func(_, _ string) (bool, bool) { return false, false },
+		func(p string) { retired = append(retired, p) })
+	if len(retired) != 0 {
+		t.Errorf("kind without a prober must not retire, got %v", retired)
+	}
+}

--- a/services/gmuxd/internal/conversations/index.go
+++ b/services/gmuxd/internal/conversations/index.go
@@ -39,6 +39,19 @@ type Index struct {
 	// byToolID maps "kind/toolID" → slug for reverse lookup
 	// (e.g., finding a conversation's slug from its tool UUID).
 	byToolID map[string]string
+	// onRemoveByPath, if set, is invoked (outside the lock) with the
+	// file path whenever RemoveByPath drops a conversation because its
+	// file disappeared. cmd/gmuxd wires this to retire dead sessions
+	// whose SessionFile matches. Set once at startup; not guarded.
+	onRemoveByPath func(path string)
+}
+
+// SetOnRemoveByPath registers a callback fired after RemoveByPath
+// removes a conversation (i.e. its file vanished on disk). Wired at
+// startup so a conversation-file deletion can retire the dead
+// session(s) backed by that file.
+func (idx *Index) SetOnRemoveByPath(fn func(path string)) {
+	idx.onRemoveByPath = fn
 }
 
 // New creates an empty index.
@@ -195,19 +208,28 @@ func (idx *Index) Remove(kind, toolID string) bool {
 // (kind, toolID) handy. Linear walk over the index; that's fine
 // because Remove events are rare (manual `rm`, file rotation) and
 // the index size stays in the hundreds-to-low-thousands range.
-// Returns true if an entry was removed.
+// Returns true if an entry was removed. On removal it fires the
+// onRemoveByPath callback (if set) outside the lock, so the caller can
+// retire sessions backed by the now-gone file without risking a
+// re-entrant deadlock.
 func (idx *Index) RemoveByPath(path string) bool {
 	idx.mu.Lock()
-	defer idx.mu.Unlock()
+	removed := false
 	for key, info := range idx.byKey {
 		if info.FilePath != path {
 			continue
 		}
 		delete(idx.byKey, key)
 		delete(idx.byToolID, toolKey(info.Kind, info.ToolID))
-		return true
+		removed = true
+		break
 	}
-	return false
+	idx.mu.Unlock()
+
+	if removed && idx.onRemoveByPath != nil {
+		idx.onRemoveByPath(path)
+	}
+	return removed
 }
 
 // SlugExists reports whether a slug is taken within a kind.

--- a/services/gmuxd/internal/conversations/index_test.go
+++ b/services/gmuxd/internal/conversations/index_test.go
@@ -248,3 +248,27 @@ func TestAll(t *testing.T) {
 		t.Fatalf("expected 2, got %d", len(all))
 	}
 }
+
+// TestRemoveByPathFiresCallback pins that the onRemoveByPath hook fires
+// with the path exactly when an entry is removed, and not on a miss.
+func TestRemoveByPathFiresCallback(t *testing.T) {
+	idx := New()
+	idx.Upsert(Info{ToolID: "a", Slug: "one", Kind: "pi", FilePath: "/x/a.jsonl"})
+
+	var got []string
+	idx.SetOnRemoveByPath(func(p string) { got = append(got, p) })
+
+	if idx.RemoveByPath("/x/missing.jsonl") {
+		t.Fatal("expected false for unindexed path")
+	}
+	if len(got) != 0 {
+		t.Errorf("callback must not fire on a miss, got %v", got)
+	}
+
+	if !idx.RemoveByPath("/x/a.jsonl") {
+		t.Fatal("expected true for indexed path")
+	}
+	if len(got) != 1 || got[0] != "/x/a.jsonl" {
+		t.Errorf("callback should fire once with the path, got %v", got)
+	}
+}

--- a/services/gmuxd/internal/sessionmeta/sessionmeta.go
+++ b/services/gmuxd/internal/sessionmeta/sessionmeta.go
@@ -17,6 +17,23 @@
 // sidebar across restarts. On Dismiss / Resume merge / slug
 // takeover, the per-session directory is removed.
 //
+// Retention model (two tiers — see RetentionPolicy and ADR 0016):
+//
+//  1. Scrollback is a cache. The big artifact in each session dir is
+//     the runner-written scrollback (up to ~2 MiB). PruneScrollback
+//     caps the *aggregate* scrollback bytes across all dead sessions,
+//     evicting the oldest scrollback files first while KEEPING
+//     meta.json — so the session stays in the sidebar and resumable,
+//     just without terminal history. It runs at startup (once the
+//     store knows which runners are alive) and, throttled, when a
+//     session is dismissed; never on a timer.
+//
+//  2. meta.json mirrors conversation existence. A dead session whose
+//     backing conversation file disappears (the conversations index
+//     reports the removal) has its whole dir retired. Dead sessions
+//     that never had a conversation file (shells) can't key off that
+//     signal, so they fall back to an age/count cap on the whole dir.
+//
 // Peer-owned sessions are excluded: the hub re-receives them from
 // the spoke on reconnect, so persisting on the hub would create
 // duplicate ghosts. Write is a no-op for sess.Peer != "".
@@ -33,8 +50,13 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"sort"
+	"strconv"
+	"sync"
+	"time"
 
 	"github.com/gmuxapp/gmux/packages/paths"
+	"github.com/gmuxapp/gmux/packages/scrollback"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/store"
 )
 
@@ -42,7 +64,99 @@ const (
 	metaFile = "meta.json"
 	dirMode  = 0o700
 	fileMode = 0o600
+
+	// pruneStampFile marks when PruneScrollback last ran. Its mtime
+	// drives the dismiss-time throttle (MaybePruneScrollback). Lives in
+	// the base dir, not a session subdir, so it's never confused for a
+	// session by Sweep (which only descends into directories).
+	pruneStampFile = ".scrollback-prune-stamp"
 )
+
+// Retention defaults bound the disk footprint of dead-but-not-dismissed
+// sessions. See ADR 0016 for the model and RetentionPolicy for the
+// per-field semantics.
+const (
+	// DefaultMaxAge / DefaultMaxCount age/count out *conversation-less*
+	// dead sessions (shells): they keep meta + scrollback under the
+	// sessions dir but have no conversation file whose removal could
+	// retire them, so they need their own lifecycle.
+	DefaultMaxAge   = 30 * 24 * time.Hour
+	DefaultMaxCount = 200
+
+	// DefaultScrollbackCacheBytes caps the aggregate size of scrollback
+	// files across all dead sessions (~128 sessions' worth at the 2 MiB
+	// per-session ceiling). Oldest scrollback is evicted first; meta is
+	// untouched.
+	DefaultScrollbackCacheBytes int64 = 256 << 20
+)
+
+// Environment variables that override the retention defaults at startup.
+// Each accepts a non-negative integer; 0 disables that limit (unbounded).
+const (
+	envRetentionDays     = "GMUX_SESSION_RETENTION_DAYS"
+	envRetentionCount    = "GMUX_SESSION_RETENTION_MAX"
+	envScrollbackCacheMB = "GMUX_SCROLLBACK_CACHE_MB"
+)
+
+// RetentionPolicy bounds the disk footprint of dead sessions. A zero
+// value for any field disables that limit.
+type RetentionPolicy struct {
+	// MaxAge ages out conversation-less dead sessions (SessionFile == "")
+	// whose effective timestamp is older than now-MaxAge. Sessions with a
+	// conversation file are exempt: their lifecycle is the conversation's
+	// (index-driven removal). Zero means no age limit.
+	MaxAge time.Duration
+	// MaxCount keeps only the newest MaxCount conversation-less dead
+	// sessions (by effective timestamp) after age-out. Zero means no
+	// count limit.
+	MaxCount int
+	// ScrollbackCacheBytes caps the total bytes of scrollback files
+	// across all dead sessions. When exceeded, PruneScrollback deletes
+	// scrollback (keeping meta.json) oldest-first until under the cap.
+	// Zero means no cap.
+	ScrollbackCacheBytes int64
+}
+
+// DefaultRetention returns the built-in policy with the
+// GMUX_SESSION_RETENTION_DAYS / GMUX_SESSION_RETENTION_MAX /
+// GMUX_SCROLLBACK_CACHE_MB environment overrides applied when set to a
+// valid non-negative integer.
+func DefaultRetention() RetentionPolicy {
+	p := RetentionPolicy{
+		MaxAge:               DefaultMaxAge,
+		MaxCount:             DefaultMaxCount,
+		ScrollbackCacheBytes: DefaultScrollbackCacheBytes,
+	}
+	if v := os.Getenv(envRetentionDays); v != "" {
+		// Cap at the largest day count that still fits in a time.Duration
+		// (int64 ns) once multiplied by 24h, so a huge value can't
+		// overflow to a negative duration that prune would silently treat
+		// as "no age limit".
+		const maxSafeDays = int(^uint(0)>>1) / int(24*time.Hour) // ~106 751 on 64-bit
+		if days, err := strconv.Atoi(v); err == nil && days >= 0 && days <= maxSafeDays {
+			p.MaxAge = time.Duration(days) * 24 * time.Hour
+		} else {
+			log.Printf("sessionmeta: ignoring invalid %s=%q", envRetentionDays, v)
+		}
+	}
+	if v := os.Getenv(envRetentionCount); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			p.MaxCount = n
+		} else {
+			log.Printf("sessionmeta: ignoring invalid %s=%q", envRetentionCount, v)
+		}
+	}
+	if v := os.Getenv(envScrollbackCacheMB); v != "" {
+		// Guard the MiB→bytes shift against int64 overflow the same way.
+		const maxSafeMB = int((^uint64(0) >> 1) >> 20) // bytes that fit in int64
+		if mb, err := strconv.Atoi(v); err == nil && mb >= 0 && mb <= maxSafeMB {
+			p.ScrollbackCacheBytes = int64(mb) << 20
+		} else {
+			log.Printf("sessionmeta: ignoring invalid %s=%q", envScrollbackCacheMB, v)
+		}
+	}
+	return p
+}
 
 // Per-session directories may also contain scrollback files written
 // by the runner (see packages/scrollback). sessionmeta does not
@@ -59,12 +173,49 @@ func DefaultDir() string {
 // is constructed at gmuxd startup with DefaultDir(); tests construct
 // their own with a temp dir.
 type Store struct {
-	dir string
+	dir       string
+	retention RetentionPolicy
+	// now is the clock used by the retention passes. Overridable in
+	// tests via WithClock; defaults to time.Now.
+	now func() time.Time
+	// pruneMu serializes PruneScrollback so the startup pass and a
+	// dismiss-triggered pass don't double-walk the dir (and double-log
+	// "no such file" on the same victim). A run that can't take it just
+	// skips: the holder's walk already covers the same work.
+	pruneMu sync.Mutex
+}
+
+// Option configures a Store at construction.
+type Option func(*Store)
+
+// WithRetention sets the dead-session retention policy. Without it,
+// Sweep performs no age/count pruning and PruneScrollback is a no-op.
+func WithRetention(p RetentionPolicy) Option {
+	return func(s *Store) { s.retention = p }
+}
+
+// WithClock overrides the clock used by the retention passes. Tests
+// inject a fixed clock to make age-out and throttling deterministic.
+func WithClock(now func() time.Time) Option {
+	return func(s *Store) { s.now = now }
 }
 
 // New returns a Store rooted at dir. The directory is created lazily
 // on first Write; no IO happens at construction.
-func New(dir string) *Store { return &Store{dir: dir} }
+func New(dir string, opts ...Option) *Store {
+	s := &Store{dir: dir, now: time.Now}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
+}
+
+func (s *Store) clock() time.Time {
+	if s.now != nil {
+		return s.now()
+	}
+	return time.Now()
+}
 
 // Dir is the base directory under which per-session subdirectories
 // live. Exposed for tests and for diagnostic logging.
@@ -227,6 +378,14 @@ func (s *Store) WatchRemovals(events <-chan store.Event) {
 //     left in place (operator may want to inspect)
 //   - non-directory entries under the base dir are ignored
 //
+// After loading, the whole-dir retention cap is applied to
+// conversation-less dead sessions (SessionFile == ""): corpses older
+// than MaxAge are aged out, then only the newest MaxCount survive.
+// Sessions with a conversation file are exempt — they are retired only
+// when their conversation file disappears (see the conversations index
+// wiring in cmd/gmuxd). Pruned sessions are not returned. Scrollback
+// space is reclaimed separately by PruneScrollback.
+//
 // Returns nil error when the base dir doesn't exist (clean install).
 func (s *Store) Sweep() ([]store.Session, error) {
 	entries, err := os.ReadDir(s.dir)
@@ -267,5 +426,231 @@ func (s *Store) Sweep() ([]store.Session, error) {
 		sess.Alive = false
 		loaded = append(loaded, sess)
 	}
-	return loaded, nil
+	return s.prune(loaded), nil
+}
+
+// effectiveTime returns the timestamp used to rank a dead session for
+// retention: ExitedAt (when it died) is preferred, falling back to
+// LastActivityAt then CreatedAt. The bool is false when none parse, in
+// which case the session is treated conservatively (never aged out,
+// kept as if newest) so an undatable record is never evicted.
+func effectiveTime(sess store.Session) (time.Time, bool) {
+	for _, ts := range []string{sess.ExitedAt, sess.LastActivityAt, sess.CreatedAt} {
+		if ts == "" {
+			continue
+		}
+		if t, err := time.Parse(time.RFC3339, ts); err == nil {
+			return t, true
+		}
+	}
+	return time.Time{}, false
+}
+
+// prune applies the whole-dir age/count cap to conversation-less dead
+// sessions and returns the survivors plus every session that has a
+// conversation file (exempt). Removes the on-disk dir of each loser.
+// A no-op when the policy disables both limits.
+func (s *Store) prune(loaded []store.Session) []store.Session {
+	if s.retention.MaxAge <= 0 && s.retention.MaxCount <= 0 {
+		return loaded
+	}
+
+	// Partition: sessions with a conversation file are never whole-dir
+	// pruned here; their lifecycle is index-driven.
+	var exempt, corpses []store.Session
+	for _, sess := range loaded {
+		if sess.SessionFile != "" {
+			exempt = append(exempt, sess)
+		} else {
+			corpses = append(corpses, sess)
+		}
+	}
+
+	survivors := corpses[:0:0]
+	if s.retention.MaxAge > 0 {
+		cutoff := s.clock().Add(-s.retention.MaxAge)
+		for _, sess := range corpses {
+			t, ok := effectiveTime(sess)
+			if ok && t.Before(cutoff) {
+				s.evict(sess.ID, "age")
+				continue
+			}
+			survivors = append(survivors, sess)
+		}
+	} else {
+		survivors = append(survivors, corpses...)
+	}
+
+	if s.retention.MaxCount > 0 && len(survivors) > s.retention.MaxCount {
+		// Sort newest-first; undatable records sort as newest so they
+		// survive the count cap. Stable so equal timestamps keep their
+		// readdir order.
+		sort.SliceStable(survivors, func(i, j int) bool {
+			ti, oki := effectiveTime(survivors[i])
+			tj, okj := effectiveTime(survivors[j])
+			if oki != okj {
+				return !oki // undatable (newest) before datable
+			}
+			return ti.After(tj)
+		})
+		for _, sess := range survivors[s.retention.MaxCount:] {
+			s.evict(sess.ID, "count")
+		}
+		survivors = survivors[:s.retention.MaxCount]
+	}
+	return append(survivors, exempt...)
+}
+
+// evict removes a pruned session's directory and logs the reason.
+func (s *Store) evict(id, reason string) {
+	log.Printf("sessionmeta: pruning dead session %s (retention: %s)", id, reason)
+	if err := s.Remove(id); err != nil {
+		log.Printf("sessionmeta: prune remove %s: %v", id, err)
+	}
+}
+
+// scrollbackUsage is one session dir's scrollback footprint, used to
+// rank eviction candidates oldest-first.
+type scrollbackUsage struct {
+	id    string
+	bytes int64
+	mtime time.Time // newest mtime across the dir's scrollback files
+}
+
+// scrollbackNames are the runner-written files PruneScrollback reclaims.
+var scrollbackNames = []string{scrollback.ActiveName, scrollback.PreviousName}
+
+// PruneScrollback enforces ScrollbackCacheBytes: it sums the scrollback
+// bytes across every session dir and, if the total exceeds the cap,
+// deletes scrollback files (keeping meta.json) oldest-first — by newest
+// scrollback mtime — until the total is back under the cap.
+//
+// alive lists session IDs whose runner may still be writing scrollback;
+// those dirs are skipped entirely (never delete a live runner's open
+// file). The store is the authority on liveness, so callers build alive
+// from it; at startup this must run only after discovery's first scan
+// has registered live runners.
+//
+// Best-effort: stat/remove errors are logged and skipped. A zero cap or
+// missing base dir is a no-op. Updates the prune stamp on completion.
+func (s *Store) PruneScrollback(alive map[string]bool) {
+	if s.retention.ScrollbackCacheBytes <= 0 {
+		return
+	}
+	if !s.pruneMu.TryLock() {
+		return // another prune is already in flight
+	}
+	defer s.pruneMu.Unlock()
+	entries, err := os.ReadDir(s.dir)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			log.Printf("sessionmeta: scrollback prune read %s: %v", s.dir, err)
+		}
+		return
+	}
+
+	var usages []scrollbackUsage
+	var total int64
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		id := e.Name()
+		if alive[id] {
+			continue // runner may be writing; off-limits
+		}
+		sessDir := s.SessionDir(id)
+		var bytes int64
+		var mtime time.Time
+		for _, name := range scrollbackNames {
+			fi, err := os.Stat(filepath.Join(sessDir, name))
+			if err != nil {
+				continue
+			}
+			bytes += fi.Size()
+			if fi.ModTime().After(mtime) {
+				mtime = fi.ModTime()
+			}
+		}
+		if bytes == 0 {
+			continue
+		}
+		usages = append(usages, scrollbackUsage{id: id, bytes: bytes, mtime: mtime})
+		total += bytes
+	}
+
+	s.stampPrune()
+
+	if total <= s.retention.ScrollbackCacheBytes {
+		return
+	}
+
+	// Oldest scrollback first.
+	sort.SliceStable(usages, func(i, j int) bool {
+		return usages[i].mtime.Before(usages[j].mtime)
+	})
+	for _, u := range usages {
+		if total <= s.retention.ScrollbackCacheBytes {
+			break
+		}
+		sessDir := s.SessionDir(u.id)
+		freed := int64(0)
+		for _, name := range scrollbackNames {
+			p := filepath.Join(sessDir, name)
+			fi, err := os.Stat(p)
+			if err != nil {
+				continue
+			}
+			if err := os.Remove(p); err != nil {
+				log.Printf("sessionmeta: scrollback prune remove %s: %v", p, err)
+				continue
+			}
+			freed += fi.Size()
+		}
+		if freed > 0 {
+			log.Printf("sessionmeta: reclaimed %d bytes of scrollback from %s (cache cap)", freed, u.id)
+		}
+		// Decrement by what was actually freed, not the scan-time size:
+		// if a remove failed those bytes are still on disk, so we must
+		// keep evicting rather than stop early on a phantom reclaim.
+		total -= freed
+	}
+}
+
+// MaybePruneScrollback runs PruneScrollback only when at least
+// minInterval has elapsed since the last run (tracked by the prune
+// stamp's mtime). Returns whether it ran. Used on dismiss so a
+// long-running daemon reclaims scrollback at a natural, user-initiated
+// moment without any background timer. A missing stamp counts as "due".
+func (s *Store) MaybePruneScrollback(alive map[string]bool, minInterval time.Duration) bool {
+	if s.retention.ScrollbackCacheBytes <= 0 {
+		return false
+	}
+	if fi, err := os.Stat(filepath.Join(s.dir, pruneStampFile)); err == nil {
+		if s.clock().Sub(fi.ModTime()) < minInterval {
+			return false
+		}
+	}
+	s.PruneScrollback(alive)
+	return true
+}
+
+// stampPrune records the current time as the last-prune marker. Best
+// effort: a failure only means the throttle may fire again sooner.
+func (s *Store) stampPrune() {
+	path := filepath.Join(s.dir, pruneStampFile)
+	now := s.clock()
+	if err := os.Chtimes(path, now, now); err == nil {
+		return
+	}
+	// Stamp doesn't exist yet (or base dir missing): create it.
+	if err := os.MkdirAll(s.dir, dirMode); err != nil {
+		return
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, fileMode)
+	if err != nil {
+		return
+	}
+	_ = f.Close()
+	_ = os.Chtimes(path, now, now)
 }

--- a/services/gmuxd/internal/sessionmeta/sessionmeta_retention_test.go
+++ b/services/gmuxd/internal/sessionmeta/sessionmeta_retention_test.go
@@ -1,0 +1,379 @@
+package sessionmeta
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gmuxapp/gmux/packages/scrollback"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/store"
+)
+
+// --- helpers -------------------------------------------------------
+
+// writeDead persists a dead session with the given id, ExitedAt and
+// SessionFile so retention tests can stage corpses on disk.
+func writeDead(t *testing.T, s *Store, id, exitedAt, sessionFile string) {
+	t.Helper()
+	sess := store.Session{ID: id, Kind: "shell", Alive: false, ExitedAt: exitedAt, SessionFile: sessionFile}
+	if err := s.Write(sess); err != nil {
+		t.Fatalf("Write %s: %v", id, err)
+	}
+}
+
+// writeScrollback stages a scrollback file of n bytes for session id
+// with the given mtime (used to rank eviction order).
+func writeScrollback(t *testing.T, s *Store, id string, n int, mtime time.Time) {
+	t.Helper()
+	p := filepath.Join(s.SessionDir(id), scrollback.ActiveName)
+	if err := os.WriteFile(p, make([]byte, n), 0o600); err != nil {
+		t.Fatalf("write scrollback %s: %v", id, err)
+	}
+	if err := os.Chtimes(p, mtime, mtime); err != nil {
+		t.Fatalf("chtimes %s: %v", id, err)
+	}
+}
+
+func loadedIDs(sessions []store.Session) map[string]bool {
+	m := make(map[string]bool, len(sessions))
+	for _, s := range sessions {
+		m[s.ID] = true
+	}
+	return m
+}
+
+func exists(t *testing.T, path string) bool {
+	t.Helper()
+	_, err := os.Stat(path)
+	if err == nil {
+		return true
+	}
+	if os.IsNotExist(err) {
+		return false
+	}
+	t.Fatalf("stat %s: %v", path, err)
+	return false
+}
+
+// --- scrollback cache cap -----------------------------------------
+
+// TestPruneScrollbackEvictsOldestKeepsMeta pins the headline behavior:
+// over the byte cap, the oldest scrollback is deleted while meta.json
+// survives and newer scrollback is kept.
+func TestPruneScrollbackEvictsOldestKeepsMeta(t *testing.T) {
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	s := New(t.TempDir(),
+		WithRetention(RetentionPolicy{ScrollbackCacheBytes: 150}),
+		WithClock(func() time.Time { return now }))
+
+	writeDead(t, s, "sess-old", now.Add(-3*time.Hour).Format(time.RFC3339), "")
+	writeDead(t, s, "sess-new", now.Add(-1*time.Hour).Format(time.RFC3339), "")
+	writeScrollback(t, s, "sess-old", 100, now.Add(-3*time.Hour))
+	writeScrollback(t, s, "sess-new", 100, now.Add(-1*time.Hour)) // total 200 > 150
+
+	s.PruneScrollback(nil)
+
+	if exists(t, filepath.Join(s.SessionDir("sess-old"), scrollback.ActiveName)) {
+		t.Error("oldest scrollback should be evicted")
+	}
+	if !exists(t, filepath.Join(s.SessionDir("sess-new"), scrollback.ActiveName)) {
+		t.Error("newer scrollback should be kept (200-100=100 <= 150)")
+	}
+	// Meta survives for both.
+	for _, id := range []string{"sess-old", "sess-new"} {
+		if !exists(t, filepath.Join(s.SessionDir(id), metaFile)) {
+			t.Errorf("%s meta.json must survive scrollback prune", id)
+		}
+	}
+}
+
+// TestPruneScrollbackCountsAndRemovesRotated pins that the rotated
+// scrollback.0 file counts toward usage and is removed alongside the
+// active file when a session is evicted.
+func TestPruneScrollbackCountsAndRemovesRotated(t *testing.T) {
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	s := New(t.TempDir(),
+		WithRetention(RetentionPolicy{ScrollbackCacheBytes: 150}),
+		WithClock(func() time.Time { return now }))
+
+	writeDead(t, s, "sess-a", now.Format(time.RFC3339), "")
+	// 100 active + 100 rotated = 200 > 150, so this session is evicted.
+	writeScrollback(t, s, "sess-a", 100, now)
+	prev := filepath.Join(s.SessionDir("sess-a"), scrollback.PreviousName)
+	if err := os.WriteFile(prev, make([]byte, 100), 0o600); err != nil {
+		t.Fatalf("write rotated: %v", err)
+	}
+	if err := os.Chtimes(prev, now, now); err != nil {
+		t.Fatalf("chtimes rotated: %v", err)
+	}
+
+	s.PruneScrollback(nil)
+
+	if exists(t, filepath.Join(s.SessionDir("sess-a"), scrollback.ActiveName)) {
+		t.Error("active scrollback should be removed")
+	}
+	if exists(t, prev) {
+		t.Error("rotated scrollback.0 should be removed too")
+	}
+	if !exists(t, filepath.Join(s.SessionDir("sess-a"), metaFile)) {
+		t.Error("meta.json must survive")
+	}
+}
+
+// TestPruneScrollbackUnderCapNoop pins that nothing is touched when the
+// aggregate is within budget.
+func TestPruneScrollbackUnderCapNoop(t *testing.T) {
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	s := New(t.TempDir(),
+		WithRetention(RetentionPolicy{ScrollbackCacheBytes: 1000}),
+		WithClock(func() time.Time { return now }))
+	writeDead(t, s, "sess-a", now.Format(time.RFC3339), "")
+	writeScrollback(t, s, "sess-a", 100, now)
+
+	s.PruneScrollback(nil)
+
+	if !exists(t, filepath.Join(s.SessionDir("sess-a"), scrollback.ActiveName)) {
+		t.Error("scrollback under cap must not be evicted")
+	}
+}
+
+// TestPruneScrollbackSkipsAlive pins the liveness guard: an alive
+// session's scrollback is never evicted even when it's the oldest and
+// the cap is exceeded.
+func TestPruneScrollbackSkipsAlive(t *testing.T) {
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	s := New(t.TempDir(),
+		WithRetention(RetentionPolicy{ScrollbackCacheBytes: 50}),
+		WithClock(func() time.Time { return now }))
+
+	writeDead(t, s, "sess-live", now.Add(-5*time.Hour).Format(time.RFC3339), "")
+	writeDead(t, s, "sess-dead", now.Add(-1*time.Hour).Format(time.RFC3339), "")
+	writeScrollback(t, s, "sess-live", 100, now.Add(-5*time.Hour)) // oldest
+	writeScrollback(t, s, "sess-dead", 100, now.Add(-1*time.Hour))
+
+	s.PruneScrollback(map[string]bool{"sess-live": true})
+
+	if !exists(t, filepath.Join(s.SessionDir("sess-live"), scrollback.ActiveName)) {
+		t.Error("alive session scrollback must never be evicted")
+	}
+	// The dead one absorbs the eviction instead.
+	if exists(t, filepath.Join(s.SessionDir("sess-dead"), scrollback.ActiveName)) {
+		t.Error("dead session scrollback should be evicted to meet the cap")
+	}
+}
+
+// TestPruneScrollbackZeroCapDisabled pins that a zero cap disables the
+// pass entirely.
+func TestPruneScrollbackZeroCapDisabled(t *testing.T) {
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	s := New(t.TempDir(),
+		WithRetention(RetentionPolicy{ScrollbackCacheBytes: 0}),
+		WithClock(func() time.Time { return now }))
+	writeDead(t, s, "sess-a", now.Format(time.RFC3339), "")
+	writeScrollback(t, s, "sess-a", 10_000, now)
+
+	s.PruneScrollback(nil)
+
+	if !exists(t, filepath.Join(s.SessionDir("sess-a"), scrollback.ActiveName)) {
+		t.Error("zero cap must disable scrollback eviction")
+	}
+}
+
+// TestMaybePruneScrollbackThrottle pins the dismiss-time throttle: the
+// first call runs, an immediate second call is skipped, and a call
+// after the interval runs again.
+func TestMaybePruneScrollbackThrottle(t *testing.T) {
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	clock := now
+	s := New(t.TempDir(),
+		WithRetention(RetentionPolicy{ScrollbackCacheBytes: 50}),
+		WithClock(func() time.Time { return clock }))
+	writeDead(t, s, "sess-a", now.Format(time.RFC3339), "")
+	writeScrollback(t, s, "sess-a", 100, now)
+
+	if !s.MaybePruneScrollback(nil, 12*time.Hour) {
+		t.Fatal("first call should run (no stamp yet)")
+	}
+	clock = now.Add(time.Hour)
+	if s.MaybePruneScrollback(nil, 12*time.Hour) {
+		t.Error("call within interval should be throttled")
+	}
+	clock = now.Add(13 * time.Hour)
+	if !s.MaybePruneScrollback(nil, 12*time.Hour) {
+		t.Error("call past interval should run")
+	}
+}
+
+// --- whole-dir age/count cap (conversation-less corpses) ----------
+
+// TestSweepAgesOutConversationlessCorpse pins that a shell corpse older
+// than MaxAge is removed entirely, while a conversation-backed dead
+// session of the same age is exempt.
+func TestSweepAgesOutConversationlessCorpse(t *testing.T) {
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	s := New(t.TempDir(),
+		WithRetention(RetentionPolicy{MaxAge: 7 * 24 * time.Hour}),
+		WithClock(func() time.Time { return now }))
+
+	old := now.Add(-30 * 24 * time.Hour).Format(time.RFC3339)
+	writeDead(t, s, "sess-shell", old, "")                        // no conversation: ages out
+	writeDead(t, s, "sess-agent", old, "/home/u/.claude/x.jsonl") // conversation-backed: exempt
+
+	loaded, err := s.Sweep()
+	if err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	ids := loadedIDs(loaded)
+	if ids["sess-shell"] {
+		t.Error("conversation-less corpse should age out")
+	}
+	if !ids["sess-agent"] {
+		t.Error("conversation-backed dead session must be exempt from age cap")
+	}
+	if exists(t, s.SessionDir("sess-shell")) {
+		t.Error("aged-out corpse dir should be removed")
+	}
+	if !exists(t, s.SessionDir("sess-agent")) {
+		t.Error("conversation-backed dir must survive")
+	}
+}
+
+// TestSweepCountCapIgnoresConversationBacked pins that the count cap
+// only ranks/evicts conversation-less corpses; conversation-backed
+// sessions neither consume budget nor get evicted.
+func TestSweepCountCapIgnoresConversationBacked(t *testing.T) {
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	s := New(t.TempDir(),
+		WithRetention(RetentionPolicy{MaxCount: 1}),
+		WithClock(func() time.Time { return now }))
+
+	writeDead(t, s, "sess-shell-old", now.Add(-3*time.Hour).Format(time.RFC3339), "")
+	writeDead(t, s, "sess-shell-new", now.Add(-1*time.Hour).Format(time.RFC3339), "")
+	writeDead(t, s, "sess-agent", now.Add(-9*time.Hour).Format(time.RFC3339), "/x.jsonl")
+
+	loaded, err := s.Sweep()
+	if err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	ids := loadedIDs(loaded)
+	if ids["sess-shell-old"] {
+		t.Error("oldest corpse should be evicted by count cap")
+	}
+	if !ids["sess-shell-new"] {
+		t.Error("newest corpse should be kept")
+	}
+	if !ids["sess-agent"] {
+		t.Error("conversation-backed session must not count against or be evicted by the cap")
+	}
+}
+
+// TestSweepNoPolicyKeepsEverything pins that the bare New (no retention)
+// prunes nothing.
+func TestSweepNoPolicyKeepsEverything(t *testing.T) {
+	s := New(t.TempDir())
+	writeDead(t, s, "sess-a", "2000-01-01T00:00:00Z", "")
+	writeDead(t, s, "sess-b", "2000-01-02T00:00:00Z", "")
+
+	loaded, err := s.Sweep()
+	if err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	if len(loaded) != 2 {
+		t.Errorf("expected both kept without a policy, got %d", len(loaded))
+	}
+}
+
+// TestSweepUndatableCorpseSurvives pins the conservative rule: a corpse
+// with no parseable timestamp is never aged out and sorts as newest.
+func TestSweepUndatableCorpseSurvives(t *testing.T) {
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	s := New(t.TempDir(),
+		WithRetention(RetentionPolicy{MaxAge: time.Hour, MaxCount: 1}),
+		WithClock(func() time.Time { return now }))
+
+	writeDead(t, s, "sess-dated", now.Add(-10*time.Hour).Format(time.RFC3339), "")
+	writeDead(t, s, "sess-undated", "", "")
+
+	loaded, err := s.Sweep()
+	if err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	ids := loadedIDs(loaded)
+	if !ids["sess-undated"] {
+		t.Error("undatable corpse must survive retention")
+	}
+	if ids["sess-dated"] {
+		t.Error("dated stale corpse should have been aged out")
+	}
+}
+
+// --- env overrides -------------------------------------------------
+
+func TestDefaultRetentionEnvOverride(t *testing.T) {
+	t.Setenv(envRetentionDays, "5")
+	t.Setenv(envRetentionCount, "10")
+	t.Setenv(envScrollbackCacheMB, "64")
+	p := DefaultRetention()
+	if p.MaxAge != 5*24*time.Hour {
+		t.Errorf("MaxAge: got %v, want 5d", p.MaxAge)
+	}
+	if p.MaxCount != 10 {
+		t.Errorf("MaxCount: got %d, want 10", p.MaxCount)
+	}
+	if p.ScrollbackCacheBytes != 64<<20 {
+		t.Errorf("ScrollbackCacheBytes: got %d, want 64MiB", p.ScrollbackCacheBytes)
+	}
+
+	t.Setenv(envRetentionDays, "0")
+	t.Setenv(envScrollbackCacheMB, "0")
+	if got := DefaultRetention().MaxAge; got != 0 {
+		t.Errorf("days=0 should disable age limit, got %v", got)
+	}
+	if got := DefaultRetention().ScrollbackCacheBytes; got != 0 {
+		t.Errorf("cache=0 should disable scrollback cap, got %d", got)
+	}
+
+	// Overflowing day count falls back to the default rather than
+	// wrapping to a negative duration.
+	t.Setenv(envRetentionDays, "100000000000")
+	if got := DefaultRetention().MaxAge; got != DefaultMaxAge {
+		t.Errorf("overflowing days should fall back to %v, got %v", DefaultMaxAge, got)
+	}
+}
+
+// TestPruneScrollbackFailedRemoveKeepsEvicting pins the fix for the
+// phantom-reclaim bug: when an older session's scrollback can't be
+// removed (unwritable dir), total must not be decremented by its
+// scan-time size, so a newer removable session still gets evicted to
+// meet the cap instead of being skipped on a fake reclaim.
+func TestPruneScrollbackFailedRemoveKeepsEvicting(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory write permissions")
+	}
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	s := New(t.TempDir(),
+		WithRetention(RetentionPolicy{ScrollbackCacheBytes: 150}),
+		WithClock(func() time.Time { return now }))
+
+	writeDead(t, s, "sess-stuck", now.Add(-3*time.Hour).Format(time.RFC3339), "")
+	writeDead(t, s, "sess-evictable", now.Add(-1*time.Hour).Format(time.RFC3339), "")
+	writeScrollback(t, s, "sess-stuck", 100, now.Add(-3*time.Hour))     // oldest, remove will fail
+	writeScrollback(t, s, "sess-evictable", 100, now.Add(-1*time.Hour)) // total 200 > 150
+
+	// Make the oldest session's dir unwritable so os.Remove fails.
+	stuck := s.SessionDir("sess-stuck")
+	if err := os.Chmod(stuck, 0o500); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(stuck, 0o700) })
+
+	s.PruneScrollback(nil)
+
+	if !exists(t, filepath.Join(stuck, scrollback.ActiveName)) {
+		t.Error("stuck scrollback should remain (remove failed)")
+	}
+	if exists(t, filepath.Join(s.SessionDir("sess-evictable"), scrollback.ActiveName)) {
+		t.Error("evictable scrollback must still be reclaimed despite the earlier failure")
+	}
+}

--- a/services/gmuxd/internal/store/store.go
+++ b/services/gmuxd/internal/store/store.go
@@ -3,6 +3,7 @@ package store
 import (
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"reflect"
 	"sync"
 	"time"
@@ -492,6 +493,51 @@ func (s *Store) Reconcile(assignFn func(Session) (slug string, index int)) {
 		sess.ProjectIndex = index
 		s.sessions[id] = sess
 	}
+}
+
+// RemoveDeadBySessionFile retires every locally-owned, dead session
+// whose SessionFile points at path, broadcasting session-remove for
+// each and returning the removed IDs. Used when the conversations
+// index reports a conversation file has disappeared: meta.json mirrors
+// conversation existence (ADR 0016), so the backing file going away
+// retires the sidebar entry.
+//
+// Guards, all load-bearing:
+//   - !Alive: a live runner may still be writing this conversation; its
+//     record is authoritative and must not be torn down here.
+//   - Peer == "": peer-owned records are re-received from the spoke; the
+//     hub doesn't own their lifecycle.
+//   - all matches: the file→session mapping is N:1 (a conversation can be
+//     resumed in several runners), so every dead match is retired.
+//
+// Paths are compared after filepath.Clean so a cosmetic difference
+// (trailing slash, "./") between the watcher-reported path and the
+// hook-reported SessionFile doesn't defeat the match. Symlinks are not
+// resolved: the file is already gone, so EvalSymlinks couldn't run, and
+// both paths derive from the same real $HOME in practice.
+func (s *Store) RemoveDeadBySessionFile(path string) []string {
+	if path == "" {
+		return nil
+	}
+	target := filepath.Clean(path)
+	s.mu.Lock()
+	var removed []string
+	for id, sess := range s.sessions {
+		if sess.Peer != "" || sess.Alive || sess.SessionFile == "" {
+			continue
+		}
+		if filepath.Clean(sess.SessionFile) != target {
+			continue
+		}
+		delete(s.sessions, id)
+		removed = append(removed, id)
+	}
+	s.mu.Unlock()
+
+	for _, id := range removed {
+		s.broadcast(Event{Type: "session-remove", ID: id})
+	}
+	return removed
 }
 
 // RemoveByPeer removes all sessions belonging to a peer and broadcasts

--- a/services/gmuxd/internal/store/store_test.go
+++ b/services/gmuxd/internal/store/store_test.go
@@ -65,6 +65,71 @@ func TestRemove(t *testing.T) {
 	}
 }
 
+func TestRemoveDeadBySessionFile(t *testing.T) {
+	const file = "/home/u/.claude/projects/abc/conv.jsonl"
+	s := New()
+	// Two dead sessions share the file (N:1, e.g. resumed in two tabs).
+	s.Upsert(Session{ID: "dead-1", Kind: "claude", Alive: false, SessionFile: file})
+	s.Upsert(Session{ID: "dead-2", Kind: "claude", Alive: false, SessionFile: file})
+	// A live session on the same file must survive (runner still writing).
+	s.Upsert(Session{ID: "live", Kind: "claude", Alive: true, SessionFile: file})
+	// A peer-owned dead session on the same file is not ours to retire.
+	s.Upsert(Session{ID: "peer", Kind: "claude", Alive: false, Peer: "box2", SessionFile: file})
+	// An unrelated dead session must be untouched.
+	s.Upsert(Session{ID: "other", Kind: "claude", Alive: false, SessionFile: "/home/u/.claude/projects/xyz/other.jsonl"})
+
+	// Cosmetic path difference must still match (filepath.Clean).
+	removed := s.RemoveDeadBySessionFile("/home/u/.claude/projects/abc/./conv.jsonl")
+
+	got := map[string]bool{}
+	for _, id := range removed {
+		got[id] = true
+	}
+	if len(removed) != 2 || !got["dead-1"] || !got["dead-2"] {
+		t.Fatalf("expected dead-1+dead-2 removed, got %v", removed)
+	}
+	for _, id := range []string{"live", "peer", "other"} {
+		if _, ok := s.Get(id); !ok {
+			t.Errorf("%s should have survived", id)
+		}
+	}
+	for _, id := range []string{"dead-1", "dead-2"} {
+		if _, ok := s.Get(id); ok {
+			t.Errorf("%s should have been removed", id)
+		}
+	}
+}
+
+func TestRemoveDeadBySessionFileNoMatch(t *testing.T) {
+	s := New()
+	s.Upsert(Session{ID: "a", Kind: "claude", Alive: false, SessionFile: "/x/a.jsonl"})
+	if got := s.RemoveDeadBySessionFile("/x/missing.jsonl"); got != nil {
+		t.Errorf("no-match should return nil, got %v", got)
+	}
+	if got := s.RemoveDeadBySessionFile(""); got != nil {
+		t.Errorf("empty path should return nil, got %v", got)
+	}
+	if _, ok := s.Get("a"); !ok {
+		t.Error("unrelated session must survive")
+	}
+}
+
+// TestRemoveDeadBySessionFileBroadcasts pins that retirement emits one
+// session-remove per removed session (so WatchRemovals drops the dir).
+func TestRemoveDeadBySessionFileBroadcasts(t *testing.T) {
+	s := New()
+	s.Upsert(Session{ID: "dead", Kind: "claude", Alive: false, SessionFile: "/x/c.jsonl"})
+	ch, cancel := s.Subscribe()
+	defer cancel()
+
+	s.RemoveDeadBySessionFile("/x/c.jsonl")
+
+	ev, ok := recvEvent(t, ch)
+	if !ok || ev.Type != "session-remove" || ev.ID != "dead" {
+		t.Fatalf("expected session-remove for dead, got %+v ok=%v", ev, ok)
+	}
+}
+
 func TestSubscribe(t *testing.T) {
 	s := New()
 	ch, cancel := s.Subscribe()


### PR DESCRIPTION
## What

Bounds the last unbounded-growth surface left after #323: per-session
dirs under `$XDG_STATE_HOME/gmux/sessions/<id>/`. Each dead,
never-dismissed session keeps a ~1 KB `meta.json` plus up to ~2 MiB of
runner-written `scrollback`/`scrollback.0`.

Adapts the (unmerged) #296 scaffolding — `RetentionPolicy`, env
overrides, the day-count overflow guard, LRU-by-exit-time, the Sweep
hook — to an agreed two-tier model instead of #296's "delete the whole
dir at 30 days".

## Retention semantics (ADR 0016)

**Tier 1 — scrollback is a cache.** `PruneScrollback` sums scrollback
bytes across all dead sessions; over `GMUX_SCROLLBACK_CACHE_MB`
(default **256 MiB**) it deletes scrollback files **oldest-first** (by
newest scrollback mtime) until under the cap, **keeping `meta.json`**.
The session stays in the sidebar and resumable — replay just has no
terminal history. Runs:
- at **startup**, from `discovery.Watch`'s first-scan hook (after live
  runners re-register as `Alive`, so an open scrollback file is never
  evicted), and
- on **dismiss**, throttled to ≥12 h since the last run (mtime of a
  `.scrollback-prune-stamp` marker).

No background timer — a periodic tick would churn disk at moments
unrelated to anything the user did. Concurrent passes (startup vs a
dismiss) are coalesced with a `TryLock`.

**Tier 2 — `meta.json` mirrors conversation existence.** A dead
session's whole entry is retired when its backing conversation file
disappears, via two paths:
- **Runtime:** the conversations index (#323) reports the removal;
  `Index.RemoveByPath` fires a callback into
  `store.RemoveDeadBySessionFile`.
- **Startup reconcile:** a file deleted *while gmuxd was down* emits no
  index event, so after the first discovery scan gmuxd asks each owning
  adapter — via the new **`ConversationProber`** capability — whether its
  dead sessions' files are gone. The adapter distinguishes a genuine
  **deletion** from **unreachable storage** (unmounted home, tool never
  installed). This is adapter-owned because only the adapter knows which
  directory anchors "storage is present" for its layout; the shared
  `ConversationGoneAtRoot` helper implements the common rule (file absent
  under a present `SessionRootDir` → deleted; absent/unreadable root or a
  non-`NotExist` stat error → undeterminable, never retires). claude,
  codex, and pi each anchor on their own root.

Both paths retire through `store.RemoveDeadBySessionFile`, which guards
`!Alive && Peer == ""`, handles the N:1 file→session mapping, compares
paths after `filepath.Clean`, and broadcasts `session-remove` (which the
existing `WatchRemovals` loop turns into a dir delete).

**Conversation-less corpses** (shells / anything that never reported a
`session_file`) keep #296's whole-dir age/count cap at `Sweep`:
`GMUX_SESSION_RETENTION_DAYS` (30), `GMUX_SESSION_RETENTION_MAX` (200).
Conversation-backed sessions are exempt — their lifecycle is the
conversation's.

All knobs take a non-negative integer; `0` disables that limit.

## Correctness

- **Never evict a live session's scrollback.** The runner writes it live
  into the same dir (`cli/gmux/.../run.go`); the prune skips any `Alive`
  ID and startup runs only after the store is warm.
- **Never retire a live/peer session.** Store guards `!Alive && Peer ==
  ""`, loops all N:1 matches.
- **Never retire on unreachable storage.** The reconcile only acts on a
  confident adapter "gone"; an absent root (unmounted home) is
  undeterminable.
- **Failed scrollback removal doesn't phantom-reclaim** — `total` drops
  by bytes actually freed, so eviction keeps going instead of stopping
  early over-budget.
- No new file watching in the daemon.

## Tests

`cd services/gmuxd && go test ./... -race` and `cd packages/adapter &&
go test ./...` green. New:
- **adapter:** `ConversationGoneAtRoot` — present/deleted/absent-root/
  file-as-root/empty; pi `ConversationGone` anchors on its own root
  (deleted vs unreachable).
- **sessionmeta:** evicts oldest / keeps meta; rotated `scrollback.0`
  counted+removed; under-cap no-op; zero-cap disabled; skips alive;
  failed-remove keeps evicting; dismiss throttle. Sweep ages/counts out
  conversation-less corpses but exempts conversation-backed; undatable
  survives; env overrides + overflow fallback.
- **store:** `RemoveDeadBySessionFile` — N:1 removal, skips
  alive/peer/unrelated, path-clean equivalence, nil on no-match/empty,
  broadcasts.
- **conversations:** `RemoveByPath` fires the callback only on removal.
- **reconcile (cmd/gmuxd):** the safety gate — retires only on
  `known && gone`, never on undeterminable storage (`known=false`);
  skips alive/peer/file-less; dedups N:1 paths; leaves kinds without a
  prober alone.

## Supersedes

Closes #296 (delete-whole-entry-at-30d → tier 1 keeps meta + tier 2
retires only when the conversation is actually gone). Scaffolding
preserved.

