### PR TITLE
feat: unified turn model — every session gets active/idle/waiting-on-you and works with gmux wait

### DIFF
--- a/UBIQUITOUS_LANGUAGE.md
+++ b/UBIQUITOUS_LANGUAGE.md
@@ -23,6 +23,17 @@
 | **Attributed**          | Tool-backed session whose adapter file exists, giving it a real slug                                | Named                  |
 | **Fast-exit**           | A runner whose child finished before gmuxd's `queryMeta` reaches it; lands in the store as Alive=false directly, never as Alive=true | Quick-exit |
 
+## Turn model (ADR 0023)
+
+| Term                    | Definition                                                                                          | Aliases to avoid       |
+| ----------------------- | --------------------------------------------------------------------------------------------------- | ---------------------- |
+| **Turn**                | One unit of "the session is doing something": an agent turn (hook-delimited), a shell command (prompt-mark-delimited), or — default — the whole process lifetime. `Status.Working` is its open/closed state | Task, job              |
+| **Turn source**         | Where a session's turn boundaries come from: agent hook for `HookDriven` adapters, otherwise the runner's default model (lifetime, upgraded by observed OSC 133 prompt marks) | —                      |
+| **Active**              | Turn open (`Status.Working == true`); the blue dot. Distinct from *Alive* (process exists) and from the transient output-activity pulse | Busy, working (in prose) |
+| **Idle**                | Turn closed; what `gmux wait` waits for. Includes a closed turn at process exit (one-shot completed, shell exited at its prompt) | Done, finished         |
+| **Waiting on you**      | Unread flag set by a turn close; cleared when the session is viewed                                 | Unread (in UI prose)   |
+| **Upgrade**             | A default-model session's switch from lifetime-as-turn to per-command turns on the first observed OSC 133 prompt mark; permanent for the session's life | Promotion              |
+
 ## Components
 
 | Term            | Definition                                                                                       | Aliases to avoid            |

--- a/apps/website/src/content/docs/develop/adapter-architecture.md
+++ b/apps/website/src/content/docs/develop/adapter-architecture.md
@@ -25,7 +25,7 @@ That split is why the adapter system is a set of small interfaces instead of one
 | Adapter availability detection | `gmuxd` | `Adapter.Discover()` |
 | Command matching | `gmux` | `Adapter.Match()` |
 | Child env injection | `gmux` | `Adapter.Env()` |
-| PTY output monitoring | `gmux` | `Adapter.Monitor()` |
+| Turn state (default model) | `gmux` | launch/exit lifecycle + OSC 133 prompt marks (non-hook-driven adapters) |
 | Child self-report API | `gmux` | Unix socket HTTP endpoints |
 | Launch menu discovery | `gmuxd` | `Launchable` + compiled adapter set |
 | Conversation metadata resolution | `gmuxd` | `ConversationDescriber` |
@@ -43,7 +43,7 @@ When you run a command through `gmux`:
    - otherwise shell fallback
 2. `gmux` starts the child under a PTY
 3. `gmux` injects the standard `GMUX_*` environment variables
-4. `gmux` feeds PTY output into `Adapter.Monitor()`
+4. `gmux` applies the default turn model for non-hook-driven adapters (active from launch; OSC 133 prompt marks upgrade to per-command turns)
 5. `gmux` serves the session on its Unix socket (`/meta`, `/events`, terminal attach, child callbacks)
 6. `gmuxd` discovers the runner socket (the runner registers itself; a periodic scan is the fallback), queries `/meta`, and subscribes to `/events`
 
@@ -71,7 +71,6 @@ type Adapter interface {
     Discover() bool
     Match(command []string) bool
     Env(ctx EnvContext) []string
-    Monitor(output []byte) *Event // partial update: title, status, unread, cwd
 }
 ```
 
@@ -254,11 +253,11 @@ This is the escape hatch for tools that want native gmux integration without nee
 
 A session's displayed state can come from multiple places:
 
-- process lifecycle defaults from gmux itself
-- adapter PTY monitoring via `Monitor()` (a no-op for the hooked agent adapters)
-- runner-tracked OSC 133 prompt marks for `PromptSignaler` adapters (shell: busy on command start, idle when the prompt returns)
-- authoritative agent-hook reports (held file, title, status)
+- the runner's default turn model for non-hook-driven adapters: active from launch, per-command turns once OSC 133 prompt marks are observed (shell: busy on command start, idle when the prompt returns), turn closed by process exit otherwise
+- authoritative agent-hook reports (held file, title, status) for hook-driven adapters
 - direct child callbacks via `PUT /status`
+
+There is deliberately no per-byte PTY inference by adapter code; status sources are declarative (hooks, marks, lifecycle) so they cannot flicker on TUI redraws.
 
 The important design point is that adapters do not own the whole session model. They contribute structured hints into a runner-owned session state that `gmuxd` then aggregates and serves.
 

--- a/apps/website/src/content/docs/develop/adapter-architecture.md
+++ b/apps/website/src/content/docs/develop/adapter-architecture.md
@@ -256,6 +256,7 @@ A session's displayed state can come from multiple places:
 
 - process lifecycle defaults from gmux itself
 - adapter PTY monitoring via `Monitor()` (a no-op for the hooked agent adapters)
+- runner-tracked OSC 133 prompt marks for `PromptSignaler` adapters (shell: busy on command start, idle when the prompt returns)
 - authoritative agent-hook reports (held file, title, status)
 - direct child callbacks via `PUT /status`
 

--- a/apps/website/src/content/docs/develop/terminal-data-pipeline.mdx
+++ b/apps/website/src/content/docs/develop/terminal-data-pipeline.mdx
@@ -43,7 +43,7 @@ The bytes pass through the kernel's PTY layer before reaching the master file de
 
 The `readPTY()` goroutine reads chunks from the PTY master fd. It coalesces rapid bursts (up to 8ms or 32KB) into a single chunk to reduce WebSocket message count, then:
 
-1. Runs adapter hooks (OSC title parsing, `Adapter.Monitor`)
+1. Runs adapter hooks (OSC title parsing, `Adapter.Monitor`, OSC 133 prompt-mark status tracking for `PromptSignaler` adapters)
 2. Appends the chunk to a pending buffer that feeds the **virtual terminal emulator** (drained asynchronously every 100ms, and synchronously when a client connects)
 3. Emits an activity signal when no client is watching
 4. Copies the chunk to the **local TTY** output (if attached)

--- a/apps/website/src/content/docs/develop/terminal-data-pipeline.mdx
+++ b/apps/website/src/content/docs/develop/terminal-data-pipeline.mdx
@@ -43,7 +43,7 @@ The bytes pass through the kernel's PTY layer before reaching the master file de
 
 The `readPTY()` goroutine reads chunks from the PTY master fd. It coalesces rapid bursts (up to 8ms or 32KB) into a single chunk to reduce WebSocket message count, then:
 
-1. Runs adapter hooks (OSC title parsing, `Adapter.Monitor`, OSC 133 prompt-mark status tracking for `PromptSignaler` adapters)
+1. Runs output hooks (OSC title parsing; OSC 133 prompt-mark turn tracking for sessions of non-hook-driven adapters)
 2. Appends the chunk to a pending buffer that feeds the **virtual terminal emulator** (drained asynchronously every 100ms, and synchronously when a client connects)
 3. Emits an activity signal when no client is watching
 4. Copies the chunk to the **local TTY** output (if attached)

--- a/apps/website/src/content/docs/develop/writing-adapters.md
+++ b/apps/website/src/content/docs/develop/writing-adapters.md
@@ -214,6 +214,18 @@ Optional lifecycle callbacks: `OnRegister` runs at registration time (return a s
 
 Optional. Marks one-shot invocations (e.g. `pi update`, `pi --version`) that should be exec'd directly instead of wrapped in a session. Implement this for CLI tools with management subcommands.
 
+### `PromptSignaler`
+
+```go
+type PromptSignaler interface {
+    StatusFromPromptMarks() bool
+}
+```
+
+Optional. Opt in to have the **runner** derive the session's busy/idle `Status` from OSC 133 prompt marks ("semantic prompt" sequences) in the PTY output: `Working` flips true when a command starts executing (`133;C`) and false when the command finishes / the next prompt is drawn (`133;D` / `133;A`). The shell adapter implements this — it's what gives shell sessions an idle signal for `gmux wait` and `gmux send --wait`.
+
+Don't combine this with hook- or `Monitor()`-driven status: the two sources would fight over `Status`. The marks come from the user's shell integration, so sessions only report status once marks are actually observed; the tracking lives in the runner (not `Monitor()`) so that a fast command's busy and idle marks arriving in a single PTY read still emit both transitions.
+
 ### `Resumer`
 
 ```go
@@ -260,7 +272,7 @@ An adapter implements only what it needs:
 
 | Adapter | Base | Launchable | ConversationDescriber | ConversationSource | Resumer | Other |
 |---------|------|------------|-----------------------|--------------------|---------|-------|
-| Shell | ✓ | ✓ | ✓ | — | ✓ | CommandTitler, SessionRegistrar, SessionFinalizer |
+| Shell | ✓ | ✓ | ✓ | — | ✓ | CommandTitler, SessionRegistrar, SessionFinalizer, PromptSignaler |
 | Editor | ✓ | ✓ | — | — | — | CommandTitler, SessionRegistrar |
 | Claude | ✓ | ✓ | ✓ | ✓ | ✓ | ConversationOpener, ConversationProber, SessionHookCommand |
 | Codex | ✓ | ✓ | ✓ | ✓ | ✓ | ConversationOpener, ConversationProber, SessionHookCommand |

--- a/apps/website/src/content/docs/develop/writing-adapters.md
+++ b/apps/website/src/content/docs/develop/writing-adapters.md
@@ -40,8 +40,6 @@ func (m *MyApp) Match(cmd []string) bool {
 }
 
 func (m *MyApp) Env(_ adapter.EnvContext) []string { return nil }
-
-func (m *MyApp) Monitor(output []byte) *adapter.Event { return nil }
 ```
 
 That's enough for a valid adapter. It:
@@ -49,8 +47,12 @@ That's enough for a valid adapter. It:
 - reports whether the tool is available on this machine with `Discover()`
 - activates when the command matches `myapp`
 - contributes no extra environment yet
-- reports no events yet
 - is available for richer optional capabilities later
+
+Sessions of a minimal adapter automatically get the runner's **default turn
+model**: active (`Working=true`) from launch, upgraded to per-command turns
+if the output ever carries OSC 133 prompt marks, otherwise idle when the
+process exits — which is what makes `gmux wait` work on them out of the box.
 
 Write tests in `myapp_test.go` alongside it.
 
@@ -79,7 +81,7 @@ Adapters may expose zero, one, or many launch presets. The built-in shell fallba
 
 ## The base interface
 
-Every adapter implements five methods:
+Every adapter implements four methods:
 
 ```go
 type Adapter interface {
@@ -87,7 +89,6 @@ type Adapter interface {
     Discover() bool
     Match(command []string) bool
     Env(ctx EnvContext) []string
-    Monitor(output []byte) *Event
 }
 ```
 
@@ -99,31 +100,22 @@ type Adapter interface {
 
 **`Env(ctx)`** returns extra environment variables for the child. The runner already sets `GMUX`, `GMUX_SOCKET`, `GMUX_SESSION_ID`, `GMUX_ADAPTER`, and `GMUX_RUNNER_VERSION`. Most adapters return `nil`.
 
-**`Monitor(output)`** receives raw PTY bytes on every read. Return a `*Event` when something meaningful happens, `nil` otherwise. This runs frequently, so keep it cheap. The built-in agent adapters (pi/claude/codex) return `nil` here — their status comes from the agent hook, not PTY parsing.
+Note there is deliberately **no per-byte PTY inference hook**: adapters never parse output to guess state. Session status comes from exactly three sources — agent hooks (for `SessionExtender`/`SessionHookCommand` adapters), the runner's default turn model (everything else: OSC 133 prompt marks when present, process lifetime otherwise), and the child's explicit `PUT /status` escape hatch.
 
 ### Important: adapters do not rewrite the user's command
 
 The command the user typed is what runs. `Env()` can add environment variables; adapters don't inject flags or wrap the process. The only sanctioned argv change is the hook-injection seam (`SessionExtender`/`SessionHookCommand`, below), which the runner drives.
 
-## Reporting events
-
-Return an `Event` from `Monitor()` to update the session. Zero/nil fields are no-ops — only explicitly set fields are applied:
+## Session status
 
 ```go
-type Event struct {
-    Title  string  // non-empty: update the adapter title
-    Status *Status // non-nil: update status; &Status{} clears it
-    Unread *bool   // non-nil: set or clear the unread flag (adapter.BoolPtr)
-    Cwd    string  // non-empty: update the session's canonical directory
-}
-
 type Status struct {
     Working bool // true while the tool is busy (pulsing dot)
     Error   bool // true on a retryable error (red dot)
 }
 ```
 
-Status carries only booleans; any display text is derived by the frontend from these plus the exit code.
+Status carries only booleans; any display text is derived by the frontend from these plus the exit code. `Status.Working` is the session's **turn state**: hooks flip it for agents, and the runner's default turn model flips it for everything else.
 
 ## Adapter resolution
 
@@ -214,17 +206,9 @@ Optional lifecycle callbacks: `OnRegister` runs at registration time (return a s
 
 Optional. Marks one-shot invocations (e.g. `pi update`, `pi --version`) that should be exec'd directly instead of wrapped in a session. Implement this for CLI tools with management subcommands.
 
-### `PromptSignaler`
+### Turn state: hooks or the default model
 
-```go
-type PromptSignaler interface {
-    StatusFromPromptMarks() bool
-}
-```
-
-Optional. Opt in to have the **runner** derive the session's busy/idle `Status` from OSC 133 prompt marks ("semantic prompt" sequences) in the PTY output: `Working` flips true when a command starts executing (`133;C`) and false when the command finishes / the next prompt is drawn (`133;D` / `133;A`). The shell adapter implements this — it's what gives shell sessions an idle signal for `gmux wait` and `gmux send --wait`.
-
-Don't combine this with hook- or `Monitor()`-driven status: the two sources would fight over `Status`. The marks come from the user's shell integration, so sessions only report status once marks are actually observed; the tracking lives in the runner (not `Monitor()`) so that a fast command's busy and idle marks arriving in a single PTY read still emit both transitions.
+There is no capability for status. Sessions of adapters that implement `SessionExtender` or `SessionHookCommand` (`adapter.HookDriven`) get their turn state exclusively from the agent hook. Every other adapter's sessions run the runner's default turn model: `Working=true` from launch; OSC 133 prompt marks ("semantic prompt" sequences) in the output — `133;C` busy, `133;A`/`133;D` idle — upgrade the session to per-command turns; without marks, the process exit closes the single lifetime turn (idle + unread, error on non-zero exit). The upgrade is evidence-based rather than declared, so `bash -c script` one-shots and mark-emitting `ssh` sessions both classify correctly, whatever adapter matched them.
 
 ### `Resumer`
 
@@ -272,7 +256,7 @@ An adapter implements only what it needs:
 
 | Adapter | Base | Launchable | ConversationDescriber | ConversationSource | Resumer | Other |
 |---------|------|------------|-----------------------|--------------------|---------|-------|
-| Shell | ✓ | ✓ | ✓ | — | ✓ | CommandTitler, SessionRegistrar, SessionFinalizer, PromptSignaler |
+| Shell | ✓ | ✓ | ✓ | — | ✓ | CommandTitler, SessionRegistrar, SessionFinalizer |
 | Editor | ✓ | ✓ | — | — | — | CommandTitler, SessionRegistrar |
 | Claude | ✓ | ✓ | ✓ | ✓ | ✓ | ConversationOpener, ConversationProber, SessionHookCommand |
 | Codex | ✓ | ✓ | ✓ | ✓ | ✓ | ConversationOpener, ConversationProber, SessionHookCommand |
@@ -284,7 +268,7 @@ A house pattern worth copying: assert your capabilities at compile time — `var
 
 ## Testing
 
-Write unit tests in `myapp_test.go` next to your adapter. Test `Match()` with different command shapes and `Monitor()` with representative output (if it does anything).
+Write unit tests in `myapp_test.go` next to your adapter. Test `Match()` with different command shapes, and any capability methods with representative inputs.
 
 If the adapter implements `Launchable`, test the returned launcher IDs, labels, and commands.
 

--- a/apps/website/src/content/docs/planned/opencode-adapter.md
+++ b/apps/website/src/content/docs/planned/opencode-adapter.md
@@ -19,7 +19,7 @@ Implement the core `Adapter` and `Launchable` interfaces.
 - **Binary**: `opencode`
 - **Match**: scan command args for `opencode` (same pattern as claude/codex)
 - **Discover**: `exec.LookPath("opencode")`
-- **Monitor**: no-op. OpenCode uses a full-screen bubbletea TUI with animated spinners, making PTY byte parsing unreliable for status detection.
+- **Turn state**: no PTY parsing (OpenCode's animated bubbletea TUI makes byte inference unreliable); until a hook exists, sessions run the runner's default turn model.
 - **Launcher**: `{ id: "opencode", label: "OpenCode", command: ["opencode"], description: "Coding Agent" }`
 
 This is enough for sessions to appear in gmux and be launchable from the UI. No working/idle status, no session discovery, no resume.

--- a/apps/website/src/content/docs/reference/cli.md
+++ b/apps/website/src/content/docs/reference/cli.md
@@ -234,13 +234,15 @@ command starts executing and idle when the next prompt is drawn. The marks
 come from your shell's integration — **fish** emits them out of the box;
 bash and zsh need an integration snippet (the same one used by kitty, VS
 Code, or WezTerm semantic prompts — e.g. for zsh, emit `\e]133;A\a` in
-`precmd` and `\e]133;C\a` in `preexec`). A shell session that has not yet
-emitted any prompt mark has no idle signal, so a plain `gmux wait` (no output
-condition) rejects it with a clear error rather than hanging forever; use
-`--for-text`/`--for-regex`, or run the command through the blocking piped
+`precmd` and `\e]133;C\a` in `preexec`). A *running* shell session that has not
+yet emitted any prompt mark has no idle signal, so a plain `gmux wait` (no
+output condition) rejects it with a clear error rather than hanging forever;
+use `--for-text`/`--for-regex`, or run the command through the blocking piped
 form (`gmux -- make build < /dev/null`) instead. The same applies to one-shot
-`gmux -- <cmd>` sessions, which never draw a prompt. Idle wait is local-only
-for now (peer support is pending).
+`gmux -- <cmd>` sessions, which never draw a prompt — though once any session
+has *exited*, `wait` resolves immediately with exit code `2` (idle includes
+process exit) instead of rejecting. Idle wait is local-only for now (peer
+support is pending).
 
 ### `gmux kill <id>`
 

--- a/apps/website/src/content/docs/reference/cli.md
+++ b/apps/website/src/content/docs/reference/cli.md
@@ -176,10 +176,11 @@ gmux send --wait a3f20187 'do the thing' Enter        # block until the reply la
 gmux send --wait --timeout 600 a3f20187 'go' Enter    # ...or fail after 600s
 ```
 
-Like `gmux wait`, `--wait` works for agent sessions and for shell sessions
-whose shell integration emits OSC 133 prompt marks (see [`gmux
-wait`](#gmux-wait-id)); for a shell it blocks until the command you sent
-finishes and the prompt returns. Local sessions only for now.
+Like `gmux wait`, `--wait` works for every session (see [`gmux
+wait`](#gmux-wait-id)): for an agent it blocks until the reply lands; for a
+shell whose integration emits OSC 133 prompt marks, until the command you
+sent finishes and the prompt returns; for anything else, until the process
+exits. Local sessions only for now.
 
 For verbatim tmux compatibility there's also `gmux send-keys -t <id> <keys...>`
 (all arguments are key names by default; `-l` sends them as literal text).
@@ -195,8 +196,9 @@ authenticated proxy.
 
 Block until the session is **idle**, optionally bounded by `--timeout N`. For
 an agent session, idle means its current turn finished (the spinner stops);
-for a shell session, it means the command finished and the shell is back at a
-fresh prompt.
+for a shell session, that the command finished and the shell is back at a
+fresh prompt; for a one-shot command (`gmux -d -- pnpm test`), that the
+process exited.
 
 ```bash
 gmux send a3f20187 'do the thing' Enter
@@ -204,14 +206,22 @@ gmux wait a3f20187
 gmux wait a3f20187 --timeout 600   # or fail after 600s
 ```
 
-The idle signal is the same `Status.Working` flag the UI's spinner consumes.
-Agents source it from their turn hooks, so `wait` returns the moment the agent
-emits its closing message; shells source it from OSC 133 prompt marks (see
-below). Exit codes (so scripts can branch on the outcome):
+The idle signal is the same `Status.Working` flag the UI's spinner consumes
+— the session's **turn state**. Agents source it from their turn hooks, so
+`wait` returns the moment the agent emits its closing message; shells source
+it from OSC 133 prompt marks (see below); every other session is one
+lifetime-long turn that closes when the process exits. Exit codes (so
+scripts can branch on the outcome):
 
-- `0` — the agent reached idle, or the output condition matched
-- `2` — the session exited before becoming idle / before its output matched
+- `0` — the session reached idle (turn finished — including a one-shot
+  command completing or a shell exiting at its prompt), or the output
+  condition matched
+- `2` — the session exited with its turn still open (crashed mid-command /
+  mid-turn) / exited before its output matched
 - `3` — `--timeout` elapsed
+
+The verdict is stable across timing: a `wait` issued after the session
+already exited answers the same as one that watched it live.
 
 **Output conditions.** Instead of the idle signal, wait until specific text
 appears in the session's output:
@@ -225,23 +235,20 @@ gmux wait a3f20187 --for-regex 'error: \d+'       # Go regexp match
 is a usage error. The match runs **server-side** against gmuxd's on-disk
 scrollback (matched per rendered, ANSI-stripped line), so nothing scrolls past
 unseen between polls (loss is bounded by the scrollback cap, not a poll
-interval). Output conditions work for **every** adapter, shell sessions
-included — unlike the idle wait below.
+interval).
 
-**Shell sessions.** A shell's idle signal comes from OSC 133 prompt marks
-("semantic prompt" sequences): the runner flips the session busy when a
-command starts executing and idle when the next prompt is drawn. The marks
-come from your shell's integration — **fish** emits them out of the box;
-bash and zsh need an integration snippet (the same one used by kitty, VS
-Code, or WezTerm semantic prompts — e.g. for zsh, emit `\e]133;A\a` in
-`precmd` and `\e]133;C\a` in `preexec`). A *running* shell session that has not
-yet emitted any prompt mark has no idle signal, so a plain `gmux wait` (no
-output condition) rejects it with a clear error rather than hanging forever;
-use `--for-text`/`--for-regex`, or run the command through the blocking piped
-form (`gmux -- make build < /dev/null`) instead. The same applies to one-shot
-`gmux -- <cmd>` sessions, which never draw a prompt — though once any session
-has *exited*, `wait` resolves immediately with exit code `2` (idle includes
-process exit) instead of rejecting. Idle wait is local-only for now (peer
+**Shell sessions.** A shell's per-command idle signal comes from OSC 133
+prompt marks ("semantic prompt" sequences): the runner flips the session
+busy when a command starts executing and idle when the next prompt is
+drawn. The marks come from your shell's integration — **fish** emits them
+out of the box; bash and zsh need an integration snippet (the same one used
+by kitty, VS Code, or WezTerm semantic prompts — e.g. for zsh, emit
+`\e]133;A\a` in `precmd` and `\e]133;C\a` in `preexec`). A session whose
+output never carries the marks — a one-shot `gmux -- <cmd>`, or an
+interactive shell without integration — stays on the lifetime turn: `wait`
+blocks until the process exits. For an interactive shell that can mean
+"forever" (it is never provably idle), so bound the wait with `--timeout`
+or use `--for-text`/`--for-regex`. Idle wait is local-only for now (peer
 support is pending).
 
 ### `gmux kill <id>`

--- a/apps/website/src/content/docs/reference/cli.md
+++ b/apps/website/src/content/docs/reference/cli.md
@@ -176,7 +176,10 @@ gmux send --wait a3f20187 'do the thing' Enter        # block until the reply la
 gmux send --wait --timeout 600 a3f20187 'go' Enter    # ...or fail after 600s
 ```
 
