### PR TITLE
fix(daemon): --wait no longer reports phantom death during session startup

### DIFF
--- a/services/gmuxd/cmd/gmuxd/wait.go
+++ b/services/gmuxd/cmd/gmuxd/wait.go
@@ -233,15 +233,28 @@ func waitForSessionExit(sessions *store.Store, evCh <-chan store.Event, sessionI
 // The Alive flag needs the symmetric treatment: right after launch
 // the session exists in the store with Alive == false until the
 // runner's first upsert lands, and reporting "died" during that
-// window is a phantom death (issue #216). seenAlive is the caller's
-// record of whether this wait ever observed Alive == true; "died" is
-// only reported after a true→false transition, or when ExitCode is
-// set — a non-nil ExitCode means the runner watched the child
-// process exit, which is definitive regardless of the startup race
-// and keeps genuinely dead-on-arrival sessions failing fast.
+// window is a phantom death (issue #216). "died" therefore requires
+// evidence the session ever ran, from any of:
+//
+//   - seenAlive: this wait observed Alive == true, then it flipped
+//     (the caller's record across snapshot/event/poll observations);
+//   - ExitCode != nil: the runner watched the child process exit
+//     (SetExited), definitive for dead-on-arrival fast-exit commands;
+//   - StartedAt != "": the runner stamped SetRunning at some point.
+//     This is what keeps already-dead sessions failing fast when the
+//     runner never reported an exit code: force-marked-dead sessions
+//     (unreachable runner on kill, stale-socket sweep) and sessions
+//     restored from sessionmeta after a daemon restart all carry
+//     their historical StartedAt, so --wait on them must not block
+//     waiting for a resurrection that can't happen.
+//
+// A session with none of the three has never run — either it's in
+// the startup window (the common case, resolved by the runner's next
+// upsert) or its runner died before ever spawning the child (rare;
+// bounded by --timeout).
 func terminalReason(s store.Session, seenAlive bool) (string, bool) {
 	if !s.Alive {
-		if seenAlive || s.ExitCode != nil {
+		if seenAlive || s.ExitCode != nil || s.StartedAt != "" {
 			return "died", true
 		}
 		return "", false

--- a/services/gmuxd/cmd/gmuxd/wait.go
+++ b/services/gmuxd/cmd/gmuxd/wait.go
@@ -77,11 +77,22 @@ func handleWait(w http.ResponseWriter, r *http.Request, sessions *store.Store, s
 	evCh, unsub := sessions.Subscribe()
 	defer unsub()
 
+	// Whether we've observed this session with Alive == true at any
+	// point during this wait. There is a startup window between
+	// sessions.Register returning the id (so the CLI can resolve it)
+	// and the runner flipping Alive to true; during that window
+	// Alive == false means "not started yet", not "died". Gating
+	// "died" on seenAlive keeps its contract as "was alive, isn't
+	// anymore" — mirroring how a nil Status is treated as "no state
+	// yet" rather than idle (see terminalReason).
+	seenAlive := false
+
 	// Already in a terminal state? Return without waiting for a
 	// transition. Callers like `--send-wait` (composition) want
 	// `--wait` to be a no-op when the agent is already idle.
 	if cur, ok := sessions.Get(sessionID); ok {
-		if reason, done := terminalReason(cur); done {
+		seenAlive = seenAlive || cur.Alive
+		if reason, done := terminalReason(cur, seenAlive); done {
 			writeJSON(w, map[string]any{"ok": true, "data": map[string]any{"reason": reason}})
 			return
 		}
@@ -121,7 +132,8 @@ func handleWait(w http.ResponseWriter, r *http.Request, sessions *store.Store, s
 				writeJSON(w, map[string]any{"ok": true, "data": map[string]any{"reason": "died"}})
 				return
 			}
-			if reason, done := terminalReason(*ev.Session); done {
+			seenAlive = seenAlive || ev.Session.Alive
+			if reason, done := terminalReason(*ev.Session, seenAlive); done {
 				writeJSON(w, map[string]any{"ok": true, "data": map[string]any{"reason": reason}})
 				return
 			}
@@ -133,7 +145,8 @@ func handleWait(w http.ResponseWriter, r *http.Request, sessions *store.Store, s
 				writeJSON(w, map[string]any{"ok": true, "data": map[string]any{"reason": "died"}})
 				return
 			}
-			if reason, done := terminalReason(cur); done {
+			seenAlive = seenAlive || cur.Alive
+			if reason, done := terminalReason(cur, seenAlive); done {
 				writeJSON(w, map[string]any{"ok": true, "data": map[string]any{"reason": reason}})
 				return
 			}
@@ -216,9 +229,22 @@ func waitForSessionExit(sessions *store.Store, evCh <-chan store.Event, sessionI
 // would race the runner's first Working:true event and return
 // immediately without the agent having processed anything. Wait
 // instead for the adapter to assert a real state.
-func terminalReason(s store.Session) (string, bool) {
+//
+// The Alive flag needs the symmetric treatment: right after launch
+// the session exists in the store with Alive == false until the
+// runner's first upsert lands, and reporting "died" during that
+// window is a phantom death (issue #216). seenAlive is the caller's
+// record of whether this wait ever observed Alive == true; "died" is
+// only reported after a true→false transition, or when ExitCode is
+// set — a non-nil ExitCode means the runner watched the child
+// process exit, which is definitive regardless of the startup race
+// and keeps genuinely dead-on-arrival sessions failing fast.
+func terminalReason(s store.Session, seenAlive bool) (string, bool) {
 	if !s.Alive {
-		return "died", true
+		if seenAlive || s.ExitCode != nil {
+			return "died", true
+		}
+		return "", false
 	}
 	if s.Status != nil && !s.Status.Working {
 		return "idle", true

--- a/services/gmuxd/cmd/gmuxd/wait.go
+++ b/services/gmuxd/cmd/gmuxd/wait.go
@@ -234,27 +234,11 @@ func waitForSessionExit(sessions *store.Store, evCh <-chan store.Event, sessionI
 // the session exists in the store with Alive == false until the
 // runner's first upsert lands, and reporting "died" during that
 // window is a phantom death (issue #216). "died" therefore requires
-// evidence the session ever ran, from any of:
-//
-//   - seenAlive: this wait observed Alive == true, then it flipped
-//     (the caller's record across snapshot/event/poll observations);
-//   - ExitCode != nil: the runner watched the child process exit
-//     (SetExited), definitive for dead-on-arrival fast-exit commands;
-//   - StartedAt != "": the runner stamped SetRunning at some point.
-//     This is what keeps already-dead sessions failing fast when the
-//     runner never reported an exit code: force-marked-dead sessions
-//     (unreachable runner on kill, stale-socket sweep) and sessions
-//     restored from sessionmeta after a daemon restart all carry
-//     their historical StartedAt, so --wait on them must not block
-//     waiting for a resurrection that can't happen.
-//
-// A session with none of the three has never run — either it's in
-// the startup window (the common case, resolved by the runner's next
-// upsert) or its runner died before ever spawning the child (rare;
-// bounded by --timeout).
+// hasRunEvidence(s, seenAlive) — see that helper for the three signals
+// that count as "this session actually ran."
 func terminalReason(s store.Session, seenAlive bool) (string, bool) {
 	if !s.Alive {
-		if seenAlive || s.ExitCode != nil || s.StartedAt != "" {
+		if hasRunEvidence(s, seenAlive) {
 			return "died", true
 		}
 		return "", false
@@ -263,6 +247,33 @@ func terminalReason(s store.Session, seenAlive bool) (string, bool) {
 		return "idle", true
 	}
 	return "", false
+}
+
+// hasRunEvidence reports whether a not-Alive session ever actually
+// ran, which is what distinguishes a genuine death from the startup
+// window where the session is registered but the runner's first
+// upsert hasn't flipped Alive to true yet (issue #216). Evidence comes
+// from any of:
+//
+//   - seenAlive: the caller observed Alive == true earlier in this
+//     wait (tracked across its snapshot/event/poll observations), so a
+//     later Alive == false is a true→false transition;
+//   - ExitCode != nil: the runner watched the child process exit
+//     (SetExited) — definitive even if this wait never saw it alive;
+//   - StartedAt != "": the runner stamped SetRunning at some point.
+//     Force-marked-dead sessions (unreachable runner on kill,
+//     stale-socket sweep) and sessions restored from sessionmeta after
+//     a daemon restart carry their historical StartedAt with no live
+//     ExitCode, so a wait on them must fail fast rather than block for
+//     a resurrection that can't come.
+//
+// A session with none of the three has never run: either it's in the
+// startup window (common; the runner's next upsert resolves it) or its
+// runner died before spawning the child (rare; bounded by --timeout).
+// Shared by the idle wait (terminalReason) and the output-condition
+// wait so the gate can't drift between them.
+func hasRunEvidence(s store.Session, seenAlive bool) bool {
+	return seenAlive || s.ExitCode != nil || s.StartedAt != ""
 }
 
 // adapterEmitsIdleSignal reports whether sessions of the given

--- a/services/gmuxd/cmd/gmuxd/wait_test.go
+++ b/services/gmuxd/cmd/gmuxd/wait_test.go
@@ -261,6 +261,38 @@ func TestWaitReportsDiedOnArrivalWithExitCode(t *testing.T) {
 	}
 }
 
+// TestWaitReportsDiedForStaleDeadSession pins the other side of the
+// #216 fix: sessions that ran in the past but are dead now must not
+// be mistaken for "still starting up". Force-marked-dead sessions
+// (unreachable runner on kill, stale-socket sweep) and sessions
+// restored from sessionmeta after a daemon restart carry StartedAt
+// but may have no ExitCode — --wait on them must return died
+// immediately, not hang until timeout.
+func TestWaitReportsDiedForStaleDeadSession(t *testing.T) {
+	srv, st := waitTestServer(t)
+	st.Upsert(store.Session{
+		ID:        "sess-stale",
+		Adapter:   "pi",
+		Alive:     false,
+		StartedAt: "2026-01-01T00:00:00Z",
+		Command:   []string{"pi", "--resume", "abc"},
+	})
+
+	start := time.Now()
+	resp, body := postWait(t, srv, "sess-stale")
+	elapsed := time.Since(start)
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if got := body["data"].(map[string]any)["reason"]; got != "died" {
+		t.Errorf("reason = %v, want died", got)
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("returned in %v, want immediate", elapsed)
+	}
+}
+
 // TestWaitTimesOut verifies the timeout escape hatch returns a
 // distinct HTTP status (408) so the CLI can tell timeout apart from
 // idle and from died.

--- a/services/gmuxd/cmd/gmuxd/wait_test.go
+++ b/services/gmuxd/cmd/gmuxd/wait_test.go
@@ -165,6 +165,102 @@ func TestWaitReturnsDiedWhenSessionDies(t *testing.T) {
 	}
 }
 
+// TestWaitDoesNotReportDiedBeforeFirstAlive pins the fix for the
+// early-Alive race (issue #216): right after `gmux --no-attach`, the
+// session exists in the store with Alive == false until the runner's
+// first upsert lands. --wait during that window must not report a
+// phantom death; it should block until the session comes alive and
+// then resolve normally.
+func TestWaitDoesNotReportDiedBeforeFirstAlive(t *testing.T) {
+	srv, st := waitTestServer(t)
+	// Registered but not yet alive: no ExitCode, no Status — the
+	// runner hasn't reported anything.
+	st.Upsert(store.Session{
+		ID:      "sess-starting",
+		Adapter: "pi",
+		Alive:   false,
+	})
+
+	done := make(chan struct{})
+	var resp *http.Response
+	var body map[string]any
+	go func() {
+		resp, body = postWait(t, srv, "sess-starting")
+		close(done)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	select {
+	case <-done:
+		t.Fatal("--wait returned before the session ever became alive")
+	default:
+	}
+
+	// Runner comes up mid-turn...
+	st.Upsert(store.Session{
+		ID:      "sess-starting",
+		Adapter: "pi",
+		Alive:   true,
+		Status:  &store.Status{Working: true},
+	})
+	time.Sleep(50 * time.Millisecond)
+	select {
+	case <-done:
+		t.Fatal("--wait returned while the agent was still working")
+	default:
+	}
+
+	// ...and finishes its turn.
+	st.Upsert(store.Session{
+		ID:      "sess-starting",
+		Adapter: "pi",
+		Alive:   true,
+		Status:  &store.Status{Working: false},
+	})
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("--wait did not return after the session became idle")
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if got := body["data"].(map[string]any)["reason"]; got != "idle" {
+		t.Errorf("reason = %v, want idle", got)
+	}
+}
+
+// TestWaitReportsDiedOnArrivalWithExitCode covers the fast-fail path
+// for sessions that are genuinely dead on arrival: a non-nil ExitCode
+// means the runner watched the child process exit, so "died" is
+// definitive even though this wait never observed Alive == true.
+func TestWaitReportsDiedOnArrivalWithExitCode(t *testing.T) {
+	srv, st := waitTestServer(t)
+	code := 1
+	st.Upsert(store.Session{
+		ID:       "sess-doa",
+		Adapter:  "claude",
+		Alive:    false,
+		ExitCode: &code,
+	})
+
+	start := time.Now()
+	resp, body := postWait(t, srv, "sess-doa")
+	elapsed := time.Since(start)
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if got := body["data"].(map[string]any)["reason"]; got != "died" {
+		t.Errorf("reason = %v, want died", got)
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("returned in %v, want immediate", elapsed)
+	}
+}
+
 // TestWaitTimesOut verifies the timeout escape hatch returns a
 // distinct HTTP status (408) so the CLI can tell timeout apart from
 // idle and from died.


### PR DESCRIPTION
Fixes #216.

Right after `gmux --no-attach <agent>`, the session exists in the store with `Alive == false` until the runner's first upsert lands (the runner registers with `Alive=false` and only `SetRunning` flips it true). `--wait` during that window returned `reason=died` — a phantom death for a session that was still spinning up.

## Fix

Local to `handleWait`, per the plan on the issue; no new store state:

- Track `seenAlive` across all three observation paths (initial snapshot, event, ticker poll).
- `terminalReason` is now pure over `(session, seenAlive)`.
- `"died"` requires evidence the session ever ran: `seenAlive || s.ExitCode != nil || s.StartedAt != ""`.
  - `ExitCode != nil`: the runner watched the child exit (`SetExited`) — dead-on-arrival fast-exit commands still fail fast.
  - `StartedAt != ""`: the runner stamped `SetRunning` at some point. This keeps already-dead sessions failing fast when no exit code was recorded — force-marked-dead sessions (unreachable runner on kill, stale-socket sweep) and sessions restored from sessionmeta after a daemon restart all carry their historical `StartedAt`. (Addresses the Greptile P1.)

The session-remove paths (nil event / store miss) still return `died` immediately — a remove is definitive regardless of the startup race.

Residual: a session whose runner dies before ever spawning the child (no StartedAt, no ExitCode, socket gone) waits until `--timeout`. That's the rare case the issue plan explicitly left to the timeout escape hatch.

## Tests

- `TestWaitDoesNotReportDiedBeforeFirstAlive`: registered-but-not-yet-alive session blocks through startup → working → idle, returns `idle`.
- `TestWaitReportsDiedOnArrivalWithExitCode`: dead-on-arrival with `ExitCode` set returns `died` immediately.
- `TestWaitReportsDiedForStaleDeadSession`: dead session with `StartedAt` but no `ExitCode` (force-dead / restart-restored shape) returns `died` immediately.
- Full `services/gmuxd` suite passes.

## Merge-order note

Open PRs #370 and #371 also touch `services/gmuxd/cmd/gmuxd/wait.go`, and #371's `awaitTurn` path calls `terminalReason` with the old one-arg signature. Whichever lands second needs a trivial rebase: pass the local `seenAlive` (or `true`, in contexts that only run after a Working=true observation) at the new call sites.