### PR TITLE
feat(cli): gmux send --follow-up / --steering — adapter-aware submit keybinds

### DIFF
--- a/apps/website/src/content/docs/develop/writing-adapters.md
+++ b/apps/website/src/content/docs/develop/writing-adapters.md
@@ -232,6 +232,16 @@ All dead sessions are resumable. When a session exits, gmuxd checks whether the 
 
 This means adapters that don't implement `Resumer` still get resume for free: the user clicks resume, a new session starts with the same command and cwd. This is the right behavior for simple tools. Only implement `Resumer` when your tool has native resume support that you want to use instead.
 
+### `PromptSubmitter`
+
+```go
+type PromptSubmitter interface {
+    SubmitSeq(mode SubmitMode) (seq string, ok bool)
+}
+```
+
+Optional. Maps `gmux send --steering` / `--follow-up` to the keystroke that submits a composed prompt in that mode: `SubmitSteering` delivers into the current turn immediately, `SubmitFollowUp` queues until the current turn ends. pi implements it (`Enter` vs `Alt+Enter`); adapters without it default to `Enter` for both modes, which is right for shells and for agents whose `Enter` submits when idle and queues when busy (claude, codex). Return `ok=false` to reject a mode your tool can't honor — the CLI surfaces that as a usage error.
+
 ### `CommandTitler`
 
 ```go
@@ -254,7 +264,7 @@ An adapter implements only what it needs:
 | Editor | ✓ | ✓ | — | — | — | CommandTitler, SessionRegistrar |
 | Claude | ✓ | ✓ | ✓ | ✓ | ✓ | ConversationOpener, ConversationProber, SessionHookCommand |
 | Codex | ✓ | ✓ | ✓ | ✓ | ✓ | ConversationOpener, ConversationProber, SessionHookCommand |
-| Pi | ✓ | ✓ | ✓ | ✓ | ✓ | ConversationOpener, ConversationProber, SessionExtender, PassthroughDetector |
+| Pi | ✓ | ✓ | ✓ | ✓ | ✓ | ConversationOpener, ConversationProber, SessionExtender, PassthroughDetector, PromptSubmitter |
 
 Shell writes a small JSON state file per session under `~/.local/state/gmux/shell-sessions/` and resumes by launching `$SHELL` in the original cwd. The editor adapter (backing `gmux edit`) is a good minimal non-agent example: it matches an internal sentinel command and is ephemeral (auto-dismissed on close).
 

--- a/apps/website/src/content/docs/reference/cli.md
+++ b/apps/website/src/content/docs/reference/cli.md
@@ -116,7 +116,7 @@ gmux tail --raw a3f20187      # keep ANSI escapes (-e also works)
 It's a snapshot, not a stream — to watch a session live, attach to it or open
 it in the browser.
 
-### `gmux send [--wait [--timeout N]] <id> [text] [Key...]`
+### `gmux send [--wait [--timeout N]] [--follow-up|--steering] <id> [text] [Key...]`
 
 Inject input into a running session as if typed at the keyboard. The text is
 sent literally; any trailing arguments that name keys (`Enter`, `C-c`,
@@ -134,6 +134,28 @@ echo "$body" | gmux send a3f20187 Enter         # pipe stdin, then submit
 When no text is given and stdin is a pipe, gmux reads stdin until EOF (capped
 at 1 MiB) and sends it — the natural shape for files and heredocs. Include a
 trailing `Enter` to submit piped input.
+
+**`--follow-up` / `--steering`** auto-append the session adapter's *submit*
+keystroke, so callers don't need to know adapter-specific key encodings:
+
+- `--follow-up` — the adapter's **queued** submit: the prompt is delivered
+  after the agent finishes what it's doing (pi: `Alt+Enter`).
+- `--steering` — the adapter's **immediate** submit: the prompt is delivered
+  into the current turn right away (pi: `Enter`).
+
+```bash
+gmux send --follow-up a3f20187 'then also update the docs'   # queue for after this turn
+gmux send --steering a3f20187 'stop — wrong file, use api.ts' # interject mid-turn
+```
+
+On an idle agent both act as a plain submit. Adapters that don't distinguish
+the two modes (shells; agents like claude/codex whose `Enter` submits when
+idle and queues when busy) map both to `Enter`. The two flags are mutually
+exclusive, and — because they own submission — cannot be combined with
+trailing key tokens. They compose with `--wait`: `send --wait --follow-up`
+blocks until the turn the queued prompt triggers completes (pi processes
+queued follow-ups before reporting idle, so the wait covers the queued reply,
+not just the current turn).
 
 **Everything after the session id is verbatim** — including tokens that start
 with a dash. `gmux send abc -v` sends the literal `-v`, and no `--` guard is

--- a/cli/gmux/cmd/gmux/actions.go
+++ b/cli/gmux/cmd/gmux/actions.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 
 	"github.com/gmuxapp/gmux/cli/gmux/internal/localterm"
+	"github.com/gmuxapp/gmux/packages/adapter"
+	"github.com/gmuxapp/gmux/packages/adapter/adapters"
 )
 
 // session is the subset of gmuxd's Session model that the CLI cares
@@ -419,7 +421,12 @@ func fetchScrollback(sess cliSession, n int) ([]byte, int) {
 // Sends bytes to the session's PTY as if typed at the terminal: the
 // inline text (or piped stdin) followed by any trailing key tokens.
 // Submission is explicit (ADR 0009) — a trailing `Enter` key, or a \r
-// in piped bytes — so there is no implicit carriage return.
+// in piped bytes — so there is no implicit carriage return. The one
+// adapter-aware exception is submit ("follow-up" or "steering"): it
+// appends the session adapter's submit keystroke for that mode, so the
+// caller doesn't have to know adapter-specific key encodings (pi
+// queues a follow-up with Alt+Enter — undiscoverable, and not even
+// expressible as a `send` key token).
 //
 // When text is provided inline it is sent verbatim; when it is omitted
 // and stdin is a pipe, stdin is read until EOF (`echo hi | gmux send
