### PR TITLE
feat(daemon): allow tagged tailscale devices via tag: entries in the allow list

### DIFF
--- a/apps/website/src/content/docs/reference/host-toml.md
+++ b/apps/website/src/content/docs/reference/host-toml.md
@@ -66,6 +66,7 @@ The config file is strictly validated at startup. gmuxd refuses to start if:
 
 - **Unknown keys** are present, catching typos like `alow` instead of `allow`
 - **`allow` entries don't contain `@` and don't start with `tag:`**, likely not a valid Tailscale login name or device tag
+- **`allow` tag entries are malformed** — the name after `tag:` must start with a letter and contain only lowercase letters, digits, and hyphens
 - **`port` is out of range** (must be 1–65535)
 - **TOML syntax is invalid**
 

--- a/apps/website/src/content/docs/reference/host-toml.md
+++ b/apps/website/src/content/docs/reference/host-toml.md
@@ -20,7 +20,7 @@ port = 8790
 # See the Remote Access guide for setup.
 [tailscale]
 enabled = false
-allow = []               # additional login names (owner is auto-whitelisted)
+allow = []               # additional login names or device tags (owner is auto-whitelisted)
 
 # Auto-discover devcontainer peers. Defaults to true.
 [discovery]
@@ -50,7 +50,7 @@ There is **no `[[peers]]` config**. Add a host you want to aggregate sessions fr
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `enabled` | `boolean` | `false` | Enable Tailscale remote access. |
-| `allow` | `string[]` | `[]` | Additional Tailscale login names to allow (owner is auto-whitelisted). Each must contain `@`. |
+| `allow` | `string[]` | `[]` | Additional Tailscale login names (e.g. `user@github`) or device tags (e.g. `tag:gmux`) to allow (owner is auto-whitelisted). Login entries must contain `@`; tag entries start with `tag:`. |
 
 ### `[discovery]`
 
