### PR TITLE
fix(pi-ext): report a title-derived slug so session URLs stay human-readable

### DIFF
--- a/cli/gmux/internal/agentext/pi-ext.mjs
+++ b/cli/gmux/internal/agentext/pi-ext.mjs
@@ -12,7 +12,7 @@
 // Socket: GMUX_SESSION_SOCK, set by the runner.
 //
 // Events posted to POST /hook/event on the runner socket:
-//   { op: "session", path, id, name, cwd, reason }      on bind (session_start)
+//   { op: "session", path, id, name, slug, cwd, reason } on bind (session_start)
 //                                                         and rename (session_info_changed)
 //   { op: "turn", phase: "start" }                       on agent loop start
 //   { op: "turn", phase: "end", outcome, title }         on agent loop end
@@ -62,7 +62,21 @@ export default function (pi) {
     }
     if (!file) return; // nothing to attribute yet
     const title = name || firstUserTitle;
-    post(sock, { op: "session", path: String(file), id, name: title || undefined, cwd, reason });
+    // Report the title as the slug source too. pi's session id is a UUID that
+    // slugifies into an unreadable URL; without an explicit slug the runner
+    // falls back to Slugify(id) and session URLs become UUIDs. The runner
+    // slugifies whatever we send, so the raw title is fine here. Mirrors the
+    // codex and claude hooks, which send a title-derived slug for the same
+    // reason.
+    post(sock, {
+      op: "session",
+      path: String(file),
+      id,
+      name: title || undefined,
+      slug: title || undefined,
+      cwd,
+      reason,
+    });
   }
 
   // session_start is the one authoritative bind event: pi fires it on startup

--- a/cli/gmux/internal/agentext/pi_ext_slug_test.go
+++ b/cli/gmux/internal/agentext/pi_ext_slug_test.go
@@ -1,0 +1,128 @@
+package agentext
+
+import (
+	"encoding/json"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestPiExtSessionEventCarriesSlug is a regression test for session URLs
+// falling back to UUIDs: the pi extension must report an explicit slug
+// source (the resolved title) in its "session" hook events, because pi's
+// session id is a UUID and the runner's fallback is Slugify(id).
+//
+// It drives the embedded pi-ext.mjs with a stub `pi` object under real node,
+// and captures what the extension POSTs to the runner socket.
+func TestPiExtSessionEventCarriesSlug(t *testing.T) {
+	nodeBin, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("node not on PATH; skipping pi-ext behavior test")
+	}
+
+	dir := t.TempDir()
+	sockPath := filepath.Join(dir, "runner.sock")
+
+	// Fake runner: capture every POST /hook/event body.
+	var mu sync.Mutex
+	var events []map[string]any
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var ev map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&ev); err == nil {
+			mu.Lock()
+			events = append(events, ev)
+			mu.Unlock()
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})}
+	go srv.Serve(ln)
+	defer srv.Close()
+
+	// Write the embedded source directly rather than via Path(): its
+	// sync.Once result may point into another test's (since removed)
+	// temp XDG_CACHE_HOME.
+	extPath := filepath.Join(dir, "pi-ext.mjs")
+	if err := os.WriteFile(extPath, extSource, 0o644); err != nil {
+		t.Fatalf("materialize extension: %v", err)
+	}
+
+	// Stub pi: register handlers, fire session_start with a named session,
+	// then a rename, and give fire-and-forget posts time to flush.
+	driver := `
+		const ext = (await import(process.argv[2])).default;
+		const handlers = {};
+		ext({ on: (ev, fn) => { handlers[ev] = fn; } });
+		let name = "";
+		const ctx = { sessionManager: {
+			getSessionFile: () => "/tmp/conv.jsonl",
+			getSessionId: () => "019f2c63-2149-7b6d-865a-4ddc2af6b684",
+			getSessionName: () => name,
+			getCwd: () => "/tmp",
+		}};
+		handlers.session_start({ reason: "startup" }, ctx);
+		handlers.agent_end({ messages: [{ role: "user", content: "Fix the login bug" }] }, ctx);
+		name = "Renamed Session";
+		handlers.session_info_changed({}, ctx);
+		await new Promise((r) => setTimeout(r, 300));
+	`
+	driverPath := filepath.Join(dir, "driver.mjs")
+	if err := os.WriteFile(driverPath, []byte(driver), 0o644); err != nil {
+		t.Fatalf("write driver: %v", err)
+	}
+	cmd := exec.Command(nodeBin, driverPath, extPath)
+	cmd.Env = append(os.Environ(), "GMUX_SESSION_SOCK="+sockPath)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("node driver: %v\n%s", err, out)
+	}
+
+	// Collect session events (posts are async; wait briefly for stragglers).
+	deadline := time.Now().Add(2 * time.Second)
+	var sessions []map[string]any
+	for {
+		mu.Lock()
+		sessions = sessions[:0]
+		for _, ev := range events {
+			if ev["op"] == "session" {
+				sessions = append(sessions, ev)
+			}
+		}
+		n := len(sessions)
+		mu.Unlock()
+		if n >= 2 || time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if len(sessions) < 2 {
+		t.Fatalf("expected >=2 session events, got %d (%v)", len(sessions), events)
+	}
+
+	// The bind after the first turn carries the first-user-message title;
+	// the slug source must follow it — never left to the UUID id fallback.
+	foundTitled := false
+	for _, ev := range sessions {
+		name, _ := ev["name"].(string)
+		slug, _ := ev["slug"].(string)
+		if name == "" {
+			continue // pre-title bind: no slug source yet, id fallback is expected
+		}
+		foundTitled = true
+		if slug != name {
+			t.Errorf("session event with name %q: want slug %q, got %q", name, name, slug)
+		}
+	}
+	if !foundTitled {
+		t.Fatalf("no titled session event observed: %v", sessions)
+	}
+}

