### PR TITLE
fix(web): scroll sidebar to selected session on mobile open

### DIFF
--- a/apps/gmux-web/src/sidebar-reveal.test.ts
+++ b/apps/gmux-web/src/sidebar-reveal.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from 'vitest'
+import { needsReveal } from './sidebar-reveal'
+
+describe('needsReveal', () => {
+  const container = { top: 100, bottom: 500 }
+
+  test('fully visible row stays put', () => {
+    expect(needsReveal(container, { top: 200, bottom: 300 })).toBe(false)
+  })
+
+  test('row flush with the edges counts as visible', () => {
+    expect(needsReveal(container, { top: 100, bottom: 500 })).toBe(false)
+  })
+
+  test('row above the viewport needs revealing', () => {
+    expect(needsReveal(container, { top: 40, bottom: 90 })).toBe(true)
+  })
+
+  test('row below the viewport needs revealing', () => {
+    expect(needsReveal(container, { top: 520, bottom: 600 })).toBe(true)
+  })
+
+  test('row taller than the viewport (clipped both ends) needs revealing', () => {
+    expect(needsReveal(container, { top: 50, bottom: 700 })).toBe(true)
+  })
+})

--- a/apps/gmux-web/src/sidebar-reveal.ts
+++ b/apps/gmux-web/src/sidebar-reveal.ts
@@ -1,0 +1,20 @@
+/** Reveal-selected-row geometry, split out from the sidebar component so
+ *  the scroll decision is testable without a DOM.
+ *
+ *  Mobile: when the off-canvas sidebar opens we want the selected session
+ *  in view rather than dumping the user at the top. But the row may not be
+ *  in the DOM yet (the drawer can open before the list renders, and the
+ *  selection can change while it stays open), so the caller retries until
+ *  a row exists — this decides whether, once found, a scroll is needed. */
+
+interface Rect {
+  top: number
+  bottom: number
+}
+
+/** True when `row` is not fully inside `container`'s viewport and should
+ *  therefore be scrolled into view. A row already fully visible stays put
+ *  so we never jump the list needlessly. */
+export function needsReveal(container: Rect, row: Rect): boolean {
+  return !(row.top >= container.top && row.bottom <= container.bottom)
+}

--- a/apps/gmux-web/src/sidebar.tsx
+++ b/apps/gmux-web/src/sidebar.tsx
@@ -6,6 +6,7 @@
  */
 
 import { useState, useCallback, useRef, useEffect } from 'preact/hooks'
+import { needsReveal } from './sidebar-reveal'
 import { sessionPath } from './routing'
 import { reorderKeysForFolder } from './projects'
 import { LaunchButton } from './launcher'
@@ -350,17 +351,30 @@ export function Sidebar({
   // scrolls when the row is actually outside the viewport (a visible
   // row stays put), and centers it so neighbors give context. Desktop
   // is unaffected: there `open` never transitions to true.
+  //
+  // The row may not exist yet: the drawer can open before the session
+  // list renders, and selection can change while it stays open. So we
+  // key on selId too and retry across a few animation frames until the
+  // row appears (or we give up), rather than fire once and miss it.
   const scrollRef = useRef<HTMLDivElement>(null)
   useEffect(() => {
     if (!open) return
-    const container = scrollRef.current
-    const el = container?.querySelector<HTMLElement>('.session-item.selected')
-    if (!container || !el) return
-    const c = container.getBoundingClientRect()
-    const r = el.getBoundingClientRect()
-    const fullyVisible = r.top >= c.top && r.bottom <= c.bottom
-    if (!fullyVisible) el.scrollIntoView({ block: 'center' })
-  }, [open])
+    let raf = 0
+    let tries = 0
+    const attempt = () => {
+      const container = scrollRef.current
+      const el = container?.querySelector<HTMLElement>('.session-item.selected')
+      if (container && el) {
+        if (needsReveal(container.getBoundingClientRect(), el.getBoundingClientRect()))
+          el.scrollIntoView({ block: 'center' })
+        return
+      }
+      // ~20 frames (~1/3s at 60fps) covers list render + drawer slide-in.
+      if (tries++ < 20) raf = requestAnimationFrame(attempt)
+    }
+    raf = requestAnimationFrame(attempt)
+    return () => cancelAnimationFrame(raf)
+  }, [open, selId])
 
   const totalVisible = foldersVal.reduce(
     (n, f) => n + f.sessions.filter(s => s.alive || s.resumable).length, 0,

--- a/apps/gmux-web/src/sidebar.tsx
+++ b/apps/gmux-web/src/sidebar.tsx
@@ -5,7 +5,7 @@
  * callbacks and the mobile open/close toggle are passed as props.
  */
 
-import { useState, useCallback } from 'preact/hooks'
+import { useState, useCallback, useRef, useEffect } from 'preact/hooks'
 import { sessionPath } from './routing'
 import { reorderKeysForFolder } from './projects'
 import { LaunchButton } from './launcher'
@@ -345,6 +345,23 @@ export function Sidebar({
   const hasUnresolved = unresolvedHosts.value.length > 0
   const bgArrival = useArrivalPulse(waiting ? 'unread' : 'none', waitingCount)
 
+  // Mobile: when the off-canvas sidebar opens, reveal the selected
+  // session instead of dumping the user at the top of the list. Only
+  // scrolls when the row is actually outside the viewport (a visible
+  // row stays put), and centers it so neighbors give context. Desktop
+  // is unaffected: there `open` never transitions to true.
+  const scrollRef = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    if (!open) return
+    const container = scrollRef.current
+    const el = container?.querySelector<HTMLElement>('.session-item.selected')
+    if (!container || !el) return
+    const c = container.getBoundingClientRect()
+    const r = el.getBoundingClientRect()
+    const fullyVisible = r.top >= c.top && r.bottom <= c.bottom
+    if (!fullyVisible) el.scrollIntoView({ block: 'center' })
+  }, [open])
+
   const totalVisible = foldersVal.reduce(
     (n, f) => n + f.sessions.filter(s => s.alive || s.resumable).length, 0,
   )
@@ -380,7 +397,7 @@ export function Sidebar({
             {hasUnresolved && <span class="settings-attention-pip" aria-hidden="true" />}
           </button>
         </div>
-        <div class="sidebar-scroll">
+        <div class="sidebar-scroll" ref={scrollRef}>
           {foldersVal.map(f => (
             <FolderGroup
               key={f.key}


### PR DESCRIPTION
When the off-canvas sidebar opens on mobile, the list now scrolls the currently-selected session into view (centered), instead of dumping the user at the top.

- No-op when the selected row is already fully visible.
- Desktop unaffected: the effect only fires on the `open` transition, which never happens for the always-visible desktop sidebar.

Part of the sidebar redesign track; this piece is independent and self-contained.