### PR TITLE
feat(web): folder-shaped cwd token + session card/header polish

### DIFF
--- a/apps/gmux-web/src/cwd-format.test.ts
+++ b/apps/gmux-web/src/cwd-format.test.ts
@@ -50,12 +50,13 @@ describe('cwdBadge', () => {
 })
 
 describe('hubCwdLabel', () => {
-  it('marks a session at the project root with a dot', () => {
-    expect(hubCwdLabel('~/dev/gmux', '~/dev/gmux')).toBe('.')
+  it('marks a session at the project root with a folder-shaped ./', () => {
+    // './' (not a bare '.') so the token always reads as a directory.
+    expect(hubCwdLabel('~/dev/gmux', '~/dev/gmux')).toBe('./')
   })
 
-  it('is blank for an unresolved (empty) cwd, not a stray dot', () => {
-    // Regression guard: an empty cwd must not collapse to '.', which
+  it('is blank for an unresolved (empty) cwd, not a stray ./', () => {
+    // Regression guard: an empty cwd must not collapse to './', which
     // would label a placeholder as if it were the project root.
     expect(hubCwdLabel('', '~/dev/gmux')).toBe('')
     expect(hubCwdLabel(undefined, '~/dev/gmux')).toBe('')

--- a/apps/gmux-web/src/cwd-format.ts
+++ b/apps/gmux-web/src/cwd-format.ts
@@ -36,13 +36,13 @@ export function cwdBadge(cwd: string | undefined, canonical?: string): string | 
 }
 
 /**
- * Project-hub row disambiguator: like relativeCwd, but a session sitting
- * at the project root reads as '.' (a meaningful "here" marker when rows
- * disagree on cwd) rather than a blank segment. An unresolved (empty)
- * cwd still yields '' so the row renders nothing — a placeholder cwd is
- * not a location worth labelling.
+ * Project-hub row disambiguator: like relativeCwd, but a session at the
+ * project root reads as './' rather than a bare '.', keeping the
+ * invariant that every rendered folder token starts with './', '~/', or
+ * '/'. An empty cwd still yields '' (never './') so its row renders no
+ * location marker.
  */
 export function hubCwdLabel(cwd: string | undefined, canonical?: string): string {
   if (!cwd) return ''
-  return relativeCwd(cwd, canonical) || '.'
+  return relativeCwd(cwd, canonical) || './'
 }

--- a/apps/gmux-web/src/host-suffix.tsx
+++ b/apps/gmux-web/src/host-suffix.tsx
@@ -17,7 +17,7 @@
 
 import { peerStatusByName } from './store'
 
-export function HostSuffix({ peer, leading = true, local = false }: { peer?: string; leading?: boolean; local?: boolean }) {
+export function HostSuffix({ peer, leading = true, local = false, connective }: { peer?: string; leading?: boolean; local?: boolean; connective?: string }) {
   if (!peer) return null
 
   // 'connected' or unknown (undefined) reads as normal; anything
@@ -33,7 +33,9 @@ export function HostSuffix({ peer, leading = true, local = false }: { peer?: str
       class={`host-suffix${offline ? ' offline' : ''}`}
       title={`${peer}${status ? ` (${status})` : ''}`}
     >
-      {leading && <span class="host-suffix-sep" aria-hidden="true"> · </span>}{peer}
+      {connective
+        ? <span class="host-suffix-prep">{connective} </span>
+        : leading && <span class="host-suffix-sep" aria-hidden="true"> · </span>}{peer}
     </span>
   )
 }

--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -225,15 +225,13 @@ function HeaderStatusChip({ session, resuming }: {
       </div>
     )
   }
-  if (!session.status?.working && !session.status?.error) return null
-  const error = !!session.status.error
+  // A live "Working…" chip is redundant with the session's own dot
+  // indicator, so only the error state earns a header chip here.
+  if (!session.status?.error) return null
   return (
-    <div class={`main-header-status ${error ? 'error' : 'working'}`}>
-      <span
-        class={`session-dot ${error ? 'error' : 'working'}`}
-        style={{ width: 5, height: 5 }}
-      />
-      {error ? 'Error' : 'Working…'}
+    <div class="main-header-status error">
+      <span class="session-dot error" style={{ width: 5, height: 5 }} />
+      Error
     </div>
   )
 }

--- a/apps/gmux-web/src/project-hub.tsx
+++ b/apps/gmux-web/src/project-hub.tsx
@@ -104,7 +104,7 @@ export function ProjectHub({ projectSlug, projectPeer, onCloseSession }: Project
       href={sessionPath(projectSlug, s, projectPeer)}
       showCwd={!sharedCwd}
       // Multi-cwd disambiguator: express each cwd relative to the
-      // canonical folder ('.' for a session at the project root, blank
+      // canonical folder ('./' for a session at the project root, blank
       // for an unresolved cwd so its segment is dropped).
       cwdLabel={hubCwdLabel(s.cwd, canonicalCwd)}
       showHost={mixedHosts}

--- a/apps/gmux-web/src/session-row.tsx
+++ b/apps/gmux-web/src/session-row.tsx
@@ -106,11 +106,23 @@ export function SessionRow({
     unavailable ? 'unavailable' : '',
   ].filter(Boolean).join(' ')
 
-  // Line-2 metadata segments. Render only the ones requested by
-  // props; empty arrays produce no separator dots in the output.
+  // Line-2 metadata, in reading order: time · project on host · folder.
+  // The bold project → muted host rhythm mirrors the sidebar folder
+  // header. Only requested segments render; empty ones add no separator.
   const metaSegments: preact.ComponentChildren[] = []
+  if (age) {
+    metaSegments.push(<span class="session-row-age">{age}</span>)
+  }
+  const hostEl = showHost && session.peer
+    ? <HostSuffix peer={session.peer} connective="on" />
+    : null
   if (showProject && projectName) {
-    metaSegments.push(<span class="session-row-project">{projectName}</span>)
+    // Grouped so the host joins the project with "on" and no dot between.
+    metaSegments.push(
+      <span class="session-row-project">{projectName}{hostEl && <> {hostEl}</>}</span>,
+    )
+  } else if (hostEl) {
+    metaSegments.push(hostEl)
   }
   if (showCwd && cwdLabel) {
     // Truncated in CSS; the title carries the full absolute cwd so a
@@ -125,9 +137,6 @@ export function SessionRow({
     metaSegments.push(
       <span class="session-row-dup" title="This conversation is open in more than one tab">⚠ open elsewhere</span>,
     )
-  }
-  if (age) {
-    metaSegments.push(<span class="session-row-age">{age}</span>)
   }
 
   return (
@@ -147,7 +156,7 @@ export function SessionRow({
       }
       <div class="session-row-content">
         <div class="session-row-title">{session.title}</div>
-        {(metaSegments.length > 0 || showHost) && (
+        {metaSegments.length > 0 && (
           <div class="session-row-meta">
             {metaSegments.map((seg, i) => (
               // Long-form Fragment carries a key: the shorthand `<>`
@@ -161,7 +170,6 @@ export function SessionRow({
                 {seg}
               </Fragment>
             ))}
-            {showHost && <HostSuffix peer={session.peer} leading={metaSegments.length > 0} />}
           </div>
         )}
       </div>

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -439,6 +439,10 @@ body {
   opacity: 0.6;
   margin: 0 0.1em;
 }
+/* "on" connective before a host name: inherits the host's muted colour. */
+.host-suffix-prep {
+  color: inherit;
+}
 
 /* ── Session Item ── */
 
@@ -796,24 +800,26 @@ body {
   display: flex;
   flex-wrap: wrap;
   align-items: baseline;
-  margin-top: 3px;
-  font-size: 11px;
+  margin-top: 4px;
+  font-size: 12px;
   color: var(--text-muted);
   min-width: 0;
 }
 .session-row-sep {
   color: var(--text-muted);
   opacity: 0.6;
+  margin: 0 0.4em; /* air so the meta line doesn't read as a run-on */
 }
 .session-row-project {
+  /* Bold, matching the sidebar folder header (.folder-name). */
   color: var(--text);
-  opacity: 0.85;
+  font-weight: 600;
 }
 .session-row-cwd {
-  font-family: var(--font-mono, monospace);
-  /* Long worktree/subfolder paths truncate rather than pushing the
-   * rest of the meta line off-screen; full path is in the title. */
-  max-width: 22ch;
+  /* No monospace: the ./ ~/ / prefix already marks it as a folder, and
+   * the shared font keeps the meta line one size. Ellipsizes only when
+   * a path exceeds the line (full path is in the title). */
+  max-width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -823,6 +829,9 @@ body {
 }
 .session-row-age {
   font-variant-numeric: tabular-nums;
+  /* Weight + colour matched to the project so the time reads as its peer. */
+  font-weight: 600;
+  color: var(--text);
 }
 .session-row-dup,
 .session-dup-warning {
@@ -1599,7 +1608,8 @@ body {
 
 .main-header-left {
   display: flex;
-  align-items: center;
+  /* Baseline so the bold title and smaller muted cwd align. */
+  align-items: baseline;
   gap: 8px;
   min-width: 0;
   overflow: hidden;


### PR DESCRIPTION
## What

Started as the scoped tweak *"make the folder/cwd token always read as a folder"* and, after a round of live review, grew into a focused polish pass on the session-card meta line and the terminal header.

### cwd token (the original ask)
- **`hubCwdLabel`**: a session at the project root now renders **`./`** instead of a bare `.`, so the token always carries a folder-shaped prefix (`./` `~/` `/`) and is identifiable as a directory by its shape. Empty/unresolved cwds still render nothing (regression guard kept).
- **`.session-row-cwd`**: dropped the monospace font (the prefix already marks it as a folder, so the whole meta line now reads at one consistent size), and replaced the hard `max-width: 22ch` cap with `max-width: 100%` — full paths show, and a path only ellipsizes when it genuinely exceeds the line.

### Session card meta line — reordered to `time · project on host · folder`
- **Time first**, in the project's weight and primary colour, sharing a baseline with it (no more lighter, higher-looking timestamp).
- **Project bold**, host introduced by an **"on" connective** (same muted colour as the host) instead of a separator dot — reads as a phrase (`home on ft`) while echoing the sidebar's bold→muted project/host rhythm.
- Wider separator gaps so the line stops reading as a cramped run-on.
- Host rendering routed through a new `connective` option on the shared `HostSuffix`, keeping offline-tinting logic centralized.

### Terminal header
- `.main-header-left` aligned to **baseline** so the bold title and the smaller muted cwd share a text baseline.
- Removed the redundant live **"Working…"** chip (the session dot already conveys it). Error / Exited / Resuming chips stay.

## The root-case decision (please veto if you disagree)
The invariant guaranteed is: **any rendered folder token starts with `./`, `~/`, or `/`** — never a bare `.` or an empty-but-present element.

- On the **project hub**, where cwd is an explicit per-row disambiguator, the project-root case now shows `./`.
- On **home cards**, the root case stays quiet (the project name is right there); showing `./` on every root session would add noise. Whenever a cwd *is* shown on home it already carries a prefix, so the invariant holds either way.

## Verify
Verified live on desktop + mobile (home cards, hub root/descendant/unrelated sessions, terminal header). The build is installed locally, so reload the UI to see it. `pnpm lint` clean; `cwd-format.test.ts` updated to the `./` contract (13/13).


