### PR TITLE
security(netauth): enforce same-origin on cookie-authed mutations and WS upgrades

### DIFF
--- a/apps/website/src/content/docs/security.md
+++ b/apps/website/src/content/docs/security.md
@@ -49,6 +49,27 @@ This is acceptable when:
 For remote access without managing certificates yourself, use [Tailscale](/remote-access/). For container deployments, see [Running in Docker](/running-in-docker/) for examples with WireGuard and Traefik.
 :::
 
+### Browser sessions: same-origin enforcement
+
+The two credentials behave very differently in a browser, so they are constrained differently:
+
+- **Bearer header** — attached explicitly by the client. A web page on another origin cannot forge it, so bearer-authenticated requests carry **no origin constraint**. CLI, API, and hub↔spoke peering traffic all use bearer auth and are unaffected by everything below.
+- **Session cookie** — attached *ambiently* by the browser, regardless of which page initiated the request. Cookie-authenticated requests must therefore prove they came from the gmux UI itself.
+
+The cookie is `HttpOnly` and `SameSite=Strict` (and `Secure` when served over HTTPS), which blocks classic cross-**site** attacks like DNS rebinding: a malicious page on `evil.com` that resolves to your loopback address gets neither the token nor the cookie. But `SameSite` reasons about *sites*, not *origins* — and `ts.net` is on the [Public Suffix List](https://publicsuffix.org/), which makes `<tailnet>.ts.net` the registrable domain. Every other web service on your own tailnet is **same-site** with gmux, so `SameSite=Strict` does nothing between them. A compromised or XSS'd co-tenant tailnet service could otherwise ride the cookie into gmux's control plane — which, via a WebSocket to a terminal, is code execution.
+
+So for cookie-authenticated requests, gmuxd enforces **same-origin**:
+
+- **WebSocket upgrades** must originate from the gmux origin itself. This closes cross-origin WebSocket hijacking of terminal I/O, the highest-value path.
+- **State-changing requests** (`POST`/`PUT`/`PATCH`/`DELETE` on `/v1/`) must carry `Sec-Fetch-Site: same-origin` or an `Origin` header matching the request's own host. Anything else gets `403`.
+- **Reads over `GET`** are exempt: gmuxd never emits CORS headers, so a foreign page cannot read the response anyway.
+
+The check is a single dynamic comparison against the request's **own** Host (honoring `X-Forwarded-Host` behind proxies that rewrite it) — whatever hostname the browser used to load the UI is, by definition, the hostname it sends in both `Origin` and `Host`. Localhost, LAN IPs, tailnet FQDNs, and reverse-proxy vhosts (e.g. Traefik routing `gmux.example.com`) all work without configuration.
+
+**Why not a hostname allowlist?** An earlier design validated the `Host` header against a configured list of trusted names (`GMUXD_TRUSTED_HOSTS`). It was rejected: an allowlist must enumerate every name the daemon can legitimately be reached by — localhost, the bind host, every tailnet FQDN, every reverse-proxy hostname — which is brittle and easy to misconfigure into a lockout, while adding nothing the token, the cookie attributes, and the same-origin check don't already provide.
+
+The UI also sends `Content-Security-Policy: frame-ancestors 'none'` and `X-Frame-Options: DENY` on every response, so gmux can never be embedded in another page's frame.
+
 ## Remote access: Tailscale
 
 Remote access is available via a separate, optional Tailscale (tsnet) listener. When enabled, gmuxd joins your tailnet and serves on `https://hostname.your-tailnet.ts.net`. See [Remote Access](/remote-access) for setup.

--- a/apps/website/src/content/docs/security.md
+++ b/apps/website/src/content/docs/security.md
@@ -70,6 +70,8 @@ The check is a single dynamic comparison against the request's **own** Host (hon
 
 The UI also sends `Content-Security-Policy: frame-ancestors 'none'` and `X-Frame-Options: DENY` on every response, so gmux can never be embedded in another page's frame.
 
+The full decision record is [ADR 0020](https://github.com/gmuxapp/gmux/blob/main/docs/adr/0020-same-origin-enforcement-for-cookie-auth.md).
+
 ## Remote access: Tailscale
 
 Remote access is available via a separate, optional Tailscale (tsnet) listener. When enabled, gmuxd joins your tailnet and serves on `https://hostname.your-tailnet.ts.net`. See [Remote Access](/remote-access) for setup.

--- a/docs/adr/0020-same-origin-enforcement-for-cookie-auth.md
+++ b/docs/adr/0020-same-origin-enforcement-for-cookie-auth.md
@@ -1,0 +1,116 @@
+# ADR 0020: Same-origin enforcement for cookie-authenticated requests
+
+**Status:** Accepted
+**Date:** 2026-07-06
+**Related:** ADR 0008 (peer authentication via token); supersedes the
+documentation approach attempted in PR #292
+
+## Context
+
+`netauth.Middleware` gates the network listeners (TCP and tsnet) with two
+credentials:
+
+- **Bearer token** (`Authorization: Bearer …`) — set explicitly by CLI,
+  API clients, and hub↔spoke peering.
+- **Session cookie** (`gmux-token`, `HttpOnly SameSite=Strict`) — set by
+  the browser login flow and attached *ambiently* by the browser to every
+  request targeting the gmux host, regardless of which page initiated it.
+
+PR #292 argued this was sufficient to skip WebSocket `Origin` checks
+(`AcceptOptions.InsecureSkipVerify`) and Host validation entirely: the
+token blocks DNS rebinding, and `SameSite=Strict` blocks cross-site
+cookie attachment. That reasoning holds for **cross-site** attackers but
+conflates *site* with *origin*:
+
+`ts.net` (and `*.c.ts.net`) is on the Public Suffix List, so the
+registrable domain — the "site" for SameSite purposes — is
+`<tailnet>.ts.net`. **Every other web service on the user's own tailnet
+is same-site with gmux.** `SameSite=Strict` provides no isolation between
+same-site origins, so the cookie *is* attached on requests from
+`anything-else.<tailnet>.ts.net` to gmux. A compromised or XSS'd
+co-tenant tailnet service can therefore CSRF the mutating `/v1/`
+endpoints or hijack the `/ws/{session}` WebSocket — which carries raw PTY
+I/O, i.e. remote code execution via `POST /v1/launch` or keystroke
+injection. Tailscale's `WhoIs` gate does not help: the request arrives
+from the user's own authorized device.
+
+An earlier iteration of #292 tried a **Host-header allowlist**
+(`GMUXD_TRUSTED_HOSTS`): validate `Host` against a configured list of
+trusted names. It was rejected, and that rejection stands: the daemon is
+legitimately reachable by many names at once — `localhost`, LAN IPs, the
+tailnet FQDN, any reverse-proxy vhost (the documented Traefik + PocketID
+pattern) — so an allowlist must enumerate them all, is brittle, and
+misconfigures into a lockout. It also adds nothing against DNS rebinding,
+which the token already defeats (a rebound page has neither token nor
+cookie).
+
+## Decision
+
+**Cookie-authenticated requests must be same-origin. Bearer-authenticated
+requests carry no origin constraint.**
+
+The middleware distinguishes which credential authenticated the request:
+
+1. **Bearer** → pass through. A bearer header cannot be forged
+   cross-origin (a hostile page cannot make the victim's browser attach
+   it), so CLI, API, and peering traffic is untouched.
+2. **Cookie** → for WebSocket upgrades and mutating methods
+   (`POST`/`PUT`/`PATCH`/`DELETE`), require proof of same-origin;
+   otherwise `403`. Plain `GET` reads stay unconstrained because gmuxd
+   never emits CORS headers, so a foreign page cannot read the response;
+   WS upgrades are checked despite being `GET` because a hijacked socket
+   *is* readable cross-origin.
+
+Same-origin proof, in order:
+
+- `Sec-Fetch-Site: same-origin` → allow; `cross-site`/`same-site` →
+  deny (an explicit browser attestation wins over everything else —
+  `same-site` is exactly the ts.net co-tenant case).
+- Otherwise `Origin` must match the request's **own** `Host` (or the
+  first hop of `X-Forwarded-Host` behind a Host-rewriting proxy), with
+  default ports normalized.
+
+Comparing against the request's own host — rather than any configured
+name — is what makes this a check and not an allowlist: whatever hostname
+the browser used to load the UI is, by definition, the hostname it sends
+in both `Origin` and `Host`. Every legitimate deployment shape works with
+zero configuration.
+
+Enforcement lives in `netauth.Middleware`, i.e. at the node terminating
+the browser connection. The hub→spoke hop of proxied WebSockets uses
+bearer auth (`apiclient.DialWS`) and is exempt at the spoke, which is
+correct: the spoke cannot see the browser's origin, and the hub already
+enforced it.
+
+Trusting the client-suppliable `X-Forwarded-Host` fallback is safe
+because the check only defends against *browser-mediated* attacks (a
+non-browser attacker holding the cookie holds the token itself). A
+hostile page cannot reach the fallback with a matching pair: any browser
+able to attach that custom header also sends `Sec-Fetch-Site` (handled
+first), and the custom header makes the request non-simple, forcing a
+CORS preflight that fails.
+
+Accompanying hardening in the same change:
+
+- `Content-Security-Policy: frame-ancestors 'none'` and
+  `X-Frame-Options: DENY` on every network-listener response
+  (clickjacking → keystroke injection).
+- The auth cookie gains `Secure` when the login transport is TLS
+  (`r.TLS` or `X-Forwarded-Proto: https`), and stays non-Secure over
+  plain-http localhost so local login keeps working.
+
+## Consequences
+
+- A same-site (or any cross-origin) page can no longer drive the
+  cookie-authed control plane; the ts.net co-tenant RCE path is closed.
+- All bearer-token flows — CLI, integrations, peering — are byte-for-byte
+  unaffected.
+- `curl`-style clients replaying the cookie as a header lose mutating
+  access; they must send the same value as a bearer token instead. This
+  is intentional: the cookie is a browser credential.
+- Browsers old enough to send neither `Sec-Fetch-Site` nor `Origin` on
+  non-GET requests (pre-2011) cannot mutate state. Accepted.
+- The library-level WS origin check stays disabled
+  (`InsecureSkipVerify: true` at the `websocket.Accept` call sites):
+  its blanket `Origin == Host` rule would break bearer clients that send
+  no `Origin`. The middleware performs the auth-aware check upstream.

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -1805,6 +1805,8 @@ func serve(stderr io.Writer) int {
 	// ── Presence WebSocket ──
 
 	mux.HandleFunc("/v1/presence", func(w http.ResponseWriter, r *http.Request) {
+		// InsecureSkipVerify: Origin enforcement for cookie-authed
+		// upgrades happens upstream in netauth.Middleware.
 		conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
 			InsecureSkipVerify: true,
 		})

--- a/services/gmuxd/internal/apiclient/client.go
+++ b/services/gmuxd/internal/apiclient/client.go
@@ -364,6 +364,9 @@ func (c *Client) ProxyWS(w http.ResponseWriter, r *http.Request, sessionID strin
 	// the storm returns the moment you view a peer's session on mobile.
 	// The hub->spoke hop (DialWS) is uncompressed too. Revisit #242's
 	// bandwidth goal another way (e.g. bounding replay size) if needed.
+	//
+	// InsecureSkipVerify: Origin enforcement for cookie-authed upgrades
+	// happens upstream in netauth.Middleware on the hub.
 	clientConn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
 		InsecureSkipVerify: true,
 	})

--- a/services/gmuxd/internal/netauth/netauth.go
+++ b/services/gmuxd/internal/netauth/netauth.go
@@ -203,16 +203,32 @@ func isSameOrigin(r *http.Request) bool {
 	// Behind a reverse proxy that rewrites Host, the browser-facing host
 	// arrives in X-Forwarded-Host (Traefik forwards Host verbatim by
 	// default, but not every proxy does).
-	if xfh := r.Header.Get("X-Forwarded-Host"); xfh != "" {
-		// Take the first hop if the header is a comma-separated chain.
-		if i := strings.IndexByte(xfh, ','); i >= 0 {
-			xfh = xfh[:i]
-		}
-		if hostsMatch(u.Host, strings.TrimSpace(xfh)) {
+	//
+	// Trusting a client-suppliable header here is safe against browser-
+	// mediated attacks, which are the only ones this check defends
+	// against (a non-browser attacker holding the cookie holds the token
+	// itself and needs no CSRF). A hostile page cannot reach this branch
+	// with a matching pair: any browser that can attach a custom
+	// X-Forwarded-Host via fetch() also sends Sec-Fetch-Site (handled
+	// above, returns false for cross-site/same-site), and the custom
+	// header makes the request non-simple, forcing a CORS preflight that
+	// fails because gmuxd never emits Access-Control-Allow-* headers.
+	// Browser WebSocket APIs cannot set custom headers at all.
+	if xfh := firstForwarded(r.Header.Get("X-Forwarded-Host")); xfh != "" {
+		if hostsMatch(u.Host, xfh) {
 			return true
 		}
 	}
 	return false
+}
+
+// firstForwarded returns the first hop of a possibly comma-separated
+// X-Forwarded-* header value, trimmed.
+func firstForwarded(v string) string {
+	if i := strings.IndexByte(v, ','); i >= 0 {
+		v = v[:i]
+	}
+	return strings.TrimSpace(v)
 }
 
 // hostsMatch compares two host[:port] strings, treating explicit default
@@ -314,7 +330,7 @@ func requestIsTLS(r *http.Request) bool {
 	if r.TLS != nil {
 		return true
 	}
-	return strings.EqualFold(r.Header.Get("X-Forwarded-Proto"), "https")
+	return strings.EqualFold(firstForwarded(r.Header.Get("X-Forwarded-Proto")), "https")
 }
 
 func serveLoginPage(w http.ResponseWriter, errMsg string) {

--- a/services/gmuxd/internal/netauth/netauth.go
+++ b/services/gmuxd/internal/netauth/netauth.go
@@ -18,6 +18,7 @@ import (
 	"encoding/base64"
 	"log"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/authtoken"
@@ -52,6 +53,12 @@ const (
 // Browser requests without valid auth are redirected to the login page.
 func Middleware(token string, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// The control plane is a full terminal: never allow it to be
+		// embedded in another origin's frame (clickjacking → keystroke
+		// injection). Set on every response from the network listener.
+		w.Header().Set("Content-Security-Policy", "frame-ancestors 'none'")
+		w.Header().Set("X-Frame-Options", "DENY")
+
 		// The login page and its POST handler must be accessible without auth.
 		if r.URL.Path == "/auth/login" {
 			handleLogin(token, w, r)
@@ -73,7 +80,30 @@ func Middleware(token string, next http.Handler) http.Handler {
 			return
 		}
 
-		if isAuthorized(r, token) {
+		switch authMethod(r, token) {
+		case authBearer:
+			// A bearer header cannot be attached by a foreign origin's
+			// page, so bearer-authed requests carry no origin constraint.
+			next.ServeHTTP(w, r)
+			return
+		case authCookie:
+			// Cookies ARE attached cross-origin. SameSite=Strict blocks
+			// cross-SITE attachment, but ts.net is on the Public Suffix
+			// List, so every co-tenant service on the same tailnet is
+			// same-site with gmux and SameSite does nothing between them.
+			// Enforce same-ORIGIN for anything state-changing: mutating
+			// methods and WebSocket upgrades (WS → PTY is remote code
+			// execution). Reads over GET stay unconstrained because a
+			// cross-origin page cannot read the response anyway (no CORS
+			// headers are ever emitted).
+			if requiresSameOrigin(r) && !isSameOrigin(r) {
+				log.Printf("netauth: blocked cross-origin cookie-authed %s %s (Origin=%q, Host=%q) from %s",
+					r.Method, r.URL.Path, r.Header.Get("Origin"), r.Host, r.RemoteAddr)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusForbidden)
+				_, _ = w.Write([]byte(`{"ok":false,"error":{"code":"cross_origin","message":"cookie-authenticated request must be same-origin; use a bearer token for programmatic access"}}`))
+				return
+			}
 			next.ServeHTTP(w, r)
 			return
 		}
@@ -91,21 +121,111 @@ func Middleware(token string, next http.Handler) http.Handler {
 	})
 }
 
-func isAuthorized(r *http.Request, token string) bool {
+// authKind identifies which credential authenticated a request. The
+// distinction matters because cookies are ambient (the browser attaches
+// them regardless of who initiated the request) while bearer headers are
+// explicit and cannot be forged cross-origin.
+type authKind int
+
+const (
+	authNone authKind = iota
+	authBearer
+	authCookie
+)
+
+func authMethod(r *http.Request, token string) authKind {
 	// Check Authorization header.
 	if h := r.Header.Get("Authorization"); h != "" {
 		val := strings.TrimPrefix(h, "Bearer ")
 		if val != h && authtoken.Equal(val, token) {
-			return true
+			return authBearer
 		}
 	}
 
 	// Check cookie.
 	if c, err := r.Cookie(cookieName); err == nil && authtoken.Equal(c.Value, token) {
-		return true
+		return authCookie
 	}
 
+	return authNone
+}
+
+func isAuthorized(r *http.Request, token string) bool {
+	return authMethod(r, token) != authNone
+}
+
+// requiresSameOrigin reports whether a cookie-authenticated request must
+// prove it originated from the gmux UI itself. WebSocket upgrades (terminal
+// I/O = code execution) and mutating methods qualify; plain reads do not.
+func requiresSameOrigin(r *http.Request) bool {
+	if strings.EqualFold(r.Header.Get("Upgrade"), "websocket") {
+		return true
+	}
+	switch r.Method {
+	case http.MethodGet, http.MethodHead, http.MethodOptions:
+		return false
+	}
+	return true
+}
+
+// isSameOrigin reports whether the browser that issued the request was on
+// the gmux control origin itself. It compares against the request's OWN
+// host rather than a configured canonical name, so every legitimate way of
+// reaching the daemon (localhost, LAN IP, tailscale FQDN, reverse-proxy
+// vhost) works without configuration: whatever host the browser used to
+// load the UI is, by definition, the host it sends in both Origin and Host.
+func isSameOrigin(r *http.Request) bool {
+	// Fetch metadata is the most precise signal when present (all
+	// evergreen browsers send it).
+	switch r.Header.Get("Sec-Fetch-Site") {
+	case "same-origin":
+		return true
+	case "cross-site", "same-site":
+		// Explicitly attested as NOT same-origin. "same-site" is exactly
+		// the ts.net co-tenant case this check exists for.
+		return false
+	}
+
+	// Older browsers: fall back to comparing Origin against the host the
+	// request itself was addressed to. Browsers always send Origin on
+	// WebSocket handshakes and on non-GET fetch/XHR/form requests.
+	origin := r.Header.Get("Origin")
+	if origin == "" || origin == "null" {
+		return false
+	}
+	u, err := url.Parse(origin)
+	if err != nil || u.Host == "" {
+		return false
+	}
+	if hostsMatch(u.Host, r.Host) {
+		return true
+	}
+	// Behind a reverse proxy that rewrites Host, the browser-facing host
+	// arrives in X-Forwarded-Host (Traefik forwards Host verbatim by
+	// default, but not every proxy does).
+	if xfh := r.Header.Get("X-Forwarded-Host"); xfh != "" {
+		// Take the first hop if the header is a comma-separated chain.
+		if i := strings.IndexByte(xfh, ','); i >= 0 {
+			xfh = xfh[:i]
+		}
+		if hostsMatch(u.Host, strings.TrimSpace(xfh)) {
+			return true
+		}
+	}
 	return false
+}
+
+// hostsMatch compares two host[:port] strings, treating explicit default
+// ports (:80, :443) as equivalent to their absence.
+func hostsMatch(a, b string) bool {
+	return normalizeHost(a) == normalizeHost(b)
+}
+
+func normalizeHost(h string) string {
+	h = strings.ToLower(h)
+	h = strings.TrimSuffix(h, ":80")
+	h = strings.TrimSuffix(h, ":443")
+	return h
 }
 
 func isAPIRequest(r *http.Request) bool {
@@ -137,7 +257,7 @@ func handleLogin(token string, w http.ResponseWriter, r *http.Request) {
 		// login page when scanning a QR code.
 		if qToken := strings.TrimSpace(r.URL.Query().Get("token")); qToken != "" {
 			if authtoken.Equal(qToken, token) {
-				setAuthCookie(w, token)
+				setAuthCookie(w, r, token)
 				log.Printf("netauth: successful login via URL token from %s", r.RemoteAddr)
 				http.Redirect(w, r, "/", http.StatusSeeOther)
 				return
@@ -162,7 +282,7 @@ func handleLogin(token string, w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		setAuthCookie(w, token)
+		setAuthCookie(w, r, token)
 		log.Printf("netauth: successful login from %s", r.RemoteAddr)
 		http.Redirect(w, r, "/", http.StatusSeeOther)
 
@@ -171,7 +291,7 @@ func handleLogin(token string, w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func setAuthCookie(w http.ResponseWriter, token string) {
+func setAuthCookie(w http.ResponseWriter, r *http.Request, token string) {
 	http.SetCookie(w, &http.Cookie{
 		Name:     cookieName,
 		Value:    token,
@@ -179,7 +299,22 @@ func setAuthCookie(w http.ResponseWriter, token string) {
 		MaxAge:   cookieMaxAge,
 		HttpOnly: true,
 		SameSite: http.SameSiteStrictMode,
+		// Secure is keyed on the transport the login actually used: the
+		// tailscale listener and TLS-terminating reverse proxies are
+		// https (Secure sticks), while plain-http localhost/LAN access
+		// must not set it or the browser drops the cookie entirely.
+		Secure: requestIsTLS(r),
 	})
+}
+
+// requestIsTLS reports whether the browser-facing transport is HTTPS,
+// either directly (tsnet listener terminates TLS in-process) or via a
+// reverse proxy that terminated TLS upstream.
+func requestIsTLS(r *http.Request) bool {
+	if r.TLS != nil {
+		return true
+	}
+	return strings.EqualFold(r.Header.Get("X-Forwarded-Proto"), "https")
 }
 
 func serveLoginPage(w http.ResponseWriter, errMsg string) {

--- a/services/gmuxd/internal/netauth/sameorigin_test.go
+++ b/services/gmuxd/internal/netauth/sameorigin_test.go
@@ -1,0 +1,265 @@
+package netauth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// cookieReq builds a cookie-authenticated request against the given
+// method/target with the given request Host.
+func cookieReq(method, target, host string) *http.Request {
+	req := httptest.NewRequest(method, target, nil)
+	req.Host = host
+	req.AddCookie(&http.Cookie{Name: cookieName, Value: testToken})
+	return req
+}
+
+func serve(t *testing.T, req *http.Request) *httptest.ResponseRecorder {
+	t.Helper()
+	h := Middleware(testToken, okHandler())
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	return rr
+}
+
+// ── Mutating /v1/ requests, cookie-authed ──
+
+func TestCookiePostSameOriginAllowed(t *testing.T) {
+	req := cookieReq("POST", "/v1/sessions", "gmux.example.com")
+	req.Header.Set("Origin", "http://gmux.example.com")
+	if rr := serve(t, req); rr.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rr.Code)
+	}
+}
+
+func TestCookiePostCrossOriginBlocked(t *testing.T) {
+	req := cookieReq("POST", "/v1/sessions", "gmux.example.com")
+	req.Header.Set("Origin", "https://evil.example.net")
+	if rr := serve(t, req); rr.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403", rr.Code)
+	}
+}
+
+func TestCookiePostSameSiteSiblingBlocked(t *testing.T) {
+	// The ts.net co-tenant case: another service on the same tailnet is
+	// same-SITE (ts.net is on the PSL) but not same-ORIGIN. SameSite=Strict
+	// attaches the cookie; the middleware must still reject.
+	req := cookieReq("POST", "/v1/sessions", "gmux-host.tailnet.ts.net")
+	req.Header.Set("Origin", "https://other-app.tailnet.ts.net")
+	if rr := serve(t, req); rr.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403 for same-site sibling origin", rr.Code)
+	}
+}
+
+func TestCookiePostSecFetchSiteSameOriginAllowed(t *testing.T) {
+	// Sec-Fetch-Site alone suffices (Origin may be absent on some paths).
+	req := cookieReq("POST", "/v1/sessions", "gmux.example.com")
+	req.Header.Set("Sec-Fetch-Site", "same-origin")
+	if rr := serve(t, req); rr.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rr.Code)
+	}
+}
+
+func TestCookiePostSecFetchSiteSameSiteBlocked(t *testing.T) {
+	// Even if Origin were spoofed to match, an explicit same-site
+	// attestation from the browser wins.
+	req := cookieReq("POST", "/v1/sessions", "gmux-host.tailnet.ts.net")
+	req.Header.Set("Sec-Fetch-Site", "same-site")
+	req.Header.Set("Origin", "https://gmux-host.tailnet.ts.net")
+	if rr := serve(t, req); rr.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403 when Sec-Fetch-Site says same-site", rr.Code)
+	}
+}
+
+func TestCookiePostMissingHeadersBlocked(t *testing.T) {
+	// A cookie-authed mutating request with neither Sec-Fetch-Site nor
+	// Origin cannot prove same-origin. Browsers always send at least
+	// Origin on non-GET; header-less mutation is curl-with-a-cookie,
+	// which should use a bearer token instead.
+	req := cookieReq("POST", "/v1/sessions", "gmux.example.com")
+	if rr := serve(t, req); rr.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403", rr.Code)
+	}
+}
+
+func TestCookiePostNullOriginBlocked(t *testing.T) {
+	req := cookieReq("POST", "/v1/sessions", "gmux.example.com")
+	req.Header.Set("Origin", "null")
+	if rr := serve(t, req); rr.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403 for Origin: null", rr.Code)
+	}
+}
+
+func TestCookieDeleteCrossOriginBlocked(t *testing.T) {
+	req := cookieReq("DELETE", "/v1/sessions/abc", "gmux.example.com")
+	req.Header.Set("Origin", "https://other.example.net")
+	if rr := serve(t, req); rr.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403", rr.Code)
+	}
+}
+
+// ── GET reads, cookie-authed: exempt ──
+
+func TestCookieGetWithoutOriginAllowed(t *testing.T) {
+	req := cookieReq("GET", "/v1/sessions", "gmux.example.com")
+	if rr := serve(t, req); rr.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200 (GET reads are exempt)", rr.Code)
+	}
+}
+
+func TestCookieGetCrossOriginAllowed(t *testing.T) {
+	// Cross-origin GETs are harmless without CORS headers: the foreign
+	// page cannot read the response. Blocking them would only break
+	// things like proxies that strip fetch metadata.
+	req := cookieReq("GET", "/v1/sessions", "gmux.example.com")
+	req.Header.Set("Origin", "https://other.example.net")
+	if rr := serve(t, req); rr.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rr.Code)
+	}
+}
+
+// ── WebSocket upgrades, cookie-authed ──
+
+func TestCookieWSUpgradeSameOriginAllowed(t *testing.T) {
+	req := cookieReq("GET", "/ws/session-1", "gmux-host.tailnet.ts.net")
+	req.Header.Set("Upgrade", "websocket")
+	req.Header.Set("Origin", "https://gmux-host.tailnet.ts.net")
+	if rr := serve(t, req); rr.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rr.Code)
+	}
+}
+
+func TestCookieWSUpgradeCrossOriginBlocked(t *testing.T) {
+	// WS upgrades are GETs but must still be origin-checked: a foreign
+	// page CAN read a hijacked WebSocket (CSWSH), and /ws is the PTY.
+	req := cookieReq("GET", "/ws/session-1", "gmux-host.tailnet.ts.net")
+	req.Header.Set("Upgrade", "websocket")
+	req.Header.Set("Origin", "https://other-app.tailnet.ts.net")
+	if rr := serve(t, req); rr.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403 for cross-origin WS hijack", rr.Code)
+	}
+}
+
+func TestCookieWSUpgradeNoOriginBlocked(t *testing.T) {
+	req := cookieReq("GET", "/ws/session-1", "gmux.example.com")
+	req.Header.Set("Upgrade", "websocket")
+	if rr := serve(t, req); rr.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403 (browsers always send Origin on WS)", rr.Code)
+	}
+}
+
+// ── Bearer auth: fully exempt from origin constraints ──
+
+func TestBearerPostCrossOriginAllowed(t *testing.T) {
+	req := httptest.NewRequest("POST", "/v1/sessions", nil)
+	req.Host = "gmux.example.com"
+	req.Header.Set("Authorization", "Bearer "+testToken)
+	req.Header.Set("Origin", "https://anywhere.example.net")
+	if rr := serve(t, req); rr.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200 (bearer requests carry no origin constraint)", rr.Code)
+	}
+}
+
+func TestBearerWSUpgradeNoOriginAllowed(t *testing.T) {
+	// Hub→spoke WS proxying and CLI clients dial with a bearer header and
+	// no Origin. They must keep working.
+	req := httptest.NewRequest("GET", "/ws/session-1", nil)
+	req.Host = "spoke.tailnet.ts.net"
+	req.Header.Set("Authorization", "Bearer "+testToken)
+	req.Header.Set("Upgrade", "websocket")
+	if rr := serve(t, req); rr.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200 (bearer WS must not require Origin)", rr.Code)
+	}
+}
+
+// ── Reverse proxy shapes ──
+
+func TestCookiePostBehindProxyMatchesForwardedHost(t *testing.T) {
+	// A proxy that rewrites Host to the upstream address must still pass:
+	// the browser-facing host arrives in X-Forwarded-Host.
+	req := cookieReq("POST", "/v1/sessions", "127.0.0.1:8790")
+	req.Header.Set("Origin", "https://gmux.example.com")
+	req.Header.Set("X-Forwarded-Host", "gmux.example.com")
+	if rr := serve(t, req); rr.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200 (X-Forwarded-Host must be honored)", rr.Code)
+	}
+}
+
+func TestCookiePostBehindProxyPreservedHost(t *testing.T) {
+	// Traefik default: Host is forwarded verbatim, no X-Forwarded-Host
+	// needed. Origin is https, upstream hop is plain http — the check
+	// must compare hosts, not schemes.
+	req := cookieReq("POST", "/v1/sessions", "gmux.example.com")
+	req.Header.Set("Origin", "https://gmux.example.com")
+	if rr := serve(t, req); rr.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rr.Code)
+	}
+}
+
+func TestHostsMatchDefaultPorts(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want bool
+	}{
+		{"gmux.example.com", "gmux.example.com", true},
+		{"GMUX.Example.com", "gmux.example.com", true},
+		{"gmux.example.com:443", "gmux.example.com", true},
+		{"gmux.example.com:80", "gmux.example.com", true},
+		{"localhost:8790", "localhost:8790", true},
+		{"localhost:8790", "localhost:3000", false},
+		{"a.tailnet.ts.net", "b.tailnet.ts.net", false},
+	}
+	for _, c := range cases {
+		if got := hostsMatch(c.a, c.b); got != c.want {
+			t.Errorf("hostsMatch(%q, %q) = %v, want %v", c.a, c.b, got, c.want)
+		}
+	}
+}
+
+// ── Response headers & cookie attributes ──
+
+func TestFrameEmbeddingDenied(t *testing.T) {
+	req := httptest.NewRequest("GET", "/", nil)
+	rr := serve(t, req)
+	if got := rr.Header().Get("Content-Security-Policy"); got != "frame-ancestors 'none'" {
+		t.Errorf("CSP = %q, want frame-ancestors 'none'", got)
+	}
+	if got := rr.Header().Get("X-Frame-Options"); got != "DENY" {
+		t.Errorf("X-Frame-Options = %q, want DENY", got)
+	}
+}
+
+func TestCookieSecureOverTLS(t *testing.T) {
+	req := httptest.NewRequest("GET", "https://gmux.example.com/auth/login?token="+testToken, nil)
+	rr := serve(t, req)
+	assertCookieSecure(t, rr, true)
+}
+
+func TestCookieSecureBehindTLSProxy(t *testing.T) {
+	req := httptest.NewRequest("GET", "/auth/login?token="+testToken, nil)
+	req.Header.Set("X-Forwarded-Proto", "https")
+	rr := serve(t, req)
+	assertCookieSecure(t, rr, true)
+}
+
+func TestCookieNotSecureOverPlainHTTP(t *testing.T) {
+	// Plain-http localhost/LAN login must not set Secure, or the browser
+	// discards the cookie and login loops forever.
+	req := httptest.NewRequest("GET", "/auth/login?token="+testToken, nil)
+	rr := serve(t, req)
+	assertCookieSecure(t, rr, false)
+}
+
+func assertCookieSecure(t *testing.T, rr *httptest.ResponseRecorder, want bool) {
+	t.Helper()
+	for _, c := range rr.Result().Cookies() {
+		if c.Name == cookieName {
+			if c.Secure != want {
+				t.Errorf("cookie Secure = %v, want %v", c.Secure, want)
+			}
+			return
+		}
+	}
+	t.Fatal("expected auth cookie to be set")
+}

