### PR TITLE
refactor: terminology phase 3 — internal Go identifier sweep

### DIFF
--- a/UBIQUITOUS_LANGUAGE.md
+++ b/UBIQUITOUS_LANGUAGE.md
@@ -9,7 +9,7 @@
 | **Slug**            | A session's mutable, human-readable display name; persistent across runner restarts and resume, but renamable. Not identity (the immutable Conversation ID is) | Name                      |
 | **Session ID**      | A specific runner instance's identifier; ephemeral for shell, stable (= conversation ID) for pi/claude    | Identifier (alone is too generic) |
 | **Key**             | The single string projects.json uses per session: slug if attributed, session ID otherwise                |                           |
-| **Conversation ID** | The agent's own identifier for a Conversation, parsed from inside the conversation file by the adapter (`SessionFileInfo.ID`; the Go type's rename to `ConversationInfo` trails with the internal cleanup). Used with the adapter name as the conversations-index key `(adapter, conversationID)` | Tool ID (the old name)    |
+| **Conversation ID** | The agent's own identifier for a Conversation, parsed from inside the conversation file by the adapter (`ConversationInfo.ID`). Used with the adapter name as the conversations-index key `(adapter, conversationID)` | Tool ID (the old name)    |
 
 ## Session lifecycle
 

--- a/apps/website/src/content/docs/develop/adapter-architecture.md
+++ b/apps/website/src/content/docs/develop/adapter-architecture.md
@@ -28,10 +28,10 @@ That split is why the adapter system is a set of small interfaces instead of one
 | PTY output monitoring | `gmux` | `Adapter.Monitor()` |
 | Child self-report API | `gmux` | Unix socket HTTP endpoints |
 | Launch menu discovery | `gmuxd` | `Launchable` + compiled adapter set |
-| Session file discovery | `gmuxd` | `SessionFiler` |
+| Conversation file discovery | `gmuxd` | `ConversationFiler` |
 | Live session state | runner → `gmuxd` | agent hook (`SessionExtender` / `SessionHookCommand`) |
 | Conversation discovery | `gmuxd` | `ConversationSource` (snapshot + watch) |
-| Resumable session discovery | `gmuxd` | `SessionFiler` + `Resumer` |
+| Resumable session discovery | `gmuxd` | `ConversationFiler` + `Resumer` |
 | Resume command generation | `gmuxd` | `Resumer.ResumeCommand()` |
 
 ## Launch lifecycle
@@ -114,21 +114,21 @@ The current built-in launcher ordering is simple:
 
 Some tools write session or conversation files to disk. Those integrations use optional capabilities discovered by `gmuxd`.
 
-### `SessionFiler`
+### `ConversationFiler`
 
 ```go
-type SessionFiler interface {
-    SessionRootDir() string
-    SessionDir(cwd string) string
-    ParseSessionFile(path string) (*SessionFileInfo, error)
+type ConversationFiler interface {
+    ConversationRootDir() string
+    ConversationDir(cwd string) string
+    ParseConversationFile(path string) (*ConversationInfo, error)
 }
 ```
 
 Use this when a tool stores session state on disk and gmux should be able to discover or inspect it.
 
-- `SessionRootDir()` returns the root containing all per-project session directories
-- `SessionDir(cwd)` returns the directory for one working directory
-- `ParseSessionFile(path)` extracts display metadata such as ID, title, cwd, created time, and message count
+- `ConversationRootDir()` returns the root containing all per-project conversation directories
+- `ConversationDir(cwd)` returns the directory for one working directory
+- `ParseConversationFile(path)` extracts display metadata such as ID, title, cwd, created time, and message count
 
 ### `ConversationSource`
 
@@ -139,13 +139,13 @@ type ConversationSource interface {
 }
 ```
 
-Use this so `gmuxd` can index your tool's conversations (for URL resolution and search). The adapter owns discovery: `SnapshotConversations` reports everything that exists now, `WatchConversations` streams changes until `ctx` ends. File-backed adapters build on the shared `filewatch` tree watcher; the daemon parses each reported path via `ParseSessionFile`.
+Use this so `gmuxd` can index your tool's conversations (for URL resolution and search). The adapter owns discovery: `SnapshotConversations` reports everything that exists now, `WatchConversations` streams changes until `ctx` ends. File-backed adapters build on the shared `filewatch` tree watcher; the daemon parses each reported path via `ParseConversationFile`.
 
 ### `Resumer`
 
 ```go
 type Resumer interface {
-    ResumeCommand(info *SessionFileInfo) []string
+    ResumeCommand(info *ConversationInfo) []string
     CanResume(path string) bool
 }
 ```
@@ -165,7 +165,7 @@ Which running session holds which conversation file — and its title and status
 is **not** inferred by the daemon. The runner injects a gmux agent hook
 (`SessionExtender` for pi's `-e` extension; `SessionHookCommand` for codex/claude
 hooks), and the agent reports the held file, title, and status authoritatively
-over the runner socket. `gmuxd` records the file on the session (`SessionFile`);
+over the runner socket. `gmuxd` records the file on the session (`ConversationFile`);
 a `/resume` rebind to a different file is just another hook report. When a tool
 can't be hooked, the session runs without daemon-reported live state — there is
 no metadata-matching fallback.
@@ -174,9 +174,9 @@ no metadata-matching fallback.
 
 Independently, `gmuxd` indexes every conversation file on disk — including dead
 conversations with no running session — for URL resolution and search. Each
-`SessionFiler` adapter also implements `ConversationSource`: it reports a
+`ConversationFiler` adapter also implements `ConversationSource`: it reports a
 startup snapshot and then streams changes, and the daemon parses each path via
-`ParseSessionFile` into the index. File-backed adapters share the `filewatch`
+`ParseConversationFile` into the index. File-backed adapters share the `filewatch`
 tree watcher; a database-backed tool would poll or subscribe instead. There is
 no daemon-global file monitor.
 
@@ -195,11 +195,11 @@ When a session exits, `gmuxd` checks whether its adapter implements `Resumer` an
 
 ### File-discovered sessions
 
-For adapters that implement both `SessionFiler` and `Resumer`, `gmuxd` also discovers sessions from files on disk (e.g. from before the daemon started):
+For adapters that implement both `ConversationFiler` and `Resumer`, `gmuxd` also discovers sessions from files on disk (e.g. from before the daemon started):
 
-1. enumerate files under `SessionRootDir()` / known `SessionDir(cwd)` directories
+1. enumerate files under `ConversationRootDir()` / known `ConversationDir(cwd)` directories
 2. filter them with `CanResume(path)`
-3. parse them with `ParseSessionFile(path)`
+3. parse them with `ParseConversationFile(path)`
 4. deduplicate them against live sessions by resume key
 5. publish them as resumable entries
 

--- a/apps/website/src/content/docs/develop/state-management.md
+++ b/apps/website/src/content/docs/develop/state-management.md
@@ -52,7 +52,7 @@ This means discovery can never race with Register to create duplicate sessions.
 
 ### Agent hook: authoritative live state
 
-Live session state is reported by the agent itself, not inferred by the daemon. The runner injects a gmux hook into the agent (`pi -e`, or codex/claude hooks), and the agent POSTs the held conversation file, title, and status to the runner socket; the runner forwards them over SSE. `gmuxd` records the file on the session (`SessionFile`). A `/resume` rebind to a different file is just another report. Tools that can't be hooked run without daemon-reported live state — there is no metadata-matching fallback.
+Live session state is reported by the agent itself, not inferred by the daemon. The runner injects a gmux hook into the agent (`pi -e`, or codex/claude hooks), and the agent POSTs the held conversation file, title, and status to the runner socket; the runner forwards them over SSE. `gmuxd` records the file on the session (`ConversationFile`). A `/resume` rebind to a different file is just another report. Tools that can't be hooked run without daemon-reported live state — there is no metadata-matching fallback.
 
 ### Conversation sources: index updates
 

--- a/apps/website/src/content/docs/develop/writing-adapters.md
+++ b/apps/website/src/content/docs/develop/writing-adapters.md
@@ -150,21 +150,21 @@ Implement this if the adapter should contribute launch presets to the UI.
 - return none by not implementing the interface at all
 - remember that launch availability is controlled separately by the required `Discover()` method
 
-### `SessionFiler`
+### `ConversationFiler`
 
 ```go
