### PR TITLE
fix(web): show reconnecting pill when the SSE control-plane drops

### DIFF
--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -689,8 +689,21 @@ function App() {
   const keyBarShown = !!selectedVal && (canAttach || USE_MOCK) && !!termOpts && !!keybindsVal
   const replayShown = !keyBarShown && !!selectedVal && !selectedVal.alive && !!termOpts && !USE_MOCK
 
+  // App-level reconnecting cue for the SSE control-plane. Distinct from
+  // the per-terminal WS pill: it covers the sidebar / home / project
+  // views where no terminal WS is active. When a terminal *is* attached
+  // its own "Connection lost, reconnecting…" pill already owns the
+  // offline cue for that view, so we suppress this one to avoid a
+  // doubled-up message on the same screen.
+  const showReconnecting = connVal === 'reconnecting' && !(selectedVal && canAttach)
+
   return (
     <div class="app-layout">
+      {showReconnecting && (
+        <div class="app-reconnecting-pill" role="status">
+          Connection lost, reconnecting…
+        </div>
+      )}
       <Sidebar
         resumingId={resumingId}
         onCloseSession={handleCloseSession}

--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -700,7 +700,7 @@ function App() {
   return (
     <div class="app-layout">
       {showReconnecting && (
-        <div class="app-reconnecting-pill" role="status">
+        <div class="reconnecting-pill app-reconnecting-pill" role="status">
           Connection lost, reconnecting…
         </div>
       )}

--- a/apps/gmux-web/src/sse-reconnect.test.ts
+++ b/apps/gmux-web/src/sse-reconnect.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { connState, initStore } from './store'
+
+// A minimal EventSource stand-in that lets the test drive the listeners
+// initStore registers (the `error` handler and the snapshot handlers).
+class FakeEventSource {
+  static instances: FakeEventSource[] = []
+  listeners: Record<string, ((e: MessageEvent) => void)[]> = {}
+  url: string
+  closed = false
+  constructor(url: string) {
+    this.url = url
+    FakeEventSource.instances.push(this)
+  }
+  addEventListener(type: string, fn: (e: MessageEvent) => void) {
+    const list = this.listeners[type] ?? []
+    list.push(fn)
+    this.listeners[type] = list
+  }
+  close() { this.closed = true }
+  emit(type: string, data?: unknown) {
+    for (const fn of this.listeners[type] ?? []) {
+      fn({ data: data === undefined ? '' : JSON.stringify(data) } as MessageEvent)
+    }
+  }
+}
+
+describe('SSE reconnecting state', () => {
+  let cleanup: () => void
+
+  beforeEach(() => {
+    connState.value = 'connecting'
+    FakeEventSource.instances = []
+    vi.stubGlobal('EventSource', FakeEventSource as unknown as typeof EventSource)
+    // fetchFrontendConfig rides a fetch; stub it so initStore doesn't hit
+    // the network. The reconnect logic doesn't depend on the result.
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({}),
+    } as Response)))
+  })
+
+  afterEach(() => {
+    cleanup?.()
+    vi.unstubAllGlobals()
+  })
+
+  function source(): FakeEventSource {
+    return FakeEventSource.instances[0]
+  }
+
+  it('goes to error when the initial connect drops before any snapshot', () => {
+    cleanup = initStore()
+    expect(connState.value).toBe('connecting')
+    source().emit('error')
+    expect(connState.value).toBe('error')
+  })
+
+  it('goes to reconnecting (not error) when an established stream drops', () => {
+    cleanup = initStore()
+    // First snapshot establishes the connection.
+    source().emit('snapshot.sessions', { sessions: [] })
+    expect(connState.value).toBe('connected')
+    // The established stream drops: transient, not a hard failure.
+    source().emit('error')
+    expect(connState.value).toBe('reconnecting')
+  })
+
+  it('clears back to connected once the next snapshot arrives', () => {
+    cleanup = initStore()
+    source().emit('snapshot.sessions', { sessions: [] })
+    source().emit('error')
+    expect(connState.value).toBe('reconnecting')
+    source().emit('snapshot.sessions', { sessions: [] })
+    expect(connState.value).toBe('connected')
+  })
+})

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -268,7 +268,13 @@ export const sessionsLoaded = signal(false)
  * *both* flags keeps it `null` until a coherent snapshot exists.
  */
 export const worldLoaded = signal(false)