--- a/services/gmuxd/internal/netauth/sameorigin_test.go
+++ b/services/gmuxd/internal/netauth/sameorigin_test.go
@@ -161,6 +161,28 @@ func TestBearerPostCrossOriginAllowed(t *testing.T) {
 	}
 }
 
+func TestBearerPrecedenceOverCookie(t *testing.T) {
+	// When both credentials are present and the bearer is valid, the
+	// request authenticated explicitly — no origin constraint applies,
+	// even if the browser also attached the ambient cookie.
+	req := cookieReq("POST", "/v1/sessions", "gmux.example.com")
+	req.Header.Set("Authorization", "Bearer "+testToken)
+	if rr := serve(t, req); rr.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200 (valid bearer wins over cookie)", rr.Code)
+	}
+}
+
+func TestInvalidBearerFallsBackToCookieConstraints(t *testing.T) {
+	// A wrong bearer must not grant the bearer exemption: auth falls back
+	// to the cookie, and the cookie's same-origin rules apply.
+	req := cookieReq("POST", "/v1/sessions", "gmux.example.com")
+	req.Header.Set("Authorization", "Bearer wrong-token")
+	req.Header.Set("Origin", "https://evil.example.net")
+	if rr := serve(t, req); rr.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403 (invalid bearer must not lift origin constraint)", rr.Code)
+	}
+}
+
 func TestBearerWSUpgradeNoOriginAllowed(t *testing.T) {
 	// Hub→spoke WS proxying and CLI clients dial with a bearer header and
 	// no Origin. They must keep working.
@@ -194,6 +216,31 @@ func TestCookiePostBehindProxyPreservedHost(t *testing.T) {
 	req.Header.Set("Origin", "https://gmux.example.com")
 	if rr := serve(t, req); rr.Code != http.StatusOK {
 		t.Errorf("status = %d, want 200", rr.Code)
+	}
+}
+
+func TestCookiePostSpoofedForwardedHostBlockedByFetchMetadata(t *testing.T) {
+	// The X-Forwarded-Host spoof shape: a hostile page fetch()es with
+	// credentials and sets X-Forwarded-Host to its own origin's host so
+	// that Origin == XFH "matches". Any browser capable of attaching that
+	// custom header sends Sec-Fetch-Site, which must win over the header
+	// comparison. (The other layer — the CORS preflight such a request
+	// triggers — can't be expressed in a unit test.)
+	req := cookieReq("POST", "/v1/sessions", "gmux-host.tailnet.ts.net")
+	req.Header.Set("Sec-Fetch-Site", "same-site")
+	req.Header.Set("Origin", "https://evil.tailnet.ts.net")
+	req.Header.Set("X-Forwarded-Host", "evil.tailnet.ts.net")
+	if rr := serve(t, req); rr.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403 (Sec-Fetch-Site must override spoofed X-Forwarded-Host)", rr.Code)
+	}
+}
+
+func TestForwardedHostChainUsesFirstHop(t *testing.T) {
+	req := cookieReq("POST", "/v1/sessions", "127.0.0.1:8790")
+	req.Header.Set("Origin", "https://gmux.example.com")
+	req.Header.Set("X-Forwarded-Host", "gmux.example.com, 10.0.0.5:8080")
+	if rr := serve(t, req); rr.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200 (first hop of X-Forwarded-Host chain)", rr.Code)
 	}
 }
 
