### PR TITLE
fix(daemon): error-check SSE writes with a bounded deadline

### DIFF
--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -1943,20 +1943,16 @@ func serve(stderr io.Writer) int {
 			return
 		}
 
-		// A half-dead client (peer gone, no FIN/RST seen) makes writes
-		// buffer locally without erroring, leaking this subscriber and
-		// its coalescer subscriptions for minutes (#243). Bound every
-		// write with a deadline via ResponseController and treat any
-		// write/flush failure as a disconnect: the deferred cancels
-		// below tear the subscriber down.
+		// Error-checked, deadline-bounded writes (#243). Previously the
+		// heartbeat and snapshot writes ignored their errors, so a
+		// half-dead client was reaped only when OS TCP keepalive gave
+		// up (minutes, tunable-dependent). Now every write goes through
+		// a deadline-armed helper and any write/flush failure returns
+		// from the handler, letting the deferred cancels below tear the
+		// subscriber's coalescer subscriptions and activity channel down.
 		rc := http.NewResponseController(w)
-		const sseWriteTimeout = 10 * time.Second
 		sendFrame := func(event string, payload any) error {
-			_ = rc.SetWriteDeadline(time.Now().Add(sseWriteTimeout))
-			if err := sendSSE(w, event, payload); err != nil {
-				return err
-			}
-			return rc.Flush()
+			return sendSSEFrame(rc, w, event, payload)
 		}
 
 		// asPeer consumers (?as=peer) get owned sessions only and no
@@ -2055,11 +2051,7 @@ func serve(stderr io.Writer) int {
 			case <-notify:
 				return
 			case <-heartbeat.C:
-				_ = rc.SetWriteDeadline(time.Now().Add(sseWriteTimeout))
-				if _, err := fmt.Fprint(w, ":\n\n"); err != nil {
-					return
-				}
-				if err := rc.Flush(); err != nil {
+				if err := sendSSEComment(rc, w); err != nil {
 					return
 				}
 			case _, open := <-sessionsSub:
@@ -2648,6 +2640,41 @@ func buildSessionInfos(sessions *store.Store, isLocalPeer func(string) bool) []p
 		}
 	}
 	return infos
