### PR TITLE
fix(gmuxd): resume in project's canonical folder when cwd is gone

### DIFF
--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -204,6 +204,59 @@ func launchGmux(gmuxBin string, command []string, cwd, resumeID string, initialC
 	return cmd.Process.Pid, nil
 }
 
+// resolveResumeDir picks the directory to (re)launch a runner in for a
+// dead session whose original cwd may have been deleted. Order:
+//
+//  1. the session's stored cwd, if it still exists;
+//  2. the owning project's canonical dir (first match-rule path), if it
+//     exists — so a resume lands where the project "+" button would;
+//  3. $HOME, as a last resort, so resume still succeeds.
+//
+// Returns the chosen dir and whether a fallback (anything but the
+// original cwd) was used. Returns ("", false) only when none of the
+// candidates exist as directories — the caller then returns a clear
+// cwd_missing error instead of letting exec fail with the misleading
+// "fork/exec .../gmux: no such file or directory" (Go reports the
+// child's chdir ENOENT against argv0).
+//
+// Every candidate is Stat'd via projects.IsDir, so a missing target can
+// never reach exec.
+func resolveResumeDir(mgr *projects.Manager, sess store.Session) (string, bool) {
+	cwd := projects.NormalizePath(sess.Cwd)
+	canonical := ""
+	if state, err := mgr.Load(); err != nil {
+		// Don't fail the resume over an unreadable projects.json: the
+		// canonical-dir candidate just drops out and we fall through to
+		// cwd/$HOME. Log it so a surprise $HOME resume is explained.
+		log.Printf("resolveResumeDir: %s: load projects: %v (canonical dir unavailable)", sess.ID, err)
+	} else {
+		canonical = state.CanonicalDirForSession(sess.ProjectSlug, projects.MatchParams{
+			Cwd:           sess.Cwd,
+			WorkspaceRoot: sess.WorkspaceRoot,
+			Remotes:       sess.Remotes,
+		})
+	}
+	dir, idx := projects.ResolveLaunchDir(projects.IsDir, cwd, canonical, os.Getenv("HOME"))
+	if dir == "" {
+		return "", false
+	}
+	return dir, idx > 0
+}
+
+// relaunchData builds the success payload for /resume and /restart. On
+// a fallback (cwd was gone), it carries original_cwd + fallback_cwd so
+// the frontend can surface an info toast ("original folder gone; resumed
+// in <fallback_cwd>") without re-deriving anything. Omitted on the
+// common path where the original cwd was used.
+func relaunchData(sessionID string, pid int, originalCwd, usedCwd string, fellBack bool) map[string]any {
+	data := map[string]any{"pid": pid, "session_id": sessionID}
+	if fellBack {
+		data["original_cwd"] = originalCwd
+		data["fallback_cwd"] = usedCwd
+	}
+	return data
+}
+
 // buildLaunchArgs assembles the gmux runner argv for the internal
 // `gmux __run [directives] -- <command>` form (ADR 0009): the hidden
 // __run verb, any non-empty daemon→runner directive flags, then a `--`