@@ -239,6 +286,15 @@ func TestCookieSecureOverTLS(t *testing.T) {
 func TestCookieSecureBehindTLSProxy(t *testing.T) {
 	req := httptest.NewRequest("GET", "/auth/login?token="+testToken, nil)
 	req.Header.Set("X-Forwarded-Proto", "https")
+	rr := serve(t, req)
+	assertCookieSecure(t, rr, true)
+}
+
+func TestCookieSecureBehindChainedTLSProxy(t *testing.T) {
+	// Multiple proxy hops append to X-Forwarded-Proto; the browser-facing
+	// hop is the first element.
+	req := httptest.NewRequest("GET", "/auth/login?token="+testToken, nil)
+	req.Header.Set("X-Forwarded-Proto", "https, http")
 	rr := serve(t, req)
 	assertCookieSecure(t, rr, true)
 }

--- a/services/gmuxd/internal/wsproxy/wsproxy.go
+++ b/services/gmuxd/internal/wsproxy/wsproxy.go
@@ -77,6 +77,10 @@ func (p *Proxy) Handler() http.HandlerFunc {
 		// replay far more than compression ever saved, so this is the
 		// right call for every client. Revisit #242's bandwidth goal
 		// another way (e.g. bounding replay size) if it proves necessary.
+		// InsecureSkipVerify disables the library's blanket Origin==Host
+		// check, which would break bearer-authed clients (no Origin) and
+		// proxied setups. Origin enforcement for cookie-authed upgrades
+		// happens upstream in netauth.Middleware instead.
 		clientConn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
 			InsecureSkipVerify: true,
 		})


