### PR TITLE
fix(web): centralize routing state; keep sidebar mode stable on Back

### DIFF
--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -1,6 +1,7 @@
 import { Component, Fragment, render, type ComponentChildren } from 'preact'
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'preact/hooks'
 import { LocationProvider, Router, Route, lazy, useLocation } from 'preact-iso'
+import { batch } from '@preact/signals'
 import '@xterm/xterm/css/xterm.css'
 import './styles.css'
 
@@ -25,8 +26,8 @@ import {
   sessions, connState, selected, selectedId, view, health, peers,
   terminalOptions, keybinds, macCommandIsCtrl,
   keyboardOpen, terminalFindOpen, terminalScrolledUp, terminalScrollToBottom,
-  urlPath, urlSearch,
-  initStore, setNavigate, navigateToSession,
+  urlPath, urlSearch, urlHash,
+  initStore, setNavigate, navigate, navigateToSession,
   dismissSession, resumeSession, restartSession,
   sessionStaleness,
 } from './store'
@@ -552,12 +553,26 @@ function App() {
   // useLayoutEffect ensures urlPath updates before paint, so the view
   // computed reacts before the browser renders a stale frame.
   useLayoutEffect(() => {
-    urlPath.value = loc.path
-    // Derive the query string from loc.url (path+search) so query-only
-    // navigations (?project=, ?cwd=) reactively re-filter sessions.
-    const q = loc.url.indexOf('?')
-    urlSearch.value = q >= 0 ? loc.url.slice(q) : ''
+    // Publish one coherent location snapshot so repair effects cannot run
+    // against a new path with the previous entry's query or fragment. Read
+    // search/hash from the browser's parsed location: preact-iso's `loc.url`
+    // is not consistent about retaining fragments across initial and SPA
+    // navigation, and fragments must never be fed to URLSearchParams.
+    batch(() => {
+      urlPath.value = loc.path
+      urlSearch.value = location.search
+      urlHash.value = location.hash
+    })
   }, [loc.url])
+
+  // Preact-iso routes path/query changes but deliberately ignores hash-only
+  // navigation. Keep the fragment signal current for native hash links and
+  // hash-only Back/Forward entries as well.
+  useEffect(() => {
+    const syncHash = () => { urlHash.value = location.hash }
+    window.addEventListener('hashchange', syncHash)
+    return () => window.removeEventListener('hashchange', syncHash)
+  }, [])
 
   // Settings modal is driven by the `?settings` query param rather than
   // local state, so it's deep-linkable and shareable. It's read off the
@@ -574,13 +589,13 @@ function App() {
     // doesn't stack a duplicate history entry that Back has to clear.
     const alreadyActive = params.get('settings') === tab
     params.set('settings', tab)
-    loc.route(`${loc.path}?${params.toString()}`, replace || alreadyActive)
+    navigate(`${loc.path}?${params.toString()}${location.hash}`, replace || alreadyActive)
   }, [loc])
   const closeSettings = useCallback(() => {
     const params = new URLSearchParams(location.search)
     params.delete('settings')
     const qs = params.toString()
-    loc.route(qs ? `${loc.path}?${qs}` : loc.path, true)
+    navigate((qs ? `${loc.path}?${qs}` : loc.path) + location.hash, true)
   }, [loc])
 
   // Initialize the store (SSE, data fetching, effects).

--- a/apps/gmux-web/src/routing.test.ts
+++ b/apps/gmux-web/src/routing.test.ts
@@ -7,22 +7,9 @@ import {
   resolveViewFromPath,
   viewToPath,
   viewsEqual,
-  withTabParams,
   hasSessionSlugCollision,
 } from './routing'
 import { makeSession } from './test-helpers'
