### PR TITLE
chore(gmux-web): bump xterm fork to gmux.5 (rebase onto upstream master + polished HiDPI fix, beta.288-stamped)

### DIFF
--- a/apps/gmux-web/package.json
+++ b/apps/gmux-web/package.json
@@ -20,10 +20,10 @@
     "@trpc/client": "^11.6.0",
     "@xterm/addon-fit": "0.12.0-beta.195",
     "@xterm/addon-search": "0.17.0-beta.195",
-    "@xterm/addon-image": "github:gmuxapp/xterm.js#v6.1.0-beta.195-gmux.3&path:addons/addon-image",
+    "@xterm/addon-image": "github:gmuxapp/xterm.js#v6.1.0-beta.288-gmux.5&path:addons/addon-image",
     "@xterm/addon-web-links": "0.13.0-beta.195",
     "@xterm/addon-webgl": "0.20.0-beta.194",
-    "@xterm/xterm": "github:gmuxapp/xterm.js#v6.1.0-beta.195-gmux.3",
+    "@xterm/xterm": "github:gmuxapp/xterm.js#v6.1.0-beta.288-gmux.5",
     "preact": "^10.26.4",
     "preact-iso": "^2.11.1",
     "valibot": "^1.3.1"

--- a/apps/gmux-web/package.json
+++ b/apps/gmux-web/package.json
@@ -20,10 +20,10 @@
     "@trpc/client": "^11.6.0",
     "@xterm/addon-fit": "0.12.0-beta.195",
     "@xterm/addon-search": "0.17.0-beta.195",
-    "@xterm/addon-image": "github:gmuxapp/xterm.js#v6.1.0-beta.195-gmux.2&path:addons/addon-image",
+    "@xterm/addon-image": "github:gmuxapp/xterm.js#v6.1.0-beta.195-gmux.3&path:addons/addon-image",
     "@xterm/addon-web-links": "0.13.0-beta.195",
     "@xterm/addon-webgl": "0.20.0-beta.194",
-    "@xterm/xterm": "github:gmuxapp/xterm.js#v6.1.0-beta.195-gmux.2",
+    "@xterm/xterm": "github:gmuxapp/xterm.js#v6.1.0-beta.195-gmux.3",
     "preact": "^10.26.4",
     "preact-iso": "^2.11.1",
     "valibot": "^1.3.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,22 +54,22 @@ importers:
         version: 11.12.0(@trpc/server@11.12.0(typescript@5.9.3))(typescript@5.9.3)
       '@xterm/addon-fit':
         specifier: 0.12.0-beta.195
-        version: 0.12.0-beta.195(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed)
+        version: 0.12.0-beta.195(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/f9f14b12959b6019b593b3636a05f25204da5e4d)
       '@xterm/addon-image':
-        specifier: github:gmuxapp/xterm.js#v6.1.0-beta.195-gmux.2&path:addons/addon-image
-        version: https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed#path:addons/addon-image
+        specifier: github:gmuxapp/xterm.js#v6.1.0-beta.195-gmux.3&path:addons/addon-image
+        version: https://codeload.github.com/gmuxapp/xterm.js/tar.gz/f9f14b12959b6019b593b3636a05f25204da5e4d#path:addons/addon-image
       '@xterm/addon-search':
         specifier: 0.17.0-beta.195
-        version: 0.17.0-beta.195(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed)
+        version: 0.17.0-beta.195(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/f9f14b12959b6019b593b3636a05f25204da5e4d)
       '@xterm/addon-web-links':
         specifier: 0.13.0-beta.195
-        version: 0.13.0-beta.195(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed)
+        version: 0.13.0-beta.195(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/f9f14b12959b6019b593b3636a05f25204da5e4d)
       '@xterm/addon-webgl':
         specifier: 0.20.0-beta.194
-        version: 0.20.0-beta.194(patch_hash=d9125d12d13397d8171c9874eae71c1adcc92e3510a7b24eafdb4d19339489a1)(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed)
+        version: 0.20.0-beta.194(patch_hash=d9125d12d13397d8171c9874eae71c1adcc92e3510a7b24eafdb4d19339489a1)(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/f9f14b12959b6019b593b3636a05f25204da5e4d)
       '@xterm/xterm':
-        specifier: github:gmuxapp/xterm.js#v6.1.0-beta.195-gmux.2
-        version: https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed
+        specifier: github:gmuxapp/xterm.js#v6.1.0-beta.195-gmux.3
+        version: https://codeload.github.com/gmuxapp/xterm.js/tar.gz/f9f14b12959b6019b593b3636a05f25204da5e4d
       preact:
         specifier: ^10.26.4
         version: 10.29.0
