### PR TITLE
feat(cli): add gmux send --wait for race-free send-and-wait

### DIFF
--- a/cli/gmux/cmd/gmux/actions.go
+++ b/cli/gmux/cmd/gmux/actions.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/gmuxapp/gmux/cli/gmux/internal/localterm"
@@ -430,7 +431,7 @@ func fetchScrollback(sess cliSession, n int) ([]byte, int) {
 // peer sessions (gmuxd forwards to the owning peer transparently).
 // Access control inherits from gmuxd: local IPC is owner-only, and
 // peers honor their own `tailscale.allow` config.
-func cmdSend(ref string, text *string, keys []string) int {
+func cmdSend(ref string, text *string, keys []string, wait bool, timeoutSecs int) int {
 	// Read stdin only when no inline text was given AND stdin is a pipe.
 	// The tty guard is essential: without it, `gmux send <id> Enter` typed
 	// interactively would block reading the terminal. With it, piped input
@@ -440,7 +441,11 @@ func cmdSend(ref string, text *string, keys []string) int {
 	if text == nil && !localterm.IsInteractive() {
 		stdin = os.Stdin
 	}
-	return sendBytes(ref, buildSendBody(text, keys, stdin))
+	body := buildSendBody(text, keys, stdin)
+	if wait {
+		return sendBytesAndWait(ref, body, timeoutSecs)
+	}
+	return sendBytes(ref, body)
 }
 
 // cmdSendKeys implements the tmux-compatible `gmux send-keys -t <id>
@@ -457,14 +462,50 @@ func sendBytes(ref string, body io.Reader) int {
 		fmt.Fprintln(os.Stderr, "gmux:", err)
 		return 1
 	}
+	return postInput(sess, body, "")
+}
 
+// sendBytesAndWait implements `gmux send --wait`: one request delivers
+// the input AND blocks until the turn it triggers completes. gmuxd
+// subscribes to session events *before* forwarding the bytes to the
+// runner, so unlike the `gmux send X && gmux wait X` composition it
+// cannot mistake the previous turn's idle state for the reply (#218).
+//
+// Exit codes mirror `gmux wait`: 0 idle, 2 died, 3 timeout, 1 usage/
+// transport errors.
+func sendBytesAndWait(ref string, body io.Reader, timeoutSecs int) int {
+	sess, err := resolveSession(ref)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "gmux:", err)
+		return 1
+	}
+	if sess.Peer != "" {
+		// Same scope rule as `gmux wait`: the wait half needs the
+		// owning daemon's event stream, which peers don't expose to
+		// the CLI yet. Bare shortID: the message names the peer itself.
+		fmt.Fprintf(os.Stderr, "gmux: send --wait is only supported for local sessions (%s is on peer %q)\n",
+			shortID(sess.ID), sess.Peer)
+		return 1
+	}
+	query := "?wait=idle"
+	if timeoutSecs > 0 {
+		query += "&timeout=" + strconv.Itoa(timeoutSecs)
+	}
+	return postInput(sess, body, query)
+}
+
+// postInput POSTs body to the session's input endpoint. With an empty
+// query this is fire-and-forget (204). With "?wait=idle..." gmuxd
+// holds the response until the triggered turn completes and answers
+// with a wait-style reason payload, mapped to `gmux wait` exit codes.
+func postInput(sess cliSession, body io.Reader, query string) int {
 	client := gmuxdClient()
 	// Stdin may be paced by a human or upstream process; the default
 	// 5s timeout would cut off legitimately slow inputs. gmuxd buffers
 	// the whole body before forwarding to the runner, so a long-lived
 	// connection here is fine.
 	client.Timeout = 0
-	url := gmuxdBaseURL() + "/v1/sessions/" + sess.ID + "/input"
+	url := gmuxdBaseURL() + "/v1/sessions/" + sess.ID + "/input" + query
 	req, err := http.NewRequest(http.MethodPost, url, body)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "gmux:", err)
@@ -485,12 +526,39 @@ func sendBytes(ref string, body io.Reader) int {
 			fmt.Fprintf(os.Stderr, "gmux: session %s not found\n", displayID(sess))
 		case http.StatusConflict:
 			fmt.Fprintf(os.Stderr, "gmux: session %s is not running\n", displayID(sess))
+		case http.StatusRequestTimeout:
+			fmt.Fprintln(os.Stderr, "gmux: session did not become idle within --timeout")
+			return waitExitTimeout
+		case http.StatusUnprocessableEntity:
+			fmt.Fprintf(os.Stderr, "gmux: %s\n", extractMessage(msg))
 		default:
 			fmt.Fprintf(os.Stderr, "gmux: send failed: %s: %s\n", resp.Status, strings.TrimSpace(string(msg)))
 		}
 		return 1
 	}
