### PR TITLE
fix(gmuxd): make discovery endpoints lifecycle-safe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,8 @@ cli/gmux/gmux
 *.local.*
 test-results/
 tests/pi-adapter/pi-adapter
-gmux gmuxd
+/gmux
+/gmuxd
 
 # Agent handoff/scratch docs
 .memory/

--- a/cli/gmux/cmd/gmux/daemon.go
+++ b/cli/gmux/cmd/gmux/daemon.go
@@ -92,14 +92,36 @@ func findGmuxdBin() string {
 	return ""
 }
 
+// autostartLogFile opens the daemon log the autostarted child will inherit as
+// its stderr.
+//
+// The path is paths.DaemonLogPath -- the same file `gmuxd start` uses, the
+// same file `gmuxd log-path` prints, and the same file the daemon bounds. It
+// used to be $TMPDIR/gmuxd.log, which split the daemon's diagnostics in two by
+// launcher: the CLI-autostarted daemon (the overwhelmingly common one) wrote
+// somewhere `gmuxd log-path` never mentions, and, because the daemon only
+// bounds a log it can confirm is its own, that copy grew without limit.
+//
+// Append, never truncate: this runs before the child has checked for a healthy
+// incumbent, and most autostarts bounce straight off one.
+func autostartLogFile() *os.File {
+	logPath := paths.DaemonLogPath()
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o700); err != nil {
+		log.Printf("warning: cannot create the state dir for %s: %v", logPath, err)
+		return nil
+	}
+	f, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		log.Printf("warning: cannot open %s: %v", logPath, err)
+		return nil
+	}
+	return f
+}
+
 // startGmuxd launches gmuxd in the background with the given args.
 func startGmuxd(gmuxdBin string, args []string) bool {
 	// Log gmuxd output to a file so users can diagnose startup failures.
-	logPath := filepath.Join(os.TempDir(), "gmuxd.log")
-	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
-	if err != nil {
-		logFile = nil
-	}
+	logFile := autostartLogFile()
 
 	cmd := exec.Command(gmuxdBin, args...)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}

--- a/cli/gmux/cmd/gmux/daemon_autostart_log_test.go
+++ b/cli/gmux/cmd/gmux/daemon_autostart_log_test.go
@@ -1,0 +1,126 @@
+package main
+
+// The CLI is the daemon's primary launcher: almost every gmuxd on a developer
+// machine is autostarted by a `gmux` invocation, not by `gmuxd start`. Where
+// that daemon's stderr points therefore decides whether the daemon's own log
+// bounding attaches at all -- it only bounds a file it can confirm is the log
+// at paths.DaemonLogPath -- and whether `gmuxd log-path` tells the truth.
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gmuxapp/gmux/packages/paths"
+)
+
+// Mutation: point autostartLogFile back at $TMPDIR/gmuxd.log, or give it
+// O_TRUNC.
+func TestAutostartLogUsesTheDaemonLogPath(t *testing.T) {
+	stateHome := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateHome)
+	tmp := t.TempDir()
+	t.Setenv("TMPDIR", tmp) // a TempDir the log must NOT land in
+
+	logPath := paths.DaemonLogPath()
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	incumbent := "an incumbent daemon's history\n"
+	if err := os.WriteFile(logPath, []byte(incumbent), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	f := autostartLogFile()
+	if f == nil {
+		t.Fatal("autostartLogFile returned nothing")
+	}
+	defer f.Close()
+
+	fi, err := f.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	pi, err := os.Lstat(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !os.SameFile(fi, pi) {
+		t.Fatalf("autostart opened %v, want the daemon log at %s", fi.Name(), logPath)
+	}
+	if _, err := os.Lstat(filepath.Join(tmp, "gmuxd.log")); err == nil {
+		t.Fatal("autostart still creates a second log in TMPDIR")
+	}
+	// An incumbent's history must survive: this runs before the child has
+	// checked whether one is already healthy.
+	content, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != incumbent {
+		t.Fatalf("autostart truncated the log; content = %q", content)
+	}
+	if fi.Mode().Perm() != 0o600 {
+		t.Fatalf("log mode = %o, want 600", fi.Mode().Perm())
+	}
+}
+
+// The end-to-end version: a real `gmux` invocation with no daemon running
+// autostarts one, and that daemon's stderr is the file `gmuxd log-path`
+// names -- which is the precondition for the daemon bounding it.
+//
+// The daemon here is a stub: this pins where the CLI points a child's stderr,
+// which is the CLI's half of the contract. The daemon's half (bounding
+// exactly that file) is pinned in services/gmuxd.
+func TestAutostartedDaemonInheritsTheDaemonLog(t *testing.T) {
+	bin := buildGmuxBinary(t)
+	stateHome := t.TempDir()
+	socketDir := filepath.Join(t.TempDir(), "sessions")
+	logPath := filepath.Join(stateHome, "gmux", "gmuxd.log")
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// A pre-existing log, as a healthy incumbent would have.
+	if err := os.WriteFile(logPath, []byte("earlier daemon output\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// A stub gmuxd next to the gmux binary, which findGmuxdBin prefers.
+	stub := filepath.Join(filepath.Dir(bin), "gmuxd")
+	if err := os.WriteFile(stub, []byte("#!/bin/sh\necho AUTOSTARTED-DAEMON-STDERR >&2\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Remove(stub) })
+
+	childTmp := t.TempDir()
+	cmd := exec.Command(bin, "--", "true")
+	cmd.Env = append(launchEnv(stateHome, socketDir), "TMPDIR="+childTmp)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gmux -- true: %v\n%s", err, out)
+	}
+
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		content, readErr := os.ReadFile(logPath)
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		if strings.Contains(string(content), "AUTOSTARTED-DAEMON-STDERR") {
+			if !strings.Contains(string(content), "earlier daemon output") {
+				t.Fatal("the autostart truncated an existing daemon log")
+			}
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("the autostarted daemon's stderr never reached %s; content = %q", logPath, content)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if _, err := os.Lstat(filepath.Join(childTmp, "gmuxd.log")); err == nil {
+		t.Fatal("the autostarted daemon logged to TMPDIR as well")
+	}
+}

--- a/cli/gmux/cmd/gmux/main.go
+++ b/cli/gmux/cmd/gmux/main.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"os/exec"
 	"time"
+
+	"github.com/gmuxapp/gmux/packages/paths"
 )
 
 // version is set at build time via -ldflags "-X main.version=..."
@@ -128,7 +130,7 @@ func openUI() {
 		time.Sleep(200 * time.Millisecond)
 	}
 	if !ready {
-		log.Fatalf("gmuxd is not running (check %s/gmuxd.log for errors)", os.TempDir())
+		log.Fatalf("gmuxd is not running (check %s for errors)", paths.DaemonLogPath())
 	}
 
 	// Parse health response for TCP address and auth token.

--- a/cli/gmux/cmd/gmux/run.go
+++ b/cli/gmux/cmd/gmux/run.go
@@ -582,6 +582,21 @@ func runSession(args []string, attach bool, dir runDirectives) {
 	// Deregister from gmuxd (best-effort)
 	deregisterFromGmuxd(sessionID)
 
+	// Give up the socket pathname while this process is still alive. Process
+	// exit releases the ownership lease (the kernel drops flock with the fd)
+	// but does NOT unlink the pathname, so without this call every short
+	// `gmux -- cmd` leaves a canonical socket file behind that the daemon then
+	// dials — and logs a refusal for — on every discovery tick, forever.
+	//
+	// Shutdown is idempotent (shutdownOnce) and its removal is
+	// identity-checked, so the /kill, signal and detached-cleanup paths that
+	// already released ownership make this a no-op and it can never unlink a
+	// replacement runner's socket.
+	//
+	// Ordering: PTY drain → exit event → <-regDone → deregister → Shutdown
+	// (pathname unlinked, lease released) → os.Exit.
+	srv.Shutdown()
+
 	if !interactive {
 		fmt.Printf("exited:   %d\n", exitCode)
 	}

--- a/cli/gmux/cmd/gmux/run_socket_lifecycle_test.go
+++ b/cli/gmux/cmd/gmux/run_socket_lifecycle_test.go
@@ -1,0 +1,322 @@
+package main
+
+// run_socket_lifecycle_test.go — end-to-end acceptance for the defect this
+// stack exists to fix: short `gmux -- cmd` launches must not leave canonical
+// socket pathnames behind.
+//
+// This test builds and runs the *real* gmux binary. Nothing here reimplements
+// the exit sequence, because the previous two attempts at covering this did
+// exactly that: they replicated run.go's ordering in a helper, and deleting
+// the production line they claimed to guard left the suite green. The only
+// way to pin a line in a func that ends in os.Exit is to run the program.
+//
+// Mutation: delete the trailing srv.Shutdown() from runSession in run.go.
+// Every launch then leaves its socket pathname behind and this test fails on
+// the first iteration.
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gmuxapp/gmux/packages/socklease"
+)
+
+var (
+	gmuxBinOnce sync.Once
+	gmuxBinPath string
+	gmuxBinErr  error
+)
+
+// buildGmuxBinary compiles the real gmux command once per test binary.
+func buildGmuxBinary(t *testing.T) string {
+	t.Helper()
+	gmuxBinOnce.Do(func() {
+		dir, err := os.MkdirTemp("", "gmux-bin-")
+		if err != nil {
+			gmuxBinErr = err
+			return
+		}
+		gmuxBinPath = filepath.Join(dir, "gmux")
+		cmd := exec.Command("go", "build", "-o", gmuxBinPath, ".")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			gmuxBinErr = fmt.Errorf("go build: %v\n%s", err, out)
+		}
+	})
+	if gmuxBinErr != nil {
+		t.Fatalf("building gmux: %v", gmuxBinErr)
+	}
+	return gmuxBinPath
+}
+
+// fakeDaemon is the smallest gmuxd the runner will accept: healthy, and
+// willing to record registrations and deregistrations.
+type fakeDaemon struct {
+	registered   atomic.Int64
+	deregistered atomic.Int64
+
+	mu       sync.Mutex
+	sockets  map[string]string // session id -> socket path, as registered
+	deleted  map[string]bool
+	srv      *http.Server
+	listener net.Listener
+}
+
+func startFakeDaemon(t *testing.T, sockPath string) *fakeDaemon {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(sockPath), 0o700); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen %s: %v", sockPath, err)
+	}
+	d := &fakeDaemon{sockets: map[string]string{}, deleted: map[string]bool{}, listener: ln}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /v1/health", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"version": "dev"}})
+	})
+	mux.HandleFunc("POST /v1/register", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			SessionID  string `json:"session_id"`
+			SocketPath string `json:"socket_path"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		d.mu.Lock()
+		d.sockets[body.SessionID] = body.SocketPath
+		d.mu.Unlock()
+		d.registered.Add(1)
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("POST /v1/deregister", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			SessionID string `json:"session_id"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		d.mu.Lock()
+		d.deleted[body.SessionID] = true
+		d.mu.Unlock()
+		d.deregistered.Add(1)
+		w.WriteHeader(http.StatusOK)
+	})
+	d.srv = &http.Server{Handler: mux}
+	go func() { _ = d.srv.Serve(ln) }()
+	t.Cleanup(func() { _ = d.srv.Close() })
+	return d
+}
+
+func (d *fakeDaemon) registrations() map[string]string {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	out := make(map[string]string, len(d.sockets))
+	for k, v := range d.sockets {
+		out[k] = v
+	}
+	return out
+}
+
+func (d *fakeDaemon) deregistrations() map[string]bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	out := make(map[string]bool, len(d.deleted))
+	for k, v := range d.deleted {
+		out[k] = v
+	}
+	return out
+}
+
+// launchEnv isolates a run completely: its own state directory (so the fake
+// daemon's socket, and any session metadata, live in the test's tempdir) and
+// its own runner socket directory.
+func launchEnv(stateHome, socketDir string) []string {
+	env := []string{}
+	for _, kv := range os.Environ() {
+		switch {
+		case strings.HasPrefix(kv, "XDG_STATE_HOME="),
+			strings.HasPrefix(kv, "GMUX_SOCKET_DIR="),
+			strings.HasPrefix(kv, "GMUX_SESSION_ID="),
+			strings.HasPrefix(kv, "GMUX_SOCKET="),
+			strings.HasPrefix(kv, "GMUX_HANDSHAKE_FD="):
+			continue
+		}
+		env = append(env, kv)
+	}
+	return append(env,
+		"XDG_STATE_HOME="+stateHome,
+		"GMUX_SOCKET_DIR="+socketDir,
+		// Deterministic, adapter-free child.
+		"SHELL=/bin/sh",
+	)
+}
+
+// leftoverSockets lists everything still in the runner socket directory.
+func leftoverSockets(t *testing.T, dir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		t.Fatalf("read socket dir: %v", err)
+	}
+	var out []string
+	for _, e := range entries {
+		out = append(out, e.Name())
+	}
+	return out
+}
+
+// TestShortLaunchesLeaveNoSocketPathnames runs 100 real, short sessions and
+// requires the socket directory to be empty afterwards -- no sockets, and no
+// lock files either, since a lock file per session ever started is the same
+// unbounded growth in a different guise.
+func TestShortLaunchesLeaveNoSocketPathnames(t *testing.T) {
+	bin := buildGmuxBinary(t)
+	stateHome := t.TempDir()
+	socketDir := filepath.Join(t.TempDir(), "sessions")
+	daemon := startFakeDaemon(t, filepath.Join(stateHome, "gmux", "gmuxd.sock"))
+	env := launchEnv(stateHome, socketDir)
+
+	const launches = 100
+	for i := range launches {
+		cmd := exec.Command(bin, "--", "true")
+		cmd.Env = env
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("launch %d: %v\n%s", i, err, out)
+		}
+		if !strings.Contains(string(out), "exited:   0") {
+			t.Fatalf("launch %d did not report a clean exit:\n%s", i, out)
+		}
+		// The socket pathname must be gone the moment the process is: the
+		// runner owns it, and nothing else is going to clean it up.
+		if left := leftoverSockets(t, socketDir); len(left) != 0 {
+			t.Fatalf("launch %d left %v in the socket directory; "+
+				"the runner exited without releasing its socket pathname", i, left)
+		}
+	}
+
+	if got := daemon.registered.Load(); got != launches {
+		t.Errorf("registrations = %d, want %d", got, launches)
+	}
+	if got := daemon.deregistered.Load(); got != launches {
+		t.Errorf("deregistrations = %d, want %d", got, launches)
+	}
+	// Every registration must have been for a socket in the isolated dir,
+	// and every registered session must also have deregistered.
+	deregistered := daemon.deregistrations()
+	for id, sock := range daemon.registrations() {
+		if filepath.Dir(sock) != socketDir {
+			t.Errorf("session %s registered socket %s outside %s", id, sock, socketDir)
+		}
+		if !deregistered[id] {
+			t.Errorf("session %s registered but never deregistered", id)
+		}
+	}
+}
+
+// A launch must also hand the pathname over cleanly enough that the very next
+// launch can take the same session id -- the restart/resume path (ADR 0003).
+func TestResumedSessionIDRebindsAfterExit(t *testing.T) {
+	bin := buildGmuxBinary(t)
+	stateHome := t.TempDir()
+	socketDir := filepath.Join(t.TempDir(), "sessions")
+	startFakeDaemon(t, filepath.Join(stateHome, "gmux", "gmuxd.sock"))
+	env := append(launchEnv(stateHome, socketDir), "GMUX_RESUME_ID=sess-fixed")
+
+	for i := range 5 {
+		cmd := exec.Command(bin, "--", "true")
+		cmd.Env = env
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("launch %d: %v\n%s", i, err, out)
+		}
+		// The resume id must be honoured every time. A leaked lease would
+		// push the runner onto a freshly minted id instead.
+		want := filepath.Join(socketDir, "sess-fixed.sock")
+		if !strings.Contains(string(out), "socket:   "+want) {
+			t.Fatalf("launch %d did not bind the resumed id:\n%s", i, out)
+		}
+		if left := leftoverSockets(t, socketDir); len(left) != 0 {
+			t.Fatalf("launch %d left %v behind", i, left)
+		}
+	}
+}
+
+// A runner killed outright (SIGKILL: no cleanup runs at all) is the population
+// the daemon's reaper exists for. This pins the two halves of that contract
+// from the runner's side: the pathname survives the kill, and the lease does
+// not -- so the daemon can tell the difference between a dead runner and a
+// live one.
+func TestKilledRunnerLeavesReapableSocket(t *testing.T) {
+	bin := buildGmuxBinary(t)
+	stateHome := t.TempDir()
+	socketDir := filepath.Join(t.TempDir(), "sessions")
+	startFakeDaemon(t, filepath.Join(stateHome, "gmux", "gmuxd.sock"))
+
+	cmd := exec.Command(bin, "--", "sleep", "60")
+	cmd.Env = launchEnv(stateHome, socketDir)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = cmd.Process.Kill(); _, _ = cmd.Process.Wait() }()
+
+	// Wait for the socket to appear.
+	var sock string
+	deadline := time.Now().Add(20 * time.Second)
+	for sock == "" {
+		if time.Now().After(deadline) {
+			t.Fatal("runner never bound a socket")
+		}
+		for _, name := range leftoverSockets(t, socketDir) {
+			if strings.HasSuffix(name, ".sock") {
+				sock = filepath.Join(socketDir, name)
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	_ = stdout
+
+	// While the runner lives, the lease is held.
+	if _, err := socklease.Acquire(sock); err == nil {
+		t.Fatal("the lease was free while the runner was alive")
+	}
+
+	if err := cmd.Process.Kill(); err != nil {
+		t.Fatal(err)
+	}
+	_, _ = cmd.Process.Wait()
+
+	// After the kill: the pathname is still there (nothing unlinked it) and
+	// the lease is free (the kernel released it). That combination is exactly
+	// what the daemon requires before it will reap.
+	if _, ok := socklease.StatSocket(sock); !ok {
+		t.Fatal("the socket pathname vanished on SIGKILL; the reaper's premise is wrong")
+	}
+	deadline = time.Now().Add(10 * time.Second)
+	for {
+		lease, err := socklease.AcquireExisting(sock)
+		if err == nil {
+			_ = lease.Release()
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("lease never became free after SIGKILL: %v", err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/cli/gmux/internal/ptyserver/incarnation_test.go
+++ b/cli/gmux/internal/ptyserver/incarnation_test.go
@@ -1,0 +1,306 @@
+package ptyserver
+
+// incarnation_test.go — the runner half of endpoint identity.
+//
+// A socket pathname identifies a *location*, not a process. Two things follow,
+// and this file pins both:
+//
+//   - Every response says which runner produced it, so a daemon that makes two
+//     calls to one pathname can tell whether both reached the same process.
+//   - /kill acts only when the caller can name this runner, so a decision made
+//     about one process can never be executed against its successor.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/gmuxapp/gmux/cli/gmux/internal/session"
+)
+
+// runnerClient dials a runner's own socket.
+func runnerClient(sockPath string) *http.Client {
+	return &http.Client{Transport: &http.Transport{
+		DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+			return net.Dial("unix", sockPath)
+		},
+	}}
+}
+
+func startRunner(t *testing.T, sockPath string, command ...string) *Server {
+	t.Helper()
+	srv, err := New(Config{
+		Command:    command,
+		Cwd:        "/tmp",
+		Listener:   mustBindSocket(t, sockPath),
+		SocketPath: sockPath,
+		State:      session.New(session.Config{ID: "sess-test", Command: command, Cwd: "/tmp", Adapter: "shell"}),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(srv.Shutdown)
+	return srv
+}
+
+// Mutation: return a constant (or the empty string) from newIncarnation.
+func TestIncarnationIsUniquePerRunner(t *testing.T) {
+	dir := t.TempDir()
+	a := startRunner(t, filepath.Join(dir, "a.sock"), "bash", "-c", "sleep 30")
+	b := startRunner(t, filepath.Join(dir, "b.sock"), "bash", "-c", "sleep 30")
+
+	if a.Incarnation() == "" || b.Incarnation() == "" {
+		t.Fatal("a runner started without an incarnation")
+	}
+	if a.Incarnation() == b.Incarnation() {
+		t.Fatal("two runners minted the same incarnation")
+	}
+}
+
+// Mutation: drop the withIncarnation middleware, or the /meta splice.
+//
+// Both surfaces matter: the daemon reads the header when it subscribes (the
+// only response it gets for a stream that never ends) and the JSON field when
+// it fetches metadata. Disagreement between them would make the whole
+// same-runner comparison meaningless.
+func TestIncarnationIsReportedOnEveryResponseAndInMeta(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "sess.sock")
+	srv := startRunner(t, sockPath, "bash", "-c", "sleep 30")
+	client := runnerClient(sockPath)
+
+	metaResp, err := client.Get("http://x/meta")
+	if err != nil {
+		t.Fatalf("GET /meta: %v", err)
+	}
+	defer metaResp.Body.Close()
+	if got := metaResp.Header.Get(IncarnationHeader); got != srv.Incarnation() {
+		t.Errorf("/meta header = %q, want %q", got, srv.Incarnation())
+	}
+	var meta map[string]any
+	if err := json.NewDecoder(metaResp.Body).Decode(&meta); err != nil {
+		t.Fatalf("decode /meta: %v", err)
+	}
+	if got, _ := meta["incarnation"].(string); got != srv.Incarnation() {
+		t.Errorf("/meta body incarnation = %q, want %q", got, srv.Incarnation())
+	}
+	// The splice must not disturb the document it splices into.
+	if _, ok := meta["id"]; !ok {
+		t.Error("/meta lost its existing fields")
+	}
+
+	// The stream reports it too, in headers, before any event is sent.
+	req, _ := http.NewRequest(http.MethodGet, "http://x/events", nil)
+	eventsResp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("GET /events: %v", err)
+	}
+	defer eventsResp.Body.Close()
+	if got := eventsResp.Header.Get(IncarnationHeader); got != srv.Incarnation() {
+		t.Errorf("/events header = %q, want %q", got, srv.Incarnation())
+	}
+}
+
+// Mutation: drop the ExpectIncarnationHeader check in handleKill.
+//
+// This is the runner half of the reaper's safety: the daemon classifies one
+// process as an orphan, but can only address it by a pathname another process
+// may own by the time the request lands. The process that answers is the one
+// that checks.
+func TestKillRefusesAnIncarnationThatIsNotOurs(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "sess.sock")
+	srv := startRunner(t, sockPath, "bash", "-c", "trap '' HUP; sleep 30")
+	client := runnerClient(sockPath)
+
+	req, _ := http.NewRequest(http.MethodPost, "http://x/kill", nil)
+	req.Header.Set(ExpectIncarnationHeader, "some-other-runners-incarnation")
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("POST /kill: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("status = %d, want 409 Conflict", resp.StatusCode)
+	}
+
+	// The child is untouched and the runner is still serving.
+	if err := syscall.Kill(srv.cmd.Process.Pid, 0); err != nil {
+		t.Fatalf("the child was killed by a /kill meant for another runner: %v", err)
+	}
+	select {
+	case <-srv.Done():
+		t.Fatal("the runner exited on a /kill meant for another runner")
+	case <-time.After(100 * time.Millisecond):
+	}
+	if _, err := net.DialTimeout("unix", sockPath, time.Second); err != nil {
+		t.Fatalf("the runner stopped serving: %v", err)
+	}
+}
+
+// The positive case, and the compatibility case: a caller that names this
+// runner is obeyed, and so is a caller that names nobody (an explicit user
+// stop, or any client that predates the header).
+func TestKillAcceptsOurOwnIncarnationAndAnAbsentExpectation(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		value func(srv *Server) string
+	}{
+		{"names this runner", func(srv *Server) string { return srv.Incarnation() }},
+		{"names nobody", func(*Server) string { return "" }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sockPath := filepath.Join(t.TempDir(), "sess.sock")
+			srv := startRunner(t, sockPath, "bash", "-c", "sleep 30")
+
+			req, _ := http.NewRequest(http.MethodPost, "http://x/kill", nil)
+			if v := tc.value(srv); v != "" {
+				req.Header.Set(ExpectIncarnationHeader, v)
+			}
+			resp, err := runnerClient(sockPath).Do(req)
+			if err != nil {
+				t.Fatalf("POST /kill: %v", err)
+			}
+			resp.Body.Close()
+			if resp.StatusCode != http.StatusNoContent {
+				t.Fatalf("status = %d, want 204", resp.StatusCode)
+			}
+			select {
+			case <-srv.Done():
+			case <-time.After(10 * time.Second):
+				t.Fatal("the child was not killed")
+			}
+		})
+	}
+}
+
+// A runner that could not mint an incarnation must not become un-killable:
+// the empty incarnation means "unidentifiable", and a caller that names a
+// specific runner is still refused.
+func TestKillRefusesWhenThisRunnerHasNoIncarnation(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "sess.sock")
+	srv := startRunner(t, sockPath, "bash", "-c", "trap '' HUP; sleep 30")
+	srv.incarnation = "" // as if the CSPRNG had failed at startup
+
+	req, _ := http.NewRequest(http.MethodPost, "http://x/kill", nil)
+	req.Header.Set(ExpectIncarnationHeader, "anything")
+	resp, err := runnerClient(sockPath).Do(req)
+	if err != nil {
+		t.Fatalf("POST /kill: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("status = %d, want 409 Conflict", resp.StatusCode)
+	}
+	if err := syscall.Kill(srv.cmd.Process.Pid, 0); err != nil {
+		t.Fatalf("an unidentifiable runner obeyed a targeted kill: %v", err)
+	}
+}
+
+// Mutation: serve /reap from handleKill (i.e. make it unconditional), or drop
+// the mandatory-expectation check.
+//
+// /reap exists as a separate route so that a runner which predates it cannot
+// obey it. Its contract: no expectation is a client error, a mismatched
+// expectation is a conflict, and only the named runner dies.
+func TestReapRequiresAndVerifiesTheExpectedIncarnation(t *testing.T) {
+	t.Run("no expectation", func(t *testing.T) {
+		sockPath := filepath.Join(t.TempDir(), "sess.sock")
+		srv := startRunner(t, sockPath, "bash", "-c", "trap '' HUP; sleep 30")
+		req, _ := http.NewRequest(http.MethodPost, "http://x/reap", nil)
+		resp, err := runnerClient(sockPath).Do(req)
+		if err != nil {
+			t.Fatalf("POST /reap: %v", err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400: an unconditional reap is not on offer", resp.StatusCode)
+		}
+		if err := syscall.Kill(srv.cmd.Process.Pid, 0); err != nil {
+			t.Fatalf("the child died for an unconditional reap: %v", err)
+		}
+	})
+
+	t.Run("another runner's incarnation", func(t *testing.T) {
+		sockPath := filepath.Join(t.TempDir(), "sess.sock")
+		srv := startRunner(t, sockPath, "bash", "-c", "trap '' HUP; sleep 30")
+		req, _ := http.NewRequest(http.MethodPost, "http://x/reap", nil)
+		req.Header.Set(ExpectIncarnationHeader, "some-other-runner")
+		resp, err := runnerClient(sockPath).Do(req)
+		if err != nil {
+			t.Fatalf("POST /reap: %v", err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusConflict {
+			t.Fatalf("status = %d, want 409", resp.StatusCode)
+		}
+		if err := syscall.Kill(srv.cmd.Process.Pid, 0); err != nil {
+			t.Fatalf("the child died for another runner's verdict: %v", err)
+		}
+	})
+
+	t.Run("our own incarnation", func(t *testing.T) {
+		sockPath := filepath.Join(t.TempDir(), "sess.sock")
+		srv := startRunner(t, sockPath, "bash", "-c", "sleep 30")
+		req, _ := http.NewRequest(http.MethodPost, "http://x/reap", nil)
+		req.Header.Set(ExpectIncarnationHeader, srv.Incarnation())
+		resp, err := runnerClient(sockPath).Do(req)
+		if err != nil {
+			t.Fatalf("POST /reap: %v", err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusNoContent {
+			t.Fatalf("status = %d, want 204", resp.StatusCode)
+		}
+		select {
+		case <-srv.Done():
+		case <-time.After(10 * time.Second):
+			t.Fatal("the named runner did not terminate")
+		}
+		// Ownership is handed over, exactly as on the /kill path.
+		if _, err := os.Lstat(sockPath); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("the socket pathname survived a reap: %v", err)
+		}
+	})
+}
+
+// A runner that could not mint an incarnation is unidentifiable, so it can
+// never be the named target of a reap.
+func TestReapRefusesWhenThisRunnerHasNoIncarnation(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "sess.sock")
+	srv := startRunner(t, sockPath, "bash", "-c", "trap '' HUP; sleep 30")
+	srv.incarnation = ""
+
+	req, _ := http.NewRequest(http.MethodPost, "http://x/reap", nil)
+	req.Header.Set(ExpectIncarnationHeader, "anything")
+	resp, err := runnerClient(sockPath).Do(req)
+	if err != nil {
+		t.Fatalf("POST /reap: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("status = %d, want 409", resp.StatusCode)
+	}
+	if err := syscall.Kill(srv.cmd.Process.Pid, 0); err != nil {
+		t.Fatalf("an unidentifiable runner obeyed a targeted reap: %v", err)
+	}
+}
+
+// The header names are a wire contract between two Go modules that cannot
+// import each other: the daemon hardcodes the same literals (see
+// services/gmuxd, runnerIncarnationHeader / expectIncarnationHeader, each
+// pinned by its own test). Renaming a constant on either side is free; changing
+// the literal breaks the protocol, so the literal is what is pinned.
+func TestIncarnationHeaderNamesAreStable(t *testing.T) {
+	if IncarnationHeader != "X-Gmux-Incarnation" {
+		t.Errorf("IncarnationHeader = %q; the daemon reads X-Gmux-Incarnation", IncarnationHeader)
+	}
+	if ExpectIncarnationHeader != "X-Gmux-Expect-Incarnation" {
+		t.Errorf("ExpectIncarnationHeader = %q; the daemon sends X-Gmux-Expect-Incarnation", ExpectIncarnationHeader)
+	}
+}

--- a/cli/gmux/internal/ptyserver/ptyserver.go
+++ b/cli/gmux/internal/ptyserver/ptyserver.go
@@ -4,6 +4,8 @@ package ptyserver
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -26,6 +28,7 @@ import (
 	"github.com/gmuxapp/gmux/cli/gmux/internal/session"
 	"github.com/gmuxapp/gmux/packages/adapter"
 	"github.com/gmuxapp/gmux/packages/adapter/adapters"
+	"github.com/gmuxapp/gmux/packages/socklease"
 	"nhooyr.io/websocket"
 )
 
@@ -34,54 +37,283 @@ import (
 const maxScrollback = 2000
 
 // ErrSocketInUse is returned by BindSocket when the requested socket
-// path is already owned by a live listener (a probe at that path got
-// a response). Callers that received this error from New should pick
-// a different session id and retry. See ADR 0003 "Collision
-// handling".
+// path is already owned by a live listener. Callers should pick a
+// different session id and retry. See ADR 0003 "Collision handling".
 var ErrSocketInUse = errors.New("socket path already in use by a live runner")
 
-// BindSocket creates and listens on a Unix socket at sockPath. The
-// parent directory is created with mode 0o700 if missing, and the
-// socket file itself is owner-only via umask 0o077.
+// BoundSocket is the result of BindSocket. It implements net.Listener and
+// additionally carries the socket ownership lease (see packages/socklease)
+// plus the physical identity of the socket file it created.
 //
-// It distinguishes a stale leftover socket file from a live owner:
-//
-//   - If a live owner answers a probe connection, returns
-//     ErrSocketInUse without touching the file. The caller should
-//     pick a different path.
-//   - Otherwise, removes any stale file and listens.
-//
-// The TOCTOU window between the probe and the listen is harmless in
-// practice: only gmux runners write to socketDir, and a runner that
-// could win the race would itself be subject to this same probe on
-// its next bind attempt.
-func BindSocket(sockPath string) (net.Listener, error) {
-	if probeSocket(sockPath) {
-		return nil, ErrSocketInUse
-	}
-	if err := os.MkdirAll(filepath.Dir(sockPath), 0o700); err != nil {
-		return nil, fmt.Errorf("BindSocket: mkdir %s: %w", filepath.Dir(sockPath), err)
-	}
-	_ = os.Remove(sockPath)
-	oldUmask := syscall.Umask(0o077)
-	defer syscall.Umask(oldUmask)
-	return net.Listen("unix", sockPath)
+// Ownership rule, enforced by every removal path in this package: the
+// canonical pathname may only be unlinked while the lease is held and only
+// while it still names the very socket this process bound. Once ownership is
+// released the pathname belongs to whoever leases it next, and this process
+// must never touch it again -- its listener stays alive on the (now unnamed)
+// inode so in-flight SSE/WebSocket connections can drain.
+type BoundSocket struct {
+	net.Listener
+	lease *socklease.Lease
+	// pin holds the socket file this process bound, so ownership can be given
+	// up by asking "is this still my file?" rather than "does the pathname
+	// still look like it did?". Inode numbers are recycled -- on some
+	// filesystems immediately -- so the second question has a wrong answer
+	// available to it, and the wrong answer unlinks a live replacement.
+	pin          *socklease.Pin
+	sockPath     string
+	releaseOnce  sync.Once
+	releaseError error
 }
 
-// probeSocket returns true if a Unix socket at sockPath accepts
-// connections within a short timeout. Used to distinguish stale
-// socket files from live runners.
-func probeSocket(sockPath string) bool {
-	if _, err := os.Stat(sockPath); err != nil {
-		return false
+// LockPath returns the path of the lease's lock file.
+func (b *BoundSocket) LockPath() string { return socklease.LockPath(b.sockPath) }
+
+// ReleaseOwnership unlinks the canonical pathname -- but only while it still
+// names the socket this BoundSocket bound -- and then drops the lease. It is
+// idempotent and safe to call from several goroutines.
+//
+// It deliberately does not close the listener: after ownership is released the
+// listener lives on as an unnamed socket so already-established connections
+// (notably the daemon's exit-event subscription) can drain, while a
+// replacement runner is free to lease and bind the pathname immediately.
+func (b *BoundSocket) ReleaseOwnership() error {
+	if b == nil {
+		return nil
 	}
-	conn, err := net.DialTimeout("unix", sockPath, 250*time.Millisecond)
-	if err != nil {
-		return false
-	}
-	conn.Close()
-	return true
+	b.releaseOnce.Do(func() {
+		rmErr := b.lease.RemoveSocket(b.pin)
+		b.releaseError = errors.Join(rmErr, b.pin.Close(), b.lease.Release())
+	})
+	return b.releaseError
 }
+
+// leaseWaitBudget bounds how long BindSocket waits for a lease somebody else
+// holds. It exists for the daemon's stale-socket reaper, which holds the lease
+// for the length of one inspection; without the wait, a runner that starts
+// inside that window falls back to a fresh session id and a restart loses its
+// identity to a bookkeeping sweep.
+const leaseWaitBudget = 750 * time.Millisecond
+
+// bindAttempts bounds the bind/clean-up/retry loop. Each extra iteration
+// requires another actor to have taken the pathname in the microseconds
+// between our unlink and our listen.
+const bindAttempts = 8
+
+// bindBarrierHook is a barrier hook for the mixed-version bind tests: it runs at
+// each named phase of BindSocket so a test can drive a pre-lease runner into the
+// exact window it wants. It is unset in production.
+//
+// It carries the socket pathname, and is read under a mutex, for the same
+// reasons the daemon's reaper barrier does: binds happen on several goroutines
+// (and in several tests) at once, so a hook that fired for any pathname would be
+// driven by whichever bind reached the phase first, and a plain variable would be
+// a data race between one test's install and another's read. The hook is copied
+// out before it is called, so a barrier that blocks never holds the lock.
+var bindBarrierHook struct {
+	mu sync.Mutex
+	fn func(sockPath, phase string)
+}
+
+func bindBarrier(sockPath, phase string) {
+	bindBarrierHook.mu.Lock()
+	fn := bindBarrierHook.fn
+	bindBarrierHook.mu.Unlock()
+	if fn != nil {
+		fn(sockPath, phase)
+	}
+}
+
+// setBindBarrier installs the barrier hook, replacing any previous one.
+func setBindBarrier(fn func(sockPath, phase string)) {
+	bindBarrierHook.mu.Lock()
+	bindBarrierHook.fn = fn
+	bindBarrierHook.mu.Unlock()
+}
+
+// BindSocket creates and listens on a Unix socket at sockPath under the socket
+// ownership lease.
+//
+// The lease makes stale-socket cleanup safe *between lease-aware processes*:
+// holding it excludes every other runner and the daemon's reaper, so the
+// pathname cannot change owner while we work on it. It says nothing at all
+// about a runner from before the protocol, which holds no lease and is
+// excluded by nothing. That asymmetry decides the whole algorithm:
+//
+//	bind first, and only clean up after a generation we can prove was
+//	lease-aware.
+//
+// Concretely:
+//
+//  1. Take the lease (waiting briefly if the reaper holds it).
+//  2. Try to listen *without unlinking anything*. A free pathname binds here,
+//     which is the overwhelmingly common case.
+//  3. EADDRINUSE means something occupies the pathname. If we had to create
+//     the lock file, no lease-aware generation ever owned this pathname: its
+//     occupant is an unleased runner, possibly one that is mid-startup right
+//     now, and unlinking it would disconnect a live listener. Refuse with
+//     ErrSocketInUse and let the caller pick a different id (ADR 0003).
+//  4. If the lock file already existed, a lease-aware generation owned this
+//     pathname and is provably not running (we hold its lease). Probe anyway
+//     -- an unleased runner may have taken the pathname over since -- and only
+//     if nothing answers, unlink the exact inode we probed and try again.
+//
+// What this buys, and it is the property the earlier probe-then-unlink version
+// could not claim: no pathname belonging to a live pre-lease runner is ever
+// unlinked, at any interleaving.
+func BindSocket(sockPath string) (*BoundSocket, error) {
+	// The lease protocol assumes a directory only this user can write in; if
+	// that is not true, nothing below proves anything (see socklease's threat
+	// model). Establish it here, where the directory is created.
+	if err := socklease.RequireOwnedDir(filepath.Dir(sockPath)); err != nil {
+		return nil, fmt.Errorf("BindSocket: %w", err)
+	}
+	lease, err := socklease.AcquireWait(sockPath, leaseWaitBudget)
+	if errors.Is(err, socklease.ErrHeld) {
+		return nil, ErrSocketInUse
+	}
+	if err != nil {
+		return nil, fmt.Errorf("BindSocket: lease: %w", err)
+	}
+	bindBarrier(sockPath, "lease-held")
+
+	for range bindAttempts {
+		ln, listenErr := listenUnixOwnerOnly(sockPath)
+		if listenErr == nil {
+			// Pin the socket we just bound, and hold the pin for as long as we
+			// own the pathname: it is what lets Shutdown unlink our own socket
+			// and nobody else's, even if the number is handed out again.
+			pin, pinErr := lease.PinSocket()
+			if pinErr != nil {
+				// The pathname we just bound is not a socket any more.
+				// Something outside the protocol is rewriting the directory;
+				// refuse to own a pathname we cannot identify rather than
+				// unlink it later on a guess.
+				_ = ln.Close()
+				releaseAfterFailedBind(lease, false)
+				return nil, fmt.Errorf("BindSocket: %s vanished or is not a socket right after listen: %w", sockPath, pinErr)
+			}
+			return &BoundSocket{Listener: ln, lease: lease, pin: pin, sockPath: sockPath}, nil
+		}
+		if !errors.Is(listenErr, syscall.EADDRINUSE) {
+			releaseAfterFailedBind(lease, false)
+			return nil, fmt.Errorf("BindSocket: listen: %w", listenErr)
+		}
+		bindBarrier(sockPath, "address-in-use")
+
+		if lease.CreatedLockFile() {
+			// No lease-aware generation ever owned this pathname, so its
+			// occupant is outside the protocol. Never unlink it.
+			releaseAfterFailedBind(lease, true)
+			return nil, ErrSocketInUse
+		}
+
+		// A lease-aware generation owned this pathname and is gone. Confirm
+		// nothing answers before touching it: an unleased runner may have
+		// taken the pathname over in the meantime, and it is not ours to
+		// remove.
+		// Pin the occupant *before* probing it, so the removal below can be
+		// conditioned on the file we probed rather than on a description of it.
+		// A pre-lease runner may replace the pathname between the two, and on a
+		// filesystem that recycles inodes its socket can carry the very same
+		// device and inode -- which is how an identity check came to unlink a
+		// live runner.
+		stale, pinErr := socklease.PinSocket(sockPath)
+		if pinErr != nil {
+			// Whatever occupies the pathname now, it is not the socket the
+			// lease-aware generation left: that history is stale.
+			releaseAfterFailedBind(lease, true)
+			return nil, fmt.Errorf("BindSocket: %s is occupied by something that is not a socket: %w", sockPath, pinErr)
+		}
+		bindBarrier(sockPath, "before-probe")
+		// Only an explicit refusal authorises the removal below. A timeout, a
+		// permission error, or a successful connect all mean the occupant is
+		// not provably gone -- and a timeout in particular is a live owner
+		// with a full backlog, not a dead one. This is the same predicate the
+		// daemon's reaper uses, deliberately: an asymmetry here is how a live
+		// socket gets unlinked by one side and spared by the other.
+		//
+		// Probed through the pin rather than the pathname: pin-then-probe is
+		// the load-bearing order, and passing the pin is what makes the other
+		// order unexpressible (socklease.ProbeRefusedPinned).
+		probeErr := probeRefusedUnderPin(sockPath, stale)
+		if probeErr != nil {
+			// A live occupant with a free lease is an unleased runner that
+			// took this pathname over, so the lease history describes a dead
+			// generation rather than the occupant: drop it. Anything else
+			// taught us nothing, so keep it.
+			_ = stale.Close()
+			releaseAfterFailedBind(lease, errors.Is(probeErr, socklease.ErrSocketLive))
+			return nil, ErrSocketInUse
+		}
+		bindBarrier(sockPath, "before-remove")
+		// Identity-checked: if the pathname was rebound since the probe, the
+		// removal is declined and the next iteration probes the newcomer
+		// instead of unlinking it.
+		rmErr := lease.RemoveSocket(stale)
+		_ = stale.Close()
+		if rmErr != nil && !errors.Is(rmErr, socklease.ErrIdentityChanged) {
+			releaseAfterFailedBind(lease, false)
+			return nil, fmt.Errorf("BindSocket: removing stale socket: %w", rmErr)
+		}
+	}
+	releaseAfterFailedBind(lease, false)
+	return nil, fmt.Errorf("BindSocket: %s was re-taken on every attempt", sockPath)
+}
+
+// releaseAfterFailedBind drops a lease taken by a bind that did not happen.
+//
+// The lock file is removed when this attempt created it -- leaving it would
+// invent a lease-aware history for a pathname that never had one -- or when
+// the attempt proved the current occupant is not lease-aware, which makes any
+// existing history false. Otherwise the lock file is left exactly as found:
+// erasing it would make a genuinely reclaimable leftover permanently
+// unreclaimable.
+func releaseAfterFailedBind(lease *socklease.Lease, occupantProvenUnleased bool) {
+	if lease.CreatedLockFile() || occupantProvenUnleased {
+		_ = lease.Release()
+		return
+	}
+	_ = lease.ReleaseKeepingLockFile()
+}
+
+// listenUnixOwnerOnly binds sockPath with an owner-only mode and without Go's
+// automatic unlink-on-close: in this package every removal of a canonical
+// pathname is explicit, leased and identity-checked.
+func listenUnixOwnerOnly(sockPath string) (net.Listener, error) {
+	oldUmask := syscall.Umask(0o077)
+	ln, err := net.Listen("unix", sockPath)
+	syscall.Umask(oldUmask)
+	if err != nil {
+		return nil, err
+	}
+	if ul, ok := ln.(*net.UnixListener); ok {
+		ul.SetUnlinkOnClose(false)
+	}
+	return ln, nil
+}
+
+// probeRefusedUnderPin probes the leftover the pin holds.
+//
+// The pin is a parameter, not something this function takes for itself, because
+// pin-then-probe is the load-bearing order and a signature guards an order
+// better than a comment does: there is nothing to pass if the pin has not been
+// taken yet.
+//
+// The barrier fires here, at the end of the probe step, rather than at the call
+// site. That placement is deliberate -- it is the only point a caller cannot get
+// in front of. A caller that pinned *after* probing would have its pin land
+// after this line, so a test can hand the pathname to a live unleased runner
+// here and watch such a caller pin, and then unlink, the newcomer.
+func probeRefusedUnderPin(sockPath string, pin *socklease.Pin) error {
+	err := socklease.ProbeRefusedPinned(pin, probeTimeout)
+	bindBarrier(sockPath, "probed")
+	return err
+}
+
+// probeTimeout bounds the connect used to decide whether a leftover pathname
+// is abandoned. It runs while the lease is held, so it also bounds how long a
+// replacement runner can be kept waiting.
+const probeTimeout = 250 * time.Millisecond
 
 // newScreen builds the replay emulator and starts the DSR drain goroutine. It
 // returns the emulator and a channel that is closed when the drain goroutine
@@ -184,10 +416,14 @@ type ResizeMsg struct {
 
 // Server holds a PTY and serves WebSocket connections.
 type Server struct {
-	cmd             *exec.Cmd
-	ptmx            *os.File
-	sockPath        string
-	listener        net.Listener
+	cmd      *exec.Cmd
+	ptmx     *os.File
+	sockPath string
+	listener net.Listener
+	// bound carries socket pathname ownership (lease + bound identity). It is
+	// nil when a test injected a bare listener; such a server owns no
+	// pathname and must never unlink one.
+	bound           *BoundSocket
 	screen          *vt.Emulator  // virtual terminal for replay snapshots (guarded by mu)
 	screenDrainDone chan struct{} // closed when the DSR drain goroutine exits
 	state           *session.State
@@ -197,6 +433,11 @@ type Server struct {
 	// the runner's default turn model). Nil for hook-driven sessions. Fed
 	// exclusively from readPTY's flush, so it needs no locking.
 	promptMarks *adapter.PromptMarkTracker
+
+	// incarnation is this runner's ephemeral identity: a random value minted
+	// once per process, exposed on every HTTP response and in /meta, and
+	// required as proof by /kill. See newIncarnation.
+	incarnation string
 
 	shutdownOnce sync.Once
 
@@ -354,24 +595,36 @@ func New(cfg Config) (*Server, error) {
 	})
 	if err != nil {
 		listener.Close()
-		os.Remove(cfg.SocketPath)
+		if bs, ok := listener.(*BoundSocket); ok {
+			// Leased removal: the pathname is only unlinked while it still
+			// names the socket we bound.
+			if relErr := bs.ReleaseOwnership(); relErr != nil {
+				log.Printf("ptyserver: releasing %s after failed pty start: %v", cfg.SocketPath, relErr)
+			}
+		}
 		return nil, fmt.Errorf("start pty: %w", err)
 	}
 
 	s := &Server{
-		cmd:        cmd,
-		ptmx:       ptmx,
-		sockPath:   cfg.SocketPath,
-		listener:   listener,
-		screen:     nil, // set below after s is constructed
-		state:      cfg.State,
-		clients:    make(map[*wsClient]struct{}),
-		localOut:   cfg.LocalOut,   // wired before readPTY starts so early output is never lost
-		scrollback: cfg.Scrollback, // same: wired pre-readPTY so fast-exit output is never lost
-		ptyCols:    cfg.Cols,
-		ptyRows:    cfg.Rows,
-		done:       make(chan struct{}),
-		ptyDone:    make(chan struct{}),
+		cmd:         cmd,
+		ptmx:        ptmx,
+		sockPath:    cfg.SocketPath,
+		listener:    listener,
+		screen:      nil, // set below after s is constructed
+		state:       cfg.State,
+		clients:     make(map[*wsClient]struct{}),
+		localOut:    cfg.LocalOut,   // wired before readPTY starts so early output is never lost
+		scrollback:  cfg.Scrollback, // same: wired pre-readPTY so fast-exit output is never lost
+		ptyCols:     cfg.Cols,
+		ptyRows:     cfg.Rows,
+		done:        make(chan struct{}),
+		ptyDone:     make(chan struct{}),
+		incarnation: newIncarnation(),
+	}
+	// Retain the ownership handle from BindSocket. Tests may inject a bare
+	// net.Listener; those servers own no pathname and never unlink one.
+	if bs, ok := listener.(*BoundSocket); ok {
+		s.bound = bs
 	}
 
 	// The callback fires under s.mu (held during drainScreenLocked → screen.Write).
@@ -532,14 +785,48 @@ func (s *Server) Resize(cols, rows uint16) {
 	s.resize(ResizeMsg{Cols: cols, Rows: rows, Source: "local_tty"})
 }
 
-// Shutdown closes the listener and all connections.
+// releaseSocketOwnership gives up the canonical socket pathname: it unlinks
+// the pathname while the lease still names this server's own socket, then
+// releases the lease so a replacement runner can bind immediately.
+//
+// It is idempotent, and it is the *only* place in the runner that unlinks a
+// canonical pathname. Both callers (the /kill handler, which releases early so
+// a restart's replacement runner never has to wait, and Shutdown, which covers
+// every other exit) may run concurrently.
+func (s *Server) releaseSocketOwnership(reason string) {
+	if s.bound == nil {
+		return // test-injected listener: this server owns no pathname
+	}
+	if err := s.bound.ReleaseOwnership(); err != nil {
+		log.Printf("ptyserver: %s: releasing socket %s: %v", reason, s.sockPath, err)
+	}
+}
+
+// Shutdown releases socket ownership, then closes the listener and all
+// connections.
+//
+// Ownership protocol:
+//
+//  1. Unlink the canonical pathname while holding the lease and only while it
+//     still names this server's socket, then drop the lease. A concurrent
+//     BindSocket cannot observe a half-released pathname: it either fails to
+//     take the lease (pathname still ours) or takes it after the unlink.
+//  2. Close the listener. Existing connections are unaffected by the unlink;
+//     closing the listener only stops new ones.
+//
+// Ordering note (resume/restart safety): the daemon learns a session died from
+// the runner's exit event, which run.go emits *before* it deregisters and
+// calls Shutdown. A restart therefore spawns the replacement runner while this
+// process is still finishing up -- which is exactly why /kill releases
+// ownership before it responds instead of waiting for Shutdown.
 func (s *Server) Shutdown() {
 	// Idempotent: Shutdown can now be invoked from more than one
 	// goroutine — a signal handler and the registration goroutine's
 	// fatal-rejection reap can race — so the whole teardown runs once.
 	s.shutdownOnce.Do(func() {
+		s.releaseSocketOwnership("shutdown")
+		// Close the listener. Existing connections are not affected.
 		s.listener.Close()
-		os.Remove(s.sockPath)
 
 		s.mu.Lock()
 		// Close ptmx and mark it closed under mu. pty.Setsize (setPtySize) calls
@@ -570,6 +857,55 @@ func (s *Server) setPtySize(ws *pty.Winsize) {
 	_ = pty.Setsize(s.ptmx, ws)
 }
 
+// IncarnationHeader carries the runner's ephemeral incarnation on every
+// response, so a client learns which runner answered without a second request.
+// ExpectIncarnationHeader carries a client's requirement back: /kill acts only
+// if the value names this runner.
+const (
+	IncarnationHeader       = "X-Gmux-Incarnation"
+	ExpectIncarnationHeader = "X-Gmux-Expect-Incarnation"
+)
+
+// newIncarnation mints a runner's ephemeral identity.
+//
+// It exists because a socket pathname, and even a socket inode, cannot
+// identify the process behind an endpoint. A pathname is reusable; an inode
+// can be hard-linked, unlinked and restored. A daemon that talks to an
+// endpoint twice -- Subscribe, then Meta -- has no filesystem evidence that
+// both calls reached the same runner, and stat-bracketing the pair only proves
+// the pathname looked the same before and after.
+//
+// The nonce closes that: it is minted once per runner process and returned
+// with every response, so two calls that report the same incarnation provably
+// reached the same runner. It is deliberately ephemeral -- never persisted,
+// never reused across restarts -- because its whole job is to distinguish this
+// process from its own successor at the same pathname.
+//
+// A failure to read the system CSPRNG degrades to the empty string, which
+// every consumer treats as "unknown", exactly like a runner that predates the
+// protocol: conservative, never a match.
+func newIncarnation() string {
+	var buf [16]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		log.Printf("ptyserver: cannot mint an incarnation (%v); the daemon will treat this runner as unidentifiable", err)
+		return ""
+	}
+	return hex.EncodeToString(buf[:])
+}
+
+// Incarnation returns this runner's ephemeral identity.
+func (s *Server) Incarnation() string { return s.incarnation }
+
+// withIncarnation stamps every response with the runner's identity.
+func (s *Server) withIncarnation(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if s.incarnation != "" {
+			w.Header().Set(IncarnationHeader, s.incarnation)
+		}
+		h.ServeHTTP(w, r)
+	})
+}
+
 func (s *Server) serve() {
 	mux := http.NewServeMux()
 
@@ -581,11 +917,12 @@ func (s *Server) serve() {
 	mux.HandleFunc("PUT /slug", s.handlePutSlug)
 	mux.HandleFunc("GET /events", s.handleEvents)
 	mux.HandleFunc("POST /kill", s.handleKill)
+	mux.HandleFunc("POST /reap", s.handleReap)
 
 	// WebSocket terminal attach (fallback for / with Upgrade header)
 	mux.HandleFunc("/", s.handleWS)
 
-	server := &http.Server{Handler: mux}
+	server := &http.Server{Handler: s.withIncarnation(mux)}
 	server.Serve(s.listener)
 }
 
@@ -594,6 +931,19 @@ func (s *Server) handleMeta(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
+	}
+	// Splice the incarnation in rather than adding it to session.State: the
+	// nonce belongs to this runner process, not to the session, and State is
+	// the session's own document. Decoding to RawMessage keeps every existing
+	// field byte-identical.
+	if s.incarnation != "" {
+		var obj map[string]json.RawMessage
+		if json.Unmarshal(data, &obj) == nil {
+			obj["incarnation"], _ = json.Marshal(s.incarnation)
+			if merged, mErr := json.Marshal(obj); mErr == nil {
+				data = merged
+			}
+		}
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.Write(data)
@@ -797,7 +1147,55 @@ func (s *Server) handlePutSlug(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
+// handleReap is termination conditional on identity, and it exists as a
+// separate route from /kill for one reason: a runner that predates this
+// protocol must be *unable* to obey it.
+//
+// The daemon's orphan reaper decides about one specific process and then has
+// to address it by pathname. Pathnames are reusable, so the occupant at
+// delivery time may be somebody else. Asking /kill and adding a header does
+// not solve that in a mixed-version fleet: a pre-protocol runner ignores
+// unknown headers and dies for a verdict passed on a different process. A
+// route it does not serve, by contrast, answers 404 and does nothing at all.
+// So the reaper only ever calls this route, and 404 is a safe, informative
+// answer that no legacy runner can get wrong.
+//
+// The expectation is mandatory here -- an unconditional reap is not a thing
+// this endpoint offers.
+func (s *Server) handleReap(w http.ResponseWriter, r *http.Request) {
+	want := r.Header.Get(ExpectIncarnationHeader)
+	if want == "" {
+		http.Error(w, "reap requires "+ExpectIncarnationHeader, http.StatusBadRequest)
+		return
+	}
+	if want != s.incarnation {
+		log.Printf("ptyserver: refusing a reap meant for incarnation %s; this runner is %s", want, s.incarnation)
+		http.Error(w, "incarnation mismatch: this pathname is owned by a different runner", http.StatusConflict)
+		return
+	}
+	s.terminateChild(w)
+}
+
 func (s *Server) handleKill(w http.ResponseWriter, r *http.Request) {
+	// /kill is the compatibility route: an explicit, user-initiated stop of
+	// whoever owns this endpoint. It honours an expectation when one is given
+	// -- a caller that knows which runner it means gets the stronger
+	// behaviour -- but an absent header keeps the original semantics, which
+	// `gmux kill` and every pre-protocol client rely on.
+	//
+	// A caller whose decision was made about one specific process earlier must
+	// not use this route at all: see handleReap.
+	if want := r.Header.Get(ExpectIncarnationHeader); want != "" && want != s.incarnation {
+		log.Printf("ptyserver: refusing /kill meant for incarnation %s; this runner is %s", want, s.incarnation)
+		http.Error(w, "incarnation mismatch: this pathname is owned by a different runner", http.StatusConflict)
+		return
+	}
+	s.terminateChild(w)
+}
+
+// terminateChild is the shared body of /kill and /reap: signal the child, wait
+// for it, hand the socket pathname over, and answer.
+func (s *Server) terminateChild(w http.ResponseWriter) {
 	if s.cmd.Process == nil {
 		w.WriteHeader(http.StatusNoContent)
 		return
@@ -812,7 +1210,7 @@ func (s *Server) handleKill(w http.ResponseWriter, r *http.Request) {
 	log.Printf("ptyserver: sent SIGHUP to child pid %d", pid)
 
 	// Block until the child actually exits (or escalate). Dismiss/restart
-	// callers rely on this: once /kill returns, gmuxd immediately removes
+	// callers rely on this: once this returns, gmuxd immediately removes
 	// the session and expects the runner's socket path to be free.
 	// Returning early while a shell (e.g. fish) ignores SIGHUP causes
 	// the next discovery scan to re-register the dead session.
@@ -824,22 +1222,21 @@ func (s *Server) handleKill(w http.ResponseWriter, r *http.Request) {
 		<-s.done
 	}
 
-	// Release the canonical socket path before responding. The runner
-	// process will linger briefly for state.SetExited / deregister /
-	// scrollback close, and its listener stays up on the inode for the
-	// existing SSE/WS connections that need to drain (notably the
-	// daemon's exit-event subscription). But the path is unreachable
-	// to new dialers, so a daemon launching a replacement runner under
-	// the same id (resume / restart, see ADR 0003) can BindSocket
-	// without racing against this runner's shutdown sequence.
+	// Release the canonical socket path — and the lease with it — before
+	// responding. The runner process will linger briefly for
+	// state.SetExited / deregister / scrollback close, and its listener stays
+	// up on the (now unnamed) inode for the existing SSE/WS connections that
+	// need to drain, notably the daemon's exit-event subscription.
 	//
-	// Idempotent: a later os.Remove on the missing path is harmless;
-	// any normal-exit code path that also tries to clean up the path
-	// (Server.Shutdown's signal-handler call, or the kernel on
-	// process exit) finds it already gone.
-	if err := os.Remove(s.sockPath); err != nil && !os.IsNotExist(err) {
-		log.Printf("ptyserver: kill: remove sockfile %s: %v", s.sockPath, err)
-	}
+	// Releasing the lease here, rather than in Shutdown, is load-bearing: the
+	// daemon's restart path observes death from the exit event this runner is
+	// about to emit and spawns the replacement immediately. If the dying
+	// runner still held the lease at that moment, the replacement's
+	// BindSocket would fail with ErrSocketInUse and fall back to a fresh
+	// session id (ADR 0003), silently breaking restart identity. Once
+	// released, this process never touches the pathname again: Shutdown's
+	// removal is idempotent and cannot unlink the replacement's socket.
+	s.releaseSocketOwnership("terminate")
 	w.WriteHeader(http.StatusNoContent)
 }
 

--- a/cli/gmux/internal/ptyserver/ptyserver_test.go
+++ b/cli/gmux/internal/ptyserver/ptyserver_test.go
@@ -33,6 +33,10 @@ func mustBindSocket(t *testing.T, sockPath string) net.Listener {
 	if err != nil {
 		t.Fatalf("BindSocket %s: %v", sockPath, err)
 	}
+	// Release the lease at the end of the test even when the test never
+	// shuts the server down, so a leaked lease cannot make an unrelated
+	// later test see ErrSocketInUse.
+	t.Cleanup(func() { _ = ln.ReleaseOwnership() })
 	return ln
 }
 
@@ -1474,19 +1478,26 @@ func TestNewSpawnsChildWithComposedEnv(t *testing.T) {
 }
 
 func TestBindSocketStaleFile(t *testing.T) {
-	// A leftover socket file with no listener is not a real owner;
-	// BindSocket should remove it and listen successfully.
+	// A leftover pathname whose lease-aware owner is gone (socket file plus
+	// its lock file, the state a SIGKILLed runner leaves) is reclaimable:
+	// holding the lease proves that owner is not running.
+	//
+	// Note the change of premise from the pre-lease version of this test,
+	// which cleared *any* occupant. An occupant with no lock file is no
+	// longer removed at all, because nothing proves it is not a live runner
+	// from before this protocol -- see TestBindSocketRefusesUnleasedOccupant.
 	dir := t.TempDir()
 	sockPath := filepath.Join(dir, "stale.sock")
-	if err := os.WriteFile(sockPath, []byte("not a socket"), 0o600); err != nil {
-		t.Fatal(err)
-	}
+	stale := crashedLeaseAwareSocket(t, sockPath)
 
 	ln, err := BindSocket(sockPath)
 	if err != nil {
-		t.Fatalf("BindSocket on stale file: %v", err)
+		t.Fatalf("BindSocket on a lease-aware stale socket: %v", err)
 	}
 	defer ln.Close()
+	if fresh := mustIdent(t, sockPath); fresh.Same(stale) {
+		t.Fatal("BindSocket reused the stale socket instead of rebinding")
+	}
 
 	// A second bind on the same path should now see a live owner
 	// (the first listener) and refuse with ErrSocketInUse.
@@ -1576,14 +1587,17 @@ func TestKillReleasesSocketPathBeforeResponding(t *testing.T) {
 	if _, err := os.Stat(sockPath); !os.IsNotExist(err) {
 		t.Errorf("socket path still exists after /kill returned 204: %v", err)
 	}
-
-	// And a fresh BindSocket on the same path must succeed:
-	// path is gone, no live owner.
+	// And a fresh BindSocket on the same path must succeed *without* waiting
+	// for the old runner's Shutdown: the daemon spawns the restart
+	// replacement as soon as it sees the exit event, which the old runner
+	// emits well before it shuts down. /kill therefore has to hand over the
+	// lease, not just unlink the pathname.
 	ln, err := BindSocket(sockPath)
 	if err != nil {
-		t.Fatalf("BindSocket after /kill: %v", err)
+		t.Fatalf("BindSocket after /kill: %v (the dying runner still owns the socket lease)", err)
 	}
-	ln.Close()
+	ln.Listener.Close()
+	_ = ln.ReleaseOwnership()
 }
 
 // TestBuildChildEnv_StripsResumeID guards the runner→child boundary
@@ -1767,10 +1781,10 @@ func TestShutdownIdempotent(t *testing.T) {
 // without embedding a path-dependent binary reference.
 type hookTestAdapter struct{}
 
-func (hookTestAdapter) Name() string                            { return "test-hook" }
-func (hookTestAdapter) Discover() bool                          { return false }
-func (hookTestAdapter) Match([]string) bool                     { return false }
-func (hookTestAdapter) Env(adapter.EnvContext) []string         { return nil }
+func (hookTestAdapter) Name() string                    { return "test-hook" }
+func (hookTestAdapter) Discover() bool                  { return false }
+func (hookTestAdapter) Match([]string) bool             { return false }
+func (hookTestAdapter) Env(adapter.EnvContext) []string { return nil }
 func (hookTestAdapter) HookCommand(args []string, _ string) ([]string, bool) {
 	// Append a fixed marker that does NOT start with '-' so Go flag.Parse in
 	// the subprocess helper treats it as a non-flag positional argument.

--- a/cli/gmux/internal/ptyserver/socket_ownership_test.go
+++ b/cli/gmux/internal/ptyserver/socket_ownership_test.go
@@ -1,0 +1,660 @@
+package ptyserver
+
+// socket_ownership_test.go — mutation-grade tests for canonical socket
+// pathname ownership (see packages/socklease for the protocol itself).
+//
+// The invariants under test:
+//
+//   - BindSocket owns the pathname for as long as it holds the lease, and no
+//     second runner — lease-aware or not — can bind underneath it.
+//   - Every removal of the pathname is leased and identity-checked, so an
+//     exiting runner can never unlink a replacement runner's socket.
+//   - /kill hands ownership over before it answers, because the daemon spawns
+//     the restart replacement as soon as it sees the exit event.
+//   - An ordinary exit leaves no pathname and no lock file behind.
+//
+// Each test names the production mutation it is designed to catch.
+
+import (
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/gmuxapp/gmux/packages/socklease"
+)
+
+// mustBind calls BindSocket and fails the test on error.
+func mustBind(t *testing.T, sockPath string) *BoundSocket {
+	t.Helper()
+	b, err := BindSocket(sockPath)
+	if err != nil {
+		t.Fatalf("BindSocket(%s): %v", sockPath, err)
+	}
+	t.Cleanup(func() {
+		_ = b.Listener.Close()
+		_ = b.ReleaseOwnership()
+	})
+	return b
+}
+
+// mustIdent returns the identity of a socket pathname, failing if it is not a
+// socket.
+func mustIdent(t *testing.T, path string) socklease.Ident {
+	t.Helper()
+	id, ok := socklease.StatSocket(path)
+	if !ok {
+		t.Fatalf("%s is not a socket", path)
+	}
+	return id
+}
+
+// runToCompletion starts a server around a trivial command and waits for the
+// PTY to finish, leaving the socket bound and the server ready for Shutdown.
+func runToCompletion(t *testing.T, sockPath string) *Server {
+	t.Helper()
+	srv, err := New(Config{
+		Command:    []string{"true"},
+		Cwd:        "/tmp",
+		Listener:   mustBind(t, sockPath),
+		SocketPath: sockPath,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	select {
+	case <-srv.PTYDone():
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for the child to exit")
+	}
+	return srv
+}
+
+// Mutation: drop the socklease.Acquire call (or ignore ErrHeld) in BindSocket.
+func TestBindSocketExcludesSecondRunner(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "sess.sock")
+	first := mustBind(t, sockPath)
+
+	_, err := BindSocket(sockPath)
+	if !errors.Is(err, ErrSocketInUse) {
+		t.Fatalf("second BindSocket = %v, want ErrSocketInUse", err)
+	}
+	// The first runner's socket is untouched by the rejected attempt.
+	if _, ok := socklease.StatSocket(sockPath); !ok {
+		t.Fatal("rejected BindSocket removed the incumbent's socket")
+	}
+	_ = first
+}
+
+// Mixed-version guard. A runner from before the lease protocol holds no lease,
+// so the lease alone says "free" while a live listener still answers. Binding
+// anyway would unlink a live older runner's socket and strand it.
+//
+// Mutation: delete the refusal probe in BindSocket.
+func TestBindSocketRejectsLiveUnleasedSocket(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "legacy.sock")
+
+	// A "pre-lease runner": a live listener with no lock file anywhere.
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			_ = c.Close()
+		}
+	}()
+	before := mustIdent(t, sockPath)
+
+	if _, err := BindSocket(sockPath); !errors.Is(err, ErrSocketInUse) {
+		t.Fatalf("BindSocket over a live unleased socket = %v, want ErrSocketInUse", err)
+	}
+	after := mustIdent(t, sockPath)
+	if after != before {
+		t.Fatal("BindSocket rebound a pathname owned by a live unleased runner")
+	}
+	// The rejected attempt must not leave a lock file behind either: the
+	// daemon reads its absence as "owner is not lease-aware, never reap".
+	if _, err := os.Lstat(socklease.LockPath(sockPath)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("rejected BindSocket left a lock file: %v", err)
+	}
+}
+
+// crashedLeaseAwareSocket reproduces what a SIGKILLed runner leaves behind: a
+// socket pathname nobody listens on, and its lock file, unheld (the kernel
+// drops flock on death but never unlinks the file). It returns the stale
+// socket's identity.
+func crashedLeaseAwareSocket(t *testing.T, sockPath string) socklease.Ident {
+	t.Helper()
+	lease, err := socklease.Acquire(sockPath)
+	if err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	ln.(*net.UnixListener).SetUnlinkOnClose(false)
+	id := mustIdent(t, sockPath)
+	_ = ln.Close()
+	// Drop the lease the way process death does, leaving the lock file.
+	if err := lease.Release(); err != nil {
+		t.Fatalf("release: %v", err)
+	}
+	if err := os.WriteFile(socklease.LockPath(sockPath), nil, 0o600); err != nil {
+		t.Fatalf("restore lock file: %v", err)
+	}
+	return id
+}
+
+// A pathname whose lease-aware owner crashed is reclaimable: we hold that
+// owner's lease, so it is provably gone.
+func TestBindSocketReplacesStaleSocket(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "stale.sock")
+	stale := crashedLeaseAwareSocket(t, sockPath)
+
+	b := mustBind(t, sockPath)
+	fresh := mustIdent(t, sockPath)
+	if fresh.Same(stale) {
+		t.Fatal("BindSocket reused the stale socket instead of rebinding")
+	}
+	// The bound socket is pinned, and the pin claims the pathname: that is what
+	// authorises this runner -- and only this runner -- to unlink it later.
+	if !b.pin.StillNamesIt() {
+		t.Fatal("BoundSocket's pin does not claim the socket it bound")
+	}
+	if b.pin.Ident() != fresh {
+		t.Fatalf("BoundSocket pin holds %s, bound socket is %s", b.pin.Ident(), fresh)
+	}
+}
+
+// Mutation: remove the CreatedLockFile gate, so an occupant with no lease
+// history is probed and unlinked like a lease-aware leftover.
+//
+// A pathname occupied with no lock file anywhere means no lease-aware
+// generation ever owned it. Its occupant is therefore outside the protocol,
+// excluded by nothing, and possibly *mid-startup right now* -- the one case a
+// probe cannot see and a lease cannot serialise. It is never removed, whatever
+// it is; the caller falls back to a fresh session id (ADR 0003).
+func TestBindSocketRefusesUnleasedOccupant(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		prepare func(t *testing.T, path string)
+	}{
+		{"stale socket from a pre-lease runner", func(t *testing.T, path string) {
+			ln, err := net.Listen("unix", path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			ln.(*net.UnixListener).SetUnlinkOnClose(false)
+			_ = ln.Close()
+		}},
+		{"live socket from a pre-lease runner", func(t *testing.T, path string) {
+			ln, err := net.Listen("unix", path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = ln.Close() })
+		}},
+		{"a file that is not a socket at all", func(t *testing.T, path string) {
+			if err := os.WriteFile(path, []byte("not a socket"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sockPath := filepath.Join(t.TempDir(), "occupied.sock")
+			tc.prepare(t, sockPath)
+			before, err := os.Lstat(sockPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if _, err := BindSocket(sockPath); !errors.Is(err, ErrSocketInUse) {
+				t.Fatalf("BindSocket = %v, want ErrSocketInUse", err)
+			}
+
+			after, err := os.Lstat(sockPath)
+			if err != nil {
+				t.Fatalf("the occupant was removed: %v", err)
+			}
+			if !os.SameFile(before, after) {
+				t.Fatal("the occupant was replaced")
+			}
+			// And no lock file is left implying a lease-aware owner that
+			// never existed -- the next attempt must reach the same verdict.
+			if _, err := os.Lstat(socklease.LockPath(sockPath)); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("a lock file was left behind for an unleased pathname: %v", err)
+			}
+		})
+	}
+}
+
+// Mutation: delete SetUnlinkOnClose(false) in BindSocket. Go's default unlinks
+// the pathname from Close(), i.e. outside the lease and without an identity
+// check — exactly the unconditional removal this design forbids.
+func TestListenerCloseDoesNotUnlinkPathname(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "sess.sock")
+	b := mustBind(t, sockPath)
+	before := mustIdent(t, sockPath)
+
+	if err := b.Listener.Close(); err != nil {
+		t.Fatalf("close listener: %v", err)
+	}
+	after, ok := socklease.StatSocket(sockPath)
+	if !ok {
+		t.Fatal("listener.Close() unlinked the pathname; removals must be leased and identity-checked")
+	}
+	if after != before {
+		t.Fatal("pathname changed identity across listener.Close()")
+	}
+}
+
+// Mutation: delete releaseSocketOwnership from Shutdown. The kernel does not
+// unlink a bound pathname when a process exits, so the pathname would linger
+// forever and every daemon scan would dial it and log a refusal.
+func TestShutdownReleasesPathnameAndLease(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "sess.sock")
+	srv := runToCompletion(t, sockPath)
+
+	if _, ok := socklease.StatSocket(sockPath); !ok {
+		t.Fatal("socket missing before Shutdown")
+	}
+	srv.Shutdown()
+
+	if _, err := os.Lstat(sockPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("socket pathname survived Shutdown: %v", err)
+	}
+	if _, err := os.Lstat(socklease.LockPath(sockPath)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("lock file survived Shutdown: %v; the socket directory would grow one file per session", err)
+	}
+	// The lease is free: a replacement runner binds immediately.
+	mustBind(t, sockPath)
+}
+
+func TestShutdownIsIdempotent(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "sess.sock")
+	srv := runToCompletion(t, sockPath)
+	srv.Shutdown()
+	srv.Shutdown()
+	if _, err := os.Lstat(sockPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("socket pathname present after double Shutdown: %v", err)
+	}
+}
+
+// The three-actor schedule that every earlier iteration of this design failed:
+// an exiting runner must never unlink a pathname a replacement runner rebound.
+//
+//	A: /kill releases ownership (pathname unlinked, lease dropped)
+//	B: replacement runner binds the same pathname
+//	A: finishes draining and calls Shutdown
+//
+// Mutation: drop the identity check in BoundSocket.ReleaseOwnership (or the
+// once-guard that keeps Shutdown from repeating /kill's removal). Either way
+// A's Shutdown unlinks B's live socket and B becomes unreachable while alive.
+func TestShutdownAfterOwnershipHandoverLeavesReplacementAlone(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "sess.sock")
+	srv := runToCompletion(t, sockPath)
+
+	// A hands ownership over, exactly as the /kill handler does.
+	srv.releaseSocketOwnership("test")
+
+	// B takes it.
+	replacement := mustBind(t, sockPath)
+	replacementID := mustIdent(t, sockPath)
+	// No skip if the inode was recycled: that is the case this guard exists
+	// for, and A's pin is what makes it decidable.
+	reused := replacementID.Dev == srv.bound.pin.Ident().Dev && replacementID.Ino == srv.bound.pin.Ident().Ino
+	t.Logf("replacement reused the inode: %v", reused)
+
+	// A finishes.
+	srv.Shutdown()
+
+	after, ok := socklease.StatSocket(sockPath)
+	if !ok {
+		t.Fatal("the old runner's Shutdown unlinked the replacement's live socket")
+	}
+	if after != replacementID {
+		t.Fatalf("pathname identity changed: got %+v, want %+v", after, replacementID)
+	}
+	// And the replacement still holds its lease.
+	if _, err := BindSocket(sockPath); !errors.Is(err, ErrSocketInUse) {
+		t.Fatalf("replacement lost its lease: BindSocket = %v", err)
+	}
+	_ = replacement
+}
+
+// The lease excludes lease-aware runners, but not everything: a stray `rm`,
+// or a runner from before the lease protocol, can still rebind the pathname
+// under a live owner. The exiting owner must then leave it alone — unlinking
+// on the strength of "this is my pathname" would disconnect a live listener.
+//
+// Mutation: replace lease.RemoveSocket(b.pin) with a bare os.Remove in
+// BoundSocket.ReleaseOwnership, or make it compare identities instead of
+// consulting the pin.
+func TestShutdownLeavesUnleasedRebindAlone(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "sess.sock")
+	srv := runToCompletion(t, sockPath)
+
+	// Somebody outside the protocol replaces the pathname with a live socket.
+	if err := os.Remove(sockPath); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	intruder, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer intruder.Close()
+	intruderID := mustIdent(t, sockPath)
+	// Deliberately no skip when the inode is recycled: an intruder that carries
+	// the very same device and inode is exactly the case a pin decides and an
+	// identity comparison gets wrong.
+	t.Logf("intruder reused the inode: %v",
+		intruderID.Dev == srv.bound.pin.Ident().Dev && intruderID.Ino == srv.bound.pin.Ident().Ino)
+
+	srv.Shutdown()
+
+	after, ok := socklease.StatSocket(sockPath)
+	if !ok {
+		t.Fatal("Shutdown unlinked a pathname that no longer named its own socket")
+	}
+	if after != intruderID {
+		t.Fatalf("pathname identity changed: got %+v, want %+v", after, intruderID)
+	}
+}
+
+// The lease must not outlive the runner through its PTY child. If the lock
+// descriptor were inherited across exec, a child that ignores SIGHUP would
+// keep the pathname leased long after the runner exited, and the restart
+// replacement would be pushed onto a fresh session id.
+//
+// Mutation: clear FD_CLOEXEC on the lease descriptor (or pass it in
+// ExtraFiles).
+func TestPTYChildDoesNotInheritLease(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "sess.sock")
+	srv, err := New(Config{
+		// Ignore SIGHUP so the child certainly outlives the runner's teardown.
+		Command:    []string{"bash", "-c", "trap '' HUP; sleep 30"},
+		Cwd:        "/tmp",
+		Listener:   mustBind(t, sockPath),
+		SocketPath: sockPath,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	childPID := srv.cmd.Process.Pid
+	defer func() { _ = syscall.Kill(-childPID, syscall.SIGKILL) }()
+
+	srv.Shutdown()
+
+	// The child is still running...
+	if err := syscall.Kill(childPID, 0); err != nil {
+		t.Skipf("child exited before the check (%v); inheritance cannot be observed", err)
+	}
+	// ...and yet the lease is free.
+	b, err := BindSocket(sockPath)
+	if err != nil {
+		t.Fatalf("BindSocket while the PTY child is alive = %v; the child inherited the lease", err)
+	}
+	_ = b.Listener.Close()
+	_ = b.ReleaseOwnership()
+}
+
+// legacyRunner is a runner from before the lease protocol: it takes a socket
+// pathname the old way (blind unlink, then listen) and holds no lease.
+type legacyRunner struct {
+	ln    *net.UnixListener
+	ident socklease.Ident
+}
+
+func startLegacyRunner(t *testing.T, sockPath string) *legacyRunner {
+	t.Helper()
+	_ = os.Remove(sockPath) // exactly what the pre-lease BindSocket did
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("legacy listen: %v", err)
+	}
+	ul := ln.(*net.UnixListener)
+	ul.SetUnlinkOnClose(false)
+	go func() {
+		for {
+			c, err := ul.Accept()
+			if err != nil {
+				return
+			}
+			_ = c.Close()
+		}
+	}()
+	t.Cleanup(func() { _ = ul.Close() })
+	return &legacyRunner{ln: ul, ident: mustIdent(t, sockPath)}
+}
+
+// onBindPhase installs BindSocket's barrier for one pathname and one test.
+//
+// Scoping on the pathname is not tidiness: binds run concurrently, in this
+// package's goroutines and in other tests', so an unfiltered barrier is driven
+// by whichever bind reaches the phase first -- the same defect the daemon's reap
+// barrier produced in CI. fired reports whether the barrier ever ran, so a test
+// must prove the schedule it asserts about actually happened.
+func onBindPhase(t *testing.T, sockPath, phase string, fn func()) (fired func() bool) {
+	t.Helper()
+	var ran atomic.Bool
+	var once sync.Once
+	setBindBarrier(func(gotPath, gotPhase string) {
+		if gotPath != sockPath || gotPhase != phase {
+			return
+		}
+		once.Do(func() {
+			ran.Store(true)
+			fn()
+		})
+	})
+	t.Cleanup(func() { setBindBarrier(nil) })
+	return ran.Load
+}
+
+// The mixed-version property, driven into every window BindSocket has.
+//
+// A pre-lease runner is excluded by nothing: it holds no lease, and it can
+// start at any instant, including between our probe and our unlink. The only
+// safe rule is to never unlink a pathname we cannot prove belonged to a
+// lease-aware generation -- and to re-check identity even when we can, because
+// the pathname may have changed hands since we looked.
+//
+// Mutation: any of the three guards -- the CreatedLockFile gate, the probe, or
+// the identity-checked removal -- lets one of these subtests unlink a live
+// pre-lease runner's socket.
+func TestBindSocketNeverUnlinksALivePreLeaseRunner(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		// phase names the BindSocket window in which the pre-lease runner
+		// takes the pathname.
+		phase string
+		// leaseHistory seeds a lock file (and a stale socket) so BindSocket
+		// takes the "a lease-aware generation owned this" branch.
+		leaseHistory bool
+	}{
+		{name: "starts while we hold a fresh lease", phase: "lease-held"},
+		{name: "starts while we hold an inherited lease", phase: "lease-held", leaseHistory: true},
+		{name: "takes over after our bind fails", phase: "address-in-use", leaseHistory: true},
+		{name: "takes over just before our probe", phase: "before-probe", leaseHistory: true},
+		// The window the pin exists for: the probe has already answered
+		// "nothing here", and the pathname changes hands before the unlink.
+		// Getting this one wrong -- by pinning after the probe rather than
+		// before it -- unlinks a live, unprobed runner.
+		{name: "takes over right after our probe", phase: "probed", leaseHistory: true},
+		{name: "takes over between our probe and our unlink", phase: "before-remove", leaseHistory: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sockPath := filepath.Join(t.TempDir(), "contested.sock")
+			if tc.leaseHistory {
+				crashedLeaseAwareSocket(t, sockPath)
+			}
+
+			var legacy *legacyRunner
+			fired := onBindPhase(t, sockPath, tc.phase, func() {
+				legacy = startLegacyRunner(t, sockPath)
+			})
+
+			b, err := BindSocket(sockPath)
+			if !fired() {
+				t.Fatalf("BindSocket never reached the %q phase", tc.phase)
+			}
+			if err == nil {
+				_ = b.Listener.Close()
+				_ = b.ReleaseOwnership()
+				t.Fatalf("BindSocket bound over a live pre-lease runner")
+			}
+			if !errors.Is(err, ErrSocketInUse) {
+				t.Fatalf("BindSocket = %v, want ErrSocketInUse", err)
+			}
+
+			// The invariant: the pre-lease runner still owns its pathname.
+			current, ok := socklease.StatSocket(sockPath)
+			if !ok {
+				t.Fatal("the live pre-lease runner's pathname was unlinked")
+			}
+			if current != legacy.ident {
+				t.Fatalf("the pathname was rebound under a live pre-lease runner: %+v -> %+v",
+					legacy.ident, current)
+			}
+			// ...and it is still reachable, which is the point of not
+			// unlinking it.
+			conn, dialErr := net.DialTimeout("unix", sockPath, 2*time.Second)
+			if dialErr != nil {
+				t.Fatalf("the pre-lease runner is no longer reachable at its pathname: %v", dialErr)
+			}
+			_ = conn.Close()
+		})
+	}
+}
+
+// The daemon's reaper holds the lease across its inspection. A runner that
+// starts in that window must wait it out, not fall back to a fresh session id:
+// losing a resume identity to a bookkeeping sweep is the exact failure the
+// /kill early release exists to prevent, arriving through another door.
+//
+// Mutation: use socklease.Acquire instead of AcquireWait in BindSocket.
+func TestBindSocketWaitsOutAReaperHoldingTheLease(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "contested.sock")
+	crashedLeaseAwareSocket(t, sockPath)
+
+	// Stand in for the reaper: hold the lease, then let go.
+	reaper, err := socklease.AcquireExisting(sockPath)
+	if err != nil {
+		t.Fatalf("reaper acquire: %v", err)
+	}
+	go func() {
+		time.Sleep(40 * time.Millisecond)
+		// The reaper puts a pathname it merely inspected back as it found it.
+		_ = reaper.ReleaseKeepingLockFile()
+	}()
+
+	b, err := BindSocket(sockPath)
+	if err != nil {
+		t.Fatalf("BindSocket = %v; it gave up while the reaper held the lease", err)
+	}
+	defer func() { _ = b.Listener.Close(); _ = b.ReleaseOwnership() }()
+	if got := b.sockPath; got != sockPath {
+		t.Fatalf("bound %s, want %s", got, sockPath)
+	}
+}
+
+// Mutation: replace socklease.ProbeRefused with an "any dial failure means
+// nothing answers" probe (the old probeSocket).
+//
+// A live occupant whose socket cannot be connected to is not a dead one. Here
+// the socket's mode denies the connect, which is deterministic; a full accept
+// backlog is the same situation arriving by accident. The runner and the daemon
+// must agree on this, or a socket one side spares is unlinked by the other.
+func TestBindSocketDoesNotRemoveALeftoverOnAnAmbiguousProbe(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: no mode denies a connect")
+	}
+	sockPath := filepath.Join(t.TempDir(), "unreachable.sock")
+	// Lease history, so BindSocket is in the branch that may remove.
+	crashedLeaseAwareSocket(t, sockPath)
+	if err := os.Remove(sockPath); err != nil {
+		t.Fatal(err)
+	}
+
+	// A live listener whose socket cannot be dialled: the probe learns nothing.
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	ln.(*net.UnixListener).SetUnlinkOnClose(false)
+	defer ln.Close()
+	go func() {
+		for {
+			c, acceptErr := ln.Accept()
+			if acceptErr != nil {
+				return
+			}
+			_ = c.Close()
+		}
+	}()
+	if err := os.Chmod(sockPath, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	before := mustIdent(t, sockPath)
+
+	// The probe must actually be ambiguous for this test to mean anything.
+	probeErr := socklease.ProbeRefused(sockPath, probeTimeout)
+	if probeErr == nil {
+		t.Fatal("an unreachable live socket was reported as refused")
+	}
+	if errors.Is(probeErr, socklease.ErrSocketLive) {
+		t.Skip("the connect succeeded despite the mode; the probe is not ambiguous here")
+	}
+
+	if _, err := BindSocket(sockPath); err == nil {
+		t.Fatal("BindSocket bound over a live listener its probe could not reach")
+	}
+	after, ok := socklease.StatSocket(sockPath)
+	if !ok {
+		t.Fatal("the unreachable live listener's pathname was unlinked")
+	}
+	if after != before {
+		t.Fatal("the pathname was rebound under a live listener")
+	}
+}
+
+// Mutation: replace socklease.RequireOwnedDir with a plain MkdirAll in
+// BindSocket.
+//
+// Every guarantee in this package is relative to a directory only this user can
+// write in. Binding into one that others can write in is not a lesser
+// guarantee, it is none, so the premise is established where the directory is
+// created rather than assumed.
+func TestBindSocketRequiresAPrivateSocketDirectory(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "sessions")
+	if err := os.MkdirAll(dir, 0o777); err != nil {
+		t.Fatal(err)
+	}
+	sockPath := filepath.Join(dir, "sess.sock")
+
+	b, err := BindSocket(sockPath)
+	if err != nil {
+		t.Fatalf("BindSocket: %v", err)
+	}
+	t.Cleanup(func() { _ = b.Listener.Close(); _ = b.ReleaseOwnership() })
+
+	fi, err := os.Lstat(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := fi.Mode().Perm(); perm != 0o700 {
+		t.Fatalf("socket directory mode = %o, want 700: a directory others can write in makes every lease in it meaningless", perm)
+	}
+}

--- a/go.work
+++ b/go.work
@@ -5,6 +5,7 @@ use (
 	./packages/adapter
 	./packages/paths
 	./packages/scrollback
+	./packages/socklease
 	./packages/sessionenv
 	./packages/workspace
 	./services/gmuxd

--- a/packages/paths/paths.go
+++ b/packages/paths/paths.go
@@ -88,6 +88,20 @@ func StateDir() string {
 	return filepath.Join(home, ".local", "state", "gmux")
 }
 
+// DaemonLogPath returns the daemon's log file. It is a single source of truth
+// on purpose: both launchers (`gmuxd start` and the gmux CLI's autostart) open
+// it, the serving process bounds it by rotating this exact pathname, and
+// `gmuxd log-path` prints it. A disagreement between any two of those would
+// mean the daemon bounding a file nobody reads, or rotating one somebody else
+// owns.
+//
+// Bounding is a rename plus a descriptor move rather than a truncation, so
+// nothing written to the log is ever destroyed in place -- see logbound.go for
+// why that distinction matters.
+func DaemonLogPath() string {
+	return filepath.Join(StateDir(), "gmuxd.log")
+}
+
 // SessionsDir returns the directory under StateDir that holds
 // per-session subdirectories (meta.json, scrollback). Both the
 // runner (writing scrollback) and gmuxd (writing meta.json,

--- a/packages/socklease/go.mod
+++ b/packages/socklease/go.mod
@@ -1,0 +1,3 @@
+module github.com/gmuxapp/gmux/packages/socklease
+
+go 1.26.1

--- a/packages/socklease/ident.go
+++ b/packages/socklease/ident.go
@@ -1,0 +1,192 @@
+package socklease
+
+import (
+	"fmt"
+	"os"
+)
+
+// StampKind names which of the inode's timestamps an Ident carries. Two
+// identities derived from different clocks are never comparable, so this is
+// part of the identity rather than a note about it.
+type StampKind uint8
+
+const (
+	// StampNone means the platform gave us no creation-ish timestamp. An Ident
+	// without one is unknown: it cannot be told apart from a later inode that
+	// happens to reuse the same number.
+	StampNone StampKind = iota
+	// StampChange is the inode's change time (st_ctim). For a file that is
+	// created and never chmod'ed or renamed -- which is every socket in this
+	// protocol -- it is the creation time.
+	StampChange
+	// StampBirth is the inode's birth time, where the platform records one.
+	StampBirth
+)
+
+func (k StampKind) String() string {
+	switch k {
+	case StampChange:
+		return "ctime"
+	case StampBirth:
+		return "btime"
+	}
+	return "no-stamp"
+}
+
+// Ident is the physical identity ("incarnation") of a socket pathname.
+//
+// Device and inode number alone are not an identity. Inode numbers are
+// recycled, and on some filesystems recycled *immediately*: a socket unlinked
+// and rebound in the same breath can come back with the same number, which is
+// how a live replacement runner came to look exactly like the dead leftover it
+// replaced -- and got unlinked for it. So an Ident also carries the inode's
+// creation timestamp, which separates two incarnations that a number cannot.
+//
+// It is deliberately a comparable value: the daemon keys installed generations
+// on it. It is also deliberately runtime-only. Nothing persists an Ident --
+// inode numbers and timestamps describe this boot of this filesystem, and a
+// stored one would be a fact about a world that no longer exists.
+//
+// # What this does and does not settle
+//
+// The stamp comes from the platform's file-timestamp clock, which is coarse:
+// Linux derives it from jiffies, so two creations a few microseconds apart
+// share a timestamp (measured on ext4 and tmpfs: ~99% of back-to-back socket
+// creations share both ctime and statx btime). An Ident therefore separates
+// incarnations that are more than a clock tick apart, and cannot separate a
+// number recycled inside one tick.
+//
+// That is why an Ident never authorises an unlink on its own. The destructive
+// paths hold a Pin, which answers "is this still the file I decided about?"
+// exactly, without reasoning about numbers or clocks at all.
+type Ident struct {
+	Dev uint64
+	Ino uint64
+	// StampSec and StampNsec are the inode's creation-ish timestamp; Stamp
+	// records which one it is.
+	StampSec  int64
+	StampNsec int64
+	Stamp     StampKind
+}
+
+// Known reports whether the identity was actually observed, in full. An
+// identity without a timestamp is not partially useful: it is exactly the
+// number-only identity that inode reuse defeats, so it counts as unknown and
+// every consumer treats it conservatively.
+func (i Ident) Known() bool {
+	return (i.Dev != 0 || i.Ino != 0) && i.Stamp != StampNone
+}
+
+// Same reports whether two identities are known and identical. Unknown
+// identities never compare equal, not even to themselves, and identities
+// derived from different clocks never compare equal to each other.
+func (i Ident) Same(o Ident) bool { return i.Known() && i == o }
+
+func (i Ident) String() string {
+	if !i.Known() {
+		return "unknown-identity"
+	}
+	return fmt.Sprintf("%d/%d@%d.%09d(%s)", i.Dev, i.Ino, i.StampSec, i.StampNsec, i.Stamp)
+}
+
+// StatSocket returns the identity of the socket file at path. It reports
+// isSocket=false when the path does not exist, is not a socket, or cannot be
+// stat'ed. It never follows symlinks: a symlinked pathname is not a socket and
+// is therefore never treated as one.
+func StatSocket(path string) (id Ident, isSocket bool) { return statSocket(path) }
+
+// Pin is a handle on one specific file, held so that a decision made about
+// that file can later be checked against the file itself rather than against
+// its name.
+//
+// This is the primitive the destructive paths rest on, because it is the only
+// one that is exact. A caller that probed a leftover socket and found nothing
+// listening wants to unlink *that file* -- but between the probe and the unlink
+// the pathname can be handed to a live runner, and no amount of stat'ing can
+// reliably tell the difference once the kernel has recycled the inode number.
+// A pin can: the file it holds is either still the one the pathname names, or
+// it is not.
+type Pin struct {
+	path  string
+	ident Ident
+	// fd is a handle on the pinned file where the platform can open one
+	// (Linux's O_PATH). It is -1 otherwise, and StillNamesIt falls back to
+	// comparing identities, which is as good as the platform's timestamps.
+	fd int
+}
+
+// PinSocket pins the socket the lease owns.
+func (l *Lease) PinSocket() (*Pin, error) { return PinSocket(l.sockPath) }
+
+// PinSocket pins the socket file at path. The caller must Close the pin.
+func PinSocket(path string) (*Pin, error) {
+	id, isSocket := StatSocket(path)
+	if !isSocket {
+		return nil, fmt.Errorf("socklease: %s is not a socket", path)
+	}
+	fd, err := pinFile(path)
+	if err != nil {
+		// No handle available: the pin degrades to its identity, which is what
+		// every pre-Pin version of this code had.
+		fd = -1
+	}
+	return &Pin{path: path, ident: id, fd: fd}, nil
+}
+
+// Ident returns the identity of the pinned file.
+func (p *Pin) Ident() Ident { return p.ident }
+
+// Path returns the pathname this pin was taken on.
+func (p *Pin) Path() string {
+	if p == nil {
+		return ""
+	}
+	return p.path
+}
+
+// Exact reports whether this pin can answer StillNamesIt exactly, or is
+// falling back to comparing identities.
+func (p *Pin) Exact() bool { return p != nil && p.fd >= 0 }
+
+// StillNamesIt reports whether the pathname still names the pinned file.
+//
+// With a handle this is exact and needs no assumptions about inode numbering:
+// the pinned file must still be linked exactly once (so it has not been
+// unlinked, and has not been hardlinked elsewhere), and the pathname must still
+// resolve to that inode. Two live inodes on one device cannot share an inode
+// number, so those two facts together mean the pathname resolves to the pinned
+// file and nothing else.
+//
+// Without a handle it compares identities, which separates incarnations by the
+// platform's timestamp granularity -- see Ident.
+func (p *Pin) StillNamesIt() bool {
+	if p == nil {
+		return false
+	}
+	current, isSocket := StatSocket(p.path)
+	if !isSocket || current.Dev != p.ident.Dev || current.Ino != p.ident.Ino {
+		return false
+	}
+	if p.fd < 0 {
+		return current.Same(p.ident)
+	}
+	links, err := pinnedLinkCount(p.fd)
+	if err != nil {
+		return false
+	}
+	return links == 1
+}
+
+// Close releases the pin.
+func (p *Pin) Close() error {
+	if p == nil || p.fd < 0 {
+		return nil
+	}
+	fd := p.fd
+	p.fd = -1
+	return closeFile(fd)
+}
+
+// statFileMode is the mode bits a socket must have; kept here so the
+// platform files agree on it.
+const fileModeSocket = os.ModeSocket

--- a/packages/socklease/moon.yml
+++ b/packages/socklease/moon.yml
@@ -1,0 +1,7 @@
+language: bash
+
+tasks:
+  test:
+    command: go test ./...
+  lint:
+    command: go vet ./...

--- a/packages/socklease/socklease.go
+++ b/packages/socklease/socklease.go
@@ -1,0 +1,453 @@
+// Package socklease implements the ownership protocol for a canonical Unix
+// socket pathname shared by the gmux runner (which binds the socket) and the
+// gmux daemon (which reaps sockets left behind by dead runners).
+//
+// # Why a lease
+//
+// AF_UNIX pathname ownership is not tied to the listening socket: closing (or
+// crashing with) a listener leaves the pathname behind, and any process may
+// unlink a pathname another process is listening on. Every "is this socket
+// stale?" answer derived purely from the filesystem or from a probe is a
+// TOCTOU: between the observation and the unlink, the pathname can be rebound
+// by a fresh, live runner, and the unlink then silently disconnects it.
+//
+// The lease closes that window with an advisory whole-file lock (flock) on a
+// side-car file, sockPath+".lock":
+//
+//   - A runner acquires the lease before it removes any stale pathname and
+//     before it listens, and holds it for as long as it owns the pathname.
+//   - The daemon acquires the same lease, non-blocking, before it inspects or
+//     unlinks a suspected-stale pathname, and holds it across the whole
+//     inspect-and-unlink sequence.
+//
+// Because flock is released by the kernel when the holding process dies
+// (including SIGKILL and panics), a successful non-blocking acquisition is
+// proof that no lease-aware owner is alive. Because the lease is held across
+// identity check and unlink, no lease-aware owner can appear in the middle of
+// that sequence.
+//
+// # Lock file lifetime
+//
+// The lock file is created by the owner and unlinked by the owner when it
+// releases the lease, so the socket directory does not accumulate one file per
+// session ever started. Unlinking a lock file is only safe if lockers detect
+// that the file they locked is no longer the file the pathname names --
+// otherwise two processes could hold locks on two different inodes for the
+// same pathname. Acquire therefore verifies, after locking, that the locked
+// inode is still the one named by the lock pathname, and retries when it is
+// not (see acquire).
+//
+// # Mixed versions
+//
+// A runner from before this protocol creates no lock file. AcquireExisting
+// (used by the daemon) never creates one, and reports ErrNoLockFile instead,
+// so the daemon can decline to touch a pathname whose owner is not
+// lease-aware: absence of proof of death is not proof of death.
+//
+// # Threat model
+//
+// This is a cooperative protocol between processes of one user inside one
+// private directory, and it is not more than that. It assumes:
+//
+//   - the socket directory is owned by the calling user and carries no group
+//     or other permissions (RequireOwnedDir establishes this at the point of
+//     creation, and the runner refuses to bind otherwise);
+//   - every process that manipulates a pathname in that directory follows this
+//     protocol, or predates it and is therefore handled conservatively.
+//
+// Within those assumptions the protocol is sound. Outside them it is not, and
+// two places are worth naming rather than glossing:
+//
+//   - Release verifies that the lock pathname still names the descriptor it is
+//     about to unlink. That is a check followed by an act, and no portable
+//     primitive makes it one operation: there is no unlink conditional on an
+//     inode. It therefore dominates a substitution that has already happened
+//     -- the reachable case, where some other actor replaced the pathname
+//     earlier -- and does not defend against an actor racing that exact
+//     instruction. Linux's renameat2 and openat2 offer nothing that closes it,
+//     and O_NOFOLLOW plus the post-lock inode verification is as far as the
+//     acquisition side can go on both Linux and Darwin.
+//   - Socket identity is device+inode. A same-user actor with write access to
+//     the directory can hard-link a bound socket and restore it later, which
+//     is why identity alone never authorises anything destructive: the daemon
+//     additionally requires the runner's own incarnation nonce to agree across
+//     two calls.
+//
+// So: no claim is made that this protocol is safe against a hostile process
+// running as the same user with write access to the socket directory. Such a
+// process can already unlink and rebind every socket in it, with or without
+// this package.
+package socklease
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"net"
+	"os"
+	"syscall"
+	"time"
+)
+
+// Suffix is appended to the canonical socket pathname to form the lock
+// pathname. It deliberately keeps the ".sock" part intact so that lock files
+// sort next to their socket, and it does not itself end in ".sock" so that
+// socket enumeration (which filters on that suffix) never sees a lock file.
+const Suffix = ".lock"
+
+var (
+	// ErrHeld reports that another live process owns the lease.
+	ErrHeld = errors.New("socklease: lease is held by another process")
+	// ErrNoLockFile reports that no lock file exists for the pathname, which
+	// means its owner (if any) predates this protocol. Only AcquireExisting
+	// returns it; Acquire creates the file.
+	ErrNoLockFile = errors.New("socklease: no lock file (owner is not lease-aware)")
+	// ErrIdentityChanged reports that the socket pathname no longer names the
+	// file the caller expected, so it was left untouched.
+	ErrIdentityChanged = errors.New("socklease: socket identity changed")
+	// ErrNotRefused reports that a connect attempt to a socket pathname was
+	// not actively refused, so nothing about the pathname's owner was proved.
+	ErrNotRefused = errors.New("socklease: socket was not actively refused")
+	// ErrSocketLive is the one ErrNotRefused case that *did* prove something:
+	// somebody accepted the connection. Callers distinguish it because "a live
+	// owner is there" and "I learned nothing" lead to different decisions
+	// about the pathname's lease history.
+	ErrSocketLive = fmt.Errorf("%w: connection accepted (a live owner)", ErrNotRefused)
+	// ErrProbeTimeout is the ambiguous case worth naming separately: the
+	// connect neither completed nor was refused. It proves nothing -- a wedged
+	// owner with a full accept backlog looks exactly like this -- and it is a
+	// distinct sentinel so that a test can pin the classification instead of
+	// pinning a message.
+	ErrProbeTimeout = fmt.Errorf("%w: probe timed out (owner may be wedged, not dead)", ErrNotRefused)
+)
+
+// ProbeRefused returns nil only when connecting to the socket at path is
+// actively refused, which for a Unix socket means the pathname exists and no
+// process holds a listening socket for it.
+//
+// Every other outcome is an error, deliberately: a successful connect means
+// somebody is alive there, and a timeout or a permission failure means nothing
+// was learned at all. Both callers -- the runner clearing a leftover before it
+// binds, and the daemon reaping an abandoned pathname -- use this one
+// predicate, because a timeout that reads as "nothing answers" on one side and
+// "learned nothing" on the other is exactly the asymmetry that gets a live
+// socket unlinked.
+func ProbeRefused(path string, timeout time.Duration) error {
+	// Connecting to a regular file reports ECONNREFUSED on Linux, which would
+	// make "refused" mean "not a socket" as well as "no listener". Callers
+	// already establish the type; establishing it here too keeps the predicate
+	// meaningful on its own.
+	if _, isSocket := StatSocket(path); !isSocket {
+		return fmt.Errorf("%w: %s is not a socket", ErrNotRefused, path)
+	}
+	conn, err := net.DialTimeout("unix", path, timeout)
+	if err == nil {
+		_ = conn.Close()
+		return ErrSocketLive
+	}
+	if errors.Is(err, syscall.ECONNREFUSED) {
+		return nil
+	}
+	// A dial that ran out of time reports a net.Error with Timeout() true, not
+	// os.ErrDeadlineExceeded -- that sentinel belongs to deadlines on an
+	// established connection. Both are checked because both are reachable
+	// depending on where the budget expires.
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() || errors.Is(err, os.ErrDeadlineExceeded) {
+		return ErrProbeTimeout
+	}
+	return fmt.Errorf("%w: %v", ErrNotRefused, err)
+}
+
+// ProbeRefusedPinned probes the pathname a pin holds, and exists so that
+// "probe, then decide what you probed" cannot be written.
+//
+// The ordering is load-bearing and easy to get backwards. A lease excludes
+// lease-aware runners, not the pre-protocol ones, so an unleased runner can take
+// the pathname over at any instant -- including between a probe and a pin. Pin
+// first and a takeover is harmless: the pin holds the file the probe found dead,
+// the pathname no longer resolves to it, and the removal declines. Probe first
+// and the pin lands on the newcomer, which is then unlinked alive and unprobed.
+//
+// Taking the pin as a parameter makes the wrong order unexpressible: there is
+// nothing to pass. A caller that tries anyway passes nil and is refused.
+func ProbeRefusedPinned(pin *Pin, timeout time.Duration) error {
+	if pin == nil {
+		return fmt.Errorf("%w: probe without a pin (probe-then-pin is not a valid order)", ErrNotRefused)
+	}
+	return ProbeRefused(pin.Path(), timeout)
+}
+
+// RequireOwnedDir creates dir with mode 0700 if needed and establishes the
+// premise the whole protocol rests on: the directory is ours and nobody else's
+// to write in.
+//
+// A directory owned by another user is refused outright -- a lease inside it
+// proves nothing, because its owner can replace any pathname at will. A
+// directory of ours that carries group or other permissions is tightened; if
+// it cannot be tightened, that is also refused. Both are reported rather than
+// silently accepted, because the alternative is a protocol whose stated
+// assumptions are false on the machine it is running on.
+func RequireOwnedDir(dir string) error {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("socklease: create %s: %w", dir, err)
+	}
+	fi, err := os.Lstat(dir)
+	if err != nil {
+		return fmt.Errorf("socklease: stat %s: %w", dir, err)
+	}
+	if !fi.IsDir() {
+		return fmt.Errorf("socklease: %s is not a directory", dir)
+	}
+	if st, ok := fi.Sys().(*syscall.Stat_t); ok {
+		if uid := geteuidFn(); int(st.Uid) != uid {
+			return fmt.Errorf("socklease: %s is owned by uid %d, not %d; refusing to trust it",
+				dir, st.Uid, uid)
+		}
+	}
+	if fi.Mode().Perm()&0o077 != 0 {
+		if err := os.Chmod(dir, 0o700); err != nil {
+			return fmt.Errorf("socklease: %s is mode %o and cannot be restricted: %w",
+				dir, fi.Mode().Perm(), err)
+		}
+	}
+	return nil
+}
+
+// acquireRetries bounds the verify-after-lock loop. Each iteration requires a
+// concurrent owner to have released (and unlinked) a lock file between our
+// open and our flock, so exhausting the budget is not reachable without an
+// adversarial rebind loop.
+const acquireRetries = 16
+
+// acquireRetryDelay is the poll interval of AcquireWait.
+const acquireRetryDelay = 5 * time.Millisecond
+
+// LockPath returns the lock pathname used for sockPath.
+func LockPath(sockPath string) string { return sockPath + Suffix }
+
+// testAfterOpen is a barrier hook for the verify-after-lock test: it runs
+// between the open and the flock in acquire, which is the only window in which
+// the lock file can be replaced under a locker. It is nil in production and
+// costs one nil check per acquisition.
+var testAfterOpen func()
+
+// testBeforeAcquireRetry is a barrier hook for the bounded-wait test: it runs
+// before each AcquireWait retry sleeps. It is nil in production.
+var testBeforeAcquireRetry func(attempt int)
+
+// geteuidFn is the effective uid, indirected so a test can pin the ownership
+// check without needing a directory owned by somebody else -- and, crucially,
+// without ever chmod'ing a directory it does not own. It is os.Geteuid in
+// production.
+var geteuidFn = os.Geteuid
+
+// Lease is a held exclusive advisory lock over one socket pathname. It is not
+// safe for concurrent use by multiple goroutines; the owner is expected to be
+// a single lifecycle (bind ... release).
+type Lease struct {
+	f        *os.File
+	sockPath string
+	created  bool
+}
+
+// Acquire takes the lease for sockPath, creating the lock file (mode 0600) if
+// needed. It returns ErrHeld when another live process owns the lease.
+//
+// The returned lease must be released with Release exactly once. The lock file
+// descriptor is close-on-exec, so an exec'd child (the runner's PTY child, for
+// instance) never inherits the lease and cannot keep it alive past the owner.
+func Acquire(sockPath string) (*Lease, error) {
+	return acquire(sockPath, true)
+}
+
+// AcquireWait is Acquire with a bounded wait for a lease that is currently
+// held. It exists for one specific contention: the daemon's stale-socket
+// reaper holds the lease for the length of its inspection (a stat, a connect
+// and an unlink), and a runner starting inside that window would otherwise
+// conclude the pathname is taken and fall back to a fresh session id --
+// silently losing a resume identity to a bookkeeping sweep.
+//
+// The wait is short and unconditional: a lease held by a genuinely live runner
+// is still reported as ErrHeld, just budget later.
+func AcquireWait(sockPath string, budget time.Duration) (*Lease, error) {
+	deadline := time.Now().Add(budget)
+	for attempt := 0; ; attempt++ {
+		lease, err := acquire(sockPath, true)
+		if !errors.Is(err, ErrHeld) || !time.Now().Before(deadline) {
+			return lease, err
+		}
+		if testBeforeAcquireRetry != nil {
+			testBeforeAcquireRetry(attempt)
+		}
+		time.Sleep(acquireRetryDelay)
+	}
+}
+
+// AcquireExisting takes the lease for sockPath but never creates the lock
+// file: it returns ErrNoLockFile when the file is absent. The daemon's reaper
+// uses it so that a socket owned by a runner that predates this protocol -- and
+// therefore holds no lease -- can never be mistaken for an abandoned one.
+func AcquireExisting(sockPath string) (*Lease, error) {
+	return acquire(sockPath, false)
+}
+
+// CreatedLockFile reports whether this acquisition created the lock file
+// rather than finding one.
+//
+// It is the runner's only evidence about who owns a pathname it could not
+// bind. A pre-existing lock file means some lease-aware generation owned this
+// pathname before, and every lease-aware actor is excluded while this lease is
+// held -- so cleaning up after that generation is safe. A lock file this call
+// had to create means the opposite: whatever occupies the pathname predates
+// the protocol, is excluded by nothing, and must never be unlinked.
+func (l *Lease) CreatedLockFile() bool { return l.created }
+
+func acquire(sockPath string, create bool) (*Lease, error) {
+	lockPath := LockPath(sockPath)
+	for range acquireRetries {
+		// Open in two steps so the caller can distinguish "found a lock file"
+		// from "had to make one", and never through a symlink: O_NOFOLLOW
+		// turns a symlink planted at the lock pathname into ELOOP rather than
+		// a lock on -- and later an unlink of -- some unrelated file.
+		f, err := os.OpenFile(lockPath, os.O_RDWR|syscall.O_NOFOLLOW, 0o600)
+		created := false
+		if errors.Is(err, fs.ErrNotExist) {
+			if !create {
+				return nil, ErrNoLockFile
+			}
+			f, err = os.OpenFile(lockPath, os.O_RDWR|os.O_CREATE|os.O_EXCL|syscall.O_NOFOLLOW, 0o600)
+			if errors.Is(err, fs.ErrExist) {
+				continue // someone created it first: reopen and lock that one
+			}
+			created = true
+		}
+		if err != nil {
+			return nil, fmt.Errorf("socklease: open %s: %w", lockPath, err)
+		}
+		if testAfterOpen != nil {
+			testAfterOpen()
+		}
+		if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+			_ = f.Close()
+			if errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN) {
+				return nil, ErrHeld
+			}
+			return nil, fmt.Errorf("socklease: flock %s: %w", lockPath, err)
+		}
+		// Verify the file we locked is still the file the lock pathname names.
+		// A previous owner may have unlinked it (and a new owner created a
+		// replacement) between our open and our flock; locking an unlinked
+		// inode excludes nobody.
+		if current, ok := sameFile(f, lockPath); ok && current {
+			return &Lease{f: f, sockPath: sockPath, created: created}, nil
+		}
+		_ = f.Close() // releases the lock on the dead inode
+	}
+	return nil, fmt.Errorf("socklease: %s: lock file replaced repeatedly", lockPath)
+}
+
+// sameFile reports whether the open file and the pathname name the same inode.
+// ok is false when the comparison could not be made at all.
+func sameFile(f *os.File, path string) (same, ok bool) {
+	fi, err := f.Stat()
+	if err != nil {
+		return false, false
+	}
+	pi, err := os.Lstat(path)
+	if err != nil {
+		return false, true // vanished: definitely not the same file
+	}
+	return os.SameFile(fi, pi), true
+}
+
+// SockPath returns the socket pathname this lease owns.
+func (l *Lease) SockPath() string { return l.sockPath }
+
+// LockPath returns the lock pathname backing this lease.
+func (l *Lease) LockPath() string { return LockPath(l.sockPath) }
+
+// RemoveSocket unlinks the socket pathname, but only while it still names the
+// file the pin holds.
+//
+// The check is a Pin rather than an identity because an identity is not enough.
+// Inode numbers are recycled -- immediately, on some filesystems -- so a live
+// replacement can present exactly the device and inode of the dead leftover it
+// replaced, and an identity comparison would unlink it. A pin answers the
+// question that actually matters: is the file at this pathname still the file
+// the caller decided about? Where the platform can hold a handle, that answer
+// is exact.
+//
+// It returns ErrIdentityChanged when the pathname names something else, and nil
+// when the pathname is already gone.
+func (l *Lease) RemoveSocket(pin *Pin) error {
+	if pin == nil {
+		return fmt.Errorf("%w: caller passed no pin", ErrIdentityChanged)
+	}
+	if pin.path != l.sockPath {
+		return fmt.Errorf("%w: pin holds %s, lease owns %s", ErrIdentityChanged, pin.path, l.sockPath)
+	}
+	if _, err := os.Lstat(l.sockPath); errors.Is(err, fs.ErrNotExist) {
+		return nil // already gone: idempotent
+	}
+	if !pin.StillNamesIt() {
+		return fmt.Errorf("%w: %s no longer names %s", ErrIdentityChanged, l.sockPath, pin.ident)
+	}
+	if err := os.Remove(l.sockPath); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("socklease: remove %s: %w", l.sockPath, err)
+	}
+	return nil
+}
+
+// Release unlinks the lock file and drops the lock. It is idempotent.
+//
+// Unlinking under the lock is what keeps the socket directory bounded, and it
+// is safe in both directions:
+//
+//   - a racing acquirer that opened this inode before the unlink either loses
+//     the flock or fails Acquire's post-lock verification and retries, so it
+//     can never come away owning a lease over an unlinked inode;
+//   - the unlink is conditional on the lock pathname still naming the file
+//     this lease holds. Without that condition, a lease whose pathname was
+//     substituted -- by anything that does not follow this protocol, or by a
+//     hostile write in the socket directory -- would unlink the *replacement's*
+//     lock file on its way out, leaving two leases that do not exclude each
+//     other: the replacement's, now over an unlinked inode, and whoever
+//     creates the pathname next.
+//
+// The condition is a check-then-act, so it does not defend against an
+// adversary racing this exact instruction. It defends against the reachable
+// case, where the substitution already happened.
+func (l *Lease) Release() error { return l.release(true) }
+
+// ReleaseKeepingLockFile drops the lock but leaves the lock file in place.
+//
+// It is for a *borrowed* lease: the daemon's reaper takes the lease to inspect
+// a pathname it does not own, and when it comes away without having learned
+// anything about the occupant -- a probe that timed out, an identity that
+// changed mid-inspection -- it must put the pathname back exactly as it found
+// it. Removing the lock file there would erase the evidence that the pathname
+// once belonged to a lease-aware generation, and that evidence is the only
+// thing that ever makes the leftover socket reclaimable (see
+// CreatedLockFile).
+func (l *Lease) ReleaseKeepingLockFile() error { return l.release(false) }
+
+func (l *Lease) release(removeLockFile bool) error {
+	if l == nil || l.f == nil {
+		return nil
+	}
+	f := l.f
+	l.f = nil
+	var rmErr error
+	if removeLockFile {
+		if same, ok := sameFile(f, l.LockPath()); ok && same {
+			rmErr = os.Remove(l.LockPath())
+		}
+		if rmErr != nil && errors.Is(rmErr, fs.ErrNotExist) {
+			rmErr = nil
+		}
+	}
+	unlockErr := syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+	closeErr := f.Close()
+	return errors.Join(rmErr, unlockErr, closeErr)
+}

--- a/packages/socklease/socklease_test.go
+++ b/packages/socklease/socklease_test.go
@@ -1,0 +1,1001 @@
+package socklease
+
+// Mutation-grade tests for the socket ownership lease.
+//
+// Each test names the production mutation it is designed to catch, so a
+// reviewer can delete the referenced line and watch exactly that test fail.
+
+import (
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func tempSock(t *testing.T, name string) string {
+	t.Helper()
+	return filepath.Join(t.TempDir(), name)
+}
+
+// listenUnix binds a real Unix socket and disables Go's unlink-on-close so the
+// test controls every pathname removal explicitly, exactly like the runner.
+func listenUnix(t *testing.T, path string) *net.UnixListener {
+	t.Helper()
+	ln, err := net.Listen("unix", path)
+	if err != nil {
+		t.Fatalf("listen %s: %v", path, err)
+	}
+	ul := ln.(*net.UnixListener)
+	ul.SetUnlinkOnClose(false)
+	t.Cleanup(func() { _ = ul.Close() })
+	return ul
+}
+
+// Mutation: delete the syscall.Flock call in acquire.
+func TestAcquireExcludesSecondHolder(t *testing.T) {
+	sock := tempSock(t, "a.sock")
+	l1, err := Acquire(sock)
+	if err != nil {
+		t.Fatalf("first Acquire: %v", err)
+	}
+	defer l1.Release()
+
+	if _, err := Acquire(sock); !errors.Is(err, ErrHeld) {
+		t.Fatalf("second Acquire = %v, want ErrHeld", err)
+	}
+	if _, err := AcquireExisting(sock); !errors.Is(err, ErrHeld) {
+		t.Fatalf("second AcquireExisting = %v, want ErrHeld", err)
+	}
+}
+
+// Mutation: make Release skip the flock LOCK_UN / Close.
+func TestAcquireSucceedsAfterRelease(t *testing.T) {
+	sock := tempSock(t, "a.sock")
+	l1, err := Acquire(sock)
+	if err != nil {
+		t.Fatalf("first Acquire: %v", err)
+	}
+	if err := l1.Release(); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+	l2, err := Acquire(sock)
+	if err != nil {
+		t.Fatalf("Acquire after Release: %v", err)
+	}
+	if err := l2.Release(); err != nil {
+		t.Fatalf("second Release: %v", err)
+	}
+	if err := l2.Release(); err != nil {
+		t.Fatalf("Release must be idempotent: %v", err)
+	}
+}
+
+// Mutation: give AcquireExisting the O_CREATE flag. A pathname whose owner
+// predates the lease protocol must stay un-leased, because the daemon treats a
+// missing lock file as "not provably dead".
+func TestAcquireExistingNeverCreatesLockFile(t *testing.T) {
+	sock := tempSock(t, "legacy.sock")
+	if _, err := AcquireExisting(sock); !errors.Is(err, ErrNoLockFile) {
+		t.Fatalf("AcquireExisting = %v, want ErrNoLockFile", err)
+	}
+	if _, err := os.Lstat(LockPath(sock)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("AcquireExisting created a lock file: %v", err)
+	}
+}
+
+// Mutation: drop the os.Remove of the lock file in Release. Without it the
+// socket directory accumulates one lock file per session ever started, which
+// the daemon then re-reads on every discovery tick.
+func TestReleaseUnlinksLockFile(t *testing.T) {
+	sock := tempSock(t, "a.sock")
+	l, err := Acquire(sock)
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	if _, err := os.Lstat(l.LockPath()); err != nil {
+		t.Fatalf("lock file missing while lease held: %v", err)
+	}
+	if err := l.Release(); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+	if _, err := os.Lstat(l.LockPath()); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("lock file survived Release: %v", err)
+	}
+}
+
+func TestLockFileIsOwnerOnly(t *testing.T) {
+	sock := tempSock(t, "a.sock")
+	l, err := Acquire(sock)
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	defer l.Release()
+	fi, err := os.Lstat(l.LockPath())
+	if err != nil {
+		t.Fatalf("lstat lock: %v", err)
+	}
+	if perm := fi.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("lock file mode = %o, want 600", perm)
+	}
+}
+
+// The lease must not survive an exec: the runner's PTY child would otherwise
+// inherit the descriptor and hold the socket pathname hostage for as long as
+// the child lives, long after the runner itself exited.
+func TestLeaseDescriptorIsCloseOnExec(t *testing.T) {
+	sock := tempSock(t, "a.sock")
+	l, err := Acquire(sock)
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	defer l.Release()
+	flags, _, errno := syscall.Syscall(syscall.SYS_FCNTL, l.f.Fd(), syscall.F_GETFD, 0)
+	if errno != 0 {
+		t.Fatalf("fcntl F_GETFD: %v", errno)
+	}
+	if flags&syscall.FD_CLOEXEC == 0 {
+		t.Fatal("lease descriptor is not close-on-exec; an exec'd child would inherit the lease")
+	}
+}
+
+// Mutation: delete the verify-after-lock branch in acquire (the sameFile
+// check). This is the schedule that makes unlinking lock files safe:
+//
+//  1. holder H owns the lease on inode X.
+//  2. acquirer A opens X (still the file the lock pathname names).
+//  3. H releases: X is unlinked, the lock is dropped.
+//  4. replacement R creates a fresh lock file Y and takes the lease.
+//  5. A's flock on X now succeeds -- X is an orphaned inode nobody else
+//     locks -- so without the verify, A and R would both believe they own the
+//     pathname.
+func TestAcquireRejectsReplacedLockFile(t *testing.T) {
+	sock := tempSock(t, "a.sock")
+
+	holder, err := Acquire(sock)
+	if err != nil {
+		t.Fatalf("holder Acquire: %v", err)
+	}
+
+	var replacement *Lease
+	defer func() {
+		if replacement != nil {
+			_ = replacement.Release()
+		}
+	}()
+
+	fired := false
+	testAfterOpen = func() {
+		if fired {
+			return // only perturb the first attempt; the retry must succeed... or not
+		}
+		fired = true
+		if err := holder.Release(); err != nil {
+			t.Errorf("holder Release: %v", err)
+		}
+		replacement, err = Acquire(sock)
+		if err != nil {
+			t.Errorf("replacement Acquire: %v", err)
+		}
+	}
+	defer func() { testAfterOpen = nil }()
+
+	got, err := Acquire(sock)
+	if err == nil {
+		_ = got.Release()
+		t.Fatal("Acquire returned a lease for a lock file that had been replaced; " +
+			"the verify-after-lock check is missing and two owners can coexist")
+	}
+	if !errors.Is(err, ErrHeld) {
+		t.Fatalf("Acquire = %v, want ErrHeld (the replacement owns the lease)", err)
+	}
+	if !fired {
+		t.Fatal("barrier hook never ran")
+	}
+}
+
+// Mutation: make RemoveSocket unlink unconditionally, or check an identity
+// instead of a pin.
+//
+// The three-actor schedule an old owner must never win: a live replacement
+// rebound the pathname, and unlinking it would leave a running runner
+// unreachable. Note what this test does *not* do: it does not require the
+// replacement to have a different inode. It cannot -- see
+// TestPinSurvivesImmediateInodeReuse -- and that is the whole reason the guard
+// is a pin.
+func TestRemoveSocketLeavesReboundPathname(t *testing.T) {
+	sock := tempSock(t, "a.sock")
+
+	old := listenUnix(t, sock)
+	lease, err := Acquire(sock)
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	defer lease.Release()
+	pin, err := lease.PinSocket()
+	if err != nil {
+		t.Fatalf("PinSocket: %v", err)
+	}
+	defer pin.Close()
+
+	// The pathname is rebound by a replacement runner.
+	_ = old.Close()
+	if err := os.Remove(sock); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	replacement := listenUnix(t, sock)
+	replacementID, ok := StatSocket(sock)
+	if !ok {
+		t.Fatal("replacement socket not found")
+	}
+
+	if err := lease.RemoveSocket(pin); !errors.Is(err, ErrIdentityChanged) {
+		t.Fatalf("RemoveSocket = %v, want ErrIdentityChanged (inode reused: %v)",
+			err, replacementID.Dev == pin.Ident().Dev && replacementID.Ino == pin.Ident().Ino)
+	}
+	after, ok := StatSocket(sock)
+	if !ok {
+		t.Fatal("RemoveSocket unlinked the replacement's live socket")
+	}
+	if after != replacementID {
+		t.Fatal("the replacement's pathname was disturbed")
+	}
+	_ = replacement
+}
+
+// The property the whole Ident/Pin distinction exists for, driven against
+// immediate inode reuse rather than around it.
+//
+// A pathname is unlinked and rebound in the same breath, many times. Some
+// filesystems hand back the inode just freed -- GitHub's runners do, this
+// project's development machines do not -- so the replacement's device and
+// inode may equal the original's exactly. The identity comparison this code
+// used to make would then say "unchanged" and unlink a live socket. The pin says
+// otherwise every single time, because it holds the file rather than describing
+// it.
+//
+// Mutation: compare identities in RemoveSocket instead of consulting the pin.
+// On a filesystem that recycles, this test then unlinks live sockets; on one
+// that does not, it still passes -- which is exactly why the guard must not be
+// an identity comparison, and why this test reports what it observed.
+func TestPinSurvivesImmediateInodeReuse(t *testing.T) {
+	sock := tempSock(t, "reuse.sock")
+	lease, err := Acquire(sock)
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	defer lease.Release()
+
+	const rounds = 200
+	reused, exact := 0, 0
+	for round := range rounds {
+		original := listenUnix(t, sock)
+		pin, err := lease.PinSocket()
+		if err != nil {
+			t.Fatalf("round %d: PinSocket: %v", round, err)
+		}
+		if pin.Exact() {
+			exact++
+		}
+		originalID := pin.Ident()
+
+		// The replacement, as abruptly as a filesystem will allow.
+		_ = original.Close()
+		if err := os.Remove(sock); err != nil {
+			t.Fatalf("round %d: remove: %v", round, err)
+		}
+		replacement := listenUnix(t, sock)
+		replacementID, ok := StatSocket(sock)
+		if !ok {
+			t.Fatalf("round %d: replacement socket not found", round)
+		}
+		if replacementID.Dev == originalID.Dev && replacementID.Ino == originalID.Ino {
+			reused++
+			// On a recycling filesystem the identities may be equal in full,
+			// stamp included: the kernel's file-timestamp clock is coarse, so
+			// two creations microseconds apart share it. That is the case the
+			// pin exists for, so assert it rather than skip it.
+			if replacementID.Same(originalID) && !pin.Exact() {
+				t.Fatalf("round %d: this platform can neither pin nor distinguish a recycled inode; "+
+					"the removal guard has nothing to stand on", round)
+			}
+		}
+
+		// The guard: the pathname no longer names the pinned file, whatever the
+		// numbers say.
+		if pin.StillNamesIt() {
+			t.Fatalf("round %d: the pin still claims the pathname after a rebind (original %s, now %s)",
+				round, originalID, replacementID)
+		}
+		if err := lease.RemoveSocket(pin); !errors.Is(err, ErrIdentityChanged) {
+			t.Fatalf("round %d: RemoveSocket = %v, want ErrIdentityChanged", round, err)
+		}
+		if _, ok := StatSocket(sock); !ok {
+			t.Fatalf("round %d: a live replacement's socket was unlinked", round)
+		}
+
+		_ = pin.Close()
+		_ = replacement.Close()
+		if err := os.Remove(sock); err != nil {
+			t.Fatalf("round %d: cleanup: %v", round, err)
+		}
+	}
+	t.Logf("%d/%d rounds reused the inode immediately; %d/%d pins were exact handles",
+		reused, rounds, exact, rounds)
+}
+
+// And the positive case: a pin that still names its file authorises the unlink.
+func TestRemoveSocketRemovesOwnPathname(t *testing.T) {
+	sock := tempSock(t, "a.sock")
+	listenUnix(t, sock)
+	lease, err := Acquire(sock)
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	defer lease.Release()
+	pin, err := lease.PinSocket()
+	if err != nil {
+		t.Fatalf("PinSocket: %v", err)
+	}
+	defer pin.Close()
+
+	if !pin.StillNamesIt() {
+		t.Fatal("a pin taken on an untouched socket does not claim its pathname")
+	}
+	if err := lease.RemoveSocket(pin); err != nil {
+		t.Fatalf("RemoveSocket: %v", err)
+	}
+	if _, err := os.Lstat(sock); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("socket still present: %v", err)
+	}
+	// Idempotent: a second removal of a vanished pathname is not an error.
+	if err := lease.RemoveSocket(pin); err != nil {
+		t.Fatalf("second RemoveSocket: %v", err)
+	}
+}
+
+// Mutation: let RemoveSocket act without a pin, or with one for another
+// pathname. "I don't know what is there" must never authorise an unlink.
+func TestRemoveSocketRejectsAnAbsentOrForeignPin(t *testing.T) {
+	sock := tempSock(t, "a.sock")
+	listenUnix(t, sock)
+	lease, err := Acquire(sock)
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	defer lease.Release()
+
+	if err := lease.RemoveSocket(nil); !errors.Is(err, ErrIdentityChanged) {
+		t.Fatalf("RemoveSocket(nil) = %v, want ErrIdentityChanged", err)
+	}
+	other := tempSock(t, "other.sock")
+	listenUnix(t, other)
+	foreign, err := PinSocket(other)
+	if err != nil {
+		t.Fatalf("PinSocket: %v", err)
+	}
+	defer foreign.Close()
+	if err := lease.RemoveSocket(foreign); !errors.Is(err, ErrIdentityChanged) {
+		t.Fatalf("RemoveSocket(foreign pin) = %v, want ErrIdentityChanged", err)
+	}
+	for _, p := range []string{sock, other} {
+		if _, ok := StatSocket(p); !ok {
+			t.Fatalf("%s was unlinked", p)
+		}
+	}
+}
+
+// A hardlink is the other way a pathname can stop being the only name for a
+// file, and on a recycling filesystem it is indistinguishable by number.
+//
+// Mutation: accept any link count in Pin.StillNamesIt.
+func TestPinRejectsAHardlinkedFile(t *testing.T) {
+	sock := tempSock(t, "a.sock")
+	listenUnix(t, sock)
+	pin, err := PinSocket(sock)
+	if err != nil {
+		t.Fatalf("PinSocket: %v", err)
+	}
+	defer pin.Close()
+	if !pin.Exact() {
+		t.Skip("this platform cannot pin a socket; link counts are not observable")
+	}
+	if !pin.StillNamesIt() {
+		t.Fatal("a fresh pin does not claim its pathname")
+	}
+
+	alias := sock + ".alias"
+	if err := os.Link(sock, alias); err != nil {
+		t.Skipf("this filesystem does not support hard-linking a socket: %v", err)
+	}
+	defer os.Remove(alias)
+	if pin.StillNamesIt() {
+		t.Fatal("a pin claims a pathname that is no longer the file's only name")
+	}
+}
+
+// Mutation: drop the ModeSocket check (or switch Lstat to Stat) in StatSocket.
+// Both would let the daemon unlink a regular file or follow a symlink out of
+// the trusted socket directory.
+func TestStatSocketRejectsNonSockets(t *testing.T) {
+	dir := t.TempDir()
+
+	regular := filepath.Join(dir, "regular.sock")
+	if err := os.WriteFile(regular, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, ok := StatSocket(regular); ok {
+		t.Error("a regular file was reported as a socket")
+	}
+
+	real := filepath.Join(dir, "real.sock")
+	listenUnix(t, real)
+	link := filepath.Join(dir, "link.sock")
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	if _, ok := StatSocket(link); ok {
+		t.Error("a symlink to a socket was reported as a socket (Lstat became Stat?)")
+	}
+
+	if _, ok := StatSocket(filepath.Join(dir, "missing.sock")); ok {
+		t.Error("a missing path was reported as a socket")
+	}
+
+	dirPath := filepath.Join(dir, "sub.sock")
+	if err := os.Mkdir(dirPath, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if _, ok := StatSocket(dirPath); ok {
+		t.Error("a directory was reported as a socket")
+	}
+}
+
+// Mutation: let Known() ignore the stamp, or let Same() compare only device and
+// inode.
+//
+// An identity without a creation stamp is exactly the number-only identity that
+// inode reuse defeats, so it counts as unknown; and two identities read from
+// different clocks are not comparable at all.
+func TestIdentKnownAndSame(t *testing.T) {
+	var zero Ident
+	if zero.Known() {
+		t.Error("zero Ident must be unknown")
+	}
+	if zero.Same(zero) {
+		t.Error("unknown identities must never compare equal")
+	}
+
+	numbersOnly := Ident{Dev: 1, Ino: 2}
+	if numbersOnly.Known() {
+		t.Error("an identity with no creation stamp must count as unknown")
+	}
+	if numbersOnly.Same(numbersOnly) {
+		t.Error("an unstamped identity must not match itself")
+	}
+
+	a := Ident{Dev: 1, Ino: 2, StampSec: 7, StampNsec: 8, Stamp: StampChange}
+	if !a.Known() {
+		t.Error("a fully observed identity must be known")
+	}
+	if !a.Same(Ident{Dev: 1, Ino: 2, StampSec: 7, StampNsec: 8, Stamp: StampChange}) {
+		t.Error("equal known identities must match")
+	}
+	for _, other := range []Ident{
+		{Dev: 1, Ino: 3, StampSec: 7, StampNsec: 8, Stamp: StampChange}, // recycled number
+		{Dev: 1, Ino: 2, StampSec: 8, StampNsec: 8, Stamp: StampChange}, // reincarnation
+		{Dev: 1, Ino: 2, StampSec: 7, StampNsec: 9, Stamp: StampChange}, // reincarnation, ns apart
+		{Dev: 1, Ino: 2, StampSec: 7, StampNsec: 8, Stamp: StampBirth},  // different clock
+		{Dev: 2, Ino: 2, StampSec: 7, StampNsec: 8, Stamp: StampChange}, // different device
+	} {
+		if a.Same(other) {
+			t.Errorf("%s must not match %s", a, other)
+		}
+	}
+	if a.Same(zero) {
+		t.Error("known must not match unknown")
+	}
+	if got := a.String(); got == "" || got == "unknown-identity" {
+		t.Errorf("String() = %q", got)
+	}
+}
+
+// A real socket's identity must be complete: this is the platform helper's
+// contract, and the reason an unsupported platform degrades to unknown rather
+// than to numbers.
+func TestStatSocketReportsACompleteIdentity(t *testing.T) {
+	sock := tempSock(t, "a.sock")
+	listenUnix(t, sock)
+	id, ok := StatSocket(sock)
+	if !ok {
+		t.Fatal("StatSocket on a real socket reported not-a-socket")
+	}
+	if !id.Known() {
+		t.Fatalf("identity %s is incomplete; inode numbers alone cannot survive reuse", id)
+	}
+	if id.Stamp == StampNone || (id.StampSec == 0 && id.StampNsec == 0) {
+		t.Fatalf("identity %s carries no creation stamp", id)
+	}
+	if id.Stamp == StampBirth && runtime.GOOS == "linux" {
+		t.Error("linux reports a birth time it cannot read without statx")
+	}
+}
+
+// Mutation: drop the sameFile condition guarding the unlink in Release.
+//
+// Three actors, and the substitution happens before A releases -- no
+// instruction-level race needed:
+//
+//  1. A holds the lease on lock inode LA.
+//  2. Something replaces the lock pathname; B acquires the replacement LB.
+//  3. A releases. An unconditional unlink here removes *B's* lock pathname,
+//     so C can create a third lock file and take a lease while B still holds
+//     one. Two live leases over one socket pathname is precisely the state
+//     this package exists to make impossible.
+func TestReleaseDoesNotUnlinkASubstitutedLockFile(t *testing.T) {
+	sock := tempSock(t, "a.sock")
+
+	a, err := Acquire(sock)
+	if err != nil {
+		t.Fatalf("A Acquire: %v", err)
+	}
+	// The lock pathname is substituted out from under A.
+	if err := os.Remove(a.LockPath()); err != nil {
+		t.Fatal(err)
+	}
+	b, err := Acquire(sock)
+	if err != nil {
+		t.Fatalf("B Acquire: %v", err)
+	}
+	defer b.Release()
+	bLock, err := os.Lstat(b.LockPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := a.Release(); err != nil {
+		t.Fatalf("A Release: %v", err)
+	}
+
+	after, err := os.Lstat(b.LockPath())
+	if err != nil {
+		t.Fatalf("A's Release unlinked B's lock file: %v", err)
+	}
+	if !os.SameFile(bLock, after) {
+		t.Fatal("A's Release replaced B's lock file")
+	}
+	// And B's lease still excludes everyone.
+	if _, err := Acquire(sock); !errors.Is(err, ErrHeld) {
+		t.Fatalf("C acquired a second lease for the same pathname: %v", err)
+	}
+}
+
+// Mutation: drop O_NOFOLLOW from the lock open.
+//
+// A symlink at the lock pathname must not become a lease on -- and later an
+// unlink of -- whatever it points at.
+func TestAcquireRefusesToFollowASymlinkedLockPath(t *testing.T) {
+	dir := t.TempDir()
+	sock := filepath.Join(dir, "a.sock")
+	victim := filepath.Join(dir, "victim")
+	if err := os.WriteFile(victim, []byte("not a lock file"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(victim, LockPath(sock)); err != nil {
+		t.Fatal(err)
+	}
+
+	lease, err := Acquire(sock)
+	if err == nil {
+		_ = lease.Release()
+		t.Fatal("Acquire followed a symlinked lock pathname")
+	}
+	// Refused at the open, not merely defeated by the post-lock verification:
+	// without O_NOFOLLOW the victim is opened and flocked 16 times before the
+	// inode comparison rejects it, which is a denial of service dressed up as
+	// safety.
+	if !errors.Is(err, syscall.ELOOP) {
+		t.Fatalf("Acquire = %v, want ELOOP (the open must refuse the symlink)", err)
+	}
+	if _, statErr := os.Lstat(victim); statErr != nil {
+		t.Fatalf("the symlink target was disturbed: %v", statErr)
+	}
+}
+
+// CreatedLockFile is the runner's evidence about who owns a pathname it could
+// not bind, so it has to be exactly right in both directions.
+//
+// Mutation: always report true (or always false) from CreatedLockFile.
+func TestCreatedLockFileDistinguishesFoundFromMade(t *testing.T) {
+	sock := tempSock(t, "a.sock")
+
+	first, err := Acquire(sock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !first.CreatedLockFile() {
+		t.Error("the first acquisition created the lock file but did not report it")
+	}
+	// Release keeps nothing behind, so the next acquisition creates it again.
+	if err := first.Release(); err != nil {
+		t.Fatal(err)
+	}
+	second, err := Acquire(sock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !second.CreatedLockFile() {
+		t.Error("acquisition after a clean release should have created the file again")
+	}
+	if err := second.Release(); err != nil {
+		t.Fatal(err)
+	}
+
+	// A lock file left behind by a crashed owner: found, not made.
+	if err := os.WriteFile(LockPath(sock), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	third, err := Acquire(sock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer third.Release()
+	if third.CreatedLockFile() {
+		t.Error("a pre-existing lock file was reported as created by this acquisition")
+	}
+}
+
+// Mutation: make AcquireWait give up on the first ErrHeld.
+//
+// The daemon's reaper holds the lease across its inspection; a runner starting
+// in that window must wait it out rather than lose its session identity.
+func TestAcquireWaitOutlastsAShortLivedHolder(t *testing.T) {
+	sock := tempSock(t, "a.sock")
+	holder, err := Acquire(sock)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	released := make(chan struct{})
+	testBeforeAcquireRetry = func(attempt int) {
+		if attempt == 0 {
+			_ = holder.Release()
+			close(released)
+		}
+	}
+	t.Cleanup(func() { testBeforeAcquireRetry = nil })
+
+	lease, err := AcquireWait(sock, 2*time.Second)
+	if err != nil {
+		t.Fatalf("AcquireWait: %v (it gave up while the holder was releasing)", err)
+	}
+	defer lease.Release()
+	select {
+	case <-released:
+	default:
+		t.Fatal("AcquireWait returned without waiting for the holder")
+	}
+}
+
+// The wait is bounded: a lease held for good is still reported as held.
+func TestAcquireWaitGivesUpOnAPersistentHolder(t *testing.T) {
+	sock := tempSock(t, "a.sock")
+	holder, err := Acquire(sock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer holder.Release()
+
+	start := time.Now()
+	if _, err := AcquireWait(sock, 40*time.Millisecond); !errors.Is(err, ErrHeld) {
+		t.Fatalf("AcquireWait = %v, want ErrHeld", err)
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("AcquireWait waited %v, far past its budget", elapsed)
+	}
+}
+
+// Mutation: make ReleaseKeepingLockFile an alias for Release.
+//
+// The reaper borrows the lease to inspect a pathname it does not own. When it
+// declines without learning anything, the lock file must survive: it is the
+// only evidence that the leftover socket belonged to a lease-aware generation,
+// and therefore the only thing that will ever let a runner reclaim it.
+func TestReleaseKeepingLockFilePreservesLeaseHistory(t *testing.T) {
+	sock := tempSock(t, "a.sock")
+	owner, err := Acquire(sock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The owner dies without cleaning up: the lock file stays.
+	if err := owner.ReleaseKeepingLockFile(); err != nil {
+		t.Fatalf("ReleaseKeepingLockFile: %v", err)
+	}
+	if _, err := os.Lstat(LockPath(sock)); err != nil {
+		t.Fatalf("lock file removed by ReleaseKeepingLockFile: %v", err)
+	}
+
+	// A borrower inspects and puts it back untouched.
+	borrower, err := AcquireExisting(sock)
+	if err != nil {
+		t.Fatalf("AcquireExisting: %v", err)
+	}
+	if borrower.CreatedLockFile() {
+		t.Error("AcquireExisting reported creating a file it cannot create")
+	}
+	if err := borrower.ReleaseKeepingLockFile(); err != nil {
+		t.Fatalf("borrower release: %v", err)
+	}
+
+	// The evidence survived both, so the next owner still knows this pathname
+	// had a lease-aware generation.
+	next, err := Acquire(sock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer next.Release()
+	if next.CreatedLockFile() {
+		t.Fatal("lease history was lost: the next owner had to create the lock file")
+	}
+}
+
+// Mutation: treat any dial failure as a refusal (drop the ECONNREFUSED check).
+//
+// One predicate, used by the runner before it clears a leftover and by the
+// daemon before it reaps one. A timeout must never read as "nothing answers":
+// a wedged live owner with a full backlog is not a dead one.
+func TestProbeRefusedOnlyAcceptsAnActualRefusal(t *testing.T) {
+	dir := t.TempDir()
+
+	t.Run("refused", func(t *testing.T) {
+		path := filepath.Join(dir, "stale.sock")
+		ln := listenUnix(t, path)
+		_ = ln.Close() // pathname stays, nobody listening
+		if err := ProbeRefused(path, time.Second); err != nil {
+			t.Fatalf("ProbeRefused on a stale socket = %v, want nil", err)
+		}
+	})
+
+	t.Run("live", func(t *testing.T) {
+		path := filepath.Join(dir, "live.sock")
+		ln := listenUnix(t, path)
+		go func() {
+			for {
+				c, err := ln.Accept()
+				if err != nil {
+					return
+				}
+				_ = c.Close()
+			}
+		}()
+		err := ProbeRefused(path, time.Second)
+		if !errors.Is(err, ErrNotRefused) {
+			t.Fatalf("ProbeRefused on a live socket = %v, want ErrNotRefused", err)
+		}
+	})
+
+	t.Run("missing", func(t *testing.T) {
+		err := ProbeRefused(filepath.Join(dir, "absent.sock"), time.Second)
+		if !errors.Is(err, ErrNotRefused) {
+			t.Fatalf("ProbeRefused on a missing pathname = %v, want ErrNotRefused", err)
+		}
+	})
+
+	// Mutation: treat a timeout as a refusal.
+	//
+	// A connect that neither completes nor is refused proves nothing: a live
+	// owner with a full accept backlog looks exactly like this. The deadline is
+	// forced to have already passed, which makes the classification -- not the
+	// timing -- the thing under test.
+	t.Run("timed out", func(t *testing.T) {
+		path := filepath.Join(dir, "wedged.sock")
+		ln := listenUnix(t, path)
+		go func() {
+			for {
+				c, err := ln.Accept()
+				if err != nil {
+					return
+				}
+				_ = c.Close()
+			}
+		}()
+		err := ProbeRefused(path, time.Nanosecond)
+		if err == nil {
+			t.Fatal("a probe that timed out was reported as a refusal")
+		}
+		if !errors.Is(err, ErrProbeTimeout) {
+			t.Fatalf("ProbeRefused = %v, want ErrProbeTimeout", err)
+		}
+		if errors.Is(err, ErrSocketLive) {
+			t.Fatal("a timeout was classified as a live owner")
+		}
+	})
+
+	t.Run("not a socket", func(t *testing.T) {
+		path := filepath.Join(dir, "regular.sock")
+		if err := os.WriteFile(path, []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		err := ProbeRefused(path, time.Second)
+		if !errors.Is(err, ErrNotRefused) {
+			t.Fatalf("ProbeRefused on a regular file = %v, want ErrNotRefused", err)
+		}
+	})
+}
+
+// The protocol's stated premise, enforced where the directory is created.
+//
+// Mutation: drop the ownership check, or the permission tightening.
+func TestRequireOwnedDir(t *testing.T) {
+	t.Run("creates a private directory", func(t *testing.T) {
+		dir := filepath.Join(t.TempDir(), "sessions")
+		if err := RequireOwnedDir(dir); err != nil {
+			t.Fatalf("RequireOwnedDir: %v", err)
+		}
+		fi, err := os.Lstat(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if perm := fi.Mode().Perm(); perm != 0o700 {
+			t.Fatalf("mode = %o, want 700", perm)
+		}
+	})
+
+	t.Run("tightens a permissive directory", func(t *testing.T) {
+		dir := filepath.Join(t.TempDir(), "sessions")
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := RequireOwnedDir(dir); err != nil {
+			t.Fatalf("RequireOwnedDir: %v", err)
+		}
+		fi, err := os.Lstat(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if perm := fi.Mode().Perm(); perm != 0o700 {
+			t.Fatalf("mode = %o, want 700: a directory others can write in makes every lease meaningless", perm)
+		}
+	})
+
+	t.Run("refuses a file", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "sessions")
+		if err := os.WriteFile(path, nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := RequireOwnedDir(path); err == nil {
+			t.Fatal("RequireOwnedDir accepted a regular file")
+		}
+	})
+
+	// Mutation: delete the ownership comparison.
+	//
+	// The check is driven through the euid seam rather than against a real
+	// foreign directory, for two reasons. It has to fail for the *ownership*
+	// reason alone -- a world-writable directory like /tmp would also fail on
+	// the chmod, so deleting the uid check would still produce an error and
+	// prove nothing -- and a test must never chmod a directory it does not
+	// own, which is exactly what the mutated code would attempt.
+	t.Run("refuses a directory owned by another user", func(t *testing.T) {
+		dir := filepath.Join(t.TempDir(), "sessions")
+		// Ours, and already private: nothing else here can fail.
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		geteuidFn = func() int { return os.Geteuid() + 1 }
+		t.Cleanup(func() { geteuidFn = os.Geteuid })
+
+		err := RequireOwnedDir(dir)
+		if err == nil {
+			t.Fatal("RequireOwnedDir accepted a directory owned by another user")
+		}
+		if !strings.Contains(err.Error(), "owned by uid") {
+			t.Fatalf("RequireOwnedDir = %v, want it to refuse on ownership", err)
+		}
+		// The directory is untouched: a foreign directory is refused, never
+		// modified.
+		fi, statErr := os.Lstat(dir)
+		if statErr != nil {
+			t.Fatal(statErr)
+		}
+		if perm := fi.Mode().Perm(); perm != 0o700 {
+			t.Fatalf("mode = %o, want it unchanged at 700", perm)
+		}
+	})
+
+	// The same schedule with permissions that *would* need tightening: the
+	// ownership check must come first, so a directory that is not ours is never
+	// chmod'ed on the way to refusing it.
+	t.Run("never modifies a directory owned by another user", func(t *testing.T) {
+		dir := filepath.Join(t.TempDir(), "sessions")
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		geteuidFn = func() int { return os.Geteuid() + 1 }
+		t.Cleanup(func() { geteuidFn = os.Geteuid })
+
+		if err := RequireOwnedDir(dir); err == nil {
+			t.Fatal("RequireOwnedDir accepted a directory owned by another user")
+		}
+		fi, err := os.Lstat(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if perm := fi.Mode().Perm(); perm != 0o755 {
+			t.Fatalf("mode = %o: a directory we do not own was modified", perm)
+		}
+	})
+}
+
+// The CI condition, forced rather than waited for.
+//
+// A filesystem that recycles inode numbers immediately produces a state this
+// project's development machines cannot: the pathname names a *different* file
+// whose device, inode and creation stamp all equal the pinned file's. Nothing a
+// test can do to a non-recycling filesystem will produce it -- unlinking and
+// rebinding always yields new numbers here, and hardlinking the original back
+// yields the same file with a fresh ctime.
+//
+// So it is constructed: the pin's recorded identity is overwritten with the
+// replacement's, which is exactly what the kernel would have handed us on a
+// recycling filesystem. The pinned *file* is still the original -- unlinked, and
+// therefore no longer named by anything -- and that is what the pin reports.
+//
+// Mutation: make RemoveSocket compare identities instead of consulting the pin.
+// This test then unlinks a live replacement, which is the production defect CI
+// caught.
+func TestPinDetectsAReplacementThatCarriesTheSameIdentity(t *testing.T) {
+	sock := tempSock(t, "recycled.sock")
+	original := listenUnix(t, sock)
+	lease, err := Acquire(sock)
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	defer lease.Release()
+	pin, err := lease.PinSocket()
+	if err != nil {
+		t.Fatalf("PinSocket: %v", err)
+	}
+	defer pin.Close()
+	if !pin.Exact() {
+		t.Skip("this platform cannot hold a handle on a socket; the identity is all there is")
+	}
+
+	// A live replacement takes the pathname.
+	_ = original.Close()
+	if err := os.Remove(sock); err != nil {
+		t.Fatal(err)
+	}
+	replacement := listenUnix(t, sock)
+	replacementID, ok := StatSocket(sock)
+	if !ok {
+		t.Fatal("replacement socket not found")
+	}
+
+	// Force the collision: pretend the kernel handed the replacement the
+	// original's numbers and stamp.
+	pin.ident = replacementID
+	if current, _ := StatSocket(sock); !current.Same(pin.ident) {
+		t.Fatal("the forced collision did not take")
+	}
+
+	// An identity comparison now says "unchanged". The pin does not.
+	if pin.StillNamesIt() {
+		t.Fatal("the pin claims a pathname that names a different file with the same identity")
+	}
+	if err := lease.RemoveSocket(pin); !errors.Is(err, ErrIdentityChanged) {
+		t.Fatalf("RemoveSocket = %v, want ErrIdentityChanged", err)
+	}
+	after, ok := StatSocket(sock)
+	if !ok {
+		t.Fatal("a live replacement's socket was unlinked because its identity matched a recycled one")
+	}
+	if after != replacementID {
+		t.Fatal("the replacement's pathname was disturbed")
+	}
+	_ = replacement.Close()
+}

--- a/packages/socklease/stat_darwin.go
+++ b/packages/socklease/stat_darwin.go
@@ -1,0 +1,45 @@
+//go:build darwin
+
+package socklease
+
+import (
+	"os"
+	"syscall"
+)
+
+// statSocket reads a socket's identity on Darwin, where the birth time is in
+// the ordinary stat result and is therefore free to use.
+//
+// Never the modification time: mtime is caller-visible and would make an
+// identity something another process can forge by touching the file.
+func statSocket(path string) (Ident, bool) {
+	fi, err := os.Lstat(path)
+	if err != nil || fi.Mode()&fileModeSocket == 0 {
+		return Ident{}, false
+	}
+	st, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		return Ident{}, false
+	}
+	return Ident{
+		Dev:       uint64(st.Dev),
+		Ino:       uint64(st.Ino),
+		StampSec:  int64(st.Birthtimespec.Sec),
+		StampNsec: int64(st.Birthtimespec.Nsec),
+		Stamp:     StampBirth,
+	}, true
+}
+
+// Darwin has no O_PATH, and open(2) on a socket fails, so there is no handle to
+// pin with: a pin degrades to its identity, which here means device, inode and
+// APFS birth time.
+//
+// The reincarnation this guards against is also much harder to reach on Darwin:
+// APFS assigns object identifiers from a counter rather than a reusable bitmap,
+// so an inode number freed now is not handed out again next. Where the number
+// cannot repeat, the number is already an identity.
+func pinFile(string) (int, error) { return -1, syscall.ENOTSUP }
+
+func pinnedLinkCount(int) (uint64, error) { return 0, syscall.ENOTSUP }
+
+func closeFile(int) error { return nil }

--- a/packages/socklease/stat_linux.go
+++ b/packages/socklease/stat_linux.go
@@ -1,0 +1,62 @@
+//go:build linux
+
+package socklease
+
+import (
+	"os"
+	"syscall"
+)
+
+// statSocket reads a socket's identity on Linux.
+//
+// The stamp is the inode change time. For a file that is created and then never
+// chmod'ed, chown'ed or renamed -- every socket in this protocol -- ctime is its
+// creation time, and it is stored with nanosecond fields.
+//
+// Not the birth time, despite btime being the more obviously correct field:
+// reading it needs statx, which the standard library does not expose, so it
+// would mean a hand-written syscall number per architecture and a hand-written
+// struct layout on the platform this code matters most on. Measured on this
+// project's filesystems, btime buys nothing for it -- both stamps come from the
+// same coarse kernel clock, and ~99% of back-to-back socket creations share
+// either one. The risk is real and the gain is zero.
+//
+// Never the modification time: mtime is caller-visible and would make an
+// identity something another process can forge by touching the file.
+func statSocket(path string) (Ident, bool) {
+	fi, err := os.Lstat(path)
+	if err != nil || fi.Mode()&fileModeSocket == 0 {
+		return Ident{}, false
+	}
+	st, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		return Ident{}, false
+	}
+	return Ident{
+		//nolint:unconvert // Dev is uint64 on linux and int32 on darwin.
+		Dev:       uint64(st.Dev),
+		Ino:       uint64(st.Ino),
+		StampSec:  int64(st.Ctim.Sec),
+		StampNsec: int64(st.Ctim.Nsec),
+		Stamp:     StampChange,
+	}, true
+}
+
+// oPath is O_PATH: open a file to refer to it, without opening it for I/O. It
+// is the only way to get a handle on a socket file, which cannot be opened
+// normally, and it is what makes an exact pin possible on Linux.
+const oPath = 0x200000
+
+func pinFile(path string) (int, error) {
+	return syscall.Open(path, syscall.O_RDONLY|oPath|syscall.O_NOFOLLOW|syscall.O_CLOEXEC, 0)
+}
+
+func pinnedLinkCount(fd int) (uint64, error) {
+	var st syscall.Stat_t
+	if err := syscall.Fstat(fd, &st); err != nil {
+		return 0, err
+	}
+	return uint64(st.Nlink), nil
+}
+
+func closeFile(fd int) error { return syscall.Close(fd) }

--- a/packages/socklease/stat_unsupported.go
+++ b/packages/socklease/stat_unsupported.go
@@ -1,0 +1,31 @@
+//go:build !linux && !darwin
+
+package socklease
+
+import (
+	"os"
+	"syscall"
+)
+
+// statSocket on a platform this package has not been taught: the socket type is
+// still checked, but no creation stamp is reported, so every identity is
+// unknown.
+//
+// That is the conservative outcome by construction rather than by policy: an
+// unknown identity suppresses no probe and authorises no unlink, so the lease
+// still excludes concurrent runners and nothing destructive happens on evidence
+// this platform cannot supply. Sockets accumulate instead, which is a leak, not
+// a hazard.
+func statSocket(path string) (Ident, bool) {
+	fi, err := os.Lstat(path)
+	if err != nil || fi.Mode()&fileModeSocket == 0 {
+		return Ident{}, false
+	}
+	return Ident{}, true
+}
+
+func pinFile(string) (int, error) { return -1, syscall.ENOSYS }
+
+func pinnedLinkCount(int) (uint64, error) { return 0, syscall.ENOSYS }
+
+func closeFile(int) error { return nil }

--- a/services/gmuxd/cmd/gmuxd/bootstrap.go
+++ b/services/gmuxd/cmd/gmuxd/bootstrap.go
@@ -130,18 +130,22 @@ type BootstrapConfig struct {
 	// Durable overrides Store only at the coordinator boundary. Production
 	// leaves it nil; composition tests use it to count durable operations while
 	// retaining the real central store for all other bootstrap components.
-	Durable                        sessioncoord.Durable
-	Runners                        sessioncoord.RunnerClient
-	Control                        sessioncoord.RunnerControl
-	Spawner                        sessioncoord.RunnerSpawner
-	Resolver                       sessioncoord.ConversationResolver
-	Reconciler                     sessioncoord.AdapterReconciler
-	LocalPeers                     sessioncoord.LocalPeerInputSource
-	Peers                          central.PeerSource
-	PeerSessions                   wire.PeerSessionSource
-	Converter                      *wire.Converter
-	Endpoints                      EndpointSource
-	Errors                         sessioncoord.ErrorSink
+	Durable      sessioncoord.Durable
+	Runners      sessioncoord.RunnerClient
+	Control      sessioncoord.RunnerControl
+	Spawner      sessioncoord.RunnerSpawner
+	Resolver     sessioncoord.ConversationResolver
+	Reconciler   sessioncoord.AdapterReconciler
+	LocalPeers   sessioncoord.LocalPeerInputSource
+	Peers        central.PeerSource
+	PeerSessions wire.PeerSessionSource
+	Converter    *wire.Converter
+	Endpoints    EndpointSource
+	Errors       sessioncoord.ErrorSink
+	// Notices receives discovery events that are not errors but must be
+	// visible exactly once: a stale socket reaped, an endpoint recovered.
+	// Production leaves it nil, which logs; tests capture it.
+	Notices                        func(context.Context, string)
 	Frames                         func(context.Context, wire.Frames)
 	Clock                          func() centralstore.UnixMillis
 	RunnerBudget, ConvergeDeadline time.Duration
@@ -166,6 +170,9 @@ type Bootstrap struct {
 	workers     sync.WaitGroup
 	closeOnce   sync.Once
 	bridge      *composerDirtyBridge
+	// diag remembers the last reported diagnosis per endpoint incarnation so
+	// discovery reports transitions rather than steady states.
+	diag *endpointDiag
 }
 
 type composerDirtyBridge struct {
@@ -202,7 +209,7 @@ func newBootstrap(cfg BootstrapConfig) (*Bootstrap, error) {
 	coord := sessioncoord.New(registry, cfg.Runners, durable, bridge, cfg.Errors, opts...)
 	cache := wire.NewCache(cfg.Converter, cfg.PeerSessions)
 	lifetimeCtx, cancel := context.WithCancel(context.Background())
-	b := &Bootstrap{Store: cfg.Store, Registry: registry, Coordinator: coord, Cache: cache, cfg: cfg, firstPair: make(chan struct{}), lifetimeCtx: lifetimeCtx, cancel: cancel, bridge: bridge}
+	b := &Bootstrap{Store: cfg.Store, Registry: registry, Coordinator: coord, Cache: cache, cfg: cfg, firstPair: make(chan struct{}), lifetimeCtx: lifetimeCtx, cancel: cancel, bridge: bridge, diag: newEndpointDiag()}
 	sink := central.SinkFunc(func(ctx context.Context, batch central.Batch) {
 		frames := cache.Apply(batch)
 		if frames.Sessions != nil && frames.World != nil {
@@ -301,7 +308,8 @@ func (b *Bootstrap) Converge(ctx context.Context) ([]string, error) {
 			defer wg.Done()
 			probe, stop := context.WithTimeout(global, runnerBudget)
 			defer stop()
-			_, e := b.Coordinator.Register(probe, sessioncoord.RegisterRequest{Endpoint: ep})
+			ident := endpointIdent(ep)
+			rt, e := b.Coordinator.Register(probe, sessioncoord.RegisterRequest{Endpoint: ep})
 			// A transport that returns success after its budget expired did not
 			// honor cancellation. It may have committed a row, but it must not
 			// release startup readiness: doing so would make the global deadline
@@ -313,13 +321,14 @@ func (b *Bootstrap) Converge(ctx context.Context) ([]string, error) {
 			if errors.Is(e, sessioncoord.ErrRunnerTransportNoncompliant) {
 				transportViolatedDeadline.Store(true)
 			}
-			if e != nil && b.cfg.Errors != nil {
+			if e != nil {
 				class := "unreachable"
 				if errors.Is(e, sessioncoord.ErrInvalidSessionID) || errors.Is(e, sessioncoord.ErrResumeIdentityMismatch) || errors.Is(e, sessioncoord.ErrReplaceWithoutClaim) {
 					class = "permanent"
 				}
-				b.cfg.Errors.Error(context.WithoutCancel(ctx), fmt.Errorf("bootstrap register %s (%s): %w", ep, class, e))
+				e = fmt.Errorf("(%s): %w", class, e)
 			}
+			b.classifyRegister(context.WithoutCancel(ctx), "bootstrap converge", ep, ident, rt, e)
 		}()
 	}
 	done := make(chan struct{})
@@ -400,6 +409,13 @@ func (b *Bootstrap) Reconcile(ctx context.Context) error {
 // Scan is the periodic discovery trigger: register candidates, then piggyback
 // orphan reaping and reconciliation. Registration itself deduplicates active
 // generations safely.
+//
+// An endpoint whose socket is exactly the one an installed generation is
+// subscribed to is skipped outright. That is the whole steady state of a
+// healthy machine, and it must cost nothing: no Subscribe, no Meta, no log.
+// Skipping is keyed on the socket's physical identity, never its pathname, so
+// a pathname rebound by a new runner is still probed and a second endpoint
+// claiming an installed session id is still visible as a collision.
 func (b *Bootstrap) Scan(ctx context.Context) error {
 	eps, err := b.cfg.Endpoints.Endpoints(ctx)
 	if err != nil {
@@ -408,11 +424,16 @@ func (b *Bootstrap) Scan(ctx context.Context) error {
 	rb, globalBudget, _, _ := b.bounds()
 	scanCtx, stop := context.WithTimeout(ctx, globalBudget)
 	defer stop()
+	installed := b.installedSockets()
 	workers := 8
 	sem := make(chan struct{}, workers)
 	var wg sync.WaitGroup
 	for _, ep := range eps {
 		ep := ep
+		ident := endpointIdent(ep)
+		if _, skip := installed[ident]; skip && ident.Known() {
+			continue
+		}
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -423,14 +444,15 @@ func (b *Bootstrap) Scan(ctx context.Context) error {
 			}
 			defer func() { <-sem }()
 			p, cancel := context.WithTimeout(scanCtx, rb)
-			_, e := b.Coordinator.Register(p, sessioncoord.RegisterRequest{Endpoint: ep})
+			rt, e := b.Coordinator.Register(p, sessioncoord.RegisterRequest{Endpoint: ep})
 			cancel()
-			if e != nil && b.cfg.Errors != nil {
-				b.cfg.Errors.Error(ctx, fmt.Errorf("bootstrap periodic register %s: %w", ep, e))
-			}
+			b.classifyRegister(ctx, "bootstrap periodic", ep, ident, rt, e)
 		}()
 	}
 	wg.Wait()
+	// Endpoints that vanished (reaped, or unlinked by their runner) will never
+	// clear their own diagnostic state, so drop it here.
+	b.diag.retain(eps)
 	if _, err := b.Coordinator.ReapOrphans(ctx, eps); err != nil {
 		if b.cfg.Errors != nil {
 			b.cfg.Errors.Error(ctx, fmt.Errorf("bootstrap periodic reap: %w", err))

--- a/services/gmuxd/cmd/gmuxd/bootstrap_adapters.go
+++ b/services/gmuxd/cmd/gmuxd/bootstrap_adapters.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -42,11 +43,26 @@ func (productionEndpointSource) Endpoints(context.Context) ([]string, error) {
 // productionRunnerControl retains the existing runner kill transport.
 type productionRunnerControl struct{}
 
-func (productionRunnerControl) Terminate(ctx context.Context, endpoint string) error {
+func (productionRunnerControl) Terminate(ctx context.Context, endpoint, expectIncarnation string) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	return discovery.KillSessionContext(ctx, endpoint)
+	return discovery.KillSessionContext(ctx, endpoint, expectIncarnation)
+}
+
+// Reap maps the coordinator's conditional reap onto the runner's /reap route
+// and translates "this runner has no such route" into the coordinator's own
+// sentinel, so the reap loop can treat a pre-protocol occupant as a decline
+// rather than a failure.
+func (productionRunnerControl) Reap(ctx context.Context, endpoint, expectIncarnation string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	err := discovery.ReapSessionContext(ctx, endpoint, expectIncarnation)
+	if errors.Is(err, discovery.ErrRunnerReapUnsupported) {
+		return fmt.Errorf("%w: %v", sessioncoord.ErrReapUnsupported, err)
+	}
+	return err
 }
 
 // productionConversationResolver dispatches opaque refs to the adapter registry.

--- a/services/gmuxd/cmd/gmuxd/bootstrap_discovery.go
+++ b/services/gmuxd/cmd/gmuxd/bootstrap_discovery.go
@@ -1,0 +1,203 @@
+package main
+
+// Discovery classification: what a periodic scan does with each endpoint, and
+// what it is allowed to say about it.
+//
+// Two problems shaped this file. The first is work: a healthy, unchanged
+// fleet was re-subscribing and re-probing every runner every 30 seconds, only
+// for the coordinator to reject each registration because that generation was
+// already installed. The second is noise: every one of those rejections, plus
+// every refused stale socket, was logged on every tick -- 96 endpoints
+// produced ~56 MiB of daemon log per day, which is also how a full disk turns
+// into a corrupted SQLite database.
+//
+// The fix for both is to compare socket identities rather than pathnames. An
+// endpoint whose socket is *exactly* the one an installed generation is
+// subscribed to is skipped: no Subscribe, no Meta, no log line. Anything else
+// -- an unknown identity, a rebound pathname, a second endpoint claiming an
+// installed session id -- is still probed and still visible, because those are
+// the cases that indicate something is actually wrong.
+//
+// Diagnostics are reported on transition. An endpoint that fails the same way
+// on every tick is reported once; when it changes, or recovers, or is reaped,
+// that is reported too. Diagnostic state is keyed by socket identity, so a
+// rebound pathname starts with a clean slate and its first failure is loud.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"sync"
+	"syscall"
+
+	"github.com/gmuxapp/gmux/packages/socklease"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/sessioncoord"
+)
+
+// diagKey identifies one diagnosable thing: a pathname *and* the socket it
+// named. Keying on the pathname alone would let a stale "unreachable" verdict
+// silence the first failure of the replacement runner that rebound it.
+type diagKey struct {
+	endpoint string
+	socket   socklease.Ident
+}
+
+// endpointDiag remembers the last reported message per endpoint incarnation so
+// discovery can report transitions instead of steady states.
+type endpointDiag struct {
+	mu   sync.Mutex
+	last map[diagKey]string
+}
+
+func newEndpointDiag() *endpointDiag { return &endpointDiag{last: make(map[diagKey]string)} }
+
+// note records msg for key and reports whether it is new information.
+func (d *endpointDiag) note(key diagKey, msg string) bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if prev, ok := d.last[key]; ok && prev == msg {
+		return false
+	}
+	d.last[key] = msg
+	return true
+}
+
+// clearEndpoint forgets everything being reported about a pathname and
+// reports whether there was anything, i.e. whether this is a recovery worth a
+// line.
+//
+// It clears by pathname rather than by incarnation on purpose. A pathname that
+// registers successfully is healthy whichever socket now answers there, and
+// the entry for the incarnation that used to fail would otherwise sit in the
+// map until the pathname vanished entirely. Failures are still *recorded* per
+// incarnation, so a new socket's first failure is never mistaken for its
+// predecessor's steady state.
+func (d *endpointDiag) clearEndpoint(ep string) bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	found := false
+	for key := range d.last {
+		if key.endpoint == ep {
+			delete(d.last, key)
+			found = true
+		}
+	}
+	return found
+}
+
+// retain drops every entry whose pathname is no longer being enumerated. Reaped
+// and vanished endpoints never come back to clear themselves, so without this
+// the map grows for the life of the daemon.
+func (d *endpointDiag) retain(endpoints []string) {
+	live := make(map[string]struct{}, len(endpoints))
+	for _, ep := range endpoints {
+		live[ep] = struct{}{}
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	for key := range d.last {
+		if _, ok := live[key.endpoint]; !ok {
+			delete(d.last, key)
+		}
+	}
+}
+
+func (d *endpointDiag) size() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return len(d.last)
+}
+
+// notice reports something that is not an error but should be visible exactly
+// once: a stale socket being reaped, or an endpoint recovering.
+func (b *Bootstrap) notice(ctx context.Context, format string, args ...any) {
+	if b.cfg.Notices != nil {
+		b.cfg.Notices(ctx, fmt.Sprintf(format, args...))
+		return
+	}
+	log.Printf("gmuxd: "+format, args...)
+}
+
+func (b *Bootstrap) report(ctx context.Context, err error) {
+	if b.cfg.Errors != nil {
+		b.cfg.Errors.Error(ctx, err)
+	}
+}
+
+// installedSockets is the set of socket identities the registry currently has
+// installed and subscribed. The registry is the authority: nothing caches this
+// alongside it, so an entry that dies stops suppressing work immediately.
+func (b *Bootstrap) installedSockets() map[socklease.Ident]struct{} {
+	return b.Registry.InstalledSockets()
+}
+
+// endpointIdent is the current physical identity of an endpoint pathname, or
+// the unknown identity for anything that is not a filesystem socket.
+func endpointIdent(ep string) socklease.Ident {
+	id, ok := socklease.StatSocket(ep)
+	if !ok {
+		return socklease.Ident{}
+	}
+	return id
+}
+
+// classifyRegister turns one Register outcome into at most one log line.
+//
+// phase distinguishes the startup convergence sweep from the periodic scan, so
+// the two call sites remain separately identifiable in the log (and separately
+// pinnable in tests).
+func (b *Bootstrap) classifyRegister(ctx context.Context, phase, ep string, ident socklease.Ident, rt sessioncoord.Runtime, err error) {
+	key := diagKey{endpoint: ep, socket: ident}
+
+	if err == nil {
+		if b.diag.clearEndpoint(ep) {
+			b.notice(ctx, "%s: %s recovered", phase, ep)
+		}
+		return
+	}
+
+	if errors.Is(err, sessioncoord.ErrGenerationActive) {
+		// The coordinator returns the installed generation's runtime with this
+		// error. If that generation is subscribed to *this exact socket*, we
+		// simply lost a harmless race with the runner-initiated registration
+		// of the same runner: expected, and not worth a line.
+		//
+		// Anything else is a genuine collision -- a different socket claiming
+		// a session id that is already installed -- and must stay visible.
+		// Note the deliberate asymmetry: an unknown identity is not treated as
+		// a match, so an unidentifiable collision is reported rather than
+		// silently swallowed.
+		if rt.Socket.Known() && rt.Socket.Same(ident) {
+			if b.diag.clearEndpoint(ep) {
+				b.notice(ctx, "%s: %s recovered", phase, ep)
+			}
+			return
+		}
+		if b.diag.note(key, err.Error()) {
+			b.report(ctx, fmt.Errorf("%s: %s claims session %s, which is already installed at %s: %w",
+				phase, ep, rt.SessionID, rt.Endpoint, err))
+		}
+		return
+	}
+
+	if errors.Is(err, syscall.ECONNREFUSED) {
+		// Nothing is listening. This is the population that accumulated: a
+		// runner died without unlinking its pathname. Try to reap it under the
+		// ownership lease; if the reaper declines, say why, once.
+		outcome := reapStaleSocket(ep)
+		if outcome.Reaped {
+			b.diag.clearEndpoint(ep)
+			b.notice(ctx, "%s: reaped stale socket %s", phase, ep)
+			return
+		}
+		if b.diag.note(key, "refused: "+outcome.Reason) {
+			b.report(ctx, fmt.Errorf("%s: %s refuses connections but was not reaped (%s)", phase, ep, outcome.Reason))
+		}
+		return
+	}
+
+	if b.diag.note(key, err.Error()) {
+		b.report(ctx, fmt.Errorf("%s register %s: %w", phase, ep, err))
+	}
+}

--- a/services/gmuxd/cmd/gmuxd/bootstrap_discovery_test.go
+++ b/services/gmuxd/cmd/gmuxd/bootstrap_discovery_test.go
@@ -1,0 +1,945 @@
+package main
+
+// bootstrap_discovery_test.go — mutation-grade tests for stale socket reaping,
+// exact-incarnation suppression and transition diagnostics.
+//
+// These tests use the production runner transport (productionRunnerClient)
+// against real Unix sockets in a real socket directory, because the properties
+// under test are filesystem properties: what ECONNREFUSED means, what an inode
+// is, and what the reaper is allowed to unlink. A fake transport could not
+// produce a genuine refusal.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gmuxapp/gmux/packages/socklease"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/centralstore"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/sessioncoord"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/snapshot/wire"
+)
+
+// socketDir points both the reaper's trust boundary and the endpoint source at
+// an isolated directory.
+func socketDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("GMUX_SOCKET_DIR", dir)
+	return dir
+}
+
+// crashedRunnerSocket reproduces the state a runner leaves behind when it dies
+// without releasing ownership: the socket pathname still exists and refuses
+// connections, and the lock file is still there with nobody holding it (the
+// kernel drops flock when the process dies, but never unlinks the file).
+func crashedRunnerSocket(t *testing.T, dir, name string) string {
+	t.Helper()
+	ep := filepath.Join(dir, name)
+	ln, err := net.Listen("unix", ep)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	ln.(*net.UnixListener).SetUnlinkOnClose(false)
+	if err := ln.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if err := os.WriteFile(socklease.LockPath(ep), nil, 0o600); err != nil {
+		t.Fatalf("write lock file: %v", err)
+	}
+	return ep
+}
+
+// liveRunner serves the minimum runner API (an /events stream and /meta) on a
+// real Unix socket, so the production transport can register against it.
+type liveRunner struct {
+	ep          string
+	id          centralstore.SessionID
+	incarnation string
+	ln          net.Listener
+	srv         *http.Server
+	lease       *socklease.Lease
+	closed      sync.Once
+}
+
+func startLiveRunner(t *testing.T, dir, name string, id centralstore.SessionID, leased bool) *liveRunner {
+	t.Helper()
+	ep := filepath.Join(dir, name)
+	// A real runner mints an ephemeral incarnation and stamps it on every
+	// response; the daemon requires subscription and metadata to agree before
+	// it will claim to know which socket a generation is subscribed to.
+	r := &liveRunner{ep: ep, id: id, incarnation: fmt.Sprintf("incarnation-%s-%d", name, time.Now().UnixNano())}
+	if leased {
+		lease, err := socklease.Acquire(ep)
+		if err != nil {
+			t.Fatalf("acquire lease: %v", err)
+		}
+		r.lease = lease
+	}
+	ln, err := net.Listen("unix", ep)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	ln.(*net.UnixListener).SetUnlinkOnClose(false)
+	r.ln = ln
+
+	mux := http.NewServeMux()
+	stamp := func(next http.HandlerFunc) http.HandlerFunc {
+		return func(w http.ResponseWriter, req *http.Request) {
+			w.Header().Set("X-Gmux-Incarnation", r.incarnation)
+			next(w, req)
+		}
+	}
+	mux.HandleFunc("GET /events", stamp(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		<-req.Context().Done()
+	}))
+	mux.HandleFunc("GET /meta", stamp(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id": string(id), "adapter": "shell", "alive": true, "pid": os.Getpid(),
+			"created_at":  time.Now().UTC().Format(time.RFC3339),
+			"incarnation": r.incarnation,
+		})
+	}))
+	r.srv = &http.Server{Handler: mux}
+	go func() { _ = r.srv.Serve(ln) }()
+	t.Cleanup(r.stop)
+	return r
+}
+
+func (r *liveRunner) stop() {
+	r.closed.Do(func() {
+		_ = r.srv.Close()
+		if r.lease != nil {
+			_ = r.lease.Release()
+		}
+	})
+}
+
+// crash makes the runner die the way a SIGKILL would: the listener goes away,
+// the pathname stays, and the lease is dropped without unlinking the lock file.
+func (r *liveRunner) crash(t *testing.T) {
+	t.Helper()
+	_ = r.srv.Close()
+	if r.lease != nil {
+		// Simulate kernel lock release on process death: the lock file must
+		// survive, so write it back after Release unlinks it.
+		_ = r.lease.Release()
+		if err := os.WriteFile(socklease.LockPath(r.ep), nil, 0o600); err != nil {
+			t.Fatalf("restore lock file: %v", err)
+		}
+		r.lease = nil
+	}
+}
+
+type discoveryHarness struct {
+	boot    *Bootstrap
+	store   *centralstore.Store
+	errs    *recorder
+	notices *recorder
+	dir     string
+	eps     func() []string
+}
+
+type recorder struct {
+	mu    sync.Mutex
+	lines []string
+}
+
+func (r *recorder) add(s string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.lines = append(r.lines, s)
+}
+func (r *recorder) all() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.lines...)
+}
+func (r *recorder) count() int { return len(r.all()) }
+func (r *recorder) countContaining(sub string) int {
+	n := 0
+	for _, l := range r.all() {
+		if strings.Contains(l, sub) {
+			n++
+		}
+	}
+	return n
+}
+
+func newDiscoveryHarness(t *testing.T) *discoveryHarness {
+	t.Helper()
+	dir := socketDir(t)
+	store, err := centralstore.Open(context.Background(), t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { store.Close() })
+	h := &discoveryHarness{store: store, errs: &recorder{}, notices: &recorder{}, dir: dir}
+	boot, err := newBootstrap(BootstrapConfig{
+		Store: store, Runners: productionRunnerClient{}, Control: bootstrapControl{}, Spawner: bootstrapSpawner{},
+		Reconciler: bootstrapReconciler{}, Converter: &wire.Converter{},
+		Endpoints: productionEndpointSource{},
+		Errors:    sessioncoord.ErrorSinkFunc(func(_ context.Context, err error) { h.errs.add(err.Error()) }),
+		Notices:   func(_ context.Context, msg string) { h.notices.add(msg) },
+		Clock:     func() centralstore.UnixMillis { return 100 },
+		// Keep a failed dial cheap: these tests deliberately probe dead sockets.
+		RunnerBudget: 2 * time.Second, ConvergeDeadline: 5 * time.Second,
+		RetryInitial: time.Millisecond, RetryMaximum: 2 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(boot.Close)
+	h.boot = boot
+	return h
+}
+
+func (h *discoveryHarness) converge(t *testing.T) {
+	t.Helper()
+	if _, err := h.boot.Converge(context.Background()); err != nil {
+		t.Fatalf("Converge: %v", err)
+	}
+}
+
+// waitForDeparture waits until the registry no longer has an installed
+// generation, i.e. until the daemon has observed a runner's death through the
+// ordinary path. Death observation is asynchronous (the drain goroutine sees
+// the stream close), and a scan that ran before it would legitimately skip the
+// still-installed socket.
+func (h *discoveryHarness) waitForDeparture(t *testing.T) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if len(h.boot.Registry.Snapshot()) == 0 {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for the daemon to observe the runner's death")
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+}
+
+func (h *discoveryHarness) scan(t *testing.T) {
+	t.Helper()
+	if err := h.boot.Scan(context.Background()); err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+}
+
+// ── the reaper predicate ────────────────────────────────────────────────────
+
+// Mutation: any of the guards in reapStaleSocket. Each row is a distinct
+// reason the daemon must keep its hands off a pathname.
+func TestReapStaleSocketDeclines(t *testing.T) {
+	t.Run("no lock file (runner predates the lease protocol)", func(t *testing.T) {
+		dir := socketDir(t)
+		ep := crashedRunnerSocket(t, dir, "a.sock")
+		if err := os.Remove(socklease.LockPath(ep)); err != nil {
+			t.Fatal(err)
+		}
+		requireDeclined(t, ep, "lease file")
+	})
+
+	t.Run("lease held by a live runner", func(t *testing.T) {
+		dir := socketDir(t)
+		ep := crashedRunnerSocket(t, dir, "a.sock")
+		lease, err := socklease.Acquire(ep)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer lease.Release()
+		requireDeclined(t, ep, "lease is held")
+	})
+
+	t.Run("outside the trusted socket directory", func(t *testing.T) {
+		socketDir(t) // trusted dir is elsewhere
+		other := t.TempDir()
+		ep := crashedRunnerSocket(t, other, "a.sock")
+		requireDeclined(t, ep, "trusted socket directory")
+	})
+
+	t.Run("not a socket", func(t *testing.T) {
+		dir := socketDir(t)
+		ep := filepath.Join(dir, "a.sock")
+		if err := os.WriteFile(ep, []byte("not a socket"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(socklease.LockPath(ep), nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		requireDeclined(t, ep, "not a socket")
+	})
+
+	t.Run("socket is live", func(t *testing.T) {
+		dir := socketDir(t)
+		r := startLiveRunner(t, dir, "a.sock", "sess-live", false)
+		// A live socket with a free lock file: the lease says nothing, only
+		// the probe does.
+		if err := os.WriteFile(socklease.LockPath(r.ep), nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		requireDeclined(t, r.ep, "live")
+	})
+
+	t.Run("pathname vanished", func(t *testing.T) {
+		dir := socketDir(t)
+		ep := crashedRunnerSocket(t, dir, "a.sock")
+		if err := os.Remove(ep); err != nil {
+			t.Fatal(err)
+		}
+		requireDeclined(t, ep, "not a socket")
+	})
+}
+
+func requireDeclined(t *testing.T, ep, wantReason string) {
+	t.Helper()
+	before, existed := socklease.StatSocket(ep)
+	outcome := reapStaleSocket(ep)
+	if outcome.Reaped {
+		t.Fatalf("reapStaleSocket(%s) removed the pathname; want declined (%s)", ep, wantReason)
+	}
+	if !strings.Contains(outcome.Reason, wantReason) {
+		t.Errorf("reason = %q, want it to mention %q", outcome.Reason, wantReason)
+	}
+	if existed {
+		after, stillThere := socklease.StatSocket(ep)
+		if !stillThere || after != before {
+			t.Error("the pathname was disturbed by a declined reap")
+		}
+	}
+}
+
+// Mutation: remove the lease acquisition, the probe, or the identity check —
+// each is covered by a decline case above; this is the positive case.
+func TestReapStaleSocketRemovesAbandonedSocketAndLockFile(t *testing.T) {
+	dir := socketDir(t)
+	ep := crashedRunnerSocket(t, dir, "a.sock")
+
+	if outcome := reapStaleSocket(ep); !outcome.Reaped {
+		t.Fatalf("reapStaleSocket declined an abandoned socket: %s", outcome.Reason)
+	}
+	if _, err := os.Lstat(ep); !os.IsNotExist(err) {
+		t.Fatalf("socket pathname survived the reap: %v", err)
+	}
+	if _, err := os.Lstat(socklease.LockPath(ep)); !os.IsNotExist(err) {
+		t.Fatalf("lock file survived the reap: %v; the socket directory would grow without bound", err)
+	}
+	// And the reap is idempotent: a second attempt finds nothing to do.
+	if outcome := reapStaleSocket(ep); outcome.Reaped {
+		t.Fatal("second reap claimed to remove an already-removed pathname")
+	}
+}
+
+// ── the two call sites, pinned independently ────────────────────────────────
+
+// Mutation: delete the reap from the periodic scan path. The convergence path
+// must not be able to mask it.
+func TestScanReapsStaleSocket(t *testing.T) {
+	h := newDiscoveryHarness(t)
+	h.converge(t) // nothing to converge yet: closes the barrier
+	ep := crashedRunnerSocket(t, h.dir, "sess-stale.sock")
+
+	h.scan(t)
+
+	if _, err := os.Lstat(ep); !os.IsNotExist(err) {
+		t.Fatalf("Scan left the stale socket behind: %v", err)
+	}
+	if got := h.notices.countContaining("reaped stale socket"); got != 1 {
+		t.Fatalf("reap notices = %d, want exactly 1: %v", got, h.notices.all())
+	}
+	// A reap is a transition, not a steady state: further scans say nothing.
+	for range 50 {
+		h.scan(t)
+	}
+	if got := h.notices.countContaining("reaped stale socket"); got != 1 {
+		t.Fatalf("reap notices after 50 further scans = %d, want 1", got)
+	}
+	if got := h.errs.count(); got != 0 {
+		t.Fatalf("errors reported = %d, want 0: %v", got, h.errs.all())
+	}
+}
+
+// Mutation: delete the reap from the convergence path. The scan path must not
+// be able to mask it.
+func TestConvergeReapsStaleSocket(t *testing.T) {
+	h := newDiscoveryHarness(t)
+	ep := crashedRunnerSocket(t, h.dir, "sess-stale.sock")
+
+	h.converge(t)
+
+	if _, err := os.Lstat(ep); !os.IsNotExist(err) {
+		t.Fatalf("Converge left the stale socket behind: %v", err)
+	}
+	if got := h.notices.countContaining("reaped stale socket"); got != 1 {
+		t.Fatalf("reap notices = %d, want exactly 1: %v", got, h.notices.all())
+	}
+}
+
+// A socket the reaper declines to touch must still be reported — once.
+//
+// Mutation: report on every tick (drop the transition check), or never report
+// (swallow declines).
+func TestScanReportsUnreapableStaleSocketOnceOnly(t *testing.T) {
+	h := newDiscoveryHarness(t)
+	h.converge(t)
+	ep := crashedRunnerSocket(t, h.dir, "sess-legacy.sock")
+	if err := os.Remove(socklease.LockPath(ep)); err != nil {
+		t.Fatal(err) // a pre-lease runner's leftovers
+	}
+
+	for range 200 {
+		h.scan(t)
+	}
+
+	if _, err := os.Lstat(ep); err != nil {
+		t.Fatalf("an unleased socket was reaped: %v", err)
+	}
+	if got := h.errs.count(); got != 1 {
+		t.Fatalf("reports for 200 identical failures = %d, want 1: %v", got, h.errs.all())
+	}
+	if !strings.Contains(h.errs.all()[0], "lease file") {
+		t.Errorf("report does not explain the decline: %q", h.errs.all()[0])
+	}
+}
+
+// ── identity-based suppression ──────────────────────────────────────────────
+
+// Mutation: skip on pathname equality instead of socket identity.
+//
+// A pathname rebound by a new runner is a new socket and must be probed. Here
+// the new runner claims the same session id as the installed generation, which
+// makes the collision observable rather than silently ignored.
+func TestScanProbesReboundPathnameAndReportsCollision(t *testing.T) {
+	h := newDiscoveryHarness(t)
+	first := startLiveRunner(t, h.dir, "sess-rebind.sock", "sess-rebind", true)
+	h.converge(t)
+
+	installed := h.boot.Registry.Snapshot()
+	if len(installed) != 1 || !installed[0].Socket.Known() {
+		t.Fatalf("expected one installed generation with a known socket, got %+v", installed)
+	}
+	before := installed[0].Socket
+
+	// The pathname is rebound by a different process claiming the same id.
+	// The installed generation keeps serving its (now unnamed) socket, so its
+	// stream stays alive and its generation stays installed -- exactly what a
+	// runner does between /kill and its final drain.
+	// Park the original aside rather than unlinking it, so its inode stays
+	// linked and the rebind necessarily lands on a different one: a filesystem
+	// that recycles immediately would otherwise hand back an identity equal to
+	// the installed generation's, and the scan would be right to skip it.
+	parked := first.ep + ".parked"
+	if err := os.Rename(first.ep, parked); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Remove(parked) })
+	second := startLiveRunner(t, h.dir, "sess-rebind.sock", "sess-rebind", false)
+	after, ok := socklease.StatSocket(second.ep)
+	if !ok {
+		t.Fatal("the replacement is not a socket")
+	}
+	if after.Same(before) {
+		t.Fatalf("the replacement carries the installed generation's identity (%s); "+
+			"parking the original aside should have made that impossible", after)
+	}
+
+	h.scan(t)
+
+	if got := h.errs.countContaining("already installed"); got != 1 {
+		t.Fatalf("collision reports = %d, want 1: %v", got, h.errs.all())
+	}
+}
+
+// Mutation: suppress every ErrGenerationActive (the "expected race" shortcut).
+//
+// A *different* endpoint claiming a session id that is already installed is
+// a real conflict — two processes believing they are the same session — and
+// must never be silenced by the same-socket shortcut.
+func TestScanReportsDistinctEndpointCollision(t *testing.T) {
+	h := newDiscoveryHarness(t)
+	startLiveRunner(t, h.dir, "sess-a.sock", "sess-collide", true)
+	h.converge(t)
+
+	startLiveRunner(t, h.dir, "sess-b.sock", "sess-collide", true)
+
+	h.scan(t)
+	if got := h.errs.countContaining("already installed"); got != 1 {
+		t.Fatalf("collision reports = %d, want 1: %v", got, h.errs.all())
+	}
+	// Steady state: the collision persists but is not re-reported.
+	for range 50 {
+		h.scan(t)
+	}
+	if got := h.errs.countContaining("already installed"); got != 1 {
+		t.Fatalf("collision reports after 50 further scans = %d, want 1", got)
+	}
+}
+
+// Mutation: treat an unknown identity as installed (skip it).
+//
+// An endpoint the daemon cannot identify must keep being probed — that is the
+// only way it can ever converge — but must not keep being logged.
+func TestScanKeepsProbingUnidentifiableEndpointsButReportsOnce(t *testing.T) {
+	socketDir(t)
+	store, err := centralstore.Open(context.Background(), t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	const ep = "synthetic-endpoint" // not a filesystem socket: unidentifiable
+	meta := sessioncoord.RunnerMeta{Registration: centralstore.RunnerRegistration{
+		ID: "sess-synthetic", Adapter: "shell", Alive: true, CreatedAt: 1, ObservedAt: 1,
+	}}
+	runners := &bootstrapRunners{metas: map[string]sessioncoord.RunnerMeta{ep: meta}, blocked: map[string]bool{}}
+	errs := &recorder{}
+	boot, err := newBootstrap(BootstrapConfig{
+		Store: store, Runners: runners, Control: bootstrapControl{}, Spawner: bootstrapSpawner{},
+		Reconciler: bootstrapReconciler{}, Converter: &wire.Converter{},
+		Endpoints: EndpointSourceFunc(func(context.Context) ([]string, error) { return []string{ep}, nil }),
+		Errors:    sessioncoord.ErrorSinkFunc(func(_ context.Context, err error) { errs.add(err.Error()) }),
+		Notices:   func(context.Context, string) {},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer boot.Close()
+	if _, err := boot.Converge(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	for range 300 {
+		if err := boot.Scan(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := runners.subscribeCalls.Load(); got != 301 {
+		t.Fatalf("Subscribe calls = %d, want 301: an unidentifiable endpoint must keep being probed", got)
+	}
+	if got := errs.count(); got != 1 {
+		t.Fatalf("reports = %d, want 1 (transition only): %v", got, errs.all())
+	}
+}
+
+// Mutation: report generic (neither refused nor collision) registration
+// failures on every tick instead of on transition. A permanently broken
+// endpoint must cost one line, not one line per tick forever.
+func TestScanReportsRepeatedRegistrationFailureOnceOnly(t *testing.T) {
+	store, err := centralstore.Open(context.Background(), t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	const ep = "broken-endpoint" // the fake transport has no meta for it
+	runners := &bootstrapRunners{metas: map[string]sessioncoord.RunnerMeta{}, blocked: map[string]bool{}}
+	errs := &recorder{}
+	boot, err := newBootstrap(BootstrapConfig{
+		Store: store, Runners: runners, Control: bootstrapControl{}, Spawner: bootstrapSpawner{},
+		Reconciler: bootstrapReconciler{}, Converter: &wire.Converter{},
+		Endpoints: EndpointSourceFunc(func(context.Context) ([]string, error) { return []string{ep}, nil }),
+		Errors:    sessioncoord.ErrorSinkFunc(func(_ context.Context, err error) { errs.add(err.Error()) }),
+		Notices:   func(context.Context, string) {},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer boot.Close()
+	if _, err := boot.Converge(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	convergeReports := errs.count()
+	if convergeReports != 1 {
+		t.Fatalf("convergence reports = %d, want 1: %v", convergeReports, errs.all())
+	}
+	for range 200 {
+		if err := boot.Scan(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// One more line than convergence produced: the periodic phase reports its
+	// own first occurrence, then goes quiet.
+	if got := errs.count(); got != convergeReports+1 {
+		t.Fatalf("reports after 200 identical failures = %d, want %d: %v", got, convergeReports+1, errs.all())
+	}
+	// 201 registration probes plus 200 orphan probes: an endpoint the daemon
+	// cannot identify is never suppressed, it is only reported once.
+	if got := runners.metaCalls.Load(); got != 401 {
+		t.Fatalf("Meta calls = %d, want 401: a broken endpoint must keep being probed", got)
+	}
+}
+
+// ── diagnostic lifecycle ────────────────────────────────────────────────────
+
+// Mutation: never clear diagnostic state on success.
+//
+// Without the clear, an endpoint that fails, recovers and fails again the same
+// way is reported once in its life: the second incident is silently swallowed.
+func TestDiagnosticsReportRecoveryAndReoccurrence(t *testing.T) {
+	h := newDiscoveryHarness(t)
+	h.converge(t)
+
+	// Incident 1: a socket that refuses and cannot be reaped.
+	ep := crashedRunnerSocket(t, h.dir, "sess-flaky.sock")
+	if err := os.Remove(socklease.LockPath(ep)); err != nil {
+		t.Fatal(err)
+	}
+	h.scan(t)
+	if got := h.errs.count(); got != 1 {
+		t.Fatalf("after incident 1: reports = %d, want 1: %v", got, h.errs.all())
+	}
+
+	// Recovery: a live runner takes over the pathname.
+	if err := os.Remove(ep); err != nil {
+		t.Fatal(err)
+	}
+	runner := startLiveRunner(t, h.dir, "sess-flaky.sock", "sess-flaky", true)
+	h.scan(t)
+	if got := h.notices.countContaining("recovered"); got != 1 {
+		t.Fatalf("recovery notices = %d, want 1: %v", got, h.notices.all())
+	}
+
+	// Incident 2: the same failure again, at a new incarnation of the
+	// pathname. It must be reported, not swallowed as "unchanged".
+	runner.crash(t)
+	h.waitForDeparture(t)
+	if err := os.Remove(socklease.LockPath(ep)); err != nil {
+		t.Fatal(err)
+	}
+	h.scan(t)
+	if got := h.errs.count(); got != 2 {
+		t.Fatalf("after incident 2: reports = %d, want 2: %v", got, h.errs.all())
+	}
+}
+
+// Mutation: drop diag.retain from Scan.
+//
+// Endpoints that are reaped or vanish never clear their own state, so without
+// the sweep the map grows for the life of the daemon.
+func TestDiagnosticStateDoesNotAccumulateForVanishedEndpoints(t *testing.T) {
+	h := newDiscoveryHarness(t)
+	h.converge(t)
+
+	for i := range 20 {
+		ep := crashedRunnerSocket(t, h.dir, fmt.Sprintf("sess-gone-%02d.sock", i))
+		if err := os.Remove(socklease.LockPath(ep)); err != nil {
+			t.Fatal(err) // unreapable, so each one is diagnosed...
+		}
+		h.scan(t)
+		if err := os.Remove(ep); err != nil {
+			t.Fatal(err) // ...and then disappears
+		}
+	}
+	h.scan(t)
+
+	if got := h.boot.diag.size(); got != 0 {
+		t.Fatalf("retained diagnostic entries = %d, want 0", got)
+	}
+}
+
+// rebindToADistinctInode replaces the socket at ep with one whose identity is
+// provably different from original, and fails the test if it cannot.
+//
+// The obvious way -- unlink, then bind again -- is not deterministic: a
+// filesystem is free to hand back the inode just freed, and GitHub's runners do,
+// which made this schedule collapse into "the replacement is the original" and
+// the reaper's removal of it entirely correct. The test then failed for a reason
+// that had nothing to do with the reaper.
+//
+// So the original inode is not freed at all: it is renamed aside, which keeps it
+// linked and therefore unusable, and only then is the pathname bound again. Any
+// inode the kernel hands out now is necessarily a different one. The retry loop
+// exists so a filesystem that still returns an equal identity accumulates
+// *retained* consumers rather than looping forever on the same free inode, and
+// the precondition is asserted before returning: no skip, no assumption.
+func rebindToADistinctInode(t *testing.T, ep string, original socklease.Ident) socklease.Ident {
+	t.Helper()
+
+	// Everything parked here stays linked (and so unusable) until the test ends.
+	var parked []string
+	t.Cleanup(func() {
+		for _, p := range parked {
+			_ = os.Remove(p)
+		}
+	})
+
+	for attempt := range 32 {
+		aside := fmt.Sprintf("%s.parked-%d", ep, attempt)
+		if err := os.Rename(ep, aside); err != nil {
+			t.Errorf("park %s aside: %v", ep, err)
+			return socklease.Ident{}
+		}
+		parked = append(parked, aside)
+
+		ln, err := net.Listen("unix", ep)
+		if err != nil {
+			t.Errorf("listen: %v", err)
+			return socklease.Ident{}
+		}
+		// The replacement is a *stale* socket, like the original: it refuses
+		// connections, so the reaper's probe still says "refused" and the only
+		// thing that differs is its identity.
+		ln.(*net.UnixListener).SetUnlinkOnClose(false)
+		_ = ln.Close()
+
+		replacement, ok := socklease.StatSocket(ep)
+		if ok && !replacement.Same(original) {
+			return replacement
+		}
+		// Either unidentifiable or the same inode after all. Leave this one
+		// parked too, consuming whatever the kernel just handed out, and try
+		// again.
+	}
+	t.Errorf("could not rebind %s to an inode distinct from %+v in 32 attempts; "+
+		"the schedule this test asserts about cannot be expressed here", ep, original)
+	return socklease.Ident{}
+}
+
+// Mutation: release with Release (history-erasing) on the reaper's
+// learned-nothing declines.
+//
+// The lock file is the only evidence that a leftover socket belonged to a
+// lease-aware generation, and that evidence is what makes it reclaimable. A
+// reaper that erases it while merely inspecting turns a recoverable
+// crashed-runner socket into one nothing can ever clean up or rebind: every
+// later attempt sees no lock file and concludes "not provably ours".
+//
+// The decline driven here is the genuinely uninformative one: the pathname's
+// identity changes between the probe and the removal, so the reaper knows
+// nothing about whatever is there now.
+func TestReaperKeepsLeaseHistoryWhenItLearnsNothing(t *testing.T) {
+	dir := socketDir(t)
+	ep := crashedRunnerSocket(t, dir, "sess-ambiguous.sock")
+	original, ok := socklease.StatSocket(ep)
+	if !ok {
+		t.Fatalf("%s is not a socket", ep)
+	}
+
+	// Make the pathname change identity inside the leased window, after the
+	// probe has seen the socket we captured: the reaper then declines the
+	// removal without having learned anything about the newcomer.
+	//
+	// The barrier is scoped to this endpoint. Unscoped, it fired for whichever
+	// reaper reached the phase first -- a concurrent one from another test --
+	// and rewrote this pathname before this test's reaper had even started.
+	fired := onReapPhase(t, ep, "before-remove", func() {
+		rebindToADistinctInode(t, ep, original)
+	})
+
+	outcome := reapStaleSocket(ep)
+	if !fired() {
+		t.Fatal("the barrier never ran")
+	}
+	if outcome.Reaped {
+		t.Fatal("the reaper removed a pathname whose identity changed under it")
+	}
+	if _, err := os.Lstat(socklease.LockPath(ep)); err != nil {
+		t.Fatalf("the reaper erased lease history on an uninformative decline: %v; "+
+			"the leftover is now permanently unreclaimable", err)
+	}
+
+	// And the pathname is still reclaimable: a later pass reaps it.
+	if outcome := reapStaleSocket(ep); !outcome.Reaped {
+		t.Fatalf("a later reap could not recover the pathname: %s", outcome.Reason)
+	}
+	if _, err := os.Lstat(ep); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("socket survived the recovering reap: %v", err)
+	}
+	if _, err := os.Lstat(socklease.LockPath(ep)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("lock file survived a successful reap: %v", err)
+	}
+}
+
+// The other half of the same discipline: a decline that *did* learn something
+// must erase the now-false history.
+func TestReaperErasesLeaseHistoryWhenItLearnsTheOccupantIsUnleased(t *testing.T) {
+	dir := socketDir(t)
+	// A crashed lease-aware runner's leftovers...
+	ep := crashedRunnerSocket(t, dir, "sess-taken-over.sock")
+	// ...whose pathname an unleased runner has since taken over.
+	if err := os.Remove(ep); err != nil {
+		t.Fatal(err)
+	}
+	r := startLiveRunner(t, dir, "sess-taken-over.sock", "sess-taken-over", false)
+
+	outcome := reapStaleSocket(r.ep)
+	if outcome.Reaped {
+		t.Fatal("the reaper removed a live socket")
+	}
+	if _, err := os.Lstat(socklease.LockPath(ep)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("lease history describing a dead generation survived proof that the occupant is unleased: %v", err)
+	}
+	if _, ok := socklease.StatSocket(r.ep); !ok {
+		t.Fatal("the live occupant's pathname was disturbed")
+	}
+}
+
+// A vanished pathname's lock file is cleaned up too: that is how lock files
+// left by a runner that died between creating one and binding stop
+// accumulating.
+func TestReaperCleansUpALockFileWhoseSocketVanished(t *testing.T) {
+	dir := socketDir(t)
+	ep := crashedRunnerSocket(t, dir, "sess-vanished.sock")
+	if err := os.Remove(ep); err != nil {
+		t.Fatal(err)
+	}
+
+	if outcome := reapStaleSocket(ep); outcome.Reaped {
+		t.Fatal("reaped a pathname that does not exist")
+	}
+	if _, err := os.Lstat(socklease.LockPath(ep)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("an orphaned lock file was left behind: %v", err)
+	}
+}
+
+// The other uninformative decline, and the one a regression is most likely to
+// get wrong: the probe neither refuses nor is accepted.
+//
+// A socket whose mode denies the connect is the deterministic way to construct
+// it; a live owner with a full accept backlog is the same verdict arriving by
+// accident (EAGAIN, which classifies as a timeout), and a genuinely wedged
+// owner is the case that matters. All three tell the reaper nothing about the
+// occupant, so the lease history must survive -- otherwise a wedged-but-live
+// runner's socket becomes permanently unreclaimable by anything: no lock file
+// means no proof of a lease-aware owner, forever.
+//
+// Mutation: `learnedNothing = false` on every probe failure (i.e. erase the
+// lock file unless the probe was refused).
+func TestReaperKeepsLeaseHistoryWhenTheProbeIsAmbiguous(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: no mode denies a connect")
+	}
+	dir := socketDir(t)
+	ep := crashedRunnerSocket(t, dir, "sess-wedged.sock")
+	// Deny the connect: the probe now fails without learning anything, exactly
+	// as it would against a wedged owner.
+	if err := os.Chmod(ep, 0o000); err != nil {
+		t.Fatal(err)
+	}
+
+	// Precondition: the probe really is ambiguous rather than refused.
+	probeErr := socklease.ProbeRefused(ep, staleProbeTimeout)
+	if probeErr == nil {
+		t.Skip("this platform refuses the connect despite the mode; the probe is not ambiguous here")
+	}
+	if errors.Is(probeErr, socklease.ErrSocketLive) {
+		t.Skip("the connect succeeded despite the mode")
+	}
+
+	outcome := reapStaleSocket(ep)
+	if outcome.Reaped {
+		t.Fatal("the reaper removed a socket it could not probe")
+	}
+	if _, err := os.Lstat(socklease.LockPath(ep)); err != nil {
+		t.Fatalf("the reaper erased lease history after an ambiguous probe: %v; "+
+			"a wedged-but-live runner's socket would become permanently unreclaimable", err)
+	}
+	if _, ok := socklease.StatSocket(ep); !ok {
+		t.Fatal("the socket was disturbed")
+	}
+
+	// And once the occupant is provably gone, the retained history is what lets
+	// a later pass finish the job.
+	if err := os.Chmod(ep, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if outcome := reapStaleSocket(ep); !outcome.Reaped {
+		t.Fatalf("a later reap could not recover the pathname: %s", outcome.Reason)
+	}
+	if _, err := os.Lstat(socklease.LockPath(ep)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("lock file survived a successful reap: %v", err)
+	}
+}
+
+// The window the pin exists for, on the daemon's side.
+//
+// The reaper has probed the leftover and found nothing listening. That verdict
+// is about a *file*, and between it and the unlink the pathname can be taken
+// over by a runner that holds no lease and is excluded by nothing -- the one
+// population a lease cannot serialise. Pinned before the probe, the reaper holds
+// the file it decided about, the pathname no longer resolves to it, and the
+// removal declines. Pinned after the probe, it would hold the newcomer instead
+// and unlink it alive and unprobed.
+//
+// Mutation: move PinSocket after probeRefused (which now requires passing a pin
+// that does not exist yet, so the mutation has to pass nil -- and either way this
+// test unlinks a live runner).
+func TestReaperDoesNotUnlinkATakeoverRightAfterItsProbe(t *testing.T) {
+	dir := socketDir(t)
+	ep := crashedRunnerSocket(t, dir, "sess-taken-after-probe.sock")
+
+	// An unleased runner takes the pathname the instant the probe has answered.
+	var replacement *net.UnixListener
+	var replacementID socklease.Ident
+	fired := onReapPhase(t, ep, "probed", func() {
+		if err := os.Remove(ep); err != nil {
+			t.Errorf("remove: %v", err)
+			return
+		}
+		ln, err := net.Listen("unix", ep)
+		if err != nil {
+			t.Errorf("listen: %v", err)
+			return
+		}
+		ul := ln.(*net.UnixListener)
+		ul.SetUnlinkOnClose(false)
+		go func() {
+			for {
+				c, acceptErr := ul.Accept()
+				if acceptErr != nil {
+					return
+				}
+				_ = c.Close()
+			}
+		}()
+		replacement = ul
+		id, ok := socklease.StatSocket(ep)
+		if !ok {
+			t.Error("the replacement is not a socket")
+			return
+		}
+		replacementID = id
+	})
+	t.Cleanup(func() {
+		if replacement != nil {
+			_ = replacement.Close()
+		}
+	})
+
+	outcome := reapStaleSocket(ep)
+	if !fired() {
+		t.Fatal("the reaper never reached the phase just after its probe")
+	}
+	if outcome.Reaped {
+		t.Fatal("the reaper unlinked a live runner that took the pathname after the probe")
+	}
+
+	// The replacement still owns its pathname...
+	current, ok := socklease.StatSocket(ep)
+	if !ok {
+		t.Fatal("the live replacement's pathname was unlinked")
+	}
+	if current != replacementID {
+		t.Fatalf("the pathname was rebound under a live runner: %s -> %s", replacementID, current)
+	}
+	// ...and is still reachable, which is the point of not unlinking it.
+	conn, err := net.DialTimeout("unix", ep, 2*time.Second)
+	if err != nil {
+		t.Fatalf("the replacement is no longer reachable at its pathname: %v", err)
+	}
+	_ = conn.Close()
+}

--- a/services/gmuxd/cmd/gmuxd/bootstrap_harness_test.go
+++ b/services/gmuxd/cmd/gmuxd/bootstrap_harness_test.go
@@ -24,19 +24,25 @@ type harnessFleet struct {
 }
 
 type harnessStream struct {
-	events chan sessioncoord.RunnerEvent
-	once   sync.Once
+	events      chan sessioncoord.RunnerEvent
+	incarnation string
+	once        sync.Once
 }
 
 func (s *harnessStream) Events() <-chan sessioncoord.RunnerEvent { return s.events }
-func (s *harnessStream) Close() error                            { s.once.Do(func() { close(s.events) }); return nil }
+
+// Incarnation mirrors the production transport: the runner's identity comes
+// out of the subscription response.
+func (s *harnessStream) Incarnation() string { return s.incarnation }
+func (s *harnessStream) Close() error        { s.once.Do(func() { close(s.events) }); return nil }
 
 func newHarnessFleet(n int) *harnessFleet {
 	f := &harnessFleet{metas: make(map[string]sessioncoord.RunnerMeta), streams: make(map[string]*harnessStream), ignore: make(map[string]chan struct{})}
 	for i := 0; i < n; i++ {
 		ep, id := fmt.Sprintf("runner-%03d", i), centralstore.SessionID(fmt.Sprintf("sess-harness-%03d", i))
-		f.metas[ep] = sessioncoord.RunnerMeta{PID: 1000 + i, Registration: centralstore.RunnerRegistration{ID: id, Adapter: "shell", Alive: true, CreatedAt: 1, ObservedAt: 1}}
-		f.streams[ep] = &harnessStream{events: make(chan sessioncoord.RunnerEvent, 32)}
+		incarnation := fmt.Sprintf("incarnation-%s", id)
+		f.metas[ep] = sessioncoord.RunnerMeta{PID: 1000 + i, Registration: centralstore.RunnerRegistration{ID: id, Adapter: "shell", Alive: true, CreatedAt: 1, ObservedAt: 1}, Incarnation: incarnation}
+		f.streams[ep] = &harnessStream{events: make(chan sessioncoord.RunnerEvent, 32), incarnation: incarnation}
 	}
 	return f
 }

--- a/services/gmuxd/cmd/gmuxd/bootstrap_runner_adapters.go
+++ b/services/gmuxd/cmd/gmuxd/bootstrap_runner_adapters.go
@@ -436,6 +436,15 @@ func launchRunnerProcess(ctx context.Context, req runnerLaunchRequest) (runnerLa
 	cmd.Dir = req.CWD
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
 	cmd.Env = sessionenv.Strip(captureLoginEnv(req.GmuxBin, req.CWD))
+	// Stdio is wired explicitly, and to nothing.
+	//
+	// A runner outlives the daemon that spawned it, so a runner holding the
+	// daemon's log descriptor would keep writing to whatever inode it names --
+	// after one rotation the archive, after the next an unlinked file. exec
+	// already gives a nil field /dev/null, and the log descriptors are marked
+	// close-on-exec, but a runner is exactly the long-lived child where the
+	// invariant matters, so say it here rather than leave it to two defaults.
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = nil, nil, nil
 	if err := cmd.Start(); err != nil {
 		if info, statErr := os.Stat(req.CWD); req.CWD != "" && (statErr != nil || !info.IsDir()) {
 			return runnerLaunchResult{}, fmt.Errorf("working directory %q does not exist: %w", req.CWD, err)

--- a/services/gmuxd/cmd/gmuxd/bootstrap_runner_adapters.go
+++ b/services/gmuxd/cmd/gmuxd/bootstrap_runner_adapters.go
@@ -27,16 +27,29 @@ import (
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/sessioncoord"
 )
 
+// runnerIncarnationHeader must match ptyserver.IncarnationHeader. It is
+// duplicated rather than imported because the runner and the daemon are
+// separate modules with no shared HTTP surface; the value is part of the
+// runner protocol and is covered by a contract test.
+const runnerIncarnationHeader = "X-Gmux-Incarnation"
+
 type productionRunnerClient struct{}
 
 type productionEventStream struct {
-	events chan sessioncoord.RunnerEvent
-	cancel context.CancelFunc
-	body   io.ReadCloser
-	once   sync.Once
+	events      chan sessioncoord.RunnerEvent
+	cancel      context.CancelFunc
+	body        io.ReadCloser
+	incarnation string
+	once        sync.Once
 }
 
 func (s *productionEventStream) Events() <-chan sessioncoord.RunnerEvent { return s.events }
+
+// Incarnation reports which runner served this subscription, from the header
+// the runner stamps on every response. It implements
+// sessioncoord.StreamIncarnation; an empty value means the runner predates the
+// protocol.
+func (s *productionEventStream) Incarnation() string { return s.incarnation }
 func (s *productionEventStream) Close() error {
 	var err error
 	s.once.Do(func() { s.cancel(); err = s.body.Close() })
@@ -76,7 +89,12 @@ func (productionRunnerClient) Subscribe(ctx context.Context, endpoint string) (s
 		cancel()
 		return nil, fmt.Errorf("runner /events: %s", resp.Status)
 	}
-	s := &productionEventStream{events: make(chan sessioncoord.RunnerEvent, 64), cancel: cancel, body: resp.Body}
+	s := &productionEventStream{
+		events:      make(chan sessioncoord.RunnerEvent, 64),
+		cancel:      cancel,
+		body:        resp.Body,
+		incarnation: resp.Header.Get(runnerIncarnationHeader),
+	}
 	go func() { defer close(s.events); defer s.Close(); scanRunnerEvents(streamCtx, resp.Body, s.events) }()
 	return s, nil
 }
@@ -203,7 +221,15 @@ func (productionRunnerClient) Meta(ctx context.Context, endpoint string) (sessio
 	}
 	reg := centralstore.RunnerRegistration{ID: centralstore.SessionID(s.ID), Adapter: s.Adapter, Alive: s.Alive, CreatedAt: parseMillis(s.CreatedAt), ObservedAt: centralstore.UnixMillis(time.Now().UnixMilli())}
 	reg.Facts = runnerMetaFacts(s)
-	return sessioncoord.RunnerMeta{Registration: reg, PID: s.PID, RunnerVersion: s.RunnerVersion, BinaryHash: s.BinaryHash}, nil
+	// Prefer the header: it is stamped by the same middleware that stamps the
+	// subscription response, so the two comparisons cannot disagree because
+	// of a body-serialisation quirk. The body field is the fallback for a
+	// transport (or proxy) that drops headers.
+	incarnation := resp.Header.Get(runnerIncarnationHeader)
+	if incarnation == "" {
+		incarnation = s.Incarnation
+	}
+	return sessioncoord.RunnerMeta{Registration: reg, PID: s.PID, RunnerVersion: s.RunnerVersion, BinaryHash: s.BinaryHash, Incarnation: incarnation}, nil
 }
 func parseMillis(v string) centralstore.UnixMillis {
 	t, _ := time.Parse(time.RFC3339, v)
@@ -212,6 +238,7 @@ func parseMillis(v string) centralstore.UnixMillis {
 
 type runnerMetaWire struct {
 	ID              string            `json:"id"`
+	Incarnation     string            `json:"incarnation"`
 	Adapter         string            `json:"adapter"`
 	Kind            string            `json:"kind"`
 	Alive           bool              `json:"alive"`

--- a/services/gmuxd/cmd/gmuxd/bootstrap_runner_adapters_test.go
+++ b/services/gmuxd/cmd/gmuxd/bootstrap_runner_adapters_test.go
@@ -194,7 +194,7 @@ func TestProductionRunnerControlUsesKillAndContext(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 	ep := unixRunner(t, mux)
-	if err := (productionRunnerControl{}).Terminate(context.Background(), ep); err != nil {
+	if err := (productionRunnerControl{}).Terminate(context.Background(), ep, ""); err != nil {
 		t.Fatal(err)
 	}
 	if calls.Load() != 1 {
@@ -202,7 +202,17 @@ func TestProductionRunnerControlUsesKillAndContext(t *testing.T) {
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	if err := (productionRunnerControl{}).Terminate(ctx, ep); err == nil {
+	if err := (productionRunnerControl{}).Terminate(ctx, ep, ""); err == nil {
 		t.Fatal("cancel ignored")
+	}
+}
+
+// The runner protocol's header names, pinned as literals. The runner lives in
+// another module (cli/gmux, ptyserver.IncarnationHeader /
+// ExpectIncarnationHeader, pinned by its own test), so the two sides cannot
+// share a constant; they can only agree on the wire.
+func TestRunnerIncarnationHeaderNamesAreStable(t *testing.T) {
+	if runnerIncarnationHeader != "X-Gmux-Incarnation" {
+		t.Errorf("runnerIncarnationHeader = %q; the runner stamps X-Gmux-Incarnation", runnerIncarnationHeader)
 	}
 }

--- a/services/gmuxd/cmd/gmuxd/bootstrap_test.go
+++ b/services/gmuxd/cmd/gmuxd/bootstrap_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"net"
 	"os"
 	"path/filepath"
 	"sync"
@@ -76,6 +77,15 @@ func (r *bootstrapCountingResolver) DescribeConversation(context.Context, string
 	return sessioncoord.ConversationInfo{ID: "conversation"}, nil
 }
 
+// A healthy, unchanged fleet must cost nothing per tick. The endpoint here is
+// a real socket file, so discovery can identify it: the installed generation
+// is subscribed to exactly that socket, so 300 further scans must perform no
+// runner I/O at all -- no Subscribe, no Meta (neither for registration nor for
+// the orphan probe) -- and produce no diagnostics.
+//
+// The takeover-I/O assertions are the original point of this test and still
+// hold: a rejected registration must not read the session list or resolve
+// conversations.
 func TestPeriodicScansRejectBeforeConversationTakeoverIO(t *testing.T) {
 	ctx := context.Background()
 	store, err := centralstore.Open(ctx, t.TempDir())
@@ -83,7 +93,12 @@ func TestPeriodicScansRejectBeforeConversationTakeoverIO(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer store.Close()
-	const endpoint = "runner"
+	endpoint := filepath.Join(t.TempDir(), "sess-periodic.sock")
+	ln, err := net.Listen("unix", endpoint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
 	ref := "multi-megabyte-transcript"
 	meta := sessioncoord.RunnerMeta{Registration: centralstore.RunnerRegistration{
 		ID: "sess-periodic", Adapter: "pi", Alive: true, CreatedAt: 1, ObservedAt: 1,
@@ -113,11 +128,11 @@ func TestPeriodicScansRejectBeforeConversationTakeoverIO(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	if got := runners.subscribeCalls.Load(); got != 301 {
-		t.Fatalf("Subscribe calls=%d, want 301", got)
+	if got := runners.subscribeCalls.Load(); got != 1 {
+		t.Fatalf("Subscribe calls=%d, want 1 (convergence only; the installed socket is skipped)", got)
 	}
-	if got := runners.metaCalls.Load(); got != 601 {
-		t.Fatalf("Meta calls=%d, want 601 (register verification + orphan probe)", got)
+	if got := runners.metaCalls.Load(); got != 1 {
+		t.Fatalf("Meta calls=%d, want 1 (convergence only; neither registration nor the orphan probe re-runs)", got)
 	}
 	// Scan's trailing Reconcile performs one expected ListSessions call. Any
 	// additional call is registration takeover preparation and is forbidden.
@@ -127,8 +142,11 @@ func TestPeriodicScansRejectBeforeConversationTakeoverIO(t *testing.T) {
 	if got := resolver.calls.Load(); got != baseResolves {
 		t.Fatalf("resolver/rchar proxy calls=%d, want unchanged %d", got, baseResolves)
 	}
-	if got := reported.Load(); got != 300 {
-		t.Fatalf("observable ErrGenerationActive reports=%d, want 300", got)
+	if got := reported.Load(); got != 0 {
+		t.Fatalf("diagnostics reported=%d, want 0 for an unchanged healthy fleet", got)
+	}
+	if got := boot.diag.size(); got != 0 {
+		t.Fatalf("diagnostic entries retained=%d, want 0", got)
 	}
 }
 

--- a/services/gmuxd/cmd/gmuxd/bootstrap_test.go
+++ b/services/gmuxd/cmd/gmuxd/bootstrap_test.go
@@ -17,10 +17,18 @@ import (
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/statetool"
 )
 
-type bootstrapStream struct{ events chan sessioncoord.RunnerEvent }
+type bootstrapStream struct {
+	events      chan sessioncoord.RunnerEvent
+	incarnation string
+}
 
 func (s *bootstrapStream) Events() <-chan sessioncoord.RunnerEvent { return s.events }
 func (s *bootstrapStream) Close() error                            { return nil }
+
+// Incarnation makes this double behave like the production transport, which
+// carries the runner's identity out of the subscription response. A double
+// that omitted it would exercise only the "unidentifiable runner" path.
+func (s *bootstrapStream) Incarnation() string { return s.incarnation }
 
 type bootstrapRunners struct {
 	mu             sync.Mutex
@@ -36,7 +44,7 @@ func (r *bootstrapRunners) Subscribe(ctx context.Context, ep string) (sessioncoo
 		<-ctx.Done()
 		return nil, ctx.Err()
 	}
-	return &bootstrapStream{events: make(chan sessioncoord.RunnerEvent)}, nil
+	return &bootstrapStream{events: make(chan sessioncoord.RunnerEvent), incarnation: r.metas[ep].Incarnation}, nil
 }
 func (r *bootstrapRunners) Meta(ctx context.Context, ep string) (sessioncoord.RunnerMeta, error) {
 	r.metaCalls.Add(1)
@@ -79,7 +87,7 @@ func TestPeriodicScansRejectBeforeConversationTakeoverIO(t *testing.T) {
 	ref := "multi-megabyte-transcript"
 	meta := sessioncoord.RunnerMeta{Registration: centralstore.RunnerRegistration{
 		ID: "sess-periodic", Adapter: "pi", Alive: true, CreatedAt: 1, ObservedAt: 1,
-	}}
+	}, Incarnation: "incarnation-periodic"}
 	meta.Registration.Facts.ConversationRef = &ref
 	runners := &bootstrapRunners{metas: map[string]sessioncoord.RunnerMeta{endpoint: meta}, blocked: map[string]bool{}}
 	resolver := &bootstrapCountingResolver{}
@@ -132,7 +140,8 @@ func (bootstrapReconciler) ReconcileRetained(context.Context, string, []sessionc
 
 type bootstrapControl struct{}
 
-func (bootstrapControl) Terminate(context.Context, string) error { return nil }
+func (bootstrapControl) Terminate(context.Context, string, string) error { return nil }
+func (bootstrapControl) Reap(context.Context, string, string) error      { return nil }
 
 type bootstrapSpawner struct{}
 

--- a/services/gmuxd/cmd/gmuxd/logbound.go
+++ b/services/gmuxd/cmd/gmuxd/logbound.go
@@ -1,0 +1,439 @@
+package main
+
+// Bounding the daemon log.
+//
+// gmuxd's log is its stderr: the launcher opens the file and the child
+// inherits it as fd 1 and fd 2. Everything that reports anything shares that
+// one descriptor -- the log package, direct fmt.Fprintf(stderr, ...) error
+// paths, runtime panic traces, and any child process that inherits it. Only
+// one of those writers can be made to take a mutex. Bounding the file
+// therefore has to be safe against writes it does not control, arriving at any
+// instant, including while the bounding is in progress.
+//
+// Three designs fail that test:
+//
+//   - Copy the file aside and truncate it in place. Any write between the
+//     copy's last read and the truncate is in neither file: silently deleted.
+//     Exactly the panic trace you needed.
+//   - Rename the file aside and leave fd 2 alone. Every future direct write
+//     lands in the archive, and disappears when the archive is next replaced.
+//   - Open a second descriptor onto the same file. One inode, two offsets.
+//
+// What works is to move the *descriptor*, not the bytes:
+//
+//  1. rename the current log to the archive. fd 2 still points at that inode,
+//     so writes racing this step land in the archive -- retained, not lost.
+//  2. create a fresh current log.
+//  3. dup3 the fresh descriptor over fd 2, atomically. Every writer that
+//     resolves fd 2 after this point -- including the ones that never heard
+//     of this package -- writes to the new file.
+//
+// A write can land on either side of step 3, and both sides are readable
+// files. No write is ever dropped.
+//
+// The bound is honest rather than absolute: rotation is checked before each
+// log-package write, and by a periodic sweep for the writers that bypass it,
+// so the current log can exceed the limit by whatever arrives between two
+// checks. The one thing it may not do is exceed it silently and forever, which
+// is what a rotation triggered only by our own writes would allow.
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"log"
+	"os"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/gmuxapp/gmux/packages/socklease"
+)
+
+// sweepInterval bounds how long the log can stay oversized when nothing is
+// writing through the log package -- a daemon whose only output is a child
+// process spewing on the inherited descriptor, say. It is a variable so tests
+// can drive the sweeper without waiting for it.
+var sweepInterval = 30 * time.Second
+
+const (
+	// defaultLogLimit is the size at which the current log is archived. One
+	// archive is kept, so the daemon's logs occupy about twice this.
+	defaultLogLimit = 8 << 20
+	// rotateRetryDelay throttles retries after a failed rotation, so a
+	// persistent filesystem problem cannot turn every log line into two.
+	rotateRetryDelay = time.Minute
+	// writeChunk caps a single write so one enormous log line cannot carry
+	// the file arbitrarily past the limit before the next check.
+	writeChunk = 1 << 20
+	// maxWriteInterrupts bounds consecutive EINTR retries that made no
+	// progress, so a signal storm cannot spin inside the logger's mutex.
+	maxWriteInterrupts = 64
+)
+
+// boundedLog keeps the process's own log file bounded.
+//
+// It owns no descriptor of its own: it writes to fd 2, the descriptor every
+// other writer in the process also uses, and rotation replaces what fd 2
+// points at rather than what the file contains.
+type boundedLog struct {
+	mu      sync.Mutex
+	fd      int // always 2; kept explicit because that is the whole design
+	dupFDs  []int
+	path    string
+	archive string
+	limit   int64
+
+	// nextAttempt and failureNote implement transition reporting for rotation
+	// failures: a permanently unwritable directory costs one line and one
+	// attempt per minute, not one of each per log line.
+	nextAttempt time.Time
+	failureNote string
+	// disabled stops rotation after a failure that left fd 2 pointing at a
+	// file this logger no longer controls. Logging continues; bounding does
+	// not, because the next rotation could unlink the inode being written to.
+	disabled bool
+
+	stop     chan struct{}
+	stopOnce sync.Once
+	sweeping sync.WaitGroup
+}
+
+// testRotatePhase is a barrier hook for the rotation tests: it runs at each
+// named phase of a rotation so a test can write directly to the descriptor in
+// the exact window it wants. It is nil in production.
+var testRotatePhase func(phase string)
+
+// dupOntoFn is the descriptor move, indirected so a test can make the one
+// step that cannot be provoked by the filesystem fail. It is dupOnto in
+// production.
+var dupOntoFn = dupOnto
+
+// writeFn is the write syscall, indirected for the same reason: a short write
+// or an EINTR on a regular file is legal, rare, and unreachable from a test
+// otherwise. It is syscall.Write in production.
+var writeFn = syscall.Write
+
+func rotatePhase(phase string) {
+	if testRotatePhase != nil {
+		testRotatePhase(phase)
+	}
+}
+
+// installBoundedLog bounds the daemon log if -- and only if -- the process's
+// stderr really is that log file. A foreground `gmuxd serve` on a terminal, or
+// one whose output the operator redirected somewhere else, is left completely
+// alone: silently retargeting or rotating a destination somebody chose would
+// be a worse bug than an unbounded log.
+//
+// It returns nil when bounding does not apply. The caller must Stop the
+// returned logger.
+func installBoundedLog(stderr io.Writer, logPath string, limit int64) *boundedLog {
+	f, ok := stderr.(*os.File)
+	if !ok {
+		return nil
+	}
+	fi, err := f.Stat()
+	if err != nil || !fi.Mode().IsRegular() {
+		return nil
+	}
+	pi, err := os.Lstat(logPath)
+	if err != nil || !os.SameFile(fi, pi) {
+		return nil
+	}
+	if int(f.Fd()) != syscall.Stderr {
+		// Bounding works by replacing what fd 2 points at. A log file that is
+		// not fd 2 would leave every direct stderr write behind.
+		return nil
+	}
+	// The mode argument of OpenFile only applies on creation, so a log file
+	// that predates this (or was created by something more permissive) can
+	// still be world-readable while carrying session titles and command
+	// lines. Fixing it is best-effort: refusing to bound an unbounded log
+	// because we could not also tighten its mode would trade a small
+	// disclosure for a disk-filling one, so the failure is loud instead.
+	if fi.Mode().Perm() != 0o600 {
+		if err := f.Chmod(0o600); err != nil {
+			log.Printf("gmuxd: WARNING: %s is mode %o and cannot be restricted (%v); "+
+				"it records session titles, working directories and command lines",
+				logPath, fi.Mode().Perm(), err)
+		}
+	}
+	b := &boundedLog{
+		fd:      syscall.Stderr,
+		path:    logPath,
+		archive: logPath + ".1",
+		limit:   limit,
+		stop:    make(chan struct{}),
+	}
+	// stdout usually names the same file; keep it following the current log
+	// too, so a child that writes to stdout does not keep the archive alive.
+	if so, soErr := os.Stdout.Stat(); soErr == nil && os.SameFile(so, fi) {
+		b.dupFDs = append(b.dupFDs, syscall.Stdout)
+	}
+	// No descendant may inherit a log descriptor.
+	//
+	// Rotation moves *this* process's descriptors; it cannot move another
+	// process's. A child holding an inherited descriptor would keep writing to
+	// the archive after one rotation and to an unlinked inode after the next,
+	// losing its output silently. Rather than trying to track such writers,
+	// make them impossible: mark the log descriptors close-on-exec, so a child
+	// only ever has the log if someone deliberately wired it in (see
+	// productionRunnerSpawner, which wires /dev/null explicitly).
+	//
+	// This is re-applied on every rotation. dupOnto already marks the
+	// descriptor it installs, so the re-application is redundant by design:
+	// two independent mechanisms establish the same flag, and a regression in
+	// either one leaves the invariant standing.
+	b.markCloseOnExec()
+	log.SetOutput(b)
+	b.sweeping.Add(1)
+	go b.sweep()
+	return b
+}
+
+// markCloseOnExec marks the log descriptors close-on-exec. Failures are
+// reported rather than fatal: an inherited descriptor is a diagnostic hazard,
+// not a reason to refuse to run.
+func (b *boundedLog) markCloseOnExec() {
+	for _, fd := range append([]int{b.fd}, b.dupFDs...) {
+		if err := setCloseOnExec(fd); err != nil {
+			log.Printf("gmuxd: cannot mark fd %d close-on-exec (%v); a child could inherit the log", fd, err)
+		}
+	}
+}
+
+// Stop ends the background sweep. It does not close fd 2.
+func (b *boundedLog) Stop() {
+	if b == nil {
+		return
+	}
+	b.stopOnce.Do(func() { close(b.stop) })
+	b.sweeping.Wait()
+}
+
+// sweep bounds the log even when nothing writes through the log package: the
+// writers this design exists to preserve -- panic traces, direct stderr
+// output, inherited children -- never call Write.
+func (b *boundedLog) sweep() {
+	defer b.sweeping.Done()
+	t := time.NewTicker(sweepInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-b.stop:
+			return
+		case <-t.C:
+			b.mu.Lock()
+			b.rotateIfLargeLocked()
+			b.mu.Unlock()
+		}
+	}
+}
+
+// Write appends to the log, rotating first when the write would carry the file
+// past the limit, and splitting writes too large to be bounded any other way.
+func (b *boundedLog) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	deferred := b.writeLocked(p)
+	b.mu.Unlock()
+	// Any complaint the write path collected is emitted after the lock is
+	// released: it goes through the log package, whose output is this writer.
+	for _, note := range deferred.notes {
+		log.Print(note)
+	}
+	return deferred.written, deferred.err
+}
+
+// writeResult carries what Write learned out of the critical section.
+type writeResult struct {
+	written int
+	err     error
+	notes   []string
+}
+
+func (b *boundedLog) writeLocked(p []byte) writeResult {
+	var res writeResult
+	interrupted := 0
+	for len(p) > 0 {
+		res.notes = append(res.notes, b.rotateIfLargeLocked()...)
+		chunk := p
+		if len(chunk) > writeChunk {
+			chunk = chunk[:writeChunk]
+		}
+		n, err := writeFn(b.fd, chunk)
+		// The write(2) convention is that n is -1 whenever errno is set, and a
+		// partial write interrupted by a signal is reported as a *successful*
+		// short write rather than EINTR. So a byte count is only ever
+		// meaningful when it is positive, and it is never safe to index with
+		// one that is not: `p[n:]` with n = -1 panics, which in this function
+		// means a panic inside the logger, under the logger's own mutex, in a
+		// daemon whose contract says a broken write degrades to a large log
+		// rather than a dead one.
+		if n < 0 {
+			n = 0
+		}
+		res.written += n
+		p = p[n:]
+
+		if err != nil {
+			if errors.Is(err, syscall.EINTR) {
+				if n == 0 {
+					// No progress at all. Retry, but not forever: a signal
+					// storm must not turn one log line into an infinite loop
+					// holding this mutex.
+					interrupted++
+					if interrupted > maxWriteInterrupts {
+						res.err = err
+						return res
+					}
+					continue
+				}
+				interrupted = 0
+				continue
+			}
+			res.err = err
+			return res
+		}
+		if n == 0 {
+			// No error and no progress. Retrying would spin forever, and
+			// reporting success would let the caller believe a truncated
+			// diagnostic was written in full.
+			res.err = io.ErrShortWrite
+			return res
+		}
+		// A short write is progress, not completion: carry on with the
+		// remainder, which is what io.Writer's contract requires of us before
+		// we may report success.
+		interrupted = 0
+	}
+	// Leave the file bounded for whatever writes next, including writers that
+	// never reach this function.
+	res.notes = append(res.notes, b.rotateIfLargeLocked()...)
+	return res
+}
+
+// rotateIfLargeLocked archives and replaces the log when it exceeds the limit.
+//
+// Every failure path leaves a usable descriptor: fd 2 always names a file that
+// exists, so the worst outcome of a broken filesystem is an unbounded log,
+// never a dead logger or a panicking daemon.
+//
+// It returns any diagnostics that must be emitted through the log package;
+// the caller emits them *after* releasing b.mu. Logging from in here would
+// re-enter Write, which takes the same non-reentrant mutex, and wedge the
+// process -- including the sweep goroutine and, through it, shutdown.
+func (b *boundedLog) rotateIfLargeLocked() (notes []string) {
+	if b.disabled {
+		return nil
+	}
+	if !b.nextAttempt.IsZero() && time.Now().Before(b.nextAttempt) {
+		return nil
+	}
+	// Stat the descriptor, not the pathname: everything that writes directly
+	// to stderr shares this file, and a bound that ignored those writes would
+	// not be a bound.
+	var st syscall.Stat_t
+	if err := syscall.Fstat(b.fd, &st); err != nil || st.Size < b.limit {
+		return nil
+	}
+	notes, err := b.rotateLocked()
+	if err != nil {
+		b.nextAttempt = time.Now().Add(rotateRetryDelay)
+		if note := err.Error(); note != b.failureNote {
+			b.failureNote = note
+			// Straight to the descriptor: going through Write would re-enter
+			// rotation, and through the log package would re-enter the mutex.
+			_, _ = writeFn(b.fd, fmt.Appendf(nil, "gmuxd: cannot rotate %s: %v\n", b.path, err))
+		}
+		return notes
+	}
+	b.nextAttempt = time.Time{}
+	b.failureNote = ""
+	return notes
+}
+
+func (b *boundedLog) rotateLocked() (notes []string, err error) {
+	// Serialise against any other daemon process that might still be bounding
+	// this same file. Ownership already makes an overlap nearly impossible --
+	// bounding installs only after the state lock is held, which an incumbent
+	// releases as it exits -- but "nearly" is doing too much work for an
+	// operation that renames files, so rotations take a lease of their own.
+	lease, err := socklease.AcquireWait(b.path, 2*time.Second)
+	if errors.Is(err, socklease.ErrHeld) {
+		return nil, errors.New("another process is rotating this log")
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = lease.Release() }()
+
+	// Re-check under the lease: the other rotator may have just finished.
+	var st syscall.Stat_t
+	if err := syscall.Fstat(b.fd, &st); err != nil {
+		return nil, err
+	}
+	if st.Size < b.limit {
+		return nil, nil
+	}
+	rotatePhase("lease-held")
+
+	// A fresh current log, prepared before anything is moved so a failure
+	// here changes nothing at all.
+	fresh, err := os.OpenFile(b.path+".new", os.O_CREATE|os.O_EXCL|os.O_WRONLY|os.O_APPEND, 0o600)
+	if errors.Is(err, fs.ErrExist) {
+		// Left by a rotation that died between creating it and renaming it.
+		_ = os.Remove(b.path + ".new")
+		fresh, err = os.OpenFile(b.path+".new", os.O_CREATE|os.O_EXCL|os.O_WRONLY|os.O_APPEND, 0o600)
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer fresh.Close()
+
+	// Archive by rename: atomic, so the previous archive is replaced in one
+	// step and a failure cannot leave a partial one. fd 2 still points at
+	// this inode, so writes racing the rename land in the archive -- retained,
+	// which is the entire reason this is a rename and not a copy.
+	rotatePhase("before-archive")
+	if err := os.Rename(b.path, b.archive); err != nil {
+		_ = os.Remove(b.path + ".new")
+		return nil, err
+	}
+	rotatePhase("archived")
+
+	if err := os.Rename(b.path+".new", b.path); err != nil {
+		// Put the log back where it was; fd 2 is still attached to it, so
+		// this restores both the name and the writer.
+		if undo := os.Rename(b.archive, b.path); undo != nil {
+			b.disabled = true
+			return nil, fmt.Errorf("%v (and the log could not be restored: %v)", err, undo)
+		}
+		_ = os.Remove(b.path + ".new")
+		return nil, err
+	}
+	rotatePhase("current-replaced")
+
+	// Move the descriptor. From here every writer in the process -- ours and
+	// everyone else's -- resolves fd 2 to the fresh file.
+	if err := dupOntoFn(int(fresh.Fd()), b.fd); err != nil {
+		// fd 2 still names the archive: logging survives, but a further
+		// rotation would rename the fresh (empty) log over it and unlink the
+		// inode being written to. Stop bounding instead.
+		b.disabled = true
+		return nil, fmt.Errorf("could not move the log descriptor: %w", err)
+	}
+	for _, fd := range b.dupFDs {
+		if err := dupOntoFn(int(fresh.Fd()), fd); err != nil {
+			// Deferred, not logged here: this runs under b.mu, and the log
+			// package's output is this writer. A secondary descriptor left on
+			// the archive is a diagnostic wart, not a reason to wedge the
+			// daemon.
+			notes = append(notes, fmt.Sprintf("gmuxd: fd %d still points at the archived log: %v", fd, err))
+		}
+	}
+	b.markCloseOnExec()
+	rotatePhase("descriptor-moved")
+	return notes, nil
+}

--- a/services/gmuxd/cmd/gmuxd/logbound_cloexec.go
+++ b/services/gmuxd/cmd/gmuxd/logbound_cloexec.go
@@ -1,0 +1,17 @@
+package main
+
+import "syscall"
+
+// setCloseOnExec marks fd close-on-exec, so no exec'd child inherits it.
+//
+// It is the enforcement half of the daemon log's inheritance invariant: a
+// child that inherited a log descriptor would go on writing to whatever inode
+// that descriptor names, which after two rotations is a file with no name at
+// all. Rotation can move this process's descriptors; nothing can move a
+// child's.
+func setCloseOnExec(fd int) error {
+	if _, _, errno := syscall.Syscall(syscall.SYS_FCNTL, uintptr(fd), syscall.F_SETFD, syscall.FD_CLOEXEC); errno != 0 {
+		return errno
+	}
+	return nil
+}

--- a/services/gmuxd/cmd/gmuxd/logbound_dup_linux.go
+++ b/services/gmuxd/cmd/gmuxd/logbound_dup_linux.go
@@ -1,0 +1,29 @@
+//go:build linux
+
+package main
+
+import "syscall"
+
+// dupOnto atomically makes dst refer to the same open file as src, and marks
+// dst close-on-exec in the same operation.
+//
+// Linux/arm64 has no dup2 syscall at all, so Dup3 is both the portable choice
+// within Linux and the atomic one: a writer racing this call sees either the
+// old file or the new one, never a closed descriptor. Passing O_CLOEXEC here
+// rather than setting it afterwards leaves no window in which a fork could
+// hand a child the daemon's log.
+//
+// What is pinned by tests and what is not: that dupOnto leaves the destination
+// close-on-exec is asserted directly (TestDupOntoMarksTheDestinationCloseOnExec),
+// and the invariant it serves -- no descendant holds a log descriptor -- is
+// asserted after install and after two rotations. The *absence of a window*
+// between the dup and the flag is not observable from user space at all: with
+// the flag folded into the syscall there is no second step to race, and a
+// version that set it afterwards would differ only in a few instructions of
+// exposure. That half rests on this argument and on review, not on a test.
+func dupOnto(src, dst int) error {
+	if src == dst {
+		return nil
+	}
+	return syscall.Dup3(src, dst, syscall.O_CLOEXEC)
+}

--- a/services/gmuxd/cmd/gmuxd/logbound_dup_unix.go
+++ b/services/gmuxd/cmd/gmuxd/logbound_dup_unix.go
@@ -1,0 +1,26 @@
+//go:build !linux
+
+package main
+
+import "syscall"
+
+// dupOnto atomically makes dst refer to the same open file as src, and marks
+// dst close-on-exec.
+//
+// Darwin has no dup3, so the close-on-exec flag needs a second call and the
+// window this platform cannot avoid is real: a fork landing between the two
+// would hand a child the daemon's log. It is not a correctness hole for the log
+// specifically -- every child launch in this package wires its stdio explicitly
+// -- and the flag is defence against code that does not.
+//
+// As on Linux, that dupOnto leaves the destination close-on-exec is asserted
+// directly; the size of the window is not testable.
+func dupOnto(src, dst int) error {
+	if src == dst {
+		return nil
+	}
+	if err := syscall.Dup2(src, dst); err != nil {
+		return err
+	}
+	return setCloseOnExec(dst)
+}

--- a/services/gmuxd/cmd/gmuxd/logbound_test.go
+++ b/services/gmuxd/cmd/gmuxd/logbound_test.go
@@ -1,0 +1,1081 @@
+package main
+
+// logbound_test.go — mutation-grade tests for daemon log bounding.
+//
+// The property that matters is not "the file gets smaller". It is that no
+// output is ever lost, including output from the writers this package cannot
+// synchronise with: direct writes to the inherited descriptor, runtime panic
+// traces, and child processes. Every test below writes directly to the
+// descriptor, in the windows a rotation actually has, and then insists on
+// finding those bytes in one of the two files an operator can read.
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// logHarness owns a real log file installed on a real descriptor. Bounding
+// replaces what a descriptor points at, so these tests cannot use an
+// arbitrary *os.File: they need the process's own fd 2. Each test therefore
+// borrows fd 2, and puts it back afterwards.
+type logHarness struct {
+	path    string
+	archive string
+	saved   int
+	b       *boundedLog
+}
+
+func newLogHarness(t *testing.T, limit int64) *logHarness {
+	t.Helper()
+	dir := t.TempDir()
+	h := &logHarness{path: filepath.Join(dir, "gmuxd.log"), archive: filepath.Join(dir, "gmuxd.log.1")}
+
+	// Save the real stderr so the test framework keeps working afterwards.
+	saved, err := syscall.Dup(syscall.Stderr)
+	if err != nil {
+		t.Fatalf("dup stderr: %v", err)
+	}
+	h.saved = saved
+
+	f, err := os.OpenFile(h.path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		t.Fatalf("open log: %v", err)
+	}
+	if err := dupOnto(int(f.Fd()), syscall.Stderr); err != nil {
+		t.Fatalf("install log on fd 2: %v", err)
+	}
+	_ = f.Close()
+	// A daemon inherits fd 2 from its launcher, and an inherited descriptor
+	// carries no close-on-exec flag. dupOnto sets one, so clear it again:
+	// otherwise the harness would be handing the code under test a descriptor
+	// that is already in the state it is supposed to establish.
+	if _, _, errno := syscall.Syscall(syscall.SYS_FCNTL, uintptr(syscall.Stderr), syscall.F_SETFD, 0); errno != 0 {
+		t.Fatalf("clear close-on-exec on fd 2: %v", errno)
+	}
+
+	t.Cleanup(func() {
+		if h.b != nil {
+			h.b.Stop()
+		}
+		_ = dupOnto(h.saved, syscall.Stderr)
+		_ = syscall.Close(h.saved)
+	})
+
+	h.b = installBoundedLog(os.Stderr, h.path, limit)
+	if h.b == nil {
+		t.Fatal("installBoundedLog declined the process's own log file")
+	}
+	return h
+}
+
+// direct writes straight to the descriptor, the way a panic trace or an
+// inherited child does: no mutex, no knowledge of this package.
+func (h *logHarness) direct(t *testing.T, s string) {
+	t.Helper()
+	if _, err := syscall.Write(syscall.Stderr, []byte(s)); err != nil {
+		t.Fatalf("direct write: %v", err)
+	}
+}
+
+func (h *logHarness) log(t *testing.T, s string) {
+	t.Helper()
+	if _, err := h.b.Write([]byte(s)); err != nil {
+		t.Fatalf("log write: %v", err)
+	}
+}
+
+func (h *logHarness) read(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return ""
+		}
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(data)
+}
+
+// somewhere asserts that a marker survived, in either readable file.
+func (h *logHarness) somewhere(t *testing.T, marker string) {
+	t.Helper()
+	if strings.Contains(h.read(t, h.path), marker) || strings.Contains(h.read(t, h.archive), marker) {
+		return
+	}
+	t.Fatalf("%q was lost by the rotation: it is in neither the current log nor the archive", marker)
+}
+
+func fill(n int) string { return strings.Repeat("x", n) + "\n" }
+
+// breakRotation makes creating the fresh log impossible, in a way the
+// rotation's own recovery cannot clear: a non-empty directory where the new
+// file must go. It stands in for the whole family of filesystem refusals
+// (ENOSPC, EROFS, EDQUOT) that a daemon must survive.
+func breakRotation(t *testing.T, h *logHarness) {
+	t.Helper()
+	if err := os.Mkdir(h.path+".new", 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(h.path+".new", "occupant"), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(h.path + ".new") })
+}
+
+// fixRotation undoes breakRotation.
+func fixRotation(t *testing.T, h *logHarness) {
+	t.Helper()
+	if err := os.RemoveAll(h.path + ".new"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Mutation: remove the rotation call from Write.
+func TestBoundedLogRotatesAndKeepsOneArchive(t *testing.T) {
+	h := newLogHarness(t, 512)
+	for i := range 20 {
+		h.log(t, fmt.Sprintf("line-%02d %s", i, fill(64)))
+	}
+
+	if size := len(h.read(t, h.path)); int64(size) >= 512 {
+		t.Fatalf("current log is %d bytes, want it bounded below 512", size)
+	}
+	if h.read(t, h.archive) == "" {
+		t.Fatal("nothing was archived")
+	}
+	if names := logDirEntries(t, h); len(names) != 2 {
+		t.Fatalf("log directory holds %v, want exactly the log and one archive", names)
+	}
+}
+
+// logDirEntries lists the log directory.
+func logDirEntries(t *testing.T, h *logHarness) []string {
+	t.Helper()
+	entries, err := os.ReadDir(filepath.Dir(h.path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var names []string
+	for _, e := range entries {
+		names = append(names, e.Name())
+	}
+	return names
+}
+
+// Mutation: rotate by copy-and-truncate, or by rename without moving the
+// descriptor.
+//
+// A direct write in *any* window of a rotation must survive. Copy-truncate
+// loses the ones between the copy and the truncate; a rename that leaves fd 2
+// behind loses every later one when the archive is next replaced.
+func TestDirectWritesSurviveEveryRotationPhase(t *testing.T) {
+	for _, phase := range []string{"lease-held", "before-archive", "archived", "current-replaced", "descriptor-moved"} {
+		t.Run(phase, func(t *testing.T) {
+			h := newLogHarness(t, 512)
+			marker := "PANIC-AT-" + phase
+			fired := false
+			testRotatePhase = func(p string) {
+				if p != phase || fired {
+					return
+				}
+				fired = true
+				h.direct(t, marker+"\n")
+			}
+			t.Cleanup(func() { testRotatePhase = nil })
+
+			// Exactly one rotation, so the archive still holds whatever the
+			// rotation displaced.
+			h.log(t, fill(600))
+			if !fired {
+				t.Fatalf("no rotation reached the %q phase", phase)
+			}
+			h.somewhere(t, marker)
+		})
+	}
+}
+
+// Mutation: dup the fresh descriptor only over fd 2 but never at all (i.e.
+// drop the dup), or archive by copy so fd 2 keeps naming the current file.
+//
+// After a rotation, writers that never call into this package must be writing
+// to the *current* log. If they are still on the archive, their output
+// vanishes at the next rotation.
+func TestDirectWritesFollowTheCurrentLogAfterRotation(t *testing.T) {
+	h := newLogHarness(t, 512)
+	for i := range 20 {
+		h.log(t, fmt.Sprintf("line-%02d %s", i, fill(64)))
+	}
+	h.direct(t, "AFTER-ROTATION\n")
+
+	if !strings.Contains(h.read(t, h.path), "AFTER-ROTATION") {
+		t.Fatal("a direct write after rotation did not reach the current log; " +
+			"the descriptor was left pointing at the archive")
+	}
+}
+
+// Two rotations, with direct writes in each generation. Only one archive is
+// kept, so the oldest generation is expected to be gone -- but nothing from
+// the two most recent may be missing.
+func TestTwoRotationsLoseNothingFromTheLastTwoGenerations(t *testing.T) {
+	h := newLogHarness(t, 512)
+
+	rotations := 0
+	testRotatePhase = func(p string) {
+		if p == "descriptor-moved" {
+			rotations++
+			h.direct(t, fmt.Sprintf("GEN-%d-DIRECT\n", rotations))
+		}
+	}
+	t.Cleanup(func() { testRotatePhase = nil })
+
+	h.log(t, fill(600))
+	h.log(t, fill(600))
+	if rotations != 2 {
+		t.Fatalf("%d rotations happened, want exactly 2", rotations)
+	}
+	// The write made right after the second rotation is in the current log;
+	// the one from the first is in the archive.
+	h.somewhere(t, "GEN-2-DIRECT")
+	h.somewhere(t, "GEN-1-DIRECT")
+}
+
+// Mutation: let a rotation failure close, replace or nil the descriptor.
+//
+// A daemon that dies, or stops logging, because it could not rotate is
+// strictly worse than one with a large log.
+func TestRotationFailureKeepsTheLoggerAlive(t *testing.T) {
+	h := newLogHarness(t, 512)
+	breakRotation(t, h)
+
+	h.log(t, fill(600))
+	h.log(t, "line-after-failure\n")
+	h.direct(t, "STILL-WRITING\n")
+
+	current := h.read(t, h.path)
+	if !strings.Contains(current, "cannot rotate") {
+		t.Fatal("a rotation failure was never reported")
+	}
+	if !strings.Contains(current, "STILL-WRITING") {
+		t.Fatal("direct writes stopped reaching the log after a failed rotation")
+	}
+	if !strings.Contains(current, "line-after-failure") {
+		t.Fatal("log-package writes stopped after a failed rotation")
+	}
+
+	// Reported once per distinct failure, not once per attempt.
+	for range 3 {
+		h.b.mu.Lock()
+		h.b.nextAttempt = time.Now().Add(-time.Second)
+		h.b.mu.Unlock()
+		h.log(t, fill(600))
+	}
+	if got := strings.Count(h.read(t, h.path), "cannot rotate"); got != 1 {
+		t.Fatalf("rotation failure reported %d times, want 1", got)
+	}
+}
+
+// Mutation: drop the retry throttle.
+func TestRotationFailureIsThrottled(t *testing.T) {
+	h := newLogHarness(t, 512)
+	breakRotation(t, h)
+	h.log(t, fill(600))
+
+	h.b.mu.Lock()
+	next := h.b.nextAttempt
+	h.b.mu.Unlock()
+	if next.IsZero() || time.Until(next) <= 0 {
+		t.Fatal("a failed rotation did not back off")
+	}
+
+	// Unblock rotation. The next write must still not attempt one.
+	fixRotation(t, h)
+	h.log(t, fill(600))
+	if h.read(t, h.archive) != "" {
+		t.Fatal("rotation was retried inside the backoff window")
+	}
+
+	// And it resumes once the window closes.
+	h.b.mu.Lock()
+	h.b.nextAttempt = time.Now().Add(-time.Second)
+	h.b.mu.Unlock()
+	h.log(t, fill(600))
+	if h.read(t, h.archive) == "" {
+		t.Fatal("rotation did not resume after the backoff window")
+	}
+}
+
+// Mutation: create the archive with O_TRUNC before the new log is ready (the
+// copy-based design), or replace the archive non-atomically.
+//
+// A failed rotation must not cost the previous archive: it is the older half
+// of the diagnostics, and the failure is often exactly when it is wanted.
+func TestFailedRotationPreservesThePreviousArchive(t *testing.T) {
+	h := newLogHarness(t, 512)
+	// One good rotation, so there is an archive worth protecting.
+	h.log(t, "first-generation "+fill(600))
+	if !strings.Contains(h.read(t, h.archive), "first-generation") {
+		t.Fatal("the first rotation did not archive the first generation")
+	}
+
+	// Now break rotation and drive another one.
+	breakRotation(t, h)
+	h.log(t, "second-generation "+fill(600))
+
+	if !strings.Contains(h.read(t, h.archive), "first-generation") {
+		t.Fatal("a failed rotation destroyed the previous archive")
+	}
+}
+
+// ENOSPC and friends: a rename that cannot happen must leave the log usable
+// and the archive intact. Simulated with a read-only directory, which is the
+// closest reachable analogue of a filesystem that refuses writes.
+func TestRotationSurvivesAnUnwritableDirectory(t *testing.T) {
+	h := newLogHarness(t, 512)
+	dir := filepath.Dir(h.path)
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+
+	h.log(t, "line-before "+fill(600))
+	h.log(t, "line-after\n")
+	h.direct(t, "SURVIVED\n")
+
+	current := h.read(t, h.path)
+	if !strings.Contains(current, "SURVIVED") || !strings.Contains(current, "line-after") {
+		t.Fatal("logging did not survive an unwritable log directory")
+	}
+}
+
+// Mutation: drop the rotation lease (and the size re-check under it).
+//
+// Two daemons can briefly overlap during a handover -- the incumbent is still
+// draining while its replacement has taken ownership. Both bound the same
+// file. Without a lease the second one walks into the middle of the first
+// one's rotation: it finds the current log already renamed, deletes the fresh
+// log the first one prepared, and leaves the directory (and the surviving
+// descriptor) in a state nobody planned.
+//
+// The barrier parks the first rotation mid-flight, which is the interleaving
+// a bare goroutine race reaches only occasionally.
+func TestConcurrentRotatorsSerialiseOnTheLogLease(t *testing.T) {
+	h := newLogHarness(t, 512)
+	// A second bounded logger over the same file, as an overlapping daemon
+	// would have.
+	other := &boundedLog{
+		fd:      syscall.Stderr,
+		path:    h.path,
+		archive: h.archive,
+		limit:   512,
+		stop:    make(chan struct{}),
+	}
+
+	parked := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	testRotatePhase = func(p string) {
+		if p != "archived" {
+			return
+		}
+		once.Do(func() {
+			close(parked)
+			<-release
+		})
+	}
+	t.Cleanup(func() { testRotatePhase = nil })
+
+	// Drive the first rotation off the test goroutine, since it parks
+	// mid-flight while holding its own lock.
+	var wg sync.WaitGroup
+	wg.Add(1)
+	writeErr := make(chan error, 1)
+	go func() {
+		defer wg.Done()
+		_, err := h.b.Write([]byte(fill(600)))
+		writeErr <- err
+	}()
+
+	select {
+	case <-parked:
+	case <-time.After(10 * time.Second):
+		close(release)
+		wg.Wait()
+		t.Fatal("the first rotation never reached its parked phase")
+	}
+
+	// The overlapping daemon tries to rotate the same file, right now.
+	other.mu.Lock()
+	other.rotateIfLargeLocked()
+	other.mu.Unlock()
+
+	close(release)
+	wg.Wait()
+	if err := <-writeErr; err != nil {
+		t.Fatalf("write during a contended rotation: %v", err)
+	}
+
+	// Exactly one rotation: the log directory holds the log and one archive,
+	// and no leftover .new file.
+	names := logDirEntries(t, h)
+	if len(names) != 2 {
+		t.Fatalf("log directory holds %v, want exactly the log and one archive", names)
+	}
+	h.direct(t, "AFTER-CONTENTION\n")
+	if !strings.Contains(h.read(t, h.path), "AFTER-CONTENTION") {
+		t.Fatal("the descriptor does not name the current log after a contended rotation")
+	}
+}
+
+// Mutation: keep rotating after the descriptor move fails.
+//
+// If fd 2 could not be moved it still names the archive. Logging survives --
+// that file exists and is readable -- but a further rotation would rename the
+// fresh log over that archive and unlink the inode being written to, turning
+// a recoverable failure into silent loss. Bounding stops instead.
+func TestRotationStopsAfterAFailedDescriptorMove(t *testing.T) {
+	h := newLogHarness(t, 512)
+	dupOntoFn = func(int, int) error { return errors.New("simulated dup failure") }
+	t.Cleanup(func() { dupOntoFn = dupOnto })
+
+	h.log(t, "first-generation "+fill(600))
+	h.direct(t, "STILL-READABLE\n")
+
+	// fd 2 now names the archive, and that file must keep receiving writes.
+	if !strings.Contains(h.read(t, h.archive), "STILL-READABLE") {
+		t.Fatal("writes stopped landing anywhere readable after a failed descriptor move")
+	}
+
+	// Further rotations must not happen: the archive holding the live
+	// descriptor may not be replaced.
+	dupOntoFn = dupOnto
+	h.b.mu.Lock()
+	h.b.nextAttempt = time.Time{}
+	h.b.mu.Unlock()
+	h.log(t, "second-generation "+fill(600))
+	h.direct(t, "STILL-READABLE-LATER\n")
+
+	if !strings.Contains(h.read(t, h.archive), "STILL-READABLE-LATER") {
+		t.Fatal("a rotation after a failed descriptor move unlinked the inode being written to")
+	}
+}
+
+// Mutation: drop the chunking, or check the size only after writing.
+//
+// One enormous log line must not carry the file arbitrarily past the limit and
+// leave it there.
+func TestOneHugeWriteDoesNotEscapeTheBound(t *testing.T) {
+	const limit = 4 << 20
+	h := newLogHarness(t, limit)
+	h.log(t, strings.Repeat("y", 12<<20)+"\n")
+
+	// Neither file may hold the whole write: without chunking the log grows
+	// to 12 MiB before anything notices, and the archive keeps it there.
+	if size := int64(len(h.read(t, h.path))); size > limit+writeChunk {
+		t.Fatalf("current log is %d bytes after one huge write, want at most limit+%d", size, writeChunk)
+	}
+	if size := int64(len(h.read(t, h.archive))); size > limit+writeChunk {
+		t.Fatalf("archive is %d bytes after one huge write, want at most limit+%d", size, writeChunk)
+	}
+}
+
+// Mutation: remove the background sweep.
+//
+// A daemon whose only output comes from writers that bypass the log package --
+// an inherited child, a stream of panics -- must still end up bounded.
+func TestSweepBoundsALogNobodyIsLoggingTo(t *testing.T) {
+	h := newLogHarness(t, 512)
+	h.direct(t, fill(600))
+
+	// The sweep would do this on its own timer; drive one iteration rather
+	// than sleeping for it.
+	h.b.mu.Lock()
+	h.b.rotateIfLargeLocked()
+	h.b.mu.Unlock()
+
+	if h.read(t, h.archive) == "" {
+		t.Fatal("a log grown entirely by direct writes was never rotated")
+	}
+	if size := len(h.read(t, h.path)); size != 0 {
+		t.Fatalf("current log is %d bytes after rotation, want 0", size)
+	}
+}
+
+// Mutation: remove the background sweep goroutine (or its Stop join).
+//
+// Nothing here writes through the log package: this is the daemon whose only
+// output comes from an inherited child or a panic, which is exactly the case
+// a write-triggered bound cannot see.
+func TestSweepRotatesWithoutAnyLogPackageWrites(t *testing.T) {
+	restore := sweepInterval
+	sweepInterval = 5 * time.Millisecond
+	t.Cleanup(func() { sweepInterval = restore })
+
+	h := newLogHarness(t, 512)
+	h.direct(t, fill(600))
+
+	deadline := time.Now().Add(5 * time.Second)
+	for h.read(t, h.archive) == "" {
+		if time.Now().After(deadline) {
+			t.Fatal("the background sweep never rotated a log grown entirely by direct writes")
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	// Stop must join the sweeper; a second Stop must be harmless.
+	h.b.Stop()
+	h.b.Stop()
+}
+
+// Mutation: drop the chmod, or the SameFile / fd-2 gates.
+func TestInstallBoundedLogGatesAndPermissions(t *testing.T) {
+	t.Run("tightens a permissive log", func(t *testing.T) {
+		h := newLogHarness(t, 512)
+		if err := os.Chmod(h.path, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		// Re-install over the same descriptor.
+		if b := installBoundedLog(os.Stderr, h.path, 512); b == nil {
+			t.Fatal("declined the process's own log")
+		} else {
+			t.Cleanup(b.Stop)
+		}
+		fi, err := os.Stat(h.path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if perm := fi.Mode().Perm(); perm != 0o600 {
+			t.Fatalf("log mode = %o, want 600", perm)
+		}
+	})
+
+	t.Run("declines a file that is not the daemon log", func(t *testing.T) {
+		dir := t.TempDir()
+		other := filepath.Join(dir, "operator-chosen.log")
+		f, err := os.OpenFile(other, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer f.Close()
+		if b := installBoundedLog(f, filepath.Join(dir, "gmuxd.log"), 512); b != nil {
+			b.Stop()
+			t.Fatal("bounded a file that is not the daemon log")
+		}
+	})
+
+	t.Run("declines a pipe", func(t *testing.T) {
+		r, w, err := os.Pipe()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer r.Close()
+		defer w.Close()
+		if b := installBoundedLog(w, filepath.Join(t.TempDir(), "gmuxd.log"), 512); b != nil {
+			b.Stop()
+			t.Fatal("bounded a pipe")
+		}
+	})
+
+	t.Run("declines a log that is not fd 2", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "gmuxd.log")
+		f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer f.Close()
+		// Same file, right pathname, wrong descriptor: bounding would leave
+		// every direct stderr write behind.
+		if b := installBoundedLog(f, path, 512); b != nil {
+			b.Stop()
+			t.Fatal("bounded a log that is not the process's stderr")
+		}
+	})
+
+	t.Run("declines a non-file writer", func(t *testing.T) {
+		if b := installBoundedLog(&strings.Builder{}, filepath.Join(t.TempDir(), "gmuxd.log"), 512); b != nil {
+			b.Stop()
+			t.Fatal("bounded a non-file writer")
+		}
+	})
+}
+
+// Mutation: give the launcher back its O_TRUNC (or drop O_APPEND).
+//
+// The launcher opens the log before the child has checked for a healthy
+// incumbent, and most invocations that get this far are autostarts that will
+// bounce straight off one: truncating destroys the running daemon's log every
+// time a health probe is slow.
+func TestLauncherOpensLogAppendOnly(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "gmuxd.log")
+	incumbent := "the incumbent daemon's history\n"
+	if err := os.WriteFile(path, []byte(incumbent), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	f, err := openDaemonLog(path)
+	if err != nil {
+		t.Fatalf("openDaemonLog: %v", err)
+	}
+	defer f.Close()
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != incumbent {
+		t.Fatalf("opening the log truncated it; content = %q", content)
+	}
+	// O_APPEND: writes land at the end even after the file has been replaced
+	// or truncated behind this descriptor's back.
+	if _, err := f.WriteString("first\n"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Truncate(path, 0); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString("second\n"); err != nil {
+		t.Fatal(err)
+	}
+	content, err = os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "second\n" {
+		t.Fatalf("log content = %q, want %q (a non-appending descriptor leaves a hole)", content, "second\n")
+	}
+	if fi, statErr := os.Stat(path); statErr != nil || fi.Mode().Perm() != 0o600 {
+		t.Fatalf("log mode = %v (err %v), want 600", fi.Mode().Perm(), statErr)
+	}
+}
+
+// ── inheritance invariant ───────────────────────────────────────────────────
+
+func fdIsCloseOnExec(t *testing.T, fd int) bool {
+	t.Helper()
+	flags, _, errno := syscall.Syscall(syscall.SYS_FCNTL, uintptr(fd), syscall.F_GETFD, 0)
+	if errno != 0 {
+		t.Fatalf("fcntl F_GETFD on fd %d: %v", fd, errno)
+	}
+	return flags&syscall.FD_CLOEXEC != 0
+}
+
+// Rotation moves this process's descriptors. It cannot move a child's, so a
+// child that inherited one keeps writing to the archive after one rotation and
+// to an unlinked inode after the next. The invariant that makes that
+// unreachable is that no descendant holds a log descriptor at all.
+//
+// Mutation: drop markCloseOnExec at install, or drop O_CLOEXEC/setCloseOnExec
+// from dupOnto (which is how the flag would be lost on the second rotation).
+func TestDaemonLogDescriptorsAreCloseOnExec(t *testing.T) {
+	h := newLogHarness(t, 512)
+	if !fdIsCloseOnExec(t, syscall.Stderr) {
+		t.Fatal("the log descriptor is not close-on-exec: a child could inherit it")
+	}
+	// And it stays that way across rotations -- dup2 does not carry the flag.
+	for range 2 {
+		h.log(t, fill(600))
+		if !fdIsCloseOnExec(t, syscall.Stderr) {
+			t.Fatal("the log descriptor lost close-on-exec across a rotation")
+		}
+	}
+}
+
+// The invariant, observed from a real child process across two rotations.
+//
+// The child writes to its own stderr throughout. With the invariant intact it
+// never had the daemon log to begin with, so nothing it writes can land in an
+// inode the second rotation unlinks -- and nothing of the daemon's is lost to
+// it either.
+//
+// Mutation: wire the child's stderr to the daemon's log (`cmd.Stderr =
+// os.Stderr`), which is what an unaudited child launch looks like. Its second
+// marker then lands in an unnamed inode and this test fails.
+func TestNoChildProcessRetainsTheDaemonLogAcrossRotations(t *testing.T) {
+	h := newLogHarness(t, 512)
+
+	// A child that writes on demand, the way a long-lived helper does.
+	script := `while read -r line; do printf 'CHILD-%s\n' "$line" >&2; printf 'ack\n'; done`
+	cmd := exec.Command("sh", "-c", script)
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Production wiring: explicit, and to nothing. See productionRunnerSpawner.
+	cmd.Stderr = nil
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = stdin.Close(); _, _ = cmd.Process.Wait() })
+	acks := bufio.NewReader(stdout)
+	tell := func(what string) {
+		if _, err := stdin.Write([]byte(what + "\n")); err != nil {
+			t.Fatalf("tell child %q: %v", what, err)
+		}
+		if _, err := acks.ReadString('\n'); err != nil {
+			t.Fatalf("child ack for %q: %v", what, err)
+		}
+	}
+
+	tell("before-any-rotation")
+	h.log(t, fill(600)) // rotation 1
+	tell("after-first-rotation")
+	h.log(t, fill(600)) // rotation 2
+	tell("after-second-rotation")
+
+	// The child's output is not in the daemon's log at all: it never had a
+	// descriptor for it. That is the invariant -- not "its writes survive
+	// rotation", but "it cannot be writing there".
+	for _, path := range []string{h.path, h.archive} {
+		if strings.Contains(h.read(t, path), "CHILD-") {
+			t.Fatalf("a child's output reached %s; it inherited a log descriptor", path)
+		}
+	}
+	// The daemon's own writes are still whole across both rotations.
+	h.direct(t, "DAEMON-AFTER-TWO-ROTATIONS\n")
+	if !strings.Contains(h.read(t, h.path), "DAEMON-AFTER-TWO-ROTATIONS") {
+		t.Fatal("the daemon's own descriptor stopped naming the current log")
+	}
+}
+
+// A descriptor inherited *before* bounding was installed is the residual this
+// invariant does not cover on its own, and the reason the flag is set as early
+// as it is: this test pins where the boundary lies, so nobody mistakes the
+// invariant for something wider than it is.
+func TestDescriptorInheritedBeforeBoundingIsNotTracked(t *testing.T) {
+	h := newLogHarness(t, 512)
+
+	// Stand in for a process that got the log before the flag was set: a
+	// second descriptor on the same inode, which rotation cannot move.
+	pre, err := syscall.Dup(syscall.Stderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer syscall.Close(pre)
+
+	h.log(t, fill(600)) // rotation 1: the retained descriptor now names the archive
+	if _, err := syscall.Write(pre, []byte("RETAINED-AFTER-ONE\n")); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(h.read(t, h.archive), "RETAINED-AFTER-ONE") {
+		t.Fatal("a retained descriptor's write after one rotation was not in the archive")
+	}
+
+	h.log(t, fill(600)) // rotation 2: the archive it names is unlinked
+	if _, err := syscall.Write(pre, []byte("RETAINED-AFTER-TWO\n")); err != nil {
+		t.Fatal(err)
+	}
+	inCurrent := strings.Contains(h.read(t, h.path), "RETAINED-AFTER-TWO")
+	inArchive := strings.Contains(h.read(t, h.archive), "RETAINED-AFTER-TWO")
+	if inCurrent || inArchive {
+		t.Skip("this platform kept the retained descriptor reachable; the residual does not apply")
+	}
+	// Documented, not fixed: nothing can retarget another open file
+	// description. The invariant above is what keeps this unreachable in
+	// production -- no descendant has one.
+	t.Log("confirmed residual: a descriptor retained from before bounding writes to an unnamed inode after the second rotation")
+}
+
+// ── error paths that must not wedge the daemon ──────────────────────────────
+
+// Mutation: log the secondary-descriptor failure from inside rotateLocked
+// (i.e. while b.mu is held).
+//
+// The log package's output *is* this writer, so logging under its own mutex
+// re-enters Write and blocks forever -- wedging the sweep goroutine and, with
+// it, Stop and shutdown. The primary dup must succeed and the secondary fail,
+// which is why the seam is per-call rather than global.
+func TestSecondaryDescriptorFailureDoesNotDeadlock(t *testing.T) {
+	h := newLogHarness(t, 512)
+	// Pretend stdout aliases the log, so there is a secondary descriptor.
+	h.b.mu.Lock()
+	h.b.dupFDs = []int{syscall.Stdout}
+	h.b.mu.Unlock()
+
+	var calls int
+	dupOntoFn = func(src, dst int) error {
+		calls++
+		if dst == syscall.Stdout {
+			return errors.New("simulated secondary dup failure")
+		}
+		return dupOnto(src, dst)
+	}
+	t.Cleanup(func() { dupOntoFn = dupOnto })
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		h.log(t, fill(600))
+		// The complaint is emitted after the lock is released; a further write
+		// must also not block.
+		h.log(t, "still-writing\n")
+	}()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("the logger deadlocked reporting a secondary descriptor failure")
+	}
+
+	stopped := make(chan struct{})
+	go func() { defer close(stopped); h.b.Stop() }()
+	select {
+	case <-stopped:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Stop hung: the sweep goroutine is wedged")
+	}
+
+	if calls < 2 {
+		t.Fatalf("dup calls = %d, want the primary and the secondary", calls)
+	}
+	current := h.read(t, h.path)
+	if !strings.Contains(current, "still-writing") {
+		t.Fatal("writes stopped after a secondary descriptor failure")
+	}
+	if !strings.Contains(current, "still points at the archived log") {
+		t.Fatalf("the secondary descriptor failure was never reported: %q", current)
+	}
+}
+
+// Mutation: report a short write as a complete one (return nil), or spin on it.
+//
+// A truncated diagnostic that the caller believes was written in full is worse
+// than an error, and the standard logger is exactly such a caller.
+func TestShortWritesAreRetriedAndReported(t *testing.T) {
+	t.Run("a short write is finished, not abandoned", func(t *testing.T) {
+		h := newLogHarness(t, 1<<20)
+		var calls int
+		writeFn = func(fd int, p []byte) (int, error) {
+			calls++
+			if len(p) > 4 {
+				p = p[:4] // pretend the kernel took only part of it
+			}
+			return syscall.Write(fd, p)
+		}
+		t.Cleanup(func() { writeFn = syscall.Write })
+
+		payload := "abcdefghijklmnopqrst\n"
+		n, err := h.b.Write([]byte(payload))
+		if err != nil {
+			t.Fatalf("Write = %v, want nil once the remainder is written", err)
+		}
+		if n != len(payload) {
+			t.Fatalf("wrote %d of %d bytes", n, len(payload))
+		}
+		if calls < 2 {
+			t.Fatalf("write calls = %d: the remainder was not retried", calls)
+		}
+		if got := h.read(t, h.path); !strings.Contains(got, payload) {
+			t.Fatalf("log holds %q, want the whole line", got)
+		}
+	})
+
+	t.Run("no progress is an error", func(t *testing.T) {
+		h := newLogHarness(t, 1<<20)
+		writeFn = func(int, []byte) (int, error) { return 0, nil }
+		t.Cleanup(func() { writeFn = syscall.Write })
+
+		n, err := h.b.Write([]byte("anything\n"))
+		if !errors.Is(err, io.ErrShortWrite) {
+			t.Fatalf("Write = (%d, %v), want io.ErrShortWrite", n, err)
+		}
+		if n != 0 {
+			t.Fatalf("reported %d bytes written", n)
+		}
+	})
+
+	// The kernel's convention, not a convenient one: write(2) reports n = -1
+	// whenever errno is set, and a partial write interrupted by a signal comes
+	// back as a *successful* short write rather than EINTR. A retry that
+	// advances the buffer by the returned count therefore indexes with -1 and
+	// panics -- inside the logger, under the logger's own mutex.
+	//
+	// Mutation: advance the buffer by n in the EINTR branch (`p = p[n:]`).
+	t.Run("EINTR follows the syscall convention and is retried", func(t *testing.T) {
+		h := newLogHarness(t, 1<<20)
+		first := true
+		writeFn = func(fd int, p []byte) (int, error) {
+			if first {
+				first = false
+				return -1, syscall.EINTR // exactly what the syscall returns
+			}
+			return syscall.Write(fd, p)
+		}
+		t.Cleanup(func() { writeFn = syscall.Write })
+
+		payload := "interrupted\n"
+		n, err := h.b.Write([]byte(payload))
+		if err != nil || n != len(payload) {
+			t.Fatalf("Write = (%d, %v), want (%d, nil)", n, err, len(payload))
+		}
+		if got := h.read(t, h.path); !strings.Contains(got, payload) {
+			t.Fatalf("log holds %q, want the whole line", got)
+		}
+	})
+
+	// Any other error also arrives with n = -1, and must not be counted as
+	// written or used to advance the buffer.
+	t.Run("a failed write reports nothing written", func(t *testing.T) {
+		h := newLogHarness(t, 1<<20)
+		writeFn = func(int, []byte) (int, error) { return -1, syscall.EIO }
+		t.Cleanup(func() { writeFn = syscall.Write })
+
+		n, err := h.b.Write([]byte("doomed\n"))
+		if !errors.Is(err, syscall.EIO) {
+			t.Fatalf("Write = (%d, %v), want EIO", n, err)
+		}
+		if n != 0 {
+			t.Fatalf("reported %d bytes written for a failed write", n)
+		}
+	})
+
+	// A relentless signal storm must not spin inside the mutex forever.
+	t.Run("endless EINTR gives up", func(t *testing.T) {
+		h := newLogHarness(t, 1<<20)
+		calls := 0
+		writeFn = func(int, []byte) (int, error) {
+			calls++
+			return -1, syscall.EINTR
+		}
+		t.Cleanup(func() { writeFn = syscall.Write })
+
+		done := make(chan error, 1)
+		go func() { _, err := h.b.Write([]byte("interrupted forever\n")); done <- err }()
+		select {
+		case err := <-done:
+			if !errors.Is(err, syscall.EINTR) {
+				t.Fatalf("Write = %v, want EINTR after the retry budget", err)
+			}
+		case <-time.After(10 * time.Second):
+			t.Fatal("Write spun on EINTR without a bound")
+		}
+		if calls <= 1 || calls > maxWriteInterrupts+2 {
+			t.Fatalf("write attempts = %d, want a bounded retry", calls)
+		}
+	})
+}
+
+// The runner spawner is the launch that matters most for the inheritance
+// invariant: a runner outlives the daemon that spawned it, so a runner holding
+// a log descriptor would still be writing to an unnamed inode long after two
+// rotations.
+//
+// Mutation: wire the daemon's stderr into the runner
+// (`cmd.Stderr = os.Stderr` in launchRunnerProcess).
+func TestSpawnedRunnerGetsNoDaemonLogDescriptor(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("descriptor introspection uses /proc")
+	}
+	h := newLogHarness(t, 1<<20)
+
+	// A stand-in "runner" that reports what its stdio actually is.
+	dir := t.TempDir()
+	report := filepath.Join(dir, "fds")
+	stub := filepath.Join(dir, "gmux")
+	// Duplicate the inherited descriptors aside first, so the report's own
+	// redirection does not become the thing being reported.
+	script := "#!/bin/sh\n" +
+		// The spawner also invokes the binary to capture login env; only the
+		// actual launch is being observed here.
+		"case \"$1\" in __dump-env) exit 0;; esac\n" +
+		"exec 3>&1 4>&2\n" +
+		"{ readlink /proc/self/fd/3; readlink /proc/self/fd/4; } > " + report + "\n" +
+		"echo RUNNER-STDERR-MARKER >&4\n" +
+		"echo RUNNER-STDOUT-MARKER >&3\n"
+	if err := os.WriteFile(stub, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := launchRunnerProcess(context.Background(), runnerLaunchRequest{
+		GmuxBin: stub, Command: []string{"true"}, CWD: dir,
+	})
+	if err != nil {
+		t.Fatalf("launchRunnerProcess: %v", err)
+	}
+	t.Cleanup(func() { _ = res.Terminate(context.Background()) })
+
+	deadline := time.Now().Add(10 * time.Second)
+	var fds string
+	for {
+		data, readErr := os.ReadFile(report)
+		if readErr == nil && strings.Count(string(data), "\n") >= 2 {
+			fds = string(data)
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("the stub runner never reported its descriptors (%v)", readErr)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	for _, line := range strings.Split(strings.TrimSpace(fds), "\n") {
+		if line != os.DevNull {
+			t.Errorf("a spawned runner's stdio is %q, want %s: it must not hold anything of the daemon's, "+
+				"least of all the log", line, os.DevNull)
+		}
+	}
+	// And nothing it wrote reached the daemon's log.
+	for _, path := range []string{h.path, h.archive} {
+		if strings.Contains(h.read(t, path), "RUNNER-ST") {
+			t.Fatalf("a spawned runner's output reached %s", path)
+		}
+	}
+}
+
+// dupOnto is what keeps the invariant true across rotations, so assert it on
+// its own rather than only through a rotation -- where markCloseOnExec would
+// mask its omission.
+//
+// Mutation: drop O_CLOEXEC from Dup3 (or setCloseOnExec from the Darwin path).
+func TestDupOntoMarksTheDestinationCloseOnExec(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "log")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	// Reserve a descriptor number to be the destination, and make sure it does
+	// *not* already carry the flag, so the assertion is about dupOnto.
+	dst, err := syscall.Dup(syscall.Stdin)
+	if err != nil {
+		t.Fatalf("dup: %v", err)
+	}
+	defer syscall.Close(dst)
+	if _, _, errno := syscall.Syscall(syscall.SYS_FCNTL, uintptr(dst), syscall.F_SETFD, 0); errno != 0 {
+		t.Fatalf("clear close-on-exec: %v", errno)
+	}
+	if fdIsCloseOnExec(t, dst) {
+		t.Fatal("could not clear close-on-exec on the destination")
+	}
+
+	if err := dupOnto(int(f.Fd()), dst); err != nil {
+		t.Fatalf("dupOnto: %v", err)
+	}
+	if !fdIsCloseOnExec(t, dst) {
+		t.Fatal("dupOnto installed a descriptor that a child would inherit")
+	}
+	// And it really is the same open file.
+	var a, b syscall.Stat_t
+	if err := syscall.Fstat(int(f.Fd()), &a); err != nil {
+		t.Fatal(err)
+	}
+	if err := syscall.Fstat(dst, &b); err != nil {
+		t.Fatal(err)
+	}
+	if a.Ino != b.Ino || a.Dev != b.Dev {
+		t.Fatal("dupOnto did not point the destination at the source's file")
+	}
+}

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -310,7 +310,7 @@ func run(args []string, stdout, stderr io.Writer) int {
 			_, _ = fmt.Fprintf(stderr, "gmuxd log-path: unexpected arguments: %s\n", strings.Join(args, " "))
 			return 2
 		}
-		_, _ = fmt.Fprintf(stdout, "%s\n", filepath.Join(paths.StateDir(), "gmuxd.log"))
+		_, _ = fmt.Fprintf(stdout, "%s\n", paths.DaemonLogPath())
 		return 0
 	case "help", "-h", "--help":
 		printUsage(stdout)
@@ -326,6 +326,27 @@ func main() {
 	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
 }
 
+// openDaemonLog opens the daemon log for the child process to inherit as its
+// stdout and stderr.
+//
+// Append, never truncate. This runs before the child has had a chance to check
+// for a healthy incumbent, and most invocations that reach here are autostarts
+// that will bounce straight off one: truncating would destroy the running
+// daemon's log every time a health probe was a little slow.
+//
+// O_APPEND matters for the same reason, from the other end: this descriptor may
+// be one of several the log has at once -- the child's stdout and stderr, plus
+// whatever a previous daemon still holds while it exits -- and appending is what
+// keeps concurrent writers from overwriting each other at a remembered offset.
+//
+// The serving process bounds this file by renaming it and moving its descriptor
+// onto a fresh one, never by truncating it (logbound.go explains why that
+// distinction is the whole design), so nothing here depends on truncation
+// semantics.
+func openDaemonLog(logPath string) (*os.File, error) {
+	return os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+}
+
 // startBackground is a pure spawn-first exact-child supervisor. The child
 // owns verification, incumbent shutdown, the lifetime lock, and database open.
 func startBackground(stdout, stderr io.Writer) int {
@@ -335,12 +356,12 @@ func startBackground(stdout, stderr io.Writer) int {
 		return 1
 	}
 	stateDir := paths.StateDir()
-	logPath := filepath.Join(stateDir, "gmuxd.log")
+	logPath := paths.DaemonLogPath()
 	if err := os.MkdirAll(stateDir, 0o700); err != nil {
 		_, _ = fmt.Fprintf(stderr, "gmuxd: cannot create state dir %s: %v\n", stateDir, err)
 		return 1
 	}
-	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	logFile, err := openDaemonLog(logPath)
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "gmuxd: cannot open log %s: %v\n", logPath, err)
 		return 1

--- a/services/gmuxd/cmd/gmuxd/production_spawner_test.go
+++ b/services/gmuxd/cmd/gmuxd/production_spawner_test.go
@@ -11,7 +11,8 @@ import (
 
 func TestRunnerMetaWireJSONFieldTable(t *testing.T) {
 	want := []struct{ field, tag string }{
-		{"ID", "id"}, {"Adapter", "adapter"}, {"Kind", "kind"},
+		{"ID", "id"}, {"Incarnation", "incarnation"},
+		{"Adapter", "adapter"}, {"Kind", "kind"},
 		{"Alive", "alive"}, {"CreatedAt", "created_at"},
 		{"StartedAt", "started_at"}, {"PID", "pid"},
 		{"RunnerVersion", "runner_version"}, {"BinaryHash", "binary_hash"},
@@ -32,7 +33,7 @@ func TestRunnerMetaWireJSONFieldTable(t *testing.T) {
 			t.Errorf("field[%d]=%s json:%q, want %s json:%q", i, field.Name, field.Tag.Get("json"), entry.field, entry.tag)
 		}
 	}
-	status := typeOf.Field(18).Type.Elem()
+	status := typeOf.Field(19).Type.Elem()
 	if status.NumField() != 2 || status.Field(0).Name != "Working" || status.Field(0).Tag.Get("json") != "working" || status.Field(1).Name != "Error" || status.Field(1).Tag.Get("json") != "error" {
 		t.Fatalf("status wire fields=%v, want explicit working/error JSON fields", status)
 	}

--- a/services/gmuxd/cmd/gmuxd/reap_route_test.go
+++ b/services/gmuxd/cmd/gmuxd/reap_route_test.go
@@ -1,0 +1,387 @@
+package main
+
+// reap_route_test.go — a reap decision must never be executable against
+// whoever happens to own the pathname by the time it is delivered, *including*
+// a runner that predates the protocol.
+//
+// The schedule, driven end to end over real Unix sockets and the real
+// production transport:
+//
+//	B answers Meta at pathname P as session S with incarnation NB, and is
+//	classified as the redundant generation. While the daemon still holds that
+//	classification, P is handed to another runner C. The reap is delivered to P.
+//
+// A header on /kill cannot save C: a runner that predates the protocol ignores
+// unknown headers and stops. So reaping addresses a route such a runner does
+// not serve at all, and C answers 404.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/centralstore"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/sessioncoord"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/snapshot/wire"
+	"nhooyr.io/websocket"
+)
+
+// protocolRunner serves what a current runner serves: an identity on every
+// response and a /reap that refuses an incarnation that is not its own. With
+// legacy set it serves what a *pre-protocol* runner serves -- no identity, no
+// /reap route, and a /kill that obeys unconditionally.
+type protocolRunner struct {
+	ep          string
+	incarnation string
+	legacy      bool
+
+	killed    atomic.Bool
+	reaped    atomic.Bool
+	killCalls atomic.Int64
+	reapCalls atomic.Int64
+
+	// afterMeta runs at the end of the /meta handler, i.e. inside the window
+	// between a classification and the action taken on it.
+	afterMeta func()
+
+	ln   *net.UnixListener
+	srv  *http.Server
+	once sync.Once
+}
+
+func startProtocolRunner(t *testing.T, dir, name string, id centralstore.SessionID, legacy bool) *protocolRunner {
+	t.Helper()
+	r := &protocolRunner{
+		ep:          filepath.Join(dir, name),
+		incarnation: "incarnation-" + name + "-" + string(id),
+		legacy:      legacy,
+	}
+	ln, err := net.Listen("unix", r.ep)
+	if err != nil {
+		t.Fatalf("listen %s: %v", r.ep, err)
+	}
+	r.ln = ln.(*net.UnixListener)
+	// Every removal of a pathname in these tests is explicit, exactly as in
+	// production: a runner's listener outlives its pathname.
+	r.ln.SetUnlinkOnClose(false)
+
+	stamp := func(next http.HandlerFunc) http.HandlerFunc {
+		return func(w http.ResponseWriter, req *http.Request) {
+			if !legacy {
+				w.Header().Set("X-Gmux-Incarnation", r.incarnation)
+			}
+			next(w, req)
+		}
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /events", stamp(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		<-req.Context().Done()
+	}))
+	mux.HandleFunc("GET /meta", stamp(func(w http.ResponseWriter, _ *http.Request) {
+		body := map[string]any{
+			"id": string(id), "adapter": "shell", "alive": true, "pid": os.Getpid(),
+			"created_at": time.Now().UTC().Format(time.RFC3339),
+		}
+		if !legacy {
+			body["incarnation"] = r.incarnation
+		}
+		_ = json.NewEncoder(w).Encode(body)
+		if r.afterMeta != nil {
+			hook := r.afterMeta
+			r.afterMeta = nil
+			hook()
+		}
+	}))
+	if legacy {
+		// The real pre-protocol surface: a catch-all "/" route for the
+		// WebSocket terminal. POST /reap lands on the WebSocket handshake,
+		// which rejects a request with no upgrade headers -- 426, not 404.
+		// A ServeMux without this route would 404 instead, and the 404 is the
+		// answer this design was originally reasoned about, so the fake has to
+		// have the catch-all or it proves nothing about a real legacy runner.
+		mux.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
+			c, err := websocket.Accept(w, req, nil)
+			if err != nil {
+				return // the handshake already wrote its own status
+			}
+			c.Close(websocket.StatusNormalClosure, "")
+		})
+	}
+	// Both kinds serve /kill: it is the compatibility route for an explicit
+	// user-initiated stop.
+	mux.HandleFunc("POST /kill", stamp(func(w http.ResponseWriter, req *http.Request) {
+		r.killCalls.Add(1)
+		if want := req.Header.Get("X-Gmux-Expect-Incarnation"); !legacy && want != "" && want != r.incarnation {
+			http.Error(w, "mismatch", http.StatusConflict)
+			return
+		}
+		// A pre-protocol runner ignores the header entirely and dies.
+		r.killed.Store(true)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	if !legacy {
+		mux.HandleFunc("POST /reap", stamp(func(w http.ResponseWriter, req *http.Request) {
+			r.reapCalls.Add(1)
+			want := req.Header.Get("X-Gmux-Expect-Incarnation")
+			if want == "" {
+				http.Error(w, "reap requires an expectation", http.StatusBadRequest)
+				return
+			}
+			if want != r.incarnation {
+				http.Error(w, "mismatch", http.StatusConflict)
+				return
+			}
+			r.reaped.Store(true)
+			w.WriteHeader(http.StatusNoContent)
+		}))
+	}
+	r.srv = &http.Server{Handler: mux}
+	go func() { _ = r.srv.Serve(r.ln) }()
+	t.Cleanup(func() { r.once.Do(func() { _ = r.srv.Close() }) })
+	return r
+}
+
+// handOver gives this runner's pathname to a replacement, the way a runner
+// that has released ownership does: unlink the pathname, leave the listener
+// alive on the unnamed inode, let somebody else bind the name.
+func (r *protocolRunner) handOver(t *testing.T, dir string, legacy bool) *protocolRunner {
+	t.Helper()
+	if err := os.Remove(r.ep); err != nil {
+		t.Fatalf("remove %s: %v", r.ep, err)
+	}
+	return startProtocolRunner(t, dir, filepath.Base(r.ep), "sess-unrelated-replacement", legacy)
+}
+
+// reapHarness converges one installed generation and then reaps whatever the
+// caller points it at.
+type reapHarness struct {
+	boot     *Bootstrap
+	dir      string
+	reported []string
+}
+
+// reapSocketDir points the endpoint enumeration and the reaper's trust
+// boundary at an isolated directory.
+func reapSocketDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("GMUX_SOCKET_DIR", dir)
+	return dir
+}
+
+func newReapHarness(t *testing.T, session centralstore.SessionID) (*reapHarness, *protocolRunner) {
+	t.Helper()
+	dir := reapSocketDir(t)
+	store, err := centralstore.Open(context.Background(), t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	installed := startProtocolRunner(t, dir, "sess-installed.sock", session, false)
+	h := &reapHarness{dir: dir}
+	boot, err := newBootstrap(BootstrapConfig{
+		Store: store, Runners: productionRunnerClient{}, Control: productionRunnerControl{},
+		Spawner: bootstrapSpawner{}, Reconciler: bootstrapReconciler{}, Converter: &wire.Converter{},
+		Endpoints: EndpointSourceFunc(func(context.Context) ([]string, error) {
+			return []string{installed.ep}, nil
+		}),
+		Errors: sessioncoord.ErrorSinkFunc(func(_ context.Context, err error) { h.reported = append(h.reported, err.Error()) }),
+		Clock:  func() centralstore.UnixMillis { return 100 },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(boot.Close)
+	if _, err := boot.Converge(context.Background()); err != nil {
+		t.Fatalf("Converge: %v", err)
+	}
+	if snap := boot.Registry.Snapshot(); len(snap) != 1 {
+		t.Fatalf("expected one installed generation, got %+v", snap)
+	}
+	h.boot = boot
+	return h, installed
+}
+
+// The baseline: the runner the decision was actually about kills itself, over
+// the conditional route, and is never addressed on /kill.
+func TestReapKillsExactlyTheClassifiedRunner(t *testing.T) {
+	const session = centralstore.SessionID("sess-contested")
+	h, _ := newReapHarness(t, session)
+	loser := startProtocolRunner(t, h.dir, "sess-loser.sock", session, false)
+
+	reaped, err := h.boot.Coordinator.ReapOrphans(context.Background(), []string{loser.ep})
+	if err != nil {
+		t.Fatalf("ReapOrphans: %v", err)
+	}
+	if len(reaped) != 1 || reaped[0] != loser.ep {
+		t.Fatalf("reaped = %v, want [%s]", reaped, loser.ep)
+	}
+	if !loser.reaped.Load() {
+		t.Fatal("the classified runner was not reaped")
+	}
+	if got := loser.killCalls.Load(); got != 0 {
+		t.Fatalf("the classified runner saw %d /kill requests; reaping must use the conditional route", got)
+	}
+}
+
+// Mutation: point ReapOrphans back at RunnerControl.Terminate (the /kill
+// route). The pre-protocol replacement then receives the verdict passed on B
+// and dies.
+func TestReapDoesNotKillAPreProtocolReplacement(t *testing.T) {
+	const session = centralstore.SessionID("sess-contested")
+	h, _ := newReapHarness(t, session)
+	loser := startProtocolRunner(t, h.dir, "sess-loser.sock", session, false)
+
+	// The pathname changes hands inside the window between the classification
+	// and the action taken on it.
+	var replacement *protocolRunner
+	loser.afterMeta = func() { replacement = loser.handOver(t, h.dir, true) }
+
+	reaped, err := h.boot.Coordinator.ReapOrphans(context.Background(), []string{loser.ep})
+	if err != nil {
+		t.Fatalf("ReapOrphans: %v", err)
+	}
+	if replacement == nil {
+		t.Fatal("the hand-over never ran")
+	}
+
+	if replacement.killed.Load() {
+		t.Fatal("a pre-protocol replacement was killed by a verdict passed on another process")
+	}
+	if got := replacement.killCalls.Load(); got != 0 {
+		t.Fatalf("the pre-protocol replacement received %d /kill requests; it must never be addressed there", got)
+	}
+	if len(reaped) != 0 {
+		t.Fatalf("reaped = %v, want nothing: the classified runner was already gone", reaped)
+	}
+	// It still owns its pathname and is still reachable.
+	if _, err := os.Stat(replacement.ep); err != nil {
+		t.Fatalf("the replacement's pathname was disturbed: %v", err)
+	}
+	conn, err := net.DialTimeout("unix", replacement.ep, 2*time.Second)
+	if err != nil {
+		t.Fatalf("the replacement is no longer reachable: %v", err)
+	}
+	_ = conn.Close()
+	// A decline is not an error: it must not be reported as one.
+	if len(h.reported) != 0 {
+		t.Fatalf("declining to reap a pre-protocol occupant was reported as an error: %v", h.reported)
+	}
+}
+
+// The same schedule with a protocol-aware replacement: it refuses (409) rather
+// than dying, which is the case the incarnation header already covered.
+func TestReapDoesNotKillAProtocolAwareReplacement(t *testing.T) {
+	const session = centralstore.SessionID("sess-contested")
+	h, _ := newReapHarness(t, session)
+	loser := startProtocolRunner(t, h.dir, "sess-loser.sock", session, false)
+
+	var replacement *protocolRunner
+	loser.afterMeta = func() { replacement = loser.handOver(t, h.dir, false) }
+
+	if _, err := h.boot.Coordinator.ReapOrphans(context.Background(), []string{loser.ep}); err != nil {
+		t.Fatalf("ReapOrphans: %v", err)
+	}
+	if replacement == nil {
+		t.Fatal("the hand-over never ran")
+	}
+	if replacement.reaped.Load() || replacement.killed.Load() {
+		t.Fatal("a replacement obeyed a verdict passed on another process")
+	}
+	if got := replacement.reapCalls.Load(); got != 1 {
+		t.Fatalf("the replacement saw %d reap requests, want 1 (and it must have refused)", got)
+	}
+	if got := replacement.killCalls.Load(); got != 0 {
+		t.Fatalf("the replacement was addressed on /kill %d times", got)
+	}
+}
+
+// An explicit user-initiated stop still uses the compatibility route, because
+// that is the only thing a pre-protocol runner understands.
+func TestExplicitStopUsesTheCompatibilityRoute(t *testing.T) {
+	dir := reapSocketDir(t)
+	runner := startProtocolRunner(t, dir, "sess-stop.sock", "sess-stop", false)
+
+	if err := (productionRunnerControl{}).Terminate(context.Background(), runner.ep, runner.incarnation); err != nil {
+		t.Fatalf("Terminate: %v", err)
+	}
+	if !runner.killed.Load() {
+		t.Fatal("an explicit stop did not reach the runner")
+	}
+	if got := runner.reapCalls.Load(); got != 0 {
+		t.Fatalf("an explicit stop used the conditional route (%d calls)", got)
+	}
+	// And an unnamed stop -- the pre-protocol client's shape -- still works.
+	legacy := startProtocolRunner(t, dir, "sess-stop-legacy.sock", "sess-stop-legacy", true)
+	if err := (productionRunnerControl{}).Terminate(context.Background(), legacy.ep, ""); err != nil {
+		t.Fatalf("unnamed Terminate: %v", err)
+	}
+	if !legacy.killed.Load() {
+		t.Fatal("an unnamed stop did not reach a pre-protocol runner")
+	}
+}
+
+// The control adapter must translate "this runner has no such route" into the
+// coordinator's own sentinel, or the reap loop cannot tell a decline from a
+// failure.
+func TestProductionReapTranslatesAnUnsupportedRoute(t *testing.T) {
+	dir := reapSocketDir(t)
+	legacy := startProtocolRunner(t, dir, "sess-legacy.sock", "sess-legacy", true)
+
+	err := (productionRunnerControl{}).Reap(context.Background(), legacy.ep, "incarnation-of-somebody")
+	if !errors.Is(err, sessioncoord.ErrReapUnsupported) {
+		t.Fatalf("Reap against a pre-protocol runner = %v, want ErrReapUnsupported", err)
+	}
+	if legacy.killed.Load() || legacy.killCalls.Load() != 0 {
+		t.Fatal("a pre-protocol runner was touched by a reap attempt")
+	}
+}
+
+// A pre-protocol occupant that cannot be reaped is a standing condition, not an
+// incident: sweeping past it must cost nothing, forever.
+//
+// What this pins is the *first* guard on that path: an occupant that reports no
+// incarnation is unidentifiable, so ReapOrphans skips it before any transport
+// call at all, silently, on every sweep. (Mutation: reap candidates with an
+// empty incarnation.) It deliberately does not pin the 426 path -- a real
+// legacy runner never gets that far, because it has no incarnation to be
+// classified by; that path is reached only when a *modern* runner was
+// classified and a legacy one took its pathname over, which is
+// TestReapDoesNotKillAPreProtocolReplacement. The decline there is stateless,
+// so silence on one sweep is silence on all of them.
+func TestRepeatedSweepsPastAPreProtocolOccupantAreSilent(t *testing.T) {
+	const session = centralstore.SessionID("sess-contested")
+	h, _ := newReapHarness(t, session)
+	// A pre-protocol runner claiming the installed session's id: a permanent
+	// reap candidate that can never be reaped.
+	legacy := startProtocolRunner(t, h.dir, "sess-legacy-orphan.sock", session, true)
+
+	for range 50 {
+		if _, err := h.boot.Coordinator.ReapOrphans(context.Background(), []string{legacy.ep}); err != nil {
+			t.Fatalf("ReapOrphans: %v", err)
+		}
+	}
+	if len(h.reported) != 0 {
+		t.Fatalf("50 sweeps past an unreapable occupant produced %d reports: %v", len(h.reported), h.reported)
+	}
+	if legacy.killed.Load() || legacy.killCalls.Load() != 0 {
+		t.Fatal("the pre-protocol occupant was touched")
+	}
+	if _, err := os.Stat(legacy.ep); err != nil {
+		t.Fatalf("its pathname was disturbed: %v", err)
+	}
+}

--- a/services/gmuxd/cmd/gmuxd/serve_central.go
+++ b/services/gmuxd/cmd/gmuxd/serve_central.go
@@ -166,6 +166,13 @@ func serveCentral(stderr io.Writer, replace bool) int {
 	defer storeHandle.Close()
 	defer storeLock.Close()
 
+	// Bound the log only now: ownership is settled, so this process is the
+	// daemon and no incumbent is writing to the same file. An invocation that
+	// yielded above returned without touching it.
+	if bounded := installBoundedLog(stderr, paths.DaemonLogPath(), defaultLogLimit); bounded != nil {
+		defer bounded.Stop()
+	}
+
 	var peerManager *peering.Manager
 	var tsListener *tsauth.Listener
 	var notifier *centralNotifyRouter

--- a/services/gmuxd/cmd/gmuxd/stale_socket.go
+++ b/services/gmuxd/cmd/gmuxd/stale_socket.go
@@ -1,0 +1,217 @@
+package main
+
+// Stale runner socket reaping.
+//
+// A runner that dies without unlinking its canonical pathname (SIGKILL, OOM,
+// power loss, or any version that predates the ownership lease) leaves a file
+// that answers every connection attempt with ECONNREFUSED. Discovery then
+// dials it, fails, and logs, once per endpoint per tick, forever.
+//
+// Deleting such a file is the dangerous half. The pathname is reusable, so
+// every judgement of the form "nothing was listening a moment ago" is a
+// TOCTOU: a fresh runner can bind the pathname between the probe and the
+// unlink, and the unlink then silently disconnects it. The daemon therefore
+// never reaps on the strength of a probe. It takes the runner's own ownership
+// lease (packages/socklease) non-blocking and holds it across the identity
+// check, the liveness probe and the unlink. Acquiring the lease is proof that
+// no lease-aware owner is alive; holding it is proof that none can appear
+// mid-sequence.
+//
+// Everything else is declined. The predicate below never deletes when:
+//
+//   - the pathname is outside the trusted socket directory,
+//   - no lock file exists (the owner predates the lease protocol -- absence
+//     of proof of death is not proof of death),
+//   - the lease is held (the owner is alive),
+//   - the pathname is not a socket, or changed identity under the sequence,
+//   - the probe returns anything other than ECONNREFUSED: a timeout, a
+//     permission error, or a successful connection all mean "not provably
+//     abandoned".
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/gmuxapp/gmux/packages/paths"
+	"github.com/gmuxapp/gmux/packages/socklease"
+)
+
+// staleProbeTimeout bounds the connect used to confirm that nothing is
+// listening. It runs while the lease is held, so it also bounds how long a
+// replacement runner could be kept waiting for the lease.
+const staleProbeTimeout = 250 * time.Millisecond
+
+// reapOutcome describes what the reaper did, for transition logging.
+type reapOutcome struct {
+	Reaped bool
+	// Reason is a short, allocation-free-ish explanation of a decline. Empty
+	// when the socket was reaped.
+	Reason string
+}
+
+// trustedSocketDir reports whether ep is a direct child of the canonical
+// runner socket directory.
+//
+// Legacy socket directories (paths.LegacySessionSocketDirs) are deliberately
+// excluded even though discovery still enumerates them: they are read-mostly
+// compatibility shims for runners that predate this daemon, exactly the
+// population that holds no lease, and the daemon has no business deleting
+// files in a directory whose ownership rules it does not define.
+func trustedSocketDir(ep string) bool {
+	dir, err := filepath.Abs(filepath.Dir(ep))
+	if err != nil {
+		return false
+	}
+	trusted, err := filepath.Abs(paths.SessionSocketDir())
+	if err != nil {
+		return false
+	}
+	if dir != trusted {
+		return false
+	}
+	// The canonical pathname is not enough on its own: a lease inside a
+	// directory other users can write in proves nothing (see socklease's threat
+	// model). Require the premise here too, rather than assuming the runner
+	// established it.
+	return socklease.RequireOwnedDir(dir) == nil
+}
+
+// reapBarrier is a barrier hook for the reaper's schedule tests: it runs at each
+// named point inside the leased inspect-and-unlink sequence, which is the window
+// a racing runner must be excluded from. It is unset in production.
+//
+// It is deliberately awkward in two ways, both of which are the point.
+//
+// It receives the endpoint, because the reaper is not a single-threaded thing: a
+// discovery scan reaps in per-endpoint workers, the stress test runs three
+// reapers at once, and other tests leave reapers running against their own
+// pathnames. A hook that fired for any endpoint would be driven by whichever
+// reaper reached the phase first, so a test's barrier would perturb a pathname
+// it does not own -- or, worse, fire before its own reaper arrived. Tests filter
+// on their exact endpoint (see onReapPhase).
+//
+// It is behind a mutex, because those same reapers read it from goroutines that
+// can outlive the statement that installed it. A plain variable is a data race
+// the moment a background scan overlaps a test's install or cleanup, and the
+// hook is copied out before it is called so a barrier that blocks -- which is
+// what a barrier is for -- never holds the lock.
+var reapBarrier struct {
+	mu sync.Mutex
+	fn func(ep, phase string)
+}
+
+func reapPhase(ep, phase string) {
+	reapBarrier.mu.Lock()
+	fn := reapBarrier.fn
+	reapBarrier.mu.Unlock()
+	if fn != nil {
+		fn(ep, phase)
+	}
+}
+
+// setReapBarrier installs the barrier hook, replacing any previous one.
+func setReapBarrier(fn func(ep, phase string)) {
+	reapBarrier.mu.Lock()
+	reapBarrier.fn = fn
+	reapBarrier.mu.Unlock()
+}
+
+// reapStaleSocket removes ep if -- and only if -- it is provably an abandoned
+// runner socket. It returns whether it unlinked anything and why not.
+func reapStaleSocket(ep string) reapOutcome {
+	if !trustedSocketDir(ep) {
+		return reapOutcome{Reason: "outside the trusted socket directory"}
+	}
+	lease, err := socklease.AcquireExisting(ep)
+	switch {
+	case errors.Is(err, socklease.ErrNoLockFile):
+		return reapOutcome{Reason: "no ownership lease file (runner predates the lease protocol)"}
+	case errors.Is(err, socklease.ErrHeld):
+		return reapOutcome{Reason: "ownership lease is held (a live runner, or another reaper mid-sequence)"}
+	case err != nil:
+		return reapOutcome{Reason: fmt.Sprintf("ownership lease unavailable: %v", err)}
+	}
+	// From here the lease is ours: no lease-aware runner can bind this
+	// pathname until we release it.
+	//
+	// How we give it back matters. The lock file is the only evidence that a
+	// pathname's leftover socket belonged to a lease-aware generation, and
+	// that evidence is what makes the leftover reclaimable at all -- both by
+	// this reaper on a later pass and by a runner resuming that session id.
+	// Removing it while merely *inspecting* would convert a recoverable
+	// crashed-runner socket into a permanently unreclaimable one: every future
+	// attempt would see no lock file, conclude "not provably ours", and refuse.
+	//
+	// So the lock file is erased only when we learned something that makes it
+	// false or pointless -- the pathname is gone, is not a socket, or is held
+	// by a live unleased occupant -- or when the reap succeeded and there is
+	// nothing left to reclaim. Every "learned nothing" decline puts it back
+	// exactly as it was found.
+	learnedNothing := true
+	defer func() {
+		if learnedNothing {
+			_ = lease.ReleaseKeepingLockFile()
+			return
+		}
+		_ = lease.Release()
+	}()
+	reapPhase(ep, "lease-held")
+
+	// Pin the socket before probing it. The unlink below has to be conditional
+	// on *the file we probed*, and a pathname's device and inode do not settle
+	// that: on a filesystem that recycles inode numbers, a live replacement can
+	// present the very same pair as the leftover it replaced.
+	before, pinErr := socklease.PinSocket(ep)
+	isSocket := pinErr == nil
+	if isSocket {
+		defer before.Close()
+	}
+	if !isSocket {
+		// Gone, or never a socket: no leftover to reclaim, so the lock file is
+		// pointless. Removing it is also how lock files left by a runner that
+		// died between creating one and binding get cleaned up.
+		learnedNothing = false
+		return reapOutcome{Reason: "not a socket"}
+	}
+	probeErr := probeRefused(ep, before)
+	if probeErr != nil {
+		// Only one of these outcomes teaches us anything about the occupant:
+		// somebody answered, which proves the pathname is held by a runner
+		// without a lease, so the lease history describes a dead generation
+		// rather than the occupant. A timeout or any other failure teaches us
+		// nothing at all.
+		learnedNothing = !errors.Is(probeErr, socklease.ErrSocketLive)
+		return reapOutcome{Reason: probeErr.Error()}
+	}
+	reapPhase(ep, "before-remove")
+	if err := lease.RemoveSocket(before); err != nil {
+		// The pathname changed under us: whatever is there now is not what we
+		// probed, and we know nothing about it.
+		return reapOutcome{Reason: fmt.Sprintf("declined removal: %v", err)}
+	}
+	learnedNothing = false
+	return reapOutcome{Reaped: true}
+}
+
+// probeRefused reports whether nothing is listening at the pathname the pin
+// holds, using the same predicate the runner uses before it clears a leftover of
+// its own: only an explicit refusal counts, and a timeout is a wedged owner
+// rather than a dead one. Sharing the predicate is the point -- an asymmetry here
+// is how a live socket gets unlinked by one side and spared by the other.
+//
+// It takes the pin rather than the pathname because pin-then-probe is the
+// load-bearing order, and a signature is a better guardian of an order than a
+// comment: there is nothing to pass if the pin has not been taken yet.
+func probeRefused(ep string, pin *socklease.Pin) error {
+	err := socklease.ProbeRefusedPinned(pin, staleProbeTimeout)
+	// The barrier fires here, at the end of the probe step, rather than at the
+	// call site. That placement is deliberate: it is the only point a caller
+	// cannot get in front of. A caller that pinned *after* probing would have
+	// its pin land after this line, so a test can take the pathname over here
+	// and watch such a caller pin -- and then unlink -- the newcomer.
+	reapPhase(ep, "probed")
+	return err
+}

--- a/services/gmuxd/cmd/gmuxd/stale_socket_race_test.go
+++ b/services/gmuxd/cmd/gmuxd/stale_socket_race_test.go
@@ -1,0 +1,312 @@
+package main
+
+// stale_socket_race_test.go — the schedule the whole ownership design exists
+// to survive.
+//
+// Every earlier iteration of stale-socket reaping in this codebase was broken
+// by the same three-actor race: the daemon decides a pathname is abandoned, a
+// fresh runner binds that pathname, and the daemon's unlink lands on the live
+// runner's socket. Reviews reproduced it against a stat/SameFile predicate and
+// again against a rename-claim protocol.
+//
+// This test runs the real production reaper flat out against a binder that
+// behaves like a runner — leasing, clearing stale files, listening, serving,
+// and exiting either cleanly or by "crashing" — and asserts the one invariant
+// that matters: while a runner is live at a pathname, nothing removes or
+// replaces it.
+//
+// Run with -race.
+
+import (
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gmuxapp/gmux/packages/socklease"
+)
+
+// The deterministic half of the same property: the reaper holds the lease for
+// its entire inspect-and-unlink sequence, so a runner cannot appear inside it.
+// Stress alone cannot pin this -- the window is microseconds wide, and reviews
+// needed thousands of rounds to hit the equivalent window in the predicate
+// this replaced.
+//
+// Mutation: drop the lease from reapStaleSocket (stat, probe, SameFile,
+// unlink). The binder below then acquires the pathname in the middle of the
+// reaper's sequence, which is exactly the schedule that unlinked live runners.
+// onReapPhase installs the reaper's barrier for one endpoint and one test.
+//
+// Filtering on the endpoint is not tidiness: reapers run concurrently -- three
+// of them in TestReaperNeverUnlinksALiveRunner, one per endpoint inside a
+// discovery scan -- so an unfiltered barrier is driven by whichever reaper
+// reaches the phase first. That is how this hook produced a CI failure: the
+// barrier for one test's pathname fired for a different reaper's pathname and
+// perturbed the filesystem before the test's own reaper had arrived.
+//
+// fired reports whether the barrier ever ran, so a test can insist that the
+// schedule it is asserting about actually happened.
+func onReapPhase(t *testing.T, ep, phase string, fn func()) (fired func() bool) {
+	t.Helper()
+	var ran atomic.Bool
+	var once sync.Once
+	setReapBarrier(func(gotEP, gotPhase string) {
+		if gotEP != ep || gotPhase != phase {
+			return
+		}
+		once.Do(func() {
+			ran.Store(true)
+			fn()
+		})
+	})
+	t.Cleanup(func() { setReapBarrier(nil) })
+	return ran.Load
+}
+
+func TestReaperHoldsTheLeaseAcrossItsWholeSequence(t *testing.T) {
+	dir := socketDir(t)
+	ep := crashedRunnerSocket(t, dir, "sess-window.sock")
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	onReapPhase(t, ep, "lease-held", func() {
+		close(entered)
+		<-release
+	})
+
+	done := make(chan reapOutcome, 1)
+	go func() { done <- reapStaleSocket(ep) }()
+
+	select {
+	case <-entered:
+	case <-time.After(10 * time.Second):
+		t.Fatal("the reaper never entered its leased window")
+	}
+
+	// A runner starting right now must be excluded until the reaper is done.
+	if _, err := socklease.Acquire(ep); !errors.Is(err, socklease.ErrHeld) {
+		close(release)
+		t.Fatalf("a runner acquired the pathname inside the reaper's window: %v", err)
+	}
+
+	close(release)
+	if outcome := <-done; !outcome.Reaped {
+		t.Fatalf("the reap did not complete: %s", outcome.Reason)
+	}
+	// And once it is done, the pathname is free for the next runner.
+	lease, err := socklease.Acquire(ep)
+	if err != nil {
+		t.Fatalf("the pathname was not released after the reap: %v", err)
+	}
+	_ = lease.Release()
+}
+
+func TestReaperNeverUnlinksALiveRunner(t *testing.T) {
+	dir := socketDir(t)
+	ep := filepath.Join(dir, "sess-race.sock")
+
+	const rounds = 400
+	var (
+		reaps       atomic.Int64
+		cleanExits  atomic.Int64
+		crashExits  atomic.Int64
+		leaseDenied atomic.Int64
+		stop        atomic.Bool
+		wg          sync.WaitGroup
+	)
+
+	// Reapers: as many concurrent daemons as the code could ever have, going
+	// as fast as they can.
+	for range 3 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for !stop.Load() {
+				if reapStaleSocket(ep).Reaped {
+					reaps.Add(1)
+				}
+			}
+		}()
+	}
+
+	// Binder: one runner lifecycle per round.
+	for round := range rounds {
+		lease, err := socklease.Acquire(ep)
+		if errors.Is(err, socklease.ErrHeld) {
+			// A reaper holds the lease for the length of its inspection.
+			leaseDenied.Add(1)
+			time.Sleep(time.Millisecond)
+			continue
+		}
+		if err != nil {
+			t.Fatalf("round %d: Acquire: %v", round, err)
+		}
+
+		// Clear whatever stale file is there and bind, exactly as BindSocket
+		// does, under the lease.
+		_ = os.Remove(ep)
+		ln, err := net.Listen("unix", ep)
+		if err != nil {
+			t.Fatalf("round %d: listen: %v", round, err)
+		}
+		ln.(*net.UnixListener).SetUnlinkOnClose(false)
+		pin, err := lease.PinSocket()
+		if err != nil {
+			t.Fatalf("round %d: PinSocket: %v", round, err)
+		}
+		ident := pin.Ident()
+
+		// Serve, so a reaper's probe gets a real answer rather than a refusal.
+		accepting := make(chan struct{})
+		go func() {
+			close(accepting)
+			for {
+				c, err := ln.Accept()
+				if err != nil {
+					return
+				}
+				_ = c.Close()
+			}
+		}()
+		<-accepting
+		time.Sleep(200 * time.Microsecond)
+
+		// THE INVARIANT: the pathname still names this live runner's socket.
+		current, ok := socklease.StatSocket(ep)
+		if !ok {
+			t.Fatalf("round %d: the reaper unlinked a live runner's socket", round)
+		}
+		if current != ident {
+			t.Fatalf("round %d: the pathname was rebound under a live runner: %s -> %s",
+				round, ident, current)
+		}
+
+		if round%2 == 0 {
+			// Clean exit: release ownership the way the runner does.
+			_ = ln.Close()
+			if err := lease.RemoveSocket(pin); err != nil {
+				t.Fatalf("round %d: RemoveSocket: %v", round, err)
+			}
+			_ = pin.Close()
+			if err := lease.Release(); err != nil {
+				t.Fatalf("round %d: Release: %v", round, err)
+			}
+			cleanExits.Add(1)
+		} else {
+			// Crash: the listener dies and the lease is dropped by the
+			// kernel, but nothing unlinks the pathname and nothing removes
+			// the lock file. This is the population the reaper exists for.
+			_ = ln.Close()
+			if err := lease.Release(); err != nil {
+				t.Fatalf("round %d: Release: %v", round, err)
+			}
+			if err := os.WriteFile(socklease.LockPath(ep), nil, 0o600); err != nil {
+				t.Fatalf("round %d: restore lock file: %v", round, err)
+			}
+			_ = pin.Close()
+			crashExits.Add(1)
+		}
+	}
+	stop.Store(true)
+	wg.Wait()
+
+	if crashExits.Load() == 0 || cleanExits.Load() == 0 {
+		t.Fatalf("test did not exercise both exit paths: clean=%d crash=%d",
+			cleanExits.Load(), crashExits.Load())
+	}
+	// The reapers must have had real work, or the invariant above proved
+	// nothing about a reaper that never fires.
+	if reaps.Load() == 0 {
+		t.Fatal("no stale socket was ever reaped; the race was never actually run")
+	}
+	t.Logf("reaped %d abandoned sockets across %d rounds (%d lease denials)",
+		reaps.Load(), rounds, leaseDenied.Load())
+}
+
+// The barrier's own contract, because everything above depends on it.
+//
+// Mutation: pass a constant instead of ep to reapPhase (or drop the parameter).
+// Every barrier in this package then belongs to whichever reaper reaches the
+// phase first, which is exactly the failure this hook produced in CI: a
+// barrier fired for a foreign pathname, rewrote the endpoint its closure had
+// captured, and the test's own reaper arrived to find the schedule already
+// spent.
+func TestReapBarrierReportsTheEndpointItFiredFor(t *testing.T) {
+	dir := socketDir(t)
+	epA := crashedRunnerSocket(t, dir, "sess-a.sock")
+	epB := crashedRunnerSocket(t, dir, "sess-b.sock")
+
+	var mu sync.Mutex
+	var seen []string
+	setReapBarrier(func(ep, phase string) {
+		mu.Lock()
+		defer mu.Unlock()
+		seen = append(seen, ep+":"+phase)
+	})
+	t.Cleanup(func() { setReapBarrier(nil) })
+
+	if outcome := reapStaleSocket(epA); !outcome.Reaped {
+		t.Fatalf("reap of A declined: %s", outcome.Reason)
+	}
+	if outcome := reapStaleSocket(epB); !outcome.Reaped {
+		t.Fatalf("reap of B declined: %s", outcome.Reason)
+	}
+
+	mu.Lock()
+	got := append([]string(nil), seen...)
+	mu.Unlock()
+	// The order is part of the contract: the pin is taken before the probe, so
+	// "probed" always follows "lease-held" and precedes "before-remove".
+	want := []string{
+		epA + ":lease-held", epA + ":probed", epA + ":before-remove",
+		epB + ":lease-held", epB + ":probed", epB + ":before-remove",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("barrier fired %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("barrier fired %v, want %v", got, want)
+		}
+	}
+}
+
+// And the filter built on it: a barrier scoped to one endpoint stays out of
+// another reaper's way, including one running concurrently.
+//
+// Mutation: drop the endpoint comparison in onReapPhase.
+func TestScopedReapBarrierIgnoresForeignEndpoints(t *testing.T) {
+	dir := socketDir(t)
+	mine := crashedRunnerSocket(t, dir, "sess-mine.sock")
+	foreign := crashedRunnerSocket(t, dir, "sess-foreign.sock")
+
+	fired := onReapPhase(t, mine, "before-remove", func() {})
+
+	// A concurrent reaper works through the foreign pathname while the barrier
+	// is installed, exactly as a discovery scan worker or another test's reaper
+	// would.
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if outcome := reapStaleSocket(foreign); !outcome.Reaped {
+			t.Errorf("reap of the foreign pathname declined: %s", outcome.Reason)
+		}
+	}()
+	wg.Wait()
+
+	if fired() {
+		t.Fatal("the barrier fired for a foreign endpoint")
+	}
+	// It still fires for its own.
+	if outcome := reapStaleSocket(mine); !outcome.Reaped {
+		t.Fatalf("reap of my pathname declined: %s", outcome.Reason)
+	}
+	if !fired() {
+		t.Fatal("the barrier never fired for its own endpoint")
+	}
+}

--- a/services/gmuxd/cmd/gmuxd/start_triggers_composed_test.go
+++ b/services/gmuxd/cmd/gmuxd/start_triggers_composed_test.go
@@ -39,7 +39,11 @@ type controlledEndpoints struct {
 }
 type barrierControl struct{ calls chan string }
 
-func (c *barrierControl) Terminate(ctx context.Context, endpoint string) error {
+func (c *barrierControl) Reap(ctx context.Context, endpoint, expect string) error {
+	return c.Terminate(ctx, endpoint, expect)
+}
+
+func (c *barrierControl) Terminate(ctx context.Context, endpoint, _ string) error {
 	select {
 	case c.calls <- endpoint:
 		return nil

--- a/services/gmuxd/internal/discovery/discovery.go
+++ b/services/gmuxd/internal/discovery/discovery.go
@@ -370,22 +370,113 @@ func queryMeta(socketPath string) (*store.Session, error) {
 // to SIGTERM its child process. The runner's normal exit lifecycle
 // handles the rest.
 func KillSession(socketPath string) error {
-	return KillSessionContext(context.Background(), socketPath)
+	return KillSessionContext(context.Background(), socketPath, "")
 }
 
-// KillSessionContext is the cancellation-aware production runner control
-// transport. Endpoint mapping is deliberately fixed to POST /kill.
-func KillSessionContext(ctx context.Context, socketPath string) error {
-	resp, err := runnerRequest(ctx, socketPath, http.MethodPost, "/kill", nil)
+// KillSessionContext is the cancellation-aware production transport for an
+// explicit stop. Endpoint mapping is deliberately fixed to POST /kill.
+//
+// expectIncarnation, when set, names the runner process the caller means. A
+// runner that understands the protocol compares it with its own identity and
+// answers 409 Conflict rather than dying for somebody else's verdict; a runner
+// that predates the protocol ignores the header and stops, which is the
+// behaviour `gmux kill` has always had. That is why a decision made earlier
+// about one specific process must use ReapSessionContext instead: this route
+// cannot refuse on behalf of a runner that has never heard of it.
+func KillSessionContext(ctx context.Context, socketPath, expectIncarnation string) error {
+	var header http.Header
+	if expectIncarnation != "" {
+		header = http.Header{expectIncarnationHeader: []string{expectIncarnation}}
+	}
+	resp, err := runnerRequestHeaders(ctx, socketPath, http.MethodPost, "/kill", nil, header)
 	if err != nil {
 		return err
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusConflict {
+		return fmt.Errorf("%w: %s", ErrRunnerIncarnationMismatch, resp.Status)
+	}
 	if resp.StatusCode >= 300 {
 		return fmt.Errorf("runner /kill: %s", resp.Status)
 	}
 	return nil
 }
+
+// ReapSessionContext asks the runner at socketPath to terminate itself, but
+// only if it is the named incarnation. Endpoint mapping is deliberately fixed
+// to POST /reap, a route that exists precisely so that a runner predating the
+// protocol cannot act on the request at all: the safety of a delayed reap
+// decision cannot rest on an occupant honouring a header it has never heard
+// of.
+//
+// It reports ErrRunnerReapUnsupported for the statuses that mean "no such
+// operation here" (see reapUnsupportedStatus -- a real pre-protocol runner
+// answers 426, not 404, because its WebSocket catch-all handles the path),
+// ErrRunnerIncarnationMismatch for a 409, and leaves the occupant untouched in
+// both cases. An empty expectIncarnation is a programming error: an
+// unconditional reap is not an operation this transport offers.
+func ReapSessionContext(ctx context.Context, socketPath, expectIncarnation string) error {
+	if expectIncarnation == "" {
+		return fmt.Errorf("discovery: reap of %s requires an expected incarnation", socketPath)
+	}
+	header := http.Header{expectIncarnationHeader: []string{expectIncarnation}}
+	resp, err := runnerRequestHeaders(ctx, socketPath, http.MethodPost, "/reap", nil, header)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusConflict {
+		return fmt.Errorf("%w: %s", ErrRunnerIncarnationMismatch, resp.Status)
+	}
+	if reapUnsupportedStatus(resp.StatusCode) {
+		return fmt.Errorf("%w: %s", ErrRunnerReapUnsupported, resp.Status)
+	}
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("runner /reap: %s", resp.Status)
+	}
+	return nil
+}
+
+// reapUnsupportedStatus reports whether a status means "this endpoint has no
+// conditional reap", as opposed to "the reap was refused" or "something went
+// wrong".
+//
+// 404 is the obvious one, but it is not what a real pre-protocol runner
+// answers: those register a catch-all "/" route for the WebSocket terminal, so
+// POST /reap reaches the WebSocket handshake, which rejects a request without
+// the upgrade headers -- 426 Upgrade Required from nhooyr.io/websocket, and 405
+// or 501 from other plausible shapes of the same "wrong protocol at this path"
+// verdict.
+//
+// Every status here shares two properties, which is what makes lumping them
+// together honest: the runner reported that it cannot perform this operation,
+// and it demonstrably did not perform it. 409 is deliberately excluded -- that
+// is a runner that understands the request and refuses it -- and so is 400,
+// which is this transport's own fault for sending no expectation.
+func reapUnsupportedStatus(code int) bool {
+	switch code {
+	case http.StatusNotFound, // no such route
+		http.StatusMethodNotAllowed, // route exists, not for POST
+		http.StatusUpgradeRequired,  // route exists only as a WebSocket upgrade
+		http.StatusNotImplemented:   // route exists, operation does not
+		return true
+	}
+	return false
+}
+
+// ErrRunnerIncarnationMismatch reports that the runner answering an endpoint
+// refused because it is not the process the caller named. It is a success for
+// the safety property, not a transport failure: the intended target is already
+// gone and its pathname belongs to somebody else.
+var ErrRunnerIncarnationMismatch = errors.New("discovery: runner declined a request meant for another incarnation")
+
+// ErrRunnerReapUnsupported reports that the runner answering an endpoint does
+// not implement conditional reaping, i.e. it predates the protocol. It was left
+// untouched.
+var ErrRunnerReapUnsupported = errors.New("discovery: runner does not implement conditional reaping")
+
+// expectIncarnationHeader must match ptyserver.ExpectIncarnationHeader.
+const expectIncarnationHeader = "X-Gmux-Expect-Incarnation"
 
 // SendInput POSTs body bytes to a runner's /input endpoint, delivering
 // them to the child PTY as if typed at the terminal. Backs the

--- a/services/gmuxd/internal/discovery/kill_incarnation_test.go
+++ b/services/gmuxd/internal/discovery/kill_incarnation_test.go
@@ -1,0 +1,148 @@
+package discovery
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"nhooyr.io/websocket"
+)
+
+// The transport half of targeted termination: the daemon decides which runner
+// to kill, and the runner enforces that decision. Between them sits this
+// request, which has to carry the name and interpret the refusal.
+//
+// Mutation: drop the header, or map 409 onto the generic error path.
+func TestKillSessionCarriesTheExpectedIncarnation(t *testing.T) {
+	var got string
+	var calls int
+	srv := startUnixServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		got = r.Header.Get(expectIncarnationHeader)
+		// Behave like a runner that is not the named process.
+		if got != "" && got != "the-runner-that-answers" {
+			http.Error(w, "incarnation mismatch", http.StatusConflict)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	err := KillSessionContext(context.Background(), srv.socketPath, "the-runner-we-classified")
+	if !errors.Is(err, ErrRunnerIncarnationMismatch) {
+		t.Fatalf("KillSessionContext = %v, want ErrRunnerIncarnationMismatch", err)
+	}
+	if got != "the-runner-we-classified" {
+		t.Fatalf("runner saw expectation %q, want the classified runner", got)
+	}
+
+	// The same call against the runner it named succeeds.
+	if err := KillSessionContext(context.Background(), srv.socketPath, "the-runner-that-answers"); err != nil {
+		t.Fatalf("KillSessionContext against the named runner: %v", err)
+	}
+
+	// And a caller with no particular runner in mind sends no expectation --
+	// the pre-protocol behaviour an explicit user stop still relies on.
+	if err := KillSessionContext(context.Background(), srv.socketPath, ""); err != nil {
+		t.Fatalf("unnamed KillSessionContext: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("an unnamed kill sent expectation %q", got)
+	}
+	if calls != 3 {
+		t.Fatalf("runner saw %d requests, want 3", calls)
+	}
+}
+
+// See the note in ptyserver's incarnation_test.go: two modules, one wire.
+func TestExpectIncarnationHeaderNameIsStable(t *testing.T) {
+	if expectIncarnationHeader != "X-Gmux-Expect-Incarnation" {
+		t.Errorf("expectIncarnationHeader = %q; the runner reads X-Gmux-Expect-Incarnation", expectIncarnationHeader)
+	}
+}
+
+// The statuses that mean "this endpoint has no conditional reap".
+//
+// 404 is the tidy case and not the real one: a pre-protocol runner registers a
+// catch-all "/" route for its WebSocket terminal, so POST /reap reaches the
+// handshake and comes back 426. Mutation: narrow this back to 404 only.
+func TestReapUnsupportedStatuses(t *testing.T) {
+	unsupported := []int{
+		http.StatusNotFound,
+		http.StatusMethodNotAllowed,
+		http.StatusUpgradeRequired,
+		http.StatusNotImplemented,
+	}
+	for _, code := range unsupported {
+		if !reapUnsupportedStatus(code) {
+			t.Errorf("status %d is not treated as an unsupported route", code)
+		}
+	}
+	// A runner that understood the request and refused it, this transport's own
+	// mistake, and a genuine failure are all distinct from "no such operation".
+	for _, code := range []int{
+		http.StatusNoContent,
+		http.StatusBadRequest,
+		http.StatusConflict,
+		http.StatusInternalServerError,
+		http.StatusServiceUnavailable,
+	} {
+		if reapUnsupportedStatus(code) {
+			t.Errorf("status %d was treated as an unsupported route", code)
+		}
+	}
+}
+
+// End to end over a real socket against the real WebSocket handshake, which is
+// what a pre-protocol runner's catch-all actually is.
+func TestReapAgainstAWebSocketCatchAllIsUnsupported(t *testing.T) {
+	mux := http.NewServeMux()
+	var reached int
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		reached++
+		c, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return // the handshake wrote its own status
+		}
+		c.Close(websocket.StatusNormalClosure, "")
+	})
+	srv := startUnixServer(t, mux)
+
+	err := ReapSessionContext(context.Background(), srv.socketPath, "incarnation-of-somebody")
+	if !errors.Is(err, ErrRunnerReapUnsupported) {
+		t.Fatalf("ReapSessionContext against a WebSocket catch-all = %v, want ErrRunnerReapUnsupported", err)
+	}
+	if reached != 1 {
+		t.Fatalf("the catch-all was reached %d times, want 1", reached)
+	}
+}
+
+// An unconditional reap is not an operation this transport offers, and the
+// refusal happens before anything leaves the process: a request with no
+// expectation would reach a runner that could only answer 400, and a
+// pre-protocol occupant would not even get that far -- its catch-all would see
+// a POST it cannot serve. Neither is a conversation worth having.
+//
+// Mutation: drop the empty-expectation early return.
+func TestReapSessionRefusesAnEmptyIncarnationWithoutAskingTheRunner(t *testing.T) {
+	var requests int
+	srv := startUnixServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	err := ReapSessionContext(context.Background(), srv.socketPath, "")
+	if err == nil {
+		t.Fatal("ReapSessionContext accepted an empty expectation")
+	}
+	if errors.Is(err, ErrRunnerReapUnsupported) || errors.Is(err, ErrRunnerIncarnationMismatch) {
+		t.Fatalf("ReapSessionContext = %v; an unnamed reap is the caller's mistake, "+
+			"not a verdict about the occupant", err)
+	}
+	if requests != 0 {
+		t.Fatalf("the runner received %d requests for an unnamed reap, want 0", requests)
+	}
+	if srv.accepts.Load() != 0 {
+		t.Fatalf("the runner's socket was dialled %d times, want 0", srv.accepts.Load())
+	}
+}

--- a/services/gmuxd/internal/discovery/runnerhttp.go
+++ b/services/gmuxd/internal/discovery/runnerhttp.go
@@ -53,9 +53,18 @@ const runnerRequestTimeout = 3 * time.Second
 // (earlier deadline wins) and cancels its internal timer when the
 // body is closed. body may be nil for parameterless GET / POST.
 func runnerRequest(ctx context.Context, socketPath, method, urlPath string, body io.Reader) (*http.Response, error) {
+	return runnerRequestHeaders(ctx, socketPath, method, urlPath, body, nil)
+}
+
+func runnerRequestHeaders(ctx context.Context, socketPath, method, urlPath string, body io.Reader, header http.Header) (*http.Response, error) {
 	req, err := http.NewRequestWithContext(ctx, method, "http://unix"+urlPath, body)
 	if err != nil {
 		return nil, err
+	}
+	for k, vs := range header {
+		for _, v := range vs {
+			req.Header.Add(k, v)
+		}
 	}
 	// Mark the connection for closure after the response. With
 	// this set, the transport closes the underlying FD when the

--- a/services/gmuxd/internal/sessioncoord/coordinator.go
+++ b/services/gmuxd/internal/sessioncoord/coordinator.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/gmuxapp/gmux/packages/paths"
+	"github.com/gmuxapp/gmux/packages/socklease"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/centralstore"
 )
 
@@ -35,6 +36,15 @@ var (
 	// generation — not even while an unrelated operation's claim is held.
 	ErrReplaceWithoutClaim      = errors.New("sessioncoord: replace provenance requires a held lifecycle claim")
 	ErrAssertedIdentityMismatch = errors.New("sessioncoord: asserted session id does not match runner meta")
+	// ErrRunnerIncarnationMismatch marks a registration whose subscription and
+	// metadata were served by different runner processes. An endpoint is a
+	// reusable pathname, so two calls to it are two calls to a location, not
+	// to a process: without agreeing incarnations there is no evidence that
+	// the stream being installed belongs to the runner whose facts are being
+	// committed. Registration aborts before any commit, fence or registry
+	// change; the next discovery pass converges whoever actually owns the
+	// endpoint.
+	ErrRunnerIncarnationMismatch = errors.New("sessioncoord: subscription and metadata came from different runners")
 )
 
 // EventStream is already ordered by the runner transport. Subscribe must not
@@ -43,6 +53,27 @@ var (
 type EventStream interface {
 	Events() <-chan RunnerEvent
 	Close() error
+}
+
+// StreamIncarnation is an optional EventStream capability: a transport that
+// learned which runner answered the subscription reports it here.
+//
+// It is optional rather than part of EventStream so that a transport, a test
+// double, or a runner from before the incarnation protocol can simply not
+// implement it. Absence means "unknown", which every consumer resolves in its
+// own conservative direction.
+type StreamIncarnation interface {
+	// Incarnation returns the ephemeral identity of the runner that served
+	// this stream, or the empty string when the transport could not learn it.
+	Incarnation() string
+}
+
+// streamIncarnation extracts a stream's incarnation, or the empty string.
+func streamIncarnation(stream EventStream) string {
+	if si, ok := stream.(StreamIncarnation); ok {
+		return si.Incarnation()
+	}
+	return ""
 }
 
 type RunnerClient interface {
@@ -101,6 +132,11 @@ type RunnerMeta struct {
 	PID           int
 	RunnerVersion string
 	BinaryHash    string
+	// Incarnation is the ephemeral identity of the runner process that served
+	// this response, or empty for a runner that predates the protocol. It is
+	// never persisted: it exists to tell one process from its own successor at
+	// the same endpoint, which is a question about right now.
+	Incarnation string
 }
 
 type RunnerEvent struct {
@@ -254,6 +290,12 @@ func (c *Coordinator) Register(ctx context.Context, req RegisterRequest) (Runtim
 	// stream. Once the entry is installed (setupDone closed without cancel)
 	// streamCtx is detached from ctx.
 
+	// Capture the endpoint's physical identity before any runner I/O, so the
+	// installed Runtime describes the socket this registration actually talked
+	// to rather than whatever the pathname names once the dust settles. It is
+	// re-checked at install time (settledIdent).
+	preSocket := socketIdent(req.Endpoint)
+
 	streamCtx, streamCancel := context.WithCancel(context.Background())
 	setupDone := make(chan struct{})
 	// installMu makes install-vs-cancel atomic: the bridge goroutine may only
@@ -306,6 +348,21 @@ func (c *Coordinator) Register(ctx context.Context, req RegisterRequest) (Runtim
 	meta, err := c.runners.Meta(ctx, req.Endpoint)
 	if err != nil {
 		return Runtime{}, err
+	}
+	// Both runner calls addressed a pathname, not a process. Require them to
+	// report the same runner before treating either as evidence about the
+	// other: a pathname can change hands between the two, and then the stream
+	// we are about to install and the facts we are about to commit describe
+	// different processes.
+	//
+	// Two empty incarnations mean neither call could identify its runner --
+	// a pre-protocol runner, or a transport that does not carry the field.
+	// That is not a mismatch, it is an absence of evidence, and it is handled
+	// by refusing to claim an identity for the installed generation (below).
+	subIncarnation := streamIncarnation(stream)
+	if subIncarnation != meta.Incarnation {
+		return Runtime{}, fmt.Errorf("%w: subscription %q, metadata %q",
+			ErrRunnerIncarnationMismatch, subIncarnation, meta.Incarnation)
 	}
 	id := meta.Registration.ID
 	if !paths.IsValidSessionID(string(id)) {
@@ -499,10 +556,33 @@ loop:
 		c.invalidateVerdict(ev.ID)
 	}
 
+	// Settle this generation's endpoint identity.
+	//
+	// Two independent facts have to hold before the installed Runtime may
+	// claim to know which socket it is subscribed to:
+	//
+	//  1. The pathname named the same inode before Subscribe and after the
+	//     commit (settledIdent). Without this, a pathname rebound mid-flight
+	//     would be recorded as ours.
+	//  2. Both runner calls reported the same, known incarnation. Stat
+	//     bracketing alone cannot establish this: a bound AF_UNIX node can be
+	//     hard-linked, so an inode can leave a pathname and come back to it
+	//     (A -> B -> A) with every stat agreeing while the two calls reached
+	//     different runners.
+	//
+	// Fail either and the identity is unknown, which suppresses nothing and
+	// authorises nothing.
+	socketIdent := settledIdent(preSocket, req.Endpoint)
+	if meta.Incarnation == "" {
+		socketIdent = socklease.Ident{}
+	}
+
 	runtime := Runtime{
 		SessionID:     id,
 		Generation:    generation,
 		Endpoint:      req.Endpoint,
+		Socket:        socketIdent,
+		Incarnation:   meta.Incarnation,
 		PID:           meta.PID,
 		RunnerVersion: meta.RunnerVersion,
 		BinaryHash:    meta.BinaryHash,
@@ -836,4 +916,34 @@ func (c *Coordinator) reportError(ctx context.Context, err error) {
 	if c.errSink != nil {
 		c.errSink.Error(ctx, err)
 	}
+}
+
+// socketIdent returns the current physical identity of an endpoint pathname,
+// or the unknown identity when the pathname is not a filesystem socket (a
+// synthetic test endpoint, a vanished pathname, or something that is not a
+// socket at all).
+func socketIdent(ep string) socklease.Ident {
+	id, ok := socklease.StatSocket(ep)
+	if !ok {
+		return socklease.Ident{}
+	}
+	return id
+}
+
+// settledIdent returns the identity of ep only if it still matches the one
+// observed earlier, and the unknown identity otherwise. "The pathname named
+// the same socket before and after" is the strongest claim available without
+// holding the runner's lease, which the daemon deliberately cannot take while
+// the runner is alive.
+//
+// Residual: a pathname rebound to a new inode and back to a recycled one
+// inside the window would compare equal. That needs an inode number to be
+// reused within a single registration on the same device, and its
+// consequence is a suppressed probe that the next rebind (a new inode)
+// immediately un-suppresses.
+func settledIdent(before socklease.Ident, ep string) socklease.Ident {
+	if !before.Same(socketIdent(ep)) {
+		return socklease.Ident{}
+	}
+	return before
 }

--- a/services/gmuxd/internal/sessioncoord/coordinator_test.go
+++ b/services/gmuxd/internal/sessioncoord/coordinator_test.go
@@ -19,9 +19,13 @@ import (
 type fakeStream struct {
 	ch     chan RunnerEvent
 	closed atomic.Bool
+	// incarnation mirrors the production transport, which carries the
+	// runner's identity out of the subscription response.
+	incarnation string
 }
 
 func newFakeStream() *fakeStream                 { return &fakeStream{ch: make(chan RunnerEvent, 64)} }
+func (s *fakeStream) Incarnation() string        { return s.incarnation }
 func (s *fakeStream) Events() <-chan RunnerEvent { return s.ch }
 func (s *fakeStream) Close() error {
 	if s.closed.CompareAndSwap(false, true) {
@@ -43,13 +47,20 @@ type fakeRunnerClient struct {
 	// subscribeBlock is closed by the test when Subscribe may proceed.
 	subscribeBlock chan struct{}
 	// metaBlock is closed by the test when Meta may proceed.
-	metaBlock      chan struct{}
+	metaBlock chan struct{}
+	// onMeta runs inside Meta, before it returns. Tests use it as a barrier
+	// to perturb the filesystem in the middle of a registration's or a reap
+	// probe's runner I/O.
+	onMeta         func()
 	subscribeCalls atomic.Int64
 	metaCalls      atomic.Int64
 }
 
 func newFakeClient(meta RunnerMeta) *fakeRunnerClient {
-	return &fakeRunnerClient{stream: newFakeStream(), meta: meta}
+	stream := newFakeStream()
+	// A real runner answers both calls with the same identity.
+	stream.incarnation = meta.Incarnation
+	return &fakeRunnerClient{stream: stream, meta: meta}
 }
 
 func (c *fakeRunnerClient) Subscribe(ctx context.Context, _ string) (EventStream, error) {
@@ -77,6 +88,9 @@ func (c *fakeRunnerClient) Meta(ctx context.Context, _ string) (RunnerMeta, erro
 			return RunnerMeta{}, ctx.Err()
 		case <-c.metaBlock:
 		}
+	}
+	if c.onMeta != nil {
+		c.onMeta()
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/services/gmuxd/internal/sessioncoord/incarnation_test.go
+++ b/services/gmuxd/internal/sessioncoord/incarnation_test.go
@@ -1,0 +1,588 @@
+package sessioncoord
+
+// incarnation_test.go — mutation-grade tests for socket identity in Runtime
+// and for the identity-based orphan classification in ReapOrphans.
+//
+// The property under test is that a *pathname* never stands in for a
+// *socket*. A pathname is reusable: a replacement runner binding the same
+// pathname is a different socket and a different process, while the old
+// generation may still be draining its own. Every consumer of the identity
+// must also treat "unknown" as proving nothing, in whichever direction is
+// conservative for that consumer (never suppress a probe, never kill).
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/gmuxapp/gmux/packages/socklease"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/centralstore"
+)
+
+// listenSock binds a real Unix socket that never unlinks itself, so the test
+// controls each rebind explicitly.
+func listenSock(t *testing.T, path string) *net.UnixListener {
+	t.Helper()
+	ln, err := net.Listen("unix", path)
+	if err != nil {
+		t.Fatalf("listen %s: %v", path, err)
+	}
+	ul := ln.(*net.UnixListener)
+	ul.SetUnlinkOnClose(false)
+	t.Cleanup(func() { _ = ul.Close() })
+	return ul
+}
+
+func identOf(t *testing.T, path string) socklease.Ident {
+	t.Helper()
+	id, ok := socklease.StatSocket(path)
+	if !ok {
+		t.Fatalf("%s is not a socket", path)
+	}
+	return id
+}
+
+func metaFor(id centralstore.SessionID) RunnerMeta {
+	return RunnerMeta{Registration: centralstore.RunnerRegistration{
+		ID: id, Adapter: "shell", Alive: true, CreatedAt: 1, ObservedAt: 1,
+	}, Incarnation: "incarnation-" + string(id)}
+}
+
+// rebind replaces the socket at path with one whose identity is provably
+// different from prev.
+//
+// It does not unlink the old socket: a filesystem is free to hand the inode
+// straight back, and the old identity's creation stamp comes from a coarse
+// clock, so the "replacement" could be indistinguishable from the original --
+// which would make this a test about nothing. Renaming the original aside keeps
+// its inode linked, and therefore unusable, so the rebind necessarily lands on a
+// different one. It fails rather than skips: an environment where a pathname
+// cannot be given a new identity is one where the property under test cannot be
+// observed at all.
+func rebind(t *testing.T, old *net.UnixListener, path string, prev socklease.Ident) (*net.UnixListener, socklease.Ident) {
+	t.Helper()
+	_ = old.Close()
+	for attempt := range 32 {
+		aside := fmt.Sprintf("%s.parked-%d", path, attempt)
+		if err := os.Rename(path, aside); err != nil {
+			t.Fatalf("park %s aside: %v", path, err)
+		}
+		t.Cleanup(func() { _ = os.Remove(aside) })
+
+		ln := listenSock(t, path)
+		id := identOf(t, path)
+		if !id.Same(prev) {
+			return ln, id
+		}
+		// Same identity after all: leave this inode parked too, consuming what
+		// the kernel just handed out, and try again.
+		_ = ln.Close()
+	}
+	t.Fatalf("could not rebind %s to an identity distinct from %s", path, prev)
+	return nil, socklease.Ident{}
+}
+
+// Mutation: drop the socket identity capture in Register.
+func TestRegisterCarriesSocketIdentity(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "sess-identity.sock")
+	listenSock(t, sockPath)
+	want := identOf(t, sockPath)
+
+	coord := New(nil, newFakeClient(metaFor("sess-identity")), newFakeDurable(0), &fakeDirtySink{}, &fakeErrorSink{})
+	closeBarrier(t, coord)
+
+	rt, err := coord.Register(context.Background(), RegisterRequest{Endpoint: sockPath})
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if !rt.Socket.Known() {
+		t.Fatal("Runtime.Socket is unknown for a real socket endpoint")
+	}
+	if rt.Socket != want {
+		t.Errorf("Runtime.Socket = %+v, want %+v", rt.Socket, want)
+	}
+}
+
+// A synthetic (non-filesystem) endpoint has no identity, and must be reported
+// as unknown rather than as some default that could accidentally compare equal
+// to another unknown one.
+func TestRegisterReportsUnknownIdentityForSyntheticEndpoint(t *testing.T) {
+	coord := New(nil, newFakeClient(metaFor("sess-synthetic")), newFakeDurable(0), &fakeDirtySink{}, &fakeErrorSink{})
+	closeBarrier(t, coord)
+
+	rt, err := coord.Register(context.Background(), RegisterRequest{Endpoint: "synthetic-ep"})
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if rt.Socket.Known() {
+		t.Fatalf("Runtime.Socket = %+v for a synthetic endpoint, want unknown", rt.Socket)
+	}
+}
+
+// Mutation: capture the identity only once (before Subscribe, or only at
+// install) instead of bracketing the runner I/O with settledIdent.
+//
+// If the pathname is rebound while a registration is in flight, the stream
+// being installed and the inode the pathname names afterwards are not
+// necessarily the same socket. Recording either one as fact would be a lie
+// with teeth: Scan suppresses probes for the exact installed identity, so a
+// wrong identity means a live replacement runner is never probed again.
+func TestRegisterRefusesIdentityWhenPathnameMovesDuringRegistration(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "sess-moving.sock")
+	ln := listenSock(t, sockPath)
+	before := identOf(t, sockPath)
+
+	client := newFakeClient(metaFor("sess-moving"))
+	// Rebind the pathname in the middle of the registration's runner I/O.
+	client.onMeta = func() { _, _ = rebind(t, ln, sockPath, before) }
+
+	coord := New(nil, client, newFakeDurable(0), &fakeDirtySink{}, &fakeErrorSink{})
+	closeBarrier(t, coord)
+
+	rt, err := coord.Register(context.Background(), RegisterRequest{Endpoint: sockPath})
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if rt.Socket.Known() {
+		t.Fatalf("Runtime.Socket = %+v after the pathname was rebound mid-registration; "+
+			"an unprovable identity must be reported as unknown", rt.Socket)
+	}
+}
+
+// Mutation: revert ReapOrphans to comparing endpoint strings.
+//
+// The schedule: generation A is installed at pathname P and keeps draining its
+// stream; P is rebound by a new process B that claims the same session id.
+// B can never win registration (A is installed) and is invisible to a
+// pathname-only comparison, so it would stay alive and unregistered forever.
+func TestReapOrphansTerminatesSamePathnameDifferentSocket(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "sess-rebound.sock")
+	id := centralstore.SessionID("sess-rebound")
+	ln := listenSock(t, sockPath)
+	first := identOf(t, sockPath)
+
+	control := &fakeControl{}
+	coord := New(nil, newFakeClient(metaFor(id)), newFakeDurable(0), &fakeDirtySink{}, &fakeErrorSink{},
+		WithRunnerControl(control))
+	closeBarrier(t, coord)
+
+	rt, err := coord.Register(context.Background(), RegisterRequest{Endpoint: sockPath})
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if rt.Socket != first {
+		t.Fatalf("installed identity %+v, want %+v", rt.Socket, first)
+	}
+
+	// B rebinds the pathname while A's generation stays installed.
+	rebind(t, ln, sockPath, first)
+
+	reaped, err := coord.ReapOrphans(context.Background(), []string{sockPath})
+	if err != nil {
+		t.Fatalf("ReapOrphans: %v", err)
+	}
+	if len(reaped) != 1 || reaped[0] != sockPath {
+		t.Fatalf("reaped = %v, want [%s]; a rebound pathname is a different socket, "+
+			"not the installed generation", reaped, sockPath)
+	}
+	if control.count() != 1 {
+		t.Fatalf("Terminate called %d times, want 1", control.count())
+	}
+}
+
+// The baseline the mutation above must not break: the installed generation's
+// own endpoint is never a reap target.
+func TestReapOrphansSkipsInstalledSocket(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "sess-installed.sock")
+	listenSock(t, sockPath)
+
+	control := &fakeControl{}
+	coord := New(nil, newFakeClient(metaFor("sess-installed")), newFakeDurable(0), &fakeDirtySink{}, &fakeErrorSink{},
+		WithRunnerControl(control))
+	closeBarrier(t, coord)
+
+	if _, err := coord.Register(context.Background(), RegisterRequest{Endpoint: sockPath}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	reaped, err := coord.ReapOrphans(context.Background(), []string{sockPath})
+	if err != nil {
+		t.Fatalf("ReapOrphans: %v", err)
+	}
+	if len(reaped) != 0 || control.count() != 0 {
+		t.Fatal("ReapOrphans terminated the installed generation")
+	}
+}
+
+// Mutation: treat an unknown identity as "different" in ReapOrphans.
+//
+// This branch ends in killing a process, so an identity nobody could observe
+// (a synthetic endpoint here; in production a pathname that moved under the
+// probe) must never authorise the kill.
+func TestReapOrphansSkipsUnknownIdentity(t *testing.T) {
+	control := &fakeControl{}
+	coord := New(nil, newFakeClient(metaFor("sess-unknown")), newFakeDurable(0), &fakeDirtySink{}, &fakeErrorSink{},
+		WithRunnerControl(control))
+	closeBarrier(t, coord)
+
+	if _, err := coord.Register(context.Background(), RegisterRequest{Endpoint: "synthetic-ep"}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	reaped, err := coord.ReapOrphans(context.Background(), []string{"synthetic-ep"})
+	if err != nil {
+		t.Fatalf("ReapOrphans: %v", err)
+	}
+	if len(reaped) != 0 || control.count() != 0 {
+		t.Fatal("ReapOrphans terminated a process whose socket identity was unknown")
+	}
+}
+
+// Mutation: settle the probe identity before Meta only (drop the post-probe
+// verification in ReapOrphans).
+//
+// If the pathname moves while the Meta probe is in flight, the answer came
+// from one socket and the pathname now names another. Neither is provably an
+// orphan, and this branch ends in killing a process.
+func TestReapOrphansSkipsPathnameThatMovedUnderTheProbe(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "sess-moving-probe.sock")
+	id := centralstore.SessionID("sess-moving-probe")
+	ln := listenSock(t, sockPath)
+	first := identOf(t, sockPath)
+
+	control := &fakeControl{}
+	client := newFakeClient(metaFor(id))
+	coord := New(nil, client, newFakeDurable(0), &fakeDirtySink{}, &fakeErrorSink{},
+		WithRunnerControl(control))
+	closeBarrier(t, coord)
+
+	if _, err := coord.Register(context.Background(), RegisterRequest{Endpoint: sockPath}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	// A different socket takes the pathname: this is now a reap candidate...
+	ln2, second := rebind(t, ln, sockPath, first)
+	// ...but it moves again while the reap probe is in flight.
+	client.onMeta = func() {
+		client.onMeta = nil
+		rebind(t, ln2, sockPath, second)
+	}
+
+	reaped, err := coord.ReapOrphans(context.Background(), []string{sockPath})
+	if err != nil {
+		t.Fatalf("ReapOrphans: %v", err)
+	}
+	if len(reaped) != 0 || control.count() != 0 {
+		t.Fatal("ReapOrphans killed a pathname whose identity changed under its own probe")
+	}
+}
+
+// Mutation: drop the incarnation argument from the reap call in ReapOrphans
+// (kill by pathname alone), or route the reap through Terminate.
+//
+// The schedule the reviews rejected:
+//
+//  1. Generation A is installed for session S at pathname P1.
+//  2. Runner B answers at P2, claims S, and is classified as an orphan.
+//  3. Before the kill lands, B exits and an unrelated runner C -- a different
+//     session entirely -- binds P2.
+//  4. The kill is addressed to P2, so it reaches C.
+//
+// Recoverability is not ownership: C is a live, healthy, unrelated runner and
+// nothing about the classification was ever about it. The kill therefore
+// carries the incarnation the classification was made about, and C's own
+// /kill handler refuses it (pinned separately in ptyserver). Here we pin the
+// half the coordinator owns: the expectation is sent, and it names B.
+func TestReapOrphansNamesTheClassifiedRunnerInItsReap(t *testing.T) {
+	installedID := centralstore.SessionID("sess-installed")
+	orphanEP := "ep-orphan"
+
+	client := &multiClient{metas: map[string]RunnerMeta{
+		orphanEP: {
+			Registration: centralstore.RunnerRegistration{ID: installedID, Adapter: "pi", Alive: true},
+			Incarnation:  "incarnation-of-B",
+		},
+	}}
+	control := &fakeControl{}
+	coord := reapCoord(t, client, control)
+	installLive(coord, installedID, "ep-installed")
+
+	// C takes the pathname over the instant B has been classified, so by the
+	// time the kill is sent the pathname belongs to an unrelated session.
+	client.afterMeta = func(endpoint string) {
+		client.mu.Lock()
+		defer client.mu.Unlock()
+		client.afterMeta = nil
+		client.metas[endpoint] = RunnerMeta{
+			Registration: centralstore.RunnerRegistration{ID: "sess-unrelated-c", Adapter: "pi", Alive: true},
+			Incarnation:  "incarnation-of-C",
+		}
+	}
+
+	reaped, err := coord.ReapOrphans(context.Background(), []string{orphanEP})
+	if err != nil {
+		t.Fatalf("ReapOrphans: %v", err)
+	}
+	if len(reaped) != 1 {
+		t.Fatalf("reaped = %v, want the classified orphan", reaped)
+	}
+	got := control.expectations()
+	if len(got) != 1 {
+		t.Fatalf("Terminate calls = %d, want 1", len(got))
+	}
+	if got[0] != "incarnation-of-B" {
+		t.Fatalf("reap named %q, want the classified runner %q; an unnamed kill lands on whoever owns the pathname now",
+			got[0], "incarnation-of-B")
+	}
+	// And it went through the conditional route, not the compatibility one: a
+	// pre-protocol occupant obeys /kill regardless of any header.
+	if routes := control.requestRoutes(); len(routes) != 1 || routes[0] != "reap" {
+		t.Fatalf("control routes = %v, want [reap]", routes)
+	}
+}
+
+// Mutation: treat ErrReapUnsupported as a failure (report it), or as a
+// success (count it as reaped).
+//
+// An occupant that predates conditional reaping is left alone. That is the
+// protocol working, not an incident: it must not be reported as an error, and
+// it must not be counted as a reap.
+func TestReapOrphansTreatsAnUnsupportedRouteAsADecline(t *testing.T) {
+	installedID := centralstore.SessionID("sess-installed")
+	client := &multiClient{metas: map[string]RunnerMeta{
+		"ep-orphan": {
+			Registration: centralstore.RunnerRegistration{ID: installedID, Adapter: "pi", Alive: true},
+			Incarnation:  "incarnation-of-B",
+		},
+	}}
+	control := &fakeControl{reapErr: fmt.Errorf("legacy occupant: %w", ErrReapUnsupported)}
+	sink := &fakeErrorSink{}
+	coord := New(nil, client, newFakeDurable(0), &fakeDirtySink{}, sink, WithRunnerControl(control))
+	closeBarrier(t, coord)
+	installLive(coord, installedID, "ep-installed")
+
+	reaped, err := coord.ReapOrphans(context.Background(), []string{"ep-orphan"})
+	if err != nil {
+		t.Fatalf("ReapOrphans: %v", err)
+	}
+	if len(reaped) != 0 {
+		t.Fatalf("reaped = %v, want nothing: the occupant could not act on the request", reaped)
+	}
+	if sink.count() != 0 {
+		t.Fatalf("a decline was reported as an error: %v", sink.count())
+	}
+}
+
+// Mutation: reap candidates whose incarnation is unknown.
+//
+// A runner that predates the incarnation protocol cannot be named, so a kill
+// against it cannot be bounded to the process the classification was about.
+// Unknown means no kill.
+func TestReapOrphansRefusesToKillAnUnidentifiableRunner(t *testing.T) {
+	installedID := centralstore.SessionID("sess-installed")
+	client := &multiClient{metas: map[string]RunnerMeta{
+		// No Incarnation: a pre-protocol runner.
+		"ep-legacy-orphan": {Registration: centralstore.RunnerRegistration{ID: installedID, Adapter: "pi", Alive: true}},
+	}}
+	control := &fakeControl{}
+	coord := reapCoord(t, client, control)
+	installLive(coord, installedID, "ep-installed")
+
+	reaped, err := coord.ReapOrphans(context.Background(), []string{"ep-legacy-orphan"})
+	if err != nil {
+		t.Fatalf("ReapOrphans: %v", err)
+	}
+	if len(reaped) != 0 || control.count() != 0 {
+		t.Fatalf("reaped an orphan the daemon cannot name: reaped=%v terminates=%d", reaped, control.count())
+	}
+}
+
+// Mutation: drop the subscription/metadata incarnation comparison in Register.
+//
+// The ABA the reviews demonstrated: a bound AF_UNIX node can be hard-linked,
+// so a pathname can name inode A, be replaced by B, and be restored to A --
+// with every stat agreeing -- while Subscribe reached A and Meta reached B.
+// Stat bracketing cannot see it; the runners' own identities can.
+func TestRegisterRejectsAStreamAndMetadataFromDifferentRunners(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "sess-aba.sock")
+	listenSock(t, sockPath)
+
+	client := newFakeClient(metaFor("sess-aba"))
+	// The stream came from one runner; the metadata answers as another. On
+	// the filesystem this is the A -> B -> A restoration: same inode before
+	// and after, two different processes in between.
+	client.stream.incarnation = "incarnation-of-A"
+	client.meta.Incarnation = "incarnation-of-B"
+
+	coord := New(nil, client, newFakeDurable(0), &fakeDirtySink{}, &fakeErrorSink{})
+	closeBarrier(t, coord)
+
+	_, err := coord.Register(context.Background(), RegisterRequest{Endpoint: sockPath})
+	if !errors.Is(err, ErrRunnerIncarnationMismatch) {
+		t.Fatalf("Register = %v, want ErrRunnerIncarnationMismatch", err)
+	}
+	// Nothing was installed: an unproven registration must not leave a trace.
+	if snap := coord.registry.Snapshot(); len(snap) != 0 {
+		t.Fatalf("registry = %+v, want empty", snap)
+	}
+}
+
+// The hard-link ABA, executed on a real filesystem against the real Register.
+//
+// Without the incarnation comparison the stat bracket is satisfied -- the
+// pathname names inode A before and after -- and the daemon would record a
+// known socket identity for a generation whose stream and metadata came from
+// different runners, then suppress every future probe of that pathname.
+//
+// Mutation: drop the incarnation comparison in Register.
+func TestRegisterSurvivesHardlinkRestoredPathname(t *testing.T) {
+	dir := t.TempDir()
+	sockPath := filepath.Join(dir, "sess-hardlink.sock")
+	parked := filepath.Join(dir, "parked.sock")
+
+	// A is bound at the endpoint, and hard-linked aside so its inode can come
+	// back to the pathname later.
+	lnA := listenSock(t, sockPath)
+	identA := identOf(t, sockPath)
+	if err := os.Link(sockPath, parked); err != nil {
+		t.Skipf("this filesystem does not support hard-linking a bound socket: %v", err)
+	}
+
+	client := newFakeClient(metaFor("sess-hardlink"))
+	client.stream.incarnation = "incarnation-of-A"
+	// Between Subscribe and Meta the pathname is B's, and B answers.
+	client.onMeta = func() {
+		client.onMeta = nil
+		_ = lnA.Close()
+		if err := os.Remove(sockPath); err != nil {
+			t.Errorf("remove: %v", err)
+		}
+		lnB := listenSock(t, sockPath)
+		client.meta.Incarnation = "incarnation-of-B"
+		// ...and then B goes away and A's inode is restored to the pathname,
+		// so the post-stat sees exactly what the pre-stat saw.
+		_ = lnB.Close()
+		if err := os.Remove(sockPath); err != nil {
+			t.Errorf("remove B: %v", err)
+		}
+		if err := os.Link(parked, sockPath); err != nil {
+			t.Errorf("restore A: %v", err)
+		}
+	}
+
+	coord := New(nil, client, newFakeDurable(0), &fakeDirtySink{}, &fakeErrorSink{})
+	closeBarrier(t, coord)
+
+	_, err := coord.Register(context.Background(), RegisterRequest{Endpoint: sockPath})
+
+	// The ABA the schedule performs is at the level of the *numbers*: the
+	// pathname names A's device and inode again.
+	restored := identOf(t, sockPath)
+	if restored.Dev != identA.Dev || restored.Ino != identA.Ino {
+		t.Fatalf("the pathname was not restored to A's inode (%s -> %s); the schedule did not run",
+			identA, restored)
+	}
+	// The full identity does not come back with it: link() touches the inode's
+	// change time, so the stamp moved. That is a second, independent reason this
+	// registration cannot claim an identity -- and it is worth noting that it is
+	// a *filesystem* accident, not a guarantee: the guarantee is the runners'
+	// own incarnations disagreeing, which is what this test asserts below and
+	// which holds whatever the clock did.
+	if restored.Same(identA) {
+		t.Logf("this filesystem restored A's identity in full (%s); "+
+			"only the incarnation comparison separates the two runners here", restored)
+	}
+	if !errors.Is(err, ErrRunnerIncarnationMismatch) {
+		t.Fatalf("Register = %v, want ErrRunnerIncarnationMismatch: the stats agree, only the runners' own identities disagree", err)
+	}
+}
+
+// A runner that predates the incarnation protocol registers normally, but the
+// daemon refuses to claim it knows which socket that generation is subscribed
+// to -- so it is probed on every sweep instead of being suppressed.
+//
+// Mutation: keep the stat-derived identity when the incarnation is unknown.
+func TestRegisterWithoutIncarnationClaimsNoSocketIdentity(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "sess-legacy.sock")
+	listenSock(t, sockPath)
+
+	meta := metaFor("sess-legacy")
+	meta.Incarnation = "" // pre-protocol runner
+	client := newFakeClient(meta)
+
+	coord := New(nil, client, newFakeDurable(0), &fakeDirtySink{}, &fakeErrorSink{})
+	closeBarrier(t, coord)
+
+	rt, err := coord.Register(context.Background(), RegisterRequest{Endpoint: sockPath})
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if rt.Socket.Known() {
+		t.Fatalf("Runtime.Socket = %+v for a runner that cannot be identified; "+
+			"stat bracketing alone cannot rule out an ABA and must not license suppression", rt.Socket)
+	}
+	if rt.Incarnation != "" {
+		t.Fatalf("Runtime.Incarnation = %q, want empty", rt.Incarnation)
+	}
+}
+
+// Runtime identity is ephemeral, and the type system should be the thing that
+// remembers that.
+//
+// An inode number, a creation timestamp and a process nonce describe this boot
+// of this filesystem and this process. Persisted, they would be facts about a
+// world that no longer exists -- and worse, a stored identity that happened to
+// match a recycled inode would authorise exactly the destructive act this whole
+// protocol exists to prevent. So neither the socket identity nor the incarnation
+// may appear anywhere in the durable surface.
+//
+// Mutation: add Runtime.Socket or Runtime.Incarnation to
+// centralstore.RunnerRegistration (or to RunnerFacts).
+func TestEphemeralIdentityIsNeverPersisted(t *testing.T) {
+	identType := reflect.TypeOf(socklease.Ident{})
+	forbiddenNames := map[string]bool{"socket": true, "incarnation": true, "ident": true}
+
+	var walk func(typ reflect.Type, path string, depth int)
+	walk = func(typ reflect.Type, path string, depth int) {
+		if depth > 4 || typ.Kind() != reflect.Struct {
+			return
+		}
+		if typ == identType {
+			t.Errorf("%s is a socklease.Ident: runtime identity must not reach durable state", path)
+			return
+		}
+		for i := range typ.NumField() {
+			f := typ.Field(i)
+			name := path + "." + f.Name
+			if forbiddenNames[strings.ToLower(f.Name)] {
+				t.Errorf("%s names an ephemeral identity in a durable type", name)
+			}
+			ft := f.Type
+			for ft.Kind() == reflect.Ptr || ft.Kind() == reflect.Slice {
+				ft = ft.Elem()
+			}
+			walk(ft, name, depth+1)
+		}
+	}
+	for _, durable := range []any{
+		centralstore.RunnerRegistration{},
+		centralstore.RunnerObservation{},
+		centralstore.Session{},
+	} {
+		typ := reflect.TypeOf(durable)
+		walk(typ, typ.Name(), 0)
+	}
+
+	// And the projection the snapshot composer sees, which is the only path out
+	// of the registry, carries neither.
+	rt := reflect.TypeOf(Runtime{})
+	if _, found := rt.FieldByName("Socket"); !found {
+		t.Fatal("Runtime.Socket is gone; this test is no longer guarding anything")
+	}
+	if _, found := rt.FieldByName("Incarnation"); !found {
+		t.Fatal("Runtime.Incarnation is gone; this test is no longer guarding anything")
+	}
+}

--- a/services/gmuxd/internal/sessioncoord/lifecycle.go
+++ b/services/gmuxd/internal/sessioncoord/lifecycle.go
@@ -23,6 +23,11 @@ var (
 	// ErrNoRunnerControl / ErrNoRunnerSpawner mark operations whose injected
 	// I/O boundary was not configured.
 	ErrNoRunnerControl = errors.New("sessioncoord: no runner control configured")
+	// ErrReapUnsupported marks an endpoint whose occupant does not implement
+	// conditional reaping: a runner that predates the protocol. It is not a
+	// failure -- it is the protocol working. The occupant is left alone and
+	// discovery converges it the ordinary way.
+	ErrReapUnsupported = errors.New("sessioncoord: endpoint does not support conditional reaping")
 	ErrNoRunnerSpawner = errors.New("sessioncoord: no runner spawner configured")
 	// ErrConvergencePending marks a resume of an exit-less row while the
 	// startup convergence window is open: its liveness is unknown until a
@@ -54,8 +59,28 @@ var (
 // ordinary observation path (exit event or stream drop). Terminate must be
 // idempotent. It is I/O and is never called under any coordinator lock or
 // inside a database transaction.
+//
+// Terminate is the explicit, user-initiated stop of whoever owns an endpoint.
+// expectIncarnation names the installed generation when the daemon knows it,
+// which makes a runner that understands the protocol refuse if the pathname
+// changed hands; an empty expectation keeps the original semantics, which is
+// all that is possible against a runner predating the protocol.
+//
+// Reap is termination conditional on identity, and it is a *different
+// operation*, not Terminate with a flag. A reap decision is made about one
+// specific process, from a probe, and executed later against a pathname that
+// may by then belong to somebody else. Adding a header to Terminate cannot
+// make that safe in a mixed-version fleet: a pre-protocol occupant ignores
+// unknown headers and dies for a verdict about another process. Reap must
+// therefore address a facility such an occupant does not implement at all, so
+// that "I cannot do this" is the answer rather than "done".
+//
+// Implementations must report ErrReapUnsupported when the occupant does not
+// implement conditional reaping, and must leave it strictly untouched in that
+// case.
 type RunnerControl interface {
-	Terminate(ctx context.Context, endpoint string) error
+	Terminate(ctx context.Context, endpoint, expectIncarnation string) error
+	Reap(ctx context.Context, endpoint, expectIncarnation string) error
 }
 
 // RunnerSpawner launches a new runner process for a retained dead session and
@@ -148,7 +173,11 @@ func (c *Coordinator) stopClaimed(ctx context.Context, id centralstore.SessionID
 	endpoint, dead := e.Endpoint, e.dead
 
 	// ── runner I/O; no locks, no DB transaction ──────────────────────────
-	if err := c.control.Terminate(ctx, endpoint); err != nil {
+	// Name the generation we are stopping when we know it. An explicit stop
+	// of a runner that predates the protocol carries no expectation, which
+	// preserves the old behaviour for exactly the population that cannot
+	// verify one.
+	if err := c.control.Terminate(ctx, endpoint, e.Incarnation); err != nil {
 		return fmt.Errorf("sessioncoord: terminate %s: %w", id, err)
 	}
 	select {

--- a/services/gmuxd/internal/sessioncoord/lifecycle_test.go
+++ b/services/gmuxd/internal/sessioncoord/lifecycle_test.go
@@ -19,15 +19,36 @@ import (
 type fakeControl struct {
 	mu        sync.Mutex
 	calls     []string
+	expects   []string
+	routes    []string
+	reapErr   error
 	err       error
 	onKill    func(endpoint string)
 	entered   chan struct{} // closed on first Terminate, if non-nil
 	enterOnce sync.Once
 }
 
-func (f *fakeControl) Terminate(_ context.Context, endpoint string) error {
+func (f *fakeControl) Terminate(ctx context.Context, endpoint, expectIncarnation string) error {
+	return f.record(ctx, "kill", endpoint, expectIncarnation)
+}
+
+// Reap is the conditional route. A test can make it decline the way a
+// pre-protocol occupant does by setting reapErr.
+func (f *fakeControl) Reap(ctx context.Context, endpoint, expectIncarnation string) error {
+	if f.reapErr != nil {
+		f.mu.Lock()
+		f.routes = append(f.routes, "reap-declined")
+		f.mu.Unlock()
+		return f.reapErr
+	}
+	return f.record(ctx, "reap", endpoint, expectIncarnation)
+}
+
+func (f *fakeControl) record(_ context.Context, route, endpoint, expectIncarnation string) error {
 	f.mu.Lock()
 	f.calls = append(f.calls, endpoint)
+	f.expects = append(f.expects, expectIncarnation)
+	f.routes = append(f.routes, route)
 	err := f.err
 	kill := f.onKill
 	f.mu.Unlock()
@@ -46,6 +67,20 @@ func (f *fakeControl) count() int {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return len(f.calls)
+}
+
+// expectations returns the incarnations the coordinator named on each request.
+func (f *fakeControl) expectations() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.expects...)
+}
+
+// requestRoutes returns which control route each request used.
+func (f *fakeControl) requestRoutes() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.routes...)
 }
 
 // fakeSpawner returns a fixed endpoint and can fail or block.

--- a/services/gmuxd/internal/sessioncoord/reap.go
+++ b/services/gmuxd/internal/sessioncoord/reap.go
@@ -2,13 +2,16 @@ package sessioncoord
 
 import (
 	"context"
+	"errors"
 	"fmt"
 )
 
 // ReapOrphans terminates exactly one orphan class: a runner process whose
 // Meta reports a session ID that already has an installed live generation on
-// a DIFFERENT endpoint. That is the lost-resume-race leftover the lifecycle
-// slice documented — a last-wins Replace superseded the loser process, whose
+// a DIFFERENT socket. "Different socket" means a different pathname, or the
+// same pathname provably rebound to a different inode while the installed
+// generation kept draining its own (unnamed) one. That is the
+// lost-resume-race leftover the lifecycle slice documented — a last-wins Replace superseded the loser process, whose
 // registration can never win without Replace provenance — so two processes
 // claim one identity and the unregistered one is provably redundant.
 //
@@ -36,6 +39,16 @@ import (
 // the window is open the registry is still converging and "live generation"
 // is not yet trustworthy enough to kill against.
 //
+// Termination goes through RunnerControl.Reap, never Terminate. A reap
+// decision is made from a probe and executed later against a pathname, and
+// pathnames change hands in between. Reap addresses a facility only a
+// protocol-aware runner implements: such a runner compares the named
+// incarnation with its own and refuses if it is not the process the decision
+// was about, and an occupant that predates the protocol cannot act on the
+// request at all (ErrReapUnsupported) and is left untouched. A candidate that
+// cannot be named is never reaped either, for the same reason: the daemon
+// would have no way to bound the blast radius of being wrong.
+//
 // Returns the endpoints that were terminated.
 func (c *Coordinator) ReapOrphans(ctx context.Context, endpoints []string) ([]string, error) {
 	if c.control == nil {
@@ -51,12 +64,24 @@ func (c *Coordinator) ReapOrphans(ctx context.Context, endpoints []string) ([]st
 	var reaped []string
 	for _, endpoint := range endpoints {
 		// ── probe: I/O, no locks ─────────────────────────────────────────
+		// Bracket the probe with the pathname's identity: probed describes
+		// the socket that actually answered Meta, or is unknown when the
+		// pathname moved underneath the probe.
+		preProbe := socketIdent(endpoint)
 		meta, err := c.runners.Meta(ctx, endpoint)
 		if err != nil {
 			continue // unreachable/unknown: discovery's problem, not reaping's
 		}
+		probed := settledIdent(preProbe, endpoint)
 		id := meta.Registration.ID
 		if id == "" {
+			continue
+		}
+		if meta.Incarnation == "" {
+			// Unidentifiable candidate: a runner from before the protocol, or
+			// one whose transport dropped the field. Killing it would mean
+			// addressing a pathname and hoping, which is the entire failure
+			// mode this guard exists to remove.
 			continue
 		}
 		_, release, err := c.claim(id, "reap")
@@ -64,14 +89,39 @@ func (c *Coordinator) ReapOrphans(ctx context.Context, endpoints []string) ([]st
 			continue // a lifecycle op owns this session right now: skip
 		}
 		live, ok := c.registry.current(id)
-		if !ok || live.Endpoint == endpoint {
-			// No live winner (discovery converges this endpoint via
-			// Register), or this IS the registered generation's endpoint.
+		if !ok {
+			// No live winner: discovery converges this endpoint via Register.
 			release()
 			continue
 		}
-		// ── terminate: I/O, no locks, no DB transaction ──────────────────
-		if err := c.control.Terminate(ctx, endpoint); err != nil {
+		if live.Endpoint == endpoint {
+			// Same pathname. Only a provably different socket is an orphan:
+			// if either identity is unknown, or they match, this either IS
+			// the installed generation or cannot be shown not to be — and
+			// this branch ends in killing a process, so unproven means no.
+			if !probed.Known() || !live.Socket.Known() || probed.Same(live.Socket) {
+				release()
+				continue
+			}
+			// A distinct process rebound the pathname while the installed
+			// generation is still draining its own socket. Fall through.
+		}
+		// ── reap: I/O, no locks, no DB transaction ───────────────────────
+		// Conditional on identity, and on a facility only a protocol-aware
+		// runner has. A replacement that took the pathname over declines (or,
+		// if it predates the protocol, cannot act at all) and stays alive; the
+		// next sweep classifies whoever is there on its own merits.
+		//
+		// Re-stat'ing the pathname here instead would only move the same
+		// check-then-act one instruction closer to the kill.
+		err = c.control.Reap(ctx, endpoint, meta.Incarnation)
+		switch {
+		case errors.Is(err, ErrReapUnsupported):
+			// The occupant predates conditional reaping and was left alone.
+			// Not an error: discovery converges it the ordinary way.
+			release()
+			continue
+		case err != nil:
 			c.reportError(ctx, fmt.Errorf("sessioncoord: reap of %s (session %s): %w", endpoint, id, err))
 			release()
 			continue

--- a/services/gmuxd/internal/sessioncoord/reap.go
+++ b/services/gmuxd/internal/sessioncoord/reap.go
@@ -61,6 +61,8 @@ func (c *Coordinator) ReapOrphans(ctx context.Context, endpoints []string) ([]st
 	}
 	c.mu.Unlock()
 
+	installed := c.registry.InstalledSockets()
+
 	var reaped []string
 	for _, endpoint := range endpoints {
 		// ── probe: I/O, no locks ─────────────────────────────────────────
@@ -68,6 +70,12 @@ func (c *Coordinator) ReapOrphans(ctx context.Context, endpoints []string) ([]st
 		// the socket that actually answered Meta, or is unknown when the
 		// pathname moved underneath the probe.
 		preProbe := socketIdent(endpoint)
+		if _, isInstalled := installed[preProbe]; isInstalled && preProbe.Known() {
+			// This pathname names a socket an installed generation is
+			// subscribed to. It cannot be an orphan, so skip the probe
+			// entirely: an unchanged fleet must cost no runner I/O per tick.
+			continue
+		}
 		meta, err := c.runners.Meta(ctx, endpoint)
 		if err != nil {
 			continue // unreachable/unknown: discovery's problem, not reaping's

--- a/services/gmuxd/internal/sessioncoord/reap_test.go
+++ b/services/gmuxd/internal/sessioncoord/reap_test.go
@@ -13,18 +13,30 @@ import (
 type multiClient struct {
 	mu    sync.Mutex
 	metas map[string]RunnerMeta
+	// afterMeta runs once a Meta call has been answered, so a test can hand
+	// the endpoint to a different runner in the window between a
+	// classification and the action taken on it.
+	afterMeta func(endpoint string)
 }
 
-func (c *multiClient) Subscribe(context.Context, string) (EventStream, error) {
-	return newFakeStream(), nil
+func (c *multiClient) Subscribe(_ context.Context, endpoint string) (EventStream, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	stream := newFakeStream()
+	stream.incarnation = c.metas[endpoint].Incarnation
+	return stream, nil
 }
 
 func (c *multiClient) Meta(_ context.Context, endpoint string) (RunnerMeta, error) {
 	c.mu.Lock()
-	defer c.mu.Unlock()
 	m, ok := c.metas[endpoint]
+	after := c.afterMeta
+	c.mu.Unlock()
 	if !ok {
 		return RunnerMeta{}, errors.New("unreachable")
+	}
+	if after != nil {
+		after(endpoint)
 	}
 	return m, nil
 }
@@ -39,7 +51,7 @@ func reapCoord(t *testing.T, client RunnerClient, control *fakeControl) *Coordin
 func TestReapOrphansTerminatesSupersededDuplicate(t *testing.T) {
 	id := sid(1)
 	client := &multiClient{metas: map[string]RunnerMeta{
-		"ep-orphan": {Registration: centralstore.RunnerRegistration{ID: id, Adapter: "pi", Alive: true}},
+		"ep-orphan": {Registration: centralstore.RunnerRegistration{ID: id, Adapter: "pi", Alive: true}, Incarnation: "incarnation-" + string(id)},
 	}}
 	control := &fakeControl{}
 	coord := reapCoord(t, client, control)
@@ -72,8 +84,8 @@ func TestReapOrphansNeverKillsTheRegisteredEndpointOrUnclaimedRunners(t *testing
 	registered := sid(2)
 	unclaimed := sid(3)
 	client := &multiClient{metas: map[string]RunnerMeta{
-		"ep-registered": {Registration: centralstore.RunnerRegistration{ID: registered, Adapter: "pi", Alive: true}},
-		"ep-unclaimed":  {Registration: centralstore.RunnerRegistration{ID: unclaimed, Adapter: "pi", Alive: true}},
+		"ep-registered": {Registration: centralstore.RunnerRegistration{ID: registered, Adapter: "pi", Alive: true}, Incarnation: "incarnation-" + string(registered)},
+		"ep-unclaimed":  {Registration: centralstore.RunnerRegistration{ID: unclaimed, Adapter: "pi", Alive: true}, Incarnation: "incarnation-" + string(unclaimed)},
 		"ep-anonymous":  {},
 	}}
 	control := &fakeControl{}
@@ -93,7 +105,7 @@ func TestReapOrphansNeverKillsTheRegisteredEndpointOrUnclaimedRunners(t *testing
 func TestReapOrphansSkipsClaimedSession(t *testing.T) {
 	id := sid(4)
 	client := &multiClient{metas: map[string]RunnerMeta{
-		"ep-orphan": {Registration: centralstore.RunnerRegistration{ID: id, Adapter: "pi", Alive: true}},
+		"ep-orphan": {Registration: centralstore.RunnerRegistration{ID: id, Adapter: "pi", Alive: true}, Incarnation: "incarnation-" + string(id)},
 	}}
 	control := &fakeControl{}
 	coord := reapCoord(t, client, control)
@@ -114,7 +126,7 @@ func TestReapOrphansSkipsClaimedSession(t *testing.T) {
 func TestReapOrphansTerminateFailureIsReportedAndSkipped(t *testing.T) {
 	id := sid(5)
 	client := &multiClient{metas: map[string]RunnerMeta{
-		"ep-orphan": {Registration: centralstore.RunnerRegistration{ID: id, Adapter: "pi", Alive: true}},
+		"ep-orphan": {Registration: centralstore.RunnerRegistration{ID: id, Adapter: "pi", Alive: true}, Incarnation: "incarnation-" + string(id)},
 	}}
 	control := &fakeControl{err: errors.New("kill failed")}
 	errs := &fakeErrorSink{}

--- a/services/gmuxd/internal/sessioncoord/registry.go
+++ b/services/gmuxd/internal/sessioncoord/registry.go
@@ -8,15 +8,38 @@ import (
 	"sort"
 	"sync"
 
+	"github.com/gmuxapp/gmux/packages/socklease"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/centralstore"
 )
 
 // Runtime is the registry's runtime-only value. Durable common session facts
 // must never be added here.
 type Runtime struct {
-	SessionID     centralstore.SessionID
-	Generation    uint64
-	Endpoint      string
+	SessionID  centralstore.SessionID
+	Generation uint64
+	Endpoint   string
+	// Socket is the physical identity (device + inode) the endpoint pathname
+	// named while this generation registered. Endpoint alone cannot identify
+	// a runner: a pathname is reusable, and a replacement runner binding the
+	// same pathname is a different socket, a different process, and a
+	// different generation, while the old one may still be draining.
+	//
+	// Consumers must treat an unknown (zero) identity as "cannot prove
+	// anything": never as a match, and never as licence to suppress a probe
+	// or to terminate a process. It is unknown when the endpoint is not a
+	// filesystem socket (synthetic test endpoints) or when the pathname was
+	// rebound while this registration was in flight, in which case the
+	// registration's stream and the pathname's current inode may disagree.
+	Socket socklease.Ident
+	// Incarnation is the runner process that served this registration, as
+	// reported by both its subscription and its metadata. Empty means the
+	// runner could not be identified (it predates the protocol, or the
+	// transport does not carry the field), which is never treated as a match.
+	//
+	// It is runtime-only and deliberately never persisted: it distinguishes a
+	// process from its own successor at the same endpoint, a question that
+	// only has meaning while both are in living memory.
+	Incarnation   string
 	PID           int
 	RunnerVersion string
 	BinaryHash    string

--- a/services/gmuxd/internal/sessioncoord/registry.go
+++ b/services/gmuxd/internal/sessioncoord/registry.go
@@ -184,6 +184,28 @@ func (r *Registry) Snapshot() []Runtime {
 	return out
 }
 
+// InstalledSockets returns the set of physical socket identities that
+// currently have an installed, subscribed, non-fenced generation. It is the
+// authority for "this socket is already installed": the registry itself, not
+// a cache maintained alongside it, so an entry that leaves the registry stops
+// suppressing work in the same instant.
+//
+// Unknown identities are excluded. They prove nothing, and an unknown identity
+// that suppressed a probe would hide every runner the daemon could not
+// identify -- the opposite of the intent.
+func (r *Registry) InstalledSockets() map[socklease.Ident]struct{} {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make(map[socklease.Ident]struct{}, len(r.entries))
+	for _, e := range r.entries {
+		if e.superseded || !e.Subscribed || !e.Socket.Known() {
+			continue
+		}
+		out[e.Socket] = struct{}{}
+	}
+	return out
+}
+
 // liveSessionIDs returns the IDs of entries with an installed, non-fenced
 // generation, sorted. Unlike Snapshot it excludes superseded (fenced)
 // entries — a fenced entry is mid-replacement and must not be treated as


### PR DESCRIPTION
## Summary

Stacked on #417.

- make runner socket cleanup ownership-safe with a shared AF_UNIX lease protocol
- remove canonical socket paths on normal exit and `/kill`, while preserving restart identity
- distinguish runner incarnations with an ephemeral nonce plus device/inode identity
- reap only lease-aware, explicitly refused stale sockets; preserve mixed-version safety
- suppress unchanged periodic discovery work by exact installed incarnation
- report discovery failures on transitions and clear vanished diagnostics
- bound daemon logs in-process without losing direct stderr or panic output
- use the same bounded log path for `gmuxd start` and CLI autostart

## Safety properties

- no stat-then-unlink cleanup: all modern cleanup is lease-held and identity-checked
- legacy/pre-lease socket occupants are never unlinked
- orphan cleanup uses a modern conditional `/reap` route; legacy replacements are untouched
- exact incarnation is required for registration suppression and conditional reaping
- distinct endpoints claiming one session ID still surface `ErrGenerationActive`
- log rotation renames the live inode and atomically moves fd 2; descriptors are close-on-exec

## Validation

- six adversarial review rounds, including deterministic filesystem schedules and production mutations
- `go test -race` for socklease, ptyserver, gmux CLI, discovery, sessioncoord, and gmuxd command packages
- real built-gmux test with 100 short launches; deleting the production trailing `Shutdown` fails it
- Linux/Darwin cross-builds (amd64/arm64), generated-store check
- production container E2E: 8/8
- final independent reviews: approve; no blocking findings

## Compatibility

Pre-protocol runners remain discoverable and stoppable explicitly, but their stale socket paths are not automatically removed because they provide no ownership proof. This is intentionally conservative and ends with the legacy socket compatibility shim.
