### PR TITLE
fix(sessioncoord): order outcomes across re-registration

### DIFF
--- a/services/gmuxd/internal/sessioncoord/acknowledge.go
+++ b/services/gmuxd/internal/sessioncoord/acknowledge.go
@@ -48,10 +48,11 @@ func (c *Coordinator) AcknowledgeDead(ctx context.Context, id centralstore.Sessi
 			version = s.Version
 		}
 		result, err := c.durable.AcknowledgeDeadSession(ctx, id, version)
+		seq := c.outcomes.allocSeq() // stamp before releasing c.mu
 		c.mu.Unlock()
 		if err == nil {
 			c.publish(ctx, result)
-			c.emitOutcomes(ctx, id)
+			c.emitOutcomes(ctx, seq, id)
 			return nil
 		}
 		if errors.Is(err, centralstore.ErrSessionNotFound) {

--- a/services/gmuxd/internal/sessioncoord/convergence.go
+++ b/services/gmuxd/internal/sessioncoord/convergence.go
@@ -92,11 +92,12 @@ func (c *Coordinator) FinishConvergence(ctx context.Context, at centralstore.Uni
 	c.convergeClosed = true
 	c.convergeCandidates = nil
 	close(c.converged)
+	seq := c.outcomes.allocSeq() // stamp before releasing c.mu
 	c.mu.Unlock()
 
 	c.publish(ctx, result)
 	if result.Changed {
-		c.emitOutcomes(ctx, sweep...)
+		c.emitOutcomes(ctx, seq, sweep...)
 	}
 	return result, nil
 }

--- a/services/gmuxd/internal/sessioncoord/coordinator.go
+++ b/services/gmuxd/internal/sessioncoord/coordinator.go
@@ -621,6 +621,7 @@ loop:
 		}
 	}
 
+	seq := c.outcomes.allocSeq() // stamp commit order before releasing c.mu
 	c.mu.Unlock()
 
 	// Silent-loss guard: a conversation-bearing registration in an embedding
@@ -637,13 +638,13 @@ loop:
 	// re-entrant dirty sink cannot stall lifecycle transitions.
 	c.publish(ctx, outcome)
 	session.ID = id // the store echoes it; make the outcome self-describing even for sparse fakes
-	c.emitUpserted(session)
+	c.emitUpserted(session, seq)
 	if len(reg.Evict) > 0 {
 		evicted := make([]centralstore.SessionID, len(reg.Evict))
 		for i, ev := range reg.Evict {
 			evicted[i] = ev.ID
 		}
-		c.emitOutcomes(ctx, evicted...)
+		c.emitOutcomes(ctx, seq, evicted...)
 	}
 	return runtime, nil
 }
@@ -868,7 +869,7 @@ func (c *Coordinator) apply(ctx context.Context, id centralstore.SessionID, gene
 		// safe, and it must not depend on the replacement's own publish.
 		c.publish(ctx, result)
 		if result.Changed {
-			c.emitOutcomes(ctx, id)
+			c.emitOutcomes(ctx, c.outcomes.allocSeq(), id)
 		}
 		return
 	}
@@ -892,7 +893,7 @@ func (c *Coordinator) apply(ctx context.Context, id centralstore.SessionID, gene
 	// stall the coordinator or deadlock.
 	c.publish(ctx, result)
 	if result.Changed {
-		c.emitOutcomes(ctx, id)
+		c.emitOutcomes(ctx, c.outcomes.allocSeq(), id)
 	}
 }
 

--- a/services/gmuxd/internal/sessioncoord/dismiss.go
+++ b/services/gmuxd/internal/sessioncoord/dismiss.go
@@ -88,6 +88,7 @@ func (c *Coordinator) Dismiss(ctx context.Context, root centralstore.SessionID) 
 	}
 
 	dismissed, result, err := c.durable.DismissSessionTree(ctx, root, c.now())
+	seq := c.outcomes.allocSeq() // stamp before releasing c.mu
 	c.mu.Unlock()
 	if err != nil {
 		return nil, err
@@ -95,7 +96,7 @@ func (c *Coordinator) Dismiss(ctx context.Context, root centralstore.SessionID) 
 	// Publish the committed outcome outside the mutex, same as every other
 	// lifecycle operation.
 	c.publish(ctx, result)
-	c.emitOutcomes(ctx, dismissed...)
+	c.emitOutcomes(ctx, seq, dismissed...)
 	return dismissed, nil
 }
 
@@ -136,11 +137,12 @@ func (c *Coordinator) Remove(ctx context.Context, id centralstore.SessionID, obs
 	if err == nil {
 		c.invalidateVerdict(id) // the row is gone; its reconciliation verdict with it
 	}
+	seq := c.outcomes.allocSeq() // stamp before releasing c.mu
 	c.mu.Unlock()
 	if err != nil {
 		return err
 	}
 	c.publish(ctx, result)
-	c.emitOutcomes(ctx, id)
+	c.emitOutcomes(ctx, seq, id)
 	return nil
 }

--- a/services/gmuxd/internal/sessioncoord/lifecycle.go
+++ b/services/gmuxd/internal/sessioncoord/lifecycle.go
@@ -239,10 +239,11 @@ func (c *Coordinator) ensureDurableExit(ctx context.Context, id centralstore.Ses
 			ID: id, ObservedVersion: version, ObservedAt: at,
 			Facts: centralstore.RunnerFacts{ExitedAt: centralstore.NullablePatch[centralstore.UnixMillis]{Set: &at}},
 		})
+		seq := c.outcomes.allocSeq() // stamp before releasing c.mu
 		c.mu.Unlock()
 		if err == nil {
 			c.publish(ctx, result)
-			c.emitOutcomes(ctx, id)
+			c.emitOutcomes(ctx, seq, id)
 			return nil
 		}
 		if errors.Is(err, centralstore.ErrSessionNotFound) {

--- a/services/gmuxd/internal/sessioncoord/outcomes.go
+++ b/services/gmuxd/internal/sessioncoord/outcomes.go
@@ -3,7 +3,9 @@ package sessioncoord
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"sync"
+	"sync/atomic"
 
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/centralstore"
 )
@@ -35,6 +37,7 @@ type Outcome struct {
 	Session    *centralstore.Session // committed row for Upserted; nil otherwise
 	Alive      bool                  // registry liveness at publish time
 	Generation uint64                // 0 when not alive
+	Sequence   uint64                // monotonic commit sequence; non-zero for post-commit Upserted/Removed outcomes
 }
 
 // outcomeActivityBacklog bounds how many undelivered outcomes a subscriber