-Like `gmux wait`, `--wait` is agent-only and local-only for now.
+Like `gmux wait`, `--wait` works for agent sessions and for shell sessions
+whose shell integration emits OSC 133 prompt marks (see [`gmux
+wait`](#gmux-wait-id)); for a shell it blocks until the command you sent
+finishes and the prompt returns. Local sessions only for now.
 
 For verbatim tmux compatibility there's also `gmux send-keys -t <id> <keys...>`
 (all arguments are key names by default; `-l` sends them as literal text).
@@ -190,8 +193,10 @@ authenticated proxy.
 
 ### `gmux wait <id>`
 
-Block until an **agent** session finishes its current turn (its spinner stops),
-optionally bounded by `--timeout N`.
+Block until the session is **idle**, optionally bounded by `--timeout N`. For
+an agent session, idle means its current turn finished (the spinner stops);
+for a shell session, it means the command finished and the shell is back at a
+fresh prompt.
 
 ```bash
 gmux send a3f20187 'do the thing' Enter
@@ -199,9 +204,10 @@ gmux wait a3f20187
 gmux wait a3f20187 --timeout 600   # or fail after 600s
 ```
 
-The idle signal is the same `Status.Working` flag the UI's spinner consumes,
-so `wait` returns the moment the agent emits its closing message. Exit codes
-(so scripts can branch on the outcome):
+The idle signal is the same `Status.Working` flag the UI's spinner consumes.
+Agents source it from their turn hooks, so `wait` returns the moment the agent
+emits its closing message; shells source it from OSC 133 prompt marks (see
+below). Exit codes (so scripts can branch on the outcome):
 
 - `0` — the agent reached idle, or the output condition matched
 - `2` — the session exited before becoming idle / before its output matched
@@ -222,10 +228,19 @@ unseen between polls (loss is bounded by the scrollback cap, not a poll
 interval). Output conditions work for **every** adapter, shell sessions
 included — unlike the idle wait below.
 
-Plain **shell** sessions have no idle signal, so a plain `gmux wait` (no output
-condition) rejects them with a clear error; use `--for-text`/`--for-regex`, or
-run the command through the blocking piped form (`gmux -- make build <
-/dev/null`) instead. Idle wait is local-only for now (peer support is pending).
+**Shell sessions.** A shell's idle signal comes from OSC 133 prompt marks
+("semantic prompt" sequences): the runner flips the session busy when a
+command starts executing and idle when the next prompt is drawn. The marks
+come from your shell's integration — **fish** emits them out of the box;
+bash and zsh need an integration snippet (the same one used by kitty, VS
+Code, or WezTerm semantic prompts — e.g. for zsh, emit `\e]133;A\a` in
+`precmd` and `\e]133;C\a` in `preexec`). A shell session that has not yet
+emitted any prompt mark has no idle signal, so a plain `gmux wait` (no output
+condition) rejects it with a clear error rather than hanging forever; use
+`--for-text`/`--for-regex`, or run the command through the blocking piped
+form (`gmux -- make build < /dev/null`) instead. The same applies to one-shot
+`gmux -- <cmd>` sessions, which never draw a prompt. Idle wait is local-only
+for now (peer support is pending).
 
 ### `gmux kill <id>`
 

--- a/cli/gmux/cmd/gmux/cli.go
+++ b/cli/gmux/cmd/gmux/cli.go
@@ -570,7 +570,7 @@ Sessions (local by default; address a peer with <id>@<peer>):
                                     (--follow-up queues after the current turn;
                                      --steering interjects now; composes with --wait)
   gmux send-keys -t <id> <keys...>  tmux-compatible key sending
-  gmux wait <id> [--timeout N]      block until an agent session is idle
+  gmux wait <id> [--timeout N]      block until the session is idle
        [--for-text S|--for-regex P] ... or until output matches S / P
   gmux kill <id>                    terminate a session
 

--- a/cli/gmux/cmd/gmux/run.go
+++ b/cli/gmux/cmd/gmux/run.go
@@ -401,25 +401,14 @@ func runSession(args []string, attach bool, dir runDirectives) {
 
 	exitCode := srv.ExitCode()
 
-	// Close the lifetime turn before announcing the exit. For sessions
-	// that never emitted prompt marks the exit IS the turn end (`gmux --
-	// pnpm test`): emit idle (+error on non-zero exit) and flag unread,
-	// so waits resolve as "idle" and the sidebar shows "waiting on you"
-	// — exactly like an agent finishing its turn. Sessions upgraded to
-	// prompt-cycle turns keep their last mark-derived state: exiting at
-	// the prompt already reads idle, dying mid-command stays working and
-	// resolves as "died". Wait for the final PTY flush first so a mark
-	// in the child's last bytes still counts (bounded; idempotent with
-	// the interactive path's earlier drain).
+	// Wait for the final PTY flush before reading LifetimeTurnOpen, so a
+	// prompt mark in the child's last bytes still counts (bounded;
+	// idempotent with the interactive path's earlier drain).
 	select {
 	case <-srv.PTYDone():
 	case <-time.After(ptyDrainTimeout):
 	}
-	if srv.LifetimeTurnOpen() {
-		state.SetStatus(&adapter.Status{Working: false, Error: exitCode != 0})
-		state.SetUnread(true)
-	}
-	state.SetExited(exitCode)
+	finalizeSessionState(state, srv.LifetimeTurnOpen(), exitCode)
 
 	// Wait for the register/handshake goroutine to finish before we
 	// touch deregister or exit. Otherwise a fast-exiting command
@@ -437,6 +426,29 @@ func runSession(args []string, attach bool, dir runDirectives) {
 		fmt.Printf("exited:   %d\n", exitCode)
 	}
 	os.Exit(exitCode)
+}
+
+// finalizeSessionState records the child's exit on the session state,
+// closing the lifetime turn first when it is still open. For sessions
+// that never emitted prompt marks the exit IS the turn end (`gmux --
+// pnpm test`): emit idle (+error on a non-zero exit code) and flag
+// unread, so waits resolve as "idle" and the sidebar shows "waiting on
+// you" — exactly like an agent finishing its turn. Sessions upgraded
+// to prompt-cycle turns keep their last mark-derived state: exiting at
+// the prompt already reads idle, dying mid-command stays working and
+// resolves as "died" (ADR 0023).
+//
+// The ordering is load-bearing: the turn-close status and unread
+// events must be emitted before the exit event, so a subscriber (the
+// daemon's wait machinery) that resolves on the first terminal signal
+// it sees observes the closed turn, and the store's exit handling
+// persists the final Status rather than a stale mid-turn one.
+func finalizeSessionState(state *session.State, lifetimeTurnOpen bool, exitCode int) {
+	if lifetimeTurnOpen {
+		state.SetStatus(&adapter.Status{Working: false, Error: exitCode != 0})
+		state.SetUnread(true)
+	}
+	state.SetExited(exitCode)
 }
 
 // sessionEditorEnv returns EDITOR/VISUAL entries pointing at `gmux

--- a/cli/gmux/cmd/gmux/run.go
+++ b/cli/gmux/cmd/gmux/run.go
@@ -308,6 +308,16 @@ func runSession(args []string, attach bool, dir runDirectives) {
 
 	state.SetRunning(srv.Pid())
 
+	// Default turn model (non-hook-driven adapters): the session is
+	// active from launch. Prompt marks — if the child's shell
+	// integration emits them — upgrade it to per-command turns inside
+	// the ptyserver; otherwise this one lifetime-long turn is closed by
+	// the exit handling below. Agent adapters skip this: their hooks own
+	// Working, and a launch-time true would misreport an idle agent.
+	if !adapter.HookDriven(a) {
+		state.SetStatus(&adapter.Status{Working: true})
+	}
+
 	if !interactive {
 		fmt.Printf("pid:      %d\n", srv.Pid())
 		fmt.Printf("socket:   %s\n", srv.SocketPath())
@@ -390,6 +400,25 @@ func runSession(args []string, attach bool, dir runDirectives) {
 	}
 
 	exitCode := srv.ExitCode()
+
+	// Close the lifetime turn before announcing the exit. For sessions
+	// that never emitted prompt marks the exit IS the turn end (`gmux --
+	// pnpm test`): emit idle (+error on non-zero exit) and flag unread,
+	// so waits resolve as "idle" and the sidebar shows "waiting on you"
+	// — exactly like an agent finishing its turn. Sessions upgraded to
+	// prompt-cycle turns keep their last mark-derived state: exiting at
+	// the prompt already reads idle, dying mid-command stays working and
+	// resolves as "died". Wait for the final PTY flush first so a mark
+	// in the child's last bytes still counts (bounded; idempotent with
+	// the interactive path's earlier drain).
+	select {
+	case <-srv.PTYDone():
+	case <-time.After(ptyDrainTimeout):
+	}
+	if srv.LifetimeTurnOpen() {
+		state.SetStatus(&adapter.Status{Working: false, Error: exitCode != 0})
+		state.SetUnread(true)
+	}
 	state.SetExited(exitCode)
 
 	// Wait for the register/handshake goroutine to finish before we

--- a/cli/gmux/cmd/gmux/run_test.go
+++ b/cli/gmux/cmd/gmux/run_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gmuxapp/gmux/cli/gmux/internal/session"
+	"github.com/gmuxapp/gmux/packages/adapter"
+)
+
+// collectEvents drains n events from ch (or times out), returning the
+// event types in arrival order plus the payloads for inspection.
+func collectEvents(t *testing.T, ch chan session.Event, n int) []session.Event {
+	t.Helper()
+	var got []session.Event
+	timeout := time.After(2 * time.Second)
+	for len(got) < n {
+		select {
+		case ev := <-ch:
+			got = append(got, ev)
+		case <-timeout:
+			t.Fatalf("timed out after %d/%d events: %+v", len(got), n, got)
+		}
+	}
+	return got
+}
+
+// TestFinalizeSessionStateClosesLifetimeTurnBeforeExit pins the
+// event ordering the daemon's wait machinery depends on (ADR 0023): a
+// lifetime-turn session's exit must emit the turn-close status and the
+// unread flag BEFORE the exit event. A subscriber that resolves on the
+// first terminal signal it sees must observe the closed turn, and the
+// store's exit handling must persist the final Status — emitting the
+// exit first would resolve waits as "died" and persist a stale
+// mid-turn Working=true.
+func TestFinalizeSessionStateClosesLifetimeTurnBeforeExit(t *testing.T) {
+	st := session.New(session.Config{ID: "sess-finalize", Adapter: "shell"})
+	st.SetStatus(&adapter.Status{Working: true}) // launch state, pre-subscription
+	ch := st.Subscribe()
+	defer st.Unsubscribe(ch)
+
+	finalizeSessionState(st, true, 3)
+
+	got := collectEvents(t, ch, 3)
+	wantTypes := []string{"status", "meta", "exit"}
+	for i, ev := range got {
+		if ev.Type != wantTypes[i] {
+			t.Fatalf("event %d = %q, want %q (order: %v)", i, ev.Type, wantTypes[i], got)
+		}
+	}
+	status, ok := got[0].Data.(*adapter.Status)
+	if !ok || status == nil || status.Working {
+		t.Errorf("turn-close status = %#v, want Working=false", got[0].Data)
+	}
+	if !status.Error {
+		t.Error("Error = false for exit code 3, want true (failed one-shot shows the error dot)")
+	}
+	if !st.UnreadSnapshot() {
+		t.Error("unread not set; a completed lifetime turn is 'waiting on you'")
+	}
+}
+
+// TestFinalizeSessionStateLeavesUpgradedTurnAlone: a session whose
+// turns are mark-delimited (lifetimeTurnOpen == false) must get only
+// the exit event — its last mark-derived Status is the truth. A shell
+// killed mid-command stays Working=true and resolves as "died"; one
+// that exited at its prompt already reads idle.
+func TestFinalizeSessionStateLeavesUpgradedTurnAlone(t *testing.T) {
+	st := session.New(session.Config{ID: "sess-upgraded", Adapter: "shell"})
+	st.SetStatus(&adapter.Status{Working: true}) // mid-command
+	ch := st.Subscribe()
+	defer st.Unsubscribe(ch)
+
+	finalizeSessionState(st, false, 0)
+
+	got := collectEvents(t, ch, 1)
+	if got[0].Type != "exit" {
+		t.Fatalf("first event = %q, want exit (and nothing before it)", got[0].Type)
+	}
+	if s := st.StatusSnapshot(); s == nil || !s.Working {
+		t.Errorf("Status = %+v, want the mark-derived Working=true preserved", s)
+	}
+	if st.UnreadSnapshot() {
+		t.Error("unread set on a mid-turn death; nothing completed")
+	}
+}

--- a/cli/gmux/cmd/gmux/wait.go
+++ b/cli/gmux/cmd/gmux/wait.go
@@ -117,15 +117,16 @@ func cmdWait(ref string, timeoutSecs int, forText, forRegex string) int {
 		fmt.Fprintf(os.Stderr, "gmux: wait timed out after %ds\n", timeoutSecs)
 		return waitExitTimeout
 	case http.StatusUnprocessableEntity:
-		// Adapter doesn't emit an idle signal. Surface the
-		// daemon's message so the user knows which adapter they hit.
+		// Current daemons only send 422 on the send --wait path
+		// (input_no_submit); older daemons also rejected sessions
+		// without an idle signal here. Surface the daemon's message
+		// either way — it explains what to change.
 		body, _ := io.ReadAll(resp.Body)
 		fmt.Fprintf(os.Stderr, "gmux: wait not supported for this session: %s\n",
 			extractMessage(body))
 		return 1
 	case http.StatusNotFound:
-		// Distinct from "no idle signal": means the session id is
-		// unknown to gmuxd entirely.
+		// Means the session id is unknown to gmuxd entirely.
 		fmt.Fprintf(os.Stderr, "gmux: session %s not found\n", displayID(sess))
 		return 1
 	default:

--- a/cli/gmux/cmd/gmux/wait.go
+++ b/cli/gmux/cmd/gmux/wait.go
@@ -13,10 +13,11 @@ import (
 // Exit codes from cmdWait. Distinct codes let scripts dispatch on the
 // reason a wait ended without parsing strings.
 //
-//   - waitExitOK (0): session reached a Working == false state (idle
-//     wait) or its output matched --for-text/--for-regex
-//   - waitExitDied (2): session crashed, was killed, or exited before
-//     going idle / before its output matched
+//   - waitExitOK (0): the session's turn closed (idle wait — including
+//     a one-shot command completing or a shell exiting at its prompt)
+//     or its output matched --for-text/--for-regex
+//   - waitExitDied (2): session crashed / was killed / exited with its
+//     turn still open, or exited before its output matched
 //   - waitExitTimeout (3): --timeout elapsed
 //
 // Any other usage / network error returns 1, matching the rest of the
@@ -33,9 +34,8 @@ const (
 // The wait itself happens server-side: gmuxd already subscribes to
 // per-session events for its own bookkeeping, so we just hand it the
 // session id and block on the HTTP response. That keeps the CLI free
-// of SSE-parsing logic and ensures the idle-detection rules (which
-// adapter kinds emit Status.Working, what counts as "died") live in
-// one place. Output conditions equally belong server-side: the bytes
+// of SSE-parsing logic and ensures the idle-detection rules (how turn
+// state resolves, what counts as "died") live in one place. Output conditions equally belong server-side: the bytes
 // live in the daemon's scrollback tee, and matching there can't miss
 // output the way client-side scrollback polling could.
 //

--- a/cli/gmux/internal/ptyserver/extension_test.go
+++ b/cli/gmux/internal/ptyserver/extension_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/gmuxapp/gmux/cli/gmux/internal/session"
+	"github.com/gmuxapp/gmux/packages/adapter"
 	"github.com/gmuxapp/gmux/packages/adapter/adapters"
 )
 
@@ -477,4 +478,62 @@ func TestApplyTurnEnd(t *testing.T) {
 			t.Errorf("%s: error=%v want %v", tc.outcome, status.Error, tc.wantError)
 		}
 	}
+}
+
+// TestReconnectReplaysStatus pins that a (re)connecting /events
+// subscriber is replayed the current Status snapshot. Status emitted
+// before the daemon subscribed would otherwise be invisible until the
+// next transition — which for the default turn model's launch-time
+// Working=true (one transition per lifetime) means never: the daemon
+// would see every one-shot as stateless until it exited.
+func TestReconnectReplaysStatus(t *testing.T) {
+	dir := t.TempDir()
+	sockPath := filepath.Join(dir, "test.sock")
+
+	st := session.New(session.Config{ID: "s1", Adapter: "shell", SocketPath: sockPath})
+	srv, err := New(Config{
+		Command:    []string{"sleep", "3"},
+		Cwd:        dir,
+		Listener:   mustBindSocket(t, sockPath),
+		SocketPath: sockPath,
+		Adapter:    adapters.NewShell(),
+		State:      st,
+	})
+	if err != nil {
+		t.Fatalf("new server: %v", err)
+	}
+	defer srv.Shutdown()
+
+	// Status set BEFORE anyone subscribes — as run.go does at launch.
+	// No other writer exists in this test, so the only way a subscriber
+	// can learn it is the replay.
+	st.SetStatus(&adapter.Status{Working: true})
+
+	client := &http.Client{Transport: &http.Transport{
+		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			return net.Dial("unix", sockPath)
+		},
+	}}
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+	defer cancel()
+	req, _ := http.NewRequestWithContext(ctx, "GET", "http://unix/events", nil)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("connect /events: %v", err)
+	}
+	defer resp.Body.Close()
+
+	sc := bufio.NewScanner(resp.Body)
+	sawStatusEvent := false
+	for sc.Scan() {
+		line := sc.Text()
+		if strings.HasPrefix(line, "event: status") {
+			sawStatusEvent = true
+			continue
+		}
+		if sawStatusEvent && strings.Contains(line, `"working":true`) {
+			return // success: status snapshot replayed on subscribe
+		}
+	}
+	t.Error("reconnecting subscriber did not receive the replayed status snapshot")
 }

--- a/cli/gmux/internal/ptyserver/promptmarks_test.go
+++ b/cli/gmux/internal/ptyserver/promptmarks_test.go
@@ -86,7 +86,6 @@ func (plainAdapter) Name() string                      { return "plain" }
 func (plainAdapter) Discover() bool                    { return true }
 func (plainAdapter) Match(_ []string) bool             { return true }
 func (plainAdapter) Env(_ adapter.EnvContext) []string { return nil }
-func (plainAdapter) Monitor(_ []byte) *adapter.Event   { return nil }
 
 // TestPromptMarksIgnoredForNonSignalerAdapters guards the capability
 // gate: OSC 133 marks in the output of an adapter that doesn't opt in

--- a/cli/gmux/internal/ptyserver/promptmarks_test.go
+++ b/cli/gmux/internal/ptyserver/promptmarks_test.go
@@ -78,29 +78,34 @@ func TestShellPromptMarksDriveStatus(t *testing.T) {
 	}
 }
 
-// plainAdapter is a minimal adapter that does NOT implement
-// adapter.PromptSignaler, standing in for any non-shell adapter.
-type plainAdapter struct{}
+// hookedAdapter is a minimal hook-driven adapter (SessionExtender),
+// standing in for the agent adapters whose turn state is owned by
+// their hooks.
+type hookedAdapter struct{}
 
-func (plainAdapter) Name() string                      { return "plain" }
-func (plainAdapter) Discover() bool                    { return true }
-func (plainAdapter) Match(_ []string) bool             { return true }
-func (plainAdapter) Env(_ adapter.EnvContext) []string { return nil }
+func (hookedAdapter) Name() string                      { return "hooked" }
+func (hookedAdapter) Discover() bool                    { return true }
+func (hookedAdapter) Match(_ []string) bool             { return true }
+func (hookedAdapter) Env(_ adapter.EnvContext) []string { return nil }
+func (hookedAdapter) ExtendCommand(args []string, _ string) []string {
+	return args
+}
 
