### PR TITLE
fix(gmux): share detached registration deadline

### DIFF
--- a/cli/gmux/cmd/gmux/daemon.go
+++ b/cli/gmux/cmd/gmux/daemon.go
@@ -23,8 +23,10 @@ import (
 // so the child process always talks to a compatible daemon.
 // Called once at startup — if gmuxd dies later, we don't restart it.
 // Returns true if gmuxd was started (or replaced) by this call.
-func ensureGmuxd() bool {
-	if !gmuxdNeedsStart() {
+func ensureGmuxd() bool { return ensureGmuxdContext(context.Background()) }
+
+func ensureGmuxdContext(ctx context.Context) bool {
+	if !gmuxdNeedsStartContext(ctx) || ctx.Err() != nil {
 		return false
 	}
 
@@ -45,13 +47,15 @@ func ensureGmuxd() bool {
 // "down" verdict spawns a daemon. (Spawning is no longer destructive — a
 // healthy same-version incumbent refuses replacement since the autostart
 // takeover incident — but pointless spawns still burn a full bootstrap.)
-func gmuxdNeedsStart() bool {
+func gmuxdNeedsStart() bool { return gmuxdNeedsStartContext(context.Background()) }
+
+func gmuxdNeedsStartContext(ctx context.Context) bool {
 	// "dev" builds never replace — avoids churn during development.
 	if version == "dev" {
-		return !gmuxdHealthyRetry()
+		return !gmuxdHealthyRetryContext(ctx)
 	}
 
-	resp, err := gmuxdHealthGet()
+	resp, err := gmuxdHealthGetContext(ctx)
 	if err != nil {
 		return true // not running
 	}
@@ -133,7 +137,7 @@ func gmuxdClient() *http.Client {
 	return &http.Client{
 		Transport: &http.Transport{
 			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
-				return net.DialTimeout("unix", sockPath, 2*time.Second)
+				return (&net.Dialer{Timeout: 2 * time.Second}).DialContext(ctx, "unix", sockPath)
 			},
 		},
 		Timeout: 5 * time.Second,
@@ -146,10 +150,12 @@ func gmuxdBaseURL() string {
 	return "http://localhost"
 }
 
-func gmuxdHealthy(timeout time.Duration) bool {
+func gmuxdHealthyContext(ctx context.Context, timeout time.Duration) bool {
+	attemptCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
 	client := gmuxdClient()
-	client.Timeout = timeout
-	resp, err := client.Get(gmuxdBaseURL() + "/v1/health")
+	req, _ := http.NewRequestWithContext(attemptCtx, http.MethodGet, gmuxdBaseURL()+"/v1/health", nil)
+	resp, err := client.Do(req)
 	if err != nil {
 		return false
 	}
@@ -159,9 +165,11 @@ func gmuxdHealthy(timeout time.Duration) bool {
 
 // gmuxdHealthyRetry probes health with growing budgets (500ms, 1s, 2s) so a
 // momentarily busy daemon isn't misdiagnosed as down.
-func gmuxdHealthyRetry() bool {
+func gmuxdHealthyRetry() bool { return gmuxdHealthyRetryContext(context.Background()) }
+
+func gmuxdHealthyRetryContext(ctx context.Context) bool {
 	for _, timeout := range []time.Duration{500 * time.Millisecond, time.Second, 2 * time.Second} {
-		if gmuxdHealthy(timeout) {
+		if gmuxdHealthyContext(ctx, timeout) {
 			return true
 		}
 	}
@@ -170,14 +178,26 @@ func gmuxdHealthyRetry() bool {
 
 // gmuxdHealthGet fetches /v1/health with the same growing budgets, returning
 // the last error if all attempts fail. Callers own resp.Body.
-func gmuxdHealthGet() (*http.Response, error) {
+func gmuxdHealthGet() (*http.Response, error) { return gmuxdHealthGetContext(context.Background()) }
+
+func gmuxdHealthGetContext(ctx context.Context) (*http.Response, error) {
 	var lastErr error
 	for _, timeout := range []time.Duration{500 * time.Millisecond, time.Second, 2 * time.Second} {
+		attemptCtx, cancel := context.WithTimeout(ctx, timeout)
 		client := gmuxdClient()
-		client.Timeout = timeout
-		resp, err := client.Get(gmuxdBaseURL() + "/v1/health")
+		req, _ := http.NewRequestWithContext(attemptCtx, http.MethodGet, gmuxdBaseURL()+"/v1/health", nil)
+		resp, err := client.Do(req)
 		if err == nil {
-			return resp, nil
+			body, readErr := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			cancel()
+			if readErr == nil {
+				resp.Body = io.NopCloser(bytes.NewReader(body))
+				return resp, nil
+			}
+			err = readErr
+		} else {
+			cancel()
 		}
 		lastErr = err
 	}
@@ -210,44 +230,48 @@ func (o registerOutcome) ok() bool { return o == registerOK }
 
 // registerWithGmuxd posts the session's registration to gmuxd and
 // reports the outcome. Transient failures (gmuxd still starting) are
-// retried a handful of times; a 4xx is fatal and returned immediately
+// retried until the caller's context ends; a 4xx is returned immediately
 // without burning the retry budget. Callers that care about the
 // outcome (the detached (-d) handshake, the orphan-reap path) branch
 // on the returned registerOutcome.
-func registerWithGmuxd(sessionID, socketPath string) registerOutcome {
-	baseURL := gmuxdBaseURL()
+func registerWithGmuxd(ctx context.Context, sessionID, socketPath string) registerOutcome {
+	return registerWithClient(ctx, gmuxdClient(), sessionID, socketPath, 500*time.Millisecond)
+}
 
-	payload, _ := json.Marshal(map[string]string{
-		"session_id":  sessionID,
-		"socket_path": socketPath,
-	})
-
-	// Retry a few times — gmux may start before the HTTP server is ready
-	for i := 0; i < 5; i++ {
-		if i > 0 {
-			time.Sleep(500 * time.Millisecond)
-		}
-		client := gmuxdClient()
-		resp, err := client.Post(baseURL+"/v1/register", "application/json", bytes.NewReader(payload))
+func registerWithClient(ctx context.Context, client *http.Client, sessionID, socketPath string, backoff time.Duration) registerOutcome {
+	payload, _ := json.Marshal(map[string]string{"session_id": sessionID, "socket_path": socketPath})
+	for {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, gmuxdBaseURL()+"/v1/register", bytes.NewReader(payload))
 		if err != nil {
-			continue
-		}
-		status := resp.StatusCode
-		resp.Body.Close()
-		if status == http.StatusOK {
-			return registerOK
-		}
-		// A 4xx is a permanent verdict on this id — the daemon
-		// understood the request and refused it (invalid session id,
-		// malformed body). No amount of retrying changes the answer, so
-		// short-circuit instead of wasting the budget. 5xx (and any
-		// other status) stays in the transient bucket: gmuxd may still
-		// be coming up.
-		if status >= 400 && status < 500 {
 			return registerFatal
 		}
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := client.Do(req)
+		if err == nil {
+			status := resp.StatusCode
+			resp.Body.Close()
+			switch {
+			case status == http.StatusOK:
+				return registerOK
+			case status >= 400 && status < 500:
+				return registerFatal
+			case status < 500 || status >= 600:
+				return registerFatal // redirects, informational, and non-HTTP protocol statuses
+			}
+		}
+		if ctx.Err() != nil {
+			return registerUnavailable
+		}
+		timer := time.NewTimer(backoff)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			return registerUnavailable
+		case <-timer.C:
+		}
 	}
-	return registerUnavailable
 }
 
 func deregisterFromGmuxd(sessionID string) {

--- a/cli/gmux/cmd/gmux/detached_topology_test.go
+++ b/cli/gmux/cmd/gmux/detached_topology_test.go
@@ -1,0 +1,368 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"os/signal"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestProcessGroupCleanupWaitsForDescendants(t *testing.T) {
+	role := os.Getenv("GMUX_GROUP_ROLE")
+	if role == "leader" {
+		child := exec.Command(os.Args[0], "-test.run=^TestProcessGroupCleanupWaitsForDescendants$")
+		child.Env = append(os.Environ(), "GMUX_GROUP_ROLE=descendant")
+		if err := child.Start(); err != nil {
+			os.Exit(92)
+		}
+		_ = os.WriteFile(os.Getenv("GMUX_GROUP_PIDFILE"), []byte(strconv.Itoa(child.Process.Pid)), 0o600)
+		os.Exit(0)
+	}
+	if role == "descendant" {
+		signalIgnore(syscall.SIGHUP, syscall.SIGTERM)
+		for {
+			time.Sleep(time.Second)
+		}
+	}
+	pidFile := t.TempDir() + "/descendant.pid"
+	cmd := exec.Command(os.Args[0], "-test.run=^TestProcessGroupCleanupWaitsForDescendants$")
+	cmd.Env = append(os.Environ(), "GMUX_GROUP_ROLE=leader", "GMUX_GROUP_PIDFILE="+pidFile)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	pgid := cmd.Process.Pid
+	if err := cmd.Wait(); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(pidFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	descendant, _ := strconv.Atoi(strings.TrimSpace(string(data)))
+	terminateProcessGroup(pgid, 30*time.Millisecond)
+	if err := syscall.Kill(descendant, 0); !errors.Is(err, syscall.ESRCH) {
+		t.Fatalf("HUP-ignoring descendant alive: %v", err)
+	}
+}
+
+func TestDetachedTopologyCleanup(t *testing.T) {
+	role := os.Getenv("GMUX_TOPOLOGY_ROLE")
+	if role == "runner" {
+		signalIgnore(syscall.SIGTERM, syscall.SIGHUP)
+		cmd := exec.Command(os.Args[0], "-test.run=^TestDetachedTopologyCleanup$")
+		cmd.Env = append(os.Environ(), "GMUX_TOPOLOGY_ROLE=target")
+		cmd.ExtraFiles = []*os.File{os.NewFile(3, "control"), os.NewFile(4, "gate")}
+		cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+		if err := cmd.Start(); err != nil {
+			os.Exit(91)
+		}
+		if os.Getenv("GMUX_TOPOLOGY_EOF") == "1" {
+			_ = os.NewFile(3, "control").Close()
+		}
+		for {
+			time.Sleep(time.Second)
+		}
+	}
+	if role == "target" {
+		signalIgnore(syscall.SIGTERM, syscall.SIGHUP)
+		pid := os.Getpid()
+		_ = os.WriteFile(os.Getenv("GMUX_TOPOLOGY_PIDFILE"), []byte(strconv.Itoa(pid)), 0o600)
+		control := os.NewFile(3, "control")
+		gate := os.NewFile(4, "gate")
+		_, _ = fmt.Fprintf(control, "TARGET %d\n", pid)
+		_ = control.Close()
+		var token [1]byte
+		_, err := io.ReadFull(gate, token[:])
+		if err != nil {
+			os.Exit(0)
+		}
+		// If allowed to start, create a same-group descendant that ignores HUP
+		// and TERM; parent cleanup must use group disappearance, not leader exit.
+		child := exec.Command(os.Args[0], "-test.run=^TestDetachedTopologyCleanup$")
+		child.Env = append(os.Environ(), "GMUX_TOPOLOGY_ROLE=descendant")
+		_ = child.Start()
+		os.Exit(0)
+	}
+	if role == "descendant" {
+		signalIgnore(syscall.SIGTERM, syscall.SIGHUP)
+		for {
+			time.Sleep(time.Second)
+		}
+	}
+
+	for _, tc := range []struct {
+		name string
+		eof  bool
+	}{{"deadline", false}, {"fatal EOF", true}} {
+		t.Run(tc.name, func(t *testing.T) {
+			pidFile := t.TempDir() + "/target.pid"
+			controlR, controlW, err := os.Pipe()
+			if err != nil {
+				t.Fatal(err)
+			}
+			gateR, gateW, err := os.Pipe()
+			if err != nil {
+				t.Fatal(err)
+			}
+			cmd := exec.Command(os.Args[0], "-test.run=^TestDetachedTopologyCleanup$")
+			cmd.Env = append(os.Environ(), "GMUX_TOPOLOGY_ROLE=runner", "GMUX_TOPOLOGY_PIDFILE="+pidFile)
+			if tc.eof {
+				cmd.Env = append(cmd.Env, "GMUX_TOPOLOGY_EOF=1")
+			}
+			cmd.ExtraFiles = []*os.File{controlW, gateR}
+			cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+			if err := cmd.Start(); err != nil {
+				t.Fatal(err)
+			}
+			_ = controlW.Close()
+			_ = gateR.Close()
+			holdR, hold, _ := os.Pipe()
+			_ = holdR.Close()
+			_, err = awaitDetachedHandshake(cmd, controlR, gateW, hold, time.Now().Add(50*time.Millisecond), 250*time.Millisecond)
+			_ = controlR.Close()
+			if err == nil {
+				t.Fatal("expected failure")
+			}
+			data, err := os.ReadFile(pidFile)
+			if err != nil {
+				t.Fatal(err)
+			}
+			pid, _ := strconv.Atoi(strings.TrimSpace(string(data)))
+			if err := syscall.Kill(cmd.Process.Pid, 0); !errors.Is(err, syscall.ESRCH) {
+				t.Fatalf("runner alive: %v", err)
+			}
+			if err := syscall.Kill(pid, 0); !errors.Is(err, syscall.ESRCH) {
+				t.Fatalf("target alive: %v", err)
+			}
+		})
+	}
+}
+
+func signalIgnore(signals ...syscall.Signal) {
+	for _, sig := range signals {
+		signal.Ignore(sig)
+	}
+}
+
+// ── F3: bounded post-SIGKILL loop ──
+
+// TestTerminateProcessGroupBoundedAfterKill verifies that terminateProcessGroup
+// returns within a bounded time even when the group does not exit on SIGHUP.
+// A process that ignores SIGHUP/SIGTERM falls through to the SIGKILL path;
+// the test confirms that path has a deadline and does not spin forever.
+func TestTerminateProcessGroupBoundedAfterKill(t *testing.T) {
+	if os.Getenv("GMUX_PGBOUND_ROLE") == "victim" {
+		signalIgnore(syscall.SIGHUP, syscall.SIGTERM)
+		for {
+			time.Sleep(time.Second)
+		}
+	}
+	cmd := exec.Command(os.Args[0], "-test.run=^TestTerminateProcessGroupBoundedAfterKill$")
+	cmd.Env = append(os.Environ(), "GMUX_PGBOUND_ROLE=victim")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	pgid := cmd.Process.Pid
+	grace := 100 * time.Millisecond
+	start := time.Now()
+	terminateProcessGroup(pgid, grace)
+	elapsed := time.Since(start)
+	// SIGHUP ignored → first loop exhausts grace. SIGKILL succeeds immediately.
+	// Total should be well within 2×grace + scheduling slack.
+	if elapsed > 4*grace {
+		t.Errorf("terminateProcessGroup took %v, want ≤ %v (bounded loop)", elapsed, 4*grace)
+	}
+	_ = cmd.Wait()
+}
+
+// ── F5: control-protocol validation ──
+
+// TestAwaitDetachedHandshakeProtocolValidation checks that malformed frames
+// (empty session id, invalid session id, oversized line) cause a prompt error
+// from awaitDetachedHandshake rather than waiting out the full deadline.
+func TestAwaitDetachedHandshakeProtocolValidation(t *testing.T) {
+	if os.Getenv("GMUX_PROTO_HELPER") == "1" {
+		for {
+			time.Sleep(time.Second)
+		}
+	}
+	startHelper := func(t *testing.T) *exec.Cmd {
+		t.Helper()
+		cmd := exec.Command(os.Args[0], "-test.run=^TestAwaitDetachedHandshakeProtocolValidation$")
+		cmd.Env = append(os.Environ(), "GMUX_PROTO_HELPER=1")
+		cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+		if err := cmd.Start(); err != nil {
+			t.Fatal(err)
+		}
+		return cmd
+	}
+
+	// deadline for awaitDetachedHandshake; a correct fix makes errors
+	// arrive well before this.
+	const longDeadline = 2 * time.Second
+
+	t.Run("empty_session_id_does_not_wait_out_deadline", func(t *testing.T) {
+		cmd := startHelper(t)
+		r, w, _ := os.Pipe()
+		defer r.Close()
+		go func() {
+			_, _ = fmt.Fprintf(w, "TARGET %d\n\n", cmd.Process.Pid)
+			_ = w.Close()
+		}()
+		_, gate := pipePair(t)
+		_, hold := pipePair(t)
+		_, err := awaitDetachedHandshake(cmd, r, gate, hold, time.Now().Add(longDeadline), 200*time.Millisecond)
+		if err == nil {
+			t.Fatal("expected error for empty session id")
+		}
+		if errors.Is(err, os.ErrDeadlineExceeded) {
+			t.Fatalf("empty id triggered deadline timeout instead of prompt error: %v", err)
+		}
+	})
+
+	t.Run("invalid_session_id_does_not_wait_out_deadline", func(t *testing.T) {
+		cmd := startHelper(t)
+		r, w, _ := os.Pipe()
+		defer r.Close()
+		go func() {
+			// Not a valid sess-<alphanumeric> id
+			_, _ = fmt.Fprintf(w, "TARGET %d\nnot!a!valid!sess!id\n", cmd.Process.Pid)
+			_ = w.Close()
+		}()
+		_, gate := pipePair(t)
+		_, hold := pipePair(t)
+		_, err := awaitDetachedHandshake(cmd, r, gate, hold, time.Now().Add(longDeadline), 200*time.Millisecond)
+		if err == nil {
+			t.Fatal("expected error for invalid session id")
+		}
+		if errors.Is(err, os.ErrDeadlineExceeded) {
+			t.Fatalf("invalid id triggered deadline timeout instead of prompt error: %v", err)
+		}
+	})
+
+	t.Run("oversized_newline_free_stream_rejected_by_cap_not_timeout", func(t *testing.T) {
+		// This sub-test is the mutation-resistance probe: the reader must
+		// return a frame-too-large error promptly via ReadSlice/ErrBufferFull,
+		// NOT by waiting until the pipe closes or the deadline fires.
+		//
+		// Mutation test: removing the bounded reader (replacing with
+		// bufio.ReadString on an unbounded reader) causes this sub-test to
+		// block until the 5 s deadline, then return os.ErrDeadlineExceeded,
+		// making both the "err == nil" check and the "ErrDeadlineExceeded"
+		// check fail together.
+		cmd := startHelper(t)
+		r, w, _ := os.Pipe()
+		defer r.Close()
+		go func() {
+			_, _ = fmt.Fprintf(w, "TARGET %d\n", cmd.Process.Pid)
+			// Write a continuous stream with no newline. The bounded reader must
+			// return ErrBufferFull before consuming all of it; an unbounded reader
+			// would block here until the deadline fires (5 s below).
+			for {
+				if _, err := w.Write(bytes.Repeat([]byte("x"), maxHandshakeFrameBytes)); err != nil {
+					return
+				}
+			}
+		}()
+		_, gate := pipePair(t)
+		_, hold := pipePair(t)
+		start := time.Now()
+		_, err := awaitDetachedHandshake(cmd, r, gate, hold, time.Now().Add(5*time.Second), 200*time.Millisecond)
+		elapsed := time.Since(start)
+		if err == nil {
+			t.Fatal("expected error for oversized newline-free stream")
+		}
+		if errors.Is(err, os.ErrDeadlineExceeded) {
+			t.Fatalf("frame cap caused 5 s deadline timeout instead of prompt ErrBufferFull: %v", err)
+		}
+		// The bounded reader returns within one buffer-fill worth of IO,
+		// which is microseconds on a local pipe. Any wall time well under
+		// the 5 s deadline proves the cap fired, not the deadline.
+		if elapsed > time.Second {
+			t.Errorf("took %v; bounded frame cap should reject in <<1s", elapsed)
+		}
+	})
+}
+
+// TestAwaitDetachedHandshakeRescanFrameCapBounded is the mutation-specific
+// rescan test. It exercises the failure-cleanup rescan path — entered when
+// targetPGID is still 0 after the main loop errors — with a newline-free
+// oversized stream and verifies the bounded reader caps consumption without
+// waiting for the rescan grace deadline.
+//
+// Mutation to kill: in the rescan, replace readHandshakeFrame(reader) with a
+// call that uses a fresh bufio.NewReader(r) (unbounded). That makes the
+// rescan block until r’s read deadline (grace = 2 s) fires, raising elapsed
+// well above the 500 ms threshold and failing the test.
+func TestAwaitDetachedHandshakeRescanFrameCapBounded(t *testing.T) {
+	if os.Getenv("GMUX_SUPERVISOR_HELPER") == "1" {
+		for {
+			time.Sleep(time.Second)
+		}
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestAwaitDetachedHandshakeRescanFrameCapBounded$")
+	cmd.Env = append(os.Environ(), "GMUX_SUPERVISOR_HELPER=1")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+	defer w.Close()
+
+	// Pre-populate the pipe buffer before calling awaitDetachedHandshake so
+	// there is no race between writer and reader goroutines:
+	//
+	//  (1) An invalid session ID line (no "TARGET" prefix) causes the main
+	//      loop to error immediately with targetPGID still 0, which directs
+	//      the cleanup path into the rescan branch.
+	//
+	//  (2) A newline-free blob > maxHandshakeFrameBytes bytes follows. The
+	//      bounded ReadSlice reader must return ErrBufferFull promptly; an
+	//      unbounded bufio.NewReader reader would block until the 2 s
+	//      SetReadDeadline fires.
+	_, _ = fmt.Fprintln(w, "not-a-valid-session-id-for-rescan!!!")
+	_, _ = w.Write(bytes.Repeat([]byte("R"), 4*maxHandshakeFrameBytes))
+	// w is kept open so the pipe does not signal EOF; the rescan reader
+	// must rely on ErrBufferFull, not on pipe closure.
+
+	_, gate := pipePair(t)
+	_, hold := pipePair(t)
+
+	const grace = 2 * time.Second // rescan SetReadDeadline deadline
+	start := time.Now()
+	_, err = awaitDetachedHandshake(cmd, r, gate, hold,
+		time.Now().Add(5*time.Second), // generous main-loop deadline
+		grace)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected protocol error")
+	}
+	// With the bounded reader the rescan returns as soon as the internal
+	// buffer fills (one ReadSlice call, microseconds). The dominant time is
+	// subprocess death after SIGTERM, which is typically <50 ms.
+	//
+	// Mutation threshold: grace/4 = 500 ms. A mutated unbounded rescan
+	// blocks for the full grace (2 s), placing elapsed well above 500 ms.
+	if elapsed > grace/4 {
+		t.Errorf("rescan took %v, want <%v — bounded ReadSlice/ErrBufferFull must "+
+			"reject the newline-free stream without waiting the grace deadline",
+			elapsed, grace/4)
+	}
+}

--- a/cli/gmux/cmd/gmux/handshake.go
+++ b/cli/gmux/cmd/gmux/handshake.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -17,19 +19,32 @@ import (
 // polling /v1/sessions or guessing.
 //
 // Wire:
-//   - Parent: os.Pipe(); attach write end as cmd.ExtraFiles[0] so the
-//     child sees it as fd 3; set GMUX_HANDSHAKE_FD=3 in the child env;
-//     cmd.Start; close parent's copy of the write end; readHandshake
-//     on the read end with a 5s deadline.
-//   - Child: after registerWithGmuxd, call handshakeAck. On registered
-//     success it writes "<session-id>\n" to fd 3 and closes the fd;
-//     on registered failure it closes without writing — the parent
-//     sees EOF with zero bytes and surfaces a clean error.
+//   - Parent (spawnDetached): creates three pipes — control write end
+//     (ExtraFiles[0] → child fd 3), gate read end (ExtraFiles[1] → child
+//     fd 4), hold read end (ExtraFiles[2] → child fd 5); passes the
+//     absolute startup deadline via env; calls cmd.Start; then reads
+//     TARGET-PGID publication and registration ack from the control pipe,
+//     writes a 'G' gate token to unblock the user command on success, and
+//     closes the hold write end when cleanup is complete.
+//   - Child runner (captureHandshakeFD → handshakeAck): captures and
+//     clears all three env vars and fds at startup (setting O_CLOEXEC so
+//     no exec'd process inherits them); derives a shared deadline context;
+//     passes fd 3 and fd 4 to the target wrapper via ExtraFiles so it can
+//     publish its PGID and receive the gate token; acks after
+//     registerWithGmuxd — writes "<session-id>\n" to fd 3 on success or
+//     closes without writing on failure. Calls waitForHandshakeRelease on
+//     fd 5 at the very end so the parent can synchronise target cleanup.
+//   - Target wrapper (__detached-target / runDetachedTarget): writes
+//     "TARGET <pid>\n" to fd 3, reads a 'G' byte from fd 4 before
+//     exec'ing the user command. Exit codes: 125 gate/protocol error,
+//     126 exec error, 127 command not found.
 //
 // Failure modes the parent disambiguates:
-//   - io.EOF                     → child exited before acking
-//   - os.ErrDeadlineExceeded     → child wedged between register and ack
-//   - "empty session id…"        → child wrote only whitespace
+//   - io.EOF                        → child exited before acking
+//   - os.ErrDeadlineExceeded        → child wedged between register and ack
+//   - "empty session id from child" → child wrote only whitespace
+//   - "invalid session id …"        → child wrote a malformed id
+//   - "handshake frame too large"   → child sent an oversized line
 //
 // The env var is consumed at process startup (captureHandshakeFD),
 // NOT at ack time. The runner forwards os.Environ to its PTY child,
@@ -40,39 +55,164 @@ import (
 // typically the Go runtime's epoll fd — writing to and closing it is
 // an instant `netpoll failed` crash. Capturing + unsetting first
 // thing in main() makes the inheritance impossible.
-const handshakeFDEnv = "GMUX_HANDSHAKE_FD"
+const (
+	handshakeFDEnv       = "GMUX_HANDSHAKE_FD"
+	handshakeGateFDEnv   = "GMUX_HANDSHAKE_GATE_FD"
+	handshakeHoldFDEnv   = "GMUX_HANDSHAKE_HOLD_FD"
+	handshakeDeadlineEnv = "GMUX_HANDSHAKE_DEADLINE"
+	targetControlFDEnv   = "GMUX_TARGET_CONTROL_FD"
+	targetGateFDEnv      = "GMUX_TARGET_GATE_FD"
+)
 
 // capturedHandshakeFD is the fd number recorded by captureHandshakeFD,
-// or -1 when this process has no handshake parent. Consumed (and
-// reset) by the single handshakeAck call.
-var capturedHandshakeFD = -1
+// or -1 when this process has no handshake parent. The deadline is captured
+// at the same time so both internal variables are gone before a target forks.
+var (
+	capturedHandshakeFD       = -1
+	capturedHandshakeGateFD   = -1
+	capturedHandshakeHoldFD   = -1
+	capturedHandshakeDeadline time.Time
+	capturedHandshakeInvalid  bool
+)
 
-// captureHandshakeFD reads GMUX_HANDSHAKE_FD, validates it, records
-// the fd for the eventual handshakeAck, and ALWAYS unsets the env var
-// so no child of this process can inherit it. Must be called at the
-// top of main(), before anything can fork.
+// captureHandshakeFD reads GMUX_HANDSHAKE_FD and the two companion fds,
+// validates all three and ALWAYS unsets the env vars so no child of this
+// process can inherit them. Must be called at the top of main(), before
+// anything can fork.
 //
-// Validation is deliberately paranoid: besides the numeric/range
-// checks, the fd must actually be a pipe. This guards the rolling-
-// upgrade window where an old runner (which leaked the env var to its
-// session) is still alive: a nested gmux would otherwise ack against
-// whatever its own fd 3 happens to be, and closing an arbitrary fd
-// (e.g. the runtime's epoll fd) is fatal.
+// Validation is deliberately paranoid:
+//
+//   - All three fds must be genuine pipes (Fstat → S_IFIFO); accepting a
+//     socket or file fd as gate/hold would silently duplicate it into the
+//     target wrapper via ExtraFiles and close it in the runner afterward,
+//     corrupting an unrelated live fd.
+//   - All three must be distinct; aliasing creates multiple *os.File
+//     finalizers on one raw fd, which is the aliasing footgun documented
+//     in the comment above.
+//   - Access directions are verified via F_GETFL (POSIX, portable to both
+//     Linux and Darwin): control must be a write-end, gate and hold must
+//     be read-ends. This rejects swapped-endpoint misconfigurations before
+//     any fd is recorded, wrapped, or exec'd into a subprocess.
+//
+// If gate or hold validation fails but the control fd is a valid pipe, the
+// control fd is recorded so handshakeAck can send an EOF-producing failure
+// ack to the parent immediately rather than waiting for process exit.
 func captureHandshakeFD() {
-	defer func() { _ = os.Unsetenv(handshakeFDEnv) }()
+	defer func() {
+		_ = os.Unsetenv(handshakeFDEnv)
+		_ = os.Unsetenv(handshakeGateFDEnv)
+		_ = os.Unsetenv(handshakeHoldFDEnv)
+		_ = os.Unsetenv(handshakeDeadlineEnv)
+	}()
 	fdStr := os.Getenv(handshakeFDEnv)
 	if fdStr == "" {
 		return
 	}
-	fd, err := strconv.Atoi(fdStr)
-	if err != nil || fd < 3 {
+
+	// Validate the control fd as a writable FIFO before recording anything.
+	controlFD, err := strconv.Atoi(fdStr)
+	if err != nil || controlFD < 3 {
 		return
 	}
+	if !isFIFO(controlFD) {
+		return
+	}
+
+	// Record the control fd and protect it now: if gate/hold validation
+	// fails below we can still send a prompt failure ack via handshakeAck.
+	capturedHandshakeFD = controlFD
+	// O_CLOEXEC: exec'd processes (e.g. autostarted gmuxd) must not inherit
+	// this fd. exec.Cmd ExtraFiles re-dups with dup2 in the child regardless,
+	// so the intended target-wrapper handoff is unaffected.
+	syscall.CloseOnExec(controlFD)
+
+	// Parse gate and hold WITHOUT recording or touching them yet.
+	gateFD, gateErr := strconv.Atoi(os.Getenv(handshakeGateFDEnv))
+	holdFD, holdErr := strconv.Atoi(os.Getenv(handshakeHoldFDEnv))
+	if gateErr != nil || gateFD < 3 || holdErr != nil || holdFD < 3 {
+		capturedHandshakeInvalid = true
+		return
+	}
+
+	// Require all three fds to be distinct. Aliasing means multiple owning
+	// *os.File finalizers on one raw fd and can silently close an unrelated
+	// live fd when either wrapper is garbage-collected.
+	if controlFD == gateFD || controlFD == holdFD || gateFD == holdFD {
+		capturedHandshakeInvalid = true
+		return
+	}
+
+	// Validate gate and hold as readable FIFOs. Do NOT call CloseOnExec or
+	// record them before this check: calling CloseOnExec on an arbitrary live
+	// fd (e.g. a socket) would silently modify its FD flags.
+	if !isFIFO(gateFD) || !isFIFO(holdFD) {
+		capturedHandshakeInvalid = true
+		return
+	}
+
+	// Validate access directions. control must be a write-end; gate and hold
+	// must be read-ends. Mismatches (e.g. swapped endpoints) are rejected
+	// here before any fd is recorded, wrapped, or passed to a subprocess.
+	if !isPipeWriteEnd(controlFD) || !isPipeReadEnd(gateFD) || !isPipeReadEnd(holdFD) {
+		capturedHandshakeInvalid = true
+		return
+	}
+
+	// All topology checks passed: record and protect the remaining fds.
+	capturedHandshakeGateFD = gateFD
+	capturedHandshakeHoldFD = holdFD
+	syscall.CloseOnExec(gateFD)
+	syscall.CloseOnExec(holdFD)
+
+	nanos, err := strconv.ParseInt(os.Getenv(handshakeDeadlineEnv), 10, 64)
+	if err != nil || nanos <= 0 {
+		capturedHandshakeInvalid = true
+		return
+	}
+	capturedHandshakeDeadline = time.Unix(0, nanos)
+	capturedHandshakeInvalid = !capturedHandshakeDeadline.After(time.Now())
+}
+
+// isFIFO reports whether fd is an open anonymous or named pipe.
+func isFIFO(fd int) bool {
 	var st syscall.Stat_t
-	if syscall.Fstat(fd, &st) != nil || st.Mode&syscall.S_IFMT != syscall.S_IFIFO {
-		return
+	return syscall.Fstat(fd, &st) == nil && st.Mode&syscall.S_IFMT == syscall.S_IFIFO
+}
+
+// isPipeReadEnd reports whether fd is the read end of a pipe (O_RDONLY or
+// O_RDWR). Uses F_GETFL which is POSIX and portable to Linux and Darwin.
+func isPipeReadEnd(fd int) bool {
+	flags, _, errno := syscall.Syscall(syscall.SYS_FCNTL, uintptr(fd), syscall.F_GETFL, 0)
+	if errno != 0 {
+		return false
 	}
-	capturedHandshakeFD = fd
+	acc := flags & 3 // O_ACCMODE mask; O_RDONLY=0, O_WRONLY=1, O_RDWR=2
+	return acc == syscall.O_RDONLY || acc == syscall.O_RDWR
+}
+
+// isPipeWriteEnd reports whether fd is the write end of a pipe (O_WRONLY or
+// O_RDWR).
+func isPipeWriteEnd(fd int) bool {
+	flags, _, errno := syscall.Syscall(syscall.SYS_FCNTL, uintptr(fd), syscall.F_GETFL, 0)
+	if errno != 0 {
+		return false
+	}
+	acc := flags & 3
+	return acc == syscall.O_WRONLY || acc == syscall.O_RDWR
+}
+
+func handshakeContext() (context.Context, context.CancelFunc, bool) {
+	if capturedHandshakeFD < 0 {
+		ctx, cancel := context.WithCancel(context.Background())
+		return ctx, cancel, false
+	}
+	if capturedHandshakeInvalid || capturedHandshakeDeadline.IsZero() {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		return ctx, func() {}, true
+	}
+	ctx, cancel := context.WithDeadline(context.Background(), capturedHandshakeDeadline)
+	return ctx, cancel, true
 }
 
 // handshakeAck signals registration outcome to the parent process via
@@ -107,6 +247,24 @@ func handshakeAckFD(f *os.File, sessionID string, registered bool) {
 	}
 }
 
+// waitForHandshakeRelease drains the hold pipe until the parent closes its
+// write end, then returns. The runner calls this at the very end of runSession
+// (after deregister) so the parent can synchronise its target-group cleanup
+// with the runner's exit — avoidng a race where the runner process table entry
+// disappears before the parent has finished signalling the target group.
+func waitForHandshakeRelease() {
+	if capturedHandshakeHoldFD < 0 {
+		return
+	}
+	f := os.NewFile(uintptr(capturedHandshakeHoldFD), "gmux-handshake-hold")
+	capturedHandshakeHoldFD = -1
+	if f == nil {
+		return
+	}
+	_, _ = io.Copy(io.Discard, f)
+	_ = f.Close()
+}
+
 // readHandshake blocks on r until the child writes its session id
 // followed by a newline (success), closes its end without writing
 // (failure → io.EOF), or the deadline fires
@@ -117,8 +275,8 @@ func handshakeAckFD(f *os.File, sessionID string, registered bool) {
 // Any read error is treated as failure, even if partial bytes
 // arrived. This protects against a script consuming a half-written
 // id from a child that crashed mid-write.
-func readHandshake(r *os.File, timeout time.Duration) (string, error) {
-	if err := r.SetReadDeadline(time.Now().Add(timeout)); err != nil {
+func readHandshake(r *os.File, deadline time.Time) (string, error) {
+	if err := r.SetReadDeadline(deadline); err != nil {
 		return "", err
 	}
 	line, err := bufio.NewReader(r).ReadString('\n')

--- a/cli/gmux/cmd/gmux/handshake_test.go
+++ b/cli/gmux/cmd/gmux/handshake_test.go
@@ -1,11 +1,15 @@
 package main
 
 import (
+	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
 	"strconv"
+	"strings"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -79,7 +83,17 @@ func TestHandshakeAckFD_ClosesFDOnSuccess(t *testing.T) {
 func resetCapture(t *testing.T) {
 	t.Helper()
 	capturedHandshakeFD = -1
-	t.Cleanup(func() { capturedHandshakeFD = -1 })
+	capturedHandshakeGateFD = -1
+	capturedHandshakeHoldFD = -1
+	capturedHandshakeDeadline = time.Time{}
+	capturedHandshakeInvalid = false
+	t.Cleanup(func() {
+		capturedHandshakeFD = -1
+		capturedHandshakeGateFD = -1
+		capturedHandshakeHoldFD = -1
+		capturedHandshakeDeadline = time.Time{}
+		capturedHandshakeInvalid = false
+	})
 }
 
 func TestCaptureHandshakeFD_NoopWhenEnvUnset(t *testing.T) {
@@ -190,7 +204,7 @@ func TestReadHandshake_RoundTripWithHandshakeAckFD(t *testing.T) {
 	r, w := pipePair(t)
 	go handshakeAckFD(w, "sess-xyz", true)
 
-	id, err := readHandshake(r, 2*time.Second)
+	id, err := readHandshake(r, time.Now().Add(2*time.Second))
 	if err != nil {
 		t.Fatalf("readHandshake: %v", err)
 	}
@@ -203,7 +217,7 @@ func TestReadHandshake_ChildFailedReturnsEOF(t *testing.T) {
 	r, w := pipePair(t)
 	handshakeAckFD(w, "ignored", false) // close-without-write
 
-	_, err := readHandshake(r, 2*time.Second)
+	_, err := readHandshake(r, time.Now().Add(2*time.Second))
 	if !errors.Is(err, io.EOF) {
 		t.Fatalf("err: got %v, want io.EOF", err)
 	}
@@ -213,7 +227,7 @@ func TestReadHandshake_TimeoutWhenChildHangs(t *testing.T) {
 	r, _ := pipePair(t) // w held open by cleanup, never written to
 
 	start := time.Now()
-	_, err := readHandshake(r, 50*time.Millisecond)
+	_, err := readHandshake(r, time.Now().Add(50*time.Millisecond))
 	elapsed := time.Since(start)
 	if !errors.Is(err, os.ErrDeadlineExceeded) {
 		t.Fatalf("err: got %v, want os.ErrDeadlineExceeded", err)
@@ -230,7 +244,7 @@ func TestReadHandshake_EmptyLineRejected(t *testing.T) {
 		_ = w.Close()
 	}()
 
-	_, err := readHandshake(r, 2*time.Second)
+	_, err := readHandshake(r, time.Now().Add(2*time.Second))
 	if err == nil {
 		t.Fatalf("expected error for empty id, got nil")
 	}
@@ -248,7 +262,7 @@ func TestReadHandshake_PartialWriteRejected(t *testing.T) {
 		_ = w.Close()
 	}()
 
-	_, err := readHandshake(r, 2*time.Second)
+	_, err := readHandshake(r, time.Now().Add(2*time.Second))
 	if err == nil {
 		t.Fatalf("expected error for partial write, got nil")
 	}
@@ -304,7 +318,7 @@ func TestPipeHandshakeRoundTripViaSubprocess(t *testing.T) {
 		t.Fatalf("close parent write end: %v", err)
 	}
 
-	id, readErr := readHandshake(r, 5*time.Second)
+	id, readErr := readHandshake(r, time.Now().Add(5*time.Second))
 	if waitErr := cmd.Wait(); waitErr != nil {
 		t.Fatalf("child exited non-zero: %v", waitErr)
 	}
@@ -313,5 +327,463 @@ func TestPipeHandshakeRoundTripViaSubprocess(t *testing.T) {
 	}
 	if id != expectedID {
 		t.Fatalf("id: got %q, want %q", id, expectedID)
+	}
+}
+
+// ── F1: CloseOnExec regression ──
+
+// TestCaptureHandshakeFD_SetsCloseOnExec verifies that captureHandshakeFD
+// sets O_CLOEXEC on all three captured fds. The test first clears CLOEXEC to
+// mirror what happens when the runner receives the fds via exec.Cmd.ExtraFiles
+// (dup2 in the child clears CLOEXEC on the new fd).
+func TestCaptureHandshakeFD_SetsCloseOnExec(t *testing.T) {
+	resetCapture(t)
+	_, control := pipePair(t) // handshake write end
+	gateR, _ := pipePair(t)  // gate read end
+	holdR, _ := pipePair(t)  // hold read end
+
+	// Clear CLOEXEC to simulate receiving via ExtraFiles (dup2 clears it).
+	for _, fd := range []uintptr{control.Fd(), gateR.Fd(), holdR.Fd()} {
+		if _, _, errno := syscall.Syscall(syscall.SYS_FCNTL, fd, syscall.F_SETFD, 0); errno != 0 {
+			t.Fatalf("F_SETFD clear: %v", errno)
+		}
+	}
+
+	deadline := time.Now().Add(time.Second).Truncate(time.Nanosecond)
+	t.Setenv(handshakeFDEnv, strconv.Itoa(int(control.Fd())))
+	t.Setenv(handshakeGateFDEnv, strconv.Itoa(int(gateR.Fd())))
+	t.Setenv(handshakeHoldFDEnv, strconv.Itoa(int(holdR.Fd())))
+	t.Setenv(handshakeDeadlineEnv, strconv.FormatInt(deadline.UnixNano(), 10))
+	captureHandshakeFD()
+
+	if capturedHandshakeFD < 0 || capturedHandshakeGateFD < 0 || capturedHandshakeHoldFD < 0 {
+		t.Fatalf("capture failed: control=%d gate=%d hold=%d",
+			capturedHandshakeFD, capturedHandshakeGateFD, capturedHandshakeHoldFD)
+	}
+	for _, tc := range []struct {
+		name string
+		fd   int
+	}{
+		{"control", capturedHandshakeFD},
+		{"gate", capturedHandshakeGateFD},
+		{"hold", capturedHandshakeHoldFD},
+	} {
+		flags, _, errno := syscall.Syscall(syscall.SYS_FCNTL, uintptr(tc.fd), syscall.F_GETFD, 0)
+		if errno != 0 {
+			t.Errorf("%s fd %d: F_GETFD: %v", tc.name, tc.fd, errno)
+			continue
+		}
+		if flags&syscall.FD_CLOEXEC == 0 {
+			t.Errorf("%s fd %d: O_CLOEXEC not set (F_GETFD flags=%#x)", tc.name, tc.fd, flags)
+		}
+	}
+}
+
+// TestCaptureHandshakeFD_ExecDoesNotLeakFDs is the production-seam exec
+// regression for F1. It simulates the runner receiving the three handshake
+// fds via exec.Cmd.ExtraFiles (dup2, no CLOEXEC in child), calling
+// captureHandshakeFD (which must set CLOEXEC on all three), and then
+// exec'ing a grandchild process without ExtraFiles — simulating startGmuxd.
+// The grandchild must not see any of the three handshake fds as open pipes.
+func TestCaptureHandshakeFD_ExecDoesNotLeakFDs(t *testing.T) {
+	const roleEnv = "GMUX_FDLEAK_ROLE"
+	switch os.Getenv(roleEnv) {
+	case "runner":
+		// Simulate the runner: fds 3/4/5 arrived via ExtraFiles without
+		// CLOEXEC. captureHandshakeFD must set it before any exec.
+		captureHandshakeFD()
+		cmd := exec.Command(os.Args[0], "-test.run=^TestCaptureHandshakeFD_ExecDoesNotLeakFDs$")
+		cmd.Env = append(os.Environ(), roleEnv+"=grandchild")
+		var stderr bytes.Buffer
+		cmd.Stderr = &stderr
+		if err := cmd.Run(); err != nil {
+			fmt.Fprintf(os.Stderr, "grandchild: %s", stderr.String())
+			os.Exit(1)
+		}
+		os.Exit(0)
+	case "grandchild":
+		// Check that none of fds 3, 4, 5 are open pipes (pipes are the only
+		// type that handshake fds can be; Go runtime internal fds are not).
+		var leaked []string
+		for _, fd := range []int{3, 4, 5} {
+			var st syscall.Stat_t
+			if err := syscall.Fstat(fd, &st); err == nil {
+				if st.Mode&syscall.S_IFMT == syscall.S_IFIFO {
+					leaked = append(leaked, strconv.Itoa(fd))
+				}
+			}
+		}
+		if len(leaked) > 0 {
+			fmt.Fprintln(os.Stderr, "leaked pipe fds: "+strings.Join(leaked, ","))
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
+
+	// Test body: create the three handshake pipes and spawn the runner via
+	// ExtraFiles, mirroring spawnDetached's setup.
+	// fd 3 = handshakeW (control write end), fd 4 = gateR (gate read end),
+	// fd 5 = holdR (hold read end) — matching the protocol direction contract.
+	handshakeR, handshakeW, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer handshakeR.Close()
+	gateR, gateW, err := os.Pipe() // gateR = read end → fd 4 in child
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer gateR.Close()
+	defer gateW.Close()
+	holdR, holdW, err := os.Pipe() // holdR = read end → fd 5 in child
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer holdR.Close()
+	defer holdW.Close()
+
+	deadline := time.Now().Add(time.Second)
+	cmd := exec.Command(os.Args[0], "-test.run=^TestCaptureHandshakeFD_ExecDoesNotLeakFDs$")
+	cmd.ExtraFiles = []*os.File{handshakeW, gateR, holdR} // fd 3=control write, 4=gate read, 5=hold read
+	cmd.Env = append(os.Environ(),
+		roleEnv+"=runner",
+		handshakeFDEnv+"=3",
+		handshakeGateFDEnv+"=4",
+		handshakeHoldFDEnv+"=5",
+		handshakeDeadlineEnv+"="+strconv.FormatInt(deadline.UnixNano(), 10),
+	)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	// Close parent's copies so the only references are via the child's ExtraFiles.
+	_ = handshakeW.Close()
+	_ = gateR.Close()
+	_ = holdR.Close()
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("fd leak detected: %s", stderr.String())
+	}
+}
+
+// ── Topology validation: non-FIFO / alias / swapped-direction ──
+
+// fdFlagsGet returns the F_GETFD flags for fd, or -1 on error.
+func fdFlagsGet(fd uintptr) int {
+	flags, _, errno := syscall.Syscall(syscall.SYS_FCNTL, fd, syscall.F_GETFD, 0)
+	if errno != 0 {
+		return -1
+	}
+	return int(flags)
+}
+
+// TestCaptureHandshakeFD_ValidatesGateAsReadableFIFO verifies that a
+// non-FIFO fd passed as the gate is rejected without touching the fd:
+// CloseOnExec is not called on it, capturedHandshakeGateFD is never set,
+// and the fd remains open and undamaged after captureHandshakeFD returns.
+func TestCaptureHandshakeFD_ValidatesGateAsReadableFIFO(t *testing.T) {
+	resetCapture(t)
+	_, control := pipePair(t)  // write end → control
+	holdR, _ := pipePair(t)   // read end → hold
+
+	nonPipe, err := os.Open(os.DevNull) // char device, not a FIFO
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer nonPipe.Close()
+
+	flagsBefore := fdFlagsGet(nonPipe.Fd())
+
+	deadline := time.Now().Add(time.Second)
+	t.Setenv(handshakeFDEnv, strconv.Itoa(int(control.Fd())))
+	t.Setenv(handshakeGateFDEnv, strconv.Itoa(int(nonPipe.Fd())))
+	t.Setenv(handshakeHoldFDEnv, strconv.Itoa(int(holdR.Fd())))
+	t.Setenv(handshakeDeadlineEnv, strconv.FormatInt(deadline.UnixNano(), 10))
+	captureHandshakeFD()
+
+	// Control fd is captured so a failure ack can reach the parent promptly.
+	if capturedHandshakeFD < 0 {
+		t.Error("control fd not captured (needed for prompt failure ack)")
+	}
+	// Gate fd must NOT be recorded or touched.
+	if !capturedHandshakeInvalid {
+		t.Error("handshake not marked invalid for non-FIFO gate")
+	}
+	if capturedHandshakeGateFD >= 0 {
+		t.Errorf("capturedHandshakeGateFD=%d recorded for non-FIFO gate", capturedHandshakeGateFD)
+	}
+	// The non-pipe fd must be undamaged: still open and FD flags unchanged
+	// (CloseOnExec must not have been called on an unverified fd).
+	if _, err := nonPipe.Stat(); err != nil {
+		t.Errorf("non-FIFO gate fd was damaged (Stat failed): %v", err)
+	}
+	if got := fdFlagsGet(nonPipe.Fd()); got != flagsBefore {
+		t.Errorf("non-FIFO gate FD flags changed: before=%#x after=%#x", flagsBefore, got)
+	}
+}
+
+// TestCaptureHandshakeFD_ValidatesHoldAsReadableFIFO mirrors the gate test
+// for the hold fd.
+func TestCaptureHandshakeFD_ValidatesHoldAsReadableFIFO(t *testing.T) {
+	resetCapture(t)
+	_, control := pipePair(t) // write end → control
+	gateR, _ := pipePair(t)  // read end → gate
+
+	nonPipe, err := os.Open(os.DevNull)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer nonPipe.Close()
+
+	flagsBefore := fdFlagsGet(nonPipe.Fd())
+
+	deadline := time.Now().Add(time.Second)
+	t.Setenv(handshakeFDEnv, strconv.Itoa(int(control.Fd())))
+	t.Setenv(handshakeGateFDEnv, strconv.Itoa(int(gateR.Fd())))
+	t.Setenv(handshakeHoldFDEnv, strconv.Itoa(int(nonPipe.Fd())))
+	t.Setenv(handshakeDeadlineEnv, strconv.FormatInt(deadline.UnixNano(), 10))
+	captureHandshakeFD()
+
+	if capturedHandshakeFD < 0 {
+		t.Error("control fd not captured (needed for prompt failure ack)")
+	}
+	if !capturedHandshakeInvalid {
+		t.Error("handshake not marked invalid for non-FIFO hold")
+	}
+	if capturedHandshakeHoldFD >= 0 {
+		t.Errorf("capturedHandshakeHoldFD=%d recorded for non-FIFO hold", capturedHandshakeHoldFD)
+	}
+	if _, err := nonPipe.Stat(); err != nil {
+		t.Errorf("non-FIFO hold fd damaged (Stat failed): %v", err)
+	}
+	if got := fdFlagsGet(nonPipe.Fd()); got != flagsBefore {
+		t.Errorf("non-FIFO hold FD flags changed: before=%#x after=%#x", flagsBefore, got)
+	}
+}
+
+// TestCaptureHandshakeFD_RequiresDistinctFDs verifies all three alias pairs:
+// gate==control, gate==hold, control==hold. Every pair must be rejected.
+func TestCaptureHandshakeFD_RequiresDistinctFDs(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		aliasFDEnv   string // the env var to set to the same fd as another
+		aliasWith    string // which env var to alias with ("control", "gate", "hold")
+	}{
+		{"gate==control", handshakeGateFDEnv, "control"},
+		{"hold==control", handshakeHoldFDEnv, "control"},
+		{"gate==hold", handshakeGateFDEnv, "hold"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			resetCapture(t)
+			_, control := pipePair(t)  // write end → control
+			gateR, _ := pipePair(t)   // read end → gate
+			holdR, _ := pipePair(t)   // read end → hold
+
+			aliasTarget := func(which string) *os.File {
+				switch which {
+				case "control":
+					return control
+				case "gate":
+					return gateR
+				default:
+					return holdR
+				}
+			}
+
+			t.Setenv(handshakeFDEnv, strconv.Itoa(int(control.Fd())))
+			t.Setenv(handshakeGateFDEnv, strconv.Itoa(int(gateR.Fd())))
+			t.Setenv(handshakeHoldFDEnv, strconv.Itoa(int(holdR.Fd())))
+			// Override the aliased fd to match its pair.
+			t.Setenv(tc.aliasFDEnv, strconv.Itoa(int(aliasTarget(tc.aliasWith).Fd())))
+			t.Setenv(handshakeDeadlineEnv, strconv.FormatInt(time.Now().Add(time.Second).UnixNano(), 10))
+			captureHandshakeFD()
+
+			if capturedHandshakeFD < 0 {
+				t.Error("control fd not captured (needed for prompt failure ack)")
+			}
+			if !capturedHandshakeInvalid {
+				t.Errorf("handshake not marked invalid for %s alias", tc.name)
+			}
+			if capturedHandshakeGateFD >= 0 {
+				t.Errorf("capturedHandshakeGateFD=%d despite %s alias", capturedHandshakeGateFD, tc.name)
+			}
+		})
+	}
+}
+
+// TestCaptureHandshakeFD_ValidatesGateDirection verifies that passing the
+// write end (instead of read end) as the gate fd is rejected, and that the
+// write-end pipe fd is left undamaged (no CloseOnExec, still open).
+func TestCaptureHandshakeFD_ValidatesGateDirection(t *testing.T) {
+	resetCapture(t)
+	_, control := pipePair(t) // write end → control (correct)
+	_, gateW := pipePair(t)  // write end → gate (WRONG: should be read end)
+	holdR, _ := pipePair(t)  // read end → hold (correct)
+
+	flagsBefore := fdFlagsGet(gateW.Fd())
+
+	deadline := time.Now().Add(time.Second)
+	t.Setenv(handshakeFDEnv, strconv.Itoa(int(control.Fd())))
+	t.Setenv(handshakeGateFDEnv, strconv.Itoa(int(gateW.Fd())))
+	t.Setenv(handshakeHoldFDEnv, strconv.Itoa(int(holdR.Fd())))
+	t.Setenv(handshakeDeadlineEnv, strconv.FormatInt(deadline.UnixNano(), 10))
+	captureHandshakeFD()
+
+	if !capturedHandshakeInvalid {
+		t.Error("handshake not marked invalid for write-end gate")
+	}
+	if capturedHandshakeGateFD >= 0 {
+		t.Errorf("capturedHandshakeGateFD=%d despite wrong direction", capturedHandshakeGateFD)
+	}
+	// The write-end fd must be undamaged.
+	if _, err := gateW.Stat(); err != nil {
+		t.Errorf("write-end gate fd damaged: %v", err)
+	}
+	if got := fdFlagsGet(gateW.Fd()); got != flagsBefore {
+		t.Errorf("write-end gate FD flags changed: before=%#x after=%#x", flagsBefore, got)
+	}
+}
+
+// TestCaptureHandshakeFD_ValidatesControlDirection verifies that passing the
+// read end (instead of write end) as the control fd is caught: the handshake
+// is marked invalid and gate/hold are not recorded.
+func TestCaptureHandshakeFD_ValidatesControlDirection(t *testing.T) {
+	resetCapture(t)
+	controlR, _ := pipePair(t) // read end → control (WRONG: should be write end)
+	gateR, _ := pipePair(t)   // read end → gate (correct)
+	holdR, _ := pipePair(t)   // read end → hold (correct)
+
+	deadline := time.Now().Add(time.Second)
+	t.Setenv(handshakeFDEnv, strconv.Itoa(int(controlR.Fd())))
+	t.Setenv(handshakeGateFDEnv, strconv.Itoa(int(gateR.Fd())))
+	t.Setenv(handshakeHoldFDEnv, strconv.Itoa(int(holdR.Fd())))
+	t.Setenv(handshakeDeadlineEnv, strconv.FormatInt(deadline.UnixNano(), 10))
+	captureHandshakeFD()
+
+	// The control fd IS a FIFO so capturedHandshakeFD is set (allowing a
+	// failure ack). The direction check must still mark the handshake invalid
+	// and leave gate/hold unrecorded.
+	if !capturedHandshakeInvalid {
+		t.Error("handshake not marked invalid for read-end control")
+	}
+	if capturedHandshakeGateFD >= 0 {
+		t.Errorf("capturedHandshakeGateFD=%d recorded despite invalid control direction", capturedHandshakeGateFD)
+	}
+	if capturedHandshakeHoldFD >= 0 {
+		t.Errorf("capturedHandshakeHoldFD=%d recorded despite invalid control direction", capturedHandshakeHoldFD)
+	}
+}
+
+// TestCaptureHandshakeFD_ValidatesHoldDirection verifies that passing the
+// write end (instead of read end) as the hold fd is rejected without touching
+// the write-end fd (no CloseOnExec, still open).
+func TestCaptureHandshakeFD_ValidatesHoldDirection(t *testing.T) {
+	resetCapture(t)
+	_, control := pipePair(t)  // write end → control (correct)
+	gateR, _ := pipePair(t)   // read end → gate (correct)
+	_, holdW := pipePair(t)   // write end → hold (WRONG: should be read end)
+
+	flagsBefore := fdFlagsGet(holdW.Fd())
+
+	deadline := time.Now().Add(time.Second)
+	t.Setenv(handshakeFDEnv, strconv.Itoa(int(control.Fd())))
+	t.Setenv(handshakeGateFDEnv, strconv.Itoa(int(gateR.Fd())))
+	t.Setenv(handshakeHoldFDEnv, strconv.Itoa(int(holdW.Fd())))
+	t.Setenv(handshakeDeadlineEnv, strconv.FormatInt(deadline.UnixNano(), 10))
+	captureHandshakeFD()
+
+	if !capturedHandshakeInvalid {
+		t.Error("handshake not marked invalid for write-end hold")
+	}
+	if capturedHandshakeHoldFD >= 0 {
+		t.Errorf("capturedHandshakeHoldFD=%d despite wrong direction", capturedHandshakeHoldFD)
+	}
+	// The write-end hold fd must be undamaged.
+	if _, err := holdW.Stat(); err != nil {
+		t.Errorf("write-end hold fd damaged: %v", err)
+	}
+	if got := fdFlagsGet(holdW.Fd()); got != flagsBefore {
+		t.Errorf("write-end hold FD flags changed: before=%#x after=%#x", flagsBefore, got)
+	}
+}
+
+// TestMalformedGateHandshakeSendsPromptFailure is a production-seam subprocess
+// test proving that a runner with a non-FIFO gate fd sends the failure ack
+// promptly (not at the 30 s deadline) and never issues the gate token, so no
+// user command can be exec'd.
+func TestMalformedGateHandshakeSendsPromptFailure(t *testing.T) {
+	const roleEnv = "GMUX_MALFGATE_ROLE"
+	switch os.Getenv(roleEnv) {
+	case "runner":
+		// Simulate the runner: fds 3/4/5 arrive via ExtraFiles.
+		// fd 4 is a tempfile (non-FIFO), so captureHandshakeFD marks invalid.
+		captureHandshakeFD()
+		// handshakeAck closes capturedHandshakeFD (fd 3 = control write end),
+		// letting the parent read EOF on its handshakeRead — prompt failure.
+		handshakeAck("", false)
+		os.Exit(0)
+	}
+
+	// Parent side: create the three pipes and one tempfile for the bogus gate.
+	handshakeR, handshakeW, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer handshakeR.Close()
+	gateR, gateW, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer gateR.Close()
+	defer gateW.Close()
+	holdR, holdW, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer holdR.Close()
+	defer holdW.Close()
+
+	// Use a regular file instead of a pipe as the gate fd — not a FIFO.
+	bogusGate, err := os.CreateTemp(t.TempDir(), "bogus-gate")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer bogusGate.Close()
+
+	deadline := time.Now().Add(2 * time.Second)
+	cmd := exec.Command(os.Args[0], "-test.run=^TestMalformedGateHandshakeSendsPromptFailure$")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	cmd.ExtraFiles = []*os.File{handshakeW, bogusGate, holdR} // fd 3=control, 4=bogusGate, 5=hold
+	cmd.Env = append(os.Environ(),
+		roleEnv+"=runner",
+		handshakeFDEnv+"=3",
+		handshakeGateFDEnv+"=4",
+		handshakeHoldFDEnv+"=5",
+		handshakeDeadlineEnv+"="+strconv.FormatInt(deadline.UnixNano(), 10),
+	)
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	// Close parent's ExtraFiles copies after the child is forked.
+	_ = handshakeW.Close()
+	_ = bogusGate.Close()
+	_ = holdR.Close()
+
+	_, err = awaitDetachedHandshake(cmd, handshakeR, gateW, holdW, deadline, 200*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected error for malformed gate fd")
+	}
+	// The failure ack (EOF on handshakeR) must arrive promptly — not at the
+	// 2 s deadline — proving the runner detected the invalid gate and sent
+	// the ack immediately instead of proceeding with the handshake.
+	if errors.Is(err, os.ErrDeadlineExceeded) {
+		t.Fatalf("malformed gate caused deadline timeout instead of prompt failure ack: %v", err)
+	}
+	// The gate must not have received the 'G' token: awaitDetachedHandshake
+	// closed gateW without writing on failure, so gateR sees only EOF.
+	gateR.SetReadDeadline(time.Now().Add(50 * time.Millisecond))
+	var tok [1]byte
+	if n, _ := gateR.Read(tok[:]); n > 0 {
+		t.Errorf("gate received unexpected byte %q — no user command should start", tok[:n])
 	}
 }

--- a/cli/gmux/cmd/gmux/main.go
+++ b/cli/gmux/cmd/gmux/main.go
@@ -14,6 +14,9 @@ import (
 var version = "dev"
 
 func main() {
+	if len(os.Args) > 2 && os.Args[1] == "__detached-target" {
+		os.Exit(runDetachedTarget(os.Args[2:]))
+	}
 	log.SetPrefix("gmux: ")
 	log.SetFlags(0)
 

--- a/cli/gmux/cmd/gmux/register_test.go
+++ b/cli/gmux/cmd/gmux/register_test.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"context"
 	"net"
 	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 // startStubGmuxd binds a Unix socket at the path registerWithGmuxd
@@ -56,7 +58,9 @@ func TestRegisterWithGmuxdOutcomes(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			startStubGmuxd(t, tc.status)
-			got := registerWithGmuxd("sess-test", "/tmp/whatever.sock")
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+			defer cancel()
+			got := registerWithGmuxd(ctx, "sess-test", "/tmp/whatever.sock")
 			if got != tc.want {
 				t.Errorf("registerWithGmuxd outcome = %d, want %d", got, tc.want)
 			}
@@ -64,29 +68,42 @@ func TestRegisterWithGmuxdOutcomes(t *testing.T) {
 	}
 }
 
-// TestReapOnFatalRegistration pins the orphan-reap decision: only a
-// fatal (permanent) rejection of a headless runner tears the process
-// down. Transient failures must never reap (gmuxd may still be coming
-// up), and an interactive runner is spared even on a fatal verdict
-// because its local terminal is still attached.
-func TestReapOnFatalRegistration(t *testing.T) {
+// TestReapOnRegistrationFailure pins the reap decision for all three outcome ×
+// interactive × handshakeOwned combinations:
+//
+//   - Fatal (4xx) + headless always reaps (permanent daemon rejection).
+//   - Transient + headless + no handshake keeps serving (daemon may still start).
+//   - Any non-OK + headless + handshakeOwned reaps (parent is gate-blocked;
+//     waiting the full 30 s is worse than a prompt failure ack).
+//   - Interactive runners are always spared (local terminal is attached).
+func TestReapOnRegistrationFailure(t *testing.T) {
 	cases := []struct {
-		name        string
-		outcome     registerOutcome
-		interactive bool
-		want        bool
+		name           string
+		outcome        registerOutcome
+		interactive    bool
+		handshakeOwned bool
+		want           bool
 	}{
-		{"fatal_headless_reaps", registerFatal, false, true},
-		{"fatal_interactive_spared", registerFatal, true, false},
-		{"unavailable_headless_keeps_serving", registerUnavailable, false, false},
-		{"unavailable_interactive_keeps_serving", registerUnavailable, true, false},
-		{"ok_headless", registerOK, false, false},
-		{"ok_interactive", registerOK, true, false},
+		// Non-handshake paths (handshakeOwned=false)
+		{"fatal_headless_reaps", registerFatal, false, false, true},
+		{"fatal_interactive_spared", registerFatal, true, false, false},
+		{"unavailable_headless_keeps_serving", registerUnavailable, false, false, false},
+		{"unavailable_interactive_keeps_serving", registerUnavailable, true, false, false},
+		{"ok_headless_keeps", registerOK, false, false, false},
+		{"ok_interactive_keeps", registerOK, true, false, false},
+		// Handshake-owned paths (handshakeOwned=true): any non-OK reaps the
+		// headless runner so the parent's gate doesn't exhaust the full deadline.
+		{"handshake_owned_unavailable_headless_reaps", registerUnavailable, false, true, true},
+		{"handshake_owned_fatal_headless_reaps", registerFatal, false, true, true},
+		{"handshake_owned_ok_headless_keeps", registerOK, false, true, false},
+		{"handshake_owned_unavailable_interactive_spared", registerUnavailable, true, true, false},
+		{"handshake_owned_fatal_interactive_spared", registerFatal, true, true, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := reapOnFatalRegistration(tc.outcome, tc.interactive); got != tc.want {
-				t.Errorf("reapOnFatalRegistration(%d, %v) = %v, want %v", tc.outcome, tc.interactive, got, tc.want)
+			if got := reapOnRegistrationFailure(tc.outcome, tc.interactive, tc.handshakeOwned); got != tc.want {
+				t.Errorf("reapOnRegistrationFailure(outcome=%v, interactive=%v, owned=%v) = %v, want %v",
+					tc.outcome, tc.interactive, tc.handshakeOwned, got, tc.want)
 			}
 		})
 	}

--- a/cli/gmux/cmd/gmux/registration_budget_test.go
+++ b/cli/gmux/cmd/gmux/registration_budget_test.go
@@ -1,0 +1,328 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"strconv"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+func response(status int) *http.Response {
+	return &http.Response{StatusCode: status, Body: io.NopCloser(&emptyReader{})}
+}
+
+type emptyReader struct{}
+
+func (*emptyReader) Read([]byte) (int, error) { return 0, io.EOF }
+
+func TestRegistrationRetriesWithinDeadlineAndClassifiesStatuses(t *testing.T) {
+	var mu sync.Mutex
+	statuses := []int{http.StatusServiceUnavailable, http.StatusBadGateway, http.StatusOK}
+	calls := 0
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		i := calls
+		calls++
+		return response(statuses[i]), nil
+	})}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if got := registerWithClient(ctx, client, "s", "/tmp/s", time.Millisecond); got != registerOK {
+		t.Fatalf("outcome %v", got)
+	}
+	if calls != 3 {
+		t.Fatalf("calls = %d", calls)
+	}
+
+	for _, status := range []int{http.StatusBadRequest, http.StatusUnauthorized, http.StatusFound, http.StatusNoContent} {
+		calls = 0
+		client.Transport = roundTripFunc(func(*http.Request) (*http.Response, error) { calls++; return response(status), nil })
+		if got := registerWithClient(ctx, client, "s", "/tmp/s", time.Millisecond); got != registerFatal {
+			t.Errorf("status %d = %v", status, got)
+		}
+		if calls != 1 {
+			t.Errorf("status %d calls = %d", status, calls)
+		}
+	}
+}
+
+func TestRegistrationCancellationReachesRequestAndBackoff(t *testing.T) {
+	seenCanceled := make(chan struct{})
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		<-r.Context().Done()
+		close(seenCanceled)
+		return nil, r.Context().Err()
+	})}
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	if got := registerWithClient(ctx, client, "s", "/tmp/s", time.Second); got != registerUnavailable {
+		t.Fatalf("outcome %v", got)
+	}
+	select {
+	case <-seenCanceled:
+	default:
+		t.Fatal("transport did not observe cancellation")
+	}
+	if time.Since(start) > 250*time.Millisecond {
+		t.Fatal("request cancellation was not prompt")
+	}
+
+	client.Transport = roundTripFunc(func(*http.Request) (*http.Response, error) { return nil, errors.New("transient") })
+	ctx2, cancel2 := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	defer cancel2()
+	start = time.Now()
+	registerWithClient(ctx2, client, "s", "/tmp/s", time.Second)
+	if time.Since(start) > 250*time.Millisecond {
+		t.Fatal("backoff ignored cancellation")
+	}
+}
+
+func TestHandshakeDeadlineCaptureAndUnset(t *testing.T) {
+	resetCapture(t)
+	capturedHandshakeDeadline = time.Time{}
+	capturedHandshakeInvalid = false
+	_, w := pipePair(t)   // write end → control
+	gateR, _ := pipePair(t) // read end → gate (child reads gate token)
+	holdR, _ := pipePair(t) // read end → hold (child drains until parent closes)
+	deadline := time.Now().Add(time.Second).Truncate(time.Nanosecond)
+	t.Setenv(handshakeFDEnv, strconv.Itoa(int(w.Fd())))
+	t.Setenv(handshakeGateFDEnv, strconv.Itoa(int(gateR.Fd())))
+	t.Setenv(handshakeHoldFDEnv, strconv.Itoa(int(holdR.Fd())))
+	t.Setenv(handshakeDeadlineEnv, strconv.FormatInt(deadline.UnixNano(), 10))
+	captureHandshakeFD()
+	if !capturedHandshakeDeadline.Equal(deadline) || capturedHandshakeInvalid {
+		t.Fatalf("deadline = %v invalid=%v", capturedHandshakeDeadline, capturedHandshakeInvalid)
+	}
+	if os.Getenv(handshakeFDEnv) != "" || os.Getenv(handshakeDeadlineEnv) != "" {
+		t.Fatal("internal env leaked")
+	}
+	ctx, cancel, owned := handshakeContext()
+	defer cancel()
+	if !owned {
+		t.Fatal("handshake not owned")
+	}
+	if got, ok := ctx.Deadline(); !ok || !got.Equal(deadline) {
+		t.Fatalf("context deadline %v %v", got, ok)
+	}
+}
+
+func TestHandshakeMalformedAndExpiredDeadlineCancel(t *testing.T) {
+	for _, value := range []string{"bad", strconv.FormatInt(time.Now().Add(-time.Second).UnixNano(), 10)} {
+		t.Run(value, func(t *testing.T) {
+			resetCapture(t)
+			capturedHandshakeDeadline = time.Time{}
+			capturedHandshakeInvalid = false
+			_, w := pipePair(t)      // write end → control
+			gateR, _ := pipePair(t) // read end → gate
+			holdR, _ := pipePair(t) // read end → hold
+			t.Setenv(handshakeFDEnv, strconv.Itoa(int(w.Fd())))
+			t.Setenv(handshakeGateFDEnv, strconv.Itoa(int(gateR.Fd())))
+			t.Setenv(handshakeHoldFDEnv, strconv.Itoa(int(holdR.Fd())))
+			t.Setenv(handshakeDeadlineEnv, value)
+			captureHandshakeFD()
+			ctx, cancel, owned := handshakeContext()
+			defer cancel()
+			if !owned || ctx.Err() == nil {
+				t.Fatal("invalid deadline did not cancel owned launch")
+			}
+			if os.Getenv(handshakeDeadlineEnv) != "" {
+				t.Fatal("deadline env leaked")
+			}
+		})
+	}
+}
+
+func TestAwaitDetachedHandshakeOwnsProcessUntilResult(t *testing.T) {
+	if os.Getenv("GMUX_SUPERVISOR_HELPER") == "1" {
+		for {
+			time.Sleep(time.Second)
+		}
+	}
+	start := func() (*exec.Cmd, *os.File, *os.File) {
+		t.Helper()
+		r, w, _ := os.Pipe()
+		cmd := exec.Command(os.Args[0], "-test.run=^TestAwaitDetachedHandshakeOwnsProcessUntilResult$")
+		cmd.Env = append(os.Environ(), "GMUX_SUPERVISOR_HELPER=1")
+		cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+		if err := cmd.Start(); err != nil {
+			t.Fatal(err)
+		}
+		return cmd, r, w
+	}
+	t.Run("timeout terminates and reaps", func(t *testing.T) {
+		cmd, r, w := start()
+		defer r.Close()
+		defer w.Close()
+		_, gate := pipePair(t)
+		_, hold := pipePair(t)
+		_, err := awaitDetachedHandshake(cmd, r, gate, hold, time.Now().Add(30*time.Millisecond), 100*time.Millisecond)
+		if !errors.Is(err, os.ErrDeadlineExceeded) {
+			t.Fatalf("err %v", err)
+		}
+		if cmd.ProcessState == nil {
+			t.Fatal("child not reaped")
+		}
+		if err := syscall.Kill(cmd.Process.Pid, 0); !errors.Is(err, syscall.ESRCH) {
+			t.Fatalf("child still live: %v", err)
+		}
+	})
+	for _, tc := range []struct {
+		name  string
+		write string
+	}{
+		{"eof terminates and reaps", ""},
+		{"partial ack near deadline terminates and reaps", "sess-accepted"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd, r, w := start()
+			if tc.write != "" {
+				_, _ = io.WriteString(w, tc.write)
+			}
+			_ = w.Close()
+			_, gate := pipePair(t)
+			_, hold := pipePair(t)
+			_, err := awaitDetachedHandshake(cmd, r, gate, hold, time.Now().Add(30*time.Millisecond), 100*time.Millisecond)
+			_ = r.Close()
+			if err == nil || cmd.ProcessState == nil {
+				t.Fatalf("err=%v reaped=%v", err, cmd.ProcessState != nil)
+			}
+			if err := syscall.Kill(cmd.Process.Pid, 0); !errors.Is(err, syscall.ESRCH) {
+				t.Fatalf("child still live: %v", err)
+			}
+		})
+	}
+	t.Run("success releases", func(t *testing.T) {
+		cmd, r, w := start()
+		pid := cmd.Process.Pid
+		defer r.Close()
+		go func() { _, _ = io.WriteString(w, fmt.Sprintf("TARGET %d\nsess-ok\n", pid)); _ = w.Close() }()
+		_, gate := pipePair(t)
+		_, hold := pipePair(t)
+		id, err := awaitDetachedHandshake(cmd, r, gate, hold, time.Now().Add(time.Second), 100*time.Millisecond)
+		if err != nil || id != "sess-ok" {
+			t.Fatalf("id=%q err=%v", id, err)
+		}
+		if err := syscall.Kill(pid, 0); err != nil {
+			t.Fatalf("successful child not alive: %v", err)
+		}
+		if err := syscall.Kill(-pid, syscall.SIGKILL); err != nil {
+			t.Fatalf("cleanup: %v", err)
+		}
+		deadline := time.Now().Add(time.Second)
+		for time.Now().Before(deadline) {
+			if errors.Is(syscall.Kill(pid, 0), syscall.ESRCH) {
+				return
+			}
+			time.Sleep(time.Millisecond)
+		}
+		t.Fatal("success waiter did not reap fast exit")
+	})
+}
+
+// ── Drain-channel bounded wait (seam tests) ──
+
+// TestDrainErrorChanIsTimeBounded verifies that drainErrorChan returns within
+// the grace period even when the done channel never closes. This is the
+// deterministic seam test for the post-SIGKILL bounded-wait invariant:
+// a real process in uninterruptible kernel sleep can hold up SIGKILL
+// indefinitely, so the parent must not block forever.
+func TestDrainErrorChanIsTimeBounded(t *testing.T) {
+	done := make(chan error) // never closes
+	grace := 40 * time.Millisecond
+	start := time.Now()
+	drainErrorChan(done, grace)
+	if elapsed := time.Since(start); elapsed > grace*5 {
+		t.Errorf("drainErrorChan blocked %v, want ≤%v", elapsed, grace*5)
+	}
+}
+
+func TestDrainErrorChanReturnsFastWhenClosed(t *testing.T) {
+	done := make(chan error, 1)
+	done <- nil
+	// External-timeout approach: a goroutine runs the drain and closes
+	// returned when done. time.After provides the hard bound rather than
+	// a wall-clock elapsed check, which is robust to CI scheduler jitter
+	// while still catching a mutation that blocks on an unconditional receive.
+	returned := make(chan struct{})
+	go func() { drainErrorChan(done, time.Second); close(returned) }()
+	select {
+	case <-returned:
+	case <-time.After(250 * time.Millisecond):
+		t.Error("drainErrorChan did not return promptly with pre-closed channel (want <<250ms)")
+	}
+}
+
+func TestDrainStructChanIsTimeBounded(t *testing.T) {
+	done := make(chan struct{}) // never closes
+	grace := 40 * time.Millisecond
+	start := time.Now()
+	drainStructChan(done, grace)
+	if elapsed := time.Since(start); elapsed > grace*5 {
+		t.Errorf("drainStructChan blocked %v, want ≤%v", elapsed, grace*5)
+	}
+}
+
+func TestDrainStructChanReturnsFastWhenClosed(t *testing.T) {
+	done := make(chan struct{})
+	close(done)
+	returned := make(chan struct{})
+	go func() { drainStructChan(done, time.Second); close(returned) }()
+	select {
+	case <-returned:
+	case <-time.After(250 * time.Millisecond):
+		t.Error("drainStructChan did not return promptly with pre-closed channel (want <<250ms)")
+	}
+}
+
+// ── F2: foreground registration budget ──
+
+// TestForegroundRegistrationBudgetIsShorterThanDetached pins the deliberate
+// budget split: foreground/nested launches must use a shorter best-effort
+// window than explicit -d so a daemon-unavailable scenario doesn't produce
+// a visible 30 s hang at the shell.
+func TestForegroundRegistrationBudgetIsShorterThanDetached(t *testing.T) {
+	if foregroundRegistrationBudget >= detachedStartupBudget {
+		t.Fatalf("foregroundRegistrationBudget (%v) must be shorter than detachedStartupBudget (%v)",
+			foregroundRegistrationBudget, detachedStartupBudget)
+	}
+}
+
+// TestForegroundRegistrationCompletesQuicklyWhenDaemonUnavailable verifies
+// that registerWithGmuxd returns within foregroundRegistrationBudget when the
+// daemon socket does not exist. This is the no-daemon fast path that the
+// budget split makes user-visible: with the old 30 s budget, a foreground
+// `gmux -- true` would hang for 30 s; with the 3 s budget it exits promptly.
+func TestForegroundRegistrationCompletesQuicklyWhenDaemonUnavailable(t *testing.T) {
+	stateHome := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateHome) // no daemon socket under this dir
+
+	ctx, cancel := context.WithTimeout(context.Background(), foregroundRegistrationBudget)
+	defer cancel()
+	start := time.Now()
+	got := registerWithGmuxd(ctx, "sess-fg-budget-test", "/tmp/fg-budget-test.sock")
+	elapsed := time.Since(start)
+
+	if got != registerUnavailable {
+		t.Errorf("expected registerUnavailable with no daemon, got %v", got)
+	}
+	// Must finish within the documented budget plus one backoff tick (500 ms).
+	// The budget is 3 s; anything substantially over that would indicate the
+	// code reverted to the 30 s detachedStartupBudget.
+	if elapsed > foregroundRegistrationBudget+500*time.Millisecond {
+		t.Errorf("registration took %v, want ≤ %v (foregroundRegistrationBudget + 500ms slack)",
+			elapsed, foregroundRegistrationBudget+500*time.Millisecond)
+	}
+}

--- a/cli/gmux/cmd/gmux/run.go
+++ b/cli/gmux/cmd/gmux/run.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bufio"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -9,6 +11,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -25,12 +28,29 @@ import (
 	"github.com/gmuxapp/gmux/packages/workspace"
 )
 
-// handshakeTimeout bounds how long the parent end of spawnDetached
-// waits for the child to finish registering with gmuxd. The child's
-// registerWithGmuxd loops up to 5 times with 500ms backoff, so the
-// realistic worst case is ~2.5s plus child startup. 5s is a
-// comfortable ceiling: any longer and something is genuinely wrong.
-const handshakeTimeout = 5 * time.Second
+// detachedStartupBudget is the single end-to-end budget for explicit -d.
+// Its absolute deadline is handed to the child, so process startup, daemon
+// health/autostart, registration requests, backoff, and acknowledgement all
+// consume the same clock.
+const detachedStartupBudget = 30 * time.Second
+
+// foregroundRegistrationBudget is the best-effort registration window for
+// foreground and nested-gmux launches. These runners are not gate-blocked:
+// the user's command is already running and the local terminal is attached.
+// Registration is opportunistic — a short window avoids a visible hang at
+// the shell when gmuxd is unreachable, while still giving a healthy daemon
+// time to accept the POST. Explicit detach (-d) uses detachedStartupBudget
+// because its registration context is shared with the user command's start
+// gate and the parent waits for the full ack before printing the session id.
+const foregroundRegistrationBudget = 3 * time.Second
+
+// maxHandshakeFrameBytes caps each line read from the control pipe, preventing
+// a wedged writer from growing parent memory indefinitely.
+const maxHandshakeFrameBytes = 512
+
+const detachedCleanupGrace = 3 * time.Second
+
+const detachedTargetCleanupGrace = 2 * time.Second
 
 // ptyDrainTimeout bounds the wait for the PTY to fully flush after the
 // child exits. A well-behaved child has its PTY slave closed by the
@@ -63,25 +83,86 @@ type runDirectives struct {
 	ParentSessionID string
 }
 
-// reapOnFatalRegistration reports whether a runner should tear itself
-// down because registration with gmuxd failed permanently.
+// reapOnRegistrationFailure reports whether a runner should tear itself
+// down because registration with gmuxd failed in a way it cannot recover
+// from. Two distinct conditions qualify:
 //
-// Only the combination of a fatal (4xx) verdict and a headless runner
-// qualifies:
+//   - outcome == registerFatal: gmuxd understood the request and refused it
+//     permanently (4xx), e.g. its IsValidSessionID guard rejected the id.
+//     Retrying or waiting changes nothing.
+//   - handshakeOwned && outcome != registerOK: the runner is gate-blocking
+//     an explicit -d launch; any non-success outcome (including the transient
+//     registerUnavailable) means the parent will time out waiting for the
+//     ack. Tearing down immediately and sending the failure ack is cleaner
+//     than forcing the parent to sit the full 30 s deadline.
 //
-//   - registerFatal means gmuxd understood the request and refused it
-//     for good (e.g. its IsValidSessionID guard rejected the id) —
-//     retrying or waiting changes nothing. registerUnavailable, by
-//     contrast, is a transient "gmuxd not ready" and must NOT reap: the
-//     runner keeps serving so a later discovery scan can pick it up.
-//   - !interactive means no local terminal is attached, so gmuxd is the
-//     only consumer; once gmuxd has permanently rejected it, the
-//     process is a pure orphan (the convIndex-rehydrate resume bug,
-//     where a session keyed by its conversation UUID could never
-//     register). An interactive runner is spared: the user's terminal
-//     is still usefully attached even if gmux never tracks the session.
-func reapOnFatalRegistration(outcome registerOutcome, interactive bool) bool {
-	return outcome == registerFatal && !interactive
+// In both cases, !interactive is required: the runner is headless (no local
+// terminal attached), making gmuxd the only consumer. An interactive runner
+// is spared even on a fatal verdict because its terminal is still usefully
+// attached. The convIndex-rehydrate resume bug (a session keyed by its
+// conversation UUID that could never register) is the canonical orphan example.
+func reapOnRegistrationFailure(outcome registerOutcome, interactive, handshakeOwned bool) bool {
+	return !interactive && (outcome == registerFatal || (handshakeOwned && outcome != registerOK))
+}
+
+// shutdownDetachedTarget closes the runner and explicitly supervises the PTY
+// child's separate process group. The PTY library gives the target its own
+// session, so killing only the runner's setsid group is insufficient when a
+// target ignores terminal-close SIGHUP.
+func shutdownDetachedTarget(srv *ptyserver.Server) {
+	srv.Shutdown()
+	pid := srv.Pid()
+	terminateProcessGroup(pid, detachedTargetCleanupGrace)
+	drainStructChan(srv.Done(), detachedTargetCleanupGrace)
+}
+
+// drainErrorChan waits for done within grace. If the timer fires first (e.g.
+// a process stuck in uninterruptible kernel sleep that SIGKILL cannot wake),
+// it returns and lets the goroutine feeding done reap the process
+// asynchronously. This bounds cleanup time while preserving the single
+// Wait-owner invariant.
+func drainErrorChan(done <-chan error, grace time.Duration) {
+	timer := time.NewTimer(grace)
+	defer timer.Stop()
+	select {
+	case <-done:
+	case <-timer.C:
+	}
+}
+
+// drainStructChan is the same as drainErrorChan for <-chan struct{} (e.g.
+// srv.Done()).
+func drainStructChan(done <-chan struct{}, grace time.Duration) {
+	timer := time.NewTimer(grace)
+	defer timer.Stop()
+	select {
+	case <-done:
+	case <-timer.C:
+	}
+}
+
+func terminateProcessGroup(pgid int, grace time.Duration) {
+	_ = syscall.Kill(-pgid, syscall.SIGHUP)
+	deadline := time.Now().Add(grace)
+	for processGroupExists(pgid) && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if processGroupExists(pgid) {
+		_ = syscall.Kill(-pgid, syscall.SIGKILL)
+		// Bound the post-SIGKILL loop: a zombie-only group returns EPERM
+		// from kill(2), which processGroupExists treats as "still exists".
+		// After the deadline, treat any remainder as done — a zombie has
+		// no further harm potential; a recycled group is not ours to track.
+		killDeadline := time.Now().Add(grace)
+		for processGroupExists(pgid) && time.Now().Before(killDeadline) {
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+}
+
+func processGroupExists(pgid int) bool {
+	err := syscall.Kill(-pgid, 0)
+	return err == nil || errors.Is(err, syscall.EPERM)
 }
 
 // runSession launches a new managed session for the given command.
@@ -122,6 +203,21 @@ func runSession(args []string, attach bool, dir runDirectives) {
 	if !attach {
 		spawnDetached(args, "", true)
 		return
+	}
+
+	registrationCtx, cancelRegistration, handshakeOwned := handshakeContext()
+	defer cancelRegistration()
+	if handshakeOwned && registrationCtx.Err() != nil {
+		handshakeAck("", false)
+		return
+	}
+	// Foreground and nested launches use a short best-effort budget rather
+	// than the 30 s detach deadline: the user's command is already running
+	// and the terminal is attached, so a 30 s hang on daemon-unavailable
+	// would be visibly user-hostile. See foregroundRegistrationBudget.
+	if !handshakeOwned {
+		registrationCtx, cancelRegistration = context.WithTimeout(context.Background(), foregroundRegistrationBudget)
+		defer cancelRegistration()
 	}
 
 	// Honour the legacy GMUX_RESUME_ID env var when --resume-id
@@ -229,6 +325,40 @@ func runSession(args []string, attach bool, dir runDirectives) {
 		State:      state,
 		Version:    version,
 	}
+	var (
+		controlFile    *os.File
+		targetGateFile *os.File
+	)
+	if handshakeOwned {
+		self, err := os.Executable()
+		if err != nil {
+			handshakeAck("", false)
+			return
+		}
+		// Dup capturedHandshakeFD so the target wrapper's ExtraFiles entry owns
+		// a separate fd; handshakeAck retains the original as the sole owner.
+		// Without the dup, both ExtraFiles and handshakeAck would wrap the same
+		// raw fd, creating two *os.File finalizers on one fd (the aliasing
+		// footgun documented in handshake.go).
+		controlDupFD, err := syscall.Dup(capturedHandshakeFD)
+		if err != nil {
+			handshakeAck("", false)
+			return
+		}
+		// Set CLOEXEC on the dup for defence in depth; exec.Cmd ExtraFiles
+		// re-dups with dup2 in the child regardless, so this does not prevent
+		// the target wrapper from receiving fd 3.
+		syscall.CloseOnExec(controlDupFD)
+		controlFile = os.NewFile(uintptr(controlDupFD), "gmux-target-control")
+		targetGateFile = os.NewFile(uintptr(capturedHandshakeGateFD), "gmux-target-gate")
+		if controlFile == nil || targetGateFile == nil {
+			handshakeAck("", false)
+			return
+		}
+		ptyCfg.CommandWrapper = []string{self, "__detached-target"}
+		ptyCfg.ExtraFiles = []*os.File{controlFile, targetGateFile}
+		ptyCfg.Env = append(ptyCfg.Env, targetControlFDEnv+"=3", targetGateFDEnv+"=4")
+	}
 	// Conditional assignment: a typed nil *scrollback.Writer
 	// stored in ptyCfg.Scrollback (an io.WriteCloser) would
 	// satisfy != nil checks downstream and panic on the first
@@ -298,6 +428,18 @@ func runSession(args []string, attach bool, dir runDirectives) {
 	// Start PTY server. The socket is already bound to `listener`
 	// (above); ptyserver.New takes ownership and serves on it.
 	srv, err = ptyserver.New(ptyCfg)
+	// Close the runner's ExtraFiles copies now that the target wrapper has
+	// been forked. controlFile wraps the dup'd fd (not capturedHandshakeFD),
+	// so closing it does not affect handshakeAck's use of the original.
+	// capturedHandshakeGateFD is cleared so a subsequent captureHandshakeFD
+	// call (e.g. from a nested runner) cannot misuse a stale value.
+	if controlFile != nil {
+		_ = controlFile.Close()
+	}
+	if targetGateFile != nil {
+		_ = targetGateFile.Close() // only the parent and target retain the gate
+		capturedHandshakeGateFD = -1
+	}
 	if err != nil {
 		if localTty != nil {
 			// Restore cooked mode before fataling out; otherwise the
@@ -325,22 +467,31 @@ func runSession(args []string, attach bool, dir runDirectives) {
 		fmt.Println("serving...")
 	}
 
+	var detachedSigCh chan os.Signal
+	if handshakeOwned && !interactive {
+		detachedSigCh = make(chan os.Signal, 1)
+		signal.Notify(detachedSigCh, syscall.SIGINT, syscall.SIGTERM)
+		defer signal.Stop(detachedSigCh)
+	}
+
 	// Auto-start gmuxd if not running (one-shot, never retried), then
 	// register. The goroutine signals regDone when the registration
 	// HTTP call has completed (succeeded or exhausted retries) and the
 	// handshake — if any — has been delivered to the parent. We block
 	// on regDone before exit so a fast-exiting command (echo, true,
 	// false) can't lose the registration race.
-	ensureGmuxd()
+	ensureGmuxdContext(registrationCtx)
 	regDone := make(chan struct{})
 	go func() {
 		defer close(regDone)
-		outcome := registerWithGmuxd(sessionID, sockPath)
-		handshakeAck(sessionID, outcome.ok())
-		if reapOnFatalRegistration(outcome, interactive) {
-			log.Printf("gmux: registration permanently rejected for %s; shutting down orphaned runner", sessionID)
-			srv.Shutdown()
+		outcome := registerWithGmuxd(registrationCtx, sessionID, sockPath)
+		if reapOnRegistrationFailure(outcome, interactive, handshakeOwned) {
+			log.Printf("gmux: registration failed for %s; shutting down orphaned runner", sessionID)
+			shutdownDetachedTarget(srv)
+			handshakeAck(sessionID, false)
+			return
 		}
+		handshakeAck(sessionID, outcome.ok())
 	}()
 
 	if interactive {
@@ -388,15 +539,22 @@ func runSession(args []string, attach bool, dir runDirectives) {
 		}
 	} else {
 		// Non-interactive: original behavior
-		sigCh := make(chan os.Signal, 1)
-		signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+		sigCh := detachedSigCh
+		if sigCh == nil {
+			sigCh = make(chan os.Signal, 1)
+			signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+		}
 
 		select {
 		case <-srv.Done():
 			// Child exited
 		case sig := <-sigCh:
 			fmt.Printf("\nreceived %v, shutting down...\n", sig)
-			srv.Shutdown()
+			if handshakeOwned {
+				shutdownDetachedTarget(srv)
+			} else {
+				srv.Shutdown()
+			}
 		}
 	}
 
@@ -417,7 +575,8 @@ func runSession(args []string, attach bool, dir runDirectives) {
 	// (no-op, not registered yet), then the register arrives, then
 	// the child exits, leaving a stale registered session.
 	//
-	// Bounded by registerWithGmuxd's retry budget (≤2.5s).
+	// Bounded by the registration context (the shared explicit-detach
+	// deadline, or the separate best-effort foreground/nested budget).
 	<-regDone
 
 	// Deregister from gmuxd (best-effort)
@@ -426,6 +585,7 @@ func runSession(args []string, attach bool, dir runDirectives) {
 	if !interactive {
 		fmt.Printf("exited:   %d\n", exitCode)
 	}
+	waitForHandshakeRelease()
 	os.Exit(exitCode)
 }
 
@@ -515,6 +675,41 @@ func reexecRunArgs(args []string) []string {
 	return append([]string{"__run", "--"}, args...)
 }
 
+// runDetachedTarget publishes its separately-sessioned process-group ID before
+// allowing the user command to exec. The parent owns the gate fd, so even if
+// the runner dies in the fork/publication window, the command cannot start
+// without the parent first learning which group it must supervise.
+func runDetachedTarget(args []string) int {
+	controlFD, err1 := strconv.Atoi(os.Getenv(targetControlFDEnv))
+	gateFD, err2 := strconv.Atoi(os.Getenv(targetGateFDEnv))
+	_ = os.Unsetenv(targetControlFDEnv)
+	_ = os.Unsetenv(targetGateFDEnv)
+	if err1 != nil || err2 != nil || controlFD < 3 || gateFD < 3 || len(args) == 0 {
+		return 125
+	}
+	control := os.NewFile(uintptr(controlFD), "gmux-target-control")
+	gate := os.NewFile(uintptr(gateFD), "gmux-target-gate")
+	if control == nil || gate == nil {
+		return 125
+	}
+	_, _ = fmt.Fprintf(control, "TARGET %d\n", os.Getpid())
+	_ = control.Close()
+	var token [1]byte
+	_, err := io.ReadFull(gate, token[:])
+	_ = gate.Close()
+	if err != nil || token[0] != 'G' {
+		return 125
+	}
+	bin, err := exec.LookPath(args[0])
+	if err != nil {
+		return 127
+	}
+	if err := syscall.Exec(bin, args, os.Environ()); err != nil {
+		return 126
+	}
+	return 0
+}
+
 // spawnDetached re-execs gmux with the given args as a setsid'd
 // background process, disconnected from the current terminal. Used
 // for both detached (-d) and nested-gmux scenarios: the child registers
@@ -554,26 +749,37 @@ func spawnDetached(args []string, msg string, waitForRegistration bool) {
 	cmd.Stdout = devNull
 	cmd.Stderr = devNull
 
-	var handshakeRead, handshakeWrite *os.File
+	var handshakeRead, handshakeWrite, gateRead, gateWrite, holdRead, holdWrite *os.File
 	if waitForRegistration {
 		var err error
 		handshakeRead, handshakeWrite, err = os.Pipe()
 		if err != nil {
 			log.Fatalf("failed to create handshake pipe: %v", err)
 		}
-		// Parent reads, child writes. cmd.ExtraFiles[0] becomes fd 3
-		// in the child; GMUX_HANDSHAKE_FD tells the child which fd to
-		// write to.
-		cmd.ExtraFiles = []*os.File{handshakeWrite}
-		cmd.Env = append(os.Environ(), handshakeFDEnv+"=3")
+		gateRead, gateWrite, err = os.Pipe()
+		if err != nil {
+			log.Fatalf("failed to create target gate pipe: %v", err)
+		}
+		holdRead, holdWrite, err = os.Pipe()
+		if err != nil {
+			log.Fatalf("failed to create runner hold pipe: %v", err)
+		}
+		// Parent reads acknowledgements and owns the target-start gate.
+		deadline := time.Now().Add(detachedStartupBudget)
+		cmd.ExtraFiles = []*os.File{handshakeWrite, gateRead, holdRead}
+		cmd.Env = append(os.Environ(),
+			handshakeFDEnv+"=3",
+			handshakeGateFDEnv+"=4",
+			handshakeHoldFDEnv+"=5",
+			handshakeDeadlineEnv+"="+fmt.Sprint(deadline.UnixNano()),
+		)
 	}
 
 	if err := cmd.Start(); err != nil {
 		log.Fatalf("failed to start background session: %v", err)
 	}
-	cmd.Process.Release()
-
 	if !waitForRegistration {
+		_ = cmd.Process.Release()
 		if msg != "" {
 			fmt.Fprintln(os.Stderr, msg)
 		}
@@ -584,14 +790,144 @@ func spawnDetached(args []string, msg string, waitForRegistration bool) {
 	// now the child; if it dies without writing, our read returns
 	// EOF with zero bytes — the unambiguous "child failed" signal.
 	_ = handshakeWrite.Close()
+	_ = gateRead.Close()
+	_ = holdRead.Close()
 	defer handshakeRead.Close()
+	defer gateWrite.Close()
+	defer holdWrite.Close()
 
-	id, err := readHandshake(handshakeRead, handshakeTimeout)
+	deadlineNanos, _ := strconv.ParseInt(envValue(cmd.Env, handshakeDeadlineEnv), 10, 64)
+	id, err := awaitDetachedHandshake(cmd, handshakeRead, gateWrite, holdWrite, time.Unix(0, deadlineNanos), detachedCleanupGrace)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to start background session: %s\n", explainHandshakeFailure(err))
 		os.Exit(1)
 	}
 	fmt.Println(id)
+}
+
+func envValue(env []string, name string) string {
+	prefix := name + "="
+	for i := len(env) - 1; i >= 0; i-- {
+		if strings.HasPrefix(env[i], prefix) {
+			return strings.TrimPrefix(env[i], prefix)
+		}
+	}
+	return ""
+}
+
+// awaitDetachedHandshake retains ownership until acknowledgement. Every
+// failure kills the setsid process group and waits, escalating if graceful
+// runner shutdown does not complete.
+// readHandshakeFrame reads one newline-terminated frame from reader using
+// ReadSlice, which returns at most reader's buffer capacity (maxHandshakeFrameBytes+1)
+// of data before returning bufio.ErrBufferFull — so allocation is strictly
+// bounded regardless of how much the child writes without a newline.
+// ErrBufferFull is mapped to a descriptive error; other errors are passed through.
+func readHandshakeFrame(reader *bufio.Reader) (string, error) {
+	line, err := reader.ReadSlice('\n')
+	if err == bufio.ErrBufferFull {
+		return "", fmt.Errorf("handshake frame too large (>%d bytes without newline)", maxHandshakeFrameBytes)
+	}
+	return strings.TrimSpace(string(line)), err
+}
+
+func awaitDetachedHandshake(cmd *exec.Cmd, r, gate, hold *os.File, deadline time.Time, grace time.Duration) (string, error) {
+	// One goroutine owns Wait for every outcome. On success it remains until the
+	// detached runner exits (or this short-lived CLI parent exits); on failure
+	// cleanup joins it. This avoids both Release-on-zombie and double Wait races.
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	targetPGID := 0
+	id := ""
+	var readErr error
+	// Use a fixed-size buffer so ReadSlice can enforce the frame cap without
+	// accumulating the full frame first. The +1 lets a frame of exactly
+	// maxHandshakeFrameBytes bytes plus its newline fit before ErrBufferFull.
+	reader := bufio.NewReaderSize(r, maxHandshakeFrameBytes+1)
+	if err := r.SetReadDeadline(deadline); err != nil {
+		// Route through the common cleanup path so cmd.Wait is always joined and
+		// the target group is signalled — preserving the ownership invariant.
+		readErr = err
+	} else {
+		for targetPGID == 0 || id == "" {
+			line, err := readHandshakeFrame(reader)
+			if err != nil {
+				readErr = err
+				break
+			}
+			if strings.HasPrefix(line, "TARGET ") {
+				targetPGID, _ = strconv.Atoi(strings.TrimPrefix(line, "TARGET "))
+				if targetPGID <= 0 {
+					readErr = errors.New("invalid target process group")
+					break
+				}
+			} else if line == "" {
+				// Prompt error: silently skipping would wait out the full
+				// deadline instead of surfacing the issue immediately.
+				readErr = errors.New("empty session id from child")
+				break
+			} else {
+				if !paths.IsValidSessionID(line) {
+					readErr = fmt.Errorf("invalid session id %q", line)
+					break
+				}
+				id = line
+			}
+		}
+	}
+	if readErr == nil {
+		if _, err := gate.Write([]byte{'G'}); err != nil {
+			readErr = err
+		} else {
+			_ = hold.Close()
+			return id, nil
+		}
+	}
+
+	// Signal before closing: while the gate is still open the target is
+	// gate-blocked and its PGID is guaranteed valid, removing the reuse
+	// window that opens when the gate closes first (wrapper exits → reaped
+	// → PGID recycled before the signal fires). Closing the gate afterward
+	// prevents exec even if the signal is delayed.
+	if targetPGID > 0 {
+		_ = syscall.Kill(-targetPGID, syscall.SIGHUP)
+	}
+	_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM)
+	_ = gate.Close()
+	_ = hold.Close()
+	timer := time.NewTimer(grace)
+	select {
+	case <-done:
+	case <-timer.C:
+		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		// Bounded: a D-state process may not become waitable after SIGKILL;
+		// the Wait goroutine continues asynchronously once the kernel allows it.
+		drainErrorChan(done, grace)
+	}
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
+	if targetPGID == 0 {
+		_ = r.SetReadDeadline(time.Now().Add(grace))
+		for {
+			// The same fixed-size reader caps the rescan too.
+			line, err := readHandshakeFrame(reader)
+			if err != nil {
+				break
+			}
+			if strings.HasPrefix(line, "TARGET ") {
+				targetPGID, _ = strconv.Atoi(strings.TrimPrefix(line, "TARGET "))
+				break
+			}
+		}
+	}
+	if targetPGID > 0 {
+		terminateProcessGroup(targetPGID, grace)
+	}
+	return "", readErr
 }
 
 // explainHandshakeFailure converts a readHandshake error into a
@@ -600,7 +936,7 @@ func spawnDetached(args []string, msg string, waitForRegistration bool) {
 func explainHandshakeFailure(err error) string {
 	switch {
 	case errors.Is(err, os.ErrDeadlineExceeded):
-		return fmt.Sprintf("registration timed out after %s", handshakeTimeout)
+		return fmt.Sprintf("registration timed out after %s", detachedStartupBudget)
 	case errors.Is(err, io.EOF):
 		return "child process exited before registering"
 	default:

--- a/cli/gmux/internal/ptyserver/ptyserver.go
+++ b/cli/gmux/internal/ptyserver/ptyserver.go
@@ -232,9 +232,11 @@ func (c *wsClient) write(typ websocket.MessageType, data []byte) error {
 
 // Config for creating a new PTY server.
 type Config struct {
-	Command []string
-	Cwd     string
-	Env     []string
+	Command        []string
+	CommandWrapper []string // internal argv prefix applied after adapter command extension
+	Cwd            string
+	Env            []string
+	ExtraFiles     []*os.File // inherited control fds for internal command wrappers
 	// Listener is the pre-bound Unix socket the server serves
 	// HTTP/WebSocket on. Required. Callers obtain one via
 	// BindSocket so they can react to ErrSocketInUse (e.g.,
@@ -300,6 +302,7 @@ func New(cfg Config) (*Server, error) {
 	cmd := exec.Command(cfg.Command[0], cfg.Command[1:]...)
 	cmd.Dir = cfg.Cwd
 	cmd.Env = buildChildEnv(os.Environ(), cfg.Env, cfg.Version)
+	cmd.ExtraFiles = cfg.ExtraFiles
 
 	// Inject the gmux session hook for adapters with a native extension/hook
 	// API: it reports session/title/status authoritatively over POST
@@ -333,6 +336,15 @@ func New(cfg Config) (*Server, error) {
 			cmd.Args = extended
 			cmd.Env = append(cmd.Env, "GMUX_SESSION_SOCK="+cfg.SocketPath)
 		}
+	}
+
+	if len(cfg.CommandWrapper) > 0 {
+		wrapped := append(append([]string{}, cfg.CommandWrapper...), cmd.Args...)
+		wrappedEnv := cmd.Env
+		cmd = exec.Command(wrapped[0], wrapped[1:]...)
+		cmd.Dir = cfg.Cwd
+		cmd.Env = wrappedEnv
+		cmd.ExtraFiles = cfg.ExtraFiles
 	}
 
 	// Start command in a new PTY

--- a/cli/gmux/internal/ptyserver/ptyserver_test.go
+++ b/cli/gmux/internal/ptyserver/ptyserver_test.go
@@ -6,16 +6,19 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 
 	"github.com/gmuxapp/gmux/cli/gmux/internal/session"
+	"github.com/gmuxapp/gmux/packages/adapter"
 	"github.com/gmuxapp/gmux/packages/scrollback"
 	"nhooyr.io/websocket"
 )
@@ -1755,4 +1758,138 @@ func TestShutdownIdempotent(t *testing.T) {
 
 	// A further call after the child has exited must also be safe.
 	srv.Shutdown()
+}
+
+// ── CommandWrapper + ExtraFiles + adapter argv extension ──
+
+// hookTestAdapter extends the command argv with a deterministic marker via the
+// SessionHookCommand path. The marker is recognisable in the subprocess output
+// without embedding a path-dependent binary reference.
+type hookTestAdapter struct{}
+
+func (hookTestAdapter) Name() string                            { return "test-hook" }
+func (hookTestAdapter) Discover() bool                          { return false }
+func (hookTestAdapter) Match([]string) bool                     { return false }
+func (hookTestAdapter) Env(adapter.EnvContext) []string         { return nil }
+func (hookTestAdapter) HookCommand(args []string, _ string) ([]string, bool) {
+	// Append a fixed marker that does NOT start with '-' so Go flag.Parse in
+	// the subprocess helper treats it as a non-flag positional argument.
+	return append(args, "HOOK_MARKER"), true
+}
+
+// TestPTYServerCommandWrapperAndExtraFiles exercises the production wiring of
+// Config.CommandWrapper + Config.ExtraFiles through ptyserver.New, including
+// the adapter argv extension that happens before wrapping. It verifies:
+//
+//  1. The final subprocess argv is [wrapper..., extended-command...] in the
+//     correct order (extension before wrapping, both before exec).
+//  2. ExtraFiles are inherited by the subprocess as open pipe fds at
+//     positions 3 and 4.
+//
+// Mutation resistance:
+//   - Dropping Config.ExtraFiles: the subprocess sees FD3/FD4 as non-pipe,
+//     failing the pipe assertions.
+//   - Removing CommandWrapper: the subprocess binary is not the test binary
+//     and the helper role check never runs, making the result pipe empty.
+//   - Removing adapter extension: HOOK_MARKER is absent from the result,
+//     failing the argv assertion.
+func TestPTYServerCommandWrapperAndExtraFiles(t *testing.T) {
+	const roleEnv = "PTYSERVER_WRAPPER_ROLE"
+	if os.Getenv(roleEnv) == "check" {
+		// Subprocess helper: write check results to fd 3 (the result pipe)
+		// then exit. os.Args[2:] contains the "command" portion passed via
+		// Config.Command plus any adapter-extended args.
+		resultFD := os.NewFile(3, "result")
+		var fd3Pipe, fd4Pipe bool
+		var st syscall.Stat_t
+		if syscall.Fstat(3, &st) == nil && st.Mode&syscall.S_IFMT == syscall.S_IFIFO {
+			fd3Pipe = true
+		}
+		if syscall.Fstat(4, &st) == nil && st.Mode&syscall.S_IFMT == syscall.S_IFIFO {
+			fd4Pipe = true
+		}
+		cmdArgs := os.Args[2:] // wrapper consumed os.Args[0..1]; command starts at [2]
+		fmt.Fprintf(resultFD, "ARGS=%s\nFD3=%v\nFD4=%v\n",
+			strings.Join(cmdArgs, ","), fd3Pipe, fd4Pipe)
+		_ = resultFD.Close()
+		os.Exit(0)
+	}
+
+	// Parent: create result pipe (fd 3 in subprocess) and an extra pipe
+	// for fd 4. Both are passed via Config.ExtraFiles so the subprocess
+	// receives them as open, usable file descriptors.
+	resultR, resultW, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resultR.Close()
+	pipe4R, pipe4W, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pipe4R.Close()
+	defer pipe4W.Close()
+
+	sockPath := filepath.Join(t.TempDir(), "test.sock")
+
+	// Config.CommandWrapper is the argv prefix prepended AFTER adapter
+	// extension. Using the test binary as the wrapper lets the subprocess
+	// role check run inside the helper and write its results.
+	// Config.Command provides the "user command" that appears after the
+	// wrapper prefix in the final argv.
+	// The hookTestAdapter extends Config.Command with HOOK_MARKER before
+	// wrapping, so the expected subprocess os.Args[2:] is:
+	//   [user-cmd, user-arg, HOOK_MARKER]
+	srv, err := New(Config{
+		CommandWrapper: []string{os.Args[0], "-test.run=^TestPTYServerCommandWrapperAndExtraFiles$"},
+		Command:        []string{"user-cmd", "user-arg"},
+		Cwd:            "/tmp",
+		Env:            []string{roleEnv + "=check", "GMUX_NO_AGENT_HOOK=0"},
+		ExtraFiles:     []*os.File{resultW, pipe4R}, // fd 3=resultW, fd 4=pipe4R
+		Listener:       mustBindSocket(t, sockPath),
+		SocketPath:     sockPath,
+		Adapter:        hookTestAdapter{},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer srv.Shutdown()
+
+	// Close the parent's copies of the ExtraFiles write-ends so the
+	// subprocess is the sole owner. resultW must be closed so io.ReadAll
+	// returns when the subprocess closes its end.
+	_ = resultW.Close()
+	_ = pipe4R.Close()
+
+	// Read result from the subprocess. Deadline guards against test hangs.
+	_ = resultR.SetReadDeadline(time.Now().Add(10 * time.Second))
+	data, _ := io.ReadAll(resultR)
+	result := string(data)
+
+	// Wait for the subprocess to finish.
+	select {
+	case <-srv.Done():
+	case <-time.After(12 * time.Second):
+		t.Fatal("timeout waiting for subprocess to exit")
+	}
+
+	if result == "" {
+		t.Fatal("subprocess wrote nothing to result pipe (check ExtraFiles or CommandWrapper)")
+	}
+
+	// (1) Argv order: user-cmd comes first, then user-arg, then the
+	//     adapter-extended HOOK_MARKER. This exact string fails if the
+	//     wrapper and command are reversed, or if extension is dropped.
+	wantArgs := "ARGS=user-cmd,user-arg,HOOK_MARKER"
+	if !strings.Contains(result, wantArgs) {
+		t.Errorf("argv order wrong; want %q in %q", wantArgs, result)
+	}
+
+	// (2) ExtraFiles: both fd 3 and fd 4 must be open pipes.
+	if !strings.Contains(result, "FD3=true") {
+		t.Errorf("fd 3 not a pipe in subprocess (ExtraFiles[0] not passed): %q", result)
+	}
+	if !strings.Contains(result, "FD4=true") {
+		t.Errorf("fd 4 not a pipe in subprocess (ExtraFiles[1] not passed): %q", result)
+	}
 }


### PR DESCRIPTION
## Summary

- give explicit detached launches one shared absolute 30-second parent/child startup deadline
- propagate cancellation through daemon health, Unix HTTP registration, and retry backoff
- retain ownership until acknowledgement and prevent user commands from executing before registration succeeds
- terminate and reap runner and separately-sessioned target groups on reported failure
- preserve short best-effort foreground/nested registration and unrelated remote/resume budgets

## Problem

The parent previously timed out after five seconds while the child could spend much longer probing and registering. It released the child immediately, so `gmux -d` could report failure while the command later registered and remained running.

## Safety

The internal protocol publishes the target process group before execution, gates execution on registration acknowledgement, and uses one Wait owner. Internal descriptors are validated, close-on-exec, distinct pipe endpoints. Control frames and cleanup waits are bounded.

## Verification

- real subprocess tests with separate runner/target sessions and signal-ignoring descendants
- autostart FD-leak, foreground latency, framing, cancellation, status, and process-reap tests
- production ptyserver wrapper/adapter argv/ExtraFiles integration test
- repeated race, vet, Darwin cross-build, and full monorepo tests
- multiple adversarial process/concurrency/test review rounds with mutation probes

## Stack

Depends on #416, which depends on #410. This PR targets `fix/discovered-project-origin`; merge after the lower stack layers or retarget to `main` as they land.
