### PR TITLE
chore: stop adding repo bin/ to PATH via direnv

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,3 +1,2 @@
 PATH_add node_modules/.bin
 PATH_add scripts
-PATH_add bin


### PR DESCRIPTION
The dev build at `bin/gmux` shadowed the installed gmux inside the repo via direnv's `PATH_add bin`, breaking subcommand usage (`gmux send`/`ls`/etc. resolved to the dev binary, which treats args as a command to exec). Removes that line; `node_modules/.bin` and `scripts` stay.