### PR TITLE
fix(gmuxd): preserve discovered project origin boundary

### DIFF
--- a/services/gmuxd/cmd/gmuxd/central_helpers.go
+++ b/services/gmuxd/cmd/gmuxd/central_helpers.go
@@ -224,6 +224,32 @@ func projectStateFromWorld(world *wire.WorldPayload) projects.State {
 	return state
 }
 
+// advertisingHostSessions returns native sessions and Local peers whose
+// project assignment this host owns. Network peers advertise themselves.
+func advertisingHostSessions(sessions []projects.SessionInfo) []projects.SessionInfo {
+	owned := make([]projects.SessionInfo, 0, len(sessions))
+	for _, session := range sessions {
+		if session.Host == "" || session.LocalHost {
+			owned = append(owned, session)
+		}
+	}
+	return owned
+}
+
+// projectDiscoveryData builds the GET /v1/projects payload. Discovery and its
+// active count deliberately share one ownership-scoped input so the endpoint
+// cannot re-advertise a network peer's sessions under this spoke's identity.
+func projectDiscoveryData(frames wire.Frames, isLocalPeer func(string) bool) map[string]any {
+	state := projectStateFromWorld(frames.World)
+	infos := buildSessionInfosWire(frames.Sessions, isLocalPeer)
+	owned := advertisingHostSessions(infos)
+	return map[string]any{
+		"configured":             state.Items,
+		"discovered":             state.Discovered(owned),
+		"unmatched_active_count": state.UnmatchedActiveCount(owned),
+	}
+}
+
 func projectSpecsFromState(state projects.State) []centralstore.ProjectEntrySpec {
 	specs := make([]centralstore.ProjectEntrySpec, 0, len(state.Items))
 	for _, item := range state.Items {

--- a/services/gmuxd/cmd/gmuxd/central_helpers_discovery_test.go
+++ b/services/gmuxd/cmd/gmuxd/central_helpers_discovery_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/projects"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/snapshot/wire"
+)
+
+func TestGetProjectsRouteKeepsAdvertisingHostBoundary(t *testing.T) {
+	frames := wire.Frames{
+		Sessions: &wire.SessionsPayload{Sessions: []wire.Session{
+			{ID: "local", Adapter: "shell", Cwd: "/work/local", Alive: true},
+			{ID: "container@dev", Peer: "dev", Adapter: "shell", Cwd: "/work/container", Alive: true},
+			{ID: "remote@node-c", Peer: "node-c", Adapter: "shell", Cwd: "/work/remote", Alive: true},
+		}},
+		World: &wire.WorldPayload{Projects: []wire.ProjectItem{{Slug: "configured"}}},
+	}
+	mux := http.NewServeMux()
+	registerGetProjectsRoute(mux, func(*http.Request) (wire.Frames, error) { return frames, nil }, func(name string) bool { return name == "dev" })
+
+	recorder := httptest.NewRecorder()
+	mux.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/v1/projects", nil))
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	var envelope struct {
+		OK   bool `json:"ok"`
+		Data struct {
+			Configured           []projects.Item              `json:"configured"`
+			Discovered           []projects.DiscoveredProject `json:"discovered"`
+			UnmatchedActiveCount int                          `json:"unmatched_active_count"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(recorder.Body).Decode(&envelope); err != nil {
+		t.Fatal(err)
+	}
+	if !envelope.OK || len(envelope.Data.Configured) != 1 || envelope.Data.Configured[0].Slug != "configured" {
+		t.Fatalf("configured projects changed: %#v", envelope)
+	}
+	gotPaths := make(map[string]bool, len(envelope.Data.Discovered))
+	for _, row := range envelope.Data.Discovered {
+		gotPaths[row.Paths[0]] = true
+	}
+	if len(envelope.Data.Discovered) != 2 || !gotPaths["/work/local"] || !gotPaths["/work/container"] || gotPaths["/work/remote"] {
+		t.Fatalf("discovered = %#v, want local and Local-peer rows only", envelope.Data.Discovered)
+	}
+	if envelope.Data.UnmatchedActiveCount != 2 {
+		t.Fatalf("unmatched_active_count = %d, want 2", envelope.Data.UnmatchedActiveCount)
+	}
+}

--- a/services/gmuxd/cmd/gmuxd/peer_discovered_contract_test.go
+++ b/services/gmuxd/cmd/gmuxd/peer_discovered_contract_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/config"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/peering"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/snapshot/wire"
+)
+
+func projectRouteSpoke(t *testing.T, frames wire.Frames) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	registerGetProjectsRoute(mux, func(*http.Request) (wire.Frames, error) { return frames, nil }, func(string) bool { return false })
+	mux.HandleFunc("GET /v1/events", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprint(w, "event: snapshot.sessions\ndata: {\"sessions\":[]}\n\n")
+		w.(http.Flusher).Flush()
+		<-r.Context().Done()
+	})
+	mux.HandleFunc("GET /v1/health", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "data": map[string]any{"service": "gmuxd"}})
+	})
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	return server
+}
+
+func TestPeerDiscoveredContractDoesNotRelayCThroughB(t *testing.T) {
+	// C owns this unmatched session. B sees the same session only as a network
+	// mirror. Both servers use the production GET /v1/projects route; A then
+	// consumes them through real Peer.fetchProjects caches and composition.
+	cFrames := wire.Frames{Sessions: &wire.SessionsPayload{Sessions: []wire.Session{
+		{ID: "from-c", Adapter: "shell", Cwd: "/c", Alive: true},
+	}}}
+	bFrames := wire.Frames{Sessions: &wire.SessionsPayload{Sessions: []wire.Session{
+		{ID: "from-c@c", Peer: "c", Adapter: "shell", Cwd: "/c", Alive: true},
+	}}}
+	b := projectRouteSpoke(t, bFrames)
+	c := projectRouteSpoke(t, cFrames)
+	manager := peering.NewProjectionManager([]config.PeerConfig{
+		{Name: "b", URL: b.URL},
+		{Name: "c", URL: c.URL},
+	}, "a", nil, peering.EventHooks{})
+	manager.Start()
+	defer manager.Stop()
+
+	var buckets map[string][]peering.SpokeDiscovered
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		buckets = composePeerDiscovered(manager)
+		if bRows, bOK := buckets["b"]; bOK && bRows != nil {
+			if cRows, cOK := buckets["c"]; cOK && len(cRows) == 1 {
+				break
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	bRows, bOK := buckets["b"]
+	if !bOK || bRows == nil || len(bRows) != 0 {
+		t.Fatalf("A peer_discovered[b] = %#v (present=%v), want present non-nil empty slice", bRows, bOK)
+	}
+	cRows := buckets["c"]
+	if len(cRows) != 1 || cRows[0].SuggestedSlug != "c" || cRows[0].Paths[0] != "/c" {
+		t.Fatalf("A peer_discovered[c] = %#v, want C row in source order", cRows)
+	}
+}

--- a/services/gmuxd/cmd/gmuxd/serve_central.go
+++ b/services/gmuxd/cmd/gmuxd/serve_central.go
@@ -54,6 +54,20 @@ import (
 // replacement was requested.
 var errIncumbentHealthy = errors.New("gmuxd: already running")
 
+// registerGetProjectsRoute installs the production GET /v1/projects handler.
+// Keeping registration and ownership projection together lets contract tests
+// exercise the same mux path peers consume.
+func registerGetProjectsRoute(mux *http.ServeMux, render func(*http.Request) (wire.Frames, error), isLocalPeer func(string) bool) {
+	mux.HandleFunc("GET /v1/projects", func(w http.ResponseWriter, r *http.Request) {
+		frames, err := render(r)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "internal", "snapshot unavailable")
+			return
+		}
+		writeJSON(w, map[string]any{"ok": true, "data": projectDiscoveryData(frames, isLocalPeer)})
+	})
+}
+
 func serveCentral(stderr io.Writer, replace bool) int {
 	gmuxBin := resolveGmux()
 	if gmuxBin != "" {
@@ -334,17 +348,10 @@ func serveCentral(stderr io.Writer, replace bool) int {
 			}
 			writeJSON(w, map[string]any{"ok": true, "data": map[string]any{"theme": theme, "settings": settings}})
 		})
-		mux.HandleFunc("GET /v1/projects", func(w http.ResponseWriter, r *http.Request) {
+		registerGetProjectsRoute(mux, func(r *http.Request) (wire.Frames, error) {
 			// Store-direct read (ADR 0026 §2a).
-			frames, err := renderStoreDirect(r.Context(), boot, converter, peerAdapter)
-			if err != nil {
-				writeError(w, http.StatusInternalServerError, "internal", "snapshot unavailable")
-				return
-			}
-			state := projectStateFromWorld(frames.World)
-			infos := buildSessionInfosWire(frames.Sessions, func(name string) bool { return peerManager != nil && peerManager.IsLocalPeer(name) })
-			writeJSON(w, map[string]any{"ok": true, "data": map[string]any{"configured": state.Items, "discovered": state.Discovered(infos), "unmatched_active_count": state.UnmatchedActiveCount(infos)}})
-		})
+			return renderStoreDirect(r.Context(), boot, converter, peerAdapter)
+		}, func(name string) bool { return peerManager != nil && peerManager.IsLocalPeer(name) })
 		mux.HandleFunc("PUT /v1/projects", func(w http.ResponseWriter, r *http.Request) {
 			body, err := io.ReadAll(io.LimitReader(r.Body, 64*1024))
 			if err != nil {

--- a/services/gmuxd/internal/projects/projects.go
+++ b/services/gmuxd/internal/projects/projects.go
@@ -113,7 +113,6 @@ func Load(stateDir string) (*State, error) {
 	return &s, nil
 }
 
-
 // sanitize removes items that fail validation, keeping the rest in
 // order. Each item is checked against the already-accepted prefix, so
 // cross-item rules (duplicate slugs, duplicate paths) resolve


### PR DESCRIPTION
## Summary

- restrict `/v1/projects` discovery to sessions owned by the advertising host
- retain parent-owned Local peers/devcontainers while excluding network-peer mirrors
- apply the same ownership scope to `unmatched_active_count`
- add production-route and real peering cache/composition coverage for the A → B → C case

## Problem

A spoke computed discovery over its fully composed session world. In a three-node topology, B could therefore advertise C's projects to A as though they belonged to B. The frontend correctly labels advertised rows with their immediate peer bucket, so C projects appeared under B.

## Verification

- focused Go and race tests
- central-store generated and cross-build checks
- production route mutation test
- real `Peer.fetchProjects`/cache/`composePeerDiscovered` contract test
- independent adversarial and contract reviews

## Stack

Depends on #410. This PR targets its `unread-on-restart` branch and should merge after #410 (or be retargeted to `main` once #410 lands).