-
-describe('withTabParams', () => {
-  it('carries filter and sidebar params onto a path', () => {
-    expect(withTabParams('/gmux/shell/x', '?filter=gmux%40server&sidebar=activity'))
-      .toBe('/gmux/shell/x?filter=gmux%40server&sidebar=activity')
-  })
-
-  it('drops transient params (settings) and returns the bare path when none apply', () => {
-    expect(withTabParams('/gmux', '?settings=hosts')).toBe('/gmux')
-    expect(withTabParams('/gmux', '')).toBe('/gmux')
-  })
-})
 
 describe('parseSessionPath', () => {
   it('parses full local path', () => {

--- a/apps/gmux-web/src/routing.ts
+++ b/apps/gmux-web/src/routing.ts
@@ -85,25 +85,6 @@ export function sessionPath(
   return `${ownerPrefix}/${projectSlug}${sessionHost}/${session.adapter}/${slug}`
 }
 
-/** Query params that define a tab's identity (its narrowing scope and
- *  sidebar view). In-app links must carry them so navigation within a
- *  pinned tab doesn't silently un-pin it. */
-const TAB_PARAMS = ['filter', 'sidebar'] as const
-
-/** Append the tab-identity params from `search` (a location.search
- *  string) onto `path`. Other params (e.g. ?settings) are not carried:
- *  they're transient UI state, not tab identity. */
-export function withTabParams(path: string, search: string): string {
-  const current = new URLSearchParams(search)
-  const carried = new URLSearchParams()
-  for (const key of TAB_PARAMS) {
-    const v = current.get(key)
-    if (v) carried.set(key, v)
-  }
-  const qs = carried.toString()
-  return qs ? `${path}?${qs}` : path
-}
-
 /**
  * Resolve a parsed URL path to a session ID.
  * Returns null if no matching session is found.

--- a/apps/gmux-web/src/sidebar.tsx
+++ b/apps/gmux-web/src/sidebar.tsx
@@ -373,7 +373,7 @@ function FolderGroup({
 
 /** Compact popover behind the header's arrange icon. Three concerns,
  *  three lifetimes:
- *    View  — Projects/Activity, persisted in the URL (?sidebar=).
+ *    View  — Projects/Activity signal, mirrored to the URL (?sidebar=).
  *    Host  — narrows the tab to one host (`*@host` in ?filter=).
  *    Alive only — hides resumable corpses; sessionStorage (per tab).
  *  One entry point, instant switching — the list is the preview. */

--- a/apps/gmux-web/src/store.test.ts
+++ b/apps/gmux-web/src/store.test.ts
@@ -5,8 +5,8 @@ import {
   markSessionRead, dismissSession, reorderSessions, resumeSession, killSession,
   handleActivity, isSessionActive, isSessionFading, activityMap,
   sessionStaleness, peers, peerAppearance, peerStatusByName,
-  isSessionUnavailable, urlPath, urlSearch, filteredSessions, sidebarSessions, selectedId, folders,
-  navigateToSession, setNavigate,
+  isSessionUnavailable, urlPath, urlSearch, urlHash, filteredSessions, sidebarSessions, selectedId, folders,
+  navigateToSession, setNavigate, navigate, tabHref, initStore,
   applyPending, _rawSessions, _setRawWorld, _pendingMutations,
   applySessionsSnapshot,
   toUISession, localHostLabel, parseConnectURL, unreadCount, discovered,
@@ -50,6 +50,8 @@ beforeEach(() => {
   worldLoaded.value = false
   urlPath.value = '/'
   urlSearch.value = ''
+  urlHash.value = ''
+  sidebarMode.value = 'projects'
 })
 
 describe('postAction surfaces backend failures as error toasts', () => {
@@ -515,8 +517,11 @@ describe('applySessionsSnapshot: /resume keeps the terminal mounted', () => {
     expect(navCalls).toContainEqual(['/myproject/pi/refactor-login', true])
   })
 
-  it('atomically switches the selected row to its full ID when a duplicate slug arrives', () => {
+  it('atomically switches the selected row to its full ID and carries route state when a duplicate slug arrives', () => {
     expect(view.value).toEqual({ kind: 'session', sessionId: '1vshk4fu' })
+    urlSearch.value = '?filter=myproject'
+    urlHash.value = '#terminal'
+    sidebarMode.value = 'activity'
 
     applySessionsSnapshot([
       makeSession({ id: '1vshk4fu', cwd: '/dev/project', adapter: 'pi', slug: 'fix-auth', alive: true }),
@@ -525,7 +530,24 @@ describe('applySessionsSnapshot: /resume keeps the terminal mounted', () => {
 
     expect(urlPath.value).toBe('/myproject/pi/~1vshk4fu')
     expect(view.value).toEqual({ kind: 'session', sessionId: '1vshk4fu' })
-    expect(navCalls).toContainEqual(['/myproject/pi/~1vshk4fu', true])
+    expect(navCalls).toContainEqual([
+      '/myproject/pi/~1vshk4fu?filter=myproject&sidebar=activity#terminal', true,
+    ])
+  })
+
+  it('preserves the tab filter across a slug-rewrite navigation', () => {
+    // Regression: the canonicalization rewrite used to navigate with the
+    // bare path, stripping ?filter= (and ?sidebar=) from a pinned tab.
+    urlSearch.value = '?filter=myproject'
+    sidebarMode.value = 'activity'
+
+    applySessionsSnapshot([
+      makeSession({ id: '1vshk4fu', cwd: '/dev/project', adapter: 'pi', slug: 'refactor-login' }),
+    ])
+
+    expect(navCalls).toContainEqual(
+      ['/myproject/pi/refactor-login?filter=myproject&sidebar=activity', true],
+    )
   })
 
   it('leaves the URL untouched when the selected slug is unchanged', () => {
@@ -800,14 +822,17 @@ describe('navigateToSession', () => {
     expect(navigateMock).not.toHaveBeenCalled()
   })
 
-  it('returns true and dispatches the project-prefixed URL once both are loaded', () => {
+  it('returns true and dispatches the exact-ID URL with applicable route context once loaded', () => {
     _setRawWorld({ projects: [{ slug: 'myproject', match: [{ path: '/dev/p' }] }] })
     _rawSessions.value = [makeSession({ id: '1vshk4fu', cwd: '/dev/p', adapter: 'shell' })]
+    urlSearch.value = '?filter=myproject&mock=&host=server'
+    sidebarMode.value = 'activity'
     expect(navigateToSession('1vshk4fu', true)).toBe(true)
     expect(navigateMock).toHaveBeenCalledTimes(1)
-    const [url, replace] = navigateMock.mock.calls[0]
-    expect(url).toMatch(/^\/myproject\/shell\//)
-    expect(replace).toBe(true)
+    expect(navigateMock).toHaveBeenCalledWith(
+      '/myproject/shell/~1vshk4fu?filter=myproject&sidebar=activity&mock=&host=server',
+      true,
+    )
   })
 
   it('routes peer-owned sessions through /@<peer>/<slug>/...', () => {
@@ -1087,30 +1112,72 @@ describe('tab-identity params (?filter=, ?sidebar=)', () => {
     setNavigate(() => {/* no-op */})
   })
 
-  it('sidebarMode parses ?sidebar=activity and defaults to projects', () => {
-    expect(sidebarMode.value).toBe('projects')
-    urlSearch.value = '?sidebar=activity'
-    expect(sidebarMode.value).toBe('activity')
-    // Unknown values fall back to the default rather than erroring.
-    urlSearch.value = '?sidebar=garbage'
-    expect(sidebarMode.value).toBe('projects')
-  })
-
-  it('setSidebarMode omits the param at the default and preserves ?filter=', () => {
+  it('setSidebarMode mirrors the signal into the URL, omitting the default', () => {
     // The default state leaves a clean URL: no ?sidebar=projects.
     urlSearch.value = '?filter=gmux&sidebar=activity'
+    sidebarMode.value = 'activity'
     setSidebarMode('projects')
+    expect(sidebarMode.value).toBe('projects')
     expect(navigateMock).toHaveBeenLastCalledWith('/?filter=gmux', true)
 
     urlSearch.value = '?filter=gmux'
     setSidebarMode('activity')
+    expect(sidebarMode.value).toBe('activity')
     expect(navigateMock).toHaveBeenLastCalledWith('/?filter=gmux&sidebar=activity', true)
+  })
+
+  it('setSidebarMode preserves non-tab params (?settings)', () => {
+    urlSearch.value = '?settings=hosts'
+    setSidebarMode('activity')
+    expect(navigateMock).toHaveBeenLastCalledWith('/?settings=hosts&sidebar=activity', true)
+  })
+
+  it('navigate stamps the sidebar mode from the signal, not the URL', () => {
+    // A stale URL param (e.g. an old history entry) never wins: the
+    // signal is the source of truth for every navigation.
+    urlSearch.value = '?sidebar=activity'
+    sidebarMode.value = 'projects'
+    navigate('/gmux/pi/x', true)
+    expect(navigateMock).toHaveBeenLastCalledWith('/gmux/pi/x', true)
+
+    urlSearch.value = ''
+    sidebarMode.value = 'activity'
+    navigate('/gmux/pi/x')
+    expect(navigateMock).toHaveBeenLastCalledWith('/gmux/pi/x?sidebar=activity', undefined)
+  })
+
+  it('navigate carries ?filter= from the current URL by default', () => {
+    urlSearch.value = '?filter=gmux%40server'
+    navigate('/gmux/pi/x')
+    expect(navigateMock).toHaveBeenLastCalledWith('/gmux/pi/x?filter=gmux%40server', undefined)
   })
 
   it('setFilterSelectors clears the param when the list empties', () => {
     urlSearch.value = '?filter=gmux&sidebar=activity'
+    sidebarMode.value = 'activity'
     setFilterSelectors([])
     expect(navigateMock).toHaveBeenLastCalledWith('/?sidebar=activity', true)
+  })
+
+  it('tabHref uses the same carry contract as navigate', () => {
+    urlSearch.value = '?filter=gmux&settings=hosts'
+    sidebarMode.value = 'activity'
+    // Filter and sidebar identify the tab; transient settings state drops.
+    expect(tabHref('/gmux/pi/x')).toBe('/gmux/pi/x?filter=gmux&sidebar=activity')
+    sidebarMode.value = 'projects'
+    urlSearch.value = ''
+    expect(tabHref('/gmux/pi/x')).toBe('/gmux/pi/x')
+  })
+
+  it('carries mock boot context so an SPA destination remains reloadable', () => {
+    urlSearch.value = '?mock=&host=server&filter=gmux&settings=hosts'
+    expect(tabHref('/gmux/pi/~1vshk4fu')).toBe(
+      '/gmux/pi/~1vshk4fu?filter=gmux&mock=&host=server',
+    )
+    // Explicit target values win over the current mock context.
+    expect(tabHref('/gmux/pi/~1vshk4fu?mock=target&host=laptop')).toBe(
+      '/gmux/pi/~1vshk4fu?mock=target&host=laptop&filter=gmux',
+    )
   })
 
   it('setHostFilter replaces host-wide selectors but keeps project selectors', () => {
@@ -1123,6 +1190,39 @@ describe('tab-identity params (?filter=, ?sidebar=)', () => {
     expect(navigateMock).toHaveBeenLastCalledWith('/?filter=gmux', true)
   })
 
+  it('setFilterSelectors preserves non-tab params (?settings, ?mock)', () => {
+    // Regression: targeting the bare path dropped every non-tab param,
+    // so a filter edit silently closed the settings modal / left mock mode.
+    urlSearch.value = '?mock=&settings=hosts&filter=old'
+    setFilterSelectors([{ project: 'gmux', host: '*' }])
+    expect(navigateMock).toHaveBeenLastCalledWith('/?mock=&settings=hosts&filter=gmux', true)
+  })
+
+  it('keeps hash fragments out of query data and preserves them on same-view edits', () => {
+    urlSearch.value = '?filter=gmux'
+    navigate('/gmux/pi/x?settings=hosts#terminal', true)
+    expect(navigateMock).toHaveBeenLastCalledWith(
+      '/gmux/pi/x?settings=hosts&filter=gmux#terminal', true,
+    )
+
+    urlPath.value = '/gmux/pi/x'
+    urlHash.value = '#stale'
+    // Hash-only navigation can update the browser before `hashchange` runs;
+    // rewrite seams must prefer the live fragment over the signal snapshot.
+    vi.stubGlobal('location', { hash: '#terminal' })
+    try {
+      setFilterSelectors([])
+    } finally {
+      vi.unstubAllGlobals()
+    }
+    expect(navigateMock).toHaveBeenLastCalledWith('/gmux/pi/x#terminal', true)
+    // Apply the router's resulting location signals before the next edit.
+    urlSearch.value = ''
+    urlHash.value = '#terminal'
+    setSidebarMode('activity')
+    expect(navigateMock).toHaveBeenLastCalledWith('/gmux/pi/x?sidebar=activity#terminal', true)
+  })
+
   it('homePartition participates in the tab scope', () => {
     _setRawWorld({ projects: [{ slug: 'proj', match: [{ path: '/work' }] }], peers: [] })
     _rawSessions.value = [
@@ -1131,6 +1231,90 @@ describe('tab-identity params (?filter=, ?sidebar=)', () => {
     ]
     urlSearch.value = '?filter=proj'
     expect(homePartition.value.flatMap(b => b.sessions.map(s => s.id))).toEqual(['in'])
+  })
+})
+
+describe('sidebar-mode deep-link seed', () => {
+  it('seeds activity from the initial document URL before repair starts', async () => {
+    vi.stubGlobal('location', { pathname: '/', search: '?sidebar=activity', hash: '' })
+    vi.resetModules()
+    try {
+      const freshStore = await import('./store')
+      expect(freshStore.sidebarMode.value).toBe('activity')
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+})
+
+describe('sidebar-mode repair effect (initStore)', () => {
+  // The commit's core invariant: after boot the sidebarMode signal is
+  // authoritative and the URL is a mirror. A history entry stamped with
+  // a stale ?sidebar (Back/Forward, old bookmark) must be rewritten in
+  // place — never adopted into the signal. Mutation-proof: inverting
+  // the repair direction (sidebarMode.value = urlMode) fails this test.
+  let navigateMock: ReturnType<typeof vi.fn>
+  let cleanup: (() => void) | null = null
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false }))
+    class FakeEventSource {
+      addEventListener() { /* no-op */ }
+      close() { /* no-op */ }
+    }
+    vi.stubGlobal('EventSource', FakeEventSource)
+    navigateMock = vi.fn()
+    setNavigate(navigateMock)
+  })
+  afterEach(() => {
+    cleanup?.()
+    cleanup = null
+    setNavigate(() => {/* no-op */})
+    vi.unstubAllGlobals()
+  })
+
+  it('rewrites a stale ?sidebar entry in place; the signal never adopts from the URL', () => {
+    cleanup = initStore()
+    // Simulate Back onto an entry stamped with the old mode while the
+    // tab is in projects mode. Non-tab params must survive the repair.
+    urlPath.value = '/gmux/pi/x'
+    urlSearch.value = '?sidebar=activity&settings=hosts'
+
+    expect(sidebarMode.value).toBe('projects')
+    expect(navigateMock).toHaveBeenLastCalledWith('/gmux/pi/x?settings=hosts', true)
+
+    // Convergence: once the router applies the repaired URL, the effect
+    // re-runs and does nothing further.
+    navigateMock.mockClear()
+    urlSearch.value = '?settings=hosts'
+    expect(navigateMock).not.toHaveBeenCalled()
+  })
+
+  it('repairs in the other direction too (activity signal, bare URL)', () => {
+    cleanup = initStore()
+    sidebarMode.value = 'activity'
+    navigateMock.mockClear()
+    urlPath.value = '/gmux/pi/x'
+    urlSearch.value = '?filter=gmux'
+    expect(sidebarMode.value).toBe('activity')
+    expect(navigateMock).toHaveBeenLastCalledWith('/gmux/pi/x?filter=gmux&sidebar=activity', true)
+  })
+
+  it('dispatches exactly one replacement for an explicit mode toggle', () => {
+    cleanup = initStore()
+    navigateMock.mockClear()
+    setSidebarMode('activity')
+    expect(navigateMock).toHaveBeenCalledTimes(1)
+    expect(navigateMock).toHaveBeenCalledWith('/?sidebar=activity', true)
+  })
+
+  it('canonicalizes malformed and repeated sidebar params in place', () => {
+    cleanup = initStore()
+    navigateMock.mockClear()
+    urlPath.value = '/gmux/pi/x'
+    urlSearch.value = '?sidebar=bogus&sidebar=activity&settings=hosts'
+    expect(sidebarMode.value).toBe('projects')
+    expect(navigateMock).toHaveBeenLastCalledWith('/gmux/pi/x?settings=hosts', true)
   })
 })
 

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -13,10 +13,10 @@
  * Call `initStore()` once from the app root to start SSE, fetch data, etc.
  */
 
-import { signal, computed, batch, effect } from '@preact/signals'
+import { signal, computed, batch, effect, untracked } from '@preact/signals'
 import type { Session, ProjectItem, DiscoveredProject, PeerInfo, PeerProject, LauncherDef, Folder } from './types'
 import type { View } from './routing'
-import { resolveViewFromPath, viewToPath, withTabParams } from './routing'
+import { resolveViewFromPath, viewToPath } from './routing'
 import { navigateWithReload } from './version-watch'
 import { buildProjectFolders, discoverProjects } from './projects'
 import { referencePresence, unresolvedReferences, removeReferenceItems, removeHostReferenceItems, type UnresolvedHost } from './references'
@@ -454,6 +454,20 @@ export const urlSearch = signal(
   typeof location !== 'undefined' ? location.search : '',
 )
 
+/** Current URL fragment (including the leading '#'). Kept separate from
+ * `urlSearch`: fragments are not query data, but same-view rewrites such as
+ * filter/sidebar edits and slug canonicalization must preserve them. */
+export const urlHash = signal(
+  typeof location !== 'undefined' ? location.hash : '',
+)
+
+/** Read the live fragment at a rewrite seam. `urlHash` drives reactive
+ * effects and supplies DOM-less tests; the browser value also covers a
+ * synchronous hash-only change before its `hashchange` event is delivered. */
+function currentHash(fallback?: string): string {
+  return typeof location !== 'undefined' ? location.hash : (fallback ?? urlHash.value)
+}
+
 /**
  * Activity tracking: which sessions recently produced output.
  *
@@ -533,22 +547,22 @@ export const filteredSessions = computed(() => {
 })
 
 /** Rewrite the tab's `?filter=` param (null/empty clears it). Replaces
- *  the history entry: narrowing tweaks shouldn't pollute Back. */
+ *  the history entry: narrowing tweaks shouldn't pollute Back. Targets
+ *  the full current URL so non-tab params (?settings, ?mock) survive a
+ *  filter edit. */
 export function setFilterSelectors(selectors: readonly Selector[]) {
-  const params = new URLSearchParams(urlSearch.value)
-  const value = formatFilterParam(selectors)
-  if (value) params.set('filter', value)
-  else params.delete('filter')
-  const qs = params.toString()
-  navigate(qs ? `${urlPath.value}?${qs}` : urlPath.value, true)
+  navigate(urlPath.value + urlSearch.value + currentHash(), true, {
+    filter: formatFilterParam(selectors) || null,
+  })
 }
 
 /** Href that carries the tab-identity params (?filter=, ?sidebar=).
  *  Every in-app link should go through this so navigating within a
- *  pinned tab keeps the pin. Reads the urlSearch signal, so links
- *  re-render when the tab's params change. */
+ *  pinned tab keeps the pin. Same carry contract as `navigate()`
+ *  (anchors bypass it: preact-iso routes the literal href), and reads
+ *  the same signals, so links re-render when the tab's params change. */
 export function tabHref(path: string): string {
-  return withTabParams(path, urlSearch.value)
+  return withCarriedParams(path)
 }
 
 export function removeSelector(sel: Selector) {
@@ -656,21 +670,29 @@ export const sidebarActivity = computed(() =>
 // Persistence is the URL (`?sidebar=activity`; absent = projects), so a
 // pinned tab keeps its view across reloads and other tabs can't
 // reconfigure it out from under the user.
+//
+// The URL is a *mirror*, not the source of truth: this signal is. It's
+// seeded from `?sidebar` once at boot (deep links work), and thereafter
+// the URL follows the signal — `navigate()` stamps the current mode
+// into every target URL, and a repair effect in `initStore` rewrites
+// (replaceState) any URL that disagrees, e.g. a history entry that
+// snapshotted an older mode. Back/Forward therefore never flips the
+// sidebar view; only the explicit toggle does.
 
 export type SidebarMode = 'projects' | 'activity'
 
-export const sidebarMode = computed<SidebarMode>(() =>
-  new URLSearchParams(urlSearch.value).get('sidebar') === 'activity'
+export const sidebarMode = signal<SidebarMode>(
+  typeof location !== 'undefined'
+    && new URLSearchParams(location.search).get('sidebar') === 'activity'
     ? 'activity'
     : 'projects',
 )
 
 export function setSidebarMode(m: SidebarMode) {
-  const params = new URLSearchParams(urlSearch.value)
-  if (m === 'activity') params.set('sidebar', 'activity')
-  else params.delete('sidebar')
-  const qs = params.toString()
-  navigate(qs ? `${urlPath.value}?${qs}` : urlPath.value, true)
+  sidebarMode.value = m
+  // Mirror into the URL immediately (replace: a view toggle is not a
+  // navigation). Preserve any non-tab params (e.g. ?settings).
+  navigate(urlPath.value + urlSearch.value + currentHash(), true)
 }
 
 // ── Alive-only toggle ────────────────────────────────────────────────────
@@ -1066,7 +1088,7 @@ function commitWithSlugRewrite(
   // Sync the browser URL bar. navigate(replace) uses history.replaceState
   // via preact-iso, so back/forward history isn't polluted. urlPath was
   // already set above inside the batch for atomicity with the session data.
-  navigate(newUrl, true)
+  navigate(newUrl + currentHash(), true)
   return true
 }
 
@@ -1480,15 +1502,59 @@ export function setNavigate(fn: (url: string, replace?: boolean) => void) {
   _navigate = fn
 }
 
-export function navigate(url: string, replace?: boolean) {
+/** Stamp the tab-identity params onto a target URL. The contract for
+ *  all programmatic navigation (`navigate`):
+ *
+ *   - `?filter=` is carried from the current URL by default; callers
+ *     change it only via `opts.filter` (string = set, null = clear) —
+ *     never by hand-building a query string.
+ *   - `?sidebar=` always mirrors the `sidebarMode` signal (the source
+ *     of truth), so no navigation can capture a stale mode.
+ *   - Recognized mock boot context (`?mock`, `?host`) is also carried,
+ *     so an SPA route remains reloadable in the same mock environment.
+ *   - Any other params already on the target URL pass through.
+ *
+ *  This is why canonicalization rewrites (rename, slug collision,
+ *  resume) can navigate with a bare path and still keep the tab's
+ *  narrowing — carrying is the default, not a per-call-site chore. */
+function withCarriedParams(url: string, opts?: { filter?: string | null }): string {
+  // Detach a hash fragment first: URLSearchParams would otherwise
+  // swallow it into the last param's value.
+  const hi = url.indexOf('#')
+  const hash = hi >= 0 ? url.slice(hi) : ''
+  const base = hi >= 0 ? url.slice(0, hi) : url
+  const qi = base.indexOf('?')
+  const path = qi >= 0 ? base.slice(0, qi) : base
+  const params = new URLSearchParams(qi >= 0 ? base.slice(qi) : '')
+  const current = new URLSearchParams(urlSearch.value)
+  const filter = opts?.filter !== undefined
+    ? opts.filter
+    : current.get('filter')
+  if (filter) params.set('filter', filter)
+  else params.delete('filter')
+  if (sidebarMode.value === 'activity') params.set('sidebar', 'activity')
+  else params.delete('sidebar')
+  // Mock mode is selected only at document boot. Keep its recognized context
+  // on route changes so a later reload does not silently leave mock mode.
+  for (const key of ['mock', 'host']) {
+    if (!params.has(key)) {
+      for (const value of current.getAll(key)) params.append(key, value)
+    }
+  }
+  const qs = params.toString()
+  return (qs ? `${path}?${qs}` : path) + hash
+}
+
+export function navigate(url: string, replace?: boolean, opts?: { filter?: string | null }) {
+  const full = withCarriedParams(url, opts)
   // When the bundle has drifted from the daemon, the version watcher
   // converts the next in-app navigation into a full document load.
   // The user perceives it as a normal route transition that happens
   // to also pick up the new bundle. (The store ↔ version-watch
   // module cycle is safe: neither side touches the other at top
   // level.)
-  if (navigateWithReload(url, replace)) return
-  _navigate?.(url, replace)
+  if (navigateWithReload(full, replace)) return
+  _navigate?.(full, replace)
 }
 
 /**
@@ -1505,9 +1571,9 @@ export function navigateToSession(sessionId: string, replace?: boolean): boolean
     sessions.value,
   )
   if (!path) return false
-  // Carry the tab-identity params (?filter=, ?sidebar=) so programmatic
-  // navigation doesn't un-pin a narrowed tab.
-  navigate(withTabParams(path, urlSearch.value), replace)
+  // navigate() carries the tab-identity params (?filter=, ?sidebar=),
+  // so programmatic navigation doesn't un-pin a narrowed tab.
+  navigate(path, replace)
   return true
 }
 
@@ -1517,6 +1583,33 @@ export function navigateToSession(sessionId: string, replace?: boolean): boolean
  */
 export function initStore(): () => void {
   const cleanups: (() => void)[] = []
+
+  // Sidebar-mode repair: the URL mirrors the `sidebarMode` signal, but
+  // history entries snapshot the query string at push time, so Back can
+  // land on an entry stamped with an older mode (or a pre-signal-era
+  // bookmark). The signal is authoritative after boot: rewrite any URL
+  // that disagrees, in place (replaceState — no history pollution, and
+  // the forward stack survives). Converges in one step: the rewritten
+  // URL matches the signal, so the effect re-runs once and does nothing.
+  const disposeSidebarRepair = effect(() => {
+    const path = urlPath.value
+    const search = urlSearch.value
+    const hash = urlHash.value
+    const params = new URLSearchParams(search)
+    const sidebarValues = params.getAll('sidebar')
+    const mode = sidebarMode.peek()
+    const canonical = mode === 'activity'
+      ? sidebarValues.length === 1 && sidebarValues[0] === 'activity'
+      : sidebarValues.length === 0
+    if (!canonical) {
+      // The setter owns signal-driven mirroring. This effect tracks URL
+      // changes only, avoiding a duplicate soft (or hard) replacement when
+      // the user toggles modes; untracked keeps navigate's signal reads from
+      // becoming dependencies during a repair run.
+      untracked(() => navigate(path + search + currentHash(hash), true))
+    }
+  })
+  cleanups.push(disposeSidebarRepair)
 
   if (USE_MOCK) {
     const localHost = new URLSearchParams(location.search).get('host')
@@ -1633,9 +1726,8 @@ export function initStore(): () => void {
     if (v === null) return
     const url = viewToPath(v, projects.value, sessions.value)
     if (url && url !== urlPath.value) {
-      // Preserve tab-identity params across normalization; the raw
-      // path replace would otherwise strip ?filter=/?sidebar=.
-      navigate(withTabParams(url, urlSearch.value), true)
+      // navigate() preserves tab-identity params across normalization.
+      navigate(url + currentHash(), true)
     }
   })
   cleanups.push(disposeUrlNorm)


### PR DESCRIPTION
## Summary

Post-2.0 routing correctness follow-up:

- centralize applicable query-state carrying in `navigate()`/`tabHref()` so rename, resume, launch, exact-ID canonicalization, normalization, and session/home navigation retain filters and mock boot context
- make the sidebar Projects/Activity mode signal-authoritative after deep-link boot; Back/Forward repairs stale URL mirrors in place without flipping the mode or growing history
- preserve target parameters and fragments, including hash-only Back/Forward, and route Settings through the centralized navigation contract
- strengthen coverage for exact `~<machine-id>` routes, slug collisions, deep-link startup, malformed sidebar params, mock reloads, and one-replace repair behavior

## Validation

- `pnpm --filter @gmux/web test` — 619 passed
- `pnpm --filter @gmux/web lint` — passed (`tsc --noEmit`)
- `pnpm --filter @gmux/web build` — passed
- Chromium/Playwright probes: stale-mode Back/Forward repair + forward-stack preservation, deep-link and multi-tab mode isolation, exact-ID/filter carrying, mock click-and-reload context, Settings/hash preservation, and hash-only Back/Forward
- Three-reviewer adversarial delta re-review — integrate
