### PR TITLE
feat(web): show session cwd on card when it differs from project folder

### DIFF
--- a/apps/gmux-web/src/cwd-format.test.ts
+++ b/apps/gmux-web/src/cwd-format.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { relativeCwd, cwdBadge } from './cwd-format'
+import { relativeCwd, cwdBadge, hubCwdLabel } from './cwd-format'
 
 describe('relativeCwd', () => {
   it('returns empty when cwd equals the canonical folder', () => {
@@ -46,5 +46,23 @@ describe('cwdBadge', () => {
 
   it('surfaces an unrelated cwd as an absolute path', () => {
     expect(cwdBadge('~/tmp/scratch', '~/dev/gmux')).toBe('~/tmp/scratch')
+  })
+})
+
+describe('hubCwdLabel', () => {
+  it('marks a session at the project root with a dot', () => {
+    expect(hubCwdLabel('~/dev/gmux', '~/dev/gmux')).toBe('.')
+  })
+
+  it('is blank for an unresolved (empty) cwd, not a stray dot', () => {
+    // Regression guard: an empty cwd must not collapse to '.', which
+    // would label a placeholder as if it were the project root.
+    expect(hubCwdLabel('', '~/dev/gmux')).toBe('')
+    expect(hubCwdLabel(undefined, '~/dev/gmux')).toBe('')
+  })
+
+  it('shows descendants and unrelated paths like relativeCwd', () => {
+    expect(hubCwdLabel('~/dev/gmux/apps/web', '~/dev/gmux')).toBe('./apps/web')
+    expect(hubCwdLabel('~/tmp/scratch', '~/dev/gmux')).toBe('~/tmp/scratch')
   })
 })

--- a/apps/gmux-web/src/cwd-format.test.ts
+++ b/apps/gmux-web/src/cwd-format.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import { relativeCwd, cwdBadge } from './cwd-format'
+
+describe('relativeCwd', () => {
+  it('returns empty when cwd equals the canonical folder', () => {
+    expect(relativeCwd('~/dev/gmux', '~/dev/gmux')).toBe('')
+  })
+
+  it('returns a project-relative path for a descendant', () => {
+    expect(relativeCwd('~/dev/gmux/apps/web', '~/dev/gmux')).toBe('./apps/web')
+  })
+
+  it('returns a project-relative path for a grove/worktree descendant', () => {
+    expect(relativeCwd('~/dev/gmux/.grove/feature', '~/dev/gmux'))
+      .toBe('./.grove/feature')
+  })
+
+  it('returns the absolute cwd when unrelated to the canonical folder', () => {
+    expect(relativeCwd('~/tmp/scratch', '~/dev/gmux')).toBe('~/tmp/scratch')
+  })
+
+  it('does not treat a sibling prefix as a descendant', () => {
+    // ~/dev/gmux-other must not be seen as under ~/dev/gmux
+    expect(relativeCwd('~/dev/gmux-other', '~/dev/gmux')).toBe('~/dev/gmux-other')
+  })
+
+  it('returns the cwd verbatim when there is no canonical folder', () => {
+    expect(relativeCwd('~/dev/gmux', undefined)).toBe('~/dev/gmux')
+    expect(relativeCwd('~/dev/gmux', '')).toBe('~/dev/gmux')
+  })
+})
+
+describe('cwdBadge', () => {
+  it('is null for an empty/unresolved cwd', () => {
+    expect(cwdBadge('', '~/dev/gmux')).toBeNull()
+    expect(cwdBadge(undefined, '~/dev/gmux')).toBeNull()
+  })
+
+  it('is null when cwd matches the canonical folder', () => {
+    expect(cwdBadge('~/dev/gmux', '~/dev/gmux')).toBeNull()
+  })
+
+  it('surfaces a descendant as a relative path', () => {
+    expect(cwdBadge('~/dev/gmux/apps/web', '~/dev/gmux')).toBe('./apps/web')
+  })
+
+  it('surfaces an unrelated cwd as an absolute path', () => {
+    expect(cwdBadge('~/tmp/scratch', '~/dev/gmux')).toBe('~/tmp/scratch')
+  })
+})

--- a/apps/gmux-web/src/cwd-format.ts
+++ b/apps/gmux-web/src/cwd-format.ts
@@ -1,0 +1,36 @@
+// Formatting a session's working directory for display on a card,
+// relative to its project's canonical folder.
+//
+// Paths arrive already canonicalized to `~/...` form (projects.ts),
+// so no $HOME expansion is needed here — we only decide how to shorten
+// a cwd against the project root the card belongs to.
+
+/**
+ * Express `cwd` relative to a project's `canonical` folder.
+ *
+ *   equal        -> ''             (nothing worth showing)
+ *   descendant   -> './sub/dir'    (worktree / subfolder)
+ *   unrelated    -> cwd            (already ~/-abbreviated absolute)
+ *
+ * A missing `canonical` (project without a path rule) yields the cwd
+ * verbatim: we can't compute a relation, so we show what we have.
+ */
+export function relativeCwd(cwd: string, canonical?: string): string {
+  if (!canonical) return cwd
+  if (cwd === canonical) return ''
+  if (cwd.startsWith(canonical + '/')) return './' + cwd.slice(canonical.length + 1)
+  return cwd
+}
+
+/**
+ * Card-facing helper: the cwd to surface *only when it differs* from
+ * the canonical folder. Returns null when there's nothing to add —
+ * an unresolved (empty) cwd, or a cwd that is exactly the project
+ * folder. Used by the home dashboard, where the default (session at
+ * the project root) should stay quiet.
+ */
+export function cwdBadge(cwd: string | undefined, canonical?: string): string | null {
+  if (!cwd) return null
+  const rel = relativeCwd(cwd, canonical)
+  return rel === '' ? null : rel
+}

--- a/apps/gmux-web/src/cwd-format.ts
+++ b/apps/gmux-web/src/cwd-format.ts
@@ -34,3 +34,15 @@ export function cwdBadge(cwd: string | undefined, canonical?: string): string | 
   const rel = relativeCwd(cwd, canonical)
   return rel === '' ? null : rel
 }
+
+/**
+ * Project-hub row disambiguator: like relativeCwd, but a session sitting
+ * at the project root reads as '.' (a meaningful "here" marker when rows
+ * disagree on cwd) rather than a blank segment. An unresolved (empty)
+ * cwd still yields '' so the row renders nothing — a placeholder cwd is
+ * not a location worth labelling.
+ */
+export function hubCwdLabel(cwd: string | undefined, canonical?: string): string {
+  if (!cwd) return ''
+  return relativeCwd(cwd, canonical) || '.'
+}

--- a/apps/gmux-web/src/home.tsx
+++ b/apps/gmux-web/src/home.tsx
@@ -12,6 +12,7 @@ import {
 } from './store'
 import { SessionRow } from './session-row'
 import { sessionPath } from './routing'
+import { cwdBadge } from './cwd-format'
 import { IconBell, type NotifPermission } from './sidebar'
 import type { Folder, Session } from './types'
 
@@ -43,6 +44,10 @@ export function Home({
     // without a folder (mid-arrival race), skip rendering rather
     // than crashing the dashboard.
     if (!folder) return null
+    // Surface the session's cwd only when it strays from the project's
+    // canonical folder (a subfolder or worktree/grove workspace);
+    // sessions at the project root stay quiet.
+    const cwd = cwdBadge(s.cwd, folder.launchCwd)
     return (
       <SessionRow
         key={s.id}
@@ -51,6 +56,8 @@ export function Home({
         showProject
         projectName={folder.name}
         showHost
+        showCwd={!!cwd}
+        cwdLabel={cwd ?? undefined}
         onClose={() => dismissSession(s.id)}
       />
     )

--- a/apps/gmux-web/src/project-hub.tsx
+++ b/apps/gmux-web/src/project-hub.tsx
@@ -20,6 +20,7 @@
 import type { Session, ProjectItem } from './types'
 import { buildProjectTopology } from './projects'
 import { sessionPath } from './routing'
+import { relativeCwd } from './cwd-format'
 import { LaunchButton } from './launcher'
 import {
   sessions, projects, peers, localPeerNames, partitionForProject,
@@ -75,6 +76,15 @@ export function ProjectHub({ projectSlug, projectPeer, onCloseSession }: Project
   const uniqueCwds = new Set(allSessions.map(s => s.cwd).filter(Boolean))
   const sharedCwd = uniqueCwds.size === 1 ? [...uniqueCwds][0] : null
 
+  // Shared cwd shown as a subtitle: express it relative to the
+  // canonical folder so a single-worktree project reads as `./sub`
+  // rather than a long absolute path. Empty (== canonical) keeps the
+  // absolute form, since the header only carries the slug and the
+  // path is still useful context there.
+  const sharedCwdLabel = sharedCwd
+    ? (relativeCwd(sharedCwd, canonicalCwd) || sharedCwd)
+    : null
+
   // Multi-host iff sessions disagree on .peer. Local-peer
   // (devcontainer) sessions in a local project's folder are the
   // common case: they make the folder mixed and earn a host suffix
@@ -90,7 +100,9 @@ export function ProjectHub({ projectSlug, projectPeer, onCloseSession }: Project
       session={s}
       href={sessionPath(projectSlug, s, projectPeer)}
       showCwd={!sharedCwd}
-      cwdLabel={s.cwd}
+      // Multi-cwd disambiguator: express each cwd relative to the
+      // canonical folder ('.' for a session at the project root).
+      cwdLabel={relativeCwd(s.cwd, canonicalCwd) || '.'}
       showHost={mixedHosts}
       onClose={() => onCloseSession(s)}
     />
@@ -118,7 +130,7 @@ export function ProjectHub({ projectSlug, projectPeer, onCloseSession }: Project
         </div>
         {(remote || sharedCwd) && (
           <div class="hub-subtitle">
-            {sharedCwd && <span class="hub-cwd">{sharedCwd}</span>}
+            {sharedCwdLabel && <span class="hub-cwd">{sharedCwdLabel}</span>}
             {remote && sharedCwd && <span class="hub-subtitle-sep"> · </span>}
             {remote && <span class="hub-remote">{remote}</span>}
           </div>

--- a/apps/gmux-web/src/project-hub.tsx
+++ b/apps/gmux-web/src/project-hub.tsx
@@ -11,6 +11,9 @@
 //     under the project title and omit it from rows.
 //   - Otherwise show each session's cwd on its row, since worktree
 //     identity is the most useful disambiguator in multi-cwd projects.
+// Both are formatted relative to the project's canonical folder (see
+// cwd-format.ts): a descendant reads as `./sub`, the project root as
+// `.`, an unrelated path as its abbreviated absolute form.
 //
 // Worktree grouping (the legacy `~/dev/gmux/.grove/<name>` headings)
 // is intentionally dropped: activity-first sectioning is more useful
@@ -20,7 +23,7 @@
 import type { Session, ProjectItem } from './types'
 import { buildProjectTopology } from './projects'
 import { sessionPath } from './routing'
-import { relativeCwd } from './cwd-format'
+import { relativeCwd, hubCwdLabel } from './cwd-format'
 import { LaunchButton } from './launcher'
 import {
   sessions, projects, peers, localPeerNames, partitionForProject,
@@ -101,8 +104,9 @@ export function ProjectHub({ projectSlug, projectPeer, onCloseSession }: Project
       href={sessionPath(projectSlug, s, projectPeer)}
       showCwd={!sharedCwd}
       // Multi-cwd disambiguator: express each cwd relative to the
-      // canonical folder ('.' for a session at the project root).
-      cwdLabel={relativeCwd(s.cwd, canonicalCwd) || '.'}
+      // canonical folder ('.' for a session at the project root, blank
+      // for an unresolved cwd so its segment is dropped).
+      cwdLabel={hubCwdLabel(s.cwd, canonicalCwd)}
       showHost={mixedHosts}
       onClose={() => onCloseSession(s)}
     />

--- a/apps/gmux-web/src/session-row.tsx
+++ b/apps/gmux-web/src/session-row.tsx
@@ -113,7 +113,9 @@ export function SessionRow({
     metaSegments.push(<span class="session-row-project">{projectName}</span>)
   }
   if (showCwd && cwdLabel) {
-    metaSegments.push(<span class="session-row-cwd">{cwdLabel}</span>)
+    // Truncated in CSS; the title carries the full absolute cwd so a
+    // hover/long-press reveals the path the relative label abbreviates.
+    metaSegments.push(<span class="session-row-cwd" title={session.cwd || cwdLabel}>{cwdLabel}</span>)
   }
   if (statusText) {
     metaSegments.push(<span class="session-row-status">{statusText}</span>)

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -811,6 +811,12 @@ body {
 }
 .session-row-cwd {
   font-family: var(--font-mono, monospace);
+  /* Long worktree/subfolder paths truncate rather than pushing the
+   * rest of the meta line off-screen; full path is in the title. */
+  max-width: 22ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .session-row-status {
   font-style: italic;


### PR DESCRIPTION
## What

The shared `SessionRow` card (home dashboard + project hub) now surfaces a session's **working directory** on line 2 whenever it differs from the project's canonical folder — a subfolder, git worktree, or grove workspace. Sessions sitting at the project root stay quiet, as before.

## Display rules

`cwd-format.ts` formats a cwd against the project's canonical folder (`Folder.launchCwd`):

| Relation to project folder | Home card | Hub row |
|---|---|---|
| Equal | *(nothing)* | `.` |
| Descendant | `./apps/api`, `./.grove/scrollback-fix` | same |
| Unrelated | `~/tmp/quick-fix` | same |
| Unresolved (empty) | *(nothing)* | *(nothing)* |

Long paths truncate with an ellipsis (`./.grove/scrollback-…`); the full absolute path is in the element `title` (hover / long-press tooltip).

## Why no wire change

`session.cwd` already ships on the protocol model, canonicalized to `~/…` form server-side (paths outside `$HOME` stay absolute), and the project's folder is `Folder.launchCwd`. Verified against a live daemon: cwds arrive as e.g. `~/dev/gmux/.grove/ws-13` with `workspace_root: ~/dev/gmux`, so a prefix comparison against the canonical folder is exactly right. This is purely presentation.

## Changes

- `cwd-format.ts` (new) + tests — `relativeCwd`, `cwdBadge` (home), `hubCwdLabel` (hub).
- `home.tsx` — home cards now render cwd (previously showed none).
- `project-hub.tsx` — per-row and shared-subtitle cwd rendered relative to the canonical folder.
- `session-row.tsx` — full-path `title` on the cwd segment.
- `styles.css` — `.session-row-cwd` truncation.

## Verification

- `pnpm lint` + `pnpm test` green (575 tests, incl. 13 cwd-format tests covering equal / descendant / grove worktree / unrelated / sibling-prefix / no-canonical / empty-cwd).
- chrome-devtools desktop + mobile screenshots of the project hub covering all cases; truncation + tooltip confirmed; mobile stays legible.
- Confirmed the wire format directly against a running daemon (cwd is `~/`-canonical), so the equality/descendant logic behaves in production, not just in mock.

### Note
The `?mock` fixtures aren't `project_slug`-stamped and there's no mock `peerProjects`, so the mock home dashboard renders no session rows today — a pre-existing gap, unrelated to this change. Verification used temporarily-stamped fixtures (reverted, not in this diff). A mock-data refresh to make `?mock` demo the activity dashboard is worth a follow-up.