### PR TITLE
fix(gmuxd): republish session stamps when placement changes

### DIFF
--- a/apps/gmux-web/src/store.test.ts
+++ b/apps/gmux-web/src/store.test.ts
@@ -7,7 +7,7 @@ import {
   sessionStaleness, peers, peerAppearance, peerStatusByName,
   isSessionUnavailable, urlPath, urlSearch, filteredSessions, sidebarSessions, selectedId, folders,
   navigateToSession, setNavigate,
-  applyPending, _rawSessions, _rawWorld, _setRawWorld, _pendingMutations,
+  applyPending, _rawSessions, _setRawWorld, _pendingMutations,
   applySessionsSnapshot,
   toUISession, localHostLabel, parseConnectURL, unreadCount, discovered,
   view, duplicateConversationFiles,
@@ -144,7 +144,7 @@ describe('reorder failures are surfaced, never silent', () => {
   beforeEach(() => { toasts.value = []; _pendingMutations.value = [] })
   afterEach(() => { vi.unstubAllGlobals(); toasts.value = []; _pendingMutations.value = [] })
 
-  it('toasts and retracts the overlay when the server rejects a local reorder', async () => {
+  it('toasts when the server rejects a local reorder', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
       ok: false, status: 500, statusText: 'Internal Server Error',
       text: () => Promise.resolve(JSON.stringify({ error: { message: 'failed to save projects' } })),
@@ -153,10 +153,12 @@ describe('reorder failures are surfaced, never silent', () => {
     expect(toasts.value[0]).toMatchObject({
       kind: 'error', message: 'Reorder failed: failed to save projects',
     })
+    // No overlay to retract: the UI still shows the server's order, which
+    // after a rejection is still the truth.
     expect(_pendingMutations.value).toHaveLength(0)
   })
 
-  it('toasts when a peer reorder is rejected (no overlay to retract)', async () => {
+  it('toasts when a peer reorder is rejected', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
       ok: false, status: 502, statusText: 'Bad Gateway',
       text: () => Promise.resolve(''),
@@ -1187,10 +1189,7 @@ describe('pending mutations overlay', () => {
   describe('applyPending (pure function)', () => {
     it('returns raw unchanged when there are no mutations', () => {
       const sess = [makeSession({ id: 'a' })]
-      const projs: ProjectItem[] = [{ slug: 'p', match: [] }]
-      const out = applyPending(sess, projs, [])
-      expect(out.sessions).toBe(sess)
-      expect(out.projects).toBe(projs)
+      expect(applyPending(sess, [])).toBe(sess)
     })
 
     it('mark-read clears unread and status.error on the targeted session', () => {
@@ -1199,32 +1198,27 @@ describe('pending mutations overlay', () => {
         makeSession({ id: 'b', unread: true }),
       ]
       const m: PendingMutation = { kind: 'mark-read', id: 'a', at: 0 }
-      const out = applyPending(sess, [], [m])
-      expect(out.sessions[0].unread).toBe(false)
-      expect(out.sessions[0].status?.error).toBe(false)
+      const out = applyPending(sess, [m])
+      expect(out[0].unread).toBe(false)
+      expect(out[0].status?.error).toBe(false)
       // Untouched session keeps its flags.
-      expect(out.sessions[1].unread).toBe(true)
+      expect(out[1].unread).toBe(true)
     })
 
     it('dismiss removes the targeted session', () => {
       const sess = [makeSession({ id: 'a' }), makeSession({ id: 'b' })]
-      const out = applyPending(sess, [], [{ kind: 'dismiss', id: 'a', at: 0 }])
-      expect(out.sessions.map(s => s.id)).toEqual(['b'])
-    })
-
-    it('reorder replaces a project sessions array', () => {
-      const projs: ProjectItem[] = [{ slug: 'p', match: [], sessions: ['x', 'y'] }]
-      const out = applyPending([], projs, [{ kind: 'reorder', slug: 'p', sessions: ['y', 'x'], at: 0 }])
-      expect(out.projects[0].sessions).toEqual(['y', 'x'])
+      const out = applyPending(sess, [{ kind: 'dismiss', id: 'a', at: 0 }])
+      expect(out.map(s => s.id)).toEqual(['b'])
     })
 
     it('stacks multiple mutations in order', () => {
-      const projs: ProjectItem[] = [{ slug: 'p', match: [], sessions: ['x'] }]
-      const out = applyPending([], projs, [
-        { kind: 'reorder', slug: 'p', sessions: ['a', 'b'], at: 0 },
-        { kind: 'reorder', slug: 'p', sessions: ['b', 'a'], at: 0 },
+      const sess = [makeSession({ id: 'a', unread: true }), makeSession({ id: 'b' })]
+      const out = applyPending(sess, [
+        { kind: 'mark-read', id: 'a', at: 0 },
+        { kind: 'dismiss', id: 'b', at: 0 },
       ])
-      expect(out.projects[0].sessions).toEqual(['b', 'a'])
+      expect(out.map(s => s.id)).toEqual(['a'])
+      expect(out[0].unread).toBe(false)
     })
   })
 
@@ -1243,14 +1237,6 @@ describe('pending mutations overlay', () => {
       dismissSession('a')
       expect(sessions.value.map(s => s.id)).toEqual(['b'])
       expect(_rawSessions.value.map(s => s.id)).toEqual(['a', 'b'])
-    })
-
-    it('reorderSessions reflects via the projects overlay', () => {
-      _setRawWorld({ projects: [{ slug: 'p', match: [], sessions: ['x', 'y'] }] })
-      reorderSessions('p', ['y', 'x'])
-      expect(projects.value[0].sessions).toEqual(['y', 'x'])
-      // Raw is untouched.
-      expect(_rawWorld.value.projects[0].sessions).toEqual(['x', 'y'])
     })
 
     it('reorderSessions for a local project hits /v1/projects/{slug}/sessions', () => {
@@ -1272,13 +1258,15 @@ describe('pending mutations overlay', () => {
       )
     })
 
-    it('peer reorder does not add a local optimistic overlay', () => {
-      // The local pending-mutations overlay is keyed by local project
-      // slug; applying it to a peer reorder would clobber the peer
-      // folder's session order with the viewer's local-projects view.
-      const before = _pendingMutations.value.length
-      reorderSessions('gmux', ['y', 'x'], 'tower')
-      expect(_pendingMutations.value.length).toBe(before)
+    it('reorder adds no optimistic overlay, local or peer', () => {
+      // Order reaches the UI only as server-stamped project_index, so
+      // there is no local array an overlay could pre-write: the owning
+      // daemon's echo is the only thing that moves a row.
+      _setRawWorld({ projects: [{ slug: 'p', match: [], sessions: ['x', 'y'] }] })
+      reorderSessions('p', ['y', 'x'])
+      reorderSessions('p', ['y', 'x'], 'tower')
+      expect(_pendingMutations.value).toHaveLength(0)
+      expect(projects.value[0].sessions).toEqual(['x', 'y'])
     })
   })
 
@@ -1297,14 +1285,6 @@ describe('pending mutations overlay', () => {
       dismissSession('a')
       expect(_pendingMutations.value).toHaveLength(1)
       _rawSessions.value = []
-      expect(_pendingMutations.value).toHaveLength(0)
-    })
-
-    it('drops a reorder mutation once raw matches the requested order', () => {
-      _setRawWorld({ projects: [{ slug: 'p', match: [], sessions: ['x', 'y'] }] })
-      reorderSessions('p', ['y', 'x'])
-      expect(_pendingMutations.value).toHaveLength(1)
-      _setRawWorld({ projects: [{ slug: 'p', match: [], sessions: ['y', 'x'] }] })
       expect(_pendingMutations.value).toHaveLength(0)
     })
 

--- a/apps/gmux-web/src/store.test.ts
+++ b/apps/gmux-web/src/store.test.ts
@@ -140,6 +140,39 @@ describe('optimistic dismiss retracts on failure', () => {
   })
 })
 
+describe('reorder failures are surfaced, never silent', () => {
+  beforeEach(() => { toasts.value = []; _pendingMutations.value = [] })
+  afterEach(() => { vi.unstubAllGlobals(); toasts.value = []; _pendingMutations.value = [] })
+
+  it('toasts and retracts the overlay when the server rejects a local reorder', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false, status: 500, statusText: 'Internal Server Error',
+      text: () => Promise.resolve(JSON.stringify({ error: { message: 'failed to save projects' } })),
+    }))
+    await reorderSessions('gmux', ['y', 'x'])
+    expect(toasts.value[0]).toMatchObject({
+      kind: 'error', message: 'Reorder failed: failed to save projects',
+    })
+    expect(_pendingMutations.value).toHaveLength(0)
+  })
+
+  it('toasts when a peer reorder is rejected (no overlay to retract)', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false, status: 502, statusText: 'Bad Gateway',
+      text: () => Promise.resolve(''),
+    }))
+    await reorderSessions('gmux', ['y', 'x'], 'tower')
+    expect(toasts.value[0].message).toBe('Reorder failed: Bad Gateway')
+  })
+
+  it('stays silent on a network reject (owned by the reconnecting pill)', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('Failed to fetch')))
+    await reorderSessions('gmux', ['y', 'x'])
+    expect(toasts.value).toHaveLength(0)
+    expect(_pendingMutations.value).toHaveLength(0)
+  })
+})
+
 describe('filteredSessions reactivity to the URL query string', () => {
   it('recomputes when urlSearch flips, without an SSE session update', () => {
     _rawSessions.value = [

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -102,10 +102,15 @@ export function _setRawWorld(patch: Partial<RawWorld>) {
 //
 // The wire delivers atomic snapshots that overwrite `_rawSessions` /
 // `_rawWorld` wholesale. Optimistic UI mutations (mark-as-read,
-// dismiss, reorder) need to survive that overwrite until the server
-// echoes them back. We do that by stacking mutations in
-// `_pendingMutations` and replaying them on top of raw in the public
-// projections.
+// dismiss) need to survive that overwrite until the server echoes them
+// back. We do that by stacking mutations in `_pendingMutations` and
+// replaying them on top of raw in the public projection.
+//
+// Session *order* deliberately has no overlay. It reaches the UI only as
+// server-stamped `project_index` (the daemon owns placement for local,
+// Local-peer and peer sessions alike), so the only honest local preview
+// is the in-drag one the sidebar renders from its own drag state; the
+// commit is the server's to make. See `reorderSessions`.
 //
 // Each mutation is auto-cleared two ways:
 //   1. when raw state already reflects the mutation
@@ -116,22 +121,19 @@ export function _setRawWorld(patch: Partial<RawWorld>) {
 export type PendingMutation =
   | { kind: 'mark-read'; id: string; at: number }
   | { kind: 'dismiss'; id: string; at: number }
-  | { kind: 'reorder'; slug: string; sessions: string[]; at: number }
 
 export const _pendingMutations = signal<PendingMutation[]>([])
 
 const PENDING_TTL_MS = 5_000
 
-/** Replay pending mutations on top of a raw sessions/projects pair.
+/** Replay pending mutations on top of a raw sessions array.
  * Pure; safe to call from `computed`. */
 export function applyPending(
   rawSessions: Session[],
-  rawProjects: ProjectItem[],
   pending: PendingMutation[],
-): { sessions: Session[]; projects: ProjectItem[] } {
-  if (pending.length === 0) return { sessions: rawSessions, projects: rawProjects }
+): Session[] {
+  if (pending.length === 0) return rawSessions
   let sess = rawSessions
-  let projs = rawProjects
   for (const m of pending) {
     switch (m.kind) {
       case 'mark-read':
@@ -144,22 +146,15 @@ export function applyPending(
       case 'dismiss':
         sess = sess.filter(s => s.id !== m.id)
         break
-      case 'reorder':
-        projs = projs.map(p => p.slug !== m.slug ? p : ({ ...p, sessions: m.sessions }))
-        break
     }
   }
-  return { sessions: sess, projects: projs }
+  return sess
 }
 
 /** True when the raw state already reflects the mutation, so replaying
  * it would be a no-op. The auto-clear effect uses this to drop
  * mutations the server has acknowledged. */
-function isResolved(
-  m: PendingMutation,
-  rawSessions: Session[],
-  rawProjects: ProjectItem[],
-): boolean {
+function isResolved(m: PendingMutation, rawSessions: Session[]): boolean {
   switch (m.kind) {
     case 'mark-read': {
       const s = rawSessions.find(x => x.id === m.id)
@@ -168,12 +163,6 @@ function isResolved(
     }
     case 'dismiss':
       return !rawSessions.some(s => s.id === m.id)
-    case 'reorder': {
-      const p = rawProjects.find(x => x.slug === m.slug)
-      if (!p) return true
-      const cur = p.sessions ?? []
-      return cur.length === m.sessions.length && cur.every((v, i) => v === m.sessions[i])
-    }
   }
 }
 
@@ -193,8 +182,8 @@ function addPending(m: PendingMutation): () => void {
 /**
  * Run an optimistic mutation: apply it locally now, fire `action`, and
  * retract immediately if the action reports failure (rather than letting
- * the row/order linger until the TTL sweeps it). `action` returns whether
- * the server accepted it. Shared by `dismissSession` and `reorderSessions`;
+ * the row linger until the TTL sweeps it). `action` returns whether
+ * the server accepted it. Used by `dismissSession`;
  * `mark-read` deliberately opts out (it's fire-and-forget — a failed
  * mark-read silently self-heals on the next snapshot and needs no toast
  * or eager rollback).
@@ -210,11 +199,9 @@ async function optimistic(m: PendingMutation, action: () => Promise<boolean>): P
 // Everything is `computed`, so writes go through the raw signals only.
 
 export const sessions = computed<Session[]>(() =>
-  applyPending(_rawSessions.value, _rawWorld.value.projects, _pendingMutations.value).sessions,
+  applyPending(_rawSessions.value, _pendingMutations.value),
 )
-export const projects = computed<ProjectItem[]>(() =>
-  applyPending(_rawSessions.value, _rawWorld.value.projects, _pendingMutations.value).projects,
-)
+export const projects = computed<ProjectItem[]>(() => _rawWorld.value.projects)
 
 /** Conversation files that are live in more than one runner (session → file
  *  is authoritative per-runner; ADR 0011). Two alive sessions sharing a
@@ -246,10 +233,9 @@ export const peerProjects = computed<Record<string, PeerProject[]>>(
 // every raw update; uses .peek() to avoid re-triggering itself.
 effect(() => {
   const rs = _rawSessions.value
-  const rw = _rawWorld.value
   const pending = _pendingMutations.peek()
   if (pending.length === 0) return
-  const filtered = pending.filter(m => !isResolved(m, rs, rw.projects))
+  const filtered = pending.filter(m => !isResolved(m, rs))
   if (filtered.length !== pending.length) {
     _pendingMutations.value = filtered
   }
@@ -1323,18 +1309,20 @@ export async function updateProjects(items: ProjectItem[]): Promise<void> {
  * Persist a new session order for a project. The `sessionKeys` array
  * contains session IDs in the desired display order.
  *
- * Local projects (peer === undefined) get an optimistic overlay via
- * `_pendingMutations` so the sidebar re-renders immediately, before
- * the snapshot.world round-trip echoes the new order back.
+ * Fire-and-report, with no optimistic overlay for either ownership case:
+ * the sidebar derives folder order solely from server-stamped
+ * project_index, so there is no local array an overlay could usefully
+ * pre-write. The owning daemon re-stamps and re-emits snapshot.sessions,
+ * which lands in the same tick as the response for a local write; the
+ * round-trip is the cost of honesty about who owns the data.
  *
  * Peer-owned projects route through the generic peer-write proxy at
  * `/v1/peers/{peer}/v1/projects/{slug}/sessions` (ADR 0002): the peer
- * owns its own projects.json and re-stamps each session's
- * project_index, which arrives over the snapshot stream. We don't
- * apply a local optimistic overlay for peer reorders because the
- * sidebar derives peer-folder order from those stamps, not from any
- * local projects array; the round-trip latency is the cost of
- * honesty about who owns the data.
+ * owns its own catalog and its own stamps.
+ *
+ * A rejection toasts (the drag then visibly snaps back to the
+ * server-stamped order, which is the truth); a network reject stays
+ * silent — connectivity is the reconnecting pill's story to tell.
  */
 export async function reorderSessions(
   projectSlug: string,
@@ -1345,38 +1333,19 @@ export async function reorderSessions(
     ? `/v1/peers/${encodeURIComponent(peer)}/v1/projects/${encodeURIComponent(projectSlug)}/sessions`
     : `/v1/projects/${encodeURIComponent(projectSlug)}/sessions`
 
-  // PATCH the new order. Returns whether the server accepted it; a
-  // received error toasts, a network reject stays silent (connectivity,
-  // owned by the reconnecting pill) — same contract as postAction.
-  const patch = async (): Promise<boolean> => {
-    try {
-      const resp = await fetch(url, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ sessions: sessionKeys }),
-      })
-      if (!resp.ok) {
-        pushError(`Reorder failed: ${await errorMessageFromResponse(resp)}`)
-        return false
-      }
-      return true
-    } catch {
-      console.debug(`${url}: network error (suppressed toast)`)
-      return false
+  // Same reporting contract as postAction: a received error toasts, a
+  // network reject only logs.
+  try {
+    const resp = await fetch(url, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ sessions: sessionKeys }),
+    })
+    if (!resp.ok) {
+      pushError(`Reorder failed: ${await errorMessageFromResponse(resp)}`)
     }
-  }
-
-  // Local reorders get an optimistic overlay that retracts on failure.
-  // Peer reorders have no local overlay (the sidebar derives peer-folder
-  // order from server-stamped project_index, not a local array), so
-  // there's nothing to roll back — just fire and let the toast report.
-  if (peer === undefined) {
-    await optimistic(
-      { kind: 'reorder', slug: projectSlug, sessions: sessionKeys, at: Date.now() },
-      patch,
-    )
-  } else {
-    await patch()
+  } catch {
+    console.debug(`${url}: network error (suppressed toast)`)
   }
 }
 

--- a/services/gmuxd/cmd/gmuxd/reorder_republish_test.go
+++ b/services/gmuxd/cmd/gmuxd/reorder_republish_test.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/centralstore"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/snapshot/wire"
+)
+
+// A reorder must reach subscribers as new project_index stamps on
+// snapshot.sessions, which is the only thing the sidebar orders by.
+//
+// Asserted over the composed graph (real store → coordinator → composer →
+// wire.Cache → Frames) rather than on the mutation's dirty flags alone: the
+// bug this pins was a *seam* bug. The cache does re-emit a sessions frame for
+// a projects-only batch, but rebuilds it from the last cached sessions
+// payload, whose placement join is exactly what a reorder invalidates. So a
+// world-only reorder republished the pre-reorder order — persisted, silent,
+// and invisible until an unrelated session event happened to recompose.
+func TestHarnessReorderRepublishesSessionStamps(t *testing.T) {
+	ctx := context.Background()
+	fleet := newHarnessFleet(0)
+	frames := make(chan wire.Frames, 64)
+	store, b := openHarness(t, t.TempDir(), fleet, func(_ context.Context, f wire.Frames) {
+		select {
+		case frames <- f:
+		default:
+		}
+	})
+	defer store.Close()
+	if _, err := b.Converge(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.StartPostConvergence(ctx, fleet.endpoints()); err != nil {
+		t.Fatal(err)
+	}
+	defer b.Close()
+
+	catalog, res, err := store.ReplaceProjectCatalog(ctx, []centralstore.ProjectEntrySpec{
+		{Owned: &centralstore.OwnedProjectSpec{Slug: "proj", Rules: []centralstore.MatchRule{{Path: "/"}}}},
+	}, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b.Composer.Invalidate(res)
+	project := catalog[0].ID
+
+	// Placement joins the session row, so the rows are registered directly
+	// rather than waited for from the runner transport: convergence runs
+	// under a millisecond-scale budget, and this test is about the
+	// publication seam, not about registration timing.
+	first, second := centralstore.SessionID("sess-reorder-000"), centralstore.SessionID("sess-reorder-001")
+	for _, id := range []centralstore.SessionID{first, second} {
+		row, reg, e := store.RegisterRunner(ctx, centralstore.RunnerRegistration{
+			ID: id, Adapter: "shell", Alive: true, CreatedAt: 1, ObservedAt: 1,
+		})
+		if e != nil {
+			t.Fatal(e)
+		}
+		b.Composer.Invalidate(reg)
+		r, e := store.PlaceLocalSession(ctx, row.ID, project)
+		if e != nil {
+			t.Fatal(e)
+		}
+		b.Composer.Invalidate(r)
+	}
+	if got := awaitStamps(t, frames, map[centralstore.SessionID]int{first: 0, second: 1}); !got {
+		t.Fatal("placement stamps never reached a sessions frame")
+	}
+
+	// The production route (PATCH /v1/projects/{slug}/sessions) reorders
+	// through the coordinator, which publishes the mutation's dirtiness.
+	if _, err = b.Coordinator.ReorderSiblingScopes(ctx, []centralstore.SiblingReorder{{
+		Project: project,
+		Order:   []centralstore.SubjectRef{{LocalSessionID: second}, {LocalSessionID: first}},
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	if got := awaitStamps(t, frames, map[centralstore.SessionID]int{second: 0, first: 1}); !got {
+		t.Fatal("reorder did not republish snapshot.sessions with the new project_index stamps")
+	}
+}
+
+// awaitStamps reports whether a sessions frame carrying exactly want (session
+// ID → project_index, all rows placed in a project) arrives in time.
+func awaitStamps(t *testing.T, frames <-chan wire.Frames, want map[centralstore.SessionID]int) bool {
+	t.Helper()
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case f := <-frames:
+			if f.Sessions == nil {
+				continue
+			}
+			got := map[centralstore.SessionID]int{}
+			for _, s := range f.Sessions.Sessions {
+				if s.ProjectSlug != "" {
+					got[centralstore.SessionID(s.ID)] = s.ProjectIndex
+				}
+			}
+			if len(got) != len(want) {
+				continue
+			}
+			match := true
+			for id, idx := range want {
+				if got[id] != idx {
+					match = false
+					break
+				}
+			}
+			if match {
+				return true
+			}
+		case <-deadline:
+			return false
+		}
+	}
+}

--- a/services/gmuxd/internal/centralstore/domain.go
+++ b/services/gmuxd/internal/centralstore/domain.go
@@ -1379,7 +1379,14 @@ func (s *Store) place(ctx context.Context, sub SubjectRef, project ProjectEntryI
 	if err = tx.Commit(); err != nil {
 		return MutationResult{}, err
 	}
-	return MutationResult{Changed: changed, WorldDirty: changed}, nil
+	// Placement is world state, but it *rides the session rows* on the
+	// wire (project_slug / project_index, FD-1). A projects-only
+	// recomposition rebuilds the sessions frame from the composer's last
+	// sessions payload, whose placement join is exactly the state this
+	// mutation just invalidated — so a placement change must dirty both
+	// kinds or subscribers keep the pre-mutation stamps until an
+	// unrelated session event happens to refresh them.
+	return MutationResult{Changed: changed, SessionsDirty: changed, WorldDirty: changed}, nil
 }
 
 type SiblingReorder struct {
@@ -1479,7 +1486,9 @@ func (s *Store) ReorderSiblingScopes(ctx context.Context, reorders []SiblingReor
 	if err = tx.Commit(); err != nil {
 		return MutationResult{}, err
 	}
-	return MutationResult{Changed: changedAny, WorldDirty: changedAny}, nil
+	// Both kinds: the new positions are read back as session-row
+	// project_index stamps (see the note in place()).
+	return MutationResult{Changed: changedAny, SessionsDirty: changedAny, WorldDirty: changedAny}, nil
 }
 
 func (s *Store) SetPromotion(ctx context.Context, id SessionID, promoted bool, index *int) (MutationResult, error) {
@@ -1553,7 +1562,11 @@ func (s *Store) SetPromotion(ctx context.Context, id SessionID, promoted bool, i
 		version++
 		changed = true
 	}
-	return MutationResult{Changed: changed, SessionVersion: version, SessionsDirty: n == 1, WorldDirty: changed}, nil
+	// A promoted-flag write (n == 1) has already set changed above, and an
+	// order-only change sets it too — so both kinds follow changed: the flag
+	// lives on the session row, and positions ride session rows as
+	// project_index stamps (see the note in place()). No-ops returned early.
+	return MutationResult{Changed: changed, SessionVersion: version, SessionsDirty: changed, WorldDirty: changed}, nil
 }
 
 func (s *Store) PruneLocalPeer(ctx context.Context, key PeerKey) (MutationResult, error) {
@@ -1578,5 +1591,7 @@ func (s *Store) PruneLocalPeer(ctx context.Context, key PeerKey) (MutationResult
 	if err = tx.Commit(); err != nil {
 		return MutationResult{}, err
 	}
-	return MutationResult{Changed: n > 0, WorldDirty: n > 0}, nil
+	// Pruning renumbers surviving siblings, including local sessions whose
+	// positions ride their session rows (see the note in place()).
+	return MutationResult{Changed: n > 0, SessionsDirty: n > 0, WorldDirty: n > 0}, nil
 }

--- a/services/gmuxd/internal/centralstore/domain_test.go
+++ b/services/gmuxd/internal/centralstore/domain_test.go
@@ -569,18 +569,25 @@ func TestPromotionNoopVersionAndExplicitOrder(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
+	// Every no-op below must also stay clean on both dirty kinds: placement
+	// now dirties sessions as well as world, so a mutation that reported
+	// dirtiness unconditionally would republish on every idle promotion or
+	// re-assert of the current order.
 	r, err := s.SetPromotion(ctx, "a", false, nil)
-	if err != nil || r.Changed || r.SessionVersion != 1 {
+	if err != nil || r.Changed || r.SessionsDirty || r.WorldDirty || r.SessionVersion != 1 {
 		t.Fatalf("promotion noop=%#v err=%v", r, err)
 	}
 	idx := 0
 	r, err = s.SetPromotion(ctx, "a", false, &idx)
-	if err != nil || r.Changed || r.SessionVersion != 1 {
+	if err != nil || r.Changed || r.SessionsDirty || r.WorldDirty || r.SessionVersion != 1 {
 		t.Fatalf("order noop=%#v err=%v", r, err)
 	}
 	idx = 1
 	r, err = s.SetPromotion(ctx, "a", false, &idx)
-	if err != nil || !r.Changed || r.SessionsDirty || !r.WorldDirty || r.SessionVersion != 1 {
+	// Order-only: the row version doesn't move (no session-row fact
+	// changed) but the sessions kind is still dirty, because positions
+	// reach the wire as session-row project_index stamps.
+	if err != nil || !r.Changed || !r.SessionsDirty || !r.WorldDirty || r.SessionVersion != 1 {
 		t.Fatalf("order-only=%#v err=%v", r, err)
 	}
 	r, err = s.SetPromotion(ctx, "a", true, nil)
@@ -588,7 +595,7 @@ func TestPromotionNoopVersionAndExplicitOrder(t *testing.T) {
 		t.Fatalf("promotion=%#v err=%v", r, err)
 	}
 	r, err = s.SetPromotion(ctx, "a", true, nil)
-	if err != nil || r.Changed || r.SessionVersion != 2 {
+	if err != nil || r.Changed || r.SessionsDirty || r.WorldDirty || r.SessionVersion != 2 {
 		t.Fatalf("second noop=%#v err=%v", r, err)
 	}
 	bad := 9
@@ -663,6 +670,64 @@ func TestReorderValidatesProjectParentAndDuplicates(t *testing.T) {
 	if _, err = s.ReorderSiblings(ctx, p1, ParentRef{Subject: &deleted}, nil); err == nil {
 		t.Fatal("deleted reorder parent accepted")
 	}
+}
+
+// Placement facts ride the session rows on the wire (project_slug /
+// project_index), so every mutation that touches the placement table has to
+// report SessionsDirty as well as WorldDirty. Regression: reorder reported
+// world-only, the composer recomposed the sessions frame from its stale
+// cached sessions payload, and the sidebar kept the pre-reorder order until
+// an unrelated session event happened to refresh it (silent no-op drag).
+func TestPlacementMutationsDirtyBothKinds(t *testing.T) {
+	ctx := context.Background()
+	s := openKernelStore(t)
+	p := addProject(t, s)
+	for _, id := range []string{"a", "b"} {
+		addSession(t, s, id, "")
+		r, err := s.PlaceLocalSession(ctx, SessionID(id), p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !r.Changed || !r.SessionsDirty || !r.WorldDirty {
+			t.Fatalf("place %s=%#v", id, r)
+		}
+		// Re-placing into the project it already occupies changes no
+		// row and must not republish either kind.
+		if again, e := s.PlaceLocalSession(ctx, SessionID(id), p); e != nil {
+			t.Fatal(e)
+		} else if again.Changed || again.SessionsDirty || again.WorldDirty {
+			t.Fatalf("re-place %s=%#v", id, again)
+		}
+	}
+	peer := LocalPeerSubject{PeerKey: "dev", SessionID: "peer"}
+	if r, err := s.UpsertLocalPeerPlacement(ctx, peer, p); err != nil {
+		t.Fatal(err)
+	} else if !r.Changed || !r.SessionsDirty || !r.WorldDirty {
+		t.Fatalf("place local-peer=%#v", r)
+	}
+
+	order := []SubjectRef{{LocalSessionID: "b"}, {LocalSessionID: "a"}, {LocalPeer: &peer}}
+	r, err := s.ReorderSiblings(ctx, p, ParentRef{}, order)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !r.Changed || !r.SessionsDirty || !r.WorldDirty {
+		t.Fatalf("reorder=%#v", r)
+	}
+	// A no-op reorder stays clean: nothing to re-emit.
+	if r, err = s.ReorderSiblings(ctx, p, ParentRef{}, order); err != nil {
+		t.Fatal(err)
+	} else if r.Changed || r.SessionsDirty || r.WorldDirty {
+		t.Fatalf("no-op reorder=%#v", r)
+	}
+
+	// Pruning a Local peer renumbers the surviving local siblings.
+	if r, err = s.PruneLocalPeer(ctx, "dev"); err != nil {
+		t.Fatal(err)
+	} else if !r.Changed || !r.SessionsDirty || !r.WorldDirty {
+		t.Fatalf("prune=%#v", r)
+	}
+	assertKernelInvariants(t, s)
 }
 
 func TestReorderSiblingScopesRollsBackAllScopes(t *testing.T) {


### PR DESCRIPTION
## Symptom

In the sidebar's **Projects view**, dragging a session to a new position
"often does nothing" — silently, with no console or UI error.

## Root cause: backend, not the drag code

The drag handlers and the `PATCH /v1/projects/{slug}/sessions` call are
correct, and the daemon **persisted every reorder**. It just never
re-published it.

Placement (membership *and* order) is world state, but on the wire it rides
the session rows as `project_slug` / `project_index` (the FD-1 flatten).
`wire.Cache` does re-emit a `snapshot.sessions` frame for a projects-only
batch — but it rebuilds that frame from the composer's last cached
`central.SessionsPayload`, whose per-row `Placement` join is exactly the state
the reorder invalidated. Because `ReorderSiblingScopes` reported `WorldDirty`
only, every subscriber (including fresh ones, whose initial snapshot comes
from the same cache) kept the pre-drag order until an unrelated session event
happened to dirty the sessions kind.

Deterministic repro against an isolated daemon — authoritative read vs. what
the UI actually receives:

```
PATCH /v1/projects/repro/sessions  -> {"ok":true}
REST  GET /v1/sessions   : [('ccad', 0), ('5b9b', 1), ('2f07', 2)]   # new order
SSE   snapshot.sessions  : [('c322', 1), ('5b9b', 2), ('2f07', 0)]   # pre-drag order
```

Why it read as intermittent: a later session event (spawn/exit/activity)
recomposes and the reorder "suddenly works"; and Local-peer (devcontainer)
rows were never affected, since their positions ride the projects payload.

## Fix

Every `centralstore` mutation that writes the placement table now reports
`SessionsDirty` alongside `WorldDirty`, with the rationale recorded at
`place()`:

- `ReorderSiblingScopes` — the drag path;
- `place()` (`PlaceLocalSession` / `PlaceLocalPeerSession`) — a session moving
  project had the same latent staleness;
- `SetPromotion` — an order-only change was world-only;
- `PruneLocalPeer` — pruning renumbers surviving local siblings.

No-op mutations stay clean, so this adds no spurious frames.

After the fix the SSE frame matches the authoritative read immediately, and a
real HTML5 drag in Chrome moves the row, persists, and survives reload;
repeated drags in both directions keep working.

## Tests

- `centralstore.TestPlacementMutationsDirtyBothKinds` (new) — place local,
  place Local-peer, reorder, no-op reorder, prune. Fails on `main`
  (`place a=…SessionsDirty:false…`).
- `TestPromotionNoopVersionAndExplicitOrder` — the assertion that codified the
  bug is inverted, with a note on why the row version still doesn't move.
- `cmd/gmuxd.TestHarnessReorderRepublishesSessionStamps` (new) — the
  regression pinned at the **composed seam**: a reorder through the
  coordinator must reach subscribers as new `project_index` stamps on
  `snapshot.sessions`. Verified to fail when `SessionsDirty` is dropped from
  `ReorderSiblingScopes` (`reorder did not republish snapshot.sessions with
  the new project_index stamps`).
- `store.test.ts` → "reorder failures are surfaced, never silent" (new) — toast
  plus no lingering overlay on a local rejection, toast on a peer rejection,
  silence on a network reject.
- `store.test.ts` → "reorder adds no optimistic overlay, local or peer" (new) —
  codifies the removal below; the obsolete auto-clear test for the deleted
  `reorder` pending-mutation kind is gone with it.

`go test ./...` green, all 609 `gmux-web` vitest tests green, biome lint and
`tsc --noEmit` clean.

## Also here: the reorder optimistic overlay is removed

The local overlay rewrote `projects[].sessions`, but the sidebar derives order
purely from server-stamped `project_index` — so it produced no visible
pre-echo and its rollback had no visible effect. Rather than leave dead weight
pretending to be optimistic UI, the `reorder` pending-mutation kind is dropped
(commit 2); order now reaches the UI only via the owning daemon's echo, which
is immediate after the fix above.

Supersedes #412 with the complete placement/order invalidation fix.
