### PR TITLE
fix(daemon): drop invalid projects.json entries on load

### DIFF
--- a/services/gmuxd/internal/projects/projects.go
+++ b/services/gmuxd/internal/projects/projects.go
@@ -98,8 +98,11 @@ func Load(stateDir string) (*State, error) {
 	// Before a real schema upgrade rewrites the file, snapshot the
 	// pre-migration bytes to projects.json.bak so the change is
 	// recoverable (notably across the 2.0 upgrade). Best-effort.
+	original := data
+	backedUp := false
 	if onDiskVersion(data) < currentVersion {
-		backupFile(path, data)
+		backupFile(path, original)
+		backedUp = true
 	}
 
 	// Run migrations on the raw JSON before unmarshaling into the
@@ -118,11 +121,17 @@ func Load(stateDir string) (*State, error) {
 	// Drop invalid items (e.g. a hand-edited "match": null) instead of
 	// letting them poison the whole state: Manager.Update validates the
 	// full state before every save, so one bad on-disk entry would make
-	// every future mutation fail. The repaired form persists on the next
-	// Save; the original bytes were backed up above if a migration ran,
-	// and we snapshot here too before dropping anything.
+	// every future mutation fail. The repair is in-memory only: the
+	// on-disk file is untouched until the next Save persists the
+	// sanitized form, so repeated loads of a still-invalid file re-drop
+	// the same items (and re-write an identical backup, since the file
+	// hasn't changed). Snapshot the original bytes before dropping —
+	// unless the migration path above already did, in which case the
+	// pre-migration backup must not be clobbered with migrated bytes.
 	if dropped := s.sanitize(); len(dropped) > 0 {
-		backupFile(path, data)
+		if !backedUp {
+			backupFile(path, original)
+		}
 		for _, err := range dropped {
 			log.Printf("projects: dropping invalid item in %s: %v", path, err)
 		}

--- a/services/gmuxd/internal/projects/projects.go
+++ b/services/gmuxd/internal/projects/projects.go
@@ -114,7 +114,39 @@ func Load(stateDir string) (*State, error) {
 	if err := json.Unmarshal(data, &s); err != nil {
 		return nil, fmt.Errorf("projects: parsing %s: %w", path, err)
 	}
+
+	// Drop invalid items (e.g. a hand-edited "match": null) instead of
+	// letting them poison the whole state: Manager.Update validates the
+	// full state before every save, so one bad on-disk entry would make
+	// every future mutation fail. The repaired form persists on the next
+	// Save; the original bytes were backed up above if a migration ran,
+	// and we snapshot here too before dropping anything.
+	if dropped := s.sanitize(); len(dropped) > 0 {
+		backupFile(path, data)
+		for _, err := range dropped {
+			log.Printf("projects: dropping invalid item in %s: %v", path, err)
+		}
+	}
 	return &s, nil
+}
+
+// sanitize removes items that fail validation, keeping the rest in
+// order. Each item is checked against the already-accepted prefix, so
+// cross-item rules (duplicate slugs, duplicate paths) resolve
+// first-wins. Returns one error per dropped item.
+func (s *State) sanitize() []error {
+	valid := State{Version: s.Version}
+	var dropped []error
+	for _, item := range s.Items {
+		candidate := State{Version: s.Version, Items: append(append([]Item{}, valid.Items...), item)}
+		if err := candidate.Validate(); err != nil {
+			dropped = append(dropped, fmt.Errorf("item %q: %w", item.Slug, err))
+			continue
+		}
+		valid.Items = candidate.Items
+	}
+	s.Items = valid.Items
+	return dropped
 }
 
 // onDiskVersion peeks at the schema version of a raw projects.json

--- a/services/gmuxd/internal/projects/projects_test.go
+++ b/services/gmuxd/internal/projects/projects_test.go
@@ -55,6 +55,56 @@ func TestSaveAndLoad(t *testing.T) {
 	}
 }
 
+func TestLoadDropsInvalidItems(t *testing.T) {
+	// Regression: a hand-edited "match": null entry must be dropped on
+	// load instead of poisoning the state (issue #118). Manager.Update
+	// validates the whole state before every save, so a bad on-disk
+	// entry would otherwise block all future mutations.
+	dir := t.TempDir()
+	raw := `{"version": 3, "items": [
+		{"slug": "good", "match": [{"path": "/home/user/good"}]},
+		{"slug": "broken", "match": null},
+		{"slug": "good", "match": [{"path": "/home/user/dup-slug"}]},
+		{"slug": "also-good", "match": [{"path": "/home/user/also"}]}
+	]}`
+	if err := os.WriteFile(filepath.Join(dir, fileName), []byte(raw), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(s.Items) != 2 {
+		t.Fatalf("expected 2 items after sanitize, got %d: %+v", len(s.Items), s.Items)
+	}
+	if s.Items[0].Slug != "good" || s.Items[1].Slug != "also-good" {
+		t.Errorf("items = %+v", s.Items)
+	}
+	if err := s.Validate(); err != nil {
+		t.Errorf("sanitized state should validate: %v", err)
+	}
+
+	// The original bytes must be backed up before repair.
+	if _, err := os.Stat(filepath.Join(dir, fileName+".bak")); err != nil {
+		t.Errorf("expected backup file: %v", err)
+	}
+
+	// Mutations through the Manager must work again (this was the
+	// user-visible breakage: invalid state blocked every update).
+	mgr := NewManager(dir)
+	if _, err := mgr.AddProject("fresh", []MatchRule{{Path: "/home/user/fresh"}}); err != nil {
+		t.Fatalf("AddProject after repair: %v", err)
+	}
+	reloaded, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(reloaded.Items) != 3 {
+		t.Fatalf("expected repaired state persisted with 3 items, got %d", len(reloaded.Items))
+	}
+}
+
 func TestSaveCreatesNestedDir(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "nested", "state", "gmux")
 	s := &State{Items: []Item{{Slug: "a", Match: []MatchRule{{Path: "/tmp/a"}}}}}

--- a/services/gmuxd/internal/projects/projects_test.go
+++ b/services/gmuxd/internal/projects/projects_test.go
@@ -105,6 +105,37 @@ func TestLoadDropsInvalidItems(t *testing.T) {
 	}
 }
 
+func TestLoadMigrationBackupNotClobberedByRepair(t *testing.T) {
+	// When a legacy file both needs migration and contains an invalid
+	// item, projects.json.bak must hold the original pre-migration
+	// bytes, not the migrated form: the backup exists so the user can
+	// roll back the schema upgrade.
+	dir := t.TempDir()
+	raw := []byte(`{"items": [
+		{"slug": "good", "paths": ["/home/user/good"]},
+		{"slug": "broken"}
+	]}`)
+	if err := os.WriteFile(filepath.Join(dir, fileName), raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(s.Items) != 1 || s.Items[0].Slug != "good" {
+		t.Fatalf("items = %+v", s.Items)
+	}
+
+	bak, err := os.ReadFile(filepath.Join(dir, fileName+".bak"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(bak) != string(raw) {
+		t.Errorf("backup = %s, want original pre-migration bytes", bak)
+	}
+}
+
 func TestSaveCreatesNestedDir(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "nested", "state", "gmux")
 	s := &State{Items: []Item{{Slug: "a", Match: []MatchRule{{Path: "/tmp/a"}}}}}


### PR DESCRIPTION
Closes #118.

## Context

On 1.1.0, a hand-edited `"match": null` entry in `projects.json` broke the web UI (stuck on "Reaching gmuxd..."). The UI symptom was fixed in #227 (null-safe matching, distinct error state) and #303 hardened `/v1/projects/add`. What remained open from #118 ("invalid project state should be rejected, repaired, or ignored safely"): the daemon never validated `projects.json` on load, so a bad on-disk entry persisted silently.

Worse than silent persistence: `Manager.Update` validates the full state before every save, so one invalid on-disk item made **every future mutation** fail with a ValidationError — adding projects, dismissing sessions, auto-assign, all blocked.

## Change

`Load()` now sanitizes the parsed state: items that fail validation are dropped, each drop is logged, and the original bytes are snapshotted to `projects.json.bak` before repair.

Semantics, deliberately chosen and documented in code:

- **Repair is in-memory only.** `Load` never writes `projects.json`; the sanitized form persists on the next `Save` (i.e. the next mutation). Repeated loads of a still-invalid file re-drop the same items and re-write an identical backup, since the file is unchanged.
- **Backup ordering.** If the file also needed a schema migration, the pre-migration backup wins: the repair path only writes `.bak` when no migration backup was taken, so the recovery file always holds the original on-disk bytes (Greptile P1, fixed in a1d0a55).
- **First-wins dedup.** Each item is validated against the already-accepted prefix in file order, so duplicate slugs/paths resolve deterministically to the earliest entry — the same items `Validate` would accept.

## Testing

- `TestLoadDropsInvalidItems`: `"match": null`, duplicate slugs, backup creation, and that Manager mutations work again after repair.
- `TestLoadMigrationBackupNotClobberedByRepair`: combined legacy-migration + repair load keeps the pre-migration bytes in `.bak`.
- `go test ./...` in services/gmuxd passes.