### PR TITLE
fix(gmuxd): stop the snapshot storm between mutually peered nodes

### DIFF
--- a/services/gmuxd/cmd/gmuxd/bootstrap_peering_world_dirty_test.go
+++ b/services/gmuxd/cmd/gmuxd/bootstrap_peering_world_dirty_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/centralstore"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/config"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/peering"
+	central "github.com/gmuxapp/gmux/services/gmuxd/internal/snapshot/central"
+)
+
+// TestComposedPeerSessionCountRequestsWorldRecompose pins the production wiring
+// for the world fields derived from peer sessions.
+//
+// peers[].session_count (peering/world.go) and PeerWorld.LocalPeerSessions come
+// from the same projection the sessions kind is built from, but the peering
+// sessions hook only marks the sessions kind dirty. Before the reciprocal-loop
+// fix the snapshot storm kept the world recomposing continuously, so the count
+// was accidentally always fresh; once the link quiesces, a missing world dirty
+// leaves the browser holding a stale session_count indefinitely.
+func TestComposedPeerSessionCountRequestsWorldRecompose(t *testing.T) {
+	ctx := context.Background()
+	st, err := centralstore.Open(ctx, t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+
+	spoke := newComposedSpoke(t, nil)
+	mgr := peering.NewProjectionManager([]config.PeerConfig{{Name: "box", URL: spoke.URL}}, "self", nil, peering.EventHooks{})
+	var mu sync.Mutex
+	var dirt [][2]bool
+	adapter := &centralPeerAdapter{
+		manager: mgr, store: st,
+		dirty:  func(s, w bool) { mu.Lock(); dirt = append(dirt, [2]bool{s, w}); mu.Unlock() },
+		health: func() central.HealthInfo { return central.HealthInfo{} },
+	}
+	mgr.SetEventHooks(adapter.hooks())
+	mgr.Start()
+	defer mgr.Stop()
+
+	peerCount := func() int {
+		for _, p := range adapter.PeerWorld().Peers {
+			if p.Name == "box" {
+				return p.SessionCount
+			}
+		}
+		return -1
+	}
+	eventually(t, func() bool {
+		for _, p := range adapter.PeerWorld().Peers {
+			if p.Name == "box" && p.Status == "connected" {
+				return true
+			}
+		}
+		return false
+	})
+	since := func(baseline int) (sessions, world bool, all [][2]bool) {
+		mu.Lock()
+		defer mu.Unlock()
+		all = append([][2]bool(nil), dirt[baseline:]...)
+		for _, d := range all {
+			sessions = sessions || d[0]
+			world = world || d[1]
+		}
+		return
+	}
+	mark := func() int { mu.Lock(); defer mu.Unlock(); return len(dirt) }
+
+	// A new session on the peer changes the alive count: both kinds must
+	// be invalidated or the world snapshot serves a stale session_count.
+	base := mark()
+	rows := []peering.SessionProjection{{ID: "s1", Alive: true, Adapter: "claude"}}
+	data, _ := json.Marshal(map[string]any{"sessions": rows})
+	spoke.frames <- fmt.Sprintf("event: snapshot.sessions\ndata: %s\n\n", data)
+	eventually(t, func() bool { return len(mgr.SessionProjections()) == 1 })
+	eventually(t, func() bool { _, w, _ := since(base); return w })
+	if s, w, all := since(base); !s || !w {
+		t.Fatalf("session set changed (count=%d) but dirt=%v: want both sessions and world invalidated", peerCount(), all)
+	}
+	if got := peerCount(); got != 1 {
+		t.Fatalf("world session_count = %d, want 1", got)
+	}
+
+	// Pure metadata churn stays on the sessions kind: promoting it to a world
+	// recompose would put avoidable world frames (and the peer /v1/projects
+	// fetches they trigger) back on the wire.
+	base = mark()
+	rows[0].Title = "renamed"
+	data, _ = json.Marshal(map[string]any{"sessions": rows})
+	spoke.frames <- fmt.Sprintf("event: snapshot.sessions\ndata: %s\n\n", data)
+	eventually(t, func() bool { s, _, _ := since(base); return s })
+	if _, w, all := since(base); w {
+		t.Fatalf("title-only change requested a world recompose: dirt=%v", all)
+	}
+
+	// An identical re-delivery must invalidate nothing at all: that is the
+	// reciprocal-loop guard, observed at the daemon adapter level. A trailing
+	// marker frame makes the assertion deterministic — the spoke writes frames
+	// in order, so once the marker's dirt is visible the no-op frame has been
+	// fully processed.
+	base = mark()
+	data, _ = json.Marshal(map[string]any{"sessions": rows})
+	spoke.frames <- fmt.Sprintf("event: snapshot.sessions\ndata: %s\n\n", data)
+	marker := []peering.SessionProjection{{ID: "s1", Alive: true, Adapter: "claude", Title: "marker"}}
+	data, _ = json.Marshal(map[string]any{"sessions": marker})
+	spoke.frames <- fmt.Sprintf("event: snapshot.sessions\ndata: %s\n\n", data)
+	eventually(t, func() bool { return peerCount() == 1 })
+	eventually(t, func() bool { _, _, all := since(base); return len(all) > 0 })
+	if _, _, all := since(base); len(all) != 1 {
+		t.Fatalf("identical snapshot re-delivery marked dirty: %v (want only the trailing marker's invalidation)", all)
+	}
+	rows = marker
+
+	// The session exiting drops the alive count: world must refresh again.
+	base = mark()
+	rows[0].Alive = false
+	rows[0].ExitCode = new(int)
+	data, _ = json.Marshal(map[string]any{"sessions": rows})
+	spoke.frames <- fmt.Sprintf("event: snapshot.sessions\ndata: %s\n\n", data)
+	eventually(t, func() bool { return peerCount() == 0 })
+	if s, w, all := since(base); !s || !w {
+		t.Fatalf("session exit: dirt=%v, want both kinds", all)
+	}
+}

--- a/services/gmuxd/internal/peering/manager.go
+++ b/services/gmuxd/internal/peering/manager.go
@@ -340,17 +340,50 @@ func (s managerProjectionSink) ReplacePeerSessions(peer string, rows []SessionPr
 		copyRows[i] = cloneProjection(rows[i])
 	}
 	s.m.mu.Lock()
+	prev, hadPrev := s.m.sessions[peer]
 	s.m.sessions[peer] = copyRows
 	local := false
 	if mp := s.m.peers[peer]; mp != nil {
 		local = mp.peer.Config.Local
 	}
 	s.m.mu.Unlock()
+	// No-op suppression (reciprocal-peering feedback loop). A spoke
+	// re-ships its full snapshot on every change and at its coalescer
+	// cadence, so most deliveries carry a projection we already hold.
+	// Propagating those as dirty made two mutually-peered nodes ping-pong
+	// identical snapshots forever: A's dirty hook recomposes and
+	// broadcasts to B's ?as=peer stream, B replaces an equal projection,
+	// marks dirty, broadcasts back. The legacy store had the equivalent
+	// guard in upsertCommon's `unchanged` check; the authority-neutral
+	// projection path (ADR 0026) lost it, so it lives here — at the one
+	// place that owns the peer projection cache, before any sink write or
+	// hook. State transitions (connect/disconnect/removal) still fire via
+	// onStatus/removePeerSessions, which do not route through here.
+	if hadPrev && projectionsEqual(prev, copyRows) {
+		return
+	}
 	if s.m.sink != nil {
 		s.m.sink.ReplacePeerSessions(peer, copyRows)
 	}
 	if s.m.hooks.PeerSessionsDirty != nil {
 		s.m.hooks.PeerSessionsDirty()
+	}
+	// The sessions hook only marks the sessions kind dirty, but part of the
+	// world payload is derived from this same projection: peers[].session_count
+	// (world.go) and PeerWorld.LocalPeerSessions. Before no-op suppression the
+	// reciprocal storm kept the world recomposing continuously so those stayed
+	// accidentally fresh; now the only other world triggers are peer status
+	// transitions and catalog/projects deltas, so a peer whose session set
+	// changes would show a stale count until an unrelated event. Ask for the
+	// world recompose explicitly, and only for the changes that can actually
+	// move those fields.
+	//
+	// This does not reopen a loop: it is reachable only from a real projection
+	// change (the equality gate above already returned for no-ops), and the
+	// world frame it produces reaches the peer as projects-update, which
+	// fetchProjects absorbs unless the fetched catalog really differs.
+	if s.m.hooks.PeerWorldDirty != nil && worldRelevantSessionChange(prev, copyRows) {
+		s.m.hooks.PeerWorldDirty()
 	}
 	if local && s.m.hooks.LocalPeerConnected != nil {
 		s.m.hooks.LocalPeerConnected(peer, copyRows)

--- a/services/gmuxd/internal/peering/peer.go
+++ b/services/gmuxd/internal/peering/peer.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -19,8 +20,9 @@ import (
 // defaultStreamIdleTimeout is the maximum time the SSE stream can be
 // silent before we assume the connection is dead and reconnect. 60s
 // is conservative: real events flow every few seconds on an active
-// spoke, and on an idle spoke the reconnect is invisible (sessions
-// stay in the store, the initial dump produces no-op upserts).
+// spoke, and on an idle spoke the reconnect is cheap (the disconnect
+// prunes this peer's projection and the initial dump on the next
+// connect refills it).
 const defaultStreamIdleTimeout = 60 * time.Second
 
 // Peer manages the connection to a single remote gmuxd instance.
@@ -252,10 +254,22 @@ func (p *Peer) fetchProjects(ctx context.Context) {
 		discovered = []SpokeDiscovered{}
 	}
 	p.mu.Lock()
+	unchanged := p.projectsLoaded &&
+		reflect.DeepEqual(p.cachedProjects, projects) &&
+		reflect.DeepEqual(p.cachedDiscovered, discovered)
 	p.cachedProjects = projects
 	p.cachedDiscovered = discovered
 	p.projectsLoaded = true
 	p.mu.Unlock()
+	// Second reciprocal feedback loop: the hub sets projects-update on
+	// every world frame it ships to ?as=peer subscribers, so a mutual
+	// peer re-fetches /v1/projects, re-broadcasts peer-status, recomposes
+	// its own world, and ships projects-update back. Only signal when the
+	// cached projection actually changed; a re-fetch that produced the
+	// same projects/discovered lists is not externally visible state.
+	if unchanged {
+		return
+	}
 	// Signal a status change so the hub's world coalescer re-emits
 	// snapshot.world with the updated peer_projects entry. Reusing
 	// peer-status keeps the wire surface minimal; the type-name is
@@ -344,12 +358,12 @@ func (p *Peer) run(ctx context.Context) {
 		wasConnected := false
 		err := p.subscribe(ctx, func() { wasConnected = true })
 
-		// Sessions stay in the store across reconnects. The spoke's
-		// initial dump on the next successful connect will upsert
-		// current state; anything the spoke no longer reports stays
-		// as stale-but-visible until the user dismisses it.
-		// RemoveByPeer only runs on intentional peer removal (see
-		// Manager.removePeer).
+		// A disconnect prunes this peer's projection
+		// (Manager.onStatus -> removePeerSessions), so nothing stale
+		// survives the gap and the spoke's initial dump on the next
+		// successful connect is always treated as a first delivery
+		// (no previous projection, so the no-op gate in
+		// managerProjectionSink.ReplacePeerSessions cannot suppress it).
 
 		if err != nil && ctx.Err() == nil {
 			p.mu.Lock()
@@ -520,14 +534,18 @@ func (p *Peer) handleEvent(ctx context.Context, eventType string, data []byte) {
 // removed.
 //
 // A spoke re-ships its full snapshot on every change (and at its
-// coalescer cadence), so the common case is that most sessions in a
-// snapshot are identical to what we already hold. We still call
-// UpsertRemote for each one; the store suppresses the redundant
-// session-upsert broadcast when nothing actually changed (see
-// upsertCommon). That dedup lives in the store rather than here
-// because only the store sees the fully-normalized session — after
-// path canonicalization and unique-slug renumbering — which is what
-// a correct equality check has to compare against.
+// coalescer cadence), so the common case is that the whole snapshot is
+// identical to what we already hold. We still hand every delivery down
+// unconditionally; the no-op dedup lives one layer below, in
+// managerProjectionSink.ReplacePeerSessions (see projectionsEqual),
+// because that is the only place that holds both the previous and the
+// new projection. Dropping that guard makes two mutually-peered nodes
+// ping-pong identical snapshots forever — it is load-bearing, not an
+// optimization.
+//
+// What this function must do first is normalize identity, since the
+// gate below compares whole rows: IDs are namespaced, Peer is stamped,
+// and SocketPath is cleared, so nothing peer-local can read as a change.
 func (p *Peer) applySessionsSnapshot(input any) {
 	var remote []SessionProjection
 	switch rows := input.(type) {

--- a/services/gmuxd/internal/peering/projection.go
+++ b/services/gmuxd/internal/peering/projection.go
@@ -1,5 +1,7 @@
 package peering
 
+import "reflect"
+
 // SessionProjection is the authority-neutral, copyable projection received
 // from a peer's snapshot.sessions stream. It intentionally contains only
 // wire/runtime facts; no durable store type crosses the peering boundary.
@@ -81,4 +83,142 @@ type EventHooks struct {
 	SessionActivity       func(string)
 	LocalPeerConnected    func(string, []SessionProjection)
 	LocalPeerDisconnected func(string)
+}
+
+// projectionsEqual reports whether two peer session projections describe
+// the same runtime facts. It is the no-op gate for snapshot replacement,
+// so it is deliberately:
+//
+//   - order-insensitive (keyed by ID): a peer reordering an unchanged set
+//     must not read as a change, or the reciprocal link never quiesces;
+//   - symmetric about duplicate IDs: a repeated ID on *either* side means the
+//     slices no longer describe the same ID set even at equal length, so the
+//     comparison degrades to "changed" rather than silently matching two new
+//     rows against one cached row;
+//   - nil/empty-insensitive for Command and Remotes: encoders differ on
+//     `null` vs `[]`/`{}` and the distinction carries no meaning;
+//   - value-comparing for the *int / *SessionStatus pointers, since the
+//     rows are freshly cloned on every delivery.
+//
+// Everything else is compared exactly. When in doubt it must return false:
+// a false negative costs one redundant broadcast, a false positive hides a
+// real update forever (nothing else re-drives peer projections).
+func projectionsEqual(a, b []SessionProjection) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	index := make(map[string]*SessionProjection, len(a))
+	for i := range a {
+		if _, dup := index[a[i].ID]; dup {
+			return false // duplicate IDs: fall back to "changed"
+		}
+		index[a[i].ID] = &a[i]
+	}
+	seen := make(map[string]struct{}, len(b))
+	for i := range b {
+		if _, dup := seen[b[i].ID]; dup {
+			return false // duplicate IDs: fall back to "changed"
+		}
+		seen[b[i].ID] = struct{}{}
+		prev, ok := index[b[i].ID]
+		if !ok || !projectionEqual(*prev, b[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// worldRelevantSessionChange reports whether a peer projection replacement can
+// move a field the world snapshot derives from peer sessions: the per-peer
+// alive session count (world.go) and the local-peer presence set keyed by
+// session ID. It is deliberately narrower than projectionsEqual — pure
+// metadata churn (title, activity timestamps) belongs to the sessions kind
+// only, and promoting it to a world recompose would put avoidable world
+// frames (and therefore peer /v1/projects fetches) back on the wire.
+//
+// Row counts are not a proxy for ID-set size: a snapshot may repeat an ID, in
+// which case the same number of rows carries a *smaller* set and
+// PeerWorld.LocalPeerSessions (keyed by ID) really does move. Both sides are
+// therefore compared by distinct-ID count as well as by membership.
+func worldRelevantSessionChange(prev, next []SessionProjection) bool {
+	if len(prev) != len(next) {
+		return true
+	}
+	aliveBefore, aliveAfter := 0, 0
+	ids := make(map[string]struct{}, len(prev))
+	for i := range prev {
+		if prev[i].Alive {
+			aliveBefore++
+		}
+		ids[prev[i].ID] = struct{}{}
+	}
+	nextIDs := make(map[string]struct{}, len(next))
+	for i := range next {
+		if next[i].Alive {
+			aliveAfter++
+		}
+		nextIDs[next[i].ID] = struct{}{}
+		if _, ok := ids[next[i].ID]; !ok {
+			return true
+		}
+	}
+	if len(ids) != len(nextIDs) {
+		return true // duplicate IDs collapsed (or un-collapsed) the ID set
+	}
+	return aliveBefore != aliveAfter
+}
+
+func projectionEqual(x, y SessionProjection) bool {
+	if !equalStringSlice(x.Command, y.Command) || !equalStringMap(x.Remotes, y.Remotes) {
+		return false
+	}
+	if !equalIntPtr(x.ExitCode, y.ExitCode) || !equalStatus(x.Status, y.Status) {
+		return false
+	}
+	// Compare the remaining scalar fields by zeroing the ones handled above
+	// so a newly added field is included by default (fail-open to "changed"
+	// only if it differs, never silently ignored).
+	x.Command, y.Command = nil, nil
+	x.Remotes, y.Remotes = nil, nil
+	x.ExitCode, y.ExitCode = nil, nil
+	x.Status, y.Status = nil, nil
+	return reflect.DeepEqual(x, y)
+}
+
+func equalStringSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func equalStringMap(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if w, ok := b[k]; !ok || v != w {
+			return false
+		}
+	}
+	return true
+}
+
+func equalIntPtr(a, b *int) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
+}
+
+func equalStatus(a, b *SessionStatus) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
 }

--- a/services/gmuxd/internal/peering/projection_equal_test.go
+++ b/services/gmuxd/internal/peering/projection_equal_test.go
@@ -1,0 +1,261 @@
+package peering
+
+import (
+	"sync/atomic"
+	"testing"
+
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/config"
+)
+
+// These tests pin the three semantics projectionsEqual is built around
+// (see its docstring). Each one is a mutation guard: a plausible
+// "simplification" of the comparator — positional compare, pointer-identity
+// compare, plain reflect.DeepEqual on the collections — reopens the
+// reciprocal snapshot loop or hides a real update, and nothing else in the
+// suite notices.
+
+func intPtr(v int) *int { return &v }
+
+// Ordering: ADR 0001 gives deterministic wire ordering today, but an
+// order-sensitive gate would turn any future reordering into a permanent loop.
+func TestProjectionsEqualIsOrderInsensitive(t *testing.T) {
+	a := []SessionProjection{
+		{ID: "s1", Adapter: "claude", Alive: true},
+		{ID: "s2", Adapter: "codex", Alive: true},
+		{ID: "s3", Adapter: "claude", Alive: false},
+	}
+	b := []SessionProjection{a[2], a[0], a[1]}
+	if !projectionsEqual(a, b) {
+		t.Fatalf("reordered identical set reported as changed (order-sensitive gate = permanent loop)")
+	}
+	// A reorder that also carries a real change must still be caught.
+	b[0].Alive = true
+	if projectionsEqual(a, b) {
+		t.Fatalf("reorder + content change reported as equal")
+	}
+}
+
+// Duplicate IDs must degrade to "changed" from whichever side they arrive on:
+// the previous projection (index build) or the incoming one. Matching two
+// incoming rows against one cached row silently drops the cached row's peer.
+func TestProjectionsEqualRejectsDuplicateIDsSymmetrically(t *testing.T) {
+	distinct := []SessionProjection{{ID: "s1", Alive: true}, {ID: "s2", Alive: true}}
+	dupes := []SessionProjection{{ID: "s1", Alive: true}, {ID: "s1", Alive: true}}
+	if projectionsEqual(distinct, dupes) {
+		t.Errorf("duplicate ID in the incoming snapshot reported equal: the s2 row would be dropped with no dirty signal")
+	}
+	if projectionsEqual(dupes, distinct) {
+		t.Errorf("duplicate ID in the cached snapshot reported equal")
+	}
+	if projectionsEqual(dupes, dupes) {
+		t.Errorf("duplicate IDs on both sides must still degrade to \"changed\"")
+	}
+}
+
+// Regression at the manager level: the asymmetric case used to update the
+// cache without firing PeerSessionsDirty, so the composer kept serving the
+// previous set until an unrelated event.
+func TestReplacePeerSessionsFiresOnDuplicateIDSnapshot(t *testing.T) {
+	var dirty atomic.Int64
+	m := NewProjectionManager(nil, "self", nil, EventHooks{PeerSessionsDirty: func() { dirty.Add(1) }})
+	m.ReplacePeerSessions("p", []SessionProjection{{ID: "s1@p", Peer: "p", Alive: true}, {ID: "s2@p", Peer: "p", Alive: true}})
+	if dirty.Load() != 1 {
+		t.Fatalf("first snapshot: dirty=%d, want 1", dirty.Load())
+	}
+	m.ReplacePeerSessions("p", []SessionProjection{{ID: "s1@p", Peer: "p", Alive: true}, {ID: "s1@p", Peer: "p", Alive: true}})
+	if dirty.Load() != 2 {
+		t.Fatalf("duplicate-ID snapshot: dirty=%d, want 2 (cache changed, so downstream must be told)", dirty.Load())
+	}
+}
+
+// Pointer fields are compared by value: rows are freshly cloned on every
+// delivery, so pointer identity never matches and an identity compare would
+// make every re-delivery look changed (loop) — while for the exit path it is
+// the value change that must be seen.
+func TestProjectionEqualComparesPointerFieldsByValue(t *testing.T) {
+	exited := func(code int) SessionProjection {
+		return SessionProjection{
+			ID: "s1", Adapter: "claude", Alive: false, ExitedAt: "t2",
+			ExitCode: intPtr(code), Status: &SessionStatus{Working: false},
+		}
+	}
+	if !projectionEqual(exited(137), exited(137)) {
+		t.Errorf("equal ExitCode values with distinct pointers reported as changed")
+	}
+	if projectionEqual(exited(137), exited(0)) {
+		t.Errorf("differing ExitCode values reported as equal: a real exit would be suppressed")
+	}
+	nilCode := exited(0)
+	nilCode.ExitCode = nil
+	if projectionEqual(nilCode, exited(0)) {
+		t.Errorf("nil vs &0 ExitCode reported as equal: the exit transition would be hidden")
+	}
+	working := exited(1)
+	working.Status = &SessionStatus{Working: true}
+	if projectionEqual(exited(1), working) {
+		t.Errorf("differing Status values reported as equal")
+	}
+	noStatus := exited(1)
+	noStatus.Status = nil
+	if projectionEqual(exited(1), noStatus) {
+		t.Errorf("nil vs non-nil Status reported as equal")
+	}
+}
+
+// End-to-end version of the above through the suppression gate: a session
+// that exits must always fire, and its re-delivery must not.
+func TestReplacePeerSessionsHandlesExitTransition(t *testing.T) {
+	var dirty atomic.Int64
+	m := NewProjectionManager(nil, "self", nil, EventHooks{PeerSessionsDirty: func() { dirty.Add(1) }})
+	alive := []SessionProjection{{ID: "s1@p", Peer: "p", Adapter: "claude", Alive: true}}
+	m.ReplacePeerSessions("p", alive)
+	exited := []SessionProjection{{ID: "s1@p", Peer: "p", Adapter: "claude", Alive: false, ExitedAt: "t2", ExitCode: intPtr(137)}}
+	m.ReplacePeerSessions("p", exited)
+	if dirty.Load() != 2 {
+		t.Fatalf("exit transition: dirty=%d, want 2", dirty.Load())
+	}
+	again := []SessionProjection{{ID: "s1@p", Peer: "p", Adapter: "claude", Alive: false, ExitedAt: "t2", ExitCode: intPtr(137)}}
+	m.ReplacePeerSessions("p", again)
+	if dirty.Load() != 2 {
+		t.Fatalf("re-delivered exited session: dirty=%d, want 2 (no-op must be suppressed)", dirty.Load())
+	}
+	other := []SessionProjection{{ID: "s1@p", Peer: "p", Adapter: "claude", Alive: false, ExitedAt: "t2", ExitCode: intPtr(1)}}
+	m.ReplacePeerSessions("p", other)
+	if dirty.Load() != 3 {
+		t.Fatalf("different exit code: dirty=%d, want 3", dirty.Load())
+	}
+}
+
+// nil vs empty collections: JSON encoders disagree on null vs []/{} and the
+// distinction carries no meaning here. A refactor to plain reflect.DeepEqual
+// on Command/Remotes would reintroduce the split and with it a live loop.
+func TestProjectionEqualTreatsNilAndEmptyCollectionsAsEqual(t *testing.T) {
+	base := SessionProjection{ID: "s1", Adapter: "claude", Alive: true}
+	empty := base
+	empty.Command = []string{}
+	empty.Remotes = map[string]string{}
+	if !projectionEqual(base, empty) {
+		t.Errorf("nil vs empty Command/Remotes reported as changed")
+	}
+	if !projectionsEqual([]SessionProjection{base}, []SessionProjection{empty}) {
+		t.Errorf("nil vs empty collections not tolerated through projectionsEqual")
+	}
+	populated := base
+	populated.Command = []string{"claude"}
+	if projectionEqual(base, populated) {
+		t.Errorf("nil vs non-empty Command reported as equal")
+	}
+	remotes := base
+	remotes.Remotes = map[string]string{"origin": "git@x"}
+	if projectionEqual(base, remotes) {
+		t.Errorf("nil vs non-empty Remotes reported as equal")
+	}
+	// Same length, different content, for both collection helpers.
+	other := populated
+	other.Command = []string{"codex"}
+	if projectionEqual(populated, other) {
+		t.Errorf("same-length differing Command reported as equal")
+	}
+	remotes2 := remotes
+	remotes2.Remotes = map[string]string{"origin": "git@y"}
+	if projectionEqual(remotes, remotes2) {
+		t.Errorf("same-length differing Remotes reported as equal")
+	}
+	// Empty projections on both sides (nil vs empty slice) are equal.
+	if !projectionsEqual(nil, []SessionProjection{}) {
+		t.Errorf("nil vs empty projection slice reported as changed")
+	}
+}
+
+// The whole-slice edges the gate relies on: first delivery always fires
+// (including an empty one), and N->0 / 0->N are real changes.
+func TestReplacePeerSessionsEmptySnapshotSemantics(t *testing.T) {
+	var dirty atomic.Int64
+	m := NewProjectionManager([]config.PeerConfig{}, "self", nil, EventHooks{PeerSessionsDirty: func() { dirty.Add(1) }})
+	m.ReplacePeerSessions("p", nil)
+	if dirty.Load() != 1 {
+		t.Fatalf("first (empty) snapshot: dirty=%d, want 1", dirty.Load())
+	}
+	m.ReplacePeerSessions("p", []SessionProjection{})
+	if dirty.Load() != 1 {
+		t.Fatalf("empty re-delivery: dirty=%d, want 1", dirty.Load())
+	}
+	m.ReplacePeerSessions("p", []SessionProjection{{ID: "s1@p", Peer: "p", Alive: true}})
+	if dirty.Load() != 2 {
+		t.Fatalf("0->1: dirty=%d, want 2", dirty.Load())
+	}
+	m.ReplacePeerSessions("p", nil)
+	if dirty.Load() != 3 {
+		t.Fatalf("1->0: dirty=%d, want 3", dirty.Load())
+	}
+}
+
+// worldRelevantSessionChange is the second gate on the same delivery: it
+// decides whether a real projection change also moves a world-derived field
+// (peers[].session_count, PeerWorld.LocalPeerSessions). It must be *narrow*
+// (metadata churn must not put world frames back on the wire) but never
+// unsound. The two tests below pin both directions together, so neither
+// "return true" nor a re-narrowing that drops the distinct-ID check survives.
+
+func alive(id string) SessionProjection { return SessionProjection{ID: id, Peer: "p", Alive: true} }
+func dead(id string) SessionProjection  { return SessionProjection{ID: id, Peer: "p", Alive: false} }
+func titled(id, t string) SessionProjection {
+	s := alive(id)
+	s.Title = t
+	return s
+}
+
+// Regression (D-1): a repeated ID carries the same row count, the same alive
+// count and no unknown ID, yet the ID *set* shrank — LocalPeerSessions is
+// keyed by ID, so b's placement row silently leaves the world. Equal row
+// counts are not a proxy for equal ID-set size.
+func TestWorldRelevantSessionChangeDetectsDuplicateIDCollapse(t *testing.T) {
+	prev := []SessionProjection{alive("a@p"), alive("b@p")}
+	next := []SessionProjection{alive("a@p"), alive("a@p")}
+	if !worldRelevantSessionChange(prev, next) {
+		t.Errorf("ID-set collapse via duplicate IDs reported as world-irrelevant")
+	}
+	// The reverse delivery (duplicates -> distinct set) restores b and is
+	// equally world-relevant; a one-sided distinct count misses it.
+	if !worldRelevantSessionChange(next, prev) {
+		t.Errorf("ID-set expansion out of duplicate IDs reported as world-irrelevant")
+	}
+	// And it must survive the trip through the manager: the world hook has
+	// to actually fire for such a delivery.
+	var world atomic.Int64
+	m := NewProjectionManager([]config.PeerConfig{}, "self", nil, EventHooks{PeerWorldDirty: func() { world.Add(1) }})
+	m.ReplacePeerSessions("p", prev)
+	before := world.Load()
+	m.ReplacePeerSessions("p", next)
+	if world.Load() == before {
+		t.Errorf("duplicate-ID collapse did not request a world recompose")
+	}
+}
+
+// Narrowness control: everything the predicate deliberately excludes must
+// stay excluded, and everything it covers must stay covered. Without this a
+// blanket `return true` would "fix" the regression above while restoring the
+// world-frame chatter the gate exists to prevent.
+func TestWorldRelevantSessionChangeStaysNarrow(t *testing.T) {
+	cases := []struct {
+		name       string
+		prev, next []SessionProjection
+		want       bool
+	}{
+		{"identical", []SessionProjection{alive("a@p")}, []SessionProjection{alive("a@p")}, false},
+		{"title only", []SessionProjection{titled("a@p", "x")}, []SessionProjection{titled("a@p", "y")}, false},
+		{"reordered", []SessionProjection{alive("a@p"), dead("b@p")}, []SessionProjection{dead("b@p"), alive("a@p")}, false},
+		{"alive/dead swap at constant count", []SessionProjection{alive("a@p"), dead("b@p")}, []SessionProjection{dead("a@p"), alive("b@p")}, false},
+		{"same duplicates on both sides", []SessionProjection{alive("a@p"), alive("a@p")}, []SessionProjection{alive("a@p"), alive("a@p")}, false},
+		{"row added", []SessionProjection{alive("a@p")}, []SessionProjection{alive("a@p"), alive("b@p")}, true},
+		{"row removed", []SessionProjection{alive("a@p"), alive("b@p")}, []SessionProjection{alive("a@p")}, true},
+		{"ID substituted", []SessionProjection{alive("a@p")}, []SessionProjection{alive("c@p")}, true},
+		{"alive count delta", []SessionProjection{alive("a@p")}, []SessionProjection{dead("a@p")}, true},
+		{"duplicate collapse", []SessionProjection{alive("a@p"), alive("b@p")}, []SessionProjection{alive("a@p"), alive("a@p")}, true},
+	}
+	for _, tc := range cases {
+		if got := worldRelevantSessionChange(tc.prev, tc.next); got != tc.want {
+			t.Errorf("%s: worldRelevantSessionChange = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}

--- a/services/gmuxd/internal/peering/reciprocal_loop_test.go
+++ b/services/gmuxd/internal/peering/reciprocal_loop_test.go
@@ -1,0 +1,338 @@
+package peering
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/config"
+)
+
+// loopNode models one gmuxd in a reciprocal peer link, with the same
+// causal chain production has:
+//
+//	peer SSE snapshot.sessions -> Manager.ReplacePeerSessions
+//	  -> EventHooks.PeerSessionsDirty  (composer MarkDirty)
+//	  -> compose + fanout               (broadcast)
+//	  -> /v1/events?as=peer subscribers get the owned-only frame
+//
+// The node's owned sessions never change, so a correct system must
+// reach quiescence: each side ships its snapshot once (plus reconnect
+// re-sends) and then goes silent.
+type loopNode struct {
+	name   string
+	owned  []SessionProjection
+	server *httptest.Server
+
+	mu   sync.Mutex
+	subs map[chan []SessionProjection]struct{}
+
+	sent           atomic.Int64 // snapshot.sessions frames written to the wire
+	projectUpdates atomic.Int64 // projects-update events written to the wire
+	projectFetches atomic.Int64 // GET /v1/projects served
+	slug           atomic.Value // string: slug served by /v1/projects
+}
+
+func newLoopNode(t *testing.T, name string, ownedCount int) *loopNode {
+	t.Helper()
+	n := &loopNode{name: name, subs: map[chan []SessionProjection]struct{}{}}
+	n.slug.Store("proj-" + name)
+	for i := 0; i < ownedCount; i++ {
+		n.owned = append(n.owned, SessionProjection{
+			ID:      fmt.Sprintf("sess-%s-%d", name, i),
+			Adapter: "claude",
+			Alive:   true,
+			Cwd:     "/home/u/work",
+			Command: []string{"claude", "--resume"},
+			Status:  &SessionStatus{Working: false},
+		})
+	}
+	if n.owned == nil {
+		n.owned = []SessionProjection{} // keep nil reserved for the world-frame marker
+	}
+	n.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		// apiclient requires the {"ok":true,"data":{...}} envelope; a bare
+		// object makes GetHealth/GetProjects fail with ok=false and
+		// fetchProjects bail before any of the peering logic runs.
+		case "/v1/health":
+			_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "data": map[string]any{"version": "test", "node_id": name}})
+		case "/v1/projects":
+			n.projectFetches.Add(1)
+			_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "data": map[string]any{
+				"configured": []any{map[string]any{"slug": n.slug.Load().(string), "match": []any{map[string]any{"path": "/w"}}}},
+				"discovered": []any{},
+			}})
+		case "/v1/events":
+			w.Header().Set("Content-Type", "text/event-stream")
+			flusher := w.(http.Flusher)
+			ch := make(chan []SessionProjection, 64)
+			n.mu.Lock()
+			n.subs[ch] = struct{}{}
+			n.mu.Unlock()
+			defer func() {
+				n.mu.Lock()
+				delete(n.subs, ch)
+				n.mu.Unlock()
+			}()
+			write := func(rows []SessionProjection) bool {
+				if rows == nil {
+					// World frame stand-in: every world frame the fanout
+					// ships to ?as=peer carries projects-update
+					// (central_helpers.go), which makes the peer re-fetch
+					// /v1/projects. That is loop B's cycle.
+					if _, err := fmt.Fprint(w, "event: projects-update\ndata: {\"type\":\"projects-update\"}\n\n"); err != nil {
+						return false
+					}
+					flusher.Flush()
+					n.projectUpdates.Add(1)
+					return true
+				}
+				b, _ := json.Marshal(map[string]any{"sessions": rows})
+				if _, err := fmt.Fprintf(w, "event: snapshot.sessions\ndata: %s\n\n", b); err != nil {
+					return false
+				}
+				flusher.Flush()
+				n.sent.Add(1)
+				return true
+			}
+			// Initial frame, exactly like the fanout's cached snapshot.
+			if !write(n.owned) {
+				return
+			}
+			for {
+				select {
+				case <-r.Context().Done():
+					return
+				case rows := <-ch:
+					if !write(rows) {
+						return
+					}
+				}
+			}
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(n.server.Close)
+	return n
+}
+
+// broadcast is the composer+fanout stand-in: any dirty signal recomposes
+// and ships the (unchanged) owned-only frame to every ?as=peer subscriber.
+func (n *loopNode) broadcast() {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	for ch := range n.subs {
+		select {
+		case ch <- n.owned:
+		default:
+		}
+	}
+}
+
+// worldDirty is the world-kind stand-in: any world recompose ships a frame
+// that carries projects-update to every ?as=peer subscriber.
+func (n *loopNode) worldDirty() {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	for ch := range n.subs {
+		select {
+		case ch <- nil:
+		default:
+		}
+	}
+}
+
+// wireEvents counts everything this node puts on (or serves off) the peer
+// link: snapshot.sessions frames, projects-update frames, and /v1/projects
+// requests. A node drives all three paths, so a quiescence assertion that
+// looks at only one of them can pass while another spins.
+func (n *loopNode) wireEvents() int64 {
+	return n.sent.Load() + n.projectUpdates.Load() + n.projectFetches.Load()
+}
+
+// loopBEvents counts everything loop B puts on the wire in both directions.
+func (n *loopNode) loopBEvents() int64 { return n.projectUpdates.Load() + n.projectFetches.Load() }
+
+// TestReciprocalPeerLinkReachesQuiescence wires two nodes as mutual peers
+// and asserts the link goes silent once both snapshots have converged.
+//
+// Without no-op suppression in managerProjectionSink.ReplacePeerSessions
+// this spins at CPU speed and the frame counters run into the thousands.
+//
+// The assertion covers every wire path the pair drives, not just
+// snapshot.sessions: since PeerWorldDirty was added to the sessions path,
+// these same two connections also carry projects-update frames and
+// /v1/projects fetches, and a test named "reaches quiescence" that ignored
+// them could pass with loop B spinning at HTTP speed.
+func TestReciprocalPeerLinkReachesQuiescence(t *testing.T) {
+	a := newLoopNode(t, "node-a", 8)
+	b := newLoopNode(t, "node-b", 8)
+
+	mgrA := NewProjectionManager(
+		[]config.PeerConfig{{Name: "node-b", URL: b.server.URL}},
+		"node-a", nil, EventHooks{PeerSessionsDirty: a.broadcast, PeerWorldDirty: a.worldDirty},
+	)
+	mgrB := NewProjectionManager(
+		[]config.PeerConfig{{Name: "node-a", URL: a.server.URL}},
+		"node-b", nil, EventHooks{PeerSessionsDirty: b.broadcast, PeerWorldDirty: b.worldDirty},
+	)
+	mgrA.Start()
+	defer mgrA.Stop()
+	mgrB.Start()
+	defer mgrB.Stop()
+
+	// Wait for convergence: both managers hold the other's 8 sessions.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(mgrA.SessionProjections()) == 8 && len(mgrB.SessionProjections()) == 8 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := len(mgrA.SessionProjections()); got != 8 {
+		t.Fatalf("node-a never converged: %d sessions", got)
+	}
+	if got := len(mgrB.SessionProjections()); got != 8 {
+		t.Fatalf("node-b never converged: %d sessions", got)
+	}
+
+	// Quiescence window: after convergence nothing changes, so neither side
+	// should produce further traffic on any path. Tolerance is the sum of
+	// the two loops' in-flight allowances: <=2 straggler snapshot.sessions
+	// frames (one per direction, still being written when the window opens)
+	// plus loop B's <=4 (a projects-update and its fetch, per direction).
+	const tolerance = 6
+	settle := a.wireEvents() + b.wireEvents()
+	time.Sleep(500 * time.Millisecond)
+	after := a.wireEvents() + b.wireEvents()
+	if delta := after - settle; delta > tolerance {
+		t.Fatalf("reciprocal link did not quiesce: %d wire events in 500ms "+
+			"(a sess=%d upd=%d fetch=%d, b sess=%d upd=%d fetch=%d); "+
+			"identical snapshots or unchanged catalogs are being re-propagated "+
+			"in a feedback loop", delta,
+			a.sent.Load(), a.projectUpdates.Load(), a.projectFetches.Load(),
+			b.sent.Load(), b.projectUpdates.Load(), b.projectFetches.Load())
+	}
+}
+
+// TestReplacePeerSessionsSuppressesEqualSnapshot is the unit-level guard:
+// re-delivering a byte-identical projection must not fire dirty hooks.
+func TestReplacePeerSessionsSuppressesEqualSnapshot(t *testing.T) {
+	var dirty atomic.Int64
+	m := NewProjectionManager(nil, "self", nil, EventHooks{PeerSessionsDirty: func() { dirty.Add(1) }})
+	rows := []SessionProjection{{
+		ID: "s1@p", Peer: "p", Adapter: "claude", Alive: true,
+		Command: []string{"claude"}, Remotes: map[string]string{"origin": "git@x"},
+		Status: &SessionStatus{Working: true},
+	}}
+	m.ReplacePeerSessions("p", rows)
+	if dirty.Load() != 1 {
+		t.Fatalf("first snapshot: dirty=%d, want 1", dirty.Load())
+	}
+	// Fresh but equal value (different backing arrays/pointers).
+	again := []SessionProjection{{
+		ID: "s1@p", Peer: "p", Adapter: "claude", Alive: true,
+		Command: []string{"claude"}, Remotes: map[string]string{"origin": "git@x"},
+		Status: &SessionStatus{Working: true},
+	}}
+	m.ReplacePeerSessions("p", again)
+	if dirty.Load() != 1 {
+		t.Fatalf("equal snapshot re-delivered: dirty=%d, want 1 (no-op must be suppressed)", dirty.Load())
+	}
+	// A real change must still fire.
+	changed := []SessionProjection{{
+		ID: "s1@p", Peer: "p", Adapter: "claude", Alive: false,
+		Command: []string{"claude"}, Remotes: map[string]string{"origin": "git@x"},
+		Status: &SessionStatus{Working: true},
+	}}
+	m.ReplacePeerSessions("p", changed)
+	if dirty.Load() != 2 {
+		t.Fatalf("changed snapshot: dirty=%d, want 2", dirty.Load())
+	}
+}
+
+// TestReciprocalPeerLinkQuiescesProjectsUpdateLoop covers loop B, the
+// world/projects half of the feedback loop, which is independent of and
+// self-sustaining without loop A:
+//
+//	world frame -> projects-update on ?as=peer -> peer fetchProjects
+//	  -> onStatus -> PeerWorldDirty -> world frame (back the other way)
+//
+// Both nodes serve a stable project catalog, so after the first fetch each
+// side must go silent. Without the unchanged-guard in fetchProjects this
+// spins at HTTP speed (tens of thousands of events and /v1/projects requests
+// per second).
+func TestReciprocalPeerLinkQuiescesProjectsUpdateLoop(t *testing.T) {
+	a := newLoopNode(t, "node-a", 0)
+	b := newLoopNode(t, "node-b", 0)
+
+	mgrA := NewProjectionManager(
+		[]config.PeerConfig{{Name: "node-b", URL: b.server.URL}},
+		"node-a", nil, EventHooks{PeerSessionsDirty: a.broadcast, PeerWorldDirty: a.worldDirty},
+	)
+	mgrB := NewProjectionManager(
+		[]config.PeerConfig{{Name: "node-a", URL: a.server.URL}},
+		"node-b", nil, EventHooks{PeerSessionsDirty: b.broadcast, PeerWorldDirty: b.worldDirty},
+	)
+	mgrA.Start()
+	defer mgrA.Stop()
+	mgrB.Start()
+	defer mgrB.Stop()
+
+	cachedSlug := func(m *Manager, peer string) string {
+		p := m.GetPeer(peer)
+		if p == nil {
+			return ""
+		}
+		if rows, ok := p.CachedProjects(); ok && len(rows) == 1 {
+			return rows[0].Slug
+		}
+		return ""
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if cachedSlug(mgrA, "node-b") == "proj-node-b" && cachedSlug(mgrB, "node-a") == "proj-node-a" {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := cachedSlug(mgrA, "node-b"); got != "proj-node-b" {
+		t.Fatalf("node-a never loaded node-b's projects: %q", got)
+	}
+	if got := cachedSlug(mgrB, "node-a"); got != "proj-node-a" {
+		t.Fatalf("node-b never loaded node-a's projects: %q", got)
+	}
+
+	settle := a.loopBEvents() + b.loopBEvents()
+	time.Sleep(500 * time.Millisecond)
+	after := a.loopBEvents() + b.loopBEvents()
+	if delta := after - settle; delta > 4 {
+		t.Fatalf("loop B did not quiesce: %d projects-update/fetch events in 500ms "+
+			"(a upd=%d fetch=%d, b upd=%d fetch=%d); an unchanged re-fetch is being "+
+			"reported as a status change", delta,
+			a.projectUpdates.Load(), a.projectFetches.Load(),
+			b.projectUpdates.Load(), b.projectFetches.Load())
+	}
+
+	// Liveness: suppression must not deafen the link. A genuine catalog
+	// change on B still has to reach A.
+	b.slug.Store("proj-changed")
+	b.worldDirty()
+	deadline = time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if cachedSlug(mgrA, "node-b") == "proj-changed" {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := cachedSlug(mgrA, "node-b"); got != "proj-changed" {
+		t.Fatalf("real project change not propagated: cached slug %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

- suppress semantically unchanged peer session projections before they dirty the central composer
- suppress unchanged peer project/discovery refreshes
- recompose world state only when peer session identity/liveness changes affect world-derived fields
- add deterministic reciprocal-link convergence tests and mutation-resistant equality coverage

## Production evidence

Two mutually peered hosts entered a snapshot feedback loop after the central-store cutover:

- 138–160% gmuxd CPU on each host
- 147 MB of SSE traffic in 3 seconds
- 1,094 of 1,095 captured `snapshot.sessions` frames were byte-identical

With this commit deployed on both hosts, reciprocal links remain connected and idle CPU falls to low single digits with state checks passing.

## Validation

- `go test -race -count=10 ./internal/peering -run 'Reciprocal|Projection|ReplacePeerSessions'`
- `go test -race -count=5 ./cmd/gmuxd -run 'ComposedPeer'`
- `go test ./...` in `services/gmuxd`
- adversarial anchor and mutation delta reviews: integrate
- frontend-enabled production build installed and validated on gmux-aquilo and gmux-hs

## Follow-ups

Non-blocking: fence out-of-order concurrent project fetches, make producer-side `ProjectsUpdate` precise, and coalesce fanout frame kinds under subscriber backpressure.
