### PR TITLE
test(centralstore): verify concurrent pool operations

### DIFF
--- a/services/gmuxd/internal/centralstore/pool_contention_test.go
+++ b/services/gmuxd/internal/centralstore/pool_contention_test.go
@@ -100,7 +100,9 @@ func TestWritesSurviveHeldReadConnections(t *testing.T) {
 }
 
 // TestReadPoolConcurrentReadWrite runs concurrent readers and writers under
-// -race to verify the separate pools don't introduce data races.
+// -race to verify the separate pools don't introduce data races. Every
+// goroutine error is collected via t.Error so failures surface clearly,
+// and the final store state is checked for consistency.
 func TestReadPoolConcurrentReadWrite(t *testing.T) {
 	s := openTestStore(t)
 	ctx := context.Background()
@@ -109,7 +111,12 @@ func TestReadPoolConcurrentReadWrite(t *testing.T) {
 	const readers = 4
 	const iterations = 50
 
-	var wg sync.WaitGroup
+	var (
+		wg        sync.WaitGroup
+		mu        sync.Mutex
+		writeErrs []string
+		readErrs  []string
+	)
 	wg.Add(writers + readers)
 
 	for w := range writers {
@@ -117,23 +124,73 @@ func TestReadPoolConcurrentReadWrite(t *testing.T) {
 			defer wg.Done()
 			for i := range iterations {
 				id := SessionID(fmt.Sprintf("rw-%d-%d", w, i))
-				_, _, _ = s.RegisterRunner(ctx, RunnerRegistration{
+				_, _, err := s.RegisterRunner(ctx, RunnerRegistration{
 					ID: id, Adapter: "test", Alive: true,
 					CreatedAt: UnixMillis(int64(w*1000 + i)), ObservedAt: UnixMillis(int64(w*1000 + i)),
 					Facts: RunnerFacts{CWD: strPtr("/tmp")},
 				})
+				if err != nil {
+					mu.Lock()
+					writeErrs = append(writeErrs, fmt.Sprintf("writer %d iter %d: %v", w, i, err))
+					mu.Unlock()
+				}
 			}
 		}()
 	}
-	for range readers {
+	for r := range readers {
 		go func() {
 			defer wg.Done()
-			for range iterations {
-				_, _ = s.ReadSnapshot(ctx, SnapshotQuery{IncludeSessions: true, IncludeProjects: true})
+			for i := range iterations {
+				_, err := s.ReadSnapshot(ctx, SnapshotQuery{IncludeSessions: true, IncludeProjects: true})
+				if err != nil {
+					mu.Lock()
+					readErrs = append(readErrs, fmt.Sprintf("reader %d iter %d: %v", r, i, err))
+					mu.Unlock()
+				}
 			}
 		}()
 	}
 	wg.Wait()
+
+	for _, e := range writeErrs {
+		t.Error("write error:", e)
+	}
+	for _, e := range readErrs {
+		t.Error("read error:", e)
+	}
+	if t.Failed() {
+		return
+	}
+
+	// Verify every unique write and its distinguishing fields reached the store.
+	snap, err := s.ReadSnapshot(ctx, SnapshotQuery{IncludeSessions: true})
+	if err != nil {
+		t.Fatalf("final ReadSnapshot: %v", err)
+	}
+	const want = writers * iterations
+	if got := len(snap.Sessions); got != want {
+		t.Errorf("final session count = %d, want %d", got, want)
+	}
+	seen := make(map[SessionID]Session, len(snap.Sessions))
+	for _, view := range snap.Sessions {
+		if _, duplicate := seen[view.ID]; duplicate {
+			t.Errorf("final snapshot contains duplicate session %q", view.ID)
+		}
+		seen[view.ID] = view.Session
+	}
+	for w := range writers {
+		for i := range iterations {
+			id := SessionID(fmt.Sprintf("rw-%d-%d", w, i))
+			session, ok := seen[id]
+			if !ok {
+				t.Errorf("final snapshot missing session %q", id)
+				continue
+			}
+			if session.Adapter != "test" || session.CWD != "/tmp" || session.CreatedAt != UnixMillis(w*1000+i) {
+				t.Errorf("final session %q = %#v", id, session)
+			}
+		}
+	}
 }
 
 func openTestStoreInDir(t *testing.T, dir string) *Store {


### PR DESCRIPTION
Follow-up test hardening for #410, now based directly on `main` after #414 merged.

`TestReadPoolConcurrentReadWrite` now:
- collects every writer and reader error without calling `testing.T` from worker goroutines;
- waits for all workers before reporting errors, so collection cannot deadlock;
- verifies the final snapshot contains all 200 unique writes; and
- checks each session's adapter, CWD, and creation timestamp.

Validation:
- `go test -race -count=10 ./internal/centralstore -run '^TestReadPoolConcurrentReadWrite$'`
- `go test ./internal/centralstore`
- `go test ./...` (from `services/gmuxd`)
- injected canceled-read mutation fails on the collected reader error
- skipped-write mutation fails on count and missing IDs