-// TestPromptMarksIgnoredForNonSignalerAdapters guards the capability
-// gate: OSC 133 marks in the output of an adapter that doesn't opt in
-// via PromptSignaler must not touch Status (agent adapters own their
-// Status via hooks; a stray mark must not fight them).
-func TestPromptMarksIgnoredForNonSignalerAdapters(t *testing.T) {
+// TestPromptMarksIgnoredForHookDrivenAdapters guards the turn-source
+// split: OSC 133 marks in the output of a hook-driven (agent) adapter
+// must not touch Status — the agent's hook is the sole owner of its
+// turn state, and a stray mark (e.g. printed by a tool the agent ran)
+// must not fight it.
+func TestPromptMarksIgnoredForHookDrivenAdapters(t *testing.T) {
 	sockPath := filepath.Join(t.TempDir(), "test.sock")
-	st := session.New(session.Config{ID: "sess-nomarks", Adapter: "plain"})
+	st := session.New(session.Config{ID: "sess-nomarks", Adapter: "hooked"})
 
 	srv, err := New(Config{
 		Command:    []string{"bash", "-c", `printf '\e]133;C\a\e]133;A\a'`},
 		Cwd:        "/tmp",
 		Listener:   mustBindSocket(t, sockPath),
 		SocketPath: sockPath,
-		Adapter:    plainAdapter{},
+		Adapter:    hookedAdapter{},
 		State:      st,
 	})
 	if err != nil {
@@ -114,6 +119,89 @@ func TestPromptMarksIgnoredForNonSignalerAdapters(t *testing.T) {
 		t.Fatal("child did not exit in time")
 	}
 	if got := st.StatusSnapshot(); got != nil {
-		t.Errorf("Status = %+v, want nil for a non-PromptSignaler adapter", got)
+		t.Errorf("Status = %+v, want nil for a hook-driven adapter", got)
+	}
+	if srv.LifetimeTurnOpen() {
+		t.Error("LifetimeTurnOpen() = true for a hook-driven session; the default turn model must not apply")
+	}
+}
+
+// TestPromptCycleSetsUnreadOnCommandCompletion pins the "waiting on
+// you" parity rule: a genuine working→idle prompt cycle flags the
+// session unread (like an agent's completed turn), while the shell's
+// initial prompt — also an idle transition — does not.
+func TestPromptCycleSetsUnreadOnCommandCompletion(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "test.sock")
+	st := session.New(session.Config{ID: "sess-unread", Adapter: "shell"})
+
+	ch := st.Subscribe()
+	defer st.Unsubscribe(ch)
+
+	srv, err := New(Config{
+		Command: []string{"bash", "-c",
+			// First prompt, pause (flush), then a full command cycle.
+			`printf '\e]133;A\a$ '; sleep 0.3; printf '\e]133;C\adone\n\e]133;D;0\a\e]133;A\a$ '`},
+		Cwd:        "/tmp",
+		Listener:   mustBindSocket(t, sockPath),
+		SocketPath: sockPath,
+		Adapter:    adapters.NewShell(),
+		State:      st,
+	})
+	if err != nil {
+		t.Fatalf("new server: %v", err)
+	}
+	defer srv.Shutdown()
+
+	// After the first idle transition (initial prompt): no unread.
+	if got := collectStatusEvents(t, ch, 1, 3*time.Second); len(got) != 1 || got[0] {
+		t.Fatalf("first transition = %v, want [false]", got)
+	}
+	if st.UnreadSnapshot() {
+		t.Error("unread = true after initial prompt; want false (no command completed yet)")
+	}
+
+	// After the full working→idle cycle: unread.
+	if got := collectStatusEvents(t, ch, 2, 3*time.Second); len(got) != 2 || got[0] != true || got[1] != false {
+		t.Fatalf("cycle transitions = %v, want [true false]", got)
+	}
+	if !st.UnreadSnapshot() {
+		t.Error("unread = false after a completed prompt cycle; want true (waiting on you)")
+	}
+	if srv.LifetimeTurnOpen() {
+		t.Error("LifetimeTurnOpen() = true after prompt marks were observed; session should be upgraded")
+	}
+}
+
+// TestLifetimeTurnStaysOpenWithoutMarks pins the default turn model's
+// upgrade signal: a session whose output never carries prompt marks
+// keeps its lifetime turn open (run.go closes it at exit — that's what
+// resolves waits on one-shot commands as "idle").
+func TestLifetimeTurnStaysOpenWithoutMarks(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "test.sock")
+	st := session.New(session.Config{ID: "sess-lifetime", Adapter: "shell"})
+
+	srv, err := New(Config{
+		Command:    []string{"bash", "-c", `echo plain output, no marks`},
+		Cwd:        "/tmp",
+		Listener:   mustBindSocket(t, sockPath),
+		SocketPath: sockPath,
+		Adapter:    adapters.NewShell(),
+		State:      st,
+	})
+	if err != nil {
+		t.Fatalf("new server: %v", err)
+	}
+	defer srv.Shutdown()
+
+	select {
+	case <-srv.PTYDone():
+	case <-time.After(3 * time.Second):
+		t.Fatal("child did not exit in time")
+	}
+	if !srv.LifetimeTurnOpen() {
+		t.Error("LifetimeTurnOpen() = false for a markless session; want true (exit closes the turn)")
+	}
+	if st.UnreadSnapshot() {
+		t.Error("unread = true without any completed turn; want false (exit-close is run.go's job)")
 	}
 }

--- a/cli/gmux/internal/ptyserver/promptmarks_test.go
+++ b/cli/gmux/internal/ptyserver/promptmarks_test.go
@@ -1,0 +1,120 @@
+package ptyserver
+
+import (
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/gmuxapp/gmux/cli/gmux/internal/session"
+	"github.com/gmuxapp/gmux/packages/adapter"
+	"github.com/gmuxapp/gmux/packages/adapter/adapters"
+)
+
+// collectStatusEvents drains status events from ch until want
+// transitions arrived or the deadline passed, returning the observed
+// Working sequence.
+func collectStatusEvents(t *testing.T, ch chan session.Event, want int, deadline time.Duration) []bool {
+	t.Helper()
+	var got []bool
+	timeout := time.After(deadline)
+	for len(got) < want {
+		select {
+		case ev, ok := <-ch:
+			if !ok {
+				return got
+			}
+			if ev.Type != "status" {
+				continue
+			}
+			status, ok := ev.Data.(*adapter.Status)
+			if !ok || status == nil {
+				t.Fatalf("status event with unexpected payload %#v", ev.Data)
+			}
+			got = append(got, status.Working)
+		case <-timeout:
+			return got
+		}
+	}
+	return got
+}
+
+// TestShellPromptMarksDriveStatus is the runner-side integration test
+// for issue #373: a shell session whose output carries OSC 133 prompt
+// marks gets busy/idle Status transitions derived by the runner. The
+// fast second phase prints the command-start and prompt-start marks in
+// one burst (a single PTY read), pinning the property that the full
+// working→idle pulse is emitted as two distinct status events — that
+// pulse is what the daemon's send --wait keys on.
+func TestShellPromptMarksDriveStatus(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "test.sock")
+	st := session.New(session.Config{ID: "sess-promptmarks", Adapter: "shell"})
+
+	// Subscribe before launch so no transition can be missed.
+	ch := st.Subscribe()
+	defer st.Unsubscribe(ch)
+
+	srv, err := New(Config{
+		Command: []string{"bash", "-c",
+			// Phase 1: first prompt (idle). Phase 2, after the coalesce
+			// window has flushed: a fast command cycle whose C and D+A
+			// marks land in one chunk.
+			`printf '\e]133;A\a$ '; sleep 0.3; printf '\e]133;C\adone\n\e]133;D;0\a\e]133;A\a$ '; sleep 0.2`},
+		Cwd:        "/tmp",
+		Listener:   mustBindSocket(t, sockPath),
+		SocketPath: sockPath,
+		Adapter:    adapters.NewShell(),
+		State:      st,
+	})
+	if err != nil {
+		t.Fatalf("new server: %v", err)
+	}
+	defer srv.Shutdown()
+
+	got := collectStatusEvents(t, ch, 3, 5*time.Second)
+	want := []bool{false, true, false}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("status transitions = %v, want %v", got, want)
+	}
+}
+
+// plainAdapter is a minimal adapter that does NOT implement
+// adapter.PromptSignaler, standing in for any non-shell adapter.
+type plainAdapter struct{}
+
+func (plainAdapter) Name() string                      { return "plain" }
+func (plainAdapter) Discover() bool                    { return true }
+func (plainAdapter) Match(_ []string) bool             { return true }
+func (plainAdapter) Env(_ adapter.EnvContext) []string { return nil }
+func (plainAdapter) Monitor(_ []byte) *adapter.Event   { return nil }
+
+// TestPromptMarksIgnoredForNonSignalerAdapters guards the capability
+// gate: OSC 133 marks in the output of an adapter that doesn't opt in
+// via PromptSignaler must not touch Status (agent adapters own their
+// Status via hooks; a stray mark must not fight them).
+func TestPromptMarksIgnoredForNonSignalerAdapters(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "test.sock")
+	st := session.New(session.Config{ID: "sess-nomarks", Adapter: "plain"})
+
+	srv, err := New(Config{
+		Command:    []string{"bash", "-c", `printf '\e]133;C\a\e]133;A\a'`},
+		Cwd:        "/tmp",
+		Listener:   mustBindSocket(t, sockPath),
+		SocketPath: sockPath,
+		Adapter:    plainAdapter{},
+		State:      st,
+	})
+	if err != nil {
+		t.Fatalf("new server: %v", err)
+	}
+	defer srv.Shutdown()
+
+	select {
+	case <-srv.PTYDone():
+	case <-time.After(3 * time.Second):
+		t.Fatal("child did not exit in time")
+	}
+	if got := st.StatusSnapshot(); got != nil {
+		t.Errorf("Status = %+v, want nil for a non-PromptSignaler adapter", got)
+	}
+}

--- a/cli/gmux/internal/ptyserver/ptyserver.go
+++ b/cli/gmux/internal/ptyserver/ptyserver.go
@@ -191,10 +191,11 @@ type Server struct {
 	screen          *vt.Emulator  // virtual terminal for replay snapshots (guarded by mu)
 	screenDrainDone chan struct{} // closed when the DSR drain goroutine exits
 	state           *session.State
-	// promptMarks derives Status from OSC 133 prompt marks for adapters
-	// that opt in via adapter.PromptSignaler (the shell adapter). Nil for
-	// everything else. Fed exclusively from readPTY's flush, so it needs
-	// no locking.
+	// promptMarks derives Status from OSC 133 prompt marks for every
+	// session whose adapter is not hook-driven (adapter.HookDriven — the
+	// agent adapters own their turn state via hooks; everything else gets
+	// the runner's default turn model). Nil for hook-driven sessions. Fed
+	// exclusively from readPTY's flush, so it needs no locking.
 	promptMarks *adapter.PromptMarkTracker
 
 	shutdownOnce sync.Once
@@ -366,16 +367,28 @@ func New(cfg Config) (*Server, error) {
 		s.cursorHidden = !visible
 	})
 
-	// Adapters that opt in (shell) get their busy/idle Status derived
-	// from OSC 133 prompt marks in the output stream: Working=true when
-	// a command starts executing, false when the next prompt returns.
+	// Non-hook-driven sessions get their busy/idle Status derived from
+	// OSC 133 prompt marks in the output stream: Working=true when a
+	// command starts executing, false when the next prompt returns.
 	// Each transition is a separate SetStatus call, so a fast command
 	// whose marks land in a single PTY read still emits the full
 	// working→idle pulse downstream — the daemon's send --wait requires
 	// observing both edges (issue #373).
-	if ps, ok := cfg.Adapter.(adapter.PromptSignaler); ok && ps.StatusFromPromptMarks() && cfg.State != nil {
+	//
+	// A genuine working→idle transition is a completed turn, so it also
+	// flags the session unread ("waiting on you") — the same policy
+	// applyTurnEnd implements for agent turns. The first idle mark (the
+	// shell's initial prompt) closes only the launch phase, not a
+	// command the user is waiting on, so it does not set unread.
+	if !adapter.HookDriven(cfg.Adapter) && cfg.State != nil {
+		sawWorking := false
 		s.promptMarks = adapter.NewPromptMarkTracker(func(working bool) {
 			s.state.SetStatus(&adapter.Status{Working: working})
+			if working {
+				sawWorking = true
+			} else if sawWorking {
+				s.state.SetUnread(true)
+			}
 		})
 	}
 
@@ -385,6 +398,15 @@ func New(cfg Config) (*Server, error) {
 	go s.serve()
 
 	return s, nil
+}
+
+// LifetimeTurnOpen reports whether this session is still on the
+// default lifetime-as-turn model (no prompt marks ever observed), so
+// the process exit is what closes its single turn. The caller (run.go)
+// emits the closing status/unread before SetExited. Only meaningful
+// after the final PTY flush — read it after PTYDone.
+func (s *Server) LifetimeTurnOpen() bool {
+	return s.promptMarks != nil && !s.promptMarks.SawMark()
 }
 
 // drainScreenLocked feeds all pending raw PTY data to the virtual terminal
@@ -826,6 +848,18 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 	// Replay the bound conversation ref to this (possibly reconnecting) subscriber
 	// so a restarted daemon re-learns attribution with no persisted state. A
 	// concurrent update may also arrive on ch; harmless (idempotent).
+	// Replay the current status snapshot so a (re)connecting daemon
+	// starts from the session's actual turn state. Without this, any
+	// status emitted before the subscription — the launch-time
+	// Working=true of the default turn model, or an agent turn that
+	// started while the daemon was down — would be invisible until the
+	// next transition.
+	if st := s.state.StatusSnapshot(); st != nil {
+		if data, err := json.Marshal(st); err == nil {
+			fmt.Fprintf(w, "event: status\ndata: %s\n\n", data)
+		}
+	}
+
 	if file := s.state.ConversationRefSnapshot(); file != "" {
 		if data, err := json.Marshal(map[string]string{"path": file}); err == nil {
 			fmt.Fprintf(w, "event: conversation_file\ndata: %s\n\n", data)

--- a/cli/gmux/internal/ptyserver/ptyserver.go
+++ b/cli/gmux/internal/ptyserver/ptyserver.go
@@ -190,7 +190,6 @@ type Server struct {
 	listener        net.Listener
 	screen          *vt.Emulator  // virtual terminal for replay snapshots (guarded by mu)
 	screenDrainDone chan struct{} // closed when the DSR drain goroutine exits
-	adapter         adapter.Adapter
 	state           *session.State
 	// promptMarks derives Status from OSC 133 prompt marks for adapters
 	// that opt in via adapter.PromptSignaler (the shell adapter). Nil for
@@ -352,7 +351,6 @@ func New(cfg Config) (*Server, error) {
 		sockPath:   cfg.SocketPath,
 		listener:   listener,
 		screen:     nil, // set below after s is constructed
-		adapter:    cfg.Adapter,
 		state:      cfg.State,
 		clients:    make(map[*wsClient]struct{}),
 		localOut:   cfg.LocalOut,   // wired before readPTY starts so early output is never lost
@@ -1112,16 +1110,6 @@ func (s *Server) readPTY() {
 		// Process adapter/title hooks on the accumulated chunk.
 		if title := adapters.ParseOSCTitle(data); title != "" {
 			s.state.SetShellTitle(title)
-		}
-		if s.adapter != nil {
-			if ev := s.adapter.Monitor(data); ev != nil {
-				if ev.Title != "" {
-					s.state.SetAdapterTitle(ev.Title)
-				}
-				if ev.Status != nil {
-					s.state.SetStatus(ev.Status)
-				}
-			}
 		}
 		if s.promptMarks != nil {
 			s.promptMarks.Feed(data)

--- a/cli/gmux/internal/ptyserver/ptyserver.go
+++ b/cli/gmux/internal/ptyserver/ptyserver.go
@@ -192,6 +192,11 @@ type Server struct {
 	screenDrainDone chan struct{} // closed when the DSR drain goroutine exits
 	adapter         adapter.Adapter
 	state           *session.State
+	// promptMarks derives Status from OSC 133 prompt marks for adapters
+	// that opt in via adapter.PromptSignaler (the shell adapter). Nil for
+	// everything else. Fed exclusively from readPTY's flush, so it needs
+	// no locking.
+	promptMarks *adapter.PromptMarkTracker
 
 	shutdownOnce sync.Once
 
@@ -362,6 +367,19 @@ func New(cfg Config) (*Server, error) {
 	s.screen, s.screenDrainDone = newScreen(int(cfg.Cols), int(cfg.Rows), func(visible bool) {
 		s.cursorHidden = !visible
 	})
+
+	// Adapters that opt in (shell) get their busy/idle Status derived
+	// from OSC 133 prompt marks in the output stream: Working=true when
+	// a command starts executing, false when the next prompt returns.
+	// Each transition is a separate SetStatus call, so a fast command
+	// whose marks land in a single PTY read still emits the full
+	// working→idle pulse downstream — the daemon's send --wait requires
+	// observing both edges (issue #373).
+	if ps, ok := cfg.Adapter.(adapter.PromptSignaler); ok && ps.StatusFromPromptMarks() && cfg.State != nil {
+		s.promptMarks = adapter.NewPromptMarkTracker(func(working bool) {
+			s.state.SetStatus(&adapter.Status{Working: working})
+		})
+	}
 
 	go s.readPTY()
 	go s.waitChild()
@@ -1104,6 +1122,9 @@ func (s *Server) readPTY() {
 					s.state.SetStatus(ev.Status)
 				}
 			}
+		}
+		if s.promptMarks != nil {
+			s.promptMarks.Feed(data)
 		}
 
 		// Queue data for the virtual terminal emulator (processed by

--- a/cli/gmux/internal/session/state.go
+++ b/cli/gmux/internal/session/state.go
@@ -265,6 +265,9 @@ func (s *State) SlugSnapshot() string {
 
 // StatusSnapshot returns a copy of the current status (nil if unset), safe to
 // read from another goroutine while the runner concurrently updates state.
+// Also replayed to every (re)connecting /events subscriber: status emitted
+// before the daemon subscribed (the launch-time Working=true of the default
+// turn model, or a turn started during a daemon restart) must not be lost.
 func (s *State) StatusSnapshot() *adapter.Status {
 	s.mu.RLock()
 	defer s.mu.RUnlock()

--- a/docs/adr/0023-unified-turn-model.md
+++ b/docs/adr/0023-unified-turn-model.md
@@ -1,0 +1,92 @@
+# ADR 0023: unified turn model — one session state machine, per-adapter turn sources
+
+**Status:** Accepted
+**Date:** 2026-07-13
+**Related:** ADR 0011 (runner-owned session state), ADR 0013 (codex hooks), ADR 0015 (hook translation at the agent side), issue #373 (shell idle waits)
+
+## Context
+
+Session liveness signals were split by adapter kind, each with its own
+mechanism and its own gaps:
+
+- **Agent sessions** (pi/claude/codex) got full turn semantics from their
+  hooks: `Status.Working` during a turn, unread ("waiting on you") and an
+  optional error dot when the turn ends.
+- **Shell sessions** got `Status.Working` from runner-tracked OSC 133 prompt
+  marks (issue #373), but no unread on command completion, and the daemon
+  gated `gmux wait` behind an adapter allowlist plus a per-session
+  "prompt-mark evidence" check, rejecting everything else with a 422.
+- **One-shot commands** (`gmux -d -- pnpm test`) — no prompt, no hook — had
+  no state at all: never "active", never "waiting on you", not waitable.
+- The base `Adapter` interface still carried `Monitor(output []byte) *Event`,
+  a per-PTY-read inference hook that every built-in adapter stubbed with
+  `return nil`; the `Event` type existed only for it.
+
+## Decision
+
+One turn state machine for every session — **active / idle / waiting on
+you** — with the turn *source* chosen by adapter kind:
+
+| Session kind | turn opens | turn closes |
+|---|---|---|
+| hook-driven adapter (`SessionExtender` / `SessionHookCommand`) | hook turn-start | hook turn-end |
+| default model, upgraded by observed OSC 133 marks | `133;C` (command starts) | `133;A` / `133;D` (prompt returns) |
+| default model, no marks ever (lifetime-as-turn) | process launch | process exit |
+
+Rules:
+
+1. **`adapter.HookDriven` is the only split.** Hook-driven adapters' turn
+   state is owned by their hooks (ADR 0015), and prompt marks in their
+   output are ignored (a tool the agent runs may print marks; they must not
+   fight the hook). Every other adapter — shell, editor, future tools — gets
+   the runner's default model with no opt-in: `Working=true` at launch,
+   mark upgrade, exit close.
+2. **Upgrade is evidence-based, not declared.** The first observed
+   `133;A/C/D` mark switches the session to prompt-cycle turns for the rest
+   of its life. Argv guessing was rejected: `bash -c script` (shell binary,
+   but a one-shot) and `ssh host` with remote shell integration (non-shell
+   binary, but mark-emitting) both classify correctly only by evidence.
+   Sessions never change adapters mid-life, so there is no conflict window.
+3. **Turn close ⇒ unread.** Every genuine working→idle transition sets
+   "waiting on you", exactly like an agent's completed turn. The initial
+   prompt (launch phase ending) does not. Lifetime-turn exits also set
+   `Status.Error` on a non-zero exit code.
+4. **Turn-state-at-death.** The exit event no longer clears `Status`; the
+   persisted flag records whether the turn was closed when the process
+   exited. `wait` resolves death by it: closed turn → `idle` (rc 0: one-shot
+   completed, shell exited at its prompt, agent exited after its turn); open
+   or never-demonstrated turn → `died` (rc 2). This makes the verdict
+   timing-independent — a wait issued after the death answers the same as
+   one that watched it live. The child's own exit code remains a separate
+   fact on the session.
+5. **Every session is waitable.** The daemon's `no_idle_signal` 422 (adapter
+   allowlist + evidence gate) is deleted. A markless interactive shell is
+   `Working` for its whole life, so a wait on it blocks honestly until exit
+   or `--timeout` — "never provably idle" is answered by not answering, not
+   by a rejection or a bogus instant idle.
+6. **No per-byte adapter inference.** `Adapter.Monitor`, `Event`, `BoolPtr`
+   and the `PromptSignaler` capability are deleted. Status truth has exactly
+   three sources: hooks, the runner's default turn model, and the child's
+   explicit `PUT /status`.
+
+To make the model hold across daemon restarts and late subscribers, the
+runner's `/events` endpoint now replays the current status snapshot on
+subscribe (previously only the conversation ref and slug were replayed).
+
+## Consequences
+
+- `gmux -d -- pnpm test && gmux wait $id` works: active while running,
+  `idle`/rc 0 on completion, "waiting on you" (+ error dot data on non-zero
+  exit) in the sidebar.
+- Agent contract change (accepted): an agent that finishes its turn and then
+  exits cleanly resolves waits as `idle`/rc 0 instead of `died`/rc 2;
+  mid-turn deaths remain rc 2.
+- Dead sessions now carry a non-nil `Status`. The web UI already keys its
+  working/error dots on `Alive` and derives "exited (N)" from the exit code,
+  so nothing breaks; rendering a red dot for failed dead one-shots is a
+  possible UI follow-up.
+- The gray "activity" dot (raw output pulse) is untouched but now redundant
+  for default-model sessions; consolidating the UI to a single "active"
+  indicator is a follow-up.
+- The base `Adapter` interface is four methods (`Name`, `Discover`, `Match`,
+  `Env`); there is no status-related capability to implement at all.

--- a/docs/adr/0023-unified-turn-model.md
+++ b/docs/adr/0023-unified-turn-model.md
@@ -50,10 +50,18 @@ Rules:
 3. **Turn close ⇒ unread.** Every genuine working→idle transition sets
    "waiting on you", exactly like an agent's completed turn. The initial
    prompt (launch phase ending) does not. Lifetime-turn exits also set
-   `Status.Error` on a non-zero exit code.
+   `Status.Error` on a non-zero exit code. Viewing acknowledges: live
+   sessions clear unread through the runner (WS attach), and — because
+   every one-shot now dies unread and has no runner — the daemon clears
+   unread (and the error dot) on *dead* sessions when a client selects
+   them (presence `OnSessionSelected`). `Working` survives the view: it
+   is the turn state at death.
 4. **Turn-state-at-death.** The exit event no longer clears `Status`; the
    persisted flag records whether the turn was closed when the process
-   exited. `wait` resolves death by it: closed turn → `idle` (rc 0: one-shot
+   exited. This holds across *every* exit path — in particular the
+   resume-command derivation hook must not clear Status for "clean
+   resumable display" (it once did, which silently made the wait verdict
+   timing-dependent for agents). `wait` resolves death by it: closed turn → `idle` (rc 0: one-shot
    completed, shell exited at its prompt, agent exited after its turn); open
    or never-demonstrated turn → `died` (rc 2). This makes the verdict
    timing-independent — a wait issued after the death answers the same as

--- a/packages/adapter/adapter.go
+++ b/packages/adapter/adapter.go
@@ -35,12 +35,6 @@ type Adapter interface {
 	// Common GMUX_* vars are set automatically by the runner.
 	// Return nil if no extra env is needed.
 	Env(ctx EnvContext) []string
-
-	// Monitor receives PTY output and optionally returns an Event describing
-	// what changed (title, status, cwd). Called on every PTY read with raw
-	// bytes. Must be cheap — no allocations or regex compilation per call.
-	// Return nil for no change.
-	Monitor(output []byte) *Event
 }
 
 // EnvContext provides launch context to Env().

--- a/packages/adapter/adapters/claude.go
+++ b/packages/adapter/adapters/claude.go
@@ -69,11 +69,6 @@ func (c *Claude) Launchers() []adapter.Launcher {
 	}}
 }
 
-// Monitor is a no-op — status is driven by the agent hook.
-func (c *Claude) Monitor(_ []byte) *adapter.Event {
-	return nil
-}
-
 // --- Conversation storage (file-backed: refs are absolute JSONL paths) ---
 
 // ConversationRootDir returns Claude Code's per-project sessions directory.

--- a/packages/adapter/adapters/claude_test.go
+++ b/packages/adapter/adapters/claude_test.go
@@ -62,21 +62,11 @@ func TestClaudeNoMatchOther(t *testing.T) {
 	}
 }
 
-// --- Env / Monitor ---
+// --- Env ---
 
 func TestClaudeEnvNil(t *testing.T) {
 	if env := NewClaude().Env(adapter.EnvContext{}); env != nil {
 		t.Fatalf("expected nil, got %v", env)
-	}
-}
-
-func TestClaudeMonitorNoOp(t *testing.T) {
-	c := NewClaude()
-	if c.Monitor([]byte("⠋ Thinking...")) != nil {
-		t.Fatal("should return nil (file-driven, not PTY)")
-	}
-	if c.Monitor([]byte("some output")) != nil {
-		t.Fatal("should return nil")
 	}
 }
 

--- a/packages/adapter/adapters/codex.go
+++ b/packages/adapter/adapters/codex.go
@@ -86,11 +86,6 @@ func (c *Codex) Launchers() []adapter.Launcher {
 	}}
 }
 
-// Monitor is a no-op — status is driven by the agent hook.
-func (c *Codex) Monitor(_ []byte) *adapter.Event {
-	return nil
-}
-
 // --- Conversation storage (file-backed: refs are absolute JSONL paths) ---
 
 // ConversationRootDir returns Codex's sessions directory.

--- a/packages/adapter/adapters/codex_test.go
+++ b/packages/adapter/adapters/codex_test.go
@@ -59,18 +59,11 @@ func TestCodexNoMatchOther(t *testing.T) {
 	}
 }
 
-// --- Env / Monitor ---
+// --- Env ---
 
 func TestCodexEnvNil(t *testing.T) {
 	if env := NewCodex().Env(adapter.EnvContext{}); env != nil {
 		t.Fatalf("expected nil, got %v", env)
-	}
-}
-
-func TestCodexMonitorNoOp(t *testing.T) {
-	c := NewCodex()
-	if c.Monitor([]byte("⠋ Thinking...")) != nil {
-		t.Fatal("should return nil (file-driven)")
 	}
 }
 

--- a/packages/adapter/adapters/editor.go
+++ b/packages/adapter/adapters/editor.go
@@ -58,8 +58,6 @@ func (e *Editor) Match(command []string) bool {
 
 func (e *Editor) Env(_ adapter.EnvContext) []string { return nil }
 
-func (e *Editor) Monitor(_ []byte) *adapter.Event { return nil }
-
 // editFilePath extracts the file argument from a matched
 // `gmux __edit-child [path]` command; empty when launched without a
 // path (the child prompts for one interactively).

--- a/packages/adapter/adapters/pi.go
+++ b/packages/adapter/adapters/pi.go
@@ -174,13 +174,6 @@ func (p *Pi) SubmitSeq(mode adapter.SubmitMode) (string, bool) {
 	return "", false
 }
 
-// Monitor is a no-op for the pi adapter — status is reported by the gmux pi
-// extension (turn events over the runner socket), not inferred from PTY
-// output. This avoids flicker from spinner redraws.
-func (p *Pi) Monitor(_ []byte) *adapter.Event {
-	return nil
-}
-
 // --- Conversation storage (file-backed: refs are absolute JSONL paths) ---
 
 // ConversationRootDir returns pi's top-level sessions directory.

--- a/packages/adapter/adapters/pi_test.go
+++ b/packages/adapter/adapters/pi_test.go
@@ -164,7 +164,7 @@ func TestPiNoMatchOther(t *testing.T) {
 	}
 }
 
-// --- Env / Monitor ---
+// --- Env ---
 
 func TestPiEnvNil(t *testing.T) {
 	if env := NewPi().Env(adapter.EnvContext{}); env != nil {
@@ -178,17 +178,6 @@ func TestPiDiscover(t *testing.T) {
 	}
 	// LookPath-based: result depends on the test machine.
 	_ = NewPi().Discover()
-}
-
-func TestPiMonitorNoOp(t *testing.T) {
-	// Pi Monitor is a no-op — status is driven by the agent hook.
-	pi := NewPi()
-	if pi.Monitor([]byte("⠋ Working...")) != nil {
-		t.Fatal("should return nil (file-driven, not PTY)")
-	}
-	if pi.Monitor([]byte("some output")) != nil {
-		t.Fatal("should return nil")
-	}
 }
 
 // TestPiSubmitSeq pins the composer keybinds `gmux send

--- a/packages/adapter/adapters/shell.go
+++ b/packages/adapter/adapters/shell.go
@@ -47,6 +47,7 @@ var (
 	_ adapter.CommandTitler         = (*Shell)(nil)
 	_ adapter.SessionRegistrar      = (*Shell)(nil)
 	_ adapter.SessionFinalizer      = (*Shell)(nil)
+	_ adapter.PromptSignaler        = (*Shell)(nil)
 )
 
 // Shell is the fallback adapter. It matches all commands and parses
@@ -88,6 +89,20 @@ func (g *Shell) Monitor(_ []byte) *adapter.Event {
 	// can use terminal titles as a fallback, not just shell sessions.
 	return nil
 }
+
+// StatusFromPromptMarks opts shell sessions into runner-side OSC 133
+// prompt-mark tracking: Working flips true when a command starts
+// executing and false when the command finishes / the next prompt is
+// drawn. That busy/idle signal is what lets `gmux wait` and `gmux send
+// --wait` work on shell sessions (issue #373). Shells whose
+// integration doesn't emit the marks simply never report Status, and
+// the daemon rejects idle waits on them.
+//
+// The tracking lives in the runner (not Monitor) because a fast
+// command's busy and idle marks can arrive in one PTY read, and
+// Monitor can only return a single collapsed Event per chunk — which
+// would swallow the working→idle pulse that send --wait keys on.
+func (g *Shell) StatusFromPromptMarks() bool { return true }
 
 // --- Conversation storage (file-backed: refs are shell state-file paths) ---
 

--- a/packages/adapter/adapters/shell.go
+++ b/packages/adapter/adapters/shell.go
@@ -51,8 +51,9 @@ var (
 )
 
 // Shell is the fallback adapter. It matches all commands and parses
-// OSC 0/2 title sequences for live sidebar titles. It does not report
-// running/idle status — that's for agent adapters, not plain shells.
+// OSC 0/2 title sequences for live sidebar titles. Busy/idle status
+// comes from runner-tracked OSC 133 prompt marks (see
+// StatusFromPromptMarks), not from Monitor.
 type Shell struct{}
 
 func NewShell() *Shell { return &Shell{} }

--- a/packages/adapter/adapters/shell.go
+++ b/packages/adapter/adapters/shell.go
@@ -47,13 +47,14 @@ var (
 	_ adapter.CommandTitler         = (*Shell)(nil)
 	_ adapter.SessionRegistrar      = (*Shell)(nil)
 	_ adapter.SessionFinalizer      = (*Shell)(nil)
-	_ adapter.PromptSignaler        = (*Shell)(nil)
 )
 
 // Shell is the fallback adapter. It matches all commands and parses
 // OSC 0/2 title sequences for live sidebar titles. Busy/idle status
-// comes from runner-tracked OSC 133 prompt marks (see
-// StatusFromPromptMarks), not from Monitor.
+// comes from the runner's default turn model (adapter.HookDriven):
+// active from launch, upgraded to per-command turns by OSC 133 prompt
+// marks when the shell integration emits them, closed by process exit
+// otherwise.
 type Shell struct{}
 
 func NewShell() *Shell { return &Shell{} }
@@ -84,20 +85,6 @@ func (g *Shell) Launchers() []adapter.Launcher {
 		Description: "Default shell",
 	}}
 }
-
-// StatusFromPromptMarks opts shell sessions into runner-side OSC 133
-// prompt-mark tracking: Working flips true when a command starts
-// executing and false when the command finishes / the next prompt is
-// drawn. That busy/idle signal is what lets `gmux wait` and `gmux send
-// --wait` work on shell sessions (issue #373). Shells whose
-// integration doesn't emit the marks simply never report Status, and
-// the daemon rejects idle waits on them.
-//
-// The tracking lives in the runner (not Monitor) because a fast
-// command's busy and idle marks can arrive in one PTY read, and
-// Monitor can only return a single collapsed Event per chunk — which
-// would swallow the working→idle pulse that send --wait keys on.
-func (g *Shell) StatusFromPromptMarks() bool { return true }
 
 // --- Conversation storage (file-backed: refs are shell state-file paths) ---
 

--- a/packages/adapter/adapters/shell.go
+++ b/packages/adapter/adapters/shell.go
@@ -85,12 +85,6 @@ func (g *Shell) Launchers() []adapter.Launcher {
 	}}
 }
 