-export const connState = signal<'connecting' | 'connected' | 'error'>('connecting')
+// 'connecting'   — initial connect, never yet established (full-screen)
+// 'connected'    — live snapshot flowing
+// 'reconnecting' — an *established* stream dropped; EventSource is
+//                  auto-reconnecting. Subtle pill, not full-screen: the
+//                  last snapshot stays on screen (sessionsLoaded holds).
+// 'error'        — initial connect failed (full-screen + Retry)
+export const connState = signal<'connecting' | 'connected' | 'reconnecting' | 'error'>('connecting')
 
 // Discovered is host-authoritative (ADR 0002/0005): each host runs its
 // own match rules over its own sessions and decides which are
@@ -1395,7 +1401,14 @@ export function initStore(): () => void {
     // Browser EventSource auto-reconnects; flag the UI as degraded
     // until the next snapshot arrives. `sessionsLoaded` stays true
     // once it has flipped, so reconnect doesn't blank the sidebar.
+    //
+    // A drop on the *initial* connect is a hard failure (full-screen +
+    // Retry). A drop on an *established* stream is transient: show a
+    // subtle reconnecting pill and keep the last snapshot on screen
+    // while EventSource retries. The next snapshot flips it back to
+    // 'connected'.
     if (connState.value === 'connecting') connState.value = 'error'
+    else if (connState.value === 'connected') connState.value = 'reconnecting'
   })
 
   // Protocol 2 (ADR 0001). The server pushes two snapshot kinds plus

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -1876,14 +1876,17 @@ body {
     0 8px 24px oklch(0% 0 0 / 0.28);
 }
 
