### PR TITLE
docs(adr): renumber ACP conversation-schema ADR to 0021

### DIFF
--- a/docs/adr/0021-acp-session-update-as-internal-conversation-schema.md
+++ b/docs/adr/0021-acp-session-update-as-internal-conversation-schema.md
@@ -1,4 +1,4 @@
-# ADR 0020: ACP `session/update` as gmux's internal normalized conversation schema
+# ADR 0021: ACP `session/update` as gmux's internal normalized conversation schema
 
 **Status:** Proposed
 **Date:** 2026-07-06


### PR DESCRIPTION
ADR 0020 number collided — the same-origin cookie-auth ADR (Accepted) also landed as 0020 in parallel. Renumbering the ACP session-update ADR (merged as Proposed in #376) to 0021. File rename + header only.