### PR TITLE
fix(gmuxd): stop Sweep from destroying live runners' scrollback on daemon restart

### DIFF
--- a/services/gmuxd/internal/sessionmeta/sessionmeta.go
+++ b/services/gmuxd/internal/sessionmeta/sessionmeta.go
@@ -373,8 +373,13 @@ func (s *Store) WatchRemovals(events <-chan store.Event) {
 // register.
 //
 // Cleanup performed during the sweep:
-//   - directories with no meta.json (orphan scrollback or empty
+//   - directories with no meta.json AND no scrollback (empty or junk
 //     dirs) are logged and removed
+//   - directories with scrollback but no meta.json are left alone:
+//     they belong to live, never-died runners (meta.json is written
+//     only on dead landings) whose open scrollback file must not be
+//     unlinked; crash leftovers among them are reclaimed by
+//     PruneScrollback's cap and swept once empty
 //   - directories whose meta.json fails to parse are logged and
 //     left in place (operator may want to inspect)
 //   - non-directory entries under the base dir are ignored
@@ -408,6 +413,18 @@ func (s *Store) Sweep() ([]store.Session, error) {
 
 		if _, err := os.Stat(metaPath); err != nil {
 			if errors.Is(err, os.ErrNotExist) {
+				// No meta.json. If the dir holds scrollback, it belongs to
+				// a live, never-died runner — meta.json is written only on
+				// dead landings, and the runner keeps its scrollback file
+				// open in this dir from launch — so removing it here would
+				// unlink the open file and sticky-break the runner's next
+				// rotation, destroying the session's post-mortem replay on
+				// every daemon restart. Leave it alone: if it is instead a
+				// crash leftover, PruneScrollback's cap reclaims the bytes
+				// and a later Sweep removes the then-empty dir.
+				if hasScrollback(sessDir) {
+					continue
+				}
 				log.Printf("sessionmeta: orphan dir %s (no %s); removing", sessDir, metaFile)
 				_ = os.RemoveAll(sessDir)
 				continue
@@ -520,6 +537,18 @@ type scrollbackUsage struct {
 
 // scrollbackNames are the runner-written files PruneScrollback reclaims.
 var scrollbackNames = []string{scrollback.ActiveName, scrollback.PreviousName}
+
+// hasScrollback reports whether the session dir contains any
+// runner-written scrollback file. Used by Sweep's orphan check to spare
+// live runners' dirs (which have scrollback but no meta.json yet).
+func hasScrollback(sessDir string) bool {
+	for _, name := range scrollbackNames {
+		if _, err := os.Stat(filepath.Join(sessDir, name)); err == nil {
+			return true
+		}
+	}
+	return false
+}
 
 // PruneScrollback enforces ScrollbackCacheBytes: it sums the scrollback
 // bytes across every session dir and, if the total exceeds the cap,

--- a/services/gmuxd/internal/sessionmeta/sessionmeta_retention_test.go
+++ b/services/gmuxd/internal/sessionmeta/sessionmeta_retention_test.go
@@ -473,3 +473,45 @@ func TestRemoveDeadBySessionFileDrivesWatchRemovals(t *testing.T) {
 	stopWatch()
 	<-done
 }
+
+// TestSweepSparesLiveRunnerScrollbackDir pins the fix for the
+// restart-nukes-live-scrollback bug: a session dir containing only
+// scrollback (no meta.json) belongs to a live, never-died runner —
+// meta.json is written only on dead landings — or to a crash leftover
+// that PruneScrollback's cap reclaims. Sweep must NOT RemoveAll it;
+// doing so unlinks the runner's open scrollback file and sticky-breaks
+// its next rotation, destroying the session's post-mortem replay on
+// every daemon restart. Truly empty dirs are still swept.
+func TestSweepSparesLiveRunnerScrollbackDir(t *testing.T) {
+	s := New(t.TempDir())
+
+	// Live runner's dir: scrollback only, no meta.json.
+	liveDir := s.SessionDir("sess-live1")
+	if err := os.MkdirAll(liveDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	sb := filepath.Join(liveDir, scrollback.ActiveName)
+	if err := os.WriteFile(sb, []byte("live output"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Genuinely empty orphan dir: still swept.
+	emptyDir := s.SessionDir("sess-empty1")
+	if err := os.MkdirAll(emptyDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := s.Sweep()
+	if err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	if len(loaded) != 0 {
+		t.Errorf("no meta.json anywhere; nothing should load, got %d", len(loaded))
+	}
+	if !exists(t, sb) {
+		t.Error("live runner's scrollback must survive Sweep")
+	}
+	if exists(t, emptyDir) {
+		t.Error("empty orphan dir should still be removed")
+	}
+}

--- a/services/gmuxd/internal/sessionmeta/sessionmeta_test.go
+++ b/services/gmuxd/internal/sessionmeta/sessionmeta_test.go
@@ -226,15 +226,17 @@ func TestSweepLoadsAllSessionsAsAliveFalse(t *testing.T) {
 
 func TestSweepRemovesOrphanDirs(t *testing.T) {
 	s := newStore(t)
-	// Orphan: dir exists with non-meta content (a scrollback file
-	// the runner wrote) but no meta.json. Sweep should treat the
-	// whole dir as orphan and clean it up.
+	// Orphan: dir exists with non-meta, non-scrollback junk but no
+	// meta.json. Sweep should treat the whole dir as orphan and clean
+	// it up. (A dir containing scrollback is NOT an orphan — it is a
+	// live, never-died runner's dir; see
+	// TestSweepSparesLiveRunnerScrollbackDir.)
 	orphan := s.SessionDir("sess-orphan")
 	if err := os.MkdirAll(orphan, dirMode); err != nil {
 		t.Fatalf("mkdir orphan: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(orphan, "scrollback"), []byte("xyz"), fileMode); err != nil {
-		t.Fatalf("write orphan scrollback: %v", err)
+	if err := os.WriteFile(filepath.Join(orphan, "meta.json.tmp-junk"), []byte("xyz"), fileMode); err != nil {
+		t.Fatalf("write orphan junk: %v", err)
 	}
 
 	if _, err := s.Sweep(); err != nil {


### PR DESCRIPTION
## What

Fixes a pre-existing bug surfaced by the post-merge retention audit (#333/#338
context): **every gmuxd restart destroyed the on-disk scrollback of every
live, never-died session.**

## The bug

Three facts that only line up wrong:

1. `Sweep` (startup, before discovery) `RemoveAll`s any session dir lacking
   `meta.json` as an "orphan".
2. `meta.json` is written **only when a session lands dead** (`persistDead`);
   a resumed session has a leftover one, but a fresh-launched live session
   never does.
3. The runner creates and holds open `sessions/<id>/scrollback` from launch
   (`cli/gmux/cmd/gmux/run.go`).

So a live session's dir is exactly "scrollback, no meta.json" — Sweep's orphan
definition. On restart (routine on upgrades): the open file is unlinked, the
runner keeps appending to the unlinked inode, its next rotation's `os.Rename`
hits ENOENT and sticky-fails, and when the session eventually dies its
post-mortem replay is permanently empty. Live-attach was unaffected (runner's
in-memory ring), which is why this went unnoticed.

Notably, the old `TestSweepRemovesOrphanDirs` staged **precisely the
live-runner layout** ("a scrollback file the runner wrote") and asserted its
destruction — the bug was codified as the contract.

## The fix

Sweep spares dirs that contain scrollback files (`hasScrollback`). Such a dir
is either:
- a **live runner's dir** — must not be touched; its `meta.json` arrives when
  the session dies; or
- a **crash leftover** — bounded by `PruneScrollback`'s cache cap (its bytes
  are already counted and evicted oldest-first, and the then-empty dir is
  swept normally on a later startup).

Truly empty/junk orphan dirs (e.g. stale `meta.json.tmp-*`) are still removed.
No new unbounded surface: leftovers live under the existing 256 MiB cap.

## Tests

- New `TestSweepSparesLiveRunnerScrollbackDir`: scrollback-only dir survives
  Sweep while an empty orphan alongside it is still removed (red before the
  fix — confirms the bug empirically).
- `TestSweepRemovesOrphanDirs` rewritten to junk-only orphans, with a comment
  pointing at the new contract.
- `go test -race ./...` green in `services/gmuxd`.
