### PR TITLE
feat: key project membership by session id; conversation-lineage takeover (ADR 0024)

### DIFF
--- a/UBIQUITOUS_LANGUAGE.md
+++ b/UBIQUITOUS_LANGUAGE.md
@@ -128,7 +128,7 @@ The four stores have orthogonal concerns. Mixing them is a smell:
 
 - **"State"** has been overloaded across **Store** (in-memory), **Sessionmeta** (per-session runtime fields on disk), **adapter state files** (per-adapter on-disk records), and the runtime Alive/Dead/Resumable. Always qualify which one.
 
-- **"Identity"**: in this codebase, **Slug** is identity, **Session ID** is instance. Treat them as distinct columns even though `SessionKey` coalesces them for projects.json's purposes.
+- **"Identity"**: a **Session ID** is the durable identity of a session and the projects.json membership key. A **session slug** is a mutable display/URL name; treat them as distinct columns.
 
 - **"Local"** has two meanings: the local *machine* (where this gmuxd runs), and a **Local peer** (`PeerConfig.Local = true`, currently devcontainers only). Prefer **Local peer** for the latter to avoid collision with "the local daemon".
 

--- a/apps/gmux-web/src/projects.test.ts
+++ b/apps/gmux-web/src/projects.test.ts
@@ -578,12 +578,12 @@ describe('reorderKeysForFolder', () => {
     expect(reorderKeysForFolder(sessions, 'tower')).toEqual(['a', 'b'])
   })
 
