### PR TITLE
fix(peering): route same-tailnet MagicDNS peers through embedded tsnet

### DIFF
--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -694,6 +694,13 @@ func serve(stderr io.Writer) int {
 	// the health handler can include the tailscale URL.
 	var tsListener *tsauth.Listener
 
+	// peerTransport routes peer HTTP traffic. Hosts under the local
+	// tailnet's MagicDNS suffix go through gmux's embedded tsnet once it
+	// is ready (set below via SetTailnet); everything else uses the
+	// default transport. Shared by the health probe and all peers so a
+	// tsnet-only hub can reach same-tailnet peers added manually (#281).
+	peerTransport := tsauth.NewRoutedTransport()
+
 	// tcpAddr and authToken are resolved after config load. Declared here
 	// so the health handler can report the address.
 	var tcpAddr string
@@ -1188,7 +1195,7 @@ func serve(stderr io.Writer) int {
 			return
 		}
 
-		peerNodeID, name, err := probePeerHealth(r.Context(), req.URL, req.Token)
+		peerNodeID, name, err := probePeerHealth(r.Context(), peerTransport, req.URL, req.Token)
 		if err != nil {
 			writeError(w, http.StatusBadGateway, "unreachable", fmt.Sprintf("could not reach host: %v", err))
 			return
@@ -2183,7 +2190,7 @@ func serve(stderr io.Writer) int {
 	// Always create the manager: peers can be added at runtime via
 	// /v1/peers (ADR 0007 §5), so it must exist even when nothing is
 	// configured or discovered at startup.
-	peerManager = peering.NewManager(manualPeers, sessions, hostname)
+	peerManager = peering.NewManager(manualPeers, sessions, hostname, peering.WithTransport(peerTransport))
 	// Prune namespaced projects.json keys when a Local peer
 	// (devcontainer) is removed: its `id@<peer>` session keys can
 	// never resolve again and would accumulate dead weight in the
@@ -2245,6 +2252,17 @@ func serve(stderr io.Writer) int {
 			Allow:    cfg.Tailscale.Allow,
 		}, stateDir, authedHandler)
 		defer tsListener.Shutdown()
+
+		// Once tsnet is up, route same-tailnet MagicDNS peers through it
+		// (#281). Existing peers share peerTransport, so they pick up
+		// tsnet routing on their next reconnect without re-construction.
+		go func(l *tsauth.Listener) {
+			<-l.Ready()
+			if suffix := l.MagicDNSSuffix(); suffix != "" {
+				peerTransport.SetTailnet(suffix, l.Transport())
+				log.Printf("peering: routing *.%s peers through tsnet", suffix)
+			}
+		}(tsListener)
 	}
 
 	// ── Signal handling for graceful shutdown ──
@@ -2640,8 +2658,9 @@ func writeJSON(w http.ResponseWriter, payload any) {
 // probePeerHealth fetches the target's /v1/health and returns its opaque
 // node_id and self-reported name (ADR 0007). The add-peer flow uses the
 // node_id to dedup and adopts the name as the peer's routing identity.
-// Manual peers use the default transport (as [[peers]] did before).
-func probePeerHealth(ctx context.Context, baseURL, token string) (nodeID, name string, err error) {
+// The transport routes same-tailnet MagicDNS hosts through tsnet once
+// it is ready; everything else uses the default transport (#281).
+func probePeerHealth(ctx context.Context, transport http.RoundTripper, baseURL, token string) (nodeID, name string, err error) {
 	ctx, cancel := context.WithTimeout(ctx, 8*time.Second)
 	defer cancel()
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/v1/health", nil)
@@ -2651,7 +2670,8 @@ func probePeerHealth(ctx context.Context, baseURL, token string) (nodeID, name s
 	if token != "" {
 		req.Header.Set("Authorization", "Bearer "+token)
 	}
-	resp, err := http.DefaultClient.Do(req)
+	client := &http.Client{Transport: transport}
+	resp, err := client.Do(req)
 	if err != nil {
 		return "", "", err
 	}

--- a/services/gmuxd/cmd/gmuxd/peers_test.go
+++ b/services/gmuxd/cmd/gmuxd/peers_test.go
@@ -25,7 +25,7 @@ func TestProbePeerHealth(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	id, name, err := probePeerHealth(context.Background(), srv.URL, "tok")
+	id, name, err := probePeerHealth(context.Background(), http.DefaultTransport, srv.URL, "tok")
 	if err != nil {
 		t.Fatalf("probePeerHealth: %v", err)
 	}
@@ -39,7 +39,7 @@ func TestProbePeerHealth_Unauthorized(t *testing.T) {
 		w.WriteHeader(http.StatusUnauthorized)
 	}))
 	defer srv.Close()
-	if _, _, err := probePeerHealth(context.Background(), srv.URL, ""); err == nil {
+	if _, _, err := probePeerHealth(context.Background(), http.DefaultTransport, srv.URL, ""); err == nil {
 		t.Fatal("expected an error when the probe is unauthorized")
 	}
 }
@@ -50,7 +50,7 @@ func TestProbePeerHealth_MissingName(t *testing.T) {
 	}))
 	defer srv.Close()
 	// A host that reports no name can't be given a routing identity.
-	if _, _, err := probePeerHealth(context.Background(), srv.URL, ""); err == nil {
+	if _, _, err := probePeerHealth(context.Background(), http.DefaultTransport, srv.URL, ""); err == nil {
 		t.Fatal("expected an error when the host reports no name")
 	}
 }
@@ -62,7 +62,7 @@ func TestProbePeerHealth_NotGmux(t *testing.T) {
 		_, _ = w.Write([]byte(`{"ok":true,"data":{"service":"other","hostname":"x"}}`))
 	}))
 	defer srv.Close()
