### PR TITLE
feat(web): find-in-terminal (search) via xterm SearchAddon

### DIFF
--- a/apps/gmux-web/package.json
+++ b/apps/gmux-web/package.json
@@ -19,6 +19,7 @@
     "@preact/signals": "^2.9.0",
     "@trpc/client": "^11.6.0",
     "@xterm/addon-fit": "0.12.0-beta.195",
+    "@xterm/addon-search": "0.17.0-beta.195",
     "@xterm/addon-image": "github:gmuxapp/xterm.js#v6.1.0-beta.195-gmux.2&path:addons/addon-image",
     "@xterm/addon-web-links": "0.13.0-beta.195",
     "@xterm/addon-webgl": "0.20.0-beta.194",

--- a/apps/gmux-web/src/keybinds.test.ts
+++ b/apps/gmux-web/src/keybinds.test.ts
@@ -135,6 +135,21 @@ describe('resolveKeybinds', () => {
     expect(keys).toContain('ctrl+alt+t')
   })
 
+  it('includes the find keybind on secondary+f', () => {
+    const resolved = resolveKeybinds(null)
+    const find = resolved.find(r => r.action === 'find')
+    expect(find).toBeDefined()
+    expect(find!.baseKey).toBe('f')
+    // "secondary" resolves to exactly one platform modifier.
+    expect(find!.ctrl || find!.meta).toBe(true)
+    expect(find!.ctrl && find!.meta).toBe(false)
+  })
+
+  it('allows disabling the find keybind', () => {
+    const resolved = resolveKeybinds([{ key: 'secondary+f', action: 'none' }])
+    expect(resolved.find(r => r.action === 'find')).toBeUndefined()
+  })
+
   it('adds new user keybinds', () => {
     const user: Keybind[] = [
       { key: 'ctrl+alt+n', action: 'sendKeys', args: 'ctrl+n' },

--- a/apps/gmux-web/src/keybinds.ts
+++ b/apps/gmux-web/src/keybinds.ts
@@ -60,6 +60,9 @@ const KNOWN_ACTIONS = new Set<string>(KEYBIND_ACTIONS)
 const UNIVERSAL_KEYBINDS: Keybind[] = [
   { key: 'shift+enter', action: 'sendText', args: '\n' },
   { key: 'ctrl+c', action: 'copyOrInterrupt' },
+  // "secondary" = Cmd on macOS, Ctrl elsewhere. Replaces the browser's
+  // in-page find, which is useless inside a canvas-rendered terminal.
+  { key: 'secondary+f', action: 'find' },
 ]
 
 /** Linux / Windows defaults. */

--- a/apps/gmux-web/src/keyboard.ts
+++ b/apps/gmux-web/src/keyboard.ts
@@ -23,6 +23,7 @@ import {
   type UploadResult,
 } from './clipboard-upload'
 import { selectionToText } from './selection'
+import { terminalFindOpen } from './store'
 
 type SendFn = (data: string) => void
 
@@ -259,6 +260,13 @@ function executeAction(
 
     case 'selectAll':
       term.selectAll()
+      return true
+
+    case 'find':
+      // Opens the find bar rendered by TerminalView. Via a signal (not a
+      // callback) because this runs deep inside the key handler, far from
+      // the component tree. The bar focuses its own input on mount.
+      terminalFindOpen.value = true
       return true
 
     default:

--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -24,7 +24,7 @@ import { pushError } from './toasts'
 import {
   sessions, connState, selected, selectedId, view, health, peers,
   terminalOptions, keybinds, macCommandIsCtrl,
-  unreadCount, keyboardOpen, terminalScrolledUp, terminalScrollToBottom,
+  unreadCount, keyboardOpen, terminalFindOpen, terminalScrolledUp, terminalScrollToBottom,
   urlPath, urlSearch,
   initStore, setNavigate, navigateToSession,
   dismissSession, resumeSession, restartSession,
@@ -247,7 +247,10 @@ function SessionMenu({ session, onRestart }: {
       ? session.binary_hash.slice(0, 8)
       : 'unknown'
 
-  const hasActions = session.alive && onRestart
+  // Find works whenever the live terminal is mounted, i.e. the session is
+  // alive. This is the touch path to the find bar (no hardware keyboard
+  // for the secondary+F keybind).
+  const canFind = session.alive
 
   return (
     <div class="session-menu" ref={menuRef}>
@@ -262,18 +265,24 @@ function SessionMenu({ session, onRestart }: {
       </button>
       {open && (
         <div class="session-menu-dropdown">
-          {hasActions && (
-            <>
-              <button
-                class={`session-menu-action${staleKind ? ' stale' : ''}`}
-                onClick={() => { setOpen(false); onRestart!() }}
-              >
-                Restart session
-                {staleKind && <span class="session-menu-action-tag">outdated</span>}
-              </button>
-              <div class="session-menu-divider" />
-            </>
+          {canFind && (
+            <button
+              class="session-menu-action"
+              onClick={() => { setOpen(false); terminalFindOpen.value = true }}
+            >
+              Find in terminal
+            </button>
           )}
+          {session.alive && onRestart && (
+            <button
+              class={`session-menu-action${staleKind ? ' stale' : ''}`}
+              onClick={() => { setOpen(false); onRestart!() }}
+            >
+              Restart session
+              {staleKind && <span class="session-menu-action-tag">outdated</span>}
+            </button>
+          )}
+          {(canFind || (session.alive && onRestart)) && <div class="session-menu-divider" />}
           <div class="session-menu-section-title">Session info</div>
           <div class="session-menu-row">
             <span class="session-menu-label">Adapter</span>

--- a/apps/gmux-web/src/settings-schema.ts
+++ b/apps/gmux-web/src/settings-schema.ts
@@ -116,7 +116,7 @@ export type ThemeColors = v.InferInput<typeof ThemeColorsSchema>
 // ── Keybind schema ──
 
 export const KEYBIND_ACTIONS = [
-  'sendText', 'sendKeys', 'copyOrInterrupt', 'copy', 'paste', 'selectAll', 'none',
+  'sendText', 'sendKeys', 'copyOrInterrupt', 'copy', 'paste', 'selectAll', 'find', 'none',
 ] as const
 
 /** Per-action descriptions. Source of truth for runtime warnings and doc generation. */
@@ -127,6 +127,7 @@ export const KEYBIND_ACTION_DESCRIPTIONS: Record<string, string> = {
   copy:             'Copy selection to clipboard. Does nothing if no text is selected.',
   paste:            'Read system clipboard and send contents to the PTY.',
   selectAll:        'Select all terminal content.',
+  find:             'Open the find-in-terminal search bar.',
   none:             'Disable this key combo (removes a built-in default).',
 }
 

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -439,6 +439,11 @@ export const terminalScrolledUp = signal(false)
  * mounted. Set by TerminalView, invoked by the toolbar's end key. */
 export const terminalScrollToBottom = signal<(() => void) | null>(null)
 
+/** True while the find-in-terminal bar is open. Lives here (not in
+ * TerminalView state) so both the keybind handler (keyboard.ts) and the
+ * session "⋮" menu (main.tsx) can open it without threading callbacks. */
+export const terminalFindOpen = signal(false)
+
 /** Current URL path, kept in sync with preact-iso's location. */
 export const urlPath = signal(
   typeof location !== 'undefined' ? (location.pathname.replace(/\/+$/, '') || '/') : '/',

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -1890,6 +1890,107 @@ body {
   white-space: nowrap;
 }
 
+/* ── Find-in-terminal bar ────────────────────────────────────────────────────────
+   Floats over the top-right of the terminal (sticky, like the resize
+   anchor, so it stays put when the shell scrolls in passive mode). Shares
+   the pill design language: translucent surface, blur, soft border. */
+.terminal-find-anchor {
+  position: sticky;
+  top: 0;
+  height: 0;
+  overflow: visible;
+  display: flex;
+  justify-content: flex-end;
+  /* The anchor is height:0; the default align-items:stretch would crush
+     the bar's content height to zero. */
+  align-items: flex-start;
+  z-index: 14;
+  pointer-events: none;
+}
+
+.terminal-find-bar {
+  pointer-events: auto;
+  position: relative;
+  top: 8px;
+  margin-right: 16px;
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 4px 6px;
+  border: 1px solid color-mix(in oklch, var(--accent) 22%, var(--border-strong));
+  border-radius: 10px;
+  background: color-mix(in oklch, var(--bg-sidebar) 82%, #0f141a 18%);
+  box-shadow: 0 8px 24px oklch(0% 0 0 / 0.28);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+}
+
+.terminal-find-input {
+  appearance: none;
+  border: none;
+  outline: none;
+  background: transparent;
+  color: var(--text);
+  font-family: 'Source Sans 3', sans-serif;
+  font-size: 13px;
+  line-height: 1.4;
+  padding: 4px 6px;
+  width: 160px;
+}
+
+.terminal-find-input::placeholder {
+  color: var(--text-muted);
+}
+
+.terminal-find-count {
+  min-width: 34px;
+  text-align: right;
+  padding-right: 4px;
+  color: var(--text-muted);
+  font-family: 'Source Sans 3', sans-serif;
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.terminal-find-count.no-matches {
+  color: oklch(0.7 0.12 20);
+}
+
+.terminal-find-btn {
+  appearance: none;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 15px;
+  line-height: 1;
+  width: 26px;
+  height: 26px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.terminal-find-btn:hover:not(:disabled) {
+  background: color-mix(in oklch, var(--bg-sidebar) 40%, var(--accent) 12%);
+  color: var(--text);
+}
+
+.terminal-find-btn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+/* Touch: bigger tap targets, and a wider input is unnecessary — keep the
+   bar compact so it doesn't cover half the terminal on phones. */
+@media (pointer: coarse) {
+  .terminal-find-bar { gap: 4px; }
+  .terminal-find-input { width: 132px; font-size: 14px; }
+  .terminal-find-btn { width: 38px; height: 38px; font-size: 18px; }
+}
+
 .terminal-loading {
   position: absolute;
   inset: 0;

--- a/apps/gmux-web/src/terminal-find.tsx
+++ b/apps/gmux-web/src/terminal-find.tsx
@@ -1,0 +1,148 @@
+/**
+ * Find-in-terminal bar, backed by @xterm/addon-search.
+ *
+ * Rendered by TerminalView inside the terminal shell (top-right, floating
+ * over the grid like the resize pill). Opened via the `find` keybind
+ * action (default secondary+F) or the session "⋮" menu — both flip the
+ * `terminalFindOpen` signal in store.ts; this component only handles the
+ * UI + addon calls while open.
+ *
+ * Search is incremental while typing (the current match expands as the
+ * query grows instead of jumping ahead), Enter/Shift+Enter and the ‹ ›
+ * buttons step through matches, Escape closes. Match highlighting uses
+ * the addon's decoration support, which is also what makes
+ * onDidChangeResults report the "n/total" counter.
+ */
+
+import type { SearchAddon } from '@xterm/addon-search'
+import { useCallback, useEffect, useRef, useState } from 'preact/hooks'
+
+/**
+ * Decoration colors for match highlighting. The addon requires the two
+ * overview-ruler colors whenever decorations are enabled. Colors follow
+ * the browser convention: dim yellow for matches, orange for the active
+ * one — chosen for contrast against the dark terminal background rather
+ * than pulled from the theme (a themed light background would need a
+ * bigger rework of these anyway).
+ */
+const SEARCH_DECORATIONS = {
+  matchBackground: '#6b5900',
+  matchOverviewRuler: '#6b5900',
+  activeMatchBackground: '#c2410c',
+  activeMatchColorOverviewRuler: '#c2410c',
+}
+
+const SEARCH_OPTIONS = { decorations: SEARCH_DECORATIONS }
+
+export function TerminalFindBar({ addon, onClose }: {
+  addon: SearchAddon
+  onClose: () => void
+}) {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [query, setQuery] = useState('')
+  const [results, setResults] = useState<{ index: number; count: number } | null>(null)
+
+  // Focus the input on mount. On touch this deliberately pops the
+  // on-screen keyboard — typing the query is the immediate next step.
+  useEffect(() => {
+    inputRef.current?.focus()
+  }, [])
+
+  // Match counter. The event only fires while decorations are active,
+  // which they always are here (SEARCH_OPTIONS). resultIndex is -1 when
+  // nothing matched.
+  useEffect(() => {
+    const d = addon.onDidChangeResults(({ resultIndex, resultCount }) => {
+      setResults({ index: resultIndex, count: resultCount })
+    })
+    return () => d.dispose()
+  }, [addon])
+
+  // Clear highlights when the bar unmounts (close, session switch).
+  useEffect(() => () => addon.clearDecorations(), [addon])
+
+  const search = useCallback((q: string) => {
+    setQuery(q)
+    if (!q) {
+      addon.clearDecorations()
+      setResults(null)
+      return
+    }
+    // incremental: keep (and extend) the current match while typing
+    // instead of jumping to the next occurrence on every keystroke.
+    addon.findNext(q, { ...SEARCH_OPTIONS, incremental: true })
+  }, [addon])
+
+  const next = useCallback(() => { if (query) addon.findNext(query, SEARCH_OPTIONS) }, [addon, query])
+  const prev = useCallback(() => { if (query) addon.findPrevious(query, SEARCH_OPTIONS) }, [addon, query])
+
+  const onKeyDown = useCallback((ev: KeyboardEvent) => {
+    if (ev.key === 'Escape') {
+      ev.preventDefault()
+      onClose()
+      return
+    }
+    if (ev.key === 'Enter') {
+      ev.preventDefault()
+      if (ev.shiftKey) prev()
+      else next()
+      return
+    }
+    // Secondary+F while already focused here: keep the browser's native
+    // find suppressed (the terminal keybind can't intercept it because
+    // the event never reaches xterm's textarea) and just reselect.
+    if (ev.key.toLowerCase() === 'f' && (ev.metaKey || ev.ctrlKey)) {
+      ev.preventDefault()
+      inputRef.current?.select()
+    }
+  }, [next, prev, onClose])
+
+  const hasMatches = results != null && results.count > 0
+
+  return (
+    <div class="terminal-find-bar" role="search" aria-label="Find in terminal">
+      <input
+        ref={inputRef}
+        class="terminal-find-input"
+        type="text"
+        // Search queries are terminal text verbatim; phone keyboards must
+        // not "help".
+        autocomplete="off"
+        autocapitalize="off"
+        autocorrect="off"
+        spellcheck={false}
+        enterkeyhint="search"
+        placeholder="Find"
+        value={query}
+        onInput={(ev) => search((ev.target as HTMLInputElement).value)}
+        onKeyDown={onKeyDown}
+      />
+      <span class={`terminal-find-count${query && !hasMatches ? ' no-matches' : ''}`}>
+        {query ? (hasMatches ? `${results.index + 1}/${results.count}` : '0/0') : ''}
+      </span>
+      <button
+        type="button"
+        class="terminal-find-btn"
+        onClick={prev}
+        disabled={!query}
+        title="Previous match (Shift+Enter)"
+        aria-label="Previous match"
+      >‹</button>
+      <button
+        type="button"
+        class="terminal-find-btn"
+        onClick={next}
+        disabled={!query}
+        title="Next match (Enter)"
+        aria-label="Next match"
+      >›</button>
+      <button
+        type="button"
+        class="terminal-find-btn"
+        onClick={onClose}
+        title="Close (Escape)"
+        aria-label="Close find bar"
+      >✕</button>
+    </div>
+  )
+}

--- a/apps/gmux-web/src/terminal.tsx
+++ b/apps/gmux-web/src/terminal.tsx
@@ -3,6 +3,7 @@ import { Terminal } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
 import { ImageAddon } from '@xterm/addon-image'
 import { WebLinksAddon } from '@xterm/addon-web-links'
+import { SearchAddon } from '@xterm/addon-search'
 import type { ResolvedTerminalOptions } from './settings-schema'
 import { loadWebglRenderer } from './webgl-renderer'
 import { refreshAtlasWhenIconFontLoads } from './nerd-font'
@@ -19,7 +20,8 @@ import { TerminalTextSheet } from './terminal-text-sheet'
 import { pressedBufferRow, readTerminalText } from './terminal-text'
 import { decideViewportResize, sameSize } from './terminal-resize'
 import { wsStateOnClose, wsStateOnOutput, type WsState } from './ws-state'
-import { terminalScrolledUp, terminalScrollToBottom } from './store'
+import { terminalFindOpen, terminalScrolledUp, terminalScrollToBottom } from './store'
+import { TerminalFindBar } from './terminal-find'
 import { MOCK_BY_ID } from './mock-data/index'
 import type { Session } from './types'
 
@@ -245,6 +247,7 @@ export function TerminalView({
   const ctrlArmedRef = useRef(ctrlArmed)
   const altArmedRef = useRef(altArmed)
   const termIoRef = useRef<ReturnType<typeof createTerminalIO> | null>(null)
+  const searchAddonRef = useRef<SearchAddon | null>(null)
   const termEpochRef = useRef(0)
 
   // True once the terminal's font is downloaded; gates xterm mount.
@@ -411,7 +414,9 @@ export function TerminalView({
   // only suppress focus/selection on shell controls for no benefit.
   const holdShellFocus = useCallback((ev: MouseEvent) => {
     if (!isTouchDevice()) return
-    if (!(ev.target instanceof Element) || !ev.target.closest('.xterm')) ev.preventDefault()
+    // The find bar's input/buttons need default mousedown behavior to
+    // gain focus, so exempt it alongside the grid.
+    if (!(ev.target instanceof Element) || !ev.target.closest('.xterm, .terminal-find-bar')) ev.preventDefault()
   }, [])
 
   const handleShellClick = useCallback((ev: MouseEvent) => {
@@ -483,6 +488,10 @@ export function TerminalView({
     term.loadAddon(new ImageAddon())
     // Detect plain-text URLs in terminal output and make them clickable.
     term.loadAddon(new WebLinksAddon())
+    // Find-in-terminal (the find bar drives it; see terminal-find.tsx).
+    const searchAddon = new SearchAddon()
+    term.loadAddon(searchAddon)
+    searchAddonRef.current = searchAddon
     term.open(containerRef.current)
     loadWebglRenderer(term)
     // The Nerd Font icon fallback loads lazily; refresh the glyph atlas once
@@ -806,6 +815,8 @@ export function TerminalView({
       scrollDisposable.dispose()
       terminalScrolledUp.value = false
       terminalScrollToBottom.value = null
+      terminalFindOpen.value = false
+      searchAddonRef.current = null
       if (reconnectTimer.current) clearTimeout(reconnectTimer.current)
       wsRef.current?.close()
       wsRef.current = null
@@ -1044,6 +1055,19 @@ export function TerminalView({
           >
             Sized for another device, click to resize
           </button>
+        </div>
+      )}
+      {terminalFindOpen.value && searchAddonRef.current && (
+        <div class="terminal-find-anchor">
+          <TerminalFindBar
+            addon={searchAddonRef.current}
+            onClose={() => {
+              terminalFindOpen.value = false
+              // Hand focus back to the terminal — but not on touch, where
+              // that would immediately re-pop the on-screen keyboard.
+              if (!isTouchDevice()) focusTerminal()
+            }}
+          />
         </div>
       )}
       <div ref={containerRef} class="terminal-container" />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,6 +58,9 @@ importers:
       '@xterm/addon-image':
         specifier: github:gmuxapp/xterm.js#v6.1.0-beta.195-gmux.2&path:addons/addon-image
         version: https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed#path:addons/addon-image
+      '@xterm/addon-search':
+        specifier: 0.17.0-beta.195
+        version: 0.17.0-beta.195(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed)
       '@xterm/addon-web-links':
         specifier: 0.13.0-beta.195
         version: 0.13.0-beta.195(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed)
@@ -1375,6 +1378,12 @@ packages:
   '@xterm/addon-image@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed#path:addons/addon-image':
     resolution: {path: addons/addon-image, tarball: https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed}
     version: 0.9.0
+
+  '@xterm/addon-search@0.17.0-beta.195':
+    resolution: {integrity: sha512-n7sQ3u1e1gSfKJvhKCz3W/Ov7KLAOB8auC9m+7sSaFgPCuFfi2/bP4I/TswPUDF5YpkYs9leBzeVdo08/+Cglg==}
+    version: 0.17.0-beta.195
+    peerDependencies:
+      '@xterm/xterm': ^6.1.0-beta.195
 
   '@xterm/addon-web-links@0.13.0-beta.195':
     resolution: {integrity: sha512-3x1jjud/TAVCSd3Jn7E9ielvPUwHAqvtqL1AKeH9sD5RKUuNr+Z4B+vhkvR0XF2BAk9af6ErgyygdAMnOL2Rwg==}
@@ -4224,6 +4233,10 @@ snapshots:
       '@xterm/xterm': https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed
 
   '@xterm/addon-image@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed#path:addons/addon-image': {}
+
+  '@xterm/addon-search@0.17.0-beta.195(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed)':
+    dependencies:
+      '@xterm/xterm': https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed
 
   '@xterm/addon-web-links@0.13.0-beta.195(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed)':
     dependencies:


### PR DESCRIPTION
Adds find-in-terminal to the gmux web terminal.

## What

- **SearchAddon**: integrates `@xterm/addon-search@0.17.0-beta.195` (same beta line as the other `@xterm/*` deps), loaded alongside fit/image/web-links in `TerminalView`.
- **Find bar** (`terminal-find.tsx`): floats top-right over the terminal (sticky anchor, same pattern/design language as the resize pill). Incremental search while typing, `n/total` match counter (red on no match), next/prev via Enter / Shift+Enter or ‹ › buttons, ✕ / Escape closes. Matches highlighted via the addon's decorations (dim yellow, active match orange) + overview-ruler marks. Closing clears decorations and hands focus back to the terminal (desktop only — on touch that would re-pop the OSK).
- **Keybind**: new `find` action, default `secondary+f` (Cmd+F on macOS, Ctrl+F elsewhere). Declared in the schema like the other actions, so it's overridable / disablable (`action: "none"`) from settings.jsonc.
- **Menu entry**: "Find in terminal" in the session **⋮** menu (the closest equivalent to a "…" overflow menu in this app), so the bar is reachable on touch devices without a hardware keyboard. Shown for alive sessions.
- Opening is wired through a `terminalFindOpen` signal in store.ts (same pattern as `terminalScrolledUp`), so both the key handler and the menu can open the bar without threading callbacks.

## Mobile

- Coarse-pointer styles: 38px tap targets, compact input so the bar doesn't cover half the terminal.
- The input focuses on mount (pops the OSK — typing the query is the immediate next step); search-shaped input attrs (`enterkeyhint=search`, autocorrect/autocapitalize off).
- The shell's touch focus-hold handler exempts the find bar so its input can actually gain focus.

## Verified

- `pnpm lint` (tsc + biome), `pnpm test` in `apps/gmux-web` (550 tests, incl. new keybind default/disable tests).
- Manual via dev stack + headless Chrome:
  - Desktop: Ctrl+F opens+focuses, incremental highlight, counter, Enter/Shift+Enter/buttons step with wraparound, Escape closes and refocuses terminal, browser-native find stays suppressed while the input is focused.
  - Off-screen matches scroll into view (verified jump from bottom to scrollback top).
  - Mobile emulation (390×844, coarse+touch): ⋮ → Find in terminal opens the bar, typing/stepping/closing all work with the OSK heuristics untouched.

## Notes / limitations

- When the terminal is in passive "sized for another device" mode on a small screen, the addon scrolls xterm's own viewport to the match, but the shell's pan offset (the overflow scroll used in that mode) is not adjusted — the match can sit outside the panned area. Normal owned-size sessions are unaffected.
- Decoration colors are fixed (dark-theme oriented) rather than theme-derived; the addon needs concrete colors and the app currently has no themed-highlight tokens.

**Screenshots** (from headless verification): desktop shows the find bar top-right with `needle` 1/3 — active match orange, other matches yellow, ruler marks on the scrollbar; mobile shows the bar under the header with enlarged tap targets and the toolbar unaffected. (Captured locally; not attached — ask if wanted.)