@@ -1375,8 +1375,8 @@ packages:
     peerDependencies:
       '@xterm/xterm': ^6.1.0-beta.195
 
-  '@xterm/addon-image@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed#path:addons/addon-image':
-    resolution: {path: addons/addon-image, tarball: https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed}
+  '@xterm/addon-image@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/f9f14b12959b6019b593b3636a05f25204da5e4d#path:addons/addon-image':
+    resolution: {path: addons/addon-image, tarball: https://codeload.github.com/gmuxapp/xterm.js/tar.gz/f9f14b12959b6019b593b3636a05f25204da5e4d}
     version: 0.9.0
 
   '@xterm/addon-search@0.17.0-beta.195':
@@ -1397,8 +1397,8 @@ packages:
     peerDependencies:
       '@xterm/xterm': ^6.1.0-beta.195
 
-  '@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed':
-    resolution: {tarball: https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed}
+  '@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/f9f14b12959b6019b593b3636a05f25204da5e4d':
+    resolution: {tarball: https://codeload.github.com/gmuxapp/xterm.js/tar.gz/f9f14b12959b6019b593b3636a05f25204da5e4d}
     version: 6.1.0-beta.195
 
   acorn-jsx@5.3.2:
@@ -4228,25 +4228,25 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
-  '@xterm/addon-fit@0.12.0-beta.195(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed)':
+  '@xterm/addon-fit@0.12.0-beta.195(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/f9f14b12959b6019b593b3636a05f25204da5e4d)':
     dependencies:
-      '@xterm/xterm': https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed
+      '@xterm/xterm': https://codeload.github.com/gmuxapp/xterm.js/tar.gz/f9f14b12959b6019b593b3636a05f25204da5e4d
 
-  '@xterm/addon-image@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed#path:addons/addon-image': {}
+  '@xterm/addon-image@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/f9f14b12959b6019b593b3636a05f25204da5e4d#path:addons/addon-image': {}
 
-  '@xterm/addon-search@0.17.0-beta.195(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed)':
+  '@xterm/addon-search@0.17.0-beta.195(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/f9f14b12959b6019b593b3636a05f25204da5e4d)':
     dependencies:
-      '@xterm/xterm': https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed
+      '@xterm/xterm': https://codeload.github.com/gmuxapp/xterm.js/tar.gz/f9f14b12959b6019b593b3636a05f25204da5e4d
 
-  '@xterm/addon-web-links@0.13.0-beta.195(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed)':
+  '@xterm/addon-web-links@0.13.0-beta.195(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/f9f14b12959b6019b593b3636a05f25204da5e4d)':
     dependencies:
-      '@xterm/xterm': https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed
+      '@xterm/xterm': https://codeload.github.com/gmuxapp/xterm.js/tar.gz/f9f14b12959b6019b593b3636a05f25204da5e4d
 
-  '@xterm/addon-webgl@0.20.0-beta.194(patch_hash=d9125d12d13397d8171c9874eae71c1adcc92e3510a7b24eafdb4d19339489a1)(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed)':
+  '@xterm/addon-webgl@0.20.0-beta.194(patch_hash=d9125d12d13397d8171c9874eae71c1adcc92e3510a7b24eafdb4d19339489a1)(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/f9f14b12959b6019b593b3636a05f25204da5e4d)':
     dependencies:
-      '@xterm/xterm': https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed
+      '@xterm/xterm': https://codeload.github.com/gmuxapp/xterm.js/tar.gz/f9f14b12959b6019b593b3636a05f25204da5e4d
 
-  '@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/a8d82b583c09be14a98d7a092a294b154dc5deed': {}
+  '@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/f9f14b12959b6019b593b3636a05f25204da5e4d': {}
 
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,22 +54,22 @@ importers:
         version: 11.12.0(@trpc/server@11.12.0(typescript@5.9.3))(typescript@5.9.3)
       '@xterm/addon-fit':
         specifier: 0.12.0-beta.195
-        version: 0.12.0-beta.195(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/f9f14b12959b6019b593b3636a05f25204da5e4d)
+        version: 0.12.0-beta.195(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/baeffe1f08c007e194c842b0f913665a48643c19)
       '@xterm/addon-image':
-        specifier: github:gmuxapp/xterm.js#v6.1.0-beta.195-gmux.3&path:addons/addon-image
-        version: https://codeload.github.com/gmuxapp/xterm.js/tar.gz/f9f14b12959b6019b593b3636a05f25204da5e4d#path:addons/addon-image
+        specifier: github:gmuxapp/xterm.js#v6.1.0-beta.288-gmux.5&path:addons/addon-image
+        version: https://codeload.github.com/gmuxapp/xterm.js/tar.gz/baeffe1f08c007e194c842b0f913665a48643c19#path:addons/addon-image
       '@xterm/addon-search':
         specifier: 0.17.0-beta.195
-        version: 0.17.0-beta.195(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/f9f14b12959b6019b593b3636a05f25204da5e4d)
+        version: 0.17.0-beta.195(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/baeffe1f08c007e194c842b0f913665a48643c19)
       '@xterm/addon-web-links':
         specifier: 0.13.0-beta.195
-        version: 0.13.0-beta.195(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/f9f14b12959b6019b593b3636a05f25204da5e4d)
+        version: 0.13.0-beta.195(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/baeffe1f08c007e194c842b0f913665a48643c19)
       '@xterm/addon-webgl':
         specifier: 0.20.0-beta.194
-        version: 0.20.0-beta.194(patch_hash=d9125d12d13397d8171c9874eae71c1adcc92e3510a7b24eafdb4d19339489a1)(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/f9f14b12959b6019b593b3636a05f25204da5e4d)
+        version: 0.20.0-beta.194(patch_hash=d9125d12d13397d8171c9874eae71c1adcc92e3510a7b24eafdb4d19339489a1)(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/baeffe1f08c007e194c842b0f913665a48643c19)
       '@xterm/xterm':
-        specifier: github:gmuxapp/xterm.js#v6.1.0-beta.195-gmux.3
-        version: https://codeload.github.com/gmuxapp/xterm.js/tar.gz/f9f14b12959b6019b593b3636a05f25204da5e4d
+        specifier: github:gmuxapp/xterm.js#v6.1.0-beta.288-gmux.5
+        version: https://codeload.github.com/gmuxapp/xterm.js/tar.gz/baeffe1f08c007e194c842b0f913665a48643c19
       preact:
         specifier: ^10.26.4
         version: 10.29.0
@@ -1375,8 +1375,8 @@ packages:
     peerDependencies:
       '@xterm/xterm': ^6.1.0-beta.195
 
-  '@xterm/addon-image@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/f9f14b12959b6019b593b3636a05f25204da5e4d#path:addons/addon-image':
-    resolution: {path: addons/addon-image, tarball: https://codeload.github.com/gmuxapp/xterm.js/tar.gz/f9f14b12959b6019b593b3636a05f25204da5e4d}
+  '@xterm/addon-image@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/baeffe1f08c007e194c842b0f913665a48643c19#path:addons/addon-image':
+    resolution: {path: addons/addon-image, tarball: https://codeload.github.com/gmuxapp/xterm.js/tar.gz/baeffe1f08c007e194c842b0f913665a48643c19}
     version: 0.9.0
 
   '@xterm/addon-search@0.17.0-beta.195':
@@ -1397,9 +1397,9 @@ packages:
     peerDependencies:
       '@xterm/xterm': ^6.1.0-beta.195
 
-  '@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/f9f14b12959b6019b593b3636a05f25204da5e4d':
-    resolution: {tarball: https://codeload.github.com/gmuxapp/xterm.js/tar.gz/f9f14b12959b6019b593b3636a05f25204da5e4d}
-    version: 6.1.0-beta.195
+  '@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/baeffe1f08c007e194c842b0f913665a48643c19':
+    resolution: {tarball: https://codeload.github.com/gmuxapp/xterm.js/tar.gz/baeffe1f08c007e194c842b0f913665a48643c19}
+    version: 6.1.0-beta.288
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -4228,25 +4228,25 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
-  '@xterm/addon-fit@0.12.0-beta.195(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/f9f14b12959b6019b593b3636a05f25204da5e4d)':
+  '@xterm/addon-fit@0.12.0-beta.195(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/baeffe1f08c007e194c842b0f913665a48643c19)':
     dependencies:
-      '@xterm/xterm': https://codeload.github.com/gmuxapp/xterm.js/tar.gz/f9f14b12959b6019b593b3636a05f25204da5e4d
+      '@xterm/xterm': https://codeload.github.com/gmuxapp/xterm.js/tar.gz/baeffe1f08c007e194c842b0f913665a48643c19
 
-  '@xterm/addon-image@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/f9f14b12959b6019b593b3636a05f25204da5e4d#path:addons/addon-image': {}
+  '@xterm/addon-image@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/baeffe1f08c007e194c842b0f913665a48643c19#path:addons/addon-image': {}
 
-  '@xterm/addon-search@0.17.0-beta.195(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/f9f14b12959b6019b593b3636a05f25204da5e4d)':
+  '@xterm/addon-search@0.17.0-beta.195(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/baeffe1f08c007e194c842b0f913665a48643c19)':
     dependencies:
-      '@xterm/xterm': https://codeload.github.com/gmuxapp/xterm.js/tar.gz/f9f14b12959b6019b593b3636a05f25204da5e4d
+      '@xterm/xterm': https://codeload.github.com/gmuxapp/xterm.js/tar.gz/baeffe1f08c007e194c842b0f913665a48643c19
 
-  '@xterm/addon-web-links@0.13.0-beta.195(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/f9f14b12959b6019b593b3636a05f25204da5e4d)':
+  '@xterm/addon-web-links@0.13.0-beta.195(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/baeffe1f08c007e194c842b0f913665a48643c19)':
     dependencies:
-      '@xterm/xterm': https://codeload.github.com/gmuxapp/xterm.js/tar.gz/f9f14b12959b6019b593b3636a05f25204da5e4d
+      '@xterm/xterm': https://codeload.github.com/gmuxapp/xterm.js/tar.gz/baeffe1f08c007e194c842b0f913665a48643c19
 
-  '@xterm/addon-webgl@0.20.0-beta.194(patch_hash=d9125d12d13397d8171c9874eae71c1adcc92e3510a7b24eafdb4d19339489a1)(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/f9f14b12959b6019b593b3636a05f25204da5e4d)':
+  '@xterm/addon-webgl@0.20.0-beta.194(patch_hash=d9125d12d13397d8171c9874eae71c1adcc92e3510a7b24eafdb4d19339489a1)(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/baeffe1f08c007e194c842b0f913665a48643c19)':
     dependencies:
-      '@xterm/xterm': https://codeload.github.com/gmuxapp/xterm.js/tar.gz/f9f14b12959b6019b593b3636a05f25204da5e4d
+      '@xterm/xterm': https://codeload.github.com/gmuxapp/xterm.js/tar.gz/baeffe1f08c007e194c842b0f913665a48643c19
 
-  '@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/f9f14b12959b6019b593b3636a05f25204da5e4d': {}
+  '@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/baeffe1f08c007e194c842b0f913665a48643c19': {}
 
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:


### PR DESCRIPTION
Rebuilds the xterm fork on **current upstream master (2026-06-28, ~367 commits newer than the old fork base)** and adopts the **polished device-resolution fix** from xtermjs/xterm.js#5775 (correct `px`=device-pixel + fractional-DPR), on top of the Gboard composition fix (preserved).

- Fork tag: [`gmuxapp/xterm.js@v6.1.0-beta.288-gmux.5`](https://github.com/gmuxapp/xterm.js/releases/tag/v6.1.0-beta.288-gmux.5) (branch `gmux-next`)
- Fork branch composition: `upstream/master` + Gboard fix + PR #5775 fix + version stamp + built `lib/`.

### Version stamp (updated per review)
The fork's `package.json` is now stamped **`6.1.0-beta.288`** — matching its actual content generation (upstream master 06-28 == published `beta.288`). This supersedes the earlier `gmux.4`/`beta.195` stamp, which understated the core by ~93 betas and, once the stacked #397 bumps the addons, would have failed their `^6.1.0-beta.288` peer range. `lib/` embeds no version string, so this is a package.json-only restamp (no rebuild).

### Verification
- xterm.js fork: `tsc` + full `npm run package` clean; Gboard unit test 10/10; upstream `width=320px` IIP test passes.
- gmux-web: `pnpm install` + build succeed; addons resolve against the restamped core cleanly.
- **Runtime smoke test (chrome-devtools, DPR=1 and DPR=2):** inline images render **full-size and crisp** — 300×150 device px @ DPR=1, **600×300 device px @ DPR=2** (not half). WebGL renderer active, fit reflows on resize, no console errors. See #397 for measurements.

### Stack / merge order (updated per review)
- **Base retargeted to `main`.** #396's branch already contains #395's commit, so merging #396 into main lands both bumps; **#395 (`image-dpi-bump`) will be closed as superseded** (same fix on the old March fork base).
- **#397** (addon alignment) is stacked on this branch and resolves the addon↔core drift risk. GitHub auto-retargets #397 to main when this merges. Land them together / in quick succession; don't cut a release from a state between #396 and #397.