### PR TITLE
docs: correct stale 2.0 documentation

### DIFF
--- a/apps/website/astro.config.mjs
+++ b/apps/website/astro.config.mjs
@@ -51,7 +51,7 @@ export default defineConfig({
             { label: 'File paths', slug: 'reference/file-paths' },
             { label: 'host.toml', slug: 'reference/host-toml' },
             { label: 'Interface stability', slug: 'reference/stability' },
-            { label: 'projects.json', slug: 'reference/projects-json' },
+            { label: 'Project model', slug: 'reference/projects-json' },
             { label: 'Settings', slug: 'reference/settings' },
             { label: 'Theme', slug: 'reference/theme' },
           ],

--- a/apps/website/src/content/docs/develop/distribution.md
+++ b/apps/website/src/content/docs/develop/distribution.md
@@ -24,7 +24,5 @@ Both ship as platform-specific binaries with checksums. The web UI is compiled i
 
 ## Open items
 
-- Release tooling for Go binaries (goreleaser or equivalent)
 - Provenance/signing approach for binary downloads
-- CLI UX for first run (`gmux doctor`, `gmux open`)
-- Homebrew / AUR / Nix packaging
+- AUR / Nix packaging

--- a/apps/website/src/content/docs/develop/state-management.md
+++ b/apps/website/src/content/docs/develop/state-management.md
@@ -11,19 +11,20 @@ Session state flows one way: runners (and their agent hooks) produce it, `gmuxd`
 
 After a domain transaction commits, it signals a coalesced invalidation. gmuxd queries a complete snapshot from SQLite and sends `snapshot.sessions` and/or `snapshot.world` to connected browsers (protocol 2, ADR 0001). REST GET endpoints read from the store directly at request time (read-your-writes); SSE snapshots come from a coalesced composer cache.
 
-### Schema changes before 2.0
+### Schema changes
 
-The SQLite schema is still pre-release: unreleased migrations are edited **in
-place** rather than superseded by a new migration. goose only records the
-migration *version*, so an already-migrated development database at that
-version is not upgraded and cannot be detected as stale — a renamed or added
-column surfaces as a query error at runtime.
+Released migrations are immutable. A schema change ships as a **new** migration
+file; never edit a migration that has shipped. goose only records the migration
+*version*, so editing one in place leaves an already-migrated database at that
+version silently un-upgraded — the renamed or added column surfaces as a query
+error at runtime instead.
 
-If gmuxd fails against an existing `state.db` after pulling a schema change,
-reset the local database (stop gmuxd, remove `~/.local/state/gmux/state.db`) or
-repair the columns by hand. Live sessions are runner-owned and re-register; the
-loss is dead-session history. Once 2.0 ships, schema changes become additive
-migrations and this note goes away.
+gmuxd refuses to start against a `state.db` whose schema version is newer than
+the embedded head, takes a backup before applying a pending migration, and runs
+integrity and foreign-key checks afterwards. If you hit a broken development
+database anyway (from editing a migration in place before it shipped), reset it
+(stop gmuxd, remove `~/.local/state/gmux/state.db`). Live sessions are
+runner-owned and re-register; the loss is dead-session history.
 
 A byte-identical snapshot is detected in the composition path and never broadcast — this no-op dedup is load-bearing for the snapshot protocol. Cross-entity operations (registration + project assignment, dismissal + recursive placement removal, etc.) execute in one transaction.
 

--- a/apps/website/src/content/docs/integrations/pi.md
+++ b/apps/website/src/content/docs/integrations/pi.md
@@ -88,7 +88,7 @@ The extension reports each turn with a normalized, agent-agnostic outcome; gmux 
 
 If a pi release ever breaks the extension, set `GMUX_NO_AGENT_HOOK=1` to launch pi without it. Pi runs normally; gmux just won't show hook-driven title/status/attribution until you unset it (or a fix ships). For sessions launched from the web UI or resumed by the daemon, set the variable in the daemon's environment (it's read by the runner, which the daemon spawns).
 
-One-shot pi commands are never extended or wrapped in a session — gmux execs them directly: the subcommands `install`, `remove`, `uninstall`, `update`, `list`, `config` (immediately after the binary) and the info flags `--help`/`-h`/`--version`.
+One-shot pi commands are never extended or wrapped in a session — gmux execs them directly: the subcommands `auth`, `install`, `remove`, `uninstall`, `update`, `list`, `config` (immediately after the binary) and the info flags `--help`/`-h`/`--version`.
 
 ## Limitations
 

--- a/apps/website/src/content/docs/reference/stability.md
+++ b/apps/website/src/content/docs/reference/stability.md
@@ -46,6 +46,6 @@ resumability, health, or capability support.
 
 ## Explicitly not covenanted
 
-- Environment variables prefixed `_GMXINTERNAL_`. They are private process plumbing and must not be read, set, or passed to session children.
+- Internal environment variables gmux uses as private process plumbing. They are undocumented on purpose and must not be read, set, or passed to session children.
 - Runtime state files, including `state.db`, sockets, and logs. Connected hosts are runtime state in `state.db`, not a public storage interface.
 - Incidental prose and layout in human-oriented exchange reports, help-text wording, and diagnostic wording, unless a specific element is explicitly documented as stable or as machine-parseable output.

--- a/apps/website/src/pages/index.astro
+++ b/apps/website/src/pages/index.astro
@@ -104,7 +104,7 @@ import Topology from '../components/Topology.astro'
       <Topology />
       <div class="remote-strip">
         <span class="remote-strip-label">Already use Tailscale?</span>
-        <span>Run <code>gmuxd remote</code> once. No ports to open.</span>
+        <span>Run <code>gmux remote</code> once. No ports to open.</span>
       </div>
     </div>
   </section>


### PR DESCRIPTION
An Opus subagent audited every user-facing page against the shipped binary — the landing page, all 41 docs pages, both skills, `README.md`, and the sidebar config — verifying claims against code and live CLI output.

Corrections:

- `integrations/pi.md`: the one-shot passthrough list omitted `auth`
- `reference/stability.md`: no longer names the internal env prefix; keeps the reserved-namespace contract
- `index.astro`: hero teaches `gmux remote`, the user-facing verb, not `gmuxd remote`
- `develop/state-management.md`: replaced the self-expiring "schema changes before 2.0" note with the shipped policy (released migrations immutable, ahead-schema refusal, pre-migration backup, post-migration integrity/FK checks)
- `develop/distribution.md`: dropped shipped items (goreleaser, Homebrew tap, `gmux open`) from Open items
- sidebar: `projects.json` → `Project model`, matching the page title

The audit found the rest of the surface accurate: CLI reference vs live `--help`, UI keybind tables vs `keybinds.ts`, `host.toml` defaults, file paths, public env set, exit-code/delivery taxonomy, peer endpoints, `planned/` status banners, and base36 ids throughout. Verified removed surfaces are gone from both docs and binary.

Website build passes with 43 pages.