### PR TITLE
fix(centralstore): enforce exit lifecycle invariant

### DIFF
--- a/services/gmuxd/internal/centralstore/admin_test.go
+++ b/services/gmuxd/internal/centralstore/admin_test.go
@@ -142,10 +142,13 @@ func TestCheckStateDismissalAndExitContracts(t *testing.T) {
 		t.Fatal(err)
 	}
 	// A dismissed row must not hold a placement; an exit code requires an
-	// exit stamp. Both manufactured with direct SQL (FK/trigger-free).
+	// exit stamp. Ignore CHECK constraints to manufacture durable corruption
+	// that the administrative checker must still diagnose.
 	exec(t, s,
 		"UPDATE local_sessions SET dismissed_at_ms = 10 WHERE id = 'a'",
+		"PRAGMA ignore_check_constraints = ON",
 		"UPDATE local_sessions SET exit_code = 1, exited_at_ms = NULL WHERE id = 'a'",
+		"PRAGMA ignore_check_constraints = OFF",
 	)
 	findings := checkFindings(t, s)
 	requireFinding(t, findings, "dismissed_placement")

--- a/services/gmuxd/internal/centralstore/domain.go
+++ b/services/gmuxd/internal/centralstore/domain.go
@@ -217,6 +217,12 @@ func validateTerminal(cols, rows *uint16) error {
 	}
 	return nil
 }
