### PR TITLE
refactor(web): unify alive vs resumable terminal chrome (Option A)

### DIFF
--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -272,8 +272,10 @@ function SessionMenu({ session, onRestart, onResume, resuming }: {
   // for the secondary+F keybind).
   const canFind = session.alive
 
-  // One lifecycle action per state (Restart alive, Resume/Rerun dead);
-  // the menu is the single home for it in both states.
+  // One lifecycle action per state (Restart alive, Resume/Rerun dead).
+  // The menu is where muscle memory expects it in both states; for dead
+  // sessions the same action is deliberately mirrored as the primary
+  // button in ReplayView's action bar.
   const action = lifecycleAction(session, resuming)
   const actionHandler = action?.id === 'restart' ? onRestart
     : action?.id === 'resume' && onResume ? () => onResume(session.id)
@@ -749,6 +751,8 @@ function App() {
           <ReplayView
             session={selectedVal}
             terminalOptions={termOpts}
+            onResume={handleResume}
+            resuming={resumingId === selectedVal.id}
           />
         ) : selectedVal ? (
           <div class="state-message">

--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -11,6 +11,7 @@ import { TerminalView } from './terminal'
 import { useArrivalPulse } from './use-arrival-pulse'
 import { Sidebar } from './sidebar'
 import { usePresence } from './use-presence'
+import { lifecycleAction, showMobileBar } from './session-actions'
 
 import type { Session } from './types'
 import { SettingsModal } from './settings'
@@ -165,9 +166,11 @@ class ErrorBoundary extends Component<
 
 // ── Components ──
 
-function MainHeader({ session, onRestart }: {
+function MainHeader({ session, onRestart, onResume, resuming }: {
   session: Session | null
   onRestart?: () => void
+  onResume?: (id: string) => void
+  resuming?: boolean
 }) {
   if (!session) {
     return (
@@ -192,7 +195,13 @@ function MainHeader({ session, onRestart }: {
         </div>
       </div>
       <div class="main-header-right">
-        {(session.status?.working || session.status?.error) && (
+        {!session.alive ? (
+          // Dead session: the exit status lives in the header (same slot as
+          // the alive working/error chip) so alive ↔ resumable share chrome.
+          <div class="main-header-status ended">
+            {session.exit_code != null ? `Exited (${session.exit_code})` : 'Exited'}
+          </div>
+        ) : (session.status?.working || session.status?.error) && (
           <div class={`main-header-status ${session.status.error ? 'error' : 'working'}`}>
             <span
               class={`session-dot ${session.status.error ? 'error' : 'working'}`}
@@ -201,15 +210,17 @@ function MainHeader({ session, onRestart }: {
             {session.status.error ? 'Error' : 'Working…'}
           </div>
         )}
-        <SessionMenu session={session} onRestart={onRestart} />
+        <SessionMenu session={session} onRestart={onRestart} onResume={onResume} resuming={resuming} />
       </div>
     </div>
   )
 }
 
-function SessionMenu({ session, onRestart }: {
+function SessionMenu({ session, onRestart, onResume, resuming }: {
   session: Session
   onRestart?: () => void
+  onResume?: (id: string) => void
+  resuming?: boolean
 }) {
   const [open, setOpen] = useState(false)
   const menuRef = useRef<HTMLDivElement>(null)
@@ -252,6 +263,14 @@ function SessionMenu({ session, onRestart }: {
   // for the secondary+F keybind).
   const canFind = session.alive
 
+  // One lifecycle action per state (Restart alive, Resume/Rerun dead);
+  // the menu is the single home for it in both states.
+  const action = lifecycleAction(session, resuming)
+  const actionHandler = action?.id === 'restart' ? onRestart
+    : action?.id === 'resume' && onResume ? () => onResume(session.id)
+    : undefined
+  const showStale = action?.id === 'restart' && !!staleKind
+
   return (
     <div class="session-menu" ref={menuRef}>
       <button
@@ -273,16 +292,17 @@ function SessionMenu({ session, onRestart }: {
               Find in terminal
             </button>
           )}
-          {session.alive && onRestart && (
+          {action && actionHandler && (
             <button
-              class={`session-menu-action${staleKind ? ' stale' : ''}`}
-              onClick={() => { setOpen(false); onRestart!() }}
+              class={`session-menu-action${showStale ? ' stale' : ''}`}
+              disabled={action.disabled}
+              onClick={() => { setOpen(false); actionHandler() }}
             >
-              Restart session
-              {staleKind && <span class="session-menu-action-tag">outdated</span>}
+              {action.label}
+              {showStale && <span class="session-menu-action-tag">outdated</span>}
             </button>
           )}
-          {(canFind || (session.alive && onRestart)) && <div class="session-menu-divider" />}
+          {(canFind || (action && actionHandler)) && <div class="session-menu-divider" />}
           <div class="session-menu-section-title">Session info</div>
           <div class="session-menu-row">
             <span class="session-menu-label">Adapter</span>
@@ -677,6 +697,8 @@ function App() {
           <MainHeader
             session={selectedVal}
             onRestart={selectedVal ? () => { void restartSession(selectedVal.id) } : undefined}
+            onResume={handleResume}
+            resuming={!!selectedVal && resumingId === selectedVal.id}
           />
         )}
 
@@ -718,8 +740,6 @@ function App() {
           <ReplayView
             session={selectedVal}
             terminalOptions={termOpts}
-            onResume={handleResume}
-            resuming={resumingId === selectedVal.id}
           />
         ) : selectedVal ? (
           <div class="state-message">
@@ -733,7 +753,10 @@ function App() {
           />
         )}
 
-        {selectedVal && (canAttach || USE_MOCK) && termOpts && keybindsVal && (
+        {/* Rendered for any selected session — alive or dead — because on
+            touch the bar's ☰ is the only way to open the sidebar overlay.
+            Dead sessions get disabled keys (canSend=false) but a live ☰. */}
+        {showMobileBar(selectedVal) && (
           <MobileTerminalBar
             canSend={canAttach}
             ctrlArmed={ctrlArmed}

--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -8,10 +8,10 @@ import { applyArmedModifiers } from './keyboard'
 import { isTouchDevice } from './touch'
 import { ReplayView } from './replay-view'
 import { TerminalView } from './terminal'
-import { useArrivalPulse } from './use-arrival-pulse'
 import { Sidebar } from './sidebar'
 import { usePresence } from './use-presence'
-import { lifecycleAction, showMobileBar } from './session-actions'
+import { lifecycleAction } from './session-actions'
+import { MenuButton } from './menu-button'
 
 import type { Session } from './types'
 import { SettingsModal } from './settings'
@@ -25,7 +25,7 @@ import { pushError } from './toasts'
 import {
   sessions, connState, selected, selectedId, view, health, peers,
   terminalOptions, keybinds, macCommandIsCtrl,
-  unreadCount, keyboardOpen, terminalFindOpen, terminalScrolledUp, terminalScrollToBottom,
+  keyboardOpen, terminalFindOpen, terminalScrolledUp, terminalScrollToBottom,
   urlPath, urlSearch,
   initStore, setNavigate, navigateToSession,
   dismissSession, resumeSession, restartSession,
@@ -419,15 +419,6 @@ function MobileTerminalBar({
   onCtrlConsumed: () => void
   onAltConsumed: () => void
 }) {
-  // Read signals directly; no props needed for these. The hamburger
-  // badge surfaces only the waiting (unread) state — working/active are
-  // deliberately omitted. unreadCount excludes the selected session and
-  // its value re-fires the arrival pulse when another session starts
-  // waiting.
-  const waitingCount = unreadCount.value
-  const waiting = waitingCount > 0
-  const arrival = useArrivalPulse(waiting ? 'unread' : 'none', waitingCount)
-
   // Don't steal focus from the terminal: a control tap leaves the
   // keyboard exactly as it is (open or closed). Bytes reach the PTY via
   // the raw input channel (onSend), independent of DOM focus, so every
@@ -469,17 +460,7 @@ function MobileTerminalBar({
 
   return (
     <div class="mobile-bottom-bar" role="toolbar" aria-label="Terminal keys" onMouseDown={keepFocus}>
-      <button
-        class={`mobile-bottom-action menu-btn mk-menu${waiting ? ' bg-waiting' : ''}${arrival ? ` bg-${arrival}` : ''}`}
-        onClick={() => {
-          // Dismiss the on-screen keyboard when opening the menu. keepFocus
-          // holds focus on the textarea through pointerdown, so it's still
-          // the active element here; blurring it slides the keyboard away.
-          (document.activeElement as HTMLElement | null)?.blur()
-          onMenu()
-        }}
-        title="Open sessions"
-      ><span class="mkey-face">☰</span></button>
+      <MenuButton variant="bar" onMenu={onMenu} />
       <button class="mobile-bottom-action mk-esc" disabled={!canSend} onClick={() => sendKey('\x1b')} title="Escape"><span class="mkey-face">esc</span></button>
       <button class="mobile-bottom-action mk-tab" disabled={!canSend} onClick={() => sendKey('\t')} title="Tab"><span class="mkey-face">tab</span></button>
       <button class={`${armedClass(ctrlArmed)} mk-ctrl`} disabled={!canSend} aria-pressed={ctrlArmed} onClick={onToggleCtrl} title={ctrlArmed ? 'Ctrl armed for next key' : 'Arm Ctrl'}><span class="mkey-face">ctrl</span></button>
@@ -699,6 +680,15 @@ function App() {
   }, [canAttach])
   const handleAltConsumed = useCallback(() => { setAltArmed(false) }, [])
 
+  const openSidebar = useCallback(() => setSidebarOpen(true), [])
+
+  // The key bar only accompanies an attached (or mock) terminal; dead
+  // sessions carry ☰ in ReplayView's action bar instead of a full set of
+  // disabled keys. Everything else (home, project hub, transient states)
+  // gets the floating ☰ so the sidebar overlay stays reachable on touch.
+  const keyBarShown = !!selectedVal && (canAttach || USE_MOCK) && !!termOpts && !!keybindsVal
+  const replayShown = !keyBarShown && !!selectedVal && !selectedVal.alive && !!termOpts && !USE_MOCK
+
   return (
     <div class="app-layout">
       <Sidebar
@@ -766,6 +756,7 @@ function App() {
             terminalOptions={termOpts}
             onResume={handleResume}
             resuming={resumingId === selectedVal.id}
+            onMenu={openSidebar}
           />
         ) : selectedVal ? (
           <div class="state-message">
@@ -779,21 +770,27 @@ function App() {
           />
         )}
 
-        {/* Rendered for any selected session — alive or dead — because on
-            touch the bar's ☰ is the only way to open the sidebar overlay.
-            Dead sessions get disabled keys (canSend=false) but a live ☰. */}
-        {showMobileBar(selectedVal) && (
+        {keyBarShown && (
           <MobileTerminalBar
             canSend={canAttach}
             ctrlArmed={ctrlArmed}
             altArmed={altArmed}
-            onMenu={() => setSidebarOpen(true)}
+            onMenu={openSidebar}
             onSend={handleMobileInput}
             onToggleCtrl={handleToggleCtrl}
             onToggleAlt={handleToggleAlt}
             onCtrlConsumed={handleCtrlConsumed}
             onAltConsumed={handleAltConsumed}
           />
+        )}
+
+        {/* On touch the sidebar is an off-canvas overlay, so every screen
+            must carry a ☰ somewhere. The key bar and ReplayView's action
+            bar have their own; everything else (home, project hub,
+            connecting/error states) gets the floating one. Hidden on fine
+            pointers via CSS. */}
+        {!keyBarShown && !replayShown && (
+          <MenuButton variant="floating" onMenu={openSidebar} />
         )}
       </div>
     </div>

--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -195,32 +195,45 @@ function MainHeader({ session, onRestart, onResume, resuming }: {
         </div>
       </div>
       <div class="main-header-right">
-        {!session.alive ? (
-          // Dead session: status lives in the header (same slot as the alive
-          // working/error chip) so alive ↔ resumable share chrome. While a
-          // resume is in flight it flips to the busy label — the menu closes
-          // on click, so this chip is the visible feedback.
-          resuming ? (
-            <div class="main-header-status working">
-              <span class="session-dot working" style={{ width: 5, height: 5 }} />
-              {lifecycleAction(session, true)?.label ?? 'Resuming…'}
-            </div>
-          ) : (
-            <div class="main-header-status ended">
-              {session.exit_code != null ? `Exited (${session.exit_code})` : 'Exited'}
-            </div>
-          )
-        ) : (session.status?.working || session.status?.error) && (
-          <div class={`main-header-status ${session.status.error ? 'error' : 'working'}`}>
-            <span
-              class={`session-dot ${session.status.error ? 'error' : 'working'}`}
-              style={{ width: 5, height: 5 }}
-            />
-            {session.status.error ? 'Error' : 'Working…'}
-          </div>
-        )}
+        <HeaderStatusChip session={session} resuming={resuming} />
         <SessionMenu session={session} onRestart={onRestart} onResume={onResume} resuming={resuming} />
       </div>
+    </div>
+  )
+}
+
+/** Session status in the header, one chip slot for both states: alive shows
+ * Working…/Error, dead shows Exited (N). While a resume is in flight the
+ * dead chip flips to the busy label — the menu closes on click, so this
+ * chip is the visible feedback until the session comes alive. */
+function HeaderStatusChip({ session, resuming }: {
+  session: Session
+  resuming?: boolean
+}) {
+  if (!session.alive) {
+    if (resuming) {
+      return (
+        <div class="main-header-status working">
+          <span class="session-dot working" style={{ width: 5, height: 5 }} />
+          {lifecycleAction(session, true)?.label ?? 'Resuming…'}
+        </div>
+      )
+    }
+    return (
+      <div class="main-header-status ended">
+        {session.exit_code != null ? `Exited (${session.exit_code})` : 'Exited'}
+      </div>
+    )
+  }
+  if (!session.status?.working && !session.status?.error) return null
+  const error = !!session.status.error
+  return (
+    <div class={`main-header-status ${error ? 'error' : 'working'}`}>
+      <span
+        class={`session-dot ${error ? 'error' : 'working'}`}
+        style={{ width: 5, height: 5 }}
+      />
+      {error ? 'Error' : 'Working…'}
     </div>
   )
 }

--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -196,11 +196,20 @@ function MainHeader({ session, onRestart, onResume, resuming }: {
       </div>
       <div class="main-header-right">
         {!session.alive ? (
-          // Dead session: the exit status lives in the header (same slot as
-          // the alive working/error chip) so alive ↔ resumable share chrome.
-          <div class="main-header-status ended">
-            {session.exit_code != null ? `Exited (${session.exit_code})` : 'Exited'}
-          </div>
+          // Dead session: status lives in the header (same slot as the alive
+          // working/error chip) so alive ↔ resumable share chrome. While a
+          // resume is in flight it flips to the busy label — the menu closes
+          // on click, so this chip is the visible feedback.
+          resuming ? (
+            <div class="main-header-status working">
+              <span class="session-dot working" style={{ width: 5, height: 5 }} />
+              {lifecycleAction(session, true)?.label ?? 'Resuming…'}
+            </div>
+          ) : (
+            <div class="main-header-status ended">
+              {session.exit_code != null ? `Exited (${session.exit_code})` : 'Exited'}
+            </div>
+          )
         ) : (session.status?.working || session.status?.error) && (
           <div class={`main-header-status ${session.status.error ? 'error' : 'working'}`}>
             <span

--- a/apps/gmux-web/src/menu-button.tsx
+++ b/apps/gmux-web/src/menu-button.tsx
@@ -1,0 +1,48 @@
+import { unreadCount } from './store'
+import { useArrivalPulse } from './use-arrival-pulse'
+
+/**
+ * The sidebar hamburger with the waiting-dot badge. One component, three
+ * touch-only placements (`variant` picks the styling):
+ *
+ * - `bar`: a cell in the mobile key bar (alive sessions).
+ * - `footer`: in ReplayView's action bar (dead sessions, which render no
+ *   key bar — showing a full set of dead keys just to carry ☰ read as
+ *   clutter).
+ * - `floating`: bottom-left overlay on the home / project-hub screens,
+ *   which have no bottom bar at all.
+ *
+ * The badge surfaces only the waiting (unread) state — working/active are
+ * deliberately omitted. unreadCount excludes the selected session and its
+ * value re-fires the arrival pulse when another session starts waiting.
+ *
+ * All variants are hidden on fine pointers via CSS; on desktop the sidebar
+ * is always visible, so the button would be dead weight.
+ */
+export function MenuButton({ variant, onMenu }: {
+  variant: 'bar' | 'footer' | 'floating'
+  onMenu: () => void
+}) {
+  const waitingCount = unreadCount.value
+  const waiting = waitingCount > 0
+  const arrival = useArrivalPulse(waiting ? 'unread' : 'none', waitingCount)
+
+  const variantClass = variant === 'bar'
+    ? 'mk-menu'
+    : `menu-btn-standalone${variant === 'floating' ? ' menu-btn-floating' : ''}`
+
+  return (
+    <button
+      class={`mobile-bottom-action menu-btn ${variantClass}${waiting ? ' bg-waiting' : ''}${arrival ? ` bg-${arrival}` : ''}`}
+      onClick={() => {
+        // Dismiss the on-screen keyboard when opening the menu. The key
+        // bar holds focus on the textarea through pointerdown (keepFocus),
+        // so it's still the active element here; blurring it slides the
+        // keyboard away. Harmless in the standalone placements.
+        (document.activeElement as HTMLElement | null)?.blur()
+        onMenu()
+      }}
+      title="Open sessions"
+    ><span class="mkey-face">☰</span></button>
+  )
+}

--- a/apps/gmux-web/src/replay-view.tsx
+++ b/apps/gmux-web/src/replay-view.tsx
@@ -9,6 +9,8 @@ import type { Session } from './types'
 import { fetchScrollback, type ScrollbackResult } from './replay-fetch'
 import { JumpToBottom } from './jump-to-bottom'
 import { lifecycleAction } from './session-actions'
+import { MenuButton } from './menu-button'
+import { isTouchDevice } from './touch'
 
 // gmuxd caps scrollback at 1 MiB × 2 files (~2 MiB max). xterm's default
 // scrollback line cap (1000) would silently truncate most of that for
@@ -37,21 +39,28 @@ type ReplayState =
  * an implicit sidebar click means clicking a dead session navigates to
  * its scrollback first, and any state-changing action is a deliberate
  * second click. Exit status is header chrome (MainHeader's "Exited"
- * chip), not repeated here; non-resumable sessions render no bar at
- * all. Dismissal is intentionally not exposed here; the sidebar's
- * per-session close affordance is the single way to remove a dead
- * session.
+ * chip), not repeated here.
+ *
+ * On touch the bar also carries the sidebar ☰: dead sessions render no
+ * mobile key bar (a full set of dead keys just to carry ☰ reads as
+ * clutter), so this is where the menu stays reachable. Without either
+ * a resume action or a touch pointer there's nothing to show and the
+ * bar is omitted. Dismissal is intentionally not exposed here; the
+ * sidebar's per-session close affordance is the single way to remove
+ * a dead session.
  */
 export function ReplayView({
   session,
   terminalOptions,
   onResume,
   resuming,
+  onMenu,
 }: {
   session: Session
   terminalOptions: ITerminalOptions
   onResume?: (id: string) => void
   resuming?: boolean
+  onMenu?: () => void
 }) {
   const containerRef = useRef<HTMLDivElement>(null)
   const [term, setTerm] = useState<Terminal | null>(null)
@@ -148,6 +157,8 @@ export function ReplayView({
   }, [session.id])
 
   const action = lifecycleAction(session, !!resuming)
+  const resumeShown = action?.id === 'resume' && !!onResume
+  const menuShown = !!onMenu && isTouchDevice()
 
   return (
     <div class="replay-root">
@@ -175,16 +186,19 @@ export function ReplayView({
           </div>
         )}
       </div>
-      {action?.id === 'resume' && onResume && (
+      {(resumeShown || menuShown) && (
         <div class="replay-actions">
-          <button
-            type="button"
-            class="btn btn-primary"
-            disabled={action.disabled}
-            onClick={() => onResume(session.id)}
-          >
-            {action.shortLabel}
-          </button>
+          {menuShown && <MenuButton variant="footer" onMenu={onMenu!} />}
+          {resumeShown && (
+            <button
+              type="button"
+              class="btn btn-primary"
+              disabled={action!.disabled}
+              onClick={() => onResume!(session.id)}
+            >
+              {action!.shortLabel}
+            </button>
+          )}
         </div>
       )}
     </div>

--- a/apps/gmux-web/src/replay-view.tsx
+++ b/apps/gmux-web/src/replay-view.tsx
@@ -19,20 +19,6 @@ type ReplayState =
   | { kind: 'loading' }
   | ScrollbackResult
 
-// Adapter kinds whose runners have an explicit resume protocol
-// (--resume <id> or equivalent). Anything not in this set falls back
-// to "Rerun" because there's no captured agent state to pick up from;
-// re-launching just runs the original command again. Listed
-// explicitly so adding a new agent adapter is a deliberate one-line
-// change here, and unknown kinds default to the safe "Rerun" label.
-const RESUMABLE_AGENT_KINDS = new Set(['claude', 'codex', 'pi'])
-
-function resumeButtonLabel(kind: string, busy: boolean): string {
-  const isAgent = RESUMABLE_AGENT_KINDS.has(kind)
-  if (busy) return isAgent ? 'Resuming…' : 'Rerunning…'
-  return isAgent ? 'Resume' : 'Rerun'
-}
-
 /**
  * Read-only xterm view that replays a dead session's persisted scrollback
  * from the gmuxd broker. No WebSocket, no input, no resize messages: this
@@ -42,30 +28,18 @@ function resumeButtonLabel(kind: string, busy: boolean): string {
  * sidebar-click model). Live sessions go through TerminalView instead;
  * see main.tsx for the routing.
  *
- * The action bar at the bottom carries the lifecycle controls that
- * previously lived as auto-trigger-on-click in the sidebar: Resume /
- * Rerun (if the adapter is resumable). Promoting it out of an implicit
- * click means clicking a dead session navigates to its scrollback
- * first, and any state-changing action is a deliberate second click.
- *
- * The button label depends on the adapter kind: agent adapters
- * (claude/codex/pi) say "Resume" because they have explicit resume
- * semantics (`--resume <id>`), shells and one-off commands say "Rerun"
- * because there's no state to resume — re-launching just runs the
- * command again. Dismissal is intentionally not exposed here; the
- * sidebar's per-session close affordance is the single way to remove
- * a dead session.
+ * Lifecycle controls (Resume / Rerun / Restart) live in the header
+ * SessionMenu, shared with alive sessions — this view is body-only,
+ * matching TerminalView. Dismissal is intentionally not exposed here;
+ * the sidebar's per-session close affordance is the single way to
+ * remove a dead session.
  */
 export function ReplayView({
   session,
   terminalOptions,
-  onResume,
-  resuming,
 }: {
   session: Session
   terminalOptions: ITerminalOptions
-  onResume?: (id: string) => void
-  resuming?: boolean
 }) {
   const containerRef = useRef<HTMLDivElement>(null)
   const [term, setTerm] = useState<Terminal | null>(null)
@@ -161,51 +135,30 @@ export function ReplayView({
     }
   }, [session.id])
 
-  const exitLabel = session.exit_code != null
-    ? `Session ended (exit ${session.exit_code})`
-    : 'Session ended'
-
   return (
-    <div class="replay-root">
-      <div class="terminal-shell">
-        <div ref={containerRef} class="terminal-container" />
-        <JumpToBottom term={term} />
-        {state.kind === 'loading' && (
-          <div class="terminal-loading">
-            Loading scrollback…
-          </div>
-        )}
-        {state.kind === 'empty' && (
-          <div class="terminal-loading">
-            No scrollback was captured for this session.
-          </div>
-        )}
-        {state.kind === 'not-found' && (
-          <div class="terminal-loading">
-            This session is no longer known to gmuxd.
-          </div>
-        )}
-        {state.kind === 'error' && (
-          <div class="terminal-loading">
-            Couldn't load scrollback (HTTP {state.status}: {state.message}).
-          </div>
-        )}
-      </div>
-      <div class="replay-actions">
-        <span class="replay-status">{exitLabel}</span>
-        <div class="replay-buttons">
-          {session.resumable && onResume && (
-            <button
-              type="button"
-              class="btn btn-primary"
-              disabled={!!resuming}
-              onClick={() => onResume(session.id)}
-            >
-              {resumeButtonLabel(session.adapter, !!resuming)}
-            </button>
-          )}
+    <div class="terminal-shell">
+      <div ref={containerRef} class="terminal-container" />
+      <JumpToBottom term={term} />
+      {state.kind === 'loading' && (
+        <div class="terminal-loading">
+          Loading scrollback…
         </div>
-      </div>
+      )}
+      {state.kind === 'empty' && (
+        <div class="terminal-loading">
+          No scrollback was captured for this session.
+        </div>
+      )}
+      {state.kind === 'not-found' && (
+        <div class="terminal-loading">
+          This session is no longer known to gmuxd.
+        </div>
+      )}
+      {state.kind === 'error' && (
+        <div class="terminal-loading">
+          Couldn't load scrollback (HTTP {state.status}: {state.message}).
+        </div>
+      )}
     </div>
   )
 }

--- a/apps/gmux-web/src/replay-view.tsx
+++ b/apps/gmux-web/src/replay-view.tsx
@@ -8,6 +8,7 @@ import { loadWebglRenderer } from './webgl-renderer'
 import type { Session } from './types'
 import { fetchScrollback, type ScrollbackResult } from './replay-fetch'
 import { JumpToBottom } from './jump-to-bottom'
+import { RESUMABLE_AGENT_KINDS } from './session-actions'
 
 // gmuxd caps scrollback at 1 MiB × 2 files (~2 MiB max). xterm's default
 // scrollback line cap (1000) would silently truncate most of that for
@@ -19,6 +20,16 @@ type ReplayState =
   | { kind: 'loading' }
   | ScrollbackResult
 
+/** Short button label for the action bar. Same agent-vs-rerun split as
+ * the header menu's lifecycleAction (shared RESUMABLE_AGENT_KINDS), just
+ * without the "session" suffix — the bar sits inside the session view,
+ * so the noun is redundant there. */
+function resumeButtonLabel(kind: string, busy: boolean): string {
+  const isAgent = RESUMABLE_AGENT_KINDS.has(kind)
+  if (busy) return isAgent ? 'Resuming…' : 'Rerunning…'
+  return isAgent ? 'Resume' : 'Rerun'
+}
+
 /**
  * Read-only xterm view that replays a dead session's persisted scrollback
  * from the gmuxd broker. No WebSocket, no input, no resize messages: this
@@ -28,18 +39,32 @@ type ReplayState =
  * sidebar-click model). Live sessions go through TerminalView instead;
  * see main.tsx for the routing.
  *
- * Lifecycle controls (Resume / Rerun / Restart) live in the header
- * SessionMenu, shared with alive sessions — this view is body-only,
- * matching TerminalView. Dismissal is intentionally not exposed here;
- * the sidebar's per-session close affordance is the single way to
- * remove a dead session.
+ * The action bar at the bottom carries the *primary* lifecycle action
+ * for a dead session: Resume / Rerun (if the adapter is resumable).
+ * The same action is deliberately duplicated in the header SessionMenu
+ * — that's where Restart lives for alive sessions, so muscle memory
+ * finds it there too. Promoting it out of an implicit sidebar click
+ * means clicking a dead session navigates to its scrollback first, and
+ * any state-changing action is a deliberate second click.
+ *
+ * The button label depends on the adapter kind: agent adapters
+ * (claude/codex/pi) say "Resume" because they have explicit resume
+ * semantics (`--resume <id>`), shells and one-off commands say "Rerun"
+ * because there's no state to resume — re-launching just runs the
+ * command again. Dismissal is intentionally not exposed here; the
+ * sidebar's per-session close affordance is the single way to remove
+ * a dead session.
  */
 export function ReplayView({
   session,
   terminalOptions,
+  onResume,
+  resuming,
 }: {
   session: Session
   terminalOptions: ITerminalOptions
+  onResume?: (id: string) => void
+  resuming?: boolean
 }) {
   const containerRef = useRef<HTMLDivElement>(null)
   const [term, setTerm] = useState<Terminal | null>(null)
@@ -135,30 +160,51 @@ export function ReplayView({
     }
   }, [session.id])
 
+  const exitLabel = session.exit_code != null
+    ? `Session ended (exit ${session.exit_code})`
+    : 'Session ended'
+
   return (
-    <div class="terminal-shell">
-      <div ref={containerRef} class="terminal-container" />
-      <JumpToBottom term={term} />
-      {state.kind === 'loading' && (
-        <div class="terminal-loading">
-          Loading scrollback…
+    <div class="replay-root">
+      <div class="terminal-shell">
+        <div ref={containerRef} class="terminal-container" />
+        <JumpToBottom term={term} />
+        {state.kind === 'loading' && (
+          <div class="terminal-loading">
+            Loading scrollback…
+          </div>
+        )}
+        {state.kind === 'empty' && (
+          <div class="terminal-loading">
+            No scrollback was captured for this session.
+          </div>
+        )}
+        {state.kind === 'not-found' && (
+          <div class="terminal-loading">
+            This session is no longer known to gmuxd.
+          </div>
+        )}
+        {state.kind === 'error' && (
+          <div class="terminal-loading">
+            Couldn't load scrollback (HTTP {state.status}: {state.message}).
+          </div>
+        )}
+      </div>
+      <div class="replay-actions">
+        <span class="replay-status">{exitLabel}</span>
+        <div class="replay-buttons">
+          {session.resumable && onResume && (
+            <button
+              type="button"
+              class="btn btn-primary"
+              disabled={!!resuming}
+              onClick={() => onResume(session.id)}
+            >
+              {resumeButtonLabel(session.kind, !!resuming)}
+            </button>
+          )}
         </div>
-      )}
-      {state.kind === 'empty' && (
-        <div class="terminal-loading">
-          No scrollback was captured for this session.
-        </div>
-      )}
-      {state.kind === 'not-found' && (
-        <div class="terminal-loading">
-          This session is no longer known to gmuxd.
-        </div>
-      )}
-      {state.kind === 'error' && (
-        <div class="terminal-loading">
-          Couldn't load scrollback (HTTP {state.status}: {state.message}).
-        </div>
-      )}
+      </div>
     </div>
   )
 }

--- a/apps/gmux-web/src/replay-view.tsx
+++ b/apps/gmux-web/src/replay-view.tsx
@@ -8,7 +8,7 @@ import { loadWebglRenderer } from './webgl-renderer'
 import type { Session } from './types'
 import { fetchScrollback, type ScrollbackResult } from './replay-fetch'
 import { JumpToBottom } from './jump-to-bottom'
-import { RESUMABLE_AGENT_KINDS } from './session-actions'
+import { lifecycleAction } from './session-actions'
 
 // gmuxd caps scrollback at 1 MiB × 2 files (~2 MiB max). xterm's default
 // scrollback line cap (1000) would silently truncate most of that for
@@ -20,16 +20,6 @@ type ReplayState =
   | { kind: 'loading' }
   | ScrollbackResult
 
-/** Short button label for the action bar. Same agent-vs-rerun split as
- * the header menu's lifecycleAction (shared RESUMABLE_AGENT_KINDS), just
- * without the "session" suffix — the bar sits inside the session view,
- * so the noun is redundant there. */
-function resumeButtonLabel(kind: string, busy: boolean): string {
-  const isAgent = RESUMABLE_AGENT_KINDS.has(kind)
-  if (busy) return isAgent ? 'Resuming…' : 'Rerunning…'
-  return isAgent ? 'Resume' : 'Rerun'
-}
-
 /**
  * Read-only xterm view that replays a dead session's persisted scrollback
  * from the gmuxd broker. No WebSocket, no input, no resize messages: this
@@ -40,20 +30,17 @@ function resumeButtonLabel(kind: string, busy: boolean): string {
  * see main.tsx for the routing.
  *
  * The action bar at the bottom carries the *primary* lifecycle action
- * for a dead session: Resume / Rerun (if the adapter is resumable).
- * The same action is deliberately duplicated in the header SessionMenu
- * — that's where Restart lives for alive sessions, so muscle memory
- * finds it there too. Promoting it out of an implicit sidebar click
- * means clicking a dead session navigates to its scrollback first, and
- * any state-changing action is a deliberate second click.
- *
- * The button label depends on the adapter kind: agent adapters
- * (claude/codex/pi) say "Resume" because they have explicit resume
- * semantics (`--resume <id>`), shells and one-off commands say "Rerun"
- * because there's no state to resume — re-launching just runs the
- * command again. Dismissal is intentionally not exposed here; the
- * sidebar's per-session close affordance is the single way to remove
- * a dead session.
+ * for a dead session: Resume / Rerun (see lifecycleAction for the
+ * agent-vs-rerun split). The same action is deliberately mirrored in
+ * the header SessionMenu — that's where Restart lives for alive
+ * sessions, so muscle memory finds it there too. Promoting it out of
+ * an implicit sidebar click means clicking a dead session navigates to
+ * its scrollback first, and any state-changing action is a deliberate
+ * second click. Exit status is header chrome (MainHeader's "Exited"
+ * chip), not repeated here; non-resumable sessions render no bar at
+ * all. Dismissal is intentionally not exposed here; the sidebar's
+ * per-session close affordance is the single way to remove a dead
+ * session.
  */
 export function ReplayView({
   session,
@@ -160,9 +147,7 @@ export function ReplayView({
     }
   }, [session.id])
 
-  const exitLabel = session.exit_code != null
-    ? `Session ended (exit ${session.exit_code})`
-    : 'Session ended'
+  const action = lifecycleAction(session, !!resuming)
 
   return (
     <div class="replay-root">
@@ -190,21 +175,18 @@ export function ReplayView({
           </div>
         )}
       </div>
-      <div class="replay-actions">
-        <span class="replay-status">{exitLabel}</span>
-        <div class="replay-buttons">
-          {session.resumable && onResume && (
-            <button
-              type="button"
-              class="btn btn-primary"
-              disabled={!!resuming}
-              onClick={() => onResume(session.id)}
-            >
-              {resumeButtonLabel(session.kind, !!resuming)}
-            </button>
-          )}
+      {action?.id === 'resume' && onResume && (
+        <div class="replay-actions">
+          <button
+            type="button"
+            class="btn btn-primary"
+            disabled={action.disabled}
+            onClick={() => onResume(session.id)}
+          >
+            {action.shortLabel}
+          </button>
         </div>
-      </div>
+      )}
     </div>
   )
 }

--- a/apps/gmux-web/src/session-actions.test.ts
+++ b/apps/gmux-web/src/session-actions.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest'
+import { lifecycleAction, showMobileBar } from './session-actions'
+
+const sess = (over: Partial<{ alive: boolean; resumable: boolean; adapter: string }>) => ({
+  alive: false,
+  resumable: false,
+  adapter: 'shell',
+  ...over,
+})
+
+describe('lifecycleAction', () => {
+  it('alive session offers Restart', () => {
+    expect(lifecycleAction(sess({ alive: true }))).toEqual({
+      id: 'restart', label: 'Restart session', disabled: false,
+    })
+  })
+
+  it('alive wins over resumable (state, not history, decides)', () => {
+    expect(lifecycleAction(sess({ alive: true, resumable: true }))!.id).toBe('restart')
+  })
+
+  it('dead resumable agent offers Resume', () => {
+    for (const adapter of ['claude', 'codex', 'pi']) {
+      expect(lifecycleAction(sess({ resumable: true, adapter }))).toEqual({
+        id: 'resume', label: 'Resume session', disabled: false,
+      })
+    }
+  })
+
+  it('dead resumable non-agent offers Rerun', () => {
+    expect(lifecycleAction(sess({ resumable: true, adapter: 'shell' }))).toEqual({
+      id: 'resume', label: 'Rerun session', disabled: false,
+    })
+    // Unknown adapter kinds default to the safe Rerun label.
+    expect(lifecycleAction(sess({ resumable: true, adapter: 'future-agent' }))!.label)
+      .toBe('Rerun session')
+  })
+
+  it('dead non-resumable session offers nothing', () => {
+    expect(lifecycleAction(sess({}))).toBeNull()
+  })
+
+  it('resuming disables the action and shows busy label per kind', () => {
+    expect(lifecycleAction(sess({ resumable: true, adapter: 'claude' }), true)).toEqual({
+      id: 'resume', label: 'Resuming…', disabled: true,
+    })
+    expect(lifecycleAction(sess({ resumable: true, adapter: 'shell' }), true)).toEqual({
+      id: 'resume', label: 'Rerunning…', disabled: true,
+    })
+  })
+
+  it('resuming does not affect an alive session', () => {
+    expect(lifecycleAction(sess({ alive: true }), true)!.disabled).toBe(false)
+  })
+})
+
+describe('showMobileBar', () => {
+  it('shows for an alive session', () => {
+    expect(showMobileBar({ id: 'a' })).toBe(true)
+  })
+
+  it('shows for a dead session (☰ must stay reachable on touch)', () => {
+    expect(showMobileBar({ id: 'dead' })).toBe(true)
+  })
+
+  it('hides when nothing is selected', () => {
+    expect(showMobileBar(null)).toBe(false)
+  })
+})

--- a/apps/gmux-web/src/session-actions.test.ts
+++ b/apps/gmux-web/src/session-actions.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { lifecycleAction, showMobileBar } from './session-actions'
+import { lifecycleAction } from './session-actions'
 
 const sess = (over: Partial<{ alive: boolean; resumable: boolean; adapter: string }>) => ({
   alive: false,
@@ -54,16 +54,3 @@ describe('lifecycleAction', () => {
   })
 })
 
-describe('showMobileBar', () => {
-  it('shows for an alive session', () => {
-    expect(showMobileBar({ id: 'a' })).toBe(true)
-  })
-
-  it('shows for a dead session (☰ must stay reachable on touch)', () => {
-    expect(showMobileBar({ id: 'dead' })).toBe(true)
-  })
-
-  it('hides when nothing is selected', () => {
-    expect(showMobileBar(null)).toBe(false)
-  })
-})

--- a/apps/gmux-web/src/session-actions.test.ts
+++ b/apps/gmux-web/src/session-actions.test.ts
@@ -11,7 +11,7 @@ const sess = (over: Partial<{ alive: boolean; resumable: boolean; adapter: strin
 describe('lifecycleAction', () => {
   it('alive session offers Restart', () => {
     expect(lifecycleAction(sess({ alive: true }))).toEqual({
-      id: 'restart', label: 'Restart session', disabled: false,
+      id: 'restart', label: 'Restart session', shortLabel: 'Restart', disabled: false,
     })
   })
 
@@ -22,18 +22,18 @@ describe('lifecycleAction', () => {
   it('dead resumable agent offers Resume', () => {
     for (const adapter of ['claude', 'codex', 'pi']) {
       expect(lifecycleAction(sess({ resumable: true, adapter }))).toEqual({
-        id: 'resume', label: 'Resume session', disabled: false,
+        id: 'resume', label: 'Resume session', shortLabel: 'Resume', disabled: false,
       })
     }
   })
 
   it('dead resumable non-agent offers Rerun', () => {
     expect(lifecycleAction(sess({ resumable: true, adapter: 'shell' }))).toEqual({
-      id: 'resume', label: 'Rerun session', disabled: false,
+      id: 'resume', label: 'Rerun session', shortLabel: 'Rerun', disabled: false,
     })
     // Unknown adapter kinds default to the safe Rerun label.
-    expect(lifecycleAction(sess({ resumable: true, adapter: 'future-agent' }))!.label)
-      .toBe('Rerun session')
+    expect(lifecycleAction(sess({ resumable: true, adapter: 'future-agent' }))!.shortLabel)
+      .toBe('Rerun')
   })
 
   it('dead non-resumable session offers nothing', () => {
@@ -42,10 +42,10 @@ describe('lifecycleAction', () => {
 
   it('resuming disables the action and shows busy label per kind', () => {
     expect(lifecycleAction(sess({ resumable: true, adapter: 'claude' }), true)).toEqual({
-      id: 'resume', label: 'Resuming…', disabled: true,
+      id: 'resume', label: 'Resuming…', shortLabel: 'Resuming…', disabled: true,
     })
     expect(lifecycleAction(sess({ resumable: true, adapter: 'shell' }), true)).toEqual({
-      id: 'resume', label: 'Rerunning…', disabled: true,
+      id: 'resume', label: 'Rerunning…', shortLabel: 'Rerunning…', disabled: true,
     })
   })
 

--- a/apps/gmux-web/src/session-actions.ts
+++ b/apps/gmux-web/src/session-actions.ts
@@ -52,13 +52,3 @@ export function lifecycleAction(
   return { id: 'resume', label: `${verb} session`, shortLabel: verb, disabled: false }
 }
 
-/**
- * Whether the mobile bottom bar renders for the current selection. It
- * must appear for *any* selected session — alive or dead — because on
- * touch devices its ☰ button is the only way to open the sidebar
- * overlay. Dead sessions get the bar with keys disabled (canSend=false)
- * but the menu reachable.
- */
-export function showMobileBar(session: Pick<Session, 'id'> | null): boolean {
-  return session !== null
-}

--- a/apps/gmux-web/src/session-actions.ts
+++ b/apps/gmux-web/src/session-actions.ts
@@ -17,7 +17,12 @@ export const RESUMABLE_AGENT_KINDS = new Set(['claude', 'codex', 'pi'])
 
 export type LifecycleAction = {
   id: 'restart' | 'resume'
+  /** Menu-item label ("Resume session") — needs the noun, since the menu
+   * also holds non-lifecycle rows. */
   label: string
+  /** Button label for ReplayView's action bar ("Resume") — the bar sits
+   * inside the session view, so the noun is redundant there. */
+  shortLabel: string
   disabled: boolean
 }
 
@@ -35,17 +40,16 @@ export function lifecycleAction(
   resuming = false,
 ): LifecycleAction | null {
   if (session.alive) {
-    return { id: 'restart', label: 'Restart session', disabled: false }
+    return { id: 'restart', label: 'Restart session', shortLabel: 'Restart', disabled: false }
   }
   if (!session.resumable) return null
   const isAgent = RESUMABLE_AGENT_KINDS.has(session.adapter)
-  return {
-    id: 'resume',
-    label: resuming
-      ? (isAgent ? 'Resuming…' : 'Rerunning…')
-      : (isAgent ? 'Resume session' : 'Rerun session'),
-    disabled: resuming,
+  if (resuming) {
+    const busy = isAgent ? 'Resuming…' : 'Rerunning…'
+    return { id: 'resume', label: busy, shortLabel: busy, disabled: true }
   }
+  const verb = isAgent ? 'Resume' : 'Rerun'
+  return { id: 'resume', label: `${verb} session`, shortLabel: verb, disabled: false }
 }
 
 /**

--- a/apps/gmux-web/src/session-actions.ts
+++ b/apps/gmux-web/src/session-actions.ts
@@ -1,0 +1,58 @@
+import type { Session } from './types'
+
+/**
+ * Lifecycle-action gating for the header session menu — the single home
+ * for "control this session's lifecycle" across alive and dead states.
+ *
+ * Adapter kinds whose runners have an explicit resume protocol
+ * (--resume <id> or equivalent). Anything not in this set falls back to
+ * "Rerun" because there's no captured agent state to pick up from;
+ * re-launching just runs the original command again. Listed explicitly
+ * so adding a new agent adapter is a deliberate one-line change here,
+ * and unknown kinds default to the safe "Rerun" label.
+ */
+export const RESUMABLE_AGENT_KINDS = new Set(['claude', 'codex', 'pi'])
+
+export type LifecycleAction = {
+  id: 'restart' | 'resume'
+  label: string
+  disabled: boolean
+}
+
+/**
+ * The one lifecycle action a session offers in its current state, or
+ * null when it offers none (dead and not resumable).
+ *
+ * - alive → Restart
+ * - dead + resumable agent (claude/codex/pi) → Resume
+ * - dead + resumable non-agent (shell, one-off command) → Rerun
+ * - dead + not resumable → none
+ */
+export function lifecycleAction(
+  session: Pick<Session, 'alive' | 'resumable' | 'adapter'>,
+  resuming = false,
+): LifecycleAction | null {
+  if (session.alive) {
+    return { id: 'restart', label: 'Restart session', disabled: false }
+  }
+  if (!session.resumable) return null
+  const isAgent = RESUMABLE_AGENT_KINDS.has(session.adapter)
+  return {
+    id: 'resume',
+    label: resuming
+      ? (isAgent ? 'Resuming…' : 'Rerunning…')
+      : (isAgent ? 'Resume session' : 'Rerun session'),
+    disabled: resuming,
+  }
+}
+
+/**
+ * Whether the mobile bottom bar renders for the current selection. It
+ * must appear for *any* selected session — alive or dead — because on
+ * touch devices its ☰ button is the only way to open the sidebar
+ * overlay. Dead sessions get the bar with keys disabled (canSend=false)
+ * but the menu reachable.
+ */
+export function showMobileBar(session: Pick<Session, 'id'> | null): boolean {
+  return session !== null
+}

--- a/apps/gmux-web/src/session-actions.ts
+++ b/apps/gmux-web/src/session-actions.ts
@@ -1,8 +1,10 @@
 import type { Session } from './types'
 
 /**
- * Lifecycle-action gating for the header session menu — the single home
- * for "control this session's lifecycle" across alive and dead states.
+ * Lifecycle-action gating for the header session menu, which offers the
+ * lifecycle action in a consistent spot across alive and dead states.
+ * (For dead sessions the same action is deliberately mirrored as the
+ * primary button in ReplayView's action bar.)
  *
  * Adapter kinds whose runners have an explicit resume protocol
  * (--resume <id> or equivalent). Anything not in this set falls back to

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -2943,6 +2943,60 @@ body {
   cursor: progress;
 }
 
+/* Replay (read-only dead session) layout: terminal area fills remaining
+   vertical space, action bar pinned beneath. The bar carries the primary
+   Resume/Rerun action (also mirrored in the header menu, where Restart
+   lives for alive sessions). */
+.replay-root {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.replay-root > .terminal-shell {
+  flex: 1;
+  min-height: 0;
+}
+
+.replay-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 16px;
+  background: var(--bg-surface);
+  border-top: 1px solid var(--border);
+}
+
+.replay-status {
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+.replay-buttons {
+  display: flex;
+  gap: 8px;
+}
+
+/* Touch: the floating key bar (see .mobile-bottom-bar) overlays the bottom
+   of .main-panel, so the action bar reserves the bar's height to keep the
+   Resume button reachable above the keys; the footer surface extends down
+   behind the translucent keys. Values mirror the bar's grid templates
+   (2×40px rows + 5px gap + 4px padding, or a single 40px row + 4px on the
+   wide single-row layout) — keep in sync. */
+@media (pointer: coarse) {
+  .replay-actions {
+    padding-bottom: calc(8px + 89px + env(safe-area-inset-bottom));
+  }
+}
+
+@media (pointer: coarse) and (min-width: 600px) {
+  .replay-actions {
+    padding-bottom: calc(8px + 44px + env(safe-area-inset-bottom));
+  }
+}
+
 
 /* Floating "jump to bottom" overlay for any xterm-hosting view (replay,
    live terminal). Anchors to the nearest positioned ancestor, which

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -1647,6 +1647,7 @@ body {
 
 .main-header-status.working { color: var(--accent); }
 .main-header-status.error   { color: var(--status-error); }
+.main-header-status.ended   { color: var(--text-muted); }
 
 /* Session actions menu */
 
@@ -1729,6 +1730,16 @@ body {
 .session-menu-action:hover {
   background: var(--bg-hover);
   color: var(--text);
+}
+
+/* Resume in flight: keep the busy label visible but inert. */
+.session-menu-action:disabled {
+  opacity: 0.6;
+  cursor: progress;
+}
+.session-menu-action:disabled:hover {
+  background: none;
+  color: var(--text-secondary);
 }
 
 .session-menu-action.stale {
@@ -2930,41 +2941,6 @@ body {
 .btn-primary:disabled {
   opacity: 0.6;
   cursor: progress;
-}
-
-/* Replay (read-only dead session) layout: terminal area fills remaining
-   vertical space, action bar pinned beneath. The action bar carries the
-   resume/dismiss buttons that the sidebar used to auto-trigger on click. */
-.replay-root {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  min-height: 0;
-}
-
-.replay-root > .terminal-shell {
-  flex: 1;
-  min-height: 0;
-}
-
-.replay-actions {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  padding: 8px 16px;
-  background: var(--bg-surface);
-  border-top: 1px solid var(--border);
-}
-
-.replay-status {
-  color: var(--text-muted);
-  font-size: 13px;
-}
-
-.replay-buttons {
-  display: flex;
-  gap: 8px;
 }
 
 

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -2963,28 +2963,56 @@ body {
 .replay-actions {
   display: flex;
   align-items: center;
-  justify-content: flex-end;
   gap: 12px;
   padding: 8px 16px;
   background: var(--bg-surface);
   border-top: 1px solid var(--border);
 }
 
-/* Touch: the floating key bar (see .mobile-bottom-bar) overlays the bottom
-   of .main-panel, so the action bar reserves the bar's height to keep the
-   Resume button reachable above the keys; the footer surface extends down
-   behind the translucent keys. Values mirror the bar's grid templates
-   (2×40px rows + 5px gap + 4px padding, or a single 40px row + 4px on the
-   wide single-row layout) — keep in sync. */
+/* Resume stays on the right whether or not the (touch-only) ☰ occupies
+   the left slot. */
+.replay-actions .btn {
+  margin-left: auto;
+}
+
+/* Notched devices: the replay action bar is the bottom-most chrome on
+   dead sessions (no key bar there), so it absorbs the safe-area inset. */
 @media (pointer: coarse) {
   .replay-actions {
-    padding-bottom: calc(8px + 89px + env(safe-area-inset-bottom));
+    padding-bottom: calc(8px + env(safe-area-inset-bottom));
   }
 }
 
-@media (pointer: coarse) and (min-width: 600px) {
-  .replay-actions {
-    padding-bottom: calc(8px + 44px + env(safe-area-inset-bottom));
+/* Standalone ☰ (replay footer / floating home + project variant): only
+   meaningful on touch, where the sidebar is an off-canvas overlay. On fine
+   pointers the sidebar is always visible, so hide it (this also skips the
+   key-visual styles, which live inside the coarse block). */
+.menu-btn-standalone {
+  display: none;
+}
+
+@media (pointer: coarse) {
+  /* Same two-layer key visuals as the bar cells, with a local --key-gap
+     (the bar defines it on the grid) and an explicit size since there's
+     no grid track to size against. */
+  .menu-btn-standalone {
+    --key-gap: 0px;
+    display: inline-flex;
+    width: 48px;
+    min-height: 38px;
+  }
+
+  /* Floating over screens without any bottom bar (home / project hub /
+     transient states). Bottom-left — the same corner the key bar's ☰
+     occupies on session screens — with an opaque fill since it overlays
+     scrollable content. */
+  .menu-btn-floating {
+    position: absolute;
+    left: 10px;
+    bottom: calc(10px + env(safe-area-inset-bottom));
+    z-index: 50;
+    background: var(--bg-surface);
+    box-shadow: 0 2px 8px oklch(0% 0 0 / 0.35);
   }
 }
 

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -2946,7 +2946,8 @@ body {
 /* Replay (read-only dead session) layout: terminal area fills remaining
    vertical space, action bar pinned beneath. The bar carries the primary
    Resume/Rerun action (also mirrored in the header menu, where Restart
-   lives for alive sessions). */
+   lives for alive sessions); exit status is header chrome, and
+   non-resumable sessions render no bar. */
 .replay-root {
   flex: 1;
   display: flex;
@@ -2962,21 +2963,11 @@ body {
 .replay-actions {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-end;
   gap: 12px;
   padding: 8px 16px;
   background: var(--bg-surface);
   border-top: 1px solid var(--border);
-}
-
-.replay-status {
-  color: var(--text-muted);
-  font-size: 13px;
-}
-
-.replay-buttons {
-  display: flex;
-  gap: 8px;
 }
 
 /* Touch: the floating key bar (see .mobile-bottom-bar) overlays the bottom


### PR DESCRIPTION
## What

Unifies the chrome around alive (`TerminalView`) and dead/resumable (`ReplayView`) sessions so they feel like one screen with different bodies:

- **Lifecycle actions in both intended homes, one label source.** ReplayView's bottom action bar carries the *primary* Resume/Rerun button; the same action is deliberately mirrored in the header `SessionMenu`, where Restart muscle memory lives for alive sessions. Both surfaces read from one pure function (`session-actions.ts` → `lifecycleAction`): alive → Restart, dead+resumable agent (claude/codex/pi) → Resume, dead+resumable non-agent → Rerun, dead+non-resumable → nothing. While a resume is in flight both show the busy label and disable.
- **Exit status is header chrome only.** `HeaderStatusChip` renders "Exited (N)" in the same slot as the alive Working…/Error chip; while a resume is pending it flips to "Resuming…"/"Rerunning…" so there's feedback after the menu closes.
- **☰ reachable everywhere on touch** (fixes the regression where a dead session stranded phone users with no sidebar toggle). The hamburger with its waiting-dot badge is extracted into `MenuButton` with three touch-only placements:
  - `bar` — cell in the mobile key bar (attached sessions, as before; the bar stays attachable-only rather than showing a full set of disabled dead keys),
  - `footer` — in ReplayView's action bar (dead sessions),
  - `floating` — bottom-left overlay on home / project hub / transient states, which previously had no ☰ at all.

## Decisions made by judgment (per handoff)

- **Action placement:** bottom bar = primary action, header menu = consistent muscle-memory mirror (per maintainer direction). Status is not duplicated — it lives only in the header chip.
- **Continuous resume** (same xterm across resume, ADR 0004's SessionStream): out of scope, nav-swap kept. No conflict with that proposal.
- **Retention contract:** verified — `fetchScrollback` + ReplayView already handle empty/absent/error scrollback; no changes needed.
- Loading copy left as-is ("Waiting for output…" vs "Loading scrollback…") — genuinely different waits, same visual treatment (`terminal-loading`).

## Testing

- `session-actions.test.ts`: action gating per state/kind, menu + button labels, busy/disabled during resume.
- `pnpm test`, `pnpm lint`, `pnpm build` all green.
- Manually verified the built bundle against a live gmuxd (mobile-emulated viewport): dead session → "Exited" chip, Resume in ⋮ menu **and** footer, footer ☰ opens the sidebar; home + project hub → floating ☰ opens the sidebar; alive session → "Working…" chip, Restart in menu, full key bar, no floating button; desktop → no ☰ anywhere (sidebar always visible).