### PR TITLE
chore(gmux-web): bump xterm fork to v6.1.0-beta.195-gmux.3 (HiDPI images)

### DIFF
--- a/apps/gmux-web/package.json
+++ b/apps/gmux-web/package.json
@@ -20,10 +20,10 @@
     "@trpc/client": "^11.6.0",
     "@xterm/addon-fit": "0.12.0-beta.195",
     "@xterm/addon-search": "0.17.0-beta.195",
-    "@xterm/addon-image": "github:gmuxapp/xterm.js#v6.1.0-beta.195-gmux.2&path:addons/addon-image",
+    "@xterm/addon-image": "github:gmuxapp/xterm.js#v6.1.0-beta.195-gmux.3&path:addons/addon-image",
     "@xterm/addon-web-links": "0.13.0-beta.195",
     "@xterm/addon-webgl": "0.20.0-beta.194",
-    "@xterm/xterm": "github:gmuxapp/xterm.js#v6.1.0-beta.195-gmux.2",
+    "@xterm/xterm": "github:gmuxapp/xterm.js#v6.1.0-beta.195-gmux.3",
     "preact": "^10.26.4",
     "preact-iso": "^2.11.1",
     "valibot": "^1.3.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,22 +54,22 @@ importers:
         version: 11.12.0(@trpc/server@11.12.0(typescript@5.9.3))(typescript@5.9.3)
       '@xterm/addon-fit':
         specifier: 0.12.0-beta.195
-        version: 0.12.0-beta.195(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed)
+        version: 0.12.0-beta.195(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/f9f14b12959b6019b593b3636a05f25204da5e4d)
       '@xterm/addon-image':
-        specifier: github:gmuxapp/xterm.js#v6.1.0-beta.195-gmux.2&path:addons/addon-image
-        version: https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed#path:addons/addon-image
+        specifier: github:gmuxapp/xterm.js#v6.1.0-beta.195-gmux.3&path:addons/addon-image
+        version: https://codeload.github.com/gmuxapp/xterm.js/tar.gz/f9f14b12959b6019b593b3636a05f25204da5e4d#path:addons/addon-image
       '@xterm/addon-search':
         specifier: 0.17.0-beta.195
-        version: 0.17.0-beta.195(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed)
+        version: 0.17.0-beta.195(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/f9f14b12959b6019b593b3636a05f25204da5e4d)
       '@xterm/addon-web-links':
         specifier: 0.13.0-beta.195
-        version: 0.13.0-beta.195(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed)
+        version: 0.13.0-beta.195(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/f9f14b12959b6019b593b3636a05f25204da5e4d)
       '@xterm/addon-webgl':
         specifier: 0.20.0-beta.194
-        version: 0.20.0-beta.194(patch_hash=d9125d12d13397d8171c9874eae71c1adcc92e3510a7b24eafdb4d19339489a1)(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed)
+        version: 0.20.0-beta.194(patch_hash=d9125d12d13397d8171c9874eae71c1adcc92e3510a7b24eafdb4d19339489a1)(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/f9f14b12959b6019b593b3636a05f25204da5e4d)
       '@xterm/xterm':
-        specifier: github:gmuxapp/xterm.js#v6.1.0-beta.195-gmux.2
-        version: https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed
+        specifier: github:gmuxapp/xterm.js#v6.1.0-beta.195-gmux.3
+        version: https://codeload.github.com/gmuxapp/xterm.js/tar.gz/f9f14b12959b6019b593b3636a05f25204da5e4d
       preact:
         specifier: ^10.26.4
         version: 10.29.0
@@ -1375,8 +1375,8 @@ packages:
     peerDependencies:
       '@xterm/xterm': ^6.1.0-beta.195
 
