### PR TITLE
refactor!: terminology rename — kind→adapter, ToolID→ConversationID, session_file→conversation_file

### DIFF
--- a/UBIQUITOUS_LANGUAGE.md
+++ b/UBIQUITOUS_LANGUAGE.md
@@ -9,7 +9,7 @@
 | **Slug**            | A session's mutable, human-readable display name; persistent across runner restarts and resume, but renamable. Not identity (the immutable Conversation ID is) | Name                      |
 | **Session ID**      | A specific runner instance's identifier; ephemeral for shell, stable (= conversation ID) for pi/claude    | Identifier (alone is too generic) |
 | **Key**             | The single string projects.json uses per session: slug if attributed, session ID otherwise                |                           |
-| **Conversation ID** | The agent's own identifier for a Conversation, parsed from inside the conversation file by the adapter (`ConversationInfo.ID`). Used with the adapter name as the conversations-index key `(adapter, conversationID)` | Tool ID (the old name)    |
+| **Conversation ID** | The agent's own identifier for a Conversation, parsed from inside the conversation file by the adapter (`SessionFileInfo.ID`; the Go type's rename to `ConversationInfo` trails with the internal cleanup). Used with the adapter name as the conversations-index key `(adapter, conversationID)` | Tool ID (the old name)    |
 
 ## Session lifecycle
 

--- a/UBIQUITOUS_LANGUAGE.md
+++ b/UBIQUITOUS_LANGUAGE.md
@@ -5,11 +5,11 @@
 | Term                | Definition                                                                                                | Aliases to avoid          |
 | ------------------- | --------------------------------------------------------------------------------------------------------- | ------------------------- |
 | **Session**         | The user-facing unit of work in a directory: a terminal pane plus everything we know about it             | Pane, terminal, tab       |
-| **Conversation**    | An agent's own thread of dialogue (pi/claude/codex's "session"), identified by its on-disk file path. The path (= **Tool ID**) is immutable; the conversation's display name (slug) is mutable. A tool-backed **Session** corresponds to a Conversation; a **Runner** binds to one and may rebind (`/resume`) to another | Agent session, thread     |
-| **Slug**            | A session's mutable, human-readable display name; persistent across runner restarts and resume, but renamable. Not identity (the immutable Tool ID is) | Name                      |
-| **Session ID**      | A specific runner instance's identifier; ephemeral for shell, stable (= tool ID) for pi/claude            | Identifier (alone is too generic) |
+| **Conversation**    | An agent's own thread of dialogue (pi/claude/codex's "session"), identified by the agent's own **Conversation ID** (a UUID in the transcript header). It lives at an on-disk **conversation file** path; the path can change (resume/fork), the ID is the stable handle. A tool-backed **Session** corresponds to a Conversation; a **Runner** binds to one and may rebind (`/resume`) to another | Agent session, thread, session file |
+| **Slug**            | A session's mutable, human-readable display name; persistent across runner restarts and resume, but renamable. Not identity (the immutable Conversation ID is) | Name                      |
+| **Session ID**      | A specific runner instance's identifier; ephemeral for shell, stable (= conversation ID) for pi/claude    | Identifier (alone is too generic) |
 | **Key**             | The single string projects.json uses per session: slug if attributed, session ID otherwise                |                           |
-| **Tool ID**         | An adapter-managed file identifier (e.g. JSONL filename) used as session ID for tool-backed sessions      |                           |
+| **Conversation ID** | The agent's own identifier for a Conversation, parsed from inside the conversation file by the adapter (`ConversationInfo.ID`). Used with the adapter name as the conversations-index key `(adapter, conversationID)` | Tool ID (the old name)    |
 
 ## Session lifecycle
 
@@ -29,7 +29,7 @@
 | **Runner**      | A `gmux` process holding a child PTY and serving WS / scrollback over a per-session Unix socket  | gmux process, child         |
 | **Daemon**      | The single per-host `gmuxd` process; central registry, broker, and proxy                         | Server, gmuxd (in prose)    |
 | **Broker**      | The daemon's role serving readonly state (today: scrollback) sourced from disk for dead sessions | Replay server               |
-| **Adapter**     | A plugin (pi, claude, shell, ...) that resolves commands, derives slugs, and may write tool files | Plugin, kind                |
+| **Adapter**     | A plugin (pi, claude, shell, ...) that resolves commands, derives slugs, and may write tool files | Plugin, kind (the old wire field name) |
 | **Agent-hook**  | A small extension the runner injects into the agent (pi: `-e <ext>`) that subscribes to the agent's own session/agent lifecycle and reports the held session file, title, and status to the runner authoritatively (ADR 0011). Supersedes the removed agent-shim fs preload (ADR 0010) | Hook, extension             |
 | **Frontend**    | The web UI consuming `/v1/events` SSE and `/ws/<id>` WebSockets                                  | Client (overloaded), web    |
 
@@ -63,7 +63,7 @@ The four stores have orthogonal concerns. Mixing them is a smell:
 | **Store**              | Caches live runtime state (the runner owns it; ADR 0011)          | Session ID                        |
 | **Sessionmeta**        | Persisted runtime state (exit code, status, title, timestamps)    | Session ID                        |
 | **Projects.json**      | Which sessions appear in the sidebar, in what project, what order | Project slug → list of **Key**s   |
-| **Conversations Index**| Cross-reference between IDs and slugs for adapter-backed sessions | (kind, ID) and (kind, slug)       |
+| **Conversations Index**| Cross-reference between IDs and slugs for adapter-backed sessions | (adapter, conversationID) and (adapter, slug) |
 
 ## Lifecycle events
 
@@ -74,7 +74,7 @@ The four stores have orthogonal concerns. Mixing them is a smell:
 | **Resume**            | User-initiated: spawn a new runner with the dead session's resume `Command`, merge new runner onto the existing ID      | Restart (overloaded — see below) |
 | **Resume merge**      | The internal step inside `Register` where a pending resume's existing ID swallows the fresh runner's ID                | Reattach                       |
 | **Restart**           | Like Resume but kills the live runner first; goes through Resume after exit                                            |                                |
-| **Slug-takeover**     | A fresh live session evicting a dead one with the same `(kind, peer, slug)` from the store                              | Slug eviction                  |
+| **Slug-takeover**     | A fresh live session evicting a dead one with the same `(adapter, peer, slug)` from the store                              | Slug eviction                  |
 | **Dismiss**           | Explicit user removal: runner killed if alive, store entry removed, sessionmeta + scrollback dropped                    | Delete, close                  |
 | **Sweep**             | Daemon startup operation: read every `meta.json` and Upsert as `Alive=false`, so previously-seen dead sessions reappear. Whether each then renders depends on project membership and match rules — `State.Discovered()` also surfaces unfiled sessions, so visibility is not strictly gated by `projects.json` | Restore                        |
 | **Attribution**       | Binding a tool-backed session to its adapter session file. **Primary:** authoritative, reported by the **Agent-hook** (pi names the held file directly, including cache-served `/resume` rebinds). **Fallback:** metadata matching (cwd + start time) for agents with no hook (codex). See ADR 0011 | Naming                         |
@@ -119,5 +119,7 @@ The four stores have orthogonal concerns. Mixing them is a smell:
 - **"Identity"**: in this codebase, **Slug** is identity, **Session ID** is instance. Treat them as distinct columns even though `SessionKey` coalesces them for projects.json's purposes.
 
 - **"Local"** has two meanings: the local *machine* (where this gmuxd runs), and a **Local peer** (`PeerConfig.Local = true`, currently devcontainers only). Prefer **Local peer** for the latter to avoid collision with "the local daemon".
