### PR TITLE
feat(agent): steering interrupts waits, stderr reports, and --json

### DIFF
--- a/apps/website/src/content/docs/integrations/scripts-and-agents.md
+++ b/apps/website/src/content/docs/integrations/scripts-and-agents.md
@@ -107,7 +107,7 @@ behind or steer); `--timeout` bounds your wait, never the launch. `--new`
 launches pi only — for any other command, the two-step `gmux -d -- <cmd>` plus
 a prompt remains fully supported and is the shape to use.
 
-`agent prompt` blocks until the turn ends and prints the agent's answer on stdout — the turn's final message only (no `[tool]` lines), as the agent asserted it for that turn (gmux does not reconstruct it from the transcript, so an answer is only ever attributed to the turn that produced it). Exit codes are gmux's global taxonomy, shared by every verb that reports a gmux verdict (`gmux -- <cmd>`/`gmux edit` pass the child's code through, and `gmux daemon|auth|remote` pass gmuxd's): `0` the turn completed, `2` it was intentionally interrupted, `1` anything else (a failed turn, a `--timeout`, a dead runner). A turn that did not complete prints **nothing**: a previous turn's answer must never be handed back as this one's. `gmux agent status <id>` shows whatever exists in that case (and `gmux agent logs --agent -n 1 <id>` the answer alone), and works even after the session has died — as a snapshot read it can be staler than the answer a wait carries.
+`agent prompt` blocks until the turn ends and prints the agent's answer on stdout — the turn's final message only (no `[tool]` lines), as the agent asserted it for that turn (gmux does not reconstruct it from the transcript, so an answer is only ever attributed to the turn that produced it). Exit codes are gmux's global taxonomy, shared by every verb that reports a gmux verdict (`gmux -- <cmd>`/`gmux edit` pass the child's code through, and `gmux daemon|auth|remote` pass gmuxd's): `0` the turn completed, `2` it was intentionally interrupted or the wait was resolved early because somebody steered the turn, `1` anything else (a failed turn, a `--timeout`, a dead runner, an injection the agent never acknowledged). A turn that did not complete prints **nothing on stdout** and a short status-shaped report on stderr instead — outcome, reason, the trigger excerpt, and the injected text when somebody steered — because a previous turn's answer must never be handed back as this one's, and a bare non-zero exit tells you nothing. `--json` swaps both for one stdout envelope (`{outcome, reason, output, trigger, steered_by, truncated, message}`, absent rather than empty) and keeps stderr silent. Every terminal path prints exactly one envelope, success included, so silence is never an outcome a script has to interpret; it is refused with `--quiet` (on `wait`) and with `--no-wait`. `gmux agent status <id>` shows whatever exists in that case (and `gmux agent logs --agent -n 1 <id>` the answer alone), and works even after the session has died — as a snapshot read it can be staler than the answer a wait carries.
 
 The other shapes:
 
@@ -121,6 +121,16 @@ gmux agent cancel "$id"; gmux wait "$id"; [ $? = 2 ] && echo stopped   # interru
 ```
 
 Note the `;` rather than `&&`: an interrupted turn exits `2`, so chaining the wait with `&&` "fails" on the outcome you asked for.
+
+**Steering interrupts waits.** A user message injected into a turn somebody is waiting on — a `--steer`, a `--follow-up` that merged into the running loop, or a human typing into the TUI — ends *their* wait early with exit `2` and reason `steered`: the answer they were promised now answers something else. The turn keeps running, so re-arm:
+
+```bash
+gmux wait "$id" || gmux wait "$id"    # first wait steered; the second gets the redirected answer
+```
+
+The injecting command keeps its own result: gmux matches the agent's report of a message entering the loop against the text it delivered, and hands that caller the merged close — but only while its message is the loop's **last** injection (a later one supersedes it, reason `steered_again`), and only if the agent acknowledged it before the turn settled (otherwise the result is `indeterminate`, exit `1`, never an answer that may predate the injection). The match is textual, since the agent's report carries the message and nothing else, so gmux requires an exact match — or a prefix, but only for an excerpt the agent explicitly reported as truncated — and credits an ambiguous report — two in-flight deliveries that could both explain it — to nobody, leaving both callers `indeterminate`.
+
+`--follow-up` therefore has two modes: delivered to an **idle** agent it starts an ordinary turn; delivered into a **running** turn it merges into that turn, so the merged close's answer is the follow-up's — and other waiters on that turn are interrupted exactly as by a steer.
 
 Flags go before the id; everything after the id is the prompt, verbatim. A plain prompt restarts a dead retained session to deliver it; `--steer` and `cancel` require a live, active turn and never resume.
 

--- a/apps/website/src/content/docs/reference/cli.md
+++ b/apps/website/src/content/docs/reference/cli.md
@@ -211,7 +211,7 @@ authenticated proxy.
 ### `gmux wait <id>`
 
 ```
-gmux wait [--quiet] [--timeout N] [--for-text S|--for-regex P] <id>
+gmux wait [--quiet] [--json] [--timeout N] [--for-text S|--for-regex P] <id>
 ```
 
 Block until the session is **idle**, optionally bounded by `--timeout N`. For
@@ -242,7 +242,8 @@ use its own codes.)
   **successfully**, or a shell returning to its prompt), or the output condition
   matched
 - `2` — the turn was **intentionally interrupted** (a human or another agent
-  stopped it)
+  stopped it), or the wait was resolved early because somebody **steered** the
+  turn it was waiting on
 - `1` — anything else: the turn ended in an error, the session died, the
   `--timeout` elapsed, the session exited before its output matched, or the
   command was misused. The stderr line names which.
@@ -285,8 +286,12 @@ gmux wait --quiet a3f20187        # synchronize only, print nothing
 
 Nothing is printed when the turn ended in an error, was interrupted, or the
 session died: a previous or partial turn's message presented as this turn's
-answer would be worse than silence. The condition is reported on stderr, and
-`gmux agent status <id>` still shows whatever exists. Also result-free, and
+answer would be worse than silence. The condition is **reported on stderr**
+instead — outcome, reason, the excerpt the turn was triggered with, and the
+injected text when somebody steered — so you never need a second command to
+learn what a non-zero exit meant. Everything in that report comes from the facts
+the agent asserted when it closed the turn; `gmux agent status <id>` is the
+snapshot verb that reads the transcript, and can be staler. Also result-free, and
 perfectly waitable: shell/process sessions, agents that assert no turn identity
 (Claude, Codex), output-condition waits, and a wait that arrives after the turn
 has already closed — it never observed that turn, so it reports the conclusion
@@ -294,6 +299,51 @@ without claiming its answer.
 
 Pressing `^C` on a blocking wait stops **the wait**, not the session: gmux says
 so on stderr, and `gmux wait <id>` re-arms.
+
+**Steering interrupts waits.** A user message injected into the turn you are
+waiting on — somebody else's `--steer`, a `--follow-up` merged into the running
+loop, or a human typing into the TUI — changes what the pending answer answers,
+so the wait resolves early: **exit 2**, reason `steered`, with the injected text
+in the stderr report. The turn itself keeps running, so re-arm when you still
+want its result:
+
+```bash
+until answer=$(gmux wait "$id"); do
+  echo "somebody redirected the turn; waiting for the new answer" >&2
+done
+```
+
+The injecting command is excluded from the interruption it causes — its own
+synchronous prompt gets the merged close — but only while its message is the
+loop's **last**: a later injection supersedes it, and it is then interrupted like
+everybody else (reason `steered_again`). And if the turn settles before the agent
+acknowledges the injected text, that command reports `indeterminate` (exit 1)
+rather than the answer, because the close may predate its message entirely.
+
+**`--json`.** One envelope on stdout for every outcome, and no stderr report —
+the envelope is the account:
+
+```bash
+gmux wait --json "$id"
+{
+  "outcome": "steered",
+  "reason": "steered",
+  "trigger": "run the tests",
+  "steered_by": "stop, fix the lint first"
+}
+```
+
+Fields: `outcome` (`completed`, `steered`, `interrupted`, `error`,
+`indeterminate`, `timeout`, `died`, `accepted`), `reason`, `output`, `trigger`,
+`steered_by`, `truncated`, `message`. Fields describing a fact the resolution
+does not have are **absent**, not empty. **Every** terminal path prints exactly
+one envelope, success included — an output condition that matched is
+`{"outcome":"completed","reason":"matched"}` (no `output`: matched bytes are
+terminal text, not an agent result), and a prompt the daemon accepted without a
+turn conclusion is `{"outcome":"accepted", ...}`. Silence is never an outcome, so
+a script never has to guess whether empty stdout meant success or a crash. The exit code is unchanged, and
+`--json --quiet` is a usage error (they ask for opposite things; the exit code
+alone needs neither).
 
 **Output conditions.** Instead of the idle signal, wait until specific text
 appears in the session's output:
@@ -370,8 +420,12 @@ git diff | gmux agent prompt a3f20187                        # prompt from stdin
 - **no flag** — start a fresh turn. Requires an idle agent; a dead but retained
   session is restarted transparently to deliver the prompt (you'll see a note
   on stderr when that happens).
-- `--follow-up` — queue the prompt so it submits after the current turn ends.
-  On an idle agent it behaves like a plain prompt.
+- `--follow-up` — submit after the current turn. Two modes, and the difference is
+  observable: delivered to an **idle** agent it starts an ordinary turn (like a
+  plain prompt); delivered into a **running** turn it **merges into that turn**
+  (pi drains its queue at the loop's next stopping point), so there is no second
+  turn — the merged close's answer is this follow-up's answer, and it interrupts
+  anybody else waiting on that turn exactly like a `--steer` does.
 - `--steer` — redirect the turn that is running *right now*. Fails if the agent
   is idle or dead; steering nothing is not a thing.
 - `--no-wait` — return as soon as the prompt is **admitted** instead of waiting
@@ -396,18 +450,47 @@ line). Prompts are capped at 1 MiB, and an oversized prompt or one that isn't
 valid UTF-8 is refused before anything is sent — never truncated, never
 re-encoded.
 
+- `--json` — print one envelope on stdout for the turn's resolution instead of
+  the answer-plus-report shape, and nothing on stderr. Same fields as
+  [`gmux wait --json`](#gmux-wait-id); under `--new` it follows the session-id
+  line. Refused with `--no-wait`, which never waits for a resolution to describe.
+
 Exit codes are the global taxonomy shared with [`gmux wait`](#gmux-wait-id):
-`0` the turn completed, `2` the turn was **intentionally interrupted**, `1`
-anything else (a turn that ended in an error, a `--timeout`, a dead runner, a
-transport failure). Timeouts have no code of their own — the stable error code
-on stderr says far more than a number could.
+`0` the turn completed, `2` the turn was **intentionally interrupted or
+steered**, `1` anything else (a turn that ended in an error, a `--timeout`, a
+dead runner, a transport failure, an injection the agent never acknowledged).
+Timeouts have no code of their own — the stable error code on stderr says far
+more than a number could.
+
+**Steering, and being steered.** A message injected into the turn you are
+waiting on resolves your wait early with exit `2` and reason `steered` (see
+[`gmux wait`](#gmux-wait-id)); the turn keeps running, so re-arm with
+`gmux wait <id>` if you still want the result. Your own `--steer` (or merged
+`--follow-up`) does **not** interrupt you: gmux matches the agent's report of a
+message entering the loop against the text it delivered for you, and hands you
+the merged close. That claim holds only while your message is the loop's last
+injection — a later one supersedes it (`steered_again`) — and if the turn settles
+before the agent acknowledges your text at all, the result is `indeterminate`
+(exit `1`) rather than an answer that may predate your message.
+
+The acknowledgement is correlated **by text**, because the agent's report carries
+the message and nothing else. gmux therefore requires an exact match — or a prefix,
+but only for an excerpt the agent explicitly reported as truncated — and refuses
+to guess when two in-flight deliveries could explain the same message: an ambiguous report is
+credited to nobody, so both callers get `indeterminate` and every bystander is
+interrupted. The residue is a human typing text identical to your steer at that
+moment — indistinguishable in principle, and it degrades to `indeterminate`
+rather than to a wrong answer.
 
 On normal completion the agent's answer is printed on stdout. It is the
 agent's OWN assertion about that turn, carried out of the agent with the turn's
 close, not a conversation read: a result is only ever served to the turn it
 belongs to, and a turn nobody could identify is served none. A turn that failed
-or was interrupted prints **nothing** — a previous or partial turn's message
-presented as this one's answer is worse than silence. Read what exists with
+or was interrupted prints **nothing** on stdout and a short status-shaped report
+on stderr — outcome, reason, the trigger excerpt, and the injected text when
+somebody steered — because a previous or partial turn's message presented as this
+one's answer is worse than silence, and a bare non-zero exit is worse than an
+account. Read what exists with
 `gmux agent status <id>`, or the answer alone with
 `gmux agent logs --agent -n 1 <id>` — both are snapshot reads of the transcript,
 and the latter is where a truncated answer's full text lives.

--- a/cli/gmux/cmd/gmux/actions.go
+++ b/cli/gmux/cmd/gmux/actions.go
@@ -611,7 +611,7 @@ func postInput(sess cliSession, body io.Reader, query string) int {
 		fmt.Fprintln(os.Stderr, "gmux: decode send --wait response:", err)
 		return 1
 	}
-	return reportWaitResult(sess, "gmux send --wait", env.Data, false, true, io.Discard)
+	return reportWaitResult(sess, "gmux send --wait", env.Data, false, true, false, io.Discard)
 }
 
 // maxSendBytes caps the number of bytes read from stdin for a single

--- a/cli/gmux/cmd/gmux/agent.go
+++ b/cli/gmux/cmd/gmux/agent.go
@@ -261,7 +261,7 @@ const agentLogsDefaultMessages = 100
 func parseAgentPrompt(args []string) (*command, error) {
 	c := &command{mode: modeAgent, agentSub: "prompt", agentMode: agentModePrompt}
 	modeSet := ""
-	noWaitSet, timeoutSet := false, false
+	noWaitSet, timeoutSet, jsonSet := false, false, false
 	newSet, modelSet, nameSet := false, false, false
 	// A leading help token asks about the verb. Only the leading position:
 	// after the ref, every token is verbatim prompt text, so
@@ -291,6 +291,12 @@ func parseAgentPrompt(args []string) (*command, error) {
 		switch {
 		case a == "-h" || a == "--help":
 			return &command{mode: modeHelp, helpTopic: "agent prompt"}, nil
+		case a == "--json":
+			if jsonSet {
+				return nil, agentRepeatedFlag(a)
+			}
+			jsonSet = true
+			c.json = true
 		case a == "--no-wait":
 			if noWaitSet {
 				return nil, agentRepeatedFlag(a)
@@ -392,6 +398,13 @@ func parseAgentPrompt(args []string) (*command, error) {
 	if c.agentNoWait && timeoutSet {
 		return nil, errors.New("agent prompt: --timeout bounds the wait, so it cannot be combined with --no-wait")
 	}
+	// --json envelopes the TURN's resolution, and --no-wait deliberately never
+	// observes one: it returns at admission. Printing an envelope for a turn this
+	// process did not wait for would either invent fields or ship an envelope that
+	// says nothing, so the combination is refused by name.
+	if c.agentNoWait && jsonSet {
+		return nil, errors.New("agent prompt: --json describes the turn's resolution, which --no-wait never waits for")
+	}
 	var rest []string
 	if c.agentNew {
 		// No ref to consume: everything left is the prompt.
@@ -479,9 +492,9 @@ func cmdAgent(c *command) int {
 	switch c.agentSub {
 	case "prompt":
 		if c.agentNew {
-			return cmdAgentPromptNew(c.agentModel, c.agentName, c.agentNoWait, c.timeout, c.promptText)
+			return cmdAgentPromptNew(c.agentModel, c.agentName, c.agentNoWait, c.timeout, c.promptText, c.json)
 		}
-		return cmdAgentPrompt(c.ref, c.agentMode, c.agentNoWait, c.timeout, c.promptText)
+		return cmdAgentPrompt(c.ref, c.agentMode, c.agentNoWait, c.timeout, c.promptText, c.json)
 	case "cancel":
 		return cmdAgentCancel(c.ref)
 	case "status":
@@ -513,7 +526,7 @@ func resolveAgentSession(ref, verb string) (cliSession, bool) {
 }
 
 // cmdAgentPrompt implements `gmux agent prompt <ref>`.
-func cmdAgentPrompt(ref, mode string, noWait bool, timeoutSecs int, text *string) int {
+func cmdAgentPrompt(ref, mode string, noWait bool, timeoutSecs int, text *string, asJSON bool) int {
 	prompt, err := readPromptText(text, os.Stdin, localterm.IsInteractive())
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "gmux:", err)
@@ -523,7 +536,7 @@ func cmdAgentPrompt(ref, mode string, noWait bool, timeoutSecs int, text *string
 	if !ok {
 		return waitExitError
 	}
-	return deliverPrompt(sess, mode, noWait, timeoutSecs, prompt)
+	return deliverPrompt(sess, mode, noWait, timeoutSecs, prompt, asJSON)
 }
 
 // agentLaunchSession spawns a detached session and returns its id. A variable
@@ -557,7 +570,7 @@ var agentLaunchAdapter adapter.Adapter = adapters.NewPi()
 // a session that never becomes ready fails its first prompt exactly as it
 // would fail its tenth: admission is the single health event, and there is no
 // launch-shaped special case to keep in sync.
-func cmdAgentPromptNew(model, name string, noWait bool, timeoutSecs int, text *string) int {
+func cmdAgentPromptNew(model, name string, noWait bool, timeoutSecs int, text *string, asJSON bool) int {
 	prompt, err := readPromptText(text, os.Stdin, localterm.IsInteractive())
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "gmux:", err)
@@ -589,7 +602,7 @@ func cmdAgentPromptNew(model, name string, noWait bool, timeoutSecs int, text *s
 		fmt.Fprintln(os.Stderr, "gmux:", err)
 		return waitExitError
 	}
-	return deliverPrompt(cliSession{ID: id}, agentModePrompt, noWait, timeoutSecs, prompt)
+	return deliverPrompt(cliSession{ID: id}, agentModePrompt, noWait, timeoutSecs, prompt, asJSON)
 }
 
 // agentLaunchArgv translates launch options into an argv, or reports that this
@@ -608,7 +621,7 @@ func agentLaunchArgv(a adapter.Adapter, opts adapter.LaunchOptions) ([]string, b
 
 // deliverPrompt performs the POST /prompt round trip shared by both prompt
 // shapes. sess must already be known local.
-func deliverPrompt(sess cliSession, mode string, noWait bool, timeoutSecs int, prompt string) int {
+func deliverPrompt(sess cliSession, mode string, noWait bool, timeoutSecs int, prompt string, asJSON bool) int {
 	body, err := json.Marshal(map[string]any{
 		"prompt":          prompt,
 		"mode":            mode,
@@ -640,9 +653,9 @@ func deliverPrompt(sess cliSession, mode string, noWait bool, timeoutSecs int, p
 	defer resp.Body.Close()
 	raw, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode >= 300 {
-		return reportAgentError(sess, "prompt", resp.StatusCode, raw)
+		return reportAgentError(sess, "prompt", resp.StatusCode, raw, asJSON)
 	}
-	return reportAgentPromptSuccess(sess, resp.StatusCode, raw, noWait)
+	return reportAgentPromptSuccess(sess, resp.StatusCode, raw, noWait, asJSON)
 }
 
 // readPromptText resolves the prompt text: the positional argument, else
@@ -699,27 +712,33 @@ type agentPromptResult struct {
 	Output string `json:"output"`
 	// Truncated says the adapter capped Output at the source.
 	Truncated bool `json:"truncated"`
+	// Trigger and SteeredBy are the report material of a non-completed
+	// resolution: what the turn was asked to do, and the message that changed it
+	// (a steer, a merged follow-up, a human typing). Both are the adapter's own
+	// excerpts, relayed through the runner's turn frame.
+	Trigger   string `json:"trigger"`
+	SteeredBy string `json:"steered_by"`
 }
 
 // reportAgentPromptSuccess turns a 2xx prompt response into output and an exit
-// code.
+// code, through the same renderer `gmux wait` uses (turnResolution): a completed
+// turn prints the agent's answer alone on stdout, every other resolution prints a
+// status-shaped report on stderr, and --json replaces both with one envelope.
 //
-// A completed turn prints the agent's answer, which the daemon selected at turn
-// close with the same selector `gmux agent status` and `gmux wait` use. Every
-// other conclusion prints NO result — a stale prior-turn answer must never be
-// presented as this turn's — and reports the condition on stderr instead.
-// `resumed` is worth a stderr line because it says the session was dead and has
-// been restarted: a state change the caller did not ask for.
+// `resumed` is worth a stderr line even under --json's silence rule inverted —
+// it is printed before the envelope only in the human shape — because it says the
+// session was dead and has been restarted: a state change the caller did not ask
+// for.
 //
-// One coupling to know about: the error hint below names `gmux agent status`
-// unconditionally, where reportWaitResult decides from the response's
+// One coupling to know about: the hints here name `gmux agent status`
+// unconditionally, where the wait path decides from the response's
 // `conversation_readable` whether to hint at `gmux tail` instead. The two agree
 // today only because a session that can be prompted has an AgentActionEncoder,
 // and the only adapter with one (pi) is also a ConversationRenderer. The moment
 // an adapter implements EncodeAction without RenderConversation, this hint starts
 // naming a route that 404s, and the prompt payload needs `conversation_readable`
 // too.
-func reportAgentPromptSuccess(sess cliSession, status int, body []byte, noWait bool) int {
+func reportAgentPromptSuccess(sess cliSession, status int, body []byte, noWait, asJSON bool) int {
 	var env struct {
 		Data agentPromptResult `json:"data"`
 	}
@@ -728,41 +747,50 @@ func reportAgentPromptSuccess(sess cliSession, status int, body []byte, noWait b
 		return waitExitError
 	}
 	res := env.Data
-	if res.Resumed {
+	if res.Resumed && !asJSON {
 		fmt.Fprintf(os.Stderr, "gmux: resumed session %s to deliver the prompt\n", displayID(sess))
 	}
 	if noWait || status == http.StatusAccepted {
 		// Detached: admission is all that is known, and it is not a result.
+		//
+		// --no-wait is refused with --json at parse time, so reaching here with
+		// asJSON means the DAEMON answered 202 to a waiting request. That still
+		// gets an envelope, with an outcome that says exactly what is known: the
+		// prompt was admitted and no turn was observed. Silence would make the
+		// machine contract unparseable — a script cannot distinguish "no envelope"
+		// from a crash — and inventing `completed` for it would claim a turn
+		// conclusion nobody reported.
+		if asJSON {
+			return turnResolution{
+				Outcome: outcomeAccepted, Reason: res.Admission,
+				Message: "the prompt was admitted; this response carries no turn conclusion",
+			}.render(os.Stdout, os.Stderr, sess, "gmux agent prompt", false, true)
+		}
 		return waitExitOK
 	}
 	switch res.Outcome {
-	case waitOutcomeCompleted:
-		if res.Output != "" {
-			// Verbatim and untruncated, with exactly one trailing newline.
-			// An absent field means "nothing gmux can read" (a non-renderer
-			// agent, or a turn with no prose), which stays quiet: the turn
-			// really did complete.
-			if _, err := io.WriteString(os.Stdout, strings.TrimRight(res.Output, "\n")+"\n"); err != nil {
-				fmt.Fprintln(os.Stderr, "gmux:", err)
-				return waitExitError
-			}
-			noteTruncatedAnswer(sess, res.Truncated)
-		}
-		return waitExitOK
-	case waitOutcomeInterrupted:
-		fmt.Fprintf(os.Stderr, "gmux: the turn was interrupted before it finished (session %s)\n", displayID(sess))
-		return waitExitInterrupted
-	case waitOutcomeError:
-		if res.Cause != "" {
-			fmt.Fprintf(os.Stderr, "gmux: the turn ended in an error (%s); see gmux agent status %s\n",
-				res.Cause, shortID(sess.ID))
-		} else {
-			fmt.Fprintf(os.Stderr, "gmux: the turn ended in an error; see gmux agent status %s\n", shortID(sess.ID))
-		}
-		return waitExitError
+	case waitOutcomeCompleted, waitOutcomeInterrupted, waitOutcomeError, outcomeSteered, outcomeIndeterminate:
+		return turnResolutionOf(sess, res.waitResult()).render(os.Stdout, os.Stderr, sess, "gmux agent prompt", false, asJSON)
 	default:
 		fmt.Fprintf(os.Stderr, "gmux: unexpected prompt outcome %q\n", res.Outcome)
 		return waitExitError
+	}
+}
+
+// waitResult projects the prompt payload onto the wait payload, which is the
+// shape the shared reporter consumes. The two routes carry the same turn facts
+// under the same names; keeping ONE reporter is what stops `gmux wait` and a
+// synchronous prompt from growing different accounts of the same turn.
+//
+// ConversationReadable is deliberately true: the prompt route does not report it
+// (see reportAgentPromptSuccess's note), and a session that just accepted a
+// semantic prompt has a readable conversation for every adapter that exists
+// today.
+func (r agentPromptResult) waitResult() waitResult {
+	return waitResult{
+		Reason: "idle", Outcome: r.Outcome, Cause: r.Cause, Output: r.Output,
+		Trigger: r.Trigger, SteeredBy: r.SteeredBy, Truncated: r.Truncated,
+		ConversationReadable: true,
 	}
 }
 
@@ -786,7 +814,7 @@ func cmdAgentCancel(ref string) int {
 	defer resp.Body.Close()
 	raw, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode >= 300 {
-		return reportAgentError(sess, "cancel", resp.StatusCode, raw)
+		return reportAgentError(sess, "cancel", resp.StatusCode, raw, false)
 	}
 	// Delivered, not stopped: saying "cancelled" would claim more than the
 	// daemon reported.
@@ -921,7 +949,7 @@ func cmdAgentLogs(ref string, n int, types []string, asJSON bool) int {
 		return waitExitError
 	}
 	if resp.StatusCode >= 300 {
-		return reportAgentError(sess, "logs", resp.StatusCode, raw)
+		return reportAgentError(sess, "logs", resp.StatusCode, raw, false)
 	}
 	if len(raw) == 0 {
 		// A 200 with no body. The daemon answers no_conversation instead of
@@ -990,9 +1018,21 @@ const conversationScopeMessage = "message"
 // agent — so rewording them risks turning an indeterminate delivery into
 // something that reads like a safe retry. The code prefix is deliberate:
 // scripts get a stable token without parsing prose.
-func reportAgentError(sess cliSession, verb string, status int, body []byte) int {
+func reportAgentError(sess cliSession, verb string, status int, body []byte, asJSON bool) int {
 	code := errorCode(body)
 	msg := extractMessage(body)
+	if asJSON {
+		// The envelope IS the account under --json, so the report below is not
+		// printed at all. A failure before the turn ended is not a turn
+		// conclusion, so it is enveloped by its CLASS (timeout when the wait
+		// outlived its bound, error otherwise) with the daemon's own stable code
+		// as the reason — which is the token a script would have grepped the
+		// stderr line for.
+		return turnResolution{
+			Outcome: agentFailureOutcome(code), Reason: code, Message: msg,
+			Tail: failedToStartTail(code, sess),
+		}.render(os.Stdout, os.Stderr, sess, verb, false, true)
+	}
 	switch {
 	case code != "" && msg != "":
 		fmt.Fprintf(os.Stderr, "gmux: %s: %s\n", code, msg)
@@ -1010,6 +1050,17 @@ func reportAgentError(sess cliSession, verb string, status int, body []byte) int
 	if hint := agentErrorHint(code, verb, sess); hint != "" {
 		fmt.Fprintln(os.Stderr, "gmux:", hint)
 	}
+	// The one failure ADR 0027 cannot source-assert: pi's prompt submission can
+	// fail before any agent loop event exists (no API key, no model), painting a
+	// banner and emitting nothing. The admission wait times out as designed, and
+	// the report appends what the screen says — labeled as the screen, on the
+	// account channel, where best-effort diagnosis is allowed.
+	if tail := failedToStartTail(code, sess); len(tail) > 0 {
+		fmt.Fprintln(os.Stderr, "gmux:   last lines of the session's terminal (not an agent report):")
+		for _, line := range tail {
+			fmt.Fprintln(os.Stderr, "gmux:   |", line)
+		}
+	}
 	// Every failure code is 1 under the global taxonomy, timeout-shaped ones
 	// included. That loses nothing a number could carry: admission_timeout,
 	// delivery_timeout describe an INDETERMINATE delivery (retrying may duplicate
@@ -1018,6 +1069,40 @@ func reportAgentError(sess cliSession, verb string, status int, body []byte) int
 	// blindly retry. The stable code printed above separates them.
 	return waitExitError
 }
+
+// agentFailureOutcome classifies a daemon failure code for the --json envelope.
+// Only the codes that mean "the wait ended, the work did not" are timeouts; the
+// indeterminate delivery codes are NOT, because a caller retrying on "timeout"
+// would duplicate a prompt that may already have landed.
+func agentFailureOutcome(code string) string {
+	if code == codeExecutionTimeout {
+		return outcomeTimeout
+	}
+	return waitOutcomeError
+}
+
+// failedToStartTail returns the terminal-tail excerpt for the failure that has
+// no turn behind it, and nothing for every other code: a tail attached to, say,
+// an execution timeout would show a turn that is running perfectly well and
+// invite the reader to diagnose a problem that is not there.
+func failedToStartTail(code string, sess cliSession) []string {
+	if code != codeAdmissionTimeout {
+		return nil
+	}
+	return terminalTailExcerpt(sess, failedToStartTailLines)
+}
+
+// failedToStartTailLines is how much screen the failed-to-start report shows:
+// enough for pi's banner and the line above it, not enough to bury the report.
+const failedToStartTailLines = 8
+
+// Daemon failure codes the CLI reacts to by name for reporting purposes. They
+// are the daemon's vocabulary, duplicated across the module boundary like the
+// rest of the wire words.
+const (
+	codeAdmissionTimeout = "admission_timeout"
+	codeExecutionTimeout = "execution_timeout"
+)
 
 // agentErrorHint adds the one actionable next step the daemon's message does
 // not already carry. Hints never soften an indeterminate outcome.
@@ -1058,7 +1143,7 @@ func printAgentUsage(w io.Writer, topic string) {
 	case "agent prompt":
 		fmt.Fprint(w, `gmux agent prompt — send a prompt to an agent session and wait for the turn
 