-.terminal-disconnected-pill {
+/* Shared "reconnecting" pill skin. One visual source of truth for the
+   offline/reconnecting cue across both data planes — the per-terminal
+   PTY WebSocket (`.terminal-disconnected-pill`) and the app-level SSE
+   control plane (`.app-reconnecting-pill`). The two keep separate
+   drivers (they watch independent transports) and separate positioning
+   wrappers; only the look and copy are shared here. */
+.reconnecting-pill {
   pointer-events: none;
-  position: relative;
-  top: 12px;
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  max-width: min(calc(100% - 24px), 460px);
   padding: 10px 16px;
   border: 1px solid oklch(0.45 0.12 20 / 0.5);
   border-radius: 999px;
@@ -1901,36 +1904,24 @@ body {
   white-space: nowrap;
 }
 
-/* App-level SSE reconnecting pill. Shares the terminal pill's design
-   language (translucent warm surface, blur, rounded) so "we're offline,
-   reconnecting" reads the same across the WS and SSE data planes. Floats
-   fixed at top-center over whatever view is showing (sidebar, home,
-   project hub) without taking over the screen. */
+/* Terminal PTY-socket pill: anchored inside the terminal shell so it
+   points at the affected pane. Skin comes from `.reconnecting-pill`. */
+.terminal-disconnected-pill {
+  position: relative;
+  top: 12px;
+  max-width: min(calc(100% - 24px), 460px);
+}
+
+/* App-level SSE pill: fixed top-center overlay for views with no
+   terminal pane to anchor to (sidebar, home, project hub). Skin comes
+   from `.reconnecting-pill`. */
 .app-reconnecting-pill {
-  pointer-events: none;
   position: fixed;
   top: 12px;
   left: 50%;
   transform: translateX(-50%);
   z-index: 60;
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
   max-width: min(calc(100vw - 24px), 460px);
-  padding: 10px 16px;
-  border: 1px solid oklch(0.45 0.12 20 / 0.5);
-  border-radius: 999px;
-  background: oklch(0.22 0.06 20 / 0.88);
-  color: oklch(0.78 0.1 20);
-  box-shadow:
-    0 8px 24px oklch(0% 0 0 / 0.28),
-    0 0 12px oklch(0.5 0.15 20 / 0.12);
-  backdrop-filter: blur(6px);
-  -webkit-backdrop-filter: blur(6px);
-  font-size: 13px;
-  line-height: 1;
-  letter-spacing: 0.01em;
-  white-space: nowrap;
 }
 
 /* ── Find-in-terminal bar ────────────────────────────────────────────────────────

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -1901,6 +1901,38 @@ body {
   white-space: nowrap;
 }
 
+/* App-level SSE reconnecting pill. Shares the terminal pill's design
+   language (translucent warm surface, blur, rounded) so "we're offline,
+   reconnecting" reads the same across the WS and SSE data planes. Floats
+   fixed at top-center over whatever view is showing (sidebar, home,
+   project hub) without taking over the screen. */
+.app-reconnecting-pill {
+  pointer-events: none;
+  position: fixed;
+  top: 12px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 60;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  max-width: min(calc(100vw - 24px), 460px);
+  padding: 10px 16px;
+  border: 1px solid oklch(0.45 0.12 20 / 0.5);
+  border-radius: 999px;
+  background: oklch(0.22 0.06 20 / 0.88);
+  color: oklch(0.78 0.1 20);
+  box-shadow:
+    0 8px 24px oklch(0% 0 0 / 0.28),
+    0 0 12px oklch(0.5 0.15 20 / 0.12);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  font-size: 13px;
+  line-height: 1;
+  letter-spacing: 0.01em;
+  white-space: nowrap;
+}
+
 /* ── Find-in-terminal bar ────────────────────────────────────────────────────────
    Floats over the top-right of the terminal (sticky, like the resize
    anchor, so it stays put when the shell scrolls in passive mode). Shares

--- a/apps/gmux-web/src/terminal.tsx
+++ b/apps/gmux-web/src/terminal.tsx
@@ -1041,7 +1041,7 @@ export function TerminalView({
     >
       {showDisconnectedPill && (
         <div class="terminal-resize-anchor">
-          <div class="terminal-disconnected-pill">
+          <div class="reconnecting-pill terminal-disconnected-pill">
             Connection lost, reconnecting…
           </div>
         </div>


### PR DESCRIPTION
Fixes #379.

## Problem

When the browser's `/v1/events` SSE connection to gmuxd dropped on an **already-established** connection, there was no user-visible indicator. The `error` listener only flipped `connecting → error`, so an established stream silently stayed `connected` while `EventSource` auto-reconnected. This is masked when a terminal is attached (its WS pill owns the offline cue) but leaves the sidebar / home / project views showing stale state with no signal.

## Change

- Extend `connState` with a distinct `'reconnecting'` state. The SSE `error` handler now maps `connected → reconnecting` (transient) while keeping `connecting → error` (hard initial-connect failure, full-screen + Retry, unchanged).
- Render a subtle app-level pill ("Connection lost, reconnecting…") that visually matches the terminal's existing WS `terminal-disconnected-pill`, so the offline language reads the same across both data planes.
- Clears automatically on the next snapshot (existing handlers set `connected`). `sessionsLoaded` stays true across reconnect, so the sidebar is not blanked.
- Suppressed while an attached terminal already shows its own reconnecting pill, to avoid a doubled-up message on the same screen.
- No toast flood — preserves the existing "the reconnecting pill owns 'we're offline'" design, now honoured outside a terminal view too.

## Tests

New `sse-reconnect.test.ts` drives `initStore` with a fake `EventSource` and asserts the three transitions: initial-drop → error, established-drop → reconnecting, next-snapshot → connected. Full web suite (565 tests) and `tsc` pass.