### PR TITLE
fix: reap orphaned runner on fatal registration rejection

### DIFF
--- a/cli/gmux/cmd/gmux/daemon.go
+++ b/cli/gmux/cmd/gmux/daemon.go
@@ -153,12 +153,37 @@ func gmuxdHealthy(timeout time.Duration) bool {
 	return resp.StatusCode == http.StatusOK
 }
 
+// registerOutcome classifies the result of a registration attempt so
+// callers can react differently to "gmuxd isn't ready yet" versus
+// "gmuxd will never accept this id."
+type registerOutcome int
+
+const (
+	// registerOK: gmuxd accepted the registration (HTTP 200).
+	registerOK registerOutcome = iota
+	// registerUnavailable: every attempt failed transiently — connection
+	// refused, timeout, or a 5xx while gmuxd was still starting. Retrying
+	// later (or a discovery-scan pickup) may still succeed, so the runner
+	// keeps serving.
+	registerUnavailable
+	// registerFatal: gmuxd answered with a client error (4xx) — a
+	// permanent rejection this id can never recover from, e.g. a
+	// malformed session id that fails the daemon's IsValidSessionID
+	// guard. Retrying is pointless; a headless runner in this state is
+	// an orphan and should exit rather than serve a session gmuxd will
+	// never track. See run.go's fatal-registration shutdown.
+	registerFatal
+)
+
+func (o registerOutcome) ok() bool { return o == registerOK }
+
 // registerWithGmuxd posts the session's registration to gmuxd and