@@ -59,11 +62,40 @@ type outcomeSub struct {
 	// version-gated and resets the watermark, because a post-removal
 	// re-registration starts a fresh version sequence at 1.
 	seen map[centralstore.SessionID]centralstore.RowVersion
+	// seenSeq is the per-session max commit-sequence watermark. It is updated
+	// on every delivered domain outcome (Upserted and Removed) and gates both
+	// types: an outcome whose Sequence < seenSeq[id] was committed before a
+	// later outcome already in the queue (or delivered), so it is dropped
+	// without changing either watermark. This prevents either half of an old
+	// generation (a Remove or a captured-row Upsert) from overwriting a live
+	// re-registration.
+	seenSeq map[centralstore.SessionID]uint64
+	// lastUpsert is the last accepted durable/runtime projection. A newer
+	// commit stamp advances stale-outcome protection, but if its post-commit
+	// read observed this exact projection again it is deduplicated rather than
+	// emitted twice. Generation is part of the projection, so same-version
+	// runtime replacement is not mistaken for a duplicate.
+	lastUpsert map[centralstore.SessionID]Outcome
 }
 
 type outcomeBus struct {
-	mu   sync.Mutex
-	subs map[*outcomeSub]struct{}
+	mu        sync.Mutex
+	subs      map[*outcomeSub]struct{}
+	commitSeq atomic.Uint64 // monotone per-commit sequence; allocate under c.mu
+}
+
+// allocSeq returns the next commit-sequence stamp. Callers that hold the
+// lifecycle mutex (c.mu) when committing should call this before releasing
+// c.mu so the sequence reflects commit order.
+//
+// uint64 wrap is deliberately not handled: reaching it requires more commits
+// than one daemon process can practically perform, and subscribers/sequence
+// state are process-local and reset together on restart. A modular comparison
+// would add ambiguity at the half-range boundary to every normal operation;
+// treat wrap as an operational restart boundary rather than complicating the
+// hot-path invariant.
+func (b *outcomeBus) allocSeq() uint64 {
+	return b.commitSeq.Add(1)
 }
 
 func (b *outcomeBus) hasSubscribers() bool {
@@ -83,6 +115,18 @@ func (b *outcomeBus) publish(o Outcome) {
 	defer b.mu.Unlock()
 	for sub := range b.subs {
 		sub.mu.Lock()
+		// Any stamped domain outcome is newer than an unstamped seed baseline.
+		// Once a stamped outcome has been seen, compare its commit sequence.
+		newerCommit := o.Type != OutcomeActivity && o.Sequence > 0
+		if newerCommit && sub.seenSeq != nil {
+			if seq := sub.seenSeq[o.ID]; seq > 0 {
+				if o.Sequence < seq {
+					sub.mu.Unlock()
+					continue // stale domain outcome: do not mutate either watermark
+				}
+				newerCommit = o.Sequence > seq
+			}
+		}
 		switch o.Type {
 		case OutcomeActivity:
 			if len(sub.queue) >= outcomeActivityBacklog {
@@ -91,20 +135,50 @@ func (b *outcomeBus) publish(o Outcome) {
 			}
 		case OutcomeUpserted:
 			if o.Session != nil {
-				if last, ok := sub.seen[o.ID]; ok && o.Session.Version <= last {
+				if last, ok := sub.lastUpsert[o.ID]; ok && sameUpsertProjection(last, o) {
+					// A racing post-commit read (or a commit already reflected by a
+					// seed) may attach the exact current row to a newer sequence.
+					// Advance sequence protection, but do not redeliver unchanged state.
+					if newerCommit {
+						if sub.seenSeq == nil {
+							sub.seenSeq = make(map[centralstore.SessionID]uint64)
+						}
+						sub.seenSeq[o.ID] = o.Sequence
+					}
 					sub.mu.Unlock()
-					continue // stale: a newer row was already enqueued (H-1)
+					continue
+				}
+				// A strictly newer commit sequence supersedes row-version order:
+				// removal/re-registration starts a fresh version generation at v1.
+				// A changed Generation is also a changed projection, including a
+				// same-version runtime replacement. For unstamped or equal-sequence
+				// outcomes, retain the H-1 version gate.
+				if last, ok := sub.seen[o.ID]; ok && !newerCommit && o.Session.Version <= last {
+					sub.mu.Unlock()
+					continue // stale within the current commit/version generation
 				}
 				if sub.seen == nil {
 					sub.seen = make(map[centralstore.SessionID]centralstore.RowVersion)
 				}
+				if sub.lastUpsert == nil {
+					sub.lastUpsert = make(map[centralstore.SessionID]Outcome)
+				}
 				sub.seen[o.ID] = o.Session.Version
+				sub.lastUpsert[o.ID] = snapshotUpsert(o)
 			}
 		case OutcomeRemoved:
-			// Never dropped by an older version; reset the watermark so a
-			// post-removal re-registration's fresh version sequence (starting
-			// over at 1) is not shadowed by the removed row's versions.
+			// A delivered removal ends the row-version generation. A stale
+			// removal was rejected above and must not reset this watermark.
 			delete(sub.seen, o.ID)
+			delete(sub.lastUpsert, o.ID)
+		}
+		if o.Type != OutcomeActivity && o.Sequence > 0 {
+			if sub.seenSeq == nil {
+				sub.seenSeq = make(map[centralstore.SessionID]uint64)
+			}
+			if o.Sequence > sub.seenSeq[o.ID] {
+				sub.seenSeq[o.ID] = o.Sequence
+			}
 		}
 		sub.queue = append(sub.queue, o)
 		sub.mu.Unlock()
@@ -113,6 +187,54 @@ func (b *outcomeBus) publish(o Outcome) {
 		default:
 		}
 	}
+}
+
+func sameUpsertProjection(a, b Outcome) bool {
+	return a.Type == OutcomeUpserted && b.Type == OutcomeUpserted &&
+		a.Alive == b.Alive && a.Generation == b.Generation &&
+		reflect.DeepEqual(a.Session, b.Session)
+}
+
+// snapshotUpsert owns every mutable part of the retained projection. The
+// original Outcome is queued/returned to consumers and is therefore mutable;
+// deduplication must never retain aliases into it.
+func snapshotUpsert(o Outcome) Outcome {
+	o.Session = cloneOutcomeSession(o.Session)
+	return o
+}
+
+func cloneOutcomeSession(s *centralstore.Session) *centralstore.Session {
+	if s == nil {
+		return nil
+	}
+	clone := *s
+	if s.Command != nil {
+		clone.Command = make([]string, len(s.Command))
+		copy(clone.Command, s.Command)
+	}
+	if s.Remotes != nil {
+		clone.Remotes = make(map[string]string, len(s.Remotes))
+		for k, v := range s.Remotes {
+			clone.Remotes[k] = v
+		}
+	}
+	clone.StartedAt = cloneOutcomePtr(s.StartedAt)
+	clone.ExitedAt = cloneOutcomePtr(s.ExitedAt)
+	clone.LastActivityAt = cloneOutcomePtr(s.LastActivityAt)
+	clone.DismissedAt = cloneOutcomePtr(s.DismissedAt)
+	clone.ExitCode = cloneOutcomePtr(s.ExitCode)
+	clone.TerminalCols = cloneOutcomePtr(s.TerminalCols)
+	clone.TerminalRows = cloneOutcomePtr(s.TerminalRows)
+	clone.LaunchParentID = cloneOutcomePtr(s.LaunchParentID)
+	return &clone
+}
+
+func cloneOutcomePtr[T any](v *T) *T {
+	if v == nil {
+		return nil
+	}
+	clone := *v
+	return &clone
 }
 
 // SubscribeOutcomes registers a post-commit outcome consumer. The returned
@@ -131,7 +253,14 @@ func (c *Coordinator) SubscribeOutcomes() (<-chan Outcome, func()) {
 }
 
 func newOutcomeSub() *outcomeSub {
-	return &outcomeSub{signal: make(chan struct{}, 1), done: make(chan struct{}), ch: make(chan Outcome), seen: make(map[centralstore.SessionID]centralstore.RowVersion)}
+	return &outcomeSub{
+		signal:     make(chan struct{}, 1),
+		done:       make(chan struct{}),
+		ch:         make(chan Outcome),
+		seen:       make(map[centralstore.SessionID]centralstore.RowVersion),
+		seenSeq:    make(map[centralstore.SessionID]uint64),
+		lastUpsert: make(map[centralstore.SessionID]Outcome),
+	}
 }
 
 func (c *Coordinator) installOutcomeSubLocked(sub *outcomeSub) {
@@ -195,8 +324,10 @@ func (c *Coordinator) SubscribeOutcomesSeed(ctx context.Context) (seed []Outcome
 		for i := range rows {
 			row := rows[i]
 			alive, generation := c.livenessOf(row.ID)
+			seedOutcome := Outcome{Type: OutcomeUpserted, ID: row.ID, Session: &row, Alive: alive, Generation: generation}
 			sub.seen[row.ID] = row.Version
-			seed = append(seed, Outcome{Type: OutcomeUpserted, ID: row.ID, Session: &row, Alive: alive, Generation: generation})
+			sub.lastUpsert[row.ID] = snapshotUpsert(seedOutcome)
+			seed = append(seed, seedOutcome)
 		}
 	}
 	c.outcomes.mu.Unlock()
@@ -230,54 +361,41 @@ func (c *Coordinator) livenessOf(id centralstore.SessionID) (bool, uint64) {
 }
 
 // emitUpserted publishes an Upserted outcome for a row the caller already
-// holds (the committed registration row). Callers must not hold the
-// lifecycle mutex. Liveness is stamped at publish time (design M-3); the
-// row may be older than the stamped world when a newer commit raced this
-// publish, but then that newer commit's own outcome either already set the
-// watermark (this one is dropped) or is still queued behind it (delivered
-// after) — the subscriber's final state is the newest row either way
-// (review M-2 rides the H-1 watermark).
-func (c *Coordinator) emitUpserted(session centralstore.Session) {
+// holds (the committed registration row). seq must be the commit-sequence
+// stamp allocated under c.mu before releasing the lifecycle mutex. Callers
+// must not hold the lifecycle mutex at call time. Liveness is stamped at
+// publish time (design M-3); the row may be older than the stamped world
+// when a newer commit raced this publish, but then that newer commit's own
+// outcome either already set the watermark (this one is dropped) or is
+// still queued behind it (delivered after) — the subscriber's final state
+// is the newest row either way (review M-2 rides the H-1 watermark).
+func (c *Coordinator) emitUpserted(session centralstore.Session, seq uint64) {
 	if !c.outcomes.hasSubscribers() {
 		return
 	}
 	alive, generation := c.livenessOf(session.ID)
 	s := session
-	c.outcomes.publish(Outcome{Type: OutcomeUpserted, ID: session.ID, Session: &s, Alive: alive, Generation: generation})
+	c.outcomes.publish(Outcome{Type: OutcomeUpserted, ID: session.ID, Session: &s, Alive: alive, Generation: generation, Sequence: seq})
 }
 
 // emitOutcomes publishes one outcome per ID after a commit: a post-commit
 // row read decides Upserted (row present, committed state attached) versus
-// Removed (row absent). The read races later commits by design — a newer
-// row is safe to deliver, and the per-subscriber version watermark drops
-// any older row published late, so delivery is monotone per session even
-// though publishes run outside the lifecycle mutex. Callers must not hold
-// the lifecycle mutex (the read is a short DB transaction; publish never
-// blocks). Read failures are reported and the outcome is skipped; consumers
-// converge on the next outcome for that row.
+// Removed (row absent). seq must be the commit-sequence stamp allocated
+// under c.mu (or via outcomeBus.allocSeq) before releasing the lifecycle
+// mutex, so the sequence reflects commit order. The per-subscriber
+// commit-seq watermark (seenSeq) uses this stamp to drop any domain outcome
+// that arrives after a newer outcome for the same session was already
+// delivered (R-2 fix: prevents either a late Remove or a captured old row
+// from overwriting a live re-registration).
 //
-// Known residual (documented, not fixable locally with per-ID watermarks;
-// it exists in BOTH directions across a removal boundary, fable delta
-// review R-2):
-//
-//   - Removed then stale Upserted: a Removed outcome followed by a stale
-//     captured-row Upserted for the SAME pre-removal generation (reachable
-//     via a fast-dead Register racing a Remove) can deliver the stale row
-//     after the watermark reset. Production consumers treat rows with exit
-//     facts as dead either way.
-//   - Upserted then late Removed: the durable read sites CAN produce the
-//     inverse — a Remove commits, its post-commit read observes absence,
-//     and before that Removed publishes, a re-registration commits and
-//     publishes its fresh Upserted; the late Removed (never version-gated,
-//     and it resets the watermark) then lands last, leaving a ghost
-//     removal for a live session. A live session self-heals on its next
-//     runner event; only a fast-dead re-registration immediately after a
-//     Remove can leave the ghost as final state.
-//
-// Consumers keyed on Removed must therefore tolerate a row reappearing via
-// the next Upserted (S5 consumer-wiring checklist). A real fix needs
-// commit-ordered sequence stamping.
-func (c *Coordinator) emitOutcomes(ctx context.Context, ids ...centralstore.SessionID) {
+// The read races later commits by design — a newer row is safe to deliver,
+// and the per-subscriber version watermark drops any older row published
+// late, so delivery is monotone per session even though publishes run
+// outside the lifecycle mutex. Callers must not hold the lifecycle mutex
+// (the read is a short DB transaction; publish never blocks). Read failures
+// are reported and the outcome is skipped; consumers converge on the next
+// outcome for that row.
+func (c *Coordinator) emitOutcomes(ctx context.Context, seq uint64, ids ...centralstore.SessionID) {
 	if len(ids) == 0 || !c.outcomes.hasSubscribers() {
 		return
 	}
@@ -289,10 +407,10 @@ func (c *Coordinator) emitOutcomes(ctx context.Context, ids ...centralstore.Sess
 		}
 		alive, generation := c.livenessOf(id)
 		if !ok {
-			c.outcomes.publish(Outcome{Type: OutcomeRemoved, ID: id, Alive: alive, Generation: generation})
+			c.outcomes.publish(Outcome{Type: OutcomeRemoved, ID: id, Alive: alive, Generation: generation, Sequence: seq})
 			continue
 		}
 		row := s
-		c.outcomes.publish(Outcome{Type: OutcomeUpserted, ID: id, Session: &row, Alive: alive, Generation: generation})
+		c.outcomes.publish(Outcome{Type: OutcomeUpserted, ID: id, Session: &row, Alive: alive, Generation: generation, Sequence: seq})
 	}
 }

--- a/services/gmuxd/internal/sessioncoord/outcomes_test.go
+++ b/services/gmuxd/internal/sessioncoord/outcomes_test.go
@@ -2,6 +2,8 @@ package sessioncoord
 
 import (
 	"context"
+	"fmt"
+	"reflect"
 	"sync"
 	"testing"
 	"time"
@@ -225,7 +227,7 @@ func TestOutcomeBusNoSubscribersSkipsReads(t *testing.T) {
 		return centralstore.Session{}, false, nil
 	}
 	coord := New(nil, newFakeClient(RunnerMeta{}), dur, &fakeDirtySink{}, nil)
-	coord.emitOutcomes(context.Background(), "sess-a", "sess-b")
+	coord.emitOutcomes(context.Background(), 0, "sess-a", "sess-b")
 	if reads != 0 {
 		t.Fatalf("expected no reads without subscribers, got %d", reads)
 	}
@@ -330,5 +332,633 @@ func TestOutcomeBusRemovedResetsWatermark(t *testing.T) {
 	}
 	if o := recvOutcome(t, ch); o.Type != OutcomeUpserted || o.Session.Version != 1 {
 		t.Fatalf("fresh sequence after removal must deliver: %+v", o)
+	}
+}
+
+// TestOutcomeBusLateRemovedDroppedAfterNewerUpserted is a deterministic
+// regression for R-2: an older Removed (commit-seq=N) that arrives AFTER a
+// newer re-registration Upserted (commit-seq=N+1) for the same session must
+// be dropped by the per-session commit-seq watermark.
+//
+// The schedule reproduced here (publish order differs from commit order):
+//
+//  1. Remove commits (seq=1).
+//  2. Register commits (seq=2) and publishes its Upserted immediately.
+//  3. Remove's post-commit read finishes late; its Removed is published last.
+//
+// Without the watermark the subscriber's final state is "removed" (wrong).
+// With the watermark the late seq=1 Removed is dropped (correct).
+func TestOutcomeBusLateRemovedDroppedAfterNewerUpserted(t *testing.T) {
+	dur := newFakeDurable(0)
+	coord := New(nil, newFakeClient(RunnerMeta{}), dur, &fakeDirtySink{}, nil)
+
+	ch, cancel := coord.SubscribeOutcomes()
+	defer cancel()
+
+	id := centralstore.SessionID("sess-r2")
+	v1 := centralstore.Session{ID: id, Version: 1}
+
+	// Publish in arrival order: newer Upserted (seq=2) first, stale Removed
+	// (seq=1) second — exactly the out-of-order window the fix closes.
+	coord.outcomes.publish(Outcome{Type: OutcomeUpserted, ID: id, Session: &v1, Sequence: 2})
+	coord.outcomes.publish(Outcome{Type: OutcomeRemoved, ID: id, Sequence: 1})
+
+	// Must receive the Upserted.
+	if o := recvOutcome(t, ch); o.Type != OutcomeUpserted || o.Sequence != 2 {
+		t.Fatalf("expected Upserted seq=2, got %+v", o)
+	}
+
+	// The stale Removed (seq=1 < seenSeq=2) must be dropped; the next
+	// delivery must be the Activity sentinel, not the Removed.
+	coord.PublishActivity(id)
+	if o := recvOutcome(t, ch); o.Type != OutcomeActivity {
+		t.Fatalf("stale Removed seq=1 delivered after Upserted seq=2 (got %+v)", o)
+	}
+}
+
+// TestOutcomeBusOldGenerationUpsertDroppedAfterReregistered deterministically
+// reproduces a three-publish composition of the removal-boundary race:
+//
+//  1. a fresh re-registration Upserted (v1, seq=2) arrives first;
+//  2. the old generation's late Removed (seq=1) is dropped;
+//  3. an even later captured old-generation Upserted (v5, seq=1) arrives.
+//
+// The stale Removed must not reset either watermark, and the stale Upserted
+// must also be sequence-gated; otherwise v5 becomes the subscriber's final
+// state despite belonging to the removed generation.
+func TestOutcomeBusOldGenerationUpsertDroppedAfterReregistered(t *testing.T) {
+	dur := newFakeDurable(0)
+	coord := New(nil, newFakeClient(RunnerMeta{}), dur, &fakeDirtySink{}, nil)
+
+	ch, cancel := coord.SubscribeOutcomes()
+	defer cancel()
+
+	id := centralstore.SessionID("sess-r2-old-upsert")
+	fresh := centralstore.Session{ID: id, Version: 1}
+	old := centralstore.Session{ID: id, Version: 5}
+
+	coord.outcomes.publish(Outcome{Type: OutcomeUpserted, ID: id, Session: &fresh, Sequence: 2})
+	coord.outcomes.publish(Outcome{Type: OutcomeRemoved, ID: id, Sequence: 1})
+	coord.outcomes.publish(Outcome{Type: OutcomeUpserted, ID: id, Session: &old, Sequence: 1})
+
+	if o := recvOutcome(t, ch); o.Type != OutcomeUpserted || o.Session == nil || o.Session.Version != 1 || o.Sequence != 2 {
+		t.Fatalf("expected fresh re-registration only, got %+v", o)
+	}
+
+	// Non-vacuously prove both stale domain outcomes were rejected: the next
+	// delivery must be this sentinel rather than Removed or old-generation v5.
+	coord.PublishActivity(id)
+	if o := recvOutcome(t, ch); o.Type != OutcomeActivity {
+		t.Fatalf("old-generation outcome delivered after re-registration: %+v", o)
+	}
+}
+
+func assertOldWatermarkReregisterSchedule(t *testing.T, coord *Coordinator, ch <-chan Outcome, id centralstore.SessionID) {
+	t.Helper()
+	fresh := centralstore.Session{ID: id, Version: 1}
+	coord.outcomes.publish(Outcome{Type: OutcomeUpserted, ID: id, Session: &fresh, Sequence: 3})
+	coord.outcomes.publish(Outcome{Type: OutcomeRemoved, ID: id, Sequence: 2})
+
+	if o := recvOutcome(t, ch); o.Type != OutcomeUpserted || o.Session == nil || o.Session.Version != 1 || o.Sequence != 3 {
+		t.Fatalf("fresh re-registration was not delivered: %+v", o)
+	}
+	coord.PublishActivity(id)
+	if o := recvOutcome(t, ch); o.Type != OutcomeActivity {
+		t.Fatalf("delayed removal survived fresh re-registration: %+v", o)
+	}
+}
+
+// TestOutcomeBusOldWatermarkAcceptsFreshGeneration pins the long-lived
+// subscriber schedule: old v5 is already reflected, fresh v1 from a newer
+// commit publishes before the intervening removal, and must supersede the old
+// row-version generation before making that delayed removal stale.
+func TestOutcomeBusOldWatermarkAcceptsFreshGeneration(t *testing.T) {
+	coord := New(nil, newFakeClient(RunnerMeta{}), newFakeDurable(0), &fakeDirtySink{}, nil)
+	ch, cancel := coord.SubscribeOutcomes()
+	defer cancel()
+	id := centralstore.SessionID("sess-old-watermark")
+	old := centralstore.Session{ID: id, Version: 5}
+	coord.outcomes.publish(Outcome{Type: OutcomeUpserted, ID: id, Session: &old, Sequence: 1})
+	if o := recvOutcome(t, ch); o.Session == nil || o.Session.Version != 5 {
+		t.Fatalf("old generation setup: %+v", o)
+	}
+	assertOldWatermarkReregisterSchedule(t, coord, ch, id)
+}
+
+// TestOutcomeBusSeededOldWatermarkAcceptsFreshGeneration exercises the same
+// schedule when old v5 came from SubscribeOutcomesSeed and therefore has a row
+// watermark but no commit-sequence stamp.
+func TestOutcomeBusSeededOldWatermarkAcceptsFreshGeneration(t *testing.T) {
+	id := centralstore.SessionID("sess-seeded-old-watermark")
+	dur := newFakeDurable(0)
+	dur.listSessions = func() ([]centralstore.Session, error) {
+		return []centralstore.Session{{ID: id, Version: 5}}, nil
+	}
+	coord := New(nil, newFakeClient(RunnerMeta{}), dur, &fakeDirtySink{}, nil)
+	seed, ch, cancel, err := coord.SubscribeOutcomesSeed(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cancel()
+	if len(seed) != 1 || seed[0].Session == nil || seed[0].Session.Version != 5 {
+		t.Fatalf("seed=%+v", seed)
+	}
+	assertOldWatermarkReregisterSchedule(t, coord, ch, id)
+}
+
+// TestOutcomeBusNewerSequenceDeduplicatesIdenticalProjection proves a newer
+// sequence advances stale-outcome protection without redelivering the exact
+// same durable/runtime projection observed by a racing post-commit read.
+func TestOutcomeBusNewerSequenceDeduplicatesIdenticalProjection(t *testing.T) {
+	coord := New(nil, newFakeClient(RunnerMeta{}), newFakeDurable(0), &fakeDirtySink{}, nil)
+	ch, cancel := coord.SubscribeOutcomes()
+	defer cancel()
+	id := centralstore.SessionID("sess-identical-projection")
+	row := centralstore.Session{ID: id, Version: 5, Title: "same"}
+	first := Outcome{Type: OutcomeUpserted, ID: id, Session: &row, Alive: true, Generation: 7, Sequence: 1}
+	second := first
+	second.Sequence = 3
+	coord.outcomes.publish(first)
+	coord.outcomes.publish(second)
+	coord.outcomes.publish(Outcome{Type: OutcomeRemoved, ID: id, Sequence: 2})
+	if o := recvOutcome(t, ch); o.Sequence != 1 {
+		t.Fatalf("first projection=%+v", o)
+	}
+	coord.PublishActivity(id)
+	if o := recvOutcome(t, ch); o.Type != OutcomeActivity {
+		t.Fatalf("duplicate projection or stale removal delivered: %+v", o)
+	}
+}
+
+// TestOutcomeBusSameVersionNewGenerationDelivered ensures projection dedup
+// includes runtime generation identity: replacement generation 8 at the same
+// durable v1 is a real state transition, not an identical row duplicate.
+func TestOutcomeBusSameVersionNewGenerationDelivered(t *testing.T) {
+	coord := New(nil, newFakeClient(RunnerMeta{}), newFakeDurable(0), &fakeDirtySink{}, nil)
+	ch, cancel := coord.SubscribeOutcomes()
+	defer cancel()
+	id := centralstore.SessionID("sess-same-version-generation")
+	row1 := centralstore.Session{ID: id, Version: 1}
+	row2 := row1
+	coord.outcomes.publish(Outcome{Type: OutcomeUpserted, ID: id, Session: &row1, Alive: true, Generation: 7, Sequence: 1})
+	coord.outcomes.publish(Outcome{Type: OutcomeUpserted, ID: id, Session: &row2, Alive: true, Generation: 8, Sequence: 2})
+	if o := recvOutcome(t, ch); o.Generation != 7 {
+		t.Fatalf("old generation=%+v", o)
+	}
+	if o := recvOutcome(t, ch); o.Generation != 8 || o.Session == nil || o.Session.Version != 1 {
+		t.Fatalf("same-version replacement was deduplicated: %+v", o)
+	}
+}
+
+// TestOutcomeBusSeedDeduplicatesReflectedCommit pins the startup contract: a
+// stamped publisher for a commit already represented by Seed advances the
+// sequence watermark but does not emit the identical projection again.
+func TestOutcomeBusSeedDeduplicatesReflectedCommit(t *testing.T) {
+	id := centralstore.SessionID("sess-seed-dedup")
+	row := centralstore.Session{ID: id, Version: 5, Title: "seeded"}
+	dur := newFakeDurable(0)
+	dur.listSessions = func() ([]centralstore.Session, error) { return []centralstore.Session{row}, nil }
+	coord := New(nil, newFakeClient(RunnerMeta{}), dur, &fakeDirtySink{}, nil)
+	seed, ch, cancel, err := coord.SubscribeOutcomesSeed(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cancel()
+	if len(seed) != 1 {
+		t.Fatalf("seed=%+v", seed)
+	}
+	copyRow := row
+	coord.outcomes.publish(Outcome{Type: OutcomeUpserted, ID: id, Session: &copyRow, Sequence: 3})
+	coord.outcomes.publish(Outcome{Type: OutcomeRemoved, ID: id, Sequence: 2})
+	coord.PublishActivity(id)
+	if o := recvOutcome(t, ch); o.Type != OutcomeActivity {
+		t.Fatalf("seed-reflected projection or stale removal delivered: %+v", o)
+	}
+}
+
+func aliasTestSession(id centralstore.SessionID, version centralstore.RowVersion, title string) centralstore.Session {
+	started, exited, activity, dismissed := centralstore.UnixMillis(1), centralstore.UnixMillis(2), centralstore.UnixMillis(3), centralstore.UnixMillis(4)
+	exitCode, cols, rows := 5, uint16(80), uint16(24)
+	parent := centralstore.SessionID("parent")
+	return centralstore.Session{
+		ID: id, Version: version, Title: title,
+		Command: []string{"cmd", "arg"}, Remotes: map[string]string{"origin": "url"},
+		StartedAt: &started, ExitedAt: &exited, LastActivityAt: &activity, DismissedAt: &dismissed,
+		ExitCode: &exitCode, TerminalCols: &cols, TerminalRows: &rows, LaunchParentID: &parent,
+	}
+}
+
+func corruptAliasSession(s *centralstore.Session) {
+	s.Title = "consumer-local"
+	s.Command[0] = "mutated"
+	s.Remotes["origin"] = "mutated"
+	*s.StartedAt = 11
+	*s.ExitedAt = 12
+	*s.LastActivityAt = 13
+	*s.DismissedAt = 14
+	*s.ExitCode = 15
+	*s.TerminalCols = 16
+	*s.TerminalRows = 17
+	*s.LaunchParentID = "mutated-parent"
+}
+
+// TestOutcomeBusEventProjectionSnapshotOwned reproduces both event alias
+// failure directions: consumer mutation must neither resurrect an unchanged
+// projection nor pre-corrupt the baseline to suppress a real future update.
+func TestOutcomeBusEventProjectionSnapshotOwned(t *testing.T) {
+	t.Run("unchanged row remains deduplicated", func(t *testing.T) {
+		id := centralstore.SessionID("sess-event-alias-duplicate")
+		coord := New(nil, newFakeClient(RunnerMeta{}), newFakeDurable(0), &fakeDirtySink{}, nil)
+		ch, cancel := coord.SubscribeOutcomes()
+		defer cancel()
+		firstRow := aliasTestSession(id, 1, "real")
+		coord.outcomes.publish(Outcome{Type: OutcomeUpserted, ID: id, Session: &firstRow, Sequence: 1})
+		got := recvOutcome(t, ch)
+		corruptAliasSession(got.Session)
+		unchanged := aliasTestSession(id, 1, "real")
+		coord.outcomes.publish(Outcome{Type: OutcomeUpserted, ID: id, Session: &unchanged, Sequence: 2})
+		coord.PublishActivity(id)
+		if o := recvOutcome(t, ch); o.Type != OutcomeActivity {
+			t.Fatalf("consumer mutation resurrected unchanged event: %+v", o)
+		}
+	})
+
+	t.Run("real update remains deliverable", func(t *testing.T) {
+		id := centralstore.SessionID("sess-event-alias-change")
+		coord := New(nil, newFakeClient(RunnerMeta{}), newFakeDurable(0), &fakeDirtySink{}, nil)
+		ch, cancel := coord.SubscribeOutcomes()
+		defer cancel()
+		old := aliasTestSession(id, 1, "old")
+		coord.outcomes.publish(Outcome{Type: OutcomeUpserted, ID: id, Session: &old, Sequence: 1})
+		got := recvOutcome(t, ch)
+		consumerFuture := aliasTestSession(id, 2, "new")
+		*got.Session = consumerFuture
+		future := aliasTestSession(id, 2, "new")
+		coord.outcomes.publish(Outcome{Type: OutcomeUpserted, ID: id, Session: &future, Sequence: 2})
+		if o := recvOutcome(t, ch); o.Session == nil || o.Session.Version != 2 || o.Session.Title != "new" {
+			t.Fatalf("consumer mutation suppressed real update: %+v", o)
+		}
+	})
+}
+
+// TestOutcomeBusSeedProjectionSnapshotOwned applies the same ownership check
+// to the Seed value, which escapes synchronously while its dedup baseline is
+// retained by the subscriber.
+func TestOutcomeBusSeedProjectionSnapshotOwned(t *testing.T) {
+	id := centralstore.SessionID("sess-seed-alias")
+	seedRow := aliasTestSession(id, 1, "real")
+	dur := newFakeDurable(0)
+	dur.listSessions = func() ([]centralstore.Session, error) { return []centralstore.Session{seedRow}, nil }
+	coord := New(nil, newFakeClient(RunnerMeta{}), dur, &fakeDirtySink{}, nil)
+	seed, ch, cancel, err := coord.SubscribeOutcomesSeed(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cancel()
+	corruptAliasSession(seed[0].Session)
+	unchanged := aliasTestSession(id, 1, "real")
+	coord.outcomes.publish(Outcome{Type: OutcomeUpserted, ID: id, Session: &unchanged, Sequence: 2})
+	coord.PublishActivity(id)
+	if o := recvOutcome(t, ch); o.Type != OutcomeActivity {
+		t.Fatalf("seed mutation resurrected reflected row: %+v", o)
+	}
+}
+
+func TestOutcomeBusConcurrentConsumerMutationDoesNotRaceProjection(t *testing.T) {
+	coord := New(nil, newFakeClient(RunnerMeta{}), newFakeDurable(0), &fakeDirtySink{}, nil)
+	ch, cancel := coord.SubscribeOutcomes()
+	defer cancel()
+	for i := range 100 {
+		id := centralstore.SessionID(fmt.Sprintf("sess-alias-race-%d", i))
+		row := aliasTestSession(id, 1, "real")
+		coord.outcomes.publish(Outcome{Type: OutcomeUpserted, ID: id, Session: &row, Sequence: uint64(i*2 + 1)})
+		got := recvOutcome(t, ch)
+		unchanged := aliasTestSession(id, 1, "real")
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() { defer wg.Done(); corruptAliasSession(got.Session) }()
+		go func() {
+			defer wg.Done()
+			coord.outcomes.publish(Outcome{Type: OutcomeUpserted, ID: id, Session: &unchanged, Sequence: uint64(i*2 + 2)})
+		}()
+		wg.Wait()
+	}
+}
+
+func TestOutcomeBusSeedMutationCannotSuppressRealUpdate(t *testing.T) {
+	id := centralstore.SessionID("sess-seed-alias-change")
+	seedRow := aliasTestSession(id, 1, "old")
+	dur := newFakeDurable(0)
+	dur.listSessions = func() ([]centralstore.Session, error) { return []centralstore.Session{seedRow}, nil }
+	coord := New(nil, newFakeClient(RunnerMeta{}), dur, &fakeDirtySink{}, nil)
+	seed, ch, cancel, err := coord.SubscribeOutcomesSeed(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cancel()
+	consumerFuture := aliasTestSession(id, 2, "new")
+	*seed[0].Session = consumerFuture
+	future := aliasTestSession(id, 2, "new")
+	coord.outcomes.publish(Outcome{Type: OutcomeUpserted, ID: id, Session: &future, Sequence: 2})
+	if o := recvOutcome(t, ch); o.Session == nil || o.Session.Version != 2 || o.Session.Title != "new" {
+		t.Fatalf("seed mutation suppressed real update: %+v", o)
+	}
+}
+
+// TestCloneOutcomeSessionOwnsEveryReferenceField documents the current
+// centralstore.Session reference shape. If Session gains another reference
+// field, this test fails until cloneOutcomeSession explicitly owns it.
+func TestCloneOutcomeSessionOwnsEveryReferenceField(t *testing.T) {
+	allowed := map[string]bool{
+		"Command": true, "Remotes": true, "StartedAt": true, "ExitedAt": true,
+		"LastActivityAt": true, "DismissedAt": true, "ExitCode": true,
+		"TerminalCols": true, "TerminalRows": true, "LaunchParentID": true,
+	}
+	typ := reflect.TypeOf(centralstore.Session{})
+	for i := range typ.NumField() {
+		field := typ.Field(i)
+		switch field.Type.Kind() {
+		case reflect.Pointer, reflect.Slice, reflect.Map, reflect.Interface:
+			if !allowed[field.Name] {
+				t.Fatalf("new Session reference field %s (%s) is not owned by cloneOutcomeSession", field.Name, field.Type)
+			}
+		}
+	}
+	if len(allowed) != 10 {
+		t.Fatalf("reference-field inventory changed: %v", allowed)
+	}
+	original := aliasTestSession("sess-clone-shape", 1, "real")
+	clone := cloneOutcomeSession(&original)
+	corruptAliasSession(&original)
+	want := aliasTestSession("sess-clone-shape", 1, "real")
+	if !reflect.DeepEqual(clone, &want) {
+		t.Fatalf("clone retained reference alias:\n got %+v\nwant %+v", clone, &want)
+	}
+}
+
+func TestOutcomeProjectionPreservesCommandNilness(t *testing.T) {
+	t.Run("identical empty non-nil deduplicates", func(t *testing.T) {
+		coord := New(nil, newFakeClient(RunnerMeta{}), newFakeDurable(0), &fakeDirtySink{}, nil)
+		ch, cancel := coord.SubscribeOutcomes()
+		defer cancel()
+		id := centralstore.SessionID("sess-command-empty-dedup")
+		first := centralstore.Session{ID: id, Version: 1, Command: []string{}}
+		second := centralstore.Session{ID: id, Version: 1, Command: []string{}}
+		coord.outcomes.publish(Outcome{Type: OutcomeUpserted, ID: id, Session: &first, Sequence: 1})
+		coord.outcomes.publish(Outcome{Type: OutcomeUpserted, ID: id, Session: &second, Sequence: 2})
+		if o := recvOutcome(t, ch); o.Session == nil || o.Session.Command == nil {
+			t.Fatalf("first empty command projection=%+v", o)
+		}
+		coord.PublishActivity(id)
+		if o := recvOutcome(t, ch); o.Type != OutcomeActivity {
+			t.Fatalf("identical empty non-nil command redelivered: %+v", o)
+		}
+	})
+
+	for _, tc := range []struct {
+		name        string
+		first, next []string
+	}{
+		{name: "empty to nil", first: []string{}, next: nil},
+		{name: "nil to empty", first: nil, next: []string{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			coord := New(nil, newFakeClient(RunnerMeta{}), newFakeDurable(0), &fakeDirtySink{}, nil)
+			ch, cancel := coord.SubscribeOutcomes()
+			defer cancel()
+			id := centralstore.SessionID("sess-command-" + tc.name)
+			first := centralstore.Session{ID: id, Version: 1, Command: tc.first}
+			next := centralstore.Session{ID: id, Version: 1, Command: tc.next}
+			coord.outcomes.publish(Outcome{Type: OutcomeUpserted, ID: id, Session: &first, Sequence: 1})
+			coord.outcomes.publish(Outcome{Type: OutcomeUpserted, ID: id, Session: &next, Sequence: 2})
+			_ = recvOutcome(t, ch)
+			got := recvOutcome(t, ch)
+			if got.Session == nil || (got.Session.Command == nil) != (tc.next == nil) {
+				t.Fatalf("Command nilness transition lost: %+v", got)
+			}
+		})
+	}
+
+	nilCommand := centralstore.Session{Command: nil}
+	emptyCommand := centralstore.Session{Command: []string{}}
+	if got := cloneOutcomeSession(&nilCommand); got.Command != nil {
+		t.Fatalf("nil Command cloned as non-nil: %#v", got.Command)
+	}
+	if got := cloneOutcomeSession(&emptyCommand); got.Command == nil || len(got.Command) != 0 {
+		t.Fatalf("empty non-nil Command not preserved: %#v", got.Command)
+	}
+}
+
+type delayedRemovalDurable struct {
+	*fakeDurable
+	stateMu           sync.Mutex
+	row               *centralstore.Session
+	blockRemovalRead  bool
+	captureBeforeWait bool
+	readEntered       chan struct{}
+	releaseRead       chan struct{}
+}
+
+func (d *delayedRemovalDurable) RegisterRunner(_ context.Context, reg centralstore.RunnerRegistration) (centralstore.Session, centralstore.MutationResult, error) {
+	d.stateMu.Lock()
+	row := centralstore.Session{ID: reg.ID, Version: 1}
+	d.row = &row
+	d.stateMu.Unlock()
+	return row, centralstore.MutationResult{Changed: true, SessionsDirty: true, SessionVersion: 1}, nil
+}
+
+func (d *delayedRemovalDurable) RemoveSessionAtVersion(_ context.Context, _ centralstore.SessionID, _ centralstore.RowVersion) (centralstore.MutationResult, error) {
+	d.stateMu.Lock()
+	d.row = nil
+	d.blockRemovalRead = true
+	d.stateMu.Unlock()
+	return centralstore.MutationResult{Changed: true, SessionsDirty: true, WorldDirty: true}, nil
+}
+
+func (d *delayedRemovalDurable) Session(_ context.Context, _ centralstore.SessionID) (centralstore.Session, bool, error) {
+	d.stateMu.Lock()
+	block := d.blockRemovalRead
+	if block {
+		d.blockRemovalRead = false
+	}
+	captureBeforeWait := d.captureBeforeWait
+	var row centralstore.Session
+	ok := d.row != nil
+	if ok {
+		row = *d.row
+	}
+	d.stateMu.Unlock()
+	if block {
+		close(d.readEntered)
+		<-d.releaseRead
+		if !captureBeforeWait {
+			d.stateMu.Lock()
+			ok = d.row != nil
+			if ok {
+				row = *d.row
+			}
+			d.stateMu.Unlock()
+		}
+	}
+	return row, ok, nil
+}
+
+func (d *delayedRemovalDurable) ListSessions(_ context.Context) ([]centralstore.Session, error) {
+	d.stateMu.Lock()
+	defer d.stateMu.Unlock()
+	if d.row == nil {
+		return nil, nil
+	}
+	return []centralstore.Session{*d.row}, nil
+}
+
+// TestCoordinatorReregisterBeatsDelayedRemoval composes the production seam:
+// a real Remove captures absence and blocks before publishing, then a real
+// Register commits and publishes fresh v1 first. Besides the ordering
+// invariant, the non-zero stamps make this test kill allocSeq=>0 and
+// Sequence-propagation=>0 mutations.
+func TestCoordinatorReregisterBeatsDelayedRemoval(t *testing.T) {
+	id := centralstore.SessionID("sess-production-order")
+	old := centralstore.Session{ID: id, Version: 5}
+	dur := &delayedRemovalDurable{
+		fakeDurable:       newFakeDurable(0),
+		row:               &old,
+		captureBeforeWait: true,
+		readEntered:       make(chan struct{}),
+		releaseRead:       make(chan struct{}),
+	}
+	client := newFakeClient(RunnerMeta{Registration: centralstore.RunnerRegistration{ID: id, Alive: true}})
+	coord := New(nil, client, dur, &fakeDirtySink{}, nil)
+	seed, ch, cancel, err := coord.SubscribeOutcomesSeed(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cancel()
+	if len(seed) != 1 || seed[0].Session == nil || seed[0].Session.Version != 5 {
+		t.Fatalf("seed=%+v", seed)
+	}
+
+	removeDone := make(chan error, 1)
+	go func() { removeDone <- coord.Remove(context.Background(), id, 5) }()
+	select {
+	case <-dur.readEntered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Remove did not reach post-commit read barrier")
+	}
+
+	if _, err := coord.Register(context.Background(), RegisterRequest{Endpoint: "ep-production-order"}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	fresh := recvOutcome(t, ch)
+	if fresh.Type != OutcomeUpserted || fresh.Session == nil || fresh.Session.Version != 1 || fresh.Sequence == 0 {
+		t.Fatalf("production registration outcome=%+v", fresh)
+	}
+	close(dur.releaseRead)
+	if err := <-removeDone; err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	coord.PublishActivity(id)
+	if o := recvOutcome(t, ch); o.Type != OutcomeActivity {
+		t.Fatalf("production delayed removal delivered after fresh row: %+v", o)
+	}
+}
+
+type registerBlockSink struct {
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (s *registerBlockSink) Committed(_ context.Context, result centralstore.MutationResult) {
+	if result.Changed && result.SessionsDirty && !result.WorldDirty {
+		close(s.entered)
+		<-s.release
+	}
+}
+
+// TestCoordinatorRacingPublishersDeduplicateCurrentProjection composes the
+// production duplicate seam. Remove commits first and pauses its post-commit
+// read; Register commits v1 but pauses before emitUpserted; Remove then reads
+// and publishes that same current v1 with its older stamp; finally Register's
+// newer-stamped identical projection must advance sequence state but not emit.
+func TestCoordinatorRacingPublishersDeduplicateCurrentProjection(t *testing.T) {
+	id := centralstore.SessionID("sess-production-dedup")
+	old := centralstore.Session{ID: id, Version: 5}
+	dur := &delayedRemovalDurable{
+		fakeDurable: newFakeDurable(0),
+		row:         &old,
+		readEntered: make(chan struct{}),
+		releaseRead: make(chan struct{}),
+	}
+	sink := &registerBlockSink{entered: make(chan struct{}), release: make(chan struct{})}
+	client := newFakeClient(RunnerMeta{Registration: centralstore.RunnerRegistration{ID: id, Alive: true}})
+	coord := New(nil, client, dur, sink, nil)
+	ch, cancel := coord.SubscribeOutcomes()
+	defer cancel()
+
+	removeDone := make(chan error, 1)
+	go func() { removeDone <- coord.Remove(context.Background(), id, 5) }()
+	select {
+	case <-dur.readEntered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Remove did not reach pre-read barrier")
+	}
+
+	registerDone := make(chan error, 1)
+	go func() {
+		_, err := coord.Register(context.Background(), RegisterRequest{Endpoint: "ep-production-dedup"})
+		registerDone <- err
+	}()
+	select {
+	case <-sink.entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Register did not reach pre-publication barrier")
+	}
+
+	close(dur.releaseRead)
+	if err := <-removeDone; err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	first := recvOutcome(t, ch)
+	if first.Type != OutcomeUpserted || first.Session == nil || first.Session.Version != 1 || first.Sequence == 0 {
+		t.Fatalf("older publisher did not carry current projection: %+v", first)
+	}
+	close(sink.release)
+	if err := <-registerDone; err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	coord.PublishActivity(id)
+	if o := recvOutcome(t, ch); o.Type != OutcomeActivity {
+		t.Fatalf("newer publisher redelivered identical projection: %+v", o)
+	}
+}
+
+// TestOutcomeBusLateRemovedNormalOrderDelivered verifies that a Removed
+// with a higher commit-seq than the preceding Upserted is delivered normally
+// (i.e. the watermark only drops truly stale outcomes).
+func TestOutcomeBusLateRemovedNormalOrderDelivered(t *testing.T) {
+	dur := newFakeDurable(0)
+	coord := New(nil, newFakeClient(RunnerMeta{}), dur, &fakeDirtySink{}, nil)
+
+	ch, cancel := coord.SubscribeOutcomes()
+	defer cancel()
+
+	id := centralstore.SessionID("sess-r2b")
+	v1 := centralstore.Session{ID: id, Version: 1}
+
+	// Normal order: Upserted (seq=1) then Removed (seq=2).
+	coord.outcomes.publish(Outcome{Type: OutcomeUpserted, ID: id, Session: &v1, Sequence: 1})
+	coord.outcomes.publish(Outcome{Type: OutcomeRemoved, ID: id, Sequence: 2})
+
+	if o := recvOutcome(t, ch); o.Type != OutcomeUpserted {
+		t.Fatalf("expected Upserted, got %+v", o)
+	}
+	if o := recvOutcome(t, ch); o.Type != OutcomeRemoved {
+		t.Fatalf("expected Removed, got %+v", o)
+	}
+	// After a delivered Removed, a fresh v1 re-registration must still pass.
+	v1b := centralstore.Session{ID: id, Version: 1}
+	coord.outcomes.publish(Outcome{Type: OutcomeUpserted, ID: id, Session: &v1b, Sequence: 3})
+	if o := recvOutcome(t, ch); o.Type != OutcomeUpserted || o.Session.Version != 1 {
+		t.Fatalf("fresh re-registration must deliver after Removed: %+v", o)
 	}
 }

--- a/services/gmuxd/internal/sessioncoord/reconcile.go
+++ b/services/gmuxd/internal/sessioncoord/reconcile.go
@@ -283,6 +283,7 @@ func (c *Coordinator) Reconcile(ctx context.Context) ([]centralstore.SessionID, 
 
 	// ── Apply (mutex per decision, short DB tx; publish outside) ─────────
 	var removed []centralstore.SessionID
+	var removedSeqs []uint64 // per-removal commit-seq stamps (allocated under c.mu)
 	var outcomes []centralstore.MutationResult
 	verdictsChanged := false
 	for _, cand := range candidates {
@@ -321,6 +322,7 @@ func (c *Coordinator) Reconcile(ctx context.Context) ([]centralstore.SessionID, 
 			case removeErr == nil:
 				verdictsChanged = c.setVerdict(cand.ID, VerdictUnknown) || verdictsChanged
 				removed = append(removed, cand.ID)
+				removedSeqs = append(removedSeqs, c.outcomes.allocSeq()) // stamp under c.mu
 				outcomes = append(outcomes, result)
 			case errors.Is(removeErr, centralstore.ErrStaleVersion), errors.Is(removeErr, centralstore.ErrSessionNotFound):
 				// The decision went stale (any conditional mutation landed)
@@ -348,6 +350,8 @@ func (c *Coordinator) Reconcile(ctx context.Context) ([]centralstore.SessionID, 
 	for _, r := range outcomes {
 		c.publish(ctx, r)
 	}
-	c.emitOutcomes(ctx, removed...)
+	for i, id := range removed {
+		c.emitOutcomes(ctx, removedSeqs[i], id)
+	}
 	return removed, verdictsChanged, nil
 }


### PR DESCRIPTION
Fixes sessioncoord outcome ordering jointly across commit order, row-version generations, and immutable delivered projection identity.

- stamps production Upserted/Removed outcomes at lifecycle commit boundaries
- allows newer commits to establish fresh v1 generations while advancing stale protection
- deduplicates unchanged durable/runtime projections without suppressing same-version Generation replacement
- retains a fully owned deep Session snapshot, preserving exact nil/empty semantics, so mutable Seed/Event values cannot corrupt or race dedup state
- pins Session reference-field ownership and Command nil-versus-empty transitions
- covers long-lived/seeded generation resets, seed-reflected dedup, and composed real Remove/Register races
- composed tests protect allocation and production sequence propagation

The fix is one commit because earlier intermediate boundaries were not independently safe. `uint64` wrap is documented as an operationally unreachable process-lifetime boundary.

Targets `main`. Do not merge until review and CI complete.