### PR TITLE
fix(web): mobile launch menu clipped by the sidebar drawer

### DIFF
--- a/apps/gmux-web/src/launcher.test.ts
+++ b/apps/gmux-web/src/launcher.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest'
-import { launchersForPeer, formatTarget, computeMenuPos } from './launcher'
+import { launchersForPeer, formatTarget, computeMenuPos, clampMenuLeft } from './launcher'
 import type { LauncherDef, PeerInfo } from './types'
 
 const localLaunchers: LauncherDef[] = [
@@ -71,6 +71,28 @@ describe('computeMenuPos', () => {
   test('offsets for the target line + divider so the default stays under the button', () => {
     const pos = computeMenuPos({ top: 100, left: 200 }, viewport, true)
     expect(pos.top).toBe(100 - 4 - 32)
+  })
+
+  test('clamps the top so a button in the first row never lifts the menu off-screen', () => {
+    // rect.top 11 (first sidebar row on mobile): 11 - 4 - 32 = -25 unclamped.
+    const pos = computeMenuPos({ top: 11, left: 200 }, viewport, true)
+    expect(pos.top).toBe(8)
+  })
+})
+
+describe('clampMenuLeft', () => {
+  test('re-clamps with the real (wider than min) menu width', () => {
+    // Menu opened at left=202 assuming 180px wide; real width 240 on a
+    // 390px viewport must pull it left so the right edge stays inside.
+    expect(clampMenuLeft(202, 240, 390)).toBe(390 - 8 - 240)
+  })
+
+  test('keeps position when it already fits', () => {
+    expect(clampMenuLeft(100, 180, 1000)).toBe(100)
+  })
+
+  test('left margin wins when menu is wider than viewport', () => {
+    expect(clampMenuLeft(50, 500, 390)).toBe(8)
   })
 })
 

--- a/apps/gmux-web/src/launcher.tsx
+++ b/apps/gmux-web/src/launcher.tsx
@@ -4,7 +4,8 @@
 // Launcher definitions come from the store's health signal (populated
 // from /v1/health). The component reads them reactively.
 
-import { useState, useRef, useEffect, useMemo } from 'preact/hooks'
+import { useState, useRef, useEffect, useLayoutEffect, useMemo } from 'preact/hooks'
+import { createPortal } from 'preact/compat'
 import type { LauncherDef, PeerInfo } from './types'
 import { launchers as launchersSignal, defaultLauncher as defaultLauncherSignal, peers as peersSignal, launchSession } from './store'
 
@@ -52,6 +53,18 @@ export interface Viewport {
 
 /** Margin kept between the menu and the viewport edges (px). */
 const MENU_VIEWPORT_MARGIN = 8
+
+/**
+ * Clamp a menu's left coordinate so a menu of `width` stays inside the
+ * viewport: right edge first, then left edge (which wins if the menu is
+ * wider than the viewport).
+ */
+export function clampMenuLeft(left: number, width: number, innerWidth: number): number {
+  const maxLeft = innerWidth - MENU_VIEWPORT_MARGIN - width
+  if (left > maxLeft) left = maxLeft
+  if (left < MENU_VIEWPORT_MARGIN) left = MENU_VIEWPORT_MARGIN
+  return left
+}
 /** How far left of the button the menu's left edge sits (px). */
 const MENU_LEFT_OFFSET = 6
 
@@ -65,7 +78,9 @@ const MENU_LEFT_OFFSET = 6
  * Vertical: lift the menu so its default item (first adapter) lands directly
  * under the button — enabling open-then-double-click on the default. The menu
  * has 4px padding-top; a shown target line adds ~32px (line + divider) that we
- * offset so the first adapter stays aligned.
+ * offset so the first adapter stays aligned. The lift is clamped so the menu
+ * never pokes above the viewport (e.g. a button in the very first sidebar row
+ * on mobile, where the sidebar has no header above the project list).
  */
 export function computeMenuPos(
   rect: Rect,
@@ -74,14 +89,10 @@ export function computeMenuPos(
   menuWidth = 180,
 ): { top: number; left: number } {
   const targetOffset = showTarget ? 32 : 0
-  const top = rect.top - 4 - targetOffset // 4px = menu padding-top
+  let top = rect.top - 4 - targetOffset // 4px = menu padding-top
+  if (top < MENU_VIEWPORT_MARGIN) top = MENU_VIEWPORT_MARGIN
 
-  let left = rect.left - MENU_LEFT_OFFSET
-  // Clamp right edge inside the viewport...
-  const maxLeft = viewport.innerWidth - MENU_VIEWPORT_MARGIN - menuWidth
-  if (left > maxLeft) left = maxLeft
-  // ...then clamp left edge (wins if the menu is wider than the viewport).
-  if (left < MENU_VIEWPORT_MARGIN) left = MENU_VIEWPORT_MARGIN
+  const left = clampMenuLeft(rect.left - MENU_LEFT_OFFSET, menuWidth, viewport.innerWidth)
 
   return { top, left }
 }
@@ -121,6 +132,7 @@ export function LaunchButton({ className, onLaunch, beforeLaunch, cwd, peer }: L
   const [menuPos, setMenuPos] = useState<{ top: number; left: number } | null>(null)
   const containerRef = useRef<HTMLDivElement>(null)
   const btnRef = useRef<HTMLButtonElement>(null)
+  const menuRef = useRef<HTMLDivElement>(null)
 
   // Read launcher config from the store (populated by /v1/health).
   const hasLaunchers = launchersSignal.value.length > 0
@@ -132,6 +144,16 @@ export function LaunchButton({ className, onLaunch, beforeLaunch, cwd, peer }: L
     const r = btn.getBoundingClientRect()
     setMenuPos(computeMenuPos(r, { innerWidth: window.innerWidth }, showTarget))
   }
+
+  // computeMenuPos clamps with the menu's *minimum* width (180px); nowrap
+  // items can render it wider, overflowing the right edge on narrow screens.
+  // Re-clamp with the real width once the menu is in the DOM — layout effect,
+  // so the correction lands in the same paint as the initial position.
+  useLayoutEffect(() => {
+    if (state !== 'open' || !menuRef.current || !menuPos) return
+    const left = clampMenuLeft(menuPos.left, menuRef.current.offsetWidth, window.innerWidth)
+    if (left !== menuPos.left) setMenuPos({ top: menuPos.top, left })
+  }, [state, menuPos])
 
   const handleClick = (e: MouseEvent) => {
     e.stopPropagation()
@@ -156,9 +178,10 @@ export function LaunchButton({ className, onLaunch, beforeLaunch, cwd, peer }: L
   useEffect(() => {
     if (state !== 'open') return
     const handler = (e: MouseEvent) => {
-      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
-        setState('idle')
-      }
+      const t = e.target as Node
+      if (containerRef.current?.contains(t)) return
+      if (menuRef.current?.contains(t)) return
+      setState('idle')
     }
     const timer = setTimeout(() => document.addEventListener('mousedown', handler), 0)
     return () => {
@@ -206,8 +229,14 @@ export function LaunchButton({ className, onLaunch, beforeLaunch, cwd, peer }: L
           </svg>
         ) : '+'}
       </button>
-      {isOpen && menuPos && (
+      {/* Portaled to <body>: on mobile the sidebar is a transformed drawer
+          (translateX), which makes it the containing block for fixed
+          descendants — rendered in place the menu would be positioned
+          relative to the sidebar and clipped at its edge. The portal keeps
+          the fixed coords viewport-relative on every layout. */}
+      {isOpen && menuPos && createPortal(
         <div
+          ref={menuRef}
           class="launch-inline-menu"
           style={{ top: menuPos.top, left: menuPos.left }}
         >
@@ -234,7 +263,8 @@ export function LaunchButton({ className, onLaunch, beforeLaunch, cwd, peer }: L
               {l.label}
             </button>
           ))}
-        </div>
+        </div>,
+        document.body,
       )}
     </div>
   )

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -307,12 +307,12 @@ body {
 }
 
 .folder-header:hover .launch-container.folder-launch-btn,
-/* Keep the button (and its open menu, which is a DOM descendant) fully
-   opaque while launching or while the menu is open — otherwise leaving the
-   folder row's hover fades the open menu out from under the cursor. */
+/* Keep the button fully opaque while launching or while the menu is open —
+   otherwise leaving the folder row's hover fades the button out from under
+   the cursor. (The open menu itself is portaled to <body>, so it never
+   inherits this opacity.) */
 .launch-container.folder-launch-btn:has(.loading),
-.launch-container.folder-launch-btn.open,
-.launch-container.folder-launch-btn:has(.launch-inline-menu) {
+.launch-container.folder-launch-btn.open {
   opacity: 1;
 }
 
@@ -351,7 +351,9 @@ body {
   to { transform: rotate(360deg); }
 }
 
-/* Inline menu — fixed-positioned by JS so it escapes overflow:hidden parents */
+/* Inline menu — portaled to <body> and fixed-positioned by JS so it escapes
+   overflow:hidden parents and transformed ancestors (the mobile sidebar
+   drawer's translateX would otherwise become its containing block). */
 .launch-inline-menu {
   position: fixed;
   background: var(--bg-surface);
@@ -359,6 +361,8 @@ body {
   border-radius: 8px;
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4), 0 2px 8px rgba(0, 0, 0, 0.2);
   min-width: 180px;
+  /* Backstop for the JS re-clamp: never wider than the viewport. */
+  max-width: calc(100vw - 16px);
   z-index: 1000;
   padding: 4px;
   overflow: hidden;


### PR DESCRIPTION
## What

Fixes the launch ("+") menu popup being clipped and misaligned in the sidebar on mobile. Desktop (fixed in #326) is unchanged.

## Why it broke on mobile only

The menu is `position: fixed` precisely so it can escape the sidebar's overflow. But on touch layouts (`@media (pointer: coarse)`) the sidebar is a slide-in drawer with `transform: translateX(...)` — and a transformed element becomes the **containing block for fixed-position descendants**. So on mobile the menu's viewport coordinates were reinterpreted as sidebar-relative and the menu was clipped at the drawer's edge.

A second, latent issue: `computeMenuPos` lifts the menu by `4 + 32px` so the default item lands under the button, but never clamped `top`. On mobile the first project row sits at the very top of the drawer (no header above the list), so the lift pushed the menu off-screen (`top: -25px`).

## Fix

- **Portal the menu to `<body>`** (same pattern as `SheetBackdrop` in `sheet.tsx`), so its fixed coords stay viewport-relative regardless of layout.
- **Clamp `top` to the viewport margin** in `computeMenuPos` (+ unit test).
- Outside-click dismissal now also checks the portaled menu's ref, so `mousedown` on a menu item no longer counts as "outside" (which would have unmounted the item before its `click` fired).
- Updated the CSS comments; dropped the now-dead `:has(.launch-inline-menu)` opacity selector (the `.open` class covers it).

## Before / after (390×844, touch emulation)

| Before | After |
|---|---|
| Menu clipped at drawer edge + pushed above viewport | Fully visible, aligned to the trigger |

(Verified with headless Chrome at 1280×800 and 390×844 w/ touch emulation; desktop position unchanged.)

## Testing

- `pnpm test` in `apps/gmux-web`: 522 passing (new test: top-clamp for first-row buttons)
- `pnpm lint` (tsc) + biome clean
- Browser-verified: menu-item mousedown keeps menu open; outside mousedown closes it; Escape unchanged.