### PR TITLE
feat: `gmux edit` — editor sessions as a first-class tab type

### DIFF
--- a/apps/gmux-web/src/projects.test.ts
+++ b/apps/gmux-web/src/projects.test.ts
@@ -15,8 +15,44 @@ import {
   discoverProjects,
   countUnmatchedActive,
   projectAvailability,
+  placeChildSessions,
 } from './projects'
 import { makeSession } from './test-helpers'
+
+describe('placeChildSessions', () => {
+  const s = (id: string, parent?: string) =>
+    makeSession({ id, cwd: '/p', parent_session_id: parent })
+
+  it('moves a child directly after its parent', () => {
+    const list = [s('child', 'parent'), s('a'), s('parent'), s('b')]
+    placeChildSessions(list)
+    expect(list.map(x => x.id)).toEqual(['a', 'parent', 'child', 'b'])
+  })
+
+  it('keeps multiple children in relative order after the parent', () => {
+    const list = [s('c1', 'p'), s('p'), s('c2', 'p'), s('x')]
+    placeChildSessions(list)
+    expect(list.map(x => x.id)).toEqual(['p', 'c1', 'c2', 'x'])
+  })
+
+  it('leaves orphans (parent not in folder) in place', () => {
+    const list = [s('a'), s('orphan', 'elsewhere'), s('b')]
+    placeChildSessions(list)
+    expect(list.map(x => x.id)).toEqual(['a', 'orphan', 'b'])
+  })
+
+  it('ignores self-referential parents', () => {
+    const list = [s('a'), s('weird', 'weird')]
+    placeChildSessions(list)
+    expect(list.map(x => x.id)).toEqual(['a', 'weird'])
+  })
+
+  it('no-ops without parent stamps', () => {
+    const list = [s('a'), s('b')]
+    placeChildSessions(list)
+    expect(list.map(x => x.id)).toEqual(['a', 'b'])
+  })
+})
 
 describe('normalizeRemote', () => {
   it('strips protocol and .git suffix', () => {

--- a/apps/gmux-web/src/projects.ts
+++ b/apps/gmux-web/src/projects.ts
@@ -370,6 +370,7 @@ export function buildProjectFolders(
     const ss = buckets.get(`${ownerPeer}::${project.slug}`) ?? []
     const visible = ss.filter(s => s.alive || s.resumable === true)
     visible.sort(compareFolderSessions)
+    placeChildSessions(visible)
     // Owned: derive launchCwd from the project's first path rule.
     // Reference: pull launchCwd from peer_projects so the launch
     // button works even when the folder is empty (no session to
@@ -454,6 +455,30 @@ export function projectAvailability(
  * server hands out distinct indices) but we fall back to `created_at`
  * then `id` so the order is deterministic across snapshot re-emits.
  */
+/**
+ * Re-place sessions that declare a parent (`parent_session_id`, e.g.
+ * an editor session spawned by `gmux edit` as $EDITOR inside another
+ * session) directly after that parent, when the parent is in the same
+ * folder. Runs after compareFolderSessions so index order is the base;
+ * children keep their relative order. Sessions whose parent isn't
+ * present stay where the base sort put them. Deliberately one level —
+ * a full hierarchy/tree UI is out of scope.
+ */
+export function placeChildSessions(sessions: Session[]): void {
+  const ids = new Set(sessions.map(s => s.id))
+  const children = sessions.filter(
+    s => s.parent_session_id && ids.has(s.parent_session_id) && s.parent_session_id !== s.id,
+  )
+  for (const child of children) {
+    const from = sessions.indexOf(child)
+    sessions.splice(from, 1)
+    // After the parent and after any earlier-placed siblings.
+    let at = sessions.findIndex(s => s.id === child.parent_session_id) + 1
+    while (at < sessions.length && sessions[at].parent_session_id === child.parent_session_id) at++
+    sessions.splice(at, 0, child)
+  }
+}
+
 function compareFolderSessions(a: Session, b: Session): number {
   const idx = (a.project_index ?? 0) - (b.project_index ?? 0)
   if (idx !== 0) return idx

--- a/apps/gmux-web/src/types.ts
+++ b/apps/gmux-web/src/types.ts
@@ -17,6 +17,12 @@ export interface Session {
   workspace_root?: string
   remotes?: Record<string, string>
   adapter: string
+  /**
+   * Session this one was spawned from (e.g. `gmux edit` invoked as
+   * $EDITOR inside an existing session). Drives adjacent placement in
+   * the sidebar: the child renders directly under its parent.
+   */
+  parent_session_id?: string
   alive: boolean
   pid: number | null
   exit_code: number | null

--- a/cli/gmux/cmd/gmux/actions.go
+++ b/cli/gmux/cmd/gmux/actions.go
@@ -16,19 +16,23 @@ import (
 // session is the subset of gmuxd's Session model that the CLI cares
 // about. Defined locally to avoid pulling in the gmuxd store package.
 type cliSession struct {
-	ID         string   `json:"id"`
-	Peer       string   `json:"peer,omitempty"`
-	Cwd        string   `json:"cwd,omitempty"`
-	Adapter    string   `json:"adapter"`
-	Alive      bool     `json:"alive"`
-	Pid        int      `json:"pid,omitempty"`
-	Title      string   `json:"title,omitempty"`
-	Slug       string   `json:"slug,omitempty"`
-	SocketPath string   `json:"socket_path,omitempty"`
-	Command    []string `json:"command,omitempty"`
-	StartedAt  string   `json:"started_at,omitempty"`
-	ExitedAt   string   `json:"exited_at,omitempty"`
-	ExitCode   *int     `json:"exit_code,omitempty"`
+	ID      string `json:"id"`
+	Peer    string `json:"peer,omitempty"`
+	Cwd     string `json:"cwd,omitempty"`
+	Adapter string `json:"adapter"`
+	Alive   bool   `json:"alive"`
+	Pid     int    `json:"pid,omitempty"`
+	Title   string `json:"title,omitempty"`
+	Slug    string `json:"slug,omitempty"`
+	// ParentSessionID links a session to the one it was spawned from
+	// (e.g. `gmux edit` as $EDITOR inside a session). Must round-trip
+	// through `gmux ls --json` for scripts to see the relationship.
+	ParentSessionID string   `json:"parent_session_id,omitempty"`
+	SocketPath      string   `json:"socket_path,omitempty"`
+	Command         []string `json:"command,omitempty"`
+	StartedAt       string   `json:"started_at,omitempty"`
+	ExitedAt        string   `json:"exited_at,omitempty"`
+	ExitCode        *int     `json:"exit_code,omitempty"`
 }
 
 // fetchSessions queries gmuxd for the full session list. Starts gmuxd

--- a/cli/gmux/cmd/gmux/cli.go
+++ b/cli/gmux/cmd/gmux/cli.go
@@ -23,6 +23,7 @@ const (
 	modeSend                  // gmux send <id> <text> [keys...]
 	modeSendKeys              // gmux send-keys -t <id> ... (tmux-compat)
 	modeWait                  // gmux wait <id>
+	modeEdit                  // gmux edit <file>
 	modeDaemon                // gmux daemon <start|stop|restart|status|log-path>
 	modeAuth                  // gmux auth
 	modeRemote                // gmux remote
@@ -66,6 +67,9 @@ type command struct {
 	// wait
 	timeout int // --timeout seconds (0 = none)
 
+	// edit
+	editFile string // file path to open
+
 	// daemon
 	daemonSub string // start|stop|restart|status|log-path
 
@@ -79,7 +83,7 @@ type command struct {
 // command in the error-only migration shim.
 var reservedVerbs = []string{
 	"open", "ls", "attach", "tail", "kill", "send", "send-keys",
-	"wait", "daemon", "auth", "remote", "version", "help",
+	"wait", "edit", "daemon", "auth", "remote", "version", "help",
 }
 
 // removedFlags maps every pre-2.0 action flag to the verb that replaced
@@ -161,6 +165,8 @@ func parseCLI(args []string) (*command, error) {
 		return parseSendKeys(rest)
 	case "wait":
 		return parseWait(rest)
+	case "edit":
+		return parseEdit(rest)
 	case "daemon":
 		return parseDaemon(rest)
 	case "auth":
@@ -314,6 +320,22 @@ func parseWait(args []string) (*command, error) {
 	return c, nil
 }
 
+// parseEdit handles `gmux edit <file>`: exactly one file path. The verb
+// is designed to be usable as $EDITOR (git commit, etc.): it blocks
+// until the editor session exits and propagates its exit code. Today it
+// opens a fallback terminal editor in a managed session; a future
+// release renders a browser-based editor tab instead, keeping this
+// interface (one path, blocking, exit code) unchanged.
+func parseEdit(args []string) (*command, error) {
+	if len(args) != 1 {
+		return nil, errors.New("edit requires exactly one file path")
+	}
+	if strings.HasPrefix(args[0], "-") {
+		return nil, fmt.Errorf("edit takes no flags (got %q)", args[0])
+	}
+	return &command{mode: modeEdit, editFile: args[0]}, nil
+}
+
 var daemonSubs = map[string]bool{
 	"start": true, "stop": true, "restart": true, "status": true, "log-path": true,
 }
@@ -445,6 +467,9 @@ Sessions (local by default; address a peer with <id>@<peer>):
   gmux send-keys -t <id> <keys...>  tmux-compatible key sending
   gmux wait <id> [--timeout N]      block until an agent session is idle
   gmux kill <id>                    terminate a session
+
+Editing (usable as $EDITOR; blocks until the editor closes):
+  gmux edit <file>                  open a file in a managed editor session
 
 UI & pairing:
   gmux open                         open the web UI

--- a/cli/gmux/cmd/gmux/cli.go
+++ b/cli/gmux/cmd/gmux/cli.go
@@ -12,24 +12,25 @@ import (
 type mode int
 
 const (
-	modeHelp      mode = iota // print usage and exit
-	modeVersion               // print version and exit
-	modeOpen                  // open the web UI
-	modeRun                   // run a command in a new session (gmux -- <cmd>)
-	modeList                  // gmux ls
-	modeAttach                // gmux attach <id>
-	modeTail                  // gmux tail <id>
-	modeKill                  // gmux kill <id>
-	modeSend                  // gmux send <id> <text> [keys...]
-	modeSendKeys              // gmux send-keys -t <id> ... (tmux-compat)
-	modeWait                  // gmux wait <id>
-	modeEdit                  // gmux edit <file>
-	modeDaemon                // gmux daemon <start|stop|restart|status|log-path>
-	modeAuth                  // gmux auth
-	modeRemote                // gmux remote
-	modeDumpEnv               // (internal) gmux __dump-env
-	modeCodexHook             // (internal) gmux __codex-hook <Event>
-	modeClaudeHook            // (internal) gmux __claude-hook
+	modeHelp       mode = iota // print usage and exit
+	modeVersion                // print version and exit
+	modeOpen                   // open the web UI
+	modeRun                    // run a command in a new session (gmux -- <cmd>)
+	modeList                   // gmux ls
+	modeAttach                 // gmux attach <id>
+	modeTail                   // gmux tail <id>
+	modeKill                   // gmux kill <id>
+	modeSend                   // gmux send <id> <text> [keys...]
+	modeSendKeys               // gmux send-keys -t <id> ... (tmux-compat)
+	modeWait                   // gmux wait <id>
+	modeEdit                   // gmux edit [file]
+	modeEditChild              // (internal) gmux __edit-child [file]
+	modeDaemon                 // gmux daemon <start|stop|restart|status|log-path>
+	modeAuth                   // gmux auth
+	modeRemote                 // gmux remote
+	modeDumpEnv                // (internal) gmux __dump-env
+	modeCodexHook              // (internal) gmux __codex-hook <Event>
+	modeClaudeHook             // (internal) gmux __claude-hook
 )
 
 // command is the fully-parsed CLI invocation. One struct for every
@@ -190,6 +191,17 @@ func parseCLI(args []string) (*command, error) {
 		return &command{mode: modeCodexHook, codexHookEvent: rest[0]}, nil
 	case "__claude-hook":
 		return &command{mode: modeClaudeHook}, nil
+	case "__edit-child":
+		// Child process of an editor session: prompt (if needed) and exec
+		// the fallback editor. Reuses the editFile field.
+		if len(rest) > 1 {
+			return nil, errors.New("__edit-child takes at most one file path")
+		}
+		c := &command{mode: modeEditChild}
+		if len(rest) == 1 {
+			c.editFile = rest[0]
+		}
+		return c, nil
 	}
 
 	// Error-only migration shim (ADR 0009): recognize removed forms and
@@ -320,20 +332,25 @@ func parseWait(args []string) (*command, error) {
 	return c, nil
 }
 
-// parseEdit handles `gmux edit <file>`: exactly one file path. The verb
+// parseEdit handles `gmux edit [file]`: at most one file path. The verb
 // is designed to be usable as $EDITOR (git commit, etc.): it blocks
-// until the editor session exits and propagates its exit code. Today it
-// opens a fallback terminal editor in a managed session; a future
-// release renders a browser-based editor tab instead, keeping this
-// interface (one path, blocking, exit code) unchanged.
+// until the editor session exits and propagates its exit code. With no
+// path (the + launcher menu can't parameterize one) the session prompts
+// for a path interactively. Today it opens a fallback terminal editor
+// in a managed session; a future release renders a browser-based editor
+// tab instead, keeping this interface (0-1 paths, blocking, exit code)
+// unchanged.
 func parseEdit(args []string) (*command, error) {
-	if len(args) != 1 {
-		return nil, errors.New("edit requires exactly one file path")
+	if len(args) > 1 {
+		return nil, errors.New("edit takes at most one file path")
 	}
-	if strings.HasPrefix(args[0], "-") {
-		return nil, fmt.Errorf("edit takes no flags (got %q)", args[0])
+	if len(args) == 1 {
+		if strings.HasPrefix(args[0], "-") {
+			return nil, fmt.Errorf("edit takes no flags (got %q)", args[0])
+		}
+		return &command{mode: modeEdit, editFile: args[0]}, nil
 	}
-	return &command{mode: modeEdit, editFile: args[0]}, nil
+	return &command{mode: modeEdit}, nil
 }
 
 var daemonSubs = map[string]bool{
@@ -469,7 +486,8 @@ Sessions (local by default; address a peer with <id>@<peer>):
   gmux kill <id>                    terminate a session
 
 Editing (usable as $EDITOR; blocks until the editor closes):
-  gmux edit <file>                  open a file in a managed editor session
+  gmux edit [file]                  open a file in a managed editor session
+                                    (no file: prompts for a path)
 
 UI & pairing:
   gmux open                         open the web UI

--- a/cli/gmux/cmd/gmux/cli_test.go
+++ b/cli/gmux/cmd/gmux/cli_test.go
@@ -57,6 +57,19 @@ func TestParseCLI(t *testing.T) {
 					t.Errorf("editFile = %q", c.editFile)
 				}
 			}},
+		{name: "edit without path prompts later", args: []string{"edit"}, wantMode: modeEdit,
+			check: func(t *testing.T, c *command) {
+				if c.editFile != "" {
+					t.Errorf("editFile = %q, want empty", c.editFile)
+				}
+			}},
+		{name: "edit child internal", args: []string{"__edit-child", "/tmp/x"}, wantMode: modeEditChild,
+			check: func(t *testing.T, c *command) {
+				if c.editFile != "/tmp/x" {
+					t.Errorf("editFile = %q", c.editFile)
+				}
+			}},
+		{name: "edit child without path", args: []string{"__edit-child"}, wantMode: modeEditChild},
 
 		{name: "ls", args: []string{"ls"}, wantMode: modeList},
 		{name: "ls --all --json", args: []string{"ls", "--all", "--json"}, wantMode: modeList,
@@ -192,13 +205,13 @@ func TestParseCLIErrors(t *testing.T) {
 		{"tail"},                   // missing id
 		{"tail", "-n", "0", "abc"}, // non-positive count
 		{"wait"},                   // missing id
-		{"send-keys", "C-c"},     // missing -t
-		{"daemon"},               // missing subcommand
-		{"daemon", "frobnicate"}, // unknown subcommand
-		{"ls", "stray"},          // ls takes no positional
-		{"edit"},                 // missing file
-		{"edit", "a", "b"},       // too many files
-		{"edit", "--wait"},       // no flags on edit (yet)
+		{"send-keys", "C-c"},       // missing -t
+		{"daemon"},                 // missing subcommand
+		{"daemon", "frobnicate"},   // unknown subcommand
+		{"ls", "stray"},            // ls takes no positional
+		{"edit", "a", "b"},         // too many files
+		{"edit", "--wait"},         // no flags on edit (yet)
+		{"__edit-child", "a", "b"}, // too many files
 	}
 	for _, args := range bad {
 		t.Run(strings.Join(args, "_"), func(t *testing.T) {

--- a/cli/gmux/cmd/gmux/cli_test.go
+++ b/cli/gmux/cmd/gmux/cli_test.go
@@ -51,6 +51,13 @@ func TestParseCLI(t *testing.T) {
 				}
 			}},
 
+		{name: "edit", args: []string{"edit", "notes.txt"}, wantMode: modeEdit,
+			check: func(t *testing.T, c *command) {
+				if c.editFile != "notes.txt" {
+					t.Errorf("editFile = %q", c.editFile)
+				}
+			}},
+
 		{name: "ls", args: []string{"ls"}, wantMode: modeList},
 		{name: "ls --all --json", args: []string{"ls", "--all", "--json"}, wantMode: modeList,
 			check: func(t *testing.T, c *command) {
@@ -189,6 +196,9 @@ func TestParseCLIErrors(t *testing.T) {
 		{"daemon"},               // missing subcommand
 		{"daemon", "frobnicate"}, // unknown subcommand
 		{"ls", "stray"},          // ls takes no positional
+		{"edit"},                 // missing file
+		{"edit", "a", "b"},       // too many files
+		{"edit", "--wait"},       // no flags on edit (yet)
 	}
 	for _, args := range bad {
 		t.Run(strings.Join(args, "_"), func(t *testing.T) {

--- a/cli/gmux/cmd/gmux/edit.go
+++ b/cli/gmux/cmd/gmux/edit.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"errors"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// fallbackEditors are probed in order when GMUX_EDIT_FALLBACK is unset.
+// Deliberately NOT $EDITOR/$VISUAL: the whole point of `gmux edit` is to
+// BE the user's $EDITOR, so consulting it would recurse.
+var fallbackEditors = []string{"nano", "vim", "vi"}
+
+// resolveFallbackEditor picks the terminal editor `gmux edit` wraps
+// today (the future browser-editor tab replaces this, not the verb).
+// GMUX_EDIT_FALLBACK, when set, wins verbatim and may carry flags
+// ("vim -u NONE"); otherwise the first of fallbackEditors on PATH.
+// lookPath is injected for tests.
+func resolveFallbackEditor(getenv func(string) string, lookPath func(string) (string, error)) ([]string, error) {
+	if custom := getenv("GMUX_EDIT_FALLBACK"); custom != "" {
+		parts := strings.Fields(custom)
+		if _, err := lookPath(parts[0]); err != nil {
+			return nil, errors.New("GMUX_EDIT_FALLBACK editor not found: " + parts[0])
+		}
+		return parts, nil
+	}
+	for _, ed := range fallbackEditors {
+		if _, err := lookPath(ed); err == nil {
+			return []string{ed}, nil
+		}
+	}
+	return nil, errors.New("no editor found (tried " + strings.Join(fallbackEditors, ", ") + "); set GMUX_EDIT_FALLBACK")
+}
+
+// runEdit implements `gmux edit <file>`: open the file in a managed
+// session and block until the editor exits, propagating its exit code
+// (runSession os.Exit's with the child's code). ForceForeground keeps
+// the blocking contract even inside an existing gmux session, where
+// runSession would otherwise detach and return immediately.
+func runEdit(file string) {
+	abs, err := filepath.Abs(file)
+	if err != nil {
+		log.Fatalf("cannot resolve path %q: %v", file, err)
+	}
+	editor, err := resolveFallbackEditor(os.Getenv, exec.LookPath)
+	if err != nil {
+		log.Fatal(err)
+	}
+	runSession(append(editor, abs), true, runDirectives{ForceForeground: true})
+}

--- a/cli/gmux/cmd/gmux/edit.go
+++ b/cli/gmux/cmd/gmux/edit.go
@@ -1,53 +1,105 @@
 package main
 
 import (
-	"errors"
+	"bufio"
+	"fmt"
 	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
+
+	"github.com/gmuxapp/gmux/packages/adapter/adapters"
 )
 
-// fallbackEditors are probed in order when GMUX_EDIT_FALLBACK is unset.
-// Deliberately NOT $EDITOR/$VISUAL: the whole point of `gmux edit` is to
-// BE the user's $EDITOR, so consulting it would recurse.
-var fallbackEditors = []string{"nano", "vim", "vi"}
-
-// resolveFallbackEditor picks the terminal editor `gmux edit` wraps
-// today (the future browser-editor tab replaces this, not the verb).
-// GMUX_EDIT_FALLBACK, when set, wins verbatim and may carry flags
-// ("vim -u NONE"); otherwise the first of fallbackEditors on PATH.
-// lookPath is injected for tests.
-func resolveFallbackEditor(getenv func(string) string, lookPath func(string) (string, error)) ([]string, error) {
-	if custom := getenv("GMUX_EDIT_FALLBACK"); custom != "" {
-		parts := strings.Fields(custom)
-		if _, err := lookPath(parts[0]); err != nil {
-			return nil, errors.New("GMUX_EDIT_FALLBACK editor not found: " + parts[0])
-		}
-		return parts, nil
+// runEdit implements `gmux edit [file]`: open the file in a managed
+// editor session (adapter "editor") and block until the editor exits,
+// propagating its exit code (runSession os.Exit's with the child's
+// code). That blocking contract is what makes the verb usable as
+// $EDITOR for git commit and friends.
+//
+// The session's child command is the internal `gmux __edit-child`
+// sentinel (see editChild), which the editor adapter matches — the
+// same command the launcher entry runs, so CLI- and UI-launched editor
+// sessions are indistinguishable. ForceForeground keeps the blocking
+// contract even inside an existing gmux session, where runSession
+// would otherwise detach and return immediately. In that nested case
+// the invoking session's id is recorded as the editor session's
+// parent, so the UI can place the editor next to the session that
+// spawned it.
+func runEdit(file string) {
+	self, err := os.Executable()
+	if err != nil {
+		log.Fatalf("cannot find own binary: %v", err)
 	}
-	for _, ed := range fallbackEditors {
-		if _, err := lookPath(ed); err == nil {
-			return []string{ed}, nil
+	args := []string{self, "__edit-child"}
+	if file != "" {
+		abs, err := filepath.Abs(file)
+		if err != nil {
+			log.Fatalf("cannot resolve path %q: %v", file, err)
 		}
+		args = append(args, abs)
 	}
-	return nil, errors.New("no editor found (tried " + strings.Join(fallbackEditors, ", ") + "); set GMUX_EDIT_FALLBACK")
+	var parent string
+	if os.Getenv("GMUX") == "1" {
+		parent = os.Getenv("GMUX_SESSION_ID")
+	}
+	runSession(args, true, runDirectives{
+		ForceForeground: true,
+		ParentSessionID: parent,
+	})
 }
 
-// runEdit implements `gmux edit <file>`: open the file in a managed
-// session and block until the editor exits, propagating its exit code
-// (runSession os.Exit's with the child's code). ForceForeground keeps
-// the blocking contract even inside an existing gmux session, where
-// runSession would otherwise detach and return immediately.
-func runEdit(file string) {
-	abs, err := filepath.Abs(file)
-	if err != nil {
-		log.Fatalf("cannot resolve path %q: %v", file, err)
+// editChild is the child process of an editor session (internal
+// `gmux __edit-child [path]`). It prompts for a path when none was
+// given (the + launcher menu can't parameterize one), resolves the
+// fallback terminal editor, and execs it — so the editor's exit code
+// is the session's exit code, verbatim.
+func editChild(path string) int {
+	if path == "" {
+		fmt.Print("File to edit: ")
+		line, err := bufio.NewReader(os.Stdin).ReadString('\n')
+		path = strings.TrimSpace(line)
+		if path == "" {
+			if err != nil {
+				fmt.Fprintln(os.Stderr, "gmux: no file given")
+			} else {
+				fmt.Fprintln(os.Stderr, "gmux: empty path")
+			}
+			return 1
+		}
 	}
-	editor, err := resolveFallbackEditor(os.Getenv, exec.LookPath)
+	abs, err := filepath.Abs(expandTilde(path))
 	if err != nil {
-		log.Fatal(err)
+		fmt.Fprintf(os.Stderr, "gmux: cannot resolve path %q: %v\n", path, err)
+		return 1
 	}
-	runSession(append(editor, abs), true, runDirectives{ForceForeground: true})
+	editor, err := adapters.ResolveFallbackEditor(os.Getenv, exec.LookPath)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "gmux:", err)
+		return 1
+	}
+	bin, err := exec.LookPath(editor[0])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "gmux: %s: %v\n", editor[0], err)
+		return 1
+	}
+	argv := append(editor, abs)
+	if err := syscall.Exec(bin, argv, os.Environ()); err != nil {
+		fmt.Fprintf(os.Stderr, "gmux: exec %s: %v\n", bin, err)
+		return 1
+	}
+	return 0 // unreachable
+}
+
+// expandTilde resolves a leading ~/ against $HOME so the interactive
+// prompt accepts the same shorthand a shell would.
+func expandTilde(p string) string {
+	if p == "~" || strings.HasPrefix(p, "~/") {
+		if home, err := os.UserHomeDir(); err == nil {
+			return filepath.Join(home, strings.TrimPrefix(strings.TrimPrefix(p, "~"), "/"))
+		}
+	}
+	return p
 }

--- a/cli/gmux/cmd/gmux/edit_test.go
+++ b/cli/gmux/cmd/gmux/edit_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// lookPathAllowing returns a lookPath stub that succeeds only for the
+// given names.
+func lookPathAllowing(names ...string) func(string) (string, error) {
+	set := map[string]bool{}
+	for _, n := range names {
+		set[n] = true
+	}
+	return func(name string) (string, error) {
+		if set[name] {
+			return "/usr/bin/" + name, nil
+		}
+		return "", errors.New("not found")
+	}
+}
+
+func noEnv(string) string { return "" }
+
+func TestResolveFallbackEditor(t *testing.T) {
+	t.Run("prefers nano", func(t *testing.T) {
+		got, err := resolveFallbackEditor(noEnv, lookPathAllowing("nano", "vim", "vi"))
+		if err != nil || strings.Join(got, " ") != "nano" {
+			t.Errorf("got %v, %v; want [nano]", got, err)
+		}
+	})
+
+	t.Run("falls through PATH order", func(t *testing.T) {
+		got, err := resolveFallbackEditor(noEnv, lookPathAllowing("vi"))
+		if err != nil || strings.Join(got, " ") != "vi" {
+			t.Errorf("got %v, %v; want [vi]", got, err)
+		}
+	})
+
+	t.Run("errors with hint when nothing found", func(t *testing.T) {
+		_, err := resolveFallbackEditor(noEnv, lookPathAllowing())
+		if err == nil || !strings.Contains(err.Error(), "GMUX_EDIT_FALLBACK") {
+			t.Errorf("want error mentioning GMUX_EDIT_FALLBACK, got %v", err)
+		}
+	})
+
+	t.Run("GMUX_EDIT_FALLBACK wins and may carry flags", func(t *testing.T) {
+		env := func(k string) string {
+			if k == "GMUX_EDIT_FALLBACK" {
+				return "vim -u NONE"
+			}
+			return ""
+		}
+		got, err := resolveFallbackEditor(env, lookPathAllowing("vim", "nano"))
+		if err != nil || strings.Join(got, " ") != "vim -u NONE" {
+			t.Errorf("got %v, %v; want [vim -u NONE]", got, err)
+		}
+	})
+
+	t.Run("GMUX_EDIT_FALLBACK missing from PATH errors", func(t *testing.T) {
+		env := func(k string) string {
+			if k == "GMUX_EDIT_FALLBACK" {
+				return "myeditor"
+			}
+			return ""
+		}
+		_, err := resolveFallbackEditor(env, lookPathAllowing("nano"))
+		if err == nil || !strings.Contains(err.Error(), "myeditor") {
+			t.Errorf("want error naming myeditor, got %v", err)
+		}
+	})
+
+	// $EDITOR must never be consulted: `EDITOR="gmux edit"` is the
+	// primary use case and reading it back would recurse.
+	t.Run("ignores EDITOR", func(t *testing.T) {
+		env := func(k string) string {
+			if k == "EDITOR" {
+				return "gmux edit"
+			}
+			return ""
+		}
+		got, err := resolveFallbackEditor(env, lookPathAllowing("nano"))
+		if err != nil || strings.Join(got, " ") != "nano" {
+			t.Errorf("got %v, %v; want [nano]", got, err)
+		}
+	})
+}

--- a/cli/gmux/cmd/gmux/edit_test.go
+++ b/cli/gmux/cmd/gmux/edit_test.go
@@ -6,6 +6,51 @@ import (
 	"testing"
 )
 
+func TestSessionEditorEnv(t *testing.T) {
+	self := func() (string, error) { return "/opt/gmux/bin/gmux", nil }
+	envWith := func(set ...string) func(string) (string, bool) {
+		m := map[string]bool{}
+		for _, k := range set {
+			m[k] = true
+		}
+		return func(k string) (string, bool) {
+			if m[k] {
+				return "something", true
+			}
+			return "", false
+		}
+	}
+
+	t.Run("defaults both when neither is set", func(t *testing.T) {
+		got := sessionEditorEnv(envWith(), self)
+		want := []string{"EDITOR=/opt/gmux/bin/gmux edit", "VISUAL=/opt/gmux/bin/gmux edit"}
+		if len(got) != 2 || got[0] != want[0] || got[1] != want[1] {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("never overrides a user-set value", func(t *testing.T) {
+		if got := sessionEditorEnv(envWith("EDITOR", "VISUAL"), self); len(got) != 0 {
+			t.Errorf("got %v, want none", got)
+		}
+	})
+
+	t.Run("fills only the unset one", func(t *testing.T) {
+		got := sessionEditorEnv(envWith("EDITOR"), self)
+		if len(got) != 1 || got[0] != "VISUAL=/opt/gmux/bin/gmux edit" {
+			t.Errorf("got %v", got)
+		}
+	})
+
+	t.Run("falls back to bare gmux without a self path", func(t *testing.T) {
+		noSelf := func() (string, error) { return "", os.ErrNotExist }
+		got := sessionEditorEnv(envWith("VISUAL"), noSelf)
+		if len(got) != 1 || got[0] != "EDITOR=gmux edit" {
+			t.Errorf("got %v", got)
+		}
+	})
+}
+
 func TestExpandTilde(t *testing.T) {
 	home, err := os.UserHomeDir()
 	if err != nil {

--- a/cli/gmux/cmd/gmux/edit_test.go
+++ b/cli/gmux/cmd/gmux/edit_test.go
@@ -1,88 +1,26 @@
 package main
 
 import (
-	"errors"
-	"strings"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
-// lookPathAllowing returns a lookPath stub that succeeds only for the
-// given names.
-func lookPathAllowing(names ...string) func(string) (string, error) {
-	set := map[string]bool{}
-	for _, n := range names {
-		set[n] = true
+func TestExpandTilde(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("no home dir")
 	}
-	return func(name string) (string, error) {
-		if set[name] {
-			return "/usr/bin/" + name, nil
-		}
-		return "", errors.New("not found")
+	cases := map[string]string{
+		"~/notes.txt":  filepath.Join(home, "notes.txt"),
+		"~":            home,
+		"/abs/path":    "/abs/path",
+		"relative.txt": "relative.txt",
+		"~user/notes":  "~user/notes", // ~user expansion not supported
 	}
-}
-
-func noEnv(string) string { return "" }
-
-func TestResolveFallbackEditor(t *testing.T) {
-	t.Run("prefers nano", func(t *testing.T) {
-		got, err := resolveFallbackEditor(noEnv, lookPathAllowing("nano", "vim", "vi"))
-		if err != nil || strings.Join(got, " ") != "nano" {
-			t.Errorf("got %v, %v; want [nano]", got, err)
+	for in, want := range cases {
+		if got := expandTilde(in); got != want {
+			t.Errorf("expandTilde(%q) = %q, want %q", in, got, want)
 		}
-	})
-
-	t.Run("falls through PATH order", func(t *testing.T) {
-		got, err := resolveFallbackEditor(noEnv, lookPathAllowing("vi"))
-		if err != nil || strings.Join(got, " ") != "vi" {
-			t.Errorf("got %v, %v; want [vi]", got, err)
-		}
-	})
-
-	t.Run("errors with hint when nothing found", func(t *testing.T) {
-		_, err := resolveFallbackEditor(noEnv, lookPathAllowing())
-		if err == nil || !strings.Contains(err.Error(), "GMUX_EDIT_FALLBACK") {
-			t.Errorf("want error mentioning GMUX_EDIT_FALLBACK, got %v", err)
-		}
-	})
-
-	t.Run("GMUX_EDIT_FALLBACK wins and may carry flags", func(t *testing.T) {
-		env := func(k string) string {
-			if k == "GMUX_EDIT_FALLBACK" {
-				return "vim -u NONE"
-			}
-			return ""
-		}
-		got, err := resolveFallbackEditor(env, lookPathAllowing("vim", "nano"))
-		if err != nil || strings.Join(got, " ") != "vim -u NONE" {
-			t.Errorf("got %v, %v; want [vim -u NONE]", got, err)
-		}
-	})
-
-	t.Run("GMUX_EDIT_FALLBACK missing from PATH errors", func(t *testing.T) {
-		env := func(k string) string {
-			if k == "GMUX_EDIT_FALLBACK" {
-				return "myeditor"
-			}
-			return ""
-		}
-		_, err := resolveFallbackEditor(env, lookPathAllowing("nano"))
-		if err == nil || !strings.Contains(err.Error(), "myeditor") {
-			t.Errorf("want error naming myeditor, got %v", err)
-		}
-	})
-
-	// $EDITOR must never be consulted: `EDITOR="gmux edit"` is the
-	// primary use case and reading it back would recurse.
-	t.Run("ignores EDITOR", func(t *testing.T) {
-		env := func(k string) string {
-			if k == "EDITOR" {
-				return "gmux edit"
-			}
-			return ""
-		}
-		got, err := resolveFallbackEditor(env, lookPathAllowing("nano"))
-		if err != nil || strings.Join(got, " ") != "nano" {
-			t.Errorf("got %v, %v; want [nano]", got, err)
-		}
-	})
+	}
 }

--- a/cli/gmux/cmd/gmux/handshake.go
+++ b/cli/gmux/cmd/gmux/handshake.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 )
 
@@ -30,34 +31,67 @@ import (
 //   - os.ErrDeadlineExceeded     → child wedged between register and ack
 //   - "empty session id…"        → child wrote only whitespace
 //
-// After dispatching the ack, handshakeAck unsets GMUX_HANDSHAKE_FD so
-// the (now-closed) fd doesn't get re-interpreted by any nested fork
-// the runner spawns later (the user's command, or a `gmux` invoked
-// from within it).
+// The env var is consumed at process startup (captureHandshakeFD),
+// NOT at ack time. The runner forwards os.Environ to its PTY child,
+// and the child is spawned before the ack — so a lazily-read env var
+// leaks to every process inside the session. A nested `gmux` (e.g.
+// `gmux edit` invoked as $EDITOR inside the session) would then
+// interpret the stale "3" against its own fd table, where fd 3 is
+// typically the Go runtime's epoll fd — writing to and closing it is
+// an instant `netpoll failed` crash. Capturing + unsetting first
+// thing in main() makes the inheritance impossible.
 const handshakeFDEnv = "GMUX_HANDSHAKE_FD"
 
-// handshakeAck signals registration outcome to the parent process via
-// the file descriptor named in GMUX_HANDSHAKE_FD. No-op when the env
-// var is unset (the common case: this gmux wasn't spawned with a
-// handshake parent).
+// capturedHandshakeFD is the fd number recorded by captureHandshakeFD,
+// or -1 when this process has no handshake parent. Consumed (and
+// reset) by the single handshakeAck call.
+var capturedHandshakeFD = -1
+
+// captureHandshakeFD reads GMUX_HANDSHAKE_FD, validates it, records
+// the fd for the eventual handshakeAck, and ALWAYS unsets the env var
+// so no child of this process can inherit it. Must be called at the
+// top of main(), before anything can fork.
 //
-// Errors are swallowed: a malformed env var, a stale fd, or a write
-// failure leaves the parent's read returning EOF, which is already
-// the failure signal. The child continues running regardless, because
-// the session itself is independent of whether the parent ever
-// learns about it.
+// Validation is deliberately paranoid: besides the numeric/range
+// checks, the fd must actually be a pipe. This guards the rolling-
+// upgrade window where an old runner (which leaked the env var to its
+// session) is still alive: a nested gmux would otherwise ack against
+// whatever its own fd 3 happens to be, and closing an arbitrary fd
+// (e.g. the runtime's epoll fd) is fatal.
+func captureHandshakeFD() {
+	defer func() { _ = os.Unsetenv(handshakeFDEnv) }()
+	fdStr := os.Getenv(handshakeFDEnv)
+	if fdStr == "" {
+		return
+	}
+	fd, err := strconv.Atoi(fdStr)
+	if err != nil || fd < 3 {
+		return
+	}
+	var st syscall.Stat_t
+	if syscall.Fstat(fd, &st) != nil || st.Mode&syscall.S_IFMT != syscall.S_IFIFO {
+		return
+	}
+	capturedHandshakeFD = fd
+}
+
+// handshakeAck signals registration outcome to the parent process via
+// the fd recorded by captureHandshakeFD. No-op when no handshake
+// parent exists (the common case).
+//
+// Errors are swallowed: a write failure leaves the parent's read
+// returning EOF, which is already the failure signal. The child
+// continues running regardless, because the session itself is
+// independent of whether the parent ever learns about it.
 func handshakeAck(sessionID string, registered bool) {
-	f := openHandshakeFD()
+	if capturedHandshakeFD < 0 {
+		return
+	}
+	f := os.NewFile(uintptr(capturedHandshakeFD), "gmux-handshake")
+	capturedHandshakeFD = -1
 	if f == nil {
 		return
 	}
-	// Clear the env var so the (about-to-be-closed) fd isn't
-	// re-interpreted by any process the runner forks later. The
-	// runner forwards os.Environ to user commands, and a nested
-	// `gmux` would otherwise call handshakeAck against a fd that
-	// in its own fd table is either closed or pointing at
-	// something unrelated.
-	_ = os.Unsetenv(handshakeFDEnv)
 	handshakeAckFD(f, sessionID, registered)
 }
 
@@ -71,22 +105,6 @@ func handshakeAckFD(f *os.File, sessionID string, registered bool) {
 	if registered {
 		fmt.Fprintln(f, sessionID)
 	}
-}
-
-// openHandshakeFD returns a *os.File wrapping GMUX_HANDSHAKE_FD, or
-// nil if the env var is unset, malformed, or names one of fds 0-2
-// (which are stdin/stdout/stderr and never a valid handshake
-// channel).
-func openHandshakeFD() *os.File {
-	fdStr := os.Getenv(handshakeFDEnv)
-	if fdStr == "" {
-		return nil
-	}
-	fd, err := strconv.Atoi(fdStr)
-	if err != nil || fd < 3 {
-		return nil
-	}
-	return os.NewFile(uintptr(fd), "gmux-handshake")
 }
 
 // readHandshake blocks on r until the child writes its session id

--- a/cli/gmux/cmd/gmux/handshake_test.go
+++ b/cli/gmux/cmd/gmux/handshake_test.go
@@ -73,51 +73,98 @@ func TestHandshakeAckFD_ClosesFDOnSuccess(t *testing.T) {
 	}
 }
 
-// ── openHandshakeFD / handshakeAck: env-lookup + dispatch glue ──
+// ── captureHandshakeFD / handshakeAck: startup capture + dispatch ──
 
-func TestOpenHandshakeFD_NilWhenEnvUnset(t *testing.T) {
+// resetCapture isolates the package-level capture state per test.
+func resetCapture(t *testing.T) {
+	t.Helper()
+	capturedHandshakeFD = -1
+	t.Cleanup(func() { capturedHandshakeFD = -1 })
+}
+
+func TestCaptureHandshakeFD_NoopWhenEnvUnset(t *testing.T) {
+	resetCapture(t)
 	t.Setenv(handshakeFDEnv, "")
-	if f := openHandshakeFD(); f != nil {
-		t.Fatalf("expected nil with empty env, got %+v", f)
+	captureHandshakeFD()
+	if capturedHandshakeFD != -1 {
+		t.Fatalf("expected no capture with empty env, got fd %d", capturedHandshakeFD)
 	}
 }
 
-func TestOpenHandshakeFD_NilForInvalidEnv(t *testing.T) {
+func TestCaptureHandshakeFD_RejectsInvalidEnv(t *testing.T) {
 	for _, v := range []string{"not-a-number", "0", "1", "2", "-1"} {
 		t.Run(v, func(t *testing.T) {
+			resetCapture(t)
 			t.Setenv(handshakeFDEnv, v)
-			if f := openHandshakeFD(); f != nil {
-				t.Fatalf("expected nil for %q, got %+v", v, f)
+			captureHandshakeFD()
+			if capturedHandshakeFD != -1 {
+				t.Fatalf("expected rejection for %q, got fd %d", v, capturedHandshakeFD)
+			}
+			if got := os.Getenv(handshakeFDEnv); got != "" {
+				t.Fatalf("env not cleared for %q: got %q", v, got)
 			}
 		})
 	}
 }
 
-// TestHandshakeAck_UnsetsEnvAfterDispatch is the regression test for
-// the env-leak fix: after handshakeAck runs once, GMUX_HANDSHAKE_FD
-// must be unset so a fork inheriting os.Environ doesn't try to write
-// to the (now-closed) fd.
-func TestHandshakeAck_UnsetsEnvAfterDispatch(t *testing.T) {
+// TestCaptureHandshakeFD_UnsetsEnvImmediately is the regression test
+// for the env-leak crash: the env var must be gone BEFORE any child
+// is spawned (i.e. right after capture), not merely after the ack.
+// A leaked GMUX_HANDSHAKE_FD=3 makes a nested gmux inside the session
+// close its own fd 3 — typically the Go runtime's epoll fd — which is
+// a fatal `netpoll failed`.
+func TestCaptureHandshakeFD_UnsetsEnvImmediately(t *testing.T) {
+	resetCapture(t)
 	_, w := pipePair(t)
 	t.Setenv(handshakeFDEnv, strconv.Itoa(int(w.Fd())))
 
-	handshakeAck("sess-xyz", true)
+	captureHandshakeFD()
 
 	if v := os.Getenv(handshakeFDEnv); v != "" {
-		t.Fatalf("env not cleared after ack: got %q", v)
+		t.Fatalf("env not cleared after capture: got %q", v)
+	}
+	if capturedHandshakeFD != int(w.Fd()) {
+		t.Fatalf("captured fd = %d, want %d", capturedHandshakeFD, int(w.Fd()))
 	}
 }
 
-// TestHandshakeAck_SecondCallIsNoOp follows from
-// UnsetsEnvAfterDispatch: a second call within the same process
-// finds an empty env and writes nothing. Captures the property from
-// the consumer's perspective (one ack per pipe).
+// TestCaptureHandshakeFD_RejectsNonPipeFD guards the rolling-upgrade
+// window: an OLD runner may still leak GMUX_HANDSHAKE_FD=3 into its
+// session, where a NEW nested gmux's fd 3 is something unrelated
+// (epoll fd, an open file, ...). Capture must refuse any fd that
+// isn't a pipe, and must not close or touch it.
+func TestCaptureHandshakeFD_RejectsNonPipeFD(t *testing.T) {
+	resetCapture(t)
+	f, err := os.Open(os.DevNull) // char device, not a FIFO
+	if err != nil {
+		t.Fatalf("open devnull: %v", err)
+	}
+	defer f.Close()
+	t.Setenv(handshakeFDEnv, strconv.Itoa(int(f.Fd())))
+
+	captureHandshakeFD()
+	handshakeAck("sess-xyz", true) // must be a no-op
+
+	if capturedHandshakeFD != -1 {
+		t.Fatalf("non-pipe fd was captured: %d", capturedHandshakeFD)
+	}
+	// The fd must still be usable — proving nothing closed it.
+	if _, err := f.Stat(); err != nil {
+		t.Fatalf("fd was damaged by capture/ack: %v", err)
+	}
+}
+
+// TestHandshakeAck_SecondCallIsNoOp: the captured fd is consumed by
+// the first ack; a second call within the same process writes
+// nothing (one ack per pipe).
 func TestHandshakeAck_SecondCallIsNoOp(t *testing.T) {
+	resetCapture(t)
 	r, w := pipePair(t)
 	t.Setenv(handshakeFDEnv, strconv.Itoa(int(w.Fd())))
+	captureHandshakeFD()
 
 	handshakeAck("first-id", true)
-	handshakeAck("second-id", true) // would re-write if env still set
+	handshakeAck("second-id", true) // would re-write if fd still captured
 
 	data, err := io.ReadAll(r)
 	if err != nil {
@@ -128,12 +175,11 @@ func TestHandshakeAck_SecondCallIsNoOp(t *testing.T) {
 	}
 }
 
-// TestHandshakeAck_NoOpWithoutEnv pins down the common-case fast
-// path: handshakeAck returns immediately when the env var is absent,
-// touching no fds. Asserted by the absence of side effects: the test
-// should run cleanly with no goroutines blocked.
-func TestHandshakeAck_NoOpWithoutEnv(t *testing.T) {
-	t.Setenv(handshakeFDEnv, "")
+// TestHandshakeAck_NoOpWithoutCapture pins down the common-case fast
+// path: handshakeAck returns immediately when no handshake parent
+// was captured, touching no fds.
+func TestHandshakeAck_NoOpWithoutCapture(t *testing.T) {
+	resetCapture(t)
 	handshakeAck("abc", true)
 	handshakeAck("abc", false)
 }
@@ -230,6 +276,9 @@ func TestPipeHandshakeRoundTripViaSubprocess(t *testing.T) {
 	const expectedID = "sess-fromchild"
 
 	if os.Getenv(childIDEnv) == "1" {
+		// Mirror production: main() captures at startup, the runner
+		// acks after registration.
+		captureHandshakeFD()
 		handshakeAck(expectedID, true)
 		os.Exit(0)
 	}

--- a/cli/gmux/cmd/gmux/main.go
+++ b/cli/gmux/cmd/gmux/main.go
@@ -17,6 +17,11 @@ func main() {
 	log.SetPrefix("gmux: ")
 	log.SetFlags(0)
 
+	// Consume GMUX_HANDSHAKE_FD before anything can fork: a lazily-read
+	// env var leaks into the session's environment and makes any nested
+	// gmux close an arbitrary fd of its own (see handshake.go).
+	captureHandshakeFD()
+
 	cmd, err := parseCLI(os.Args[1:])
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "gmux:", err)

--- a/cli/gmux/cmd/gmux/main.go
+++ b/cli/gmux/cmd/gmux/main.go
@@ -54,6 +54,8 @@ func main() {
 		os.Exit(cmdWait(cmd.ref, cmd.timeout))
 	case modeEdit:
 		runEdit(cmd.editFile)
+	case modeEditChild:
+		os.Exit(editChild(cmd.editFile))
 	case modeDaemon:
 		os.Exit(execGmuxd(cmd.daemonSub))
 	case modeAuth:

--- a/cli/gmux/cmd/gmux/main.go
+++ b/cli/gmux/cmd/gmux/main.go
@@ -52,6 +52,8 @@ func main() {
 		os.Exit(cmdSendKeys(cmd.ref, cmd.keys, cmd.keysLiteral))
 	case modeWait:
 		os.Exit(cmdWait(cmd.ref, cmd.timeout))
+	case modeEdit:
+		runEdit(cmd.editFile)
 	case modeDaemon:
 		os.Exit(execGmuxd(cmd.daemonSub))
 	case modeAuth:

--- a/cli/gmux/cmd/gmux/run.go
+++ b/cli/gmux/cmd/gmux/run.go
@@ -48,6 +48,14 @@ type runDirectives struct {
 	ResumeID    string
 	InitialCols int
 	InitialRows int
+
+	// ForceForeground disables the nested-gmux auto-detach: even when
+	// running inside an existing gmux session, attach the local terminal
+	// and block until the child exits. Required by callers with blocking
+	// semantics (`gmux edit` as $EDITOR must not return before the user
+	// closes the file), where detaching would silently return exit code 0
+	// to the invoking program (git would commit an unedited message).
+	ForceForeground bool
 }
 
 // runSession launches a new managed session for the given command.
@@ -76,7 +84,7 @@ func runSession(args []string, attach bool, dir runDirectives) {
 	// of doing PTY passthrough (which would nest PTY-within-PTY). The
 	// detached process registers with gmuxd and the session appears in the
 	// gmux UI. The original process returns immediately to the parent shell.
-	if os.Getenv("GMUX") == "1" && localterm.IsInteractive() {
+	if os.Getenv("GMUX") == "1" && localterm.IsInteractive() && !dir.ForceForeground {
 		spawnDetached(args, "started "+strings.Join(args, " ")+" in background (visible in gmux)", false)
 		return
 	}

--- a/cli/gmux/cmd/gmux/run.go
+++ b/cli/gmux/cmd/gmux/run.go
@@ -56,6 +56,11 @@ type runDirectives struct {
 	// closes the file), where detaching would silently return exit code 0
 	// to the invoking program (git would commit an unedited message).
 	ForceForeground bool
+
+	// ParentSessionID records the session this one was spawned from
+	// (e.g. `gmux edit` invoked as $EDITOR inside an existing session).
+	// Flows into session meta so the UI can relate the two.
+	ParentSessionID string
 }
 
 // runSession launches a new managed session for the given command.
@@ -156,15 +161,16 @@ func runSession(args []string, attach bool, dir runDirectives) {
 
 	// Create in-memory session state
 	state := session.New(session.Config{
-		ID:            sessionID,
-		Command:       args,
-		Cwd:           workDir,
-		Adapter:       a.Name(),
-		WorkspaceRoot: wsRoot,
-		Remotes:       remotes,
-		SocketPath:    sockPath,
-		BinaryHash:    binhash.Self(),
-		RunnerVersion: version,
+		ID:              sessionID,
+		Command:         args,
+		Cwd:             workDir,
+		Adapter:         a.Name(),
+		ParentSessionID: dir.ParentSessionID,
+		WorkspaceRoot:   wsRoot,
+		Remotes:         remotes,
+		SocketPath:      sockPath,
+		BinaryHash:      binhash.Self(),
+		RunnerVersion:   version,
 	})
 
 	// Common env vars — set for every child, per ADR-0005

--- a/cli/gmux/cmd/gmux/run.go
+++ b/cli/gmux/cmd/gmux/run.go
@@ -182,6 +182,7 @@ func runSession(args []string, attach bool, dir runDirectives) {
 		"GMUX_RUNNER_VERSION=" + version,
 	}
 	env = append(env, adapterEnv...)
+	env = append(env, sessionEditorEnv(os.LookupEnv, os.Executable)...)
 
 	interactive := localterm.IsInteractive()
 
@@ -382,6 +383,37 @@ func runSession(args []string, attach bool, dir runDirectives) {
 		fmt.Printf("exited:   %d\n", exitCode)
 	}
 	os.Exit(exitCode)
+}
+
+// sessionEditorEnv returns EDITOR/VISUAL entries pointing at `gmux
+// edit` for whichever of the two the invoking environment does NOT
+// already define. Inside a gmux session, programs that shell out to an
+// editor (git commit, crontab -e, ...) then open the file as a managed
+// editor session with zero user configuration.
+//
+// Default-if-unset, never override: duplicate env keys resolve
+// inconsistently across consumers (glibc getenv takes the first entry,
+// bash exports the last), so appending an override would be
+// unreliable — and a user who exported EDITOR=vim chose vim. Shell rc
+// files that export EDITOR, and git's core.editor, still outrank this
+// default, as they should.
+//
+// The value uses the runner's own absolute binary path (selfExe), not
+// a bare "gmux": dev builds and per-session runners aren't necessarily
+// on the child's PATH. Falls back to "gmux" if the path is unknown.
+func sessionEditorEnv(lookupEnv func(string) (string, bool), selfExe func() (string, error)) []string {
+	bin := "gmux"
+	if p, err := selfExe(); err == nil {
+		bin = p
+	}
+	editCmd := bin + " edit"
+	var out []string
+	for _, name := range []string{"EDITOR", "VISUAL"} {
+		if _, set := lookupEnv(name); !set {
+			out = append(out, name+"="+editCmd)
+		}
+	}
+	return out
 }
 
 // resolveAdapter builds the adapter registry (registered adapters first,

--- a/cli/gmux/internal/session/state.go
+++ b/cli/gmux/internal/session/state.go
@@ -25,6 +25,11 @@ type State struct {
 	WorkspaceRoot string            `json:"workspace_root,omitempty"`
 	Remotes       map[string]string `json:"remotes,omitempty"`
 
+	// ParentSessionID is the session this one was spawned from (e.g.
+	// `gmux edit` invoked as $EDITOR inside an existing session).
+	// Empty for top-level sessions. Immutable after creation.
+	ParentSessionID string `json:"parent_session_id,omitempty"`
+
 	// Process state (owned by runner)
 	Alive     bool   `json:"alive"`
 	Pid       int    `json:"pid"`
@@ -76,31 +81,33 @@ type Event struct {
 
 // Config for creating a new session state.
 type Config struct {
-	ID            string
-	Command       []string
-	Cwd           string
-	Adapter       string
-	SocketPath    string
-	BinaryHash    string
-	RunnerVersion string
-	WorkspaceRoot string
-	Remotes       map[string]string
+	ID              string
+	Command         []string
+	Cwd             string
+	Adapter         string
+	SocketPath      string
+	BinaryHash      string
+	RunnerVersion   string
+	WorkspaceRoot   string
+	Remotes         map[string]string
+	ParentSessionID string
 }
 
 // New creates a new session state.
 func New(cfg Config) *State {
 	return &State{
-		ID:            cfg.ID,
-		CreatedAt:     time.Now().UTC().Format(time.RFC3339),
-		Command:       cfg.Command,
-		Cwd:           cfg.Cwd,
-		Adapter:       cfg.Adapter,
-		WorkspaceRoot: cfg.WorkspaceRoot,
-		Remotes:       cfg.Remotes,
-		SocketPath:    cfg.SocketPath,
-		BinaryHash:    cfg.BinaryHash,
-		RunnerVersion: cfg.RunnerVersion,
-		Alive:         false,
+		ID:              cfg.ID,
+		CreatedAt:       time.Now().UTC().Format(time.RFC3339),
+		Command:         cfg.Command,
+		Cwd:             cfg.Cwd,
+		Adapter:         cfg.Adapter,
+		WorkspaceRoot:   cfg.WorkspaceRoot,
+		Remotes:         cfg.Remotes,
+		ParentSessionID: cfg.ParentSessionID,
+		SocketPath:      cfg.SocketPath,
+		BinaryHash:      cfg.BinaryHash,
+		RunnerVersion:   cfg.RunnerVersion,
+		Alive:           false,
 	}
 }
 

--- a/docs/adr/0009-verb-first-cli-and-frozen-top-level-namespace.md
+++ b/docs/adr/0009-verb-first-cli-and-frozen-top-level-namespace.md
@@ -219,3 +219,17 @@ For 2.0 we unify on a single **verb-first** grammar fronted by the
 - `--host` is dropped. `<id>@<peer>` is the **sole** way to address a
   peer session, which simplifies `matchSession` (the `host` parameter
   and the `--host`/`@suffix` reconciliation branch both go away).
+
+## Amendment (2026-07-06): `edit` joins the top-level namespace
+
+`gmux edit [file]` is added as a top-level verb. It cannot live under a
+namespace group because its primary use is `EDITOR="gmux edit"` — the
+string a third-party program execs must be a single terse invocation.
+
+This amends decision 5's "adding a new top-level verb is a breaking
+change requiring a major bump" in practice: the namespace remains
+*deliberately small and closed to casual growth*, but first-class
+session/tab types (of which the editor is the first; more are expected)
+warrant top-level verbs when the verb is itself an external interface
+contract like `$EDITOR`. Each such addition still requires an explicit
+amendment here.

--- a/packages/adapter/adapters/editor.go
+++ b/packages/adapter/adapters/editor.go
@@ -109,8 +109,9 @@ var FallbackEditors = []string{"nano", "vim", "vi"}
 // flags ("vim -u NONE"); otherwise the first of FallbackEditors on
 // PATH. getenv and lookPath are injected for tests.
 func ResolveFallbackEditor(getenv func(string) string, lookPath func(string) (string, error)) ([]string, error) {
-	if custom := getenv("GMUX_EDIT_FALLBACK"); custom != "" {
-		parts := strings.Fields(custom)
+	// strings.Fields first: a whitespace-only value yields no parts and
+	// is treated like unset instead of panicking on parts[0].
+	if parts := strings.Fields(getenv("GMUX_EDIT_FALLBACK")); len(parts) > 0 {
 		if _, err := lookPath(parts[0]); err != nil {
 			return nil, errors.New("GMUX_EDIT_FALLBACK editor not found: " + parts[0])
 		}

--- a/packages/adapter/adapters/editor.go
+++ b/packages/adapter/adapters/editor.go
@@ -1,0 +1,125 @@
+package adapters
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/gmuxapp/gmux/packages/adapter"
+)
+
+func init() {
+	All = append(All, NewEditor())
+}
+
+// Compile-time interface checks.
+var (
+	_ adapter.CommandTitler    = (*Editor)(nil)
+	_ adapter.Launchable       = (*Editor)(nil)
+	_ adapter.SessionRegistrar = (*Editor)(nil)
+)
+
+// Editor is the adapter for `gmux edit` sessions: a file opened for
+// editing, launched blocking so the verb is usable as $EDITOR (git
+// commit and friends). Today the session wraps a terminal editor via
+// the internal `gmux __edit-child` helper; a future release renders a
+// browser-based editor tab instead, keeping this adapter identity
+// ("editor" kind, /editor/ URLs, launcher entry) unchanged.
+//
+// Editor sessions are ephemeral: gmuxd auto-dismisses them from the
+// sidebar when their runner deregisters (see the /v1/deregister
+// handler), so no session state file is written and nothing is
+// rediscovered after a daemon restart.
+type Editor struct{}
+
+func NewEditor() *Editor { return &Editor{} }
+
+func (e *Editor) Name() string { return "editor" }
+
+// Discover reports whether an editor session can actually run here:
+// either the user pinned a fallback editor or one of the built-in
+// candidates is on PATH.
+func (e *Editor) Discover() bool {
+	_, err := ResolveFallbackEditor(os.Getenv, exec.LookPath)
+	return err == nil
+}
+
+// Match claims the internal `gmux __edit-child [path]` command that
+// both `gmux edit` and the launcher entry run. Matching the sentinel
+// (rather than the wrapped editor binary) keeps plain `gmux -- nano x`
+// sessions on the shell adapter.
+func (e *Editor) Match(command []string) bool {
+	return len(command) >= 2 &&
+		adapter.BaseName(command[0]) == "gmux" &&
+		command[1] == "__edit-child"
+}
+
+func (e *Editor) Env(_ adapter.EnvContext) []string { return nil }
+
+func (e *Editor) Monitor(_ []byte) *adapter.Event { return nil }
+
+// editFilePath extracts the file argument from a matched
+// `gmux __edit-child [path]` command; empty when launched without a
+// path (the child prompts for one interactively).
+func editFilePath(command []string) string {
+	if len(command) >= 3 {
+		return command[2]
+	}
+	return ""
+}
+
+// CommandTitle shows the file being edited, not the internal command.
+func (e *Editor) CommandTitle(command []string) string {
+	if p := editFilePath(command); p != "" {
+		return filepath.Base(p)
+	}
+	return "editor"
+}
+
+func (e *Editor) Launchers() []adapter.Launcher {
+	return []adapter.Launcher{{
+		ID:          "editor",
+		Label:       "Editor",
+		Command:     []string{"gmux", "__edit-child"},
+		Description: "Edit a file",
+	}}
+}
+
+// OnRegister derives the slug from the edited file's name so URLs read
+// /<project>/editor/<file-slug>. No state file is written: editor
+// sessions are ephemeral by design (auto-dismissed on close).
+func (e *Editor) OnRegister(_, _ string, command []string) (adapter.RegistrationInfo, error) {
+	slug := adapter.Slugify(filepath.Base(editFilePath(command)))
+	if slug == "" {
+		slug = "editor"
+	}
+	return adapter.RegistrationInfo{Slug: slug}, nil
+}
+
+// FallbackEditors are probed in order when GMUX_EDIT_FALLBACK is unset.
+// Deliberately NOT $EDITOR/$VISUAL: the whole point of `gmux edit` is
+// to BE the user's $EDITOR, so consulting it would recurse.
+var FallbackEditors = []string{"nano", "vim", "vi"}
+
+// ResolveFallbackEditor picks the terminal editor an editor session
+// wraps today (the future browser-editor tab replaces this, not the
+// verb). GMUX_EDIT_FALLBACK, when set, wins verbatim and may carry
+// flags ("vim -u NONE"); otherwise the first of FallbackEditors on
+// PATH. getenv and lookPath are injected for tests.
+func ResolveFallbackEditor(getenv func(string) string, lookPath func(string) (string, error)) ([]string, error) {
+	if custom := getenv("GMUX_EDIT_FALLBACK"); custom != "" {
+		parts := strings.Fields(custom)
+		if _, err := lookPath(parts[0]); err != nil {
+			return nil, errors.New("GMUX_EDIT_FALLBACK editor not found: " + parts[0])
+		}
+		return parts, nil
+	}
+	for _, ed := range FallbackEditors {
+		if _, err := lookPath(ed); err == nil {
+			return []string{ed}, nil
+		}
+	}
+	return nil, errors.New("no editor found (tried " + strings.Join(FallbackEditors, ", ") + "); set GMUX_EDIT_FALLBACK")
+}

--- a/packages/adapter/adapters/editor_test.go
+++ b/packages/adapter/adapters/editor_test.go
@@ -1,0 +1,146 @@
+package adapters
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// lookPathAllowing returns a lookPath stub that succeeds only for the
+// given names.
+func lookPathAllowing(names ...string) func(string) (string, error) {
+	set := map[string]bool{}
+	for _, n := range names {
+		set[n] = true
+	}
+	return func(name string) (string, error) {
+		if set[name] {
+			return "/usr/bin/" + name, nil
+		}
+		return "", errors.New("not found")
+	}
+}
+
+func noEnv(string) string { return "" }
+
+func TestEditorMatch(t *testing.T) {
+	e := NewEditor()
+	match := [][]string{
+		{"gmux", "__edit-child"},
+		{"gmux", "__edit-child", "/tmp/notes.txt"},
+		{"/usr/local/bin/gmux", "__edit-child", "/tmp/notes.txt"},
+	}
+	for _, cmd := range match {
+		if !e.Match(cmd) {
+			t.Errorf("Match(%v) = false, want true", cmd)
+		}
+	}
+	noMatch := [][]string{
+		{},
+		{"gmux"},
+		{"nano", "/tmp/notes.txt"},          // plain editor run stays on shell adapter
+		{"gmux", "edit", "/tmp/notes.txt"},  // outer verb, not the sentinel
+		{"other", "__edit-child", "/tmp/x"}, // not gmux
+	}
+	for _, cmd := range noMatch {
+		if e.Match(cmd) {
+			t.Errorf("Match(%v) = true, want false", cmd)
+		}
+	}
+}
+
+func TestEditorCommandTitle(t *testing.T) {
+	e := NewEditor()
+	if got := e.CommandTitle([]string{"gmux", "__edit-child", "/home/x/COMMIT_EDITMSG"}); got != "COMMIT_EDITMSG" {
+		t.Errorf("title = %q, want COMMIT_EDITMSG", got)
+	}
+	if got := e.CommandTitle([]string{"gmux", "__edit-child"}); got != "editor" {
+		t.Errorf("title = %q, want editor", got)
+	}
+}
+
+func TestEditorOnRegister(t *testing.T) {
+	e := NewEditor()
+	info, err := e.OnRegister("id1", "/tmp", []string{"gmux", "__edit-child", "/tmp/My Notes.TXT"})
+	if err != nil || info.Slug != "my-notes-txt" {
+		t.Errorf("slug = %q, err = %v; want my-notes-txt", info.Slug, err)
+	}
+	info, err = e.OnRegister("id2", "/tmp", []string{"gmux", "__edit-child"})
+	if err != nil || info.Slug != "editor" {
+		t.Errorf("slug = %q, err = %v; want editor", info.Slug, err)
+	}
+}
+
+func TestEditorRegisteredWithLauncher(t *testing.T) {
+	if FindByAdapter("editor") == nil {
+		t.Fatal("editor adapter not registered in All")
+	}
+	ls := NewEditor().Launchers()
+	if len(ls) != 1 || ls[0].ID != "editor" || strings.Join(ls[0].Command, " ") != "gmux __edit-child" {
+		t.Errorf("launchers = %+v", ls)
+	}
+}
+
+func TestResolveFallbackEditor(t *testing.T) {
+	t.Run("prefers nano", func(t *testing.T) {
+		got, err := ResolveFallbackEditor(noEnv, lookPathAllowing("nano", "vim", "vi"))
+		if err != nil || strings.Join(got, " ") != "nano" {
+			t.Errorf("got %v, %v; want [nano]", got, err)
+		}
+	})
+
+	t.Run("falls through PATH order", func(t *testing.T) {
+		got, err := ResolveFallbackEditor(noEnv, lookPathAllowing("vi"))
+		if err != nil || strings.Join(got, " ") != "vi" {
+			t.Errorf("got %v, %v; want [vi]", got, err)
+		}
+	})
+
+	t.Run("errors with hint when nothing found", func(t *testing.T) {
+		_, err := ResolveFallbackEditor(noEnv, lookPathAllowing())
+		if err == nil || !strings.Contains(err.Error(), "GMUX_EDIT_FALLBACK") {
+			t.Errorf("want error mentioning GMUX_EDIT_FALLBACK, got %v", err)
+		}
+	})
+
+	t.Run("GMUX_EDIT_FALLBACK wins and may carry flags", func(t *testing.T) {
+		env := func(k string) string {
+			if k == "GMUX_EDIT_FALLBACK" {
+				return "vim -u NONE"
+			}
+			return ""
+		}
+		got, err := ResolveFallbackEditor(env, lookPathAllowing("vim", "nano"))
+		if err != nil || strings.Join(got, " ") != "vim -u NONE" {
+			t.Errorf("got %v, %v; want [vim -u NONE]", got, err)
+		}
+	})
+
+	t.Run("GMUX_EDIT_FALLBACK missing from PATH errors", func(t *testing.T) {
+		env := func(k string) string {
+			if k == "GMUX_EDIT_FALLBACK" {
+				return "myeditor"
+			}
+			return ""
+		}
+		_, err := ResolveFallbackEditor(env, lookPathAllowing("nano"))
+		if err == nil || !strings.Contains(err.Error(), "myeditor") {
+			t.Errorf("want error naming myeditor, got %v", err)
+		}
+	})
+
+	// $EDITOR must never be consulted: `EDITOR="gmux edit"` is the
+	// primary use case and reading it back would recurse.
+	t.Run("ignores EDITOR", func(t *testing.T) {
+		env := func(k string) string {
+			if k == "EDITOR" {
+				return "gmux edit"
+			}
+			return ""
+		}
+		got, err := ResolveFallbackEditor(env, lookPathAllowing("nano"))
+		if err != nil || strings.Join(got, " ") != "nano" {
+			t.Errorf("got %v, %v; want [nano]", got, err)
+		}
+	})
+}

--- a/packages/adapter/adapters/editor_test.go
+++ b/packages/adapter/adapters/editor_test.go
@@ -116,6 +116,21 @@ func TestResolveFallbackEditor(t *testing.T) {
 		}
 	})
 
+	// Regression (greptile P1): a whitespace-only value must behave
+	// like unset — fall through to the chain — not panic on parts[0].
+	t.Run("GMUX_EDIT_FALLBACK whitespace-only treated as unset", func(t *testing.T) {
+		env := func(k string) string {
+			if k == "GMUX_EDIT_FALLBACK" {
+				return "   \t "
+			}
+			return ""
+		}
+		got, err := ResolveFallbackEditor(env, lookPathAllowing("nano"))
+		if err != nil || strings.Join(got, " ") != "nano" {
+			t.Errorf("got %v, %v; want [nano]", got, err)
+		}
+	})
+
 	t.Run("GMUX_EDIT_FALLBACK missing from PATH errors", func(t *testing.T) {
 		env := func(k string) string {
 			if k == "GMUX_EDIT_FALLBACK" {

--- a/packages/protocol/src/session.ts
+++ b/packages/protocol/src/session.ts
@@ -16,6 +16,10 @@ export const SessionSchema = z.object({
   workspace_root: z.string().optional(),
   remotes: z.record(z.string()).optional(),
   adapter: z.string().default('shell'),
+  // Session this one was spawned from (e.g. `gmux edit` invoked as
+  // $EDITOR inside an existing session). The UI places the child
+  // directly under its parent in the sidebar.
+  parent_session_id: z.string().optional(),
   alive: z.boolean(),
   pid: z.number().optional().nullable(),
   exit_code: z.number().optional().nullable(),

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -1318,6 +1318,18 @@ func serve(stderr io.Writer) int {
 		// already marked it alive: false. Just clean up the subscription.
 		subs.Unsubscribe(req.SessionID)
 		log.Printf("deregister: %s", req.SessionID)
+
+		// Editor sessions are ephemeral: a closed editor has no replay
+		// value (its scrollback is a text editor screen) and would only
+		// clutter the sidebar, so auto-dismiss it on close instead of
+		// keeping a dead session around. A general "ephemeral session"
+		// flag is future work; for now the adapter kind is the marker.
+		if sess, ok := sessions.Get(req.SessionID); ok && sess.Adapter == "editor" {
+			projectMgr.DismissSession(req.SessionID, sess.Slug)
+			sessions.Remove(req.SessionID)
+			forgetMeta(req.SessionID)
+			log.Printf("deregister: auto-dismissed editor session %s", req.SessionID)
+		}
 		writeJSON(w, map[string]any{"ok": true})
 	})
 

--- a/services/gmuxd/internal/store/store.go
+++ b/services/gmuxd/internal/store/store.go
@@ -28,15 +28,19 @@ type Session struct {
 	Adapter       string            `json:"adapter"`
 	WorkspaceRoot string            `json:"workspace_root,omitempty"`
 	Remotes       map[string]string `json:"remotes,omitempty"`
-	Alive         bool              `json:"alive"`
-	Pid           int               `json:"pid,omitempty"`
-	ExitCode      *int              `json:"exit_code,omitempty"`
-	StartedAt     string            `json:"started_at,omitempty"`
-	ExitedAt      string            `json:"exited_at,omitempty"`
-	Title         string            `json:"title,omitempty"`
-	Subtitle      string            `json:"subtitle,omitempty"`
-	Status        *Status           `json:"status"`
-	Unread        bool              `json:"unread"`
+	// ParentSessionID is the session this one was spawned from (e.g.
+	// `gmux edit` invoked as $EDITOR inside an existing session). The
+	// UI uses it to place the child next to its parent in the sidebar.
+	ParentSessionID string  `json:"parent_session_id,omitempty"`
+	Alive           bool    `json:"alive"`
+	Pid             int     `json:"pid,omitempty"`
+	ExitCode        *int    `json:"exit_code,omitempty"`
+	StartedAt       string  `json:"started_at,omitempty"`
+	ExitedAt        string  `json:"exited_at,omitempty"`
+	Title           string  `json:"title,omitempty"`
+	Subtitle        string  `json:"subtitle,omitempty"`
+	Status          *Status `json:"status"`
+	Unread          bool    `json:"unread"`
 
 	// LastActivityAt timestamps the most recent noteworthy state
 	// transition for this session, used by the UI to surface
@@ -125,6 +129,7 @@ func (s Session) MarshalJSON() ([]byte, error) {
 		Adapter          string            `json:"adapter"`
 		WorkspaceRoot    string            `json:"workspace_root,omitempty"`
 		Remotes          map[string]string `json:"remotes,omitempty"`
+		ParentSessionID  string            `json:"parent_session_id,omitempty"`
 		Alive            bool              `json:"alive"`
 		Pid              int               `json:"pid,omitempty"`
 		ExitCode         *int              `json:"exit_code,omitempty"`
@@ -149,7 +154,8 @@ func (s Session) MarshalJSON() ([]byte, error) {
 	return json.Marshal(wire{
 		ID: s.ID, Peer: s.Peer, CreatedAt: s.CreatedAt, Command: s.Command,
 		Cwd: s.Cwd, Adapter: s.Adapter, WorkspaceRoot: s.WorkspaceRoot,
-		Remotes: s.Remotes, Alive: s.Alive, Pid: s.Pid,
+		Remotes: s.Remotes, ParentSessionID: s.ParentSessionID,
+		Alive: s.Alive, Pid: s.Pid,
 		ExitCode: s.ExitCode, StartedAt: s.StartedAt, ExitedAt: s.ExitedAt,
 		Title: s.Title, Subtitle: s.Subtitle, Status: s.Status,
 		Unread: s.Unread, Resumable: s.Resumable,

--- a/services/gmuxd/internal/store/store_test.go
+++ b/services/gmuxd/internal/store/store_test.go
@@ -1128,6 +1128,7 @@ func fullyPopulatedSession() Session {
 		Adapter:          "pi",
 		WorkspaceRoot:    "/tmp/work",
 		Remotes:          map[string]string{"origin": "github.com/x/y"},
+		ParentSessionID:  "sess-parent",
 		Alive:            true,
 		Pid:              42,
 		ExitCode:         &exit,


### PR DESCRIPTION
## What

Adds `gmux edit [file]`: a blocking, exit-code-propagating verb designed to be used as `$EDITOR` (`EDITOR="gmux edit" git commit` works end to end), backed by a proper **`editor` adapter** — the first non-shell, non-agent session type and the groundwork for the planned browser-based editor tab.

Two commits:
1. **MVP verb** — `gmux edit <file>` wraps a fallback terminal editor in a managed session.
2. **Editor adapter** — promotes it to a first-class `editor` session kind with launcher-menu entry, `/editor/` URLs, parent-session linkage, and ephemeral lifecycle.

## How it works

- `gmux edit [file]` runs the internal `gmux __edit-child [path]` sentinel as the session's child command; the new `Editor` adapter (`packages/adapter/adapters/editor.go`) matches that sentinel — so plain `gmux -- nano x` stays on the shell adapter.
- The child prompts for a path when none was given (`File to edit: `), which is exactly what the **+ launcher menu** entry runs, since the menu can't parameterize a path. It then `exec`s the fallback editor (`GMUX_EDIT_FALLBACK` → `nano` → `vim` → `vi`; **never** `$EDITOR`/`$VISUAL`, which would recurse), so the editor's exit code is the session's, verbatim.
- **Blocking contract**: new `runDirectives.ForceForeground` bypasses the nested-gmux auto-detach. Without it, `git commit` inside a gmux session would detach and instantly get exit 0 — committing an unedited message.
- **Parent linkage**: when invoked as `$EDITOR` inside an existing session, the invoking session's id is recorded as `parent_session_id` (runner state → store → wire → protocol/web types). The sidebar places a child directly under its parent via a small post-sort pass (`placeChildSessions`). A full hierarchy/tree UI is deliberately out of scope.
- **Ephemeral lifecycle**: gmuxd auto-dismisses editor sessions on runner deregister — a closed editor has no replay value and would only clutter the sidebar.
- **ADR 0009 amendment**: `edit` joins the frozen top-level namespace (it must be a single terse invocation to serve as `$EDITOR`); the amendment notes more first-class tab-type verbs are expected, each via explicit amendment.
- Slugs/titles derive from the file basename, so URLs read `/<project>/editor/<file-slug>` from day one.

## Forward compatibility

The verb's interface (0–1 paths, blocking, exit code) is frozen; the future browser editor (CodeMirror 6; feasibility notes in `.memory/report-editor-tab-type.md` on the branch workspace) replaces only the child/rendering side: the runner will serve `GET/PUT /file` + `POST /close {exit_code}` on its existing per-session socket (close-without-save → exit 1, so git aborts), and the web main panel branches on `adapter === 'editor'`. Because the daemon already proxies runner sockets for peers, remote/headless editing through the hub will work like terminals do.

## Related future work (not built here)

- Browser `EditorView` (CodeMirror 6) + file protocol on the runner socket.
- Launcher-menu path-picking UX (replaces the terminal prompt).
- A general **"ephemeral session" flag** — the auto-dismiss currently keys on `Kind == "editor"`; generalizing it is a separate discussion.

## Testing

- New: adapter match/title/slug/launcher + fallback-editor resolution; CLI parse cases; store wire-marshal field; web `placeChildSessions` ordering tests.
- Full suite green, except `TestPiCommandsWithExtensionInjected` under moon — **pre-existing flake**: it times out identically on unrelated branches/workspaces and passes with direct `go test` (it execs the real `pi` binary; unrelated to this change).