### PR TITLE
fix(web): open the sidebar view menu upward on mobile

### DIFF
--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -2833,6 +2833,13 @@ body {
     border-bottom: none;
   }
   .sidebar-scroll { order: 1; }
+
+  /* The header sits at the bottom of the screen here, so the view menu
+   * opens upward instead of downward — otherwise it drops off-screen. */
+  .view-menu {
+    top: auto;
+    bottom: calc(100% + 4px);
+  }
 }
 
 /* Collapse the session header while the on-screen keyboard is open on


### PR DESCRIPTION
## Problem
On mobile/touch layouts the sidebar header is moved to the **bottom** of the screen (`@media (pointer: coarse)` → `.sidebar-header { order: 3 }`) for thumb reach. But the view/sort menu still dropped **downward** (`top: calc(100% + 4px)`), so it fell off the bottom edge of the screen — most options were unreachable.

## Fix
Under `@media (pointer: coarse)`, flip `.view-menu` to anchor its bottom to the button:

```css
.view-menu { top: auto; bottom: calc(100% + 4px); }
```

so it opens **upward** and stays on-screen. Desktop (fine pointer, header on top) is unchanged.

## Verification
Emulated a 420×880 touch viewport: menu now spans top 490→bottom 841, entirely above the button at y=845 (`opensUpward: true`).

biome + tsc clean.

Follow-up to the merged sidebar redesign (#404).