### PR TITLE
fix(gmuxd): guard notify Router's prevState seeding with the router mutex

### DIFF
--- a/services/gmuxd/internal/notify/notify.go
+++ b/services/gmuxd/internal/notify/notify.go
@@ -103,10 +103,15 @@ func (r *Router) Run(ctx context.Context) {
 	defer cancel()
 
 	// Seed prevState from current sessions so we don't fire notifications
-	// for pre-existing state on startup.
+	// for pre-existing state on startup. Under r.mu like every other
+	// prevState access: Run executes on its own goroutine, and presence
+	// callbacks (CancelForSession et al.) can touch router state
+	// concurrently from the moment the router is wired up.
+	r.mu.Lock()
 	for _, s := range r.sessions.List() {
 		r.prevState[s.ID] = snapshotOf(s)
 	}
+	r.mu.Unlock()
 
 	for {
 		select {


### PR DESCRIPTION
## What

Fixes a long-flaky data race in the notify router that has tripped the race
detector on three recent reviews (#333, #338, and Greptile's P1 on #340).

## The race

`Router.Run`'s startup seeding loop wrote `r.prevState` **without holding
`r.mu`** (notify.go), while every other `prevState` access in the file takes
the lock. `Run` executes on its own goroutine, and presence callbacks
(`CancelForSession` / `CancelAllPending`) can touch router state concurrently
from the moment the router is wired — so the seed raced with any early
lock-holding access. `TestSessionRemove_CleansUpPrevState` (which reads
`prevState` under the lock right after startup) failed ~50% of `-race` runs.

## The fix

Two lines: take `r.mu` around the seed loop. (`genID`'s callers were audited —
both already run under `mu`; the seed loop was the only unguarded access.)

## Verification

- Pre-fix: `go test -race -count=4 -run TestSessionRemove_CleansUpPrevState
  ./internal/notify/` fails ~half the runs on clean main.
- Post-fix: 12 consecutive `-race` runs of the whole package pass; the
  previously flaky test is the regression guard.
- Full `go test ./...` green in `services/gmuxd`.

Unblocks `go test -race ./...` as a usable validation gate (resolves the P1
Greptile posted on #340, which was pre-existing and unrelated to that PR's
change).