### PR DESCRIPTION
Supersedes #292.

## Threat model

gmuxd authenticates via bearer token or an `HttpOnly SameSite=Strict` session cookie. #292 argued that combination was sufficient to skip WebSocket Origin checks and Host validation. The gap: **`ts.net` is on the Public Suffix List**, so `<tailnet>.ts.net` is the registrable domain — every other web service on the user's own tailnet is *same-site* with gmux, and `SameSite=Strict` provides no protection between same-site origins. A compromised or XSS'd co-tenant tailnet service could therefore ride the ambient cookie into the control plane: CSRF on mutating `/v1/` endpoints, or cross-origin WebSocket hijack of `/ws/{session}` → PTY → code execution. `WhoIs` doesn't help; the request comes from the user's own authorized device.

## The fix

**Cookie-authed ⇒ same-origin enforced. Bearer-authed ⇒ unconstrained.**

- **WebSocket upgrades** (cookie-authed): must be same-origin. Highest-value item — WS→PTY is the RCE path.
- **Mutating `/v1/` requests** (cookie-authed `POST`/`PUT`/`PATCH`/`DELETE`): must carry `Sec-Fetch-Site: same-origin` or an `Origin` matching the request's own Host (first hop of `X-Forwarded-Host` honored for proxies that rewrite Host). Otherwise `403`.
- **GET reads exempt**: no CORS headers are ever emitted, so a foreign page can't read responses.
- **Bearer requests fully exempt**: a bearer header can't be forged cross-origin — CLI, API clients, and hub↔spoke peering (all `WithBearerToken`) are untouched. The hub terminates the browser connection and enforces there; the hub→spoke hop is bearer.
- `Content-Security-Policy: frame-ancestors 'none'` + `X-Frame-Options: DENY` on every network-listener response.
- Cookie gains `Secure` when the transport is TLS (tsnet listener, or `X-Forwarded-Proto: https` behind a TLS-terminating proxy); stays unset on plain-http localhost so login keeps working.