-type SessionFiler interface {
-    SessionRootDir() string
-    SessionDir(cwd string) string
-    ParseSessionFile(path string) (*SessionFileInfo, error)
+type ConversationFiler interface {
+    ConversationRootDir() string
+    ConversationDir(cwd string) string
+    ParseConversationFile(path string) (*ConversationInfo, error)
 }
 ```
 
 Implement this if your tool writes session or conversation files to disk.
 
-- `SessionRootDir()` returns the root containing all session directories
-- `SessionDir(cwd)` returns the directory for a particular working directory
-- `ParseSessionFile(path)` extracts display metadata from one file
+- `ConversationRootDir()` returns the root containing all session directories
+- `ConversationDir(cwd)` returns the directory for a particular working directory
+- `ParseConversationFile(path)` extracts display metadata from one file
 
 ### `ConversationSource`
 
@@ -175,7 +175,7 @@ type ConversationSource interface {
 }
 ```
 
-Implement this if your tool's conversations live in files (or anywhere else) that gmux should index for URL resolution and search. The adapter owns *how* it discovers them: `SnapshotConversations` reports everything that exists now (synchronous, at startup), and `WatchConversations` streams changes until `ctx` is cancelled. Both report absolute paths to a `ConversationSink` (`Upsert(path)` / `Remove(path)`); the daemon parses each via your `ParseSessionFile`.
+Implement this if your tool's conversations live in files (or anywhere else) that gmux should index for URL resolution and search. The adapter owns *how* it discovers them: `SnapshotConversations` reports everything that exists now (synchronous, at startup), and `WatchConversations` streams changes until `ctx` is cancelled. Both report absolute paths to a `ConversationSink` (`Upsert(path)` / `Remove(path)`); the daemon parses each via your `ParseConversationFile`.
 
 File-backed adapters build both on `packages/adapter/filewatch`, a reusable recursive tree watcher, in a few lines each — see `pi.go`. A non-file source (e.g. a database) implements the same interface with a poller or subscription instead.
 
@@ -185,7 +185,7 @@ Note: live session state — title, status, and the held conversation file — i
 
 ```go
 type Resumer interface {
-    ResumeCommand(info *SessionFileInfo) []string
+    ResumeCommand(info *ConversationInfo) []string
     CanResume(path string) bool
 }
 ```
@@ -195,7 +195,7 @@ Implement this if your tool supports resuming previous sessions.
 - `CanResume()` filters out invalid or empty files
 - `ResumeCommand()` tells gmux how to resume a valid session
 
-All dead sessions are resumable. When a session exits, gmuxd checks whether the adapter implements `Resumer` and has a recorded session file (`SessionFile`, reported by the agent hook). If so, the session's command is replaced with the adapter's resume command (e.g. `["claude", "--resume", "abc"]`). If not, the original launch command is kept as-is, so "resume" simply re-runs the command in the same working directory.
+All dead sessions are resumable. When a session exits, gmuxd checks whether the adapter implements `Resumer` and has a recorded conversation file (`ConversationFile`, reported by the agent hook). If so, the session's command is replaced with the adapter's resume command (e.g. `["claude", "--resume", "abc"]`). If not, the original launch command is kept as-is, so "resume" simply re-runs the command in the same working directory.
 
 This means adapters that don't implement `Resumer` still get resume for free: the user clicks resume, a new session starts with the same command and cwd. This is the right behavior for shell sessions and simple tools. Only implement `Resumer` when your tool has native resume support that you want to use instead.
 
@@ -209,13 +209,13 @@ type CommandTitler interface {
 
 Implement this if your adapter needs custom fallback title display from the command array. Without it, the fallback title is the adapter name (e.g. "codex", "pi"). Shell implements this to show the full command with args (e.g. "pytest -x").
 
-This only matters when no adapter or shell title has been set yet, which is rare for agent adapters (titles come from the agent hook or session file) but common for plain shell sessions.
+This only matters when no adapter or shell title has been set yet, which is rare for agent adapters (titles come from the agent hook or conversation file) but common for plain shell sessions.
 
 ### Capability composition
 
 An adapter implements only what it needs:
 
-| Adapter | Base | Launchable | SessionFiler | ConversationSource | Resumer |
+| Adapter | Base | Launchable | ConversationFiler | ConversationSource | Resumer |
 |---------|------|------------|-------------|--------------------|---------|
 | Shell | ✓ | ✓ | — | — | —* |
 | Claude | ✓ | ✓ | ✓ | ✓ | ✓ |
@@ -230,7 +230,7 @@ Write unit tests in `myapp_test.go` next to your adapter. Test `Match()` with di
 
 If the adapter implements `Launchable`, test the returned launcher IDs, labels, and commands.
 
-For adapters with `SessionFiler`, create temp files in your tool's format and verify `ParseSessionFile()` extracts the expected metadata.
+For adapters with `ConversationFiler`, create temp files in your tool's format and verify `ParseConversationFile()` extracts the expected metadata.
 
 For the full end-to-end pipeline (launch → file attribution → title → resume), add integration tests that run real processes through gmuxd. See [Integration Tests](/develop/integration-tests) for the harness, patterns, and gotchas.
 

--- a/apps/website/src/content/docs/planned/opencode-adapter.md
+++ b/apps/website/src/content/docs/planned/opencode-adapter.md
@@ -5,7 +5,7 @@ description: Adapter for the OpenCode AI coding agent.
 
 > This feature is not yet implemented. Depends on [folder management](/planned/folder-management/).
 
-[OpenCode](https://opencode.ai) is an open-source AI coding agent that runs in the terminal. Unlike Claude Code, pi, and Codex (which write JSONL session files to central directories), OpenCode stores sessions in a SQLite database at `.opencode/opencode.db` relative to the working directory. This per-project storage model requires the folder management refactor before the adapter can discover sessions.
+[OpenCode](https://opencode.ai) is an open-source AI coding agent that runs in the terminal. Unlike Claude Code, pi, and Codex (which write JSONL conversation files to central directories), OpenCode stores sessions in a SQLite database at `.opencode/opencode.db` relative to the working directory. This per-project storage model requires the folder management refactor before the adapter can discover sessions.
 
 ## Phases
 
@@ -44,9 +44,9 @@ parts TEXT NOT NULL default '[]',  -- JSON array
 finished_at INTEGER
 ```
 
-The adapter would implement `SessionFiler` by:
+The adapter would implement `ConversationFiler` by:
 - Querying `SELECT id, title, message_count, created_at FROM sessions ORDER BY updated_at DESC`
-- Mapping results to `SessionFileInfo` structs
+- Mapping results to `ConversationInfo` structs
 
 This requires a SQLite dependency. `modernc.org/sqlite` (pure Go, no CGo) is preferred to avoid requiring a C compiler in the build chain.
 

--- a/cli/gmux/cmd/gmux/actions.go
+++ b/cli/gmux/cmd/gmux/actions.go
@@ -16,19 +16,19 @@ import (
 // session is the subset of gmuxd's Session model that the CLI cares
 // about. Defined locally to avoid pulling in the gmuxd store package.
 type cliSession struct {
-	ID         string `json:"id"`
-	Peer       string `json:"peer,omitempty"`
-	Cwd        string `json:"cwd,omitempty"`
-	Kind       string `json:"adapter"`
-	Alive      bool   `json:"alive"`
-	Pid        int    `json:"pid,omitempty"`
-	Title      string `json:"title,omitempty"`
-	Slug       string `json:"slug,omitempty"`
-	SocketPath string `json:"socket_path,omitempty"`
+	ID         string   `json:"id"`
+	Peer       string   `json:"peer,omitempty"`
+	Cwd        string   `json:"cwd,omitempty"`
+	Adapter    string   `json:"adapter"`
+	Alive      bool     `json:"alive"`
+	Pid        int      `json:"pid,omitempty"`
+	Title      string   `json:"title,omitempty"`
+	Slug       string   `json:"slug,omitempty"`
+	SocketPath string   `json:"socket_path,omitempty"`
 	Command    []string `json:"command,omitempty"`
-	StartedAt  string `json:"started_at,omitempty"`
-	ExitedAt   string `json:"exited_at,omitempty"`
-	ExitCode   *int   `json:"exit_code,omitempty"`
+	StartedAt  string   `json:"started_at,omitempty"`
+	ExitedAt   string   `json:"exited_at,omitempty"`
+	ExitCode   *int     `json:"exit_code,omitempty"`
 }
 
 // fetchSessions queries gmuxd for the full session list. Starts gmuxd
@@ -241,7 +241,7 @@ func displayID(s cliSession) string {
 // send, kill, etc.
 //
 // Rows are grouped alive-first then by start time; columns are kept
-// shallow (id, status, kind, title, cwd) so the output stays readable
+// shallow (id, status, adapter, title, cwd) so the output stays readable
 // in a narrow terminal.
 func cmdList(all bool, asJSON bool) int {
 	sessions, err := fetchSessions()
@@ -293,7 +293,7 @@ func cmdList(all bool, asJSON bool) int {
 		if title == "" {
 			title = strings.Join(s.Command, " ")
 		}
-		row := [5]string{id, status, s.Kind, title, s.Cwd}
+		row := [5]string{id, status, s.Adapter, title, s.Cwd}
 		rows = append(rows, row)
 		if n := len(row[0]); n > idW {
 			idW = n

--- a/cli/gmux/cmd/gmux/run.go
+++ b/cli/gmux/cmd/gmux/run.go
@@ -151,7 +151,7 @@ func runSession(args []string, attach bool, dir runDirectives) {
 		ID:            sessionID,
 		Command:       args,
 		Cwd:           workDir,
-		Kind:          a.Name(),
+		Adapter:       a.Name(),
 		WorkspaceRoot: wsRoot,
 		Remotes:       remotes,
 		SocketPath:    sockPath,

--- a/cli/gmux/cmd/gmux/wait.go
+++ b/cli/gmux/cmd/gmux/wait.go
@@ -98,8 +98,8 @@ func cmdWait(ref string, timeoutSecs int) int {
 		fmt.Fprintf(os.Stderr, "gmux: wait timed out after %ds\n", timeoutSecs)
 		return waitExitTimeout
 	case http.StatusUnprocessableEntity:
-		// Adapter kind doesn't emit an idle signal. Surface the
-		// daemon's message so the user knows which kind they hit.
+		// Adapter doesn't emit an idle signal. Surface the
+		// daemon's message so the user knows which adapter they hit.
 		body, _ := io.ReadAll(resp.Body)
 		fmt.Fprintf(os.Stderr, "gmux: wait not supported for this session: %s\n",
 			extractMessage(body))

--- a/cli/gmux/internal/agentext/pi-ext.mjs
+++ b/cli/gmux/internal/agentext/pi-ext.mjs
@@ -140,7 +140,7 @@ function extractUserText(msg) {
 
 // truncateTitle collapses whitespace and caps length at a word boundary, with
 // an ellipsis. Mirrors pi.go's truncateTitle (maxLen 80) so the live title and
-// the one ParseSessionFile recovers after a restart agree. Go measures length
+// the one ParseConversationFile recovers after a restart agree. Go measures length
 // in UTF-8 bytes, so we operate on bytes too (JS string length is UTF-16 code
 // units, which would diverge for non-ASCII prompts near the boundary).
 function truncateTitle(s) {

--- a/cli/gmux/internal/ptyserver/extension_test.go
+++ b/cli/gmux/internal/ptyserver/extension_test.go
@@ -49,10 +49,10 @@ func postSessionEvent(t *testing.T, sockPath, body string) {
 	resp.Body.Close()
 }
 
-// TestReconnectReplaysSessionFile checks that a newly-connected /events
-// subscriber (a reconnecting daemon) is replayed the bound session file, so
+// TestReconnectReplaysConversationFile checks that a newly-connected /events
+// subscriber (a reconnecting daemon) is replayed the bound conversation file, so
 // attribution survives a daemon restart without persisted state.
-func TestReconnectReplaysSessionFile(t *testing.T) {
+func TestReconnectReplaysConversationFile(t *testing.T) {
 	node, err := exec.LookPath("node")
 	if err != nil {
 		t.Skip("node not available")
@@ -77,10 +77,10 @@ func TestReconnectReplaysSessionFile(t *testing.T) {
 
 	postSessionEvent(t, sockPath, `{"op":"session","path":`+strconv.Quote(sessFile)+`}`)
 	deadline := time.After(5 * time.Second)
-	for st.SessionFileSnapshot() != sessFile {
+	for st.ConversationFileSnapshot() != sessFile {
 		select {
 		case <-deadline:
-			t.Fatalf("runner never recorded session file; got %q", st.SessionFileSnapshot())
+			t.Fatalf("runner never recorded conversation file; got %q", st.ConversationFileSnapshot())
 		case <-time.After(20 * time.Millisecond):
 		}
 	}
@@ -150,10 +150,10 @@ func TestSessionEventIsAuthoritative(t *testing.T) {
 	waitFor := func(want string) {
 		t.Helper()
 		deadline := time.After(2 * time.Second)
-		for st.SessionFileSnapshot() != want {
+		for st.ConversationFileSnapshot() != want {
 			select {
 			case <-deadline:
-				t.Fatalf("runner did not bind to %q; got %q", want, st.SessionFileSnapshot())
+				t.Fatalf("runner did not bind to %q; got %q", want, st.ConversationFileSnapshot())
 			case <-time.After(20 * time.Millisecond):
 			}
 		}

--- a/cli/gmux/internal/ptyserver/extension_test.go
+++ b/cli/gmux/internal/ptyserver/extension_test.go
@@ -61,7 +61,7 @@ func TestReconnectReplaysSessionFile(t *testing.T) {
 	sockPath := filepath.Join(dir, "test.sock")
 	sessFile := filepath.Join(dir, "2026-06-19_sess-reconnect.jsonl")
 
-	st := session.New(session.Config{ID: "s1", Kind: "pi", SocketPath: sockPath})
+	st := session.New(session.Config{ID: "s1", Adapter: "pi", SocketPath: sockPath})
 	srv, err := New(Config{
 		Command:    []string{node, "-e", "setTimeout(()=>{},3000)"},
 		Cwd:        dir,
@@ -122,7 +122,7 @@ func TestSessionEventIsAuthoritative(t *testing.T) {
 		}
 	}
 
-	st := session.New(session.Config{ID: "s1", Kind: "pi", SocketPath: sockPath})
+	st := session.New(session.Config{ID: "s1", Adapter: "pi", SocketPath: sockPath})
 	srv, err := New(Config{
 		Command:    []string{node, "-e", "setTimeout(()=>{},2000)"},
 		Cwd:        dir,
@@ -177,7 +177,7 @@ func TestTurnEventDrivesState(t *testing.T) {
 	}
 	dir := t.TempDir()
 	sockPath := filepath.Join(dir, "test.sock")
-	st := session.New(session.Config{ID: "s1", Kind: "pi", SocketPath: sockPath})
+	st := session.New(session.Config{ID: "s1", Adapter: "pi", SocketPath: sockPath})
 	srv, err := New(Config{
 		Command:    []string{node, "-e", "setTimeout(()=>{},2000)"},
 		Cwd:        dir,
@@ -241,7 +241,7 @@ func TestSessionSlugPrefersExplicitSlug(t *testing.T) {
 		t.Helper()
 		dir := t.TempDir()
 		sockPath := filepath.Join(dir, "test.sock")
-		st := session.New(session.Config{ID: "s1", Kind: "codex", SocketPath: sockPath})
+		st := session.New(session.Config{ID: "s1", Adapter: "codex", SocketPath: sockPath})
 		srv, err := New(Config{
 			Command:    []string{node, "-e", "setTimeout(()=>{},2000)"},
 			Cwd:        dir,
@@ -284,7 +284,7 @@ func TestApplyTurnEnd(t *testing.T) {
 		{"error", false, true},
 	}
 	for _, tc := range cases {
-		st := session.New(session.Config{ID: "s1", Kind: "pi"})
+		st := session.New(session.Config{ID: "s1", Adapter: "pi"})
 		srv := &Server{state: st}
 		srv.applyTurnEnd(tc.outcome, "")
 		status := st.StatusSnapshot()

--- a/cli/gmux/internal/ptyserver/ptyserver.go
+++ b/cli/gmux/internal/ptyserver/ptyserver.go
@@ -539,7 +539,7 @@ type hookEvent struct {
 // busy/idle/unread/error on every agent-loop transition. There is no
 // inference and no per-adapter branching — the agent tells us exactly what it
 // holds and does, and the runner relays those facts (ADR 0011). State written
-// here (SetSessionFile et al.) is a relay snapshot for /events replay, not
+// here (SetConversationFile et al.) is a relay snapshot for /events replay, not
 // derived or sticky.
 func (s *Server) handleHookEvent(w http.ResponseWriter, r *http.Request) {
 	var ev hookEvent
@@ -552,7 +552,7 @@ func (s *Server) handleHookEvent(w http.ResponseWriter, r *http.Request) {
 		// Authoritative bind (e.g. pi's session_start): the file the
 		// agent holds, named and slugged.
 		if ev.Path != "" {
-			s.state.SetSessionFile(ev.Path)
+			s.state.SetConversationFile(ev.Path)
 		}
 		if ev.Name != "" {
 			s.state.SetAdapterTitle(ev.Name)
@@ -720,10 +720,10 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 	ch := s.state.Subscribe()
 	defer s.state.Unsubscribe(ch)
 
-	// Replay the bound session file to this (possibly reconnecting) subscriber
+	// Replay the bound conversation file to this (possibly reconnecting) subscriber
 	// so a restarted daemon re-learns attribution with no persisted state. A
 	// concurrent update may also arrive on ch; harmless (idempotent).
-	if file := s.state.SessionFileSnapshot(); file != "" {
+	if file := s.state.ConversationFileSnapshot(); file != "" {
 		if data, err := json.Marshal(map[string]string{"path": file}); err == nil {
 			fmt.Fprintf(w, "event: conversation_file\ndata: %s\n\n", data)
 		}

--- a/cli/gmux/internal/session/state.go
+++ b/cli/gmux/internal/session/state.go
@@ -44,11 +44,11 @@ type State struct {
 	// Slug is an adapter-provided stable identifier for URL routing.
 	Slug string `json:"slug,omitempty"`
 
-	// SessionFile is the agent's on-disk JSONL conversation file, as
+	// ConversationFile is the agent's on-disk JSONL conversation file, as
 	// reported authoritatively by the agent hook (ADR 0011). It is the
 	// immutable Tool ID's address; a change here is a rebind (/resume).
 	// Empty until the agent reports it, or for unhooked adapters.
-	SessionFile string `json:"conversation_file,omitempty"`
+	ConversationFile string `json:"conversation_file,omitempty"`
 
 	// Terminal size (updated by the runner whenever PTY is resized).
 	TerminalCols uint16 `json:"terminal_cols,omitempty"`
@@ -188,7 +188,7 @@ func (s *State) SetStatus(status *adapter.Status) {
 	s.emit(Event{Type: "status", Data: status})
 }
 
-// SetAdapterTitle sets the high-priority title from the adapter (agent hook / session file).
+// SetAdapterTitle sets the high-priority title from the adapter (agent hook / conversation file).
 func (s *State) SetAdapterTitle(title string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -221,13 +221,13 @@ func (s *State) SetSlug(slug string) {
 	s.emit(Event{Type: "meta", Data: map[string]string{"slug": slug}})
 }
 
-// SessionFileSnapshot returns the held conversation file, for replay to a
+// ConversationFileSnapshot returns the held conversation file, for replay to a
 // newly-connected /events subscriber so a reconnecting daemon re-learns
 // attribution without persisted state.
-func (s *State) SessionFileSnapshot() string {
+func (s *State) ConversationFileSnapshot() string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	return s.SessionFile
+	return s.ConversationFile
 }
 
 // SlugSnapshot returns the current URL-safe slug under lock.
@@ -256,16 +256,16 @@ func (s *State) UnreadSnapshot() bool {
 	return s.Unread
 }
 
-// SetSessionFile records the agent's current conversation file as reported by
+// SetConversationFile records the agent's current conversation file as reported by
 // the extension. Emits a conversation_file event only when the path changes, so
 // the daemon sees first-attribution and rebind (/resume) but not every write.
-func (s *State) SetSessionFile(path string) {
+func (s *State) SetConversationFile(path string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if path == "" || path == s.SessionFile {
+	if path == "" || path == s.ConversationFile {
 		return
 	}
-	s.SessionFile = path
+	s.ConversationFile = path
 	s.emit(Event{Type: "conversation_file", Data: map[string]string{"path": path}})
 }
 

--- a/cli/gmux/internal/session/state.go
+++ b/cli/gmux/internal/session/state.go
@@ -21,9 +21,7 @@ type State struct {
 	CreatedAt     string            `json:"created_at"`
 	Command       []string          `json:"command"`
 	Cwd           string            `json:"cwd"`
-	// Kind holds the adapter name; wire key "adapter" (v2 rename), Go
-	// identifier rename trails with the internal cleanup.
-	Kind          string            `json:"adapter"`
+	Adapter       string            `json:"adapter"`
 	WorkspaceRoot string            `json:"workspace_root,omitempty"`
 	Remotes       map[string]string `json:"remotes,omitempty"`
 
@@ -81,7 +79,7 @@ type Config struct {
 	ID            string
 	Command       []string
 	Cwd           string
-	Kind          string
+	Adapter       string
 	SocketPath    string
 	BinaryHash    string
 	RunnerVersion string
@@ -96,7 +94,7 @@ func New(cfg Config) *State {
 		CreatedAt:     time.Now().UTC().Format(time.RFC3339),
 		Command:       cfg.Command,
 		Cwd:           cfg.Cwd,
-		Kind:          cfg.Kind,
+		Adapter:       cfg.Adapter,
 		WorkspaceRoot: cfg.WorkspaceRoot,
 		Remotes:       cfg.Remotes,
 		SocketPath:    cfg.SocketPath,

--- a/cli/gmux/internal/session/state_test.go
+++ b/cli/gmux/internal/session/state_test.go
@@ -12,7 +12,7 @@ func TestNewState(t *testing.T) {
 		ID:         "sess-test",
 		Command:    []string{"echo", "hello"},
 		Cwd:        "/tmp",
-		Kind:       "generic",
+		Adapter:    "generic",
 		SocketPath: "/tmp/gmux-sessions/sess-test.sock",
 	})
 
@@ -28,14 +28,14 @@ func TestNewState(t *testing.T) {
 }
 
 func TestTitleFallsBackToCommandBasename(t *testing.T) {
-	s := New(Config{ID: "s", Command: []string{"/usr/bin/pi"}, Kind: "pi"})
+	s := New(Config{ID: "s", Command: []string{"/usr/bin/pi"}, Adapter: "pi"})
 	if s.Title() != "pi" {
 		t.Fatalf("expected 'pi', got %q", s.Title())
 	}
 }
 
 func TestShellTitleBeforeAdapterTitle(t *testing.T) {
-	s := New(Config{ID: "s", Command: []string{"pi"}, Kind: "pi"})
+	s := New(Config{ID: "s", Command: []string{"pi"}, Adapter: "pi"})
 
 	s.SetShellTitle("~/dev/project")
 	if s.Title() != "~/dev/project" {
@@ -54,7 +54,7 @@ func TestShellTitleBeforeAdapterTitle(t *testing.T) {
 }
 
 func TestClearAdapterTitleRevealsShellTitle(t *testing.T) {
-	s := New(Config{ID: "s", Command: []string{"pi"}, Kind: "pi"})
+	s := New(Config{ID: "s", Command: []string{"pi"}, Adapter: "pi"})
 
 	s.SetShellTitle("~/dev/project")
 	s.SetAdapterTitle("named task")
@@ -69,7 +69,7 @@ func TestClearAdapterTitleRevealsShellTitle(t *testing.T) {
 }
 
 func TestSetRunning(t *testing.T) {
-	s := New(Config{ID: "s", Command: []string{"echo"}, Kind: "generic"})
+	s := New(Config{ID: "s", Command: []string{"echo"}, Adapter: "generic"})
 	s.SetRunning(12345)
 
 	if !s.Alive {
@@ -81,7 +81,7 @@ func TestSetRunning(t *testing.T) {
 }
 
 func TestSetExited(t *testing.T) {
-	s := New(Config{ID: "s", Command: []string{"echo"}, Kind: "generic"})
+	s := New(Config{ID: "s", Command: []string{"echo"}, Adapter: "generic"})
 	s.SetRunning(12345)
 	s.SetExited(42)
 
@@ -94,7 +94,7 @@ func TestSetExited(t *testing.T) {
 }
 
 func TestSetStatus(t *testing.T) {
-	s := New(Config{ID: "s", Command: []string{"echo"}, Kind: "generic"})
+	s := New(Config{ID: "s", Command: []string{"echo"}, Adapter: "generic"})
 	s.SetStatus(&adapter.Status{Working: true, Error: true})
 
 	if s.Status == nil || !s.Status.Working || !s.Status.Error {
@@ -107,7 +107,7 @@ func TestJSONIncludesComputedTitle(t *testing.T) {
 		ID:      "sess-json",
 		Command: []string{"pi"},
 		Cwd:     "/home/user",
-		Kind:    "pi",
+		Adapter: "pi",
 	})
 	s.SetShellTitle("~/dev/gmux")
 
@@ -130,7 +130,7 @@ func TestJSONIncludesComputedTitle(t *testing.T) {
 }
 
 func TestSubscribeEvents(t *testing.T) {
-	s := New(Config{ID: "s", Command: []string{"echo"}, Kind: "generic"})
+	s := New(Config{ID: "s", Command: []string{"echo"}, Adapter: "generic"})
 	ch := s.Subscribe()
 	defer s.Unsubscribe(ch)
 
@@ -143,7 +143,7 @@ func TestSubscribeEvents(t *testing.T) {
 }
 
 func TestUnsubscribe(t *testing.T) {
-	s := New(Config{ID: "s", Command: []string{"echo"}, Kind: "generic"})
+	s := New(Config{ID: "s", Command: []string{"echo"}, Adapter: "generic"})
 	ch := s.Subscribe()
 	s.Unsubscribe(ch)
 
@@ -154,7 +154,7 @@ func TestUnsubscribe(t *testing.T) {
 }
 
 func TestEmitActivityThrottles(t *testing.T) {
-	s := New(Config{ID: "s", Command: []string{"echo"}, Kind: "generic"})
+	s := New(Config{ID: "s", Command: []string{"echo"}, Adapter: "generic"})
 	ch := s.Subscribe()
 	defer s.Unsubscribe(ch)
 

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -8,7 +8,7 @@
  * if those parsers grow new required fields, the smoke spec is the
  * first place to fail and the failure points at fixture drift.
  *
- * Path encoding mirrors each adapter's `SessionDir(cwd)` exactly. We
+ * Path encoding mirrors each adapter's `ConversationDir(cwd)` exactly. We
  * intentionally don't import any Go logic; the fixtures stand on their
  * own and the smoke spec round-trips them through the real parsers via
  * the public API.
@@ -76,7 +76,7 @@ function codexFile(home: string, spec: FixtureSpec): string {
   // Codex is date-nested by file creation time. Path layout is
   // YYYY/MM/DD/. Bootstrap uses ListSessionFiles which walks the
   // entire tree (date-agnostic), so any reasonable date works for
-  // the smoke spec. Use *local* time to match Go's codex.SessionDir,
+  // the smoke spec. Use *local* time to match Go's codex.ConversationDir,
   // which calls time.Now() (local) — keeps the fixture path
   // identical to whatever a real codex session would create today
   // on the same machine.

--- a/packages/adapter/adapters/claude.go
+++ b/packages/adapter/adapters/claude.go
@@ -20,7 +20,7 @@ var (
 	_ adapter.ConversationSource = (*Claude)(nil)
 	_ adapter.ConversationProber = (*Claude)(nil)
 	_ adapter.Launchable         = (*Claude)(nil)
-	_ adapter.SessionFiler       = (*Claude)(nil)
+	_ adapter.ConversationFiler  = (*Claude)(nil)
 	_ adapter.Resumer            = (*Claude)(nil)
 )
 
@@ -29,7 +29,7 @@ func init() {
 }
 
 // Claude is the adapter for Claude Code (claude CLI).
-// Session files are JSONL in ~/.claude/projects/<encoded-cwd>/.
+// Conversation files are JSONL in ~/.claude/projects/<encoded-cwd>/.
 // Status is driven by the agent hook (see claude_hook.go), not PTY output.
 type Claude struct{}
 
@@ -72,10 +72,10 @@ func (c *Claude) Monitor(_ []byte) *adapter.Event {
 	return nil
 }
 
-// --- SessionFiler ---
+// --- ConversationFiler ---
 
-// SessionRootDir returns Claude Code's per-project sessions directory.
-func (c *Claude) SessionRootDir() string {
+// ConversationRootDir returns Claude Code's per-project sessions directory.
+func (c *Claude) ConversationRootDir() string {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return ""
@@ -83,11 +83,11 @@ func (c *Claude) SessionRootDir() string {
 	return filepath.Join(home, ".claude", "projects")
 }
 
-// ConversationGone anchors deletion detection on SessionRootDir
+// ConversationGone anchors deletion detection on ConversationRootDir
 // (~/.claude/projects): if that tree is present, a missing transcript
 // was deleted; if it's absent, the storage is unavailable.
 func (c *Claude) ConversationGone(path string) (gone bool, ok bool) {
-	return adapter.ConversationGoneAtRoot(path, c.SessionRootDir())
+	return adapter.ConversationGoneAtRoot(path, c.ConversationRootDir())
 }
 
 // encodeClaudeCwd encodes a working directory into Claude Code's directory
@@ -100,9 +100,9 @@ func encodeClaudeCwd(cwd string) string {
 
 var claudeCwdReplacer = strings.NewReplacer("/", "-", ".", "-")
 
-// SessionDir returns Claude Code's session directory for a given cwd.
-func (c *Claude) SessionDir(cwd string) string {
-	root := c.SessionRootDir()
+// ConversationDir returns Claude Code's session directory for a given cwd.
+func (c *Claude) ConversationDir(cwd string) string {
+	root := c.ConversationRootDir()
 	if root == "" {
 		return ""
 	}
@@ -110,7 +110,7 @@ func (c *Claude) SessionDir(cwd string) string {
 }
 
 // claudeFirstLine is the JSON shape of the first meaningful line in a
-// Claude Code session file (type "user").
+// Claude Code conversation file (type "user").
 type claudeFirstLine struct {
 	Type      string `json:"type"`
 	SessionID string `json:"sessionId"`
@@ -122,11 +122,11 @@ type claudeFirstLine struct {
 	} `json:"message"`
 }
 
-// ParseSessionFile reads a Claude Code JSONL session file and returns
+// ParseConversationFile reads a Claude Code JSONL conversation file and returns
 // display metadata.
 // Title priority: custom-title line > first user message text > "" (no
 // conversation-derived title yet; callers fall back to cwd/adapter).
-func (c *Claude) ParseSessionFile(path string) (*adapter.SessionFileInfo, error) {
+func (c *Claude) ParseConversationFile(path string) (*adapter.ConversationInfo, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
@@ -189,7 +189,7 @@ func (c *Claude) ParseSessionFile(path string) (*adapter.SessionFileInfo, error)
 		}
 
 		created, _ := time.Parse(time.RFC3339Nano, header.Timestamp)
-		return &adapter.SessionFileInfo{
+		return &adapter.ConversationInfo{
 			ID:           header.SessionID,
 			Title:        "", // header only, no messages yet
 			Created:      created,
@@ -200,7 +200,7 @@ func (c *Claude) ParseSessionFile(path string) (*adapter.SessionFileInfo, error)
 
 	created, _ := time.Parse(time.RFC3339Nano, firstUser.Timestamp)
 
-	info := &adapter.SessionFileInfo{
+	info := &adapter.ConversationInfo{
 		ID:           firstUser.SessionID,
 		Cwd:          firstUser.Cwd,
 		Created:      created,
@@ -232,13 +232,13 @@ func (c *Claude) ParseSessionFile(path string) (*adapter.SessionFileInfo, error)
 // --- Resumer ---
 
 // ResumeCommand returns the command to resume a Claude Code session.
-func (c *Claude) ResumeCommand(info *adapter.SessionFileInfo) []string {
+func (c *Claude) ResumeCommand(info *adapter.ConversationInfo) []string {
 	return []string{"claude", "--resume", info.ID}
 }
 
-// CanResume checks if a session file has user messages worth resuming.
+// CanResume checks if a conversation file has user messages worth resuming.
 func (c *Claude) CanResume(path string) bool {
-	info, err := c.ParseSessionFile(path)
+	info, err := c.ParseConversationFile(path)
 	if err != nil {
 		return false
 	}
@@ -293,11 +293,11 @@ func cleanClaudeUserText(s string) string {
 // --- ConversationSource ---
 
 func (c *Claude) SnapshotConversations(sink adapter.ConversationSink) {
-	filewatch.Snapshot(c.SessionRootDir(), ".jsonl", sink.Upsert)
+	filewatch.Snapshot(c.ConversationRootDir(), ".jsonl", sink.Upsert)
 }
 
 func (c *Claude) WatchConversations(ctx context.Context, sink adapter.ConversationSink) error {
-	return filewatch.Watch(ctx, c.SessionRootDir(), ".jsonl", func(e filewatch.Event) {
+	return filewatch.Watch(ctx, c.ConversationRootDir(), ".jsonl", func(e filewatch.Event) {
 		if e.Removed {
 			sink.Remove(e.Path)
 		} else {

--- a/packages/adapter/adapters/claude.go
+++ b/packages/adapter/adapters/claude.go
@@ -125,7 +125,7 @@ type claudeFirstLine struct {
 // ParseSessionFile reads a Claude Code JSONL session file and returns
 // display metadata.
 // Title priority: custom-title line > first user message text > "" (no
-// conversation-derived title yet; callers fall back to cwd/kind).
+// conversation-derived title yet; callers fall back to cwd/adapter).
 func (c *Claude) ParseSessionFile(path string) (*adapter.SessionFileInfo, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {

--- a/packages/adapter/adapters/claude_hook.go
+++ b/packages/adapter/adapters/claude_hook.go
@@ -212,7 +212,7 @@ func ClaudeHookBodies(input []byte) [][]byte {
 	case "UserPromptSubmit":
 		// /rename fires no hook of its own — it only appends a custom-title
 		// line to the transcript. Refresh the title here (custom-title wins in
-		// ParseSessionFile) so a mid-session rename shows up at the next
+		// ParseConversationFile) so a mid-session rename shows up at the next
 		// prompt instead of waiting for the turn to end.
 		if b, ok := claudeSessionBody(in.TranscriptPath, in.SessionID, "", in.SessionTitle); ok {
 			return [][]byte{b, turn("start", "")}
@@ -262,7 +262,7 @@ func claudeTitleSlug(transcriptPath, sessionTitle string) (title, slug string) {
 	if t := strings.TrimSpace(sessionTitle); t != "" {
 		return t, adapter.Slugify(t)
 	}
-	info, err := NewClaude().ParseSessionFile(transcriptPath)
+	info, err := NewClaude().ParseConversationFile(transcriptPath)
 	if err != nil || info == nil || info.Title == "" {
 		return "", ""
 	}

--- a/packages/adapter/adapters/claude_integration_test.go
+++ b/packages/adapter/adapters/claude_integration_test.go
@@ -52,8 +52,8 @@ func TestClaudeTurnAndTitle(t *testing.T) {
 	cwd := t.TempDir()
 
 	sess := g.Launch(claudeModel, cwd)
-	if sess.Kind != "claude" {
-		t.Fatalf("expected kind=claude, got %q", sess.Kind)
+	if sess.Adapter != "claude" {
+		t.Fatalf("expected adapter=claude, got %q", sess.Adapter)
 	}
 	t.Logf("session %s alive", sess.ID)
 

--- a/packages/adapter/adapters/claude_test.go
+++ b/packages/adapter/adapters/claude_test.go
@@ -87,8 +87,8 @@ func TestClaudeImplementsCapabilities(t *testing.T) {
 	if _, ok := a.(adapter.Launchable); !ok {
 		t.Fatal("should implement Launchable")
 	}
-	if _, ok := a.(adapter.SessionFiler); !ok {
-		t.Fatal("should implement SessionFiler")
+	if _, ok := a.(adapter.ConversationFiler); !ok {
+		t.Fatal("should implement ConversationFiler")
 	}
 	if _, ok := a.(adapter.Resumer); !ok {
 		t.Fatal("should implement Resumer")
@@ -114,9 +114,9 @@ func TestClaudeLaunchers(t *testing.T) {
 	}
 }
 
-// --- SessionDir encoding ---
+// --- ConversationDir encoding ---
 
-func TestClaudeSessionDirEncoding(t *testing.T) {
+func TestClaudeConversationDirEncoding(t *testing.T) {
 	tests := []struct {
 		cwd  string
 		want string
@@ -128,10 +128,10 @@ func TestClaudeSessionDirEncoding(t *testing.T) {
 	}
 	c := NewClaude()
 	for _, tt := range tests {
-		dir := c.SessionDir(tt.cwd)
+		dir := c.ConversationDir(tt.cwd)
 		base := filepath.Base(dir)
 		if base != tt.want {
-			t.Errorf("SessionDir(%q) base = %q, want %q", tt.cwd, base, tt.want)
+			t.Errorf("ConversationDir(%q) base = %q, want %q", tt.cwd, base, tt.want)
 		}
 	}
 }
@@ -152,7 +152,7 @@ func TestEncodeClaudeCwd(t *testing.T) {
 	}
 }
 
-// --- ParseSessionFile ---
+// --- ParseConversationFile ---
 
 func writeClaudeJSONL(t *testing.T, lines ...string) string {
 	t.Helper()
@@ -166,12 +166,12 @@ func writeClaudeJSONL(t *testing.T, lines ...string) string {
 	return path
 }
 
-func TestClaudeParseSessionFileFirstUserMessage(t *testing.T) {
+func TestClaudeParseConversationFileFirstUserMessage(t *testing.T) {
 	path := writeClaudeJSONL(t,
 		`{"parentUuid":null,"type":"user","sessionId":"abc-123","timestamp":"2026-03-15T10:00:00Z","cwd":"/tmp/test","message":{"role":"user","content":[{"type":"text","text":"Fix the auth bug in login.go"}]},"uuid":"u1"}`,
 		`{"parentUuid":"u1","type":"assistant","sessionId":"abc-123","timestamp":"2026-03-15T10:01:00Z","message":{"role":"assistant","content":[{"type":"text","text":"I'll fix that for you."}],"stop_reason":null},"uuid":"a1"}`,
 	)
-	info, err := NewClaude().ParseSessionFile(path)
+	info, err := NewClaude().ParseConversationFile(path)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -192,13 +192,13 @@ func TestClaudeParseSessionFileFirstUserMessage(t *testing.T) {
 	}
 }
 
-func TestClaudeParseSessionFileCustomTitle(t *testing.T) {
+func TestClaudeParseConversationFileCustomTitle(t *testing.T) {
 	path := writeClaudeJSONL(t,
 		`{"parentUuid":null,"type":"user","sessionId":"abc","timestamp":"2026-03-15T10:00:00Z","cwd":"/tmp","message":{"role":"user","content":[{"type":"text","text":"Fix the bug"}]},"uuid":"u1"}`,
 		`{"parentUuid":"u1","type":"assistant","sessionId":"abc","message":{"role":"assistant","content":[{"type":"text","text":"Done."}]},"uuid":"a1"}`,
 		`{"type":"custom-title","customTitle":"  Auth refactor  ","sessionId":"abc"}`,
 	)
-	info, _ := NewClaude().ParseSessionFile(path)
+	info, _ := NewClaude().ParseConversationFile(path)
 	if info.Title != "Auth refactor" {
 		t.Errorf("expected custom title, got %q", info.Title)
 	}
@@ -209,11 +209,11 @@ func TestClaudeParseSessionFileCustomTitle(t *testing.T) {
 	}
 }
 
-func TestClaudeParseSessionFileQueueOnly(t *testing.T) {
+func TestClaudeParseConversationFileQueueOnly(t *testing.T) {
 	path := writeClaudeJSONL(t,
 		`{"type":"queue-operation","operation":"dequeue","timestamp":"2026-03-15T10:00:00Z","sessionId":"q-123"}`,
 	)
-	info, err := NewClaude().ParseSessionFile(path)
+	info, err := NewClaude().ParseConversationFile(path)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -225,51 +225,51 @@ func TestClaudeParseSessionFileQueueOnly(t *testing.T) {
 	}
 }
 
-func TestClaudeParseSessionFileStringContent(t *testing.T) {
+func TestClaudeParseConversationFileStringContent(t *testing.T) {
 	path := writeClaudeJSONL(t,
 		`{"type":"user","sessionId":"abc","timestamp":"2026-03-15T10:00:00Z","cwd":"/tmp","message":{"role":"user","content":"Help me debug this"},"uuid":"u1"}`,
 	)
-	info, _ := NewClaude().ParseSessionFile(path)
+	info, _ := NewClaude().ParseConversationFile(path)
 	if info.Title != "Help me debug this" {
 		t.Errorf("expected string content as title, got %q", info.Title)
 	}
 }
 
-func TestClaudeParseSessionFileLongTitleTruncated(t *testing.T) {
+func TestClaudeParseConversationFileLongTitleTruncated(t *testing.T) {
 	long := "Please help me with this very long request that goes on and on about many different things and really should be truncated for the sidebar"
 	path := writeClaudeJSONL(t,
 		`{"type":"user","sessionId":"abc","timestamp":"2026-03-15T10:00:00Z","cwd":"/tmp","message":{"role":"user","content":[{"type":"text","text":"`+long+`"}]},"uuid":"u1"}`,
 	)
-	info, _ := NewClaude().ParseSessionFile(path)
+	info, _ := NewClaude().ParseConversationFile(path)
 	if len(info.Title) > 85 {
 		t.Errorf("title too long: %q", info.Title)
 	}
 }
 
-func TestClaudeParseSessionFileContextRefStripped(t *testing.T) {
+func TestClaudeParseConversationFileContextRefStripped(t *testing.T) {
 	path := writeClaudeJSONL(t,
 		`{"type":"user","sessionId":"abc","timestamp":"2026-03-15T10:00:00Z","cwd":"/tmp","message":{"role":"user","content":[{"type":"text","text":"@file.go\n<context ref=\"file:///tmp/file.go#L1:10\">\nfunc main() {}\n</context>\nFix the bug in main()"}]},"uuid":"u1"}`,
 	)
-	info, _ := NewClaude().ParseSessionFile(path)
+	info, _ := NewClaude().ParseConversationFile(path)
 	// Context block removed, leaves @file.go reference + trailing text
 	if info.Title != "@file.go Fix the bug in main()" {
 		t.Errorf("expected context stripped from title, got %q", info.Title)
 	}
 }
 
-func TestClaudeParseSessionFileEmpty(t *testing.T) {
+func TestClaudeParseConversationFileEmpty(t *testing.T) {
 	path := writeClaudeJSONL(t)
-	_, err := NewClaude().ParseSessionFile(path)
+	_, err := NewClaude().ParseConversationFile(path)
 	if err == nil {
 		t.Fatal("expected error for empty file")
 	}
 }
 
-func TestClaudeParseSessionFileNoSessionID(t *testing.T) {
+func TestClaudeParseConversationFileNoSessionID(t *testing.T) {
 	path := writeClaudeJSONL(t,
 		`{"type":"unknown","data":"something"}`,
 	)
-	_, err := NewClaude().ParseSessionFile(path)
+	_, err := NewClaude().ParseConversationFile(path)
 	if err != errNotSession {
 		t.Errorf("expected errNotSession, got %v", err)
 	}
@@ -278,7 +278,7 @@ func TestClaudeParseSessionFileNoSessionID(t *testing.T) {
 // --- Resumer ---
 
 func TestClaudeResumeCommand(t *testing.T) {
-	cmd := NewClaude().ResumeCommand(&adapter.SessionFileInfo{
+	cmd := NewClaude().ResumeCommand(&adapter.ConversationInfo{
 		ID: "abc-123-def",
 	})
 	if len(cmd) != 3 || cmd[0] != "claude" || cmd[1] != "--resume" || cmd[2] != "abc-123-def" {

--- a/packages/adapter/adapters/codex.go
+++ b/packages/adapter/adapters/codex.go
@@ -25,7 +25,7 @@ var (
 	_ adapter.ConversationSource = (*Codex)(nil)
 	_ adapter.ConversationProber = (*Codex)(nil)
 	_ adapter.Launchable         = (*Codex)(nil)
-	_ adapter.SessionFiler       = (*Codex)(nil)
+	_ adapter.ConversationFiler  = (*Codex)(nil)
 	_ adapter.SessionHookCommand = (*Codex)(nil)
 	_ adapter.Resumer            = (*Codex)(nil)
 )
@@ -89,10 +89,10 @@ func (c *Codex) Monitor(_ []byte) *adapter.Event {
 	return nil
 }
 
-// --- SessionFiler ---
+// --- ConversationFiler ---
 
-// SessionRootDir returns Codex's sessions directory.
-func (c *Codex) SessionRootDir() string {
+// ConversationRootDir returns Codex's sessions directory.
+func (c *Codex) ConversationRootDir() string {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return ""
@@ -100,19 +100,19 @@ func (c *Codex) SessionRootDir() string {
 	return filepath.Join(home, ".codex", "sessions")
 }
 
-// ConversationGone anchors deletion detection on SessionRootDir
+// ConversationGone anchors deletion detection on ConversationRootDir
 // (~/.codex/sessions). The date-nested YYYY/MM/DD subtree may be
 // cleaned up around a deleted transcript, so the stable root — not the
 // file's immediate parent — is the right availability anchor.
 func (c *Codex) ConversationGone(path string) (gone bool, ok bool) {
-	return adapter.ConversationGoneAtRoot(path, c.SessionRootDir())
+	return adapter.ConversationGoneAtRoot(path, c.ConversationRootDir())
 }
 
-// SessionDir returns today's date-nested directory where Codex writes new
-// session files. Codex organizes by date (YYYY/MM/DD), not by cwd; the
+// ConversationDir returns today's date-nested directory where Codex writes new
+// conversation files. Codex organizes by date (YYYY/MM/DD), not by cwd; the
 // ConversationSource walks the whole tree for historical sessions.
-func (c *Codex) SessionDir(_ string) string {
-	root := c.SessionRootDir()
+func (c *Codex) ConversationDir(_ string) string {
+	root := c.ConversationRootDir()
 	if root == "" {
 		return ""
 	}
@@ -127,11 +127,11 @@ type codexSessionMeta struct {
 	Cwd       string `json:"cwd"`
 }
 
-// ParseSessionFile reads a Codex JSONL session file and returns display
+// ParseConversationFile reads a Codex JSONL conversation file and returns display
 // metadata.
 // Title priority: first user prompt text > "" (no conversation-derived title
 // yet; callers fall back to cwd/adapter).
-func (c *Codex) ParseSessionFile(path string) (*adapter.SessionFileInfo, error) {
+func (c *Codex) ParseConversationFile(path string) (*adapter.ConversationInfo, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
@@ -157,7 +157,7 @@ func (c *Codex) ParseSessionFile(path string) (*adapter.SessionFileInfo, error) 
 	meta := firstLine.Payload
 	created, _ := time.Parse(time.RFC3339Nano, meta.Timestamp)
 
-	info := &adapter.SessionFileInfo{
+	info := &adapter.ConversationInfo{
 		ID:       meta.ID,
 		Cwd:      meta.Cwd,
 		Created:  created,
@@ -395,7 +395,7 @@ func shellQuote(s string) string {
 // stdin (its SessionStart/Stop input carries session_id, transcript_path, cwd).
 //
 // codex has no title/slug field of its own, so this derives them by parsing the
-// transcript's first user prompt (reusing ParseSessionFile) and reports them as
+// transcript's first user prompt (reusing ParseConversationFile) and reports them as
 // the session title + an explicit slug — codex's session_id is a UUID that would
 // slugify into an unreadable URL.
 func CodexHookBodies(eventName string, input []byte) [][]byte {
@@ -461,7 +461,7 @@ func codexSessionBody(input []byte) ([]byte, bool) {
 // codexHookTitle returns a codex session's display title — the first non-system
 // user prompt, truncated — or "" if the transcript has none yet.
 //
-// Unlike ParseSessionFile it early-exits at the first user message instead of
+// Unlike ParseConversationFile it early-exits at the first user message instead of
 // reading the whole file. This matters because the hook derives the title on
 // every turn-end (codex blocks on the Stop hook), the title never changes after
 // the first prompt, and the transcript grows each turn: a full re-parse would be
@@ -571,13 +571,13 @@ func semverLess(a, b []int) bool {
 // --- Resumer ---
 
 // ResumeCommand returns the command to resume a Codex session.
-func (c *Codex) ResumeCommand(info *adapter.SessionFileInfo) []string {
+func (c *Codex) ResumeCommand(info *adapter.ConversationInfo) []string {
 	return []string{"codex", "resume", info.ID}
 }
 
-// CanResume checks if a session file has user messages worth resuming.
+// CanResume checks if a conversation file has user messages worth resuming.
 func (c *Codex) CanResume(path string) bool {
-	info, err := c.ParseSessionFile(path)
+	info, err := c.ParseConversationFile(path)
 	if err != nil {
 		return false
 	}
@@ -623,11 +623,11 @@ func isCodexSystemContext(s string) bool {
 // --- ConversationSource ---
 
 func (c *Codex) SnapshotConversations(sink adapter.ConversationSink) {
-	filewatch.Snapshot(c.SessionRootDir(), ".jsonl", sink.Upsert)
+	filewatch.Snapshot(c.ConversationRootDir(), ".jsonl", sink.Upsert)
 }
 
 func (c *Codex) WatchConversations(ctx context.Context, sink adapter.ConversationSink) error {
-	return filewatch.Watch(ctx, c.SessionRootDir(), ".jsonl", func(e filewatch.Event) {
+	return filewatch.Watch(ctx, c.ConversationRootDir(), ".jsonl", func(e filewatch.Event) {
 		if e.Removed {
 			sink.Remove(e.Path)
 		} else {

--- a/packages/adapter/adapters/codex.go
+++ b/packages/adapter/adapters/codex.go
@@ -130,7 +130,7 @@ type codexSessionMeta struct {
 // ParseSessionFile reads a Codex JSONL session file and returns display
 // metadata.
 // Title priority: first user prompt text > "" (no conversation-derived title
-// yet; callers fall back to cwd/kind).
+// yet; callers fall back to cwd/adapter).
 func (c *Codex) ParseSessionFile(path string) (*adapter.SessionFileInfo, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {

--- a/packages/adapter/adapters/codex_integration_test.go
+++ b/packages/adapter/adapters/codex_integration_test.go
@@ -55,8 +55,8 @@ func TestCodexTurnAndTitle(t *testing.T) {
 	cwd := t.TempDir()
 
 	sess := g.Launch(codexModel, cwd)
-	if sess.Kind != "codex" {
-		t.Fatalf("expected kind=codex, got %q", sess.Kind)
+	if sess.Adapter != "codex" {
+		t.Fatalf("expected adapter=codex, got %q", sess.Adapter)
 	}
 	t.Logf("session %s alive", sess.ID)
 

--- a/packages/adapter/adapters/codex_test.go
+++ b/packages/adapter/adapters/codex_test.go
@@ -81,8 +81,8 @@ func TestCodexImplementsCapabilities(t *testing.T) {
 	if _, ok := a.(adapter.Launchable); !ok {
 		t.Fatal("should implement Launchable")
 	}
-	if _, ok := a.(adapter.SessionFiler); !ok {
-		t.Fatal("should implement SessionFiler")
+	if _, ok := a.(adapter.ConversationFiler); !ok {
+		t.Fatal("should implement ConversationFiler")
 	}
 	if _, ok := a.(adapter.Resumer); !ok {
 		t.Fatal("should implement Resumer")
@@ -105,7 +105,7 @@ func TestCodexLaunchers(t *testing.T) {
 	}
 }
 
-// --- ParseSessionFile ---
+// --- ParseConversationFile ---
 
 func writeCodexJSONL(t *testing.T, lines ...string) string {
 	t.Helper()
@@ -119,13 +119,13 @@ func writeCodexJSONL(t *testing.T, lines ...string) string {
 	return path
 }
 
-func TestCodexParseSessionFileBasic(t *testing.T) {
+func TestCodexParseConversationFileBasic(t *testing.T) {
 	path := writeCodexJSONL(t,
 		`{"timestamp":"2026-03-17T01:00:00Z","type":"session_meta","payload":{"id":"abc-123","timestamp":"2026-03-17T01:00:00Z","cwd":"/home/mg/dev/test"}}`,
 		`{"timestamp":"2026-03-17T01:00:01Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"Fix the auth bug"}]}}`,
 		`{"timestamp":"2026-03-17T01:00:02Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"I'll fix that for you."}]}}`,
 	)
-	info, err := NewCodex().ParseSessionFile(path)
+	info, err := NewCodex().ParseConversationFile(path)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -143,7 +143,7 @@ func TestCodexParseSessionFileBasic(t *testing.T) {
 	}
 }
 
-func TestCodexParseSessionFileSkipsSystemContext(t *testing.T) {
+func TestCodexParseConversationFileSkipsSystemContext(t *testing.T) {
 	path := writeCodexJSONL(t,
 		`{"timestamp":"2026-03-17T01:00:00Z","type":"session_meta","payload":{"id":"abc","timestamp":"2026-03-17T01:00:00Z","cwd":"/tmp"}}`,
 		`{"timestamp":"2026-03-17T01:00:01Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"<permissions instructions>sandboxing...</permissions instructions>"}]}}`,
@@ -151,47 +151,47 @@ func TestCodexParseSessionFileSkipsSystemContext(t *testing.T) {
 		`{"timestamp":"2026-03-17T01:00:01Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"# AGENTS.md instructions for /tmp\n<INSTRUCTIONS>...</INSTRUCTIONS>"}]}}`,
 		`{"timestamp":"2026-03-17T01:00:02Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"What files are in this directory?"}]}}`,
 	)
-	info, _ := NewCodex().ParseSessionFile(path)
+	info, _ := NewCodex().ParseConversationFile(path)
 	if info.Title != "What files are in this directory?" {
 		t.Errorf("expected user prompt as title (skipping system context), got %q", info.Title)
 	}
 }
 
-func TestCodexParseSessionFileNoMessages(t *testing.T) {
+func TestCodexParseConversationFileNoMessages(t *testing.T) {
 	path := writeCodexJSONL(t,
 		`{"timestamp":"2026-03-17T01:00:00Z","type":"session_meta","payload":{"id":"abc","timestamp":"2026-03-17T01:00:00Z","cwd":"/tmp"}}`,
 	)
-	info, _ := NewCodex().ParseSessionFile(path)
+	info, _ := NewCodex().ParseConversationFile(path)
 	if info.Title != "" {
 		t.Errorf("expected empty title for a session with no messages, got %q", info.Title)
 	}
 }
 
-func TestCodexParseSessionFileLongTitle(t *testing.T) {
+func TestCodexParseConversationFileLongTitle(t *testing.T) {
 	long := "Please help me with this very long request that goes on and on about many different things and really should be truncated for the sidebar"
 	path := writeCodexJSONL(t,
 		`{"timestamp":"2026-03-17T01:00:00Z","type":"session_meta","payload":{"id":"abc","timestamp":"2026-03-17T01:00:00Z","cwd":"/tmp"}}`,
 		`{"timestamp":"2026-03-17T01:00:01Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"`+long+`"}]}}`,
 	)
-	info, _ := NewCodex().ParseSessionFile(path)
+	info, _ := NewCodex().ParseConversationFile(path)
 	if len(info.Title) > 85 {
 		t.Errorf("title too long: %q", info.Title)
 	}
 }
 
-func TestCodexParseSessionFileEmpty(t *testing.T) {
+func TestCodexParseConversationFileEmpty(t *testing.T) {
 	path := writeCodexJSONL(t)
-	_, err := NewCodex().ParseSessionFile(path)
+	_, err := NewCodex().ParseConversationFile(path)
 	if err == nil {
 		t.Fatal("expected error for empty file")
 	}
 }
 
-func TestCodexParseSessionFileNotSessionMeta(t *testing.T) {
+func TestCodexParseConversationFileNotSessionMeta(t *testing.T) {
 	path := writeCodexJSONL(t,
 		`{"type":"response_item","payload":{"type":"message","role":"user"}}`,
 	)
-	_, err := NewCodex().ParseSessionFile(path)
+	_, err := NewCodex().ParseConversationFile(path)
 	if err != errNotSession {
 		t.Errorf("expected errNotSession, got %v", err)
 	}
@@ -200,7 +200,7 @@ func TestCodexParseSessionFileNotSessionMeta(t *testing.T) {
 // --- Resumer ---
 
 func TestCodexResumeCommand(t *testing.T) {
-	cmd := NewCodex().ResumeCommand(&adapter.SessionFileInfo{
+	cmd := NewCodex().ResumeCommand(&adapter.ConversationInfo{
 		ID: "019cf93a-c782-7942-ab76-010c81df6744",
 	})
 	expected := []string{"codex", "resume", "019cf93a-c782-7942-ab76-010c81df6744"}

--- a/packages/adapter/adapters/pi.go
+++ b/packages/adapter/adapters/pi.go
@@ -191,7 +191,7 @@ func (p *Pi) SessionDir(cwd string) string {
 
 // ParseSessionFile reads a pi JSONL session file and returns display metadata.
 // Title priority: session_info.name > first user message > "" (no
-// conversation-derived title yet; callers fall back to cwd/kind).
+// conversation-derived title yet; callers fall back to cwd/adapter).
 func (p *Pi) ParseSessionFile(path string) (*adapter.SessionFileInfo, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {

--- a/packages/adapter/adapters/pi.go
+++ b/packages/adapter/adapters/pi.go
@@ -19,7 +19,7 @@ var (
 	_ adapter.ConversationSource  = (*Pi)(nil)
 	_ adapter.ConversationProber  = (*Pi)(nil)
 	_ adapter.Launchable          = (*Pi)(nil)
-	_ adapter.SessionFiler        = (*Pi)(nil)
+	_ adapter.ConversationFiler   = (*Pi)(nil)
 	_ adapter.Resumer             = (*Pi)(nil)
 	_ adapter.SessionExtender     = (*Pi)(nil)
 	_ adapter.PassthroughDetector = (*Pi)(nil)
@@ -150,13 +150,13 @@ func (p *Pi) Monitor(_ []byte) *adapter.Event {
 	return nil
 }
 
-// --- SessionFiler ---
+// --- ConversationFiler ---
 
-// SessionRootDir returns pi's top-level sessions directory.
+// ConversationRootDir returns pi's top-level sessions directory.
 // Respects PI_CODING_AGENT_DIR (pi's own env var for overriding the
 // agent data directory, default ~/.pi/agent). This lets dev instances
 // use an isolated session store.
-func (p *Pi) SessionRootDir() string {
+func (p *Pi) ConversationRootDir() string {
 	if dir := os.Getenv("PI_CODING_AGENT_DIR"); dir != "" {
 		return filepath.Join(dir, "sessions")
 	}
@@ -167,19 +167,19 @@ func (p *Pi) SessionRootDir() string {
 	return filepath.Join(home, ".pi", "agent", "sessions")
 }
 
-// ConversationGone anchors deletion detection on SessionRootDir
+// ConversationGone anchors deletion detection on ConversationRootDir
 // (PI_CODING_AGENT_DIR/sessions or ~/.pi/agent/sessions): present root
-// means a missing session file was deleted; absent root means the
+// means a missing conversation file was deleted; absent root means the
 // storage is unavailable.
 func (p *Pi) ConversationGone(path string) (gone bool, ok bool) {
-	return adapter.ConversationGoneAtRoot(path, p.SessionRootDir())
+	return adapter.ConversationGoneAtRoot(path, p.ConversationRootDir())
 }
 
-// SessionDir returns pi's session directory for a given cwd.
+// ConversationDir returns pi's session directory for a given cwd.
 // Pi encodes: strip leading /, replace remaining / with -, wrap in --.
 // /home/mg/dev/gmux → --home-mg-dev-gmux--
-func (p *Pi) SessionDir(cwd string) string {
-	root := p.SessionRootDir()
+func (p *Pi) ConversationDir(cwd string) string {
+	root := p.ConversationRootDir()
 	if root == "" {
 		return ""
 	}
@@ -189,10 +189,10 @@ func (p *Pi) SessionDir(cwd string) string {
 	return filepath.Join(root, encoded)
 }
 
-// ParseSessionFile reads a pi JSONL session file and returns display metadata.
+// ParseConversationFile reads a pi JSONL conversation file and returns display metadata.
 // Title priority: session_info.name > first user message > "" (no
 // conversation-derived title yet; callers fall back to cwd/adapter).
-func (p *Pi) ParseSessionFile(path string) (*adapter.SessionFileInfo, error) {
+func (p *Pi) ParseConversationFile(path string) (*adapter.ConversationInfo, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
@@ -218,7 +218,7 @@ func (p *Pi) ParseSessionFile(path string) (*adapter.SessionFileInfo, error) {
 
 	created, _ := time.Parse(time.RFC3339Nano, header.Timestamp)
 
-	info := &adapter.SessionFileInfo{
+	info := &adapter.ConversationInfo{
 		ID:       header.ID,
 		Cwd:      header.Cwd,
 		Created:  created,
@@ -269,13 +269,13 @@ func (p *Pi) ParseSessionFile(path string) (*adapter.SessionFileInfo, error) {
 	return info, nil
 }
 
-func (p *Pi) ResumeCommand(info *adapter.SessionFileInfo) []string {
+func (p *Pi) ResumeCommand(info *adapter.ConversationInfo) []string {
 	return []string{"pi", "--session", info.FilePath, "-c"}
 }
 
-// CanResume checks if a session file is valid and has content worth resuming.
+// CanResume checks if a conversation file is valid and has content worth resuming.
 func (p *Pi) CanResume(path string) bool {
-	info, err := p.ParseSessionFile(path)
+	info, err := p.ParseConversationFile(path)
 	if err != nil {
 		return false
 	}
@@ -342,11 +342,11 @@ func (e *parseError) Error() string { return e.msg }
 // --- ConversationSource ---
 
 func (p *Pi) SnapshotConversations(sink adapter.ConversationSink) {
-	filewatch.Snapshot(p.SessionRootDir(), ".jsonl", sink.Upsert)
+	filewatch.Snapshot(p.ConversationRootDir(), ".jsonl", sink.Upsert)
 }
 
 func (p *Pi) WatchConversations(ctx context.Context, sink adapter.ConversationSink) error {
-	return filewatch.Watch(ctx, p.SessionRootDir(), ".jsonl", func(e filewatch.Event) {
+	return filewatch.Watch(ctx, p.ConversationRootDir(), ".jsonl", func(e filewatch.Event) {
 		if e.Removed {
 			sink.Remove(e.Path)
 		} else {

--- a/packages/adapter/adapters/pi_integration_test.go
+++ b/packages/adapter/adapters/pi_integration_test.go
@@ -56,8 +56,8 @@ func TestPiTurnAndTitle(t *testing.T) {
 	cwd := t.TempDir()
 
 	sess := g.Launch(piModel, cwd)
-	if sess.Kind != "pi" {
-		t.Fatalf("expected kind=pi, got %q", sess.Kind)
+	if sess.Adapter != "pi" {
+		t.Fatalf("expected adapter=pi, got %q", sess.Adapter)
 	}
 
 	send, _ := g.ConnectSession(sess.ID)

--- a/packages/adapter/adapters/pi_test.go
+++ b/packages/adapter/adapters/pi_test.go
@@ -196,15 +196,15 @@ func TestPiImplementsCapabilities(t *testing.T) {
 	if _, ok := a.(adapter.Launchable); !ok {
 		t.Fatal("should implement Launchable")
 	}
-	if _, ok := a.(adapter.SessionFiler); !ok {
-		t.Fatal("should implement SessionFiler")
+	if _, ok := a.(adapter.ConversationFiler); !ok {
+		t.Fatal("should implement ConversationFiler")
 	}
 	if _, ok := a.(adapter.Resumer); !ok {
 		t.Fatal("should implement Resumer")
 	}
 }
 
-// --- SessionFiler ---
+// --- ConversationFiler ---
 
 func writeTempJSONL(t *testing.T, lines ...string) string {
 	t.Helper()
@@ -218,14 +218,14 @@ func writeTempJSONL(t *testing.T, lines ...string) string {
 	return path
 }
 
-func TestParseSessionFileFirstUserMessage(t *testing.T) {
+func TestParseConversationFileFirstUserMessage(t *testing.T) {
 	path := writeTempJSONL(t,
 		`{"type":"session","version":3,"id":"abc-123","timestamp":"2026-03-15T10:00:00Z","cwd":"/tmp/test"}`,
 		`{"type":"model_change","id":"m1","timestamp":"2026-03-15T10:00:00Z"}`,
 		`{"type":"message","id":"u1","timestamp":"2026-03-15T10:01:00Z","message":{"role":"user","content":[{"type":"text","text":"Fix the auth bug in login.go"}]}}`,
 		`{"type":"message","id":"a1","timestamp":"2026-03-15T10:01:05Z","message":{"role":"assistant","content":[{"type":"text","text":"I'll fix that for you."}]}}`,
 	)
-	info, err := NewPi().ParseSessionFile(path)
+	info, err := NewPi().ParseConversationFile(path)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -243,13 +243,13 @@ func TestParseSessionFileFirstUserMessage(t *testing.T) {
 	}
 }
 
-func TestParseSessionFileNameOverrides(t *testing.T) {
+func TestParseConversationFileNameOverrides(t *testing.T) {
 	path := writeTempJSONL(t,
 		`{"type":"session","version":3,"id":"abc","timestamp":"2026-03-15T10:00:00Z","cwd":"/tmp/test"}`,
 		`{"type":"message","id":"u1","timestamp":"2026-03-15T10:01:00Z","message":{"role":"user","content":[{"type":"text","text":"Fix the auth bug"}]}}`,
 		`{"type":"session_info","name":"  Auth refactor  "}`,
 	)
-	info, _ := NewPi().ParseSessionFile(path)
+	info, _ := NewPi().ParseConversationFile(path)
 	if info.Title != "Auth refactor" {
 		t.Errorf("expected session_info name, got %q", info.Title)
 	}
@@ -259,34 +259,34 @@ func TestParseSessionFileNameOverrides(t *testing.T) {
 	}
 }
 
-func TestParseSessionFileNoMessages(t *testing.T) {
+func TestParseConversationFileNoMessages(t *testing.T) {
 	path := writeTempJSONL(t,
 		`{"type":"session","version":3,"id":"abc","timestamp":"2026-03-15T10:00:00Z","cwd":"/tmp/test"}`,
 	)
-	info, _ := NewPi().ParseSessionFile(path)
+	info, _ := NewPi().ParseConversationFile(path)
 	if info.Title != "" {
 		t.Errorf("expected empty title for a session with no messages, got %q", info.Title)
 	}
 }
 
-func TestParseSessionFileLongTitleTruncated(t *testing.T) {
+func TestParseConversationFileLongTitleTruncated(t *testing.T) {
 	long := "Please help me with this very long request that goes on and on about many different things and really should be truncated for the sidebar"
 	path := writeTempJSONL(t,
 		`{"type":"session","version":3,"id":"abc","timestamp":"2026-03-15T10:00:00Z","cwd":"/tmp/test"}`,
 		`{"type":"message","id":"u1","timestamp":"2026-03-15T10:01:00Z","message":{"role":"user","content":[{"type":"text","text":"`+long+`"}]}}`,
 	)
-	info, _ := NewPi().ParseSessionFile(path)
+	info, _ := NewPi().ParseConversationFile(path)
 	if len(info.Title) > 85 {
 		t.Errorf("title too long: %q", info.Title)
 	}
 }
 
-func TestParseSessionFileStringContent(t *testing.T) {
+func TestParseConversationFileStringContent(t *testing.T) {
 	path := writeTempJSONL(t,
 		`{"type":"session","version":3,"id":"abc","timestamp":"2026-03-15T10:00:00Z","cwd":"/tmp/test"}`,
 		`{"type":"message","id":"u1","timestamp":"2026-03-15T10:01:00Z","message":{"role":"user","content":"Help me debug this"}}`,
 	)
-	info, _ := NewPi().ParseSessionFile(path)
+	info, _ := NewPi().ParseConversationFile(path)
 	if info.Title != "Help me debug this" {
 		t.Errorf("expected string content as title, got %q", info.Title)
 	}
@@ -295,7 +295,7 @@ func TestParseSessionFileStringContent(t *testing.T) {
 // --- Resumer ---
 
 func TestResumeCommand(t *testing.T) {
-	cmd := NewPi().ResumeCommand(&adapter.SessionFileInfo{
+	cmd := NewPi().ResumeCommand(&adapter.ConversationInfo{
 		FilePath: "/tmp/test.jsonl",
 	})
 	if len(cmd) != 4 || cmd[0] != "pi" || cmd[1] != "--session" || cmd[3] != "-c" {
@@ -322,26 +322,26 @@ func TestCanResume(t *testing.T) {
 
 // --- Helpers ---
 
-func TestSessionDirEncoding(t *testing.T) {
-	dir := NewPi().SessionDir("/home/mg/dev/gmux")
+func TestConversationDirEncoding(t *testing.T) {
+	dir := NewPi().ConversationDir("/home/mg/dev/gmux")
 	if base := filepath.Base(dir); base != "--home-mg-dev-gmux--" {
 		t.Errorf("expected --home-mg-dev-gmux--, got %s", base)
 	}
 }
 
-func TestSessionRootDirRespectsEnvVar(t *testing.T) {
+func TestConversationRootDirRespectsEnvVar(t *testing.T) {
 	custom := t.TempDir()
 	t.Setenv("PI_CODING_AGENT_DIR", custom)
-	root := NewPi().SessionRootDir()
+	root := NewPi().ConversationRootDir()
 	want := filepath.Join(custom, "sessions")
 	if root != want {
 		t.Errorf("expected %s, got %s", want, root)
 	}
 }
 
-func TestSessionRootDirDefaultWithoutEnvVar(t *testing.T) {
+func TestConversationRootDirDefaultWithoutEnvVar(t *testing.T) {
 	t.Setenv("PI_CODING_AGENT_DIR", "")
-	root := NewPi().SessionRootDir()
+	root := NewPi().ConversationRootDir()
 	home, _ := os.UserHomeDir()
 	want := filepath.Join(home, ".pi", "agent", "sessions")
 	if root != want {
@@ -387,13 +387,13 @@ func TestPiExtendCommand(t *testing.T) {
 }
 
 // TestPiConversationGone verifies the adapter anchors deletion detection
-// on its own SessionRootDir: a missing file under a live root reads as
+// on its own ConversationRootDir: a missing file under a live root reads as
 // deleted, while a missing root (unreachable storage) is undeterminable.
 func TestPiConversationGone(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("PI_CODING_AGENT_DIR", dir)
 	p := NewPi()
-	root := p.SessionRootDir() // <dir>/sessions
+	root := p.ConversationRootDir() // <dir>/sessions
 	if err := os.MkdirAll(root, 0o755); err != nil {
 		t.Fatal(err)
 	}

--- a/packages/adapter/adapters/scrollback_integration_test.go
+++ b/packages/adapter/adapters/scrollback_integration_test.go
@@ -131,7 +131,7 @@ func TestScrollbackPiNoSpinnerFrames(t *testing.T) {
 
 // --- Claude scrollback tests ---
 // NOTE: Claude integration tests are currently broken due to a pre-existing
-// adapter detection issue (claude detected as kind "pi") and TUI interaction
+// adapter detection issue (claude detected as adapter "pi") and TUI interaction
 // changes (welcome overlay intercepts input). These need a separate fix to
 // the claude adapter and test harness. The scrollback fix itself is validated
 // by the pi and shell tests below, which exercise the same TermWriter code path.

--- a/packages/adapter/adapters/shell.go
+++ b/packages/adapter/adapters/shell.go
@@ -29,11 +29,11 @@ func AllAdapters() []adapter.Adapter {
 	return result
 }
 
-// FindByKind returns the adapter with the given name, or nil if not found.
+// FindByAdapter returns the adapter with the given name, or nil if not found.
 // Includes the shell fallback adapter.
-func FindByKind(kind string) adapter.Adapter {
+func FindByAdapter(name string) adapter.Adapter {
 	for _, a := range AllAdapters() {
-		if a.Name() == kind {
+		if a.Name() == name {
 			return a
 		}
 	}

--- a/packages/adapter/adapters/shell.go
+++ b/packages/adapter/adapters/shell.go
@@ -42,11 +42,11 @@ func FindByAdapter(name string) adapter.Adapter {
 
 // Compile-time interface checks.
 var (
-	_ adapter.SessionFiler     = (*Shell)(nil)
-	_ adapter.Resumer          = (*Shell)(nil)
-	_ adapter.CommandTitler    = (*Shell)(nil)
-	_ adapter.SessionRegistrar = (*Shell)(nil)
-	_ adapter.SessionFinalizer = (*Shell)(nil)
+	_ adapter.ConversationFiler = (*Shell)(nil)
+	_ adapter.Resumer           = (*Shell)(nil)
+	_ adapter.CommandTitler     = (*Shell)(nil)
+	_ adapter.SessionRegistrar  = (*Shell)(nil)
+	_ adapter.SessionFinalizer  = (*Shell)(nil)
 )
 
 // Shell is the fallback adapter. It matches all commands and parses
@@ -89,19 +89,19 @@ func (g *Shell) Monitor(_ []byte) *adapter.Event {
 	return nil
 }
 
-// --- SessionFiler ---
+// --- ConversationFiler ---
 
 // shellSessionsDir returns the directory for shell state files.
 func shellSessionsDir() string {
 	return filepath.Join(paths.StateDir(), "shell-sessions")
 }
 
-func (g *Shell) SessionRootDir() string {
+func (g *Shell) ConversationRootDir() string {
 	return shellSessionsDir()
 }
 
-func (g *Shell) SessionDir(cwd string) string {
-	root := g.SessionRootDir()
+func (g *Shell) ConversationDir(cwd string) string {
+	root := g.ConversationRootDir()
 	if root == "" {
 		return ""
 	}
@@ -121,7 +121,7 @@ type shellStateFile struct {
 	Created time.Time `json:"created"`
 }
 
-func (g *Shell) ParseSessionFile(path string) (*adapter.SessionFileInfo, error) {
+func (g *Shell) ParseConversationFile(path string) (*adapter.ConversationInfo, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
@@ -133,7 +133,7 @@ func (g *Shell) ParseSessionFile(path string) (*adapter.SessionFileInfo, error) 
 	if sf.ID == "" || sf.Cwd == "" {
 		return nil, os.ErrInvalid
 	}
-	return &adapter.SessionFileInfo{
+	return &adapter.ConversationInfo{
 		ID:       sf.ID,
 		Title:    g.CommandTitle(sf.Command),
 		Slug:     adapter.Slugify(filepath.Base(sf.Cwd)),
@@ -145,7 +145,7 @@ func (g *Shell) ParseSessionFile(path string) (*adapter.SessionFileInfo, error) 
 
 // --- Resumer ---
 
-func (g *Shell) ResumeCommand(info *adapter.SessionFileInfo) []string {
+func (g *Shell) ResumeCommand(info *adapter.ConversationInfo) []string {
 	// Resume a shell session by launching the user's default shell in the
 	// original cwd. The cwd is passed via the session metadata, not the
 	// command itself.
@@ -157,7 +157,7 @@ func (g *Shell) ResumeCommand(info *adapter.SessionFileInfo) []string {
 }
 
 func (g *Shell) CanResume(path string) bool {
-	_, err := g.ParseSessionFile(path)
+	_, err := g.ParseConversationFile(path)
 	return err == nil
 }
 
@@ -189,7 +189,7 @@ func (g *Shell) OnDismiss(id, cwd string) {
 // after a gmuxd restart.
 func WriteShellStateFile(sessionID, cwd string, command []string) (string, error) {
 	sh := NewShell()
-	dir := sh.SessionDir(cwd)
+	dir := sh.ConversationDir(cwd)
 	if dir == "" {
 		return "", os.ErrInvalid
 	}
@@ -219,7 +219,7 @@ func WriteShellStateFile(sessionID, cwd string, command []string) (string, error
 // Called when a shell session is dismissed.
 func RemoveShellStateFile(sessionID, cwd string) {
 	sh := NewShell()
-	dir := sh.SessionDir(cwd)
+	dir := sh.ConversationDir(cwd)
 	if dir == "" {
 		return
 	}

--- a/packages/adapter/adapters/shell_test.go
+++ b/packages/adapter/adapters/shell_test.go
@@ -10,8 +10,8 @@ import (
 
 func TestShellImplementsInterfaces(t *testing.T) {
 	var s adapter.Adapter = NewShell()
-	if _, ok := s.(adapter.SessionFiler); !ok {
-		t.Fatal("Shell should implement SessionFiler")
+	if _, ok := s.(adapter.ConversationFiler); !ok {
+		t.Fatal("Shell should implement ConversationFiler")
 	}
 	if _, ok := s.(adapter.Resumer); !ok {
 		t.Fatal("Shell should implement Resumer")
@@ -42,9 +42,9 @@ func TestShellWriteAndParseStateFile(t *testing.T) {
 	}
 
 	sh := NewShell()
-	info, err := sh.ParseSessionFile(path)
+	info, err := sh.ParseConversationFile(path)
 	if err != nil {
-		t.Fatalf("ParseSessionFile: %v", err)
+		t.Fatalf("ParseConversationFile: %v", err)
 	}
 
 	if info.ID != "sess-abc123" {
@@ -88,7 +88,7 @@ func TestShellCanResume(t *testing.T) {
 func TestShellResumeCommand(t *testing.T) {
 	t.Setenv("SHELL", "/usr/bin/fish")
 	sh := NewShell()
-	cmd := sh.ResumeCommand(&adapter.SessionFileInfo{
+	cmd := sh.ResumeCommand(&adapter.ConversationInfo{
 		Cwd: "/home/user/project",
 	})
 	if len(cmd) != 1 || cmd[0] != "/usr/bin/fish" {
@@ -96,15 +96,15 @@ func TestShellResumeCommand(t *testing.T) {
 	}
 }
 
-func TestShellSessionDir(t *testing.T) {
+func TestShellConversationDir(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_STATE_HOME", tmp)
 
 	sh := NewShell()
-	dir := sh.SessionDir("/home/user/dev/project")
+	dir := sh.ConversationDir("/home/user/dev/project")
 	expected := filepath.Join(tmp, "gmux", "shell-sessions", "--home-user-dev-project--")
 	if dir != expected {
-		t.Errorf("SessionDir = %q, want %q", dir, expected)
+		t.Errorf("ConversationDir = %q, want %q", dir, expected)
 	}
 }
 
@@ -170,7 +170,7 @@ func TestShellOnRegister(t *testing.T) {
 	}
 
 	// State file should exist so the session can be rediscovered after restart.
-	statePath := filepath.Join(sh.SessionDir("/home/user/dev/myproject"), "sess-reg1.json")
+	statePath := filepath.Join(sh.ConversationDir("/home/user/dev/myproject"), "sess-reg1.json")
 	if _, err := os.Stat(statePath); err != nil {
 		t.Fatalf("state file not created at %s: %v", statePath, err)
 	}
@@ -190,7 +190,7 @@ func TestShellOnDismiss(t *testing.T) {
 	if _, err := sh.OnRegister("sess-dis1", "/home/user/dev/proj", []string{"zsh"}); err != nil {
 		t.Fatalf("OnRegister: %v", err)
 	}
-	statePath := filepath.Join(sh.SessionDir("/home/user/dev/proj"), "sess-dis1.json")
+	statePath := filepath.Join(sh.ConversationDir("/home/user/dev/proj"), "sess-dis1.json")
 	if _, err := os.Stat(statePath); err != nil {
 		t.Fatalf("state file should exist before dismiss: %v", err)
 	}

--- a/packages/adapter/adapters/shell_test.go
+++ b/packages/adapter/adapters/shell_test.go
@@ -145,7 +145,7 @@ func TestAllAdaptersIncludesShell(t *testing.T) {
 func TestFindByKind(t *testing.T) {
 	// Shell is the fallback — not in All — so FindByKind is the only way
 	// to look it up by name without a match call.
-	shell := FindByKind("shell")
+	shell := FindByAdapter("shell")
 	if shell == nil {
 		t.Fatal("FindByKind(\"shell\") returned nil")
 	}
@@ -153,8 +153,8 @@ func TestFindByKind(t *testing.T) {
 		t.Errorf("got adapter name %q, want \"shell\"", shell.Name())
 	}
 
-	// Unknown kind should return nil.
-	if got := FindByKind("nonexistent"); got != nil {
+	// Unknown adapter should return nil.
+	if got := FindByAdapter("nonexistent"); got != nil {
 		t.Errorf("FindByKind(\"nonexistent\") = %v, want nil", got)
 	}
 }

--- a/packages/adapter/adapters/testutil/harness.go
+++ b/packages/adapter/adapters/testutil/harness.go
@@ -27,7 +27,7 @@ import (
 // Session mirrors the gmuxd session schema fields we care about.
 type Session struct {
 	ID           string   `json:"id"`
-	Kind         string   `json:"adapter"`
+	Adapter      string   `json:"adapter"`
 	Alive        bool     `json:"alive"`
 	Pid          int      `json:"pid"`
 	Title        string   `json:"title"`
@@ -36,7 +36,7 @@ type Session struct {
 	SocketPath   string   `json:"socket_path"`
 	Status       *Status  `json:"status"`
 	Resumable    bool     `json:"resumable"`
-	Slug    string   `json:"slug"`
+	Slug         string   `json:"slug"`
 	Command      []string `json:"command"`
 }
 
@@ -134,7 +134,7 @@ func (g *Gmuxd) Launch(command []string, cwd string) Session {
 	}
 
 	return g.WaitFor(func(s Session) bool {
-		return s.Alive && s.Cwd == cwd && s.Kind != "" && s.SocketPath != ""
+		return s.Alive && s.Cwd == cwd && s.Adapter != "" && s.SocketPath != ""
 	}, 15*time.Second, "session to appear alive")
 }
 
@@ -146,7 +146,9 @@ func (g *Gmuxd) Sessions() []Session {
 		g.t.Fatalf("list sessions: %v", err)
 	}
 	defer resp.Body.Close()
-	var env struct{ Data []Session `json:"data"` }
+	var env struct {
+		Data []Session `json:"data"`
+	}
 	json.NewDecoder(resp.Body).Decode(&env)
 	return env.Data
 }
@@ -298,7 +300,9 @@ func findRepoRoot(t *testing.T) string {
 func freePort(t *testing.T) int {
 	t.Helper()
 	l, err := net.Listen("tcp", "localhost:0")
-	if err != nil { t.Fatal(err) }
+	if err != nil {
+		t.Fatal(err)
+	}
 	port := l.Addr().(*net.TCPAddr).Port
 	l.Close()
 	return port

--- a/packages/adapter/capabilities.go
+++ b/packages/adapter/capabilities.go
@@ -5,8 +5,8 @@ import (
 	"time"
 )
 
-// SessionFileInfo holds metadata extracted from a tool's session file.
-type SessionFileInfo struct {
+// ConversationInfo holds metadata extracted from a tool's conversation file.
+type ConversationInfo struct {
 	ID           string
 	Title        string
 	Slug         string // Human-readable, URL-safe session identity. Set by the adapter.
@@ -37,27 +37,27 @@ type Launchable interface {
 	Launchers() []Launcher
 }
 
-// SessionFiler is implemented by adapters whose tools write session
-// files to disk (pi, claude-code, etc). Used by gmuxd for resumable
-// session discovery and session file attribution.
-type SessionFiler interface {
-	// SessionRootDir returns the parent directory containing all per-cwd
-	// session subdirectories (e.g. ~/.pi/agent/sessions/).
+// ConversationFiler is implemented by adapters whose tools write
+// conversation files to disk (pi, claude-code, etc). Used by gmuxd for
+// resumable-conversation discovery and conversation file attribution.
+type ConversationFiler interface {
+	// ConversationRootDir returns the parent directory containing all per-cwd
+	// conversation subdirectories (e.g. ~/.pi/agent/sessions/).
 	// Used by the scanner to enumerate all known working directories.
-	SessionRootDir() string
+	ConversationRootDir() string
 
-	// SessionDir returns the directory where this tool stores session
-	// files for the given cwd. Returns "" if not applicable.
-	SessionDir(cwd string) string
+	// ConversationDir returns the directory where this tool stores
+	// conversation files for the given cwd. Returns "" if not applicable.
+	ConversationDir(cwd string) string
 
-	// ParseSessionFile reads a session file and returns display metadata.
+	// ParseConversationFile reads a conversation file and returns display metadata.
 	// Called by gmuxd to index conversations and resolve resume commands.
-	ParseSessionFile(path string) (*SessionFileInfo, error)
+	ParseConversationFile(path string) (*ConversationInfo, error)
 }
 
 // ConversationSink receives conversation-file changes from a ConversationSource.
-// Paths are absolute session-file paths the daemon resolves via the adapter's
-// ParseSessionFile.
+// Paths are absolute conversation-file paths the daemon resolves via the adapter's
+// ParseConversationFile.
 type ConversationSink interface {
 	// Upsert reports a conversation file that exists, was created, or changed.
 	Upsert(path string)
@@ -80,7 +80,7 @@ type ConversationSource interface {
 	WatchConversations(ctx context.Context, sink ConversationSink) error
 }
 
-// ConversationProber is implemented by SessionFiler adapters that can
+// ConversationProber is implemented by ConversationFiler adapters that can
 // tell a *deleted* conversation file apart from one whose storage is
 // merely *unavailable* (unmounted home, a tool dir that doesn't exist
 // yet). The startup retention reconcile (services/gmuxd) uses it to
@@ -183,9 +183,9 @@ type SessionFinalizer interface {
 // after the process exits.
 type Resumer interface {
 	// ResumeCommand returns the command to resume the given session.
-	ResumeCommand(info *SessionFileInfo) []string
+	ResumeCommand(info *ConversationInfo) []string
 
-	// CanResume returns whether a session file represents a resumable
+	// CanResume returns whether a conversation file represents a resumable
 	// session (vs a corrupted/empty/incompatible one).
 	CanResume(path string) bool
 }

--- a/packages/adapter/conversation.go
+++ b/packages/adapter/conversation.go
@@ -16,7 +16,7 @@ import (
 //   - path absent, root absent/unreadable    → (false, false) undeterminable
 //   - any non-NotExist stat error on path    → (false, false) undeterminable
 //
-// root is the adapter's layout anchor (e.g. SessionRootDir). It lives
+// root is the adapter's layout anchor (e.g. ConversationRootDir). It lives
 // under the same storage as path, so an unmounted home or a tool that
 // was never installed makes root absent too — yielding ok=false rather
 // than a false "deleted". Empty path or root is undeterminable.

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -582,8 +582,8 @@ func serve(stderr io.Writer) int {
 	// event. Run from discovery's first-scan hook (live runners flagged),
 	// it asks each owning adapter whether its dead sessions' files are
 	// gone. See reconcileDeletedConversations for the safety gate.
-	convProbe := func(kind, path string) (gone, known bool) {
-		if p, ok := adapters.FindByKind(kind).(adapter.ConversationProber); ok {
+	convProbe := func(adapterName, path string) (gone, known bool) {
+		if p, ok := adapters.FindByAdapter(adapterName).(adapter.ConversationProber); ok {
 			return p.ConversationGone(path)
 		}
 		return false, false
@@ -652,7 +652,7 @@ func serve(stderr io.Writer) int {
 	stopScanner := make(chan struct{})
 	defer close(stopScanner)
 
-	// Conversations index — maps (kind, slug) to file metadata for URL
+	// Conversations index — maps (adapter, slug) to file metadata for URL
 	// resolution of dead conversations and future fulltext search. Each
 	// adapter's ConversationSource supplies a snapshot at startup and
 	// incremental updates thereafter; the daemon owns no file monitor.
@@ -1257,7 +1257,7 @@ func serve(stderr io.Writer) int {
 			"ok": true,
 			"data": map[string]any{
 				"slug":           info.Slug,
-				"adapter":        info.Kind,
+				"adapter":        info.Adapter,
 				"title":          info.Title,
 				"cwd":            info.Cwd,
 				"resume_command": info.ResumeCommand,
@@ -1745,7 +1745,7 @@ func serve(stderr io.Writer) int {
 				}
 			}
 			// Let the adapter perform any cleanup (e.g. removing a state file).
-			if a := adapters.FindByKind(sess.Kind); a != nil {
+			if a := adapters.FindByAdapter(sess.Adapter); a != nil {
 				if fin, ok := a.(adapter.SessionFinalizer); ok {
 					fin.OnDismiss(sessionID, projects.NormalizePath(sess.Cwd))
 				}

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -575,7 +575,7 @@ func serve(stderr io.Writer) int {
 	// and meta.json mirrors conversation existence (ADR 0016). The store
 	// applies the alive/peer/N:1 guards; its session-remove broadcast is
 	// what WatchRemovals turns into a meta-dir delete.
-	convRetireMeta := func(path string) { sessions.RemoveDeadBySessionFile(path) }
+	convRetireMeta := func(path string) { sessions.RemoveDeadByConversationFile(path) }
 
 	// retireDeleted closes the gap the runtime index signal can't cover:
 	// a conversation file deleted while gmuxd was *down* emits no removal
@@ -589,7 +589,7 @@ func serve(stderr io.Writer) int {
 		return false, false
 	}
 	retireDeleted := func(path string) {
-		if ids := sessions.RemoveDeadBySessionFile(path); len(ids) > 0 {
+		if ids := sessions.RemoveDeadByConversationFile(path); len(ids) > 0 {
 			log.Printf("sessionmeta: retired %d dead session(s) for deleted conversation %s", len(ids), path)
 		}
 	}
@@ -643,8 +643,8 @@ func serve(stderr io.Writer) int {
 	}, 3*time.Second, stopDiscovery)
 	defer close(stopDiscovery)
 
-	// Session file scanner — discovers resumable sessions from adapter
-	// session files (e.g. pi's JSONL conversations). Also purges stale
+	// Conversation file scanner — discovers resumable sessions from adapter
+	// conversation files (e.g. pi's JSONL conversations). Also purges stale
 	// dead sessions that were never attributed to a file. Started below
 	// after the project manager is set up so the first-scan callback
 	// can clean up orphaned project session refs.

--- a/services/gmuxd/cmd/gmuxd/rehydrate.go
+++ b/services/gmuxd/cmd/gmuxd/rehydrate.go
@@ -26,7 +26,7 @@ import (
 //     the steady-state for shell sessions, where the runner ID and
 //     the conversations-index ConversationID are the same string.
 //
-//  2. Same (kind, slug) present (sessions.HasLocalSlug). This is
+//  2. Same (adapter, slug) present (sessions.HasLocalSlug). This is
 //     critical for agent-backed adapters (pi, claude, codex) where
 //     the conversations index uses the adapter's own UUID (e.g. the
 //     JSONL filename) as ConversationID, while sessionmeta keys by the
@@ -54,7 +54,7 @@ func rehydrateProjects(sessions *store.Store, convIndex *conversations.Index, st
 			if _, exists := sessions.Get(info.ConversationID); exists {
 				continue
 			}
-			if sessions.HasLocalSlug(info.Kind, info.Slug) {
+			if sessions.HasLocalSlug(info.Adapter, info.Slug) {
 				continue
 			}
 			fallbacks++
@@ -63,7 +63,7 @@ func rehydrateProjects(sessions *store.Store, convIndex *conversations.Index, st
 				CreatedAt:    info.Created.UTC().Format(time.RFC3339),
 				Command:      info.ResumeCommand,
 				Cwd:          info.Cwd,
-				Kind:         info.Kind,
+				Adapter:      info.Adapter,
 				Alive:        false,
 				AdapterTitle: info.Title,
 				Slug:         info.Slug,

--- a/services/gmuxd/cmd/gmuxd/rehydrate_test.go
+++ b/services/gmuxd/cmd/gmuxd/rehydrate_test.go
@@ -29,7 +29,7 @@ func TestRehydrateProjects_PreservesSessionmetaState(t *testing.T) {
 	loaded := store.Session{
 		ID:         "tool-abc",
 		Slug:       "fix-auth",
-		Kind:       "shell",
+		Adapter:    "shell",
 		Cwd:        "/home/me/proj",
 		Alive:      false,
 		ExitCode:   &exitCode,
@@ -44,12 +44,12 @@ func TestRehydrateProjects_PreservesSessionmetaState(t *testing.T) {
 	// from scanning adapter state files. Pre-fix, this would feed
 	// into Upsert via projects rehydration, take precedence over the
 	// already-loaded ShellTitle (AdapterTitle > ShellTitle), and
-	// clobber Title to the generic kind label.
+	// clobber Title to the generic adapter label.
 	idx := conversations.New()
 	idx.Upsert(conversations.Info{
 		ConversationID: "tool-abc",
 		Slug:           "fix-auth",
-		Kind:           "shell",
+		Adapter:        "shell",
 		Title:          "shell", // becomes AdapterTitle on rehydrate
 		Cwd:            "/home/me/proj",
 		Created:        time.Date(2024, 1, 1, 11, 0, 0, 0, time.UTC),
@@ -96,11 +96,11 @@ func TestRehydrateProjects_PreventsDuplicateForToolBackedAdapter(t *testing.T) {
 
 	// Sessionmeta-loaded entry: keyed by runner session ID.
 	sessions.Upsert(store.Session{
-		ID:    "sess-runner-A",
-		Slug:  "fix-auth",
-		Kind:  "pi",
-		Cwd:   "/work",
-		Alive: false,
+		ID:      "sess-runner-A",
+		Slug:    "fix-auth",
+		Adapter: "pi",
+		Cwd:     "/work",
+		Alive:   false,
 	})
 
 	// convIndex entry: same logical session, but ConversationID is the JSONL
@@ -109,7 +109,7 @@ func TestRehydrateProjects_PreventsDuplicateForToolBackedAdapter(t *testing.T) {
 	idx.Upsert(conversations.Info{
 		ConversationID: "jsonl-uuid-XYZ",
 		Slug:           "fix-auth",
-		Kind:           "pi",
+		Adapter:        "pi",
 		Title:          "fix auth",
 		Cwd:            "/work",
 		Created:        time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
@@ -146,7 +146,7 @@ func TestRehydrateProjects_FallbackForMissingSessionmeta(t *testing.T) {
 	idx.Upsert(conversations.Info{
 		ConversationID: "tool-old",
 		Slug:           "legacy",
-		Kind:           "shell",
+		Adapter:        "shell",
 		Title:          "shell",
 		Cwd:            "/home/me/legacy",
 		Created:        time.Date(2023, 6, 1, 0, 0, 0, 0, time.UTC),

--- a/services/gmuxd/cmd/gmuxd/retention.go
+++ b/services/gmuxd/cmd/gmuxd/retention.go
@@ -21,16 +21,16 @@ import "github.com/gmuxapp/gmux/services/gmuxd/internal/store"
 func reconcileDeletedConversations(
 	list []store.Session,
 	probe func(adapter, conversationFile string) (gone, known bool),
-	retire func(sessionFile string),
+	retire func(conversationFile string),
 ) {
 	seen := map[string]bool{}
 	for _, sess := range list {
-		if sess.Alive || sess.Peer != "" || sess.SessionFile == "" || seen[sess.SessionFile] {
+		if sess.Alive || sess.Peer != "" || sess.ConversationFile == "" || seen[sess.ConversationFile] {
 			continue
 		}
-		seen[sess.SessionFile] = true
-		if gone, known := probe(sess.Adapter, sess.SessionFile); known && gone {
-			retire(sess.SessionFile)
+		seen[sess.ConversationFile] = true
+		if gone, known := probe(sess.Adapter, sess.ConversationFile); known && gone {
+			retire(sess.ConversationFile)
 		}
 	}
 }

--- a/services/gmuxd/cmd/gmuxd/retention.go
+++ b/services/gmuxd/cmd/gmuxd/retention.go
@@ -8,7 +8,7 @@ import "github.com/gmuxapp/gmux/services/gmuxd/internal/store"
 // confidently reports deleted. It covers the gap the index can't —
 // a conversation file removed while gmuxd was down emits no event.
 //
-// probe answers "is this kind's conversation file at path gone?" as
+// probe answers "is this adapter's conversation file at path gone?" as
 // (gone, known). Retirement happens only on (known && gone): when the
 // adapter can't tell (known=false, e.g. its storage root is unreachable
 // because home isn't mounted), the entry is kept. That gate is the
@@ -20,7 +20,7 @@ import "github.com/gmuxapp/gmux/services/gmuxd/internal/store"
 // that path. Alive, peer-owned, and file-less sessions are skipped.
 func reconcileDeletedConversations(
 	list []store.Session,
-	probe func(kind, sessionFile string) (gone, known bool),
+	probe func(adapter, conversationFile string) (gone, known bool),
 	retire func(sessionFile string),
 ) {
 	seen := map[string]bool{}
@@ -29,7 +29,7 @@ func reconcileDeletedConversations(
 			continue
 		}
 		seen[sess.SessionFile] = true
-		if gone, known := probe(sess.Kind, sess.SessionFile); known && gone {
+		if gone, known := probe(sess.Adapter, sess.SessionFile); known && gone {
 			retire(sess.SessionFile)
 		}
 	}

--- a/services/gmuxd/cmd/gmuxd/retention_test.go
+++ b/services/gmuxd/cmd/gmuxd/retention_test.go
@@ -14,11 +14,11 @@ import (
 // the reconcile asks an adapter instead of stat'ing the file directly.
 func TestReconcileDeletedConversations_SafetyGate(t *testing.T) {
 	list := []store.Session{
-		{ID: "deleted", Kind: "claude", SessionFile: "/c/deleted.jsonl"},
-		{ID: "present", Kind: "claude", SessionFile: "/c/present.jsonl"},
-		{ID: "unreachable", Kind: "codex", SessionFile: "/x/unreachable.jsonl"},
+		{ID: "deleted", Adapter: "claude", SessionFile: "/c/deleted.jsonl"},
+		{ID: "present", Adapter: "claude", SessionFile: "/c/present.jsonl"},
+		{ID: "unreachable", Adapter: "codex", SessionFile: "/x/unreachable.jsonl"},
 	}
-	probe := func(kind, path string) (gone, known bool) {
+	probe := func(adapter, path string) (gone, known bool) {
 		switch path {
 		case "/c/deleted.jsonl":
 			return true, true // confidently deleted
@@ -42,9 +42,9 @@ func TestReconcileDeletedConversations_SafetyGate(t *testing.T) {
 // and file-less sessions are never probed or retired.
 func TestReconcileDeletedConversations_Skips(t *testing.T) {
 	list := []store.Session{
-		{ID: "alive", Kind: "claude", SessionFile: "/c/a.jsonl", Alive: true},
-		{ID: "peer", Kind: "claude", SessionFile: "/c/b.jsonl", Peer: "box2"},
-		{ID: "nofile", Kind: "claude", SessionFile: ""},
+		{ID: "alive", Adapter: "claude", SessionFile: "/c/a.jsonl", Alive: true},
+		{ID: "peer", Adapter: "claude", SessionFile: "/c/b.jsonl", Peer: "box2"},
+		{ID: "nofile", Adapter: "claude", SessionFile: ""},
 	}
 	var probed, retired []string
 	reconcileDeletedConversations(list,
@@ -65,9 +65,9 @@ func TestReconcileDeletedConversations_Skips(t *testing.T) {
 func TestReconcileDeletedConversations_DedupsPaths(t *testing.T) {
 	const shared = "/c/shared.jsonl"
 	list := []store.Session{
-		{ID: "d1", Kind: "claude", SessionFile: shared},
-		{ID: "d2", Kind: "claude", SessionFile: shared},
-		{ID: "d3", Kind: "claude", SessionFile: shared},
+		{ID: "d1", Adapter: "claude", SessionFile: shared},
+		{ID: "d2", Adapter: "claude", SessionFile: shared},
+		{ID: "d3", Adapter: "claude", SessionFile: shared},
 	}
 	var probed, retired []string
 	reconcileDeletedConversations(list,
@@ -82,16 +82,16 @@ func TestReconcileDeletedConversations_DedupsPaths(t *testing.T) {
 	}
 }
 
-// TestReconcileDeletedConversations_NoProberKind pins that a kind whose
+// TestReconcileDeletedConversations_NoProberKind pins that an adapter whose
 // adapter can't probe (probe returns known=false) is left alone — this
 // is how the real convProbe reports a missing/incapable adapter.
 func TestReconcileDeletedConversations_NoProberKind(t *testing.T) {
-	list := []store.Session{{ID: "s", Kind: "shell", SessionFile: "/s/x"}}
+	list := []store.Session{{ID: "s", Adapter: "shell", SessionFile: "/s/x"}}
 	var retired []string
 	reconcileDeletedConversations(list,
 		func(_, _ string) (bool, bool) { return false, false },
 		func(p string) { retired = append(retired, p) })
 	if len(retired) != 0 {
-		t.Errorf("kind without a prober must not retire, got %v", retired)
+		t.Errorf("adapter without a prober must not retire, got %v", retired)
 	}
 }

--- a/services/gmuxd/cmd/gmuxd/retention_test.go
+++ b/services/gmuxd/cmd/gmuxd/retention_test.go
@@ -14,9 +14,9 @@ import (
 // the reconcile asks an adapter instead of stat'ing the file directly.
 func TestReconcileDeletedConversations_SafetyGate(t *testing.T) {
 	list := []store.Session{
-		{ID: "deleted", Adapter: "claude", SessionFile: "/c/deleted.jsonl"},
-		{ID: "present", Adapter: "claude", SessionFile: "/c/present.jsonl"},
-		{ID: "unreachable", Adapter: "codex", SessionFile: "/x/unreachable.jsonl"},
+		{ID: "deleted", Adapter: "claude", ConversationFile: "/c/deleted.jsonl"},
+		{ID: "present", Adapter: "claude", ConversationFile: "/c/present.jsonl"},
+		{ID: "unreachable", Adapter: "codex", ConversationFile: "/x/unreachable.jsonl"},
 	}
 	probe := func(adapter, path string) (gone, known bool) {
 		switch path {
@@ -42,9 +42,9 @@ func TestReconcileDeletedConversations_SafetyGate(t *testing.T) {
 // and file-less sessions are never probed or retired.
 func TestReconcileDeletedConversations_Skips(t *testing.T) {
 	list := []store.Session{
-		{ID: "alive", Adapter: "claude", SessionFile: "/c/a.jsonl", Alive: true},
-		{ID: "peer", Adapter: "claude", SessionFile: "/c/b.jsonl", Peer: "box2"},
-		{ID: "nofile", Adapter: "claude", SessionFile: ""},
+		{ID: "alive", Adapter: "claude", ConversationFile: "/c/a.jsonl", Alive: true},
+		{ID: "peer", Adapter: "claude", ConversationFile: "/c/b.jsonl", Peer: "box2"},
+		{ID: "nofile", Adapter: "claude", ConversationFile: ""},
 	}
 	var probed, retired []string
 	reconcileDeletedConversations(list,
@@ -65,9 +65,9 @@ func TestReconcileDeletedConversations_Skips(t *testing.T) {
 func TestReconcileDeletedConversations_DedupsPaths(t *testing.T) {
 	const shared = "/c/shared.jsonl"
 	list := []store.Session{
-		{ID: "d1", Adapter: "claude", SessionFile: shared},
-		{ID: "d2", Adapter: "claude", SessionFile: shared},
-		{ID: "d3", Adapter: "claude", SessionFile: shared},
+		{ID: "d1", Adapter: "claude", ConversationFile: shared},
+		{ID: "d2", Adapter: "claude", ConversationFile: shared},
+		{ID: "d3", Adapter: "claude", ConversationFile: shared},
 	}
 	var probed, retired []string
 	reconcileDeletedConversations(list,
@@ -86,7 +86,7 @@ func TestReconcileDeletedConversations_DedupsPaths(t *testing.T) {
 // adapter can't probe (probe returns known=false) is left alone — this
 // is how the real convProbe reports a missing/incapable adapter.
 func TestReconcileDeletedConversations_NoProberKind(t *testing.T) {
-	list := []store.Session{{ID: "s", Adapter: "shell", SessionFile: "/s/x"}}
+	list := []store.Session{{ID: "s", Adapter: "shell", ConversationFile: "/s/x"}}
 	var retired []string
 	reconcileDeletedConversations(list,
 		func(_, _ string) (bool, bool) { return false, false },

--- a/services/gmuxd/cmd/gmuxd/scrollback_test.go
+++ b/services/gmuxd/cmd/gmuxd/scrollback_test.go
@@ -35,7 +35,7 @@ func newBrokerFixture(t *testing.T) *brokerFixture {
 
 func (f *brokerFixture) addSession(t *testing.T, id string) {
 	t.Helper()
-	f.sessions.Upsert(store.Session{ID: id, Kind: "shell", Alive: true})
+	f.sessions.Upsert(store.Session{ID: id, Adapter: "shell", Alive: true})
 }
 
 func (f *brokerFixture) writeScrollback(t *testing.T, id, body string) {

--- a/services/gmuxd/cmd/gmuxd/wait.go
+++ b/services/gmuxd/cmd/gmuxd/wait.go
@@ -55,7 +55,7 @@ func handleWait(w http.ResponseWriter, r *http.Request, sessions *store.Store, s
 	}
 	if !adapterEmitsIdleSignal(sess.Adapter) {
 		writeError(w, http.StatusUnprocessableEntity, "no_idle_signal",
-			"session kind "+sess.Adapter+" does not emit an idle signal; --wait is only supported for agent sessions")
+			"the "+sess.Adapter+" adapter does not emit an idle signal; --wait is only supported for agent sessions")
 		return
 	}
 

--- a/services/gmuxd/cmd/gmuxd/wait.go
+++ b/services/gmuxd/cmd/gmuxd/wait.go
@@ -40,7 +40,7 @@ import (
 //   - 200 with {reason}: terminal state reached (caller maps to its
 //     own exit code)
 //   - 408 Request Timeout: --timeout deadline elapsed
-//   - 422: session kind has no idle signal
+//   - 422: session adapter has no idle signal
 //   - 404: session not found
 func handleWait(w http.ResponseWriter, r *http.Request, sessions *store.Store, sessionID string) {
 	if r.Method != http.MethodPost {
@@ -53,9 +53,9 @@ func handleWait(w http.ResponseWriter, r *http.Request, sessions *store.Store, s
 		writeError(w, http.StatusNotFound, "not_found", "session not found")
 		return
 	}
-	if !kindEmitsIdleSignal(sess.Kind) {
+	if !adapterEmitsIdleSignal(sess.Adapter) {
 		writeError(w, http.StatusUnprocessableEntity, "no_idle_signal",
-			"session kind "+sess.Kind+" does not emit an idle signal; --wait is only supported for agent sessions")
+			"session kind "+sess.Adapter+" does not emit an idle signal; --wait is only supported for agent sessions")
 		return
 	}
 
@@ -161,16 +161,16 @@ func terminalReason(s store.Session) (string, bool) {
 	return "", false
 }
 
-// kindEmitsIdleSignal reports whether sessions of the given adapter
-// kind ever transition Status.Working — i.e. whether --wait can
+// adapterEmitsIdleSignal reports whether sessions of the given
+// adapter ever transition Status.Working — i.e. whether --wait can
 // observe a meaningful idle event for them. Currently the agent
 // adapters (claude, codex, pi) all emit Working; the shell adapter
 // doesn't. Kept as an explicit allowlist so adding a new agent
-// adapter requires a deliberate update here, and so unknown kinds
+// adapter requires a deliberate update here, and so unknown adapters
 // (peer sessions whose adapter we don't know about, future adapters)
 // fail loudly instead of silently degrading to "always idle."
-func kindEmitsIdleSignal(kind string) bool {
-	switch kind {
+func adapterEmitsIdleSignal(adapter string) bool {
+	switch adapter {
 	case "claude", "codex", "pi":
 		return true
 	}

--- a/services/gmuxd/cmd/gmuxd/wait_test.go
+++ b/services/gmuxd/cmd/gmuxd/wait_test.go
@@ -48,10 +48,10 @@ func waitURL(srv *httptest.Server, id string) string {
 func TestWaitReturnsImmediatelyWhenAlreadyIdle(t *testing.T) {
 	srv, st := waitTestServer(t)
 	st.Upsert(store.Session{
-		ID:     "sess-idle",
-		Kind:   "claude",
-		Alive:  true,
-		Status: &store.Status{Working: false},
+		ID:      "sess-idle",
+		Adapter: "claude",
+		Alive:   true,
+		Status:  &store.Status{Working: false},
 	})
 
 	start := time.Now()
@@ -77,10 +77,10 @@ func TestWaitReturnsImmediatelyWhenAlreadyIdle(t *testing.T) {
 func TestWaitBlocksUntilWorkingFlipsFalse(t *testing.T) {
 	srv, st := waitTestServer(t)
 	st.Upsert(store.Session{
-		ID:     "sess-busy",
-		Kind:   "pi",
-		Alive:  true,
-		Status: &store.Status{Working: true},
+		ID:      "sess-busy",
+		Adapter: "pi",
+		Alive:   true,
+		Status:  &store.Status{Working: true},
 	})
 
 	done := make(chan struct{})
@@ -102,10 +102,10 @@ func TestWaitBlocksUntilWorkingFlipsFalse(t *testing.T) {
 	}
 
 	st.Upsert(store.Session{
-		ID:     "sess-busy",
-		Kind:   "pi",
-		Alive:  true,
-		Status: &store.Status{Working: false},
+		ID:      "sess-busy",
+		Adapter: "pi",
+		Alive:   true,
+		Status:  &store.Status{Working: false},
 	})
 
 	select {
@@ -129,10 +129,10 @@ func TestWaitBlocksUntilWorkingFlipsFalse(t *testing.T) {
 func TestWaitReturnsDiedWhenSessionDies(t *testing.T) {
 	srv, st := waitTestServer(t)
 	st.Upsert(store.Session{
-		ID:     "sess-busy",
-		Kind:   "claude",
-		Alive:  true,
-		Status: &store.Status{Working: true},
+		ID:      "sess-busy",
+		Adapter: "claude",
+		Alive:   true,
+		Status:  &store.Status{Working: true},
 	})
 
 	done := make(chan struct{})
@@ -147,10 +147,10 @@ func TestWaitReturnsDiedWhenSessionDies(t *testing.T) {
 	// true at the point of death (adapter never got to emit a final
 	// flip) — that's exactly the case the "died" reason is for.
 	st.Upsert(store.Session{
-		ID:     "sess-busy",
-		Kind:   "claude",
-		Alive:  false,
-		Status: &store.Status{Working: true},
+		ID:      "sess-busy",
+		Adapter: "claude",
+		Alive:   false,
+		Status:  &store.Status{Working: true},
 	})
 
 	select {
@@ -170,10 +170,10 @@ func TestWaitReturnsDiedWhenSessionDies(t *testing.T) {
 func TestWaitTimesOut(t *testing.T) {
 	srv, st := waitTestServer(t)
 	st.Upsert(store.Session{
-		ID:     "sess-stuck",
-		Kind:   "codex",
-		Alive:  true,
-		Status: &store.Status{Working: true},
+		ID:      "sess-stuck",
+		Adapter: "codex",
+		Alive:   true,
+		Status:  &store.Status{Working: true},
 	})
 
 	// 1-second timeout; production callers compose with `timeout`
@@ -203,9 +203,9 @@ func TestWaitTimesOut(t *testing.T) {
 func TestWaitRejectsShellSessions(t *testing.T) {
 	srv, st := waitTestServer(t)
 	st.Upsert(store.Session{
-		ID:    "sess-shell",
-		Kind:  "shell",
-		Alive: true,
+		ID:      "sess-shell",
+		Adapter: "shell",
+		Alive:   true,
 	})
 
 	resp, _ := postWait(t, srv, "sess-shell")
@@ -222,10 +222,10 @@ func TestWaitRejectsShellSessions(t *testing.T) {
 func TestWaitDoesNotTreatNilStatusAsIdle(t *testing.T) {
 	srv, st := waitTestServer(t)
 	st.Upsert(store.Session{
-		ID:     "sess-fresh",
-		Kind:   "pi",
-		Alive:  true,
-		Status: nil, // hasn't emitted its first status yet
+		ID:      "sess-fresh",
+		Adapter: "pi",
+		Alive:   true,
+		Status:  nil, // hasn't emitted its first status yet
 	})
 
 	done := make(chan struct{})
@@ -246,10 +246,10 @@ func TestWaitDoesNotTreatNilStatusAsIdle(t *testing.T) {
 	}
 
 	st.Upsert(store.Session{
-		ID:     "sess-fresh",
-		Kind:   "pi",
-		Alive:  true,
-		Status: &store.Status{Working: false},
+		ID:      "sess-fresh",
+		Adapter: "pi",
+		Alive:   true,
+		Status:  &store.Status{Working: false},
 	})
 
 	select {
@@ -274,10 +274,10 @@ func TestWaitDoesNotTreatNilStatusAsIdle(t *testing.T) {
 func TestWaitUnderHighEventLoad(t *testing.T) {
 	srv, st := waitTestServer(t)
 	st.Upsert(store.Session{
-		ID:     "sess-drop",
-		Kind:   "claude",
-		Alive:  true,
-		Status: &store.Status{Working: true},
+		ID:      "sess-drop",
+		Adapter: "claude",
+		Alive:   true,
+		Status:  &store.Status{Working: true},
 	})
 
 	done := make(chan struct{})
@@ -289,13 +289,13 @@ func TestWaitUnderHighEventLoad(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 
 	for i := 0; i < 500; i++ {
-		st.Upsert(store.Session{ID: "sess-noise", Kind: "claude", Alive: true, Status: &store.Status{Working: true}})
+		st.Upsert(store.Session{ID: "sess-noise", Adapter: "claude", Alive: true, Status: &store.Status{Working: true}})
 	}
 	st.Upsert(store.Session{
-		ID:     "sess-drop",
-		Kind:   "claude",
-		Alive:  true,
-		Status: &store.Status{Working: false},
+		ID:      "sess-drop",
+		Adapter: "claude",
+		Alive:   true,
+		Status:  &store.Status{Working: false},
 	})
 
 	select {
@@ -319,10 +319,10 @@ func TestWaitUnderHighEventLoad(t *testing.T) {
 func TestWaitReturnsDiedWhenSessionRemoved(t *testing.T) {
 	srv, st := waitTestServer(t)
 	st.Upsert(store.Session{
-		ID:     "sess-dismiss",
-		Kind:   "pi",
-		Alive:  true,
-		Status: &store.Status{Working: true},
+		ID:      "sess-dismiss",
+		Adapter: "pi",
+		Alive:   true,
+		Status:  &store.Status{Working: true},
 	})
 
 	done := make(chan struct{})

--- a/services/gmuxd/internal/conversations/index.go
+++ b/services/gmuxd/internal/conversations/index.go
@@ -135,12 +135,12 @@ func (idx *Index) All() []Info {
 // ScanFile indexes a single conversation file (snapshot or live update
 // from an adapter ConversationSource). Returns the assigned slug.
 func (idx *Index) ScanFile(a adapter.Adapter, path string) string {
-	sf, ok := a.(adapter.SessionFiler)
+	sf, ok := a.(adapter.ConversationFiler)
 	if !ok {
 		return ""
 	}
 
-	fileInfo, err := sf.ParseSessionFile(path)
+	fileInfo, err := sf.ParseConversationFile(path)
 	if err != nil {
 		return ""
 	}

--- a/services/gmuxd/internal/conversations/index.go
+++ b/services/gmuxd/internal/conversations/index.go
@@ -1,5 +1,5 @@
 // Package conversations maintains an index of conversation files
-// discovered on disk. It maps (kind, slug) to file metadata, enabling
+// discovered on disk. It maps (adapter, slug) to file metadata, enabling
 // URL resolution for dead conversations and (future) fulltext search.
 //
 // The index is populated and kept current by adapter ConversationSources
@@ -19,8 +19,8 @@ import (
 // Info holds metadata for a single conversation file.
 type Info struct {
 	ConversationID string    // full UUID from the session file header
-	Slug           string    // human-readable URL identifier, unique within (kind)
-	Kind           string    // adapter name (claude, codex, pi, shell)
+	Slug           string    // human-readable URL identifier, unique within (adapter)
+	Adapter        string    // adapter name (claude, codex, pi, shell)
 	Title          string    // display title
 	Cwd            string    // working directory
 	FilePath       string    // absolute path to the session file
@@ -30,13 +30,13 @@ type Info struct {
 
 // Index is a concurrency-safe lookup table for conversation files.
 // It is the authority on slug uniqueness: when two conversations
-// produce the same slug within the same kind, the index assigns
+// produce the same slug within the same adapter, the index assigns
 // -2, -3 suffixes.
 type Index struct {
 	mu sync.RWMutex
-	// byKey maps "kind/slug" → Info.
+	// byKey maps "adapter/slug" → Info.
 	byKey map[string]Info
-	// byConversationID maps "kind/conversationID" → slug for reverse lookup
+	// byConversationID maps "adapter/conversationID" → slug for reverse lookup
 	// (e.g., finding a conversation's slug from the agent's conversation UUID).
 	byConversationID map[string]string
 }
@@ -49,33 +49,33 @@ func New() *Index {
 	}
 }
 
-func indexKey(kind, slug string) string {
-	return kind + "/" + slug
+func indexKey(adapterName, slug string) string {
+	return adapterName + "/" + slug
 }
 
-func convKey(kind, conversationID string) string {
-	return kind + "/" + conversationID
+func convKey(adapterName, conversationID string) string {
+	return adapterName + "/" + conversationID
 }
 
-// Lookup returns the conversation info for a (kind, slug) pair.
+// Lookup returns the conversation info for an (adapter, slug) pair.
 // Returns ok=false if no matching conversation exists.
-func (idx *Index) Lookup(kind, slug string) (Info, bool) {
+func (idx *Index) Lookup(adapterName, slug string) (Info, bool) {
 	idx.mu.RLock()
 	defer idx.mu.RUnlock()
-	info, ok := idx.byKey[indexKey(kind, slug)]
+	info, ok := idx.byKey[indexKey(adapterName, slug)]
 	return info, ok
 }
 
 // LookupByConversationID returns the slug for a conversation identified by
 // its agent-native conversation ID. Returns empty string if unknown.
-func (idx *Index) LookupByConversationID(kind, conversationID string) string {
+func (idx *Index) LookupByConversationID(adapterName, conversationID string) string {
 	idx.mu.RLock()
 	defer idx.mu.RUnlock()
-	return idx.byConversationID[convKey(kind, conversationID)]
+	return idx.byConversationID[convKey(adapterName, conversationID)]
 }
 
 // Upsert adds or updates a conversation in the index. If the slug
-// collides with an existing entry of the same kind (but different
+// collides with an existing entry of the same adapter (but different
 // conversation ID), a -2, -3, ... suffix is appended. Returns the final
 // (possibly suffixed) slug.
 func (idx *Index) Upsert(info Info) string {
@@ -83,29 +83,29 @@ func (idx *Index) Upsert(info Info) string {
 	defer idx.mu.Unlock()
 
 	// If this conversation ID already has a slug, update in place.
-	tk := convKey(info.Kind, info.ConversationID)
+	tk := convKey(info.Adapter, info.ConversationID)
 	if existing, ok := idx.byConversationID[tk]; ok {
-		ik := indexKey(info.Kind, existing)
+		ik := indexKey(info.Adapter, existing)
 		info.Slug = existing
 		idx.byKey[ik] = info
 		return existing
 	}
 
 	// Assign a unique slug.
-	info.Slug = idx.uniqueSlugLocked(info.Kind, info.Slug, info.ConversationID)
-	ik := indexKey(info.Kind, info.Slug)
+	info.Slug = idx.uniqueSlugLocked(info.Adapter, info.Slug, info.ConversationID)
+	ik := indexKey(info.Adapter, info.Slug)
 	idx.byKey[ik] = info
 	idx.byConversationID[tk] = info.Slug
 	return info.Slug
 }
 
 // uniqueSlugLocked returns a slug that doesn't collide within the
-// given kind. Appends -2, -3, ... on collision. Must be called with
+// given adapter. Appends -2, -3, ... on collision. Must be called with
 // idx.mu held.
-func (idx *Index) uniqueSlugLocked(kind, slug, conversationID string) string {
+func (idx *Index) uniqueSlugLocked(adapterName, slug, conversationID string) string {
 	base := slug
 	for i := 2; ; i++ {
-		ik := indexKey(kind, slug)
+		ik := indexKey(adapterName, slug)
 		existing, occupied := idx.byKey[ik]
 		if !occupied || existing.ConversationID == conversationID {
 			return slug
@@ -165,7 +165,7 @@ func (idx *Index) ScanFile(a adapter.Adapter, path string) string {
 	info := Info{
 		ConversationID: fileInfo.ID,
 		Slug:           slug,
-		Kind:           a.Name(),
+		Adapter:        a.Name(),
 		Title:          fileInfo.Title,
 		Cwd:            fileInfo.Cwd,
 		FilePath:       path,
@@ -177,22 +177,22 @@ func (idx *Index) ScanFile(a adapter.Adapter, path string) string {
 
 // Remove deletes a conversation from the index by conversation ID.
 // Returns true if it was present.
-func (idx *Index) Remove(kind, conversationID string) bool {
+func (idx *Index) Remove(adapterName, conversationID string) bool {
 	idx.mu.Lock()
 	defer idx.mu.Unlock()
-	tk := convKey(kind, conversationID)
+	tk := convKey(adapterName, conversationID)
 	slug, ok := idx.byConversationID[tk]
 	if !ok {
 		return false
 	}
 	delete(idx.byConversationID, tk)
-	delete(idx.byKey, indexKey(kind, slug))
+	delete(idx.byKey, indexKey(adapterName, slug))
 	return true
 }
 
 // RemoveByPath deletes any conversation whose FilePath matches path.
 // Used when a ConversationSource observes a deletion event and we don't have the
-// (kind, conversationID) handy. Linear walk over the index; that's fine
+// (adapter, conversationID) handy. Linear walk over the index; that's fine
 // because Remove events are rare (manual `rm`, file rotation) and
 // the index size stays in the hundreds-to-low-thousands range.
 // Returns true if an entry was removed.
@@ -209,28 +209,28 @@ func (idx *Index) RemoveByPath(path string) bool {
 			continue
 		}
 		delete(idx.byKey, key)
-		delete(idx.byConversationID, convKey(info.Kind, info.ConversationID))
+		delete(idx.byConversationID, convKey(info.Adapter, info.ConversationID))
 		return true
 	}
 	return false
 }
 
-// SlugExists reports whether a slug is taken within a kind.
-func (idx *Index) SlugExists(kind, slug string) bool {
+// SlugExists reports whether a slug is taken within an adapter.
+func (idx *Index) SlugExists(adapterName, slug string) bool {
 	idx.mu.RLock()
 	defer idx.mu.RUnlock()
-	_, ok := idx.byKey[indexKey(kind, slug)]
+	_, ok := idx.byKey[indexKey(adapterName, slug)]
 	return ok
 }
 
 // LookupBySlug searches for a conversation by slug across all kinds.
-// Returns the first match. Used when the caller doesn't know the kind
+// Returns the first match. Used when the caller doesn't know the adapter
 // (e.g., project session arrays that store bare slugs).
 func (idx *Index) LookupBySlug(slug string) (Info, bool) {
 	idx.mu.RLock()
 	defer idx.mu.RUnlock()
 	for key, info := range idx.byKey {
-		// key is "kind/slug"; check if the slug suffix matches.
+		// key is "adapter/slug"; check if the slug suffix matches.
 		if i := len(key) - len(slug); i > 0 && key[i-1] == '/' && key[i:] == slug {
 			return info, true
 		}
@@ -239,12 +239,12 @@ func (idx *Index) LookupBySlug(slug string) (Info, bool) {
 }
 
 // FindByPrefix returns conversations whose slug starts with the given
-// prefix, within a kind. Used for URL resolution when the frontend
+// prefix, within an adapter. Used for URL resolution when the frontend
 // provides a partial slug (e.g. from session.id.slice(0, 8)).
-func (idx *Index) FindByPrefix(kind, prefix string) (Info, bool) {
+func (idx *Index) FindByPrefix(adapterName, prefix string) (Info, bool) {
 	idx.mu.RLock()
 	defer idx.mu.RUnlock()
-	keyPrefix := kind + "/" + prefix
+	keyPrefix := adapterName + "/" + prefix
 	for key, info := range idx.byKey {
 		if strings.HasPrefix(key, keyPrefix) {
 			return info, true

--- a/services/gmuxd/internal/conversations/index.go
+++ b/services/gmuxd/internal/conversations/index.go
@@ -18,12 +18,12 @@ import (
 
 // Info holds metadata for a single conversation file.
 type Info struct {
-	ConversationID string    // full UUID from the session file header
+	ConversationID string    // full UUID from the conversation file header
 	Slug           string    // human-readable URL identifier, unique within (adapter)
 	Adapter        string    // adapter name (claude, codex, pi, shell)
 	Title          string    // display title
 	Cwd            string    // working directory
-	FilePath       string    // absolute path to the session file
+	FilePath       string    // absolute path to the conversation file
 	ResumeCommand  []string  // command to resume this conversation
 	Created        time.Time // when the conversation started
 }

--- a/services/gmuxd/internal/conversations/index_test.go
+++ b/services/gmuxd/internal/conversations/index_test.go
@@ -18,7 +18,7 @@ func TestUpsert_BasicLookup(t *testing.T) {
 	slug := idx.Upsert(Info{
 		ConversationID: "abc-123",
 		Slug:           "fix-auth",
-		Kind:           "pi",
+		Adapter:        "pi",
 		Title:          "fix auth bug",
 	})
 	if slug != "fix-auth" {
@@ -41,13 +41,13 @@ func TestUpsert_UpdateInPlace(t *testing.T) {
 	idx.Upsert(Info{
 		ConversationID: "abc-123",
 		Slug:           "fix-auth",
-		Kind:           "pi",
+		Adapter:        "pi",
 		Title:          "old title",
 	})
 	idx.Upsert(Info{
 		ConversationID: "abc-123",
 		Slug:           "fix-auth",
-		Kind:           "pi",
+		Adapter:        "pi",
 		Title:          "new title",
 	})
 	if idx.Count() != 1 {
@@ -61,9 +61,9 @@ func TestUpsert_UpdateInPlace(t *testing.T) {
 
 func TestUpsert_SlugCollision(t *testing.T) {
 	idx := New()
-	s1 := idx.Upsert(Info{ConversationID: "aaa", Slug: "say-hi", Kind: "claude"})
-	s2 := idx.Upsert(Info{ConversationID: "bbb", Slug: "say-hi", Kind: "claude"})
-	s3 := idx.Upsert(Info{ConversationID: "ccc", Slug: "say-hi", Kind: "claude"})
+	s1 := idx.Upsert(Info{ConversationID: "aaa", Slug: "say-hi", Adapter: "claude"})
+	s2 := idx.Upsert(Info{ConversationID: "bbb", Slug: "say-hi", Adapter: "claude"})
+	s3 := idx.Upsert(Info{ConversationID: "ccc", Slug: "say-hi", Adapter: "claude"})
 
 	if s1 != "say-hi" {
 		t.Errorf("first should be unsuffixed, got %q", s1)
@@ -81,23 +81,23 @@ func TestUpsert_SlugCollision(t *testing.T) {
 
 func TestUpsert_SlugCollisionAcrossKinds(t *testing.T) {
 	idx := New()
-	s1 := idx.Upsert(Info{ConversationID: "aaa", Slug: "fix-auth", Kind: "pi"})
-	s2 := idx.Upsert(Info{ConversationID: "bbb", Slug: "fix-auth", Kind: "claude"})
+	s1 := idx.Upsert(Info{ConversationID: "aaa", Slug: "fix-auth", Adapter: "pi"})
+	s2 := idx.Upsert(Info{ConversationID: "bbb", Slug: "fix-auth", Adapter: "claude"})
 
 	// Different kinds should not collide.
 	if s1 != "fix-auth" || s2 != "fix-auth" {
-		t.Errorf("cross-kind collision: pi=%q, claude=%q", s1, s2)
+		t.Errorf("cross-adapter collision: pi=%q, claude=%q", s1, s2)
 	}
 }
 
 func TestUpsert_UpdatePreservesSlug(t *testing.T) {
 	idx := New()
-	idx.Upsert(Info{ConversationID: "aaa", Slug: "say-hi", Kind: "claude"})
-	idx.Upsert(Info{ConversationID: "bbb", Slug: "say-hi", Kind: "claude"})
+	idx.Upsert(Info{ConversationID: "aaa", Slug: "say-hi", Adapter: "claude"})
+	idx.Upsert(Info{ConversationID: "bbb", Slug: "say-hi", Adapter: "claude"})
 
 	// Update the second one with a different base slug (e.g., title changed).
 	// It should keep its assigned slug "say-hi-2", not get a new one.
-	s := idx.Upsert(Info{ConversationID: "bbb", Slug: "hello", Kind: "claude", Title: "updated"})
+	s := idx.Upsert(Info{ConversationID: "bbb", Slug: "hello", Adapter: "claude", Title: "updated"})
 	if s != "say-hi-2" {
 		t.Errorf("update should preserve assigned slug, got %q", s)
 	}
@@ -105,7 +105,7 @@ func TestUpsert_UpdatePreservesSlug(t *testing.T) {
 
 func TestLookupByConversationID(t *testing.T) {
 	idx := New()
-	idx.Upsert(Info{ConversationID: "abc-123", Slug: "fix-auth", Kind: "pi"})
+	idx.Upsert(Info{ConversationID: "abc-123", Slug: "fix-auth", Adapter: "pi"})
 
 	slug := idx.LookupByConversationID("pi", "abc-123")
 	if slug != "fix-auth" {
@@ -120,7 +120,7 @@ func TestLookupByConversationID(t *testing.T) {
 
 func TestRemove(t *testing.T) {
 	idx := New()
-	idx.Upsert(Info{ConversationID: "abc-123", Slug: "fix-auth", Kind: "pi"})
+	idx.Upsert(Info{ConversationID: "abc-123", Slug: "fix-auth", Adapter: "pi"})
 
 	if !idx.Remove("pi", "abc-123") {
 		t.Error("expected remove to return true")
@@ -138,9 +138,9 @@ func TestRemove(t *testing.T) {
 
 func TestRemoveByPath(t *testing.T) {
 	idx := New()
-	idx.Upsert(Info{ConversationID: "a", Slug: "one", Kind: "pi", FilePath: "/x/a.jsonl"})
-	idx.Upsert(Info{ConversationID: "b", Slug: "two", Kind: "pi", FilePath: "/x/b.jsonl"})
-	idx.Upsert(Info{ConversationID: "c", Slug: "three", Kind: "claude", FilePath: "/y/c.jsonl"})
+	idx.Upsert(Info{ConversationID: "a", Slug: "one", Adapter: "pi", FilePath: "/x/a.jsonl"})
+	idx.Upsert(Info{ConversationID: "b", Slug: "two", Adapter: "pi", FilePath: "/x/b.jsonl"})
+	idx.Upsert(Info{ConversationID: "c", Slug: "three", Adapter: "claude", FilePath: "/y/c.jsonl"})
 
 	if !idx.RemoveByPath("/x/b.jsonl") {
 		t.Fatal("expected RemoveByPath to return true for indexed path")
@@ -151,18 +151,18 @@ func TestRemoveByPath(t *testing.T) {
 	if _, ok := idx.Lookup("pi", "two"); ok {
 		t.Error("expected miss for removed slug")
 	}
-	// Sibling entries with same kind unaffected.
+	// Sibling entries with same adapter unaffected.
 	if _, ok := idx.Lookup("pi", "one"); !ok {
 		t.Error("sibling pi entry was incorrectly removed")
 	}
-	// Cross-kind unaffected.
+	// Cross-adapter unaffected.
 	if _, ok := idx.Lookup("claude", "three"); !ok {
-		t.Error("cross-kind entry was incorrectly removed")
+		t.Error("cross-adapter entry was incorrectly removed")
 	}
 	// Reverse-lookup (byConversationID) cleared too: Upserting the same conversationID
 	// at a new slug should yield the new slug, not update-in-place at
 	// the old one.
-	slug := idx.Upsert(Info{ConversationID: "b", Slug: "different", Kind: "pi", FilePath: "/x/b2.jsonl"})
+	slug := idx.Upsert(Info{ConversationID: "b", Slug: "different", Adapter: "pi", FilePath: "/x/b2.jsonl"})
 	if slug != "different" {
 		t.Errorf("expected fresh slug 'different' (byConversationID was cleared), got %q", slug)
 	}
@@ -173,7 +173,7 @@ func TestRemoveByPath(t *testing.T) {
 
 func TestSlugExists(t *testing.T) {
 	idx := New()
-	idx.Upsert(Info{ConversationID: "abc", Slug: "fix-auth", Kind: "pi"})
+	idx.Upsert(Info{ConversationID: "abc", Slug: "fix-auth", Adapter: "pi"})
 
 	if !idx.SlugExists("pi", "fix-auth") {
 		t.Error("expected true")
@@ -182,14 +182,14 @@ func TestSlugExists(t *testing.T) {
 		t.Error("expected false for unknown slug")
 	}
 	if idx.SlugExists("claude", "fix-auth") {
-		t.Error("expected false for wrong kind")
+		t.Error("expected false for wrong adapter")
 	}
 }
 
 func TestFindByPrefix(t *testing.T) {
 	idx := New()
-	idx.Upsert(Info{ConversationID: "abc-123", Slug: "fix-auth-bug", Kind: "pi"})
-	idx.Upsert(Info{ConversationID: "def-456", Slug: "fix-typo", Kind: "pi"})
+	idx.Upsert(Info{ConversationID: "abc-123", Slug: "fix-auth-bug", Adapter: "pi"})
+	idx.Upsert(Info{ConversationID: "def-456", Slug: "fix-typo", Adapter: "pi"})
 
 	info, ok := idx.FindByPrefix("pi", "fix-auth")
 	if !ok {
@@ -207,23 +207,23 @@ func TestFindByPrefix(t *testing.T) {
 
 func TestLookupBySlug_AcrossKinds(t *testing.T) {
 	idx := New()
-	idx.Upsert(Info{ConversationID: "aaa", Slug: "fix-auth", Kind: "pi", Title: "pi session"})
-	idx.Upsert(Info{ConversationID: "bbb", Slug: "add-tests", Kind: "claude", Title: "claude session"})
+	idx.Upsert(Info{ConversationID: "aaa", Slug: "fix-auth", Adapter: "pi", Title: "pi session"})
+	idx.Upsert(Info{ConversationID: "bbb", Slug: "add-tests", Adapter: "claude", Title: "claude session"})
 
 	info, ok := idx.LookupBySlug("fix-auth")
 	if !ok {
 		t.Fatal("expected hit for fix-auth")
 	}
-	if info.Kind != "pi" {
-		t.Errorf("expected kind pi, got %q", info.Kind)
+	if info.Adapter != "pi" {
+		t.Errorf("expected adapter pi, got %q", info.Adapter)
 	}
 
 	info, ok = idx.LookupBySlug("add-tests")
 	if !ok {
 		t.Fatal("expected hit for add-tests")
 	}
-	if info.Kind != "claude" {
-		t.Errorf("expected kind claude, got %q", info.Kind)
+	if info.Adapter != "claude" {
+		t.Errorf("expected adapter claude, got %q", info.Adapter)
 	}
 
 	_, ok = idx.LookupBySlug("nonexistent")
@@ -240,8 +240,8 @@ func TestLookupBySlug_AcrossKinds(t *testing.T) {
 
 func TestAll(t *testing.T) {
 	idx := New()
-	idx.Upsert(Info{ConversationID: "a", Slug: "one", Kind: "pi", Created: time.Now()})
-	idx.Upsert(Info{ConversationID: "b", Slug: "two", Kind: "claude", Created: time.Now()})
+	idx.Upsert(Info{ConversationID: "a", Slug: "one", Adapter: "pi", Created: time.Now()})
+	idx.Upsert(Info{ConversationID: "b", Slug: "two", Adapter: "claude", Created: time.Now()})
 
 	all := idx.All()
 	if len(all) != 2 {
@@ -257,7 +257,7 @@ func TestAll(t *testing.T) {
 // It also still removes indexed entries from the index.
 func TestSinkRemoveFiresOnRemovedEvenWhenUnindexed(t *testing.T) {
 	idx := New()
-	idx.Upsert(Info{ConversationID: "a", Slug: "one", Kind: "pi", FilePath: "/x/a.jsonl"})
+	idx.Upsert(Info{ConversationID: "a", Slug: "one", Adapter: "pi", FilePath: "/x/a.jsonl"})
 
 	var got []string
 	sink := indexSink{idx: idx, onRemoved: func(p string) { got = append(got, p) }}

--- a/services/gmuxd/internal/discovery/discovery.go
+++ b/services/gmuxd/internal/discovery/discovery.go
@@ -263,15 +263,15 @@ func Register(sessions *store.Store, subs *Subscriptions, socketPath string, onD
 		// re-registration means alive, so always clear.
 		existing.Resumable = false
 		*newSess = existing
-		log.Printf("register: re-registered %s session %s (slug=%s)", newSess.Kind, newSess.ID, newSess.Slug)
-	} else if a := adapters.FindByKind(newSess.Kind); a != nil {
+		log.Printf("register: re-registered %s session %s (slug=%s)", newSess.Adapter, newSess.ID, newSess.Slug)
+	} else if a := adapters.FindByAdapter(newSess.Adapter); a != nil {
 		if reg, ok := a.(adapter.SessionRegistrar); ok {
 			info, err := reg.OnRegister(newSess.ID, newSess.Cwd, newSess.Command)
 			if err != nil {
-				log.Printf("register: %s adapter OnRegister failed for %s: %v", newSess.Kind, newSess.ID, err)
+				log.Printf("register: %s adapter OnRegister failed for %s: %v", newSess.Adapter, newSess.ID, err)
 			} else if info.Slug != "" {
 				newSess.Slug = info.Slug
-				log.Printf("register: %s registered session %s (slug=%s)", newSess.Kind, newSess.ID, info.Slug)
+				log.Printf("register: %s registered session %s (slug=%s)", newSess.Adapter, newSess.ID, info.Slug)
 			}
 		}
 	}
@@ -309,14 +309,14 @@ func queryMeta(socketPath string) (*store.Session, error) {
 	// Legacy-read shim: pre-v2 runners report "kind" and "session_file"
 	// in /meta. Long-lived runners survive daemon upgrades, so accept the
 	// old keys for one release. TODO(v2.1): drop this shim.
-	if sess.Kind == "" || sess.SessionFile == "" {
+	if sess.Adapter == "" || sess.SessionFile == "" {
 		var legacy struct {
 			Kind        string `json:"kind"`
 			SessionFile string `json:"session_file"`
 		}
 		if err := json.Unmarshal(body, &legacy); err == nil {
-			if sess.Kind == "" {
-				sess.Kind = legacy.Kind
+			if sess.Adapter == "" {
+				sess.Adapter = legacy.Kind
 			}
 			if sess.SessionFile == "" {
 				sess.SessionFile = legacy.SessionFile

--- a/services/gmuxd/internal/discovery/discovery.go
+++ b/services/gmuxd/internal/discovery/discovery.go
@@ -309,7 +309,7 @@ func queryMeta(socketPath string) (*store.Session, error) {
 	// Legacy-read shim: pre-v2 runners report "kind" and "session_file"
 	// in /meta. Long-lived runners survive daemon upgrades, so accept the
 	// old keys for one release. TODO(v2.1): drop this shim.
-	if sess.Adapter == "" || sess.SessionFile == "" {
+	if sess.Adapter == "" || sess.ConversationFile == "" {
 		var legacy struct {
 			Kind        string `json:"kind"`
 			SessionFile string `json:"session_file"`
@@ -318,8 +318,8 @@ func queryMeta(socketPath string) (*store.Session, error) {
 			if sess.Adapter == "" {
 				sess.Adapter = legacy.Kind
 			}
-			if sess.SessionFile == "" {
-				sess.SessionFile = legacy.SessionFile
+			if sess.ConversationFile == "" {
+				sess.ConversationFile = legacy.SessionFile
 			}
 		}
 	}

--- a/services/gmuxd/internal/discovery/discovery_test.go
+++ b/services/gmuxd/internal/discovery/discovery_test.go
@@ -314,8 +314,8 @@ func TestQueryMetaLegacyPreV2Keys(t *testing.T) {
 	if sess.Adapter != "pi" {
 		t.Errorf("Adapter = %q, want %q (legacy \"kind\" fallback)", sess.Adapter, "pi")
 	}
-	if want := "/home/u/.pi/agent/sessions/x/conv.jsonl"; sess.SessionFile != want {
-		t.Errorf("SessionFile = %q, want %q (legacy \"session_file\" fallback)", sess.SessionFile, want)
+	if want := "/home/u/.pi/agent/sessions/x/conv.jsonl"; sess.ConversationFile != want {
+		t.Errorf("ConversationFile = %q, want %q (legacy \"session_file\" fallback)", sess.ConversationFile, want)
 	}
 }
 
@@ -341,7 +341,7 @@ func TestQueryMetaNewKeysWinOverLegacy(t *testing.T) {
 	if sess.Adapter != "claude" {
 		t.Errorf("Adapter = %q, want %q (new key must win)", sess.Adapter, "claude")
 	}
-	if sess.SessionFile != "/new/conv.jsonl" {
-		t.Errorf("SessionFile = %q, want /new/conv.jsonl (new key must win)", sess.SessionFile)
+	if sess.ConversationFile != "/new/conv.jsonl" {
+		t.Errorf("ConversationFile = %q, want /new/conv.jsonl (new key must win)", sess.ConversationFile)
 	}
 }

--- a/services/gmuxd/internal/discovery/discovery_test.go
+++ b/services/gmuxd/internal/discovery/discovery_test.go
@@ -58,11 +58,11 @@ func TestScanReregistersDeadButAliveRunnerAfterDaemonRestart(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/meta", func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(store.Session{
-			ID:    id,
-			Kind:  "shell",
-			Cwd:   "/home/user/proj",
-			Alive: true,
-			Pid:   12345,
+			ID:      id,
+			Adapter: "shell",
+			Cwd:     "/home/user/proj",
+			Alive:   true,
+			Pid:     12345,
 			// Empty Slug here mirrors what an adapter-less /meta would
 			// return; the post-attribution slug in the store must win.
 		})
@@ -78,7 +78,7 @@ func TestScanReregistersDeadButAliveRunnerAfterDaemonRestart(t *testing.T) {
 	sessions := store.New()
 	sessions.Upsert(store.Session{
 		ID:           id,
-		Kind:         "shell",
+		Adapter:      "shell",
 		Cwd:          "/home/user/proj",
 		SocketPath:   sockPath,
 		Alive:        false,
@@ -149,7 +149,7 @@ func TestScanSkipsTrackedAliveSubscribedSession(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/meta", func(w http.ResponseWriter, r *http.Request) {
 		metaCalls.Add(1)
-		_ = json.NewEncoder(w).Encode(store.Session{ID: id, Kind: "shell", Alive: true})
+		_ = json.NewEncoder(w).Encode(store.Session{ID: id, Adapter: "shell", Alive: true})
 	})
 	mux.HandleFunc("/events", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
@@ -167,7 +167,7 @@ func TestScanSkipsTrackedAliveSubscribedSession(t *testing.T) {
 	sessions := store.New()
 	sessions.Upsert(store.Session{
 		ID:         id,
-		Kind:       "shell",
+		Adapter:    "shell",
 		Alive:      true,
 		SocketPath: sockPath,
 	})
@@ -231,7 +231,7 @@ func TestScanReregistersOnTransientSubscriptionDrop(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/meta", func(w http.ResponseWriter, r *http.Request) {
 		metaCalls.Add(1)
-		_ = json.NewEncoder(w).Encode(store.Session{ID: id, Kind: "shell", Alive: true, Pid: 99})
+		_ = json.NewEncoder(w).Encode(store.Session{ID: id, Adapter: "shell", Alive: true, Pid: 99})
 	})
 	mux.HandleFunc("/events", func(w http.ResponseWriter, r *http.Request) {
 		// Close immediately so the daemon-side subscription drops.
@@ -246,7 +246,7 @@ func TestScanReregistersOnTransientSubscriptionDrop(t *testing.T) {
 	sessions := store.New()
 	sessions.Upsert(store.Session{
 		ID:         id,
-		Kind:       "shell",
+		Adapter:    "shell",
 		Alive:      true,
 		SocketPath: sockPath,
 	})
@@ -311,8 +311,8 @@ func TestQueryMetaLegacyPreV2Keys(t *testing.T) {
 	if err != nil {
 		t.Fatalf("queryMeta: %v", err)
 	}
-	if sess.Kind != "pi" {
-		t.Errorf("Kind = %q, want %q (legacy \"kind\" fallback)", sess.Kind, "pi")
+	if sess.Adapter != "pi" {
+		t.Errorf("Adapter = %q, want %q (legacy \"kind\" fallback)", sess.Adapter, "pi")
 	}
 	if want := "/home/u/.pi/agent/sessions/x/conv.jsonl"; sess.SessionFile != want {
 		t.Errorf("SessionFile = %q, want %q (legacy \"session_file\" fallback)", sess.SessionFile, want)
@@ -338,8 +338,8 @@ func TestQueryMetaNewKeysWinOverLegacy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("queryMeta: %v", err)
 	}
-	if sess.Kind != "claude" {
-		t.Errorf("Kind = %q, want %q (new key must win)", sess.Kind, "claude")
+	if sess.Adapter != "claude" {
+		t.Errorf("Adapter = %q, want %q (new key must win)", sess.Adapter, "claude")
 	}
 	if sess.SessionFile != "/new/conv.jsonl" {
 		t.Errorf("SessionFile = %q, want /new/conv.jsonl (new key must win)", sess.SessionFile)

--- a/services/gmuxd/internal/discovery/register_test.go
+++ b/services/gmuxd/internal/discovery/register_test.go
@@ -38,22 +38,22 @@ func metaHandler(sess store.Session) http.Handler {
 // runner's /meta cannot speak to it on resume.
 func TestRegisterReRegistrationPreservesPersistedSlug(t *testing.T) {
 	srv := startUnixServer(t, metaHandler(store.Session{
-		ID:    "sess-resume",
-		Kind:  "shell",
-		Cwd:   t.TempDir(),
-		Alive: true,
-		Pid:   4242,
-		Slug:  "initial-from-runner",
+		ID:      "sess-resume",
+		Adapter: "shell",
+		Cwd:     t.TempDir(),
+		Alive:   true,
+		Pid:     4242,
+		Slug:    "initial-from-runner",
 	}))
 	defer srv.cleanup()
 
 	sessions := store.New()
 	sessions.Upsert(store.Session{
-		ID:    "sess-resume",
-		Kind:  "shell",
-		Cwd:   "/old/cwd",
-		Alive: false, // dead: the resume target
-		Slug:  "post-attribution-name",
+		ID:      "sess-resume",
+		Adapter: "shell",
+		Cwd:     "/old/cwd",
+		Alive:   false, // dead: the resume target
+		Slug:    "post-attribution-name",
 	})
 
 	if err := Register(sessions, nil, srv.socketPath, nil); err != nil {
@@ -88,7 +88,7 @@ func TestRegisterReRegistrationPreservesAttributionAndHistory(t *testing.T) {
 	// for everything the agent hook would have set.
 	srv := startUnixServer(t, metaHandler(store.Session{
 		ID:        "sess-resume",
-		Kind:      "pi",
+		Adapter:   "pi",
 		Cwd:       "/work/repo",
 		Alive:     true,
 		Pid:       9001,
@@ -99,7 +99,7 @@ func TestRegisterReRegistrationPreservesAttributionAndHistory(t *testing.T) {
 	sessions := store.New()
 	sessions.Upsert(store.Session{
 		ID:            "sess-resume",
-		Kind:          "pi",
+		Adapter:       "pi",
 		Cwd:           "/work/repo",
 		Alive:         false,
 		Resumable:     true,
@@ -161,10 +161,10 @@ func TestRegisterReRegistrationPreservesAttributionAndHistory(t *testing.T) {
 func TestRegisterFreshSessionRunsOnRegisterForShell(t *testing.T) {
 	cwd := filepath.Join(t.TempDir(), "myproject")
 	srv := startUnixServer(t, metaHandler(store.Session{
-		ID:    "sess-fresh",
-		Kind:  "shell",
-		Cwd:   cwd,
-		Alive: true,
+		ID:      "sess-fresh",
+		Adapter: "shell",
+		Cwd:     cwd,
+		Alive:   true,
 		// Empty slug from runner: forces the test to depend on
 		// OnRegister rather than coincidentally passing because the
 		// runner happened to have populated Slug.
@@ -218,7 +218,7 @@ func TestScanIgnoresMissingPathWhileSubscriptionAlive(t *testing.T) {
 	sessions := store.New()
 	sessions.Upsert(store.Session{
 		ID:         "sess-graceful-kill",
-		Kind:       "shell",
+		Adapter:    "shell",
 		Alive:      true,
 		SocketPath: srv.socketPath,
 	})

--- a/services/gmuxd/internal/discovery/resume.go
+++ b/services/gmuxd/internal/discovery/resume.go
@@ -13,7 +13,7 @@ func ResolveResumeCommand(sess *store.Session) []string {
 	if sess.SessionFile == "" {
 		return nil
 	}
-	a := adapters.FindByKind(sess.Kind)
+	a := adapters.FindByAdapter(sess.Adapter)
 	if a == nil {
 		return nil
 	}

--- a/services/gmuxd/internal/discovery/resume.go
+++ b/services/gmuxd/internal/discovery/resume.go
@@ -17,7 +17,7 @@ func ResolveResumeCommand(sess *store.Session) []string {
 	if a == nil {
 		return nil
 	}
-	filer, ok := a.(adapter.SessionFiler)
+	filer, ok := a.(adapter.ConversationFiler)
 	if !ok {
 		return nil
 	}
@@ -25,7 +25,7 @@ func ResolveResumeCommand(sess *store.Session) []string {
 	if !ok {
 		return nil
 	}
-	info, err := filer.ParseSessionFile(sess.SessionFile)
+	info, err := filer.ParseConversationFile(sess.SessionFile)
 	if err != nil {
 		return nil
 	}

--- a/services/gmuxd/internal/discovery/resume.go
+++ b/services/gmuxd/internal/discovery/resume.go
@@ -7,10 +7,10 @@ import (
 )
 
 // ResolveResumeCommand derives the resume command for a dead session from its
-// authoritative session file (store.Session.SessionFile, reported by the agent
+// authoritative conversation file (store.Session.ConversationFile, reported by the agent
 // hook). Returns nil if the session has no recorded file or isn't resumable.
 func ResolveResumeCommand(sess *store.Session) []string {
-	if sess.SessionFile == "" {
+	if sess.ConversationFile == "" {
 		return nil
 	}
 	a := adapters.FindByAdapter(sess.Adapter)
@@ -25,7 +25,7 @@ func ResolveResumeCommand(sess *store.Session) []string {
 	if !ok {
 		return nil
 	}
-	info, err := filer.ParseConversationFile(sess.SessionFile)
+	info, err := filer.ParseConversationFile(sess.ConversationFile)
 	if err != nil {
 		return nil
 	}

--- a/services/gmuxd/internal/discovery/resume_test.go
+++ b/services/gmuxd/internal/discovery/resume_test.go
@@ -34,10 +34,10 @@ func TestResolveResumeCommand(t *testing.T) {
 		sess    store.Session
 		wantNil bool
 	}{
-		{"no session file", store.Session{Adapter: "pi"}, true},
-		{"unknown adapter", store.Session{Adapter: "nope", SessionFile: good}, true},
-		{"unparseable file", store.Session{Adapter: "pi", SessionFile: filepath.Join(dir, "ghost.jsonl")}, true},
-		{"resumable pi", store.Session{Adapter: "pi", SessionFile: good}, false},
+		{"no conversation file", store.Session{Adapter: "pi"}, true},
+		{"unknown adapter", store.Session{Adapter: "nope", ConversationFile: good}, true},
+		{"unparseable file", store.Session{Adapter: "pi", ConversationFile: filepath.Join(dir, "ghost.jsonl")}, true},
+		{"resumable pi", store.Session{Adapter: "pi", ConversationFile: good}, false},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -55,7 +55,7 @@ func TestResolveResumeCommand(t *testing.T) {
 	}
 }
 
-// A shell session never carries a SessionFile, so the guard returns before the
+// A shell session never carries a ConversationFile, so the guard returns before the
 // adapter lookup — even though shell is itself a ConversationFiler/Resumer.
 func TestResolveResumeCommandShellGuarded(t *testing.T) {
 	if cmd := ResolveResumeCommand(&store.Session{Adapter: "shell"}); cmd != nil {

--- a/services/gmuxd/internal/discovery/resume_test.go
+++ b/services/gmuxd/internal/discovery/resume_test.go
@@ -34,10 +34,10 @@ func TestResolveResumeCommand(t *testing.T) {
 		sess    store.Session
 		wantNil bool
 	}{
-		{"no session file", store.Session{Kind: "pi"}, true},
-		{"unknown kind", store.Session{Kind: "nope", SessionFile: good}, true},
-		{"unparseable file", store.Session{Kind: "pi", SessionFile: filepath.Join(dir, "ghost.jsonl")}, true},
-		{"resumable pi", store.Session{Kind: "pi", SessionFile: good}, false},
+		{"no session file", store.Session{Adapter: "pi"}, true},
+		{"unknown adapter", store.Session{Adapter: "nope", SessionFile: good}, true},
+		{"unparseable file", store.Session{Adapter: "pi", SessionFile: filepath.Join(dir, "ghost.jsonl")}, true},
+		{"resumable pi", store.Session{Adapter: "pi", SessionFile: good}, false},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -58,7 +58,7 @@ func TestResolveResumeCommand(t *testing.T) {
 // A shell session never carries a SessionFile, so the guard returns before the
 // adapter lookup — even though shell is itself a SessionFiler/Resumer.
 func TestResolveResumeCommandShellGuarded(t *testing.T) {
-	if cmd := ResolveResumeCommand(&store.Session{Kind: "shell"}); cmd != nil {
+	if cmd := ResolveResumeCommand(&store.Session{Adapter: "shell"}); cmd != nil {
 		t.Fatalf("shell session should not resolve a resume command, got %v", cmd)
 	}
 }

--- a/services/gmuxd/internal/discovery/resume_test.go
+++ b/services/gmuxd/internal/discovery/resume_test.go
@@ -56,7 +56,7 @@ func TestResolveResumeCommand(t *testing.T) {
 }
 
 // A shell session never carries a SessionFile, so the guard returns before the
-// adapter lookup — even though shell is itself a SessionFiler/Resumer.
+// adapter lookup — even though shell is itself a ConversationFiler/Resumer.
 func TestResolveResumeCommandShellGuarded(t *testing.T) {
 	if cmd := ResolveResumeCommand(&store.Session{Adapter: "shell"}); cmd != nil {
 		t.Fatalf("shell session should not resolve a resume command, got %v", cmd)

--- a/services/gmuxd/internal/discovery/subscribe.go
+++ b/services/gmuxd/internal/discovery/subscribe.go
@@ -318,7 +318,7 @@ func (sub *Subscriptions) handleEvent(sessionID, socketPath, eventType string, d
 		// rebind (/resume) just overwrites this session's own file; it never
 		// clobbers another session's.
 		sub.store.Update(sessionID, func(sess *store.Session) {
-			sess.SessionFile = sf.Path
+			sess.ConversationFile = sf.Path
 		})
 
 	case "activity":

--- a/services/gmuxd/internal/discovery/subscribe_test.go
+++ b/services/gmuxd/internal/discovery/subscribe_test.go
@@ -76,7 +76,7 @@ func TestSubscribeReplacesExistingForSameID(t *testing.T) {
 
 	const id = "sess-restart-race"
 	sessions := store.New()
-	sessions.Upsert(store.Session{ID: id, Kind: "shell", Alive: true, SocketPath: r1.socketPath})
+	sessions.Upsert(store.Session{ID: id, Adapter: "shell", Alive: true, SocketPath: r1.socketPath})
 
 	subs := NewSubscriptions(sessions)
 	t.Cleanup(func() { subs.UnsubscribeAll() })
@@ -154,7 +154,7 @@ func TestSubscribeOldDeferDoesNotEvictNewEntry(t *testing.T) {
 
 	const id = "sess-defer-eviction"
 	sessions := store.New()
-	sessions.Upsert(store.Session{ID: id, Kind: "shell", Alive: true})
+	sessions.Upsert(store.Session{ID: id, Adapter: "shell", Alive: true})
 
 	subs := NewSubscriptions(sessions)
 	t.Cleanup(func() { subs.UnsubscribeAll() })
@@ -193,7 +193,7 @@ func TestExitEventDoesNotResurrectDismissedSession(t *testing.T) {
 	sessions := store.New()
 	sessions.Upsert(store.Session{
 		ID:      id,
-		Kind:    "shell",
+		Adapter: "shell",
 		Alive:   true,
 		Command: []string{"bash"},
 	})

--- a/services/gmuxd/internal/discovery/subscribe_test.go
+++ b/services/gmuxd/internal/discovery/subscribe_test.go
@@ -245,8 +245,8 @@ func TestConversationFileEventRecordsPath(t *testing.T) {
 	subs.handleEvent("sess-1", "/sock", "conversation_file", []byte(`{"path":"`+path+`"}`))
 
 	got, ok := sessions.Get("sess-1")
-	if !ok || got.SessionFile != path {
-		t.Fatalf("SessionFile = %q (ok=%v), want %q", got.SessionFile, ok, path)
+	if !ok || got.ConversationFile != path {
+		t.Fatalf("ConversationFile = %q (ok=%v), want %q", got.ConversationFile, ok, path)
 	}
 }
 
@@ -262,8 +262,8 @@ func TestLegacySessionFileEventStillAccepted(t *testing.T) {
 	subs.handleEvent("sess-1", "/sock", "session_file", []byte(`{"path":"`+path+`"}`))
 
 	got, ok := sessions.Get("sess-1")
-	if !ok || got.SessionFile != path {
-		t.Fatalf("SessionFile = %q (ok=%v), want %q", got.SessionFile, ok, path)
+	if !ok || got.ConversationFile != path {
+		t.Fatalf("ConversationFile = %q (ok=%v), want %q", got.ConversationFile, ok, path)
 	}
 }
 
@@ -272,7 +272,7 @@ func TestConversationFileEventEmptyPathIgnored(t *testing.T) {
 	sessions.Upsert(store.Session{ID: "sess-1", Alive: true})
 	subs := NewSubscriptions(sessions)
 	subs.handleEvent("sess-1", "/sock", "conversation_file", []byte(`{"path":""}`))
-	if got, _ := sessions.Get("sess-1"); got.SessionFile != "" {
-		t.Errorf("empty path should not set SessionFile, got %q", got.SessionFile)
+	if got, _ := sessions.Get("sess-1"); got.ConversationFile != "" {
+		t.Errorf("empty path should not set ConversationFile, got %q", got.ConversationFile)
 	}
 }

--- a/services/gmuxd/internal/peering/peer.go
+++ b/services/gmuxd/internal/peering/peer.go
@@ -37,9 +37,9 @@ type Peer struct {
 
 	mu             sync.RWMutex
 	status         Status
-	lastError      string      // human-readable reason for last disconnect
-	cachedHealth   SpokeHealth // peer's /v1/health data, fetched on connect
-	healthLoaded   bool        // true after first successful health fetch
+	lastError      string         // human-readable reason for last disconnect
+	cachedHealth   SpokeHealth    // peer's /v1/health data, fetched on connect
+	healthLoaded   bool           // true after first successful health fetch
 	cachedProjects []SpokeProject // peer's projects, refreshed on connect and on projects-update
 	projectsLoaded bool
 	// cachedDiscovered is the spoke's self-advertised discovered list
@@ -486,7 +486,7 @@ func (p *Peer) applySessionsSnapshot(remote []store.Session) {
 		// Title and Resumable. Upsert would re-run resolveTitle against
 		// the wire session where ShellTitle/AdapterTitle are absent
 		// (they're internal fields, intentionally off the wire) and
-		// overwrite the correct title with the Kind fallback.
+		// overwrite the correct title with the adapter-name fallback.
 		p.store.UpsertRemote(sess)
 	}
 

--- a/services/gmuxd/internal/peering/peering_test.go
+++ b/services/gmuxd/internal/peering/peering_test.go
@@ -170,15 +170,15 @@ func spokeServer(t *testing.T, token string, sessions []store.Session) *spoke {
 // resolved by the spoke but with empty ShellTitle/AdapterTitle
 // (those are internal, intentionally off-wire). The hub must not
 // re-resolve the title or it would replace the spoke's value with
-// the Kind fallback (e.g. "codex" instead of "fix remote bug").
+// the adapter-name fallback (e.g. "codex" instead of "fix remote bug").
 func TestPeerSubscribe_PreservesTitles(t *testing.T) {
 	st := store.New()
 	sessions := []store.Session{
 		{
-			ID:    "sess-1",
-			Kind:  "codex",
-			Alive: true,
-			Title: "fix remote bug",
+			ID:      "sess-1",
+			Adapter: "codex",
+			Alive:   true,
+			Title:   "fix remote bug",
 			// ShellTitle/AdapterTitle intentionally empty: that's
 			// how they arrive on the wire because store.MarshalJSON
 			// drops them.
@@ -228,8 +228,8 @@ func TestPeerStatus_CarriesSource(t *testing.T) {
 func TestPeerSubscribe_InitialSessions(t *testing.T) {
 	st := store.New()
 	sessions := []store.Session{
-		{ID: "sess-1", Kind: "pi", Alive: true, Slug: "fix-auth"},
-		{ID: "sess-2", Kind: "shell", Alive: true, Slug: "bash"},
+		{ID: "sess-1", Adapter: "pi", Alive: true, Slug: "fix-auth"},
+		{ID: "sess-2", Adapter: "shell", Alive: true, Slug: "bash"},
 	}
 
 	token := "test-token-abc"
@@ -253,8 +253,8 @@ func TestPeerSubscribe_InitialSessions(t *testing.T) {
 	if s1.Peer != "server" {
 		t.Errorf("peer = %q, want %q", s1.Peer, "server")
 	}
-	if s1.Kind != "pi" {
-		t.Errorf("kind = %q, want %q", s1.Kind, "pi")
+	if s1.Adapter != "pi" {
+		t.Errorf("adapter = %q, want %q", s1.Adapter, "pi")
 	}
 	if s1.SocketPath != "" {
 		t.Errorf("socket_path should be cleared for remote sessions, got %q", s1.SocketPath)
@@ -264,8 +264,8 @@ func TestPeerSubscribe_InitialSessions(t *testing.T) {
 	if !ok {
 		t.Fatal("expected sess-2@server in store")
 	}
-	if s2.Kind != "shell" {
-		t.Errorf("kind = %q, want %q", s2.Kind, "shell")
+	if s2.Adapter != "shell" {
+		t.Errorf("adapter = %q, want %q", s2.Adapter, "shell")
 	}
 
 	mgr.Stop()
@@ -313,7 +313,7 @@ func TestPeerSubscribe_AuthFailure(t *testing.T) {
 func TestPeerSubscribe_SocketPathCleared(t *testing.T) {
 	st := store.New()
 	sessions := []store.Session{
-		{ID: "sess-1", Kind: "pi", Alive: true, SocketPath: "/tmp/gmux-sessions/sess-1.sock"},
+		{ID: "sess-1", Adapter: "pi", Alive: true, SocketPath: "/tmp/gmux-sessions/sess-1.sock"},
 	}
 
 	sk := spokeServer(t, "", sessions)
@@ -377,8 +377,8 @@ func TestFindPeer_UnknownPeer(t *testing.T) {
 
 func TestPeerStatus(t *testing.T) {
 	st := store.New()
-	st.Upsert(store.Session{ID: "s1@server", Kind: "pi", Alive: true, Peer: "server"})
-	st.Upsert(store.Session{ID: "s2@server", Kind: "shell", Alive: true, Peer: "server"})
+	st.Upsert(store.Session{ID: "s1@server", Adapter: "pi", Alive: true, Peer: "server"})
+	st.Upsert(store.Session{ID: "s2@server", Adapter: "shell", Alive: true, Peer: "server"})
 
 	cfg := []config.PeerConfig{
 		{Name: "server", URL: "http://10.0.0.5:8790", Token: "t"},
@@ -412,7 +412,7 @@ func TestPeerStatus(t *testing.T) {
 func TestPeerStatusEventBroadcast(t *testing.T) {
 	st := store.New()
 	sk := spokeServer(t, "", []store.Session{
-		{ID: "sess-1", Kind: "pi", Alive: true, Slug: "test"},
+		{ID: "sess-1", Adapter: "pi", Alive: true, Slug: "test"},
 	})
 
 	// Subscribe to store events before starting the manager.
@@ -443,8 +443,8 @@ func TestPeerStatusEventBroadcast(t *testing.T) {
 func TestPeerSubscribe_SessionRemoveEvent(t *testing.T) {
 	st := store.New()
 	initialSessions := []store.Session{
-		{ID: "sess-1", Kind: "pi", Alive: true, Slug: "fix-auth"},
-		{ID: "sess-2", Kind: "shell", Alive: true, Slug: "bash"},
+		{ID: "sess-1", Adapter: "pi", Alive: true, Slug: "fix-auth"},
+		{ID: "sess-2", Adapter: "shell", Alive: true, Slug: "bash"},
 	}
 
 	sk := spokeServer(t, "", initialSessions)
@@ -458,7 +458,7 @@ func TestPeerSubscribe_SessionRemoveEvent(t *testing.T) {
 
 	// Drop sess-1 from the spoke's snapshot. The hub diffs and removes.
 	sk.setSessions([]store.Session{
-		{ID: "sess-2", Kind: "shell", Alive: true, Slug: "bash"},
+		{ID: "sess-2", Adapter: "shell", Alive: true, Slug: "bash"},
 	})
 
 	// Wait for removal.
@@ -485,7 +485,7 @@ func TestPeerSubscribe_SessionRemoveEvent(t *testing.T) {
 func TestPeerSubscribe_ActivityForwarded(t *testing.T) {
 	st := store.New()
 	initialSessions := []store.Session{
-		{ID: "sess-1", Kind: "pi", Alive: true, Slug: "fix-auth"},
+		{ID: "sess-1", Adapter: "pi", Alive: true, Slug: "fix-auth"},
 	}
 
 	sk := spokeServer(t, "", initialSessions)
@@ -525,7 +525,7 @@ func TestPeerSubscribe_NewSessionViaPush(t *testing.T) {
 
 	// Start with one session.
 	sk := spokeServer(t, "", []store.Session{
-		{ID: "sess-1", Kind: "pi", Alive: true, Slug: "initial"},
+		{ID: "sess-1", Adapter: "pi", Alive: true, Slug: "initial"},
 	})
 
 	cfg := config.PeerConfig{Name: "server", URL: sk.URL, Token: ""}
@@ -536,8 +536,8 @@ func TestPeerSubscribe_NewSessionViaPush(t *testing.T) {
 
 	// Add a new session to the spoke and re-emit the snapshot.
 	sk.setSessions([]store.Session{
-		{ID: "sess-1", Kind: "pi", Alive: true, Slug: "initial"},
-		{ID: "sess-new", Kind: "shell", Alive: true, Slug: "new-one"},
+		{ID: "sess-1", Adapter: "pi", Alive: true, Slug: "initial"},
+		{ID: "sess-new", Adapter: "shell", Alive: true, Slug: "new-one"},
 	})
 
 	waitForSessions(t, st, "server", 2)
@@ -546,8 +546,8 @@ func TestPeerSubscribe_NewSessionViaPush(t *testing.T) {
 	if !ok {
 		t.Fatal("expected sess-new@server in store")
 	}
-	if got.Kind != "shell" {
-		t.Errorf("kind = %q, want %q", got.Kind, "shell")
+	if got.Adapter != "shell" {
+		t.Errorf("adapter = %q, want %q", got.Adapter, "shell")
 	}
 	if got.Peer != "server" {
 		t.Errorf("peer = %q, want %q", got.Peer, "server")
@@ -565,7 +565,7 @@ func TestPeerSubscribe_ProjectStampsPropagateFromOrigin(t *testing.T) {
 
 	originSess := store.Session{
 		ID:           "sess-1",
-		Kind:         "pi",
+		Adapter:      "pi",
 		Alive:        true,
 		Slug:         "fix-auth",
 		ProjectSlug:  "gmux",
@@ -600,10 +600,10 @@ func TestPeerSubscribe_DisclaimedSessionRoundTripsAsZero(t *testing.T) {
 	st := store.New()
 
 	origin := store.Session{
-		ID:    "sess-1",
-		Kind:  "pi",
-		Alive: true,
-		Slug:  "loose",
+		ID:      "sess-1",
+		Adapter: "pi",
+		Alive:   true,
+		Slug:    "loose",
 		// ProjectSlug == "", ProjectIndex == 0.
 	}
 	sk := spokeServer(t, "", []store.Session{origin})
@@ -646,8 +646,8 @@ func waitForSessions(t *testing.T, st *store.Store, peer string, want int) {
 
 func TestManagerStop_CleansUpSessions(t *testing.T) {
 	st := store.New()
-	st.Upsert(store.Session{ID: "local-1", Kind: "pi", Alive: true})
-	st.Upsert(store.Session{ID: "s1@server", Kind: "pi", Alive: true, Peer: "server"})
+	st.Upsert(store.Session{ID: "local-1", Adapter: "pi", Alive: true})
+	st.Upsert(store.Session{ID: "s1@server", Adapter: "pi", Alive: true, Peer: "server"})
 
 	cfg := []config.PeerConfig{{Name: "server", URL: "http://10.0.0.5:8790", Token: "t"}}
 	mgr := NewManager(cfg, st, "test-host")
@@ -706,7 +706,7 @@ func TestManager_AddPeerIdempotent(t *testing.T) {
 func TestManager_RemovePeer(t *testing.T) {
 	st := store.New()
 	sk := spokeServer(t, "", []store.Session{
-		{ID: "s1", Kind: "pi", Alive: true},
+		{ID: "s1", Adapter: "pi", Alive: true},
 	})
 
 	mgr := NewManager(nil, st, "test-host")
@@ -745,8 +745,8 @@ func TestManager_RemovePeer(t *testing.T) {
 // peers; the projects-side cleanup relies on the wasLocal branch.
 func TestManager_RemovePeer_FiresOnPeerRemoved(t *testing.T) {
 	type call struct {
-		name    string
-		local   bool
+		name  string
+		local bool
 	}
 
 	run := func(t *testing.T, peerLocal bool) {
@@ -1087,8 +1087,8 @@ func TestForwardLaunch_StripsPeerField(t *testing.T) {
 
 func TestPeerStatusCountsOnlyAlive(t *testing.T) {
 	st := store.New()
-	st.Upsert(store.Session{ID: "alive@server", Kind: "shell", Alive: true, Peer: "server"})
-	st.Upsert(store.Session{ID: "dead@server", Kind: "pi", Alive: false, Peer: "server", Command: []string{"pi"}})
+	st.Upsert(store.Session{ID: "alive@server", Adapter: "shell", Alive: true, Peer: "server"})
+	st.Upsert(store.Session{ID: "dead@server", Adapter: "pi", Alive: false, Peer: "server", Command: []string{"pi"}})
 
 	cfg := []config.PeerConfig{
 		{Name: "server", URL: "http://10.0.0.5:8790", Token: "t"},
@@ -1111,11 +1111,11 @@ func TestForwardingFilter_SelfEchoPrevented(t *testing.T) {
 	// Peer "remote" sends us a session "sess-1@test-host" — that's our
 	// own session echoed back. It should be dropped.
 	st := store.New()
-	st.Upsert(store.Session{ID: "sess-1", Kind: "shell", Alive: true}) // our local session
+	st.Upsert(store.Session{ID: "sess-1", Adapter: "shell", Alive: true}) // our local session
 
 	sk := spokeServer(t, "", []store.Session{
 		// The spoke has our session in its store as "sess-1@test-host".
-		{ID: "sess-1@test-host", Kind: "shell", Alive: true, Peer: "test-host"},
+		{ID: "sess-1@test-host", Adapter: "shell", Alive: true, Peer: "test-host"},
 	})
 
 	mgr := NewManager([]config.PeerConfig{
@@ -1146,11 +1146,11 @@ func TestForwardingFilter_KnownPeerSessionDropped(t *testing.T) {
 	st := store.New()
 
 	skAlpha := spokeServer(t, "", []store.Session{
-		{ID: "sess-a", Kind: "shell", Alive: true},
+		{ID: "sess-a", Adapter: "shell", Alive: true},
 	})
 	skBeta := spokeServer(t, "", []store.Session{
-		{ID: "sess-b", Kind: "shell", Alive: true},
-		{ID: "sess-a@alpha", Kind: "shell", Alive: true, Peer: "alpha"}, // forwarded
+		{ID: "sess-b", Adapter: "shell", Alive: true},
+		{ID: "sess-a@alpha", Adapter: "shell", Alive: true, Peer: "alpha"}, // forwarded
 	})
 
 	mgr := NewManager([]config.PeerConfig{
@@ -1186,8 +1186,8 @@ func TestForwardingFilter_UnknownPeerSessionKept(t *testing.T) {
 	st := store.New()
 
 	sk := spokeServer(t, "", []store.Session{
-		{ID: "sess-1", Kind: "shell", Alive: true},
-		{ID: "sess-d@devcontainer", Kind: "pi", Alive: true, Peer: "devcontainer"},
+		{ID: "sess-1", Adapter: "shell", Alive: true},
+		{ID: "sess-d@devcontainer", Adapter: "pi", Alive: true, Peer: "devcontainer"},
 	})
 
 	mgr := NewManager([]config.PeerConfig{
@@ -1211,8 +1211,8 @@ func TestOnSleep_ReconnectsAndResyncs(t *testing.T) {
 	st := store.New()
 
 	sessions := []store.Session{
-		{ID: "sess-1", Kind: "pi", Alive: true},
-		{ID: "sess-2", Kind: "shell", Alive: true},
+		{ID: "sess-1", Adapter: "pi", Alive: true},
+		{ID: "sess-2", Adapter: "shell", Alive: true},
 	}
 	sk := spokeServer(t, "", sessions)
 
@@ -1226,7 +1226,7 @@ func TestOnSleep_ReconnectsAndResyncs(t *testing.T) {
 	// (no SSE event delivered).
 	sk.mu.Lock()
 	sk.sessions = []store.Session{
-		{ID: "sess-1", Kind: "pi", Alive: true},
+		{ID: "sess-1", Adapter: "pi", Alive: true},
 		// sess-2 is gone
 	}
 	sk.mu.Unlock()
@@ -1264,8 +1264,8 @@ func TestOnSleep_ReconnectsAndResyncs(t *testing.T) {
 func TestDisconnect_SessionsPersist(t *testing.T) {
 	st := store.New()
 	sessions := []store.Session{
-		{ID: "sess-1", Kind: "pi", Alive: true, Title: "important work"},
-		{ID: "sess-2", Kind: "codex", Alive: true, Title: "background task"},
+		{ID: "sess-1", Adapter: "pi", Alive: true, Title: "important work"},
+		{ID: "sess-2", Adapter: "codex", Alive: true, Title: "background task"},
 	}
 
 	// spokeServer sends sessions then closes, simulating a disconnect.
@@ -1311,9 +1311,9 @@ func TestApplySessionsSnapshot_DedupsIdenticalState(t *testing.T) {
 	p := newPeer(cfg, st, nil)
 
 	sessions := []store.Session{
-		{ID: "sess-1", Kind: "pi", Alive: true, Slug: "a", Cwd: "/tmp"},
-		{ID: "sess-2", Kind: "shell", Alive: true, Slug: "b", Cwd: "/home"},
-		{ID: "sess-3", Kind: "pi", Alive: false, Slug: "c", Cwd: "/var"},
+		{ID: "sess-1", Adapter: "pi", Alive: true, Slug: "a", Cwd: "/tmp"},
+		{ID: "sess-2", Adapter: "shell", Alive: true, Slug: "b", Cwd: "/home"},
+		{ID: "sess-3", Adapter: "pi", Alive: false, Slug: "c", Cwd: "/var"},
 	}
 
 	// First application: every session is new, so each one must
@@ -1367,8 +1367,8 @@ func TestApplySessionsSnapshot_BroadcastsOnRealChange(t *testing.T) {
 	p := newPeer(cfg, st, nil)
 
 	sessions := []store.Session{
-		{ID: "sess-1", Kind: "pi", Alive: true, Slug: "a", Cwd: "/tmp"},
-		{ID: "sess-2", Kind: "shell", Alive: true, Slug: "b", Cwd: "/home"},
+		{ID: "sess-1", Adapter: "pi", Alive: true, Slug: "a", Cwd: "/tmp"},
+		{ID: "sess-2", Adapter: "shell", Alive: true, Slug: "b", Cwd: "/home"},
 	}
 	p.applySessionsSnapshot(sessions)
 
@@ -1386,8 +1386,8 @@ drained2:
 
 	// Flip alive on sess-2 only.
 	sessions2 := []store.Session{
-		{ID: "sess-1", Kind: "pi", Alive: true, Slug: "a", Cwd: "/tmp"},
-		{ID: "sess-2", Kind: "shell", Alive: false, Slug: "b", Cwd: "/home"},
+		{ID: "sess-1", Adapter: "pi", Alive: true, Slug: "a", Cwd: "/tmp"},
+		{ID: "sess-2", Adapter: "shell", Alive: false, Slug: "b", Cwd: "/home"},
 	}
 	p.applySessionsSnapshot(sessions2)
 

--- a/services/gmuxd/internal/sessionmeta/sessionmeta.go
+++ b/services/gmuxd/internal/sessionmeta/sessionmeta.go
@@ -102,7 +102,7 @@ const (
 // RetentionPolicy bounds the disk footprint of dead sessions. A zero
 // value for any field disables that limit.
 type RetentionPolicy struct {
-	// MaxAge ages out conversation-less dead sessions (SessionFile == "")
+	// MaxAge ages out conversation-less dead sessions (ConversationFile == "")
 	// whose effective timestamp is older than now-MaxAge. Sessions with a
 	// conversation file are exempt: their lifecycle is the conversation's
 	// (index-driven removal). Zero means no age limit.
@@ -326,7 +326,7 @@ func (s *Store) Read(id string) (store.Session, error) {
 	// meta.json has no schema version, so fall back to the old keys when
 	// the new ones are absent. Write emits only the new keys.
 	// TODO(v2.1): drop this shim.
-	if ps.Adapter == "" || ps.SessionFile == "" {
+	if ps.Adapter == "" || ps.ConversationFile == "" {
 		var legacy struct {
 			Kind        string `json:"kind"`
 			SessionFile string `json:"session_file"`
@@ -335,8 +335,8 @@ func (s *Store) Read(id string) (store.Session, error) {
 			if ps.Adapter == "" {
 				ps.Adapter = legacy.Kind
 			}
-			if ps.SessionFile == "" {
-				ps.SessionFile = legacy.SessionFile
+			if ps.ConversationFile == "" {
+				ps.ConversationFile = legacy.SessionFile
 			}
 		}
 	}
@@ -403,7 +403,7 @@ func (s *Store) WatchRemovals(events <-chan store.Event) {
 //   - non-directory entries under the base dir are ignored
 //
 // After loading, the whole-dir retention cap is applied to
-// conversation-less dead sessions (SessionFile == ""): corpses older
+// conversation-less dead sessions (ConversationFile == ""): corpses older
 // than MaxAge are aged out, then only the newest MaxCount survive.
 // Sessions with a conversation file are exempt — they are retired only
 // when their conversation file disappears (see the conversations index
@@ -495,7 +495,7 @@ func (s *Store) prune(loaded []store.Session) []store.Session {
 	// pruned here; their lifecycle is index-driven.
 	var exempt, corpses []store.Session
 	for _, sess := range loaded {
-		if sess.SessionFile != "" {
+		if sess.ConversationFile != "" {
 			exempt = append(exempt, sess)
 		} else {
 			corpses = append(corpses, sess)

--- a/services/gmuxd/internal/sessionmeta/sessionmeta.go
+++ b/services/gmuxd/internal/sessionmeta/sessionmeta.go
@@ -326,14 +326,14 @@ func (s *Store) Read(id string) (store.Session, error) {
 	// meta.json has no schema version, so fall back to the old keys when
 	// the new ones are absent. Write emits only the new keys.
 	// TODO(v2.1): drop this shim.
-	if ps.Kind == "" || ps.SessionFile == "" {
+	if ps.Adapter == "" || ps.SessionFile == "" {
 		var legacy struct {
 			Kind        string `json:"kind"`
 			SessionFile string `json:"session_file"`
 		}
 		if err := json.Unmarshal(data, &legacy); err == nil {
-			if ps.Kind == "" {
-				ps.Kind = legacy.Kind
+			if ps.Adapter == "" {
+				ps.Adapter = legacy.Kind
 			}
 			if ps.SessionFile == "" {
 				ps.SessionFile = legacy.SessionFile
@@ -365,7 +365,7 @@ func (s *Store) Remove(id string) error {
 // paths that have explicit Remove calls.
 //
 // Catches the slug-takeover case: when a fresh live session
-// shadows a dead one with the same (kind, peer, slug), the store
+// shadows a dead one with the same (adapter, peer, slug), the store
 // silently evicts the dead record and broadcasts session-remove.
 // Without this loop those orphan meta.json files accumulate — the
 // next Sweep would re-load them and the next slug collision would

--- a/services/gmuxd/internal/sessionmeta/sessionmeta_retention_test.go
+++ b/services/gmuxd/internal/sessionmeta/sessionmeta_retention_test.go
@@ -17,7 +17,7 @@ import (
 // SessionFile so retention tests can stage corpses on disk.
 func writeDead(t *testing.T, s *Store, id, exitedAt, sessionFile string) {
 	t.Helper()
-	sess := store.Session{ID: id, Kind: "shell", Alive: false, ExitedAt: exitedAt, SessionFile: sessionFile}
+	sess := store.Session{ID: id, Adapter: "shell", Alive: false, ExitedAt: exitedAt, SessionFile: sessionFile}
 	if err := s.Write(sess); err != nil {
 		t.Fatalf("Write %s: %v", id, err)
 	}
@@ -444,7 +444,7 @@ func TestPruneScrollbackCoalesces(t *testing.T) {
 // consumed by WatchRemovals, delete the on-disk meta dir.
 func TestRemoveDeadBySessionFileDrivesWatchRemovals(t *testing.T) {
 	metaStore := New(t.TempDir())
-	sess := store.Session{ID: "sess-dead1", Kind: "claude", Alive: false, SessionFile: "/c/conv.jsonl"}
+	sess := store.Session{ID: "sess-dead1", Adapter: "claude", Alive: false, SessionFile: "/c/conv.jsonl"}
 	if err := metaStore.Write(sess); err != nil {
 		t.Fatal(err)
 	}

--- a/services/gmuxd/internal/sessionmeta/sessionmeta_retention_test.go
+++ b/services/gmuxd/internal/sessionmeta/sessionmeta_retention_test.go
@@ -14,10 +14,10 @@ import (
 // --- helpers -------------------------------------------------------
 
 // writeDead persists a dead session with the given id, ExitedAt and
-// SessionFile so retention tests can stage corpses on disk.
-func writeDead(t *testing.T, s *Store, id, exitedAt, sessionFile string) {
+// ConversationFile so retention tests can stage corpses on disk.
+func writeDead(t *testing.T, s *Store, id, exitedAt, conversationFile string) {
 	t.Helper()
-	sess := store.Session{ID: id, Adapter: "shell", Alive: false, ExitedAt: exitedAt, SessionFile: sessionFile}
+	sess := store.Session{ID: id, Adapter: "shell", Alive: false, ExitedAt: exitedAt, ConversationFile: conversationFile}
 	if err := s.Write(sess); err != nil {
 		t.Fatalf("Write %s: %v", id, err)
 	}
@@ -438,13 +438,13 @@ func TestPruneScrollbackCoalesces(t *testing.T) {
 	}
 }
 
-// TestRemoveDeadBySessionFileDrivesWatchRemovals pins the seam between
+// TestRemoveDeadByConversationFileDrivesWatchRemovals pins the seam between
 // the store broadcast and the meta persister: retiring a dead session
-// via RemoveDeadBySessionFile must, through the session-remove event
+// via RemoveDeadByConversationFile must, through the session-remove event
 // consumed by WatchRemovals, delete the on-disk meta dir.
-func TestRemoveDeadBySessionFileDrivesWatchRemovals(t *testing.T) {
+func TestRemoveDeadByConversationFileDrivesWatchRemovals(t *testing.T) {
 	metaStore := New(t.TempDir())
-	sess := store.Session{ID: "sess-dead1", Adapter: "claude", Alive: false, SessionFile: "/c/conv.jsonl"}
+	sess := store.Session{ID: "sess-dead1", Adapter: "claude", Alive: false, ConversationFile: "/c/conv.jsonl"}
 	if err := metaStore.Write(sess); err != nil {
 		t.Fatal(err)
 	}
@@ -458,7 +458,7 @@ func TestRemoveDeadBySessionFileDrivesWatchRemovals(t *testing.T) {
 	done := make(chan struct{})
 	go func() { metaStore.WatchRemovals(events); close(done) }()
 
-	if ids := sessions.RemoveDeadBySessionFile("/c/conv.jsonl"); len(ids) != 1 {
+	if ids := sessions.RemoveDeadByConversationFile("/c/conv.jsonl"); len(ids) != 1 {
 		t.Fatalf("expected 1 retired session, got %v", ids)
 	}
 

--- a/services/gmuxd/internal/sessionmeta/sessionmeta_test.go
+++ b/services/gmuxd/internal/sessionmeta/sessionmeta_test.go
@@ -21,7 +21,7 @@ func sampleSession() store.Session {
 	exit := 42
 	return store.Session{
 		ID:           "sess-test123",
-		Kind:         "shell",
+		Adapter:      "shell",
 		Command:      []string{"bash", "-l"},
 		Cwd:          "/home/u/proj",
 		Alive:        false,
@@ -39,7 +39,7 @@ func sampleSession() store.Session {
 // claim of this package: persisted sessions come back with the
 // internal Title-precedence fields (ShellTitle, AdapterTitle) intact.
 // Without this, a restored session loses its title resolution and
-// shows up as the bare Kind ("shell") instead of "proj".
+// shows up as the bare adapter name ("shell") instead of "proj".
 func TestRoundTripPreservesInternalFields(t *testing.T) {
 	s := newStore(t)
 	in := sampleSession()
@@ -77,31 +77,31 @@ func TestRoundTripFullSession(t *testing.T) {
 	s := newStore(t)
 	exit := 7
 	in := store.Session{
-		ID:            "sess-full",
-		CreatedAt:     "2026-04-26T10:00:00Z",
-		Command:       []string{"bash", "-c", "echo hi"},
-		Cwd:           "~/work",
-		Kind:          "shell",
-		WorkspaceRoot: "~/work/repo",
-		Remotes:       map[string]string{"origin": "github.com/me/repo"},
-		Alive:         false,
-		Pid:           12345,
-		ExitCode:      &exit,
-		StartedAt:     "2026-04-26T10:00:01Z",
-		ExitedAt:      "2026-04-26T10:05:00Z",
-		Title:         "my title",
-		Subtitle:      "my subtitle",
-		Status:        &store.Status{Working: true, Error: false},
-		Unread:        true,
-		Resumable:     true,
-		SocketPath:    "/tmp/gmux-sessions/sess-full.sock",
-		TerminalCols:  120,
-		TerminalRows:  40,
-		Slug:          "my-slug",
-		RunnerVersion: "v1.4.0",
-		BinaryHash:    "abc123",
-		ShellTitle:    "shell-title",
-		AdapterTitle:  "adapter-title",
+		ID:             "sess-full",
+		CreatedAt:      "2026-04-26T10:00:00Z",
+		Command:        []string{"bash", "-c", "echo hi"},
+		Cwd:            "~/work",
+		Adapter:        "shell",
+		WorkspaceRoot:  "~/work/repo",
+		Remotes:        map[string]string{"origin": "github.com/me/repo"},
+		Alive:          false,
+		Pid:            12345,
+		ExitCode:       &exit,
+		StartedAt:      "2026-04-26T10:00:01Z",
+		ExitedAt:       "2026-04-26T10:05:00Z",
+		Title:          "my title",
+		Subtitle:       "my subtitle",
+		Status:         &store.Status{Working: true, Error: false},
+		Unread:         true,
+		Resumable:      true,
+		SocketPath:     "/tmp/gmux-sessions/sess-full.sock",
+		TerminalCols:   120,
+		TerminalRows:   40,
+		Slug:           "my-slug",
+		RunnerVersion:  "v1.4.0",
+		BinaryHash:     "abc123",
+		ShellTitle:     "shell-title",
+		AdapterTitle:   "adapter-title",
 		LastActivityAt: "2026-04-26T10:04:30Z",
 	}
 
@@ -205,8 +205,8 @@ func TestReadLegacyPreV2Keys(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Read: %v", err)
 	}
-	if got.Kind != "pi" {
-		t.Errorf("Kind = %q, want %q (legacy \"kind\" fallback)", got.Kind, "pi")
+	if got.Adapter != "pi" {
+		t.Errorf("Adapter = %q, want %q (legacy \"kind\" fallback)", got.Adapter, "pi")
 	}
 	if want := "/home/u/.pi/agent/sessions/x/conv.jsonl"; got.SessionFile != want {
 		t.Errorf("SessionFile = %q, want %q (legacy \"session_file\" fallback)", got.SessionFile, want)

--- a/services/gmuxd/internal/sessionmeta/sessionmeta_test.go
+++ b/services/gmuxd/internal/sessionmeta/sessionmeta_test.go
@@ -208,8 +208,8 @@ func TestReadLegacyPreV2Keys(t *testing.T) {
 	if got.Adapter != "pi" {
 		t.Errorf("Adapter = %q, want %q (legacy \"kind\" fallback)", got.Adapter, "pi")
 	}
-	if want := "/home/u/.pi/agent/sessions/x/conv.jsonl"; got.SessionFile != want {
-		t.Errorf("SessionFile = %q, want %q (legacy \"session_file\" fallback)", got.SessionFile, want)
+	if want := "/home/u/.pi/agent/sessions/x/conv.jsonl"; got.ConversationFile != want {
+		t.Errorf("SessionFile = %q, want %q (legacy \"session_file\" fallback)", got.ConversationFile, want)
 	}
 }
 
@@ -218,7 +218,7 @@ func TestReadLegacyPreV2Keys(t *testing.T) {
 func TestWriteEmitsOnlyNewKeys(t *testing.T) {
 	s := newStore(t)
 	sess := sampleSession()
-	sess.SessionFile = "/tmp/conv.jsonl"
+	sess.ConversationFile = "/tmp/conv.jsonl"
 	if err := s.Write(sess); err != nil {
 		t.Fatalf("Write: %v", err)
 	}

--- a/services/gmuxd/internal/store/store.go
+++ b/services/gmuxd/internal/store/store.go
@@ -16,18 +16,16 @@ import (
 // backend logic but excluded from MarshalJSON).
 type Session struct {
 	// ── API-visible fields ──
-	ID            string            `json:"id"`
+	ID string `json:"id"`
 
 	// Peer identifies which gmuxd instance owns this session.
 	// Empty = local. Non-empty = the peer name (manual peer in peers.json, or a discovered peer).
-	Peer string `json:"peer,omitempty"`
-	CreatedAt     string            `json:"created_at,omitempty"`
-	Command       []string          `json:"command,omitempty"`
-	Cwd           string            `json:"cwd,omitempty"`
-	// Kind holds the adapter name ("pi", "claude", "shell", ...). The wire
-	// key is "adapter" (v2 rename); the Go identifier's rename to Adapter
-	// trails with the internal cleanup.
-	Kind          string            `json:"adapter"`
+	Peer      string   `json:"peer,omitempty"`
+	CreatedAt string   `json:"created_at,omitempty"`
+	Command   []string `json:"command,omitempty"`
+	Cwd       string   `json:"cwd,omitempty"`
+	// Adapter holds the adapter name ("pi", "claude", "shell", ...).
+	Adapter       string            `json:"adapter"`
 	WorkspaceRoot string            `json:"workspace_root,omitempty"`
 	Remotes       map[string]string `json:"remotes,omitempty"`
 	Alive         bool              `json:"alive"`
@@ -58,14 +56,14 @@ type Session struct {
 	// Peer sessions arrive over the wire with this already set by
 	// the owning daemon; UpsertRemote preserves it as-received.
 	LastActivityAt string `json:"last_activity_at,omitempty"`
-	Resumable     bool              `json:"resumable,omitempty"`
-	SocketPath    string            `json:"socket_path,omitempty"`
-	TerminalCols  uint16            `json:"terminal_cols,omitempty"`
-	TerminalRows  uint16            `json:"terminal_rows,omitempty"`
+	Resumable      bool   `json:"resumable,omitempty"`
+	SocketPath     string `json:"socket_path,omitempty"`
+	TerminalCols   uint16 `json:"terminal_cols,omitempty"`
+	TerminalRows   uint16 `json:"terminal_rows,omitempty"`
 	// Slug is a human-readable stable identifier derived from the
 	// adapter's session file slug. Used for URL routing (the frontend
 	// falls back to id[:8] when empty) and for matching dead sessions
-	// to project membership arrays. Unique within (kind, peer).
+	// to project membership arrays. Unique within (adapter, peer).
 	Slug string `json:"slug,omitempty"`
 
 	// SessionFile is the conversation file this runner authoritatively
@@ -119,38 +117,38 @@ type Session struct {
 // fields (ShellTitle, AdapterTitle) that are resolved into Title before sending.
 func (s Session) MarshalJSON() ([]byte, error) {
 	type wire struct {
-		ID            string            `json:"id"`
-		Peer          string            `json:"peer,omitempty"`
-		CreatedAt     string            `json:"created_at,omitempty"`
-		Command       []string          `json:"command,omitempty"`
-		Cwd           string            `json:"cwd,omitempty"`
-		Kind          string            `json:"adapter"`
-		WorkspaceRoot string            `json:"workspace_root,omitempty"`
-		Remotes       map[string]string `json:"remotes,omitempty"`
-		Alive         bool              `json:"alive"`
-		Pid           int               `json:"pid,omitempty"`
-		ExitCode      *int              `json:"exit_code,omitempty"`
-		StartedAt     string            `json:"started_at,omitempty"`
-		ExitedAt      string            `json:"exited_at,omitempty"`
-		Title         string            `json:"title,omitempty"`
-		Subtitle      string            `json:"subtitle,omitempty"`
-		Status        *Status           `json:"status"`
-		Unread        bool              `json:"unread"`
-		Resumable     bool              `json:"resumable,omitempty"`
-		SocketPath    string            `json:"socket_path,omitempty"`
-		TerminalCols  uint16            `json:"terminal_cols,omitempty"`
-		TerminalRows  uint16            `json:"terminal_rows,omitempty"`
-		Slug          string            `json:"slug,omitempty"`
-		SessionFile   string            `json:"conversation_file,omitempty"`
-		RunnerVersion string            `json:"runner_version,omitempty"`
-		BinaryHash    string            `json:"binary_hash,omitempty"`
-		ProjectSlug   string            `json:"project_slug,omitempty"`
-		ProjectIndex  int               `json:"project_index,omitempty"`
-		LastActivityAt string           `json:"last_activity_at,omitempty"`
+		ID             string            `json:"id"`
+		Peer           string            `json:"peer,omitempty"`
+		CreatedAt      string            `json:"created_at,omitempty"`
+		Command        []string          `json:"command,omitempty"`
+		Cwd            string            `json:"cwd,omitempty"`
+		Adapter        string            `json:"adapter"`
+		WorkspaceRoot  string            `json:"workspace_root,omitempty"`
+		Remotes        map[string]string `json:"remotes,omitempty"`
+		Alive          bool              `json:"alive"`
+		Pid            int               `json:"pid,omitempty"`
+		ExitCode       *int              `json:"exit_code,omitempty"`
+		StartedAt      string            `json:"started_at,omitempty"`
+		ExitedAt       string            `json:"exited_at,omitempty"`
+		Title          string            `json:"title,omitempty"`
+		Subtitle       string            `json:"subtitle,omitempty"`
+		Status         *Status           `json:"status"`
+		Unread         bool              `json:"unread"`
+		Resumable      bool              `json:"resumable,omitempty"`
+		SocketPath     string            `json:"socket_path,omitempty"`
+		TerminalCols   uint16            `json:"terminal_cols,omitempty"`
+		TerminalRows   uint16            `json:"terminal_rows,omitempty"`
+		Slug           string            `json:"slug,omitempty"`
+		SessionFile    string            `json:"conversation_file,omitempty"`
+		RunnerVersion  string            `json:"runner_version,omitempty"`
+		BinaryHash     string            `json:"binary_hash,omitempty"`
+		ProjectSlug    string            `json:"project_slug,omitempty"`
+		ProjectIndex   int               `json:"project_index,omitempty"`
+		LastActivityAt string            `json:"last_activity_at,omitempty"`
 	}
 	return json.Marshal(wire{
 		ID: s.ID, Peer: s.Peer, CreatedAt: s.CreatedAt, Command: s.Command,
-		Cwd: s.Cwd, Kind: s.Kind, WorkspaceRoot: s.WorkspaceRoot,
+		Cwd: s.Cwd, Adapter: s.Adapter, WorkspaceRoot: s.WorkspaceRoot,
 		Remotes: s.Remotes, Alive: s.Alive, Pid: s.Pid,
 		ExitCode: s.ExitCode, StartedAt: s.StartedAt, ExitedAt: s.ExitedAt,
 		Title: s.Title, Subtitle: s.Subtitle, Status: s.Status,
@@ -197,7 +195,7 @@ func New() *Store {
 	}
 }
 
-// SetCommandTitlers configures per-kind functions that derive a display
+// SetCommandTitlers configures per-adapter functions that derive a display
 // title from a command array. Used as the fallback when no adapter or
 // shell title is set (e.g. "codex" instead of "codex resume <id>").
 func (s *Store) SetCommandTitlers(titlers map[string]func([]string) string) {
@@ -223,18 +221,18 @@ func (s *Store) Get(id string) (Session, bool) {
 }
 
 // HasLocalSlug reports whether the store already contains a local
-// (non-peer) session with the given (kind, slug). Slug is identity
+// (non-peer) session with the given (adapter, slug). Slug is identity
 // for sidebar purposes (see UBIQUITOUS_LANGUAGE.md), so this is the
 // right check when deciding whether a project-tracked session is
 // already represented, regardless of which instance ID it carries.
-func (s *Store) HasLocalSlug(kind, slug string) bool {
+func (s *Store) HasLocalSlug(adapter, slug string) bool {
 	if slug == "" {
 		return false
 	}
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	for _, sess := range s.sessions {
-		if sess.Peer == "" && sess.Kind == kind && sess.Slug == slug {
+		if sess.Peer == "" && sess.Adapter == adapter && sess.Slug == slug {
 			return true
 		}
 	}
@@ -250,12 +248,12 @@ func (s *Store) resolveTitle(sess Session) string {
 		return sess.ShellTitle
 	}
 	// Ask the adapter for a command title if it implements CommandTitler.
-	if fn := s.commandTitlers[sess.Kind]; fn != nil && len(sess.Command) > 0 {
+	if fn := s.commandTitlers[sess.Adapter]; fn != nil && len(sess.Command) > 0 {
 		return fn(sess.Command)
 	}
-	// Default: use the adapter kind as the title (e.g. "codex", "claude").
-	if sess.Kind != "" {
-		return sess.Kind
+	// Default: use the adapter name as the title (e.g. "codex", "claude").
+	if sess.Adapter != "" {
+		return sess.Adapter
 	}
 	return sess.Title
 }
@@ -272,7 +270,7 @@ func (s *Store) Upsert(sess Session) {
 // arriving in the SSE payload already. The spoke intentionally keeps
 // its internal ShellTitle/AdapterTitle fields off the wire, so the
 // hub never has enough information to re-resolve correctly and would
-// otherwise overwrite a correct Title with the adapter Kind fallback.
+// otherwise overwrite a correct Title with the adapter-name fallback.
 //
 // Canonicalization, duplicate-slug handling, unique-slug
 // numbering, and event broadcast all still run; only the title and
@@ -427,7 +425,7 @@ func (s *Store) SetTerminalSize(id string, cols, rows uint16) bool {
 }
 
 // resolveDuplicateSlugsLocked deduplicates sessions that share a Slug
-// within the same (kind, peer) scope. When a live session arrives and
+// within the same (adapter, peer) scope. When a live session arrives and
 // a dead session with the same slug exists, the dead one is removed.
 // When a dead session arrives and a live one exists, the dead one is
 // skipped.
@@ -439,8 +437,8 @@ func (s *Store) resolveDuplicateSlugsLocked(sess Session) (removed []string, ski
 		if id == sess.ID || other.Slug != sess.Slug {
 			continue
 		}
-		// Same (kind, peer) scope check.
-		if other.Kind != sess.Kind || other.Peer != sess.Peer {
+		// Same (adapter, peer) scope check.
+		if other.Adapter != sess.Adapter || other.Peer != sess.Peer {
 			continue
 		}
 		switch {
@@ -615,7 +613,7 @@ func NowUnix() float64 {
 }
 
 // ensureUniqueSlug appends "-2", "-3" suffixes to the session's
-// Slug when another session in the same (kind, peer) scope already
+// Slug when another session in the same (adapter, peer) scope already
 // uses that key. Sessions without a Slug (fresh launches before
 // file attribution) are left alone; the frontend falls back to the
 // session ID prefix for URL routing.
@@ -629,7 +627,7 @@ func (s *Store) ensureUniqueSlug(sess *Session) {
 	for i := 2; ; i++ {
 		conflict := false
 		for _, existing := range s.sessions {
-			if existing.ID != sess.ID && existing.Kind == sess.Kind && existing.Peer == sess.Peer && existing.Slug == sess.Slug {
+			if existing.ID != sess.ID && existing.Adapter == sess.Adapter && existing.Peer == sess.Peer && existing.Slug == sess.Slug {
 				conflict = true
 				break
 			}
@@ -640,7 +638,6 @@ func (s *Store) ensureUniqueSlug(sess *Session) {
 		sess.Slug = fmt.Sprintf("%s-%d", base, i)
 	}
 }
-
 
 // activitySnapshot captures the four scalar bits that determine
 // whether a session transition bumps LastActivityAt. Snapshotting

--- a/services/gmuxd/internal/store/store.go
+++ b/services/gmuxd/internal/store/store.go
@@ -61,17 +61,17 @@ type Session struct {
 	TerminalCols   uint16 `json:"terminal_cols,omitempty"`
 	TerminalRows   uint16 `json:"terminal_rows,omitempty"`
 	// Slug is a human-readable stable identifier derived from the
-	// adapter's session file slug. Used for URL routing (the frontend
+	// adapter's conversation file slug. Used for URL routing (the frontend
 	// falls back to id[:8] when empty) and for matching dead sessions
 	// to project membership arrays. Unique within (adapter, peer).
 	Slug string `json:"slug,omitempty"`
 
-	// SessionFile is the conversation file this runner authoritatively
+	// ConversationFile is the conversation file this runner authoritatively
 	// writes, as reported by the agent hook (session → file; ADR 0011).
-	// Two live sessions may carry the same SessionFile when the same
+	// Two live sessions may carry the same ConversationFile when the same
 	// conversation is resumed in more than one tab; the frontend groups
 	// by this to warn about a conversation open in multiple runners.
-	SessionFile string `json:"conversation_file,omitempty"`
+	ConversationFile string `json:"conversation_file,omitempty"`
 
 	// RunnerVersion is the version string of the gmux runner binary that
 	// launched this session. Set by the runner at startup. The frontend
@@ -117,34 +117,34 @@ type Session struct {
 // fields (ShellTitle, AdapterTitle) that are resolved into Title before sending.
 func (s Session) MarshalJSON() ([]byte, error) {
 	type wire struct {
-		ID             string            `json:"id"`
-		Peer           string            `json:"peer,omitempty"`
-		CreatedAt      string            `json:"created_at,omitempty"`
-		Command        []string          `json:"command,omitempty"`
-		Cwd            string            `json:"cwd,omitempty"`
-		Adapter        string            `json:"adapter"`
-		WorkspaceRoot  string            `json:"workspace_root,omitempty"`
-		Remotes        map[string]string `json:"remotes,omitempty"`
-		Alive          bool              `json:"alive"`
-		Pid            int               `json:"pid,omitempty"`
-		ExitCode       *int              `json:"exit_code,omitempty"`
-		StartedAt      string            `json:"started_at,omitempty"`
-		ExitedAt       string            `json:"exited_at,omitempty"`
-		Title          string            `json:"title,omitempty"`
-		Subtitle       string            `json:"subtitle,omitempty"`
-		Status         *Status           `json:"status"`
-		Unread         bool              `json:"unread"`
-		Resumable      bool              `json:"resumable,omitempty"`
-		SocketPath     string            `json:"socket_path,omitempty"`
-		TerminalCols   uint16            `json:"terminal_cols,omitempty"`
-		TerminalRows   uint16            `json:"terminal_rows,omitempty"`
-		Slug           string            `json:"slug,omitempty"`
-		SessionFile    string            `json:"conversation_file,omitempty"`
-		RunnerVersion  string            `json:"runner_version,omitempty"`
-		BinaryHash     string            `json:"binary_hash,omitempty"`
-		ProjectSlug    string            `json:"project_slug,omitempty"`
-		ProjectIndex   int               `json:"project_index,omitempty"`
-		LastActivityAt string            `json:"last_activity_at,omitempty"`
+		ID               string            `json:"id"`
+		Peer             string            `json:"peer,omitempty"`
+		CreatedAt        string            `json:"created_at,omitempty"`
+		Command          []string          `json:"command,omitempty"`
+		Cwd              string            `json:"cwd,omitempty"`
+		Adapter          string            `json:"adapter"`
+		WorkspaceRoot    string            `json:"workspace_root,omitempty"`
+		Remotes          map[string]string `json:"remotes,omitempty"`
+		Alive            bool              `json:"alive"`
+		Pid              int               `json:"pid,omitempty"`
+		ExitCode         *int              `json:"exit_code,omitempty"`
+		StartedAt        string            `json:"started_at,omitempty"`
+		ExitedAt         string            `json:"exited_at,omitempty"`
+		Title            string            `json:"title,omitempty"`
+		Subtitle         string            `json:"subtitle,omitempty"`
+		Status           *Status           `json:"status"`
+		Unread           bool              `json:"unread"`
+		Resumable        bool              `json:"resumable,omitempty"`
+		SocketPath       string            `json:"socket_path,omitempty"`
+		TerminalCols     uint16            `json:"terminal_cols,omitempty"`
+		TerminalRows     uint16            `json:"terminal_rows,omitempty"`
+		Slug             string            `json:"slug,omitempty"`
+		ConversationFile string            `json:"conversation_file,omitempty"`
+		RunnerVersion    string            `json:"runner_version,omitempty"`
+		BinaryHash       string            `json:"binary_hash,omitempty"`
+		ProjectSlug      string            `json:"project_slug,omitempty"`
+		ProjectIndex     int               `json:"project_index,omitempty"`
+		LastActivityAt   string            `json:"last_activity_at,omitempty"`
 	}
 	return json.Marshal(wire{
 		ID: s.ID, Peer: s.Peer, CreatedAt: s.CreatedAt, Command: s.Command,
@@ -155,8 +155,8 @@ func (s Session) MarshalJSON() ([]byte, error) {
 		Unread: s.Unread, Resumable: s.Resumable,
 		SocketPath: s.SocketPath, TerminalCols: s.TerminalCols,
 		TerminalRows: s.TerminalRows, Slug: s.Slug,
-		SessionFile:   s.SessionFile,
-		RunnerVersion: s.RunnerVersion, BinaryHash: s.BinaryHash,
+		ConversationFile: s.ConversationFile,
+		RunnerVersion:    s.RunnerVersion, BinaryHash: s.BinaryHash,
 		ProjectSlug: s.ProjectSlug, ProjectIndex: s.ProjectIndex,
 		LastActivityAt: s.LastActivityAt,
 	})
@@ -496,8 +496,8 @@ func (s *Store) Reconcile(assignFn func(Session) (slug string, index int)) {
 	}
 }
 
-// RemoveDeadBySessionFile retires every locally-owned, dead session
-// whose SessionFile points at path, broadcasting session-remove for
+// RemoveDeadByConversationFile retires every locally-owned, dead session
+// whose ConversationFile points at path, broadcasting session-remove for
 // each and returning the removed IDs. Used when the conversations
 // index reports a conversation file has disappeared: meta.json mirrors
 // conversation existence (ADR 0016), so the backing file going away
@@ -513,10 +513,10 @@ func (s *Store) Reconcile(assignFn func(Session) (slug string, index int)) {
 //
 // Paths are compared after filepath.Clean so a cosmetic difference
 // (trailing slash, "./") between the watcher-reported path and the
-// hook-reported SessionFile doesn't defeat the match. Symlinks are not
+// hook-reported ConversationFile doesn't defeat the match. Symlinks are not
 // resolved: the file is already gone, so EvalSymlinks couldn't run, and
 // both paths derive from the same real $HOME in practice.
-func (s *Store) RemoveDeadBySessionFile(path string) []string {
+func (s *Store) RemoveDeadByConversationFile(path string) []string {
 	if path == "" {
 		return nil
 	}
@@ -524,10 +524,10 @@ func (s *Store) RemoveDeadBySessionFile(path string) []string {
 	s.mu.Lock()
 	var removed []string
 	for id, sess := range s.sessions {
-		if sess.Peer != "" || sess.Alive || sess.SessionFile == "" {
+		if sess.Peer != "" || sess.Alive || sess.ConversationFile == "" {
 			continue
 		}
-		if filepath.Clean(sess.SessionFile) != target {
+		if filepath.Clean(sess.ConversationFile) != target {
 			continue
 		}
 		delete(s.sessions, id)

--- a/services/gmuxd/internal/store/store_test.go
+++ b/services/gmuxd/internal/store/store_test.go
@@ -19,7 +19,7 @@ func TestUpsertAndGet(t *testing.T) {
 	s := New()
 	s.Upsert(Session{
 		ID:           "s1",
-		Kind:         "pi",
+		Adapter:      "pi",
 		Alive:        true,
 		AdapterTitle: "test",
 	})
@@ -38,8 +38,8 @@ func TestUpsertAndGet(t *testing.T) {
 
 func TestUpsertOverwrite(t *testing.T) {
 	s := New()
-	s.Upsert(Session{ID: "s1", Kind: "pi", AdapterTitle: "v1"})
-	s.Upsert(Session{ID: "s1", Kind: "pi", AdapterTitle: "v2"})
+	s.Upsert(Session{ID: "s1", Adapter: "pi", AdapterTitle: "v1"})
+	s.Upsert(Session{ID: "s1", Adapter: "pi", AdapterTitle: "v2"})
 
 	got, _ := s.Get("s1")
 	if got.Title != "v2" {
@@ -52,7 +52,7 @@ func TestUpsertOverwrite(t *testing.T) {
 
 func TestRemove(t *testing.T) {
 	s := New()
-	s.Upsert(Session{ID: "s1", Kind: "pi"})
+	s.Upsert(Session{ID: "s1", Adapter: "pi"})
 
 	if !s.Remove("s1") {
 		t.Fatal("expected remove to succeed")
@@ -69,14 +69,14 @@ func TestRemoveDeadBySessionFile(t *testing.T) {
 	const file = "/home/u/.claude/projects/abc/conv.jsonl"
 	s := New()
 	// Two dead sessions share the file (N:1, e.g. resumed in two tabs).
-	s.Upsert(Session{ID: "dead-1", Kind: "claude", Alive: false, SessionFile: file})
-	s.Upsert(Session{ID: "dead-2", Kind: "claude", Alive: false, SessionFile: file})
+	s.Upsert(Session{ID: "dead-1", Adapter: "claude", Alive: false, SessionFile: file})
+	s.Upsert(Session{ID: "dead-2", Adapter: "claude", Alive: false, SessionFile: file})
 	// A live session on the same file must survive (runner still writing).
-	s.Upsert(Session{ID: "live", Kind: "claude", Alive: true, SessionFile: file})
+	s.Upsert(Session{ID: "live", Adapter: "claude", Alive: true, SessionFile: file})
 	// A peer-owned dead session on the same file is not ours to retire.
-	s.Upsert(Session{ID: "peer", Kind: "claude", Alive: false, Peer: "box2", SessionFile: file})
+	s.Upsert(Session{ID: "peer", Adapter: "claude", Alive: false, Peer: "box2", SessionFile: file})
 	// An unrelated dead session must be untouched.
-	s.Upsert(Session{ID: "other", Kind: "claude", Alive: false, SessionFile: "/home/u/.claude/projects/xyz/other.jsonl"})
+	s.Upsert(Session{ID: "other", Adapter: "claude", Alive: false, SessionFile: "/home/u/.claude/projects/xyz/other.jsonl"})
 
 	// Cosmetic path difference must still match (filepath.Clean).
 	removed := s.RemoveDeadBySessionFile("/home/u/.claude/projects/abc/./conv.jsonl")
@@ -102,7 +102,7 @@ func TestRemoveDeadBySessionFile(t *testing.T) {
 
 func TestRemoveDeadBySessionFileNoMatch(t *testing.T) {
 	s := New()
-	s.Upsert(Session{ID: "a", Kind: "claude", Alive: false, SessionFile: "/x/a.jsonl"})
+	s.Upsert(Session{ID: "a", Adapter: "claude", Alive: false, SessionFile: "/x/a.jsonl"})
 	if got := s.RemoveDeadBySessionFile("/x/missing.jsonl"); got != nil {
 		t.Errorf("no-match should return nil, got %v", got)
 	}
@@ -118,7 +118,7 @@ func TestRemoveDeadBySessionFileNoMatch(t *testing.T) {
 // session-remove per removed session (so WatchRemovals drops the dir).
 func TestRemoveDeadBySessionFileBroadcasts(t *testing.T) {
 	s := New()
-	s.Upsert(Session{ID: "dead", Kind: "claude", Alive: false, SessionFile: "/x/c.jsonl"})
+	s.Upsert(Session{ID: "dead", Adapter: "claude", Alive: false, SessionFile: "/x/c.jsonl"})
 	ch, cancel := s.Subscribe()
 	defer cancel()
 
@@ -135,7 +135,7 @@ func TestSubscribe(t *testing.T) {
 	ch, cancel := s.Subscribe()
 	defer cancel()
 
-	s.Upsert(Session{ID: "s1", Kind: "pi", Alive: true})
+	s.Upsert(Session{ID: "s1", Adapter: "pi", Alive: true})
 
 	select {
 	case ev := <-ch:
@@ -185,7 +185,7 @@ func TestUpsertIdenticalSuppressesBroadcast(t *testing.T) {
 	ch, cancel := s.Subscribe()
 	defer cancel()
 
-	sess := Session{ID: "s1", Kind: "pi", Alive: true, Slug: "fix", Cwd: "/work"}
+	sess := Session{ID: "s1", Adapter: "pi", Alive: true, Slug: "fix", Cwd: "/work"}
 	s.Upsert(sess)
 	if ev, ok := recvEvent(t, ch); !ok || ev.Type != "session-upsert" {
 		t.Fatalf("first upsert should broadcast, got ok=%v ev=%+v", ok, ev)
@@ -205,7 +205,7 @@ func TestUpsertRemoteIdenticalSuppressesBroadcast(t *testing.T) {
 	ch, cancel := s.Subscribe()
 	defer cancel()
 
-	sess := Session{ID: "s1@peer", Kind: "pi", Peer: "peer", Alive: true, Slug: "fix", Title: "Fix auth"}
+	sess := Session{ID: "s1@peer", Adapter: "pi", Peer: "peer", Alive: true, Slug: "fix", Title: "Fix auth"}
 	s.UpsertRemote(sess)
 	if _, ok := recvEvent(t, ch); !ok {
 		t.Fatal("first UpsertRemote should broadcast")
@@ -224,7 +224,7 @@ func TestUpsertChangedFieldStillBroadcasts(t *testing.T) {
 	ch, cancel := s.Subscribe()
 	defer cancel()
 
-	sess := Session{ID: "s1", Kind: "pi", Alive: true, Slug: "fix"}
+	sess := Session{ID: "s1", Adapter: "pi", Alive: true, Slug: "fix"}
 	s.Upsert(sess)
 	if _, ok := recvEvent(t, ch); !ok {
 		t.Fatal("first upsert should broadcast")
@@ -251,7 +251,7 @@ func TestUpsertChangedFieldStillBroadcasts(t *testing.T) {
 // re-stamping the same status) must not broadcast.
 func TestUpdateNoOpSuppressesBroadcast(t *testing.T) {
 	s := New()
-	s.Upsert(Session{ID: "s1", Kind: "pi", Alive: true, Slug: "fix"})
+	s.Upsert(Session{ID: "s1", Adapter: "pi", Alive: true, Slug: "fix"})
 	ch, cancel := s.Subscribe()
 	defer cancel()
 
@@ -268,7 +268,7 @@ func TestUpdateNoOpSuppressesBroadcast(t *testing.T) {
 // field still broadcasts exactly once with the new value.
 func TestUpdateRealChangeBroadcasts(t *testing.T) {
 	s := New()
-	s.Upsert(Session{ID: "s1", Kind: "pi", Alive: true, Slug: "fix"})
+	s.Upsert(Session{ID: "s1", Adapter: "pi", Alive: true, Slug: "fix"})
 	ch, cancel := s.Subscribe()
 	defer cancel()
 
@@ -290,7 +290,7 @@ func TestUpdateRealChangeBroadcasts(t *testing.T) {
 // SetTerminalSize must not fan out a snapshot.
 func TestSetTerminalSizeNoOpSuppressesBroadcast(t *testing.T) {
 	s := New()
-	s.Upsert(Session{ID: "s1", Kind: "pi", Alive: true})
+	s.Upsert(Session{ID: "s1", Adapter: "pi", Alive: true})
 	s.SetTerminalSize("s1", 80, 24)
 	ch, cancel := s.Subscribe()
 	defer cancel()
@@ -315,12 +315,12 @@ func TestSetTerminalSizeNoOpSuppressesBroadcast(t *testing.T) {
 }
 
 // --- Derived field tests ---
-// All dead sessions with a command are resumable, regardless of kind.
+// All dead sessions with a command are resumable, regardless of adapter.
 
 func TestDerivedResumable_AliveSessionNeverResumable(t *testing.T) {
 	s := New()
 	s.Upsert(Session{
-		ID: "s1", Kind: "claude", Alive: true,
+		ID: "s1", Adapter: "claude", Alive: true,
 		Command: []string{"claude"},
 	})
 	got, _ := s.Get("s1")
@@ -332,7 +332,7 @@ func TestDerivedResumable_AliveSessionNeverResumable(t *testing.T) {
 func TestDerivedResumable_DeadWithCommand(t *testing.T) {
 	s := New()
 	s.Upsert(Session{
-		ID: "s1", Kind: "claude", Alive: false,
+		ID: "s1", Adapter: "claude", Alive: false,
 		Command: []string{"claude"},
 	})
 	got, _ := s.Get("s1")
@@ -344,7 +344,7 @@ func TestDerivedResumable_DeadWithCommand(t *testing.T) {
 func TestDerivedResumable_DeadNoCommand(t *testing.T) {
 	s := New()
 	s.Upsert(Session{
-		ID: "s1", Kind: "claude", Alive: false,
+		ID: "s1", Adapter: "claude", Alive: false,
 	})
 	got, _ := s.Get("s1")
 	if got.Resumable {
@@ -355,7 +355,7 @@ func TestDerivedResumable_DeadNoCommand(t *testing.T) {
 func TestDerivedResumable_ShellIsResumable(t *testing.T) {
 	s := New()
 	s.Upsert(Session{
-		ID: "s1", Kind: "shell", Alive: false,
+		ID: "s1", Adapter: "shell", Alive: false,
 		Command: []string{"/bin/bash"},
 	})
 	got, _ := s.Get("s1")
@@ -366,7 +366,7 @@ func TestDerivedResumable_ShellIsResumable(t *testing.T) {
 
 func TestUpdateAtomic(t *testing.T) {
 	s := New()
-	s.Upsert(Session{ID: "s1", Kind: "pi", AdapterTitle: "original"})
+	s.Upsert(Session{ID: "s1", Adapter: "pi", AdapterTitle: "original"})
 
 	ok := s.Update("s1", func(sess *Session) {
 		sess.AdapterTitle = "updated"
@@ -395,7 +395,7 @@ func TestUpdateMissing(t *testing.T) {
 func TestUpdatePreservesOtherFields(t *testing.T) {
 	s := New()
 	s.Upsert(Session{
-		ID: "s1", Kind: "pi",
+		ID: "s1", Adapter: "pi",
 		AdapterTitle: "my title",
 		Status:       &Status{Working: true},
 	})
@@ -414,7 +414,7 @@ func TestUpdatePreservesOtherFields(t *testing.T) {
 
 func TestUpdateBroadcasts(t *testing.T) {
 	s := New()
-	s.Upsert(Session{ID: "s1", Kind: "pi"})
+	s.Upsert(Session{ID: "s1", Adapter: "pi"})
 	ch, cancel := s.Subscribe()
 	defer cancel()
 
@@ -441,11 +441,11 @@ func TestUpdateBroadcasts(t *testing.T) {
 func TestUpsertAliveSessionRemovesDeadShadowWithSameSlug(t *testing.T) {
 	s := New()
 	s.Upsert(Session{
-		ID: "dead-abc", Kind: "pi", Alive: false,
+		ID: "dead-abc", Adapter: "pi", Alive: false,
 		Command: []string{"pi"}, Slug: "rk-1", AdapterTitle: "shadow",
 	})
 	s.Upsert(Session{
-		ID: "sess-123", Kind: "pi", Alive: true,
+		ID: "sess-123", Adapter: "pi", Alive: true,
 		Slug: "rk-1", AdapterTitle: "live",
 	})
 
@@ -461,11 +461,11 @@ func TestUpsertAliveSessionRemovesDeadShadowWithSameSlug(t *testing.T) {
 func TestUpsertDeadShadowSkippedWhenAliveSessionExists(t *testing.T) {
 	s := New()
 	s.Upsert(Session{
-		ID: "sess-123", Kind: "pi", Alive: true,
+		ID: "sess-123", Adapter: "pi", Alive: true,
 		Slug: "rk-1", AdapterTitle: "live",
 	})
 	s.Upsert(Session{
-		ID: "dead-abc", Kind: "pi", Alive: false,
+		ID: "dead-abc", Adapter: "pi", Alive: false,
 		Command: []string{"pi"}, Slug: "rk-1", AdapterTitle: "shadow",
 	})
 
@@ -481,11 +481,11 @@ func TestUpsertDeadShadowSkippedWhenAliveSessionExists(t *testing.T) {
 func TestUpdateSlugOnAliveSessionRemovesDeadShadow(t *testing.T) {
 	s := New()
 	s.Upsert(Session{
-		ID: "dead-abc", Kind: "pi", Alive: false,
+		ID: "dead-abc", Adapter: "pi", Alive: false,
 		Command: []string{"pi"}, Slug: "rk-1", AdapterTitle: "shadow",
 	})
 	s.Upsert(Session{
-		ID: "sess-123", Kind: "pi", Alive: true, AdapterTitle: "live",
+		ID: "sess-123", Adapter: "pi", Alive: true, AdapterTitle: "live",
 	})
 
 	ok := s.Update("sess-123", func(sess *Session) {
@@ -507,16 +507,16 @@ func TestUpdateSlugOnAliveSessionRemovesDeadShadow(t *testing.T) {
 func TestSlugDedup_ScopedToKindAndPeer(t *testing.T) {
 	s := New()
 	// Dead pi session with slug "fix-auth".
-	s.Upsert(Session{ID: "dead-1", Kind: "pi", Alive: false, Command: []string{"pi"}, Slug: "fix-auth"})
-	// Live claude session with the same slug — different kind, should NOT remove the dead pi session.
-	s.Upsert(Session{ID: "live-1", Kind: "claude", Alive: true, Slug: "fix-auth"})
+	s.Upsert(Session{ID: "dead-1", Adapter: "pi", Alive: false, Command: []string{"pi"}, Slug: "fix-auth"})
+	// Live claude session with the same slug — different adapter, should NOT remove the dead pi session.
+	s.Upsert(Session{ID: "live-1", Adapter: "claude", Alive: true, Slug: "fix-auth"})
 
 	if len(s.List()) != 2 {
 		t.Fatalf("expected 2 sessions (different kinds coexist), got %d", len(s.List()))
 	}
 
 	// Now a live pi session arrives — should remove the dead pi session.
-	s.Upsert(Session{ID: "live-2", Kind: "pi", Alive: true, Slug: "fix-auth"})
+	s.Upsert(Session{ID: "live-2", Adapter: "pi", Alive: true, Slug: "fix-auth"})
 
 	items := s.List()
 	if len(items) != 2 {
@@ -531,7 +531,7 @@ func TestSlugDedup_ScopedToKindAndPeer(t *testing.T) {
 
 func TestBroadcastDoesNotMutateState(t *testing.T) {
 	s := New()
-	s.Upsert(Session{ID: "s1", Kind: "shell", Alive: true})
+	s.Upsert(Session{ID: "s1", Adapter: "shell", Alive: true})
 	ch, cancel := s.Subscribe()
 	defer cancel()
 
@@ -568,12 +568,12 @@ func TestBroadcastDoesNotMutateState(t *testing.T) {
 //
 // Slug is the single human-readable identifier used for both URL
 // routing and session resumption. The store enforces uniqueness within
-// (kind, peer). Sessions without a Slug (fresh launches before
+// (adapter, peer). Sessions without a Slug (fresh launches before
 // file attribution) are left alone; the frontend falls back to id[:8].
 
 func TestSlugPreserved(t *testing.T) {
 	s := New()
-	s.Upsert(Session{ID: "s1", Kind: "pi", Slug: "fix-the-auth-bug"})
+	s.Upsert(Session{ID: "s1", Adapter: "pi", Slug: "fix-the-auth-bug"})
 	got, _ := s.Get("s1")
 	if got.Slug != "fix-the-auth-bug" {
 		t.Fatalf("slug = %q, want %q", got.Slug, "fix-the-auth-bug")
@@ -582,7 +582,7 @@ func TestSlugPreserved(t *testing.T) {
 
 func TestSlugEmptyForFreshLaunch(t *testing.T) {
 	s := New()
-	s.Upsert(Session{ID: "s1", Kind: "pi"})
+	s.Upsert(Session{ID: "s1", Adapter: "pi"})
 	got, _ := s.Get("s1")
 	if got.Slug != "" {
 		t.Fatalf("fresh launch should have empty slug, got %q", got.Slug)
@@ -591,9 +591,9 @@ func TestSlugEmptyForFreshLaunch(t *testing.T) {
 
 func TestSlugUniqueness(t *testing.T) {
 	s := New()
-	s.Upsert(Session{ID: "s1", Kind: "pi", Slug: "fix-auth"})
-	s.Upsert(Session{ID: "s2", Kind: "pi", Slug: "fix-auth"})
-	s.Upsert(Session{ID: "s3", Kind: "pi", Slug: "fix-auth"})
+	s.Upsert(Session{ID: "s1", Adapter: "pi", Slug: "fix-auth"})
+	s.Upsert(Session{ID: "s2", Adapter: "pi", Slug: "fix-auth"})
+	s.Upsert(Session{ID: "s3", Adapter: "pi", Slug: "fix-auth"})
 
 	s1, _ := s.Get("s1")
 	s2, _ := s.Get("s2")
@@ -606,8 +606,8 @@ func TestSlugUniqueness(t *testing.T) {
 
 func TestSlugUniquenessAcrossKindsAllowed(t *testing.T) {
 	s := New()
-	s.Upsert(Session{ID: "s1", Kind: "pi", Slug: "fix-auth"})
-	s.Upsert(Session{ID: "s2", Kind: "claude", Slug: "fix-auth"})
+	s.Upsert(Session{ID: "s1", Adapter: "pi", Slug: "fix-auth"})
+	s.Upsert(Session{ID: "s2", Adapter: "claude", Slug: "fix-auth"})
 
 	s1, _ := s.Get("s1")
 	s2, _ := s.Get("s2")
@@ -619,7 +619,7 @@ func TestSlugUniquenessAcrossKindsAllowed(t *testing.T) {
 
 func TestSlugStableOnUpdate(t *testing.T) {
 	s := New()
-	s.Upsert(Session{ID: "s1", Kind: "pi", Slug: "fix-auth"})
+	s.Upsert(Session{ID: "s1", Adapter: "pi", Slug: "fix-auth"})
 
 	s.Update("s1", func(sess *Session) {
 		sess.Subtitle = "something"
@@ -632,10 +632,10 @@ func TestSlugStableOnUpdate(t *testing.T) {
 
 func TestSlugFreedAfterRemove(t *testing.T) {
 	s := New()
-	s.Upsert(Session{ID: "s1", Kind: "pi", Slug: "fix-auth"})
+	s.Upsert(Session{ID: "s1", Adapter: "pi", Slug: "fix-auth"})
 	s.Remove("s1")
 
-	s.Upsert(Session{ID: "s2", Kind: "pi", Slug: "fix-auth"})
+	s.Upsert(Session{ID: "s2", Adapter: "pi", Slug: "fix-auth"})
 	s2, _ := s.Get("s2")
 	if s2.Slug != "fix-auth" {
 		t.Fatalf("expected slug reusable after remove, got %q", s2.Slug)
@@ -644,7 +644,7 @@ func TestSlugFreedAfterRemove(t *testing.T) {
 
 func TestSlugSetByAttribution(t *testing.T) {
 	s := New()
-	s.Upsert(Session{ID: "s1", Kind: "pi"})
+	s.Upsert(Session{ID: "s1", Adapter: "pi"})
 	before, _ := s.Get("s1")
 	if before.Slug != "" {
 		t.Fatalf("expected empty slug before attribution, got %q", before.Slug)
@@ -663,8 +663,8 @@ func TestSlugSetByAttribution(t *testing.T) {
 func TestEmptySlugsCoexist(t *testing.T) {
 	s := New()
 	// Two fresh launches, neither attributed yet.
-	s.Upsert(Session{ID: "s1", Kind: "pi", Alive: true})
-	s.Upsert(Session{ID: "s2", Kind: "pi", Alive: true})
+	s.Upsert(Session{ID: "s1", Adapter: "pi", Alive: true})
+	s.Upsert(Session{ID: "s2", Adapter: "pi", Alive: true})
 
 	s1, _ := s.Get("s1")
 	s2, _ := s.Get("s2")
@@ -675,7 +675,7 @@ func TestEmptySlugsCoexist(t *testing.T) {
 
 func TestSlugStableOnTitleChange(t *testing.T) {
 	s := New()
-	s.Upsert(Session{ID: "s1", Kind: "pi", Slug: "fix-auth"})
+	s.Upsert(Session{ID: "s1", Adapter: "pi", Slug: "fix-auth"})
 
 	s.Update("s1", func(sess *Session) {
 		sess.AdapterTitle = "completely different title"
@@ -688,7 +688,7 @@ func TestSlugStableOnTitleChange(t *testing.T) {
 
 func TestSetTerminalSize(t *testing.T) {
 	s := New()
-	s.Upsert(Session{ID: "s1", Kind: "shell", Alive: true})
+	s.Upsert(Session{ID: "s1", Adapter: "shell", Alive: true})
 
 	if !s.SetTerminalSize("s1", 120, 40) {
 		t.Fatal("expected terminal size update to succeed")
@@ -712,11 +712,11 @@ func TestSlugUniqueness_ScopedToPeer(t *testing.T) {
 	s := New()
 
 	// Local session with slug "fix-auth".
-	s.Upsert(Session{ID: "s1", Kind: "pi", Alive: true, Slug: "fix-auth"})
+	s.Upsert(Session{ID: "s1", Adapter: "pi", Alive: true, Slug: "fix-auth"})
 
 	// Remote session from "server" with the same slug. Should NOT be
-	// renamed because it's in a different (kind, peer) scope.
-	s.Upsert(Session{ID: "s2@server", Kind: "pi", Alive: true, Slug: "fix-auth", Peer: "server"})
+	// renamed because it's in a different (adapter, peer) scope.
+	s.Upsert(Session{ID: "s2@server", Adapter: "pi", Alive: true, Slug: "fix-auth", Peer: "server"})
 
 	got, _ := s.Get("s2@server")
 	if got.Slug != "fix-auth" {
@@ -727,8 +727,8 @@ func TestSlugUniqueness_ScopedToPeer(t *testing.T) {
 func TestSlugUniqueness_WithinSamePeer(t *testing.T) {
 	s := New()
 
-	s.Upsert(Session{ID: "s1@server", Kind: "pi", Alive: true, Slug: "fix-auth", Peer: "server"})
-	s.Upsert(Session{ID: "s2@server", Kind: "pi", Alive: true, Slug: "fix-auth", Peer: "server"})
+	s.Upsert(Session{ID: "s1@server", Adapter: "pi", Alive: true, Slug: "fix-auth", Peer: "server"})
+	s.Upsert(Session{ID: "s2@server", Adapter: "pi", Alive: true, Slug: "fix-auth", Peer: "server"})
 
 	got, _ := s.Get("s2@server")
 	if got.Slug != "fix-auth-2" {
@@ -740,10 +740,10 @@ func TestSlugUniqueness_WithinSamePeer(t *testing.T) {
 
 func TestRemoveByPeer(t *testing.T) {
 	s := New()
-	s.Upsert(Session{ID: "local-1", Kind: "pi", Alive: true})
-	s.Upsert(Session{ID: "s1@server", Kind: "pi", Alive: true, Peer: "server"})
-	s.Upsert(Session{ID: "s2@server", Kind: "shell", Alive: true, Peer: "server"})
-	s.Upsert(Session{ID: "s3@dev", Kind: "pi", Alive: true, Peer: "dev"})
+	s.Upsert(Session{ID: "local-1", Adapter: "pi", Alive: true})
+	s.Upsert(Session{ID: "s1@server", Adapter: "pi", Alive: true, Peer: "server"})
+	s.Upsert(Session{ID: "s2@server", Adapter: "shell", Alive: true, Peer: "server"})
+	s.Upsert(Session{ID: "s3@dev", Adapter: "pi", Alive: true, Peer: "dev"})
 
 	removed := s.RemoveByPeer("server")
 	if len(removed) != 2 {
@@ -766,9 +766,9 @@ func TestRemoveByPeer(t *testing.T) {
 
 func TestListByPeer(t *testing.T) {
 	s := New()
-	s.Upsert(Session{ID: "local-1", Kind: "pi", Alive: true})
-	s.Upsert(Session{ID: "s1@server", Kind: "pi", Alive: true, Peer: "server"})
-	s.Upsert(Session{ID: "s2@server", Kind: "shell", Alive: true, Peer: "server"})
+	s.Upsert(Session{ID: "local-1", Adapter: "pi", Alive: true})
+	s.Upsert(Session{ID: "s1@server", Adapter: "pi", Alive: true, Peer: "server"})
+	s.Upsert(Session{ID: "s2@server", Adapter: "shell", Alive: true, Peer: "server"})
 
 	ids := s.ListByPeer("server")
 	if len(ids) != 2 {
@@ -786,7 +786,7 @@ func TestListByPeer(t *testing.T) {
 
 func TestMarshalJSON_PeerField(t *testing.T) {
 	// Peer field present.
-	s := Session{ID: "s1@server", Kind: "pi", Alive: true, Peer: "server"}
+	s := Session{ID: "s1@server", Adapter: "pi", Alive: true, Peer: "server"}
 	data, _ := json.Marshal(s)
 	var wire map[string]interface{}
 	json.Unmarshal(data, &wire)
@@ -795,7 +795,7 @@ func TestMarshalJSON_PeerField(t *testing.T) {
 	}
 
 	// Local session: peer should be omitted.
-	s2 := Session{ID: "s2", Kind: "pi", Alive: true}
+	s2 := Session{ID: "s2", Adapter: "pi", Alive: true}
 	data2, _ := json.Marshal(s2)
 	var wire2 map[string]interface{}
 	json.Unmarshal(data2, &wire2)
@@ -806,10 +806,10 @@ func TestMarshalJSON_PeerField(t *testing.T) {
 
 func TestMarshalJSON_FrontendFields(t *testing.T) {
 	s := Session{
-		ID:        "s1",
-		Kind:      "pi",
-		Alive:     false,
-		Slug: "fix-auth",
+		ID:      "s1",
+		Adapter: "pi",
+		Alive:   false,
+		Slug:    "fix-auth",
 	}
 	data, err := json.Marshal(s)
 	if err != nil {
@@ -841,7 +841,7 @@ func TestUpsertCanonicalizesPaths(t *testing.T) {
 	s := New()
 	s.Upsert(Session{
 		ID:            "s1",
-		Kind:          "pi",
+		Adapter:       "pi",
 		Alive:         true,
 		Cwd:           home + "/dev/gmux/src",
 		WorkspaceRoot: home + "/dev/gmux",
@@ -864,7 +864,7 @@ func TestUpdateCanonicalizesPaths(t *testing.T) {
 	t.Setenv("HOME", home)
 
 	s := New()
-	s.Upsert(Session{ID: "s1", Kind: "pi", Alive: true, Cwd: "/tmp"})
+	s.Upsert(Session{ID: "s1", Adapter: "pi", Alive: true, Cwd: "/tmp"})
 
 	s.Update("s1", func(sess *Session) {
 		sess.Cwd = home + "/projects/app"
@@ -886,14 +886,14 @@ func TestUpsertRemote_PreservesTitle(t *testing.T) {
 	s := New()
 	// A remote session arrives with Title already set (spoke
 	// resolved it) but internal ShellTitle/AdapterTitle empty (those
-	// are off-wire). Upsert would overwrite Title with Kind; UpsertRemote
+	// are off-wire). Upsert would overwrite Title with Adapter; UpsertRemote
 	// must not.
 	s.UpsertRemote(Session{
-		ID:    "sess-123@server",
-		Kind:  "codex",
-		Alive: true,
-		Peer:  "server",
-		Title: "fix remote bug",
+		ID:      "sess-123@server",
+		Adapter: "codex",
+		Alive:   true,
+		Peer:    "server",
+		Title:   "fix remote bug",
 	})
 
 	got, ok := s.Get("sess-123@server")
@@ -913,7 +913,7 @@ func TestUpsertRemote_PreservesResumableFromSpoke(t *testing.T) {
 	// UpsertRemote must preserve the spoke's value.
 	s.UpsertRemote(Session{
 		ID:        "sess-1@server",
-		Kind:      "pi",
+		Adapter:   "pi",
 		Alive:     false,
 		Command:   []string{"pi"},
 		Peer:      "server",
@@ -931,12 +931,12 @@ func TestUpsertRemote_CanonicalizesPaths(t *testing.T) {
 	t.Setenv("HOME", home)
 	s := New()
 	s.UpsertRemote(Session{
-		ID:    "sess-path@server",
-		Kind:  "shell",
-		Alive: true,
-		Peer:  "server",
-		Title: "ok",
-		Cwd:   home + "/projects/app",
+		ID:      "sess-path@server",
+		Adapter: "shell",
+		Alive:   true,
+		Peer:    "server",
+		Title:   "ok",
+		Cwd:     home + "/projects/app",
 	})
 	got, _ := s.Get("sess-path@server")
 	if got.Cwd != "~/projects/app" {
@@ -947,20 +947,20 @@ func TestUpsertRemote_CanonicalizesPaths(t *testing.T) {
 func TestUpsertRemote_DedupsSlug(t *testing.T) {
 	s := New()
 	s.UpsertRemote(Session{
-		ID:        "sess-1@server",
-		Kind:      "codex",
-		Alive:     true,
-		Peer:      "server",
-		Title:     "a",
-		Slug: "fix-bug",
+		ID:      "sess-1@server",
+		Adapter: "codex",
+		Alive:   true,
+		Peer:    "server",
+		Title:   "a",
+		Slug:    "fix-bug",
 	})
 	s.UpsertRemote(Session{
-		ID:        "sess-2@server",
-		Kind:      "codex",
-		Alive:     true,
-		Peer:      "server",
-		Title:     "b",
-		Slug: "fix-bug",
+		ID:      "sess-2@server",
+		Adapter: "codex",
+		Alive:   true,
+		Peer:    "server",
+		Title:   "b",
+		Slug:    "fix-bug",
 	})
 
 	got, _ := s.Get("sess-2@server")
@@ -975,11 +975,11 @@ func TestUpsertRemote_BroadcastsEvent(t *testing.T) {
 	defer cancel()
 
 	s.UpsertRemote(Session{
-		ID:    "sess-1@server",
-		Kind:  "codex",
-		Alive: true,
-		Peer:  "server",
-		Title: "hello from spoke",
+		ID:      "sess-1@server",
+		Adapter: "codex",
+		Alive:   true,
+		Peer:    "server",
+		Title:   "hello from spoke",
 	})
 
 	select {
@@ -995,13 +995,10 @@ func TestUpsertRemote_BroadcastsEvent(t *testing.T) {
 	}
 }
 
-
-
-
 func TestSessionMarshalJSON_WireFormat(t *testing.T) {
 	s := Session{
 		ID:            "sess-abc",
-		Kind:          "pi",
+		Adapter:       "pi",
 		Alive:         true,
 		RunnerVersion: "1.2.0",
 		BinaryHash:    "aabbccdd",
@@ -1128,7 +1125,7 @@ func fullyPopulatedSession() Session {
 		CreatedAt:      "2026-01-01T00:00:00Z",
 		Command:        []string{"bash"},
 		Cwd:            "/tmp/work",
-		Kind:           "pi",
+		Adapter:        "pi",
 		WorkspaceRoot:  "/tmp/work",
 		Remotes:        map[string]string{"origin": "github.com/x/y"},
 		Alive:          true,
@@ -1165,7 +1162,7 @@ func fullyPopulatedSession() Session {
 // class of regression, not to test the std library's JSON encoder.
 func TestSessionMarshalJSON_LastActivityAt(t *testing.T) {
 	ts := "2026-05-23T10:30:00Z"
-	s := Session{ID: "sess-1", Kind: "pi", Alive: true, LastActivityAt: ts}
+	s := Session{ID: "sess-1", Adapter: "pi", Alive: true, LastActivityAt: ts}
 	b, err := json.Marshal(s)
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
@@ -1182,7 +1179,7 @@ func TestSessionMarshalJSON_LastActivityAt(t *testing.T) {
 	// an empty string. Matters because the frontend treats "" and
 	// absent identically today but might diverge later, and empty
 	// strings on RFC3339 fields are a smell.
-	s2 := Session{ID: "sess-2", Kind: "pi", Alive: true}
+	s2 := Session{ID: "sess-2", Adapter: "pi", Alive: true}
 	b2, _ := json.Marshal(s2)
 	var m2 map[string]any
 	json.Unmarshal(b2, &m2)
@@ -1200,7 +1197,7 @@ func TestSessionMarshalJSON_LastActivityAt(t *testing.T) {
 // someone adds an UnmarshalJSON later.
 func TestSessionRoundTrip_LastActivityAt(t *testing.T) {
 	ts := "2026-05-23T10:30:00Z"
-	original := Session{ID: "sess-1", Kind: "pi", Alive: true, LastActivityAt: ts}
+	original := Session{ID: "sess-1", Adapter: "pi", Alive: true, LastActivityAt: ts}
 	b, err := json.Marshal(original)
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
@@ -1218,8 +1215,8 @@ func TestSessionRoundTrip_LastActivityAt(t *testing.T) {
 
 func TestReconcile_StampsOwnedSessions(t *testing.T) {
 	s := New()
-	s.Upsert(Session{ID: "a", Slug: "alpha", Kind: "k", Alive: true})
-	s.Upsert(Session{ID: "b", Slug: "beta", Kind: "k", Alive: true})
+	s.Upsert(Session{ID: "a", Slug: "alpha", Adapter: "k", Alive: true})
+	s.Upsert(Session{ID: "b", Slug: "beta", Adapter: "k", Alive: true})
 
 	s.Reconcile(func(sess Session) (string, int) {
 		switch sess.Slug {
@@ -1248,7 +1245,7 @@ func TestReconcile_CallerControlsPeerStampPreservation(t *testing.T) {
 	// peers. This test verifies the contract: assignFn sees every
 	// session and its return value is honoured.
 	s := New()
-	s.UpsertRemote(Session{ID: "p1", Slug: "peer-sess", Kind: "k", Peer: "tower", Alive: true, ProjectSlug: "from-origin", ProjectIndex: 3})
+	s.UpsertRemote(Session{ID: "p1", Slug: "peer-sess", Adapter: "k", Peer: "tower", Alive: true, ProjectSlug: "from-origin", ProjectIndex: 3})
 
 	s.Reconcile(func(sess Session) (string, int) {
 		if sess.Peer != "" {
@@ -1269,7 +1266,7 @@ func TestReconcile_DoesNotBroadcast(t *testing.T) {
 	s := New()
 	ch, cancel := s.Subscribe()
 	defer cancel()
-	s.Upsert(Session{ID: "a", Slug: "alpha", Kind: "k", Alive: true})
+	s.Upsert(Session{ID: "a", Slug: "alpha", Adapter: "k", Alive: true})
 	// Drain the upsert event from setup.
 	<-ch
 
@@ -1291,7 +1288,7 @@ func TestReconcile_DoesNotBroadcast(t *testing.T) {
 
 func TestReconcile_NoOpWhenStampsUnchanged(t *testing.T) {
 	s := New()
-	s.Upsert(Session{ID: "a", Slug: "alpha", Kind: "k", Alive: true})
+	s.Upsert(Session{ID: "a", Slug: "alpha", Adapter: "k", Alive: true})
 
 	calls := 0
 	assignFn := func(sess Session) (string, int) {
@@ -1314,7 +1311,7 @@ func TestReconcile_NoOpWhenStampsUnchanged(t *testing.T) {
 func TestSession_MarshalEmitsProjectStamps(t *testing.T) {
 	sess := Session{
 		ID:           "a",
-		Kind:         "k",
+		Adapter:      "k",
 		Alive:        true,
 		ProjectSlug:  "gmux",
 		ProjectIndex: 4,
@@ -1340,7 +1337,7 @@ func TestSession_MarshalOmitsDisclaimedStamps(t *testing.T) {
 	// A disclaimed session (no project match) leaves slug="" and
 	// index=0. Both fields use omitempty so neither appears on the
 	// wire; viewers fall through to their own match rules.
-	sess := Session{ID: "a", Kind: "k", Alive: true}
+	sess := Session{ID: "a", Adapter: "k", Alive: true}
 	b, err := json.Marshal(sess)
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
@@ -1375,7 +1372,7 @@ func TestSession_WireRoundTripPreservesStamps(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			orig := Session{
 				ID:           "a",
-				Kind:         "k",
+				Adapter:      "k",
 				Alive:        true,
 				ProjectSlug:  tc.slug,
 				ProjectIndex: tc.index,
@@ -1404,7 +1401,7 @@ func TestSession_WireRoundTripPreservesStamps(t *testing.T) {
 // resumable dead session to "now".
 func TestLastActivityAt_NewSessionDoesNotBump(t *testing.T) {
 	s := New()
-	s.Upsert(Session{ID: "s1", Kind: "pi", Alive: true})
+	s.Upsert(Session{ID: "s1", Adapter: "pi", Alive: true})
 	got, _ := s.Get("s1")
 	if got.LastActivityAt != "" {
 		t.Fatalf("new session should not bump LastActivityAt, got %q", got.LastActivityAt)
@@ -1428,7 +1425,7 @@ func TestLastActivityAt_BumpOnTransitions(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			s := New()
-			s.Upsert(Session{ID: "s1", Kind: "pi", Alive: true})
+			s.Upsert(Session{ID: "s1", Adapter: "pi", Alive: true})
 			before, _ := s.Get("s1")
 			if before.LastActivityAt != "" {
 				t.Fatalf("baseline should be unset, got %q", before.LastActivityAt)
@@ -1465,7 +1462,7 @@ func TestLastActivityAt_NoBumpOnNoise(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			s := New()
-			s.Upsert(Session{ID: "s1", Kind: "pi", Alive: true, AdapterTitle: "orig"})
+			s.Upsert(Session{ID: "s1", Adapter: "pi", Alive: true, AdapterTitle: "orig"})
 			// Pre-seed a LastActivityAt by transitioning to unread.
 			s.Update("s1", func(sess *Session) { sess.Unread = true })
 			seeded, _ := s.Get("s1")
@@ -1491,7 +1488,7 @@ func TestLastActivityAt_NoBumpOnNoise(t *testing.T) {
 // should keep its existing timestamp.
 func TestLastActivityAt_OnlyTransitionEdgeBumps(t *testing.T) {
 	s := New()
-	s.Upsert(Session{ID: "s1", Kind: "pi", Alive: true})
+	s.Upsert(Session{ID: "s1", Adapter: "pi", Alive: true})
 	s.Update("s1", func(sess *Session) { sess.Unread = true })
 	first, _ := s.Get("s1")
 	time.Sleep(1100 * time.Millisecond)
@@ -1509,7 +1506,7 @@ func TestLastActivityAt_OnlyTransitionEdgeBumps(t *testing.T) {
 // to working), it must stamp LastActivityAt the same way Update does.
 func TestLastActivityAt_UpsertOnExistingBumps(t *testing.T) {
 	cases := []struct {
-		name string
+		name   string
 		mutate func(*Session)
 	}{
 		{"exited", func(s *Session) { s.Alive = false }},
@@ -1520,7 +1517,7 @@ func TestLastActivityAt_UpsertOnExistingBumps(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			s := New()
-			baseline := Session{ID: "s1", Kind: "pi", Alive: true}
+			baseline := Session{ID: "s1", Adapter: "pi", Alive: true}
 			s.Upsert(baseline)
 			before, _ := s.Get("s1")
 			if before.LastActivityAt != "" {
@@ -1549,7 +1546,7 @@ func TestLastActivityAt_UpsertOnExistingBumps(t *testing.T) {
 func TestLastActivityAt_UpsertNoBumpPreservesStamp(t *testing.T) {
 	s := New()
 	// Seed with a stamped session via a transition.
-	s.Upsert(Session{ID: "s1", Kind: "pi", Alive: true})
+	s.Upsert(Session{ID: "s1", Adapter: "pi", Alive: true})
 	s.Update("s1", func(sess *Session) { sess.Unread = true })
 	before, _ := s.Get("s1")
 	stamp := before.LastActivityAt
@@ -1558,7 +1555,7 @@ func TestLastActivityAt_UpsertNoBumpPreservesStamp(t *testing.T) {
 	}
 	// Routine refresh: same state, only adapter title changed. No
 	// transition fires; LastActivityAt is absent from the payload.
-	s.Upsert(Session{ID: "s1", Kind: "pi", Alive: true, Unread: true, AdapterTitle: "renamed"})
+	s.Upsert(Session{ID: "s1", Adapter: "pi", Alive: true, Unread: true, AdapterTitle: "renamed"})
 	after, _ := s.Get("s1")
 	if after.LastActivityAt != stamp {
 		t.Fatalf("no-bump Upsert must preserve LastActivityAt (was %q, now %q)", stamp, after.LastActivityAt)
@@ -1580,7 +1577,7 @@ func TestLastActivityAt_UpsertNoBumpPreservesStamp(t *testing.T) {
 func TestLastActivityAt_PointerAliasingDoesNotHideTransition(t *testing.T) {
 	s := New()
 	// Seed with a non-working Status pointer present.
-	s.Upsert(Session{ID: "s1", Kind: "pi", Alive: true, Status: &Status{}})
+	s.Upsert(Session{ID: "s1", Adapter: "pi", Alive: true, Status: &Status{}})
 
 	// Mutator writes Working=true through the existing Status pointer
 	// rather than allocating a new Status. This is the alias-risk
@@ -1605,14 +1602,14 @@ func TestLastActivityAt_PointerAliasingDoesNotHideTransition(t *testing.T) {
 func TestLastActivityAt_UpsertRemotePreserves(t *testing.T) {
 	s := New()
 	wired := "2026-01-01T12:00:00Z"
-	s.UpsertRemote(Session{ID: "s1", Kind: "pi", Peer: "remote", Alive: true, LastActivityAt: wired})
+	s.UpsertRemote(Session{ID: "s1", Adapter: "pi", Peer: "remote", Alive: true, LastActivityAt: wired})
 	got, _ := s.Get("s1")
 	if got.LastActivityAt != wired {
 		t.Fatalf("UpsertRemote should preserve LastActivityAt (want %q, got %q)", wired, got.LastActivityAt)
 	}
 	// Even a transition arriving via UpsertRemote must not recompute:
 	// it's the spoke's job to stamp, not ours.
-	s.UpsertRemote(Session{ID: "s1", Kind: "pi", Peer: "remote", Alive: false, LastActivityAt: wired})
+	s.UpsertRemote(Session{ID: "s1", Adapter: "pi", Peer: "remote", Alive: false, LastActivityAt: wired})
 	got2, _ := s.Get("s1")
 	if got2.LastActivityAt != wired {
 		t.Fatalf("UpsertRemote alive→false should preserve peer-supplied timestamp (want %q, got %q)", wired, got2.LastActivityAt)

--- a/services/gmuxd/internal/store/store_test.go
+++ b/services/gmuxd/internal/store/store_test.go
@@ -65,21 +65,21 @@ func TestRemove(t *testing.T) {
 	}
 }
 
-func TestRemoveDeadBySessionFile(t *testing.T) {
+func TestRemoveDeadByConversationFile(t *testing.T) {
 	const file = "/home/u/.claude/projects/abc/conv.jsonl"
 	s := New()
 	// Two dead sessions share the file (N:1, e.g. resumed in two tabs).
-	s.Upsert(Session{ID: "dead-1", Adapter: "claude", Alive: false, SessionFile: file})
-	s.Upsert(Session{ID: "dead-2", Adapter: "claude", Alive: false, SessionFile: file})
+	s.Upsert(Session{ID: "dead-1", Adapter: "claude", Alive: false, ConversationFile: file})
+	s.Upsert(Session{ID: "dead-2", Adapter: "claude", Alive: false, ConversationFile: file})
 	// A live session on the same file must survive (runner still writing).
-	s.Upsert(Session{ID: "live", Adapter: "claude", Alive: true, SessionFile: file})
+	s.Upsert(Session{ID: "live", Adapter: "claude", Alive: true, ConversationFile: file})
 	// A peer-owned dead session on the same file is not ours to retire.
-	s.Upsert(Session{ID: "peer", Adapter: "claude", Alive: false, Peer: "box2", SessionFile: file})
+	s.Upsert(Session{ID: "peer", Adapter: "claude", Alive: false, Peer: "box2", ConversationFile: file})
 	// An unrelated dead session must be untouched.
-	s.Upsert(Session{ID: "other", Adapter: "claude", Alive: false, SessionFile: "/home/u/.claude/projects/xyz/other.jsonl"})
+	s.Upsert(Session{ID: "other", Adapter: "claude", Alive: false, ConversationFile: "/home/u/.claude/projects/xyz/other.jsonl"})
 
 	// Cosmetic path difference must still match (filepath.Clean).
-	removed := s.RemoveDeadBySessionFile("/home/u/.claude/projects/abc/./conv.jsonl")
+	removed := s.RemoveDeadByConversationFile("/home/u/.claude/projects/abc/./conv.jsonl")
 
 	got := map[string]bool{}
 	for _, id := range removed {
@@ -100,13 +100,13 @@ func TestRemoveDeadBySessionFile(t *testing.T) {
 	}
 }
 
-func TestRemoveDeadBySessionFileNoMatch(t *testing.T) {
+func TestRemoveDeadByConversationFileNoMatch(t *testing.T) {
 	s := New()
-	s.Upsert(Session{ID: "a", Adapter: "claude", Alive: false, SessionFile: "/x/a.jsonl"})
-	if got := s.RemoveDeadBySessionFile("/x/missing.jsonl"); got != nil {
+	s.Upsert(Session{ID: "a", Adapter: "claude", Alive: false, ConversationFile: "/x/a.jsonl"})
+	if got := s.RemoveDeadByConversationFile("/x/missing.jsonl"); got != nil {
 		t.Errorf("no-match should return nil, got %v", got)
 	}
-	if got := s.RemoveDeadBySessionFile(""); got != nil {
+	if got := s.RemoveDeadByConversationFile(""); got != nil {
 		t.Errorf("empty path should return nil, got %v", got)
 	}
 	if _, ok := s.Get("a"); !ok {
@@ -114,15 +114,15 @@ func TestRemoveDeadBySessionFileNoMatch(t *testing.T) {
 	}
 }
 
-// TestRemoveDeadBySessionFileBroadcasts pins that retirement emits one
+// TestRemoveDeadByConversationFileBroadcasts pins that retirement emits one
 // session-remove per removed session (so WatchRemovals drops the dir).
-func TestRemoveDeadBySessionFileBroadcasts(t *testing.T) {
+func TestRemoveDeadByConversationFileBroadcasts(t *testing.T) {
 	s := New()
-	s.Upsert(Session{ID: "dead", Adapter: "claude", Alive: false, SessionFile: "/x/c.jsonl"})
+	s.Upsert(Session{ID: "dead", Adapter: "claude", Alive: false, ConversationFile: "/x/c.jsonl"})
 	ch, cancel := s.Subscribe()
 	defer cancel()
 
-	s.RemoveDeadBySessionFile("/x/c.jsonl")
+	s.RemoveDeadByConversationFile("/x/c.jsonl")
 
 	ev, ok := recvEvent(t, ch)
 	if !ok || ev.Type != "session-remove" || ev.ID != "dead" {
@@ -997,15 +997,15 @@ func TestUpsertRemote_BroadcastsEvent(t *testing.T) {
 
 func TestSessionMarshalJSON_WireFormat(t *testing.T) {
 	s := Session{
-		ID:            "sess-abc",
-		Adapter:       "pi",
-		Alive:         true,
-		RunnerVersion: "1.2.0",
-		BinaryHash:    "aabbccdd",
-		ShellTitle:    "internal-only",
-		AdapterTitle:  "internal-only",
-		Slug:          "my-slug",
-		SessionFile:   "/home/u/.pi/agent/sessions/x/conv.jsonl",
+		ID:               "sess-abc",
+		Adapter:          "pi",
+		Alive:            true,
+		RunnerVersion:    "1.2.0",
+		BinaryHash:       "aabbccdd",
+		ShellTitle:       "internal-only",
+		AdapterTitle:     "internal-only",
+		Slug:             "my-slug",
+		ConversationFile: "/home/u/.pi/agent/sessions/x/conv.jsonl",
 	}
 	b, err := json.Marshal(s)
 	if err != nil {
@@ -1120,36 +1120,36 @@ func TestSessionMarshalJSON_AllFieldsAppearOnWire(t *testing.T) {
 func fullyPopulatedSession() Session {
 	exit := 0
 	return Session{
-		ID:             "sess-full",
-		Peer:           "peer-x",
-		CreatedAt:      "2026-01-01T00:00:00Z",
-		Command:        []string{"bash"},
-		Cwd:            "/tmp/work",
-		Adapter:        "pi",
-		WorkspaceRoot:  "/tmp/work",
-		Remotes:        map[string]string{"origin": "github.com/x/y"},
-		Alive:          true,
-		Pid:            42,
-		ExitCode:       &exit,
-		StartedAt:      "2026-01-01T00:00:01Z",
-		ExitedAt:       "2026-01-01T00:00:02Z",
-		Title:          "t",
-		Subtitle:       "s",
-		Status:         &Status{Working: true, Error: true},
-		Unread:         true,
-		LastActivityAt: "2026-01-01T00:00:03Z",
-		Resumable:      true,
-		SocketPath:     "/tmp/sock",
-		TerminalCols:   80,
-		TerminalRows:   24,
-		Slug:           "slug",
-		SessionFile:    "/home/u/.pi/sess.jsonl",
-		RunnerVersion:  "v1",
-		BinaryHash:     "hash",
-		ShellTitle:     "shell-internal",
-		AdapterTitle:   "adapter-internal",
-		ProjectSlug:    "proj",
-		ProjectIndex:   3,
+		ID:               "sess-full",
+		Peer:             "peer-x",
+		CreatedAt:        "2026-01-01T00:00:00Z",
+		Command:          []string{"bash"},
+		Cwd:              "/tmp/work",
+		Adapter:          "pi",
+		WorkspaceRoot:    "/tmp/work",
+		Remotes:          map[string]string{"origin": "github.com/x/y"},
+		Alive:            true,
+		Pid:              42,
+		ExitCode:         &exit,
+		StartedAt:        "2026-01-01T00:00:01Z",
+		ExitedAt:         "2026-01-01T00:00:02Z",
+		Title:            "t",
+		Subtitle:         "s",
+		Status:           &Status{Working: true, Error: true},
+		Unread:           true,
+		LastActivityAt:   "2026-01-01T00:00:03Z",
+		Resumable:        true,
+		SocketPath:       "/tmp/sock",
+		TerminalCols:     80,
+		TerminalRows:     24,
+		Slug:             "slug",
+		ConversationFile: "/home/u/.pi/sess.jsonl",
+		RunnerVersion:    "v1",
+		BinaryHash:       "hash",
+		ShellTitle:       "shell-internal",
+		AdapterTitle:     "adapter-internal",
+		ProjectSlug:      "proj",
+		ProjectIndex:     3,
 	}
 }
 

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -24,7 +24,7 @@ import (
 // session mirrors the schema v2 fields we care about.
 type session struct {
 	ID         string  `json:"id"`
-	Kind       string  `json:"adapter"`
+	Adapter    string  `json:"adapter"`
 	Alive      bool    `json:"alive"`
 	Pid        int     `json:"pid"`
 	Title      string  `json:"title"`
@@ -146,8 +146,8 @@ func TestEndToEnd(t *testing.T) {
 	if !found.Alive {
 		t.Error("expected alive=true")
 	}
-	if found.Kind != "generic" {
-		t.Errorf("expected kind=generic, got %q", found.Kind)
+	if found.Adapter != "generic" {
+		t.Errorf("expected adapter=generic, got %q", found.Adapter)
 	}
 	if found.Pid == 0 {
 		t.Error("expected non-zero pid")


### PR DESCRIPTION
Phase 3 of the terminology rename (report §4, trailing internal sweep deferred by #352). Behavior-neutral by construction: zero wire, persisted, URL, CLI-output, or env-var changes.

## What's in it

- **`Kind` → `Adapter`**: `store.Session.Adapter`, `conversations.Info.Adapter`, `adapters.FindByAdapter()`, cli/gmux mirrors, e2e Go test struct, locals/params/prose. Field names now agree with the `json:"adapter"` tags again, so the orientation comments from #352's review pass are removed.
- **`SessionFile*` API family → `Conversation*`**: `adapter.ConversationInfo`, `ConversationFiler`, `ConversationRootDir`/`ConversationDir`, `ParseConversationFile`, across all four adapters, conversations index, discovery/resume, and tests.
- **`store.Session.ConversationFile`** (tag was already `conversation_file`), `RemoveDeadByConversationFile`, runner `SetConversationFile`/`ConversationFileSnapshot`.
- **Prose**: "session file" → "conversation file" in touched files; living docs (writing-adapters, adapter-architecture, state-management, planned/opencode-adapter, UL) updated where they cite renamed identifiers. Historical ADRs and the changelog untouched.

## Justified leftovers (`rg -nw Kind` in Go)

- `testutil.Event.Kind` / `EventsOfKind` — event kind, not adapter name.
- `sessionmeta.go:331` / `discovery.go:314` — v2.1-fenced legacy-read shims; their `Kind`/`SessionFile` mirror fields match the legacy `"kind"`/`"session_file"` wire strings, kept intact per the shim TODOs.
- ~~`wait.go` 422 message string~~ — reworded after review to "the X adapter does not emit an idle signal" (the one deliberate CLI-output wording change; exit codes and the `no_idle_signal` error code untouched). The function is renamed to `adapterEmitsIdleSignal`. The legacy-read shims are kept intentionally: they carry the v1.x→v2.0 upgrade (persisted meta.json + surviving runners) and self-destruct at v2.1.

## Verification

- Renames done with `gopls rename` (fields, methods, funcs) + reviewed rg-driven edits for locals/prose; no blind sed.
- `go build ./...` + `go vet` per module (incl. `-tags integration`); `go test ./...` green in every module; `pnpm lint` + `pnpm test` green except known environmental noise verified pre-existing on main: `tests/e2e` TestEndToEnd socket timeout and `cli/gmux/cmd/gmux` hanging under moon (passes with direct `go test -count=1`, verified).
- The store MarshalJSON wire-format test from #352's review pass passes with its assertions unmodified (pins `"adapter"`/`"conversation_file"` keys and absence of legacy keys); no JSON tag, wire string, URL, or CLI output changed.