@@ -431,7 +438,27 @@ func fetchScrollback(sess cliSession, n int) ([]byte, int) {
 // peer sessions (gmuxd forwards to the owning peer transparently).
 // Access control inherits from gmuxd: local IPC is owner-only, and
 // peers honor their own `tailscale.allow` config.
-func cmdSend(ref string, text *string, keys []string, wait bool, timeoutSecs int) int {
+func cmdSend(ref string, text *string, keys []string, submit string, wait bool, timeoutSecs int) int {
+	// Resolve up front: the submit sequence depends on the session's
+	// adapter, which only the resolved session knows. Because the
+	// adapter name travels with the session record, this works for peer
+	// sessions too — the mapping happens here, the peer just gets bytes.
+	sess, err := resolveSession(ref)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "gmux:", err)
+		return 1
+	}
+
+	var submitSeq string
+	if submit != "" {
+		seq, ok := submitSeqFor(sess.Adapter, submit)
+		if !ok {
+			fmt.Fprintf(os.Stderr, "gmux: the %s adapter does not support --%s\n", sess.Adapter, submit)
+			return 1
+		}
+		submitSeq = seq
+	}
+
 	// Read stdin only when no inline text was given AND stdin is a pipe.
 	// The tty guard is essential: without it, `gmux send <id> Enter` typed
 	// interactively would block reading the terminal. With it, piped input
@@ -441,11 +468,50 @@ func cmdSend(ref string, text *string, keys []string, wait bool, timeoutSecs int
 	if text == nil && !localterm.IsInteractive() {
 		stdin = os.Stdin
 	}
-	body := buildSendBody(text, keys, stdin)
-	if wait {
-		return sendBytesAndWait(ref, body, timeoutSecs)
+	body := buildSendBody(text, keys, stdin, submitSeq)
+	if !wait {
+		return postInput(sess, body, "")
 	}
-	return sendBytes(ref, body)
+
+	// `gmux send --wait`: one request delivers the input AND blocks
+	// until the turn it triggers completes. gmuxd subscribes to session
+	// events *before* forwarding the bytes to the runner, so unlike the
+	// `gmux send X && gmux wait X` composition it cannot mistake the
+	// previous turn's idle state for the reply (#218). With --follow-up
+	// on a busy pi session this also waits for the queued prompt's
+	// reply, not just the current turn: pi drains its follow-up queue
+	// inside the same agent loop, so Working stays true until the
+	// queued turn is done.
+	//
+	// Exit codes mirror `gmux wait`: 0 idle, 2 died, 3 timeout, 1
+	// usage/transport errors.
+	if sess.Peer != "" {
+		// Same scope rule as `gmux wait`: the wait half needs the
+		// owning daemon's event stream, which peers don't expose to
+		// the CLI yet. Bare shortID: the message names the peer itself.
+		fmt.Fprintf(os.Stderr, "gmux: send --wait is only supported for local sessions (%s is on peer %q)\n",
+			shortID(sess.ID), sess.Peer)
+		return 1
+	}
+	query := "?wait=idle"
+	if timeoutSecs > 0 {
+		query += "&timeout=" + strconv.Itoa(timeoutSecs)
+	}
+	return postInput(sess, body, query)
+}
+
+// submitSeqFor maps a session's adapter name plus a submit-mode flag
+// ("follow-up" | "steering") to the PTY byte sequence that submits the
+// prompt. The adapter capability (adapter.PromptSubmitter) owns the
+// mapping; adapters without it — and adapter names this build doesn't
+// know — fall back to Enter for both modes, the universal single
+// submit (see adapter.SubmitSeqFor).
+func submitSeqFor(adapterName, mode string) (string, bool) {
+	m := adapter.SubmitSteering
+	if mode == "follow-up" {
+		m = adapter.SubmitFollowUp
+	}
+	return adapter.SubmitSeqFor(adapters.FindByAdapter(adapterName), m)
 }
 
 // cmdSendKeys implements the tmux-compatible `gmux send-keys -t <id>
@@ -463,35 +529,6 @@ func sendBytes(ref string, body io.Reader) int {
 		return 1
 	}
 	return postInput(sess, body, "")
-}
-
-// sendBytesAndWait implements `gmux send --wait`: one request delivers
-// the input AND blocks until the turn it triggers completes. gmuxd
-// subscribes to session events *before* forwarding the bytes to the
-// runner, so unlike the `gmux send X && gmux wait X` composition it
-// cannot mistake the previous turn's idle state for the reply (#218).
-//
-// Exit codes mirror `gmux wait`: 0 idle, 2 died, 3 timeout, 1 usage/
-// transport errors.
-func sendBytesAndWait(ref string, body io.Reader, timeoutSecs int) int {
-	sess, err := resolveSession(ref)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, "gmux:", err)
-		return 1
-	}
-	if sess.Peer != "" {
-		// Same scope rule as `gmux wait`: the wait half needs the
-		// owning daemon's event stream, which peers don't expose to
-		// the CLI yet. Bare shortID: the message names the peer itself.
-		fmt.Fprintf(os.Stderr, "gmux: send --wait is only supported for local sessions (%s is on peer %q)\n",
-			shortID(sess.ID), sess.Peer)
-		return 1
-	}
-	query := "?wait=idle"
-	if timeoutSecs > 0 {
-		query += "&timeout=" + strconv.Itoa(timeoutSecs)
-	}
-	return postInput(sess, body, query)
 }
 
 // postInput POSTs body to the session's input endpoint. With an empty