-	return 0
+	if query == "" {
+		return 0
+	}
+	// wait=idle response: { ok: true, data: { reason: "idle" | "died" } }
+	var env struct {
+		Data struct {
+			Reason string `json:"reason"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+		fmt.Fprintln(os.Stderr, "gmux: decode send --wait response:", err)
+		return 1
+	}
+	switch env.Data.Reason {
+	case "idle":
+		return waitExitOK
+	case "died":
+		fmt.Fprintf(os.Stderr, "gmux: session %s died before becoming idle\n", displayID(sess))
+		return waitExitDied
+	default:
+		fmt.Fprintf(os.Stderr, "gmux: unexpected send --wait reason %q\n", env.Data.Reason)
+		return 1
+	}
 }
 
 // maxSendBytes caps the number of bytes read from stdin for a single

--- a/cli/gmux/cmd/gmux/cli.go
+++ b/cli/gmux/cmd/gmux/cli.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"regexp"
+	"strconv"
 	"strings"
 )
 
@@ -61,6 +62,7 @@ type command struct {
 	// send
 	sendText *string  // literal text to type (nil = none)
 	sendKeys []string // trailing key-name tokens (Enter, C-c, ...)
+	sendWait bool     // --wait: block until the triggered turn completes
 
 	// send-keys (tmux-compat)
 	keysLiteral bool     // -l: treat args as literal text, not key names
@@ -273,16 +275,65 @@ func parseTail(args []string) (*command, error) {
 	return c, nil
 }
 
-// parseSend handles `gmux send <id> [text] [Key...]`. The first
-// positional is the session ref; an optional second positional is the
-// literal text; any further bare tokens are key-name tokens. With no
-// text and no keys, stdin supplies the text.
+// parseSend handles `gmux send [--wait] [--timeout N] [--] <id> [text]
+// [Key...]`. The first positional is the session ref; an optional
+// second positional is the literal text; any further bare tokens are
+// key-name tokens. With no text and no keys, stdin supplies the text.
+//
+// Grammar (ADR 0009 decision 9, verbatim-content rule): behavior
+// modifiers precede the session ref; the ref is the first non-flag
+// token, and *everything after it is verbatim* — including tokens that
+// start with a dash. So `gmux send abc -v` sends the literal `-v`, and
+// `gmux send abc '--weird text'` needs no `--` guard. This deliberately
+// diverges from parsing flags anywhere: send's trailing content is
+// arbitrary user text, so taxing the common case with a `--` guard to
+// support two rare flags is the wrong trade. To wait, put the flag
+// before the id: `gmux send --wait abc 'do it' Enter`. A `--` before
+// the ref is accepted as an explicit end-of-flags marker.
 func parseSend(args []string) (*command, error) {
-	if len(args) < 1 {
+	c := &command{mode: modeSend}
+	i := 0
+	for i < len(args) {
+		a := args[i]
+		if a == "--" { // explicit end-of-flags; ref follows
+			i++
+			break
+		}
+		if !strings.HasPrefix(a, "-") { // first non-flag token is the ref
+			break
+		}
+		switch {
+		case a == "--wait":
+			c.sendWait = true
+		case a == "--timeout" || strings.HasPrefix(a, "--timeout="):
+			val := strings.TrimPrefix(a, "--timeout")
+			if val == "" {
+				i++
+				if i >= len(args) {
+					return nil, errors.New("--timeout requires a number of seconds")
+				}
+				val = args[i]
+			} else {
+				val = strings.TrimPrefix(val, "=")
+			}
+			n, err := strconv.Atoi(val)
+			if err != nil || n <= 0 {
+				return nil, errors.New("--timeout must be a positive number of seconds")
+			}
+			c.timeout = n
+		default:
+			return nil, fmt.Errorf("send: unknown flag %q (flags go before the session id; text after the id is literal)", a)
+		}
+		i++
+	}
+	if c.timeout > 0 && !c.sendWait {
+		return nil, errors.New("send: --timeout only applies with --wait")
+	}
+	if i >= len(args) {
 		return nil, errors.New("send requires a session id")
 	}
-	c := &command{mode: modeSend, ref: args[0]}
-	rest := args[1:]
+	c.ref = args[i]
+	rest := args[i+1:]
 	if len(rest) > 0 {
 		// Heuristic: the first non-key token is the literal text; the
 		// rest are keys. If the first token is itself a key name, there
@@ -496,6 +547,8 @@ Sessions (local by default; address a peer with <id>@<peer>):
   gmux attach <id>                  reattach to a session
   gmux tail <id> [-n N] [--raw]     print recent output (snapshot)
   gmux send <id> <text> [Key...]    type text and/or send keys (e.g. Enter, C-c)
+  gmux send --wait [--timeout N] <id> <text> [Key...]
+                                    ... and block until the triggered turn ends
   gmux send-keys -t <id> <keys...>  tmux-compatible key sending
   gmux wait <id> [--timeout N]      block until an agent session is idle
        [--for-text S|--for-regex P] ... or until output matches S / P

--- a/cli/gmux/cmd/gmux/cli_test.go
+++ b/cli/gmux/cmd/gmux/cli_test.go
@@ -128,6 +128,46 @@ func TestParseCLI(t *testing.T) {
 				if c.sendText != nil || len(c.sendKeys) != 0 {
 					t.Errorf("expected stdin form: text=%v keys=%v", c.sendText, c.sendKeys)
 				}
+				if c.sendWait {
+					t.Error("sendWait should default to false")
+				}
+			}},
+		{name: "send --wait with timeout", args: []string{"send", "--wait", "--timeout", "60", "abc", "do it", "Enter"}, wantMode: modeSend,
+			check: func(t *testing.T, c *command) {
+				if !c.sendWait || c.timeout != 60 {
+					t.Errorf("sendWait=%v timeout=%d", c.sendWait, c.timeout)
+				}
+				if c.ref != "abc" || c.sendText == nil || *c.sendText != "do it" ||
+					len(c.sendKeys) != 1 || c.sendKeys[0] != "Enter" {
+					t.Errorf("ref=%q text=%v keys=%v", c.ref, c.sendText, c.sendKeys)
+				}
+			}},
+		{name: "send --timeout=N form before ref", args: []string{"send", "--wait", "--timeout=30", "abc", "go", "Enter"}, wantMode: modeSend,
+			check: func(t *testing.T, c *command) {
+				if !c.sendWait || c.timeout != 30 {
+					t.Errorf("sendWait=%v timeout=%d", c.sendWait, c.timeout)
+				}
+			}},
+		{name: "send dash-leading text after ref is literal (no guard)", args: []string{"send", "abc", "-v"}, wantMode: modeSend,
+			check: func(t *testing.T, c *command) {
+				if c.sendText == nil || *c.sendText != "-v" {
+					t.Errorf("text = %v, want literal -v", c.sendText)
+				}
+			}},
+		{name: "send flag-looking text after ref is literal", args: []string{"send", "abc", "--wait"}, wantMode: modeSend,
+			check: func(t *testing.T, c *command) {
+				if c.sendWait {
+					t.Error("--wait after the ref must be literal text, not a flag")
+				}
+				if c.sendText == nil || *c.sendText != "--wait" {
+					t.Errorf("text = %v, want literal --wait", c.sendText)
+				}
+			}},
+		{name: "send -- guard before ref still works", args: []string{"send", "--", "abc", "hi"}, wantMode: modeSend,
+			check: func(t *testing.T, c *command) {
+				if c.ref != "abc" || c.sendText == nil || *c.sendText != "hi" {
+					t.Errorf("ref=%q text=%v", c.ref, c.sendText)
+				}
 			}},
 
 		{name: "send-keys tmux compat", args: []string{"send-keys", "-t", "abc", "C-c"}, wantMode: modeSendKeys,
@@ -220,6 +260,10 @@ func TestParseCLIErrors(t *testing.T) {
 		{"wait", "abc", "--for-text", "a", "--for-regex", "b"}, // mutually exclusive
 		{"wait", "abc", "--for-regex", "["},                    // invalid regex
 		{"send-keys", "C-c"},                                   // missing -t
+		{"send", "--timeout", "5", "abc", "x"},                 // --timeout without --wait
+		{"send", "--wait", "--timeout", "0", "abc", "x"},       // non-positive timeout
+		{"send", "--frob", "abc"},                              // unknown leading flag
+		{"send", "--wait"},                                     // missing id (only a flag given)
 		{"daemon"},                                             // missing subcommand
 		{"daemon", "frobnicate"},                               // unknown subcommand
 		{"ls", "stray"},                                        // ls takes no positional

--- a/cli/gmux/cmd/gmux/main.go
+++ b/cli/gmux/cmd/gmux/main.go
@@ -52,7 +52,7 @@ func main() {
 	case modeAttach:
 		os.Exit(cmdAttach(cmd.ref))
 	case modeSend:
-		os.Exit(cmdSend(cmd.ref, cmd.sendText, cmd.sendKeys))
+		os.Exit(cmdSend(cmd.ref, cmd.sendText, cmd.sendKeys, cmd.sendWait, cmd.timeout))
 	case modeSendKeys:
 		os.Exit(cmdSendKeys(cmd.ref, cmd.keys, cmd.keysLiteral))
 	case modeWait:

--- a/docs/adr/0009-verb-first-cli-and-frozen-top-level-namespace.md
+++ b/docs/adr/0009-verb-first-cli-and-frozen-top-level-namespace.md
@@ -222,6 +222,39 @@ For 2.0 we unify on a single **verb-first** grammar fronted by the
   peer session, which simplifies `matchSession` (the `host` parameter
   and the `--host`/`@suffix` reconciliation branch both go away).
 
+## Amendment (2026-07-06): `send --wait` composes send and wait
+
+`gmux send` gains a `--wait` behavior modifier (with `--timeout N`):
+deliver the input and block until the turn it triggers completes, with
+`gmux wait`'s exit codes (0 idle, 2 died, 3 timeout).
+
+This exists because the obvious composition `gmux send <id> … &&
+gmux wait <id>` is inherently racy: `wait`'s initial snapshot can
+observe the previous turn's idle state before the send-induced
+`Working=true` has propagated into gmuxd's store ([#218]). The fix is
+ordering — subscribe before delivering the input, then require a fresh
+working→idle transition — which only one actor can guarantee, so the
+two verbs must fuse for this use case. It lands as a flag, not a new
+top-level verb (`send-wait` would breach decision 5), and server-side
+(`POST …/input?wait=idle`), keeping idle-detection rules in gmuxd per
+ADR 0005 and the `wait` design in decision 13.
+
+Consequences for `send`'s grammar: to keep `send`'s trailing content
+fully verbatim (its whole point — arbitrary text, including tokens that
+start with a dash), the new flags are parsed **only before the session
+ref**. The ref is the first non-flag token; everything after it is
+literal, so `gmux send abc -v` still sends `-v` and no `--` guard is
+needed for dash-leading text. To wait, the flag precedes the id:
+`gmux send --wait abc 'do it' Enter`. A `--` before the ref is accepted
+as an explicit end-of-flags marker. This applies decision 9's
+verbatim-content rule (flags-then-`--`-then-verbatim, as in `gmux --
+<cmd>`) rather than parsing flags amongst the content, which would have
+taxed the common case with a guard. Under `--wait`, non-submitting
+input (no `\r`) is rejected — it would never start a turn, so the wait
+could only time out.
+
+[#218]: https://github.com/gmuxapp/gmux/issues/218
+
 ## Amendment (2026-07-06): `edit` joins the top-level namespace
 
 `gmux edit [file]` is added as a top-level verb. It cannot live under a

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -1728,6 +1728,21 @@ func serve(stderr io.Writer) int {
 					fmt.Sprintf("input exceeds %d bytes", maxInputBytes))
 				return
 			}
+			if r.URL.Query().Get("wait") != "" {
+				// `gmux send --wait`: deliver the input and block until
+				// the turn it triggers completes. handleInputWait
+				// validates the wait mode and subscribes to the store
+				// before invoking send, which is what makes the
+				// composition race-free (issue #218).
+				handleInputWait(w, r, sessions, sess, body, func() error {
+					err := discovery.SendInput(r.Context(), sess.SocketPath, bytes.NewReader(body))
+					if err != nil {
+						log.Printf("input: %s: %v", sessionID, err)
+					}
+					return err
+				})
+				return
+			}
 			if err := discovery.SendInput(r.Context(), sess.SocketPath, bytes.NewReader(body)); err != nil {
 				log.Printf("input: %s: %v", sessionID, err)
 				writeError(w, http.StatusBadGateway, "runner_unreachable", err.Error())

--- a/services/gmuxd/cmd/gmuxd/sendwait_test.go
+++ b/services/gmuxd/cmd/gmuxd/sendwait_test.go
@@ -1,0 +1,245 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/store"
+)
+
+// postInput POSTs to /v1/sessions/<idAndQuery> where idAndQuery is
+// "<id>/input?..." and decodes the JSON envelope (if any).
+func postInput(t *testing.T, srv *httptest.Server, idAndQuery string) (*http.Response, map[string]any) {
+	t.Helper()
+	resp, err := http.Post(srv.URL+"/v1/sessions/"+idAndQuery, "", nil)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	t.Cleanup(func() { resp.Body.Close() })
+	raw, _ := io.ReadAll(resp.Body)
+	var body map[string]any
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &body); err != nil {
+			t.Fatalf("unmarshal %q: %v", raw, err)
+		}
+	}
+	return resp, body
+}
+
+// sendWaitTestServer wires handleInputWait against a real store the
+// way main.go's input?wait=idle branch does, with the runner delivery
+// replaced by a send closure. Like waitTestServer, the store is the
+// load-bearing dependency: handleInputWait's whole contract is about
+// its subscription ordering against real store broadcasts.
+func sendWaitTestServer(t *testing.T, send func(st *store.Store)) (*httptest.Server, *store.Store) {
+	t.Helper()
+	st := store.New()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/sessions/", func(w http.ResponseWriter, r *http.Request) {
+		parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
+		if len(parts) != 4 || parts[3] != "input" {
+			http.NotFound(w, r)
+			return
+		}
+		sess, ok := st.Get(parts[2])
+		if !ok {
+			writeError(w, http.StatusNotFound, "not_found", "session not found")
+			return
+		}
+		body := []byte("prompt\r")
+		if b := r.URL.Query().Get("body"); b != "" {
+			body = []byte(b)
+		}
+		handleInputWait(w, r, st, sess, body, func() error {
+			if send != nil {
+				send(st)
+			}
+			return nil
+		})
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv, st
+}
+
+func upsertAgent(st *store.Store, id string, alive bool, status *store.Status) {
+	st.Upsert(store.Session{ID: id, Adapter: "pi", Alive: alive, Status: status})
+}
+
+// TestSendWaitIgnoresStalePreviousIdle is the regression test for
+// issue #218: at the moment the input is delivered, the store still
+// holds the *previous* turn's Working=false. A naive send-then-wait
+// composition returns "idle" immediately off that stale snapshot.
+// send --wait must instead hold until a fresh Working=true pulse and
+// its subsequent Working=false.
+func TestSendWaitIgnoresStalePreviousIdle(t *testing.T) {
+	const id = "sess-stale"
+	srv, st := sendWaitTestServer(t, func(st *store.Store) {
+		// Simulate the async runner: the agent starts working shortly
+		// after the bytes land, then finishes its turn.
+		go func() {
+			time.Sleep(100 * time.Millisecond)
+			upsertAgent(st, id, true, &store.Status{Working: true})
+			time.Sleep(150 * time.Millisecond)
+			upsertAgent(st, id, true, &store.Status{Working: false})
+		}()
+	})
+	// Stale state: idle from the previous turn.
+	upsertAgent(st, id, true, &store.Status{Working: false})
+
+	start := time.Now()
+	resp, body := postInput(t, srv, id+"/input?wait=idle")
+	elapsed := time.Since(start)
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if got := body["data"].(map[string]any)["reason"]; got != "idle" {
+		t.Errorf("reason = %v, want idle", got)
+	}
+	if elapsed < 200*time.Millisecond {
+		t.Errorf("returned in %v — observed the stale previous idle instead of the fresh turn", elapsed)
+	}
+}
+
+// TestSendWaitCannotMissTheWorkingPulse pins the subscribe-before-send
+// ordering: even when the Working pulse is broadcast synchronously
+// inside the send delivery itself (the fastest possible agent), the
+// wait half observes it because the subscription already exists.
+func TestSendWaitCannotMissTheWorkingPulse(t *testing.T) {
+	const id = "sess-fast"
+	srv, st := sendWaitTestServer(t, func(st *store.Store) {
+		// The entire turn happens "instantly" during delivery.
+		upsertAgent(st, id, true, &store.Status{Working: true})
+		upsertAgent(st, id, true, &store.Status{Working: false})
+	})
+	upsertAgent(st, id, true, &store.Status{Working: false})
+
+	resp, body := postInput(t, srv, id+"/input?wait=idle&timeout=2")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if got := body["data"].(map[string]any)["reason"]; got != "idle" {
+		t.Errorf("reason = %v, want idle", got)
+	}
+}
+
+// TestSendWaitReturnsDiedMidTurn: the agent starts working and then
+// crashes before going idle.
+func TestSendWaitReturnsDiedMidTurn(t *testing.T) {
+	const id = "sess-crash"
+	srv, st := sendWaitTestServer(t, func(st *store.Store) {
+		go func() {
+			time.Sleep(50 * time.Millisecond)
+			upsertAgent(st, id, true, &store.Status{Working: true})
+			time.Sleep(50 * time.Millisecond)
+			upsertAgent(st, id, false, &store.Status{Working: true})
+		}()
+	})
+	upsertAgent(st, id, true, &store.Status{Working: false})
+
+	resp, body := postInput(t, srv, id+"/input?wait=idle")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if got := body["data"].(map[string]any)["reason"]; got != "died" {
+		t.Errorf("reason = %v, want died", got)
+	}
+}
+
+// TestSendWaitTimesOut: the agent never reacts (wedged adapter, modal
+// dialog); ?timeout=N bounds the wait with a distinct 408.
+func TestSendWaitTimesOut(t *testing.T) {
+	const id = "sess-wedged"
+	srv, st := sendWaitTestServer(t, nil)
+	upsertAgent(st, id, true, &store.Status{Working: false})
+
+	start := time.Now()
+	resp, _ := postInput(t, srv, id+"/input?wait=idle&timeout=1")
+	elapsed := time.Since(start)
+
+	if resp.StatusCode != http.StatusRequestTimeout {
+		t.Fatalf("status = %d, want 408", resp.StatusCode)
+	}
+	if elapsed < 900*time.Millisecond || elapsed > 2*time.Second {
+		t.Errorf("elapsed = %v, want ~1s", elapsed)
+	}
+}
+
+// TestSendWaitRejectsShellSessions mirrors handleWait's allowlist:
+// adapters without an idle signal can't answer "turn finished".
+func TestSendWaitRejectsShellSessions(t *testing.T) {
+	srv, st := sendWaitTestServer(t, func(st *store.Store) {
+		t.Error("input must not be delivered when the wait contract can't be honored")
+	})
+	st.Upsert(store.Session{ID: "sess-shell", Adapter: "shell", Alive: true})
+
+	resp, _ := postInput(t, srv, "sess-shell/input?wait=idle")
+	if resp.StatusCode != http.StatusUnprocessableEntity {
+		t.Errorf("status = %d, want 422", resp.StatusCode)
+	}
+}
+
+// TestSendWaitRejectsNonSubmittingInput: input without a carriage
+// return never starts a turn, so waiting on it would only ever time
+// out. Fail loudly instead, and don't deliver the bytes.
+func TestSendWaitRejectsNonSubmittingInput(t *testing.T) {
+	srv, st := sendWaitTestServer(t, func(st *store.Store) {
+		t.Error("non-submitting input must not be delivered under --wait")
+	})
+	upsertAgent(st, "sess-nosubmit", true, &store.Status{Working: false})
+
+	resp, body := postInput(t, srv, "sess-nosubmit/input?wait=idle&body=no+enter+here")
+	if resp.StatusCode != http.StatusUnprocessableEntity {
+		t.Errorf("status = %d, want 422", resp.StatusCode)
+	}
+	if body != nil {
+		if errObj, ok := body["error"].(map[string]any); ok {
+			if errObj["code"] != "input_no_submit" {
+				t.Errorf("error code = %v, want input_no_submit", errObj["code"])
+			}
+		}
+	}
+}
+
+// TestSendWaitRejectsUnknownWaitMode: a typo'd wait mode (wait=true,
+// wait=1, ...) must fail loudly rather than silently degrading to
+// fire-and-forget — the caller believes it waited for the reply.
+func TestSendWaitRejectsUnknownWaitMode(t *testing.T) {
+	srv, st := sendWaitTestServer(t, func(st *store.Store) {
+		t.Error("input must not be delivered for an unsupported wait mode")
+	})
+	upsertAgent(st, "sess-typo", true, &store.Status{Working: false})
+
+	resp, _ := postInput(t, srv, "sess-typo/input?wait=true")
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", resp.StatusCode)
+	}
+}
+
+// TestSendWaitAlreadyWorkingWaitsForCurrentTurn: if the agent is
+// already mid-turn when the input lands, the bytes queue behind the
+// current turn; its completion is the answer.
+func TestSendWaitAlreadyWorkingWaitsForCurrentTurn(t *testing.T) {
+	const id = "sess-busy"
+	srv, st := sendWaitTestServer(t, func(st *store.Store) {
+		go func() {
+			time.Sleep(100 * time.Millisecond)
+			upsertAgent(st, id, true, &store.Status{Working: false})
+		}()
+	})
+	upsertAgent(st, id, true, &store.Status{Working: true})
+
+	resp, body := postInput(t, srv, id+"/input?wait=idle")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if got := body["data"].(map[string]any)["reason"]; got != "idle" {
+		t.Errorf("reason = %v, want idle", got)
+	}
+}

--- a/services/gmuxd/cmd/gmuxd/wait.go
+++ b/services/gmuxd/cmd/gmuxd/wait.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bytes"
+	"context"
 	"errors"
 	"net/http"
 	"os"
@@ -88,14 +90,10 @@ func handleWait(w http.ResponseWriter, r *http.Request, sessions *store.Store, s
 		return
 	}
 
-	var deadline <-chan time.Time
-	if ts := r.URL.Query().Get("timeout"); ts != "" {
-		secs, err := strconv.Atoi(ts)
-		if err != nil || secs <= 0 {
-			writeError(w, http.StatusBadRequest, "bad_request", "timeout must be a positive integer of seconds")
-			return
-		}
-		deadline = time.After(time.Duration(secs) * time.Second)
+	deadline, err := timeoutChan(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
 	}
 
 	if forText != "" || forRegex != "" {
@@ -132,8 +130,11 @@ func handleWait(w http.ResponseWriter, r *http.Request, sessions *store.Store, s
 	seenAlive := false
 
 	// Already in a terminal state? Return without waiting for a
-	// transition. Callers like `--send-wait` (composition) want
-	// `--wait` to be a no-op when the agent is already idle.
+	// transition. Composing scripts want `gmux wait` to be a no-op
+	// when the agent is already idle. (Note this is also why the bare
+	// `send && wait` composition is racy: the "already idle" snapshot
+	// may be the previous turn's. `gmux send --wait` routes through
+	// handleInputWait instead, which requires a fresh Working pulse.)
 	if cur, ok := sessions.Get(sessionID); ok {
 		seenAlive = seenAlive || cur.Alive
 		if reason, done := terminalReason(cur, seenAlive); done {
@@ -372,6 +373,175 @@ func outputMatches(dir string, sessions *store.Store, sessionID string, match fu
 		}
 	}
 	return false
+}
+
+// timeoutChan parses the optional ?timeout=N query parameter into a
+// deadline channel. A nil channel (no timeout) blocks forever in a
+// select, which is exactly the no-deadline behavior we want.
+func timeoutChan(r *http.Request) (<-chan time.Time, error) {
+	ts := r.URL.Query().Get("timeout")
+	if ts == "" {
+		return nil, nil
+	}
+	secs, err := strconv.Atoi(ts)
+	if err != nil || secs <= 0 {
+		return nil, errors.New("timeout must be a positive integer of seconds")
+	}
+	return time.After(time.Duration(secs) * time.Second), nil
+}
+
+// handleInputWait implements POST /v1/sessions/{id}/input?wait=idle:
+// deliver input to the session and block until the turn it triggers
+// completes (issue #218).
+//
+// The bare composition `gmux send <id> ... && gmux wait <id>` has an
+// inherent race: `wait`'s initial snapshot can observe the *previous*
+// turn's idle state before the send-induced Working=true has propagated
+// from the runner's adapter into the store, returning "idle"
+// immediately with stale output. The fix is ordering, done here where
+// both halves live in one process: subscribe to the store BEFORE
+// forwarding the input bytes, then require a fresh Working=true
+// observation before any Working=false counts as "this turn is done".
+// The Working pulse cannot be missed because the subscription predates
+// the input delivery.
+//
+// Contract mirrors handleWait: 200 {reason: idle|died}, 408 on
+// ?timeout=N elapsing, 422 for adapters with no idle signal. One
+// additional 422 ("input_no_submit") rejects bodies that carry no
+// carriage return: input that doesn't submit never starts a turn, so
+// waiting on it would only ever time out — fail loudly at the edge
+// instead.
+//
+// send is a closure over the runner delivery (discovery.SendInput)
+// so this handler — and its tests — stay independent of the socket
+// transport.
+func handleInputWait(w http.ResponseWriter, r *http.Request, sessions *store.Store, sess store.Session, body []byte, send func() error) {
+	if mode := r.URL.Query().Get("wait"); mode != "idle" {
+		// "idle" is the only wait mode today; the value exists so
+		// future conditions (e.g. output text, #313) can slot in.
+		// Rejecting unknown modes keeps a client typo from silently
+		// degrading to fire-and-forget.
+		writeError(w, http.StatusBadRequest, "bad_request",
+			"unsupported wait mode "+strconv.Quote(mode)+`; expected "idle"`)
+		return
+	}
+	if !adapterEmitsIdleSignal(sess.Adapter) {
+		writeError(w, http.StatusUnprocessableEntity, "no_idle_signal",
+			"the "+sess.Adapter+" adapter does not emit an idle signal; --wait is only supported for agent sessions")
+		return
+	}
+	if !bytes.ContainsRune(body, '\r') {
+		writeError(w, http.StatusUnprocessableEntity, "input_no_submit",
+			"input does not submit (no carriage return \\r; a bare newline \\n is treated as literal text, not a submit); "+
+				"add a trailing Enter key or drop --wait")
+		return
+	}
+	deadline, err := timeoutChan(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+
+	// Subscribe BEFORE delivering the input. This ordering is the
+	// entire point of the endpoint: the Working=true pulse the input
+	// triggers is broadcast to subscribers that already exist, so it
+	// can't slip between "bytes delivered" and "wait armed".
+	evCh, unsub := sessions.Subscribe()
+	defer unsub()
+
+	if err := send(); err != nil {
+		writeError(w, http.StatusBadGateway, "runner_unreachable", err.Error())
+		return
+	}
+
+	reason, timedOut := awaitTurn(r.Context(), sessions, evCh, sess.ID, deadline)
+	switch {
+	case timedOut:
+		writeError(w, http.StatusRequestTimeout, "timeout", "session did not become idle within timeout")
+	case reason != "":
+		writeJSON(w, map[string]any{"ok": true, "data": map[string]any{"reason": reason}})
+		// reason == "" and !timedOut: client disconnected; nothing to write.
+	}
+}
+
+// awaitTurn blocks until the session completes a turn: a Working=true
+// observation followed by Working=false ("idle"), or the session dying
+// or being removed at any point ("died"). Unlike terminalReason, a
+// Working=false state observed before any Working=true does NOT
+// terminate — that's exactly the stale previous-turn idle the caller
+// subscribed early to skip past.
+//
+// Returns ("", false) when ctx is cancelled and ("", true) on deadline.
+//
+// Like handleWait, events are complemented by a periodic re-poll: the
+// 64-slot subscriber buffers drop events under load, so both edges of
+// the pulse could theoretically be missed. The poll recovers the
+// Working=true edge whenever the turn outlasts one tick; a sub-tick
+// turn whose both edge events were dropped is the one (vanishingly
+// unlikely) case that rides out the deadline.
+func awaitTurn(ctx context.Context, sessions *store.Store, evCh <-chan store.Event, sessionID string, deadline <-chan time.Time) (reason string, timedOut bool) {
+	seenWorking := false
+	check := func(s store.Session) (string, bool) {
+		if !s.Alive {
+			// No #216 startup-window gate here (unlike terminalReason /
+			// hasRunEvidence): handleInputWait only runs after the input
+			// handler's `!sess.Alive => 409` check, so we enter with a
+			// live session and any Alive==false is a genuine death.
+			return "died", true
+		}
+		if s.Status != nil && s.Status.Working {
+			seenWorking = true
+			return "", false
+		}
+		if seenWorking {
+			// Status went non-working after a fresh Working pulse:
+			// the turn our input triggered is over.
+			if s.Status != nil && !s.Status.Working {
+				return "idle", true
+			}
+		}
+		return "", false
+	}
+
+	// Initial snapshot: catches a session already mid-turn (our bytes
+	// queue behind the current turn; treat its end as the answer) or
+	// already dead.
+	if cur, ok := sessions.Get(sessionID); !ok {
+		return "died", false
+	} else if reason, done := check(cur); done {
+		return reason, false
+	}
+
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return "", false
+		case <-deadline:
+			return "", true
+		case ev := <-evCh:
+			if ev.ID != sessionID {
+				continue
+			}
+			if ev.Session == nil {
+				// session-remove: dismissed mid-wait. See handleWait.
+				return "died", false
+			}
+			if reason, done := check(*ev.Session); done {
+				return reason, false
+			}
+		case <-ticker.C:
+			cur, ok := sessions.Get(sessionID)
+			if !ok {
+				return "died", false
+			}
+			if reason, done := check(cur); done {
+				return reason, false
+			}
+		}
+	}
 }
 
 // Sentinel results for waitForSessionExit. Distinct errors let the

--- a/skills/gmux/SKILL.md
+++ b/skills/gmux/SKILL.md
@@ -17,6 +17,7 @@ gmux -- <cmd> [args]         # run blocking; exits with the child's exit code
 gmux -d -- <cmd> [args]      # run detached; prints the session id on stdout
 gmux send <id> 'text' Enter  # type text and submit (Enter is explicit)
 gmux send <id> C-c           # send a control key (interrupt), no text
+gmux send --wait <id> 'text' Enter  # send AND block until the reply is done
 gmux wait <id>               # block until the agent finishes its turn
 gmux wait <id> --for-text S  # block until S appears in the output
 gmux tail <id> [-n N]        # last N lines of output (ANSI stripped; default 100)
@@ -54,11 +55,18 @@ Key names follow tmux: `Enter`, `Tab`, `Escape`, `Up`/`Down`/`Left`/`Right`,
 id=$(gmux -d -- pi "implement the feature")
 gmux wait $id
 
-gmux send $id "$(cat review.txt)" Enter
-gmux wait $id
+gmux send --wait $id "$(cat review.txt)" Enter
 
 gmux tail $id -n 100
 ```
+
+**Prefer `gmux send --wait` over `gmux send … && gmux wait`** for "send a
+prompt and wait for the reply": the two-command composition can observe the
+*previous* turn's idle state and return before the agent has even started,
+while `--wait` is race-free (the daemon arms the wait before delivering the
+input and requires a fresh working→idle transition). `--wait` requires the
+input to submit (a trailing `Enter` or a `\r` in piped stdin) and accepts
+`--timeout N`; exit codes match `gmux wait` below.
 
 ## Parallel orchestration
 


### PR DESCRIPTION
Closes #218.

## What

`gmux send <id> <text> Enter --wait [--timeout N]` delivers input and blocks until the turn it triggers completes, with `gmux wait`'s exit codes (0 idle, 2 died, 3 timeout).

## Why not the shape proposed in the issue

#218 predates the 2.0 verb-first CLI. A `send-wait` top-level verb would breach ADR 0009's frozen namespace, and a CLI-side SSE implementation would duplicate idle-detection rules that deliberately live in gmuxd (ADR 0005, `gmux wait`'s design). So:

- **CLI surface:** `--wait` is a behavior-modifier flag on `send` (ADR 0009 decision 9), not a new verb.
- **Implementation:** server-side, `POST /v1/sessions/{id}/input?wait=idle&timeout=N`. gmuxd subscribes to the session store **before** forwarding the bytes to the runner, then requires a fresh `Working=true` observation before any `Working=false` counts as "turn done". Race-free by construction: the pulse cannot slip between delivery and arming the wait (pinned by `TestSendWaitCannotMissTheWorkingPulse`, where the whole turn happens synchronously inside delivery).

## Details

- Stale previous-turn idle (the #218 race) is ignored: only a fresh working→idle transition returns `idle`. Regression-tested (`TestSendWaitIgnoresStalePreviousIdle`).
- `died` / timeout / shell-adapter 422 semantics mirror `handleWait`, including the dropped-event re-poll fallback.
- Non-submitting input is rejected with 422 `input_no_submit` before delivery — it would never start a turn, so the wait could only time out (the post-2.0 analogue of the issue's "reject `--no-submit`"). The check runs on the final rendered bytes, so every submit encoding the send path accepts passes: trailing `Enter` key, `C-m`, or a literal `\r` in piped stdin. `\n`-only input fails, matching the documented submit semantics (agents treat bare `\n` as a literal newline).
- Unknown `?wait=` modes are rejected with 400 rather than silently degrading to fire-and-forget; `idle` is the only mode today, leaving room for output conditions (#313).
- Session already mid-turn: the bytes queue behind the current turn; its completion is the answer.
- Peer sessions are rejected for `--wait`, same scope rule as `gmux wait`.
- Bare `send && wait` keeps working with its documented race; the skill now points at `send --wait` as the correct primitive.

## ⚠️ Behavior change

`send` now parses leading-dash tokens as flags; **literal text starting with `-` needs the `--` guard** (`gmux send abc -- '--weird text'`), per ADR 0009's verbatim-content convention. Previously `gmux send abc -v` sent `-v` as literal text; it now errors with guidance. Unknown dash tokens error instead of being sent silently.

## Merge-order note (#362, #370)

#362 (phantom-death fix for #216) and #370 (`wait --for-text/--for-regex`) both touch `wait.go` (daemon and/or CLI) in the same regions (`handleWait` snapshot block, `terminalReason`, usage text, ADR 0009 amendments). Conflicts with either are **textual, not semantic** — whichever lands later needs a trivial rebase:

- vs #362: `awaitTurn` here has its own alive-check and is *not* exposed to the #216 phantom-death window: the input branch requires `Alive=true` before `handleInputWait` runs, so a later `Alive=false` is a genuine true→false transition — exactly #362's `seenAlive` rule.
- vs #370: independent features; both amend ADR 0009 and the `wait`-adjacent plumbing.

Docs: ADR 0009 amendment, usage text, `skills/gmux/SKILL.md`.

## Testing

- `go test ./...` in `cli/gmux` and `services/gmuxd` (all green), `go vet` clean.
- New: 8 daemon tests for `handleInputWait`/`awaitTurn`, CLI parser tests for `--wait`/`--timeout`/`--` guard and error cases.