### PR TITLE
fix(gmuxd): reseed last_activity_at from file mtime on daemon restart

### DIFF
--- a/services/gmuxd/cmd/gmuxd/activityseed.go
+++ b/services/gmuxd/cmd/gmuxd/activityseed.go
@@ -32,6 +32,17 @@ import (
 // empty and the UI would fall back to created_at ("3 days ago"). The
 // store applies this value only as a floor for empty stamps, so it can
 // never overwrite a live or persisted timestamp.
+//
+// Note: the store can't tell a restart-rehydrate from a first-ever
+// registration — both arrive with an empty stamp — so a brand-new
+// session is seeded too. That is harmless: its files' mtimes are ~now,
+// which is the same instant the UI would show via the created_at
+// fallback anyway, and the first real state transition bumps the stamp
+// forward. The one visibly-odd case is resuming an *old* conversation
+// when the scrollback tee failed to open: the seed would then be the old
+// conversation file's mtime (days ago) until the first transition
+// corrects it. Rare and self-healing, so we accept rather than guard —
+// there is no reliable restart-vs-fresh signal at this layer.
 func activitySeedFor(sess store.Session, sessionDir func(string) string) string {
 	var newest time.Time
 	consider := func(path string) {

--- a/services/gmuxd/cmd/gmuxd/activityseed.go
+++ b/services/gmuxd/cmd/gmuxd/activityseed.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/gmuxapp/gmux/packages/scrollback"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/store"
+)
+
+// activitySeedFor returns an RFC3339 timestamp to seed a rehydrated
+// session's LastActivityAt from the newest durable on-disk activity
+// proxy. Two sources, newest wins:
+//
+//   - the adapter's conversation file (primary): appended on every
+//     message, so its mtime is an accurate, restart-surviving proxy for
+//     when the session last did something. The path is adapter-supplied
+//     (session.ConversationFile, reported by the agent hook per ADR
+//     0011); the daemon only stats it, so no adapter-specific reseed
+//     logic is needed.
+//   - the runner's scrollback tee (generic fallback): every session has
+//     one under the per-session dir, written live by the runner. Covers
+//     plain shells and agent sessions whose conversation file hasn't
+//     appeared yet.
+//
+// Returns "" when neither file yields a usable mtime.
+//
+// This recovers "last activity" across a daemon restart. An alive
+// session's LastActivityAt is never persisted (only dead sessions land
+// in sessionmeta), so on re-register the store would otherwise leave it
+// empty and the UI would fall back to created_at ("3 days ago"). The
+// store applies this value only as a floor for empty stamps, so it can
+// never overwrite a live or persisted timestamp.
+func activitySeedFor(sess store.Session, sessionDir func(string) string) string {
+	var newest time.Time
+	consider := func(path string) {
+		if path == "" {
+			return
+		}
+		info, err := os.Stat(path)
+		if err != nil {
+			return
+		}
+		if mt := info.ModTime(); mt.After(newest) {
+			newest = mt
+		}
+	}
+	consider(sess.ConversationFile)
+	if sessionDir != nil && sess.ID != "" {
+		consider(filepath.Join(sessionDir(sess.ID), scrollback.ActiveName))
+	}
+	if newest.IsZero() {
+		return ""
+	}
+	// Cap at now: a conversation file with a skewed clock (or one on a
+	// remote filesystem) must not stamp activity in the future.
+	if now := time.Now(); newest.After(now) {
+		newest = now
+	}
+	return newest.UTC().Format(time.RFC3339)
+}

--- a/services/gmuxd/cmd/gmuxd/activityseed_test.go
+++ b/services/gmuxd/cmd/gmuxd/activityseed_test.go
@@ -72,6 +72,41 @@ func TestActivitySeedFor_NoFilesReturnsEmpty(t *testing.T) {
 	}
 }
 
+// TestActivitySeedWiring_ReseedsRehydratedSession exercises the actual
+// wiring the daemon uses: SetActivitySeed(activitySeedFor(...,
+// SessionDir)) as in serve(), driving a real store Upsert against a real
+// on-disk scrollback tee. This is the rehydrate path — both
+// sessionmeta.Sweep restore and discovery.Register re-register land a
+// session in the store via Upsert with an empty stamp — so a single
+// Upsert of a stampless session pins the end-to-end regression that the
+// isolated helper/store unit tests each only cover half of.
+func TestActivitySeedWiring_ReseedsRehydratedSession(t *testing.T) {
+	root := t.TempDir()
+	sessionDir := func(id string) string { return filepath.Join(root, id) }
+	want := time.Now().Add(-45 * time.Minute).Truncate(time.Second)
+	writeFileWithMtime(t, filepath.Join(sessionDir("sess-abc"), scrollback.ActiveName), want)
+
+	// Mirror serve()'s wiring exactly.
+	sessions := store.New()
+	sessions.SetActivitySeed(func(sess store.Session) string {
+		return activitySeedFor(sess, sessionDir)
+	})
+
+	// A surviving runner re-registering after a daemon restart lands here
+	// via discovery.Register → Upsert, with no LastActivityAt (runner /meta
+	// never carries it).
+	sessions.Upsert(store.Session{ID: "sess-abc", Adapter: "pi", Alive: true})
+
+	got, ok := sessions.Get("sess-abc")
+	if !ok {
+		t.Fatal("session missing after upsert")
+	}
+	if got.LastActivityAt != want.UTC().Format(time.RFC3339) {
+		t.Fatalf("rehydrated stamp = %q, want scrollback mtime %q",
+			got.LastActivityAt, want.UTC().Format(time.RFC3339))
+	}
+}
+
 func TestActivitySeedFor_CapsFutureMtimeAtNow(t *testing.T) {
 	dir := t.TempDir()
 	conv := filepath.Join(dir, "conv.jsonl")

--- a/services/gmuxd/cmd/gmuxd/activityseed_test.go
+++ b/services/gmuxd/cmd/gmuxd/activityseed_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gmuxapp/gmux/packages/scrollback"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/store"
+)
+
+func writeFileWithMtime(t *testing.T, path string, mt time.Time) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(path, mt, mt); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestActivitySeedFor_ConversationFileMtime(t *testing.T) {
+	dir := t.TempDir()
+	conv := filepath.Join(dir, "conv.jsonl")
+	want := time.Now().Add(-90 * time.Minute).Truncate(time.Second)
+	writeFileWithMtime(t, conv, want)
+
+	got := activitySeedFor(store.Session{ID: "sess-abc", ConversationFile: conv}, nil)
+	if got != want.UTC().Format(time.RFC3339) {
+		t.Fatalf("seed = %q, want %q", got, want.UTC().Format(time.RFC3339))
+	}
+}
+
+func TestActivitySeedFor_ScrollbackFallback(t *testing.T) {
+	root := t.TempDir()
+	sessionDir := func(id string) string { return filepath.Join(root, id) }
+	want := time.Now().Add(-30 * time.Minute).Truncate(time.Second)
+	writeFileWithMtime(t, filepath.Join(sessionDir("sess-abc"), scrollback.ActiveName), want)
+
+	// No conversation file: falls back to scrollback tee mtime.
+	got := activitySeedFor(store.Session{ID: "sess-abc"}, sessionDir)
+	if got != want.UTC().Format(time.RFC3339) {
+		t.Fatalf("seed = %q, want %q", got, want.UTC().Format(time.RFC3339))
+	}
+}
+
+func TestActivitySeedFor_NewestWins(t *testing.T) {
+	root := t.TempDir()
+	sessionDir := func(id string) string { return filepath.Join(root, id) }
+	conv := filepath.Join(root, "conv.jsonl")
+	older := time.Now().Add(-2 * time.Hour).Truncate(time.Second)
+	newer := time.Now().Add(-10 * time.Minute).Truncate(time.Second)
+	writeFileWithMtime(t, conv, older)
+	writeFileWithMtime(t, filepath.Join(sessionDir("sess-abc"), scrollback.ActiveName), newer)
+
+	got := activitySeedFor(store.Session{ID: "sess-abc", ConversationFile: conv}, sessionDir)
+	if got != newer.UTC().Format(time.RFC3339) {
+		t.Fatalf("seed = %q, want newer %q", got, newer.UTC().Format(time.RFC3339))
+	}
+}
+
+func TestActivitySeedFor_NoFilesReturnsEmpty(t *testing.T) {
+	root := t.TempDir()
+	sessionDir := func(id string) string { return filepath.Join(root, id) }
+	got := activitySeedFor(store.Session{ID: "sess-missing", ConversationFile: "/nope/nope.jsonl"}, sessionDir)
+	if got != "" {
+		t.Fatalf("expected empty seed when no files exist, got %q", got)
+	}
+}
+
+func TestActivitySeedFor_CapsFutureMtimeAtNow(t *testing.T) {
+	dir := t.TempDir()
+	conv := filepath.Join(dir, "conv.jsonl")
+	writeFileWithMtime(t, conv, time.Now().Add(48*time.Hour))
+
+	got := activitySeedFor(store.Session{ID: "sess-abc", ConversationFile: conv}, nil)
+	parsed, err := time.Parse(time.RFC3339, got)
+	if err != nil {
+		t.Fatalf("unparseable seed %q: %v", got, err)
+	}
+	if parsed.After(time.Now().Add(time.Minute)) {
+		t.Fatalf("future mtime not capped at now: %q", got)
+	}
+}

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -518,6 +518,14 @@ func serve(stderr io.Writer) int {
 	// Resume merge / slug takeover drop the corresponding directory.
 	// See sessionmeta package doc for the full lifecycle.
 	metaStore := sessionmeta.New(sessionmeta.DefaultDir(), sessionmeta.WithRetention(sessionmeta.DefaultRetention()))
+	// Reseed last_activity_at from durable file mtimes when a session is
+	// (re-)registered without a stamp — the alive-across-restart case, where
+	// the in-memory value was never persisted. Installed before Sweep so it
+	// applies to every rehydrate path; dead sessions restored with a
+	// persisted stamp are left untouched (the store gates the seed on empty).
+	sessions.SetActivitySeed(func(sess store.Session) string {
+		return activitySeedFor(sess, metaStore.SessionDir)
+	})
 	// persistedKeys records the id and slug of every session sessionmeta
 	// holds on disk at startup (the post-retention sweep survivors). The
 	// startup CleanupSessions unions this with the live store so a project

--- a/services/gmuxd/internal/store/store.go
+++ b/services/gmuxd/internal/store/store.go
@@ -311,6 +311,17 @@ func (s *Store) UpsertRemote(sess Session) {
 func (s *Store) upsertCommon(sess Session, bumpLocally bool) {
 	sess.Cwd = paths.CanonicalizePath(sess.Cwd)
 	sess.WorkspaceRoot = paths.CanonicalizePath(sess.WorkspaceRoot)
+	// Compute the activity seed BEFORE taking the lock. The hook stats
+	// an adapter-supplied path that may live on a remote/FUSE filesystem;
+	// a hung stat under s.mu would stall the whole store (all reads, the
+	// SSE snapshot fan-out), not just this upsert. It's only relevant when
+	// the incoming stamp is empty (the rehydrate/fresh case), and it's
+	// applied under the lock only if the stamp is still empty after
+	// carry-forward — so it stays a pure floor.
+	var seed string
+	if bumpLocally && sess.LastActivityAt == "" && s.activitySeed != nil {
+		seed = s.activitySeed(sess)
+	}
 	s.mu.Lock()
 	prev, hadPrev := s.sessions[sess.ID]
 	if bumpLocally {
@@ -330,10 +341,8 @@ func (s *Store) upsertCommon(sess Session, bumpLocally bool) {
 		// value nor a persisted one exists. Gated on empty so it acts
 		// purely as a floor and never clobbers a newer value; and only
 		// on locally-owned sessions (peers carry the owner's stamp).
-		if sess.LastActivityAt == "" && s.activitySeed != nil {
-			if seed := s.activitySeed(sess); seed != "" {
-				sess.LastActivityAt = seed
-			}
+		if sess.LastActivityAt == "" && seed != "" {
+			sess.LastActivityAt = seed
 		}
 	}
 	removed, skip, unchanged := s.commitLocked(prev, hadPrev, &sess)

--- a/services/gmuxd/internal/store/store.go
+++ b/services/gmuxd/internal/store/store.go
@@ -192,6 +192,12 @@ type Store struct {
 	sessions       map[string]Session
 	subscribers    map[*subscriber]struct{}
 	commandTitlers map[string]func([]string) string
+	// activitySeed, when set, supplies a durable last-activity floor
+	// (RFC3339) for a session that arrives with no LastActivityAt —
+	// the rehydrate/re-register case after a daemon restart, where the
+	// in-memory stamp was never persisted. Returns "" when no seed is
+	// available. See SetActivitySeed.
+	activitySeed func(Session) string
 }
 
 func New() *Store {
@@ -206,6 +212,19 @@ func New() *Store {
 // shell title is set (e.g. "codex" instead of "codex resume <id>").
 func (s *Store) SetCommandTitlers(titlers map[string]func([]string) string) {
 	s.commandTitlers = titlers
+}
+
+// SetActivitySeed installs a hook that reseeds LastActivityAt from a
+// durable on-disk activity proxy (conversation-file / scrollback mtime)
+// when a locally-owned session is upserted with an empty stamp. This
+// recovers "last activity" across a daemon restart: an alive session's
+// LastActivityAt is never persisted, so on re-register it would
+// otherwise reset to (effectively) creation time. The hook is applied
+// only as a seed/floor — a session that already carries a stamp (a live
+// value, or a persisted one restored from sessionmeta) is never
+// overwritten. seed may return "" to decline.
+func (s *Store) SetActivitySeed(seed func(Session) string) {
+	s.activitySeed = seed
 }
 
 func (s *Store) List() []Session {
@@ -305,6 +324,16 @@ func (s *Store) upsertCommon(sess Session, bumpLocally bool) {
 			// a routine title/cwd refresh would silently zero out
 			// the field and drop the session from Recent.
 			sess.LastActivityAt = prev.LastActivityAt
+		}
+		// Reseed from a durable on-disk proxy when we still have no
+		// stamp — the alive-across-restart case, where neither a live
+		// value nor a persisted one exists. Gated on empty so it acts
+		// purely as a floor and never clobbers a newer value; and only
+		// on locally-owned sessions (peers carry the owner's stamp).
+		if sess.LastActivityAt == "" && s.activitySeed != nil {
+			if seed := s.activitySeed(sess); seed != "" {
+				sess.LastActivityAt = seed
+			}
 		}
 	}
 	removed, skip, unchanged := s.commitLocked(prev, hadPrev, &sess)

--- a/services/gmuxd/internal/store/store_test.go
+++ b/services/gmuxd/internal/store/store_test.go
@@ -1409,6 +1409,49 @@ func TestLastActivityAt_NewSessionDoesNotBump(t *testing.T) {
 	}
 }
 
+// TestActivitySeed_ReseedsEmptyStamp pins the restart-recovery fix: a
+// session upserted with no LastActivityAt (the alive-across-restart
+// re-register case) is seeded from the activitySeed hook. This is the
+// regression — without the hook the stamp stays empty and the UI falls
+// back to created_at ("3 days ago").
+func TestActivitySeed_ReseedsEmptyStamp(t *testing.T) {
+	seed := "2026-01-02T03:04:05Z"
+	s := New()
+	s.SetActivitySeed(func(Session) string { return seed })
+	s.Upsert(Session{ID: "s1", Adapter: "pi", Alive: true})
+	got, _ := s.Get("s1")
+	if got.LastActivityAt != seed {
+		t.Fatalf("expected reseed to %q, got %q", seed, got.LastActivityAt)
+	}
+}
+
+// TestActivitySeed_DoesNotOverwriteExistingStamp pins that the seed is
+// a floor, not an override: a session that already carries a stamp (a
+// live value, or one restored from sessionmeta) keeps it.
+func TestActivitySeed_DoesNotOverwriteExistingStamp(t *testing.T) {
+	existing := "2026-05-05T05:05:05Z"
+	s := New()
+	s.SetActivitySeed(func(Session) string { return "2020-01-01T00:00:00Z" })
+	s.Upsert(Session{ID: "s1", Adapter: "pi", Alive: true, LastActivityAt: existing})
+	got, _ := s.Get("s1")
+	if got.LastActivityAt != existing {
+		t.Fatalf("expected existing stamp %q preserved, got %q", existing, got.LastActivityAt)
+	}
+}
+
+// TestActivitySeed_SkippedForPeer pins that peer sessions (UpsertRemote)
+// are not reseeded: the owning daemon stamps its own, and the mtime
+// source lives on the owning host.
+func TestActivitySeed_SkippedForPeer(t *testing.T) {
+	s := New()
+	s.SetActivitySeed(func(Session) string { return "2026-01-02T03:04:05Z" })
+	s.UpsertRemote(Session{ID: "s1", Adapter: "pi", Alive: true, Peer: "host2"})
+	got, _ := s.Get("s1")
+	if got.LastActivityAt != "" {
+		t.Fatalf("peer session should not be reseeded, got %q", got.LastActivityAt)
+	}
+}
+
 // TestLastActivityAt_BumpOnTransitions pins the exact set of state
 // transitions that bump: exited, unread on, working on, error on.
 // Each subtest starts from an alive-and-idle baseline and applies


### PR DESCRIPTION
## Problem

When the daemon restarts and re-adopts a **surviving** runner, the session's `last_activity_at` is lost and the UI falls back to `created_at` → "3 days ago".

Root cause: an **alive** session's `LastActivityAt` is never persisted — only *dead* sessions land in sessionmeta. On restart the alive session isn't in the sweep, so `discovery.Register` takes the fresh-upsert path and stores it with an empty stamp (`/meta` doesn't carry `last_activity_at`, and a brand-new session doesn't bump). Dead sessions were already fine (their real stamp is persisted and swept back).

## Fix

Seed `LastActivityAt` from the newest durable on-disk activity proxy whenever a locally-owned session is upserted **without** a stamp:

1. **`Session.ConversationFile` mtime** (primary) — the conversation file is appended on every message, so its mtime is an accurate, restart-surviving proxy. The path is adapter-supplied (agent hook, ADR 0011); the daemon only stats it, so there's **no adapter-specific reseed logic** (resolves the adapter-vs-generic fork).
2. **scrollback tee mtime** (generic fallback) — every session has one, incl. plain shells.

Applied only as a **floor** for empty stamps (never clobbers a live or sessionmeta-restored value), capped at `now` (clock-skew defense), and skipped for peer payloads (owning daemon stamps its own).

## Notes

- Does **not** build on #390 (`BumpActivity`) — that PR is closed/unmerged ("misdiagnosed"). This targets the real restart data-loss.
- No wire/web change: `conversation_file` and `last_activity_at` already exist.

## Tests

- store: reseed-empty (regression), floor-not-override, peer-skipped.
- seed helper: conv-file mtime, scrollback fallback, newest-wins, no-files→empty, future-mtime capped.
- `go build/vet/test ./...` in `services/gmuxd` all green.