### PR TITLE
refactor(adapter): conversation refs are adapter-opaque (ADR 0022)

### DIFF
--- a/UBIQUITOUS_LANGUAGE.md
+++ b/UBIQUITOUS_LANGUAGE.md
@@ -5,11 +5,12 @@
 | Term                | Definition                                                                                                | Aliases to avoid          |
 | ------------------- | --------------------------------------------------------------------------------------------------------- | ------------------------- |
 | **Session**         | The user-facing unit of work in a directory: a terminal pane plus everything we know about it             | Pane, terminal, tab       |
-| **Conversation**    | An agent's own thread of dialogue (pi/claude/codex's "session"), identified by the agent's own **Conversation ID** (a UUID in the transcript header). It lives at an on-disk **conversation file** path; the path can change (resume/fork), the ID is the stable handle. A tool-backed **Session** corresponds to a Conversation; a **Runner** binds to one and may rebind (`/resume`) to another | Agent session, thread, session file |
+| **Conversation**    | An agent's own thread of dialogue (pi/claude/codex's "session"), identified by the agent's own **Conversation ID** (a UUID in the transcript header). It lives in adapter-owned storage, located by a **Conversation Ref**; the ref can change (resume/fork), the ID is the stable handle. A tool-backed **Session** corresponds to a Conversation; a **Runner** binds to one and may rebind (`/resume`) to another | Agent session, thread, session file |
 | **Slug**            | A session's mutable, human-readable display name; persistent across runner restarts and resume, but renamable. Not identity (the immutable Conversation ID is) | Name                      |
 | **Session ID**      | A specific runner instance's identifier; ephemeral for shell, stable (= conversation ID) for pi/claude    | Identifier (alone is too generic) |
 | **Key**             | The single string projects.json uses per session: slug if attributed, session ID otherwise                |                           |
-| **Conversation ID** | The agent's own identifier for a Conversation, parsed from inside the conversation file by the adapter (`ConversationInfo.ID`). Used with the adapter name as the conversations-index key `(adapter, conversationID)` | Tool ID (the old name)    |
+| **Conversation ID** | The agent's own identifier for a Conversation, extracted from the conversation's stored content by the adapter (`ConversationInfo.ID`). Used with the adapter name as the conversations-index key `(adapter, conversationID)` | Tool ID (the old name)    |
+| **Conversation Ref** | An opaque, adapter-scoped locator for one stored Conversation (ADR 0022). Only the owning adapter interprets it: file-backed adapters use the transcript's absolute path; a DB-backed adapter may use a row key. The wire/persisted key `conversation_file` carries it for compatibility | Conversation file path (as an identity), session file |
 
 ## Session lifecycle
 
@@ -51,8 +52,8 @@
 | **Sessionmeta**          | Per-session runtime persistence: `<state>/sessions/<id>/meta.json`. SOT for **runtime state** of dead sessions | Session metadata, meta files |
 | **Scrollback**           | Per-session persisted PTY byte stream: `<state>/sessions/<id>/scrollback{,.0}`. SOT for terminal history     | History, log                  |
 | **Projects.json**        | The on-disk SOT for **sidebar membership and ordering** (project rules + ordered key lists)                  | Project state, projects file  |
-| **Conversations Index**  | In-memory id↔slug map rebuilt on startup by scanning **adapter state files**; serves URL resolution & search | Conv index, conversations DB  |
-| **Adapter state files**  | Per-adapter on-disk records the conversations index reads (shell `<cwd>/<id>.json`, pi/claude JSONLs, ...)    | Session files                 |
+| **Conversations Index**  | In-memory id↔slug map rebuilt on startup from each adapter's **ConversationSource** (refs resolved via `DescribeConversation`); serves URL resolution & search | Conv index, conversations DB  |
+| **Adapter state files**  | Per-adapter on-disk records behind file-backed ConversationSources (shell `<cwd>/<id>.json`, pi/claude JSONLs, ...) — an adapter implementation detail    | Session files                 |
 
 ## State separation
 

--- a/apps/website/src/content/docs/develop/adapter-architecture.md
+++ b/apps/website/src/content/docs/develop/adapter-architecture.md
@@ -28,10 +28,10 @@ That split is why the adapter system is a set of small interfaces instead of one
 | PTY output monitoring | `gmux` | `Adapter.Monitor()` |
 | Child self-report API | `gmux` | Unix socket HTTP endpoints |
 | Launch menu discovery | `gmuxd` | `Launchable` + compiled adapter set |
-| Conversation file discovery | `gmuxd` | `ConversationFiler` |
+| Conversation metadata resolution | `gmuxd` | `ConversationDescriber` |
 | Live session state | runner → `gmuxd` | agent hook (`SessionExtender` / `SessionHookCommand`) |
 | Conversation discovery | `gmuxd` | `ConversationSource` (snapshot + watch) |
-| Resume command derivation | `gmuxd` | `ConversationFiler` + `Resumer` on the session's `ConversationFile` |
+| Resume command derivation | `gmuxd` | `ConversationDescriber` + `Resumer` on the session's `ConversationRef` |
 
 ## Launch lifecycle
 
@@ -111,25 +111,19 @@ The current built-in launcher ordering is simple:
 - non-fallback adapters contribute launchers in adapter registration order
 - shell is appended last
 
-## File-backed adapters
+## Conversation-storing adapters
 
-Some tools write session or conversation files to disk. Those integrations use optional capabilities discovered by `gmuxd`.
+Some tools persist conversations (pi/claude/codex write JSONL files; a future tool might use a database). Those integrations use optional capabilities discovered by `gmuxd`, all keyed by an opaque, adapter-scoped **conversation ref** (ADR 0022): the adapter picks the locator — file-backed adapters use the transcript's absolute path — and everything above the adapter just stores and round-trips the string.
 
-### `ConversationFiler`
+### `ConversationDescriber`
 
 ```go
-type ConversationFiler interface {
-    ConversationRootDir() string
-    ConversationDir(cwd string) string
-    ParseConversationFile(path string) (*ConversationInfo, error)
+type ConversationDescriber interface {
+    DescribeConversation(ref string) (*ConversationInfo, error)
 }
 ```
 
-Use this when a tool stores session state on disk and gmux should be able to discover or inspect it.
-
-- `ConversationRootDir()` returns the root containing all per-project conversation directories
-- `ConversationDir(cwd)` returns the directory for one working directory
-- `ParseConversationFile(path)` extracts display metadata such as ID, title, cwd, created time, and message count
+Use this when a tool stores conversations that gmux should be able to inspect. `DescribeConversation(ref)` resolves a ref to display metadata: ID, title, cwd, created time, last activity, and message count. How the adapter reads its storage (JSONL file, database row) is private to the adapter — including freshness: file-backed adapters report `LastActivity` from the transcript's mtime.
 
 ### `ConversationSource`
 
@@ -140,21 +134,31 @@ type ConversationSource interface {
 }
 ```
 
-Use this so `gmuxd` can index your tool's conversations (for URL resolution and search). The adapter owns discovery: `SnapshotConversations` reports everything that exists now, `WatchConversations` streams changes until `ctx` ends. File-backed adapters build on the shared `filewatch` tree watcher; the daemon parses each reported path via `ParseConversationFile`.
+Use this so `gmuxd` can index your tool's conversations (for URL resolution and search). The adapter owns discovery: `SnapshotConversations` reports everything that exists now, `WatchConversations` streams changes until `ctx` ends. Both report refs to a `ConversationSink` (`Upsert(ref)` / `Remove(ref)`); the daemon resolves each via `DescribeConversation`. File-backed adapters build on the shared `filewatch` tree watcher; a database-backed adapter would poll or subscribe instead.
+
+### `ConversationOpener`
+
+```go
+type ConversationOpener interface {
+    OpenConversation(ref string) (io.ReadCloser, error)
+}
+```
+
+Use this to let derived consumers (e.g. the fulltext search index) stream a conversation's raw, adapter-native content.
 
 ### `Resumer`
 
 ```go
 type Resumer interface {
     ResumeCommand(info *ConversationInfo) []string
-    CanResume(path string) bool
+    CanResume(ref string) bool
 }
 ```
 
 Use this when a finished session can be resumed later.
 
-- `CanResume(path)` filters out invalid or empty files
-- `ResumeCommand(info)` tells gmux how to resume the session when the user clicks it
+- `CanResume(ref)` filters out invalid or empty conversations
+- `ResumeCommand(info)` tells gmux how to resume the session when the user clicks it — if the command embeds a locator (pi's `--session <path>`), take it from `info.Ref`
 
 ## Live state and conversation discovery
 
@@ -162,23 +166,23 @@ These are two separate concerns, with two different owners.
 
 ### Live session state comes from the agent hook
 
-Which running session holds which conversation file — and its title and status —
+Which running session holds which conversation — and its title and status —
 is **not** inferred by the daemon. The runner injects a gmux agent hook
 (`SessionExtender` for pi's `-e` extension; `SessionHookCommand` for codex/claude
-hooks), and the agent reports the held file, title, and status authoritatively
-over the runner socket (`POST /hook/event`; see `docs/runner-hook-protocol.md`
-in the repo). `gmuxd` records the file on the session (`ConversationFile`);
-a `/resume` rebind to a different file is just another hook report. When a tool
-can't be hooked, the session runs without daemon-reported live state — there is
-no metadata-matching fallback.
+hooks), and the agent reports the held conversation, title, and status
+authoritatively over the runner socket (`POST /hook/event`; see
+`docs/runner-hook-protocol.md` in the repo). `gmuxd` records the ref on the
+session (`ConversationRef`); a `/resume` rebind to a different conversation is
+just another hook report. When a tool can't be hooked, the session runs without
+daemon-reported live state — there is no metadata-matching fallback.
 
 ### Conversation discovery via `ConversationSource`
 
-Independently, `gmuxd` indexes every conversation file on disk — including dead
+Independently, `gmuxd` indexes every stored conversation — including dead
 conversations with no running session — for URL resolution and search. Each
-`ConversationFiler` adapter also implements `ConversationSource`: it reports a
-startup snapshot and then streams changes, and the daemon parses each path via
-`ParseConversationFile` into the index. File-backed adapters share the `filewatch`
+`ConversationDescriber` adapter also implements `ConversationSource`: it reports
+a startup snapshot and then streams changes, and the daemon resolves each ref via
+`DescribeConversation` into the index. File-backed adapters share the `filewatch`
 tree watcher; a database-backed tool would poll or subscribe instead. There is
 no daemon-global file monitor.
 
@@ -188,14 +192,14 @@ Sessions transition seamlessly between alive and resumable states.
 
 ### Live → resumable transition
 
-When a session exits, `gmuxd` checks whether its adapter implements `ConversationFiler` + `Resumer` and whether the session has a recorded `ConversationFile` (reported by the agent hook). If so:
+When a session exits, `gmuxd` checks whether its adapter implements `ConversationDescriber` + `Resumer` and whether the session has a recorded `ConversationRef` (reported by the agent hook). If so:
 
 1. the resume command is derived from the adapter's `ResumeCommand()`
 2. `command` is set to the resume command
 3. `resumable` is derived automatically (`!alive && command present`)
 4. the session appears in the sidebar as clickable to resume — no intermediate "exited" state
 
-Sessions without a conversation file keep their original command, so "resume" re-runs it.
+Sessions without a recorded conversation keep their original command, so "resume" re-runs it.
 
 ### Dead sessions survive daemon restarts
 

--- a/apps/website/src/content/docs/develop/state-management.md
+++ b/apps/website/src/content/docs/develop/state-management.md
@@ -53,7 +53,7 @@ This means discovery can never race with Register to create duplicate sessions.
 
 ### Agent hook: authoritative live state
 
-Live session state is reported by the agent itself, not inferred by the daemon. The runner injects a gmux hook into the agent (`pi -e`, or codex/claude hooks), and the agent POSTs the held conversation file, title, and status to the runner socket; the runner forwards them over SSE. `gmuxd` records the file on the session (`ConversationFile`). A `/resume` rebind to a different file is just another report. Tools that can't be hooked run without daemon-reported live state — there is no metadata-matching fallback.
+Live session state is reported by the agent itself, not inferred by the daemon. The runner injects a gmux hook into the agent (`pi -e`, or codex/claude hooks), and the agent POSTs the held conversation, title, and status to the runner socket; the runner forwards them over SSE. `gmuxd` records the conversation's ref on the session (`ConversationRef`). A `/resume` rebind to a different conversation is just another report. Tools that can't be hooked run without daemon-reported live state — there is no metadata-matching fallback.
 
 ### Conversation sources: index updates
 

--- a/apps/website/src/content/docs/develop/writing-adapters.md
+++ b/apps/website/src/content/docs/develop/writing-adapters.md
@@ -156,21 +156,17 @@ Implement this if the adapter should contribute launch presets to the UI.
 - return none by not implementing the interface at all
 - remember that launch availability is controlled separately by the required `Discover()` method
 
-### `ConversationFiler`
+### `ConversationDescriber`
 
 ```go