This is **not** the host allowlist #292 rejected — that rejection stands and is documented. The check is a single dynamic comparison against the request's own host, so localhost, LAN IPs, tailnet FQDNs, and reverse-proxy vhosts (Traefik/PocketID pattern) all work with zero configuration.

The `X-Forwarded-Host` fallback is client-suppliable but safe against the only attacker class this check addresses (browser-mediated ambient-credential attacks): `Sec-Fetch-Site` is evaluated first and wins, and attaching the custom header forces a CORS preflight that fails. A non-browser client holding the cookie holds the token itself. This reasoning is documented at the code site and pinned by a test.

## Docs

- **ADR 0020** (`docs/adr/0020-same-origin-enforcement-for-cookie-auth.md`) records the decision: the same-site/PSL threat, the preserved rationale for rejecting `GMUXD_TRUSTED_HOSTS` (#292's text described that allowlist as implemented; it never was), the dynamic same-origin design, and its consequences.
- `security.md` gains a "Browser sessions: same-origin enforcement" section describing the actual posture, linking the ADR.

## Tests

New `sameorigin_test.go` (28 tests) covers: cookie vs bearer, bearer precedence when both credentials are present, invalid-bearer fallback to cookie constraints, same-origin vs cross-origin vs same-site ts.net sibling, Sec-Fetch-Site handling (including overriding a spoofed Origin/X-Forwarded-Host pair), missing/null Origin, WS upgrade paths, reverse-proxy shapes (preserved Host, X-Forwarded-Host, chained hops), default-port normalization, frame headers, and Secure-cookie transport gating. Existing netauth e2e/integration suites pass unchanged.