--- a/cli/gmux/internal/agentext/pi_ext_slug_test.go
+++ b/cli/gmux/internal/agentext/pi_ext_slug_test.go
@@ -10,6 +10,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/gmuxapp/gmux/packages/adapter"
 )
 
 // TestPiExtSessionEventCarriesSlug is a regression test for session URLs
@@ -108,18 +110,23 @@ func TestPiExtSessionEventCarriesSlug(t *testing.T) {
 		t.Fatalf("expected >=2 session events, got %d (%v)", len(sessions), events)
 	}
 
-	// The bind after the first turn carries the first-user-message title;
-	// the slug source must follow it — never left to the UUID id fallback.
+	// The runner slugifies whatever the hook sends, so pin behavior, not the
+	// wire encoding: every titled bind must carry a slug source that slugifies
+	// to the title's slug — never left to the UUID id fallback. The pre-title
+	// bind (session_start before any message) legitimately has no slug source.
 	foundTitled := false
 	for _, ev := range sessions {
 		name, _ := ev["name"].(string)
 		slug, _ := ev["slug"].(string)
 		if name == "" {
-			continue // pre-title bind: no slug source yet, id fallback is expected
+			if slug != "" {
+				t.Errorf("pre-title bind: want no slug source, got %q", slug)
+			}
+			continue
 		}
 		foundTitled = true
-		if slug != name {
-			t.Errorf("session event with name %q: want slug %q, got %q", name, name, slug)
+		if got, want := adapter.Slugify(slug), adapter.Slugify(name); got == "" || got != want {
+			t.Errorf("session event with name %q: slug source %q slugifies to %q, want %q", name, slug, got, want)
 		}
 	}
 	if !foundTitled {

--- a/cli/gmux/internal/ptyserver/ptyserver.go
+++ b/cli/gmux/internal/ptyserver/ptyserver.go
@@ -526,7 +526,7 @@ type hookEvent struct {
 	Pid  int    `json:"pid"`
 
 	ID      string `json:"id,omitempty"`
-	Slug    string `json:"slug,omitempty"` // explicit URL-safe slug; preferred over Slugify(ID)
+	Slug    string `json:"slug,omitempty"` // slug source (runner slugifies); preferred over Slugify(ID)
 	Name    string `json:"name,omitempty"`
 	Reason  string `json:"reason,omitempty"`
 	Title   string `json:"title,omitempty"`
@@ -558,8 +558,8 @@ func (s *Server) handleHookEvent(w http.ResponseWriter, r *http.Request) {
 			s.state.SetAdapterTitle(ev.Name)
 		}
 		// Slug source, in order of preference: an explicit slug the agent
-		// reports (e.g. codex, whose session id is a UUID that slugifies badly,
-		// sends a title-derived slug), else the identity to slugify.
+		// reports (codex and pi session ids are UUIDs that slugify badly, so
+		// their hooks send a title-derived slug), else the identity to slugify.
 		if ev.Slug != "" {
 			s.state.SetSlug(adapter.Slugify(ev.Slug))
 		} else if ev.ID != "" {

--- a/docs/runner-hook-protocol.md
+++ b/docs/runner-hook-protocol.md
@@ -45,7 +45,7 @@ One JSON object per event, discriminated by `op`. Unknown ops/values are ignored
   "op":     "session",
   "path":   "/abs/path/to/conversation-file",  // required
   "id":     "session-id",                       // optional; slugified for the URL if no slug
-  "slug":   "human-title",                      // optional; explicit URL-safe slug, preferred over id
+  "slug":   "human-title",                      // optional; slug source (runner slugifies), preferred over id
   "name":   "human title",                      // optional; sets the adapter title
   "cwd":    "/project/dir",                      // optional; accepted, not yet applied
   "reason": "startup|new|resume|fork|activity"  // optional; informational
@@ -63,7 +63,7 @@ One JSON object per event, discriminated by `op`. Unknown ops/values are ignored
 |-----------|----------|---------|
 | `path`    | session  | Absolute path of the held conversation file. |
 | `id`      | session  | Session identity; slugified into the URL when no `slug`. |
-| `slug`    | session  | Explicit URL-safe slug; preferred over `id` (e.g. codex's UUID slugifies badly). |
+| `slug`    | session  | Slug source, slugified by the runner; preferred over `id` (codex/pi session ids are UUIDs that slugify badly). |
 | `name`    | session  | Display title at bind time. |
 | `cwd`     | session  | Project dir. Accepted for forward-compat but not applied — the runner knows the launch cwd. |
 | `reason`  | session  | Why the bind happened; informational. |

--- a/services/gmuxd/internal/discovery/subscribe_test.go
+++ b/services/gmuxd/internal/discovery/subscribe_test.go
@@ -276,3 +276,31 @@ func TestConversationFileEventEmptyPathIgnored(t *testing.T) {
 		t.Errorf("empty path should not set ConversationFile, got %q", got.ConversationFile)
 	}
 }
+
+// TestMetaEventUpdatesSlugAndIgnoresEmpty pins the daemon half of the
+// session-URL slug chain: a runner "meta" event carrying a slug updates
+// the store (the web UI builds session URLs from it), and a later meta
+// event without a slug — the runner emits other meta fields
+// independently — must not clobber the one already recorded.
+func TestMetaEventUpdatesSlugAndIgnoresEmpty(t *testing.T) {
+	sessions := store.New()
+	sessions.Upsert(store.Session{ID: "sess-1", Alive: true})
+	subs := NewSubscriptions(sessions)
+
+	subs.handleEvent("sess-1", "/sock", "meta", []byte(`{"slug":"fix-the-login-bug"}`))
+	if got, _ := sessions.Get("sess-1"); got.Slug != "fix-the-login-bug" {
+		t.Fatalf("Slug = %q, want %q", got.Slug, "fix-the-login-bug")
+	}
+
+	// Unrelated meta update (title only) and an explicit empty slug: both
+	// must leave the recorded slug intact.
+	subs.handleEvent("sess-1", "/sock", "meta", []byte(`{"adapter_title":"Fix the login bug"}`))
+	subs.handleEvent("sess-1", "/sock", "meta", []byte(`{"slug":""}`))
+	got, _ := sessions.Get("sess-1")
+	if got.Slug != "fix-the-login-bug" {
+		t.Errorf("Slug after slug-less meta events = %q, want %q preserved", got.Slug, "fix-the-login-bug")
+	}
+	if got.AdapterTitle != "Fix the login bug" {
+		t.Errorf("AdapterTitle = %q, want %q", got.AdapterTitle, "Fix the login bug")
+	}
+}


### PR DESCRIPTION
## Problem

Web UI session URLs for pi sessions regressed from human-readable slugs (`/gmux/pi/fix-the-login-bug`) to UUIDs (`/gmux/pi/019f2c63-2149-7b6d-…`).

## Root cause

#315 (ADR 0010/0011) made the runner authoritative for session state and removed the daemon-side file-attribution path that used to derive pi slugs from the first user message. The runner's slug fallback is `Slugify(ev.ID)` (`cli/gmux/internal/ptyserver/ptyserver.go`, `handleHookEvent`), and pi session ids are UUIDv7 — so every live pi session got a UUID slug, which `sessionPath` in the web UI then puts in the URL.

#319 fixed the same problem for codex by having its hook send an explicit title-derived `slug`; the claude hook does too (`claudeSessionBody`). pi-ext.mjs was never given one — it sent `id` + `name` only.

## Fix

pi-ext.mjs now sends `slug: title` (session name, else first-user-message fallback) in every `op: "session"` event. The runner slugifies whatever the hook sends (already pinned by `TestSessionSlugPrefersExplicitSlug`, which feeds a raw title through the slug field), matching daemon-side `pi.go ParseConversationFile` — which already derives `Slug` from `Title` for dead sessions — so live and rehydrated slugs agree. Per #348, slug is the session's mutable display name, so slug-follows-rename is intended.

The pre-title bind (`session_start` before any message) still sends no slug source, so the id fallback covers it until the first turn ends — same staleness profile as claude.

Deep links by session id still resolve — routing's prefix match on session ID (`apps/gmux-web/src/routing.ts`) is untouched. Existing UUID-slugged sessions keep their persisted slug until their next bind refreshes it.

## Docs

Synced `docs/runner-hook-protocol.md` and the `hookEvent` comment: `slug` is a *slug source* the runner slugifies (not required to be pre-slugified), and the UUID-id caveat now names pi alongside codex.

## Test

New Go regression test drives the embedded pi-ext.mjs under real node with a stub `pi` object and a fake runner socket. It pins behavior, not wire encoding: titled session events must carry a slug source that slugifies to the title's slug, and the pre-title bind must not. Verified red (fails with the slug field removed) and green. Skips when node is absent.

## Coverage of the full chain

The bug spanned ext → runner → daemon → web; each link is now pinned:
- **ext → runner**: new `pi_ext_slug_test.go` (drives the embedded .mjs under node; titled binds carry a slug source, pre-title bind does not)
- **runner slug policy**: pre-existing `TestSessionSlugPrefersExplicitSlug` (explicit slug wins over `Slugify(id)`)
- **daemon store**: new `TestMetaEventUpdatesSlugAndIgnoresEmpty` (meta slug updates the store; slug-less/empty-slug meta events don't clobber it)
- **web**: pre-existing routing tests (`sessionPath` uses `session.slug`)