### PR TITLE
fix(gmuxd): harden dead-session retention (post-merge review follow-ups)

### DIFF
--- a/docs/adr/0016-session-retention-scrollback-as-cache.md
+++ b/docs/adr/0016-session-retention-scrollback-as-cache.md
@@ -38,7 +38,10 @@ durable record.
 live session's scrollback must never be evicted. The store is the authority on
 liveness; the prune skips any session ID the store reports `Alive`. At startup
 this runs only from discovery's first-scan hook, *after* live runners have
-re-registered as alive.
+re-registered as alive. Because the alive set is a snapshot, a session resumed
+*during* the prune (or a runner the store hasn't registered yet) is covered by
+a write-freshness guard instead: a victim whose scrollback mtime advanced past
+its scan-time value is skipped — any writer bumps the mtime.
 
 **When it runs.** At startup (first-scan hook) and, throttled to ≥12 h since
 the last run, when a session is **dismissed**. No background timer: a periodic
@@ -49,12 +52,13 @@ throttle is tracked by the mtime of a `.scrollback-prune-stamp` marker.
 ### 2. `meta.json` mirrors conversation existence
 
 A dead session's *whole* entry is retired only when its backing conversation
-file disappears. The conversations index (ADR 0014) already observes file
-removals via adapter sources; `RemoveByPath` now fires a callback, and gmuxd
-retires the dead session(s) whose `SessionFile` matches (skipping any alive or
-peer-owned session — the mapping is N:1). `sessions.Remove` broadcasts
-`session-remove`, which the existing `WatchRemovals` loop catches to drop the
-dir.
+file disappears. The adapter conversation watchers (ADR 0014) already observe
+file removals; the watcher-level sink reports every file-gone event —
+including files the index never held (parse failure, `CanResume=false`, empty
+cwd) — and gmuxd retires the dead session(s) whose `SessionFile` matches
+(skipping any alive or peer-owned session — the mapping is N:1).
+`sessions.Remove` broadcasts `session-remove`, which the existing
+`WatchRemovals` loop catches to drop the dir.
 
 The index only observes removals while gmuxd runs, so a file deleted *while the
 daemon is down* would otherwise leave an orphan entry. A **startup reconcile**

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -561,8 +561,9 @@ func serve(stderr io.Writer) int {
 	const scrollbackCacheInterval = 12 * time.Hour
 
 	// Retire the dead session(s) backed by a conversation file when that
-	// file disappears: the conversations index reports the removal, and
-	// meta.json mirrors conversation existence (ADR 0016). The store
+	// file disappears: the adapter conversation watchers report file-gone
+	// (WatchSources below — fires even for files the index never held),
+	// and meta.json mirrors conversation existence (ADR 0016). The store
 	// applies the alive/peer/N:1 guards; its session-remove broadcast is
 	// what WatchRemovals turns into a meta-dir delete.
 	convRetireMeta := func(path string) { sessions.RemoveDeadBySessionFile(path) }
@@ -647,13 +648,12 @@ func serve(stderr io.Writer) int {
 	// adapter's ConversationSource supplies a snapshot at startup and
 	// incremental updates thereafter; the daemon owns no file monitor.
 	convIndex := conversations.New()
-	convIndex.SetOnRemoveByPath(convRetireMeta)
 	convIndex.Snapshot()
 	log.Printf("conversations: indexed %d files", convIndex.Count())
 
 	srcCtx, cancelSources := context.WithCancel(context.Background())
 	defer cancelSources()
-	convIndex.WatchSources(srcCtx)
+	convIndex.WatchSources(srcCtx, convRetireMeta)
 
 	// Start background update checker
 	updateChecker := update.New(version)

--- a/services/gmuxd/internal/conversations/index.go
+++ b/services/gmuxd/internal/conversations/index.go
@@ -39,19 +39,6 @@ type Index struct {
 	// byToolID maps "kind/toolID" → slug for reverse lookup
 	// (e.g., finding a conversation's slug from its tool UUID).
 	byToolID map[string]string
-	// onRemoveByPath, if set, is invoked (outside the lock) with the
-	// file path whenever RemoveByPath drops a conversation because its
-	// file disappeared. cmd/gmuxd wires this to retire dead sessions
-	// whose SessionFile matches. Set once at startup; not guarded.
-	onRemoveByPath func(path string)
-}
-
-// SetOnRemoveByPath registers a callback fired after RemoveByPath
-// removes a conversation (i.e. its file vanished on disk). Wired at
-// startup so a conversation-file deletion can retire the dead
-// session(s) backed by that file.
-func (idx *Index) SetOnRemoveByPath(fn func(path string)) {
-	idx.onRemoveByPath = fn
 }
 
 // New creates an empty index.
@@ -208,28 +195,24 @@ func (idx *Index) Remove(kind, toolID string) bool {
 // (kind, toolID) handy. Linear walk over the index; that's fine
 // because Remove events are rare (manual `rm`, file rotation) and
 // the index size stays in the hundreds-to-low-thousands range.
-// Returns true if an entry was removed. On removal it fires the
-// onRemoveByPath callback (if set) outside the lock, so the caller can
-// retire sessions backed by the now-gone file without risking a
-// re-entrant deadlock.
+// Returns true if an entry was removed.
+//
+// Session retirement on file-gone deliberately does NOT hang off this
+// method: an unindexed conversation (parse failure, CanResume=false,
+// empty cwd) still needs retiring when its file disappears, so the
+// watcher-level sink (sources.go) owns that signal instead.
 func (idx *Index) RemoveByPath(path string) bool {
 	idx.mu.Lock()
-	removed := false
+	defer idx.mu.Unlock()
 	for key, info := range idx.byKey {
 		if info.FilePath != path {
 			continue
 		}
 		delete(idx.byKey, key)
 		delete(idx.byToolID, toolKey(info.Kind, info.ToolID))
-		removed = true
-		break
+		return true
 	}
-	idx.mu.Unlock()
-
-	if removed && idx.onRemoveByPath != nil {
-		idx.onRemoveByPath(path)
-	}
-	return removed
+	return false
 }
 
 // SlugExists reports whether a slug is taken within a kind.

--- a/services/gmuxd/internal/conversations/index_test.go
+++ b/services/gmuxd/internal/conversations/index_test.go
@@ -249,26 +249,33 @@ func TestAll(t *testing.T) {
 	}
 }
 
-// TestRemoveByPathFiresCallback pins that the onRemoveByPath hook fires
-// with the path exactly when an entry is removed, and not on a miss.
-func TestRemoveByPathFiresCallback(t *testing.T) {
+// TestSinkRemoveFiresOnRemovedEvenWhenUnindexed pins the retirement
+// seam: the watcher-level sink reports every file-gone event to
+// onRemoved — including files the index never held (parse failure,
+// CanResume=false, empty cwd) — because a dead session bound to an
+// unindexed conversation must still retire when its file is deleted.
+// It also still removes indexed entries from the index.
+func TestSinkRemoveFiresOnRemovedEvenWhenUnindexed(t *testing.T) {
 	idx := New()
 	idx.Upsert(Info{ToolID: "a", Slug: "one", Kind: "pi", FilePath: "/x/a.jsonl"})
 
 	var got []string
-	idx.SetOnRemoveByPath(func(p string) { got = append(got, p) })
+	sink := indexSink{idx: idx, onRemoved: func(p string) { got = append(got, p) }}
 
-	if idx.RemoveByPath("/x/missing.jsonl") {
-		t.Fatal("expected false for unindexed path")
+	sink.Remove("/x/never-indexed.jsonl")
+	sink.Remove("/x/a.jsonl")
+
+	want := []string{"/x/never-indexed.jsonl", "/x/a.jsonl"}
+	if len(got) != 2 || got[0] != want[0] || got[1] != want[1] {
+		t.Errorf("onRemoved should fire for every removal event, got %v want %v", got, want)
 	}
-	if len(got) != 0 {
-		t.Errorf("callback must not fire on a miss, got %v", got)
+	if _, ok := idx.Lookup("pi", "one"); ok {
+		t.Error("indexed entry should have been removed from the index")
+	}
+	if idx.Count() != 0 {
+		t.Errorf("index should be empty, count=%d", idx.Count())
 	}
 
-	if !idx.RemoveByPath("/x/a.jsonl") {
-		t.Fatal("expected true for indexed path")
-	}
-	if len(got) != 1 || got[0] != "/x/a.jsonl" {
-		t.Errorf("callback should fire once with the path, got %v", got)
-	}
+	// nil callback must not panic.
+	indexSink{idx: idx}.Remove("/x/whatever.jsonl")
 }

--- a/services/gmuxd/internal/conversations/sources.go
+++ b/services/gmuxd/internal/conversations/sources.go
@@ -10,34 +10,48 @@ import (
 )
 
 // indexSink bridges one adapter's ConversationSource to the index.
+// onRemoved, if set, additionally observes every file-gone event —
+// including files the index never held (parse failure, CanResume=false,
+// empty cwd), which is why retirement hangs here and not off
+// Index.RemoveByPath: a dead session bound to an unindexed conversation
+// must still retire when that file is deleted.
 type indexSink struct {
-	idx *Index
-	a   adapter.Adapter
+	idx       *Index
+	a         adapter.Adapter
+	onRemoved func(path string)
 }
 
 func (s indexSink) Upsert(path string) { s.idx.ScanFile(s.a, path) }
-func (s indexSink) Remove(path string) { s.idx.RemoveByPath(path) }
+func (s indexSink) Remove(path string) {
+	s.idx.RemoveByPath(path)
+	if s.onRemoved != nil {
+		s.onRemoved(path)
+	}
+}
 
 // Snapshot populates the index from every adapter ConversationSource.
 // Synchronous; call once at startup before consumers read the index.
 func (idx *Index) Snapshot() {
 	for _, a := range adapters.AllAdapters() {
 		if src, ok := a.(adapter.ConversationSource); ok {
-			src.SnapshotConversations(indexSink{idx, a})
+			src.SnapshotConversations(indexSink{idx: idx, a: a})
 		}
 	}
 }
 
 // WatchSources starts every adapter ConversationSource in its own goroutine,
-// feeding the index until ctx is cancelled.
-func (idx *Index) WatchSources(ctx context.Context) {
+// feeding the index until ctx is cancelled. onFileRemoved, if non-nil,
+// is invoked (from the watcher goroutines) with each conversation file
+// path observed to disappear — whether or not it was indexed. cmd/gmuxd
+// wires this to retire dead sessions backed by the deleted file.
+func (idx *Index) WatchSources(ctx context.Context, onFileRemoved func(path string)) {
 	for _, a := range adapters.AllAdapters() {
 		src, ok := a.(adapter.ConversationSource)
 		if !ok {
 			continue
 		}
 		go func(a adapter.Adapter, src adapter.ConversationSource) {
-			if err := src.WatchConversations(ctx, indexSink{idx, a}); err != nil && !errors.Is(err, context.Canceled) {
+			if err := src.WatchConversations(ctx, indexSink{idx: idx, a: a, onRemoved: onFileRemoved}); err != nil && !errors.Is(err, context.Canceled) {
 				log.Printf("conversations: source %s stopped: %v", a.Name(), err)
 			}
 		}(a, src)

--- a/services/gmuxd/internal/conversations/sources_test.go
+++ b/services/gmuxd/internal/conversations/sources_test.go
@@ -39,7 +39,7 @@ func TestSnapshotAndWatchSources(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	idx.WatchSources(ctx)
+	idx.WatchSources(ctx, nil)
 	time.Sleep(150 * time.Millisecond) // let the watchers establish
 
 	writePiFile(t, filepath.Join(root, "--tmp-b--", "id-2.jsonl"), "id-2")

--- a/services/gmuxd/internal/sessionmeta/sessionmeta.go
+++ b/services/gmuxd/internal/sessionmeta/sessionmeta.go
@@ -48,6 +48,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"math"
 	"os"
 	"path/filepath"
 	"sort"
@@ -132,8 +133,8 @@ func DefaultRetention() RetentionPolicy {
 		// (int64 ns) once multiplied by 24h, so a huge value can't
 		// overflow to a negative duration that prune would silently treat
 		// as "no age limit".
-		const maxSafeDays = int(^uint(0)>>1) / int(24*time.Hour) // ~106 751 on 64-bit
-		if days, err := strconv.Atoi(v); err == nil && days >= 0 && days <= maxSafeDays {
+		const maxSafeDays = math.MaxInt64 / int64(24*time.Hour) // ~106 751
+		if days, err := strconv.Atoi(v); err == nil && days >= 0 && int64(days) <= maxSafeDays {
 			p.MaxAge = time.Duration(days) * 24 * time.Hour
 		} else {
 			log.Printf("sessionmeta: ignoring invalid %s=%q", envRetentionDays, v)
@@ -148,8 +149,8 @@ func DefaultRetention() RetentionPolicy {
 	}
 	if v := os.Getenv(envScrollbackCacheMB); v != "" {
 		// Guard the MiB→bytes shift against int64 overflow the same way.
-		const maxSafeMB = int((^uint64(0) >> 1) >> 20) // bytes that fit in int64
-		if mb, err := strconv.Atoi(v); err == nil && mb >= 0 && mb <= maxSafeMB {
+		const maxSafeMB = math.MaxInt64 >> 20 // MiB counts whose byte value fits in int64
+		if mb, err := strconv.Atoi(v); err == nil && mb >= 0 && int64(mb) <= maxSafeMB {
 			p.ScrollbackCacheBytes = int64(mb) << 20
 		} else {
 			log.Printf("sessionmeta: ignoring invalid %s=%q", envScrollbackCacheMB, v)
@@ -593,28 +594,49 @@ func (s *Store) PruneScrollback(alive map[string]bool) {
 		if total <= s.retention.ScrollbackCacheBytes {
 			break
 		}
-		sessDir := s.SessionDir(u.id)
-		freed := int64(0)
-		for _, name := range scrollbackNames {
-			p := filepath.Join(sessDir, name)
-			fi, err := os.Stat(p)
-			if err != nil {
-				continue
-			}
-			if err := os.Remove(p); err != nil {
-				log.Printf("sessionmeta: scrollback prune remove %s: %v", p, err)
-				continue
-			}
-			freed += fi.Size()
-		}
-		if freed > 0 {
-			log.Printf("sessionmeta: reclaimed %d bytes of scrollback from %s (cache cap)", freed, u.id)
-		}
 		// Decrement by what was actually freed, not the scan-time size:
-		// if a remove failed those bytes are still on disk, so we must
-		// keep evicting rather than stop early on a phantom reclaim.
-		total -= freed
+		// if a remove failed (or the victim was skipped) those bytes are
+		// still on disk, so we must keep evicting rather than stop early
+		// on a phantom reclaim.
+		total -= s.evictScrollback(u)
 	}
+}
+
+// evictScrollback removes one session's scrollback files and returns
+// the bytes actually freed.
+//
+// Write-freshness guard: the alive set is a snapshot, so a session
+// resumed *during* the prune isn't in it — yet its fresh runner reopens
+// (truncating) the same scrollback path (see cli/gmux run). Deleting
+// that open file would leave the runner appending to an unlinked inode
+// and break its next rotation (sticky failure). Any writer — including
+// a runner the store doesn't know about — bumps the file mtime, so a
+// victim whose scrollback mtime advanced past its scan-time value is
+// skipped entirely. The remaining stat→remove window is microseconds.
+func (s *Store) evictScrollback(u scrollbackUsage) (freed int64) {
+	sessDir := s.SessionDir(u.id)
+	for _, name := range scrollbackNames {
+		if fi, err := os.Stat(filepath.Join(sessDir, name)); err == nil && fi.ModTime().After(u.mtime) {
+			log.Printf("sessionmeta: scrollback prune skipping %s (written since scan)", u.id)
+			return 0
+		}
+	}
+	for _, name := range scrollbackNames {
+		p := filepath.Join(sessDir, name)
+		fi, err := os.Stat(p)
+		if err != nil {
+			continue
+		}
+		if err := os.Remove(p); err != nil {
+			log.Printf("sessionmeta: scrollback prune remove %s: %v", p, err)
+			continue
+		}
+		freed += fi.Size()
+	}
+	if freed > 0 {
+		log.Printf("sessionmeta: reclaimed %d bytes of scrollback from %s (cache cap)", freed, u.id)
+	}
+	return freed
 }
 
 // MaybePruneScrollback runs PruneScrollback only when at least

--- a/services/gmuxd/internal/sessionmeta/sessionmeta_retention_test.go
+++ b/services/gmuxd/internal/sessionmeta/sessionmeta_retention_test.go
@@ -3,6 +3,7 @@ package sessionmeta
 import (
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -376,4 +377,99 @@ func TestPruneScrollbackFailedRemoveKeepsEvicting(t *testing.T) {
 	if exists(t, filepath.Join(s.SessionDir("sess-evictable"), scrollback.ActiveName)) {
 		t.Error("evictable scrollback must still be reclaimed despite the earlier failure")
 	}
+}
+
+// TestEvictScrollbackSkipsFreshlyWritten pins the write-freshness guard
+// against the prune-vs-resume race: a victim whose scrollback mtime
+// advanced past its scan-time value (someone — e.g. a just-resumed
+// runner — wrote it after the scan) is skipped entirely, freeing 0.
+func TestEvictScrollbackSkipsFreshlyWritten(t *testing.T) {
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	s := New(t.TempDir(),
+		WithRetention(RetentionPolicy{ScrollbackCacheBytes: 1}),
+		WithClock(func() time.Time { return now }))
+	writeDead(t, s, "sess-a", now.Format(time.RFC3339), "")
+	writeScrollback(t, s, "sess-a", 100, now)
+
+	// Scan-time snapshot says the file is older than it now is.
+	stale := scrollbackUsage{id: "sess-a", bytes: 100, mtime: now.Add(-time.Hour)}
+	if freed := s.evictScrollback(stale); freed != 0 {
+		t.Errorf("freshly-written victim must be skipped, freed %d", freed)
+	}
+	if !exists(t, filepath.Join(s.SessionDir("sess-a"), scrollback.ActiveName)) {
+		t.Error("freshly-written scrollback must survive")
+	}
+
+	// With an accurate snapshot the same victim is evicted.
+	current := scrollbackUsage{id: "sess-a", bytes: 100, mtime: now}
+	if freed := s.evictScrollback(current); freed != 100 {
+		t.Errorf("accurate-snapshot victim should free 100, freed %d", freed)
+	}
+	if exists(t, filepath.Join(s.SessionDir("sess-a"), scrollback.ActiveName)) {
+		t.Error("scrollback should be evicted")
+	}
+}
+
+// TestPruneScrollbackCoalesces pins the TryLock coalescing: a prune
+// entering while another holds the lock must do nothing (no eviction,
+// no stamp), and a later un-contended run must evict normally.
+func TestPruneScrollbackCoalesces(t *testing.T) {
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	s := New(t.TempDir(),
+		WithRetention(RetentionPolicy{ScrollbackCacheBytes: 1}),
+		WithClock(func() time.Time { return now }))
+	writeDead(t, s, "sess-a", now.Format(time.RFC3339), "")
+	writeScrollback(t, s, "sess-a", 100, now)
+
+	s.pruneMu.Lock()
+	s.PruneScrollback(nil) // contended: must skip
+	s.pruneMu.Unlock()
+
+	if !exists(t, filepath.Join(s.SessionDir("sess-a"), scrollback.ActiveName)) {
+		t.Fatal("contended prune must not evict")
+	}
+	if exists(t, filepath.Join(s.Dir(), pruneStampFile)) {
+		t.Error("contended prune must not advance the throttle stamp")
+	}
+
+	s.PruneScrollback(nil) // uncontended: evicts
+	if exists(t, filepath.Join(s.SessionDir("sess-a"), scrollback.ActiveName)) {
+		t.Error("uncontended prune should evict")
+	}
+}
+
+// TestRemoveDeadBySessionFileDrivesWatchRemovals pins the seam between
+// the store broadcast and the meta persister: retiring a dead session
+// via RemoveDeadBySessionFile must, through the session-remove event
+// consumed by WatchRemovals, delete the on-disk meta dir.
+func TestRemoveDeadBySessionFileDrivesWatchRemovals(t *testing.T) {
+	metaStore := New(t.TempDir())
+	sess := store.Session{ID: "sess-dead1", Kind: "claude", Alive: false, SessionFile: "/c/conv.jsonl"}
+	if err := metaStore.Write(sess); err != nil {
+		t.Fatal(err)
+	}
+
+	sessions := store.New()
+	sessions.Upsert(sess)
+	events, cancel := sessions.Subscribe()
+	var cancelOnce sync.Once
+	stopWatch := func() { cancelOnce.Do(cancel) }
+	defer stopWatch()
+	done := make(chan struct{})
+	go func() { metaStore.WatchRemovals(events); close(done) }()
+
+	if ids := sessions.RemoveDeadBySessionFile("/c/conv.jsonl"); len(ids) != 1 {
+		t.Fatalf("expected 1 retired session, got %v", ids)
+	}
+
+	deadline := time.After(2 * time.Second)
+	for exists(t, metaStore.SessionDir("sess-dead1")) {
+		select {
+		case <-deadline:
+			t.Fatal("meta dir not removed via WatchRemovals within 2s")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+	stopWatch()
+	<-done
 }


### PR DESCRIPTION
## What

Post-merge hardening of #333 (ADR 0016 dead-session retention). I ran an
independent adversarial review (fresh manual audit + an unbiased subagent
given only the original task spec and the merged diff — both converged on
the same top finding). Four issues, all fixed:

### 1. Prune-vs-resume race (both reviews' top finding)

`PruneScrollback` picks eviction victims by **scan-time** mtime and skips a
**snapshot** of alive IDs. A session resumed *during* the prune — or a runner
whose `Register` transiently failed on the first scan — could have its freshly
reopened scrollback unlinked: the runner keeps appending to an unlinked inode,
and its next rotation's `os.Rename` hits ENOENT → sticky failure, scrollback
persistence silently dead for that runner.

Fix: `evictScrollback` re-stats each victim and **skips it when the scrollback
mtime advanced past the scan-time value**. Any writer bumps mtime (resume
truncation included), store-known or not — strictly stronger than re-checking
the store, and self-contained. Residual window is the stat→remove microseconds.
Regression test verified to fail with the guard disabled.

### 2. Retirement signal missed unindexed conversations

`Index.RemoveByPath` only fired the retire callback for files the index held.
A conversation that never indexed (parse failure, `CanResume=false`, empty
cwd) therefore didn't retire its dead session on runtime deletion — only the
next restart's reconcile healed it. The hook now lives on the **watcher-level
sink** (`WatchSources(ctx, onFileRemoved)`), which fires for *every* file-gone
event. `Index` loses its callback state entirely — which also removes the
latent trap of `Remove(kind, toolID)` silently bypassing the hook.

### 3. Untested seams

- TryLock coalescing: a contended prune must neither evict nor advance the
  throttle stamp — pinned.
- store broadcast → `WatchRemovals`: `RemoveDeadBySessionFile` actually
  deleting the meta dir end-to-end — pinned.

### 4. Portability nit

The env-override overflow guards used constants that don't compile on 32-bit
`int` (`int(24*time.Hour)`); now `int64`/`math.MaxInt64` based.

ADR 0016 updated (write-freshness guard; watcher-level retirement signal).

## Review verdict context

Both reviews judged #333 fine-as-shipped (no data-destroying bugs); these are
the ranked follow-ups. Full subagent report available on request.

## Tests

`go test -race ./...` green in `services/gmuxd` and `packages/adapter`. New:
freshly-written victim skipped (mutation-checked), coalescing, broadcast seam,
sink fires for unindexed paths (+ nil-callback safety).
