### PR TITLE
fix(gmuxd): disambiguate launch failure when the working directory is missing

### DIFF
--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -198,6 +198,15 @@ func launchGmux(gmuxBin string, command []string, cwd, resumeID string, initialC
 	cmd.Env = sessionenv.Strip(captureLoginEnv(gmuxBin, cwd))
 
 	if err := cmd.Start(); err != nil {
+		// Go surfaces the child's chdir ENOENT against argv0, so a
+		// missing cwd reads as "fork/exec .../gmux: no such file or
+		// directory" — as if the gmux binary were gone. Callers Stat
+		// their target first (resolveResumeDir, the /launch guard), but
+		// the directory can still vanish between that check and Start.
+		// Disambiguate here so the misleading message can never escape.
+		if cwd != "" && !projects.IsDir(cwd) {
+			return 0, fmt.Errorf("working directory %q does not exist: %w", cwd, err)
+		}
 		return 0, err
 	}
 	go cmd.Wait()

--- a/services/gmuxd/cmd/gmuxd/resumedir_test.go
+++ b/services/gmuxd/cmd/gmuxd/resumedir_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/projects"
@@ -99,5 +100,37 @@ func TestResolveResumeDir_NoProject_CwdMissingFallsToHome(t *testing.T) {
 	dir, fellBack := resolveResumeDir(mgr, sess)
 	if dir != home || !fellBack {
 		t.Errorf("got (%q, %v), want (%q, true)", dir, fellBack, home)
+	}
+}
+
+// launchGmux must never surface a missing cwd as the misleading
+// "fork/exec .../gmux: no such file or directory". Callers Stat their
+// target first, but the dir can vanish between check and Start (TOCTOU);
+// the wrap in launchGmux is the last line of defense.
+func TestLaunchGmux_MissingCwd_DisambiguatedError(t *testing.T) {
+	t.Setenv("SHELL", "") // skip the login-env probe; inherit daemon env
+	gone := filepath.Join(t.TempDir(), "vanished")
+
+	_, err := launchGmux("/bin/true", []string{"true"}, gone, "", 0, 0)
+	if err == nil {
+		t.Fatal("expected error for missing cwd")
+	}
+	if !strings.Contains(err.Error(), "working directory") || !strings.Contains(err.Error(), gone) {
+		t.Errorf("error does not name the missing cwd: %v", err)
+	}
+}
+
+// A genuinely missing binary (with a valid cwd) must keep the original
+// exec error — the disambiguation must not mislabel it as a cwd problem.
+func TestLaunchGmux_MissingBinary_KeepsExecError(t *testing.T) {
+	t.Setenv("SHELL", "")
+	cwd := t.TempDir()
+
+	_, err := launchGmux(filepath.Join(t.TempDir(), "no-such-gmux"), []string{"x"}, cwd, "", 0, 0)
+	if err == nil {
+		t.Fatal("expected error for missing binary")
+	}
+	if strings.Contains(err.Error(), "working directory") {
+		t.Errorf("missing binary mislabeled as cwd problem: %v", err)
 	}
 }


### PR DESCRIPTION
Follow-up to #334, closing the one gap an independent review found there.

#334 Stats every launch-dir candidate before exec, but a TOCTOU window
remains: the directory can vanish between the check and `cmd.Start()`,
in which case Go reports the child's `chdir` ENOENT against argv0 and
the misleading `fork/exec .../gmux: no such file or directory` returns.

Close the gap at the source: when `Start` fails and the cwd is not an
existing directory, `launchGmux` now names the cwd explicitly
(`working directory %q does not exist: <original error>`). This also
protects any future caller that skips an up-front check.

Tests pin both directions: a missing cwd yields the disambiguated
error, and a genuinely missing binary (valid cwd) keeps the original
exec error — the wrap must not mislabel binary problems as cwd
problems.