### PR TITLE
fix(web): keep the terminal mounted when /resume changes a session's slug

### DIFF
--- a/apps/gmux-web/src/store.test.ts
+++ b/apps/gmux-web/src/store.test.ts
@@ -8,6 +8,7 @@ import {
   isSessionUnavailable, urlPath, urlSearch, filteredSessions, selectedId,
   navigateToSession, setNavigate,
   applyPending, _rawSessions, _rawWorld, _setRawWorld, _pendingMutations,
+  applySessionsSnapshot,
   toUISession, localHostLabel, parseConnectURL, unreadCount, discovered,
   view, duplicateConversationFiles,
 } from './store'
@@ -305,6 +306,97 @@ describe('upsertSession', () => {
     // URL should be unchanged.
     expect(urlPath.value).toBe('/myproject/pi/fix-auth')
     expect(selectedId.value).toBe('sess-1')
+  })
+})
+
+describe('applySessionsSnapshot: /resume keeps the terminal mounted', () => {
+  // Regression for the /resume boot-to-project bug (and the same class of
+  // rename bug, #348/#360). A pi /resume keeps the gmux session id but
+  // swaps the active conversation, so the title-derived slug changes. The
+  // daemon re-pushes the *entire* session list (protocol 2 / ADR 0001),
+  // which the client applies wholesale via applySessionsSnapshot.
+  //
+  // These drive the real production entry point (not the extracted helper
+  // in isolation) and assert the observable that actually regressed: the
+  // resolved `view` must stay on the session, with the URL rewritten in
+  // place — not fall back to the project hub. Testing the seam, not just
+  // the helper, is deliberate: the original regression was precisely that
+  // the rewrite logic existed but nothing on the live path called it.
+  const testProjects: ProjectItem[] = [
+    { slug: 'myproject', match: [{ path: '/dev/project' }] },
+  ]
+  const navCalls: Array<[string, boolean | undefined]> = []
+  beforeEach(() => {
+    navCalls.length = 0
+    setNavigate((url, replace) => { navCalls.push([url, replace]) })
+    _setRawWorld({ projects: testProjects })
+    _rawSessions.value = [
+      makeSession({ id: 'sess-1', cwd: '/dev/project', adapter: 'pi', slug: 'fix-auth' }),
+    ]
+    sessionsLoaded.value = true
+    worldLoaded.value = true
+    urlPath.value = '/myproject/pi/fix-auth'
+  })
+
+  it('rewrites the URL and keeps the session view when the selected slug changes', () => {
+    expect(view.value).toEqual({ kind: 'session', sessionId: 'sess-1' })
+
+    // Snapshot: same id, resumed slug, brand-new array (the wire shape).
+    applySessionsSnapshot([
+      makeSession({ id: 'sess-1', cwd: '/dev/project', adapter: 'pi', slug: 'refactor-login' }),
+    ])
+
+    expect(urlPath.value).toBe('/myproject/pi/refactor-login')
+    // The user stays on the terminal — no boot to the project hub.
+    expect(view.value).toEqual({ kind: 'session', sessionId: 'sess-1' })
+    // Address bar synced via replaceState (replace=true), so back/forward
+    // history isn't polluted.
+    expect(navCalls).toContainEqual(['/myproject/pi/refactor-login', true])
+  })
+
+  it('leaves the URL untouched when the selected slug is unchanged', () => {
+    applySessionsSnapshot([
+      makeSession({ id: 'sess-1', cwd: '/dev/project', adapter: 'pi', slug: 'fix-auth', title: 'now working' }),
+    ])
+
+    expect(urlPath.value).toBe('/myproject/pi/fix-auth')
+    expect(view.value).toEqual({ kind: 'session', sessionId: 'sess-1' })
+    expect(navCalls).toEqual([])
+  })
+
+  it('does not rewrite when a non-selected session changes slug', () => {
+    _rawSessions.value = [
+      makeSession({ id: 'sess-1', cwd: '/dev/project', adapter: 'pi', slug: 'fix-auth' }),
+      makeSession({ id: 'sess-2', cwd: '/dev/project', adapter: 'pi', slug: 'old' }),
+    ]
+
+    applySessionsSnapshot([
+      makeSession({ id: 'sess-1', cwd: '/dev/project', adapter: 'pi', slug: 'fix-auth' }),
+      makeSession({ id: 'sess-2', cwd: '/dev/project', adapter: 'pi', slug: 'new' }),
+    ])
+
+    expect(urlPath.value).toBe('/myproject/pi/fix-auth')
+    expect(navCalls).toEqual([])
+  })
+
+  it('boots to the hub only when the selected session is genuinely gone', () => {
+    // A snapshot that drops the session (killed) — distinct from a slug
+    // change — should fall through to the normal commit and let the view
+    // resolve to the project hub.
+    applySessionsSnapshot([])
+
+    expect(view.value).toEqual({ kind: 'project', projectSlug: 'myproject' })
+  })
+
+  it('still commits the snapshot (loaded flags flip) when nothing is selected', () => {
+    urlPath.value = '/'
+    sessionsLoaded.value = false
+    applySessionsSnapshot([
+      makeSession({ id: 'sess-9', cwd: '/dev/project', adapter: 'pi', slug: 'x' }),
+    ])
+    expect(sessionsLoaded.value).toBe(true)
+    expect(sessions.value.map(s => s.id)).toContain('sess-9')
+    expect(navCalls).toEqual([])
   })
 })
 

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -909,6 +909,103 @@ export function sessionStaleness(
   return null
 }
 