-func (g *Shell) Monitor(_ []byte) *adapter.Event {
-	// Shell title parsing is handled centrally in gmux so all sessions
-	// can use terminal titles as a fallback, not just shell sessions.
-	return nil
-}
-
 // StatusFromPromptMarks opts shell sessions into runner-side OSC 133
 // prompt-mark tracking: Working flips true when a command starts
 // executing and false when the command finishes / the next prompt is

--- a/packages/adapter/capabilities.go
+++ b/packages/adapter/capabilities.go
@@ -146,25 +146,29 @@ type SessionHookCommand interface {
 	HookCommand(args []string, selfBin string) (out []string, ok bool)
 }
 
-// PromptSignaler marks adapters whose sessions derive their busy/idle
-// Status from OSC 133 prompt marks ("semantic prompt" sequences) in the
-// PTY output stream, rather than from an agent hook or Monitor. The
-// runner watches the output for the marks and flips Status.Working
-// itself: busy when a command starts executing (133;C), idle when the
-// command finishes / the next prompt is drawn (133;D / 133;A). This is
-// what gives shell sessions the same crisp busy→idle signal that agent
-// sessions get from their turn hooks, so `gmux wait` and `gmux send
-// --wait` work on them (issue #373).
+// HookDriven reports whether sessions of this adapter derive their
+// turn state (Status.Working, unread, error) from an agent-side hook
+// (SessionExtender or SessionHookCommand — ADR 0011/0015): the agent
+// itself reports turn start/end over the runner socket, and the
+// runner applies no turn inference of its own.
 //
