### PR TITLE
fix(daemon): point at tailnet HTTPS settings when remote setup stalls

### DIFF
--- a/services/gmuxd/cmd/gmuxd/remote.go
+++ b/services/gmuxd/cmd/gmuxd/remote.go
@@ -280,11 +280,22 @@ func remotePoll(stdout, stderr io.Writer) int {
 
 	fmt.Fprintln(stdout) // end the "Connecting..." line
 
-	if result == nil || result.TS == nil {
+	if result == nil {
 		fmt.Fprintln(stdout)
 		fmt.Fprintln(stderr, "Could not reach the daemon. Check that it's running:")
 		fmt.Fprintln(stderr, "  gmuxd start")
 		return 1
+	}
+	if result.TS == nil {
+		// Daemon is reachable but hasn't started Tailscale yet.
+		fmt.Fprintln(stdout)
+		fmt.Fprintln(stdout, "The daemon is running but Tailscale hasn't started yet.")
+		fmt.Fprintln(stdout)
+		fmt.Fprintln(stdout, "Try again shortly:")
+		fmt.Fprintln(stdout, "  gmuxd remote")
+		fmt.Fprintln(stdout)
+		fmt.Fprintf(stdout, "Docs: %s\n", remoteDocsURL)
+		return 0
 	}
 
 	return displayStatus(result, stdout)
@@ -339,7 +350,24 @@ func displayStatus(h *tailscaleHealth, stdout io.Writer) int {
 		return 0
 	}
 
-	// Not connected and no auth URL. Tailscale is in some intermediate state.
+	// Not connected and no auth URL. Tailscale is in some intermediate
+	// state. If the tailnet doesn't have HTTPS certificates enabled,
+	// the listener can never come up: tsnet needs a cert to serve.
+	// Surface that directly instead of telling the user to retry forever.
+	if !ts.HTTPS {
+		fmt.Fprintln(stdout, "Tailscale is logged in but the connection isn't coming up.")
+		fmt.Fprintln(stdout, "The most likely cause: HTTPS is not enabled in your tailnet,")
+		fmt.Fprintln(stdout, "which gmuxd needs to serve remote access.")
+		fmt.Fprintln(stdout)
+		fmt.Fprintln(stdout, "Enable HTTPS (and MagicDNS) in your Tailscale admin console:")
+		fmt.Fprintln(stdout, "  https://login.tailscale.com/admin/dns")
+		fmt.Fprintln(stdout)
+		fmt.Fprintln(stdout, "Then run `gmuxd remote` again.")
+		fmt.Fprintln(stdout)
+		fmt.Fprintf(stdout, "Docs: %s\n", remoteDocsURL)
+		return 1
+	}
+
 	fmt.Fprintln(stdout, "Tailscale is still connecting. This can take a minute on first setup.")
 	fmt.Fprintln(stdout)
 	fmt.Fprintln(stdout, "Try again shortly:")

--- a/services/gmuxd/cmd/gmuxd/remote.go
+++ b/services/gmuxd/cmd/gmuxd/remote.go
@@ -200,11 +200,12 @@ type tailscaleHealth struct {
 }
 
 type tsHealth struct {
-	FQDN      string `json:"fqdn"`
-	MagicDNS  bool   `json:"magic_dns"`
-	HTTPS     bool   `json:"https"`
-	AuthURL   string `json:"auth_url"`
-	Connected bool   `json:"connected"`
+	FQDN         string `json:"fqdn"`
+	MagicDNS     bool   `json:"magic_dns"`
+	HTTPS        bool   `json:"https"`
+	AuthURL      string `json:"auth_url"`
+	BackendState string `json:"backend_state"`
+	Connected    bool   `json:"connected"`
 }
 
 // fetchTailscaleHealth fetches the tailscale status from the daemon.
@@ -286,8 +287,16 @@ func remotePoll(stdout, stderr io.Writer) int {
 		fmt.Fprintln(stderr, "  gmuxd start")
 		return 1
 	}
-	if result.TS == nil {
-		// Daemon is reachable but hasn't started Tailscale yet.
+
+	return displayStatus(result, stdout)
+}
+
+// displayStatus renders the tailscale connection status.
+func displayStatus(h *tailscaleHealth, stdout io.Writer) int {
+	ts := h.TS
+
+	// Daemon is reachable but hasn't started Tailscale yet.
+	if ts == nil {
 		fmt.Fprintln(stdout)
 		fmt.Fprintln(stdout, "The daemon is running but Tailscale hasn't started yet.")
 		fmt.Fprintln(stdout)
@@ -297,13 +306,6 @@ func remotePoll(stdout, stderr io.Writer) int {
 		fmt.Fprintf(stdout, "Docs: %s\n", remoteDocsURL)
 		return 0
 	}
-
-	return displayStatus(result, stdout)
-}
-
-// displayStatus renders the tailscale connection status.
-func displayStatus(h *tailscaleHealth, stdout io.Writer) int {
-	ts := h.TS
 
 	// Needs login: show the auth URL and nothing else. The user must
 	// complete login before we can know about HTTPS/MagicDNS.
@@ -351,13 +353,16 @@ func displayStatus(h *tailscaleHealth, stdout io.Writer) int {
 	}
 
 	// Not connected and no auth URL. Tailscale is in some intermediate
-	// state. If the tailnet doesn't have HTTPS certificates enabled,
-	// the listener can never come up: tsnet needs a cert to serve.
-	// Surface that directly instead of telling the user to retry forever.
-	if !ts.HTTPS {
+	// state. If the backend is running (logged in, netmap synced) but
+	// the tailnet has no HTTPS certificates enabled, the listener can
+	// never come up: tsnet needs a cert to serve. Surface that directly
+	// instead of telling the user to retry forever. Only trust the
+	// HTTPS flag when the backend reports Running; before that, false
+	// may just mean the state isn't known yet.
+	if ts.BackendState == "Running" && !ts.HTTPS {
 		fmt.Fprintln(stdout, "Tailscale is logged in but the connection isn't coming up.")
-		fmt.Fprintln(stdout, "The most likely cause: HTTPS is not enabled in your tailnet,")
-		fmt.Fprintln(stdout, "which gmuxd needs to serve remote access.")
+		fmt.Fprintln(stdout, "The cause: HTTPS is not enabled in your tailnet, which gmuxd")
+		fmt.Fprintln(stdout, "needs to serve remote access.")
 		fmt.Fprintln(stdout)
 		fmt.Fprintln(stdout, "Enable HTTPS (and MagicDNS) in your Tailscale admin console:")
 		fmt.Fprintln(stdout, "  https://login.tailscale.com/admin/dns")

--- a/services/gmuxd/cmd/gmuxd/remote_test.go
+++ b/services/gmuxd/cmd/gmuxd/remote_test.go
@@ -315,8 +315,9 @@ func TestDisplayStatus_NotConnectedMissingHTTPS(t *testing.T) {
 	h := &tailscaleHealth{
 		Listen: "127.0.0.1:8790",
 		TS: &tsHealth{
-			Connected: false,
-			HTTPS:     false,
+			Connected:    false,
+			HTTPS:        false,
+			BackendState: "Running",
 		},
 	}
 	code := displayStatus(h, &stdout)
@@ -329,6 +330,47 @@ func TestDisplayStatus_NotConnectedMissingHTTPS(t *testing.T) {
 	}
 	if !strings.Contains(out, "login.tailscale.com/admin/dns") {
 		t.Errorf("should link to admin console:\n%s", out)
+	}
+}
+
+// Before the backend reaches Running, HTTPS=false may just mean the
+// tailnet state isn't known yet. Don't blame HTTPS settings then.
+func TestDisplayStatus_StartingHTTPSUnknown(t *testing.T) {
+	var stdout bytes.Buffer
+	h := &tailscaleHealth{
+		Listen: "127.0.0.1:8790",
+		TS: &tsHealth{
+			Connected:    false,
+			HTTPS:        false,
+			BackendState: "Starting",
+		},
+	}
+	code := displayStatus(h, &stdout)
+	if code != 0 {
+		t.Errorf("exit code = %d, want 0", code)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "still connecting") {
+		t.Errorf("should say still connecting:\n%s", out)
+	}
+	if strings.Contains(out, "login.tailscale.com/admin/dns") {
+		t.Errorf("should not blame HTTPS while backend state is unknown:\n%s", out)
+	}
+}
+
+func TestDisplayStatus_TailscaleNotStarted(t *testing.T) {
+	var stdout bytes.Buffer
+	h := &tailscaleHealth{Listen: "127.0.0.1:8790", TS: nil}
+	code := displayStatus(h, &stdout)
+	if code != 0 {
+		t.Errorf("exit code = %d, want 0", code)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "Tailscale hasn't started yet") {
+		t.Errorf("should say tailscale hasn't started:\n%s", out)
+	}
+	if strings.Contains(out, "Could not reach the daemon") {
+		t.Errorf("should not claim the daemon is unreachable:\n%s", out)
 	}
 }
 

--- a/services/gmuxd/cmd/gmuxd/remote_test.go
+++ b/services/gmuxd/cmd/gmuxd/remote_test.go
@@ -293,6 +293,8 @@ func TestDisplayStatus_NotConnected(t *testing.T) {
 		Listen: "127.0.0.1:8790",
 		TS: &tsHealth{
 			Connected: false,
+			HTTPS:     true,
+			MagicDNS:  true,
 		},
 	}
 	code := displayStatus(h, &stdout)
@@ -303,9 +305,30 @@ func TestDisplayStatus_NotConnected(t *testing.T) {
 	if !strings.Contains(out, "still connecting") {
 		t.Errorf("should say still connecting:\n%s", out)
 	}
-	// Should NOT mention HTTPS or MagicDNS problems.
-	if strings.Contains(out, "HTTPS") || strings.Contains(out, "MagicDNS") {
-		t.Errorf("should not mention HTTPS/MagicDNS when not connected:\n%s", out)
+	if strings.Contains(out, "login.tailscale.com/admin/dns") {
+		t.Errorf("should not point at admin console when tailnet is fine:\n%s", out)
+	}
+}
+
+func TestDisplayStatus_NotConnectedMissingHTTPS(t *testing.T) {
+	var stdout bytes.Buffer
+	h := &tailscaleHealth{
+		Listen: "127.0.0.1:8790",
+		TS: &tsHealth{
+			Connected: false,
+			HTTPS:     false,
+		},
+	}
+	code := displayStatus(h, &stdout)
+	if code != 1 {
+		t.Errorf("exit code = %d, want 1", code)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "HTTPS is not enabled") {
+		t.Errorf("should name HTTPS as the likely cause:\n%s", out)
+	}
+	if !strings.Contains(out, "login.tailscale.com/admin/dns") {
+		t.Errorf("should link to admin console:\n%s", out)
 	}
 }
 

--- a/services/gmuxd/internal/tsauth/tsauth.go
+++ b/services/gmuxd/internal/tsauth/tsauth.go
@@ -47,6 +47,11 @@ type DiagStatus struct {
 	// AuthURL is set when the node needs login. The user must visit
 	// this URL to register the device in their tailnet.
 	AuthURL string `json:"auth_url,omitempty"`
+	// BackendState is the tailscale backend state (e.g. "Running",
+	// "Starting", "NeedsLogin"). When it is "Running", the netmap is
+	// synced and HTTPS/MagicDNS above are authoritative; otherwise
+	// they may read false simply because the state isn't known yet.
+	BackendState string `json:"backend_state,omitempty"`
 	// Connected is true when the listener is fully operational.
 	Connected bool `json:"connected"`
 }
@@ -81,6 +86,7 @@ func (l *Listener) Diag() DiagStatus {
 	if status.AuthURL != "" {
 		ds.AuthURL = status.AuthURL
 	}
+	ds.BackendState = status.BackendState
 	ds.HTTPS = len(status.CertDomains) > 0
 	if status.CurrentTailnet != nil {
 		ds.MagicDNS = status.CurrentTailnet.MagicDNSSuffix != ""


### PR DESCRIPTION
Fixes #220.

When `gmuxd remote` times out waiting for Tailscale, the generic "still connecting, try again" message hides the most common real cause: HTTPS is not enabled in the tailnet, so tsnet can never fetch a cert and the listener never comes up. Re-running the command loops forever.

Instead of guessing, the CLI now probes the actual cause. The daemon's health payload gains a `backend_state` field (from `lc.Status().BackendState`); `https` (from `CertDomains`) is only trusted once the backend reports `Running`, i.e. logged in with the netmap synced.

- **Not connected + backend `Running` + `https: false`** → HTTPS is confirmed disabled in the tailnet: say so, link to https://login.tailscale.com/admin/dns, exit 1.
- **Not connected, backend not `Running` yet** (or `https: true`) → existing "still connecting" message; `https: false` before `Running` may just mean the state isn't known yet.
- **Daemon reachable but no tailscale object in health** → honest "daemon is running but Tailscale hasn't started yet" instead of the misleading "Could not reach the daemon". Moved into `displayStatus` so it's unit-testable.

Tests cover all four branches.