### PR TITLE
fix(ptyserver): fix data races between Shutdown and the DSR drain / PTY Setsize

### DIFF
--- a/cli/gmux/internal/ptyserver/ptyserver.go
+++ b/cli/gmux/internal/ptyserver/ptyserver.go
@@ -200,6 +200,7 @@ type Server struct {
 	ptyCols        uint16         // last applied PTY cols (guarded by mu)
 	ptyRows        uint16         // last applied PTY rows (guarded by mu)
 	cursorHidden   bool           // tracks DECTCEM via callback (guarded by mu)
+	ptmxClosed     bool           // true once ptmx is closed by Shutdown (guarded by mu)
 	screenPending  []byte         // raw PTY data not yet fed to screen (guarded by mu)
 	lastClientLeft time.Time      // when the last WS client disconnected (guarded by mu)
 
@@ -482,15 +483,34 @@ func (s *Server) Resize(cols, rows uint16) {
 // Shutdown closes the listener and all connections.
 func (s *Server) Shutdown() {
 	s.listener.Close()
-	s.ptmx.Close()
 	os.Remove(s.sockPath)
 
 	s.mu.Lock()
+	// Close ptmx and mark it closed under mu. pty.Setsize (setPtySize) calls
+	// (*os.File).Fd(), which races (*os.File).Close(); serializing both under
+	// mu, plus the ptmxClosed guard, keeps resize/shrink from touching the fd
+	// once Shutdown has closed it. (Read/Write go through the reference-counted
+	// poll.FD and are already safe against Close.)
+	s.ptmxClosed = true
+	s.ptmx.Close()
 	stopScreenDrain(s.screen, s.screenDrainDone) // unblocks + joins the DSR drain goroutine, then closes
 	for c := range s.clients {
 		c.cancel()
 	}
 	s.mu.Unlock()
+}
+
+// setPtySize applies a window size to the PTY unless Shutdown has already closed
+// it. pty.Setsize calls (*os.File).Fd(), which is not safe against a concurrent
+// (*os.File).Close(); holding mu (which Shutdown also holds while closing) and
+// skipping once closed serializes the two.
+func (s *Server) setPtySize(ws *pty.Winsize) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.ptmxClosed {
+		return
+	}
+	_ = pty.Setsize(s.ptmx, ws)
 }
 
 func (s *Server) serve() {
@@ -924,7 +944,7 @@ func (s *Server) shrinkForReconnect() {
 	s.screen.Resize(int(cols), int(rows))
 	s.mu.Unlock()
 
-	pty.Setsize(s.ptmx, &pty.Winsize{Cols: cols, Rows: rows})
+	s.setPtySize(&pty.Winsize{Cols: cols, Rows: rows})
 	if s.cmd.Process != nil {
 		syscall.Kill(-s.cmd.Process.Pid, syscall.SIGWINCH)
 	}
@@ -952,7 +972,7 @@ func (s *Server) resize(msg ResizeMsg) {
 	s.mu.Unlock()
 
 	if sizeChanged {
-		pty.Setsize(s.ptmx, &pty.Winsize{
+		s.setPtySize(&pty.Winsize{
 			Cols: msg.Cols,
 			Rows: msg.Rows,
 			X:    msg.PixelWidth,

--- a/cli/gmux/internal/ptyserver/ptyserver.go
+++ b/cli/gmux/internal/ptyserver/ptyserver.go
@@ -83,7 +83,10 @@ func probeSocket(sockPath string) bool {
 	return true
 }
 
-func newScreen(cols, rows int, cursorCb func(visible bool)) *vt.Emulator {
+// newScreen builds the replay emulator and starts the DSR drain goroutine. It
+// returns the emulator and a channel that is closed when the drain goroutine
+// exits, so shutdown can join it (see stopScreenDrain).
+func newScreen(cols, rows int, cursorCb func(visible bool)) (*vt.Emulator, chan struct{}) {
 	// Default to 80x24 when launched non-interactively (no terminal).
 	// The first resize from a connecting client will set the real size.
 	if cols <= 0 {
@@ -99,9 +102,39 @@ func newScreen(cols, rows int, cursorCb func(visible bool)) *vt.Emulator {
 	})
 	// The emulator writes responses (e.g. DSR cursor position reports)
 	// to an internal pipe. If nothing reads them, Write blocks. We don't
-	// need the responses, so drain them in the background.
-	go io.Copy(io.Discard, e)
-	return e
+	// need the responses, so drain them in the background. The goroutine
+	// exits when the pipe is closed during shutdown (see stopScreenDrain),
+	// at which point drainDone is closed.
+	drainDone := make(chan struct{})
+	go func() {
+		defer close(drainDone)
+		_, _ = io.Copy(io.Discard, e)
+	}()
+	return e, drainDone
+}
+
+// stopScreenDrain unblocks and joins the DSR drain goroutine, then closes the
+// emulator.
+//
+// We must NOT call e.Close() while the drain goroutine's io.Copy is still
+// calling e.Read(): vt.Emulator guards its `closed` flag with no
+// synchronization, so a concurrent Read (drain) and Close (shutdown) is a data
+// race (github.com/charmbracelet/x/vt, still present as of the latest version).
+//
+// Instead we close the emulator's pipe directly via InputPipe(), which uses
+// only io.Pipe's concurrency-safe methods. That returns EOF from the pending
+// e.Read(), so the drain goroutine's io.Copy returns and drainDone closes. Once
+// the drain goroutine has exited, no Read is in flight and e.Close() is safe.
+func stopScreenDrain(e *vt.Emulator, drainDone chan struct{}) {
+	if c, ok := e.InputPipe().(io.Closer); ok {
+		_ = c.Close()
+	} else {
+		// Fallback: no closable pipe exposed. Close() races the drain, but
+		// it's the only lever left. Should not happen with current vt.
+		_ = e.Close()
+	}
+	<-drainDone
+	_ = e.Close()
 }
 
 // renderScreen produces the ANSI snapshot: scrollback lines followed by
@@ -151,13 +184,14 @@ type ResizeMsg struct {
 
 // Server holds a PTY and serves WebSocket connections.
 type Server struct {
-	cmd      *exec.Cmd
-	ptmx     *os.File
-	sockPath string
-	listener net.Listener
-	screen   *vt.Emulator // virtual terminal for replay snapshots (guarded by mu)
-	adapter  adapter.Adapter
-	state    *session.State
+	cmd             *exec.Cmd
+	ptmx            *os.File
+	sockPath        string
+	listener        net.Listener
+	screen          *vt.Emulator  // virtual terminal for replay snapshots (guarded by mu)
+	screenDrainDone chan struct{} // closed when the DSR drain goroutine exits
+	adapter         adapter.Adapter
+	state           *session.State
 
 	mu             sync.Mutex
 	clients        map[*wsClient]struct{}
@@ -322,7 +356,7 @@ func New(cfg Config) (*Server, error) {
 	}
 
 	// The callback fires under s.mu (held during drainScreenLocked → screen.Write).
-	s.screen = newScreen(int(cfg.Cols), int(cfg.Rows), func(visible bool) {
+	s.screen, s.screenDrainDone = newScreen(int(cfg.Cols), int(cfg.Rows), func(visible bool) {
 		s.cursorHidden = !visible
 	})
 
@@ -452,7 +486,7 @@ func (s *Server) Shutdown() {
 	os.Remove(s.sockPath)
 
 	s.mu.Lock()
-	s.screen.Close() // unblocks the DSR drain goroutine
+	stopScreenDrain(s.screen, s.screenDrainDone) // unblocks + joins the DSR drain goroutine, then closes
 	for c := range s.clients {
 		c.cancel()
 	}

--- a/cli/gmux/internal/ptyserver/ptyserver_test.go
+++ b/cli/gmux/internal/ptyserver/ptyserver_test.go
@@ -874,8 +874,8 @@ func stringContains(s, sub string) bool {
 // response-drain goroutine, Write blocks forever because the emulator
 // writes the response to an internal pipe that nobody reads.
 func TestNewScreenDSRNonBlocking(t *testing.T) {
-	screen := newScreen(80, 24, func(bool) {})
-	defer screen.Close()
+	screen, screenDrain := newScreen(80, 24, func(bool) {})
+	defer stopScreenDrain(screen, screenDrain)
 
 	done := make(chan struct{})
 	go func() {
@@ -892,11 +892,35 @@ func TestNewScreenDSRNonBlocking(t *testing.T) {
 	}
 }
 
+// TestShutdownDrainNoRace guards against the data race between the DSR drain
+// goroutine's e.Read (via io.Copy) and shutting the emulator down. It writes
+// DSR-generating input continuously (forcing the drain goroutine to keep
+// Reading) and then tears the screen down via stopScreenDrain. Under -race
+// this fails if the drain goroutine's Read runs concurrently with Close
+// touching the emulator's unsynchronized `closed` flag.
+func TestShutdownDrainNoRace(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		screen, screenDrain := newScreen(80, 24, func(bool) {})
+
+		// Writes are serialized w.r.t. shutdown in the real Server (both run
+		// under s.mu), so we finish writing before tearing down. Each DSR
+		// (ESC[6n) makes the emulator queue a response the drain goroutine
+		// must Read, keeping the drain busy right up to teardown.
+		for j := 0; j < 100; j++ {
+			screen.Write([]byte("x\x1b[6n"))
+		}
+
+		// Tears down while the drain goroutine is still Reading queued
+		// responses: its e.Read must not race the emulator Close.
+		stopScreenDrain(screen, screenDrain)
+	}
+}
+
 // TestRenderScreenIncludesScrollback verifies that renderScreen includes
 // lines that scrolled off the top of the screen, not just the visible rows.
 func TestRenderScreenIncludesScrollback(t *testing.T) {
-	screen := newScreen(80, 5, func(bool) {})
-	defer screen.Close()
+	screen, screenDrain := newScreen(80, 5, func(bool) {})
+	defer stopScreenDrain(screen, screenDrain)
 
 	// Write 10 lines through a 5-row terminal: lines 1-5 scroll off,
 	// lines 6-10 remain visible.
@@ -918,8 +942,8 @@ func TestRenderScreenIncludesScrollback(t *testing.T) {
 // filled screen has exactly Height-1 CRLF separators (no extra blank rows
 // from buffer growth) and that adding scrollback increases the total.
 func TestRenderScreenLineCount(t *testing.T) {
-	screen := newScreen(40, 5, func(bool) {})
-	defer screen.Close()
+	screen, screenDrain := newScreen(40, 5, func(bool) {})
+	defer stopScreenDrain(screen, screenDrain)
 
 	// Write 3 short lines, staying within the 5-row screen.
 	for i := 1; i <= 3; i++ {
@@ -934,8 +958,8 @@ func TestRenderScreenLineCount(t *testing.T) {
 	}
 
 	// Now push content into scrollback: write 10 lines through a 5-row terminal.
-	screen2 := newScreen(40, 5, func(bool) {})
-	defer screen2.Close()
+	screen2, screen2Drain := newScreen(40, 5, func(bool) {})
+	defer stopScreenDrain(screen2, screen2Drain)
 	for i := 1; i <= 10; i++ {
 		fmt.Fprintf(screen2, "Line-%02d\r\n", i)
 	}

--- a/cli/gmux/internal/ptyserver/ptyserver_test.go
+++ b/cli/gmux/internal/ptyserver/ptyserver_test.go
@@ -555,7 +555,9 @@ func TestPTYServerSnapshotBeforeLiveData(t *testing.T) {
 
 	for i := 0; i < numClients; i++ {
 		go func() {
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			// Generous timeout: 20 concurrent clients over the race detector
+			// take several seconds; a tighter budget flakes under -race.
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()
 
 			conn, _, err := websocket.Dial(ctx, "ws://localhost/", &websocket.DialOptions{

--- a/cli/gmux/moon.yml
+++ b/cli/gmux/moon.yml
@@ -12,6 +12,9 @@ tasks:
       - "go.mod"
       - "/packages/adapter/**/*.go"
   test:
-    command: go test ./...
+    # -race guards against concurrency regressions (e.g. the ptyserver
+    # Shutdown vs DSR-drain / PTY-Setsize races). The whole module is
+    # race-clean; keep it that way.
+    command: go test -race ./...
   lint:
     command: go vet ./...


### PR DESCRIPTION
## Summary

Fixes a pre-existing data race in `internal/ptyserver` between the `vt.Emulator`
DSR-drain goroutine and `Shutdown`, plus a second race surfaced while validating
the fix under `-race`. The whole `cli/gmux` module is now race-clean, and CI runs
`go test -race`.

This closes the gap deliberately scoped out of #386 (`TestShutdownIdempotent`
tripped this under `-race`).

## Root causes & fixes

### 1. vt.Emulator drain vs Close (the assigned bug)
`newScreen` spawns `go io.Copy(io.Discard, e)` to drain the emulator's DSR
responses; `Shutdown` called `s.screen.Close()` to unblock it. But
`vt.Emulator` guards its `closed` flag with **no synchronization**, so the
drain's `e.Read()` raced `Close()`'s write:

```
Read  emulator.go:252  (io.Copy drain)   vs   Write emulator.go:265 (Close)
```

This is a genuine upstream bug in `github.com/charmbracelet/x/vt` — still present
in the latest version (`v0.0.0-...-2cc9a8fe1146`), so upgrading doesn't help.

**Fix (usage-level, no dep change):** close the emulator's pipe via
`InputPipe()` (io.Pipe's methods are concurrency-safe) to unblock the drain,
**join** the drain goroutine, then call `Close()` when no `Read` is in flight.
See the new `stopScreenDrain` helper and `TestShutdownDrainNoRace`, which fails
under `-race` before the fix and passes after.

### 2. PTY Setsize vs ptmx.Close (sibling race)
Running the whole package under `-race` revealed a second, unrelated pre-existing
race: `pty.Setsize` (from `resize` / `shrinkForReconnect`) calls
`(*os.File).Fd()`, which is **not safe against a concurrent `(*os.File).Close()`**
from `Shutdown`. (`Read`/`Write` go through the reference-counted `poll.FD` and
were already safe — only the `Fd()` path raced.)

**Fix:** a `setPtySize` helper that holds `mu` and skips once `ptmxClosed` is set;
`Shutdown` now closes `ptmx` and sets the flag under `mu`, serializing the two.

## Test-timeout note
`TestPTYServerSnapshotBeforeLiveData` had a 5s per-client timeout; 20 concurrent
clients exceed it under the race detector's slowdown (~7s real work). Bumped to
30s — a test-budget issue, not a race.

## CI
`cli/gmux` is fully race-clean (`go test -race ./...` green), so the moon `test`
task now runs with `-race` to keep this class of bug from silently returning.

## Verification
- `go test ./internal/ptyserver/ -race` — green (ran repeatedly)
- `go test ./... -race` (whole module) — green
- `go test ./internal/ptyserver/ ./cmd/gmux/` (no -race) — green
- `go vet ./...` + `gofmt` — clean