+func validateExitLifecycle(exitedAt *UnixMillis, exitCode *int) error {
+	if exitCode != nil && exitedAt == nil {
+		return errors.New("centralstore: exit code requires exited timestamp")
+	}
+	return nil
+}
 func validateNewSession(v NewSession) error {
 	if v.ID == "" || v.Adapter == "" {
 		return errors.New("centralstore: session id and adapter required")
@@ -231,6 +237,9 @@ func validateNewSession(v NewSession) error {
 		if err := validateMillis(name, x); err != nil {
 			return err
 		}
+	}
+	if err := validateExitLifecycle(v.ExitedAt, v.ExitCode); err != nil {
+		return err
 	}
 	return validateTerminal(v.TerminalCols, v.TerminalRows)
 }
@@ -312,6 +321,9 @@ func sessionFromDB(v db.LocalSession) (Session, error) {
 		}
 		x := int(v.ExitCode.Int64)
 		out.ExitCode = &x
+	}
+	if err := validateExitLifecycle(out.ExitedAt, out.ExitCode); err != nil {
+		return Session{}, errors.New("centralstore: corrupt exit lifecycle")
 	}
 	toUint := func(n sql.NullInt64) (*uint16, error) {
 		if !n.Valid {
@@ -564,6 +576,9 @@ func (s *Store) applyCommonFacts(ctx context.Context, id SessionID, observed Row
 		if err = validateMillis(name, x); err != nil {
 			return MutationResult{}, err
 		}
+	}
+	if err = validateExitLifecycle(v.ExitedAt, v.ExitCode); err != nil {
+		return MutationResult{}, err
 	}
 	if v.Adapter == "" {
 		return MutationResult{}, errors.New("centralstore: adapter required")

--- a/services/gmuxd/internal/centralstore/domain_test.go
+++ b/services/gmuxd/internal/centralstore/domain_test.go
@@ -149,6 +149,87 @@ func TestDedicatedInsertAndTriStatePatch(t *testing.T) {
 	}
 }
 
+func TestExitLifecycleTypedValidationUsesFinalState(t *testing.T) {
+	ctx := context.Background()
+	exited := UnixMillis(2)
+	code := 7
+	type state struct {
+		name   string
+		exited *UnixMillis
+		code   *int
+		valid  bool
+	}
+	states := []state{
+		{name: "live", valid: true},
+		{name: "timestamp-only", exited: &exited, valid: true},
+		{name: "timestamp-and-code", exited: &exited, code: &code, valid: true},
+		{name: "code-only", code: &code},
+	}
+	for _, final := range states {
+		t.Run("new-session/"+final.name, func(t *testing.T) {
+			s := openKernelStore(t)
+			_, _, err := s.InsertSession(ctx, NewSession{ID: "new", Adapter: "shell", CWD: "/", CreatedAt: 1, ExitedAt: final.exited, ExitCode: final.code})
+			if final.valid && err != nil {
+				t.Fatalf("valid state rejected: %v", err)
+			}
+			if !final.valid && (err == nil || err.Error() != "centralstore: exit code requires exited timestamp") {
+				t.Fatalf("invalid state error = %v", err)
+			}
+		})
+	}
+
+	transitions := []struct {
+		name  string
+		start state
+		patch CommonFactsPatch
+		valid bool
+	}{
+		{"live-to-live", states[0], CommonFactsPatch{}, true},
+		{"live-to-timestamp", states[0], CommonFactsPatch{ExitedAt: NullablePatch[UnixMillis]{Set: &exited}}, true},
+		{"live-to-complete", states[0], CommonFactsPatch{ExitedAt: NullablePatch[UnixMillis]{Set: &exited}, ExitCode: NullablePatch[int]{Set: &code}}, true},
+		{"live-to-code-only", states[0], CommonFactsPatch{ExitCode: NullablePatch[int]{Set: &code}}, false},
+		{"timestamp-to-live", states[1], CommonFactsPatch{ExitedAt: NullablePatch[UnixMillis]{Clear: true}}, true},
+		{"timestamp-to-timestamp", states[1], CommonFactsPatch{}, true},
+		{"timestamp-add-code", states[1], CommonFactsPatch{ExitCode: NullablePatch[int]{Set: &code}}, true},
+		{"timestamp-to-code-only", states[1], CommonFactsPatch{ExitedAt: NullablePatch[UnixMillis]{Clear: true}, ExitCode: NullablePatch[int]{Set: &code}}, false},
+		{"complete-to-live", states[2], CommonFactsPatch{ExitedAt: NullablePatch[UnixMillis]{Clear: true}, ExitCode: NullablePatch[int]{Clear: true}}, true},
+		{"complete-clear-code", states[2], CommonFactsPatch{ExitCode: NullablePatch[int]{Clear: true}}, true},
+		{"complete-to-complete", states[2], CommonFactsPatch{}, true},
+		{"complete-clear-timestamp", states[2], CommonFactsPatch{ExitedAt: NullablePatch[UnixMillis]{Clear: true}}, false},
+	}
+	for _, tc := range transitions {
+		t.Run("patch/"+tc.name, func(t *testing.T) {
+			s := openKernelStore(t)
+			row, _, err := s.InsertSession(ctx, NewSession{ID: "patch", Adapter: "shell", CWD: "/", CreatedAt: 1, ExitedAt: tc.start.exited, ExitCode: tc.start.code})
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, err = s.ApplyCommonFacts(ctx, row.ID, row.Version, tc.patch)
+			if tc.valid && err != nil {
+				t.Fatalf("valid transition rejected: %v", err)
+			}
+			if !tc.valid && (err == nil || err.Error() != "centralstore: exit code requires exited timestamp") {
+				t.Fatalf("invalid transition error = %v", err)
+			}
+		})
+	}
+}
+
+func TestSessionDecodeRejectsMalformedExitLifecycle(t *testing.T) {
+	ctx := context.Background()
+	s := openKernelStore(t)
+	addSession(t, s, "bad-exit", "")
+	if _, err := s.database.ExecContext(ctx, "PRAGMA ignore_check_constraints=ON"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.database.ExecContext(ctx, `UPDATE local_sessions SET exit_code=9 WHERE id='bad-exit'`); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := s.Session(ctx, "bad-exit"); err == nil {
+		t.Fatal("malformed durable exit lifecycle was decoded")
+	}
+}
+
 func TestTitleNoopObservedVersionAndCorruptJSON(t *testing.T) {
 	ctx := context.Background()
 	s := openKernelStore(t)

--- a/services/gmuxd/internal/centralstore/migrations/00002_domain_kernel.sql
+++ b/services/gmuxd/internal/centralstore/migrations/00002_domain_kernel.sql
@@ -42,7 +42,8 @@ CREATE TABLE local_sessions (
 
     CHECK (launch_parent_id IS NULL OR
            (length(launch_parent_id) > 0 AND launch_parent_id <> id)),
-    CHECK ((terminal_cols IS NULL) = (terminal_rows IS NULL))
+    CHECK ((terminal_cols IS NULL) = (terminal_rows IS NULL)),
+    CHECK (exit_code IS NULL OR exited_at_ms IS NOT NULL)
 ) STRICT;
 
 CREATE UNIQUE INDEX local_sessions_adapter_slug_unique_idx

--- a/services/gmuxd/internal/centralstore/register.go
+++ b/services/gmuxd/internal/centralstore/register.go
@@ -532,6 +532,9 @@ func validateMergedSession(v Session) error {
 			return err
 		}
 	}
+	if err := validateExitLifecycle(v.ExitedAt, v.ExitCode); err != nil {
+		return err
+	}
 	return validateTerminal(v.TerminalCols, v.TerminalRows)
 }
 

--- a/services/gmuxd/internal/centralstore/register_test.go
+++ b/services/gmuxd/internal/centralstore/register_test.go
@@ -195,6 +195,57 @@ func TestRegisterRunnerTriStateFactsAndActivityTransitions(t *testing.T) {
 	}
 }
 
+func TestRegisterRunnerExitLifecycleValidatesMergedFinalState(t *testing.T) {
+	exited := UnixMillis(2)
+	code := 7
+	tests := []struct {
+		name                 string
+		initialExited        *UnixMillis
+		initialCode          *int
+		facts                RunnerFacts
+		valid                bool
+		wantExited, wantCode bool
+	}{
+		{name: "set-code-without-timestamp", facts: RunnerFacts{ExitCode: NullablePatch[int]{Set: &code}}},
+		{name: "clear-timestamp-retaining-code", initialExited: &exited, initialCode: &code, facts: RunnerFacts{ExitedAt: NullablePatch[UnixMillis]{Clear: true}}},
+		{name: "set-both-atomically", facts: RunnerFacts{ExitedAt: NullablePatch[UnixMillis]{Set: &exited}, ExitCode: NullablePatch[int]{Set: &code}}, valid: true, wantExited: true, wantCode: true},
+		{name: "clear-both-atomically", initialExited: &exited, initialCode: &code, facts: RunnerFacts{ExitedAt: NullablePatch[UnixMillis]{Clear: true}, ExitCode: NullablePatch[int]{Clear: true}}, valid: true},
+		{name: "timestamp-only", facts: RunnerFacts{ExitedAt: NullablePatch[UnixMillis]{Set: &exited}}, valid: true, wantExited: true},
+		{name: "add-code-to-timestamp", initialExited: &exited, facts: RunnerFacts{ExitCode: NullablePatch[int]{Set: &code}}, valid: true, wantExited: true, wantCode: true},
+		{name: "clear-code-retain-timestamp", initialExited: &exited, initialCode: &code, facts: RunnerFacts{ExitCode: NullablePatch[int]{Clear: true}}, valid: true, wantExited: true},
+		{name: "clear-timestamp-from-timestamp-only", initialExited: &exited, facts: RunnerFacts{ExitedAt: NullablePatch[UnixMillis]{Clear: true}}, valid: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			s := openKernelStore(t)
+			before, _, err := s.InsertSession(ctx, NewSession{ID: "merge", Adapter: "shell", Command: []string{}, CWD: "/", Remotes: map[string]string{}, CreatedAt: 1, ExitedAt: tc.initialExited, ExitCode: tc.initialCode})
+			if err != nil {
+				t.Fatal(err)
+			}
+			reg := registration("merge", "shell", "/", false, 3)
+			reg.Facts = tc.facts
+			got, _, err := s.RegisterRunner(ctx, reg)
+			if !tc.valid {
+				if err == nil || err.Error() != "centralstore: exit code requires exited timestamp" {
+					t.Fatalf("merged validation error = %v", err)
+				}
+				after, ok, readErr := s.Session(ctx, "merge")
+				if readErr != nil || !ok || !reflect.DeepEqual(after.ExitedAt, before.ExitedAt) || !reflect.DeepEqual(after.ExitCode, before.ExitCode) {
+					t.Fatalf("invalid merge changed row: after=%#v before=%#v ok=%v err=%v", after, before, ok, readErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("valid merge rejected: %v", err)
+			}
+			if (got.ExitedAt != nil) != tc.wantExited || (got.ExitCode != nil) != tc.wantCode {
+				t.Fatalf("merged state exited=%v code=%v", got.ExitedAt, got.ExitCode)
+			}
+		})
+	}
+}
+
 func TestRegisterRunnerGenerationProvenance(t *testing.T) {
 	makeDead := func(t *testing.T) (*Store, Session) {
 		t.Helper()

--- a/services/gmuxd/internal/centralstore/store_test.go
+++ b/services/gmuxd/internal/centralstore/store_test.go
@@ -46,6 +46,43 @@ func TestOpenFreshAndReopen(t *testing.T) {
 	}
 }
 
+func TestFreshSchemaExitLifecycleCheckGuardsInsertAndUpdate(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+
+	insert := func(id string, exited any, code any) error {
+		_, err := store.database.ExecContext(ctx, `INSERT INTO local_sessions
+			(id, adapter, command_json, cwd, remotes_json, created_at_ms, exited_at_ms, exit_code)
+			VALUES (?, 'shell', '[]', '/', '{}', 1, ?, ?)`, id, exited, code)
+		return err
+	}
+	if err := insert("live", nil, nil); err != nil {
+		t.Fatalf("valid live insert: %v", err)
+	}
+	if err := insert("exited-no-code", 2, nil); err != nil {
+		t.Fatalf("valid timestamp-only insert: %v", err)
+	}
+	if err := insert("exited-with-code", 2, 7); err != nil {
+		t.Fatalf("valid complete exit insert: %v", err)
+	}
+	if err := insert("bad-insert", nil, 7); err == nil {
+		t.Fatal("fresh schema accepted malformed direct INSERT")
+	}
+
+	if _, err := store.database.ExecContext(ctx, `UPDATE local_sessions SET exited_at_ms=3, exit_code=9 WHERE id='live'`); err != nil {
+		t.Fatalf("valid atomic exit update: %v", err)
+	}
+	if _, err := store.database.ExecContext(ctx, `UPDATE local_sessions SET exited_at_ms=NULL, exit_code=NULL WHERE id='live'`); err != nil {
+		t.Fatalf("valid atomic clear update: %v", err)
+	}
+	if _, err := store.database.ExecContext(ctx, `UPDATE local_sessions SET exit_code=9 WHERE id='live'`); err == nil {
+		t.Fatal("fresh schema accepted malformed direct UPDATE")
+	}
+	if _, err := store.database.ExecContext(ctx, `UPDATE local_sessions SET exited_at_ms=NULL WHERE id='exited-with-code'`); err == nil {
+		t.Fatal("fresh schema accepted clearing exited timestamp while code remained")
+	}
+}
+
 func TestOpenUsesOwnerOnlyModes(t *testing.T) {
 	ctx := context.Background()
 	dir := filepath.Join(t.TempDir(), "new", "state")


### PR DESCRIPTION
## Summary

Enforce the local-session exit lifecycle invariant on clean-state gmux 2.0:

- define `exit_code IS NULL OR exited_at_ms IS NOT NULL` directly in migration `00002`, where `local_sessions` is created
- validate `NewSession`, common-facts patches, and runner-registration merges against their final state
- reject malformed durable rows defensively during decode
- cover fresh-schema direct SQL inserts and updates, including valid atomic set/clear states

This intentionally keeps schema head at 4. It adds no migration 00005, upgrade remediation, backfill, or legacy-upgrade behavior.

## Verification

- `pnpm moon run gmuxd:check-centralstore-generated`
- `go test ./services/gmuxd/internal/centralstore -count=10`
- `go test -race ./services/gmuxd/internal/centralstore -count=3`
- `go test -race ./services/gmuxd/cmd/gmuxd ./services/gmuxd/internal/sessioncoord -count=2`
- focused invariant tests repeated 20 times, including the full typed transition matrix and runner-registration merges
- mutation checks independently killed removal of Go patch validation, runner-registration validation, defensive decode validation, and the SQLite CHECK guard; an over-restrictive validator mutation was also killed
