### PR TITLE
feat(cli): gmux tail renders conversation markdown from the session file

### DIFF
--- a/apps/website/src/content/docs/integrations/scripts-and-agents.md
+++ b/apps/website/src/content/docs/integrations/scripts-and-agents.md
@@ -69,7 +69,7 @@ When no text argument is given and stdin is a pipe, gmux reads stdin until EOF (
 gmux send --wait <id> Enter < step-1.txt
 gmux send --wait <id> Enter < step-2.txt
 
-gmux tail <id> -n 200          # extract the final answer
+gmux tail <id> -n 2            # the prompt and the reply, clean markdown
 ```
 
 The idle signal is the same `Status.Working` flag the UI's spinner consumes, so `wait` returns the moment the agent emits its closing message. Exit codes: `0` idle (or matched), `2` the session died first, `3` `--timeout N` elapsed.
@@ -86,11 +86,11 @@ gmux wait <id> --for-text 'Listening on' --timeout 30   # wait for a server to c
 
 ## Reading output
 
-`gmux tail <id>` prints recent output as plain text (ANSI stripped; `-n N` for line count, default 100). Pair it with `wait` to capture an agent's final answer:
+`gmux tail <id>` prints the session's conversation as clean markdown when the agent persists a conversation file (pi): `## User` / `## Assistant` messages with compact `[tool] …` one-liners — the actual exchange, not the TUI's box-drawing and spinners. `-n N` counts messages there (default 100). Sessions without a conversation file (shells, plain commands) print recent terminal output as plain text instead, where `-n` counts lines; `--raw` forces that terminal view for any session. Pair it with `wait` to capture an agent's final answer:
 
 ```bash
 gmux send --wait --timeout 600 <id> Enter < ship-prompt.txt
-url=$(gmux tail <id> -n 50 | grep -oE 'https://github\.com/[^ ]+/pull/[0-9]+' | tail -1)
+url=$(gmux tail <id> -n 1 | grep -oE 'https://github\.com/[^ ]+/pull/[0-9]+' | tail -1)
 echo "$url"
 ```
 

--- a/apps/website/src/content/docs/reference/cli.md
+++ b/apps/website/src/content/docs/reference/cli.md
@@ -104,14 +104,26 @@ gmux attach a3f20187@desktop  # a session on a peer
 
 ### `gmux tail <id>`
 
-Print recent output as plain text. ANSI escapes are stripped by default so the
-output is grep-friendly.
+Print the session's conversation as clean markdown. For agents that persist a
+structured conversation file (pi), the transcript is reconstructed from that
+file — the actual user/assistant messages plus compact one-line tool calls —
+rather than the terminal rendering of the TUI, so the output is readable and
+pipe-friendly. Thinking blocks and tool outputs are omitted.
+
+Sessions without a conversation file (shells, plain commands) print recent PTY
+output as plain text instead, exactly as before.
 
 ```bash
-gmux tail a3f20187            # last 100 lines (default)
-gmux tail -n 500 a3f20187     # last 500 lines
-gmux tail --raw a3f20187      # keep ANSI escapes (-e also works)
+gmux tail a3f20187            # conversation markdown (last 100 messages),
+                              # or last 100 lines of output for shells
+gmux tail -n 5 a3f20187       # last 5 messages (or lines)
+gmux tail --raw a3f20187      # force the PTY view: last N lines of terminal
+                              # output, plain text (-e also works)
 ```
+
+`-n` counts messages in the conversation view and lines in the PTY view. The
+transcript is read from the conversation file the agent has flushed to disk,
+so an assistant message that is still streaming appears once it completes.
 
 It's a snapshot, not a stream — to watch a session live, attach to it or open
 it in the browser.

--- a/cli/gmux/cmd/gmux/actions.go
+++ b/cli/gmux/cmd/gmux/actions.go
@@ -360,13 +360,25 @@ func cmdKill(ref string) int {
 
 // cmdTail implements `gmux tail <id> [-n N] [--raw]`.
 //
-// Routes through gmuxd's scrollback broker rather than the per-session
-// Unix socket so the same code path serves four cases uniformly:
-// local-live (broker reads from disk; the runner tees output there),
-// local-dead (broker still reads from disk), peer-live (broker forwards
-// to the owning gmuxd), and peer-dead (forward-then-disk on the peer).
-// Output is raw PTY bytes including ANSI; pipe through your favorite
-// stripper if you want plain text.
+// Default view: when the session's adapter persists a structured
+// conversation file (pi's JSONL under ~/.pi/agent/sessions/), gmuxd
+// reconstructs clean markdown from it — the actual user/assistant
+// exchange — which beats the PTY rendering of a TUI (box-drawing,
+// spinners, viewport truncation) for humans and for agents driving
+// via the CLI. Sessions without a renderable conversation (shell,
+// deleted file, no messages yet) fall back to PTY scrollback
+// transparently, keyed on the daemon's no_conversation error code.
+//
+// --raw (alias -e) forces the PTY scrollback view — the pre-2.1
+// default output. It is plain text either way: tail requests are
+// rendered through a terminal emulator in the broker, so ANSI
+// escapes never survive the server side.
+//
+// Everything routes through gmuxd rather than the per-session Unix
+// socket so the same code path serves local-live, local-dead,
+// peer-live, and peer-dead uniformly (conversation and scrollback
+// requests are forwarded to the owning gmuxd for peer sessions, which
+// is also where the conversation file lives).
 func cmdTail(ref string, n int, raw bool) int {
 	sess, err := resolveSession(ref)
 	if err != nil {
@@ -374,18 +386,109 @@ func cmdTail(ref string, n int, raw bool) int {
 		return 1
 	}
 
+	if !raw {
+		md, outcome := fetchConversation(sess, n)
+		switch outcome {
+		case convServe:
+			if _, err := os.Stdout.Write(md); err != nil {
+				fmt.Fprintln(os.Stderr, "gmux:", err)
+				return 1
+			}
+			return 0
+		case convError:
+			return 1
+		}
+		// convFallback: no renderable conversation — use scrollback.
+	}
+
 	data, code := fetchScrollback(sess, n)
 	if code != 0 {
 		return code
 	}
-	if !raw {
-		data = stripANSI(data)
-	}
+	data = stripANSI(data)
 	if _, err := os.Stdout.Write(data); err != nil {
 		fmt.Fprintln(os.Stderr, "gmux:", err)
 		return 1
 	}
 	return 0
+}
+
+// convOutcome is what a /conversation response tells cmdTail to do.
+type convOutcome int
+
+const (
+	convServe    convOutcome = iota // 200: print the markdown body
+	convFallback                    // no conversation: use PTY scrollback
+	convError                       // reported to the user; exit nonzero
+)
+
+// classifyConversationResponse maps gmuxd's /conversation status+body
+// to a tail action. Pure so the fallback contract is unit-testable
+// without a daemon.
+//
+// Every 404 EXCEPT an explicit not_found (session vanished mid-flight)
+// means fallback: no_conversation is the designed signal, and a plain
+// non-JSON 404 is an older gmuxd (or peer) without the endpoint —
+// falling back preserves pre-2.1 tail behavior across version skew
+// instead of failing the command.
+func classifyConversationResponse(status int, body []byte) convOutcome {
+	switch {
+	case status == http.StatusOK:
+		return convServe
+	case status == http.StatusNotFound && errorCode(body) == "not_found":
+		return convError
+	case status == http.StatusNotFound:
+		return convFallback
+	default:
+		return convError
+	}
+}
+
+// errorCode extracts the machine-readable code from a gmuxd error
+// envelope ({"ok":false,"error":{"code":...}}); "" if the body isn't one.
+func errorCode(body []byte) string {
+	var env struct {
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(body, &env); err != nil {
+		return ""
+	}
+	return env.Error.Code
+}
+
+// fetchConversation asks gmuxd for the session's markdown transcript
+// (last n messages). On convError the user-facing message has already
+// been printed.
+func fetchConversation(sess cliSession, n int) ([]byte, convOutcome) {
+	client := gmuxdClient()
+	url := fmt.Sprintf("%s/v1/sessions/%s/conversation?tail=%d", gmuxdBaseURL(), sess.ID, n)
+	resp, err := client.Get(url)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "gmux:", err)
+		return nil, convError
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil && !errors.Is(err, io.EOF) {
+		fmt.Fprintln(os.Stderr, "gmux:", err)
+		return nil, convError
+	}
+	outcome := classifyConversationResponse(resp.StatusCode, body)
+	switch outcome {
+	case convServe:
+		return body, convServe
+	case convError:
+		if resp.StatusCode == http.StatusNotFound {
+			fmt.Fprintf(os.Stderr, "gmux: session %s not found\n", displayID(sess))
+		} else {
+			fmt.Fprintf(os.Stderr, "gmux: tail failed: %s: %s\n", resp.Status, extractMessage(body))
+		}
+		return nil, convError
+	default:
+		return nil, convFallback
+	}
 }
 
 // fetchScrollback pulls the last n lines of a session's scrollback from
@@ -645,8 +748,10 @@ func emitSessionsJSON(sessions []cliSession) int {
 }
 
 // stripANSI removes ANSI/VT escape sequences from PTY output so the
-// default `gmux tail` is grep-friendly plain text. `--raw` bypasses
-// this. Handles CSI (ESC [ ... letter), OSC (ESC ] ... BEL/ST), and
+// scrollback view of `gmux tail` is grep-friendly plain text. The
+// broker already renders tail responses through a terminal emulator,
+// so this is belt-and-braces for whatever survives that pass.
+// Handles CSI (ESC [ ... letter), OSC (ESC ] ... BEL/ST), and
 // lone two-byte escapes; this is a pragmatic stripper, not a full
 // terminal emulator.
 func stripANSI(b []byte) []byte {

--- a/cli/gmux/cmd/gmux/cli.go
+++ b/cli/gmux/cmd/gmux/cli.go
@@ -57,7 +57,7 @@ type command struct {
 
 	// tail
 	tailLines int
-	raw       bool
+	raw       bool // --raw/-e: PTY scrollback instead of conversation markdown
 
 	// send
 	sendText   *string  // literal text to type (nil = none)
@@ -256,12 +256,20 @@ func parseRefOnly(m mode, name string, args []string) (*command, error) {
 	return &command{mode: m, ref: args[0]}, nil
 }
 
+// parseTail handles `gmux tail [-n N] [--raw] <id>`.
+//
+// Default output is the conversation transcript when the session's
+// adapter persists one (markdown from the conversation file), falling
+// back to PTY scrollback otherwise. --raw forces the PTY scrollback
+// view (plain text; the broker renders tail requests through a
+// terminal emulator, so escapes never survive server-side). -e stays
+// as an alias for tmux capture-pane muscle memory.
 func parseTail(args []string) (*command, error) {
 	c := &command{mode: modeTail, tailLines: 100}
 	fs := newFlagSet("tail")
-	fs.IntVar(&c.tailLines, "n", 100, "number of lines to show")
-	fs.BoolVar(&c.raw, "raw", false, "preserve ANSI escapes")
-	fs.BoolVar(&c.raw, "e", false, "preserve ANSI escapes (short)")
+	fs.IntVar(&c.tailLines, "n", 100, "number of lines (or conversation messages) to show")
+	fs.BoolVar(&c.raw, "raw", false, "PTY scrollback instead of conversation markdown")
+	fs.BoolVar(&c.raw, "e", false, "alias of --raw")
 	pos, err := parseInterspersed(fs, args)
 	if err != nil {
 		return nil, err
@@ -561,7 +569,7 @@ Run a command:
 Sessions (local by default; address a peer with <id>@<peer>):
   gmux ls [--all] [--json]          list sessions
   gmux attach <id>                  reattach to a session
-  gmux tail <id> [-n N] [--raw]     print recent output (snapshot)
+  gmux tail <id> [-n N] [--raw]     print conversation or recent output (snapshot)
   gmux send <id> <text> [Key...]    type text and/or send keys (e.g. Enter, C-c)
   gmux send --wait [--timeout N] <id> <text> [Key...]
                                     ... and block until the triggered turn ends

--- a/cli/gmux/cmd/gmux/cli_test.go
+++ b/cli/gmux/cmd/gmux/cli_test.go
@@ -104,6 +104,15 @@ func TestParseCLI(t *testing.T) {
 					t.Errorf("tailLines=%d raw=%v", c.tailLines, c.raw)
 				}
 			}},
+		// -e (tmux capture-pane muscle memory) stays an alias of --raw:
+		// both mean "PTY scrollback view" and both bypass the
+		// conversation transcript (issue #384).
+		{name: "tail -e is an alias of --raw", args: []string{"tail", "-e", "abc"}, wantMode: modeTail,
+			check: func(t *testing.T, c *command) {
+				if !c.raw {
+					t.Errorf("raw=%v, want true", c.raw)
+				}
+			}},
 
 		{name: "send text + Enter", args: []string{"send", "abc", "pytest -q", "Enter"}, wantMode: modeSend,
 			check: func(t *testing.T, c *command) {

--- a/cli/gmux/cmd/gmux/tail_test.go
+++ b/cli/gmux/cmd/gmux/tail_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"net/http"
+	"testing"
+)
+
+// TestClassifyConversationResponse pins the CLI half of the tail
+// fallback contract (the daemon half lives in gmuxd's conversation
+// handler tests): only a 200 serves markdown; a 404 falls back to PTY
+// scrollback unless the daemon explicitly says the *session* is gone;
+// and — crucially for version skew — a plain non-JSON 404 from an
+// older gmuxd or peer that predates the /conversation endpoint also
+// falls back, so `gmux tail` keeps working instead of erroring.
+func TestClassifyConversationResponse(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+		body   string
+		want   convOutcome
+	}{
+		{"200 serves markdown", http.StatusOK, "## User\n\nhi\n", convServe},
+		{"no_conversation falls back to scrollback", http.StatusNotFound,
+			`{"ok":false,"error":{"code":"no_conversation","message":"session has no conversation file"}}`, convFallback},
+		{"session not_found is an error, not a fallback", http.StatusNotFound,
+			`{"ok":false,"error":{"code":"not_found","message":"session not found"}}`, convError},
+		{"plain 404 from an old daemon falls back", http.StatusNotFound,
+			"404 page not found\n", convFallback},
+		{"500 is an error", http.StatusInternalServerError,
+			`{"ok":false,"error":{"code":"internal","message":"conversation render failed"}}`, convError},
+		{"400 is an error", http.StatusBadRequest,
+			`{"ok":false,"error":{"code":"bad_request","message":"tail must be a positive integer"}}`, convError},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := classifyConversationResponse(tt.status, []byte(tt.body)); got != tt.want {
+				t.Errorf("classifyConversationResponse(%d, %q) = %v, want %v", tt.status, tt.body, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestErrorCode covers the envelope extractor the classification
+// depends on: a well-formed gmuxd envelope yields its code, anything
+// else yields "".
+func TestErrorCode(t *testing.T) {
+	if got := errorCode([]byte(`{"ok":false,"error":{"code":"no_conversation","message":"x"}}`)); got != "no_conversation" {
+		t.Errorf("want no_conversation, got %q", got)
+	}
+	if got := errorCode([]byte("404 page not found\n")); got != "" {
+		t.Errorf("non-JSON body: want empty code, got %q", got)
+	}
+	if got := errorCode([]byte(`{"ok":true,"data":{}}`)); got != "" {
+		t.Errorf("success envelope: want empty code, got %q", got)
+	}
+}

--- a/docs/adr/0009-verb-first-cli-and-frozen-top-level-namespace.md
+++ b/docs/adr/0009-verb-first-cli-and-frozen-top-level-namespace.md
@@ -288,6 +288,46 @@ blocks until the queued prompt's reply, per the issue's contract.
 
 [#385]: https://github.com/gmuxapp/gmux/issues/385
 
+## Amendment (2026-07-12): `tail` defaults to the conversation transcript
+
+`gmux tail` (decision 13a) changes its default view for sessions whose
+adapter persists a structured conversation file (pi's JSONL; the
+adapter capability is `ConversationRenderer`): it prints clean markdown
+reconstructed from that file — the actual user/assistant exchange with
+compact tool-call lines — instead of the emulator-rendered PTY
+scrollback, which for agent TUIs is box-drawing, spinners, and
+viewport-truncated redraws ([#384]). Sessions without a renderable
+conversation (shells, deleted conversations, no messages yet, adapters
+without the capability) keep the PTY output, so scripts against shell
+sessions see no change. The capability takes the opaque adapter-scoped
+conversation ref of ADR 0022; for file adapters the ref is the
+transcript's path, but that stays the adapter's private convention.
+
+Grammar consequences, per the behavior-modifier-flag pattern (no new
+verbs):
+
+- **`--raw` forces the PTY scrollback view** — the pre-change default
+  output. `-e` remains an alias. 13a described `--raw`/`-e` as
+  "preserve ANSI escapes", but that had already been vestigial since
+  the broker began rendering `?tail=N` through a terminal emulator
+  (which strips escapes server-side); both flags' *observable*
+  behavior — plain-text PTY output — is unchanged.
+- **`-n` counts messages in the conversation view**, lines in the PTY
+  view. One knob, unit follows the view.
+- Still snapshot-only; no `-f` (13a stands). A live conversation
+  stream is ADR 0021's `session/load` + `session/update` territory.
+
+Server-side this is `GET /v1/sessions/{id}/conversation?tail=N` on
+gmuxd (ADR 0005: the CLI routes through the daemon; peer sessions
+forward to the owning host, where the conversation lives). The
+endpoint answers 404 `no_conversation` when there is nothing to
+render, which is the CLI's signal to fall back to scrollback — also
+the path taken against older daemons that lack the endpoint entirely.
+The daemon stays content-free (ADR 0011): the adapter re-reads the
+stored conversation per request; nothing is cached or stored.
+
+[#384]: https://github.com/gmuxapp/gmux/issues/384
+
 ## Amendment (2026-07-06): `edit` joins the top-level namespace
 
 `gmux edit [file]` is added as a top-level verb. It cannot live under a

--- a/packages/adapter/adapters/pi_conversation.go
+++ b/packages/adapter/adapters/pi_conversation.go
@@ -1,0 +1,136 @@
+package adapters
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"strings"
+
+	"github.com/gmuxapp/gmux/packages/adapter"
+)
+
+// Compile-time interface check (the main var block lives in pi.go; this
+// one stays next to the implementation it guards).
+var _ adapter.ConversationRenderer = (*Pi)(nil)
+
+// RenderConversation reconstructs a clean transcript from a pi JSONL
+// conversation (the ref is the transcript's absolute path — pi's
+// private ref convention, ADR 0022): user and assistant messages,
+// oldest first, with tool calls rendered as compact one-liners.
+//
+// What is deliberately omitted:
+//   - thinking blocks — internal reasoning, often huge, hidden by pi's
+//     own transcript view too;
+//   - toolResult messages — echoes of tool output (file reads, command
+//     output) that dwarf the conversation itself;
+//   - non-message entries (session header, model_change, compaction,
+//     branch_summary, ...).
+//
+// A malformed line is skipped rather than failing the whole file: pi
+// appends live, so the last line can be mid-write when we read it.
+func (p *Pi) RenderConversation(ref string) ([]adapter.ConversationMessage, error) {
+	data, err := os.ReadFile(ref)
+	if err != nil {
+		return nil, err
+	}
+
+	var out []adapter.ConversationMessage
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		if line == "" {
+			continue
+		}
+		var entry struct {
+			Type    string `json:"type"`
+			Message *struct {
+				Role    string          `json:"role"`
+				Content json.RawMessage `json:"content"`
+			} `json:"message"`
+		}
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			continue
+		}
+		if entry.Type != "message" || entry.Message == nil {
+			continue
+		}
+		role := entry.Message.Role
+		if role != "user" && role != "assistant" {
+			continue // toolResult and any future roles
+		}
+		text := renderPiContent(entry.Message.Content)
+		if text == "" {
+			continue // e.g. thinking-only assistant turn
+		}
+		out = append(out, adapter.ConversationMessage{Role: role, Text: text})
+	}
+	return out, nil
+}
+
+// renderPiContent renders a message's content to markdown. pi encodes
+// content either as a plain string (old format) or as an array of
+// typed blocks: text, thinking, toolCall, image.
+func renderPiContent(content json.RawMessage) string {
+	var s string
+	if err := json.Unmarshal(content, &s); err == nil {
+		return strings.TrimSpace(s)
+	}
+
+	var blocks []struct {
+		Type      string          `json:"type"`
+		Text      string          `json:"text"`
+		Name      string          `json:"name"`      // toolCall
+		Arguments json.RawMessage `json:"arguments"` // toolCall
+	}
+	if err := json.Unmarshal(content, &blocks); err != nil {
+		return ""
+	}
+
+	parts := make([]string, 0, len(blocks))
+	for _, b := range blocks {
+		switch b.Type {
+		case "text":
+			if t := strings.TrimSpace(b.Text); t != "" {
+				parts = append(parts, t)
+			}
+		case "toolCall":
+			parts = append(parts, formatPiToolCall(b.Name, b.Arguments))
+		case "image":
+			parts = append(parts, "[image]")
+		}
+		// thinking (and unknown block types): skipped.
+	}
+	return strings.Join(parts, "\n\n")
+}
+
+// maxToolArgChars caps the rendered tool-call arguments. Tool calls are
+// activity context in the transcript, not payload: a bash command or an
+// edit's full replacement text can run to kilobytes, which would drown
+// the conversation the transcript exists to surface.
+const maxToolArgChars = 120
+
+// formatPiToolCall renders a tool call as a compact single line:
+// "[tool] <name> <compact-json-args>". Plain text, no markdown
+// emphasis or inline code — arguments are arbitrary bytes (shell
+// commands full of backticks), so any markdown wrapping would break.
+func formatPiToolCall(name string, args json.RawMessage) string {
+	if name == "" {
+		name = "?"
+	}
+	var buf strings.Builder
+	buf.WriteString("[tool] ")
+	buf.WriteString(name)
+
+	var dst bytes.Buffer
+	if err := json.Compact(&dst, args); err != nil {
+		return buf.String()
+	}
+	s := dst.String()
+	if s == "{}" || s == "null" || s == "" {
+		return buf.String()
+	}
+	if runes := []rune(s); len(runes) > maxToolArgChars {
+		s = string(runes[:maxToolArgChars]) + "…"
+	}
+	buf.WriteString(" ")
+	buf.WriteString(s)
+	return buf.String()
+}

--- a/packages/adapter/adapters/pi_conversation_test.go
+++ b/packages/adapter/adapters/pi_conversation_test.go
@@ -1,0 +1,152 @@
+package adapters
+
+import (
+	"errors"
+	"io/fs"
+	"strings"
+	"testing"
+
+	"github.com/gmuxapp/gmux/packages/adapter"
+)
+
+// TestRenderConversationTranscript is the core contract of the pi
+// ConversationRenderer: a JSONL file yields the user/assistant exchange
+// in order, with tool calls compacted to one-liners and internal noise
+// (thinking blocks, toolResult messages, non-message entries) dropped.
+// This is what `gmux tail` prints by default for pi sessions.
+func TestRenderConversationTranscript(t *testing.T) {
+	path := writeTempJSONL(t,
+		`{"type":"session","version":3,"id":"abc-123","timestamp":"2026-03-15T10:00:00Z","cwd":"/tmp/test"}`,
+		`{"type":"model_change","id":"m1","timestamp":"2026-03-15T10:00:00Z"}`,
+		`{"type":"message","id":"u1","message":{"role":"user","content":[{"type":"text","text":"Fix the auth bug"}]}}`,
+		`{"type":"message","id":"a1","message":{"role":"assistant","content":[{"type":"thinking","thinking":"let me look around"},{"type":"text","text":"Looking now."},{"type":"toolCall","id":"t1","name":"bash","arguments":{"command":"go test ./..."}}]}}`,
+		`{"type":"message","id":"r1","message":{"role":"toolResult","toolCallId":"t1","toolName":"bash","content":[{"type":"text","text":"ok\t0.5s"}]}}`,
+		`{"type":"message","id":"a2","message":{"role":"assistant","content":[{"type":"text","text":"All green."}]}}`,
+	)
+
+	msgs, err := NewPi().RenderConversation(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []adapter.ConversationMessage{
+		{Role: "user", Text: "Fix the auth bug"},
+		{Role: "assistant", Text: "Looking now.\n\n[tool] bash {\"command\":\"go test ./...\"}"},
+		{Role: "assistant", Text: "All green."},
+	}
+	if len(msgs) != len(want) {
+		t.Fatalf("message count: want %d, got %d (%+v)", len(want), len(msgs), msgs)
+	}
+	for i := range want {
+		if msgs[i] != want[i] {
+			t.Errorf("msg[%d]: want %+v, got %+v", i, want[i], msgs[i])
+		}
+	}
+}
+
+// TestRenderConversationSkipsThinkingOnlyTurn: an assistant message
+// consisting solely of thinking blocks renders to nothing and must be
+// omitted entirely — otherwise the transcript would show empty
+// "## Assistant" stubs for every internal deliberation.
+func TestRenderConversationSkipsThinkingOnlyTurn(t *testing.T) {
+	path := writeTempJSONL(t,
+		`{"type":"session","version":3,"id":"abc","timestamp":"2026-03-15T10:00:00Z","cwd":"/tmp"}`,
+		`{"type":"message","id":"a1","message":{"role":"assistant","content":[{"type":"thinking","thinking":"hmm"}]}}`,
+		`{"type":"message","id":"u1","message":{"role":"user","content":[{"type":"text","text":"hello"}]}}`,
+	)
+	msgs, err := NewPi().RenderConversation(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(msgs) != 1 || msgs[0].Role != "user" {
+		t.Fatalf("want only the user message, got %+v", msgs)
+	}
+}
+
+// TestRenderConversationStringContent covers pi's older plain-string
+// content encoding (also produced by some injected messages). It must
+// render as the message body, not be dropped as unparseable.
+func TestRenderConversationStringContent(t *testing.T) {
+	path := writeTempJSONL(t,
+		`{"type":"session","version":3,"id":"abc","timestamp":"2026-03-15T10:00:00Z","cwd":"/tmp"}`,
+		`{"type":"message","id":"u1","message":{"role":"user","content":"plain string prompt"}}`,
+	)
+	msgs, err := NewPi().RenderConversation(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(msgs) != 1 || msgs[0].Text != "plain string prompt" {
+		t.Fatalf("want plain string content, got %+v", msgs)
+	}
+}
+
+// TestRenderConversationImagePlaceholder: image blocks carry base64
+// payloads that must never hit the transcript; they render as a
+// placeholder token instead.
+func TestRenderConversationImagePlaceholder(t *testing.T) {
+	path := writeTempJSONL(t,
+		`{"type":"session","version":3,"id":"abc","timestamp":"2026-03-15T10:00:00Z","cwd":"/tmp"}`,
+		`{"type":"message","id":"u1","message":{"role":"user","content":[{"type":"image","data":"aGVsbG8=","mimeType":"image/png"},{"type":"text","text":"what is this?"}]}}`,
+	)
+	msgs, err := NewPi().RenderConversation(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(msgs) != 1 || msgs[0].Text != "[image]\n\nwhat is this?" {
+		t.Fatalf("want image placeholder + text, got %+v", msgs)
+	}
+}
+
+// TestRenderConversationSkipsMalformedTailLine: pi appends to the JSONL
+// live, so a read can catch the final line mid-write. A torn line must
+// be skipped, not fail the whole render — `gmux tail` on a live session
+// is exactly when this happens.
+func TestRenderConversationSkipsMalformedTailLine(t *testing.T) {
+	path := writeTempJSONL(t,
+		`{"type":"session","version":3,"id":"abc","timestamp":"2026-03-15T10:00:00Z","cwd":"/tmp"}`,
+		`{"type":"message","id":"u1","message":{"role":"user","content":[{"type":"text","text":"hi"}]}}`,
+		`{"type":"message","id":"a1","message":{"role":"assistant","con`, // torn write
+	)
+	msgs, err := NewPi().RenderConversation(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(msgs) != 1 || msgs[0].Text != "hi" {
+		t.Fatalf("want the intact message only, got %+v", msgs)
+	}
+}
+
+// TestRenderConversationMissingFile: the error must satisfy
+// fs.ErrNotExist so gmuxd can map "file deleted" to the scrollback
+// fallback rather than a 500.
+func TestRenderConversationMissingFile(t *testing.T) {
+	_, err := NewPi().RenderConversation("/nonexistent/conv.jsonl")
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("want fs.ErrNotExist, got %v", err)
+	}
+}
+
+// TestFormatPiToolCallTruncatesArgs: tool arguments (edit bodies, long
+// shell commands) are capped so tool lines stay one-line context, and
+// no markdown wrapping is added around the arbitrary argument bytes.
+func TestFormatPiToolCallTruncatesArgs(t *testing.T) {
+	long := strings.Repeat("x", 500)
+	got := formatPiToolCall("edit", []byte(`{"text":"`+long+`"}`))
+	if !strings.HasPrefix(got, "[tool] edit {\"text\":\"xxx") {
+		t.Fatalf("prefix: got %q", got)
+	}
+	if !strings.HasSuffix(got, "…") {
+		t.Fatalf("want truncation ellipsis, got %q", got)
+	}
+	if n := len([]rune(got)); n > len("[tool] edit ")+maxToolArgChars+1 {
+		t.Fatalf("rendered tool call too long: %d runes: %q", n, got)
+	}
+
+	// No-arg and empty-arg calls render bare.
+	if got := formatPiToolCall("ls", nil); got != "[tool] ls" {
+		t.Fatalf("nil args: got %q", got)
+	}
+	if got := formatPiToolCall("ls", []byte(`{}`)); got != "[tool] ls" {
+		t.Fatalf("empty args: got %q", got)
+	}
+}

--- a/packages/adapter/capabilities.go
+++ b/packages/adapter/capabilities.go
@@ -66,6 +66,34 @@ type ConversationOpener interface {
 	OpenConversation(ref string) (io.ReadCloser, error)
 }
 
+// ConversationMessage is one message of a conversation transcript,
+// reconstructed from an adapter's stored conversation. Text is markdown:
+// the adapter renders its native content blocks (text, tool calls,
+// images) into a readable body; internal noise (thinking blocks, tool
+// result payloads) is omitted. Consumers add role headings and message
+// separation — the adapter owns only per-message content.
+type ConversationMessage struct {
+	Role string // "user", "assistant", ... (lowercase, adapter-reported)
+	Text string // markdown body, non-empty
+}
+
+// ConversationRenderer is implemented by adapters that can reconstruct a
+// clean transcript from a stored conversation — the actual user/assistant
+// exchange rather than the PTY rendering of a TUI. Where
+// ConversationOpener exposes the raw adapter-native bytes, this is the
+// normalized-content seam: the adapter translates its own format into
+// messages. gmuxd's /v1/sessions/{id}/conversation endpoint (backing the
+// default `gmux tail` view) uses it; adapters without it fall back to
+// scrollback.
+type ConversationRenderer interface {
+	// RenderConversation resolves an opaque conversation ref (ADR 0022)
+	// and returns its messages oldest-first. Messages that render to
+	// nothing (e.g. thinking-only turns) are omitted. Returns an error
+	// satisfying errors.Is(err, fs.ErrNotExist) when the conversation is
+	// gone (the same convention the ConversationProber helpers use).
+	RenderConversation(ref string) ([]ConversationMessage, error)
+}
+
 // ConversationSink receives conversation-ref changes from a ConversationSource.
 // Refs are opaque adapter-scoped locators the daemon resolves via the
 // owning adapter's DescribeConversation.

--- a/services/gmuxd/cmd/gmuxd/conversation.go
+++ b/services/gmuxd/cmd/gmuxd/conversation.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"io/fs"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/gmuxapp/gmux/packages/adapter"
+	"github.com/gmuxapp/gmux/packages/adapter/adapters"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/store"
+)
+
+// conversationHandler serves GET /v1/sessions/{id}/conversation: a
+// clean markdown transcript reconstructed from the session's
+// conversation file (the structured file the agent itself writes, e.g.
+// pi's JSONL), rather than the PTY rendering of its TUI. This is what
+// the default `gmux tail` prints for conversation-backed sessions.
+//
+// The daemon stays content-free (ADR 0011): nothing here is cached or
+// stored — the adapter re-reads the conversation file per request, the
+// same way the scrollback broker re-reads the tee. Snapshot semantics
+// mirror `gmux tail`: the durable file only, so an in-flight partial
+// assistant message (not yet flushed by the agent) is not included.
+//
+// Optional ?tail=<N> trims to the last N messages — the conversation
+// analog of scrollback's last-N-lines. Absent means the whole
+// transcript; non-positive or non-numeric N is a 400 (same contract as
+// the scrollback broker).
+//
+// Status code semantics:
+//
+//   - 405 non-GET: the transcript is read-only.
+//   - 404 "not_found": session ID isn't in the store (peer sessions
+//     were already forwarded to the owning gmuxd before this handler).
+//   - 404 "no_conversation": the session exists but has no renderable
+//     conversation — no conversation file attributed, the adapter
+//     doesn't implement ConversationRenderer, the file was deleted,
+//     or it contains no messages yet. The distinct code is the CLI's
+//     signal to fall back to PTY scrollback; a bare not_found would
+//     make `gmux tail` misreport the session as missing.
+//   - 500 on read/parse IO errors other than file-gone.
+func conversationHandler(w http.ResponseWriter, r *http.Request, sessionID string, sessions *store.Store) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "bad_request", "method not allowed")
+		return
+	}
+	sess, ok := sessions.Get(sessionID)
+	if !ok {
+		writeError(w, http.StatusNotFound, "not_found", "session not found")
+		return
+	}
+
+	tailN := 0
+	if v := r.URL.Query().Get("tail"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n <= 0 {
+			writeError(w, http.StatusBadRequest, "bad_request", "tail must be a positive integer")
+			return
+		}
+		tailN = n
+	}
+
+	if sess.ConversationRef == "" {
+		writeError(w, http.StatusNotFound, "no_conversation", "session has no conversation")
+		return
+	}
+	a := adapters.FindByAdapter(sess.Adapter)
+	if a == nil {
+		writeError(w, http.StatusNotFound, "no_conversation", "session has no adapter")
+		return
+	}
+	renderer, ok := a.(adapter.ConversationRenderer)
+	if !ok {
+		writeError(w, http.StatusNotFound, "no_conversation", "adapter does not render conversations")
+		return
+	}
+
+	msgs, err := renderer.RenderConversation(sess.ConversationRef)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			// The conversation was deleted (or its storage unmounted)
+			// after attribution. Scrollback may still exist; let the CLI
+			// fall back rather than erroring a tail that used to work.
+			writeError(w, http.StatusNotFound, "no_conversation", "conversation is gone")
+			return
+		}
+		log.Printf("conversation: %s: %v", sessionID, err)
+		writeError(w, http.StatusInternalServerError, "internal", "conversation render failed")
+		return
+	}
+	if len(msgs) == 0 {
+		// A conversation with no renderable messages yet (fresh session:
+		// header line only). Falling back to scrollback shows the agent's
+		// startup screen, which is strictly more useful than an empty
+		// 200 body.
+		writeError(w, http.StatusNotFound, "no_conversation", "conversation has no messages yet")
+		return
+	}
+	if tailN > 0 && len(msgs) > tailN {
+		msgs = msgs[len(msgs)-tailN:]
+	}
+
+	w.Header().Set("Content-Type", "text/markdown; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-store")
+	_, _ = w.Write(formatConversationMarkdown(msgs))
+}
+
+// formatConversationMarkdown renders messages as a markdown transcript:
+// a "## <Role>" heading per message, bodies separated by blank lines.
+// The heading format is daemon-owned so every adapter's transcript
+// reads the same; adapters own only per-message content.
+func formatConversationMarkdown(msgs []adapter.ConversationMessage) []byte {
+	var b bytes.Buffer
+	for i, m := range msgs {
+		if i > 0 {
+			b.WriteByte('\n')
+		}
+		b.WriteString("## ")
+		b.WriteString(roleHeading(m.Role))
+		b.WriteString("\n\n")
+		b.WriteString(strings.TrimRight(m.Text, "\n"))
+		b.WriteByte('\n')
+	}
+	return b.Bytes()
+}
+
+// roleHeading maps an adapter-reported role to its transcript heading.
+func roleHeading(role string) string {
+	switch role {
+	case "user":
+		return "User"
+	case "assistant":
+		return "Assistant"
+	case "":
+		return "Message"
+	default:
+		return strings.ToUpper(role[:1]) + role[1:]
+	}
+}

--- a/services/gmuxd/cmd/gmuxd/conversation_test.go
+++ b/services/gmuxd/cmd/gmuxd/conversation_test.go
@@ -1,0 +1,207 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/store"
+)
+
+// conversationFixture wires a real store plus temp conversation files
+// and runs requests against conversationHandler the way the dispatcher
+// does at runtime. The pi adapter is exercised for real (its JSONL
+// parser is the production render path), so these tests double as the
+// endpoint-level contract for pi transcripts.
+type conversationFixture struct {
+	sessions *store.Store
+	dir      string
+}
+
+func newConversationFixture(t *testing.T) *conversationFixture {
+	t.Helper()
+	return &conversationFixture{sessions: store.New(), dir: t.TempDir()}
+}
+
+// addPiSession registers a pi session whose ConversationRef points at
+// a JSONL file with the given lines. Returns the file path.
+func (f *conversationFixture) addPiSession(t *testing.T, id string, lines ...string) string {
+	t.Helper()
+	path := filepath.Join(f.dir, id+".jsonl")
+	var content string
+	for _, l := range lines {
+		content += l + "\n"
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write conversation: %v", err)
+	}
+	f.sessions.Upsert(store.Session{ID: id, Adapter: "pi", Alive: true, ConversationRef: path})
+	return path
+}
+
+func (f *conversationFixture) do(method, sessionID, rawQuery string) *http.Response {
+	url := "/v1/sessions/" + sessionID + "/conversation"
+	if rawQuery != "" {
+		url += "?" + rawQuery
+	}
+	req := httptest.NewRequest(method, url, nil)
+	rec := httptest.NewRecorder()
+	conversationHandler(rec, req, sessionID, f.sessions)
+	return rec.Result()
+}
+
+// errCode extracts the error envelope code the CLI keys its
+// scrollback fallback on.
+func errCode(t *testing.T, resp *http.Response) string {
+	t.Helper()
+	var env struct {
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+		t.Fatalf("decode error envelope: %v", err)
+	}
+	return env.Error.Code
+}
+
+// piSessionHeader is a minimal valid pi JSONL header line.
+const piSessionHeader = `{"type":"session","version":3,"id":"abc-123","timestamp":"2026-03-15T10:00:00Z","cwd":"/tmp"}`
+
+// TestConversationRendersMarkdownTranscript is the endpoint's central
+// claim: a pi session's JSONL comes back as a role-headed markdown
+// transcript with text/markdown content type — the body `gmux tail`
+// prints verbatim.
+func TestConversationRendersMarkdownTranscript(t *testing.T) {
+	f := newConversationFixture(t)
+	f.addPiSession(t, "sess-1",
+		piSessionHeader,
+		`{"type":"message","id":"u1","message":{"role":"user","content":[{"type":"text","text":"run the tests"}]}}`,
+		`{"type":"message","id":"a1","message":{"role":"assistant","content":[{"type":"toolCall","id":"t1","name":"bash","arguments":{"command":"go test ./..."}},{"type":"text","text":"All green."}]}}`,
+	)
+
+	resp := f.do(http.MethodGet, "sess-1", "")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: want 200, got %d", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Content-Type"); got != "text/markdown; charset=utf-8" {
+		t.Errorf("Content-Type: want text/markdown, got %q", got)
+	}
+	if got := resp.Header.Get("Cache-Control"); got != "no-store" {
+		t.Errorf("Cache-Control: want no-store, got %q", got)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	want := "## User\n\nrun the tests\n\n## Assistant\n\n[tool] bash {\"command\":\"go test ./...\"}\n\nAll green.\n"
+	if string(body) != want {
+		t.Errorf("body:\nwant %q\ngot  %q", want, body)
+	}
+}
+
+// TestConversationTailParamTrimsToLastNMessages: ?tail=N is the
+// message-unit analog of scrollback's last-N-lines — `gmux tail -n 1`
+// must return only the newest message, not the newest line.
+func TestConversationTailParamTrimsToLastNMessages(t *testing.T) {
+	f := newConversationFixture(t)
+	f.addPiSession(t, "sess-1",
+		piSessionHeader,
+		`{"type":"message","id":"u1","message":{"role":"user","content":[{"type":"text","text":"first"}]}}`,
+		`{"type":"message","id":"a1","message":{"role":"assistant","content":[{"type":"text","text":"second"}]}}`,
+	)
+
+	resp := f.do(http.MethodGet, "sess-1", "tail=1")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: want 200, got %d", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	want := "## Assistant\n\nsecond\n"
+	if string(body) != want {
+		t.Errorf("body: want %q, got %q", want, body)
+	}
+}
+
+// TestConversationTailParamRejectsBadValue mirrors the scrollback
+// broker's input contract: a typo must 400, not silently return the
+// full transcript.
+func TestConversationTailParamRejectsBadValue(t *testing.T) {
+	f := newConversationFixture(t)
+	f.addPiSession(t, "sess-1", piSessionHeader,
+		`{"type":"message","id":"u1","message":{"role":"user","content":[{"type":"text","text":"hi"}]}}`)
+
+	for _, raw := range []string{"tail=abc", "tail=0", "tail=-3"} {
+		resp := f.do(http.MethodGet, "sess-1", raw)
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Errorf("%s: want 400, got %d", raw, resp.StatusCode)
+		}
+	}
+}
+
+// TestConversationUnknownSession404 keeps "session never existed"
+// (code not_found, CLI reports an error) distinct from "session has no
+// conversation" (code no_conversation, CLI falls back to scrollback).
+func TestConversationUnknownSession404(t *testing.T) {
+	f := newConversationFixture(t)
+	resp := f.do(http.MethodGet, "sess-ghost", "")
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status: want 404, got %d", resp.StatusCode)
+	}
+	if code := errCode(t, resp); code != "not_found" {
+		t.Errorf("code: want not_found, got %q", code)
+	}
+}
+
+// TestConversationFallbackSignals enumerates every "no renderable
+// conversation" shape and pins them all to 404/no_conversation — the
+// single signal the CLI keys its scrollback fallback on. If any of
+// these leaked a different code, `gmux tail` would either error out or
+// misreport the session as missing instead of showing PTY output.
+func TestConversationFallbackSignals(t *testing.T) {
+	f := newConversationFixture(t)
+
+	// A shell session: no conversation file at all.
+	f.sessions.Upsert(store.Session{ID: "sess-shell", Adapter: "shell", Alive: true})
+
+	// A session whose adapter has a conversation file on record but does
+	// not implement ConversationRenderer (shell never will; stands in
+	// for any future filer-without-renderer adapter).
+	f.sessions.Upsert(store.Session{ID: "sess-norender", Adapter: "shell", Alive: true,
+		ConversationRef: filepath.Join(f.dir, "whatever.jsonl")})
+
+	// A pi session whose conversation file was deleted.
+	gone := f.addPiSession(t, "sess-deleted", piSessionHeader,
+		`{"type":"message","id":"u1","message":{"role":"user","content":[{"type":"text","text":"hi"}]}}`)
+	if err := os.Remove(gone); err != nil {
+		t.Fatal(err)
+	}
+
+	// A fresh pi session: header line only, no messages yet.
+	f.addPiSession(t, "sess-fresh", piSessionHeader)
+
+	for _, id := range []string{"sess-shell", "sess-norender", "sess-deleted", "sess-fresh"} {
+		resp := f.do(http.MethodGet, id, "")
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("%s: status: want 404, got %d", id, resp.StatusCode)
+			continue
+		}
+		if code := errCode(t, resp); code != "no_conversation" {
+			t.Errorf("%s: code: want no_conversation, got %q", id, code)
+		}
+	}
+}
+
+// TestConversationRejectsNonGet locks down readonly semantics, same as
+// the scrollback broker.
+func TestConversationRejectsNonGet(t *testing.T) {
+	f := newConversationFixture(t)
+	f.addPiSession(t, "sess-1", piSessionHeader)
+
+	for _, method := range []string{http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodPatch} {
+		resp := f.do(method, "sess-1", "")
+		if resp.StatusCode != http.StatusMethodNotAllowed {
+			t.Errorf("%s: want 405, got %d", method, resp.StatusCode)
+		}
+	}
+}

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -1782,6 +1782,9 @@ func serve(stderr io.Writer) int {
 		case "scrollback":
 			scrollbackBrokerHandler(w, r, sessionID, sessions, metaStore.SessionDir)
 
+		case "conversation":
+			conversationHandler(w, r, sessionID, sessions)
+
 		case "clipboard":
 			// Materialize a clipboard binary payload as a file in this
 			// gmuxd's os.TempDir() and return the absolute path. For

--- a/skills/gmux/SKILL.md
+++ b/skills/gmux/SKILL.md
@@ -22,7 +22,9 @@ gmux send --follow-up <id> 'text'   # queue a prompt for after the current turn
 gmux send --steering <id> 'text'    # interject a prompt into the current turn
 gmux wait <id>               # block until idle (agent turn done / shell at prompt)
 gmux wait <id> --for-text S  # block until S appears in the output
-gmux tail <id> [-n N]        # last N lines of output (ANSI stripped; default 100)
+gmux tail <id> [-n N]        # conversation as markdown (agents) or last N
+                             # lines of output (shells); default N=100
+gmux tail --raw <id>         # force the terminal-output view (plain text)
 gmux ls [--json]             # list sessions (--json for machine parsing)
 gmux kill <id>               # SIGTERM the runner
 ```
@@ -143,8 +145,23 @@ gmux wait $id --for-regex 'tests? passed: \d+' --timeout 120
 
 Same exit codes (`0` matched, `2` session exited first, `3` timeout). Matching
 is line-wise against the rendered terminal output (ANSI stripped, same text
-`gmux tail` shows), including output that appeared before the wait started, so
-the pattern must fit on one terminal line.
+`gmux tail --raw` shows), including output that appeared before the wait
+started, so the pattern must fit on one terminal line.
+
+## Reading a session's conversation
+
+For agent sessions backed by a conversation file (pi), `gmux tail` prints the
+conversation itself as markdown — `## User` / `## Assistant` messages with
+compact `[tool] …` one-liners — instead of the TUI's terminal rendering.
+`-n` counts messages there, not lines; thinking blocks and tool outputs are
+omitted. This is the best way to read another agent's answer:
+
+```bash
+gmux send --wait $id 'summarize your findings' Enter
+gmux tail $id -n 2           # the prompt and the reply, clean markdown
+```
+
+Shell sessions (and `--raw`) show terminal output instead.
 
 ## Other agents have one-shot modes
 


### PR DESCRIPTION
## Problem

`gmux tail` returns the rendered PTY scrollback. For agent TUIs that's box-drawing, spinners, redraws, and viewport-width truncation — a poor representation of the conversation, for humans and for agents driving other agents via the CLI. For adapters that persist a structured conversation file (pi's session JSONL), that file is the source of truth for what was actually said.

## What this does

- **Default `gmux tail <id>`** now prints a clean markdown transcript reconstructed from the conversation file when the session's adapter supports it: `## User` / `## Assistant` messages with compact `[tool] name {args…}` one-liners. Thinking blocks and tool-result payloads are omitted (internal noise / output that dwarfs the conversation).
- **`--raw` (alias `-e`)** forces the PTY scrollback view — byte-identical to the pre-change default output.
- **`-n`** counts **messages** in the conversation view, lines in the PTY view (default 100 unchanged).
- Sessions without a renderable conversation (shells, adapters without the capability, deleted file, no messages yet) fall back to PTY output transparently — scripts against shell sessions see no change.

```
$ gmux tail -n 2 0209052c
## User

say hello

## Assistant

[tool] bash {"command":"echo hello"}

Hello!
```

## Design (and alternatives considered)

One new seam per layer:

1. **`packages/adapter`** — optional `ConversationRenderer` capability: `RenderConversation(path) ([]ConversationMessage{Role, Text}, error)`. The adapter owns file-format knowledge (ADR 0014). pi implements it; claude/codex can slot in later behind the same seam. Torn tail lines (live file mid-append) are skipped, not fatal.
2. **`services/gmuxd`** — `GET /v1/sessions/{id}/conversation?tail=N` → `text/markdown`, dispatched from the same `/v1/sessions/` switch as scrollback, so **peer forwarding is free** (generic `peer.Forward` preserves the query string, and the conversation file lives on the owning host — exactly where the request lands). The daemon stays content-free (ADR 0011): the adapter re-reads the file per request, mirroring the scrollback broker; the daemon owns the uniform transcript shape so all adapters read the same. Every "nothing to render" shape answers 404 `no_conversation` — the single fallback signal — kept distinct from `not_found`.
3. **`cli/gmux`** — try `/conversation`, fall back to scrollback on `no_conversation` **or a plain non-JSON 404**, so a newer CLI against an older daemon/peer (no endpoint) degrades to pre-change behavior instead of erroring. Verified manually against a live pre-change daemon.

**Alternatives rejected:**
- *CLI reads the conversation file directly* — breaks for peer sessions and violates ADR 0005 (CLI routes through gmuxd).
- *Adapter returns fully-formatted markdown* — structured messages + daemon-side headings keep the transcript uniform across future adapters and leave room for a `--json` view without a new adapter method.
- *Splitting `--raw` (stripped) from `-e` (keep escapes)* — turns out escape preservation has been vestigial since the broker began rendering `?tail=N` through a terminal emulator (strips escapes server-side); a flag claiming to preserve escapes would be a lie. Both stay aliases meaning "PTY view". ADR 0009 amendment records this.
- *Building on ADR 0021's ACP stream* — that's the live-streaming runner endpoint (`session/load`/`session/update`); this issue is the snapshot CLI slice reading the durable JSONL (the "durable conversation" half of 0021 §4). No conflict; the endpoint can proxy the runner stream for live sessions later.

**Open questions from the issue, resolved as:** `-n` maps to messages (unit follows the view); session→file mapping uses the existing runner-attributed `store.Session.ConversationFile`; `-f`/live follow stays out of scope (tail remains snapshot-only per ADR 0009 13a; live streaming is 0021 territory).

## Tests

- `packages/adapter`: pi renderer table tests — transcript reconstruction, thinking-only turns dropped, string-content encoding, image placeholder, torn tail line, `fs.ErrNotExist` contract, tool-arg truncation.
- `services/gmuxd`: handler tests (real pi adapter + temp JSONL, scrollback-broker fixture pattern) — markdown output + headers, `tail=N` message trimming, bad-value 400, `not_found` vs the 4-shape `no_conversation` fallback matrix, GET-only.
- `cli/gmux`: parse tests (`--raw`, `-e` alias) and table tests for the pure fallback classification incl. old-daemon plain 404.
- Manual e2e (isolated daemon, seeded pi session via sessionmeta rehydration): default markdown / `-n 1` / `--raw` / `-e`; plus new CLI ↔ old daemon skew fallback.
- `go test ./...` + `go vet` green in `packages/adapter`, `services/gmuxd`, `cli/gmux`.

## Docs

CLI reference, scripts-and-agents integration page, `skills/gmux/SKILL.md`, and an ADR 0009 amendment (tail default, `--raw`/`-e` clarification, `-n` unit rule).

## Overlap note (concurrent PRs)

#373 / #385 touch the send/wait/adapter surface; this PR adds one dispatch case in `main.go` and stays out of the send/wait paths. Synergies left for follow-ups: claude/codex `ConversationRenderer` implementations, a `--json` tail view, web UI reuse of the endpoint.

Closes #384
