### PR TITLE
feat(cli): define managed-session standard streams

### DIFF
--- a/apps/website/src/content/docs/integrations/scripts-and-agents.md
+++ b/apps/website/src/content/docs/integrations/scripts-and-agents.md
@@ -31,7 +31,8 @@ Running a command always uses the explicit `--` separator — there is no bare `
 When stdin is not a TTY, `gmux -- <cmd>`:
 
 - **Blocks** until the child exits.
-- **Streams bounded metadata** to stdout (session id, adapter, command, pid, exit status), not the full PTY output. Your script's logs stay readable.
+- **Streams the child's output to stdout** — ANSI escapes stripped and CRLF normalised to LF, so `gmux -- make build | tail` reads the build's own last lines. The full escape stream still reaches the UI and scrollback.
+- **Prints the session id on stderr**, before the child runs, so a watcher can attach or `gmux tail` the session mid-run without disturbing stdout.
 - **Exits with the child's exit code**, so `gmux -- make build < /dev/null && deploy.sh` works.
 - **Keeps the session in the UI** for the duration: a human can watch it live in the browser without affecting the script.
 
@@ -74,18 +75,18 @@ sends the prompt as its first turn.
 id=$(gmux agent prompt --new --no-wait --name review 'review the diff on this branch')
 gmux wait "$id"
 
-gmux agent prompt --new --model anthropic/sonnet 'summarize this repo'   # id, blank line, report
+gmux agent prompt --new --model anthropic/sonnet 'summarize this repo'   # report on stdout; id on stderr
 ```
 
-**The session id is stdout line 1**, written the moment the session exists —
+**The session id is written immediately**, the moment the session exists —
 before the prompt is even delivered — so you can always address the session you
 just paid for, including when admission or the work then fails. It means only
 that: the session exists and is addressable. It is not an admission receipt and
-not a readiness signal — the exit code carries those. Under `--new`
-the completion signal is therefore the **exit code**, not non-empty stdout: a
-successful synchronous run prints the id, a blank line, then the exchange
-report. With `--no-wait`
-the bare id is the only output and exit `0` means the work was **admitted** — the
+not a readiness signal — the exit code carries those. Under synchronous `--new`,
+the bare id goes to stderr and stdout contains only the exchange report; the
+completion signal is therefore the **exit code**, not non-empty stdout. With
+`--no-wait`, the bare id is instead the stdout payload and the only output, and
+exit `0` means the work was **admitted** — the
 agent actually started it. The id still prints immediately, but the process
 returns only once that happened (or the 60 s admission window expires), so on a
 sick session the launch line can block that long instead of returning at

--- a/apps/website/src/content/docs/reference/cli.md
+++ b/apps/website/src/content/docs/reference/cli.md
@@ -51,11 +51,13 @@ inside a gmux session:
 | ------------------ | ---------------- | ------------------------------------------------------------------------------------------------------- |
 | TTY                | no               | Attach: wire your terminal to the child PTY, forward Ctrl-C and resize, detach when the terminal closes. |
 | TTY                | yes              | Auto-detach: spawn the session in the background and return immediately, so PTYs don't nest.            |
-| Pipe / file / null | either           | Block, stream bounded metadata to stdout, exit with the child's exit code. The session keeps running for the UI to attach to. |
+| Pipe / file / null | either           | Block, stream the child's output to stdout (ANSI stripped, CRLF normalised), print the session id on stderr, exit with the child's exit code. The session keeps running for the UI to attach to. |
 
 The pipe/file/null row is the canonical shape for scripts and agent harnesses:
-a blocking call, bounded stdout (no full PTY noise in your logs), and reliable
-exit-code propagation — so `if gmux -- pytest -q; then …` works.
+a blocking call, stdout that carries exactly what the child printed (so
+`gmux -- pnpm build | tail` reads the build's own tail), the session id on
+stderr for attaching or tailing mid-run, and reliable exit-code propagation —
+so `if gmux -- pytest -q; then …` works.
 
 See [Scripts and agents](/integrations/scripts-and-agents/) for the narrative
 version with a worked build-and-report example.
@@ -528,7 +530,7 @@ gmux agent prompt --new [--model M] [--name N] [--timeout N] [--no-wait] [prompt
 id=$(gmux agent prompt --new --no-wait --name review 'review the diff on this branch')
 gmux wait "$id"
 
-# synchronous: the id, a blank line, then the report
+# synchronous: the id on stderr, the exchange report on stdout
 gmux agent prompt --new --model anthropic/sonnet 'summarize this repo'
 ```
 
@@ -551,10 +553,13 @@ its first work. Pass either a session id or `--new`, never both.
 - Other agents answer `unsupported_adapter`: launch those with `gmux -d -- <cmd>`
   and prompt the id it prints. That two-step route stays valid for pi too.
 
-**The session id is stdout line 1**, printed the moment the session exists and
-*before* the prompt is delivered — so a watcher can attach or tail while the
-agent is still coming up, and so you can always address the session you just
-paid for even when admission or the turn then fails.
+**The bare session id is printed the moment the session exists** and *before*
+the prompt is delivered — so a watcher can attach or tail while the agent is
+still coming up, and so you can always address the session you just paid for
+even when admission or the turn then fails. With `--no-wait` it is stdout's
+only content (the command-substitution shape: the id is the payload);
+synchronously it goes to **stderr**, keeping stdout for the exchange report
+alone.
 
 The line means exactly one thing: **the session exists and is addressable.** It
 is not an admission receipt, not a readiness signal, and not a claim that the
@@ -562,8 +567,9 @@ prompt was delivered — the exit code carries all of those. Two consequences
 worth pinning:
 
 - Under `--new`, **the completion signal is the exit code, not non-empty
-  stdout.** A successful synchronous run prints the id, a blank line, then the
-  exchange report; a failed one prints the id and exits non-zero.
+  stdout.** A successful synchronous run prints the exchange report on stdout;
+  a failed one may print nothing there at all — the id is already on stderr
+  and the exit code carries the verdict.
 - With `--no-wait`, the bare id is the only output and exit `0` means the work
   was **admitted**: the id prints immediately, but the process returns only once
   the agent has started it (or the admission window expires). On a sick
@@ -576,12 +582,13 @@ the session stays behind and it is **yours**: gmux does not tear it down, and it
 may still be running. Retry against the printed id, read it with `gmux agent
 logs`, or `gmux kill <id>` it.
 
-If the launch itself fails (nothing registered with gmuxd), **nothing** is
-printed on stdout and the command exits `1`: there is no session to address.
-The rule scripts can rely on is that stdout line 1 is a session id whenever a
-session exists, and stdout is empty whenever one does not. A prompt that is
-empty, oversized or not valid UTF-8 is refused before anything is spawned, so a
-usage error never leaves an orphan session behind.
+If the launch itself fails (nothing registered with gmuxd), **no id** is
+printed anywhere and the command exits `1`: there is no session to address.
+The rule scripts can rely on is that the bare id is emitted exactly once
+whenever a session exists (stdout under `--no-wait`, stderr line 1 otherwise),
+and no id is emitted whenever one does not. A prompt that is empty, oversized
+or not valid UTF-8 is refused before anything is spawned, so a usage error
+never leaves an orphan session behind.
 
 ### `gmux agent cancel <id>`
 

--- a/cli/gmux/cmd/gmux/actions.go
+++ b/cli/gmux/cmd/gmux/actions.go
@@ -649,47 +649,12 @@ func emitSessionsJSON(sessions []cliSession) int {
 }
 
 // stripANSI removes ANSI/VT escape sequences from PTY output so the
-// scrollback view of `gmux tail` is grep-friendly plain text. The
-// broker already renders tail responses through a terminal emulator,
-// so this is belt-and-braces for whatever survives that pass.
-// Handles CSI (ESC [ ... letter), OSC (ESC ] ... BEL/ST), and
-// lone two-byte escapes; this is a pragmatic stripper, not a full
-// terminal emulator.
+// scrollback view of `gmux tail` is grep-friendly text. The broker already
+// renders tail responses through a terminal emulator, so this is
+// belt-and-braces for whatever survives that pass. Reuse the foreground
+// relay's parser so tail and `gmux -- <cmd>` cannot drift in what they strip.
 func stripANSI(b []byte) []byte {
-	out := make([]byte, 0, len(b))
-	for i := 0; i < len(b); {
-		c := b[i]
-		if c != 0x1b { // not ESC
-			if c != '\r' { // collapse bare CRs that survive re-render
-				out = append(out, c)
-			}
-			i++
-			continue
-		}
-		// ESC sequence.
-		if i+1 >= len(b) {
-			break
-		}
-		switch b[i+1] {
-		case '[': // CSI: ESC [ params... final-byte (0x40-0x7e)
-			j := i + 2
-			for j < len(b) && (b[j] < 0x40 || b[j] > 0x7e) {
-				j++
-			}
-			i = j + 1
-		case ']': // OSC: ESC ] ... (BEL | ESC \)
-			j := i + 2
-			for j < len(b) && b[j] != 0x07 {
-				if b[j] == 0x1b && j+1 < len(b) && b[j+1] == '\\' {
-					j++
-					break
-				}
-				j++
-			}
-			i = j + 1
-		default: // two-byte escape
-			i += 2
-		}
-	}
-	return out
+	var out strings.Builder
+	_, _ = newANSIStrippingWriter(&out).Write(b) // strings.Builder never fails
+	return []byte(out.String())
 }

--- a/cli/gmux/cmd/gmux/actions_test.go
+++ b/cli/gmux/cmd/gmux/actions_test.go
@@ -290,6 +290,7 @@ func TestStripANSI(t *testing.T) {
 		{"cursor-move CSI removed", "a\x1b[2Kb\x1b[1;5Hc", "abc"},
 		{"OSC title (BEL-terminated) removed", "\x1b]0;my title\x07done", "done"},
 		{"OSC (ST-terminated) removed", "\x1b]8;;http://x\x1b\\link", "link"},
+		{"DCS payload removed", "before\x1bPq?sixel-data\x1b\\after", "beforeafter"},
 		{"CRLF normalized to LF", "line1\r\nline2\r\n", "line1\nline2\n"},
 		{"UTF-8 multibyte preserved", "café — π ✓", "café — π ✓"},
 		{"lone ESC at end does not panic", "trailing\x1b", "trailing"},

--- a/cli/gmux/cmd/gmux/agent.go
+++ b/cli/gmux/cmd/gmux/agent.go
@@ -431,12 +431,13 @@ var agentLaunchAdapter adapter.Adapter = adapters.NewPi()
 //
 // Ordering is the whole design. The prompt is read and the argv translated
 // BEFORE anything is spawned, so a usage error never leaves an orphan session
-// behind. Once the spawn succeeds the session id is written to stdout
-// immediately — before the prompt is even delivered — because from that
-// moment the caller owns a session they must be able to address no matter
-// what happens next. Everything after that point (admission failure, a turn
-// that errors, a --timeout) reports on stderr and exits per the taxonomy,
-// leaving stdout's first line exactly one bare session id.
+// behind. Once the spawn succeeds its id is emitted immediately — before the
+// prompt is delivered — because from that moment the caller owns a session it
+// must be able to address no matter what happens next. Which channel carries
+// it follows the payload rule (ADR 0028 amendment): --no-wait prints the bare
+// id on stdout because the id IS its payload; a synchronous run prints the
+// bare id on stderr, keeping stdout for the exchange report alone. Everything
+// after that point exits per the taxonomy without retracting that address.
 //
 // So the id line means one thing only: the session exists and is addressable.
 // It is not an admission receipt, not a readiness signal and not a claim that
@@ -468,20 +469,19 @@ func cmdAgentPromptNew(model, name string, noWait bool, timeoutSecs int, text *s
 		fmt.Fprintf(os.Stderr, "gmux: could not start %s: %s\n", strings.Join(argv, " "), err)
 		return waitExitError
 	}
-	// Line 1 of stdout, unconditionally and before delivery (ADR 0027, the
-	// 2026-07-27 --new amendment: "stdout line 1 means the session exists and
-	// is addressable"). It asserts NOTHING about admission, readiness or the
-	// turn — the exit code carries every one of those verdicts. Printing it
-	// here rather than at admission is what makes the guarantee
-	// unconditional: whatever fails next, the caller can address, retry
-	// against or kill the session it just paid for. os.Stdout is unbuffered,
-	// so a watcher reading the pipe can attach or tail during readiness.
-	if _, err := fmt.Fprintln(os.Stdout, id); err != nil {
+	// Print as soon as the session exists, before delivery. --no-wait keeps
+	// its command-substitution-friendly bare id on stdout; a synchronous run
+	// puts the bare id on stderr so stdout stays the report alone. Either form
+	// asserts only that the session is addressable — the exit code carries the
+	// delivery verdict.
+	if noWait {
+		_, err = fmt.Fprintln(os.Stdout, id)
+	} else {
+		_, err = fmt.Fprintln(os.Stderr, id)
+	}
+	if err != nil {
 		fmt.Fprintln(os.Stderr, "gmux:", err)
 		return waitExitError
-	}
-	if !noWait {
-		fmt.Fprintln(os.Stdout)
 	}
 	return deliverPrompt(cliSession{ID: id}, agentModePrompt, noWait, timeoutSecs, prompt)
 }
@@ -857,9 +857,10 @@ instructions never end another observer's wait; all user boundaries admitted
 before the source settles appear in the report. Exit 0 means completed, 2 means
 intentionally interrupted, and 1 means failure or timeout.
 
-With --new, stdout is the bare id, a blank line, then the report. With
---new --no-wait, stdout is the id only. Semantic reads and delivery hide runner
-residency: an inactive conversation is resumed automatically when prompted.
+With synchronous --new, the bare session id is printed on stderr the moment the
+session exists and stdout is the report alone. With --new --no-wait, stdout is
+the bare id only. Semantic reads and delivery hide runner residency: an inactive
+conversation is resumed automatically when prompted.
 `)
 	case "agent cancel":
 		fmt.Fprint(w, `gmux agent cancel — interrupt active agent work

--- a/cli/gmux/cmd/gmux/agent_launch_exchange_test.go
+++ b/cli/gmux/cmd/gmux/agent_launch_exchange_test.go
@@ -31,7 +31,7 @@ func TestAgentPromptNewOutputAndOrphanContracts(t *testing.T) {
 		}
 	})
 
-	t.Run("sync id precedes exchange report", func(t *testing.T) {
+	t.Run("sync stdout is the report alone, id on stderr", func(t *testing.T) {
 		d := startStubDaemon(t, localSession())
 		d.on(func(w http.ResponseWriter, _ *http.Request) {
 			writeEnvelope(w, http.StatusOK, map[string]any{"admission": "accepted", "outcome": "completed",
@@ -40,13 +40,19 @@ func TestAgentPromptNewOutputAndOrphanContracts(t *testing.T) {
 		stubAgentLaunch(t, "1va8lvdv", nil)
 		text := "go"
 		var code int
-		stdout := captureStdout(t, func() { code = cmdAgentPromptNew("", "", false, 0, &text) })
-		if code != 0 || !strings.HasPrefix(stdout, "1va8lvdv\n\n[USER]: go") || !strings.Contains(stdout, "[AGENT]: done") {
+		var stderr string
+		stdout := captureStdout(t, func() {
+			stderr = captureStderr(t, func() { code = cmdAgentPromptNew("", "", false, 0, &text) })
+		})
+		if code != 0 || !strings.HasPrefix(stdout, "[USER]: go") || !strings.Contains(stdout, "[AGENT]: done") {
 			t.Fatalf("exit=%d stdout=%q", code, stdout)
+		}
+		if stderr != "1va8lvdv\n" {
+			t.Fatalf("stderr=%q, want bare id line", stderr)
 		}
 	})
 
-	t.Run("failure after spawn still prints id", func(t *testing.T) {
+	t.Run("failure after spawn still prints id on stderr", func(t *testing.T) {
 		d := startStubDaemon(t, localSession())
 		d.on(func(w http.ResponseWriter, _ *http.Request) {
 			writeErrEnvelope(w, http.StatusGatewayTimeout, "admission_timeout", "not ready")
@@ -54,9 +60,15 @@ func TestAgentPromptNewOutputAndOrphanContracts(t *testing.T) {
 		stubAgentLaunch(t, "1va8lvdv", nil)
 		text := "go"
 		var code int
-		stdout := captureStdout(t, func() { captureStderr(t, func() { code = cmdAgentPromptNew("", "", false, 0, &text) }) })
-		if code != waitExitError || stdout != "1va8lvdv\n\n" {
+		var stderr string
+		stdout := captureStdout(t, func() {
+			stderr = captureStderr(t, func() { code = cmdAgentPromptNew("", "", false, 0, &text) })
+		})
+		if code != waitExitError || stdout != "" {
 			t.Fatalf("exit=%d stdout=%q", code, stdout)
+		}
+		if !strings.HasPrefix(stderr, "1va8lvdv\n") {
+			t.Fatalf("stderr=%q, want the id as line 1", stderr)
 		}
 	})
 

--- a/cli/gmux/cmd/gmux/edit.go
+++ b/cli/gmux/cmd/gmux/edit.go
@@ -46,8 +46,9 @@ func runEdit(file string) {
 		parent = os.Getenv("GMUX_SESSION_ID")
 	}
 	runSession(args, true, runDirectives{
-		ForceForeground: true,
-		ParentSessionID: parent,
+		ForceForeground:           true,
+		AttachControllingTerminal: true,
+		ParentSessionID:           parent,
 	})
 }
 

--- a/cli/gmux/cmd/gmux/help.go
+++ b/cli/gmux/cmd/gmux/help.go
@@ -82,6 +82,23 @@ unrecognized name.
 // one-liners in the synopsis. The agent namespace has its own pages in
 // printAgentUsage, and daemon help is served by the gmuxd binary itself.
 var verbHelpPages = map[string]string{
+	"run": `gmux run: run a command in a managed session
+
+  gmux -- <cmd> [args]
+  gmux -d -- <cmd> [args]
+
+A session receives input only through an interactive attach, 'gmux send', or
+'gmux agent prompt'. The launching process's stdin is never forwarded.
+
+The child runs on a terminal, so its stdout and stderr are one stream, as in
+'ssh -t' or 'script'. That payload is written to stdout; gmux's own stderr
+carries the session id and diagnostics.
+
+To launch and then send input from a script:
+
+  id=$(gmux -d -- cmd); gmux send "$id" 'input' Enter
+`,
+
 	"ls": `gmux ls: list sessions, alive first, newest first
 
   gmux ls [--all|-a] [--json|-j]

--- a/cli/gmux/cmd/gmux/run.go
+++ b/cli/gmux/cmd/gmux/run.go
@@ -470,9 +470,15 @@ func runSession(args []string, attach bool, dir runDirectives) {
 	}
 
 	if !interactive {
-		fmt.Printf("session:  %s\n", sessionID)
-		fmt.Printf("adapter:  %s\n", a.Name())
-		fmt.Printf("command:  %s\n", strings.Join(args, " "))
+		// The payload rule (ADR 0028 amendment): stdout carries the child's
+		// output and nothing else, so `gmux -- pnpm build | tail` reads the
+		// build, not gmux metadata. The session id goes to stderr — printed
+		// before the child runs, so a watcher can still attach or tail while
+		// the command is starting. LocalOut relays the PTY stream to stdout
+		// with escapes stripped and CRLF normalised; the UI and scrollback
+		// keep the full escape stream.
+		fmt.Fprintln(os.Stderr, sessionID)
+		ptyCfg.LocalOut = newANSIStrippingWriter(os.Stdout)
 	}
 
 	// Start PTY server. The socket is already bound to `listener`
@@ -509,12 +515,6 @@ func runSession(args []string, attach bool, dir runDirectives) {
 	// Active, and a launch-time true would misreport an idle agent.
 	if !adapter.HookDriven(a) {
 		state.SetStatus(&adapter.Status{Active: true})
-	}
-
-	if !interactive {
-		fmt.Printf("pid:      %d\n", srv.Pid())
-		fmt.Printf("socket:   %s\n", srv.SocketPath())
-		fmt.Println("serving...")
 	}
 
 	var detachedSigCh chan os.Signal
@@ -604,8 +604,7 @@ func runSession(args []string, attach bool, dir runDirectives) {
 		select {
 		case <-srv.Done():
 			// Child exited
-		case sig := <-sigCh:
-			fmt.Printf("\nreceived %v, shutting down...\n", sig)
+		case <-sigCh:
 			if handshakeOwned {
 				shutdownDetachedTarget(srv)
 			} else {
@@ -653,9 +652,6 @@ func runSession(args []string, attach bool, dir runDirectives) {
 	// (pathname unlinked, lease released) → os.Exit.
 	srv.Shutdown()
 
-	if !interactive {
-		fmt.Printf("exited:   %d\n", exitCode)
-	}
 	waitForHandshakeRelease()
 	os.Exit(exitCode)
 }

--- a/cli/gmux/cmd/gmux/run.go
+++ b/cli/gmux/cmd/gmux/run.go
@@ -78,6 +78,11 @@ type runDirectives struct {
 	// to the invoking program (git would commit an unedited message).
 	ForceForeground bool
 
+	// AttachControllingTerminal binds the interactive attach to /dev/tty
+	// instead of inherited stdin/stdout. Used only by `gmux edit`, whose UI
+	// must remain interactive when its caller redirects stdout.
+	AttachControllingTerminal bool
+
 	// ParentSessionID records the session this one was spawned from
 	// (e.g. `gmux edit` invoked as $EDITOR inside an existing session).
 	// Flows into session meta so the UI can relate the two.
@@ -168,8 +173,8 @@ func processGroupExists(pgid int) bool {
 
 // runSession launches a new managed session for the given command.
 //
-// When attach is true and stdin is a tty, the local terminal is wired
-// to the PTY so the command behaves transparently (the default). When
+// When attach is true and stdin and stdout are ttys, the local terminal is
+// wired to the PTY so the command behaves transparently (the default). When
 // attach is false, the session is spawned detached from the tty and
 // this call returns immediately once the session is running, leaving
 // the session visible in the gmux UI.
@@ -187,12 +192,27 @@ func runSession(args []string, attach bool, dir runDirectives) {
 		execPassthrough(args)
 	}
 
+	attachStdin, attachStdout := os.Stdin, os.Stdout
+	var controllingTTY *os.File
+	if dir.AttachControllingTerminal {
+		var err error
+		controllingTTY, err = os.OpenFile("/dev/tty", os.O_RDWR, 0)
+		if err != nil {
+			log.Fatalf("gmux edit requires a controlling terminal: %v", err)
+		}
+		defer controllingTTY.Close()
+		if !localterm.IsTransparentFiles(controllingTTY, controllingTTY) {
+			log.Fatalf("gmux edit requires a controlling terminal")
+		}
+		attachStdin, attachStdout = controllingTTY, controllingTTY
+	}
+
 	// Nested gmux detection: if we're running interactively inside an
 	// existing gmux session, re-exec as a detached headless process instead
 	// of doing PTY passthrough (which would nest PTY-within-PTY). The
 	// detached process registers with gmuxd and the session appears in the
 	// gmux UI. The original process returns immediately to the parent shell.
-	if os.Getenv("GMUX") == "1" && localterm.IsInteractive() && !dir.ForceForeground {
+	if os.Getenv("GMUX") == "1" && localterm.IsTransparent() && !dir.ForceForeground {
 		spawnDetached(args, "started "+strings.Join(args, " ")+" in background (visible in gmux)", false)
 		return
 	}
@@ -352,7 +372,7 @@ func runSession(args []string, attach bool, dir runDirectives) {
 	env = append(env, adapterEnv...)
 	env = append(env, sessionEditorEnv(os.LookupEnv, os.Executable)...)
 
-	interactive := localterm.IsInteractive()
+	interactive := dir.AttachControllingTerminal || localterm.IsTransparent()
 
 	// Open the persistent scrollback sink for this runner. Best-
 	// effort: a failure to open (disk full, permission denied)
@@ -422,9 +442,14 @@ func runSession(args []string, attach bool, dir runDirectives) {
 	// Even non-interactive launches (background, piped) benefit from
 	// a real size: the PTY and virtual terminal start correctly sized
 	// instead of falling back to 80x24.
-	if cols, rows, err := localterm.TerminalSize(); err == nil {
-		ptyCfg.Cols = cols
-		ptyCfg.Rows = rows
+	var sizeErr error
+	if dir.AttachControllingTerminal {
+		ptyCfg.Cols, ptyCfg.Rows, sizeErr = localterm.TerminalSizeFiles(controllingTTY)
+	} else {
+		ptyCfg.Cols, ptyCfg.Rows, sizeErr = localterm.TerminalSize()
+	}
+	if sizeErr != nil {
+		ptyCfg.Cols, ptyCfg.Rows = 0, 0
 	}
 	// --initial-cols / --initial-rows, when the daemon passed
 	// them on /resume or /restart, override the local TTY
@@ -457,6 +482,8 @@ func runSession(args []string, attach bool, dir runDirectives) {
 	)
 	if interactive {
 		lt, err := localterm.New(localterm.Config{
+			Stdin:  attachStdin,
+			Stdout: attachStdout,
 			PTYWriter: ptyWriterFunc(func(p []byte) (int, error) {
 				return srv.WritePTY(p)
 			}),
@@ -478,6 +505,9 @@ func runSession(args []string, attach bool, dir runDirectives) {
 		// with escapes stripped and CRLF normalised; the UI and scrollback
 		// keep the full escape stream.
 		fmt.Fprintln(os.Stderr, sessionID)
+		if stdinHasPendingData(os.Stdin) {
+			fmt.Fprintf(os.Stderr, "gmux: stdin is not forwarded into the session; use 'gmux send %s'.\n", sessionID)
+		}
 		ptyCfg.LocalOut = newANSIStrippingWriter(os.Stdout)
 	}
 
@@ -651,6 +681,9 @@ func runSession(args []string, attach bool, dir runDirectives) {
 	// Ordering: PTY drain → exit event → <-regDone → deregister → Shutdown
 	// (pathname unlinked, lease released) → os.Exit.
 	srv.Shutdown()
+	if controllingTTY != nil {
+		_ = controllingTTY.Close()
+	}
 
 	waitForHandshakeRelease()
 	os.Exit(exitCode)

--- a/cli/gmux/cmd/gmux/run_output_contract_test.go
+++ b/cli/gmux/cmd/gmux/run_output_contract_test.go
@@ -1,0 +1,99 @@
+package main
+
+// run_output_contract_test.go — acceptance for the CLI output-channel rule
+// (ADR 0028 amendment): in the non-interactive `gmux -- <cmd>` flow, stdout
+// carries exactly the payload the command was asked to produce — the child's
+// output, ANSI-stripped and CRLF-normalised — while the session id goes to
+// stderr. `gmux -d` keeps the id on stdout because the id IS its payload.
+//
+// Like run_socket_lifecycle_test.go, these tests run the real binary: the
+// contract lives in runSession, a func that ends in os.Exit.
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/gmuxapp/gmux/packages/paths"
+)
+
+// runGmux runs the built gmux binary with the given args in an isolated
+// environment and returns stdout, stderr, and the exit code.
+func runGmux(t *testing.T, env []string, args ...string) (string, string, int) {
+	t.Helper()
+	bin := buildGmuxBinary(t)
+	cmd := exec.Command(bin, args...)
+	cmd.Env = env
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	code := 0
+	if err != nil {
+		exitErr, ok := err.(*exec.ExitError)
+		if !ok {
+			t.Fatalf("gmux %v: %v\nstdout: %s\nstderr: %s", args, err, stdout.String(), stderr.String())
+		}
+		code = exitErr.ExitCode()
+	}
+	return stdout.String(), stderr.String(), code
+}
+
+func outputContractEnv(t *testing.T) []string {
+	t.Helper()
+	stateHome := t.TempDir()
+	socketDir := t.TempDir() + "/sessions"
+	startFakeDaemon(t, stateHome+"/gmux/gmuxd.sock")
+	return launchEnv(stateHome, socketDir)
+}
+
+// TestPipedRunStdoutIsChildOutput pins the payload rule for the piped flow:
+// stdout is the child's output — escapes stripped, CRLF normalised — and
+// nothing else; the session id is a bare line on stderr.
+func TestPipedRunStdoutIsChildOutput(t *testing.T) {
+	env := outputContractEnv(t)
+	stdout, stderr, code := runGmux(t, env, "--",
+		"sh", "-c", `printf '\033[31mred\033[0m one\ntwo\r\n\033]0;title\007three\n'`)
+	if code != 0 {
+		t.Fatalf("exit=%d\nstdout: %q\nstderr: %q", code, stdout, stderr)
+	}
+	if stdout != "red one\ntwo\nthree\n" {
+		t.Errorf("stdout = %q, want the child's plain output alone", stdout)
+	}
+	id := strings.TrimSpace(stderr)
+	if !paths.IsValidSessionID(id) {
+		t.Errorf("stderr = %q, want a bare session id line", stderr)
+	}
+}
+
+// TestPipedRunPropagatesExitCode: a failing child fails the gmux invocation,
+// with no payload invented on stdout.
+func TestPipedRunPropagatesExitCode(t *testing.T) {
+	env := outputContractEnv(t)
+	stdout, stderr, code := runGmux(t, env, "--", "false")
+	if code != 1 {
+		t.Fatalf("exit=%d, want 1\nstdout: %q\nstderr: %q", code, stdout, stderr)
+	}
+	if stdout != "" {
+		t.Errorf("stdout = %q, want empty for a silent child", stdout)
+	}
+	if !paths.IsValidSessionID(strings.TrimSpace(stderr)) {
+		t.Errorf("stderr = %q, want a bare session id line", stderr)
+	}
+}
+
+// TestDetachedRunKeepsIDOnStdout: for `gmux -d` the id is the payload, so it
+// stays on stdout (the id=$(gmux -d -- …) capture shape), stderr silent.
+func TestDetachedRunKeepsIDOnStdout(t *testing.T) {
+	env := outputContractEnv(t)
+	stdout, stderr, code := runGmux(t, env, "-d", "--", "sleep", "0.1")
+	if code != 0 {
+		t.Fatalf("exit=%d\nstdout: %q\nstderr: %q", code, stdout, stderr)
+	}
+	if !paths.IsValidSessionID(strings.TrimSpace(stdout)) {
+		t.Errorf("stdout = %q, want the bare session id", stdout)
+	}
+	if stderr != "" {
+		t.Errorf("stderr = %q, want empty on a successful detach", stderr)
+	}
+}

--- a/cli/gmux/cmd/gmux/run_socket_lifecycle_test.go
+++ b/cli/gmux/cmd/gmux/run_socket_lifecycle_test.go
@@ -194,12 +194,20 @@ func TestShortLaunchesLeaveNoSocketPathnames(t *testing.T) {
 	for i := range launches {
 		cmd := exec.Command(bin, "--", "true")
 		cmd.Env = env
-		out, err := cmd.CombinedOutput()
-		if err != nil {
-			t.Fatalf("launch %d: %v\n%s", i, err, out)
+		var stdout, stderr strings.Builder
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("launch %d: %v\nstdout: %s\nstderr: %s", i, err, stdout.String(), stderr.String())
 		}
-		if !strings.Contains(string(out), "exited:   0") {
-			t.Fatalf("launch %d did not report a clean exit:\n%s", i, out)
+		// The payload rule: stdout carries only the child's output (`true`
+		// prints nothing), the bare session id goes to stderr.
+		if stdout.String() != "" {
+			t.Fatalf("launch %d wrote non-payload bytes to stdout: %q", i, stdout.String())
+		}
+		id := strings.TrimSpace(stderr.String())
+		if len(id) != 8 {
+			t.Fatalf("launch %d did not report a bare 8-character session id on stderr: %q", i, stderr.String())
 		}
 		// The socket pathname must be gone the moment the process is: the
 		// runner owns it, and nothing else is going to clean it up.
@@ -240,15 +248,17 @@ func TestResumedSessionIDRebindsAfterExit(t *testing.T) {
 	for i := range 5 {
 		cmd := exec.Command(bin, "--", "true")
 		cmd.Env = env
-		out, err := cmd.CombinedOutput()
-		if err != nil {
-			t.Fatalf("launch %d: %v\n%s", i, err, out)
+		var stdout, stderr strings.Builder
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("launch %d: %v\nstdout: %s\nstderr: %s", i, err, stdout.String(), stderr.String())
 		}
 		// The resume id must be honoured every time. A leaked lease would
-		// push the runner onto a freshly minted id instead.
-		want := filepath.Join(socketDir, "10khtpym.sock")
-		if !strings.Contains(string(out), "socket:   "+want) {
-			t.Fatalf("launch %d did not bind the resumed id:\n%s", i, out)
+		// push the runner onto a freshly minted id instead. The runner reports
+		// its session id on stderr.
+		if strings.TrimSpace(stderr.String()) != "10khtpym" {
+			t.Fatalf("launch %d did not bind the resumed id:\nstderr: %s", i, stderr.String())
 		}
 		if left := leftoverSockets(t, socketDir); len(left) != 0 {
 			t.Fatalf("launch %d left %v behind", i, left)

--- a/cli/gmux/cmd/gmux/run_stdin_contract_test.go
+++ b/cli/gmux/cmd/gmux/run_stdin_contract_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/gmuxapp/gmux/packages/paths"
+)
+
+func runGmuxWithStdin(t *testing.T, env []string, stdin io.Reader, args ...string) (string, string, int) {
+	t.Helper()
+	cmd := exec.Command(buildGmuxBinary(t), args...)
+	cmd.Env = env
+	cmd.Stdin = stdin
+	var stdout, stderr strings.Builder
+	cmd.Stdout, cmd.Stderr = &stdout, &stderr
+	err := cmd.Run()
+	if err == nil {
+		return stdout.String(), stderr.String(), 0
+	}
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok {
+		t.Fatalf("gmux %v: %v\nstdout: %s\nstderr: %s", args, err, stdout.String(), stderr.String())
+	}
+	return stdout.String(), stderr.String(), exitErr.ExitCode()
+}
+
+func assertStdinContractRun(t *testing.T, stdin io.Reader, wantNotice bool) {
+	t.Helper()
+	stdout, stderr, code := runGmuxWithStdin(t, outputContractEnv(t), stdin, "--", "sh", "-c",
+		"stty -icanon min 0 time 1; data=$(dd bs=1 count=16 2>/dev/null); printf 'out:%s\\n' \"$data\"; exit 7")
+	if code != 7 {
+		t.Fatalf("exit=%d, want 7\nstdout: %q\nstderr: %q", code, stdout, stderr)
+	}
+	if stdout != "out:\n" {
+		t.Errorf("stdout=%q, want child output with no forwarded input", stdout)
+	}
+	lines := strings.Split(strings.TrimSpace(stderr), "\n")
+	if len(lines) == 0 || !paths.IsValidSessionID(lines[0]) {
+		t.Fatalf("stderr=%q, want session id first", stderr)
+	}
+	hasNotice := strings.Contains(stderr, "stdin is not forwarded into the session; use 'gmux send "+lines[0]+"'.")
+	if hasNotice != wantNotice {
+		t.Errorf("notice=%v, want %v; stderr=%q", hasNotice, wantNotice, stderr)
+	}
+}
+
+func TestPrefilledPipeStdinWarnsAndIsNotForwarded(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.WriteString("input\\n"); err != nil {
+		t.Fatal(err)
+	}
+	_ = w.Close()
+	defer r.Close()
+	assertStdinContractRun(t, r, true)
+}
+
+func TestEmptyPipeStdinDoesNotWarn(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+	defer w.Close()
+	assertStdinContractRun(t, r, false)
+}
+
+func TestDevNullStdinDoesNotWarn(t *testing.T) {
+	f, err := os.Open(os.DevNull)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	assertStdinContractRun(t, f, false)
+}
+
+func TestRegularFileStdinWarns(t *testing.T) {
+	assertStdinContractRun(t, regularInputFile(t, "input\\n"), true)
+}

--- a/cli/gmux/cmd/gmux/run_terminal_contract_test.go
+++ b/cli/gmux/cmd/gmux/run_terminal_contract_test.go
@@ -1,0 +1,263 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func requireScript(t *testing.T) string {
+	t.Helper()
+	path, err := exec.LookPath("script")
+	if err != nil {
+		t.Skip("script(1) is not available")
+	}
+	if !supportsRequiredScriptDialect(path) {
+		t.Skip("script(1) does not support util-linux -qec")
+	}
+	return path
+}
+
+// supportsRequiredScriptDialect contains a normally hung tool on timeout; a
+// successful capability probe assumes the executable returns without daemonizing.
+func supportsRequiredScriptDialect(path string) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, path, "-qec", "exit 23", os.DevNull)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	}
+	cmd.WaitDelay = 100 * time.Millisecond
+	cmd.Stdin = nil
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+	err := cmd.Run()
+	if ctx.Err() != nil {
+		return false
+	}
+	var exitErr *exec.ExitError
+	return errors.As(err, &exitErr) && exitErr.ExitCode() == 23
+}
+
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
+}
+
+func fakeScript(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "script")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"+content), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestRequiredScriptDialectRejectsOptionError(t *testing.T) {
+	path := fakeScript(t, "case \"$1\" in *e*) exit 64;; esac\nexit 0\n")
+	if supportsRequiredScriptDialect(path) {
+		t.Fatal("accepted script implementation that rejects -e")
+	}
+}
+
+func TestRequiredScriptDialectRejectsNoExecImplementation(t *testing.T) {
+	path := fakeScript(t, "exit 0\n")
+	if supportsRequiredScriptDialect(path) {
+		t.Fatal("accepted script implementation that never executes the command")
+	}
+}
+
+func TestRequiredScriptDialectBoundsHangingImplementation(t *testing.T) {
+	dir := t.TempDir()
+	leaderFile := filepath.Join(dir, "leader.pid")
+	childFile := filepath.Join(dir, "child.pid")
+	path := fakeScript(t, "echo $$ >"+shellQuote(leaderFile)+"\n"+
+		"sleep 30 & child=$!\n"+
+		"echo $child >"+shellQuote(childFile)+"\n"+
+		"wait\n")
+
+	start := time.Now()
+	if supportsRequiredScriptDialect(path) {
+		t.Fatal("accepted hanging script implementation")
+	}
+	if elapsed := time.Since(start); elapsed > 3*time.Second {
+		t.Fatalf("capability probe took %v, want a bounded result", elapsed)
+	}
+
+	leader := readPIDFile(t, leaderFile)
+	child := readPIDFile(t, childFile)
+	// This also makes mutation failures safe: never leave the fake tool's
+	// descendant behind if the production cleanup stops killing its group.
+	cleanupArmed := true
+	t.Cleanup(func() {
+		if cleanupArmed {
+			_ = syscall.Kill(-leader, syscall.SIGKILL)
+			_ = syscall.Kill(child, syscall.SIGKILL)
+		}
+	})
+	deadline := time.Now().Add(2 * time.Second)
+	for _, proc := range []struct {
+		name string
+		pid  int
+	}{{"leader", leader}, {"child", child}, {"process group", -leader}} {
+		for {
+			err := syscall.Kill(proc.pid, 0)
+			if errors.Is(err, syscall.ESRCH) {
+				break
+			}
+			if err != nil {
+				t.Fatalf("probe %s existence: %v", proc.name, err)
+			}
+			if time.Now().After(deadline) {
+				t.Fatalf("probe %s %d still exists after timeout cleanup", proc.name, proc.pid)
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+	// All recorded process identities are gone. Do not signal numeric IDs that
+	// the OS might reuse before test cleanup runs.
+	cleanupArmed = false
+}
+
+func readPIDFile(t *testing.T, path string) int {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read probe pid %s: %v", path, err)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(raw)))
+	if err != nil || pid <= 0 {
+		t.Fatalf("invalid probe pid %q in %s", raw, path)
+	}
+	return pid
+}
+
+func TestRequiredScriptDialectAcceptsInstalledUtilLinux(t *testing.T) {
+	path, err := exec.LookPath("script")
+	if err != nil {
+		t.Skip("script(1) is not available")
+	}
+	out, err := exec.Command(path, "--version").CombinedOutput()
+	if err != nil || !strings.Contains(strings.ToLower(string(out)), "util-linux") {
+		t.Skip("installed script(1) is not util-linux")
+	}
+	if !supportsRequiredScriptDialect(path) {
+		t.Fatal("util-linux script failed the required -qec capability probe")
+	}
+}
+
+func TestRequireScriptWiringSkipsIncompatibleDialect(t *testing.T) {
+	fake := fakeScript(t, "exit 0\n")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestTTYStdinWithPipedStdoutUsesHeadlessRelay$", "-test.v")
+	for _, entry := range os.Environ() {
+		if !strings.HasPrefix(entry, "PATH=") {
+			cmd.Env = append(cmd.Env, entry)
+		}
+	}
+	cmd.Env = append(cmd.Env, "PATH="+filepath.Dir(fake))
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() != nil {
+		t.Fatalf("wiring subprocess timed out: %v", ctx.Err())
+	}
+	if err != nil {
+		t.Fatalf("wiring subprocess failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "--- SKIP: TestTTYStdinWithPipedStdoutUsesHeadlessRelay") {
+		t.Fatalf("wiring subprocess did not skip incompatible script:\n%s", out)
+	}
+}
+
+func TestTTYStdinWithPipedStdoutUsesHeadlessRelay(t *testing.T) {
+	script := requireScript(t)
+	bin := buildGmuxBinary(t)
+	capture := filepath.Join(t.TempDir(), "stdout")
+	command := shellQuote(bin) + " -- sh -c " + shellQuote("printf '\\033[31mred\\033[0m\\n'") + " >" + shellQuote(capture)
+	cmd := exec.Command(script, "-qec", command, os.DevNull)
+	cmd.Env = outputContractEnv(t)
+	var transcript strings.Builder
+	cmd.Stdout, cmd.Stderr = &transcript, &transcript
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("script probe: %v\ntranscript: %q", err, transcript.String())
+	}
+	got, err := os.ReadFile(capture)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "red\n" {
+		t.Fatalf("piped stdout=%q, want stripped child output", got)
+	}
+	if strings.Contains(string(got), "\x1b") {
+		t.Fatalf("piped stdout contains terminal escapes: %q", got)
+	}
+}
+
+func TestEditUsesControllingTerminalWhenStdoutIsRedirected(t *testing.T) {
+	script := requireScript(t)
+	bin := buildGmuxBinary(t)
+	dir := t.TempDir()
+	editor := filepath.Join(dir, "editor")
+	content := "#!/bin/sh\nIFS= read -r key\nprintf '%s' \"$key\" > \"$1\"\nprintf '\\033[31meditor-ui\\033[0m\\n'\nexit 7\n"
+	if err := os.WriteFile(editor, []byte(content), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	file := filepath.Join(dir, "edited")
+	capture := filepath.Join(dir, "stdout")
+	command := shellQuote(bin) + " edit " + shellQuote(file) + " >" + shellQuote(capture)
+	cmd := exec.Command(script, "-qec", command, os.DevNull)
+	cmd.Env = append(outputContractEnv(t), "GMUX_EDIT_FALLBACK="+editor)
+	cmd.Stdin = strings.NewReader("typed\n")
+	var transcript strings.Builder
+	cmd.Stdout, cmd.Stderr = &transcript, &transcript
+	err := cmd.Run()
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) || exitErr.ExitCode() != 7 {
+		t.Fatalf("exit error=%v, want editor exit 7\ntranscript: %q", err, transcript.String())
+	}
+	got, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatalf("editor did not receive terminal input: %v\ntranscript: %q", err, transcript.String())
+	}
+	if string(got) != "typed" {
+		t.Errorf("edited content=%q, want typed", got)
+	}
+	redirected, err := os.ReadFile(capture)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(redirected) != 0 {
+		t.Errorf("redirected stdout=%q, want editor UI only on /dev/tty", redirected)
+	}
+	if !strings.Contains(transcript.String(), "editor-ui") {
+		t.Errorf("terminal transcript=%q, want editor UI", transcript.String())
+	}
+}
+
+func TestEditWithoutControllingTerminalFailsBeforeLaunch(t *testing.T) {
+	bin := buildGmuxBinary(t)
+	cmd := exec.Command(bin, "edit", filepath.Join(t.TempDir(), "file"))
+	cmd.Env = outputContractEnv(t)
+	cmd.Stdin = strings.NewReader("")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	var stdout, stderr strings.Builder
+	cmd.Stdout, cmd.Stderr = &stdout, &stderr
+	err := cmd.Run()
+	if err == nil {
+		t.Fatal("edit unexpectedly succeeded without a controlling terminal")
+	}
+	if stdout.Len() != 0 || !strings.Contains(stderr.String(), "requires a controlling terminal") {
+		t.Fatalf("stdout=%q stderr=%q, want controlling-terminal error", stdout.String(), stderr.String())
+	}
+}

--- a/cli/gmux/cmd/gmux/stdin_notice.go
+++ b/cli/gmux/cmd/gmux/stdin_notice.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// stdinHasPendingData reports whether f contains launch-time input which the
+// headless session path will not forward. It is deliberately non-consuming
+// and best-effort: any inspection error means no notice.
+func stdinHasPendingData(f *os.File) bool {
+	info, err := f.Stat()
+	if err != nil {
+		return false
+	}
+
+	switch {
+	case info.Mode().IsRegular():
+		offset, err := f.Seek(0, 1)
+		return err == nil && info.Size() > offset
+	case info.Mode()&os.ModeNamedPipe != 0:
+		fds := []unix.PollFd{{Fd: int32(f.Fd()), Events: unix.POLLIN}}
+		n, err := unix.Poll(fds, 0)
+		return err == nil && n > 0 && fds[0].Revents&unix.POLLIN != 0
+	default:
+		// Character devices (including /dev/null), sockets, and unknown file
+		// types are not launcher input, even when poll calls them readable.
+		return false
+	}
+}

--- a/cli/gmux/cmd/gmux/stdin_notice_test.go
+++ b/cli/gmux/cmd/gmux/stdin_notice_test.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestStdinHasPendingData(t *testing.T) {
+	t.Run("pipe with data", func(t *testing.T) {
+		r, w, err := os.Pipe()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer r.Close()
+		defer w.Close()
+		if _, err := w.WriteString("input"); err != nil {
+			t.Fatal(err)
+		}
+		if !stdinHasPendingData(r) {
+			t.Error("want pending data")
+		}
+		got := make([]byte, len("input"))
+		if _, err := r.Read(got); err != nil {
+			t.Fatal(err)
+		}
+		if string(got) != "input" {
+			t.Errorf("read %q after inspection, want original input", got)
+		}
+	})
+
+	t.Run("empty open pipe", func(t *testing.T) {
+		r, w, err := os.Pipe()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer r.Close()
+		defer w.Close()
+		if stdinHasPendingData(r) {
+			t.Error("empty pipe reported pending data")
+		}
+	})
+
+	t.Run("dev null", func(t *testing.T) {
+		f, err := os.Open(os.DevNull)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer f.Close()
+		if stdinHasPendingData(f) {
+			t.Error("/dev/null reported pending data")
+		}
+	})
+
+	t.Run("regular file with remaining content", func(t *testing.T) {
+		f := regularInputFile(t, "input")
+		if _, err := f.Seek(2, 0); err != nil {
+			t.Fatal(err)
+		}
+		if !stdinHasPendingData(f) {
+			t.Error("want pending data")
+		}
+		offset, err := f.Seek(0, 1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if offset != 2 {
+			t.Errorf("offset=%d after inspection, want 2", offset)
+		}
+		got := make([]byte, 3)
+		if _, err := f.Read(got); err != nil {
+			t.Fatal(err)
+		}
+		if string(got) != "put" {
+			t.Errorf("remaining content=%q, want %q", got, "put")
+		}
+	})
+
+	t.Run("regular file at end", func(t *testing.T) {
+		f := regularInputFile(t, "input")
+		if _, err := f.Seek(0, 2); err != nil {
+			t.Fatal(err)
+		}
+		if stdinHasPendingData(f) {
+			t.Error("file at end reported pending data")
+		}
+	})
+}
+
+func regularInputFile(t *testing.T, content string) *os.File {
+	t.Helper()
+	path := t.TempDir() + "/stdin"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = f.Close() })
+	return f
+}

--- a/cli/gmux/cmd/gmux/streamstrip.go
+++ b/cli/gmux/cmd/gmux/streamstrip.go
@@ -1,0 +1,110 @@
+package main
+
+import "io"
+
+// ansiStrippingWriter is a stream-safe variant of stripANSI: it removes
+// ANSI/VT escape sequences and carriage returns from PTY output on its way
+// to a downstream writer, carrying parser state across Write calls so an
+// escape sequence split over two PTY reads is still recognized. It exists
+// for the non-interactive `gmux -- <cmd>` flow, where the child's PTY output
+// is relayed to the caller's stdout: the UI and scrollback keep the full
+// escape stream, only this relay is cleaned.
+//
+// Dropping every '\r' both normalises the PTY's CRLF line endings to LF and
+// collapses bare-CR progress redraws, matching stripANSI's behaviour for
+// `gmux tail`. Like stripANSI it is a pragmatic stripper, not a terminal
+// emulator: CSI (ESC [ ... final-byte), OSC (ESC ] ... BEL/ST), DCS/SOS/PM/APC
+// control strings (ESC P/X/^/_ ... ST), and lone two-byte escapes are handled.
+type ansiStrippingWriter struct {
+	w     io.Writer
+	state ansiStripState
+}
+
+type ansiStripState int
+
+const (
+	ansiStripText      ansiStripState = iota // ordinary output
+	ansiStripEsc                             // seen ESC, awaiting the selector byte
+	ansiStripCSI                             // inside ESC [ ... awaiting final byte 0x40-0x7e
+	ansiStripOSC                             // inside ESC ] ... awaiting BEL or ESC \
+	ansiStripOSCEsc                          // inside OSC, seen ESC (possible ST)
+	ansiStripString                          // inside DCS/SOS/PM/APC ... awaiting ESC \
+	ansiStripStringEsc                       // inside a control string, seen ESC (possible ST)
+)
+
+func newANSIStrippingWriter(w io.Writer) *ansiStrippingWriter {
+	return &ansiStrippingWriter{w: w}
+}
+
+// Write filters p and forwards the surviving bytes downstream. It reports
+// len(p) consumed on success: bytes swallowed by the filter are consumed by
+// design, not lost.
+func (a *ansiStrippingWriter) Write(p []byte) (int, error) {
+	out := make([]byte, 0, len(p))
+	for _, c := range p {
+		switch a.state {
+		case ansiStripText:
+			switch c {
+			case 0x1b:
+				a.state = ansiStripEsc
+			case '\r':
+				// dropped: CRLF becomes LF, bare-CR redraws collapse
+			default:
+				out = append(out, c)
+			}
+		case ansiStripEsc:
+			switch c {
+			case '[':
+				a.state = ansiStripCSI
+			case ']':
+				a.state = ansiStripOSC
+			case 'P', 'X', '^', '_': // DCS, SOS, PM, APC: terminated by ST
+				a.state = ansiStripString
+			default: // two-byte escape: the selector is the last byte
+				a.state = ansiStripText
+			}
+		case ansiStripCSI:
+			if c >= 0x40 && c <= 0x7e { // final byte
+				a.state = ansiStripText
+			}
+		case ansiStripOSC:
+			switch c {
+			case 0x07: // BEL terminator
+				a.state = ansiStripText
+			case 0x1b: // possible ESC \ (ST) terminator
+				a.state = ansiStripOSCEsc
+			}
+		case ansiStripOSCEsc:
+			if c == '\\' { // ST
+				a.state = ansiStripText
+			} else {
+				// Not a terminator; stay inside the OSC string. A second
+				// ESC keeps the maybe-ST state alive.
+				if c != 0x1b {
+					a.state = ansiStripOSC
+				}
+			}
+		case ansiStripString:
+			if c == 0x1b {
+				a.state = ansiStripStringEsc
+			}
+		case ansiStripStringEsc:
+			if c == '\\' { // ST
+				a.state = ansiStripText
+			} else if c != 0x1b {
+				// Not a terminator. A second ESC remains a possible ST.
+				a.state = ansiStripString
+			}
+		}
+	}
+	if len(out) > 0 {
+		n, err := a.w.Write(out)
+		if err != nil {
+			return 0, err
+		}
+		if n != len(out) {
+			return 0, io.ErrShortWrite
+		}
+	}
+	return len(p), nil
+}

--- a/cli/gmux/cmd/gmux/streamstrip_test.go
+++ b/cli/gmux/cmd/gmux/streamstrip_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+type shortWriter struct{}
+
+func (shortWriter) Write(p []byte) (int, error) { return len(p) - 1, nil }
+
+func TestANSIStrippingWriter(t *testing.T) {
+	cases := []struct {
+		name   string
+		chunks []string
+		want   string
+	}{
+		{"plain", []string{"hello\n"}, "hello\n"},
+		{"crlf normalised", []string{"one\r\ntwo\r\n"}, "one\ntwo\n"},
+		{"bare cr collapsed", []string{"50%\rdone\n"}, "50%done\n"},
+		{"csi stripped", []string{"\x1b[31mred\x1b[0m\n"}, "red\n"},
+		{"osc bel stripped", []string{"\x1b]0;title\x07text\n"}, "text\n"},
+		{"osc st stripped", []string{"\x1b]0;title\x1b\\text\n"}, "text\n"},
+		{"dcs stripped", []string{"before\x1bPq?sixel-data\x1b\\after"}, "beforeafter"},
+		{"string controls stripped", []string{"a\x1bXprivate\x1b\\b\x1b^private\x1b\\c\x1b_private\x1b\\d"}, "abcd"},
+		{"two-byte escape stripped", []string{"\x1b=x\n"}, "x\n"},
+		// The reason this type exists: sequences split across Write calls.
+		{"csi split across writes", []string{"a\x1b[3", "1mred\x1b[", "0mb\n"}, "aredb\n"},
+		{"esc at chunk boundary", []string{"a\x1b", "[1mb"}, "ab"},
+		{"crlf split across writes", []string{"one\r", "\ntwo"}, "one\ntwo"},
+		{"osc split across writes", []string{"\x1b]0;ti", "tle\x07ok"}, "ok"},
+		{"osc st split across writes", []string{"\x1b]0;title\x1b", "\\ok"}, "ok"},
+		{"dcs split across writes", []string{"before\x1b", "Pq?sixel-", "data\x1b", "\\after"}, "beforeafter"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var out strings.Builder
+			w := newANSIStrippingWriter(&out)
+			for _, chunk := range tc.chunks {
+				n, err := w.Write([]byte(chunk))
+				if err != nil || n != len(chunk) {
+					t.Fatalf("Write(%q) = (%d, %v), want (%d, nil)", chunk, n, err, len(chunk))
+				}
+			}
+			if out.String() != tc.want {
+				t.Errorf("got %q, want %q", out.String(), tc.want)
+			}
+		})
+	}
+}
+
+func TestANSIStrippingWriterRejectsShortWrite(t *testing.T) {
+	w := newANSIStrippingWriter(shortWriter{})
+	if _, err := w.Write([]byte("text")); !errors.Is(err, io.ErrShortWrite) {
+		t.Fatalf("Write error = %v, want io.ErrShortWrite", err)
+	}
+}

--- a/cli/gmux/internal/localterm/localterm.go
+++ b/cli/gmux/internal/localterm/localterm.go
@@ -35,11 +35,30 @@ func IsInteractive() bool {
 	return term.IsTerminal(int(os.Stdin.Fd()))
 }
 
+// IsTransparent returns true when stdin and stdout are both terminals.
+func IsTransparent() bool {
+	return IsTransparentFiles(os.Stdin, os.Stdout)
+}
+
+// IsTransparentFiles reports whether input and output can host a transparent
+// terminal attachment.
+func IsTransparentFiles(stdin, stdout *os.File) bool {
+	return stdin != nil && stdout != nil && term.IsTerminal(int(stdin.Fd())) && term.IsTerminal(int(stdout.Fd()))
+}
+
 // TerminalSize returns the current terminal dimensions.
 // It tries stdin, stdout, and stderr in order, since background
 // processes may have stdin redirected to /dev/null.
 func TerminalSize() (cols, rows uint16, err error) {
-	for _, f := range []*os.File{os.Stdin, os.Stdout, os.Stderr} {
+	return TerminalSizeFiles(os.Stdin, os.Stdout, os.Stderr)
+}
+
+// TerminalSizeFiles returns dimensions from the first terminal in files.
+func TerminalSizeFiles(files ...*os.File) (cols, rows uint16, err error) {
+	for _, f := range files {
+		if f == nil {
+			continue
+		}
 		w, h, e := term.GetSize(int(f.Fd()))
 		if e == nil {
 			return uint16(w), uint16(h), nil
@@ -51,6 +70,10 @@ func TerminalSize() (cols, rows uint16, err error) {
 
 // Config for creating a local terminal attachment.
 type Config struct {
+	// Stdin and Stdout select the attached terminal. Nil uses the process's
+	// corresponding standard stream.
+	Stdin  *os.File
+	Stdout *os.File
 	// PTYWriter receives bytes from stdin (writes to ptmx).
 	PTYWriter io.Writer
 	// ResizeFn is called when the terminal is resized.
@@ -67,8 +90,17 @@ type Config struct {
 // any PTY bytes are read, so fast-exiting commands don't race the
 // attach wiring and lose their output.
 func New(cfg Config) (*Attach, error) {
-	stdin := os.Stdin
-	stdout := os.Stdout
+	stdin := cfg.Stdin
+	if stdin == nil {
+		stdin = os.Stdin
+	}
+	stdout := cfg.Stdout
+	if stdout == nil {
+		stdout = os.Stdout
+	}
+	if !IsTransparentFiles(stdin, stdout) {
+		return nil, syscall.ENOTTY
+	}
 
 	// Enter raw mode — keystrokes pass through to child
 	oldState, err := term.MakeRaw(int(stdin.Fd()))

--- a/cli/gmux/internal/localterm/localterm_transparent_test.go
+++ b/cli/gmux/internal/localterm/localterm_transparent_test.go
@@ -1,0 +1,52 @@
+package localterm
+
+import (
+	"os"
+	"testing"
+
+	"github.com/creack/pty"
+)
+
+func TestIsTransparentFiles(t *testing.T) {
+	ptmx, tty, err := pty.Open()
+	if err != nil {
+		t.Skipf("allocate PTY: %v", err)
+	}
+	defer ptmx.Close()
+	defer tty.Close()
+	pipeR, pipeW, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pipeR.Close()
+	defer pipeW.Close()
+
+	for _, tc := range []struct {
+		name        string
+		stdin       *os.File
+		stdout      *os.File
+		transparent bool
+	}{
+		{"both tty", tty, tty, true},
+		{"tty stdin only", tty, pipeW, false},
+		{"tty stdout only", pipeR, tty, false},
+		{"neither tty", pipeR, pipeW, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsTransparentFiles(tc.stdin, tc.stdout); got != tc.transparent {
+				t.Errorf("IsTransparentFiles()=%v, want %v", got, tc.transparent)
+			}
+		})
+	}
+}
+
+func TestNewRejectsExplicitNonTerminalFiles(t *testing.T) {
+	f, err := os.OpenFile(os.DevNull, os.O_RDWR, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	if _, err := New(Config{Stdin: f, Stdout: f}); err == nil {
+		t.Fatal("New accepted non-terminal input and output")
+	}
+}

--- a/docs/adr/0027-semantic-agent-cli-and-result-bearing-wait.md
+++ b/docs/adr/0027-semantic-agent-cli-and-result-bearing-wait.md
@@ -993,6 +993,14 @@ property of that agent's cold start, not of the caller's patience.
 
 ### Output contract: the bare id is always stdout line 1
 
+> **Superseded in part (2026-07-30) by ADR 0028's payload-rule amendment:**
+> the synchronous shape prints the bare id on **stderr** and its stdout is
+> the exchange report alone; only `--no-wait` keeps the id on stdout, because
+> there the id is the payload. The id is still emitted exactly once, the
+> moment the session exists and before delivery, and nothing is emitted when
+> no session exists. The rest of this section — what the id means, the
+> exit-code contract, post-spawn ownership — stands.
+
 Under `--new` the session id is written to stdout, on its own line, **the
 moment the session exists** — after the spawn registers and *before* the prompt
 is delivered. With `--no-wait` it is the only output and exit 0 means admitted:

--- a/docs/adr/0028-cli-output-channels.md
+++ b/docs/adr/0028-cli-output-channels.md
@@ -2,8 +2,9 @@
 
 **Status:** Accepted
 **Date:** 2026-07-29
+**Amended:** 2026-07-30 (the payload rule: session ids move to stderr where they are not the payload)
 **Related:** ADR 0009 (verb-first CLI), ADR 0027 (semantic agent CLI and result-bearing wait), ADR 0030 (exchange-oriented agent reads and observational wait)
-**Supersedes in part:** ADR 0027's 2026-07-28 amendment (the "Output routing" section, its `--json` envelope, and the interrupted-wait stderr notice)
+**Supersedes in part:** ADR 0027's 2026-07-28 amendment (the "Output routing" section, its `--json` envelope, and the interrupted-wait stderr notice); ADR 0027's "stdout line 1 is a session id" output contract (2026-07-30 amendment below)
 
 ## Context
 
@@ -37,7 +38,10 @@ not diagnostics. Exit codes keep ADR 0027 §8's global taxonomy (0 success,
 1 error/timeout, 2 intentional interruption), plus 128+N for waits killed by
 a local signal (below).
 
-### 2. stderr is only for inability to produce the report
+### 2. stderr is for inability to produce the report — and for session metadata
+
+*(Retitled by the 2026-07-30 amendment: stderr additionally carries session
+ids where they are not the payload; see below.)*
 
 stderr carries exactly one thing: the reason gmux could **not** produce the
 requested report. Usage errors, an unknown or ambiguous session reference, an
@@ -158,3 +162,65 @@ Rejected: two copies invite drift, and interactive users see it twice.
 
 Rejected. Freezing a per-verb, partially-thought envelope at first release is
 the most expensive possible way to get a machine contract.
+
+## Amendment (2026-07-30): the payload rule — session ids go to stderr unless they are the payload
+
+### Context
+
+The non-interactive `gmux -- <cmd>` flow printed a metadata block on stdout
+(`session:`, `adapter:`, `command:`, `pid:`, `socket:`, `serving...`,
+`exited:`) and none of the child's output — a leftover from the first
+`gmux-run` prototype, when printing a session's name and socket *was* the
+entire UX. Interactive attach later gated the block behind `!interactive`,
+and it silently became the piped-flow contract: an agent running
+`gmux -- pnpm build | tail` saw seven lines of metadata and could not read
+the failure it had just detected without a second `gmux tail` round trip.
+Similarly, synchronous `gmux agent prompt --new` prefixed its stdout report
+with an `=== <id> ===` header, mixing an address into the document.
+
+### Decision
+
+**stdout carries exactly the payload the command was asked to produce;
+stderr carries diagnostics and session metadata.** A session id is the
+payload only when producing it is the whole point of the command.
+
+| Command | payload on stdout | session id |
+| --- | --- | --- |
+| `gmux -- <cmd>` (non-interactive) | the child's output | **stderr** |
+| `gmux -d -- <cmd>` | the id | stdout (unchanged) |
+| `gmux agent prompt --new` (sync) | the exchange report | **stderr** |
+| `gmux agent prompt --new --no-wait` | the id | stdout (unchanged) |
+| `gmux wait <id>...` | the report(s) | n/a — `=== <id> ===` headers stay on stdout; they delimit multiple payloads |
+
+Consequences of the rule:
+
+- Rule 2 above is widened: stderr is no longer *only* the account of an
+  inability to report. It also carries session metadata — today, the bare
+  session id — printed the moment the session exists, so a watcher can
+  attach or tail while the command runs. Rule 2's discipline still applies
+  to diagnostics: one statement of the problem, one actionable hint.
+- The non-interactive `gmux -- <cmd>` flow relays the child's PTY output to
+  stdout with ANSI escape sequences stripped and CRLF normalised to LF. The
+  UI and scrollback keep the full escape stream; only the relay is cleaned.
+  The child's exit code keeps propagating unchanged.
+- `gmux -d -- <cmd>` and `gmux agent prompt --new --no-wait` keep the id on
+  stdout, because the id *is* their payload — the command-substitution shape
+  (`id=$(…)`) is their entire reason to exist.
+- Synchronous `gmux agent prompt --new` prints the bare id on stderr (still
+  the moment the session exists, before delivery) and its stdout is the
+  exchange report alone — the same document a plain sync prompt prints.
+- Multi-payload commands (`gmux wait a b c`) keep their `=== <id> ===`
+  headers on stdout: there they are not metadata but the delimiters that
+  make several payloads one readable document (rule 3).
+
+### What this amends in ADR 0027
+
+ADR 0027's "Output contract: the bare id is always stdout line 1" clause is
+superseded for the synchronous shape: under `--new`, stdout line 1 is a
+session id only with `--no-wait`. The invariant that survives, rephrased:
+**the id is emitted exactly once, the moment the session exists and before
+delivery — on stdout when it is the payload (`--no-wait`), on stderr
+otherwise — and nothing is emitted when no session exists.** Everything else
+in that clause stands: the id means only that the session is addressable,
+the exit code carries every verdict, and a post-spawn failure leaves the
+session owned by the caller.

--- a/docs/adr/0028-cli-output-channels.md
+++ b/docs/adr/0028-cli-output-channels.md
@@ -2,7 +2,7 @@
 
 **Status:** Accepted
 **Date:** 2026-07-29
-**Amended:** 2026-07-30 (the payload rule: session ids move to stderr where they are not the payload)
+**Amended:** 2026-07-30 (the payload rule; PTY stderr merge and stdin notice clarified)
 **Related:** ADR 0009 (verb-first CLI), ADR 0027 (semantic agent CLI and result-bearing wait), ADR 0030 (exchange-oriented agent reads and observational wait)
 **Supersedes in part:** ADR 0027's 2026-07-28 amendment (the "Output routing" section, its `--json` envelope, and the interrupted-wait stderr notice); ADR 0027's "stdout line 1 is a session id" output contract (2026-07-30 amendment below)
 
@@ -212,6 +212,15 @@ Consequences of the rule:
 - Multi-payload commands (`gmux wait a b c`) keep their `=== <id> ===`
   headers on stdout: there they are not metadata but the delimiters that
   make several payloads one readable document (rule 3).
+
+### Amendment clarification (2026-07-30): PTY merge and stdin notice
+
+For non-interactive `gmux -- <cmd>`, the stdout payload explicitly includes
+the child's stderr bytes. A PTY presents child stdout and stderr as one ordered
+terminal stream, as in `ssh -t` or `script`; redirecting gmux stderr therefore
+captures gmux metadata and diagnostics, not child stderr. stderr additionally
+carries ADR 0032's best-effort notice when launcher stdin has pending data that
+will not be forwarded.
 
 ### What this amends in ADR 0027
 

--- a/docs/adr/0030-exchange-oriented-agent-reads-and-observational-wait.md
+++ b/docs/adr/0030-exchange-oriented-agent-reads-and-observational-wait.md
@@ -124,7 +124,10 @@ Rules:
   id on stdout line 1 (unchanged: printed as soon as the session exists), a
   blank line, then the report. `--new --no-wait`: the id only. The `--new`
   amendment's other rules (admission gate, pre-validation, failed sessions
-  are the caller's to keep) stand.
+  are the caller's to keep) stand. *(Amended 2026-07-30 by ADR 0028's
+  payload-rule amendment: the synchronous id line moves to stderr with no
+  separator; stdout is the report alone. `--no-wait` keeps the id on
+  stdout.)*
 - **`gmux agent status` is removed entirely.** Its "what matters now"
   question is answered by `logs` (defaults to the latest exchange, and shows
   `[Agent active, …]` when work is in flight).

--- a/docs/adr/0032-session-input-doors-and-standard-streams.md
+++ b/docs/adr/0032-session-input-doors-and-standard-streams.md
@@ -1,0 +1,83 @@
+# ADR 0032: Session input doors and standard streams
+
+**Status:** Accepted
+**Date:** 2026-07-30
+**Related:** ADR 0028 (CLI output channels)
+
+## Context
+
+gmux is a session manager, not a pipeline element. Every managed command runs
+on a durable PTY so it can be watched, attached to, and replayed. The existing
+non-interactive foreground path relayed cleaned PTY output and the exit code,
+but silently ignored launcher stdin. It also selected transparent attach from
+stdin alone, putting a terminal into raw mode even when stdout was redirected.
+
+## Decision
+
+1. **Launcher stdin is not session input.** Input enters only through a live
+   attach (including the web UI), `gmux send`, or semantic agent verbs such as
+   `gmux agent prompt`. In headless foreground mode gmux neither reads nor
+   forwards stdin. If launch-time inspection, without consuming bytes, finds
+   pending data in a pipe or unread bytes in a regular file, gmux prints a
+   best-effort stderr notice naming `gmux send <id>`. Empty pipes, character
+   devices such as `/dev/null`, sockets, unknown types, and inspection errors
+   are silent.
+2. **The PTY merge is part of stdout.** A child's stdout and stderr are one
+   terminal stream, as with `ssh -t` or `script`. That combined payload is
+   relayed on gmux stdout; gmux stderr remains the channel for the session id
+   and diagnostics, including the stdin notice. This refines ADR 0028 without
+   changing its channel discipline.
+3. **Transparent attach requires both stdin and stdout TTYs.** Otherwise gmux
+   uses the headless relay: cleaned stdout, metadata and diagnostics on stderr,
+   no stdin relay, and no raw terminal mode. The same predicate governs nested
+   gmux auto-detach. stderr TTY status is irrelevant.
+4. **Sessions always use a PTY.** There is no pipes mode and no `-i`/`-t` flag
+   matrix. A command requiring ordinary pipeline semantics belongs outside a
+   managed session (or in an existing passthrough adapter).
+5. **The input doors are the contract.** Help and diagnostics point to attach,
+   `send`, and agent prompting. The scripted pipeline-shaped recipe is
+   `id=$(gmux -d -- cmd); gmux send "$id" 'input' Enter`.
+
+## Conventions survey
+
+- **tmux/screen: follow.** Server-owned terminals receive input through attach
+  or send-keys. gmux adds a foreground wait, so it warns rather than refusing
+  the non-TTY launch shape.
+- **ssh: differ deliberately.** ssh owns one command invocation; gmux owns a
+  durable session with later and concurrent writers. ssh's `-n` also shows how
+  implicit stdin coupling harms scripts.
+- **docker: follow the default.** Without `-i`, launcher stdin is disconnected.
+  gmux's session-addressed input doors remove the need for an `-i` axis.
+- **script/unbuffer/expect: differ.** Their PTY disguises one invocation and
+  assumes one writer and matching lifetimes; a gmux PTY is durable state.
+- **nohup/setsid/systemd-run/CI: follow.** Managed or detached work must not
+  unexpectedly depend on launcher stdin, and interactivity limitations belong
+  in diagnostics.
+
+## Rejected alternatives
+
+- **Forward stdin with EOF-to-VEOF translation.** Launches from `/dev/null`, CI,
+  cron, and common agent harnesses would inject immediate `^D` and terminate
+  agents. `while read; do gmux -- …; done` would consume the loop's input. The
+  implementation would also require slave-termios VEOF lookup, unterminated
+  line handling, backpressure, and detach machinery for a pipeline use case
+  that sessions do not serve.
+- **Forward without EOF translation.** It retains stdin stealing while leaving
+  draining children unable to observe EOF.
+- **Refuse piped stdin.** Agent harnesses routinely provide an empty pipe; the
+  useful compromise is a notice only when data is already pending.
+- **No PTY or a separate child-stderr channel.** Either removes attachable
+  terminal semantics or destroys the session's ordered terminal truth.
+- **Inject VEOF at launch.** This kills agents and later-send workflows.
+- **Adapter-specific forwarding.** Stream semantics must not depend on command
+  classification.
+
+## Consequences
+
+`printf hi | gmux -- cat` remains an idle, addressable session, but now states
+why and how to send input. Empty harness pipes remain quiet. Redirecting stdout
+selects a cleaned headless relay and never alters the caller's terminal.
+Child-stderr bytes are intentionally part of stdout, while the id and gmux
+notices remain on stderr. In headless foreground mode, SIGINT shuts down the
+session rather than forwarding a terminal keystroke. Detached launches,
+passthrough commands, terminal sizing, and daemon behavior are unchanged.

--- a/skills/gmux/SKILL.md
+++ b/skills/gmux/SKILL.md
@@ -13,10 +13,10 @@ the command begins.
 ## Primitives
 
 ```bash
-gmux -- <cmd> [args]         # run blocking; exits with the child's exit code
+gmux -- <cmd> [args]         # run blocking; command output on stdout, session id on stderr
 gmux -d -- <cmd> [args]      # run detached; prints the session id on stdout
 gmux agent prompt <id> 'text'   # prompt an AGENT session; waits, prints the exchange report
-gmux agent prompt --new 'text'  # launch a new pi session AND prompt it (id, blank line, report)
+gmux agent prompt --new 'text'  # launch and prompt; id on stderr, report on stdout
 gmux agent logs <id> [-n N]     # the last N exchanges of the conversation (default 1)
 gmux agent cancel <id>          # interrupt the work in progress
 gmux send <id> 'text' Enter  # RAW: type text and submit (Enter is explicit)
@@ -41,8 +41,9 @@ fail with `unsupported_adapter`).
 `agent` / `send` / `wait` / `tail` / `kill`. Tip: `alias gm='gmux --'` makes
 `gm pytest` shorthand for `gmux -- pytest`.
 
-Because `gmux -- <cmd>` propagates the child's exit code, it composes:
-`if gmux -- pytest -q; then ...`.
+Because `gmux -- <cmd>` streams the command's ANSI-stripped output on stdout,
+prints its session id on stderr, and propagates the child's exit code, it
+composes: `gmux -- pytest -q | tail` or `if gmux -- pytest -q; then ...`.
 
 ## The exchange report
 
@@ -123,15 +124,15 @@ gmux agent prompt --new --model anthropic/sonnet 'summarize this repo'
 your env and cwd) and sends the prompt as its first work. Pass either an id or
 `--new`, never both.
 
-**The session id is stdout line 1**, printed the moment the session exists and
-before the prompt is delivered — so you can always address a session you just
-created, even if admission or the work then fails. It means only "this session
-exists and is addressable"; the exit code carries everything else. A
-synchronous run prints the id, a **blank line**, then the exchange report;
-`--no-wait` prints the bare id only and exits 0 once the work was **admitted**
+**The bare session id is printed the moment the session exists**, before the
+prompt is delivered — so you can always address a session you just created,
+even if admission or the work then fails. It means only "this session exists
+and is addressable"; the exit code carries everything else. A synchronous run
+prints the id on **stderr** and the exchange report alone on stdout; `--no-wait`
+prints the bare id on stdout only and exits 0 once the work was **admitted**
 (the agent started it) — on a sick session that line can block up to the 60 s
-admission window. A launch that never registers prints nothing on stdout and
-exits 1. A failure after the launch leaves the session behind and **you own
+admission window. A launch that never registers prints no id and exits 1. A
+failure after the launch leaves the session behind and **you own
 it** (it may still be running): retry against the id, read it, or
 `gmux kill $id`.
 


### PR DESCRIPTION
## Summary

- make non-interactive `gmux -- <cmd>` stream the child's cleaned PTY payload on stdout while keeping session metadata on stderr
- define headless session input explicitly: launcher stdin is not forwarded; attach, `gmux send`, and `gmux agent prompt` are the input doors
- warn when ignored stdin already contains data, without consuming it
- require stdin and stdout TTYs for transparent attach; keep `gmux edit` interactive through `/dev/tty` when stdout is redirected
- document the PTY stdout/stderr merge and session stream contract in ADR 0032 / ADR 0028

## Compatibility

Every managed command still runs in a PTY and remains watchable/attachable. Interactive terminal launches remain transparent. Non-interactive child stderr is part of the PTY payload on stdout; gmux stderr carries the session id, diagnostics, and the pending-stdin notice.

## Validation

- `cd cli/gmux && go test ./...`
- `pnpm --dir apps/website build`
- repeated and race-tested terminal/script capability tests
- adversarial review rounds covering PTY routing, `/dev/tty` ownership/restoration, stdin non-consumption, script dialect portability, timeout descendant cleanup, and PID-reuse-safe test cleanup
- post-rebase conflict resolution preserved main's bare 8-character session IDs and current routing/API behavior