@@ -1328,6 +1381,19 @@ func serve(stderr io.Writer) int {
 		// Expand ~ to absolute path for exec.Command.Dir.
 		cwd = projects.NormalizePath(cwd)
 
+		// Stat the target before exec. Without this a missing dir reaches
+		// the child's chdir and Go reports the ENOENT against argv0,
+		// surfacing the misleading "fork/exec .../gmux: no such file or
+		// directory". Fresh launches carry an explicit user-chosen cwd, so
+		// we return a clear error rather than silently redirecting (unlike
+		// resume/restart, which fall back to the project's canonical dir).
+		if !projects.IsDir(cwd) {
+			log.Printf("launch: cwd %q does not exist", cwd)
+			writeError(w, http.StatusUnprocessableEntity, "cwd_missing",
+				fmt.Sprintf("working directory %q does not exist", cwd))
+			return
+		}
+
 		if gmuxBin == "" {
 			writeError(w, http.StatusInternalServerError, "gmux_not_found", "gmux not found (install gmux alongside gmuxd)")
 			return
@@ -1440,7 +1506,16 @@ func serve(stderr io.Writer) int {
 			// preserve the last-known PTY dimensions through the
 			// fork; without them claude / vim / prompt frameworks
 			// reading $COLUMNS at startup would clamp to 80.
-			resumeCwd := projects.NormalizePath(sess.Cwd)
+			resumeCwd, fellBack := resolveResumeDir(projectMgr, sess)
+			if resumeCwd == "" {
+				log.Printf("resume: %s: cwd %q gone and no fallback dir exists", sessionID, projects.NormalizePath(sess.Cwd))
+				writeError(w, http.StatusUnprocessableEntity, "cwd_missing",
+					"the session's working directory no longer exists and no fallback directory is available")
+				return
+			}
+			if fellBack {
+				log.Printf("resume: %s: cwd %q missing, resuming in %q", sessionID, projects.NormalizePath(sess.Cwd), resumeCwd)
+			}
 			pid, err := launchGmux(gmuxBin, sess.Command, resumeCwd, sessionID, sess.TerminalCols, sess.TerminalRows)
 			if err != nil {
 				log.Printf("resume: failed to start gmux: %v", err)
@@ -1455,7 +1530,7 @@ func serve(stderr io.Writer) int {
 			log.Printf("resume: started gmux pid=%d for %s cwd=%s", pid, sessionID, resumeCwd)
 			writeJSON(w, map[string]any{
 				"ok":   true,
-				"data": map[string]any{"pid": pid, "session_id": sessionID},
+				"data": relaunchData(sessionID, pid, projects.NormalizePath(sess.Cwd), resumeCwd, fellBack),
 			})
 
 		case "restart":
@@ -1524,7 +1599,16 @@ func serve(stderr io.Writer) int {
 			// Same as /resume: launch a new runner under the existing
 			// session id; Register's re-registration branch handles
 			// the rest.
-			restartCwd := projects.NormalizePath(sess.Cwd)
+			restartCwd, fellBack := resolveResumeDir(projectMgr, sess)
+			if restartCwd == "" {
+				log.Printf("restart: %s: cwd %q gone and no fallback dir exists", sessionID, projects.NormalizePath(sess.Cwd))
+				writeError(w, http.StatusUnprocessableEntity, "cwd_missing",
+					"the session's working directory no longer exists and no fallback directory is available")
+				return
+			}
+			if fellBack {
+				log.Printf("restart: %s: cwd %q missing, restarting in %q", sessionID, projects.NormalizePath(sess.Cwd), restartCwd)
+			}
 			pid, err := launchGmux(gmuxBin, sess.Command, restartCwd, sessionID, sess.TerminalCols, sess.TerminalRows)
 			if err != nil {
 				log.Printf("restart: failed to start gmux: %v", err)
@@ -1534,7 +1618,7 @@ func serve(stderr io.Writer) int {
 			log.Printf("restart: started gmux pid=%d for %s cwd=%s", pid, sessionID, restartCwd)
 			writeJSON(w, map[string]any{
 				"ok":   true,
-				"data": map[string]any{"pid": pid, "session_id": sessionID},
+				"data": relaunchData(sessionID, pid, projects.NormalizePath(sess.Cwd), restartCwd, fellBack),
 			})
 
 		case "kill":

--- a/services/gmuxd/cmd/gmuxd/resumedir_test.go
+++ b/services/gmuxd/cmd/gmuxd/resumedir_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/projects"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/store"
+)
+
+// newProjectMgr writes a projects.json with a single owned project whose
+// canonical dir is canonicalPath, then returns a loaded manager.
+func newProjectMgr(t *testing.T, canonicalPath string) *projects.Manager {
+	t.Helper()
+	dir := t.TempDir()
+	mgr := projects.NewManager(dir)
+	if _, err := mgr.AddProject("proj", []projects.MatchRule{{Path: canonicalPath}}); err != nil {
+		t.Fatalf("AddProject: %v", err)
+	}
+	return mgr
+}
+
+func TestResolveResumeDir_CwdExists(t *testing.T) {
+	cwd := t.TempDir()
+	canon := t.TempDir()
+	mgr := newProjectMgr(t, canon)
+	sess := store.Session{Cwd: cwd, ProjectSlug: "proj"}
+
+	dir, fellBack := resolveResumeDir(mgr, sess)
+	if dir != cwd || fellBack {
+		t.Errorf("got (%q, %v), want (%q, false)", dir, fellBack, cwd)
+	}
+}
+
+func TestResolveResumeDir_CwdMissing_FallsToCanonical(t *testing.T) {
+	canon := t.TempDir()
+	mgr := newProjectMgr(t, canon)
+	gone := filepath.Join(t.TempDir(), "deleted-grove")
+	sess := store.Session{Cwd: gone, ProjectSlug: "proj"}
+
+	dir, fellBack := resolveResumeDir(mgr, sess)
+	if dir != canon || !fellBack {
+		t.Errorf("got (%q, %v), want (%q, true)", dir, fellBack, canon)
+	}
+}
+
+func TestResolveResumeDir_CanonicalAlsoMissing_FallsToHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	goneCanon := filepath.Join(t.TempDir(), "gone-canon")
+	mgr := newProjectMgr(t, goneCanon)
+	goneCwd := filepath.Join(t.TempDir(), "gone-cwd")
+	sess := store.Session{Cwd: goneCwd, ProjectSlug: "proj"}
+
+	dir, fellBack := resolveResumeDir(mgr, sess)
+	if dir != home || !fellBack {
+		t.Errorf("got (%q, %v), want (%q, true)", dir, fellBack, home)
+	}
+}
+
+func TestResolveResumeDir_NothingExists(t *testing.T) {
+	t.Setenv("HOME", filepath.Join(t.TempDir(), "gone-home"))
+	goneCanon := filepath.Join(t.TempDir(), "gone-canon")
+	mgr := newProjectMgr(t, goneCanon)
+	sess := store.Session{Cwd: filepath.Join(t.TempDir(), "gone-cwd"), ProjectSlug: "proj"}
+
+	dir, fellBack := resolveResumeDir(mgr, sess)
+	if dir != "" || fellBack {
+		t.Errorf("got (%q, %v), want (\"\", false)", dir, fellBack)
+	}
+}
+
+func TestRelaunchData(t *testing.T) {
+	// Common path: cwd was used, no fallback fields leak into the payload.
+	d := relaunchData("sess-1", 42, "/orig", "/orig", false)
+	if d["pid"] != 42 || d["session_id"] != "sess-1" {
+		t.Errorf("missing core fields: %v", d)
+	}
+	if _, ok := d["original_cwd"]; ok {
+		t.Errorf("original_cwd should be absent without fallback: %v", d)
+	}
+	if _, ok := d["fallback_cwd"]; ok {
+		t.Errorf("fallback_cwd should be absent without fallback: %v", d)
+	}
+
+	// Fallback path: original + fallback dirs surfaced for the toast layer.
+	d = relaunchData("sess-1", 42, "/gone", "/canon", true)
+	if d["original_cwd"] != "/gone" || d["fallback_cwd"] != "/canon" {
+		t.Errorf("expected fallback fields, got %v", d)
+	}
+}
+
+func TestResolveResumeDir_NoProject_CwdMissingFallsToHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	mgr := projects.NewManager(t.TempDir()) // empty: no owning project
+	sess := store.Session{Cwd: filepath.Join(t.TempDir(), "gone")}
+
+	dir, fellBack := resolveResumeDir(mgr, sess)
+	if dir != home || !fellBack {
+		t.Errorf("got (%q, %v), want (%q, true)", dir, fellBack, home)
+	}
+}

--- a/services/gmuxd/internal/projects/launchdir.go
+++ b/services/gmuxd/internal/projects/launchdir.go
@@ -1,0 +1,82 @@
+package projects
+
+import "os"
+
+// CanonicalDir returns the project's canonical launch directory: the
+// first match-rule path, normalized. Empty when the item is nil, a
+// reference, or carries no path rule.
+//
+// This is the single server-side source of truth for "the project's
+// canonical folder". It matches the definition used everywhere else:
+//   - the frontend project-row / hub "+" button (launchCwd = first
+//     match-rule path), and
+//   - the peering launch_cwd hint advertised to viewers.
+//
+// Keep the three in agreement: a session resumed in CanonicalDir lands
+// where the "+" button would have launched a fresh one.
+func (i *Item) CanonicalDir() string {
+	if i == nil || i.IsReference() {
+		return ""
+	}
+	for _, r := range i.Match {
+		if r.Path == "" {
+			continue
+		}
+		if n := NormalizePath(r.Path); n != "" {
+			return n
+		}
+	}
+	return ""
+}
+
+// ProjectBySlug returns the owned project with the given slug, or nil.
+// References are skipped: only host-owned projects carry the match
+// rules CanonicalDir reads.
+func (s *State) ProjectBySlug(slug string) *Item {
+	if slug == "" {
+		return nil
+	}
+	for i := range s.Items {
+		if s.Items[i].Slug == slug && !s.Items[i].IsReference() {
+			return &s.Items[i]
+		}
+	}
+	return nil
+}
+
+// CanonicalDirForSession returns the canonical launch directory for a
+// session's owning project. It prefers the session's assigned project
+// slug and falls back to matching the session's stored cwd / workspace
+// / remotes against the project rules (the stored cwd string still
+// matches even when the directory no longer exists on disk). Empty when
+// no owning project is found or that project has no path rule.
+func (s *State) CanonicalDirForSession(projectSlug string, p MatchParams) string {
+	item := s.ProjectBySlug(projectSlug)
+	if item == nil {
+		item = s.Match(p)
+	}
+	return item.CanonicalDir()
+}
+
+// IsDir reports whether path is an existing directory.
+func IsDir(path string) bool {
+	fi, err := os.Stat(path)
+	return err == nil && fi.IsDir()
+}
+
+// ResolveLaunchDir returns the first candidate that isDir reports as an
+// existing directory, skipping empty candidates, along with its index
+// (0 = primary, >0 = a fallback was used). Returns ("", -1) when none
+// qualify. isDir is injected so callers and tests can supply a fake
+// filesystem; production callers pass IsDir.
+func ResolveLaunchDir(isDir func(string) bool, candidates ...string) (string, int) {
+	for idx, c := range candidates {
+		if c == "" {
+			continue
+		}
+		if isDir(c) {
+			return c, idx
+		}
+	}
+	return "", -1
+}

--- a/services/gmuxd/internal/projects/launchdir_test.go
+++ b/services/gmuxd/internal/projects/launchdir_test.go
@@ -1,0 +1,122 @@
+package projects
+
+import "testing"
+
+func TestItemCanonicalDir(t *testing.T) {
+	tests := []struct {
+		name string
+		item *Item
+		want string
+	}{
+		{"nil", nil, ""},
+		{"no rules", &Item{Slug: "p"}, ""},
+		{"first path rule", &Item{Slug: "p", Match: []MatchRule{{Path: "/dev/proj"}}}, "/dev/proj"},
+		{"remote then path", &Item{Slug: "p", Match: []MatchRule{
+			{Remote: "github.com/o/r"}, {Path: "/dev/proj"},
+		}}, "/dev/proj"},
+		{"first of several paths", &Item{Slug: "p", Match: []MatchRule{
+			{Path: "/dev/a"}, {Path: "/dev/b"},
+		}}, "/dev/a"},
+		{"reference ignored", &Item{Slug: "p", Peer: "host", Match: []MatchRule{{Path: "/dev/proj"}}}, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.item.CanonicalDir(); got != tc.want {
+				t.Errorf("CanonicalDir() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestStateProjectBySlug(t *testing.T) {
+	s := &State{Items: []Item{
+		{Slug: "owned", Match: []MatchRule{{Path: "/dev/owned"}}},
+		{Slug: "ref", Peer: "host"},
+	}}
+	if got := s.ProjectBySlug("owned"); got == nil || got.Slug != "owned" {
+		t.Errorf("expected owned project, got %v", got)
+	}
+	if got := s.ProjectBySlug("ref"); got != nil {
+		t.Errorf("reference should not resolve, got %v", got)
+	}
+	if got := s.ProjectBySlug("missing"); got != nil {
+		t.Errorf("missing slug should be nil, got %v", got)
+	}
+	if got := s.ProjectBySlug(""); got != nil {
+		t.Errorf("empty slug should be nil, got %v", got)
+	}
+}
+
+func TestCanonicalDirForSession(t *testing.T) {
+	s := &State{Items: []Item{
+		{Slug: "proj", Match: []MatchRule{{Path: "/dev/proj"}}},
+	}}
+
+	// By assigned slug.
+	if got := s.CanonicalDirForSession("proj", MatchParams{}); got != "/dev/proj" {
+		t.Errorf("by slug = %q, want /dev/proj", got)
+	}
+	// Slug empty: fall back to matching the (deleted) cwd against rules.
+	if got := s.CanonicalDirForSession("", MatchParams{Cwd: "/dev/proj/gone"}); got != "/dev/proj" {
+		t.Errorf("by cwd match = %q, want /dev/proj", got)
+	}
+	// No owning project at all.
+	if got := s.CanonicalDirForSession("", MatchParams{Cwd: "/elsewhere"}); got != "" {
+		t.Errorf("unmatched = %q, want empty", got)
+	}
+}
+
+// The assigned slug is authoritative: a session must resume in its own
+// project's dir, never get relocated into a different project whose
+// path rule happens to match the (deleted) cwd.
+func TestCanonicalDirForSession_SlugBeatsCwdMatch(t *testing.T) {
+	s := &State{Items: []Item{
+		{Slug: "home", Match: []MatchRule{{Path: "/dev/proj"}}},
+		{Slug: "proj", Match: []MatchRule{{Path: "/dev/proj/sub"}}},
+	}}
+	// Session is stamped to "home" but its cwd sits under proj's rule.
+	got := s.CanonicalDirForSession("home", MatchParams{Cwd: "/dev/proj/sub/gone"})
+	if got != "/dev/proj" {
+		t.Errorf("got %q, want /dev/proj (assigned slug wins over cwd match)", got)
+	}
+}
+
+// A slug-assigned project with only a remote rule has no canonical
+// local folder: return empty so the caller falls through to $HOME
+// rather than silently borrowing some other project's path.
+func TestCanonicalDirForSession_RemoteOnlyProjectYieldsEmpty(t *testing.T) {
+	s := &State{Items: []Item{
+		{Slug: "remote", Match: []MatchRule{{Remote: "github.com/o/r"}}},
+		{Slug: "other", Match: []MatchRule{{Path: "/dev/other"}}},
+	}}
+	got := s.CanonicalDirForSession("remote", MatchParams{Cwd: "/dev/other/gone"})
+	if got != "" {
+		t.Errorf("got %q, want empty (remote-only project has no canonical local dir)", got)
+	}
+}
+
+func TestResolveLaunchDir(t *testing.T) {
+	exists := map[string]bool{"/cwd": true, "/canon": true, "/home": true}
+	isDir := func(p string) bool { return exists[p] }
+
+	tests := []struct {
+		name       string
+		candidates []string
+		wantDir    string
+		wantIdx    int
+	}{
+		{"cwd exists", []string{"/cwd", "/canon", "/home"}, "/cwd", 0},
+		{"cwd gone, canonical", []string{"/gone", "/canon", "/home"}, "/canon", 1},
+		{"cwd+canon gone, home", []string{"/gone", "/gone2", "/home"}, "/home", 2},
+		{"skip empties", []string{"", "", "/home"}, "/home", 2},
+		{"none", []string{"/gone", "", "/x"}, "", -1},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir, idx := ResolveLaunchDir(isDir, tc.candidates...)
+			if dir != tc.wantDir || idx != tc.wantIdx {
+				t.Errorf("ResolveLaunchDir = (%q, %d), want (%q, %d)", dir, idx, tc.wantDir, tc.wantIdx)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

Resuming/restarting a session whose working directory no longer exists
(e.g. a since-deleted grove workspace or `/tmp` scratch dir) fails with a
**misleading** error. `launchGmux` sets `cmd.Dir = cwd` then execs, and
Go reports the child's `chdir` ENOENT against argv0, so the daemon logs:

```
resume: failed to start gmux: fork/exec /home/.../gmux: no such file or directory
```

…which looks like the gmux binary is missing when it's actually the cwd.

## Fix

Resume/restart now resolve the launch dir up front and `Stat` every
candidate before exec. Fallback chain:

1. the session's stored cwd, if it still exists;
2. the owning project's **canonical dir** (first match-rule path), if it exists;
3. `$HOME`, as a last resort.

If none exist, the daemon returns a clear `cwd_missing` error (422)
instead of the phantom "gmux not found". Fallbacks are logged. `/launch`
gains the same up-front `Stat` guard — clear error, no silent redirect
(the cwd is user-chosen).

## Canonical folder definition

**The project's first match-rule path**, normalized. This is already the
definition used by:

- the frontend project-row / hub "+" button (`launchCwd`, in-flight
  `project-launch-cwd`), and
- the peering `launch_cwd` hint advertised to viewers.

Centralized server-side in the `projects` package
(`Item.CanonicalDir` / `State.CanonicalDirForSession`) as the single
source of truth, so a resumed session lands exactly where the "+" button
would launch a fresh one. Two contracts are pinned by tests: the
assigned project slug is authoritative over a cwd that happens to match a
*different* project (no accidental relocation), and a remote-only project
yields no local canonical dir (falls through to `$HOME`).

## Feedback signal (no UI built here)

On a fallback, the `/resume` and `/restart` success payloads carry
`original_cwd` + `fallback_cwd` so a future info-toast ("original folder
gone; resumed in …") can be rendered without re-deriving anything. The
`cwd_missing` failure path returns a structured error the toast layer can
consume. Building the toast UI itself stays out of scope (error-toasts
owns it).

## Peers

Peer-owned sessions are `peer.Forward`'d to the owning host before
reaching these handlers, so the fallback only runs for local sessions —
canonical paths stay correctly per-host.

## Tests

- `internal/projects`: `Item.CanonicalDir`, `State.ProjectBySlug`,
  `State.CanonicalDirForSession` (incl. slug-beats-cwd-match and
  remote-only-yields-empty contracts), pure `ResolveLaunchDir`
  (table-driven, injected fs).
- `cmd/gmuxd`: `resolveResumeDir` — cwd exists (no fallback); cwd missing
  → canonical; canonical also missing → `$HOME`; nothing exists → empty
  (caller errors); no owning project → `$HOME`. Plus `relaunchData`
  payload shape (fallback fields present only on fallback).
- `go test ./...` green; `-race` green for touched packages
  (`cmd/gmuxd`, `internal/projects`). A pre-existing flaky race in
  `internal/notify` (in `newTestEnv`, untouched here) is unrelated.

## Out of scope

Toast UI (error-toasts owns it; this just returns/logs good signal) and
the frontend launch-button change (project-launch-cwd owns it).