### PR TITLE
docs: full 2.0 documentation refresh + Migrating to 2.0 guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,15 @@ Or download from [GitHub Releases](https://github.com/gmuxapp/gmux/releases).
 ## Quick start
 
 ```bash
-gmux pi                    # launch a coding agent
-gmux pytest --watch        # launch a test watcher
-gmux make build            # or literally any command
-gmux                       # open the UI
+gmux -- pi                 # launch a coding agent
+gmux -- pytest --watch     # launch a test watcher
+gmux -d -- make build      # detached; prints the session id
+gmux open                  # open the UI
 ```
 
-Open `localhost:8790` — all three sessions are there, grouped by project, with live status indicators. Click one to attach a full terminal. The same xterm.js that powers the VS Code terminal, running in your browser.
+Open the dashboard — all three sessions are there, grouped by project, with live status indicators. Click one to attach a full terminal. The same xterm.js that powers the VS Code terminal, running in your browser.
 
-The daemon (`gmuxd`) starts automatically on first use. There's nothing else to set up. For daemon commands, run `gmuxd -h`.
+The daemon (`gmuxd`) starts automatically on first use. There's nothing else to set up. Power users alias `gm='gmux --'`. For daemon lifecycle commands, run `gmux daemon status` (see `gmux help`).
 
 ## How it works
 
@@ -47,102 +47,89 @@ graph LR
     gmuxd -- "HTTP · SSE · WS" --> web
 ```
 
-**`gmux`** wraps any command in a managed session. It allocates a PTY, serves a WebSocket for terminal access, and runs an **adapter** that understands what the child process is doing. A pi session knows when the agent is thinking vs waiting for input. A test runner knows when tests are failing. A generic command gets alive/dead/activity tracking out of the box. With no arguments, it opens the UI in your browser.
+**`gmux`** wraps any command in a managed session. It allocates a PTY, serves a WebSocket for terminal access, and runs an **adapter** that understands what the child process is doing. For agent tools (pi, Claude Code, Codex), gmux installs a small hook into the agent so the agent itself reports its state — working, idle, which conversation it holds — authoritatively, with no output scraping. A generic command gets alive/dead/activity tracking out of the box.
 
-**`gmuxd`** runs once per machine (auto-started by `gmux`). It discovers sessions via their Unix sockets, caches their state, proxies WebSocket connections, and pushes real-time updates to the browser via SSE. It's stateless — restart it anytime, it rebuilds from what's running.
+**`gmuxd`** runs once per machine (auto-started by `gmux`). It discovers sessions via their Unix sockets, caches their state, proxies WebSocket connections, and pushes real-time updates to the browser via SSE. Session state lives with each runner, so gmuxd's session cache rebuilds on restart; projects, peers, and the auth token persist in `~/.local/state/gmux`.
 
-**`gmux-web`** is the browser UI. The sidebar groups sessions by working directory, with status dots that pulse when something needs attention. The terminal is xterm.js — the same battle-tested terminal emulator that powers VS Code's integrated terminal — with synchronized output for flicker-free session switching and ~1 MiB of persisted scrollback that replays instantly on reconnect.
+**`gmux-web`** is the browser UI. The sidebar groups sessions into projects, with status dots that pulse when something needs attention. The terminal is xterm.js — the same battle-tested terminal emulator that powers VS Code's integrated terminal — with synchronized output for flicker-free session switching and ~1 MiB of persisted scrollback that replays instantly on reconnect.
 
 ## What you see
 
 ```
 ┌─────────────────────────────────────┐
-│ gmux                          alpha │
+│ gmux                             ⚙  │
 │                                     │
 │ ▼ myapp                        ● 2  │
-│   main · 3 changed · PR #42        │
 │                                     │
 │   ● fix auth bug               now  │
-│     thinking · pi                   │
+│     working · pi                    │
 │                                     │
 │   ● test watcher             2m ago │
-│     47/47 passing · pytest          │
+│     pytest --watch                  │
 │                                     │
 │ ▼ gmux                         ● 1  │
-│   feature/probes · clean            │
 │                                     │
 │   ● bootstrap                  5m   │
-│     waiting for input · pi          │
+│     unread · pi                     │
 │                                     │
-│ ▸ docs                        ○ 1   │
-│   main · completed                  │
+│ ▸ docs                         ○ 1  │
 └─────────────────────────────────────┘
 ```
 
-Sessions are grouped into **folders** by working directory. Each folder heading is enriched by **probes** — lightweight observers that report git branch, dirty state, open PRs, or anything you script. The folder's status dot reflects the most urgent session inside it.
+Sessions are grouped into **projects** by working directory — manage the project list in Settings, where gmux also suggests directories it discovered from past sessions. Each project's status dot reflects the most urgent session inside it.
 
 ## Features
 
 ### Sessions
-- **Launch anything** — `gmux <command>` wraps any process in a managed session
+- **Launch anything** — `gmux -- <command>` wraps any process in a managed session
 - **Full terminal** — xterm.js with WebSocket transport, the same terminal emulator as VS Code
 - **~1 MiB persisted scrollback** — replays instantly on reconnect, survives runner exit, no lost context
 - **Flicker-free switching** — DEC 2026 synchronized output renders session swaps in a single frame
-- **Session lifecycle** — live status, exit codes, kill from the UI
+- **Session lifecycle** — live status, exit codes, kill from the UI; dead sessions stay resumable
 - **Reconnecting** — tab away, come back, the terminal is right where you left it
+- **Editor tabs** — `gmux edit <file>` opens a managed editor session; works as `$EDITOR` (blocks and propagates the exit code, so `git commit` just works)
 
 ### Adapters — session-level intelligence
 Adapters teach gmux how to work with specific tools. They're compiled into the binary and selected automatically by command name.
 
-- **Auto-detection** — `gmux pi` recognizes pi and activates the pi adapter. No flags needed.
-- **Rich status** — adapters report what the child is doing: thinking, waiting for input, tests passing, build failing
+- **Auto-detection** — `gmux -- pi` recognizes pi and activates the pi adapter. No flags needed.
+- **Authoritative agent status** — pi, Claude Code, and Codex report session identity, titles, and working/idle state through the tools' own hook mechanisms, injected per launch
 - **Child awareness** — any tool can self-report status via `PUT /status` on `$GMUX_SOCKET`, no adapter required
 - **Graceful fallback** — unknown commands get the shell adapter
 
-### Probes — directory-level intelligence
-Probes observe the working directory and enrich folder headings with project context.
+### Scripting & agents
+gmux is a full CLI, designed to compose into scripts and agent workflows:
 
-```mermaid
-graph TD
-    subgraph "Folder: ~/dev/myapp"
-        git["git probe\nmain · 3 files changed"]
-        pr["github-pr probe\nPR #42 open"]
-        s1["Session: pi\n● thinking"]
-        s2["Session: pytest --watch\n● 47/47 passing"]
-    end
-
-    git --> heading["Folder heading\nmyapp — main · 3 changed · PR #42"]
-    pr --> heading
-    s1 --> dot["Aggregate status dot"]
-    s2 --> dot
+```bash
+id=$(gmux -d -- pi)                     # launch detached, capture the id
+gmux send "$id" 'refactor the auth module' Enter
+gmux wait "$id" --timeout 600           # block until the agent goes idle
+gmux tail "$id" -n 50                   # read the plain-text tail
 ```
 
-- **Git** — branch name, dirty file count
-- **GitHub PR** — PR number, status, clickable link
-- **Script probes** — drop a bash script in `~/.config/gmux/probes/`, it runs against each matching directory and returns JSON. Five lines gets you custom folder intelligence.
+`gmux ls --json` gives agents a machine-readable session list; `gmux send-keys -t` is tmux-compatible. See the [scripting guide](apps/website/src/content/docs/integrations/scripts-and-agents.md).
+
+### Multi-machine
+Run gmux on each machine, then connect them: `gmux auth` on the remote host prints a connect URL you paste into **Settings → Hosts → Connect to host**. Peers authenticate with bearer tokens; sessions on other hosts are addressable as `<id>@<peer>`. Devcontainers running the gmux feature are discovered automatically. See [Multi-machine](apps/website/src/content/docs/multi-machine.md).
 
 ### UI
-- **Triage-first** — sessions sorted by what needs attention, not alphabetically
-- **Automatic grouping** — sessions sharing a working directory group into folders, no manual organization
-- **Header bar** — contextual metadata and actions for the selected session
-- **Mobile responsive** — same URL on your phone, tap a session, type a steering message, done
-- **URL scoping** — `?project=myapp` filters to one project. Bookmark it for a per-project browser tab.
-- **Nord dark theme** — designed for long sessions, Inter + JetBrains Mono typography
+- **Triage-first** — the home screen surfaces waiting and active sessions first, then recency buckets
+- **Project grouping** — sessions group into projects by working directory; manage the list in Settings
+- **Find in terminal** — Cmd/Ctrl+F searches the terminal buffer
+- **Mobile responsive** — same URL on your phone; a dedicated toolbar, keyboard handling, and long-press link actions
+- **URL routing** — every project and session has a stable URL you can bookmark
+- **Customizable theme** — dark theme with a Windows Terminal–compatible terminal palette (`theme.jsonc`)
 
 ### Architecture
-- **Runner-authoritative** — gmux is the source of truth, gmuxd is a rebuildable cache
+- **Runner-authoritative** — each session's runner is the source of truth for its state; gmuxd's session cache is rebuilt from running sessions
 - **No external dependencies** — no tmux, no screen, no abduco. Two Go binaries and a web app.
 - **Web-first** — works on desktop, tablet, phone. Same URL everywhere.
-- **Zero config** — run `gmux <command>`, open a browser
+- **Zero config** — run `gmux -- <command>`, open a browser
 
 ## Extensibility
 
-| Layer | Mechanism | Runs in | What it does |
-|-------|-----------|---------|--------------|
-| Session | **Adapters** (Go) | gmux | Recognize commands, monitor output, report rich status |
-| Directory | **Probes** (Go or bash) | gmuxd | Observe directories, report git/PR/CI metadata |
-| Child process | **HTTP API** on `$GMUX_SOCKET` | child | Self-report status without any adapter |
-| User scripts | **Script probes** in `~/.config/gmux/probes/` | gmuxd | Custom directory intelligence, no compilation |
+- **Adapters** (Go, compiled in) — recognize commands, launch presets, titles, resume, hook-driven status
+- **Child self-reporting** — any process can `PUT /status` on `$GMUX_SOCKET` to set working/error state, no adapter required
 
 ## Development
 
@@ -150,7 +137,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for prerequisites and setup.
 
 ```bash
 pnpm install      # JS dependencies
-./dev              # start all services with watch/HMR
+pnpm dev          # start all services with watch/HMR
 ```
 
 ### Monorepo layout
@@ -158,11 +145,11 @@ pnpm install      # JS dependencies
 ```mermaid
 graph TB
     subgraph "CLI"
-        gmux2["cli/gmux\nGo — PTY, WebSocket, adapters"]
+        gmux2["cli/gmux\nGo — PTY, WebSocket, runner"]
     end
 
     subgraph "Daemon"
-        gmuxd1["services/gmuxd\nGo — discovery, cache, proxy, probes"]
+        gmuxd1["services/gmuxd\nGo — discovery, cache, proxy"]
     end
 
     subgraph "Web"
@@ -177,8 +164,9 @@ graph TB
 
 | Path | Language | Purpose |
 |------|----------|---------|
-| `cli/gmux` | Go | Session launcher — PTY, WebSocket, adapters |
+| `cli/gmux` | Go | Session launcher — PTY, WebSocket, runner |
 | `services/gmuxd` | Go | Machine daemon — discovery, cache, WS proxy, embedded web UI |
+| `packages/*` | Go | Shared libraries — adapters, paths, scrollback, session env |
 | `apps/gmux-web` | TypeScript/Preact | Browser UI — sidebar, terminal, header bar |
 | `packages/protocol` | TypeScript | Shared schemas, zod-validated |
 | `apps/website` | Astro/Starlight | Documentation site |
@@ -187,11 +175,14 @@ graph TB
 
 Documentation lives in the [website](apps/website/src/content/docs/):
 
+- [Getting Started](apps/website/src/content/docs/getting-started.mdx) — install and first session
 - [Architecture](apps/website/src/content/docs/architecture.md) — runtime structure (gmux, gmuxd, web UI)
+- [CLI Reference](apps/website/src/content/docs/reference/cli.md) — every verb and flag
+- [Multi-machine](apps/website/src/content/docs/multi-machine.md) — connecting hosts
 - [Session Schema](apps/website/src/content/docs/develop/session-schema.md) — metadata model
 - [Adapter Architecture](apps/website/src/content/docs/develop/adapter-architecture.md) — how adapters work
 - [Security](apps/website/src/content/docs/security.md) — threat model and safeguards
-- [Remote Access](apps/website/src/content/docs/remote-access.md) — tailscale setup
+- [Remote Access](apps/website/src/content/docs/remote-access.md) — `gmux remote` / Tailscale setup
 
 ## License
 

--- a/apps/website/astro.config.mjs
+++ b/apps/website/astro.config.mjs
@@ -20,6 +20,7 @@ export default defineConfig({
       customCss: ['./src/styles/custom.css'],
       sidebar: [
         { label: 'Getting Started', slug: 'getting-started' },
+        { label: 'Migrating to 2.0', slug: 'migrating-to-2' },
         { label: 'Changelog', slug: 'changelog' },
         {
           label: 'Guides',

--- a/apps/website/scripts/generate-reference.ts
+++ b/apps/website/scripts/generate-reference.ts
@@ -318,6 +318,16 @@ These are ready to paste into \`settings.jsonc\`.
 }
 \`\`\`
 
+**Restore browser find** -- gmux binds \`secondary+f\` (Cmd+F on macOS, Ctrl+F elsewhere) to open the find-in-terminal search bar, replacing the browser's in-page find (which can't see into a canvas-rendered terminal). To get browser find back:
+
+\`\`\`jsonc
+{
+  "keybinds": [
+    { "key": "secondary+f", "action": "none" }
+  ]
+}
+\`\`\`
+
 **Disable all browser workarounds** -- if you run gmux as a PWA or \`--app\` window, the browser doesn't steal Ctrl+T/N/W, so the Ctrl+Alt workarounds are unnecessary:
 
 \`\`\`jsonc

--- a/apps/website/src/content/docs/adapters.md
+++ b/apps/website/src/content/docs/adapters.md
@@ -7,12 +7,15 @@ Adapters teach gmux how to interpret specific tools. When you launch a session, 
 
 ## What adapters do
 
-An adapter watches the terminal output of your process and reports structured status to the sidebar:
+An adapter teaches gmux how to launch, title, resume, and track a tool. For agent tools (Claude Code, Codex, pi), gmux installs a small hook into the agent when it launches; the agent itself reports session state authoritatively — no output scraping. The sidebar shows:
 
 - **Working** — the tool is busy (cyan pulsing dot)
+- **Error** — the tool reported an error (red dot)
 - **Idle** — the tool is waiting (no dot)
 
-Without an adapter, gmux still tracks whether the process is alive — but with one, you get at-a-glance working/error state, unread markers, and meaningful session titles.
+Without a specific adapter, gmux still tracks whether the process is alive — but with one, you get at-a-glance working/error state, unread markers, meaningful session titles, and resumable conversations.
+
+Terminal titles (OSC 0/2, e.g. your shell's `PS1`) work for every session regardless of adapter.
 
 ## Automatic detection
 
@@ -22,51 +25,60 @@ You don't configure adapters. gmux recognizes tools by their command name:
 gmux -- claude       # → claude adapter
 gmux -- codex        # → codex adapter
 gmux -- pi           # → pi adapter
+gmux edit README.md  # → editor adapter
 gmux -- bash         # → shell adapter (fallback)
 gmux -- make build   # → shell adapter (fallback)
 ```
 
-If no specific adapter matches, the **shell** adapter handles it.
+If no specific adapter matches, the **shell** adapter handles it. Setting `GMUX_ADAPTER=<name>` forces an adapter, but only when that adapter also matches the command — a leaked variable can't hijack an unrelated command.
 
 ## Built-in adapters
 
 ### Shell (default)
 
-Always active. Tracks terminal title changes so your shell's `PS1` or tool-set window titles appear in the sidebar.
+The catch-all. Titles sessions by their command (e.g. `pytest -x`), keeps them resumable (resume reopens `$SHELL` in the original directory), and picks up terminal title changes from your shell's `PS1` or tool-set window titles.
 
 ### Claude Code
 
-Active when `claude` is installed. Provides:
+Matched whenever you run `claude`; its launcher appears in the UI when `claude` is on PATH. Provides:
 
-- Live status detection (working while assistant responds, idle when done)
-- Session titles from conversation files or Claude's auto-generated titles
+- Live status via Claude Code hooks (working while a turn runs, idle when done)
+- Session titles reported live by the hook (follows `/rename`)
 - Resumable sessions — exited sessions stay in the sidebar, click to resume via `claude --resume`
 
 See [Claude Code integration](/integrations/claude-code) for details.
 
 ### Codex
 
-Active when `codex` is installed. Provides:
+Matched whenever you run `codex`; its launcher appears when `codex` is on PATH. Provides:
 
-- Live status detection (working while agent responds, idle on task completion)
-- Session titles from your first prompt (system context filtered out)
+- Live status via Codex hooks (Codex CLI ≥ 0.135.0)
+- Session titles from your first prompt
 - Resumable sessions — exited sessions stay in the sidebar, click to resume via `codex resume`
 
 See [Codex integration](/integrations/codex) for details.
 
 ### pi
 
-Active when `pi` is installed. Provides:
+Matched whenever you run `pi`; its launcher appears when `pi` is on PATH. Provides:
 
-- Live status detection (thinking, waiting for input, etc.)
-- Session titles from conversation files
+- Live status via a gmux pi extension (turn start/end, working/idle)
+- Session titles from pi's session name or your first message
 - Resumable sessions — exited sessions stay in the sidebar, click to resume
 
 See [pi integration](/integrations/pi) for details.
 
+### Editor
+
+Backs `gmux edit [file]` — editor sessions as a first-class tab type, usable as `$EDITOR`. Editor sessions are ephemeral: they're dismissed automatically when the editor closes. Plain `gmux -- nano file` stays on the shell adapter.
+
+## Agent hooks
+
+For claude, codex, and pi, gmux injects a lightweight hook (a pi extension, or command hooks for claude/codex) into each launch. The agent reports which conversation it holds, turn boundaries (working/idle), titles, and slugs directly to gmux — the launch is otherwise unmodified, and nothing is written to the tools' config directories. Set `GMUX_NO_AGENT_HOOK=1` to launch the agent completely unmodified; the session then runs without hook-driven title/status/attribution.
+
 ## Self-reporting
 
-Any process can report its own status without a custom adapter. `gmux` sets `$GMUX_SOCKET` in the child's environment:
+Any process or script can report its own status without a custom adapter. `gmux` sets `$GMUX_SOCKET` in the child's environment:
 
 ```bash
 curl -X PUT --unix-socket "$GMUX_SOCKET" \
@@ -74,6 +86,8 @@ curl -X PUT --unix-socket "$GMUX_SOCKET" \
   -H 'Content-Type: application/json' \
   -d '{"working": true}'
 ```
+
+Status carries only `working` and `error` booleans — display text is derived by the UI. Send `null` to clear the status. See [Scripts & agents](/integrations/scripts-and-agents) for how this composes with `gmux wait`.
 
 ## Writing an adapter
 

--- a/apps/website/src/content/docs/adapters.md
+++ b/apps/website/src/content/docs/adapters.md
@@ -76,6 +76,8 @@ Backs `gmux edit [file]` — editor sessions as a first-class tab type, usable a
 
 For claude, codex, and pi, gmux injects a lightweight hook (a pi extension, or command hooks for claude/codex) into each launch. The agent reports which conversation it holds, turn boundaries (working/idle), titles, and slugs directly to gmux — the launch is otherwise unmodified, and nothing is written to the tools' config directories. Set `GMUX_NO_AGENT_HOOK=1` to launch the agent completely unmodified; the session then runs without hook-driven title/status/attribution.
 
+The hook mechanism is documented in depth in [Adapter Architecture](/develop/adapter-architecture/#live-session-state-comes-from-the-agent-hook); per-tool specifics are on the [pi](/integrations/pi/), [Claude Code](/integrations/claude-code/), and [Codex](/integrations/codex/) pages.
+
 ## Self-reporting
 
 Any process or script can report its own status without a custom adapter. `gmux` sets `$GMUX_SOCKET` in the child's environment:

--- a/apps/website/src/content/docs/architecture.md
+++ b/apps/website/src/content/docs/architecture.md
@@ -13,7 +13,7 @@ One per session. It:
 - Owns the live session state (title, status, working flag)
 - Persists PTY output to an on-disk scrollback file for session replay on reconnect
 - Exposes the session on a Unix socket (metadata, events, terminal attach)
-- Runs adapter logic over child output
+- Runs the session's adapter: agents report authoritative state (conversation binding, turn phase, title) to the runner via a tool-neutral hook protocol; OSC title parsing over child output remains for everything else
 
 `gmux` is the source of truth for a live session.
 
@@ -21,15 +21,15 @@ One per session. It:
 
 One per machine. It:
 
-- Discovers live runner sockets (`~/.local/state/gmux/run/sessions/*.sock`)
+- Discovers live runner sockets (`~/.local/state/gmux/run/sessions/*.sock`) — runners register themselves on startup; a periodic socket scan is the fallback (legacy socket dirs from pre-2.0 runners are scanned for one release)
 - Subscribes to runner events for live updates
-- Watches adapter session files (e.g. pi's JSONL conversations)
+- Maintains a conversations index fed by adapter-owned conversation sources (e.g. pi's JSONL conversation files), used for discovery and resume
 - Serves the REST API, SSE event stream, and WebSocket proxy
 - Serves the embedded web frontend as a SPA
 - Manages session launch, kill, dismiss, and resume
 - Optionally connects to other gmuxd instances (peers) and aggregates their sessions into a single UI (see [Multi-Machine](/multi-machine/))
 
-`gmuxd` is stateless — if it restarts, it rediscovers running sessions. On startup it hashes the `gmux` binary it ships with; sessions running a different build are marked **stale** so the UI can flag them.
+`gmuxd` holds no authoritative live state — live sessions are rediscovered from runner sockets on restart. It does persist lightweight per-session metadata (`~/.local/state/gmux/sessions/<id>/meta.json`) so dead sessions remain visible and resumable across restarts; scrollback for dead sessions is treated as an evictable cache (ADR 0016). On startup it hashes the `gmux` binary it ships with; sessions running a different build are marked **stale** so the UI can flag them.
 
 `gmux` auto-starts `gmuxd` if it isn't already running. If a daemon from an older version is detected, `gmux` automatically replaces it so the child process always talks to a compatible daemon.
 
@@ -85,7 +85,7 @@ Two distinct mechanisms back replay, and they should not be conflated:
 
 ## API surface
 
-Served by `gmuxd` on a Unix socket (local IPC) and a TCP listener (default `127.0.0.1:8790`, token-authenticated):
+Served by `gmuxd` on a Unix socket (local IPC) and a TCP listener (default `127.0.0.1:8790`, token-authenticated; cookie-authed mutations and WebSocket upgrades additionally enforce same-origin — see [Security](/security)). This is a non-exhaustive overview of the main endpoints:
 
 | Endpoint | Purpose |
 |---|---|
@@ -98,6 +98,10 @@ Served by `gmuxd` on a Unix socket (local IPC) and a TCP listener (default `127.
 | `POST /v1/sessions/{id}/kill` | Kill a session |
 | `POST /v1/sessions/{id}/dismiss` | Kill + remove |
 | `POST /v1/sessions/{id}/resume` | Resume a resumable session |
+| `POST /v1/sessions/{id}/{input,read,scrollback,wait,...}` | Other session actions (input injection, tail, wait-for-idle, …) |
+| `GET /v1/conversations/{adapter}/{slug}` | Conversation lookup for resume |
+| `POST /v1/peers` / `DELETE /v1/peers/{name}` | Add / remove a peer host |
+| `POST /v1/register` / `POST /v1/deregister` | Runner registration fast path |
 | `GET /v1/events` | SSE: `snapshot.sessions`, `snapshot.world`, `session-activity` (ADR 0001) |
 | `/v1/peers/{peer}/...` | Forward an allowlisted write to a peer (ADR 0002) |
 | `GET /v1/health` | Daemon health, version, launchers, peer status |

--- a/apps/website/src/content/docs/configuration.md
+++ b/apps/website/src/content/docs/configuration.md
@@ -7,7 +7,7 @@ gmux works out of the box with no configuration. Everything is customizable thro
 
 | File | Purpose | Reference |
 |------|---------|-----------|
-| `host.toml` | Daemon behavior: port, Tailscale remote access | [host.toml →](/reference/host-toml/) |
+| `host.toml` | Daemon behavior: port, Tailscale remote access, devcontainer discovery | [host.toml →](/reference/host-toml/) |
 | `settings.jsonc` | Terminal options, keybinds, UI preferences | [settings.jsonc →](/reference/settings/) |
 | `theme.jsonc` | Terminal color palette (Windows Terminal theme compatible) | [theme.jsonc →](/reference/theme/) |
 
@@ -15,8 +15,19 @@ All files are optional. Create or edit them manually. The only exception is `gmu
 
 Settings and theme changes take effect on browser refresh (no daemon restart needed). Host config changes require restarting gmuxd.
 
+## Runtime state
+
+Not everything lives in config files. gmux keeps daemon-owned state in `~/.local/state/gmux/`:
+
+- **Peers** are added at runtime via *Settings → Hosts → Connect to host* and stored in `peers.json` — they are **not** configured in `host.toml` (the pre-2.0 `[[peers]]` key is ignored with a warning).
+- **Projects** live in `projects.json`, managed via *Settings → Projects*.
+- The **host auth token** lives in `auth-token` (seedable with `GMUXD_TOKEN`); `gmux auth` prints it along with a login/pairing URL.
+
+See [Multi-machine](/multi-machine/) and [File paths](/reference/file-paths/) for details.
+
 ## More reference
 
 - [File paths](/reference/file-paths/) — config files, sockets, runtime state, logs
 - [CLI commands](/reference/cli/) — `gmux` and `gmuxd` usage
 - [Environment variables](/reference/environment/) — variables that affect gmux and variables set inside sessions
+- [projects.json](/reference/projects-json/) — project list state

--- a/apps/website/src/content/docs/devcontainers.md
+++ b/apps/website/src/content/docs/devcontainers.md
@@ -24,14 +24,18 @@ That's it. Rebuild the container and any `gmux` session you start inside it show
 
 The feature installs `gmux` and `gmuxd` into the container and starts the daemon automatically. The host gmuxd discovers the container through Docker events:
 
-1. Container starts with `GMUXD_LISTEN=0.0.0.0` in its environment (set by the feature)
-2. Host gmuxd detects the start event and reads the container's auth token via `docker exec`
+1. Container starts with `GMUXD_LISTEN=0.0.0.0` in its environment (set by the feature) and the `devcontainer.local_folder` label (set automatically by the devcontainer CLI / VS Code). Both are required — containers launched outside a devcontainer tool are not discovered.
+2. Host gmuxd detects the start event and reads the container's auth token via `docker exec` (retried for slow-starting containers)
 3. Host connects to the container's gmuxd over the Docker bridge network
 4. Container sessions stream into the host dashboard via the standard peer protocol
 
-The container's sessions appear in the sidebar with a topology breadcrumb showing the chain (e.g. `workstation > alpine-dev`). Launching from the project hub's per-folder **+** button routes new sessions to the correct container.
+The container's sessions appear in the sidebar with a container icon and an `@<peer>` suffix (the peer is named after the host folder, e.g. `my-project`). Discovered containers also show up in **Settings → Hosts** with `Source: devcontainer`. Launching from that project routes new sessions to the correct container.
 
-When the container stops, its sessions are marked as disconnected. When it starts again, they reconnect.
+When the container stops, its sessions disappear from the dashboard. When it starts again, the host re-discovers it and the sessions come back — conversation history lives inside the container, so nothing is lost.
+
+:::note[2.0 upgrade]
+Host and container must run the same major version: a 2.0 host cannot connect to a 1.x container daemon. After upgrading the host, rebuild your devcontainers so the feature installs a matching gmux.
+:::
 
 ## Pin a version
 
@@ -66,7 +70,7 @@ With auto-discovery, you rarely need a pre-provisioned token. The host reads it 
 
 ## Disabling auto-discovery
 
-To keep containers from being auto-discovered (e.g. if you want to manage them as manual peers):
+Devcontainer discovery is on by default. To keep containers from being auto-discovered (e.g. if you want to manage them as manual peers):
 
 ```toml
 # ~/.config/gmux/host.toml

--- a/apps/website/src/content/docs/develop/adapter-architecture.md
+++ b/apps/website/src/content/docs/develop/adapter-architecture.md
@@ -31,8 +31,7 @@ That split is why the adapter system is a set of small interfaces instead of one
 | Conversation file discovery | `gmuxd` | `ConversationFiler` |
 | Live session state | runner → `gmuxd` | agent hook (`SessionExtender` / `SessionHookCommand`) |
 | Conversation discovery | `gmuxd` | `ConversationSource` (snapshot + watch) |
-| Resumable session discovery | `gmuxd` | `ConversationFiler` + `Resumer` |
-| Resume command generation | `gmuxd` | `Resumer.ResumeCommand()` |
+| Resume command derivation | `gmuxd` | `ConversationFiler` + `Resumer` on the session's `ConversationFile` |
 
 ## Launch lifecycle
 
@@ -46,15 +45,17 @@ When you run a command through `gmux`:
 3. `gmux` injects the standard `GMUX_*` environment variables
 4. `gmux` feeds PTY output into `Adapter.Monitor()`
 5. `gmux` serves the session on its Unix socket (`/meta`, `/events`, terminal attach, child callbacks)
-6. `gmuxd` discovers the runner socket, queries `/meta`, and subscribes to `/events`
+6. `gmuxd` discovers the runner socket (the runner registers itself; a periodic scan is the fallback), queries `/meta`, and subscribes to `/events`
 
-The command itself is never rewritten by the adapter. Adapters can add environment variables, but what the user launched is exactly what runs.
+Step 0, before any of this: `PassthroughDetector` adapters can mark one-shot invocations (e.g. `pi update`) that gmux execs directly without creating a session at all.
+
+The user's command semantics are preserved: adapters never change *what* runs. But for hooked adapters the runner splices the gmux agent hook into the launch argv (`SessionExtender` / `SessionHookCommand`), and `GMUX_NO_AGENT_HOOK=1` disables that injection. Per-session sockets live under `~/.local/state/gmux/run/sessions` (override: `GMUX_SOCKET_DIR`).
 
 ## Adapter resolution
 
 Adapter selection happens entirely in `gmux`:
 
-1. **Explicit override**: `GMUX_ADAPTER=<name>`
+1. **Explicit override**: `GMUX_ADAPTER=<name>`, honored only if that adapter's `Match()` accepts the command (a leaked env var can't hijack an unrelated command)
 2. **Registered adapters in order**: first `Match()` wins
 3. **Shell fallback**: always matches, always last
 
@@ -62,7 +63,7 @@ This keeps matching cheap and predictable. A false negative is low-cost because 
 
 ## Adapter discovery and available launchers
 
-Every adapter now implements a required discovery probe:
+Every adapter implements a required discovery probe:
 
 ```go
 type Adapter interface {
@@ -70,7 +71,7 @@ type Adapter interface {
     Discover() bool
     Match(command []string) bool
     Env(ctx EnvContext) []string
-    Monitor(output []byte) *Status
+    Monitor(output []byte) *Event // partial update: title, status, unread, cwd
 }
 ```
 
@@ -80,7 +81,8 @@ That tells gmux which adapters are actually usable on the current machine.
 For the built-in adapters:
 
 - **shell** always returns `true`
-- **pi** runs `pi --version` and returns true only if the command succeeds
+- **pi**, **claude**, **codex** check for their binary on `PATH` (`exec.LookPath`; executing the binary would be too slow)
+- **editor** returns `true` when a usable fallback editor resolves
 
 ## Launchers and `Launchable`
 
@@ -101,7 +103,6 @@ A few important consequences:
 - launch menu support is optional, like other adapter capabilities
 - adapter availability is mandatory, because every adapter must implement `Discover()`
 - one adapter can expose zero, one, or many launch presets
-- `gmuxd` no longer shells out to `gmux adapters` to discover launchers
 - the shell fallback also implements `Launchable`, so shell appears in the UI without a separate special-case launcher registry
 - unavailable launchers are omitted from the launch config entirely
 
@@ -165,7 +166,8 @@ Which running session holds which conversation file — and its title and status
 is **not** inferred by the daemon. The runner injects a gmux agent hook
 (`SessionExtender` for pi's `-e` extension; `SessionHookCommand` for codex/claude
 hooks), and the agent reports the held file, title, and status authoritatively
-over the runner socket. `gmuxd` records the file on the session (`ConversationFile`);
+over the runner socket (`POST /hook/event`; see `docs/runner-hook-protocol.md`
+in the repo). `gmuxd` records the file on the session (`ConversationFile`);
 a `/resume` rebind to a different file is just another hook report. When a tool
 can't be hooked, the session runs without daemon-reported live state — there is
 no metadata-matching fallback.
@@ -182,28 +184,22 @@ no daemon-global file monitor.
 
 ## Resumable sessions
 
-For adapters that implement `Resumer`, sessions transition seamlessly between alive and resumable states.
+Sessions transition seamlessly between alive and resumable states.
 
 ### Live → resumable transition
 
-When a session exits, `gmuxd` checks whether its adapter implements `Resumer` and whether the session has an attributed file (identified by `resume_key`, set during file attribution). If so:
+When a session exits, `gmuxd` checks whether its adapter implements `ConversationFiler` + `Resumer` and whether the session has a recorded `ConversationFile` (reported by the agent hook). If so:
 
 1. the resume command is derived from the adapter's `ResumeCommand()`
 2. `command` is set to the resume command
-3. `resumable` is derived automatically (`!alive && resume-capable kind && command present`)
+3. `resumable` is derived automatically (`!alive && command present`)
 4. the session appears in the sidebar as clickable to resume — no intermediate "exited" state
 
-### File-discovered sessions
+Sessions without a conversation file keep their original command, so "resume" re-runs it.
 
-For adapters that implement both `ConversationFiler` and `Resumer`, `gmuxd` also discovers sessions from files on disk (e.g. from before the daemon started):
+### Dead sessions survive daemon restarts
 
-1. enumerate files under `ConversationRootDir()` / known `ConversationDir(cwd)` directories
-2. filter them with `CanResume(path)`
-3. parse them with `ParseConversationFile(path)`
-4. deduplicate them against live sessions by resume key
-5. publish them as resumable entries
-
-When the user resumes one, `gmuxd` uses `ResumeCommand()` to launch the new live session.
+Dead sessions are not rediscovered from conversation files. Instead, `gmuxd` persists a `meta.json` per session (`~/.local/state/gmux/sessions/<id>/`) when it dies and sweeps those back into the store at startup. Retention follows ADR 0016: `meta.json` mirrors conversation existence (retired when the adapter's `ConversationProber` says the file is genuinely gone; conversation-less sessions age out), and dead-session scrollback is an evictable cache. The conversations index (from `ConversationSource`) serves URL resolution and search, not sidebar entries.
 
 For concrete examples, see [Claude Code](/integrations/claude-code), [Codex](/integrations/codex), or [pi](/integrations/pi).
 
@@ -220,6 +216,7 @@ Every child launched by `gmux` gets a small protocol for detecting gmux and repo
 | `GMUX_SESSION_ID` | Unique session identifier |
 | `GMUX_ADAPTER` | Name of the matched adapter |
 | `GMUX_RUNNER_VERSION` | Version of the gmux runner hosting the session |
+| `GMUX_SESSION_SOCK` | Same socket as `GMUX_SOCKET`; set only when an agent hook was injected — the socket the hook posts to (the hook contract is deliberately independent of the general child env) |
 
 Most tools ignore these. gmux-aware tools, wrappers, or hooks can use them to integrate directly.
 
@@ -230,9 +227,12 @@ Served by `gmux` on the session socket:
 | Endpoint | Method | Purpose |
 |---|---|---|
 | `/meta` | `GET` | Read current session metadata |
-| `/meta` | `PATCH` | Update title and subtitle |
-| `/status` | `PUT` | Set or clear application status |
-| `/events` | `GET` | Subscribe to live state changes |
+| `/hook/event` | `POST` | Authoritative agent-hook events: conversation bind, title, slug, turn status |
+| `/status` | `PUT` | Set or clear application status (`null` clears) |
+| `/slug` | `PUT` | Set the session slug |
+| `/events` | `GET` | Subscribe to live state changes (SSE) |
+
+There is no child title endpoint — titles come from the hook or from OSC 0/2 title sequences, which the runner parses centrally for all sessions.
 
 Example:
 
@@ -242,6 +242,8 @@ curl --unix-socket "$GMUX_SOCKET" http://localhost/status \
   -d '{"working":true}'
 ```
 
+`Status` carries only `working`/`error` booleans; display text is derived in the frontend.
+
 This is the escape hatch for tools that want native gmux integration without needing a custom PTY parser.
 
 ## Status sources
@@ -249,17 +251,18 @@ This is the escape hatch for tools that want native gmux integration without nee
 A session's displayed state can come from multiple places:
 
 - process lifecycle defaults from gmux itself
-- adapter PTY monitoring via `Monitor()`
+- adapter PTY monitoring via `Monitor()` (a no-op for the hooked agent adapters)
 - authoritative agent-hook reports (held file, title, status)
-- direct child callbacks via `/status` and `PATCH /meta`
+- direct child callbacks via `PUT /status`
 
 The important design point is that adapters do not own the whole session model. They contribute structured hints into a runner-owned session state that `gmuxd` then aggregates and serves.
 
 ## Built-in examples
 
-- **Shell**: fallback adapter; watches terminal title escape sequences and contributes the default shell launcher
-- **Claude Code**: file-backed adapter; supports launch presets, status detection, title extraction, live file updates, and resume
-- **Codex**: file-backed adapter with date-nested session storage; supports launch presets, status detection, title extraction, and resume
-- **pi**: file-backed adapter; supports launch presets, status detection, title extraction, live file updates, and resume
+- **Shell**: fallback adapter; contributes the default shell launcher, keeps per-session state files, and resumes as `$SHELL` in the original cwd (terminal title parsing is handled centrally in the runner, for all sessions)
+- **Editor**: backs `gmux edit`; matches an internal sentinel command, ephemeral (auto-dismissed on close)
+- **Claude Code**: hook-driven agent adapter (status/title/attribution via injected `--settings` hooks); conversation files feed discovery and `claude --resume`
+- **Codex**: hook-driven agent adapter with date-nested conversation storage; resume via `codex resume`
+- **pi**: agent adapter using a pi extension (`-e`) for authoritative state; conversation files feed discovery and resume
 
 See [Adapters](/adapters) for the high-level overview and the [Integrations](/integrations/claude-code) section for concrete integration behavior.

--- a/apps/website/src/content/docs/develop/distribution.md
+++ b/apps/website/src/content/docs/develop/distribution.md
@@ -1,9 +1,11 @@
 ---
 title: Distribution
-description: How gmux will be shipped — binaries, packaging, and deployment modes.
+description: How gmux is shipped — binaries, packaging, and deployment modes.
 ---
 
-> **Status (2.0):** largely shipped — goreleaser releases with checksums, the Homebrew tap, `install.sh`, and automatic daemon upgrade all exist. Still open: signing/provenance, `gmux doctor`, AUR/Nix packaging.
+:::note[Design record]
+This is the design/ops record for how gmux ships. Most of it is in place today (goreleaser releases with checksums, the Homebrew tap, `install.sh`, automatic daemon upgrade). Items still open are called out inline; anything not marked is shipped.
+:::
 
 ## Artifacts
 

--- a/apps/website/src/content/docs/develop/integration-tests.md
+++ b/apps/website/src/content/docs/develop/integration-tests.md
@@ -3,7 +3,7 @@ title: Integration Tests
 description: End-to-end tests that launch real tools through gmuxd.
 ---
 
-Integration tests verify the full pipeline — from launching a real tool through gmuxd to observing session state transitions, file attribution, title derivation, and resume. They catch issues that unit tests can't: timing between inotify and file writes, TUI input handling, trust prompts, and adapter attribution against real session files.
+Integration tests verify the full pipeline — from launching a real tool through gmuxd to observing session state transitions, file attribution, title derivation, and resume. They catch issues that unit tests can't: hook/file attribution timing, TUI input handling, trust prompts, and title derivation against real conversation files. (pi's discovery is file-watch based; claude and codex report state via authoritative agent hooks.)
 
 ## Running
 
@@ -33,12 +33,12 @@ Each adapter has a consistent set of tests:
 
 | Test | Verifies |
 |------|----------|
-| `TurnAndTitle` | Send a message → file attribution → title from first user message → resume key set |
+| `TurnAndTitle` | Send a message → attribution (slug set) → title from first user message |
 | `SecondTurnKeepsTitle` | Send two messages → title stays as first message |
-| `Resumability` | Send message → kill → session becomes resumable → resume → alive again with same title |
+| `Resumability` | Send message → kill → session becomes resumable with a resume command → resume → alive again with same title |
 | `NameOverridesTitle` (pi only) | Use `/name` command → title updates to explicit name |
 
-Shell has a single `WSInput` smoke test that verifies the WebSocket → PTY input pipeline.
+Shell has lifecycle tests (`WSInput`, `Kill`, `KillFish`, `Restart`) covering the WebSocket → PTY input pipeline and kill/restart semantics. A scrollback suite (`TestScrollback*`) verifies persisted scrollback captures conversation content and omits overwritten spinner frames.
 
 ## Test harness
 
@@ -47,23 +47,26 @@ Tests use a shared harness in `packages/adapter/adapters/testutil/`. The key com
 ### `StartGmuxd(t)`
 
 Launches an isolated gmuxd instance:
-- Random port (no conflicts with dev or other tests)
-- Temp socket directory
-- Empty `XDG_CONFIG_HOME` (no tailscale, no user config)
+- Random free port, written into a temp `host.toml` (isolated `XDG_CONFIG_HOME`)
+- Temp state dir (`XDG_STATE_HOME`) and temp socket dir (`GMUX_SOCKET_DIR`)
+- HTTP calls go over the daemon's Unix socket, bypassing the TCP listener's token auth
 - `PATH` includes the built `bin/gmux` binary
 - Cleaned up automatically when the test ends
 
+Launching and driving sessions goes through `g.Launch`, `g.Kill`, `g.Resume`, `g.Restart`, `g.Dismiss`.
+
 ### `ConnectSession(sessionID)`
 
-Opens a WebSocket directly to the runner's Unix socket (bypassing gmuxd's WS proxy). Sends an initial resize message so TUI apps render properly. Returns a `send` function for typing into the terminal.
+Opens a WebSocket directly to the runner's Unix socket (bypassing gmuxd's WS proxy). Sends an initial resize message so TUI apps render properly. Returns `(send, close)`; cleanup is automatic via `t.Cleanup`, so the close function can usually be ignored.
 
 ### Polling helpers
 
 | Helper | What it does |
 |--------|-------------|
-| `WaitForSession(id, pred, timeout)` | Polls `GET /v1/sessions` until the predicate matches |
-| `WaitForOutput(sessionID, timeout)` | Polls scrollback until the TUI has rendered |
+| `WaitForSession(id, pred, timeout, desc)` | Polls `GET /v1/sessions` until the predicate matches |
+| `WaitForOutput(sessionID, timeout)` | Polls scrollback until the TUI has rendered (returns the text) |
 | `WaitForScrollback(socketPath, substr, timeout)` | Polls scrollback for a specific string |
+| `ReadScrollback(t, socketPath)` | One-shot scrollback read |
 
 ## Writing a test for a new adapter
 
@@ -91,10 +94,10 @@ func TestMyAppTurnAndTitle(t *testing.T) {
     time.Sleep(2 * time.Second)
     send("say hi\r")
 
-    // Wait for file attribution.
+    // Wait for attribution (slug is derived from the conversation title).
     g.WaitForSession(sess.ID, func(s testutil.Session) bool {
-        return s.ResumeKey != ""
-    }, 60*time.Second, "file attribution")
+        return s.Slug != ""
+    }, 60*time.Second, "attribution (slug)")
 
     // Verify title.
     updated := g.WaitForSession(sess.ID, func(s testutil.Session) bool {
@@ -109,7 +112,8 @@ func TestMyAppTurnAndTitle(t *testing.T) {
 - **Trust prompts.** Claude Code and Codex both ask "do you trust this directory?" on first launch in a new workspace. Dismiss them by waiting for `"trust"` in the scrollback, then sending `\r`.
 - **TUI readiness.** Ink-based TUIs (pi, codex) need a moment after rendering before they accept input. A 2-second sleep after `WaitForOutput` is usually enough.
 - **Batch file writes.** Some tools write user + assistant messages in one batch after the turn completes (pi does this). You can't reliably observe transient `working=true` status via polling — wait for the final state instead.
-- **Shared session directories.** Codex uses date-based directories shared across all sessions. Old files from previous test runs may be present. The adapter's `AttributeFile` handles this, but expect attribution-rejection log lines for stale files.
+- **Hook-driven adapters attribute fast.** Claude and Codex report session identity through an injected hook (ADR 0010/0011), so attribution appears as soon as the hook fires — no file-watcher race. The long attribution timeout is only needed for file-watch adapters like pi.
+- **Not every adapter needs these tests.** Shell and editor sessions have no API cost and are covered by cheaper lifecycle tests; the API-cost suite is for agent adapters.
 
 ## Related docs
 

--- a/apps/website/src/content/docs/develop/notifications.md
+++ b/apps/website/src/content/docs/develop/notifications.md
@@ -3,7 +3,9 @@ title: Notifications
 description: Daemon-driven session notifications with presence tracking and smart routing.
 ---
 
-> **Status (2.0): implemented** as described (presence tracking, grace period, coalescing, best-client routing). A follow-up redesign toward stateful, resolve-once interactive notifications is proposed in ADR 0018.
+:::note[Design record]
+This is the architecture of the shipped notification system (presence tracking, grace period, coalescing, best-client routing). A follow-up redesign toward stateful, resolve-once interactive notifications is proposed in [ADR 0018](https://github.com/gmuxapp/gmux/blob/main/docs/adr/0018-stateful-notifications-and-interactive-actions.md).
+:::
 
 ## How it works
 

--- a/apps/website/src/content/docs/develop/project-model.md
+++ b/apps/website/src/content/docs/develop/project-model.md
@@ -1,16 +1,17 @@
 ---
-title: Project Management
-description: User-curated project list with VCS-aware matching and stable URL routing.
+title: Project Model
+description: The design behind gmux's user-curated project list, VCS-aware matching, and stable URL routing.
 ---
 
-> **Status (2.0): implemented.** Server-side project state (`projects.json`, host-authoritative discovery), the Settings → Projects UI, and hierarchical URL routing all shipped — see [Using the UI](/using-the-ui/) and [projects.json](/reference/projects-json/). Terminology note: `kind` in this document is now `adapter`. Kept for design rationale.
+:::note[Design record]
+This is the design rationale behind gmux's project model, which shipped in 2.0. For current behavior and configuration see [Using the UI](/using-the-ui/) and the [projects.json reference](/reference/projects-json/). Terminology note: `kind` throughout this document is now `adapter`.
+:::
 
+Before this model, folders appeared in the sidebar automatically when sessions started, and a scanner walked all adapter session directories to discover every resumable session across all projects. That created noise, didn't sync between clients, and prevented adapters with per-project storage (like OpenCode's SQLite) from integrating cleanly.
 
-Today, folders appear in the sidebar automatically when sessions start, and the scanner walks all adapter session directories to discover every resumable session across all projects. This works but creates noise, doesn't sync between clients, and prevents adapters with per-project storage (like OpenCode's SQLite) from integrating cleanly.
-
-This document describes the replacement, delivered in three steps:
-1. Server-side project state with user-curated project list
-2. Manage projects UI
+The replacement shipped in three parts:
+1. Server-side project state with a user-curated project list
+2. The Settings → Projects UI
 3. URL routing (stable, hierarchical session URLs)
 
 ## Design principles

--- a/apps/website/src/content/docs/develop/session-schema.md
+++ b/apps/website/src/content/docs/develop/session-schema.md
@@ -23,21 +23,22 @@ Session data flows through three boundaries. Not every field crosses every bound
 
 Two paths: the runner's `GET /meta` endpoint (polled by discovery) and its SSE `/events` stream (subscribed for live updates).
 
-**GET /meta** returns the full session state including internal title inputs (`shell_title`, `adapter_title`) and build identity (`binary_hash`). gmuxd deserializes this into `store.Session`.
+**GET /meta** returns the full session state including internal title inputs (`shell_title`, `adapter_title`) and build identity (`binary_hash`, `runner_version`). gmuxd deserializes this into `store.Session`.
 
 **SSE events** carry incremental updates:
 
 | Event | Fields |
 |-------|--------|
 | `status` | `working`, `error` |
-| `meta` | `title`, `shell_title`, `adapter_title`, `subtitle`, `unread` |
+| `meta` | `shell_title`, `adapter_title`, `subtitle`, `unread`, `slug` |
 | `exit` | `exit_code` |
+| `conversation_file` | `path` (legacy name `session_file` accepted until v2.1) |
 | `terminal_resize` | `cols`, `rows` |
 | `activity` | (no fields, signal only) |
 
 ### gmuxd → frontend
 
-gmuxd exposes the aggregated store via `GET /v1/sessions` and `session-upsert` / `session-remove` SSE events. A custom `MarshalJSON` on `store.Session` controls which fields are serialized. Internal fields are excluded; their derived outputs are included instead.
+gmuxd exposes the aggregated store to the browser via `GET /v1/events` (SSE). Session state arrives as coalesced `snapshot.sessions` full-replacement snapshots (ADR 0001); `session-activity` is forwarded as a bare signal. `GET /v1/sessions` remains for CLI/scripting. A custom `MarshalJSON` on `store.Session` controls which fields are serialized in both. Internal fields are excluded; their derived outputs are included instead.
 
 ### Field map
 
@@ -48,7 +49,9 @@ gmuxd exposes the aggregated store via `GET /v1/sessions` and `session-upsert` /
 | `created_at` | ✓ | ✓ | ✓ | ✓ age display |
 | `command` | ✓ | ✓ | ✓ | title fallback only |
 | `cwd` | ✓ | ✓ | ✓ | ✓ header, grouping |
-| `kind` | ✓ | ✓ | ✓ | ✓ adapter badge |
+| `adapter` | ✓ | ✓ | ✓ | ✓ adapter badge, URLs |
+| `peer` | — | ✓ (hub) | ✓ | ✓ host attribution |
+| `parent_session_id` | ✓ | ✓ | ✓ | ✓ sidebar placement of editor children |
 | `workspace_root` | ✓ | ✓ | ✓ | ✓ folder grouping |
 | `remotes` | ✓ | ✓ | ✓ | ✓ folder grouping |
 | **Process state** |
@@ -57,14 +60,15 @@ gmuxd exposes the aggregated store via `GET /v1/sessions` and `session-upsert` /
 | `exit_code` | ✓ | ✓ | ✓ | — |
 | `started_at` | ✓ | ✓ | ✓ | — |
 | `exited_at` | ✓ | ✓ | ✓ | — |
+| `last_activity_at` | — | ✓ stamped | ✓ | ✓ home recency buckets |
 | **Display** |
 | `title` | ✓ computed | ✓ re-resolved | ✓ | ✓ header, sidebar |
 | `subtitle` | ✓ | ✓ | ✓ | — |
 | `status` | ✓ | ✓ | ✓ | ✓ dots, header indicator |
 | `unread` | ✓ | ✓ | ✓ | ✓ dots, tab badge |
-| **Resume** |
+| **Resume & conversations** |
 | `resumable` | — | ✓ derived | ✓ | ✓ sidebar |
-| `resume_key` | — | ✓ | ✓ | ✓ project membership |
+| `conversation_file` | ✓ (hook) | ✓ | ✓ | ✓ duplicate-conversation warning |
 | **Routing** |
 | `slug` | ✓ opt | ✓ auto-derived | ✓ | ✓ URL routing |
 | **Terminal** |
@@ -72,23 +76,17 @@ gmuxd exposes the aggregated store via `GET /v1/sessions` and `session-upsert` /
 | `terminal_cols` | ✓ | ✓ | ✓ | ✓ initial size |
 | `terminal_rows` | ✓ | ✓ | ✓ | ✓ initial size |
 | **Build identity** |
-| `stale` | — | ✓ derived | ✓ | ✓ "outdated" badge |
+| `runner_version` | ✓ | ✓ | ✓ | ✓ staleness input |
+| `binary_hash` | ✓ | ✓ | ✓ | ✓ staleness input |
+| **Project assignment (ADR 0002)** |
+| `project_slug`, `project_index` | — | ✓ stamped | ✓ | ✓ folder rendering |
 | **Internal (not in API)** |
 | `shell_title` | ✓ | ✓ | — | — |
 | `adapter_title` | ✓ | ✓ | — | — |
-| `resume_key` | — | ✓ | ✓ | ✓ project membership |
-| `binary_hash` | ✓ | ✓ | — | — |
 
-Fields marked "—" in the "Frontend reads" column are sent by the API but not used by any rendering or logic code. They exist for future features (exit codes, process timing, subtitle display) or as defensive redundancy.
+Fields marked "—" in the "Frontend reads" column are sent by the API but not used by any rendering or logic code. They exist for future features or as defensive redundancy.
 
-Internal fields are inputs to derived fields. The API only exposes the derived output:
-
-| Internal input | Derived output |
-|---|---|
-| `shell_title`, `adapter_title` | `title` (via `resolveTitle`) |
-| `binary_hash` | `stale` (via `markStale`) |
-
-`resume_key` is both an input to `resumable` and directly API-visible (the frontend needs it for project session array membership to identify dead sessions).
+Internal fields are inputs to derived fields. The API only exposes the derived output: `shell_title` and `adapter_title` resolve into `title` (via `resolveTitle`). There is no `stale` field — the frontend derives staleness by comparing `runner_version`/`binary_hash` against `GET /v1/health`'s daemon version and `runner_hash`.
 
 ## Schema
 
@@ -103,6 +101,8 @@ Internal fields are inputs to derived fields. The API only exposes the derived o
 | `adapter` | string | Adapter name: `"shell"`, `"claude"`, `"codex"`, `"pi"`, etc. |
 | `workspace_root` | string? | Root of the workspace (jj/git), if detected. Used for folder grouping. |
 | `remotes` | map? | Git/jj remote URLs. Used for cross-machine folder grouping. |
+| `peer` | string? | Owning gmuxd instance; empty = local. Set by the hub for remote sessions, never by runners. |
+| `parent_session_id` | string? | Session this one was spawned from (`gmux edit` as `$EDITOR`); places the child next to its parent in the sidebar. |
 
 ### Process State (owned by gmux, authoritative)
 
@@ -113,27 +113,28 @@ Internal fields are inputs to derived fields. The API only exposes the derived o
 | `exit_code` | number? | Exit code when dead |
 | `started_at` | ISO 8601 | When the process was started |
 | `exited_at` | ISO 8601? | When the process exited |
+| `last_activity_at` | ISO 8601? | Stamped by the owning daemon on noteworthy transitions (exit, unread on, working on, error on). Powers the home screen's recency buckets. |
 
-### Resume (derived by gmuxd)
+### Resume & conversations
 
 | Field | Type | Description |
 |-------|------|-------------|
 | `resumable` | boolean | Derived: `!alive && command present`. Never set manually. |
-| `resume_key` | string? | Session-file ID used for resume. Also used by the frontend to match dead sessions against project membership arrays. |
+| `conversation_file` | string? | The agent's on-disk conversation file, reported authoritatively by the agent hook (ADR 0011). Drives resume-command derivation on exit; duplicate values across live sessions trigger a "conversation open in multiple tabs" warning. |
 
-All dead sessions with a command are resumable.
+All dead sessions with a command are resumable. On exit, adapters with native resume (pi, claude, codex) get their command replaced with a tool-specific resume command derived from the conversation file; sessions without one keep the original command, so "resume" re-runs it in the same working directory. Dead conversations can be resolved via `GET /v1/conversations/{adapter}/{slug}`.
 
 ### Routing
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `slug` | string? | Stable URL-friendly identifier. Auto-derived from resume_key basename, command basename, or session ID prefix. Unique within a kind. Adapters can override via the runner's `PUT /slug` endpoint. | Adapters with native resume (pi, claude, codex) provide a tool-specific resume command derived from the session file. Adapters without native resume (shell) keep the original command, so "resume" re-runs it in the same working directory.
+| `slug` | string? | Stable URL-friendly identifier, unique within (adapter, peer). Reported by the agent hook (or set via the runner's `PUT /slug` endpoint); gmuxd enforces uniqueness; the frontend falls back to the short ID when empty. |
 
 ### Display (set by child or gmux, mutable)
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `title` | string | Primary display name. Resolved by gmuxd: adapter title > shell title > CommandTitler > adapter kind. |
+| `title` | string | Primary display name. Resolved by gmuxd: adapter title > shell title > CommandTitler > adapter name. |
 | `subtitle` | string? | Secondary context line. |
 | `status` | Status? | Application-reported status (see below). |
 | `unread` | boolean | Whether this session has unseen activity. |
@@ -150,7 +151,8 @@ All dead sessions with a command are resumable.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `stale` | boolean | True when the session's binary hash doesn't match the current gmux binary. Derived from the internal `binary_hash` field. |
+| `runner_version` | string | Version of the runner binary hosting the session. |
+| `binary_hash` | string | sha256 of the runner binary. The frontend compares both against `GET /v1/health` to derive the "outdated" badge (version mismatch, or hash drift in dev). |
 
 ### Status Object (set by child process)
 
@@ -167,26 +169,29 @@ interface Status {
 
 - **`null`** — normal. Alive sessions show a steady dot, dead sessions are dimmed.
 - **`working: true`** — pulsing dot. The animation says "something is happening."
-- **`error: true`** — red dot; the agent gave up and needs attention.
+- **`error: true`** — red dot; the agent gave up and needs attention. A turn-end `unread` report clears it — error is treated as enhanced unread.
 - Display text is the frontend's concern: it derives "Working…"/"Error" from the booleans and `exited (N)` from `exit_code`.
 
 ### How Children Set Status
 
-**Option A — Environment variable + HTTP** (preferred):
+**Option A — the agent hook** (agents; primary): gmux injects a hook into pi/claude/codex launches. The hook `POST`s to `/hook/event` on `$GMUX_SESSION_SOCK`:
+
+- `op: "session"` — binds the session: `path` (conversation file), `name` (title), `slug`/`id`.
+- `op: "turn"` — `phase: "start"` sets working; `phase: "end"` + `outcome` (`completed` → idle + unread, `error` → red dot, `aborted` → idle).
+
+See `docs/runner-hook-protocol.md` in the repo and ADRs 0010/0011/0013/0015.
+
+**Option B — `PUT /status` on `$GMUX_SOCKET`** (any process; generic fallback):
 ```bash
 # gmux sets this in the child's environment
 GMUX_SOCKET=~/.local/state/gmux/run/sessions/sess-abc123.sock
 
-# Child (or a hook) sets status via HTTP on the same socket
+# Child (or a wrapper script) sets status via HTTP on the socket
 curl --unix-socket $GMUX_SOCKET http://localhost/status \
-  -X PUT -d '{"working":true}'
+  -X PUT -d '{"working":true}'    # 'null' clears
 ```
 
-**Option B — OSC escape sequences** (terminal-native):
-```bash
-# OSC 7777 ; json ST  (custom, parsed by gmux's PTY reader)
-printf '\e]7777;{"working":false}\e\\'
-```
+There is no OSC status channel; the PTY reader parses only OSC 0/2 titles (which set `shell_title`).
 
 ### Full Example
 
@@ -208,6 +213,8 @@ As served by `GET /meta` on a runner's Unix socket (runner → gmuxd):
   "status": { "working": true },
   "unread": false,
   "socket_path": "~/.local/state/gmux/run/sessions/sess-abc123.sock",
+  "conversation_file": "/home/user/.pi/agent/sessions/…/abc.jsonl",
+  "runner_version": "2.0.0",
   "binary_hash": "a1b2c3d4e5f6..."
 }
 ```
@@ -229,12 +236,18 @@ As served by `GET /v1/sessions` (gmuxd → frontend):
   "unread": false,
   "socket_path": "~/.local/state/gmux/run/sessions/sess-abc123.sock",
   "slug": "fix-auth-bug",
-  "resume_key": "2026-03-14T10-00-00_abc123",
-  "stale": false
+  "conversation_file": "/home/user/.pi/agent/sessions/…/abc.jsonl",
+  "last_activity_at": "2026-03-14T10:05:00Z",
+  "runner_version": "2.0.0",
+  "binary_hash": "a1b2c3d4e5f6..."
 }
 ```
 
-Note the differences: `shell_title`, `adapter_title`, and `binary_hash` are absent from the API response. `title` is the resolved value. `stale` is derived from `binary_hash`. `slug` is auto-derived. `resume_key` is passed through for project membership matching.
+Note the differences: `shell_title` and `adapter_title` are absent from the API response — `title` is the resolved value. `runner_version` and `binary_hash` ride the wire so the frontend can derive staleness against `/v1/health`. `last_activity_at` is stamped by the daemon.
+
+## Terminology (2.0)
+
+Pre-2.0 docs and payloads used `kind` (now `adapter`), `session_file` (now `conversation_file`), and `resume_key` (gone — its roles are covered by `conversation_file` and `slug`). See [Migrating to 2.0](/migrating-to-2/).
 
 ## What's NOT in This Schema
 

--- a/apps/website/src/content/docs/develop/session-schema.md
+++ b/apps/website/src/content/docs/develop/session-schema.md
@@ -52,8 +52,8 @@ gmuxd exposes the aggregated store to the browser via `GET /v1/events` (SSE). Se
 | `adapter` | ✓ | ✓ | ✓ | ✓ adapter badge, URLs |
 | `peer` | — | ✓ (hub) | ✓ | ✓ host attribution |
 | `parent_session_id` | ✓ | ✓ | ✓ | ✓ sidebar placement of editor children |
-| `workspace_root` | ✓ | ✓ | ✓ | ✓ folder grouping |
-| `remotes` | ✓ | ✓ | ✓ | ✓ folder grouping |
+| `workspace_root` | ✓ | ✓ | ✓ | ✓ project grouping |
+| `remotes` | ✓ | ✓ | ✓ | ✓ project grouping |
 | **Process state** |
 | `alive` | ✓ | ✓ | ✓ | ✓ everywhere |
 | `pid` | ✓ | ✓ | ✓ | — |
@@ -79,7 +79,7 @@ gmuxd exposes the aggregated store to the browser via `GET /v1/events` (SSE). Se
 | `runner_version` | ✓ | ✓ | ✓ | ✓ staleness input |
 | `binary_hash` | ✓ | ✓ | ✓ | ✓ staleness input |
 | **Project assignment (ADR 0002)** |
-| `project_slug`, `project_index` | — | ✓ stamped | ✓ | ✓ folder rendering |
+| `project_slug`, `project_index` | — | ✓ stamped | ✓ | ✓ project rendering |
 | **Internal (not in API)** |
 | `shell_title` | ✓ | ✓ | — | — |
 | `adapter_title` | ✓ | ✓ | — | — |
@@ -99,8 +99,8 @@ Internal fields are inputs to derived fields. The API only exposes the derived o
 | `command` | string[] | The command being run. For resumed sessions, replaced with the resume command. |
 | `cwd` | string | Working directory |
 | `adapter` | string | Adapter name: `"shell"`, `"claude"`, `"codex"`, `"pi"`, etc. |
-| `workspace_root` | string? | Root of the workspace (jj/git), if detected. Used for folder grouping. |
-| `remotes` | map? | Git/jj remote URLs. Used for cross-machine folder grouping. |
+| `workspace_root` | string? | Root of the workspace (jj/git), if detected. Used for project grouping. |
+| `remotes` | map? | Git/jj remote URLs. Used for cross-machine project grouping. |
 | `peer` | string? | Owning gmuxd instance; empty = local. Set by the hub for remote sessions, never by runners. |
 | `parent_session_id` | string? | Session this one was spawned from (`gmux edit` as `$EDITOR`); places the child next to its parent in the sidebar. |
 

--- a/apps/website/src/content/docs/develop/state-management.md
+++ b/apps/website/src/content/docs/develop/state-management.md
@@ -9,17 +9,17 @@ Session state flows one way: runners (and their agent hooks) produce it, `gmuxd`
 
 `gmuxd` holds all sessions in an in-memory store. Every mutation goes through `store.Upsert(session)`, which:
 
-1. Derives computed fields (`title`, `resumable`)
+1. Derives computed fields (`title`, `resumable`, `last_activity_at`)
 2. Writes the session under a lock
-3. Broadcasts a `session-upsert` SSE event to all connected browsers
+3. Notifies in-process subscribers with a `session-upsert` event. The SSE layer coalesces these into full `snapshot.sessions` payloads for browsers (protocol 2, ADR 0001).
 
-`store.Remove(id)` broadcasts `session-remove`. There are no other write paths.
+A byte-identical write is detected in the commit path and never broadcast — this no-op dedup is load-bearing for the snapshot protocol. `store.Remove(id)` notifies with `session-remove`. Other writers (`Update`, `UpsertRemote`, `Reconcile`, peer removals) all route through the same commit path, which is where dedup and slug resolution live.
 
 ### `Upsert` vs `UpsertRemote`
 
-Sessions owned by a peer go through `store.UpsertRemote` instead of `store.Upsert`. The difference is that `UpsertRemote` does **not** re-run `resolveTitle` or re-derive `resumable`: those fields were already authoritatively resolved on the spoke and arrive in the SSE payload. Canonicalization, duplicate-resume-key handling, unique-resume-key numbering, and the broadcast all still run.
+Sessions owned by a peer go through `store.UpsertRemote` instead of `store.Upsert`. The difference is that `UpsertRemote` does **not** re-run `resolveTitle` or re-derive `resumable`: those fields were already authoritatively resolved on the spoke and arrive in the SSE payload. It also skips `last_activity_at` recomputation — the stamp arrives in the peer payload. Canonicalization, duplicate-slug handling, unique-slug numbering, and the broadcast all still run.
 
-This split exists because the spoke keeps `shell_title` and `adapter_title` as internal fields and drops them in `MarshalJSON`. If the hub called `Upsert` on a remote session it would see those fields empty, fall through to the `CommandTitler` or the bare `kind` string, and overwrite the correct spoke-resolved `title`. `UpsertRemote` trusts the spoke. The alternative, putting the internal title fields on the wire, was rejected: it widens the public API surface for a purely internal concern.
+This split exists because the spoke keeps `shell_title` and `adapter_title` as internal fields and drops them in `MarshalJSON`. If the hub called `Upsert` on a remote session it would see those fields empty, fall through to the `CommandTitler` or the bare adapter name, and overwrite the correct spoke-resolved `title`. `UpsertRemote` trusts the spoke. The alternative, putting the internal title fields on the wire, was rejected: it widens the public API surface for a purely internal concern.
 
 ## Who writes what
 
@@ -28,22 +28,23 @@ Each field on a session has a single owner. No two subsystems write the same fie
 | Transition | Owner | Trigger |
 |---|---|---|
 | Session appears (live) | **Register** | Runner calls `POST /v1/register` |
-| Session appears (from file) | **Scanner** | Periodic scan of adapter session directories |
+| Session reappears after restart (dead) | **sessionmeta Sweep** | `meta.json` loaded at startup |
 | Metadata updates | **Subscription** | Runner SSE `status` / `meta` events |
 | Held file + title + status | **Agent hook** | runner SSE `conversation_file` / `status` events |
 | Session dies (clean exit) | **Subscription** | Runner SSE `exit` event |
 | Session dies (crash) | **Discovery Scan** | Socket file gone |
 | Session removed | **Dismiss handler** | User clicks × |
+| Activity stamp | **Store** | `last_activity_at` on noteworthy transitions |
 
 ### Register: single entry point for live sessions
 
 All live session creation flows through `Register()`. It queries the runner's `/meta` endpoint, creates or merges the session, and starts an SSE subscription. Both the `POST /v1/register` HTTP handler and the discovery scan delegate to it.
 
-For resumed sessions, `Register()` merges the new runner into the existing store entry (keeping the original ID and resume key) via the `PendingResumes` mechanism.
+For resumed sessions, the daemon launches the runner with `--resume-id` (ADR 0003): the runner registers under the same session ID and `Register()` lands in its re-registration merge branch, which overwrites only runtime-owned fields and preserves slug, creation time, and the hook-reported title. Resume also preserves PTY size hints and falls back to the project's canonical folder when the original cwd is gone.
 
 ### Discovery Scan: consistency check, not session creator
 
-Scan runs every 3 seconds and does two things:
+Scan runs every 3 seconds (plus once at startup, with a first-scan hook) and does two things:
 
 1. **New sockets** → delegates to `Register()` (never creates sessions directly)
 2. **Missing sockets** → marks alive sessions as dead
@@ -58,9 +59,9 @@ Live session state is reported by the agent itself, not inferred by the daemon. 
 
 Separately, each file-backed adapter implements `ConversationSource` to keep the conversations index (URL resolution + search) current: a snapshot at startup, then incremental create/change/remove events via the shared `filewatch` watcher. This covers dead conversations that have no running session, which the hook path cannot.
 
-### Scanner: file-discovered sessions
+### sessionmeta: dead-session persistence
 
-Runs every 30 seconds. Enumerates adapter session files on disk (e.g. `~/.claude/projects/`) and creates resumable entries for sessions not already in the store. Respects the dismissed set — sessions the user removed won't reappear.
+Dead sessions survive daemon restarts. When a session lands alive→dead, gmuxd writes `$XDG_STATE_HOME/gmux/sessions/<id>/meta.json`; at startup a Sweep loads those back into the store as `Alive=false`. Retention (ADR 0016): `meta.json` mirrors conversation-file existence, conversation-less sessions (shells) age out (30 days / 200 max by default), and dead-session scrollback is a cache with an aggregate byte cap. A separate 30-second maintenance pass purges ephemeral dead sessions that never bound a conversation file. There is no periodic scan of adapter conversation directories creating sessions — that mechanism was retired; the conversations index handles dead-conversation URL resolution.
 
 ## Session lifecycle
 
@@ -69,7 +70,7 @@ Runs every 30 seconds. Enumerates adapter session files on disk (e.g. `~/.claude
 stateDiagram-v2
     direction LR
     [*] --> alive : Register\n(new launch)
-    [*] --> resumable : Scanner\n(from session files)
+    [*] --> resumable : sessionmeta Sweep\n(daemon restart)
     alive --> resumable : exit
     resumable --> alive : user clicks resume\n(Register merges)
     resumable --> [*] : dismiss
@@ -79,7 +80,8 @@ stateDiagram-v2
 
 - **alive → resumable:** Subscription receives exit event from the runner, or discovery finds the socket gone. All dead sessions with a command are immediately resumable. For adapters with native resume (pi, claude, codex), the exit handler replaces the command with the tool-specific resume command. For others, the original command is kept.
 - **resumable → alive:** User clicks the session. The resume handler launches a runner with the session's command but does **not** modify the store. When the runner registers, `Register()` merges it back to alive.
-- **resumable → dismissed:** Resumable sessions in the "Resume previous" drawer can be dismissed with ×. Dismissed resume keys are tracked in memory so the scanner doesn't re-add them. Restarting `gmuxd` clears this set.
+- **resumable → dismissed:** Dismiss kills any live runner, runs the adapter's `OnDismiss`, removes project membership, and deletes the persisted meta dir — so a dismissed session stays gone, including across daemon restarts.
+- **Editor sessions** (`gmux edit`) are an exception: they're dismissed automatically when the editor closes, never becoming resumable.
 
 ## Derived fields
 
@@ -87,26 +89,29 @@ These are computed in `Upsert()` and `Update()`, never set manually:
 
 | Field | Derivation |
 |---|---|
-| `title` | `adapter_title` > `shell_title` > `CommandTitler` > adapter kind |
+| `title` | `adapter_title` > `shell_title` > `CommandTitler` > adapter name |
 | `resumable` | `!alive && has command` |
-| `stale` | `binary_hash` differs from gmuxd's expected runner hash |
+| `last_activity_at` | stamped on noteworthy transitions (exit, unread on, working/error on) |
 
-All dead sessions with a command are resumable, regardless of adapter kind. Adapters with native resume (pi, claude, codex) provide tool-specific resume commands via the `Resumer` interface. Adapters without it (shell) keep the original launch command, so "resume" re-runs it in the same working directory.
+Staleness (the "outdated" badge) is **frontend-derived**: the UI compares each session's `runner_version`/`binary_hash` against `/v1/health`. There is no `stale` store field.
 
-**Title priority:** `adapter_title` always wins over `shell_title`. An empty `adapter_title` from the runner never overwrites a non-empty one on the daemon, preserving titles across resume where the daemon knows the title from file attribution but the freshly-started runner doesn't yet. The next fallback is the adapter's `CommandTitler` interface (shell uses this to show `pytest -x`). The final fallback is the adapter kind name (e.g. "codex").
+All dead sessions with a command are resumable, regardless of adapter. The exit handler swaps in a tool-specific resume command only for sessions with a recorded conversation file (adapters implementing `Resumer`); everything else keeps the original launch command, so "resume" re-runs it in the same working directory.
+
+**Title priority:** `adapter_title` always wins over `shell_title`. An empty `adapter_title` from the runner never overwrites a non-empty one on the daemon, preserving titles across resume where the daemon knows the title but the freshly-started runner doesn't yet. The next fallback is the adapter's `CommandTitler` interface (shell uses this to show `pytest -x`). The final fallback is the adapter name (e.g. "codex").
 
 **Internal vs API-visible fields.** Several fields are internal to gmuxd and excluded from the API response via `MarshalJSON`. Their derived outputs are exposed instead. See the [field map](/develop/session-schema#field-map) for the full breakdown.
 
 ## Frontend architecture
 
-The frontend is a pure projection of backend state. Session state arrives exclusively via:
+The frontend is a projection of backend state. Session state arrives exclusively via a single `EventSource('/v1/events')` (protocol 2, ADR 0001):
 
-1. `GET /v1/sessions` — initial fetch on page load
-2. SSE `session-upsert` — real-time updates
-3. SSE `session-remove` — real-time removals
-4. SSE reconnect — re-fetches all sessions
+1. `snapshot.sessions` — full replacement of the session list (a leading-edge snapshot arrives on connect, so there is no bulk-GET prefetch)
+2. `snapshot.world` — projects, peers, health, launchers, peer projects
+3. `session-activity` — bare `{id}` ping, lossy by design
 
-There are **no optimistic updates**. When the user clicks dismiss, the frontend sends `POST /v1/sessions/{id}/dismiss` and waits for the `session-remove` SSE event. On localhost the round-trip is <10ms — imperceptible.
+Reconnect is trivial: the browser's `EventSource` auto-reconnects, and since every snapshot is a full replacement, missed deltas don't matter. (`GET /v1/sessions` still exists for the CLI and scripts.)
+
+Mutations use a bounded **optimistic overlay**: mark-read, dismiss, and reorder are stacked as pending mutations and replayed on top of incoming raw snapshots until the server echoes them back or a 5-second TTL expires. The UI feels instant, and a failed action self-heals back to server truth (plus an error toast).
 
 ### UI state (frontend-owned)
 
@@ -117,16 +122,16 @@ selectedId: string | null   // which session the terminal shows
 resumingId: string | null   // which session has a resume in flight
 ```
 
-**`selectedId`** — set on click, cleared when the selected session dies. Only sessions with `alive && socket_path` can be selected (the terminal needs a socket to connect to). Auto-selected on initial load for the first attachable session.
+**`selectedId`** — derived from the URL: selection *is* routing (`navigateToSession`). The view resolves only after both snapshots load, so a deep session URL survives a refresh.
 
 **`resumingId`** — set when the user clicks a resumable session. Shows a pulsing dot on the sidebar row while waiting for the backend to confirm the session is alive. Cleared when the SSE upsert arrives with `alive: true` and a valid `socket_path`, or after a 10-second timeout.
 
 ### canAttach
 
-The terminal renders when `selected.alive && selected.socket_path` is true. This means:
+The terminal renders when `selected.alive && (selected.socket_path || selected.peer)` is true. This means:
 
-- Dead/resumable sessions: no terminal, empty state shown
-- Alive but no socket yet: impossible — `Register()` always sets both `alive` and `socket_path` atomically
+- Dead/resumable sessions: no live terminal — the replay view shows persisted scrollback with a Resume/Rerun action
+- Alive but no socket yet: impossible for local sessions — `Register()` sets both `alive` and `socket_path` atomically; peer sessions have no local socket and attach through the hub proxy instead
 - Alive with socket: terminal connects via WebSocket proxy
 
 ## Status

--- a/apps/website/src/content/docs/develop/terminal-data-pipeline.mdx
+++ b/apps/website/src/content/docs/develop/terminal-data-pipeline.mdx
@@ -3,7 +3,7 @@ title: Terminal Data Pipeline
 description: How bytes travel from a child process to the screen, and how gmux captures scrollback along the way.
 ---
 
-This page traces what happens between a TUI program printing bytes and those bytes appearing on screen. It covers the three ways a user can observe a gmux session, and explains the scrollback buffer that ties them together.
+This page traces what happens between a TUI program printing bytes and those bytes appearing on screen. It covers the four ways a user can observe a gmux session, and the two storage layers that back replay.
 
 ## The full path
 
@@ -12,19 +12,21 @@ This page traces what happens between a TUI program printing bytes and those byt
 flowchart TD
     Child["Child process\n(pi, claude, bash)"]
     PTY["Kernel PTY layer<br/>onlcr: LF → CR LF"]
-    ReadPTY["ptyserver readPTY()"]
-    TW["TermWriter\n(ring buffer)"]
+    ReadPTY["ptyserver readPTY()\n(coalesce 8ms / 32KB)"]
+    Emu["vt emulator\n(in-memory, ~2000 lines)"]
+    Tee["scrollback tee\n(on disk, 2 × 1 MiB)"]
     XTerm["xterm.js\n(WebSocket)"]
     LocalTTY["Local TTY"]
-    API["/scrollback/text API"]
+    Broker["gmuxd /v1/sessions/:id/scrollback\n(raw | ?tail=N)"]
 
     Child -->|"raw bytes"| PTY
     PTY -->|"CR CR LF bytes"| ReadPTY
-    ReadPTY -->|"store"| TW
+    ReadPTY -->|"async, 100ms"| Emu
+    ReadPTY -->|"append"| Tee
     ReadPTY -->|"forward live"| XTerm
     ReadPTY -->|"copy"| LocalTTY
-    TW -.->|"replay snapshot"| XTerm
-    TW -.->|"normalize"| API
+    Emu -.->|"replay snapshot"| XTerm
+    Tee -.->|"dead-session replay / tail"| Broker
 ```
 
 ### 1. Child process writes to stdout/stderr
@@ -35,75 +37,62 @@ The child (pi, claude, bash) writes raw bytes. These are terminal escape sequenc
 
 The bytes pass through the kernel's PTY layer before reaching the master file descriptor that ptyserver reads. The PTY applies **line discipline** transformations. The most important one:
 
-**`onlcr` (output NL to CR-NL):** The kernel translates every `\n` (LF) into `\r\n` (CR LF). This means if a child writes `\r\n` explicitly (common in TUI apps), it becomes `\r\r\n` on the master side.
-
-This is transparent in normal terminal usage, but it matters for scrollback recording because `\r` has special meaning (carriage return, move cursor to column 0).
+**`onlcr` (output NL to CR-NL):** The kernel translates every `\n` (LF) into `\r\n` (CR LF). This means if a child writes `\r\n` explicitly (common in TUI apps), it becomes `\r\r\n` on the master side. This mostly matters for understanding how the emulator's rendered snapshot joins rows back into `\r\n`-terminated lines.
 
 ### 3. ptyserver reads from the PTY master
 
 The `readPTY()` goroutine reads chunks from the PTY master fd. It coalesces rapid bursts (up to 8ms or 32KB) into a single chunk to reduce WebSocket message count, then:
 
-1. Runs adapter hooks (title detection, status monitoring)
-2. Writes the chunk to the **TermWriter** (scrollback buffer)
-3. Copies the chunk to all connected **WebSocket clients** (live viewers)
+1. Runs adapter hooks (OSC title parsing, `Adapter.Monitor`)
+2. Appends the chunk to a pending buffer that feeds the **virtual terminal emulator** (drained asynchronously every 100ms, and synchronously when a client connects)
+3. Emits an activity signal when no client is watching
 4. Copies the chunk to the **local TTY** output (if attached)
+5. Appends the chunk to the **on-disk scrollback tee**
+6. Copies the chunk to all connected **WebSocket clients** (live viewers)
 
-The raw bytes are forwarded unmodified to WebSocket clients and the local TTY. Only the TermWriter processes them for storage.
+The raw bytes are forwarded unmodified to WebSocket clients, the local TTY, and the scrollback file. Only the emulator interprets them.
 
-## Three viewing paths
+## Two storage layers
+
+### In-memory: the vt emulator
+
+The runner feeds all output into a full virtual terminal emulator (`charmbracelet/x/vt`) with a ~2000-line scrollback. Because it is a real VT implementation, carriage returns, cursor movement, screen clears, and the alternate screen all behave like a genuine terminal: overwritten spinner frames simply vanish from the cell grid, and the emulator always holds the session's *current visual state*.
+
+Its one job is **connect-time replay for live sessions**: when a client attaches, the runner renders the emulator's scrollback plus visible screen into a snapshot frame. It lives only while the runner is alive.
+
+### On disk: the scrollback tee
+
+Independently, the runner appends every raw chunk to `$XDG_STATE_HOME/gmux/sessions/<id>/scrollback` (`packages/scrollback`). The format is raw PTY bytes with no framing. It's an append-only active file that rotates to `scrollback.0` when it exceeds 1 MiB, bounding disk usage at 2 MiB per session.
+
+The tee is deliberately dumb — clears and alt-screen switches are stored verbatim; whoever replays the bytes interprets them. Because it lives on disk, it survives runner exit and backs **dead-session replay**. For dead sessions it's treated as an evictable cache: an aggregate budget (`GMUX_SCROLLBACK_CACHE_MB`, default 256 MB) evicts scrollback oldest-first while the session metadata survives (ADR 0016).
+
+## Four viewing paths
 
 ### Local TTY (direct attach)
 
-When you run `gmux` in a terminal, the local terminal is attached as both input and output. PTY output bytes are copied directly to your terminal's stdout. Your terminal emulator (kitty, iTerm2, etc.) interprets the escape sequences and renders them.
+When you launch a session with `gmux -- <cmd>` or attach with `gmux attach <id>`, the local terminal is wired as input and output. PTY output bytes are copied directly to your terminal's stdout; your terminal emulator (kitty, iTerm2, etc.) interprets them.
 
 **Data flow:** PTY master → `readPTY()` → `localOut.Write(data)` → your terminal
 
-No filtering or transformation. You see exactly what the child process produces (after PTY line discipline).
+### xterm.js (live WebSocket viewer)
 
-### xterm.js (WebSocket viewer)
+When you open the gmux web UI, the browser runs xterm.js. On connection:
 
-When you open the gmux web UI or connect from another machine, the browser runs xterm.js. On connection:
-
-1. The server sends a **scrollback replay frame**: synchronized update begin, reset sequences (clear scroll region, cursor home, erase display, erase scrollback), the full TermWriter snapshot, then synchronized update end.
+1. The server sends a **replay frame**: synchronized-update begin (`ESC[?2026h`), reset sequences (clear scroll region, cursor home, erase display + scrollback), the emulator's rendered snapshot (scrollback lines plus the visible screen, style-diffed), the cursor position and visibility, then synchronized-update end. The snapshot is a *rendered reconstruction* — clears were already applied by the emulator, so the client starts from exactly the session's current state in a single frame.
 2. After replay, live chunks are forwarded in real time via WebSocket binary messages.
 
-**Data flow (replay):** TermWriter.Snapshot() → WebSocket → xterm.js
+**Data flow (replay):** vt emulator → `renderScreen()` → WebSocket → xterm.js
 **Data flow (live):** PTY master → `readPTY()` → WebSocket → xterm.js
 
-The replay frame includes `ESC[2J` and `ESC[3J` (erase display and scrollback) before the snapshot content. This ensures the connecting client starts from a clean slate, then sees the buffered output. Any clear sequences stored in the scrollback are processed by xterm.js naturally.
+One subtle trick: when the last viewer disconnects, the PTY is shrunk by one column so the next client's resize forces a full TUI redraw — this resynchronizes anything the emulator can't reconstruct (e.g. kitty graphics).
 
-### Scrollback text API (`/scrollback/text`)
+### Dead-session replay (browser)
 
-The scrollback text endpoint returns the TermWriter snapshot with ANSI sequences stripped and whitespace normalized. This is used for:
+For exited sessions, the browser's read-only replay view streams the on-disk scrollback from gmuxd (`GET /v1/sessions/<id>/scrollback`) into xterm.js (capped at the last 2000 lines). The raw bytes include any clear sequences the program emitted; xterm.js processes them naturally. Since alive and resumable sessions share unified terminal chrome, this looks like the live terminal with a Resume/Rerun action.
 
-- **Session file attribution:** matching terminal content to JSONL session files
-- **Content similarity:** determining which session a file belongs to
+### Rendered tail (`gmux tail` / `?tail=N`)
 
-**Data flow:** TermWriter.Snapshot() → `NormalizeScrollback()` (strip ANSI, collapse whitespace) → plain text
-
-## The TermWriter
-
-The TermWriter sits between the raw PTY output and the ring buffer. Its job is to store a compact, meaningful representation of terminal output by collapsing content that has been visually overwritten.
-
-### What it does
-
-**Spinner collapsing.** When a program writes `frame1\rframe2\rframe3`, only `frame3` is stored. The bare `\r` (carriage return not followed by line feed) signals that the program is overwriting the current line. Earlier frames are discarded.
-
-**Line buffering.** Content is accumulated in a pending buffer until a newline (`\n` or `\r\n`) arrives, then the complete line is flushed to the ring buffer. This ensures that mid-line overwrites (spinners) are fully resolved before storage.
-
-**PTY onlcr awareness.** The sequence `\r\r\n` (produced when a TUI writes `\r\n` through a PTY with onlcr enabled) is treated as a single CRLF line terminator. More generally, any run of `\r` characters followed by `\n` is treated as CRLF. Only `\r` followed by a non-CR, non-LF byte triggers overwrite collapsing.
-
-### What it does NOT do
-
-**Screen clear handling.** Clear sequences (`ESC[2J`, `ESC[3J`) are passed through as regular content. They are not used to reset the ring buffer. TUI apps like pi and claude use these sequences as part of normal rendering (redrawing the screen after state changes). Resetting on clears would destroy conversation content. WebSocket clients that replay the scrollback process the clear sequences themselves, so the visual result is correct.
-
-**Cursor movement.** The TermWriter does not interpret cursor positioning sequences (`ESC[H`, `ESC[nA`, `ESC[row;colH`, etc.). These are stored as regular bytes. A full virtual terminal emulator would be needed to track cursor position, which is out of scope. The trade-off is that TUI redraws accumulate in the buffer (each render cycle adds content), but the ring buffer's fixed size (128KB) naturally evicts old content.
-
-**Alternate screen buffer.** The TermWriter does not track `ESC[?1049h` (enter alt screen) or `ESC[?1049l` (leave alt screen). Content from both the main and alternate screen buffers is stored in the same ring buffer.
-
-### Ring buffer
-
-The underlying storage is a fixed-size circular buffer (default 128KB). When full, new writes overwrite the oldest data. This provides natural eviction without explicit management, keeping memory usage bounded regardless of how much output the child produces.
+`gmux tail <id>` and `GET /v1/sessions/<id>/scrollback?tail=N` return a plain-text rendering of the last N lines: gmuxd replays the on-disk bytes through an emulator sized to the session's last known dimensions (falling back to 80×24), collapsing overwrites, stripping ANSI, and trimming trailing blanks. It works identically for live and dead sessions.
 
 ## Escape sequence handling in the web client
 
@@ -113,16 +102,18 @@ xterm.js handles most escape sequences natively. The gmux web client registers a
 
 Applications write `ESC ] 52 ; c ; <base64> BEL` to set the system clipboard. This is the standard mechanism used by pi (`/copy`), tmux, vim, and SSH sessions to transfer text to the user's clipboard without direct OS access.
 
-xterm.js does not handle OSC 52 natively. The web client registers a parser handler via `term.parser.registerOscHandler(52, ...)` that decodes the base64 payload and calls `navigator.clipboard.writeText()`. Clipboard read requests (payload `?`) are not supported since the Clipboard API requires a user gesture.
+xterm.js does not handle OSC 52 natively. The web client registers a parser handler via `term.parser.registerOscHandler(52, ...)` that decodes the base64 payload and calls `navigator.clipboard.writeText()`. Clipboard read requests (payload `?`) are not supported since the Clipboard API requires a user gesture. The dead-session replay view registers OSC 52 as a swallow-handler, so replayed bytes can't clobber your clipboard.
 
 ### Sequences handled by xterm.js
 
 | OSC | Purpose | Notes |
 |-----|---------|-------|
-| 0, 1, 2 | Window/icon title | Parsed but not surfaced in the gmux UI |
+| 0, 1, 2 | Window/icon title | Parsed by the runner to set `shell_title` |
 | 4, 104 | Color palette set/reset | |
-| 8 | Hyperlinks | Rendered clickable via WebLinksAddon |
+| 8 | Hyperlinks | Handled natively (OscLinkProvider); plain-text URLs via WebLinksAddon; both routed through a custom link handler (with mobile long-press support) |
 | 10-12, 110-112 | Foreground/background/cursor color | Used by theme-aware applications |
+
+The web client also ships find-in-terminal (Cmd/Ctrl+F) via the xterm SearchAddon.
 
 ### Sequences that pass through unhandled
 
@@ -134,11 +125,10 @@ xterm.js does not handle OSC 52 natively. The web client registers a parser hand
 
 ## Example: what happens when pi renders a response
 
-1. Pi's Bubble Tea TUI computes a view string containing the full screen layout.
-2. Pi writes cursor movement sequences to go back to the top of the view, then writes each line followed by `\r\n`.
-3. The PTY kernel converts each `\r\n` to `\r\r\n` (onlcr).
-4. ptyserver's `readPTY()` reads a chunk containing multiple lines.
-5. The TermWriter sees `\r\r\n` at the end of each line, recognizes it as CRLF (not a bare CR), and flushes each line to the ring buffer.
-6. Spinner lines like `⠋ Working...\r⠙ Working...\r⠹ Working...` are collapsed: only `⠹ Working...` survives.
-7. When pi finishes the response and does a full-screen clear (`ESC[2J ESC[3J`), these bytes are stored in the ring buffer as regular content. The pre-clear conversation content remains.
-8. A WebSocket client connecting at this point receives the full ring buffer snapshot. xterm.js processes the clear sequences, showing only the post-clear content on screen, but the conversation text is still available via the `/scrollback/text` API.
+1. Pi's TUI computes a view string containing the full screen layout and writes cursor movement plus each line followed by `\r\n`.
+2. The PTY kernel converts each `\r\n` to `\r\r\n` (onlcr).
+3. ptyserver's `readPTY()` reads a coalesced chunk containing multiple lines.
+4. The chunk is appended verbatim to the on-disk scrollback and forwarded to any live viewers; within 100ms the emulator processes it, overwriting the cells of the previous frame.
+5. Spinner frames like `⠋ Working...\r⠙ Working...\r⠹ Working...` end up as a single row in the emulator's grid — earlier frames were overwritten. (On disk, all frames are stored; the tail renderer collapses them at read time.)
+6. A WebSocket client connecting now receives the emulator's rendered snapshot: the current screen and scrollback, with no stale spinner frames and no redundant redraw bytes.
+7. After the session exits, `gmux tail <id>` (or the browser replay) reconstructs the conversation from the on-disk scrollback.

--- a/apps/website/src/content/docs/develop/versioning.md
+++ b/apps/website/src/content/docs/develop/versioning.md
@@ -3,7 +3,9 @@ title: Versioning
 description: How gmux versions its artifacts and contracts.
 ---
 
-> **Status (2.0): implemented.** This page describes shipped behavior (binary-hash staleness, automatic daemon upgrade, `/v1` API prefix); it is kept here as the design record.
+:::note[Design record]
+This describes shipped behavior — binary-hash staleness, automatic daemon upgrade, and the `/v1` API prefix. See [Migrating to 2.0](/migrating-to-2/) for the 2.0 compatibility break and [Session Schema](/develop/session-schema/) for schema versioning.
+:::
 
 ## Principles
 

--- a/apps/website/src/content/docs/develop/writing-adapters.md
+++ b/apps/website/src/content/docs/develop/writing-adapters.md
@@ -41,7 +41,7 @@ func (m *MyApp) Match(cmd []string) bool {
 
 func (m *MyApp) Env(_ adapter.EnvContext) []string { return nil }
 
-func (m *MyApp) Monitor(output []byte) *adapter.Status { return nil }
+func (m *MyApp) Monitor(output []byte) *adapter.Event { return nil }
 ```
 
 That's enough for a valid adapter. It:
@@ -49,7 +49,7 @@ That's enough for a valid adapter. It:
 - reports whether the tool is available on this machine with `Discover()`
 - activates when the command matches `myapp`
 - contributes no extra environment yet
-- reports no custom status yet
+- reports no events yet
 - is available for richer optional capabilities later
 
 Write tests in `myapp_test.go` alongside it.
@@ -87,43 +87,49 @@ type Adapter interface {
     Discover() bool
     Match(command []string) bool
     Env(ctx EnvContext) []string
-    Monitor(output []byte) *Status
+    Monitor(output []byte) *Event
 }
 ```
 
 **`Name()`** returns a short identifier like `"pi"` or `"myapp"`.
 
-**`Discover()`** reports whether the backing tool is available on the current machine. `gmuxd` runs this in parallel for all compiled adapters during startup and only includes launchers from adapters whose discovery succeeds. Keep it cheap and deterministic. For example, shell returns `true`, while pi runs `pi --version` and checks whether it succeeds.
+**`Discover()`** reports whether the backing tool is available on the current machine. `gmuxd` runs this in parallel for all compiled adapters during startup and only includes launchers from adapters whose discovery succeeds. Keep it cheap and deterministic. For example, shell returns `true`, while pi checks that the `pi` binary is on `PATH` (`exec.LookPath`) without executing it — running the binary would be too slow.
 
 **`Match(cmd)`** receives the full command array and decides whether this adapter should handle it. Match on `filepath.Base(arg)` so full paths and wrappers work. Stop scanning at `"--"`.
 
 **`Env(ctx)`** returns extra environment variables for the child. The runner already sets `GMUX`, `GMUX_SOCKET`, `GMUX_SESSION_ID`, `GMUX_ADAPTER`, and `GMUX_RUNNER_VERSION`. Most adapters return `nil`.
 
-**`Monitor(output)`** receives raw PTY bytes on every read. Return a `*Status` when something meaningful happens, `nil` otherwise. This runs frequently, so keep it cheap.
+**`Monitor(output)`** receives raw PTY bytes on every read. Return a `*Event` when something meaningful happens, `nil` otherwise. This runs frequently, so keep it cheap. The built-in agent adapters (pi/claude/codex) return `nil` here — their status comes from the agent hook, not PTY parsing.
 
-### Important: adapters never modify the command
+### Important: adapters do not rewrite the user's command
 
-The command the user typed is exactly what runs. `Env()` can add environment variables, but adapters do not inject flags, wrap the process, or rewrite argv.
+The command the user typed is what runs. `Env()` can add environment variables; adapters don't inject flags or wrap the process. The only sanctioned argv change is the hook-injection seam (`SessionExtender`/`SessionHookCommand`, below), which the runner drives.
 
-## Reporting status
+## Reporting events
 
-Return a `Status` from `Monitor()` to update the sidebar:
+Return an `Event` from `Monitor()` to update the session. Zero/nil fields are no-ops — only explicitly set fields are applied:
 
 ```go
+type Event struct {
+    Title  string  // non-empty: update the adapter title
+    Status *Status // non-nil: update status; &Status{} clears it
+    Unread *bool   // non-nil: set or clear the unread flag (adapter.BoolPtr)
+    Cwd    string  // non-empty: update the session's canonical directory
+}
+
 type Status struct {
-    Label   string // Short text: "thinking", "3/10 passed"
-    Working bool   // true while the tool is busy (shows pulsing cyan dot)
-    Title   string // Optional: if set, updates the session title
+    Working bool // true while the tool is busy (pulsing dot)
+    Error   bool // true on a retryable error (red dot)
 }
 ```
 
-`Working` controls the sidebar dot (cyan pulse when true, hidden when false). `Label` appears as secondary text below the session title. Set `Title` if the PTY output should rename the session.
+Status carries only booleans; any display text is derived by the frontend from these plus the exit code.
 
 ## Adapter resolution
 
 When `gmux` launches a command, adapters are tried in this order:
 
-1. **`GMUX_ADAPTER` env var** — explicit override
+1. **`GMUX_ADAPTER` env var** — explicit override, validated against `Match()`. If the named adapter doesn't match the command (or is unknown), resolution falls through — this prevents a `GMUX_ADAPTER` leaked from a parent session from forcing the wrong adapter.
 2. **Registered adapters** — `Match()` in registration order; first match wins
 3. **Shell fallback** — always matches
 
@@ -179,7 +185,28 @@ Implement this if your tool's conversations live in files (or anywhere else) tha
 
 File-backed adapters build both on `packages/adapter/filewatch`, a reusable recursive tree watcher, in a few lines each — see `pi.go`. A non-file source (e.g. a database) implements the same interface with a poller or subscription instead.
 
-Note: live session state — title, status, and the held conversation file — is **not** reported here. That flows authoritatively from the agent hook (`SessionExtender` for pi, `SessionHookCommand` for codex/claude); see [Adapter Architecture](/develop/adapter-architecture).
+Note: live session state — title, status, and the held conversation file — is **not** reported here. That flows authoritatively from the agent hook (`SessionExtender` for pi, `SessionHookCommand` for codex/claude); see below and [Adapter Architecture](/develop/adapter-architecture).
+
+### `SessionExtender` / `SessionHookCommand`
+
+These are *the* way an agent adapter reports authoritative session identity, titles, and turn status (ADR 0010/0011/0013; protocol in `docs/runner-hook-protocol.md`). The runner splices the hook into the launch argv:
+
+- **`SessionExtender.ExtendCommand`** — injects an extension file into the agent's own extension mechanism (pi: `-e <ext.mjs>`).
+- **`SessionHookCommand.HookCommand`** — injects config overrides that make the agent run `gmux __<agent>-hook` on lifecycle events (claude: `--settings`, codex: `-c hooks.…`).
+
+Only opt in if gmux fully controls the argv — a shell-wrapped launch (`bash -c 'claude'`) can't be extended and simply runs without live state. `GMUX_NO_AGENT_HOOK` disables injection.
+
+### `ConversationProber`
+
+Optional. Lets the startup retention reconcile distinguish a *deleted* conversation file from *unavailable* storage, so dead sessions are only retired when their conversation is genuinely gone (ADR 0016). The agent adapters implement it via the shared `ConversationGoneAtRoot` helper.
+
+### `SessionRegistrar` / `SessionFinalizer`
+
+Optional lifecycle callbacks: `OnRegister` runs at registration time (return a slug, write a state file — shell and editor use this), `OnDismiss` cleans up when a session is dismissed.
+
+### `PassthroughDetector`
+
+Optional. Marks one-shot invocations (e.g. `pi update`, `pi --version`) that should be exec'd directly instead of wrapped in a session. Implement this for CLI tools with management subcommands.
 
 ### `Resumer`
 
@@ -195,9 +222,9 @@ Implement this if your tool supports resuming previous sessions.
 - `CanResume()` filters out invalid or empty files
 - `ResumeCommand()` tells gmux how to resume a valid session
 
-All dead sessions are resumable. When a session exits, gmuxd checks whether the adapter implements `Resumer` and has a recorded conversation file (`ConversationFile`, reported by the agent hook). If so, the session's command is replaced with the adapter's resume command (e.g. `["claude", "--resume", "abc"]`). If not, the original launch command is kept as-is, so "resume" simply re-runs the command in the same working directory.
+All dead sessions are resumable. When a session exits, gmuxd checks whether the adapter implements `Resumer` **and** the session has a recorded conversation file (`ConversationFile`, reported by the agent hook). If so, the session's command is replaced with the adapter's resume command (e.g. `["claude", "--resume", "abc"]`). If not, the original launch command is kept as-is, so "resume" simply re-runs the command in the same working directory.
 
-This means adapters that don't implement `Resumer` still get resume for free: the user clicks resume, a new session starts with the same command and cwd. This is the right behavior for shell sessions and simple tools. Only implement `Resumer` when your tool has native resume support that you want to use instead.
+This means adapters that don't implement `Resumer` still get resume for free: the user clicks resume, a new session starts with the same command and cwd. This is the right behavior for simple tools. Only implement `Resumer` when your tool has native resume support that you want to use instead.
 
 ### `CommandTitler`
 
@@ -207,7 +234,7 @@ type CommandTitler interface {
 }
 ```
 
-Implement this if your adapter needs custom fallback title display from the command array. Without it, the fallback title is the adapter name (e.g. "codex", "pi"). Shell implements this to show the full command with args (e.g. "pytest -x").
+Implement this to customize the fallback title derived from the command array. Without it, the store joins the full command (e.g. `pytest -x`). Adapters that use resume commands implement this to avoid titles like `codex resume 019cfb54-…`; the editor adapter shows the edited file's basename.
 
 This only matters when no adapter or shell title has been set yet, which is rare for agent adapters (titles come from the agent hook or conversation file) but common for plain shell sessions.
 
@@ -215,18 +242,21 @@ This only matters when no adapter or shell title has been set yet, which is rare
 
 An adapter implements only what it needs:
 
-| Adapter | Base | Launchable | ConversationFiler | ConversationSource | Resumer |
-|---------|------|------------|-------------|--------------------|---------|
-| Shell | ✓ | ✓ | — | — | —* |
-| Claude | ✓ | ✓ | ✓ | ✓ | ✓ |
-| Codex | ✓ | ✓ | ✓ | ✓ | ✓ |
-| Pi | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Adapter | Base | Launchable | ConversationFiler | ConversationSource | Resumer | Other |
+|---------|------|------------|-------------------|--------------------|---------|-------|
+| Shell | ✓ | ✓ | ✓ | — | ✓ | CommandTitler, SessionRegistrar, SessionFinalizer |
+| Editor | ✓ | ✓ | — | — | — | CommandTitler, SessionRegistrar |
+| Claude | ✓ | ✓ | ✓ | ✓ | ✓ | ConversationProber, SessionHookCommand |
+| Codex | ✓ | ✓ | ✓ | ✓ | ✓ | ConversationProber, SessionHookCommand |
+| Pi | ✓ | ✓ | ✓ | ✓ | ✓ | ConversationProber, SessionExtender, PassthroughDetector |
 
-\* Shell sessions are still resumable (all sessions are). They just re-run the original command in the same cwd, which starts a fresh shell. Adapters only need to implement `Resumer` when the tool has native resume (e.g. `claude --resume`).
+Shell writes a small JSON state file per session under `~/.local/state/gmux/shell-sessions/` and resumes by launching `$SHELL` in the original cwd. The editor adapter (backing `gmux edit`) is a good minimal non-agent example: it matches an internal sentinel command and is ephemeral (auto-dismissed on close).
+
+A house pattern worth copying: assert your capabilities at compile time — `var _ adapter.Resumer = (*MyApp)(nil)`.
 
 ## Testing
 
-Write unit tests in `myapp_test.go` next to your adapter. Test `Match()` with different command shapes and `Monitor()` with representative output.
+Write unit tests in `myapp_test.go` next to your adapter. Test `Match()` with different command shapes and `Monitor()` with representative output (if it does anything).
 
 If the adapter implements `Launchable`, test the returned launcher IDs, labels, and commands.
 

--- a/apps/website/src/content/docs/getting-started.mdx
+++ b/apps/website/src/content/docs/getting-started.mdx
@@ -36,7 +36,9 @@ gmux open               # open the dashboard
 
 Running a command uses the `--` separator: everything after it is your command, verbatim. `gmux` auto-starts the daemon (`gmuxd`) on first run. `gmux open` launches the dashboard in a dedicated browser window (Chrome/Chromium app mode when available, otherwise your default browser); bare `gmux` prints help. If you run commands often, `alias gm='gmux --'` lets you type `gm pi`.
 
-The first time, the sidebar will be empty. Click **Add project** to pick which project directories appear. Once added, sessions in those directories show up automatically. Click a session to attach a live terminal.
+The first time, the sidebar shows just your new session. To organize sessions by repo, open **Settings** (gear icon) **→ Projects** and add your project directories — gmux also suggests directories it discovered from past sessions. Click a session to attach a live terminal.
+
+gmux is also a full CLI: `gmux ls`, `gmux attach <id>`, `gmux send <id> …`, `gmux wait <id>`, `gmux edit <file>` — see the [CLI reference](/reference/cli/).
 
 See [Using the UI](/using-the-ui) for a full walkthrough.
 

--- a/apps/website/src/content/docs/integrations/claude-code.md
+++ b/apps/website/src/content/docs/integrations/claude-code.md
@@ -9,7 +9,7 @@ gmux has built-in support for [Claude Code](https://docs.anthropic.com/en/docs/c
 
 ### Live status
 
-The sidebar shows when Claude Code is actively working. gmux detects user and assistant messages in the session file — a user message sets the status to **working** (pulsing cyan dot), and a completed assistant response clears it.
+The sidebar shows when Claude Code is actively working. gmux injects a small hook configuration (via `--settings`) when it launches `claude`; the hooks report turn boundaries directly to gmux, so status is authoritative rather than inferred from output or file writes. A user prompt sets the status to **working** (pulsing cyan dot); the end of the turn clears it.
 
 ### Session titles
 
@@ -23,9 +23,9 @@ Instead of showing "claude" for every session, gmux extracts a meaningful title:
 ```
 
 Title priority:
-1. Claude Code's auto-generated title (the `custom-title` entry in the session file)
+1. Claude Code's own session title (reported by the hook, or the `custom-title` entry in the conversation file) — renaming with `/rename` shows up at your next prompt, and the URL slug follows the resolved title
 2. The text of your first message
-3. "(new)" if there are no messages yet
+3. Otherwise the session falls back to its working directory / adapter name
 
 ### Resumable sessions
 
@@ -53,15 +53,24 @@ gmux -- env claude                   # ✓ matched
 gmux -- echo "not claude"            # ✗ not matched
 ```
 
-If detection fails, override it:
+`GMUX_ADAPTER` can force adapter selection, but only if the adapter's own matcher also accepts the command — the binary must still be named `claude` (e.g. a symlink `claude -> my-wrapper`). A wrapper with a different name is not matched and cannot be overridden.
 
-```bash
-GMUX_ADAPTER=claude gmux my-claude-wrapper
-```
+### Hooks
 
-### Session files
+When gmux owns the launch, it appends a `--settings` argument registering Claude Code hooks that run `gmux __claude-hook`. If you pass your own `--settings` or have hooks configured, gmux deep-merges: hook arrays concatenate, your scalar values win, and your settings can never wipe gmux's hook entries. Nothing is written to `~/.claude` — the injection is per-launch and ephemeral. Set `GMUX_NO_AGENT_HOOK=1` to launch claude unmodified (the session then runs without live status).
 
-Claude Code stores conversations as JSONL files in `~/.claude/projects/`. Each working directory gets its own subfolder with an encoded name — `/` and `.` are replaced with `-`:
+| Hook event | Effect |
+|---|---|
+| `SessionStart` | Binds the session to its conversation file, ID, and title (also fires on `/resume`, `/clear`, compaction — gmux follows the new transcript) |
+| `UserPromptSubmit` | Working (cyan dot); also refreshes the title, so a `/rename` shows up at your next prompt |
+| `Stop` | Idle — turn completed |
+| `SessionEnd` | Idle — session ended/aborted (Ctrl+C, exit) |
+
+Because turn state is authoritative, `gmux wait <id>` works reliably with Claude Code for scripting.
+
+### Conversation files
+
+Claude Code stores conversations (it calls them session transcripts) as JSONL files in `~/.claude/projects/`. Each working directory gets its own subfolder with an encoded name — `/` and `.` are replaced with `-`:
 
 ```
 ~/.claude/projects/
@@ -74,23 +83,9 @@ Claude Code stores conversations as JSONL files in `~/.claude/projects/`. Each w
 
 Note the double dash in `-home-mg--local-share-chezmoi` — that's because `/home/mg/.local` has a dot that also becomes a dash.
 
-gmuxd watches these directories and reads the files to populate the sidebar. Each line in the file is a JSON object with a `type` field (`user`, `assistant`, `system`, `custom-title`, etc.).
-
-### Status detection
-
-gmux watches the session file (not PTY output) for status signals:
-
-| File event | Sidebar effect |
-|---|---|
-| `type: "user"` line appended | Working (cyan dot) — assistant will respond |
-| `type: "assistant"` with only text content | Idle (dot clears) — turn complete |
-| `type: "assistant"` with `tool_use` content | Still working — tool execution in progress |
-| `type: "custom-title"` line appended | Title updates to the generated title |
-
-This approach avoids the flickering that would result from parsing Claude Code's TUI spinner output.
+gmuxd's Claude adapter watches these directories to discover past conversations and populate resumable entries. Each line in the file is a JSON object with a `type` field (`user`, `assistant`, `system`, `custom-title`, etc.). Live status and attribution do **not** come from these files — the hook binds the exact transcript path at `SessionStart`, so multiple sessions in one directory attribute correctly and immediately.
 
 ## Limitations
 
-- **Status has one-message granularity.** gmux marks the session as working after a user message and idle after a text-only assistant message. It doesn't distinguish between "thinking", "writing code", or "running a tool" — all are shown as "working".
-- **File creation timing.** Claude Code writes to the session file in real time, so there's no significant delay for initial title or status.
-- **Multi-instance attribution.** If you run two Claude Code sessions in the same directory, gmuxd uses content matching to attribute files. This works well in practice but has a one-write delay for initial attribution.
+- **Status is coarse.** gmux doesn't distinguish thinking/tool-use sub-states — all are shown as "working". An Esc-interrupted turn stays "working" until the next prompt (Claude's `Stop` hook only fires on a clean finish).
+- **Hook injection needs a visible `claude` binary.** A shell-wrapped launch (`gmux -- bash -c 'claude'`, or `claude` after a `--`) can't be extended, so that session runs without live status.

--- a/apps/website/src/content/docs/integrations/codex.md
+++ b/apps/website/src/content/docs/integrations/codex.md
@@ -3,13 +3,13 @@ title: Codex
 description: How gmux works with OpenAI Codex CLI.
 ---
 
-gmux has built-in support for [Codex CLI](https://developers.openai.com/codex/cli). No configuration is needed — launch Codex through gmux and everything works automatically.
+gmux has built-in support for [Codex CLI](https://developers.openai.com/codex/cli). No configuration is needed — launch Codex through gmux and everything works automatically. Live status requires Codex CLI **0.135.0 or newer**; older versions still launch, resume, and get titles from the transcript, but show no working/idle status.
 
 ## What you get
 
 ### Live status
 
-The sidebar shows when Codex is actively working. gmux detects `user_message` and `task_complete` events in the session file — a user message sets the status to **working** (pulsing cyan dot), and a completed task clears it.
+The sidebar shows when Codex is actively working. gmux injects a lightweight hook into every Codex launch; Codex reports prompt-submitted and turn-finished events directly to gmux, so status is exact — no file polling.
 
 ### Session titles
 
@@ -46,11 +46,19 @@ gmux -- /usr/bin/codex               # ✓ matched
 gmux -- echo "not codex"             # ✗ not matched
 ```
 
-If detection fails, override it:
+`GMUX_ADAPTER=codex` only disambiguates between adapters that already match — some argv token must still be a `codex` binary (e.g. `GMUX_ADAPTER=codex gmux -- env codex …`). It cannot force codex handling for an arbitrarily-named wrapper, and hook injection also needs a literal `codex` token in argv.
 
-```bash
-GMUX_ADAPTER=codex gmux my-codex-wrapper
-```
+### Live status via hooks
+
+When gmux owns the launch (and codex ≥ 0.135.0), it appends per-launch `-c hooks.…` config overrides so codex runs `gmux __codex-hook` on lifecycle events. Nothing is written to `~/.codex` — the injection is ephemeral. gmux pre-trusts *only its own* hooks by computing codex's per-hook trusted hash; your own hook trust model is untouched, and on any mismatch the hook is silently skipped (the session just lacks live state). Set `GMUX_NO_AGENT_HOOK=1` to disable injection.
+
+| Codex hook event | Effect |
+|---|---|
+| `SessionStart` | Binds the session (transcript path, title, slug) |
+| `UserPromptSubmit` | Working (cyan dot) |
+| `Stop` | Idle + unread; title refreshed |
+
+The hook also reports an explicit URL slug derived from your first prompt (codex's UUID session ids would make unreadable URLs), and refreshes the title at each turn end.
 
 ### Session files
 
@@ -67,7 +75,7 @@ Codex stores sessions as JSONL files in `~/.codex/sessions/`, organized by date:
 
 Unlike Claude Code and pi which organize by working directory, Codex uses a flat date-based structure. The working directory is stored inside each session's `session_meta` header.
 
-gmuxd walks the full date tree to discover session files.
+The codex adapter walks the full date tree to discover conversation files. If a transcript is deleted, the session stops being offered for resume.
 
 ### Session file format
 
@@ -77,21 +85,12 @@ Each line is a JSON object with a `type` field:
 |---|---|
 | `session_meta` | First line — session ID, cwd, timestamp, CLI version |
 | `response_item` | Message content — user prompts, assistant responses, function calls |
-| `event_msg` | Lifecycle events — `user_message`, `agent_message`, `task_complete`, `task_started` |
+| `event_msg` | Codex's own lifecycle log — `user_message`, `agent_message`, `task_complete`, … (not consumed by gmux) |
 | `turn_context` | Per-turn metadata (model, instructions) |
-
-### Status detection
-
-gmux watches event_msg lines in the session file for status signals:
-
-| Event type | Sidebar effect |
-|---|---|
-| `user_message` | Working (cyan dot) — assistant will respond |
-| `task_complete` | Idle (dot clears) — turn complete |
-| `turn_cancelled` / `turn_aborted` | Idle — turn ended early |
 
 ## Limitations
 
+- **Requires codex ≥ 0.135.0 for live status.** Below that, no hooks are injected and the session runs without working/idle status (there is no file-watch fallback).
 - **No custom titles.** Codex doesn't generate session titles like Claude Code does. gmux uses the first user prompt as the title.
-- **Date-based storage.** Sessions aren't grouped by project. gmux scans all session files and matches them to working directories by reading the `session_meta` header.
-- **Status is event-based.** gmux doesn't distinguish between "thinking", "running a command", or "writing code" — all are shown as "working" between `user_message` and `task_complete`.
+- **Date-based storage.** Sessions aren't grouped by project. gmux scans all conversation files and matches them to working directories by reading the `session_meta` header.
+- **Status is coarse.** gmux doesn't distinguish between "thinking", "running a command", or "writing code" — all are shown as "working". Codex's `Stop` hook carries no exit reason, so an interrupted turn is reported as completed (idle + unread) rather than aborted.

--- a/apps/website/src/content/docs/integrations/pi.md
+++ b/apps/website/src/content/docs/integrations/pi.md
@@ -26,7 +26,7 @@ Renaming with pi's `/name` command updates the sidebar live.
 
 ### Resumable sessions
 
-When a pi session exits, it remains in the sidebar as a resumable entry. Click it to resume exactly where you left off — gmux launches `pi --session <path> -c` with the right session file.
+When a pi session exits, it remains in the sidebar as a resumable entry. Click it to resume exactly where you left off — gmux launches `pi --session <path> -c` with the right conversation file.
 
 Resumable sessions are deduplicated: if you're already running a session that matches a resumable entry, only the live one appears.
 

--- a/apps/website/src/content/docs/integrations/pi.md
+++ b/apps/website/src/content/docs/integrations/pi.md
@@ -32,7 +32,7 @@ Resumable sessions are deduplicated: if you're already running a session that ma
 
 ### Launch from the UI
 
-Pi appears in the launch menu only when it is available on the current machine. `gmuxd` checks this at startup by running `pi --version`; if that fails, the pi launcher is omitted from the UI.
+Pi appears in the launch menu only when it is available on the current machine. `gmuxd` checks this at startup by looking for a `pi` binary on `PATH`; if none is found, the pi launcher is omitted from the UI. (Restart the daemon after installing pi.)
 
 ## How it works
 
@@ -40,7 +40,7 @@ Pi appears in the launch menu only when it is available on the current machine. 
 
 There are two separate pi checks:
 
-- **availability discovery** in `gmuxd`: run `pi --version` at startup to see whether pi is installed and the pi launcher should be shown
+- **availability discovery** in `gmuxd`: look up `pi` on `PATH` at daemon startup to decide whether the pi launcher should be shown
 - **runtime matching** in `gmux`: scan the launched command for a `pi` or `pi-coding-agent` binary name
 
 The runtime matching works with direct invocation, full paths, `npx`, `nix run`, and other wrappers:
@@ -49,14 +49,11 @@ The runtime matching works with direct invocation, full paths, `npx`, `nix run`,
 gmux -- pi                           # ✓ matched
 gmux -- /home/user/.local/bin/pi     # ✓ matched
 gmux -- npx pi                       # ✓ matched
+gmux -- pi update                    # ✓ matched, but runs directly (passthrough)
 gmux -- echo "not pi"                # ✗ not matched
 ```
 
-If detection fails (e.g., an unusual wrapper), override it:
-
-```bash
-GMUX_ADAPTER=pi gmux my-pi-wrapper
-```
+Detection is validated: `GMUX_ADAPTER=pi` only takes effect if the command actually invokes a `pi` / `pi-coding-agent` binary, so it can't force the pi adapter onto an arbitrary wrapper script. If you wrap pi, keep the binary name visible in the command (e.g. `gmux -- env FOO=1 pi`), or name your wrapper `pi`/`pi-coding-agent`.
 
 ### Session files
 
@@ -69,7 +66,7 @@ Pi stores conversations as JSONL files in `~/.pi/agent/sessions/`. Each working 
     2026-03-15T11-30-00-000Z_def456.jsonl
 ```
 
-gmuxd indexes these files for conversation search and history. Live session state — attribution, title, and status — comes from the extension, not from parsing these files. The first line of each file is a session header with a UUID and timestamp.
+gmuxd watches this directory to discover resumable conversations and to notice when a conversation file is deleted (a deleted conversation also retires its resumable entry). gmux honors pi's own `PI_CODING_AGENT_DIR` override: if you point pi at an isolated data directory, gmux looks for conversations under `$PI_CODING_AGENT_DIR/sessions`. Live session state — attribution, title, and status — comes from the extension, not from parsing these files. The first line of each file is a session header with a UUID and timestamp.
 
 ### The gmux extension
 
@@ -89,9 +86,11 @@ The extension reports each turn with a normalized, agent-agnostic outcome; gmux 
 
 ### Disabling the extension
 
-If a pi release ever breaks the extension, set `GMUX_NO_AGENT_HOOK=1` to launch pi without it. Pi runs normally; gmux just won't show hook-driven title/status/attribution until you unset it (or a fix ships). One-shot pi commands (`pi update`, `pi list`, `pi --help`, …) are never extended — gmux runs them directly rather than wrapping them in a session.
+If a pi release ever breaks the extension, set `GMUX_NO_AGENT_HOOK=1` to launch pi without it. Pi runs normally; gmux just won't show hook-driven title/status/attribution until you unset it (or a fix ships). For sessions launched from the web UI or resumed by the daemon, set the variable in the daemon's environment (it's read by the runner, which the daemon spawns).
+
+One-shot pi commands are never extended or wrapped in a session — gmux execs them directly: the subcommands `install`, `remove`, `uninstall`, `update`, `list`, `config` (immediately after the binary) and the info flags `--help`/`-h`/`--version`.
 
 ## Limitations
 
-- **Title appears after the first turn.** Pi generates the session name once the first response completes, so a brand-new session shows a generic title until then.
+- **Title appears after the first turn.** While the first turn is running, the session shows a generic title. Once the turn ends, gmux titles it with your first message; when pi generates or you set a session name, that name takes over.
 - **The extension only loads when gmux controls the launch.** A shell-wrapped invocation (e.g. `bash -lc "pi …"`) doesn't receive the `-e` flag, so that session won't report hook-driven state.

--- a/apps/website/src/content/docs/integrations/scripts-and-agents.md
+++ b/apps/website/src/content/docs/integrations/scripts-and-agents.md
@@ -31,11 +31,13 @@ Running a command always uses the explicit `--` separator — there is no bare `
 When stdin is not a TTY, `gmux -- <cmd>`:
 
 - **Blocks** until the child exits.
-- **Streams bounded metadata** to stdout (session id, kind, exit status), not the full PTY output. Your script's logs stay readable.
+- **Streams bounded metadata** to stdout (session id, adapter, command, pid, exit status), not the full PTY output. Your script's logs stay readable.
 - **Exits with the child's exit code**, so `gmux -- make build < /dev/null && deploy.sh` works.
 - **Keeps the session in the UI** for the duration: a human can watch it live in the browser without affecting the script.
 
 This is the shape every other line on this page builds on. It works the same in CI, cron jobs, and agent harnesses (whose stdin is a pipe by default).
+
+One exception: recognized one-shot adapter subcommands (e.g. `pi update`, `pi --version`) are exec'd directly and never create a session.
 
 ## Spawning detached
 
@@ -57,7 +59,7 @@ gmux send <id> Enter < prompt.txt          # pipe a file, then submit
 gmux send <id> C-c                          # interrupt, no Enter
 ```
 
-When no text is given and stdin is a pipe, gmux reads stdin until EOF (capped at 1 MiB). `send` is gated by Unix-socket file permissions (owner-only); see the [CLI reference](/reference/cli/) for the access-control story.
+When no text argument is given and stdin is a pipe, gmux reads stdin until EOF (capped at 1 MiB). `send` is gated by the daemon's owner-only Unix socket; see the [CLI reference](/reference/cli/) for the access-control story. For drop-in tmux compatibility, `gmux send-keys -t <id> [-l] <keys...>` is also supported.
 
 ## Waiting
 
@@ -75,7 +77,7 @@ gmux tail <id> -n 200          # extract the final answer
 
 The idle signal is the same `Status.Working` flag the UI's spinner consumes, so `wait` returns the moment the agent emits its closing message. Exit codes: `0` idle, `2` the session died first, `3` `--timeout N` elapsed.
 
-`wait` is for agent sessions (`claude`, `codex`, `pi`); shell sessions have no working signal and are rejected with a clear error. To wait for a shell command, run it through the blocking piped flow above (`gmux -- make build < /dev/null`) — that's exactly the shape `gmux -- <cmd>` already provides. (Waiting on arbitrary output — "until this text appears" — is planned as a server-side `wait` condition, [#313](https://github.com/gmuxapp/gmux/issues/313).)
+`wait` is for agent sessions (`claude`, `codex`, `pi`); shell sessions have no working signal and are rejected with a clear error, and `wait` only works for sessions on the local host — peer sessions (`<id>@<peer>`) are rejected. To wait for a shell command, run it through the blocking piped flow above (`gmux -- make build < /dev/null`) — that's exactly the shape `gmux -- <cmd>` already provides. (Waiting on arbitrary output — "until this text appears" — is planned as a server-side `wait` condition, [#313](https://github.com/gmuxapp/gmux/issues/313).)
 
 ## Reading output
 
@@ -92,9 +94,12 @@ echo "$url"
 
 ```bash
 gmux ls            # all local sessions, alive first, newest first
+gmux ls --all      # include sessions on paired peer hosts (ids print as <id>@<peer>)
 gmux ls --json     # machine-readable, for parsing in scripts
 gmux kill <id>     # SIGTERM the runner, normal exit lifecycle
 ```
+
+`send`, `tail`, and `kill` accept `<id>@<peer>` ids; `wait` does not (local only).
 
 Every verb accepts id prefixes, full session ids, or slugs, so the eight-character short form `ls` prints passes straight back to `kill`, `send`, `tail`, or `wait`.
 
@@ -123,6 +128,10 @@ The agents run concurrently because `gmux -d -- pi <prompt>` returns as soon as 
 ## Nested gmux
 
 When `gmux -- <cmd>` runs inside an existing gmux session (detected via the `GMUX=1` env var), gmux auto-detaches into a headless background process so you don't get a PTY-within-PTY. The auto-detach only triggers when stdin is a TTY: agent harnesses whose stdin is a pipe land in the piped flow above and behave normally. You don't need to special-case nested invocations.
+
+## Editor sessions as $EDITOR
+
+`gmux edit <file>` opens a managed editor session, blocks until the editor closes, and propagates its exit code — so it works anywhere `$EDITOR` does (`git commit`, `crontab -e`). Inside gmux sessions, `EDITOR`/`VISUAL` already default to `gmux edit` when your dotfiles don't set them, so an agent asking git to open an editor gets a proper tab in the UI.
 
 ## Agent-specific integrations
 

--- a/apps/website/src/content/docs/migrating-to-2.md
+++ b/apps/website/src/content/docs/migrating-to-2.md
@@ -1,0 +1,186 @@
+---
+title: Migrating to 2.0
+description: Every breaking change from 1.x to gmux 2.0, who it affects, and how to migrate.
+tableOfContents:
+  maxHeadingLevel: 3
+---
+
+gmux 2.0 is a breaking release. Most changes are one-time: the daemon migrates its own state automatically, and the CLI tells you the new form of any removed command. This page lists every breaking change — what changed, who is affected, and the exact migration steps.
+
+**The short version:**
+
+1. Upgrade every machine (and rebuild devcontainers) **together** — 2.0 hosts can't peer with 1.x hosts.
+2. Update scripts and muscle memory to the verb-first CLI: `gmux -- <cmd>` to run, `gmux open` for the UI, `gmux ls/attach/send/wait/kill` instead of flags.
+3. Re-authorize your tailnet hosts: peers now require the host's token (**Settings → Hosts → Add token**, using `gmux auth` on each host).
+4. If you parse gmux JSON: `kind` → `adapter`, `session_file` → `conversation_file`.
+
+---
+
+## CLI: verb-first grammar
+
+**Who:** everyone — interactive users, scripts, aliases, agent skills. ([ADR 0009](https://github.com/gmuxapp/gmux/blob/main/docs/adr/0009-verb-first-cli-and-frozen-top-level-namespace.md))
+
+### Bare-command shorthand removed
+
+| Before | After |
+|--------|-------|
+| `gmux pi` | `gmux -- pi` |
+| `gmux pytest --watch` | `gmux -- pytest --watch` |
+
+A bare word now errors with the run-form hint. If you run commands constantly, `alias gm='gmux --'` is shorter than the old shorthand.
+
+### Bare `gmux` no longer opens the dashboard
+
+| Before | After |
+|--------|-------|
+| `gmux` (no args) → opens the UI | `gmux` prints help; `gmux open` opens the UI |
+
+Daemon auto-start and the update notice moved to `gmux open` (and session launches).
+
+### Action flags replaced by verbs
+
+Every removed flag prints an error naming its replacement — nothing silently changes behavior:
+
+| Before | After |
+|--------|-------|
+| `gmux --list` / `-l` | `gmux ls` |
+| `gmux --all` | `gmux ls --all` |
+| `gmux --attach <id>` / `-a` | `gmux attach <id>` |
+| `gmux --tail <id>` / `-t` | `gmux tail <id>` |
+| `gmux --kill <id>` / `-k` | `gmux kill <id>` |
+| `gmux --send <id> <text>` | `gmux send <id> <text> Enter` |
+| `gmux --send --no-submit …` | `gmux send <id> <text>` (omit the trailing `Enter`) |
+| `gmux --wait <id>` | `gmux wait <id>` |
+| `gmux --no-attach <cmd>` | `gmux -d -- <cmd>` |
+| `gmux --host <peer> …` | address the session as `<id>@<peer>` |
+
+Note the **inverted `send` semantics**: 1.x auto-appended a newline unless `--no-submit`; 2.0 never auto-submits — add a trailing `Enter` key token to dispatch. Audit any script that pipes prompts.
+
+### Daemon lifecycle fronted by `gmux daemon`
+
+`gmux daemon start|stop|restart|status|log-path` is the canonical interface. The `gmuxd` binary keeps its verbs for service managers, so nothing breaks operationally — but update docs and scripts to the `gmux` spellings. `gmux auth` (token/pairing) and `gmux remote` (Tailscale setup) are top-level verbs.
+
+### New verbs (not breaking, but update your habits)
+
+- `gmux edit [file]` — managed editor sessions, usable as `$EDITOR`. Inside gmux sessions, `EDITOR`/`VISUAL` now default to `gmux edit` when your dotfiles don't set them — scripts that branch on `EDITOR` being empty inside sessions will see a value.
+- `gmux send-keys -t <id> …` — tmux-compatible key sending.
+- `gmux wait --timeout N` with exit codes `0` (idle) / `2` (died) / `3` (timeout).
+
+---
+
+## Multi-machine: tokens everywhere, no autodiscovery
+
+**Who:** anyone with peered hosts, tailnet setups, or devcontainers. ([ADR 0008](https://github.com/gmuxapp/gmux/blob/main/docs/adr/0008-peer-authentication-via-token.md))
+
+### All hosts must run 2.0
+
+The wire protocol is v2-only: a 2.0 hub cannot aggregate a 1.x spoke and vice versa. **Upgrade every machine together, and rebuild devcontainers** so the feature installs a matching gmux.
+
+### Tailnet identity no longer grants access
+
+Before, passing the Tailscale allow list granted the full API. Now tailnet identity only gets you to the login page; every request additionally needs the host's bearer token — the same two-gate model as the browser. If you opened `https://gmux-<host>.ts.net` and got straight in, you'll now see the login page once: paste the token from `gmux auth` on that host.
+
+### Tailscale peer autodiscovery removed
+
+Before, gmux machines on your tailnet appeared as hosts automatically. Now peers are explicit: run `gmux auth` on the host, paste its connect URL into **Settings → Hosts → Connect to host**.
+
+**Automatic migration on first 2.0 start:** hosts you had project references on are imported from the old discovery cache as **Auth needed** rows — click **Add token** on each to bring it back online (references keep resolving throughout). Unreferenced machines are dropped; re-add them on demand. The legacy cache is deleted, and `projects.json` is backed up to `projects.json.bak` first.
+
+### Removed `host.toml` keys
+
+These are **ignored with a warning** (not fatal), so an old config won't brick the daemon. Remove them to silence the warning:
+
+| Key | Replacement |
+|-----|-------------|
+| `tailscale.hostname` | Name derives from the OS hostname (`gmux-<hostname>`) and is then owned by Tailscale. Seed a different name *before first registration* with `GMUXD_TS_HOSTNAME`, or rename in the Tailscale admin console. |
+| `[[peers]]` | Runtime state in `peers.json`, managed via **Settings → Hosts**. |
+| `discovery.tailscale` | Gone — add tailnet hosts via **Connect to host**. |
+
+### Host renames no longer follow automatically
+
+A peer's name is now frozen at first contact (ADR 0017): renaming a machine doesn't relabel your roster, and references keep working under the original label. Node IDs act as a liveness anchor — a removed-and-re-added host reclaims its references automatically.
+
+---
+
+## API & schema: terminology rename
+
+**Who:** anyone parsing `gmux ls --json`, the REST API, SSE payloads, or `meta.json` files.
+
+| Before | After |
+|--------|-------|
+| `"kind": "pi"` (session JSON) | `"adapter": "pi"` |
+| `KIND` column in `gmux ls` | `ADAPTER` |
+| `GET /v1/conversations/{kind}/{slug}` | `GET /v1/conversations/{adapter}/{slug}` |
+| `"session_file"` | `"conversation_file"` |
+| `resume_key` field | gone — use `conversation_file` (resume identity) and `slug` (membership/URLs) |
+| `stale` field | gone — derive from `runner_version`/`binary_hash` vs `GET /v1/health` |
+
+The daemon reads legacy `meta.json` keys and accepts the legacy runner `session_file` event for one release (dropped in v2.1) but writes/emits only the new names. The `GMUX_ADAPTER` env var is unchanged (it was already named that in 1.6). URL path segments (`/project/pi/slug`) are unchanged, so bookmarks keep working — though a Claude `/rename` now moves the slug with the title.
+
+### Wire protocol v2
+
+Custom consumers of the daemon SSE stream: the per-event `session-upsert`/`session-remove` surface and bulk-GET prefetch are gone. Subscribe to `GET /v1/events` and consume full-replacement `snapshot.sessions` / `snapshot.world` payloads plus lossy `session-activity` pings. `GET /v1/sessions` remains for one-shot listing.
+
+### Same-origin enforcement
+
+Cookie-authenticated mutations and WebSocket upgrades are now rejected cross-origin (`403 cross_origin`). Browser-based tooling on another origin must switch to bearer-token auth; reverse proxies that rewrite `Host` must forward the browser-facing host in `X-Forwarded-Host`. See [Security](/security/#browser-sessions-same-origin-enforcement).
+
+---
+
+## Adapter API (out-of-tree adapters & integrations)
+
+**Who:** authors of custom adapters or tooling against `packages/adapter` / the runner socket.
+
+- **Renames:** `SessionFiler` → `ConversationFiler`, `ParseSessionFile` → `ParseConversationFile`, `SessionFileInfo` → `ConversationInfo`, `SessionRootDir`/`SessionDir` → `ConversationRootDir`/`ConversationDir`; internal `Kind` → `Adapter`.
+- **Removed capabilities:** `FileMonitor`, `FileAttributor`, `SessionFileLister`. Daemon-side file attribution and live tailing were replaced by runner-owned agent hooks (`SessionExtender` / `SessionHookCommand` + `POST /hook/event`) and adapter-owned `ConversationSource`s. There is no metadata-matching fallback: an unhookable tool runs without daemon-reported live state.
+- **`Status.label` removed:** `Status` is only `{working, error}` booleans. Scripts that `PUT /status` with a `label` should drop it — display text is derived in the frontend.
+- **Runner endpoints removed:** `GET /scrollback/text` and `GET /scrollback/tail` are gone from the runner socket. Use `gmux tail <id>` or gmuxd's `GET /v1/sessions/<id>/scrollback?tail=N` (works for dead sessions too).
+- **New surface:** `GMUX_SESSION_SOCK` env var, `POST /hook/event` hook protocol (`docs/runner-hook-protocol.md`), `GMUX_NO_AGENT_HOOK` opt-out, `ConversationProber`, `PassthroughDetector`, `SessionRegistrar`/`SessionFinalizer`.
+
+---
+
+## Behavior changes
+
+### Agent status is hook-driven
+
+pi, Claude Code, and Codex now report status/titles/attribution through injected hooks instead of file watching:
+
+- **Codex needs CLI ≥ 0.135.0** for live status; older versions launch fine but show no working/idle state.
+- **Shell-wrapped launches** (`gmux -- bash -c 'claude'`) can't be hooked and run without live status.
+- The agent's argv gains a hook argument (`-e <ext>` for pi, `--settings` for claude, `-c hooks.…` for codex). `GMUX_NO_AGENT_HOOK=1` launches the agent unmodified.
+
+### Sessions and retention
+
+- **Dead sessions persist across daemon restarts** (from `~/.local/state/gmux/sessions/<id>/meta.json`), and **dismiss is now permanent** — restarting the daemon no longer resurfaces dismissed sessions.
+- gmux no longer surfaces conversations it never saw by scanning `~/.claude`/`~/.codex`/`~/.pi` into resumable sidebar entries; those files still power URL resolution and resume of known sessions.
+- Retention caps apply: conversation-less dead sessions age out (30 days / 200 max), dead-session scrollback is capped at 256 MB aggregate. Override with `GMUX_SESSION_RETENTION_DAYS` / `GMUX_SESSION_RETENTION_MAX` / `GMUX_SCROLLBACK_CACHE_MB`.
+
+### Per-session sockets moved
+
+1.6 put runner sockets in shared `/tmp/gmux-sessions`; 2.0 uses `~/.local/state/gmux/run/sessions` (per-user, 0700). Tooling should read `$GMUX_SOCKET` instead of constructing paths. Legacy directories are scanned for one release so pre-upgrade runners survive; the shim disappears in v2.1. `GMUX_SOCKET_DIR` still overrides.
+
+### Fresh login environment
+
+Daemon-initiated launches (UI launcher, resume, restart) source a fresh `$SHELL -l -i` environment per launch instead of inheriting the daemon's frozen environment. Dotfile edits take effect on the next launch without a daemon restart. (No `$SHELL` — Docker/systemd — means unchanged behavior.)
+
+### Devcontainer discovery requires the devcontainer label
+
+Containers are only auto-discovered when they carry the `devcontainer.local_folder` label (set by the devcontainer CLI / VS Code) in addition to `GMUXD_LISTEN`. Plain `docker run` containers with `GMUXD_LISTEN` set are no longer picked up — add them as manual peers, or use the [Running in Docker](/running-in-docker/) flow.
+
+### projects.json schema v3
+
+Migrated automatically (with a `.bak` backup). The `hosts` match-rule field is dropped; cross-host projects are peer **reference items** (`{slug, peer, node_id}`). Tools that read or write `projects.json` must handle items without `match`. See [projects.json](/reference/projects-json/).
+
+---
+
+## UI changes (where did X go?)
+
+Not breaking, but 1.x docs and muscle memory point at moved things:
+
+- **Home screen** is now a pure activity dashboard (Waiting / Active / recency buckets). Host cards and quick-launch buttons are gone.
+- **Project management** moved from the sidebar's "Manage projects" modal to **Settings → Projects** (gear button).
+- **Hosts roster** lives in **Settings → Hosts**, with explicit Online / Connecting… / Auth needed / Offline statuses.
+- **Mobile toolbar** reworked: dedicated ↑ ↓ and word-jump keys are always present; ctrl/alt arm-and-highlight instead of relabeling keys; paste moved off the toolbar (paste keybind or long-press).
+- **Cmd/Ctrl+F** now opens find-in-terminal instead of browser find. Restore browser find with `{ "key": "secondary+f", "action": "none" }` in [`settings.jsonc`](/reference/settings/#keybinds-guide).
+
+Nothing in `settings.jsonc` or `theme.jsonc` changed — old files parse identically.

--- a/apps/website/src/content/docs/multi-machine.md
+++ b/apps/website/src/content/docs/multi-machine.md
@@ -20,7 +20,9 @@ Spokes need zero configuration changes. The hub authenticates with each spoke's 
 
 gmux does **not** auto-connect machines on your tailnet. Being on the same tailnet lets a machine *reach* another, but connecting still requires that host's bearer token, exactly like any other peer ([ADR 0008](https://github.com/gmuxapp/gmux/blob/main/docs/adr/0008-peer-authentication-via-token.md)). This keeps a single compromised node (say, a container running an untrusted agent) from driving every other machine on the tailnet.
 
-To add a tailnet machine, run `gmux auth` on it and copy the **connect URL** it prints:
+All connected hosts must run gmux 2.0. A 2.0 hub cannot aggregate a 1.x spoke and vice versa; upgrade every machine (and rebuild devcontainers) together.
+
+To add a tailnet machine, run `gmux auth` on it and copy the **connect URL** it prints (it also prints a QR code you can scan from a device on your tailnet). If the machine doesn't have gmux remote access enabled yet, run `gmux remote` first — without it, `gmux auth` prints only the local URL:
 
 ```
 To add this host from another gmux machine, paste this into "Connect to host":
@@ -49,17 +51,15 @@ gmux probes the host, adopts the name it reports about itself (no name to assign
 
 There is no `[[peers]]` config block (removed in [ADR 0007](https://github.com/gmuxapp/gmux/blob/main/docs/adr/0007-host-identity-and-peer-urls.md)) — peers are runtime state managed from the UI.
 
-## When a referenced host is renamed
+## When a referenced host is renamed or removed
 
-A host's name is derived from Tailscale (or its OS hostname), so it can change — for example when you upgrade a machine. A project reference pins another host's project into your sidebar by name, so a rename could silently strip those projects out.
-
-To prevent that, a reference is anchored on the host's stable, opaque node ID, not just its name. References you create from the UI capture that ID immediately, so a later rename is followed automatically and the projects stay put under the new name.
+A host's name is adopted at first contact and then frozen — renaming the machine later doesn't change what your roster calls it, so references keep working under the original label until you remove and re-add the host. Each reference also records the host's stable, opaque node ID as a liveness anchor: it lets a re-added host reclaim its old references automatically, and stops a *different* machine that reuses the name from silently adopting them.
 
 If gmux can't match a reference to any current host — it's not in the roster because it was removed, or set up on a previous install — the reference is **not** silently dropped:
 
 - The sidebar shows the project muted, with a warning marker.
 - The settings gear gets a small red pip.
-- **Settings → Hosts → Referenced but not found** lists each unmatched host with the projects pointing at it. Re-add the host under **Connect to host** (a manual peer's references are anchored on its node ID, so a later rename follows it automatically) and the references resolve again; otherwise remove them.
+- **Settings → Hosts → Referenced but not found** lists each unmatched host with the projects pointing at it. Re-add the host under **Connect to host** (the reference re-anchors on the re-added host's node ID) and the references resolve again; otherwise remove them.
 
 Removing a host clears the references that pointed at it, so a deliberate removal leaves nothing behind here.
 
@@ -74,10 +74,10 @@ Remote sessions carry their origin in the session ID using `@` separators:
 ```
 sess-abc123               # local
 sess-abc123@desktop       # from spoke "desktop"
-sess-abc123@dev@server    # from spoke "dev", which is a spoke of "server"
+sess-abc123@dev@server    # from "dev", a devcontainer attached to spoke "server"
 ```
 
-The UI parses these to build the topology breadcrumbs on the project hub. Routing uses the chain to forward actions hop-by-hop: the hub only knows its direct spokes, each spoke only knows its own.
+The UI parses these to attribute each session to its host (the `@host` suffix and devcontainer marker). Actions are routed by splitting on the last `@` and forwarding one hop; only devcontainer (local-peer) sessions forward through their parent host — sessions of one network peer are never relayed through another.
 
 ## Fault tolerance
 
@@ -86,7 +86,7 @@ Each spoke connection is independent. A slow or dead spoke never blocks the hub 
 When a spoke goes offline:
 
 - Its sessions remain visible but marked as disconnected.
-- The host status indicator turns red on the project hub.
+- The host shows as **Offline** in Settings → Hosts (with the connection error as detail); a host whose token is missing or wrong shows **Auth needed** instead.
 - The hub reconnects with exponential backoff (1s initial, 30s max, reset on success).
 - When the spoke comes back, sessions go live again. No user action needed.
 
@@ -108,9 +108,9 @@ The hub connects to these public gmuxd endpoints on each spoke:
 
 | Endpoint | Purpose |
 |----------|---------|
-| `GET /v1/events` | SSE subscription for session updates |
-| `GET /v1/sessions` | Initial session list on connect |
-| `GET /v1/health` | Version, hostname, available launchers |
+| `GET /v1/events?as=peer` | SSE snapshot stream — full `snapshot.sessions` on connect and on every change |
+| `GET /v1/projects` | Spoke's projects + discovered list (refreshed on `projects-update` events) |
+| `GET /v1/health` | Version, hostname, node ID, available launchers |
 | `POST /v1/launch` | Forward launch requests |
 | `WS /ws/:id` | Proxy terminal WebSocket connections |
 | `POST /v1/sessions/:id/kill` | Forward kill |

--- a/apps/website/src/content/docs/planned/distribution.md
+++ b/apps/website/src/content/docs/planned/distribution.md
@@ -3,6 +3,8 @@ title: Distribution
 description: How gmux will be shipped — binaries, packaging, and deployment modes.
 ---
 
+> **Status (2.0):** largely shipped — goreleaser releases with checksums, the Homebrew tap, `install.sh`, and automatic daemon upgrade all exist. Still open: signing/provenance, `gmux doctor`, AUR/Nix packaging.
+
 ## Artifacts
 
 ### Native binaries

--- a/apps/website/src/content/docs/planned/folder-management.md
+++ b/apps/website/src/content/docs/planned/folder-management.md
@@ -3,7 +3,8 @@ title: Project Management
 description: User-curated project list with VCS-aware matching and stable URL routing.
 ---
 
-> This feature is not yet implemented.
+> **Status (2.0): implemented.** Server-side project state (`projects.json`, host-authoritative discovery), the Settings → Projects UI, and hierarchical URL routing all shipped — see [Using the UI](/using-the-ui/) and [projects.json](/reference/projects-json/). Terminology note: `kind` in this document is now `adapter`. Kept for design rationale.
+
 
 Today, folders appear in the sidebar automatically when sessions start, and the scanner walks all adapter session directories to discover every resumable session across all projects. This works but creates noise, doesn't sync between clients, and prevents adapters with per-project storage (like OpenCode's SQLite) from integrating cleanly.
 

--- a/apps/website/src/content/docs/planned/mobile-notifications.md
+++ b/apps/website/src/content/docs/planned/mobile-notifications.md
@@ -3,7 +3,9 @@ title: Mobile Notifications
 description: Push notifications for mobile — current landscape and planned approach.
 ---
 
-> This feature is not yet implemented.
+:::note[Not implemented]
+This is a design sketch; nothing here has shipped.
+:::
 
 ## The problem with Web Push on iOS
 

--- a/apps/website/src/content/docs/planned/notifications.md
+++ b/apps/website/src/content/docs/planned/notifications.md
@@ -3,6 +3,8 @@ title: Notifications
 description: Daemon-driven session notifications with presence tracking and smart routing.
 ---
 
+> **Status (2.0): implemented** as described (presence tracking, grace period, coalescing, best-client routing). A follow-up redesign toward stateful, resolve-once interactive notifications is proposed in ADR 0018.
+
 ## How it works
 
 The daemon owns all notification decisions. Browser clients are dumb reporters

--- a/apps/website/src/content/docs/planned/opencode-adapter.md
+++ b/apps/website/src/content/docs/planned/opencode-adapter.md
@@ -3,7 +3,8 @@ title: OpenCode Adapter
 description: Adapter for the OpenCode AI coding agent.
 ---
 
-> This feature is not yet implemented. Depends on [folder management](/planned/folder-management/).
+> **Status (2.0):** not implemented, but the stated blocker is gone — project management shipped. The mechanism described below predates the 2.0 architecture: discovery would now be an adapter-owned `ConversationSource` (ADR 0014), and status should come from an agent hook (ADR 0013/0015) rather than DB polling.
+
 
 [OpenCode](https://opencode.ai) is an open-source AI coding agent that runs in the terminal. Unlike Claude Code, pi, and Codex (which write JSONL conversation files to central directories), OpenCode stores sessions in a SQLite database at `.opencode/opencode.db` relative to the working directory. This per-project storage model requires the folder management refactor before the adapter can discover sessions.
 

--- a/apps/website/src/content/docs/planned/opencode-adapter.md
+++ b/apps/website/src/content/docs/planned/opencode-adapter.md
@@ -3,10 +3,11 @@ title: OpenCode Adapter
 description: Adapter for the OpenCode AI coding agent.
 ---
 
-> **Status (2.0):** not implemented, but the stated blocker is gone — project management shipped. The mechanism described below predates the 2.0 architecture: discovery would now be an adapter-owned `ConversationSource` (ADR 0014), and status should come from an agent hook (ADR 0013/0015) rather than DB polling.
+:::note[Not implemented]
+The original blocker (project management) shipped in 2.0. The mechanism sketched below predates the current architecture: discovery would now be an adapter-owned [`ConversationSource`](/develop/writing-adapters/#conversationsource) (ADR 0014), and live status should come from an [agent hook](/develop/adapter-architecture/#live-session-state-comes-from-the-agent-hook) (ADR 0013/0015) rather than DB polling.
+:::
 
-
-[OpenCode](https://opencode.ai) is an open-source AI coding agent that runs in the terminal. Unlike Claude Code, pi, and Codex (which write JSONL conversation files to central directories), OpenCode stores sessions in a SQLite database at `.opencode/opencode.db` relative to the working directory. This per-project storage model requires the folder management refactor before the adapter can discover sessions.
+[OpenCode](https://opencode.ai) is an open-source AI coding agent that runs in the terminal. Unlike Claude Code, pi, and Codex (which write JSONL conversation files to central directories), OpenCode stores sessions in a SQLite database at `.opencode/opencode.db` relative to the working directory. This per-project storage model is why the adapter needs an adapter-owned conversation source to discover sessions.
 
 ## Phases
 
@@ -25,7 +26,7 @@ This is enough for sessions to appear in gmux and be launchable from the UI. No 
 
 ### Phase 2: Session discovery via SQLite
 
-Requires the folder management refactor. With scoped scanning, the scanner checks each configured folder for `.opencode/opencode.db` and queries it for sessions.
+The adapter's `ConversationSource` checks each configured project directory for `.opencode/opencode.db` and queries it for sessions.
 
 OpenCode's SQLite schema stores sessions and messages in two tables:
 

--- a/apps/website/src/content/docs/planned/peer-discovery-aggregation.md
+++ b/apps/website/src/content/docs/planned/peer-discovery-aggregation.md
@@ -1,7 +1,11 @@
 ---
-title: Planned Features
-description: Features under consideration for future releases.
+title: Peer Discovery & Aggregation
+description: Features under consideration for cross-host discovery and nested aggregation.
 ---
+
+:::note[Not implemented]
+These are ideas under consideration; nothing here has shipped. For what multi-machine does today, see [Multi-Machine Sessions](/multi-machine/).
+:::
 
 ## Canonical project URI
 

--- a/apps/website/src/content/docs/planned/probes.md
+++ b/apps/website/src/content/docs/planned/probes.md
@@ -3,9 +3,11 @@ title: Probes
 description: Planned folder-level metadata and project context.
 ---
 
-> This feature is not yet implemented.
+:::note[Not implemented]
+Probes are a design sketch; nothing here has shipped.
+:::
 
-Probes would add project-level context to folder groups in the sidebar — things like git branch, CI status, or dependency health. They're distinct from adapters, which operate per-session.
+Probes would add project-level context to project groups in the sidebar — things like git branch, CI status, or dependency health. They're distinct from adapters, which operate per-session.
 
 Open questions:
 

--- a/apps/website/src/content/docs/planned/session-persistence.md
+++ b/apps/website/src/content/docs/planned/session-persistence.md
@@ -3,7 +3,8 @@ title: Session Persistence
 description: Survive reboots — resume all sessions from where you left off.
 ---
 
-> This feature is not yet implemented.
+> **Status (2.0): partially superseded.** The core landed differently: the runner writes scrollback live (not on shutdown), dead sessions persist across daemon restarts and are resumable from the UI, and dead-session scrollback is a bounded cache (ADR 0016). Still open from this plan: per-folder "Resume All" and seeding a resumed shell's PTY with prior scrollback.
+
 
 When your computer reboots (or gmuxd restarts), all sessions are lost. Session persistence would let you pick up exactly where you left off.
 

--- a/apps/website/src/content/docs/planned/session-persistence.md
+++ b/apps/website/src/content/docs/planned/session-persistence.md
@@ -3,7 +3,9 @@ title: Session Persistence
 description: Survive reboots — resume all sessions from where you left off.
 ---
 
-> **Status (2.0): partially superseded.** The core landed differently: the runner writes scrollback live (not on shutdown), dead sessions persist across daemon restarts and are resumable from the UI, and dead-session scrollback is a bounded cache (ADR 0016). Still open from this plan: per-folder "Resume All" and seeding a resumed shell's PTY with prior scrollback.
+:::note[Mostly shipped]
+The core of this landed in 2.0, differently than described below: the runner writes scrollback live (not on shutdown), dead sessions persist across daemon restarts and are resumable from the UI, and dead-session scrollback is a bounded cache ([ADR 0016](https://github.com/gmuxapp/gmux/blob/main/docs/adr/0016-session-retention-scrollback-as-cache.md); see [State Management](/develop/state-management/)). **What remains planned** is the bulk workflow: a per-project **Resume All**, and seeding a resumed shell's PTY with its prior scrollback above a separator. The rest of this page is the original design sketch.
+:::
 
 
 When your computer reboots (or gmuxd restarts), all sessions are lost. Session persistence would let you pick up exactly where you left off.

--- a/apps/website/src/content/docs/planned/versioning.md
+++ b/apps/website/src/content/docs/planned/versioning.md
@@ -3,6 +3,8 @@ title: Versioning
 description: How gmux versions its artifacts and contracts.
 ---
 
+> **Status (2.0): implemented.** This page describes shipped behavior (binary-hash staleness, automatic daemon upgrade, `/v1` API prefix); it is kept here as the design record.
+
 ## Principles
 
 - Version user-facing artifacts, not internal implementation details.

--- a/apps/website/src/content/docs/reference/cli.md
+++ b/apps/website/src/content/docs/reference/cli.md
@@ -21,6 +21,10 @@ you, and `gmux daemon …` controls it.
 that isn't a verb — it uses an explicit `--` separator so gmux never has to
 guess where its flags end and your command begins.
 
+Coming from a pre-2.0 version? Every removed flag (`--list`, `--attach`,
+`--send`, …) and the old bare-command shorthand print a precise error naming
+the new form — see [Migrating to 2.0](/migrating-to-2/).
+
 ## Running a command
 
 ### `gmux -- <command> [args...]`
@@ -76,14 +80,14 @@ List sessions, alive first, newest first. Local only unless `--all`.
 
 ```
 $ gmux ls
-ID        STATUS  KIND   TITLE
-a3f20187  alive   pi     fix auth bug  (/home/mg/dev/myapp)
-be14b052  alive   shell  bash          (/home/mg/dev/gmux)
-7d3304e9  dead    shell  make build    (/home/mg/dev/myapp)
+ID        STATUS  ADAPTER  TITLE
+a3f20187  alive   pi       fix auth bug  (/home/mg/dev/myapp)
+be14b052  alive   shell    bash          (/home/mg/dev/gmux)
+7d3304e9  dead    shell    make build    (/home/mg/dev/myapp)
 ```
 
-- `--all` — include sessions from every connected peer (adds a peer column).
-- `--json` — emit a JSON array instead of the table, for scripts and agents.
+- `--all` — include sessions from every connected peer (ids print as `<id>@<peer>`).
+- `--json` — emit a JSON array instead of the table, for scripts and agents (the adapter field is `"adapter"`).
 
 ### `gmux attach <id>`
 
@@ -137,9 +141,9 @@ Use plain `send` for everyday use; `send-keys` only when porting tmux commands.
 
 **Access control.** `send` is powerful — anything you send lands in the
 session's PTY, indistinguishable from keyboard input. Access is gated by
-filesystem permissions on the session's Unix socket (owner-only), so only the
-user who started a session can send to it. Peer sessions are reached through
-gmuxd's authenticated proxy.
+gmuxd's local IPC: the daemon's Unix socket is owner-only, so only your user
+can send to sessions on this host. Peer sessions are reached through gmuxd's
+authenticated proxy.
 
 ### `gmux wait <id>`
 
@@ -176,6 +180,24 @@ session marked dead — the same path as the UI's kill button.
 gmux kill a3f20187
 ```
 
+### `gmux edit [file]`
+
+Open a file in a managed **editor session** — a first-class tab in the UI.
+Blocks until the editor exits and propagates its exit code, so it works as
+`$EDITOR` (git commit, etc.), even from inside another gmux session. With no
+file, the session prompts for a path (`~` expands).
+
+```bash
+gmux edit notes.md
+export EDITOR='gmux edit'   # git commit opens an editor tab
+```
+
+Inside gmux sessions, `EDITOR`/`VISUAL` already default to `gmux edit` when
+your dotfiles don't set them. Today the session runs a fallback terminal
+editor: `$GMUX_EDIT_FALLBACK` if set (may include flags, e.g. `vim -u NONE`),
+otherwise the first of `nano`, `vim`, `vi` on PATH. `edit` takes at most one
+path and no flags.
+
 ## UI, pairing, and the daemon
 
 ### `gmux open`
@@ -186,8 +208,8 @@ in app mode for a standalone window; falls back to the default browser. (Bare
 
 ### `gmux auth`
 
-Print this host's login URL and token, plus a connect URL and QR code for
-pairing another machine. This reveals a secret — run it deliberately, not as a
+Print this host's login URL and token — plus, when remote access is enabled,
+a connect URL and QR code for pairing another machine. This reveals a secret — run it deliberately, not as a
 status check.
 
 ### `gmux remote`
@@ -221,9 +243,12 @@ gmuxd 2.0.0 (ready)
 Sessions: 3 alive (2 local, 1 remote), 12 dead (15 total)
 
 Peers:
-  • desktop (1 session)        https://gmux-desktop.tailnet.ts.net
-  ○ gmux-server (offline)      https://gmux-server.tailnet.ts.net
-  ✗ manual-peer (refused)      https://peer.example.com
+  • desktop (1 session)
+    https://gmux-desktop.tailnet.ts.net
+  ○ gmux-server (offline)
+    https://gmux-server.tailnet.ts.net
+  ✗ manual-peer (connection refused)
+    https://peer.example.com
 ```
 
 ### `gmux version` · `gmux help`

--- a/apps/website/src/content/docs/reference/environment.md
+++ b/apps/website/src/content/docs/reference/environment.md
@@ -15,7 +15,13 @@ Variables that affect the daemon.
 | `GMUXD_TOKEN` | Seed the auth token file on first start. | *(none)* |
 | `XDG_CONFIG_HOME` | Base directory for config files. | `~/.config` |
 | `XDG_STATE_HOME` | Base directory for runtime state (socket, auth token). | `~/.local/state` |
+| `GMUXD_TS_HOSTNAME` | Seed the requested Tailscale node name at *first* registration (advanced/multi-instance setups); ignored once registered. | `gmux-<hostname>` |
+| `GMUX_SESSION_RETENTION_DAYS` | Age out dead shell sessions (no conversation file) older than N days. `0` = unlimited. | `30` |
+| `GMUX_SESSION_RETENTION_MAX` | Keep at most N dead shell sessions. `0` = unlimited. | `200` |
+| `GMUX_SCROLLBACK_CACHE_MB` | Aggregate cap on dead-session scrollback; evicted oldest-first (session metadata survives). `0` = unlimited. | `256` |
 | `GMUXD_DEV_PROXY` | Proxy frontend requests to a Vite dev server (development only). | *(none)* |
+
+(The retention variables use the `GMUX_` prefix, not `GMUXD_`.)
 
 ### Bind address
 
@@ -70,7 +76,8 @@ Variables that affect the session runner.
 |----------|---------|---------|
 | `GMUX_ADAPTER` | Force a specific adapter instead of auto-detection. | *(auto)* |
 | `GMUX_SOCKET_DIR` | Directory for per-session Unix sockets. | `~/.local/state/gmux/run/sessions` |
-| `GMUX_NO_AGENT_HOOK` | Disable injecting the gmux agent extension/hook (e.g. the pi extension). An escape hatch if an agent release breaks the extension: the agent runs unmodified, and gmux loses hook-driven title/status/attribution for it. Any value other than `0`/empty disables. Read by the runner, so it covers foreground and `-d` launches; for daemon-initiated launches set it in the daemon's environment. | *(unset)* |
+| `GMUX_EDIT_FALLBACK` | Editor command for `gmux edit` (may include flags, e.g. `vim -u NONE`). Without it, the first of `nano`, `vim`, `vi` on PATH is used. | *(unset)* |
+| `GMUX_NO_AGENT_HOOK` | Disable injecting the gmux agent extension/hook (the pi extension, or the claude/codex command hooks). An escape hatch if an agent release breaks the extension: the agent runs unmodified, and gmux loses hook-driven title/status/attribution for it. Any value other than `0`/empty disables. Read by the runner, so it covers foreground and `-d` launches; for daemon-initiated launches set it in the daemon's environment. | *(unset)* |
 
 ## Set by gmux in child processes
 
@@ -82,14 +89,15 @@ These are available inside every session launched by `gmux`. Use them to detect 
 | `GMUX_SOCKET` | Unix socket path for callbacks to the session runner. | `~/.local/state/gmux/run/sessions/sess-abc123.sock` |
 | `GMUX_SESSION_ID` | Unique session identifier. | `sess-abc123` |
 | `GMUX_ADAPTER` | Name of the matched adapter. | `pi`, `shell` |
-| `GMUX_RUNNER_VERSION` | Version of the gmux runner hosting the session. | `0.4.0` |
-| `GMUX_SESSION_SOCK` | Socket the agent extension/hook posts session + turn events to. Set only for adapters that ship a hook (pi); absent if `GMUX_NO_AGENT_HOOK` is set. | `~/.local/state/gmux/run/sessions/sess-abc123.sock` |
+| `GMUX_RUNNER_VERSION` | Version of the gmux runner hosting the session. | `2.0.0` |
+| `GMUX_SESSION_SOCK` | Socket the agent extension/hook posts session + turn events to (same socket as `GMUX_SOCKET`; a separate variable so hooks stay decoupled from the general child API). Set only for adapters that ship a hook (pi, claude, codex); absent if `GMUX_NO_AGENT_HOOK` is set. | `~/.local/state/gmux/run/sessions/sess-abc123.sock` |
+| `EDITOR`, `VISUAL` | Defaulted to `<gmux> edit` so agents/git open files as managed editor tabs. Only set when your dotfiles don't set them. | `/usr/local/bin/gmux edit` |
 
 See [Adapter Architecture](/develop/adapter-architecture) for how to use the child-to-runner API.
 
 ## How a session's environment is sourced
 
-When the daemon starts, resumes, or **restarts** a session (the launch buttons in the UI), it sources a fresh environment from an interactive login shell — roughly `$SHELL -l -i` run in the session's working directory — and hands that to the session. This means edits to your `~/.zshrc` / `~/.bashrc` / `~/.profile` (and per-directory hooks like `direnv`) take effect on the next launch or restart, **without** needing a `gmux daemon restart`. Clicking **Restart session** behaves like opening a fresh terminal.
+When the daemon starts, resumes, or **restarts** a session (the launch buttons in the UI), it sources a fresh environment from an interactive login shell — the probe is `$SHELL -l -i -c 'gmux __dump-env'` run in the session's working directory — and hands that to the session. This means edits to your `~/.zshrc` / `~/.bashrc` / `~/.profile` (and per-directory hooks like `direnv`) take effect on the next launch or restart, **without** needing a `gmux daemon restart`. Clicking **Restart session** behaves like opening a fresh terminal.
 
 The captured environment is merged onto the daemon's own environment, so session/desktop variables that your dotfiles never set — `DISPLAY`, `SSH_AUTH_SOCK`, `XDG_RUNTIME_DIR`, and similar — are preserved. (One consequence of the merge: a variable you *remove* from your dotfiles may linger until the daemon itself is restarted.)
 

--- a/apps/website/src/content/docs/reference/file-paths.md
+++ b/apps/website/src/content/docs/reference/file-paths.md
@@ -28,6 +28,10 @@ Created by gmuxd. Lives under `~/.local/state/gmux` (or `$XDG_STATE_HOME/gmux`).
 | `~/.local/state/gmux/projects.json` | User-curated project list (sidebar grouping, ordering) |
 | `~/.local/state/gmux/projects.json.bak` | Snapshot of `projects.json` taken before a schema migration rewrites it (notably the 2.0 upgrade) |
 | `~/.local/state/gmux/peers.json` | Hosts you connected to via **Connect to host** — URL, token, and node id (0600; it carries a token) |
+| `~/.local/state/gmux/node-id` | Stable, opaque per-node identity (ADR 0007), generated on first start. Not a secret, but back it up with `auth-token` — if it changes, peers see a different host |
+| `~/.local/state/gmux/sessions/<session-id>/meta.json` | Per-session metadata (adapter, conversation file, title) — keeps dead sessions visible across daemon restarts |
+| `~/.local/state/gmux/sessions/<session-id>/scrollback`, `scrollback.0` | Terminal scrollback (written by the runner). For dead sessions this is a cache: an aggregate budget (`GMUX_SCROLLBACK_CACHE_MB`, default 256 MB) evicts oldest-first while `meta.json` survives |
+| `~/.local/state/gmux/shell-sessions/` | Shell adapter per-session state files |
 | `~/.local/state/gmux/gmuxd.log` | Daemon log (when started via `gmux daemon start`) |
 | `~/.local/state/gmux/tsnet/` | Tailscale state directory (when remote access is enabled) |
 
@@ -41,14 +45,29 @@ Created by `gmux` (the CLI) for each running session. gmuxd connects to these to
 
 Override the directory with `GMUX_SOCKET_DIR`. The default deliberately lives under the state dir rather than `$XDG_RUNTIME_DIR`: runtime dirs are torn down by logind when your last login session ends, which would unlink the sockets of still-running sessions.
 
+During the 2.0 transition, gmuxd also scans the legacy locations (`$XDG_RUNTIME_DIR/gmux/sessions` and the per-uid temp dir) so runners started under older versions stay discoverable; this shim is dropped in v2.1 and is disabled when `GMUX_SOCKET_DIR` is set.
+
 ## Adapter-specific paths
 
 | Path | Purpose | Used by |
 |------|---------|---------|
-| `~/.pi/agent/sessions/` | Pi conversation files (JSONL) | Pi adapter (session discovery and resume) |
+| `~/.pi/agent/sessions/` | Pi conversation files (JSONL). Root overridable with `PI_CODING_AGENT_DIR` | Pi adapter (conversation discovery and resume) |
+| `~/.claude/projects/<encoded-cwd>/` | Claude Code conversation files (JSONL) | Claude adapter |
+| `~/.codex/sessions/YYYY/MM/DD/` | Codex conversation files (JSONL) | Codex adapter |
+
+gmux only reads these directories — agent hooks are injected per launch, never written into `~/.claude` or `~/.codex`.
+
+## Temporary files
+
+| Path | Purpose |
+|------|---------|
+| `$TMPDIR/paste-<n>.<ext>` | Image/binary pastes from the web UI (created 0600) |
 
 ## Logs
 
 | Path | Purpose |
 |------|---------|
-| `~/.local/state/gmux/gmuxd.log` | Daemon log when started via `gmux daemon start` or auto-started by `gmux` |
+| `~/.local/state/gmux/gmuxd.log` | Daemon log when started via `gmux daemon start` (truncated on each start) |
+| `$TMPDIR/gmuxd.log` (usually `/tmp/gmuxd.log`) | Daemon stderr when gmuxd is auto-started by a `gmux` command |
+
+`gmux daemon log-path` prints the state-dir log path.

--- a/apps/website/src/content/docs/reference/host-toml.md
+++ b/apps/website/src/content/docs/reference/host-toml.md
@@ -45,6 +45,8 @@ There is **no `[[peers]]` config**. Add a host you want to aggregate sessions fr
 |-------|------|---------|-------|-------------|
 | `port` | `number` | `8790` | 1–65535 | TCP port for the HTTP listener. |
 
+The bind address is not configurable here — it is the `GMUXD_LISTEN` environment variable (default `127.0.0.1`). See [Environment variables](/reference/environment/#bind-address).
+
 ### `[tailscale]`
 
 | Field | Type | Default | Description |
@@ -71,7 +73,8 @@ The config file is strictly validated at startup. gmuxd refuses to start if:
 
 This is intentional. Silent fallback to defaults is dangerous for security settings. See [Security](/security) for the reasoning.
 
-Two keys were **removed** in ADR 0007 and are now **ignored with a deprecation warning** (rather than failing startup), so upgrading a host that still has an old config doesn't brick the daemon. Remove them to silence the warning:
+Three keys were **removed** (ADR 0007 / ADR 0008) and are now **ignored with a deprecation warning** (rather than failing startup), so upgrading a host that still has an old config doesn't brick the daemon. Remove them to silence the warning:
 
-- **`tailscale.hostname`** — the node name now comes from Tailscale / the OS hostname.
-- **`[[peers]]`** — manual peers are runtime state; add them via *Connect to host* (stored in `peers.json`).
+- **`tailscale.hostname`** (ADR 0007) — the node name now comes from Tailscale / the OS hostname.
+- **`[[peers]]`** (ADR 0007) — manual peers are runtime state; add them via *Connect to host* (stored in `peers.json`).
+- **`discovery.tailscale`** (ADR 0008) — tailnet autodiscovery was removed; add tailnet hosts via *Connect to host*.

--- a/apps/website/src/content/docs/reference/projects-json.md
+++ b/apps/website/src/content/docs/reference/projects-json.md
@@ -7,13 +7,13 @@ tableOfContents:
 
 `~/.local/state/gmux/projects.json` (or `$XDG_STATE_HOME/gmux/projects.json`)
 
-Projects control which sessions appear in the sidebar and how they're grouped. gmuxd reads and writes this file. You can also edit it directly; changes are picked up on the next daemon restart. The UI's **Manage projects** modal is the primary editing interface.
+Projects control which sessions appear in the sidebar and how they're grouped. gmuxd reads and writes this file. You can also edit it directly — gmuxd re-reads the file on every access, so manual edits take effect immediately (open UIs won't refresh until the next change made through gmux, and a daemon-side mutation racing your edit will overwrite it). **Settings → Projects** is the primary editing interface. gmuxd seeds a default `home` project when the file is empty or missing.
 
 ## Example
 
 ```json
 {
-  "version": 2,
+  "version": 3,
   "items": [
     {
       "slug": "home",
@@ -31,9 +31,8 @@ Projects control which sessions appear in the sidebar and how they're grouped. g
     },
     {
       "slug": "ml-data",
-      "match": [
-        { "path": "/data/ml", "hosts": ["gpu-server"] }
-      ]
+      "peer": "gpu-server",
+      "node_id": "n-3f9c…"
     }
   ]
 }
@@ -43,16 +42,20 @@ Projects control which sessions appear in the sidebar and how they're grouped. g
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `version` | `number` | Schema version. Currently `2`. Managed by gmuxd; do not change manually. |
+| `version` | `number` | Schema version. Currently `3`. Managed by gmuxd; do not change manually. |
 | `items` | `Item[]` | Ordered list of projects. Order matters: it controls sidebar display order and tiebreaking for remote matches. |
 
 ## Item fields
 
+An item is either an **owned project** (`slug` + `match`, optionally `sessions`) or a **peer reference** (`slug` + `peer`, optionally `node_id`). References carry no `match` or `sessions` — the peer's own `projects.json` is the source of truth.
+
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `slug` | `string` | yes | URL-safe identifier. Lowercase alphanumeric and hyphens, no leading/trailing hyphen. Appears in URLs (`/:slug/:adapter/:session`). |
-| `match` | `MatchRule[]` | yes | One or more rules that determine which sessions belong to this project. At least one rule is required. |
-| `sessions` | `string[]` | no | Session keys (resume keys or IDs) assigned to this project. Managed by gmuxd; preserved but not required when editing. |
+| `match` | `MatchRule[]` | owned items | One or more rules that determine which sessions belong to this project. Required on owned items; forbidden on references. |
+| `sessions` | `string[]` | no | Session keys (the session's slug when attributed, otherwise its ID; devcontainer sessions are suffixed `@<peer>`) assigned to this project. Managed by gmuxd; owned items only. |
+| `peer` | `string` | references | The display name of the peer host that owns this project. Its presence makes the item a reference. |
+| `node_id` | `string` | no | References only. Stable opaque identity of the referenced peer; keeps the reference anchored to the right host across removes/re-adds. Stamped by gmuxd. |
 
 ## Match rules
 
@@ -62,7 +65,6 @@ Each rule is either a **path rule** or a **remote rule**. A rule cannot have bot
 |-------|------|-------------|
 | `path` | `string` | Filesystem path. Sessions whose working directory is at or under this path match. Paths starting with `~/` are expanded to `$HOME`. |
 | `remote` | `string` | Normalized git remote URL (e.g. `github.com/org/repo`). Sessions whose repository has a matching remote match regardless of filesystem path. |
-| `hosts` | `string[]` | Restrict this rule to sessions from specific peer hosts. Empty or absent means any host. |
 | `exact` | `boolean` | Path rules only. When `true`, only sessions whose working directory equals the path exactly match. Subdirectories do not match. |
 
 ### Path rules
@@ -95,9 +97,11 @@ By default, path rules match subdirectories. Set `exact: true` to match only the
 
 This matches sessions started from `$HOME` itself, but not `~/dev/gmux` or any other subdirectory. The default "home" project uses this to avoid catching every session.
 
-### Host ownership
+## Peer references
 
-Match rules are local to the host that owns the project. Network peer projects are represented as reference items with `peer`; their match rules and session order live in that peer's own `projects.json`. The old `hosts` match-rule field is ignored by current gmuxd versions and is dropped the next time the file is saved.
+Match rules are local to the host that owns the project. Another host's project is pinned into your sidebar as a **reference item** (`{ "slug": …, "peer": …, "node_id": … }`); its match rules and session order live in that peer's own `projects.json`. See [Multi-machine](/multi-machine/) for how references resolve and recover.
+
+The pre-2.0 `hosts` match-rule field is gone: it decodes silently for compatibility and is dropped the next time the file is saved. Host scoping is now implicit in ownership — each project is owned by exactly one host, and other hosts see it via a reference.
 
 ## Match precedence
 
@@ -105,7 +109,7 @@ When multiple projects could match a session:
 
 1. **Path specificity**: the project with the longest matching path wins. A session in `~/dev/gmux/.grove/teak/src` matches `~/dev/gmux/.grove/teak` over `~/dev/gmux`.
 2. **Path over remote**: a path match always takes priority over a remote match.
-3. **First remote wins**: when only remote rules match, the first matching project in list order wins. Drag to reorder projects in the manage modal to control this.
+3. **First remote wins**: when only remote rules match, the first matching project in list order wins. Drag to reorder projects in **Settings → Projects** to control this.
 
 ## Combining rules
 
@@ -135,28 +139,20 @@ The remote catches sessions in any clone on any machine. The path catches sessio
 }
 ```
 
-**Host-specific rules** for the same project on different machines:
-```json
-{
-  "slug": "ml",
-  "match": [
-    { "path": "~/ml", "hosts": ["laptop"] },
-    { "path": "/data/ml", "hosts": ["gpu-server"] }
-  ]
-}
-```
-
 ## Validation
 
 gmuxd validates the file on load. Invalid state is rejected with an error. Rules:
 
 - Every item must have a non-empty `slug` matching `^[a-z0-9]+(-[a-z0-9]+)*$`
-- No duplicate slugs
-- Every item must have at least one match rule
+- No duplicate slugs among owned projects; no duplicate `peer`+`slug` pairs among references (an owned project and a peer reference may share a slug)
+- Every owned item must have at least one match rule; references must not carry `match` or `sessions`
+- `node_id` is only valid on references
 - Each rule must have exactly one of `path` or `remote` (not both, not neither)
 - `exact` is only valid on path rules
 - No duplicate normalized paths across items (nesting is allowed)
 
+All API mutations are validated the same way; an invalid mutation is rejected (4xx) and nothing is written.
+
 ## Migration
 
-Older projects.json files (version 1 or unversioned) are migrated automatically on load. The migration converts the old `remote`/`paths` fields to `match` rules and canonicalizes paths under `$HOME` to `~/...` form. The migrated version is written back on the next save.
+Older projects.json files are migrated automatically on load: unversioned files' `remote`/`paths` fields become `match` rules (paths canonicalized to `~/...` form), and version-2 files pass through with the removed `hosts` field dropped. Before any schema upgrade rewrites the file, the pre-migration bytes are snapshotted to `projects.json.bak`. The migrated version is written back on the next save.

--- a/apps/website/src/content/docs/reference/settings.md
+++ b/apps/website/src/content/docs/reference/settings.md
@@ -202,6 +202,7 @@ Action to perform.
 | `copy` | Copy selection to clipboard. Does nothing if no text is selected. |
 | `paste` | Read system clipboard and send contents to the PTY. |
 | `selectAll` | Select all terminal content. |
+| `find` | Open the find-in-terminal search bar. |
 | `none` | Disable this key combo (removes a built-in default). |
 
 #### `args`
@@ -309,6 +310,16 @@ These are ready to paste into `settings.jsonc`.
 {
   "keybinds": [
     { "key": "ctrl+c", "action": "none" }
+  ]
+}
+```
+
+**Restore browser find** -- gmux binds `secondary+f` (Cmd+F on macOS, Ctrl+F elsewhere) to open the find-in-terminal search bar, replacing the browser's in-page find (which can't see into a canvas-rendered terminal). To get browser find back:
+
+```jsonc
+{
+  "keybinds": [
+    { "key": "secondary+f", "action": "none" }
   ]
 }
 ```

--- a/apps/website/src/content/docs/remote-access.md
+++ b/apps/website/src/content/docs/remote-access.md
@@ -49,7 +49,7 @@ Enable remote access? [y/N] y
 
 Enabled tailscale in /home/user/.config/gmux/host.toml
 Restarting daemon...
-gmuxd: running (pid 12345)
+gmuxd: running v2.0.0 (pid 12345)
   Logs: /home/user/.local/state/gmux/gmuxd.log
 
 Connecting to Tailscale...
@@ -66,7 +66,7 @@ Visit the URL to approve the device. gmux registers as its own device in your ta
 $ gmux remote
 Connecting to Tailscale...
   local:  http://127.0.0.1:8790
-  remote: https://gmux.your-tailnet.ts.net
+  remote: https://gmux-laptop.your-tailnet.ts.net
 
 Remote access is active.
 ```
@@ -81,12 +81,12 @@ enabled = true
 See [host.toml reference](/reference/host-toml/) for all fields (allow list).
 
 :::note[Multiple machines]
-Each machine joins the tailnet under `gmux-<its-hostname>`, derived from the OS hostname on first registration and then owned by Tailscale (it dedups names automatically). To use a specific name, set the machine's name in the Tailscale admin console or rename the host — there is no `hostname` key in `host.toml` (see [ADR 0007](https://github.com/gmuxapp/gmux/blob/main/docs/adr/0007-host-identity-and-peer-urls.md)). A machine named `gmux-desktop` is reachable at `https://gmux-desktop.your-tailnet.ts.net`.
+Each machine joins the tailnet under `gmux-<its-hostname>`, derived from the OS hostname on first registration and then owned by Tailscale (it dedups names automatically). To use a specific name, set the machine's name in the Tailscale admin console or rename the host — there is no `hostname` key in `host.toml` (see [ADR 0007](https://github.com/gmuxapp/gmux/blob/main/docs/adr/0007-host-identity-and-peer-urls.md)). To seed a different name *before first registration*, set `GMUXD_TS_HOSTNAME` in the daemon's environment. A machine named `gmux-desktop` is reachable at `https://gmux-desktop.your-tailnet.ts.net`.
 :::
 
 ### 4. Connect
 
-On your other device, open `https://gmux.your-tailnet.ts.net`. The connection is HTTPS with a valid certificate. You'll be asked for the host's access token (run `gmux auth` on the host to get it, or scan its QR/connect URL) — being on the tailnet lets you *reach* the host, but the token is what authorizes you ([ADR 0008](https://github.com/gmuxapp/gmux/blob/main/docs/adr/0008-peer-authentication-via-token.md)).
+On your other device, open the URL that `gmux remote` printed — typically `https://gmux-<hostname>.your-tailnet.ts.net`. The connection is HTTPS with a valid certificate. You'll be asked for the host's access token (run `gmux auth` on the host to get it, or scan its QR/connect URL) — being on the tailnet lets you *reach* the host, but the token is what authorizes you ([ADR 0008](https://github.com/gmuxapp/gmux/blob/main/docs/adr/0008-peer-authentication-via-token.md)).
 
 :::note
 The Tailscale listener is independent from the localhost listener. Local access (`127.0.0.1:8790`) always works, so you can't lock yourself out by misconfiguring Tailscale.
@@ -108,7 +108,11 @@ allow = ["your-work-account@github"]
 
 Then restart: `gmux daemon restart`.
 
-If the other account is on a **different tailnet**, you also need to share the gmux device via the [Machines](https://login.tailscale.com/admin/machines) page (⋯ → Share). The device is then accessible at `gmux.owner-tailnet.ts.net` (using the owner's tailnet name).
+If the other account is on a **different tailnet**, you also need to share the gmux device via the [Machines](https://login.tailscale.com/admin/machines) page (⋯ → Share). The device is then accessible at its `gmux-<hostname>.owner-tailnet.ts.net` name (using the owner's tailnet name).
+
+### Connecting another gmux host
+
+To aggregate this machine's sessions into another machine's dashboard, run `gmux auth` here and paste the connect URL it prints into **Settings → Hosts → Connect to host** on the other machine. Since tailscale autodiscovery was removed in 2.0, this is the only way two gmux hosts peer — see [Multi-machine](/multi-machine/). Note that all peered hosts must run gmux 2.0.
 
 ## Troubleshooting
 

--- a/apps/website/src/content/docs/running-in-docker.md
+++ b/apps/website/src/content/docs/running-in-docker.md
@@ -25,11 +25,24 @@ EOF
 
 # The container's hostname becomes its Tailscale name (gmux-<hostname>).
 docker compose up -d --build   # compose sets hostname: dev → joins as gmux-dev
-docker logs dev 2>&1 | grep "login.tailscale.com"
+docker logs dev 2>&1 | grep "login.tailscale.com"   # first run only; the state mount persists registration
 # Visit the URL to register, then open https://gmux-dev.your-tailnet.ts.net
 ```
 
+On first visit you'll see the gmux login page — being on the tailnet lets you *reach* the host, but the token is what authorizes you. Paste the container's token (`docker exec dev cat /root/.local/state/gmux/auth-token`, or run `docker exec dev gmuxd auth`).
+
 See [Remote Access](/remote-access/) for Tailscale setup details.
+
+### Connecting the container to your main gmux
+
+To aggregate the container's sessions into your main dashboard:
+
+```bash
+docker exec dev gmuxd auth
+# paste the printed "Connect to host" URL into Settings → Hosts → Connect to host
+```
+
+Only your machine holds the container's token — the container never gets yours — so a compromised agent inside the container can't drive your other machines ([ADR 0008](https://github.com/gmuxapp/gmux/blob/main/docs/adr/0008-peer-authentication-via-token.md)).
 
 ## WireGuard
 
@@ -55,7 +68,7 @@ This gives you a valid Let's Encrypt certificate on your own domain, with the gm
 
 By default, gmuxd generates a random auth token on first start. For container deployments where you need a known value (reverse proxy injection, health checks, scripting), there are two options.
 
-**Option 1: Environment variable (recommended for containers).** Set `GMUXD_TOKEN` in your compose file. On first start, gmuxd writes it to disk. On subsequent starts, the file already exists and the env var is verified against it.
+**Option 1: Environment variable (recommended for containers).** Set `GMUXD_TOKEN` in your compose file. On first start, gmuxd writes it to disk. On subsequent starts, the env var must match the existing file or gmuxd refuses to start. Tokens must be at least 64 hex characters (`openssl rand -hex 32`).
 
 ```bash
 openssl rand -hex 32   # copy the output into your compose.yaml or .env
@@ -79,7 +92,7 @@ Either way, any client that needs access can set the `Authorization: Bearer <tok
 
 ## How it works
 
-The container runs `gmuxd` as its entrypoint. Inside the container, `GMUXD_LISTEN=0.0.0.0` binds to all interfaces so the host (or Tailscale) can reach the port. The entrypoint script auto-updates gmux binaries on each start.
+The container runs `gmuxd run` as its entrypoint. In the WireGuard and Traefik examples, `GMUXD_LISTEN=0.0.0.0` binds the TCP listener to all interfaces so the host can map the port. The Tailscale example doesn't need it — the tsnet listener is reachable over the tailnet directly, and the TCP listener stays on loopback (used only by the compose health check). The entrypoint script auto-updates gmux binaries on each start.
 
 ### Bind address
 
@@ -129,4 +142,4 @@ services:
 enabled = true
 ```
 
-The node name is owned by Tailscale after first registration (it survives container recreation as long as the state mount persists), so there is no `hostname` key in `host.toml`. To see sessions from all containers in a single dashboard instead, set up [Multi-Machine Sessions](/multi-machine) with one gmuxd as the hub.
+The node name is owned by Tailscale after first registration (it survives container recreation as long as the state mount persists), so there is no `hostname` key in `host.toml`; alternatively, set `GMUXD_TS_HOSTNAME` in the container environment to pick the tailscale name directly. To see sessions from all containers in a single dashboard instead, set up [Multi-Machine Sessions](/multi-machine) with one gmuxd as the hub.

--- a/apps/website/src/content/docs/running-in-docker.md
+++ b/apps/website/src/content/docs/running-in-docker.md
@@ -29,7 +29,7 @@ docker logs dev 2>&1 | grep "login.tailscale.com"   # first run only; the state 
 # Visit the URL to register, then open https://gmux-dev.your-tailnet.ts.net
 ```
 
-On first visit you'll see the gmux login page — being on the tailnet lets you *reach* the host, but the token is what authorizes you. Paste the container's token (`docker exec dev cat /root/.local/state/gmux/auth-token`, or run `docker exec dev gmuxd auth`).
+On first visit you'll see the gmux login page — being on the tailnet lets you *reach* the host, but the token is what authorizes you. Paste the container's token (`docker exec dev cat /root/.local/state/gmux/auth-token`, or run `docker exec dev gmux auth`).
 
 See [Remote Access](/remote-access/) for Tailscale setup details.
 
@@ -38,7 +38,7 @@ See [Remote Access](/remote-access/) for Tailscale setup details.
 To aggregate the container's sessions into your main dashboard:
 
 ```bash
-docker exec dev gmuxd auth
+docker exec dev gmux auth
 # paste the printed "Connect to host" URL into Settings → Hosts → Connect to host
 ```
 

--- a/apps/website/src/content/docs/security.md
+++ b/apps/website/src/content/docs/security.md
@@ -21,9 +21,9 @@ This is equivalent to SSH access. The server must not be reachable by anyone who
 
 gmuxd uses two listeners:
 
-1. **Unix socket** (`~/.local/state/gmux/gmuxd.sock`) for local CLI-to-daemon IPC. No authentication needed; access is enforced by filesystem permissions (0600 socket, 0700 directory). This socket cannot be forwarded by VS Code, Docker, or SSH.
+1. **Unix socket** (`~/.local/state/gmux/gmuxd.sock`) for local CLI-to-daemon IPC. No authentication needed; access is enforced by filesystem permissions (0600 socket, 0700 directory). Unlike a TCP port, it is never auto-forwarded by VS Code, Docker Desktop, or SSH port forwarding.
 
-2. **TCP listener** (`127.0.0.1:8790` by default) for browser access. Every request must present a bearer token or session cookie. There is no unauthenticated TCP access, and no option to disable auth.
+2. **TCP listener** (`127.0.0.1:8790` by default) for browser access. Every request must present a bearer token or session cookie — the only unauthenticated paths are the login page itself and the web-app manifest. There is no option to disable auth, and daemon shutdown is refused on the TCP listener entirely (it is a Unix-socket-only operation), even with valid credentials.
 
 By default, the TCP listener binds to `127.0.0.1`:
 
@@ -32,7 +32,7 @@ By default, the TCP listener binds to `127.0.0.1`:
 - ❌ Not reachable from Tailscale or other VPNs
 - ❌ Not reachable from the internet
 
-The bind address can be changed via `GMUXD_LISTEN` for container and VPN deployments (see [Running in Docker](/running-in-docker/)). The port can be changed in the [config file](/reference/host-toml/).
+The bind address can be changed via `GMUXD_LISTEN` for container and VPN deployments (see [Running in Docker](/running-in-docker/)) — it is validated at startup and only accepts loopback, private (RFC 1918), link-local, CGNAT, ULA, or all-interfaces addresses; binding directly to a public IP is refused (use Tailscale instead). The port can be changed in the [config file](/reference/host-toml/).
 
 ### Bearer token
 
@@ -61,7 +61,7 @@ The cookie is `HttpOnly` and `SameSite=Strict` (and `Secure` when served over HT
 So for cookie-authenticated requests, gmuxd enforces **same-origin**:
 
 - **WebSocket upgrades** must originate from the gmux origin itself. This closes cross-origin WebSocket hijacking of terminal I/O, the highest-value path.
-- **State-changing requests** (`POST`/`PUT`/`PATCH`/`DELETE` on `/v1/`) must carry `Sec-Fetch-Site: same-origin` or an `Origin` header matching the request's own host. Anything else gets `403`.
+- **State-changing requests** — any `POST`/`PUT`/`PATCH`/`DELETE`, on any path — must carry `Sec-Fetch-Site: same-origin`; browsers that don't send fetch metadata fall back to an `Origin` header matching the request's own host. Anything else gets `403`.
 - **Reads over `GET`** are exempt: gmuxd never emits CORS headers, so a foreign page cannot read the response anyway.
 
 The check is a single dynamic comparison against the request's **own** Host (honoring `X-Forwarded-Host` behind proxies that rewrite it) — whatever hostname the browser used to load the UI is, by definition, the hostname it sends in both `Origin` and `Host`. Localhost, LAN IPs, tailnet FQDNs, and reverse-proxy vhosts (e.g. Traefik routing `gmux.example.com`) all work without configuration.
@@ -71,6 +71,14 @@ The check is a single dynamic comparison against the request's **own** Host (hon
 The UI also sends `Content-Security-Policy: frame-ancestors 'none'` and `X-Frame-Options: DENY` on every response, so gmux can never be embedded in another page's frame.
 
 The full decision record is [ADR 0020](https://github.com/gmuxapp/gmux/blob/main/docs/adr/0020-same-origin-enforcement-for-cookie-auth.md).
+
+The login page itself is self-contained: no external resources are loaded before authentication (the brand font is embedded), so nothing leaks pre-auth and it works air-gapped.
+
+### Local filesystem safeguards
+
+- Per-session runner sockets live in a per-user directory under the state dir (`~/.local/state/gmux/run/sessions`, mode 0700) — never in world-shared `/tmp`, where another local user could squat the directory.
+- Clipboard paste files are created with `0600` permissions so pasted secrets aren't readable by other local users.
+- Session IDs and slugs are validated against a strict allowlist before any filesystem or URL use, so an attacker-influenced ID can't carry `..` or path separators into the state directory.
 
 ## Remote access: Tailscale
 
@@ -101,7 +109,7 @@ gmux faces the same security problem as [Jupyter](https://jupyter-server.readthe
 
 **You don't lose anything.** The token is a plain file on disk at `~/.local/state/gmux/auth-token`. Any integration that needs programmatic access can read it and set the `Authorization: Bearer <token>` header. A reverse proxy like Traefik can inject the token into forwarded requests via a headers middleware, so you never interact with it directly.
 
-For container deployments, the `GMUXD_TOKEN` environment variable can seed the token file on first start. If a token file already exists, the env var must match or gmuxd refuses to start. The variable is unset from the process after consumption so child shells don't inherit it. See [Environment variables](/reference/environment/#auth-token) for details.
+For container deployments, the `GMUXD_TOKEN` environment variable can seed the token file on first start. User-provided tokens must be at least 64 hex characters (256 bits) — the same strength as auto-generated ones. If a token file already exists, the env var must match or gmuxd refuses to start. The variable is unset from the process after consumption so child shells don't inherit it. See [Environment variables](/reference/environment/#auth-token) for details.
 
 The file remains the primary storage. Environment variables are inherited by child processes, visible in `/proc/*/environ`, and tend to appear in CI logs and Docker inspect output. CLI flags show up in `ps` and shell history. A file with `0600` permissions is the smallest attack surface for a long-lived secret. The env var is a provisioning convenience for containers, not a replacement for the file.
 
@@ -111,7 +119,7 @@ The [`examples/`](https://github.com/gmuxapp/gmux/tree/main/examples) directory 
 
 ## Config validation
 
-The config file is strictly validated at startup. Silent fallback to defaults is dangerous for security settings: a typo like `alow` instead of `allow` would silently result in an empty allow list. See [host.toml reference](/reference/host-toml/#strict-validation) for the full list of rules.
+The config file is strictly validated at startup. Silent fallback to defaults is dangerous for security settings: a typo like `alow` instead of `allow` would silently result in an empty allow list. Keys removed in 2.0 (`tailscale.hostname`, `[[peers]]`, `discovery.tailscale`) produce a warning instead of an error, so an old config won't brick the daemon. See [host.toml reference](/reference/host-toml/#strict-validation) for the full list of rules.
 
 ## Recommendations
 

--- a/apps/website/src/content/docs/troubleshooting.md
+++ b/apps/website/src/content/docs/troubleshooting.md
@@ -5,7 +5,7 @@ description: Common problems and how to fix them.
 
 ## Dashboard doesn't open / "gmuxd is not running"
 
-`gmux` auto-starts `gmuxd` on first run. If the dashboard doesn't appear at [localhost:8790](http://localhost:8790), `gmuxd` may have failed to start.
+`gmux open` (and any session launch) auto-starts `gmuxd` if it isn't running. If the dashboard doesn't appear at [localhost:8790](http://localhost:8790), `gmuxd` may have failed to start.
 
 **Check the log:**
 
@@ -13,10 +13,12 @@ description: Common problems and how to fix them.
 cat $(gmux daemon log-path)
 ```
 
+If the daemon was auto-started by `gmux open`, startup errors may instead be in `$TMPDIR/gmuxd.log`.
+
 Common causes:
 
 - **Port already in use** — something else is on port 8790. Change it in `~/.config/gmux/host.toml` (`port = 9999`).
-- **Config file error** — gmuxd refuses to start with unknown keys or invalid values. The log will say which key. See [host.toml reference](/reference/host-toml/#strict-validation).
+- **Config file error** — gmuxd refuses to start with unknown keys or invalid values. The log will say which key. (Keys removed in 2.0 only produce a warning.) See [host.toml reference](/reference/host-toml/#strict-validation).
 - **`gmuxd` not in PATH** — `gmux` looks for `gmuxd` as a sibling binary first, then in `PATH`. Make sure both are installed together (e.g. via `brew install gmuxapp/tap/gmux`).
 
 **Start manually to see errors immediately:**
@@ -29,13 +31,21 @@ This runs the daemon in the foreground so you can see errors directly. Use `gmux
 
 ## Sessions don't appear in the sidebar
 
-- **No project configured.** gmux discovers session groups but doesn't add them to the sidebar automatically. Click **Add project** in the empty state, or the **Manage projects** button. Unmatched sessions show a badge count on the manage button.
+- **No project configured.** gmux discovers sessions but doesn't add them to the sidebar automatically. Open **Settings → Projects** (gear button) and add the project from the *Discovered* list, or click **Add a project** in the empty state.
 - **Session exited immediately.** If the command exits before gmuxd discovers it, it won't appear. Check if the command works when run directly (outside of `gmux`).
-- **Different daemon.** If you have multiple gmux installs (e.g. Homebrew and a dev build), `gmux` and `gmuxd` might not be talking to the same instance. Run `gmux daemon status` to check which binary is running.
+- **Different daemon.** If you have multiple gmux installs (e.g. Homebrew and a dev build), `gmux` and `gmuxd` might not be talking to the same instance. Run `gmux daemon status` to see the running daemon's version and socket path and compare against `gmux version`.
 
 ## "outdated" badge on a session
 
-After updating gmux, sessions that were started with the old version show an **outdated** tag. The session still works, but the runner binary doesn't match the daemon. Kill and relaunch the session to pick up the new version.
+After updating gmux, sessions that were started with the old version show an **outdated** tag. The session still works, but the runner binary doesn't match the daemon. Restart the session (session **⋮** menu → Restart) to pick up the new version.
+
+## Session fails to launch: working directory missing
+
+If a session's directory was deleted (e.g. a removed worktree), launch fails with a working-directory error. Resuming an existing session whose directory is gone falls back to the project's canonical folder instead.
+
+## Actions fail with 403 behind a reverse proxy
+
+gmuxd rejects cross-origin cookie-authenticated mutations and WebSocket upgrades (see [Security](/security/#browser-sessions-same-origin-enforcement)). A proxy that rewrites the `Host` header must forward the browser-facing host in `X-Forwarded-Host`; programmatic clients should use bearer-token auth instead of the cookie.
 
 ## WebSocket disconnects / terminal goes blank
 
@@ -61,12 +71,12 @@ See the [Remote Access troubleshooting section](/remote-access/#troubleshooting)
 
 ## Updating
 
-It's safe to update gmux while sessions are running; they reconnect automatically. gmux checks for new releases in the background and notifies you in the dashboard sidebar and when you run `gmux` with no arguments.
+It's safe to update gmux while sessions are running; they reconnect automatically. gmux checks for new releases in the background and notifies you in the dashboard and when you run `gmux open` or `gmux daemon status`. Open dashboard tabs reload themselves after the daemon updates.
 
 After updating, the old daemon is replaced automatically:
 
 - **Homebrew**: the postflight hook restarts the daemon during install
 - **`curl | sh` installer**: restarts the daemon if it was running
-- **Manual installs**: the next `gmux` invocation detects the version mismatch and replaces the daemon
+- **Manual installs**: the next `gmux open` (or session launch) detects the version mismatch and replaces the daemon
 
 To force a restart manually: `gmux daemon restart` (or just `gmux daemon start`, which replaces any running instance).

--- a/apps/website/src/content/docs/using-the-ui.md
+++ b/apps/website/src/content/docs/using-the-ui.md
@@ -11,21 +11,19 @@ The left panel lists your sessions grouped into projects.
 
 ### Logo
 
-Click the **gmux** logo at the top of the sidebar to return to the home screen.
+Click the **gmux** logo at the top of the sidebar to return to the home screen. The logo doubles as a cue: it lights up when a session elsewhere is waiting on you. The gear button next to it opens **Settings**; a red pip on the gear flags unresolved host references.
 
-## Home screen
+## Home: the Activity dashboard
 
-The home screen shows your hosts, projects, and quick-launch buttons.
+The home screen is a pure overview of your sessions across all hosts, newest-first:
 
-### Host cards
+- **Waiting** — sessions with unread output that need your attention.
+- **Active** — sessions where the agent or command is currently working.
+- **Recency buckets** — everything else, grouped by last activity (last hour, earlier today, yesterday, earlier this week…).
 
-Each machine (local and remote) gets a card with a status indicator, session count, and launch buttons.
+An **Enable notifications** pill in the Activity header opts into browser notifications. Project and host management live in **Settings** (gear button in the sidebar header).
 
-| Indicator | Meaning |
-|-----------|---------||
-| **Green dot** | Connected, sessions visible |
-| **Pulsing dot** | Connecting to peer |
-| **Red ✗** | Peer disconnected (shows error reason) |
+## Settings → Hosts
 
 Hosts you add via **Settings → Hosts → Connect to host** persist across restarts and reconnect automatically. gmux does not auto-discover tailnet machines — adding one is an explicit, token-authenticated step (see [Multi-Machine](/multi-machine/) and [ADR 0008](https://github.com/gmuxapp/gmux/blob/main/docs/adr/0008-peer-authentication-via-token.md)).
 
@@ -40,68 +38,56 @@ In **Settings → Hosts**, each host shows an explicit status:
 
 Removing a host also clears the project references that pointed at it, so it leaves nothing behind under **Referenced but not found**.
 
-**Upgrading to 2.0:** hosts you had projects on — that earlier versions auto-discovered on your tailnet — are migrated into the roster as **Auth needed**. Click **Add token** on each and paste its token (run `gmux auth` on that host) to bring it back online. Other tailnet machines aren't carried over; re-add them with **Connect to host** if you want them. Your `projects.json` is backed up to `projects.json.bak` before the upgrade rewrites it.
+**Upgrading to 2.0:** hosts you had projects on — that earlier versions auto-discovered on your tailnet — are migrated into the roster as **Auth needed**. Click **Add token** on each and paste its token (run `gmux auth` on that host) to bring it back online. Other tailnet machines aren't carried over; re-add them with **Connect to host** if you want them. Your `projects.json` is backed up to `projects.json.bak` before the upgrade rewrites it. See the [migration guide](/migrating-to-2/) for the full 2.0 upgrade story.
 
-Connected peers show launch buttons for each configured adapter, just like the local host.
+## Projects
 
-### Projects
+Sessions don't appear in the sidebar until you add a project. The first time you open the dashboard, click the **+** button to launch a session. gmux creates a default "home" project that catches sessions started in your home directory itself. As you work in more repositories, open **Settings → Projects** to organize sessions by repo.
 
-Sessions don't appear in the sidebar until you add a project. The first time you open the dashboard, click the **+** button to launch a session. gmux creates a default "home" project that catches sessions started from your home directory. As you work in more repositories, use **Manage projects** to organize sessions by repo.
+Click a **project name** to open the [project hub](#project-hub), an overview of all sessions in that project. The active project is highlighted in the sidebar.
 
-Click a **project name** to open the [project hub](#project-hub), an overview of all sessions in that project grouped by host and working directory. The active project is highlighted in the sidebar.
+Each project has **match rules** that determine which sessions belong to it. Rules can match by filesystem path (`~/dev/gmux` and its subdirectories) or by git remote URL (grouping clones across machines). See [`projects.json`](/reference/projects-json/) for the full reference on rules, precedence, and advanced options like exact matching.
 
-Each project has **match rules** that determine which sessions belong to it. Rules can match by filesystem path (`~/dev/gmux` and its subdirectories) or by git remote URL (grouping clones across machines). See [`projects.json`](/reference/projects-json/) for the full reference on rules, precedence, and advanced options like exact matching and host scoping.
-
-You can manage projects at any time via the **Manage projects** button at the bottom of the sidebar. A badge shows when there are running sessions that don't match any project yet. The modal has two sections:
+You can manage projects at any time in **Settings → Projects** (gear button in the sidebar header, or the `?settings` URL parameter):
 
 - **Your projects**: configured projects with their match rules. Drag to reorder, click **×** to remove.
-- **Discovered**: directories with running sessions that don't match any project. Type to filter, or enter a path to add directly.
+- **Discovered**: directories gmux noticed sessions in that don't match any project — including directories advertised by peer hosts. Type to filter, click **Add**, or enter a local path manually.
 
-### Sessions
+## Sessions
 
 Each session has a dot on the left edge:
 
 | Indicator | Meaning |
 |-----------|---------|
 | **Pulsing ring** | The tool is actively working (building, thinking, running tests) |
-| **Blue dot** | New output you haven't seen yet (viewing the session clears it) |
+| **Cyan dot** | New output you haven't seen yet (viewing the session clears it) |
+| **Red dot** | The agent reported an error |
 | **Muted ring** (brief) | Transient terminal activity, fades after a few seconds |
 | **No dot** | Idle or waiting for input |
 
-Agent sessions (pi, Claude, Codex) only trigger the blue unread dot when the assistant completes a turn, not on every line of output.
+Agent sessions (pi, Claude, Codex) only trigger the unread dot when the assistant completes a turn, not on every line of output.
 
 Hover over a session to reveal the **×** button. This dismisses the session: live runners are killed, the sidebar/project membership is removed, and persisted runtime metadata is dropped so the session does not come back as resumable. Use **Resume** from a dead session view only when you want to continue it.
 
 ## Project hub
 
-Click a project name in the sidebar (or navigate to `/:project`) to see the project hub. This is an overview of every session in the project, grouped first by host, then by working directory.
+Click a project name in the sidebar (or navigate to `/:project`) to see the project hub — an overview of every session in the project, mirroring the home layout: **Waiting**, **Active**, and **All sessions** rows, newest-first.
 
-### Host sections
-
-Each host gets a section with a status indicator and a breadcrumb path showing the topology chain. For example, a devcontainer running on a remote peer might show `workstation › alpine-dev`. Status indicators:
-
-| Indicator | Meaning |
-|-----------|---------|
-| **Accent dot** | Local host |
-| **Green dot** | Connected remote peer |
-| **Pulsing yellow dot** | Reconnecting to peer |
-| **Red dot** | Peer disconnected |
-
-### Folder rows
-
-Within each host, sessions are grouped by their working directory. Each folder row shows a path label and the session cards underneath. A **+** button on each row lets you launch a new session in that directory on that host.
-
-### Session cards
-
-Each card shows a status dot and the session title. Click a card to attach to that session's terminal. The **×** button dismisses the session, killing it first if it is still alive.
-
-### Empty projects
-
-If a project has no sessions yet, the hub shows the project's configured path with a **+** launcher to get started.
+When every session shares the same working directory, it appears once as a subtitle; otherwise each row shows its own directory. If the project spans hosts, rows carry an `@host` suffix (devcontainer sessions get a container icon). The **+** in the hub header launches a new session in the project's canonical directory — for a referenced project this routes to the owning machine. If a project has no sessions yet, the hub shows the project's configured path with a **+** launcher to get started.
 
 ## The terminal
 
-Click a session to attach. You get a full interactive terminal powered by [xterm.js](https://xtermjs.org/). Colors, cursor positioning, mouse support, and images all work. The header bar shows the session title and, while an agent is busy, a working/error status indicator.
+Click a session to attach. You get a full interactive terminal powered by [xterm.js](https://xtermjs.org/). Colors, cursor positioning, mouse support, and images all work. The header bar shows the session title and a status chip: **Working…**/**Error** while an agent is busy, **Exited (N)** for dead sessions, **Resuming…** during a resume.
+
+### Find in terminal
+
+Press **Cmd/Ctrl+F** (or use the session **⋮** menu → *Find in terminal*) to open a floating find bar over the terminal. Search is incremental; step through matches with Enter/Shift+Enter or the ‹ › buttons, and press Escape to close. This replaces the browser's in-page find, which can't see into a canvas-rendered terminal.
+
+### Session menu
+
+The **⋮** menu in the terminal header offers *Find in terminal*, one lifecycle action (**Restart** for alive sessions; **Resume** or **Rerun** for dead ones — dead sessions also show the same action as a primary button over the replay), and session info (adapter, version, host). An **outdated** badge appears when the session's runner binary is stale relative to the daemon — restart the session to pick up the new version.
+
+Backend or action failures surface as error toasts.
 
 ## Launching sessions
 
@@ -112,16 +98,19 @@ gmux -- pi              # coding agent
 gmux -- pytest --watch  # any command
 ```
 
+```bash
+gmux -d -- make build   # detached; prints the session id
+gmux edit notes.md      # editor session; also works as $EDITOR
+```
+
 ### From the UI
 
-There are several places to launch:
+There are two places to launch:
 
-- **Sidebar header**: click the **+** button at the top of the sidebar to launch in the default directory.
 - **Sidebar project**: hover a project name to reveal a **+** button. It launches in the project's own directory — the first configured path for a project you own, or the upstream directory for a [referenced](/multi-machine) project (which routes to the owning machine) — regardless of which session you're currently viewing.
 - **Project hub**: the **+** in the header launches in that same project directory, routing to the owning machine for referenced projects.
-- **Home screen**: quick-launch buttons for starting a session without any project context.
 
-All launch menus show the available adapters (Shell, pi, Claude Code, Codex). The first item aligns with the **+** button so a double-click launches the default adapter instantly.
+Launch menus show the adapters available on that host (by default: Shell, pi, Claude Code, Codex, Editor — whichever are installed). The first item aligns with the **+** button so a double-click launches the default adapter instantly.
 
 ## URL routing
 
@@ -129,9 +118,10 @@ Every view has a stable URL:
 
 | URL pattern | What it shows |
 |-------------|---------------|
-| `/` | Home: host status, projects, quick launch |
+| `/` | Home: the Activity dashboard |
 | `/:project` | Project hub overview |
 | `/:project/:adapter/:slug` | A specific session's terminal |
+| `/@:owner/:project/...` | A project owned by a peer host |
 
 For example, `/gmux/pi/fix-auth-bug` links directly to a pi session in the gmux project. URLs update as you navigate, work with browser back/forward, and are bookmarkable. Session slugs remain stable across kill and resume.
 
@@ -145,6 +135,7 @@ gmux ships a complete default keymap. Keys not listed here go straight to the te
 |----------|--------|
 | **Shift+Enter** | Sends a plain newline (`\n`) instead of Enter |
 | **Ctrl+C** | If text is selected: copy to clipboard. Otherwise: sends SIGINT |
+| **Cmd/Ctrl+F** | Open find-in-terminal (replaces the browser's in-page find) |
 
 ### Linux / Windows
 
@@ -156,6 +147,8 @@ gmux ships a complete default keymap. Keys not listed here go straight to the te
 | **Ctrl+Alt+T** | Sends Ctrl+T (browser steals Ctrl+T) |
 | **Ctrl+Alt+N** | Sends Ctrl+N (browser steals Ctrl+N) |
 | **Ctrl+Alt+W** | Sends Ctrl+W (browser steals Ctrl+W) |
+| **Ctrl+Backspace** | Delete word backward |
+| **Ctrl+Delete** | Delete word forward |
 
 ### Mac
 
@@ -181,15 +174,19 @@ If you prefer every Cmd+character to send its Ctrl equivalent (Cmd+A = beginning
 
 ## Mobile
 
-Open the same URL on your phone (or via [remote access](/remote-access)). The sidebar slides in from the left (tap ☰), and a bottom bar provides keys that phones don't have:
+Open the same URL on your phone (or via [remote access](/remote-access)). The sidebar slides in from the left (tap ☰ — a badge on it flags waiting sessions), and a bottom toolbar provides keys that phones don't have:
 
 | Button | Sends |
 |--------|-------|
+| **☰** | Opens the sidebar |
 | **esc** | Escape |
 | **tab** | Tab |
 | **ctrl** | Arms Ctrl for the next key (tap ctrl, then c = Ctrl+C) |
 | **alt** | Arms Alt for the next key |
-| **← →** | Arrow keys (hold to repeat) |
-| **▶** | Send (Enter) |
+| **← ↑ ↓ →** | Arrow keys (hold to repeat) |
+| **⇤ ⇥** | Word-jump left / right |
+| **▶** | Send (Enter; Alt+Enter when alt is armed) |
 
-When **ctrl** is armed, the toolbar transforms: **esc** and **tab** become **↑** and **↓** arrow keys, **▶** (send) becomes **paste**, and **← →** switch to word-jump navigation. The toolbar returns to normal after the next keypress or when you tap ctrl again.
+When **ctrl** or **alt** is armed, the key highlights and applies to the next key you press — on the toolbar or the on-screen keyboard — then disarms. Keys never change meaning. When you've scrolled up, an extra key jumps back to the bottom. The toolbar works with the keyboard closed, and on narrow phones it wraps into two rows.
+
+Long-press a link in the terminal to copy it or open it in a new tab. Paste goes through the paste keybind or long-press, not a toolbar key.

--- a/services/gmuxd/cmd/gmuxd/remote.go
+++ b/services/gmuxd/cmd/gmuxd/remote.go
@@ -186,7 +186,7 @@ func remoteStatus(stdout, stderr io.Writer) int {
 		fmt.Fprintln(stdout, "Remote access is enabled but the daemon is not running.")
 		fmt.Fprintln(stdout)
 		fmt.Fprintln(stdout, "Start it with:")
-		fmt.Fprintln(stdout, "  gmuxd start")
+		fmt.Fprintln(stdout, "  gmux daemon start")
 		return 0
 	}
 
@@ -283,7 +283,7 @@ func remotePoll(stdout, stderr io.Writer) int {
 	if result == nil || result.TS == nil {
 		fmt.Fprintln(stdout)
 		fmt.Fprintln(stderr, "Could not reach the daemon. Check that it's running:")
-		fmt.Fprintln(stderr, "  gmuxd start")
+		fmt.Fprintln(stderr, "  gmux daemon start")
 		return 1
 	}
 
@@ -300,7 +300,7 @@ func displayStatus(h *tailscaleHealth, stdout io.Writer) int {
 		fmt.Fprintln(stdout, "To complete setup, log in to Tailscale:")
 		fmt.Fprintf(stdout, "  %s\n", ts.AuthURL)
 		fmt.Fprintln(stdout)
-		fmt.Fprintln(stdout, "After logging in, run `gmuxd remote` again to check the connection.")
+		fmt.Fprintln(stdout, "After logging in, run `gmux remote` again to check the connection.")
 		fmt.Fprintln(stdout)
 		fmt.Fprintf(stdout, "Docs: %s\n", remoteDocsURL)
 		return 0
@@ -343,7 +343,7 @@ func displayStatus(h *tailscaleHealth, stdout io.Writer) int {
 	fmt.Fprintln(stdout, "Tailscale is still connecting. This can take a minute on first setup.")
 	fmt.Fprintln(stdout)
 	fmt.Fprintln(stdout, "Try again shortly:")
-	fmt.Fprintln(stdout, "  gmuxd remote")
+	fmt.Fprintln(stdout, "  gmux remote")
 	fmt.Fprintln(stdout)
 	fmt.Fprintf(stdout, "Docs: %s\n", remoteDocsURL)
 	return 0

--- a/services/gmuxd/cmd/gmuxd/remote_test.go
+++ b/services/gmuxd/cmd/gmuxd/remote_test.go
@@ -230,8 +230,8 @@ func TestDisplayStatus_NeedsLogin(t *testing.T) {
 	if !strings.Contains(out, "https://login.tailscale.com/a/abc123") {
 		t.Errorf("missing auth URL in:\n%s", out)
 	}
-	if !strings.Contains(out, "gmuxd remote") {
-		t.Errorf("should tell user to run gmuxd remote again:\n%s", out)
+	if !strings.Contains(out, "gmux remote") {
+		t.Errorf("should tell user to run gmux remote again:\n%s", out)
 	}
 	// Should NOT mention HTTPS or MagicDNS problems.
 	if strings.Contains(out, "HTTPS") || strings.Contains(out, "MagicDNS") {

--- a/services/gmuxd/internal/netauth/netauth.go
+++ b/services/gmuxd/internal/netauth/netauth.go
@@ -463,7 +463,7 @@ func serveLoginPage(w http.ResponseWriter, errMsg string) {
            autocapitalize="off" autocorrect="off" spellcheck="false">
     <button type="submit">Sign in</button>
   </form>
-  <p class="hint">Run <code>gmuxd auth</code> on the host for instructions.</p>
+  <p class="hint">Run <code>gmux auth</code> on the host for instructions.</p>
 </main>
 <p class="tip">One gmux can show every machine's sessions in a single sidebar. <a href="https://gmux.app/multi-machine/" target="_blank" rel="noopener">Multi-machine setup →</a></p>
 </body>


### PR DESCRIPTION
Full documentation refresh for the upcoming 2.0 release, plus a new **Migrating to 2.0** guide. Every docs page (and the README) was audited against current code with `file:line` evidence; changes below fix claims that no longer hold since v1.6.0 and document the new surface.

## New page

- **`/migrating-to-2/`** — one section per breaking change (CLI, multi-machine/tokens, API/schema renames, adapter API, behavior changes, UI relocations), each with who's affected, before → after, and migration steps. Linked from the sidebar (after Getting Started), the CLI reference, and using-the-ui.

## Breaking changes covered

verb-first CLI (#314) · wire protocol v2 (#247/#224) · token-authenticated peers, autodiscovery removed (#265/#280/#282) · frozen peer names / node-id anchor (#331, ADR 0017) · `kind`→`adapter` / `session_file`→`conversation_file` (#352) · adapter API: FileMonitor/FileAttributor removed, `Status.label` removed, runner scrollback endpoints removed (#315/#323/#329) · same-origin enforcement (#358) · socket dir move (#295/#359) · retention/persistent dead sessions (#333/#338) · codex hooks ≥ 0.135.0 (#319) · devcontainer label requirement · projects.json v3 · fresh login env (#246) · `EDITOR` defaulting (#356)

## Page → changes

| Page | Main changes |
|---|---|
| README | Verb-first quick start; **removed the unshipped probes feature entirely**; fixed stateless-gmuxd/Nord/`./dev` claims; added scripting, multi-machine, `gmux edit` |
| getting-started | "Add project" → Settings → Projects; CLI-verbs pointer |
| using-the-ui | Home rewritten as Activity dashboard; hosts material → Settings → Hosts; Manage projects → Settings; project hub rewrite (rows, no breadcrumbs); find-in-terminal; ⋮ session menu; error dot; mobile toolbar rework; new keybind rows |
| configuration | Runtime-state section (peers.json, auth-token, projects.json) |
| adapters | Hook-driven model; editor adapter; `GMUX_ADAPTER` validation; status booleans |
| architecture | sessionmeta persistence (not "stateless"); conversation sources; runner registration; API table additions |
| security | Same-origin precedence fix; `/v1/shutdown`; GMUXD_LISTEN validation; filesystem-safeguards section; token strength |
| multi-machine | **Rename section rewritten per ADR 0017** (old text documented superseded behavior); protocol table fixes; 2.0-together note |
| remote-access | `gmux-<hostname>` URLs; GMUXD_TS_HOSTNAME; peer-pairing subsection |
| troubleshooting | gmux open auto-start; $TMPDIR log; new entries (missing cwd, 403 behind proxy) |
| devcontainers | `devcontainer.local_folder` label requirement; stop/start behavior fix; 2.0 rebuild note |
| running-in-docker | Login/token step in the tailscale quick start; per-example `GMUXD_LISTEN`; connect-to-main-gmux |
| reference/cli | ADAPTER column; `gmux edit`; send access-control fix; daemon-status output fix |
| reference/settings | Regenerated (new `find` action); restore-browser-find template added to the generator |
| reference/environment | Retention vars, GMUXD_TS_HOSTNAME, GMUX_EDIT_FALLBACK, EDITOR/VISUAL, hook adapters |
| reference/file-paths | node-id, sessions/<id> meta+scrollback, shell-sessions, claude/codex paths, log split, legacy socket note |
| reference/host-toml | Third deprecated key (`discovery.tailscale`); bind-address pointer |
| reference/projects-json | Version 3; `hosts` removed; peer reference items; validation/migration updates |
| develop/writing-adapters | `Monitor → *Event`; real Status struct; capability table incl. editor; hook/prober/registrar/passthrough sections |
| develop/adapter-architecture | Endpoint table fix (no `PATCH /meta`); resume via sessionmeta; hook injection; examples rewrite |
| develop/session-schema | Dropped fictional `resume_key`/`stale`/OSC-7777; protocol-2 transport; new fields; hook as primary status path |
| develop/state-management | Protocol-2 frontend rewrite; optimistic overlay; permanent dismiss; `--resume-id` |
| develop/integration-tests | `Slug`-based attribution; harness env; hook-vs-file notes |
| develop/terminal-data-pipeline | **Full rewrite** — vt emulator + on-disk scrollback tee (the documented "TermWriter" never existed) |
| integrations/{pi,claude-code,codex} | Hook-driven status rewrites; codex ≥ 0.135.0; passthrough; title/slug behavior; fixed `GMUX_ADAPTER` wrapper examples |
| integrations/scripts-and-agents | adapter terminology; `wait` local-only; `ls --all`; send-keys; `$EDITOR` section |
| planned/* | Status banners on pages overtaken by reality (folder-management/notifications/versioning implemented; session-persistence superseded by ADR 0016; opencode blocker gone) |

## Verification

- `pnpm build` (apps/website): 41 pages, clean.
- `pnpm lint`: green.
- settings/theme regenerated via `scripts/generate-reference.ts`.

## Follow-ups flagged (code, not docs)

- `gmuxd remote` output and the login page still say `gmuxd remote`/`gmuxd auth`; docs standardize on `gmux …` per ADR 0009.
- `testutil/harness.go` still calls the removed runner `/scrollback/text`.
- If the in-flight `tag:` allow-list change lands before 2.0, host-toml's "must contain `@`" rule needs an update.
- Consider promoting `planned/{folder-management,notifications,versioning}` out of planned/ — banners added for now.
