### PR TITLE
fix(runner): drop UUID slug in the pre-title window; clear stale slugs on re-bind

### DIFF
--- a/apps/gmux-web/src/routing.test.ts
+++ b/apps/gmux-web/src/routing.test.ts
@@ -75,9 +75,12 @@ describe('sessionPath', () => {
       .toBe('/gmux/pi/fix-auth')
   })
 
-  it('falls back to ID prefix when slug missing', () => {
-    expect(sessionPath('gmux', { adapter: 'pi', id: 'abcdef12-3456-7890' }))
-      .toBe('/gmux/pi/abcdef12')
+  it('falls back to the full session id when slug missing', () => {
+    // Untitled session: no slug yet. Use the whole `sess-<hex>` id, not a
+    // truncation — `slice(0, 8)` would leave only 3 hex of entropy and
+    // collide across untitled sessions (resolveSessionFromPath prefix-matches).
+    expect(sessionPath('gmux', { adapter: 'pi', id: 'sess-a1b2c3d4' }))
+      .toBe('/gmux/pi/sess-a1b2c3d4')
   })
 
   it('includes @peer for remote sessions', () => {

--- a/apps/gmux-web/src/routing.ts
+++ b/apps/gmux-web/src/routing.ts
@@ -73,7 +73,13 @@ export function sessionPath(
   session: { adapter: string; slug?: string; id: string; peer?: string },
   projectPeer?: string,
 ): string {
-  const slug = session.slug || session.id.slice(0, 8)
+  // Fallback for an untitled session (no slug yet): the full gmux session
+  // id. It's already short and URL-safe (`sess-<8 hex>`) and unique, unlike
+  // a truncation — `id.slice(0, 8)` would keep only `sess-` + 3 hex (~4096
+  // values), and resolveSessionFromPath's prefix match returns the first
+  // hit, so two untitled sessions could collide onto one URL. Resolution
+  // still works: `s.id.startsWith(slug)` matches the full id exactly.
+  const slug = session.slug || session.id
   const ownerPrefix = projectPeer ? `/@${projectPeer}` : ''
   // Mid-path session-host segment is needed only when the session
   // lives on a different host than the project owner.

--- a/cli/gmux/internal/agentext/pi-ext.mjs
+++ b/cli/gmux/internal/agentext/pi-ext.mjs
@@ -62,12 +62,12 @@ export default function (pi) {
     }
     if (!file) return; // nothing to attribute yet
     const title = name || firstUserTitle;
-    // Report the title as the slug source too. pi's session id is a UUID that
-    // slugifies into an unreadable URL; without an explicit slug the runner
-    // falls back to Slugify(id) and session URLs become UUIDs. The runner
-    // slugifies whatever we send, so the raw title is fine here. Mirrors the
-    // codex and claude hooks, which send a title-derived slug for the same
-    // reason.
+    // Report the title as the slug source too (runner slugifies it). Until the
+    // session has a title we send no slug: pi's session id is a UUID, and the
+    // runner deliberately won't synthesize a slug from it — it leaves the slug
+    // empty so the web layer falls back to a short id.slice(0,8). Mirrors the
+    // codex and claude hooks, which also send a title-derived slug only once
+    // they have a title.
     post(sock, {
       op: "session",
       path: String(file),

--- a/cli/gmux/internal/ptyserver/extension_test.go
+++ b/cli/gmux/internal/ptyserver/extension_test.go
@@ -227,17 +227,19 @@ func TestTurnEventDrivesState(t *testing.T) {
 	}
 }
 
-// TestSessionSlugPrefersExplicitSlug pins, through the real /hook/event
-// handler, that an explicit slug in a session event wins over Slugify(id) — the
-// codex path reports a title-derived slug because its session id is a UUID that
-// slugifies badly — while a session event with only an id still slugifies the
-// id (pi's behavior, unchanged).
-func TestSessionSlugPrefersExplicitSlug(t *testing.T) {
+// TestSessionSlugFromExplicitSourceOnly pins, through the real /hook/event
+// handler, that the runner sets the slug ONLY from an explicit title-derived
+// source and never synthesizes one from the adapter session id: ev.ID is a
+// UUID for every real adapter, and slugifying it produces an unreadable
+// full-UUID URL that also defeats the web's short id.slice(0,8) fallback
+// (the pre-title-window regression behind #360's follow-up). With no slug
+// source the runner leaves Slug empty for the web layer to fill.
+func TestSessionSlugFromExplicitSourceOnly(t *testing.T) {
 	node, err := exec.LookPath("node")
 	if err != nil {
 		t.Skip("node not available")
 	}
-	check := func(name, body, wantSlug string) {
+	newSrv := func(t *testing.T) (*Server, *session.State, string) {
 		t.Helper()
 		dir := t.TempDir()
 		sockPath := filepath.Join(dir, "test.sock")
@@ -251,25 +253,73 @@ func TestSessionSlugPrefersExplicitSlug(t *testing.T) {
 			State:      st,
 		})
 		if err != nil {
-			t.Fatalf("%s: new server: %v", name, err)
+			t.Fatalf("new server: %v", err)
 		}
-		defer srv.Shutdown()
-		postSessionEvent(t, sockPath, body)
+		t.Cleanup(srv.Shutdown)
+		return srv, st, sockPath
+	}
+
+	// A real title-derived slug is slugified and recorded.
+	t.Run("explicit-slug", func(t *testing.T) {
+		_, st, sockPath := newSrv(t)
+		postSessionEvent(t, sockPath,
+			`{"op":"session","path":"/x.jsonl","id":"019cfb54-dead-beef","slug":"fix the auth bug"}`)
 		deadline := time.After(2 * time.Second)
-		for st.SlugSnapshot() != wantSlug {
+		for st.SlugSnapshot() != "fix-the-auth-bug" {
 			select {
 			case <-deadline:
-				t.Fatalf("%s: slug = %q, want %q", name, st.SlugSnapshot(), wantSlug)
+				t.Fatalf("slug = %q, want %q", st.SlugSnapshot(), "fix-the-auth-bug")
 			case <-time.After(20 * time.Millisecond):
 			}
 		}
-	}
-	check("explicit-slug",
-		`{"op":"session","path":"/x.jsonl","id":"019cfb54-dead-beef","slug":"fix the auth bug"}`,
-		"fix-the-auth-bug")
-	check("id-fallback",
-		`{"op":"session","path":"/y.jsonl","id":"my-chat"}`,
-		"my-chat")
+	})
+
+	// A pre-title bind (only an id, no slug) must leave the slug EMPTY so the
+	// web fallback applies. Poll for a settle window to catch a synthesized
+	// slug that arrives slightly after the POST returns.
+	t.Run("no-slug-source-stays-empty", func(t *testing.T) {
+		_, st, sockPath := newSrv(t)
+		postSessionEvent(t, sockPath,
+			`{"op":"session","path":"/y.jsonl","id":"019f2c75-5279-7012-b054-ce2a71441a4e"}`)
+		deadline := time.After(500 * time.Millisecond)
+		for {
+			if got := st.SlugSnapshot(); got != "" {
+				t.Fatalf("slug = %q, want empty (no title source → web owns the fallback)", got)
+			}
+			select {
+			case <-deadline:
+				return
+			case <-time.After(20 * time.Millisecond):
+			}
+		}
+	})
+
+	// A bind is authoritative: switching from a titled conversation to a
+	// fresh untitled one (pi re-binds through the same runner on
+	// new/switch/resume/fork) must CLEAR the old slug, not keep serving it.
+	t.Run("no-slug-source-clears-prior-slug", func(t *testing.T) {
+		_, st, sockPath := newSrv(t)
+		postSessionEvent(t, sockPath,
+			`{"op":"session","path":"/a.jsonl","id":"id-a","slug":"fix the auth bug"}`)
+		deadline := time.After(2 * time.Second)
+		for st.SlugSnapshot() != "fix-the-auth-bug" {
+			select {
+			case <-deadline:
+				t.Fatalf("setup: slug = %q, want %q", st.SlugSnapshot(), "fix-the-auth-bug")
+			case <-time.After(20 * time.Millisecond):
+			}
+		}
+		postSessionEvent(t, sockPath,
+			`{"op":"session","path":"/b.jsonl","id":"019f2c75-5279-7012-b054-ce2a71441a4e","reason":"new"}`)
+		deadline = time.After(2 * time.Second)
+		for st.SlugSnapshot() != "" {
+			select {
+			case <-deadline:
+				t.Fatalf("slug = %q, want cleared after untitled re-bind", st.SlugSnapshot())
+			case <-time.After(20 * time.Millisecond):
+			}
+		}
+	})
 }
 
 // TestApplyTurnEnd pins the outcome→sidebar-state policy directly (no node).

--- a/cli/gmux/internal/ptyserver/extension_test.go
+++ b/cli/gmux/internal/ptyserver/extension_test.go
@@ -107,6 +107,69 @@ func TestReconnectReplaysConversationRef(t *testing.T) {
 	}
 	t.Error("reconnecting subscriber did not receive replayed conversation_file")
 }
+
+// TestReconnectReplaysSlug pins that a (re)connecting /events subscriber
+// re-learns the authoritative slug — so a slug set/rename/clear emitted while
+// the daemon was down is not lost (SetSlug dedups, so it never re-emits on its
+// own). Without the replay the store keeps a stale slug across a daemon
+// restart.
+func TestReconnectReplaysSlug(t *testing.T) {
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("node not available")
+	}
+	dir := t.TempDir()
+	sockPath := filepath.Join(dir, "test.sock")
+	sessFile := filepath.Join(dir, "2026-06-19_sess-slugreplay.jsonl")
+
+	st := session.New(session.Config{ID: "s1", Adapter: "pi", SocketPath: sockPath})
+	srv, err := New(Config{
+		Command:    []string{node, "-e", "setTimeout(()=>{},3000)"},
+		Cwd:        dir,
+		Listener:   mustBindSocket(t, sockPath),
+		SocketPath: sockPath,
+		Adapter:    adapters.NewPi(),
+		State:      st,
+	})
+	if err != nil {
+		t.Fatalf("new server: %v", err)
+	}
+	defer srv.Shutdown()
+
+	// Bind a titled conversation, then wait for the slug to land.
+	postSessionEvent(t, sockPath,
+		`{"op":"session","path":`+strconv.Quote(sessFile)+`,"id":"id-x","slug":"fix the auth bug"}`)
+	deadline := time.After(5 * time.Second)
+	for st.SlugSnapshot() != "fix-the-auth-bug" {
+		select {
+		case <-deadline:
+			t.Fatalf("runner never recorded slug; got %q", st.SlugSnapshot())
+		case <-time.After(20 * time.Millisecond):
+		}
+	}
+
+	client := &http.Client{Transport: &http.Transport{
+		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			return net.Dial("unix", sockPath)
+		},
+	}}
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+	defer cancel()
+	req, _ := http.NewRequestWithContext(ctx, "GET", "http://unix/events", nil)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("connect /events: %v", err)
+	}
+	defer resp.Body.Close()
+
+	sc := bufio.NewScanner(resp.Body)
+	for sc.Scan() {
+		if strings.Contains(sc.Text(), "fix-the-auth-bug") {
+			return // success: slug replayed on subscribe
+		}
+	}
+	t.Error("reconnecting subscriber did not receive replayed slug")
+}
 func TestSessionEventIsAuthoritative(t *testing.T) {
 	node, err := exec.LookPath("node")
 	if err != nil {
@@ -231,8 +294,8 @@ func TestTurnEventDrivesState(t *testing.T) {
 // handler, that the runner sets the slug ONLY from an explicit title-derived
 // source and never synthesizes one from the adapter session id: ev.ID is a
 // UUID for every real adapter, and slugifying it produces an unreadable
-// full-UUID URL that also defeats the web's short id.slice(0,8) fallback
-// (the pre-title-window regression behind #360's follow-up). With no slug
+// full-UUID URL that also defeats the web's session-id fallback (the
+// pre-title-window regression behind #360's follow-up). With no slug
 // source the runner leaves Slug empty for the web layer to fill.
 func TestSessionSlugFromExplicitSourceOnly(t *testing.T) {
 	node, err := exec.LookPath("node")
@@ -285,6 +348,72 @@ func TestSessionSlugFromExplicitSourceOnly(t *testing.T) {
 		for {
 			if got := st.SlugSnapshot(); got != "" {
 				t.Fatalf("slug = %q, want empty (no title source → web owns the fallback)", got)
+			}
+			select {
+			case <-deadline:
+				return
+			case <-time.After(20 * time.Millisecond):
+			}
+		}
+	})
+
+	// An untitled re-bind must EMIT the empty-slug clear even when the runner
+	// state is already empty (fresh runner after a daemon re-register that
+	// preserved a stale slug). A dedup'd SetSlug would emit nothing and leave
+	// the daemon stale; BindSlug on the rebind path fixes it.
+	t.Run("untitled-rebind-emits-clear-even-when-state-empty", func(t *testing.T) {
+		_, st, sockPath := newSrv(t)
+		ch := st.Subscribe()
+		defer st.Unsubscribe(ch)
+		// First bind, untitled: runner state is already "" here.
+		postSessionEvent(t, sockPath,
+			`{"op":"session","path":"/fresh.jsonl","id":"019f2c75-5279-7012-b054-ce2a71441a4e"}`)
+		deadline := time.After(2 * time.Second)
+		for {
+			select {
+			case <-deadline:
+				t.Fatal("no empty-slug meta event emitted on untitled bind")
+			case e := <-ch:
+				if e.Type != "meta" {
+					continue
+				}
+				m, ok := e.Data.(map[string]string)
+				if !ok {
+					continue
+				}
+				if v, present := m["slug"]; present {
+					if v != "" {
+						t.Fatalf("slug event = %q, want empty clear", v)
+					}
+					return // success
+				}
+			}
+		}
+	})
+
+	// A same-conversation refresh (claude/codex re-send the bind on every turn
+	// end) with a transiently empty slug source must NOT clear an established
+	// slug — that would flap the URL on a parse hiccup. Re-bind is detected by
+	// a changed conversation path, so the same path must preserve the slug.
+	t.Run("same-conversation-refresh-keeps-slug", func(t *testing.T) {
+		_, st, sockPath := newSrv(t)
+		postSessionEvent(t, sockPath,
+			`{"op":"session","path":"/c.jsonl","id":"id-c","slug":"fix the auth bug"}`)
+		deadline := time.After(2 * time.Second)
+		for st.SlugSnapshot() != "fix-the-auth-bug" {
+			select {
+			case <-deadline:
+				t.Fatalf("setup: slug = %q, want %q", st.SlugSnapshot(), "fix-the-auth-bug")
+			case <-time.After(20 * time.Millisecond):
+			}
+		}
+		// Same path, no slug source (transient title-derivation failure).
+		postSessionEvent(t, sockPath,
+			`{"op":"session","path":"/c.jsonl","id":"id-c","reason":"activity"}`)
+		deadline = time.After(500 * time.Millisecond)
+		for {
+			if got := st.SlugSnapshot(); got != "fix-the-auth-bug" {
+				t.Fatalf("slug = %q, want %q preserved on same-conversation refresh", got, "fix-the-auth-bug")
 			}
 			select {
 			case <-deadline:

--- a/cli/gmux/internal/ptyserver/ptyserver.go
+++ b/cli/gmux/internal/ptyserver/ptyserver.go
@@ -586,8 +586,8 @@ type hookEvent struct {
 	Path string `json:"path"`
 	Pid  int    `json:"pid"`
 
-	ID      string `json:"id,omitempty"`
-	Slug    string `json:"slug,omitempty"` // slug source (runner slugifies); preferred over Slugify(ID)
+	ID      string `json:"id,omitempty"`   // adapter session id; informational (the runner keys on the gmux id)
+	Slug    string `json:"slug,omitempty"` // slug source (runner slugifies); empty until the session has a title
 	Name    string `json:"name,omitempty"`
 	Reason  string `json:"reason,omitempty"`
 	Title   string `json:"title,omitempty"`
@@ -618,13 +618,20 @@ func (s *Server) handleHookEvent(w http.ResponseWriter, r *http.Request) {
 		if ev.Name != "" {
 			s.state.SetAdapterTitle(ev.Name)
 		}
-		// Slug source, in order of preference: an explicit slug the agent
-		// reports (codex and pi session ids are UUIDs that slugify badly, so
-		// their hooks send a title-derived slug), else the identity to slugify.
+		// A session bind is authoritative for the slug, so set it on every bind
+		// — including clearing it when there's no title-derived source. We do
+		// NOT synthesize one from ev.ID: it's the adapter's session id, which
+		// for every real adapter is a UUID that slugifies into an unreadable
+		// URL. Leaving the slug empty lets the web layer own the fallback — a
+		// short, stable id.slice(0,8) off the *gmux* session id (routing.ts
+		// sessionPath), which the runner doesn't know. Clearing (not just
+		// skipping) matters because pi re-binds through the same runner on
+		// switch/new/resume/fork: switching from a titled conversation to a
+		// fresh untitled one must drop the old slug, not keep serving it.
 		if ev.Slug != "" {
 			s.state.SetSlug(adapter.Slugify(ev.Slug))
-		} else if ev.ID != "" {
-			s.state.SetSlug(adapter.Slugify(ev.ID))
+		} else {
+			s.state.SetSlug("")
 		}
 	case "turn":
 		// Agent-loop transition. The extension reports phase + outcome; the

--- a/cli/gmux/internal/ptyserver/ptyserver.go
+++ b/cli/gmux/internal/ptyserver/ptyserver.go
@@ -612,26 +612,45 @@ func (s *Server) handleHookEvent(w http.ResponseWriter, r *http.Request) {
 	case "session":
 		// Authoritative bind (e.g. pi's session_start): the file the
 		// agent holds, named and slugged.
+		// Snapshot the currently-bound conversation before SetConversationRef
+		// overwrites it, so the slug logic below can tell a genuine re-bind
+		// (different conversation) from a same-conversation refresh.
+		priorRef := s.state.ConversationRefSnapshot()
 		if ev.Path != "" {
 			s.state.SetConversationRef(ev.Path)
 		}
 		if ev.Name != "" {
 			s.state.SetAdapterTitle(ev.Name)
 		}
-		// A session bind is authoritative for the slug, so set it on every bind
-		// — including clearing it when there's no title-derived source. We do
-		// NOT synthesize one from ev.ID: it's the adapter's session id, which
-		// for every real adapter is a UUID that slugifies into an unreadable
-		// URL. Leaving the slug empty lets the web layer own the fallback — a
-		// short, stable id.slice(0,8) off the *gmux* session id (routing.ts
-		// sessionPath), which the runner doesn't know. Clearing (not just
-		// skipping) matters because pi re-binds through the same runner on
-		// switch/new/resume/fork: switching from a titled conversation to a
-		// fresh untitled one must drop the old slug, not keep serving it.
-		if ev.Slug != "" {
-			s.state.SetSlug(adapter.Slugify(ev.Slug))
-		} else {
-			s.state.SetSlug("")
+		// The slug is the session's URL identity. Prefer a real title-derived
+		// source the agent reports; we NEVER synthesize one from ev.ID (the
+		// adapter's session id, a UUID for every real adapter that slugifies
+		// into an unreadable URL). With no source, leave the slug empty so the
+		// web owns the fallback — the *gmux* session id itself (routing.ts
+		// sessionPath), which the runner doesn't know.
+		//
+		// Clear only on a genuine re-bind to a *different* conversation (pi
+		// re-binds through the same runner on switch/new/resume/fork): switching
+		// from a titled conversation to a fresh untitled one must drop the old
+		// slug. A same-conversation refresh (claude/codex re-send the bind on
+		// every turn end) with a transiently empty source must NOT clear an
+		// established slug — that would flap the URL on a parse hiccup.
+		//
+		// A genuine re-bind uses BindSlug (always emits): after a re-register
+		// the daemon may hold a stale slug that diverges from this fresh runner
+		// state, so a dedup'd SetSlug could leave the store stale. A refresh
+		// uses SetSlug (dedup) — runner and store agree there.
+		rebind := ev.Path != "" && ev.Path != priorRef
+		switch {
+		case ev.Slug != "":
+			slug := adapter.Slugify(ev.Slug)
+			if rebind {
+				s.state.BindSlug(slug)
+			} else {
+				s.state.SetSlug(slug)
+			}
+		case rebind:
+			s.state.BindSlug("")
 		}
 	case "turn":
 		// Agent-loop transition. The extension reports phase + outcome; the
@@ -794,6 +813,17 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 	if file := s.state.ConversationRefSnapshot(); file != "" {
 		if data, err := json.Marshal(map[string]string{"path": file}); err == nil {
 			fmt.Fprintf(w, "event: conversation_file\ndata: %s\n\n", data)
+		}
+		// Replay the slug too (the runner owns it, ADR 0011). Once a
+		// conversation is bound the slug snapshot is authoritative for it,
+		// including an *empty* slug (untitled) — which the daemon honors as an
+		// explicit clear. Without this, a slug set/rename/clear emitted while
+		// the daemon was down is never re-learned (SetSlug dedups, so it won't
+		// re-emit) and the store keeps a stale value. Gated on a bound
+		// conversation so a just-started runner (no bind yet) can't transiently
+		// clear a good persisted slug before its session hook fires.
+		if data, err := json.Marshal(map[string]string{"slug": s.state.SlugSnapshot()}); err == nil {
+			fmt.Fprintf(w, "event: meta\ndata: %s\n\n", data)
 		}
 	}
 

--- a/cli/gmux/internal/session/state.go
+++ b/cli/gmux/internal/session/state.go
@@ -221,13 +221,28 @@ func (s *State) SetShellTitle(title string) {
 	s.emitMetaLocked()
 }
 
-// SetSlug sets the URL-safe session identifier.
+// SetSlug sets the URL-safe session identifier, emitting a meta event only
+// when it changes. Use on same-conversation refreshes, where the runner's
+// state and the daemon's store are known to agree.
 func (s *State) SetSlug(slug string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.Slug == slug {
 		return
 	}
+	s.Slug = slug
+	s.emit(Event{Type: "meta", Data: map[string]string{"slug": slug}})
+}
+
+// BindSlug sets the slug on an authoritative session bind and ALWAYS emits,
+// even when the value is unchanged. On a re-register the daemon may have
+// preserved a stale slug that diverges from this (fresh, possibly empty)
+// runner state; a dedup'd SetSlug would then never tell the daemon to
+// converge. Re-binds (switch/new/resume/fork) are infrequent, so the extra
+// event is cheap. See handleHookEvent's session case.
+func (s *State) BindSlug(slug string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.Slug = slug
 	s.emit(Event{Type: "meta", Data: map[string]string{"slug": slug}})
 }

--- a/cli/gmux/internal/session/state_test.go
+++ b/cli/gmux/internal/session/state_test.go
@@ -178,3 +178,53 @@ func TestEmitActivityThrottles(t *testing.T) {
 		// good, throttled
 	}
 }
+
+// TestBindSlugAlwaysEmits pins the divergence-recovery contract behind the
+// runner→daemon slug sync. SetSlug dedups (no event when unchanged), which is
+// right for a same-conversation refresh where runner and daemon agree. But on
+// an authoritative re-bind after a daemon re-register — where the daemon may
+// hold a STALE slug while this fresh runner state is empty — a dedup'd clear
+// would never reach the daemon. BindSlug therefore always emits, even when the
+// value is unchanged, so the daemon converges.
+func TestBindSlugAlwaysEmits(t *testing.T) {
+	s := New(Config{ID: "sess-x", Adapter: "pi", SocketPath: "/tmp/x.sock"})
+	ch := s.Subscribe()
+	defer s.Unsubscribe(ch)
+
+	slugEvents := func() []string {
+		var got []string
+		for {
+			select {
+			case e := <-ch:
+				if e.Type != "meta" {
+					continue
+				}
+				if m, ok := e.Data.(map[string]string); ok {
+					if v, present := m["slug"]; present {
+						got = append(got, v)
+					}
+				}
+			default:
+				return got
+			}
+		}
+	}
+
+	// SetSlug on an unchanged (empty→empty) value must NOT emit.
+	s.SetSlug("")
+	if got := slugEvents(); len(got) != 0 {
+		t.Fatalf("SetSlug(unchanged) emitted %v, want nothing", got)
+	}
+
+	// BindSlug on the same unchanged empty value MUST emit — this is the
+	// re-register clear that would otherwise be lost.
+	s.BindSlug("")
+	if got := slugEvents(); len(got) != 1 || got[0] != "" {
+		t.Fatalf("BindSlug(\"\") emitted %v, want one empty-slug event", got)
+	}
+
+	// And it keeps runner state consistent.
+	if s.SlugSnapshot() != "" {
+		t.Fatalf("SlugSnapshot = %q, want empty", s.SlugSnapshot())
+	}
+}

--- a/docs/adr/0013-codex-authoritative-state-via-hooks.md
+++ b/docs/adr/0013-codex-authoritative-state-via-hooks.md
@@ -52,8 +52,13 @@ protocol unchanged. Concretely:
    `session_id` is a UUID that slugifies into an unreadable URL. The hook parses
    the transcript's first user prompt (reusing `ParseSessionFile`) and reports a
    human title plus an explicit title-derived **`slug`** — a small, tool-neutral
-   addition to the protocol (the runner prefers an explicit `slug` over
-   `Slugify(id)`; pi is unchanged).
+   addition to the protocol.
+
+   > **Update (#360, #394):** the runner no longer synthesizes a slug from the
+   > session id at all — `Slugify(id)` produced unreadable full-UUID URLs in the
+   > pre-title window. The slug is set only from an explicit title-derived
+   > source (else left empty for the web to fall back to the short gmux session
+   > id), and pi now sends a `slug` the same way (it was *not* unchanged).
 
 4. **Trust scoped to our own hooks via injected `trusted_hash`.** A CLI-injected
    hook is non-managed and therefore `Untrusted`, which codex silently skips.

--- a/docs/runner-hook-protocol.md
+++ b/docs/runner-hook-protocol.md
@@ -44,8 +44,8 @@ One JSON object per event, discriminated by `op`. Unknown ops/values are ignored
 {
   "op":     "session",
   "path":   "/abs/path/to/conversation-file",  // required; the conversation ref (a transcript path for today's file-backed agents)
-  "id":     "session-id",                       // optional; slugified for the URL if no slug
-  "slug":   "human-title",                      // optional; slug source (runner slugifies), preferred over id
+  "id":     "session-id",                       // optional; adapter session id, informational
+  "slug":   "human-title",                      // optional; slug source (runner slugifies); omit until titled
   "name":   "human title",                      // optional; sets the adapter title
   "cwd":    "/project/dir",                      // optional; accepted, not yet applied
   "reason": "startup|new|resume|fork|activity"  // optional; informational
@@ -62,8 +62,8 @@ One JSON object per event, discriminated by `op`. Unknown ops/values are ignored
 | Field     | Op       | Meaning |
 |-----------|----------|---------|
 | `path`    | session  | The held conversation's ref — adapter-opaque above the runner (ADR 0022); today's file-backed agents report the transcript's absolute path. |
-| `id`      | session  | Session identity; slugified into the URL when no `slug`. |
-| `slug`    | session  | Slug source, slugified by the runner; preferred over `id` (codex/pi session ids are UUIDs that slugify badly). |
+| `id`      | session  | Adapter's session id. Informational — the runner keys on the gmux session id, and never derives a slug from this (it's a UUID for real adapters). |
+| `slug`    | session  | Slug source, slugified by the runner. Send only once the session has a title; while omitted the runner leaves the slug empty and the web layer falls back to a short `id.slice(0,8)` of the gmux session id. |
 | `name`    | session  | Display title at bind time. |
 | `cwd`     | session  | Project dir. Accepted for forward-compat but not applied — the runner knows the launch cwd. |
 | `reason`  | session  | Why the bind happened; informational. |

--- a/docs/runner-hook-protocol.md
+++ b/docs/runner-hook-protocol.md
@@ -63,7 +63,7 @@ One JSON object per event, discriminated by `op`. Unknown ops/values are ignored
 |-----------|----------|---------|
 | `path`    | session  | The held conversation's ref — adapter-opaque above the runner (ADR 0022); today's file-backed agents report the transcript's absolute path. |
 | `id`      | session  | Adapter's session id. Informational — the runner keys on the gmux session id, and never derives a slug from this (it's a UUID for real adapters). |
-| `slug`    | session  | Slug source, slugified by the runner. Send only once the session has a title; while omitted the runner leaves the slug empty and the web layer falls back to a short `id.slice(0,8)` of the gmux session id. |
+| `slug`    | session  | Slug source, slugified by the runner. Send only once the session has a title; while omitted the runner leaves the slug empty and the web layer falls back to the gmux session id itself for the URL. |
 | `name`    | session  | Display title at bind time. |
 | `cwd`     | session  | Project dir. Accepted for forward-compat but not applied — the runner knows the launch cwd. |
 | `reason`  | session  | Why the bind happened; informational. |

--- a/services/gmuxd/internal/conversations/index.go
+++ b/services/gmuxd/internal/conversations/index.go
@@ -249,7 +249,8 @@ func (idx *Index) LookupBySlug(slug string) (Info, bool) {
 
 // FindByPrefix returns conversations whose slug starts with the given
 // prefix, within an adapter. Used for URL resolution when the frontend
-// provides a partial slug (e.g. from session.id.slice(0, 8)).
+// provides a partial slug (e.g. an abbreviated or legacy session-id
+// prefix); an exact/full id is just the degenerate prefix case.
 func (idx *Index) FindByPrefix(adapterName, prefix string) (Info, bool) {
 	idx.mu.RLock()
 	defer idx.mu.RUnlock()

--- a/services/gmuxd/internal/discovery/discovery.go
+++ b/services/gmuxd/internal/discovery/discovery.go
@@ -269,9 +269,12 @@ func Register(sessions *store.Store, subs *Subscriptions, socketPath string, onD
 		// Re-registration. The runner reports fresh runtime state;
 		// the store has the historical and attribution-derived
 		// state from before the seam. Merge by overwriting only the
-		// runtime-owned fields so anything the runner doesn't know
-		// about (slug, created_at, hook-reported title / subtitle,
-		// workspace metadata) survives.
+		// runtime-owned fields so the rest (created_at, hook-reported
+		// title / subtitle, workspace metadata, and the slug) survives
+		// this handshake. The slug is runner-owned (ADR 0011) but its
+		// /register /meta snapshot may predate the session hook, so we
+		// keep the stored value here and let the /events replay converge
+		// it (handleEvents replays the authoritative slug on subscribe).
 		existing.Alive = newSess.Alive
 		existing.Pid = newSess.Pid
 		existing.SocketPath = socketPath

--- a/services/gmuxd/internal/discovery/subscribe.go
+++ b/services/gmuxd/internal/discovery/subscribe.go
@@ -252,7 +252,13 @@ func (sub *Subscriptions) handleEvent(sessionID, socketPath, eventType string, d
 					sess.Status.Error = false
 				}
 			}
-			if meta.Slug != nil && *meta.Slug != "" {
+			// A slug key is only ever present on a deliberate SetSlug (the
+			// general meta emission omits it), so honor it verbatim — including
+			// an explicit empty, which clears a stale slug when a session
+			// re-binds to an untitled conversation (web then falls back to
+			// id.slice(0,8)). A title-only meta update has meta.Slug == nil and
+			// leaves the recorded slug untouched.
+			if meta.Slug != nil {
 				sess.Slug = *meta.Slug
 			}
 		})

--- a/services/gmuxd/internal/discovery/subscribe.go
+++ b/services/gmuxd/internal/discovery/subscribe.go
@@ -255,8 +255,8 @@ func (sub *Subscriptions) handleEvent(sessionID, socketPath, eventType string, d
 			// A slug key is only ever present on a deliberate SetSlug (the
 			// general meta emission omits it), so honor it verbatim — including
 			// an explicit empty, which clears a stale slug when a session
-			// re-binds to an untitled conversation (web then falls back to
-			// id.slice(0,8)). A title-only meta update has meta.Slug == nil and
+			// re-binds to an untitled conversation (web then falls back to the
+			// gmux session id). A title-only meta update has meta.Slug == nil and
 			// leaves the recorded slug untouched.
 			if meta.Slug != nil {
 				sess.Slug = *meta.Slug

--- a/services/gmuxd/internal/discovery/subscribe_test.go
+++ b/services/gmuxd/internal/discovery/subscribe_test.go
@@ -284,7 +284,7 @@ func TestConversationFileEventEmptyPathIgnored(t *testing.T) {
 //   - slug present, non-empty → record it (the web builds URLs from it);
 //   - slug key ABSENT (a title-only meta update) → leave the slug untouched;
 //   - slug present but EMPTY → clear it (session re-bound to an untitled
-//     conversation; the web falls back to id.slice(0,8)).
+//     conversation; the web falls back to the gmux session id).
 func TestMetaEventSlugSemantics(t *testing.T) {
 	sessions := store.New()
 	sessions.Upsert(store.Session{ID: "sess-1", Alive: true})

--- a/services/gmuxd/internal/discovery/subscribe_test.go
+++ b/services/gmuxd/internal/discovery/subscribe_test.go
@@ -277,12 +277,15 @@ func TestConversationFileEventEmptyPathIgnored(t *testing.T) {
 	}
 }
 
-// TestMetaEventUpdatesSlugAndIgnoresEmpty pins the daemon half of the
-// session-URL slug chain: a runner "meta" event carrying a slug updates
-// the store (the web UI builds session URLs from it), and a later meta
-// event without a slug — the runner emits other meta fields
-// independently — must not clobber the one already recorded.
-func TestMetaEventUpdatesSlugAndIgnoresEmpty(t *testing.T) {
+// TestMetaEventSlugSemantics pins the daemon half of the session-URL slug
+// chain. The runner emits a slug key only on a deliberate SetSlug (the
+// general meta emission omits it), so the daemon distinguishes:
+//
+//   - slug present, non-empty → record it (the web builds URLs from it);
+//   - slug key ABSENT (a title-only meta update) → leave the slug untouched;
+//   - slug present but EMPTY → clear it (session re-bound to an untitled
+//     conversation; the web falls back to id.slice(0,8)).
+func TestMetaEventSlugSemantics(t *testing.T) {
 	sessions := store.New()
 	sessions.Upsert(store.Session{ID: "sess-1", Alive: true})
 	subs := NewSubscriptions(sessions)
@@ -292,13 +295,18 @@ func TestMetaEventUpdatesSlugAndIgnoresEmpty(t *testing.T) {
 		t.Fatalf("Slug = %q, want %q", got.Slug, "fix-the-login-bug")
 	}
 
-	// Unrelated meta update (title only) and an explicit empty slug: both
-	// must leave the recorded slug intact.
+	// Title-only update (no slug key): the recorded slug must survive.
 	subs.handleEvent("sess-1", "/sock", "meta", []byte(`{"adapter_title":"Fix the login bug"}`))
+	if got, _ := sessions.Get("sess-1"); got.Slug != "fix-the-login-bug" {
+		t.Errorf("Slug after title-only meta = %q, want %q preserved", got.Slug, "fix-the-login-bug")
+	}
+
+	// Explicit empty slug (re-bind to an untitled conversation): must clear,
+	// so the web falls back to the short session-id prefix.
 	subs.handleEvent("sess-1", "/sock", "meta", []byte(`{"slug":""}`))
 	got, _ := sessions.Get("sess-1")
-	if got.Slug != "fix-the-login-bug" {
-		t.Errorf("Slug after slug-less meta events = %q, want %q preserved", got.Slug, "fix-the-login-bug")
+	if got.Slug != "" {
+		t.Errorf("Slug after explicit empty = %q, want cleared", got.Slug)
 	}
 	if got.AdapterTitle != "Fix the login bug" {
 		t.Errorf("AdapterTitle = %q, want %q", got.AdapterTitle, "Fix the login bug")


### PR DESCRIPTION
## Problem

Follow-up to #360. Brand-new pi sessions — before they have a name/title — still get a **full-UUID** slug in the web UI URL:

- new: `/gmux/pi/019f2c75-5279-7012-b054-ce2a71441a4e`  ❌
- named/resumable: `/gmux/pi/driver`  ✅

#360 fixed the *has-title* case. The pre-title window was still broken.

## Root cause (general, not pi-specific)

On a pre-title bind, **all three** adapter hooks (pi, codex, claude) send the adapter session `id` but omit `slug`. The runner's `handleHookEvent` then fell back to `Slugify(ev.ID)` — the adapter's session id, a UUID for every real adapter — yielding an unreadable ~36-char slug that got **persisted** as `Session.Slug`, defeating the web's intended fallback:

```ts
// apps/gmux-web/src/routing.ts sessionPath
const slug = session.slug || session.id.slice(0, 8)  // .slice never reached — slug non-empty
```

## Fix

**A session bind is authoritative for the slug.** The runner sets it from a real title-derived source (`ev.Slug`) or **clears** it when there is none — never synthesizes from `ev.ID`. An empty slug lets the **web own the "no title yet" fallback** — a short, stable `id.slice(0,8)` of the *gmux* session id, which the runner doesn't know. Single source of truth for the fallback.

### Clearing, not just skipping (review follow-up)

Greptile caught that pi re-binds through the **same runner** on new/switch/resume/fork, so switching from a titled conversation to a fresh untitled one must **drop** the old slug rather than keep serving it. Skipping left it sticky. So:

- Runner: no-source bind now calls `SetSlug("")`.
- Daemon: `subscribe.go` honors an **explicit empty** slug (clears), while a **title-only** meta update (slug key absent) still leaves the recorded slug untouched. This is safe because the runner emits a slug key *only* on a deliberate `SetSlug` — the general meta emission (`emitMetaLocked`) never includes it.

Bonus: existing UUID-slugged sessions now recover on their **next bind**, titled or not.

### Scope note

`conversations/index.go`'s `Slugify(id)` is left alone: there the slug is a **unique identity key** (`Lookup(adapter, slug)`), not a display choice; emptying it would break lookups. It only reaches display via the migration-window `rehydrate` path — a separate, narrower surface.

## Tests

- `extension_test.go` (`TestSessionSlugFromExplicitSourceOnly`), through the real `/hook/event` handler:
  - **explicit-slug** → slugified and recorded.
  - **no-slug-source-stays-empty** → pre-title bind leaves slug empty (settle-polled).
  - **no-slug-source-clears-prior-slug** → titled → untitled re-bind clears the slug (Greptile's scenario).
- `subscribe_test.go` (`TestMetaEventSlugSemantics`) — three-way daemon semantics: set / preserve-on-absent / clear-on-explicit-empty.
- Already covered: web fallback `id.slice(0,8)` (`routing.test.ts`), pi-ext omits slug pre-title (`pi_ext_slug_test.go`).

Docs + pi-ext comment updated: `id` is informational; `slug` is omitted until the session has a title.