### PR TITLE
fix: move per-session sockets out of XDG_RUNTIME_DIR to the state dir

### DIFF
--- a/apps/website/src/content/docs/architecture.md
+++ b/apps/website/src/content/docs/architecture.md
@@ -21,7 +21,7 @@ One per session. It:
 
 One per machine. It:
 
-- Discovers live runner sockets (`/tmp/gmux-sessions/*.sock`)
+- Discovers live runner sockets (`~/.local/state/gmux/run/sessions/*.sock`)
 - Subscribes to runner events for live updates
 - Watches adapter session files (e.g. pi's JSONL conversations)
 - Serves the REST API, SSE event stream, and WebSocket proxy

--- a/apps/website/src/content/docs/develop/session-schema.md
+++ b/apps/website/src/content/docs/develop/session-schema.md
@@ -175,7 +175,7 @@ interface Status {
 **Option A — Environment variable + HTTP** (preferred):
 ```bash
 # gmux sets this in the child's environment
-GMUX_SOCKET=/tmp/gmux-sessions/sess-abc123.sock
+GMUX_SOCKET=~/.local/state/gmux/run/sessions/sess-abc123.sock
 
 # Child (or a hook) sets status via HTTP on the same socket
 curl --unix-socket $GMUX_SOCKET http://localhost/status \
@@ -207,7 +207,7 @@ As served by `GET /meta` on a runner's Unix socket (runner → gmuxd):
   "adapter_title": "fix auth bug",
   "status": { "working": true },
   "unread": false,
-  "socket_path": "/tmp/gmux-sessions/sess-abc123.sock",
+  "socket_path": "~/.local/state/gmux/run/sessions/sess-abc123.sock",
   "binary_hash": "a1b2c3d4e5f6..."
 }
 ```
@@ -227,7 +227,7 @@ As served by `GET /v1/sessions` (gmuxd → frontend):
   "title": "fix auth bug",
   "status": { "working": true },
   "unread": false,
-  "socket_path": "/tmp/gmux-sessions/sess-abc123.sock",
+  "socket_path": "~/.local/state/gmux/run/sessions/sess-abc123.sock",
   "slug": "fix-auth-bug",
   "resume_key": "2026-03-14T10-00-00_abc123",
   "stale": false

--- a/apps/website/src/content/docs/reference/environment.md
+++ b/apps/website/src/content/docs/reference/environment.md
@@ -69,7 +69,7 @@ Variables that affect the session runner.
 | Variable | Purpose | Default |
 |----------|---------|---------|
 | `GMUX_ADAPTER` | Force a specific adapter instead of auto-detection. | *(auto)* |
-| `GMUX_SOCKET_DIR` | Directory for per-session Unix sockets. | `/tmp/gmux-sessions` |
+| `GMUX_SOCKET_DIR` | Directory for per-session Unix sockets. | `~/.local/state/gmux/run/sessions` |
 | `GMUX_NO_AGENT_HOOK` | Disable injecting the gmux agent extension/hook (e.g. the pi extension). An escape hatch if an agent release breaks the extension: the agent runs unmodified, and gmux loses hook-driven title/status/attribution for it. Any value other than `0`/empty disables. Read by the runner, so it covers foreground and `-d` launches; for daemon-initiated launches set it in the daemon's environment. | *(unset)* |
 
 ## Set by gmux in child processes
@@ -79,11 +79,11 @@ These are available inside every session launched by `gmux`. Use them to detect 
 | Variable | Purpose | Example |
 |----------|---------|---------|
 | `GMUX` | Always `1` inside a gmux session. Used for nested-session detection. | `1` |
-| `GMUX_SOCKET` | Unix socket path for callbacks to the session runner. | `/tmp/gmux-sessions/sess-abc123.sock` |
+| `GMUX_SOCKET` | Unix socket path for callbacks to the session runner. | `~/.local/state/gmux/run/sessions/sess-abc123.sock` |
 | `GMUX_SESSION_ID` | Unique session identifier. | `sess-abc123` |
 | `GMUX_ADAPTER` | Name of the matched adapter. | `pi`, `shell` |
 | `GMUX_RUNNER_VERSION` | Version of the gmux runner hosting the session. | `0.4.0` |
-| `GMUX_SESSION_SOCK` | Socket the agent extension/hook posts session + turn events to. Set only for adapters that ship a hook (pi); absent if `GMUX_NO_AGENT_HOOK` is set. | `/tmp/gmux-sessions/sess-abc123.sock` |
+| `GMUX_SESSION_SOCK` | Socket the agent extension/hook posts session + turn events to. Set only for adapters that ship a hook (pi); absent if `GMUX_NO_AGENT_HOOK` is set. | `~/.local/state/gmux/run/sessions/sess-abc123.sock` |
 
 See [Adapter Architecture](/develop/adapter-architecture) for how to use the child-to-runner API.
 

--- a/apps/website/src/content/docs/reference/file-paths.md
+++ b/apps/website/src/content/docs/reference/file-paths.md
@@ -37,9 +37,9 @@ Created by `gmux` (the CLI) for each running session. gmuxd connects to these to
 
 | Path | Purpose |
 |------|---------|
-| `/tmp/gmux-sessions/<session-id>.sock` | Per-session Unix socket |
+| `~/.local/state/gmux/run/sessions/<session-id>.sock` | Per-session Unix socket |
 
-Override the directory with `GMUX_SOCKET_DIR`.
+Override the directory with `GMUX_SOCKET_DIR`. The default deliberately lives under the state dir rather than `$XDG_RUNTIME_DIR`: runtime dirs are torn down by logind when your last login session ends, which would unlink the sockets of still-running sessions.
 
 ## Adapter-specific paths
 

--- a/packages/paths/paths.go
+++ b/packages/paths/paths.go
@@ -39,22 +39,44 @@ func SocketPath() string {
 //
 // The GMUX_SOCKET_DIR env var overrides everything; it is used by tests
 // and devcontainers and is passed through to the daemon so both ends
-// scan the same place. Otherwise the default is per-user so that two OS
-// users on the same host never collide on one world-shared directory
-// (whoever creates it first owns it 0700, locking everyone else out):
+// scan the same place. Otherwise the default is StateDir()/run/sessions
+// (~/.local/state/gmux/run/sessions), which is:
 //
-//   - $XDG_RUNTIME_DIR/gmux/sessions when XDG_RUNTIME_DIR is set (the
-//     standard per-user, 0700, tmpfs-backed runtime dir on Linux), else
-//   - a per-uid subdirectory of the system temp dir, e.g.
-//     /tmp/gmux-sessions-1000.
+//   - per-user by construction (under $HOME), preserving the property
+//     from the /tmp/gmux-sessions fix that two OS users never collide
+//     on one world-shared, squattable directory (the runner creates it
+//     0700 via ptyserver.BindSocket), and
+//   - tied to the same lifetime as the daemon socket (gmuxd.sock lives
+//     in the same state tree). Earlier versions defaulted to
+//     $XDG_RUNTIME_DIR/gmux/sessions, but the XDG runtime dir is by
+//     spec torn down when the user's last login session ends
+//     (logind/elogind unmount /run/user/$UID unless Linger=yes), which
+//     unlinked the sockets of live runners that outlived the login —
+//     gmux's whole design. See LegacySessionSocketDirs.
 func SessionSocketDir() string {
 	if d := os.Getenv("GMUX_SOCKET_DIR"); d != "" {
 		return d
 	}
-	if rt := os.Getenv("XDG_RUNTIME_DIR"); rt != "" {
-		return filepath.Join(rt, "gmux", "sessions")
+	return filepath.Join(StateDir(), "run", "sessions")
+}
+
+// LegacySessionSocketDirs returns socket directories that older runner
+// versions may still be binding sockets in. Long-lived runners survive
+// daemon upgrades, so gmuxd's discovery scans these read-mostly for one
+// release alongside SessionSocketDir. TODO(v2.1): drop this shim.
+//
+// Not consulted when GMUX_SOCKET_DIR is set: the override pins both
+// ends (tests, devcontainers) to a single explicit directory.
+func LegacySessionSocketDirs() []string {
+	if os.Getenv("GMUX_SOCKET_DIR") != "" {
+		return nil
 	}
-	return filepath.Join(os.TempDir(), fmt.Sprintf("gmux-sessions-%d", os.Getuid()))
+	var dirs []string
+	if rt := os.Getenv("XDG_RUNTIME_DIR"); rt != "" {
+		dirs = append(dirs, filepath.Join(rt, "gmux", "sessions"))
+	}
+	dirs = append(dirs, filepath.Join(os.TempDir(), fmt.Sprintf("gmux-sessions-%d", os.Getuid())))
+	return dirs
 }
 
 // StateDir returns the gmux state directory (~/.local/state/gmux).

--- a/packages/paths/paths_test.go
+++ b/packages/paths/paths_test.go
@@ -68,26 +68,50 @@ func TestSessionSocketDir(t *testing.T) {
 		}
 	})
 
-	t.Run("falls back to XDG_RUNTIME_DIR", func(t *testing.T) {
+	t.Run("defaults to state dir, ignoring XDG_RUNTIME_DIR", func(t *testing.T) {
 		t.Setenv("GMUX_SOCKET_DIR", "")
+		// logind/elogind tear down $XDG_RUNTIME_DIR on last logout, so it
+		// must never be the socket home for login-outliving runners.
 		t.Setenv("XDG_RUNTIME_DIR", "/run/user/1000")
-		want := "/run/user/1000/gmux/sessions"
+		t.Setenv("XDG_STATE_HOME", "/home/u/.local/state")
+		want := "/home/u/.local/state/gmux/run/sessions"
 		if got := SessionSocketDir(); got != want {
 			t.Errorf("SessionSocketDir() = %q, want %q", got, want)
 		}
+		// Must not be the old world-shared path either.
+		if got := SessionSocketDir(); got == "/tmp/gmux-sessions" {
+			t.Errorf("SessionSocketDir() must not default to the shared /tmp/gmux-sessions")
+		}
+	})
+}
+
+func TestLegacySessionSocketDirs(t *testing.T) {
+	t.Run("empty when GMUX_SOCKET_DIR is set", func(t *testing.T) {
+		t.Setenv("GMUX_SOCKET_DIR", "/tmp/custom-sockets")
+		if got := LegacySessionSocketDirs(); len(got) != 0 {
+			t.Errorf("LegacySessionSocketDirs() = %v, want empty", got)
+		}
 	})
 
-	t.Run("per-uid temp dir when no XDG_RUNTIME_DIR", func(t *testing.T) {
+	t.Run("includes XDG runtime dir and per-uid temp dir", func(t *testing.T) {
+		t.Setenv("GMUX_SOCKET_DIR", "")
+		t.Setenv("XDG_RUNTIME_DIR", "/run/user/1000")
+		got := LegacySessionSocketDirs()
+		want := []string{
+			"/run/user/1000/gmux/sessions",
+			filepath.Join(os.TempDir(), fmt.Sprintf("gmux-sessions-%d", os.Getuid())),
+		}
+		if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+			t.Errorf("LegacySessionSocketDirs() = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("per-uid temp dir only when no XDG_RUNTIME_DIR", func(t *testing.T) {
 		t.Setenv("GMUX_SOCKET_DIR", "")
 		t.Setenv("XDG_RUNTIME_DIR", "")
-		got := SessionSocketDir()
-		want := filepath.Join(os.TempDir(), fmt.Sprintf("gmux-sessions-%d", os.Getuid()))
-		if got != want {
-			t.Errorf("SessionSocketDir() = %q, want %q", got, want)
-		}
-		// Must not be the old world-shared path.
-		if got == "/tmp/gmux-sessions" {
-			t.Errorf("SessionSocketDir() must not default to the shared /tmp/gmux-sessions")
+		got := LegacySessionSocketDirs()
+		if len(got) != 1 {
+			t.Fatalf("LegacySessionSocketDirs() = %v, want 1 entry", got)
 		}
 	})
 }

--- a/packages/paths/paths_test.go
+++ b/packages/paths/paths_test.go
@@ -132,16 +132,16 @@ func TestIsValidSessionID(t *testing.T) {
 
 	invalid := []string{
 		"",
-		"abcd1234",          // missing prefix
-		"sess-",             // empty suffix
-		"sess-../escape",    // path traversal
-		"sess-..",           // parent dir
-		"../sess-abcd",      // leading traversal
-		"sess-a/b",          // separator
-		`sess-a\b`,          // backslash separator
-		"sess-a::b",         // folder-key separator
-		"sess-a b",          // space
-		"sess-a\n",          // newline
+		"abcd1234",       // missing prefix
+		"sess-",          // empty suffix
+		"sess-../escape", // path traversal
+		"sess-..",        // parent dir
+		"../sess-abcd",   // leading traversal
+		"sess-a/b",       // separator
+		`sess-a\b`,       // backslash separator
+		"sess-a::b",      // folder-key separator
+		"sess-a b",       // space
+		"sess-a\n",       // newline
 	}
 	for _, id := range invalid {
 		if IsValidSessionID(id) {

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -631,7 +631,8 @@ func serve(stderr io.Writer) int {
 		}
 		return false
 	}
-	// Start socket-based discovery (scans paths.SessionSocketDir() for *.sock)
+	// Start socket-based discovery (scans paths.SessionSocketDir() — plus
+	// paths.LegacySessionSocketDirs() for pre-upgrade runners — for *.sock).
 	// Discovery also subscribes to each runner's /events SSE for live updates.
 	stopDiscovery := make(chan struct{})
 	// onFirstScan fires after the initial socket scan has registered live

--- a/services/gmuxd/internal/discovery/discovery.go
+++ b/services/gmuxd/internal/discovery/discovery.go
@@ -77,13 +77,29 @@ func Watch(sessions *store.Store, subs *Subscriptions, onDead OnDeadFunc, onFirs
 // Reachable sockets → upsert session + subscribe to /events.
 // Unreachable → remove + cleanup + unsubscribe.
 func Scan(sessions *store.Store, subs *Subscriptions, onDead OnDeadFunc) {
-	dir := socketDir()
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		if !os.IsNotExist(err) {
-			log.Printf("discovery: read dir: %v", err)
+	// Primary dir first, then legacy dirs (pre-upgrade runners outlive
+	// a gmuxd upgrade and keep their sockets where they bound them; see
+	// paths.LegacySessionSocketDirs). Entries carry their absolute path
+	// so the rest of the scan is location-agnostic.
+	type sockEntry struct {
+		path string
+		entry os.DirEntry
+	}
+	var socks []sockEntry
+	for _, dir := range append([]string{socketDir()}, paths.LegacySessionSocketDirs()...) {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			if !os.IsNotExist(err) {
+				log.Printf("discovery: read dir %s: %v", dir, err)
+			}
+			continue
 		}
-		return
+		for _, entry := range entries {
+			if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".sock") {
+				continue
+			}
+			socks = append(socks, sockEntry{path: filepath.Join(dir, entry.Name()), entry: entry})
+		}
 	}
 
 	// Index existing store entries by SocketPath so Phase 1 can
@@ -116,11 +132,8 @@ func Scan(sessions *store.Store, subs *Subscriptions, onDead OnDeadFunc) {
 
 	// Phase 1: discover new sockets → Register is the single entry
 	// point for creating/merging sessions.
-	for _, entry := range entries {
-		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".sock") {
-			continue
-		}
-		sockPath := filepath.Join(dir, entry.Name())
+	for _, se := range socks {
+		sockPath := se.path
 		if t, ok := tracked[sockPath]; ok && t.alive && subs.IsActive(t.id) {
 			continue // already current — runner is alive and we're streaming /events
 		}
@@ -138,7 +151,7 @@ func Scan(sessions *store.Store, subs *Subscriptions, onDead OnDeadFunc) {
 			// The 10s ModTime threshold is generous for the first case
 			// (a runner takes milliseconds to listen) and irrelevant
 			// for the second (the file is hours / days old).
-			if info, serr := entry.Info(); serr == nil && time.Since(info.ModTime()) > 10*time.Second {
+			if info, serr := se.entry.Info(); serr == nil && time.Since(info.ModTime()) > 10*time.Second {
 				os.Remove(sockPath)
 			}
 		}

--- a/services/gmuxd/internal/discovery/discovery.go
+++ b/services/gmuxd/internal/discovery/discovery.go
@@ -82,7 +82,7 @@ func Scan(sessions *store.Store, subs *Subscriptions, onDead OnDeadFunc) {
 	// paths.LegacySessionSocketDirs). Entries carry their absolute path
 	// so the rest of the scan is location-agnostic.
 	type sockEntry struct {
-		path string
+		path  string
 		entry os.DirEntry
 	}
 	var socks []sockEntry

--- a/services/gmuxd/internal/discovery/discovery_test.go
+++ b/services/gmuxd/internal/discovery/discovery_test.go
@@ -4,11 +4,13 @@ import (
 	"encoding/json"
 	"net"
 	"net/http"
+	"os"
 	"path/filepath"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/gmuxapp/gmux/packages/paths"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/store"
 )
 
@@ -343,5 +345,76 @@ func TestQueryMetaNewKeysWinOverLegacy(t *testing.T) {
 	}
 	if sess.ConversationFile != "/new/conv.jsonl" {
 		t.Errorf("ConversationFile = %q, want /new/conv.jsonl (new key must win)", sess.ConversationFile)
+	}
+}
+
+// serveAliveRunner binds a fake runner at sockPath whose /meta reports
+// the given session id as alive. /events is left unregistered (404) so
+// the subscription goroutine exits quickly; these tests assert on the
+// Scan→Register→Upsert seam, not SSE behavior.
+func serveAliveRunner(t *testing.T, sockPath, id string) {
+	t.Helper()
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen %s: %v", sockPath, err)
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/meta", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(store.Session{ID: id, Adapter: "shell", Alive: true, Pid: 1})
+	})
+	srv := &http.Server{Handler: mux}
+	done := make(chan struct{})
+	go func() { _ = srv.Serve(ln); close(done) }()
+	t.Cleanup(func() { _ = srv.Close(); <-done })
+}
+
+// TestScanDiscoversRunnersInPrimaryAndLegacyDirs pins the upgrade
+// contract of the XDG_RUNTIME_DIR → state-dir socket move: runners
+// outlive gmuxd upgrades, so a runner that bound its socket in the old
+// default ($XDG_RUNTIME_DIR/gmux/sessions) must stay discoverable —
+// and attachable via its stored absolute SocketPath — alongside
+// runners in the new default (StateDir()/run/sessions). Without the
+// legacy scan, every pre-upgrade session would go dark on daemon
+// upgrade exactly the way the logind-teardown incident stranded them.
+func TestScanDiscoversRunnersInPrimaryAndLegacyDirs(t *testing.T) {
+	// Route every SessionSocketDir/LegacySessionSocketDirs branch into
+	// isolated temp dirs: no GMUX_SOCKET_DIR override (that disables
+	// the legacy scan by design), fresh XDG dirs, and a fresh TMPDIR so
+	// the per-uid temp fallback can't pick up real sockets on the host.
+	t.Setenv("GMUX_SOCKET_DIR", "")
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
+	t.Setenv("TMPDIR", t.TempDir())
+
+	primary := paths.SessionSocketDir()
+	legacy := paths.LegacySessionSocketDirs()[0]
+	for _, dir := range []string{primary, legacy} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+
+	newSock := filepath.Join(primary, "sess-new.sock")
+	oldSock := filepath.Join(legacy, "sess-old.sock")
+	serveAliveRunner(t, newSock, "sess-new")
+	serveAliveRunner(t, oldSock, "sess-old")
+
+	sessions := store.New()
+	subs := NewSubscriptions(sessions)
+	t.Cleanup(func() { subs.UnsubscribeAll() })
+
+	Scan(sessions, subs, nil)
+
+	for id, wantSock := range map[string]string{"sess-new": newSock, "sess-old": oldSock} {
+		got, ok := sessions.Get(id)
+		if !ok {
+			t.Fatalf("session %s missing from store after Scan", id)
+		}
+		if !got.Alive {
+			t.Errorf("%s: Alive = false, want true", id)
+		}
+		if got.SocketPath != wantSock {
+			t.Errorf("%s: SocketPath = %q, want %q (must keep the dir it bound in)", id, got.SocketPath, wantSock)
+		}
 	}
 }


### PR DESCRIPTION
## Problem

Runner sockets defaulted to `$XDG_RUNTIME_DIR/gmux/sessions` (since #295). But logind/elogind tear down `/run/user/$UID` when the user's last login session ends — `Linger=no` is the default for every user, including root — and the XDG spec *mandates* that runtime-dir contents not survive a full logout/login cycle. gmux runners outlive logins by design, so a single SSH login/logout cycle unlinked every live runner socket.

Observed in production (unraid host, root, gmuxd 1.6.1-snapshot): all runners alive and healthy, `/run/user/0/gmux/sessions` gone, every attach blinking "Connection lost", gmuxd dialing `connect: no such file or directory` at 1 Hz forever. Affected sessions can only be killed and resumed.

This is fully general: any process that inherits `XDG_RUNTIME_DIR` from a login session and outlives it hits this on any systemd/elogind host. It's the same reason tmux deliberately uses `/tmp/tmux-$UID` instead of the runtime dir.

## Fix

New default: **`~/.local/state/gmux/run/sessions`** — the same state tree as `gmuxd.sock`, which demonstrably survived the incident. Chosen over a per-uid `/tmp` dir because /tmp is exposed to systemd-tmpfiles age-based reaping of in-use sockets (tmux's long-standing pain), while stale socket files in the state dir are already self-healing: discovery `Scan` unlinks unreachable sockets older than 10s each tick.

Security parity with #295 is preserved:
- per-user by construction (under `$HOME`, no shared/squattable namespace at all — strictly better than /tmp),
- created 0700 by `ptyserver.BindSocket`,
- single source of truth in `paths.SessionSocketDir()` for runner + daemon,
- `GMUX_SOCKET_DIR` override unchanged (tests, devcontainers).

## Upgrade shim

Runners outlive daemon upgrades. Discovery additionally scans the legacy locations (`$XDG_RUNTIME_DIR/gmux/sessions`, per-uid temp dir) via `paths.LegacySessionSocketDirs()` so pre-upgrade runners stay discoverable and attachable through their stored absolute `SocketPath`. Disabled when `GMUX_SOCKET_DIR` is set. TODO(v2.1): drop.

## Tests

- `TestSessionSocketDir`: default ignores `XDG_RUNTIME_DIR`, resolves under the state dir.
- `TestLegacySessionSocketDirs`: all branches incl. suppression under `GMUX_SOCKET_DIR`.
- `TestScanDiscoversRunnersInPrimaryAndLegacyDirs`: live fake runners in both the new default and the legacy XDG dir are registered alive with their original socket paths (env fully isolated so the host's real sockets can't leak in).

## Docs

Updated environment.md, file-paths.md, architecture.md, session-schema.md — closing the stale-docs follow-up noted in #295 (they still cited `/tmp/gmux-sessions`).

## Known trade-offs (accepted)

- Unix `sun_path` (~104 bytes) with very long homedirs, and NFS-mounted homes where sockets can't bind — both fail loudly at runner startup; `GMUX_SOCKET_DIR` is the escape hatch.
- Daemon-side 1 Hz ENOENT redial with no backoff/state change is out of scope (noted for the reconnect-pill investigation).
- Sessions already stranded by a runtime-dir teardown can't be rescued by this; they need kill + resume.