### PR TITLE
feat(web): copy in the long-press sheets closes them and confirms via toast

### DIFF
--- a/apps/gmux-web/src/link-action-sheet.tsx
+++ b/apps/gmux-web/src/link-action-sheet.tsx
@@ -36,7 +36,7 @@ export function LinkActionSheet({ link, onClose }: LinkActionSheetProps) {
           <div class="link-sheet-uri">{link.uri}</div>
         </div>
         <div class="link-sheet-actions">
-          <CopyButton label="Copy URL" text={link.uri} />
+          <CopyButton label="Copy URL" text={link.uri} onClose={onClose} />
           <SheetButton primary onActivate={handleOpen}>Open</SheetButton>
         </div>
       </div>

--- a/apps/gmux-web/src/sheet.tsx
+++ b/apps/gmux-web/src/sheet.tsx
@@ -44,8 +44,9 @@
  * The panel (with its role/aria-label) is passed as children.
  */
 import type { ComponentChildren } from 'preact'
-import { useEffect, useState } from 'preact/hooks'
 import { createPortal } from 'preact/compat'
+import { useEffect } from 'preact/hooks'
+import { pushError, pushToast } from './toasts'
 
 /**
  * Defer a sheet's *dismissal* (the DOM unmount) to the next macrotask
@@ -116,26 +117,25 @@ export function SheetButton({ primary = false, quiet = false, onActivate, childr
   )
 }
 
-type CopyState = 'idle' | 'copied' | 'failed'
-
-/** A {@link SheetButton} that copies `text` to the clipboard and shows
- * inline feedback in place of `label`. Deliberately does NOT dismiss: a
- * copy is often mid-task, and an auto-close timer is an unwinnable guess
- * (a toast will confirm + close on its own once that lands). Centralises
- * the copy-with-feedback both the link and text sheets need. */
-export function CopyButton({ label, text }: { label: string; text: string }) {
-  const [state, setState] = useState<CopyState>('idle')
-  const copy = async () => {
-    try {
-      await navigator.clipboard.writeText(text)
-      setState('copied')
-    } catch {
-      setState('failed')
-    }
+/** A {@link SheetButton} that copies `text` to the clipboard, closes the
+ * sheet immediately, and confirms via a toast (`Copied to clipboard` /
+ * `Copy failed`). Confirmation is decoupled from the surface: the sheet
+ * doesn't need to linger (or guess an auto-close delay) just to show
+ * feedback. The clipboard write is initiated synchronously inside the
+ * click task — WebKit gesture-gates it (see {@link dismissAfterGesture}) —
+ * and the toast fires when the promise settles. Centralises the copy
+ * behaviour both the link and text sheets need. */
+export function CopyButton({ label, text, onClose }: {
+  label: string
+  text: string
+  onClose: () => void
+}) {
+  const copy = () => {
+    navigator.clipboard.writeText(text).then(
+      () => pushToast('info', 'Copied to clipboard'),
+      () => pushError('Copy failed'),
+    )
+    onClose()
   }
-  return (
-    <SheetButton onActivate={copy}>
-      {state === 'idle' ? label : state === 'copied' ? 'Copied ✓' : 'Copy failed'}
-    </SheetButton>
-  )
+  return <SheetButton onActivate={copy}>{label}</SheetButton>
 }

--- a/apps/gmux-web/src/sheet.tsx
+++ b/apps/gmux-web/src/sheet.tsx
@@ -131,10 +131,17 @@ export function CopyButton({ label, text, onClose }: {
   onClose: () => void
 }) {
   const copy = () => {
-    navigator.clipboard.writeText(text).then(
-      () => pushToast('info', 'Copied to clipboard'),
-      () => pushError('Copy failed'),
-    )
+    // The write can also throw synchronously (e.g. `navigator.clipboard`
+    // is undefined outside a secure context); either way the sheet still
+    // closes and the failure surfaces as a toast.
+    try {
+      navigator.clipboard.writeText(text).then(
+        () => pushToast('info', 'Copied to clipboard'),
+        () => pushError('Copy failed'),
+      )
+    } catch {
+      pushError('Copy failed')
+    }
     onClose()
   }
   return <SheetButton onActivate={copy}>{label}</SheetButton>

--- a/apps/gmux-web/src/terminal-text-sheet.tsx
+++ b/apps/gmux-web/src/terminal-text-sheet.tsx
@@ -5,10 +5,9 @@
  *
  * The long-press is a "give me my clipboard actions" gesture, so Copy all
  * and Paste are co-equal peers (neither is the accent), with a quiet Close
- * set apart. Copy doesn't dismiss — a copy is often not the end of the
- * task, and an auto-dismiss timer is an unwinnable guess. (A toast will
- * eventually confirm + close on its own; until then the sheet just stays
- * open with inline feedback.)
+ * set apart. Copy closes the sheet immediately and a toast confirms —
+ * confirmation is decoupled from the surface, so no lingering sheet and
+ * no arbitrary auto-close timer.
  *
  * Why plain text instead of growing xterm's own selection: on touch,
  * native selection (OS handles, magnifier, the system Copy callout) is
@@ -66,7 +65,7 @@ export function TerminalTextSheet({ lines, anchorRow, onPaste, onClose }: Termin
         </div>
         <div class="text-sheet-footer">
           <SheetButton quiet onActivate={onClose}>Close</SheetButton>
-          <CopyButton label="Copy all" text={lines.join('\n')} />
+          <CopyButton label="Copy all" text={lines.join('\n')} onClose={onClose} />
           <SheetButton onActivate={() => { onPaste(); onClose() }}>Paste</SheetButton>
         </div>
       </div>


### PR DESCRIPTION
Closes #312.

The toast primitive from the issue's scope already landed in #324; this PR completes the remaining half:

- `CopyButton` (shared by both sheets) now closes the sheet immediately and confirms via toast — `Copied to clipboard` (info) / `Copy failed` (error) — instead of keeping the sheet open with inline `Copied ✓` feedback.
- The clipboard write is still initiated synchronously inside the click task (WebKit gesture-gates it); the toast fires when the promise settles. A synchronous throw (e.g. `navigator.clipboard` undefined outside a secure context) also surfaces as a `Copy failed` toast, and the sheet closes either way.
- Removed the now-unused inline `copyState` and updated the doc comments that promised this follow-up.

Toast accessibility (`aria-live="polite"` region) was already handled by the toast host from #324.

Tested: `pnpm lint` + `pnpm test` in `apps/gmux-web` (562 passed).