-  it('peer folder: keeps slug as-is for slugged sessions', () => {
+  it('peer folder: strips @<peer> namespace from titled session ids', () => {
     const sessions = [
       makeSession({ id: 'a@tower', cwd: '/x', slug: 'fix-auth', peer: 'tower' }),
       makeSession({ id: 'b@tower', cwd: '/x', slug: 'login-page', peer: 'tower' }),
     ]
-    expect(reorderKeysForFolder(sessions, 'tower')).toEqual(['fix-auth', 'login-page'])
+    expect(reorderKeysForFolder(sessions, 'tower')).toEqual(['a', 'b'])
   })
 
   it('local folder: drops adopted peer-owned sessions', () => {
@@ -597,7 +597,7 @@ describe('reorderKeysForFolder', () => {
       makeSession({ id: 'local-2', cwd: '/x', slug: '' }),
     ]
     expect(reorderKeysForFolder(sessions, undefined))
-      .toEqual(['fix-auth', 'local-2'])
+      .toEqual(['local-1', 'local-2'])
   })
 
   it('returns empty when no session matches the folder owner', () => {
@@ -624,15 +624,13 @@ describe('reorderKeysForFolder', () => {
       .toEqual(['sess-1', 'sess-2@container'])
   })
 
-  it('local folder + Local peer: slug takes precedence over namespaced id', () => {
-    // A container session that's been attribution-resolved (e.g.
-    // claude/codex) keys by slug, not id, in projects.json.
+  it('local folder + Local peer: keeps namespaced id for titled sessions', () => {
     const sessions = [
       makeSession({ id: 'sess-1@container', cwd: '/x', slug: 'claude-fix', peer: 'container' }),
     ]
     const isLocal = (n: string) => n === 'container'
     expect(reorderKeysForFolder(sessions, undefined, isLocal))
-      .toEqual(['claude-fix'])
+      .toEqual(['sess-1@container'])
   })
 })
 

--- a/apps/gmux-web/src/projects.ts
+++ b/apps/gmux-web/src/projects.ts
@@ -547,16 +547,15 @@ export function parseSessionHostPath(sessionId: string): { originalId: string; p
  *     sending them would add phantom entries on the daemon's next
  *     ReorderSessions merge.
  *
- *  2. Key sessions appropriately for the owning daemon's projects.json:
+ *  2. Key sessions by the owning daemon's session IDs:
  *     - For references (folder.peer set, not a Local peer): the peer's
  *       projects.json keys by the original (unnamespaced) id, so we
- *       strip `@<peer>` from slugless ids before sending.
+ *       strip `@<peer>` before sending.
  *     - For local folders (folder.peer absent or Local): the parent's
  *       projects.json keys may include namespaced ids for Local-peer
  *       sessions, since the parent owns project assignment for them.
  *       We keep `@<peer>` for those sessions and strip nothing for
  *       genuinely local sessions.
- *     Slugged sessions always key by `s.slug`, which is never namespaced.
  *
  * Returns an empty array when no session in the request belongs to
  * the folder owner: caller should skip the PATCH entirely so the
@@ -579,7 +578,6 @@ export function reorderKeysForFolder(
       return sessionPeer === folderPeer
     })
     .map(s => {
-      if (s.slug) return s.slug
       const sessionPeer = s.peer ?? ''
       // For Local-peer sessions in a local folder, the parent keys by
       // the namespaced id since the namespace is part of the session's

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -1201,7 +1201,7 @@ export async function updateProjects(items: ProjectItem[]): Promise<void> {
 
 /**
  * Persist a new session order for a project. The `sessionKeys` array
- * contains session keys (slug or id) in the desired display order.
+ * contains session IDs in the desired display order.
  *
  * Local projects (peer === undefined) get an optimistic overlay via
  * `_pendingMutations` so the sidebar re-renders immediately, before

--- a/apps/gmux-web/src/types.ts
+++ b/apps/gmux-web/src/types.ts
@@ -124,7 +124,7 @@ export interface MatchRule {
  *
  *   - Owned: `slug` + `match[]` (+ `sessions[]` maintained by server)
  *     A project owned by this host. Match rules drive session
- *     attribution; `sessions[]` is the ordered list of session keys
+ *     attribution; `sessions[]` is the ordered list of session IDs
  *     for sidebar order.
  *   - Reference: `slug` + `peer`
  *     A pointer to a project owned by a peer. The peer's projects.json

--- a/docs/adr/0005-references-and-local-peer-exception.md
+++ b/docs/adr/0005-references-and-local-peer-exception.md
@@ -127,8 +127,7 @@ sessions.Reconcile(func(s store.Session) (string, int) {
     if s.Peer != "" && !peerManager.IsLocalPeer(s.Peer) {
         return s.ProjectSlug, s.ProjectIndex // network peer: preserve
     }
-    key := projects.SessionKey(s.ID, s.Slug)
-    a := assignments[key]
+    a := assignments[s.ID]
     return a.Slug, a.Index
 })
 ```

--- a/docs/adr/0012-defer-relational-storage-migration.md
+++ b/docs/adr/0012-defer-relational-storage-migration.md
@@ -1,6 +1,6 @@
 # ADR 0012: Relational (SQLite) storage is a non-goal
 
-**Status:** Accepted (partially superseded by ADR 0023: the "`SessionKey`
+**Status:** Accepted (partially superseded by ADR 0024: the "`SessionKey`
 (slug-or-id) membership … unchanged" freeze below no longer holds —
 membership is keyed by session ID and takeover by conversation lineage.
 The storage decision itself — no relational store — stands.)

--- a/docs/adr/0012-defer-relational-storage-migration.md
+++ b/docs/adr/0012-defer-relational-storage-migration.md
@@ -1,6 +1,9 @@
 # ADR 0012: Relational (SQLite) storage is a non-goal
 
-**Status:** Accepted
+**Status:** Accepted (partially superseded by ADR 0023: the "`SessionKey`
+(slug-or-id) membership … unchanged" freeze below no longer holds —
+membership is keyed by session ID and takeover by conversation lineage.
+The storage decision itself — no relational store — stands.)
 **Date:** 2026-06-16
 **Related:** ADR 0002 (project ownership; share-nothing peering), ADR 0010 /
 ADR 0011 (authoritative attribution + runner-owned state)

--- a/docs/adr/0023-project-membership-keyed-by-session-id.md
+++ b/docs/adr/0023-project-membership-keyed-by-session-id.md
@@ -1,0 +1,203 @@
+# ADR 0023: Project membership keyed by session ID; conversation-lineage takeover
+
+**Status:** Accepted
+**Date:** 2026-07-12
+**Related:** ADR 0002 (project ownership), ADR 0003 (resume-by-id), ADR 0011
+(runner-owned session state), ADR 0012 (relational storage non-goal — partially
+superseded, see below), ADR 0014 (adapter-owned conversation sources),
+ADR 0022 (adapter-opaque conversation refs)
+
+## Context
+
+`projects.json` `Item.Sessions[]` is the ordered list of session keys that
+controls sidebar membership and order. A key is `SessionKey(id, slug)` =
+`slug || id`, justified by a comment claiming slugs are "stable across
+restarts" while IDs are "ephemeral". Both halves of that justification are
+now false:
+
+- **Session IDs are durable.** Daemon-driven resume/restart preserves the
+  `sess-` ID across the seam (`--resume-id`, ADR 0003), and dead sessions
+  persist under `sessions/<id>/meta.json` (sessionmeta) across daemon
+  restarts. The ID survives the full alive → dead → resumed lifecycle.
+- **Slugs are mutable display names.** Per #348 the slug follows the title;
+  per ADR 0011 it is *runner-owned* state; since #360/#394 it is empty until
+  the conversation is titled and cleared on genuine re-binds. It is also
+  renumbered (`-2`) on collision per (adapter, peer) — so the key depends on
+  what else happened to be alive at commit time — and it is only unique per
+  (adapter, peer) while `Sessions[]` spans adapters within a project.
+
+The slug was doing three jobs; only the first is legitimate:
+
+1. **Display/URL name** — its real job (web routing).
+2. **Membership key** in `projects.json` — every slug transition (title
+   arrives, rename, clear on re-bind) orphans the key, and the session is
+   re-appended at the bottom of the array: the "sidebar reorder" bug.
+   Cross-adapter same-title sessions silently collide on one key.
+3. **Continuity detection** — the store's takeover rule evicts a dead
+   session shadowed by a live one with the same (adapter, peer, slug). This
+   both *misses* true continuations (untitled conversations have no slug to
+   collide on → duplicate rows) and *invents* false ones (two different
+   conversations with the same title → a dead resumable session is wrongly
+   evicted).
+
+ADR 0012 froze `SessionKey` on the premise that "the motivating bugs are
+already fixed" by authoritative attribution. That held only while slug
+transitions were rare; #394 made them the normal session lifecycle (every
+session starts slugless), re-exposing the reorder-to-bottom bug ADR 0012
+listed as motivation. This ADR supersedes ADR 0012's "the remaining
+`SessionKey` (slug-or-id) membership … unchanged" — while keeping its actual
+decision (no relational store; JSON files + versioned migration).
+
+## Decision
+
+Give each identifier exactly one job:
+
+| Identifier | Job |
+| --- | --- |
+| **Session ID** | row identity: membership, order, dismiss, cleanup |
+| **Conversation ID (+ lineage)** | continuity: takeover/eviction |
+| **Slug** | display and URLs, nothing else |
+
+### 1. Membership keys are session IDs
+
+`Item.Sessions[]` holds store session IDs only: `sess-<hex>` for
+runner-born sessions, the conversation UUID for migration-window
+convIndex-rehydrated rows, namespaced IDs for Local-peer sessions — in all
+cases, exactly the ID the store row carries. `SessionKey` is deleted;
+`AutoAssignSession`'s ID→slug replacement hack is deleted; `DismissSession`
+takes only the ID. `projects.json` becomes less human-editable
+(`"sessions": ["sess-a1b2c3d4", …]`); that is accepted. Hand-edited slug
+keys are no longer supported.
+
+### 2. Takeover is keyed by conversation lineage, not slug
+
+The store's duplicate resolution (`resolveDuplicateSlugsLocked`) changes
+trigger: a **live** session that binds conversation *C* evicts a **dead**
+row whose conversation ID is in *C*'s lineage set:
+
+    lineage(C) = { C's own conversation ID } ∪ C's AncestorIDs
+
+`adapter.ConversationInfo` gains `AncestorIDs []string` (adapter-owned
+knowledge, ADR 0014):
+
+- **pi / codex:** empty — they resume into the same file, so plain
+  conversation-ID equality covers them (the degenerate lineage set).
+- **claude:** `--resume` writes a *new* transcript (new UUID) that replays
+  the prior history. Replayed lines keep their original per-line
+  `sessionId`, and the first user message embeds a
+  `# session-start -- <original-uuid>.jsonl` marker. `DescribeConversation`
+  (which already scans every line) collects distinct `sessionId` values;
+  ancestors = all except the file's own UUID, with the marker as a
+  corroborating signal. Both signals are load-bearing for Claude's own
+  replay mechanism, not incidental formatting.
+
+No runner or hook-protocol change: the runner keeps reporting only the
+conversation ref (ADR 0011, opaque per ADR 0022); the daemon computes lineage with the
+adapter parse it already performs for the conversations index and resume
+commands. The eviction fires at conversation-bind time — the earliest
+moment identity is actually known.
+
+Failure modes are asymmetric by construction: a future Claude that stops
+replaying history degrades to a *missed* link (duplicate rows — old row
+remains as a legitimate fork point), never a false eviction. A conversation
+ID appears in a lineage only if the agent itself wrote it there.
+
+**Alive–alive collisions coexist.** Two live sessions bound to the same
+conversation (external resume of a still-running conversation) are two
+honest rows; takeover is strictly live-evicts-dead. `ensureUniqueSlug`
+survives, re-scoped as URL/display dedup only.
+
+### 3. No identity-transfer event; relaunch heals
+
+There is no `session-replace {old→new}` plumbing. On takeover the evicted
+row's key is removed from `projects.json` by a small projects-manager hook
+on the **existing** `session-remove` broadcast (the sessionmeta
+`WatchRemovals` pattern; idempotent with explicit dismiss; no-op for peer
+sessions, which hold no local keys per ADR 0002). The successor session is
+added by the existing live auto-assign — at the **end** of the array.
+External resume therefore does not inherit sidebar position; "a new session
+lands at the end" is the accepted model.
+
+### 4. One-shot v4 migration; no compatibility layer
+
+`projects.json` v3 → v4 converts keys once at load:
+
+- Keys matching a known session ID pass through.
+- Slug keys are resolved to IDs against the sessionmeta sweep, which runs
+  before `projects.Load` and covers exactly the cohort that cannot
+  self-heal: **dead/resumable sessions are never auto-assigned** (dismiss
+  must stick), so dropping their keys would orphan them permanently.
+- Unresolvable keys (sessions live at upgrade time, hand-edited entries)
+  are dropped; live sessions re-auto-assign on register at the end of the
+  array. `backupFile` snapshots the pre-migration file.
+
+There is **no** dual-key resolution layer and **no** wire tolerance for
+slug keys. The web is embedded in the gmuxd binary (version-locked), so no
+old-web/new-daemon window exists. `ReorderSessions` filters incoming keys
+to known sessions (previously it merged arbitrary strings into the array).
+Mixed 1.6/2.0 *peer* fleets already degrade to a silent no-sessions mode on
+the SSE protocol seam (no version gate exists; see the peer-skew
+investigation), so cross-version reorder compatibility is moot; a peer
+protocol-version handshake is optional backlog, out of scope here.
+
+`CleanupSessions`' `known` set becomes persisted sessionmeta IDs ∪ live
+store IDs (slug entries dropped from both sides). The pre-existing
+local-peer first-scan race (keys pruned if the peer connects after first
+scan) is unchanged and self-healing (live re-auto-assign).
+
+### 5. Slug becomes display-only everywhere
+
+With no identity riding on slugs, the last UUID-slug remnant is fixed:
+convIndex-rehydrated rows no longer surface `Slugify(conversationID)` as
+their slug. The conversations index may keep an internal unique key, but
+the surfaced row slug for untitled conversations is empty; the web falls
+back to the session ID for URLs (as established in #394).
+
+## Accepted breakage (one-time, v2.0 window)
+
+1. Sessions **live at upgrade** lose their sidebar position once
+   (re-auto-assigned at the end on first register). No data loss.
+2. **Hand-edited** slug keys in `projects.json` stop working.
+3. Mixed-version **peer** reorder no-ops during a fleet rolling upgrade
+   (subsumed by the existing silent no-sessions skew; self-heals on
+   upgrade).
+4. **External resume** no longer inherits sidebar position (ongoing, by
+   design — see §3).
+
+## Alternatives considered
+
+- **Patch slug keys harder** (more re-key paths in `AutoAssignSession`).
+  Rejected: post-#394, slug transitions are the normal lifecycle, not an
+  edge case; this is whack-a-mole on a wrong key.
+- **ID keys, but keep slug-collision takeover.** Rejected: it wires correct
+  membership to an incorrect continuity signal — still misses untitled
+  resumes (duplicates) and still falsely evicts on same-title collisions.
+- **Conversation ID as the membership key** ("the sidebar row is the
+  conversation"). Rejected: shells have no conversation → a mixed key space
+  again (the `slug || id` shape we are escaping); everything else — store,
+  SSE, dismiss, sessionmeta, web — speaks session IDs, so it adds a
+  parallel identity layer with a mapping obligation at every consumer; and
+  the key would still mutate once at first bind.
+- **`session-replace` pair event to preserve position across takeover.**
+  Rejected as machinery disproportionate to external resume's frequency;
+  can be added later without schema impact if it ever grates.
+- **Permanent dual-key resolver + opportunistic rewrite** (accept slug keys
+  at every use site forever). Rejected: it existed to protect a
+  mixed-version window that doesn't exist (embedded web) and a one-time
+  upgrade cohort crossing a declared breaking window anyway.
+- **Claude-only slug-takeover fallback** for the lineage gap. Rejected:
+  reintroduces the false-positive eviction this ADR eliminates.
+
+## Consequences
+
+- Rename, titling, re-bind, and slug clears no longer touch
+  `projects.json`: sidebar order is stable under all display-name changes.
+- Untitled conversations resume without duplicating rows (pi/codex by file
+  identity; claude by lineage); same-title conversations can no longer
+  evict each other.
+- `projects.json` v4 is machine-oriented; the versioned-migration framework
+  (ADR 0012) carries the one-shot conversion with a backup.
+- The store's eviction seam gains an adapter parse at bind time — bounded
+  by the same parsing the conversations index already does.
+- ADR 0012's storage decision stands; its `SessionKey` freeze is
+  superseded by this ADR.

--- a/docs/adr/0024-project-membership-keyed-by-session-id.md
+++ b/docs/adr/0024-project-membership-keyed-by-session-id.md
@@ -1,4 +1,4 @@
-# ADR 0023: Project membership keyed by session ID; conversation-lineage takeover
+# ADR 0024: Project membership keyed by session ID; conversation-lineage takeover
 
 **Status:** Accepted
 **Date:** 2026-07-12

--- a/e2e/tests/conversation-discovery.spec.ts
+++ b/e2e/tests/conversation-discovery.spec.ts
@@ -114,7 +114,7 @@ test.describe('conversation discovery (watcher-driven)', () => {
     // Append a `custom-title` line. Claude's parser prefers
     // custom-title over first-user-message text, so the indexed
     // title should update on re-parse. The lookup key FOLLOWS the
-    // displayed slug (ADR 0023 §5, the #348 slug-follows-rename
+    // displayed slug (ADR 0024 §5, the #348 slug-follows-rename
     // semantics), so the retitled conversation resolves under its
     // new slug; conversation-ID URLs keep resolving across renames.
     const newTitle = 'claude custom retitled'

--- a/e2e/tests/conversation-discovery.spec.ts
+++ b/e2e/tests/conversation-discovery.spec.ts
@@ -6,6 +6,7 @@ import {
   type AdapterName,
   type FixtureSpec,
   appendToSession,
+  slugify,
   writeFakeSession,
 } from '../fixtures'
 
@@ -112,20 +113,27 @@ test.describe('conversation discovery (watcher-driven)', () => {
 
     // Append a `custom-title` line. Claude's parser prefers
     // custom-title over first-user-message text, so the indexed
-    // title should update on re-parse. The slug stays stable across
-    // updates (Upsert preserves it via byToolID, so existing URLs
-    // don't break) — we query the same slug and expect a new title.
+    // title should update on re-parse. The lookup key FOLLOWS the
+    // displayed slug (ADR 0023 §5, the #348 slug-follows-rename
+    // semantics), so the retitled conversation resolves under its
+    // new slug; conversation-ID URLs keep resolving across renames.
     const newTitle = 'claude custom retitled'
+    const newSlug = slugify(newTitle)
     appendToSession(filePath, { type: 'custom-title', customTitle: newTitle })
 
     await pollUntil(
       async () => {
-        const { status, body } = await apiGet<ConvBody>(`/v1/conversations/claude/${expectedSlug}`)
+        const { status, body } = await apiGet<ConvBody>(`/v1/conversations/claude/${newSlug}`)
         if (status !== 200) return null
         return body.data.title === newTitle ? body.data : null
       },
-      { description: `claude/${expectedSlug} title updated to ${newTitle}` },
+      { description: `claude/${newSlug} title updated to ${newTitle}` },
     )
+
+    // The conversation-ID deep link tracks the rename.
+    const byId = await apiGet<ConvBody>(`/v1/conversations/claude/${spec.conversationID}`)
+    expect(byId.status).toBe(200)
+    expect(byId.body.data.title).toBe(newTitle)
   })
 
   test('pi: deleting session file -> 404 within 2s', async () => {

--- a/packages/adapter/adapters/claude.go
+++ b/packages/adapter/adapters/claude.go
@@ -136,12 +136,31 @@ func (c *Claude) DescribeConversation(ref string) (*adapter.ConversationInfo, er
 		return nil, errEmpty
 	}
 
+	// A resumed Claude transcript has a new UUID filename, while replayed
+	// history retains the original per-line sessionId. Keep every valid ID in
+	// first-appearance order; malformed values must not create a false link.
+	ownID := claudeConversationIDFromPath(path)
+	lineSessionIDs := make([]string, 0)
+	seenLineSessionIDs := make(map[string]struct{})
+
 	// Find the first user line for session metadata.
 	var firstUser *claudeFirstLine
 	var customTitle string
 	messageCount := 0
 
 	for _, line := range lines {
+		var session struct {
+			SessionID string `json:"sessionId"`
+		}
+		if err := json.Unmarshal([]byte(line), &session); err == nil {
+			if id, ok := validClaudeConversationID(session.SessionID); ok && id != ownID {
+				if _, exists := seenLineSessionIDs[id]; !exists {
+					seenLineSessionIDs[id] = struct{}{}
+					lineSessionIDs = append(lineSessionIDs, id)
+				}
+			}
+		}
+
 		if line == "" {
 			continue
 		}
@@ -195,6 +214,7 @@ func (c *Claude) DescribeConversation(ref string) (*adapter.ConversationInfo, er
 			LastActivity: fileLastActivity(path),
 			MessageCount: messageCount,
 			Ref:          path,
+			AncestorIDs:  claudeAncestorIDs(nil, ownID, lineSessionIDs),
 		}, nil
 	}
 
@@ -226,6 +246,7 @@ func (c *Claude) DescribeConversation(ref string) (*adapter.ConversationInfo, er
 	// matching pi and the hook path (claudeTitleSlug already slugs
 	// session_title when the payload carries it).
 	info.Slug = adapter.Slugify(info.Title)
+	info.AncestorIDs = claudeAncestorIDs(firstUser.Message.Content, ownID, lineSessionIDs)
 
 	return info, nil
 }
@@ -252,6 +273,55 @@ func (c *Claude) OpenConversation(ref string) (io.ReadCloser, error) {
 }
 
 // --- Helpers ---
+
+var (
+	claudeUUIDPattern         = regexp.MustCompile(`(?i)^[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$`)
+	claudeSessionStartPattern = regexp.MustCompile(`(?i)# session-start -- ([0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12})\.jsonl`)
+)
+
+// claudeConversationIDFromPath returns the canonical UUID filename stem, if any.
+func claudeConversationIDFromPath(path string) string {
+	id, _ := validClaudeConversationID(strings.TrimSuffix(filepath.Base(path), filepath.Ext(path)))
+	return id
+}
+
+func validClaudeConversationID(id string) (string, bool) {
+	if !claudeUUIDPattern.MatchString(id) {
+		return "", false
+	}
+	return strings.ToLower(id), true
+}
+
+// claudeAncestorIDs unions the first-user resume marker with replayed line
+// session IDs. The marker leads when it is new; this makes the result stable
+// even when Claude's replay ordering changes.
+func claudeAncestorIDs(firstUserContent json.RawMessage, ownID string, lineSessionIDs []string) []string {
+	ancestors := make([]string, 0, len(lineSessionIDs)+1)
+	seen := make(map[string]struct{})
+	add := func(id string) {
+		if id == "" || id == ownID {
+			return
+		}
+		if _, exists := seen[id]; !exists {
+			seen[id] = struct{}{}
+			ancestors = append(ancestors, id)
+		}
+	}
+
+	content := extractClaudeUserText(firstUserContent)
+	if match := claudeSessionStartPattern.FindStringSubmatch(content); len(match) == 2 {
+		if id, ok := validClaudeConversationID(match[1]); ok {
+			add(id)
+		}
+	}
+	for _, id := range lineSessionIDs {
+		add(id)
+	}
+	if len(ancestors) == 0 {
+		return nil
+	}
+	return ancestors
+}
 
 // extractClaudeUserText extracts the first text block from a Claude Code
 // user message content field. Content can be a string or array of blocks.

--- a/packages/adapter/adapters/claude.go
+++ b/packages/adapter/adapters/claude.go
@@ -292,9 +292,14 @@ func validClaudeConversationID(id string) (string, bool) {
 	return strings.ToLower(id), true
 }
 
-// claudeAncestorIDs unions the first-user resume marker with replayed line
-// session IDs. The marker leads when it is new; this makes the result stable
-// even when Claude's replay ordering changes.
+// claudeAncestorIDs derives resume lineage from the replayed per-line session
+// IDs. The `# session-start -- <uuid>.jsonl` marker in the first user message
+// is used ONLY to order the result (lead with it) — never as an independent
+// source: that text is user-authorable, so trusting it alone would let a
+// crafted first prompt forge an ancestor edge and drive a false takeover of an
+// unrelated dead conversation (ADR 0024 §2 — a false link must be impossible;
+// only a missed link is acceptable). Claude stamps every replayed line with
+// the genuine ancestor's sessionId, so a real resume is always corroborated.
 func claudeAncestorIDs(firstUserContent json.RawMessage, ownID string, lineSessionIDs []string) []string {
 	ancestors := make([]string, 0, len(lineSessionIDs)+1)
 	seen := make(map[string]struct{})
@@ -308,10 +313,19 @@ func claudeAncestorIDs(firstUserContent json.RawMessage, ownID string, lineSessi
 		}
 	}
 
+	// Line IDs are the trusted source. The marker only promotes a
+	// corroborated ID to the front; an uncorroborated marker contributes
+	// nothing.
+	lineSet := make(map[string]struct{}, len(lineSessionIDs))
+	for _, id := range lineSessionIDs {
+		lineSet[id] = struct{}{}
+	}
 	content := extractClaudeUserText(firstUserContent)
 	if match := claudeSessionStartPattern.FindStringSubmatch(content); len(match) == 2 {
 		if id, ok := validClaudeConversationID(match[1]); ok {
-			add(id)
+			if _, corroborated := lineSet[id]; corroborated {
+				add(id)
+			}
 		}
 	}
 	for _, id := range lineSessionIDs {

--- a/packages/adapter/adapters/claude_test.go
+++ b/packages/adapter/adapters/claude_test.go
@@ -306,10 +306,23 @@ func TestClaudeDescribeConversationAncestorIDs(t *testing.T) {
 			}, want: nil,
 		},
 		{
-			name: "marker only", file: c + ".jsonl",
+			// An UNCORROBORATED marker (its UUID never appears as a
+			// replayed line sessionId) is user-authorable text and must
+			// NOT forge an ancestor edge — otherwise a crafted first prompt
+			// could evict an unrelated dead conversation (ADR 0024 §2).
+			name: "uncorroborated marker is ignored", file: c + ".jsonl",
 			lines: []string{
 				`{"type":"user","sessionId":"` + c + `","timestamp":"2026-03-15T10:00:00Z","message":{"content":"# session-start -- ` + a + `.jsonl"}}`,
-			}, want: []string{a},
+			}, want: nil,
+		},
+		{
+			// A user pasting the marker string for a REAL other conversation
+			// still cannot forge lineage: no replayed line carries that id.
+			name: "forged marker for a real id is ignored", file: c + ".jsonl",
+			lines: []string{
+				`{"type":"user","sessionId":"` + c + `","timestamp":"2026-03-15T10:00:00Z","message":{"content":"why is # session-start -- ` + b + `.jsonl here"}}`,
+				`{"type":"user","sessionId":"` + c + `","timestamp":"2026-03-15T10:01:00Z","message":{"content":"go"}}`,
+			}, want: nil,
 		},
 		{
 			name: "lines only", file: c + ".jsonl",

--- a/packages/adapter/adapters/claude_test.go
+++ b/packages/adapter/adapters/claude_test.go
@@ -3,6 +3,7 @@ package adapters
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/gmuxapp/gmux/packages/adapter"
@@ -146,8 +147,13 @@ func TestEncodeClaudeCwd(t *testing.T) {
 
 func writeClaudeJSONL(t *testing.T, lines ...string) string {
 	t.Helper()
+	return writeNamedClaudeJSONL(t, "test-session.jsonl", lines...)
+}
+
+func writeNamedClaudeJSONL(t *testing.T, name string, lines ...string) string {
+	t.Helper()
 	dir := t.TempDir()
-	path := filepath.Join(dir, "test-session.jsonl")
+	path := filepath.Join(dir, name)
 	var content string
 	for _, l := range lines {
 		content += l + "\n"
@@ -262,6 +268,74 @@ func TestClaudeDescribeConversationNoSessionID(t *testing.T) {
 	_, err := NewClaude().DescribeConversation(path)
 	if err != errNotSession {
 		t.Errorf("expected errNotSession, got %v", err)
+	}
+}
+
+func TestClaudeDescribeConversationAncestorIDs(t *testing.T) {
+	const (
+		a = "11111111-1111-1111-1111-111111111111"
+		b = "22222222-2222-2222-2222-222222222222"
+		c = "33333333-3333-3333-3333-333333333333"
+	)
+	tests := []struct {
+		name  string
+		file  string
+		lines []string
+		want  []string
+	}{
+		{
+			name: "resumed transcript deduplicates marker and replay", file: c + ".jsonl",
+			lines: []string{
+				`{"type":"user","sessionId":"` + a + `","timestamp":"2026-03-15T10:00:00Z","message":{"content":"# session-start -- ` + a + `.jsonl\nContinue work"}}`,
+				`{"type":"assistant","sessionId":"` + a + `"}`,
+				`{"type":"user","sessionId":"` + c + `","timestamp":"2026-03-15T10:01:00Z","message":{"content":"new prompt"}}`,
+			}, want: []string{a},
+		},
+		{
+			name: "chained resume preserves replay order", file: c + ".jsonl",
+			lines: []string{
+				`{"type":"user","sessionId":"` + a + `","timestamp":"2026-03-15T10:00:00Z","message":{"content":"first"}}`,
+				`{"type":"assistant","sessionId":"` + b + `"}`,
+				`{"type":"user","sessionId":"` + c + `","timestamp":"2026-03-15T10:01:00Z","message":{"content":"latest"}}`,
+			}, want: []string{a, b},
+		},
+		{
+			name: "single session", file: c + ".jsonl",
+			lines: []string{
+				`{"type":"user","sessionId":"` + c + `","timestamp":"2026-03-15T10:00:00Z","message":{"content":"only"}}`,
+			}, want: nil,
+		},
+		{
+			name: "marker only", file: c + ".jsonl",
+			lines: []string{
+				`{"type":"user","sessionId":"` + c + `","timestamp":"2026-03-15T10:00:00Z","message":{"content":"# session-start -- ` + a + `.jsonl"}}`,
+			}, want: []string{a},
+		},
+		{
+			name: "lines only", file: c + ".jsonl",
+			lines: []string{
+				`{"type":"user","sessionId":"` + a + `","timestamp":"2026-03-15T10:00:00Z","message":{"content":"replayed"}}`,
+				`{"type":"user","sessionId":"` + c + `","timestamp":"2026-03-15T10:01:00Z","message":{"content":"new"}}`,
+			}, want: []string{a},
+		},
+		{
+			name: "malformed values are ignored", file: c + ".jsonl",
+			lines: []string{
+				`{"type":"user","sessionId":"not-a-uuid","timestamp":"2026-03-15T10:00:00Z","message":{"content":"# session-start -- definitely-not-a-uuid.jsonl"}}`,
+				`{"type":"assistant","sessionId":"also-not-a-uuid"}`,
+			}, want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			info, err := NewClaude().DescribeConversation(writeNamedClaudeJSONL(t, tt.file, tt.lines...))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(tt.want, info.AncestorIDs) {
+				t.Errorf("AncestorIDs = %v, want %v", info.AncestorIDs, tt.want)
+			}
+		})
 	}
 }
 

--- a/packages/adapter/adapters/codex_test.go
+++ b/packages/adapter/adapters/codex_test.go
@@ -134,6 +134,9 @@ func TestCodexDescribeConversationBasic(t *testing.T) {
 	if info.MessageCount != 2 {
 		t.Errorf("expected 2 messages, got %d", info.MessageCount)
 	}
+	if len(info.AncestorIDs) != 0 {
+		t.Errorf("expected no ancestors for in-place codex resume, got %v", info.AncestorIDs)
+	}
 }
 
 func TestCodexDescribeConversationSkipsSystemContext(t *testing.T) {

--- a/packages/adapter/adapters/pi_test.go
+++ b/packages/adapter/adapters/pi_test.go
@@ -295,6 +295,9 @@ func TestDescribeConversationFirstUserMessage(t *testing.T) {
 	if info.Slug != "fix-the-auth-bug-in-login-go" {
 		t.Errorf("expected slug from title, got %q", info.Slug)
 	}
+	if len(info.AncestorIDs) != 0 {
+		t.Errorf("expected no ancestors for in-place pi resume, got %v", info.AncestorIDs)
+	}
 }
 
 func TestDescribeConversationNameOverrides(t *testing.T) {

--- a/packages/adapter/capabilities.go
+++ b/packages/adapter/capabilities.go
@@ -33,7 +33,7 @@ type ConversationInfo struct {
 	MessageCount int
 	Ref          string // the opaque conversation ref this info was described from
 	// AncestorIDs are IDs of conversations this one was resumed from, oldest-first
-	// when that order is derivable; empty when the adapter resumes in place (ADR 0023 §2).
+	// when that order is derivable; empty when the adapter resumes in place (ADR 0024 §2).
 	AncestorIDs []string
 }
 

--- a/packages/adapter/capabilities.go
+++ b/packages/adapter/capabilities.go
@@ -32,6 +32,9 @@ type ConversationInfo struct {
 	LastActivity time.Time
 	MessageCount int
 	Ref          string // the opaque conversation ref this info was described from
+	// AncestorIDs are IDs of conversations this one was resumed from, oldest-first
+	// when that order is derivable; empty when the adapter resumes in place (ADR 0023 §2).
+	AncestorIDs []string
 }
 
 // Launchable is implemented by adapters that want to expose one or more

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -537,8 +537,11 @@ func serve(stderr io.Writer) int {
 	persistedKeys := make(map[string]bool)
 	// legacySlugToID resolves v3 projects.json membership keys during the
 	// one-shot v4 migration. Only swept dead/resumable sessions need this:
-	// live sessions re-auto-assign after startup.
-	legacySlugToID := make(map[string]string)
+	// live sessions re-auto-assign after startup. A slug maps to a SLICE of
+	// IDs: slugs were unique only within (adapter, peer), but a v3 membership
+	// key spanned adapters, so one key could legitimately match several dead
+	// sessions — all must survive the migration.
+	legacySlugToID := make(map[string][]string)
 	if loaded, err := metaStore.Sweep(); err != nil {
 		log.Printf("sessionmeta: sweep failed: %v", err)
 	} else {
@@ -546,7 +549,7 @@ func serve(stderr io.Writer) int {
 			sessions.Upsert(sess)
 			persistedKeys[sess.ID] = true
 			if sess.Slug != "" {
-				legacySlugToID[sess.Slug] = sess.ID
+				legacySlugToID[sess.Slug] = append(legacySlugToID[sess.Slug], sess.ID)
 			}
 		}
 		if n := len(loaded); n > 0 {

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -527,10 +527,10 @@ func serve(stderr io.Writer) int {
 	sessions.SetActivitySeed(func(sess store.Session) string {
 		return activitySeedFor(sess, metaStore.SessionDir)
 	})
-	// persistedKeys records the id and slug of every session sessionmeta
-	// holds on disk at startup (the post-retention sweep survivors). The
-	// startup CleanupSessions unions this with the live store so a project
-	// membership key is pruned only when it is neither live nor persisted.
+	// persistedKeys records the ID of every session sessionmeta holds on disk
+	// at startup (the post-retention sweep survivors). The startup
+	// CleanupSessions unions this with the live store so a project membership
+	// ID is pruned only when it is neither live nor persisted.
 	// Capturing it here rather than re-deriving it from the store at
 	// cleanup time keeps the guard correct regardless of whether the swept
 	// dead sessions are still populated in the store by then.
@@ -541,9 +541,6 @@ func serve(stderr io.Writer) int {
 		for _, sess := range loaded {
 			sessions.Upsert(sess)
 			persistedKeys[sess.ID] = true
-			if sess.Slug != "" {
-				persistedKeys[sess.Slug] = true
-			}
 		}
 		if n := len(loaded); n > 0 {
 			log.Printf("sessionmeta: restored %d session(s) from %s", n, metaStore.Dir())
@@ -605,7 +602,7 @@ func serve(stderr io.Writer) int {
 	}
 
 	// Drive the persister's removal loop off store events so every
-	// session-remove (dismiss, slug takeover, peer disconnect, etc.)
+	// session-remove (dismiss, lineage takeover, peer disconnect, etc.)
 	// drops the matching meta dir. The explicit forgetMeta call in
 	// the dismiss handler is redundant but cheap. Resume is an
 	// alive=false→true Upsert under the same id (ADR 0003) and
@@ -761,6 +758,9 @@ func serve(stderr io.Writer) int {
 	// Project manager handles concurrent access to projects.json and
 	// auto-assignment of sessions to projects.
 	projectMgr := projects.NewManager(stateDir)
+	projectRemovalEvents, cancelProjectRemovalEvents := sessions.Subscribe()
+	defer cancelProjectRemovalEvents()
+	go projectMgr.WatchRemovals(projectRemovalEvents)
 
 	// One-time upgrade: ADR 0008 removed tailscale autodiscovery, so the
 	// hosts it surfaced automatically would otherwise vanish (orphaning
@@ -800,8 +800,7 @@ func serve(stderr io.Writer) int {
 			}
 			// Local sessions and Local-peer (devcontainer) sessions:
 			// parent owns assignment, stamp from its projects.json.
-			key := projects.SessionKey(s.ID, s.Slug)
-			a := assignments[key]
+			a := assignments[s.ID]
 			return a.Slug, a.Index
 		})
 	}
@@ -844,9 +843,6 @@ func serve(stderr io.Writer) int {
 		}
 		for _, s := range sessions.List() {
 			known[s.ID] = true
-			if s.Slug != "" {
-				known[s.Slug] = true
-			}
 		}
 		projectMgr.CleanupSessions(known)
 	}
@@ -859,7 +855,7 @@ func serve(stderr io.Writer) int {
 	// overflow, add an explicit reconcile hook — don't reintroduce the
 	// periodic ticker.
 
-	// Auto-assign sessions to projects when they appear or get a Slug.
+	// Auto-assign sessions to projects when they appear.
 	sessionEvents, unsubSessionEvents := sessions.Subscribe()
 	defer unsubSessionEvents()
 	go func() {
@@ -883,7 +879,6 @@ func serve(stderr io.Writer) int {
 				LocalHost:     s.Peer != "" && peerManager != nil && peerManager.IsLocalPeer(s.Peer),
 				Alive:         s.Alive,
 				Resumable:     s.Resumable,
-				Slug:          s.Slug,
 			})
 		}
 	}()
@@ -1144,9 +1139,19 @@ func serve(stderr io.Writer) int {
 			writeError(w, http.StatusBadRequest, "bad_request", "invalid JSON")
 			return
 		}
+		known := make(map[string]bool)
+		for _, session := range sessions.List() {
+			known[session.ID] = true
+		}
+		filtered := make([]string, 0, len(req.Sessions))
+		for _, id := range req.Sessions {
+			if known[id] {
+				filtered = append(filtered, id)
+			}
+		}
 		found := false
 		err = projectMgr.Update(func(state *projects.State) bool {
-			found = state.ReorderSessions(slug, req.Sessions)
+			found = state.ReorderSessions(slug, filtered)
 			return found
 		})
 		if err != nil {
@@ -1372,7 +1377,7 @@ func serve(stderr io.Writer) int {
 		// keeping a dead session around. A general "ephemeral session"
 		// flag is future work; for now the adapter kind is the marker.
 		if sess, ok := sessions.Get(req.SessionID); ok && sess.Adapter == "editor" {
-			projectMgr.DismissSession(req.SessionID, sess.Slug)
+			projectMgr.DismissSession(req.SessionID)
 			sessions.Remove(req.SessionID)
 			forgetMeta(req.SessionID)
 			log.Printf("deregister: auto-dismissed editor session %s", req.SessionID)
@@ -1818,7 +1823,7 @@ func serve(stderr io.Writer) int {
 				}
 			}
 			// Remove session from its project's sessions array.
-			projectMgr.DismissSession(sessionID, sess.Slug)
+			projectMgr.DismissSession(sessionID)
 			// Remove from store — broadcasts session-remove to all clients
 			// (which the cleanup goroutine catches to drop meta), then
 			// also drop meta synchronously to defeat any subscriber lag.
@@ -2707,7 +2712,6 @@ func buildSessionInfos(sessions *store.Store, isLocalPeer func(string) bool) []p
 			LocalHost:     s.Peer != "" && isLocalPeer != nil && isLocalPeer(s.Peer),
 			Alive:         s.Alive,
 			Resumable:     s.Resumable,
-			Slug:          s.Slug,
 			LastActive:    sessionLastActive(s),
 		}
 	}

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -535,12 +535,19 @@ func serve(stderr io.Writer) int {
 	// cleanup time keeps the guard correct regardless of whether the swept
 	// dead sessions are still populated in the store by then.
 	persistedKeys := make(map[string]bool)
+	// legacySlugToID resolves v3 projects.json membership keys during the
+	// one-shot v4 migration. Only swept dead/resumable sessions need this:
+	// live sessions re-auto-assign after startup.
+	legacySlugToID := make(map[string]string)
 	if loaded, err := metaStore.Sweep(); err != nil {
 		log.Printf("sessionmeta: sweep failed: %v", err)
 	} else {
 		for _, sess := range loaded {
 			sessions.Upsert(sess)
 			persistedKeys[sess.ID] = true
+			if sess.Slug != "" {
+				legacySlugToID[sess.Slug] = sess.ID
+			}
 		}
 		if n := len(loaded); n > 0 {
 			log.Printf("sessionmeta: restored %d session(s) from %s", n, metaStore.Dir())
@@ -757,7 +764,7 @@ func serve(stderr io.Writer) int {
 
 	// Project manager handles concurrent access to projects.json and
 	// auto-assignment of sessions to projects.
-	projectMgr := projects.NewManager(stateDir)
+	projectMgr := projects.NewManager(stateDir, legacySlugToID)
 	projectRemovalEvents, cancelProjectRemovalEvents := sessions.Subscribe()
 	defer cancelProjectRemovalEvents()
 	go projectMgr.WatchRemovals(projectRemovalEvents)

--- a/services/gmuxd/cmd/gmuxd/rehydrate_test.go
+++ b/services/gmuxd/cmd/gmuxd/rehydrate_test.go
@@ -184,6 +184,35 @@ func TestRehydrateProjects_FallbackForMissingSessionmeta(t *testing.T) {
 // projects.json references a key that resolves nowhere: neither
 // sessionmeta nor convIndex knows about it. The function must leave
 // the store untouched and not panic.
+func TestRehydrateProjects_UntitledConversationDoesNotSurfaceUUIDSlug(t *testing.T) {
+	sessions := store.New()
+	const id = "7e41c769-5efc-4d31-b5f4-4b2a7e800a81"
+
+	idx := conversations.New()
+	idx.Upsert(conversations.Info{
+		ConversationID: id,
+		Key:            id,
+		Adapter:        "pi",
+		Cwd:            "/work",
+		Created:        time.Date(2023, 6, 1, 0, 0, 0, 0, time.UTC),
+		ResumeCommand:  []string{"pi", "--resume", id},
+	})
+	state := &projects.State{Items: []projects.Item{{
+		Slug:     "proj",
+		Sessions: []string{id},
+	}}}
+
+	rehydrateProjects(sessions, idx, state)
+
+	got, ok := sessions.Get(id)
+	if !ok {
+		t.Fatal("fallback rehydration did not populate store")
+	}
+	if got.Slug != "" {
+		t.Errorf("Slug = %q, want empty for untitled conversation", got.Slug)
+	}
+}
+
 func TestRehydrateProjects_SkipsUnknownKey(t *testing.T) {
 	sessions := store.New()
 	idx := conversations.New()

--- a/services/gmuxd/internal/conversations/index.go
+++ b/services/gmuxd/internal/conversations/index.go
@@ -67,8 +67,16 @@ func convKey(adapterName, conversationID string) string {
 func (idx *Index) Lookup(adapterName, key string) (Info, bool) {
 	idx.mu.RLock()
 	defer idx.mu.RUnlock()
-	info, ok := idx.byKey[indexKey(adapterName, key)]
-	return info, ok
+	if info, ok := idx.byKey[indexKey(adapterName, key)]; ok {
+		return info, true
+	}
+	// A conversation ID (or its old untitled fallback key) keeps resolving
+	// after the key upgraded to a titled slug — deep links must not break.
+	if k, ok := idx.byConversationID[convKey(adapterName, key)]; ok {
+		info, ok := idx.byKey[indexKey(adapterName, k)]
+		return info, ok
+	}
+	return Info{}, false
 }
 
 // LookupByConversationID returns the internal key for a conversation identified
@@ -93,9 +101,22 @@ func (idx *Index) Upsert(info Info) string {
 		info.Key = info.Slug
 	}
 
-	// If this conversation ID already has a key, update in place.
+	// If this conversation ID already has a key, update in place — unless
+	// the conversation has since gained a titled slug while the stored key
+	// is still the untitled UUID fallback. Keys and display slugs are
+	// separate (ADR 0023 §5), but a titled conversation must be reachable
+	// through its displayed slug, so the key upgrades once when the title
+	// arrives. Old UUID deep links keep resolving via the conversation-ID
+	// fallbacks in Lookup/FindByPrefix.
 	tk := convKey(info.Adapter, info.ConversationID)
 	if existing, ok := idx.byConversationID[tk]; ok {
+		if info.Slug != "" && existing != info.Slug && existing == adapter.Slugify(info.ConversationID) {
+			delete(idx.byKey, indexKey(info.Adapter, existing))
+			info.Key = idx.uniqueSlugLocked(info.Adapter, info.Slug, info.ConversationID)
+			idx.byKey[indexKey(info.Adapter, info.Key)] = info
+			idx.byConversationID[tk] = info.Key
+			return info.Key
+		}
 		ik := indexKey(info.Adapter, existing)
 		info.Key = existing
 		idx.byKey[ik] = info
@@ -268,6 +289,14 @@ func (idx *Index) FindByPrefix(adapterName, prefix string) (Info, bool) {
 	for key, info := range idx.byKey {
 		if strings.HasPrefix(key, keyPrefix) {
 			return info, true
+		}
+	}
+	// Conversation-ID prefixes keep resolving after a titled-key upgrade.
+	for ck, key := range idx.byConversationID {
+		if strings.HasPrefix(ck, keyPrefix) {
+			if info, ok := idx.byKey[indexKey(adapterName, key)]; ok {
+				return info, true
+			}
 		}
 	}
 	return Info{}, false

--- a/services/gmuxd/internal/conversations/index.go
+++ b/services/gmuxd/internal/conversations/index.go
@@ -23,7 +23,8 @@ import (
 // Info holds metadata for a single stored conversation.
 type Info struct {
 	ConversationID string    // adapter-native conversation ID (typically a UUID)
-	Slug           string    // human-readable URL identifier, unique within (adapter)
+	Key            string    // internal lookup key, unique within (adapter)
+	Slug           string    // human-readable URL identifier; empty until titled
 	Adapter        string    // adapter name (claude, codex, pi, shell)
 	Title          string    // display title
 	Cwd            string    // working directory
@@ -34,15 +35,14 @@ type Info struct {
 }
 
 // Index is a concurrency-safe lookup table for stored conversations.
-// It is the authority on slug uniqueness: when two conversations
-// produce the same slug within the same adapter, the index assigns
+// It is the authority on internal-key uniqueness: when two conversations
+// produce the same key within the same adapter, the index assigns
 // -2, -3 suffixes.
 type Index struct {
 	mu sync.RWMutex
-	// byKey maps "adapter/slug" → Info.
+	// byKey maps "adapter/key" → Info.
 	byKey map[string]Info
-	// byConversationID maps "adapter/conversationID" → slug for reverse lookup
-	// (e.g., finding a conversation's slug from the agent's conversation UUID).
+	// byConversationID maps "adapter/conversationID" → internal key for reverse lookup.
 	byConversationID map[string]string
 }
 
@@ -62,46 +62,52 @@ func convKey(adapterName, conversationID string) string {
 	return adapterName + "/" + conversationID
 }
 
-// Lookup returns the conversation info for an (adapter, slug) pair.
+// Lookup returns the conversation info for an (adapter, key) pair.
 // Returns ok=false if no matching conversation exists.
-func (idx *Index) Lookup(adapterName, slug string) (Info, bool) {
+func (idx *Index) Lookup(adapterName, key string) (Info, bool) {
 	idx.mu.RLock()
 	defer idx.mu.RUnlock()
-	info, ok := idx.byKey[indexKey(adapterName, slug)]
+	info, ok := idx.byKey[indexKey(adapterName, key)]
 	return info, ok
 }
 
-// LookupByConversationID returns the slug for a conversation identified by
-// its agent-native conversation ID. Returns empty string if unknown.
+// LookupByConversationID returns the internal key for a conversation identified
+// by its agent-native conversation ID. Returns empty string if unknown.
 func (idx *Index) LookupByConversationID(adapterName, conversationID string) string {
 	idx.mu.RLock()
 	defer idx.mu.RUnlock()
 	return idx.byConversationID[convKey(adapterName, conversationID)]
 }
 
-// Upsert adds or updates a conversation in the index. If the slug
+// Upsert adds or updates a conversation in the index. If the internal key
 // collides with an existing entry of the same adapter (but different
 // conversation ID), a -2, -3, ... suffix is appended. Returns the final
-// (possibly suffixed) slug.
+// (possibly suffixed) key.
 func (idx *Index) Upsert(info Info) string {
 	idx.mu.Lock()
 	defer idx.mu.Unlock()
 
-	// If this conversation ID already has a slug, update in place.
+	// Callers that construct Info directly historically supplied only Slug.
+	// Keep that shorthand for titled conversations.
+	if info.Key == "" {
+		info.Key = info.Slug
+	}
+
+	// If this conversation ID already has a key, update in place.
 	tk := convKey(info.Adapter, info.ConversationID)
 	if existing, ok := idx.byConversationID[tk]; ok {
 		ik := indexKey(info.Adapter, existing)
-		info.Slug = existing
+		info.Key = existing
 		idx.byKey[ik] = info
 		return existing
 	}
 
-	// Assign a unique slug.
-	info.Slug = idx.uniqueSlugLocked(info.Adapter, info.Slug, info.ConversationID)
-	ik := indexKey(info.Adapter, info.Slug)
+	// Assign a unique internal key.
+	info.Key = idx.uniqueSlugLocked(info.Adapter, info.Key, info.ConversationID)
+	ik := indexKey(info.Adapter, info.Key)
 	idx.byKey[ik] = info
-	idx.byConversationID[tk] = info.Slug
-	return info.Slug
+	idx.byConversationID[tk] = info.Key
+	return info.Key
 }
 
 // uniqueSlugLocked returns a slug that doesn't collide within the
@@ -155,9 +161,12 @@ func (idx *Index) Scan(a adapter.Adapter, ref string) string {
 		return ""
 	}
 
-	slug := convInfo.Slug
-	if slug == "" {
-		slug = adapter.Slugify(convInfo.ID)
+	displaySlug := convInfo.Slug
+	key := displaySlug
+	if key == "" {
+		// Untitled conversations still need an internal unique lookup key
+		// for UUID deep links, but that fallback must not surface as a URL slug.
+		key = adapter.Slugify(convInfo.ID)
 	}
 
 	var cmd []string
@@ -170,7 +179,8 @@ func (idx *Index) Scan(a adapter.Adapter, ref string) string {
 
 	info := Info{
 		ConversationID: convInfo.ID,
-		Slug:           slug,
+		Key:            key,
+		Slug:           displaySlug,
 		Adapter:        a.Name(),
 		Title:          convInfo.Title,
 		Cwd:            convInfo.Cwd,
@@ -188,12 +198,12 @@ func (idx *Index) Remove(adapterName, conversationID string) bool {
 	idx.mu.Lock()
 	defer idx.mu.Unlock()
 	tk := convKey(adapterName, conversationID)
-	slug, ok := idx.byConversationID[tk]
+	key, ok := idx.byConversationID[tk]
 	if !ok {
 		return false
 	}
 	delete(idx.byConversationID, tk)
-	delete(idx.byKey, indexKey(adapterName, slug))
+	delete(idx.byKey, indexKey(adapterName, key))
 	return true
 }
 
@@ -224,30 +234,30 @@ func (idx *Index) RemoveByRef(adapterName, ref string) bool {
 	return false
 }
 
-// SlugExists reports whether a slug is taken within an adapter.
-func (idx *Index) SlugExists(adapterName, slug string) bool {
+// SlugExists reports whether an internal key is taken within an adapter.
+func (idx *Index) SlugExists(adapterName, key string) bool {
 	idx.mu.RLock()
 	defer idx.mu.RUnlock()
-	_, ok := idx.byKey[indexKey(adapterName, slug)]
+	_, ok := idx.byKey[indexKey(adapterName, key)]
 	return ok
 }
 
-// LookupBySlug searches for a conversation by slug across all kinds.
+// LookupBySlug searches for a conversation by internal key across all kinds.
 // Returns the first match. Used when the caller doesn't know the adapter
-// (e.g., project session arrays that store bare slugs).
-func (idx *Index) LookupBySlug(slug string) (Info, bool) {
+// (e.g., project session arrays that store bare legacy slugs or UUID keys).
+func (idx *Index) LookupBySlug(lookupKey string) (Info, bool) {
 	idx.mu.RLock()
 	defer idx.mu.RUnlock()
-	for key, info := range idx.byKey {
-		// key is "adapter/slug"; check if the slug suffix matches.
-		if i := len(key) - len(slug); i > 0 && key[i-1] == '/' && key[i:] == slug {
+	for indexedKey, info := range idx.byKey {
+		// indexedKey is "adapter/internal-key"; check its suffix.
+		if i := len(indexedKey) - len(lookupKey); i > 0 && indexedKey[i-1] == '/' && indexedKey[i:] == lookupKey {
 			return info, true
 		}
 	}
 	return Info{}, false
 }
 
-// FindByPrefix returns conversations whose slug starts with the given
+// FindByPrefix returns conversations whose internal key starts with the given
 // prefix, within an adapter. Used for URL resolution when the frontend
 // provides a partial slug (e.g. an abbreviated or legacy session-id
 // prefix); an exact/full id is just the degenerate prefix case.

--- a/services/gmuxd/internal/conversations/index.go
+++ b/services/gmuxd/internal/conversations/index.go
@@ -103,7 +103,7 @@ func (idx *Index) Upsert(info Info) string {
 
 	// If this conversation ID already has a key, update in place — but a
 	// TITLED conversation must stay reachable through its displayed slug
-	// (keys and display slugs are otherwise separate, ADR 0023 §5). So the
+	// (keys and display slugs are otherwise separate, ADR 0024 §5). So the
 	// key follows the slug: it upgrades from the untitled UUID fallback
 	// when a title first arrives, and re-keys again on rename — the same
 	// slug-follows-rename semantics session URLs have (#348). Conversation-

--- a/services/gmuxd/internal/conversations/index.go
+++ b/services/gmuxd/internal/conversations/index.go
@@ -101,16 +101,17 @@ func (idx *Index) Upsert(info Info) string {
 		info.Key = info.Slug
 	}
 
-	// If this conversation ID already has a key, update in place — unless
-	// the conversation has since gained a titled slug while the stored key
-	// is still the untitled UUID fallback. Keys and display slugs are
-	// separate (ADR 0023 §5), but a titled conversation must be reachable
-	// through its displayed slug, so the key upgrades once when the title
-	// arrives. Old UUID deep links keep resolving via the conversation-ID
-	// fallbacks in Lookup/FindByPrefix.
+	// If this conversation ID already has a key, update in place — but a
+	// TITLED conversation must stay reachable through its displayed slug
+	// (keys and display slugs are otherwise separate, ADR 0023 §5). So the
+	// key follows the slug: it upgrades from the untitled UUID fallback
+	// when a title first arrives, and re-keys again on rename — the same
+	// slug-follows-rename semantics session URLs have (#348). Conversation-
+	// ID deep links keep resolving via the fallbacks in Lookup/FindByPrefix.
+	// A transiently empty slug (a parse hiccup) keeps the existing key.
 	tk := convKey(info.Adapter, info.ConversationID)
 	if existing, ok := idx.byConversationID[tk]; ok {
-		if info.Slug != "" && existing != info.Slug && existing == adapter.Slugify(info.ConversationID) {
+		if info.Slug != "" && existing != info.Slug {
 			delete(idx.byKey, indexKey(info.Adapter, existing))
 			info.Key = idx.uniqueSlugLocked(info.Adapter, info.Slug, info.ConversationID)
 			idx.byKey[indexKey(info.Adapter, info.Key)] = info

--- a/services/gmuxd/internal/conversations/index.go
+++ b/services/gmuxd/internal/conversations/index.go
@@ -111,12 +111,22 @@ func (idx *Index) Upsert(info Info) string {
 	// A transiently empty slug (a parse hiccup) keeps the existing key.
 	tk := convKey(info.Adapter, info.ConversationID)
 	if existing, ok := idx.byConversationID[tk]; ok {
-		if info.Slug != "" && existing != info.Slug {
-			delete(idx.byKey, indexKey(info.Adapter, existing))
-			info.Key = idx.uniqueSlugLocked(info.Adapter, info.Slug, info.ConversationID)
-			idx.byKey[indexKey(info.Adapter, info.Key)] = info
-			idx.byConversationID[tk] = info.Key
-			return info.Key
+		if info.Slug != "" {
+			// Dedup FIRST (with the old key still in place, so a refresh
+			// that resolves to the same suffixed key is a no-op), then
+			// re-key only on genuine change. Display slug = final key,
+			// always: a collision-suffixed key must be the URL the row
+			// advertises, or the unsuffixed URL resolves a DIFFERENT
+			// conversation.
+			final := idx.uniqueSlugLocked(info.Adapter, info.Slug, info.ConversationID)
+			info.Key = final
+			info.Slug = final
+			if final != existing {
+				delete(idx.byKey, indexKey(info.Adapter, existing))
+				idx.byConversationID[tk] = final
+			}
+			idx.byKey[indexKey(info.Adapter, final)] = info
+			return final
 		}
 		ik := indexKey(info.Adapter, existing)
 		info.Key = existing
@@ -124,8 +134,12 @@ func (idx *Index) Upsert(info Info) string {
 		return existing
 	}
 
-	// Assign a unique internal key.
+	// Assign a unique internal key; a titled conversation's displayed slug
+	// is the final deduped key, so URLs and display never diverge.
 	info.Key = idx.uniqueSlugLocked(info.Adapter, info.Key, info.ConversationID)
+	if info.Slug != "" {
+		info.Slug = info.Key
+	}
 	ik := indexKey(info.Adapter, info.Key)
 	idx.byKey[ik] = info
 	idx.byConversationID[tk] = info.Key

--- a/services/gmuxd/internal/conversations/index_test.go
+++ b/services/gmuxd/internal/conversations/index_test.go
@@ -193,6 +193,30 @@ func TestSlugExists(t *testing.T) {
 	}
 }
 
+func TestUntitledConversationKeepsUUIDKeyButNoDisplaySlug(t *testing.T) {
+	idx := New()
+	const id = "7e41c769-5efc-4d31-b5f4-4b2a7e800a81"
+	key := idx.Upsert(Info{
+		ConversationID: id,
+		Key:            id,
+		Adapter:        "pi",
+	})
+	if key != id {
+		t.Fatalf("Key = %q, want %q", key, id)
+	}
+	info, ok := idx.Lookup("pi", id)
+	if !ok {
+		t.Fatal("Lookup by UUID key failed")
+	}
+	if info.Slug != "" {
+		t.Errorf("Slug = %q, want empty for untitled conversation", info.Slug)
+	}
+	info, ok = idx.FindByPrefix("pi", "7e41c769")
+	if !ok || info.ConversationID != id {
+		t.Errorf("FindByPrefix(UUID) = %+v, %v; want conversation %q", info, ok, id)
+	}
+}
+
 func TestFindByPrefix(t *testing.T) {
 	idx := New()
 	idx.Upsert(Info{ConversationID: "abc-123", Slug: "fix-auth-bug", Adapter: "pi"})

--- a/services/gmuxd/internal/conversations/index_test.go
+++ b/services/gmuxd/internal/conversations/index_test.go
@@ -310,3 +310,40 @@ func TestSinkRemoveFiresOnRemovedEvenWhenUnindexed(t *testing.T) {
 	// nil callback must not panic.
 	indexSink{idx: idx, a: &dbAdapter{name: "pi"}}.Remove("/x/whatever.jsonl")
 }
+
+// TestUpsertUpgradesUntitledKeyWhenTitled pins the titled-key upgrade
+// (PR #405 review): a conversation first indexed untitled gets the UUID
+// fallback key; when the title arrives, the key must upgrade so the displayed
+// slug resolves — while old UUID deep links keep working through the
+// conversation-ID fallbacks in Lookup and FindByPrefix.
+func TestUpsertUpgradesUntitledKeyWhenTitled(t *testing.T) {
+	idx := New()
+	const conv = "44444444-4444-4444-8444-444444444444"
+
+	key := idx.Upsert(Info{ConversationID: conv, Key: conv, Adapter: "pi"})
+	if key != conv {
+		t.Fatalf("untitled key = %q, want UUID fallback", key)
+	}
+
+	key = idx.Upsert(Info{ConversationID: conv, Key: "fix-the-bug", Slug: "fix-the-bug", Adapter: "pi", Title: "Fix the bug"})
+	if key != "fix-the-bug" {
+		t.Fatalf("titled key = %q, want upgraded slug key", key)
+	}
+
+	// The displayed slug resolves.
+	if info, ok := idx.Lookup("pi", "fix-the-bug"); !ok || info.ConversationID != conv {
+		t.Fatalf("Lookup by titled slug failed: ok=%v info=%+v", ok, info)
+	}
+	// Old UUID deep links keep resolving (exact and prefix).
+	if info, ok := idx.Lookup("pi", conv); !ok || info.Key != "fix-the-bug" {
+		t.Fatalf("Lookup by conversation ID failed: ok=%v info=%+v", ok, info)
+	}
+	if info, ok := idx.FindByPrefix("pi", conv[:8]); !ok || info.Key != "fix-the-bug" {
+		t.Fatalf("FindByPrefix by conversation-ID prefix failed: ok=%v info=%+v", ok, info)
+	}
+	// The stale UUID key entry is gone from the key namespace (a NEW
+	// conversation could claim it), yet resolution above still works.
+	if n := len(idx.All()); n != 1 {
+		t.Fatalf("index should hold exactly 1 conversation, got %d", n)
+	}
+}

--- a/services/gmuxd/internal/conversations/index_test.go
+++ b/services/gmuxd/internal/conversations/index_test.go
@@ -90,16 +90,27 @@ func TestUpsert_SlugCollisionAcrossKinds(t *testing.T) {
 	}
 }
 
-func TestUpsert_UpdatePreservesSlug(t *testing.T) {
+func TestUpsert_RenameFollowsSlug(t *testing.T) {
 	idx := New()
 	idx.Upsert(Info{ConversationID: "aaa", Slug: "say-hi", Adapter: "claude"})
 	idx.Upsert(Info{ConversationID: "bbb", Slug: "say-hi", Adapter: "claude"})
 
-	// Update the second one with a different base slug (e.g., title changed).
-	// It should keep its assigned slug "say-hi-2", not get a new one.
+	// A title change re-keys so the displayed slug always resolves (ADR
+	// 0023 §5, the #348 slug-follows-rename semantics). The old suffixed
+	// key is released; conversation-ID lookups track the move.
 	s := idx.Upsert(Info{ConversationID: "bbb", Slug: "hello", Adapter: "claude", Title: "updated"})
-	if s != "say-hi-2" {
-		t.Errorf("update should preserve assigned slug, got %q", s)
+	if s != "hello" {
+		t.Errorf("rename should re-key to the new slug, got %q", s)
+	}
+	if _, ok := idx.Lookup("claude", "say-hi-2"); ok {
+		t.Error("old suffixed key should be released on rename")
+	}
+	if info, ok := idx.Lookup("claude", "bbb"); !ok || info.Key != "hello" {
+		t.Errorf("conversation-ID lookup should track the rename, got %+v ok=%v", info, ok)
+	}
+	// The first conversation's key is untouched.
+	if info, ok := idx.Lookup("claude", "say-hi"); !ok || info.ConversationID != "aaa" {
+		t.Errorf("unrelated conversation must keep its key, got %+v ok=%v", info, ok)
 	}
 }
 
@@ -345,5 +356,26 @@ func TestUpsertUpgradesUntitledKeyWhenTitled(t *testing.T) {
 	// conversation could claim it), yet resolution above still works.
 	if n := len(idx.All()); n != 1 {
 		t.Fatalf("index should hold exactly 1 conversation, got %d", n)
+	}
+
+	// A RENAME re-keys again: the displayed slug must always resolve.
+	key = idx.Upsert(Info{ConversationID: conv, Key: "ship-the-fix", Slug: "ship-the-fix", Adapter: "pi", Title: "Ship the fix"})
+	if key != "ship-the-fix" {
+		t.Fatalf("renamed key = %q, want re-keyed slug", key)
+	}
+	if info, ok := idx.Lookup("pi", "ship-the-fix"); !ok || info.ConversationID != conv {
+		t.Fatalf("Lookup by renamed slug failed: ok=%v info=%+v", ok, info)
+	}
+	if _, ok := idx.Lookup("pi", "fix-the-bug"); ok {
+		t.Fatal("old titled key should be released on rename")
+	}
+	if info, ok := idx.Lookup("pi", conv); !ok || info.Key != "ship-the-fix" {
+		t.Fatal("conversation-ID lookup should track the renamed key")
+	}
+
+	// A transiently empty slug (parse hiccup) must NOT downgrade the key.
+	key = idx.Upsert(Info{ConversationID: conv, Key: "", Adapter: "pi"})
+	if key != "ship-the-fix" {
+		t.Fatalf("untitled refresh re-keyed to %q, want stable ship-the-fix", key)
 	}
 }

--- a/services/gmuxd/internal/conversations/index_test.go
+++ b/services/gmuxd/internal/conversations/index_test.go
@@ -379,3 +379,34 @@ func TestUpsertUpgradesUntitledKeyWhenTitled(t *testing.T) {
 		t.Fatalf("untitled refresh re-keyed to %q, want stable ship-the-fix", key)
 	}
 }
+
+// TestRenameIntoCollidingSlugKeepsDisplayResolvable pins the PR #405 review
+// finding "Collision Key Diverges From Slug": renaming a conversation onto a
+// slug another conversation already holds must suffix BOTH the key and the
+// displayed slug — otherwise the row advertises a URL that resolves the other
+// conversation.
+func TestRenameIntoCollidingSlugKeepsDisplayResolvable(t *testing.T) {
+	idx := New()
+	idx.Upsert(Info{ConversationID: "aaa", Slug: "fix-auth", Adapter: "pi"})
+	idx.Upsert(Info{ConversationID: "bbb", Slug: "hello", Adapter: "pi"})
+
+	key := idx.Upsert(Info{ConversationID: "bbb", Slug: "fix-auth", Adapter: "pi", Title: "fix auth"})
+	if key != "fix-auth-2" {
+		t.Fatalf("colliding rename key = %q, want fix-auth-2", key)
+	}
+	info, ok := idx.Lookup("pi", "fix-auth-2")
+	if !ok || info.ConversationID != "bbb" {
+		t.Fatalf("suffixed key lookup: ok=%v info=%+v", ok, info)
+	}
+	if info.Slug != "fix-auth-2" {
+		t.Fatalf("displayed slug = %q, must equal the deduped key", info.Slug)
+	}
+	// The unsuffixed URL still resolves the ORIGINAL holder.
+	if orig, ok := idx.Lookup("pi", "fix-auth"); !ok || orig.ConversationID != "aaa" {
+		t.Fatalf("unsuffixed slug must keep resolving aaa: ok=%v info=%+v", ok, orig)
+	}
+	// A same-content refresh is a stable no-op (no key churn).
+	if again := idx.Upsert(Info{ConversationID: "bbb", Slug: "fix-auth", Adapter: "pi", Title: "fix auth"}); again != "fix-auth-2" {
+		t.Fatalf("refresh re-keyed to %q, want stable fix-auth-2", again)
+	}
+}

--- a/services/gmuxd/internal/peering/peer.go
+++ b/services/gmuxd/internal/peering/peer.go
@@ -470,7 +470,7 @@ func (p *Peer) handleEvent(ctx context.Context, eventType string, data []byte) {
 		// Authoritative replacement: the spoke's view of its owned
 		// sessions. We mirror it into the local store namespaced by
 		// peer name and remove any local entries for this peer that
-		// no longer appear (handles dismiss, kill, slug takeover that
+		// no longer appear (handles dismiss, kill, conversation takeover that
 		// happened on the spoke).
 		var payload sseSnapshotSessions
 		if err := json.Unmarshal(data, &payload); err != nil {

--- a/services/gmuxd/internal/projects/manager.go
+++ b/services/gmuxd/internal/projects/manager.go
@@ -306,7 +306,7 @@ func (m *Manager) DismissSession(id string) string {
 // Errors are logged so a failed cleanup does not stop the event loop.
 func (m *Manager) WatchRemovals(events <-chan store.Event) {
 	for ev := range events {
-		if ev.Type != "session-remove" {
+		if ev.Type != store.EventSessionRemove {
 			continue
 		}
 		if err := m.RemoveSessionFromAll(ev.ID); err != nil {

--- a/services/gmuxd/internal/projects/manager.go
+++ b/services/gmuxd/internal/projects/manager.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"log"
 	"sync"
+
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/store"
 )
 
 // ValidationError wraps a State.Validate failure produced while applying
@@ -138,7 +140,6 @@ func (m *Manager) Update(fn func(s *State) bool) error {
 // to that project's sessions list. Returns the project slug if assigned.
 // This is called when:
 //   - A new session is discovered (Register)
-//   - A session gets a Slug (file attribution)
 //
 // Dead/resumable sessions are not auto-assigned. projects.json is the
 // source of truth for sidebar membership; if dismiss removed a session key,
@@ -156,33 +157,11 @@ func (m *Manager) AutoAssignSession(info SessionInfo) string {
 	}
 	var assigned string
 	err := m.Update(func(state *State) bool {
-		key := SessionKey(info.ID, info.Slug)
+		key := info.ID
 
 		// Already in a project?
 		if state.FindSessionProject(key) != "" {
 			return false
-		}
-
-		// If the session has a Slug different from its ID, check if
-		// the old key (session ID) is already assigned. This handles the
-		// transition when a session gets attributed: replace the ID-based
-		// entry with the Slug-based entry to preserve ordering.
-		if info.Slug != "" && info.Slug != info.ID {
-			if slug := state.FindSessionProject(info.ID); slug != "" {
-				// Replace ID with Slug in the same position.
-				for i := range state.Items {
-					if state.Items[i].Slug != slug {
-						continue
-					}
-					for j, existing := range state.Items[i].Sessions {
-						if existing == info.ID {
-							state.Items[i].Sessions[j] = info.Slug
-							assigned = slug
-							return true
-						}
-					}
-				}
-			}
 		}
 
 		// Match against project rules.
@@ -223,7 +202,7 @@ func (m *Manager) AutoAssignAll(sessions []SessionInfo) {
 			if info.Host != "" && !info.LocalHost {
 				continue
 			}
-			key := SessionKey(info.ID, info.Slug)
+			key := info.ID
 			if state.FindSessionProject(key) != "" {
 				continue
 			}
@@ -299,20 +278,12 @@ func (m *Manager) CleanupSessions(known map[string]bool) {
 	}
 }
 
-// DismissSession removes a session from its project's sessions list.
+// DismissSession removes a session ID from its project's sessions list.
 // Returns the project slug if the session was found.
-func (m *Manager) DismissSession(id, slug string) string {
+func (m *Manager) DismissSession(id string) string {
 	var removed string
 	err := m.Update(func(state *State) bool {
-		key := SessionKey(id, slug)
-		projectSlug := state.RemoveSessionFromAll(key)
-		if projectSlug == "" {
-			// Also try the ID if we used slug.
-			if slug != "" && slug != id {
-				projectSlug = state.RemoveSessionFromAll(id)
-			}
-		}
-		if projectSlug != "" {
+		if projectSlug := state.RemoveSessionFromAll(id); projectSlug != "" {
 			removed = projectSlug
 			return true
 		}
@@ -322,4 +293,24 @@ func (m *Manager) DismissSession(id, slug string) string {
 		log.Printf("projects: dismiss error: %v", err)
 	}
 	return removed
+}
+
+// WatchRemovals removes project membership for every removed store session.
+// Errors are logged so a failed cleanup does not stop the event loop.
+func (m *Manager) WatchRemovals(events <-chan store.Event) {
+	for ev := range events {
+		if ev.Type != "session-remove" {
+			continue
+		}
+		if err := m.RemoveSessionFromAll(ev.ID); err != nil {
+			log.Printf("projects: cleanup remove %s: %v", ev.ID, err)
+		}
+	}
+}
+
+// RemoveSessionFromAll removes an ID from project membership.
+func (m *Manager) RemoveSessionFromAll(id string) error {
+	return m.Update(func(state *State) bool {
+		return state.RemoveSessionFromAll(id) != ""
+	})
 }

--- a/services/gmuxd/internal/projects/manager.go
+++ b/services/gmuxd/internal/projects/manager.go
@@ -23,8 +23,9 @@ func (e *ValidationError) Unwrap() error { return e.Err }
 // auto-assignment of sessions to projects. All mutations go through
 // Manager to ensure atomic load+modify+save.
 type Manager struct {
-	mu       sync.Mutex
-	stateDir string
+	mu             sync.Mutex
+	stateDir       string
+	legacySlugToID map[string]string
 
 	// Broadcast is called after every state mutation that should be
 	// synced to connected clients (via SSE). The caller receives the
@@ -35,15 +36,21 @@ type Manager struct {
 	Broadcast func(state *State)
 }
 
-func NewManager(stateDir string) *Manager {
-	return &Manager{stateDir: stateDir}
+// NewManager creates a manager. legacySlugToID is the slug-to-session-ID
+// table from sessionmeta's startup sweep, used only while loading v3 files.
+func NewManager(stateDir string, legacySlugToID ...map[string]string) *Manager {
+	var resolver map[string]string
+	if len(legacySlugToID) > 0 {
+		resolver = legacySlugToID[0]
+	}
+	return &Manager{stateDir: stateDir, legacySlugToID: resolver}
 }
 
 // Load returns the current project state. Thread-safe.
 func (m *Manager) Load() (*State, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return Load(m.stateDir)
+	return Load(m.stateDir, m.legacySlugToID)
 }
 
 // SeedIfEmpty creates a default "home" project when no projects exist.
@@ -113,7 +120,7 @@ func (m *Manager) Update(fn func(s *State) bool) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	state, err := Load(m.stateDir)
+	state, err := Load(m.stateDir, m.legacySlugToID)
 	if err != nil {
 		return err
 	}

--- a/services/gmuxd/internal/projects/manager.go
+++ b/services/gmuxd/internal/projects/manager.go
@@ -25,7 +25,7 @@ func (e *ValidationError) Unwrap() error { return e.Err }
 type Manager struct {
 	mu             sync.Mutex
 	stateDir       string
-	legacySlugToID map[string]string
+	legacySlugToID map[string][]string
 
 	// Broadcast is called after every state mutation that should be
 	// synced to connected clients (via SSE). The caller receives the
@@ -38,8 +38,8 @@ type Manager struct {
 
 // NewManager creates a manager. legacySlugToID is the slug-to-session-ID
 // table from sessionmeta's startup sweep, used only while loading v3 files.
-func NewManager(stateDir string, legacySlugToID ...map[string]string) *Manager {
-	var resolver map[string]string
+func NewManager(stateDir string, legacySlugToID ...map[string][]string) *Manager {
+	var resolver map[string][]string
 	if len(legacySlugToID) > 0 {
 		resolver = legacySlugToID[0]
 	}

--- a/services/gmuxd/internal/projects/migrate.go
+++ b/services/gmuxd/internal/projects/migrate.go
@@ -23,7 +23,7 @@ import (
 //     the struct field is gone and the JSON decoder silently drops it.
 //   - 4: Sessions contains session IDs only. v3 → v4 is a structural
 //     pass-through here; Load resolves legacy slug keys with sessionmeta's
-//     startup sweep before decoding (ADR 0023). Hand-edited slug keys are
+//     startup sweep before decoding (ADR 0024). Hand-edited slug keys are
 //     unsupported.
 func migrateState(data []byte) ([]byte, error) {
 	var doc map[string]any

--- a/services/gmuxd/internal/projects/migrate.go
+++ b/services/gmuxd/internal/projects/migrate.go
@@ -21,6 +21,10 @@ import (
 //     is dropped (replaced by ownership). v2 → v3 is a pass-through:
 //     existing items remain owned-style; rule.hosts evaporates because
 //     the struct field is gone and the JSON decoder silently drops it.
+//   - 4: Sessions contains session IDs only. v3 → v4 is a structural
+//     pass-through here; Load resolves legacy slug keys with sessionmeta's
+//     startup sweep before decoding (ADR 0023). Hand-edited slug keys are
+//     unsupported.
 func migrateState(data []byte) ([]byte, error) {
 	var doc map[string]any
 	if err := json.Unmarshal(data, &doc); err != nil {
@@ -35,11 +39,14 @@ func migrateState(data []byte) ([]byte, error) {
 	if version < 2 {
 		migrateV1toV2(doc)
 	}
+	if version < 4 {
+		migrateV3toV4(doc)
+	}
 	// v2 → v3 is structural only: rule.hosts is silently dropped on
 	// load (unknown field), peer references didn't exist before so
-	// nothing to transform. The version bump alone signals "saved by
-	// a v3-aware daemon" so any future migrations downstream see the
-	// right starting point.
+	// nothing to transform. v3 → v4 is likewise structural here: its
+	// session-key conversion requires sessionmeta data and runs in Load.
+	// The version bump signals the resulting schema to future migrations.
 
 	doc["version"] = float64(currentVersion)
 	return json.Marshal(doc)
@@ -57,6 +64,10 @@ func migrateState(data []byte) ([]byte, error) {
 //	{"slug": "gmux", "match": [{"remote": "github.com/gmuxapp/gmux"}, {"path": "~/dev/gmux"}]}
 //
 // The "remote" and "paths" fields are removed. Sessions are preserved as-is.
+// migrateV3toV4 is intentionally a pass-through. Converting Sessions keys
+// needs sessionmeta's slug-to-ID table, which only Load has at startup.
+func migrateV3toV4(doc map[string]any) {}
+
 func migrateV1toV2(doc map[string]any) {
 	items, ok := doc["items"].([]any)
 	if !ok {

--- a/services/gmuxd/internal/projects/migrate_test.go
+++ b/services/gmuxd/internal/projects/migrate_test.go
@@ -40,10 +40,10 @@ func TestMigrateV1ToV2(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	state, err := Load(dir, map[string]string{
-		"hub-protocol": "sess-hub",
-		"gmux":         "sess-gmux",
-		"new":          "sess-new",
+	state, err := Load(dir, map[string][]string{
+		"hub-protocol": {"sess-hub"},
+		"gmux":         {"sess-gmux"},
+		"new":          {"sess-new"},
 	})
 	if err != nil {
 		t.Fatalf("Load: %v", err)
@@ -248,9 +248,9 @@ func TestLoadMigratesV3SessionSlugsToIDs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	state, err := Load(dir, map[string]string{
-		"old-slug":       "sess-resolved",
-		"duplicate-slug": "sess-existing",
+	state, err := Load(dir, map[string][]string{
+		"old-slug":       {"sess-resolved"},
+		"duplicate-slug": {"sess-existing"},
 	})
 	if err != nil {
 		t.Fatalf("Load: %v", err)
@@ -274,7 +274,7 @@ func TestLoadV4DoesNotConvertSessionSlugs(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, fileName), []byte(v4), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	state, err := Load(dir, map[string]string{"typed-slug": "sess-resolved"})
+	state, err := Load(dir, map[string][]string{"typed-slug": {"sess-resolved"}})
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
@@ -299,5 +299,31 @@ func TestMigrateV1EmptyItems(t *testing.T) {
 	}
 	if len(state.Items) != 0 {
 		t.Errorf("expected 0 items, got %d", len(state.Items))
+	}
+}
+
+
+// TestMigrateV3ExpandsCrossAdapterDuplicateSlug pins the adversarial-review
+// P2: a v3 membership key that resolved to MORE THAN ONE dead session (slugs
+// were unique only within (adapter, peer), but a key spanned adapters) must
+// expand to every ID in sweep order — not collapse to one, silently dropping
+// the other dead session from the sidebar.
+func TestMigrateV3ExpandsCrossAdapterDuplicateSlug(t *testing.T) {
+	dir := t.TempDir()
+	v3 := `{"version":3,"items":[{"slug":"proj","match":[{"path":"~/p"}],"sessions":["fix-auth","keep"]}]}`
+	if err := os.WriteFile(filepath.Join(dir, fileName), []byte(v3), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// "fix-auth" was held by a Claude AND a Codex dead session.
+	state, err := Load(dir, map[string][]string{
+		"fix-auth": {"sess-claude", "sess-codex"},
+		"keep":     {"sess-keep"},
+	})
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	want := "[sess-claude sess-codex sess-keep]"
+	if got := fmt.Sprint(state.Items[0].Sessions); got != want {
+		t.Errorf("sessions = %s, want %s (both dead sessions must survive)", got, want)
 	}
 }

--- a/services/gmuxd/internal/projects/migrate_test.go
+++ b/services/gmuxd/internal/projects/migrate_test.go
@@ -40,7 +40,11 @@ func TestMigrateV1ToV2(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	state, err := Load(dir)
+	state, err := Load(dir, map[string]string{
+		"hub-protocol": "sess-hub",
+		"gmux":         "sess-gmux",
+		"new":          "sess-new",
+	})
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
@@ -66,8 +70,8 @@ func TestMigrateV1ToV2(t *testing.T) {
 	if gmux.Match[1].Path != "~/dev/gmux" {
 		t.Errorf("gmux rule 1: path = %q, want ~/dev/gmux", gmux.Match[1].Path)
 	}
-	if len(gmux.Sessions) != 2 || gmux.Sessions[0] != "hub-protocol" {
-		t.Errorf("gmux sessions = %v", gmux.Sessions)
+	if got, want := fmt.Sprint(gmux.Sessions), "[sess-hub sess-gmux]"; got != want {
+		t.Errorf("gmux sessions = %v, want %s", gmux.Sessions, want)
 	}
 
 	// Item 1: tmp — path outside $HOME stays absolute.
@@ -226,6 +230,56 @@ func TestMigrateRoundtrip(t *testing.T) {
 	b, _ := json.Marshal(loaded)
 	if string(a) != string(b) {
 		t.Errorf("roundtrip mismatch:\n  original: %s\n  loaded:   %s", a, b)
+	}
+}
+
+func TestLoadMigratesV3SessionSlugsToIDs(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, fileName)
+	v3 := `{
+  "version": 3,
+  "items": [{
+    "slug": "gmux",
+    "match": [{"path": "~/dev/gmux"}],
+    "sessions": ["sess-existing", "old-slug", "missing-slug", "duplicate-slug", "01234567-89ab-cdef-0123-456789abcdef"]
+  }]
+}`
+	if err := os.WriteFile(path, []byte(v3), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	state, err := Load(dir, map[string]string{
+		"old-slug":       "sess-resolved",
+		"duplicate-slug": "sess-existing",
+	})
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	want := "[sess-existing sess-resolved 01234567-89ab-cdef-0123-456789abcdef]"
+	if got := fmt.Sprint(state.Items[0].Sessions); got != want {
+		t.Errorf("sessions = %s, want %s", got, want)
+	}
+	backup, err := os.ReadFile(path + ".bak")
+	if err != nil {
+		t.Fatalf("reading migration backup: %v", err)
+	}
+	if string(backup) != v3 {
+		t.Errorf("backup = %q, want original v3 bytes", backup)
+	}
+}
+
+func TestLoadV4DoesNotConvertSessionSlugs(t *testing.T) {
+	dir := t.TempDir()
+	v4 := `{"version":4,"items":[{"slug":"gmux","match":[{"path":"~/dev/gmux"}],"sessions":["typed-slug"]}]}`
+	if err := os.WriteFile(filepath.Join(dir, fileName), []byte(v4), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	state, err := Load(dir, map[string]string{"typed-slug": "sess-resolved"})
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := fmt.Sprint(state.Items[0].Sessions); got != "[typed-slug]" {
+		t.Errorf("sessions = %s, want [typed-slug]", got)
 	}
 }
 

--- a/services/gmuxd/internal/projects/projects.go
+++ b/services/gmuxd/internal/projects/projects.go
@@ -25,7 +25,7 @@ const fileName = "projects.json"
 
 // currentVersion is the latest projects.json schema version.
 // See migrateState for the evolution history.
-const currentVersion = 3
+const currentVersion = 4
 
 // MatchRule is a single criterion for matching sessions to a project.
 // Exactly one of Path or Remote should be set.
@@ -56,10 +56,12 @@ type MatchRule struct {
 //
 // Validate enforces exactly one of {Match present, Peer present}.
 type Item struct {
-	Slug     string      `json:"slug"`
-	Peer     string      `json:"peer,omitempty"`
-	Match    []MatchRule `json:"match,omitempty"`
-	Sessions []string    `json:"sessions,omitempty"`
+	Slug  string      `json:"slug"`
+	Peer  string      `json:"peer,omitempty"`
+	Match []MatchRule `json:"match,omitempty"`
+	// Sessions holds ordered session IDs only (v4). Hand-edited slug keys are
+	// unsupported; legacy slug keys are converted once during v3 → v4 Load.
+	Sessions []string `json:"sessions,omitempty"`
 	// NodeID is the referenced peer's stable opaque identity (ADR 0007).
 	// Peer (the display name) is the runtime key; NodeID is only the
 	// viewer's liveness anchor (ADR 0017): it keeps a reference matching
@@ -84,8 +86,9 @@ type State struct {
 // Load reads the project state from stateDir/projects.json.
 // Returns an empty state if the file doesn't exist.
 // Older schema versions are migrated in memory; the migrated form is
-// written back on the next Save.
-func Load(stateDir string) (*State, error) {
+// written back on the next Save. legacySlugToID is the slug-to-session-ID
+// table from sessionmeta's startup sweep, used only by the v3 → v4 migration.
+func Load(stateDir string, legacySlugToID ...map[string]string) (*State, error) {
 	path := filepath.Join(stateDir, fileName)
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -98,9 +101,10 @@ func Load(stateDir string) (*State, error) {
 	// Before a real schema upgrade rewrites the file, snapshot the
 	// pre-migration bytes to projects.json.bak so the change is
 	// recoverable (notably across the 2.0 upgrade). Best-effort.
+	onDisk := onDiskVersion(data)
 	original := data
 	backedUp := false
-	if onDiskVersion(data) < currentVersion {
+	if onDisk < currentVersion {
 		backupFile(path, original)
 		backedUp = true
 	}
@@ -116,6 +120,17 @@ func Load(stateDir string) (*State, error) {
 	var s State
 	if err := json.Unmarshal(data, &s); err != nil {
 		return nil, fmt.Errorf("projects: parsing %s: %w", path, err)
+	}
+
+	if onDisk < 4 {
+		var slugToID map[string]string
+		if len(legacySlugToID) > 0 {
+			slugToID = legacySlugToID[0]
+		}
+		converted, dropped := s.migrateLegacySessionKeys(slugToID)
+		if converted > 0 || dropped > 0 {
+			log.Printf("projects: migrated v3 → v4 session keys (%d converted, %d dropped)", converted, dropped)
+		}
 	}
 
 	// Drop invalid items (e.g. a hand-edited "match": null) instead of
@@ -137,6 +152,41 @@ func Load(stateDir string) (*State, error) {
 		}
 	}
 	return &s, nil
+}
+
+var conversationUUIDRe = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+
+// migrateLegacySessionKeys converts v3 slug membership keys to session IDs.
+// It preserves order and keeps only the first occurrence of each resulting ID.
+func (s *State) migrateLegacySessionKeys(slugToID map[string]string) (converted, dropped int) {
+	knownIDs := make(map[string]bool, len(slugToID))
+	for _, id := range slugToID {
+		knownIDs[id] = true
+	}
+	for i := range s.Items {
+		seen := make(map[string]bool, len(s.Items[i].Sessions))
+		keys := s.Items[i].Sessions[:0]
+		for _, key := range s.Items[i].Sessions {
+			id := key
+			if !knownIDs[key] && !paths.IsValidSessionID(key) && !conversationUUIDRe.MatchString(key) {
+				var ok bool
+				id, ok = slugToID[key]
+				if !ok {
+					dropped++
+					continue
+				}
+				converted++
+			}
+			if seen[id] {
+				dropped++
+				continue
+			}
+			seen[id] = true
+			keys = append(keys, id)
+		}
+		s.Items[i].Sessions = keys
+	}
+	return converted, dropped
 }
 
 // sanitize removes items that fail validation, keeping the rest in

--- a/services/gmuxd/internal/projects/projects.go
+++ b/services/gmuxd/internal/projects/projects.go
@@ -88,7 +88,7 @@ type State struct {
 // Older schema versions are migrated in memory; the migrated form is
 // written back on the next Save. legacySlugToID is the slug-to-session-ID
 // table from sessionmeta's startup sweep, used only by the v3 → v4 migration.
-func Load(stateDir string, legacySlugToID ...map[string]string) (*State, error) {
+func Load(stateDir string, legacySlugToID ...map[string][]string) (*State, error) {
 	path := filepath.Join(stateDir, fileName)
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -123,7 +123,7 @@ func Load(stateDir string, legacySlugToID ...map[string]string) (*State, error) 
 	}
 
 	if onDisk < 4 {
-		var slugToID map[string]string
+		var slugToID map[string][]string
 		if len(legacySlugToID) > 0 {
 			slugToID = legacySlugToID[0]
 		}
@@ -157,32 +157,45 @@ func Load(stateDir string, legacySlugToID ...map[string]string) (*State, error) 
 var conversationUUIDRe = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
 
 // migrateLegacySessionKeys converts v3 slug membership keys to session IDs.
-// It preserves order and keeps only the first occurrence of each resulting ID.
-func (s *State) migrateLegacySessionKeys(slugToID map[string]string) (converted, dropped int) {
+// Order is preserved and each resulting ID is kept once. A slug that resolved
+// to several dead sessions (slugs were unique only within (adapter, peer), but
+// a membership key spanned adapters) expands to ALL of them in sweep order, so
+// no dead session silently loses its sidebar slot.
+func (s *State) migrateLegacySessionKeys(slugToID map[string][]string) (converted, dropped int) {
 	knownIDs := make(map[string]bool, len(slugToID))
-	for _, id := range slugToID {
-		knownIDs[id] = true
+	for _, ids := range slugToID {
+		for _, id := range ids {
+			knownIDs[id] = true
+		}
 	}
 	for i := range s.Items {
 		seen := make(map[string]bool, len(s.Items[i].Sessions))
-		keys := s.Items[i].Sessions[:0]
-		for _, key := range s.Items[i].Sessions {
-			id := key
-			if !knownIDs[key] && !paths.IsValidSessionID(key) && !conversationUUIDRe.MatchString(key) {
-				var ok bool
-				id, ok = slugToID[key]
-				if !ok {
-					dropped++
-					continue
-				}
-				converted++
-			}
+		// A fresh slice, NOT Sessions[:0]: one key can expand to several IDs
+		// (a cross-adapter duplicate slug), and in-place aliasing would
+		// overwrite not-yet-read entries.
+		keys := make([]string, 0, len(s.Items[i].Sessions))
+		emit := func(id string) {
 			if seen[id] {
 				dropped++
-				continue
+				return
 			}
 			seen[id] = true
 			keys = append(keys, id)
+		}
+		for _, key := range s.Items[i].Sessions {
+			if knownIDs[key] || paths.IsValidSessionID(key) || conversationUUIDRe.MatchString(key) {
+				emit(key)
+				continue
+			}
+			ids, ok := slugToID[key]
+			if !ok {
+				dropped++
+				continue
+			}
+			for _, id := range ids {
+				converted++
+				emit(id)
+			}
 		}
 		s.Items[i].Sessions = keys
 	}

--- a/services/gmuxd/internal/projects/projects.go
+++ b/services/gmuxd/internal/projects/projects.go
@@ -47,7 +47,7 @@ type MatchRule struct {
 //
 //   - Owned: Slug + Match[] + Sessions[]. This is a project owned by
 //     this host. Match drives session attribution; Sessions[] holds
-//     the ordered list of session keys for sidebar order.
+//     the ordered list of session IDs for sidebar order.
 //   - Reference: Slug + Peer. This is a viewer-side reference to a
 //     project owned by a peer. Match and Sessions are unused: the
 //     peer's projects.json is the source of truth for both. The viewer
@@ -578,15 +578,11 @@ type Assignment struct {
 	Index int
 }
 
-// AssignmentsByKey returns a flat map from session key to the
-// project Assignment claiming it. Pure derivation from State; the
-// caller is expected to use the result to stamp sessions (see
-// store.Store.Reconcile).
-//
-// First occurrence wins on duplicate keys: a key appearing in two
-// items would point at the first item's Assignment. This shouldn't
-// happen because dismiss/auto-assign keep entries unique, but the
-// behaviour is at least defined.
+// AssignmentsByKey returns a flat map from session ID to the project
+// Assignment claiming it. Pure derivation from State; the caller is expected
+// to use the result to stamp sessions (see store.Store.Reconcile). IDs are
+// unique by construction because auto-assignment never adds an ID already
+// present in a project.
 func (s *State) AssignmentsByKey() map[string]Assignment {
 	out := make(map[string]Assignment)
 	for _, item := range s.Items {
@@ -613,16 +609,6 @@ func (s *State) FindSessionProject(key string) string {
 	return ""
 }
 
-// SessionKey returns the key used to identify a session in project arrays.
-// Uses Slug if available (stable across restarts), falls back to
-// session ID (ephemeral, for sessions without attribution).
-func SessionKey(id, slug string) string {
-	if slug != "" {
-		return slug
-	}
-	return id
-}
-
 // --- Discovery (offered projects) ---
 
 // SessionInfo contains the session fields needed for matching and discovery.
@@ -639,7 +625,6 @@ type SessionInfo struct {
 	LocalHost bool
 	Alive     bool
 	Resumable bool // dead but has a resume command persisted
-	Slug      string
 	// LastActive is an RFC3339 timestamp of the session's most recent
 	// noteworthy activity (last_activity_at, falling back to
 	// created_at). Used to sort discovered suggestions by recency so a
@@ -680,7 +665,7 @@ func (s *State) UnmatchedActiveCount(sessions []SessionInfo) int {
 		if !sess.Alive {
 			continue
 		}
-		key := SessionKey(sess.ID, sess.Slug)
+		key := sess.ID
 		if s.FindSessionProject(key) != "" {
 			continue
 		}

--- a/services/gmuxd/internal/projects/projects_test.go
+++ b/services/gmuxd/internal/projects/projects_test.go
@@ -4,6 +4,9 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
+
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/store"
 )
 
 // --- Load / Save ---
@@ -796,10 +799,10 @@ func TestReorderSessions(t *testing.T) {
 		}
 	})
 
-	t.Run("keys not in existing list are appended at request positions", func(t *testing.T) {
-		// New session `z` arrives in the request before the daemon
-		// has stamped it. ReorderSessions accepts it and inserts it
-		// at the requested position.
+	t.Run("store-validated keys not in existing list are appended", func(t *testing.T) {
+		// The HTTP handler filters unknown IDs against the store before
+		// calling this store-agnostic method. A newly known session can
+		// still be inserted at its requested position.
 		s := State{Items: []Item{
 			{Slug: "gmux", Sessions: []string{"a", "b"}},
 		}}
@@ -873,15 +876,6 @@ func TestFindSessionProject(t *testing.T) {
 	}
 }
 
-func TestSessionKey(t *testing.T) {
-	if key := SessionKey("sess-123", "resume-abc"); key != "resume-abc" {
-		t.Errorf("expected slug, got %q", key)
-	}
-	if key := SessionKey("sess-123", ""); key != "sess-123" {
-		t.Errorf("expected session ID, got %q", key)
-	}
-}
-
 func TestDiscoveredActiveCount(t *testing.T) {
 	s := State{Items: []Item{
 		{Slug: "gmux", Match: []MatchRule{{Remote: "github.com/gmuxapp/gmux"}, {Path: "/dev/gmux"}}},
@@ -948,7 +942,30 @@ func TestManagerAutoAssign(t *testing.T) {
 	}
 }
 
-func TestManagerAutoAssignSlugUpgrade(t *testing.T) {
+func TestManagerAutoAssignDistinctIDsDoNotCollide(t *testing.T) {
+	mgr := NewManager(t.TempDir())
+	if err := mgr.Update(func(s *State) bool {
+		s.Items = []Item{{Slug: "gmux", Match: []MatchRule{{Path: "/dev/gmux"}}}}
+		return true
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	mgr.AutoAssignAll([]SessionInfo{
+		{ID: "sess-adapter-a", Cwd: "/dev/gmux", Alive: true},
+		{ID: "sess-adapter-b", Cwd: "/dev/gmux", Alive: true},
+	})
+	state, err := mgr.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"sess-adapter-a", "sess-adapter-b"}
+	if !equalStrings(state.Items[0].Sessions, want) {
+		t.Errorf("distinct IDs must not collide: got %v, want %v", state.Items[0].Sessions, want)
+	}
+}
+
+func TestManagerAutoAssignKeepsIDOnDisplayNameChange(t *testing.T) {
 	dir := t.TempDir()
 	mgr := NewManager(dir)
 
@@ -969,18 +986,12 @@ func TestManagerAutoAssignSlugUpgrade(t *testing.T) {
 		t.Fatalf("expected sess-1, got %v", state.Items[0].Sessions)
 	}
 
-	// Session gets a slug (file attributed).
-	mgr.AutoAssignSession(SessionInfo{
-		ID: "sess-1", Cwd: "/dev/gmux", Alive: true,
-		Slug: "2026-04-03_abc123.jsonl",
-	})
+	// A later upsert must leave the membership ID and its position unchanged.
+	mgr.AutoAssignSession(SessionInfo{ID: "sess-1", Cwd: "/dev/gmux", Alive: true})
 
 	state, _ = mgr.Load()
-	if len(state.Items[0].Sessions) != 1 {
-		t.Fatalf("expected 1 session after upgrade, got %d", len(state.Items[0].Sessions))
-	}
-	if state.Items[0].Sessions[0] != "2026-04-03_abc123.jsonl" {
-		t.Errorf("expected slug, got %q", state.Items[0].Sessions[0])
+	if len(state.Items[0].Sessions) != 1 || state.Items[0].Sessions[0] != "sess-1" {
+		t.Errorf("expected [sess-1], got %v", state.Items[0].Sessions)
 	}
 }
 
@@ -990,12 +1001,12 @@ func TestManagerDismissSession(t *testing.T) {
 
 	mgr.Update(func(s *State) bool {
 		s.Items = []Item{
-			{Slug: "gmux", Match: []MatchRule{{Path: "/dev/gmux"}}, Sessions: []string{"key-1", "key-2"}},
+			{Slug: "gmux", Match: []MatchRule{{Path: "/dev/gmux"}}, Sessions: []string{"sess-x", "key-2"}},
 		}
 		return true
 	})
 
-	slug := mgr.DismissSession("sess-x", "key-1")
+	slug := mgr.DismissSession("sess-x")
 	if slug != "gmux" {
 		t.Errorf("expected 'gmux', got %q", slug)
 	}
@@ -1043,7 +1054,7 @@ func TestManagerDeadResumableNotAutoAssigned(t *testing.T) {
 	})
 
 	assigned := mgr.AutoAssignSession(SessionInfo{
-		ID: "sess-1", Cwd: "/dev/gmux", Alive: false, Resumable: true, Slug: "fix-sidebar",
+		ID: "sess-1", Cwd: "/dev/gmux", Alive: false, Resumable: true,
 	})
 	if assigned != "" {
 		t.Fatalf("dead/resumable session should not be auto-assigned, got %q", assigned)
@@ -1087,28 +1098,31 @@ func TestUnmatchedActiveCountAllMatched(t *testing.T) {
 	}
 }
 
-// --- DismissSession with ID fallback ---
-
-func TestManagerDismissSessionByIDFallback(t *testing.T) {
-	dir := t.TempDir()
-	mgr := NewManager(dir)
-
-	// Array stores session by ID (no slug at assignment time).
-	mgr.Update(func(s *State) bool {
-		s.Items = []Item{
-			{Slug: "gmux", Match: []MatchRule{{Path: "/dev/gmux"}}, Sessions: []string{"sess-1"}},
-		}
+func TestManagerWatchRemovals(t *testing.T) {
+	mgr := NewManager(t.TempDir())
+	if err := mgr.Update(func(s *State) bool {
+		s.Items = []Item{{Slug: "gmux", Match: []MatchRule{{Path: "/dev/gmux"}}, Sessions: []string{"sess-1"}}}
 		return true
-	})
-
-	// Dismiss provides slug, but array has the session by ID.
-	// DismissSession should fall back to trying the ID.
-	slug := mgr.DismissSession("sess-1", "resume-key-abc")
-	if slug != "gmux" {
-		t.Errorf("expected 'gmux', got %q", slug)
+	}); err != nil {
+		t.Fatal(err)
 	}
 
-	state, _ := mgr.Load()
+	events := make(chan store.Event)
+	done := make(chan struct{})
+	go func() { mgr.WatchRemovals(events); close(done) }()
+	events <- store.Event{Type: "session-remove", ID: "sess-1"}
+	events <- store.Event{Type: "session-remove", ID: "sess-1"} // idempotent after dismiss/removal
+	close(events)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("WatchRemovals did not return after channel close")
+	}
+
+	state, err := mgr.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
 	if len(state.Items[0].Sessions) != 0 {
 		t.Errorf("expected empty sessions, got %v", state.Items[0].Sessions)
 	}

--- a/services/gmuxd/internal/projects/projects_test.go
+++ b/services/gmuxd/internal/projects/projects_test.go
@@ -1110,8 +1110,11 @@ func TestManagerWatchRemovals(t *testing.T) {
 	events := make(chan store.Event)
 	done := make(chan struct{})
 	go func() { mgr.WatchRemovals(events); close(done) }()
-	events <- store.Event{Type: "session-remove", ID: "sess-1"}
-	events <- store.Event{Type: "session-remove", ID: "sess-1"} // idempotent after dismiss/removal
+	// Activity pulses (#399's turn model) share the bus but are not
+	// removals — membership must survive them.
+	events <- store.Event{Type: store.EventSessionActivity, ID: "sess-1"}
+	events <- store.Event{Type: store.EventSessionRemove, ID: "sess-1"}
+	events <- store.Event{Type: store.EventSessionRemove, ID: "sess-1"} // idempotent after dismiss/removal
 	close(events)
 	select {
 	case <-done:

--- a/services/gmuxd/internal/sessionmeta/sessionmeta.go
+++ b/services/gmuxd/internal/sessionmeta/sessionmeta.go
@@ -364,11 +364,10 @@ func (s *Store) Remove(id string) error {
 // after every store removal, not just the dismiss / resume-merge
 // paths that have explicit Remove calls.
 //
-// Catches the slug-takeover case: when a fresh live session
-// shadows a dead one with the same (adapter, peer, slug), the store
-// silently evicts the dead record and broadcasts session-remove.
-// Without this loop those orphan meta.json files accumulate — the
-// next Sweep would re-load them and the next slug collision would
+// Catches conversation-lineage takeover: when a fresh live session
+// resumes a dead conversation, the store silently evicts the dead record and
+// broadcasts session-remove. Without this loop those orphan meta.json files
+// accumulate — the next Sweep would re-load them and the next takeover would
 // re-orphan, indefinitely.
 //
 // Errors from Remove are logged; failure to clean up one entry

--- a/services/gmuxd/internal/sessionmeta/sessionmeta_test.go
+++ b/services/gmuxd/internal/sessionmeta/sessionmeta_test.go
@@ -383,7 +383,7 @@ func TestSweepReturnsEmptyForMissingDir(t *testing.T) {
 // on-disk record; events of other types do not; the loop terminates
 // cleanly when the channel closes.
 //
-// This is the catch-all for slug-takeover orphans (and any other
+// This is the catch-all for conversation-takeover orphans (and any other
 // store removal not paired with an explicit Remove call). A
 // regression here would silently leak per-session directories.
 func TestWatchRemovalsRemovesOnSessionRemoveEvent(t *testing.T) {

--- a/services/gmuxd/internal/store/store.go
+++ b/services/gmuxd/internal/store/store.go
@@ -223,7 +223,7 @@ type Store struct {
 	activitySeed func(Session) string
 
 	lineageMu    sync.Mutex
-	lineageByRef map[string]lineageEntry
+	lineageByRef map[string]lineageEntry // key: adapter\x00ref (refs are unique only within an adapter, ADR 0022)
 }
 
 func New() *Store {
@@ -444,6 +444,11 @@ func (s *Store) Update(id string, fn func(*Session)) bool {
 	// update — warm the lineage cache OUTSIDE the critical section and
 	// retry the whole update from fresh state. The loop is bounded: the
 	// cache records failures too, so the second pass always hits it.
+	// describedRef guards the unlock-describe-retry so it runs at most once
+	// per distinct ref this call: termination is independent of whether the
+	// describe succeeded or was cached (a transient describe failure is not
+	// cached, so a cache-presence gate would livelock here).
+	describedRef := ""
 	for {
 		s.mu.Lock()
 		prev, ok := s.sessions[id]
@@ -462,11 +467,16 @@ func (s *Store) Update(id string, fn func(*Session)) bool {
 			sess.LastActivityAt = nowRFC3339()
 		}
 		if sess.Peer == "" && sess.ConversationRef != "" && sess.ConversationRef != prev.ConversationRef {
-			if !s.lineagePrepared(sess.ConversationRef) {
+			if describedRef != sess.ConversationRef {
 				s.mu.Unlock()
 				s.prepareConversationLineage(&sess)
+				describedRef = sess.ConversationRef
 				continue
 			}
+			// Second pass for this ref: re-apply the lineage onto the
+			// fresh copy (cache hit when the describe succeeded; a
+			// re-describe of a still-missing ref just yields empty again
+			// and we proceed — no loop).
 			s.prepareConversationLineage(&sess)
 		}
 		removed, skip, unchanged := s.commitLocked(prev, true, &sess)
@@ -474,15 +484,6 @@ func (s *Store) Update(id string, fn func(*Session)) bool {
 		s.broadcastCommit(sess, removed, skip, unchanged)
 		return true
 	}
-}
-
-// lineagePrepared reports whether the lineage cache already covers ref, i.e.
-// prepareConversationLineage will not perform adapter I/O for it.
-func (s *Store) lineagePrepared(ref string) bool {
-	s.lineageMu.Lock()
-	defer s.lineageMu.Unlock()
-	_, known := s.lineageByRef[ref]
-	return known
 }
 
 // GetTerminalSize returns the current terminal dimensions for a session.
@@ -526,6 +527,13 @@ func (s *Store) SetTerminalSize(id string, cols, rows uint16) bool {
 	return true
 }
 
+// lineageKey scopes the lineage cache to a single adapter: opaque refs are
+// unique only within an adapter (ADR 0022), so two adapters that happen to
+// use the same ref string must not share a cache entry.
+func lineageKey(adapterName, ref string) string {
+	return adapterName + "\x00" + ref
+}
+
 // prepareConversationLineage describes the bound conversation at bind time,
 // outside the store mutex. Its per-ref cache means recurring writes (notably
 // peer snapshots) never re-describe. Peer (including Local-peer) refs are
@@ -536,24 +544,33 @@ func (s *Store) prepareConversationLineage(sess *Session) {
 	if sess.Peer != "" || sess.ConversationRef == "" {
 		return
 	}
+	key := lineageKey(sess.Adapter, sess.ConversationRef)
 	s.lineageMu.Lock()
 	defer s.lineageMu.Unlock()
-	if cached, known := s.lineageByRef[sess.ConversationRef]; known {
+	if cached, known := s.lineageByRef[key]; known {
 		sess.conversationID = cached.id
 		sess.conversationAncestors = cached.ancestors
 		return
 	}
-	// Cache describe failures too: ref-equality takeover needs no describe,
-	// and repeatedly trying a missing/bad ref on status updates is pointless.
+	// A describe FAILURE (ref absent/unreadable — e.g. a resumed transcript
+	// not yet on disk at first bind) is NOT cached: caching it would poison
+	// the ref permanently and silently defeat takeover once the file lands.
+	// A successful describe is stable (ancestors never disappear) and cached.
 	var entry lineageEntry
+	cache := false
 	if a := adapters.FindByAdapter(sess.Adapter); a != nil {
 		if describer, ok := a.(adapter.ConversationDescriber); ok {
 			if info, err := describer.DescribeConversation(sess.ConversationRef); err == nil {
 				entry = lineageEntry{id: info.ID, ancestors: info.AncestorIDs}
+				cache = true
 			}
 		}
+	} else {
+		cache = true // no describer for this adapter: nothing to learn later
 	}
-	s.lineageByRef[sess.ConversationRef] = entry
+	if cache {
+		s.lineageByRef[key] = entry
+	}
 	sess.conversationID = entry.id
 	sess.conversationAncestors = entry.ancestors
 }

--- a/services/gmuxd/internal/store/store.go
+++ b/services/gmuxd/internal/store/store.go
@@ -438,33 +438,51 @@ func (s *Store) broadcastCommit(sess Session, removed []string, skip, unchanged 
 // (e.g. the file monitor and the SSE subscriber goroutines).
 // Returns false if the session doesn't exist.
 func (s *Store) Update(id string, fn func(*Session)) bool {
-	s.mu.Lock()
-	prev, ok := s.sessions[id]
-	if !ok {
-		s.mu.Unlock()
-		return false
-	}
-	prevSnap := snapshotActivity(prev)
-	sess := prev
-	fn(&sess)
-	sess.Cwd = paths.CanonicalizePath(sess.Cwd)
-	sess.WorkspaceRoot = paths.CanonicalizePath(sess.WorkspaceRoot)
-	sess.Title = s.resolveTitle(sess)
-	sess.Resumable = !sess.Alive && len(sess.Command) > 0
-	if shouldBumpActivity(prevSnap, true, snapshotActivity(sess)) {
-		sess.LastActivityAt = nowRFC3339()
-	}
-	// Conversation attribution arrives through Update. Only a new local bind
-	// needs adapter I/O; routine updates retain Update's atomic critical section.
-	if sess.Peer == "" && sess.ConversationRef != "" && sess.ConversationRef != prev.ConversationRef {
-		s.mu.Unlock()
-		s.prepareConversationLineage(&sess)
+	// A new conversation bind needs adapter I/O (DescribeConversation) that
+	// must not run under s.mu. Rather than dropping the lock mid-update —
+	// which could write a stale copy back over a concurrent dismiss or
+	// update — warm the lineage cache OUTSIDE the critical section and
+	// retry the whole update from fresh state. The loop is bounded: the
+	// cache records failures too, so the second pass always hits it.
+	for {
 		s.mu.Lock()
+		prev, ok := s.sessions[id]
+		if !ok {
+			s.mu.Unlock()
+			return false
+		}
+		prevSnap := snapshotActivity(prev)
+		sess := prev
+		fn(&sess)
+		sess.Cwd = paths.CanonicalizePath(sess.Cwd)
+		sess.WorkspaceRoot = paths.CanonicalizePath(sess.WorkspaceRoot)
+		sess.Title = s.resolveTitle(sess)
+		sess.Resumable = !sess.Alive && len(sess.Command) > 0
+		if shouldBumpActivity(prevSnap, true, snapshotActivity(sess)) {
+			sess.LastActivityAt = nowRFC3339()
+		}
+		if sess.Peer == "" && sess.ConversationRef != "" && sess.ConversationRef != prev.ConversationRef {
+			if !s.lineagePrepared(sess.ConversationRef) {
+				s.mu.Unlock()
+				s.prepareConversationLineage(&sess)
+				continue
+			}
+			s.prepareConversationLineage(&sess)
+		}
+		removed, skip, unchanged := s.commitLocked(prev, true, &sess)
+		s.mu.Unlock()
+		s.broadcastCommit(sess, removed, skip, unchanged)
+		return true
 	}
-	removed, skip, unchanged := s.commitLocked(prev, true, &sess)
-	s.mu.Unlock()
-	s.broadcastCommit(sess, removed, skip, unchanged)
-	return true
+}
+
+// lineagePrepared reports whether the lineage cache already covers ref, i.e.
+// prepareConversationLineage will not perform adapter I/O for it.
+func (s *Store) lineagePrepared(ref string) bool {
+	s.lineageMu.Lock()
+	defer s.lineageMu.Unlock()
+	_, known := s.lineageByRef[ref]
+	return known
 }
 
 // GetTerminalSize returns the current terminal dimensions for a session.

--- a/services/gmuxd/internal/store/store.go
+++ b/services/gmuxd/internal/store/store.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/gmuxapp/gmux/packages/adapter"
+	"github.com/gmuxapp/gmux/packages/adapter/adapters"
 	"github.com/gmuxapp/gmux/packages/paths"
 )
 
@@ -66,8 +68,8 @@ type Session struct {
 	TerminalRows   uint16 `json:"terminal_rows,omitempty"`
 	// Slug is a human-readable stable identifier derived from the
 	// adapter's conversation-derived slug. Used for URL routing (the frontend
-	// falls back to id[:8] when empty) and for matching dead sessions
-	// to project membership arrays. Unique within (adapter, peer).
+	// falls back to the session id when empty). It is display-only and unique
+	// within (adapter, peer).
 	Slug string `json:"slug,omitempty"`
 
 	// ConversationRef is the opaque, adapter-scoped ref of the conversation
@@ -119,6 +121,14 @@ type Session struct {
 	// can never be observed stale.
 	ProjectSlug  string `json:"project_slug,omitempty"`
 	ProjectIndex int    `json:"project_index,omitempty"`
+
+	// conversationID and conversationAncestors are described once when a
+	// local runner binds a conversation ref (prepareConversationLineage) and
+	// drive lineage takeover. The daemon treats the ref itself as opaque
+	// (ADR 0022); identity comes from the adapter's DescribeConversation.
+	// Both are unexported: in-memory matching state, never marshaled.
+	conversationID        string
+	conversationAncestors []string
 }
 
 // MarshalJSON serializes a Session for the frontend API, excluding internal
@@ -211,12 +221,16 @@ type Store struct {
 	// in-memory stamp was never persisted. Returns "" when no seed is
 	// available. See SetActivitySeed.
 	activitySeed func(Session) string
+
+	lineageMu    sync.Mutex
+	lineageByRef map[string]lineageEntry
 }
 
 func New() *Store {
 	return &Store{
-		sessions:    make(map[string]Session),
-		subscribers: make(map[*subscriber]struct{}),
+		sessions:     make(map[string]Session),
+		subscribers:  make(map[*subscriber]struct{}),
+		lineageByRef: make(map[string]lineageEntry),
 	}
 }
 
@@ -335,6 +349,12 @@ func (s *Store) upsertCommon(sess Session, bumpLocally bool) {
 	if bumpLocally && sess.LastActivityAt == "" && s.activitySeed != nil {
 		seed = s.activitySeed(sess)
 	}
+
+	// Describing adapter conversations can be expensive. Do it before taking
+	// the store mutex, and only once per local conversation ref; peer
+	// snapshots arrive frequently and their refs belong to another host.
+	s.prepareConversationLineage(&sess)
+
 	s.mu.Lock()
 	prev, hadPrev := s.sessions[sess.ID]
 	if bumpLocally {
@@ -364,15 +384,15 @@ func (s *Store) upsertCommon(sess Session, bumpLocally bool) {
 }
 
 // commitLocked finalizes sess into the store and reports what the write
-// did. It resolves duplicate slugs (which may evict shadowed sessions),
-// assigns a unique slug, and stores the result. The caller must hold
+// did. It resolves conversation takeovers (which may evict shadowed
+// sessions), assigns a unique display/URL slug, and stores the result. The caller must hold
 // s.mu.
 //
 // Returns:
-//   - removed: ids evicted by duplicate-slug resolution (a live session
-//     shadows a dead one with the same slug).
-//   - skip: the write was dropped entirely (a dead session shadowed by a
-//     live one); nothing was stored.
+//   - removed: ids evicted by conversation-lineage takeover (a live session
+//     shadows a dead conversation it resumes).
+//   - skip: the write was dropped entirely (a dead conversation shadowed by a
+//     live session that owns it); nothing was stored.
 //   - unchanged: the stored session is byte-identical to prev, so this
 //     was a no-op that must NOT broadcast session-upsert.
 //
@@ -386,7 +406,7 @@ func (s *Store) upsertCommon(sess Session, bumpLocally bool) {
 // and unique-slug renumbering), not the caller's raw input, is what
 // makes the comparison correct. See ADR 0001.
 func (s *Store) commitLocked(prev Session, hadPrev bool, sess *Session) (removed []string, skip, unchanged bool) {
-	removed, skip = s.resolveDuplicateSlugsLocked(*sess)
+	removed, skip = s.resolveConversationTakeoverLocked(*sess)
 	if skip {
 		return removed, true, false
 	}
@@ -433,6 +453,13 @@ func (s *Store) Update(id string, fn func(*Session)) bool {
 	sess.Resumable = !sess.Alive && len(sess.Command) > 0
 	if shouldBumpActivity(prevSnap, true, snapshotActivity(sess)) {
 		sess.LastActivityAt = nowRFC3339()
+	}
+	// Conversation attribution arrives through Update. Only a new local bind
+	// needs adapter I/O; routine updates retain Update's atomic critical section.
+	if sess.Peer == "" && sess.ConversationRef != "" && sess.ConversationRef != prev.ConversationRef {
+		s.mu.Unlock()
+		s.prepareConversationLineage(&sess)
+		s.mu.Lock()
 	}
 	removed, skip, unchanged := s.commitLocked(prev, true, &sess)
 	s.mu.Unlock()
@@ -481,29 +508,98 @@ func (s *Store) SetTerminalSize(id string, cols, rows uint16) bool {
 	return true
 }
 
-// resolveDuplicateSlugsLocked deduplicates sessions that share a Slug
-// within the same (adapter, peer) scope. When a live session arrives and
-// a dead session with the same slug exists, the dead one is removed.
-// When a dead session arrives and a live one exists, the dead one is
-// skipped.
-func (s *Store) resolveDuplicateSlugsLocked(sess Session) (removed []string, skip bool) {
-	if sess.Slug == "" {
+// prepareConversationLineage describes the bound conversation at bind time,
+// outside the store mutex. Its per-ref cache means recurring writes (notably
+// peer snapshots) never re-describe. Peer (including Local-peer) refs are
+// owned by another daemon, so they deliberately get no local takeover
+// behavior. The ref is opaque to the daemon (ADR 0022): both the
+// conversation's own ID and its ancestors come from the adapter.
+func (s *Store) prepareConversationLineage(sess *Session) {
+	if sess.Peer != "" || sess.ConversationRef == "" {
+		return
+	}
+	s.lineageMu.Lock()
+	defer s.lineageMu.Unlock()
+	if cached, known := s.lineageByRef[sess.ConversationRef]; known {
+		sess.conversationID = cached.id
+		sess.conversationAncestors = cached.ancestors
+		return
+	}
+	// Cache describe failures too: ref-equality takeover needs no describe,
+	// and repeatedly trying a missing/bad ref on status updates is pointless.
+	var entry lineageEntry
+	if a := adapters.FindByAdapter(sess.Adapter); a != nil {
+		if describer, ok := a.(adapter.ConversationDescriber); ok {
+			if info, err := describer.DescribeConversation(sess.ConversationRef); err == nil {
+				entry = lineageEntry{id: info.ID, ancestors: info.AncestorIDs}
+			}
+		}
+	}
+	s.lineageByRef[sess.ConversationRef] = entry
+	sess.conversationID = entry.id
+	sess.conversationAncestors = entry.ancestors
+}
+
+// lineageEntry caches what the adapter said about a conversation ref.
+type lineageEntry struct {
+	id        string
+	ancestors []string
+}
+
+// conversationLineage is the set of conversation IDs a session's bound
+// conversation covers: its own ID plus every ancestor it was resumed from.
+// Empty when the adapter could not describe the ref — ref equality still
+// applies then.
+func conversationLineage(sess *Session) map[string]struct{} {
+	lineage := make(map[string]struct{}, len(sess.conversationAncestors)+1)
+	if sess.conversationID != "" {
+		lineage[sess.conversationID] = struct{}{}
+	}
+	for _, id := range sess.conversationAncestors {
+		lineage[id] = struct{}{}
+	}
+	return lineage
+}
+
+// coversConversation reports whether owner's bound conversation is, or
+// descends from, other's: same opaque ref (adapter-scoped equality is
+// daemon-legal even without a describe), or other's conversation ID is in
+// owner's lineage.
+func coversConversation(owner, other *Session) bool {
+	if owner.ConversationRef == other.ConversationRef {
+		return true
+	}
+	if other.conversationID == "" {
+		return false
+	}
+	_, owns := conversationLineage(owner)[other.conversationID]
+	return owns
+}
+
+// resolveConversationTakeoverLocked applies continuity only to local
+// sessions bound to conversation refs. Within one adapter/peer scope, a live
+// binder evicts dead rows whose conversation it covers (same ref, or an
+// ancestor per the adapter's lineage); a dead write is skipped when a live
+// row covers its conversation. Live rows always coexist. The caller must
+// hold s.mu.
+func (s *Store) resolveConversationTakeoverLocked(sess Session) (removed []string, skip bool) {
+	if sess.Peer != "" || sess.ConversationRef == "" {
 		return nil, false
 	}
 	for id, other := range s.sessions {
-		if id == sess.ID || other.Slug != sess.Slug {
-			continue
-		}
-		// Same (adapter, peer) scope check.
-		if other.Adapter != sess.Adapter || other.Peer != sess.Peer {
+		if id == sess.ID || other.Adapter != sess.Adapter || other.Peer != sess.Peer || other.ConversationRef == "" {
 			continue
 		}
 		switch {
 		case sess.Alive && !other.Alive:
-			delete(s.sessions, id)
-			removed = append(removed, id)
+			if coversConversation(&sess, &other) {
+				delete(s.sessions, id)
+				removed = append(removed, id)
+			}
 		case !sess.Alive && other.Alive:
-			return removed, true
+			if coversConversation(&other, &sess) {
+				return removed, true
+			}
 		}
 	}
 	return removed, false
@@ -692,8 +788,8 @@ func NowUnix() float64 {
 	return float64(time.Now().UnixNano()) / float64(time.Second)
 }
 
-// ensureUniqueSlug appends "-2", "-3" suffixes to the session's
-// Slug when another session in the same (adapter, peer) scope already
+// ensureUniqueSlug keeps display/URL slugs distinct by appending "-2",
+// "-3" suffixes when another session in the same (adapter, peer) scope already
 // uses that key. Sessions without a Slug (fresh launches before
 // file attribution) are left alone; the frontend falls back to the
 // session ID prefix for URL routing.

--- a/services/gmuxd/internal/store/store_test.go
+++ b/services/gmuxd/internal/store/store_test.go
@@ -2,6 +2,8 @@ package store
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -71,8 +73,10 @@ func TestRemoveDeadByConversationRef(t *testing.T) {
 	// Two dead sessions share the file (N:1, e.g. resumed in two tabs).
 	s.Upsert(Session{ID: "dead-1", Adapter: "claude", Alive: false, ConversationRef: file})
 	s.Upsert(Session{ID: "dead-2", Adapter: "claude", Alive: false, ConversationRef: file})
-	// A live session on the same file must survive (runner still writing).
-	s.Upsert(Session{ID: "live", Adapter: "claude", Alive: true, ConversationRef: file})
+	// An unrelated live session must survive (runner still writing). (A live
+	// session on the SAME ref would legitimately take the dead rows over
+	// before this removal runs — that's conversation-lineage takeover.)
+	s.Upsert(Session{ID: "live", Adapter: "claude", Alive: true, ConversationRef: "/home/u/.claude/projects/abc/live.jsonl"})
 	// A peer-owned dead session on the same file is not ours to retire.
 	s.Upsert(Session{ID: "peer", Adapter: "claude", Alive: false, Peer: "box2", ConversationRef: file})
 	// An unrelated dead session must be untouched.
@@ -476,94 +480,68 @@ func TestUpdateBroadcasts(t *testing.T) {
 	}
 }
 
-func TestUpsertAliveSessionRemovesDeadShadowWithSameSlug(t *testing.T) {
+func TestConversationTakeoverSameFileAndUntitled(t *testing.T) {
 	s := New()
-	s.Upsert(Session{
-		ID: "dead-abc", Adapter: "pi", Alive: false,
-		Command: []string{"pi"}, Slug: "rk-1", AdapterTitle: "shadow",
-	})
-	s.Upsert(Session{
-		ID: "sess-123", Adapter: "pi", Alive: true,
-		Slug: "rk-1", AdapterTitle: "live",
-	})
-
-	items := s.List()
-	if len(items) != 1 {
-		t.Fatalf("expected 1 session, got %d: %+v", len(items), items)
-	}
-	if items[0].ID != "sess-123" {
-		t.Fatalf("expected live session to remain, got %q", items[0].ID)
+	file := "/tmp/pi/conversation.jsonl"
+	s.Upsert(Session{ID: "dead", Adapter: "pi", Alive: false, ConversationRef: file})
+	s.Upsert(Session{ID: "live", Adapter: "pi", Alive: true, ConversationRef: file})
+	if _, ok := s.Get("dead"); ok {
+		t.Fatal("live binder should evict its dead same-file predecessor")
 	}
 }
 
-func TestUpsertDeadShadowSkippedWhenAliveSessionExists(t *testing.T) {
-	s := New()
-	s.Upsert(Session{
-		ID: "sess-123", Adapter: "pi", Alive: true,
-		Slug: "rk-1", AdapterTitle: "live",
-	})
-	s.Upsert(Session{
-		ID: "dead-abc", Adapter: "pi", Alive: false,
-		Command: []string{"pi"}, Slug: "rk-1", AdapterTitle: "shadow",
-	})
-
-	items := s.List()
-	if len(items) != 1 {
-		t.Fatalf("expected 1 session, got %d: %+v", len(items), items)
+func TestConversationTakeoverClaudeLineage(t *testing.T) {
+	const ancestor = "11111111-1111-4111-8111-111111111111"
+	const resumed = "22222222-2222-4222-8222-222222222222"
+	dir := t.TempDir()
+	newFile := filepath.Join(dir, resumed+".jsonl")
+	if err := os.WriteFile(newFile, []byte(`{"type":"user","sessionId":"`+ancestor+`","message":{"role":"user","content":"hello"}}`), 0o644); err != nil {
+		t.Fatal(err)
 	}
-	if items[0].ID != "sess-123" {
-		t.Fatalf("expected live session to remain, got %q", items[0].ID)
+	// The dead row's transcript exists on disk (it's a resumable session);
+	// its identity comes from DescribeConversation, never from the ref
+	// string — refs are adapter-opaque (ADR 0022).
+	ancestorFile := filepath.Join(dir, ancestor+".jsonl")
+	if err := os.WriteFile(ancestorFile, []byte(`{"type":"user","sessionId":"`+ancestor+`","message":{"role":"user","content":"hello"}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s := New()
+	s.Upsert(Session{ID: "dead", Adapter: "claude", Alive: false, ConversationRef: ancestorFile})
+	s.Upsert(Session{ID: "live", Adapter: "claude", Alive: true, ConversationRef: newFile})
+	if _, ok := s.Get("dead"); ok {
+		t.Fatal("live Claude resume should evict a dead ancestor")
 	}
 }
 
-func TestUpdateSlugOnAliveSessionRemovesDeadShadow(t *testing.T) {
+func TestConversationTakeoverIgnoresSameSlug(t *testing.T) {
 	s := New()
-	s.Upsert(Session{
-		ID: "dead-abc", Adapter: "pi", Alive: false,
-		Command: []string{"pi"}, Slug: "rk-1", AdapterTitle: "shadow",
-	})
-	s.Upsert(Session{
-		ID: "sess-123", Adapter: "pi", Alive: true, AdapterTitle: "live",
-	})
-
-	ok := s.Update("sess-123", func(sess *Session) {
-		sess.Slug = "rk-1"
-	})
-	if !ok {
-		t.Fatal("expected update to succeed")
-	}
-
-	items := s.List()
-	if len(items) != 1 {
-		t.Fatalf("expected 1 session, got %d: %+v", len(items), items)
-	}
-	if items[0].ID != "sess-123" {
-		t.Fatalf("expected live session to remain, got %q", items[0].ID)
-	}
-}
-
-func TestSlugDedup_ScopedToKindAndPeer(t *testing.T) {
-	s := New()
-	// Dead pi session with slug "fix-auth".
-	s.Upsert(Session{ID: "dead-1", Adapter: "pi", Alive: false, Command: []string{"pi"}, Slug: "fix-auth"})
-	// Live claude session with the same slug — different adapter, should NOT remove the dead pi session.
-	s.Upsert(Session{ID: "live-1", Adapter: "claude", Alive: true, Slug: "fix-auth"})
-
+	s.Upsert(Session{ID: "dead", Adapter: "pi", Alive: false, Slug: "same-title", ConversationRef: "/tmp/a.jsonl"})
+	s.Upsert(Session{ID: "live", Adapter: "pi", Alive: true, Slug: "same-title", ConversationRef: "/tmp/b.jsonl"})
 	if len(s.List()) != 2 {
-		t.Fatalf("expected 2 sessions (different kinds coexist), got %d", len(s.List()))
+		t.Fatal("different conversations with the same title must coexist")
 	}
+}
 
-	// Now a live pi session arrives — should remove the dead pi session.
-	s.Upsert(Session{ID: "live-2", Adapter: "pi", Alive: true, Slug: "fix-auth"})
-
-	items := s.List()
-	if len(items) != 2 {
-		t.Fatalf("expected 2 sessions (claude + live pi), got %d", len(items))
+func TestConversationTakeoverLiveLiveAndDeadShadow(t *testing.T) {
+	file := "/tmp/pi/conversation.jsonl"
+	s := New()
+	s.Upsert(Session{ID: "live-1", Adapter: "pi", Alive: true, ConversationRef: file})
+	s.Upsert(Session{ID: "live-2", Adapter: "pi", Alive: true, ConversationRef: file})
+	if len(s.List()) != 2 {
+		t.Fatal("live sessions on one conversation must coexist")
 	}
-	for _, item := range items {
-		if item.ID == "dead-1" {
-			t.Error("dead pi session should have been replaced by live pi session")
-		}
+	s.Upsert(Session{ID: "dead", Adapter: "pi", Alive: false, ConversationRef: file})
+	if _, ok := s.Get("dead"); ok {
+		t.Fatal("dead write shadowed by a live conversation owner must be skipped")
+	}
+}
+
+func TestConversationTakeoverDoesNotApplyToShells(t *testing.T) {
+	s := New()
+	s.Upsert(Session{ID: "dead", Adapter: "shell", Alive: false, Slug: "same"})
+	s.Upsert(Session{ID: "live", Adapter: "shell", Alive: true, Slug: "same"})
+	if len(s.List()) != 2 {
+		t.Fatal("sessions without conversation files must not take over")
 	}
 }
 

--- a/services/gmuxd/internal/store/store_test.go
+++ b/services/gmuxd/internal/store/store_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -1673,5 +1674,55 @@ func TestLastActivityAt_UpsertRemotePreserves(t *testing.T) {
 	got2, _ := s.Get("s1")
 	if got2.LastActivityAt != wired {
 		t.Fatalf("UpsertRemote alive→false should preserve peer-supplied timestamp (want %q, got %q)", wired, got2.LastActivityAt)
+	}
+}
+
+// TestUpdateBindDoesNotResurrectRemovedSession pins the fix for a race in
+// Update's first-bind path: describing a conversation (adapter I/O) must not
+// run under s.mu, but dropping the lock and writing the pre-drop copy back
+// afterwards could resurrect a session dismissed during the window. Update now
+// warms the lineage cache outside the lock and RETRIES from fresh state, so a
+// concurrent Remove wins.
+//
+// A FIFO makes the race deterministic: claude's DescribeConversation blocks
+// reading it, and opening the write end succeeds exactly when the reader has
+// the FIFO open — i.e. while Update is inside the unlocked window.
+func TestUpdateBindDoesNotResurrectRemovedSession(t *testing.T) {
+	dir := t.TempDir()
+	fifo := filepath.Join(dir, "33333333-3333-4333-8333-333333333333.jsonl")
+	if err := syscall.Mkfifo(fifo, 0o600); err != nil {
+		t.Skipf("mkfifo unavailable: %v", err)
+	}
+
+	s := New()
+	s.Upsert(Session{ID: "sess-race", Adapter: "claude", Alive: true})
+
+	done := make(chan bool, 1)
+	go func() {
+		done <- s.Update("sess-race", func(sess *Session) {
+			sess.ConversationRef = fifo
+		})
+	}()
+
+	// Blocks until the describe's ReadFile has the FIFO open for reading —
+	// Update is now past the unlock.
+	w, err := os.OpenFile(fifo, os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatalf("open fifo writer: %v", err)
+	}
+
+	// Dismiss the session while Update is stuck describing.
+	if !s.Remove("sess-race") {
+		t.Fatal("remove should have found the session")
+	}
+
+	// Unblock the describe (EOF → parse failure → cached), letting Update
+	// retry and observe the removal.
+	w.Close()
+	if got := <-done; got {
+		t.Fatal("Update should report false after a concurrent Remove")
+	}
+	if _, ok := s.Get("sess-race"); ok {
+		t.Fatal("removed session must not be resurrected by a stale bind write-back")
 	}
 }

--- a/services/gmuxd/internal/store/store_test.go
+++ b/services/gmuxd/internal/store/store_test.go
@@ -1726,3 +1726,68 @@ func TestUpdateBindDoesNotResurrectRemovedSession(t *testing.T) {
 		t.Fatal("removed session must not be resurrected by a stale bind write-back")
 	}
 }
+
+// TestLineageRecoversAfterLateTranscriptFlush pins the fix for permanent
+// negative caching: a resumed transcript that is absent at first bind (describe
+// fails) must NOT poison the ref — once the file lands, a later bind learns the
+// lineage and takeover fires. Regression for the adversarial-review P1.
+func TestLineageRecoversAfterLateTranscriptFlush(t *testing.T) {
+	const ancestor = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+	const resumed = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+	dir := t.TempDir()
+	ancestorFile := filepath.Join(dir, ancestor+".jsonl")
+	if err := os.WriteFile(ancestorFile, []byte(`{"type":"user","sessionId":"`+ancestor+`","message":{"role":"user","content":"hi"}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	newFile := filepath.Join(dir, resumed+".jsonl") // not on disk yet
+
+	s := New()
+	s.Upsert(Session{ID: "dead", Adapter: "claude", Alive: false, ConversationRef: ancestorFile})
+	s.Upsert(Session{ID: "live", Adapter: "claude", Alive: true})
+
+	// First bind: the resumed transcript hasn't been flushed — describe fails.
+	s.Update("live", func(sess *Session) { sess.ConversationRef = newFile })
+	if _, ok := s.Get("dead"); !ok {
+		t.Fatal("dead row should survive a bind whose transcript is not yet readable")
+	}
+
+	// Claude flushes the replayed history + the ancestor's line id.
+	if err := os.WriteFile(newFile, []byte(`{"type":"user","sessionId":"`+ancestor+`","message":{"role":"user","content":"hi"}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// A later genuine bind to the same ref (e.g. switch away and back) must
+	// now learn the lineage and evict the ancestor.
+	s.Update("live", func(sess *Session) { sess.ConversationRef = "" })
+	s.Update("live", func(sess *Session) { sess.ConversationRef = newFile })
+	if _, ok := s.Get("dead"); ok {
+		t.Fatal("takeover should fire once the transcript is readable (no permanent negative cache)")
+	}
+}
+
+// TestLineageCacheScopedByAdapter pins that the lineage cache is keyed by
+// (adapter, ref): two adapters sharing an opaque ref string must not inherit
+// each other's cached identity. Regression for the adversarial-review P2.
+func TestLineageCacheScopedByAdapter(t *testing.T) {
+	dir := t.TempDir()
+	// Same bare ref string, different adapters, different content.
+	ref := filepath.Join(dir, "shared.jsonl")
+	if err := os.WriteFile(ref, []byte(`{"type":"user","sessionId":"cccccccc-cccc-4ccc-8ccc-cccccccccccc","message":{"role":"user","content":"x"}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s := New()
+	// pi binds the ref first (pi's describer sees pi content; here it just
+	// populates the pi-scoped cache entry).
+	s.Upsert(Session{ID: "pi-live", Adapter: "pi", Alive: true, ConversationRef: ref})
+	// A claude dead row with a DIFFERENT ref must not be evicted by a claude
+	// live bind to the shared ref just because pi cached something for it.
+	claudeDead := filepath.Join(dir, "dddddddd-dddd-4ddd-8ddd-dddddddddddd.jsonl")
+	if err := os.WriteFile(claudeDead, []byte(`{"type":"user","sessionId":"dddddddd-dddd-4ddd-8ddd-dddddddddddd","message":{"role":"user","content":"y"}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s.Upsert(Session{ID: "claude-dead", Adapter: "claude", Alive: false, ConversationRef: claudeDead})
+	s.Upsert(Session{ID: "claude-live", Adapter: "claude", Alive: true})
+	s.Update("claude-live", func(sess *Session) { sess.ConversationRef = ref })
+	if _, ok := s.Get("claude-dead"); !ok {
+		t.Fatal("claude dead row must survive: pi's cache entry for the shared ref must not leak into claude's identity")
+	}
+}


### PR DESCRIPTION
## What

Sidebar membership/order in `projects.json` is now keyed by **immutable session IDs**, and dead-session takeover is detected by **conversation lineage** instead of slug collision. Slug becomes a display/URL name and nothing else.

Design record: **ADR 0024** (`docs/adr/0024-project-membership-keyed-by-session-id.md`), which partially supersedes ADR 0012's `SessionKey` freeze and builds on #403's opaque conversation refs (ADR 0022).

## Why

`SessionKey = slug || id` predates slug's current semantics. Since #348/#360/#394 the slug is a *mutable, runner-owned display name* — empty until titled, follows renames, cleared on re-bind, renumbered on collision, and only unique per (adapter, peer) while membership arrays span adapters. Every slug transition orphaned the membership key and the session re-appended at the bottom of the sidebar (the reorder bug ADR 0012 listed as motivation and declared fixed). Slug-collision takeover was equally wrong in both directions: untitled resumes produced duplicate rows; two conversations with the same title could wrongly evict each other.

## How (one identifier, one job)

| Identifier | Job |
| --- | --- |
| session ID | row identity: membership, order, dismiss, cleanup |
| conversation ref + adapter lineage | continuity: takeover/eviction |
| slug | display and URLs, nothing else |

- **`adapter`**: `ConversationInfo.AncestorIDs` — Claude's `DescribeConversation` extracts resume lineage from replayed per-line `sessionId`s + the `# session-start` marker (UUID-validated; a missed link degrades to a duplicate row, a false link is structurally impossible). pi/codex resume in place → empty.
- **`store`**: takeover = live binder evicts dead rows it *covers* (same opaque ref, or the dead row's adapter-reported conversation ID ∈ binder lineage). Describe runs outside the mutex, once per ref (peer snapshots never touch adapter I/O). Live–live coexist. `ensureUniqueSlug` survives as URL dedup only.
- **`projects`**: `SessionKey` deleted; dismiss/reorder/cleanup by ID; reorder requests filtered to known sessions; membership pruned promptly via a `session-remove` subscription (`WatchRemovals` pattern).
- **migration**: `projects.json` v4, one-shot at load — slug keys resolve against the sessionmeta sweep (dead sessions are exactly the cohort that can't self-heal, since they're never auto-assigned); unresolvable keys drop; pre-migration file backed up. No permanent dual-key resolver: the web is embedded (version-locked) and 1.6↔2.0 peers already don't exchange sessions.
- **web**: membership keys are always session IDs (`reorderKeysForFolder` slug branch removed).
- **cleanup**: rehydrated untitled conversations no longer surface `Slugify(UUID)` as their slug — index keeps an internal key, URLs fall back to the session id (#394 semantics).

## Accepted breakage (v2.0 window, per ADR 0024)

- Sessions live at upgrade lose sidebar *position* once (re-auto-assigned; no data loss).
- Hand-edited slug keys in projects.json are unsupported.
- External resume lands at the end of the array (a new session, honestly placed).

## Tests

Regression tests pin both old takeover bugs (same-title ≠ eviction, untitled resume = eviction), lineage parsing (chained/marker-only/lines-only/malformed), v1→v4 migration ladder incl. dedup + backup, reorder filtering, WatchRemovals idempotence, rehydrate slug emptiness + UUID deep-link resolution. Full Go suites, web 585 tests, lint green.