-// returns true once gmuxd accepts it. Retries a handful of times to
-// cover the case where gmuxd is still starting up. Returns false if
-// every attempt fails: callers that care about registration outcome
-// (e.g. the detached (-d) handshake) treat false as "give up".
-func registerWithGmuxd(sessionID, socketPath string) bool {
+// reports the outcome. Transient failures (gmuxd still starting) are
+// retried a handful of times; a 4xx is fatal and returned immediately
+// without burning the retry budget. Callers that care about the
+// outcome (the detached (-d) handshake, the orphan-reap path) branch
+// on the returned registerOutcome.
+func registerWithGmuxd(sessionID, socketPath string) registerOutcome {
 	baseURL := gmuxdBaseURL()
 
 	payload, _ := json.Marshal(map[string]string{
@@ -176,12 +201,22 @@ func registerWithGmuxd(sessionID, socketPath string) bool {
 		if err != nil {
 			continue
 		}
+		status := resp.StatusCode
 		resp.Body.Close()
-		if resp.StatusCode == 200 {
-			return true
+		if status == http.StatusOK {
+			return registerOK
+		}
+		// A 4xx is a permanent verdict on this id — the daemon
+		// understood the request and refused it (invalid session id,
+		// malformed body). No amount of retrying changes the answer, so
+		// short-circuit instead of wasting the budget. 5xx (and any
+		// other status) stays in the transient bucket: gmuxd may still
+		// be coming up.
+		if status >= 400 && status < 500 {
+			return registerFatal
 		}
 	}
-	return false
+	return registerUnavailable
 }
 
 func deregisterFromGmuxd(sessionID string) {

--- a/cli/gmux/cmd/gmux/register_test.go
+++ b/cli/gmux/cmd/gmux/register_test.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// startStubGmuxd binds a Unix socket at the path registerWithGmuxd
+// dials (StateDir()/gmuxd.sock) and answers POST /v1/register with the
+// given status. Returns nothing; cleanup is registered on t.
+func startStubGmuxd(t *testing.T, status int) {
+	t.Helper()
+	// paths.SocketPath() resolves under XDG_STATE_HOME/gmux.
+	stateHome := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateHome)
+	sockPath := filepath.Join(stateHome, "gmux", "gmuxd.sock")
+	if err := os.MkdirAll(filepath.Dir(sockPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen %s: %v", sockPath, err)
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/register", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(status)
+	})
+	srv := &http.Server{Handler: mux}
+	done := make(chan struct{})
+	go func() { _ = srv.Serve(ln); close(done) }()
+	t.Cleanup(func() { _ = srv.Close(); <-done })
+}
+
+// TestRegisterWithGmuxdOutcomes pins the fatal/transient/ok
+// classification that the orphan-reap fix depends on:
+//
+//   - 200 → registerOK
+//   - 4xx (the invalid-session-id verdict) → registerFatal, so a
+//     headless runner exits instead of lingering as an orphan
+//   - 5xx / unreachable → registerUnavailable, so a runner keeps
+//     serving while gmuxd is still coming up
+func TestRegisterWithGmuxdOutcomes(t *testing.T) {
+	cases := []struct {
+		name   string
+		status int
+		want   registerOutcome
+	}{
+		{"ok", http.StatusOK, registerOK},
+		{"invalid_id_is_fatal", http.StatusBadRequest, registerFatal},
+		{"server_error_is_transient", http.StatusBadGateway, registerUnavailable},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			startStubGmuxd(t, tc.status)
+			got := registerWithGmuxd("sess-test", "/tmp/whatever.sock")
+			if got != tc.want {
+				t.Errorf("registerWithGmuxd outcome = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestReapOnFatalRegistration pins the orphan-reap decision: only a
+// fatal (permanent) rejection of a headless runner tears the process
+// down. Transient failures must never reap (gmuxd may still be coming
+// up), and an interactive runner is spared even on a fatal verdict
+// because its local terminal is still attached.
+func TestReapOnFatalRegistration(t *testing.T) {
+	cases := []struct {
+		name        string
+		outcome     registerOutcome
+		interactive bool
+		want        bool
+	}{
+		{"fatal_headless_reaps", registerFatal, false, true},
+		{"fatal_interactive_spared", registerFatal, true, false},
+		{"unavailable_headless_keeps_serving", registerUnavailable, false, false},
+		{"unavailable_interactive_keeps_serving", registerUnavailable, true, false},
+		{"ok_headless", registerOK, false, false},
+		{"ok_interactive", registerOK, true, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := reapOnFatalRegistration(tc.outcome, tc.interactive); got != tc.want {
+				t.Errorf("reapOnFatalRegistration(%d, %v) = %v, want %v", tc.outcome, tc.interactive, got, tc.want)
+			}
+		})
+	}
+}

--- a/cli/gmux/cmd/gmux/run.go
+++ b/cli/gmux/cmd/gmux/run.go
@@ -63,6 +63,27 @@ type runDirectives struct {
 	ParentSessionID string
 }
 
+// reapOnFatalRegistration reports whether a runner should tear itself
+// down because registration with gmuxd failed permanently.
+//
+// Only the combination of a fatal (4xx) verdict and a headless runner
+// qualifies:
+//
+//   - registerFatal means gmuxd understood the request and refused it
+//     for good (e.g. its IsValidSessionID guard rejected the id) —
+//     retrying or waiting changes nothing. registerUnavailable, by
+//     contrast, is a transient "gmuxd not ready" and must NOT reap: the
+//     runner keeps serving so a later discovery scan can pick it up.
+//   - !interactive means no local terminal is attached, so gmuxd is the
+//     only consumer; once gmuxd has permanently rejected it, the
+//     process is a pure orphan (the convIndex-rehydrate resume bug,
+//     where a session keyed by its conversation UUID could never
+//     register). An interactive runner is spared: the user's terminal
+//     is still usefully attached even if gmux never tracks the session.
+func reapOnFatalRegistration(outcome registerOutcome, interactive bool) bool {
+	return outcome == registerFatal && !interactive
+}
+
 // runSession launches a new managed session for the given command.
 //
 // When attach is true and stdin is a tty, the local terminal is wired
@@ -303,8 +324,12 @@ func runSession(args []string, attach bool, dir runDirectives) {
 	regDone := make(chan struct{})
 	go func() {
 		defer close(regDone)
-		ok := registerWithGmuxd(sessionID, sockPath)
-		handshakeAck(sessionID, ok)
+		outcome := registerWithGmuxd(sessionID, sockPath)
+		handshakeAck(sessionID, outcome.ok())
+		if reapOnFatalRegistration(outcome, interactive) {
+			log.Printf("gmux: registration permanently rejected for %s; shutting down orphaned runner", sessionID)
+			srv.Shutdown()
+		}
 	}()
 
 	if interactive {

--- a/cli/gmux/internal/ptyserver/ptyserver.go
+++ b/cli/gmux/internal/ptyserver/ptyserver.go
@@ -193,6 +193,8 @@ type Server struct {
 	adapter         adapter.Adapter
 	state           *session.State
 
+	shutdownOnce sync.Once
+
 	mu             sync.Mutex
 	clients        map[*wsClient]struct{}
 	localOut       io.Writer      // optional local terminal output sink
@@ -482,22 +484,27 @@ func (s *Server) Resize(cols, rows uint16) {
 
 // Shutdown closes the listener and all connections.
 func (s *Server) Shutdown() {
-	s.listener.Close()
-	os.Remove(s.sockPath)
+	// Idempotent: Shutdown can now be invoked from more than one
+	// goroutine — a signal handler and the registration goroutine's
+	// fatal-rejection reap can race — so the whole teardown runs once.
+	s.shutdownOnce.Do(func() {
+		s.listener.Close()
+		os.Remove(s.sockPath)
 
-	s.mu.Lock()
-	// Close ptmx and mark it closed under mu. pty.Setsize (setPtySize) calls
-	// (*os.File).Fd(), which races (*os.File).Close(); serializing both under
-	// mu, plus the ptmxClosed guard, keeps resize/shrink from touching the fd
-	// once Shutdown has closed it. (Read/Write go through the reference-counted
-	// poll.FD and are already safe against Close.)
-	s.ptmxClosed = true
-	s.ptmx.Close()
-	stopScreenDrain(s.screen, s.screenDrainDone) // unblocks + joins the DSR drain goroutine, then closes
-	for c := range s.clients {
-		c.cancel()
-	}
-	s.mu.Unlock()
+		s.mu.Lock()
+		// Close ptmx and mark it closed under mu. pty.Setsize (setPtySize) calls
+		// (*os.File).Fd(), which races (*os.File).Close(); serializing both under
+		// mu, plus the ptmxClosed guard, keeps resize/shrink from touching the fd
+		// once Shutdown has closed it. (Read/Write go through the reference-counted
+		// poll.FD and are already safe against Close.)
+		s.ptmxClosed = true
+		s.ptmx.Close()
+		stopScreenDrain(s.screen, s.screenDrainDone) // unblocks + joins the DSR drain goroutine, then closes
+		for c := range s.clients {
+			c.cancel()
+		}
+		s.mu.Unlock()
+	})
 }
 
 // setPtySize applies a window size to the PTY unless Shutdown has already closed

--- a/cli/gmux/internal/ptyserver/ptyserver_test.go
+++ b/cli/gmux/internal/ptyserver/ptyserver_test.go
@@ -1707,3 +1707,52 @@ func TestPutSlugValidation(t *testing.T) {
 		t.Errorf("put unslugifiable = %d, want 400", code)
 	}
 }
+
+// TestShutdownIdempotent guards the sync.Once added to Shutdown: the
+// registration-reap path and a signal handler can now both call
+// Shutdown concurrently, so a second (or concurrent) call must not
+// panic on a double listener/ptmx close or a re-closed screen.
+func TestShutdownIdempotent(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "test.sock")
+	// A short-lived child keeps the Done assertion robust: Shutdown
+	// closes the PTY master to SIGHUP the child, but delivery races the
+	// child's controlling-terminal setup — calling Shutdown microseconds
+	// after New (as this test does) can land before that, so the SIGHUP
+	// is missed. A 1s command means the child self-exits well within the
+	// timeout even in that case; we're asserting Shutdown doesn't
+	// deadlock, not that it kills instantly.
+	srv, err := New(Config{
+		Command:    []string{"sleep", "1"},
+		Cwd:        "/tmp",
+		Listener:   mustBindSocket(t, sockPath),
+		SocketPath: sockPath,
+	})
+	if err != nil {
+		t.Fatalf("new server: %v", err)
+	}
+
+	// Concurrent shutdowns — the exact race the sync.Once defends. None
+	// may panic (double listener/ptmx close, re-closed screen, double
+	// drain-join) and all must return (no deadlock in the once'd body).
+	const n = 8
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			srv.Shutdown()
+		}()
+	}
+	wg.Wait()
+
+	// Done must fire: either the SIGHUP took, or the child ran to
+	// completion. Generous timeout so this can't flake under CI load.
+	select {
+	case <-srv.Done():
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout: Done not closed after Shutdown")
+	}
+
+	// A further call after the child has exited must also be safe.
+	srv.Shutdown()
+}

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -1309,6 +1309,16 @@ func serve(stderr io.Writer) int {
 
 		log.Printf("register: %s at %s", req.SessionID, req.SocketPath)
 		if err := discovery.Register(sessions, subs, req.SocketPath, persistDead); err != nil {
+			// A malformed session id is a permanent rejection, not a
+			// gateway hiccup: answer 400 so the runner can tell "this id
+			// is hopeless, exit" from "gmuxd is unreachable, retry."
+			// Without this the runner retried, gave up, and lingered
+			// headless as an orphan (the convIndex-rehydrate resume bug).
+			if errors.Is(err, discovery.ErrInvalidSessionID) {
+				log.Printf("register: rejecting %s: %v", req.SessionID, err)
+				writeError(w, http.StatusBadRequest, "invalid_session_id", err.Error())
+				return
+			}
 			log.Printf("register: failed to query meta for %s: %v", req.SessionID, err)
 			writeError(w, http.StatusBadGateway, "runner_unreachable", err.Error())
 			return

--- a/services/gmuxd/internal/discovery/discovery.go
+++ b/services/gmuxd/internal/discovery/discovery.go
@@ -7,6 +7,7 @@ package discovery
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -22,6 +23,17 @@ import (
 	"github.com/gmuxapp/gmux/packages/paths"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/store"
 )
+
+// ErrInvalidSessionID reports that a runner registered under an id that
+// fails paths.IsValidSessionID. It is a permanent verdict, not a
+// transient gateway hiccup: the id can never be accepted (it would be
+// unsafe as a path segment under SessionsDir), so callers surface it as
+// a 4xx rather than a 502, letting the runner distinguish "gmuxd will
+// never accept me" (exit) from "gmuxd is unreachable" (retry). This is
+// the seam the orphaned-resume bug turned up: a convIndex-rehydrated
+// agent session is keyed by its conversation UUID, which is not a
+// sess-<hex> id, so its resume runner used to retry-then-linger forever.
+var ErrInvalidSessionID = errors.New("register: invalid session id")
 
 // ExpectedRunnerHash is the sha256 hash of the gmux binary that gmuxd
 // would launch for new sessions. Set by main at startup. Exposed via
@@ -250,7 +262,7 @@ func Register(sessions *store.Store, subs *Subscriptions, socketPath string, onD
 	// anything that isn't a well-formed sess-<hex> ID so a crafted
 	// socket_path cannot steer writes outside the sessions dir.
 	if !paths.IsValidSessionID(newSess.ID) {
-		return fmt.Errorf("register: invalid session id %q from %s", newSess.ID, socketPath)
+		return fmt.Errorf("%w %q from %s", ErrInvalidSessionID, newSess.ID, socketPath)
 	}
 
 	if existing, ok := sessions.Get(newSess.ID); ok {

--- a/services/gmuxd/internal/discovery/discovery_test.go
+++ b/services/gmuxd/internal/discovery/discovery_test.go
@@ -2,6 +2,7 @@ package discovery
 
 import (
 	"encoding/json"
+	"errors"
 	"net"
 	"net/http"
 	"os"
@@ -416,5 +417,47 @@ func TestScanDiscoversRunnersInPrimaryAndLegacyDirs(t *testing.T) {
 		if got.SocketPath != wantSock {
 			t.Errorf("%s: SocketPath = %q, want %q (must keep the dir it bound in)", id, got.SocketPath, wantSock)
 		}
+	}
+}
+
+// TestRegisterRejectsInvalidSessionID pins the fatal-registration
+// seam behind the convIndex-rehydrate resume bug: a runner that
+// binds a socket under an id that is not a well-formed sess-<hex>
+// (e.g. a rehydrated agent session keyed by its conversation UUID)
+// must be rejected with ErrInvalidSessionID, not silently accepted
+// and not confused with a transient gateway error. The runner keys
+// off this to exit rather than linger as an orphan.
+func TestRegisterRejectsInvalidSessionID(t *testing.T) {
+	sockDir := t.TempDir()
+	t.Setenv("GMUX_SOCKET_DIR", sockDir)
+
+	// The runner reports a bare UUID as its id — exactly what a
+	// convIndex-rehydrated agent session would carry.
+	const badID = "019e03b3-1111-2222-3333-444455556666"
+	sockPath := filepath.Join(sockDir, badID+".sock")
+
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen %s: %v", sockPath, err)
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/meta", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(store.Session{ID: badID, Adapter: "pi", Alive: true})
+	})
+	srv := &http.Server{Handler: mux}
+	done := make(chan struct{})
+	go func() { _ = srv.Serve(ln); close(done) }()
+	t.Cleanup(func() { _ = srv.Close(); <-done })
+
+	sessions := store.New()
+	subs := NewSubscriptions(sessions)
+	t.Cleanup(func() { subs.UnsubscribeAll() })
+
+	err = Register(sessions, subs, sockPath, nil)
+	if !errors.Is(err, ErrInvalidSessionID) {
+		t.Fatalf("Register err = %v, want ErrInvalidSessionID", err)
+	}
+	if _, ok := sessions.Get(badID); ok {
+		t.Errorf("invalid-id session was added to the store; must be rejected")
 	}
 }


### PR DESCRIPTION
## Problem

Resuming a session that appears only via the **convIndex-rehydrate fallback** (`rehydrate: N session(s) restored from convIndex`) hangs forever and leaks a `gmux __run` process — the macOS bug report on gmuxd 1.6.1.

Root cause of *this* PR's slice: a rehydrated **agent** session (pi/claude/codex) is keyed in the store by its *conversation UUID* (the JSONL filename), not a `sess-<hex>` id. On resume the daemon launches a headless `gmux __run --resume-id=<UUID>`; the runner registers under the UUID; gmuxd's `paths.IsValidSessionID` guard **permanently** rejects it. But:

- the daemon returned **502 runner_unreachable** for the validation failure — indistinguishable from a genuine gateway hiccup;
- the runner treated *every* non-200 as retryable, burned its 5×500ms budget, then **lingered forever** serving a session gmuxd would never track — one orphaned process per resume click.

## Fix (orphan-reap + fatal/transient classification)

- **gmuxd** distinguishes the verdict: `discovery.Register` returns a new `ErrInvalidSessionID` sentinel and `POST /v1/register` maps it to **400 `invalid_session_id`** instead of 502.
- **runner** classifies outcomes (`registerOK` / `registerUnavailable` / `registerFatal`): a 4xx is fatal and short-circuits the retry loop; 5xx/unreachable stays transient.
- A **headless** runner tears itself down on a fatal rejection instead of orphaning (`reapOnFatalRegistration`, a small pure decision so it's testable). Interactive runners are spared — the local terminal is still usefully attached.
- `ptyserver.Server.Shutdown` is now idempotent (`sync.Once`), since a signal handler and the reap path can both call it.

## Scope

This does **not** change the rehydrate id-minting itself (the underlying resume-eligibility defect — agent sessions should be minted a valid `sess-` id at rehydrate). That's a separate, more contentious change being discussed. This PR is the clean, low-blast-radius half: no more orphaned processes, and a fatal registration error is no longer mistaken for a transient one.

## Tests

- `discovery.TestRegisterRejectsInvalidSessionID` — a UUID-keyed runner is rejected with `ErrInvalidSessionID` and not added to the store.
- `TestRegisterWithGmuxdOutcomes` — 200→ok, 4xx→fatal, 5xx→transient (guards the "don't reap while gmuxd is still starting" contract).
- `TestReapOnFatalRegistration` — the decision matrix: only fatal + headless reaps.
- `TestShutdownIdempotent` — concurrent/repeat `Shutdown` never panics on double-close.

`go vet` + `gofmt` clean; `cmd/gmux`, `internal/ptyserver`, `cmd/gmuxd`, `internal/discovery` suites green.

> Note: `internal/ptyserver` has a pre-existing `-race` finding in the third-party `vt.Emulator` (Read vs Close), unrelated to this change and present on `main`; that package is not run under `-race`.

Related: #219 (resume-failure feedback) — the async register-failure path is still not surfaced in the UI; noted for follow-up.