-type ConversationFiler interface {
-    ConversationRootDir() string
-    ConversationDir(cwd string) string
-    ParseConversationFile(path string) (*ConversationInfo, error)
+type ConversationDescriber interface {
+    DescribeConversation(ref string) (*ConversationInfo, error)
 }
 ```
 
-Implement this if your tool writes session or conversation files to disk.
+Implement this if your tool persists conversations gmux should be able to inspect. Conversations are located by an opaque, adapter-scoped **ref** string: *you* pick the locator (the file-backed adapters use the transcript's absolute path; a database-backed tool would use a row key or UUID), and gmux never interprets it — it only stores refs and hands them back to you.
 
-- `ConversationRootDir()` returns the root containing all session directories
-- `ConversationDir(cwd)` returns the directory for a particular working directory
-- `ParseConversationFile(path)` extracts display metadata from one file
+`DescribeConversation(ref)` resolves a ref to display metadata: ID, title, slug, cwd, created time, `LastActivity` (freshness — file-backed adapters report the transcript's mtime), and message count. Set `Ref` to the ref you were given so resume commands that embed a locator can use it.
 
 ### `ConversationSource`
 
@@ -181,11 +177,11 @@ type ConversationSource interface {
 }
 ```
 
-Implement this if your tool's conversations live in files (or anywhere else) that gmux should index for URL resolution and search. The adapter owns *how* it discovers them: `SnapshotConversations` reports everything that exists now (synchronous, at startup), and `WatchConversations` streams changes until `ctx` is cancelled. Both report absolute paths to a `ConversationSink` (`Upsert(path)` / `Remove(path)`); the daemon parses each via your `ParseConversationFile`.
+Implement this if your tool's conversations live in files (or anywhere else) that gmux should index for URL resolution and search. The adapter owns *how* it discovers them: `SnapshotConversations` reports everything that exists now (synchronous, at startup), and `WatchConversations` streams changes until `ctx` is cancelled. Both report opaque refs to a `ConversationSink` (`Upsert(ref)` / `Remove(ref)`); the daemon resolves each via your `DescribeConversation`.
 
 File-backed adapters build both on `packages/adapter/filewatch`, a reusable recursive tree watcher, in a few lines each — see `pi.go`. A non-file source (e.g. a database) implements the same interface with a poller or subscription instead.
 
-Note: live session state — title, status, and the held conversation file — is **not** reported here. That flows authoritatively from the agent hook (`SessionExtender` for pi, `SessionHookCommand` for codex/claude); see below and [Adapter Architecture](/develop/adapter-architecture).
+Note: live session state — title, status, and the held conversation — is **not** reported here. That flows authoritatively from the agent hook (`SessionExtender` for pi, `SessionHookCommand` for codex/claude); see below and [Adapter Architecture](/develop/adapter-architecture).
 
 ### `SessionExtender` / `SessionHookCommand`
 
@@ -198,7 +194,17 @@ Only opt in if gmux fully controls the argv — a shell-wrapped launch (`bash -c
 
 ### `ConversationProber`
 
-Optional. Lets the startup retention reconcile distinguish a *deleted* conversation file from *unavailable* storage, so dead sessions are only retired when their conversation is genuinely gone (ADR 0016). The agent adapters implement it via the shared `ConversationGoneAtRoot` helper.
+Optional. Lets the startup retention reconcile distinguish a *deleted* conversation from *unavailable* storage, so dead sessions are only retired when their conversation is genuinely gone (ADR 0016). The file-backed agent adapters implement it via the shared `ConversationGoneAtRoot` helper.
+
+### `ConversationOpener`
+
+```go
+type ConversationOpener interface {
+    OpenConversation(ref string) (io.ReadCloser, error)
+}
+```
+
+Optional. Streams a conversation's raw, adapter-native content (e.g. the JSONL transcript) for derived consumers such as the fulltext search index. The file-backed adapters implement it as `os.Open(ref)`.
 
 ### `SessionRegistrar` / `SessionFinalizer`
 
@@ -213,16 +219,16 @@ Optional. Marks one-shot invocations (e.g. `pi update`, `pi --version`) that sho
 ```go
 type Resumer interface {
     ResumeCommand(info *ConversationInfo) []string
-    CanResume(path string) bool
+    CanResume(ref string) bool
 }
 ```
 
 Implement this if your tool supports resuming previous sessions.
 
-- `CanResume()` filters out invalid or empty files
+- `CanResume(ref)` filters out invalid or empty conversations
 - `ResumeCommand()` tells gmux how to resume a valid session
 
-All dead sessions are resumable. When a session exits, gmuxd checks whether the adapter implements `Resumer` **and** the session has a recorded conversation file (`ConversationFile`, reported by the agent hook). If so, the session's command is replaced with the adapter's resume command (e.g. `["claude", "--resume", "abc"]`). If not, the original launch command is kept as-is, so "resume" simply re-runs the command in the same working directory.
+All dead sessions are resumable. When a session exits, gmuxd checks whether the adapter implements `Resumer` **and** the session has a recorded conversation ref (`ConversationRef`, reported by the agent hook). If so, the session's command is replaced with the adapter's resume command (e.g. `["claude", "--resume", "abc"]`). If not, the original launch command is kept as-is, so "resume" simply re-runs the command in the same working directory.
 
 This means adapters that don't implement `Resumer` still get resume for free: the user clicks resume, a new session starts with the same command and cwd. This is the right behavior for simple tools. Only implement `Resumer` when your tool has native resume support that you want to use instead.
 
@@ -236,19 +242,19 @@ type CommandTitler interface {
 
 Implement this to customize the fallback title derived from the command array. Without it, the store joins the full command (e.g. `pytest -x`). Adapters that use resume commands implement this to avoid titles like `codex resume 019cfb54-…`; the editor adapter shows the edited file's basename.
 
-This only matters when no adapter or shell title has been set yet, which is rare for agent adapters (titles come from the agent hook or conversation file) but common for plain shell sessions.
+This only matters when no adapter or shell title has been set yet, which is rare for agent adapters (titles come from the agent hook or stored conversation) but common for plain shell sessions.
 
 ### Capability composition
 
 An adapter implements only what it needs:
 
-| Adapter | Base | Launchable | ConversationFiler | ConversationSource | Resumer | Other |
-|---------|------|------------|-------------------|--------------------|---------|-------|
+| Adapter | Base | Launchable | ConversationDescriber | ConversationSource | Resumer | Other |
+|---------|------|------------|-----------------------|--------------------|---------|-------|
 | Shell | ✓ | ✓ | ✓ | — | ✓ | CommandTitler, SessionRegistrar, SessionFinalizer |
 | Editor | ✓ | ✓ | — | — | — | CommandTitler, SessionRegistrar |
-| Claude | ✓ | ✓ | ✓ | ✓ | ✓ | ConversationProber, SessionHookCommand |
-| Codex | ✓ | ✓ | ✓ | ✓ | ✓ | ConversationProber, SessionHookCommand |
-| Pi | ✓ | ✓ | ✓ | ✓ | ✓ | ConversationProber, SessionExtender, PassthroughDetector |
+| Claude | ✓ | ✓ | ✓ | ✓ | ✓ | ConversationOpener, ConversationProber, SessionHookCommand |
+| Codex | ✓ | ✓ | ✓ | ✓ | ✓ | ConversationOpener, ConversationProber, SessionHookCommand |
+| Pi | ✓ | ✓ | ✓ | ✓ | ✓ | ConversationOpener, ConversationProber, SessionExtender, PassthroughDetector |
 
 Shell writes a small JSON state file per session under `~/.local/state/gmux/shell-sessions/` and resumes by launching `$SHELL` in the original cwd. The editor adapter (backing `gmux edit`) is a good minimal non-agent example: it matches an internal sentinel command and is ephemeral (auto-dismissed on close).
 
@@ -260,7 +266,7 @@ Write unit tests in `myapp_test.go` next to your adapter. Test `Match()` with di
 
 If the adapter implements `Launchable`, test the returned launcher IDs, labels, and commands.
 
-For adapters with `ConversationFiler`, create temp files in your tool's format and verify `ParseConversationFile()` extracts the expected metadata.
+For adapters with `ConversationDescriber`, create temp conversations in your tool's format and verify `DescribeConversation()` extracts the expected metadata.
 
 For the full end-to-end pipeline (launch → file attribution → title → resume), add integration tests that run real processes through gmuxd. See [Integration Tests](/develop/integration-tests) for the harness, patterns, and gotchas.
 

--- a/apps/website/src/content/docs/planned/opencode-adapter.md
+++ b/apps/website/src/content/docs/planned/opencode-adapter.md
@@ -46,9 +46,11 @@ parts TEXT NOT NULL default '[]',  -- JSON array
 finished_at INTEGER
 ```
 
-The adapter would implement `ConversationFiler` by:
-- Querying `SELECT id, title, message_count, created_at FROM sessions ORDER BY updated_at DESC`
-- Mapping results to `ConversationInfo` structs
+The adapter would implement `ConversationDescriber` (with the session row's `id` as the opaque conversation ref — ADR 0022) by:
+- Querying `SELECT id, title, message_count, updated_at, created_at FROM sessions WHERE id = ?`
+- Mapping results to `ConversationInfo` structs (`updated_at` → `LastActivity`)
+
+Enumeration comes from a `ConversationSource` that snapshots the sessions table and watches the WAL for changes, emitting row-id refs to the sink.
 
 This requires a SQLite dependency. `modernc.org/sqlite` (pure Go, no CGo) is preferred to avoid requiring a C compiler in the build chain.
 

--- a/cli/gmux/internal/ptyserver/extension_test.go
+++ b/cli/gmux/internal/ptyserver/extension_test.go
@@ -49,10 +49,10 @@ func postSessionEvent(t *testing.T, sockPath, body string) {
 	resp.Body.Close()
 }
 
-// TestReconnectReplaysConversationFile checks that a newly-connected /events
+// TestReconnectReplaysConversationRef checks that a newly-connected /events
 // subscriber (a reconnecting daemon) is replayed the bound conversation file, so
 // attribution survives a daemon restart without persisted state.
-func TestReconnectReplaysConversationFile(t *testing.T) {
+func TestReconnectReplaysConversationRef(t *testing.T) {
 	node, err := exec.LookPath("node")
 	if err != nil {
 		t.Skip("node not available")
@@ -77,10 +77,10 @@ func TestReconnectReplaysConversationFile(t *testing.T) {
 
 	postSessionEvent(t, sockPath, `{"op":"session","path":`+strconv.Quote(sessFile)+`}`)
 	deadline := time.After(5 * time.Second)
-	for st.ConversationFileSnapshot() != sessFile {
+	for st.ConversationRefSnapshot() != sessFile {
 		select {
 		case <-deadline:
-			t.Fatalf("runner never recorded conversation file; got %q", st.ConversationFileSnapshot())
+			t.Fatalf("runner never recorded conversation file; got %q", st.ConversationRefSnapshot())
 		case <-time.After(20 * time.Millisecond):
 		}
 	}
@@ -150,10 +150,10 @@ func TestSessionEventIsAuthoritative(t *testing.T) {
 	waitFor := func(want string) {
 		t.Helper()
 		deadline := time.After(2 * time.Second)
-		for st.ConversationFileSnapshot() != want {
+		for st.ConversationRefSnapshot() != want {
 			select {
 			case <-deadline:
-				t.Fatalf("runner did not bind to %q; got %q", want, st.ConversationFileSnapshot())
+				t.Fatalf("runner did not bind to %q; got %q", want, st.ConversationRefSnapshot())
 			case <-time.After(20 * time.Millisecond):
 			}
 		}

--- a/cli/gmux/internal/ptyserver/ptyserver.go
+++ b/cli/gmux/internal/ptyserver/ptyserver.go
@@ -572,7 +572,7 @@ const maxInputBytes = 1 << 20 // 1 MiB
 // per-adapter assumptions. The agent reports facts about itself; the runner
 // maps them to sidebar state:
 //
-//	op "session"          — the bound conversation file, id, name (on bind)
+//	op "session"          — the bound conversation ref, id, name (on bind)
 //	op "turn" phase start — the agent loop began (→ working)
 //	op "turn" phase end   — the loop ended with Outcome + title
 //
@@ -596,11 +596,11 @@ type hookEvent struct {
 }
 
 // handleHookEvent applies the authoritative session state an agent's gmux hook
-// reports: the bound conversation file + title + slug on every bind, and
+// reports: the bound conversation ref + title + slug on every bind, and
 // busy/idle/unread/error on every agent-loop transition. There is no
 // inference and no per-adapter branching — the agent tells us exactly what it
 // holds and does, and the runner relays those facts (ADR 0011). State written
-// here (SetConversationFile et al.) is a relay snapshot for /events replay, not
+// here (SetConversationRef et al.) is a relay snapshot for /events replay, not
 // derived or sticky.
 func (s *Server) handleHookEvent(w http.ResponseWriter, r *http.Request) {
 	var ev hookEvent
@@ -613,7 +613,7 @@ func (s *Server) handleHookEvent(w http.ResponseWriter, r *http.Request) {
 		// Authoritative bind (e.g. pi's session_start): the file the
 		// agent holds, named and slugged.
 		if ev.Path != "" {
-			s.state.SetConversationFile(ev.Path)
+			s.state.SetConversationRef(ev.Path)
 		}
 		if ev.Name != "" {
 			s.state.SetAdapterTitle(ev.Name)
@@ -781,10 +781,10 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 	ch := s.state.Subscribe()
 	defer s.state.Unsubscribe(ch)
 
-	// Replay the bound conversation file to this (possibly reconnecting) subscriber
+	// Replay the bound conversation ref to this (possibly reconnecting) subscriber
 	// so a restarted daemon re-learns attribution with no persisted state. A
 	// concurrent update may also arrive on ch; harmless (idempotent).
-	if file := s.state.ConversationFileSnapshot(); file != "" {
+	if file := s.state.ConversationRefSnapshot(); file != "" {
 		if data, err := json.Marshal(map[string]string{"path": file}); err == nil {
 			fmt.Fprintf(w, "event: conversation_file\ndata: %s\n\n", data)
 		}

--- a/cli/gmux/internal/session/state.go
+++ b/cli/gmux/internal/session/state.go
@@ -49,11 +49,15 @@ type State struct {
 	// Slug is an adapter-provided stable identifier for URL routing.
 	Slug string `json:"slug,omitempty"`
 
-	// ConversationFile is the agent's on-disk JSONL conversation file, as
-	// reported authoritatively by the agent hook (ADR 0011). It is the
-	// immutable Tool ID's address; a change here is a rebind (/resume).
-	// Empty until the agent reports it, or for unhooked adapters.
-	ConversationFile string `json:"conversation_file,omitempty"`
+	// ConversationRef is the adapter-scoped ref of the conversation the
+	// agent is writing, as reported authoritatively by the agent hook
+	// (ADR 0011). Opaque above the adapter: today's file-backed adapters
+	// report their on-disk JSONL transcript path; other storage schemes
+	// may report a different locator. It is the immutable Tool ID's
+	// address; a change here is a rebind (/resume). Empty until the agent
+	// reports it, or for unhooked adapters. The wire key stays
+	// "conversation_file" for compatibility.
+	ConversationRef string `json:"conversation_file,omitempty"`
 
 	// Terminal size (updated by the runner whenever PTY is resized).
 	TerminalCols uint16 `json:"terminal_cols,omitempty"`
@@ -228,13 +232,13 @@ func (s *State) SetSlug(slug string) {
 	s.emit(Event{Type: "meta", Data: map[string]string{"slug": slug}})
 }
 
-// ConversationFileSnapshot returns the held conversation file, for replay to a
+// ConversationRefSnapshot returns the held conversation ref, for replay to a
 // newly-connected /events subscriber so a reconnecting daemon re-learns
 // attribution without persisted state.
-func (s *State) ConversationFileSnapshot() string {
+func (s *State) ConversationRefSnapshot() string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	return s.ConversationFile
+	return s.ConversationRef
 }
 
 // SlugSnapshot returns the current URL-safe slug under lock.
@@ -263,17 +267,18 @@ func (s *State) UnreadSnapshot() bool {
 	return s.Unread
 }
 
-// SetConversationFile records the agent's current conversation file as reported by
-// the extension. Emits a conversation_file event only when the path changes, so
-// the daemon sees first-attribution and rebind (/resume) but not every write.
-func (s *State) SetConversationFile(path string) {
+// SetConversationRef records the agent's current conversation ref as reported
+// by the extension. Emits a conversation_file event (legacy wire name; the
+// payload's "path" key carries the ref) only when the ref changes, so the
+// daemon sees first-attribution and rebind (/resume) but not every write.
+func (s *State) SetConversationRef(ref string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if path == "" || path == s.ConversationFile {
+	if ref == "" || ref == s.ConversationRef {
 		return
 	}
-	s.ConversationFile = path
-	s.emit(Event{Type: "conversation_file", Data: map[string]string{"path": path}})
+	s.ConversationRef = ref
+	s.emit(Event{Type: "conversation_file", Data: map[string]string{"path": ref}})
 }
 
 // SetSubtitle updates the display subtitle.

--- a/docs/adr/0014-adapter-owned-conversation-sources.md
+++ b/docs/adr/0014-adapter-owned-conversation-sources.md
@@ -1,6 +1,7 @@
 # ADR 0014: conversation discovery is adapter-owned; no daemon-global file monitor
 
-**Status:** Accepted
+**Status:** Accepted (amended by ADR 0022: the sink/index/session plumbing now
+carries adapter-opaque conversation refs instead of file paths)
 **Date:** 2026-06-21
 **Related:** ADR 0011 (runner-owned session state), ADR 0013 (codex hooks), ADR 0012 (relational storage a non-goal)
 

--- a/docs/adr/0022-adapter-opaque-conversation-refs.md
+++ b/docs/adr/0022-adapter-opaque-conversation-refs.md
@@ -1,0 +1,127 @@
+# ADR 0022: conversation refs are adapter-opaque
+
+**Status:** Accepted
+**Date:** 2026-07-12
+**Related:** ADR 0011 (runner-owned session state), ADR 0012 (relational storage a non-goal; search is a derived index), ADR 0014 (adapter-owned conversation sources), ADR 0016 (scrollback as cache), ADR 0021 (ACP session/update as internal conversation schema)
+
+## Context
+
+ADR 0014 made conversation *discovery* adapter-owned: the daemon consumes a
+`ConversationSource` event stream instead of running a global file monitor,
+and explicitly promised that "non-file adapters fit without new daemon code".
+But the interfaces around that seam still spoke in files:
+
+- The sink and index traded in **paths** (`ConversationSink.Upsert(path)`,
+  `Index.ScanFile`, `Info.FilePath`, `RemoveByPath`).
+- The daemon resolved those paths itself via
+  `ConversationFiler.ParseConversationFile(path)` — an interface whose other
+  methods (`ConversationRootDir`, `ConversationDir`) exposed each tool's
+  on-disk **layout** to any importer.
+- The session record carried the transcript path as a first-class field
+  (`store.Session.ConversationFile`, wire key `conversation_file`), and
+  resume/retention keyed off it as a *path* (`filepath.Clean` matching,
+  mtime-based freshness proposals such as PR #393 statting it directly).
+
+For pi/claude/codex — all one-JSONL-per-conversation — this works. For a
+future adapter that stores conversations in a database (e.g. opencode), every
+one of these sites breaks: there is no path to emit, parse, stat, or clean.
+That contradicts both ADR 0014's consequence and the direction of ADR 0021
+(conversation content is adapter/runner-translated, never daemon-interpreted).
+
+## Decision
+
+**Introduce the *conversation ref*: an opaque, adapter-scoped locator string
+for one stored conversation. Everything above the adapter stores, compares,
+and round-trips refs; only the owning adapter interprets them.**
+
+For today's file-backed adapters the ref *is* the transcript's absolute path —
+but that is now the adapter's private convention, not a contract.
+
+### The corrected adapter contract (`packages/adapter`)
+
+| Capability | Shape | Replaces |
+| --- | --- | --- |
+| `ConversationSource` | unchanged: `SnapshotConversations(sink)` + `WatchConversations(ctx, sink)`; the sink's `Upsert(ref)` / `Remove(ref)` now carry opaque refs | path-carrying sink |
+| `ConversationDescriber` | `DescribeConversation(ref) (*ConversationInfo, error)` — the only way to turn a ref into metadata | `ConversationFiler.ParseConversationFile(path)` |
+| `ConversationOpener` | `OpenConversation(ref) (io.ReadCloser, error)` — raw, adapter-native content stream (the fulltext-search content seam) | *(new)* |
+| `ConversationProber` | `ConversationGone(ref) (gone, ok bool)` — deleted vs storage-unavailable | same, path-typed |
+| `Resumer` | `CanResume(ref)`; `ResumeCommand(*ConversationInfo)` | same, path-typed |
+
+`ConversationInfo` gains two fields and loses one:
+
+- `Ref string` replaces `FilePath` — the ref the info was described from, so
+  resume commands that embed a locator (pi's `--session <path>`) get it from
+  the adapter's own answer, not from daemon-side path knowledge.
+- `LastActivity time.Time` — **adapter-provided freshness**. File-backed
+  adapters implement it as the transcript's mtime (shared `fileLastActivity`
+  helper); a DB adapter returns its own timestamp. Consumers (activity
+  reseeding à la PR #393, search recency ranking) must take this field, never
+  stat anything themselves.
+
+`ConversationRootDir` / `ConversationDir` are no longer part of any
+daemon-facing interface. They remain concrete methods on the file-backed
+adapters (layout knowledge stays co-located with the layout owner), used only
+inside `packages/adapter/adapters` and its tests.
+
+### Daemon changes (`services/gmuxd`)
+
+- `conversations.Index` speaks refs: `Info.Ref` (+ `Info.LastActivity`),
+  `Scan(adapter, ref)` via `ConversationDescriber`, `RemoveByRef`.
+- `store.Session.ConversationFile` → **`ConversationRef`**. The wire and
+  persisted JSON key stays `conversation_file`, and the runner's
+  `conversation_file` /events event (payload key `path`) stays, purely for
+  compatibility — both are documented as legacy names carrying a ref.
+  Likewise the runner's `session.State.ConversationRef`.
+- Retention (`RemoveDeadByConversationRef`, `reconcileDeletedConversations`)
+  and resume (`ResolveResumeCommand`) key off the ref and hand it straight
+  back to the owning adapter. The one residual path-ism is deliberate:
+  `RemoveDeadByConversationRef` still compares refs after `filepath.Clean`,
+  because hook-reported and watcher-reported *paths* can differ cosmetically;
+  for non-path refs (no separators) `Clean` is the identity, so it degrades to
+  exact equality.
+- `internal/sessionfiles` → `internal/storegc`: the package had nothing to do
+  with files anymore (it purges never-attributed dead sessions); the name was
+  a fossil asserting the file model.
+
+### What ADR 0014 got right, kept
+
+ADR 0014 rejected "adapter emits parsed `ConversationInfo` instead of file
+paths" to keep the sink thin. That still holds: the sink stays *locator-level*
+(one string), and the daemon still decides *when* to resolve a ref to
+metadata. What changes is *who understands the locator*: resolution goes
+through `DescribeConversation`, so the daemon no longer knows the locator is a
+file. ADR 0014's mechanism-ownership (filewatch lives in the adapter module)
+is untouched.
+
+## Consequences
+
+- **A DB-backed adapter needs zero daemon changes**: implement
+  `ConversationSource` (poll/subscribe), `ConversationDescriber`,
+  `ConversationOpener`, `ConversationProber`, `Resumer` with row-key refs, and
+  discovery, URL resolution, resume, retention, and activity freshness all
+  work. No stat, no mtime, no directory layout anywhere above the adapter.
+- **Fulltext search builds on this seam** (per ADR 0012's derived-index
+  stance): enumerate via the conversations index / `ConversationSource`
+  stream, rank freshness via `Info.LastActivity`, fetch content via
+  `ConversationOpener.OpenConversation(ref)`. Content bytes are
+  adapter-native; a consumer needing a normalized schema translates per
+  ADR 0021.
+- **Freshness-from-mtime is now an adapter detail.** Daemon-side proposals
+  that stat `ConversationFile` (PR #393's `activitySeedFor`) should instead
+  ask the adapter (`DescribeConversation(...).LastActivity`), falling back to
+  runner-owned signals (scrollback tee) that the daemon legitimately owns.
+- Wire and on-disk formats are unchanged (`conversation_file` key, event
+  name, meta.json) — pure Go-level refactor, no migration.
+
+## Alternatives
+
+- **Record-level sink (adapter pushes `ConversationInfo`).** Re-rejected for
+  the same reason as ADR 0014: duplicates the index's type across the module
+  boundary and forces every source event to carry a full parse even when the
+  index will discard it (dedupe, slug-unchanged).
+- **Rename the wire key to `conversation_ref` now.** Rejected: long-lived
+  runners survive daemon upgrades (see the `session_file` shim being retired
+  in v2.1); a second rename would need a second shim for zero user value.
+- **Keep `ConversationFiler` and add a parallel DB interface later.** Rejected:
+  two capability families for one concept is exactly the interface zoo ADR
+  0014 collapsed; the opaque ref makes one family sufficient.

--- a/docs/adr/0022-adapter-opaque-conversation-refs.md
+++ b/docs/adr/0022-adapter-opaque-conversation-refs.md
@@ -66,15 +66,21 @@ inside `packages/adapter/adapters` and its tests.
 ### Daemon changes (`services/gmuxd`)
 
 - `conversations.Index` speaks refs: `Info.Ref` (+ `Info.LastActivity`),
-  `Scan(adapter, ref)` via `ConversationDescriber`, `RemoveByRef`.
+  `Scan(adapter, ref)` via `ConversationDescriber`, `RemoveByRef(adapter, ref)`.
+  Because a ref is only unique *within* an adapter, every removal path is
+  keyed by `(adapter, ref)` — the sink re-scopes its source's bare ref with
+  the owning adapter's name before touching the index or the retirement
+  callback, so two adapters using the same ref string can never delete
+  each other's conversations. (Absolute file paths made this collision
+  impossible by accident; opaque refs make the scoping explicit.)
 - `store.Session.ConversationFile` → **`ConversationRef`**. The wire and
   persisted JSON key stays `conversation_file`, and the runner's
   `conversation_file` /events event (payload key `path`) stays, purely for
   compatibility — both are documented as legacy names carrying a ref.
   Likewise the runner's `session.State.ConversationRef`.
-- Retention (`RemoveDeadByConversationRef`, `reconcileDeletedConversations`)
-  and resume (`ResolveResumeCommand`) key off the ref and hand it straight
-  back to the owning adapter. The one residual path-ism is deliberate:
+- Retention (`RemoveDeadByConversationRef(adapter, ref)`,
+  `reconcileDeletedConversations`) and resume (`ResolveResumeCommand`) key
+  off `(adapter, ref)` and hand the ref straight back to the owning adapter. The one residual path-ism is deliberate:
   `RemoveDeadByConversationRef` still compares refs after `filepath.Clean`,
   because hook-reported and watcher-reported *paths* can differ cosmetically;
   for non-path refs (no separators) `Clean` is the identity, so it degrades to

--- a/docs/adr/0022-adapter-opaque-conversation-refs.md
+++ b/docs/adr/0022-adapter-opaque-conversation-refs.md
@@ -73,6 +73,11 @@ inside `packages/adapter/adapters` and its tests.
   callback, so two adapters using the same ref string can never delete
   each other's conversations. (Absolute file paths made this collision
   impossible by accident; opaque refs make the scoping explicit.)
+  Ref comparison itself is exact; only refs that are *rooted paths* (the
+  file adapters' spelling) are `filepath.Clean`-normalized, because the
+  hook-reported and watcher-reported spellings of the same transcript can
+  differ cosmetically. An opaque ref is never normalized — an adapter may
+  legitimately use "a/../b" and "b" as distinct locators.
 - `store.Session.ConversationFile` → **`ConversationRef`**. The wire and
   persisted JSON key stays `conversation_file`, and the runner's
   `conversation_file` /events event (payload key `path`) stays, purely for
@@ -112,10 +117,11 @@ is untouched.
   `ConversationOpener.OpenConversation(ref)`. Content bytes are
   adapter-native; a consumer needing a normalized schema translates per
   ADR 0021.
-- **Freshness-from-mtime is now an adapter detail.** Daemon-side proposals
-  that stat `ConversationFile` (PR #393's `activitySeedFor`) should instead
-  ask the adapter (`DescribeConversation(...).LastActivity`), falling back to
-  runner-owned signals (scrollback tee) that the daemon legitimately owns.
+- **Freshness-from-mtime is now an adapter detail.** The activity reseed
+  (PR #393's `activitySeedFor`) asks the adapter
+  (`DescribeConversation(...).LastActivity`) instead of statting the ref,
+  falling back to the runner's scrollback tee — a daemon-owned cache
+  (ADR 0016) that a direct stat is legitimate for.
 - Wire and on-disk formats are unchanged (`conversation_file` key, event
   name, meta.json) — pure Go-level refactor, no migration.
 

--- a/docs/runner-hook-protocol.md
+++ b/docs/runner-hook-protocol.md
@@ -40,10 +40,10 @@ One JSON object per event, discriminated by `op`. Unknown ops/values are ignored
 // op "session" — authoritative bind. Sent on startup and on every rebind
 // (switch/new/resume/fork). "session" here denotes the agent's own session
 // (its conversation) — the agent's language, per ADR 0015; gmux calls the
-// bound artifact a conversation file.
+// bound artifact's locator a conversation ref (ADR 0022).
 {
   "op":     "session",
-  "path":   "/abs/path/to/conversation-file",  // required
+  "path":   "/abs/path/to/conversation-file",  // required; the conversation ref (a transcript path for today's file-backed agents)
   "id":     "session-id",                       // optional; slugified for the URL if no slug
   "slug":   "human-title",                      // optional; slug source (runner slugifies), preferred over id
   "name":   "human title",                      // optional; sets the adapter title
@@ -61,7 +61,7 @@ One JSON object per event, discriminated by `op`. Unknown ops/values are ignored
 
 | Field     | Op       | Meaning |
 |-----------|----------|---------|
-| `path`    | session  | Absolute path of the held conversation file. |
+| `path`    | session  | The held conversation's ref — adapter-opaque above the runner (ADR 0022); today's file-backed agents report the transcript's absolute path. |
 | `id`      | session  | Session identity; slugified into the URL when no `slug`. |
 | `slug`    | session  | Slug source, slugified by the runner; preferred over `id` (codex/pi session ids are UUIDs that slugify badly). |
 | `name`    | session  | Display title at bind time. |

--- a/e2e/tests/conversation-discovery.spec.ts
+++ b/e2e/tests/conversation-discovery.spec.ts
@@ -135,7 +135,7 @@ test.describe('conversation discovery (watcher-driven)', () => {
 
     await awaitIndexed('pi', expectedSlug)
 
-    // Remove triggers fsnotify Remove -> RemoveByPath.
+    // Remove triggers fsnotify Remove -> RemoveByRef.
     fs.unlinkSync(filePath)
 
     await awaitRemoved('pi', expectedSlug)

--- a/packages/adapter/adapters/claude.go
+++ b/packages/adapter/adapters/claude.go
@@ -3,6 +3,7 @@ package adapters
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -17,11 +18,12 @@ import (
 
 // Compile-time interface checks.
 var (
-	_ adapter.ConversationSource = (*Claude)(nil)
-	_ adapter.ConversationProber = (*Claude)(nil)
-	_ adapter.Launchable         = (*Claude)(nil)
-	_ adapter.ConversationFiler  = (*Claude)(nil)
-	_ adapter.Resumer            = (*Claude)(nil)
+	_ adapter.ConversationSource    = (*Claude)(nil)
+	_ adapter.ConversationProber    = (*Claude)(nil)
+	_ adapter.Launchable            = (*Claude)(nil)
+	_ adapter.ConversationDescriber = (*Claude)(nil)
+	_ adapter.ConversationOpener    = (*Claude)(nil)
+	_ adapter.Resumer               = (*Claude)(nil)
 )
 
 func init() {
@@ -72,7 +74,7 @@ func (c *Claude) Monitor(_ []byte) *adapter.Event {
 	return nil
 }
 
-// --- ConversationFiler ---
+// --- Conversation storage (file-backed: refs are absolute JSONL paths) ---
 
 // ConversationRootDir returns Claude Code's per-project sessions directory.
 func (c *Claude) ConversationRootDir() string {
@@ -85,9 +87,10 @@ func (c *Claude) ConversationRootDir() string {
 
 // ConversationGone anchors deletion detection on ConversationRootDir
 // (~/.claude/projects): if that tree is present, a missing transcript
-// was deleted; if it's absent, the storage is unavailable.
-func (c *Claude) ConversationGone(path string) (gone bool, ok bool) {
-	return adapter.ConversationGoneAtRoot(path, c.ConversationRootDir())
+// was deleted; if it's absent, the storage is unavailable. Refs are
+// conversation-file paths for claude.
+func (c *Claude) ConversationGone(ref string) (gone bool, ok bool) {
+	return adapter.ConversationGoneAtRoot(ref, c.ConversationRootDir())
 }
 
 // encodeClaudeCwd encodes a working directory into Claude Code's directory
@@ -122,11 +125,12 @@ type claudeFirstLine struct {
 	} `json:"message"`
 }
 
-// ParseConversationFile reads a Claude Code JSONL conversation file and returns
-// display metadata.
+// DescribeConversation reads a Claude Code JSONL conversation file (the ref
+// is the absolute file path) and returns display metadata.
 // Title priority: custom-title line > first user message text > "" (no
 // conversation-derived title yet; callers fall back to cwd/adapter).
-func (c *Claude) ParseConversationFile(path string) (*adapter.ConversationInfo, error) {
+func (c *Claude) DescribeConversation(ref string) (*adapter.ConversationInfo, error) {
+	path := ref
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
@@ -193,8 +197,9 @@ func (c *Claude) ParseConversationFile(path string) (*adapter.ConversationInfo, 
 			ID:           header.SessionID,
 			Title:        "", // header only, no messages yet
 			Created:      created,
+			LastActivity: fileLastActivity(path),
 			MessageCount: messageCount,
-			FilePath:     path,
+			Ref:          path,
 		}, nil
 	}
 
@@ -204,8 +209,9 @@ func (c *Claude) ParseConversationFile(path string) (*adapter.ConversationInfo, 
 		ID:           firstUser.SessionID,
 		Cwd:          firstUser.Cwd,
 		Created:      created,
+		LastActivity: fileLastActivity(path),
 		MessageCount: messageCount,
-		FilePath:     path,
+		Ref:          path,
 	}
 
 	firstUserText := extractClaudeUserText(firstUser.Message.Content)
@@ -236,13 +242,18 @@ func (c *Claude) ResumeCommand(info *adapter.ConversationInfo) []string {
 	return []string{"claude", "--resume", info.ID}
 }
 
-// CanResume checks if a conversation file has user messages worth resuming.
-func (c *Claude) CanResume(path string) bool {
-	info, err := c.ParseConversationFile(path)
+// CanResume checks if a conversation has user messages worth resuming.
+func (c *Claude) CanResume(ref string) bool {
+	info, err := c.DescribeConversation(ref)
 	if err != nil {
 		return false
 	}
 	return info.MessageCount > 0
+}
+
+// OpenConversation streams the raw JSONL transcript at ref.
+func (c *Claude) OpenConversation(ref string) (io.ReadCloser, error) {
+	return os.Open(ref)
 }
 
 // --- Helpers ---

--- a/packages/adapter/adapters/claude_hook.go
+++ b/packages/adapter/adapters/claude_hook.go
@@ -212,7 +212,7 @@ func ClaudeHookBodies(input []byte) [][]byte {
 	case "UserPromptSubmit":
 		// /rename fires no hook of its own — it only appends a custom-title
 		// line to the transcript. Refresh the title here (custom-title wins in
-		// ParseConversationFile) so a mid-session rename shows up at the next
+		// DescribeConversation) so a mid-session rename shows up at the next
 		// prompt instead of waiting for the turn to end.
 		if b, ok := claudeSessionBody(in.TranscriptPath, in.SessionID, "", in.SessionTitle); ok {
 			return [][]byte{b, turn("start", "")}
@@ -262,7 +262,7 @@ func claudeTitleSlug(transcriptPath, sessionTitle string) (title, slug string) {
 	if t := strings.TrimSpace(sessionTitle); t != "" {
 		return t, adapter.Slugify(t)
 	}
-	info, err := NewClaude().ParseConversationFile(transcriptPath)
+	info, err := NewClaude().DescribeConversation(transcriptPath)
 	if err != nil || info == nil || info.Title == "" {
 		return "", ""
 	}

--- a/packages/adapter/adapters/claude_test.go
+++ b/packages/adapter/adapters/claude_test.go
@@ -87,8 +87,8 @@ func TestClaudeImplementsCapabilities(t *testing.T) {
 	if _, ok := a.(adapter.Launchable); !ok {
 		t.Fatal("should implement Launchable")
 	}
-	if _, ok := a.(adapter.ConversationFiler); !ok {
-		t.Fatal("should implement ConversationFiler")
+	if _, ok := a.(adapter.ConversationDescriber); !ok {
+		t.Fatal("should implement ConversationDescriber")
 	}
 	if _, ok := a.(adapter.Resumer); !ok {
 		t.Fatal("should implement Resumer")
@@ -152,7 +152,7 @@ func TestEncodeClaudeCwd(t *testing.T) {
 	}
 }
 
-// --- ParseConversationFile ---
+// --- DescribeConversation ---
 
 func writeClaudeJSONL(t *testing.T, lines ...string) string {
 	t.Helper()
@@ -166,12 +166,12 @@ func writeClaudeJSONL(t *testing.T, lines ...string) string {
 	return path
 }
 
-func TestClaudeParseConversationFileFirstUserMessage(t *testing.T) {
+func TestClaudeDescribeConversationFirstUserMessage(t *testing.T) {
 	path := writeClaudeJSONL(t,
 		`{"parentUuid":null,"type":"user","sessionId":"abc-123","timestamp":"2026-03-15T10:00:00Z","cwd":"/tmp/test","message":{"role":"user","content":[{"type":"text","text":"Fix the auth bug in login.go"}]},"uuid":"u1"}`,
 		`{"parentUuid":"u1","type":"assistant","sessionId":"abc-123","timestamp":"2026-03-15T10:01:00Z","message":{"role":"assistant","content":[{"type":"text","text":"I'll fix that for you."}],"stop_reason":null},"uuid":"a1"}`,
 	)
-	info, err := NewClaude().ParseConversationFile(path)
+	info, err := NewClaude().DescribeConversation(path)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -192,13 +192,13 @@ func TestClaudeParseConversationFileFirstUserMessage(t *testing.T) {
 	}
 }
 
-func TestClaudeParseConversationFileCustomTitle(t *testing.T) {
+func TestClaudeDescribeConversationCustomTitle(t *testing.T) {
 	path := writeClaudeJSONL(t,
 		`{"parentUuid":null,"type":"user","sessionId":"abc","timestamp":"2026-03-15T10:00:00Z","cwd":"/tmp","message":{"role":"user","content":[{"type":"text","text":"Fix the bug"}]},"uuid":"u1"}`,
 		`{"parentUuid":"u1","type":"assistant","sessionId":"abc","message":{"role":"assistant","content":[{"type":"text","text":"Done."}]},"uuid":"a1"}`,
 		`{"type":"custom-title","customTitle":"  Auth refactor  ","sessionId":"abc"}`,
 	)
-	info, _ := NewClaude().ParseConversationFile(path)
+	info, _ := NewClaude().DescribeConversation(path)
 	if info.Title != "Auth refactor" {
 		t.Errorf("expected custom title, got %q", info.Title)
 	}
@@ -209,11 +209,11 @@ func TestClaudeParseConversationFileCustomTitle(t *testing.T) {
 	}
 }
 
-func TestClaudeParseConversationFileQueueOnly(t *testing.T) {
+func TestClaudeDescribeConversationQueueOnly(t *testing.T) {
 	path := writeClaudeJSONL(t,
 		`{"type":"queue-operation","operation":"dequeue","timestamp":"2026-03-15T10:00:00Z","sessionId":"q-123"}`,
 	)
-	info, err := NewClaude().ParseConversationFile(path)
+	info, err := NewClaude().DescribeConversation(path)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -225,51 +225,51 @@ func TestClaudeParseConversationFileQueueOnly(t *testing.T) {
 	}
 }
 
-func TestClaudeParseConversationFileStringContent(t *testing.T) {
+func TestClaudeDescribeConversationStringContent(t *testing.T) {
 	path := writeClaudeJSONL(t,
 		`{"type":"user","sessionId":"abc","timestamp":"2026-03-15T10:00:00Z","cwd":"/tmp","message":{"role":"user","content":"Help me debug this"},"uuid":"u1"}`,
 	)
-	info, _ := NewClaude().ParseConversationFile(path)
+	info, _ := NewClaude().DescribeConversation(path)
 	if info.Title != "Help me debug this" {
 		t.Errorf("expected string content as title, got %q", info.Title)
 	}
 }
 
-func TestClaudeParseConversationFileLongTitleTruncated(t *testing.T) {
+func TestClaudeDescribeConversationLongTitleTruncated(t *testing.T) {
 	long := "Please help me with this very long request that goes on and on about many different things and really should be truncated for the sidebar"
 	path := writeClaudeJSONL(t,
 		`{"type":"user","sessionId":"abc","timestamp":"2026-03-15T10:00:00Z","cwd":"/tmp","message":{"role":"user","content":[{"type":"text","text":"`+long+`"}]},"uuid":"u1"}`,
 	)
-	info, _ := NewClaude().ParseConversationFile(path)
+	info, _ := NewClaude().DescribeConversation(path)
 	if len(info.Title) > 85 {
 		t.Errorf("title too long: %q", info.Title)
 	}
 }
 
-func TestClaudeParseConversationFileContextRefStripped(t *testing.T) {
+func TestClaudeDescribeConversationContextRefStripped(t *testing.T) {
 	path := writeClaudeJSONL(t,
 		`{"type":"user","sessionId":"abc","timestamp":"2026-03-15T10:00:00Z","cwd":"/tmp","message":{"role":"user","content":[{"type":"text","text":"@file.go\n<context ref=\"file:///tmp/file.go#L1:10\">\nfunc main() {}\n</context>\nFix the bug in main()"}]},"uuid":"u1"}`,
 	)
-	info, _ := NewClaude().ParseConversationFile(path)
+	info, _ := NewClaude().DescribeConversation(path)
 	// Context block removed, leaves @file.go reference + trailing text
 	if info.Title != "@file.go Fix the bug in main()" {
 		t.Errorf("expected context stripped from title, got %q", info.Title)
 	}
 }
 
-func TestClaudeParseConversationFileEmpty(t *testing.T) {
+func TestClaudeDescribeConversationEmpty(t *testing.T) {
 	path := writeClaudeJSONL(t)
-	_, err := NewClaude().ParseConversationFile(path)
+	_, err := NewClaude().DescribeConversation(path)
 	if err == nil {
 		t.Fatal("expected error for empty file")
 	}
 }
 
-func TestClaudeParseConversationFileNoSessionID(t *testing.T) {
+func TestClaudeDescribeConversationNoSessionID(t *testing.T) {
 	path := writeClaudeJSONL(t,
 		`{"type":"unknown","data":"something"}`,
 	)
-	_, err := NewClaude().ParseConversationFile(path)
+	_, err := NewClaude().DescribeConversation(path)
 	if err != errNotSession {
 		t.Errorf("expected errNotSession, got %v", err)
 	}

--- a/packages/adapter/adapters/codex.go
+++ b/packages/adapter/adapters/codex.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -22,12 +23,13 @@ import (
 
 // Compile-time interface checks.
 var (
-	_ adapter.ConversationSource = (*Codex)(nil)
-	_ adapter.ConversationProber = (*Codex)(nil)
-	_ adapter.Launchable         = (*Codex)(nil)
-	_ adapter.ConversationFiler  = (*Codex)(nil)
-	_ adapter.SessionHookCommand = (*Codex)(nil)
-	_ adapter.Resumer            = (*Codex)(nil)
+	_ adapter.ConversationSource    = (*Codex)(nil)
+	_ adapter.ConversationProber    = (*Codex)(nil)
+	_ adapter.Launchable            = (*Codex)(nil)
+	_ adapter.ConversationDescriber = (*Codex)(nil)
+	_ adapter.ConversationOpener    = (*Codex)(nil)
+	_ adapter.SessionHookCommand    = (*Codex)(nil)
+	_ adapter.Resumer               = (*Codex)(nil)
 )
 
 func init() {
@@ -89,7 +91,7 @@ func (c *Codex) Monitor(_ []byte) *adapter.Event {
 	return nil
 }
 
-// --- ConversationFiler ---
+// --- Conversation storage (file-backed: refs are absolute JSONL paths) ---
 
 // ConversationRootDir returns Codex's sessions directory.
 func (c *Codex) ConversationRootDir() string {
@@ -103,9 +105,10 @@ func (c *Codex) ConversationRootDir() string {
 // ConversationGone anchors deletion detection on ConversationRootDir
 // (~/.codex/sessions). The date-nested YYYY/MM/DD subtree may be
 // cleaned up around a deleted transcript, so the stable root — not the
-// file's immediate parent — is the right availability anchor.
-func (c *Codex) ConversationGone(path string) (gone bool, ok bool) {
-	return adapter.ConversationGoneAtRoot(path, c.ConversationRootDir())
+// file's immediate parent — is the right availability anchor. Refs are
+// conversation-file paths for codex.
+func (c *Codex) ConversationGone(ref string) (gone bool, ok bool) {
+	return adapter.ConversationGoneAtRoot(ref, c.ConversationRootDir())
 }
 
 // ConversationDir returns today's date-nested directory where Codex writes new
@@ -127,11 +130,12 @@ type codexSessionMeta struct {
 	Cwd       string `json:"cwd"`
 }
 
-// ParseConversationFile reads a Codex JSONL conversation file and returns display
-// metadata.
+// DescribeConversation reads a Codex JSONL conversation file (the ref is the
+// absolute file path) and returns display metadata.
 // Title priority: first user prompt text > "" (no conversation-derived title
 // yet; callers fall back to cwd/adapter).
-func (c *Codex) ParseConversationFile(path string) (*adapter.ConversationInfo, error) {
+func (c *Codex) DescribeConversation(ref string) (*adapter.ConversationInfo, error) {
+	path := ref
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
@@ -158,10 +162,11 @@ func (c *Codex) ParseConversationFile(path string) (*adapter.ConversationInfo, e
 	created, _ := time.Parse(time.RFC3339Nano, meta.Timestamp)
 
 	info := &adapter.ConversationInfo{
-		ID:       meta.ID,
-		Cwd:      meta.Cwd,
-		Created:  created,
-		FilePath: path,
+		ID:           meta.ID,
+		Cwd:          meta.Cwd,
+		Created:      created,
+		LastActivity: fileLastActivity(path),
+		Ref:          path,
 	}
 
 	// Scan for user prompts and message count.
@@ -395,7 +400,7 @@ func shellQuote(s string) string {
 // stdin (its SessionStart/Stop input carries session_id, transcript_path, cwd).
 //
 // codex has no title/slug field of its own, so this derives them by parsing the
-// transcript's first user prompt (reusing ParseConversationFile) and reports them as
+// transcript's first user prompt (reusing DescribeConversation) and reports them as
 // the session title + an explicit slug — codex's session_id is a UUID that would
 // slugify into an unreadable URL.
 func CodexHookBodies(eventName string, input []byte) [][]byte {
@@ -461,7 +466,7 @@ func codexSessionBody(input []byte) ([]byte, bool) {
 // codexHookTitle returns a codex session's display title — the first non-system
 // user prompt, truncated — or "" if the transcript has none yet.
 //
-// Unlike ParseConversationFile it early-exits at the first user message instead of
+// Unlike DescribeConversation it early-exits at the first user message instead of
 // reading the whole file. This matters because the hook derives the title on
 // every turn-end (codex blocks on the Stop hook), the title never changes after
 // the first prompt, and the transcript grows each turn: a full re-parse would be
@@ -575,13 +580,18 @@ func (c *Codex) ResumeCommand(info *adapter.ConversationInfo) []string {
 	return []string{"codex", "resume", info.ID}
 }
 
-// CanResume checks if a conversation file has user messages worth resuming.
-func (c *Codex) CanResume(path string) bool {
-	info, err := c.ParseConversationFile(path)
+// CanResume checks if a conversation has user messages worth resuming.
+func (c *Codex) CanResume(ref string) bool {
+	info, err := c.DescribeConversation(ref)
 	if err != nil {
 		return false
 	}
 	return info.MessageCount > 0
+}
+
+// OpenConversation streams the raw JSONL transcript at ref.
+func (c *Codex) OpenConversation(ref string) (io.ReadCloser, error) {
+	return os.Open(ref)
 }
 
 // --- Helpers ---

--- a/packages/adapter/adapters/codex_test.go
+++ b/packages/adapter/adapters/codex_test.go
@@ -81,8 +81,8 @@ func TestCodexImplementsCapabilities(t *testing.T) {
 	if _, ok := a.(adapter.Launchable); !ok {
 		t.Fatal("should implement Launchable")
 	}
-	if _, ok := a.(adapter.ConversationFiler); !ok {
-		t.Fatal("should implement ConversationFiler")
+	if _, ok := a.(adapter.ConversationDescriber); !ok {
+		t.Fatal("should implement ConversationDescriber")
 	}
 	if _, ok := a.(adapter.Resumer); !ok {
 		t.Fatal("should implement Resumer")
@@ -105,7 +105,7 @@ func TestCodexLaunchers(t *testing.T) {
 	}
 }
 
-// --- ParseConversationFile ---
+// --- DescribeConversation ---
 
 func writeCodexJSONL(t *testing.T, lines ...string) string {
 	t.Helper()
@@ -119,13 +119,13 @@ func writeCodexJSONL(t *testing.T, lines ...string) string {
 	return path
 }
 
-func TestCodexParseConversationFileBasic(t *testing.T) {
+func TestCodexDescribeConversationBasic(t *testing.T) {
 	path := writeCodexJSONL(t,
 		`{"timestamp":"2026-03-17T01:00:00Z","type":"session_meta","payload":{"id":"abc-123","timestamp":"2026-03-17T01:00:00Z","cwd":"/home/mg/dev/test"}}`,
 		`{"timestamp":"2026-03-17T01:00:01Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"Fix the auth bug"}]}}`,
 		`{"timestamp":"2026-03-17T01:00:02Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"I'll fix that for you."}]}}`,
 	)
-	info, err := NewCodex().ParseConversationFile(path)
+	info, err := NewCodex().DescribeConversation(path)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -143,7 +143,7 @@ func TestCodexParseConversationFileBasic(t *testing.T) {
 	}
 }
 
-func TestCodexParseConversationFileSkipsSystemContext(t *testing.T) {
+func TestCodexDescribeConversationSkipsSystemContext(t *testing.T) {
 	path := writeCodexJSONL(t,
 		`{"timestamp":"2026-03-17T01:00:00Z","type":"session_meta","payload":{"id":"abc","timestamp":"2026-03-17T01:00:00Z","cwd":"/tmp"}}`,
 		`{"timestamp":"2026-03-17T01:00:01Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"<permissions instructions>sandboxing...</permissions instructions>"}]}}`,
@@ -151,47 +151,47 @@ func TestCodexParseConversationFileSkipsSystemContext(t *testing.T) {
 		`{"timestamp":"2026-03-17T01:00:01Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"# AGENTS.md instructions for /tmp\n<INSTRUCTIONS>...</INSTRUCTIONS>"}]}}`,
 		`{"timestamp":"2026-03-17T01:00:02Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"What files are in this directory?"}]}}`,
 	)
-	info, _ := NewCodex().ParseConversationFile(path)
+	info, _ := NewCodex().DescribeConversation(path)
 	if info.Title != "What files are in this directory?" {
 		t.Errorf("expected user prompt as title (skipping system context), got %q", info.Title)
 	}
 }
 
-func TestCodexParseConversationFileNoMessages(t *testing.T) {
+func TestCodexDescribeConversationNoMessages(t *testing.T) {
 	path := writeCodexJSONL(t,
 		`{"timestamp":"2026-03-17T01:00:00Z","type":"session_meta","payload":{"id":"abc","timestamp":"2026-03-17T01:00:00Z","cwd":"/tmp"}}`,
 	)
-	info, _ := NewCodex().ParseConversationFile(path)
+	info, _ := NewCodex().DescribeConversation(path)
 	if info.Title != "" {
 		t.Errorf("expected empty title for a session with no messages, got %q", info.Title)
 	}
 }
 
-func TestCodexParseConversationFileLongTitle(t *testing.T) {
+func TestCodexDescribeConversationLongTitle(t *testing.T) {
 	long := "Please help me with this very long request that goes on and on about many different things and really should be truncated for the sidebar"
 	path := writeCodexJSONL(t,
 		`{"timestamp":"2026-03-17T01:00:00Z","type":"session_meta","payload":{"id":"abc","timestamp":"2026-03-17T01:00:00Z","cwd":"/tmp"}}`,
 		`{"timestamp":"2026-03-17T01:00:01Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"`+long+`"}]}}`,
 	)
-	info, _ := NewCodex().ParseConversationFile(path)
+	info, _ := NewCodex().DescribeConversation(path)
 	if len(info.Title) > 85 {
 		t.Errorf("title too long: %q", info.Title)
 	}
 }
 
-func TestCodexParseConversationFileEmpty(t *testing.T) {
+func TestCodexDescribeConversationEmpty(t *testing.T) {
 	path := writeCodexJSONL(t)
-	_, err := NewCodex().ParseConversationFile(path)
+	_, err := NewCodex().DescribeConversation(path)
 	if err == nil {
 		t.Fatal("expected error for empty file")
 	}
 }
 
-func TestCodexParseConversationFileNotSessionMeta(t *testing.T) {
+func TestCodexDescribeConversationNotSessionMeta(t *testing.T) {
 	path := writeCodexJSONL(t,
 		`{"type":"response_item","payload":{"type":"message","role":"user"}}`,
 	)
-	_, err := NewCodex().ParseConversationFile(path)
+	_, err := NewCodex().DescribeConversation(path)
 	if err != errNotSession {
 		t.Errorf("expected errNotSession, got %v", err)
 	}

--- a/packages/adapter/adapters/fileconv.go
+++ b/packages/adapter/adapters/fileconv.go
@@ -1,0 +1,19 @@
+package adapters
+
+import (
+	"os"
+	"time"
+)
+
+// fileLastActivity returns the conversation file's mtime — the file-backed
+// adapters' implementation detail behind ConversationInfo.LastActivity
+// (the tools append to the transcript on every message, so mtime tracks
+// real conversation activity). Returns the zero time when the file can't
+// be statted; consumers treat zero as "unknown".
+func fileLastActivity(path string) time.Time {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return time.Time{}
+	}
+	return fi.ModTime()
+}

--- a/packages/adapter/adapters/pi.go
+++ b/packages/adapter/adapters/pi.go
@@ -3,6 +3,7 @@ package adapters
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -16,13 +17,14 @@ import (
 
 // Compile-time interface checks.
 var (
-	_ adapter.ConversationSource  = (*Pi)(nil)
-	_ adapter.ConversationProber  = (*Pi)(nil)
-	_ adapter.Launchable          = (*Pi)(nil)
-	_ adapter.ConversationFiler   = (*Pi)(nil)
-	_ adapter.Resumer             = (*Pi)(nil)
-	_ adapter.SessionExtender     = (*Pi)(nil)
-	_ adapter.PassthroughDetector = (*Pi)(nil)
+	_ adapter.ConversationSource    = (*Pi)(nil)
+	_ adapter.ConversationProber    = (*Pi)(nil)
+	_ adapter.Launchable            = (*Pi)(nil)
+	_ adapter.ConversationDescriber = (*Pi)(nil)
+	_ adapter.ConversationOpener    = (*Pi)(nil)
+	_ adapter.Resumer               = (*Pi)(nil)
+	_ adapter.SessionExtender       = (*Pi)(nil)
+	_ adapter.PassthroughDetector   = (*Pi)(nil)
 )
 
 // piSubcommands are pi's one-shot CLI verbs (`pi <verb> ...`). pi recognizes
@@ -150,7 +152,7 @@ func (p *Pi) Monitor(_ []byte) *adapter.Event {
 	return nil
 }
 
-// --- ConversationFiler ---
+// --- Conversation storage (file-backed: refs are absolute JSONL paths) ---
 
 // ConversationRootDir returns pi's top-level sessions directory.
 // Respects PI_CODING_AGENT_DIR (pi's own env var for overriding the
@@ -170,9 +172,9 @@ func (p *Pi) ConversationRootDir() string {
 // ConversationGone anchors deletion detection on ConversationRootDir
 // (PI_CODING_AGENT_DIR/sessions or ~/.pi/agent/sessions): present root
 // means a missing conversation file was deleted; absent root means the
-// storage is unavailable.
-func (p *Pi) ConversationGone(path string) (gone bool, ok bool) {
-	return adapter.ConversationGoneAtRoot(path, p.ConversationRootDir())
+// storage is unavailable. Refs are conversation-file paths for pi.
+func (p *Pi) ConversationGone(ref string) (gone bool, ok bool) {
+	return adapter.ConversationGoneAtRoot(ref, p.ConversationRootDir())
 }
 
 // ConversationDir returns pi's session directory for a given cwd.
@@ -189,10 +191,12 @@ func (p *Pi) ConversationDir(cwd string) string {
 	return filepath.Join(root, encoded)
 }
 
-// ParseConversationFile reads a pi JSONL conversation file and returns display metadata.
+// DescribeConversation reads a pi JSONL conversation file (the ref is the
+// absolute file path) and returns display metadata.
 // Title priority: session_info.name > first user message > "" (no
 // conversation-derived title yet; callers fall back to cwd/adapter).
-func (p *Pi) ParseConversationFile(path string) (*adapter.ConversationInfo, error) {
+func (p *Pi) DescribeConversation(ref string) (*adapter.ConversationInfo, error) {
+	path := ref
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
@@ -219,10 +223,11 @@ func (p *Pi) ParseConversationFile(path string) (*adapter.ConversationInfo, erro
 	created, _ := time.Parse(time.RFC3339Nano, header.Timestamp)
 
 	info := &adapter.ConversationInfo{
-		ID:       header.ID,
-		Cwd:      header.Cwd,
-		Created:  created,
-		FilePath: path,
+		ID:           header.ID,
+		Cwd:          header.Cwd,
+		Created:      created,
+		LastActivity: fileLastActivity(path),
+		Ref:          path,
 	}
 
 	var name string
@@ -270,16 +275,21 @@ func (p *Pi) ParseConversationFile(path string) (*adapter.ConversationInfo, erro
 }
 
 func (p *Pi) ResumeCommand(info *adapter.ConversationInfo) []string {
-	return []string{"pi", "--session", info.FilePath, "-c"}
+	return []string{"pi", "--session", info.Ref, "-c"}
 }
 
-// CanResume checks if a conversation file is valid and has content worth resuming.
-func (p *Pi) CanResume(path string) bool {
-	info, err := p.ParseConversationFile(path)
+// CanResume checks if a conversation is valid and has content worth resuming.
+func (p *Pi) CanResume(ref string) bool {
+	info, err := p.DescribeConversation(ref)
 	if err != nil {
 		return false
 	}
 	return info.MessageCount > 0
+}
+
+// OpenConversation streams the raw JSONL transcript at ref.
+func (p *Pi) OpenConversation(ref string) (io.ReadCloser, error) {
+	return os.Open(ref)
 }
 
 // --- Helpers ---

--- a/packages/adapter/adapters/pi_test.go
+++ b/packages/adapter/adapters/pi_test.go
@@ -1,12 +1,14 @@
 package adapters
 
 import (
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gmuxapp/gmux/packages/adapter"
 )
@@ -196,15 +198,15 @@ func TestPiImplementsCapabilities(t *testing.T) {
 	if _, ok := a.(adapter.Launchable); !ok {
 		t.Fatal("should implement Launchable")
 	}
-	if _, ok := a.(adapter.ConversationFiler); !ok {
-		t.Fatal("should implement ConversationFiler")
+	if _, ok := a.(adapter.ConversationDescriber); !ok {
+		t.Fatal("should implement ConversationDescriber")
 	}
 	if _, ok := a.(adapter.Resumer); !ok {
 		t.Fatal("should implement Resumer")
 	}
 }
 
-// --- ConversationFiler ---
+// --- Conversation storage ---
 
 func writeTempJSONL(t *testing.T, lines ...string) string {
 	t.Helper()
@@ -218,14 +220,57 @@ func writeTempJSONL(t *testing.T, lines ...string) string {
 	return path
 }
 
-func TestParseConversationFileFirstUserMessage(t *testing.T) {
+// The ref/LastActivity contract (ADR 0022): DescribeConversation must echo
+// the ref it was given and report freshness itself — file-backed adapters
+// answer with the transcript's mtime, so consumers (activity reseeding,
+// search recency) never stat anything.
+func TestDescribeConversationRefAndLastActivity(t *testing.T) {
+	path := writeTempJSONL(t,
+		`{"type":"session","version":3,"id":"abc-123","timestamp":"2026-03-15T10:00:00Z","cwd":"/tmp/test"}`,
+	)
+	mtime := time.Date(2026, 3, 16, 9, 30, 0, 0, time.UTC)
+	if err := os.Chtimes(path, mtime, mtime); err != nil {
+		t.Fatal(err)
+	}
+	info, err := NewPi().DescribeConversation(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Ref != path {
+		t.Errorf("Ref = %q, want the ref echoed back (%q)", info.Ref, path)
+	}
+	if !info.LastActivity.Equal(mtime) {
+		t.Errorf("LastActivity = %v, want transcript mtime %v", info.LastActivity, mtime)
+	}
+}
+
+// OpenConversation is the content seam for derived consumers (fulltext
+// search): it must stream the raw transcript bytes for a ref.
+func TestOpenConversationStreamsTranscript(t *testing.T) {
+	line := `{"type":"session","version":3,"id":"abc-123","timestamp":"2026-03-15T10:00:00Z","cwd":"/tmp/test"}`
+	path := writeTempJSONL(t, line)
+	rc, err := NewPi().OpenConversation(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rc.Close()
+	got, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != line+"\n" {
+		t.Errorf("OpenConversation content = %q, want the raw transcript", got)
+	}
+}
+
+func TestDescribeConversationFirstUserMessage(t *testing.T) {
 	path := writeTempJSONL(t,
 		`{"type":"session","version":3,"id":"abc-123","timestamp":"2026-03-15T10:00:00Z","cwd":"/tmp/test"}`,
 		`{"type":"model_change","id":"m1","timestamp":"2026-03-15T10:00:00Z"}`,
 		`{"type":"message","id":"u1","timestamp":"2026-03-15T10:01:00Z","message":{"role":"user","content":[{"type":"text","text":"Fix the auth bug in login.go"}]}}`,
 		`{"type":"message","id":"a1","timestamp":"2026-03-15T10:01:05Z","message":{"role":"assistant","content":[{"type":"text","text":"I'll fix that for you."}]}}`,
 	)
-	info, err := NewPi().ParseConversationFile(path)
+	info, err := NewPi().DescribeConversation(path)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -243,13 +288,13 @@ func TestParseConversationFileFirstUserMessage(t *testing.T) {
 	}
 }
 
-func TestParseConversationFileNameOverrides(t *testing.T) {
+func TestDescribeConversationNameOverrides(t *testing.T) {
 	path := writeTempJSONL(t,
 		`{"type":"session","version":3,"id":"abc","timestamp":"2026-03-15T10:00:00Z","cwd":"/tmp/test"}`,
 		`{"type":"message","id":"u1","timestamp":"2026-03-15T10:01:00Z","message":{"role":"user","content":[{"type":"text","text":"Fix the auth bug"}]}}`,
 		`{"type":"session_info","name":"  Auth refactor  "}`,
 	)
-	info, _ := NewPi().ParseConversationFile(path)
+	info, _ := NewPi().DescribeConversation(path)
 	if info.Title != "Auth refactor" {
 		t.Errorf("expected session_info name, got %q", info.Title)
 	}
@@ -259,34 +304,34 @@ func TestParseConversationFileNameOverrides(t *testing.T) {
 	}
 }
 
-func TestParseConversationFileNoMessages(t *testing.T) {
+func TestDescribeConversationNoMessages(t *testing.T) {
 	path := writeTempJSONL(t,
 		`{"type":"session","version":3,"id":"abc","timestamp":"2026-03-15T10:00:00Z","cwd":"/tmp/test"}`,
 	)
-	info, _ := NewPi().ParseConversationFile(path)
+	info, _ := NewPi().DescribeConversation(path)
 	if info.Title != "" {
 		t.Errorf("expected empty title for a session with no messages, got %q", info.Title)
 	}
 }
 
-func TestParseConversationFileLongTitleTruncated(t *testing.T) {
+func TestDescribeConversationLongTitleTruncated(t *testing.T) {
 	long := "Please help me with this very long request that goes on and on about many different things and really should be truncated for the sidebar"
 	path := writeTempJSONL(t,
 		`{"type":"session","version":3,"id":"abc","timestamp":"2026-03-15T10:00:00Z","cwd":"/tmp/test"}`,
 		`{"type":"message","id":"u1","timestamp":"2026-03-15T10:01:00Z","message":{"role":"user","content":[{"type":"text","text":"`+long+`"}]}}`,
 	)
-	info, _ := NewPi().ParseConversationFile(path)
+	info, _ := NewPi().DescribeConversation(path)
 	if len(info.Title) > 85 {
 		t.Errorf("title too long: %q", info.Title)
 	}
 }
 
-func TestParseConversationFileStringContent(t *testing.T) {
+func TestDescribeConversationStringContent(t *testing.T) {
 	path := writeTempJSONL(t,
 		`{"type":"session","version":3,"id":"abc","timestamp":"2026-03-15T10:00:00Z","cwd":"/tmp/test"}`,
 		`{"type":"message","id":"u1","timestamp":"2026-03-15T10:01:00Z","message":{"role":"user","content":"Help me debug this"}}`,
 	)
-	info, _ := NewPi().ParseConversationFile(path)
+	info, _ := NewPi().DescribeConversation(path)
 	if info.Title != "Help me debug this" {
 		t.Errorf("expected string content as title, got %q", info.Title)
 	}
@@ -296,7 +341,7 @@ func TestParseConversationFileStringContent(t *testing.T) {
 
 func TestResumeCommand(t *testing.T) {
 	cmd := NewPi().ResumeCommand(&adapter.ConversationInfo{
-		FilePath: "/tmp/test.jsonl",
+		Ref: "/tmp/test.jsonl",
 	})
 	if len(cmd) != 4 || cmd[0] != "pi" || cmd[1] != "--session" || cmd[3] != "-c" {
 		t.Errorf("unexpected resume command: %v", cmd)

--- a/packages/adapter/adapters/shell.go
+++ b/packages/adapter/adapters/shell.go
@@ -42,11 +42,11 @@ func FindByAdapter(name string) adapter.Adapter {
 
 // Compile-time interface checks.
 var (
-	_ adapter.ConversationFiler = (*Shell)(nil)
-	_ adapter.Resumer           = (*Shell)(nil)
-	_ adapter.CommandTitler     = (*Shell)(nil)
-	_ adapter.SessionRegistrar  = (*Shell)(nil)
-	_ adapter.SessionFinalizer  = (*Shell)(nil)
+	_ adapter.ConversationDescriber = (*Shell)(nil)
+	_ adapter.Resumer               = (*Shell)(nil)
+	_ adapter.CommandTitler         = (*Shell)(nil)
+	_ adapter.SessionRegistrar      = (*Shell)(nil)
+	_ adapter.SessionFinalizer      = (*Shell)(nil)
 )
 
 // Shell is the fallback adapter. It matches all commands and parses
@@ -89,7 +89,7 @@ func (g *Shell) Monitor(_ []byte) *adapter.Event {
 	return nil
 }
 
-// --- ConversationFiler ---
+// --- Conversation storage (file-backed: refs are shell state-file paths) ---
 
 // shellSessionsDir returns the directory for shell state files.
 func shellSessionsDir() string {
@@ -121,7 +121,10 @@ type shellStateFile struct {
 	Created time.Time `json:"created"`
 }
 
-func (g *Shell) ParseConversationFile(path string) (*adapter.ConversationInfo, error) {
+// DescribeConversation reads a shell state file (the ref is the absolute
+// file path) and returns display metadata.
+func (g *Shell) DescribeConversation(ref string) (*adapter.ConversationInfo, error) {
+	path := ref
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
@@ -134,12 +137,13 @@ func (g *Shell) ParseConversationFile(path string) (*adapter.ConversationInfo, e
 		return nil, os.ErrInvalid
 	}
 	return &adapter.ConversationInfo{
-		ID:       sf.ID,
-		Title:    g.CommandTitle(sf.Command),
-		Slug:     adapter.Slugify(filepath.Base(sf.Cwd)),
-		Cwd:      sf.Cwd,
-		Created:  sf.Created,
-		FilePath: path,
+		ID:           sf.ID,
+		Title:        g.CommandTitle(sf.Command),
+		Slug:         adapter.Slugify(filepath.Base(sf.Cwd)),
+		Cwd:          sf.Cwd,
+		Created:      sf.Created,
+		LastActivity: fileLastActivity(path),
+		Ref:          path,
 	}, nil
 }
 
@@ -156,8 +160,8 @@ func (g *Shell) ResumeCommand(info *adapter.ConversationInfo) []string {
 	return []string{shell}
 }
 
-func (g *Shell) CanResume(path string) bool {
-	_, err := g.ParseConversationFile(path)
+func (g *Shell) CanResume(ref string) bool {
+	_, err := g.DescribeConversation(ref)
 	return err == nil
 }
 

--- a/packages/adapter/adapters/shell_test.go
+++ b/packages/adapter/adapters/shell_test.go
@@ -10,8 +10,8 @@ import (
 
 func TestShellImplementsInterfaces(t *testing.T) {
 	var s adapter.Adapter = NewShell()
-	if _, ok := s.(adapter.ConversationFiler); !ok {
-		t.Fatal("Shell should implement ConversationFiler")
+	if _, ok := s.(adapter.ConversationDescriber); !ok {
+		t.Fatal("Shell should implement ConversationDescriber")
 	}
 	if _, ok := s.(adapter.Resumer); !ok {
 		t.Fatal("Shell should implement Resumer")
@@ -42,9 +42,9 @@ func TestShellWriteAndParseStateFile(t *testing.T) {
 	}
 
 	sh := NewShell()
-	info, err := sh.ParseConversationFile(path)
+	info, err := sh.DescribeConversation(path)
 	if err != nil {
-		t.Fatalf("ParseConversationFile: %v", err)
+		t.Fatalf("DescribeConversation: %v", err)
 	}
 
 	if info.ID != "sess-abc123" {
@@ -56,8 +56,8 @@ func TestShellWriteAndParseStateFile(t *testing.T) {
 	if info.Title != "fish" {
 		t.Errorf("Title = %q, want %q", info.Title, "fish")
 	}
-	if info.FilePath != path {
-		t.Errorf("FilePath = %q, want %q", info.FilePath, path)
+	if info.Ref != path {
+		t.Errorf("FilePath = %q, want %q", info.Ref, path)
 	}
 	// Slug derived from cwd basename.
 	if info.Slug != "project" {

--- a/packages/adapter/capabilities.go
+++ b/packages/adapter/capabilities.go
@@ -2,18 +2,36 @@ package adapter
 
 import (
 	"context"
+	"io"
 	"time"
 )
 
-// ConversationInfo holds metadata extracted from a tool's conversation file.
+// Conversation refs.
+//
+// A conversation ref is an opaque, adapter-scoped locator for one stored
+// conversation. Where a conversation lives is an adapter implementation
+// detail (ADR 0014): today's file-backed adapters (pi, claude, codex) use
+// the absolute conversation-file path as their ref, but a future adapter
+// may store conversations in a database and use a row key or UUID. The
+// daemon MUST treat refs as opaque strings — store them, compare them for
+// equality, and hand them back to the owning adapter — never parse them,
+// stat them, or assume they name a file.
+
+// ConversationInfo holds adapter-parsed metadata for one stored
+// conversation, returned by ConversationDescriber.DescribeConversation.
 type ConversationInfo struct {
-	ID           string
-	Title        string
-	Slug         string // Human-readable, URL-safe session identity. Set by the adapter.
-	Cwd          string
-	Created      time.Time
+	ID      string // adapter-native conversation ID (typically a UUID)
+	Title   string
+	Slug    string // Human-readable, URL-safe session identity. Set by the adapter.
+	Cwd     string
+	Created time.Time
+	// LastActivity is the adapter-reported time of the most recent
+	// activity in this conversation. File-backed adapters derive it from
+	// the conversation file's mtime; that is their implementation detail —
+	// consumers must not stat anything themselves. Zero when unknown.
+	LastActivity time.Time
 	MessageCount int
-	FilePath     string
+	Ref          string // the opaque conversation ref this info was described from
 }
 
 // Event is a partial session state update emitted by an adapter from observed
@@ -37,32 +55,38 @@ type Launchable interface {
 	Launchers() []Launcher
 }
 
-// ConversationFiler is implemented by adapters whose tools write
-// conversation files to disk (pi, claude-code, etc). Used by gmuxd for
-// resumable-conversation discovery and conversation file attribution.
-type ConversationFiler interface {
-	// ConversationRootDir returns the parent directory containing all per-cwd
-	// conversation subdirectories (e.g. ~/.pi/agent/sessions/).
-	// Used by the scanner to enumerate all known working directories.
-	ConversationRootDir() string
-
-	// ConversationDir returns the directory where this tool stores
-	// conversation files for the given cwd. Returns "" if not applicable.
-	ConversationDir(cwd string) string
-
-	// ParseConversationFile reads a conversation file and returns display metadata.
-	// Called by gmuxd to index conversations and resolve resume commands.
-	ParseConversationFile(path string) (*ConversationInfo, error)
+// ConversationDescriber is implemented by adapters whose tool persists
+// conversations (pi, claude-code, codex, ...). It is the daemon's only way
+// to turn an opaque conversation ref into display metadata; how the
+// adapter reads its storage (JSONL file, database row, ...) is private to
+// the adapter.
+type ConversationDescriber interface {
+	// DescribeConversation resolves an opaque conversation ref to display
+	// metadata. Called by gmuxd to index conversations and resolve resume
+	// commands.
+	DescribeConversation(ref string) (*ConversationInfo, error)
 }
 
-// ConversationSink receives conversation-file changes from a ConversationSource.
-// Paths are absolute conversation-file paths the daemon resolves via the adapter's
-// ParseConversationFile.
+// ConversationOpener is implemented by adapters that can stream a stored
+// conversation's raw, adapter-native content (e.g. the JSONL transcript).
+// This is the content seam for derived consumers such as the fulltext
+// search index: enumerate refs via ConversationSource, then open each ref
+// for indexing. The byte format is adapter-specific; consumers that need a
+// normalized schema translate per ADR 0021.
+type ConversationOpener interface {
+	// OpenConversation returns a reader over the conversation's raw
+	// content. The caller must Close it.
+	OpenConversation(ref string) (io.ReadCloser, error)
+}
+
+// ConversationSink receives conversation-ref changes from a ConversationSource.
+// Refs are opaque adapter-scoped locators the daemon resolves via the
+// owning adapter's DescribeConversation.
 type ConversationSink interface {
-	// Upsert reports a conversation file that exists, was created, or changed.
-	Upsert(path string)
-	// Remove reports a conversation file that no longer exists.
-	Remove(path string)
+	// Upsert reports a conversation that exists, was created, or changed.
+	Upsert(ref string)
+	// Remove reports a conversation that no longer exists.
+	Remove(ref string)
 }
 
 // ConversationSource is implemented by adapters that expose a set of
@@ -80,13 +104,13 @@ type ConversationSource interface {
 	WatchConversations(ctx context.Context, sink ConversationSink) error
 }
 
-// ConversationProber is implemented by ConversationFiler adapters that can
-// tell a *deleted* conversation file apart from one whose storage is
+// ConversationProber is implemented by conversation-storing adapters that
+// can tell a *deleted* conversation apart from one whose storage is
 // merely *unavailable* (unmounted home, a tool dir that doesn't exist
-// yet). The startup retention reconcile (services/gmuxd) uses it to
-// retire dead sessions whose backing conversation is genuinely gone
-// without nuking entries when the tool's on-disk layout simply isn't
-// reachable.
+// yet, an unreachable database). The startup retention reconcile
+// (services/gmuxd) uses it to retire dead sessions whose backing
+// conversation is genuinely gone without nuking entries when the tool's
+// storage simply isn't reachable.
 //
 // The distinction is adapter-owned because only the adapter knows which
 // directory anchors "storage is present" for its layout — e.g. the
@@ -95,12 +119,12 @@ type ConversationSource interface {
 // implements the common root-anchored rule; adapters with quirkier
 // layouts may answer differently.
 type ConversationProber interface {
-	// ConversationGone reports whether the conversation file at path was
-	// deleted. ok=false means the answer is undeterminable (storage
-	// unavailable), in which case the caller MUST NOT treat the
-	// conversation as gone. When the file is present, returns
+	// ConversationGone reports whether the conversation identified by the
+	// opaque ref was deleted. ok=false means the answer is undeterminable
+	// (storage unavailable), in which case the caller MUST NOT treat the
+	// conversation as gone. When the conversation is present, returns
 	// (false, true).
-	ConversationGone(path string) (gone bool, ok bool)
+	ConversationGone(ref string) (gone bool, ok bool)
 }
 
 // SessionExtender marks adapters whose agent exposes a native extension/hook
@@ -185,7 +209,8 @@ type Resumer interface {
 	// ResumeCommand returns the command to resume the given session.
 	ResumeCommand(info *ConversationInfo) []string
 
-	// CanResume returns whether a conversation file represents a resumable
-	// session (vs a corrupted/empty/incompatible one).
-	CanResume(path string) bool
+	// CanResume returns whether the conversation identified by the opaque
+	// ref represents a resumable session (vs a corrupted/empty/incompatible
+	// one).
+	CanResume(ref string) bool
 }

--- a/services/gmuxd/cmd/gmuxd/activityseed.go
+++ b/services/gmuxd/cmd/gmuxd/activityseed.go
@@ -5,26 +5,29 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/gmuxapp/gmux/packages/adapter"
+	"github.com/gmuxapp/gmux/packages/adapter/adapters"
 	"github.com/gmuxapp/gmux/packages/scrollback"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/store"
 )
 
 // activitySeedFor returns an RFC3339 timestamp to seed a rehydrated
-// session's LastActivityAt from the newest durable on-disk activity
-// proxy. Two sources, newest wins:
+// session's LastActivityAt from the newest durable activity proxy. Two
+// sources, newest wins:
 //
-//   - the adapter's conversation file (primary): appended on every
-//     message, so its mtime is an accurate, restart-surviving proxy for
-//     when the session last did something. The path is adapter-supplied
-//     (session.ConversationFile, reported by the agent hook per ADR
-//     0011); the daemon only stats it, so no adapter-specific reseed
-//     logic is needed.
+//   - the adapter-reported conversation freshness (primary): the owning
+//     adapter's DescribeConversation(sess.ConversationRef).LastActivity
+//     (ADR 0022). For file-backed adapters that is the transcript's
+//     mtime — updated on every message — but that is the adapter's
+//     detail; the daemon never stats the ref itself, so a DB-backed
+//     adapter reseeds identically.
 //   - the runner's scrollback tee (generic fallback): every session has
-//     one under the per-session dir, written live by the runner. Covers
-//     plain shells and agent sessions whose conversation file hasn't
-//     appeared yet.
+//     one under the per-session dir, written live by the runner and
+//     owned by the daemon (ADR 0016), so a direct stat is legitimate.
+//     Covers plain shells and agent sessions whose conversation hasn't
+//     been reported yet.
 //
-// Returns "" when neither file yields a usable mtime.
+// Returns "" when neither source yields a usable timestamp.
 //
 // This recovers "last activity" across a daemon restart. An alive
 // session's LastActivityAt is never persisted (only dead sessions land
@@ -35,37 +38,33 @@ import (
 //
 // Note: the store can't tell a restart-rehydrate from a first-ever
 // registration — both arrive with an empty stamp — so a brand-new
-// session is seeded too. That is harmless: its files' mtimes are ~now,
-// which is the same instant the UI would show via the created_at
+// session is seeded too. That is harmless: its activity proxies are
+// ~now, which is the same instant the UI would show via the created_at
 // fallback anyway, and the first real state transition bumps the stamp
 // forward. The one visibly-odd case is resuming an *old* conversation
 // when the scrollback tee failed to open: the seed would then be the old
-// conversation file's mtime (days ago) until the first transition
+// conversation's LastActivity (days ago) until the first transition
 // corrects it. Rare and self-healing, so we accept rather than guard —
 // there is no reliable restart-vs-fresh signal at this layer.
 func activitySeedFor(sess store.Session, sessionDir func(string) string) string {
 	var newest time.Time
-	consider := func(path string) {
-		if path == "" {
-			return
-		}
-		info, err := os.Stat(path)
-		if err != nil {
-			return
-		}
-		if mt := info.ModTime(); mt.After(newest) {
-			newest = mt
+	if sess.ConversationRef != "" {
+		if desc, ok := adapters.FindByAdapter(sess.Adapter).(adapter.ConversationDescriber); ok {
+			if info, err := desc.DescribeConversation(sess.ConversationRef); err == nil && info.LastActivity.After(newest) {
+				newest = info.LastActivity
+			}
 		}
 	}
-	consider(sess.ConversationFile)
 	if sessionDir != nil && sess.ID != "" {
-		consider(filepath.Join(sessionDir(sess.ID), scrollback.ActiveName))
+		if fi, err := os.Stat(filepath.Join(sessionDir(sess.ID), scrollback.ActiveName)); err == nil && fi.ModTime().After(newest) {
+			newest = fi.ModTime()
+		}
 	}
 	if newest.IsZero() {
 		return ""
 	}
-	// Cap at now: a conversation file with a skewed clock (or one on a
-	// remote filesystem) must not stamp activity in the future.
+	// Cap at now: a conversation on a skewed clock (or a remote
+	// filesystem) must not stamp activity in the future.
 	if now := time.Now(); newest.After(now) {
 		newest = now
 	}

--- a/services/gmuxd/cmd/gmuxd/activityseed_test.go
+++ b/services/gmuxd/cmd/gmuxd/activityseed_test.go
@@ -10,12 +10,12 @@ import (
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/store"
 )
 
-func writeFileWithMtime(t *testing.T, path string, mt time.Time) {
+func writeFileWithMtime(t *testing.T, path, content string, mt time.Time) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(path, []byte("x"), 0o600); err != nil {
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.Chtimes(path, mt, mt); err != nil {
@@ -23,13 +23,23 @@ func writeFileWithMtime(t *testing.T, path string, mt time.Time) {
 	}
 }
 
-func TestActivitySeedFor_ConversationFileMtime(t *testing.T) {
+// writePiTranscript writes a minimal valid pi conversation at path with the
+// given mtime, so the real pi adapter's DescribeConversation resolves it —
+// the seed's primary source is adapter-reported LastActivity (ADR 0022),
+// which for pi is the transcript mtime.
+func writePiTranscript(t *testing.T, path string, mt time.Time) {
+	t.Helper()
+	writeFileWithMtime(t, path,
+		`{"type":"session","version":3,"id":"seed-test","timestamp":"2026-03-15T10:00:00Z","cwd":"/tmp/test"}`+"\n", mt)
+}
+
+func TestActivitySeedFor_AdapterConversationActivity(t *testing.T) {
 	dir := t.TempDir()
 	conv := filepath.Join(dir, "conv.jsonl")
 	want := time.Now().Add(-90 * time.Minute).Truncate(time.Second)
-	writeFileWithMtime(t, conv, want)
+	writePiTranscript(t, conv, want)
 
-	got := activitySeedFor(store.Session{ID: "sess-abc", ConversationFile: conv}, nil)
+	got := activitySeedFor(store.Session{ID: "sess-abc", Adapter: "pi", ConversationRef: conv}, nil)
 	if got != want.UTC().Format(time.RFC3339) {
 		t.Fatalf("seed = %q, want %q", got, want.UTC().Format(time.RFC3339))
 	}
@@ -39,9 +49,9 @@ func TestActivitySeedFor_ScrollbackFallback(t *testing.T) {
 	root := t.TempDir()
 	sessionDir := func(id string) string { return filepath.Join(root, id) }
 	want := time.Now().Add(-30 * time.Minute).Truncate(time.Second)
-	writeFileWithMtime(t, filepath.Join(sessionDir("sess-abc"), scrollback.ActiveName), want)
+	writeFileWithMtime(t, filepath.Join(sessionDir("sess-abc"), scrollback.ActiveName), "x", want)
 
-	// No conversation file: falls back to scrollback tee mtime.
+	// No conversation ref: falls back to scrollback tee mtime.
 	got := activitySeedFor(store.Session{ID: "sess-abc"}, sessionDir)
 	if got != want.UTC().Format(time.RFC3339) {
 		t.Fatalf("seed = %q, want %q", got, want.UTC().Format(time.RFC3339))
@@ -54,21 +64,37 @@ func TestActivitySeedFor_NewestWins(t *testing.T) {
 	conv := filepath.Join(root, "conv.jsonl")
 	older := time.Now().Add(-2 * time.Hour).Truncate(time.Second)
 	newer := time.Now().Add(-10 * time.Minute).Truncate(time.Second)
-	writeFileWithMtime(t, conv, older)
-	writeFileWithMtime(t, filepath.Join(sessionDir("sess-abc"), scrollback.ActiveName), newer)
+	writePiTranscript(t, conv, older)
+	writeFileWithMtime(t, filepath.Join(sessionDir("sess-abc"), scrollback.ActiveName), "x", newer)
 
-	got := activitySeedFor(store.Session{ID: "sess-abc", ConversationFile: conv}, sessionDir)
+	got := activitySeedFor(store.Session{ID: "sess-abc", Adapter: "pi", ConversationRef: conv}, sessionDir)
 	if got != newer.UTC().Format(time.RFC3339) {
 		t.Fatalf("seed = %q, want newer %q", got, newer.UTC().Format(time.RFC3339))
 	}
 }
 
-func TestActivitySeedFor_NoFilesReturnsEmpty(t *testing.T) {
+func TestActivitySeedFor_NoSourcesReturnsEmpty(t *testing.T) {
 	root := t.TempDir()
 	sessionDir := func(id string) string { return filepath.Join(root, id) }
-	got := activitySeedFor(store.Session{ID: "sess-missing", ConversationFile: "/nope/nope.jsonl"}, sessionDir)
+	got := activitySeedFor(store.Session{ID: "sess-missing", Adapter: "pi", ConversationRef: "/nope/nope.jsonl"}, sessionDir)
 	if got != "" {
-		t.Fatalf("expected empty seed when no files exist, got %q", got)
+		t.Fatalf("expected empty seed when no sources resolve, got %q", got)
+	}
+}
+
+// An adapter the daemon doesn't know (or one without ConversationDescriber)
+// must be skipped, not treated as an error: the scrollback fallback still
+// applies. This is the DB-adapter-shaped path — the daemon never touches
+// the ref itself.
+func TestActivitySeedFor_UnknownAdapterFallsBack(t *testing.T) {
+	root := t.TempDir()
+	sessionDir := func(id string) string { return filepath.Join(root, id) }
+	want := time.Now().Add(-20 * time.Minute).Truncate(time.Second)
+	writeFileWithMtime(t, filepath.Join(sessionDir("sess-abc"), scrollback.ActiveName), "x", want)
+
+	got := activitySeedFor(store.Session{ID: "sess-abc", Adapter: "no-such-tool", ConversationRef: "row:42"}, sessionDir)
+	if got != want.UTC().Format(time.RFC3339) {
+		t.Fatalf("seed = %q, want scrollback fallback %q", got, want.UTC().Format(time.RFC3339))
 	}
 }
 
@@ -84,7 +110,7 @@ func TestActivitySeedWiring_ReseedsRehydratedSession(t *testing.T) {
 	root := t.TempDir()
 	sessionDir := func(id string) string { return filepath.Join(root, id) }
 	want := time.Now().Add(-45 * time.Minute).Truncate(time.Second)
-	writeFileWithMtime(t, filepath.Join(sessionDir("sess-abc"), scrollback.ActiveName), want)
+	writeFileWithMtime(t, filepath.Join(sessionDir("sess-abc"), scrollback.ActiveName), "x", want)
 
 	// Mirror serve()'s wiring exactly.
 	sessions := store.New()
@@ -107,17 +133,17 @@ func TestActivitySeedWiring_ReseedsRehydratedSession(t *testing.T) {
 	}
 }
 
-func TestActivitySeedFor_CapsFutureMtimeAtNow(t *testing.T) {
+func TestActivitySeedFor_CapsFutureActivityAtNow(t *testing.T) {
 	dir := t.TempDir()
 	conv := filepath.Join(dir, "conv.jsonl")
-	writeFileWithMtime(t, conv, time.Now().Add(48*time.Hour))
+	writePiTranscript(t, conv, time.Now().Add(48*time.Hour))
 
-	got := activitySeedFor(store.Session{ID: "sess-abc", ConversationFile: conv}, nil)
+	got := activitySeedFor(store.Session{ID: "sess-abc", Adapter: "pi", ConversationRef: conv}, nil)
 	parsed, err := time.Parse(time.RFC3339, got)
 	if err != nil {
 		t.Fatalf("unparseable seed %q: %v", got, err)
 	}
 	if parsed.After(time.Now().Add(time.Minute)) {
-		t.Fatalf("future mtime not capped at now: %q", got)
+		t.Fatalf("future activity not capped at now: %q", got)
 	}
 }

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -39,11 +39,11 @@ import (
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/peerstore"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/presence"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/projects"
-	"github.com/gmuxapp/gmux/services/gmuxd/internal/sessionfiles"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/sessionmeta"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/sleep"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/snapshot"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/store"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/storegc"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/tsauth"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/unixipc"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/update"
@@ -577,28 +577,29 @@ func serve(stderr io.Writer) int {
 	// runs an unthrottled prune via discovery's first-scan hook below.
 	const scrollbackCacheInterval = 12 * time.Hour
 
-	// Retire the dead session(s) backed by a conversation file when that
-	// file disappears: the adapter conversation watchers report file-gone
-	// (WatchSources below — fires even for files the index never held),
-	// and meta.json mirrors conversation existence (ADR 0016). The store
-	// applies the alive/peer/N:1 guards; its session-remove broadcast is
-	// what WatchRemovals turns into a meta-dir delete.
-	convRetireMeta := func(path string) { sessions.RemoveDeadByConversationFile(path) }
+	// Retire the dead session(s) backed by a conversation when that
+	// conversation disappears: the adapter ConversationSources report
+	// conversation-gone (WatchSources below — fires even for refs the
+	// index never held), and meta.json mirrors conversation existence
+	// (ADR 0016). The store applies the alive/peer/N:1 guards; its
+	// session-remove broadcast is what WatchRemovals turns into a
+	// meta-dir delete.
+	convRetireMeta := func(ref string) { sessions.RemoveDeadByConversationRef(ref) }
 
 	// retireDeleted closes the gap the runtime index signal can't cover:
-	// a conversation file deleted while gmuxd was *down* emits no removal
+	// a conversation deleted while gmuxd was *down* emits no removal
 	// event. Run from discovery's first-scan hook (live runners flagged),
-	// it asks each owning adapter whether its dead sessions' files are
-	// gone. See reconcileDeletedConversations for the safety gate.
-	convProbe := func(adapterName, path string) (gone, known bool) {
+	// it asks each owning adapter whether its dead sessions' conversations
+	// are gone. See reconcileDeletedConversations for the safety gate.
+	convProbe := func(adapterName, ref string) (gone, known bool) {
 		if p, ok := adapters.FindByAdapter(adapterName).(adapter.ConversationProber); ok {
-			return p.ConversationGone(path)
+			return p.ConversationGone(ref)
 		}
 		return false, false
 	}
-	retireDeleted := func(path string) {
-		if ids := sessions.RemoveDeadByConversationFile(path); len(ids) > 0 {
-			log.Printf("sessionmeta: retired %d dead session(s) for deleted conversation %s", len(ids), path)
+	retireDeleted := func(ref string) {
+		if ids := sessions.RemoveDeadByConversationRef(ref); len(ids) > 0 {
+			log.Printf("sessionmeta: retired %d dead session(s) for deleted conversation %s", len(ids), ref)
 		}
 	}
 
@@ -652,22 +653,21 @@ func serve(stderr io.Writer) int {
 	}, 3*time.Second, stopDiscovery)
 	defer close(stopDiscovery)
 
-	// Conversation file scanner — discovers resumable sessions from adapter
-	// conversation files (e.g. pi's JSONL conversations). Also purges stale
-	// dead sessions that were never attributed to a file. Started below
-	// after the project manager is set up so the first-scan callback
-	// can clean up orphaned project session refs.
-	scanner := sessionfiles.New(sessions)
+	// Store GC — purges stale dead sessions that were never attributed to
+	// a conversation. Started below after the project manager is set up so
+	// the first-scan callback can clean up orphaned project session refs.
+	scanner := storegc.New(sessions)
 	stopScanner := make(chan struct{})
 	defer close(stopScanner)
 
-	// Conversations index — maps (adapter, slug) to file metadata for URL
-	// resolution of dead conversations and future fulltext search. Each
-	// adapter's ConversationSource supplies a snapshot at startup and
-	// incremental updates thereafter; the daemon owns no file monitor.
+	// Conversations index — maps (adapter, slug) to conversation metadata
+	// for URL resolution of dead conversations and future fulltext search.
+	// Each adapter's ConversationSource supplies a snapshot at startup and
+	// incremental updates thereafter; the daemon owns no file monitor and
+	// treats conversation refs as adapter-opaque.
 	convIndex := conversations.New()
 	convIndex.Snapshot()
-	log.Printf("conversations: indexed %d files", convIndex.Count())
+	log.Printf("conversations: indexed %d conversations", convIndex.Count())
 
 	srcCtx, cancelSources := context.WithCancel(context.Background())
 	defer cancelSources()

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -518,7 +518,8 @@ func serve(stderr io.Writer) int {
 	// Resume merge / slug takeover drop the corresponding directory.
 	// See sessionmeta package doc for the full lifecycle.
 	metaStore := sessionmeta.New(sessionmeta.DefaultDir(), sessionmeta.WithRetention(sessionmeta.DefaultRetention()))
-	// Reseed last_activity_at from durable file mtimes when a session is
+	// Reseed last_activity_at from durable activity proxies (adapter-reported
+	// conversation freshness, scrollback tee mtime) when a session is
 	// (re-)registered without a stamp — the alive-across-restart case, where
 	// the in-memory value was never persisted. Installed before Sweep so it
 	// applies to every rehydrate path; dead sessions restored with a

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -584,7 +584,7 @@ func serve(stderr io.Writer) int {
 	// (ADR 0016). The store applies the alive/peer/N:1 guards; its
 	// session-remove broadcast is what WatchRemovals turns into a
 	// meta-dir delete.
-	convRetireMeta := func(ref string) { sessions.RemoveDeadByConversationRef(ref) }
+	convRetireMeta := func(adapterName, ref string) { sessions.RemoveDeadByConversationRef(adapterName, ref) }
 
 	// retireDeleted closes the gap the runtime index signal can't cover:
 	// a conversation deleted while gmuxd was *down* emits no removal
@@ -597,9 +597,9 @@ func serve(stderr io.Writer) int {
 		}
 		return false, false
 	}
-	retireDeleted := func(ref string) {
-		if ids := sessions.RemoveDeadByConversationRef(ref); len(ids) > 0 {
-			log.Printf("sessionmeta: retired %d dead session(s) for deleted conversation %s", len(ids), ref)
+	retireDeleted := func(adapterName, ref string) {
+		if ids := sessions.RemoveDeadByConversationRef(adapterName, ref); len(ids) > 0 {
+			log.Printf("sessionmeta: retired %d dead session(s) for deleted %s conversation %s", len(ids), adapterName, ref)
 		}
 	}
 

--- a/services/gmuxd/cmd/gmuxd/retention.go
+++ b/services/gmuxd/cmd/gmuxd/retention.go
@@ -15,22 +15,24 @@ import "github.com/gmuxapp/gmux/services/gmuxd/internal/store"
 // whole point — it must never retire on undeterminable storage — so it
 // lives in one tested place rather than inline at the call site.
 //
-// Each distinct conversation ref is probed once (the conversation→session
-// mapping is N:1); retire is expected to drop every dead session for
-// that ref. Alive, peer-owned, and conversation-less sessions are skipped.
+// Each distinct (adapter, ref) pair is probed once (the conversation→session
+// mapping is N:1, and refs are only unique within an adapter — ADR 0022);
+// retire is expected to drop every dead session of that adapter for that
+// ref. Alive, peer-owned, and conversation-less sessions are skipped.
 func reconcileDeletedConversations(
 	list []store.Session,
 	probe func(adapter, ref string) (gone, known bool),
-	retire func(ref string),
+	retire func(adapter, ref string),
 ) {
-	seen := map[string]bool{}
+	seen := map[[2]string]bool{}
 	for _, sess := range list {
-		if sess.Alive || sess.Peer != "" || sess.ConversationRef == "" || seen[sess.ConversationRef] {
+		key := [2]string{sess.Adapter, sess.ConversationRef}
+		if sess.Alive || sess.Peer != "" || sess.ConversationRef == "" || seen[key] {
 			continue
 		}
-		seen[sess.ConversationRef] = true
+		seen[key] = true
 		if gone, known := probe(sess.Adapter, sess.ConversationRef); known && gone {
-			retire(sess.ConversationRef)
+			retire(sess.Adapter, sess.ConversationRef)
 		}
 	}
 }

--- a/services/gmuxd/cmd/gmuxd/retention.go
+++ b/services/gmuxd/cmd/gmuxd/retention.go
@@ -4,33 +4,33 @@ import "github.com/gmuxapp/gmux/services/gmuxd/internal/store"
 
 // reconcileDeletedConversations is the startup counterpart to the
 // runtime conversations-index removal callback: it retires dead,
-// locally-owned sessions whose backing conversation file an adapter
+// locally-owned sessions whose backing conversation an adapter
 // confidently reports deleted. It covers the gap the index can't —
-// a conversation file removed while gmuxd was down emits no event.
+// a conversation removed while gmuxd was down emits no event.
 //
-// probe answers "is this adapter's conversation file at path gone?" as
+// probe answers "is this adapter's conversation at ref gone?" as
 // (gone, known). Retirement happens only on (known && gone): when the
-// adapter can't tell (known=false, e.g. its storage root is unreachable
+// adapter can't tell (known=false, e.g. its storage is unreachable
 // because home isn't mounted), the entry is kept. That gate is the
 // whole point — it must never retire on undeterminable storage — so it
 // lives in one tested place rather than inline at the call site.
 //
-// Each distinct conversation file is probed once (the file→session
+// Each distinct conversation ref is probed once (the conversation→session
 // mapping is N:1); retire is expected to drop every dead session for
-// that path. Alive, peer-owned, and file-less sessions are skipped.
+// that ref. Alive, peer-owned, and conversation-less sessions are skipped.
 func reconcileDeletedConversations(
 	list []store.Session,
-	probe func(adapter, conversationFile string) (gone, known bool),
-	retire func(conversationFile string),
+	probe func(adapter, ref string) (gone, known bool),
+	retire func(ref string),
 ) {
 	seen := map[string]bool{}
 	for _, sess := range list {
-		if sess.Alive || sess.Peer != "" || sess.ConversationFile == "" || seen[sess.ConversationFile] {
+		if sess.Alive || sess.Peer != "" || sess.ConversationRef == "" || seen[sess.ConversationRef] {
 			continue
 		}
-		seen[sess.ConversationFile] = true
-		if gone, known := probe(sess.Adapter, sess.ConversationFile); known && gone {
-			retire(sess.ConversationFile)
+		seen[sess.ConversationRef] = true
+		if gone, known := probe(sess.Adapter, sess.ConversationRef); known && gone {
+			retire(sess.ConversationRef)
 		}
 	}
 }

--- a/services/gmuxd/cmd/gmuxd/retention_test.go
+++ b/services/gmuxd/cmd/gmuxd/retention_test.go
@@ -31,7 +31,7 @@ func TestReconcileDeletedConversations_SafetyGate(t *testing.T) {
 	}
 
 	var retired []string
-	reconcileDeletedConversations(list, probe, func(p string) { retired = append(retired, p) })
+	reconcileDeletedConversations(list, probe, func(_, p string) { retired = append(retired, p) })
 
 	if !reflect.DeepEqual(retired, []string{"/c/deleted.jsonl"}) {
 		t.Fatalf("only the confidently-deleted file should retire, got %v", retired)
@@ -49,7 +49,7 @@ func TestReconcileDeletedConversations_Skips(t *testing.T) {
 	var probed, retired []string
 	reconcileDeletedConversations(list,
 		func(_, path string) (bool, bool) { probed = append(probed, path); return true, true },
-		func(p string) { retired = append(retired, p) })
+		func(_, p string) { retired = append(retired, p) })
 
 	if len(probed) != 0 {
 		t.Errorf("alive/peer/file-less sessions must not be probed, probed %v", probed)
@@ -72,7 +72,7 @@ func TestReconcileDeletedConversations_DedupsPaths(t *testing.T) {
 	var probed, retired []string
 	reconcileDeletedConversations(list,
 		func(_, path string) (bool, bool) { probed = append(probed, path); return true, true },
-		func(p string) { retired = append(retired, p) })
+		func(_, p string) { retired = append(retired, p) })
 
 	if !reflect.DeepEqual(probed, []string{shared}) {
 		t.Errorf("shared path should be probed once, got %v", probed)
@@ -90,7 +90,7 @@ func TestReconcileDeletedConversations_NoProberKind(t *testing.T) {
 	var retired []string
 	reconcileDeletedConversations(list,
 		func(_, _ string) (bool, bool) { return false, false },
-		func(p string) { retired = append(retired, p) })
+		func(_, p string) { retired = append(retired, p) })
 	if len(retired) != 0 {
 		t.Errorf("adapter without a prober must not retire, got %v", retired)
 	}

--- a/services/gmuxd/cmd/gmuxd/retention_test.go
+++ b/services/gmuxd/cmd/gmuxd/retention_test.go
@@ -14,9 +14,9 @@ import (
 // the reconcile asks an adapter instead of stat'ing the file directly.
 func TestReconcileDeletedConversations_SafetyGate(t *testing.T) {
 	list := []store.Session{
-		{ID: "deleted", Adapter: "claude", ConversationFile: "/c/deleted.jsonl"},
-		{ID: "present", Adapter: "claude", ConversationFile: "/c/present.jsonl"},
-		{ID: "unreachable", Adapter: "codex", ConversationFile: "/x/unreachable.jsonl"},
+		{ID: "deleted", Adapter: "claude", ConversationRef: "/c/deleted.jsonl"},
+		{ID: "present", Adapter: "claude", ConversationRef: "/c/present.jsonl"},
+		{ID: "unreachable", Adapter: "codex", ConversationRef: "/x/unreachable.jsonl"},
 	}
 	probe := func(adapter, path string) (gone, known bool) {
 		switch path {
@@ -42,9 +42,9 @@ func TestReconcileDeletedConversations_SafetyGate(t *testing.T) {
 // and file-less sessions are never probed or retired.
 func TestReconcileDeletedConversations_Skips(t *testing.T) {
 	list := []store.Session{
-		{ID: "alive", Adapter: "claude", ConversationFile: "/c/a.jsonl", Alive: true},
-		{ID: "peer", Adapter: "claude", ConversationFile: "/c/b.jsonl", Peer: "box2"},
-		{ID: "nofile", Adapter: "claude", ConversationFile: ""},
+		{ID: "alive", Adapter: "claude", ConversationRef: "/c/a.jsonl", Alive: true},
+		{ID: "peer", Adapter: "claude", ConversationRef: "/c/b.jsonl", Peer: "box2"},
+		{ID: "nofile", Adapter: "claude", ConversationRef: ""},
 	}
 	var probed, retired []string
 	reconcileDeletedConversations(list,
@@ -65,9 +65,9 @@ func TestReconcileDeletedConversations_Skips(t *testing.T) {
 func TestReconcileDeletedConversations_DedupsPaths(t *testing.T) {
 	const shared = "/c/shared.jsonl"
 	list := []store.Session{
-		{ID: "d1", Adapter: "claude", ConversationFile: shared},
-		{ID: "d2", Adapter: "claude", ConversationFile: shared},
-		{ID: "d3", Adapter: "claude", ConversationFile: shared},
+		{ID: "d1", Adapter: "claude", ConversationRef: shared},
+		{ID: "d2", Adapter: "claude", ConversationRef: shared},
+		{ID: "d3", Adapter: "claude", ConversationRef: shared},
 	}
 	var probed, retired []string
 	reconcileDeletedConversations(list,
@@ -86,7 +86,7 @@ func TestReconcileDeletedConversations_DedupsPaths(t *testing.T) {
 // adapter can't probe (probe returns known=false) is left alone — this
 // is how the real convProbe reports a missing/incapable adapter.
 func TestReconcileDeletedConversations_NoProberKind(t *testing.T) {
-	list := []store.Session{{ID: "s", Adapter: "shell", ConversationFile: "/s/x"}}
+	list := []store.Session{{ID: "s", Adapter: "shell", ConversationRef: "/s/x"}}
 	var retired []string
 	reconcileDeletedConversations(list,
 		func(_, _ string) (bool, bool) { return false, false },

--- a/services/gmuxd/internal/apiclient/client.go
+++ b/services/gmuxd/internal/apiclient/client.go
@@ -58,9 +58,9 @@ const httpActionTimeout = 10 * time.Second
 // Client is an authenticated HTTP + WebSocket client pointed at one
 // gmuxd instance (the "spoke" from the hub's perspective).
 type Client struct {
-	baseURL          string
-	token            string
-	transport        http.RoundTripper
+	baseURL           string
+	token             string
+	transport         http.RoundTripper
 	streamIdleTimeout time.Duration
 
 	// httpClient is a long-lived client with no Timeout so SSE

--- a/services/gmuxd/internal/apiclient/client_test.go
+++ b/services/gmuxd/internal/apiclient/client_test.go
@@ -674,7 +674,6 @@ func TestProxyWS_NoCompressionToBrowser(t *testing.T) {
 	}
 }
 
-
 // TestForwardAction_PreservesQueryString locks in the contract that
 // action endpoints with query parameters (e.g. /scrollback?tail=N)
 // work the same against peer sessions as against local ones.

--- a/services/gmuxd/internal/config/config.go
+++ b/services/gmuxd/internal/config/config.go
@@ -278,4 +278,3 @@ func Dir() string {
 func Path() string {
 	return filepath.Join(Dir(), "host.toml")
 }
-

--- a/services/gmuxd/internal/config/config_test.go
+++ b/services/gmuxd/internal/config/config_test.go
@@ -351,7 +351,6 @@ func TestListenAddrIPv6(t *testing.T) {
 	}
 }
 
-
 // ── [[peers]] ──
 
 func TestLoadDiscoveryDefaults(t *testing.T) {

--- a/services/gmuxd/internal/conversations/index.go
+++ b/services/gmuxd/internal/conversations/index.go
@@ -1,10 +1,14 @@
-// Package conversations maintains an index of conversation files
-// discovered on disk. It maps (adapter, slug) to file metadata, enabling
-// URL resolution for dead conversations and (future) fulltext search.
+// Package conversations maintains an index of the conversations each
+// adapter's tool has stored. It maps (adapter, slug) to conversation
+// metadata, enabling URL resolution for dead conversations and (future)
+// fulltext search.
 //
 // The index is populated and kept current by adapter ConversationSources
-// (snapshot at startup, incremental thereafter). It never writes to the
-// session store.
+// (snapshot at startup, incremental thereafter), which emit opaque
+// conversation refs; the index resolves each ref to metadata via the
+// owning adapter's DescribeConversation and never interprets the ref
+// itself (for file-backed adapters it happens to be a path — that is the
+// adapter's detail). It never writes to the session store.
 package conversations
 
 import (
@@ -16,19 +20,20 @@ import (
 	"github.com/gmuxapp/gmux/packages/adapter"
 )
 
-// Info holds metadata for a single conversation file.
+// Info holds metadata for a single stored conversation.
 type Info struct {
-	ConversationID string    // full UUID from the conversation file header
+	ConversationID string    // adapter-native conversation ID (typically a UUID)
 	Slug           string    // human-readable URL identifier, unique within (adapter)
 	Adapter        string    // adapter name (claude, codex, pi, shell)
 	Title          string    // display title
 	Cwd            string    // working directory
-	FilePath       string    // absolute path to the conversation file
+	Ref            string    // opaque adapter-scoped conversation ref (a file path for file-backed adapters)
 	ResumeCommand  []string  // command to resume this conversation
 	Created        time.Time // when the conversation started
+	LastActivity   time.Time // adapter-reported most recent activity (zero when unknown)
 }
 
-// Index is a concurrency-safe lookup table for conversation files.
+// Index is a concurrency-safe lookup table for stored conversations.
 // It is the authority on slug uniqueness: when two conversations
 // produce the same slug within the same adapter, the index assigns
 // -2, -3 suffixes.
@@ -132,45 +137,47 @@ func (idx *Index) All() []Info {
 	return out
 }
 
-// ScanFile indexes a single conversation file (snapshot or live update
-// from an adapter ConversationSource). Returns the assigned slug.
-func (idx *Index) ScanFile(a adapter.Adapter, path string) string {
-	sf, ok := a.(adapter.ConversationFiler)
+// Scan indexes a single conversation ref (snapshot or live update from an
+// adapter ConversationSource), resolving it to metadata via the owning
+// adapter's DescribeConversation. Returns the assigned slug.
+func (idx *Index) Scan(a adapter.Adapter, ref string) string {
+	desc, ok := a.(adapter.ConversationDescriber)
 	if !ok {
 		return ""
 	}
 
-	fileInfo, err := sf.ParseConversationFile(path)
+	convInfo, err := desc.DescribeConversation(ref)
 	if err != nil {
 		return ""
 	}
 
-	if fileInfo.Cwd == "" {
+	if convInfo.Cwd == "" {
 		return ""
 	}
 
-	slug := fileInfo.Slug
+	slug := convInfo.Slug
 	if slug == "" {
-		slug = adapter.Slugify(fileInfo.ID)
+		slug = adapter.Slugify(convInfo.ID)
 	}
 
 	var cmd []string
 	if resumer, ok := a.(adapter.Resumer); ok {
-		if !resumer.CanResume(path) {
+		if !resumer.CanResume(ref) {
 			return ""
 		}
-		cmd = resumer.ResumeCommand(fileInfo)
+		cmd = resumer.ResumeCommand(convInfo)
 	}
 
 	info := Info{
-		ConversationID: fileInfo.ID,
+		ConversationID: convInfo.ID,
 		Slug:           slug,
 		Adapter:        a.Name(),
-		Title:          fileInfo.Title,
-		Cwd:            fileInfo.Cwd,
-		FilePath:       path,
+		Title:          convInfo.Title,
+		Cwd:            convInfo.Cwd,
+		Ref:            ref,
 		ResumeCommand:  cmd,
-		Created:        fileInfo.Created,
+		Created:        convInfo.Created,
+		LastActivity:   convInfo.LastActivity,
 	}
 	return idx.Upsert(info)
 }
@@ -190,22 +197,22 @@ func (idx *Index) Remove(adapterName, conversationID string) bool {
 	return true
 }
 
-// RemoveByPath deletes any conversation whose FilePath matches path.
-// Used when a ConversationSource observes a deletion event and we don't have the
+// RemoveByRef deletes any conversation whose Ref matches ref.
+// Used when a ConversationSource observes a removal event and we don't have the
 // (adapter, conversationID) handy. Linear walk over the index; that's fine
 // because Remove events are rare (manual `rm`, file rotation) and
 // the index size stays in the hundreds-to-low-thousands range.
 // Returns true if an entry was removed.
 //
-// Session retirement on file-gone deliberately does NOT hang off this
-// method: an unindexed conversation (parse failure, CanResume=false,
-// empty cwd) still needs retiring when its file disappears, so the
-// watcher-level sink (sources.go) owns that signal instead.
-func (idx *Index) RemoveByPath(path string) bool {
+// Session retirement on conversation-gone deliberately does NOT hang off
+// this method: an unindexed conversation (describe failure,
+// CanResume=false, empty cwd) still needs retiring when it disappears, so
+// the source-level sink (sources.go) owns that signal instead.
+func (idx *Index) RemoveByRef(ref string) bool {
 	idx.mu.Lock()
 	defer idx.mu.Unlock()
 	for key, info := range idx.byKey {
-		if info.FilePath != path {
+		if info.Ref != ref {
 			continue
 		}
 		delete(idx.byKey, key)

--- a/services/gmuxd/internal/conversations/index.go
+++ b/services/gmuxd/internal/conversations/index.go
@@ -197,22 +197,24 @@ func (idx *Index) Remove(adapterName, conversationID string) bool {
 	return true
 }
 
-// RemoveByRef deletes any conversation whose Ref matches ref.
-// Used when a ConversationSource observes a removal event and we don't have the
-// (adapter, conversationID) handy. Linear walk over the index; that's fine
-// because Remove events are rare (manual `rm`, file rotation) and
-// the index size stays in the hundreds-to-low-thousands range.
-// Returns true if an entry was removed.
+// RemoveByRef deletes the conversation whose (Adapter, Ref) matches.
+// Used when a ConversationSource observes a removal event and we don't have
+// the (adapter, conversationID) handy. Refs are only unique within an
+// adapter (ADR 0022: opaque, adapter-scoped), so the match is scoped to the
+// reporting adapter — two adapters may legitimately use the same ref string.
+// Linear walk over the index; that's fine because Remove events are rare
+// (manual `rm`, file rotation) and the index size stays in the
+// hundreds-to-low-thousands range. Returns true if an entry was removed.
 //
 // Session retirement on conversation-gone deliberately does NOT hang off
 // this method: an unindexed conversation (describe failure,
 // CanResume=false, empty cwd) still needs retiring when it disappears, so
 // the source-level sink (sources.go) owns that signal instead.
-func (idx *Index) RemoveByRef(ref string) bool {
+func (idx *Index) RemoveByRef(adapterName, ref string) bool {
 	idx.mu.Lock()
 	defer idx.mu.Unlock()
 	for key, info := range idx.byKey {
-		if info.Ref != ref {
+		if info.Adapter != adapterName || info.Ref != ref {
 			continue
 		}
 		delete(idx.byKey, key)

--- a/services/gmuxd/internal/conversations/index_test.go
+++ b/services/gmuxd/internal/conversations/index_test.go
@@ -136,14 +136,14 @@ func TestRemove(t *testing.T) {
 	}
 }
 
-func TestRemoveByPath(t *testing.T) {
+func TestRemoveByRef(t *testing.T) {
 	idx := New()
-	idx.Upsert(Info{ConversationID: "a", Slug: "one", Adapter: "pi", FilePath: "/x/a.jsonl"})
-	idx.Upsert(Info{ConversationID: "b", Slug: "two", Adapter: "pi", FilePath: "/x/b.jsonl"})
-	idx.Upsert(Info{ConversationID: "c", Slug: "three", Adapter: "claude", FilePath: "/y/c.jsonl"})
+	idx.Upsert(Info{ConversationID: "a", Slug: "one", Adapter: "pi", Ref: "/x/a.jsonl"})
+	idx.Upsert(Info{ConversationID: "b", Slug: "two", Adapter: "pi", Ref: "/x/b.jsonl"})
+	idx.Upsert(Info{ConversationID: "c", Slug: "three", Adapter: "claude", Ref: "/y/c.jsonl"})
 
-	if !idx.RemoveByPath("/x/b.jsonl") {
-		t.Fatal("expected RemoveByPath to return true for indexed path")
+	if !idx.RemoveByRef("/x/b.jsonl") {
+		t.Fatal("expected RemoveByRef to return true for indexed path")
 	}
 	if idx.Count() != 2 {
 		t.Errorf("expected count 2 after remove, got %d", idx.Count())
@@ -162,12 +162,12 @@ func TestRemoveByPath(t *testing.T) {
 	// Reverse-lookup (byConversationID) cleared too: Upserting the same conversationID
 	// at a new slug should yield the new slug, not update-in-place at
 	// the old one.
-	slug := idx.Upsert(Info{ConversationID: "b", Slug: "different", Adapter: "pi", FilePath: "/x/b2.jsonl"})
+	slug := idx.Upsert(Info{ConversationID: "b", Slug: "different", Adapter: "pi", Ref: "/x/b2.jsonl"})
 	if slug != "different" {
 		t.Errorf("expected fresh slug 'different' (byConversationID was cleared), got %q", slug)
 	}
-	if idx.RemoveByPath("/x/nope.jsonl") {
-		t.Error("expected RemoveByPath to return false for unknown path")
+	if idx.RemoveByRef("/x/nope.jsonl") {
+		t.Error("expected RemoveByRef to return false for unknown path")
 	}
 }
 
@@ -257,7 +257,7 @@ func TestAll(t *testing.T) {
 // It also still removes indexed entries from the index.
 func TestSinkRemoveFiresOnRemovedEvenWhenUnindexed(t *testing.T) {
 	idx := New()
-	idx.Upsert(Info{ConversationID: "a", Slug: "one", Adapter: "pi", FilePath: "/x/a.jsonl"})
+	idx.Upsert(Info{ConversationID: "a", Slug: "one", Adapter: "pi", Ref: "/x/a.jsonl"})
 
 	var got []string
 	sink := indexSink{idx: idx, onRemoved: func(p string) { got = append(got, p) }}

--- a/services/gmuxd/internal/conversations/index_test.go
+++ b/services/gmuxd/internal/conversations/index_test.go
@@ -141,12 +141,15 @@ func TestRemoveByRef(t *testing.T) {
 	idx.Upsert(Info{ConversationID: "a", Slug: "one", Adapter: "pi", Ref: "/x/a.jsonl"})
 	idx.Upsert(Info{ConversationID: "b", Slug: "two", Adapter: "pi", Ref: "/x/b.jsonl"})
 	idx.Upsert(Info{ConversationID: "c", Slug: "three", Adapter: "claude", Ref: "/y/c.jsonl"})
+	// Same ref string under a different adapter: refs are only unique
+	// within an adapter (ADR 0022), so pi's removal must not touch it.
+	idx.Upsert(Info{ConversationID: "d", Slug: "four", Adapter: "claude", Ref: "/x/b.jsonl"})
 
-	if !idx.RemoveByRef("/x/b.jsonl") {
+	if !idx.RemoveByRef("pi", "/x/b.jsonl") {
 		t.Fatal("expected RemoveByRef to return true for indexed path")
 	}
-	if idx.Count() != 2 {
-		t.Errorf("expected count 2 after remove, got %d", idx.Count())
+	if idx.Count() != 3 {
+		t.Errorf("expected count 3 after remove, got %d", idx.Count())
 	}
 	if _, ok := idx.Lookup("pi", "two"); ok {
 		t.Error("expected miss for removed slug")
@@ -159,6 +162,10 @@ func TestRemoveByRef(t *testing.T) {
 	if _, ok := idx.Lookup("claude", "three"); !ok {
 		t.Error("cross-adapter entry was incorrectly removed")
 	}
+	// Cross-adapter entry with the SAME ref unaffected.
+	if _, ok := idx.Lookup("claude", "four"); !ok {
+		t.Error("cross-adapter entry sharing the ref string was incorrectly removed")
+	}
 	// Reverse-lookup (byConversationID) cleared too: Upserting the same conversationID
 	// at a new slug should yield the new slug, not update-in-place at
 	// the old one.
@@ -166,7 +173,7 @@ func TestRemoveByRef(t *testing.T) {
 	if slug != "different" {
 		t.Errorf("expected fresh slug 'different' (byConversationID was cleared), got %q", slug)
 	}
-	if idx.RemoveByRef("/x/nope.jsonl") {
+	if idx.RemoveByRef("pi", "/x/nope.jsonl") {
 		t.Error("expected RemoveByRef to return false for unknown path")
 	}
 }
@@ -260,7 +267,7 @@ func TestSinkRemoveFiresOnRemovedEvenWhenUnindexed(t *testing.T) {
 	idx.Upsert(Info{ConversationID: "a", Slug: "one", Adapter: "pi", Ref: "/x/a.jsonl"})
 
 	var got []string
-	sink := indexSink{idx: idx, onRemoved: func(p string) { got = append(got, p) }}
+	sink := indexSink{idx: idx, a: &dbAdapter{name: "pi"}, onRemoved: func(_, ref string) { got = append(got, ref) }}
 
 	sink.Remove("/x/never-indexed.jsonl")
 	sink.Remove("/x/a.jsonl")
@@ -277,5 +284,5 @@ func TestSinkRemoveFiresOnRemovedEvenWhenUnindexed(t *testing.T) {
 	}
 
 	// nil callback must not panic.
-	indexSink{idx: idx}.Remove("/x/whatever.jsonl")
+	indexSink{idx: idx, a: &dbAdapter{name: "pi"}}.Remove("/x/whatever.jsonl")
 }

--- a/services/gmuxd/internal/conversations/opaque_ref_test.go
+++ b/services/gmuxd/internal/conversations/opaque_ref_test.go
@@ -1,0 +1,110 @@
+package conversations
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/gmuxapp/gmux/packages/adapter"
+)
+
+// dbAdapter is a minimal non-file adapter: its conversation refs are opaque
+// row keys ("row:<id>"), not paths, and metadata comes from an in-memory
+// "table". It exercises the ADR 0022 contract the index promises: a
+// DB-backed adapter needs only ConversationDescriber (+ Resumer) — no
+// directory layout, no stat, no path semantics anywhere in the daemon.
+type dbAdapter struct {
+	rows map[string]adapter.ConversationInfo // ref → row
+}
+
+func (d *dbAdapter) Name() string                      { return "dbtool" }
+func (d *dbAdapter) Discover() bool                    { return true }
+func (d *dbAdapter) Match(_ []string) bool             { return false }
+func (d *dbAdapter) Env(_ adapter.EnvContext) []string { return nil }
+func (d *dbAdapter) Monitor(_ []byte) *adapter.Event   { return nil }
+
+func (d *dbAdapter) DescribeConversation(ref string) (*adapter.ConversationInfo, error) {
+	row, ok := d.rows[ref]
+	if !ok {
+		return nil, errors.New("no such row")
+	}
+	row.Ref = ref
+	return &row, nil
+}
+
+func (d *dbAdapter) ResumeCommand(info *adapter.ConversationInfo) []string {
+	return []string{"dbtool", "resume", info.ID}
+}
+
+func (d *dbAdapter) CanResume(ref string) bool {
+	_, ok := d.rows[ref]
+	return ok
+}
+
+var (
+	_ adapter.ConversationDescriber = (*dbAdapter)(nil)
+	_ adapter.Resumer               = (*dbAdapter)(nil)
+)
+
+// TestScan_OpaqueRefAdapter proves the index seam is ref-opaque end to end:
+// a non-file adapter's row-key refs flow through Scan, land in the Info
+// unmodified alongside adapter-provided freshness, resolve for URL lookup,
+// and are removable by the same ref a source's Remove event would carry.
+func TestScan_OpaqueRefAdapter(t *testing.T) {
+	activity := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	a := &dbAdapter{rows: map[string]adapter.ConversationInfo{
+		"row:42": {
+			ID:           "conv-42",
+			Title:        "fix the flaky test",
+			Slug:         "fix-the-flaky-test",
+			Cwd:          "/home/u/proj",
+			Created:      activity.Add(-time.Hour),
+			LastActivity: activity,
+			MessageCount: 3,
+		},
+	}}
+
+	idx := New()
+	slug := idx.Scan(a, "row:42")
+	if slug != "fix-the-flaky-test" {
+		t.Fatalf("Scan slug = %q, want fix-the-flaky-test", slug)
+	}
+
+	info, ok := idx.Lookup("dbtool", slug)
+	if !ok {
+		t.Fatal("indexed conversation not found by (adapter, slug)")
+	}
+	if info.Ref != "row:42" {
+		t.Errorf("Info.Ref = %q, want the opaque ref back unmodified", info.Ref)
+	}
+	if !info.LastActivity.Equal(activity) {
+		t.Errorf("Info.LastActivity = %v, want adapter-provided %v", info.LastActivity, activity)
+	}
+	if got, want := len(info.ResumeCommand), 3; got != want {
+		t.Fatalf("ResumeCommand = %v, want dbtool resume conv-42", info.ResumeCommand)
+	}
+	if info.ResumeCommand[2] != "conv-42" {
+		t.Errorf("ResumeCommand resumes by %q, want conv-42", info.ResumeCommand[2])
+	}
+
+	// A source Remove event carries the same ref; the index must match it.
+	if !idx.RemoveByRef("row:42") {
+		t.Fatal("RemoveByRef(row:42) = false, want removal by opaque ref")
+	}
+	if _, ok := idx.Lookup("dbtool", slug); ok {
+		t.Error("conversation still indexed after RemoveByRef")
+	}
+}
+
+// TestScan_DescribeFailureNotIndexed: an unresolvable ref (deleted row,
+// unreadable file) must not be indexed — mirrors the parse-failure behavior
+// the file adapters had.
+func TestScan_DescribeFailureNotIndexed(t *testing.T) {
+	idx := New()
+	if slug := idx.Scan(&dbAdapter{}, "row:missing"); slug != "" {
+		t.Fatalf("Scan of unresolvable ref returned slug %q, want empty", slug)
+	}
+	if idx.Count() != 0 {
+		t.Errorf("index count = %d, want 0", idx.Count())
+	}
+}

--- a/services/gmuxd/internal/conversations/opaque_ref_test.go
+++ b/services/gmuxd/internal/conversations/opaque_ref_test.go
@@ -14,10 +14,16 @@ import (
 // DB-backed adapter needs only ConversationDescriber (+ Resumer) — no
 // directory layout, no stat, no path semantics anywhere in the daemon.
 type dbAdapter struct {
+	name string                              // adapter name; "dbtool" when empty
 	rows map[string]adapter.ConversationInfo // ref → row
 }
 
-func (d *dbAdapter) Name() string                      { return "dbtool" }
+func (d *dbAdapter) Name() string {
+	if d.name == "" {
+		return "dbtool"
+	}
+	return d.name
+}
 func (d *dbAdapter) Discover() bool                    { return true }
 func (d *dbAdapter) Match(_ []string) bool             { return false }
 func (d *dbAdapter) Env(_ adapter.EnvContext) []string { return nil }
@@ -88,7 +94,7 @@ func TestScan_OpaqueRefAdapter(t *testing.T) {
 	}
 
 	// A source Remove event carries the same ref; the index must match it.
-	if !idx.RemoveByRef("row:42") {
+	if !idx.RemoveByRef("dbtool", "row:42") {
 		t.Fatal("RemoveByRef(row:42) = false, want removal by opaque ref")
 	}
 	if _, ok := idx.Lookup("dbtool", slug); ok {

--- a/services/gmuxd/internal/conversations/sources.go
+++ b/services/gmuxd/internal/conversations/sources.go
@@ -10,22 +10,22 @@ import (
 )
 
 // indexSink bridges one adapter's ConversationSource to the index.
-// onRemoved, if set, additionally observes every file-gone event —
-// including files the index never held (parse failure, CanResume=false,
+// onRemoved, if set, additionally observes every conversation-gone event —
+// including refs the index never held (describe failure, CanResume=false,
 // empty cwd), which is why retirement hangs here and not off
-// Index.RemoveByPath: a dead session bound to an unindexed conversation
-// must still retire when that file is deleted.
+// Index.RemoveByRef: a dead session bound to an unindexed conversation
+// must still retire when that conversation is deleted.
 type indexSink struct {
 	idx       *Index
 	a         adapter.Adapter
-	onRemoved func(path string)
+	onRemoved func(ref string)
 }
 
-func (s indexSink) Upsert(path string) { s.idx.ScanFile(s.a, path) }
-func (s indexSink) Remove(path string) {
-	s.idx.RemoveByPath(path)
+func (s indexSink) Upsert(ref string) { s.idx.Scan(s.a, ref) }
+func (s indexSink) Remove(ref string) {
+	s.idx.RemoveByRef(ref)
 	if s.onRemoved != nil {
-		s.onRemoved(path)
+		s.onRemoved(ref)
 	}
 }
 
@@ -40,18 +40,18 @@ func (idx *Index) Snapshot() {
 }
 
 // WatchSources starts every adapter ConversationSource in its own goroutine,
-// feeding the index until ctx is cancelled. onFileRemoved, if non-nil,
-// is invoked (from the watcher goroutines) with each conversation file
-// path observed to disappear — whether or not it was indexed. cmd/gmuxd
-// wires this to retire dead sessions backed by the deleted file.
-func (idx *Index) WatchSources(ctx context.Context, onFileRemoved func(path string)) {
+// feeding the index until ctx is cancelled. onRemoved, if non-nil, is
+// invoked (from the source goroutines) with each conversation ref
+// observed to disappear — whether or not it was indexed. cmd/gmuxd
+// wires this to retire dead sessions backed by the deleted conversation.
+func (idx *Index) WatchSources(ctx context.Context, onRemoved func(ref string)) {
 	for _, a := range adapters.AllAdapters() {
 		src, ok := a.(adapter.ConversationSource)
 		if !ok {
 			continue
 		}
 		go func(a adapter.Adapter, src adapter.ConversationSource) {
-			if err := src.WatchConversations(ctx, indexSink{idx: idx, a: a, onRemoved: onFileRemoved}); err != nil && !errors.Is(err, context.Canceled) {
+			if err := src.WatchConversations(ctx, indexSink{idx: idx, a: a, onRemoved: onRemoved}); err != nil && !errors.Is(err, context.Canceled) {
 				log.Printf("conversations: source %s stopped: %v", a.Name(), err)
 			}
 		}(a, src)

--- a/services/gmuxd/internal/conversations/sources.go
+++ b/services/gmuxd/internal/conversations/sources.go
@@ -18,14 +18,18 @@ import (
 type indexSink struct {
 	idx       *Index
 	a         adapter.Adapter
-	onRemoved func(ref string)
+	onRemoved func(adapterName, ref string)
 }
 
 func (s indexSink) Upsert(ref string) { s.idx.Scan(s.a, ref) }
+
+// Remove re-scopes the source's bare ref with the owning adapter before it
+// touches anything: refs are only unique within an adapter (ADR 0022), so
+// both the index removal and the retirement callback carry (adapter, ref).
 func (s indexSink) Remove(ref string) {
-	s.idx.RemoveByRef(ref)
+	s.idx.RemoveByRef(s.a.Name(), ref)
 	if s.onRemoved != nil {
-		s.onRemoved(ref)
+		s.onRemoved(s.a.Name(), ref)
 	}
 }
 
@@ -41,10 +45,10 @@ func (idx *Index) Snapshot() {
 
 // WatchSources starts every adapter ConversationSource in its own goroutine,
 // feeding the index until ctx is cancelled. onRemoved, if non-nil, is
-// invoked (from the source goroutines) with each conversation ref
-// observed to disappear — whether or not it was indexed. cmd/gmuxd
-// wires this to retire dead sessions backed by the deleted conversation.
-func (idx *Index) WatchSources(ctx context.Context, onRemoved func(ref string)) {
+// invoked (from the source goroutines) with each (adapter, ref) observed
+// to disappear — whether or not it was indexed. cmd/gmuxd wires this to
+// retire dead sessions backed by the deleted conversation.
+func (idx *Index) WatchSources(ctx context.Context, onRemoved func(adapterName, ref string)) {
 	for _, a := range adapters.AllAdapters() {
 		src, ok := a.(adapter.ConversationSource)
 		if !ok {

--- a/services/gmuxd/internal/discovery/discovery.go
+++ b/services/gmuxd/internal/discovery/discovery.go
@@ -334,7 +334,7 @@ func queryMeta(socketPath string) (*store.Session, error) {
 	// Legacy-read shim: pre-v2 runners report "kind" and "session_file"
 	// in /meta. Long-lived runners survive daemon upgrades, so accept the
 	// old keys for one release. TODO(v2.1): drop this shim.
-	if sess.Adapter == "" || sess.ConversationFile == "" {
+	if sess.Adapter == "" || sess.ConversationRef == "" {
 		var legacy struct {
 			Kind        string `json:"kind"`
 			SessionFile string `json:"session_file"`
@@ -343,8 +343,8 @@ func queryMeta(socketPath string) (*store.Session, error) {
 			if sess.Adapter == "" {
 				sess.Adapter = legacy.Kind
 			}
-			if sess.ConversationFile == "" {
-				sess.ConversationFile = legacy.SessionFile
+			if sess.ConversationRef == "" {
+				sess.ConversationRef = legacy.SessionFile
 			}
 		}
 	}

--- a/services/gmuxd/internal/discovery/discovery_test.go
+++ b/services/gmuxd/internal/discovery/discovery_test.go
@@ -317,8 +317,8 @@ func TestQueryMetaLegacyPreV2Keys(t *testing.T) {
 	if sess.Adapter != "pi" {
 		t.Errorf("Adapter = %q, want %q (legacy \"kind\" fallback)", sess.Adapter, "pi")
 	}
-	if want := "/home/u/.pi/agent/sessions/x/conv.jsonl"; sess.ConversationFile != want {
-		t.Errorf("ConversationFile = %q, want %q (legacy \"session_file\" fallback)", sess.ConversationFile, want)
+	if want := "/home/u/.pi/agent/sessions/x/conv.jsonl"; sess.ConversationRef != want {
+		t.Errorf("ConversationRef = %q, want %q (legacy \"session_file\" fallback)", sess.ConversationRef, want)
 	}
 }
 
@@ -344,8 +344,8 @@ func TestQueryMetaNewKeysWinOverLegacy(t *testing.T) {
 	if sess.Adapter != "claude" {
 		t.Errorf("Adapter = %q, want %q (new key must win)", sess.Adapter, "claude")
 	}
-	if sess.ConversationFile != "/new/conv.jsonl" {
-		t.Errorf("ConversationFile = %q, want /new/conv.jsonl (new key must win)", sess.ConversationFile)
+	if sess.ConversationRef != "/new/conv.jsonl" {
+		t.Errorf("ConversationRef = %q, want /new/conv.jsonl (new key must win)", sess.ConversationRef)
 	}
 }
 

--- a/services/gmuxd/internal/discovery/resume.go
+++ b/services/gmuxd/internal/discovery/resume.go
@@ -7,17 +7,18 @@ import (
 )
 
 // ResolveResumeCommand derives the resume command for a dead session from its
-// authoritative conversation file (store.Session.ConversationFile, reported by the agent
-// hook). Returns nil if the session has no recorded file or isn't resumable.
+// authoritative conversation ref (store.Session.ConversationRef, reported by
+// the agent hook). Returns nil if the session has no recorded conversation
+// or isn't resumable.
 func ResolveResumeCommand(sess *store.Session) []string {
-	if sess.ConversationFile == "" {
+	if sess.ConversationRef == "" {
 		return nil
 	}
 	a := adapters.FindByAdapter(sess.Adapter)
 	if a == nil {
 		return nil
 	}
-	filer, ok := a.(adapter.ConversationFiler)
+	desc, ok := a.(adapter.ConversationDescriber)
 	if !ok {
 		return nil
 	}
@@ -25,7 +26,7 @@ func ResolveResumeCommand(sess *store.Session) []string {
 	if !ok {
 		return nil
 	}
-	info, err := filer.ParseConversationFile(sess.ConversationFile)
+	info, err := desc.DescribeConversation(sess.ConversationRef)
 	if err != nil {
 		return nil
 	}

--- a/services/gmuxd/internal/discovery/resume_test.go
+++ b/services/gmuxd/internal/discovery/resume_test.go
@@ -35,9 +35,9 @@ func TestResolveResumeCommand(t *testing.T) {
 		wantNil bool
 	}{
 		{"no conversation file", store.Session{Adapter: "pi"}, true},
-		{"unknown adapter", store.Session{Adapter: "nope", ConversationFile: good}, true},
-		{"unparseable file", store.Session{Adapter: "pi", ConversationFile: filepath.Join(dir, "ghost.jsonl")}, true},
-		{"resumable pi", store.Session{Adapter: "pi", ConversationFile: good}, false},
+		{"unknown adapter", store.Session{Adapter: "nope", ConversationRef: good}, true},
+		{"unparseable file", store.Session{Adapter: "pi", ConversationRef: filepath.Join(dir, "ghost.jsonl")}, true},
+		{"resumable pi", store.Session{Adapter: "pi", ConversationRef: good}, false},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -55,7 +55,7 @@ func TestResolveResumeCommand(t *testing.T) {
 	}
 }
 
-// A shell session never carries a ConversationFile, so the guard returns before the
+// A shell session never carries a ConversationRef, so the guard returns before the
 // adapter lookup — even though shell is itself a ConversationFiler/Resumer.
 func TestResolveResumeCommandShellGuarded(t *testing.T) {
 	if cmd := ResolveResumeCommand(&store.Session{Adapter: "shell"}); cmd != nil {

--- a/services/gmuxd/internal/discovery/subscribe.go
+++ b/services/gmuxd/internal/discovery/subscribe.go
@@ -299,7 +299,9 @@ func (sub *Subscriptions) handleEvent(sessionID, socketPath, eventType string, d
 
 	// "session_file" is the pre-v2 name for the same event: long-lived
 	// runners survive daemon upgrades, so the daemon accepts both for one
-	// release. New runners emit only "conversation_file".
+	// release. New runners emit only "conversation_file" — itself a legacy
+	// wire name whose "path" payload carries the adapter-opaque
+	// conversation ref (ADR 0022).
 	// TODO(v2.1): drop the "session_file" case.
 	case "conversation_file", "session_file":
 		var sf struct {
@@ -312,13 +314,13 @@ func (sub *Subscriptions) handleEvent(sessionID, socketPath, eventType string, d
 		if sf.Path == "" {
 			return
 		}
-		// session → file is authoritative and per-session (ADR 0011): record it
-		// on the session itself so the frontend can derive file → {sessions}
-		// and warn when a conversation is open in more than one runner. A
-		// rebind (/resume) just overwrites this session's own file; it never
-		// clobbers another session's.
+		// session → conversation is authoritative and per-session (ADR 0011):
+		// record the ref on the session itself so the frontend can derive
+		// ref → {sessions} and warn when a conversation is open in more than
+		// one runner. A rebind (/resume) just overwrites this session's own
+		// ref; it never clobbers another session's.
 		sub.store.Update(sessionID, func(sess *store.Session) {
-			sess.ConversationFile = sf.Path
+			sess.ConversationRef = sf.Path
 		})
 
 	case "activity":

--- a/services/gmuxd/internal/discovery/subscribe_test.go
+++ b/services/gmuxd/internal/discovery/subscribe_test.go
@@ -245,8 +245,8 @@ func TestConversationFileEventRecordsPath(t *testing.T) {
 	subs.handleEvent("sess-1", "/sock", "conversation_file", []byte(`{"path":"`+path+`"}`))
 
 	got, ok := sessions.Get("sess-1")
-	if !ok || got.ConversationFile != path {
-		t.Fatalf("ConversationFile = %q (ok=%v), want %q", got.ConversationFile, ok, path)
+	if !ok || got.ConversationRef != path {
+		t.Fatalf("ConversationRef = %q (ok=%v), want %q", got.ConversationRef, ok, path)
 	}
 }
 
@@ -262,8 +262,8 @@ func TestLegacySessionFileEventStillAccepted(t *testing.T) {
 	subs.handleEvent("sess-1", "/sock", "session_file", []byte(`{"path":"`+path+`"}`))
 
 	got, ok := sessions.Get("sess-1")
-	if !ok || got.ConversationFile != path {
-		t.Fatalf("ConversationFile = %q (ok=%v), want %q", got.ConversationFile, ok, path)
+	if !ok || got.ConversationRef != path {
+		t.Fatalf("ConversationRef = %q (ok=%v), want %q", got.ConversationRef, ok, path)
 	}
 }
 
@@ -272,8 +272,8 @@ func TestConversationFileEventEmptyPathIgnored(t *testing.T) {
 	sessions.Upsert(store.Session{ID: "sess-1", Alive: true})
 	subs := NewSubscriptions(sessions)
 	subs.handleEvent("sess-1", "/sock", "conversation_file", []byte(`{"path":""}`))
-	if got, _ := sessions.Get("sess-1"); got.ConversationFile != "" {
-		t.Errorf("empty path should not set ConversationFile, got %q", got.ConversationFile)
+	if got, _ := sessions.Get("sess-1"); got.ConversationRef != "" {
+		t.Errorf("empty path should not set ConversationRef, got %q", got.ConversationRef)
 	}
 }
 

--- a/services/gmuxd/internal/identity/identity_test.go
+++ b/services/gmuxd/internal/identity/identity_test.go
@@ -4,10 +4,10 @@ import "testing"
 
 func TestResolve(t *testing.T) {
 	tests := []struct {
-		name     string
-		fqdn     string
-		osHost   string
-		want     string
+		name   string
+		fqdn   string
+		osHost string
+		want   string
 	}{
 		{"tailscale fqdn wins over os hostname", "gmux-laptop.tailnet.ts.net", "ca75413aec31", "gmux-laptop"},
 		{"fqdn without dot used as-is", "gmux-laptop", "host", "gmux-laptop"},

--- a/services/gmuxd/internal/notify/notify.go
+++ b/services/gmuxd/internal/notify/notify.go
@@ -33,8 +33,8 @@ func DefaultConfig() Config {
 
 // NotifyMessage is sent to the browser over the presence WebSocket.
 type NotifyMessage struct {
-	Type      string `json:"type"`       // "notify"
-	ID        string `json:"id"`         // daemon-assigned notification ID
+	Type      string `json:"type"` // "notify"
+	ID        string `json:"id"`   // daemon-assigned notification ID
 	SessionID string `json:"session_id"`
 	Title     string `json:"title"`
 	Body      string `json:"body"`

--- a/services/gmuxd/internal/notify/notify_test.go
+++ b/services/gmuxd/internal/notify/notify_test.go
@@ -375,5 +375,3 @@ func TestFormatDuration(t *testing.T) {
 		}
 	}
 }
-
-

--- a/services/gmuxd/internal/peering/manager.go
+++ b/services/gmuxd/internal/peering/manager.go
@@ -276,5 +276,3 @@ func (m *Manager) HasPeers() bool {
 	defer m.mu.RUnlock()
 	return len(m.peers) > 0
 }
-
-

--- a/services/gmuxd/internal/presence/presence.go
+++ b/services/gmuxd/internal/presence/presence.go
@@ -14,9 +14,9 @@ import (
 type Client struct {
 	ID                     string
 	Conn                   *websocket.Conn
-	DeviceType             string  // "desktop" | "mobile"
-	NotificationPermission string  // "granted" | "denied" | "default" | "unavailable"
-	Visibility             string  // "visible" | "hidden"
+	DeviceType             string // "desktop" | "mobile"
+	NotificationPermission string // "granted" | "denied" | "default" | "unavailable"
+	Visibility             string // "visible" | "hidden"
 	Focused                bool
 	SelectedSessionID      string
 	LastInteraction        float64 // Unix timestamp (seconds)

--- a/services/gmuxd/internal/projects/migrate_test.go
+++ b/services/gmuxd/internal/projects/migrate_test.go
@@ -247,4 +247,3 @@ func TestMigrateV1EmptyItems(t *testing.T) {
 		t.Errorf("expected 0 items, got %d", len(state.Items))
 	}
 }
-

--- a/services/gmuxd/internal/projects/projects.go
+++ b/services/gmuxd/internal/projects/projects.go
@@ -383,7 +383,6 @@ func NormalizePath(p string) string {
 	return paths.NormalizePath(p)
 }
 
-
 // --- Remote normalization ---
 
 // NormalizeRemote converts a git remote URL to a canonical form.

--- a/services/gmuxd/internal/sessionmeta/sessionmeta.go
+++ b/services/gmuxd/internal/sessionmeta/sessionmeta.go
@@ -29,9 +29,9 @@
 //     session is dismissed; never on a timer.
 //
 //  2. meta.json mirrors conversation existence. A dead session whose
-//     backing conversation file disappears (the conversations index
+//     backing conversation disappears (the conversations index
 //     reports the removal) has its whole dir retired. Dead sessions
-//     that never had a conversation file (shells) can't key off that
+//     that never had a conversation (shells) can't key off that
 //     signal, so they fall back to an age/count cap on the whole dir.
 //
 // Peer-owned sessions are excluded: the hub re-receives them from
@@ -79,7 +79,7 @@ const (
 const (
 	// DefaultMaxAge / DefaultMaxCount age/count out *conversation-less*
 	// dead sessions (shells): they keep meta + scrollback under the
-	// sessions dir but have no conversation file whose removal could
+	// sessions dir but have no conversation whose removal could
 	// retire them, so they need their own lifecycle.
 	DefaultMaxAge   = 30 * 24 * time.Hour
 	DefaultMaxCount = 200
@@ -102,9 +102,9 @@ const (
 // RetentionPolicy bounds the disk footprint of dead sessions. A zero
 // value for any field disables that limit.
 type RetentionPolicy struct {
-	// MaxAge ages out conversation-less dead sessions (ConversationFile == "")
+	// MaxAge ages out conversation-less dead sessions (ConversationRef == "")
 	// whose effective timestamp is older than now-MaxAge. Sessions with a
-	// conversation file are exempt: their lifecycle is the conversation's
+	// conversation are exempt: their lifecycle is the conversation's
 	// (index-driven removal). Zero means no age limit.
 	MaxAge time.Duration
 	// MaxCount keeps only the newest MaxCount conversation-less dead
@@ -326,7 +326,7 @@ func (s *Store) Read(id string) (store.Session, error) {
 	// meta.json has no schema version, so fall back to the old keys when
 	// the new ones are absent. Write emits only the new keys.
 	// TODO(v2.1): drop this shim.
-	if ps.Adapter == "" || ps.ConversationFile == "" {
+	if ps.Adapter == "" || ps.ConversationRef == "" {
 		var legacy struct {
 			Kind        string `json:"kind"`
 			SessionFile string `json:"session_file"`
@@ -335,8 +335,8 @@ func (s *Store) Read(id string) (store.Session, error) {
 			if ps.Adapter == "" {
 				ps.Adapter = legacy.Kind
 			}
-			if ps.ConversationFile == "" {
-				ps.ConversationFile = legacy.SessionFile
+			if ps.ConversationRef == "" {
+				ps.ConversationRef = legacy.SessionFile
 			}
 		}
 	}
@@ -403,10 +403,10 @@ func (s *Store) WatchRemovals(events <-chan store.Event) {
 //   - non-directory entries under the base dir are ignored
 //
 // After loading, the whole-dir retention cap is applied to
-// conversation-less dead sessions (ConversationFile == ""): corpses older
+// conversation-less dead sessions (ConversationRef == ""): corpses older
 // than MaxAge are aged out, then only the newest MaxCount survive.
-// Sessions with a conversation file are exempt — they are retired only
-// when their conversation file disappears (see the conversations index
+// Sessions with a conversation ref are exempt — they are retired only
+// when their conversation disappears (see the conversations index
 // wiring in cmd/gmuxd). Pruned sessions are not returned. Scrollback
 // space is reclaimed separately by PruneScrollback.
 //
@@ -484,18 +484,18 @@ func effectiveTime(sess store.Session) (time.Time, bool) {
 
 // prune applies the whole-dir age/count cap to conversation-less dead
 // sessions and returns the survivors plus every session that has a
-// conversation file (exempt). Removes the on-disk dir of each loser.
+// conversation ref (exempt). Removes the on-disk dir of each loser.
 // A no-op when the policy disables both limits.
 func (s *Store) prune(loaded []store.Session) []store.Session {
 	if s.retention.MaxAge <= 0 && s.retention.MaxCount <= 0 {
 		return loaded
 	}
 
-	// Partition: sessions with a conversation file are never whole-dir
+	// Partition: sessions with a conversation ref are never whole-dir
 	// pruned here; their lifecycle is index-driven.
 	var exempt, corpses []store.Session
 	for _, sess := range loaded {
-		if sess.ConversationFile != "" {
+		if sess.ConversationRef != "" {
 			exempt = append(exempt, sess)
 		} else {
 			corpses = append(corpses, sess)

--- a/services/gmuxd/internal/sessionmeta/sessionmeta_retention_test.go
+++ b/services/gmuxd/internal/sessionmeta/sessionmeta_retention_test.go
@@ -458,7 +458,7 @@ func TestRemoveDeadByConversationRefDrivesWatchRemovals(t *testing.T) {
 	done := make(chan struct{})
 	go func() { metaStore.WatchRemovals(events); close(done) }()
 
-	if ids := sessions.RemoveDeadByConversationRef("/c/conv.jsonl"); len(ids) != 1 {
+	if ids := sessions.RemoveDeadByConversationRef("claude", "/c/conv.jsonl"); len(ids) != 1 {
 		t.Fatalf("expected 1 retired session, got %v", ids)
 	}
 

--- a/services/gmuxd/internal/sessionmeta/sessionmeta_retention_test.go
+++ b/services/gmuxd/internal/sessionmeta/sessionmeta_retention_test.go
@@ -14,10 +14,10 @@ import (
 // --- helpers -------------------------------------------------------
 
 // writeDead persists a dead session with the given id, ExitedAt and
-// ConversationFile so retention tests can stage corpses on disk.
+// ConversationRef so retention tests can stage corpses on disk.
 func writeDead(t *testing.T, s *Store, id, exitedAt, conversationFile string) {
 	t.Helper()
-	sess := store.Session{ID: id, Adapter: "shell", Alive: false, ExitedAt: exitedAt, ConversationFile: conversationFile}
+	sess := store.Session{ID: id, Adapter: "shell", Alive: false, ExitedAt: exitedAt, ConversationRef: conversationFile}
 	if err := s.Write(sess); err != nil {
 		t.Fatalf("Write %s: %v", id, err)
 	}
@@ -438,13 +438,13 @@ func TestPruneScrollbackCoalesces(t *testing.T) {
 	}
 }
 
-// TestRemoveDeadByConversationFileDrivesWatchRemovals pins the seam between
+// TestRemoveDeadByConversationRefDrivesWatchRemovals pins the seam between
 // the store broadcast and the meta persister: retiring a dead session
-// via RemoveDeadByConversationFile must, through the session-remove event
+// via RemoveDeadByConversationRef must, through the session-remove event
 // consumed by WatchRemovals, delete the on-disk meta dir.
-func TestRemoveDeadByConversationFileDrivesWatchRemovals(t *testing.T) {
+func TestRemoveDeadByConversationRefDrivesWatchRemovals(t *testing.T) {
 	metaStore := New(t.TempDir())
-	sess := store.Session{ID: "sess-dead1", Adapter: "claude", Alive: false, ConversationFile: "/c/conv.jsonl"}
+	sess := store.Session{ID: "sess-dead1", Adapter: "claude", Alive: false, ConversationRef: "/c/conv.jsonl"}
 	if err := metaStore.Write(sess); err != nil {
 		t.Fatal(err)
 	}
@@ -458,7 +458,7 @@ func TestRemoveDeadByConversationFileDrivesWatchRemovals(t *testing.T) {
 	done := make(chan struct{})
 	go func() { metaStore.WatchRemovals(events); close(done) }()
 
-	if ids := sessions.RemoveDeadByConversationFile("/c/conv.jsonl"); len(ids) != 1 {
+	if ids := sessions.RemoveDeadByConversationRef("/c/conv.jsonl"); len(ids) != 1 {
 		t.Fatalf("expected 1 retired session, got %v", ids)
 	}
 

--- a/services/gmuxd/internal/sessionmeta/sessionmeta_test.go
+++ b/services/gmuxd/internal/sessionmeta/sessionmeta_test.go
@@ -208,8 +208,8 @@ func TestReadLegacyPreV2Keys(t *testing.T) {
 	if got.Adapter != "pi" {
 		t.Errorf("Adapter = %q, want %q (legacy \"kind\" fallback)", got.Adapter, "pi")
 	}
-	if want := "/home/u/.pi/agent/sessions/x/conv.jsonl"; got.ConversationFile != want {
-		t.Errorf("SessionFile = %q, want %q (legacy \"session_file\" fallback)", got.ConversationFile, want)
+	if want := "/home/u/.pi/agent/sessions/x/conv.jsonl"; got.ConversationRef != want {
+		t.Errorf("SessionFile = %q, want %q (legacy \"session_file\" fallback)", got.ConversationRef, want)
 	}
 }
 
@@ -218,7 +218,7 @@ func TestReadLegacyPreV2Keys(t *testing.T) {
 func TestWriteEmitsOnlyNewKeys(t *testing.T) {
 	s := newStore(t)
 	sess := sampleSession()
-	sess.ConversationFile = "/tmp/conv.jsonl"
+	sess.ConversationRef = "/tmp/conv.jsonl"
 	if err := s.Write(sess); err != nil {
 		t.Fatalf("Write: %v", err)
 	}

--- a/services/gmuxd/internal/snapshot/snapshot.go
+++ b/services/gmuxd/internal/snapshot/snapshot.go
@@ -4,11 +4,11 @@
 // The protocol has two snapshot kinds plus one bare event:
 //
 //   - snapshot.sessions  full list of owned sessions (replaces the
-//                        per-event session-upsert / session-remove
-//                        stream of protocol 1).
+//     per-event session-upsert / session-remove
+//     stream of protocol 1).
 //   - snapshot.world     bundle of projects, peers, health, launchers
-//                        (replaces projects-update / peer-status).
-//                        Not sent to peer consumers.
+//     (replaces projects-update / peer-status).
+//     Not sent to peer consumers.
 //   - session-activity   bare {id} ping; lossy, not coalesced.
 //
 // Snapshots are composed lazily at emit time by a per-kind coalescer

--- a/services/gmuxd/internal/sseclient/client_test.go
+++ b/services/gmuxd/internal/sseclient/client_test.go
@@ -17,9 +17,9 @@ import (
 type sseServer struct {
 	*httptest.Server
 	mu         sync.Mutex
-	frames     []string   // frames queued for the next connection
-	expectAuth string     // if set, requires "Authorization: Bearer <expectAuth>"
-	clients    chan int   // signals "client connected" by sending 1
+	frames     []string      // frames queued for the next connection
+	expectAuth string        // if set, requires "Authorization: Bearer <expectAuth>"
+	clients    chan int      // signals "client connected" by sending 1
 	hold       chan struct{} // if set, server holds the stream open until closed
 }
 

--- a/services/gmuxd/internal/store/store.go
+++ b/services/gmuxd/internal/store/store.go
@@ -563,25 +563,27 @@ func (s *Store) Reconcile(assignFn func(Session) (slug string, index int)) {
 //   - all matches: the conversation→session mapping is N:1 (a conversation
 //     can be resumed in several runners), so every dead match is retired.
 //
-// Refs are compared after filepath.Clean: for file-backed adapters this
-// keeps a cosmetic difference (trailing slash, "./") between the
-// source-reported ref and the hook-reported ConversationRef from defeating
-// the match; for non-path refs (no separators) Clean is the identity, so
-// the comparison degrades to exact equality. Symlinks are not resolved:
-// the file is already gone, so EvalSymlinks couldn't run, and both paths
-// derive from the same real $HOME in practice.
+// Refs are compared by canonicalRef: exact equality, except that refs
+// which are rooted paths (today's file-backed adapters) are compared
+// after filepath.Clean so a cosmetic difference (trailing slash, "./")
+// between the source-reported ref and the hook-reported ConversationRef
+// doesn't defeat the match. Opaque refs are never normalized — an
+// adapter may legitimately use "a/../b" and "b" as distinct locators.
+// Symlinks are not resolved: the file is already gone, so EvalSymlinks
+// couldn't run, and both paths derive from the same real $HOME in
+// practice.
 func (s *Store) RemoveDeadByConversationRef(adapterName, ref string) []string {
 	if adapterName == "" || ref == "" {
 		return nil
 	}
-	target := filepath.Clean(ref)
+	target := canonicalRef(ref)
 	s.mu.Lock()
 	var removed []string
 	for id, sess := range s.sessions {
 		if sess.Adapter != adapterName || sess.Peer != "" || sess.Alive || sess.ConversationRef == "" {
 			continue
 		}
-		if filepath.Clean(sess.ConversationRef) != target {
+		if canonicalRef(sess.ConversationRef) != target {
 			continue
 		}
 		delete(s.sessions, id)
@@ -593,6 +595,21 @@ func (s *Store) RemoveDeadByConversationRef(adapterName, ref string) []string {
 		s.broadcast(Event{Type: "session-remove", ID: id})
 	}
 	return removed
+}
+
+// canonicalRef returns the comparison form of a conversation ref (ADR
+// 0022). Refs are opaque, so the daemon must not interpret them — with
+// one narrow, deliberate exception: a ref that is a rooted path is a
+// file-backed adapter's transcript path, where the hook-reported and
+// watcher-reported spellings can differ cosmetically ("./", trailing
+// slash), so those are compared after filepath.Clean. Anything else is
+// returned verbatim: normalizing an opaque ref could conflate locators
+// the adapter considers distinct (e.g. "a/../b" vs "b").
+func canonicalRef(ref string) string {
+	if filepath.IsAbs(ref) {
+		return filepath.Clean(ref)
+	}
+	return ref
 }
 
 // RemoveByPeer removes all sessions belonging to a peer and broadcasts

--- a/services/gmuxd/internal/store/store.go
+++ b/services/gmuxd/internal/store/store.go
@@ -65,17 +65,21 @@ type Session struct {
 	TerminalCols   uint16 `json:"terminal_cols,omitempty"`
 	TerminalRows   uint16 `json:"terminal_rows,omitempty"`
 	// Slug is a human-readable stable identifier derived from the
-	// adapter's conversation file slug. Used for URL routing (the frontend
+	// adapter's conversation-derived slug. Used for URL routing (the frontend
 	// falls back to id[:8] when empty) and for matching dead sessions
 	// to project membership arrays. Unique within (adapter, peer).
 	Slug string `json:"slug,omitempty"`
 
-	// ConversationFile is the conversation file this runner authoritatively
-	// writes, as reported by the agent hook (session → file; ADR 0011).
-	// Two live sessions may carry the same ConversationFile when the same
+	// ConversationRef is the opaque, adapter-scoped ref of the conversation
+	// this runner authoritatively writes, as reported by the agent hook
+	// (session → conversation; ADR 0011). The daemon never interprets it —
+	// only the owning adapter does (today's file-backed adapters use the
+	// transcript's absolute path; a DB-backed adapter may use a row key).
+	// Two live sessions may carry the same ConversationRef when the same
 	// conversation is resumed in more than one tab; the frontend groups
 	// by this to warn about a conversation open in multiple runners.
-	ConversationFile string `json:"conversation_file,omitempty"`
+	// The wire/persisted key stays "conversation_file" for compatibility.
+	ConversationRef string `json:"conversation_file,omitempty"`
 
 	// RunnerVersion is the version string of the gmux runner binary that
 	// launched this session. Set by the runner at startup. The frontend
@@ -121,35 +125,35 @@ type Session struct {
 // fields (ShellTitle, AdapterTitle) that are resolved into Title before sending.
 func (s Session) MarshalJSON() ([]byte, error) {
 	type wire struct {
-		ID               string            `json:"id"`
-		Peer             string            `json:"peer,omitempty"`
-		CreatedAt        string            `json:"created_at,omitempty"`
-		Command          []string          `json:"command,omitempty"`
-		Cwd              string            `json:"cwd,omitempty"`
-		Adapter          string            `json:"adapter"`
-		WorkspaceRoot    string            `json:"workspace_root,omitempty"`
-		Remotes          map[string]string `json:"remotes,omitempty"`
-		ParentSessionID  string            `json:"parent_session_id,omitempty"`
-		Alive            bool              `json:"alive"`
-		Pid              int               `json:"pid,omitempty"`
-		ExitCode         *int              `json:"exit_code,omitempty"`
-		StartedAt        string            `json:"started_at,omitempty"`
-		ExitedAt         string            `json:"exited_at,omitempty"`
-		Title            string            `json:"title,omitempty"`
-		Subtitle         string            `json:"subtitle,omitempty"`
-		Status           *Status           `json:"status"`
-		Unread           bool              `json:"unread"`
-		Resumable        bool              `json:"resumable,omitempty"`
-		SocketPath       string            `json:"socket_path,omitempty"`
-		TerminalCols     uint16            `json:"terminal_cols,omitempty"`
-		TerminalRows     uint16            `json:"terminal_rows,omitempty"`
-		Slug             string            `json:"slug,omitempty"`
-		ConversationFile string            `json:"conversation_file,omitempty"`
-		RunnerVersion    string            `json:"runner_version,omitempty"`
-		BinaryHash       string            `json:"binary_hash,omitempty"`
-		ProjectSlug      string            `json:"project_slug,omitempty"`
-		ProjectIndex     int               `json:"project_index,omitempty"`
-		LastActivityAt   string            `json:"last_activity_at,omitempty"`
+		ID              string            `json:"id"`
+		Peer            string            `json:"peer,omitempty"`
+		CreatedAt       string            `json:"created_at,omitempty"`
+		Command         []string          `json:"command,omitempty"`
+		Cwd             string            `json:"cwd,omitempty"`
+		Adapter         string            `json:"adapter"`
+		WorkspaceRoot   string            `json:"workspace_root,omitempty"`
+		Remotes         map[string]string `json:"remotes,omitempty"`
+		ParentSessionID string            `json:"parent_session_id,omitempty"`
+		Alive           bool              `json:"alive"`
+		Pid             int               `json:"pid,omitempty"`
+		ExitCode        *int              `json:"exit_code,omitempty"`
+		StartedAt       string            `json:"started_at,omitempty"`
+		ExitedAt        string            `json:"exited_at,omitempty"`
+		Title           string            `json:"title,omitempty"`
+		Subtitle        string            `json:"subtitle,omitempty"`
+		Status          *Status           `json:"status"`
+		Unread          bool              `json:"unread"`
+		Resumable       bool              `json:"resumable,omitempty"`
+		SocketPath      string            `json:"socket_path,omitempty"`
+		TerminalCols    uint16            `json:"terminal_cols,omitempty"`
+		TerminalRows    uint16            `json:"terminal_rows,omitempty"`
+		Slug            string            `json:"slug,omitempty"`
+		ConversationRef string            `json:"conversation_file,omitempty"`
+		RunnerVersion   string            `json:"runner_version,omitempty"`
+		BinaryHash      string            `json:"binary_hash,omitempty"`
+		ProjectSlug     string            `json:"project_slug,omitempty"`
+		ProjectIndex    int               `json:"project_index,omitempty"`
+		LastActivityAt  string            `json:"last_activity_at,omitempty"`
 	}
 	return json.Marshal(wire{
 		ID: s.ID, Peer: s.Peer, CreatedAt: s.CreatedAt, Command: s.Command,
@@ -161,8 +165,8 @@ func (s Session) MarshalJSON() ([]byte, error) {
 		Unread: s.Unread, Resumable: s.Resumable,
 		SocketPath: s.SocketPath, TerminalCols: s.TerminalCols,
 		TerminalRows: s.TerminalRows, Slug: s.Slug,
-		ConversationFile: s.ConversationFile,
-		RunnerVersion:    s.RunnerVersion, BinaryHash: s.BinaryHash,
+		ConversationRef: s.ConversationRef,
+		RunnerVersion:   s.RunnerVersion, BinaryHash: s.BinaryHash,
 		ProjectSlug: s.ProjectSlug, ProjectIndex: s.ProjectIndex,
 		LastActivityAt: s.LastActivityAt,
 	})
@@ -540,38 +544,40 @@ func (s *Store) Reconcile(assignFn func(Session) (slug string, index int)) {
 	}
 }
 
-// RemoveDeadByConversationFile retires every locally-owned, dead session
-// whose ConversationFile points at path, broadcasting session-remove for
+// RemoveDeadByConversationRef retires every locally-owned, dead session
+// whose ConversationRef matches ref, broadcasting session-remove for
 // each and returning the removed IDs. Used when the conversations
-// index reports a conversation file has disappeared: meta.json mirrors
-// conversation existence (ADR 0016), so the backing file going away
-// retires the sidebar entry.
+// index reports a conversation has disappeared: meta.json mirrors
+// conversation existence (ADR 0016), so the backing conversation going
+// away retires the sidebar entry.
 //
 // Guards, all load-bearing:
 //   - !Alive: a live runner may still be writing this conversation; its
 //     record is authoritative and must not be torn down here.
 //   - Peer == "": peer-owned records are re-received from the spoke; the
 //     hub doesn't own their lifecycle.
-//   - all matches: the file→session mapping is N:1 (a conversation can be
-//     resumed in several runners), so every dead match is retired.
+//   - all matches: the conversation→session mapping is N:1 (a conversation
+//     can be resumed in several runners), so every dead match is retired.
 //
-// Paths are compared after filepath.Clean so a cosmetic difference
-// (trailing slash, "./") between the watcher-reported path and the
-// hook-reported ConversationFile doesn't defeat the match. Symlinks are not
-// resolved: the file is already gone, so EvalSymlinks couldn't run, and
-// both paths derive from the same real $HOME in practice.
-func (s *Store) RemoveDeadByConversationFile(path string) []string {
-	if path == "" {
+// Refs are compared after filepath.Clean: for file-backed adapters this
+// keeps a cosmetic difference (trailing slash, "./") between the
+// source-reported ref and the hook-reported ConversationRef from defeating
+// the match; for non-path refs (no separators) Clean is the identity, so
+// the comparison degrades to exact equality. Symlinks are not resolved:
+// the file is already gone, so EvalSymlinks couldn't run, and both paths
+// derive from the same real $HOME in practice.
+func (s *Store) RemoveDeadByConversationRef(ref string) []string {
+	if ref == "" {
 		return nil
 	}
-	target := filepath.Clean(path)
+	target := filepath.Clean(ref)
 	s.mu.Lock()
 	var removed []string
 	for id, sess := range s.sessions {
-		if sess.Peer != "" || sess.Alive || sess.ConversationFile == "" {
+		if sess.Peer != "" || sess.Alive || sess.ConversationRef == "" {
 			continue
 		}
-		if filepath.Clean(sess.ConversationFile) != target {
+		if filepath.Clean(sess.ConversationRef) != target {
 			continue
 		}
 		delete(s.sessions, id)

--- a/services/gmuxd/internal/store/store.go
+++ b/services/gmuxd/internal/store/store.go
@@ -545,13 +545,17 @@ func (s *Store) Reconcile(assignFn func(Session) (slug string, index int)) {
 }
 
 // RemoveDeadByConversationRef retires every locally-owned, dead session
-// whose ConversationRef matches ref, broadcasting session-remove for
-// each and returning the removed IDs. Used when the conversations
-// index reports a conversation has disappeared: meta.json mirrors
-// conversation existence (ADR 0016), so the backing conversation going
-// away retires the sidebar entry.
+// of the given adapter whose ConversationRef matches ref, broadcasting
+// session-remove for each and returning the removed IDs. Used when the
+// conversations index reports a conversation has disappeared: meta.json
+// mirrors conversation existence (ADR 0016), so the backing conversation
+// going away retires the sidebar entry.
 //
 // Guards, all load-bearing:
+//   - Adapter match: refs are only unique within an adapter (ADR 0022:
+//     opaque, adapter-scoped), so adapter A reporting ref "x" deleted must
+//     never retire adapter B's session that happens to carry the same
+//     ref string.
 //   - !Alive: a live runner may still be writing this conversation; its
 //     record is authoritative and must not be torn down here.
 //   - Peer == "": peer-owned records are re-received from the spoke; the
@@ -566,15 +570,15 @@ func (s *Store) Reconcile(assignFn func(Session) (slug string, index int)) {
 // the comparison degrades to exact equality. Symlinks are not resolved:
 // the file is already gone, so EvalSymlinks couldn't run, and both paths
 // derive from the same real $HOME in practice.
-func (s *Store) RemoveDeadByConversationRef(ref string) []string {
-	if ref == "" {
+func (s *Store) RemoveDeadByConversationRef(adapterName, ref string) []string {
+	if adapterName == "" || ref == "" {
 		return nil
 	}
 	target := filepath.Clean(ref)
 	s.mu.Lock()
 	var removed []string
 	for id, sess := range s.sessions {
-		if sess.Peer != "" || sess.Alive || sess.ConversationRef == "" {
+		if sess.Adapter != adapterName || sess.Peer != "" || sess.Alive || sess.ConversationRef == "" {
 			continue
 		}
 		if filepath.Clean(sess.ConversationRef) != target {

--- a/services/gmuxd/internal/store/store_test.go
+++ b/services/gmuxd/internal/store/store_test.go
@@ -111,6 +111,10 @@ func TestRemoveDeadByConversationRefOpaque(t *testing.T) {
 	s.Upsert(Session{ID: "dead", Adapter: "dbtool", Alive: false, ConversationRef: "row:42"})
 	s.Upsert(Session{ID: "near", Adapter: "dbtool", Alive: false, ConversationRef: "row:421"})
 	s.Upsert(Session{ID: "other-adapter", Adapter: "othertool", Alive: false, ConversationRef: "row:42"})
+	// Distinct opaque refs that a path-Clean would conflate: the daemon
+	// must not canonicalize non-rooted refs (they're not paths).
+	s.Upsert(Session{ID: "plain", Adapter: "dbtool", Alive: false, ConversationRef: "b"})
+	s.Upsert(Session{ID: "dotted", Adapter: "dbtool", Alive: false, ConversationRef: "a/../b"})
 
 	removed := s.RemoveDeadByConversationRef("dbtool", "row:42")
 	if len(removed) != 1 || removed[0] != "dead" {
@@ -121,6 +125,16 @@ func TestRemoveDeadByConversationRefOpaque(t *testing.T) {
 	}
 	if _, ok := s.Get("other-adapter"); !ok {
 		t.Error("another adapter's session with the same ref string must survive")
+	}
+
+	// Removing "a/../b" must not conflate with "b": opaque refs compare
+	// exactly, never path-normalized.
+	removed = s.RemoveDeadByConversationRef("dbtool", "a/../b")
+	if len(removed) != 1 || removed[0] != "dotted" {
+		t.Fatalf("expected exactly [dotted] removed, got %v", removed)
+	}
+	if _, ok := s.Get("plain"); !ok {
+		t.Error("opaque ref \"b\" must survive removal of \"a/../b\"")
 	}
 }
 

--- a/services/gmuxd/internal/store/store_test.go
+++ b/services/gmuxd/internal/store/store_test.go
@@ -65,21 +65,21 @@ func TestRemove(t *testing.T) {
 	}
 }
 
-func TestRemoveDeadByConversationFile(t *testing.T) {
+func TestRemoveDeadByConversationRef(t *testing.T) {
 	const file = "/home/u/.claude/projects/abc/conv.jsonl"
 	s := New()
 	// Two dead sessions share the file (N:1, e.g. resumed in two tabs).
-	s.Upsert(Session{ID: "dead-1", Adapter: "claude", Alive: false, ConversationFile: file})
-	s.Upsert(Session{ID: "dead-2", Adapter: "claude", Alive: false, ConversationFile: file})
+	s.Upsert(Session{ID: "dead-1", Adapter: "claude", Alive: false, ConversationRef: file})
+	s.Upsert(Session{ID: "dead-2", Adapter: "claude", Alive: false, ConversationRef: file})
 	// A live session on the same file must survive (runner still writing).
-	s.Upsert(Session{ID: "live", Adapter: "claude", Alive: true, ConversationFile: file})
+	s.Upsert(Session{ID: "live", Adapter: "claude", Alive: true, ConversationRef: file})
 	// A peer-owned dead session on the same file is not ours to retire.
-	s.Upsert(Session{ID: "peer", Adapter: "claude", Alive: false, Peer: "box2", ConversationFile: file})
+	s.Upsert(Session{ID: "peer", Adapter: "claude", Alive: false, Peer: "box2", ConversationRef: file})
 	// An unrelated dead session must be untouched.
-	s.Upsert(Session{ID: "other", Adapter: "claude", Alive: false, ConversationFile: "/home/u/.claude/projects/xyz/other.jsonl"})
+	s.Upsert(Session{ID: "other", Adapter: "claude", Alive: false, ConversationRef: "/home/u/.claude/projects/xyz/other.jsonl"})
 
 	// Cosmetic path difference must still match (filepath.Clean).
-	removed := s.RemoveDeadByConversationFile("/home/u/.claude/projects/abc/./conv.jsonl")
+	removed := s.RemoveDeadByConversationRef("/home/u/.claude/projects/abc/./conv.jsonl")
 
 	got := map[string]bool{}
 	for _, id := range removed {
@@ -100,13 +100,31 @@ func TestRemoveDeadByConversationFile(t *testing.T) {
 	}
 }
 
-func TestRemoveDeadByConversationFileNoMatch(t *testing.T) {
+// Non-path refs (a DB-backed adapter's row keys — ADR 0022) must match by
+// exact equality: the filepath.Clean normalization used for cosmetic path
+// variance has to be the identity for separator-free refs, and near-miss
+// refs must not be conflated.
+func TestRemoveDeadByConversationRefOpaque(t *testing.T) {
 	s := New()
-	s.Upsert(Session{ID: "a", Adapter: "claude", Alive: false, ConversationFile: "/x/a.jsonl"})
-	if got := s.RemoveDeadByConversationFile("/x/missing.jsonl"); got != nil {
+	s.Upsert(Session{ID: "dead", Adapter: "dbtool", Alive: false, ConversationRef: "row:42"})
+	s.Upsert(Session{ID: "near", Adapter: "dbtool", Alive: false, ConversationRef: "row:421"})
+
+	removed := s.RemoveDeadByConversationRef("row:42")
+	if len(removed) != 1 || removed[0] != "dead" {
+		t.Fatalf("expected exactly [dead] removed, got %v", removed)
+	}
+	if _, ok := s.Get("near"); !ok {
+		t.Error("near-miss ref row:421 must survive a row:42 removal")
+	}
+}
+
+func TestRemoveDeadByConversationRefNoMatch(t *testing.T) {
+	s := New()
+	s.Upsert(Session{ID: "a", Adapter: "claude", Alive: false, ConversationRef: "/x/a.jsonl"})
+	if got := s.RemoveDeadByConversationRef("/x/missing.jsonl"); got != nil {
 		t.Errorf("no-match should return nil, got %v", got)
 	}
-	if got := s.RemoveDeadByConversationFile(""); got != nil {
+	if got := s.RemoveDeadByConversationRef(""); got != nil {
 		t.Errorf("empty path should return nil, got %v", got)
 	}
 	if _, ok := s.Get("a"); !ok {
@@ -114,15 +132,15 @@ func TestRemoveDeadByConversationFileNoMatch(t *testing.T) {
 	}
 }
 
-// TestRemoveDeadByConversationFileBroadcasts pins that retirement emits one
+// TestRemoveDeadByConversationRefBroadcasts pins that retirement emits one
 // session-remove per removed session (so WatchRemovals drops the dir).
-func TestRemoveDeadByConversationFileBroadcasts(t *testing.T) {
+func TestRemoveDeadByConversationRefBroadcasts(t *testing.T) {
 	s := New()
-	s.Upsert(Session{ID: "dead", Adapter: "claude", Alive: false, ConversationFile: "/x/c.jsonl"})
+	s.Upsert(Session{ID: "dead", Adapter: "claude", Alive: false, ConversationRef: "/x/c.jsonl"})
 	ch, cancel := s.Subscribe()
 	defer cancel()
 
-	s.RemoveDeadByConversationFile("/x/c.jsonl")
+	s.RemoveDeadByConversationRef("/x/c.jsonl")
 
 	ev, ok := recvEvent(t, ch)
 	if !ok || ev.Type != "session-remove" || ev.ID != "dead" {
@@ -997,15 +1015,15 @@ func TestUpsertRemote_BroadcastsEvent(t *testing.T) {
 
 func TestSessionMarshalJSON_WireFormat(t *testing.T) {
 	s := Session{
-		ID:               "sess-abc",
-		Adapter:          "pi",
-		Alive:            true,
-		RunnerVersion:    "1.2.0",
-		BinaryHash:       "aabbccdd",
-		ShellTitle:       "internal-only",
-		AdapterTitle:     "internal-only",
-		Slug:             "my-slug",
-		ConversationFile: "/home/u/.pi/agent/sessions/x/conv.jsonl",
+		ID:              "sess-abc",
+		Adapter:         "pi",
+		Alive:           true,
+		RunnerVersion:   "1.2.0",
+		BinaryHash:      "aabbccdd",
+		ShellTitle:      "internal-only",
+		AdapterTitle:    "internal-only",
+		Slug:            "my-slug",
+		ConversationRef: "/home/u/.pi/agent/sessions/x/conv.jsonl",
 	}
 	b, err := json.Marshal(s)
 	if err != nil {
@@ -1120,37 +1138,37 @@ func TestSessionMarshalJSON_AllFieldsAppearOnWire(t *testing.T) {
 func fullyPopulatedSession() Session {
 	exit := 0
 	return Session{
-		ID:               "sess-full",
-		Peer:             "peer-x",
-		CreatedAt:        "2026-01-01T00:00:00Z",
-		Command:          []string{"bash"},
-		Cwd:              "/tmp/work",
-		Adapter:          "pi",
-		WorkspaceRoot:    "/tmp/work",
-		Remotes:          map[string]string{"origin": "github.com/x/y"},
-		ParentSessionID:  "sess-parent",
-		Alive:            true,
-		Pid:              42,
-		ExitCode:         &exit,
-		StartedAt:        "2026-01-01T00:00:01Z",
-		ExitedAt:         "2026-01-01T00:00:02Z",
-		Title:            "t",
-		Subtitle:         "s",
-		Status:           &Status{Working: true, Error: true},
-		Unread:           true,
-		LastActivityAt:   "2026-01-01T00:00:03Z",
-		Resumable:        true,
-		SocketPath:       "/tmp/sock",
-		TerminalCols:     80,
-		TerminalRows:     24,
-		Slug:             "slug",
-		ConversationFile: "/home/u/.pi/sess.jsonl",
-		RunnerVersion:    "v1",
-		BinaryHash:       "hash",
-		ShellTitle:       "shell-internal",
-		AdapterTitle:     "adapter-internal",
-		ProjectSlug:      "proj",
-		ProjectIndex:     3,
+		ID:              "sess-full",
+		Peer:            "peer-x",
+		CreatedAt:       "2026-01-01T00:00:00Z",
+		Command:         []string{"bash"},
+		Cwd:             "/tmp/work",
+		Adapter:         "pi",
+		WorkspaceRoot:   "/tmp/work",
+		Remotes:         map[string]string{"origin": "github.com/x/y"},
+		ParentSessionID: "sess-parent",
+		Alive:           true,
+		Pid:             42,
+		ExitCode:        &exit,
+		StartedAt:       "2026-01-01T00:00:01Z",
+		ExitedAt:        "2026-01-01T00:00:02Z",
+		Title:           "t",
+		Subtitle:        "s",
+		Status:          &Status{Working: true, Error: true},
+		Unread:          true,
+		LastActivityAt:  "2026-01-01T00:00:03Z",
+		Resumable:       true,
+		SocketPath:      "/tmp/sock",
+		TerminalCols:    80,
+		TerminalRows:    24,
+		Slug:            "slug",
+		ConversationRef: "/home/u/.pi/sess.jsonl",
+		RunnerVersion:   "v1",
+		BinaryHash:      "hash",
+		ShellTitle:      "shell-internal",
+		AdapterTitle:    "adapter-internal",
+		ProjectSlug:     "proj",
+		ProjectIndex:    3,
 	}
 }
 

--- a/services/gmuxd/internal/store/store_test.go
+++ b/services/gmuxd/internal/store/store_test.go
@@ -79,7 +79,7 @@ func TestRemoveDeadByConversationRef(t *testing.T) {
 	s.Upsert(Session{ID: "other", Adapter: "claude", Alive: false, ConversationRef: "/home/u/.claude/projects/xyz/other.jsonl"})
 
 	// Cosmetic path difference must still match (filepath.Clean).
-	removed := s.RemoveDeadByConversationRef("/home/u/.claude/projects/abc/./conv.jsonl")
+	removed := s.RemoveDeadByConversationRef("claude", "/home/u/.claude/projects/abc/./conv.jsonl")
 
 	got := map[string]bool{}
 	for _, id := range removed {
@@ -101,30 +101,36 @@ func TestRemoveDeadByConversationRef(t *testing.T) {
 }
 
 // Non-path refs (a DB-backed adapter's row keys — ADR 0022) must match by
-// exact equality: the filepath.Clean normalization used for cosmetic path
-// variance has to be the identity for separator-free refs, and near-miss
-// refs must not be conflated.
+// exact equality within the reporting adapter: the filepath.Clean
+// normalization used for cosmetic path variance has to be the identity for
+// separator-free refs, near-miss refs must not be conflated, and — refs
+// being only unique within an adapter — another adapter's session carrying
+// the same ref string must survive.
 func TestRemoveDeadByConversationRefOpaque(t *testing.T) {
 	s := New()
 	s.Upsert(Session{ID: "dead", Adapter: "dbtool", Alive: false, ConversationRef: "row:42"})
 	s.Upsert(Session{ID: "near", Adapter: "dbtool", Alive: false, ConversationRef: "row:421"})
+	s.Upsert(Session{ID: "other-adapter", Adapter: "othertool", Alive: false, ConversationRef: "row:42"})
 
-	removed := s.RemoveDeadByConversationRef("row:42")
+	removed := s.RemoveDeadByConversationRef("dbtool", "row:42")
 	if len(removed) != 1 || removed[0] != "dead" {
 		t.Fatalf("expected exactly [dead] removed, got %v", removed)
 	}
 	if _, ok := s.Get("near"); !ok {
 		t.Error("near-miss ref row:421 must survive a row:42 removal")
 	}
+	if _, ok := s.Get("other-adapter"); !ok {
+		t.Error("another adapter's session with the same ref string must survive")
+	}
 }
 
 func TestRemoveDeadByConversationRefNoMatch(t *testing.T) {
 	s := New()
 	s.Upsert(Session{ID: "a", Adapter: "claude", Alive: false, ConversationRef: "/x/a.jsonl"})
-	if got := s.RemoveDeadByConversationRef("/x/missing.jsonl"); got != nil {
+	if got := s.RemoveDeadByConversationRef("claude", "/x/missing.jsonl"); got != nil {
 		t.Errorf("no-match should return nil, got %v", got)
 	}
-	if got := s.RemoveDeadByConversationRef(""); got != nil {
+	if got := s.RemoveDeadByConversationRef("claude", ""); got != nil {
 		t.Errorf("empty path should return nil, got %v", got)
 	}
 	if _, ok := s.Get("a"); !ok {
@@ -140,7 +146,7 @@ func TestRemoveDeadByConversationRefBroadcasts(t *testing.T) {
 	ch, cancel := s.Subscribe()
 	defer cancel()
 
-	s.RemoveDeadByConversationRef("/x/c.jsonl")
+	s.RemoveDeadByConversationRef("claude", "/x/c.jsonl")
 
 	ev, ok := recvEvent(t, ch)
 	if !ok || ev.Type != "session-remove" || ev.ID != "dead" {

--- a/services/gmuxd/internal/storegc/scanner.go
+++ b/services/gmuxd/internal/storegc/scanner.go
@@ -1,10 +1,10 @@
-// Package sessionfiles provides periodic maintenance for the session
+// Package storegc provides periodic maintenance for the session
 // store: purging ephemeral dead sessions that were never attributed
-// to a conversation file.
+// to a conversation.
 //
-// File-backed conversation discovery is handled by the conversations
-// package. This package only handles cleanup.
-package sessionfiles
+// Conversation discovery is handled by the conversations package (fed
+// by adapter ConversationSources). This package only handles cleanup.
+package storegc
 
 import (
 	"log"
@@ -51,7 +51,7 @@ func (sc *Scanner) Run(interval time.Duration, stop <-chan struct{}) {
 
 // PurgeStaleSessions removes dead sessions that have no slug and
 // are older than maxAge. These are short-lived sessions that exited
-// without ever being attributed to a conversation file.
+// without ever being attributed to a conversation.
 func (sc *Scanner) PurgeStaleSessions(maxAge time.Duration) {
 	now := time.Now().UTC()
 	for _, s := range sc.store.List() {
@@ -63,7 +63,7 @@ func (sc *Scanner) PurgeStaleSessions(maxAge time.Duration) {
 			continue
 		}
 		if now.Sub(exited) > maxAge {
-			log.Printf("sessionfiles: purging stale session %s (exited %s ago)", s.ID, now.Sub(exited).Round(time.Second))
+			log.Printf("storegc: purging stale session %s (exited %s ago)", s.ID, now.Sub(exited).Round(time.Second))
 			sc.store.Remove(s.ID)
 		}
 	}

--- a/services/gmuxd/internal/storegc/scanner_test.go
+++ b/services/gmuxd/internal/storegc/scanner_test.go
@@ -1,4 +1,4 @@
-package sessionfiles
+package storegc
 
 import (
 	"testing"

--- a/services/gmuxd/internal/update/update_test.go
+++ b/services/gmuxd/internal/update/update_test.go
@@ -13,9 +13,9 @@ func TestNewer(t *testing.T) {
 		{"v0.4.6", "v0.4.6", false},
 		{"v0.4.5", "v0.4.6", false},
 		{"v0.3.0", "v0.4.6", false},
-		{"0.5.0", "0.4.6", true},    // no prefix
-		{"dev", "v0.4.6", false},     // unparseable
-		{"v0.4.6", "dev", false},     // unparseable
+		{"0.5.0", "0.4.6", true}, // no prefix
+		{"dev", "v0.4.6", false}, // unparseable
+		{"v0.4.6", "dev", false}, // unparseable
 	}
 	for _, tt := range tests {
 		got := newer(tt.a, tt.b)


### PR DESCRIPTION
## What

Cleanup pass before fulltext search builds on the conversation interfaces: everywhere above the adapter, conversations are now located by an **opaque, adapter-scoped ref string** instead of a file path. For pi/claude/codex the ref *is* the transcript's absolute path — but that is now the adapter's private convention, so a future DB-backed adapter (e.g. opencode) slots in with zero daemon changes, as ADR 0014 promised.

Design + full violation audit: **`docs/adr/0022-adapter-opaque-conversation-refs.md`** (ADR 0014 amended to point at it).

## Changes

**`packages/adapter`**
- `ConversationFiler` → `ConversationDescriber` (`DescribeConversation(ref)`); `ConversationRootDir`/`ConversationDir` are no longer part of any daemon-facing interface (they stay as concrete file-adapter methods).
- New `ConversationOpener` (`OpenConversation(ref) → io.ReadCloser`) — the content seam for the upcoming fulltext-search index.
- `ConversationInfo`: `FilePath` → `Ref`; new **`LastActivity`** (adapter-provided freshness; file adapters return the transcript mtime via a shared helper — consumers never stat).
- `ConversationSink`/`ConversationProber`/`Resumer.CanResume` re-typed/re-documented to opaque refs.

**`services/gmuxd`**
- `conversations.Index`: `Info.Ref` + `Info.LastActivity`, `Scan(a, ref)` via the describer, `RemoveByRef(adapter, ref)`.
- Removal paths are **(adapter, ref)-scoped** (review follow-up): refs are only unique within an adapter, so `RemoveByRef`, `RemoveDeadByConversationRef`, the source sink's retirement callback, and `reconcileDeletedConversations` all carry the owning adapter — two adapters sharing a ref string can never delete each other's conversations. (Absolute paths made that collision impossible by accident; opaque refs make the scoping explicit.)
- Ref comparison is **exact** (review follow-up): `canonicalRef` applies `filepath.Clean` only to rooted-path refs (cosmetic hook-vs-watcher spelling variance of the same transcript); opaque refs are never normalized, so `a/../b` and `b` stay distinct.
- **Activity reseed rebased onto merged #393**: `activitySeedFor` no longer stats `ConversationFile` — its primary source is the owning adapter's `DescribeConversation(ref).LastActivity` (for file adapters still the transcript mtime, now as the adapter's detail), with the daemon-owned scrollback tee (ADR 0016) as the fallback. A DB-backed adapter reseeds identically.
- `store.Session.ConversationFile` → `ConversationRef`; resume + retention key off refs and hand them back to the owning adapter.
- `internal/sessionfiles` → `internal/storegc` (the package purges stale sessions; it had nothing to do with files).

**`cli/gmux`**: `session.State.ConversationRef` rename (runner side).

**Docs**: ADR 0022, ADR 0014 amendment, UBIQUITOUS_LANGUAGE gains **Conversation Ref**; website contributor docs (adapter-architecture, writing-adapters, planned/opencode-adapter, state-management) and `docs/runner-hook-protocol.md` rewritten against the new contract.

## Tests

Beyond mechanically-updated existing suites, new contract tests lock the seam:
- **conversations**: a fake DB-backed adapter with row-key refs (`row:42`) flows through `Index.Scan`/`RemoveByRef` end to end — ref echoed unmodified, adapter-provided `LastActivity` carried, resume by ID; unresolvable refs are not indexed. Cross-adapter same-ref removal regression cases at index, store, and sink layers.
- **store**: `RemoveDeadByConversationRef` matches non-path refs by exact equality within the reporting adapter — near-miss refs, cross-adapter same-ref sessions, and Clean-conflatable pairs (`a/../b` vs `b`) all survive.
- **pi adapter**: `DescribeConversation` echoes `Ref` and reports `LastActivity` from the transcript mtime; `OpenConversation` streams the raw transcript.
- **activity reseed**: seeds from adapter-reported `LastActivity` (real pi transcript), falls back to the scrollback tee for unknown/describer-less adapters instead of erroring.

## Compatibility

Behavior-preserving; **no wire or on-disk format changes**. The JSON key `conversation_file` (store, /meta, meta.json) and the runner's `conversation_file` /events event are kept as legacy names carrying a ref; the pre-v2 `session_file` shims are untouched.

## Testing

`go build`, `go vet`, `go test ./...` green across all workspace modules.
