### PR TITLE
docs: consolidate ADR set — renumber, status pass, supersession pointers

### DIFF
--- a/apps/gmux-web/src/projects.test.ts
+++ b/apps/gmux-web/src/projects.test.ts
@@ -969,7 +969,7 @@ describe('discoverProjects', () => {
   })
 
   it('excludes ALL peer sessions (discovery is host-authoritative)', () => {
-    // Discovery is owned by the originating host (ADR 0002/0005): the
+    // Discovery is owned by the originating host (ADR 0002/0025): the
     // viewer computes discovery only for its own local sessions. Peer
     // sessions — connected or not — are discovered by their owning
     // host and relayed verbatim (merged in store.discovered), never
@@ -985,7 +985,7 @@ describe('discoverProjects', () => {
   })
 
   it('treats local-peer (devcontainer) sessions as local', () => {
-    // Per ADR 0005 a Local peer's project assignment is owned by the
+    // Per ADR 0025 a Local peer's project assignment is owned by the
     // parent, so its disclaimed sessions flow through the parent's
     // local discovery rather than the container's own.
     const sessions = [

--- a/apps/gmux-web/src/projects.ts
+++ b/apps/gmux-web/src/projects.ts
@@ -167,7 +167,7 @@ export function mostCommonRemote(sessions: Session[]): string {
 
 /** Discover suggested projects from the viewer's OWN (local) sessions.
  *
- * Discovery is host-authoritative (ADR 0002/0005): each host runs its
+ * Discovery is host-authoritative (ADR 0002/0025): each host runs its
  * own match rules over its own sessions and decides which are unclaimed.
  * This function therefore handles local sessions only — peer sessions
  * are discovered by their owning host and relayed verbatim (merged in
@@ -175,7 +175,7 @@ export function mostCommonRemote(sessions: Session[]): string {
  *
  * A session is in scope iff it is local (`s.peer` empty, or a Local
  * peer / devcontainer whose project assignment the parent owns — see
- * ADR 0005), it is disclaimed (`s.project_slug` empty), and it doesn't
+ * ADR 0025), it is disclaimed (`s.project_slug` empty), and it doesn't
  * match a local owned project (those get stamped imminently by
  * auto-assign, so surfacing them as discovered would just flicker).
  *
@@ -191,10 +191,10 @@ export function discoverProjects(
   const byKey = new Map<string, { peer: string; dir: string; group: Session[] }>()
   for (const s of sessions) {
     if (s.project_slug) continue // claimed by origin
-    // Discovery is host-authoritative (ADR 0002/0005): this viewer only
+    // Discovery is host-authoritative (ADR 0002/0025): this viewer only
     // discovers its OWN (local) sessions. Peer sessions are discovered
     // by their owning host and relayed verbatim (see store.discovered).
-    // Local-peer/devcontainer sessions count as local: per ADR 0005
+    // Local-peer/devcontainer sessions count as local: per ADR 0025
     // their project assignment is owned by the parent's rules, so they
     // flow through the parent's local discovery, not the container's.
     const rawPeer = s.peer ?? ''

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -70,7 +70,7 @@ export interface RawWorld {
   peerProjects: Record<string, PeerProject[]>
   /**
    * Per-peer authoritative discovered list, keyed by peer name.
-   * Discovery is host-authoritative (ADR 0002/0005): each connected
+   * Discovery is host-authoritative (ADR 0002/0025): each connected
    * peer advertises the sessions it owns but no project of its own
    * claims, and the viewer renders these rows verbatim rather than
    * recomputing peer discovery blind. The viewer's own (local) sessions
@@ -276,7 +276,7 @@ export const worldLoaded = signal(false)
 // 'error'        — initial connect failed (full-screen + Retry)
 export const connState = signal<'connecting' | 'connected' | 'reconnecting' | 'error'>('connecting')
 
-// Discovered is host-authoritative (ADR 0002/0005): each host runs its
+// Discovered is host-authoritative (ADR 0002/0025): each host runs its
 // own match rules over its own sessions and decides which are
 // unclaimed. So this viewer computes discovery only for its OWN (local)
 // sessions, and merges in each connected peer's self-advertised

--- a/cli/gmux/cmd/gmux/run.go
+++ b/cli/gmux/cmd/gmux/run.go
@@ -194,7 +194,8 @@ func runSession(args []string, attach bool, dir runDirectives) {
 		RunnerVersion:   version,
 	})
 
-	// Common env vars — set for every child, per ADR-0005
+	// Common env vars — set for every child so nested gmux invocations can
+	// discover their session context (see ADR 0003 for GMUX_SESSION_ID).
 	env := []string{
 		"GMUX=1",
 		"GMUX_SOCKET=" + sockPath,

--- a/docs/adr/0001-snapshot-push-protocol.md
+++ b/docs/adr/0001-snapshot-push-protocol.md
@@ -1,6 +1,6 @@
 # ADR 0001: Snapshot push protocol
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-04-25
 **Related:** ADR 0002 (Project ownership from session origin)
 
@@ -180,7 +180,7 @@ removes them from the SSE path.
 per-viewer projection" framing is correct only for the viewer's OWN
 (local) sessions, whose owner is the viewer. Discovery is the inverse
 of ownership ("which of MY sessions does no project of mine claim"),
-and per ADR 0002/0005 ownership is host-authoritative — so a PEER's
+and per ADR 0002/0025 ownership is host-authoritative — so a PEER's
 discovery belongs to that peer, not the viewer. A viewer recomputing
 peer discovery is rule-blind (it can't see the peer's match rules) and
 would offer a project the peer already owns by a path-vs-remote rule
@@ -190,7 +190,7 @@ connected peer's self-advertised `discovered` list verbatim, relayed
 through the hub's `snapshot.world.peer_discovered` map (the hub caches
 it from the peer's `GET /v1/projects` response). Local-peer /
 devcontainer sessions flow through the parent's local discovery (ADR
-0005). Disconnected peers contribute no rows.
+0025). Disconnected peers contribute no rows.
 
 A `ready` computed gates initial render: `_rawSessions !== null &&
 _rawWorld !== null`. The hydration race the existing

--- a/docs/adr/0002-project-ownership-from-session-origin.md
+++ b/docs/adr/0002-project-ownership-from-session-origin.md
@@ -1,8 +1,18 @@
 # ADR 0002: Project ownership from session origin
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-04-25
-**Related:** ADR 0001 (Snapshot push protocol)
+**Related:** ADR 0001 (Snapshot push protocol), ADR 0025 (references and the Local-peer exception)
+
+> **Extended by ADR 0025 (2026-07).** This ADR establishes the core rule
+> — a session's project assignment is owned by and stamped on its origin
+> host. ADR 0025 is the current, canonical model for the rest of the story:
+> it removes this ADR's disclaimed-session viewer *fallback*, introduces
+> explicit **references**, and defines the **Local-peer** (devcontainer)
+> exception under which the parent host may be the authority. Read ADR 0002
+> for the origin-authority rationale and ADR 0025 for how membership is
+> resolved today; the fallback-adoption behavior described below no longer
+> applies.
 
 ## Context
 

--- a/docs/adr/0004-session-stream-and-live-dead-view.md
+++ b/docs/adr/0004-session-stream-and-live-dead-view.md
@@ -1,11 +1,24 @@
 # ADR 0004: `SessionStream` and the live↔dead view abstraction
 
-**Status:** Proposed
+**Status:** Superseded / not adopted (2026-07)
 **Date:** 2026-05-04
 **Related:** ADR 0003 (Daemon-initiated resume passes Session.ID to the runner)
 
-> **Note (2026-06, CLI 2.0):** Decision stands; any pre-2.0 command syntax in
-> the examples (e.g. `--tail`) is superseded by ADR 0009's verb-first grammar.
+> **Not adopted (2026-07).** This design was never implemented and the
+> shipped web contradicts it in its load-bearing details. `main` has **no**
+> `SessionStream`, pooled byte buffers, or always-on per-session WebSockets.
+> Instead the frontend selects `TerminalView` for live/attachable sessions
+> and a separate `ReplayView` (dead-session xterm, no WebSocket) — the split
+> this ADR set out to remove — with a single `TerminalView` xterm reused
+> across switches among live sessions (reset + reconnect `/ws/{id}` on
+> switch) that is unmounted on the live→dead transition (`apps/gmux-web/src/main.tsx`,
+> `terminal.tsx`, `replay-view.tsx`). The document is retained for its
+> problem statement and rejected alternatives; do **not** read it as the
+> current architecture. If the seamless live↔dead seam is revisited, open a
+> fresh ADR rather than reviving this one in place.
+
+> **Note (2026-06, CLI 2.0):** Any pre-2.0 command syntax in the examples
+> (e.g. `--tail`) is superseded by ADR 0009's verb-first grammar.
 
 ## Context
 

--- a/docs/adr/0007-host-identity-and-peer-urls.md
+++ b/docs/adr/0007-host-identity-and-peer-urls.md
@@ -1,8 +1,8 @@
 # ADR 0007: Host identity, naming, and peer URLs
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-05-29
-**Related:** ADR 0002 (project ownership from session origin), ADR 0005 (references and the local-peer exception)
+**Related:** ADR 0002 (project ownership from session origin), ADR 0025 (references and the local-peer exception)
 **Target:** gmux 2.0 (breaking; no backwards compatibility)
 
 ## Context

--- a/docs/adr/0009-verb-first-cli-and-frozen-top-level-namespace.md
+++ b/docs/adr/0009-verb-first-cli-and-frozen-top-level-namespace.md
@@ -1,6 +1,6 @@
 # ADR 0009: Verb-first CLI, explicit run syntax, and a frozen top-level namespace
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-06-15
 **Supersedes (in part):** the flag-based action surface of ADR 0005 (the
 *transport* decision in 0005 stands; only the user-facing flag grammar changes)

--- a/docs/adr/0011-runner-owned-session-state.md
+++ b/docs/adr/0011-runner-owned-session-state.md
@@ -3,6 +3,17 @@
 **Status:** Accepted
 **Date:** 2026-06-16
 **Related:** ADR 0004 (SessionStream), ADR 0010 (the agent-shim this supersedes)
+**Partially superseded by:** ADR 0013 (codex authoritative state via hooks) and ADR 0014 (adapter-owned conversation sources)
+
+> **Superseded prose (2026-07):** references below to the **daemon's**
+> `FileMonitor` / inotify file-watch and to codex as "the only remaining
+> file-watch consumer" are historical. ADR 0013 moved codex onto
+> authoritative hooks, and ADR 0014 deleted daemon-global attribution
+> entirely — conversation watching now lives in the adapter
+> (`packages/adapter/filewatch`) and the daemon consumes adapter
+> `ConversationSource`s (there is **no** daemon file-watch fallback). The
+> core decision of this ADR — runner/adapter owns state, daemon is a read
+> cache — stands; only the file-watch ownership detail changed.
 
 > **Outcome.** Built and shipped. The decisive change beyond the original plan:
 > the fragile fs signal (ADR 0010's shim) was replaced by an **agent-hook** —

--- a/docs/adr/0017-reference-resolution-name-key-nodeid-plumbing.md
+++ b/docs/adr/0017-reference-resolution-name-key-nodeid-plumbing.md
@@ -1,14 +1,14 @@
 # ADR 0017: References identify by name; node_id is a liveness anchor
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-06-23
-**Related:** ADR 0005 (references), ADR 0007 (host identity)
+**Related:** ADR 0025 (references), ADR 0007 (host identity)
 **Supersedes:** the ad-hoc reference resolver from refs #270
 **Target:** gmux 2.0
 
 ## Context
 
-A *reference* (ADR 0005) is a `projects.json` entry `{slug, peer}`
+A *reference* (ADR 0025) is a `projects.json` entry `{slug, peer}`
 pointing at a peer-owned project. ADR 0007 made the peer **name** a
 viewer-owned label and added a stable opaque **`node_id`**.
 

--- a/docs/adr/0025-references-and-local-peer-exception.md
+++ b/docs/adr/0025-references-and-local-peer-exception.md
@@ -1,8 +1,14 @@
-# ADR 0005: Project references and the Local-peer exception
+# ADR 0025: Project references and the Local-peer exception
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-05-22
 **Related:** ADR 0002 (Project ownership from session origin)
+
+> **Note (2026-07):** Renumbered from ADR 0005 → 0025 to resolve a number
+> collision with "ADR 0005: CLI routes session actions through gmuxd" (two
+> files claimed 0005). This document's decision and date are unchanged; it
+> extends ADR 0002 and is the canonical record for the reference /
+> Local-peer model. Cross-references in ADRs 0007 and 0017 were updated.
 
 ## Context
 

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -2518,7 +2518,7 @@ func composePeerProjects(mgr *peering.Manager) map[string][]peering.SpokeProject
 
 // composePeerDiscovered gathers each connected peer's self-advertised
 // discovered list into a map keyed by peer name. Discovery is
-// host-authoritative (ADR 0002/0005): the viewer renders each peer's
+// host-authoritative (ADR 0002/0025): the viewer renders each peer's
 // own discovered rows verbatim instead of recomputing them blind. Local
 // peers are skipped (their sessions flow through the parent's local
 // discovery). Peers not yet fetched appear with an empty list.

--- a/services/gmuxd/internal/peering/manager.go
+++ b/services/gmuxd/internal/peering/manager.go
@@ -37,9 +37,18 @@ type managedPeer struct {
 // NewManager creates a manager but does not start connections.
 // Call Start() to begin subscribing to peers.
 //
-// selfName is the local machine's hostname, used to detect (and drop)
-// sessions that are our own data echoed back through a mutual peer
-// subscription.
+// selfName is the local machine's hostname, used by isKnownOrigin as a
+// defensive backstop against our own data echoed back through a mutual
+// peer. NOTE: this is a backstop only, not the load-bearing guard. The
+// actual protection against re-forwarding a network peer's sessions is
+// the ADR 0002 owned-only filter on `?as=peer` streams (see isOwned in
+// cmd/gmuxd/main.go): a spoke only ever ships sessions it owns
+// (Peer=="" or a Local/devcontainer peer), so a well-behaved peer never
+// echoes our own sessions back here. Consequently selfName is *not*
+// required to match this node's tailscale/URL identity (ADR 0007); the
+// two can legitimately diverge (e.g. os.Hostname()==container-id) with
+// no observable effect. Do not "fix" this into a load-bearing check
+// without also revisiting the owned-only filter.
 func NewManager(configs []config.PeerConfig, st *store.Store, selfName string, opts ...PeerOption) *Manager {
 	m := &Manager{
 		peers:       make(map[string]*managedPeer, len(configs)),

--- a/services/gmuxd/internal/peering/peer.go
+++ b/services/gmuxd/internal/peering/peer.go
@@ -246,7 +246,7 @@ func (p *Peer) fetchProjects(ctx context.Context) {
 	}
 	// The spoke's discovered list is host-authoritative: it ran its
 	// own match rules over its own sessions, so we cache it verbatim
-	// rather than recomputing peer discovery blind (ADR 0002/0005).
+	// rather than recomputing peer discovery blind (ADR 0002/0025).
 	discovered := envelope.Discovered
 	if discovered == nil {
 		discovered = []SpokeDiscovered{}

--- a/services/gmuxd/internal/peering/peering.go
+++ b/services/gmuxd/internal/peering/peering.go
@@ -104,7 +104,7 @@ type SpokeProject struct {
 
 // SpokeDiscovered is the hub's verbatim copy of a single entry from a
 // spoke's authoritative `discovered` list (GET /v1/projects). Discovery
-// is host-authoritative (ADR 0002/0005): only the owning host runs its
+// is host-authoritative (ADR 0002/0025): only the owning host runs its
 // own match rules over its own sessions, so the hub re-broadcasts the
 // spoke's self-advertised discovered rows under
 // peer_discovered[<peerName>][] rather than recomputing them blind.

--- a/services/gmuxd/internal/snapshot/snapshot.go
+++ b/services/gmuxd/internal/snapshot/snapshot.go
@@ -76,7 +76,7 @@ type WorldPayload struct {
 	// PeerDiscovered carries each connected peer's self-advertised
 	// discovered list (sessions the peer owns but no project of its own
 	// claims), keyed by peer name. Discovery is host-authoritative
-	// (ADR 0002/0005): the owning host runs its own match rules over
+	// (ADR 0002/0025): the owning host runs its own match rules over
 	// its own sessions, so the viewer renders these rows verbatim
 	// rather than recomputing peer discovery blind (which could offer a
 	// project the peer already owns by a rule the viewer can't see).


### PR DESCRIPTION
Follow-up to the ADR audit (subagent, gpt-5.6-sol:medium). Documentation only, plus one clarifying code comment — no behavioral change.

## What & why
- **Renumber duplicate ADR 0005.** Two files claimed `0005`; "references and the Local-peer exception" → **ADR 0025** (next free number = least churn). Cross-refs in 0007/0017 updated; CLI-routing ADR keeps 0005.
- **Status pass.** Shipped decisions flipped Proposed → **Accepted**: 0001, 0002, 0007, 0009, 0017, 0025. Left **0018** and **0021** Proposed — genuinely unimplemented on `main`.
- **ADR 0004 → Superseded / not adopted.** `SessionStream` was never built; the shipped web (single app-lifetime xterm + separate `ReplayView`) contradicts it. Kept for problem statement + rejected alternatives.
- **ADR 0011.** Flagged the daemon-file-watch prose as superseded by 0013/0014 (attribution is adapter-owned; no daemon file-watch fallback). Core decision stands.
- **ADR 0002.** Linked to 0025 as the canonical extension; cross-linked rather than physically merged to preserve decision history.
- **peering (`manager.go`).** Documented that `Manager.selfName` is a defensive backstop, **not** the load-bearing re-forward guard (that's the ADR 0002 owned-only `?as=peer` filter). Records why `selfName` may diverge from the ADR 0007 identity with no observable effect — so nobody "fixes" a non-bug.

## Not done (deliberately)
- **No ADR deleted** — every superseded record keeps useful rejected-alternative rationale.
- Did **not** physically merge 0002 + 0025 (would destroy decision-log fidelity); cross-linked instead.
- The peering `selfName` divergence is a real inconsistency with an **unreachable** failure path (ADR-audit verdict) → documented, not code-fixed.

Found via ADR audit; two P1 *code* bugs from the same audit shipped separately as #405-era fixes and #406 (turn-state-at-death).