### PR TITLE
fix(web): word-delete on Ctrl+Backspace/Delete by default

### DIFF
--- a/apps/gmux-web/src/keybinds.test.ts
+++ b/apps/gmux-web/src/keybinds.test.ts
@@ -145,20 +145,26 @@ describe('resolveKeybinds', () => {
     expect(find!.ctrl && find!.meta).toBe(false)
   })
 
-  it('maps secondary+Backspace to backward-kill-word by default', () => {
+  // Closes the loop on the reported bug: pressing Ctrl+Backspace (secondary on
+  // Linux, where these tests run) must resolve to a *word* delete, not the old
+  // \x08 char-delete. Drives a real KeyboardEvent through the same match path
+  // the keyboard handler uses.
+  it('resolves a real secondary+Backspace event to backward-kill-word', () => {
     const resolved = resolveKeybinds(null)
-    const bs = resolved.find(r => r.baseKey === 'backspace')
-    expect(bs).toBeDefined()
-    expect(bs!.action).toBe('sendText')
-    expect(bs!.args).toBe('\x1b\x7f')
+    const ev = { ctrlKey: true, shiftKey: false, altKey: false, metaKey: false, key: 'Backspace' } as KeyboardEvent
+    const match = resolved.find(kb => eventMatchesKeybind(ev, kb))
+    expect(match).toBeDefined()
+    expect(match!.action).toBe('sendText')
+    expect(match!.args).toBe('\x1b\x7f')
   })
 
-  it('maps secondary+Delete to forward-kill-word by default', () => {
+  it('resolves a real secondary+Delete event to forward-kill-word', () => {
     const resolved = resolveKeybinds(null)
-    const del = resolved.find(r => r.baseKey === 'delete')
-    expect(del).toBeDefined()
-    expect(del!.action).toBe('sendText')
-    expect(del!.args).toBe('\x1bd')
+    const ev = { ctrlKey: true, shiftKey: false, altKey: false, metaKey: false, key: 'Delete' } as KeyboardEvent
+    const match = resolved.find(kb => eventMatchesKeybind(ev, kb))
+    expect(match).toBeDefined()
+    expect(match!.action).toBe('sendText')
+    expect(match!.args).toBe('\x1bd')
   })
 
   it('allows disabling the find keybind', () => {

--- a/apps/gmux-web/src/keybinds.test.ts
+++ b/apps/gmux-web/src/keybinds.test.ts
@@ -103,8 +103,8 @@ describe('keyComboToSequence', () => {
     expect(keyComboToSequence('ctrl+shift+right')).toBe('\x1b[1;6C')
   })
 
-  it('converts ctrl+backspace to BS (\x08)', () => {
-    expect(keyComboToSequence('ctrl+backspace')).toBe('\x08')
+  it('converts ctrl+backspace to backward-kill-word (ESC DEL)', () => {
+    expect(keyComboToSequence('ctrl+backspace')).toBe('\x1b\x7f')
   })
 
   it('encodes alt in CSI parameter, not as ESC prefix', () => {
@@ -143,6 +143,22 @@ describe('resolveKeybinds', () => {
     // "secondary" resolves to exactly one platform modifier.
     expect(find!.ctrl || find!.meta).toBe(true)
     expect(find!.ctrl && find!.meta).toBe(false)
+  })
+
+  it('maps secondary+Backspace to backward-kill-word by default', () => {
+    const resolved = resolveKeybinds(null)
+    const bs = resolved.find(r => r.baseKey === 'backspace')
+    expect(bs).toBeDefined()
+    expect(bs!.action).toBe('sendText')
+    expect(bs!.args).toBe('\x1b\x7f')
+  })
+
+  it('maps secondary+Delete to forward-kill-word by default', () => {
+    const resolved = resolveKeybinds(null)
+    const del = resolved.find(r => r.baseKey === 'delete')
+    expect(del).toBeDefined()
+    expect(del!.action).toBe('sendText')
+    expect(del!.args).toBe('\x1bd')
   })
 
   it('allows disabling the find keybind', () => {

--- a/apps/gmux-web/src/keybinds.ts
+++ b/apps/gmux-web/src/keybinds.ts
@@ -74,10 +74,14 @@ const LINUX_KEYBINDS: Keybind[] = [
   { key: 'ctrl+alt+n', action: 'sendKeys', args: 'ctrl+n' },
   { key: 'ctrl+alt+w', action: 'sendKeys', args: 'ctrl+w' },
   // Ctrl+Backspace/Delete: explicitly intercepted so the browser does not
-  // swallow the event on xterm's hidden textarea. Sequences match what
-  // gnome-terminal, xterm, and alacritty send.
-  { key: 'ctrl+backspace', action: 'sendText', args: '\x08' },
-  { key: 'ctrl+delete',    action: 'sendText', args: '\x1b[3;5~' },
+  // swallow the event on xterm's hidden textarea, and mapped to word-delete
+  // (the convention Linux/Windows terminal users expect from Ctrl+Backspace).
+  //   backward-kill-word: ESC DEL  (readline `backward-kill-word`, aka Alt+Backspace)
+  //   forward-kill-word:  ESC d    (readline `kill-word`, aka Alt+d)
+  // NB: BS (\x08) is only backward-delete-*char* in readline, so the previous
+  // \x08 binding never deleted a word — that was the reported bug.
+  { key: 'ctrl+backspace', action: 'sendText', args: '\x1b\x7f' },
+  { key: 'ctrl+delete',    action: 'sendText', args: '\x1bd' },
 ]
 
 /** macOS defaults. Replicate iTerm2 / macOS Terminal conventions. */
@@ -216,9 +220,9 @@ export function keyComboToSequence(combo: string): string {
   } else if (baseKey === 'tab') {
     seq = '\t'
   } else if (baseKey === 'backspace') {
-    // Ctrl+Backspace: \x08 (BS), matching gnome-terminal/xterm/alacritty.
-    // Plain backspace: \x7f (DEL).
-    seq = ctrl ? '\x08' : '\x7f'
+    // Ctrl+Backspace: ESC DEL (readline backward-kill-word) so it deletes a
+    // word rather than a char. Plain backspace: \x7f (DEL).
+    seq = ctrl ? '\x1b\x7f' : '\x7f'
   } else if (baseKey.length === 1) {
     seq = baseKey
   }


### PR DESCRIPTION
## Problem
With the default keybinds, **Ctrl+Backspace doesn't delete a word** in the terminal — it deletes a single character.

## Root cause
In `apps/gmux-web/src/keybinds.ts`, `ctrl+backspace` was bound to `sendText '\x08'`. `\x08` is ASCII **BS**, which readline (bash/zsh/fish) maps to `backward-delete-char` — one char, not a word. `ctrl+delete` sent `\x1b[3;5~` (modified Delete), also not a word-kill.

## Fix
"secondary" = Ctrl on Linux/Windows, Cmd on macOS. On the desktop platform where the bug was reported, secondary = Ctrl:

- **secondary+Backspace** → `\x1b\x7f` (ESC DEL = readline `backward-kill-word`)
- **secondary+Delete** → `\x1bd` (ESC d = readline `kill-word`, forward)

`keyComboToSequence('ctrl+backspace')` updated to match (`\x1b\x7f`) so the `sendKeys` path is consistent.

## macOS note (please sanity-check)
macOS `Cmd+Backspace` = line-kill (`ctrl+u`) is **left untouched** — that's the native mac convention (Cmd+Backspace deletes to line start; Option+Backspace deletes a word). Mac already gets word-delete via the native **Option+Backspace**: `macOptionIsMeta` defaults to `true`, so Option sends an ESC prefix and Option+Backspace → `\x1b\x7f`. Forcing Cmd+Backspace to word-delete would regress mac users, so the new word-delete default applies where the convention and the bug live.

## Verification
- **Real bash readline (pty):** `\x1b\x7f` on `echo hello world foo` removes exactly `foo` (one word, not one char, not the whole line); `\x1bd` at line start deletes `echo`. zsh emacs mode binds the same sequences.
- **Wiring:** confirmed the keyboard handler intercepts Ctrl+Backspace/Delete (`preventDefault`) and its `sendText` action emits `kb.args` verbatim.
- **Tests:** `vitest run src/keybinds.test.ts` → 38 passing. Added tests drive a real `Ctrl+Backspace`/`Ctrl+Delete` `KeyboardEvent` through `resolveKeybinds` + `eventMatchesKeybind` (the same seam the handler uses) and assert it resolves to the word-kill binding — this is the guard that would have caught the original bug. Updated the `keyComboToSequence` backspace test accordingly.
- `tsc --noEmit` clean.