### PR TITLE
fix(claude): refresh title on UserPromptSubmit to pick up /rename

### DIFF
--- a/packages/adapter/adapters/claude_hook.go
+++ b/packages/adapter/adapters/claude_hook.go
@@ -104,7 +104,8 @@ func buildClaudeSettings(selfBin string, userSettings []string) (string, error) 
 //
 //   - SessionStart    → bind held transcript + id + title/slug; fires on
 //     startup AND resume/clear/compact, so it rebinds on /resume.
-//   - UserPromptSubmit → turn start (working).
+//   - UserPromptSubmit → title refresh + turn start (working); the refresh
+//     picks up a /rename, which fires no hook of its own.
 //   - Stop             → rebind + turn end completed.
 //   - SessionEnd       → turn end aborted; covers Ctrl+C / exit where Stop
 //     does not fire.
@@ -209,6 +210,13 @@ func ClaudeHookBodies(input []byte) [][]byte {
 			return [][]byte{b}
 		}
 	case "UserPromptSubmit":
+		// /rename fires no hook of its own — it only appends a custom-title
+		// line to the transcript. Refresh the title here (custom-title wins in
+		// ParseSessionFile) so a mid-session rename shows up at the next
+		// prompt instead of waiting for the turn to end.
+		if b, ok := claudeSessionBody(in.TranscriptPath, in.SessionID, "", in.SessionTitle); ok {
+			return [][]byte{b, turn("start", "")}
+		}
 		return [][]byte{turn("start", "")}
 	case "Stop":
 		// Stop fires only on a clean finish — Claude routes interrupts/API errors

--- a/packages/adapter/adapters/claude_hook_test.go
+++ b/packages/adapter/adapters/claude_hook_test.go
@@ -76,6 +76,35 @@ func TestClaudeHookBodies_TurnLifecycle(t *testing.T) {
 	}
 }
 
+// /rename appends a custom-title line to the transcript without firing any
+// hook; the next UserPromptSubmit must refresh the title so the rename isn't
+// invisible until the turn ends.
+func TestClaudeHookBodies_PromptSubmitRefreshesRenamedTitle(t *testing.T) {
+	tr := writeClaudeTranscript(t)
+	ct := `{"type":"custom-title","customTitle":"Renamed Session"}`
+	f, err := os.OpenFile(tr, os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString(ct + "\n"); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	in, _ := json.Marshal(map[string]string{"hook_event_name": "UserPromptSubmit", "transcript_path": tr})
+	got := decodeBodies(t, ClaudeHookBodies(in))
+	if len(got) != 2 || got[0]["op"] != "session" || got[1]["op"] != "turn" || got[1]["phase"] != "start" {
+		t.Fatalf("UserPromptSubmit → [session, turn start], got %v", got)
+	}
+	if got[0]["name"] != "Renamed Session" {
+		t.Fatalf("want renamed title, got %v", got[0]["name"])
+	}
+	// Slug stays derived from the first user message (immutable), so the URL
+	// doesn't churn on rename.
+	if got[0]["slug"] != "hello-world" {
+		t.Fatalf("slug must stay stable across rename, got %v", got[0]["slug"])
+	}
+}
+
 func TestClaudeHookBodies_StopRefreshesThenEnds(t *testing.T) {
 	tr := writeClaudeTranscript(t)
 	in, _ := json.Marshal(map[string]string{"hook_event_name": "Stop", "transcript_path": tr})


### PR DESCRIPTION
Follow-up to #345 — sweep of the other adapters for the same "rename not reflected in sidebar" bug class.

## Sweep results

| Adapter | Rename mechanism | Live propagation | Verdict |
|---|---|---|---|
| pi | `/name` → `session_info_changed` ext event | fixed in #345 | ✅ |
| **claude** | `/rename` → appends `custom-title` line to transcript, **fires no hook** | title refreshed only on `SessionStart`/`Stop` → rename invisible until next turn *ends* | **fixed here (mitigation)** |
| codex | none — no rename feature (openai/codex#15533 open) | n/a | ✅ immune |
| shell | OSC title escapes | live via `SetShellTitle` | ✅ |

## This change

Claude Code offers no rename hook event, so a push-based fix like pi's isn't possible. Best available: also emit a session/title refresh on `UserPromptSubmit` (its payload carries `transcript_path`; `ParseSessionFile` gives `custom-title` top priority). This shrinks staleness from "next turn end" to "next prompt submit". Slug stays derived from the first user message, so URLs don't churn on rename (covered by the new test).

Truly-live rename for claude would require the daemon's conversation file-watcher to write through to a live session's `AdapterTitle` — that crosses the "conversations index never writes to the session store" boundary, so it's left as a design question.