### PR TITLE
chore: forbid pattern-matched process kills in tests and scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,29 @@ messages directly. Rules that follow from this:
   Discord announcement falls back to the auto-generated bullet list
   so subscribers can still see what changed without clicking through.
 
+## Killing processes
+
+Tests, probes and cleanup scripts run on real developer desktops, not in
+throwaway containers. A stray signal takes down the user's session.
+
+- **Never derive a signal target from a process-name pattern.** `pgrep -f
+  'sleep 30'` matches other people's processes, including ones owned by the
+  graphical session. Signal only PIDs that the test or script recorded when it
+  spawned them.
+- **Never signal a negative PID unless we created that process group.** Verify
+  `getpgid(pid) == pid` first: gmux detaches runners with `setsid`, so a leader
+  we own is its own group. A group id read out of `ps` may be the compositor's,
+  and `kill -- -$pgid` then takes the whole desktop with it.
+- **Escalate inside our own tree only**: TERM the recorded PID or a verified
+  group, poll for disappearance, then KILL. Never `kill -1`, never `kill 0`.
+- **Isolate destructive process work** in a container or a separate login
+  session. Isolated `XDG_*` directories scope files, not signals.
+
+Precedent: a review agent reaped a leaked `sleep 30` by pattern, matched the
+unrelated `sleep 30` polling inside `pi-sleep-guard`, and TERM+KILLed its
+process group — which was the compositor's. The desktop died and the user was
+returned to the login screen.
+
 ## Other rules
 
 - Push changes and create pull requests. Don't commit directly to


### PR DESCRIPTION
## Summary

Add a `Killing processes` section to `AGENTS.md` requiring cleanup code to signal only PIDs it spawned, and to verify group ownership before ever signalling a negative PID.

## Why

During the 2.0 release round, a review agent reaped a leaked `sleep 30` test process by pattern:

```sh
for p in $(pgrep -f '^sleep 30$'); do
  pg=$(ps -o pgid= -p "$p" | tr -d ' ')
  kill -TERM -- "-$pg"; sleep .05; kill -KILL -- "-$pg"
done
```

`pgrep` matched the unrelated `sleep 30` that `pi-sleep-guard` polls with. Its process group was `1051` — the niri compositor's. The loop TERM+KILLed that group, so the whole graphical session died and the developer was dropped to the login screen for six hours.

Journal evidence: `xwayland-satellite exited with: signal: 15 (SIGTERM)` and `niri: quitting due to receiving signal SIGTERM` in the same millisecond, then `niri.service: Main process exited, code=killed, status=9/KILL`. No OOM kill, no logind logout, no watchdog — a plain group signal from outside.

The committed test suite is not affected: its cleanup takes `Getpgid` of a PID its own child published, and `gmux -d` puts that child in its own `setsid` group. The hazard was ad-hoc cleanup, so the rule belongs in `AGENTS.md`.

## Rules added

- never derive a signal target from a process-name pattern
- never signal a negative PID without verifying `getpgid(pid) == pid`
- escalate TERM → poll → KILL inside our own tree only; never `kill -1` or `kill 0`
- isolate destructive process work in a container or separate login session, since isolated `XDG_*` directories scope files but not signals
