### PR TITLE
fix(gmuxd): bump last_activity_at on raw terminal output

### DIFF
--- a/services/gmuxd/internal/discovery/subscribe.go
+++ b/services/gmuxd/internal/discovery/subscribe.go
@@ -322,8 +322,12 @@ func (sub *Subscriptions) handleEvent(sessionID, socketPath, eventType string, d
 		})
 
 	case "activity":
-		// Transient signal: terminal produced output with no attached clients.
-		// Forward to the store's subscribers without mutating state.
+		// Raw terminal output. Bump the persisted last-activity timestamp
+		// (coarsely throttled inside the store) so interactively-used
+		// sessions surface as recently active even when they trigger no
+		// alive/unread/status transition — then forward the transient
+		// signal to the store's subscribers for the live activity dot.
+		sub.store.BumpActivity(sessionID)
 		sub.store.Broadcast(store.Event{
 			Type: "session-activity",
 			ID:   sessionID,

--- a/services/gmuxd/internal/discovery/subscribe_test.go
+++ b/services/gmuxd/internal/discovery/subscribe_test.go
@@ -304,3 +304,30 @@ func TestMetaEventUpdatesSlugAndIgnoresEmpty(t *testing.T) {
 		t.Errorf("AdapterTitle = %q, want %q", got.AdapterTitle, "Fix the login bug")
 	}
 }
+
+// TestActivityEventBumpsLastActivity pins the wire half of the
+// stale-"last activity" fix: an "activity" event from a live runner
+// (raw terminal output, which triggers no alive/unread/status edge)
+// must refresh the session's persisted LastActivityAt, not just fire
+// the transient session-activity dot. This is the gap that made an
+// actively-used session read "last activity N days ago".
+func TestActivityEventBumpsLastActivity(t *testing.T) {
+	sessions := store.New()
+	stale := time.Now().UTC().Add(-72 * time.Hour).Format(time.RFC3339)
+	sessions.Upsert(store.Session{ID: "sess-1", Alive: true, LastActivityAt: stale})
+	subs := NewSubscriptions(sessions)
+
+	subs.handleEvent("sess-1", "/sock", "activity", nil)
+
+	got, _ := sessions.Get("sess-1")
+	if got.LastActivityAt == stale {
+		t.Fatalf("activity event should freshen LastActivityAt, still %q", got.LastActivityAt)
+	}
+	ts, err := time.Parse(time.RFC3339, got.LastActivityAt)
+	if err != nil {
+		t.Fatalf("LastActivityAt %q not RFC3339: %v", got.LastActivityAt, err)
+	}
+	if time.Since(ts) > time.Minute {
+		t.Fatalf("activity event should stamp ~now, got %q", got.LastActivityAt)
+	}
+}

--- a/services/gmuxd/internal/store/store.go
+++ b/services/gmuxd/internal/store/store.go
@@ -52,6 +52,9 @@ type Session struct {
 	//   - unread: false → true  (new output the user hasn't seen)
 	//   - status.working: false → true  (adapter started a task)
 	//   - status.error: false → true  (status went into error)
+	//   - raw terminal output (via BumpActivity, coarsely throttled
+	//     to once per activityBumpInterval) — covers interactive use
+	//     that triggers none of the edges above.
 	//
 	// Not bumped on: new session creation (the first follow-up
 	// transition does it), title/cwd/slug/stamp changes, no-op status
@@ -387,6 +390,49 @@ func (s *Store) Update(id string, fn func(*Session)) bool {
 	s.mu.Unlock()
 	s.broadcastCommit(sess, removed, skip, unchanged)
 	return true
+}
+
+// activityBumpInterval is the coarse throttle for BumpActivity: raw
+// terminal output refreshes LastActivityAt at most once per interval
+// per session. The runner already throttles its "activity" SSE to one
+// per 2s; this second, coarser gate keeps a busy session from
+// broadcasting a full session-upsert (and re-persisting) every 2s
+// while still keeping "last activity" fresh to within a minute.
+const activityBumpInterval = 60 * time.Second
+
+// BumpActivity refreshes LastActivityAt to now for raw terminal
+// activity (PTY output), coarsely throttled by activityBumpInterval.
+//
+// It exists because shouldBumpActivity only fires on alive/unread/
+// working/error edges. An interactively-used session — a shell the
+// user is typing in, or an agent streaming output while its tab is
+// focused (so unread stays false) — produces none of those
+// transitions, so without this its LastActivityAt would stay frozen
+// at the first post-creation transition (often creation-ish time),
+// making an actively-used session read "last activity N days ago".
+//
+// Only locally-owned sessions reach this path (the discovery
+// subscriber calls it for runners this daemon owns). Peer activity is
+// relayed as a transient session-activity event and never bumps a
+// timestamp here, so a dead/peer session correctly freezes at its
+// last real activity.
+func (s *Store) BumpActivity(id string) {
+	now := time.Now().UTC()
+	s.mu.Lock()
+	prev, ok := s.sessions[id]
+	if !ok {
+		s.mu.Unlock()
+		return
+	}
+	if t, err := time.Parse(time.RFC3339, prev.LastActivityAt); err == nil && now.Sub(t) < activityBumpInterval {
+		s.mu.Unlock()
+		return
+	}
+	sess := prev
+	sess.LastActivityAt = now.Format(time.RFC3339)
+	removed, skip, unchanged := s.commitLocked(prev, true, &sess)
+	s.mu.Unlock()
+	s.broadcastCommit(sess, removed, skip, unchanged)
 }
 
 // GetTerminalSize returns the current terminal dimensions for a session.

--- a/services/gmuxd/internal/store/store.go
+++ b/services/gmuxd/internal/store/store.go
@@ -416,11 +416,16 @@ const activityBumpInterval = 60 * time.Second
 // relayed as a transient session-activity event and never bumps a
 // timestamp here, so a dead/peer session correctly freezes at its
 // last real activity.
+//
+// Dead sessions are ignored: a final buffered activity event can race
+// the exit event over the same SSE stream, and stamping a just-exited
+// session at ~now would make it read as active. The requirement is
+// that a dead session freezes at its last real activity.
 func (s *Store) BumpActivity(id string) {
 	now := time.Now().UTC()
 	s.mu.Lock()
 	prev, ok := s.sessions[id]
-	if !ok {
+	if !ok || !prev.Alive {
 		s.mu.Unlock()
 		return
 	}

--- a/services/gmuxd/internal/store/store_test.go
+++ b/services/gmuxd/internal/store/store_test.go
@@ -1616,3 +1616,88 @@ func TestLastActivityAt_UpsertRemotePreserves(t *testing.T) {
 		t.Fatalf("UpsertRemote alive→false should preserve peer-supplied timestamp (want %q, got %q)", wired, got2.LastActivityAt)
 	}
 }
+
+// TestBumpActivity_FreshensInteractiveSession is the regression test
+// for the "last activity N days ago" bug: an alive session that only
+// ever produces raw terminal output (no alive/unread/working/error
+// transition) never bumps via shouldBumpActivity, so its
+// LastActivityAt would stay frozen. BumpActivity is the path that
+// keeps it fresh.
+func TestBumpActivity_FreshensInteractiveSession(t *testing.T) {
+	s := New()
+	// A shell created "days ago", stamped once (e.g. its first unread
+	// edge) and then read, so it sits alive with a stale timestamp.
+	s.Upsert(Session{ID: "s1", Adapter: "shell", Alive: true})
+	stale := time.Now().UTC().Add(-72 * time.Hour).Format(time.RFC3339)
+	s.Update("s1", func(sess *Session) { sess.LastActivityAt = stale })
+
+	// Raw terminal output arrives — no transition, only BumpActivity.
+	s.BumpActivity("s1")
+
+	after, _ := s.Get("s1")
+	if after.LastActivityAt == stale {
+		t.Fatalf("BumpActivity should freshen stale LastActivityAt, still %q", after.LastActivityAt)
+	}
+	ts, err := time.Parse(time.RFC3339, after.LastActivityAt)
+	if err != nil {
+		t.Fatalf("LastActivityAt %q not RFC3339: %v", after.LastActivityAt, err)
+	}
+	if time.Since(ts) > time.Minute {
+		t.Fatalf("BumpActivity should stamp ~now, got %q", after.LastActivityAt)
+	}
+}
+
+// TestBumpActivity_ThrottledWithinInterval pins the coarse throttle:
+// a second bump inside activityBumpInterval is a no-op, so a busy
+// session doesn't re-broadcast/re-persist on every 2s activity tick.
+func TestBumpActivity_ThrottledWithinInterval(t *testing.T) {
+	s := New()
+	s.Upsert(Session{ID: "s1", Adapter: "shell", Alive: true})
+	s.BumpActivity("s1")
+	first, _ := s.Get("s1")
+	if first.LastActivityAt == "" {
+		t.Fatal("first BumpActivity on unstamped session should stamp")
+	}
+	s.BumpActivity("s1")
+	second, _ := s.Get("s1")
+	if second.LastActivityAt != first.LastActivityAt {
+		t.Fatalf("bump within interval should be a no-op (was %q, now %q)", first.LastActivityAt, second.LastActivityAt)
+	}
+}
+
+// TestBumpActivity_BroadcastsOnStamp pins that a real bump emits a
+// session-upsert so subscribers (and thereby the UI) observe the
+// refreshed timestamp, while a throttled no-op stays silent.
+func TestBumpActivity_BroadcastsOnStamp(t *testing.T) {
+	s := New()
+	stale := time.Now().UTC().Add(-72 * time.Hour).Format(time.RFC3339)
+	s.Upsert(Session{ID: "s1", Adapter: "shell", Alive: true, LastActivityAt: stale})
+
+	ch, cancel := s.Subscribe()
+	defer cancel()
+
+	s.BumpActivity("s1")
+	select {
+	case ev := <-ch:
+		if ev.Type != "session-upsert" || ev.ID != "s1" {
+			t.Fatalf("expected session-upsert for s1, got %+v", ev)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("BumpActivity on stale session should broadcast session-upsert")
+	}
+
+	// Second bump is throttled → no broadcast.
+	s.BumpActivity("s1")
+	select {
+	case ev := <-ch:
+		t.Fatalf("throttled BumpActivity should not broadcast, got %+v", ev)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+// TestBumpActivity_UnknownSessionNoPanic pins that bumping a missing
+// session is a safe no-op (activity can race session removal).
+func TestBumpActivity_UnknownSessionNoPanic(t *testing.T) {
+	s := New()
+	s.BumpActivity("nope")
+}

--- a/services/gmuxd/internal/store/store_test.go
+++ b/services/gmuxd/internal/store/store_test.go
@@ -1701,3 +1701,17 @@ func TestBumpActivity_UnknownSessionNoPanic(t *testing.T) {
 	s := New()
 	s.BumpActivity("nope")
 }
+
+// TestBumpActivity_IgnoresDeadSession pins that a late activity event
+// racing a session's exit does not resurrect its timestamp: a dead
+// session must freeze at its last real activity.
+func TestBumpActivity_IgnoresDeadSession(t *testing.T) {
+	s := New()
+	stale := time.Now().UTC().Add(-72 * time.Hour).Format(time.RFC3339)
+	s.Upsert(Session{ID: "s1", Adapter: "shell", Alive: false, LastActivityAt: stale})
+	s.BumpActivity("s1")
+	after, _ := s.Get("s1")
+	if after.LastActivityAt != stale {
+		t.Fatalf("BumpActivity on dead session must not bump (was %q, now %q)", stale, after.LastActivityAt)
+	}
+}


### PR DESCRIPTION
## Problem

The "last activity N ago" shown for a session was stale: an actively-used session (producing output *today*) displayed **"last activity 3 days ago."** The timestamp reflected roughly session-creation time, not recent activity.

## Root cause

The displayed field is `last_activity_at` (`Session.LastActivityAt` in `services/gmuxd`, stamped by the daemon; rendered by `session-row.tsx` via `formatAge`). It's bumped by `shouldBumpActivity` only on four *edges*: exit (`alive` true→false), `unread` false→true, `status.working` false→true, `status.error` false→true.

An **interactively-used session produces none of these edges** — a shell you're typing in, or an agent streaming output while its tab is focused (so `unread` stays false and `working` doesn't re-toggle). Its only signal is the runner's transient `activity` SSE event, which the discovery handler re-broadcast as the live activity dot **without mutating state**. So `last_activity_at` froze at the first post-creation transition (~creation time).

## Fix

New `Store.BumpActivity(id)`, called from the `"activity"` case in `discovery/subscribe.go`, freshens `LastActivityAt` on real terminal output and broadcasts a `session-upsert` so the UI/CLI observe it.

**Write cadence** (no fsync-per-keystroke): the runner already throttles `activity` to ≤1/2s; `BumpActivity` adds a coarse 60s gate (`activityBumpInterval`), so a busy session emits at most one `session-upsert` per minute. Since the UI renders `<60s` as "now", worst-case staleness is imperceptible.

**Edge cases:**
- **Peer sessions** never bump here — peer activity is relayed as a separate namespaced `session-activity` broadcast (`peering/peer.go`); the owning daemon stamps the timestamp and `UpsertRemote` preserves it as-received.
- **Dead sessions** are guarded: a final buffered `activity` event can race the `exit` event over the same SSE stream, so `BumpActivity` ignores non-alive sessions — a dead session freezes at its last real activity. Persisted via sessionmeta, survives restart.
- **Unknown/removed session**: safe no-op (activity can race removal).

Consistent with the existing design that brand-new sessions don't bump (avoids stamping every rehydrated dead session at startup).

## Tests

- `store_test.go`: `TestBumpActivity_FreshensInteractiveSession` (the regression — a 72h-stale alive session with no transition gets freshened), `_ThrottledWithinInterval`, `_BroadcastsOnStamp`, `_IgnoresDeadSession`, `_UnknownSessionNoPanic`.
- `subscribe_test.go`: `TestActivityEventBumpsLastActivity` — wire-level proof that an `activity` event from a live runner bumps the persisted timestamp (the actual gap).

Each regression test verified to fail without its corresponding fix.

## Checks

`go test ./...` + `go vet ./...` (gmuxd) ✅ · `pnpm lint` ✅ · `pnpm -C apps/gmux-web test` ✅ (580)