### PR TITLE
fix(peering): dedupe repeated disconnect logs for an unreachable peer

### DIFF
--- a/services/gmuxd/internal/peering/peer.go
+++ b/services/gmuxd/internal/peering/peer.go
@@ -277,15 +277,30 @@ func (p *Peer) ProxyWS(w http.ResponseWriter, r *http.Request, originalID string
 	p.api.ProxyWS(w, r, originalID)
 }
 
+// Backoff bounds for peer reconnects. The ceiling stays at 30s
+// deliberately: peering is a dial-out-only relationship (the hub
+// opens the SSE stream; the spoke cannot push "I'm online"), so
+// reconnect latency is bounded solely by this interval. A longer
+// ceiling would mean a peer that just came online stays invisible
+// for minutes. The log spam that motivated issue #244 is handled by
+// deduping the disconnect log (see run's lastLogged), not by
+// stretching the retry cadence. Transient drops recover fast because
+// backoff resets to initialBackoff after any successful connection.
+const (
+	initialBackoff = 1 * time.Second
+	maxBackoff     = 30 * time.Second
+)
+
 // run connects to the spoke's SSE stream and processes events until
 // the context is cancelled. Handles reconnection with exponential
 // backoff.
 func (p *Peer) run(ctx context.Context) {
-	const (
-		initialBackoff = 1 * time.Second
-		maxBackoff     = 30 * time.Second
-	)
 	backoff := initialBackoff
+	// lastLogged dedupes disconnect logs: repeated identical failures
+	// against a down host are logged once, not on every retry. Any
+	// change in the failure (or a successful connection in between)
+	// logs again.
+	lastLogged := ""
 
 	for {
 		if ctx.Err() != nil {
@@ -322,9 +337,14 @@ func (p *Peer) run(ctx context.Context) {
 		// reconnect quickly instead of carrying over stale backoff.
 		if wasConnected {
 			backoff = initialBackoff
+			lastLogged = ""
 		}
 
-		log.Printf("peering: %s: disconnected: %v (retry in %s)", p.Config.Name, err, backoff)
+		msg := fmt.Sprintf("%v", err)
+		if msg != lastLogged {
+			log.Printf("peering: %s: disconnected: %v (retrying, up to every %s)", p.Config.Name, err, maxBackoff)
+			lastLogged = msg
+		}
 
 		select {
 		case <-ctx.Done():

--- a/services/gmuxd/internal/peering/peer.go
+++ b/services/gmuxd/internal/peering/peer.go
@@ -64,6 +64,11 @@ type Peer struct {
 	// streamIdleTimeout overrides the default SSE idle timeout.
 	// Zero means use defaultStreamIdleTimeout.
 	streamIdleTimeout time.Duration
+
+	// reconnectBackoff overrides initialBackoff in the run loop.
+	// Zero means use initialBackoff. Test-only: lets the reconnect
+	// tests run at millisecond cadence instead of real seconds.
+	reconnectBackoff time.Duration
 }
 
 func newPeer(cfg config.PeerConfig, st *store.Store, onStatus func(string, Status), opts ...PeerOption) *Peer {
@@ -295,7 +300,11 @@ const (
 // the context is cancelled. Handles reconnection with exponential
 // backoff.
 func (p *Peer) run(ctx context.Context) {
-	backoff := initialBackoff
+	minBackoff := initialBackoff
+	if p.reconnectBackoff > 0 {
+		minBackoff = p.reconnectBackoff
+	}
+	backoff := minBackoff
 	// lastLogged dedupes disconnect logs: repeated identical failures
 	// against a down host are logged once, not on every retry. Any
 	// change in the failure (or a successful connection in between)
@@ -336,7 +345,7 @@ func (p *Peer) run(ctx context.Context) {
 		// Reset backoff after a successful connection so transient drops
 		// reconnect quickly instead of carrying over stale backoff.
 		if wasConnected {
-			backoff = initialBackoff
+			backoff = minBackoff
 			lastLogged = ""
 		}
 

--- a/services/gmuxd/internal/peering/peer_error_test.go
+++ b/services/gmuxd/internal/peering/peer_error_test.go
@@ -1,8 +1,17 @@
 package peering
 
 import (
+	"bytes"
+	"context"
 	"errors"
+	"log"
+	"strings"
+	"sync"
 	"testing"
+	"time"
+
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/config"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/store"
 )
 
 func TestCategorizeError(t *testing.T) {
@@ -27,4 +36,53 @@ func TestCategorizeError(t *testing.T) {
 			t.Errorf("categorizeError(%q) = %q, want %q", tt.err, got, tt.want)
 		}
 	}
+}
+
+// TestRun_DedupesDisconnectLogs verifies that repeated identical
+// connection failures produce a single disconnect log line rather
+// than one per retry attempt (issue #244).
+func TestRun_DedupesDisconnectLogs(t *testing.T) {
+	var buf syncBuffer
+	prev := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(prev)
+
+	// Point at a port nothing listens on: every attempt fails the
+	// same way (connection refused).
+	p := newPeer(config.PeerConfig{Name: "down", URL: "http://127.0.0.1:1"}, store.New(), nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		p.run(ctx)
+		close(done)
+	}()
+
+	// Enough time for several attempts (backoff starts at 1s).
+	time.Sleep(2500 * time.Millisecond)
+	cancel()
+	<-done
+
+	got := strings.Count(buf.String(), "peering: down: disconnected:")
+	if got != 1 {
+		t.Errorf("want exactly 1 disconnect log for repeated identical failures, got %d\nlogs:\n%s", got, buf.String())
+	}
+}
+
+// syncBuffer is a goroutine-safe bytes.Buffer for capturing log output.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
 }

--- a/services/gmuxd/internal/peering/peer_error_test.go
+++ b/services/gmuxd/internal/peering/peer_error_test.go
@@ -4,9 +4,13 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"log"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -38,18 +42,48 @@ func TestCategorizeError(t *testing.T) {
 	}
 }
 
-// TestRun_DedupesDisconnectLogs verifies that repeated identical
-// connection failures produce a single disconnect log line rather
-// than one per retry attempt (issue #244).
-func TestRun_DedupesDisconnectLogs(t *testing.T) {
+// failingTransport fails every request with the error currently in
+// errs[0], advancing through errs as attempts arrive (the last error
+// repeats). It counts attempts so tests can wait for a deterministic
+// number of reconnects instead of sleeping.
+type failingTransport struct {
+	mu       sync.Mutex
+	errs     []error
+	attempts int
+}
+
+func (f *failingTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.attempts++
+	i := f.attempts - 1
+	if i >= len(f.errs) {
+		i = len(f.errs) - 1
+	}
+	return nil, f.errs[i]
+}
+
+func (f *failingTransport) count() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.attempts
+}
+
+// runFailingPeer runs a peer whose every connection attempt fails
+// with the given errors, captures log output, and returns it once at
+// least minAttempts attempts have been made.
+func runFailingPeer(t *testing.T, minAttempts int, errs ...error) string {
+	t.Helper()
+
 	var buf syncBuffer
 	prev := log.Writer()
 	log.SetOutput(&buf)
 	defer log.SetOutput(prev)
 
-	// Point at a port nothing listens on: every attempt fails the
-	// same way (connection refused).
-	p := newPeer(config.PeerConfig{Name: "down", URL: "http://127.0.0.1:1"}, store.New(), nil)
+	ft := &failingTransport{errs: errs}
+	p := newPeer(config.PeerConfig{Name: "down", URL: "http://spoke.invalid"}, store.New(), nil,
+		WithTransport(ft))
+	p.reconnectBackoff = time.Millisecond
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
@@ -58,14 +92,45 @@ func TestRun_DedupesDisconnectLogs(t *testing.T) {
 		close(done)
 	}()
 
-	// Enough time for several attempts (backoff starts at 1s).
-	time.Sleep(2500 * time.Millisecond)
+	deadline := time.Now().Add(5 * time.Second)
+	for ft.count() < minAttempts {
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %d attempts (got %d)", minAttempts, ft.count())
+		}
+		time.Sleep(time.Millisecond)
+	}
 	cancel()
 	<-done
 
-	got := strings.Count(buf.String(), "peering: down: disconnected:")
+	return buf.String()
+}
+
+// TestRun_DedupesDisconnectLogs verifies that repeated identical
+// connection failures produce a single disconnect log line rather
+// than one per retry attempt (issue #244).
+func TestRun_DedupesDisconnectLogs(t *testing.T) {
+	logs := runFailingPeer(t, 5, errors.New("connection refused"))
+
+	got := strings.Count(logs, "peering: down: disconnected:")
 	if got != 1 {
-		t.Errorf("want exactly 1 disconnect log for repeated identical failures, got %d\nlogs:\n%s", got, buf.String())
+		t.Errorf("want exactly 1 disconnect log for repeated identical failures, got %d\nlogs:\n%s", got, logs)
+	}
+}
+
+// TestRun_LogsAgainWhenErrorChanges verifies that log dedup keys on
+// the error text: a different failure logs again rather than being
+// swallowed by the dedup of the previous one.
+func TestRun_LogsAgainWhenErrorChanges(t *testing.T) {
+	logs := runFailingPeer(t, 5,
+		errors.New("connection refused"),
+		errors.New("connection refused"),
+		errors.New("no such host"))
+
+	if got := strings.Count(logs, "peering: down: disconnected:"); got != 2 {
+		t.Errorf("want 2 disconnect logs (one per distinct error), got %d\nlogs:\n%s", got, logs)
+	}
+	if !strings.Contains(logs, "connection refused") || !strings.Contains(logs, "no such host") {
+		t.Errorf("want both error texts logged\nlogs:\n%s", logs)
 	}
 }
 
@@ -85,4 +150,59 @@ func (b *syncBuffer) String() string {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	return b.buf.String()
+}
+
+// TestRun_LogsAgainAfterReconnect verifies that a successful
+// connection resets the log dedup (and backoff): the same failure
+// occurring again after a reconnect is logged again, not swallowed
+// as a duplicate of the pre-reconnect failure.
+func TestRun_LogsAgainAfterReconnect(t *testing.T) {
+	var buf syncBuffer
+	prev := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(prev)
+
+	// A spoke that serves a valid SSE stream but ends it immediately:
+	// every attempt connects successfully, then drops with the same
+	// "stream ended" error.
+	var attempts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/events" {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, "{}")
+			return
+		}
+		attempts.Add(1)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.(http.Flusher).Flush()
+		// Return immediately: stream ends right after connecting.
+	}))
+	defer srv.Close()
+
+	p := newPeer(config.PeerConfig{Name: "flappy", URL: srv.URL}, store.New(), nil)
+	p.reconnectBackoff = time.Millisecond
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		p.run(ctx)
+		close(done)
+	}()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for attempts.Load() < 3 {
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for 3 connections (got %d)", attempts.Load())
+		}
+		time.Sleep(time.Millisecond)
+	}
+	cancel()
+	<-done
+
+	// Each drop follows a successful connection, so dedup resets each
+	// time: expect one disconnect log per completed connection cycle
+	// even though the error text is identical.
+	if got := strings.Count(buf.String(), "peering: flappy: disconnected:"); got < 2 {
+		t.Errorf("want a disconnect log per post-reconnect drop, got %d\nlogs:\n%s", got, buf.String())
+	}
 }