@@ -65,7 +65,7 @@ There is no `tailscale` discovery flag (removed in [ADR 0008](https://github.com
 The config file is strictly validated at startup. gmuxd refuses to start if:
 
 - **Unknown keys** are present, catching typos like `alow` instead of `allow`
-- **`allow` entries don't contain `@`**, likely not a valid Tailscale login name
+- **`allow` entries don't contain `@` and don't start with `tag:`**, likely not a valid Tailscale login name or device tag
 - **`port` is out of range** (must be 1–65535)
 - **TOML syntax is invalid**
 

--- a/apps/website/src/content/docs/security.md
+++ b/apps/website/src/content/docs/security.md
@@ -89,7 +89,9 @@ The Tailscale account that owns the node is automatically added to the allow lis
 
 ### Allow list design
 
-The allow list matches **login names**, not device names. Tailscale device names are unique within a tailnet, but they can be renamed by the user. A renamed device would silently fall off the allow list. Login names are stable identities tied to the authentication provider (GitHub, Google, etc.). For per-device access control, use [Tailscale ACLs](https://tailscale.com/kb/1018/acls).
+The allow list matches **login names** and **device tags**, not device names. Tailscale device names are unique within a tailnet, but they can be renamed by the user. A renamed device would silently fall off the allow list. Login names are stable identities tied to the authentication provider (GitHub, Google, etc.). For per-device access control, use [Tailscale ACLs](https://tailscale.com/kb/1018/acls).
+
+[Tagged devices](https://tailscale.com/kb/1068/tags) carry no user identity — `WhoIs` reports the pseudo-login `tagged-devices` — so they cannot be allowed by login name. Instead, add the device's ACL tag (e.g. `tag:gmux`) to the allow list. Tags are assigned via your tailnet's ACL policy and can only be changed by tailnet admins, making them a stable, admin-controlled identity.
 
 The allow list is for when you have multiple accounts on the same tailnet (e.g. a personal and a work account) or when you've shared the gmux device to another tailnet you own. It is not designed for giving other people access. See the [not a collaboration tool](/remote-access) caveat.
 

--- a/services/gmuxd/internal/config/config.go
+++ b/services/gmuxd/internal/config/config.go
@@ -165,11 +165,19 @@ func validate(cfg Config) error {
 		return fmt.Errorf("port %d is out of range (1-65535)", cfg.Port)
 	}
 
-	// Tailscale: allow list entries must look like login names.
+	// Tailscale: allow list entries must look like login names or device
+	// tags. Tagged devices have no user identity, so they are allowed by
+	// tag (e.g. "tag:gmux") instead of login name.
 	// An empty allow list is fine — the node owner is auto-whitelisted at runtime.
 	for _, entry := range cfg.Tailscale.Allow {
+		if strings.HasPrefix(entry, "tag:") {
+			if len(entry) == len("tag:") {
+				return fmt.Errorf("tailscale.allow entry %q is missing a tag name (expected format: tag:name)", entry)
+			}
+			continue
+		}
 		if !strings.Contains(entry, "@") {
-			return fmt.Errorf("tailscale.allow entry %q doesn't look like a login name (expected format: user@provider)", entry)
+			return fmt.Errorf("tailscale.allow entry %q doesn't look like a login name or device tag (expected format: user@provider or tag:name)", entry)
 		}
 	}
 

--- a/services/gmuxd/internal/config/config.go
+++ b/services/gmuxd/internal/config/config.go
@@ -13,6 +13,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/BurntSushi/toml"
@@ -159,6 +160,11 @@ func Load() (Config, error) {
 	return cfg, nil
 }
 
+// tagNameRe matches valid Tailscale ACL tag names: they must start with
+// a letter and contain only lowercase letters, digits, and hyphens.
+// https://tailscale.com/kb/1068/tags
+var tagNameRe = regexp.MustCompile(`^[a-z][a-z0-9-]*$`)
+
 func validate(cfg Config) error {
 	// Port range.
 	if cfg.Port < 1 || cfg.Port > 65535 {
@@ -171,8 +177,8 @@ func validate(cfg Config) error {
 	// An empty allow list is fine — the node owner is auto-whitelisted at runtime.
 	for _, entry := range cfg.Tailscale.Allow {
 		if strings.HasPrefix(entry, "tag:") {
-			if len(entry) == len("tag:") {
-				return fmt.Errorf("tailscale.allow entry %q is missing a tag name (expected format: tag:name)", entry)
+			if !tagNameRe.MatchString(strings.TrimPrefix(entry, "tag:")) {
+				return fmt.Errorf("tailscale.allow entry %q is not a valid device tag (expected format: tag:name, where name starts with a letter and contains only lowercase letters, digits, and hyphens)", entry)
 			}
 			continue
 		}

--- a/services/gmuxd/internal/config/config_test.go
+++ b/services/gmuxd/internal/config/config_test.go
@@ -222,21 +222,33 @@ allow = ["alice@github", "tag:gmux"]
 	}
 }
 
-func TestLoadRejectsEmptyTag(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("XDG_CONFIG_HOME", dir)
-	writeConfig(t, dir, `
+func TestLoadRejectsMalformedTags(t *testing.T) {
+	bad := []string{
+		"tag:",           // empty name
+		"tag:my tag",     // whitespace
+		"tag:tag:double", // nested prefix
+		"tag:GMux",       // uppercase
+		"tag:1abc",       // must start with a letter
+		"tag:-abc",       // must start with a letter
+	}
+	for _, entry := range bad {
+		t.Run(entry, func(t *testing.T) {
+			dir := t.TempDir()
+			t.Setenv("XDG_CONFIG_HOME", dir)
+			writeConfig(t, dir, `
 [tailscale]
 enabled = true
-allow = ["tag:"]
+allow = ["`+entry+`"]
 `)
 
-	_, err := Load()
-	if err == nil {
-		t.Fatal("expected error for empty tag name")
-	}
-	if !strings.Contains(err.Error(), "missing a tag name") {
-		t.Errorf("error = %q", err)
+			_, err := Load()
+			if err == nil {
+				t.Fatalf("expected error for malformed tag %q", entry)
+			}
+			if !strings.Contains(err.Error(), "not a valid device tag") {
+				t.Errorf("error = %q", err)
+			}
+		})
 	}
 }
 

--- a/services/gmuxd/internal/config/config_test.go
+++ b/services/gmuxd/internal/config/config_test.go
@@ -204,6 +204,42 @@ allow = ["not-a-login-name"]
 	}
 }
 
+func TestLoadAcceptsDeviceTags(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	writeConfig(t, dir, `
+[tailscale]
+enabled = true
+allow = ["alice@github", "tag:gmux"]
+`)
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfg.Tailscale.Allow) != 2 {
+		t.Fatalf("allow = %v, want 2 entries", cfg.Tailscale.Allow)
+	}
+}
+
+func TestLoadRejectsEmptyTag(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	writeConfig(t, dir, `
+[tailscale]
+enabled = true
+allow = ["tag:"]
+`)
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected error for empty tag name")
+	}
+	if !strings.Contains(err.Error(), "missing a tag name") {
+		t.Errorf("error = %q", err)
+	}
+}
+
 func TestLoadRejectsBadTOML(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", dir)

--- a/services/gmuxd/internal/tsauth/tsauth.go
+++ b/services/gmuxd/internal/tsauth/tsauth.go
@@ -30,7 +30,7 @@ import (
 // Config mirrors the tailscale section of the gmuxd config file.
 type Config struct {
 	Hostname string
-	Allow    []string // tailscale login names (e.g. "user@github")
+	Allow    []string // tailscale login names (e.g. "user@github") or device tags (e.g. "tag:gmux")
 }
 
 // DiagStatus contains diagnostic information about the Tailscale connection.
@@ -199,9 +199,15 @@ func (l *Listener) authMiddleware(next http.Handler) http.Handler {
 		}
 
 		loginName := who.UserProfile.LoginName
+		var tags []string
+		var device string
+		if who.Node != nil {
+			tags = who.Node.Tags
+			device = who.Node.ComputedName
+		}
 
-		if !l.isAllowed(loginName) {
-			log.Printf("tsauth: DENIED %s (login=%s device=%s)", r.RemoteAddr, loginName, who.Node.ComputedName)
+		if !l.isAllowed(loginName, tags) {
+			log.Printf("tsauth: DENIED %s (login=%s tags=%v device=%s)", r.RemoteAddr, loginName, tags, device)
 			http.Error(w, "Forbidden", http.StatusForbidden)
 			return
 		}
@@ -210,20 +216,22 @@ func (l *Listener) authMiddleware(next http.Handler) http.Handler {
 	})
 }
 
-// isAllowed checks if the connecting peer's login name matches any entry
-// in the allow list. Login names (e.g. "user@github") are stable identities
-// tied to the user's auth provider. Device names are not checked — use
-// tailscale ACLs for per-device control.
-// Comparison is case-insensitive.
-func (l *Listener) isAllowed(loginName string) bool {
-	if loginName == "" {
-		return false
-	}
-	loginLower := strings.ToLower(loginName)
-
+// isAllowed checks if the connecting peer's login name or one of its
+// device tags matches any entry in the allow list. Login names (e.g.
+// "user@github") are stable identities tied to the user's auth provider.
+// Tagged devices don't carry a user identity (WhoIs reports
+// login=tagged-devices), so they are matched by their ACL tags (e.g.
+// "tag:gmux") instead. Device names are not checked — use tailscale ACLs
+// for per-device control. Comparison is case-insensitive.
+func (l *Listener) isAllowed(loginName string, tags []string) bool {
 	for _, entry := range l.cfg.Allow {
-		if strings.ToLower(entry) == loginLower {
+		if loginName != "" && strings.EqualFold(entry, loginName) {
 			return true
+		}
+		for _, tag := range tags {
+			if strings.EqualFold(entry, tag) {
+				return true
+			}
 		}
 	}
 	return false

--- a/services/gmuxd/internal/tsauth/tsauth_test.go
+++ b/services/gmuxd/internal/tsauth/tsauth_test.go
@@ -9,25 +9,32 @@ import (
 func TestIsAllowed(t *testing.T) {
 	l := &Listener{
 		cfg: Config{
-			Allow: []string{"alice@github", "bob@github"},
+			Allow: []string{"alice@github", "bob@github", "tag:gmux"},
 		},
 	}
 
 	tests := []struct {
 		login string
+		tags  []string
 		want  bool
 	}{
-		{"alice@github", true},    // exact match
-		{"bob@github", true},      // exact match
-		{"eve@github", false},     // no match
-		{"Alice@GitHub", true},    // case-insensitive
-		{"", false},               // empty
+		{"alice@github", nil, true},                             // exact match
+		{"bob@github", nil, true},                               // exact match
+		{"eve@github", nil, false},                              // no match
+		{"Alice@GitHub", nil, true},                             // case-insensitive
+		{"", nil, false},                                        // empty
+		{"tagged-devices", []string{"tag:gmux"}, true},          // tagged device, allowed tag
+		{"tagged-devices", []string{"tag:other"}, false},        // tagged device, tag not on list
+		{"tagged-devices", []string{"tag:a", "tag:gmux"}, true}, // any tag matches
+		{"tagged-devices", []string{"Tag:GMux"}, true},          // tags case-insensitive
+		{"tagged-devices", nil, false},                          // pseudo-login never matches by name
+		{"", []string{"tag:gmux"}, true},                        // tag match doesn't need login
 	}
 
 	for _, tt := range tests {
-		got := l.isAllowed(tt.login)
+		got := l.isAllowed(tt.login, tt.tags)
 		if got != tt.want {
-			t.Errorf("isAllowed(%q) = %v, want %v", tt.login, got, tt.want)
+			t.Errorf("isAllowed(%q, %v) = %v, want %v", tt.login, tt.tags, got, tt.want)
 		}
 	}
 }
@@ -37,8 +44,11 @@ func TestIsAllowedEmptyList(t *testing.T) {
 		cfg: Config{Allow: nil},
 	}
 
-	if l.isAllowed("anyone@github") {
+	if l.isAllowed("anyone@github", nil) {
 		t.Error("empty allow list should deny everyone")
+	}
+	if l.isAllowed("tagged-devices", []string{"tag:gmux"}) {
+		t.Error("empty allow list should deny tagged devices too")
 	}
 }
 


### PR DESCRIPTION
Fixes #316.

Tagged Tailscale devices carry no user identity — WhoIs reports the pseudo-login `tagged-devices` — so they could never pass the login-name allow list, and `host.toml` validation rejected any entry without `@`.

## Changes

- **tsauth**: `isAllowed` now also matches the peer's `Node.Tags` (exact, case-insensitive) against allow-list entries, so `tag:gmux` style entries work. Denied-connection logs now include the peer's tags for easier debugging.
- **config**: validation accepts `tag:<name>` entries alongside `user@provider` login names. Tag names are strictly validated against Tailscale's tag rules (`^[a-z][a-z0-9-]*$`) so malformed entries like `tag:my tag` fail fast at startup instead of silently never matching.
- **docs**: host.toml reference and security page updated to describe tag entries and why tags (admin-controlled, stable) are the right identity for tagged devices.

## Security notes

- Matching is exact via `strings.EqualFold` — no prefix/substring looseness.
- The `tagged-devices` pseudo-login can never match an allow entry: valid entries either contain `@` or start with `tag:`.
- The two-gate design (ADR 0008) is unchanged: a tag only passes the outer identity gate; the host's bearer token is still required.

## Tests

- `isAllowed` table extended with tagged-device cases (tag match, case-insensitivity, pseudo-login never matches by name, tag match with empty login, empty list denies).
- Config tests for accepting `tag:gmux` and rejecting malformed tags (empty, whitespace, nested prefix, uppercase, leading digit/hyphen).

`go test ./internal/tsauth/ ./internal/config/` passes.