### PR TITLE
feat(acp): stream assistant text end-to-end (ACP session/update tracer)

### DIFF
--- a/apps/gmux-web/package.json
+++ b/apps/gmux-web/package.json
@@ -30,6 +30,7 @@
   },
   "devDependencies": {
     "@preact/preset-vite": "^2.10.2",
+    "preact-render-to-string": "^6.6.6",
     "typescript": "^5.8.2",
     "vite": "^6.2.0",
     "vitest": "^3.0.7"

--- a/apps/gmux-web/src/conversation-view.test.tsx
+++ b/apps/gmux-web/src/conversation-view.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import { renderToString } from 'preact-render-to-string'
+import { ConversationView } from './conversation-view'
+import { createConversationStore } from './conversation'
+
+// Render test: a pre-fed store rendered without opening a WebSocket
+// (connect=false) must produce the streamed assistant text in the DOM output.
+describe('ConversationView', () => {
+  it('renders user and assistant messages from the store', () => {
+    const store = createConversationStore()
+    store.applyFrame({
+      jsonrpc: '2.0',
+      method: 'session/load',
+      params: {
+        sessionId: 's1',
+        messages: [{ role: 'user', content: [{ type: 'text', text: 'ping' }] }],
+      },
+    })
+    store.applyFrame({
+      jsonrpc: '2.0',
+      method: 'session/update',
+      params: {
+        sessionId: 's1',
+        update: { sessionUpdate: 'agent_message_chunk', messageId: 'm1', content: { type: 'text', text: 'pong' } },
+      },
+    })
+
+    const html = renderToString(<ConversationView sessionId="s1" store={store} connect={false} />)
+    expect(html).toContain('ping')
+    expect(html).toContain('pong')
+    expect(html).toContain('conversation-message--assistant')
+  })
+
+  it('renders an empty state with no messages', () => {
+    const store = createConversationStore()
+    const html = renderToString(<ConversationView sessionId="s1" store={store} connect={false} />)
+    expect(html).toContain('No conversation yet.')
+  })
+})

--- a/apps/gmux-web/src/conversation-view.tsx
+++ b/apps/gmux-web/src/conversation-view.tsx
@@ -1,0 +1,71 @@
+/**
+ * Conversation view (ADR 0021 tracer #1): a live, structured render of one
+ * session's assistant text, separate from the xterm PTY surface. It attaches
+ * to the runner's ACP stream via connectConversation and re-renders as token
+ * deltas coalesce into the store.
+ *
+ * NOTE (convention flagged for review): ADR 0021 and the tracer brief suggest
+ * `@assistant-ui/react`. This app is Preact, not React; assistant-ui is
+ * React-only and pulling react/react-dom in behind preact/compat is a
+ * consequential dependency+build decision that shouldn't be baked in silently
+ * by the foundational tracer. So this slice ships a minimal native Preact
+ * renderer over the same store, and defers the assistant-ui decision (compat
+ * alias vs. a dedicated React island) to a follow-up. The store
+ * (conversation.ts) is UI-framework-agnostic, so swapping the renderer later
+ * touches only this file.
+ */
+import { useEffect, useState } from 'preact/hooks'
+import {
+  type ConversationStore,
+  type ConvMessage,
+  createConversationStore,
+  connectConversation,
+  messageText,
+} from './conversation'
+
+interface Props {
+  sessionId: string
+  /** Injectable for tests; defaults to a fresh store wired to the live WS. */
+  store?: ConversationStore
+  /** When false, skip opening the WebSocket (tests pass a pre-fed store). */
+  connect?: boolean
+}
+
+export function ConversationView({ sessionId, store: injected, connect = true }: Props) {
+  const [store] = useState(() => injected ?? createConversationStore())
+  const [, forceRender] = useState(0)
+  const [connState, setConnState] = useState<'open' | 'closed'>('closed')
+
+  useEffect(() => {
+    const unsub = store.subscribe(() => forceRender((n) => n + 1))
+    let conn: { close(): void } | undefined
+    if (connect) {
+      conn = connectConversation(sessionId, store, { onStateChange: setConnState })
+    }
+    return () => {
+      unsub()
+      conn?.close()
+    }
+  }, [sessionId, store, connect])
+
+  const messages = store.getMessages()
+
+  return (
+    <div class="conversation-view" data-conn={connState}>
+      {messages.length === 0 ? (
+        <div class="conversation-empty">No conversation yet.</div>
+      ) : (
+        messages.map((m, i) => <MessageRow key={m.messageId ?? i} message={m} />)
+      )}
+    </div>
+  )
+}
+
+function MessageRow({ message }: { message: ConvMessage }) {
+  return (
+    <div class={`conversation-message conversation-message--${message.role}`} data-role={message.role}>
+      <span class="conversation-role">{message.role}</span>
+      <span class="conversation-text">{messageText(message)}</span>
+    </div>
+  )
+}

--- a/apps/gmux-web/src/conversation.test.ts
+++ b/apps/gmux-web/src/conversation.test.ts
@@ -55,20 +55,21 @@ describe('conversation store', () => {
     expect(messageText(msgs[1])).toBe('second')
   })
 
-  it('continues streaming after a snapshot that includes a partial tail', () => {
+  it('continues the same message when a mid-turn snapshot tail carries its messageId', () => {
     const s = createConversationStore()
-    // snapshot: prior user turn + a partial assistant tail (no id in snapshot)
+    // snapshot: prior user turn + the in-flight assistant tail, tagged with its
+    // streaming messageId (as the runner sends for a mid-turn joiner).
     s.applyFrame(
       loadFrame([
         { role: 'user', content: [{ type: 'text', text: 'q' }] },
-        { role: 'assistant', content: [{ type: 'text', text: 'par' }] },
+        { role: 'assistant', messageId: 'm9', content: [{ type: 'text', text: 'par' }] },
       ]),
     )
-    // a fresh assistant message with an id streams next
+    // subsequent deltas of the SAME message append rather than opening a new one
     s.applyFrame(chunkFrame('tial', 'm9'))
     const msgs = s.getMessages()
-    expect(msgs).toHaveLength(3)
-    expect(messageText(msgs[2])).toBe('tial')
+    expect(msgs).toHaveLength(2)
+    expect(messageText(msgs[1])).toBe('partial')
   })
 
   it('notifies subscribers once per burst (coalesced)', async () => {

--- a/apps/gmux-web/src/conversation.test.ts
+++ b/apps/gmux-web/src/conversation.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest'
+import { createConversationStore, messageText } from './conversation'
+
+const loadFrame = (messages: unknown[]) => ({
+  jsonrpc: '2.0',
+  method: 'session/load',
+  params: { sessionId: 's1', messages },
+})
+
+const chunkFrame = (delta: string, messageId?: string) => ({
+  jsonrpc: '2.0',
+  method: 'session/update',
+  params: {
+    sessionId: 's1',
+    update: { sessionUpdate: 'agent_message_chunk', messageId, content: { type: 'text', text: delta } },
+  },
+})
+
+// flush the coalesced microtask notification
+const tick = () => new Promise((r) => queueMicrotask(() => r(undefined)))
+
+describe('conversation store', () => {
+  it('loads history snapshot as the initial messages', () => {
+    const s = createConversationStore()
+    s.applyFrame(
+      loadFrame([
+        { role: 'user', content: [{ type: 'text', text: 'hi' }] },
+        { role: 'assistant', content: [{ type: 'text', text: 'hello' }] },
+      ]),
+    )
+    const msgs = s.getMessages()
+    expect(msgs).toHaveLength(2)
+    expect(msgs[0].role).toBe('user')
+    expect(messageText(msgs[1])).toBe('hello')
+  })
+
+  it('coalesces token deltas of the same messageId into one assistant message', () => {
+    const s = createConversationStore()
+    s.applyFrame(chunkFrame('Hel', 'm1'))
+    s.applyFrame(chunkFrame('lo ', 'm1'))
+    s.applyFrame(chunkFrame('world', 'm1'))
+    const msgs = s.getMessages()
+    expect(msgs).toHaveLength(1)
+    expect(msgs[0].role).toBe('assistant')
+    expect(messageText(msgs[0])).toBe('Hello world')
+  })
+
+  it('starts a new assistant message when the messageId changes', () => {
+    const s = createConversationStore()
+    s.applyFrame(chunkFrame('first', 'm1'))
+    s.applyFrame(chunkFrame('second', 'm2'))
+    const msgs = s.getMessages()
+    expect(msgs).toHaveLength(2)
+    expect(messageText(msgs[0])).toBe('first')
+    expect(messageText(msgs[1])).toBe('second')
+  })
+
+  it('continues streaming after a snapshot that includes a partial tail', () => {
+    const s = createConversationStore()
+    // snapshot: prior user turn + a partial assistant tail (no id in snapshot)
+    s.applyFrame(
+      loadFrame([
+        { role: 'user', content: [{ type: 'text', text: 'q' }] },
+        { role: 'assistant', content: [{ type: 'text', text: 'par' }] },
+      ]),
+    )
+    // a fresh assistant message with an id streams next
+    s.applyFrame(chunkFrame('tial', 'm9'))
+    const msgs = s.getMessages()
+    expect(msgs).toHaveLength(3)
+    expect(messageText(msgs[2])).toBe('tial')
+  })
+
+  it('notifies subscribers once per burst (coalesced)', async () => {
+    const s = createConversationStore()
+    let count = 0
+    s.subscribe(() => count++)
+    s.applyFrame(chunkFrame('a', 'm1'))
+    s.applyFrame(chunkFrame('b', 'm1'))
+    s.applyFrame(chunkFrame('c', 'm1'))
+    await tick()
+    expect(count).toBe(1)
+  })
+
+  it('ignores non-text updates and malformed frames', () => {
+    const s = createConversationStore()
+    s.applyFrame({ jsonrpc: '2.0', method: 'session/update', params: { update: { sessionUpdate: 'tool_call' } } })
+    s.applyFrame(null)
+    s.applyFrame({ foo: 'bar' })
+    expect(s.getMessages()).toHaveLength(0)
+  })
+})

--- a/apps/gmux-web/src/conversation.ts
+++ b/apps/gmux-web/src/conversation.ts
@@ -32,7 +32,7 @@ export interface ConvMessage {
 
 interface LoadParams {
   sessionId: string
-  messages: ConvMessage[]
+  messages: (ConvMessage & { messageId?: string })[]
 }
 
 interface UpdateParams {
@@ -81,10 +81,15 @@ export function createConversationStore(): ConversationStore {
   }
 
   function applyLoad(p: LoadParams) {
-    // The snapshot is authoritative history: replace everything. Any partial
-    // assistant tail the runner included arrives as a plain message here; the
-    // live stream that follows continues appending to its messageId.
-    messages = p.messages.map((m) => ({ role: m.role, content: [...m.content] }))
+    // The snapshot is authoritative history: replace everything. The runner
+    // tags the in-flight assistant tail (if any) with its streaming messageId,
+    // so the live deltas that follow keep appending to that same message
+    // instead of opening a duplicate bubble.
+    messages = p.messages.map((m) => ({
+      role: m.role,
+      messageId: m.messageId,
+      content: [...m.content],
+    }))
     notify()
   }
 

--- a/apps/gmux-web/src/conversation.ts
+++ b/apps/gmux-web/src/conversation.ts
@@ -1,0 +1,175 @@
+/**
+ * ACP conversation store (ADR 0021 tracer #1: streaming assistant text).
+ *
+ * A headless, framework-agnostic model of one session's conversation, fed by
+ * the runner's ACP WebSocket (`/acp/{sessionId}`). It consumes JSON-RPC 2.0
+ * frames:
+ *
+ *   - `session/load`   — the history snapshot, sent unsolicited as the first
+ *                        frame (mirrors the PTY renderScreen snapshot).
+ *   - `session/update` — live `agent_message_chunk` token deltas.
+ *
+ * Tokens are chatty by design (per-token on the wire); this store COALESCES
+ * them: deltas with the same messageId append to one assistant message, and
+ * subscribers are notified on a microtask so a burst of tokens triggers a
+ * single render. The store is transport-agnostic so it can be unit-tested by
+ * feeding frames directly via `applyFrame`.
+ */
+
+export type Role = 'user' | 'assistant'
+
+export interface ContentBlock {
+  type: string
+  text?: string
+}
+
+export interface ConvMessage {
+  role: Role
+  content: ContentBlock[]
+  /** Present for the in-flight assistant message being streamed. */
+  messageId?: string
+}
+
+interface LoadParams {
+  sessionId: string
+  messages: ConvMessage[]
+}
+
+interface UpdateParams {
+  sessionId: string
+  update: {
+    sessionUpdate: string
+    messageId?: string
+    content: ContentBlock
+  }
+}
+
+interface JsonRpcFrame {
+  jsonrpc: string
+  method: string
+  params: unknown
+}
+
+type Listener = () => void
+
+export interface ConversationStore {
+  applyFrame(frame: unknown): void
+  getMessages(): ConvMessage[]
+  subscribe(listener: Listener): () => void
+}
+
+function textOf(content: ContentBlock[]): string {
+  return content
+    .filter((b) => b.type === 'text')
+    .map((b) => b.text ?? '')
+    .join('')
+}
+
+export function createConversationStore(): ConversationStore {
+  let messages: ConvMessage[] = []
+  const listeners = new Set<Listener>()
+  let notifyScheduled = false
+
+  // Coalesce notifications: a burst of token deltas schedules one flush.
+  function notify() {
+    if (notifyScheduled) return
+    notifyScheduled = true
+    queueMicrotask(() => {
+      notifyScheduled = false
+      for (const l of listeners) l()
+    })
+  }
+
+  function applyLoad(p: LoadParams) {
+    // The snapshot is authoritative history: replace everything. Any partial
+    // assistant tail the runner included arrives as a plain message here; the
+    // live stream that follows continues appending to its messageId.
+    messages = p.messages.map((m) => ({ role: m.role, content: [...m.content] }))
+    notify()
+  }
+
+  function applyUpdate(p: UpdateParams) {
+    const u = p.update
+    if (u.sessionUpdate !== 'agent_message_chunk') return // only text this slice
+    const delta = u.content?.text ?? ''
+    if (!delta && !u.messageId) return
+
+    // Append to the in-flight assistant message with the same id, else open a
+    // new one. Without an id, fall back to the trailing assistant message.
+    const last = messages[messages.length - 1]
+    const matches =
+      last &&
+      last.role === 'assistant' &&
+      (u.messageId ? last.messageId === u.messageId : last.messageId === undefined)
+
+    if (matches) {
+      const block = last.content[last.content.length - 1]
+      if (block && block.type === 'text') {
+        block.text = (block.text ?? '') + delta
+      } else {
+        last.content.push({ type: 'text', text: delta })
+      }
+    } else {
+      messages.push({
+        role: 'assistant',
+        messageId: u.messageId,
+        content: [{ type: 'text', text: delta }],
+      })
+    }
+    notify()
+  }
+
+  return {
+    applyFrame(frame: unknown) {
+      if (!frame || typeof frame !== 'object') return
+      const f = frame as JsonRpcFrame
+      if (f.method === 'session/load') applyLoad(f.params as LoadParams)
+      else if (f.method === 'session/update') applyUpdate(f.params as UpdateParams)
+    },
+    getMessages() {
+      return messages
+    },
+    subscribe(listener: Listener) {
+      listeners.add(listener)
+      return () => listeners.delete(listener)
+    },
+  }
+}
+
+/** Plain-text of one message's content, for rendering. */
+export function messageText(m: ConvMessage): string {
+  return textOf(m.content)
+}
+
+export interface ConversationConnection {
+  close(): void
+}
+
+/**
+ * Connect a store to a session's ACP WebSocket. Returns a handle to close it.
+ * Reconnect/backoff hardening is deliberately out of scope for the tracer.
+ */
+export function connectConversation(
+  sessionId: string,
+  store: ConversationStore,
+  opts?: { onStateChange?: (state: 'open' | 'closed') => void },
+): ConversationConnection {
+  const proto = location.protocol === 'https:' ? 'wss:' : 'ws:'
+  const ws = new WebSocket(`${proto}//${location.host}/acp/${sessionId}`)
+
+  ws.onopen = () => opts?.onStateChange?.('open')
+  ws.onclose = () => opts?.onStateChange?.('closed')
+  ws.onmessage = (ev) => {
+    try {
+      store.applyFrame(JSON.parse(ev.data as string))
+    } catch {
+      // ignore malformed frames
+    }
+  }
+
+  return {
+    close() {
+      ws.close()
+    },
+  }
+}

--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -8,6 +8,7 @@ import { applyArmedModifiers } from './keyboard'
 import { isTouchDevice } from './touch'
 import { ReplayView } from './replay-view'
 import { TerminalView } from './terminal'
+import { ConversationView } from './conversation-view'
 import { Sidebar } from './sidebar'
 import { usePresence } from './use-presence'
 import { lifecycleAction } from './session-actions'
@@ -768,6 +769,16 @@ function App() {
             notifPermission={notifPermission}
             onRequestNotifPermission={requestNotifPermission}
           />
+        )}
+
+        {/* ACP conversation panel (ADR 0021 tracer #1). Opt-in via ?conv so
+            it's non-invasive while the transport/schema are proven: the
+            terminal remains the primary surface and keeps working. Renders
+            live streaming assistant text over the same session. */}
+        {selectedVal && new URLSearchParams(location.search).has('conv') && (
+          <div class="conversation-panel">
+            <ConversationView sessionId={selectedVal.id} />
+          </div>
         )}
 
         {keyBarShown && (

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -3399,3 +3399,41 @@ body {
   gap: 8px;
   justify-content: center;
 }
+
+/* ACP conversation panel (ADR 0021 tracer #1: streaming assistant text).
+   A floating overlay over the terminal surface, toggled with ?conv. Minimal
+   by design — the assistant-ui vs. native renderer decision is deferred. */
+.conversation-panel {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: min(480px, 42vw);
+  height: 100%;
+  overflow-y: auto;
+  background: var(--bg, #14171c);
+  border-left: 1px solid var(--border, #2a2f37);
+  padding: 12px 14px;
+  z-index: 20;
+  font-size: 14px;
+  line-height: 1.5;
+}
+.conversation-empty {
+  color: var(--fg-muted, #7a828e);
+  font-style: italic;
+}
+.conversation-message {
+  margin-bottom: 12px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.conversation-role {
+  display: block;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--fg-muted, #7a828e);
+  margin-bottom: 2px;
+}
+.conversation-message--assistant .conversation-role {
+  color: var(--accent, #6ea8fe);
+}

--- a/apps/gmux-web/vite.config.ts
+++ b/apps/gmux-web/vite.config.ts
@@ -25,6 +25,10 @@ export default defineConfig({
         target: `http://127.0.0.1:${gmuxdPort}`,
         ws: true,
       },
+      '/acp': {
+        target: `http://127.0.0.1:${gmuxdPort}`,
+        ws: true,
+      },
     },
   },
 })

--- a/cli/gmux/internal/acp/acp.go
+++ b/cli/gmux/internal/acp/acp.go
@@ -9,6 +9,9 @@
 // `agent_message_chunk` variant. Thinking, tool calls, prompt/cancel, and the
 // rest of ADR 0021 §7 are intentionally omitted; add them in later slices.
 //
+// The full wire contract (both channels) is documented in
+// docs/acp-conversation-stream.md.
+//
 // CONVENTION (flagged for review — ADR 0021 tracer): the wire framing is
 // JSON-RPC 2.0 objects over a WebSocket. Mirroring the PTY attach
 // (ADR 0004 snapshot-then-stream), the server pushes an unsolicited
@@ -61,9 +64,15 @@ func TextBlock(text string) ContentBlock {
 // Message is one turn in the conversation history snapshot: a role plus its
 // content blocks. Roles mirror pi/ACP: "user" and "assistant" (this slice
 // renders only these two; toolResult and others are dropped from the snapshot).
+//
+// MessageID is set only for the in-flight assistant tail in a session/load
+// snapshot: it carries the streaming id so a client that joins mid-turn keeps
+// appending subsequent session/update deltas to the same message instead of
+// starting a new one. Durable (JSONL) history messages leave it empty.
 type Message struct {
-	Role    string         `json:"role"`
-	Content []ContentBlock `json:"content"`
+	Role      string         `json:"role"`
+	MessageID string         `json:"messageId,omitempty"`
+	Content   []ContentBlock `json:"content"`
 }
 
 // LoadParams is the params of the first `session/load` frame: the full

--- a/cli/gmux/internal/acp/acp.go
+++ b/cli/gmux/internal/acp/acp.go
@@ -1,0 +1,115 @@
+// Package acp defines gmux's internal normalized conversation schema — a
+// deliberately minimal subset of the Agent Client Protocol (ACP), per
+// ADR 0021. The runner produces these shapes (synthesized from the read-only
+// pi extension for terminal pi, or re-published from a real ACP agent later);
+// the frontend consumes them through one renderer regardless of adapter.
+//
+// SCOPE (tracer #1): only streaming assistant text. This package defines just
+// the `session/load` history snapshot and the `session/update`
+// `agent_message_chunk` variant. Thinking, tool calls, prompt/cancel, and the
+// rest of ADR 0021 §7 are intentionally omitted; add them in later slices.
+//
+// CONVENTION (flagged for review — ADR 0021 tracer): the wire framing is
+// JSON-RPC 2.0 objects over a WebSocket. Mirroring the PTY attach
+// (ADR 0004 snapshot-then-stream), the server pushes an unsolicited
+// `session/load` notification as the first frame (the history snapshot),
+// then streams live `session/update` notifications. We do not implement a
+// client→server `session/load` request for this slice; the snapshot is
+// server-initiated exactly like the PTY renderScreen frame.
+package acp
+
+import "encoding/json"
+
+// JSONRPCVersion is the fixed protocol tag on every frame.
+const JSONRPCVersion = "2.0"
+
+// Method names carried over the wire.
+const (
+	MethodSessionLoad   = "session/load"   // first frame: history snapshot
+	MethodSessionUpdate = "session/update" // live token stream
+)
+
+// SessionUpdate discriminator values (ACP `update.sessionUpdate`).
+const (
+	UpdateAgentMessageChunk = "agent_message_chunk"
+)
+
+// ContentType discriminates a content block. Only text is used this slice.
+const ContentTypeText = "text"
+
+// Notification is a JSON-RPC 2.0 notification frame (no id, no response).
+// Both the snapshot and the live stream are sent as notifications.
+type Notification struct {
+	JSONRPC string          `json:"jsonrpc"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params"`
+}
+
+// ContentBlock is a single piece of message content. This slice emits only
+// text blocks; Type is carried explicitly so later slices can add image /
+// resource without a schema break.
+type ContentBlock struct {
+	Type string `json:"type"`
+	Text string `json:"text,omitempty"`
+}
+
+// TextBlock is a convenience constructor for a text content block.
+func TextBlock(text string) ContentBlock {
+	return ContentBlock{Type: ContentTypeText, Text: text}
+}
+
+// Message is one turn in the conversation history snapshot: a role plus its
+// content blocks. Roles mirror pi/ACP: "user" and "assistant" (this slice
+// renders only these two; toolResult and others are dropped from the snapshot).
+type Message struct {
+	Role    string         `json:"role"`
+	Content []ContentBlock `json:"content"`
+}
+
+// LoadParams is the params of the first `session/load` frame: the full
+// conversation history known at connect time (durable JSONL + the in-memory
+// unwritten tail).
+type LoadParams struct {
+	SessionID string    `json:"sessionId"`
+	Messages  []Message `json:"messages"`
+}
+
+// UpdateParams is the params of a live `session/update` frame.
+type UpdateParams struct {
+	SessionID string        `json:"sessionId"`
+	Update    SessionUpdate `json:"update"`
+}
+
+// SessionUpdate is the discriminated update payload. This slice emits only
+// agent_message_chunk (SessionUpdate == UpdateAgentMessageChunk), carrying a
+// single token-level text delta in Content.
+type SessionUpdate struct {
+	SessionUpdate string       `json:"sessionUpdate"`
+	MessageID     string       `json:"messageId,omitempty"`
+	Content       ContentBlock `json:"content"`
+}
+
+// NewLoad builds the snapshot notification frame.
+func NewLoad(sessionID string, messages []Message) (Notification, error) {
+	p, err := json.Marshal(LoadParams{SessionID: sessionID, Messages: messages})
+	if err != nil {
+		return Notification{}, err
+	}
+	return Notification{JSONRPC: JSONRPCVersion, Method: MethodSessionLoad, Params: p}, nil
+}
+
+// NewAgentMessageChunk builds a live token-delta notification frame.
+func NewAgentMessageChunk(sessionID, messageID, delta string) (Notification, error) {
+	p, err := json.Marshal(UpdateParams{
+		SessionID: sessionID,
+		Update: SessionUpdate{
+			SessionUpdate: UpdateAgentMessageChunk,
+			MessageID:     messageID,
+			Content:       TextBlock(delta),
+		},
+	})
+	if err != nil {
+		return Notification{}, err
+	}
+	return Notification{JSONRPC: JSONRPCVersion, Method: MethodSessionUpdate, Params: p}, nil
+}

--- a/cli/gmux/internal/acp/acp_test.go
+++ b/cli/gmux/internal/acp/acp_test.go
@@ -1,0 +1,104 @@
+package acp
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNewAgentMessageChunkShape(t *testing.T) {
+	note, err := NewAgentMessageChunk("sess1", "m1", "hello")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if note.JSONRPC != "2.0" || note.Method != MethodSessionUpdate {
+		t.Fatalf("bad envelope: %+v", note)
+	}
+	var p UpdateParams
+	if err := json.Unmarshal(note.Params, &p); err != nil {
+		t.Fatal(err)
+	}
+	if p.SessionID != "sess1" {
+		t.Errorf("sessionId = %q", p.SessionID)
+	}
+	if p.Update.SessionUpdate != UpdateAgentMessageChunk {
+		t.Errorf("sessionUpdate = %q", p.Update.SessionUpdate)
+	}
+	if p.Update.MessageID != "m1" {
+		t.Errorf("messageId = %q", p.Update.MessageID)
+	}
+	if p.Update.Content.Type != ContentTypeText || p.Update.Content.Text != "hello" {
+		t.Errorf("content = %+v", p.Update.Content)
+	}
+}
+
+func TestNewLoadShape(t *testing.T) {
+	note, err := NewLoad("s", []Message{{Role: "user", Content: []ContentBlock{TextBlock("hi")}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if note.Method != MethodSessionLoad {
+		t.Fatalf("method = %q", note.Method)
+	}
+	var p LoadParams
+	if err := json.Unmarshal(note.Params, &p); err != nil {
+		t.Fatal(err)
+	}
+	if len(p.Messages) != 1 || p.Messages[0].Role != "user" {
+		t.Fatalf("messages = %+v", p.Messages)
+	}
+}
+
+func TestLoadHistory(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "conv.jsonl")
+	lines := []string{
+		`{"type":"session","id":"x","cwd":"/tmp"}`,
+		`{"type":"message","message":{"role":"user","content":[{"type":"text","text":"install cowsay"}]}}`,
+		`{"type":"message","message":{"role":"assistant","content":[{"type":"thinking","thinking":"skip me"},{"type":"text","text":"Sure!"}]}}`,
+		`{"type":"message","message":{"role":"toolResult","content":[{"type":"text","text":"dropped"}]}}`,
+		`{"type":"message","message":{"role":"user","content":"plain string form"}}`,
+	}
+	if err := os.WriteFile(path, []byte(join(lines)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	msgs, err := LoadHistory(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(msgs) != 3 {
+		t.Fatalf("want 3 messages (2 user, 1 assistant), got %d: %+v", len(msgs), msgs)
+	}
+	if msgs[0].Role != "user" || msgs[0].Content[0].Text != "install cowsay" {
+		t.Errorf("msg0 = %+v", msgs[0])
+	}
+	// thinking block dropped, only text surfaces
+	if msgs[1].Role != "assistant" || msgs[1].Content[0].Text != "Sure!" {
+		t.Errorf("msg1 = %+v", msgs[1])
+	}
+	if msgs[2].Content[0].Text != "plain string form" {
+		t.Errorf("msg2 = %+v", msgs[2])
+	}
+}
+
+func TestLoadHistoryMissingFileIsEmpty(t *testing.T) {
+	msgs, err := LoadHistory(filepath.Join(t.TempDir(), "nope.jsonl"))
+	if err != nil {
+		t.Fatalf("missing file should not error: %v", err)
+	}
+	if len(msgs) != 0 {
+		t.Fatalf("want empty, got %+v", msgs)
+	}
+	if m, _ := LoadHistory(""); m != nil {
+		t.Fatalf("empty path should be nil, got %+v", m)
+	}
+}
+
+func join(lines []string) string {
+	out := ""
+	for _, l := range lines {
+		out += l + "\n"
+	}
+	return out
+}

--- a/cli/gmux/internal/acp/history.go
+++ b/cli/gmux/internal/acp/history.go
@@ -1,0 +1,94 @@
+package acp
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"strings"
+)
+
+// LoadHistory reads a pi JSONL conversation file and returns the user +
+// assistant text messages as the ACP history snapshot.
+//
+// SCOPE (tracer #1): only user text and assistant text blocks are surfaced.
+// Thinking, toolCall, toolResult, and non-message records are skipped — later
+// slices add agent_thought_chunk / tool_call to both the stream and this
+// snapshot. A missing or unreadable file yields an empty history (nil, nil):
+// a brand-new session whose JSONL isn't written yet is not an error.
+func LoadHistory(path string) ([]Message, error) {
+	if path == "" {
+		return nil, nil
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	defer f.Close()
+
+	var out []Message
+	sc := bufio.NewScanner(f)
+	// pi messages can be large (long assistant turns); raise the line cap.
+	sc.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" {
+			continue
+		}
+		var rec struct {
+			Type    string `json:"type"`
+			Message *struct {
+				Role    string          `json:"role"`
+				Content json.RawMessage `json:"content"`
+			} `json:"message"`
+		}
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			continue // tolerate partial/corrupt trailing lines
+		}
+		if rec.Type != "message" || rec.Message == nil {
+			continue
+		}
+		role := rec.Message.Role
+		if role != "user" && role != "assistant" {
+			continue // drop toolResult and anything else this slice
+		}
+		text := extractText(rec.Message.Content)
+		if text == "" {
+			continue
+		}
+		out = append(out, Message{Role: role, Content: []ContentBlock{TextBlock(text)}})
+	}
+	if err := sc.Err(); err != nil {
+		return out, err
+	}
+	return out, nil
+}
+
+// extractText pulls concatenated text from a pi message content field, which
+// is either a plain string or an array of typed blocks. Only "text" blocks
+// contribute (thinking/toolCall are ignored this slice).
+func extractText(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s
+	}
+	var blocks []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(raw, &blocks); err != nil {
+		return ""
+	}
+	var b strings.Builder
+	for _, blk := range blocks {
+		if blk.Type == "text" {
+			b.WriteString(blk.Text)
+		}
+	}
+	return b.String()
+}

--- a/cli/gmux/internal/agentext/pi-ext.mjs
+++ b/cli/gmux/internal/agentext/pi-ext.mjs
@@ -17,6 +17,16 @@
 //   { op: "turn", phase: "start" }                       on agent loop start
 //   { op: "turn", phase: "end", outcome, title }         on agent loop end
 //
+// Events posted to POST /acp/ingest (ADR 0021 streaming conversation schema):
+//   { op: "message_start", messageId }        on assistant message_start
+//   { op: "chunk", messageId, delta }         per assistant text token
+//   { op: "message_end" }                     on assistant message_end
+//
+// The /acp/ingest channel is the token-level assistant-text feed the runner
+// turns into ACP session/update notifications. It is one-way and read-only
+// (the extension only observes; the write path is keystrokes, per ADR 0021 §6)
+// and, like /hook/event, fire-and-forget.
+//
 // `name`/`title` is pi's session name when it has one; until pi titles the
 // conversation we fall back to its first user message (truncated), so a working
 // session is identifiable by what it's about rather than a bare cwd. This
@@ -101,6 +111,38 @@ export default function (pi) {
   // normalize it. The runner decides what each outcome means for the sidebar.
   pi.on("agent_start", () => post(sock, { op: "turn", phase: "start" }));
 
+  // --- streaming assistant text (ADR 0021) --------------------------------
+  // Forward token-level assistant text to the runner's ACP ingest channel.
+  // message_start/message_end bound the assistant message; message_update
+  // carries the token-by-token stream via event.assistantMessageEvent, whose
+  // text_delta variant holds the incremental text in `.delta`. We forward only
+  // assistant text this slice (thinking/tool activity are later slices).
+  //
+  // messageId: pi's message_start carries event.message with an id; we reuse it
+  // to correlate the deltas of one message. Fall back to a monotonic counter
+  // if pi ever omits it.
+  let acpMsgId = "";
+  let acpMsgSeq = 0;
+
+  pi.on("message_start", (ev) => {
+    if (ev?.message?.role !== "assistant") return;
+    acpMsgId = String(ev.message.id ?? `m${++acpMsgSeq}`);
+    postACP(sock, { op: "message_start", messageId: acpMsgId });
+  });
+
+  pi.on("message_update", (ev) => {
+    const ame = ev?.assistantMessageEvent;
+    if (!ame || ame.type !== "text_delta" || !ame.delta) return;
+    if (!acpMsgId) acpMsgId = `m${++acpMsgSeq}`;
+    postACP(sock, { op: "chunk", messageId: acpMsgId, delta: ame.delta });
+  });
+
+  pi.on("message_end", (ev) => {
+    if (ev?.message?.role !== "assistant") return;
+    postACP(sock, { op: "message_end", messageId: acpMsgId });
+    acpMsgId = "";
+  });
+
   pi.on("agent_end", (ev, ctx) => {
     const msgs = ev.messages ?? [];
     let stopReason;
@@ -169,11 +211,55 @@ function truncateTitle(s) {
 }
 
 function post(socketPath, event) {
+  postTo(socketPath, "/hook/event", event);
+}
+
+// postACP forwards a streaming-conversation event to the runner's ACP ingest
+// channel. Unlike /hook/event (low-frequency, order-independent facts), token
+// deltas MUST arrive in order: independent fire-and-forget requests can
+// complete out of order and corrupt the reassembled text. So ACP posts are
+// serialized through a promise chain — each request is issued only after the
+// previous one has completed. Still fire-and-forget: errors are swallowed and
+// never surface into pi. Ordering is per-message and cheap over a local
+// socket.
+let acpChain = Promise.resolve();
+function postACP(socketPath, event) {
+  acpChain = acpChain.then(() => postToAwait(socketPath, "/acp/ingest", event)).catch(() => {});
+}
+
+// postToAwait issues a POST and resolves when the request completes (response
+// received or error), so callers can chain to preserve ordering.
+function postToAwait(socketPath, path, event) {
+  return new Promise((resolve) => {
+    try {
+      const body = Buffer.from(JSON.stringify(event), "utf8");
+      const req = http.request(
+        {
+          socketPath,
+          path,
+          method: "POST",
+          headers: { "content-type": "application/json", "content-length": body.length },
+        },
+        (res) => {
+          res.on("end", resolve);
+          res.on("error", resolve);
+          res.resume(); // drain
+        },
+      );
+      req.on("error", resolve); // never surface transport errors into pi
+      req.end(body);
+    } catch {
+      resolve();
+    }
+  });
+}
+
+function postTo(socketPath, path, event) {
   try {
     const body = Buffer.from(JSON.stringify(event), "utf8");
     const req = http.request({
       socketPath,
-      path: "/hook/event",
+      path,
       method: "POST",
       headers: { "content-type": "application/json", "content-length": body.length },
     });

--- a/cli/gmux/internal/agentext/pi-ext.mjs
+++ b/cli/gmux/internal/agentext/pi-ext.mjs
@@ -25,7 +25,8 @@
 // The /acp/ingest channel is the token-level assistant-text feed the runner
 // turns into ACP session/update notifications. It is one-way and read-only
 // (the extension only observes; the write path is keystrokes, per ADR 0021 §6)
-// and, like /hook/event, fire-and-forget.
+// and, like /hook/event, fire-and-forget — but ordered (see postACP). The full
+// contract is documented in docs/acp-conversation-stream.md.
 //
 // `name`/`title` is pi's session name when it has one; until pi titles the
 // conversation we fall back to its first user message (truncated), so a working
@@ -118,21 +119,24 @@ export default function (pi) {
   // text_delta variant holds the incremental text in `.delta`. We forward only
   // assistant text this slice (thinking/tool activity are later slices).
   //
-  // messageId: pi's message_start carries event.message with an id; we reuse it
-  // to correlate the deltas of one message. Fall back to a monotonic counter
-  // if pi ever omits it.
+  // messageId correlates the deltas of one assistant message so the runner and
+  // frontend can group them. pi's in-memory AssistantMessage has no id field,
+  // so we mint a monotonic per-turn counter on each assistant message_start.
+  // message_update fires only for assistant messages (per pi's event protocol),
+  // and we forward only text_delta — thinking/toolcall deltas are later slices.
   let acpMsgId = "";
   let acpMsgSeq = 0;
 
   pi.on("message_start", (ev) => {
     if (ev?.message?.role !== "assistant") return;
-    acpMsgId = String(ev.message.id ?? `m${++acpMsgSeq}`);
+    acpMsgId = `m${++acpMsgSeq}`;
     postACP(sock, { op: "message_start", messageId: acpMsgId });
   });
 
   pi.on("message_update", (ev) => {
     const ame = ev?.assistantMessageEvent;
     if (!ame || ame.type !== "text_delta" || !ame.delta) return;
+    // Open a message implicitly if a delta somehow precedes message_start.
     if (!acpMsgId) acpMsgId = `m${++acpMsgSeq}`;
     postACP(sock, { op: "chunk", messageId: acpMsgId, delta: ame.delta });
   });

--- a/cli/gmux/internal/agentext/pi_ext_acp_test.go
+++ b/cli/gmux/internal/agentext/pi_ext_acp_test.go
@@ -58,7 +58,7 @@ func TestPiExtForwardsAssistantTextDeltas(t *testing.T) {
 		const handlers = {};
 		ext({ on: (ev, fn) => { handlers[ev] = fn; } });
 		const ctx = {};
-		handlers.message_start({ message: { role: "assistant", id: "msg-1" } }, ctx);
+		handlers.message_start({ message: { role: "assistant" } }, ctx);
 		handlers.message_update({ assistantMessageEvent: { type: "text_delta", delta: "Hel" } }, ctx);
 		handlers.message_update({ assistantMessageEvent: { type: "text_delta", delta: "lo" } }, ctx);
 		// a non-text stream event must be ignored
@@ -109,8 +109,17 @@ func TestPiExtForwardsAssistantTextDeltas(t *testing.T) {
 	if text != "Hello" {
 		t.Errorf("forwarded text = %q, want %q", text, "Hello")
 	}
-	// messageId propagated from pi's message.id
-	if id, _ := got[0]["messageId"].(string); id != "msg-1" {
-		t.Errorf("messageId = %q, want msg-1", id)
+	// pi's in-memory AssistantMessage has no id, so the extension mints a
+	// per-turn counter; the same id must tag the whole message's deltas.
+	startID, _ := got[0]["messageId"].(string)
+	if startID != "m1" {
+		t.Errorf("message_start messageId = %q, want m1", startID)
+	}
+	for _, ev := range got {
+		if ev["op"] == "chunk" {
+			if id, _ := ev["messageId"].(string); id != startID {
+				t.Errorf("chunk messageId = %q, want %q", id, startID)
+			}
+		}
 	}
 }

--- a/cli/gmux/internal/agentext/pi_ext_acp_test.go
+++ b/cli/gmux/internal/agentext/pi_ext_acp_test.go
@@ -1,0 +1,116 @@
+package agentext
+
+import (
+	"encoding/json"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestPiExtForwardsAssistantTextDeltas drives the embedded pi-ext.mjs with a
+// stub `pi` that fires the assistant message lifecycle (message_start →
+// message_update text_delta ×N → message_end) and asserts the extension
+// forwards them one-way to the runner's /acp/ingest channel as
+// message_start / chunk / message_end (ADR 0021 tracer #1).
+func TestPiExtForwardsAssistantTextDeltas(t *testing.T) {
+	nodeBin, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("node not on PATH; skipping pi-ext behavior test")
+	}
+
+	dir := t.TempDir()
+	sockPath := filepath.Join(dir, "runner.sock")
+
+	// Fake runner: capture every POST /acp/ingest body.
+	var mu sync.Mutex
+	var acpEvents []map[string]any
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/acp/ingest" {
+			var ev map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&ev); err == nil {
+				mu.Lock()
+				acpEvents = append(acpEvents, ev)
+				mu.Unlock()
+			}
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})}
+	go srv.Serve(ln)
+	defer srv.Close()
+
+	extPath := filepath.Join(dir, "pi-ext.mjs")
+	if err := os.WriteFile(extPath, extSource, 0o644); err != nil {
+		t.Fatalf("materialize extension: %v", err)
+	}
+
+	driver := `
+		const ext = (await import(process.argv[2])).default;
+		const handlers = {};
+		ext({ on: (ev, fn) => { handlers[ev] = fn; } });
+		const ctx = {};
+		handlers.message_start({ message: { role: "assistant", id: "msg-1" } }, ctx);
+		handlers.message_update({ assistantMessageEvent: { type: "text_delta", delta: "Hel" } }, ctx);
+		handlers.message_update({ assistantMessageEvent: { type: "text_delta", delta: "lo" } }, ctx);
+		// a non-text stream event must be ignored
+		handlers.message_update({ assistantMessageEvent: { type: "reasoning_delta", delta: "nope" } }, ctx);
+		handlers.message_end({ message: { role: "assistant", id: "msg-1" } }, ctx);
+		await new Promise((r) => setTimeout(r, 300));
+	`
+	driverPath := filepath.Join(dir, "driver.mjs")
+	if err := os.WriteFile(driverPath, []byte(driver), 0o644); err != nil {
+		t.Fatalf("write driver: %v", err)
+	}
+	cmd := exec.Command(nodeBin, driverPath, extPath)
+	cmd.Env = append(os.Environ(), "GMUX_SESSION_SOCK="+sockPath)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("node driver: %v\n%s", err, out)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	var got []map[string]any
+	for {
+		mu.Lock()
+		got = append([]map[string]any(nil), acpEvents...)
+		mu.Unlock()
+		if len(got) >= 4 || time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	// Expect: message_start, chunk "Hel", chunk "lo", message_end.
+	// reasoning_delta must NOT appear.
+	var ops []string
+	var text string
+	for _, ev := range got {
+		op, _ := ev["op"].(string)
+		ops = append(ops, op)
+		if op == "chunk" {
+			d, _ := ev["delta"].(string)
+			text += d
+		}
+	}
+	if len(ops) != 4 {
+		t.Fatalf("want 4 acp events, got %d: %v", len(ops), ops)
+	}
+	if ops[0] != "message_start" || ops[3] != "message_end" {
+		t.Errorf("bounds ops = %v", ops)
+	}
+	if text != "Hello" {
+		t.Errorf("forwarded text = %q, want %q", text, "Hello")
+	}
+	// messageId propagated from pi's message.id
+	if id, _ := got[0]["messageId"].(string); id != "msg-1" {
+		t.Errorf("messageId = %q, want msg-1", id)
+	}
+}

--- a/cli/gmux/internal/ptyserver/acp.go
+++ b/cli/gmux/internal/ptyserver/acp.go
@@ -97,20 +97,31 @@ func (h *acpHub) snapshotLocked(convFile string) (acp.Notification, error) {
 	msgs, _ := acp.LoadHistory(convFile) // best-effort; empty history is fine
 	if h.tailActive && h.tailText != "" {
 		msgs = append(msgs, acp.Message{
-			Role:    "assistant",
-			Content: []acp.ContentBlock{acp.TextBlock(h.tailText)},
+			Role:      "assistant",
+			MessageID: h.tailMsgID, // lets a mid-turn joiner keep appending live deltas
+			Content:   []acp.ContentBlock{acp.TextBlock(h.tailText)},
 		})
 	}
 	return acp.NewLoad(h.sessionID, msgs)
 }
 
-// subscribe registers a new subscriber channel. Buffered so brief frontend
-// stalls don't block ingest.
-func (h *acpHub) subscribe() chan acp.Notification {
-	ch := make(chan acp.Notification, 256)
+// attach atomically builds the session/load snapshot and registers a live
+// subscriber under the same lock, so no session/update delta can be broadcast
+// in the gap between reading the snapshot and subscribing (the snapshot-then-
+// stream ordering guarantee, ADR 0004/0021).
+func (h *acpHub) attach(convFile string) (acp.Notification, chan acp.Notification, error) {
 	h.mu.Lock()
+	defer h.mu.Unlock()
+	snapshot, err := h.snapshotLocked(convFile)
+	ch := h.addSubLocked()
+	return snapshot, ch, err
+}
+
+// addSubLocked registers and returns a new buffered subscriber, sized so brief
+// frontend stalls don't block ingest. Caller holds mu.
+func (h *acpHub) addSubLocked() chan acp.Notification {
+	ch := make(chan acp.Notification, 256)
 	h.subs[ch] = struct{}{}
-	h.mu.Unlock()
 	return ch
 }
 
@@ -178,13 +189,7 @@ func (s *Server) handleACP(w http.ResponseWriter, r *http.Request) {
 		convFile = s.state.ConversationFileSnapshot()
 	}
 
-	// Register the subscriber and build the snapshot under the same lock so no
-	// live delta can be broadcast between the snapshot read and subscription.
-	s.acp.mu.Lock()
-	snapshot, snapErr := s.acp.snapshotLocked(convFile)
-	ch := make(chan acp.Notification, 256)
-	s.acp.subs[ch] = struct{}{}
-	s.acp.mu.Unlock()
+	snapshot, ch, snapErr := s.acp.attach(convFile)
 	defer s.acp.unsubscribe(ch)
 
 	if snapErr == nil {

--- a/cli/gmux/internal/ptyserver/acp.go
+++ b/cli/gmux/internal/ptyserver/acp.go
@@ -1,0 +1,226 @@
+package ptyserver
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"sync"
+
+	"github.com/gmuxapp/gmux/cli/gmux/internal/acp"
+	"nhooyr.io/websocket"
+)
+
+// acpHub synthesizes the ACP conversation stream (ADR 0021) for one session.
+//
+// It holds ONLY the in-memory unwritten tail — the in-flight partial assistant
+// message and its accumulated text — and forgets it the moment pi finalizes
+// the message to JSONL (message_end). Durable history lives in the JSONL file
+// the runner already owns; the daemon holds no conversation content
+// (ADR 0011). This mirrors the PTY ring-buffer + persistent-scrollback split
+// (ADR 0016): a small live buffer for what hasn't been persisted, disk for the
+// rest.
+//
+// The hub fans token deltas out to any number of /acp WebSocket subscribers.
+// Sends are non-blocking with a buffered channel; a slow client drops frames
+// rather than stalling the ingest path (backpressure note in the PR).
+type acpHub struct {
+	sessionID string
+
+	mu   sync.Mutex
+	subs map[chan acp.Notification]struct{}
+
+	// In-memory unwritten tail: the current partial assistant message.
+	// tailActive is false between turns (nothing unflushed).
+	tailActive bool
+	tailMsgID  string
+	tailText   string
+}
+
+func newACPHub(sessionID string) *acpHub {
+	return &acpHub{
+		sessionID: sessionID,
+		subs:      make(map[chan acp.Notification]struct{}),
+	}
+}
+
+// acpIngest is the one-way payload the read-only pi extension POSTs to
+// /acp/ingest. It is deliberately tiny: begin a message, append a token
+// delta, or finalize. See pi-ext.mjs.
+type acpIngest struct {
+	Op        string `json:"op"`                  // "message_start" | "chunk" | "message_end"
+	MessageID string `json:"messageId,omitempty"` // stable id for the in-flight message
+	Delta     string `json:"delta,omitempty"`     // token-level text (op "chunk")
+}
+
+// ingest applies one extension event: it updates the unwritten tail and, for a
+// chunk, broadcasts an agent_message_chunk to live subscribers.
+func (h *acpHub) ingest(ev acpIngest) {
+	switch ev.Op {
+	case "message_start":
+		h.mu.Lock()
+		h.tailActive = true
+		h.tailMsgID = ev.MessageID
+		h.tailText = ""
+		h.mu.Unlock()
+	case "chunk":
+		h.mu.Lock()
+		if !h.tailActive {
+			// A chunk with no preceding message_start (e.g. extension loaded
+			// mid-turn): open a tail implicitly so nothing is lost.
+			h.tailActive = true
+			h.tailMsgID = ev.MessageID
+		}
+		h.tailText += ev.Delta
+		msgID := h.tailMsgID
+		h.mu.Unlock()
+		if note, err := acp.NewAgentMessageChunk(h.sessionID, msgID, ev.Delta); err == nil {
+			h.broadcast(note)
+		}
+	case "message_end":
+		// pi has appended the finalized message to JSONL; forget the tail so
+		// session/load reads it from disk, not from memory (ADR 0011/0016).
+		h.mu.Lock()
+		h.tailActive = false
+		h.tailMsgID = ""
+		h.tailText = ""
+		h.mu.Unlock()
+	}
+}
+
+// snapshot builds the session/load history: durable JSONL messages plus the
+// in-memory unwritten tail (the current partial assistant message, if any).
+// Returns the frame under the same lock that registers the subscriber (caller
+// coordinates) so no live delta can slip in before the snapshot.
+func (h *acpHub) snapshotLocked(convFile string) (acp.Notification, error) {
+	msgs, _ := acp.LoadHistory(convFile) // best-effort; empty history is fine
+	if h.tailActive && h.tailText != "" {
+		msgs = append(msgs, acp.Message{
+			Role:    "assistant",
+			Content: []acp.ContentBlock{acp.TextBlock(h.tailText)},
+		})
+	}
+	return acp.NewLoad(h.sessionID, msgs)
+}
+
+// subscribe registers a new subscriber channel. Buffered so brief frontend
+// stalls don't block ingest.
+func (h *acpHub) subscribe() chan acp.Notification {
+	ch := make(chan acp.Notification, 256)
+	h.mu.Lock()
+	h.subs[ch] = struct{}{}
+	h.mu.Unlock()
+	return ch
+}
+
+func (h *acpHub) unsubscribe(ch chan acp.Notification) {
+	h.mu.Lock()
+	if _, ok := h.subs[ch]; ok {
+		delete(h.subs, ch)
+		close(ch)
+	}
+	h.mu.Unlock()
+}
+
+// broadcast fans a notification to all subscribers, dropping frames for any
+// client whose buffer is full (backpressure: the wire is token-chatty; a
+// stalled renderer must not stall ingest).
+func (h *acpHub) broadcast(note acp.Notification) {
+	h.mu.Lock()
+	for ch := range h.subs {
+		select {
+		case ch <- note:
+		default:
+		}
+	}
+	h.mu.Unlock()
+}
+
+// handleACPIngest is the one-way sink for the read-only pi extension's token
+// deltas. Fire-and-forget: like /hook/event, it never pushes back on pi.
+func (s *Server) handleACPIngest(w http.ResponseWriter, r *http.Request) {
+	if s.acp == nil {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	var ev acpIngest
+	if err := json.NewDecoder(io.LimitReader(r.Body, 512*1024)).Decode(&ev); err != nil {
+		http.Error(w, "invalid JSON: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	s.acp.ingest(ev)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// handleACP serves the ACP conversation WebSocket: snapshot-then-stream,
+// mirroring the PTY attach (ADR 0004). The first frame is the session/load
+// history snapshot; subsequent frames are live session/update notifications.
+// Frames are JSON text messages (JSON-RPC 2.0 objects).
+func (s *Server) handleACP(w http.ResponseWriter, r *http.Request) {
+	if s.acp == nil {
+		http.Error(w, "acp not available", http.StatusNotFound)
+		return
+	}
+	conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
+		InsecureSkipVerify: true, // local Unix socket / authed upstream
+	})
+	if err != nil {
+		log.Printf("ptyserver: acp ws accept: %v", err)
+		return
+	}
+	ctx, cancel := context.WithCancel(r.Context())
+	defer cancel()
+	defer conn.Close(websocket.StatusNormalClosure, "")
+
+	convFile := ""
+	if s.state != nil {
+		convFile = s.state.ConversationFileSnapshot()
+	}
+
+	// Register the subscriber and build the snapshot under the same lock so no
+	// live delta can be broadcast between the snapshot read and subscription.
+	s.acp.mu.Lock()
+	snapshot, snapErr := s.acp.snapshotLocked(convFile)
+	ch := make(chan acp.Notification, 256)
+	s.acp.subs[ch] = struct{}{}
+	s.acp.mu.Unlock()
+	defer s.acp.unsubscribe(ch)
+
+	if snapErr == nil {
+		if data, err := json.Marshal(snapshot); err == nil {
+			if err := conn.Write(ctx, websocket.MessageText, data); err != nil {
+				return
+			}
+		}
+	}
+
+	// Drain client reads (this slice has no client→server messages, but we must
+	// read to observe close) while we push notifications.
+	go func() {
+		for {
+			if _, _, err := conn.Read(ctx); err != nil {
+				cancel()
+				return
+			}
+		}
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case note, ok := <-ch:
+			if !ok {
+				return
+			}
+			data, err := json.Marshal(note)
+			if err != nil {
+				continue
+			}
+			if err := conn.Write(ctx, websocket.MessageText, data); err != nil {
+				return
+			}
+		}
+	}
+}

--- a/cli/gmux/internal/ptyserver/acp_test.go
+++ b/cli/gmux/internal/ptyserver/acp_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestACPHubBroadcastsChunks(t *testing.T) {
 	h := newACPHub("sess1")
-	ch := h.subscribe()
+	_, ch, _ := h.attach("") // subscribe to the live stream
 
 	h.ingest(acpIngest{Op: "message_start", MessageID: "m1"})
 	h.ingest(acpIngest{Op: "chunk", MessageID: "m1", Delta: "Hel"})
@@ -41,6 +41,11 @@ func TestACPHubSnapshotIncludesUnwrittenTail(t *testing.T) {
 	}
 	if p.Messages[0].Content[0].Text != "partial" {
 		t.Errorf("tail text = %q", p.Messages[0].Content[0].Text)
+	}
+	// The tail must carry its streaming messageId so a mid-turn joiner keeps
+	// appending subsequent deltas to the same message rather than duplicating it.
+	if p.Messages[0].MessageID != "m1" {
+		t.Errorf("tail messageId = %q, want m1", p.Messages[0].MessageID)
 	}
 }
 

--- a/cli/gmux/internal/ptyserver/acp_test.go
+++ b/cli/gmux/internal/ptyserver/acp_test.go
@@ -1,0 +1,76 @@
+package ptyserver
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/gmuxapp/gmux/cli/gmux/internal/acp"
+)
+
+func TestACPHubBroadcastsChunks(t *testing.T) {
+	h := newACPHub("sess1")
+	ch := h.subscribe()
+
+	h.ingest(acpIngest{Op: "message_start", MessageID: "m1"})
+	h.ingest(acpIngest{Op: "chunk", MessageID: "m1", Delta: "Hel"})
+	h.ingest(acpIngest{Op: "chunk", MessageID: "m1", Delta: "lo"})
+
+	got := drainText(t, ch, 2)
+	if got != "Hello" {
+		t.Fatalf("broadcast deltas = %q, want %q", got, "Hello")
+	}
+}
+
+func TestACPHubSnapshotIncludesUnwrittenTail(t *testing.T) {
+	h := newACPHub("sess1")
+	h.ingest(acpIngest{Op: "message_start", MessageID: "m1"})
+	h.ingest(acpIngest{Op: "chunk", MessageID: "m1", Delta: "partial"})
+
+	h.mu.Lock()
+	note, err := h.snapshotLocked("") // no JSONL; only the in-mem tail
+	h.mu.Unlock()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var p acp.LoadParams
+	if err := json.Unmarshal(note.Params, &p); err != nil {
+		t.Fatal(err)
+	}
+	if len(p.Messages) != 1 || p.Messages[0].Role != "assistant" {
+		t.Fatalf("snapshot messages = %+v", p.Messages)
+	}
+	if p.Messages[0].Content[0].Text != "partial" {
+		t.Errorf("tail text = %q", p.Messages[0].Content[0].Text)
+	}
+}
+
+func TestACPHubForgetsTailAfterMessageEnd(t *testing.T) {
+	h := newACPHub("sess1")
+	h.ingest(acpIngest{Op: "message_start", MessageID: "m1"})
+	h.ingest(acpIngest{Op: "chunk", MessageID: "m1", Delta: "done"})
+	h.ingest(acpIngest{Op: "message_end", MessageID: "m1"})
+
+	h.mu.Lock()
+	note, _ := h.snapshotLocked("") // JSONL now owns it; memory forgot it
+	h.mu.Unlock()
+	var p acp.LoadParams
+	_ = json.Unmarshal(note.Params, &p)
+	if len(p.Messages) != 0 {
+		t.Fatalf("tail should be forgotten after message_end, got %+v", p.Messages)
+	}
+}
+
+// drainText reads n notifications and concatenates their text deltas.
+func drainText(t *testing.T, ch chan acp.Notification, n int) string {
+	t.Helper()
+	out := ""
+	for i := 0; i < n; i++ {
+		note := <-ch
+		var p acp.UpdateParams
+		if err := json.Unmarshal(note.Params, &p); err != nil {
+			t.Fatal(err)
+		}
+		out += p.Update.Content.Text
+	}
+	return out
+}

--- a/cli/gmux/internal/ptyserver/acp_ws_test.go
+++ b/cli/gmux/internal/ptyserver/acp_ws_test.go
@@ -1,0 +1,105 @@
+package ptyserver
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gmuxapp/gmux/cli/gmux/internal/acp"
+	"github.com/gmuxapp/gmux/cli/gmux/internal/session"
+	"github.com/gmuxapp/gmux/packages/adapter/adapters"
+	"nhooyr.io/websocket"
+)
+
+// TestACPWebSocketSnapshotThenStream is an end-to-end transport test: a client
+// attaching to /acp gets the session/load snapshot (durable JSONL history)
+// first, then live session/update deltas ingested afterward (ADR 0021 §3).
+func TestACPWebSocketSnapshotThenStream(t *testing.T) {
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("node not available")
+	}
+	dir := t.TempDir()
+	sockPath := filepath.Join(dir, "test.sock")
+	convFile := filepath.Join(dir, "conv.jsonl")
+	if err := os.WriteFile(convFile, []byte(
+		`{"type":"message","message":{"role":"user","content":[{"type":"text","text":"hi there"}]}}`+"\n",
+	), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	st := session.New(session.Config{ID: "s1", Adapter: "pi", SocketPath: sockPath})
+	st.SetConversationFile(convFile)
+	srv, err := New(Config{
+		Command:    []string{node, "-e", "setTimeout(()=>{},5000)"},
+		Cwd:        dir,
+		Listener:   mustBindSocket(t, sockPath),
+		SocketPath: sockPath,
+		Adapter:    adapters.NewPi(),
+		State:      st,
+	})
+	if err != nil {
+		t.Fatalf("new server: %v", err)
+	}
+	defer srv.Shutdown()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	dialer := &http.Client{Transport: &http.Transport{DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+		return net.Dial("unix", sockPath)
+	}}}
+	conn, _, err := websocket.Dial(ctx, "ws://unix/acp", &websocket.DialOptions{HTTPClient: dialer})
+	if err != nil {
+		t.Fatalf("dial /acp: %v", err)
+	}
+	defer conn.Close(websocket.StatusNormalClosure, "")
+
+	// First frame: session/load with the JSONL history.
+	load := readNote(t, ctx, conn)
+	if load.Method != acp.MethodSessionLoad {
+		t.Fatalf("first frame method = %q, want %q", load.Method, acp.MethodSessionLoad)
+	}
+	var lp acp.LoadParams
+	if err := json.Unmarshal(load.Params, &lp); err != nil {
+		t.Fatal(err)
+	}
+	if len(lp.Messages) != 1 || lp.Messages[0].Content[0].Text != "hi there" {
+		t.Fatalf("snapshot messages = %+v", lp.Messages)
+	}
+
+	// Now ingest a live delta and expect a session/update frame.
+	srv.acp.ingest(acpIngest{Op: "message_start", MessageID: "m1"})
+	srv.acp.ingest(acpIngest{Op: "chunk", MessageID: "m1", Delta: "yo"})
+
+	upd := readNote(t, ctx, conn)
+	if upd.Method != acp.MethodSessionUpdate {
+		t.Fatalf("live frame method = %q, want %q", upd.Method, acp.MethodSessionUpdate)
+	}
+	var up acp.UpdateParams
+	if err := json.Unmarshal(upd.Params, &up); err != nil {
+		t.Fatal(err)
+	}
+	if up.Update.Content.Text != "yo" {
+		t.Fatalf("live delta = %q", up.Update.Content.Text)
+	}
+}
+
+func readNote(t *testing.T, ctx context.Context, conn *websocket.Conn) acp.Notification {
+	t.Helper()
+	_, data, err := conn.Read(ctx)
+	if err != nil {
+		t.Fatalf("ws read: %v", err)
+	}
+	var n acp.Notification
+	if err := json.Unmarshal(data, &n); err != nil {
+		t.Fatalf("unmarshal frame: %v", err)
+	}
+	return n
+}

--- a/cli/gmux/internal/ptyserver/ptyserver.go
+++ b/cli/gmux/internal/ptyserver/ptyserver.go
@@ -169,6 +169,8 @@ type Server struct {
 	screenPending  []byte         // raw PTY data not yet fed to screen (guarded by mu)
 	lastClientLeft time.Time      // when the last WS client disconnected (guarded by mu)
 
+	acp *acpHub // ACP conversation stream synthesizer (ADR 0021)
+
 	done    chan struct{} // closed when child exits
 	ptyDone chan struct{} // closed when readPTY finishes draining
 	err     error         // child exit error
@@ -320,6 +322,12 @@ func New(cfg Config) (*Server, error) {
 		done:       make(chan struct{}),
 		ptyDone:    make(chan struct{}),
 	}
+	// ACP conversation hub (ADR 0021): synthesizes session/load + session/update
+	// from the read-only pi extension's token deltas. sessionID drives the
+	// sessionId field on every ACP frame.
+	if cfg.State != nil {
+		s.acp = newACPHub(cfg.State.ID)
+	}
 
 	// The callback fires under s.mu (held during drainScreenLocked → screen.Write).
 	s.screen = newScreen(int(cfg.Cols), int(cfg.Rows), func(visible bool) {
@@ -470,6 +478,11 @@ func (s *Server) serve() {
 	mux.HandleFunc("PUT /slug", s.handlePutSlug)
 	mux.HandleFunc("GET /events", s.handleEvents)
 	mux.HandleFunc("POST /kill", s.handleKill)
+
+	// ACP conversation stream (ADR 0021): one-way ingest from the read-only pi
+	// extension, and the snapshot-then-stream WebSocket the frontend attaches to.
+	mux.HandleFunc("POST /acp/ingest", s.handleACPIngest)
+	mux.HandleFunc("/acp", s.handleACP)
 
 	// WebSocket terminal attach (fallback for / with Upgrade header)
 	mux.HandleFunc("/", s.handleWS)

--- a/docs/acp-conversation-stream.md
+++ b/docs/acp-conversation-stream.md
@@ -1,0 +1,88 @@
+# ACP conversation stream: runner-synthesized `session/update`
+
+**Status:** Tracer (streaming assistant text only) · **Related:** ADR 0021, ADR 0004, ADR 0011, ADR 0016, `cli/gmux/internal/acp`, `cli/gmux/internal/ptyserver`
+
+gmux adopts a minimal subset of the Agent Client Protocol (ACP) as its internal
+normalized conversation schema (ADR 0021). The runner produces it; one frontend
+client consumes it. For terminal pi the runner **synthesizes** the stream from
+the read-only pi extension; a future ACP-native adapter re-publishes the same
+shapes from a real agent. Everything above the runner is adapter-agnostic.
+
+This document is the wire contract for the **first tracer slice: streaming
+assistant text**. Later slices extend it (thinking, tool calls, prompt/cancel);
+they add variants without breaking these shapes.
+
+## Two channels
+
+### 1. Extension → runner ingest (`POST /acp/ingest`, one-way)
+
+The read-only pi extension (`agentext/pi-ext.mjs`) forwards token-level
+assistant text over the same `GMUX_SESSION_SOCK` it uses for `/hook/event`.
+Fire-and-forget, but — unlike `/hook/event` — **ordered**: token deltas must
+arrive in sequence, so the extension serializes these POSTs through a promise
+chain (independent fire-and-forget requests can complete out of order and
+corrupt the reassembled text).
+
+```jsonc
+{ "op": "message_start", "messageId": "m1" }            // assistant message begins
+{ "op": "chunk", "messageId": "m1", "delta": "Hel" }     // one token-level text delta
+{ "op": "message_end", "messageId": "m1" }               // pi finalized it to JSONL
+```
+
+`messageId` is a per-turn monotonic counter minted by the extension (pi's
+in-memory `AssistantMessage` has no id). It correlates the deltas of one
+message. Sourced from pi's `message_start` / `message_update`
+(`assistantMessageEvent.type === "text_delta"`) / `message_end` events; only
+`text_delta` is forwarded this slice.
+
+### 2. Runner → client stream (`/acp` WebSocket, snapshot-then-stream)
+
+Mirrors the PTY attach (ADR 0004): on connect the server pushes the history
+**snapshot** first, then streams **live** notifications. Frames are JSON-RPC
+2.0 objects as WebSocket **text** messages. This slice has no client→server
+messages (the write path is keystrokes via `/input`, per ADR 0021 §6).
+
+```jsonc
+// First frame — the history snapshot (server-initiated, not a client request).
+{ "jsonrpc": "2.0", "method": "session/load",
+  "params": { "sessionId": "...", "messages": [
+    { "role": "user", "content": [{ "type": "text", "text": "hi" }] },
+    // The in-flight assistant tail (if any) carries its streaming messageId so a
+    // mid-turn joiner keeps appending live deltas to the same message.
+    { "role": "assistant", "messageId": "m1", "content": [{ "type": "text", "text": "Hel" }] }
+  ] } }
+
+// Live frames — token deltas.
+{ "jsonrpc": "2.0", "method": "session/update",
+  "params": { "sessionId": "...", "update": {
+    "sessionUpdate": "agent_message_chunk", "messageId": "m1",
+    "content": { "type": "text", "text": "lo" } } } }
+```
+
+## Content ownership (ADR 0011 / 0016 intact)
+
+- The **daemon holds no conversation content** — gmuxd is a transparent
+  WebSocket proxy (`/acp/{sessionId}` → runner `/acp`).
+- The **runner holds only the unwritten tail**: the in-flight partial assistant
+  message and its accumulated text. It is dropped on `message_end`, once pi has
+  persisted the message to its JSONL. This mirrors the PTY ring-buffer +
+  scrollback split (ADR 0016).
+- `session/load` = durable JSONL history **+** the in-memory tail. Live stream =
+  tokens as they arrive.
+
+## Backpressure
+
+Tokens are chatty. The runner broadcasts per-token and **drops frames for a
+subscriber whose buffer is full** rather than stalling ingest; the frontend
+coalesces deltas into one render per burst.
+
+## Known limits (this slice)
+
+- Only `agent_message_chunk` (assistant text). Thinking, tool calls,
+  `session/prompt`, `session/cancel` are later slices.
+- **Stitch-across-flush window:** between `message_end` (tail forgotten) and pi
+  actually appending to JSONL, a client connecting in that gap can miss the
+  just-finished message from its snapshot. Full parity hardening is a later
+  slice (ADR 0021 migration plan step 3).
+- Peer (remote-session) proxying of the ACP stream is not implemented; gmuxd
+  returns `501` for remote sessions.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,9 @@ importers:
       '@preact/preset-vite':
         specifier: ^2.10.2
         version: 2.10.3(@babel/core@7.29.0)(preact@10.29.0)(rollup@4.59.0)(vite@6.4.1(@types/node@24.12.0)(tsx@4.21.0))
+      preact-render-to-string:
+        specifier: ^6.6.6
+        version: 6.6.6(preact@10.29.0)
       typescript:
         specifier: ^5.8.2
         version: 5.9.3

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -1832,6 +1832,21 @@ func serve(stderr io.Writer) int {
 		wsProxy.Handler()(w, r)
 	})
 
+	// ── ACP conversation stream (ADR 0021) ──
+	// Snapshot-then-stream conversation WebSocket, proxied to the runner's
+	// /acp endpoint. Local sessions only for this tracer slice; peer proxying
+	// (remote sessions) is a documented follow-up.
+	mux.HandleFunc("/acp/{sessionID}", func(w http.ResponseWriter, r *http.Request) {
+		sessionID := r.PathValue("sessionID")
+		if peerManager != nil {
+			if peer, _ := peerManager.FindPeer(sessionID); peer != nil {
+				http.Error(w, "acp stream not yet proxied for remote sessions", http.StatusNotImplemented)
+				return
+			}
+		}
+		wsProxy.ACPHandler()(w, r)
+	})
+
 	// ── Presence WebSocket ──
 
 	mux.HandleFunc("/v1/presence", func(w http.ResponseWriter, r *http.Request) {

--- a/services/gmuxd/internal/netauth/netauth.go
+++ b/services/gmuxd/internal/netauth/netauth.go
@@ -246,7 +246,8 @@ func normalizeHost(h string) string {
 
 func isAPIRequest(r *http.Request) bool {
 	// WebSocket upgrades, API paths, and SSE requests are programmatic.
-	if strings.HasPrefix(r.URL.Path, "/v1/") || strings.HasPrefix(r.URL.Path, "/ws/") {
+	if strings.HasPrefix(r.URL.Path, "/v1/") || strings.HasPrefix(r.URL.Path, "/ws/") ||
+		strings.HasPrefix(r.URL.Path, "/acp/") {
 		return true
 	}
 	if strings.EqualFold(r.Header.Get("Upgrade"), "websocket") {

--- a/services/gmuxd/internal/wsproxy/wsproxy.go
+++ b/services/gmuxd/internal/wsproxy/wsproxy.go
@@ -155,6 +155,74 @@ func (p *Proxy) Handler() http.HandlerFunc {
 	}
 }
 
+// ACPHandler returns the http.HandlerFunc for /acp/{sessionID}: the ACP
+// conversation stream (ADR 0021). Unlike the PTY proxy it is a transparent
+// bidirectional pipe with no resize interception — it carries JSON-RPC 2.0
+// text frames (session/load snapshot then session/update deltas). Local
+// sessions only for this tracer slice; peer proxying is a follow-up.
+func (p *Proxy) ACPHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		sessionID := r.PathValue("sessionID")
+		if sessionID == "" {
+			http.Error(w, "missing session_id", http.StatusBadRequest)
+			return
+		}
+		sockPath, err := p.resolve(sessionID)
+		if err != nil {
+			log.Printf("wsproxy: acp resolve %s: %v", sessionID, err)
+			http.Error(w, fmt.Sprintf("session not found: %v", err), http.StatusNotFound)
+			return
+		}
+		clientConn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
+			InsecureSkipVerify: true,
+		})
+		if err != nil {
+			log.Printf("wsproxy: acp accept: %v", err)
+			return
+		}
+		ctx := r.Context()
+		backendConn, _, err := websocket.Dial(ctx, "ws://localhost/acp", &websocket.DialOptions{
+			HTTPClient: &http.Client{
+				Transport: &http.Transport{
+					DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+						return net.Dial("unix", sockPath)
+					},
+				},
+			},
+		})
+		if err != nil {
+			log.Printf("wsproxy: acp dial backend %s: %v", sockPath, err)
+			clientConn.Close(websocket.StatusInternalError, "backend unavailable")
+			return
+		}
+		clientConn.SetReadLimit(256 * 1024)
+		backendConn.SetReadLimit(4 * 1024 * 1024) // session/load snapshot can be large
+
+		proxyCtx, proxyCancel := context.WithCancel(ctx)
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() { defer wg.Done(); defer proxyCancel(); pipeWS(proxyCtx, backendConn, clientConn) }()
+		go func() { defer wg.Done(); defer proxyCancel(); pipeWS(proxyCtx, clientConn, backendConn) }()
+		wg.Wait()
+
+		clientConn.Close(websocket.StatusNormalClosure, "")
+		backendConn.Close(websocket.StatusNormalClosure, "")
+	}
+}
+
+// pipeWS forwards every frame from src to dst until either side errors.
+func pipeWS(ctx context.Context, src, dst *websocket.Conn) {
+	for {
+		typ, data, err := src.Read(ctx)
+		if err != nil {
+			return
+		}
+		if err := dst.Write(ctx, typ, data); err != nil {
+			return
+		}
+	}
+}
+
 // proxyClientToBackend forwards all client messages to the backend.
 // Resize messages are tagged with source=web_client before forwarding.
 func (p *Proxy) proxyClientToBackend(ctx context.Context, client, backend *websocket.Conn) {


### PR DESCRIPTION
## Tracer #1 — streaming assistant text, end-to-end (ADR 0021)

The foundational HITL tracer for **ADR 0021** (ACP `session/update` as gmux's internal conversation schema). It proves schema + transport + renderer on the narrowest slice — **streaming assistant text only** — and sets the conventions later slices build on. Wire contract documented in **`docs/acp-conversation-stream.md`**.

### Flow
```
pi extension (read-only, one-way, ordered)
  → POST /acp/ingest (token deltas)
  → runner acpHub: synthesizes ACP session/load snapshot + session/update stream
  → runner /acp WebSocket (snapshot-then-stream, mirrors PTY attach, ADR 0004)
  → gmuxd /acp/{id} proxy
  → gmux-web conversation panel (live assistant text)
```

### Content ownership (ADR 0011 / 0016 intact)
- Daemon holds **no** conversation content — it's a transparent WS proxy.
- Runner keeps only the **in-memory unwritten tail** (current partial assistant message) and **forgets it** on `message_end`, once pi has persisted it to JSONL.
- `session/load` = durable JSONL history **+** the in-mem tail; live stream = tokens.

## Conventions established — please review

1. **WS framing.** JSON-RPC 2.0 objects over a WebSocket. Endpoint: runner `/acp`, proxied at gmuxd `/acp/{sessionId}`. The server **pushes `session/load` as the first frame** (the history snapshot), then streams `session/update` notifications — no client→server `session/load` request this slice; the snapshot is server-initiated exactly like the PTY `renderScreen` frame.

2. **Schema home.** Go types in `cli/gmux/internal/acp` (runner-only; the daemon doesn't parse). TS types local to `gmux-web` (`conversation.ts`). Deliberately minimal: only `session/load` + `session/update: agent_message_chunk`.

3. **Token volume / ordering.** Per-token on the wire. The extension **serializes** its ACP posts through a promise chain so token order is preserved (independent fire-and-forget POSTs can otherwise arrive out of order and corrupt the text). Runner broadcast is non-blocking and **drops frames for a slow subscriber** (backpressure). Frontend **coalesces** deltas into one render per microtask burst.

4. **Renderer — `assistant-ui` NOT adopted (needs a call).** ADR 0021 and the brief suggest `@assistant-ui/react`, but **gmux-web is Preact, not React**. Pulling in `react`/`react-dom` behind `preact/compat`, or standing up a dedicated React island, is a consequential dependency + build decision I didn't want the foundational tracer to bake in silently. This slice ships a **minimal native Preact conversation view** over the same store. The store (`conversation.ts`) is UI-framework-agnostic, so the renderer can be swapped in a focused follow-up. **Decision needed:** compat-alias React, React island, or stay native?

## Try it
Open a pi session under gmux, then load the session with `?conv` in the URL — the terminal stays primary and keeps working; the conversation panel streams assistant text live over the same session.

## Commits
1. **feat(acp): stream assistant text end-to-end** — the tracer (schema, extension, runner, proxy, frontend, tests).
2. **refactor(acp): verify pi event shapes, fix mid-turn message continuity, document protocol** — post-review hardening:
   - Verified pi's event shapes against its typed protocol: `AssistantMessage` has **no `id`**, so the extension mints a per-turn `messageId` counter (removed a dead `message.id` lookup + misleading comment). Confirmed `message_update` is assistant-only and the `text_delta.delta` shape.
   - **Mid-turn continuity fix:** the `session/load` snapshot now tags the in-flight assistant tail with its streaming `messageId` so a client joining mid-turn keeps appending subsequent deltas to the *same* message instead of a duplicate bubble — makes the ADR's "connects mid-turn then continues streaming" criterion actually hold.
   - Extracted the snapshot+subscribe locking invariant into `acpHub.attach()`.
   - Added `docs/acp-conversation-stream.md`.

## Out of scope (later slices; stubbed/omitted, not half-built)
`agent_thought_chunk`, `tool_call`/`tool_call_update`, `session/prompt`, `session/cancel`, `tail --clean/--json`, ACP-native adapter, and **peer proxying of the ACP stream** (remote sessions return `501`). Also the **stitch-across-flush window** (a client connecting between `message_end` and pi's JSONL append can miss the just-finished message) — full parity hardening is a later slice, documented in the protocol doc.

## Tests
- `pi_ext_acp_test.go` — extension→runner delta forwarding, ordering, and messageId consistency, driving the real `pi-ext.mjs` under node.
- `acp_test.go` (acp pkg) — schema shapes + JSONL history assembly (text/thinking/toolResult/plain-string).
- `acp_test.go` / `acp_ws_test.go` (ptyserver) — hub broadcast, unwritten-tail snapshot incl. messageId, forget-after-`message_end`, and full `/acp` WS snapshot-then-stream.
- `conversation.test.ts` / `conversation-view.test.tsx` — coalescing store, mid-turn continuation, Preact render.

Go (`cli/gmux`, `services/gmuxd`) and web (`pnpm test`, 570 tests) suites green; `tsc` and `vite build` clean.

Refs ADR 0021.
