### PR TITLE
feat(peering): reconnect immediately when a browser client connects

### DIFF
--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -670,8 +670,23 @@ func serve(stderr io.Writer) int {
 
 	// ── Presence + Notification router ──
 
+	// peerManager is initialized later after config is loaded. Declared
+	// here (ahead of the presence callbacks and various handler closures
+	// that capture it) so it can be referenced before assignment; all
+	// uses run at request time, after Start().
+	var peerManager *peering.Manager
+
 	notifRouter := (*notify.Router)(nil) // assigned after presence table
 	presenceTable := presence.New(presence.Callbacks{
+		OnClientConnected: func(clientID string) {
+			// A browser client just connected: the user is here and
+			// wants current data. Nudge dial-out-only peers to retry
+			// now instead of waiting out a backoff, so a peer that
+			// came online while we were backing off shows up promptly.
+			if peerManager != nil {
+				peerManager.ReconnectAll()
+			}
+		},
 		OnClientFocused: func(clientID string) {
 			if notifRouter != nil {
 				notifRouter.CancelAllPending()
@@ -716,11 +731,6 @@ func serve(stderr io.Writer) int {
 	if err != nil {
 		log.Fatalf("FATAL: %v", err)
 	}
-
-	// peerManager is initialized later after config is loaded. Closures
-	// (reconcileProjectStamps, buildSessionInfos call sites) capture this
-	// pointer so handlers work once it's set.
-	var peerManager *peering.Manager
 
 	// Project manager handles concurrent access to projects.json and
 	// auto-assignment of sessions to projects.

--- a/services/gmuxd/internal/peering/manager.go
+++ b/services/gmuxd/internal/peering/manager.go
@@ -132,6 +132,21 @@ func (m *Manager) OnSleep() {
 	}
 }
 
+// ReconnectAll signals every peer to retry immediately, cutting short
+// any backoff wait. Used when an external event suggests peers may now
+// be reachable — e.g. a browser client connecting (the user opened or
+// returned to the UI and wants to see peer sessions promptly). Peering
+// is dial-out only, so without a nudge like this a just-online peer is
+// only discovered on its next scheduled retry. A healthy connected
+// peer is unaffected: the signal only shortcuts the reconnect wait.
+func (m *Manager) ReconnectAll() {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	for _, mp := range m.peers {
+		mp.peer.Reconnect()
+	}
+}
+
 // Stop cancels all peer connections and waits for goroutines to finish.
 func (m *Manager) Stop() {
 	if m.cancel != nil {

--- a/services/gmuxd/internal/peering/peer.go
+++ b/services/gmuxd/internal/peering/peer.go
@@ -69,6 +69,16 @@ type Peer struct {
 	// Zero means use initialBackoff. Test-only: lets the reconnect
 	// tests run at millisecond cadence instead of real seconds.
 	reconnectBackoff time.Duration
+
+	// wake shortcuts the reconnect backoff wait. A signal here makes a
+	// backing-off peer retry immediately and resets its backoff to the
+	// initial interval. Buffered (cap 1) and sent non-blocking, so a
+	// signal that arrives while the peer is connected (not waiting)
+	// simply queues and is consumed at the next disconnect — harmless.
+	// Peering is dial-out only, so this is the only way an external
+	// event (e.g. a browser client connecting) can pull a just-online
+	// peer in faster than the backoff schedule.
+	wake chan struct{}
 }
 
 func newPeer(cfg config.PeerConfig, st *store.Store, onStatus func(string, Status), opts ...PeerOption) *Peer {
@@ -77,6 +87,7 @@ func newPeer(cfg config.PeerConfig, st *store.Store, onStatus func(string, Statu
 		store:    st,
 		status:   StatusDisconnected,
 		onStatus: onStatus,
+		wake:     make(chan struct{}, 1),
 	}
 	for _, o := range opts {
 		o(p)
@@ -95,6 +106,18 @@ func newPeer(cfg config.PeerConfig, st *store.Store, onStatus func(string, Statu
 	apiOpts = append(apiOpts, apiclient.WithStreamIdleTimeout(idleTimeout))
 	p.api = apiclient.New(cfg.URL, apiOpts...)
 	return p
+}
+
+// Reconnect signals the run loop to stop waiting out its backoff and
+// retry immediately, resetting backoff to the initial interval. Safe
+// to call at any time and from any goroutine: the send is
+// non-blocking, so it never stalls the caller, and a signal delivered
+// while the peer is connected (or already pending) is coalesced.
+func (p *Peer) Reconnect() {
+	select {
+	case p.wake <- struct{}{}:
+	default:
+	}
 }
 
 // Status returns the current connection state.
@@ -358,6 +381,14 @@ func (p *Peer) run(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			return
+		case <-p.wake:
+			// External trigger (e.g. a browser client connected):
+			// retry now and start over from the initial backoff so a
+			// peer that just came online is picked up promptly rather
+			// than after a grown wait.
+			backoff = minBackoff
+			lastLogged = ""
+			continue
 		case <-time.After(backoff):
 		}
 

--- a/services/gmuxd/internal/peering/peer_error_test.go
+++ b/services/gmuxd/internal/peering/peer_error_test.go
@@ -206,3 +206,61 @@ func TestRun_LogsAgainAfterReconnect(t *testing.T) {
 		t.Errorf("want a disconnect log per post-reconnect drop, got %d\nlogs:\n%s", got, buf.String())
 	}
 }
+
+// TestReconnect_ShortcutsBackoffWait verifies that Reconnect() cuts a
+// long backoff wait short: an external nudge makes a backing-off peer
+// retry promptly instead of waiting out the full interval.
+func TestReconnect_ShortcutsBackoffWait(t *testing.T) {
+	ft := &failingTransport{errs: []error{errors.New("connection refused")}}
+	p := newPeer(config.PeerConfig{Name: "down", URL: "http://spoke.invalid"}, store.New(), nil,
+		WithTransport(ft))
+	// Large backoff: without a nudge the second attempt would be ~30s away.
+	p.reconnectBackoff = 30 * time.Second
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		p.run(ctx)
+		close(done)
+	}()
+	defer func() { cancel(); <-done }()
+
+	// Wait for the first (immediate) attempt, then confirm we're parked
+	// in the backoff wait (no second attempt yet).
+	waitForAttempts(t, ft, 1)
+	time.Sleep(50 * time.Millisecond)
+	if got := ft.count(); got != 1 {
+		t.Fatalf("expected to be waiting out backoff after 1 attempt, got %d", got)
+	}
+
+	// Nudge: a second attempt should follow quickly despite the 30s wait.
+	p.Reconnect()
+	waitForAttempts(t, ft, 2)
+}
+
+// TestReconnect_NonBlockingAndCoalesced verifies Reconnect() never
+// blocks and repeated calls collapse to at most one pending wake.
+func TestReconnect_NonBlockingAndCoalesced(t *testing.T) {
+	p := newPeer(config.PeerConfig{Name: "x", URL: "http://spoke.invalid"}, store.New(), nil)
+	// No run loop consuming the channel: every call must still return.
+	for i := 0; i < 100; i++ {
+		p.Reconnect()
+	}
+	// Exactly one signal buffered; the rest were dropped.
+	if got := len(p.wake); got != 1 {
+		t.Errorf("want 1 buffered wake after repeated calls, got %d", got)
+	}
+}
+
+// waitForAttempts blocks until the transport has seen at least n
+// attempts or fails the test after a generous deadline.
+func waitForAttempts(t *testing.T, ft *failingTransport, n int) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for ft.count() < n {
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %d attempts (got %d)", n, ft.count())
+		}
+		time.Sleep(time.Millisecond)
+	}
+}

--- a/services/gmuxd/internal/presence/presence.go
+++ b/services/gmuxd/internal/presence/presence.go
@@ -26,6 +26,11 @@ type Client struct {
 // Callbacks lets the notification router react to presence changes
 // synchronously inside Update(). Set these before any clients connect.
 type Callbacks struct {
+	// OnClientConnected fires after a new browser client is registered.
+	// It's the "a user is here and wants fresh data" signal — used to
+	// nudge dial-out-only peer connections to retry immediately rather
+	// than wait out a backoff.
+	OnClientConnected func(clientID string)
 	OnClientFocused   func(clientID string)
 	OnSessionSelected func(clientID string, sessionID string)
 }
@@ -50,6 +55,11 @@ func (t *Table) Add(client *Client) {
 	t.mu.Lock()
 	t.clients[client.ID] = client
 	t.mu.Unlock()
+
+	// Fire outside the lock to avoid holding it across the callback.
+	if t.callbacks.OnClientConnected != nil {
+		t.callbacks.OnClientConnected(client.ID)
+	}
 }
 
 // Remove unregisters a client by ID.

--- a/services/gmuxd/internal/presence/presence_test.go
+++ b/services/gmuxd/internal/presence/presence_test.go
@@ -210,3 +210,29 @@ func TestRemove(t *testing.T) {
 		t.Fatal("removed client should not be counted")
 	}
 }
+
+// TestOnClientConnectedFires verifies the callback fires exactly once
+// per Add, carrying the client's ID. This is the hook peering uses to
+// nudge dial-out-only peers to reconnect when a user shows up.
+func TestOnClientConnectedFires(t *testing.T) {
+	var gotIDs []string
+	tbl := New(Callbacks{
+		OnClientConnected: func(id string) { gotIDs = append(gotIDs, id) },
+	})
+
+	tbl.Add(nilClient("a", "desktop", "granted", nowSecs()))
+	tbl.Add(nilClient("b", "mobile", "granted", nowSecs()))
+
+	if len(gotIDs) != 2 || gotIDs[0] != "a" || gotIDs[1] != "b" {
+		t.Errorf("want callback fired for [a b], got %v", gotIDs)
+	}
+}
+
+// TestOnClientConnectedNilSafe verifies Add works when no callback is set.
+func TestOnClientConnectedNilSafe(t *testing.T) {
+	tbl := New(Callbacks{})
+	tbl.Add(nilClient("a", "desktop", "granted", nowSecs())) // must not panic
+	if got := len(tbl.Conns()); got != 1 {
+		t.Errorf("client should be registered, got %d conns", got)
+	}
+}


### PR DESCRIPTION
Closes #374. Follow-up from #244 / #363.

## Why

Peering is dial-out only — the hub opens the SSE stream to a spoke, and the spoke has no way to push "I'm online." Reconnect latency is bounded solely by the retry backoff (30s ceiling, per #363), so a peer that comes back is only discovered on its next scheduled retry. There was no accelerant.

## What

- **Core wake mechanism** (`peer.go`): a buffered `wake` channel per `Peer`, a non-blocking `Peer.Reconnect()`, and a third `select` case in the reconnect loop that resets backoff to the initial interval and retries at once. `Manager.ReconnectAll()` fans out to every peer. Waking only shortcuts the `time.After(backoff)` wait — a live connection is never torn down, and a signal that arrives mid-connection is coalesced and consumed at the next disconnect.
- **Trigger** (`presence` + `main.go`): `presence.Callbacks.OnClientConnected` fires when a browser client registers; `main.go` wires it to `peerManager.ReconnectAll()`. Opening or returning to the UI immediately re-attempts any backing-off peer. No frontend changes.

## Testing

- `TestReconnect_ShortcutsBackoffWait` — with a 30s backoff, a `Reconnect()` nudge produces the next attempt promptly (deterministic; counts real attempts via injected transport).
- `TestReconnect_NonBlockingAndCoalesced` — repeated calls never block and collapse to one pending wake.
- `TestOnClientConnectedFires` / `TestOnClientConnectedNilSafe` — presence callback fires per `Add`, nil-safe.
- Full `gmuxd` suite passes with `-race`.