### PR TITLE
fix: preserve turn status on forced-death paths (ADR 0023)

### DIFF
--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -1713,11 +1713,7 @@ func serve(stderr io.Writer) int {
 			if sess.SocketPath != "" && sess.Alive {
 				if err := discovery.KillSession(sess.SocketPath); err != nil {
 					log.Printf("kill: %s: runner unreachable, forcing dead: %v", sessionID, err)
-					sess.Alive = false
-					sess.Status = nil
-					if cmd := discovery.ResolveResumeCommand(&sess); cmd != nil {
-						sess.Command = cmd
-					}
+					sess = forceKillDead(sess)
 					sessions.Upsert(sess)
 					persistDead(sess)
 					subs.Unsubscribe(sessionID)
@@ -2381,6 +2377,23 @@ func serve(stderr io.Writer) int {
 
 	log.Printf("gmuxd stopped")
 	return 0
+}
+
+// forceKillDead builds the force-dead session state for the /kill path
+// when the runner can't be reached to perform a graceful exit. It marks
+// the session not-alive and resolves its resume command, but PRESERVES
+// the last observed Status. Per ADR 0023 §4 ("Turn-state-at-death"),
+// the turn state at death is the wait verdict and must hold across every
+// exit path — a forced death must not erase a Status we already saw, or
+// `gmux wait` would resolve differently depending on how the death was
+// detected (a closed turn would wrongly become "died"). A nil Status
+// (session never reported one) legitimately stays nil.
+func forceKillDead(sess store.Session) store.Session {
+	sess.Alive = false
+	if cmd := discovery.ResolveResumeCommand(&sess); cmd != nil {
+		sess.Command = cmd
+	}
+	return sess
 }
 
 // runStatus queries the running daemon via Unix socket and prints health info.

--- a/services/gmuxd/cmd/gmuxd/main_test.go
+++ b/services/gmuxd/cmd/gmuxd/main_test.go
@@ -766,3 +766,49 @@ func TestSSEFrameDeadlineAndErrorPropagation(t *testing.T) {
 		t.Error("heartbeat flush error not propagated")
 	}
 }
+
+// TestForceKillDeadPreservesClosedTurnStatus pins the ADR 0023 §4
+// invariant for the /kill force-dead path (runner unreachable): a
+// session whose turn had already CLOSED must keep Status{Working:false}
+// so a post-death `gmux wait` resolves "idle" (see terminalReason in
+// wait.go) — the same verdict a live wait watching the clean exit would
+// give. The path previously hard-cleared Status to nil, which wait.go
+// maps to "died", making the verdict depend on how death was detected.
+func TestForceKillDeadPreservesClosedTurnStatus(t *testing.T) {
+	sess := store.Session{
+		ID:     "sess-kill-closed",
+		Alive:  true,
+		Status: &store.Status{Working: false},
+	}
+	got := forceKillDead(sess)
+	if got.Alive {
+		t.Fatalf("Alive = true, want false (force-dead must mark not-alive)")
+	}
+	if got.Status == nil {
+		t.Fatalf("Status = nil after force-dead; want preserved closed turn (ADR 0023 §4)")
+	}
+	if got.Status.Working {
+		t.Errorf("Status.Working = true, want false (closed turn must be preserved)")
+	}
+}
+
+// TestForceKillDeadPreservesOpenTurnStatus is the mid-turn counterpart:
+// killing a session whose turn was still OPEN must keep Working=true so
+// the wait resolves "died" rather than losing the evidence to nil.
+func TestForceKillDeadPreservesOpenTurnStatus(t *testing.T) {
+	sess := store.Session{
+		ID:     "sess-kill-open",
+		Alive:  true,
+		Status: &store.Status{Working: true},
+	}
+	got := forceKillDead(sess)
+	if got.Alive {
+		t.Fatalf("Alive = true, want false")
+	}
+	if got.Status == nil {
+		t.Fatalf("Status = nil after force-dead; want preserved open turn (ADR 0023 §4)")
+	}
+	if !got.Status.Working {
+		t.Errorf("Status.Working = false, want true (open turn evidence must be preserved)")
+	}
+}

--- a/services/gmuxd/internal/discovery/discovery.go
+++ b/services/gmuxd/internal/discovery/discovery.go
@@ -195,9 +195,15 @@ func Scan(sessions *store.Store, subs *Subscriptions, onDead OnDeadFunc) {
 		if _, err := os.Stat(s.SocketPath); err == nil && probeSocket(s.SocketPath) {
 			continue // path exists and responds — subscription will reconnect
 		}
-		// Socket gone or unresponsive — mark dead.
+		// Socket gone or unresponsive — mark dead. Preserve the last
+		// observed Status: the turn state at death is the wait verdict
+		// (ADR 0023 §invariant) and must not depend on how death was
+		// detected. Clearing it here made a cleanly-closed turn reaped
+		// via stale socket resolve as "died", and lost the open-turn
+		// evidence a mid-turn crash needs. A nil Status (session never
+		// reported) legitimately stays nil — terminalReason treats that
+		// as "died" already.
 		s.Alive = false
-		s.Status = nil
 		if cmd := ResolveResumeCommand(&s); cmd != nil {
 			s.Command = cmd
 		}

--- a/services/gmuxd/internal/discovery/discovery_test.go
+++ b/services/gmuxd/internal/discovery/discovery_test.go
@@ -461,3 +461,92 @@ func TestRegisterRejectsInvalidSessionID(t *testing.T) {
 		t.Errorf("invalid-id session was added to the store; must be rejected")
 	}
 }
+
+// TestScanForcedDeathPreservesClosedTurnStatus pins the ADR 0023
+// invariant (docs/adr/0023-unified-turn-model.md §4 "Turn-state-at-
+// death") for the stale-socket sweep: a session whose runner vanished
+// (socket gone, no live subscription) but whose turn had already
+// CLOSED must keep its Status{Working:false} so a post-death `gmux
+// wait` resolves "idle" — the same verdict a live wait watching the
+// clean exit would return. Phase 2 previously hard-cleared Status to
+// nil, which terminalReason maps to "died": the verdict became
+// timing-dependent on how the death was detected.
+func TestScanForcedDeathPreservesClosedTurnStatus(t *testing.T) {
+	sockDir := t.TempDir()
+	t.Setenv("GMUX_SOCKET_DIR", sockDir)
+
+	const id = "sess-closed-turn"
+	// Socket path that does NOT exist: Phase 1 discovers no sockets,
+	// Phase 2 stats this path, fails, and force-marks the session dead.
+	sockPath := filepath.Join(sockDir, id+".sock")
+
+	sessions := store.New()
+	sessions.Upsert(store.Session{
+		ID:         id,
+		Adapter:    "shell",
+		Alive:      true,
+		SocketPath: sockPath,
+		StartedAt:  "2026-01-02T03:04:05Z",
+		Status:     &store.Status{Working: false},
+	})
+
+	subs := NewSubscriptions(sessions)
+	t.Cleanup(func() { subs.UnsubscribeAll() })
+
+	Scan(sessions, subs, nil)
+
+	got, ok := sessions.Get(id)
+	if !ok {
+		t.Fatalf("session %s missing after Scan", id)
+	}
+	if got.Alive {
+		t.Fatalf("Alive = true, want false (stale socket must force death)")
+	}
+	if got.Status == nil {
+		t.Fatalf("Status = nil after forced death; want preserved closed turn (ADR 0023): a cleanly-exited session reaped via stale socket must still resolve 'idle'")
+	}
+	if got.Status.Working {
+		t.Errorf("Status.Working = true, want false (closed turn must be preserved)")
+	}
+}
+
+// TestScanForcedDeathPreservesOpenTurnStatus is the mid-turn crash
+// counterpart: a session that died with its turn still OPEN
+// (Working:true) must keep that evidence so `gmux wait` resolves
+// "died" rather than losing the open-turn state to a nil Status.
+func TestScanForcedDeathPreservesOpenTurnStatus(t *testing.T) {
+	sockDir := t.TempDir()
+	t.Setenv("GMUX_SOCKET_DIR", sockDir)
+
+	const id = "sess-open-turn"
+	sockPath := filepath.Join(sockDir, id+".sock")
+
+	sessions := store.New()
+	sessions.Upsert(store.Session{
+		ID:         id,
+		Adapter:    "shell",
+		Alive:      true,
+		SocketPath: sockPath,
+		StartedAt:  "2026-01-02T03:04:05Z",
+		Status:     &store.Status{Working: true},
+	})
+
+	subs := NewSubscriptions(sessions)
+	t.Cleanup(func() { subs.UnsubscribeAll() })
+
+	Scan(sessions, subs, nil)
+
+	got, ok := sessions.Get(id)
+	if !ok {
+		t.Fatalf("session %s missing after Scan", id)
+	}
+	if got.Alive {
+		t.Fatalf("Alive = true, want false (stale socket must force death)")
+	}
+	if got.Status == nil {
+		t.Fatalf("Status = nil after forced death; want preserved open turn (ADR 0023): a mid-turn crash must keep Working=true to resolve 'died'")
+	}
+	if !got.Status.Working {
+		t.Errorf("Status.Working = false, want true (open turn evidence must be preserved)")
+	}
+}


### PR DESCRIPTION
## What

Two daemon-side **forced-death** paths hard-cleared `Status` to `nil`, violating the ADR 0023 §4 "Turn-state-at-death" invariant (`docs/adr/0023-unified-turn-model.md`): the persisted turn state must hold across **every** exit path, because post-death `gmux wait` derives its verdict from the preserved `Status` (`services/gmuxd/cmd/gmuxd/wait.go`, `terminalReason`: closed turn → `idle`, open/nil turn → `died`).

Clearing it made the wait verdict depend on *how* death was detected rather than the actual turn state:

- **`discovery.Scan`** (stale-socket sweep, `internal/discovery/discovery.go`): a cleanly-closed turn reaped via a gone/unresponsive socket lost its verdict and wrongly resolved `died`; a mid-turn crash lost its `Working=true` evidence.
- **`/kill`** (runner unreachable, `cmd/gmuxd/main.go`): same erasure of an already-observed verdict.

Found by an ADR audit and independently verified.

## Fix

Drop the `Status = nil` assignment in both paths. The last observed `Status` on the session struct is exactly what `wait` needs; a `nil` Status (session never reported one) already resolves as `died`, so it legitimately stays nil — we only stop *erasing* a status we did observe.

### Preserve-as-is vs. close-the-turn

I chose to **preserve the observed status as-is** rather than synthesize a turn close (as `finalizeSessionState` does on the normal runner exit path in `cli/gmux/cmd/gmux/run.go`). A forced death means the daemon *lost contact* with the runner — unlike the normal path, the child is not known to have exited cleanly. So an open turn (`Working=true`) genuinely reflects a mid-turn crash and must resolve `died`. Synthesizing a close would wrongly turn a mid-turn crash into `idle`. Preserving as-is makes the post-death verdict match a **live** wait, which is precisely the invariant's goal.

The `/kill` force-dead logic is extracted into `forceKillDead` so the status-preservation is unit-testable.

## Tests (red-green)

Each test is demonstrably RED without the fix (verified by temporarily reintroducing `Status = nil`), covering the matrix:

- `TestScanForcedDeathPreservesClosedTurnStatus` — stale-socket death, closed turn → status preserved.
- `TestScanForcedDeathPreservesOpenTurnStatus` — stale-socket death, open turn → evidence preserved.
- `TestForceKillDeadPreservesClosedTurnStatus` — unreachable-kill, closed turn → status preserved.
- `TestForceKillDeadPreservesOpenTurnStatus` — unreachable-kill, open turn → evidence preserved.

`go build ./...` and `go test ./...` green across `services/gmuxd`. No runner code touched.