-// The marks come from the user's shell integration (fish emits them by
-// default; bash/zsh need an integration snippet), so a session of a
-// PromptSignaler adapter only reports Status once marks are actually
-// observed. Sessions that never emit marks simply keep a nil Status.
-type PromptSignaler interface {
-	// StatusFromPromptMarks reports whether the runner should track
-	// OSC 133 prompt marks in this adapter's PTY output and derive
-	// session Status from them.
-	StatusFromPromptMarks() bool
+// Every other adapter gets the runner's default turn model instead:
+// the session is active (Working=true) from launch, OSC 133 prompt
+// marks in the PTY output — when the child's shell integration emits
+// them — upgrade it to per-command prompt-cycle turns, and for
+// sessions that never emit marks the process exit closes the one
+// lifetime-long turn.
+func HookDriven(a Adapter) bool {
+	if a == nil {
+		return false
+	}
+	if _, ok := a.(SessionExtender); ok {
+		return true
+	}
+	if _, ok := a.(SessionHookCommand); ok {
+		return true
+	}
+	return false
 }
 
 // PassthroughDetector marks adapters that recognize invocations which are NOT

--- a/packages/adapter/capabilities.go
+++ b/packages/adapter/capabilities.go
@@ -159,6 +159,27 @@ type SessionHookCommand interface {
 	HookCommand(args []string, selfBin string) (out []string, ok bool)
 }
 
+// PromptSignaler marks adapters whose sessions derive their busy/idle
+// Status from OSC 133 prompt marks ("semantic prompt" sequences) in the
+// PTY output stream, rather than from an agent hook or Monitor. The
+// runner watches the output for the marks and flips Status.Working
+// itself: busy when a command starts executing (133;C), idle when the
+// command finishes / the next prompt is drawn (133;D / 133;A). This is
+// what gives shell sessions the same crisp busy→idle signal that agent
+// sessions get from their turn hooks, so `gmux wait` and `gmux send
+// --wait` work on them (issue #373).
+//
+// The marks come from the user's shell integration (fish emits them by
+// default; bash/zsh need an integration snippet), so a session of a
+// PromptSignaler adapter only reports Status once marks are actually
+// observed. Sessions that never emit marks simply keep a nil Status.
+type PromptSignaler interface {
+	// StatusFromPromptMarks reports whether the runner should track
+	// OSC 133 prompt marks in this adapter's PTY output and derive
+	// session Status from them.
+	StatusFromPromptMarks() bool
+}
+
 // PassthroughDetector marks adapters that recognize invocations which are NOT
 // interactive sessions — one-shot subcommands like `pi update` or `pi list`.
 // gmux execs these directly (inheriting the tty, returning their exit code)

--- a/packages/adapter/capabilities.go
+++ b/packages/adapter/capabilities.go
@@ -34,19 +34,6 @@ type ConversationInfo struct {
 	Ref          string // the opaque conversation ref this info was described from
 }
 
-// Event is a partial session state update emitted by an adapter from observed
-// PTY bytes (via Monitor). Zero/nil fields are no-ops; the system only applies
-// fields that are explicitly set.
-type Event struct {
-	Title  string  // non-empty: update the adapter title
-	Status *Status // non-nil: update status; &Status{} clears it
-	Unread *bool   // non-nil: set or clear the unread flag
-	Cwd    string  // non-empty: update the session's canonical directory
-}
-
-// BoolPtr returns a pointer to v. Convenience for setting Event.Unread.
-func BoolPtr(v bool) *bool { return &v }
-
 // Launchable is implemented by adapters that want to expose one or more
 // launch presets in the UI.
 type Launchable interface {

--- a/packages/adapter/promptmarks.go
+++ b/packages/adapter/promptmarks.go
@@ -1,0 +1,166 @@
+package adapter
+
+import "bytes"
+
+// PromptMarkTracker derives a busy/idle signal from OSC 133 prompt
+// marks ("semantic prompt" / FinalTerm sequences) in a raw PTY byte
+// stream. It is the runner-side machinery behind the PromptSignaler
+// capability: shells with an emitting integration get the same crisp
+// busy→idle Status transitions that agent adapters report via hooks.
+//
+// Mark semantics (terminator is BEL or ST, extra params after the mark
+// letter — "133;D;0", kitty's ";k=s" — are ignored):
+//
+//	OSC 133;C → working (command execution started)
+//	OSC 133;D → idle    (command finished)
+//	OSC 133;A → idle    (a fresh prompt is being drawn)
+//	OSC 133;B → ignored (prompt end / input start: the shell is idle,
+//	            but that was already established by the preceding A)
+//
+// Both D and A map to idle so integrations that emit only one of the
+// two still produce a usable signal; the tracker dedupes, so a D
+// immediately followed by an A reports a single transition.
+//
+// Feed is a streaming parser: escape sequences split across Feed calls
+// (PTY reads chunk arbitrarily) are handled, and — critically — every
+// transition inside a single chunk is reported in order. A fast command
+// whose C and A marks arrive in one PTY read still produces the full
+// working→idle pulse, which is what `gmux send --wait` keys on.
+//
+// Not safe for concurrent use; the runner feeds it from the single
+// readPTY flush path.
+type PromptMarkTracker struct {
+	// onTransition is invoked once per busy/idle transition, in stream
+	// order. The first observed mark always fires (there is no prior
+	// state to dedupe against).
+	onTransition func(working bool)
+
+	state   promptParseState
+	payload []byte // first bytes of the current OSC payload (capped)
+
+	working bool // last reported polarity
+	seen    bool // whether any transition has been reported yet
+}
+
+type promptParseState uint8
+
+const (
+	ppGround promptParseState = iota // scanning for ESC
+	ppEsc                            // saw ESC, expecting ']' for OSC
+	ppOsc                            // inside OSC, consuming until BEL / ST
+	ppOscEsc                         // inside OSC, saw ESC (ST if '\' follows)
+)
+
+// promptPayloadCap bounds how much of an OSC payload is retained for
+// the prefix check. "133;X" is 5 bytes; anything longer than the cap
+// can't be a bare prompt mark prefix we care about, and capping keeps
+// unrelated giant OSCs (e.g. long titles) from growing the buffer.
+const promptPayloadCap = 8
+
+// NewPromptMarkTracker returns a tracker that calls onTransition for
+// every busy/idle transition derived from the fed bytes.
+func NewPromptMarkTracker(onTransition func(working bool)) *PromptMarkTracker {
+	return &PromptMarkTracker{
+		onTransition: onTransition,
+		payload:      make([]byte, 0, promptPayloadCap),
+	}
+}
+
+// Feed consumes the next chunk of raw PTY output. Parser state persists
+// across calls, so sequences split between chunks are recognized.
+func (t *PromptMarkTracker) Feed(data []byte) {
+	for i := 0; i < len(data); i++ {
+		b := data[i]
+		switch t.state {
+		case ppGround:
+			if b != 0x1b {
+				// Fast-skip: jump straight to the next ESC instead of
+				// walking every byte of ordinary output.
+				j := bytes.IndexByte(data[i:], 0x1b)
+				if j < 0 {
+					return
+				}
+				i += j
+			}
+			t.state = ppEsc
+		case ppEsc:
+			switch b {
+			case ']':
+				t.state = ppOsc
+				t.payload = t.payload[:0]
+			case 0x1b:
+				// Another ESC: still at the start of an escape sequence.
+			default:
+				// Some other escape sequence (CSI, charset, ...). Not an
+				// OSC; back to scanning. CSI parameter bytes can't contain
+				// a raw ESC, so skipping their body is safe.
+				t.state = ppGround
+			}
+		case ppOsc:
+			switch b {
+			case 0x07: // BEL terminator
+				t.finishOSC()
+			case 0x1b:
+				t.state = ppOscEsc
+			default:
+				if len(t.payload) < promptPayloadCap {
+					t.payload = append(t.payload, b)
+				}
+			}
+		case ppOscEsc:
+			switch b {
+			case '\\': // ST terminator (ESC \)
+				t.finishOSC()
+			case ']':
+				// The ESC aborted the OSC and immediately starts a new one.
+				t.state = ppOsc
+				t.payload = t.payload[:0]
+			case 0x1b:
+				// ESC ESC: the first aborted the OSC, the second starts a
+				// fresh escape sequence.
+				t.state = ppEsc
+			default:
+				// ESC + other: aborted OSC followed by some non-OSC escape.
+				t.state = ppGround
+			}
+		}
+	}
+}
+
+// finishOSC inspects the completed OSC payload and reports a transition
+// when it is a recognized 133 prompt mark.
+func (t *PromptMarkTracker) finishOSC() {
+	p := t.payload
+	t.payload = t.payload[:0]
+	t.state = ppGround
+
+	if len(p) < 5 || string(p[:4]) != "133;" {
+		return
+	}
+	// Anything after the mark letter must be a parameter separator
+	// ("133;D;0", "133;A;k=s"), otherwise it's not a prompt mark.
+	if len(p) > 5 && p[5] != ';' {
+		return
+	}
+	switch p[4] {
+	case 'C':
+		t.transition(true)
+	case 'A', 'D':
+		t.transition(false)
+	}
+}
+
+// transition dedupes and reports a polarity change. The first observed
+// mark always reports: a session's initial prompt (133;A) is what
+// establishes "this shell emits marks" downstream, so it must surface
+// even though nothing changed relative to the zero value.
+func (t *PromptMarkTracker) transition(working bool) {
+	if t.seen && t.working == working {
+		return
+	}
+	t.seen = true
+	t.working = working
+	if t.onTransition != nil {
+		t.onTransition(working)
+	}
+}

--- a/packages/adapter/promptmarks.go
+++ b/packages/adapter/promptmarks.go
@@ -4,9 +4,12 @@ import "bytes"
 
 // PromptMarkTracker derives a busy/idle signal from OSC 133 prompt
 // marks ("semantic prompt" / FinalTerm sequences) in a raw PTY byte
-// stream. It is the runner-side machinery behind the PromptSignaler
-// capability: shells with an emitting integration get the same crisp
-// busy→idle Status transitions that agent adapters report via hooks.
+// stream. The runner tracks marks on every session whose adapter is
+// not hook-driven (see HookDriven): shells with an emitting
+// integration get the same crisp busy→idle Status transitions that
+// agent adapters report via hooks, upgrading the session from the
+// default lifetime-as-turn model (active from launch to exit) to
+// per-command prompt-cycle turns.
 //
 // Mark semantics (terminator is BEL or ST, extra params after the mark
 // letter — "133;D;0", kitty's ";k=s" — are ignored):
@@ -41,6 +44,15 @@ type PromptMarkTracker struct {
 	working bool // last reported polarity
 	seen    bool // whether any transition has been reported yet
 }
+
+// SawMark reports whether any actionable prompt mark (133;A/C/D) has
+// been observed. The runner uses this as the upgrade signal: once a
+// session demonstrates prompt cycles, its turns are delimited by the
+// marks and process exit no longer closes a turn by itself.
+//
+// Like Feed, not safe for concurrent use; the runner reads it only
+// after the final PTY flush (PTYDone) has completed.
+func (t *PromptMarkTracker) SawMark() bool { return t.seen }
 
 type promptParseState uint8
 

--- a/packages/adapter/promptmarks_test.go
+++ b/packages/adapter/promptmarks_test.go
@@ -1,0 +1,152 @@
+package adapter
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// feedAll runs one Feed call per chunk and returns the reported
+// transition sequence (true = working).
+func feedAll(t *testing.T, chunks ...string) []bool {
+	t.Helper()
+	var got []bool
+	tr := NewPromptMarkTracker(func(working bool) { got = append(got, working) })
+	for _, c := range chunks {
+		tr.Feed([]byte(c))
+	}
+	return got
+}
+
+func TestPromptMarkTrackerTransitions(t *testing.T) {
+	tests := []struct {
+		name   string
+		chunks []string
+		want   []bool
+	}{
+		{
+			name:   "first prompt reports idle",
+			chunks: []string{"\x1b]133;A\x07$ "},
+			want:   []bool{false},
+		},
+		{
+			name: "full prompt cycle: busy on C, idle on next A",
+			chunks: []string{
+				"\x1b]133;A\x07$ ",                 // prompt
+				"\x1b]133;C\x07compiling\n",        // command starts
+				"\x1b]133;D;0\x07\x1b]133;A\x07$ ", // finished + next prompt
+			},
+			want: []bool{false, true, false},
+		},
+		{
+			name: "C and A in one chunk still produce the full pulse",
+			chunks: []string{
+				"\x1b]133;A\x07$ ",
+				"\x1b]133;C\x07hi\n\x1b]133;D;0\x07\x1b]133;A\x07$ ",
+			},
+			want: []bool{false, true, false},
+		},
+		{
+			name:   "ST terminator recognized",
+			chunks: []string{"\x1b]133;C\x1b\\"},
+			want:   []bool{true},
+		},
+		{
+			name:   "D alone reports idle (integrations that skip A)",
+			chunks: []string{"\x1b]133;C\x07out\x1b]133;D;127\x07"},
+			want:   []bool{true, false},
+		},
+		{
+			name:   "repeated idle marks dedupe",
+			chunks: []string{"\x1b]133;A\x07", "\x1b]133;A\x07", "\x1b]133;D\x07"},
+			want:   []bool{false},
+		},
+		{
+			name:   "B marks are ignored",
+			chunks: []string{"\x1b]133;A\x07prompt> \x1b]133;B\x07"},
+			want:   []bool{false},
+		},
+		{
+			name:   "kitty-style params after the mark letter",
+			chunks: []string{"\x1b]133;A;k=s\x07"},
+			want:   []bool{false},
+		},
+		{
+			name:   "sequence split across chunks",
+			chunks: []string{"out\x1b]13", "3;C", "\x07more"},
+			want:   []bool{true},
+		},
+		{
+			name:   "terminator split across chunks (ESC then backslash)",
+			chunks: []string{"\x1b]133;A\x1b", "\\$ "},
+			want:   []bool{false},
+		},
+		{
+			name:   "unrelated OSC ignored",
+			chunks: []string{"\x1b]0;my title\x07\x1b]2;other\x1b\\"},
+			want:   nil,
+		},
+		{
+			name:   "long unrelated OSC payload does not hide later marks",
+			chunks: []string{"\x1b]0;" + strings.Repeat("x", 4096) + "\x07\x1b]133;C\x07"},
+			want:   []bool{true},
+		},
+		{
+			name:   "133 prefix with junk instead of mark letter ignored",
+			chunks: []string{"\x1b]133;Zoo\x07\x1b]133;AB\x07"},
+			want:   nil,
+		},
+		{
+			name:   "CSI sequences between marks are skipped",
+			chunks: []string{"\x1b]133;A\x07\x1b[2J\x1b[1;1H\x1b]133;C\x07"},
+			want:   []bool{false, true},
+		},
+		{
+			name:   "aborted OSC followed by a new OSC (ESC ])",
+			chunks: []string{"\x1b]0;unterminated\x1b]133;C\x07"},
+			want:   []bool{true},
+		},
+		{
+			name:   "plain output produces nothing",
+			chunks: []string{"hello world\nno escapes here\n"},
+			want:   nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := feedAll(t, tt.chunks...)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("transitions = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestPromptMarkTrackerByteAtATime pins the streaming property in the
+// most hostile chunking: every byte arrives in its own Feed call.
+func TestPromptMarkTrackerByteAtATime(t *testing.T) {
+	stream := "\x1b]133;A\x07$ \x1b]133;C\x07work\x1b]133;D;0\x1b\\\x1b]133;A\x07$ "
+	var got []bool
+	tr := NewPromptMarkTracker(func(working bool) { got = append(got, working) })
+	for i := 0; i < len(stream); i++ {
+		tr.Feed([]byte{stream[i]})
+	}
+	want := []bool{false, true, false}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("transitions = %v, want %v", got, want)
+	}
+}
+
+// TestPromptMarkTrackerPayloadBounded guards the memory bound: an OSC
+// spammed with megabytes of payload must not grow the tracker's buffer.
+func TestPromptMarkTrackerPayloadBounded(t *testing.T) {
+	tr := NewPromptMarkTracker(nil)
+	tr.Feed([]byte("\x1b]0;"))
+	for i := 0; i < 1000; i++ {
+		tr.Feed([]byte(strings.Repeat("y", 1024)))
+	}
+	if cap(tr.payload) > promptPayloadCap {
+		t.Errorf("payload cap grew to %d, want <= %d", cap(tr.payload), promptPayloadCap)
+	}
+}

--- a/packages/adapter/registry_test.go
+++ b/packages/adapter/registry_test.go
@@ -13,7 +13,6 @@ func (a *testAdapter) Name() string              { return a.name }
 func (a *testAdapter) Discover() bool            { return true }
 func (a *testAdapter) Match(_ []string) bool     { return a.matches }
 func (a *testAdapter) Env(_ EnvContext) []string { return nil }
-func (a *testAdapter) Monitor(_ []byte) *Event { return nil }
 
 func TestRegistryFallback(t *testing.T) {
 	t.Setenv("GMUX_ADAPTER", "") // isolate from ambient env (e.g. running inside gmux)

--- a/packages/scrollback/scrollback.go
+++ b/packages/scrollback/scrollback.go
@@ -271,18 +271,29 @@ func RenderTail(r io.Reader, cols, rows, n int) ([]string, error) {
 	// The emulator writes back responses (e.g. DSR cursor position
 	// reports) into a pipe. Nothing reads them here, and a blocked
 	// write would deadlock our Write below. Drain in the background,
-	// and close the emulator on the way out so the drain goroutine
-	// sees EOF and exits — without the Close it blocks on the pipe
-	// forever, leaking one goroutine per render. One-shot tail
-	// requests barely noticed; the output-condition wait re-renders
-	// on a ticker and would accumulate them.
+	// and unblock the drain on the way out so it sees EOF and exits —
+	// otherwise it blocks on the pipe forever, leaking one goroutine
+	// per render. One-shot tail requests barely noticed; the
+	// output-condition wait re-renders on a ticker and would
+	// accumulate them.
+	//
+	// The unblocking deliberately closes the response pipe's write end
+	// (InputPipe) instead of calling e.Close(): Close sets an
+	// unsynchronized bool that the drain goroutine's concurrent Read
+	// also checks — a data race in the vt package. Closing the
+	// *io.PipeWriter is everything Close does minus that bool, and
+	// io.Pipe is safe for concurrent use.
 	drainDone := make(chan struct{})
 	go func() {
 		_, _ = io.Copy(io.Discard, e)
 		close(drainDone)
 	}()
 	defer func() {
-		_ = e.Close()
+		if c, ok := e.InputPipe().(io.Closer); ok {
+			_ = c.Close()
+		} else {
+			_ = e.Close() // future-proof fallback; racy only if vt changes InputPipe
+		}
 		<-drainDone
 	}()
 	if _, err := e.Write(raw); err != nil {

--- a/packages/scrollback/scrollback_test.go
+++ b/packages/scrollback/scrollback_test.go
@@ -629,3 +629,23 @@ func TestRenderTailDoesNotLeakGoroutines(t *testing.T) {
 		t.Fatalf("goroutines grew from %d to %d across %d renders; drain goroutine is leaking", before, after, n)
 	}
 }
+
+// TestRenderTailRaceFreeWithResponses replays input that makes the
+// emulator emit responses into its output pipe (a DSR cursor-position
+// query), which is what forces the concurrent drain goroutine to be
+// mid-Read when RenderTail tears the emulator down. Run under -race
+// this pins the teardown path that closes the response pipe directly
+// instead of calling Emulator.Close, whose unsynchronized closed-flag
+// races with the drain's Read.
+func TestRenderTailRaceFreeWithResponses(t *testing.T) {
+	raw := "before\x1b[6nafter\r\n" // ESC[6n = DSR: emulator writes a report back
+	for i := 0; i < 50; i++ {
+		lines, err := RenderTail(strings.NewReader(raw), 80, 24, 5)
+		if err != nil {
+			t.Fatalf("RenderTail: %v", err)
+		}
+		if len(lines) == 0 {
+			t.Fatal("no lines rendered")
+		}
+	}
+}

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -632,14 +632,17 @@ func serve(stderr io.Writer) int {
 	var resumeMu sync.Mutex
 
 	// When a session exits, derive the resume command so it transitions
-	// to resumable immediately — no "exited" limbo state.
-	subs.OnExit = func(sess *store.Session) bool {
+	// to resumable immediately — no "exited" limbo state. Only Command is
+	// touched: the last Status must survive death regardless of
+	// resumability, because it records whether the turn was closed at
+	// exit — what lets a wait issued after the death resolve identically
+	// to one that watched it live (ADR 0023). The frontend keys its
+	// working/error dots on Alive, so a persisted Status doesn't bleed
+	// into the resumable display.
+	subs.OnExit = func(sess *store.Session) {
 		if cmd := discovery.ResolveResumeCommand(sess); cmd != nil {
 			sess.Command = cmd
-			sess.Status = nil // clear exit status for clean resumable display
-			return true
 		}
-		return false
 	}
 	// Start socket-based discovery (scans paths.SessionSocketDir() — plus
 	// paths.LegacySessionSocketDirs() for pre-upgrade runners — for *.sock).
@@ -705,6 +708,13 @@ func serve(stderr io.Writer) int {
 			if notifRouter != nil {
 				notifRouter.CancelForSession(sessionID)
 			}
+			// Viewing clears "waiting on you". Live sessions clear it
+			// through the runner (WS attach → SetUnread(false) → meta
+			// event); a dead session has no runner, and under the unified
+			// turn model every one-shot dies unread (exit closes its
+			// turn, ADR 0023) — without this daemon-side clear that dot
+			// could only be removed by dismissing the session.
+			clearDeadSessionUnread(sessions, sessionID)
 		},
 	})
 	notifRouter = notify.New(presenceTable, sessions, notify.DefaultConfig())
@@ -854,7 +864,7 @@ func serve(stderr io.Writer) int {
 	defer unsubSessionEvents()
 	go func() {
 		for ev := range sessionEvents {
-			if ev.Type != "session-upsert" || ev.Session == nil {
+			if ev.Type != store.EventSessionUpsert || ev.Session == nil {
 				continue
 			}
 			s := ev.Session
@@ -2124,14 +2134,14 @@ func serve(stderr io.Writer) int {
 					return
 				}
 				switch ev.Type {
-				case "session-activity":
+				case store.EventSessionActivity:
 					// Peer subscribers (?as=peer) get activity for owned
 					// sessions only; browser subscribers see everything so
 					// peer-owned session indicators update.
 					if !shouldForwardActivity(asPeer, ev.ID, isLocalPeer) {
 						continue
 					}
-					if err := sendFrame("session-activity", ev); err != nil {
+					if err := sendFrame(store.EventSessionActivity, ev); err != nil {
 						return
 					}
 				case "projects-update":
@@ -2604,7 +2614,7 @@ func runAuth(stdout, stderr io.Writer) int {
 //     change.
 func snapshotPumpRoute(eventType string) (pushSessions, pushWorld bool) {
 	switch eventType {
-	case "session-upsert", "session-remove":
+	case store.EventSessionUpsert, store.EventSessionRemove:
 		return true, false
 	case "peer-status":
 		return false, true

--- a/services/gmuxd/cmd/gmuxd/main_test.go
+++ b/services/gmuxd/cmd/gmuxd/main_test.go
@@ -30,7 +30,6 @@ func (a discoverTestAdapter) Name() string                      { return a.name 
 func (a discoverTestAdapter) Discover() bool                    { return a.available }
 func (a discoverTestAdapter) Match(_ []string) bool             { return false }
 func (a discoverTestAdapter) Env(_ adapter.EnvContext) []string { return nil }
-func (a discoverTestAdapter) Monitor(_ []byte) *adapter.Event   { return nil }
 func (a discoverTestAdapter) Launchers() []adapter.Launcher {
 	return []adapter.Launcher{{ID: a.name, Label: a.name}}
 }

--- a/services/gmuxd/cmd/gmuxd/sendwait_test.go
+++ b/services/gmuxd/cmd/gmuxd/sendwait_test.go
@@ -171,19 +171,51 @@ func TestSendWaitTimesOut(t *testing.T) {
 	}
 }
 
-// TestSendWaitRejectsShellSessionsWithoutPromptMarks mirrors
-// handleWait's gate: a shell session with a nil Status has never
-// emitted an OSC 133 prompt mark, so no idle signal exists and the
-// wait contract can't be honored — fail loudly, don't deliver.
-func TestSendWaitRejectsShellSessionsWithoutPromptMarks(t *testing.T) {
-	srv, st := sendWaitTestServer(t, func(st *store.Store) {
-		t.Error("input must not be delivered when the wait contract can't be honored")
-	})
-	st.Upsert(store.Session{ID: "sess-shell", Adapter: "shell", Alive: true})
+// TestSendWaitMarklessShellBlocksUntilTimeout: a shell session whose
+// integration emits no prompt marks stays on the lifetime turn —
+// Working=true from launch — so its triggered "turn" can only close
+// at process exit. send --wait on it is accepted (no gate) and blocks
+// honestly until exit or ?timeout.
+func TestSendWaitMarklessShellBlocksUntilTimeout(t *testing.T) {
+	const id = "sess-shell-markless"
+	srv, st := sendWaitTestServer(t, nil)
+	upsertShell(st, id, true, &store.Status{Working: true})
 
-	resp, _ := postInput(t, srv, "sess-shell/input?wait=idle")
-	if resp.StatusCode != http.StatusUnprocessableEntity {
-		t.Errorf("status = %d, want 422", resp.StatusCode)
+	start := time.Now()
+	resp, _ := postInput(t, srv, id+"/input?wait=idle&timeout=1")
+	elapsed := time.Since(start)
+
+	if resp.StatusCode != http.StatusRequestTimeout {
+		t.Fatalf("status = %d, want 408", resp.StatusCode)
+	}
+	if elapsed < 900*time.Millisecond || elapsed > 2*time.Second {
+		t.Errorf("elapsed = %v, want ~1s", elapsed)
+	}
+}
+
+// TestSendWaitOneShotExitResolvesIdle: input to a lifetime-turn
+// session (one-shot command, Working=true since launch) resolves
+// "idle" when the runner closes the turn at exit — the close status
+// precedes the exit event, and the persisted Status keeps the verdict
+// stable whichever event the wait observes.
+func TestSendWaitOneShotExitResolvesIdle(t *testing.T) {
+	const id = "sess-oneshot"
+	srv, st := sendWaitTestServer(t, func(st *store.Store) {
+		go func() {
+			time.Sleep(50 * time.Millisecond)
+			// Runner order: turn-close status, then exit.
+			upsertShell(st, id, true, &store.Status{Working: false})
+			upsertShell(st, id, false, &store.Status{Working: false})
+		}()
+	})
+	upsertShell(st, id, true, &store.Status{Working: true})
+
+	resp, body := postInput(t, srv, id+"/input?wait=idle&timeout=2")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if got := body["data"].(map[string]any)["reason"]; got != "idle" {
+		t.Errorf("reason = %v, want idle", got)
 	}
 }
 
@@ -253,9 +285,11 @@ func TestSendWaitShellFastCommandPulse(t *testing.T) {
 }
 
 // TestSendWaitShellDiesOnExit: `gmux send <id> 'exit' Enter --wait`
-// ends the session instead of returning to a prompt. The wait must
-// unblock with "died" rather than hang — process exit always
-// satisfies a wait, just with a distinct reason/exit code.
+// on a prompt-cycle shell ends the session mid-turn: the command-start
+// mark flips Working=true and no prompt ever returns, so the persisted
+// turn state at death is open — the wait unblocks with "died" rather
+// than hang. (Contrast TestSendWaitOneShotExitResolvesIdle, where the
+// turn closes at exit.)
 func TestSendWaitShellDiesOnExit(t *testing.T) {
 	const id = "sess-shell-exit"
 	srv, st := sendWaitTestServer(t, func(st *store.Store) {
@@ -263,7 +297,7 @@ func TestSendWaitShellDiesOnExit(t *testing.T) {
 			time.Sleep(50 * time.Millisecond)
 			upsertShell(st, id, true, &store.Status{Working: true})
 			time.Sleep(50 * time.Millisecond)
-			upsertShell(st, id, false, nil)
+			upsertShell(st, id, false, &store.Status{Working: true})
 		}()
 	})
 	upsertShell(st, id, true, &store.Status{Working: false})

--- a/services/gmuxd/cmd/gmuxd/sendwait_test.go
+++ b/services/gmuxd/cmd/gmuxd/sendwait_test.go
@@ -171,9 +171,11 @@ func TestSendWaitTimesOut(t *testing.T) {
 	}
 }
 
-// TestSendWaitRejectsShellSessions mirrors handleWait's allowlist:
-// adapters without an idle signal can't answer "turn finished".
-func TestSendWaitRejectsShellSessions(t *testing.T) {
+// TestSendWaitRejectsShellSessionsWithoutPromptMarks mirrors
+// handleWait's gate: a shell session with a nil Status has never
+// emitted an OSC 133 prompt mark, so no idle signal exists and the
+// wait contract can't be honored — fail loudly, don't deliver.
+func TestSendWaitRejectsShellSessionsWithoutPromptMarks(t *testing.T) {
 	srv, st := sendWaitTestServer(t, func(st *store.Store) {
 		t.Error("input must not be delivered when the wait contract can't be honored")
 	})
@@ -182,6 +184,96 @@ func TestSendWaitRejectsShellSessions(t *testing.T) {
 	resp, _ := postInput(t, srv, "sess-shell/input?wait=idle")
 	if resp.StatusCode != http.StatusUnprocessableEntity {
 		t.Errorf("status = %d, want 422", resp.StatusCode)
+	}
+}
+
+// upsertShell mirrors upsertAgent for shell sessions, whose Status
+// comes from runner-tracked OSC 133 prompt marks (issue #373).
+func upsertShell(st *store.Store, id string, alive bool, status *store.Status) {
+	st.Upsert(store.Session{ID: id, Adapter: "shell", Alive: alive, Status: status})
+}
+
+// TestSendWaitShellPromptCycle: `gmux send --wait` on a shell sitting
+// at its prompt (idle Status from the last OSC 133;A mark) must hold
+// through the command it triggers — busy on the command-start mark,
+// idle again when the prompt returns — exactly like an agent turn.
+// Without the per-session evidence gate this 422s; without honoring
+// the pulse it would return off the stale pre-send idle.
+func TestSendWaitShellPromptCycle(t *testing.T) {
+	const id = "sess-shell-cycle"
+	srv, st := sendWaitTestServer(t, func(st *store.Store) {
+		// Simulate the runner's prompt-mark tracking after the bytes
+		// land: 133;C flips busy, the next 133;A flips idle.
+		go func() {
+			time.Sleep(100 * time.Millisecond)
+			upsertShell(st, id, true, &store.Status{Working: true})
+			time.Sleep(150 * time.Millisecond)
+			upsertShell(st, id, true, &store.Status{Working: false})
+		}()
+	})
+	// Stale state: at the prompt since the previous command.
+	upsertShell(st, id, true, &store.Status{Working: false})
+
+	start := time.Now()
+	resp, body := postInput(t, srv, id+"/input?wait=idle")
+	elapsed := time.Since(start)
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if got := body["data"].(map[string]any)["reason"]; got != "idle" {
+		t.Errorf("reason = %v, want idle", got)
+	}
+	if elapsed < 200*time.Millisecond {
+		t.Errorf("returned in %v — observed the stale pre-send prompt idle instead of the triggered command's cycle", elapsed)
+	}
+}
+
+// TestSendWaitShellFastCommandPulse: a fast shell command's busy and
+// idle marks can arrive in a single PTY read; the runner still emits
+// both Status transitions, and because the subscription predates the
+// delivery, send --wait observes the full pulse. This pins the
+// daemon half of that contract (the runner half lives in
+// ptyserver's prompt-mark tests).
+func TestSendWaitShellFastCommandPulse(t *testing.T) {
+	const id = "sess-shell-fast"
+	srv, st := sendWaitTestServer(t, func(st *store.Store) {
+		upsertShell(st, id, true, &store.Status{Working: true})
+		upsertShell(st, id, true, &store.Status{Working: false})
+	})
+	upsertShell(st, id, true, &store.Status{Working: false})
+
+	resp, body := postInput(t, srv, id+"/input?wait=idle&timeout=2")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if got := body["data"].(map[string]any)["reason"]; got != "idle" {
+		t.Errorf("reason = %v, want idle", got)
+	}
+}
+
+// TestSendWaitShellDiesOnExit: `gmux send <id> 'exit' Enter --wait`
+// ends the session instead of returning to a prompt. The wait must
+// unblock with "died" rather than hang — process exit always
+// satisfies a wait, just with a distinct reason/exit code.
+func TestSendWaitShellDiesOnExit(t *testing.T) {
+	const id = "sess-shell-exit"
+	srv, st := sendWaitTestServer(t, func(st *store.Store) {
+		go func() {
+			time.Sleep(50 * time.Millisecond)
+			upsertShell(st, id, true, &store.Status{Working: true})
+			time.Sleep(50 * time.Millisecond)
+			upsertShell(st, id, false, nil)
+		}()
+	})
+	upsertShell(st, id, true, &store.Status{Working: false})
+
+	resp, body := postInput(t, srv, id+"/input?wait=idle")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if got := body["data"].(map[string]any)["reason"]; got != "died" {
+		t.Errorf("reason = %v, want died", got)
 	}
 }
 

--- a/services/gmuxd/cmd/gmuxd/sendwait_test.go
+++ b/services/gmuxd/cmd/gmuxd/sendwait_test.go
@@ -203,8 +203,10 @@ func TestSendWaitOneShotExitResolvesIdle(t *testing.T) {
 	srv, st := sendWaitTestServer(t, func(st *store.Store) {
 		go func() {
 			time.Sleep(50 * time.Millisecond)
-			// Runner order: turn-close status, then exit.
-			upsertShell(st, id, true, &store.Status{Working: false})
+			// Worst case for the wait: it only ever observes the session
+			// already dead (the live turn-close event was coalesced into
+			// the exit upsert). The persisted closed-turn Status must
+			// still resolve "idle", not "died".
 			upsertShell(st, id, false, &store.Status{Working: false})
 		}()
 	})

--- a/services/gmuxd/cmd/gmuxd/unread.go
+++ b/services/gmuxd/cmd/gmuxd/unread.go
@@ -1,0 +1,32 @@
+package main
+
+import "github.com/gmuxapp/gmux/services/gmuxd/internal/store"
+
+// clearDeadSessionUnread clears the "waiting on you" flag on a dead
+// session when a client views it. Live sessions don't need this: the
+// runner clears unread itself when a terminal attaches (WS connect →
+// SetUnread(false) → meta event), and a daemon-side clear would race
+// that authoritative path. Dead sessions have no runner, and under the
+// unified turn model (ADR 0023) every one-shot dies unread — the exit
+// closes its lifetime turn — so viewing must be able to acknowledge it.
+//
+// The error flag rides the unread lifecycle, mirroring the runner-path
+// rule in subscribe.go's meta handling: acknowledging the output also
+// acknowledges the red dot. Working is left untouched — it is the turn
+// state at death, which post-mortem waits resolve by.
+//
+// Status is replaced, not mutated in place: store.Update's copy is
+// shallow, so writing through the shared *Status would also rewrite
+// the store's previous snapshot and defeat its no-op change detection.
+func clearDeadSessionUnread(sessions *store.Store, sessionID string) {
+	sess, ok := sessions.Get(sessionID)
+	if !ok || sess.Alive || (!sess.Unread && (sess.Status == nil || !sess.Status.Error)) {
+		return
+	}
+	sessions.Update(sessionID, func(s *store.Session) {
+		s.Unread = false
+		if s.Status != nil && s.Status.Error {
+			s.Status = &store.Status{Working: s.Status.Working}
+		}
+	})
+}

--- a/services/gmuxd/cmd/gmuxd/unread_test.go
+++ b/services/gmuxd/cmd/gmuxd/unread_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/store"
+)
+
+// TestClearDeadSessionUnread pins the view-acknowledges rule for dead
+// sessions (ADR 0023): viewing clears unread and the error dot but
+// must not touch the persisted turn state (Status.Working) that
+// post-mortem waits resolve by, and must not interfere with live
+// sessions, whose unread is owned by the runner.
+func TestClearDeadSessionUnread(t *testing.T) {
+	exit3 := 3
+	cases := []struct {
+		name string
+		in   store.Session
+		want func(t *testing.T, s store.Session)
+	}{
+		{
+			name: "dead unread one-shot: unread and error clear, Working survives",
+			in: store.Session{
+				ID: "s", Adapter: "shell", Alive: false, Unread: true,
+				ExitCode: &exit3,
+				Status:   &store.Status{Working: false, Error: true},
+			},
+			want: func(t *testing.T, s store.Session) {
+				if s.Unread {
+					t.Error("unread not cleared on view")
+				}
+				if s.Status == nil || s.Status.Error {
+					t.Errorf("Status = %+v, want error cleared", s.Status)
+				}
+				if s.Status != nil && s.Status.Working {
+					t.Error("Working mutated; turn state at death must survive the view")
+				}
+			},
+		},
+		{
+			name: "live unread session: untouched (runner owns it)",
+			in: store.Session{
+				ID: "s", Adapter: "shell", Alive: true, Unread: true,
+				Status: &store.Status{Working: false},
+			},
+			want: func(t *testing.T, s store.Session) {
+				if !s.Unread {
+					t.Error("live session's unread cleared daemon-side; the runner owns that transition")
+				}
+			},
+		},
+		{
+			name: "dead already-read session: no-op",
+			in: store.Session{
+				ID: "s", Adapter: "shell", Alive: false, Unread: false,
+				Status: &store.Status{Working: false},
+			},
+			want: func(t *testing.T, s store.Session) {
+				if s.Unread {
+					t.Error("unread flipped on")
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sessions := store.New()
+			sessions.Upsert(tc.in)
+			clearDeadSessionUnread(sessions, "s")
+			got, ok := sessions.Get("s")
+			if !ok {
+				t.Fatal("session vanished")
+			}
+			tc.want(t, got)
+		})
+	}
+
+	t.Run("unknown session: no panic", func(t *testing.T) {
+		clearDeadSessionUnread(store.New(), "nope")
+	})
+}

--- a/services/gmuxd/cmd/gmuxd/wait.go
+++ b/services/gmuxd/cmd/gmuxd/wait.go
@@ -59,8 +59,12 @@ import (
 //   - 200 with {reason}: terminal state reached (caller maps to its
 //     own exit code)
 //   - 408 Request Timeout: --timeout deadline elapsed
-//   - 422: session adapter has no idle signal (idle mode only;
-//     output conditions work for every adapter, including shell)
+//   - 422: session has no idle signal (idle mode only; output
+//     conditions work for every adapter, including shell). Only
+//     *live* sessions are rejected — the 422 exists to prevent waits
+//     that could hang forever, and a session that already exited
+//     resolves immediately as "died" instead (idle includes process
+//     exit)
 //   - 404: session not found
 //   - 400: bad timeout, bad regex, or both output conditions at once
 //
@@ -88,6 +92,17 @@ func handleWait(w http.ResponseWriter, r *http.Request, sessions *store.Store, s
 	// Output conditions don't need the idle signal: they read the
 	// scrollback tee, which every adapter (including shell) produces.
 	if forText == "" && forRegex == "" && !sessionHasIdleSignal(sess) {
+		// A session that already exited is a resolved wait, not a
+		// missing capability: idle includes process exit, so answer
+		// "died" (same as a dead agent) instead of rejecting with
+		// shell-integration advice that can't help a dead session.
+		// The 422 below only fires for sessions that could otherwise
+		// hang the wait forever — live (or startup-window) sessions
+		// that have never demonstrated an idle signal.
+		if reason, done := terminalReason(sess, false); done {
+			writeJSON(w, map[string]any{"ok": true, "data": map[string]any{"reason": reason}})
+			return
+		}
 		writeError(w, http.StatusUnprocessableEntity, "no_idle_signal", noIdleSignalMessage(sess))
 		return
 	}
@@ -408,7 +423,9 @@ func timeoutChan(r *http.Request) (<-chan time.Time, error) {
 // the input delivery.
 //
 // Contract mirrors handleWait: 200 {reason: idle|died}, 408 on
-// ?timeout=N elapsing, 422 for adapters with no idle signal. One
+// ?timeout=N elapsing, 422 for sessions with no idle signal (the
+// input handler's !Alive => 409 check runs first, so unlike
+// handleWait there is no dead-session case to resolve here). One
 // additional 422 ("input_no_submit") rejects bodies that carry no
 // carriage return: input that doesn't submit never starts a turn, so
 // waiting on it would only ever time out — fail loudly at the edge

--- a/services/gmuxd/cmd/gmuxd/wait.go
+++ b/services/gmuxd/cmd/gmuxd/wait.go
@@ -29,16 +29,19 @@ import (
 // scrollback cap, not the poll interval). See waitForOutput.
 //
 // The single signal we wait on is the per-session Status.Working flag
-// the adapters emit. That's a precise, debounced signal: each adapter
-// flips it false once its agent has finished its turn (claude /
-// codex / pi all emit a Working transition). Falling back to "no
-// output bytes for N seconds" would race ad-hoc against tool-call
-// progress prints; the explicit Working flag is what we already use
-// in the UI's idle indicator and is the right thing to consume here.
+// the adapters emit. That's a precise, debounced signal: the agent
+// adapters flip it false once their agent has finished its turn
+// (claude / codex / pi all emit a Working transition), and shell
+// sessions flip it via runner-tracked OSC 133 prompt marks (busy on
+// command start, idle when the prompt returns — issue #373). Falling
+// back to "no output bytes for N seconds" would race ad-hoc against
+// tool-call progress prints; the explicit Working flag is what we
+// already use in the UI's idle indicator and is the right thing to
+// consume here.
 //
-// Sessions whose adapter doesn't emit Working (notably the shell
-// adapter) are rejected with 422 rather than silently returning
-// "idle" immediately, which would foot-trap the obvious composition
+// Sessions with no idle signal (see sessionHasIdleSignal) are
+// rejected with 422 rather than silently returning "idle"
+// immediately, which would foot-trap the obvious composition
 // `gmux make build && gmux --wait <id>` into doing nothing.
 //
 // Reasons returned in the response body:
@@ -84,9 +87,8 @@ func handleWait(w http.ResponseWriter, r *http.Request, sessions *store.Store, s
 
 	// Output conditions don't need the idle signal: they read the
 	// scrollback tee, which every adapter (including shell) produces.
-	if forText == "" && forRegex == "" && !adapterEmitsIdleSignal(sess.Adapter) {
-		writeError(w, http.StatusUnprocessableEntity, "no_idle_signal",
-			"the "+sess.Adapter+" adapter does not emit an idle signal; --wait is only supported for agent sessions")
+	if forText == "" && forRegex == "" && !sessionHasIdleSignal(sess) {
+		writeError(w, http.StatusUnprocessableEntity, "no_idle_signal", noIdleSignalMessage(sess))
 		return
 	}
 
@@ -425,9 +427,8 @@ func handleInputWait(w http.ResponseWriter, r *http.Request, sessions *store.Sto
 			"unsupported wait mode "+strconv.Quote(mode)+`; expected "idle"`)
 		return
 	}
-	if !adapterEmitsIdleSignal(sess.Adapter) {
-		writeError(w, http.StatusUnprocessableEntity, "no_idle_signal",
-			"the "+sess.Adapter+" adapter does not emit an idle signal; --wait is only supported for agent sessions")
+	if !sessionHasIdleSignal(sess) {
+		writeError(w, http.StatusUnprocessableEntity, "no_idle_signal", noIdleSignalMessage(sess))
 		return
 	}
 	if !inputSubmits(body) {
@@ -684,14 +685,55 @@ func hasRunEvidence(s store.Session, seenAlive bool) bool {
 	return seenAlive || s.ExitCode != nil || s.StartedAt != ""
 }
 
+// sessionHasIdleSignal reports whether --wait can observe a
+// meaningful idle transition for this session. Two sources:
+//
+//   - Adapter allowlist: the agent adapters always emit Working via
+//     their turn hooks, so their sessions are waitable from the moment
+//     they register — even before the first status event lands (a nil
+//     Status there means "turn in flight, hook not fired yet", and
+//     terminalReason correctly holds the wait for it).
+//
+//   - Per-session evidence: any other session whose Status is non-nil
+//     has demonstrably emitted a status transition. This is how shell
+//     sessions qualify (issue #373): the runner derives Working from
+//     OSC 133 prompt marks, so a shell whose integration emits them
+//     carries a non-nil Status from its first prompt on. A shell
+//     without that integration keeps a nil Status forever and is
+//     rejected up front, instead of accepting a wait that can never
+//     end. The cost of the evidence gate is a small startup window:
+//     a wait issued before the shell has drawn its first prompt is
+//     rejected even if the integration would have emitted marks.
+func sessionHasIdleSignal(sess store.Session) bool {
+	if adapterEmitsIdleSignal(sess.Adapter) {
+		return true
+	}
+	return sess.Status != nil
+}
+
+// noIdleSignalMessage explains a no_idle_signal rejection. Shell
+// sessions get an actionable message (the fix is enabling OSC 133
+// shell integration); everything else gets the generic adapter
+// limitation.
+func noIdleSignalMessage(sess store.Session) string {
+	if sess.Adapter == "shell" {
+		return "this shell session has not reported a prompt yet (no OSC 133 prompt marks observed); " +
+			"idle wait needs shell integration that emits them (fish does by default; bash/zsh need an integration snippet) — " +
+			"or wait on output with --for-text/--for-regex"
+	}
+	return "the " + sess.Adapter + " adapter does not emit an idle signal; --wait is only supported for agent and shell sessions"
+}
+
 // adapterEmitsIdleSignal reports whether sessions of the given
-// adapter ever transition Status.Working — i.e. whether --wait can
-// observe a meaningful idle event for them. Currently the agent
-// adapters (claude, codex, pi) all emit Working; the shell adapter
-// doesn't. Kept as an explicit allowlist so adding a new agent
-// adapter requires a deliberate update here, and so unknown adapters
-// (peer sessions whose adapter we don't know about, future adapters)
-// fail loudly instead of silently degrading to "always idle."
+// adapter always emit Status.Working transitions, regardless of
+// per-session evidence. Currently the agent adapters (claude, codex,
+// pi), whose hooks flip Working on every turn. Kept as an explicit
+// allowlist so adding a new agent adapter requires a deliberate
+// update here, and so unknown adapters (peer sessions whose adapter
+// we don't know about, future adapters) fail loudly instead of
+// silently degrading to "always idle." Shell sessions are not listed:
+// their signal depends on the user's shell integration, so they
+// qualify per-session via sessionHasIdleSignal's evidence check.
 func adapterEmitsIdleSignal(adapter string) bool {
 	switch adapter {
 	case "claude", "codex", "pi":

--- a/services/gmuxd/cmd/gmuxd/wait.go
+++ b/services/gmuxd/cmd/gmuxd/wait.go
@@ -157,17 +157,25 @@ func handleWait(w http.ResponseWriter, r *http.Request, sessions *store.Store, s
 			if ev.ID != sessionID {
 				continue
 			}
-			if ev.Session == nil {
-				// session-remove: the session was dismissed (UI close)
-				// or otherwise dropped from the store. From --wait's
-				// perspective this is indistinguishable from a crash:
-				// the agent is no longer reachable and won't ever
-				// reach idle. Without this case --wait would hang
-				// forever (the ticker fallback also returns no-op for
-				// missing sessions), which is exactly the failure mode
-				// no-default-timeout was meant to avoid.
+			if ev.Type == store.EventSessionRemove {
+				// The session was dismissed (UI close) or otherwise
+				// dropped from the store. From --wait's perspective this
+				// is indistinguishable from a crash: the session is no
+				// longer reachable and won't ever reach idle. Without
+				// this case --wait would hang forever (the ticker
+				// fallback also returns no-op for missing sessions),
+				// which is exactly the failure mode no-default-timeout
+				// was meant to avoid.
 				writeJSON(w, map[string]any{"ok": true, "data": map[string]any{"reason": "died"}})
 				return
+			}
+			if ev.Session == nil {
+				// Not a state change: session-activity (and any future
+				// payload-less signal) carries no Session. Dispatching on
+				// the event type matters here — treating every nil-Session
+				// event as a removal turned an unwatched session's output
+				// pulse into a spurious "died".
+				continue
 			}
 			seenAlive = seenAlive || ev.Session.Alive
 			if reason, done := terminalReason(*ev.Session, seenAlive); done {
@@ -540,9 +548,13 @@ func awaitTurn(ctx context.Context, sessions *store.Store, evCh <-chan store.Eve
 			if ev.ID != sessionID {
 				continue
 			}
-			if ev.Session == nil {
-				// session-remove: dismissed mid-wait. See handleWait.
+			if ev.Type == store.EventSessionRemove {
+				// Dismissed mid-wait. See handleWait.
 				return "died", false
+			}
+			if ev.Session == nil {
+				// session-activity: transient pulse, not a state change.
+				continue
 			}
 			if reason, done := check(*ev.Session); done {
 				return reason, false
@@ -601,12 +613,15 @@ func waitForSessionExit(sessions *store.Store, evCh <-chan store.Event, sessionI
 			if ev.ID != sessionID {
 				continue
 			}
-			if ev.Session == nil {
-				// session-remove for our id: the store dropped the
-				// session (a remove is never followed by a transient
-				// re-upsert of the same id; shadow eviction only
-				// removes other ids).
+			if ev.Type == store.EventSessionRemove {
+				// The store dropped the session (a remove is never
+				// followed by a transient re-upsert of the same id;
+				// shadow eviction only removes other ids).
 				return store.Session{}, errExitWaitRemoved
+			}
+			if ev.Session == nil {
+				// session-activity: transient pulse, not a state change.
+				continue
 			}
 			if ev.Session.Resumable {
 				return *ev.Session, nil

--- a/services/gmuxd/cmd/gmuxd/wait.go
+++ b/services/gmuxd/cmd/gmuxd/wait.go
@@ -29,42 +29,36 @@ import (
 // scrollback cap, not the poll interval). See waitForOutput.
 //
 // The single signal we wait on is the per-session Status.Working flag
-// the adapters emit. That's a precise, debounced signal: the agent
-// adapters flip it false once their agent has finished its turn
-// (claude / codex / pi all emit a Working transition), and shell
-// sessions flip it via runner-tracked OSC 133 prompt marks (busy on
-// command start, idle when the prompt returns — issue #373). Falling
-// back to "no output bytes for N seconds" would race ad-hoc against
-// tool-call progress prints; the explicit Working flag is what we
-// already use in the UI's idle indicator and is the right thing to
-// consume here.
+// — the turn state every session carries under the unified turn model:
+// agent adapters flip it via their turn hooks, shell sessions via
+// runner-tracked OSC 133 prompt marks, and sessions without either
+// (one-shot commands) are Working from launch until their exit closes
+// the lifetime turn (issue #373). Falling back to "no output bytes for
+// N seconds" would race ad-hoc against tool-call progress prints; the
+// explicit Working flag is what we already use in the UI's idle
+// indicator and is the right thing to consume here.
 //
-// Sessions with no idle signal (see sessionHasIdleSignal) are
-// rejected with 422 rather than silently returning "idle"
-// immediately, which would foot-trap the obvious composition
-// `gmux make build && gmux --wait <id>` into doing nothing.
+// Every session is waitable. A markless interactive shell is Working
+// for its whole life, so a wait on it blocks until the session exits —
+// honest "never provably idle" behavior, bounded by --timeout.
 //
 // Reasons returned in the response body:
 //
-//   - "idle": session reached Status.Working == false
-//   - "died": session is no longer reachable before becoming idle.
-//     This covers Alive flipping to false (the session crashed or its
-//     adapter exited) and the session being removed from the store
-//     (UI dismiss, or any other code path calling sessions.Remove).
-//     Both surface to the CLI as exit code 2; --wait callers don't
-//     need to distinguish them.
+//   - "idle": the session's turn closed — Status.Working == false,
+//     whether observed live or (via the Status persisted across death)
+//     because the turn was already closed when the process exited: a
+//     one-shot command completing, a shell exiting at its prompt, an
+//     agent exiting after finishing its turn.
+//   - "died": the session became unreachable with its turn still open
+//     (crash mid-command / mid-turn), never demonstrated a turn state
+//     at all, or was removed from the store (UI dismiss). Surfaces to
+//     the CLI as exit code 2.
 //
 // HTTP status codes:
 //
 //   - 200 with {reason}: terminal state reached (caller maps to its
 //     own exit code)
 //   - 408 Request Timeout: --timeout deadline elapsed
-//   - 422: session has no idle signal (idle mode only; output
-//     conditions work for every adapter, including shell). Only
-//     *live* sessions are rejected — the 422 exists to prevent waits
-//     that could hang forever, and a session that already exited
-//     resolves immediately as "died" instead (idle includes process
-//     exit)
 //   - 404: session not found
 //   - 400: bad timeout, bad regex, or both output conditions at once
 //
@@ -76,8 +70,7 @@ func handleWait(w http.ResponseWriter, r *http.Request, sessions *store.Store, s
 		return
 	}
 
-	sess, ok := sessions.Get(sessionID)
-	if !ok {
+	if _, ok := sessions.Get(sessionID); !ok {
 		writeError(w, http.StatusNotFound, "not_found", "session not found")
 		return
 	}
@@ -86,27 +79,6 @@ func handleWait(w http.ResponseWriter, r *http.Request, sessions *store.Store, s
 	forRegex := r.URL.Query().Get("for_regex")
 	if forText != "" && forRegex != "" {
 		writeError(w, http.StatusBadRequest, "bad_request", "for_text and for_regex are mutually exclusive")
-		return
-	}
-
-	// Output conditions don't need the idle signal: they read the
-	// scrollback tee, which every adapter (including shell) produces.
-	if forText == "" && forRegex == "" && !sessionHasIdleSignal(sess) {
-		// A session that already exited is a resolved wait, not a
-		// missing capability: idle includes process exit, so answer
-		// "died" (same as a dead agent) instead of rejecting with
-		// shell-integration advice that can't help a dead session.
-		// Strictly death, though — NOT terminalReason, whose idle arm
-		// would let a live no-signal session with a stale one-off
-		// Status silently return "idle", the exact foot-gun this 422
-		// exists to prevent. The 422 below fires only for sessions
-		// that could otherwise hang the wait forever — live (or
-		// startup-window) sessions with no demonstrated idle signal.
-		if !sess.Alive && hasRunEvidence(sess, false) {
-			writeJSON(w, map[string]any{"ok": true, "data": map[string]any{"reason": "died"}})
-			return
-		}
-		writeError(w, http.StatusUnprocessableEntity, "no_idle_signal", noIdleSignalMessage(sess))
 		return
 	}
 
@@ -426,13 +398,12 @@ func timeoutChan(r *http.Request) (<-chan time.Time, error) {
 // the input delivery.
 //
 // Contract mirrors handleWait: 200 {reason: idle|died}, 408 on
-// ?timeout=N elapsing, 422 for sessions with no idle signal (the
-// input handler's !Alive => 409 check runs first, so unlike
-// handleWait there is no dead-session case to resolve here). One
-// additional 422 ("input_no_submit") rejects bodies that carry no
-// carriage return: input that doesn't submit never starts a turn, so
-// waiting on it would only ever time out — fail loudly at the edge
-// instead.
+// ?timeout=N elapsing. A 422 ("input_no_submit") rejects bodies that
+// carry no carriage return: input that doesn't submit never starts a
+// turn, so waiting on it would only ever time out — fail loudly at
+// the edge instead. Every session is otherwise accepted; on a session
+// that never closes its turn (markless interactive shell) the wait
+// blocks until exit or --timeout, same as handleWait.
 //
 // send is a closure over the runner delivery (discovery.SendInput)
 // so this handler — and its tests — stay independent of the socket
@@ -445,10 +416,6 @@ func handleInputWait(w http.ResponseWriter, r *http.Request, sessions *store.Sto
 		// degrading to fire-and-forget.
 		writeError(w, http.StatusBadRequest, "bad_request",
 			"unsupported wait mode "+strconv.Quote(mode)+`; expected "idle"`)
-		return
-	}
-	if !sessionHasIdleSignal(sess) {
-		writeError(w, http.StatusUnprocessableEntity, "no_idle_signal", noIdleSignalMessage(sess))
 		return
 	}
 	if !inputSubmits(body) {
@@ -525,7 +492,16 @@ func awaitTurn(ctx context.Context, sessions *store.Store, evCh <-chan store.Eve
 			// No #216 startup-window gate here (unlike terminalReason /
 			// hasRunEvidence): handleInputWait only runs after the input
 			// handler's `!sess.Alive => 409` check, so we enter with a
-			// live session and any Alive==false is a genuine death.
+			// live session and any Alive==false is a genuine exit. Like
+			// terminalReason, the exit resolves by turn state: if a fresh
+			// Working pulse was observed and the turn is closed at death
+			// (the runner emits the close before the exit event), the
+			// input's turn completed — e.g. input to a one-shot whose
+			// processing ended when the process exited. Otherwise the
+			// session died mid-turn.
+			if seenWorking && s.Status != nil && !s.Status.Working {
+				return "idle", true
+			}
 			return "died", true
 		}
 		if s.Status != nil && s.Status.Working {
@@ -662,15 +638,25 @@ func waitForSessionExit(sessions *store.Store, evCh <-chan store.Event, sessionI
 // The Alive flag needs the symmetric treatment: right after launch
 // the session exists in the store with Alive == false until the
 // runner's first upsert lands, and reporting "died" during that
-// window is a phantom death (issue #216). "died" therefore requires
-// hasRunEvidence(s, seenAlive) — see that helper for the three signals
-// that count as "this session actually ran."
+// window is a phantom death (issue #216). A dead-session verdict
+// therefore requires hasRunEvidence(s, seenAlive) — see that helper
+// for the three signals that count as "this session actually ran."
+//
+// Death itself resolves by turn state (the Status the exit handling
+// persists across death): a closed turn at exit means the session
+// reached idle — a one-shot command completing, a shell exiting at
+// its prompt, an agent exiting after its turn — and reports "idle"
+// whether the wait watched it live or arrived afterwards. An open (or
+// never-demonstrated) turn at death is a genuine "died".
 func terminalReason(s store.Session, seenAlive bool) (string, bool) {
 	if !s.Alive {
-		if hasRunEvidence(s, seenAlive) {
-			return "died", true
+		if !hasRunEvidence(s, seenAlive) {
+			return "", false
 		}
-		return "", false
+		if s.Status != nil && !s.Status.Working {
+			return "idle", true
+		}
+		return "died", true
 	}
 	if s.Status != nil && !s.Status.Working {
 		return "idle", true
@@ -705,68 +691,3 @@ func hasRunEvidence(s store.Session, seenAlive bool) bool {
 	return seenAlive || s.ExitCode != nil || s.StartedAt != ""
 }
 
-// sessionHasIdleSignal reports whether --wait can observe a
-// meaningful idle transition for this session. Two sources:
-//
-//   - Adapter allowlist: the agent adapters always emit Working via
-//     their turn hooks, so their sessions are waitable from the moment
-//     they register — even before the first status event lands (a nil
-//     Status there means "turn in flight, hook not fired yet", and
-//     terminalReason correctly holds the wait for it).
-//
-//   - Per-session evidence, for shell sessions only (issue #373): the
-//     runner derives Working from OSC 133 prompt marks, so a shell
-//     whose integration emits them carries a non-nil Status from its
-//     first prompt on — evidence of a real busy/idle cycle. A shell
-//     without that integration keeps a nil Status forever and is
-//     rejected up front, instead of accepting a wait that can never
-//     end. The cost of the evidence gate is a small startup window:
-//     a wait issued before the shell has drawn its first prompt is
-//     rejected even if the integration would have emitted marks.
-//
-// The evidence check is deliberately NOT generalized to other
-// adapters: a non-nil Status only proves *some* status was emitted
-// (a one-off Monitor event, a child's single PUT /status, even a
-// status *clear*), not that the session produces the busy→idle turn
-// pulse send --wait requires — accepting those would trade the loud
-// 422 for a silent timeout. For the shell adapter the runner itself
-// owns the semantics (prompt marks are the only Status writer), so
-// the evidence is trustworthy. New adapter kinds should be admitted
-// deliberately, matching adapterEmitsIdleSignal's allowlist stance.
-func sessionHasIdleSignal(sess store.Session) bool {
-	if adapterEmitsIdleSignal(sess.Adapter) {
-		return true
-	}
-	return sess.Adapter == "shell" && sess.Status != nil
-}
-
-// noIdleSignalMessage explains a no_idle_signal rejection. Shell
-// sessions get an actionable message (the fix is enabling OSC 133
-// shell integration); everything else gets the generic adapter
-// limitation.
-func noIdleSignalMessage(sess store.Session) string {
-	if sess.Adapter == "shell" {
-		return "this shell session has not reported a prompt yet (no OSC 133 prompt marks observed); " +
-			"idle wait needs shell integration that emits them (fish does by default; bash/zsh need an integration snippet) — " +
-			"or wait on output with --for-text/--for-regex"
-	}
-	return "the " + sess.Adapter + " adapter does not emit an idle signal; --wait is only supported for agent and shell sessions"
-}
-
-// adapterEmitsIdleSignal reports whether sessions of the given
-// adapter always emit Status.Working transitions, regardless of
-// per-session evidence. Currently the agent adapters (claude, codex,
-// pi), whose hooks flip Working on every turn. Kept as an explicit
-// allowlist so adding a new agent adapter requires a deliberate
-// update here, and so unknown adapters (peer sessions whose adapter
-// we don't know about, future adapters) fail loudly instead of
-// silently degrading to "always idle." Shell sessions are not listed:
-// their signal depends on the user's shell integration, so they
-// qualify per-session via sessionHasIdleSignal's evidence check.
-func adapterEmitsIdleSignal(adapter string) bool {
-	switch adapter {
-	case "claude", "codex", "pi":
-		return true
-	}
-	return false
-}

--- a/services/gmuxd/cmd/gmuxd/wait.go
+++ b/services/gmuxd/cmd/gmuxd/wait.go
@@ -96,11 +96,14 @@ func handleWait(w http.ResponseWriter, r *http.Request, sessions *store.Store, s
 		// missing capability: idle includes process exit, so answer
 		// "died" (same as a dead agent) instead of rejecting with
 		// shell-integration advice that can't help a dead session.
-		// The 422 below only fires for sessions that could otherwise
-		// hang the wait forever — live (or startup-window) sessions
-		// that have never demonstrated an idle signal.
-		if reason, done := terminalReason(sess, false); done {
-			writeJSON(w, map[string]any{"ok": true, "data": map[string]any{"reason": reason}})
+		// Strictly death, though — NOT terminalReason, whose idle arm
+		// would let a live no-signal session with a stale one-off
+		// Status silently return "idle", the exact foot-gun this 422
+		// exists to prevent. The 422 below fires only for sessions
+		// that could otherwise hang the wait forever — live (or
+		// startup-window) sessions with no demonstrated idle signal.
+		if !sess.Alive && hasRunEvidence(sess, false) {
+			writeJSON(w, map[string]any{"ok": true, "data": map[string]any{"reason": "died"}})
 			return
 		}
 		writeError(w, http.StatusUnprocessableEntity, "no_idle_signal", noIdleSignalMessage(sess))
@@ -711,21 +714,30 @@ func hasRunEvidence(s store.Session, seenAlive bool) bool {
 //     Status there means "turn in flight, hook not fired yet", and
 //     terminalReason correctly holds the wait for it).
 //
-//   - Per-session evidence: any other session whose Status is non-nil
-//     has demonstrably emitted a status transition. This is how shell
-//     sessions qualify (issue #373): the runner derives Working from
-//     OSC 133 prompt marks, so a shell whose integration emits them
-//     carries a non-nil Status from its first prompt on. A shell
+//   - Per-session evidence, for shell sessions only (issue #373): the
+//     runner derives Working from OSC 133 prompt marks, so a shell
+//     whose integration emits them carries a non-nil Status from its
+//     first prompt on — evidence of a real busy/idle cycle. A shell
 //     without that integration keeps a nil Status forever and is
 //     rejected up front, instead of accepting a wait that can never
 //     end. The cost of the evidence gate is a small startup window:
 //     a wait issued before the shell has drawn its first prompt is
 //     rejected even if the integration would have emitted marks.
+//
+// The evidence check is deliberately NOT generalized to other
+// adapters: a non-nil Status only proves *some* status was emitted
+// (a one-off Monitor event, a child's single PUT /status, even a
+// status *clear*), not that the session produces the busy→idle turn
+// pulse send --wait requires — accepting those would trade the loud
+// 422 for a silent timeout. For the shell adapter the runner itself
+// owns the semantics (prompt marks are the only Status writer), so
+// the evidence is trustworthy. New adapter kinds should be admitted
+// deliberately, matching adapterEmitsIdleSignal's allowlist stance.
 func sessionHasIdleSignal(sess store.Session) bool {
 	if adapterEmitsIdleSignal(sess.Adapter) {
 		return true
 	}
-	return sess.Status != nil
+	return sess.Adapter == "shell" && sess.Status != nil
 }
 
 // noIdleSignalMessage explains a no_idle_signal rejection. Shell

--- a/services/gmuxd/cmd/gmuxd/wait_test.go
+++ b/services/gmuxd/cmd/gmuxd/wait_test.go
@@ -349,36 +349,38 @@ func TestWaitTimesOut(t *testing.T) {
 	}
 }
 
-// TestWaitRejectsShellSessionsWithoutPromptMarks pins the evidence
-// gate: a shell session that has never emitted a status transition
-// (nil Status — no OSC 133 prompt marks observed by the runner) has
-// no idle signal, so `gmux wait` against it would either return
-// immediately with a bogus "idle" or hang forever. 422 surfaces the
-// limitation explicitly, keeping `gmux make build && gmux wait <id>`
-// from silently doing nothing.
-func TestWaitRejectsShellSessionsWithoutPromptMarks(t *testing.T) {
+// TestWaitMarklessLiveShellBlocks pins the "hangs honestly" contract
+// that replaced the old no_idle_signal 422: a live shell on the
+// lifetime turn (Working=true since launch, no prompt marks) is never
+// provably idle, so the wait blocks until exit or ?timeout — it must
+// neither reject nor return a bogus immediate "idle".
+func TestWaitMarklessLiveShellBlocks(t *testing.T) {
 	srv, st, _ := waitTestServer(t)
 	st.Upsert(store.Session{
 		ID:      "sess-shell",
 		Adapter: "shell",
 		Alive:   true,
+		Status:  &store.Status{Working: true},
 	})
 
-	resp, _ := postWait(t, srv, "sess-shell")
-	if resp.StatusCode != http.StatusUnprocessableEntity {
-		t.Errorf("status = %d, want 422", resp.StatusCode)
+	start := time.Now()
+	resp, _ := postWaitQuery(t, srv, "sess-shell", "timeout=1")
+	elapsed := time.Since(start)
+
+	if resp.StatusCode != http.StatusRequestTimeout {
+		t.Fatalf("status = %d, want 408", resp.StatusCode)
+	}
+	if elapsed < 900*time.Millisecond || elapsed > 2*time.Second {
+		t.Errorf("elapsed = %v, want ~1s", elapsed)
 	}
 }
 
-// TestWaitRejectsNonShellStatusEvidence pins the scope of the
-// per-session evidence gate: a non-agent, non-shell session with a
-// non-nil Status (a one-off Monitor event, a child's single
-// PUT /status — even a status clear round-trips as a non-nil zero
-// value) is NOT waitable. Such a status proves something was emitted
-// once, not that the session produces the busy→idle pulse the wait
-// contract needs; admitting it would trade the loud 422 for a silent
-// timeout. New adapter kinds must be allowlisted deliberately.
-func TestWaitRejectsNonShellStatusEvidence(t *testing.T) {
+// TestWaitAnyAdapterWithTurnStateIsWaitable pins the removal of the
+// adapter allowlist/evidence gate: under the unified turn model every
+// session carries turn state (the runner's default model covers
+// non-hook-driven adapters like editor), so an idle Status resolves
+// the wait regardless of adapter name.
+func TestWaitAnyAdapterWithTurnStateIsWaitable(t *testing.T) {
 	srv, st, _ := waitTestServer(t)
 	st.Upsert(store.Session{
 		ID:      "sess-editor",
@@ -387,36 +389,53 @@ func TestWaitRejectsNonShellStatusEvidence(t *testing.T) {
 		Status:  &store.Status{Working: false},
 	})
 
-	resp, _ := postWait(t, srv, "sess-editor")
-	if resp.StatusCode != http.StatusUnprocessableEntity {
-		t.Errorf("status = %d, want 422", resp.StatusCode)
-	}
-}
-
-// TestWaitDeadShellWithoutMarksReturnsDied: a shell session that
-// already exited — the one-shot `gmux -d -- make && gmux wait $id`
-// arriving after the command finished — must resolve as "died"
-// (exit code 2, same as a dead agent), not 422 with shell-integration
-// advice that can't help a dead session. The no-idle-signal rejection
-// exists to prevent waits that could hang forever; a dead session
-// resolves immediately, so there is nothing to protect against.
-func TestWaitDeadShellWithoutMarksReturnsDied(t *testing.T) {
-	srv, st, _ := waitTestServer(t)
-	exitCode := 0
-	st.Upsert(store.Session{
-		ID:        "sess-shell-dead",
-		Adapter:   "shell",
-		Alive:     false,
-		ExitCode:  &exitCode,
-		StartedAt: "2026-07-11T00:00:00Z",
-	})
-
-	resp, body := postWait(t, srv, "sess-shell-dead")
+	resp, body := postWait(t, srv, "sess-editor")
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status = %d, want 200", resp.StatusCode)
 	}
-	if got := body["data"].(map[string]any)["reason"]; got != "died" {
-		t.Errorf("reason = %v, want died", got)
+	if got := body["data"].(map[string]any)["reason"]; got != "idle" {
+		t.Errorf("reason = %v, want idle", got)
+	}
+}
+
+// TestWaitDeadSessionResolvesByTurnState pins turn-state-at-death: the
+// Status persisted across the exit event records whether the session's
+// turn was closed when it exited, and a wait arriving after the death
+// answers the same as one that watched it live — "idle" for a closed
+// turn (one-shot completed, shell exited at its prompt, agent exited
+// after its turn), "died" for an open turn (mid-command crash) or for
+// a session that never demonstrated any turn state (nil Status).
+func TestWaitDeadSessionResolvesByTurnState(t *testing.T) {
+	exitCode := 0
+	cases := []struct {
+		name   string
+		status *store.Status
+		want   string
+	}{
+		{"closed turn → idle", &store.Status{Working: false}, "idle"},
+		{"open turn → died", &store.Status{Working: true}, "died"},
+		{"no turn state → died", nil, "died"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, st, _ := waitTestServer(t)
+			st.Upsert(store.Session{
+				ID:        "sess-dead",
+				Adapter:   "shell",
+				Alive:     false,
+				ExitCode:  &exitCode,
+				StartedAt: "2026-07-11T00:00:00Z",
+				Status:    tc.status,
+			})
+
+			resp, body := postWait(t, srv, "sess-dead")
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status = %d, want 200", resp.StatusCode)
+			}
+			if got := body["data"].(map[string]any)["reason"]; got != tc.want {
+				t.Errorf("reason = %v, want %s", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/services/gmuxd/cmd/gmuxd/wait_test.go
+++ b/services/gmuxd/cmd/gmuxd/wait_test.go
@@ -370,6 +370,33 @@ func TestWaitRejectsShellSessionsWithoutPromptMarks(t *testing.T) {
 	}
 }
 
+// TestWaitDeadShellWithoutMarksReturnsDied: a shell session that
+// already exited — the one-shot `gmux -d -- make && gmux wait $id`
+// arriving after the command finished — must resolve as "died"
+// (exit code 2, same as a dead agent), not 422 with shell-integration
+// advice that can't help a dead session. The no-idle-signal rejection
+// exists to prevent waits that could hang forever; a dead session
+// resolves immediately, so there is nothing to protect against.
+func TestWaitDeadShellWithoutMarksReturnsDied(t *testing.T) {
+	srv, st, _ := waitTestServer(t)
+	exitCode := 0
+	st.Upsert(store.Session{
+		ID:        "sess-shell-dead",
+		Adapter:   "shell",
+		Alive:     false,
+		ExitCode:  &exitCode,
+		StartedAt: "2026-07-11T00:00:00Z",
+	})
+
+	resp, body := postWait(t, srv, "sess-shell-dead")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if got := body["data"].(map[string]any)["reason"]; got != "died" {
+		t.Errorf("reason = %v, want died", got)
+	}
+}
+
 // TestWaitShellWithPromptMarksReturnsWhenIdle: a shell session whose
 // runner has observed OSC 133 prompt marks carries a non-nil Status,
 // which is the per-session evidence that an idle signal exists

--- a/services/gmuxd/cmd/gmuxd/wait_test.go
+++ b/services/gmuxd/cmd/gmuxd/wait_test.go
@@ -375,6 +375,38 @@ func TestWaitMarklessLiveShellBlocks(t *testing.T) {
 	}
 }
 
+// TestWaitIgnoresActivityPulse guards the event dispatch: a
+// session-activity broadcast (transient output pulse) carries no
+// Session payload, and the wait loop must skip it — not mistake it
+// for a session-remove and report a spurious "died". Regression test
+// for the bug where any unwatched session that produced output while
+// a wait was pending resolved the wait as died.
+func TestWaitIgnoresActivityPulse(t *testing.T) {
+	srv, st, _ := waitTestServer(t)
+	st.Upsert(store.Session{
+		ID:      "sess-pulse",
+		Adapter: "shell",
+		Alive:   true,
+		Status:  &store.Status{Working: true},
+	})
+
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		st.Broadcast(store.Event{Type: store.EventSessionActivity, ID: "sess-pulse"})
+	}()
+
+	start := time.Now()
+	resp, _ := postWaitQuery(t, srv, "sess-pulse", "timeout=1")
+	elapsed := time.Since(start)
+
+	if resp.StatusCode != http.StatusRequestTimeout {
+		t.Fatalf("status = %d, want 408 (activity pulse must not resolve the wait)", resp.StatusCode)
+	}
+	if elapsed < 900*time.Millisecond {
+		t.Errorf("wait returned after %v — resolved by the activity pulse", elapsed)
+	}
+}
+
 // TestWaitAnyAdapterWithTurnStateIsWaitable pins the removal of the
 // adapter allowlist/evidence gate: under the unified turn model every
 // session carries turn state (the runner's default model covers

--- a/services/gmuxd/cmd/gmuxd/wait_test.go
+++ b/services/gmuxd/cmd/gmuxd/wait_test.go
@@ -349,12 +349,14 @@ func TestWaitTimesOut(t *testing.T) {
 	}
 }
 
-// TestWaitRejectsShellSessions pins the allowlist: shell sessions
-// don't emit Working transitions, so `gmux --wait` against them
-// would return immediately with reason=idle and silently do the
-// wrong thing for `gmux make build && gmux --wait <id>`-style
-// composition. 422 surfaces the limitation explicitly.
-func TestWaitRejectsShellSessions(t *testing.T) {
+// TestWaitRejectsShellSessionsWithoutPromptMarks pins the evidence
+// gate: a shell session that has never emitted a status transition
+// (nil Status — no OSC 133 prompt marks observed by the runner) has
+// no idle signal, so `gmux wait` against it would either return
+// immediately with a bogus "idle" or hang forever. 422 surfaces the
+// limitation explicitly, keeping `gmux make build && gmux wait <id>`
+// from silently doing nothing.
+func TestWaitRejectsShellSessionsWithoutPromptMarks(t *testing.T) {
 	srv, st, _ := waitTestServer(t)
 	st.Upsert(store.Session{
 		ID:      "sess-shell",
@@ -365,6 +367,79 @@ func TestWaitRejectsShellSessions(t *testing.T) {
 	resp, _ := postWait(t, srv, "sess-shell")
 	if resp.StatusCode != http.StatusUnprocessableEntity {
 		t.Errorf("status = %d, want 422", resp.StatusCode)
+	}
+}
+
+// TestWaitShellWithPromptMarksReturnsWhenIdle: a shell session whose
+// runner has observed OSC 133 prompt marks carries a non-nil Status,
+// which is the per-session evidence that an idle signal exists
+// (issue #373). A shell sitting at its prompt (Working=false) is
+// idle; wait returns immediately, same as an idle agent.
+func TestWaitShellWithPromptMarksReturnsWhenIdle(t *testing.T) {
+	srv, st, _ := waitTestServer(t)
+	st.Upsert(store.Session{
+		ID:      "sess-shell-prompt",
+		Adapter: "shell",
+		Alive:   true,
+		Status:  &store.Status{Working: false},
+	})
+
+	resp, body := postWait(t, srv, "sess-shell-prompt")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if got := body["data"].(map[string]any)["reason"]; got != "idle" {
+		t.Errorf("reason = %v, want idle", got)
+	}
+}
+
+// TestWaitShellBlocksUntilPromptReturns: a shell mid-command
+// (Working=true from the OSC 133 command-start mark) blocks the wait;
+// the prompt-start mark flipping Working=false unblocks it. This is
+// the shell counterpart of TestWaitBlocksUntilWorkingFlipsFalse and
+// fails with a 422 without the per-session evidence gate.
+func TestWaitShellBlocksUntilPromptReturns(t *testing.T) {
+	srv, st, _ := waitTestServer(t)
+	st.Upsert(store.Session{
+		ID:      "sess-shell-busy",
+		Adapter: "shell",
+		Alive:   true,
+		Status:  &store.Status{Working: true},
+	})
+
+	done := make(chan struct{})
+	var resp *http.Response
+	var body map[string]any
+	go func() {
+		resp, body = postWait(t, srv, "sess-shell-busy")
+		close(done)
+	}()
+
+	time.Sleep(150 * time.Millisecond)
+	select {
+	case <-done:
+		t.Fatal("wait returned while the shell was still running its command")
+	default:
+	}
+
+	// The prompt returns: runner-tracked OSC 133;A flips Working=false.
+	st.Upsert(store.Session{
+		ID:      "sess-shell-busy",
+		Adapter: "shell",
+		Alive:   true,
+		Status:  &store.Status{Working: false},
+	})
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("wait did not return after the prompt returned")
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if got := body["data"].(map[string]any)["reason"]; got != "idle" {
+		t.Errorf("reason = %v, want idle", got)
 	}
 }
 

--- a/services/gmuxd/cmd/gmuxd/wait_test.go
+++ b/services/gmuxd/cmd/gmuxd/wait_test.go
@@ -370,6 +370,29 @@ func TestWaitRejectsShellSessionsWithoutPromptMarks(t *testing.T) {
 	}
 }
 
+// TestWaitRejectsNonShellStatusEvidence pins the scope of the
+// per-session evidence gate: a non-agent, non-shell session with a
+// non-nil Status (a one-off Monitor event, a child's single
+// PUT /status — even a status clear round-trips as a non-nil zero
+// value) is NOT waitable. Such a status proves something was emitted
+// once, not that the session produces the busy→idle pulse the wait
+// contract needs; admitting it would trade the loud 422 for a silent
+// timeout. New adapter kinds must be allowlisted deliberately.
+func TestWaitRejectsNonShellStatusEvidence(t *testing.T) {
+	srv, st, _ := waitTestServer(t)
+	st.Upsert(store.Session{
+		ID:      "sess-editor",
+		Adapter: "editor",
+		Alive:   true,
+		Status:  &store.Status{Working: false},
+	})
+
+	resp, _ := postWait(t, srv, "sess-editor")
+	if resp.StatusCode != http.StatusUnprocessableEntity {
+		t.Errorf("status = %d, want 422", resp.StatusCode)
+	}
+}
+
 // TestWaitDeadShellWithoutMarksReturnsDied: a shell session that
 // already exited — the one-shot `gmux -d -- make && gmux wait $id`
 // arriving after the command finished — must resolve as "died"

--- a/services/gmuxd/internal/conversations/opaque_ref_test.go
+++ b/services/gmuxd/internal/conversations/opaque_ref_test.go
@@ -27,7 +27,6 @@ func (d *dbAdapter) Name() string {
 func (d *dbAdapter) Discover() bool                    { return true }
 func (d *dbAdapter) Match(_ []string) bool             { return false }
 func (d *dbAdapter) Env(_ adapter.EnvContext) []string { return nil }
-func (d *dbAdapter) Monitor(_ []byte) *adapter.Event   { return nil }
 
 func (d *dbAdapter) DescribeConversation(ref string) (*adapter.ConversationInfo, error) {
 	row, ok := d.rows[ref]

--- a/services/gmuxd/internal/discovery/subscribe.go
+++ b/services/gmuxd/internal/discovery/subscribe.go
@@ -282,18 +282,18 @@ func (sub *Subscriptions) handleEvent(sessionID, socketPath, eventType string, d
 		sess.ExitCode = &exit.ExitCode
 		sess.ExitedAt = time.Now().UTC().Format(time.RFC3339)
 		// Let the OnExit hook set the resume command before upsert.
-		// If it returns true, the session transitioned to resumable,
-		// so don't overwrite with exit status.
-		resumed := false
 		if sub.OnExit != nil {
-			resumed = sub.OnExit(&sess)
+			sub.OnExit(&sess)
 		}
-		if !resumed {
-			// Status carries only live working/error state; on exit it's
-			// meaningless. The frontend derives any "exited (N)" text from
-			// exit_code, so just clear it.
-			sess.Status = nil
-		}
+		// The last Status is deliberately kept across death: it records
+		// whether the session's turn was closed when the process exited,
+		// which is what lets a wait issued after the exit resolve the
+		// same way as one that watched it live — "idle" for a closed
+		// turn (one-shot completed, shell exited at its prompt, agent
+		// exited after its turn), "died" for an open one (mid-command /
+		// mid-turn crash). See terminalReason. The frontend keys its
+		// working/error dots on Alive and derives "exited (N)" from
+		// exit_code, so a persisted Status doesn't disturb it.
 		if !sub.store.Update(sessionID, func(current *store.Session) {
 			*current = sess
 		}) {

--- a/services/gmuxd/internal/discovery/subscribe.go
+++ b/services/gmuxd/internal/discovery/subscribe.go
@@ -30,10 +30,12 @@ type Subscriptions struct {
 	mu     sync.Mutex
 	active map[string]*subEntry // sessionID → entry
 	store  *store.Store
-	// OnExit is called after a session exit event is processed.
-	// Returns true if the session was transitioned to resumable
-	// (caller should not set exit status).
-	OnExit func(sess *store.Session) bool
+	// OnExit is called while a session exit event is being processed,
+	// before the dead session is written back to the store. The hook may
+	// mutate the session (gmuxd derives the resume command here) but must
+	// leave Status alone: the last Status is the session's turn state at
+	// death, which post-mortem waits resolve by (ADR 0023).
+	OnExit func(sess *store.Session)
 	// OnDead fires after the store Upsert that records an exit
 	// event. The session passed is the post-Upsert snapshot,
 	// including any Title / Resumable derivation the store applied
@@ -249,7 +251,11 @@ func (sub *Subscriptions) handleEvent(sessionID, socketPath, eventType string, d
 			if meta.Unread != nil {
 				sess.Unread = *meta.Unread
 				if !*meta.Unread && sess.Status != nil && sess.Status.Error {
-					sess.Status.Error = false
+					// Replace, don't mutate: store.Update's copy is shallow,
+					// so writing through the shared *Status would also
+					// rewrite the store's previous snapshot and defeat its
+					// no-op change detection.
+					sess.Status = &store.Status{Working: sess.Status.Working}
 				}
 			}
 			// A slug key is only ever present on a deliberate SetSlug (the
@@ -333,7 +339,7 @@ func (sub *Subscriptions) handleEvent(sessionID, socketPath, eventType string, d
 		// Transient signal: terminal produced output with no attached clients.
 		// Forward to the store's subscribers without mutating state.
 		sub.store.Broadcast(store.Event{
-			Type: "session-activity",
+			Type: store.EventSessionActivity,
 			ID:   sessionID,
 		})
 

--- a/services/gmuxd/internal/discovery/subscribe_test.go
+++ b/services/gmuxd/internal/discovery/subscribe_test.go
@@ -201,11 +201,10 @@ func TestExitEventDoesNotResurrectDismissedSession(t *testing.T) {
 	subs := NewSubscriptions(sessions)
 	onExitStarted := make(chan struct{})
 	allowOnExit := make(chan struct{})
-	subs.OnExit = func(sess *store.Session) bool {
+	subs.OnExit = func(sess *store.Session) {
 		close(onExitStarted)
 		<-allowOnExit
 		sess.Command = []string{"bash", "-l"}
-		return true
 	}
 
 	exitDone := make(chan struct{})
@@ -233,6 +232,46 @@ func TestExitEventDoesNotResurrectDismissedSession(t *testing.T) {
 
 	if got, ok := sessions.Get(id); ok {
 		t.Fatalf("dismissed session was resurrected by late exit event: %+v", got)
+	}
+}
+
+// TestExitEventPreservesTurnStateThroughResumeDerivation pins the
+// turn-state-at-death contract (ADR 0023) at the exit seam: the last
+// Status must survive the exit event even when the OnExit hook
+// transitions the session to resumable. Nil-ing it there ("clean
+// resumable display", as gmuxd once did) silently split the wait
+// contract by timing — a live wait on a cleanly-exited agent resolved
+// "idle" while a wait issued a moment later resolved "died".
+func TestExitEventPreservesTurnStateThroughResumeDerivation(t *testing.T) {
+	const id = "sess-exit-turn-state"
+	sessions := store.New()
+	sessions.Upsert(store.Session{
+		ID:      id,
+		Adapter: "pi",
+		Alive:   true,
+		Command: []string{"pi"},
+		Status:  &store.Status{Working: false}, // turn closed before exit
+	})
+
+	subs := NewSubscriptions(sessions)
+	subs.OnExit = func(sess *store.Session) {
+		sess.Command = []string{"pi", "--resume", "abc"} // resumable
+	}
+
+	subs.handleEvent(id, "", "exit", []byte(`{"exit_code":0}`))
+
+	got, ok := sessions.Get(id)
+	if !ok {
+		t.Fatal("session missing after exit event")
+	}
+	if got.Alive {
+		t.Error("session still alive after exit event")
+	}
+	if !got.Resumable {
+		t.Error("session not resumable despite OnExit setting a resume command")
+	}
+	if got.Status == nil || got.Status.Working {
+		t.Errorf("Status = %+v after exit, want the pre-exit closed-turn state to survive", got.Status)
 	}
 }
 

--- a/services/gmuxd/internal/notify/notify.go
+++ b/services/gmuxd/internal/notify/notify.go
@@ -139,9 +139,9 @@ func snapshotOf(s store.Session) sessionSnapshot {
 }
 
 func (r *Router) handleEvent(ev store.Event) {
-	if ev.Type != "session-upsert" || ev.Session == nil {
+	if ev.Type != store.EventSessionUpsert || ev.Session == nil {
 		// session-remove: clean up prevState
-		if ev.Type == "session-remove" {
+		if ev.Type == store.EventSessionRemove {
 			r.mu.Lock()
 			delete(r.prevState, ev.ID)
 			r.mu.Unlock()

--- a/services/gmuxd/internal/peering/peer.go
+++ b/services/gmuxd/internal/peering/peer.go
@@ -479,7 +479,7 @@ func (p *Peer) handleEvent(ctx context.Context, eventType string, data []byte) {
 		}
 		p.applySessionsSnapshot(payload.Sessions)
 
-	case "session-activity":
+	case store.EventSessionActivity:
 		var ev sseActivity
 		if err := json.Unmarshal(data, &ev); err != nil {
 			return
@@ -489,7 +489,7 @@ func (p *Peer) handleEvent(ctx context.Context, eventType string, data []byte) {
 		}
 		namespacedID := NamespaceID(ev.ID, p.Config.Name)
 		p.store.Broadcast(store.Event{
-			Type: "session-activity",
+			Type: store.EventSessionActivity,
 			ID:   namespacedID,
 		})
 

--- a/services/gmuxd/internal/sessionmeta/sessionmeta.go
+++ b/services/gmuxd/internal/sessionmeta/sessionmeta.go
@@ -376,7 +376,7 @@ func (s *Store) Remove(id string) error {
 // (i.e., when the store subscription is cancelled at shutdown).
 func (s *Store) WatchRemovals(events <-chan store.Event) {
 	for ev := range events {
-		if ev.Type != "session-remove" {
+		if ev.Type != store.EventSessionRemove {
 			continue
 		}
 		if err := s.Remove(ev.ID); err != nil {

--- a/services/gmuxd/internal/store/store.go
+++ b/services/gmuxd/internal/store/store.go
@@ -179,8 +179,17 @@ type Status struct {
 	Error   bool `json:"error,omitempty"`
 }
 
+// Event types on the store's subscriber bus. Only EventSessionUpsert
+// carries a Session payload; consumers must dispatch on Type, not on
+// Session == nil (an activity pulse is not a removal).
+const (
+	EventSessionUpsert   = "session-upsert"   // state change; Session present
+	EventSessionRemove   = "session-remove"   // session dropped from the store
+	EventSessionActivity = "session-activity" // transient output pulse; no Session
+)
+
 type Event struct {
-	Type string `json:"type"` // "session-upsert" | "session-remove"
+	Type string `json:"type"` // EventSessionUpsert | EventSessionRemove | EventSessionActivity
 	ID   string `json:"id"`
 
 	// Present for session-upsert

--- a/services/gmuxd/internal/store/store.go
+++ b/services/gmuxd/internal/store/store.go
@@ -401,13 +401,13 @@ func (s *Store) commitLocked(prev Session, hadPrev bool, sess *Session) (removed
 // unless the write was skipped or a no-op. Caller must NOT hold s.mu.
 func (s *Store) broadcastCommit(sess Session, removed []string, skip, unchanged bool) {
 	for _, id := range removed {
-		s.broadcast(Event{Type: "session-remove", ID: id})
+		s.broadcast(Event{Type: EventSessionRemove, ID: id})
 	}
 	if skip || unchanged {
 		return
 	}
 	s.broadcast(Event{
-		Type:    "session-upsert",
+		Type:    EventSessionUpsert,
 		ID:      sess.ID,
 		Session: &sess,
 	})
@@ -474,7 +474,7 @@ func (s *Store) SetTerminalSize(id string, cols, rows uint16) bool {
 	s.mu.Unlock()
 
 	s.broadcast(Event{
-		Type:    "session-upsert",
+		Type:    EventSessionUpsert,
 		ID:      sess.ID,
 		Session: &sess,
 	})
@@ -519,7 +519,7 @@ func (s *Store) Remove(id string) bool {
 
 	if ok {
 		s.broadcast(Event{
-			Type: "session-remove",
+			Type: EventSessionRemove,
 			ID:   id,
 		})
 	}
@@ -601,7 +601,7 @@ func (s *Store) RemoveDeadByConversationRef(adapterName, ref string) []string {
 	s.mu.Unlock()
 
 	for _, id := range removed {
-		s.broadcast(Event{Type: "session-remove", ID: id})
+		s.broadcast(Event{Type: EventSessionRemove, ID: id})
 	}
 	return removed
 }
@@ -635,7 +635,7 @@ func (s *Store) RemoveByPeer(peer string) []string {
 	s.mu.Unlock()
 
 	for _, id := range removed {
-		s.broadcast(Event{Type: "session-remove", ID: id})
+		s.broadcast(Event{Type: EventSessionRemove, ID: id})
 	}
 	return removed
 }

--- a/skills/gmux/SKILL.md
+++ b/skills/gmux/SKILL.md
@@ -113,21 +113,25 @@ done
 ## Waiting
 
 `gmux wait <id>` blocks until the session goes **idle** — an agent finishing
-its turn, or a shell finishing its command and returning to a fresh prompt —
-optionally bounded by `--timeout N`. Exit codes:
+its turn, a shell finishing its command and returning to a fresh prompt, or
+a one-shot command's process exiting — optionally bounded by `--timeout N`.
+Exit codes:
 
-- `0` session reached idle
-- `2` session exited/died before going idle
+- `0` session reached idle (including a one-shot completing / a shell
+  exiting at its prompt)
+- `2` session exited with its turn still open (crash mid-command/mid-turn)
 - `3` `--timeout` elapsed
 
-**Shell sessions** are waitable when the shell emits OSC 133 prompt marks
-(fish does by default; bash/zsh need shell integration). `gmux send --wait
-<id> 'make build' Enter` then blocks until the command finishes and the
-prompt returns. A *running* shell that has never emitted a prompt mark has no
-idle signal and is rejected — that includes one-shot `gmux -- <cmd>` sessions
-— so run those blocking instead (`gmux -- make build < /dev/null` exits with
-the command's own status) or use an output condition below. Waiting on any
-session that already *exited* returns `2` immediately.
+Every session is waitable. **Shell sessions** get per-command idle from OSC
+133 prompt marks (fish emits them by default; bash/zsh need shell
+integration): `gmux send --wait <id> 'make build' Enter` blocks until the
+command finishes and the prompt returns. Sessions that never emit marks —
+one-shot `gmux -d -- <cmd>` runs, or shells without integration — are one
+lifetime-long turn: `wait` blocks until the process exits (`gmux -d -- pnpm
+test; gmux wait $id` waits for the test run). Careful: an interactive shell
+without integration never exits on its own, so bound that wait with
+`--timeout` or use an output condition below. Waits issued after the exit
+answer the same as live ones.
 
 To wait for specific **output** instead of idle, use `--for-text <substr>` or
 `--for-regex <pattern>` (works for shell sessions too — no grep loop needed):

--- a/skills/gmux/SKILL.md
+++ b/skills/gmux/SKILL.md
@@ -123,10 +123,11 @@ optionally bounded by `--timeout N`. Exit codes:
 **Shell sessions** are waitable when the shell emits OSC 133 prompt marks
 (fish does by default; bash/zsh need shell integration). `gmux send --wait
 <id> 'make build' Enter` then blocks until the command finishes and the
-prompt returns. A shell that has never emitted a prompt mark has no idle
-signal and is rejected — that includes one-shot `gmux -- <cmd>` sessions —
-so run those blocking instead (`gmux -- make build < /dev/null` exits with
-the command's own status) or use an output condition below.
+prompt returns. A *running* shell that has never emitted a prompt mark has no
+idle signal and is rejected — that includes one-shot `gmux -- <cmd>` sessions
+— so run those blocking instead (`gmux -- make build < /dev/null` exits with
+the command's own status) or use an output condition below. Waiting on any
+session that already *exited* returns `2` immediately.
 
 To wait for specific **output** instead of idle, use `--for-text <substr>` or
 `--for-regex <pattern>` (works for shell sessions too — no grep loop needed):

--- a/skills/gmux/SKILL.md
+++ b/skills/gmux/SKILL.md
@@ -20,7 +20,7 @@ gmux send <id> C-c           # send a control key (interrupt), no text
 gmux send --wait <id> 'text' Enter  # send AND block until the reply is done
 gmux send --follow-up <id> 'text'   # queue a prompt for after the current turn
 gmux send --steering <id> 'text'    # interject a prompt into the current turn
-gmux wait <id>               # block until the agent finishes its turn
+gmux wait <id>               # block until idle (agent turn done / shell at prompt)
 gmux wait <id> --for-text S  # block until S appears in the output
 gmux tail <id> [-n N]        # last N lines of output (ANSI stripped; default 100)
 gmux ls [--json]             # list sessions (--json for machine parsing)
@@ -112,16 +112,21 @@ done
 
 ## Waiting
 
-`gmux wait <id>` blocks until an **agent** session goes idle (turn finished) or
-the session exits, optionally bounded by `--timeout N`. Exit codes:
+`gmux wait <id>` blocks until the session goes **idle** — an agent finishing
+its turn, or a shell finishing its command and returning to a fresh prompt —
+optionally bounded by `--timeout N`. Exit codes:
 
-- `0` agent reached idle
+- `0` session reached idle
 - `2` session exited/died before going idle
 - `3` `--timeout` elapsed
 
-Plain **shell** commands don't emit an idle signal and are rejected, so run
-those blocking instead: `gmux -- make build < /dev/null` exits with the
-command's own status.
+**Shell sessions** are waitable when the shell emits OSC 133 prompt marks
+(fish does by default; bash/zsh need shell integration). `gmux send --wait
+<id> 'make build' Enter` then blocks until the command finishes and the
+prompt returns. A shell that has never emitted a prompt mark has no idle
+signal and is rejected — that includes one-shot `gmux -- <cmd>` sessions —
+so run those blocking instead (`gmux -- make build < /dev/null` exits with
+the command's own status) or use an output condition below.
 
 To wait for specific **output** instead of idle, use `--for-text <substr>` or
 `--for-regex <pattern>` (works for shell sessions too — no grep loop needed):


### PR DESCRIPTION
## What

Closes #373 — and generalizes it. Instead of a shell-specific idle signal bolted onto the agent wait machinery, every session now runs **one turn state machine** — *active / idle / waiting-on-you* — with the turn **source** chosen by adapter kind. Design record: **`docs/adr/0023-unified-turn-model.md`**.

| Session kind | turn opens | turn closes |
|---|---|---|
| hook-driven adapter (`SessionExtender` / `SessionHookCommand`) | hook turn-start | hook turn-end |
| default model, **upgraded** by observed OSC 133 prompt marks | `133;C` (command starts) | `133;A`/`133;D` (prompt returns) |
| default model, no marks ever (**lifetime-as-turn**) | process launch | process exit |

What that buys concretely:

- `gmux wait` / `gmux send --wait` work on **every session**: agents (unchanged), integrated shells (per-command), and one-shots — `gmux -d -- pnpm test && gmux wait $id` blocks until the test run exits, rc 0.
- Shells and one-shots get full **agent parity in the sidebar**: blue active dot while a command/process runs, "waiting on you" on completion, error flag data on a failed one-shot (`Status.Error` when exit ≠ 0).
- The adapter surface **shrinks**: `Monitor(output []byte) *Event` (stubbed `return nil` by all five built-ins — dead code), the `Event` type, `BoolPtr`, and the `PromptSignaler` capability are deleted. Base interface is now `Name/Discover/Match/Env`; there is no status capability to implement at all.

## Design decisions (each argued in ADR 0023)

- **Evidence over declaration.** The upgrade to prompt-cycle turns happens on the first *observed* mark, not by argv classification. `bash -c script` (shell binary, really a one-shot) and `ssh host` with remote shell integration (non-shell argv, marks flow through the PTY) both classify correctly only by evidence. Sessions never switch adapters mid-life, so there's no conflict window; hook-driven sessions ignore marks entirely (a tool the agent runs may print them).
- **Turn-state-at-death.** The exit event no longer clears `Status`; it records whether the turn was closed at exit. `wait` resolves death by it — closed turn → `idle`/rc 0 (one-shot completed, shell exited at its prompt, agent exited after its turn), open or never-demonstrated turn → `died`/rc 2. **Timing-independent**: a wait issued after the exit answers the same as one that watched it live. Agent contract change (deliberate): a *clean post-turn* agent exit is now rc 0; mid-turn deaths stay rc 2.
- **Every session is waitable — the `no_idle_signal` 422 is deleted.** A markless interactive shell is Working for its whole life, so a wait on it *blocks honestly* until exit or `--timeout` ("never provably idle" is answered by not answering). The CLI keeps its 422 branch for skew against older daemons.
- **Unread parity.** Every genuine working→idle transition sets "waiting on you", exactly like `applyTurnEnd` for agents. The shell's *initial* prompt closes only the launch phase and does not. Notifications can't double-fire: the notify router already coalesces per-session (finished preferred over unread).
- **Status snapshot replay.** The runner's `/events` now replays the current `Status` on subscribe — previously the launch-time `Working=true` (and any agent turn spanning a daemon restart) never reached a late subscriber.

## Bugs found & fixed on the way

1. **Activity pulses misread as removals.** The wait loops dispatched on `ev.Session == nil` to detect session-removal — but `session-activity` pulses also carry no `Session`. Any unwatched session that produced output while a wait was pending resolved it as a spurious `died`; the new model made it deterministic (a detached one-shot emits its final output pulse in the same breath as its exit). Fixed by dispatching on named event-type constants (now used at every producer/consumer); regression test `TestWaitIgnoresActivityPulse`. Found by live e2e — the unit suite never emitted activity pulses.
2. **Resume derivation destroyed turn state.** gmuxd's `OnExit` hook nil'd `Status` when setting a resume command ("clean resumable display"), which would have silently split the wait verdict by timing for agents: live wait on a cleanly-exited agent → `idle`, wait a moment later → `died`. The hook now touches only `Command` (regression test at the exit-event seam); `OnExit` drops its unused bool return.
3. **Dead sessions couldn't clear "waiting on you".** Every one-shot now dies unread, and dead sessions have no runner WS (the live path for clearing the flag) — the dot would persist until dismiss. The presence `OnSessionSelected` callback now clears unread + error dot on dead sessions when viewed; `Working` (turn state at death) survives. Live sessions stay runner-owned.
4. **Shared-pointer Status mutations** (subscribe.go's unread-clear, and the new view-clear) corrupted the store's previous snapshot and defeated its no-op change detection; `Status` is now replaced, not mutated in place.
5. **Pre-existing `scrollback.RenderTail` data race** (vt `Emulator.Close`'s unsynchronized flag vs the drain goroutine's `Read`) — tripped by every `--for-text` test under `-race`. Fixed by closing the response pipe's write end directly (everything `Close` does minus the racy bool); `-race` regression test replaying a DSR query.

## Tests

All new behavioral tests verified red without their change:

- **runner** (`ptyserver/promptmarks_test.go`, real bash children): mark-driven busy/idle pulse (fast command's C+A in one PTY read emits both edges); marks ignored for hook-driven adapters; unread set on a completed prompt cycle but not on the initial prompt; markless session keeps its lifetime turn open. `finalizeSessionState` extracted from `run()` so the load-bearing ordering (turn-close status + unread **before** the exit event) is pinned by unit tests; `/events` status replay covered at the HTTP seam.
- **daemon** (`wait_test.go`, `sendwait_test.go`, `subscribe_test.go`, `unread_test.go`): dead-session resolution by turn state (closed→idle / open→died / none→died, table-driven); markless live shell blocks to 408 instead of 422; any adapter with turn state is waitable (gate removal); one-shot exit resolves send--wait as idle even when only the dead upsert is observed; `send --wait 'exit'` on a prompt-cycle shell → died; activity-pulse regression.
- **manual e2e** (isolated daemon): one-shot success (live rc 0 @ exit, post-mortem rc 0, unread+idle persisted), one-shot failure (`error:true`, exit 3), markless interactive bash (timeout rc 3), synthetic prompt-cycle (wait blocks mid-command, idle at prompt, session alive), real `bash` with PS0/PROMPT_COMMAND integration (`send --wait 'sleep 2'` → 2.0s rc 0; `send --wait 'exit'` → rc 2 with `working:true` persisted at death).
- `go build` / `go vet` / `go test ./...` green across `packages/adapter`, `cli/gmux`, `services/gmuxd`.

## Compatibility

- No wire or on-disk format changes. `Status` is the same object; it's now also present on dead sessions (the web UI keys working/error dots on `alive` and renders "exited (N)" from `exit_code`, so nothing breaks — verified).
- Contract changes, all intentional and documented: `wait` on shells/one-shots (was 422), rc 0 for closed-turn exits (was rc 2 `died`), unread/error state for non-agent sessions.
- Adapters are compiled-in Go, so deleting `Monitor`/`Event`/`PromptSignaler` breaks no external plugin ABI; contributor docs rewritten.

## Docs

ADR 0023 (+ this PR's history: the first six commits are the original shell-specific implementation, superseded in-place after design review — kept for the record). UBIQUITOUS_LANGUAGE gains the turn-model terms. `reference/cli.md`, `skills/gmux/SKILL.md`, `develop/writing-adapters.md`, `develop/adapter-architecture.md`, `develop/terminal-data-pipeline.mdx`, `planned/opencode-adapter.md` updated.

## Follow-ups (not in this PR)

- Web UI: single blue "active" indicator (gray activity dot is now redundant for default-model sessions); red error dot for dead failed one-shots (data is already there, `sessionDotState` currently gates on `alive`).