-  '@xterm/addon-image@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed#path:addons/addon-image':
-    resolution: {path: addons/addon-image, tarball: https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed}
+  '@xterm/addon-image@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/f9f14b12959b6019b593b3636a05f25204da5e4d#path:addons/addon-image':
+    resolution: {path: addons/addon-image, tarball: https://codeload.github.com/gmuxapp/xterm.js/tar.gz/f9f14b12959b6019b593b3636a05f25204da5e4d}
     version: 0.9.0
 
   '@xterm/addon-search@0.17.0-beta.195':
@@ -1397,8 +1397,8 @@ packages:
     peerDependencies:
       '@xterm/xterm': ^6.1.0-beta.195
 
-  '@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed':
-    resolution: {tarball: https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed}
+  '@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/f9f14b12959b6019b593b3636a05f25204da5e4d':
+    resolution: {tarball: https://codeload.github.com/gmuxapp/xterm.js/tar.gz/f9f14b12959b6019b593b3636a05f25204da5e4d}
     version: 6.1.0-beta.195
 
   acorn-jsx@5.3.2:
@@ -4228,25 +4228,25 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
-  '@xterm/addon-fit@0.12.0-beta.195(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed)':
+  '@xterm/addon-fit@0.12.0-beta.195(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/f9f14b12959b6019b593b3636a05f25204da5e4d)':
     dependencies:
-      '@xterm/xterm': https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed
+      '@xterm/xterm': https://codeload.github.com/gmuxapp/xterm.js/tar.gz/f9f14b12959b6019b593b3636a05f25204da5e4d
 
-  '@xterm/addon-image@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed#path:addons/addon-image': {}
+  '@xterm/addon-image@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/f9f14b12959b6019b593b3636a05f25204da5e4d#path:addons/addon-image': {}
 
-  '@xterm/addon-search@0.17.0-beta.195(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed)':
+  '@xterm/addon-search@0.17.0-beta.195(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/f9f14b12959b6019b593b3636a05f25204da5e4d)':
     dependencies:
-      '@xterm/xterm': https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed
+      '@xterm/xterm': https://codeload.github.com/gmuxapp/xterm.js/tar.gz/f9f14b12959b6019b593b3636a05f25204da5e4d
 
-  '@xterm/addon-web-links@0.13.0-beta.195(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed)':
+  '@xterm/addon-web-links@0.13.0-beta.195(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/f9f14b12959b6019b593b3636a05f25204da5e4d)':
     dependencies:
-      '@xterm/xterm': https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed
+      '@xterm/xterm': https://codeload.github.com/gmuxapp/xterm.js/tar.gz/f9f14b12959b6019b593b3636a05f25204da5e4d
 
-  '@xterm/addon-webgl@0.20.0-beta.194(patch_hash=d9125d12d13397d8171c9874eae71c1adcc92e3510a7b24eafdb4d19339489a1)(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed)':
+  '@xterm/addon-webgl@0.20.0-beta.194(patch_hash=d9125d12d13397d8171c9874eae71c1adcc92e3510a7b24eafdb4d19339489a1)(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/f9f14b12959b6019b593b3636a05f25204da5e4d)':
     dependencies:
-      '@xterm/xterm': https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed
+      '@xterm/xterm': https://codeload.github.com/gmuxapp/xterm.js/tar.gz/f9f14b12959b6019b593b3636a05f25204da5e4d
 
-  '@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed': {}
+  '@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/f9f14b12959b6019b593b3636a05f25204da5e4d': {}
 
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:


### PR DESCRIPTION
Bumps the `@xterm/xterm` + `@xterm/addon-image` pins from `gmux.2` → `gmux.3`.

**gmux.3** adds the device-resolution HiDPI image rendering fix — inline images (imgcat/sixel/kitty) now render crisp on HiDPI displays instead of blurry/half-size — on top of the existing Gboard composition fix (both preserved).

- Fork tag: [`gmuxapp/xterm.js@v6.1.0-beta.195-gmux.3`](https://github.com/gmuxapp/xterm.js/releases/tag/v6.1.0-beta.195-gmux.3)
- The upstream version of this fix is in flight at xtermjs/xterm.js#5775.

Verified: `pnpm install` resolves both deps to the gmux.3 tarball and `pnpm --filter @gmux/web build` succeeds.

Note: a follow-up will rebase the fork onto current upstream master (it's ~367 commits behind) and adopt the polished upstream fix.