@@ -566,23 +603,16 @@ func postInput(sess cliSession, body io.Reader, query string) int {
 // fast on the client side rather than letting the server truncate us.
 const maxSendBytes = 1 << 20 // 1 MiB
 
-// buildSendBody assembles the bytes that --send writes to the session's
-// PTY input. When text is non-nil it is sent verbatim; otherwise stdin
-// is read up to maxSendBytes. Unless noSubmit is set, a trailing \r is
-// appended — that's what xterm sends for Enter and what every PTY
-// (agent or shell) treats as "submit this line." \n alone is not
-// enough: most agents see it as a literal newline and keep buffering,
-// which is how `gmux --send <id> < prompt.txt` ended up silently
-// failing for users who expected `cat`-style behavior. A redundant \r
-// in the input is harmless (submits an empty line at most), so we don't
-// try to detect and dedupe.
 // buildSendBody assembles the bytes to write to the session PTY: the
 // message body (inline text, else piped stdin if provided) followed by
-// any trailing key sequences. stdin is nil unless the caller determined
-// it is a pipe to read (see cmdSend). Submission is explicit — a
-// trailing Enter key, or a \r in the piped bytes.
-func buildSendBody(text *string, keys []string, stdin io.Reader) io.Reader {
-	readers := make([]io.Reader, 0, 2)
+// any trailing key sequences, then the adapter submit sequence (from
+// --follow-up/--steering; "" for neither — the parser guarantees keys
+// and submitSeq never coexist). stdin is nil unless the caller
+// determined it is a pipe to read (see cmdSend). Submission is
+// explicit — a trailing Enter key, a \r in the piped bytes, or a
+// submit-mode flag.
+func buildSendBody(text *string, keys []string, stdin io.Reader, submitSeq string) io.Reader {
+	readers := make([]io.Reader, 0, 3)
 	switch {
 	case text != nil:
 		readers = append(readers, strings.NewReader(*text))
@@ -591,6 +621,9 @@ func buildSendBody(text *string, keys []string, stdin io.Reader) io.Reader {
 	}
 	if len(keys) > 0 {
 		readers = append(readers, strings.NewReader(renderKeys(keys, false)))
+	}
+	if submitSeq != "" {
+		readers = append(readers, strings.NewReader(submitSeq))
 	}
 	return io.MultiReader(readers...)
 }

--- a/cli/gmux/cmd/gmux/actions_test.go
+++ b/cli/gmux/cmd/gmux/actions_test.go
@@ -117,20 +117,20 @@ func TestShortID(t *testing.T) {
 	}
 }
 
-// TestBuildSendBody pins the wire-level contract of --send: by default
-// the bytes written to the PTY end with the carriage return that
-// submits the input, and --no-submit suppresses exactly that byte and
-// nothing else. Both inline-text and stdin paths are covered because
-// they construct the body differently and the carriage-return logic
-// has to wrap both.
+// TestBuildSendBody pins the wire-level contract of `gmux send`: the
+// bytes written to the PTY are exactly text/stdin, then rendered keys,
+// then the adapter submit sequence — nothing implicit. Inline-text and
+// stdin paths are both covered because they construct the body
+// differently, and the submit sequence has to compose with both.
 func TestBuildSendBody(t *testing.T) {
 	noStdin := "\x00NIL" // sentinel: this case passes a nil stdin reader
 	tests := []struct {
-		name  string
-		text  *string
-		keys  []string
-		stdin string // noStdin → nil reader (the tty / no-pipe case)
-		want  string
+		name   string
+		text   *string
+		keys   []string
+		stdin  string // noStdin → nil reader (the tty / no-pipe case)
+		submit string // adapter submit sequence (--follow-up/--steering)
+		want   string
 	}{
 		{
 			name:  "text without keys sends verbatim, no submit",
@@ -169,6 +169,19 @@ func TestBuildSendBody(t *testing.T) {
 			stdin: "hi",
 			want:  "hi\r",
 		},
+		{
+			name:   "text + follow-up submit seq (pi Alt+Enter)",
+			text:   stringPtr("also do X"),
+			stdin:  noStdin,
+			submit: "\x1b\r",
+			want:   "also do X\x1b\r",
+		},
+		{
+			name:   "piped stdin + steering submit seq",
+			stdin:  "course-correct",
+			submit: "\r",
+			want:   "course-correct\r",
+		},
 	}
 
 	for _, tc := range tests {
@@ -177,7 +190,7 @@ func TestBuildSendBody(t *testing.T) {
 			if tc.stdin != noStdin {
 				stdin = strings.NewReader(tc.stdin)
 			}
-			body := buildSendBody(tc.text, tc.keys, stdin)
+			body := buildSendBody(tc.text, tc.keys, stdin, tc.submit)
 			got, err := io.ReadAll(body)
 			if err != nil {
 				t.Fatalf("read body: %v", err)
@@ -190,6 +203,39 @@ func TestBuildSendBody(t *testing.T) {
 }
 
 func stringPtr(s string) *string { return &s }
+
+// TestSubmitSeqFor pins the adapter-name → submit-bytes mapping that
+// `gmux send --follow-up/--steering` relies on: pi distinguishes the
+// two modes (Enter vs Alt+Enter), while every other adapter — shells,
+// agents whose Enter both submits and queues, and adapter names this
+// build doesn't know (e.g. a peer session created by a newer gmux) —
+// falls back to the universal Enter for both.
+func TestSubmitSeqFor(t *testing.T) {
+	cases := []struct {
+		adapter string
+		mode    string
+		want    string
+	}{
+		{"pi", "steering", "\r"},
+		{"pi", "follow-up", "\x1b\r"}, // Alt+Enter = ESC CR
+		{"shell", "steering", "\r"},
+		{"shell", "follow-up", "\r"},
+		{"claude", "follow-up", "\r"},
+		{"codex", "steering", "\r"},
+		{"some-future-adapter", "follow-up", "\r"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.adapter+"/"+tc.mode, func(t *testing.T) {
+			got, ok := submitSeqFor(tc.adapter, tc.mode)
+			if !ok {
+				t.Fatalf("submitSeqFor(%q, %q) not ok", tc.adapter, tc.mode)
+			}
+			if got != tc.want {
+				t.Errorf("submitSeqFor(%q, %q) = %q, want %q", tc.adapter, tc.mode, got, tc.want)
+			}
+		})
+	}
+}
 
 // TestMatchSessionStrictLocalDefault locks in the rule that drove
 // the new addressing design: with no --host and no @suffix, peer

--- a/cli/gmux/cmd/gmux/actions_test.go
+++ b/cli/gmux/cmd/gmux/actions_test.go
@@ -173,8 +173,8 @@ func TestBuildSendBody(t *testing.T) {
 			name:   "text + follow-up submit seq (pi Alt+Enter)",
 			text:   stringPtr("also do X"),
 			stdin:  noStdin,
-			submit: "\x1b\r",
-			want:   "also do X\x1b\r",
+			submit: "\x1b[13;3u",
+			want:   "also do X\x1b[13;3u",
 		},
 		{
 			name:   "piped stdin + steering submit seq",
@@ -217,7 +217,7 @@ func TestSubmitSeqFor(t *testing.T) {
 		want    string
 	}{
 		{"pi", "steering", "\r"},
-		{"pi", "follow-up", "\x1b\r"}, // Alt+Enter = ESC CR
+		{"pi", "follow-up", "\x1b[13;3u"}, // Alt+Enter, Kitty CSI-u encoding
 		{"shell", "steering", "\r"},
 		{"shell", "follow-up", "\r"},
 		{"claude", "follow-up", "\r"},

--- a/cli/gmux/cmd/gmux/cli.go
+++ b/cli/gmux/cmd/gmux/cli.go
@@ -60,9 +60,10 @@ type command struct {
 	raw       bool
 
 	// send
-	sendText *string  // literal text to type (nil = none)
-	sendKeys []string // trailing key-name tokens (Enter, C-c, ...)
-	sendWait bool     // --wait: block until the triggered turn completes
+	sendText   *string  // literal text to type (nil = none)
+	sendKeys   []string // trailing key-name tokens (Enter, C-c, ...)
+	sendWait   bool     // --wait: block until the triggered turn completes
+	sendSubmit string   // --follow-up/--steering: auto-append the adapter's submit key ("" = neither)
 
 	// send-keys (tmux-compat)
 	keysLiteral bool     // -l: treat args as literal text, not key names
@@ -275,10 +276,16 @@ func parseTail(args []string) (*command, error) {
 	return c, nil
 }
 
-// parseSend handles `gmux send [--wait] [--timeout N] [--] <id> [text]
-// [Key...]`. The first positional is the session ref; an optional
-// second positional is the literal text; any further bare tokens are
-// key-name tokens. With no text and no keys, stdin supplies the text.
+// parseSend handles `gmux send [--wait] [--timeout N]
+// [--follow-up|--steering] [--] <id> [text] [Key...]`. The first
+// positional is the session ref; an optional second positional is the
+// literal text; any further bare tokens are key-name tokens. With no
+// text and no keys, stdin supplies the text.
+//
+// --follow-up and --steering auto-append the session adapter's submit
+// keystroke (pi: Alt+Enter vs Enter), so they are mutually exclusive
+// with each other AND with trailing key tokens: the flag owns
+// submission, and `--follow-up ... Enter` would double-submit.
 //
 // Grammar (ADR 0009 decision 9, verbatim-content rule): behavior
 // modifiers precede the session ref; the ref is the first non-flag
@@ -305,6 +312,12 @@ func parseSend(args []string) (*command, error) {
 		switch {
 		case a == "--wait":
 			c.sendWait = true
+		case a == "--follow-up" || a == "--steering":
+			mode := strings.TrimPrefix(a, "--")
+			if c.sendSubmit != "" && c.sendSubmit != mode {
+				return nil, errors.New("send: --follow-up and --steering are mutually exclusive")
+			}
+			c.sendSubmit = mode
 		case a == "--timeout" || strings.HasPrefix(a, "--timeout="):
 			val := strings.TrimPrefix(a, "--timeout")
 			if val == "" {
@@ -344,6 +357,9 @@ func parseSend(args []string) (*command, error) {
 			rest = rest[1:]
 		}
 		c.sendKeys = rest
+	}
+	if c.sendSubmit != "" && len(c.sendKeys) > 0 {
+		return nil, fmt.Errorf("send: --%s appends the adapter's submit keystroke itself; pass the message as a single argument with no trailing key tokens", c.sendSubmit)
 	}
 	return c, nil
 }
@@ -549,6 +565,10 @@ Sessions (local by default; address a peer with <id>@<peer>):
   gmux send <id> <text> [Key...]    type text and/or send keys (e.g. Enter, C-c)
   gmux send --wait [--timeout N] <id> <text> [Key...]
                                     ... and block until the triggered turn ends
+  gmux send --follow-up|--steering <id> <text>
+                                    ... auto-append the adapter's submit key
+                                    (--follow-up queues after the current turn;
+                                     --steering interjects now; composes with --wait)
   gmux send-keys -t <id> <keys...>  tmux-compatible key sending
   gmux wait <id> [--timeout N]      block until an agent session is idle
        [--for-text S|--for-regex P] ... or until output matches S / P

--- a/cli/gmux/cmd/gmux/cli_test.go
+++ b/cli/gmux/cmd/gmux/cli_test.go
@@ -148,6 +148,42 @@ func TestParseCLI(t *testing.T) {
 					t.Errorf("sendWait=%v timeout=%d", c.sendWait, c.timeout)
 				}
 			}},
+		{name: "send --follow-up before ref", args: []string{"send", "--follow-up", "abc", "also do X"}, wantMode: modeSend,
+			check: func(t *testing.T, c *command) {
+				if c.sendSubmit != "follow-up" {
+					t.Errorf("sendSubmit = %q, want follow-up", c.sendSubmit)
+				}
+				if c.ref != "abc" || c.sendText == nil || *c.sendText != "also do X" || len(c.sendKeys) != 0 {
+					t.Errorf("ref=%q text=%v keys=%v", c.ref, c.sendText, c.sendKeys)
+				}
+			}},
+		{name: "send --steering before ref", args: []string{"send", "--steering", "abc", "stop, wrong file"}, wantMode: modeSend,
+			check: func(t *testing.T, c *command) {
+				if c.sendSubmit != "steering" {
+					t.Errorf("sendSubmit = %q, want steering", c.sendSubmit)
+				}
+			}},
+		{name: "send --wait --follow-up compose", args: []string{"send", "--wait", "--follow-up", "--timeout", "60", "abc", "go"}, wantMode: modeSend,
+			check: func(t *testing.T, c *command) {
+				if !c.sendWait || c.sendSubmit != "follow-up" || c.timeout != 60 {
+					t.Errorf("sendWait=%v sendSubmit=%q timeout=%d", c.sendWait, c.sendSubmit, c.timeout)
+				}
+			}},
+		{name: "send --follow-up with stdin form (ref only)", args: []string{"send", "--follow-up", "abc"}, wantMode: modeSend,
+			check: func(t *testing.T, c *command) {
+				if c.sendSubmit != "follow-up" || c.sendText != nil || len(c.sendKeys) != 0 {
+					t.Errorf("sendSubmit=%q text=%v keys=%v", c.sendSubmit, c.sendText, c.sendKeys)
+				}
+			}},
+		{name: "send literal --steering after ref is text", args: []string{"send", "abc", "--steering"}, wantMode: modeSend,
+			check: func(t *testing.T, c *command) {
+				if c.sendSubmit != "" {
+					t.Error("--steering after the ref must be literal text, not a flag")
+				}
+				if c.sendText == nil || *c.sendText != "--steering" {
+					t.Errorf("text = %v, want literal --steering", c.sendText)
+				}
+			}},
 		{name: "send dash-leading text after ref is literal (no guard)", args: []string{"send", "abc", "-v"}, wantMode: modeSend,
 			check: func(t *testing.T, c *command) {
 				if c.sendText == nil || *c.sendText != "-v" {
@@ -264,6 +300,9 @@ func TestParseCLIErrors(t *testing.T) {
 		{"send", "--wait", "--timeout", "0", "abc", "x"},       // non-positive timeout
 		{"send", "--frob", "abc"},                              // unknown leading flag
 		{"send", "--wait"},                                     // missing id (only a flag given)
+		{"send", "--follow-up", "--steering", "abc", "x"},      // submit modes are mutually exclusive
+		{"send", "--follow-up", "abc", "x", "Enter"},           // submit flag owns submission; no key tokens
+		{"send", "--steering", "abc", "C-c"},                   // keys-only form conflicts with submit flag too
 		{"daemon"},                                             // missing subcommand
 		{"daemon", "frobnicate"},                               // unknown subcommand
 		{"ls", "stray"},                                        // ls takes no positional

--- a/cli/gmux/cmd/gmux/main.go
+++ b/cli/gmux/cmd/gmux/main.go
@@ -52,7 +52,7 @@ func main() {
 	case modeAttach:
 		os.Exit(cmdAttach(cmd.ref))
 	case modeSend:
-		os.Exit(cmdSend(cmd.ref, cmd.sendText, cmd.sendKeys, cmd.sendWait, cmd.timeout))
+		os.Exit(cmdSend(cmd.ref, cmd.sendText, cmd.sendKeys, cmd.sendSubmit, cmd.sendWait, cmd.timeout))
 	case modeSendKeys:
 		os.Exit(cmdSendKeys(cmd.ref, cmd.keys, cmd.keysLiteral))
 	case modeWait:

--- a/docs/adr/0009-verb-first-cli-and-frozen-top-level-namespace.md
+++ b/docs/adr/0009-verb-first-cli-and-frozen-top-level-namespace.md
@@ -271,7 +271,12 @@ resolved CLI-side from the session's adapter name; adapters that don't
 distinguish the modes fall back to `Enter` for both (shells; agents
 like claude/codex whose `Enter` submits when idle and queues when
 busy). Nothing changes on the wire — the daemon still receives raw
-bytes.
+bytes. pi's follow-up is encoded as Kitty CSI-u Alt+Enter
+(`\x1b[13;3u`) rather than legacy ESC CR, because pi parses CSI-u
+under either negotiated keyboard protocol while ESC CR misparses as
+shift+enter (no submit) on sessions started in the foreground of a
+Kitty-protocol terminal; gmuxd's `--wait` input-must-submit guard
+recognizes the CSI-u Enter alongside `\r`.
 
 Grammar consequences: like `--wait`, the flags are recognized **only
 before the session ref** (the verbatim-content rule above). Because

--- a/docs/adr/0009-verb-first-cli-and-frozen-top-level-namespace.md
+++ b/docs/adr/0009-verb-first-cli-and-frozen-top-level-namespace.md
@@ -255,6 +255,34 @@ could only time out.
 
 [#218]: https://github.com/gmuxapp/gmux/issues/218
 
+## Amendment (2026-07-12): `send --follow-up` / `--steering` — adapter-aware submit
+
+`gmux send` gains two mutually-exclusive behavior modifiers that
+auto-append the session adapter's *submit* keystroke ([#385]):
+`--follow-up` for the queued submit (delivered after the agent's
+current turn; pi: `Alt+Enter`) and `--steering` for the immediate one
+(delivered into the current turn; pi: `Enter`). This keeps submission
+explicit (decision 10) while removing the need to know per-adapter key
+encodings — the follow-up distinction is undiscoverable, and pi's
+`Alt+Enter` (ESC CR) isn't even expressible as a `send` key token.
+
+The mapping is an adapter capability (`adapter.PromptSubmitter`),
+resolved CLI-side from the session's adapter name; adapters that don't
+distinguish the modes fall back to `Enter` for both (shells; agents
+like claude/codex whose `Enter` submits when idle and queues when
+busy). Nothing changes on the wire — the daemon still receives raw
+bytes.
+
+Grammar consequences: like `--wait`, the flags are recognized **only
+before the session ref** (the verbatim-content rule above). Because
+the flag owns submission, combining it with trailing key tokens is a
+usage error — `--follow-up … Enter` would double-submit. The flags
+compose with `--wait`; on pi the queued follow-up is processed within
+the same agent loop before idle is reported, so `--wait --follow-up`
+blocks until the queued prompt's reply, per the issue's contract.
+
+[#385]: https://github.com/gmuxapp/gmux/issues/385
+
 ## Amendment (2026-07-06): `edit` joins the top-level namespace
 
 `gmux edit [file]` is added as a top-level verb. It cannot live under a

--- a/packages/adapter/adapters/pi.go
+++ b/packages/adapter/adapters/pi.go
@@ -25,6 +25,7 @@ var (
 	_ adapter.Resumer               = (*Pi)(nil)
 	_ adapter.SessionExtender       = (*Pi)(nil)
 	_ adapter.PassthroughDetector   = (*Pi)(nil)
+	_ adapter.PromptSubmitter       = (*Pi)(nil)
 )
 
 // piSubcommands are pi's one-shot CLI verbs (`pi <verb> ...`). pi recognizes
@@ -143,6 +144,22 @@ func (p *Pi) Launchers() []adapter.Launcher {
 		Command:     []string{"pi"},
 		Description: "Coding agent",
 	}}
+}
+
+// SubmitSeq maps gmux's submit modes to pi's composer keybinds:
+// steering is Enter (\r) — delivered into the current turn immediately —
+// and follow-up is Alt+Enter (ESC CR, \x1b\r) — queued until the current
+// turn ends. Both act as a plain submit when pi is idle. The encodings
+// match what an xterm-class terminal (and the gmux web terminal, see
+// keyboard.ts) emits for those keystrokes.
+func (p *Pi) SubmitSeq(mode adapter.SubmitMode) (string, bool) {
+	switch mode {
+	case adapter.SubmitSteering:
+		return "\r", true
+	case adapter.SubmitFollowUp:
+		return "\x1b\r", true
+	}
+	return "", false
 }
 
 // Monitor is a no-op for the pi adapter — status is reported by the gmux pi

--- a/packages/adapter/adapters/pi.go
+++ b/packages/adapter/adapters/pi.go
@@ -147,17 +147,29 @@ func (p *Pi) Launchers() []adapter.Launcher {
 }
 
 // SubmitSeq maps gmux's submit modes to pi's composer keybinds:
-// steering is Enter (\r) — delivered into the current turn immediately —
-// and follow-up is Alt+Enter (ESC CR, \x1b\r) — queued until the current
-// turn ends. Both act as a plain submit when pi is idle. The encodings
-// match what an xterm-class terminal (and the gmux web terminal, see
-// keyboard.ts) emits for those keystrokes.
+// steering is Enter — delivered into the current turn immediately — and
+// follow-up is Alt+Enter — queued until the current turn ends. Both act
+// as a plain submit when pi is idle.
+//
+// Encodings are chosen to parse correctly regardless of which keyboard
+// protocol pi negotiated with its startup-attached terminal:
+//
+//   - Enter is "\r": pi-tui parses a bare CR as "enter" in both its
+//     legacy and Kitty-protocol modes.
+//   - Alt+Enter is the Kitty CSI-u encoding "\x1b[13;3u" (codepoint 13,
+//     modifier 3 = 1+alt), NOT the legacy ESC CR ("\x1b\r"): pi-tui
+//     tries CSI-u parsing unconditionally, so this reads as alt+enter
+//     in both modes — whereas ESC CR is misparsed as shift+enter
+//     (newline, no submit) whenever pi negotiated the Kitty protocol,
+//     which happens for any `gmux -- pi` started in the foreground of a
+//     Kitty-protocol terminal (kitty, ghostty, wezterm, foot). Both
+//     behaviors verified against pi-tui's parseKey and live sessions.
 func (p *Pi) SubmitSeq(mode adapter.SubmitMode) (string, bool) {
 	switch mode {
 	case adapter.SubmitSteering:
 		return "\r", true
 	case adapter.SubmitFollowUp:
-		return "\x1b\r", true
+		return "\x1b[13;3u", true
 	}
 	return "", false
 }

--- a/packages/adapter/adapters/pi_test.go
+++ b/packages/adapter/adapters/pi_test.go
@@ -191,6 +191,23 @@ func TestPiMonitorNoOp(t *testing.T) {
 	}
 }
 
+// TestPiSubmitSeq pins the composer keybinds `gmux send
+// --steering/--follow-up` relies on: steering is Enter (delivered into
+// the current turn immediately), follow-up is Alt+Enter (ESC CR — what
+// xterm-class terminals and the gmux web terminal emit), queued until
+// the current turn ends. Changing these bytes changes what agents
+// receive on those flags, so any intentional change must update this
+// test and the CLI docs together.
+func TestPiSubmitSeq(t *testing.T) {
+	pi := NewPi()
+	if seq, ok := pi.SubmitSeq(adapter.SubmitSteering); !ok || seq != "\r" {
+		t.Errorf("SubmitSeq(SubmitSteering) = %q, %v; want \\r, true", seq, ok)
+	}
+	if seq, ok := pi.SubmitSeq(adapter.SubmitFollowUp); !ok || seq != "\x1b\r" {
+		t.Errorf("SubmitSeq(SubmitFollowUp) = %q, %v; want ESC CR, true", seq, ok)
+	}
+}
+
 // --- Capability interface checks ---
 
 func TestPiImplementsCapabilities(t *testing.T) {

--- a/packages/adapter/adapters/pi_test.go
+++ b/packages/adapter/adapters/pi_test.go
@@ -193,18 +193,21 @@ func TestPiMonitorNoOp(t *testing.T) {
 
 // TestPiSubmitSeq pins the composer keybinds `gmux send
 // --steering/--follow-up` relies on: steering is Enter (delivered into
-// the current turn immediately), follow-up is Alt+Enter (ESC CR — what
-// xterm-class terminals and the gmux web terminal emit), queued until
-// the current turn ends. Changing these bytes changes what agents
-// receive on those flags, so any intentional change must update this
-// test and the CLI docs together.
+// the current turn immediately), follow-up is Alt+Enter (queued until
+// the current turn ends). Follow-up MUST be the Kitty CSI-u encoding,
+// not legacy ESC CR (\x1b\r): pi parses CSI-u under either negotiated
+// keyboard protocol, while ESC CR turns into shift+enter (newline, no
+// submit) on sessions started in the foreground of a Kitty-protocol
+// terminal. Changing these bytes changes what agents receive on those
+// flags AND must stay in sync with gmuxd's inputSubmits guard — update
+// this test, the daemon guard test, and the CLI docs together.
 func TestPiSubmitSeq(t *testing.T) {
 	pi := NewPi()
 	if seq, ok := pi.SubmitSeq(adapter.SubmitSteering); !ok || seq != "\r" {
 		t.Errorf("SubmitSeq(SubmitSteering) = %q, %v; want \\r, true", seq, ok)
 	}
-	if seq, ok := pi.SubmitSeq(adapter.SubmitFollowUp); !ok || seq != "\x1b\r" {
-		t.Errorf("SubmitSeq(SubmitFollowUp) = %q, %v; want ESC CR, true", seq, ok)
+	if seq, ok := pi.SubmitSeq(adapter.SubmitFollowUp); !ok || seq != "\x1b[13;3u" {
+		t.Errorf("SubmitSeq(SubmitFollowUp) = %q, %v; want Kitty CSI-u alt+enter, true", seq, ok)
 	}
 }
 

--- a/packages/adapter/capabilities.go
+++ b/packages/adapter/capabilities.go
@@ -197,8 +197,12 @@ const (
 // the wrong meaning.
 type PromptSubmitter interface {
 	// SubmitSeq returns the PTY byte sequence that submits a composed
-	// prompt in the given mode, exactly as an xterm-class terminal
-	// would emit for the corresponding keystroke.
+	// prompt in the given mode — the encoding of the corresponding
+	// keystroke that the adapter's tool parses most robustly (which
+	// may differ from what an xterm-class terminal emits; see the pi
+	// adapter's Kitty CSI-u choice). Sequences without a carriage
+	// return must be kept in sync with gmuxd's inputSubmits guard so
+	// `send --wait` keeps accepting them as submitting input.
 	SubmitSeq(mode SubmitMode) (seq string, ok bool)
 }
 

--- a/packages/adapter/capabilities.go
+++ b/packages/adapter/capabilities.go
@@ -172,6 +172,48 @@ type PassthroughDetector interface {
 	IsPassthrough(args []string) bool
 }
 
+// SubmitMode selects which submit keystroke ends a prompt typed into an
+// agent's composer. `gmux send --steering / --follow-up` resolves the
+// mode to concrete PTY bytes via SubmitSeqFor, so callers never need to
+// know adapter-specific key encodings (issue #385).
+type SubmitMode int
+
+const (
+	// SubmitSteering delivers the prompt into the current turn
+	// immediately (pi: Enter). On an idle agent it simply submits.
+	SubmitSteering SubmitMode = iota
+	// SubmitFollowUp queues the prompt until the current turn ends
+	// (pi: Alt+Enter). On an idle agent it degrades to a plain submit.
+	SubmitFollowUp
+)
+
+// PromptSubmitter is optionally implemented by adapters whose agent
+// distinguishes submit keystrokes by mode. Adapters that don't
+// implement it get the universal default (see SubmitSeqFor): Enter for
+// both modes — correct for shells and for agents like claude/codex,
+// where Enter both submits when idle and queues when busy. An
+// implementer may reject a mode it can't honor by returning ok=false;
+// the CLI surfaces that as a usage error instead of sending bytes with
+// the wrong meaning.
+type PromptSubmitter interface {
+	// SubmitSeq returns the PTY byte sequence that submits a composed
+	// prompt in the given mode, exactly as an xterm-class terminal
+	// would emit for the corresponding keystroke.
+	SubmitSeq(mode SubmitMode) (seq string, ok bool)
+}
+
+// SubmitSeqFor resolves the submit byte sequence for a session's
+// adapter. Nil adapters (names FindByAdapter doesn't know, e.g. a peer
+// session created by a newer gmux) and adapters without the
+// PromptSubmitter capability fall back to "\r" — Enter, the single
+// submit keystroke of every PTY application — for both modes.
+func SubmitSeqFor(a Adapter, mode SubmitMode) (string, bool) {
+	if ps, ok := a.(PromptSubmitter); ok {
+		return ps.SubmitSeq(mode)
+	}
+	return "\r", true
+}
+
 // CommandTitler is optionally implemented by adapters that want to
 // control how a command array is displayed as a fallback title.
 // Without it, the store joins the full command (e.g. "pytest -x").

--- a/packages/adapter/capabilities_test.go
+++ b/packages/adapter/capabilities_test.go
@@ -1,0 +1,45 @@
+package adapter
+
+import "testing"
+
+// fakeSubmitter implements PromptSubmitter and supports only steering,
+// exercising the reject path the capability allows for adapters that
+// can't honor a mode.
+type fakeSubmitter struct {
+	Adapter // embed to satisfy the base interface without implementing it
+}
+
+func (f *fakeSubmitter) SubmitSeq(mode SubmitMode) (string, bool) {
+	if mode == SubmitSteering {
+		return "\r", true
+	}
+	return "", false
+}
+
+// TestSubmitSeqForDefault pins the fallback contract: adapters without
+// the PromptSubmitter capability — and nil (adapter name unknown to
+// this build) — resolve to Enter for both modes. This is what makes
+// `gmux send --follow-up/--steering` work on every session out of the
+// box: Enter is the single submit keystroke of every PTY application,
+// and agents like claude/codex use it both to submit when idle and to
+// queue when busy.
+func TestSubmitSeqForDefault(t *testing.T) {
+	for _, mode := range []SubmitMode{SubmitSteering, SubmitFollowUp} {
+		if seq, ok := SubmitSeqFor(nil, mode); !ok || seq != "\r" {
+			t.Errorf("SubmitSeqFor(nil, %d) = %q, %v; want \\r, true", mode, seq, ok)
+		}
+	}
+}
+
+// TestSubmitSeqForDelegates verifies the capability is consulted when
+// present, including its right to reject a mode (ok=false), which the
+// CLI turns into a usage error instead of sending wrong-meaning bytes.
+func TestSubmitSeqForDelegates(t *testing.T) {
+	f := &fakeSubmitter{}
+	if seq, ok := SubmitSeqFor(f, SubmitSteering); !ok || seq != "\r" {
+		t.Errorf("SubmitSeqFor(fake, steering) = %q, %v; want \\r, true", seq, ok)
+	}
+	if _, ok := SubmitSeqFor(f, SubmitFollowUp); ok {
+		t.Error("SubmitSeqFor(fake, follow-up) should propagate the adapter's rejection")
+	}
+}

--- a/services/gmuxd/cmd/gmuxd/sendwait_test.go
+++ b/services/gmuxd/cmd/gmuxd/sendwait_test.go
@@ -207,6 +207,59 @@ func TestSendWaitRejectsNonSubmittingInput(t *testing.T) {
 	}
 }
 
+// TestSendWaitAcceptsKittyEnterSubmit is the regression test for
+// `gmux send --follow-up --wait` on pi: the follow-up submit is the
+// Kitty CSI-u encoding of Alt+Enter (\x1b[13;3u), which contains no
+// carriage return. The input_no_submit guard must recognize it as a
+// submit — rejecting it would break the flag composition the pi
+// adapter's SubmitSeq deliberately produces.
+func TestSendWaitAcceptsKittyEnterSubmit(t *testing.T) {
+	const id = "sess-kitty"
+	srv, st := sendWaitTestServer(t, func(st *store.Store) {
+		upsertAgent(st, id, true, &store.Status{Working: true})
+		upsertAgent(st, id, true, &store.Status{Working: false})
+	})
+	upsertAgent(st, id, true, &store.Status{Working: false})
+
+	resp, body := postInput(t, srv, id+"/input?wait=idle&timeout=2&body=prompt%1B%5B13%3B3u")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (CSI-u Enter must count as a submit)", resp.StatusCode)
+	}
+	if got := body["data"].(map[string]any)["reason"]; got != "idle" {
+		t.Errorf("reason = %v, want idle", got)
+	}
+}
+
+// TestInputSubmits pins the daemon's definition of "this input can
+// start a turn": a carriage return anywhere (xterm Enter, legacy
+// Alt+Enter = ESC CR) or a Kitty CSI-u Enter sequence (any modifier /
+// event-type shape). Non-Enter CSI-u keys and bare newlines must NOT
+// count — they never submit, so a --wait on them could only time out.
+func TestInputSubmits(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{"plain Enter", "prompt\r", true},
+		{"legacy alt+enter (ESC CR)", "prompt\x1b\r", true},
+		{"kitty alt+enter", "prompt\x1b[13;3u", true},
+		{"kitty bare enter", "prompt\x1b[13u", true},
+		{"kitty enter with event type", "prompt\x1b[13;3:1u", true},
+		{"bare newline is literal text", "prompt\n", false},
+		{"no submit at all", "prompt", false},
+		{"kitty non-enter key (alt+a)", "prompt\x1b[97;3u", false},
+		{"csi-u-looking text without ESC", "prompt[13;3u", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := inputSubmits([]byte(tc.body)); got != tc.want {
+				t.Errorf("inputSubmits(%q) = %v, want %v", tc.body, got, tc.want)
+			}
+		})
+	}
+}
+
 // TestSendWaitRejectsUnknownWaitMode: a typo'd wait mode (wait=true,
 // wait=1, ...) must fail loudly rather than silently degrading to
 // fire-and-forget — the caller believes it waited for the reply.

--- a/services/gmuxd/cmd/gmuxd/wait.go
+++ b/services/gmuxd/cmd/gmuxd/wait.go
@@ -430,9 +430,9 @@ func handleInputWait(w http.ResponseWriter, r *http.Request, sessions *store.Sto
 			"the "+sess.Adapter+" adapter does not emit an idle signal; --wait is only supported for agent sessions")
 		return
 	}
-	if !bytes.ContainsRune(body, '\r') {
+	if !inputSubmits(body) {
 		writeError(w, http.StatusUnprocessableEntity, "input_no_submit",
-			"input does not submit (no carriage return \\r; a bare newline \\n is treated as literal text, not a submit); "+
+			"input does not submit (no carriage return \\r or Enter key sequence; a bare newline \\n is treated as literal text, not a submit); "+
 				"add a trailing Enter key or drop --wait")
 		return
 	}
@@ -462,6 +462,24 @@ func handleInputWait(w http.ResponseWriter, r *http.Request, sessions *store.Sto
 		writeJSON(w, map[string]any{"ok": true, "data": map[string]any{"reason": reason}})
 		// reason == "" and !timedOut: client disconnected; nothing to write.
 	}
+}
+
+// kittyEnterRe matches the Kitty keyboard protocol's CSI-u encoding of
+// the Enter key (codepoint 13) with optional modifier and event-type
+// fields: ESC [ 13 [;mod[:event]] u. `gmux send --follow-up` on a pi
+// session sends Alt+Enter in this encoding (\x1b[13;3u) because pi
+// parses it correctly under either negotiated keyboard protocol — see
+// the pi adapter's SubmitSeq.
+var kittyEnterRe = regexp.MustCompile(`\x1b\[13(?:;[0-9]+(?::[0-9]+)?)?u`)
+
+// inputSubmits reports whether the input bytes contain a submit
+// keystroke — something that can start a turn. A carriage return is
+// what xterm-class terminals send for Enter (bare or Alt-modified); the
+// CSI-u form is Enter under the Kitty keyboard protocol. Anything else
+// is text the agent just buffers, so a --wait on it could only ever
+// time out; handleInputWait rejects it up front.
+func inputSubmits(body []byte) bool {
+	return bytes.ContainsRune(body, '\r') || kittyEnterRe.Match(body)
 }
 
 // awaitTurn blocks until the session completes a turn: a Working=true

--- a/skills/gmux/SKILL.md
+++ b/skills/gmux/SKILL.md
@@ -18,6 +18,8 @@ gmux -d -- <cmd> [args]      # run detached; prints the session id on stdout
 gmux send <id> 'text' Enter  # type text and submit (Enter is explicit)
 gmux send <id> C-c           # send a control key (interrupt), no text
 gmux send --wait <id> 'text' Enter  # send AND block until the reply is done
+gmux send --follow-up <id> 'text'   # queue a prompt for after the current turn
+gmux send --steering <id> 'text'    # interject a prompt into the current turn
 gmux wait <id>               # block until the agent finishes its turn
 gmux wait <id> --for-text S  # block until S appears in the output
 gmux tail <id> [-n N]        # last N lines of output (ANSI stripped; default 100)
@@ -51,7 +53,25 @@ Key names follow tmux: `Enter`, `Tab`, `Escape`, `Up`/`Down`/`Left`/`Right`,
 
 **Everything after the id is verbatim** — including dash-leading tokens, so
 `gmux send $id -v` sends a literal `-v` with no `--` guard needed. `send`'s own
-flags (`--wait`, `--timeout`) only work *before* the id.
+flags (`--wait`, `--timeout`, `--follow-up`, `--steering`) only work *before*
+the id.
+
+### Prompting a busy agent: `--follow-up` vs `--steering`
+
+When the target is an AI agent mid-turn, plain `Enter` vs the adapter's
+queued-submit keystroke mean different things. Instead of memorizing
+per-agent keybinds, use the mode flags — gmux appends the right submit
+keystroke for the session's adapter (mutually exclusive; no trailing key
+tokens; text only):
+
+```bash
+gmux send --follow-up $id 'then also update the changelog'  # runs after this turn
+gmux send --steering $id 'stop — wrong branch, use main'    # delivered right now
+gmux send --wait --follow-up $id 'next task'  # waits for the queued turn's reply
+```
+
+On an idle agent both are a plain submit. For agents whose Enter already
+queues while busy (claude, codex) and for shells, both flags map to `Enter`.
 
 ## Sequential orchestration
 


### PR DESCRIPTION
## Problem

Sending a prompt to an agent session requires knowing adapter-specific submit keybinds. For pi, `Enter` steers (delivered into the current turn immediately) while `Alt+Enter` queues a follow-up (delivered after the turn ends). That distinction is undiscoverable, non-portable across adapters — and pi's `Alt+Enter` (ESC CR) isn't even expressible as a `gmux send` key token (the key vocabulary has no Alt combos).

Closes #385

## Design

**Adapter capability, resolved CLI-side, zero wire changes.**

- New capability in `packages/adapter`: `PromptSubmitter` with `SubmitSeq(mode) (seq, ok)` and two modes, `SubmitSteering` / `SubmitFollowUp`. The helper `SubmitSeqFor(a, mode)` falls back to `"\r"` (Enter — the universal PTY submit) for adapters without the capability and for nil/unknown adapter names.
- pi implements it: steering → `\r` (Enter), follow-up → `\x1b[13;3u` — **Alt+Enter in the Kitty CSI-u encoding, not legacy ESC CR**. pi-tui parses `\x1b\r` as alt+enter only in legacy keyboard mode; when pi negotiated the Kitty keyboard protocol with its startup-attached terminal (any foreground `gmux -- pi` in kitty/ghostty/wezterm/foot), `\x1b\r` misparses as shift+enter (newline, never submits). pi runs its CSI-u parser unconditionally, so `\x1b[13;3u` reads as alt+enter under **both** modes. Verified empirically on live sessions in both modes (Kitty mode reproduced by faking the `\x1b[?1u` negotiation response): ESC CR left the prompt unsubmitted, CSI-u submitted.
- One small daemon change follows from that encoding: the CSI-u sequence carries no `\r`, so `input?wait=idle`'s input-must-submit guard (`input_no_submit`) now recognizes a Kitty CSI-u Enter sequence alongside a carriage return (`inputSubmits` in `wait.go`, unit-tested). Version skew is safe: a new CLI against an old daemon fails loudly with 422, never silently.
- `gmux send` gains `--follow-up` / `--steering` (before the ref, per ADR 0009's verbatim-content rule). The CLI resolves the session, maps its adapter name → submit bytes, and appends them to the input body. The daemon keeps receiving raw bytes on the existing `/input` endpoint (no wire/protocol change).

### Semantics

- Mutually exclusive with each other, and with trailing key tokens (`send --follow-up <id> 'x' Enter` is a usage error — the flag owns submission; combining would double-submit).
- Works with piped stdin (`echo prompt | gmux send --follow-up <id>`).
- Works for peer sessions for free: the adapter name travels with the session record; the peer just gets bytes.
- Adapters that don't distinguish the modes get `Enter` for both — genuinely correct for shells and for claude/codex, whose `Enter` submits when idle and queues when busy. An adapter may reject a mode (`ok=false`); the CLI surfaces that as an error instead of sending wrong-meaning bytes. No current adapter rejects.
- **`--follow-up --wait` needs no daemon change**: I verified in pi's source that the agent loop drains the steering and follow-up queues *before* emitting `agent_end` ("The agent loop drains both queues before emitting agent_end", agent-session.js), so `Working` stays true across a queued follow-up and the existing `input?wait=idle` turn-tracking (#218/#371) already blocks until the queued prompt's reply. Also verified: pi treats `Alt+Enter` as plain `Enter` when idle, so `--follow-up` on an idle agent degrades to a normal submit; and both sequences end in `\r`, satisfying `--wait`'s input-must-submit guard.

### Alternatives considered

1. **Daemon-side mapping** (`POST /input?submit=follow-up`): needs a wire addition plus peer query forwarding; rejected since the CLI already has the adapter name and the result is plain bytes.
2. **Add `M-<key>`/`Alt+<key>` key tokens** instead of modes: keeps the per-adapter-keybind burden on the caller — the exact problem the issue wants removed. Could still be added independently later.
3. **Rejecting the flags on non-distinguishing adapters**: the issue explicitly allows mapping both to the single submit; defaulting to Enter makes the flags universally usable.

## Tests

- `packages/adapter/capabilities_test.go`: default fallback (nil + non-implementing adapters), capability delegation and rejection propagation.
- `packages/adapter/adapters/pi_test.go`: pins pi's two byte sequences.
- CLI parse tests: flag placement, mutual exclusions (both flags; flag + key tokens), composition with `--wait --timeout`, stdin form, and literal `--steering` *after* the ref staying verbatim text.
- `actions_test.go`: adapter-name → sequence mapping incl. unknown adapters; `buildSendBody` composition of text/stdin + submit sequence.
- Verified the new parse tests fail without the parser change (red/green).
- Manual e2e against live sessions: `send --steering` / `--follow-up` submit correctly (shell fallback path).
- `go test ./...` + `go vet` green in `packages/adapter`, `cli/gmux`, `services/gmuxd`.

## Docs

- CLI reference (`reference/cli.md`), `skills/gmux/SKILL.md`, `writing-adapters.md` (new capability section + composition table), and an ADR 0009 amendment for the grammar growth.

## Notes for sibling work (not implemented here)

- #373 (shell OSC prompt events): once shells have turn semantics, the shell adapter could implement `PromptSubmitter` with different choices.
- ADR 0021 / ACP gateway: `session/prompt` ↔ `send --follow-up`; `SubmitSeqFor` is now the single seam where that keystroke translation lives, reusable by the gateway and the web UI.
- Discovered while verifying: the web UI's alt-armed send uses legacy `\x1b\r` and shares the Kitty-mode limitation described above for sessions that negotiated the protocol with another attached terminal — candidate follow-up fix (switch it to CSI-u), not done here to keep the diff tight.
