### PR TITLE
fix(web): put Up before Down in single-row mobile toolbar layouts

### DIFF
--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -433,8 +433,8 @@ function MobileTerminalBar({
       <button class={`${armedClass(altArmed)} mk-alt`} disabled={!canSend} aria-pressed={altArmed} onClick={onToggleAlt} title={altArmed ? 'Alt armed for next key' : 'Arm Alt'}><span class="mkey-face">alt</span></button>
       <button class="mobile-bottom-action mk-wl" disabled={!canSend} {...repeat(() => sendWord('\x1b[D'), WORD_REPEAT_MS)} title="Word left"><span class="mkey-face"><IconWordLeft /></span></button>
       <button class="mobile-bottom-action mk-al" disabled={!canSend} {...repeat(() => sendKey('\x1b[D'), ARROW_REPEAT_MS)} title="Left arrow"><span class="mkey-face"><IconLeft /></span></button>
-      <button class="mobile-bottom-action mk-ad" disabled={!canSend} {...repeat(() => sendKey('\x1b[B'), ARROW_REPEAT_MS)} title="Down arrow"><span class="mkey-face"><IconDown /></span></button>
       <button class="mobile-bottom-action mk-au" disabled={!canSend} {...repeat(() => sendKey('\x1b[A'), ARROW_REPEAT_MS)} title="Up arrow"><span class="mkey-face"><IconUp /></span></button>
+      <button class="mobile-bottom-action mk-ad" disabled={!canSend} {...repeat(() => sendKey('\x1b[B'), ARROW_REPEAT_MS)} title="Down arrow"><span class="mkey-face"><IconDown /></span></button>
       <button class="mobile-bottom-action mk-ar" disabled={!canSend} {...repeat(() => sendKey('\x1b[C'), ARROW_REPEAT_MS)} title="Right arrow"><span class="mkey-face"><IconRight /></span></button>
       <button class="mobile-bottom-action mk-wr" disabled={!canSend} {...repeat(() => sendWord('\x1b[C'), WORD_REPEAT_MS)} title="Word right"><span class="mkey-face"><IconWordRight /></span></button>
       {terminalScrolledUp.value && (

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -3045,7 +3045,7 @@ body {
   .mobile-bottom-bar {
     grid-template-columns: repeat(10, 1fr);
     grid-template-rows: 40px;
-    grid-template-areas: 'menu esc tab ctrl alt al ad au ar send';
+    grid-template-areas: 'menu esc tab ctrl alt al au ad ar send';
   }
   /* Word-jumps aren't part of the single-row layout. */
   .mk-wl,
@@ -3073,7 +3073,7 @@ body {
 @media (pointer: coarse) and (min-width: 820px) {
   .mobile-bottom-bar {
     grid-template-columns: repeat(12, 1fr);
-    grid-template-areas: 'menu esc tab ctrl alt wl al ad au ar wr send';
+    grid-template-areas: 'menu esc tab ctrl alt wl al au ad ar wr send';
   }
   .mk-wl,
   .mk-wr {


### PR DESCRIPTION
The mobile button row's single-row layouts (landscape ≥600px, tablet ≥820px) ordered the arrows **← ↓ ↑ →**, a leftover from the j/k analogy. That muscle-memory argument applies to touch-typed physical keys, not visually scanned on-screen buttons, and it clashed with everything else:

- **gmux's own phone grid** already places Up directly *above* Down (inverted-T), so the single-row collapse should read that column top-to-bottom: ↑ before ↓.
- **Termux's default extra-keys** is inverted-T too — `[['ESC','/','-','HOME','UP','END','PGUP'],['TAB','CTRL','ALT','LEFT','DOWN','RIGHT','PGDN']]` ([TermuxPropertyConstants.java](https://github.com/termux/termux-app/blob/401bbe54b8f4e68302b1ff70678015a24628fb1d/termux-shared/src/main/java/com/termux/shared/termux/settings/properties/TermuxPropertyConstants.java#L328-L329)). Their commented-out *legacy* single-row default was `..., DOWN, UP` — the same jk order — and they abandoned it.
- **Physical single-row arrow clusters** (Apple Magic Keyboard, most laptops) use left / half-height up-over-down / right — Up on top.
- **Usage**: Up (previous command, scrollback) is by far the most-pressed arrow.

### Change
- `styles.css`: `al ad au ar` → `al au ad ar` in both coarse-pointer single-row `grid-template-areas`.
- `main.tsx`: swapped the two buttons so DOM/tab order matches. Phone 2-row layout unchanged (already correct).

Buttons are unreleased, so no compat concerns.

`pnpm lint` ✓ · gmux-web tests 548/548 ✓ (Go `TestPiCommandsWithExtensionInjected` e2e timeouts are a pre-existing workspace/env issue, unrelated).