### PR TITLE
fix(resume): reclaim stale sockets without phantom sessions

### DIFF
--- a/cli/gmux/cmd/gmux/run.go
+++ b/cli/gmux/cmd/gmux/run.go
@@ -249,14 +249,25 @@ func runSession(args []string, attach bool, dir runDirectives) {
 	sockPath := filepath.Join(socketDir, sessionID+".sock")
 
 	// Bind the socket BEFORE any sessionID-dependent setup
-	// (scrollback path, env, state). On collision with a live
-	// runner — which typically only happens when a daemon-supplied
-	// GMUX_RESUME_ID lands in a window where the targeted session
-	// is actually still alive — fall back to a fresh id and bind
-	// that instead. See ADR 0003 "Collision handling".
-	listener, err := ptyserver.BindSocket(sockPath)
-	if errors.Is(err, ptyserver.ErrSocketInUse) {
-		log.Printf("gmux: requested session id %s is in use; falling back to a fresh id", sessionID)
+	// (scrollback path, env, state). Ordinary new sessions may recover from an
+	// unexpected generated-id collision by minting another id. An explicit
+	// resume id is an identity contract with gmuxd: silently changing it starts
+	// an unrelated durable session, which a failed resume then exposes as a
+	// phantom resumable entry.
+	var listener *ptyserver.BoundSocket
+	if rawFD := os.Getenv("GMUX_SOCKET_LEASE_FD"); rawFD != "" {
+		_ = os.Unsetenv("GMUX_SOCKET_LEASE_FD")
+		fd, parseErr := strconv.Atoi(rawFD)
+		if parseErr != nil || fd < 3 {
+			err = fmt.Errorf("invalid inherited socket lease fd %q", rawFD)
+		} else {
+			listener, err = ptyserver.BindSocketWithInheritedLease(sockPath, os.NewFile(uintptr(fd), "gmux-socket-lease"))
+		}
+	} else {
+		listener, err = ptyserver.BindSocket(sockPath)
+	}
+	if mayRetrySessionID(dir.ResumeID, err) {
+		log.Printf("gmux: generated session id %s is in use; falling back to a fresh id", sessionID)
 		sessionID = naming.SessionID()
 		sockPath = filepath.Join(socketDir, sessionID+".sock")
 		listener, err = ptyserver.BindSocket(sockPath)
@@ -943,6 +954,10 @@ func awaitDetachedHandshake(cmd *exec.Cmd, r, gate, hold *os.File, deadline time
 		terminateProcessGroup(targetPGID, grace)
 	}
 	return "", readErr
+}
+
+func mayRetrySessionID(resumeID string, bindErr error) bool {
+	return resumeID == "" && errors.Is(bindErr, ptyserver.ErrSocketInUse)
 }
 
 // explainHandshakeFailure converts a readHandshake error into a

--- a/cli/gmux/cmd/gmux/run_test.go
+++ b/cli/gmux/cmd/gmux/run_test.go
@@ -1,12 +1,26 @@
 package main
 
 import (
+	"errors"
 	"testing"
 	"time"
 
+	"github.com/gmuxapp/gmux/cli/gmux/internal/ptyserver"
 	"github.com/gmuxapp/gmux/cli/gmux/internal/session"
 	"github.com/gmuxapp/gmux/packages/adapter"
 )
+
+func TestExplicitResumeIDNeverFallsBackToPhantomSession(t *testing.T) {
+	if mayRetrySessionID("sess-retained", ptyserver.ErrSocketInUse) {
+		t.Fatal("explicit resume collision would mint an unrelated session id")
+	}
+	if !mayRetrySessionID("", ptyserver.ErrSocketInUse) {
+		t.Fatal("ordinary generated-id collision should remain retryable")
+	}
+	if mayRetrySessionID("", errors.New("bind failed")) {
+		t.Fatal("non-collision bind error became retryable")
+	}
+}
 
 // collectEvents drains n events from ch (or times out), returning the
 // event types in arrival order plus the payloads for inspection.

--- a/cli/gmux/internal/ptyserver/inherited_lease_test.go
+++ b/cli/gmux/internal/ptyserver/inherited_lease_test.go
@@ -1,0 +1,40 @@
+package ptyserver
+
+import (
+	"net"
+	"path/filepath"
+	"testing"
+
+	"github.com/gmuxapp/gmux/packages/socklease"
+)
+
+func TestBindSocketWithInheritedLeaseTransfersWithoutReacquire(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.sock")
+	parent, err := socklease.Acquire(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	childFD, err := parent.DuplicateForExec()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := parent.ReleaseForTransfer(); err != nil {
+		t.Fatal(err)
+	}
+	bound, err := BindSocketWithInheritedLease(path, childFD)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = bound.ReleaseOwnership()
+		_ = bound.Close()
+	}()
+	conn, err := net.Dial("unix", path)
+	if err != nil {
+		t.Fatalf("inherited lease did not bind canonical socket: %v", err)
+	}
+	conn.Close()
+	if _, err := socklease.AcquireExisting(path); err != socklease.ErrHeld {
+		t.Fatalf("child did not retain inherited lease: %v", err)
+	}
+}

--- a/cli/gmux/internal/ptyserver/ptyserver.go
+++ b/cli/gmux/internal/ptyserver/ptyserver.go
@@ -174,6 +174,24 @@ func BindSocket(sockPath string) (*BoundSocket, error) {
 	if err != nil {
 		return nil, fmt.Errorf("BindSocket: lease: %w", err)
 	}
+	return bindSocketWithLease(sockPath, lease)
+}
+
+// BindSocketWithInheritedLease binds using a lease descriptor transferred by
+// the spawning daemon. Ownership is continuous across exec, so child startup
+// never races a wall-clock lease acquisition timeout against its parent.
+func BindSocketWithInheritedLease(sockPath string, leaseFile *os.File) (*BoundSocket, error) {
+	if err := socklease.RequireOwnedDir(filepath.Dir(sockPath)); err != nil {
+		return nil, fmt.Errorf("BindSocket: %w", err)
+	}
+	lease, err := socklease.AdoptInherited(sockPath, leaseFile)
+	if err != nil {
+		return nil, fmt.Errorf("BindSocket: inherited lease: %w", err)
+	}
+	return bindSocketWithLease(sockPath, lease)
+}
+
+func bindSocketWithLease(sockPath string, lease *socklease.Lease) (*BoundSocket, error) {
 	bindBarrier(sockPath, "lease-held")
 
 	for range bindAttempts {

--- a/packages/socklease/inherited_test.go
+++ b/packages/socklease/inherited_test.go
@@ -1,0 +1,91 @@
+package socklease
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+func TestDuplicateForExecIsCloseOnExecExceptForExplicitExtraFiles(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.sock")
+	lease, err := Acquire(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lease.Release()
+	dup, err := lease.DuplicateForExec()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dup.Close()
+	flags, _, errno := syscall.Syscall(syscall.SYS_FCNTL, dup.Fd(), syscall.F_GETFD, 0)
+	if errno != 0 {
+		t.Fatal(errno)
+	}
+	if flags&syscall.FD_CLOEXEC == 0 {
+		t.Fatal("lease duplicate can leak into unrelated execs")
+	}
+}
+
+func TestAdoptInheritedRejectsSidecarReplacedBeforeLock(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.sock")
+	seed, err := Acquire(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := seed.ReleaseKeepingLockFile(); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.OpenFile(LockPath(path), os.O_RDWR, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var replacement *Lease
+	_, err = adoptInherited(path, f, func() {
+		if err := os.Rename(LockPath(path), LockPath(path)+".parked"); err != nil {
+			t.Fatal(err)
+		}
+		replacement, err = Acquire(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+	defer replacement.Release()
+	if !errors.Is(err, ErrIdentityChanged) {
+		t.Fatalf("adopt replaced sidecar error=%v, want identity change", err)
+	}
+	if contender, err := AcquireExisting(path); !errors.Is(err, ErrHeld) {
+		if err == nil {
+			_ = contender.ReleaseKeepingLockFile()
+		}
+		t.Fatalf("replacement lease was not retained: %v", err)
+	}
+}
+
+func TestAdoptInheritedEstablishesExclusivityForUnlockedDescriptor(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.sock")
+	seed, err := Acquire(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := seed.ReleaseKeepingLockFile(); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.OpenFile(LockPath(path), os.O_RDWR, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	adopted, err := AdoptInherited(path, f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer adopted.Release()
+	if contender, err := AcquireExisting(path); !errors.Is(err, ErrHeld) {
+		if err == nil {
+			_ = contender.ReleaseKeepingLockFile()
+		}
+		t.Fatalf("adopted descriptor was not exclusive: %v", err)
+	}
+}

--- a/packages/socklease/socklease.go
+++ b/packages/socklease/socklease.go
@@ -367,6 +367,59 @@ func (l *Lease) SockPath() string { return l.sockPath }
 // LockPath returns the lock pathname backing this lease.
 func (l *Lease) LockPath() string { return LockPath(l.sockPath) }
 
+// DuplicateForExec duplicates the held lease descriptor for an explicitly
+// coordinated child process. The duplicate refers to the same flock-owning
+// open file description, so the lease remains continuously held while parent
+// ownership is transferred to the child across exec.
+func (l *Lease) DuplicateForExec() (*os.File, error) {
+	fd, _, errno := syscall.Syscall(syscall.SYS_FCNTL, l.f.Fd(), syscall.F_DUPFD_CLOEXEC, 0)
+	if errno != 0 {
+		return nil, fmt.Errorf("socklease: duplicate lease: %w", errno)
+	}
+	return os.NewFile(fd, l.f.Name()), nil
+}
+
+// AdoptInherited adopts a descriptor inherited from a coordinating parent.
+// It verifies that the descriptor still names the current sidecar before
+// allowing the child to use it as its lease.
+func AdoptInherited(sockPath string, f *os.File) (*Lease, error) {
+	return adoptInherited(sockPath, f, nil)
+}
+
+func adoptInherited(sockPath string, f *os.File, beforeLock func()) (*Lease, error) {
+	if f == nil {
+		return nil, errors.New("socklease: adopt nil lease descriptor")
+	}
+	if same, ok := sameFile(f, LockPath(sockPath)); !ok || !same {
+		_ = f.Close()
+		return nil, fmt.Errorf("socklease: inherited lease no longer names %s", LockPath(sockPath))
+	}
+	if beforeLock != nil {
+		beforeLock()
+	}
+	// Reassert the lock rather than trusting the environment-selected fd. On
+	// the duplicated open-file description inherited from the parent this is a
+	// no-op; on an unlocked descriptor it establishes real exclusivity before
+	// the caller can act as an owner.
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		_ = f.Close()
+		if errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN) {
+			return nil, ErrHeld
+		}
+		return nil, fmt.Errorf("socklease: lock inherited lease: %w", err)
+	}
+	// The sidecar may have been replaced between the first identity check and
+	// flock. Verify after locking, just like acquire(), so adoption can never
+	// return ownership of an unlinked predecessor while another process owns
+	// the current pathname.
+	if same, ok := sameFile(f, LockPath(sockPath)); !ok || !same {
+		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+		_ = f.Close()
+		return nil, fmt.Errorf("socklease: inherited lease changed before lock: %w", ErrIdentityChanged)
+	}
+	return &Lease{f: f, sockPath: sockPath}, nil
+}
+
 // RemoveSocket unlinks the socket pathname, but only while it still names the
 // file the pin holds.
 //
@@ -431,6 +484,18 @@ func (l *Lease) Release() error { return l.release(true) }
 // thing that ever makes the leftover socket reclaimable (see
 // CreatedLockFile).
 func (l *Lease) ReleaseKeepingLockFile() error { return l.release(false) }
+
+// ReleaseForTransfer closes this process's descriptor without explicitly
+// unlocking it. It is valid only after DuplicateForExec: the inherited
+// duplicate keeps the shared open-file-description lock held continuously.
+func (l *Lease) ReleaseForTransfer() error {
+	if l == nil || l.f == nil {
+		return nil
+	}
+	err := l.f.Close()
+	l.f = nil
+	return err
+}
 
 func (l *Lease) release(removeLockFile bool) error {
 	if l == nil || l.f == nil {

--- a/services/gmuxd/cmd/gmuxd/bootstrap_runner_adapters.go
+++ b/services/gmuxd/cmd/gmuxd/bootstrap_runner_adapters.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/gmuxapp/gmux/packages/paths"
 	"github.com/gmuxapp/gmux/packages/sessionenv"
+	"github.com/gmuxapp/gmux/packages/socklease"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/centralstore"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/discovery"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/sessioncoord"
@@ -296,6 +297,7 @@ type runnerLaunchRequest struct {
 	CWD, ResumeID     string
 	InitialCols, Rows uint16
 	Endpoint          string
+	LeaseFile         *os.File
 }
 
 type runnerLaunchResult struct {
@@ -311,8 +313,10 @@ type productionRunnerSpawner struct {
 	ResolveCommand func(centralstore.Session) []string
 	Launch         func(context.Context, runnerLaunchRequest) (runnerLaunchResult, error)
 	ReadyTimeout   time.Duration
-	mu             sync.Mutex
-	launched       map[string]runnerLaunchResult
+	// prepareBeforeRemove is a test-only schedule seam for replacement races.
+	prepareBeforeRemove func(string)
+	mu                  sync.Mutex
+	launched            map[string]runnerLaunchResult
 }
 
 func (s *productionRunnerSpawner) Spawn(ctx context.Context, row centralstore.Session) (string, error) {
@@ -342,14 +346,38 @@ func (s *productionRunnerSpawner) Spawn(ctx context.Context, row centralstore.Se
 		return "", fmt.Errorf("runner spawn: session %s is not resumable", row.ID)
 	}
 	endpoint := filepath.Join(paths.SessionSocketDir(), legacy.ID+".sock")
+	// A retained session may predate the socket lease protocol and therefore
+	// have a refused socket but no lock-file history. BindSocket deliberately
+	// will not remove that shape on its own, because an ordinary runner cannot
+	// know whether an unleased owner is starting concurrently. Resume has the
+	// stronger identity contract and prepares the exact canonical endpoint:
+	// pin, probe, and conditionally remove only the refused inode, then leave
+	// lease history for the child. A live occupant aborts before any process (or
+	// session-scoped state) is created.
+	prepared, err := prepareResumeSocket(endpoint, s.prepareBeforeRemove)
+	if err != nil {
+		return "", fmt.Errorf("runner spawn: prepare socket: %w", err)
+	}
 	launch := s.Launch
 	if launch == nil {
 		launch = launchRunnerProcess
 	}
-	result, err := launch(ctx, runnerLaunchRequest{GmuxBin: s.GmuxBin, Command: legacy.Command, CWD: cwd, ResumeID: legacy.ID, InitialCols: value16(row.TerminalCols), Rows: value16(row.TerminalRows), Endpoint: endpoint})
+	leaseFile, err := prepared.lease.DuplicateForExec()
 	if err != nil {
+		prepared.rollback()
+		return "", fmt.Errorf("runner spawn: transfer socket lease: %w", err)
+	}
+	result, err := launch(ctx, runnerLaunchRequest{GmuxBin: s.GmuxBin, Command: legacy.Command, CWD: cwd, ResumeID: legacy.ID, InitialCols: value16(row.TerminalCols), Rows: value16(row.TerminalRows), Endpoint: endpoint, LeaseFile: leaseFile})
+	_ = leaseFile.Close()
+	if err != nil {
+		prepared.rollback()
 		return "", err
 	}
+	// cmd.Start is the ownership-transfer point. Keep the exact sidecar lease
+	// held until then: failed launch can remove the file it created without a
+	// pathname reacquisition race, while a successful child cannot acquire and
+	// bind until the parent publishes the prepared history here.
+	prepared.transfer()
 	if result.Endpoint == "" {
 		result.Endpoint = endpoint
 	}
@@ -381,6 +409,67 @@ func (s *productionRunnerSpawner) Spawn(ctx context.Context, row centralstore.Se
 	s.launched[result.Endpoint] = result
 	s.mu.Unlock()
 	return result.Endpoint, nil
+}
+
+type preparedResumeSocket struct {
+	lease   *socklease.Lease
+	created bool
+}
+
+func (p *preparedResumeSocket) transfer() {
+	_ = p.lease.ReleaseForTransfer()
+	p.lease = nil
+}
+
+func (p *preparedResumeSocket) rollback() {
+	if p.created {
+		_ = p.lease.Release()
+	} else {
+		_ = p.lease.ReleaseKeepingLockFile()
+	}
+	p.lease = nil
+}
+
+func prepareResumeSocket(endpoint string, beforeRemove func(string)) (*preparedResumeSocket, error) {
+	if err := socklease.RequireOwnedDir(filepath.Dir(endpoint)); err != nil {
+		return nil, err
+	}
+	lease, err := socklease.Acquire(endpoint)
+	if err != nil {
+		return nil, err
+	}
+	prepared := &preparedResumeSocket{lease: lease, created: lease.CreatedLockFile()}
+	fail := func(err error, discardHistory bool) (*preparedResumeSocket, error) {
+		if prepared.created || discardHistory {
+			_ = lease.Release()
+		} else {
+			_ = lease.ReleaseKeepingLockFile()
+		}
+		return nil, err
+	}
+
+	if _, err := os.Lstat(endpoint); errors.Is(err, os.ErrNotExist) {
+		return prepared, nil
+	} else if err != nil {
+		return fail(err, false)
+	}
+	pin, err := socklease.PinSocket(endpoint)
+	if err != nil {
+		return fail(err, false)
+	}
+	defer pin.Close()
+	if err := socklease.ProbeRefusedPinned(pin, 200*time.Millisecond); err != nil {
+		// A successful connection is an unleased live owner, so existing lease
+		// history describes an older generation and must not survive either.
+		return fail(err, errors.Is(err, socklease.ErrSocketLive))
+	}
+	if beforeRemove != nil {
+		beforeRemove(endpoint)
+	}
+	if err := lease.RemoveSocket(pin); err != nil {
+		return fail(err, false)
+	}
+	return prepared, nil
 }
 
 func waitRunnerSocket(ctx context.Context, endpoint string, exited <-chan error, timeout time.Duration) error {
@@ -436,6 +525,10 @@ func launchRunnerProcess(ctx context.Context, req runnerLaunchRequest) (runnerLa
 	cmd.Dir = req.CWD
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
 	cmd.Env = sessionenv.Strip(captureLoginEnv(req.GmuxBin, req.CWD))
+	if req.LeaseFile != nil {
+		cmd.ExtraFiles = append(cmd.ExtraFiles, req.LeaseFile)
+		cmd.Env = append(cmd.Env, "GMUX_SOCKET_LEASE_FD=3")
+	}
 	// Stdio is wired explicitly, and to nothing.
 	//
 	// A runner outlives the daemon that spawned it, so a runner holding the

--- a/services/gmuxd/cmd/gmuxd/production_spawner_composed_test.go
+++ b/services/gmuxd/cmd/gmuxd/production_spawner_composed_test.go
@@ -7,12 +7,15 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"path/filepath"
 	"reflect"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/gmuxapp/gmux/packages/paths"
+	"github.com/gmuxapp/gmux/packages/socklease"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/centralstore"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/sessioncoord"
 )
@@ -108,11 +111,33 @@ func TestProductionSpawnerResumeComposedWithRealUnixRunner(t *testing.T) {
 	}
 	defer st.Close()
 	row := insertRetainedDead(t, st, "sess-resume-composed")
+	// Simulate a runner from before the lease protocol crashing: the canonical
+	// socket refuses connections and has no sidecar lock file. This was the
+	// production regression shape: BindSocket refused to reclaim it, silently
+	// chose a new id, and the spawner waited on this pathname until timeout.
+	stalePath := filepath.Join(paths.SessionSocketDir(), string(row.ID)+".sock")
+	stale, err := net.ListenUnix("unix", &net.UnixAddr{Name: stalePath, Net: "unix"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	stale.SetUnlinkOnClose(false)
+	if err := stale.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(stalePath + socklease.Suffix); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("test did not create a pre-lease stale socket: %v", err)
+	}
 	var got runnerLaunchRequest
 	var child *unixFakeRunner
 	prod := &productionRunnerSpawner{ResolveDir: func(centralstore.Session) (string, error) { return "/chosen", nil }, ResolveCommand: func(centralstore.Session) []string { return []string{"shell", "--resume", "conversation"} }}
 	prod.Launch = func(_ context.Context, req runnerLaunchRequest) (runnerLaunchResult, error) {
 		got = req
+		if _, err := os.Stat(stalePath); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("stale socket still present at launch: %v", err)
+		}
+		if _, err := os.Stat(stalePath + socklease.Suffix); err != nil {
+			t.Fatalf("resume did not seed lease history for child: %v", err)
+		}
 		child = startUnixFakeRunner(t, req.Endpoint, string(row.ID), http.StatusOK)
 		return runnerLaunchResult{Endpoint: req.Endpoint, PID: 4321, Terminate: child.terminate}, nil
 	}

--- a/services/gmuxd/cmd/gmuxd/production_spawner_test.go
+++ b/services/gmuxd/cmd/gmuxd/production_spawner_test.go
@@ -3,9 +3,16 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
+	"time"
 
+	"github.com/gmuxapp/gmux/packages/paths"
+	"github.com/gmuxapp/gmux/packages/socklease"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/centralstore"
 )
 
@@ -87,6 +94,185 @@ func TestProductionSpawnerLaunchPolicyAndCleanup(t *testing.T) {
 	}
 	if err := spawner.CleanupSpawn(context.Background(), ep); err != nil {
 		t.Fatalf("idempotent cleanup: %v", err)
+	}
+}
+
+func TestProductionSpawnerExecTransfersPreparedLease(t *testing.T) {
+	t.Setenv("GMUX_SOCKET_DIR", shortSocketDir(t))
+	endpoint := filepath.Join(paths.SessionSocketDir(), "sess-exec.sock")
+	dir := t.TempDir()
+	script := filepath.Join(dir, "lease-runner")
+	body := fmt.Sprintf(`#!/usr/bin/python3
+import os, socket, time
+fd = int(os.environ["GMUX_SOCKET_LEASE_FD"])
+os.fstat(fd)
+s = socket.socket(socket.AF_UNIX)
+s.bind(%q)
+s.listen(1)
+time.sleep(30)
+`, endpoint)
+	if err := os.WriteFile(script, []byte(body), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	spawner := &productionRunnerSpawner{
+		GmuxBin:        script,
+		ResolveDir:     func(centralstore.Session) (string, error) { return dir, nil },
+		ResolveCommand: func(centralstore.Session) []string { return []string{"x"} },
+		ReadyTimeout:   2 * time.Second,
+	}
+	ep, err := spawner.Spawn(context.Background(), centralstore.Session{ID: "sess-exec"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer spawner.CleanupSpawn(context.Background(), ep)
+	if ep != endpoint {
+		t.Fatalf("endpoint=%q, want %q", ep, endpoint)
+	}
+	if contender, err := socklease.AcquireExisting(endpoint); !errors.Is(err, socklease.ErrHeld) {
+		if err == nil {
+			_ = contender.ReleaseKeepingLockFile()
+		}
+		t.Fatalf("exec child did not retain lease: %v", err)
+	}
+}
+
+func TestProductionSpawnerLiveSocketAbortsBeforeLaunch(t *testing.T) {
+	t.Setenv("GMUX_SOCKET_DIR", shortSocketDir(t))
+	endpoint := filepath.Join(paths.SessionSocketDir(), "sess-live.sock")
+	listener, err := net.Listen("unix", endpoint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+	launched := false
+	spawner := &productionRunnerSpawner{
+		ResolveDir:     func(centralstore.Session) (string, error) { return t.TempDir(), nil },
+		ResolveCommand: func(centralstore.Session) []string { return []string{"x"} },
+		Launch: func(context.Context, runnerLaunchRequest) (runnerLaunchResult, error) {
+			launched = true
+			return runnerLaunchResult{}, nil
+		},
+	}
+	if _, err := spawner.Spawn(context.Background(), centralstore.Session{ID: "sess-live"}); !errors.Is(err, socklease.ErrSocketLive) {
+		t.Fatalf("Spawn error=%v, want live-socket refusal", err)
+	}
+	if launched {
+		t.Fatal("live endpoint allowed child launch")
+	}
+	conn, err := net.Dial("unix", endpoint)
+	if err != nil {
+		t.Fatalf("live endpoint was unlinked: %v", err)
+	}
+	conn.Close()
+	if _, err := os.Stat(endpoint + socklease.Suffix); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("fabricated lease history retained: %v", err)
+	}
+}
+
+func TestProductionSpawnerIdentityChangeAbortsBeforeLaunch(t *testing.T) {
+	t.Setenv("GMUX_SOCKET_DIR", shortSocketDir(t))
+	endpoint := filepath.Join(paths.SessionSocketDir(), "sess-rebound.sock")
+	stale, err := net.ListenUnix("unix", &net.UnixAddr{Name: endpoint, Net: "unix"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	stale.SetUnlinkOnClose(false)
+	if err := stale.Close(); err != nil {
+		t.Fatal(err)
+	}
+	var replacement net.Listener
+	launched := false
+	spawner := &productionRunnerSpawner{
+		ResolveDir:     func(centralstore.Session) (string, error) { return t.TempDir(), nil },
+		ResolveCommand: func(centralstore.Session) []string { return []string{"x"} },
+		prepareBeforeRemove: func(path string) {
+			if err := os.Rename(path, path+".parked"); err != nil {
+				t.Fatal(err)
+			}
+			replacement, err = net.Listen("unix", path)
+			if err != nil {
+				t.Fatal(err)
+			}
+		},
+		Launch: func(context.Context, runnerLaunchRequest) (runnerLaunchResult, error) {
+			launched = true
+			return runnerLaunchResult{}, nil
+		},
+	}
+	defer func() {
+		if replacement != nil {
+			replacement.Close()
+		}
+	}()
+	if _, err := spawner.Spawn(context.Background(), centralstore.Session{ID: "sess-rebound"}); !errors.Is(err, socklease.ErrIdentityChanged) {
+		t.Fatalf("Spawn error=%v, want identity change", err)
+	}
+	if launched {
+		t.Fatal("ambiguous replacement allowed child launch")
+	}
+	conn, err := net.Dial("unix", endpoint)
+	if err != nil {
+		t.Fatalf("replacement socket was removed: %v", err)
+	}
+	conn.Close()
+}
+
+func TestProductionSpawnerLaunchFailureDropsPreparedHistory(t *testing.T) {
+	t.Setenv("GMUX_SOCKET_DIR", shortSocketDir(t))
+	spawner := &productionRunnerSpawner{ResolveDir: func(centralstore.Session) (string, error) { return t.TempDir(), nil }, ResolveCommand: func(centralstore.Session) []string { return []string{"x"} }, Launch: func(_ context.Context, req runnerLaunchRequest) (runnerLaunchResult, error) {
+		if lease, err := socklease.AcquireExisting(req.Endpoint); !errors.Is(err, socklease.ErrHeld) {
+			if err == nil {
+				_ = lease.ReleaseKeepingLockFile()
+			}
+			t.Fatalf("prepared lease not held across launch: %v", err)
+		}
+		return runnerLaunchResult{}, errors.New("fork failed")
+	}}
+	if _, err := spawner.Spawn(context.Background(), centralstore.Session{ID: "sess-no-launch"}); err == nil {
+		t.Fatal("launch failure swallowed")
+	}
+	lock := filepath.Join(paths.SessionSocketDir(), "sess-no-launch.sock") + socklease.Suffix
+	if _, err := os.Stat(lock); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("failed launch retained fabricated history: %v", err)
+	}
+}
+
+func TestProductionSpawnerLaunchFailurePreservesExistingHistory(t *testing.T) {
+	t.Setenv("GMUX_SOCKET_DIR", shortSocketDir(t))
+	endpoint := filepath.Join(paths.SessionSocketDir(), "sess-existing.sock")
+	seed, err := socklease.Acquire(endpoint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := seed.ReleaseKeepingLockFile(); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.Stat(endpoint + socklease.Suffix)
+	if err != nil {
+		t.Fatal(err)
+	}
+	spawner := &productionRunnerSpawner{
+		ResolveDir:     func(centralstore.Session) (string, error) { return t.TempDir(), nil },
+		ResolveCommand: func(centralstore.Session) []string { return []string{"x"} },
+		Launch: func(_ context.Context, req runnerLaunchRequest) (runnerLaunchResult, error) {
+			if lease, err := socklease.AcquireExisting(req.Endpoint); !errors.Is(err, socklease.ErrHeld) {
+				if err == nil {
+					_ = lease.ReleaseKeepingLockFile()
+				}
+				t.Fatalf("existing lease not held across launch: %v", err)
+			}
+			return runnerLaunchResult{}, errors.New("fork failed")
+		},
+	}
+	if _, err := spawner.Spawn(context.Background(), centralstore.Session{ID: "sess-existing"}); err == nil {
+		t.Fatal("launch failure swallowed")
+	}
+	after, err := os.Stat(endpoint + socklease.Suffix)
+	if err != nil {
+		t.Fatalf("pre-existing history removed: %v", err)
+	}
+	if !os.SameFile(before, after) {
+		t.Fatal("pre-existing history was replaced")
 	}
 }
 


### PR DESCRIPTION
## Summary

- safely reclaim a refused canonical session socket before launching a resumed runner
- make explicit `--resume-id` strict so a failed resume cannot mint an unrelated durable session
- roll back lease history when launch never starts, and fail before launch for live/ambiguous occupants

## User-visible regressions fixed

1. Resume no longer times out for 5s on a stale canonical socket with `connect: connection refused`.
2. Failed resume attempts no longer create duplicate/phantom sleeping sidebar entries.

## Cause

`df328e6d0aaa` made generic runner socket cleanup correctly conservative: a refused socket with no lock sidecar could belong to a pre-lease runner, so `BindSocket` declined to unlink it. Resume did not prepare that legacy stale shape. The runner then treated the explicit resume collision as an ordinary generated-ID collision, bound a fresh ID, while gmuxd kept waiting on the original refused pathname.

The spawner now uses the shared lease + pin/probe/conditional-remove protocol at the stronger resume boundary, and the runner never changes an explicit resume identity.

## Tests

- stale/refused pre-lease Unix socket is removed and resume registers under the original ID
- live canonical socket aborts before launch, remains connectable, and leaves no fabricated sidecar
- failed launch rolls back prepared lease history
- explicit resume collision cannot enter generated-ID fallback
- failed registration retries terminate children and retain the original session

Validated with:

- `go test ./cli/gmux/cmd/gmux ./services/gmuxd/cmd/gmuxd ./packages/socklease ./cli/gmux/internal/ptyserver`
- `go vet ./cli/gmux/cmd/gmux ./services/gmuxd/cmd/gmuxd ./packages/socklease`
