### PR TITLE
fix(pi-ext): forward /name renames to the runner immediately

### DIFF
--- a/cli/gmux/internal/agentext/pi-ext.mjs
+++ b/cli/gmux/internal/agentext/pi-ext.mjs
@@ -13,6 +13,7 @@
 //
 // Events posted to POST /hook/event on the runner socket:
 //   { op: "session", path, id, name, cwd, reason }      on bind (session_start)
+//                                                         and rename (session_info_changed)
 //   { op: "turn", phase: "start" }                       on agent loop start
 //   { op: "turn", phase: "end", outcome, title }         on agent loop end
 //
@@ -73,6 +74,12 @@ export default function (pi) {
     firstUserTitle = ""; // new bind → forget the previous conversation's fallback
     reportSession(ev?.reason ?? "start", ctx);
   });
+
+  // /name (or any extension calling setSessionName) renames the bound session
+  // without running a turn; session_start/agent_end won't fire until the next
+  // interaction, so forward the rename immediately or the sidebar title stays
+  // stale.
+  pi.on("session_info_changed", (_ev, ctx) => reportSession("rename", ctx));
 
   // --- turn lifecycle: drive the sidebar busy/idle without parsing the file -
   // pi's agent loop bounds map onto the sidebar's working/idle; agent_end


### PR DESCRIPTION
## Problem

Naming a pi session with `/name` doesn't update the gmux sidebar title until the next agent turn ends.

## Root cause

pi's `/name` runs `setSessionName()`, which emits a `session_info_changed` extension event and does **not** run a turn. The gmux pi extension only reported the session name on `session_start` (bind) and `agent_end` (turn end), so the rename sat unreported. The rest of the pipeline (runner `op:"session"` → `SetAdapterTitle` → meta SSE → gmuxd store → web upsert) handles it correctly once the event arrives.

## Fix

Subscribe to `session_info_changed` and re-report the session bind:

```js
pi.on("session_info_changed", (_ev, ctx) => reportSession("rename", ctx));
```

Verified with a Node smoke harness (fake `pi` + Unix-socket HTTP server): the handler posts `{op:"session", ..., name, reason:"rename"}`. Runner-side handling of named session events is already covered by `extension_test.go`. `go test` + `pnpm lint` pass.