-  gmux agent prompt [--no-wait] [--follow-up|--steer] [--timeout|-t N] <id> [prompt]
+  gmux agent prompt [--no-wait] [--follow-up|--steer] [--timeout|-t N] [--json] <id> [prompt]
   gmux agent prompt --new [--model M] [--name N] [--no-wait] [--timeout N] [prompt]
 
   <prompt>          the prompt text; omit it to read the prompt from stdin
@@ -1069,14 +1154,44 @@ func printAgentUsage(w io.Writer, topic string) {
   --name N          --new only: the session display name (pi's --name)
   --no-wait         return as soon as the prompt is admitted, without waiting
                     for the turn to finish (see "What --no-wait waits for")
-  --follow-up       queue the prompt to submit after the current turn ends
+  --follow-up       submit after the current turn (see "What --follow-up does")
   --steer           redirect the turn that is running right now (fails if idle)
   --timeout/-t N    give up waiting after N seconds (0/absent: wait indefinitely)
+  --json            print one machine envelope for the turn's resolution
+                    instead of the answer-plus-report shape — on every terminal
+                    path, success included (not with --no-wait, which never
+                    waits for a resolution)
 
 --follow-up and --steer are mutually exclusive; --no-wait composes with either.
 Pass either a session id or --new, never both. --new rejects --follow-up and
 --steer (a session that does not exist yet has no turn to queue behind or
 steer), and --model/--name mean nothing without it.
+
+What --follow-up does depends on what the agent is doing when it arrives:
+
+  - delivered to an IDLE agent it starts an ordinary turn. Nothing else is
+    affected, and its own close is its answer.
+  - delivered into a RUNNING turn it MERGES into that turn (pi drains its
+    queue at the loop's next stopping point). There is no second turn: the
+    merged close's answer is this follow-up's answer — and, exactly like a
+    --steer, it interrupts anybody else waiting on that turn, because the
+    answer they were promised now answers something else too.
+
+Being steered, and re-arming. A user message injected into the turn you are
+waiting on — somebody else's --steer or merged --follow-up, or a human typing
+into the TUI — ends your wait early with exit 2 and reason 'steered'. The turn
+keeps running under its new instructions, so wait again if you still want the
+result: 'gmux wait <id>'. Your OWN steer never interrupts you — but only while
+your message is the loop's last: a later injection supersedes it, and you are
+told the turn was steered again after your text.
+
+If the turn settles before the agent acknowledges the text you injected, the
+result is reported as indeterminate (exit 1) rather than as the answer: that
+close may predate your message entirely, and gmux will not present it as
+yours. The acknowledgement is matched by TEXT (the agent reports the message and
+nothing else), so two in-flight deliveries that could both explain one report are
+credited to neither, and both callers get indeterminate rather than one of them
+getting a coin-flip answer.
 
 What --no-wait waits for depends on whether the prompt STARTS a turn:
 
@@ -1126,9 +1241,17 @@ ready fails its first prompt exactly like any later one.
   are refused with --new, so the delivery-only case above cannot arise.
 
 Waits by default: the command returns when the turn ends and prints the agent's
-answer. Exit status is 0 for a completed turn, 2 for an interrupted one, and 1
-for anything else (a failed turn, a --timeout, a dead runner). A turn that did
-not complete prints no answer — see what happened with 'gmux agent status <id>'.
+answer. Exit status is 0 for a completed turn, 2 for one that was interrupted or
+steered, and 1 for anything else (a failed turn, a --timeout, a dead runner, an
+injection the agent never acknowledged). A turn that did not complete prints no
+answer on stdout and a short report on stderr instead — outcome, reason, the
+excerpt the turn was triggered with, and the injected text when somebody steered
+— so you do not need a second command to learn what happened. With --json that
+report becomes one stdout envelope ({outcome, reason, output, trigger,
+steered_by, truncated, message}) and stderr stays empty; under --new the envelope
+follows the session-id line. For the fuller picture after the fact — including
+after the session died — read 'gmux agent status <id>'; as a snapshot it can be
+staler than the answer this command carried.
 
 A plain prompt (no flag) restarts a dead retained session to deliver the
 prompt; --steer never does. Local sessions only.

--- a/cli/gmux/cmd/gmux/agent_new_test.go
+++ b/cli/gmux/cmd/gmux/agent_new_test.go
@@ -214,7 +214,7 @@ func TestAgentPromptNewUnsupportedAdapter(t *testing.T) {
 	text := "go"
 	var code int
 	stdout := captureStdout(t, func() {
-		stderr := captureStderr(t, func() { code = cmdAgentPromptNew("", "", false, 0, &text) })
+		stderr := captureStderr(t, func() { code = cmdAgentPromptNew("", "", false, 0, &text, false) })
 		if !strings.Contains(stderr, codeUnsupportedAdapter) {
 			t.Errorf("stderr = %q, want the %s code", stderr, codeUnsupportedAdapter)
 		}
@@ -242,7 +242,7 @@ func TestAgentPromptNewNoWaitPrintsBareID(t *testing.T) {
 	text := "start the refactor"
 	var code int
 	stdout := captureStdout(t, func() {
-		code = cmdAgentPromptNew("sonnet", "refactor", true, 0, &text)
+		code = cmdAgentPromptNew("sonnet", "refactor", true, 0, &text, false)
 	})
 	if code != waitExitOK {
 		t.Fatalf("exit = %d, want 0", code)
@@ -276,7 +276,7 @@ func TestAgentPromptNewSyncPrintsIDThenAnswer(t *testing.T) {
 
 	text := "do it"
 	var code int
-	stdout := captureStdout(t, func() { code = cmdAgentPromptNew("", "", false, 0, &text) })
+	stdout := captureStdout(t, func() { code = cmdAgentPromptNew("", "", false, 0, &text, false) })
 	if code != waitExitOK {
 		t.Fatalf("exit = %d, want 0", code)
 	}
@@ -313,7 +313,7 @@ func TestAgentPromptNewIDPrintedBeforeDelivery(t *testing.T) {
 	orig := os.Stdout
 	os.Stdout = w
 	text := "go"
-	code := cmdAgentPromptNew("", "", false, 0, &text)
+	code := cmdAgentPromptNew("", "", false, 0, &text, false)
 	os.Stdout = orig
 	_ = w.Close()
 	if code != waitExitOK {
@@ -352,7 +352,7 @@ func TestAgentPromptNewFailureAfterSpawnStillPrintsID(t *testing.T) {
 			var code int
 			var stderr string
 			stdout := captureStdout(t, func() {
-				stderr = captureStderr(t, func() { code = cmdAgentPromptNew("", "", false, 0, &text) })
+				stderr = captureStderr(t, func() { code = cmdAgentPromptNew("", "", false, 0, &text, false) })
 			})
 			if code != waitExitError {
 				t.Errorf("exit = %d, want %d", code, waitExitError)
@@ -376,7 +376,7 @@ func TestAgentPromptNewSpawnFailurePrintsNoID(t *testing.T) {
 	var code int
 	var stderr string
 	stdout := captureStdout(t, func() {
-		stderr = captureStderr(t, func() { code = cmdAgentPromptNew("", "", false, 0, &text) })
+		stderr = captureStderr(t, func() { code = cmdAgentPromptNew("", "", false, 0, &text, false) })
 	})
 	if code != waitExitError {
 		t.Errorf("exit = %d, want %d", code, waitExitError)
@@ -399,7 +399,7 @@ func TestAgentPromptNewRejectsBadPromptBeforeSpawning(t *testing.T) {
 	argv := stubLaunch(t, "sess-abcd1234", nil)
 	empty := "   "
 	var code int
-	captureStderr(t, func() { code = cmdAgentPromptNew("", "", false, 0, &empty) })
+	captureStderr(t, func() { code = cmdAgentPromptNew("", "", false, 0, &empty, false) })
 	if code != waitExitError {
 		t.Errorf("exit = %d, want %d", code, waitExitError)
 	}
@@ -419,7 +419,7 @@ func TestAgentPromptRefPathPrintsNoIDLine(t *testing.T) {
 	})
 	text := "go"
 	var code int
-	stdout := captureStdout(t, func() { code = cmdAgentPrompt("abcd1234", agentModePrompt, false, 0, &text) })
+	stdout := captureStdout(t, func() { code = cmdAgentPrompt("abcd1234", agentModePrompt, false, 0, &text, false) })
 	if code != waitExitOK {
 		t.Fatalf("exit = %d", code)
 	}

--- a/cli/gmux/cmd/gmux/agent_test.go
+++ b/cli/gmux/cmd/gmux/agent_test.go
@@ -371,7 +371,7 @@ func TestAgentPromptSendsMultibytePromptByteExact(t *testing.T) {
 			var code int
 			if tt.positional {
 				text := prompt
-				code = cmdAgentPrompt("abcd1234", agentModePrompt, false, 0, &text)
+				code = cmdAgentPrompt("abcd1234", agentModePrompt, false, 0, &text, false)
 			} else {
 				code = agentPromptWithStdin(nil, prompt)
 			}
@@ -466,7 +466,7 @@ func TestAgentPromptRefusesInvalidUTF8BeforeSending(t *testing.T) {
 // guard keys on the actual os.Stdin).
 func agentPromptWithStdin(text *string, raw string) int {
 	if text != nil {
-		return cmdAgentPrompt("abcd1234", agentModePrompt, false, 0, text)
+		return cmdAgentPrompt("abcd1234", agentModePrompt, false, 0, text, false)
 	}
 	r, w, err := os.Pipe()
 	if err != nil {
@@ -476,7 +476,7 @@ func agentPromptWithStdin(text *string, raw string) int {
 	os.Stdin = r
 	go func() { _, _ = w.WriteString(raw); _ = w.Close() }()
 	defer func() { os.Stdin = orig; _ = r.Close() }()
-	return cmdAgentPrompt("abcd1234", agentModePrompt, false, 0, nil)
+	return cmdAgentPrompt("abcd1234", agentModePrompt, false, 0, nil, false)
 }
 
 // TestAgentEnvelopeLessNotFoundIsVersionSkew: a bare net/http 404 on an action
@@ -489,7 +489,7 @@ func TestAgentEnvelopeLessNotFoundIsVersionSkew(t *testing.T) {
 		name string
 		run  func() int
 	}{
-		{"prompt", func() int { text := "go"; return cmdAgentPrompt("abcd1234", agentModePrompt, false, 0, &text) }},
+		{"prompt", func() int { text := "go"; return cmdAgentPrompt("abcd1234", agentModePrompt, false, 0, &text, false) }},
 		{"cancel", func() int { return cmdAgentCancel("abcd1234") }},
 		{"status", func() int { return cmdAgentStatus("abcd1234", false) }},
 	} {
@@ -556,7 +556,7 @@ func TestAgentPromptAcceptedWithoutNoWait(t *testing.T) {
 	})
 	stderr := captureStderr(t, func() {
 		text := "go"
-		if code := cmdAgentPrompt("abcd1234", agentModePrompt, false, 0, &text); code != waitExitOK {
+		if code := cmdAgentPrompt("abcd1234", agentModePrompt, false, 0, &text, false); code != waitExitOK {
 			t.Errorf("exit = %d, want 0", code)
 		}
 	})
@@ -723,7 +723,7 @@ func TestAgentPromptRequestBody(t *testing.T) {
 				})
 			})
 			text := "review this branch"
-			if code := cmdAgentPrompt("abcd1234", tt.mode, tt.noWait, tt.timeout, &text); code != waitExitOK {
+			if code := cmdAgentPrompt("abcd1234", tt.mode, tt.noWait, tt.timeout, &text, false); code != waitExitOK {
 				t.Fatalf("exit = %d, want 0", code)
 			}
 			req := d.lastRequest(t)
@@ -771,7 +771,7 @@ func TestAgentPromptOutcomeExits(t *testing.T) {
 			d.on(func(w http.ResponseWriter, r *http.Request) { writeEnvelope(w, http.StatusOK, tt.data) })
 			captureStderr(t, func() {
 				text := "go"
-				if code := cmdAgentPrompt("abcd1234", agentModePrompt, false, 0, &text); code != tt.want {
+				if code := cmdAgentPrompt("abcd1234", agentModePrompt, false, 0, &text, false); code != tt.want {
 					t.Errorf("exit = %d, want %d", code, tt.want)
 				}
 			})
@@ -788,7 +788,7 @@ func TestAgentPromptDetachedIsQuietSuccess(t *testing.T) {
 	})
 	stderr := captureStderr(t, func() {
 		text := "go"
-		if code := cmdAgentPrompt("abcd1234", agentModePrompt, true, 0, &text); code != waitExitOK {
+		if code := cmdAgentPrompt("abcd1234", agentModePrompt, true, 0, &text, false); code != waitExitOK {
 			t.Errorf("exit = %d, want 0", code)
 		}
 	})
@@ -830,7 +830,7 @@ func TestAgentErrorCodeSurfacing(t *testing.T) {
 			})
 			stderr := captureStderr(t, func() {
 				text := "go"
-				if code := cmdAgentPrompt("abcd1234", agentModePrompt, false, 0, &text); code != tt.want {
+				if code := cmdAgentPrompt("abcd1234", agentModePrompt, false, 0, &text, false); code != tt.want {
 					t.Errorf("exit = %d, want %d", code, tt.want)
 				}
 			})
@@ -937,7 +937,10 @@ func TestAgentRefusesPeerSessions(t *testing.T) {
 		name string
 		run  func() int
 	}{
-		{"prompt", func() int { text := "go"; return cmdAgentPrompt("c0b3c1a1@laptop", agentModePrompt, false, 0, &text) }},
+		{"prompt", func() int {
+			text := "go"
+			return cmdAgentPrompt("c0b3c1a1@laptop", agentModePrompt, false, 0, &text, false)
+		}},
 		{"cancel", func() int { return cmdAgentCancel("c0b3c1a1@laptop") }},
 		{"status", func() int { return cmdAgentStatus("c0b3c1a1@laptop", false) }},
 	} {
@@ -1030,7 +1033,7 @@ func TestAgentPromptPrintsTheResultOnlyOnCompletion(t *testing.T) {
 			out := captureStdout(t, func() {
 				captureStderr(t, func() {
 					text := "go"
-					code = cmdAgentPrompt("abcd1234", agentModePrompt, noWait, 0, &text)
+					code = cmdAgentPrompt("abcd1234", agentModePrompt, noWait, 0, &text, false)
 				})
 			})
 			if code != tt.wantExit {

--- a/cli/gmux/cmd/gmux/cli.go
+++ b/cli/gmux/cmd/gmux/cli.go
@@ -511,12 +511,16 @@ func parseWait(args []string) (*command, error) {
 	fs.StringVar(&c.forRegex, "for-regex", "", "wait for a regex match in the session's output")
 	fs.BoolVar(&c.quiet, "quiet", false, "do not print the agent's result; synchronize only")
 	fs.BoolVar(&c.quiet, "q", false, "alias of --quiet")
+	fs.BoolVar(&c.json, "json", false, "print one machine envelope for the resolution instead of answer-plus-report")
 	pos, err := parseInterspersed(fs, args)
 	if err != nil {
 		return nil, err
 	}
 	if len(pos) != 1 {
 		return nil, errors.New("wait requires a session id")
+	}
+	if err := refuseJSONWithQuiet(c.json, c.quiet, "wait"); err != nil {
+		return nil, err
 	}
 	if c.timeout < 0 {
 		return nil, errors.New("--timeout must be a non-negative number of seconds")
@@ -533,6 +537,18 @@ func parseWait(args []string) (*command, error) {
 	}
 	c.ref = pos[0]
 	return c, nil
+}
+
+// refuseJSONWithQuiet rejects `--json --quiet`. They are opposite answers to the
+// same question — one asks for the complete machine account, the other for no
+// output at all — and every resolution of the conflict silently ignores half of
+// what the caller asked for. The exit code alone is available without either
+// flag, so the caller who wants only a verdict has already got it.
+func refuseJSONWithQuiet(asJSON, quiet bool, verb string) error {
+	if asJSON && quiet {
+		return fmt.Errorf("%s: --json and --quiet ask for opposite things (the whole machine account, and no output at all); the exit code alone needs neither flag", verb)
+	}
+	return nil
 }
 
 // parseEdit handles `gmux edit [file]`: at most one file path. The verb

--- a/cli/gmux/cmd/gmux/help.go
+++ b/cli/gmux/cmd/gmux/help.go
@@ -174,29 +174,48 @@ not a recognized key name is typed as literal text rather than refused.
 
 	"wait": `gmux wait: block until a session's turn ends, or until output appears
 
-  gmux wait <id> [--timeout|-t N] [--quiet|-q]
+  gmux wait <id> [--timeout|-t N] [--quiet|-q] [--json]
   gmux wait <id> --for-text <substring> [--timeout|-t N]
   gmux wait <id> --for-regex <pattern> [--timeout|-t N]
 
 Blocks until the session goes idle: an agent finishing its turn, a shell
 back at its prompt (OSC 133 marks), or a one-shot command exiting. For
-agent sessions whose turn completed, prints the agent's latest final message
-on stdout — the same answer 'gmux agent status' reports. --quiet suppresses
-it. A failed, interrupted or dead turn prints nothing (richer failure
-detail is planned).
+agent sessions whose turn completed, prints the agent's answer on stdout —
+the one the adapter asserted when it closed the turn. --quiet suppresses it.
+
+A turn that did NOT complete prints nothing on stdout and a short report on
+stderr instead: the outcome, the reason, what the turn was asked to do, and
+the message that changed it when somebody steered. No second command needed.
 
 A wait on an already-idle session returns at once and reports the LAST
 turn's conclusion; to gate on a turn you are about to trigger, use
 'gmux agent prompt' or 'gmux send --wait', which arm the wait first.
 
+A user message injected into the turn you are waiting on — a steer, a
+follow-up merged into the running loop, or a human typing into the TUI —
+ends this wait early with exit 2 and reason 'steered': the answer it was
+holding out for now answers something else. The turn keeps running, so
+re-arm when you still care:
+
+  gmux wait "$id" || gmux wait "$id"   # first wait steered, second one waits
+                                       # for the redirected turn's answer
+
   --timeout/-t N give up after N seconds (exit 1)
   --quiet/-q     synchronize only; print no result
+  --json         print one envelope on stdout for every outcome instead —
+                 {outcome, reason, output, trigger, steered_by, truncated,
+                 message}, absent rather than empty — and no stderr report.
+                 Every terminal path prints exactly one envelope, success
+                 included (a matched output condition is {"outcome":
+                 "completed","reason":"matched"}), so silence is never an
+                 outcome. The machine contract for this verb. Not with --quiet.
   --for-text S   resolve when S appears in the output instead of on idle
   --for-regex P  ... or when P (RE2, line-wise) matches; works for shell
                  sessions too, and prints no result
 
 Exit codes: 0 the turn completed (or the output matched), 2 the turn was
-intentionally interrupted, 1 anything else (error, death, timeout).
+intentionally interrupted or steered, 1 anything else (error, death,
+timeout, an injection the agent never acknowledged).
 `,
 
 	"kill": `gmux kill: terminate a session

--- a/cli/gmux/cmd/gmux/main.go
+++ b/cli/gmux/cmd/gmux/main.go
@@ -71,7 +71,7 @@ func main() {
 	case modeSendKeys:
 		os.Exit(cmdSendKeys(cmd.ref, cmd.keys, cmd.keysLiteral))
 	case modeWait:
-		os.Exit(cmdWait(cmd.ref, cmd.timeout, cmd.forText, cmd.forRegex, cmd.quiet))
+		os.Exit(cmdWait(cmd.ref, cmd.timeout, cmd.forText, cmd.forRegex, cmd.quiet, cmd.json))
 	case modeAgent:
 		os.Exit(cmdAgent(cmd))
 	case modeEdit:

--- a/cli/gmux/cmd/gmux/turnreport.go
+++ b/cli/gmux/cmd/gmux/turnreport.go
@@ -1,0 +1,261 @@
+package main
+
+// turnreport.go — output routing for a blocking wait (ADR 0027, "Output
+// routing: stdout is data, stderr is the account, the exit code is the
+// verdict").
+//
+// One type, turnResolution, is what `gmux wait` and a synchronous `gmux agent
+// prompt` both resolve to, and one renderer decides where each part goes:
+//
+//   - COMPLETED: stdout is the answer, alone. No report, no trigger echo — a
+//     script piping stdout gets bytes it can use, and a human gets no noise for
+//     a thing that worked.
+//   - NON-COMPLETED: stdout is empty and stderr carries a status-shaped report
+//     naming the outcome, the reason, what the turn was asked to do and (for a
+//     steer) what was injected. The account arrives exactly when the caller
+//     needs it, with no second command — which is the whole point: the previous
+//     behavior made the caller run `gmux agent status` to find out what a
+//     non-zero exit meant, by which time the session may have moved on.
+//   - --json: one stable envelope on stdout regardless of outcome, and NO
+//     stderr report, because the envelope is the account. It releases the human
+//     default from purity pressure.
+//
+// Every field a report or an envelope prints comes from the RELAYED TURN FACTS
+// the daemon carried with the resolution — never from a fresh conversation read.
+// A re-read would reopen the staleness gap the source-asserted result closes,
+// and would describe a session that has moved on rather than the turn that just
+// ended. `gmux agent status` is the verb that reads the tape.
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// Outcome words a resolution can carry. completed/error/interrupted come from
+// the daemon's turn classification; the rest name resolutions that are not turn
+// conclusions at all.
+const (
+	// outcomeSteered — a user message entered the turn this wait was bound to,
+	// so the pending answer no longer answers what was asked. The turn keeps
+	// running.
+	outcomeSteered = "steered"
+	// outcomeIndeterminate — this request injected text into a running loop and
+	// the loop settled without the adapter unambiguously acknowledging it
+	// (either no report matched its text, or one did but so did somebody else's
+	// pending delivery). Neither "here is your answer" nor "your steer failed"
+	// is assertable.
+	outcomeIndeterminate = "indeterminate"
+	// outcomeTimeout — the wait ended, the turn did not.
+	outcomeTimeout = "timeout"
+	// outcomeDied — the session went away before its turn ended.
+	outcomeDied = "died"
+	// outcomeAccepted — the prompt was admitted and this response carries no
+	// turn conclusion (a daemon-side 202 on a waiting request). It exists so the
+	// --json contract has an envelope for every terminal path: a script must never
+	// have to read "no output" as an outcome.
+	outcomeAccepted = "accepted"
+)
+
+// turnResolution is what one blocking wait resolved to, in the vocabulary both
+// verbs share.
+type turnResolution struct {
+	// Outcome is the verdict word and the only thing the exit code reads.
+	Outcome string
+	// Reason is the finer cause when one exists (steered_again,
+	// injection_unacknowledged, runner_died, a daemon error code…). It is what a
+	// script matches on without parsing prose.
+	Reason string
+	// Output is the agent's answer, present only for a completed turn.
+	Output string
+	// Trigger is the excerpt of what started the turn, as the adapter asserted
+	// it.
+	Trigger string
+	// SteeredBy is the injected excerpt that ended this wait early.
+	SteeredBy string
+	// Truncated says the adapter capped Output at the source.
+	Truncated bool
+	// Message is the daemon's own prose for a failure it named (an error code's
+	// message). It is passed through rather than reworded: it encodes facts this
+	// process cannot re-derive, above all whether bytes reached the agent.
+	Message string
+	// Note is the one actionable next step for a human — a re-arm command, an
+	// inspection verb. Report-only: it is advice, not a fact about the turn, so
+	// it never enters the envelope.
+	Note string
+	// Tail is a labeled terminal-tail excerpt, appended to the report for the
+	// one failure ADR 0027 cannot source-assert: a prompt that fails before any
+	// turn starts (no API key, no model), where pi paints a banner and emits no
+	// event at all. Best-effort diagnosis on the account channel, where
+	// impurity is allowed — and labeled as the screen so it can never be
+	// mistaken for an asserted fact.
+	Tail []string
+}
+
+// exitCode maps an outcome onto ADR 0027 §8's taxonomy: 0 completed, 2 for an
+// intentional stop (a stop and a steer are both expected coordination rather
+// than faults, and both are routinely handled differently from a failure), 1 for
+// everything else.
+func (r turnResolution) exitCode() int {
+	switch r.Outcome {
+	case waitOutcomeCompleted, outcomeAccepted:
+		return waitExitOK
+	case waitOutcomeInterrupted, outcomeSteered:
+		return waitExitInterrupted
+	default:
+		return waitExitError
+	}
+}
+
+// render writes one resolution to the right streams and returns the exit code.
+//
+// quiet suppresses the answer (pure synchronization) but never the report: the
+// caller asked for no DATA, not to be lied to about what happened.
+func (r turnResolution) render(stdout, stderr io.Writer, sess cliSession, verb string, quiet, asJSON bool) int {
+	if asJSON {
+		return r.renderJSON(stdout, stderr)
+	}
+	if r.Outcome == waitOutcomeCompleted || r.Outcome == outcomeAccepted {
+		if quiet || r.Output == "" {
+			// Nothing to print: --quiet, a tool-only turn, or a session whose
+			// adapter asserts no result. Silence under exit 0 is the
+			// pre-existing synchronization behavior, not a failure.
+			return waitExitOK
+		}
+		// Verbatim, with exactly one trailing newline so the answer is usable in
+		// a shell without swallowing a final one.
+		if _, err := io.WriteString(stdout, strings.TrimRight(r.Output, "\n")+"\n"); err != nil {
+			fmt.Fprintln(stderr, "gmux:", err)
+			return waitExitError
+		}
+		if r.Truncated {
+			fmt.Fprintf(stderr, "gmux: the answer was truncated at the agent; read it in full with 'gmux agent logs --agent -n 1 %s'\n",
+				shortID(sess.ID))
+		}
+		return waitExitOK
+	}
+	r.writeReport(stderr, sess, verb)
+	return r.exitCode()
+}
+
+// writeReport renders the status-shaped stderr account of a non-completed
+// resolution. Every line is prefixed like every other gmux diagnostic, so a
+// caller's log stays greppable and nothing here can be confused for data.
+func (r turnResolution) writeReport(stderr io.Writer, sess cliSession, verb string) {
+	head := r.Outcome
+	if r.Reason != "" && r.Reason != r.Outcome {
+		head += " (" + r.Reason + ")"
+	}
+	fmt.Fprintf(stderr, "gmux: %s did not complete: %s\n", verb, head)
+	field := func(label, value string) {
+		if value == "" {
+			return
+		}
+		fmt.Fprintf(stderr, "gmux:   %-9s %s\n", label+":", value)
+	}
+	field("session", displayID(sess))
+	field("trigger", quoteExcerpt(r.Trigger))
+	field("injected", quoteExcerpt(r.SteeredBy))
+	field("detail", r.Message)
+	if len(r.Tail) > 0 {
+		// Labeled as what it is: the screen, not an assertion.
+		fmt.Fprintf(stderr, "gmux:   last lines of the session's terminal (not an agent report):\n")
+		for _, line := range r.Tail {
+			fmt.Fprintf(stderr, "gmux:   | %s\n", line)
+		}
+	}
+	if r.Note != "" {
+		fmt.Fprintf(stderr, "gmux:   %s\n", r.Note)
+	}
+}
+
+// renderJSON prints the machine contract: one envelope on stdout for every
+// outcome, and nothing on stderr.
+func (r turnResolution) renderJSON(stdout, stderr io.Writer) int {
+	env := struct {
+		Outcome   string `json:"outcome"`
+		Reason    string `json:"reason,omitempty"`
+		Output    string `json:"output,omitempty"`
+		Trigger   string `json:"trigger,omitempty"`
+		SteeredBy string `json:"steered_by,omitempty"`
+		Truncated bool   `json:"truncated,omitempty"`
+		Message   string `json:"message,omitempty"`
+	}{
+		Outcome: r.Outcome, Reason: r.Reason, Output: r.Output, Trigger: r.Trigger,
+		SteeredBy: r.SteeredBy, Truncated: r.Truncated, Message: r.Message,
+	}
+	// Omit-not-empty throughout (the struct tags), for the same reason `agent
+	// status --json` does it: an absent field says "this turn has no such fact",
+	// while an empty string would claim the fact exists and is blank.
+	out, err := json.MarshalIndent(env, "", "  ")
+	if err != nil {
+		fmt.Fprintln(stderr, "gmux:", err)
+		return waitExitError
+	}
+	if _, err := fmt.Fprintln(stdout, string(out)); err != nil {
+		fmt.Fprintln(stderr, "gmux:", err)
+		return waitExitError
+	}
+	return r.exitCode()
+}
+
+// fetchScrollbackQuiet is the tail read with no diagnostics of its own: it feeds
+// a report that already names a failure, so its own failure must be silence
+// rather than a second, louder error about scrollback.
+func fetchScrollbackQuiet(sess cliSession, lines int) []byte {
+	client := gmuxdClient()
+	resp, err := client.Get(fmt.Sprintf("%s/v1/sessions/%s/scrollback?tail=%d", gmuxdBaseURL(), sess.ID, lines))
+	if err != nil {
+		return nil
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil
+	}
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil
+	}
+	return data
+}
+
+// quoteExcerpt renders an excerpt on one line. The daemon already collapsed the
+// whitespace at the source; quoting is what keeps an empty-looking or
+// leading-space excerpt visible as a value rather than as a formatting accident.
+func quoteExcerpt(s string) string {
+	if s == "" {
+		return ""
+	}
+	return `"` + s + `"`
+}
+
+// steerNote is the re-arm advice a steered wait ends with. It is the difference
+// between "something went wrong" and "somebody redirected the work you were
+// waiting on, and here is how to wait for the new answer".
+func steerNote(sess cliSession) string {
+	return "the turn is still running under its new instructions; wait for it again with 'gmux wait " + shortID(sess.ID) + "'"
+}
+
+// terminalTailExcerpt reads the last few lines the session painted, for the
+// failed-to-start report. Best-effort by contract: any failure yields no lines
+// and no diagnostic of its own, because this is a garnish on an error that has
+// already been reported and a second failure message would bury it.
+func terminalTailExcerpt(sess cliSession, lines int) []string {
+	data := fetchScrollbackQuiet(sess, lines)
+	if len(data) == 0 {
+		return nil
+	}
+	var out []string
+	for _, line := range strings.Split(strings.TrimRight(string(stripANSI(data)), "\n"), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue // the TUI pads generously; blank lines carry no diagnosis
+		}
+		out = append(out, strings.TrimRight(line, " "))
+	}
+	if len(out) > lines {
+		out = out[len(out)-lines:]
+	}
+	return out
+}

--- a/cli/gmux/cmd/gmux/turnreport_test.go
+++ b/cli/gmux/cmd/gmux/turnreport_test.go
@@ -1,0 +1,337 @@
+package main
+
+// turnreport_test.go pins ADR 0027's "Output routing" at the CLI boundary: what
+// lands on stdout, what lands on stderr, what the exit code says, and the shape
+// of the --json envelope.
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func reportSession() cliSession {
+	return cliSession{ID: "sess-abcd1234", Adapter: "pi", Alive: true}
+}
+
+// A steered wait: exit 2, no stdout, and a report that carries BOTH excerpts —
+// what the turn was asked to do and what changed it — plus the re-arm move.
+func TestSteeredWaitReportsWhatWentIn(t *testing.T) {
+	res := waitResult{
+		Reason: "steered", Trigger: "run the tests", SteeredBy: "stop, fix the lint first",
+	}
+	var stdout bytes.Buffer
+	var code int
+	stderr := captureStderr(t, func() {
+		code = reportWaitResult(reportSession(), "gmux wait", res, false, false, false, &stdout)
+	})
+	if code != waitExitInterrupted {
+		t.Fatalf("exit=%d (stderr=%q)", code, stderr)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("a steered wait printed data: %q", stdout.String())
+	}
+	for _, want := range []string{
+		"did not complete: steered", "run the tests", "stop, fix the lint first", "gmux wait abcd1234",
+	} {
+		if !strings.Contains(stderr, want) {
+			t.Fatalf("stderr=%q missing %q", stderr, want)
+		}
+	}
+}
+
+// The superseded injector gets its own word: "somebody steered the turn" and
+// "your steer went in and was then overridden" call for different next moves.
+func TestSupersededInjectorIsNamedAsSuch(t *testing.T) {
+	res := waitResult{Reason: "steered", Cause: causeSteeredAgain, SteeredBy: "no, revert it"}
+	var stdout bytes.Buffer
+	code := 0
+	stderr := captureStderr(t, func() {
+		code = reportWaitResult(reportSession(), "gmux agent prompt", res, false, false, false, &stdout)
+	})
+	if code != waitExitInterrupted || !strings.Contains(stderr, causeSteeredAgain) {
+		t.Fatalf("exit=%d stderr=%q", code, stderr)
+	}
+}
+
+// An injection the loop never acknowledged is exit 1 and says why: the answer
+// that turn produced is not this command's result.
+func TestIndeterminateInjectionIsExitOneAndExplained(t *testing.T) {
+	res := waitResult{
+		Reason: "idle", Outcome: outcomeIndeterminate, Cause: causeInjectionUnacknowledged,
+		Trigger: "go", Output: "pre-steer answer",
+	}
+	var stdout bytes.Buffer
+	code := 0
+	stderr := captureStderr(t, func() {
+		code = reportWaitResult(reportSession(), "gmux agent prompt", res, false, false, false, &stdout)
+	})
+	if code != waitExitError {
+		t.Fatalf("exit=%d", code)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("an indeterminate resolution printed an answer: %q", stdout.String())
+	}
+	if !strings.Contains(stderr, causeInjectionUnacknowledged) {
+		t.Fatalf("stderr=%q", stderr)
+	}
+}
+
+// Every non-completed resolution reports, and a completed one stays silent.
+// That pairing is the contract: stderr noise on success would poison logs, and
+// silence on failure is what forced the caller to run a second command.
+func TestReportsExistExactlyForNonCompletedResolutions(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		res        waitResult
+		wantReport bool
+	}{
+		{"completed", waitResult{Reason: "idle", Outcome: "completed", Output: "x"}, false},
+		{"interrupted", waitResult{Reason: "idle", Outcome: "interrupted"}, true},
+		{"error", waitResult{Reason: "idle", Outcome: "error", Cause: causeRunnerDied}, true},
+		{"steered", waitResult{Reason: "steered"}, true},
+		{"indeterminate", waitResult{Reason: "idle", Outcome: outcomeIndeterminate}, true},
+		{"died", waitResult{Reason: "died", Outcome: "error", Cause: causeRunnerDied}, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var stdout bytes.Buffer
+			stderr := captureStderr(t, func() {
+				reportWaitResult(reportSession(), "gmux wait", tc.res, false, false, false, &stdout)
+			})
+			if got := strings.Contains(stderr, "did not complete:"); got != tc.wantReport {
+				t.Fatalf("report=%v want %v (stderr=%q)", got, tc.wantReport, stderr)
+			}
+		})
+	}
+}
+
+// --quiet suppresses the ANSWER, never the account: a caller who wants no data
+// still must not be lied to about what happened.
+func TestQuietStillReports(t *testing.T) {
+	var stdout bytes.Buffer
+	stderr := captureStderr(t, func() {
+		reportWaitResult(reportSession(), "gmux wait", waitResult{Reason: "steered", SteeredBy: "hold on"}, false, true, false, &stdout)
+	})
+	if !strings.Contains(stderr, "did not complete: steered") {
+		t.Fatalf("--quiet swallowed the report: %q", stderr)
+	}
+}
+
+// The --json envelope: one stable shape on stdout for every outcome, nothing on
+// stderr, and the exit code unchanged.
+func TestJSONEnvelopeShape(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		res      waitResult
+		wantExit int
+		want     map[string]any
+	}{
+		{
+			name:     "completed",
+			res:      waitResult{Reason: "idle", Outcome: "completed", Output: "All green.", Trigger: "run the tests", Truncated: true},
+			wantExit: waitExitOK,
+			want: map[string]any{
+				"outcome": "completed", "output": "All green.", "trigger": "run the tests", "truncated": true,
+			},
+		},
+		{
+			name:     "steered",
+			res:      waitResult{Reason: "steered", Trigger: "run the tests", SteeredBy: "stop"},
+			wantExit: waitExitInterrupted,
+			want: map[string]any{
+				"outcome": "steered", "reason": "steered", "trigger": "run the tests", "steered_by": "stop",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var stdout bytes.Buffer
+			var code int
+			stderr := captureStderr(t, func() {
+				code = reportWaitResult(reportSession(), "gmux wait", tc.res, false, false, true, &stdout)
+			})
+			if code != tc.wantExit {
+				t.Fatalf("exit=%d want %d", code, tc.wantExit)
+			}
+			if stderr != "" {
+				t.Fatalf("--json wrote a report to stderr as well: %q", stderr)
+			}
+			var got map[string]any
+			if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+				t.Fatalf("stdout=%q: %v", stdout.String(), err)
+			}
+			for k, v := range tc.want {
+				if got[k] != v {
+					t.Fatalf("envelope[%q]=%v want %v (full=%v)", k, got[k], v, got)
+				}
+			}
+			// Omit-not-empty: a field describing a fact the turn does not have
+			// must be ABSENT, not blank, exactly like `agent status --json`.
+			for _, k := range []string{"output", "trigger", "steered_by", "reason", "message"} {
+				if v, ok := got[k]; ok && v == "" {
+					t.Fatalf("envelope carried an empty %q instead of omitting it: %v", k, got)
+				}
+			}
+		})
+	}
+}
+
+// --json and --quiet are opposite answers to the same question, so the
+// combination is a usage error rather than a silent choice between them.
+func TestJSONAndQuietIsAUsageError(t *testing.T) {
+	if _, err := parseWait([]string{"--json", "--quiet", "s1"}); err == nil {
+		t.Fatal("wait accepted --json --quiet")
+	}
+	if _, err := parseAgentPrompt([]string{"--json", "--no-wait", "s1", "hi"}); err == nil {
+		t.Fatal("agent prompt accepted --json --no-wait, which never observes a resolution")
+	}
+	if _, err := parseAgentPrompt([]string{"--json", "s1", "hi"}); err != nil {
+		t.Fatalf("agent prompt --json: %v", err)
+	}
+	if _, err := parseAgentPrompt([]string{"--json", "--json", "s1", "hi"}); err == nil {
+		t.Fatal("agent prompt accepted a repeated --json")
+	}
+}
+
+// The failed-to-start report (ADR 0027, "Failures before the turn starts"): pi's
+// prompt submission can fail with no turn and no event at all — no API key, no
+// model — so the admission timeout appends what the screen says, labeled as the
+// screen. It is the one impure ingredient in this design, and it is confined to
+// the account channel and to this one code.
+func TestAdmissionTimeoutAppendsTheTerminalTail(t *testing.T) {
+	d := startStubDaemon(t, localSession())
+	d.on(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/scrollback") {
+			_, _ = w.Write([]byte("some earlier line\n\nerror: model \"nope\" is not available\n"))
+			return
+		}
+		writeErrEnvelope(w, http.StatusGatewayTimeout, codeAdmissionTimeout,
+			"prompt was delivered but the agent did not start a turn within 1m0s")
+	})
+	text := "hi"
+	var code int
+	stderr := captureStderr(t, func() { code = cmdAgentPrompt("sess-abcd1234", agentModePrompt, false, 0, &text, false) })
+	if code != waitExitError {
+		t.Fatalf("exit=%d stderr=%q", code, stderr)
+	}
+	for _, want := range []string{
+		codeAdmissionTimeout,
+		"not an agent report", // the label: this is the screen, not an assertion
+		`error: model "nope" is not available`,
+	} {
+		if !strings.Contains(stderr, want) {
+			t.Fatalf("stderr=%q missing %q", stderr, want)
+		}
+	}
+	// Blank padding from the TUI carries no diagnosis and is dropped.
+	if strings.Contains(stderr, "|  \n") {
+		t.Fatalf("blank screen padding leaked into the report: %q", stderr)
+	}
+
+	// A failure that is NOT "the turn never started" gets no tail: it would show
+	// a turn running perfectly well and invite a diagnosis of a problem that is
+	// not there.
+	d.on(func(w http.ResponseWriter, r *http.Request) {
+		writeErrEnvelope(w, http.StatusGatewayTimeout, codeExecutionTimeout, "the turn did not complete within the requested timeout")
+	})
+	stderr = captureStderr(t, func() { cmdAgentPrompt("sess-abcd1234", agentModePrompt, false, 0, &text, false) })
+	if strings.Contains(stderr, "not an agent report") {
+		t.Fatalf("an execution timeout showed the screen: %q", stderr)
+	}
+}
+
+// --json swaps the report for an envelope even for a daemon-reported failure, and
+// keeps the daemon's own stable code as the reason: that code is the token a
+// script would otherwise have grepped out of the stderr line.
+func TestJSONEnvelopeForADaemonFailure(t *testing.T) {
+	d := startStubDaemon(t, localSession())
+	d.on(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/scrollback") {
+			_, _ = w.Write([]byte("banner\n"))
+			return
+		}
+		writeErrEnvelope(w, http.StatusGatewayTimeout, codeExecutionTimeout, "the turn did not complete within the requested timeout")
+	})
+	text := "hi"
+	var code int
+	var stderr string
+	out := captureStdout(t, func() {
+		stderr = captureStderr(t, func() { code = cmdAgentPrompt("sess-abcd1234", agentModePrompt, false, 30, &text, true) })
+	})
+	if code != waitExitError || stderr != "" {
+		t.Fatalf("exit=%d stderr=%q", code, stderr)
+	}
+	var env map[string]any
+	if err := json.Unmarshal([]byte(out), &env); err != nil {
+		t.Fatalf("stdout=%q: %v", out, err)
+	}
+	if env["outcome"] != outcomeTimeout || env["reason"] != codeExecutionTimeout {
+		t.Fatalf("envelope=%v", env)
+	}
+}
+
+// --json must emit an envelope on EVERY terminal path. A contract that prints an
+// object for failure and nothing for success forces a script to treat "empty
+// stdout" as an undocumented third outcome — and to guess whether it means
+// success or a crash.
+func TestJSONEnvelopeOnEveryTerminalPath(t *testing.T) {
+	t.Run("predicate wait success", func(t *testing.T) {
+		var stdout bytes.Buffer
+		var code int
+		stderr := captureStderr(t, func() {
+			code = reportWaitResult(reportSession(), "gmux wait",
+				waitResult{Reason: "matched"}, true, false, true, &stdout)
+		})
+		if code != waitExitOK || stderr != "" {
+			t.Fatalf("exit=%d stderr=%q", code, stderr)
+		}
+		var env map[string]any
+		if err := json.Unmarshal(stdout.Bytes(), &env); err != nil {
+			t.Fatalf("a matched predicate wait printed %q under --json: %v", stdout.String(), err)
+		}
+		if env["outcome"] != waitOutcomeCompleted || env["reason"] != "matched" {
+			t.Fatalf("envelope=%v", env)
+		}
+		// The matched bytes are terminal output, not an agent result, so the
+		// envelope carries no output — exactly like the human shape.
+		if _, ok := env["output"]; ok {
+			t.Fatalf("a predicate wait's envelope claimed an agent result: %v", env)
+		}
+	})
+
+	t.Run("without --json a matched wait stays silent", func(t *testing.T) {
+		var stdout bytes.Buffer
+		stderr := captureStderr(t, func() {
+			reportWaitResult(reportSession(), "gmux wait", waitResult{Reason: "matched"}, true, false, false, &stdout)
+		})
+		if stdout.Len() != 0 || stderr != "" {
+			t.Fatalf("stdout=%q stderr=%q", stdout.String(), stderr)
+		}
+	})
+
+	t.Run("daemon-side 202 on a waiting request", func(t *testing.T) {
+		body := []byte(`{"ok":true,"data":{"admission":"delivered","resumed":false}}`)
+		var code int
+		var stderr string
+		out := captureStdout(t, func() {
+			stderr = captureStderr(t, func() {
+				// noWait=false: this process WAS waiting; the daemon answered 202.
+				code = reportAgentPromptSuccess(reportSession(), http.StatusAccepted, body, false, true)
+			})
+		})
+		if code != waitExitOK || stderr != "" {
+			t.Fatalf("exit=%d stderr=%q", code, stderr)
+		}
+		var env map[string]any
+		if err := json.Unmarshal([]byte(out), &env); err != nil {
+			t.Fatalf("a 202 printed %q under --json: %v", out, err)
+		}
+		if env["outcome"] != outcomeAccepted || env["reason"] != "delivered" {
+			t.Fatalf("envelope=%v", env)
+		}
+		if _, ok := env["output"]; ok {
+			t.Fatalf("an admission-only envelope claimed a result: %v", env)
+		}
+	})
+}

--- a/cli/gmux/cmd/gmux/wait.go
+++ b/cli/gmux/cmd/gmux/wait.go
@@ -8,7 +8,6 @@ import (
 	"net/url"
 	"os"
 	"strconv"
-	"strings"
 )
 
 // The global gmux exit taxonomy (ADR 0027 §8). It is deliberately small
@@ -84,7 +83,7 @@ const (
 // against its local store and consults the adapter allowlist; remote
 // peer sessions are out of scope until peer subscriptions stream
 // Status events back to the hub.
-func cmdWait(ref string, timeoutSecs int, forText, forRegex string, quiet bool) int {
+func cmdWait(ref string, timeoutSecs int, forText, forRegex string, quiet, asJSON bool) int {
 	sess, err := resolveSession(ref)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "gmux:", err)
@@ -148,10 +147,20 @@ func cmdWait(ref string, timeoutSecs int, forText, forRegex string, quiet bool) 
 			fmt.Fprintln(os.Stderr, "gmux: decode wait response:", err)
 			return waitExitError
 		}
-		return reportWaitResult(sess, "gmux wait", env.Data, predicate, quiet, os.Stdout)
+		return reportWaitResult(sess, "gmux wait", env.Data, predicate, quiet, asJSON, os.Stdout)
 	case http.StatusRequestTimeout:
-		fmt.Fprintf(os.Stderr, "gmux: wait timed out after %ds\n", timeoutSecs)
-		return waitExitError
+		// The wait ended; the turn did not. Reported through the shared renderer so
+		// --json gets an envelope for it like every other outcome.
+		res := turnResolution{
+			Outcome: outcomeTimeout, Reason: outcomeTimeout,
+			Message: fmt.Sprintf("the wait ended after %ds; the session's turn is still running", timeoutSecs),
+			Note:    "wait for it again with 'gmux wait " + shortID(sess.ID) + "'",
+		}
+		if predicate {
+			res.Message = fmt.Sprintf("the session's output did not match within %ds", timeoutSecs)
+			res.Note = ""
+		}
+		return res.render(os.Stdout, os.Stderr, sess, "gmux wait", quiet, asJSON)
 	case http.StatusUnprocessableEntity:
 		// Current daemons only send 422 on the send --wait path
 		// (input_no_submit); older daemons also rejected sessions
@@ -183,6 +192,13 @@ type waitResult struct {
 	Outcome string `json:"outcome"`
 	Cause   string `json:"cause"`
 	Output  string `json:"output"`
+	// Trigger is the excerpt of what started the turn, and SteeredBy the message
+	// that entered it, both as the ADAPTER asserted them and relayed through the
+	// runner's turn frame. They are the material of a non-completed resolution's
+	// report, which is why they arrive with the resolution rather than being read
+	// back afterwards.
+	Trigger   string `json:"trigger"`
+	SteeredBy string `json:"steered_by"`
 	// Truncated says the adapter capped Output at the source. stdout still
 	// carries what there is (silently dropping the tail would be worse), and the
 	// fact goes to stderr where the account belongs.
@@ -200,20 +216,41 @@ type waitResult struct {
 // which one hit a limitation: `send --wait` shares every exit decision here but
 // is deliberately result-free, so telling its caller the daemon "predates
 // result-bearing waits" would describe a feature they did not ask for.
-func reportWaitResult(sess cliSession, verb string, res waitResult, predicate, quiet bool, stdout io.Writer) int {
+func reportWaitResult(sess cliSession, verb string, res waitResult, predicate, quiet, asJSON bool, stdout io.Writer) int {
 	switch res.Reason {
 	case "matched":
 		// Predicate wait: synchronization only, by design. The matched
 		// bytes are terminal output the caller can read with gmux tail;
 		// they are not an agent result.
-		return waitExitOK
-	case "died":
-		if predicate {
-			fmt.Fprintf(os.Stderr, "gmux: session %s exited before its output matched\n", displayID(sess))
-		} else {
-			fmt.Fprintf(os.Stderr, "gmux: session %s died before its turn ended\n", displayID(sess))
+		//
+		// Under --json it still gets an envelope. A machine contract that emits
+		// an object for every failure and SILENCE for success is the one shape a
+		// script cannot parse uniformly — it would have to treat "empty stdout"
+		// as a third, undocumented outcome. The envelope carries no output for the
+		// same reason the human shape prints none.
+		if asJSON {
+			return turnResolution{Outcome: waitOutcomeCompleted, Reason: "matched"}.
+				render(stdout, os.Stderr, sess, verb, quiet, true)
 		}
-		return waitExitError
+		return waitExitOK
+	case outcomeSteered:
+		// A user message entered the turn this wait was bound to. The turn is
+		// still running — this is coordination, not a fault — so the report says
+		// what went in and how to wait for the new answer.
+		return turnResolution{
+			Outcome: outcomeSteered, Reason: steeredReason(res.Cause),
+			Trigger: res.Trigger, SteeredBy: res.SteeredBy,
+			Note: steerNote(sess),
+		}.render(stdout, os.Stderr, sess, verb, quiet, asJSON)
+	case "died":
+		dead := turnResolution{Outcome: outcomeDied, Reason: causeRunnerDied, Trigger: res.Trigger}
+		if predicate {
+			dead.Message = "the session exited before its output matched"
+		} else {
+			dead.Message = "the session died before its turn ended"
+			dead.Note = inspectHint(sess, res.ConversationReadable)
+		}
+		return dead.render(stdout, os.Stderr, sess, verb, quiet, asJSON)
 	case "idle":
 		if predicate {
 			// A predicate wait resolves on "matched" or "died" only;
@@ -221,7 +258,7 @@ func reportWaitResult(sess cliSession, verb string, res waitResult, predicate, q
 			fmt.Fprintf(os.Stderr, "gmux: unexpected wait reason %q for an output condition\n", res.Reason)
 			return waitExitError
 		}
-		return reportTurnConclusion(sess, verb, res, quiet, stdout)
+		return reportTurnConclusion(sess, verb, res, quiet, asJSON, stdout)
 	default:
 		fmt.Fprintf(os.Stderr, "gmux: unexpected wait reason %q\n", res.Reason)
 		return waitExitError
@@ -234,56 +271,61 @@ func reportWaitResult(sess cliSession, verb string, res waitResult, predicate, q
 // predates turn conclusions always resolves a closed turn as bare "idle", and
 // silently treating that as success would report a failed or interrupted turn as
 // a clean one — under exit 0, with no result. Fail loudly and name the fix.
-func reportTurnConclusion(sess cliSession, verb string, res waitResult, quiet bool, stdout io.Writer) int {
+func reportTurnConclusion(sess cliSession, verb string, res waitResult, quiet, asJSON bool, stdout io.Writer) int {
 	switch res.Outcome {
 	case "":
 		fmt.Fprintf(os.Stderr, "gmux: this gmuxd predates the turn conclusions '%s' needs (it reported no turn outcome); restart the daemon with 'gmux daemon restart'\n", verb)
 		return waitExitError
-	case waitOutcomeCompleted:
-		if quiet || res.Output == "" {
-			// Nothing to print: --quiet, a shell/process session, or an
-			// agent whose conversation gmux cannot read. Silence here is
-			// the pre-existing synchronization behavior, not a failure.
-			return waitExitOK
-		}
-		// Verbatim, with exactly one trailing newline so the output is usable
-		// in a shell without swallowing a final one.
-		if _, err := io.WriteString(stdout, strings.TrimRight(res.Output, "\n")+"\n"); err != nil {
-			fmt.Fprintln(os.Stderr, "gmux:", err)
-			return waitExitError
-		}
-		noteTruncatedAnswer(sess, res.Truncated)
-		return waitExitOK
-	case waitOutcomeInterrupted:
-		fmt.Fprintf(os.Stderr, "gmux: the turn was interrupted before it finished (session %s); %s\n",
-			displayID(sess), inspectHint(sess, res.ConversationReadable))
-		return waitExitInterrupted
-	case waitOutcomeError:
-		if res.Cause != "" {
-			fmt.Fprintf(os.Stderr, "gmux: the turn ended in an error (%s); %s\n",
-				res.Cause, inspectHint(sess, res.ConversationReadable))
-		} else {
-			fmt.Fprintf(os.Stderr, "gmux: the turn ended in an error (session %s); %s\n",
-				displayID(sess), inspectHint(sess, res.ConversationReadable))
-		}
-		return waitExitError
+	case waitOutcomeCompleted, waitOutcomeInterrupted, waitOutcomeError, outcomeSteered, outcomeIndeterminate:
+		return turnResolutionOf(sess, res).render(stdout, os.Stderr, sess, verb, quiet, asJSON)
 	default:
 		fmt.Fprintf(os.Stderr, "gmux: unexpected turn outcome %q\n", res.Outcome)
 		return waitExitError
 	}
 }
 
-// noteTruncatedAnswer tells the caller on stderr that the answer they just got
-// on stdout is not the whole one. The adapter caps a turn's output at the source
-// so an enormous answer can never cost the turn's close; the full text is still
-// in the conversation, which is what the hint points at.
-func noteTruncatedAnswer(sess cliSession, truncated bool) {
-	if !truncated {
-		return
+// turnResolutionOf translates the daemon's payload into the shared resolution,
+// adding only the human advice (a re-arm command, an inspection verb) that the
+// daemon has no business choosing.
+func turnResolutionOf(sess cliSession, res waitResult) turnResolution {
+	out := turnResolution{
+		Outcome: res.Outcome, Reason: res.Cause, Output: res.Output,
+		Trigger: res.Trigger, SteeredBy: res.SteeredBy, Truncated: res.Truncated,
 	}
-	fmt.Fprintf(os.Stderr, "gmux: the answer was truncated at the agent; read it in full with 'gmux agent logs --agent -n 1 %s'\n",
-		shortID(sess.ID))
+	switch res.Outcome {
+	case outcomeSteered:
+		out.Reason = steeredReason(res.Cause)
+		out.Note = steerNote(sess)
+	case outcomeIndeterminate:
+		out.Message = "the turn settled without the agent acknowledging the text this command delivered, so it may never have entered the loop; the answer that turn produced is not this command's result"
+		out.Note = inspectHint(sess, res.ConversationReadable)
+	case waitOutcomeInterrupted:
+		out.Message = "the turn was intentionally stopped before it finished"
+		out.Note = inspectHint(sess, res.ConversationReadable)
+	case waitOutcomeError:
+		out.Message = "the turn ended in an error"
+		out.Note = inspectHint(sess, res.ConversationReadable)
+	}
+	return out
 }
+
+// steeredReason words WHY a steered wait ended. The superseded injector's case is
+// deliberately distinct: "somebody steered the turn" and "your steer went in and
+// was then overridden" call for different next moves.
+func steeredReason(cause string) string {
+	if cause == causeSteeredAgain {
+		return causeSteeredAgain
+	}
+	return outcomeSteered
+}
+
+// Reasons the daemon reports alongside a resolution that is not a turn
+// conclusion. Duplicated as constants rather than imported: gmuxd and the CLI
+// are separate modules and this is a wire vocabulary.
+const (
+	causeSteeredAgain            = "steered_again"
+	causeInjectionUnacknowledged = "injection_unacknowledged"
+)
 
 // inspectHint names the verb that can actually show what happened.
 //

--- a/cli/gmux/cmd/gmux/wait_test.go
+++ b/cli/gmux/cmd/gmux/wait_test.go
@@ -74,7 +74,7 @@ func TestWaitReportsConclusionAndSuppressesStaleResults(t *testing.T) {
 			var stdout bytes.Buffer
 			var code int
 			stderr := captureStderr(t, func() {
-				code = reportWaitResult(sess, "gmux wait", tc.res, false, tc.quiet, &stdout)
+				code = reportWaitResult(sess, "gmux wait", tc.res, false, tc.quiet, false, &stdout)
 			})
 			if code != tc.wantExit {
 				t.Errorf("exit = %d, want %d (stderr=%q)", code, tc.wantExit, stderr)
@@ -99,13 +99,13 @@ func TestWaitReportsConclusionAndSuppressesStaleResults(t *testing.T) {
 func TestWaitPredicateStaysQuiet(t *testing.T) {
 	sess := cliSession{ID: "sess-abcd1234", Adapter: "pi", Alive: true}
 	var stdout bytes.Buffer
-	code := reportWaitResult(sess, "gmux wait", waitResult{Reason: "matched", Output: "not mine to print"}, true, false, &stdout)
+	code := reportWaitResult(sess, "gmux wait", waitResult{Reason: "matched", Output: "not mine to print"}, true, false, false, &stdout)
 	if code != waitExitOK || stdout.Len() != 0 {
 		t.Fatalf("matched: exit=%d stdout=%q", code, stdout.String())
 	}
 	stdout.Reset()
 	stderr := captureStderr(t, func() {
-		code = reportWaitResult(sess, "gmux wait", waitResult{Reason: "died"}, true, false, &stdout)
+		code = reportWaitResult(sess, "gmux wait", waitResult{Reason: "died"}, true, false, false, &stdout)
 	})
 	if code != waitExitError || stdout.Len() != 0 || !strings.Contains(stderr, "before its output matched") {
 		t.Fatalf("died: exit=%d stdout=%q stderr=%q", code, stdout.String(), stderr)
@@ -114,7 +114,7 @@ func TestWaitPredicateStaysQuiet(t *testing.T) {
 	// answers "idle" here it answered a different question.
 	stdout.Reset()
 	stderr = captureStderr(t, func() {
-		code = reportWaitResult(sess, "gmux wait", waitResult{Reason: "idle", Outcome: "completed", Output: "x"}, true, false, &stdout)
+		code = reportWaitResult(sess, "gmux wait", waitResult{Reason: "idle", Outcome: "completed", Output: "x"}, true, false, false, &stdout)
 	})
 	if code != waitExitError || stdout.Len() != 0 || !strings.Contains(stderr, "output condition") {
 		t.Fatalf("idle on a predicate wait: exit=%d stdout=%q stderr=%q", code, stdout.String(), stderr)
@@ -133,7 +133,7 @@ func TestWaitEndToEndAgainstAStubDaemon(t *testing.T) {
 			})
 		})
 		var code int
-		out := captureStdout(t, func() { code = cmdWait("sess-abcd1234", 30, "", "", false) })
+		out := captureStdout(t, func() { code = cmdWait("sess-abcd1234", 30, "", "", false, false) })
 		if code != waitExitOK || out != "All green.\n" {
 			t.Fatalf("exit=%d stdout=%q", code, out)
 		}
@@ -150,7 +150,7 @@ func TestWaitEndToEndAgainstAStubDaemon(t *testing.T) {
 			})
 		})
 		var code int
-		out := captureStdout(t, func() { code = cmdWait("sess-abcd1234", 0, "", "", true) })
+		out := captureStdout(t, func() { code = cmdWait("sess-abcd1234", 0, "", "", true, false) })
 		if code != waitExitOK || out != "" {
 			t.Fatalf("exit=%d stdout=%q", code, out)
 		}
@@ -161,11 +161,13 @@ func TestWaitEndToEndAgainstAStubDaemon(t *testing.T) {
 			writeErrEnvelope(w, http.StatusRequestTimeout, "timeout", "session did not become idle within timeout")
 		})
 		var code int
-		stderr := captureStderr(t, func() { code = cmdWait("sess-abcd1234", 5, "", "", false) })
+		stderr := captureStderr(t, func() { code = cmdWait("sess-abcd1234", 5, "", "", false, false) })
 		if code != waitExitError {
 			t.Fatalf("exit=%d stderr=%q", code, stderr)
 		}
-		if !strings.Contains(stderr, "timed out after 5s") {
+		// The timeout is reported through the shared status-shaped report now, so
+		// it names the bound and says the turn outlived the wait.
+		if !strings.Contains(stderr, "did not complete: timeout") || !strings.Contains(stderr, "after 5s") {
 			t.Fatalf("stderr=%q", stderr)
 		}
 	})
@@ -179,7 +181,7 @@ func TestWaitEndToEndAgainstAStubDaemon(t *testing.T) {
 		var code int
 		var stderr string
 		out := captureStdout(t, func() {
-			stderr = captureStderr(t, func() { code = cmdWait("sess-abcd1234", 0, "", "", false) })
+			stderr = captureStderr(t, func() { code = cmdWait("sess-abcd1234", 0, "", "", false, false) })
 		})
 		if code != waitExitInterrupted || out != "" {
 			t.Fatalf("exit=%d stdout=%q stderr=%q", code, out, stderr)
@@ -191,7 +193,7 @@ func TestWaitEndToEndAgainstAStubDaemon(t *testing.T) {
 			writeEnvelope(w, http.StatusOK, map[string]any{"reason": "matched"})
 		})
 		var code int
-		out := captureStdout(t, func() { code = cmdWait("sess-abcd1234", 0, "BUILD DONE", "", false) })
+		out := captureStdout(t, func() { code = cmdWait("sess-abcd1234", 0, "BUILD DONE", "", false, false) })
 		if code != waitExitOK || out != "" {
 			t.Fatalf("exit=%d stdout=%q", code, out)
 		}
@@ -206,7 +208,7 @@ func TestWaitEndToEndAgainstAStubDaemon(t *testing.T) {
 				writeErrEnvelope(w, status, "nope", "no")
 			})
 			var code int
-			captureStderr(t, func() { code = cmdWait("sess-abcd1234", 0, "", "", false) })
+			captureStderr(t, func() { code = cmdWait("sess-abcd1234", 0, "", "", false, false) })
 			if code != waitExitError {
 				t.Fatalf("status %d gave exit %d", status, code)
 			}
@@ -310,7 +312,7 @@ func TestWaitHintMatchesWhatCanBeRead(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			stdout.Reset()
-			stderr := captureStderr(t, func() { reportWaitResult(sess, "gmux wait", tc.res, false, false, &stdout) })
+			stderr := captureStderr(t, func() { reportWaitResult(sess, "gmux wait", tc.res, false, false, false, &stdout) })
 			if !strings.Contains(stderr, tc.wantSub) {
 				t.Errorf("stderr = %q, want it to mention %q", stderr, tc.wantSub)
 			}
@@ -379,7 +381,7 @@ func TestSkewMessageNamesTheCommand(t *testing.T) {
 		stdout.Reset()
 		var code int
 		stderr := captureStderr(t, func() {
-			code = reportWaitResult(sess, verb, waitResult{Reason: "idle"}, false, true, &stdout)
+			code = reportWaitResult(sess, verb, waitResult{Reason: "idle"}, false, true, false, &stdout)
 		})
 		if code != waitExitError {
 			t.Errorf("%s: exit = %d, want 1", verb, code)

--- a/cli/gmux/cmd/gmux/waitsignal_test.go
+++ b/cli/gmux/cmd/gmux/waitsignal_test.go
@@ -24,7 +24,7 @@ func TestTruncatedAnswerIsReportedOnStderr(t *testing.T) {
 	stderr := captureStderr(t, func() {
 		if code := reportWaitResult(sess, "gmux wait",
 			waitResult{Reason: "idle", Outcome: "completed", Output: "half an answer", Truncated: true},
-			false, false, &stdout); code != waitExitOK {
+			false, false, false, &stdout); code != waitExitOK {
 			t.Fatalf("exit=%d", code)
 		}
 	})
@@ -40,7 +40,7 @@ func TestTruncatedAnswerIsReportedOnStderr(t *testing.T) {
 	stderr = captureStderr(t, func() {
 		reportWaitResult(sess, "gmux wait",
 			waitResult{Reason: "idle", Outcome: "completed", Output: "the answer"},
-			false, false, &stdout)
+			false, false, false, &stdout)
 	})
 	if stderr != "" {
 		t.Fatalf("a clean completion wrote to stderr: %q", stderr)

--- a/cli/gmux/internal/agentext/pi-ext.mjs
+++ b/cli/gmux/internal/agentext/pi-ext.mjs
@@ -17,7 +17,8 @@
 //   { op: "session", path, id, name, slug, cwd, reason } on bind (session_start)
 //                                                         and rename (session_info_changed)
 //   { op: "turn", phase: "start", turn_seq, trigger }   on agent loop start
-//   { op: "turn", phase: "steered", turn_seq, text }    on a mid-turn user message
+//   { op: "turn", phase: "steered", turn_seq, text, truncated }
+//                                                       on a mid-turn user message
 //   { op: "turn", phase: "end", turn_seq, outcome,
 //     output, truncated, diagnostic, title }             on agent_settled
 //
@@ -206,7 +207,17 @@ export default function (pi) {
       if (!heldTrigger) heldTrigger = excerpt(text);
       return;
     }
-    post(sock, { op: "turn", phase: "steered", turn_seq: turnSeq, text: excerpt(text) });
+    // `truncated` travels with the excerpt because the runner may only match a
+    // PREFIX of what gmux delivered when this excerpt is genuinely a prefix of
+    // the message. See excerptParts.
+    const injected = excerptParts(text);
+    post(sock, {
+      op: "turn",
+      phase: "steered",
+      turn_seq: turnSeq,
+      text: injected.text,
+      truncated: injected.truncated || undefined,
+    });
   });
 
   pi.on("agent_end", (ev, ctx) => {
@@ -321,15 +332,39 @@ export function capOutput(s) {
   return { text: decodeWhole(bytes.subarray(0, maxOutputBytes)), truncated: true };
 }
 
-// excerpt collapses whitespace and caps a trigger/injection text. Excerpts are
-// diagnostics (they appear in stderr reports), so a byte cap with an ellipsis is
-// enough; they are never presented as the agent's answer.
-export function excerpt(s) {
-  const collapsed = String(s ?? "").replace(/\s+/g, " ").trim();
-  if (!collapsed) return "";
+// excerptParts collapses whitespace and caps a trigger/injection text, and
+// reports WHETHER it capped. Excerpts are diagnostics (they appear in stderr
+// reports), so a byte cap with an ellipsis is enough; they are never presented as
+// the agent's answer.
+//
+// The whitespace class is a CONTRACT with the runner, not a local convenience:
+// an injection excerpt is what the runner compares against the text gmux
+// delivered, to decide whether an injection is a given request's (ADR 0027's
+// steer self-exclusion). The two runtimes disagree by default — JavaScript's \s
+// matches U+FEFF but not U+0085, Go's unicode.IsSpace the reverse — so both
+// sides collapse the UNION: `\s` plus U+0085 here, IsSpace plus U+FEFF in
+// session.normalizeExcerpt. A prompt containing either character would otherwise
+// fail to correlate and silently downgrade its injector to an indeterminate
+// result.
+//
+// `truncated` is the second half of that contract, and it is reported as a FACT
+// rather than left to be inferred from the text. Truncation is the runner's only
+// licence to accept a prefix instead of an exact match, and this function is the
+// one place that knows whether it truncated — a reader sniffing the trailing
+// ellipsis cannot tell a capped excerpt from a message that simply ends in one,
+// which is enough to let a foreign message claim a pending delivery's identity.
+export function excerptParts(s) {
+  const collapsed = String(s ?? "").replace(/[\s\u0085]+/g, " ").trim();
+  if (!collapsed) return { text: "", truncated: false };
   const bytes = Buffer.from(collapsed, "utf8");
-  if (bytes.length <= maxExcerptBytes) return collapsed;
-  return decodeWhole(bytes.subarray(0, maxExcerptBytes - 3)) + "…";
+  if (bytes.length <= maxExcerptBytes) return { text: collapsed, truncated: false };
+  return { text: decodeWhole(bytes.subarray(0, maxExcerptBytes - 3)) + "…", truncated: true };
+}
+
+// excerpt is excerptParts' text alone, for the places where the cap is a
+// presentation detail (a trigger, an error diagnostic) rather than evidence.
+export function excerpt(s) {
+  return excerptParts(s).text;
 }
 
 // decodeWhole decodes a byte slice, dropping a trailing partial UTF-8 sequence

--- a/cli/gmux/internal/agentext/pi_ext_turn_test.go
+++ b/cli/gmux/internal/agentext/pi_ext_turn_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/gmuxapp/gmux/cli/gmux/internal/session"
 )
 
 // runExtDriver materializes the shipped extension, runs an inline node driver
@@ -197,8 +199,57 @@ func TestPiExtReportsInjections(t *testing.T) {
 	if evs[1]["phase"] != "steered" || evs[1]["text"] != "actually, stop" {
 		t.Errorf("steered event = %v", evs[1])
 	}
+	if _, ok := evs[1]["truncated"]; ok {
+		// A whole message must not claim to be an excerpt: `truncated` is what
+		// licenses the runner to match this text as a PREFIX of a delivery, so
+		// asserting it here would hand a shorter message a longer delivery's
+		// identity.
+		t.Errorf("an uncapped injection reported truncated: %v", evs[1])
+	}
 	if seqOf(t, evs[1]) != seqOf(t, evs[0]) {
 		t.Errorf("injection reported against another turn: %v", evs)
+	}
+}
+
+// TestPiExtInjectionReportsItsOwnTruncation: the adapter is the only party that
+// knows whether it capped an injection excerpt, so it says so as a FACT on the
+// event. The runner's correlation grants the prefix rule on that flag alone —
+// never on the text ending in an ellipsis, which a foreign message can also do.
+func TestPiExtInjectionReportsItsOwnTruncation(t *testing.T) {
+	// Longer than the extension's excerpt cap, so the report is genuinely a
+	// prefix; and a second injection that merely ENDS in an ellipsis, which is
+	// not one.
+	evs := turnEvents(runExtDriver(t, `
+		handlers.agent_start({}, ctx);
+		handlers.message_start({ message: { role: "assistant", content: [{ type: "text", text: "working" }] } }, ctx);
+		handlers.message_start({ message: { role: "user", content: "x".repeat(4000) } }, ctx);
+		handlers.message_start({ message: { role: "user", content: "wait\u2026" } }, ctx);
+		handlers.agent_end({ messages: [
+			{ role: "assistant", content: [{ type: "text", text: "ok" }], stopReason: "stop" },
+		] }, ctx);
+		handlers.agent_settled({}, ctx);
+	`))
+	var steers []map[string]any
+	for _, e := range evs {
+		if e["phase"] == "steered" {
+			steers = append(steers, e)
+		}
+	}
+	if len(steers) != 2 {
+		t.Fatalf("want two injections, got %v", evs)
+	}
+	capped, plain := steers[0], steers[1]
+	if capped["truncated"] != true {
+		t.Errorf("a capped excerpt did not report its truncation: %v", capped)
+	}
+	if text, _ := capped["text"].(string); !strings.HasSuffix(text, "\u2026") {
+		t.Errorf("a capped excerpt lost its ellipsis: %q", text)
+	}
+	if _, ok := plain["truncated"]; ok {
+		t.Errorf("a whole message ending in an ellipsis claimed truncation: %v", plain)
+	}
+	if plain["text"] != "wait\u2026" {
+		t.Errorf("text = %v", plain["text"])
 	}
 }
 
@@ -338,6 +389,67 @@ func TestPiExtProseHelpers(t *testing.T) {
 	for k, v := range want {
 		if got[k] != v {
 			t.Errorf("%s = %q, want %q", k, got[k], v)
+		}
+	}
+}
+
+// TestPiExtExcerptWhitespaceMatchesRunner pins the whitespace class as a
+// CROSS-RUNTIME CONTRACT rather than as each side's local habit.
+//
+// The runner decides whether an injection belongs to a given gmux request by
+// comparing the adapter's excerpt against the same normalization of the text it
+// delivered (ADR 0027's steer self-exclusion). The two runtimes disagree out of
+// the box — JavaScript's \s matches U+FEFF but not U+0085, Go's unicode.IsSpace
+// the reverse — so a prompt containing either character would normalize
+// differently on the two sides, fail to correlate, and silently downgrade its
+// injector to an indeterminate result. Both sides collapse the union; this test
+// is what keeps them collapsing the SAME union.
+func TestPiExtExcerptWhitespaceMatchesRunner(t *testing.T) {
+	nodeBin, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("node not on PATH; skipping pi-ext behavior test")
+	}
+	dir := t.TempDir()
+	extPath := filepath.Join(dir, "pi-ext.mjs")
+	if err := os.WriteFile(extPath, extSource, 0o644); err != nil {
+		t.Fatalf("materialize extension: %v", err)
+	}
+	// One case per character the two runtimes disagree about, plus the ordinary
+	// ones both already agreed on.
+	inputs := []string{
+		"a\n\n b\tc  ",
+		"bom\uFEFFhere", // JS \s only
+		"nel\u0085here", // Go IsSpace only
+		"mixed\uFEFF\u0085 x",
+		"\uFEFFleading and trailing\u0085",
+	}
+	driver := `
+		const { excerpt } = await import(process.argv[2]);
+		process.stdout.write(JSON.stringify(JSON.parse(process.argv[3]).map(excerpt)));
+	`
+	driverPath := filepath.Join(dir, "driver.mjs")
+	if err := os.WriteFile(driverPath, []byte(driver), 0o644); err != nil {
+		t.Fatalf("write driver: %v", err)
+	}
+	payload, err := json.Marshal(inputs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := exec.Command(nodeBin, driverPath, extPath, string(payload)).Output()
+	if err != nil {
+		t.Fatalf("node driver: %v (%s)", err, out)
+	}
+	var got []string
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("decode %q: %v", out, err)
+	}
+	if len(got) != len(inputs) {
+		t.Fatalf("got %d excerpts for %d inputs", len(got), len(inputs))
+	}
+	for i, in := range inputs {
+		if want := session.NormalizeExcerpt(in); got[i] != want {
+			t.Errorf("excerpt(%q) = %q (node), but the runner normalizes it to %q; "+
+				"the correlation compares these two strings, so they must agree", in, got[i], want)
 		}
 	}
 }

--- a/cli/gmux/internal/ptyserver/actions.go
+++ b/cli/gmux/internal/ptyserver/actions.go
@@ -165,6 +165,12 @@ const maxPromptBytes = maxInputBytes
 // plus room for the field names and any future sibling fields.
 const maxPromptEnvelopeBytes = 8 << 20
 
+// maxDeliveryIDBytes caps the caller's delivery identity. It is an opaque token
+// gmuxd mints (a short random string), so anything longer is a caller mistake
+// and is refused rather than stored: the id is retained in runner memory for
+// the length of a turn.
+const maxDeliveryIDBytes = 128
+
 // Delivery modes accepted by POST /prompt. They map 1:1 onto the adapter's
 // submit-like actions; the plain/steer distinction is NOT here, it is the
 // `require` field, because both are the same keystroke (ADR 0027).
@@ -187,15 +193,22 @@ type promptRequest struct {
 	Prompt   string
 	Delivery string
 	Require  string
+	// DeliveryID is the caller's identity for this delivery, used to correlate
+	// the text with the injection the adapter reports when it enters a RUNNING
+	// loop (ADR 0027's steer self-exclusion). Optional: a caller that sends none
+	// simply cannot be told apart from a human typing, and its injections carry
+	// no id.
+	DeliveryID string
 }
 
 // promptWire is the on-the-wire shape. Prompt is decoded as a raw token so the
 // exact JSON string the caller sent can be validated before encoding/json gets
 // a chance to rewrite it (see validateJSONStringToken).
 type promptWire struct {
-	Prompt   *json.RawMessage `json:"prompt"`
-	Delivery string           `json:"delivery"`
-	Require  string           `json:"require"`
+	Prompt     *json.RawMessage `json:"prompt"`
+	Delivery   string           `json:"delivery"`
+	Require    string           `json:"require"`
+	DeliveryID string           `json:"delivery_id"`
 }
 
 var (
@@ -304,7 +317,7 @@ func (s *Server) handlePrompt(w http.ResponseWriter, r *http.Request) {
 		action = adapter.ActionSendAfterTurn
 	}
 	require, reserve := admissionPolicy(req.Delivery, req.Require)
-	s.deliver(w, r, req.Prompt, action, require, reserve)
+	s.deliver(w, r, req.Prompt, req.DeliveryID, action, require, reserve)
 }
 
 // handleCancel aborts the agent's current turn.
@@ -322,7 +335,7 @@ func (s *Server) handleCancel(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// An interrupt starts no turn, so it reserves nothing.
-	s.deliver(w, r, "", adapter.ActionInterrupt, session.RequireActive, session.ReserveNever)
+	s.deliver(w, r, "", "", adapter.ActionInterrupt, session.RequireActive, session.ReserveNever)
 }
 
 // admissionPolicy maps a validated request onto the state layer's requirement
@@ -358,7 +371,7 @@ func admissionPolicy(delivery, require string) (session.TurnRequirement, session
 // deliver is the shared body of both semantic routes: capability → readiness →
 // slot → commit → one write. See this file's header for the ordering model and
 // for what is and is not guaranteed.
-func (s *Server) deliver(w http.ResponseWriter, r *http.Request, prompt string, action adapter.AgentAction, require session.TurnRequirement, reserve session.ReservePolicy) {
+func (s *Server) deliver(w http.ResponseWriter, r *http.Request, prompt, deliveryID string, action adapter.AgentAction, require session.TurnRequirement, reserve session.ReservePolicy) {
 	if err := s.requireIncarnation(w, r); err != nil {
 		return
 	}
@@ -433,6 +446,13 @@ func (s *Server) deliver(w http.ResponseWriter, r *http.Request, prompt string, 
 	// written verbatim, never parsed as key tokens, so a prompt that happens
 	// to contain "\r" or an escape sequence is the caller's text, not a
 	// second action.
+	// Arm the injection correlation window BEFORE the write, so the adapter's
+	// report of this text — which can arrive while the write's own goroutine is
+	// still unwinding — finds the record it belongs to. It is withdrawn below if
+	// the payload did not go out whole. Arming it unconditionally is safe: when
+	// the delivery starts a turn instead of joining one, the text becomes that
+	// turn's trigger and the window closes unmatched (State.OpenTurn).
+	s.state.NotePendingInjection(deliveryID, prompt)
 	payload := []byte(prompt + input)
 	n, err := s.deliverBytes(payload)
 	if err == nil && n != len(payload) {
@@ -440,6 +460,12 @@ func (s *Server) deliver(w http.ResponseWriter, r *http.Request, prompt string, 
 		// a prompt, possibly without its submit keystroke. Report it as a
 		// transport failure rather than 204.
 		err = fmt.Errorf("%w: wrote %d of %d bytes", errShortWrite, n, len(payload))
+	}
+	if err != nil {
+		// Nothing (or a fragment) reached the loop, so nothing of ours can be
+		// acknowledged as an injection; leaving the window armed could only
+		// mis-attribute a later message to this request.
+		s.state.DropPendingInjection(deliveryID)
 	}
 	if reserved {
 		if err != nil {
@@ -567,7 +593,10 @@ func decodePromptRequest(r *http.Request) (promptRequest, error) {
 	if dec.More() {
 		return req, errors.New("invalid JSON: trailing content after the request object")
 	}
-	req.Delivery, req.Require = wire.Delivery, wire.Require
+	req.Delivery, req.Require, req.DeliveryID = wire.Delivery, wire.Require, wire.DeliveryID
+	if len(req.DeliveryID) > maxDeliveryIDBytes {
+		return req, fmt.Errorf("delivery_id exceeds %d bytes", maxDeliveryIDBytes)
+	}
 	if wire.Prompt == nil {
 		return req, errors.New("prompt is empty")
 	}

--- a/cli/gmux/internal/ptyserver/ptyserver.go
+++ b/cli/gmux/internal/ptyserver/ptyserver.go
@@ -1033,6 +1033,7 @@ const maxInputBytes = 1 << 20 // 1 MiB
 //	op "turn" phase start   — the agent loop began (→ active), with the turn's
 //	                          identity (TurnSeq) and Trigger excerpt
 //	op "turn" phase steered — a user message entered the RUNNING loop
+//	                          (text + truncated: whether that text is an excerpt)
 //	op "turn" phase end     — the turn settled: Outcome, Output, Truncated,
 //	                          Diagnostic, title
 //
@@ -1064,11 +1065,16 @@ type hookEvent struct {
 	// monotonic turn counter binding start, injections and close together; an
 	// adapter that does not assert turn identity leaves it 0, and consumers
 	// treat 0 as "unknown" and serve no result for it.
-	TurnSeq    uint64 `json:"turn_seq,omitempty"`
-	Trigger    string `json:"trigger,omitempty"`    // phase start: what began the turn
-	Text       string `json:"text,omitempty"`       // phase steered: the injected message
-	Output     string `json:"output,omitempty"`     // phase end: the turn's final assistant prose
-	Truncated  bool   `json:"truncated,omitempty"`  // phase end: Output was capped at the source
+	TurnSeq uint64 `json:"turn_seq,omitempty"`
+	Trigger string `json:"trigger,omitempty"` // phase start: what began the turn
+	Text    string `json:"text,omitempty"`    // phase steered: the injected message
+	Output  string `json:"output,omitempty"`  // phase end: the turn's final assistant prose
+	// Truncated says the adapter capped what it sent: Output on phase end, Text on
+	// phase steered. On a steered event it is EVIDENCE, not a display detail — it
+	// is the runner's only licence to match the excerpt as a prefix of the text
+	// gmux delivered (see session.matchPendingLocked). Absent means "this is the
+	// whole message", which is what an adapter predating the field also means.
+	Truncated  bool   `json:"truncated,omitempty"`
 	Diagnostic string `json:"diagnostic,omitempty"` // phase end: short reason for a non-completed close
 }
 
@@ -1159,7 +1165,7 @@ func (s *Server) handleHookEvent(w http.ResponseWriter, r *http.Request) {
 			// edge are published together and in that order.
 			s.state.OpenTurn(ev.TurnSeq, ev.Trigger)
 		case "steered":
-			s.state.NoteInjection(ev.TurnSeq, ev.Text)
+			s.state.NoteInjection(ev.TurnSeq, ev.Text, ev.Truncated)
 		default:
 			s.applyTurnEnd(ev)
 		}

--- a/cli/gmux/internal/ptyserver/turn_frame_test.go
+++ b/cli/gmux/internal/ptyserver/turn_frame_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/gmuxapp/gmux/cli/gmux/internal/session"
+	"github.com/gmuxapp/gmux/packages/adapter"
 )
 
 // TestTurnFrameAssertedFacts pins the whole source-asserted turn record as the
@@ -32,7 +33,7 @@ func TestTurnFrameAssertedFacts(t *testing.T) {
 
 	postHook(t, srv, []byte(`{"op":"turn","phase":"steered","turn_seq":7,"text":"actually, stop"}`))
 	f = st.TurnFrameSnapshot()
-	if f.Current == nil || len(f.Current.Injections) != 1 || f.Current.Injections[0] != "actually, stop" {
+	if f.Current == nil || len(f.Current.Injections) != 1 || f.Current.Injections[0].Text != "actually, stop" {
 		t.Fatalf("after steer: %+v", f.Current)
 	}
 
@@ -292,5 +293,91 @@ func TestRawStatusCloseLeavesNoRunningTurnInTheFrame(t *testing.T) {
 	postHook(t, srv, []byte(`{"op":"turn","phase":"steered","turn_seq":4,"text":"too late"}`))
 	if cur := st.TurnFrameSnapshot().Current; cur != nil {
 		t.Fatalf("an injection resurrected the abandoned turn: %+v", cur)
+	}
+}
+
+// A steer's delivery identity travels from the daemon's POST /prompt into the
+// runner's correlation window, so the adapter's injection report can be matched
+// back to the request that caused it (ADR 0027's steer self-exclusion). Without
+// this hop the injecting caller could not tell its own message from a human's,
+// and would report every merged close as indeterminate.
+func TestPromptDeliveryIDReachesTheInjection(t *testing.T) {
+	f := newActionFixture(t, &fakeAgent{
+		encode: map[adapter.AgentAction]string{adapter.ActionSend: "\r"},
+	})
+	f.ready(t)
+	// A turn is running: this delivery joins it rather than starting one.
+	f.state.OpenTurn(4, "go")
+	if code, errCode := f.post(t, "/prompt",
+		`{"prompt":"use the other API","delivery":"now","require":"active","delivery_id":"d-77"}`); code != 204 {
+		t.Fatalf("steer refused: %d %s", code, errCode)
+	}
+	f.state.NoteInjection(4, "use the other API", false)
+	inj := f.state.TurnFrameSnapshot().Current.Injections
+	if len(inj) != 1 || inj[0].DeliveryID != "d-77" {
+		t.Fatalf("injections=%+v", inj)
+	}
+}
+
+// The adapter's truncation flag travels from the injection event into the
+// matcher, and it is the ONLY thing that licenses a prefix comparison there.
+//
+// The delta's D1: reading the marker off the text instead cannot tell a capped
+// excerpt from a message that merely ends in an ellipsis, so a foreign message
+// could buy itself the prefix rule and steal an in-flight delivery's identity —
+// after which that caller reads as "acknowledged and last" and is handed the
+// merged close under exit 0.
+func TestSteeredTruncationFlagGatesPrefixMatching(t *testing.T) {
+	post := func(t *testing.T, f *actionFixture, event string) session.TurnInjection {
+		t.Helper()
+		postHook(t, f.srv, []byte(event))
+		inj := f.state.TurnFrameSnapshot().Current.Injections
+		if len(inj) == 0 {
+			t.Fatal("no injection was recorded")
+		}
+		return inj[len(inj)-1]
+	}
+
+	t.Run("a flagged excerpt matches as a prefix", func(t *testing.T) {
+		f := newActionFixture(t, &fakeAgent{encode: map[adapter.AgentAction]string{adapter.ActionSend: "\r"}})
+		f.ready(t)
+		f.state.OpenTurn(1, "go")
+		if code, e := f.post(t, "/prompt",
+			`{"prompt":"please switch to the streaming endpoint and retry","delivery":"now","require":"active","delivery_id":"d-1"}`); code != 204 {
+			t.Fatalf("steer refused: %d %s", code, e)
+		}
+		got := post(t, f, `{"op":"turn","phase":"steered","turn_seq":1,"text":"please switch to the\u2026","truncated":true}`)
+		if got.DeliveryID != "d-1" {
+			t.Fatalf("a flagged excerpt lost its correlation: %+v", got)
+		}
+	})
+
+	t.Run("an unflagged message ending in an ellipsis does not", func(t *testing.T) {
+		f := newActionFixture(t, &fakeAgent{encode: map[adapter.AgentAction]string{adapter.ActionSend: "\r"}})
+		f.ready(t)
+		f.state.OpenTurn(1, "go")
+		if code, e := f.post(t, "/prompt",
+			`{"prompt":"please switch to the streaming endpoint and retry","delivery":"now","require":"active","delivery_id":"d-1"}`); code != 204 {
+			t.Fatalf("steer refused: %d %s", code, e)
+		}
+		// Same shape on the wire, minus the adapter's assertion that it capped.
+		got := post(t, f, `{"op":"turn","phase":"steered","turn_seq":1,"text":"please switch to the\u2026"}`)
+		if got.DeliveryID != "" {
+			t.Fatalf("a message that merely ends in an ellipsis claimed a pending delivery: %+v", got)
+		}
+	})
+}
+
+// An oversized identity is refused rather than stored: it is an opaque token the
+// daemon mints, and the runner holds it in memory for the length of a turn.
+func TestPromptRejectsAnOversizedDeliveryID(t *testing.T) {
+	f := newActionFixture(t, &fakeAgent{
+		encode: map[adapter.AgentAction]string{adapter.ActionSend: "\r"},
+	})
+	f.ready(t)
+	body := `{"prompt":"x","delivery":"now","require":"any","delivery_id":"` +
+		strings.Repeat("a", maxDeliveryIDBytes+1) + `"}`
+	if code, errCode := f.post(t, "/prompt", body); code != http.StatusBadRequest || errCode != CodeInvalidRequest {
+		t.Fatalf("code=%d err=%q", code, errCode)
 	}
 }

--- a/cli/gmux/internal/session/injection_correlation_test.go
+++ b/cli/gmux/internal/session/injection_correlation_test.go
@@ -1,0 +1,297 @@
+package session
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/gmuxapp/gmux/packages/adapter"
+)
+
+// The correlation contract (ADR 0027's steer self-exclusion): the runner can say
+// which injection is the one a given gmux request delivered, and it says so from
+// the adapter's own report rather than from delivery order.
+func TestInjectionCorrelation(t *testing.T) {
+	open := func() *State {
+		s := New(Config{ID: "s1", Adapter: "pi"})
+		s.OpenTurn(1, "go")
+		return s
+	}
+	lastInjection := func(t *testing.T, s *State) TurnInjection {
+		t.Helper()
+		inj := s.TurnFrameSnapshot().Current.Injections
+		if len(inj) == 0 {
+			t.Fatal("no injection was recorded")
+		}
+		return inj[len(inj)-1]
+	}
+
+	t.Run("the delivered text carries the delivering request's id", func(t *testing.T) {
+		s := open()
+		s.NotePendingInjection("d-1", "use the other API")
+		s.NoteInjection(1, "use the other API", false)
+		if got := lastInjection(t, s); got.DeliveryID != "d-1" {
+			t.Fatalf("injection=%+v", got)
+		}
+	})
+
+	// The reviewers' probes: an uncapped report must match EXACTLY, so no
+	// shorter message can consume a longer delivery's identity. Both cases used
+	// to hand the caller an id it had not earned, and the caller — "acknowledged
+	// and last" — was then served the merged close under exit 0, which is
+	// exactly the settle-before-ack case that must read as indeterminate.
+	t.Run("a shorter human message cannot steal a pending id", func(t *testing.T) {
+		s := open()
+		s.NotePendingInjection("id-A", "stop and say kiwi")
+		s.NoteInjection(1, "stop", false) // typed into the TUI
+		if got := lastInjection(t, s); got.DeliveryID != "" {
+			t.Fatalf("a prefix of a pending delivery claimed its identity: %+v", got)
+		}
+		// And the delivery is still armed for its own message.
+		s.NoteInjection(1, "stop and say kiwi", false)
+		if got := lastInjection(t, s); got.DeliveryID != "id-A" {
+			t.Fatalf("the real injection lost its identity: %+v", got)
+		}
+	})
+
+	t.Run("a shorter caller's steer cannot steal another caller's id", func(t *testing.T) {
+		s := open()
+		s.NotePendingInjection("id-A", "stop and say kiwi")
+		s.NotePendingInjection("id-B", "stop")
+		s.NoteInjection(1, "stop", false)
+		if got := lastInjection(t, s); got.DeliveryID != "id-B" {
+			t.Fatalf("the wrong caller was credited with the injection: %+v", got)
+		}
+	})
+
+	t.Run("identical pending texts are attributed to nobody", func(t *testing.T) {
+		s := open()
+		s.NotePendingInjection("id-A", "same")
+		s.NotePendingInjection("id-B", "same")
+		s.NoteInjection(1, "same", false)
+		// No fact in the report separates them, so gmux declines to guess: both
+		// injectors resolve indeterminate and every bystander is interrupted by
+		// an id-less injection. An arbitrary first match would be a coin flip on
+		// whose answer the close is.
+		if got := lastInjection(t, s); got.DeliveryID != "" {
+			t.Fatalf("an ambiguous report was attributed to %q", got.DeliveryID)
+		}
+	})
+
+	t.Run("an ambiguous capped excerpt is attributed to nobody", func(t *testing.T) {
+		s := open()
+		s.NotePendingInjection("id-A", "please switch to the streaming endpoint")
+		s.NotePendingInjection("id-B", "please switch to the batch endpoint")
+		s.NoteInjection(1, "please switch to the\u2026", true)
+		if got := lastInjection(t, s); got.DeliveryID != "" {
+			t.Fatalf("a truncated excerpt matching two deliveries was attributed to %q", got.DeliveryID)
+		}
+	})
+
+	t.Run("an unambiguous capped excerpt still matches", func(t *testing.T) {
+		s := open()
+		s.NotePendingInjection("id-A", "please switch to the streaming endpoint")
+		s.NotePendingInjection("id-B", "and skip the migration")
+		s.NoteInjection(1, "please switch to the\u2026", true)
+		if got := lastInjection(t, s); got.DeliveryID != "id-A" {
+			t.Fatalf("injection=%+v", got)
+		}
+	})
+
+	t.Run("a prefix the adapter did not flag as capped is not a match", func(t *testing.T) {
+		s := open()
+		s.NotePendingInjection("id-A", "please switch to the streaming endpoint")
+		// The adapter reports truncation as a fact; without it, a prefix is
+		// somebody else's shorter message.
+		s.NoteInjection(1, "please switch to the", false)
+		if got := lastInjection(t, s); got.DeliveryID != "" {
+			t.Fatalf("an unflagged prefix matched: %+v", got)
+		}
+	})
+
+	// The delta's D1 repro: a message that genuinely ENDS IN an ellipsis and
+	// happens to prefix an in-flight delivery. Reading the marker off the text
+	// could not tell it from a capped excerpt, so it bought itself the prefix
+	// rule and stole the delivery's identity — leaving that caller "acknowledged
+	// and last" and served the merged close under exit 0. The flag is the
+	// adapter's own assertion and this text does not carry it.
+	t.Run("a foreign message ending in an ellipsis cannot buy the prefix rule", func(t *testing.T) {
+		s := open()
+		s.NotePendingInjection("id-A", "wait\u2026 actually use the other API")
+		s.NoteInjection(1, "wait\u2026", false) // typed by a human, not capped by the adapter
+		if got := lastInjection(t, s); got.DeliveryID != "" {
+			t.Fatalf("a message ending in an ellipsis claimed a pending delivery: %+v", got)
+		}
+		// The delivery is still armed for its own, whole message.
+		s.NoteInjection(1, "wait\u2026 actually use the other API", false)
+		if got := lastInjection(t, s); got.DeliveryID != "id-A" {
+			t.Fatalf("the real injection lost its identity: %+v", got)
+		}
+	})
+
+	// ...and the mirror image: a delivery whose text ends in an ellipsis is
+	// matched exactly, with no trimming, because the marker is part of the
+	// message when the adapter did not flag a cap.
+	t.Run("an unflagged report keeps its ellipsis for the comparison", func(t *testing.T) {
+		s := open()
+		s.NotePendingInjection("id-A", "hold on\u2026")
+		s.NoteInjection(1, "hold on\u2026", false)
+		if got := lastInjection(t, s); got.DeliveryID != "id-A" {
+			t.Fatalf("an exact match was trimmed apart: %+v", got)
+		}
+	})
+
+	t.Run("normalization spans both runtimes' whitespace", func(t *testing.T) {
+		s := open()
+		s.NotePendingInjection("id-A", "bom\uFEFFhere and nel\u0085there")
+		// What pi-ext.mjs's excerpt() produces for that text: both sides collapse
+		// the union of the two runtimes' whitespace classes.
+		s.NoteInjection(1, "bom here and nel there", false)
+		if got := lastInjection(t, s); got.DeliveryID != "id-A" {
+			t.Fatalf("normalization diverged between the adapter and the runner: %+v", got)
+		}
+	})
+
+	t.Run("an excerpted report still matches its delivery", func(t *testing.T) {
+		s := open()
+		s.NotePendingInjection("d-1", "please switch to the streaming endpoint and retry")
+		// The adapter caps excerpts at the source and SAYS SO on the event, so the
+		// report is known to be a prefix of what was delivered.
+		s.NoteInjection(1, "please switch to the streaming\u2026", true)
+		if got := lastInjection(t, s); got.DeliveryID != "d-1" {
+			t.Fatalf("a capped excerpt lost its correlation: %+v", got)
+		}
+	})
+
+	t.Run("whitespace differences do not break the match", func(t *testing.T) {
+		s := open()
+		s.NotePendingInjection("d-1", "line one\n\nline two")
+		s.NoteInjection(1, "line one line two", false)
+		if got := lastInjection(t, s); got.DeliveryID != "d-1" {
+			t.Fatalf("injection=%+v", got)
+		}
+	})
+
+	t.Run("a human's message never inherits a pending id", func(t *testing.T) {
+		s := open()
+		s.NotePendingInjection("d-1", "use the other API")
+		// A human typed something else into the TUI while the steer was in
+		// flight. Matching by arrival order would hand this message the caller's
+		// identity, and the caller would then claim an answer its own text never
+		// entered.
+		s.NoteInjection(1, "stop, I'll drive", false)
+		if got := lastInjection(t, s); got.DeliveryID != "" {
+			t.Fatalf("a foreign injection was attributed to a pending delivery: %+v", got)
+		}
+		// The pending record survives for its own message.
+		s.NoteInjection(1, "use the other API", false)
+		if got := lastInjection(t, s); got.DeliveryID != "d-1" {
+			t.Fatalf("injection=%+v", got)
+		}
+	})
+
+	t.Run("one delivery is claimed once", func(t *testing.T) {
+		s := open()
+		s.NotePendingInjection("d-1", "again")
+		s.NoteInjection(1, "again", false)
+		s.NoteInjection(1, "again", false)
+		inj := s.TurnFrameSnapshot().Current.Injections
+		if len(inj) != 2 || inj[0].DeliveryID != "d-1" || inj[1].DeliveryID != "" {
+			t.Fatalf("a consumed delivery id was reused: %+v", inj)
+		}
+	})
+
+	t.Run("a withdrawn delivery matches nothing", func(t *testing.T) {
+		s := open()
+		s.NotePendingInjection("d-1", "half-written")
+		s.DropPendingInjection("d-1")
+		s.NoteInjection(1, "half-written", false)
+		if got := lastInjection(t, s); got.DeliveryID != "" {
+			t.Fatalf("a failed write still claimed an injection: %+v", got)
+		}
+	})
+
+	t.Run("a delivery that STARTED a turn is that turn's trigger", func(t *testing.T) {
+		s := New(Config{ID: "s1", Adapter: "pi"})
+		s.NotePendingInjection("d-1", "first ask")
+		s.OpenTurn(1, "first ask")
+		// pi replays the opening prompt as a message on the loop; the runner's
+		// window is already closed, so nothing can mistake it for an injection
+		// belonging to a wait.
+		s.NoteInjection(1, "first ask", false)
+		if got := lastInjection(t, s); got.DeliveryID != "" {
+			t.Fatalf("a trigger was correlated as an injection: %+v", got)
+		}
+	})
+
+	t.Run("the window does not outlive the turn", func(t *testing.T) {
+		s := open()
+		s.NotePendingInjection("d-1", "too late")
+		s.CloseTurnFrame(TurnClose{TurnSeq: 1, Outcome: "completed"}, &adapter.Status{})
+		s.OpenTurn(2, "next")
+		s.NoteInjection(2, "too late", false)
+		if got := lastInjection(t, s); got.DeliveryID != "" {
+			t.Fatalf("a stale delivery claimed the NEXT turn's injection: %+v", got)
+		}
+	})
+
+	t.Run("the pending window is bounded", func(t *testing.T) {
+		s := open()
+		for i := 0; i < maxPendingInjections*3; i++ {
+			s.NotePendingInjection("d", "text")
+		}
+		if got := len(s.pendingInjections); got > maxPendingInjections {
+			t.Fatalf("pending window grew to %d", got)
+		}
+	})
+}
+
+// The frame is a wire contract between the runner and gmuxd, and the runner may
+// be older than the daemon reading it: the object shape and the bare excerpt
+// string an earlier runner sent must both decode, because a frame that fails to
+// decode wholesale costs every result in it.
+func TestTurnInjectionDecodesBothShapes(t *testing.T) {
+	var frame TurnFrame
+	raw := `{"seq":1,"current":{"turn_seq":3,"injections":["old shape",{"text":"new shape","delivery_id":"d-9"}]}}`
+	if err := json.NewDecoder(strings.NewReader(raw)).Decode(&frame); err != nil {
+		t.Fatal(err)
+	}
+	inj := frame.Current.Injections
+	if len(inj) != 2 || inj[0] != (TurnInjection{Text: "old shape"}) ||
+		inj[1] != (TurnInjection{Text: "new shape", DeliveryID: "d-9"}) {
+		t.Fatalf("injections=%+v", inj)
+	}
+}
+
+// The injection COUNT is what novelty is decided against downstream, so it must
+// keep growing after the bounded excerpt list has saturated. A count that
+// saturated with the list would make every later injection look like "nothing
+// new" to a wait that armed at that point — and that wait would then be served
+// the merged answer under exit 0, which is the one direction the steer rule may
+// not fail in.
+func TestInjectionCountOutlivesTheBoundedList(t *testing.T) {
+	s := New(Config{ID: "s1", Adapter: "pi"})
+	s.OpenTurn(1, "go")
+	const total = maxTurnInjections * 2
+	for i := 0; i < total; i++ {
+		s.NoteInjection(1, "steer "+strconv.Itoa(i), false)
+	}
+	cur := s.TurnFrameSnapshot().Current
+	if len(cur.Injections) != maxTurnInjections {
+		t.Fatalf("retained %d injections, want the list capped at %d", len(cur.Injections), maxTurnInjections)
+	}
+	if cur.InjectionCount != total {
+		t.Fatalf("InjectionCount = %d after %d injections", cur.InjectionCount, total)
+	}
+	// The newest is the one that owns the answer, and it is the one kept.
+	if last := cur.Injections[len(cur.Injections)-1]; last.Text != "steer "+strconv.Itoa(total-1) {
+		t.Fatalf("the bounded list dropped the NEWEST injection: %+v", last)
+	}
+	// The close carries the count too, so a waiter that only learns of a steer
+	// at the close decides novelty exactly as it would have live.
+	s.CloseTurnFrame(TurnClose{TurnSeq: 1, Outcome: "completed"}, &adapter.Status{})
+	if got := s.TurnFrameSnapshot().Last.InjectionCount; got != total {
+		t.Fatalf("close carried InjectionCount = %d, want %d", got, total)
+	}
+}

--- a/cli/gmux/internal/session/state.go
+++ b/cli/gmux/internal/session/state.go
@@ -102,6 +102,11 @@ type State struct {
 	// truth, not row state.
 	turnFrame *TurnFrame
 	frameSeq  uint64
+	// pendingInjections is the correlation window between a semantic delivery
+	// gmux wrote to the composer and the adapter reporting that text as an
+	// injection on the running loop (see NotePendingInjection). Generation-local
+	// and never serialized, like the reservation next to it.
+	pendingInjections []TurnInjection
 
 	// SSE subscribers (not serialized)
 	subs []chan Event

--- a/cli/gmux/internal/session/turnframe.go
+++ b/cli/gmux/internal/session/turnframe.go
@@ -1,6 +1,12 @@
 package session
 
-import "github.com/gmuxapp/gmux/packages/adapter"
+import (
+	"encoding/json"
+	"strings"
+	"unicode"
+
+	"github.com/gmuxapp/gmux/packages/adapter"
+)
 
 // The turn frame is the runner's live record of what the adapter asserted about
 // its turns (ADR 0027, 2026-07-28 amendment: "the result is asserted at the
@@ -37,11 +43,55 @@ type TurnCurrent struct {
 	TurnSeq uint64 `json:"turn_seq"`
 	// Trigger is the excerpt of what started the turn.
 	Trigger string `json:"trigger,omitempty"`
-	// Injections are the excerpts of user messages that entered the running
-	// loop after it started (steers, and follow-ups pi merged into the loop).
-	// They accumulate across the run: each one changes what the turn's answer
-	// means.
-	Injections []string `json:"injections,omitempty"`
+	// Injections are the user messages that entered the running loop after it
+	// started (steers, and follow-ups pi merged into the loop). They accumulate
+	// across the run: each one changes what the turn's answer means. The list is
+	// BOUNDED (maxTurnInjections) and keeps the newest, so it is report material,
+	// not a count.
+	Injections []TurnInjection `json:"injections,omitempty"`
+	// InjectionCount is how many messages have entered this loop in total, and it
+	// never trims. Novelty is decided against this number rather than against
+	// len(Injections): once the bounded list saturates, its length stops growing,
+	// and a length-based baseline would make every later injection invisible to a
+	// wait that armed at that point — which would serve it the merged answer under
+	// exit 0, the one direction this rule may not fail in.
+	InjectionCount uint64 `json:"injection_count,omitempty"`
+}
+
+// TurnInjection is one user message that entered a running loop.
+//
+// DeliveryID is the identity of the gmux request that delivered it, correlated
+// at the runner (see State.NotePendingInjection). It is what lets an injecting
+// caller be excluded from the interruption its own steer causes: the injector
+// may claim the merged close only while its message is the loop's LAST
+// injection (ADR 0027, "Steering interrupts waits"). It is empty for an
+// injection gmux did not deliver — a human typing into the TUI, or raw `gmux
+// send` — which is exactly the case that interrupts every waiter.
+type TurnInjection struct {
+	Text       string `json:"text,omitempty"`
+	DeliveryID string `json:"delivery_id,omitempty"`
+}
+
+// UnmarshalJSON accepts both the object shape and the bare excerpt string a
+// runner predating delivery identity sends. The lenient direction is the one
+// that matters: a frame that failed to decode wholesale would cost every result
+// in it, which is the loss the frame exists to prevent.
+func (t *TurnInjection) UnmarshalJSON(b []byte) error {
+	if strings.HasPrefix(strings.TrimSpace(string(b)), `"`) {
+		var s string
+		if err := json.Unmarshal(b, &s); err != nil {
+			return err
+		}
+		*t = TurnInjection{Text: s}
+		return nil
+	}
+	type raw TurnInjection
+	var v raw
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	*t = TurnInjection(v)
+	return nil
 }
 
 // TurnClose is a settled turn's asserted result.
@@ -50,8 +100,11 @@ type TurnClose struct {
 	Outcome string `json:"outcome"`
 	// Trigger/Injections are carried over from the turn's open record so a
 	// report can name what the closed turn was asked to do.
-	Trigger    string   `json:"trigger,omitempty"`
-	Injections []string `json:"injections,omitempty"`
+	Trigger    string          `json:"trigger,omitempty"`
+	Injections []TurnInjection `json:"injections,omitempty"`
+	// InjectionCount is the closed turn's total injection count, carried over
+	// from its open record for the same reason it exists there.
+	InjectionCount uint64 `json:"injection_count,omitempty"`
 	// Output is the settled turn's final assistant prose, present only for a
 	// completed turn and OMITTED (never empty) when the turn produced none: an
 	// absent output means a tool-only turn, never transport loss.
@@ -68,6 +121,13 @@ type TurnClose struct {
 // are the ones that matter (the last injection is the one that owns the
 // answer), so the oldest are dropped.
 const maxTurnInjections = 64
+
+// maxPendingInjections bounds the correlation window (see
+// NotePendingInjection). Semantic deliveries into one running turn are
+// serialized by the runner's delivery slot and acknowledged within a message
+// round trip, so the queue is short by construction; the cap only stops a
+// pathological caller from growing it.
+const maxPendingInjections = 8
 
 // turnEdge is the wire payload of a turn edge: a status transition and the turn
 // frame that transition belongs to, in ONE event.
@@ -97,6 +157,11 @@ type turnEdge struct {
 func (s *State) OpenTurn(turnSeq uint64, trigger string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	// A delivery still armed when a turn STARTS was the thing that started it:
+	// its text is this turn's trigger, not an injection into it, so the
+	// correlation window closes here rather than waiting to match a message that
+	// can no longer arrive.
+	s.pendingInjections = nil
 	frame := s.publishFrameLocked(&TurnFrame{
 		Current: &TurnCurrent{TurnSeq: turnSeq, Trigger: trigger},
 		Last:    s.lastClosedLocked(),
@@ -112,15 +177,21 @@ func (s *State) OpenTurn(turnSeq uint64, trigger string) {
 // applies only to the turn it names: an injection reported against a turn that
 // has already closed (or against a different one) is stale and dropped rather
 // than attached to the wrong answer.
-func (s *State) NoteInjection(turnSeq uint64, text string) {
+// The injection is correlated with a pending semantic delivery (by the text the
+// adapter reported, see matchPendingLocked) so the request that injected it can
+// tell its own message from somebody else's. excerpted is the adapter's own
+// assertion that `text` is a capped prefix of the message rather than the whole
+// of it — the one thing that licenses a prefix comparison.
+func (s *State) NoteInjection(turnSeq uint64, text string, excerpted bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	cur := s.currentTurnLocked()
 	if cur == nil || cur.TurnSeq != turnSeq || text == "" {
 		return
 	}
-	next := &TurnCurrent{TurnSeq: cur.TurnSeq, Trigger: cur.Trigger}
-	next.Injections = append(append([]string(nil), cur.Injections...), text)
+	next := &TurnCurrent{TurnSeq: cur.TurnSeq, Trigger: cur.Trigger, InjectionCount: cur.InjectionCount + 1}
+	inj := TurnInjection{Text: text, DeliveryID: s.matchPendingLocked(text, excerpted)}
+	next.Injections = append(append([]TurnInjection(nil), cur.Injections...), inj)
 	if len(next.Injections) > maxTurnInjections {
 		next.Injections = next.Injections[len(next.Injections)-maxTurnInjections:]
 	}
@@ -128,6 +199,155 @@ func (s *State) NoteInjection(turnSeq uint64, text string) {
 	// and stays active, so this is the one frame update that travels alone. A
 	// dropped injection costs a report detail, never an attribution.
 	s.emitFrameLocked(s.publishFrameLocked(&TurnFrame{Current: next, Last: s.lastClosedLocked()}))
+}
+
+// NotePendingInjection arms the correlation window for one semantic delivery:
+// gmux wrote `text` to the agent's composer on behalf of the request identified
+// by deliveryID, and if that text turns up as an injection on the running loop,
+// the injection MAY be that request's — see matchPendingLocked for when gmux is
+// willing to say so.
+//
+// What this is NOT: a cryptographic identity carried through the agent. pi's
+// injection report contains the message text and nothing else, so the only
+// evidence available is textual, and text cannot prove which source produced
+// identical text. The correlation is therefore deliberately conservative and
+// biased toward refusing to answer: an ambiguous report is attributed to nobody,
+// and the injectors involved report an indeterminate result rather than one of
+// them claiming a close its own text may never have entered.
+func (s *State) NotePendingInjection(deliveryID, text string) {
+	if deliveryID == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.pendingInjections = append(s.pendingInjections, TurnInjection{Text: normalizeExcerpt(text), DeliveryID: deliveryID})
+	if len(s.pendingInjections) > maxPendingInjections {
+		s.pendingInjections = s.pendingInjections[len(s.pendingInjections)-maxPendingInjections:]
+	}
+}
+
+// DropPendingInjection withdraws a delivery whose write did not go out whole.
+// Nothing of it reached the loop, so leaving it armed could only mis-attribute
+// somebody else's later message to this request.
+func (s *State) DropPendingInjection(deliveryID string) {
+	if deliveryID == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	kept := s.pendingInjections[:0]
+	for _, p := range s.pendingInjections {
+		if p.DeliveryID != deliveryID {
+			kept = append(kept, p)
+		}
+	}
+	s.pendingInjections = kept
+}
+
+// matchPendingLocked consumes and returns the delivery id of the pending
+// delivery the adapter's injection report UNAMBIGUOUSLY names, or "" when there
+// is no such delivery. Caller must hold s.mu.
+//
+// Two rules, and both exist because the alternative fails in the one direction
+// this design promises never to fail — a caller being served a close its text
+// may never have entered:
+//
+//   - MATCHING IS EXACT, unless the adapter SAYS it truncated. Applying prefix
+//     tolerance unconditionally let any SHORTER message consume a longer pending
+//     delivery's identity: a human typing "stop" while "stop and say kiwi" was in
+//     flight would be recorded as that caller's injection, and the caller — now
+//     "acknowledged and last" — would be handed the merged answer under exit 0,
+//     which is precisely the settle-before-ack case that must read as
+//     indeterminate.
+//
+//     `excerpted` is the adapter's explicit flag on the injection event, not a
+//     shape read off the text. Sniffing the trailing ellipsis instead cannot
+//     distinguish a capped excerpt from a message that merely ends in one, so a
+//     foreign message ending in "…" — typed, pasted, or emitted by another tool —
+//     could still buy itself the prefix rule and steal an in-flight delivery's
+//     identity. The adapter is the only party that knows whether it capped, so it
+//     is the party that says so.
+//
+//   - MATCHING MUST BE UNIQUE. If two pending deliveries could explain the same
+//     report (identical texts, or a truncated excerpt that prefixes both), the
+//     report names nobody: no id is assigned and nothing is consumed. Both
+//     injectors then resolve indeterminate and every bystander is interrupted by
+//     an id-less injection. Ambiguity always degrades toward "nobody claims the
+//     close", never toward an arbitrary first match, because a first match is a
+//     coin flip on whose answer this is.
+//
+// The irreducible residue is a human typing text byte-identical to an in-flight
+// steer at that same moment: pi reports one message with one text, and no
+// evidence exists that could separate them. That is accepted and recorded in
+// ADR 0027 rather than papered over.
+func (s *State) matchPendingLocked(text string, excerpted bool) string {
+	reported := normalizeExcerpt(text)
+	if reported == "" {
+		return ""
+	}
+	// Only a report the adapter FLAGGED as capped is compared as a prefix, and
+	// only then is its ellipsis marker stripped: on an unflagged report the
+	// ellipsis is part of the message, and trimming it would compare a string the
+	// agent never saw.
+	prefix := reported
+	if excerpted {
+		prefix = strings.TrimSuffix(reported, excerptEllipsis)
+		if prefix == "" {
+			return ""
+		}
+	}
+	match := -1
+	for i, p := range s.pendingInjections {
+		var names bool
+		if excerpted {
+			names = strings.HasPrefix(p.Text, prefix)
+		} else {
+			names = p.Text == reported
+		}
+		if !names {
+			continue
+		}
+		if match >= 0 {
+			// Ambiguous. Consume nothing: leaving both records armed keeps them
+			// available for a later report that IS unambiguous, and costs only
+			// the (already safe) indeterminate answer in the meantime.
+			return ""
+		}
+		match = i
+	}
+	if match < 0 {
+		return ""
+	}
+	id := s.pendingInjections[match].DeliveryID
+	s.pendingInjections = append(s.pendingInjections[:match:match], s.pendingInjections[match+1:]...)
+	return id
+}
+
+// excerptEllipsis is the marker the adapter appends to an excerpt it capped. It
+// is a DISPLAY detail: what licenses a prefix comparison is the adapter's
+// explicit truncation flag, and this constant only strips the marker back off
+// before comparing a flagged excerpt against the delivered text.
+const excerptEllipsis = "\u2026"
+
+// normalizeExcerpt mirrors the adapter's excerpt normalization so both sides of
+// the correlation compare the same string.
+//
+// "Mirrors" is a contract, not a coincidence, and the two runtimes disagree by
+// default: JavaScript's \s matches U+FEFF but not U+0085, while Go's
+// unicode.IsSpace matches U+0085 but not U+FEFF. Both sides therefore collapse
+// the UNION (see pi-ext.mjs's excerpt()), so a prompt containing either
+// character still correlates instead of silently degrading its injector to an
+// indeterminate result.
+func normalizeExcerpt(s string) string {
+	return strings.Join(strings.FieldsFunc(s, isExcerptSpace), " ")
+}
+
+// NormalizeExcerpt exposes that normalization so the adapter-side test can pin
+// the two runtimes against each other rather than against a copy of the rule.
+func NormalizeExcerpt(s string) string { return normalizeExcerpt(s) }
+
+func isExcerptSpace(r rune) bool {
+	return unicode.IsSpace(r) || r == '\uFEFF'
 }
 
 // CloseTurnFrame atomically records a settled turn's asserted result and closes
@@ -169,10 +389,14 @@ func (s *State) NoteInjection(turnSeq uint64, text string) {
 func (s *State) CloseTurnFrame(close TurnClose, status *adapter.Status) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	// Whatever was armed can no longer enter this loop.
+	s.pendingInjections = nil
 	if cur := s.currentTurnLocked(); cur != nil && cur.TurnSeq == close.TurnSeq {
 		// Carry the turn's inputs into the close record so a report can say
-		// what the closed turn was asked to do without a second lookup.
-		close.Trigger, close.Injections = cur.Trigger, cur.Injections
+		// what the closed turn was asked to do without a second lookup. The count
+		// travels with them: a waiter that only learns of a steer at the close
+		// decides novelty the same way it would have live.
+		close.Trigger, close.Injections, close.InjectionCount = cur.Trigger, cur.Injections, cur.InjectionCount
 	}
 	frame := s.publishFrameLocked(&TurnFrame{Last: &close})
 	if s.Status == nil || !s.Status.Active {
@@ -230,6 +454,7 @@ func (s *State) SetStatusAbandoningTurn(status *adapter.Status) {
 func (s *State) ClearTurnFrame() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	s.pendingInjections = nil
 	if s.turnFrame == nil || (s.turnFrame.Current == nil && s.turnFrame.Last == nil) {
 		return
 	}

--- a/cli/gmux/internal/session/turnframe_test.go
+++ b/cli/gmux/internal/session/turnframe_test.go
@@ -172,7 +172,7 @@ func TestInjectionEmitsFrameOnly(t *testing.T) {
 	st.OpenTurn(3, "go")
 	drain(ch)
 
-	st.NoteInjection(3, "actually, stop")
+	st.NoteInjection(3, "actually, stop", false)
 	events := drain(ch)
 	if len(events) != 1 || events[0].Type != "turn_frame" {
 		t.Fatalf("injection emitted %+v", events)

--- a/docs/adr/0027-semantic-agent-cli-and-result-bearing-wait.md
+++ b/docs/adr/0027-semantic-agent-cli-and-result-bearing-wait.md
@@ -812,10 +812,17 @@ else is waiting on — a steer, or a follow-up merged into the active loop —
 changes the contract of the pending answer, so it resolves that wait early:
 exit 2, reason `steered`, report on stderr carrying the injected text. The
 turn itself keeps running; the waiter re-arms if it still cares. The injecting
-request's own sync wait is excluded by runner-local correlation with a real
-identity: the delivery carries an id, and the injector may claim the merged
-close **only after the correlated `message_start` steer event acknowledged
-that its text entered the loop**. If the turn settles before that
+request's own sync wait is excluded by runner-local correlation: the delivery
+carries an id, and the injector may claim the merged close **only after a
+`message_start` steer event was unambiguously correlated to it by text** —
+exact equality under one shared normalization, or an extension-marked
+truncation prefix. Ambiguity (identical pending texts, an unmarked prefix)
+credits the acknowledgement to nobody: the injectors resolve indeterminate and
+bystanders are interrupted by the id-less injection. One residue is accepted
+rather than closed: a human typing text byte-identical to an in-flight steer
+at the same moment is indistinguishable by construction — and the merged
+answer then reflects that identical instruction, a distinction without a
+difference. If the turn settles before that
 acknowledgement arrives, pi may have closed without consuming the injection —
 the injector's result is then indeterminate (reported as such), never the
 pre-injection answer under exit 0. And the claim holds only while the

--- a/docs/runner-hook-protocol.md
+++ b/docs/runner-hook-protocol.md
@@ -87,6 +87,7 @@ One JSON object per event, discriminated by `op`. Unknown ops/values are ignored
 | `outcome` | turn end | Normalized terminal state — see below. |
 | `output`  | turn end | The settled turn's final assistant prose. `completed` only, and **omitted rather than empty**: absence means the turn produced no prose (a tool-only turn), never that the transport lost it. |
 | `truncated` | turn end | The adapter capped `output` at the source; the full text is in the conversation. |
+| `truncated` | turn steered | The adapter capped `text`, so it is a PREFIX of the injected message. Evidence, not decoration: it is the only thing that lets the runner correlate the excerpt as a prefix of what gmux delivered (see below). Absent means the whole message. |
 | `diagnostic` | turn end | Short reason for a non-completed close. The account channel — never presented as a result. |
 | `title`   | turn end | Display title at turn end. |
 
@@ -106,10 +107,13 @@ surviving every hop. The frame looks like this:
 ```jsonc
 { "seq": 12,                                    // frame version, monotonic per runner
   "current": { "turn_seq": 7, "trigger": "…",    // the turn running right now
-               "injections": ["…"] },
+               "injections": [{ "text": "…", "delivery_id": "…" }],
+               "injection_count": 3 },
   "last":    { "turn_seq": 6, "outcome": "completed",
                "output": "…", "truncated": false,
-               "diagnostic": "…", "trigger": "…", "injections": ["…"] } }
+               "diagnostic": "…", "trigger": "…",
+               "injections": [{ "text": "…", "delivery_id": "…" }],
+               "injection_count": 3 } }
 ```
 
 It reaches `/events` subscribers two ways:
@@ -187,6 +191,63 @@ mid-turn produces no second turn: it is reported as a `steered` injection on the
 open turn, and the merged close's answer is that turn's answer. A user message
 injected into a running turn — by gmux or typed by a human — changes what the
 turn's answer means, which is why injections are reported at all.
+
+### Injections carry a delivery identity, and a count
+
+`injection_count` is the turn's **total** number of injections and never trims,
+while `injections` is a **bounded** list keeping the newest (report material).
+Consumers must decide "did anything new enter this loop since I started
+watching?" from the count: once the list saturates its length stops growing, and
+a length-based comparison would make every later injection invisible — handing a
+waiter the merged answer under exit 0, the one direction the steer rule may not
+fail in. A frame from a runner that reports no count falls back to the list
+length, which is worse but never zero.
+
+An injection's `delivery_id` is the identity of the gmux request that delivered
+its text, or **absent** for a message gmux did not deliver — a human typing into
+the TUI, raw `gmux send`, or a delivery that could not be told apart from
+another. It exists for exactly one rule (ADR 0027, "Steering interrupts waits"):
+an injection resolves every armed wait on that turn early, except the wait
+belonging to the request that injected it, and that exception holds only while
+its message is the loop's **last** injection.
+
+The daemon mints the id and passes it as `delivery_id` on `POST /prompt` when —
+and only when — the delivery joins a turn that is already running (a steer, or a
+follow-up merged into an active loop).
+
+**How the runner decides, and what it will not claim.** The adapter's injection
+report carries the message text and nothing else, so the correlation is textual
+and deliberately conservative:
+
+- an **uncapped** report must equal the delivered text exactly, after both sides
+  apply the same normalization (whitespace collapse over the union of Go's and
+  JavaScript's whitespace classes, so U+FEFF and U+0085 behave identically on
+  both sides);
+- a report the adapter **flagged as truncated** (`"truncated": true` on the
+  steered event) may match by prefix, because only then is it known to be a
+  prefix of the message. The flag is the licence, and it is a fact the adapter
+  asserts — never a shape read off the text. The trailing `…` an excerpt carries
+  is a display detail: a message can end in one without having been capped, so
+  sniffing it would let a foreign message buy the prefix rule and consume an
+  in-flight delivery's identity. An adapter that reports no flag is treated as
+  reporting whole messages, which is the safe reading;
+- the match must be **unique**. If two pending deliveries could explain the same
+  report (identical texts, or a truncated excerpt that prefixes both), the
+  injection is recorded with **no** id. Both callers then report an
+  indeterminate result and every bystander is interrupted, because an arbitrary
+  first match would be a coin flip on whose answer the close is.
+
+This is an acknowledgement correlated by text, not an identity carried through
+the agent: text cannot prove which source produced identical text. A human
+typing text byte-identical to an in-flight steer at that moment is
+indistinguishable, and that residue is accepted rather than papered over.
+
+For wire compatibility `injections` also decodes the bare `["…"]` form an earlier
+runner sent, as injections with no identity: refusing it would fail the whole
+frame's decode and cost every result in it. The opposite direction is **not**
+covered — a gmuxd older than these fields fails to decode the object form
+wholesale — so runner and daemon must be upgraded together, as they are by
+`gmux daemon restart` after an install.
 
 ### Outcome vocabulary
 

--- a/services/gmuxd/cmd/gmuxd/agent_actions.go
+++ b/services/gmuxd/cmd/gmuxd/agent_actions.go
@@ -208,7 +208,7 @@ type agentDeps struct {
 	subscribe        func(ctx context.Context) ([]sessioncoord.Outcome, <-chan sessioncoord.Outcome, func(), error)
 	live             func(id centralstore.SessionID) (sessioncoord.Runtime, bool)
 	resume           func(ctx context.Context, id centralstore.SessionID) (sessioncoord.Runtime, error)
-	sendPrompt       func(ctx context.Context, endpoint, incarnation, prompt, delivery, require string) error
+	sendPrompt       func(ctx context.Context, endpoint, incarnation, prompt, delivery, require, deliveryID string) error
 	sendCancel       func(ctx context.Context, endpoint, incarnation string) error
 	admissionWindow  time.Duration
 	deliveryTimeout  time.Duration
@@ -220,6 +220,22 @@ type agentDeps struct {
 	// "this deployment retains no frames", under which every close is served
 	// result-free.
 	frame func(id centralstore.SessionID) *sessioncoord.TurnFrame
+	// newDeliveryID mints the identity a prompt delivered INTO A RUNNING TURN
+	// carries, so the runner can correlate the adapter's injection report back to
+	// this request and this request alone (ADR 0027's steer self-exclusion).
+	// Substituted in tests for a deterministic token.
+	newDeliveryID func() string
+}
+
+// deliveryID mints one delivery identity, or "" when this deployment has no
+// minter (tests that never exercise self-exclusion). An empty id is the safe
+// degradation: the injector then cannot recognize its own message and reports an
+// indeterminate result instead of claiming an answer.
+func (d agentDeps) deliveryID() string {
+	if d.newDeliveryID == nil {
+		return ""
+	}
+	return d.newDeliveryID()
 }
 
 // turnFrame reads the retained frame for a session, or nil.
@@ -239,6 +255,9 @@ func productionAgentDeps(boot *Bootstrap, gmuxBin string) agentDeps {
 		},
 		resume:     boot.Coordinator.Resume,
 		sendPrompt: discovery.SendPrompt,
+		newDeliveryID: func() string {
+			return newDeliveryID()
+		},
 		sendCancel: discovery.SendCancel,
 		frame: func(id centralstore.SessionID) *sessioncoord.TurnFrame {
 			return boot.Registry.Frame(id)
@@ -471,9 +490,25 @@ func handleAgentPromptCentral(w http.ResponseWriter, r *http.Request, deps agent
 	// it binds at the active edge instead (see runAgentWait) — binding it to
 	// whatever is running now would let a stale seed bit hand it the PREVIOUS
 	// turn's answer.
+	//
+	// The same condition decides whether this delivery needs an IDENTITY: only a
+	// request that injects into a running loop has a self-exclusion problem to
+	// solve, and only for it does the runner have to tell gmux's text from a
+	// human's. A plain prompt (and a follow-up to an idle agent) starts its own
+	// turn, so its text is that turn's trigger, not an injection into anyone's
+	// wait.
 	var observedSeq uint64
+	var watch injectionWatch
+	deliveryID := ""
 	if baselineActive && req.Mode != modePrompt {
-		observedSeq = deps.turnFrame(sid).CurrentTurnSeq()
+		frame := deps.turnFrame(sid)
+		observedSeq = frame.CurrentTurnSeq()
+		if observedSeq != 0 {
+			deliveryID = deps.deliveryID()
+			// Injections already on the turn predate this request and are not its
+			// business; only what enters the loop from here on can supersede it.
+			watch = injectionWatch{turnSeq: observedSeq, baseline: baselineInjections(frame, observedSeq), deliveryID: deliveryID}
+		}
 	}
 	spec := agentWaitSpec{
 		baselineActive: baselineActive,
@@ -493,6 +528,7 @@ func handleAgentPromptCentral(w http.ResponseWriter, r *http.Request, deps agent
 		execution:         req.ExecTimeout,
 		generation:        deliveredGen,
 		observedSeq:       observedSeq,
+		watch:             watch,
 		frame:             func() *sessioncoord.TurnFrame { return deps.turnFrame(sid) },
 		generationLost:    func() bool { return deps.generationLost(sid, deliveredGen) },
 	}
@@ -501,7 +537,7 @@ func handleAgentPromptCentral(w http.ResponseWriter, r *http.Request, deps agent
 	// ctx-only would let a wedged PTY write park this request for as long as
 	// the client tolerates.
 	dctx, releaseDelivery := context.WithTimeout(r.Context(), deps.delivery())
-	err = deps.sendPrompt(dctx, runtime.Endpoint, runtime.Incarnation, req.Prompt, delivery, require)
+	err = deps.sendPrompt(dctx, runtime.Endpoint, runtime.Incarnation, req.Prompt, delivery, require, deliveryID)
 	releaseDelivery()
 	if err != nil {
 		writeAgentDeliveryError(w, r, dctx, opPrompt, err)
@@ -635,6 +671,17 @@ func finishAgentAction(w http.ResponseWriter, r *http.Request, outcomes <-chan s
 	if res.Cause != "" {
 		data["cause"] = res.Cause
 	}
+	// The report fields, rendered by the CLI from RELAYED TURN FACTS only (ADR
+	// 0027, "Output routing"): the trigger excerpt names what the turn was asked
+	// to do, and steered_by carries the message that changed it. Absent rather
+	// than empty, so "no trigger was asserted" and "the trigger was blank" stay
+	// distinguishable.
+	if res.Trigger != "" {
+		data["trigger"] = res.Trigger
+	}
+	if res.SteeredBy != "" {
+		data["steered_by"] = res.SteeredBy
+	}
 	// A completed turn carries the answer the ADAPTER asserted for exactly this
 	// turn (res.Close is nil unless the settled frame's turn_seq matched the turn
 	// this request observed). Any other outcome carries no output: an interrupted
@@ -674,6 +721,11 @@ type agentWaitSpec struct {
 	// (a steer, a merged follow-up); otherwise it is learned at the turn-start
 	// edge. 0 means "no turn of ours is identified", which serves no result.
 	observedSeq uint64
+	// watch is this wait's injection watch on the turn it is bound to (see
+	// steer_watch.go). It is pre-armed for a request that injected into a running
+	// loop — carrying that request's delivery identity, so its own steer does not
+	// interrupt it — and armed at the turn-start edge otherwise.
+	watch injectionWatch
 	// frame reads the retained turn frame. It is the fallback for a resolution
 	// whose outcome carried no frame (a coalesced publish, a seeded look); nil
 	// makes every close result-free.
@@ -690,6 +742,13 @@ type agentWaitResult struct {
 	Admission string
 	Outcome   string
 	Cause     string
+	// Trigger is the excerpt of what started the turn this wait observed, from
+	// the runner-asserted frame. It is the report's "what was this turn asked to
+	// do", and it is never re-read from the conversation.
+	Trigger string
+	// SteeredBy is the injected excerpt that resolved this wait early, for
+	// Outcome steered.
+	SteeredBy string
 	// Close is the adapter's asserted record for the turn this wait observed,
 	// or nil when no matching settled frame was available (a non-asserting
 	// adapter, a raw PUT /status close, a version-skewed runner, or two
@@ -745,6 +804,7 @@ func runAgentWait(ctx context.Context, outcomes <-chan sessioncoord.Outcome, ses
 	active := spec.baselineActive
 	sawActive := active
 	observedSeq := spec.observedSeq
+	watch := spec.watch
 	// frameFor prefers the frame stamped on the resolving outcome (retained at
 	// apply time for the generation that published it) and falls back to the
 	// registry read for a resolution that carried none.
@@ -825,6 +885,17 @@ func runAgentWait(ctx context.Context, outcomes <-chan sessioncoord.Outcome, ses
 				}
 				return res
 			}
+			// An injection into the turn this wait is bound to resolves it early:
+			// the answer it was promised is not the answer the loop will now give
+			// (ADR 0027, "Steering interrupts waits"). Checked before the Upserted
+			// filter because an injection writes no row — it arrives as a transient
+			// frame signal, with no session attached.
+			if v := watch.check(frameFor(o)); v.Steered {
+				return agentWaitResult{
+					Admission: res.Admission, Outcome: outcomeSteered, Cause: v.Cause,
+					SteeredBy: v.Text, Trigger: frameFor(o).CurrentTurn(watch.turnSeq).TriggerExcerpt(),
+				}
+			}
 			if o.Type != sessioncoord.OutcomeUpserted || o.Session == nil {
 				continue
 			}
@@ -841,6 +912,12 @@ func runAgentWait(ctx context.Context, outcomes <-chan sessioncoord.Outcome, ses
 				// no turn until this edge.
 				if seq := frameFor(o).CurrentTurnSeq(); seq != 0 {
 					observedSeq = seq
+					// A turn this request STARTED carries no injections yet, and
+					// this request injected nothing into it: every injection from
+					// here on is somebody else's and interrupts this wait.
+					if watch.turnSeq == 0 {
+						watch = injectionWatch{turnSeq: seq}
+					}
 				}
 				if !admitted {
 					admitted = true
@@ -869,6 +946,18 @@ func runAgentWait(ctx context.Context, outcomes <-chan sessioncoord.Outcome, ses
 			// (classifyTurnClose) so the two paths cannot drift.
 			res.Outcome = classifyTurnClose(row.Error, row.Interrupted)
 			res.Close = frameFor(o).ClosedTurn(observedSeq)
+			res.Trigger = res.Close.TriggerExcerpt()
+			// The close carries the turn's whole injection list, so a steer whose
+			// transient signal never arrived (or arrived in this same look) is still
+			// caught here rather than answered with the merged result — and an
+			// injector whose own text the loop never acknowledged is told so instead
+			// of being handed the pre-injection answer.
+			if outcome, cause, text := watch.closeVerdict(res.Close); outcome != "" {
+				return agentWaitResult{
+					Admission: res.Admission, Outcome: outcome, Cause: cause,
+					SteeredBy: text, Trigger: res.Trigger,
+				}
+			}
 			return res
 		}
 	}

--- a/services/gmuxd/cmd/gmuxd/agent_actions_test.go
+++ b/services/gmuxd/cmd/gmuxd/agent_actions_test.go
@@ -55,7 +55,7 @@ type fakeTimer struct {
 
 func (t *fakeTimer) fire() { t.ch <- time.Now() }
 
-type promptCall struct{ endpoint, incarnation, prompt, delivery, require string }
+type promptCall struct{ endpoint, incarnation, prompt, delivery, require, deliveryID string }
 
 type agentHarness struct {
 	store    *centralstore.Store
@@ -126,9 +126,13 @@ func (h *agentHarness) currentLive(id centralstore.SessionID) (sessioncoord.Runt
 // and harnessIncarnation the identity of the runner process behind it. Every
 // semantic call is conditional on the latter, so a runtime a test hands the
 // handler must carry one or delivery is refused before it starts.
+// harnessDeliveryID is the identity the harness mints for a delivery into a
+// running turn, so a test can express "the adapter acknowledged THIS request's
+// injection" (steer self-exclusion) deterministically.
 const (
 	harnessGeneration  = uint64(7)
 	harnessIncarnation = "inc-A"
+	harnessDeliveryID  = "d-1"
 )
 
 func newAgentHarness(t *testing.T, rows ...centralstore.NewSession) *agentHarness {
@@ -264,6 +268,16 @@ func (h *agentHarness) closeTurn(seq uint64, outcome, output string) {
 	}})
 }
 
+// mergedClose is the settled frame of a turn that took THIS harness's injection
+// and then closed: the shape a steer or a merged follow-up must see before it may
+// claim the close as its own result.
+func mergedClose(seq uint64, outcome, output string) *sessioncoord.TurnFrame {
+	return &sessioncoord.TurnFrame{Seq: seq + 100, Last: &sessioncoord.TurnClose{
+		TurnSeq: seq, Outcome: outcome, Output: output,
+		Injections: []sessioncoord.TurnInjection{{Text: "injected", DeliveryID: harnessDeliveryID}},
+	}}
+}
+
 // seedActive overrides this session's seeded status without touching the store,
 // which is how a test expresses "the seed disagrees with the store read".
 func (h *agentHarness) seedStatus(id string, o sessioncoord.Outcome) {
@@ -302,7 +316,7 @@ func (h *agentHarness) deps() agentDeps {
 			h.setLive(func(centralstore.SessionID) (sessioncoord.Runtime, bool) { return rt, true })
 			return rt, nil
 		},
-		sendPrompt: func(ctx context.Context, endpoint, incarnation, prompt, delivery, require string) error {
+		sendPrompt: func(ctx context.Context, endpoint, incarnation, prompt, delivery, require, deliveryID string) error {
 			if err := h.checkOwner(endpoint, incarnation); err != nil {
 				return err
 			}
@@ -314,7 +328,7 @@ func (h *agentHarness) deps() agentDeps {
 				// the window; it is a bug, not a slower path.
 				return errors.New("harness: prompt delivered before any subscription existed")
 			}
-			h.prompts <- promptCall{endpoint, incarnation, prompt, delivery, require}
+			h.prompts <- promptCall{endpoint, incarnation, prompt, delivery, require, deliveryID}
 			if h.onPrompt != nil {
 				h.onPrompt()
 			}
@@ -340,6 +354,7 @@ func (h *agentHarness) deps() agentDeps {
 			h.timers <- tm
 			return tm.ch
 		},
+		newDeliveryID: func() string { return harnessDeliveryID },
 		frame: func(id centralstore.SessionID) *sessioncoord.TurnFrame {
 			h.frameReads.Add(1)
 			h.mu.Lock()
@@ -1088,7 +1103,11 @@ func TestFollowUpResolvesOnTheMergedClose(t *testing.T) {
 		h.openTurn(9, "first ask") // the loop the follow-up will merge into
 		get := runPromptAsync(t, h, promptBodyJSON(t, map[string]any{"prompt": "and then", "mode": modeFollowUp}))
 		<-h.prompts
-		h.closeTurn(9, outcomeCompleted, "merged answer")
+		// The adapter acknowledges that this follow-up's text entered the running
+		// loop, which is what entitles it to the merged close (ADR 0027's steer
+		// self-exclusion; without the acknowledgement the close might predate the
+		// injection and is reported indeterminate).
+		h.setFrame(mergedClose(9, outcomeCompleted, "merged answer"))
 		h.publish(statusOutcome("s", false, false, false))
 		got := get()
 		if got.data()["outcome"] != outcomeCompleted || got.data()["output"] != "merged answer" {
@@ -1100,7 +1119,7 @@ func TestFollowUpResolvesOnTheMergedClose(t *testing.T) {
 		h.openTurn(9, "first ask")
 		get := runPromptAsync(t, h, promptBodyJSON(t, map[string]any{"prompt": "and then", "mode": modeFollowUp}))
 		<-h.prompts
-		h.closeTurn(9, outcomeError, "")
+		h.setFrame(mergedClose(9, outcomeError, ""))
 		h.publish(statusOutcome("s", false, true, false))
 		got := get()
 		if got.data()["outcome"] != outcomeError {

--- a/services/gmuxd/cmd/gmuxd/serve_central.go
+++ b/services/gmuxd/cmd/gmuxd/serve_central.go
@@ -1446,6 +1446,14 @@ func handleWaitCentral(w http.ResponseWriter, r *http.Request, boot *Bootstrap, 
 	// answer it cannot attribute, and `gmux agent status` remains the snapshot
 	// read for those.
 	var observedSeq uint64
+	// watch is the injection watch on that same turn: a user message entering the
+	// loop this wait is bound to resolves it early with reason `steered`, because
+	// the answer it is waiting for no longer answers what it waited for (ADR 0027,
+	// "Steering interrupts waits"). A bare `gmux wait` injects nothing, so it
+	// carries no delivery identity and every injection is somebody else's — while
+	// injections that PREDATE the wait are part of the turn it chose to wait on,
+	// which is what the baseline records.
+	var watch injectionWatch
 	active := false
 	// frameFor prefers a frame stamped on the resolving outcome (retained at apply
 	// time for the generation that published it) and falls back to the frame
@@ -1463,8 +1471,10 @@ func handleWaitCentral(w http.ResponseWriter, r *http.Request, boot *Bootstrap, 
 			return
 		}
 		if s.Status.Active && !active {
-			if seq := frameFor(o).CurrentTurnSeq(); seq != 0 {
+			frame := frameFor(o)
+			if seq := frame.CurrentTurnSeq(); seq != 0 {
 				observedSeq = seq
+				watch = injectionWatch{turnSeq: seq, baseline: baselineInjections(frame, seq)}
 			}
 		}
 		active = s.Status.Active
@@ -1472,12 +1482,25 @@ func handleWaitCentral(w http.ResponseWriter, r *http.Request, boot *Bootstrap, 
 	closedTurn := func(o *sessioncoord.Outcome) *sessioncoord.TurnClose {
 		return frameFor(o).ClosedTurn(observedSeq)
 	}
+	// steered answers the wait early when the frame shows a foreign injection on
+	// the bound turn. Written once and used from all three observation paths (the
+	// initial look, the outcome stream, the ticker) so none of them can grow a
+	// different idea of what a steer means.
+	steered := func(o *sessioncoord.Outcome) bool {
+		frame := frameFor(o)
+		v := watch.check(frame)
+		if !v.Steered {
+			return false
+		}
+		writeSteeredWait(w, frame.CurrentTurn(watch.turnSeq).TriggerExcerpt(), v.Text, v.Cause)
+		return true
+	}
 	if cur, ok := visibleSession(fanout.Current().Sessions, sessionID); ok {
 		legacy := legacySessionFromWire(cur)
 		seenAlive = seenAlive || cur.Alive
 		observe(legacy, nil)
 		if verdict, done := terminalReason(legacy, seenAlive); done {
-			writeWaitConclusion(w, r, boot, sessionID, verdict, closedTurn(nil))
+			writeWaitConclusion(w, r, boot, sessionID, verdict, closedTurn(nil), watch)
 			return
 		}
 	}
@@ -1496,34 +1519,69 @@ func handleWaitCentral(w http.ResponseWriter, r *http.Request, boot *Bootstrap, 
 			}
 			if outcome.Type == sessioncoord.OutcomeRemoved {
 				// A death carries no result by contract, so no frame is consulted.
-				writeWaitConclusion(w, r, boot, sessionID, diedConclusion(), nil)
+				writeWaitConclusion(w, r, boot, sessionID, diedConclusion(), nil, injectionWatch{})
 				return
 			}
 			if outcome.Type != sessioncoord.OutcomeUpserted || outcome.Session == nil {
+				// An injection changes no row, so it arrives as a transient
+				// frame-bearing signal with no session attached. It can still end
+				// this wait.
+				if steered(&outcome) {
+					return
+				}
 				continue
 			}
 			legacy := legacySessionFromOutcome(*outcome.Session, outcome.Alive)
 			seenAlive = seenAlive || outcome.Alive
 			observe(legacy, &outcome)
+			if steered(&outcome) {
+				return
+			}
 			if verdict, done := terminalReason(legacy, seenAlive); done {
-				writeWaitConclusion(w, r, boot, sessionID, verdict, closedTurn(&outcome))
+				writeWaitConclusion(w, r, boot, sessionID, verdict, closedTurn(&outcome), watch)
 				return
 			}
 		case <-ticker.C:
 			cur, ok := visibleSession(fanout.Current().Sessions, sessionID)
 			if !ok {
-				writeWaitConclusion(w, r, boot, sessionID, diedConclusion(), nil)
+				writeWaitConclusion(w, r, boot, sessionID, diedConclusion(), nil, injectionWatch{})
 				return
 			}
 			legacy := legacySessionFromWire(cur)
 			seenAlive = seenAlive || cur.Alive
 			observe(legacy, nil)
+			// The ticker re-reads the RETAINED frame, which is what makes a steer
+			// observable even when its transient signal was dropped under backlog.
+			if steered(nil) {
+				return
+			}
 			if verdict, done := terminalReason(legacy, seenAlive); done {
-				writeWaitConclusion(w, r, boot, sessionID, verdict, closedTurn(nil))
+				writeWaitConclusion(w, r, boot, sessionID, verdict, closedTurn(nil), watch)
 				return
 			}
 		}
 	}
+}
+
+// writeSteeredWait answers a wait that a user message resolved early.
+//
+// It is deliberately a 200 with its own reason word rather than an error: the
+// wait was answered, correctly, with the one fact the caller needs — the turn it
+// was waiting on is not the turn that will answer. The turn itself keeps running
+// and re-arming is one command away, which is why nothing here suggests the
+// session is in trouble.
+func writeSteeredWait(w http.ResponseWriter, trigger, injected, cause string) {
+	data := map[string]any{"reason": outcomeSteered, "outcome": outcomeSteered}
+	if cause != "" {
+		data["cause"] = cause
+	}
+	if trigger != "" {
+		data["trigger"] = trigger
+	}
+	if injected != "" {
+		data["steered_by"] = injected
+	}
+	writeJSON(w, map[string]any{"ok": true, "data": data})
 }
 
 // writeWaitConclusion answers a resolved turn wait, attaching the turn's
@@ -1563,8 +1621,22 @@ var retainedTurnFrame = func(boot *Bootstrap, sessionID string) *sessioncoord.Tu
 	return boot.Registry.Frame(centralstore.SessionID(sessionID))
 }
 
-func writeWaitConclusion(w http.ResponseWriter, r *http.Request, boot *Bootstrap, sessionID string, verdict waitConclusion, close *sessioncoord.TurnClose) {
+func writeWaitConclusion(w http.ResponseWriter, r *http.Request, boot *Bootstrap, sessionID string, verdict waitConclusion, close *sessioncoord.TurnClose, watch injectionWatch) {
+	// The settled record carries the turn's whole injection list, so a steer this
+	// wait never saw live (a dropped transient signal, or one that arrived in the
+	// same look as the close) is still caught here: the merged answer does not
+	// answer what this wait asked, whenever gmux found out.
+	if outcome, cause, text := watch.closeVerdict(close); outcome == outcomeSteered {
+		writeSteeredWait(w, close.TriggerExcerpt(), text, cause)
+		return
+	}
 	data := map[string]any{"reason": verdict.Reason}
+	// The trigger excerpt travels with every turn conclusion so a non-completed
+	// resolution's stderr report can name what the turn was asked to do — from
+	// relayed facts, never a fresh conversation read.
+	if t := close.TriggerExcerpt(); t != "" {
+		data["trigger"] = t
+	}
 	if verdict.Outcome != "" {
 		data["outcome"] = verdict.Outcome
 		if boot != nil {
@@ -1697,7 +1769,7 @@ func handleInputWaitCentral(w http.ResponseWriter, r *http.Request, boot *Bootst
 		// without it an intentionally interrupted turn would exit 0 through the
 		// composition the docs call preferred, while `gmux wait` exits 2. Passing
 		// no close record is what keeps it result-free.
-		writeWaitConclusion(w, r, boot, sessionID, verdict, nil)
+		writeWaitConclusion(w, r, boot, sessionID, verdict, nil, injectionWatch{})
 	}
 }
 

--- a/services/gmuxd/cmd/gmuxd/steer_wait_test.go
+++ b/services/gmuxd/cmd/gmuxd/steer_wait_test.go
@@ -1,0 +1,383 @@
+package main
+
+// steer_wait_test.go pins ADR 0027's "Steering interrupts waits" at the daemon
+// boundary: an injection into an active turn resolves every OTHER armed wait
+// early, the injecting request is excluded by delivery identity but only while
+// its message is the loop's last, and an injection the loop never acknowledged
+// makes the injector's own result indeterminate rather than the pre-injection
+// answer.
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/centralstore"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/sessioncoord"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/snapshot/wire"
+)
+
+// injected is the frame shape of a turn that is running and has taken user
+// messages since it started.
+func injectedFrame(seq uint64, trigger string, injections ...sessioncoord.TurnInjection) *sessioncoord.TurnFrame {
+	return &sessioncoord.TurnFrame{Seq: seq, Current: &sessioncoord.TurnCurrent{
+		TurnSeq: seq, Trigger: trigger, Injections: injections,
+		// The runner's monotonic counter, which is what novelty is decided
+		// against; here it happens to equal the retained list's length because
+		// these turns are nowhere near the list's bound.
+		InjectionCount: uint64(len(injections)),
+	}}
+}
+
+// injectionSignal is how an injection reaches a waiter in production: a
+// transient, frame-bearing outcome with no session row attached, because an
+// injection changes no row.
+func injectionSignal(id string, frame *sessioncoord.TurnFrame) sessioncoord.Outcome {
+	return sessioncoord.Outcome{
+		Type: sessioncoord.OutcomeActivity, ID: centralstore.SessionID(id), Alive: true,
+		Generation: harnessGeneration, Frame: frame,
+	}
+}
+
+// ── the unit rule ───────────────────────────────────────────────────────────
+
+func TestInjectionWatchRules(t *testing.T) {
+	mine := sessioncoord.TurnInjection{Text: "actually, do X", DeliveryID: "d-1"}
+	theirs := sessioncoord.TurnInjection{Text: "no, do Y", DeliveryID: "d-2"}
+	human := sessioncoord.TurnInjection{Text: "stop, I'll drive"}
+	for _, tc := range []struct {
+		name       string
+		watch      injectionWatch
+		injections []sessioncoord.TurnInjection
+		want       steerVerdict
+	}{
+		{
+			name:       "a bystander is interrupted by any injection",
+			watch:      injectionWatch{turnSeq: 5},
+			injections: []sessioncoord.TurnInjection{mine},
+			want:       steerVerdict{Steered: true, Text: mine.Text},
+		},
+		{
+			name:       "a human injection interrupts every waiter",
+			watch:      injectionWatch{turnSeq: 5},
+			injections: []sessioncoord.TurnInjection{human},
+			want:       steerVerdict{Steered: true, Text: human.Text},
+		},
+		{
+			name:       "the injector is not interrupted by its own message",
+			watch:      injectionWatch{turnSeq: 5, deliveryID: "d-1"},
+			injections: []sessioncoord.TurnInjection{mine},
+			want:       steerVerdict{},
+		},
+		{
+			name:       "a later injection supersedes the earlier injector",
+			watch:      injectionWatch{turnSeq: 5, deliveryID: "d-1"},
+			injections: []sessioncoord.TurnInjection{mine, theirs},
+			want:       steerVerdict{Steered: true, Text: theirs.Text, Cause: causeSteeredAgain},
+		},
+		{
+			name:       "a human superseding the injector is still steered_again",
+			watch:      injectionWatch{turnSeq: 5, deliveryID: "d-1"},
+			injections: []sessioncoord.TurnInjection{mine, human},
+			want:       steerVerdict{Steered: true, Text: human.Text, Cause: causeSteeredAgain},
+		},
+		{
+			name:       "a foreign injection before our own ack still interrupts",
+			watch:      injectionWatch{turnSeq: 5, deliveryID: "d-1"},
+			injections: []sessioncoord.TurnInjection{human},
+			want:       steerVerdict{Steered: true, Text: human.Text},
+		},
+		{
+			name:       "injections that predate the wait are part of the turn it chose",
+			watch:      injectionWatch{turnSeq: 5, baseline: 1},
+			injections: []sessioncoord.TurnInjection{human},
+			want:       steerVerdict{},
+		},
+		{
+			name:       "an injection on a DIFFERENT turn is somebody else's business",
+			watch:      injectionWatch{turnSeq: 9},
+			injections: []sessioncoord.TurnInjection{human},
+			want:       steerVerdict{},
+		},
+		{
+			name:  "a wait that identified no turn watches nothing",
+			watch: injectionWatch{},
+			// An empty delivery id must never match a human's id-less injection.
+			injections: []sessioncoord.TurnInjection{human},
+			want:       steerVerdict{},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			frame := injectedFrame(5, "go", tc.injections...)
+			if got := tc.watch.check(frame); got != tc.want {
+				t.Fatalf("check=%+v want %+v", got, tc.want)
+			}
+			// The same rule must hold over the settled record: a waiter that
+			// learns of the steer only at the close may not be handed the merged
+			// answer either.
+			close := &sessioncoord.TurnClose{TurnSeq: 5, Outcome: outcomeCompleted, Trigger: "go", Injections: tc.injections}
+			if got := tc.watch.checkClose(close); got != tc.want {
+				t.Fatalf("checkClose=%+v want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+// The saturation case both anchors found: once the frame's bounded injection
+// list stops growing, novelty must still be visible. Deciding it from the list's
+// LENGTH made every later injection invisible to a wait that armed on a
+// heavily-steered turn, and that wait was then served the merged answer under
+// exit 0 — the inversion the rule exists to prevent.
+func TestSaturatedInjectionListStillInterrupts(t *testing.T) {
+	// A turn that has taken 64 injections; the list is capped there and its
+	// length can never grow again.
+	const cap = 64
+	list := make([]sessioncoord.TurnInjection, cap)
+	for i := range list {
+		list[i] = sessioncoord.TurnInjection{Text: "old steer"}
+	}
+	w := injectionWatch{turnSeq: 5, baseline: cap}
+
+	// Another injection arrives: the list evicts its oldest and stays at 64,
+	// while the runner's monotonic counter advances.
+	list[cap-1] = sessioncoord.TurnInjection{Text: "NEW STEER"}
+	frame := &sessioncoord.TurnFrame{Seq: 2, Current: &sessioncoord.TurnCurrent{
+		TurnSeq: 5, Trigger: "go", Injections: list, InjectionCount: cap + 1,
+	}}
+	if v := w.check(frame); !v.Steered || v.Text != "NEW STEER" {
+		t.Fatalf("a saturated list hid a new injection: %+v", v)
+	}
+	// Same at the close, which is the backstop for a missed live signal.
+	closed := &sessioncoord.TurnClose{
+		TurnSeq: 5, Outcome: outcomeCompleted, Output: "merged answer",
+		Injections: list, InjectionCount: cap + 1,
+	}
+	if v := w.checkClose(closed); !v.Steered {
+		t.Fatalf("a saturated list hid a new injection at the close: %+v", v)
+	}
+	// And nothing new still means nothing new.
+	quiet := &sessioncoord.TurnFrame{Seq: 3, Current: &sessioncoord.TurnCurrent{
+		TurnSeq: 5, Trigger: "go", Injections: list, InjectionCount: cap,
+	}}
+	if v := w.check(quiet); v.Steered {
+		t.Fatalf("the baseline injections interrupted the wait: %+v", v)
+	}
+}
+
+// A runner that predates the counter reports none, and novelty then falls back
+// to the retained list. Reading a missing counter as zero would make every
+// injection invisible on that runner — strictly worse than the bounded list.
+func TestMissingInjectionCountFallsBackToTheList(t *testing.T) {
+	w := injectionWatch{turnSeq: 5, baseline: baselineInjections(&sessioncoord.TurnFrame{
+		Current: &sessioncoord.TurnCurrent{TurnSeq: 5, Injections: []sessioncoord.TurnInjection{{Text: "already there"}}},
+	}, 5)}
+	if w.baseline != 1 {
+		t.Fatalf("baseline=%d from a counter-less frame", w.baseline)
+	}
+	frame := &sessioncoord.TurnFrame{Current: &sessioncoord.TurnCurrent{TurnSeq: 5, Injections: []sessioncoord.TurnInjection{
+		{Text: "already there"}, {Text: "new one"},
+	}}}
+	if v := w.check(frame); !v.Steered || v.Text != "new one" {
+		t.Fatalf("counter-less frame lost its novelty: %+v", v)
+	}
+}
+
+// The settle-before-ack race, which is the one case where the injector's result
+// is neither the answer nor a steer: pi may have closed the loop without ever
+// consuming the delivered text.
+func TestUnacknowledgedInjectionIsIndeterminate(t *testing.T) {
+	w := injectionWatch{turnSeq: 5, deliveryID: "d-1"}
+	close := &sessioncoord.TurnClose{TurnSeq: 5, Outcome: outcomeCompleted, Output: "pre-steer answer"}
+	outcome, cause, _ := w.closeVerdict(close)
+	if outcome != outcomeIndeterminate || cause != causeInjectionUnacknowledged {
+		t.Fatalf("outcome=%q cause=%q; the pre-injection answer must never be served as the injector's", outcome, cause)
+	}
+	// A non-injecting wait on the very same close is served normally.
+	if outcome, _, _ := (injectionWatch{turnSeq: 5}).closeVerdict(close); outcome != "" {
+		t.Fatalf("a bystander's ordinary completion was replaced by %q", outcome)
+	}
+}
+
+// ── the generic wait ────────────────────────────────────────────────────────
+
+// A `gmux wait` armed on a running turn resolves as soon as somebody steers it:
+// the turn keeps running, but its answer no longer answers what this wait asked.
+func TestGenericWaitResolvesOnAForeignSteer(t *testing.T) {
+	f := newWaitFixture(t)
+	f.register(t, "s", "pi", piResultLines...)
+	f.openTurn(7, "run the tests")
+	// The turn NEVER closes here: a steer resolves the wait while the turn keeps
+	// running, which is the whole point of the rule.
+	data := runGenericWait(t, f, func() {
+		// A human grabbed the wheel. The ticker re-reads the retained frame, so
+		// no event is needed for this to be observed.
+		f.setFrame(injectedFrame(7, "run the tests", sessioncoord.TurnInjection{Text: "stop, fix the lint first"}))
+	})
+	if data["reason"] != outcomeSteered || data["outcome"] != outcomeSteered {
+		t.Fatalf("data=%v", data)
+	}
+	if data["steered_by"] != "stop, fix the lint first" || data["trigger"] != "run the tests" {
+		t.Fatalf("the report lost its facts: %v", data)
+	}
+	if _, ok := data["output"]; ok {
+		t.Fatalf("a steered wait must carry no answer: %v", data)
+	}
+}
+
+// An injection that was already on the turn when the wait armed is part of the
+// turn it chose to wait on, so it resolves normally and carries the answer — and
+// the trigger excerpt rides the conclusion, which is what lets the CLI report a
+// non-completed resolution without reading the tape.
+func TestGenericWaitIgnoresInjectionsItArmedOn(t *testing.T) {
+	f := newWaitFixture(t)
+	f.register(t, "s", "pi", piResultLines...)
+	f.setFrame(injectedFrame(7, "run the tests", sessioncoord.TurnInjection{Text: "also check the docs"}))
+	data := runGenericWait(t, f, func() {
+		f.setFrame(&sessioncoord.TurnFrame{Seq: 99, Last: &sessioncoord.TurnClose{
+			TurnSeq: 7, Outcome: outcomeCompleted, Trigger: "run the tests", Output: "All green.",
+			Injections: []sessioncoord.TurnInjection{{Text: "also check the docs"}},
+		}})
+	})
+	if data["outcome"] != outcomeCompleted || data["output"] != "All green." {
+		t.Fatalf("data=%v", data)
+	}
+	if data["trigger"] != "run the tests" {
+		t.Fatalf("the conclusion lost the trigger excerpt a report needs: %v", data)
+	}
+}
+
+// runGenericWait arms handleWaitCentral on a session that is active, runs settle
+// once the wait has observed the open turn, and returns the resolved payload.
+// The fanout's active→inactive flip is what closes the turn, so a test that only
+// changes the frame (a steer) simply does not call it.
+func runGenericWait(t *testing.T, f *waitFixture, settle func()) map[string]any {
+	t.Helper()
+	fan := wf(wire.Session{ID: "s", Alive: true, Status: &wire.Status{Active: true}})
+	rec := httptest.NewRecorder()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		handleWaitCentral(rec, httptest.NewRequest(http.MethodPost, "/wait?timeout=5", nil),
+			f.boot, fan, "s", func(string) string { return f.dir })
+	}()
+	waitForLook(t, f)
+	settle()
+	fan.BroadcastFrames(wire.Frames{Sessions: &wire.SessionsPayload{
+		Sessions: []wire.Session{{ID: "s", Alive: true, Status: &wire.Status{Active: false}}},
+	}})
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("wait did not resolve")
+	}
+	return decodeWaitData(t, rec)
+}
+
+// ── the synchronous prompt ──────────────────────────────────────────────────
+
+// A sync prompt waiting on a turn somebody else steers is interrupted like any
+// other waiter, and told what went in.
+func TestSyncPromptInterruptedByAForeignSteer(t *testing.T) {
+	h := newAgentHarness(t, liveRow("s", false))
+	get := runPromptAsync(t, h, promptBodyJSON(t, map[string]any{"prompt": "what is 2+2?", "mode": modePrompt}))
+	<-h.prompts
+	h.nextTimer(t)
+	h.openTurn(3, "what is 2+2?")
+	h.publish(statusOutcome("s", true, false, false))
+	steered := injectedFrame(3, "what is 2+2?", sessioncoord.TurnInjection{Text: "never mind, do Y"})
+	h.setFrame(steered)
+	h.publish(injectionSignal("s", steered))
+	got := get()
+	if got.code != http.StatusOK {
+		t.Fatalf("status=%d body=%v", got.code, got.body)
+	}
+	if got.data()["outcome"] != outcomeSteered || got.data()["steered_by"] != "never mind, do Y" {
+		t.Fatalf("body=%v", got.body)
+	}
+	if _, ok := got.data()["output"]; ok {
+		t.Fatalf("a steered prompt must carry no answer: %v", got.body)
+	}
+}
+
+// The steerer's own sync wait is excluded: its delivery id is on the injection,
+// so the merged close is its result.
+func TestSteererClaimsTheMergedClose(t *testing.T) {
+	h := newAgentHarness(t, liveRow("s", true))
+	h.openTurn(5, "go")
+	get := runPromptAsync(t, h, promptBodyJSON(t, map[string]any{"prompt": "use the other API", "mode": modeSteer}))
+	call := <-h.prompts
+	if call.deliveryID != harnessDeliveryID {
+		t.Fatalf("a steer must carry a delivery identity, got %q", call.deliveryID)
+	}
+	// The adapter acknowledges the injection, then the merged loop settles.
+	acked := injectedFrame(5, "go", sessioncoord.TurnInjection{Text: "use the other API", DeliveryID: harnessDeliveryID})
+	h.setFrame(acked)
+	h.publish(injectionSignal("s", acked))
+	h.setFrame(&sessioncoord.TurnFrame{Seq: 90, Last: &sessioncoord.TurnClose{
+		TurnSeq: 5, Outcome: outcomeCompleted, Trigger: "go", Output: "used the other API",
+		Injections: []sessioncoord.TurnInjection{{Text: "use the other API", DeliveryID: harnessDeliveryID}},
+	}})
+	h.publish(statusOutcome("s", false, false, false))
+	got := get()
+	if got.data()["outcome"] != outcomeCompleted || got.data()["output"] != "used the other API" {
+		t.Fatalf("the steerer lost the close it caused: %v", got.body)
+	}
+}
+
+// ...but only while its message is the LAST injection: a later one supersedes it
+// and it is interrupted like everybody else.
+func TestSupersededSteererIsInterrupted(t *testing.T) {
+	h := newAgentHarness(t, liveRow("s", true))
+	h.openTurn(5, "go")
+	get := runPromptAsync(t, h, promptBodyJSON(t, map[string]any{"prompt": "use the other API", "mode": modeSteer}))
+	<-h.prompts
+	frame := injectedFrame(5, "go",
+		sessioncoord.TurnInjection{Text: "use the other API", DeliveryID: harnessDeliveryID},
+		sessioncoord.TurnInjection{Text: "no, revert it"})
+	h.setFrame(frame)
+	h.publish(injectionSignal("s", frame))
+	got := get()
+	if got.data()["outcome"] != outcomeSteered || got.data()["cause"] != causeSteeredAgain {
+		t.Fatalf("body=%v", got.body)
+	}
+	if got.data()["steered_by"] != "no, revert it" {
+		t.Fatalf("body=%v", got.body)
+	}
+}
+
+// A steer whose text the loop never acknowledged before settling is
+// INDETERMINATE: the pre-injection answer is not this request's result, and
+// exit 0 for it would be the exact lie this design exists to prevent.
+func TestUnacknowledgedSteerReportsIndeterminate(t *testing.T) {
+	h := newAgentHarness(t, liveRow("s", true))
+	h.openTurn(5, "go")
+	get := runPromptAsync(t, h, promptBodyJSON(t, map[string]any{"prompt": "use the other API", "mode": modeSteer}))
+	<-h.prompts
+	h.setFrame(&sessioncoord.TurnFrame{Seq: 90, Last: &sessioncoord.TurnClose{
+		TurnSeq: 5, Outcome: outcomeCompleted, Trigger: "go", Output: "pre-steer answer",
+	}})
+	h.publish(statusOutcome("s", false, false, false))
+	got := get()
+	if got.data()["outcome"] != outcomeIndeterminate || got.data()["cause"] != causeInjectionUnacknowledged {
+		t.Fatalf("body=%v", got.body)
+	}
+	if _, ok := got.data()["output"]; ok {
+		t.Fatalf("an unacknowledged steer was handed the pre-injection answer: %v", got.body)
+	}
+}
+
+// A plain prompt starts its own turn, so it needs no delivery identity: nothing
+// of its text is an injection into anybody's wait.
+func TestPlainPromptCarriesNoDeliveryIdentity(t *testing.T) {
+	h := newAgentHarness(t, liveRow("s", false))
+	get := runPromptAsync(t, h, promptBodyJSON(t, map[string]any{"prompt": "hi", "mode": modePrompt, "wait": false}))
+	call := <-h.prompts
+	if call.deliveryID != "" {
+		t.Fatalf("a plain prompt sent a delivery id (%q); the runner would arm a correlation window for a turn nobody is joining", call.deliveryID)
+	}
+	h.nextTimer(t)
+	h.openTurn(1, "hi")
+	h.publish(statusOutcome("s", true, false, false))
+	get()
+}

--- a/services/gmuxd/cmd/gmuxd/steer_watch.go
+++ b/services/gmuxd/cmd/gmuxd/steer_watch.go
@@ -1,0 +1,260 @@
+package main
+
+// steer_watch.go — "a user message injected into an active turn resolves every
+// OTHER armed wait on that session early" (ADR 0027, "Steering interrupts
+// waits").
+//
+// The rule exists because an injection changes the CONTRACT of the pending
+// answer: the turn a waiter armed on was asked to do one thing, and after a
+// steer (or a follow-up the agent merged into the same loop, or a human typing
+// into the TUI) its answer speaks to something else. Serving that answer under
+// exit 0 would be a plausible, silent lie, so the wait resolves early instead:
+// exit 2, reason `steered`, and the turn keeps running so the caller can re-arm.
+//
+// Self-exclusion is the whole subtlety. The request that DID the injecting is
+// waiting for exactly the merged close it caused, so it must not interrupt
+// itself — but it may only claim that close under two conditions, both of which
+// this file enforces from runner-asserted facts alone.
+//
+// A word on what the delivery id is: the adapter reports an injection's TEXT and
+// nothing else, so the runner correlates that text with what gmux delivered and
+// stamps the id only on an unambiguous match (see session.matchPendingLocked).
+// It is an acknowledgement correlated by text, not an identity carried through
+// the agent, and every ambiguity resolves to NO id — which lands here as an
+// id-less injection: it interrupts everyone, and the callers who might have
+// owned it report indeterminate. This layer therefore never has to weigh
+// "probably mine".
+//
+//  1. ACKNOWLEDGED. The adapter reported an injection carrying this request's
+//     delivery id, i.e. gmux's text demonstrably entered the loop. Delivery
+//     alone proves bytes on a PTY, not consumption; a turn that settles before
+//     the acknowledgement may have closed without ever seeing the text, so that
+//     result is INDETERMINATE and never the pre-injection answer under exit 0.
+//  2. LAST. A later injection — human or semantic — supersedes it. The newest
+//     injection owns the answer, so the earlier injector is interrupted like any
+//     other waiter, told that the turn was steered again after its message.
+//
+// Both are decided against the turn the waiter is BOUND to (turn_seq), never
+// against "whatever is running now": an injection into a later turn is somebody
+// else's business, and reacting to it would resolve a wait on evidence about a
+// turn it never observed.
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/sessioncoord"
+)
+
+// newDeliveryID mints an opaque identity for one delivery into a running turn.
+//
+// Random rather than a counter: the id is the only thing standing between "my
+// steer landed" and "somebody else's did", it travels to a separate process, and
+// a per-process counter would repeat across a daemon restart while a runner still
+// held the older value in its correlation window. A crypto/rand read cannot fail
+// in practice; if it ever did, an empty id degrades safely (the injector reports
+// its result as indeterminate rather than claiming an answer).
+func newDeliveryID() string {
+	var b [12]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return ""
+	}
+	return hex.EncodeToString(b[:])
+}
+
+// Public vocabulary for a wait that a steer resolved, and for an injector whose
+// own text was never acknowledged.
+const (
+	// outcomeSteered is reported instead of a turn conclusion: the turn did not
+	// end, it changed. It maps onto the interrupted exit code (2) at the CLI —
+	// expected coordination, not a fault.
+	outcomeSteered = "steered"
+	// outcomeIndeterminate is the injector's honest non-answer: its message may
+	// or may not have entered the loop that just closed, so no result may be
+	// served for it in either direction.
+	outcomeIndeterminate = "indeterminate"
+	// causeSteeredAgain distinguishes the superseded injector ("your text went
+	// in, then somebody steered again") from a plain foreign steer.
+	causeSteeredAgain = "steered_again"
+	// causeInjectionUnacknowledged marks the settle-before-ack race: the turn
+	// closed without the adapter ever reporting this request's injection.
+	causeInjectionUnacknowledged = "injection_unacknowledged"
+)
+
+// injectionWatch is one armed wait's view of the injections on the turn it is
+// bound to.
+//
+// The zero value watches nothing (turnSeq 0 matches no turn), which is the right
+// answer for a wait that never identified a turn: it has no answer to lose.
+type injectionWatch struct {
+	// turnSeq is the turn this wait is bound to, as the adapter identified it.
+	turnSeq uint64
+	// baseline is the turn's TOTAL injection count when this wait bound to it
+	// (TurnCurrent.InjectionsSeen, a monotonic counter the runner never trims).
+	// Injections that predate the wait did not change the contract the wait signed
+	// up for — a `gmux wait` arriving into an already-steered turn asked about
+	// THAT turn as it stands — so only newer ones interrupt.
+	//
+	// It is a counter and not len(Injections) on purpose: the frame's injection
+	// LIST is bounded and drops its oldest entries, so on a saturated turn its
+	// length stops growing and every later injection would read as "nothing new"
+	// — inverting this rule into serving the merged answer under exit 0.
+	baseline uint64
+	// deliveryID is this wait's own injection identity, or "" for a wait that
+	// injected nothing (a plain prompt, a follow-up delivered to an idle agent,
+	// a bare `gmux wait`). An empty id deliberately matches no injection: a
+	// human's message carries no id either, and treating "no id" as "mine"
+	// would let every waiter claim a human's steer as its own.
+	deliveryID string
+}
+
+// steerVerdict is what an injection watch concluded.
+type steerVerdict struct {
+	// Steered is true when the wait must resolve early.
+	Steered bool
+	// Text is the injected excerpt that resolved it — the "injected text" the
+	// stderr report and the --json envelope carry.
+	Text string
+	// Cause is causeSteeredAgain when the interrupted waiter is the earlier
+	// INJECTOR (its message went in and was then superseded), "" otherwise.
+	Cause string
+}
+
+// check reports whether a frame's open turn interrupts this wait.
+func (w injectionWatch) check(frame *sessioncoord.TurnFrame) steerVerdict {
+	cur := frame.CurrentTurn(w.turnSeq)
+	if cur == nil {
+		return steerVerdict{}
+	}
+	return w.judge(cur.Injections, cur.InjectionsSeen())
+}
+
+// checkClose applies the same rule to a SETTLED turn's carried injections.
+//
+// It is not redundant with check: the injection event and the close can arrive
+// in the same look (or the injection's own transient publish can be dropped
+// under backlog), and a waiter that learns of the steer only at the close must
+// still refuse to present the merged answer as the one it asked for.
+func (w injectionWatch) checkClose(close *sessioncoord.TurnClose) steerVerdict {
+	if close == nil || close.TurnSeq != w.turnSeq {
+		return steerVerdict{}
+	}
+	return w.judge(close.Injections, close.InjectionsSeen())
+}
+
+// judge is the rule itself: `seen` decides whether anything NEW entered the loop
+// (a monotonic count), and the bounded list supplies the text and the identity
+// of the newest one.
+func (w injectionWatch) judge(injections []sessioncoord.TurnInjection, seen uint64) steerVerdict {
+	if seen <= w.baseline {
+		return steerVerdict{} // nothing new entered the loop
+	}
+	if len(injections) == 0 {
+		// The count says a message entered the loop but no text came with it.
+		// The wait is still interrupted — the contract of the pending answer
+		// changed either way — with a report that names no excerpt.
+		return steerVerdict{Steered: true}
+	}
+	last := injections[len(injections)-1]
+	if w.deliveryID != "" && last.DeliveryID == w.deliveryID {
+		// Acknowledged AND last: this is the injector whose merged close is
+		// still its own to claim.
+		return steerVerdict{}
+	}
+	v := steerVerdict{Steered: true, Text: last.Text}
+	if w.deliveryID != "" && w.acknowledged(injections) {
+		v.Cause = causeSteeredAgain
+	}
+	return v
+}
+
+// acknowledged reports whether this wait's own injection is among the turn's
+// RETAINED injections.
+//
+// On a turn steered more times than the frame retains, an injector's own record
+// can have been evicted, and it then reads as unacknowledged rather than as
+// superseded. Both are non-claims (indeterminate vs steered), so the loss costs
+// a word in the report and never an answer.
+func (w injectionWatch) acknowledged(injections []sessioncoord.TurnInjection) bool {
+	if w.deliveryID == "" {
+		return false
+	}
+	for _, inj := range injections {
+		if inj.DeliveryID == w.deliveryID {
+			return true
+		}
+	}
+	return false
+}
+
+// mayClaimClose reports whether an INJECTING wait may be served the result of
+// the close it observed, and why not when it may not.
+//
+// For a non-injecting wait (deliveryID == "") there is nothing to exclude and
+// the ordinary turn-identity match decides, so it always may.
+func (w injectionWatch) mayClaimClose(close *sessioncoord.TurnClose) (ok bool, cause string) {
+	if w.deliveryID == "" {
+		return true, ""
+	}
+	if close == nil || close.TurnSeq != w.turnSeq {
+		// No settled record for our turn: the ordinary result-free path, which
+		// says nothing about the injection either way.
+		return true, ""
+	}
+	injections := close.Injections
+	if len(injections) > 0 && injections[len(injections)-1].DeliveryID == w.deliveryID {
+		return true, ""
+	}
+	if w.acknowledged(injections) {
+		// Our text entered the loop and was then superseded: the answer belongs
+		// to whoever injected last.
+		return false, causeSteeredAgain
+	}
+	// The loop settled without ever acknowledging our text. pi may have closed
+	// without consuming it, so neither "here is your answer" nor "your steer
+	// failed" is assertable.
+	return false, causeInjectionUnacknowledged
+}
+
+// closeVerdict is the single injection-aware decision at a turn's close: it
+// reports the outcome that REPLACES the ordinary turn conclusion, or ("", "",
+// "") when the conclusion stands and the result may be served.
+//
+// Two replacements exist, and the difference matters to the caller:
+//
+//   - steered (exit 2): a user message changed this turn's contract. For a
+//     bystander that is any new injection; for an injector it is a LATER
+//     injection superseding its own.
+//   - indeterminate (exit 1): this injector's text was never acknowledged as
+//     having entered the loop that just closed, so no claim is assertable in
+//     either direction — above all not the pre-injection answer under exit 0.
+func (w injectionWatch) closeVerdict(close *sessioncoord.TurnClose) (outcome, cause, text string) {
+	if v := w.checkClose(close); v.Steered {
+		return outcomeSteered, v.Cause, v.Text
+	}
+	ok, cause := w.mayClaimClose(close)
+	switch {
+	case ok:
+		return "", "", ""
+	case cause == causeSteeredAgain:
+		// Superseded, but by an injection the baseline already covered (a wait
+		// that bound after somebody else's steer and then steered itself). It is
+		// the same fact as above and gets the same word.
+		return outcomeSteered, cause, lastInjectionText(close)
+	default:
+		return outcomeIndeterminate, cause, ""
+	}
+}
+
+func lastInjectionText(close *sessioncoord.TurnClose) string {
+	if close == nil || len(close.Injections) == 0 {
+		return ""
+	}
+	return close.Injections[len(close.Injections)-1].Text
+}
+
+// baselineInjections is the total injection count a frame's open turn already
+// carries, which is what a wait binding to that turn must not react to.
+func baselineInjections(frame *sessioncoord.TurnFrame, turnSeq uint64) uint64 {
+	return frame.CurrentTurn(turnSeq).InjectionsSeen()
+}

--- a/services/gmuxd/cmd/gmuxd/wait_result_central_test.go
+++ b/services/gmuxd/cmd/gmuxd/wait_result_central_test.go
@@ -682,12 +682,21 @@ func TestFirstPromptOfAFreshSessionReturnsItsAnswer(t *testing.T) {
 
 // A steer joins a turn that is already open, so its identity is knowable before
 // delivery: the steer may claim the merged close of THAT turn, and nothing else.
+//
+// Claiming it also requires the adapter to have acknowledged that the steer's
+// text entered the loop (ADR 0027's self-exclusion rule, added in the steer
+// slice), which is what the injection on the close record is: without it the
+// close might be the pre-injection answer, and that is reported as indeterminate
+// instead — see TestUnacknowledgedSteerReportsIndeterminate.
 func TestSteerClaimsTheTurnItJoined(t *testing.T) {
 	h := newAgentHarness(t, liveRow("s", true))
 	h.openTurn(5, "go")
 	get := runPromptAsync(t, h, promptBodyJSON(t, map[string]any{"prompt": "no, this way", "mode": modeSteer}))
 	<-h.prompts
-	h.closeTurn(5, outcomeCompleted, "post-steer answer")
+	h.setFrame(&sessioncoord.TurnFrame{Seq: 105, Last: &sessioncoord.TurnClose{
+		TurnSeq: 5, Outcome: outcomeCompleted, Output: "post-steer answer",
+		Injections: []sessioncoord.TurnInjection{{Text: "no, this way", DeliveryID: harnessDeliveryID}},
+	}})
 	h.publish(statusOutcome("s", false, false, false))
 	got := get()
 	if got.data()["output"] != "post-steer answer" {

--- a/services/gmuxd/internal/discovery/actions.go
+++ b/services/gmuxd/internal/discovery/actions.go
@@ -65,6 +65,12 @@ type promptBody struct {
 	Prompt   string `json:"prompt"`
 	Delivery string `json:"delivery"`
 	Require  string `json:"require"`
+	// DeliveryID identifies this delivery so the runner can correlate the text
+	// with the injection the adapter reports when it enters a running loop (ADR
+	// 0027's steer self-exclusion). Omitted when the caller has no wait to
+	// exclude; a runner that predates the field refuses unknown fields, so it is
+	// omitted rather than sent empty.
+	DeliveryID string `json:"delivery_id,omitempty"`
 }
 
 // SendPrompt delivers prompt text plus a submit-like action to the agent
@@ -89,8 +95,8 @@ type promptBody struct {
 // on an agent that declines to read, so the ordinary 3 s runner request
 // timeout would turn a legitimate slow admission into a transport error of
 // indeterminate delivery. Callers must supply a deadline of their own.
-func SendPrompt(ctx context.Context, socketPath, expectIncarnation, prompt, delivery, require string) error {
-	body, err := json.Marshal(promptBody{Prompt: prompt, Delivery: delivery, Require: require})
+func SendPrompt(ctx context.Context, socketPath, expectIncarnation, prompt, delivery, require, deliveryID string) error {
+	body, err := json.Marshal(promptBody{Prompt: prompt, Delivery: delivery, Require: require, DeliveryID: deliveryID})
 	if err != nil {
 		return err
 	}

--- a/services/gmuxd/internal/discovery/actions_test.go
+++ b/services/gmuxd/internal/discovery/actions_test.go
@@ -20,7 +20,7 @@ func TestSendPromptDeliversTheRunnerContract(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
 	defer srv.cleanup()
-	if err := SendPrompt(context.Background(), srv.socketPath, "inc-1", "review this\nbranch", "after_turn", "any"); err != nil {
+	if err := SendPrompt(context.Background(), srv.socketPath, "inc-1", "review this\nbranch", "after_turn", "any", ""); err != nil {
 		t.Fatalf("SendPrompt: %v", err)
 	}
 	if gotPath != "/prompt" || gotCT != "application/json" {
@@ -41,7 +41,7 @@ func TestSendPromptPassesEnumsThroughVerbatim(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
 	defer srv.cleanup()
-	if err := SendPrompt(context.Background(), srv.socketPath, "inc-1", "x", "tomorrow", "whenever"); err != nil {
+	if err := SendPrompt(context.Background(), srv.socketPath, "inc-1", "x", "tomorrow", "whenever", ""); err != nil {
 		t.Fatal(err)
 	}
 	if got.Delivery != "tomorrow" || got.Require != "whenever" {
@@ -77,7 +77,7 @@ func TestSemanticCallsAreConditionalOnTheRunnersIdentity(t *testing.T) {
 			w.WriteHeader(http.StatusNoContent)
 		}))
 		defer srv.cleanup()
-		if err := SendPrompt(context.Background(), srv.socketPath, "inc-A", "x", "now", "inactive"); err != nil {
+		if err := SendPrompt(context.Background(), srv.socketPath, "inc-A", "x", "now", "inactive", ""); err != nil {
 			t.Fatal(err)
 		}
 		if err := SendCancel(context.Background(), srv.socketPath, "inc-A"); err != nil {
@@ -100,7 +100,7 @@ func TestSemanticCallsAreConditionalOnTheRunnersIdentity(t *testing.T) {
 				"code": "incarnation_mismatch", "error": "owned by a different runner"})
 		}))
 		defer srv.cleanup()
-		err := SendPrompt(context.Background(), srv.socketPath, "inc-A", "x", "now", "inactive")
+		err := SendPrompt(context.Background(), srv.socketPath, "inc-A", "x", "now", "inactive", "")
 		if !errors.Is(err, ErrRunnerIncarnationMismatch) {
 			t.Fatalf("SendPrompt = %v, want ErrRunnerIncarnationMismatch", err)
 		}
@@ -115,7 +115,7 @@ func TestSemanticCallsAreConditionalOnTheRunnersIdentity(t *testing.T) {
 			w.WriteHeader(http.StatusNoContent)
 		}))
 		defer srv.cleanup()
-		if err := SendPrompt(context.Background(), srv.socketPath, "", "x", "now", "inactive"); err == nil {
+		if err := SendPrompt(context.Background(), srv.socketPath, "", "x", "now", "inactive", ""); err == nil {
 			t.Fatal("an unconditional prompt must not be sent at all")
 		}
 		if err := SendCancel(context.Background(), srv.socketPath, ""); err == nil {
@@ -135,7 +135,7 @@ func TestOldRunnerStatusesBecomeUnsupported(t *testing.T) {
 		srv := startUnixServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(code)
 		}))
-		err := SendPrompt(context.Background(), srv.socketPath, "inc-1", "x", "now", "inactive")
+		err := SendPrompt(context.Background(), srv.socketPath, "inc-1", "x", "now", "inactive", "")
 		srv.cleanup()
 		if !errors.Is(err, ErrRunnerSemanticActionsUnsupported) {
 			t.Fatalf("status %d: %v", code, err)
@@ -190,7 +190,7 @@ func TestUnparseableRefusalKeepsTheRunnersWords(t *testing.T) {
 		_, _ = w.Write([]byte("not json at all"))
 	}))
 	defer srv.cleanup()
-	err := SendPrompt(context.Background(), srv.socketPath, "inc-1", "x", "now", "inactive")
+	err := SendPrompt(context.Background(), srv.socketPath, "inc-1", "x", "now", "inactive", "")
 	var actErr *RunnerActionError
 	if !errors.As(err, &actErr) {
 		t.Fatalf("want structured error, got %v", err)
@@ -218,7 +218,7 @@ func TestSemanticCallsAreBoundedOnlyByContext(t *testing.T) {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
-	if err := SendPrompt(ctx, srv.socketPath, "inc-1", "x", "now", "inactive"); err == nil {
+	if err := SendPrompt(ctx, srv.socketPath, "inc-1", "x", "now", "inactive", ""); err == nil {
 		t.Fatal("caller deadline must bound the call")
 	}
 }

--- a/services/gmuxd/internal/sessioncoord/coordinator.go
+++ b/services/gmuxd/internal/sessioncoord/coordinator.go
@@ -824,7 +824,14 @@ func (c *Coordinator) drain(ctx context.Context, id centralstore.SessionID, gene
 				// the close reads the result asserted for that exact turn.
 				c.registry.setFrame(id, generation, ev.Frame)
 				if ev.FrameOnly {
-					continue // nothing durable to apply
+					// Nothing durable to apply — but an armed wait may have to
+					// resolve on it: a mid-turn injection changes what the turn's
+					// answer means and interrupts every other waiter (ADR 0027,
+					// "Steering interrupts waits"). It writes no row, so no domain
+					// outcome announces it; publish the frame as a transient signal
+					// so waiters see it without polling.
+					c.publishFrameSignal(id, ev.Frame)
+					continue
 				}
 			}
 			if ev.TransientActivity {

--- a/services/gmuxd/internal/sessioncoord/outcomes.go
+++ b/services/gmuxd/internal/sessioncoord/outcomes.go
@@ -368,6 +368,28 @@ func (c *Coordinator) PublishActivity(id centralstore.SessionID) {
 	c.outcomes.publish(Outcome{Type: OutcomeActivity, ID: id, Alive: alive, Generation: generation})
 }
 
+// publishFrameSignal announces a frame that changed without the row changing —
+// today a mid-turn injection (a steer, a merged follow-up, a human typing).
+//
+// It rides the Activity type deliberately rather than inventing a fourth outcome
+// kind: an injection IS session activity, every existing consumer already
+// tolerates the type, and nothing durable is being claimed. The cost is that it
+// is lossy under deep backlog, which is acceptable because it is an OPTIMIZATION
+// of timing, not the correctness path: a waiter that misses the signal still
+// refuses to serve the merged answer, because the settled close carries the same
+// injection list (see injectionWatch.checkClose), and the generic wait's ticker
+// re-reads the retained frame within 500 ms either way.
+func (c *Coordinator) publishFrameSignal(id centralstore.SessionID, frame *TurnFrame) {
+	if frame == nil || frame.Current == nil || len(frame.Current.Injections) == 0 {
+		return // only an injection can resolve a wait early
+	}
+	if !c.outcomes.hasSubscribers() {
+		return
+	}
+	alive, generation := c.livenessOf(id)
+	c.outcomes.publish(Outcome{Type: OutcomeActivity, ID: id, Alive: alive, Generation: generation, Frame: frame})
+}
+
 func (c *Coordinator) livenessOf(id centralstore.SessionID) (bool, uint64) {
 	if e, ok := c.registry.current(id); ok {
 		return true, e.Generation

--- a/services/gmuxd/internal/sessioncoord/turnframe.go
+++ b/services/gmuxd/internal/sessioncoord/turnframe.go
@@ -1,6 +1,11 @@
 package sessioncoord
 
-import "github.com/gmuxapp/gmux/services/gmuxd/internal/centralstore"
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/centralstore"
+)
 
 // TurnFrame is the runner-held turn record (docs/runner-hook-protocol.md,
 // ADR 0027's 2026-07-28 amendment), as this daemon retains it.
@@ -21,22 +26,80 @@ type TurnFrame struct {
 
 // TurnCurrent is the open turn's identity and inputs so far.
 type TurnCurrent struct {
-	TurnSeq    uint64   `json:"turn_seq"`
-	Trigger    string   `json:"trigger,omitempty"`
-	Injections []string `json:"injections,omitempty"`
+	TurnSeq    uint64          `json:"turn_seq"`
+	Trigger    string          `json:"trigger,omitempty"`
+	Injections []TurnInjection `json:"injections,omitempty"`
+	// InjectionCount is the turn's TOTAL number of injections, which never
+	// trims, unlike the bounded Injections list. Novelty is decided against it
+	// (see InjectionsSeen).
+	InjectionCount uint64 `json:"injection_count,omitempty"`
+}
+
+// InjectionsSeen reports how many messages have entered this loop, from the
+// runner's monotonic counter when it sent one and from the retained list
+// otherwise.
+//
+// The fallback is for a runner that predates the counter: its list is bounded
+// too, so a saturated turn can still hide later injections there, but reading
+// the list is strictly better than reading zero — which would make every
+// injection invisible on that runner and hand waiters the merged answer.
+func (c *TurnCurrent) InjectionsSeen() uint64 {
+	if c == nil {
+		return 0
+	}
+	if c.InjectionCount > 0 {
+		return c.InjectionCount
+	}
+	return uint64(len(c.Injections))
+}
+
+// TurnInjection is one user message that entered the running loop: a steer, a
+// follow-up the agent merged into the turn, or a human typing into the TUI.
+//
+// DeliveryID is the identity of the gmux request that delivered it, correlated
+// at the runner. It is empty for an injection gmux did not deliver, and that
+// emptiness is load-bearing: a human grabbing the wheel interrupts every
+// waiter, including one that had just steered.
+type TurnInjection struct {
+	Text       string `json:"text,omitempty"`
+	DeliveryID string `json:"delivery_id,omitempty"`
+}
+
+// UnmarshalJSON accepts the bare excerpt string a runner predating delivery
+// identity sends, as well as the object shape. Refusing it would fail the whole
+// frame's decode and cost every result in it — the loss the frame exists to
+// prevent — so the old shape degrades to "an injection with no identity",
+// which is exactly what it is.
+func (t *TurnInjection) UnmarshalJSON(b []byte) error {
+	if strings.HasPrefix(strings.TrimSpace(string(b)), `"`) {
+		var s string
+		if err := json.Unmarshal(b, &s); err != nil {
+			return err
+		}
+		*t = TurnInjection{Text: s}
+		return nil
+	}
+	type raw TurnInjection
+	var v raw
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	*t = TurnInjection(v)
+	return nil
 }
 
 // TurnClose is a settled turn's asserted result. Output is present only for a
 // completed turn and is omitted rather than empty: absence means the turn
 // produced no prose, never that the transport lost it.
 type TurnClose struct {
-	TurnSeq    uint64   `json:"turn_seq"`
-	Outcome    string   `json:"outcome"`
-	Trigger    string   `json:"trigger,omitempty"`
-	Injections []string `json:"injections,omitempty"`
-	Output     string   `json:"output,omitempty"`
-	Truncated  bool     `json:"truncated,omitempty"`
-	Diagnostic string   `json:"diagnostic,omitempty"`
+	TurnSeq        uint64          `json:"turn_seq"`
+	Outcome        string          `json:"outcome"`
+	Trigger        string          `json:"trigger,omitempty"`
+	Injections     []TurnInjection `json:"injections,omitempty"`
+	InjectionCount uint64          `json:"injection_count,omitempty"`
+	Output         string          `json:"output,omitempty"`
+	Truncated      bool            `json:"truncated,omitempty"`
+	Diagnostic     string          `json:"diagnostic,omitempty"`
 }
 
 // CurrentTurnSeq reports the running turn's identity, or 0 when no turn is open
@@ -59,6 +122,46 @@ func (f *TurnFrame) ClosedTurn(turnSeq uint64) *TurnClose {
 		return nil
 	}
 	return f.Last
+}
+
+// TriggerExcerpt is the nil-safe read of an open turn's trigger, so a report can
+// name what the turn was asked to do without every caller re-checking for a
+// frame that does not exist.
+func (c *TurnCurrent) TriggerExcerpt() string {
+	if c == nil {
+		return ""
+	}
+	return c.Trigger
+}
+
+// TriggerExcerpt is the nil-safe read of a settled turn's trigger.
+func (t *TurnClose) TriggerExcerpt() string {
+	if t == nil {
+		return ""
+	}
+	return t.Trigger
+}
+
+// InjectionsSeen is the settled turn's total injection count, with the same
+// list fallback (and the same reason) as the open record's.
+func (t *TurnClose) InjectionsSeen() uint64 {
+	if t == nil {
+		return 0
+	}
+	if t.InjectionCount > 0 {
+		return t.InjectionCount
+	}
+	return uint64(len(t.Injections))
+}
+
+// CurrentTurn returns the open turn's record for turnSeq, or nil when no turn
+// with that identity is open. It is the injection-watch lookup: a waiter asks
+// about the turn IT is bound to, never about "whatever is running".
+func (f *TurnFrame) CurrentTurn(turnSeq uint64) *TurnCurrent {
+	if f == nil || f.Current == nil || turnSeq == 0 || f.Current.TurnSeq != turnSeq {
+		return nil
+	}
+	return f.Current
 }
 
 // setFrame retains a generation's newest frame in registry runtime. It reports

--- a/skills/gmux/SKILL.md
+++ b/skills/gmux/SKILL.md
@@ -24,6 +24,7 @@ gmux send <id> C-c           # send a control key (interrupt), no text
 gmux send --wait <id> 'text' Enter  # raw send AND block until the reply is done
 gmux wait <id>               # block until the turn ends; prints an agent's answer
 gmux wait --quiet <id>       # ...synchronize only, print nothing
+gmux wait --json <id>        # ...one envelope for the resolution, whatever it is
 gmux wait <id> --for-text S  # block until S appears in the output
 gmux tail <id> [-n N]        # RAW: last N lines of terminal output (N=100)
 gmux agent logs <id> [-n N] [--user|--agent|--tool|--all] [--json]
@@ -156,6 +157,37 @@ gmux agent cancel $id; gmux wait $id; [ $? = 2 ] && echo stopped   # interrupt, 
 Do **not** chain cancel with `&& gmux wait`: an interrupted turn exits `2`, so the
 wait "fails" on exactly the outcome you asked for (and aborts the script under
 `set -e`).
+
+**Steering interrupts waits.** A user message injected into a turn somebody else
+is waiting on — your `--steer`, a `--follow-up` that merged into the running
+loop, or a human typing into the TUI — ends *their* wait early with exit `2` and
+reason `steered`, because the answer they were promised now answers something
+else. The turn keeps running, so re-arm when you still want the result:
+
+```bash
+gmux wait $id || gmux wait $id     # first wait steered; the second gets the new answer
+```
+
+Your own steer is not interrupted by itself: gmux matches the agent's report of
+a message entering the loop against the text it delivered for you, and hands you
+the merged close
+— but only while your message is the loop's **last** injection (a later one
+supersedes it: reason `steered_again`), and only if the agent acknowledged it
+before the turn settled (otherwise you get `indeterminate`, exit `1`, rather than
+an answer that may predate your text). `--follow-up` accordingly has two modes:
+to an **idle** agent it starts an ordinary turn; into a **running** turn it merges
+into that turn, and the merged close's answer is the follow-up's.
+
+A non-completed `wait`/`prompt` prints nothing on stdout and a short report on
+stderr — outcome, reason, the trigger excerpt, the injected text when steered —
+so you never need a second command to learn what a non-zero exit meant. Both
+verbs also take `--json`: one stdout envelope (`{outcome, reason, output,
+trigger, steered_by, truncated, message}`, fields absent rather than empty) and
+no stderr report — on every terminal path, success included, so silence is never
+an outcome. `--json` is refused with `--quiet` and with `--no-wait`. The match
+that excludes your own steer is textual (the agent reports the message, nothing
+else), so an ambiguous report — two in-flight deliveries that could both explain
+it — is credited to nobody and both callers get `indeterminate`.
 
 `--follow-up` and `--steer` are mutually exclusive; `--no-wait` composes with
 either (it only decides whether you block, so `--no-wait --timeout N` is a usage


### PR DESCRIPTION
## Summary

Implements the last two follow-ups of ADR 0027's "result is asserted at the source" amendment:

**Steering interrupts waits.** A user message injected into an active turn — `--steer`, a `--follow-up` merged into pi's running loop, or a human typing — resolves every *other* armed wait early: exit 2, reason `steered`, stderr report carrying the trigger and the injected excerpt. The turn keeps running; re-arming works. The injector's own sync wait is excluded by text-correlated acknowledgement: it claims the merged close only after its `message_start` was **unambiguously** matched (exact under one shared normalization, or prefix only when the extension's explicit truncation flag licenses it), only while its injection is the loop's last. Ambiguity credits nobody — indeterminate, never the pre-injection answer under exit 0. Novelty is tracked by a monotonic per-turn counter, immune to injection-list rollover.

**Reports and `--json`.** Every non-completed `wait`/sync-`prompt` resolution prints a status-shaped report to stderr (outcome, reason, trigger, injected text; the admission-timeout path appends a labeled terminal-tail excerpt). `--json` emits a stable envelope on stdout for **every** terminal path — including matched output-conditions and daemon-side 202s — with no stderr report; `--json --quiet` is refused.

## Review

Adversarial round (2 anchors + 1 spot) found a genuine blocker both anchors hit independently: the original prefix matching let a shorter message steal an in-flight steer's delivery id — the exact exit-0 misattribution the design forbids. Fixed at the root (unique exact-or-flag-licensed matching, tie→nobody), plus the counter, normalization alignment, the two silent `--json` paths, and a delta-round fix making truncation an explicit wire field instead of marker-sniffing. Final anchor verdict: accept, no open findings. The one irreducible residue (a human typing byte-identical text simultaneously) is recorded in the ADR.

## Note

`TestHarnessRestartMidConvergenceSweepsOnlyMissingRunner` (pre-existing, central-store commit) flaked on main's last two CI runs and passes 30× locally with `-race` — unrelated to this stack, worth its own investigation.
