### PR TITLE
fix(web): stop stale WebSocket closes from sticking the reconnect pill

### DIFF
--- a/apps/gmux-web/src/terminal.tsx
+++ b/apps/gmux-web/src/terminal.tsx
@@ -18,7 +18,7 @@ import { LinkActionSheet } from './link-action-sheet'
 import { TerminalTextSheet } from './terminal-text-sheet'
 import { pressedBufferRow, readTerminalText } from './terminal-text'
 import { decideViewportResize, sameSize } from './terminal-resize'
-import { wsStateOnClose, type WsState } from './ws-state'
+import { wsStateOnClose, wsStateOnOutput, type WsState } from './ws-state'
 import { terminalScrolledUp, terminalScrollToBottom } from './store'
 import { MOCK_BY_ID } from './mock-data/index'
 import type { Session } from './types'
@@ -915,7 +915,7 @@ export function TerminalView({
         if (wsRef.current !== ws) return
         // Safety net: live output proves the connection works. Never show the
         // disconnected pill while data is flowing on the current socket.
-        setWsState(prev => prev === 'lost' ? 'open' : prev)
+        setWsState(wsStateOnOutput)
         if (typeof ev.data === 'string') {
           try {
             const msg = JSON.parse(ev.data)
@@ -974,9 +974,10 @@ export function TerminalView({
         // fires *after* the replacement socket opened, and marking the
         // connection 'lost' then would leave the pill stuck on screen
         // forever while the live socket streams output behind it.
-        if (wsRef.current !== ws) return
+        const isCurrent = wsRef.current === ws
+        setWsState(prev => wsStateOnClose(prev, isCurrent))
+        if (!isCurrent) return
         resetResizeEchoGate()
-        setWsState(prev => wsStateOnClose(prev, true))
         if (disposed.current || intentionalClose) return
         if (currentSessionId.current !== session.id) return
 

--- a/apps/gmux-web/src/terminal.tsx
+++ b/apps/gmux-web/src/terminal.tsx
@@ -18,6 +18,7 @@ import { LinkActionSheet } from './link-action-sheet'
 import { TerminalTextSheet } from './terminal-text-sheet'
 import { pressedBufferRow, readTerminalText } from './terminal-text'
 import { decideViewportResize, sameSize } from './terminal-resize'
+import { wsStateOnClose, type WsState } from './ws-state'
 import { terminalScrolledUp, terminalScrollToBottom } from './store'
 import { MOCK_BY_ID } from './mock-data/index'
 import type { Session } from './types'
@@ -251,7 +252,7 @@ export function TerminalView({
   const [fontReady, setFontReady] = useState(false)
 
   const [termLoading, setTermLoading] = useState(true)
-  const [wsState, setWsState] = useState<'connecting' | 'open' | 'lost'>('connecting')
+  const [wsState, setWsState] = useState<WsState>('connecting')
   const [viewportSize, setViewportSize] = useState<TerminalSize | null>(null)
   const [linkSheet, setLinkSheet] = useState<LinkInfo | null>(null)
   const [textSheet, setTextSheet] = useState<{ lines: string[]; anchorRow: number } | null>(null)
@@ -880,6 +881,7 @@ export function TerminalView({
       wsRef.current = ws
 
       ws.onopen = () => {
+        if (wsRef.current !== ws) return
         attempt = 0
         setWsState('open')
 
@@ -910,6 +912,10 @@ export function TerminalView({
       }
 
       ws.onmessage = (ev) => {
+        if (wsRef.current !== ws) return
+        // Safety net: live output proves the connection works. Never show the
+        // disconnected pill while data is flowing on the current socket.
+        setWsState(prev => prev === 'lost' ? 'open' : prev)
         if (typeof ev.data === 'string') {
           try {
             const msg = JSON.parse(ev.data)
@@ -963,8 +969,14 @@ export function TerminalView({
       }
 
       ws.onclose = () => {
+        // A stale socket (superseded by a newer connect() or by the effect
+        // re-running) must not touch shared state: its close event often
+        // fires *after* the replacement socket opened, and marking the
+        // connection 'lost' then would leave the pill stuck on screen
+        // forever while the live socket streams output behind it.
+        if (wsRef.current !== ws) return
         resetResizeEchoGate()
-        setWsState(prev => prev === 'open' ? 'lost' : prev)
+        setWsState(prev => wsStateOnClose(prev, true))
         if (disposed.current || intentionalClose) return
         if (currentSessionId.current !== session.id) return
 

--- a/apps/gmux-web/src/ws-state.test.ts
+++ b/apps/gmux-web/src/ws-state.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { wsStateOnClose, type WsState } from './ws-state'
+
+describe('wsStateOnClose', () => {
+  it('marks the connection lost when the current socket closes while open', () => {
+    expect(wsStateOnClose('open', true)).toBe('lost')
+  })
+
+  it('does not regress connecting/lost states on a current-socket close', () => {
+    expect(wsStateOnClose('connecting', true)).toBe('connecting')
+    expect(wsStateOnClose('lost', true)).toBe('lost')
+  })
+
+  it('ignores stale-socket closes entirely', () => {
+    for (const prev of ['connecting', 'open', 'lost'] as const) {
+      expect(wsStateOnClose(prev, false)).toBe(prev)
+    }
+  })
+
+  // Regression: the stuck "Connection lost, reconnecting…" pill.
+  //
+  // Sequence: the connection effect re-runs (session switch, font load, dep
+  // identity change). Cleanup closes socket A, the new run opens socket B.
+  // Close events dispatch asynchronously, so A's close often arrives *after*
+  // B's open. Before the fix, A's close handler ran the 'open' → 'lost'
+  // transition unconditionally, flipping state to 'lost' with no path back:
+  // the pill stayed on screen while socket B streamed live output behind it.
+  it('a stale close arriving after the replacement socket opened does not flip open → lost', () => {
+    let state: WsState = 'connecting'
+    // socket B opens
+    state = 'open'
+    // socket A's close event finally dispatches; A is no longer current
+    state = wsStateOnClose(state, false)
+    expect(state).toBe('open')
+  })
+})

--- a/apps/gmux-web/src/ws-state.test.ts
+++ b/apps/gmux-web/src/ws-state.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { wsStateOnClose, type WsState } from './ws-state'
+import { wsStateOnClose, wsStateOnOutput, type WsState } from './ws-state'
 
 describe('wsStateOnClose', () => {
   it('marks the connection lost when the current socket closes while open', () => {
@@ -19,10 +19,10 @@ describe('wsStateOnClose', () => {
 
   // Regression: the stuck "Connection lost, reconnecting…" pill.
   //
-  // Sequence: the connection effect re-runs (session switch, font load, dep
-  // identity change). Cleanup closes socket A, the new run opens socket B.
-  // Close events dispatch asynchronously, so A's close often arrives *after*
-  // B's open. Before the fix, A's close handler ran the 'open' → 'lost'
+  // Sequence: the connection effect re-runs (session switch is the common
+  // trigger). Cleanup closes socket A, the new run opens socket B. Close
+  // events dispatch asynchronously, so A's close often arrives *after* B's
+  // open. Before the fix, A's close handler ran the 'open' → 'lost'
   // transition unconditionally, flipping state to 'lost' with no path back:
   // the pill stayed on screen while socket B streamed live output behind it.
   it('a stale close arriving after the replacement socket opened does not flip open → lost', () => {
@@ -32,5 +32,16 @@ describe('wsStateOnClose', () => {
     // socket A's close event finally dispatches; A is no longer current
     state = wsStateOnClose(state, false)
     expect(state).toBe('open')
+  })
+})
+
+describe('wsStateOnOutput', () => {
+  it('clears a stuck lost state when output arrives on the current socket', () => {
+    expect(wsStateOnOutput('lost')).toBe('open')
+  })
+
+  it('leaves other states untouched so per-message calls never re-render', () => {
+    expect(wsStateOnOutput('open')).toBe('open')
+    expect(wsStateOnOutput('connecting')).toBe('connecting')
   })
 })

--- a/apps/gmux-web/src/ws-state.ts
+++ b/apps/gmux-web/src/ws-state.ts
@@ -1,0 +1,20 @@
+export type WsState = 'connecting' | 'open' | 'lost'
+
+/**
+ * State transition for a WebSocket close event.
+ *
+ * A terminal may briefly have two sockets alive: when the connection effect
+ * re-runs (session switch, font load, callback identity change) or when
+ * connect() replaces a lingering socket, the old socket's close event
+ * dispatches asynchronously — often *after* the replacement socket has
+ * already opened. If that stale close were allowed to transition
+ * 'open' → 'lost', the "Connection lost, reconnecting…" pill would get stuck
+ * on screen while the live socket streams output behind it, because nothing
+ * else ever clears it.
+ *
+ * Only the socket that is still the current one may mark the connection lost.
+ */
+export function wsStateOnClose(prev: WsState, isCurrentSocket: boolean): WsState {
+  if (!isCurrentSocket) return prev
+  return prev === 'open' ? 'lost' : prev
+}

--- a/apps/gmux-web/src/ws-state.ts
+++ b/apps/gmux-web/src/ws-state.ts
@@ -18,3 +18,17 @@ export function wsStateOnClose(prev: WsState, isCurrentSocket: boolean): WsState
   if (!isCurrentSocket) return prev
   return prev === 'open' ? 'lost' : prev
 }
+
+/**
+ * State transition for output received on the current socket.
+ *
+ * Live output proves the connection works, so the disconnected pill must
+ * never be visible while data is flowing. This is a safety net for any
+ * future path that marks the connection 'lost' without a matching clear.
+ *
+ * Returns `prev` unchanged (same reference) unless it was 'lost', so calling
+ * this per message never triggers a re-render.
+ */
+export function wsStateOnOutput(prev: WsState): WsState {
+  return prev === 'lost' ? 'open' : prev
+}


### PR DESCRIPTION
Fixes the stuck "Connection lost, reconnecting…" pill that could stay on screen indefinitely while the terminal behind it was clearly receiving live output.

## Root cause

The pill is driven solely by `wsState === 'lost'` in `terminal.tsx`. The `ws.onclose` handler ran the `open → lost` transition **before** the `intentionalClose`/`disposed` guards, and no handler checked whether its socket was still the current one (`wsRef.current`).

`TerminalView` is not keyed by session, so a session switch re-runs the connection effect in the same component instance: cleanup closes socket A, the new run opens socket B (`fontReady` and `connect()`-replacing-a-lingering-socket are further triggers). WebSocket close events dispatch asynchronously, so **socket A's `onclose` frequently fires after socket B's `onopen`** already set the state to `open`. The stale close then flipped it to `lost` — and since B never fires another `onopen`, nothing ever cleared it.

## Fix

- Every socket handler (`onopen`, `onmessage`, `onclose`) ignores events from sockets that are no longer `wsRef.current`, so stale sockets can no longer touch shared state (including `resetResizeEchoGate`, which a stale close could previously clobber).
- The pill's state transitions live in `ws-state.ts`: `wsStateOnClose()` (a stale close never flips `open → lost`) and `wsStateOnOutput()` (output on the current socket always clears `lost` — live data proves the connection works, so the pill can never sit on top of flowing output even if a future path regresses). `onclose` passes the real `isCurrent` value through, so the unit-tested stale branch is the actual production path.
- Regression test in `ws-state.test.ts` encodes the exact race ordering: replacement socket opens, then the stale socket's close dispatches — state must stay `open`.

## Verification

`pnpm test` (548 passing) and `pnpm lint` clean in `apps/gmux-web`. Preact bails on identity-equal `setState`, so the per-message safety net never triggers re-renders.