+}
+
+// sseWriteTimeout bounds every SSE write so the daemon reacts to its
+// own failed writes instead of delegating all client-liveness
+// detection to OS TCP keepalive (#243). Without it, a half-dead client
+// (peer gone, no FIN/RST seen) is only reaped when the kernel exhausts
+// TCP retransmits — non-deterministic and dependent on host tunables.
+//
+// This governs how long a Write blocks waiting for kernel send-buffer
+// space, not end-to-end delivery: it fires only if the client drains
+// nothing for the full window, which is exactly a dead peer. A healthy
+// slow client whose frame fits the send buffer is never affected, and
+// the deadline is re-armed before every write so it can't fire on an
+// idle-but-live connection between frames.
+const sseWriteTimeout = 10 * time.Second
+
+// sendSSEFrame writes one event frame with a fresh write deadline and
+// flushes it. Any write or flush error means the client is gone; the
+// caller must treat it as a disconnect and tear the subscriber down.
+func sendSSEFrame(rc *http.ResponseController, w io.Writer, event string, payload any) error {
+	_ = rc.SetWriteDeadline(time.Now().Add(sseWriteTimeout))
+	if err := sendSSE(w, event, payload); err != nil {
+		return err
+	}
+	return rc.Flush()
+}
+
+// sendSSEComment writes a heartbeat comment frame (":") with a fresh
+// write deadline and flushes it. Same error contract as sendSSEFrame.
+func sendSSEComment(rc *http.ResponseController, w io.Writer) error {
+	_ = rc.SetWriteDeadline(time.Now().Add(sseWriteTimeout))
+	if _, err := fmt.Fprint(w, ":\n\n"); err != nil {
+		return err
+	}
+	return rc.Flush()
 }
 
 // sendSSE writes one SSE frame. A marshal failure skips the frame

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -1938,10 +1938,25 @@ func serve(stderr io.Writer) int {
 		w.Header().Set("Cache-Control", "no-cache")
 		w.Header().Set("Connection", "keep-alive")
 
-		flusher, ok := w.(http.Flusher)
-		if !ok {
+		if _, ok := w.(http.Flusher); !ok {
 			http.Error(w, "streaming unsupported", http.StatusInternalServerError)
 			return
+		}
+
+		// A half-dead client (peer gone, no FIN/RST seen) makes writes
+		// buffer locally without erroring, leaking this subscriber and
+		// its coalescer subscriptions for minutes (#243). Bound every
+		// write with a deadline via ResponseController and treat any
+		// write/flush failure as a disconnect: the deferred cancels
+		// below tear the subscriber down.
+		rc := http.NewResponseController(w)
+		const sseWriteTimeout = 10 * time.Second
+		sendFrame := func(event string, payload any) error {
+			_ = rc.SetWriteDeadline(time.Now().Add(sseWriteTimeout))
+			if err := sendSSE(w, event, payload); err != nil {
+				return err
+			}
+			return rc.Flush()
 		}
 
 		// asPeer consumers (?as=peer) get owned sessions only and no
@@ -2017,12 +2032,14 @@ func serve(stderr io.Writer) int {
 		defer cancelActivity()
 
 		// Initial snapshots (leading edge: subscriber is idle).
-		sendSSE(w, "snapshot.sessions", composeSessions())
-		if !asPeer {
-			sendSSE(w, "snapshot.world", composeWorld())
+		if err := sendFrame("snapshot.sessions", composeSessions()); err != nil {
+			return
 		}
-
-		flusher.Flush()
+		if !asPeer {
+			if err := sendFrame("snapshot.world", composeWorld()); err != nil {
+				return
+			}
+		}
 
 		// Heartbeat: send an SSE comment every 30s to keep the connection
 		// alive through idle periods. Without this, the hub's sseclient
@@ -2038,20 +2055,27 @@ func serve(stderr io.Writer) int {
 			case <-notify:
 				return
 			case <-heartbeat.C:
-				fmt.Fprint(w, ":\n\n")
-				flusher.Flush()
+				_ = rc.SetWriteDeadline(time.Now().Add(sseWriteTimeout))
+				if _, err := fmt.Fprint(w, ":\n\n"); err != nil {
+					return
+				}
+				if err := rc.Flush(); err != nil {
+					return
+				}
 			case _, open := <-sessionsSub:
 				if !open {
 					return
 				}
-				sendSSE(w, "snapshot.sessions", composeSessions())
-				flusher.Flush()
+				if err := sendFrame("snapshot.sessions", composeSessions()); err != nil {
+					return
+				}
 			case _, open := <-worldSub:
 				if !open {
 					return
 				}
-				sendSSE(w, "snapshot.world", composeWorld())
-				flusher.Flush()
+				if err := sendFrame("snapshot.world", composeWorld()); err != nil {
+					return
+				}
 			case ev, open := <-activityCh:
 				if !open {
 					return
@@ -2064,8 +2088,9 @@ func serve(stderr io.Writer) int {
 					if !shouldForwardActivity(asPeer, ev.ID, isLocalPeer) {
 						continue
 					}
-					sendSSE(w, "session-activity", ev)
-					flusher.Flush()
+					if err := sendFrame("session-activity", ev); err != nil {
+						return
+					}
 				case "projects-update":
 					// Peer-hub trigger only. A `?as=peer` subscriber has
 					// no snapshot.world, so it relies on this event to
@@ -2078,8 +2103,9 @@ func serve(stderr io.Writer) int {
 					if !asPeer {
 						continue
 					}
-					sendSSE(w, ev.Type, ev)
-					flusher.Flush()
+					if err := sendFrame(ev.Type, ev); err != nil {
+						return
+					}
 				}
 			}
 		}
@@ -2624,12 +2650,16 @@ func buildSessionInfos(sessions *store.Store, isLocalPeer func(string) bool) []p
 	return infos
 }
 
-func sendSSE(w http.ResponseWriter, event string, payload any) {
+// sendSSE writes one SSE frame. A marshal failure skips the frame
+// (payload bug, not a connection problem); a write failure is
+// returned so the caller can treat it as a client disconnect.
+func sendSSE(w io.Writer, event string, payload any) error {
 	bytes, err := json.Marshal(payload)
 	if err != nil {
-		return
+		return nil
 	}
-	fmt.Fprintf(w, "event: %s\ndata: %s\n\n", event, bytes)
+	_, err = fmt.Fprintf(w, "event: %s\ndata: %s\n\n", event, bytes)
+	return err
 }
 
 func writeJSON(w http.ResponseWriter, payload any) {

--- a/services/gmuxd/cmd/gmuxd/main_test.go
+++ b/services/gmuxd/cmd/gmuxd/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -674,3 +675,28 @@ func TestBuildLaunchArgs(t *testing.T) {
 		}
 	})
 }
+
+// sendSSE must surface write errors so the events handler can treat
+// them as a client disconnect and tear the subscriber down (#243).
+func TestSendSSEPropagatesWriteError(t *testing.T) {
+	if err := sendSSE(failWriter{}, "snapshot.sessions", map[string]int{"a": 1}); err == nil {
+		t.Fatal("expected write error to propagate")
+	}
+	var buf bytes.Buffer
+	if err := sendSSE(&buf, "snapshot.sessions", map[string]int{"a": 1}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "event: snapshot.sessions\ndata: {\"a\":1}\n\n"
+	if buf.String() != want {
+		t.Errorf("got %q, want %q", buf.String(), want)
+	}
+	// A marshal failure skips the frame; it is a payload bug, not a
+	// connection problem, so no error is returned.
+	if err := sendSSE(failWriter{}, "x", make(chan int)); err != nil {
+		t.Errorf("marshal failure should not report a connection error, got %v", err)
+	}
+}
+
+type failWriter struct{}
+
+func (failWriter) Write([]byte) (int, error) { return 0, errors.New("broken pipe") }

--- a/services/gmuxd/cmd/gmuxd/main_test.go
+++ b/services/gmuxd/cmd/gmuxd/main_test.go
@@ -700,3 +700,70 @@ func TestSendSSEPropagatesWriteError(t *testing.T) {
 type failWriter struct{}
 
 func (failWriter) Write([]byte) (int, error) { return 0, errors.New("broken pipe") }
+
+// fakeSSEWriter implements the optional ResponseController interfaces
+// (FlushError, SetWriteDeadline) so frame-level behavior — fresh
+// deadline per write, flush errors surfacing as disconnects — can be
+// verified without a real connection.
+type fakeSSEWriter struct {
+	buf       bytes.Buffer
+	writeErr  error
+	flushErr  error
+	deadlines []time.Time
+}
+
+func (f *fakeSSEWriter) Header() http.Header { return http.Header{} }
+func (f *fakeSSEWriter) WriteHeader(int)     {}
+func (f *fakeSSEWriter) Write(p []byte) (int, error) {
+	if f.writeErr != nil {
+		return 0, f.writeErr
+	}
+	return f.buf.Write(p)
+}
+func (f *fakeSSEWriter) FlushError() error { return f.flushErr }
+func (f *fakeSSEWriter) SetWriteDeadline(t time.Time) error {
+	f.deadlines = append(f.deadlines, t)
+	return nil
+}
+
+// Every SSE write (frame or heartbeat) must arm a fresh write deadline
+// and surface write/flush failures so the events handler tears the
+// subscriber down instead of leaking it on a half-dead client (#243).
+func TestSSEFrameDeadlineAndErrorPropagation(t *testing.T) {
+	fw := &fakeSSEWriter{}
+	rc := http.NewResponseController(fw)
+
+	if err := sendSSEFrame(rc, fw, "snapshot.sessions", map[string]int{"a": 1}); err != nil {
+		t.Fatalf("healthy write: %v", err)
+	}
+	if err := sendSSEComment(rc, fw); err != nil {
+		t.Fatalf("healthy heartbeat: %v", err)
+	}
+	if got := len(fw.deadlines); got != 2 {
+		t.Fatalf("expected a fresh deadline per write, got %d", got)
+	}
+	if !fw.deadlines[1].After(time.Now().Add(sseWriteTimeout - time.Minute)) {
+		t.Errorf("deadline not re-armed into the future: %v", fw.deadlines[1])
+	}
+	if !strings.HasSuffix(fw.buf.String(), ":\n\n") {
+		t.Errorf("heartbeat comment missing, got %q", fw.buf.String())
+	}
+
+	fw = &fakeSSEWriter{writeErr: errors.New("broken pipe")}
+	rc = http.NewResponseController(fw)
+	if err := sendSSEFrame(rc, fw, "x", 1); err == nil {
+		t.Error("frame write error not propagated")
+	}
+	if err := sendSSEComment(rc, fw); err == nil {
+		t.Error("heartbeat write error not propagated")
+	}
+
+	fw = &fakeSSEWriter{flushErr: errors.New("deadline exceeded")}
+	rc = http.NewResponseController(fw)
+	if err := sendSSEFrame(rc, fw, "x", 1); err == nil {
+		t.Error("frame flush error not propagated")
+	}
+	if err := sendSSEComment(rc, fw); err == nil {
+		t.Error("heartbeat flush error not propagated")
+	}
+}


### PR DESCRIPTION
## Problem

A hard-killed `/v1/events` client stayed `ESTAB` server-side for minutes (#243). The real gap wasn't a permanent leak — TCP keepalive reaps the socket eventually — it was that the heartbeat and snapshot writes **ignored their errors entirely**, so client-liveness detection was fully delegated to OS TCP keepalive: non-deterministic, host-tunable-dependent, and disable-able. Until the kernel exhausted its retransmits, the subscriber goroutine and its coalescer/activity subscriptions stayed alive, and every state change still composed and write-attempted a full snapshot for a dead peer.

This is the SSE complement to the mobile-data work in #240 (snapshot amplification) and #245 (PTY WebSocket keepalive) — both explicitly listed #243 as an out-of-scope follow-up.

## Fix

- New `sendSSEFrame` / `sendSSEComment` helpers: each write (event frames and the 30s heartbeat comment) arms a fresh 10s write deadline via `http.ResponseController.SetWriteDeadline`, writes, and flushes — returning any write **or flush** error.
- The events handler treats any helper error as a disconnect and returns, so the deferred cancels tear down the coalescer subscriptions and activity channel (no goroutine leak).
- The deadline governs how long a write blocks waiting for kernel **send-buffer space**, not end-to-end delivery — it fires only if the client drains nothing for the full window (a dead peer). A healthy slow client whose frame fits the send buffer is unaffected, and the deadline is re-armed before every write so it never fires on an idle-but-live connection.
- `sendSSE` returns write errors; marshal failures still skip the frame silently — payload bug, not a connection problem.

Net effect: a hard-killed client is reaped within ~1 heartbeat interval + 10s, deterministically, instead of depending on kernel TCP timeouts.

## User-facing error handling

No new notification path is required: the reaped party is by definition gone, so there is no user to notify on that connection, and the teardown is correctly silent. A healthy browser is never affected by the deadline (see above). The browser's own connection-loss handling is unchanged:

- A failed *initial* connect surfaces the full-screen "Connection failed / Is it running?" state with a Retry button (`connState: connecting→error`).
- When a terminal is open, the daemon dropping also drops that terminal's PTY WebSocket, which shows a "Connection lost, reconnecting…" pill (`terminal.tsx`, driven by `wsState`) — independent of the SSE stream.
- An established SSE drop while the user is *not* attached to a terminal (sidebar / home / project view) currently shows no indicator: `connState` stays `connected` and `EventSource` auto-reconnects silently. That gap is pre-existing and out of scope here; tracked separately.

## Testing

- `go test ./...` in `services/gmuxd` — all green.
- `TestSendSSEPropagatesWriteError`: write-error propagation and marshal-failure skip.
- `TestSSEFrameDeadlineAndErrorPropagation`: fake `ResponseController` writer verifying a fresh deadline is armed per write (frame + heartbeat) and that write **and flush** errors both surface as disconnects.

Fixes #243
