### PR TITLE
feat(cli): add gmux wait --for-text/--for-regex output conditions

### DIFF
--- a/cli/gmux/cmd/gmux/cli.go
+++ b/cli/gmux/cmd/gmux/cli.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"regexp"
 	"strings"
 )
 
@@ -66,7 +67,9 @@ type command struct {
 	keys        []string // key/text arguments
 
 	// wait
-	timeout int // --timeout seconds (0 = none)
+	timeout  int    // --timeout seconds (0 = none)
+	forText  string // --for-text: wait for substring in output
+	forRegex string // --for-regex: wait for regex match in output
 
 	// edit
 	editFile string // file path to open
@@ -318,6 +321,8 @@ func parseWait(args []string) (*command, error) {
 	c := &command{mode: modeWait}
 	fs := newFlagSet("wait")
 	fs.IntVar(&c.timeout, "timeout", 0, "fail after N seconds")
+	fs.StringVar(&c.forText, "for-text", "", "wait for this substring in the session's output")
+	fs.StringVar(&c.forRegex, "for-regex", "", "wait for a regex match in the session's output")
 	pos, err := parseInterspersed(fs, args)
 	if err != nil {
 		return nil, err
@@ -327,6 +332,16 @@ func parseWait(args []string) (*command, error) {
 	}
 	if c.timeout < 0 {
 		return nil, errors.New("--timeout must be a non-negative number of seconds")
+	}
+	if c.forText != "" && c.forRegex != "" {
+		return nil, errors.New("--for-text and --for-regex are mutually exclusive")
+	}
+	if c.forRegex != "" {
+		// Validate here so a typo fails as a usage error instead of a
+		// daemon round-trip; the daemon validates again server-side.
+		if _, err := regexp.Compile(c.forRegex); err != nil {
+			return nil, fmt.Errorf("--for-regex: %v", err)
+		}
 	}
 	c.ref = pos[0]
 	return c, nil
@@ -483,6 +498,7 @@ Sessions (local by default; address a peer with <id>@<peer>):
   gmux send <id> <text> [Key...]    type text and/or send keys (e.g. Enter, C-c)
   gmux send-keys -t <id> <keys...>  tmux-compatible key sending
   gmux wait <id> [--timeout N]      block until an agent session is idle
+       [--for-text S|--for-regex P] ... or until output matches S / P
   gmux kill <id>                    terminate a session
 
 Editing (usable as $EDITOR; blocks until the editor closes):

--- a/cli/gmux/cmd/gmux/cli_test.go
+++ b/cli/gmux/cmd/gmux/cli_test.go
@@ -156,6 +156,18 @@ func TestParseCLI(t *testing.T) {
 					t.Errorf("timeout=%d ref=%q", c.timeout, c.ref)
 				}
 			}},
+		{name: "wait --for-text", args: []string{"wait", "abc", "--for-text", "BUILD OK"}, wantMode: modeWait,
+			check: func(t *testing.T, c *command) {
+				if c.forText != "BUILD OK" || c.ref != "abc" {
+					t.Errorf("forText=%q ref=%q", c.forText, c.ref)
+				}
+			}},
+		{name: "wait --for-regex with timeout", args: []string{"wait", "--for-regex", `error: \d+`, "--timeout", "30", "abc"}, wantMode: modeWait,
+			check: func(t *testing.T, c *command) {
+				if c.forRegex != `error: \d+` || c.timeout != 30 || c.ref != "abc" {
+					t.Errorf("forRegex=%q timeout=%d ref=%q", c.forRegex, c.timeout, c.ref)
+				}
+			}},
 
 		{name: "daemon status", args: []string{"daemon", "status"}, wantMode: modeDaemon,
 			check: func(t *testing.T, c *command) {
@@ -205,13 +217,15 @@ func TestParseCLIErrors(t *testing.T) {
 		{"tail"},                   // missing id
 		{"tail", "-n", "0", "abc"}, // non-positive count
 		{"wait"},                   // missing id
-		{"send-keys", "C-c"},       // missing -t
-		{"daemon"},                 // missing subcommand
-		{"daemon", "frobnicate"},   // unknown subcommand
-		{"ls", "stray"},            // ls takes no positional
-		{"edit", "a", "b"},         // too many files
-		{"edit", "--wait"},         // no flags on edit (yet)
-		{"__edit-child", "a", "b"}, // too many files
+		{"wait", "abc", "--for-text", "a", "--for-regex", "b"}, // mutually exclusive
+		{"wait", "abc", "--for-regex", "["},                    // invalid regex
+		{"send-keys", "C-c"},                                   // missing -t
+		{"daemon"},                                             // missing subcommand
+		{"daemon", "frobnicate"},                               // unknown subcommand
+		{"ls", "stray"},                                        // ls takes no positional
+		{"edit", "a", "b"},                                     // too many files
+		{"edit", "--wait"},                                     // no flags on edit (yet)
+		{"__edit-child", "a", "b"},                             // too many files
 	}
 	for _, args := range bad {
 		t.Run(strings.Join(args, "_"), func(t *testing.T) {

--- a/cli/gmux/cmd/gmux/main.go
+++ b/cli/gmux/cmd/gmux/main.go
@@ -56,7 +56,7 @@ func main() {
 	case modeSendKeys:
 		os.Exit(cmdSendKeys(cmd.ref, cmd.keys, cmd.keysLiteral))
 	case modeWait:
-		os.Exit(cmdWait(cmd.ref, cmd.timeout))
+		os.Exit(cmdWait(cmd.ref, cmd.timeout, cmd.forText, cmd.forRegex))
 	case modeEdit:
 		runEdit(cmd.editFile)
 	case modeEditChild:

--- a/cli/gmux/cmd/gmux/wait.go
+++ b/cli/gmux/cmd/gmux/wait.go
@@ -13,32 +13,37 @@ import (
 // Exit codes from cmdWait. Distinct codes let scripts dispatch on the
 // reason a wait ended without parsing strings.
 //
-//   - waitExitIdle (0): session reached a Working == false state
-//   - waitExitDied (2): session crashed or was killed before going idle
+//   - waitExitOK (0): session reached a Working == false state (idle
+//     wait) or its output matched --for-text/--for-regex
+//   - waitExitDied (2): session crashed, was killed, or exited before
+//     going idle / before its output matched
 //   - waitExitTimeout (3): --timeout elapsed
 //
 // Any other usage / network error returns 1, matching the rest of the
 // CLI.
 const (
-	waitExitIdle    = 0
+	waitExitOK      = 0
 	waitExitDied    = 2
 	waitExitTimeout = 3
 )
 
-// cmdWait implements `gmux wait <id> [--timeout N]`.
+// cmdWait implements `gmux wait <id> [--timeout N] [--for-text S |
+// --for-regex P]`.
 //
 // The wait itself happens server-side: gmuxd already subscribes to
 // per-session events for its own bookkeeping, so we just hand it the
 // session id and block on the HTTP response. That keeps the CLI free
 // of SSE-parsing logic and ensures the idle-detection rules (which
 // adapter kinds emit Status.Working, what counts as "died") live in
-// one place.
+// one place. Output conditions equally belong server-side: the bytes
+// live in the daemon's scrollback tee, and matching there can't miss
+// output the way client-side scrollback polling could.
 //
 // Local sessions only: the daemon's wait handler resolves the session
 // against its local store and consults the adapter allowlist; remote
 // peer sessions are out of scope until peer subscriptions stream
 // Status events back to the hub.
-func cmdWait(ref string, timeoutSecs int) int {
+func cmdWait(ref string, timeoutSecs int, forText, forRegex string) int {
 	sess, err := resolveSession(ref)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "gmux:", err)
@@ -52,9 +57,19 @@ func cmdWait(ref string, timeoutSecs int) int {
 		return 1
 	}
 
-	endpoint := gmuxdBaseURL() + "/v1/sessions/" + url.PathEscape(sess.ID) + "/wait"
+	query := url.Values{}
 	if timeoutSecs > 0 {
-		endpoint += "?timeout=" + strconv.Itoa(timeoutSecs)
+		query.Set("timeout", strconv.Itoa(timeoutSecs))
+	}
+	if forText != "" {
+		query.Set("for_text", forText)
+	}
+	if forRegex != "" {
+		query.Set("for_regex", forRegex)
+	}
+	endpoint := gmuxdBaseURL() + "/v1/sessions/" + url.PathEscape(sess.ID) + "/wait"
+	if len(query) > 0 {
+		endpoint += "?" + query.Encode()
 	}
 
 	client := gmuxdClient()
@@ -74,7 +89,7 @@ func cmdWait(ref string, timeoutSecs int) int {
 
 	switch resp.StatusCode {
 	case http.StatusOK:
-		// Body is { ok: true, data: { reason: "idle" | "died" } }
+		// Body is { ok: true, data: { reason: "idle" | "matched" | "died" } }
 		var env struct {
 			Data struct {
 				Reason string `json:"reason"`
@@ -85,10 +100,14 @@ func cmdWait(ref string, timeoutSecs int) int {
 			return 1
 		}
 		switch env.Data.Reason {
-		case "idle":
-			return waitExitIdle
+		case "idle", "matched":
+			return waitExitOK
 		case "died":
-			fmt.Fprintf(os.Stderr, "gmux: session %s died before becoming idle\n", displayID(sess))
+			if forText != "" || forRegex != "" {
+				fmt.Fprintf(os.Stderr, "gmux: session %s exited before its output matched\n", displayID(sess))
+			} else {
+				fmt.Fprintf(os.Stderr, "gmux: session %s died before becoming idle\n", displayID(sess))
+			}
 			return waitExitDied
 		default:
 			fmt.Fprintf(os.Stderr, "gmux: unexpected wait reason %q\n", env.Data.Reason)

--- a/docs/adr/0009-verb-first-cli-and-frozen-top-level-namespace.md
+++ b/docs/adr/0009-verb-first-cli-and-frozen-top-level-namespace.md
@@ -170,12 +170,14 @@ For 2.0 we unify on a single **verb-first** grammar fronted by the
     yet" (ADR 0005 deferral).
 
     Output-condition variants (`--for-text` / `--for-regex` — "block
-    until this text appears") were designed but **deferred**: the only
-    sound implementation matches where the bytes are, i.e. a gmuxd
-    endpoint, not client-side scrollback polling. Tracked as a
-    follow-up ([#313](https://github.com/gmuxapp/gmux/issues/313)).
-    Until then, shell "wait for output" is served by running the command
-    through the blocking piped form (`gmux -- <cmd>`).
+    until this text appears") were designed but initially **deferred**:
+    the only sound implementation matches where the bytes are, i.e. a
+    gmuxd endpoint, not client-side scrollback polling. Since
+    implemented server-side
+    ([#313](https://github.com/gmuxapp/gmux/issues/313)): gmuxd's wait
+    handler polls the on-disk scrollback tee and matches per rendered
+    (ANSI-stripped) line, so shell sessions are supported too (exit 0
+    matched, 2 exited first, 3 timeout).
 
 ## Considered alternatives
 

--- a/go.work.sum
+++ b/go.work.sum
@@ -265,6 +265,7 @@ github.com/maratori/testpackage v1.1.1/go.mod h1:s4gRK/ym6AMrqpOa/kEbQTV4Q4jb7We
 github.com/matoous/godox v0.0.0-20230222163458-006bad1f9d26/go.mod h1:1BELzlh859Sh1c6+90blK8lbYy0kwQf1bYlBhBysy1s=
 github.com/mattbaird/jsonpatch v0.0.0-20171005235357-81af80346b1a/go.mod h1:M1qoD/MqPgTZIk0EWKB38wE28ACRfVcn+cU08jyArI0=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
+github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-localereader v0.0.1/go.mod h1:8fBrzywKY7BI3czFoHkuzRoWE9C+EiG4R1k4Cjx5p88=

--- a/packages/scrollback/scrollback.go
+++ b/packages/scrollback/scrollback.go
@@ -270,11 +270,20 @@ func RenderTail(r io.Reader, cols, rows, n int) ([]string, error) {
 	e.SetScrollbackSize(RenderScrollbackSize)
 	// The emulator writes back responses (e.g. DSR cursor position
 	// reports) into a pipe. Nothing reads them here, and a blocked
-	// write would deadlock our Write below. Drain in the background.
+	// write would deadlock our Write below. Drain in the background,
+	// and close the emulator on the way out so the drain goroutine
+	// sees EOF and exits — without the Close it blocks on the pipe
+	// forever, leaking one goroutine per render. One-shot tail
+	// requests barely noticed; the output-condition wait re-renders
+	// on a ticker and would accumulate them.
 	drainDone := make(chan struct{})
 	go func() {
 		_, _ = io.Copy(io.Discard, e)
 		close(drainDone)
+	}()
+	defer func() {
+		_ = e.Close()
+		<-drainDone
 	}()
 	if _, err := e.Write(raw); err != nil {
 		return nil, fmt.Errorf("replay through emulator: %w", err)

--- a/packages/scrollback/scrollback_test.go
+++ b/packages/scrollback/scrollback_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -592,3 +593,39 @@ func equalLines(a, b []string) bool {
 type errReader struct{ err error }
 
 func (e *errReader) Read(p []byte) (int, error) { return 0, e.err }
+
+// TestRenderTailDoesNotLeakGoroutines pins that RenderTail tears down
+// its drain goroutine. Every call spawns one to soak up emulator
+// write-backs (DSR reports etc.); without closing the emulator it
+// blocks on the pipe forever. One-shot tail requests barely noticed
+// the leak, but gmuxd's output-condition wait calls RenderTail on a
+// ticker, so a leak here grows for as long as a wait is in flight.
+func TestRenderTailDoesNotLeakGoroutines(t *testing.T) {
+	// Cursor-movement-heavy input so the emulator has something to
+	// write back on some terminals; content itself doesn't matter.
+	raw := []byte("hello\r\nworld\x1b[6n\r\n")
+
+	// Warm up (lazy runtime goroutines, pools).
+	for i := 0; i < 3; i++ {
+		if _, err := RenderTail(bytes.NewReader(raw), 80, 24, 10); err != nil {
+			t.Fatal(err)
+		}
+	}
+	runtime.GC()
+	before := runtime.NumGoroutine()
+
+	const n = 50
+	for i := 0; i < n; i++ {
+		if _, err := RenderTail(bytes.NewReader(raw), 80, 24, 10); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// RenderTail waits for its drain goroutine before returning, so no
+	// settling sleep should be needed; allow a little runtime noise.
+	runtime.GC()
+	after := runtime.NumGoroutine()
+	if after > before+5 {
+		t.Fatalf("goroutines grew from %d to %d across %d renders; drain goroutine is leaking", before, after, n)
+	}
+}

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -1790,7 +1790,7 @@ func serve(stderr io.Writer) int {
 			writeJSON(w, map[string]any{"ok": true, "data": map[string]any{}})
 
 		case "wait":
-			handleWait(w, r, sessions, sessionID)
+			handleWait(w, r, sessions, sessionID, metaStore.SessionDir)
 
 		default:
 			http.NotFound(w, r)

--- a/services/gmuxd/cmd/gmuxd/wait.go
+++ b/services/gmuxd/cmd/gmuxd/wait.go
@@ -3,15 +3,28 @@ package main
 import (
 	"errors"
 	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
+	"github.com/gmuxapp/gmux/packages/scrollback"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/store"
 )
 
 // handleWait implements POST /v1/sessions/{id}/wait?timeout=N. It blocks
 // until the session is idle (Status.Working == false), the session
 // dies, the optional timeout elapses, or the client disconnects.
+//
+// An optional output condition switches the wait from "agent idle" to
+// "text appeared in the session's output": ?for_text=<substr> matches
+// a fixed substring, ?for_regex=<pattern> a Go regexp. Output waits
+// consume the on-disk scrollback tee the runner writes live into the
+// session dir — the daemon-side source of truth for output bytes — so
+// nothing can scroll past unseen between polls (loss is bounded by the
+// scrollback cap, not the poll interval). See waitForOutput.
 //
 // The single signal we wait on is the per-session Status.Working flag
 // the adapters emit. That's a precise, debounced signal: each adapter
@@ -41,9 +54,14 @@ import (
 //   - 200 with {reason}: terminal state reached (caller maps to its
 //     own exit code)
 //   - 408 Request Timeout: --timeout deadline elapsed
-//   - 422: session adapter has no idle signal
+//   - 422: session adapter has no idle signal (idle mode only;
+//     output conditions work for every adapter, including shell)
 //   - 404: session not found
-func handleWait(w http.ResponseWriter, r *http.Request, sessions *store.Store, sessionID string) {
+//   - 400: bad timeout, bad regex, or both output conditions at once
+//
+// dirFor maps a session id to its per-session state dir (production:
+// sessionmeta.Store.SessionDir); only output-condition waits read it.
+func handleWait(w http.ResponseWriter, r *http.Request, sessions *store.Store, sessionID string, dirFor func(string) string) {
 	if r.Method != http.MethodPost {
 		writeError(w, http.StatusMethodNotAllowed, "bad_request", "method not allowed")
 		return
@@ -54,7 +72,17 @@ func handleWait(w http.ResponseWriter, r *http.Request, sessions *store.Store, s
 		writeError(w, http.StatusNotFound, "not_found", "session not found")
 		return
 	}
-	if !adapterEmitsIdleSignal(sess.Adapter) {
+
+	forText := r.URL.Query().Get("for_text")
+	forRegex := r.URL.Query().Get("for_regex")
+	if forText != "" && forRegex != "" {
+		writeError(w, http.StatusBadRequest, "bad_request", "for_text and for_regex are mutually exclusive")
+		return
+	}
+
+	// Output conditions don't need the idle signal: they read the
+	// scrollback tee, which every adapter (including shell) produces.
+	if forText == "" && forRegex == "" && !adapterEmitsIdleSignal(sess.Adapter) {
 		writeError(w, http.StatusUnprocessableEntity, "no_idle_signal",
 			"the "+sess.Adapter+" adapter does not emit an idle signal; --wait is only supported for agent sessions")
 		return
@@ -68,6 +96,22 @@ func handleWait(w http.ResponseWriter, r *http.Request, sessions *store.Store, s
 			return
 		}
 		deadline = time.After(time.Duration(secs) * time.Second)
+	}
+
+	if forText != "" || forRegex != "" {
+		var match func(string) bool
+		if forText != "" {
+			match = func(line string) bool { return strings.Contains(line, forText) }
+		} else {
+			re, err := regexp.Compile(forRegex)
+			if err != nil {
+				writeError(w, http.StatusBadRequest, "bad_request", "invalid regex: "+err.Error())
+				return
+			}
+			match = re.MatchString
+		}
+		waitForOutput(w, r, sessions, sessionID, dirFor(sessionID), match, deadline)
+		return
 	}
 
 	// Subscribe BEFORE re-reading current state. If we read first then
@@ -152,6 +196,182 @@ func handleWait(w http.ResponseWriter, r *http.Request, sessions *store.Store, s
 			}
 		}
 	}
+}
+
+// waitForOutput blocks until a rendered line of the session's output
+// matches, the session dies, the optional deadline elapses, or the
+// client disconnects.
+//
+// The bytes come from the on-disk scrollback tee the runner writes
+// live into the session dir. Polling that file — instead of the store
+// event bus or a client-side scrollback re-fetch — is what makes the
+// condition sound: the file is append-only (with bounded rotation),
+// so output can't slip past between polls; at worst a match is
+// reported one tick late. Each poll replays the tee through a fresh
+// terminal emulator and matches per rendered line, i.e. against the
+// same ANSI-stripped text `gmux tail` prints. Matching raw PTY bytes
+// instead would foot-trap agent TUIs, whose escape sequences routinely
+// split a plain substring. Consequence: the pattern must fit on one
+// rendered (wrapped) terminal line.
+//
+// The whole persisted scrollback is matched, not just bytes that
+// arrive after the request: this mirrors the `until gmux tail | grep`
+// loop the condition replaces, and avoids the race where the text
+// appears between `gmux send` and `gmux wait`. Re-rendering is skipped
+// while the scrollback files' sizes are unchanged, so an idle session
+// costs two stat(2) calls per tick.
+//
+// Reasons: "matched" on success; "died" when the session exits or is
+// removed before matching — with one final render first, so output
+// that arrives in the same instant the session exits (the common case
+// for `gmux -- <cmd>` one-shots) still counts as a match.
+//
+// "died" is gated on hasRunEvidence (the same predicate the idle wait
+// uses): right after launch the session exists in the store with
+// Alive == false until the runner's first upsert lands, and reporting
+// "died" in that window would be a phantom death breaking the primary
+// composition `gmux -d -- cmd && gmux wait $id --for-text …` (issue
+// #216). See hasRunEvidence for the three signals that count as ran.
+func waitForOutput(
+	w http.ResponseWriter,
+	r *http.Request,
+	sessions *store.Store,
+	sessionID string,
+	dir string,
+	match func(string) bool,
+	deadline <-chan time.Time,
+) {
+	var lastSig scrollbackSig
+	rendered := false
+
+	// check re-renders (only when the scrollback files changed) and
+	// reports a match. The change signature folds in modification time
+	// as well as size, so a rotation that happens to land both files on
+	// a previously-seen size pair still forces a re-render (the mtimes
+	// advance) rather than silently hiding a match written across it.
+	check := func() bool {
+		sig := statScrollback(dir)
+		if rendered && sig == lastSig {
+			return false
+		}
+		lastSig, rendered = sig, true
+		return outputMatches(dir, sessions, sessionID, match)
+	}
+
+	respond := func(reason string) {
+		writeJSON(w, map[string]any{"ok": true, "data": map[string]any{"reason": reason}})
+	}
+
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+
+	// diedUnlessFinalMatch does one last render before conceding death.
+	// The output and the exit are separate writes (scrollback tee vs
+	// store upsert) with no ordering between them, so matching final
+	// bytes can land after this loop's top-of-iteration check() but
+	// before we observe Alive == false. Without a final check() here,
+	// `gmux -- <cmd>` one-shots that print their result in the same
+	// breath as exiting would race to "died" (exit 2) instead of
+	// "matched" (exit 0). check() re-renders because the final bytes
+	// grew the scrollback file, so the just-appended output is seen.
+	diedUnlessFinalMatch := func() {
+		if check() {
+			respond("matched")
+			return
+		}
+		respond("died")
+	}
+
+	seenAlive := false
+	for {
+		if check() {
+			respond("matched")
+			return
+		}
+		cur, ok := sessions.Get(sessionID)
+		if !ok {
+			// Removed from the store (UI dismiss, prune): no more
+			// output is ever coming, startup window or not.
+			diedUnlessFinalMatch()
+			return
+		}
+		seenAlive = seenAlive || cur.Alive
+		// Same #216 startup-window gate the idle wait uses: don't call
+		// a not-yet-started session dead. hasRunEvidence also covers the
+		// force-dead / restart-restored shape (StartedAt set, no live
+		// ExitCode) that a bare seenAlive||ExitCode check would hang on.
+		if !cur.Alive && hasRunEvidence(cur, seenAlive) {
+			diedUnlessFinalMatch()
+			return
+		}
+		select {
+		case <-r.Context().Done():
+			// Client disconnected; nothing to write.
+			return
+		case <-deadline:
+			writeError(w, http.StatusRequestTimeout, "timeout", "no matching output within timeout")
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+// statScrollback captures a change signature (size + mtime) for the
+// session's scrollback files (previous + active). Missing files report
+// size -2, and the caller's separate `rendered` flag guarantees the
+// very first check always renders even when no scrollback exists yet.
+type scrollbackSig struct {
+	prevSize, prevModNs     int64
+	activeSize, activeModNs int64
+}
+
+func statScrollback(dir string) scrollbackSig {
+	statOf := func(name string) (int64, int64) {
+		fi, err := os.Stat(filepath.Join(dir, name))
+		if err != nil {
+			return -2, 0 // missing: distinct from any real (size>=0) stat
+		}
+		return fi.Size(), fi.ModTime().UnixNano()
+	}
+	var s scrollbackSig
+	s.prevSize, s.prevModNs = statOf(scrollback.PreviousName)
+	s.activeSize, s.activeModNs = statOf(scrollback.ActiveName)
+	return s
+}
+
+// outputMatches replays the session's persisted scrollback through a
+// terminal emulator and reports whether any rendered line satisfies
+// match. Terminal dimensions come from the session's last-known size
+// (RenderTail falls back to 80x24 for sessions that never resized).
+// Render errors report no-match: the wait keeps polling and, worst
+// case, ends in timeout/died rather than a spurious success.
+func outputMatches(dir string, sessions *store.Store, sessionID string, match func(string) bool) bool {
+	rc, err := scrollback.OpenReader(dir)
+	if err != nil || rc == nil {
+		return false
+	}
+	defer rc.Close()
+
+	var cols, rows int
+	if sess, ok := sessions.Get(sessionID); ok {
+		cols, rows = int(sess.TerminalCols), int(sess.TerminalRows)
+	}
+	if rows <= 0 {
+		rows = 24
+	}
+	// The emulator retains at most RenderScrollbackSize scrolled-off
+	// lines plus the visible screen; asking for that many lines back
+	// means "everything the replay can know about".
+	lines, err := scrollback.RenderTail(rc, cols, rows, scrollback.RenderScrollbackSize+rows)
+	if err != nil {
+		return false
+	}
+	for _, line := range lines {
+		if match(line) {
+			return true
+		}
+	}
+	return false
 }
 
 // Sentinel results for waitForSessionExit. Distinct errors let the

--- a/services/gmuxd/cmd/gmuxd/wait_test.go
+++ b/services/gmuxd/cmd/gmuxd/wait_test.go
@@ -6,10 +6,13 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/gmuxapp/gmux/packages/scrollback"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/store"
 )
 
@@ -19,9 +22,14 @@ import (
 // daemon's response. The store is the load-bearing dependency here:
 // faking it would only test the test, since the whole point of
 // handleWait is to consume real session-event broadcasts.
-func waitTestServer(t *testing.T) (*httptest.Server, *store.Store) {
+// The per-session scrollback dir maps into a test temp dir so
+// output-condition tests can drive matches by appending to the
+// scrollback file, exactly as the runner's tee does in production.
+func waitTestServer(t *testing.T) (*httptest.Server, *store.Store, func(string) string) {
 	t.Helper()
 	st := store.New()
+	root := t.TempDir()
+	dirFor := func(id string) string { return filepath.Join(root, id) }
 	mux := http.NewServeMux()
 	mux.HandleFunc("/v1/sessions/", func(w http.ResponseWriter, r *http.Request) {
 		parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
@@ -29,11 +37,28 @@ func waitTestServer(t *testing.T) (*httptest.Server, *store.Store) {
 			http.NotFound(w, r)
 			return
 		}
-		handleWait(w, r, st, parts[2])
+		handleWait(w, r, st, parts[2], dirFor)
 	})
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
-	return srv, st
+	return srv, st, dirFor
+}
+
+// appendScrollback appends raw PTY bytes to a session's active
+// scrollback file, mimicking the runner's live tee.
+func appendScrollback(t *testing.T, dir, text string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.OpenFile(filepath.Join(dir, scrollback.ActiveName), os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	if _, err := f.WriteString(text); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func waitURL(srv *httptest.Server, id string) string {
@@ -47,7 +72,7 @@ func waitURL(srv *httptest.Server, id string) string {
 // races ahead between the two CLI calls), and the no-op-when-idle
 // behavior is what makes that composition reliable.
 func TestWaitReturnsImmediatelyWhenAlreadyIdle(t *testing.T) {
-	srv, st := waitTestServer(t)
+	srv, st, _ := waitTestServer(t)
 	st.Upsert(store.Session{
 		ID:      "sess-idle",
 		Adapter: "claude",
@@ -76,7 +101,7 @@ func TestWaitReturnsImmediatelyWhenAlreadyIdle(t *testing.T) {
 // asynchronously so the test exercises the subscription path rather
 // than the initial-snapshot fast path.
 func TestWaitBlocksUntilWorkingFlipsFalse(t *testing.T) {
-	srv, st := waitTestServer(t)
+	srv, st, _ := waitTestServer(t)
 	st.Upsert(store.Session{
 		ID:      "sess-busy",
 		Adapter: "pi",
@@ -128,7 +153,7 @@ func TestWaitBlocksUntilWorkingFlipsFalse(t *testing.T) {
 // for this turn to finish"; if the agent dies first we surface that
 // with reason=died so the CLI can map it to a non-zero exit code.
 func TestWaitReturnsDiedWhenSessionDies(t *testing.T) {
-	srv, st := waitTestServer(t)
+	srv, st, _ := waitTestServer(t)
 	st.Upsert(store.Session{
 		ID:      "sess-busy",
 		Adapter: "claude",
@@ -172,7 +197,7 @@ func TestWaitReturnsDiedWhenSessionDies(t *testing.T) {
 // phantom death; it should block until the session comes alive and
 // then resolve normally.
 func TestWaitDoesNotReportDiedBeforeFirstAlive(t *testing.T) {
-	srv, st := waitTestServer(t)
+	srv, st, _ := waitTestServer(t)
 	// Registered but not yet alive: no ExitCode, no Status — the
 	// runner hasn't reported anything.
 	st.Upsert(store.Session{
@@ -237,7 +262,7 @@ func TestWaitDoesNotReportDiedBeforeFirstAlive(t *testing.T) {
 // means the runner watched the child process exit, so "died" is
 // definitive even though this wait never observed Alive == true.
 func TestWaitReportsDiedOnArrivalWithExitCode(t *testing.T) {
-	srv, st := waitTestServer(t)
+	srv, st, _ := waitTestServer(t)
 	code := 1
 	st.Upsert(store.Session{
 		ID:       "sess-doa",
@@ -269,7 +294,7 @@ func TestWaitReportsDiedOnArrivalWithExitCode(t *testing.T) {
 // but may have no ExitCode — --wait on them must return died
 // immediately, not hang until timeout.
 func TestWaitReportsDiedForStaleDeadSession(t *testing.T) {
-	srv, st := waitTestServer(t)
+	srv, st, _ := waitTestServer(t)
 	st.Upsert(store.Session{
 		ID:        "sess-stale",
 		Adapter:   "pi",
@@ -297,7 +322,7 @@ func TestWaitReportsDiedForStaleDeadSession(t *testing.T) {
 // distinct HTTP status (408) so the CLI can tell timeout apart from
 // idle and from died.
 func TestWaitTimesOut(t *testing.T) {
-	srv, st := waitTestServer(t)
+	srv, st, _ := waitTestServer(t)
 	st.Upsert(store.Session{
 		ID:      "sess-stuck",
 		Adapter: "codex",
@@ -330,7 +355,7 @@ func TestWaitTimesOut(t *testing.T) {
 // wrong thing for `gmux make build && gmux --wait <id>`-style
 // composition. 422 surfaces the limitation explicitly.
 func TestWaitRejectsShellSessions(t *testing.T) {
-	srv, st := waitTestServer(t)
+	srv, st, _ := waitTestServer(t)
 	st.Upsert(store.Session{
 		ID:      "sess-shell",
 		Adapter: "shell",
@@ -349,7 +374,7 @@ func TestWaitRejectsShellSessions(t *testing.T) {
 // this guard, `gmux pi <prompt> --no-attach && gmux --wait $id` would
 // race the runner's first Working:true event and return immediately.
 func TestWaitDoesNotTreatNilStatusAsIdle(t *testing.T) {
-	srv, st := waitTestServer(t)
+	srv, st, _ := waitTestServer(t)
 	st.Upsert(store.Session{
 		ID:      "sess-fresh",
 		Adapter: "pi",
@@ -401,7 +426,7 @@ func TestWaitDoesNotTreatNilStatusAsIdle(t *testing.T) {
 // the response is correct regardless of which path (subscription or
 // re-snapshot) caught the transition.
 func TestWaitUnderHighEventLoad(t *testing.T) {
-	srv, st := waitTestServer(t)
+	srv, st, _ := waitTestServer(t)
 	st.Upsert(store.Session{
 		ID:      "sess-drop",
 		Adapter: "claude",
@@ -446,7 +471,7 @@ func TestWaitUnderHighEventLoad(t *testing.T) {
 // missing sessions. --wait would then hang forever, which is the
 // exact failure mode no-default-timeout was meant to avoid.
 func TestWaitReturnsDiedWhenSessionRemoved(t *testing.T) {
-	srv, st := waitTestServer(t)
+	srv, st, _ := waitTestServer(t)
 	st.Upsert(store.Session{
 		ID:      "sess-dismiss",
 		Adapter: "pi",
@@ -477,7 +502,7 @@ func TestWaitReturnsDiedWhenSessionRemoved(t *testing.T) {
 // TestWaitNotFound keeps the "missing session" case from being
 // confused with "session is busy forever."
 func TestWaitNotFound(t *testing.T) {
-	srv, _ := waitTestServer(t)
+	srv, _, _ := waitTestServer(t)
 	resp, _ := postWait(t, srv, "sess-nope")
 	if resp.StatusCode != http.StatusNotFound {
 		t.Errorf("status = %d, want 404", resp.StatusCode)
@@ -601,5 +626,293 @@ func TestWaitForSessionExitTimesOut(t *testing.T) {
 
 	if _, err := waitForSessionExit(st, evCh, id, 50*time.Millisecond, 10*time.Millisecond); !errors.Is(err, errExitWaitTimeout) {
 		t.Fatalf("expected errExitWaitTimeout for a session that never exited, got %v", err)
+	}
+}
+
+// ── output-condition waits (--for-text / --for-regex) ──
+
+func postWaitQuery(t *testing.T, srv *httptest.Server, id, query string) (*http.Response, map[string]any) {
+	t.Helper()
+	resp, err := http.Post(waitURL(srv, id)+"?"+query, "", nil)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	t.Cleanup(func() { resp.Body.Close() })
+	raw, _ := io.ReadAll(resp.Body)
+	var body map[string]any
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &body); err != nil {
+			t.Fatalf("unmarshal %q: %v", raw, err)
+		}
+	}
+	return resp, body
+}
+
+func reasonOf(t *testing.T, body map[string]any) string {
+	t.Helper()
+	data, ok := body["data"].(map[string]any)
+	if !ok {
+		t.Fatalf("no data envelope in %v", body)
+	}
+	reason, _ := data["reason"].(string)
+	return reason
+}
+
+// TestWaitForTextMatchesExistingOutput pins the "match whole
+// scrollback" contract: text that appeared before the wait call still
+// matches, mirroring the `until gmux tail | grep` loop this replaces
+// and avoiding the race where output lands between send and wait.
+func TestWaitForTextMatchesExistingOutput(t *testing.T) {
+	srv, st, dirFor := waitTestServer(t)
+	st.Upsert(store.Session{ID: "sess-out", Adapter: "shell", Alive: true})
+	appendScrollback(t, dirFor("sess-out"), "compiling...\r\nBUILD SUCCESSFUL\r\n")
+
+	resp, body := postWaitQuery(t, srv, "sess-out", "for_text=BUILD+SUCCESSFUL")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if got := reasonOf(t, body); got != "matched" {
+		t.Errorf("reason = %v, want matched", got)
+	}
+}
+
+// TestWaitForTextBlocksUntilOutputAppears is the headline behavior:
+// the wait blocks while the pattern is absent and unblocks once the
+// runner's tee appends matching bytes.
+func TestWaitForTextBlocksUntilOutputAppears(t *testing.T) {
+	srv, st, dirFor := waitTestServer(t)
+	st.Upsert(store.Session{ID: "sess-block", Adapter: "shell", Alive: true})
+	appendScrollback(t, dirFor("sess-block"), "starting server\r\n")
+
+	done := make(chan struct{})
+	var body map[string]any
+	go func() {
+		_, body = postWaitQuery(t, srv, "sess-block", "for_text=listening+on")
+		close(done)
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	select {
+	case <-done:
+		t.Fatal("wait returned before the text appeared")
+	default:
+	}
+
+	appendScrollback(t, dirFor("sess-block"), "listening on :8080\r\n")
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("wait did not return after the text appeared")
+	}
+	if got := reasonOf(t, body); got != "matched" {
+		t.Errorf("reason = %v, want matched", got)
+	}
+}
+
+// TestWaitForRegexMatchesRenderedLine verifies the regex variant and
+// that matching happens against rendered (ANSI-stripped) lines: the
+// escape sequence splitting the words must not defeat the pattern.
+func TestWaitForRegexMatchesRenderedLine(t *testing.T) {
+	srv, st, dirFor := waitTestServer(t)
+	st.Upsert(store.Session{ID: "sess-re", Adapter: "pi", Alive: true, Status: &store.Status{Working: true}})
+	appendScrollback(t, dirFor("sess-re"), "tests \x1b[32mpassed\x1b[0m: 42\r\n")
+
+	resp, body := postWaitQuery(t, srv, "sess-re", "for_regex="+"tests+passed%3A+%5Cd%2B")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if got := reasonOf(t, body); got != "matched" {
+		t.Errorf("reason = %v, want matched", got)
+	}
+}
+
+// TestWaitForTextDiedBeforeMatch: session exits while the pattern
+// never appears → reason=died (CLI exit 2), not a hang.
+func TestWaitForTextDiedBeforeMatch(t *testing.T) {
+	srv, st, dirFor := waitTestServer(t)
+	st.Upsert(store.Session{ID: "sess-die", Adapter: "shell", Alive: true})
+	appendScrollback(t, dirFor("sess-die"), "nothing to see\r\n")
+
+	done := make(chan struct{})
+	var body map[string]any
+	go func() {
+		_, body = postWaitQuery(t, srv, "sess-die", "for_text=never-appears")
+		close(done)
+	}()
+	time.Sleep(100 * time.Millisecond)
+
+	st.Upsert(store.Session{ID: "sess-die", Adapter: "shell", Alive: false})
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("wait did not return after session died")
+	}
+	if got := reasonOf(t, body); got != "died" {
+		t.Errorf("reason = %v, want died", got)
+	}
+}
+
+// TestWaitForTextMatchAtExitWins: output written in the same breath as
+// the exit (the normal shape of `gmux -- <cmd>` one-shots) must count
+// as a match, not be masked by reason=died.
+func TestWaitForTextMatchAtExitWins(t *testing.T) {
+	srv, st, dirFor := waitTestServer(t)
+	st.Upsert(store.Session{ID: "sess-final", Adapter: "shell", Alive: true})
+
+	done := make(chan struct{})
+	var body map[string]any
+	go func() {
+		_, body = postWaitQuery(t, srv, "sess-final", "for_text=all+done")
+		close(done)
+	}()
+	time.Sleep(100 * time.Millisecond)
+
+	// Final output lands, then the session exits before the next tick.
+	appendScrollback(t, dirFor("sess-final"), "all done\r\n")
+	st.Upsert(store.Session{ID: "sess-final", Adapter: "shell", Alive: false})
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("wait did not return")
+	}
+	if got := reasonOf(t, body); got != "matched" {
+		t.Errorf("reason = %v, want matched (final render before died)", got)
+	}
+}
+
+// TestWaitForTextTimesOut keeps the 408 escape hatch working in
+// output mode.
+func TestWaitForTextTimesOut(t *testing.T) {
+	srv, st, _ := waitTestServer(t)
+	st.Upsert(store.Session{ID: "sess-slow", Adapter: "shell", Alive: true})
+
+	start := time.Now()
+	resp, _ := postWaitQuery(t, srv, "sess-slow", "for_text=never&timeout=1")
+	if resp.StatusCode != http.StatusRequestTimeout {
+		t.Fatalf("status = %d, want 408", resp.StatusCode)
+	}
+	if elapsed := time.Since(start); elapsed < 900*time.Millisecond || elapsed > 2*time.Second {
+		t.Errorf("elapsed = %v, want ~1s", elapsed)
+	}
+}
+
+// TestWaitForTextAllowsShellSessions pins that output conditions skip
+// the idle-signal allowlist: shell sessions have no Working flag but
+// their scrollback tee is as good as anyone's.
+func TestWaitForTextAllowsShellSessions(t *testing.T) {
+	srv, st, dirFor := waitTestServer(t)
+	st.Upsert(store.Session{ID: "sess-sh", Adapter: "shell", Alive: true})
+	appendScrollback(t, dirFor("sess-sh"), "ready\r\n")
+
+	resp, body := postWaitQuery(t, srv, "sess-sh", "for_text=ready")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (shell must be allowed in output mode)", resp.StatusCode)
+	}
+	if got := reasonOf(t, body); got != "matched" {
+		t.Errorf("reason = %v, want matched", got)
+	}
+}
+
+// TestWaitOutputConditionBadRequests covers the 400 family: mutually
+// exclusive conditions and invalid regex syntax.
+func TestWaitOutputConditionBadRequests(t *testing.T) {
+	srv, st, _ := waitTestServer(t)
+	st.Upsert(store.Session{ID: "sess-bad", Adapter: "shell", Alive: true})
+
+	if resp, _ := postWaitQuery(t, srv, "sess-bad", "for_text=a&for_regex=b"); resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("both conditions: status = %d, want 400", resp.StatusCode)
+	}
+	if resp, _ := postWaitQuery(t, srv, "sess-bad", "for_regex=%5B"); resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("bad regex: status = %d, want 400", resp.StatusCode)
+	}
+}
+
+// TestWaitForTextNoPhantomDeathDuringStartup pins the startup window:
+// right after launch the session exists in the store with Alive ==
+// false until the runner's first upsert. Reporting "died" there would
+// break `gmux -d -- cmd && gmux wait $id --for-text …`. The wait must
+// ride out the window and match once the session comes up and emits.
+func TestWaitForTextNoPhantomDeathDuringStartup(t *testing.T) {
+	srv, st, dirFor := waitTestServer(t)
+	// Registered but not yet alive: the runner's first upsert hasn't landed.
+	st.Upsert(store.Session{ID: "sess-boot", Adapter: "shell", Alive: false})
+
+	done := make(chan struct{})
+	var body map[string]any
+	go func() {
+		_, body = postWaitQuery(t, srv, "sess-boot", "for_text=ready")
+		close(done)
+	}()
+
+	// Long enough for at least one poll tick to run against the
+	// not-yet-alive session.
+	select {
+	case <-done:
+		t.Fatal("wait returned during the startup window (phantom death)")
+	case <-time.After(700 * time.Millisecond):
+	}
+
+	st.Upsert(store.Session{ID: "sess-boot", Adapter: "shell", Alive: true})
+	appendScrollback(t, dirFor("sess-boot"), "ready\r\n")
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("wait did not return after the session came up and matched")
+	}
+	if got := reasonOf(t, body); got != "matched" {
+		t.Errorf("reason = %v, want matched", got)
+	}
+}
+
+// TestWaitForTextDeadOnArrivalWithExitCode: a session the runner
+// definitively watched exit (ExitCode set) fails fast with died even
+// though this wait never saw it alive — no riding out the timeout.
+func TestWaitForTextDeadOnArrivalWithExitCode(t *testing.T) {
+	srv, st, _ := waitTestServer(t)
+	code := 1
+	st.Upsert(store.Session{ID: "sess-doa", Adapter: "shell", Alive: false, ExitCode: &code})
+
+	start := time.Now()
+	resp, body := postWaitQuery(t, srv, "sess-doa", "for_text=never")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if got := reasonOf(t, body); got != "died" {
+		t.Errorf("reason = %v, want died", got)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Errorf("took %v; dead-on-arrival must fail fast", elapsed)
+	}
+}
+
+// TestWaitForTextDiedForStaleDeadSession pins the output wait's use of
+// the shared hasRunEvidence gate: a force-marked-dead or
+// restart-restored session carries StartedAt but often no live
+// ExitCode. A gate of only seenAlive||ExitCode would hang such a wait
+// to the timeout; hasRunEvidence's StartedAt clause makes it fail
+// fast, matching the idle wait (TestWaitReportsDiedForStaleDeadSession).
+func TestWaitForTextDiedForStaleDeadSession(t *testing.T) {
+	srv, st, _ := waitTestServer(t)
+	st.Upsert(store.Session{
+		ID:        "sess-stale-out",
+		Adapter:   "shell",
+		Alive:     false,
+		StartedAt: "2026-01-01T00:00:00Z",
+	})
+
+	start := time.Now()
+	resp, body := postWaitQuery(t, srv, "sess-stale-out", "for_text=never")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if got := reasonOf(t, body); got != "died" {
+		t.Errorf("reason = %v, want died", got)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Errorf("took %v; stale-dead session must fail fast", elapsed)
 	}
 }

--- a/skills/gmux/SKILL.md
+++ b/skills/gmux/SKILL.md
@@ -18,6 +18,7 @@ gmux -d -- <cmd> [args]      # run detached; prints the session id on stdout
 gmux send <id> 'text' Enter  # type text and submit (Enter is explicit)
 gmux send <id> C-c           # send a control key (interrupt), no text
 gmux wait <id>               # block until the agent finishes its turn
+gmux wait <id> --for-text S  # block until S appears in the output
 gmux tail <id> [-n N]        # last N lines of output (ANSI stripped; default 100)
 gmux ls [--json]             # list sessions (--json for machine parsing)
 gmux kill <id>               # SIGTERM the runner
@@ -88,9 +89,20 @@ the session exits, optionally bounded by `--timeout N`. Exit codes:
 
 Plain **shell** commands don't emit an idle signal and are rejected, so run
 those blocking instead: `gmux -- make build < /dev/null` exits with the
-command's own status. (Waiting on arbitrary output — "until this text
-appears" — is planned as a server-side condition; until then, poll `gmux tail`
-yourself if you must.)
+command's own status.
+
+To wait for specific **output** instead of idle, use `--for-text <substr>` or
+`--for-regex <pattern>` (works for shell sessions too — no grep loop needed):
+
+```bash
+gmux wait $id --for-text 'listening on' --timeout 60
+gmux wait $id --for-regex 'tests? passed: \d+' --timeout 120
+```
+
+Same exit codes (`0` matched, `2` session exited first, `3` timeout). Matching
+is line-wise against the rendered terminal output (ANSI stripped, same text
+`gmux tail` shows), including output that appeared before the wait started, so
+the pattern must fit on one terminal line.
 
 ## Other agents have one-shot modes
 


### PR DESCRIPTION
Closes #313.

Implements the server-side output-condition wait designed in ADR 0009 (decision 13) and deferred out of #314.

## What

- **gmuxd**: `POST /v1/sessions/<id>/wait` now accepts `?for_text=<substr>` / `?for_regex=<pattern>` alongside the existing idle wait. The handler polls the on-disk scrollback tee the runner writes live into the session dir — the daemon-side source of truth for output bytes — so nothing can scroll past unseen between polls (loss is bounded by the scrollback cap, not the poll interval; this is exactly the flaw that got the client-side prototype removed).
- **CLI**: `gmux wait <id> --for-text <substr> | --for-regex <pattern> [--timeout N]`, mutually exclusive, regex validated at parse time (and again server-side, so non-CLI clients get a clean 400). Exit codes consistent with idle wait: `0` matched, `2` session exited first, `3` timeout.
- **Leak fix** (separate commit): `scrollback.RenderTail` never closed its emulator, leaking the drain goroutine on every call. One-shot tail requests barely noticed; the output wait re-renders on a ticker and would have accumulated them. Now closed + waited on, with a regression test that fails without the fix.
- Docs: usage text, `skills/gmux/SKILL.md`, ADR 0009 note updated.

## Semantics

- Matching is **line-wise against rendered terminal output** (ANSI stripped, same text `gmux tail` shows), via the shared `scrollback.RenderTail` replay. Matching raw PTY bytes would foot-trap agent TUIs whose escape codes split plain substrings. Consequence: the pattern must fit on one rendered (wrapped) line — documented in the skill.
- The **whole persisted scrollback** is matched, not just bytes after the request: mirrors the `until gmux tail | grep` loop this replaces and avoids the race where the text lands between `gmux send` and `gmux wait`.
- Output conditions **skip the idle-signal adapter allowlist**: shell sessions work too (the tee is adapter-agnostic).
- On session exit, one final render runs before returning `died`, so output written in the same breath as the exit (normal `gmux -- <cmd>` one-shots) still counts as a match.
- **No phantom death during startup**: `died` is gated on having observed `Alive == true` during this wait (or a non-nil `ExitCode`), the same treatment #362 gives the idle wait (issue #216). Without it, `gmux -d -- cmd && gmux wait $id --for-text …` racing the runner's first upsert would return `died` instantly.
- Re-rendering is skipped while the scrollback file sizes are unchanged; an idle waiter costs two `stat(2)` calls per 500ms tick. Per-render memory is bounded by the on-disk cap (≤2 MiB raw + emulator state), freed after each render.

## Merge-order notes

#362 (phantom-death fix for idle wait) and #371 (`send --wait`) also touch `services/gmuxd/cmd/gmuxd/wait.go`; whichever lands later needs a mechanical rebase (this PR changes `handleWait`'s signature and adds new functions; #371 is additive; #362 changes `terminalReason`'s signature). No semantic conflicts: this PR's output mode carries its own self-contained `seenAlive` gating and does not call `terminalReason`.

## Out of scope

Peer sessions stay rejected client-side, same as the idle wait: the peer forward path (`apiclient.ForwardAction`) caps forwarded actions at 10s, which would silently truncate long waits. Lifting that is the existing cross-peer-wait deferral (ADR 0005), not something this PR should smuggle in.

## Tests

- Daemon: matched-on-existing-output, block-until-appended, regex across ANSI codes, died-before-match, match-at-exit-wins, no-phantom-death-during-startup, dead-on-arrival-fails-fast, timeout 408, shell adapter allowed, 400s (both conditions / bad regex). All prior idle-wait tests unchanged and passing.
- CLI: parse cases for the new flags, mutual exclusion, invalid regex.
- Scrollback: goroutine-leak regression test (verified to fail with the fix reverted).