### PR TITLE
fix(claude): slug follows the resolved title across renames

### DIFF
--- a/packages/adapter/adapters/claude.go
+++ b/packages/adapter/adapters/claude.go
@@ -219,13 +219,12 @@ func (c *Claude) ParseSessionFile(path string) (*adapter.SessionFileInfo, error)
 		info.Title = "" // no custom title and no message yet
 	}
 
-	// Slug from the first user message (immutable), not custom-title
-	// (which the user can change). Falls back to display title.
-	if firstUserText != "" {
-		info.Slug = adapter.Slugify(truncateTitle(firstUserText, 80))
-	} else {
-		info.Slug = adapter.Slugify(info.Title)
-	}
+	// Slug from the resolved title, custom-title included. Slug is the
+	// session's mutable display name (UBIQUITOUS_LANGUAGE.md), not identity
+	// — the immutable Tool ID is — so a /rename moves the slug with it,
+	// matching pi and the hook path (claudeTitleSlug already slugs
+	// session_title when the payload carries it).
+	info.Slug = adapter.Slugify(info.Title)
 
 	return info, nil
 }

--- a/packages/adapter/adapters/claude_hook_test.go
+++ b/packages/adapter/adapters/claude_hook_test.go
@@ -98,10 +98,10 @@ func TestClaudeHookBodies_PromptSubmitRefreshesRenamedTitle(t *testing.T) {
 	if got[0]["name"] != "Renamed Session" {
 		t.Fatalf("want renamed title, got %v", got[0]["name"])
 	}
-	// Slug stays derived from the first user message (immutable), so the URL
-	// doesn't churn on rename.
-	if got[0]["slug"] != "hello-world" {
-		t.Fatalf("slug must stay stable across rename, got %v", got[0]["slug"])
+	// Slug follows the rename: slug is the mutable display name, not
+	// identity. The frontend rewrites the URL atomically on slug change.
+	if got[0]["slug"] != "renamed-session" {
+		t.Fatalf("slug must follow rename, got %v", got[0]["slug"])
 	}
 }
 

--- a/packages/adapter/adapters/claude_test.go
+++ b/packages/adapter/adapters/claude_test.go
@@ -202,9 +202,10 @@ func TestClaudeParseSessionFileCustomTitle(t *testing.T) {
 	if info.Title != "Auth refactor" {
 		t.Errorf("expected custom title, got %q", info.Title)
 	}
-	// Slug uses first user message (immutable), not custom-title.
-	if info.Slug != "fix-the-bug" {
-		t.Errorf("expected slug from first user message, got %q", info.Slug)
+	// Slug follows the resolved title: a rename moves the slug (slug is the
+	// mutable display name, not identity — the Tool ID is).
+	if info.Slug != "auth-refactor" {
+		t.Errorf("expected slug from custom title, got %q", info.Slug)
 	}
 }
 


### PR DESCRIPTION
Precursor to the name/fallback-title split (follow-up to #345/#346).

## Problem

Claude's `ParseSessionFile` pinned the slug to the **first user message**, so a `/rename` (or `claude --name`) never moved the URL slug. This contradicts:

- the domain model: slug is "a session's **mutable**, human-readable display name; … renamable. **Not identity** (the immutable Tool ID is)" (UBIQUITOUS_LANGUAGE.md), reaffirmed by ADR 0003 alt. H which rejects slug-as-identity *because* it's mutable;
- **pi**, which already slugs from the resolved title;
- claude's **own hook path** — `claudeTitleSlug` already returns `Slugify(session_title)` when the hook payload carries it, so the hook and file-parse paths disagreed with each other.

The frontend is built for slug changes (it atomically rewrites the URL when a selected session's slug changes), so nothing downstream relies on pinning.

## Change

Derive the slug from the resolved title (`custom-title` > first user message), matching pi. Inverts the slug-stability assertion added in #346, which had codified the wrong behavior.