+/**
+ * When the currently-selected session's slug changes between two session
+ * arrays, compute the canonical URL for the new slug. Callers rewrite the
+ * address bar in place with this URL so the stale slug doesn't fail to
+ * resolve and boot the user back to the project hub.
+ *
+ * The slug is title-derived (#348/#360), so it changes on rename *and*
+ * when a pi `/resume` swaps the active conversation. Both cases keep the
+ * same underlying gmux session id; only the slug moves. Resolving the
+ * post-update session list here means the returned URL sees the new slug.
+ *
+ * `selectedId` is read before the caller commits the new array, so it
+ * still resolves against the current (pre-change) slug in the URL.
+ *
+ * Returns null when nothing needs rewriting.
+ */
+function selectedSlugRewrite(prev: Session[], next: Session[]): string | null {
+  const id = selectedId.value
+  if (!id) return null
+  const old = prev.find(s => s.id === id)
+  const cur = next.find(s => s.id === id)
+  if (!old || !cur || old.slug === cur.slug) return null
+  // viewToPath routes peer-owned sessions through `/@<peer>/...` (ADR 0002)
+  // just like every other URL serializer.
+  return viewToPath({ kind: 'session', sessionId: id }, projects.value, next)
+}
+
+/**
+ * Rewrite the address bar in place when the selected session's slug moved.
+ * Sets `urlPath` inside the same batch as the session commit so the `view`
+ * computed never observes the new slug against the old URL (which would
+ * briefly fail to resolve and deselect the session). Returns true when a
+ * rewrite happened, meaning the caller has already committed `nextSessions`
+ * to `_rawSessions` inside the batch.
+ */
+function commitWithSlugRewrite(
+  nextSessions: Session[],
+  extra?: () => void,
+): boolean {
+  const newUrl = selectedSlugRewrite(_rawSessions.value, nextSessions)
+  if (!newUrl) return false
+  batch(() => {
+    _rawSessions.value = nextSessions
+    urlPath.value = newUrl
+    extra?.()
+  })
+  // Sync the browser URL bar. navigate(replace) uses history.replaceState
+  // via preact-iso, so back/forward history isn't polluted. urlPath was
+  // already set above inside the batch for atomicity with the session data.
+  navigate(newUrl, true)
+  return true
+}
+
+/**
+ * Apply a wholesale `snapshot.sessions` payload (protocol 2 / ADR 0001):
+ * the daemon re-sends the *entire* session list on any session state
+ * change, and we replace `_rawSessions` in one shot rather than patching
+ * individual entries.
+ *
+ * Because the replacement is wholesale, a slug change on the currently
+ * viewed session (a rename, or a pi `/resume` that swaps the active
+ * conversation — #348/#360) arrives here, NOT via `upsertSession`. This is
+ * the seam that silently regressed when #191 replaced per-session
+ * `session-upsert` events (which ran `upsertSession`, and with it the
+ * slug→URL rewrite) with snapshots: the rewrite logic was left in
+ * `upsertSession`, which the live path no longer calls. Routing the
+ * commit through `commitWithSlugRewrite` reconnects it, so the URL follows
+ * the new slug in place instead of the stale slug failing to resolve and
+ * booting the user back to the project hub.
+ */
+export function applySessionsSnapshot(list: Session[]): void {
+  // Detect newly-arrived IDs vs the previous snapshot so a pending launch
+  // (just-POSTed /v1/launch awaiting an id) can navigate to its session as
+  // soon as the daemon publishes it. Computed before we commit the new
+  // array so the launch navigation runs against the new state.
+  const prevIds = new Set(_rawSessions.value.map(s => s.id))
+  const newIds = list.filter(s => !prevIds.has(s.id)).map(s => s.id)
+
+  const rewritten = commitWithSlugRewrite(list, () => {
+    sessionsLoaded.value = true
+    connState.value = 'connected'
+  })
+  if (!rewritten) {
+    batch(() => {
+      _rawSessions.value = list
+      sessionsLoaded.value = true
+      connState.value = 'connected'
+    })
+  }
+
+  if (newIds.length > 0 && consumePendingLaunch()) {
+    // Most recent new id wins; with one launch in flight at a time this
+    // is unambiguous.
+    navigateToSession(newIds[newIds.length - 1], true)
+  }
+}
+
 /** Upsert a session from SSE. Returns true if the session was new. */
 export function upsertSession(raw: ProtocolSession): boolean {
   const updated = toUISession(raw)
@@ -916,38 +1013,9 @@ export function upsertSession(raw: ProtocolSession): boolean {
   const prev = _rawSessions.value
   const idx = prev.findIndex(s => s.id === updated.id)
   if (idx >= 0) {
-    const old = prev[idx]
     const next = [...prev]
     next[idx] = updated
-
-    // When the currently-selected session changes slug, update the URL
-    // atomically with the session data. Without batch(), the view
-    // computed would see the new sessions (slug changed) but the old
-    // URL (still has the old slug), fail to resolve, and briefly
-    // deselect the session.
-    if (old.slug !== updated.slug && selectedId.value === updated.id) {
-      // viewToPath gets the post-update sessions array so it sees the
-      // new slug. Routes peer-owned sessions through `/@<peer>/...`
-      // (ADR 0002) just like every other URL serializer.
-      const newUrl = viewToPath(
-        { kind: 'session', sessionId: updated.id },
-        projects.value,
-        next,
-      )
-      if (newUrl) {
-        batch(() => {
-          _rawSessions.value = next
-          urlPath.value = newUrl
-        })
-        // Sync the browser URL bar. navigate() calls preact-iso's
-        // loc.route which would also set urlPath via the
-        // useLayoutEffect in App, but we already set it above
-        // inside the batch for atomicity.
-        navigate(newUrl, true)
-        return isNew
-      }
-    }
-
+    if (commitWithSlugRewrite(next)) return isNew
     _rawSessions.value = next
   } else {
     isNew = true
@@ -1418,27 +1486,7 @@ export function initStore(): () => void {
   source.addEventListener('snapshot.sessions', (e) => {
     try {
       const envelope = JSON.parse(e.data) as { sessions?: ProtocolSession[] }
-      const list = (envelope.sessions ?? []).map(toUISession)
-
-      // Detect newly-arrived IDs vs the previous snapshot so a
-      // pending launch (just-POSTed /v1/launch awaiting an id) can
-      // navigate to its session as soon as the daemon publishes it.
-      // Done before we commit the new array so consumers see the
-      // navigation against the new state.
-      const prevIds = new Set(_rawSessions.value.map(s => s.id))
-      const newIds = list.filter(s => !prevIds.has(s.id)).map(s => s.id)
-
-      batch(() => {
-        _rawSessions.value = list
-        sessionsLoaded.value = true
-        connState.value = 'connected'
-      })
-
-      if (newIds.length > 0 && consumePendingLaunch()) {
-        // Most recent new id wins; with one launch in flight at a
-        // time this is unambiguous.
-        navigateToSession(newIds[newIds.length - 1], true)
-      }
+      applySessionsSnapshot((envelope.sessions ?? []).map(toUISession))
     } catch (err) {
       console.warn('snapshot.sessions: bad event', err)
     }


### PR DESCRIPTION
## The bug

Running `/resume` inside a live pi session (to switch to a prior conversation) **boots the user back to the project hub** and forces a manual re-select, instead of transparently keeping them on the same terminal with the URL silently rewritten.

## Root cause

gmux URLs are addressed by the **title-derived slug** (`/<project>/<adapter>/<slug>`, `routing.ts`). A pi `/resume` swaps the active conversation → the adapter title and slug change while the **gmux session id stays the same** (same runner/pty; only `slug`/`conversation_file` move, via `state.go` `SetSlug`).

The daemon re-pushes the **entire** session list on any state change, and the client applies it **wholesale** via `snapshot.sessions` (protocol 2 / ADR 0001). So on resume:

1. `snapshot.sessions` swaps `_rawSessions` with the new slug.
2. The `view` computed re-resolves the **old** URL slug → no exact-slug match, no id-prefix match → `resolveSessionFromPath` returns `null`.
3. `resolveViewFromPath` falls back to the **project view** → boot to hub (then the URL-normalization effect cements it by rewriting the address bar to the project path).

### This used to work — it regressed at #191

Before **#191 (snapshot push protocol)**, the store consumed **per-session** SSE events:

```
source.addEventListener('session-upsert', e => { … upsertSession(session) … })
source.addEventListener('session-remove', …)
```

`upsertSession` carried exactly the slug-change → `replaceState` logic, so it fired on every per-session update and the URL correctly followed rename/resume. #191 rewrote the transport to wholesale snapshots (`_rawSessions.value = list`) and deleted the `session-upsert`/`session-remove` listeners — but left `upsertSession` (and its slug-rewrite block) behind, now **orphaned**. The behavior silently regressed there; it wasn't intentionally removed. The same gap hits plain renames (#348/#360).

## The fix

- Route **every wholesale session commit** through `commitWithSlugRewrite`, which sets `_rawSessions` + `urlPath` in one `batch()` (so `view` never sees the new slug against the old URL) and navigates with `replace` → `history.replaceState` (no back/forward pollution). `upsertSession` reuses the same helper.
- Compute the canonical URL via `viewToPath(...)` (not the old `matchSession`+`sessionPath`), so peer-owned / `@host` URLs (ADR 0002, added after #191) are handled correctly — strictly more correct than the pre-#191 version.
- Extract the `snapshot.sessions` handler body into a documented, exported `applySessionsSnapshot()` — the actual seam that regressed — so tests guard the **wiring**, not just the helper.

Result: when the viewed session's slug moves, the URL is rewritten in place, the terminal stays mounted, the session stays selected. Deep-links and stale-slug URLs still resolve via the existing exact/id-prefix matching.

## Tests

New `store.test.ts` suite *applySessionsSnapshot: /resume keeps the terminal mounted* drives the **real production entry point** and asserts the observable that actually broke — the resolved `view` stays `{ kind: 'session' }` with `urlPath` rewritten in place — plus: unchanged slug (no-op), non-selected slug change (no-op), session genuinely gone (→ hub), and nothing-selected (snapshot still commits). Testing the seam (not just the helper) is deliberate: the original regression was precisely that the rewrite logic existed but nothing on the live path called it.

Full web suite: **585 passed**, `tsc` clean, `biome lint` clean.

Browser (chrome-devtools): confirmed the fixed bundle builds, loads, connects, and routes projects/sessions (mock mode, desktop + mobile). A full live pi `/resume` repro through chrome was blocked by daemon bearer-token auth on a fresh dev-server origin; the regression is proven at the unit level against the exact resolve-by-slug fallback path.