### PR DESCRIPTION
Fixes #244.

## What

The pain in #244 is **log noise**: an unreachable peer logged the same disconnect on every retry. This dedupes the disconnect log — one line per *distinct* failure, re-logged when the error changes or after a successful reconnect.

The retry **ceiling stays at 30s**, deliberately. Peering is dial-out only: the hub opens the SSE stream to the spoke, and the spoke has no way to push "I'm online." Reconnect latency is therefore bounded solely by the retry interval, so stretching the ceiling to minutes (as an earlier revision of this PR did) would leave a just-powered-on peer invisible for minutes with no accelerant. The idle cost of one failed handshake per 30s is negligible; the noise was the real problem, and dedup fixes it without a UX regression.

Faster peer-online detection (a push/interest-triggered reconnect) is worth doing but is separate design work — tracked as a follow-up.

## Testing

Deterministic tests in `peer_error_test.go` (no wall-clock sleeps; they count real connection attempts via an injected failing transport / flapping SSE spoke):

- `TestRun_DedupesDisconnectLogs` — identical repeated failures → exactly one log line.
- `TestRun_LogsAgainWhenErrorChanges` — a different failure logs again.
- `TestRun_LogsAgainAfterReconnect` — a successful connection resets dedup (and backoff), so a post-reconnect drop logs again.

Full `internal/peering` suite passes with `-race`.