### PR TITLE
fix(install): launch the UI from the desktop entry and post-install hint

### DIFF
--- a/apps/website/public/install-pr.sh
+++ b/apps/website/public/install-pr.sh
@@ -67,14 +67,14 @@ main() {
 
   # If gmuxd was already running, restart it so the new version takes effect.
   # Active sessions survive (the new daemon rediscovers them on startup).
-  if curl -sSf http://localhost:8790/v1/health > /dev/null 2>&1; then
+  if "${INSTALL_DIR}/gmuxd" status > /dev/null 2>&1; then
     if "${INSTALL_DIR}/gmuxd" start; then
       echo "gmuxd restarted to apply the update."
     else
       echo "Warning: gmuxd restart did not complete successfully; check logs."
     fi
   else
-    echo "To start gmux, run: gmux"
+    echo "To open the web UI, run: gmux open"
   fi
 }
 

--- a/apps/website/public/install.sh
+++ b/apps/website/public/install.sh
@@ -73,7 +73,7 @@ ICON
 Name=gmux
 Comment=Terminal session manager
 GenericName=Terminal Manager
-Exec=${INSTALL_DIR}/gmux
+Exec=${INSTALL_DIR}/gmux open
 Icon=gmux
 Terminal=false
 Type=Application
@@ -146,7 +146,7 @@ main() {
       echo "Warning: gmuxd restart did not complete successfully; check logs."
     fi
   else
-    echo "To start gmux, run: gmux"
+    echo "To open the web UI, run: gmux open"
   fi
 
   case ":${PATH}:" in


### PR DESCRIPTION
Found while auditing the release install path.

`apps/website/public/install.sh` wrote a desktop entry with `Exec=<dir>/gmux` and `Terminal=false`. Under the verb-first CLI, bare `gmux` prints help to stdout and exits (`cli.go:133`), so clicking the launcher icon did nothing visible. Both installers also ended with "To start gmux, run: gmux", which does not start anything.

Both now point at `gmux open`, which calls `ensureGmuxd()` and then opens the UI (`main.go:124-125`).

`install-pr.sh` also probed a hardcoded `http://localhost:8790/v1/health` to decide whether to restart the daemon, which is wrong when `host.toml` sets another port; it now uses `gmuxd status`, matching `install.sh` and the Homebrew cask postflight.

Verified: `sh -n` on both scripts; generated the entry from the shipped function and confirmed `Exec=<dir>/gmux open` passes `desktop-file-validate`.

Also checked, no change needed: the cask postflight (`gmuxd status` then `gmuxd start`) is correct — `gmuxd start` runs `run --replace` and replaces the incumbent (`background_readiness.go:57`); the goreleaser archive names and `checksums.txt` match what `install.sh` downloads and verifies.