-	if _, _, err := probePeerHealth(context.Background(), srv.URL, ""); err == nil {
+	if _, _, err := probePeerHealth(context.Background(), http.DefaultTransport, srv.URL, ""); err == nil {
 		t.Fatal("expected an error when the host is not running gmux")
 	}
 }

--- a/services/gmuxd/internal/peering/peer.go
+++ b/services/gmuxd/internal/peering/peer.go
@@ -57,8 +57,9 @@ type Peer struct {
 	isKnownOrigin func(name string) bool
 
 	// transport is the HTTP round-tripper for all spoke connections.
-	// nil means use the default transport. Set via WithTransport for
-	// tailscale-discovered peers that route through tsnet.
+	// nil means use the default transport. Set via WithTransport; the
+	// hub passes a routed transport that sends same-tailnet MagicDNS
+	// hosts through tsnet.
 	transport http.RoundTripper
 
 	// streamIdleTimeout overrides the default SSE idle timeout.

--- a/services/gmuxd/internal/peering/peering.go
+++ b/services/gmuxd/internal/peering/peering.go
@@ -30,8 +30,9 @@ import (
 type PeerOption func(*Peer)
 
 // WithTransport sets a custom HTTP transport for all peer connections.
-// Used for tailscale-discovered peers that route through tsnet. The
-// transport is stored and applied when newPeer constructs the
+// The hub passes a shared tsauth.RoutedTransport so same-tailnet
+// MagicDNS peers route through the embedded tsnet once it is ready.
+// The transport is stored and applied when newPeer constructs the
 // underlying apiclient.Client.
 func WithTransport(rt http.RoundTripper) PeerOption {
 	return func(p *Peer) {

--- a/services/gmuxd/internal/tsauth/transport.go
+++ b/services/gmuxd/internal/tsauth/transport.go
@@ -1,0 +1,78 @@
+package tsauth
+
+import (
+	"net/http"
+	"strings"
+	"sync"
+)
+
+// RoutedTransport is an http.RoundTripper that routes requests for hosts
+// under the local tailnet's MagicDNS suffix through a tsnet-backed
+// transport, and everything else through the fallback (default) transport.
+//
+// It exists to solve a timing problem: the peering manager is constructed
+// at startup, but the tsnet listener becomes ready much later (tailscale
+// login can take minutes). A single shared RoutedTransport is handed to
+// all peers and the health probe up front; once tsnet is ready, SetTailnet
+// installs the suffix and dialer atomically, and peers on the tailnet pick
+// up tsnet routing on their next request without re-construction.
+//
+// A host on a *different* tailnet (reachable only via system tailscaled)
+// won't match the local suffix and keeps the default transport, as before.
+type RoutedTransport struct {
+	fallback http.RoundTripper
+
+	mu     sync.RWMutex
+	suffix string // local tailnet MagicDNS suffix, e.g. "tailnet.ts.net"
+	tsnet  http.RoundTripper
+}
+
+// NewRoutedTransport returns a RoutedTransport that sends everything
+// through http.DefaultTransport until SetTailnet is called.
+func NewRoutedTransport() *RoutedTransport {
+	return &RoutedTransport{fallback: http.DefaultTransport}
+}
+
+// SetTailnet installs the tailnet MagicDNS suffix and the tsnet-backed
+// transport. Safe to call from any goroutine; requests in flight keep
+// whichever transport they already selected.
+func (t *RoutedTransport) SetTailnet(suffix string, rt http.RoundTripper) {
+	suffix = normalizeHost(suffix)
+	t.mu.Lock()
+	t.suffix = suffix
+	t.tsnet = rt
+	t.mu.Unlock()
+}
+
+// RoundTrip implements http.RoundTripper.
+func (t *RoutedTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return t.pick(req.URL.Hostname()).RoundTrip(req)
+}
+
+// pick returns the transport to use for the given request host.
+func (t *RoutedTransport) pick(host string) http.RoundTripper {
+	t.mu.RLock()
+	suffix, ts := t.suffix, t.tsnet
+	t.mu.RUnlock()
+	if ts != nil && hostOnTailnet(host, suffix) {
+		return ts
+	}
+	return t.fallback
+}
+
+// hostOnTailnet reports whether host falls under the MagicDNS suffix:
+// either a label under it ("gmux.tailnet.ts.net" for "tailnet.ts.net")
+// or the suffix itself. Comparison is case-insensitive and ignores
+// trailing dots.
+func hostOnTailnet(host, suffix string) bool {
+	if suffix == "" {
+		return false
+	}
+	host = normalizeHost(host)
+	return host == suffix || strings.HasSuffix(host, "."+suffix)
+}
+
+// normalizeHost lowercases and strips any trailing dot from a DNS name.
+func normalizeHost(h string) string {
+	return strings.ToLower(strings.TrimSuffix(strings.TrimSpace(h), "."))
+}

--- a/services/gmuxd/internal/tsauth/transport_test.go
+++ b/services/gmuxd/internal/tsauth/transport_test.go
@@ -1,0 +1,81 @@
+package tsauth
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+type stubRT struct{ name string }
+
+func (s *stubRT) RoundTrip(*http.Request) (*http.Response, error) { return nil, nil }
+
+func reqFor(t *testing.T, rawURL string) *http.Request {
+	t.Helper()
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatalf("parse %q: %v", rawURL, err)
+	}
+	return &http.Request{URL: u}
+}
+
+// A RoutedTransport with no tailnet configured must send everything —
+// including .ts.net hosts — through the fallback, so behavior before
+// tsnet is ready matches the pre-#281 default-transport path.
+func TestRoutedTransport_FallbackBeforeReady(t *testing.T) {
+	fallback := &stubRT{name: "fallback"}
+	rt := &RoutedTransport{fallback: fallback}
+
+	for _, u := range []string{
+		"https://gmux.tailnet.ts.net",
+		"http://192.168.1.10:9999",
+		"http://localhost:9999",
+	} {
+		if got := rt.pick(reqFor(t, u).URL.Hostname()); got != fallback {
+			t.Errorf("pick(%s) before SetTailnet: got tsnet route, want fallback", u)
+		}
+	}
+}
+
+// After SetTailnet, only hosts under the local tailnet's MagicDNS suffix
+// route through tsnet; raw IPs, LAN names, and hosts on a *different*
+// tailnet keep the default transport (issue #281 acceptance).
+func TestRoutedTransport_SuffixRouting(t *testing.T) {
+	fallback := &stubRT{name: "fallback"}
+	ts := &stubRT{name: "tsnet"}
+	rt := &RoutedTransport{fallback: fallback}
+	rt.SetTailnet("tailnet.ts.net", ts)
+
+	cases := []struct {
+		url    string
+		wantTS bool
+	}{
+		{"https://gmux.tailnet.ts.net", true},
+		{"https://gmux.tailnet.ts.net:443", true},
+		{"https://GMUX.TAILNET.TS.NET", true},     // case-insensitive
+		{"https://gmux.tailnet.ts.net./v1", true}, // trailing dot
+		{"https://other.othernet.ts.net", false},  // different tailnet
+		{"https://evil-tailnet.ts.net", false},    // suffix must match on a label boundary
+		{"http://192.168.1.10:9999", false},
+		{"http://localhost:9999", false},
+		{"http://nas.lan:9999", false},
+	}
+	for _, c := range cases {
+		got := rt.pick(reqFor(t, c.url).URL.Hostname())
+		if (got == ts) != c.wantTS {
+			t.Errorf("pick(%s): tsnet=%v, want %v", c.url, got == ts, c.wantTS)
+		}
+	}
+}
+
+// SetTailnet normalizes the suffix so a trailing-dot value from
+// tailscale's Status (e.g. "tailnet.ts.net.") still matches.
+func TestRoutedTransport_NormalizesSuffix(t *testing.T) {
+	ts := &stubRT{name: "tsnet"}
+	rt := NewRoutedTransport()
+	rt.SetTailnet("Tailnet.ts.net.", ts)
+
+	if got := rt.pick("gmux.tailnet.ts.net"); got != ts {
+		t.Errorf("suffix with trailing dot/case: got fallback, want tsnet")
+	}
+}

--- a/services/gmuxd/internal/tsauth/transport_test.go
+++ b/services/gmuxd/internal/tsauth/transport_test.go
@@ -8,7 +8,9 @@ import (
 
 type stubRT struct{ name string }
 
-func (s *stubRT) RoundTrip(*http.Request) (*http.Response, error) { return nil, nil }
+func (s *stubRT) RoundTrip(*http.Request) (*http.Response, error) {
+	return &http.Response{Header: http.Header{"X-Stub": []string{s.name}}}, nil
+}
 
 func reqFor(t *testing.T, rawURL string) *http.Request {
 	t.Helper()
@@ -64,6 +66,26 @@ func TestRoutedTransport_SuffixRouting(t *testing.T) {
 		got := rt.pick(reqFor(t, c.url).URL.Hostname())
 		if (got == ts) != c.wantTS {
 			t.Errorf("pick(%s): tsnet=%v, want %v", c.url, got == ts, c.wantTS)
+		}
+	}
+}
+
+// RoundTrip must dispatch to whichever transport pick selects — the
+// routing decision is worthless if the actual request path ignores it.
+func TestRoutedTransport_RoundTripDispatch(t *testing.T) {
+	rt := &RoutedTransport{fallback: &stubRT{name: "fallback"}}
+	rt.SetTailnet("tailnet.ts.net", &stubRT{name: "tsnet"})
+
+	for _, c := range []struct{ url, want string }{
+		{"https://gmux.tailnet.ts.net/v1/health", "tsnet"},
+		{"http://192.168.1.10:9999/v1/health", "fallback"},
+	} {
+		resp, err := rt.RoundTrip(reqFor(t, c.url))
+		if err != nil {
+			t.Fatalf("RoundTrip(%s): %v", c.url, err)
+		}
+		if got := resp.Header.Get("X-Stub"); got != c.want {
+			t.Errorf("RoundTrip(%s) went through %q, want %q", c.url, got, c.want)
 		}
 	}
 }

--- a/services/gmuxd/internal/tsauth/tsauth.go
+++ b/services/gmuxd/internal/tsauth/tsauth.go
@@ -53,16 +53,22 @@ type DiagStatus struct {
 
 // Listener manages a tsnet server and its HTTPS listener.
 type Listener struct {
-	srv   *tsnet.Server
-	lc    *tailscale.LocalClient
-	cfg   Config
-	fqdn  string         // resolved tailnet FQDN, set once ready
-	ready chan struct{}   // closed when the listener is fully connected
+	srv         *tsnet.Server
+	lc          *tailscale.LocalClient
+	cfg         Config
+	fqdn        string        // resolved tailnet FQDN, set once ready
+	magicSuffix string        // tailnet MagicDNS suffix (e.g. "tailnet.ts.net"), set once ready
+	ready       chan struct{} // closed when the listener is fully connected
 }
 
 // FQDN returns the full tailnet DNS name (e.g. "gmuxd.angler-map.ts.net")
 // once the listener is ready. Returns "" if tailscale hasn't connected yet.
 func (l *Listener) FQDN() string { return l.fqdn }
+
+// MagicDNSSuffix returns the tailnet's MagicDNS suffix (e.g.
+// "tailnet.ts.net") once the listener is ready. Returns "" if tailscale
+// hasn't connected yet or MagicDNS is disabled.
+func (l *Listener) MagicDNSSuffix() string { return l.magicSuffix }
 
 // Diag returns diagnostic status about the Tailscale connection.
 // Safe to call at any time, including before the listener is ready.
@@ -168,10 +174,17 @@ func (l *Listener) run(handler http.Handler) {
 
 	// Resolve the full tailnet FQDN so users know exactly what to type.
 	fqdn := l.cfg.Hostname
-	if status, err := lc.Status(context.Background()); err == nil && status.Self != nil {
-		if dnsName := strings.TrimSuffix(status.Self.DNSName, "."); dnsName != "" {
-			fqdn = dnsName
+	if status, err := lc.Status(context.Background()); err == nil {
+		if status.Self != nil {
+			if dnsName := strings.TrimSuffix(status.Self.DNSName, "."); dnsName != "" {
+				fqdn = dnsName
+			}
 		}
+		suffix := status.MagicDNSSuffix
+		if status.CurrentTailnet != nil && status.CurrentTailnet.MagicDNSSuffix != "" {
+			suffix = status.CurrentTailnet.MagicDNSSuffix
+		}
+		l.magicSuffix = strings.TrimSuffix(suffix, ".")
 	}
 	l.fqdn = fqdn
 	close(l.ready)


### PR DESCRIPTION
Closes #281 (follow-up from ADR 0008 / #280).

## Problem

A hub whose only tailscale connection is gmux's embedded (userspace) tsnet cannot reach a same-tailnet `.ts.net` peer added via Connect-to-host: both the `/v1/health` probe and the ongoing peering client used `http.DefaultClient` / the default transport, which only resolves MagicDNS names when **system** tailscaled runs. Autodiscovery used to mask this by passing `peering.WithTransport(tsListener.Transport())`; ADR 0008 removed it, making manual-add the primary path.

## Fix

- New `tsauth.RoutedTransport`: a shared `http.RoundTripper` that routes hosts under the local tailnet's MagicDNS suffix through tsnet and everything else through the default transport. The tsnet dialer + suffix are installed **late and atomically** via `SetTailnet` once `tsListener.Ready()` fires, solving the timing problem (peer manager is built at startup; tailscale login can take minutes).
- The health probe (`probePeerHealth`) and the peer manager (default `WithTransport` option) share the routed transport, so existing peers pick up tsnet routing on their next reconnect without re-construction.
- `tsauth.Listener` now exposes `MagicDNSSuffix()`, captured from tailscale Status at ready time.
- Suffix matching is case-insensitive, ignores trailing dots, and only matches on a label boundary (`evil-tailnet.ts.net` does not match `tailnet.ts.net`).

## Acceptance mapping

- tsnet-only hub + same-tailnet `.ts.net` peer: routed through tsnet for probe and peering; late-ready handled by shared transport → reconnect picks it up.
- Other tailnets / raw IPs / LAN hosts: keep the default transport (covered by `TestRoutedTransport_SuffixRouting`).
- Unit coverage for suffix-based selection in `internal/tsauth/transport_test.go`.

Tests: `go test ./...` in `services/gmuxd` all green.