### PR TITLE
docs: renumber duplicate ADR 0015 (references) to 0017

### DIFF
--- a/apps/gmux-web/src/projects.test.ts
+++ b/apps/gmux-web/src/projects.test.ts
@@ -317,7 +317,7 @@ describe('buildProjectFolders', () => {
   })
 
   it('buckets a reference\'s sessions by its stored name and stays resolved when present', () => {
-    // `peer` is the runtime key (ADR 0015): sessions stamped with the
+    // `peer` is the runtime key (ADR 0017): sessions stamped with the
     // same name land in the folder, and the liveness predicate (node_id
     // present) keeps it resolved.
     const projects: ProjectItem[] = [{ slug: 'apps', peer: 'gmux-hs', node_id: 'node_hs' }]

--- a/apps/gmux-web/src/projects.ts
+++ b/apps/gmux-web/src/projects.ts
@@ -333,7 +333,7 @@ export function buildProjectFolders(
   sessions: Session[],
   isLocalPeer?: (peerName: string) => boolean,
   peerProjects?: Record<string, { slug: string; launch_cwd?: string }[]>,
-  // Liveness predicate: is a reference's host in the roster? (ADR 0015).
+  // Liveness predicate: is a reference's host in the roster? (ADR 0017).
   // `peer` is a frozen viewer-owned label, so references bucket/label by
   // it directly; this only sets the unresolved flag. Omitted ⇒ present.
   isPresent?: (peer: string, nodeId?: string) => boolean,

--- a/apps/gmux-web/src/references.ts
+++ b/apps/gmux-web/src/references.ts
@@ -1,4 +1,4 @@
-// --- Peer reference liveness (ADR 0015) ---
+// --- Peer reference liveness (ADR 0017) ---
 //
 // A reference points at a peer-owned project. Its `peer` name is the
 // runtime key (folder bucketing, peer_projects, URLs, routing) and is a
@@ -74,7 +74,7 @@ export function unresolvedReferences(
  * Remove the references `(peer, slug)` for `slug` in `slugs`. Pure:
  * returns a new items array. Scoping to the surfaced unresolved `slugs`
  * is what prevents deleting a same-named reference that is actually
- * present via its node_id anchor (ADR 0015).
+ * present via its node_id anchor (ADR 0017).
  */
 export function removeReferenceItems(
   items: readonly ProjectItem[],

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -518,7 +518,7 @@ export const localPeerNames = computed<ReadonlySet<string>>(() => {
 
 /** Distinct referenced host names absent from the roster. Drives the
  *  Hosts-tab "Referenced but not found" group and the gear pip — a
- *  node_id/name membership check against the roster (ADR 0015). */
+ *  node_id/name membership check against the roster (ADR 0017). */
 export const unresolvedHosts = computed<UnresolvedHost[]>(
   () => unresolvedReferences(projects.value, peers.value),
 )

--- a/docs/adr/0017-reference-resolution-name-key-nodeid-plumbing.md
+++ b/docs/adr/0017-reference-resolution-name-key-nodeid-plumbing.md
@@ -1,4 +1,4 @@
-# ADR 0015: References identify by name; node_id is a liveness anchor
+# ADR 0017: References identify by name; node_id is a liveness anchor
 
 **Status:** Proposed
 **Date:** 2026-06-23

--- a/services/gmuxd/internal/projects/projects.go
+++ b/services/gmuxd/internal/projects/projects.go
@@ -62,7 +62,7 @@ type Item struct {
 	Sessions []string    `json:"sessions,omitempty"`
 	// NodeID is the referenced peer's stable opaque identity (ADR 0007).
 	// Peer (the display name) is the runtime key; NodeID is only the
-	// viewer's liveness anchor (ADR 0015): it keeps a reference matching
+	// viewer's liveness anchor (ADR 0017): it keeps a reference matching
 	// the right host across re-adds and stops a reused name from matching
 	// the wrong one. Set only on references; stamped at creation.
 	NodeID string `json:"node_id,omitempty"`

--- a/services/gmuxd/internal/projects/projects_test.go
+++ b/services/gmuxd/internal/projects/projects_test.go
@@ -1408,7 +1408,7 @@ func TestValidateRejectsReferenceWithMatchRules(t *testing.T) {
 }
 
 // A reference's node_id anchor must survive a Save/Load round-trip so
-// the daemon can follow a renamed peer across restarts (ADR 0015).
+// the daemon can follow a renamed peer across restarts (ADR 0017).
 func TestReferenceNodeIDRoundTrips(t *testing.T) {
 	dir := t.TempDir()
 	orig := &State{Items: []Item{


### PR DESCRIPTION
## Problem
Two merged PRs both landed an **ADR 0015**:
- \`0015-hook-translation-at-the-agent-side.md\` (#327, merged first) — keeps 0015.
- \`0015-reference-resolution-name-key-nodeid-plumbing.md\` (#331) — collision; and 0016 was already taken by retention (#333).

## Fix
Renumber the **references** ADR (the second 0015) to **0017** (0016 is taken):
- Rename the file → \`0017-reference-resolution-name-key-nodeid-plumbing.md\` and bump its header.
- Repoint the 6 code/doc citations that referred to *that* ADR (\`projects.ts\`, \`projects.test.ts\`, \`references.ts\` ×2, \`store.ts\`, \`projects.go\`, \`projects_test.go\`) from \`ADR 0015\` → \`ADR 0017\`.

Left untouched: the hook-translation \`ADR 0015\` (file header + \`runner-hook-protocol.md\` citation) and all \`ADR 0016\` retention citations — verified each citation points at the intended ADR before rewiring.

Docs/comment-only; `projects` package builds.