### PR TITLE
feat(cli): split agent reads into status and filterable logs

### DIFF
--- a/apps/website/src/content/docs/integrations/scripts-and-agents.md
+++ b/apps/website/src/content/docs/integrations/scripts-and-agents.md
@@ -56,7 +56,7 @@ For **agent sessions on this host** (pi today), `gmux agent` is the verb to scri
 ```bash
 id=$(gmux -d -- pi)
 answer=$(gmux agent prompt --timeout 600 "$id" 'run the suite and fix what fails')
-gmux agent output "$id"                 # the same answer, read again later
+gmux agent status "$id"                 # what matters now: state, trigger, answer
 ```
 
 ### Launching and prompting in one command
@@ -67,7 +67,7 @@ sends the prompt as its first turn.
 
 ```bash
 id=$(gmux agent prompt --new --no-wait --name review 'review the diff on this branch')
-gmux wait "$id" && gmux agent output "$id"
+gmux wait "$id" && gmux agent status "$id"
 
 gmux agent prompt --new --model anthropic/sonnet 'summarize this repo'   # id, then the answer
 ```
@@ -107,7 +107,7 @@ behind or steer); `--timeout` bounds your wait, never the launch. `--new`
 launches pi only — for any other command, the two-step `gmux -d -- <cmd>` plus
 a prompt remains fully supported and is the shape to use.
 
-`agent prompt` blocks until the turn ends and prints the agent's answer on stdout — the turn's final message only (no `[tool]` lines), as the agent asserted it for that turn (gmux does not reconstruct it from the transcript, so an answer is only ever attributed to the turn that produced it). Exit codes are gmux's global taxonomy, shared by every verb that reports a gmux verdict (`gmux -- <cmd>`/`gmux edit` pass the child's code through, and `gmux daemon|auth|remote` pass gmuxd's): `0` the turn completed, `2` it was intentionally interrupted, `1` anything else (a failed turn, a `--timeout`, a dead runner). A turn that did not complete prints **nothing**: a previous turn's answer must never be handed back as this one's. `gmux agent output <id>` reads whatever exists in that case, and works even after the session has died.
+`agent prompt` blocks until the turn ends and prints the agent's answer on stdout — the turn's final message only (no `[tool]` lines), as the agent asserted it for that turn (gmux does not reconstruct it from the transcript, so an answer is only ever attributed to the turn that produced it). Exit codes are gmux's global taxonomy, shared by every verb that reports a gmux verdict (`gmux -- <cmd>`/`gmux edit` pass the child's code through, and `gmux daemon|auth|remote` pass gmuxd's): `0` the turn completed, `2` it was intentionally interrupted, `1` anything else (a failed turn, a `--timeout`, a dead runner). A turn that did not complete prints **nothing**: a previous turn's answer must never be handed back as this one's. `gmux agent status <id>` shows whatever exists in that case (and `gmux agent logs --agent -n 1 <id>` the answer alone), and works even after the session has died — as a snapshot read it can be staler than the answer a wait carries.
 
 The other shapes:
 
@@ -153,7 +153,7 @@ gmux agent logs <id> -n 2      # the prompt and the reply, clean markdown
 
 The idle signal is the same `Status.Active` flag the UI's spinner consumes, so `wait` returns the moment the agent emits its closing message. On an already-idle session it returns immediately and reports the **last** turn's conclusion and result — to gate on a turn you are about to trigger, use `gmux agent prompt` or `send --wait` (below), which arm the wait before delivering anything. Exit codes: `0` the turn completed (or the output condition matched), `2` the turn was intentionally interrupted, `1` anything else — a failed turn, a death, or `--timeout N` elapsing.
 
-`wait` is also **result-bearing**: for a result-bearing agent (pi today — one that asserts its own turn boundary and result), a turn that completed normally prints that turn's final message, exactly like `gmux agent prompt`. A wait that arrives after the turn already closed reports the conclusion but no answer: it never observed the turn, so it does not claim one — `gmux agent output` is the snapshot read for that.
+`wait` is also **result-bearing**: for a result-bearing agent (pi today — one that asserts its own turn boundary and result), a turn that completed normally prints that turn's final message, exactly like `gmux agent prompt`. A wait that arrives after the turn already closed reports the conclusion but no answer: it never observed the turn, so it does not claim one — `gmux agent status` is the snapshot read for that.
 
 ```bash
 answer=$(gmux wait "$id")       # the reply, or empty for a shell/other agent
@@ -178,21 +178,25 @@ Every session is waitable: agents get their idle signal from turn hooks, shells 
 
 ## Reading output
 
-Three commands answer three different questions, so a script never has to know what is running in a session to know what shape its output will be:
+Three commands split by **what you know you want**, so a script never has to know what is running in a session to know what shape its output will be:
 
 ```bash
