### PR TITLE
docs: reconcile docs with changes merged after the 2.0 overhaul (#372)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,7 @@ gmux is a full CLI, designed to compose into scripts and agent workflows:
 
 ```bash
 id=$(gmux -d -- pi)                     # launch detached, capture the id
-gmux send "$id" 'refactor the auth module' Enter
-gmux wait "$id" --timeout 600           # block until the agent goes idle
+gmux send --wait --timeout 600 "$id" 'refactor the auth module' Enter  # send, block until the turn ends
 gmux tail "$id" -n 50                   # read the plain-text tail
 ```
 

--- a/apps/website/src/content/docs/integrations/scripts-and-agents.md
+++ b/apps/website/src/content/docs/integrations/scripts-and-agents.md
@@ -66,26 +66,30 @@ When no text argument is given and stdin is a pipe, gmux reads stdin until EOF (
 `gmux wait <id>` blocks until an agent session finishes its current turn — the primitive that turns sequential orchestration into one line per step:
 
 ```bash
-gmux send <id> Enter < step-1.txt
-gmux wait <id>
-
-gmux send <id> Enter < step-2.txt
-gmux wait <id>
+gmux send --wait <id> Enter < step-1.txt
+gmux send --wait <id> Enter < step-2.txt
 
 gmux tail <id> -n 200          # extract the final answer
 ```
 
-The idle signal is the same `Status.Working` flag the UI's spinner consumes, so `wait` returns the moment the agent emits its closing message. Exit codes: `0` idle, `2` the session died first, `3` `--timeout N` elapsed.
+The idle signal is the same `Status.Working` flag the UI's spinner consumes, so `wait` returns the moment the agent emits its closing message. Exit codes: `0` idle (or matched), `2` the session died first, `3` `--timeout N` elapsed.
 
-`wait` is for agent sessions (`claude`, `codex`, `pi`); shell sessions have no working signal and are rejected with a clear error, and `wait` only works for sessions on the local host — peer sessions (`<id>@<peer>`) are rejected. To wait for a shell command, run it through the blocking piped flow above (`gmux -- make build < /dev/null`) — that's exactly the shape `gmux -- <cmd>` already provides. (Waiting on arbitrary output — "until this text appears" — is planned as a server-side `wait` condition, [#313](https://github.com/gmuxapp/gmux/issues/313).)
+**Prefer `send --wait` over `send` then `wait`.** The two-command form is subtly racy: `wait`'s opening snapshot can catch the *previous* turn's idle state before the send-induced `Working=true` has propagated, returning immediately. `gmux send --wait <id> … Enter` subscribes before delivering the input, so it always gates on a fresh turn. Bound it with `--timeout N`; exit codes match `wait`. A standalone `gmux wait <id>` is still the right tool when you're waiting on a turn you didn't just trigger.
+
+**Waiting on output.** `gmux wait <id> --for-text 'DONE'` (or `--for-regex 'error: \d+'`) blocks until text appears in the session's output instead of on the idle signal. The match runs server-side against gmuxd's scrollback (per rendered line), and — unlike the idle wait — works for **shell** sessions too:
+
+```bash
+gmux wait <id> --for-text 'Listening on' --timeout 30   # wait for a server to come up
+```
+
+`wait` (idle mode) is for agent sessions (`claude`, `codex`, `pi`); shell sessions have no working signal and are rejected with a clear error unless you give an output condition. `wait` only works for sessions on the local host — peer sessions (`<id>@<peer>`) are rejected. To wait for a shell *command* to finish, run it through the blocking piped flow above (`gmux -- make build < /dev/null`) — that's exactly the shape `gmux -- <cmd>` already provides.
 
 ## Reading output
 
 `gmux tail <id>` prints recent output as plain text (ANSI stripped; `-n N` for line count, default 100). Pair it with `wait` to capture an agent's final answer:
 
 ```bash
-gmux send <id> Enter < ship-prompt.txt
-gmux wait <id> --timeout 600
+gmux send --wait --timeout 600 <id> Enter < ship-prompt.txt
 url=$(gmux tail <id> -n 50 | grep -oE 'https://github\.com/[^ ]+/pull/[0-9]+' | tail -1)
 echo "$url"
 ```

--- a/apps/website/src/content/docs/migrating-to-2.md
+++ b/apps/website/src/content/docs/migrating-to-2.md
@@ -64,7 +64,8 @@ Note the **inverted `send` semantics**: 1.x auto-appended a newline unless `--no
 
 - `gmux edit [file]` — managed editor sessions, usable as `$EDITOR`. Inside gmux sessions, `EDITOR`/`VISUAL` now default to `gmux edit` when your dotfiles don't set them — scripts that branch on `EDITOR` being empty inside sessions will see a value.
 - `gmux send-keys -t <id> …` — tmux-compatible key sending.
-- `gmux wait --timeout N` with exit codes `0` (idle) / `2` (died) / `3` (timeout).
+- `gmux wait --timeout N` with exit codes `0` (idle/matched) / `2` (died) / `3` (timeout). `gmux wait --for-text S` / `--for-regex P` wait until output appears instead of the idle signal, and work for shell sessions too.
+- `gmux send --wait [--timeout N]` fuses send-and-wait race-free (subscribes before delivering the input). Note `send`'s grammar: flags go **before** the id; everything after the id is verbatim, so `gmux send abc -v` sends a literal `-v` with no `--` guard needed.
 
 ---
 

--- a/apps/website/src/content/docs/reference/cli.md
+++ b/apps/website/src/content/docs/reference/cli.md
@@ -116,7 +116,7 @@ gmux tail --raw a3f20187      # keep ANSI escapes (-e also works)
 It's a snapshot, not a stream — to watch a session live, attach to it or open
 it in the browser.
 
-### `gmux send <id> [text] [Key...]`
+### `gmux send [--wait [--timeout N]] <id> [text] [Key...]`
 
 Inject input into a running session as if typed at the keyboard. The text is
 sent literally; any trailing arguments that name keys (`Enter`, `C-c`,
@@ -134,6 +134,27 @@ echo "$body" | gmux send a3f20187 Enter         # pipe stdin, then submit
 When no text is given and stdin is a pipe, gmux reads stdin until EOF (capped
 at 1 MiB) and sends it — the natural shape for files and heredocs. Include a
 trailing `Enter` to submit piped input.
+
+**Everything after the session id is verbatim** — including tokens that start
+with a dash. `gmux send abc -v` sends the literal `-v`, and no `--` guard is
+needed for dash-leading text. The trade-off is that `send`'s own flags are only
+recognized *before* the id (the first non-flag token). A `--` before the id is
+accepted as an explicit end-of-flags marker.
+
+**`--wait`** fuses send-and-wait into one race-free step: deliver the input,
+then block until the turn it triggers completes, with the same exit codes as
+[`gmux wait`](#gmux-wait-id) (`0` idle, `2` died, `3` timeout). Bound it with
+`--timeout N`. Because gmuxd subscribes to the session's events *before*
+forwarding the bytes, it can't mistake the previous turn's idle state for the
+reply — unlike the racy `gmux send X Enter && gmux wait X` composition. The
+flags precede the id:
+
+```bash
+gmux send --wait a3f20187 'do the thing' Enter        # block until the reply lands
+gmux send --wait --timeout 600 a3f20187 'go' Enter    # ...or fail after 600s
+```
+
+Like `gmux wait`, `--wait` is agent-only and local-only for now.
 
 For verbatim tmux compatibility there's also `gmux send-keys -t <id> <keys...>`
 (all arguments are key names by default; `-l` sends them as literal text).
@@ -160,16 +181,29 @@ The idle signal is the same `Status.Working` flag the UI's spinner consumes,
 so `wait` returns the moment the agent emits its closing message. Exit codes
 (so scripts can branch on the outcome):
 
-- `0` — the agent reached idle
-- `2` — the session exited before becoming idle
+- `0` — the agent reached idle, or the output condition matched
+- `2` — the session exited before becoming idle / before its output matched
 - `3` — `--timeout` elapsed
 
-Plain **shell** sessions have no idle signal and are rejected with a clear
-error; to wait for a shell command, run it through the blocking piped form
-(`gmux -- make build < /dev/null`) instead. Idle wait is local-only for now
-(peer support is pending). Waiting on arbitrary output ("until this text
-appears") is planned as a server-side `wait` condition
-([#313](https://github.com/gmuxapp/gmux/issues/313)).
+**Output conditions.** Instead of the idle signal, wait until specific text
+appears in the session's output:
+
+```bash
+gmux wait a3f20187 --for-text 'BUILD OK'          # substring match
+gmux wait a3f20187 --for-regex 'error: \d+'       # Go regexp match
+```
+
+`--for-text` and `--for-regex` are mutually exclusive, and an invalid regexp
+is a usage error. The match runs **server-side** against gmuxd's on-disk
+scrollback (matched per rendered, ANSI-stripped line), so nothing scrolls past
+unseen between polls (loss is bounded by the scrollback cap, not a poll
+interval). Output conditions work for **every** adapter, shell sessions
+included — unlike the idle wait below.
+
+Plain **shell** sessions have no idle signal, so a plain `gmux wait` (no output
+condition) rejects them with a clear error; use `--for-text`/`--for-regex`, or
+run the command through the blocking piped form (`gmux -- make build <
+/dev/null`) instead. Idle wait is local-only for now (peer support is pending).
 
 ### `gmux kill <id>`
 

--- a/apps/website/src/content/docs/reference/projects-json.md
+++ b/apps/website/src/content/docs/reference/projects-json.md
@@ -141,7 +141,7 @@ The remote catches sessions in any clone on any machine. The path catches sessio
 
 ## Validation
 
-gmuxd validates the file on load. Invalid state is rejected with an error. Rules:
+gmuxd validates the file on load. A file that can't be parsed as JSON is a hard error, but individual items that fail the rules below are **dropped** on load (each logged) rather than rejecting the whole file — one hand-edited bad entry can't poison the roster and block every later mutation. The original bytes are snapshotted to `projects.json.bak` before the sanitized form is written back on the next save. Rules:
 
 - Every item must have a non-empty `slug` matching `^[a-z0-9]+(-[a-z0-9]+)*$`
 - No duplicate slugs among owned projects; no duplicate `peer`+`slug` pairs among references (an owned project and a peer reference may share a slug)
@@ -151,7 +151,7 @@ gmuxd validates the file on load. Invalid state is rejected with an error. Rules
 - `exact` is only valid on path rules
 - No duplicate normalized paths across items (nesting is allowed)
 
-All API mutations are validated the same way; an invalid mutation is rejected (4xx) and nothing is written.
+All API mutations are validated the same way, but here the whole mutation is rejected (4xx) and nothing is written — the drop-invalid-items repair applies only to what's already on disk at load time.
 
 ## Migration
 

--- a/apps/website/src/content/docs/using-the-ui.md
+++ b/apps/website/src/content/docs/using-the-ui.md
@@ -73,7 +73,7 @@ Hover over a session to reveal the **×** button. This dismisses the session: li
 
 Click a project name in the sidebar (or navigate to `/:project`) to see the project hub — an overview of every session in the project, mirroring the home layout: **Waiting**, **Active**, and **All sessions** rows, newest-first.
 
-When every session shares the same working directory, it appears once as a subtitle; otherwise each row shows its own directory. If the project spans hosts, rows carry an `@host` suffix (devcontainer sessions get a container icon). The **+** in the hub header launches a new session in the project's canonical directory — for a referenced project this routes to the owning machine. If a project has no sessions yet, the hub shows the project's configured path with a **+** launcher to get started.
+When every session shares the same working directory, it appears once as a subtitle; otherwise each row shows its own directory. On the home dashboard, a session card surfaces its working directory only when it differs from the project's canonical folder — a subfolder or worktree shows as a relative `./sub/dir` badge, an unrelated path as its absolute `~/…` form — so sessions launched somewhere other than the project root are easy to spot. If the project spans hosts, rows carry an `@host` suffix (devcontainer sessions get a container icon). The **+** in the hub header launches a new session in the project's canonical directory — for a referenced project this routes to the owning machine. If a project has no sessions yet, the hub shows the project's configured path with a **+** launcher to get started.
 
 ## The terminal
 

--- a/skills/gmux/SKILL.md
+++ b/skills/gmux/SKILL.md
@@ -49,6 +49,10 @@ Key names follow tmux: `Enter`, `Tab`, `Escape`, `Up`/`Down`/`Left`/`Right`,
 `C-c`, `C-d`, etc. For verbatim tmux compatibility there is also
 `gmux send-keys -t <id> <keys...>` (with `-l` for literal text).
 
+**Everything after the id is verbatim** — including dash-leading tokens, so
+`gmux send $id -v` sends a literal `-v` with no `--` guard needed. `send`'s own
+flags (`--wait`, `--timeout`) only work *before* the id.
+
 ## Sequential orchestration
 
 ```bash
@@ -91,8 +95,8 @@ done
 `gmux wait <id>` blocks until an **agent** session goes idle (turn finished) or
 the session exits, optionally bounded by `--timeout N`. Exit codes:
 
-- `0` agent reached idle (or session exited)
-- `2` session died before going idle
+- `0` agent reached idle
+- `2` session exited/died before going idle
 - `3` `--timeout` elapsed
 
 Plain **shell** commands don't emit an idle signal and are rejected, so run


### PR DESCRIPTION
Follow-up to the #372 docs refresh: reconciles the docs with everything merged **after** #372 (2026-07-07 09:29:26Z). Each doc claim was verified against current code, not just PR descriptions.

## Doc changes

| PR since #372 | Doc change |
|---------------|------------|
| **#370** `gmux wait --for-text/--for-regex` | CLI reference: new output-condition subsection + exit-code wording; shell-session note now conditional. Scripting guide: output-wait example, dropped the now-shipped "planned #313" note. Migration guide: new-verbs list. |
| **#371** `gmux send --wait` | CLI reference: `--wait`/`--timeout` + the verbatim-after-id / dash-guard grammar. Scripting guide + README: prefer `send --wait` over the racy `send` then `wait`. Migration guide. |
| **#365** drop invalid `projects.json` items on load | `projects-json.md` validation: load drops invalid *items* (with `.bak` snapshot); API mutations still reject wholesale. |
| **#377** session cwd on card | `using-the-ui.md`: home-dashboard cards surface a relative/absolute cwd badge when it differs from the project folder. |

## `skills/gmux/SKILL.md`

Already carried the #370/#371 additions (those PRs amended it). Two follow-up tidies: add the verbatim-after-id / dash-guard note (#371), and fix the `wait` exit-code list — a session that exits *before* idle returns `2`, not `0`.

## No doc impact (verified)

- **#362** `--wait` phantom-death fix — behavioral; existing exit-`2` wording stays accurate.
- **#375 / #369 / #366 / #381 / #368** — internal peering/SSE/mobile-polish; no doc-level claim affected.
- **#376 / #378** ACP conversation-schema ADRs — design-only, unshipped, not referenced by any docs page. **Left undocumented** per "don't over-document unshipped work"; flagged for revisit when it lands.

## Already correct in-tree (verified, not re-edited)

- **#367** `tag:` allow-list entries — shipped its own `host-toml.md` + `security.md` edits (merged after #372).
- **#382** word-delete on Ctrl+Backspace/Delete — `using-the-ui.md` keybind table already documented this behavior.

Site build (`pnpm build`) passes: 41 pages, no broken links/frontmatter.