+
+- **"Session file"** is banned: say **conversation file** (gmux's term) — or use the agent's own term only at its API boundary (ADR 0015: agent-native JSON tags like `sessionId`/`transcript_path` keep the agent's language).
 
 - **"Broker"** was introduced for the scrollback endpoint. Reserve it for read-only daemon endpoints serving disk-backed state for dead sessions; not a synonym for the daemon as a whole.

--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -277,7 +277,7 @@ function SessionMenu({ session, onRestart }: {
           <div class="session-menu-section-title">Session info</div>
           <div class="session-menu-row">
             <span class="session-menu-label">Adapter</span>
-            <span class="session-menu-value">{session.kind}</span>
+            <span class="session-menu-value">{session.adapter}</span>
           </div>
           <div class="session-menu-row">
             <span class="session-menu-label">Version</span>

--- a/apps/gmux-web/src/mock-data/export-session.ts
+++ b/apps/gmux-web/src/mock-data/export-session.ts
@@ -225,7 +225,7 @@ function generateFile(session: Session, terminal: string, cursorX: number, curso
   if (session.workspace_root) {
     lines.push(`  workspace_root: '${session.workspace_root}',`)
   }
-  lines.push(`  kind: '${session.kind}',`)
+  lines.push(`  adapter: '${session.adapter}',`)
   lines.push(`  alive: ${session.alive},`)
   lines.push(`  pid: ${session.pid},`)
   lines.push(`  exit_code: ${session.exit_code},`)

--- a/apps/gmux-web/src/mock-data/sessions/claude-design-landing.ts
+++ b/apps/gmux-web/src/mock-data/sessions/claude-design-landing.ts
@@ -14,7 +14,7 @@ export default {
   cwd: '/home/user/dev/my-project',
   workspace_root: '/home/user/dev/my-project',
   remotes: { origin: 'github.com/acme/my-project' },
-  kind: 'claude',
+  adapter: 'claude',
   alive: true,
   pid: 44200,
   exit_code: null,

--- a/apps/gmux-web/src/mock-data/sessions/codex-migrate.ts
+++ b/apps/gmux-web/src/mock-data/sessions/codex-migrate.ts
@@ -14,7 +14,7 @@ export default {
   cwd: '/home/user/dev/my-project',
   workspace_root: '/home/user/dev/my-project',
   remotes: { origin: 'github.com/acme/my-project' },
-  kind: 'codex',
+  adapter: 'codex',
   alive: true,
   pid: 8830,
   exit_code: null,

--- a/apps/gmux-web/src/mock-data/sessions/codex-refactor-adapters.ts
+++ b/apps/gmux-web/src/mock-data/sessions/codex-refactor-adapters.ts
@@ -22,7 +22,7 @@ export default {
   cwd: '/home/user/dev/my-project',
   workspace_root: '/home/user/dev/my-project',
   remotes: { origin: 'github.com/acme/my-project' },
-  kind: 'codex',
+  adapter: 'codex',
   alive: true,
   pid: 568143,
   exit_code: null,

--- a/apps/gmux-web/src/mock-data/sessions/pi-autoresearch.ts
+++ b/apps/gmux-web/src/mock-data/sessions/pi-autoresearch.ts
@@ -14,7 +14,7 @@ export default {
   cwd: '/home/user/dev/my-other-project',
   workspace_root: '/home/user/dev/my-other-project',
   remotes: { origin: 'github.com/acme/my-other-project' },
-  kind: 'pi',
+  adapter: 'pi',
   alive: true,
   pid: 8821,
   exit_code: null,

--- a/apps/gmux-web/src/mock-data/sessions/pi-fix-scrollback.ts
+++ b/apps/gmux-web/src/mock-data/sessions/pi-fix-scrollback.ts
@@ -14,7 +14,7 @@ export default {
   cwd: '/home/user/dev/my-project',
   workspace_root: '/home/user/dev/my-project',
   remotes: { origin: 'github.com/acme/my-project' },
-  kind: 'pi',
+  adapter: 'pi',
   alive: true,
   pid: 44300,
   exit_code: null,

--- a/apps/gmux-web/src/mock-data/sessions/shell-openclaw-configure.ts
+++ b/apps/gmux-web/src/mock-data/sessions/shell-openclaw-configure.ts
@@ -11,7 +11,7 @@ export default {
   cwd: '/home/user/dev/openclaw',
   workspace_root: '/home/user/dev/openclaw',
   remotes: { origin: 'github.com/acme/openclaw' },
-  kind: 'shell',
+  adapter: 'shell',
   alive: true,
   pid: 9100,
   exit_code: null,

--- a/apps/gmux-web/src/mock-data/sessions/shell-openclaw-logs.ts
+++ b/apps/gmux-web/src/mock-data/sessions/shell-openclaw-logs.ts
@@ -11,7 +11,7 @@ export default {
   cwd: '/home/user/dev/openclaw',
   workspace_root: '/home/user/dev/openclaw',
   remotes: { origin: 'github.com/acme/openclaw' },
-  kind: 'shell',
+  adapter: 'shell',
   alive: true,
   pid: 9200,
   exit_code: null,

--- a/apps/gmux-web/src/replay-view.tsx
+++ b/apps/gmux-web/src/replay-view.tsx
@@ -201,7 +201,7 @@ export function ReplayView({
               disabled={!!resuming}
               onClick={() => onResume(session.id)}
             >
-              {resumeButtonLabel(session.kind, !!resuming)}
+              {resumeButtonLabel(session.adapter, !!resuming)}
             </button>
           )}
         </div>

--- a/apps/gmux-web/src/routing.test.ts
+++ b/apps/gmux-web/src/routing.test.ts
@@ -71,17 +71,17 @@ describe('parseSessionPath', () => {
 
 describe('sessionPath', () => {
   it('builds URL from slug', () => {
-    expect(sessionPath('gmux', { kind: 'pi', slug: 'fix-auth', id: 'abc' }))
+    expect(sessionPath('gmux', { adapter: 'pi', slug: 'fix-auth', id: 'abc' }))
       .toBe('/gmux/pi/fix-auth')
   })
 
   it('falls back to ID prefix when slug missing', () => {
-    expect(sessionPath('gmux', { kind: 'pi', id: 'abcdef12-3456-7890' }))
+    expect(sessionPath('gmux', { adapter: 'pi', id: 'abcdef12-3456-7890' }))
       .toBe('/gmux/pi/abcdef12')
   })
 
   it('includes @peer for remote sessions', () => {
-    expect(sessionPath('gmux', { kind: 'pi', slug: 'fix-auth', id: 'abc', peer: 'server' }))
+    expect(sessionPath('gmux', { adapter: 'pi', slug: 'fix-auth', id: 'abc', peer: 'server' }))
       .toBe('/gmux/@server/pi/fix-auth')
   })
 
@@ -90,7 +90,7 @@ describe('sessionPath', () => {
     // segment is redundant and is omitted.
     expect(sessionPath(
       'gmux',
-      { id: 'sess-1@tower', kind: 'pi', slug: 'fix-auth', peer: 'tower' },
+      { id: 'sess-1@tower', adapter: 'pi', slug: 'fix-auth', peer: 'tower' },
       'tower',
     )).toBe('/@tower/gmux/pi/fix-auth')
   })
@@ -101,12 +101,12 @@ describe('sessionPath', () => {
     // (mid-path @<host> needed to disambiguate).
     expect(sessionPath(
       'gmux',
-      { id: 'sess-1@dev', kind: 'pi', slug: 'fix-auth', peer: 'dev' },
+      { id: 'sess-1@dev', adapter: 'pi', slug: 'fix-auth', peer: 'dev' },
     )).toBe('/gmux/@dev/pi/fix-auth')
   })
 
   it('omits @peer for local sessions', () => {
-    expect(sessionPath('gmux', { kind: 'pi', slug: 'fix-auth', id: 'abc', peer: undefined }))
+    expect(sessionPath('gmux', { adapter: 'pi', slug: 'fix-auth', id: 'abc', peer: undefined }))
       .toBe('/gmux/pi/fix-auth')
   })
 })
@@ -116,9 +116,9 @@ describe('resolveSessionFromPath', () => {
     { slug: 'gmux', match: [{ remote: 'github.com/gmuxapp/gmux' }, { path: '/dev/gmux' }] },
   ]
   const localSessions = [
-    makeSession({ id: 'sess-1', cwd: '/dev/gmux', kind: 'pi', slug: 'fix-auth',
+    makeSession({ id: 'sess-1', cwd: '/dev/gmux', adapter: 'pi', slug: 'fix-auth',
       remotes: { origin: 'github.com/gmuxapp/gmux' } }),
-    makeSession({ id: 'sess-2', cwd: '/dev/gmux', kind: 'shell', slug: 'fish',
+    makeSession({ id: 'sess-2', cwd: '/dev/gmux', adapter: 'shell', slug: 'fish',
       remotes: { origin: 'github.com/gmuxapp/gmux' } }),
   ]
 
@@ -142,9 +142,9 @@ describe('resolveSessionFromPath', () => {
   // Peer-aware resolution
   const mixedSessions = [
     ...localSessions,
-    makeSession({ id: 'sess-r1@server', cwd: '/dev/gmux', kind: 'pi', slug: 'fix-auth',
+    makeSession({ id: 'sess-r1@server', cwd: '/dev/gmux', adapter: 'pi', slug: 'fix-auth',
       peer: 'server', remotes: { origin: 'github.com/gmuxapp/gmux' } }),
-    makeSession({ id: 'sess-r2@server', cwd: '/dev/gmux', kind: 'shell', slug: 'bash',
+    makeSession({ id: 'sess-r2@server', cwd: '/dev/gmux', adapter: 'shell', slug: 'bash',
       peer: 'server', remotes: { origin: 'github.com/gmuxapp/gmux' } }),
   ]
 
@@ -182,7 +182,7 @@ describe('resolveSessionFromPath', () => {
 
   it('resolves by ID prefix when session has no slug', () => {
     const unattributed = [
-      makeSession({ id: 'sess-abc12345', cwd: '/dev/gmux', kind: 'pi',
+      makeSession({ id: 'sess-abc12345', cwd: '/dev/gmux', adapter: 'pi',
         remotes: { origin: 'github.com/gmuxapp/gmux' } }),
     ]
     const id = resolveSessionFromPath(
@@ -197,7 +197,7 @@ describe('resolveSessionFromPath', () => {
     // a 'gmux' project, but the URL `/@tower/gmux/...` addresses the
     // peer-owned one; we must trust the stamp, not re-run match.
     const claimed = makeSession({
-      id: 'sess-t1@tower', cwd: '/elsewhere', kind: 'pi', slug: 'fix-auth',
+      id: 'sess-t1@tower', cwd: '/elsewhere', adapter: 'pi', slug: 'fix-auth',
       peer: 'tower', project_slug: 'gmux', project_index: 0,
     })
     const id = resolveSessionFromPath(
@@ -209,11 +209,11 @@ describe('resolveSessionFromPath', () => {
 
   it('peer-owned project URL ignores local-stamped same-slug sessions', () => {
     const localGmux = makeSession({
-      id: 'sess-local', cwd: '/dev/gmux', kind: 'pi', slug: 'fix-auth',
+      id: 'sess-local', cwd: '/dev/gmux', adapter: 'pi', slug: 'fix-auth',
       project_slug: 'gmux', project_index: 0,
     })
     const towerGmux = makeSession({
-      id: 'sess-t@tower', cwd: '/elsewhere', kind: 'pi', slug: 'fix-auth',
+      id: 'sess-t@tower', cwd: '/elsewhere', adapter: 'pi', slug: 'fix-auth',
       peer: 'tower', project_slug: 'gmux', project_index: 0,
     })
     const id = resolveSessionFromPath(
@@ -229,7 +229,7 @@ describe('resolveViewFromPath', () => {
     { slug: 'gmux', match: [{ remote: 'github.com/gmuxapp/gmux' }, { path: '/dev/gmux' }] },
   ]
   const sessions = [
-    makeSession({ id: 'sess-1', cwd: '/dev/gmux', kind: 'pi', slug: 'fix-auth',
+    makeSession({ id: 'sess-1', cwd: '/dev/gmux', adapter: 'pi', slug: 'fix-auth',
       remotes: { origin: 'github.com/gmuxapp/gmux' } }),
   ]
 
@@ -259,7 +259,7 @@ describe('resolveViewFromPath', () => {
 
   it('peer-owned project URL resolves to project view when sessions exist', () => {
     const peerSession = makeSession({
-      id: 'sess-t@tower', cwd: '/elsewhere', kind: 'pi', slug: 'fix-auth',
+      id: 'sess-t@tower', cwd: '/elsewhere', adapter: 'pi', slug: 'fix-auth',
       peer: 'tower', project_slug: 'gmux', project_index: 0,
     })
     expect(resolveViewFromPath('/@tower/gmux', projects, [peerSession])).toEqual({
@@ -289,7 +289,7 @@ describe('resolveViewFromPath', () => {
 
   it('remote session URL resolves to session view', () => {
     const remoteSess = makeSession({
-      id: 'sess-3@server', cwd: '/dev/gmux', kind: 'shell', slug: 'bash',
+      id: 'sess-3@server', cwd: '/dev/gmux', adapter: 'shell', slug: 'bash',
       peer: 'server', remotes: { origin: 'github.com/gmuxapp/gmux' },
     })
     expect(resolveViewFromPath('/gmux/@server/shell/bash', projects, [...sessions, remoteSess])).toEqual({
@@ -309,9 +309,9 @@ describe('viewToPath', () => {
     { slug: 'gmux', match: [{ remote: 'github.com/gmuxapp/gmux' }, { path: '/dev/gmux' }] },
   ]
   const sessions = [
-    makeSession({ id: 'sess-1', cwd: '/dev/gmux', kind: 'pi', slug: 'fix-auth',
+    makeSession({ id: 'sess-1', cwd: '/dev/gmux', adapter: 'pi', slug: 'fix-auth',
       remotes: { origin: 'github.com/gmuxapp/gmux' } }),
-    makeSession({ id: 'sess-2@server', cwd: '/dev/gmux', kind: 'shell', slug: 'bash',
+    makeSession({ id: 'sess-2@server', cwd: '/dev/gmux', adapter: 'shell', slug: 'bash',
       peer: 'server', remotes: { origin: 'github.com/gmuxapp/gmux' } }),
   ]
 
@@ -338,7 +338,7 @@ describe('viewToPath', () => {
   })
 
   it('session view for unmatched session -> null', () => {
-    const orphan = makeSession({ id: 'orphan', cwd: '/nowhere', kind: 'pi' })
+    const orphan = makeSession({ id: 'orphan', cwd: '/nowhere', adapter: 'pi' })
     expect(viewToPath({ kind: 'session', sessionId: 'orphan' }, projects, [orphan])).toBeNull()
   })
 
@@ -351,7 +351,7 @@ describe('viewToPath', () => {
 
   it('peer-claimed session -> /@<owner>/<slug>/...', () => {
     const claimed = makeSession({
-      id: 'sess-c@tower', cwd: '/dev/gmux', kind: 'pi', slug: 'on-tower',
+      id: 'sess-c@tower', cwd: '/dev/gmux', adapter: 'pi', slug: 'on-tower',
       peer: 'tower', project_slug: 'gmux', project_index: 0,
     })
     expect(viewToPath(
@@ -362,7 +362,7 @@ describe('viewToPath', () => {
 
   it('local-claimed session uses local URL form', () => {
     const claimed = makeSession({
-      id: 'sess-l', cwd: '/dev/gmux', kind: 'pi', slug: 'local',
+      id: 'sess-l', cwd: '/dev/gmux', adapter: 'pi', slug: 'local',
       project_slug: 'gmux', project_index: 0,
     })
     expect(viewToPath(
@@ -411,7 +411,7 @@ describe('View round-trip', () => {
     { slug: 'gmux', match: [{ remote: 'github.com/gmuxapp/gmux' }, { path: '/dev/gmux' }] },
   ]
   const sessions = [
-    makeSession({ id: 'sess-1', cwd: '/dev/gmux', kind: 'pi', slug: 'fix-auth',
+    makeSession({ id: 'sess-1', cwd: '/dev/gmux', adapter: 'pi', slug: 'fix-auth',
       remotes: { origin: 'github.com/gmuxapp/gmux' } }),
   ]
 

--- a/apps/gmux-web/src/routing.ts
+++ b/apps/gmux-web/src/routing.ts
@@ -70,7 +70,7 @@ export function parseSessionPath(path: string): {
  */
 export function sessionPath(
   projectSlug: string,
-  session: { kind: string; slug?: string; id: string; peer?: string },
+  session: { adapter: string; slug?: string; id: string; peer?: string },
   projectPeer?: string,
 ): string {
   const slug = session.slug || session.id.slice(0, 8)
@@ -78,7 +78,7 @@ export function sessionPath(
   // Mid-path session-host segment is needed only when the session
   // lives on a different host than the project owner.
   const sessionHost = session.peer && session.peer !== projectPeer ? `/@${session.peer}` : ''
-  return `${ownerPrefix}/${projectSlug}${sessionHost}/${session.kind}/${slug}`
+  return `${ownerPrefix}/${projectSlug}${sessionHost}/${session.adapter}/${slug}`
 }
 
 /** Build the URL for a project hub (no session). */
@@ -141,7 +141,7 @@ export function resolveSessionFromPath(
   }
 
   // Filter by adapter kind.
-  const adapterSessions = projectSessions.filter(s => s.kind === parsed.adapter)
+  const adapterSessions = projectSessions.filter(s => s.adapter === parsed.adapter)
 
   if (!parsed.slug) {
     // /:project/:adapter only - return first alive, or first.

--- a/apps/gmux-web/src/session-row.tsx
+++ b/apps/gmux-web/src/session-row.tsx
@@ -14,7 +14,7 @@ import type { Session } from './types'
 import {
   activityMap, peerStatusByName,
   sessionDotState, isSessionUnavailable,
-  duplicateSessionFiles,
+  duplicateConversationFiles,
 } from './store'
 import { useArrivalPulse } from './use-arrival-pulse'
 import { HostSuffix } from './host-suffix'
@@ -119,7 +119,7 @@ export function SessionRow({
     metaSegments.push(<span class="session-row-status">{statusText}</span>)
   }
   // Same conversation file open in another live runner (ADR 0011 N:1).
-  if (session.session_file && duplicateSessionFiles.value.has(session.session_file)) {
+  if (session.conversation_file && duplicateConversationFiles.value.has(session.conversation_file)) {
     metaSegments.push(
       <span class="session-row-dup" title="This conversation is open in more than one tab">⚠ open elsewhere</span>,
     )

--- a/apps/gmux-web/src/sidebar.tsx
+++ b/apps/gmux-web/src/sidebar.tsx
@@ -15,7 +15,7 @@ import {
   activityMap, projects, connState,
   updateProjects, reorderSessions,
   peerStatusByName, isSessionUnavailable, localPeerNames, sessionDotState,
-  unreadCount, localHostLabel, unresolvedHosts, duplicateSessionFiles,
+  unreadCount, localHostLabel, unresolvedHosts, duplicateConversationFiles,
   type DotState,
 } from './store'
 import { HostSuffix } from './host-suffix'
@@ -134,7 +134,7 @@ function SessionItem({
   const arrival = useArrivalPulse(dotState)
   const sleeping = !session.alive && session.resumable
   // Same conversation file live in another runner (ADR 0011 N:1).
-  const duplicateOpen = !!session.session_file && duplicateSessionFiles.value.has(session.session_file)
+  const duplicateOpen = !!session.conversation_file && duplicateConversationFiles.value.has(session.conversation_file)
 
   const cls = [
     'session-item',

--- a/apps/gmux-web/src/store.test.ts
+++ b/apps/gmux-web/src/store.test.ts
@@ -9,7 +9,7 @@ import {
   navigateToSession, setNavigate,
   applyPending, _rawSessions, _rawWorld, _setRawWorld, _pendingMutations,
   toUISession, localHostLabel, parseConnectURL, unreadCount, discovered,
-  view, duplicateSessionFiles,
+  view, duplicateConversationFiles,
 } from './store'
 import { SessionSchema } from '@gmux/protocol'
 import type { PendingMutation } from './store'
@@ -21,7 +21,7 @@ function makeSession(overrides: Partial<Session> & { id: string }): Session {
     created_at: '2026-01-01T00:00:00Z',
     command: ['/bin/sh'],
     cwd: '/home/user',
-    kind: 'shell',
+    adapter: 'shell',
     alive: true,
     pid: 1,
     exit_code: null,
@@ -225,7 +225,7 @@ describe('upsertSession', () => {
   it('inserts a new session and returns true', () => {
     const isNew = upsertSession({
       id: 'sess-1', alive: true, cwd: '/home/user',
-      command: ['/bin/sh'], kind: 'shell',
+      command: ['/bin/sh'], adapter: 'shell',
     } as any)
     expect(isNew).toBe(true)
     expect(sessions.value).toHaveLength(1)
@@ -236,7 +236,7 @@ describe('upsertSession', () => {
     _rawSessions.value = [makeSession({ id: 'sess-1', title: 'old' })]
     const isNew = upsertSession({
       id: 'sess-1', alive: true, title: 'new',
-      cwd: '/home/user', command: ['/bin/sh'], kind: 'shell',
+      cwd: '/home/user', command: ['/bin/sh'], adapter: 'shell',
     } as any)
     expect(isNew).toBe(false)
     expect(sessions.value).toHaveLength(1)
@@ -250,7 +250,7 @@ describe('upsertSession', () => {
     ]
     upsertSession({
       id: 'sess-1', alive: false, title: 'updated',
-      cwd: '/home/user', command: ['/bin/sh'], kind: 'shell',
+      cwd: '/home/user', command: ['/bin/sh'], adapter: 'shell',
     } as any)
     expect(sessions.value).toHaveLength(2)
     expect(sessions.value[0].title).toBe('updated')
@@ -265,7 +265,7 @@ describe('upsertSession', () => {
     sessionsLoaded.value = true
     worldLoaded.value = true
     _rawSessions.value = [
-      makeSession({ id: 'sess-1', cwd: '/dev/project', kind: 'pi', slug: 'fix-auth' }),
+      makeSession({ id: 'sess-1', cwd: '/dev/project', adapter: 'pi', slug: 'fix-auth' }),
     ]
     // Simulate the session being selected via URL.
     urlPath.value = '/myproject/pi/fix-auth'
@@ -273,7 +273,7 @@ describe('upsertSession', () => {
 
     // SSE upserts with a new slug (e.g., /new changed the active file).
     upsertSession({
-      id: 'sess-1', alive: true, cwd: '/dev/project', kind: 'pi',
+      id: 'sess-1', alive: true, cwd: '/dev/project', adapter: 'pi',
       slug: 'refactor-login', command: ['pi'], title: 'pi',
     } as any)
 
@@ -290,15 +290,15 @@ describe('upsertSession', () => {
     sessionsLoaded.value = true
     worldLoaded.value = true
     _rawSessions.value = [
-      makeSession({ id: 'sess-1', cwd: '/dev/project', kind: 'pi', slug: 'fix-auth' }),
-      makeSession({ id: 'sess-2', cwd: '/dev/project', kind: 'pi', slug: 'old-slug' }),
+      makeSession({ id: 'sess-1', cwd: '/dev/project', adapter: 'pi', slug: 'fix-auth' }),
+      makeSession({ id: 'sess-2', cwd: '/dev/project', adapter: 'pi', slug: 'old-slug' }),
     ]
     urlPath.value = '/myproject/pi/fix-auth'
     expect(selectedId.value).toBe('sess-1')
 
     // sess-2's slug changes, but it's not the selected session.
     upsertSession({
-      id: 'sess-2', alive: true, cwd: '/dev/project', kind: 'pi',
+      id: 'sess-2', alive: true, cwd: '/dev/project', adapter: 'pi',
       slug: 'new-slug', command: ['pi'], title: 'pi',
     } as any)
 
@@ -320,7 +320,7 @@ describe('deep-link refresh: snapshot ordering race (#308-adjacent)', () => {
   it('does not resolve a session URL to home before the world loads', () => {
     urlPath.value = '/myproject/pi/fix-auth'
     _rawSessions.value = [
-      makeSession({ id: 'sess-1', cwd: '/dev/project', kind: 'pi', slug: 'fix-auth', project_slug: 'myproject' }),
+      makeSession({ id: 'sess-1', cwd: '/dev/project', adapter: 'pi', slug: 'fix-auth', project_slug: 'myproject' }),
     ]
     // Sessions snapshot arrived; world has not (projects still empty).
     sessionsLoaded.value = true
@@ -536,7 +536,7 @@ describe('navigateToSession', () => {
 
   it('returns true and dispatches the project-prefixed URL once both are loaded', () => {
     _setRawWorld({ projects: [{ slug: 'myproject', match: [{ path: '/dev/p' }] }] })
-    _rawSessions.value = [makeSession({ id: 'sess-1', cwd: '/dev/p', kind: 'shell' })]
+    _rawSessions.value = [makeSession({ id: 'sess-1', cwd: '/dev/p', adapter: 'shell' })]
     expect(navigateToSession('sess-1', true)).toBe(true)
     expect(navigateMock).toHaveBeenCalledTimes(1)
     const [url, replace] = navigateMock.mock.calls[0]
@@ -553,7 +553,7 @@ describe('navigateToSession', () => {
     _setRawWorld({ projects: [] })
     _rawSessions.value = [makeSession({
       id: 'remote-1',
-      kind: 'shell',
+      adapter: 'shell',
       slug: 'remote-1-slug',
       peer: 'workstation',
       project_slug: 'gmux',
@@ -776,8 +776,8 @@ describe('unreadCount (sidebar-only attention blip)', () => {
 
   it('excludes the currently-selected session', () => {
     _rawSessions.value = [
-      makeSession({ id: 'a', cwd: '/work', kind: 'shell', slug: 'aa', alive: true, unread: true, project_slug: 'proj' }),
-      makeSession({ id: 'b', cwd: '/work', kind: 'shell', slug: 'bb', alive: true, unread: true, project_slug: 'proj' }),
+      makeSession({ id: 'a', cwd: '/work', adapter: 'shell', slug: 'aa', alive: true, unread: true, project_slug: 'proj' }),
+      makeSession({ id: 'b', cwd: '/work', adapter: 'shell', slug: 'bb', alive: true, unread: true, project_slug: 'proj' }),
     ]
     expect(unreadCount.value).toBe(2)
     urlPath.value = '/proj/shell/aa'
@@ -1020,24 +1020,24 @@ describe('parseConnectURL', () => {
   })
 })
 
-describe('session_file (duplicate-open warning)', () => {
-  it('carries session_file from the wire through to the UI session', () => {
+describe('conversation_file (duplicate-open warning)', () => {
+  it('carries conversation_file from the wire through to the UI session', () => {
     // Guards the two gaps that silently disabled the warning: the protocol
-    // Zod schema must keep session_file (not strip it), and toUISession must
+    // Zod schema must keep conversation_file (not strip it), and toUISession must
     // map it through.
-    const parsed = SessionSchema.parse({ id: 'a', alive: true, session_file: '/conv.jsonl' })
-    expect(parsed.session_file).toBe('/conv.jsonl')
-    expect(toUISession(parsed).session_file).toBe('/conv.jsonl')
+    const parsed = SessionSchema.parse({ id: 'a', alive: true, conversation_file: '/conv.jsonl' })
+    expect(parsed.conversation_file).toBe('/conv.jsonl')
+    expect(toUISession(parsed).conversation_file).toBe('/conv.jsonl')
   })
 
   it('flags a conversation that is live in more than one tab', () => {
     _rawSessions.value = [
-      makeSession({ id: 'a', alive: true, session_file: '/conv.jsonl' }),
-      makeSession({ id: 'b', alive: true, session_file: '/conv.jsonl' }),
-      makeSession({ id: 'c', alive: true, session_file: '/other.jsonl' }),
-      makeSession({ id: 'd', alive: false, session_file: '/conv.jsonl' }), // dead doesn't count
+      makeSession({ id: 'a', alive: true, conversation_file: '/conv.jsonl' }),
+      makeSession({ id: 'b', alive: true, conversation_file: '/conv.jsonl' }),
+      makeSession({ id: 'c', alive: true, conversation_file: '/other.jsonl' }),
+      makeSession({ id: 'd', alive: false, conversation_file: '/conv.jsonl' }), // dead doesn't count
     ]
-    const dups = duplicateSessionFiles.value
+    const dups = duplicateConversationFiles.value
     expect(dups.has('/conv.jsonl')).toBe(true)
     expect(dups.has('/other.jsonl')).toBe(false)
   })

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -217,13 +217,13 @@ export const projects = computed<ProjectItem[]>(() =>
 
 /** Conversation files that are live in more than one runner (session → file
  *  is authoritative per-runner; ADR 0011). Two alive sessions sharing a
- *  session_file means the same conversation is open in multiple tabs, which
- *  the UI surfaces as a warning. Keyed by session_file. */
-export const duplicateSessionFiles = computed<Set<string>>(() => {
+ *  conversation_file means the same conversation is open in multiple tabs, which
+ *  the UI surfaces as a warning. Keyed by conversation_file. */
+export const duplicateConversationFiles = computed<Set<string>>(() => {
   const counts = new Map<string, number>()
   for (const s of sessions.value) {
-    if (!s.alive || !s.session_file) continue
-    counts.set(s.session_file, (counts.get(s.session_file) ?? 0) + 1)
+    if (!s.alive || !s.conversation_file) continue
+    counts.set(s.conversation_file, (counts.get(s.conversation_file) ?? 0) + 1)
   }
   const dups = new Set<string>()
   for (const [file, n] of counts) if (n > 1) dups.add(file)
@@ -849,7 +849,7 @@ export function toUISession(s: ProtocolSession): Session {
     cwd: s.cwd ?? '',
     workspace_root: s.workspace_root ?? undefined,
     remotes: s.remotes ?? undefined,
-    kind: s.kind ?? 'shell',
+    adapter: s.adapter ?? 'shell',
     alive: s.alive,
     pid: s.pid ?? null,
     exit_code: s.exit_code ?? null,
@@ -860,7 +860,7 @@ export function toUISession(s: ProtocolSession): Session {
     status: s.status ?? null,
     unread: s.unread ?? false,
     resumable: s.resumable ?? false,
-    session_file: s.session_file ?? undefined,
+    conversation_file: s.conversation_file ?? undefined,
     last_activity_at: s.last_activity_at ?? undefined,
     socket_path: s.socket_path ?? '',
     terminal_cols: s.terminal_cols ?? undefined,

--- a/apps/gmux-web/src/test-helpers.ts
+++ b/apps/gmux-web/src/test-helpers.ts
@@ -4,7 +4,7 @@ export function makeSession(overrides: Partial<Session> & { id: string; cwd: str
   return {
     created_at: new Date().toISOString(),
     command: ['pi'],
-    kind: 'pi',
+    adapter: 'pi',
     alive: true,
     pid: 1234,
     exit_code: null,

--- a/apps/gmux-web/src/types.ts
+++ b/apps/gmux-web/src/types.ts
@@ -16,7 +16,7 @@ export interface Session {
   cwd: string
   workspace_root?: string
   remotes?: Record<string, string>
-  kind: string
+  adapter: string
   alive: boolean
   pid: number | null
   exit_code: number | null
@@ -41,10 +41,10 @@ export interface Session {
   slug?: string
   /**
    * Conversation file this runner authoritatively writes (session → file,
-   * ADR 0011). Two live sessions sharing a session_file means the same
+   * ADR 0011). Two live sessions sharing a conversation_file means the same
    * conversation is open in multiple tabs — surfaced as a warning.
    */
-  session_file?: string
+  conversation_file?: string
   /** Version string of the gmux runner binary that owns this session. */
   runner_version?: string
   /** SHA-256 of the gmux runner binary (first 8 chars useful for display). */

--- a/apps/website/src/content/docs/develop/session-schema.md
+++ b/apps/website/src/content/docs/develop/session-schema.md
@@ -100,7 +100,7 @@ Internal fields are inputs to derived fields. The API only exposes the derived o
 | `created_at` | ISO 8601 | When the session was created |
 | `command` | string[] | The command being run. For resumed sessions, replaced with the resume command. |
 | `cwd` | string | Working directory |
-| `kind` | string | Adapter kind: `"shell"`, `"claude"`, `"codex"`, `"pi"`, etc. |
+| `adapter` | string | Adapter name: `"shell"`, `"claude"`, `"codex"`, `"pi"`, etc. |
 | `workspace_root` | string? | Root of the workspace (jj/git), if detected. Used for folder grouping. |
 | `remotes` | map? | Git/jj remote URLs. Used for cross-machine folder grouping. |
 
@@ -198,7 +198,7 @@ As served by `GET /meta` on a runner's Unix socket (runner → gmuxd):
   "created_at": "2026-03-14T10:00:00Z",
   "command": ["pi"],
   "cwd": "/home/user/dev/gmux",
-  "kind": "pi",
+  "adapter": "pi",
   "alive": true,
   "pid": 12345,
   "started_at": "2026-03-14T10:00:01Z",
@@ -220,7 +220,7 @@ As served by `GET /v1/sessions` (gmuxd → frontend):
   "created_at": "2026-03-14T10:00:00Z",
   "command": ["pi"],
   "cwd": "/home/user/dev/gmux",
-  "kind": "pi",
+  "adapter": "pi",
   "alive": true,
   "pid": 12345,
   "started_at": "2026-03-14T10:00:01Z",

--- a/apps/website/src/content/docs/develop/state-management.md
+++ b/apps/website/src/content/docs/develop/state-management.md
@@ -30,7 +30,7 @@ Each field on a session has a single owner. No two subsystems write the same fie
 | Session appears (live) | **Register** | Runner calls `POST /v1/register` |
 | Session appears (from file) | **Scanner** | Periodic scan of adapter session directories |
 | Metadata updates | **Subscription** | Runner SSE `status` / `meta` events |
-| Held file + title + status | **Agent hook** | runner SSE `session_file` / `status` events |
+| Held file + title + status | **Agent hook** | runner SSE `conversation_file` / `status` events |
 | Session dies (clean exit) | **Subscription** | Runner SSE `exit` event |
 | Session dies (crash) | **Discovery Scan** | Socket file gone |
 | Session removed | **Dismiss handler** | User clicks × |

--- a/cli/gmux/cmd/gmux/actions.go
+++ b/cli/gmux/cmd/gmux/actions.go
@@ -19,7 +19,7 @@ type cliSession struct {
 	ID         string `json:"id"`
 	Peer       string `json:"peer,omitempty"`
 	Cwd        string `json:"cwd,omitempty"`
-	Kind       string `json:"kind"`
+	Kind       string `json:"adapter"`
 	Alive      bool   `json:"alive"`
 	Pid        int    `json:"pid,omitempty"`
 	Title      string `json:"title,omitempty"`
@@ -275,7 +275,7 @@ func cmdList(all bool, asJSON bool) int {
 	})
 
 	// Measure columns.
-	idW, statusW, kindW := len("ID"), len("STATUS"), len("KIND")
+	idW, statusW, adapterW := len("ID"), len("STATUS"), len("ADAPTER")
 	rows := make([][5]string, 0, len(sessions))
 	for _, s := range sessions {
 		status := "dead"
@@ -301,14 +301,14 @@ func cmdList(all bool, asJSON bool) int {
 		if n := len(row[1]); n > statusW {
 			statusW = n
 		}
-		if n := len(row[2]); n > kindW {
-			kindW = n
+		if n := len(row[2]); n > adapterW {
+			adapterW = n
 		}
 	}
 
-	fmt.Printf("%-*s  %-*s  %-*s  %s\n", idW, "ID", statusW, "STATUS", kindW, "KIND", "TITLE")
+	fmt.Printf("%-*s  %-*s  %-*s  %s\n", idW, "ID", statusW, "STATUS", adapterW, "ADAPTER", "TITLE")
 	for _, r := range rows {
-		line := fmt.Sprintf("%-*s  %-*s  %-*s  %s", idW, r[0], statusW, r[1], kindW, r[2], r[3])
+		line := fmt.Sprintf("%-*s  %-*s  %-*s  %s", idW, r[0], statusW, r[1], adapterW, r[2], r[3])
 		if r[4] != "" {
 			line += "  (" + r[4] + ")"
 		}

--- a/cli/gmux/internal/ptyserver/extension_test.go
+++ b/cli/gmux/internal/ptyserver/extension_test.go
@@ -102,10 +102,10 @@ func TestReconnectReplaysSessionFile(t *testing.T) {
 	sc := bufio.NewScanner(resp.Body)
 	for sc.Scan() {
 		if strings.Contains(sc.Text(), sessFile) {
-			return // success: session_file replayed
+			return // success: conversation_file replayed
 		}
 	}
-	t.Error("reconnecting subscriber did not receive replayed session_file")
+	t.Error("reconnecting subscriber did not receive replayed conversation_file")
 }
 func TestSessionEventIsAuthoritative(t *testing.T) {
 	node, err := exec.LookPath("node")

--- a/cli/gmux/internal/ptyserver/ptyserver.go
+++ b/cli/gmux/internal/ptyserver/ptyserver.go
@@ -725,7 +725,7 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 	// concurrent update may also arrive on ch; harmless (idempotent).
 	if file := s.state.SessionFileSnapshot(); file != "" {
 		if data, err := json.Marshal(map[string]string{"path": file}); err == nil {
-			fmt.Fprintf(w, "event: session_file\ndata: %s\n\n", data)
+			fmt.Fprintf(w, "event: conversation_file\ndata: %s\n\n", data)
 		}
 	}
 

--- a/cli/gmux/internal/session/state.go
+++ b/cli/gmux/internal/session/state.go
@@ -21,7 +21,9 @@ type State struct {
 	CreatedAt     string            `json:"created_at"`
 	Command       []string          `json:"command"`
 	Cwd           string            `json:"cwd"`
-	Kind          string            `json:"kind"`
+	// Kind holds the adapter name; wire key "adapter" (v2 rename), Go
+	// identifier rename trails with the internal cleanup.
+	Kind          string            `json:"adapter"`
 	WorkspaceRoot string            `json:"workspace_root,omitempty"`
 	Remotes       map[string]string `json:"remotes,omitempty"`
 
@@ -48,7 +50,7 @@ type State struct {
 	// reported authoritatively by the agent hook (ADR 0011). It is the
 	// immutable Tool ID's address; a change here is a rebind (/resume).
 	// Empty until the agent reports it, or for unhooked adapters.
-	SessionFile string `json:"session_file,omitempty"`
+	SessionFile string `json:"conversation_file,omitempty"`
 
 	// Terminal size (updated by the runner whenever PTY is resized).
 	TerminalCols uint16 `json:"terminal_cols,omitempty"`
@@ -221,7 +223,7 @@ func (s *State) SetSlug(slug string) {
 	s.emit(Event{Type: "meta", Data: map[string]string{"slug": slug}})
 }
 
-// SessionFileSnapshot returns the held session file, for replay to a
+// SessionFileSnapshot returns the held conversation file, for replay to a
 // newly-connected /events subscriber so a reconnecting daemon re-learns
 // attribution without persisted state.
 func (s *State) SessionFileSnapshot() string {
@@ -256,8 +258,8 @@ func (s *State) UnreadSnapshot() bool {
 	return s.Unread
 }
 
-// SetSessionFile records the agent's current session file as reported by
-// the extension. Emits a session_file event only when the path changes, so
+// SetSessionFile records the agent's current conversation file as reported by
+// the extension. Emits a conversation_file event only when the path changes, so
 // the daemon sees first-attribution and rebind (/resume) but not every write.
 func (s *State) SetSessionFile(path string) {
 	s.mu.Lock()
@@ -266,7 +268,7 @@ func (s *State) SetSessionFile(path string) {
 		return
 	}
 	s.SessionFile = path
-	s.emit(Event{Type: "session_file", Data: map[string]string{"path": path}})
+	s.emit(Event{Type: "conversation_file", Data: map[string]string{"path": path}})
 }
 
 // SetSubtitle updates the display subtitle.

--- a/docs/runner-hook-protocol.md
+++ b/docs/runner-hook-protocol.md
@@ -38,7 +38,9 @@ One JSON object per event, discriminated by `op`. Unknown ops/values are ignored
 
 ```jsonc
 // op "session" — authoritative bind. Sent on startup and on every rebind
-// (switch/new/resume/fork).
+// (switch/new/resume/fork). "session" here denotes the agent's own session
+// (its conversation) — the agent's language, per ADR 0015; gmux calls the
+// bound artifact a conversation file.
 {
   "op":     "session",
   "path":   "/abs/path/to/conversation-file",  // required
@@ -84,7 +86,7 @@ agent's concern.
 ## The runner does NOT, for hooked sessions
 
 Parse the conversation file, infer status from PTY/scrollback, apply per-adapter
-heuristics in `handleHookEvent`, or use the `session_file` snapshot for anything
+heuristics in `handleHookEvent`, or use the `conversation_file` snapshot for anything
 but `/events` replay.
 
 ## Implementing for a new agent

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -23,7 +23,7 @@ export interface FixtureSpec {
   /** Synthetic cwd for path encoding; must be unique within a test run. */
   cwd: string
   /** Session ID / UUID, used as filename. */
-  toolID: string
+  conversationID: string
   /**
    * Human-readable title. Drives slug derivation. Use clean
    * lowercase-with-spaces text so the slug is predictable.
@@ -63,12 +63,12 @@ function encodeClaudeCwd(cwd: string): string {
 
 function piFile(home: string, spec: FixtureSpec): string {
   const root = path.join(home, '.pi', 'agent', 'sessions')
-  return path.join(root, encodePiCwd(spec.cwd), `${spec.toolID}.jsonl`)
+  return path.join(root, encodePiCwd(spec.cwd), `${spec.conversationID}.jsonl`)
 }
 
 function claudeFile(home: string, spec: FixtureSpec): string {
   const root = path.join(home, '.claude', 'projects')
-  return path.join(root, encodeClaudeCwd(spec.cwd), `${spec.toolID}.jsonl`)
+  return path.join(root, encodeClaudeCwd(spec.cwd), `${spec.conversationID}.jsonl`)
 }
 
 function codexFile(home: string, spec: FixtureSpec): string {
@@ -84,7 +84,7 @@ function codexFile(home: string, spec: FixtureSpec): string {
   const yyyy = String(now.getFullYear())
   const mm = String(now.getMonth() + 1).padStart(2, '0')
   const dd = String(now.getDate()).padStart(2, '0')
-  return path.join(root, yyyy, mm, dd, `${spec.toolID}.jsonl`)
+  return path.join(root, yyyy, mm, dd, `${spec.conversationID}.jsonl`)
 }
 
 function piContent(spec: FixtureSpec): string {
@@ -93,7 +93,7 @@ function piContent(spec: FixtureSpec): string {
   // (so `MessageCount > 0` and the conversation passes `CanResume`).
   const header = JSON.stringify({
     type: 'session',
-    id: spec.toolID,
+    id: spec.conversationID,
     cwd: spec.cwd,
     timestamp: ts,
   })
@@ -114,7 +114,7 @@ function claudeContent(spec: FixtureSpec): string {
   // we use a user message so the title round-trip is observable.
   const userLine = JSON.stringify({
     type: 'user',
-    sessionId: spec.toolID,
+    sessionId: spec.conversationID,
     cwd: spec.cwd,
     timestamp: ts,
     message: { role: 'user', content: spec.title },
@@ -128,7 +128,7 @@ function codexContent(spec: FixtureSpec): string {
   // first-user-text (codex has no custom-title mechanism).
   const meta = JSON.stringify({
     type: 'session_meta',
-    payload: { id: spec.toolID, timestamp: ts, cwd: spec.cwd },
+    payload: { id: spec.conversationID, timestamp: ts, cwd: spec.cwd },
   })
   const userMsg = JSON.stringify({
     type: 'response_item',
@@ -180,7 +180,7 @@ export function appendToSession(filePath: string, jsonLine: object): void {
  * Pre-seeded smoke fixtures, written by global-setup before gmuxd
  * starts. Each tests the bootstrap scan path through a real parser.
  *
- * These slugs and toolIDs are referenced from the smoke spec, so the
+ * These slugs and conversationIDs are referenced from the smoke spec, so the
  * spec asserts the same fixtures global-setup wrote without
  * re-deriving them.
  */
@@ -188,19 +188,19 @@ export const SMOKE_FIXTURES: FixtureSpec[] = [
   {
     kind: 'pi',
     cwd: '/var/gmux-e2e/smoke-pi',
-    toolID: '00000000-0000-0000-0000-0000000000a1',
+    conversationID: '00000000-0000-0000-0000-0000000000a1',
     title: 'pi smoke fixture',
   },
   {
     kind: 'claude',
     cwd: '/var/gmux-e2e/smoke-claude',
-    toolID: '00000000-0000-0000-0000-0000000000a2',
+    conversationID: '00000000-0000-0000-0000-0000000000a2',
     title: 'claude smoke fixture',
   },
   {
     kind: 'codex',
     cwd: '/var/gmux-e2e/smoke-codex',
-    toolID: '00000000-0000-0000-0000-0000000000a3',
+    conversationID: '00000000-0000-0000-0000-0000000000a3',
     title: 'codex smoke fixture',
   },
 ]

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -16,10 +16,10 @@
 import * as fs from 'node:fs'
 import * as path from 'node:path'
 
-export type AdapterKind = 'pi' | 'claude' | 'codex'
+export type AdapterName = 'pi' | 'claude' | 'codex'
 
 export interface FixtureSpec {
-  kind: AdapterKind
+  adapter: AdapterName
   /** Synthetic cwd for path encoding; must be unique within a test run. */
   cwd: string
   /** Session ID / UUID, used as filename. */
@@ -145,7 +145,7 @@ function codexContent(spec: FixtureSpec): string {
 export function writeFakeSession(home: string, spec: FixtureSpec): FixtureResult {
   let filePath: string
   let content: string
-  switch (spec.kind) {
+  switch (spec.adapter) {
     case 'pi':
       filePath = piFile(home, spec)
       content = piContent(spec)
@@ -186,19 +186,19 @@ export function appendToSession(filePath: string, jsonLine: object): void {
  */
 export const SMOKE_FIXTURES: FixtureSpec[] = [
   {
-    kind: 'pi',
+    adapter: 'pi',
     cwd: '/var/gmux-e2e/smoke-pi',
     conversationID: '00000000-0000-0000-0000-0000000000a1',
     title: 'pi smoke fixture',
   },
   {
-    kind: 'claude',
+    adapter: 'claude',
     cwd: '/var/gmux-e2e/smoke-claude',
     conversationID: '00000000-0000-0000-0000-0000000000a2',
     title: 'claude smoke fixture',
   },
   {
-    kind: 'codex',
+    adapter: 'codex',
     cwd: '/var/gmux-e2e/smoke-codex',
     conversationID: '00000000-0000-0000-0000-0000000000a3',
     title: 'codex smoke fixture',

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -144,7 +144,7 @@ export default async function globalSetup(_config: FullConfig) {
 
   // Pre-seed smoke fixtures (one valid JSONL per adapter) before
   // gmuxd starts. The bootstrap scan picks them up and the smoke spec
-  // asserts they're reachable at /v1/conversations/{kind}/{slug}. If a
+  // asserts they're reachable at /v1/conversations/{adapter}/{slug}. If a
   // fixture is invalid for its parser, the smoke spec fails first with
   // a clear "fixture didn't reach the index" signal, before the
   // discovery spec's tests run.

--- a/e2e/tests/conversation-discovery.spec.ts
+++ b/e2e/tests/conversation-discovery.spec.ts
@@ -69,7 +69,7 @@ function uniqueFixture(kind: AdapterKind, label: string): FixtureSpec {
   return {
     kind,
     cwd: `/var/gmux-e2e/discovery/${tag}`,
-    toolID: `disc-${tag}`,
+    conversationID: `disc-${tag}`,
     title: `${kind} discovery ${tag}`,
   }
 }

--- a/e2e/tests/conversation-discovery.spec.ts
+++ b/e2e/tests/conversation-discovery.spec.ts
@@ -3,7 +3,7 @@ import * as fs from 'node:fs'
 import * as path from 'node:path'
 import { apiGet, pollUntil } from '../helpers'
 import {
-  type AdapterKind,
+  type AdapterName,
   type FixtureSpec,
   appendToSession,
   writeFakeSession,
@@ -27,7 +27,7 @@ import {
  */
 
 interface ConvBody {
-  data: { kind: string; title: string; cwd: string; slug: string }
+  data: { adapter: string; title: string; cwd: string; slug: string }
 }
 
 const TEST_HOME = (): string => {
@@ -36,26 +36,26 @@ const TEST_HOME = (): string => {
   return home
 }
 
-/** Poll /v1/conversations/{kind}/{slug} until it returns 200, or timeout. */
-async function awaitIndexed(kind: AdapterKind, slug: string, timeoutMs = 2_000): Promise<ConvBody['data']> {
+/** Poll /v1/conversations/{adapter}/{slug} until it returns 200, or timeout. */
+async function awaitIndexed(adapter: AdapterName, slug: string, timeoutMs = 2_000): Promise<ConvBody['data']> {
   return pollUntil(
     async () => {
-      const { status, body } = await apiGet<ConvBody>(`/v1/conversations/${kind}/${slug}`)
+      const { status, body } = await apiGet<ConvBody>(`/v1/conversations/${adapter}/${slug}`)
       if (status !== 200) return null
       return body.data
     },
-    { timeoutMs, description: `${kind}/${slug} reachable via API` },
+    { timeoutMs, description: `${adapter}/${slug} reachable via API` },
   )
 }
 
-/** Poll until /v1/conversations/{kind}/{slug} returns 404, or timeout. */
-async function awaitRemoved(kind: AdapterKind, slug: string, timeoutMs = 2_000): Promise<void> {
+/** Poll until /v1/conversations/{adapter}/{slug} returns 404, or timeout. */
+async function awaitRemoved(adapter: AdapterName, slug: string, timeoutMs = 2_000): Promise<void> {
   await pollUntil(
     async () => {
-      const { status } = await apiGet<unknown>(`/v1/conversations/${kind}/${slug}`)
+      const { status } = await apiGet<unknown>(`/v1/conversations/${adapter}/${slug}`)
       return status === 404 ? true : null
     },
-    { timeoutMs, description: `${kind}/${slug} removed from API` },
+    { timeoutMs, description: `${adapter}/${slug} removed from API` },
   )
 }
 
@@ -64,13 +64,13 @@ async function awaitRemoved(kind: AdapterKind, slug: string, timeoutMs = 2_000):
  * name + a random suffix so concurrent tests (or repeat runs) don't
  * collide on slug/path.
  */
-function uniqueFixture(kind: AdapterKind, label: string): FixtureSpec {
+function uniqueFixture(adapter: AdapterName, label: string): FixtureSpec {
   const tag = `${label}-${Math.random().toString(36).slice(2, 10)}`
   return {
-    kind,
+    adapter,
     cwd: `/var/gmux-e2e/discovery/${tag}`,
     conversationID: `disc-${tag}`,
-    title: `${kind} discovery ${tag}`,
+    title: `${adapter} discovery ${tag}`,
   }
 }
 
@@ -86,14 +86,14 @@ test.describe('conversation discovery (watcher-driven)', () => {
     }
   })
 
-  for (const kind of ['pi', 'claude', 'codex'] as const) {
-    test(`${kind}: write session file -> reachable in API within 2s`, async () => {
-      const spec = uniqueFixture(kind, 'create')
+  for (const adapter of ['pi', 'claude', 'codex'] as const) {
+    test(`${adapter}: write session file -> reachable in API within 2s`, async () => {
+      const spec = uniqueFixture(adapter, 'create')
       const { filePath, expectedSlug } = writeFakeSession(TEST_HOME(), spec)
       filesCreated.push(filePath)
 
-      const result = await awaitIndexed(kind, expectedSlug)
-      expect(result.kind).toBe(kind)
+      const result = await awaitIndexed(adapter, expectedSlug)
+      expect(result.adapter).toBe(adapter)
       expect(result.title).toBe(spec.title)
       expect(result.cwd).toBe(spec.cwd)
       expect(result.slug).toBe(expectedSlug)

--- a/e2e/tests/conversation-fixtures.spec.ts
+++ b/e2e/tests/conversation-fixtures.spec.ts
@@ -4,7 +4,7 @@ import { SMOKE_FIXTURES, slugify } from '../fixtures'
 
 /**
  * Smoke spec: pre-seeded fixtures (written by global-setup before gmuxd
- * starts) must be reachable at /v1/conversations/{kind}/{slug} once the
+ * starts) must be reachable at /v1/conversations/{adapter}/{slug} once the
  * bootstrap scan completes.
  *
  * Purpose: detect drift between the TS fixtures in `e2e/fixtures.ts`
@@ -20,9 +20,9 @@ import { SMOKE_FIXTURES, slugify } from '../fixtures'
  */
 test.describe('conversation fixtures (bootstrap scan)', () => {
   // Each smoke fixture rendered as one parameterized test, so a
-  // failure names the offending kind directly.
+  // failure names the offending adapter directly.
   for (const fixture of SMOKE_FIXTURES) {
-    test(`${fixture.kind}: pre-seeded fixture reachable via API`, async () => {
+    test(`${fixture.adapter}: pre-seeded fixture reachable via API`, async () => {
       const expectedSlug = slugify(fixture.title)
       // Bootstrap is one-shot at daemon start, but we still poll: the
       // first test in the run might race the daemon's `Scan()` call,
@@ -30,19 +30,19 @@ test.describe('conversation fixtures (bootstrap scan)', () => {
       // of milliseconds.
       const result = await pollUntil(
         async () => {
-          const { status, body } = await apiGet<{ data: { kind: string; title: string; cwd: string } }>(
-            `/v1/conversations/${fixture.kind}/${expectedSlug}`,
+          const { status, body } = await apiGet<{ data: { adapter: string; title: string; cwd: string } }>(
+            `/v1/conversations/${fixture.adapter}/${expectedSlug}`,
           )
           if (status !== 200) return null
           return body.data
         },
         {
           timeoutMs: 5_000,
-          description: `fixture ${fixture.kind}/${expectedSlug} reachable via API`,
+          description: `fixture ${fixture.adapter}/${expectedSlug} reachable via API`,
         },
       )
 
-      expect(result.kind).toBe(fixture.kind)
+      expect(result.adapter).toBe(fixture.adapter)
       expect(result.title).toBe(fixture.title)
       expect(result.cwd).toBe(fixture.cwd)
     })

--- a/e2e/tests/harness.spec.ts
+++ b/e2e/tests/harness.spec.ts
@@ -47,14 +47,14 @@ test.describe('harness isolation', () => {
     const resp = await fetch(`http://127.0.0.1:${port()}/v1/sessions`, { headers: headers() })
     expect(resp.ok).toBe(true)
     const body = await resp.json() as {
-      data: Array<{ id: string; alive: boolean; cwd: string; kind: string }>
+      data: Array<{ id: string; alive: boolean; cwd: string; adapter: string }>
     }
     const alive = body.data.filter(s => s.alive)
     expect(alive).toHaveLength(1)
 
     const ours = alive[0]
     expect(ours.id).toBe(sessionId())
-    expect(ours.kind).toBe('shell')
+    expect(ours.adapter).toBe('shell')
     // The session was spawned with cwd=$tmpDir/workspace; we don't
     // pin the exact path (it's per-run) but it must end in
     // /workspace and live under the OS temp dir.

--- a/packages/adapter/adapters/testutil/harness.go
+++ b/packages/adapter/adapters/testutil/harness.go
@@ -27,7 +27,7 @@ import (
 // Session mirrors the gmuxd session schema fields we care about.
 type Session struct {
 	ID           string   `json:"id"`
-	Kind         string   `json:"kind"`
+	Kind         string   `json:"adapter"`
 	Alive        bool     `json:"alive"`
 	Pid          int      `json:"pid"`
 	Title        string   `json:"title"`

--- a/packages/protocol/src/session.ts
+++ b/packages/protocol/src/session.ts
@@ -15,7 +15,7 @@ export const SessionSchema = z.object({
   cwd: z.string().optional(),
   workspace_root: z.string().optional(),
   remotes: z.record(z.string()).optional(),
-  kind: z.string().default('shell'),
+  adapter: z.string().default('shell'),
   alive: z.boolean(),
   pid: z.number().optional().nullable(),
   exit_code: z.number().optional().nullable(),
@@ -28,9 +28,9 @@ export const SessionSchema = z.object({
   resumable: z.boolean().optional().default(false),
   // Absolute path of the agent conversation file this session holds, as
   // reported by the agent hook (ADR 0011). Two live sessions sharing one
-  // session_file means the same conversation is open in multiple tabs; the UI
-  // surfaces that as an "open elsewhere" warning.
-  session_file: z.string().optional(),
+  // conversation_file means the same conversation is open in multiple tabs;
+  // the UI surfaces that as an "open elsewhere" warning.
+  conversation_file: z.string().optional(),
   // RFC3339 timestamp of the most recent noteworthy state transition
   // (exited, unread on, working on, error on). Set by the owning
   // daemon; the UI uses it to populate the "Recent" section on the

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -1243,12 +1243,12 @@ func serve(stderr io.Writer) int {
 		writeJSON(w, map[string]any{"ok": true, "data": sessions.List()})
 	})
 
-	// Conversation lookup — resolve dead conversations by (kind, slug)
+	// Conversation lookup — resolve dead conversations by (adapter, slug)
 	// for URL resolution. Returns file metadata + resume command.
-	mux.HandleFunc("GET /v1/conversations/{kind}/{slug}", func(w http.ResponseWriter, r *http.Request) {
-		kind := r.PathValue("kind")
+	mux.HandleFunc("GET /v1/conversations/{adapter}/{slug}", func(w http.ResponseWriter, r *http.Request) {
+		adapterName := r.PathValue("adapter")
 		slug := r.PathValue("slug")
-		info, ok := convIndex.Lookup(kind, slug)
+		info, ok := convIndex.Lookup(adapterName, slug)
 		if !ok {
 			writeError(w, http.StatusNotFound, "not_found", "conversation not found")
 			return
@@ -1257,7 +1257,7 @@ func serve(stderr io.Writer) int {
 			"ok": true,
 			"data": map[string]any{
 				"slug":           info.Slug,
-				"kind":           info.Kind,
+				"adapter":        info.Kind,
 				"title":          info.Title,
 				"cwd":            info.Cwd,
 				"resume_command": info.ResumeCommand,

--- a/services/gmuxd/cmd/gmuxd/rehydrate.go
+++ b/services/gmuxd/cmd/gmuxd/rehydrate.go
@@ -22,14 +22,14 @@ import (
 //
 // Two skip checks, in priority order:
 //
-//  1. Same instance ID present (sessions.Get(info.ToolID)). This is
+//  1. Same instance ID present (sessions.Get(info.ConversationID)). This is
 //     the steady-state for shell sessions, where the runner ID and
-//     the conversations-index ToolID are the same string.
+//     the conversations-index ConversationID are the same string.
 //
 //  2. Same (kind, slug) present (sessions.HasLocalSlug). This is
-//     critical for tool-backed adapters (pi, claude, codex) where
+//     critical for agent-backed adapters (pi, claude, codex) where
 //     the conversations index uses the adapter's own UUID (e.g. the
-//     JSONL filename) as ToolID, while sessionmeta keys by the
+//     JSONL filename) as ConversationID, while sessionmeta keys by the
 //     runner-generated session ID. Without this check, a single
 //     pi/claude session restored from sessionmeta would gain a
 //     parallel ghost entry from convIndex, surfacing as a duplicate
@@ -51,7 +51,7 @@ func rehydrateProjects(sessions *store.Store, convIndex *conversations.Index, st
 				// orphan-cleanup pass below removes the latter.
 				continue
 			}
-			if _, exists := sessions.Get(info.ToolID); exists {
+			if _, exists := sessions.Get(info.ConversationID); exists {
 				continue
 			}
 			if sessions.HasLocalSlug(info.Kind, info.Slug) {
@@ -59,7 +59,7 @@ func rehydrateProjects(sessions *store.Store, convIndex *conversations.Index, st
 			}
 			fallbacks++
 			sessions.Upsert(store.Session{
-				ID:           info.ToolID,
+				ID:           info.ConversationID,
 				CreatedAt:    info.Created.UTC().Format(time.RFC3339),
 				Command:      info.ResumeCommand,
 				Cwd:          info.Cwd,

--- a/services/gmuxd/cmd/gmuxd/rehydrate_test.go
+++ b/services/gmuxd/cmd/gmuxd/rehydrate_test.go
@@ -47,12 +47,12 @@ func TestRehydrateProjects_PreservesSessionmetaState(t *testing.T) {
 	// clobber Title to the generic kind label.
 	idx := conversations.New()
 	idx.Upsert(conversations.Info{
-		ToolID:  "tool-abc",
-		Slug:    "fix-auth",
-		Kind:    "shell",
-		Title:   "shell", // becomes AdapterTitle on rehydrate
-		Cwd:     "/home/me/proj",
-		Created: time.Date(2024, 1, 1, 11, 0, 0, 0, time.UTC),
+		ConversationID: "tool-abc",
+		Slug:           "fix-auth",
+		Kind:           "shell",
+		Title:          "shell", // becomes AdapterTitle on rehydrate
+		Cwd:            "/home/me/proj",
+		Created:        time.Date(2024, 1, 1, 11, 0, 0, 0, time.UTC),
 	})
 
 	state := &projects.State{
@@ -103,16 +103,16 @@ func TestRehydrateProjects_PreventsDuplicateForToolBackedAdapter(t *testing.T) {
 		Alive: false,
 	})
 
-	// convIndex entry: same logical session, but ToolID is the JSONL
+	// convIndex entry: same logical session, but ConversationID is the JSONL
 	// UUID, which is a different string from the runner ID.
 	idx := conversations.New()
 	idx.Upsert(conversations.Info{
-		ToolID:  "jsonl-uuid-XYZ",
-		Slug:    "fix-auth",
-		Kind:    "pi",
-		Title:   "fix auth",
-		Cwd:     "/work",
-		Created: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+		ConversationID: "jsonl-uuid-XYZ",
+		Slug:           "fix-auth",
+		Kind:           "pi",
+		Title:          "fix auth",
+		Cwd:            "/work",
+		Created:        time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
 	})
 
 	state := &projects.State{
@@ -144,13 +144,13 @@ func TestRehydrateProjects_FallbackForMissingSessionmeta(t *testing.T) {
 
 	idx := conversations.New()
 	idx.Upsert(conversations.Info{
-		ToolID:        "tool-old",
-		Slug:          "legacy",
-		Kind:          "shell",
-		Title:         "shell",
-		Cwd:           "/home/me/legacy",
-		Created:       time.Date(2023, 6, 1, 0, 0, 0, 0, time.UTC),
-		ResumeCommand: []string{"bash"},
+		ConversationID: "tool-old",
+		Slug:           "legacy",
+		Kind:           "shell",
+		Title:          "shell",
+		Cwd:            "/home/me/legacy",
+		Created:        time.Date(2023, 6, 1, 0, 0, 0, 0, time.UTC),
+		ResumeCommand:  []string{"bash"},
 	})
 
 	state := &projects.State{

--- a/services/gmuxd/internal/conversations/index.go
+++ b/services/gmuxd/internal/conversations/index.go
@@ -18,14 +18,14 @@ import (
 
 // Info holds metadata for a single conversation file.
 type Info struct {
-	ToolID        string    // full UUID from the session file header
-	Slug          string    // human-readable URL identifier, unique within (kind)
-	Kind          string    // adapter name (claude, codex, pi, shell)
-	Title         string    // display title
-	Cwd           string    // working directory
-	FilePath      string    // absolute path to the session file
-	ResumeCommand []string  // command to resume this conversation
-	Created       time.Time // when the conversation started
+	ConversationID string    // full UUID from the session file header
+	Slug           string    // human-readable URL identifier, unique within (kind)
+	Kind           string    // adapter name (claude, codex, pi, shell)
+	Title          string    // display title
+	Cwd            string    // working directory
+	FilePath       string    // absolute path to the session file
+	ResumeCommand  []string  // command to resume this conversation
+	Created        time.Time // when the conversation started
 }
 
 // Index is a concurrency-safe lookup table for conversation files.
@@ -36,16 +36,16 @@ type Index struct {
 	mu sync.RWMutex
 	// byKey maps "kind/slug" → Info.
 	byKey map[string]Info
-	// byToolID maps "kind/toolID" → slug for reverse lookup
-	// (e.g., finding a conversation's slug from its tool UUID).
-	byToolID map[string]string
+	// byConversationID maps "kind/conversationID" → slug for reverse lookup
+	// (e.g., finding a conversation's slug from the agent's conversation UUID).
+	byConversationID map[string]string
 }
 
 // New creates an empty index.
 func New() *Index {
 	return &Index{
-		byKey:    make(map[string]Info),
-		byToolID: make(map[string]string),
+		byKey:            make(map[string]Info),
+		byConversationID: make(map[string]string),
 	}
 }
 
@@ -53,8 +53,8 @@ func indexKey(kind, slug string) string {
 	return kind + "/" + slug
 }
 
-func toolKey(kind, toolID string) string {
-	return kind + "/" + toolID
+func convKey(kind, conversationID string) string {
+	return kind + "/" + conversationID
 }
 
 // Lookup returns the conversation info for a (kind, slug) pair.
@@ -66,25 +66,25 @@ func (idx *Index) Lookup(kind, slug string) (Info, bool) {
 	return info, ok
 }
 
-// LookupByToolID returns the slug for a conversation identified by
-// its adapter-level tool ID. Returns empty string if unknown.
-func (idx *Index) LookupByToolID(kind, toolID string) string {
+// LookupByConversationID returns the slug for a conversation identified by
+// its agent-native conversation ID. Returns empty string if unknown.
+func (idx *Index) LookupByConversationID(kind, conversationID string) string {
 	idx.mu.RLock()
 	defer idx.mu.RUnlock()
-	return idx.byToolID[toolKey(kind, toolID)]
+	return idx.byConversationID[convKey(kind, conversationID)]
 }
 
 // Upsert adds or updates a conversation in the index. If the slug
 // collides with an existing entry of the same kind (but different
-// tool ID), a -2, -3, ... suffix is appended. Returns the final
+// conversation ID), a -2, -3, ... suffix is appended. Returns the final
 // (possibly suffixed) slug.
 func (idx *Index) Upsert(info Info) string {
 	idx.mu.Lock()
 	defer idx.mu.Unlock()
 
-	// If this tool ID already has a slug, update in place.
-	tk := toolKey(info.Kind, info.ToolID)
-	if existing, ok := idx.byToolID[tk]; ok {
+	// If this conversation ID already has a slug, update in place.
+	tk := convKey(info.Kind, info.ConversationID)
+	if existing, ok := idx.byConversationID[tk]; ok {
 		ik := indexKey(info.Kind, existing)
 		info.Slug = existing
 		idx.byKey[ik] = info
@@ -92,22 +92,22 @@ func (idx *Index) Upsert(info Info) string {
 	}
 
 	// Assign a unique slug.
-	info.Slug = idx.uniqueSlugLocked(info.Kind, info.Slug, info.ToolID)
+	info.Slug = idx.uniqueSlugLocked(info.Kind, info.Slug, info.ConversationID)
 	ik := indexKey(info.Kind, info.Slug)
 	idx.byKey[ik] = info
-	idx.byToolID[tk] = info.Slug
+	idx.byConversationID[tk] = info.Slug
 	return info.Slug
 }
 
 // uniqueSlugLocked returns a slug that doesn't collide within the
 // given kind. Appends -2, -3, ... on collision. Must be called with
 // idx.mu held.
-func (idx *Index) uniqueSlugLocked(kind, slug, toolID string) string {
+func (idx *Index) uniqueSlugLocked(kind, slug, conversationID string) string {
 	base := slug
 	for i := 2; ; i++ {
 		ik := indexKey(kind, slug)
 		existing, occupied := idx.byKey[ik]
-		if !occupied || existing.ToolID == toolID {
+		if !occupied || existing.ConversationID == conversationID {
 			return slug
 		}
 		slug = base + "-" + strconv.Itoa(i)
@@ -163,36 +163,36 @@ func (idx *Index) ScanFile(a adapter.Adapter, path string) string {
 	}
 
 	info := Info{
-		ToolID:        fileInfo.ID,
-		Slug:          slug,
-		Kind:          a.Name(),
-		Title:         fileInfo.Title,
-		Cwd:           fileInfo.Cwd,
-		FilePath:      path,
-		ResumeCommand: cmd,
-		Created:       fileInfo.Created,
+		ConversationID: fileInfo.ID,
+		Slug:           slug,
+		Kind:           a.Name(),
+		Title:          fileInfo.Title,
+		Cwd:            fileInfo.Cwd,
+		FilePath:       path,
+		ResumeCommand:  cmd,
+		Created:        fileInfo.Created,
 	}
 	return idx.Upsert(info)
 }
 
-// Remove deletes a conversation from the index by tool ID.
+// Remove deletes a conversation from the index by conversation ID.
 // Returns true if it was present.
-func (idx *Index) Remove(kind, toolID string) bool {
+func (idx *Index) Remove(kind, conversationID string) bool {
 	idx.mu.Lock()
 	defer idx.mu.Unlock()
-	tk := toolKey(kind, toolID)
-	slug, ok := idx.byToolID[tk]
+	tk := convKey(kind, conversationID)
+	slug, ok := idx.byConversationID[tk]
 	if !ok {
 		return false
 	}
-	delete(idx.byToolID, tk)
+	delete(idx.byConversationID, tk)
 	delete(idx.byKey, indexKey(kind, slug))
 	return true
 }
 
 // RemoveByPath deletes any conversation whose FilePath matches path.
 // Used when a ConversationSource observes a deletion event and we don't have the
-// (kind, toolID) handy. Linear walk over the index; that's fine
+// (kind, conversationID) handy. Linear walk over the index; that's fine
 // because Remove events are rare (manual `rm`, file rotation) and
 // the index size stays in the hundreds-to-low-thousands range.
 // Returns true if an entry was removed.
@@ -209,7 +209,7 @@ func (idx *Index) RemoveByPath(path string) bool {
 			continue
 		}
 		delete(idx.byKey, key)
-		delete(idx.byToolID, toolKey(info.Kind, info.ToolID))
+		delete(idx.byConversationID, convKey(info.Kind, info.ConversationID))
 		return true
 	}
 	return false

--- a/services/gmuxd/internal/conversations/index_test.go
+++ b/services/gmuxd/internal/conversations/index_test.go
@@ -16,10 +16,10 @@ func TestLookup_Empty(t *testing.T) {
 func TestUpsert_BasicLookup(t *testing.T) {
 	idx := New()
 	slug := idx.Upsert(Info{
-		ToolID: "abc-123",
-		Slug:   "fix-auth",
-		Kind:   "pi",
-		Title:  "fix auth bug",
+		ConversationID: "abc-123",
+		Slug:           "fix-auth",
+		Kind:           "pi",
+		Title:          "fix auth bug",
 	})
 	if slug != "fix-auth" {
 		t.Fatalf("expected slug fix-auth, got %q", slug)
@@ -39,16 +39,16 @@ func TestUpsert_BasicLookup(t *testing.T) {
 func TestUpsert_UpdateInPlace(t *testing.T) {
 	idx := New()
 	idx.Upsert(Info{
-		ToolID: "abc-123",
-		Slug:   "fix-auth",
-		Kind:   "pi",
-		Title:  "old title",
+		ConversationID: "abc-123",
+		Slug:           "fix-auth",
+		Kind:           "pi",
+		Title:          "old title",
 	})
 	idx.Upsert(Info{
-		ToolID: "abc-123",
-		Slug:   "fix-auth",
-		Kind:   "pi",
-		Title:  "new title",
+		ConversationID: "abc-123",
+		Slug:           "fix-auth",
+		Kind:           "pi",
+		Title:          "new title",
 	})
 	if idx.Count() != 1 {
 		t.Fatalf("expected count 1, got %d", idx.Count())
@@ -61,9 +61,9 @@ func TestUpsert_UpdateInPlace(t *testing.T) {
 
 func TestUpsert_SlugCollision(t *testing.T) {
 	idx := New()
-	s1 := idx.Upsert(Info{ToolID: "aaa", Slug: "say-hi", Kind: "claude"})
-	s2 := idx.Upsert(Info{ToolID: "bbb", Slug: "say-hi", Kind: "claude"})
-	s3 := idx.Upsert(Info{ToolID: "ccc", Slug: "say-hi", Kind: "claude"})
+	s1 := idx.Upsert(Info{ConversationID: "aaa", Slug: "say-hi", Kind: "claude"})
+	s2 := idx.Upsert(Info{ConversationID: "bbb", Slug: "say-hi", Kind: "claude"})
+	s3 := idx.Upsert(Info{ConversationID: "ccc", Slug: "say-hi", Kind: "claude"})
 
 	if s1 != "say-hi" {
 		t.Errorf("first should be unsuffixed, got %q", s1)
@@ -81,8 +81,8 @@ func TestUpsert_SlugCollision(t *testing.T) {
 
 func TestUpsert_SlugCollisionAcrossKinds(t *testing.T) {
 	idx := New()
-	s1 := idx.Upsert(Info{ToolID: "aaa", Slug: "fix-auth", Kind: "pi"})
-	s2 := idx.Upsert(Info{ToolID: "bbb", Slug: "fix-auth", Kind: "claude"})
+	s1 := idx.Upsert(Info{ConversationID: "aaa", Slug: "fix-auth", Kind: "pi"})
+	s2 := idx.Upsert(Info{ConversationID: "bbb", Slug: "fix-auth", Kind: "claude"})
 
 	// Different kinds should not collide.
 	if s1 != "fix-auth" || s2 != "fix-auth" {
@@ -92,27 +92,27 @@ func TestUpsert_SlugCollisionAcrossKinds(t *testing.T) {
 
 func TestUpsert_UpdatePreservesSlug(t *testing.T) {
 	idx := New()
-	idx.Upsert(Info{ToolID: "aaa", Slug: "say-hi", Kind: "claude"})
-	idx.Upsert(Info{ToolID: "bbb", Slug: "say-hi", Kind: "claude"})
+	idx.Upsert(Info{ConversationID: "aaa", Slug: "say-hi", Kind: "claude"})
+	idx.Upsert(Info{ConversationID: "bbb", Slug: "say-hi", Kind: "claude"})
 
 	// Update the second one with a different base slug (e.g., title changed).
 	// It should keep its assigned slug "say-hi-2", not get a new one.
-	s := idx.Upsert(Info{ToolID: "bbb", Slug: "hello", Kind: "claude", Title: "updated"})
+	s := idx.Upsert(Info{ConversationID: "bbb", Slug: "hello", Kind: "claude", Title: "updated"})
 	if s != "say-hi-2" {
 		t.Errorf("update should preserve assigned slug, got %q", s)
 	}
 }
 
-func TestLookupByToolID(t *testing.T) {
+func TestLookupByConversationID(t *testing.T) {
 	idx := New()
-	idx.Upsert(Info{ToolID: "abc-123", Slug: "fix-auth", Kind: "pi"})
+	idx.Upsert(Info{ConversationID: "abc-123", Slug: "fix-auth", Kind: "pi"})
 
-	slug := idx.LookupByToolID("pi", "abc-123")
+	slug := idx.LookupByConversationID("pi", "abc-123")
 	if slug != "fix-auth" {
 		t.Errorf("expected fix-auth, got %q", slug)
 	}
 
-	slug = idx.LookupByToolID("pi", "unknown")
+	slug = idx.LookupByConversationID("pi", "unknown")
 	if slug != "" {
 		t.Errorf("expected empty for unknown, got %q", slug)
 	}
@@ -120,7 +120,7 @@ func TestLookupByToolID(t *testing.T) {
 
 func TestRemove(t *testing.T) {
 	idx := New()
-	idx.Upsert(Info{ToolID: "abc-123", Slug: "fix-auth", Kind: "pi"})
+	idx.Upsert(Info{ConversationID: "abc-123", Slug: "fix-auth", Kind: "pi"})
 
 	if !idx.Remove("pi", "abc-123") {
 		t.Error("expected remove to return true")
@@ -138,9 +138,9 @@ func TestRemove(t *testing.T) {
 
 func TestRemoveByPath(t *testing.T) {
 	idx := New()
-	idx.Upsert(Info{ToolID: "a", Slug: "one", Kind: "pi", FilePath: "/x/a.jsonl"})
-	idx.Upsert(Info{ToolID: "b", Slug: "two", Kind: "pi", FilePath: "/x/b.jsonl"})
-	idx.Upsert(Info{ToolID: "c", Slug: "three", Kind: "claude", FilePath: "/y/c.jsonl"})
+	idx.Upsert(Info{ConversationID: "a", Slug: "one", Kind: "pi", FilePath: "/x/a.jsonl"})
+	idx.Upsert(Info{ConversationID: "b", Slug: "two", Kind: "pi", FilePath: "/x/b.jsonl"})
+	idx.Upsert(Info{ConversationID: "c", Slug: "three", Kind: "claude", FilePath: "/y/c.jsonl"})
 
 	if !idx.RemoveByPath("/x/b.jsonl") {
 		t.Fatal("expected RemoveByPath to return true for indexed path")
@@ -159,12 +159,12 @@ func TestRemoveByPath(t *testing.T) {
 	if _, ok := idx.Lookup("claude", "three"); !ok {
 		t.Error("cross-kind entry was incorrectly removed")
 	}
-	// Reverse-lookup (byToolID) cleared too: Upserting the same toolID
+	// Reverse-lookup (byConversationID) cleared too: Upserting the same conversationID
 	// at a new slug should yield the new slug, not update-in-place at
 	// the old one.
-	slug := idx.Upsert(Info{ToolID: "b", Slug: "different", Kind: "pi", FilePath: "/x/b2.jsonl"})
+	slug := idx.Upsert(Info{ConversationID: "b", Slug: "different", Kind: "pi", FilePath: "/x/b2.jsonl"})
 	if slug != "different" {
-		t.Errorf("expected fresh slug 'different' (byToolID was cleared), got %q", slug)
+		t.Errorf("expected fresh slug 'different' (byConversationID was cleared), got %q", slug)
 	}
 	if idx.RemoveByPath("/x/nope.jsonl") {
 		t.Error("expected RemoveByPath to return false for unknown path")
@@ -173,7 +173,7 @@ func TestRemoveByPath(t *testing.T) {
 
 func TestSlugExists(t *testing.T) {
 	idx := New()
-	idx.Upsert(Info{ToolID: "abc", Slug: "fix-auth", Kind: "pi"})
+	idx.Upsert(Info{ConversationID: "abc", Slug: "fix-auth", Kind: "pi"})
 
 	if !idx.SlugExists("pi", "fix-auth") {
 		t.Error("expected true")
@@ -188,8 +188,8 @@ func TestSlugExists(t *testing.T) {
 
 func TestFindByPrefix(t *testing.T) {
 	idx := New()
-	idx.Upsert(Info{ToolID: "abc-123", Slug: "fix-auth-bug", Kind: "pi"})
-	idx.Upsert(Info{ToolID: "def-456", Slug: "fix-typo", Kind: "pi"})
+	idx.Upsert(Info{ConversationID: "abc-123", Slug: "fix-auth-bug", Kind: "pi"})
+	idx.Upsert(Info{ConversationID: "def-456", Slug: "fix-typo", Kind: "pi"})
 
 	info, ok := idx.FindByPrefix("pi", "fix-auth")
 	if !ok {
@@ -207,8 +207,8 @@ func TestFindByPrefix(t *testing.T) {
 
 func TestLookupBySlug_AcrossKinds(t *testing.T) {
 	idx := New()
-	idx.Upsert(Info{ToolID: "aaa", Slug: "fix-auth", Kind: "pi", Title: "pi session"})
-	idx.Upsert(Info{ToolID: "bbb", Slug: "add-tests", Kind: "claude", Title: "claude session"})
+	idx.Upsert(Info{ConversationID: "aaa", Slug: "fix-auth", Kind: "pi", Title: "pi session"})
+	idx.Upsert(Info{ConversationID: "bbb", Slug: "add-tests", Kind: "claude", Title: "claude session"})
 
 	info, ok := idx.LookupBySlug("fix-auth")
 	if !ok {
@@ -240,8 +240,8 @@ func TestLookupBySlug_AcrossKinds(t *testing.T) {
 
 func TestAll(t *testing.T) {
 	idx := New()
-	idx.Upsert(Info{ToolID: "a", Slug: "one", Kind: "pi", Created: time.Now()})
-	idx.Upsert(Info{ToolID: "b", Slug: "two", Kind: "claude", Created: time.Now()})
+	idx.Upsert(Info{ConversationID: "a", Slug: "one", Kind: "pi", Created: time.Now()})
+	idx.Upsert(Info{ConversationID: "b", Slug: "two", Kind: "claude", Created: time.Now()})
 
 	all := idx.All()
 	if len(all) != 2 {
@@ -257,7 +257,7 @@ func TestAll(t *testing.T) {
 // It also still removes indexed entries from the index.
 func TestSinkRemoveFiresOnRemovedEvenWhenUnindexed(t *testing.T) {
 	idx := New()
-	idx.Upsert(Info{ToolID: "a", Slug: "one", Kind: "pi", FilePath: "/x/a.jsonl"})
+	idx.Upsert(Info{ConversationID: "a", Slug: "one", Kind: "pi", FilePath: "/x/a.jsonl"})
 
 	var got []string
 	sink := indexSink{idx: idx, onRemoved: func(p string) { got = append(got, p) }}

--- a/services/gmuxd/internal/conversations/sources_test.go
+++ b/services/gmuxd/internal/conversations/sources_test.go
@@ -33,7 +33,7 @@ func TestSnapshotAndWatchSources(t *testing.T) {
 
 	idx := New()
 	idx.Snapshot()
-	if idx.LookupByToolID("pi", "id-1") == "" {
+	if idx.LookupByConversationID("pi", "id-1") == "" {
 		t.Fatal("Snapshot did not index the pre-existing conversation")
 	}
 
@@ -45,7 +45,7 @@ func TestSnapshotAndWatchSources(t *testing.T) {
 	writePiFile(t, filepath.Join(root, "--tmp-b--", "id-2.jsonl"), "id-2")
 
 	deadline := time.After(3 * time.Second)
-	for idx.LookupByToolID("pi", "id-2") == "" {
+	for idx.LookupByConversationID("pi", "id-2") == "" {
 		select {
 		case <-deadline:
 			t.Fatal("WatchSources did not index a conversation created after startup")

--- a/services/gmuxd/internal/discovery/discovery.go
+++ b/services/gmuxd/internal/discovery/discovery.go
@@ -306,6 +306,24 @@ func queryMeta(socketPath string) (*store.Session, error) {
 		return nil, err
 	}
 
+	// Legacy-read shim: pre-v2 runners report "kind" and "session_file"
+	// in /meta. Long-lived runners survive daemon upgrades, so accept the
+	// old keys for one release. TODO(v2.1): drop this shim.
+	if sess.Kind == "" || sess.SessionFile == "" {
+		var legacy struct {
+			Kind        string `json:"kind"`
+			SessionFile string `json:"session_file"`
+		}
+		if err := json.Unmarshal(body, &legacy); err == nil {
+			if sess.Kind == "" {
+				sess.Kind = legacy.Kind
+			}
+			if sess.SessionFile == "" {
+				sess.SessionFile = legacy.SessionFile
+			}
+		}
+	}
+
 	// Ensure socket_path is set (runner might not include it)
 	if sess.SocketPath == "" {
 		sess.SocketPath = socketPath

--- a/services/gmuxd/internal/discovery/discovery_test.go
+++ b/services/gmuxd/internal/discovery/discovery_test.go
@@ -271,3 +271,77 @@ func TestScanReregistersOnTransientSubscriptionDrop(t *testing.T) {
 		t.Errorf("Pid = %d, want 99 (re-registration must refresh runtime fields)", got.Pid)
 	}
 }
+
+// serveMetaJSON starts a fake runner on a Unix socket whose /meta
+// returns the given raw JSON body verbatim, so tests can exercise
+// queryMeta against wire shapes a store.Session round-trip could
+// never produce (e.g. pre-v2 key names).
+func serveMetaJSON(t *testing.T, body string) (socketPath string) {
+	t.Helper()
+	sockPath := filepath.Join(t.TempDir(), "runner.sock")
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen %s: %v", sockPath, err)
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/meta", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	})
+	srv := &http.Server{Handler: mux}
+	done := make(chan struct{})
+	go func() { _ = srv.Serve(ln); close(done) }()
+	t.Cleanup(func() { _ = srv.Close(); <-done })
+	return sockPath
+}
+
+// TestQueryMetaLegacyPreV2Keys covers queryMeta's legacy-read shim:
+// long-lived pre-v2 runners survive a daemon upgrade and still report
+// "kind" / "session_file" in /meta, so the new daemon must map them to
+// the renamed fields. TODO(v2.1): drop alongside the shim.
+func TestQueryMetaLegacyPreV2Keys(t *testing.T) {
+	sock := serveMetaJSON(t, `{
+		"id": "sess-old-runner",
+		"kind": "pi",
+		"session_file": "/home/u/.pi/agent/sessions/x/conv.jsonl",
+		"alive": true
+	}`)
+
+	sess, err := queryMeta(sock)
+	if err != nil {
+		t.Fatalf("queryMeta: %v", err)
+	}
+	if sess.Kind != "pi" {
+		t.Errorf("Kind = %q, want %q (legacy \"kind\" fallback)", sess.Kind, "pi")
+	}
+	if want := "/home/u/.pi/agent/sessions/x/conv.jsonl"; sess.SessionFile != want {
+		t.Errorf("SessionFile = %q, want %q (legacy \"session_file\" fallback)", sess.SessionFile, want)
+	}
+}
+
+// TestQueryMetaNewKeysWinOverLegacy pins the shim's precedence: the
+// fallback only fills fields the new keys left empty. A payload
+// carrying both (never emitted by a real runner, but the invariant
+// that keeps the shim safe to leave in place) must resolve to the new
+// keys' values.
+func TestQueryMetaNewKeysWinOverLegacy(t *testing.T) {
+	sock := serveMetaJSON(t, `{
+		"id": "sess-mixed",
+		"adapter": "claude",
+		"kind": "pi",
+		"conversation_file": "/new/conv.jsonl",
+		"session_file": "/old/conv.jsonl",
+		"alive": true
+	}`)
+
+	sess, err := queryMeta(sock)
+	if err != nil {
+		t.Fatalf("queryMeta: %v", err)
+	}
+	if sess.Kind != "claude" {
+		t.Errorf("Kind = %q, want %q (new key must win)", sess.Kind, "claude")
+	}
+	if sess.SessionFile != "/new/conv.jsonl" {
+		t.Errorf("SessionFile = %q, want /new/conv.jsonl (new key must win)", sess.SessionFile)
+	}
+}

--- a/services/gmuxd/internal/discovery/subscribe.go
+++ b/services/gmuxd/internal/discovery/subscribe.go
@@ -297,12 +297,16 @@ func (sub *Subscriptions) handleEvent(sessionID, socketPath, eventType string, d
 			sub.OnDead(sess)
 		}
 
-	case "session_file":
+	// "session_file" is the pre-v2 name for the same event: long-lived
+	// runners survive daemon upgrades, so the daemon accepts both for one
+	// release. New runners emit only "conversation_file".
+	// TODO(v2.1): drop the "session_file" case.
+	case "conversation_file", "session_file":
 		var sf struct {
 			Path string `json:"path"`
 		}
 		if err := json.Unmarshal(data, &sf); err != nil {
-			log.Printf("subscribe: %s: bad session_file event: %v", sessionID, err)
+			log.Printf("subscribe: %s: bad conversation_file event: %v", sessionID, err)
 			return
 		}
 		if sf.Path == "" {

--- a/services/gmuxd/internal/discovery/subscribe_test.go
+++ b/services/gmuxd/internal/discovery/subscribe_test.go
@@ -236,12 +236,29 @@ func TestExitEventDoesNotResurrectDismissedSession(t *testing.T) {
 	}
 }
 
-func TestSessionFileEventRecordsPath(t *testing.T) {
+func TestConversationFileEventRecordsPath(t *testing.T) {
 	sessions := store.New()
 	sessions.Upsert(store.Session{ID: "sess-1", Alive: true})
 	subs := NewSubscriptions(sessions)
 
 	const path = "/home/u/.pi/agent/sessions/x/2026_sess.jsonl"
+	subs.handleEvent("sess-1", "/sock", "conversation_file", []byte(`{"path":"`+path+`"}`))
+
+	got, ok := sessions.Get("sess-1")
+	if !ok || got.SessionFile != path {
+		t.Fatalf("SessionFile = %q (ok=%v), want %q", got.SessionFile, ok, path)
+	}
+}
+
+// Pre-v2 runners emit "session_file" for the same event; long-lived
+// runners survive daemon upgrades, so the daemon must keep accepting it
+// for one release. TODO(v2.1): drop alongside the subscribe.go case.
+func TestLegacySessionFileEventStillAccepted(t *testing.T) {
+	sessions := store.New()
+	sessions.Upsert(store.Session{ID: "sess-1", Alive: true})
+	subs := NewSubscriptions(sessions)
+
+	const path = "/home/u/.claude/projects/x/old-runner.jsonl"
 	subs.handleEvent("sess-1", "/sock", "session_file", []byte(`{"path":"`+path+`"}`))
 
 	got, ok := sessions.Get("sess-1")
@@ -250,11 +267,11 @@ func TestSessionFileEventRecordsPath(t *testing.T) {
 	}
 }
 
-func TestSessionFileEventEmptyPathIgnored(t *testing.T) {
+func TestConversationFileEventEmptyPathIgnored(t *testing.T) {
 	sessions := store.New()
 	sessions.Upsert(store.Session{ID: "sess-1", Alive: true})
 	subs := NewSubscriptions(sessions)
-	subs.handleEvent("sess-1", "/sock", "session_file", []byte(`{"path":""}`))
+	subs.handleEvent("sess-1", "/sock", "conversation_file", []byte(`{"path":""}`))
 	if got, _ := sessions.Get("sess-1"); got.SessionFile != "" {
 		t.Errorf("empty path should not set SessionFile, got %q", got.SessionFile)
 	}

--- a/services/gmuxd/internal/sessionmeta/sessionmeta.go
+++ b/services/gmuxd/internal/sessionmeta/sessionmeta.go
@@ -322,6 +322,24 @@ func (s *Store) Read(id string) (store.Session, error) {
 	if err := json.Unmarshal(data, &ps); err != nil {
 		return store.Session{}, fmt.Errorf("sessionmeta: parse %s: %w", path, err)
 	}
+	// Legacy-read shim: pre-v2 meta.json used "kind" and "session_file".
+	// meta.json has no schema version, so fall back to the old keys when
+	// the new ones are absent. Write emits only the new keys.
+	// TODO(v2.1): drop this shim.
+	if ps.Kind == "" || ps.SessionFile == "" {
+		var legacy struct {
+			Kind        string `json:"kind"`
+			SessionFile string `json:"session_file"`
+		}
+		if err := json.Unmarshal(data, &legacy); err == nil {
+			if ps.Kind == "" {
+				ps.Kind = legacy.Kind
+			}
+			if ps.SessionFile == "" {
+				ps.SessionFile = legacy.SessionFile
+			}
+		}
+	}
 	return store.Session(ps), nil
 }
 

--- a/services/gmuxd/internal/sessionmeta/sessionmeta_test.go
+++ b/services/gmuxd/internal/sessionmeta/sessionmeta_test.go
@@ -180,6 +180,69 @@ func TestWriteFilePermissions(t *testing.T) {
 	}
 }
 
+// TestReadLegacyPreV2Keys covers the legacy-read shim: pre-v2 meta.json
+// files carry "kind" and "session_file" instead of "adapter" and
+// "conversation_file". meta.json has no schema version, so Read falls
+// back to the old keys. TODO(v2.1): drop alongside the shim.
+func TestReadLegacyPreV2Keys(t *testing.T) {
+	s := newStore(t)
+	legacy := []byte(`{
+		"id": "sess-legacy1",
+		"kind": "pi",
+		"session_file": "/home/u/.pi/agent/sessions/x/conv.jsonl",
+		"alive": false,
+		"cwd": "/home/u/proj"
+	}`)
+	dir := s.SessionDir("sess-legacy1")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, metaFile), legacy, 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	got, err := s.Read("sess-legacy1")
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if got.Kind != "pi" {
+		t.Errorf("Kind = %q, want %q (legacy \"kind\" fallback)", got.Kind, "pi")
+	}
+	if want := "/home/u/.pi/agent/sessions/x/conv.jsonl"; got.SessionFile != want {
+		t.Errorf("SessionFile = %q, want %q (legacy \"session_file\" fallback)", got.SessionFile, want)
+	}
+}
+
+// TestWriteEmitsOnlyNewKeys pins the write side of the shim: new
+// meta.json files must not contain the legacy keys.
+func TestWriteEmitsOnlyNewKeys(t *testing.T) {
+	s := newStore(t)
+	sess := sampleSession()
+	sess.SessionFile = "/tmp/conv.jsonl"
+	if err := s.Write(sess); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(s.SessionDir(sess.ID), metaFile))
+	if err != nil {
+		t.Fatalf("read meta.json: %v", err)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("parse meta.json: %v", err)
+	}
+	for _, legacy := range []string{"kind", "session_file"} {
+		if _, ok := raw[legacy]; ok {
+			t.Errorf("meta.json still contains legacy key %q", legacy)
+		}
+	}
+	if _, ok := raw["adapter"]; !ok {
+		t.Error("meta.json missing \"adapter\" key")
+	}
+	if _, ok := raw["conversation_file"]; !ok {
+		t.Error("meta.json missing \"conversation_file\" key")
+	}
+}
+
 func TestRemoveIsIdempotent(t *testing.T) {
 	s := newStore(t)
 	if err := s.Write(sampleSession()); err != nil {

--- a/services/gmuxd/internal/store/store.go
+++ b/services/gmuxd/internal/store/store.go
@@ -24,7 +24,10 @@ type Session struct {
 	CreatedAt     string            `json:"created_at,omitempty"`
 	Command       []string          `json:"command,omitempty"`
 	Cwd           string            `json:"cwd,omitempty"`
-	Kind          string            `json:"kind"`
+	// Kind holds the adapter name ("pi", "claude", "shell", ...). The wire
+	// key is "adapter" (v2 rename); the Go identifier's rename to Adapter
+	// trails with the internal cleanup.
+	Kind          string            `json:"adapter"`
 	WorkspaceRoot string            `json:"workspace_root,omitempty"`
 	Remotes       map[string]string `json:"remotes,omitempty"`
 	Alive         bool              `json:"alive"`
@@ -70,7 +73,7 @@ type Session struct {
 	// Two live sessions may carry the same SessionFile when the same
 	// conversation is resumed in more than one tab; the frontend groups
 	// by this to warn about a conversation open in multiple runners.
-	SessionFile string `json:"session_file,omitempty"`
+	SessionFile string `json:"conversation_file,omitempty"`
 
 	// RunnerVersion is the version string of the gmux runner binary that
 	// launched this session. Set by the runner at startup. The frontend
@@ -121,7 +124,7 @@ func (s Session) MarshalJSON() ([]byte, error) {
 		CreatedAt     string            `json:"created_at,omitempty"`
 		Command       []string          `json:"command,omitempty"`
 		Cwd           string            `json:"cwd,omitempty"`
-		Kind          string            `json:"kind"`
+		Kind          string            `json:"adapter"`
 		WorkspaceRoot string            `json:"workspace_root,omitempty"`
 		Remotes       map[string]string `json:"remotes,omitempty"`
 		Alive         bool              `json:"alive"`
@@ -138,7 +141,7 @@ func (s Session) MarshalJSON() ([]byte, error) {
 		TerminalCols  uint16            `json:"terminal_cols,omitempty"`
 		TerminalRows  uint16            `json:"terminal_rows,omitempty"`
 		Slug          string            `json:"slug,omitempty"`
-		SessionFile   string            `json:"session_file,omitempty"`
+		SessionFile   string            `json:"conversation_file,omitempty"`
 		RunnerVersion string            `json:"runner_version,omitempty"`
 		BinaryHash    string            `json:"binary_hash,omitempty"`
 		ProjectSlug   string            `json:"project_slug,omitempty"`

--- a/services/gmuxd/internal/store/store_test.go
+++ b/services/gmuxd/internal/store/store_test.go
@@ -1008,6 +1008,7 @@ func TestSessionMarshalJSON_WireFormat(t *testing.T) {
 		ShellTitle:    "internal-only",
 		AdapterTitle:  "internal-only",
 		Slug:          "my-slug",
+		SessionFile:   "/home/u/.pi/agent/sessions/x/conv.jsonl",
 	}
 	b, err := json.Marshal(s)
 	if err != nil {
@@ -1027,6 +1028,22 @@ func TestSessionMarshalJSON_WireFormat(t *testing.T) {
 	}
 	if got := m["slug"]; got != "my-slug" {
 		t.Errorf("slug = %v, want my-slug", got)
+	}
+	// v2 renamed the wire keys: "kind" → "adapter", "session_file" →
+	// "conversation_file". Pin both the new names and the absence of the
+	// old ones — the frontend, peering, and meta.json all consume this
+	// exact shape.
+	if got := m["adapter"]; got != "pi" {
+		t.Errorf("adapter = %v, want pi", got)
+	}
+	if got := m["conversation_file"]; got != "/home/u/.pi/agent/sessions/x/conv.jsonl" {
+		t.Errorf("conversation_file = %v, want the session's conversation file", got)
+	}
+	if _, ok := m["kind"]; ok {
+		t.Error("legacy key \"kind\" must not appear in wire JSON")
+	}
+	if _, ok := m["session_file"]; ok {
+		t.Error("legacy key \"session_file\" must not appear in wire JSON")
 	}
 
 	// Internal fields must not appear on the wire.

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -24,7 +24,7 @@ import (
 // session mirrors the schema v2 fields we care about.
 type session struct {
 	ID         string  `json:"id"`
-	Kind       string  `json:"kind"`
+	Kind       string  `json:"adapter"`
 	Alive      bool    `json:"alive"`
 	Pid        int     `json:"pid"`
 	Title      string  `json:"title"`


### PR DESCRIPTION
Implements phases 1 and 2 of the terminology cleanup (see the report's verdicts table: `kind`→`adapter` **clear yes**, `ToolID`→`ConversationID` **clear yes, cheap**, session-as-conversation→conversation **yes, scoped**). Vocabulary is anchored in [UBIQUITOUS_LANGUAGE.md](../blob/terminology-rename/UBIQUITOUS_LANGUAGE.md), updated in this PR.

**One PR, two commits** — phase 1 is non-breaking and phase 2 rides the declared v2.0 breaking window; keeping them together means the review sees the whole vocabulary shift at once, while the commits stay independently revertable.

## Commit 1 — phase 1 (non-breaking)

- `ToolID` → `ConversationID` throughout the conversations index (`Info.ConversationID`, `byConversationID`, `convKey`, `LookupByConversationID`, `Remove`), rehydrate comments/tests, e2e fixture `toolID` helper field.
- UBIQUITOUS_LANGUAGE.md: **Tool ID** row replaced with **Conversation ID** (fixing the file-path-vs-header-UUID contradiction), Conversation row rewritten, index keys now `(adapter, conversationID)`, "session file" flagged as banned with the ADR 0015 boundary rule.

## Commit 2 — phase 2 (v2.0 breaking window)

- Wire + persisted `"kind"` → `"adapter"`, `"session_file"` → `"conversation_file"`: store.Session json tags + MarshalJSON wire struct, protocol zod schema, web types/store (TS-union `kind` discriminants untouched — renamed by hand, not sed), e2e specs, Go e2e harness.
- URL `/v1/conversations/{kind}/{slug}` → `{adapter}` (+ response key).
- CLI `gmux ls` KIND column → ADAPTER.
- Runner SSE event `session_file` → `conversation_file`; daemon accepts **both** for one release (long-lived runners survive daemon upgrades), covered by `TestLegacySessionFileEventStillAccepted`. `TODO(v2.1)` marks the drop.
- Legacy-read shims (meta.json has no schema version): `sessionmeta.Read` and discovery `queryMeta` fall back to the old keys when the new ones are absent; write emits only new keys (`TestReadLegacyPreV2Keys`, `TestWriteEmitsOnlyNewKeys`). Droppable in v2.1.
- Docs: runner-hook-protocol.md documents that hook op `"session"` denotes the agent's own session (kept per ADR 0015); website session-schema/state-management pages updated. ADRs untouched (historical records).

## Kept as "session" (means the gmux session)

`store.Session`, `GMUX_SESSION_*`, `sessionmeta`, `sessions/` state dir, `session-upsert`/`session-remove` SSE, `SessionRegistrar`/`SessionFinalizer`. Agent-native tags (`sessionId`, `session_id`, `transcript_path`, pi ext events) stay in the agent's language.

## Out of scope (phase 3, later PR)

Internal Go `Kind`→`Adapter` (~310 refs) and `SessionFileInfo`/`ParseSessionFile`/`SessionFiler`/`SessionRootDir`→`Conversation*`; optional `SessionExtender`→`AgentHook*`.

## Verification

- `go test ./...` green in all modules (`tests/e2e` TestEndToEnd fails identically on main — environmental).
- `pnpm lint` green; gmux-web vitest 548 passed.
- Playwright e2e: 43/43 passed.


## Review pass (commit 3)

Post-implementation double-check of every surface (`rg` sweeps for stray `json:"kind"` / `json:"session_file"` / `.kind` adapter-meaning uses — only the intentional shim structs remain):

- **New: wire-key pinning** — `TestSessionMarshalJSON_WireFormat` now asserts `adapter`/`conversation_file` are present and the legacy keys absent; this is the exact shape frontend, peering, and meta.json consume, and nothing previously pinned the key names themselves.
- **New: `queryMeta` shim coverage** — the runner `/meta` legacy-read shim (the one surface the original plan missed) had no tests; added legacy-fallback and new-keys-win cases against a fake runner socket, reusing the discovery test harness pattern.
- **Readability** — `Kind` / `json:"adapter"` now diverge until the phase-3 identifier rename; added orientation comments at the two definition sites (store.Session, runner state) so readers aren't left guessing (squashed into commit 2).
- **Doc fix** — UBIQUITOUS_LANGUAGE.md referenced `ConversationInfo.ID`, a Go type that only exists after the deferred phase-3 cleanup; now points at the current `SessionFileInfo.ID` with a note about the trailing rename.