-gmux tail <id> -n 50           # what is on its screen: raw terminal text, any session
-gmux agent logs <id> -n 10     # what it has been doing: conversation markdown (agents)
-gmux agent output <id>         # what the answer is: the latest message
+gmux tail <id> -n 50                # the raw screen: terminal text, any session
+gmux agent logs <id> --agent -n 1   # the exact text you want (here: the answer alone)
+gmux agent status <id>              # "show me what matters": state, trigger, content
 ```
 
 `gmux tail <id>` is always the raw view: the last `-n N` **lines** of rendered terminal output as plain text (default 100), for shells, one-shot commands and agents alike.
 
-`gmux agent logs <id>` prints the session's conversation as clean markdown for agents that persist a conversation file (pi): `## User` / `## Assistant` messages with compact `[tool] …` one-liners — the actual exchange, not the TUI's box-drawing and spinners. Here `-n N` counts **messages** (default 100). It reads the agent's stored conversation, so it never starts or resumes anything and works on a dead session; agents with no readable conversation answer `unsupported_adapter`, where `gmux tail` is the fallback. Pair the reads with `wait` to capture an agent's final answer:
+`gmux agent logs <id>` prints the session's conversation as clean markdown for agents that persist a conversation file (pi): `## User` / `## Assistant` messages with compact `[tool] …` one-liners — the actual exchange, not the TUI's box-drawing and spinners. Here `-n N` counts **messages** (default 100), counted after the message-type filter: no flag gives user messages plus assistant prose, and `--user`/`--agent`/`--tool`/`--all` **replace** that set (`--agent -n 1` is the latest answer alone). `--json` prints a JSON array of `{role, type, text, prose}` — the machine contract for this read. There is no `--thinking`: no adapter renders thinking blocks, so the flag is refused by name instead of printing nothing.
+
+`gmux agent status <id>` answers "what is going on with this session" in a fixed three-part shape — a state line (alive/dead, active/idle, the last *closed* turn's outcome and rough recency), the triggering excerpt, and the relevant content (the final answer when idle; the last few messages and a working indicator while a turn runs). A running turn is reported with no outcome, and a session that died mid-turn reads `the turn never finished (runner died)` — the same verdict `gmux wait` reaches for that row (`error`, cause `runner_died`), so the two verbs never disagree. `--json` gives one object with those three parts and a `content.kind` of `"answer"`, `"recent"` or `"none"`; fields describing a turn that does not exist (`state.last_turn_outcome`, `state.last_turn_cause`, `trigger.code`) are absent rather than empty, so branch on `state.active`/`state.turn_recorded`.
+
+Both agent reads are snapshots of the agent's stored conversation: they never start or resume anything and work on a dead session, and they can be staler than the answer a `wait` or a synchronous `prompt` carries. Agents with no readable conversation answer `unsupported_adapter` for `logs`, while `status` still prints its (adapter-independent) state line with a note — `gmux tail` is the fallback for the content. Pair the reads with `wait` to capture an agent's final answer:
 
 ```bash
 gmux agent prompt --timeout 600 <id> < ship-prompt.txt   # prints the reply
-url=$(gmux agent output <id> | grep -oE 'https://github\.com/[^ ]+/pull/[0-9]+' | tail -1)
+url=$(gmux agent logs --agent -n 1 <id> | grep -oE 'https://github\.com/[^ ]+/pull/[0-9]+' | tail -1)
 echo "$url"
 ```
 

--- a/apps/website/src/content/docs/reference/cli.md
+++ b/apps/website/src/content/docs/reference/cli.md
@@ -128,9 +128,11 @@ It's a snapshot, not a stream — to watch a session live, attach to it or open
 it in the browser.
 
 For an agent session, the semantic views usually answer the question better:
-[`gmux agent logs`](#gmux-agent-logs-id) prints the conversation as markdown
-(what it has been doing) and [`gmux agent output`](#gmux-agent-output-id)
-prints just its latest answer.
+[`gmux agent logs`](#gmux-agent-logs-id) prints the exact conversation text you
+ask for (filterable by message type) and
+[`gmux agent status`](#gmux-agent-status-id) shows what matters right now: state
+line, trigger excerpt, and the answer (or the last few messages while a turn is
+running).
 
 :::note[Changed]
 `gmux tail` briefly defaulted to the conversation transcript for agent
@@ -284,7 +286,7 @@ gmux wait --quiet a3f20187        # synchronize only, print nothing
 Nothing is printed when the turn ended in an error, was interrupted, or the
 session died: a previous or partial turn's message presented as this turn's
 answer would be worse than silence. The condition is reported on stderr, and
-`gmux agent output <id>` still reads whatever exists. Also result-free, and
+`gmux agent status <id>` still shows whatever exists. Also result-free, and
 perfectly waitable: shell/process sessions, agents that assert no turn identity
 (Claude, Codex), output-condition waits, and a wait that arrives after the turn
 has already closed — it never observed that turn, so it reports the conclusion
@@ -334,14 +336,20 @@ quietly typing something — drive those with `gmux send` and read them with
 `gmux tail`. `gmux agent help` prints the namespace guide in the terminal;
 each verb also answers `--help`.
 
-Three reading commands answer three different questions, and no word does
-double duty across the raw/semantic boundary:
+Three reading commands split by **what you know you want**, not by the shape
+that comes back:
 
-| Question | Command | Unit of `-n` |
+| You want | Command | Unit of `-n` |
 | --- | --- | --- |
-| What is on its screen? | [`gmux tail <id>`](#gmux-tail-id) (any session) | lines |
-| What has it been doing? | [`gmux agent logs <id>`](#gmux-agent-logs-id) | messages |
-| What is the answer? | [`gmux agent output <id>`](#gmux-agent-output-id) | — |
+| The raw screen | [`gmux tail <id>`](#gmux-tail-id) (any session) | lines |
+| The exact text you want | [`gmux agent logs <id>`](#gmux-agent-logs-id) | messages (post-filter) |
+| "Show me what matters" | [`gmux agent status <id>`](#gmux-agent-status-id) | — |
+
+:::note[Changed]
+`gmux agent output` was replaced by `gmux agent status` (the report) and
+`gmux agent logs --agent -n 1 <id>` (the answer alone). The old verb fails by
+name and prints both replacements.
+:::
 
 ### `gmux agent prompt [flags] <id> [prompt]`
 
@@ -400,8 +408,9 @@ close, not a conversation read: a result is only ever served to the turn it
 belongs to, and a turn nobody could identify is served none. A turn that failed
 or was interrupted prints **nothing** — a previous or partial turn's message
 presented as this one's answer is worse than silence. Read what exists with
-`gmux agent output <id>`, which is explicitly a snapshot read of the transcript
-and is also where a truncated answer's full text lives.
+`gmux agent status <id>`, or the answer alone with
+`gmux agent logs --agent -n 1 <id>` — both are snapshot reads of the transcript,
+and the latter is where a truncated answer's full text lives.
 
 Failures name a stable code, and the wording distinguishes what is known about
 delivery. `admission_timeout`, `delivery_timeout` and
@@ -425,7 +434,7 @@ gmux agent prompt --new [--model M] [--name N] [--timeout N] [--no-wait] [prompt
 
 # handoff pattern, one command instead of two
 id=$(gmux agent prompt --new --no-wait --name review 'review the diff on this branch')
-gmux wait "$id" && gmux agent output "$id"
+gmux wait "$id" && gmux agent status "$id"
 
 # synchronous: the id, then the answer
 gmux agent prompt --new --model anthropic/sonnet 'summarize this repo'
@@ -517,7 +526,7 @@ action. Plain prompts (Enter) are unaffected.
 
 ### `gmux agent logs <id>`
 
-Print what the agent has been doing: its conversation as clean markdown. For
+Print the exact conversation text you want, as clean markdown. For
 agents that persist a structured conversation file (pi), the transcript is
 reconstructed from that file — the actual user/assistant messages plus compact
 one-line tool calls — rather than the terminal rendering of the TUI, so the
@@ -525,38 +534,109 @@ output is readable and pipe-friendly. Thinking blocks and tool outputs are
 omitted.
 
 ```bash
-gmux agent logs a3f20187          # last 100 messages
-gmux agent logs -n 2 a3f20187     # the prompt and the reply
-gmux agent prompt a3f20187 'fix the failing test' && gmux agent logs -n 4 a3f20187
+gmux agent logs a3f20187              # last 100 messages (user + agent prose)
+gmux agent logs -n 2 a3f20187         # the prompt and the reply
+gmux agent logs --agent -n 1 a3f20187 # the latest answer, alone
+gmux agent logs --tool -n 20 a3f20187 # what it has been running
+gmux agent logs --all a3f20187        # every rendered message type
+gmux agent logs --json --user a3f20187
 ```
 
+**Message-type filters.** With no flag you get the conversation without the
+machinery: user messages and assistant messages that actually said something
+(tool-call-only messages and tool output are excluded). Explicit type flags
+**replace** that default set and compose with each other:
+
+| Flag | Shows |
+| --- | --- |
+| `--user` | user messages (prompts, steers, merged follow-ups) |
+| `--agent` | assistant messages that carry prose |
+| `--tool` | messages that are only tool calls |
+| `--all` | every type gmux renders |
+
+There is no `--thinking`: no adapter renders thinking blocks today (pi's own
+transcript drops them), so the flag is refused by name rather than answering
+with silence — `gmux tail <id>` shows whatever the TUI painted.
+
+`--json` prints a JSON array of `{role, type, text, prose}` on stdout. That
+array is the machine contract for this read; `text` is the message as rendered
+(tool one-liners included) and `prose` is only what the agent said.
+
 `-n` counts **messages** (default 100), not lines — that is the unit difference
-that earned this view its own command. The transcript is read from the
+that earned this view its own command — and it counts them **after** the type
+filter, so `--tool -n 1` is the last tool call rather than "the last message, if
+it happens to be one". The transcript is read from the
 conversation file the agent has flushed to disk, so an assistant message that is
 still streaming appears once it completes.
 
-Read from the agent's own stored conversation, so like `gmux agent output` it
+Read from the agent's own stored conversation, so like `gmux agent status` it
 never starts, resumes or touches a process, and it works on a dead retained
 session. Local sessions only. Exits `1` with a stable code when there is nothing
-to print: `no_conversation` (nothing rendered yet) or `unsupported_adapter` (this
-agent has no conversation gmux can read) — use `gmux tail <id>` for those, which
-shows the terminal itself.
+to print: `no_message` (nothing of the requested types), `no_conversation`
+(nothing rendered yet) or `unsupported_adapter` (this agent has no conversation
+gmux can read) — use `gmux tail <id>` for those, which shows the terminal itself.
 
-### `gmux agent output <id>`
+`gmux agent logs --agent -n 1 <id>` approximates the old `gmux agent output`. It
+is a **snapshot** read, so it can be staler than the answer a `gmux wait` or a
+synchronous `gmux agent prompt` carries: those report what the adapter asserted
+at turn close, while this reads the conversation the agent has flushed to disk.
 
-Print the agent's latest message — its answer, verbatim and untruncated,
-without the compact `[tool]` lines that appear in the transcript.
+### `gmux agent status <id>`
+
+Show what matters about an agent session right now — the verb for "I don't know
+what I want, show me what matters". Always the same three parts, whatever the
+session is doing:
 
 ```bash
-gmux agent prompt a3f20187 'summarize the failures' && gmux agent output a3f20187
+gmux agent status a3f20187
+gmux agent status --json a3f20187
 ```
 
-Read from the agent's own stored conversation, so it never starts, resumes or
-touches a process, and it works on a dead session. Exits `1` with a stable code
-when there is nothing to print: `no_message` (the agent hasn't produced one
-yet), `no_conversation` (no conversation on record), `unsupported_adapter`
-(this agent has no conversation gmux can read). Use `gmux agent logs` for the
-whole conversation, or `gmux tail` for the terminal itself.
+```
+## State
+
+a3f20187 pi — alive, idle; last turn completed 2m ago
+
+## Triggered by
+
+fix the failing test in internal/store
+
+## Answer
+
+Fixed: the fixture wrote the row before the migration ran.
+```
+
+- **State** — short id and adapter, alive/dead, active/idle, and the last
+  *closed* turn's outcome (`completed`, `interrupted`, `error`) with a rough
+  recency. A turn that is still running gets **no** outcome, in the report and
+  in `--json` alike: it has not concluded, and the flags describe the previous
+  turn. A session that **died mid-turn** reads `the turn never finished (runner
+  died)` — the same verdict `gmux wait` reaches for that row (`error`, cause
+  `runner_died`), never `completed`.
+- **Triggered by** — the first lines of the user message that started the
+  current (or last) turn, labeled so it can never be read as the answer. It is
+  the newest user message in the whole conversation, so a turn with hundreds of
+  tool calls cannot crowd it out. When gmux cannot read the conversation at all,
+  this part carries the daemon's reason instead of claiming nothing was asked.
+- **Answer** — the agent's final message when the session is idle. While a turn
+  is running this becomes **Recent**: the last few messages plus a working
+  indicator, because the previous turn's answer is not this turn's.
+
+A **snapshot**: store-only, no runner contact, no resume, so it works on a dead
+retained session — and it can be staler than the answer a `wait` or a
+synchronous prompt carries. The State part is adapter-independent, so a session
+whose conversation gmux cannot read (Claude, Codex, a shell) still gets it, with
+a note instead of the content rather than an error. Local sessions only.
+
+`--json` prints one object mirroring the three parts:
+`{state: {...}, trigger: {text, truncated}, content: {kind, ...}}`, where
+`content.kind` is `"answer"`, `"recent"` or `"none"`. Fields that describe a
+turn which does not exist are **absent** rather than empty:
+`state.last_turn_outcome` (and `state.last_turn_cause`, today only
+`runner_died`) appear only for a concluded turn, so `state.turn_recorded` and
+`state.active` are what a script branches on. `trigger.code` appears only when
+the conversation could not be read. That object is the machine contract for this
+read. For the answer and nothing else, use `gmux agent logs --agent -n 1 <id>`.
 
 ### `gmux kill <id>`
 

--- a/cli/gmux/cmd/gmux/agent.go
+++ b/cli/gmux/cmd/gmux/agent.go
@@ -5,8 +5,8 @@ package main
 //
 //	gmux agent prompt [--no-wait] [--follow-up|--steer] [--timeout|-t N] <ref> [prompt]
 //	gmux agent cancel <ref>
-//	gmux agent output <ref>
-//	gmux agent logs <ref> [-n N]
+//	gmux agent status <ref> [--json]
+//	gmux agent logs <ref> [-n N] [--user|--agent|--tool|--all] [--json]
 //
 // The distinction from `gmux send` is the whole point of the namespace: send
 // types bytes at a terminal and tells you nothing about whether an agent read
@@ -19,8 +19,12 @@ package main
 // This namespace is deliberately local-and-pi-only. A synchronous prompt that
 // completes prints the agent's answer (the daemon selects it at turn close);
 // a failed or interrupted turn prints nothing, because the newest stored
-// message would be a previous or partial turn's. `gmux agent output` reads it
-// explicitly in those cases.
+// message would be a previous or partial turn's. `gmux agent status` shows
+// what is there in those cases.
+//
+// The reading verbs split cognitively, not by shape (ADR 0027's 2026-07-28
+// amendment): `status` is "I don't know what I want, show me what matters",
+// `logs` is "I know the exact text I want", `tail` is the raw screen.
 
 import (
 	"encoding/json"
@@ -83,12 +87,19 @@ func parseAgent(args []string) (*command, error) {
 	switch head {
 	case "prompt":
 		return parseAgentPrompt(rest)
-	case "cancel", "output":
+	case "cancel":
 		return parseAgentRefOnly(head, rest)
+	case "status":
+		return parseAgentStatus(rest)
 	case "logs":
 		return parseAgentLogs(rest)
+	case "output":
+		// Removed by name, with both replacements spelled out. Silently
+		// aliasing it to `status` would print a three-part report where a
+		// script expected one bare answer on stdout, so the verb fails.
+		return nil, errors.New("agent output was replaced by 'gmux agent status <id>' (the state, the trigger and the relevant content); for the answer alone use 'gmux agent logs --agent -n 1 <id>'")
 	}
-	return nil, fmt.Errorf("unknown agent verb %q; expected prompt, logs, cancel or output", head)
+	return nil, fmt.Errorf("unknown agent verb %q; expected prompt, logs, status or cancel", head)
 }
 
 // parseAgentRefOnly handles the two ref-only verbs. Flags are rejected rather
@@ -99,7 +110,7 @@ func parseAgentRefOnly(sub string, args []string) (*command, error) {
 	}
 	// Report what is actually wrong. "requires a session id" for
 	// `agent cancel s1 s2` is false (one was given) and for
-	// `agent output s1 -h` it hides the misplaced flag.
+	// `agent cancel s1 -h` it hides the misplaced flag.
 	if len(args) == 0 {
 		return nil, fmt.Errorf("agent %s requires a session id", sub)
 	}
@@ -115,17 +126,62 @@ func parseAgentRefOnly(sub string, args []string) (*command, error) {
 	return &command{mode: modeAgent, agentSub: sub, ref: args[0]}, nil
 }
 
-// parseAgentLogs handles `gmux agent logs <ref> [-n N]`.
+// parseAgentStatus handles `gmux agent status <ref> [--json]`.
 //
-// The only knob is how much to print, so unlike prompt this verb takes flags
-// on either side of the ref (the interspersed convention `tail` and `wait`
-// already use): there is no verbatim trailing content here to protect, and a
-// caller who typed `gmux agent logs s1 -n 5` meant the count.
+// Flags may sit on either side of the ref, like logs: there is no verbatim
+// trailing content to protect here.
+func parseAgentStatus(args []string) (*command, error) {
+	if len(args) == 1 && isHelpToken(args[0]) {
+		return &command{mode: modeHelp, helpTopic: "agent status"}, nil
+	}
+	c := &command{mode: modeAgent, agentSub: "status"}
+	fs := newFlagSet("agent status")
+	fs.BoolVar(&c.json, "json", false, "print the machine shape instead of the report")
+	pos, err := parseInterspersed(fs, args)
+	if err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return &command{mode: modeHelp, helpTopic: "agent status"}, nil
+		}
+		return nil, fmt.Errorf("agent status: %v", err)
+	}
+	if len(pos) == 0 {
+		return nil, errors.New("agent status requires a session id")
+	}
+	if len(pos) > 1 {
+		return nil, fmt.Errorf("agent status takes exactly one session id (got %d: %s)", len(pos), strings.Join(pos, " "))
+	}
+	c.ref = pos[0]
+	return c, nil
+}
+
+// agentLogsTypes is the wire vocabulary of the transcript filter, shared with
+// the daemon's `types=` parameter.
+const (
+	agentLogTypeUser  = "user"
+	agentLogTypeAgent = "agent"
+	agentLogTypeTool  = "tool"
+)
+
+// parseAgentLogs handles
+// `gmux agent logs <ref> [-n N] [--user|--agent|--tool|--all] [--json]`.
+//
+// Flags sit on either side of the ref (the interspersed convention `tail` and
+// `wait` already use): there is no verbatim trailing content here to protect,
+// and a caller who typed `gmux agent logs s1 -n 5` meant the count.
 //
 // -n counts MESSAGES, not lines: the view is the rendered conversation, and
 // counting its lines would cut a message in half. That difference in unit
 // from `gmux tail -n` is the whole reason the two views stopped sharing one
-// verb.
+// verb. It counts POST-FILTER messages, because the filter is what the caller
+// asked to see: `--tool -n 1` is the last tool call, not "the last message if
+// it happens to be one".
+//
+// Type flags REPLACE the default set rather than adding to it, so the printed
+// view is always exactly the union of the types named — and `--all` is a name
+// for "every type gmux renders" rather than a magic widening of a default.
+// `--thinking` is refused by name: no adapter renders thinking blocks today
+// (pi's renderer drops them), so accepting it would answer with silence, which
+// reads as "the agent thought nothing".
 func parseAgentLogs(args []string) (*command, error) {
 	if len(args) == 1 && isHelpToken(args[0]) {
 		return &command{mode: modeHelp, helpTopic: "agent logs"}, nil
@@ -133,6 +189,13 @@ func parseAgentLogs(args []string) (*command, error) {
 	c := &command{mode: modeAgent, agentSub: "logs", tailLines: agentLogsDefaultMessages}
 	fs := newFlagSet("agent logs")
 	fs.IntVar(&c.tailLines, "n", agentLogsDefaultMessages, "number of conversation messages to show")
+	var user, agentProse, tool, all, thinking bool
+	fs.BoolVar(&user, "user", false, "show user messages")
+	fs.BoolVar(&agentProse, "agent", false, "show assistant messages that carry prose")
+	fs.BoolVar(&tool, "tool", false, "show tool-call-only messages")
+	fs.BoolVar(&all, "all", false, "show every rendered message type")
+	fs.BoolVar(&thinking, "thinking", false, "show thinking blocks (not rendered by any adapter)")
+	fs.BoolVar(&c.json, "json", false, "print the machine shape instead of markdown")
 	pos, err := parseInterspersed(fs, args)
 	if err != nil {
 		if errors.Is(err, flag.ErrHelp) {
@@ -148,6 +211,33 @@ func parseAgentLogs(args []string) (*command, error) {
 	}
 	if c.tailLines <= 0 {
 		return nil, errors.New("agent logs: -n must be a positive number of messages")
+	}
+	if thinking {
+		return nil, errors.New("agent logs: --thinking is not rendered by this adapter (pi's transcript drops thinking blocks); 'gmux tail <id>' shows whatever the TUI painted")
+	}
+	if all && (user || agentProse || tool) {
+		// --all IS the full set, so naming a subset beside it either repeats it
+		// or contradicts it. Picking a winner would print a view the caller did
+		// not ask for.
+		return nil, errors.New("agent logs: --all already selects every message type, so it cannot be combined with a type flag")
+	}
+	switch {
+	case all:
+		c.logTypes = []string{agentLogTypeUser, agentLogTypeAgent, agentLogTypeTool}
+	case user || agentProse || tool:
+		// Explicit types REPLACE the default pair.
+		if user {
+			c.logTypes = append(c.logTypes, agentLogTypeUser)
+		}
+		if agentProse {
+			c.logTypes = append(c.logTypes, agentLogTypeAgent)
+		}
+		if tool {
+			c.logTypes = append(c.logTypes, agentLogTypeTool)
+		}
+	default:
+		// The conversation without the machinery: what was asked and what was
+		// said. nil means "the daemon's default", which is this same pair.
 	}
 	c.ref = pos[0]
 	return c, nil
@@ -394,10 +484,10 @@ func cmdAgent(c *command) int {
 		return cmdAgentPrompt(c.ref, c.agentMode, c.agentNoWait, c.timeout, c.promptText)
 	case "cancel":
 		return cmdAgentCancel(c.ref)
-	case "output":
-		return cmdAgentOutput(c.ref)
+	case "status":
+		return cmdAgentStatus(c.ref, c.json)
 	case "logs":
-		return cmdAgentLogs(c.ref, c.tailLines)
+		return cmdAgentLogs(c.ref, c.tailLines, c.logTypes, c.json)
 	}
 	fmt.Fprintf(os.Stderr, "gmux: unknown agent verb %q\n", c.agentSub)
 	return waitExitError
@@ -615,13 +705,13 @@ type agentPromptResult struct {
 // code.
 //
 // A completed turn prints the agent's answer, which the daemon selected at turn
-// close with the same selector `gmux agent output` and `gmux wait` use. Every
+// close with the same selector `gmux agent status` and `gmux wait` use. Every
 // other conclusion prints NO result — a stale prior-turn answer must never be
 // presented as this turn's — and reports the condition on stderr instead.
 // `resumed` is worth a stderr line because it says the session was dead and has
 // been restarted: a state change the caller did not ask for.
 //
-// One coupling to know about: the error hint below names `gmux agent output`
+// One coupling to know about: the error hint below names `gmux agent status`
 // unconditionally, where reportWaitResult decides from the response's
 // `conversation_readable` whether to hint at `gmux tail` instead. The two agree
 // today only because a session that can be prompted has an AgentActionEncoder,
@@ -664,10 +754,10 @@ func reportAgentPromptSuccess(sess cliSession, status int, body []byte, noWait b
 		return waitExitInterrupted
 	case waitOutcomeError:
 		if res.Cause != "" {
-			fmt.Fprintf(os.Stderr, "gmux: the turn ended in an error (%s); see gmux agent output %s\n",
+			fmt.Fprintf(os.Stderr, "gmux: the turn ended in an error (%s); see gmux agent status %s\n",
 				res.Cause, shortID(sess.ID))
 		} else {
-			fmt.Fprintf(os.Stderr, "gmux: the turn ended in an error; see gmux agent output %s\n", shortID(sess.ID))
+			fmt.Fprintf(os.Stderr, "gmux: the turn ended in an error; see gmux agent status %s\n", shortID(sess.ID))
 		}
 		return waitExitError
 	default:
@@ -704,15 +794,30 @@ func cmdAgentCancel(ref string) int {
 	return waitExitOK
 }
 
-// cmdAgentOutput implements `gmux agent output`: print the agent's latest
-// final message, verbatim and untruncated, from the daemon's semantic
-// conversation read. It never resumes and never needs a live runner, so it
-// works on a dead retained session.
-func cmdAgentOutput(ref string) int {
-	sess, ok := resolveAgentSession(ref, "output")
-	if !ok {
-		return waitExitError
-	}
+// agentAnswerRead is the outcome of the daemon's semantic message-scope read:
+// the latest final assistant message, or the reason there is none.
+//
+// The reason is kept as the daemon's own code (and message) rather than
+// collapsed into an error: `status` reports "no answer yet" as part of a
+// perfectly good snapshot, while a transport failure is a failure.
+type agentAnswerRead struct {
+	Text string
+	// Code is the daemon's stable error code when there is no answer
+	// (no_message, no_conversation, unsupported_adapter, ...), "" on success.
+	Code string
+	// Message is the daemon's prose for Code.
+	Message string
+	// Failed marks a read that could not be performed at all (transport,
+	// version skew, an empty 200): not "there is no answer", but "gmux does not
+	// know". Report is the line to print for it.
+	Failed bool
+	Report string
+}
+
+// readAgentAnswer performs the store-only message-scope read for sess. It never
+// resumes and never needs a live runner, so it works on a dead retained
+// session.
+func readAgentAnswer(sess cliSession) agentAnswerRead {
 	client := gmuxdClient()
 	// No client deadline: the daemon re-reads and renders the agent's whole
 	// stored conversation to select one message, which on a long session and a
@@ -722,71 +827,88 @@ func cmdAgentOutput(ref string) int {
 	url := gmuxdBaseURL() + "/v1/sessions/" + sess.ID + "/conversation?scope=message"
 	resp, err := client.Get(url)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "gmux:", err)
-		return waitExitError
+		return agentAnswerRead{Failed: true, Report: err.Error()}
 	}
 	defer resp.Body.Close()
 	raw, err := io.ReadAll(resp.Body)
 	if err != nil && !errors.Is(err, io.EOF) {
-		fmt.Fprintln(os.Stderr, "gmux:", err)
-		return waitExitError
+		return agentAnswerRead{Failed: true, Report: err.Error()}
 	}
 	if msg := agentOutputSkewError(resp.StatusCode, resp.Header.Get(conversationScopeHeader)); msg != "" {
-		fmt.Fprintln(os.Stderr, "gmux:", msg)
-		return waitExitError
+		return agentAnswerRead{Failed: true, Report: msg}
 	}
 	if resp.StatusCode >= 300 {
-		return reportAgentError(sess, "output", resp.StatusCode, raw)
+		code, msg := errorCode(raw), extractMessage(raw)
+		if code == "" {
+			return agentAnswerRead{Failed: true, Report: agentSkewOrRawReport("status", resp.StatusCode, raw)}
+		}
+		return agentAnswerRead{Code: code, Message: msg}
 	}
 	if len(raw) == 0 {
 		// A marked but empty 200. The daemon cannot currently produce one (it
 		// answers no_message instead), so this is a contract guard rather than a
-		// known case: printing nothing under exit 0 would tell a script the
-		// agent answered with silence, which is the one thing the message scope
-		// exists to never say.
-		fmt.Fprintf(os.Stderr, "gmux: the daemon reported a message for %s but sent no content\n", displayID(sess))
-		return waitExitError
+		// known case: reporting silence as the answer is the one thing the
+		// message scope exists to never do.
+		return agentAnswerRead{Failed: true, Report: fmt.Sprintf("the daemon reported a message for %s but sent no content", displayID(sess))}
 	}
-	if _, err := os.Stdout.Write(raw); err != nil {
-		fmt.Fprintln(os.Stderr, "gmux:", err)
-		return waitExitError
+	return agentAnswerRead{Text: strings.TrimRight(string(raw), "\n")}
+}
+
+// agentSkewOrRawReport describes an envelope-less error response: a bare 404 is
+// a missing ROUTE (the session was resolved through this same daemon one
+// request earlier), i.e. version skew; anything else is passed through.
+func agentSkewOrRawReport(verb string, status int, body []byte) string {
+	if status == http.StatusNotFound {
+		return fmt.Sprintf("this gmuxd predates 'gmux agent %s' (no such route); restart the daemon with 'gmux daemon restart'", verb)
 	}
-	return waitExitOK
+	return fmt.Sprintf("agent %s failed: %s", verb, strings.TrimSpace(string(body)))
 }
 
 // cmdAgentLogs implements `gmux agent logs`: print the session's conversation
-// as markdown (last n messages), read from the agent's own stored
-// conversation.
+// as markdown (the last n messages of the requested types), read from the
+// agent's own stored conversation. With json, the same selection is printed as
+// the machine shape instead: a JSON array of {role, type, text, prose}.
 //
-// Store-only, exactly like `agent output`: it never starts, resumes or even
+// The filter travels as `types=` and the serialization as `format=`, so the
+// daemon serves exactly the messages asked for and -n counts them post-filter.
+// An empty types list means the daemon's default (user + prose-bearing agent
+// messages), which is deliberately the same default as no flags at all.
+//
+// Store-only, exactly like `agent status`: it never starts, resumes or even
 // touches a runner, so it works on a dead retained session, and it is
 // local-only for the same reason the rest of the namespace is. The daemon's
 // transcript scope is the read (`?tail=N`, no scope parameter — that IS the
 // transcript), so nothing new is asked of gmuxd.
 //
-// Error taxonomy is `agent output`'s, verbatim: the daemon's code and message
+// Error taxonomy is the message scope's, verbatim: the daemon's code and message
 // are printed as-is by reportAgentError, an envelope-less 404 is reported as
 // version skew rather than a missing session, and a non-renderer adapter's
 // refusal carries the read-side 'gmux tail' hint — the raw view is exactly
 // what a caller who cannot have a transcript should reach for.
 //
-// No marker-header guard here, unlike `agent output`: that guard exists
+// No marker-header guard here, unlike the message-scope read: that guard exists
 // because an old daemon ignoring `scope=message` would answer with the whole
 // transcript, and the whole transcript is precisely what this verb asked for.
 // The only skew that can bite is a daemon with no /conversation route at all,
 // which arrives as an envelope-less 404 and is reported as such.
-func cmdAgentLogs(ref string, n int) int {
+func cmdAgentLogs(ref string, n int, types []string, asJSON bool) int {
 	sess, ok := resolveAgentSession(ref, "logs")
 	if !ok {
 		return waitExitError
 	}
 	client := gmuxdClient()
-	// No client deadline, for the same reason `agent output` drops it: the
+	// No client deadline, for the same reason the message-scope read drops it: the
 	// daemon re-reads and renders the agent's whole stored conversation, which
 	// on a long session and a cold filesystem can outlast the default 5s and
 	// turn a readable transcript into a transport error.
 	client.Timeout = 0
 	url := fmt.Sprintf("%s/v1/sessions/%s/conversation?tail=%d", gmuxdBaseURL(), sess.ID, n)
+	if len(types) > 0 {
+		url += "&types=" + strings.Join(types, ",")
+	}
+	if asJSON {
+		url += "&format=json"
+	}
 	resp, err := client.Get(url)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "gmux:", err)
@@ -809,6 +931,30 @@ func cmdAgentLogs(ref string, n int) int {
 		fmt.Fprintf(os.Stderr, "gmux: the daemon reported a conversation for %s but sent no content\n", displayID(sess))
 		return waitExitError
 	}
+	if asJSON {
+		// The daemon wraps its JSON in the house envelope; the CLI's contract is
+		// the bare array, so the messages are unwrapped and re-emitted. An
+		// undecodable body is a contract breach, not an empty conversation.
+		var env struct {
+			Data struct {
+				Messages []json.RawMessage `json:"messages"`
+			} `json:"data"`
+		}
+		if err := json.Unmarshal(raw, &env); err != nil || env.Data.Messages == nil {
+			fmt.Fprintf(os.Stderr, "gmux: this gmuxd cannot serve 'gmux agent logs --json' (it answered with something else); restart the daemon with 'gmux daemon restart'\n")
+			return waitExitError
+		}
+		out, err := json.MarshalIndent(env.Data.Messages, "", "  ")
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "gmux:", err)
+			return waitExitError
+		}
+		if _, err := fmt.Fprintln(os.Stdout, string(out)); err != nil {
+			fmt.Fprintln(os.Stderr, "gmux:", err)
+			return waitExitError
+		}
+		return waitExitOK
+	}
 	if _, err := os.Stdout.Write(raw); err != nil {
 		fmt.Fprintln(os.Stderr, "gmux:", err)
 		return waitExitError
@@ -829,7 +975,7 @@ const conversationScopeHeader = "X-Gmux-Conversation-Scope"
 // envelope-less status as version skew too.
 func agentOutputSkewError(status int, scopeHeader string) string {
 	if status == http.StatusOK && scopeHeader != conversationScopeMessage {
-		return "this gmuxd predates 'gmux agent output' (it answered with the whole transcript); restart the daemon with 'gmux daemon restart', or use 'gmux tail'"
+		return "this gmuxd predates 'gmux agent status' (it answered with the whole transcript); restart the daemon with 'gmux daemon restart', or use 'gmux tail'"
 	}
 	return ""
 }
@@ -876,14 +1022,16 @@ func reportAgentError(sess cliSession, verb string, status int, body []byte) int
 // agentErrorHint adds the one actionable next step the daemon's message does
 // not already carry. Hints never soften an indeterminate outcome.
 //
-// The unsupported hint is verb-aware: on a write verb the fallback is raw
-// input, while on `output` the caller wants to READ, and telling them to send
-// keystrokes answers a question they did not ask.
+// The unsupported hint is verb-aware: on a write verb (prompt, cancel) the
+// fallback is raw input, while on the read verb the caller wants to READ, and
+// telling them to send keystrokes answers a question they did not ask.
+// `logs` is the only read that routes through here — `status` reports a
+// non-renderer adapter as part of its own report instead of as an error.
 func agentErrorHint(code, verb string, sess cliSession) string {
 	tailHint := "'gmux tail " + shortID(sess.ID) + "' shows this session directly"
 	switch code {
 	case codeUnsupportedAdapter, codeUnsupportedAction:
-		if verb == "output" || verb == "logs" {
+		if verb == "logs" {
 			return "this session's agent exposes no conversation gmux can read; " + tailHint
 		}
 		return "this session's agent has no semantic support yet; drive it with 'gmux send' and read it with 'gmux tail'"
@@ -980,7 +1128,7 @@ ready fails its first prompt exactly like any later one.
 Waits by default: the command returns when the turn ends and prints the agent's
 answer. Exit status is 0 for a completed turn, 2 for an interrupted one, and 1
 for anything else (a failed turn, a --timeout, a dead runner). A turn that did
-not complete prints no answer — read what exists with 'gmux agent output <id>'.
+not complete prints no answer — see what happened with 'gmux agent status <id>'.
 
 A plain prompt (no flag) restarts a dead retained session to deliver the
 prompt; --steer never does. Local sessions only.
@@ -994,38 +1142,99 @@ Delivers an interrupt to a live, active agent and returns once it is
 delivered — not once the agent has stopped. Follow with 'gmux wait <id>' when
 the next step needs the turn to be over. Local sessions only.
 `)
-	case "agent output":
-		fmt.Fprint(w, `gmux agent output — print an agent session's latest message
+	case "agent status":
+		fmt.Fprint(w, `gmux agent status — show what matters about an agent session right now
 
-  gmux agent output <id>
+  gmux agent status <id> [--json]
 
-Prints the agent's latest final message, verbatim and untruncated, read from
-the agent's own stored conversation. Never starts or resumes anything, so it
-works on a dead session. For the whole conversation use 'gmux agent logs <id>',
-and for the terminal itself 'gmux tail <id>'.
+  --json            print the machine shape instead of the report
+
+The verb for "I don't know what I want, show me what matters". Always the same
+three parts, whatever the session is doing:
+
+  ## State         short id and adapter, alive/dead, active/idle, and the last
+                   CLOSED turn's outcome (completed/interrupted/error) with a
+                   rough recency. A running turn has no outcome yet, and a
+                   session that died mid-turn reads "the turn never finished
+                   (runner died)" — the verdict 'gmux wait' reaches for that
+                   same row, never "completed"
+  ## Triggered by  the first lines of the user message that started the
+                   current (or last) turn — labeled so it can never be
+                   mistaken for the answer, and found however many tool
+                   calls the turn has made since
+  ## Answer        the agent's final message when the session is idle
+  ## Recent        instead of Answer while a turn is running: the last few
+                   messages and a working indicator
+
+A SNAPSHOT: store-only, no runner contact, no resume, so it works on a dead
+retained session — and it can be staler than the answer a 'gmux wait' or a
+synchronous 'gmux agent prompt' carries, because those report what the adapter
+asserted at turn close while this reads the stored conversation.
+
+The State part is adapter-independent, so a session whose conversation gmux
+cannot read (claude, codex, a shell) still gets it, with a note instead of the
+content rather than an error. Local sessions only.
+
+--json prints one object mirroring the three parts: {state:{...},
+trigger:{text,truncated}, content:{kind,...}}, where content.kind is "answer",
+"recent" or "none". Fields describing a turn that does not exist are ABSENT
+rather than empty: state.last_turn_outcome (and state.last_turn_cause, today
+only runner_died) appear only for a concluded turn, and trigger.code only when
+the conversation could not be read. That object is the machine contract for
+this read.
+
+The answer ALONE, for a script that wants nothing else:
+
+  gmux agent logs --agent -n 1 <id>
 `)
 	case "agent logs":
-		fmt.Fprint(w, `gmux agent logs — print what an agent session has been doing
+		fmt.Fprint(w, `gmux agent logs — print the exact conversation text you want
 
-  gmux agent logs <id> [-n N]
+  gmux agent logs <id> [-n N] [--user] [--agent] [--tool] [--all] [--json]
 
-  -n N              how many conversation messages to print (default 100)
+  -n N              how many messages to print (default 100), counted AFTER
+                    the type filter
+  --user            user messages (prompts, steers, merged follow-ups)
+  --agent           assistant messages that carry prose
+  --tool            messages that are only tool calls
+  --all             every type gmux renders
+  --json            print the machine shape instead of markdown
 
 Prints the agent's conversation as markdown, read from the agent's own stored
 conversation: '## User' / '## Assistant' messages with compact [tool]
 one-liners — the actual exchange, not the TUI's box-drawing and spinners.
 -n counts MESSAGES here, not lines.
 
-A store-only snapshot, like 'gmux agent output': it never starts or resumes
+With no type flag you get the conversation without the machinery: user
+messages and assistant messages that actually said something. Type flags
+REPLACE that default rather than adding to it, and they compose
+('--user --tool'), so the view is always exactly the types you named.
+
+  gmux agent logs --agent -n 1 <id>   the latest answer, alone
+  gmux agent logs --tool -n 20 <id>   what it has been running
+
+There is no --thinking: no adapter renders thinking blocks today (pi's own
+transcript drops them), so the flag is refused by name instead of answering
+with silence. 'gmux tail <id>' shows whatever the TUI painted.
+
+--json prints a JSON array of {role, type, text, prose} — the machine contract
+for this read.
+
+A store-only snapshot, like 'gmux agent status': it never starts or resumes
 anything, so it works on a dead retained session. Local sessions only, and
 only for agents whose conversation gmux can read — anything else answers
 unsupported_adapter, where 'gmux tail <id>' shows the terminal instead.
 
-The three reading verbs answer three different questions:
+The reading verbs split by what you know you want:
 
-  gmux tail <id>          what is on its screen (raw terminal, any session)
-  gmux agent logs <id>    what it has been doing (this command)
-  gmux agent output <id>  what the answer is (its latest message)
+  gmux tail <id>          the raw screen (any session)
+  gmux agent logs <id>    the exact text you want (this command)
+  gmux agent status <id>  show me what matters, I'll decide after
+
+'gmux agent logs --agent -n 1' approximates the old 'gmux agent output'. It is
+a snapshot read, so it can be staler than the answer a 'gmux wait' or a
+synchronous prompt carries — those report the adapter's assertion at turn
+close.
 `)
 	default:
 		fmt.Fprint(w, `gmux agent — drive an agent session by intent instead of keystrokes
@@ -1035,13 +1244,14 @@ The three reading verbs answer three different questions:
   gmux agent prompt --new [--model M] [--name N] [prompt]
                                     launch a session and send its first prompt
   gmux agent cancel <id>            interrupt the running turn
-  gmux agent logs <id> [-n N]       print the conversation as markdown
-  gmux agent output <id>            print the agent's latest message
+  gmux agent status <id> [--json]   state, trigger and the content that matters
+  gmux agent logs <id> [-n N] [--user|--agent|--tool|--all] [--json]
+                                    print the conversation, filtered
 
 Unlike 'gmux send', which types raw bytes at a terminal and cannot say whether
 the agent read them, prompt and cancel wait until the agent can accept input,
-submit the way that agent expects, and report what the daemon observed. logs
-and output are store-only snapshots: they never start or resume the agent.
+submit the way that agent expects, and report what the daemon observed. status
+and logs are store-only snapshots: they never start or resume the agent.
 
 Prompting. A plain prompt starts a fresh turn (restarting a dead retained
 session if needed); --new launches a new pi session first and prints its id as
@@ -1052,17 +1262,19 @@ with either and only decides whether you block. Flags go before the id;
 everything after the id is the prompt, verbatim. Omit the prompt to pipe it on
 stdin (it stays one prompt).
 
-Reading. Three questions, three verbs, no word doing double duty: 'gmux tail'
-shows what is on the session's screen (raw terminal, any session); 'gmux agent
-logs' shows what the agent has been doing (the conversation as markdown, -n in
-messages); 'gmux agent output' shows what the answer is (its latest message).
-logs and output are store-only snapshots: they never start or resume the agent
-and work on a dead retained session.
+Reading. The split is what you know you want, not what shape comes back:
+'gmux tail' is the raw screen (any session); 'gmux agent logs' is the exact
+text you want (filter by --user/--agent/--tool/--all, -n counts messages
+post-filter); 'gmux agent status' is "show me what matters" — state line,
+trigger excerpt, and the answer or the last few messages. Both agent reads are
+store-only snapshots: they never start or resume the agent, they work on a dead
+retained session, and both take --json for a stable machine shape.
 
 Results. A synchronous prompt — and 'gmux wait' — prints the agent's answer
 when the turn completes. A failed or interrupted turn prints nothing (a stale
-answer is worse than none); 'gmux agent output <id>' reads what exists, even
-after the session died. Exit codes: 0 completed, 2 intentionally interrupted,
+answer is worse than none); 'gmux agent status <id>' shows what exists, even
+after the session died — as a snapshot it can be staler than the answer a wait
+carries. Exit codes: 0 completed, 2 intentionally interrupted,
 1 anything else (failed turn, timeout, dead runner, usage, transport).
 
 Retrying. admission_timeout, delivery_timeout, and
@@ -1076,7 +1288,7 @@ Scope. Agent sessions on this host only, and pi only for now; other agents
 fail with unsupported_adapter — drive those with 'gmux send' and read them
 with 'gmux tail'.
 
-  gmux agent prompt|logs|cancel|output --help   per-verb help
+  gmux agent prompt|logs|status|cancel --help   per-verb help
 `)
 	}
 }

--- a/cli/gmux/cmd/gmux/agent_logs_test.go
+++ b/cli/gmux/cmd/gmux/agent_logs_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 // TestParseAgentLogs covers the verb's grammar: it joins prompt/cancel/output
-// in the namespace, takes exactly one ref, and its only flag is -n — on
+// in the namespace, takes exactly one ref, and takes its flags — on
 // either side of the ref, since there is no verbatim trailing content here to
 // protect.
 func TestParseAgentLogs(t *testing.T) {
@@ -99,7 +99,7 @@ func TestAgentLogsHelpRouting(t *testing.T) {
 		"Local sessions only",
 		"unsupported_adapter",
 		"gmux tail <id>",
-		"gmux agent output <id>",
+		"gmux agent status <id>",
 	} {
 		if !strings.Contains(page, want) {
 			t.Errorf("agent logs page missing %q:\n%s", want, page)
@@ -142,7 +142,7 @@ func TestTopLevelSynopsisMatchesTheVerbs(t *testing.T) {
 	// The reading split is the headline change, so the agent pointer names the
 	// two semantic reads — without spending a third 'gmux agent' line, which
 	// TestTopLevelUsageAgentSection budgets.
-	for _, want := range []string{"logs", "output"} {
+	for _, want := range []string{"logs", "status"} {
 		if !strings.Contains(usage, want) {
 			t.Errorf("synopsis must surface the %q read:\n%s", want, usage)
 		}
@@ -162,7 +162,7 @@ func TestTopLevelSynopsisMatchesTheVerbs(t *testing.T) {
 		{"kill", "abc"},
 		{"agent", "prompt", "abc", "a prompt"},
 		{"agent", "logs", "abc"},
-		{"agent", "output", "abc"},
+		{"agent", "status", "abc"},
 	} {
 		if _, err := parseCLI(args); err != nil {
 			t.Errorf("the synopsis teaches %v, which does not parse: %v", args, err)
@@ -172,7 +172,7 @@ func TestTopLevelSynopsisMatchesTheVerbs(t *testing.T) {
 
 // TestAgentLogs covers the read end to end against the daemon stub: the
 // request shape (transcript scope with a message count), verbatim stdout, and
-// the failure taxonomy it shares with `agent output`.
+// the failure taxonomy it shares with the other conversation reads.
 func TestAgentLogs(t *testing.T) {
 	body := "## User\n\nfix the test\n\n## Assistant\n\n[tool] bash\n\ndone\n"
 	d := startStubDaemon(t, localSession())
@@ -181,7 +181,7 @@ func TestAgentLogs(t *testing.T) {
 		_, _ = w.Write([]byte(body))
 	})
 	stdout := captureStdout(t, func() {
-		if code := cmdAgentLogs("abcd1234", 7); code != waitExitOK {
+		if code := cmdAgentLogs("abcd1234", 7, nil, false); code != waitExitOK {
 			t.Errorf("exit = %d, want 0", code)
 		}
 	})
@@ -206,7 +206,7 @@ func TestAgentLogs(t *testing.T) {
 		})
 		stderr := captureStderr(t, func() {
 			out := captureStdout(t, func() {
-				if code := cmdAgentLogs("abcd1234", 100); code != waitExitError {
+				if code := cmdAgentLogs("abcd1234", 100, nil, false); code != waitExitError {
 					t.Errorf("%s: exit = %d, want 1", tt.code, code)
 				}
 			})
@@ -232,7 +232,7 @@ func TestAgentLogs(t *testing.T) {
 	// resolved through this same daemon.
 	d.on(func(w http.ResponseWriter, r *http.Request) { http.NotFound(w, r) })
 	stderr := captureStderr(t, func() {
-		if code := cmdAgentLogs("abcd1234", 100); code != waitExitError {
+		if code := cmdAgentLogs("abcd1234", 100, nil, false); code != waitExitError {
 			t.Errorf("skew: exit = %d, want 1", code)
 		}
 	})
@@ -247,7 +247,7 @@ func TestAgentLogs(t *testing.T) {
 	d.on(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) })
 	stderr = captureStderr(t, func() {
 		out := captureStdout(t, func() {
-			if code := cmdAgentLogs("abcd1234", 100); code != waitExitError {
+			if code := cmdAgentLogs("abcd1234", 100, nil, false); code != waitExitError {
 				t.Errorf("empty 200: exit = %d, want 1", code)
 			}
 		})
@@ -260,7 +260,7 @@ func TestAgentLogs(t *testing.T) {
 	}
 }
 
-// TestAgentLogsIsStoreOnly: like `agent output`, logs must work on a dead
+// TestAgentLogsIsStoreOnly: like `agent status`, logs must work on a dead
 // retained session and must never issue anything that could start or resume
 // one — one GET, no writes.
 func TestAgentLogsIsStoreOnly(t *testing.T) {
@@ -270,7 +270,7 @@ func TestAgentLogsIsStoreOnly(t *testing.T) {
 		_, _ = w.Write([]byte("## User\n\nhi\n"))
 	})
 	stdout := captureStdout(t, func() {
-		if code := cmdAgentLogs("abcd1234", 100); code != waitExitOK {
+		if code := cmdAgentLogs("abcd1234", 100, nil, false); code != waitExitOK {
 			t.Errorf("dead session: exit = %d, want 0", code)
 		}
 	})
@@ -295,7 +295,7 @@ func TestAgentLogsRefusesPeerSessions(t *testing.T) {
 	peer := []cliSession{{ID: "sess-c0b3c1a1", Peer: "laptop", Adapter: "pi", Alive: true}}
 	d := startStubDaemon(t, peer)
 	stderr := captureStderr(t, func() {
-		if code := cmdAgentLogs("c0b3c1a1@laptop", 100); code != waitExitError {
+		if code := cmdAgentLogs("c0b3c1a1@laptop", 100, nil, false); code != waitExitError {
 			t.Errorf("exit = %d, want 1", code)
 		}
 	})

--- a/cli/gmux/cmd/gmux/agent_status.go
+++ b/cli/gmux/cmd/gmux/agent_status.go
@@ -1,0 +1,593 @@
+package main
+
+// agent_status.go — `gmux agent status <id>`: the snapshot read.
+//
+// ADR 0027's 2026-07-28 amendment splits the reading verbs COGNITIVELY rather
+// than by output shape:
+//
+//	gmux tail <id>          the raw screen — what the TUI painted
+//	gmux agent logs <id>    the exact text I want (filterable transcript)
+//	gmux agent status <id>  I don't know what I want; show me what matters
+//
+// status therefore has a FIXED three-part skeleton that never varies with
+// flags, session state or adapter:
+//
+//  1. the state line — session identity (short id, adapter), alive/dead,
+//     active/idle, the last turn's outcome and a rough recency;
+//  2. the triggering excerpt — the first lines of the user message that started
+//     the current (or last) turn, under its own heading so it can never be
+//     mistaken for the answer;
+//  3. the relevant content — the final answer when idle, the last few messages
+//     plus a working indicator when active.
+//
+// It is a SNAPSHOT: store-only, no runner contact, no resume, no persisted
+// state. It works on a dead retained session, and it is the one verb allowed to
+// read the tape (the conversation) — which is also why its content can be
+// staler than a wait's carried result.
+//
+// The state line is adapter-independent: it comes from the session row. So a
+// non-renderer adapter (claude, codex, a shell) gets the state line and a note
+// saying its conversation cannot be read, not an error — refusing the whole
+// question because part of it is unanswerable would be worse than answering the
+// part that is.
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+// agentStatusTriggerLines caps the trigger excerpt. A prompt can be a whole
+// specification; the first lines are what identify it, and status is a summary
+// verb — `gmux agent logs --user -n 1 <id>` prints the whole thing.
+const agentStatusTriggerLines = 5
+
+// agentStatusRecentMessages is how many conversation messages the active-turn
+// content shows. Small on purpose: "what is it doing right now" is answered by
+// the last handful, and a longer window is `gmux agent logs`.
+const agentStatusRecentMessages = 5
+
+// agentConvMessage is one message of the daemon's JSON conversation format.
+type agentConvMessage struct {
+	Role  string `json:"role"`
+	Type  string `json:"type"`
+	Text  string `json:"text"`
+	Prose string `json:"prose"`
+}
+
+// agentConvRead is a transcript read outcome, with the same three-way split as
+// agentAnswerRead: messages, a daemon "nothing to read" code, or a failure.
+type agentConvRead struct {
+	Messages []agentConvMessage
+	Code     string
+	Message  string
+	Failed   bool
+	Report   string
+}
+
+// readAgentConversation reads the last n messages of the given types as JSON.
+// Store-only, like every read in this namespace.
+//
+// The types are a parameter rather than a constant because status asks two
+// different questions of the same endpoint: the newest USER message (the
+// trigger, which must never be crowded out by a busy turn's own tool calls) and
+// the last few messages of every type (what the turn is doing). Asking one
+// windowed question for both is what let a long turn report "nothing has been
+// asked of this session yet" while printing that turn's activity.
+func readAgentConversation(sess cliSession, n int, types ...string) agentConvRead {
+	client := gmuxdClient()
+	// No client deadline, for the reason the other conversation reads drop it:
+	// the daemon re-reads and renders the whole stored conversation, which on a
+	// long session and a cold filesystem can outlast the default 5s and turn a
+	// readable snapshot into a transport error.
+	client.Timeout = 0
+	url := fmt.Sprintf("%s/v1/sessions/%s/conversation?tail=%d&types=%s&format=json",
+		gmuxdBaseURL(), sess.ID, n, strings.Join(types, ","))
+	resp, err := client.Get(url)
+	if err != nil {
+		return agentConvRead{Failed: true, Report: err.Error()}
+	}
+	defer resp.Body.Close()
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return agentConvRead{Failed: true, Report: err.Error()}
+	}
+	if resp.StatusCode >= 300 {
+		code, msg := errorCode(raw), extractMessage(raw)
+		if code == "" {
+			return agentConvRead{Failed: true, Report: agentSkewOrRawReport("status", resp.StatusCode, raw)}
+		}
+		return agentConvRead{Code: code, Message: msg}
+	}
+	var env struct {
+		Data struct {
+			Messages []agentConvMessage `json:"messages"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(raw, &env); err != nil || env.Data.Messages == nil {
+		// A 200 this CLI cannot decode is a daemon that does not know the JSON
+		// format (it served markdown). Reporting "no messages" would claim the
+		// agent has done nothing.
+		return agentConvRead{Failed: true, Report: "this gmuxd predates 'gmux agent status' (it cannot serve the conversation as JSON); restart the daemon with 'gmux daemon restart'"}
+	}
+	return agentConvRead{Messages: env.Data.Messages}
+}
+
+// agentStateRow is the slice of the session row the state line needs.
+//
+// Read as its own shape rather than by widening cliSession: `gmux ls --json` is
+// a pinned schema (ADR 0009 13b) and status is not a reason to grow it.
+type agentStateRow struct {
+	ID     string `json:"id"`
+	Status *struct {
+		Active      bool `json:"active"`
+		Error       bool `json:"error"`
+		Interrupted bool `json:"interrupted"`
+	} `json:"status"`
+	LastOutputAt string `json:"last_output_at"`
+	ExitedAt     string `json:"exited_at"`
+	StartedAt    string `json:"started_at"`
+}
+
+// resolveAgentSessionSnapshot resolves ref AND reads its turn-state row from
+// ONE session listing, refusing peer-owned sessions like the rest of the
+// namespace.
+//
+// One listing, not two, for a correctness reason rather than a cost one:
+// liveness (`alive`) and the turn flags (`status`) are classified together by
+// the state line, and reading them from two snapshots lets a session that dies
+// in between be reported as `alive` with its post-death flags — the exact
+// liveness/turn-flag pairing this file is careful about everywhere else.
+//
+// The retry mirrors resolveSession's: a session registered moments ago may not
+// be in the composed snapshot yet, and only a clean miss is transient.
+func resolveAgentSessionSnapshot(ref, verb string) (cliSession, agentStateRow, bool) {
+	const (
+		maxRetries = 6
+		retryDelay = 100 * time.Millisecond
+	)
+	for attempt := 0; ; attempt++ {
+		sessions, rows, err := fetchSessionsWithRows()
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "gmux:", err)
+			return cliSession{}, agentStateRow{}, false
+		}
+		sess, err := matchSession(sessions, ref)
+		if err != nil {
+			if attempt < maxRetries && isNoMatchError(err) {
+				time.Sleep(retryDelay)
+				continue
+			}
+			fmt.Fprintln(os.Stderr, "gmux:", err)
+			return cliSession{}, agentStateRow{}, false
+		}
+		if sess.Peer != "" {
+			fmt.Fprintf(os.Stderr, "gmux: agent %s is only supported for local sessions (%s is on peer %q); run gmux agent in a session on that host instead\n",
+				verb, shortID(sess.ID), sess.Peer)
+			return cliSession{}, agentStateRow{}, false
+		}
+		for _, row := range rows {
+			if row.ID == sess.ID {
+				return sess, row, true
+			}
+		}
+		// The row came from the same body as the session, so this cannot
+		// normally happen; an absent row degrades to "no turn recorded" rather
+		// than failing a question the rest of the snapshot can answer.
+		return sess, agentStateRow{}, true
+	}
+}
+
+// fetchSessionsWithRows reads GET /v1/sessions once and decodes the same body
+// into both shapes the CLI needs: the pinned cliSession view used for ref
+// resolution, and the turn-state row.
+func fetchSessionsWithRows() ([]cliSession, []agentStateRow, error) {
+	ensureGmuxd()
+	client := gmuxdClient()
+	resp, err := client.Get(gmuxdBaseURL() + "/v1/sessions")
+	if err != nil {
+		return nil, nil, fmt.Errorf("contact gmuxd: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, nil, fmt.Errorf("gmuxd returned %s", resp.Status)
+	}
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return nil, nil, fmt.Errorf("read sessions: %w", err)
+	}
+	var sessions struct {
+		Data []cliSession `json:"data"`
+	}
+	if err := json.Unmarshal(raw, &sessions); err != nil {
+		return nil, nil, fmt.Errorf("decode sessions: %w", err)
+	}
+	var rows struct {
+		Data []agentStateRow `json:"data"`
+	}
+	if err := json.Unmarshal(raw, &rows); err != nil {
+		return nil, nil, fmt.Errorf("decode sessions: %w", err)
+	}
+	return sessions.Data, rows.Data, nil
+}
+
+// agentStatusState is part 1 of the report, as data.
+//
+// Outcome and Cause are omitted rather than emptied when there is no concluded
+// turn to describe (a running turn, a session that never reported a status):
+// `""` is not in the outcome vocabulary, and a consumer must not have to know
+// that it means "ask turn_recorded instead". Recency follows the same rule.
+type agentStatusState struct {
+	ID      string `json:"id"`
+	ShortID string `json:"short_id"`
+	Adapter string `json:"adapter"`
+	Alive   bool   `json:"alive"`
+	Active  bool   `json:"active"`
+	Outcome string `json:"last_turn_outcome,omitempty"`
+	// Cause qualifies a non-completed outcome the way the daemon's wait verdict
+	// does; today the only value is runner_died.
+	Cause    string `json:"last_turn_cause,omitempty"`
+	Recency  string `json:"last_activity_at,omitempty"`
+	Recorded bool   `json:"turn_recorded"`
+}
+
+// causeRunnerDied mirrors the daemon's cause vocabulary (agent_actions.go): an
+// error outcome caused by the session dying rather than by the agent reporting
+// a failed turn.
+const causeRunnerDied = "runner_died"
+
+// agentStatusStateOf derives the state line's facts from the session row.
+//
+// Classification follows the daemon's own rule (wait_pure.go's terminalReason /
+// diedConclusion), and it is deliberately keyed on the row's raw Active flag
+// BEFORE liveness is considered:
+//
+//   - a turn still OPEN has not concluded, so no outcome may be attributed to
+//     it. On a live session that is "working"; on a DEAD one the open turn will
+//     never close, which the daemon calls an error with cause runner_died —
+//     never "completed". A runner that dies mid-turn leaves exactly this row
+//     (Active=true, Error=false), preserved on purpose by the store's sweep, so
+//     ANDing Active away with liveness first and falling through to the default
+//     branch made the most ordinary failure the tool has (an agent killed while
+//     working) report a turn that succeeded.
+//   - a CLOSED turn's outcome is the row's terminal flags: error > interrupted >
+//     completed.
+//   - a row whose runner never reported a status carries no turn at all, and
+//     that is reported as "no turn recorded" rather than guessed as completed —
+//     a fresh session has not succeeded at anything.
+//
+// `gmux wait` and `gmux agent status` must never disagree about what
+// "completed" means for one identical row; this is that agreement, spelled out
+// on the CLI side because the row is all status has.
+func agentStatusStateOf(sess cliSession, row agentStateRow, found bool) agentStatusState {
+	st := agentStatusState{
+		ID:      sess.ID,
+		ShortID: shortID(sess.ID),
+		Adapter: sess.Adapter,
+		Alive:   sess.Alive,
+	}
+	if !found || row.Status == nil {
+		return st
+	}
+	st.Recorded = true
+	open := row.Status.Active
+	// Active means "a turn is running right now", which a dead runner cannot do.
+	st.Active = open && sess.Alive
+	st.Recency = firstNonEmpty(row.LastOutputAt, row.ExitedAt, row.StartedAt)
+	switch {
+	case open && sess.Alive:
+		// Running: no outcome, in the report and in the JSON alike.
+	case open:
+		st.Outcome, st.Cause = waitOutcomeError, causeRunnerDied
+	case row.Status.Error:
+		st.Outcome = waitOutcomeError
+	case row.Status.Interrupted:
+		st.Outcome = waitOutcomeInterrupted
+	default:
+		st.Outcome = waitOutcomeCompleted
+	}
+	return st
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// agentStatusStateLine renders part 1 for humans.
+func agentStatusStateLine(st agentStatusState) string {
+	liveness := "dead"
+	if st.Alive {
+		liveness = "alive"
+	}
+	activity := "idle"
+	if st.Active {
+		activity = "active"
+	}
+	adapter := st.Adapter
+	if adapter == "" {
+		adapter = "unknown adapter"
+	}
+	line := fmt.Sprintf("%s %s — %s, %s", st.ShortID, adapter, liveness, activity)
+	switch {
+	case st.Active:
+		line += "; working" + agentStatusSince(st.Recency, ", last output ")
+	case !st.Recorded:
+		line += "; no turn recorded yet"
+	case st.Cause == causeRunnerDied:
+		// Naming the death beats a bare "error": the turn did not fail, it was
+		// never finished, and the answer a caller might be waiting for will
+		// never arrive.
+		line += "; the turn never finished (runner died)" + agentStatusSince(st.Recency, ", died ")
+	default:
+		line += "; last turn " + st.Outcome + agentStatusSince(st.Recency, " ")
+	}
+	return line
+}
+
+// agentStatusSince renders a rough recency for an RFC3339 timestamp, or ""
+// when there is none to render. Rough on purpose: status answers "recently or
+// long ago", and a precise duration would invite arithmetic on a snapshot.
+func agentStatusSince(ts, prefix string) string {
+	if ts == "" {
+		return ""
+	}
+	t, err := time.Parse(time.RFC3339Nano, ts)
+	if err != nil {
+		t, err = time.Parse(time.RFC3339, ts)
+		if err != nil {
+			return ""
+		}
+	}
+	d := time.Since(t)
+	if d < 0 {
+		d = 0
+	}
+	var rough string
+	switch {
+	case d < time.Minute:
+		rough = fmt.Sprintf("%ds ago", int(d.Seconds()))
+	case d < time.Hour:
+		rough = fmt.Sprintf("%dm ago", int(d.Minutes()))
+	case d < 48*time.Hour:
+		rough = fmt.Sprintf("%dh ago", int(d.Hours()))
+	default:
+		rough = fmt.Sprintf("%dd ago", int(d.Hours()/24))
+	}
+	return prefix + rough
+}
+
+// agentStatusTrigger extracts part 2: the excerpt of the user message that
+// started the current or last turn.
+//
+// The newest user message is the cheapest honest turn boundary available from
+// the tape without inventing turn metadata — the same rule the daemon's
+// message scope uses. It is an approximation of the runner's asserted trigger,
+// and status says so by being a snapshot verb.
+func agentStatusTrigger(msgs []agentConvMessage) (text string, truncated bool) {
+	for i := len(msgs) - 1; i >= 0; i-- {
+		if msgs[i].Type != agentLogTypeUser {
+			continue
+		}
+		lines := strings.Split(strings.TrimRight(msgs[i].Text, "\n"), "\n")
+		if len(lines) > agentStatusTriggerLines {
+			return strings.Join(lines[:agentStatusTriggerLines], "\n"), true
+		}
+		return strings.Join(lines, "\n"), false
+	}
+	return "", false
+}
+
+// agentStatusReport is the `--json` shape: one object mirroring the three
+// parts, so a script reads the same snapshot the human report shows.
+type agentStatusReport struct {
+	State   agentStatusState `json:"state"`
+	Trigger struct {
+		Text      string `json:"text"`
+		Truncated bool   `json:"truncated"`
+		// Code/Note are the daemon's reason there is no trigger text, when the
+		// reason is that no user message could be READ. An absent code with
+		// empty text means the opposite: the read succeeded and the
+		// conversation holds no user message, i.e. nothing has been asked. The
+		// two facts must stay distinguishable — collapsing them is how a report
+		// claims nothing was ever asked of a session whose tape it cannot read.
+		Code string `json:"code,omitempty"`
+		Note string `json:"note,omitempty"`
+	} `json:"trigger"`
+	Content struct {
+		// Kind is "answer" (idle: the final assistant prose), "recent"
+		// (active: the last few messages) or "none" (nothing readable), and it
+		// is what a consumer switches on.
+		Kind     string             `json:"kind"`
+		Text     string             `json:"text,omitempty"`
+		Messages []agentConvMessage `json:"messages,omitempty"`
+		// Note carries the reason there is no content, as the daemon's stable
+		// code plus its prose.
+		Code string `json:"code,omitempty"`
+		Note string `json:"note,omitempty"`
+	} `json:"content"`
+}
+
+// Content kinds.
+const (
+	agentStatusContentAnswer = "answer"
+	agentStatusContentRecent = "recent"
+	agentStatusContentNone   = "none"
+)
+
+// cmdAgentStatus implements `gmux agent status`.
+//
+// Exit codes: 0 whenever the snapshot could be taken — including for a session
+// whose conversation gmux cannot read, because the state line IS an answer to
+// the question asked. 1 only when the read itself failed (transport, version
+// skew, an unresolvable ref, a peer session).
+func cmdAgentStatus(ref string, asJSON bool) int {
+	sess, row, ok := resolveAgentSessionSnapshot(ref, "status")
+	if !ok {
+		return waitExitError
+	}
+	rep := agentStatusReport{State: agentStatusStateOf(sess, row, true)}
+
+	// The trigger gets its OWN read, filtered to the newest user message. It is
+	// the newest user boundary in the whole conversation, not a member of some
+	// last-N window: a turn that made thirty tool calls used to push its own
+	// prompt out of a shared window, and the report then claimed nothing had
+	// ever been asked while printing that turn's activity.
+	trigger := readAgentConversation(sess, 1, agentLogTypeUser)
+	if trigger.Failed {
+		fmt.Fprintln(os.Stderr, "gmux:", trigger.Report)
+		return waitExitError
+	}
+	if trigger.Code != "" {
+		// codeNoMessage here means "readable, and no user message in it", which
+		// IS "nothing has been asked" — so it stays an absent code with empty
+		// text. Any other code means the conversation could not be read, and the
+		// report must not turn that into a claim about what was asked.
+		if trigger.Code != codeNoMessage {
+			rep.Trigger.Code, rep.Trigger.Note = trigger.Code, trigger.Message
+		}
+	} else {
+		rep.Trigger.Text, rep.Trigger.Truncated = agentStatusTrigger(trigger.Messages)
+	}
+
+	switch {
+	case rep.State.Active:
+		conv := readAgentConversation(sess, agentStatusRecentMessages,
+			agentLogTypeUser, agentLogTypeAgent, agentLogTypeTool)
+		if conv.Failed {
+			fmt.Fprintln(os.Stderr, "gmux:", conv.Report)
+			return waitExitError
+		}
+		if conv.Code != "" {
+			// Adapter-gated, or nothing recorded yet: the state line stands, and
+			// the note says which.
+			rep.Content.Kind = agentStatusContentNone
+			rep.Content.Code, rep.Content.Note = conv.Code, conv.Message
+			break
+		}
+		rep.Content.Kind = agentStatusContentRecent
+		rep.Content.Messages = conv.Messages
+	default:
+		answer := readAgentAnswer(sess)
+		if answer.Failed {
+			fmt.Fprintln(os.Stderr, "gmux:", answer.Report)
+			return waitExitError
+		}
+		if answer.Code != "" {
+			rep.Content.Kind = agentStatusContentNone
+			rep.Content.Code, rep.Content.Note = answer.Code, answer.Message
+			break
+		}
+		rep.Content.Kind = agentStatusContentAnswer
+		rep.Content.Text = answer.Text
+	}
+
+	if asJSON {
+		out, err := json.MarshalIndent(rep, "", "  ")
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "gmux:", err)
+			return waitExitError
+		}
+		if _, err := fmt.Fprintln(os.Stdout, string(out)); err != nil {
+			fmt.Fprintln(os.Stderr, "gmux:", err)
+			return waitExitError
+		}
+		return waitExitOK
+	}
+	if _, err := io.WriteString(os.Stdout, renderAgentStatus(rep)); err != nil {
+		fmt.Fprintln(os.Stderr, "gmux:", err)
+		return waitExitError
+	}
+	return waitExitOK
+}
+
+// renderAgentStatus renders the three-part report.
+//
+// Every part is announced by a heading, present even when the part is empty:
+// the skeleton is the contract, and a reader must never have to guess whether
+// the text they are looking at is the prompt or the answer.
+func renderAgentStatus(rep agentStatusReport) string {
+	var b strings.Builder
+	b.WriteString("## State\n\n")
+	b.WriteString(agentStatusStateLine(rep.State))
+	b.WriteString("\n\n## Triggered by\n\n")
+	switch {
+	case rep.Trigger.Text == "" && rep.Trigger.Code != "":
+		// No user message could be read, so nothing may be claimed about what
+		// was asked — only the daemon's reason for not knowing.
+		fmt.Fprintf(&b, "(%s: %s)\n", rep.Trigger.Code, orNothingToRead(rep.Trigger.Note))
+	case rep.Trigger.Text == "":
+		b.WriteString("(nothing has been asked of this session yet)\n")
+	default:
+		b.WriteString(rep.Trigger.Text)
+		b.WriteString("\n")
+		if rep.Trigger.Truncated {
+			b.WriteString("(excerpt; 'gmux agent logs --user -n 1' prints all of it)\n")
+		}
+	}
+	switch rep.Content.Kind {
+	case agentStatusContentAnswer:
+		b.WriteString("\n## Answer\n\n")
+		b.WriteString(rep.Content.Text)
+		b.WriteString("\n")
+	case agentStatusContentRecent:
+		b.WriteString("\n## Recent\n\n")
+		for i, m := range rep.Content.Messages {
+			if i > 0 {
+				b.WriteString("\n")
+			}
+			fmt.Fprintf(&b, "### %s\n\n%s\n", agentStatusRoleHeading(m), strings.TrimRight(m.Text, "\n"))
+		}
+		b.WriteString("\n(still working — 'gmux wait' blocks until the turn ends)\n")
+	default:
+		// The third part keeps the name of what it WOULD have held: a running
+		// turn has no answer to be missing, it has content that cannot be read.
+		if rep.State.Active {
+			b.WriteString("\n## Recent\n\n")
+		} else {
+			b.WriteString("\n## Answer\n\n")
+		}
+		note := orNothingToRead(rep.Content.Note)
+		if rep.Content.Code == codeUnsupportedAdapter || rep.Content.Code == codeUnsupportedAction {
+			fmt.Fprintf(&b, "(%s: %s; 'gmux tail %s' shows the terminal instead)\n",
+				rep.Content.Code, note, rep.State.ShortID)
+			break
+		}
+		fmt.Fprintf(&b, "(%s: %s)\n", codeOrNothing(rep.Content.Code), note)
+	}
+	return b.String()
+}
+
+func codeOrNothing(code string) string {
+	if code == "" {
+		return "nothing"
+	}
+	return code
+}
+
+func orNothingToRead(note string) string {
+	if note == "" {
+		return "nothing to read"
+	}
+	return note
+}
+
+func agentStatusRoleHeading(m agentConvMessage) string {
+	switch m.Type {
+	case agentLogTypeUser:
+		return "User"
+	case agentLogTypeTool:
+		return "Assistant (tools)"
+	default:
+		return "Assistant"
+	}
+}

--- a/cli/gmux/cmd/gmux/agent_status_test.go
+++ b/cli/gmux/cmd/gmux/agent_status_test.go
@@ -1,0 +1,568 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// TestParseAgentLogsFilters pins the filter grammar: type flags REPLACE the
+// default set, they compose, --all is the whole set and cannot be narrowed, and
+// --thinking is refused by name rather than answering with silence.
+func TestParseAgentLogsFilters(t *testing.T) {
+	for _, tt := range []struct {
+		args []string
+		want []string
+	}{
+		{[]string{"agent", "logs", "s1"}, nil}, // default: the daemon's pair
+		{[]string{"agent", "logs", "--user", "s1"}, []string{"user"}},
+		{[]string{"agent", "logs", "--agent", "s1"}, []string{"agent"}},
+		{[]string{"agent", "logs", "--tool", "s1"}, []string{"tool"}},
+		{[]string{"agent", "logs", "--user", "--tool", "s1"}, []string{"user", "tool"}},
+		{[]string{"agent", "logs", "s1", "--all"}, []string{"user", "agent", "tool"}},
+	} {
+		c, err := parseCLI(tt.args)
+		if err != nil {
+			t.Fatalf("parseCLI(%v): %v", tt.args, err)
+		}
+		if strings.Join(c.logTypes, ",") != strings.Join(tt.want, ",") {
+			t.Errorf("parseCLI(%v) types = %v, want %v", tt.args, c.logTypes, tt.want)
+		}
+	}
+
+	// --json is a serialization, not a type: it leaves the filter alone.
+	c, err := parseCLI([]string{"agent", "logs", "--json", "--agent", "-n", "1", "s1"})
+	if err != nil || !c.json || strings.Join(c.logTypes, ",") != "agent" || c.tailLines != 1 {
+		t.Fatalf("parseCLI(--json --agent -n 1) = (%+v, %v)", c, err)
+	}
+
+	for _, tt := range []struct {
+		name, want string
+		args       []string
+	}{
+		{"thinking is refused by name", "not rendered by this adapter",
+			[]string{"agent", "logs", "--thinking", "s1"}},
+		{"all cannot be narrowed", "cannot be combined with a type flag",
+			[]string{"agent", "logs", "--all", "--user", "s1"}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := parseCLI(tt.args)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Errorf("parseCLI(%v) = %v, want an error mentioning %q", tt.args, err, tt.want)
+			}
+		})
+	}
+}
+
+// TestAgentLogsRequestCarriesTheFilter: the filter and the serialization travel
+// to the daemon, so -n counts POST-filter messages and the daemon serves
+// exactly what was asked for. Filtering client-side would make -n mean "of the
+// last N messages, the ones that matched", which is a different question.
+func TestAgentLogsRequestCarriesTheFilter(t *testing.T) {
+	d := startStubDaemon(t, localSession())
+	d.on(func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte("## User\n\nhi\n")) })
+	captureStdout(t, func() {
+		if code := cmdAgentLogs("abcd1234", 1, []string{"agent"}, false); code != waitExitOK {
+			t.Errorf("exit = %d, want 0", code)
+		}
+	})
+	q, err := url.ParseQuery(d.lastRequest(t).query)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if q.Get("tail") != "1" || q.Get("types") != "agent" || q.Get("format") != "" {
+		t.Errorf("query = %v, want tail=1&types=agent and no format", q)
+	}
+
+	// The default filter is the daemon's default: no types parameter at all, so
+	// there is one definition of "the conversation" rather than two.
+	captureStdout(t, func() { cmdAgentLogs("abcd1234", 100, nil, false) })
+	q, _ = url.ParseQuery(d.lastRequest(t).query)
+	if _, present := q["types"]; present {
+		t.Errorf("query = %v, want no types parameter for the default view", q)
+	}
+}
+
+// TestAgentLogsJSONPrintsABareArray: the machine contract is the array, not the
+// daemon's envelope, and an envelope this CLI cannot decode is version skew
+// rather than an empty conversation.
+func TestAgentLogsJSONPrintsABareArray(t *testing.T) {
+	d := startStubDaemon(t, localSession())
+	d.on(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"ok":true,"data":{"messages":[{"role":"assistant","type":"agent","text":"done","prose":"done"}]}}`))
+	})
+	stdout := captureStdout(t, func() {
+		if code := cmdAgentLogs("abcd1234", 1, []string{"agent"}, true); code != waitExitOK {
+			t.Errorf("exit = %d, want 0", code)
+		}
+	})
+	var msgs []map[string]any
+	if err := json.Unmarshal([]byte(stdout), &msgs); err != nil {
+		t.Fatalf("stdout is not a JSON array: %v (%q)", err, stdout)
+	}
+	if len(msgs) != 1 || msgs[0]["role"] != "assistant" || msgs[0]["text"] != "done" {
+		t.Errorf("stdout = %q, want one {role,text,...} object", stdout)
+	}
+	q, _ := url.ParseQuery(d.lastRequest(t).query)
+	if q.Get("format") != "json" {
+		t.Errorf("query = %v, want format=json", q)
+	}
+
+	// A markdown-serving daemon (no JSON support) must not look like an empty
+	// conversation.
+	d.on(func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte("## User\n\nhi\n")) })
+	stderr := captureStderr(t, func() {
+		out := captureStdout(t, func() {
+			if code := cmdAgentLogs("abcd1234", 1, nil, true); code != waitExitError {
+				t.Errorf("skew: exit = %d, want 1", code)
+			}
+		})
+		if out != "" {
+			t.Errorf("skew printed %q", out)
+		}
+	})
+	if !strings.Contains(stderr, "restart the daemon") {
+		t.Errorf("skew stderr = %q", stderr)
+	}
+}
+
+// statusStub wires a daemon stub that answers both reads `agent status`
+// performs: the JSON transcript and the message scope.
+func statusStub(t *testing.T, rows []map[string]any, messages string, answer string, answerCode string) *stubDaemon {
+	t.Helper()
+	d := startStubDaemon(t, localSession())
+	d.mu.Lock()
+	d.rows = rows
+	d.mu.Unlock()
+	d.on(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("scope") == conversationScopeMessage {
+			if answerCode != "" {
+				writeErrEnvelope(w, http.StatusNotFound, answerCode, "the agent has not produced a message yet")
+				return
+			}
+			w.Header().Set(conversationScopeHeader, conversationScopeMessage)
+			_, _ = w.Write([]byte(answer + "\n"))
+			return
+		}
+		_, _ = w.Write([]byte(messages))
+	})
+	return d
+}
+
+func piRow(active bool, extra map[string]any) []map[string]any {
+	return piRowAlive(true, map[string]any{"active": active}, extra)
+}
+
+// piRowAlive builds a session row with an explicit liveness and an explicit
+// status map, so the liveness/turn-flag COMBINATIONS can be pinned — the
+// dead-and-active row (a runner that died mid-turn) above all.
+func piRowAlive(alive bool, status map[string]any, extra map[string]any) []map[string]any {
+	row := map[string]any{
+		"id":      "sess-abcd1234",
+		"adapter": "pi",
+		"alive":   alive,
+		"status":  status,
+	}
+	for k, v := range extra {
+		row[k] = v
+	}
+	return []map[string]any{row}
+}
+
+const statusMessagesJSON = `{"ok":true,"data":{"messages":[
+	{"role":"user","type":"user","text":"run the tests\nand report\nline3\nline4\nline5\nline6","prose":"run the tests"},
+	{"role":"assistant","type":"tool","text":"[tool] bash {\"cmd\":\"go test\"}"},
+	{"role":"assistant","type":"agent","text":"All green.","prose":"All green."}
+]}}`
+
+// TestAgentStatusIdleShape pins the fixed three-part skeleton on an idle
+// session: state line, labeled trigger excerpt, then the final answer. The
+// labels are the contract — a reader must never have to guess whether the text
+// in front of them is the prompt or the answer.
+func TestAgentStatusIdleShape(t *testing.T) {
+	statusStub(t, piRow(false, map[string]any{"last_output_at": "2020-01-01T00:00:00Z"}), statusMessagesJSON, "All green.", "")
+	stdout := captureStdout(t, func() {
+		if code := cmdAgentStatus("abcd1234", false); code != waitExitOK {
+			t.Errorf("exit = %d, want 0", code)
+		}
+	})
+	for _, want := range []string{
+		"## State", "abcd1234 pi — alive, idle; last turn completed",
+		"## Triggered by", "run the tests",
+		"## Answer", "All green.",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("status output missing %q:\n%s", want, stdout)
+		}
+	}
+	// Order matters: the trigger must never be printed after the answer, where
+	// a skimming reader would read it as part of it.
+	if strings.Index(stdout, "## Triggered by") > strings.Index(stdout, "## Answer") {
+		t.Errorf("the trigger must precede the answer:\n%s", stdout)
+	}
+	// The excerpt is capped, and says so instead of pretending to be whole.
+	if !strings.Contains(stdout, "excerpt") || strings.Contains(stdout, "line6") {
+		t.Errorf("a long trigger must be excerpted and labeled as one:\n%s", stdout)
+	}
+}
+
+// TestAgentStatusActiveShowsRecentAndWorking: while a turn runs there is no
+// answer to show, so the third part becomes the last few messages plus a
+// working indicator. Printing the previous turn's answer there is exactly the
+// stale-result failure this design forbids.
+func TestAgentStatusActiveShowsRecentAndWorking(t *testing.T) {
+	statusStub(t, piRow(true, nil), statusMessagesJSON, "must not appear", "")
+	stdout := captureStdout(t, func() {
+		if code := cmdAgentStatus("abcd1234", false); code != waitExitOK {
+			t.Errorf("exit = %d, want 0", code)
+		}
+	})
+	for _, want := range []string{"alive, active; working", "## Recent", "[tool] bash", "still working"} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("active status missing %q:\n%s", want, stdout)
+		}
+	}
+	if strings.Contains(stdout, "## Answer") {
+		t.Errorf("an active turn has no answer to report:\n%s", stdout)
+	}
+}
+
+// TestAgentStatusJSONMirrorsTheThreeParts: the machine shape is one object with
+// the same three parts, and content.kind is what a consumer switches on.
+func TestAgentStatusJSONMirrorsTheThreeParts(t *testing.T) {
+	statusStub(t, piRow(false, nil), statusMessagesJSON, "All green.", "")
+	stdout := captureStdout(t, func() {
+		if code := cmdAgentStatus("abcd1234", true); code != waitExitOK {
+			t.Errorf("exit = %d, want 0", code)
+		}
+	})
+	var rep struct {
+		State struct {
+			ShortID string `json:"short_id"`
+			Adapter string `json:"adapter"`
+			Alive   bool   `json:"alive"`
+			Active  bool   `json:"active"`
+			Outcome string `json:"last_turn_outcome"`
+		} `json:"state"`
+		Trigger struct {
+			Text      string `json:"text"`
+			Truncated bool   `json:"truncated"`
+		} `json:"trigger"`
+		Content struct {
+			Kind string `json:"kind"`
+			Text string `json:"text"`
+		} `json:"content"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &rep); err != nil {
+		t.Fatalf("stdout is not one JSON object: %v (%q)", err, stdout)
+	}
+	if rep.State.ShortID != "abcd1234" || rep.State.Adapter != "pi" || !rep.State.Alive || rep.State.Active {
+		t.Errorf("state = %+v", rep.State)
+	}
+	if rep.State.Outcome != waitOutcomeCompleted {
+		t.Errorf("last_turn_outcome = %q", rep.State.Outcome)
+	}
+	if !strings.HasPrefix(rep.Trigger.Text, "run the tests") || !rep.Trigger.Truncated {
+		t.Errorf("trigger = %+v", rep.Trigger)
+	}
+	if rep.Content.Kind != agentStatusContentAnswer || rep.Content.Text != "All green." {
+		t.Errorf("content = %+v", rep.Content)
+	}
+}
+
+// TestAgentStatusIsAdapterGated: a session whose conversation gmux cannot read
+// still gets the state line, which is adapter-independent, plus a note and the
+// raw-view hint. Refusing the whole question because one part is unanswerable
+// would be worse than answering the part that is — so this exits 0.
+func TestAgentStatusIsAdapterGated(t *testing.T) {
+	d := startStubDaemon(t, []cliSession{{ID: "sess-abcd1234", Adapter: "shell", Alive: true}})
+	d.on(func(w http.ResponseWriter, r *http.Request) {
+		writeErrEnvelope(w, http.StatusUnprocessableEntity, codeUnsupportedAdapter, `adapter "shell" does not render conversations`)
+	})
+	stdout := captureStdout(t, func() {
+		if code := cmdAgentStatus("abcd1234", false); code != waitExitOK {
+			t.Errorf("exit = %d, want 0 (the state line is still an answer)", code)
+		}
+	})
+	for _, want := range []string{"## State", "abcd1234 shell", codeUnsupportedAdapter, "gmux tail abcd1234"} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("gated status missing %q:\n%s", want, stdout)
+		}
+	}
+}
+
+// TestAgentStatusIsAStoreOnlySnapshot: it works on a dead retained session and
+// issues nothing that could start, resume or drive one.
+func TestAgentStatusIsAStoreOnlySnapshot(t *testing.T) {
+	d := statusStub(t, nil, statusMessagesJSON, "All green.", "")
+	d.mu.Lock()
+	d.sessions = []cliSession{{ID: "sess-abcd1234", Adapter: "pi", Alive: false}}
+	d.mu.Unlock()
+	stdout := captureStdout(t, func() {
+		if code := cmdAgentStatus("abcd1234", false); code != waitExitOK {
+			t.Errorf("dead session: exit = %d, want 0", code)
+		}
+	})
+	if !strings.Contains(stdout, "dead, idle") {
+		t.Errorf("a dead session's state line must say so:\n%s", stdout)
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	for _, r := range d.requests {
+		if r.method != http.MethodGet {
+			t.Errorf("status issued a %s to %s; the read must be store-only", r.method, r.path)
+		}
+		if strings.Contains(r.path, "/prompt") || strings.Contains(r.path, "/input") || strings.Contains(r.path, "/resume") {
+			t.Errorf("status touched %s", r.path)
+		}
+	}
+}
+
+// TestAgentStatusReportsAnEmptySessionWithoutClaimingSilence: a session with
+// nothing recorded yet gets the skeleton with the daemon's code as the note,
+// never an empty Answer that reads as "the agent said nothing" — and never a
+// claim about what was asked, which an unreadable tape cannot support.
+func TestAgentStatusReportsAnEmptySessionWithoutClaimingSilence(t *testing.T) {
+	d := startStubDaemon(t, localSession())
+	d.on(func(w http.ResponseWriter, r *http.Request) {
+		writeErrEnvelope(w, http.StatusNotFound, codeNoConversation, "session has no conversation")
+	})
+	stdout := captureStdout(t, func() {
+		if code := cmdAgentStatus("abcd1234", false); code != waitExitOK {
+			t.Errorf("exit = %d, want 0", code)
+		}
+	})
+	for _, want := range []string{"## Triggered by", codeNoConversation, "## Answer"} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("empty-session status missing %q:\n%s", want, stdout)
+		}
+	}
+}
+
+// TestAgentStatusHelpTeachesTheCognitiveSplit: the page must teach the fixed
+// shape, the snapshot property (and its staleness against a wait), the machine
+// shape, and the answer-only read that replaced `agent output`.
+func TestAgentStatusHelpTeachesTheCognitiveSplit(t *testing.T) {
+	var b strings.Builder
+	printAgentUsage(&b, "agent status")
+	page := b.String()
+	for _, want := range []string{
+		"gmux agent status <id> [--json]",
+		"## State", "## Triggered by", "## Answer", "## Recent",
+		"SNAPSHOT", "staler",
+		// The fourth state and the omit rule are contract, so the page teaches
+		// them: a caller who reads only help must not expect "completed" for a
+		// session that died mid-turn, nor an always-present outcome field.
+		"runner died", "ABSENT",
+		"gmux agent logs --agent -n 1 <id>",
+		"Local sessions only",
+	} {
+		if !strings.Contains(page, want) {
+			t.Errorf("agent status page missing %q:\n%s", want, page)
+		}
+	}
+	b.Reset()
+	printAgentUsage(&b, "agent logs")
+	logs := b.String()
+	for _, want := range []string{"--user", "--agent", "--tool", "--all", "--json", "AFTER", "--thinking", "gmux agent status <id>"} {
+		if !strings.Contains(logs, want) {
+			t.Errorf("agent logs page missing %q:\n%s", want, logs)
+		}
+	}
+}
+
+// TestAgentStatusDeadMidTurnIsAnError is the honesty rule `gmux wait` already
+// follows (wait_pure.go's terminalReason/diedConclusion): a runner that dies
+// with its turn still open leaves Active=true and NO terminal flag in the store
+// — deliberately preserved — and that turn did not complete, it will never
+// finish. Reporting "last turn completed" for a killed agent is the most
+// ordinary lie this verb could tell, and the two verbs must never disagree
+// about one identical row.
+//
+// The classification must key on the row's Active flag BEFORE liveness: ANDing
+// liveness in first is what fell through to "completed".
+func TestAgentStatusDeadMidTurnIsAnError(t *testing.T) {
+	statusStub(t, piRowAlive(false, map[string]any{"active": true}, map[string]any{
+		"exited_at": "2020-01-01T00:00:00Z",
+	}), statusMessagesJSON, "", codeNoMessage)
+	stdout := captureStdout(t, func() {
+		if code := cmdAgentStatus("abcd1234", false); code != waitExitOK {
+			t.Errorf("exit = %d, want 0", code)
+		}
+	})
+	if strings.Contains(stdout, "completed") {
+		t.Errorf("a session that died mid-turn must not report a completed turn:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "dead, idle; the turn never finished (runner died)") {
+		t.Errorf("state line must name the death:\n%s", stdout)
+	}
+
+	// And the machine shape agrees with `wait`: error, cause runner_died.
+	stdout = captureStdout(t, func() { cmdAgentStatus("abcd1234", true) })
+	var rep struct {
+		State struct {
+			Alive   bool   `json:"alive"`
+			Active  bool   `json:"active"`
+			Outcome string `json:"last_turn_outcome"`
+			Cause   string `json:"last_turn_cause"`
+		} `json:"state"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &rep); err != nil {
+		t.Fatalf("decode: %v (%q)", err, stdout)
+	}
+	if rep.State.Alive || rep.State.Active {
+		t.Errorf("a dead runner runs nothing: %+v", rep.State)
+	}
+	if rep.State.Outcome != waitOutcomeError || rep.State.Cause != causeRunnerDied {
+		t.Errorf("state = %+v, want error/runner_died like gmux wait", rep.State)
+	}
+}
+
+// TestAgentStatusActiveTurnHasNoOutcome: a running turn has not concluded, so
+// neither rendering may attribute one — the human line already hid it, while
+// the JSON published the PREVIOUS turn's flags as `last_turn_outcome`, which a
+// script reads as this turn's verdict. Pinned for all three active rows.
+func TestAgentStatusActiveTurnHasNoOutcome(t *testing.T) {
+	for _, flags := range []map[string]any{
+		{"active": true},
+		{"active": true, "error": true},
+		{"active": true, "interrupted": true},
+	} {
+		statusStub(t, piRowAlive(true, flags, nil), statusMessagesJSON, "must not appear", "")
+		stdout := captureStdout(t, func() {
+			if code := cmdAgentStatus("abcd1234", true); code != waitExitOK {
+				t.Errorf("%v: exit = %d, want 0", flags, code)
+			}
+		})
+		var rep struct {
+			State map[string]any `json:"state"`
+		}
+		if err := json.Unmarshal([]byte(stdout), &rep); err != nil {
+			t.Fatalf("decode: %v (%q)", err, stdout)
+		}
+		if rep.State["active"] != true {
+			t.Errorf("%v: state.active = %v, want true", flags, rep.State["active"])
+		}
+		if _, present := rep.State["last_turn_outcome"]; present {
+			t.Errorf("%v: an active turn must publish no outcome, got %v", flags, rep.State["last_turn_outcome"])
+		}
+		if _, present := rep.State["last_turn_cause"]; present {
+			t.Errorf("%v: an active turn must publish no cause", flags)
+		}
+		// The human line and the JSON must agree.
+		human := captureStdout(t, func() { cmdAgentStatus("abcd1234", false) })
+		if strings.Contains(human, "last turn ") {
+			t.Errorf("%v: state line must not name a last turn while active:\n%s", flags, human)
+		}
+	}
+}
+
+// TestAgentStatusStateOmitsRatherThanEmpties: a never-prompted session has no
+// concluded turn, so the outcome is ABSENT rather than "" — the empty string is
+// not in the outcome vocabulary, and a consumer must not have to know it means
+// "consult turn_recorded".
+func TestAgentStatusStateOmitsRatherThanEmpties(t *testing.T) {
+	statusStub(t, []map[string]any{{"id": "sess-abcd1234", "adapter": "pi", "alive": true}},
+		statusMessagesJSON, "", codeNoMessage)
+	stdout := captureStdout(t, func() { cmdAgentStatus("abcd1234", true) })
+	var rep struct {
+		State map[string]any `json:"state"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &rep); err != nil {
+		t.Fatalf("decode: %v (%q)", err, stdout)
+	}
+	if _, present := rep.State["last_turn_outcome"]; present {
+		t.Errorf("state = %v, want no outcome for a session with no turn on record", rep.State)
+	}
+	if rep.State["turn_recorded"] != false {
+		t.Errorf("turn_recorded = %v, want false", rep.State["turn_recorded"])
+	}
+}
+
+// TestAgentStatusTriggerSurvivesABusyTurn: the trigger is the newest USER
+// boundary in the conversation, not a member of some last-N window. A turn that
+// makes thirty tool calls used to push its own prompt out of the shared window,
+// and the report then claimed nothing had ever been asked while printing that
+// turn's activity — a self-contradiction inside one fixed-shape report.
+func TestAgentStatusTriggerSurvivesABusyTurn(t *testing.T) {
+	var tools []string
+	for i := 0; i < 30; i++ {
+		tools = append(tools, `{"role":"assistant","type":"tool","text":"[tool] bash {}","prose":""}`)
+	}
+	d := startStubDaemon(t, localSession())
+	d.mu.Lock()
+	d.rows = piRow(true, nil)
+	d.mu.Unlock()
+	var triggerQueries []string
+	d.on(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		if q.Get("types") == agentLogTypeUser {
+			// The daemon filters to user messages, then tails: the newest user
+			// message is always in the answer, however busy the turn.
+			triggerQueries = append(triggerQueries, r.URL.RawQuery)
+			_, _ = w.Write([]byte(`{"ok":true,"data":{"messages":[{"role":"user","type":"user","text":"refactor the store","prose":"refactor the store"}]}}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"ok":true,"data":{"messages":[` + strings.Join(tools, ",") + `]}}`))
+	})
+	stdout := captureStdout(t, func() {
+		if code := cmdAgentStatus("abcd1234", false); code != waitExitOK {
+			t.Errorf("exit = %d, want 0", code)
+		}
+	})
+	if !strings.Contains(stdout, "refactor the store") {
+		t.Errorf("the trigger must survive a busy turn:\n%s", stdout)
+	}
+	if strings.Contains(stdout, "nothing has been asked") {
+		t.Errorf("report contradicts itself (no trigger, yet activity):\n%s", stdout)
+	}
+	if len(triggerQueries) != 1 || !strings.Contains(triggerQueries[0], "tail=1") {
+		t.Errorf("trigger read = %v, want one targeted types=user&tail=1 read", triggerQueries)
+	}
+}
+
+// TestAgentStatusDoesNotClaimNothingWasAskedWhenItCannotRead: an unreadable
+// conversation supports no claim about what was asked. "No user message in a
+// readable transcript" and "no readable transcript" are different facts and the
+// report keeps them apart.
+func TestAgentStatusDoesNotClaimNothingWasAskedWhenItCannotRead(t *testing.T) {
+	d := startStubDaemon(t, []cliSession{{ID: "sess-abcd1234", Adapter: "shell", Alive: true}})
+	d.on(func(w http.ResponseWriter, r *http.Request) {
+		writeErrEnvelope(w, http.StatusUnprocessableEntity, codeUnsupportedAdapter, `adapter "shell" does not render conversations`)
+	})
+	stdout := captureStdout(t, func() {
+		if code := cmdAgentStatus("abcd1234", false); code != waitExitOK {
+			t.Errorf("exit = %d, want 0", code)
+		}
+	})
+	if strings.Contains(stdout, "nothing has been asked") {
+		t.Errorf("an unreadable conversation cannot support that claim:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, codeUnsupportedAdapter) {
+		t.Errorf("the trigger part must carry the daemon's reason:\n%s", stdout)
+	}
+
+	// A readable transcript with no user message keeps the plain claim, and the
+	// JSON marks the difference with the presence of trigger.code.
+	statusStub(t, piRow(false, nil), `{"ok":true,"data":{"messages":[]}}`, "", codeNoMessage)
+	d2Stdout := captureStdout(t, func() { cmdAgentStatus("abcd1234", false) })
+	if !strings.Contains(d2Stdout, "nothing has been asked") {
+		t.Errorf("a readable, prompt-free conversation is 'nothing has been asked':\n%s", d2Stdout)
+	}
+}
+
+// TestAgentStatusReadsOneSessionListing: liveness and the turn flags are
+// classified together, so they must come from ONE snapshot. Two listings let a
+// session that dies in between be reported as alive with its post-death flags —
+// the same liveness/turn-flag pairing the died-mid-turn rule depends on.
+func TestAgentStatusReadsOneSessionListing(t *testing.T) {
+	d := statusStub(t, piRow(false, nil), statusMessagesJSON, "All green.", "")
+	captureStdout(t, func() { cmdAgentStatus("abcd1234", false) })
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.sessionsRequests != 1 {
+		t.Errorf("status issued %d session listings, want exactly 1", d.sessionsRequests)
+	}
+}

--- a/cli/gmux/cmd/gmux/agent_test.go
+++ b/cli/gmux/cmd/gmux/agent_test.go
@@ -115,13 +115,13 @@ func TestParseAgent(t *testing.T) {
 					t.Errorf("sub=%q ref=%q", c.agentSub, c.ref)
 				}
 			}},
-		{name: "output", args: []string{"agent", "output", "abc123"},
+		{name: "status", args: []string{"agent", "status", "abc123"},
 			check: func(t *testing.T, c *command) {
-				if c.agentSub != "output" || c.ref != "abc123" {
+				if c.agentSub != "status" || c.ref != "abc123" {
 					t.Errorf("sub=%q ref=%q", c.agentSub, c.ref)
 				}
 			}},
-		{name: "peer-qualified ref parses (rejected at execution)", args: []string{"agent", "output", "abc@laptop"},
+		{name: "peer-qualified ref parses (rejected at execution)", args: []string{"agent", "status", "abc@laptop"},
 			check: func(t *testing.T, c *command) {
 				if c.ref != "abc@laptop" {
 					t.Errorf("ref = %q", c.ref)
@@ -179,8 +179,13 @@ func TestParseAgentErrors(t *testing.T) {
 		// The message must name the real problem: a second id was given, not
 		// zero ids; and a trailing flag is a misplaced flag, not a missing id.
 		{"cancel with extra ref", []string{"agent", "cancel", "s1", "s2"}, "exactly one session id"},
-		{"output flag", []string{"agent", "output", "--json"}, "takes no flags"},
-		{"output ref then flag", []string{"agent", "output", "s1", "-h"}, "takes no flags"},
+		// The removed read verb fails by name, and the error names BOTH
+		// replacements: the report and the answer-only read.
+		{"output is removed", []string{"agent", "output", "s1"}, "gmux agent status <id>"},
+		{"output names the answer read", []string{"agent", "output", "s1"}, "logs --agent -n 1"},
+		{"status without ref", []string{"agent", "status"}, "requires a session id"},
+		{"status with extra ref", []string{"agent", "status", "s1", "s2"}, "exactly one session id"},
+		{"status unknown flag", []string{"agent", "status", "--raw", "s1"}, "agent status:"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -212,7 +217,7 @@ func TestParseAgentHelp(t *testing.T) {
 		{[]string{"agent", "cancel", "?"}, "agent cancel"},
 		{[]string{"agent", "prompt", "--help"}, "agent prompt"},
 		{[]string{"agent", "cancel", "--help"}, "agent cancel"},
-		{[]string{"agent", "output", "-h"}, "agent output"},
+		{[]string{"agent", "status", "-h"}, "agent status"},
 		{[]string{"agent", "logs", "--help"}, "agent logs"},
 		{[]string{"help", "agent"}, "agent"},
 		{[]string{"help", "agent", "prompt"}, "agent prompt"},
@@ -235,7 +240,7 @@ func TestParseAgentHelp(t *testing.T) {
 	printAgentUsage(&b, "agent")
 	guide := b.String()
 	for _, want := range []string{
-		"agent prompt", "agent cancel", "agent output", "agent logs",
+		"agent prompt", "agent cancel", "agent status", "agent logs",
 		"--no-wait", "--follow-up", "--steer", "--timeout",
 		"stdin",
 		"0 completed", "2 intentionally interrupted",
@@ -252,7 +257,7 @@ func TestParseAgentHelp(t *testing.T) {
 	}
 	b.Reset()
 	printAgentUsage(&b, "agent prompt")
-	for _, want := range []string{"--no-wait", "--follow-up", "--steer", "--timeout", "gmux agent output"} {
+	for _, want := range []string{"--no-wait", "--follow-up", "--steer", "--timeout", "gmux agent status"} {
 		if !strings.Contains(b.String(), want) {
 			t.Errorf("prompt help missing %q:\n%s", want, b.String())
 		}
@@ -267,7 +272,7 @@ func TestParseAgentHelp(t *testing.T) {
 // namespace: a prominent section surfacing the one command a first-time
 // caller wants (prompt) plus the pointer to the namespace guide — and
 // nothing else. Per-verb flag detail and the management verbs (cancel,
-// output) live in 'gmux agent --help', keeping the synopsis scannable.
+// status) live in 'gmux agent --help', keeping the synopsis scannable.
 func TestTopLevelUsageAgentSection(t *testing.T) {
 	var b strings.Builder
 	printUsage(&b)
@@ -486,7 +491,7 @@ func TestAgentEnvelopeLessNotFoundIsVersionSkew(t *testing.T) {
 	}{
 		{"prompt", func() int { text := "go"; return cmdAgentPrompt("abcd1234", agentModePrompt, false, 0, &text) }},
 		{"cancel", func() int { return cmdAgentCancel("abcd1234") }},
-		{"output", func() int { return cmdAgentOutput("abcd1234") }},
+		{"status", func() int { return cmdAgentStatus("abcd1234", false) }},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			d := startStubDaemon(t, localSession())
@@ -523,28 +528,19 @@ func TestAgentEnvelopeLessNotFoundIsVersionSkew(t *testing.T) {
 	}
 }
 
-// TestAgentOutputRejectsMarkedEmptyBody: a marked but empty 200 is not a
+// TestAgentAnswerRejectsMarkedEmptyBody: a marked but empty 200 is not a
 // silent success. The daemon cannot currently emit one (it answers
-// no_message), so this pins the contract rather than a known case: printing
-// nothing under exit 0 would tell a script the agent answered with silence.
-func TestAgentOutputRejectsMarkedEmptyBody(t *testing.T) {
+// no_message), so this pins the contract rather than a known case: treating
+// silence as the answer is the one thing the message scope must never do.
+func TestAgentAnswerRejectsMarkedEmptyBody(t *testing.T) {
 	d := startStubDaemon(t, localSession())
 	d.on(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set(conversationScopeHeader, conversationScopeMessage)
 		w.WriteHeader(http.StatusOK)
 	})
-	stderr := captureStderr(t, func() {
-		out := captureStdout(t, func() {
-			if code := cmdAgentOutput("abcd1234"); code != waitExitError {
-				t.Errorf("exit = %d, want 1", code)
-			}
-		})
-		if out != "" {
-			t.Errorf("stdout = %q", out)
-		}
-	})
-	if !strings.Contains(stderr, "no content") {
-		t.Errorf("stderr = %q", stderr)
+	got := readAgentAnswer(cliSession{ID: "sess-abcd1234", Adapter: "pi", Alive: true})
+	if !got.Failed || !strings.Contains(got.Report, "no content") {
+		t.Errorf("readAgentAnswer = %+v, want a failed read naming the empty body", got)
 	}
 	_ = d
 }
@@ -599,6 +595,15 @@ type stubDaemon struct {
 	requests []recordedRequest
 	handler  func(w http.ResponseWriter, r *http.Request)
 	sessions []cliSession
+	// sessionsRequests counts GET /v1/sessions calls: `agent status` must
+	// classify liveness and turn flags from ONE listing, and a stub that only
+	// records the sub-routes cannot see a second one.
+	sessionsRequests int
+	// rows, when set, replaces the /v1/sessions payload with raw JSON objects.
+	// The session row carries fields cliSession deliberately does not (status,
+	// last_output_at), and `agent status` reads them: pinning them needs a row
+	// shape the CLI's pinned ls schema does not have.
+	rows []map[string]any
 }
 
 type recordedRequest struct {
@@ -627,6 +632,14 @@ func startStubDaemon(t *testing.T, sessions []cliSession) *stubDaemon {
 		_, _ = w.Write([]byte(`{"ok":true,"data":{"version":"dev"}}`))
 	})
 	mux.HandleFunc("/v1/sessions", func(w http.ResponseWriter, r *http.Request) {
+		d.mu.Lock()
+		d.sessionsRequests++
+		rows := d.rows
+		d.mu.Unlock()
+		if rows != nil {
+			_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "data": rows})
+			return
+		}
 		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "data": d.sessions})
 	})
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
@@ -866,9 +879,12 @@ func TestAgentCancelRequest(t *testing.T) {
 	}
 }
 
-// TestAgentOutput covers the semantic read: the request shape, verbatim
-// untruncated stdout, and the two distinguishable "nothing to show" answers.
-func TestAgentOutput(t *testing.T) {
+// TestAgentAnswerRead covers the semantic message-scope read that backs
+// `agent status`'s Answer part (and, in spirit, `logs --agent -n 1`): the
+// request shape, the verbatim text, and the three distinguishable "nothing to
+// show" answers, which are reasons rather than failures.
+func TestAgentAnswerRead(t *testing.T) {
+	sess := cliSession{ID: "sess-abcd1234", Adapter: "pi", Alive: true}
 	body := "Here is the answer.\n\n```go\nfunc main() {}\n```\n"
 	d := startStubDaemon(t, localSession())
 	d.on(func(w http.ResponseWriter, r *http.Request) {
@@ -876,71 +892,39 @@ func TestAgentOutput(t *testing.T) {
 		w.Header().Set("Content-Type", "text/markdown; charset=utf-8")
 		_, _ = w.Write([]byte(body))
 	})
-	stdout := captureStdout(t, func() {
-		if code := cmdAgentOutput("abcd1234"); code != waitExitOK {
-			t.Errorf("exit = %d, want 0", code)
-		}
-	})
-	if stdout != body {
-		t.Errorf("stdout = %q, want the message verbatim (%q)", stdout, body)
+	got := readAgentAnswer(sess)
+	if got.Failed || got.Code != "" || got.Text != strings.TrimRight(body, "\n") {
+		t.Errorf("readAgentAnswer = %+v, want the message verbatim", got)
 	}
 	req := d.lastRequest(t)
 	if req.method != http.MethodGet || req.path != "/v1/sessions/sess-abcd1234/conversation" || req.query != "scope=message" {
 		t.Fatalf("request = %s %s?%s", req.method, req.path, req.query)
 	}
 
-	for _, tt := range []struct{ code, status string }{
-		{codeNoMessage, ""},
-		{codeNoConversation, ""},
-		{codeUnsupportedAdapter, ""},
-	} {
+	// A daemon "nothing to read" code is a REASON, not a failure: status
+	// reports it as a note beside a perfectly good state line.
+	for _, code := range []string{codeNoMessage, codeNoConversation, codeUnsupportedAdapter} {
 		d.on(func(w http.ResponseWriter, r *http.Request) {
 			status := http.StatusNotFound
-			if tt.code == codeUnsupportedAdapter {
+			if code == codeUnsupportedAdapter {
 				status = http.StatusUnprocessableEntity
 			}
-			writeErrEnvelope(w, status, tt.code, "nothing for you")
+			writeErrEnvelope(w, status, code, "nothing for you")
 		})
-		stderr := captureStderr(t, func() {
-			out := captureStdout(t, func() {
-				if code := cmdAgentOutput("abcd1234"); code != waitExitError {
-					t.Errorf("%s: exit = %d, want 1", tt.code, code)
-				}
-			})
-			if out != "" {
-				t.Errorf("%s: stdout = %q, want nothing printed", tt.code, out)
-			}
-		})
-		if !strings.Contains(stderr, tt.code) {
-			t.Errorf("%s: stderr = %q", tt.code, stderr)
-		}
-		// The hint must be verb-aware: `output` is a READ, so telling the
-		// caller to send keystrokes answers a question they did not ask.
-		if !strings.Contains(stderr, "gmux tail abcd1234") {
-			t.Errorf("%s: stderr = %q, want the read-side 'gmux tail <id>' hint", tt.code, stderr)
-		}
-		if strings.Contains(stderr, "gmux send") {
-			t.Errorf("%s: stderr = %q, output must not suggest sending keystrokes", tt.code, stderr)
+		got := readAgentAnswer(sess)
+		if got.Failed || got.Code != code || got.Message == "" {
+			t.Errorf("%s: readAgentAnswer = %+v, want the daemon's code carried as a reason", code, got)
 		}
 	}
 
-	// Version skew: an unmarked 200 must fail loudly instead of printing a
+	// Version skew: an unmarked 200 must fail loudly instead of presenting a
 	// whole transcript as the latest message.
 	d.on(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte("## User\n\nhi\n\n## Assistant\n\nhello\n"))
 	})
-	stderr := captureStderr(t, func() {
-		out := captureStdout(t, func() {
-			if code := cmdAgentOutput("abcd1234"); code != waitExitError {
-				t.Errorf("skewed daemon: exit = %d, want 1", code)
-			}
-		})
-		if out != "" {
-			t.Errorf("skewed daemon printed %q", out)
-		}
-	})
-	if !strings.Contains(stderr, "predates") {
-		t.Errorf("skew stderr = %q", stderr)
+	got = readAgentAnswer(sess)
+	if !got.Failed || !strings.Contains(got.Report, "predates") {
+		t.Errorf("skewed daemon: readAgentAnswer = %+v, want a version-skew failure", got)
 	}
 }
 
@@ -955,7 +939,7 @@ func TestAgentRefusesPeerSessions(t *testing.T) {
 	}{
 		{"prompt", func() int { text := "go"; return cmdAgentPrompt("c0b3c1a1@laptop", agentModePrompt, false, 0, &text) }},
 		{"cancel", func() int { return cmdAgentCancel("c0b3c1a1@laptop") }},
-		{"output", func() int { return cmdAgentOutput("c0b3c1a1@laptop") }},
+		{"status", func() int { return cmdAgentStatus("c0b3c1a1@laptop", false) }},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			d := startStubDaemon(t, peer)

--- a/cli/gmux/cmd/gmux/cli.go
+++ b/cli/gmux/cmd/gmux/cli.go
@@ -69,8 +69,12 @@ type command struct {
 	keysLiteral bool     // -l: treat args as literal text, not key names
 	keys        []string // key/text arguments
 
+	// agent logs message-type filter (nil = the daemon's default: user +
+	// prose-bearing agent messages). Explicit type flags replace that set.
+	logTypes []string
+
 	// agent (modeAgent)
-	agentSub    string  // prompt|cancel|output
+	agentSub    string  // prompt|cancel|status|logs
 	agentMode   string  // prompt|follow_up|steer (prompt verb only)
 	agentNoWait bool    // --no-wait: return at the admission boundary
 	promptText  *string // inline prompt text (nil = read stdin)
@@ -277,7 +281,14 @@ func parseCLI(args []string) (*command, error) {
 	// Agent verbs typed without their namespace get the namespace guide:
 	// `gmux prompt <id> ...` is far more likely a missing `agent` than a
 	// program named prompt.
-	if head == "prompt" || head == "cancel" || head == "output" || head == "logs" {
+	// The removed read verb keeps its own migration line, namespace or not: a
+	// caller typing it is following older docs, and "unknown command" would not
+	// say what replaced it.
+	if head == "output" {
+		return nil, &usageError{topic: "agent", err: errors.New(
+			"agent output was replaced by 'gmux agent status <id>'; for the answer alone use 'gmux agent logs --agent -n 1 <id>'")}
+	}
+	if head == "prompt" || head == "cancel" || head == "status" || head == "logs" {
 		return nil, &usageError{topic: "agent", err: fmt.Errorf(
 			"unknown command %q; agent commands are namespaced: gmux agent %s ... (%s)", head, head, runHint)}
 	}

--- a/cli/gmux/cmd/gmux/help.go
+++ b/cli/gmux/cmd/gmux/help.go
@@ -23,8 +23,8 @@ Run a command:
 
 Drive an agent (semantic turn control):
   gmux agent prompt <id> <prompt>   prompt an agent, wait, print its answer
-  gmux agent --help                 all options, and the reads: logs (what it
-                                    has been doing), output (its answer)
+  gmux agent --help                 all options, and the reads: status (what
+                                    matters now), logs (the exact text)
 
 Sessions (local by default; address a peer with <id>@<peer>):
   gmux ls [--all|-a] [--json|-j]    list sessions
@@ -118,7 +118,7 @@ For an agent session you usually want a semantic view instead:
 
   gmux agent logs <id> [-n N]    what it has been doing (the conversation
                                  as markdown; -n counts messages)
-  gmux agent output <id>         just its latest answer
+  gmux agent status <id>         what matters now (state, trigger, answer)
 
 ('gmux tail --raw' and its -e/-r aliases are gone: tail is raw by
 definition, and the conversation view moved to 'gmux agent logs'.)
@@ -181,7 +181,7 @@ not a recognized key name is typed as literal text rather than refused.
 Blocks until the session goes idle: an agent finishing its turn, a shell
 back at its prompt (OSC 133 marks), or a one-shot command exiting. For
 agent sessions whose turn completed, prints the agent's latest final message
-on stdout — the same text 'gmux agent output' returns. --quiet suppresses
+on stdout — the same answer 'gmux agent status' reports. --quiet suppresses
 it. A failed, interrupted or dead turn prints nothing (richer failure
 detail is planned).
 

--- a/cli/gmux/cmd/gmux/wait.go
+++ b/cli/gmux/cmd/gmux/wait.go
@@ -67,14 +67,14 @@ const (
 // A wait is also conditionally RESULT-BEARING (ADR 0027 §11 and its
 // "where a result-bearing answer comes from" amendment): when a
 // renderer-capable agent session completes its turn normally, the
-// daemon returns the same latest-final-message `gmux agent output`
+// daemon returns the same latest-final-message the message-scope read
 // selects and this prints it on stdout. Deliberate omissions:
 //
 //   - --quiet suppresses it (pure synchronization);
 //   - an error, an interruption or a death prints NO result. The newest
 //     stored message would belong to a previous or partial turn, and
 //     presenting it as this turn's answer is worse than silence; the
-//     condition goes to stderr instead. `gmux agent output` remains
+//     condition goes to stderr instead. `gmux agent status` remains
 //     available for explicit inspection;
 //   - predicate waits (--for-text/--for-regex) and shell/process
 //     sessions stay synchronization-only, exactly as before: the daemon
@@ -187,7 +187,7 @@ type waitResult struct {
 	// carries what there is (silently dropping the tail would be worse), and the
 	// fact goes to stderr where the account belongs.
 	Truncated bool `json:"truncated"`
-	// ConversationReadable says whether `gmux agent output` can answer for
+	// ConversationReadable says whether `gmux agent status` can answer for
 	// this session at all. Shells, one-shot commands and Claude/Codex
 	// sessions have no semantic conversation, and pointing them at that verb
 	// would send the caller to a route that answers 404.
@@ -281,20 +281,20 @@ func noteTruncatedAnswer(sess cliSession, truncated bool) {
 	if !truncated {
 		return
 	}
-	fmt.Fprintf(os.Stderr, "gmux: the answer was truncated at the agent; read it in full with 'gmux agent output %s'\n",
+	fmt.Fprintf(os.Stderr, "gmux: the answer was truncated at the agent; read it in full with 'gmux agent logs --agent -n 1 %s'\n",
 		shortID(sess.ID))
 }
 
 // inspectHint names the verb that can actually show what happened.
 //
-// `gmux agent output` only exists for sessions with a readable agent
+// `gmux agent status` only exists for sessions with a readable agent
 // conversation. A failed one-shot command (`gmux -d -- make build`, whose
 // non-zero exit closes its lifetime turn with Error=true) or a Claude/Codex
 // session has none, and sending the caller there would answer 404 — for those,
 // the terminal output is the record.
 func inspectHint(sess cliSession, conversationReadable bool) string {
 	if conversationReadable {
-		return "read what exists with 'gmux agent output " + shortID(sess.ID) + "'"
+		return "see what happened with 'gmux agent status " + shortID(sess.ID) + "'"
 	}
 	return "see its output with 'gmux tail " + shortID(sess.ID) + "'"
 }

--- a/cli/gmux/cmd/gmux/wait_test.go
+++ b/cli/gmux/cmd/gmux/wait_test.go
@@ -282,7 +282,7 @@ func TestNoRetiredExitCodesRemain(t *testing.T) {
 	}
 }
 
-// The hint must name a verb that can actually answer. `gmux agent output` is
+// The hint must name a verb that can actually answer. `gmux agent status` is
 // meaningless for a failed one-shot command or a Claude/Codex session (it 404s
 // there), which is exactly the population that now exits 1 because a non-zero
 // child exit closes its lifetime turn with Error=true.
@@ -295,18 +295,18 @@ func TestWaitHintMatchesWhatCanBeRead(t *testing.T) {
 		wantSub    string
 		notWantSub string
 	}{
-		{"readable agent points at agent output",
+		{"readable agent points at agent status",
 			waitResult{Reason: "idle", Outcome: "error", ConversationReadable: true},
-			"gmux agent output abcd1234", "gmux tail"},
+			"gmux agent status abcd1234", "gmux tail"},
 		{"failed one-shot points at tail",
 			waitResult{Reason: "idle", Outcome: "error"},
-			"gmux tail abcd1234", "gmux agent output"},
+			"gmux tail abcd1234", "gmux agent status"},
 		{"interrupted shell points at tail",
 			waitResult{Reason: "idle", Outcome: "interrupted"},
-			"gmux tail abcd1234", "gmux agent output"},
-		{"interrupted agent points at agent output",
+			"gmux tail abcd1234", "gmux agent status"},
+		{"interrupted agent points at agent status",
 			waitResult{Reason: "idle", Outcome: "interrupted", ConversationReadable: true},
-			"gmux agent output abcd1234", "gmux tail"},
+			"gmux agent status abcd1234", "gmux tail"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			stdout.Reset()

--- a/cli/gmux/cmd/gmux/waitsignal_test.go
+++ b/cli/gmux/cmd/gmux/waitsignal_test.go
@@ -31,7 +31,7 @@ func TestTruncatedAnswerIsReportedOnStderr(t *testing.T) {
 	if got := stdout.String(); got != "half an answer\n" {
 		t.Fatalf("stdout=%q", got)
 	}
-	if !strings.Contains(stderr, "truncated") || !strings.Contains(stderr, "gmux agent output") {
+	if !strings.Contains(stderr, "truncated") || !strings.Contains(stderr, "gmux agent logs --agent -n 1") {
 		t.Fatalf("stderr=%q", stderr)
 	}
 

--- a/packages/adapter/capabilities.go
+++ b/packages/adapter/capabilities.go
@@ -82,7 +82,8 @@ type ConversationMessage struct {
 	// compact tool-call lines, image placeholders and anything else that
 	// is activity context rather than something the agent said. It exists
 	// for the semantic "what did the agent answer" read behind
-	// `gmux agent output`, which must not surface a `[tool]` line as the
+	// `gmux agent status` (and `gmux agent logs --agent`), which must not
+	// surface a `[tool]` line as the
 	// agent's reply. Empty when the message carries no prose at all (a
 	// tool-only assistant message).
 	//

--- a/services/gmuxd/cmd/gmuxd/conversation.go
+++ b/services/gmuxd/cmd/gmuxd/conversation.go
@@ -73,6 +73,15 @@ func conversationMessageScopeCentral(w http.ResponseWriter, r *http.Request, ses
 		return
 	}
 	msgs, err := renderer.RenderConversation(sess.ConversationRef)
+	// ENOENT is a conversation with no messages yet, not a lost one: pi reports
+	// the transcript path before it writes the first line, so a brand-new
+	// session (or one whose first turn is still running) lands here. Saying
+	// "gone" would tell the caller their transcript had been destroyed. Same
+	// distinction, same wording as the transcript scope.
+	if errors.Is(err, os.ErrNotExist) {
+		writeError(w, http.StatusNotFound, "no_conversation", "conversation has no messages yet")
+		return
+	}
 	if err != nil {
 		writeError(w, http.StatusNotFound, "no_conversation", "conversation is gone")
 		return
@@ -88,38 +97,107 @@ func conversationMessageScopeCentral(w http.ResponseWriter, r *http.Request, ses
 	_, _ = w.Write([]byte(text + "\n"))
 }
 
-// renderSessionConversation reads and renders a session's adapter-owned
-// conversation. ok is false for every "nothing to read" shape: no store row,
-// non-renderer adapter, no conversation ref, unreadable file.
-func renderSessionConversation(ctx context.Context, store *centralstore.Store, sessionID string) ([]adapter.ConversationMessage, bool) {
-	if store == nil {
-		return nil, false
+// Message-type vocabulary for the transcript scope's `types` filter (ADR
+// 0027's 2026-07-28 amendment, retrieval verbs). The types are gmux's, not
+// pi's: they name what a caller wants to READ, and the classification below is
+// the only place that maps an adapter's rendering onto them.
+//
+//   - user  — a user message (a prompt, a steer, a merged follow-up).
+//   - agent — an assistant message that carries prose (what the agent SAID),
+//     even when the same message also rendered tool calls.
+//   - tool  — an assistant message that rendered tool calls and nothing else.
+//
+// There is deliberately no `thinking`: no adapter renders thinking blocks
+// today (pi's renderer drops them), so serving the type would answer every
+// request with silence. The CLI refuses the flag by name instead.
+const (
+	messageTypeUser  = "user"
+	messageTypeAgent = "agent"
+	messageTypeTool  = "tool"
+)
+
+// conversationMessageType classifies one rendered message.
+//
+// Classification is per MESSAGE, not per line: a pi assistant message routinely
+// mixes prose with [tool] one-liners, and splitting it would invent messages
+// the adapter never asserted. So a mixed message is `agent` and is rendered
+// whole — the filter chooses which messages are shown, never how they read.
+func conversationMessageType(m adapter.ConversationMessage) string {
+	if m.Role == "user" {
+		return messageTypeUser
 	}
-	row, ok, err := store.Session(ctx, centralstore.SessionID(sessionID))
-	if err != nil || !ok || row.ConversationRef == "" {
-		return nil, false
+	if strings.TrimSpace(m.Prose) != "" {
+		return messageTypeAgent
 	}
-	renderer, ok := adapters.FindByAdapter(row.Adapter).(adapter.ConversationRenderer)
-	if !ok {
-		return nil, false
+	return messageTypeTool
+}
+
+// parseConversationTypes validates a `types=` list. An empty string means the
+// default set (user + agent prose): the conversation, without the machinery.
+//
+// An unknown type is refused rather than dropped: a caller who asked for
+// `--thinkin` and got a silently narrowed transcript would read the absence as
+// "the agent thought nothing".
+func parseConversationTypes(raw string) (map[string]bool, error) {
+	if raw == "" {
+		return map[string]bool{messageTypeUser: true, messageTypeAgent: true}, nil
 	}
-	msgs, err := renderer.RenderConversation(row.ConversationRef)
-	if errors.Is(err, os.ErrNotExist) {
-		// Pi reports the path for a brand-new conversation before creating the
-		// JSONL file. That is a readable conversation with zero messages, not an
-		// unsafe unknown boundary: everything later written to this path belongs
-		// after this watermark. Treating ENOENT as unreadable makes the first
-		// synchronous prompt exit 0 while omitting its answer.
-		return []adapter.ConversationMessage{}, true
+	allowed := map[string]bool{}
+	for _, part := range strings.Split(raw, ",") {
+		t := strings.TrimSpace(part)
+		switch t {
+		case messageTypeUser, messageTypeAgent, messageTypeTool:
+			allowed[t] = true
+		case "":
+			return nil, errors.New("types must not contain an empty entry")
+		default:
+			return nil, fmt.Errorf("unknown message type %q; expected user, agent or tool", t)
+		}
 	}
-	if err != nil {
-		return nil, false
+	return allowed, nil
+}
+
+func filterConversationMessages(msgs []adapter.ConversationMessage, allowed map[string]bool) []adapter.ConversationMessage {
+	out := make([]adapter.ConversationMessage, 0, len(msgs))
+	for _, m := range msgs {
+		if allowed[conversationMessageType(m)] {
+			out = append(out, m)
+		}
 	}
-	return msgs, true
+	return out
+}
+
+// conversationWireMessage is the machine contract of `format=json`
+// (`gmux agent logs --json`): the rendered message, plus the type it was
+// filtered on and the prose subset so a consumer can separate what the agent
+// said from what it did without re-parsing the rendering.
+//
+// Every field is always present, Prose included: the documented shape is
+// {role, type, text, prose}, and omitting prose for a tool-only message would
+// make `.prose` null there and "" elsewhere — two spellings of the same fact,
+// in a contract two verbs (`logs --json` and `status --json`) must agree on.
+type conversationWireMessage struct {
+	Role  string `json:"role"`
+	Type  string `json:"type"`
+	Text  string `json:"text"`
+	Prose string `json:"prose"`
+}
+
+func conversationWireMessages(msgs []adapter.ConversationMessage) []conversationWireMessage {
+	out := make([]conversationWireMessage, 0, len(msgs))
+	for _, m := range msgs {
+		out = append(out, conversationWireMessage{
+			Role:  m.Role,
+			Type:  conversationMessageType(m),
+			Text:  strings.TrimRight(m.Text, "\n"),
+			Prose: strings.TrimRight(m.Prose, "\n"),
+		})
+	}
+	return out
 }
 
 // conversationReadable reports whether this session has a conversation gmux can
-// read at all. It answers the CLI's hint question ("is `gmux agent output`
+// read at all. It answers the CLI's hint question ("is `gmux agent status`
 // meaningful here?") without rendering anything: a shell or a Claude/Codex
 // session must not be told to read a semantic conversation that will 404.
 func conversationReadable(ctx context.Context, store *centralstore.Store, sessionID string) bool {

--- a/services/gmuxd/cmd/gmuxd/conversation_filter_test.go
+++ b/services/gmuxd/cmd/gmuxd/conversation_filter_test.go
@@ -1,0 +1,227 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// filterFixtureLines is a transcript with one of each type: a user message, an
+// assistant message that only calls tools, and an assistant message that mixes
+// a tool call with prose.
+func filterFixtureLines() []string {
+	return []string{
+		piSessionHeader,
+		`{"type":"message","id":"u1","message":{"role":"user","content":[{"type":"text","text":"run the tests"}]}}`,
+		`{"type":"message","id":"a1","message":{"role":"assistant","content":[{"type":"toolCall","id":"t1","name":"bash","arguments":{"command":"go test ./..."}}]}}`,
+		`{"type":"message","id":"tr","message":{"role":"toolResult","content":[{"type":"text","text":"ok"}]}}`,
+		`{"type":"message","id":"a2","message":{"role":"assistant","content":[{"type":"thinking","text":"hmm"},{"type":"toolCall","id":"t2","name":"bash","arguments":{"command":"go vet ./..."}},{"type":"text","text":"All green."}]}}`,
+	}
+}
+
+// TestConversationTypeFilter is the read behind `gmux agent logs`' filters: the
+// default set is user + prose-bearing agent messages (tool-only and toolResult
+// messages excluded), explicit types REPLACE that set, and they compose.
+func TestConversationTypeFilter(t *testing.T) {
+	f := newConversationFixture(t)
+	f.addPiSession(t, "sess-1", filterFixtureLines()...)
+
+	for _, tt := range []struct {
+		query      string
+		wantHave   []string
+		wantAbsent []string
+	}{
+		{"", []string{"run the tests", "All green."}, []string{"go test ./..."}},
+		{"types=user", []string{"run the tests"}, []string{"All green.", "go test ./..."}},
+		{"types=agent", []string{"All green."}, []string{"run the tests"}},
+		{"types=tool", []string{"go test ./..."}, []string{"run the tests"}},
+		{"types=user,tool", []string{"run the tests", "go test ./..."}, []string{"All green."}},
+		{"types=user,agent,tool", []string{"run the tests", "All green.", "go test ./..."}, nil},
+	} {
+		t.Run("?"+tt.query, func(t *testing.T) {
+			resp := f.do(http.MethodGet, "sess-1", tt.query)
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status = %d, want 200", resp.StatusCode)
+			}
+			body, _ := io.ReadAll(resp.Body)
+			for _, want := range tt.wantHave {
+				if !strings.Contains(string(body), want) {
+					t.Errorf("body missing %q:\n%s", want, body)
+				}
+			}
+			for _, absent := range tt.wantAbsent {
+				if strings.Contains(string(body), absent) {
+					t.Errorf("body must not contain %q:\n%s", absent, body)
+				}
+			}
+			// A toolResult echo is never a message type: the renderer drops it
+			// upstream, and no filter may resurrect it.
+			if strings.Contains(string(body), `"ok"`) {
+				t.Errorf("toolResult content leaked into the transcript:\n%s", body)
+			}
+		})
+	}
+}
+
+// TestConversationTailCountsPostFilter: tail counts the messages the caller
+// asked to see. Counting pre-filter would make `--tool -n 1` mean "the last
+// message, if it happens to be a tool call".
+func TestConversationTailCountsPostFilter(t *testing.T) {
+	f := newConversationFixture(t)
+	f.addPiSession(t, "sess-1", filterFixtureLines()...)
+	resp := f.do(http.MethodGet, "sess-1", "types=tool&tail=1")
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK || !strings.Contains(string(body), "go test ./...") {
+		t.Fatalf("status=%d body=%s, want the single tool message", resp.StatusCode, body)
+	}
+	// And a filter that matches nothing is an explicit code, never an empty
+	// success: printing nothing under a 200 would say the agent has done none of
+	// this.
+	f.addPiSession(t, "sess-2", piSessionHeader,
+		`{"type":"message","id":"u1","message":{"role":"user","content":[{"type":"text","text":"hi"}]}}`)
+	resp = f.do(http.MethodGet, "sess-2", "types=tool")
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404 for a filter that matches nothing", resp.StatusCode)
+	}
+	body, _ = io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), codeNoMessage) {
+		t.Errorf("body = %s, want %s", body, codeNoMessage)
+	}
+}
+
+// TestConversationMissingFileIsEmptyNotGone: pi reports its conversation path
+// before writing the first line, so a brand-new session (or one whose first
+// turn is still running) has a ref pointing at nothing. Reporting that as
+// "conversation is gone" told the caller their transcript had been destroyed —
+// `gmux agent status` on a session that has just been launched hit exactly this.
+func TestConversationMissingFileIsEmptyNotGone(t *testing.T) {
+	f := newConversationFixture(t)
+	f.addSession(t, "sess-new", "pi", f.dir+"/never-written.jsonl")
+	resp := f.do(http.MethodGet, "sess-new", "")
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "no messages yet") || strings.Contains(string(body), "gone") {
+		t.Errorf("body = %s, want it to say the conversation has no messages yet", body)
+	}
+}
+
+// TestConversationJSONFormat pins the machine contract of `logs --json` and the
+// shape `agent status` reads: role, type, text and the prose subset.
+func TestConversationJSONFormat(t *testing.T) {
+	f := newConversationFixture(t)
+	f.addPiSession(t, "sess-1", filterFixtureLines()...)
+	resp := f.do(http.MethodGet, "sess-1", "types=user,agent,tool&format=json")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	var env struct {
+		Data struct {
+			Messages []struct {
+				Role  string `json:"role"`
+				Type  string `json:"type"`
+				Text  string `json:"text"`
+				Prose string `json:"prose"`
+			} `json:"messages"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	msgs := env.Data.Messages
+	if len(msgs) != 3 {
+		t.Fatalf("got %d messages, want 3: %+v", len(msgs), msgs)
+	}
+	if msgs[0].Role != "user" || msgs[0].Type != messageTypeUser {
+		t.Errorf("first message = %+v", msgs[0])
+	}
+	if msgs[1].Type != messageTypeTool || msgs[1].Prose != "" {
+		t.Errorf("a tool-only message must have no prose: %+v", msgs[1])
+	}
+	// A mixed message stays ONE message: text carries the tool rendering too,
+	// prose carries only what the agent said. Splitting it would invent messages
+	// the adapter never asserted.
+	if msgs[2].Type != messageTypeAgent || msgs[2].Prose != "All green." || !strings.Contains(msgs[2].Text, "[tool] bash") {
+		t.Errorf("mixed message = %+v", msgs[2])
+	}
+	// Thinking is not rendered by this adapter, so no type can surface it.
+	for _, m := range msgs {
+		if strings.Contains(m.Text, "hmm") {
+			t.Errorf("thinking leaked into %+v", m)
+		}
+	}
+}
+
+// TestConversationJSONAlwaysCarriesEveryField: the documented shape is
+// {role, type, text, prose}, and `logs --json` re-emits the daemon's objects
+// verbatim while `status --json` re-marshals through the CLI's own struct. If
+// prose were omitted for a tool-only message, `.prose` would be null in one
+// contract and "" in the other for the same message.
+func TestConversationJSONAlwaysCarriesEveryField(t *testing.T) {
+	f := newConversationFixture(t)
+	f.addPiSession(t, "sess-1", filterFixtureLines()...)
+	resp := f.do(http.MethodGet, "sess-1", "types=tool&format=json")
+	var env struct {
+		Data struct {
+			Messages []map[string]any `json:"messages"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(env.Data.Messages) != 1 {
+		t.Fatalf("got %d messages, want the one tool message", len(env.Data.Messages))
+	}
+	for _, field := range []string{"role", "type", "text", "prose"} {
+		if _, present := env.Data.Messages[0][field]; !present {
+			t.Errorf("tool-only message omits %q: %v", field, env.Data.Messages[0])
+		}
+	}
+}
+
+// TestConversationMessageScopeMissingFileIsEmptyNotGone: both scopes tell the
+// same ENOENT truth. The transcript scope shadows this one for `agent status`
+// today by read ordering alone; a direct caller of scope=message must not be
+// told a brand-new session's transcript was destroyed.
+func TestConversationMessageScopeMissingFileIsEmptyNotGone(t *testing.T) {
+	f := newConversationFixture(t)
+	f.addSession(t, "sess-new", "pi", f.dir+"/never-written.jsonl")
+	resp := f.do(http.MethodGet, "sess-new", "scope=message")
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "no messages yet") || strings.Contains(string(body), "gone") {
+		t.Errorf("body = %s, want it to say the conversation has no messages yet", body)
+	}
+}
+
+// TestConversationFilterValidation: a mistyped filter or format is refused, not
+// silently resolved to a default. A narrowed transcript served as a success
+// reads as "the agent did none of that".
+func TestConversationFilterValidation(t *testing.T) {
+	f := newConversationFixture(t)
+	f.addPiSession(t, "sess-1", filterFixtureLines()...)
+	for _, tt := range []struct{ query, want string }{
+		{"types=thinking", "unknown message type"},
+		{"types=", "must not be empty"},
+		{"types=user&types=tool", "at most once"},
+		{"types=user,", "empty entry"},
+		{"format=yaml", "unknown format"},
+		{"format=", "must not be empty"},
+	} {
+		t.Run("?"+tt.query, func(t *testing.T) {
+			resp := f.do(http.MethodGet, "sess-1", tt.query)
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400", resp.StatusCode)
+			}
+			body, _ := io.ReadAll(resp.Body)
+			if !strings.Contains(string(body), tt.want) {
+				t.Errorf("body = %s, want it to mention %q", body, tt.want)
+			}
+		})
+	}
+}

--- a/services/gmuxd/cmd/gmuxd/serve_central.go
+++ b/services/gmuxd/cmd/gmuxd/serve_central.go
@@ -1223,7 +1223,7 @@ func conversationHandlerCentral(w http.ResponseWriter, r *http.Request, sessionI
 	// scope selects WHAT is read, not how much: absent (or the explicit
 	// "transcript") is the pre-existing markdown transcript every current
 	// caller expects, byte for byte. "message" is ADR 0027's semantic read
-	// behind `gmux agent output`. Validation is strict because a mistyped
+	// behind `gmux agent status`'s answer part. Validation is strict because a mistyped
 	// scope silently served as a transcript would hand a script the whole
 	// conversation where it asked for one answer.
 	//
@@ -1255,6 +1255,38 @@ func conversationHandlerCentral(w http.ResponseWriter, r *http.Request, sessionI
 		}
 		tailN = n
 	}
+	// types selects WHICH messages are read (`gmux agent logs`' filters);
+	// format selects how they are serialized. Both are validated strictly and
+	// judged on the query KEY for the same reason scope is: a mistyped filter
+	// silently served as the default would hand a caller a narrower or wider
+	// conversation than they asked for, and absence is indistinguishable from
+	// "the agent did none of that".
+	typesRaw := ""
+	if _, present := r.URL.Query()["types"]; present {
+		v, err := singleQueryValue(r.URL.Query(), "types")
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "bad_request", err.Error())
+			return
+		}
+		typesRaw = v
+	}
+	allowedTypes, err := parseConversationTypes(typesRaw)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+	format, err := singleQueryValue(r.URL.Query(), "format")
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+	switch format {
+	case "", "markdown", "json":
+	default:
+		writeError(w, http.StatusBadRequest, "bad_request",
+			fmt.Sprintf("unknown format %q; expected markdown or json", format))
+		return
+	}
 	// Adapter first, then the ref — the same ordering (and the same reason) as
 	// the message scope: "this adapter has no conversation model" is permanent
 	// and actionable, while "no conversation ref yet" is transient, and
@@ -1274,6 +1306,14 @@ func conversationHandlerCentral(w http.ResponseWriter, r *http.Request, sessionI
 		return
 	}
 	msgs, err := renderer.RenderConversation(sess.ConversationRef)
+	// A missing file is a conversation with no messages yet, not a lost one: pi
+	// reports the path before it writes the first line, so a brand-new session
+	// (or one whose first turn is still running) lands here. Reporting it as
+	// "gone" told the caller their transcript had been destroyed.
+	if errors.Is(err, os.ErrNotExist) {
+		writeError(w, http.StatusNotFound, "no_conversation", "conversation has no messages yet")
+		return
+	}
 	if err != nil {
 		writeError(w, http.StatusNotFound, "no_conversation", "conversation is gone")
 		return
@@ -1282,8 +1322,24 @@ func conversationHandlerCentral(w http.ResponseWriter, r *http.Request, sessionI
 		writeError(w, http.StatusNotFound, "no_conversation", "conversation has no messages yet")
 		return
 	}
+	// Filter BEFORE tail: tail counts the messages the caller asked to see, so
+	// `--tool -n 1` means the last tool message, not "the last message, if it
+	// happens to be a tool call".
+	msgs = filterConversationMessages(msgs, allowedTypes)
+	if len(msgs) == 0 {
+		// The conversation exists and is readable; nothing in it matches. That is
+		// codeNoMessage's exact meaning, and it must not be an empty 200:
+		// printing nothing under a success would say the agent has done none of
+		// this, which only an explicit code may claim.
+		writeError(w, http.StatusNotFound, codeNoMessage, "no messages of the requested type")
+		return
+	}
 	if tailN > 0 && len(msgs) > tailN {
 		msgs = msgs[len(msgs)-tailN:]
+	}
+	if format == "json" {
+		writeJSON(w, map[string]any{"ok": true, "data": map[string]any{"messages": conversationWireMessages(msgs)}})
+		return
 	}
 	w.Header().Set("Content-Type", "text/markdown; charset=utf-8")
 	w.Header().Set("Cache-Control", "no-store")
@@ -1387,7 +1443,7 @@ func handleWaitCentral(w http.ResponseWriter, r *http.Request, boot *Bootstrap, 
 	// A wait that never identifies a turn — one that finds the turn already
 	// closed, or a session whose adapter asserts no turn identity — resolves
 	// result-free. It still reports the conclusion; it just does not claim an
-	// answer it cannot attribute, and `gmux agent output` remains the snapshot
+	// answer it cannot attribute, and `gmux agent status` remains the snapshot
 	// read for those.
 	var observedSeq uint64
 	active := false
@@ -1484,12 +1540,13 @@ func handleWaitCentral(w http.ResponseWriter, r *http.Request, boot *Bootstrap, 
 // An error or interruption carries no output either way: a partial or previous
 // turn's answer presented as this turn's is the failure mode ADR 0027 §11
 // forbids. Nothing is re-read from the conversation here — a re-read would reopen
-// the §9 staleness gap the source assertion closes; `gmux agent output`, the
+// the §9 staleness gap the source assertion closes; `gmux agent status`, the
 // snapshot verb, is the one that reads the tape.
 //
 // conversation_readable travels with every turn conclusion so the CLI can pick
 // an actionable hint: pointing a failed shell or Claude/Codex session at
-// `gmux agent output` sends the caller at a route that answers 404 for them.
+// `gmux agent status`'s conversation reads sends the caller at routes that
+// answer 404 for them.
 // retainedTurnFrame reads the turn frame gmuxd retains for a session's live
 // generation. It is indirected through a variable because the guarantee under
 // test is that the frame-less resolution paths (the initial fanout look and the

--- a/skills/gmux/SKILL.md
+++ b/skills/gmux/SKILL.md
@@ -17,7 +17,7 @@ gmux -- <cmd> [args]         # run blocking; exits with the child's exit code
 gmux -d -- <cmd> [args]      # run detached; prints the session id on stdout
 gmux agent prompt <id> 'text'   # prompt an AGENT session; blocks until the turn ends
 gmux agent prompt --new 'text'  # launch a new pi session AND prompt it (prints the id first)
-gmux agent output <id>          # print that agent's latest message
+gmux agent status <id>          # what matters now: state, trigger, answer
 gmux agent cancel <id>          # interrupt the running turn
 gmux send <id> 'text' Enter  # RAW: type text and submit (Enter is explicit)
 gmux send <id> C-c           # send a control key (interrupt), no text
@@ -26,7 +26,10 @@ gmux wait <id>               # block until the turn ends; prints an agent's answ
 gmux wait --quiet <id>       # ...synchronize only, print nothing
 gmux wait <id> --for-text S  # block until S appears in the output
 gmux tail <id> [-n N]        # RAW: last N lines of terminal output (N=100)
-gmux agent logs <id> [-n N]  # an agent's conversation as markdown (N messages)
+gmux agent logs <id> [-n N] [--user|--agent|--tool|--all] [--json]
+                             # an agent's conversation as markdown (N messages,
+                             # counted after the type filter)
+gmux agent logs --agent -n 1 <id>   # just the latest answer
 gmux ls [--json]             # list sessions (--json for machine parsing)
 gmux kill <id>               # SIGTERM the runner
 ```
@@ -79,7 +82,8 @@ flags (`--wait`, `--timeout`) only work *before* the id.
 ```bash
 id=$(gmux -d -- pi)
 gmux agent prompt --timeout 600 $id 'run the suite and fix what fails'
-gmux agent output $id                     # the answer, verbatim, no [tool] lines
+gmux agent status $id                     # state, trigger, and the answer
+gmux agent logs --agent -n 1 $id           # the answer alone, no [tool] lines
 git diff | gmux agent prompt $id           # prompt from stdin (stays one prompt)
 ```
 
@@ -87,7 +91,7 @@ git diff | gmux agent prompt $id           # prompt from stdin (stays one prompt
 
 ```bash
 id=$(gmux agent prompt --new --no-wait --name review 'review the diff on this branch')
-gmux wait $id && gmux agent output $id
+gmux wait $id && gmux agent status $id
 
 gmux agent prompt --new --model anthropic/sonnet 'summarize this repo'
 ```
@@ -124,15 +128,19 @@ launch. `--new` is pi-only — for any other command the two-step
 stdout (the turn's final message, no `[tool]` lines), as the agent asserted it
 for that exact turn. A turn nobody could identify as yours prints nothing rather
 than somebody else's answer, and a very long answer is capped at the agent with
-a note on stderr — `gmux agent output <id>` has the full text. Exit codes are
+a note on stderr — `gmux agent logs --agent -n 1 <id>` has the full text. Exit codes are
 gmux's global taxonomy, identical for every verb that reports a gmux verdict:
 `0` completed, `2` intentionally interrupted, `1` everything else (failed turn,
 `--timeout`, dead runner, usage/transport error). The exceptions pass a code
 through instead: `gmux -- <cmd>` and `gmux edit` return the child's, and
 `gmux daemon|auth|remote` return gmuxd's. A turn that did not complete prints **no**
 answer — a previous turn's reply must never be presented as this one's; read
-what exists with `gmux agent output <id>` (works even after the session died).
-Use `gmux agent logs <id>` when you want the whole conversation.
+what exists with `gmux agent status <id>` (works even after the session died).
+Use `gmux agent logs <id>` when you want specific text: no flag gives the
+conversation (user messages plus assistant prose), `--user`/`--agent`/`--tool`/
+`--all` **replace** that set, `-n` counts messages after the filter, and
+`--json` prints `{role, type, text, prose}` objects. Both reads are snapshots of
+the stored conversation, so they can be staler than the answer a wait carries.
 
 Other shapes, all with the flags **before** the id (text after the id is
 verbatim):
@@ -169,7 +177,7 @@ silently.
 Errors carry a stable code. `admission_timeout`, `delivery_timeout` and
 `transport_error` are **indeterminate** — the prompt
 may already have landed, so do not blindly retry; inspect with `gmux agent
-output`/`gmux agent logs` first. So is a bare transport failure with no code (a dropped
+status`/`gmux agent logs` first. So is a bare transport failure with no code (a dropped
 connection to gmuxd): the request may have been delivered before the connection
 went away. `runner_outdated` (the session predates semantic actions: restart it),
 `precondition_failed`, `delivery_pending`, `not_ready`, `not_running` and
@@ -184,7 +192,7 @@ id=$(gmux -d -- pi "implement the feature")
 gmux wait $id
 
 gmux agent prompt --timeout 900 $id "$(cat review.txt)"
-gmux agent output $id
+gmux agent status $id
 ```
 
 For **raw** (non-agent) sessions, **prefer `gmux send --wait` over `gmux send … && gmux wait`** for "send a
@@ -209,7 +217,8 @@ done
 
 for id in "${ids[@]}"; do
   echo "=== $id ==="
-  gmux agent output "$id"      # each agent's final answer (agent logs for the conversation)
+  gmux agent logs --agent -n 1 "$id"   # each agent's final answer
+  # ...or 'gmux agent status "$id"' for state + trigger + answer
 done
 ```
 
@@ -244,7 +253,7 @@ deploy.sh` **will** deploy after a failed build. Run the command as its own
 session (`gmux -- make build`) if you need its result.
 
 For a pi session whose turn completed, `wait` also **prints the agent's latest
-final message** — the same text `gmux agent output` returns — so
+final message** — the same answer `gmux agent status` reports — so
 `answer=$(gmux wait $id)` works. `--quiet` suppresses it. A failed, interrupted
 or dead turn prints nothing (the stderr line says which); shell sessions,
 Claude/Codex sessions and output-condition waits are synchronization-only.
@@ -274,13 +283,13 @@ is line-wise against the rendered terminal output (ANSI stripped, same text
 `gmux tail` shows), including output that appeared before the wait
 started, so the pattern must fit on one terminal line.
 
-## Reading a session: three questions, three commands
+## Reading a session: three commands, split by what you know you want
 
-| Question | Command | `-n` counts |
+| You want | Command | `-n` counts |
 | --- | --- | --- |
-| What is on its screen? | `gmux tail <id>` (any session) | lines |
-| What has it been doing? | `gmux agent logs <id>` (agents) | messages |
-| What is the answer? | `gmux agent output <id>` | — |
+| The raw screen | `gmux tail <id>` (any session) | lines |
+| The exact text you want | `gmux agent logs <id>` (agents) | messages (post-filter) |
+| "Show me what matters" | `gmux agent status <id>` (agents) | — |
 
 `gmux tail` is always raw: the last N lines of rendered terminal output, plain
 text, for shells, one-shot commands and agents alike.
@@ -289,14 +298,32 @@ For agent sessions backed by a conversation file (pi), `gmux agent logs` prints
 the conversation itself as markdown — `## User` / `## Assistant` messages with
 compact `[tool] …` one-liners — instead of the TUI's terminal rendering. `-n`
 counts messages there, not lines; thinking blocks and tool outputs are omitted.
-Like `agent output` it reads the stored conversation, so it never starts or
-resumes anything and works on a dead session (local sessions only). This is the
-best way to read another agent's work:
+Type filters pick what you get: no flag gives user messages plus assistant
+prose, and `--user`/`--agent`/`--tool`/`--all` **replace** that default set
+(`--json` prints `{role, type, text, prose}` objects). There is no `--thinking`:
+nothing renders thinking blocks today, so the flag is refused by name.
+
+`gmux agent status <id>` is the other end of the split — one fixed shape
+whatever the session is doing: a state line (alive/dead, active/idle, the last
+closed turn's outcome and rough recency), the triggering excerpt, and the
+relevant content (the answer when idle; the last few messages and a working
+indicator while a turn runs). A running turn reports no outcome, and a session
+that died mid-turn reports `the turn never finished (runner died)` — the same
+verdict `gmux wait` gives that row, never "completed". `--json` gives one object
+with those parts and a `content.kind` of `"answer"`, `"recent"` or `"none"`;
+fields for a turn that does not exist (`state.last_turn_outcome`,
+`state.last_turn_cause`) are absent rather than empty.
+
+Both agent reads are snapshots of the stored conversation: they never start or
+resume anything, they work on a dead session (local sessions only), and they can
+be staler than the answer a `wait` or a synchronous `prompt` carries. This is
+the best way to read another agent's work:
 
 ```bash
 gmux agent prompt $id 'summarize your findings'
-gmux agent output $id        # just the reply
-gmux agent logs $id -n 2     # the prompt and the reply, clean markdown
+gmux agent logs --agent -n 1 $id  # just the reply
+gmux agent logs $id -n 2          # the prompt and the reply, clean markdown
+gmux agent status $id             # state + trigger + answer, one report
 ```
 
 Shell sessions, and agents with no readable conversation (`unsupported_adapter`),


### PR DESCRIPTION
## Summary

Splits the semantic reads along a cognitive boundary (ADR 0027, "Retrieval verbs"):

- **`gmux agent status <id>`** (replaces `agent output`) — "show me what matters": a fixed three-part snapshot (state line incl. died-mid-turn detection, the triggering prompt excerpt, and the final answer when idle / recent activity when active). Store-only, works on dead sessions, adapter-gated content with an adapter-independent state line.
- **`gmux agent logs <id>`** gains message-type filters: default is user+agent prose (tool noise excluded); `--user/--agent/--tool` replace the default set; `--all`; `-n` counts post-filter. `logs --agent -n 1` approximates the old `output` read (documented as potentially staler than a wait's carried result).
- **`--json`** on both: stable machine shapes, one message schema across the two.

`agent output` fails by name with a migration hint. Also: ENOENT on a not-yet-written pi transcript now reads as "no messages yet" instead of "conversation is gone" (both handlers).

## Review

Adversarial round (2 anchors + 1 spot): 1 high (status fabricated `completed` for sessions that died mid-turn — the store deliberately preserves the open-turn flags at death and the classifier now honors them), 2 medium honesty fixes (trigger lost on busy turns; `--json` pairing a running turn with an outcome), 5 lows, all fixed and delta-verified. Final verdict: integrate.
