### PR TITLE
feat(adapter): add Claude semantic agent parity

### DIFF
--- a/cli/gmux/cmd/gmux/agent.go
+++ b/cli/gmux/cmd/gmux/agent.go
@@ -437,9 +437,9 @@ func cmdAgentPrompt(ref, mode string, noWait bool, timeoutSecs int, text *string
 // so tests can drive `--new`'s output contract without forking a real agent.
 var agentLaunchSession = launchDetachedSession
 
-// agentLaunchAdapter is the adapter `--new` launches through. The launch is
-// pi-only for now (there is no --adapter flag), exactly like the rest of this
-// namespace; a variable so tests can substitute a non-launcher adapter.
+// agentLaunchAdapter is the default adapter `--new` launches when no
+// --adapter selector is supplied; a variable so tests can substitute a
+// non-launcher adapter.
 var agentLaunchAdapter adapter.Adapter = adapters.NewPi()
 
 // cmdAgentPromptNew implements `gmux agent prompt --new`: launch a session and

--- a/cli/gmux/cmd/gmux/agent.go
+++ b/cli/gmux/cmd/gmux/agent.go
@@ -10,6 +10,7 @@ package main
 // and wait share one stdout exchange report; logs reads adapter storage only.
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -503,7 +504,7 @@ func cmdAgentPromptNew(adapterName, model, name string, noWait bool, timeoutSecs
 		fmt.Fprintln(os.Stderr, "gmux:", err)
 		return waitExitError
 	}
-	return deliverPrompt(cliSession{ID: id}, agentModePrompt, noWait, timeoutSecs, prompt)
+	return deliverPrompt(cliSession{ID: id, Adapter: launchAdapter.Name()}, agentModePrompt, noWait, timeoutSecs, prompt)
 }
 
 // agentLaunchArgv translates launch options into an argv, or reports that this
@@ -648,6 +649,13 @@ func reportAgentPromptSuccess(sess cliSession, status int, body []byte, noWait b
 	}
 	switch res.Outcome {
 	case waitOutcomeCompleted, waitOutcomeInterrupted, waitOutcomeError, outcomeTimeout:
+		// Claude's terminal hook and gmuxd's outcome projection travel on
+		// independent streams. If the fused prompt response won that race before
+		// carrying any exchange data, the already-settled observational wait is
+		// the authoritative read and completes immediately.
+		if sess.Adapter == "claude" && len(res.Exchanges) == 0 && res.Output == "" {
+			return waitSession(context.Background(), sess, 0, 0, "", "", false, os.Stdout)
+		}
 		text := ""
 		if len(submitted) > 0 {
 			text = submitted[0]

--- a/cli/gmux/cmd/gmux/agent.go
+++ b/cli/gmux/cmd/gmux/agent.go
@@ -155,7 +155,7 @@ func parseAgentPrompt(args []string) (*command, error) {
 	c := &command{mode: modeAgent, agentSub: "prompt", agentMode: agentModePrompt}
 	modeSet := ""
 	noWaitSet, timeoutSet := false, false
-	newSet, modelSet, nameSet := false, false, false
+	newSet, adapterSet, modelSet, nameSet := false, false, false, false
 	// A leading help token asks about the verb. Only the leading position:
 	// after the ref, every token is verbatim prompt text, so
 	// `agent prompt s1 ?` prompts with a literal `?`.
@@ -196,6 +196,19 @@ func parseAgentPrompt(args []string) (*command, error) {
 			}
 			newSet = true
 			c.agentNew = true
+		case a == "--adapter" || strings.HasPrefix(a, "--adapter="):
+			if adapterSet {
+				return nil, agentRepeatedFlag("--adapter")
+			}
+			adapterSet = true
+			v, next, err := agentFlagValue(args, i, "--adapter")
+			if err != nil {
+				return nil, err
+			}
+			if v != "pi" && v != "claude" {
+				return nil, fmt.Errorf("agent prompt: unknown launch adapter %q (expected pi or claude)", v)
+			}
+			c.agentAdapter, i = v, next
 		case a == "--model" || strings.HasPrefix(a, "--model="):
 			if modelSet {
 				return nil, agentRepeatedFlag("--model")
@@ -265,6 +278,9 @@ func parseAgentPrompt(args []string) (*command, error) {
 			return nil, fmt.Errorf("agent prompt: %s needs a turn to act on, so it cannot be combined with --new", modeSet)
 		}
 	} else {
+		if adapterSet {
+			return nil, errors.New("agent prompt: --adapter only applies to a session gmux is launching; pass it with --new")
+		}
 		if modelSet {
 			return nil, errors.New("agent prompt: --model only applies to a session gmux is launching; pass it with --new")
 		}
@@ -372,7 +388,7 @@ func cmdAgent(c *command) int {
 	switch c.agentSub {
 	case "prompt":
 		if c.agentNew {
-			return cmdAgentPromptNew(c.agentModel, c.agentName, c.agentNoWait, c.timeout, c.promptText)
+			return cmdAgentPromptNew(c.agentAdapter, c.agentModel, c.agentName, c.agentNoWait, c.timeout, c.promptText)
 		}
 		return cmdAgentPrompt(c.ref, c.agentMode, c.agentNoWait, c.timeout, c.promptText)
 	case "cancel":
@@ -449,16 +465,20 @@ var agentLaunchAdapter adapter.Adapter = adapters.NewPi()
 // a session that never becomes ready fails its first prompt exactly as it
 // would fail its tenth: admission is the single health event, and there is no
 // launch-shaped special case to keep in sync.
-func cmdAgentPromptNew(model, name string, noWait bool, timeoutSecs int, text *string) int {
+func cmdAgentPromptNew(adapterName, model, name string, noWait bool, timeoutSecs int, text *string) int {
 	prompt, err := readPromptText(text, os.Stdin, localterm.IsInteractive())
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "gmux:", err)
 		return waitExitError
 	}
-	argv, ok := agentLaunchArgv(agentLaunchAdapter, adapter.LaunchOptions{Model: model, Name: name})
+	launchAdapter := agentLaunchAdapter
+	if adapterName == "claude" {
+		launchAdapter = adapters.NewClaude()
+	}
+	argv, ok := agentLaunchArgv(launchAdapter, adapter.LaunchOptions{Model: model, Name: name})
 	if !ok {
-		fmt.Fprintf(os.Stderr, "gmux: %s: %s cannot be launched by gmux agent prompt --new\n",
-			codeUnsupportedAdapter, agentLaunchAdapter.Name())
+		fmt.Fprintf(os.Stderr, "gmux: %s: %s cannot apply the requested gmux agent prompt --new options\n",
+			codeUnsupportedAdapter, launchAdapter.Name())
 		fmt.Fprintln(os.Stderr, "gmux: start it yourself with 'gmux -d -- <command>' and prompt the id it prints")
 		return waitExitError
 	}
@@ -842,11 +862,12 @@ func printAgentUsage(w io.Writer, topic string) {
 		fmt.Fprint(w, `gmux agent prompt — send instructions and report the observed activity
 
   gmux agent prompt [--no-wait] [--follow-up|--steer] [--timeout|-t N] <id> [prompt]
-  gmux agent prompt --new [--model M] [--name N] [--no-wait] [--timeout N] [prompt]
+  gmux agent prompt --new [--adapter pi|claude] [--model M] [--name N] [--no-wait] [--timeout N] [prompt]
 
-  --new             launch a new pi conversation
-  --model M         --new only: model passed to pi
-  --name N          --new only: conversation name passed to pi
+  --new             launch a new agent conversation
+  --adapter A       --new only: adapter to launch (pi default; claude supported)
+  --model M         --new only: model passed to the selected agent
+  --name N          --new only: conversation name passed to the selected agent
   --no-wait         return after admission; print no activity report
   --follow-up       submit after the current model response
   --steer           redirect activity that is currently in progress

--- a/cli/gmux/cmd/gmux/agent_launch_exchange_test.go
+++ b/cli/gmux/cmd/gmux/agent_launch_exchange_test.go
@@ -16,6 +16,23 @@ func stubAgentLaunch(t *testing.T, id string, err error) *[]string {
 	return &got
 }
 
+func TestAgentPromptNewClaudeSelection(t *testing.T) {
+	d := startStubDaemon(t, localSession())
+	d.on(func(w http.ResponseWriter, _ *http.Request) {
+		writeEnvelope(w, http.StatusAccepted, map[string]any{"admission": "accepted"})
+	})
+	argv := stubAgentLaunch(t, "1va8lvdv", nil)
+	text := "go"
+	stdout := captureStdout(t, func() {
+		if code := cmdAgentPromptNew("claude", "sonnet", "review", true, 0, &text); code != 0 {
+			t.Fatalf("exit = %d", code)
+		}
+	})
+	if stdout != "1va8lvdv\n" || strings.Join(*argv, " ") != "claude --model sonnet --name review" {
+		t.Fatalf("stdout=%q argv=%v", stdout, *argv)
+	}
+}
+
 func TestAgentPromptNewOutputAndOrphanContracts(t *testing.T) {
 	t.Run("no wait prints bare id", func(t *testing.T) {
 		d := startStubDaemon(t, localSession())
@@ -25,7 +42,7 @@ func TestAgentPromptNewOutputAndOrphanContracts(t *testing.T) {
 		stubAgentLaunch(t, "1va8lvdv", nil)
 		text := "go"
 		var code int
-		stdout := captureStdout(t, func() { code = cmdAgentPromptNew("", "", true, 0, &text) })
+		stdout := captureStdout(t, func() { code = cmdAgentPromptNew("", "", "", true, 0, &text) })
 		if code != 0 || stdout != "1va8lvdv\n" {
 			t.Fatalf("exit=%d stdout=%q", code, stdout)
 		}
@@ -42,7 +59,7 @@ func TestAgentPromptNewOutputAndOrphanContracts(t *testing.T) {
 		var code int
 		var stderr string
 		stdout := captureStdout(t, func() {
-			stderr = captureStderr(t, func() { code = cmdAgentPromptNew("", "", false, 0, &text) })
+			stderr = captureStderr(t, func() { code = cmdAgentPromptNew("", "", "", false, 0, &text) })
 		})
 		if code != 0 || !strings.HasPrefix(stdout, "[USER]: go") || !strings.Contains(stdout, "[AGENT]: done") {
 			t.Fatalf("exit=%d stdout=%q", code, stdout)
@@ -62,7 +79,7 @@ func TestAgentPromptNewOutputAndOrphanContracts(t *testing.T) {
 		var code int
 		var stderr string
 		stdout := captureStdout(t, func() {
-			stderr = captureStderr(t, func() { code = cmdAgentPromptNew("", "", false, 0, &text) })
+			stderr = captureStderr(t, func() { code = cmdAgentPromptNew("", "", "", false, 0, &text) })
 		})
 		if code != waitExitError || stdout != "" {
 			t.Fatalf("exit=%d stdout=%q", code, stdout)
@@ -77,7 +94,7 @@ func TestAgentPromptNewOutputAndOrphanContracts(t *testing.T) {
 		stubAgentLaunch(t, "", errors.New("spawn failed"))
 		text := "go"
 		var code int
-		stdout := captureStdout(t, func() { captureStderr(t, func() { code = cmdAgentPromptNew("", "", false, 0, &text) }) })
+		stdout := captureStdout(t, func() { captureStderr(t, func() { code = cmdAgentPromptNew("", "", "", false, 0, &text) }) })
 		if code != waitExitError || stdout != "" {
 			t.Fatalf("exit=%d stdout=%q", code, stdout)
 		}
@@ -87,7 +104,7 @@ func TestAgentPromptNewOutputAndOrphanContracts(t *testing.T) {
 		startStubDaemon(t, localSession())
 		argv := stubAgentLaunch(t, "1va8lvdv", nil)
 		empty := "   "
-		captureStderr(t, func() { _ = cmdAgentPromptNew("", "", false, 0, &empty) })
+		captureStderr(t, func() { _ = cmdAgentPromptNew("", "", "", false, 0, &empty) })
 		if *argv != nil {
 			t.Fatalf("spawned invalid prompt: %q", *argv)
 		}

--- a/cli/gmux/cmd/gmux/claudehook.go
+++ b/cli/gmux/cmd/gmux/claudehook.go
@@ -3,10 +3,12 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"net"
 	"net/http"
 	"os"
+	"os/exec"
 	"time"
 
 	"github.com/gmuxapp/gmux/packages/adapter/adapters"
@@ -41,6 +43,44 @@ func runClaudeHook(in io.Reader, sock string) {
 	for _, body := range adapters.ClaudeHookBodies(input) {
 		postClaudeHookEvent(sock, body)
 	}
+	var event struct {
+		Name string `json:"hook_event_name"`
+	}
+	if json.Unmarshal(input, &event) == nil && event.Name == "SessionStart" {
+		scheduleClaudeReady(sock)
+	}
+}
+
+// Claude invokes SessionStart before its interactive composer can reliably
+// retain terminal input. A detached helper reports readiness after that startup
+// window; keeping the delay out of the awaited hook lets Claude finish mounting
+// its UI. Duplicate SessionStart events are harmless because runner readiness
+// is idempotent.
+var scheduleClaudeReady = func(sock string) {
+	self, err := os.Executable()
+	if err != nil {
+		return
+	}
+	cmd := exec.Command(self, "__claude-ready")
+	cmd.Env = append(os.Environ(), "GMUX_SESSION_SOCK="+sock)
+	if cmd.Start() == nil {
+		_ = cmd.Process.Release()
+	}
+}
+
+const claudeComposerStartupDelay = 2 * time.Second
+
+func claudeReady() int {
+	runClaudeReady(os.Getenv("GMUX_SESSION_SOCK"), claudeComposerStartupDelay)
+	return 0
+}
+
+func runClaudeReady(sock string, delay time.Duration) {
+	if sock == "" {
+		return
+	}
+	time.Sleep(delay)
+	postClaudeHookEvent(sock, []byte(`{"op":"ready"}`))
 }
 
 // postClaudeHookEvent POSTs one event body to the runner's /hook/event over the

--- a/cli/gmux/cmd/gmux/claudehook.go
+++ b/cli/gmux/cmd/gmux/claudehook.go
@@ -40,13 +40,18 @@ func runClaudeHook(in io.Reader, sock string) {
 	if sock == "" {
 		return
 	}
+	var event struct {
+		Name           string `json:"hook_event_name"`
+		TranscriptPath string `json:"transcript_path"`
+	}
+	_ = json.Unmarshal(input, &event)
+	if event.Name == "Stop" || event.Name == "StopFailure" {
+		awaitClaudeTerminalExchange(event.TranscriptPath, 500*time.Millisecond)
+	}
 	for _, body := range adapters.ClaudeHookBodies(input) {
 		postClaudeHookEvent(sock, body)
 	}
-	var event struct {
-		Name string `json:"hook_event_name"`
-	}
-	if json.Unmarshal(input, &event) == nil && event.Name == "SessionStart" {
+	if event.Name == "SessionStart" {
 		scheduleClaudeReady(sock)
 	}
 }
@@ -86,6 +91,30 @@ func runClaudeReady(sock string, delay time.Duration) {
 // postClaudeHookEvent POSTs one event body to the runner's /hook/event over the
 // Unix socket. Best-effort with a short timeout; transport errors are swallowed
 // so the hook never surfaces a failure into Claude.
+// Claude can invoke its terminal hook just before the final transcript append
+// becomes visible. Give that append a short bounded window before publishing
+// the turn end, so an observational wait can render the exchange it resolved.
+func awaitClaudeTerminalExchange(ref string, timeout time.Duration) {
+	if ref == "" {
+		return
+	}
+	deadline := time.Now().Add(timeout)
+	for {
+		exchanges, err := adapters.NewClaude().RenderConversationExchanges(ref)
+		if err == nil && len(exchanges) > 0 && exchanges[len(exchanges)-1].Iterations > 0 {
+			// The runner bind and conversation watcher reach gmuxd on separate
+			// streams. Let the already-visible append propagate before the turn
+			// end releases observational waiters.
+			time.Sleep(200 * time.Millisecond)
+			return
+		}
+		if time.Now().After(deadline) {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
 func postClaudeHookEvent(sock string, body []byte) {
 	client := &http.Client{
 		Timeout: 2 * time.Second,

--- a/cli/gmux/cmd/gmux/claudehook_test.go
+++ b/cli/gmux/cmd/gmux/claudehook_test.go
@@ -73,6 +73,29 @@ func TestRunClaudeHookPosts(t *testing.T) {
 	}
 }
 
+func TestAwaitClaudeTerminalExchangeWaitsForFinalAppend(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	if err := os.WriteFile(path, []byte(`{"type":"user","message":{"role":"user","content":"hi"}}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan struct{})
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		f, _ := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o600)
+		if f != nil {
+			_, _ = f.WriteString(`{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"done"}]}}` + "\n")
+			_ = f.Close()
+		}
+		close(done)
+	}()
+	awaitClaudeTerminalExchange(path, time.Second)
+	select {
+	case <-done:
+	default:
+		t.Fatal("returned before final transcript append")
+	}
+}
+
 func TestClaudeHookExitsZero(t *testing.T) {
 	// Redirect stdin to empty so claudeHook doesn't block; it must exit 0 and
 	// (implicitly) write nothing to stdout.

--- a/cli/gmux/cmd/gmux/claudehook_test.go
+++ b/cli/gmux/cmd/gmux/claudehook_test.go
@@ -16,11 +16,31 @@ func TestParseClaudeHookCLI(t *testing.T) {
 	if err != nil || cmd.mode != modeClaudeHook {
 		t.Fatalf("want modeClaudeHook, got %+v err=%v", cmd, err)
 	}
+	cmd, err = parseCLI([]string{"__claude-ready"})
+	if err != nil || cmd.mode != modeClaudeReady {
+		t.Fatalf("want modeClaudeReady, got %+v err=%v", cmd, err)
+	}
 }
 
 func TestRunClaudeHookInertWithoutSocket(t *testing.T) {
 	// No socket: must drain stdin and return without panicking.
 	runClaudeHook(strings.NewReader(`{"hook_event_name":"UserPromptSubmit"}`), "")
+}
+
+func TestClaudeSessionStartSchedulesDelayedReadiness(t *testing.T) {
+	old := scheduleClaudeReady
+	defer func() { scheduleClaudeReady = old }()
+	called := ""
+	scheduleClaudeReady = func(sock string) { called = sock }
+	runClaudeHook(strings.NewReader(`{"hook_event_name":"SessionStart"}`), "/tmp/runner.sock")
+	if called != "/tmp/runner.sock" {
+		t.Fatalf("scheduled socket = %q", called)
+	}
+	called = ""
+	runClaudeHook(strings.NewReader(`{"hook_event_name":"UserPromptSubmit"}`), "/tmp/runner.sock")
+	if called != "" {
+		t.Fatalf("non-start event scheduled readiness: %q", called)
+	}
 }
 
 func TestRunClaudeHookPosts(t *testing.T) {

--- a/cli/gmux/cmd/gmux/cli.go
+++ b/cli/gmux/cmd/gmux/cli.go
@@ -34,6 +34,7 @@ const (
 	modeDumpEnv                // (internal) gmux __dump-env
 	modeCodexHook              // (internal) gmux __codex-hook <Event>
 	modeClaudeHook             // (internal) gmux __claude-hook
+	modeClaudeReady            // (internal) delayed Claude composer readiness
 )
 
 // command is the fully-parsed CLI invocation. One struct for every
@@ -244,6 +245,11 @@ func parseCLI(args []string) (*command, error) {
 		return &command{mode: modeCodexHook, codexHookEvent: rest[0]}, nil
 	case "__claude-hook":
 		return &command{mode: modeClaudeHook}, nil
+	case "__claude-ready":
+		if len(rest) != 0 {
+			return nil, errors.New("__claude-ready takes no arguments")
+		}
+		return &command{mode: modeClaudeReady}, nil
 	case "__edit-child":
 		// Child process of an editor session: prompt (if needed) and exec
 		// the fallback editor. Reuses the editFile field.

--- a/cli/gmux/cmd/gmux/cli.go
+++ b/cli/gmux/cmd/gmux/cli.go
@@ -76,6 +76,7 @@ type command struct {
 	agentNoWait bool    // --no-wait: return at the admission boundary
 	promptText  *string // inline prompt text (nil = read stdin)
 	agentNew    bool    // --new: launch the session this prompt starts
+	agentAdapter string  // --new only: adapter selector (pi default)
 	agentModel  string  // --new only: model selector for the launch
 	agentName   string  // --new only: session display name for the launch
 

--- a/cli/gmux/cmd/gmux/exchange_report_test.go
+++ b/cli/gmux/cmd/gmux/exchange_report_test.go
@@ -59,6 +59,8 @@ func TestAgentPromptGrammarMatrix(t *testing.T) {
 		{"agent", "prompt", "--timeout", "1", "--no-wait", "s", "x"},
 		{"agent", "prompt", "--model", "m", "s", "x"},
 		{"agent", "prompt", "--name", "n", "s", "x"},
+		{"agent", "prompt", "--adapter", "claude", "s", "x"},
+		{"agent", "prompt", "--new", "--adapter", "codex", "x"},
 		{"agent", "cancel", "a", "b"},
 	}
 	for _, args := range invalid {
@@ -66,7 +68,11 @@ func TestAgentPromptGrammarMatrix(t *testing.T) {
 			t.Errorf("accepted %v", args)
 		}
 	}
-	c, err := parseCLI([]string{"agent", "prompt", "s", "--timeout literal"})
+	c, err := parseCLI([]string{"agent", "prompt", "--new", "--adapter", "claude", "--model", "sonnet", "x"})
+	if err != nil || !c.agentNew || c.agentAdapter != "claude" || c.agentModel != "sonnet" {
+		t.Fatalf("claude launch selector: c=%+v err=%v", c, err)
+	}
+	c, err = parseCLI([]string{"agent", "prompt", "s", "--timeout literal"})
 	if err != nil || c.promptText == nil || *c.promptText != "--timeout literal" {
 		t.Fatalf("post-ref text was parsed as flags: c=%+v err=%v", c, err)
 	}

--- a/cli/gmux/cmd/gmux/exchange_report_test.go
+++ b/cli/gmux/cmd/gmux/exchange_report_test.go
@@ -190,6 +190,27 @@ func TestAgentLogsRequiresExchangeScopeMarker(t *testing.T) {
 	}
 }
 
+func TestClaudePromptFallsBackToSettledObservationalWait(t *testing.T) {
+	d := startStubDaemon(t, localSession())
+	d.on(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/wait") {
+			t.Fatalf("fallback path = %s", r.URL.Path)
+		}
+		writeEnvelope(w, http.StatusOK, map[string]any{
+			"reason": "idle", "outcome": "error", "output": "provider failed",
+			"exchanges": []map[string]any{{"ordinal": 1, "user": "go", "iterations": 1}},
+		})
+	})
+	body := []byte(`{"data":{"outcome":"error","exchanges":[]}}`)
+	var code int
+	stdout := captureStdout(t, func() {
+		code = reportAgentPromptSuccess(cliSession{ID: "s1", Adapter: "claude"}, http.StatusOK, body, false, "go")
+	})
+	if code != waitExitError || !strings.Contains(stdout, "[USER]: go") || !strings.Contains(stdout, "[AGENT, partial]: provider failed") {
+		t.Fatalf("exit=%d report=%q", code, stdout)
+	}
+}
+
 func TestWaitExitTaxonomyAndSignalFormatting(t *testing.T) {
 	if waitExitOK != 0 || waitExitError != 1 || waitExitInterrupted != 2 {
 		t.Fatalf("exit taxonomy=%d/%d/%d", waitExitOK, waitExitError, waitExitInterrupted)

--- a/cli/gmux/cmd/gmux/main.go
+++ b/cli/gmux/cmd/gmux/main.go
@@ -90,6 +90,8 @@ func main() {
 		os.Exit(codexHook(cmd.codexHookEvent))
 	case modeClaudeHook:
 		os.Exit(claudeHook())
+	case modeClaudeReady:
+		os.Exit(claudeReady())
 	}
 }
 

--- a/cli/gmux/internal/ptyserver/actions_test.go
+++ b/cli/gmux/internal/ptyserver/actions_test.go
@@ -573,7 +573,7 @@ func TestCancelRejectsABody(t *testing.T) {
 
 func TestUnsupportedAdaptersAndActions(t *testing.T) {
 	t.Run("adapter without semantic actions", func(t *testing.T) {
-		for _, ad := range []adapter.Adapter{adapters.NewClaude(), adapters.NewCodex(), adapters.NewShell()} {
+		for _, ad := range []adapter.Adapter{adapters.NewCodex(), adapters.NewShell()} {
 			f := newActionFixture(t, ad)
 			f.ready(t) // ready, so the refusal is about capability and nothing else
 			code, ec := f.post(t, "/prompt", `{"prompt":"go","delivery":"now","require":"any"}`)

--- a/latewait.out
+++ b/latewait.out
@@ -1,0 +1,7 @@
+[USER]: Reply with exactly: GMUX_CLAUDE_RESULT4_OK
+
+[Agent worked for 1 iteration]
+
+[AGENT, partial]: Your organization has disabled Claude subscription access for Claude Code · Use an Anthropic API key instead, or ask your admin to enable access
+
+[Agent failed: activity could not be completed]

--- a/packages/adapter/adapters/claude.go
+++ b/packages/adapter/adapters/claude.go
@@ -24,6 +24,8 @@ var (
 	_ adapter.ConversationDescriber = (*Claude)(nil)
 	_ adapter.ConversationOpener    = (*Claude)(nil)
 	_ adapter.Resumer               = (*Claude)(nil)
+	_ adapter.AgentActionEncoder    = (*Claude)(nil)
+	_ adapter.AgentLauncher         = (*Claude)(nil)
 )
 
 func init() {
@@ -67,6 +69,42 @@ func (c *Claude) Launchers() []adapter.Launcher {
 		Command:     []string{"claude"},
 		Description: "Coding Agent",
 	}}
+}
+
+// Claude's input loop accepts prompts as soon as SessionStart runs. Ten
+// seconds accommodates a cold Node.js start without turning a missing hook
+// into an indefinite semantic delivery.
+const claudeActionReadyTimeout = 10 * time.Second
+
+// EncodeAction maps gmux's semantic operations to Claude Code's reserved
+// interactive bindings. Enter submits both an in-flight steering instruction
+// and a queued follow-up; gmux's delivery requirement distinguishes those
+// intents. Ctrl+C is Claude's non-rebindable interrupt (Escape is unsuitable:
+// it cancels editor input, closes dialogs, and is affected by vim mode).
+func (c *Claude) EncodeAction(action adapter.AgentAction) (string, bool) {
+	switch action {
+	case adapter.ActionSend, adapter.ActionSendAfterTurn:
+		return "\r", true
+	case adapter.ActionInterrupt:
+		return "\x03", true
+	default:
+		return "", false
+	}
+}
+
+func (c *Claude) ActionReadyTimeout() time.Duration { return claudeActionReadyTimeout }
+
+// LaunchCommand starts a bare interactive Claude session. The initial prompt
+// is deliberately delivered through the readiness-gated semantic path.
+func (c *Claude) LaunchCommand(opts adapter.LaunchOptions) ([]string, bool) {
+	argv := []string{"claude"}
+	if opts.Model != "" {
+		argv = append(argv, "--model", opts.Model)
+	}
+	if opts.Name != "" {
+		argv = append(argv, "--name", opts.Name)
+	}
+	return argv, true
 }
 
 // --- Conversation storage (file-backed: refs are absolute JSONL paths) ---

--- a/packages/adapter/adapters/claude_conversation.go
+++ b/packages/adapter/adapters/claude_conversation.go
@@ -18,6 +18,8 @@ var (
 // alone is deliberately not enough to establish a user exchange boundary.
 type claudeConversationEntry struct {
 	Type        string `json:"type"`
+	UUID        string `json:"uuid"`
+	ParentUUID  string `json:"parentUuid"`
 	IsMeta      bool   `json:"isMeta"`
 	IsSidechain bool   `json:"isSidechain"`
 	Message     *struct {
@@ -31,19 +33,72 @@ func readClaudeEntries(ref string) ([]claudeConversationEntry, error) {
 	if err != nil {
 		return nil, err
 	}
-	var entries []claudeConversationEntry
+	var linear []claudeConversationEntry
 	for _, line := range strings.Split(string(data), "\n") {
 		if strings.TrimSpace(line) == "" {
 			continue
 		}
 		var entry claudeConversationEntry
 		// A transcript can be observed while its final line is being appended.
-		if json.Unmarshal([]byte(line), &entry) != nil || entry.IsMeta || entry.IsSidechain {
+		if json.Unmarshal([]byte(line), &entry) != nil {
 			continue
 		}
-		entries = append(entries, entry)
+		linear = append(linear, entry)
 	}
-	return entries, nil
+	return claudeActiveBranch(linear), nil
+}
+
+// claudeActiveBranch follows Claude's native parent-linked history from the
+// final persisted node. Rewind/fork leaves abandoned messages in the JSONL;
+// rendering file order would disclose and misattribute that abandoned branch.
+// Older transcripts without parent links remain linear.
+func claudeActiveBranch(linear []claudeConversationEntry) []claudeConversationEntry {
+	if len(linear) == 0 {
+		return nil
+	}
+	hasParents := false
+	byID := make(map[string]claudeConversationEntry, len(linear))
+	for _, entry := range linear {
+		if entry.ParentUUID != "" {
+			hasParents = true
+		}
+		if entry.UUID != "" {
+			byID[entry.UUID] = entry
+		}
+	}
+	if !hasParents {
+		return linear
+	}
+	// Non-conversation bookkeeping records can trail the active message and
+	// carry no UUID. They must not disable branch reconstruction.
+	leaf := claudeConversationEntry{}
+	for i := len(linear) - 1; i >= 0; i-- {
+		if linear[i].UUID != "" {
+			leaf = linear[i]
+			break
+		}
+	}
+	if leaf.UUID == "" {
+		return linear
+	}
+	var reverse []claudeConversationEntry
+	seen := make(map[string]bool)
+	for cur := leaf; cur.UUID != "" && !seen[cur.UUID]; {
+		reverse = append(reverse, cur)
+		seen[cur.UUID] = true
+		if cur.ParentUUID == "" {
+			break
+		}
+		next, ok := byID[cur.ParentUUID]
+		if !ok {
+			break
+		}
+		cur = next
+	}
+	for left, right := 0, len(reverse)-1; left < right; left, right = left+1, right-1 {
+		reverse[left], reverse[right] = reverse[right], reverse[left]
+	}
+	return reverse
 }
 
 // renderClaudeContent returns a visible rendering, its prose-only subset, and
@@ -77,6 +132,7 @@ func renderClaudeContent(raw json.RawMessage) (text, prose string, userBoundary 
 			parts = append(parts, formatPiToolCall(block.Name, block.Input))
 		case "image":
 			parts = append(parts, "[image]")
+			userBoundary = true
 		}
 	}
 	return strings.Join(parts, "\n\n"), strings.Join(proseParts, "\n\n"), userBoundary
@@ -89,7 +145,7 @@ func (c *Claude) RenderConversation(ref string) ([]adapter.ConversationMessage, 
 	}
 	var out []adapter.ConversationMessage
 	for _, entry := range entries {
-		if entry.Message == nil || (entry.Type != "user" && entry.Type != "assistant") {
+		if entry.IsMeta || entry.IsSidechain || entry.Message == nil || (entry.Type != "user" && entry.Type != "assistant") {
 			continue
 		}
 		text, prose, boundary := renderClaudeContent(entry.Message.Content)
@@ -110,7 +166,7 @@ func (c *Claude) RenderConversationExchanges(ref string) ([]adapter.Exchange, er
 	}
 	var out []adapter.Exchange
 	for _, entry := range entries {
-		if entry.Message == nil {
+		if entry.IsMeta || entry.IsSidechain || entry.Message == nil {
 			continue
 		}
 		text, prose, boundary := renderClaudeContent(entry.Message.Content)

--- a/packages/adapter/adapters/claude_conversation.go
+++ b/packages/adapter/adapters/claude_conversation.go
@@ -1,0 +1,131 @@
+package adapters
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+
+	"github.com/gmuxapp/gmux/packages/adapter"
+)
+
+var (
+	_ adapter.ConversationRenderer         = (*Claude)(nil)
+	_ adapter.ConversationExchangeRenderer = (*Claude)(nil)
+)
+
+// claudeConversationEntry is the stable subset of Claude Code's append-only
+// JSONL transcript. Tool results are encoded as user-role messages, so role
+// alone is deliberately not enough to establish a user exchange boundary.
+type claudeConversationEntry struct {
+	Type        string `json:"type"`
+	IsMeta      bool   `json:"isMeta"`
+	IsSidechain bool   `json:"isSidechain"`
+	Message     *struct {
+		Role    string          `json:"role"`
+		Content json.RawMessage `json:"content"`
+	} `json:"message"`
+}
+
+func readClaudeEntries(ref string) ([]claudeConversationEntry, error) {
+	data, err := os.ReadFile(ref)
+	if err != nil {
+		return nil, err
+	}
+	var entries []claudeConversationEntry
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		var entry claudeConversationEntry
+		// A transcript can be observed while its final line is being appended.
+		if json.Unmarshal([]byte(line), &entry) != nil || entry.IsMeta || entry.IsSidechain {
+			continue
+		}
+		entries = append(entries, entry)
+	}
+	return entries, nil
+}
+
+// renderClaudeContent returns a visible rendering, its prose-only subset, and
+// whether the content establishes a real user boundary. Thinking and tool
+// results are never exposed; tool use is represented compactly without its
+// result payload.
+func renderClaudeContent(raw json.RawMessage) (text, prose string, userBoundary bool) {
+	var s string
+	if json.Unmarshal(raw, &s) == nil {
+		return s, s, s != ""
+	}
+	var blocks []struct {
+		Type  string          `json:"type"`
+		Text  string          `json:"text"`
+		Name  string          `json:"name"`
+		Input json.RawMessage `json:"input"`
+	}
+	if json.Unmarshal(raw, &blocks) != nil {
+		return "", "", false
+	}
+	var parts, proseParts []string
+	for _, block := range blocks {
+		switch block.Type {
+		case "text":
+			if block.Text != "" {
+				parts = append(parts, block.Text)
+				proseParts = append(proseParts, block.Text)
+				userBoundary = true
+			}
+		case "tool_use":
+			parts = append(parts, formatPiToolCall(block.Name, block.Input))
+		case "image":
+			parts = append(parts, "[image]")
+		}
+	}
+	return strings.Join(parts, "\n\n"), strings.Join(proseParts, "\n\n"), userBoundary
+}
+
+func (c *Claude) RenderConversation(ref string) ([]adapter.ConversationMessage, error) {
+	entries, err := readClaudeEntries(ref)
+	if err != nil {
+		return nil, err
+	}
+	var out []adapter.ConversationMessage
+	for _, entry := range entries {
+		if entry.Message == nil || (entry.Type != "user" && entry.Type != "assistant") {
+			continue
+		}
+		text, prose, boundary := renderClaudeContent(entry.Message.Content)
+		if entry.Type == "user" && !boundary { // tool_result message
+			continue
+		}
+		if text != "" {
+			out = append(out, adapter.ConversationMessage{Role: entry.Message.Role, Text: text, Prose: prose})
+		}
+	}
+	return out, nil
+}
+
+func (c *Claude) RenderConversationExchanges(ref string) ([]adapter.Exchange, error) {
+	entries, err := readClaudeEntries(ref)
+	if err != nil {
+		return nil, err
+	}
+	var out []adapter.Exchange
+	for _, entry := range entries {
+		if entry.Message == nil {
+			continue
+		}
+		text, prose, boundary := renderClaudeContent(entry.Message.Content)
+		switch entry.Type {
+		case "user":
+			if boundary {
+				out = append(out, adapter.Exchange{Ordinal: uint64(len(out) + 1), User: text})
+			}
+		case "assistant":
+			if len(out) > 0 {
+				out[len(out)-1].Iterations++
+				// Only the latest assistant API iteration can be terminal prose.
+				out[len(out)-1].Terminal = prose
+			}
+		}
+	}
+	return out, nil
+}

--- a/packages/adapter/adapters/claude_conversation.go
+++ b/packages/adapter/adapters/claude_conversation.go
@@ -69,11 +69,13 @@ func claudeActiveBranch(linear []claudeConversationEntry) []claudeConversationEn
 	if !hasParents {
 		return linear
 	}
-	// Non-conversation bookkeeping records can trail the active message and
-	// carry no UUID. They must not disable branch reconstruction.
+	// Sidechain/meta records can be UUID-linked and trail the visible main
+	// conversation while subagent/bookkeeping work is appended. They remain in
+	// byID because a later main record may name one as an ancestor, but they
+	// must never replace the latest eligible main-conversation leaf.
 	leaf := claudeConversationEntry{}
 	for i := len(linear) - 1; i >= 0; i-- {
-		if linear[i].UUID != "" {
+		if linear[i].UUID != "" && !linear[i].IsSidechain && !linear[i].IsMeta {
 			leaf = linear[i]
 			break
 		}

--- a/packages/adapter/adapters/claude_conversation_test.go
+++ b/packages/adapter/adapters/claude_conversation_test.go
@@ -66,6 +66,50 @@ func TestClaudeConversationUsesActiveParentBranch(t *testing.T) {
 	}
 }
 
+func TestClaudeConversationIgnoresTrailingHiddenLeaves(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		tail string
+	}{
+		{"sidechain", `{"uuid":"side","parentUuid":"u1","type":"assistant","isSidechain":true,"message":{"role":"assistant","content":[{"type":"text","text":"private sidechain"}]}}`},
+		{"meta", `{"uuid":"meta","parentUuid":"u1","type":"user","isMeta":true,"message":{"role":"user","content":"hidden metadata"}}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "hidden-tail.jsonl")
+			transcript := `{"uuid":"u1","parentUuid":null,"type":"user","message":{"role":"user","content":"root"}}
+{"uuid":"main","parentUuid":"u1","type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"main answer"}]}}
+` + tc.tail
+			if err := os.WriteFile(path, []byte(transcript), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			ex, err := NewClaude().RenderConversationExchanges(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(ex) != 1 || ex[0].Iterations != 1 || ex[0].Terminal != "main answer" {
+				t.Fatalf("trailing hidden leaf erased main tail: %#v", ex)
+			}
+		})
+	}
+}
+
+func TestClaudeConversationRetainsHiddenTraversalAncestors(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "hidden-ancestor.jsonl")
+	transcript := `{"uuid":"u1","parentUuid":null,"type":"user","message":{"role":"user","content":"root"}}
+{"uuid":"hidden","parentUuid":"u1","type":"assistant","isSidechain":true,"message":{"role":"assistant","content":[{"type":"text","text":"private"}]}}
+{"uuid":"main","parentUuid":"hidden","type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"visible continuation"}]}}`
+	if err := os.WriteFile(path, []byte(transcript), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ex, err := NewClaude().RenderConversationExchanges(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ex) != 1 || ex[0].Iterations != 1 || ex[0].Terminal != "visible continuation" {
+		t.Fatalf("hidden ancestor broke traversal: %#v", ex)
+	}
+}
+
 func TestClaudeImageOnlyUserIsExchangeBoundary(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "image.jsonl")
 	transcript := `{"type":"user","message":{"role":"user","content":[{"type":"image","source":{"type":"base64","data":"secret"}}]}}

--- a/packages/adapter/adapters/claude_conversation_test.go
+++ b/packages/adapter/adapters/claude_conversation_test.go
@@ -1,0 +1,47 @@
+package adapters
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestClaudeConversationExchanges(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	transcript := `{"type":"user","message":{"role":"user","content":" fix it "}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"thinking","thinking":"secret"},{"type":"text","text":"Checking"},{"type":"tool_use","name":"Read","input":{"file_path":"a.go"}}]}}
+{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"1","content":"private file contents"}]}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Done exactly"}]}}
+{"type":"user","isMeta":true,"message":{"role":"user","content":"synthetic"}}
+{"type":"assistant","isSidechain":true,"message":{"role":"assistant","content":[{"type":"text","text":"subagent private"}]}}
+{"type":"user","message":{"role":"user","content":[{"type":"text","text":" follow up "},{"type":"image","source":{}}]}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"thinking","thinking":"still secret"},{"type":"tool_use","name":"Bash","input":{"command":"go test ./..."}}]}}
+{partial`
+	if err := os.WriteFile(path, []byte(transcript), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	ex, err := NewClaude().RenderConversationExchanges(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ex) != 2 {
+		t.Fatalf("exchanges = %#v", ex)
+	}
+	if ex[0].User != " fix it " || ex[0].Iterations != 2 || ex[0].Terminal != "Done exactly" {
+		t.Fatalf("first exchange = %#v", ex[0])
+	}
+	if ex[1].User != " follow up \n\n[image]" || ex[1].Iterations != 1 || ex[1].Terminal != "" {
+		t.Fatalf("second exchange = %#v", ex[1])
+	}
+
+	msgs, err := NewClaude().RenderConversation(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, msg := range msgs {
+		if msg.Text == "private file contents" || msg.Text == "secret" || msg.Text == "subagent private" {
+			t.Fatalf("private content leaked: %#v", msgs)
+		}
+	}
+}

--- a/packages/adapter/adapters/claude_conversation_test.go
+++ b/packages/adapter/adapters/claude_conversation_test.go
@@ -45,3 +45,39 @@ func TestClaudeConversationExchanges(t *testing.T) {
 		}
 	}
 }
+
+func TestClaudeConversationUsesActiveParentBranch(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "branched.jsonl")
+	transcript := `{"uuid":"u1","parentUuid":null,"type":"user","message":{"role":"user","content":"root"}}
+{"uuid":"a-old","parentUuid":"u1","type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"old"}]}}
+{"uuid":"u-old","parentUuid":"a-old","type":"user","message":{"role":"user","content":"abandoned private text"}}
+{"uuid":"a-new","parentUuid":"u1","type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"active"}]}}
+{"uuid":"u-new","parentUuid":"a-new","type":"user","message":{"role":"user","content":"active followup"}}
+{"uuid":"a-end","parentUuid":"u-new","type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"done"}]}}`
+	if err := os.WriteFile(path, []byte(transcript), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ex, err := NewClaude().RenderConversationExchanges(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ex) != 2 || ex[0].User != "root" || ex[0].Terminal != "active" || ex[1].User != "active followup" || ex[1].Terminal != "done" {
+		t.Fatalf("active exchanges = %#v", ex)
+	}
+}
+
+func TestClaudeImageOnlyUserIsExchangeBoundary(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "image.jsonl")
+	transcript := `{"type":"user","message":{"role":"user","content":[{"type":"image","source":{"type":"base64","data":"secret"}}]}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"seen"}]}}`
+	if err := os.WriteFile(path, []byte(transcript), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ex, err := NewClaude().RenderConversationExchanges(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ex) != 1 || ex[0].User != "[image]" || ex[0].Terminal != "seen" {
+		t.Fatalf("image exchange = %#v", ex)
+	}
+}

--- a/packages/adapter/adapters/claude_hook.go
+++ b/packages/adapter/adapters/claude_hook.go
@@ -203,11 +203,13 @@ func mergeClaudeSettings(base, over any) any {
 // for the title, so it is unit-testable. Returns nil for events we don't map.
 func ClaudeHookBodies(input []byte) [][]byte {
 	var in struct {
-		HookEventName  string `json:"hook_event_name"`
-		SessionID      string `json:"session_id"`
-		TranscriptPath string `json:"transcript_path"`
-		Source         string `json:"source"`
-		SessionTitle   string `json:"session_title"`
+		HookEventName        string `json:"hook_event_name"`
+		SessionID            string `json:"session_id"`
+		TranscriptPath       string `json:"transcript_path"`
+		Source               string `json:"source"`
+		SessionTitle         string `json:"session_title"`
+		ErrorDetails         string `json:"error_details"`
+		LastAssistantMessage string `json:"last_assistant_message"`
 	}
 	if err := json.Unmarshal(input, &in); err != nil {
 		return nil
@@ -249,10 +251,28 @@ func ClaudeHookBodies(input []byte) [][]byte {
 		if in.HookEventName == "StopFailure" {
 			outcome = "error"
 		}
-		if b, ok := claudeSessionBody(in.TranscriptPath, in.SessionID, "", in.SessionTitle); ok {
-			return [][]byte{b, turn("end", outcome)} // refresh title/slug, then end the turn
+		end := turn("end", outcome)
+		var terminal map[string]any
+		if json.Unmarshal(end, &terminal) == nil {
+			output, truncated := capClaudeTerminal(in.LastAssistantMessage)
+			if output == "" {
+				output, truncated = claudeLatestTerminal(in.TranscriptPath)
+			}
+			if output != "" {
+				terminal["output"] = output
+				if truncated {
+					terminal["truncated"] = true
+				}
+			}
+			if in.ErrorDetails != "" {
+				terminal["diagnostic"] = in.ErrorDetails
+			}
+			end, _ = json.Marshal(terminal)
 		}
-		return [][]byte{turn("end", outcome)}
+		if b, ok := claudeSessionBody(in.TranscriptPath, in.SessionID, "", in.SessionTitle); ok {
+			return [][]byte{b, end} // refresh title/slug, then end the turn
+		}
+		return [][]byte{end}
 	case "SessionEnd":
 		// Only reaches durable state when the turn is still OPEN (the runner
 		// gates terminal ends on turn polarity), i.e. the session was exited
@@ -260,6 +280,30 @@ func ClaudeHookBodies(input []byte) [][]byte {
 		return [][]byte{turn("end", "interrupted")}
 	}
 	return nil
+}
+
+const maxClaudeTerminalBytes = 256 << 10
+
+func claudeLatestTerminal(ref string) (string, bool) {
+	if ref == "" {
+		return "", false
+	}
+	exchanges, err := NewClaude().RenderConversationExchanges(ref)
+	if err != nil || len(exchanges) == 0 {
+		return "", false
+	}
+	return capClaudeTerminal(exchanges[len(exchanges)-1].Terminal)
+}
+
+func capClaudeTerminal(output string) (string, bool) {
+	if len(output) <= maxClaudeTerminalBytes {
+		return output, false
+	}
+	cut := maxClaudeTerminalBytes
+	for cut > 0 && (output[cut]&0xc0) == 0x80 {
+		cut--
+	}
+	return output[:cut], true
 }
 
 // claudeSessionBody builds the authoritative "session" bind body: the held

--- a/packages/adapter/adapters/claude_hook.go
+++ b/packages/adapter/adapters/claude_hook.go
@@ -2,6 +2,8 @@ package adapters
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -31,7 +33,10 @@ func (c *Claude) HookCommand(args []string, selfBin string) ([]string, bool) {
 	if i < 0 || selfBin == "" {
 		return args, false
 	}
-	tail, userSettings := extractClaudeSettings(args[i+1:])
+	tail, userSettings, err := extractClaudeSettings(args[i+1:])
+	if err != nil {
+		return args, false
+	}
 	settingsJSON, err := buildClaudeSettings(selfBin, userSettings)
 	if err != nil {
 		return args, false
@@ -59,7 +64,7 @@ func claudeBinaryIndex(args []string) int {
 // extractClaudeSettings removes `--settings <value>` / `--settings=<value>`
 // pairs from tokens, returning the filtered tokens and the collected values.
 // Stops at a bare `--` so a positional prompt is never misread as a flag value.
-func extractClaudeSettings(tokens []string) (filtered, values []string) {
+func extractClaudeSettings(tokens []string) (filtered, values []string, err error) {
 	for i := 0; i < len(tokens); i++ {
 		tok := tokens[i]
 		if tok == "--" {
@@ -68,17 +73,22 @@ func extractClaudeSettings(tokens []string) (filtered, values []string) {
 		}
 		switch {
 		case tok == "--settings":
-			if i+1 < len(tokens) {
-				values = append(values, tokens[i+1])
-				i++
+			if i+1 >= len(tokens) || tokens[i+1] == "--" {
+				return nil, nil, errors.New("claude --settings requires a value")
 			}
+			values = append(values, tokens[i+1])
+			i++
 		case strings.HasPrefix(tok, "--settings="):
-			values = append(values, strings.TrimPrefix(tok, "--settings="))
+			value := strings.TrimPrefix(tok, "--settings=")
+			if value == "" {
+				return nil, nil, errors.New("claude --settings requires a value")
+			}
+			values = append(values, value)
 		default:
 			filtered = append(filtered, tok)
 		}
 	}
-	return filtered, values
+	return filtered, values, nil
 }
 
 // buildClaudeSettings returns the inline JSON for `--settings`: gmux's session
@@ -86,9 +96,11 @@ func extractClaudeSettings(tokens []string) (filtered, values []string) {
 func buildClaudeSettings(selfBin string, userSettings []string) (string, error) {
 	var base any = claudeGmuxHooks(selfBin)
 	for _, us := range userSettings {
-		if obj, ok := parseClaudeSettings(us); ok {
-			base = mergeClaudeSettings(base, obj)
+		obj, err := parseClaudeSettings(us)
+		if err != nil {
+			return "", fmt.Errorf("invalid Claude settings %q: %w", us, err)
 		}
+		base = mergeClaudeSettings(base, obj)
 	}
 	out, err := json.Marshal(base)
 	if err != nil {
@@ -138,7 +150,7 @@ func claudeGmuxHooks(selfBin string) map[string]any {
 
 // parseClaudeSettings interprets a user `--settings` value as inline JSON
 // (starts with `{`) or a path to a JSON file.
-func parseClaudeSettings(value string) (map[string]any, bool) {
+func parseClaudeSettings(value string) (map[string]any, error) {
 	trimmed := strings.TrimSpace(value)
 	var data []byte
 	if strings.HasPrefix(trimmed, "{") {
@@ -146,15 +158,15 @@ func parseClaudeSettings(value string) (map[string]any, bool) {
 	} else {
 		b, err := os.ReadFile(trimmed)
 		if err != nil {
-			return nil, false
+			return nil, err
 		}
 		data = b
 	}
 	var obj map[string]any
 	if err := json.Unmarshal(data, &obj); err != nil {
-		return nil, false
+		return nil, err
 	}
-	return obj, true
+	return obj, nil
 }
 
 // mergeClaudeSettings deep-merges over onto base. Objects merge recursively;

--- a/packages/adapter/adapters/claude_hook.go
+++ b/packages/adapter/adapters/claude_hook.go
@@ -212,9 +212,15 @@ func ClaudeHookBodies(input []byte) [][]byte {
 
 	switch in.HookEventName {
 	case "SessionStart":
+		// SessionStart runs after Claude's interactive input handlers are
+		// installed. Readiness must not depend on a transcript: a fresh session
+		// has no file until its first prompt, and doing so would deadlock
+		// semantic prompt delivery.
+		ready := []byte(`{"op":"ready"}`)
 		if b, ok := claudeSessionBody(in.TranscriptPath, in.SessionID, in.Source, in.SessionTitle); ok {
-			return [][]byte{b}
+			return [][]byte{b, ready}
 		}
+		return [][]byte{ready}
 	case "UserPromptSubmit":
 		// /rename fires no hook of its own — it only appends a custom-title
 		// line to the transcript. Refresh the title here (custom-title wins in

--- a/packages/adapter/adapters/claude_hook.go
+++ b/packages/adapter/adapters/claude_hook.go
@@ -224,15 +224,12 @@ func ClaudeHookBodies(input []byte) [][]byte {
 
 	switch in.HookEventName {
 	case "SessionStart":
-		// SessionStart runs after Claude's interactive input handlers are
-		// installed. Readiness must not depend on a transcript: a fresh session
-		// has no file until its first prompt, and doing so would deadlock
-		// semantic prompt delivery.
-		ready := []byte(`{"op":"ready"}`)
+		// Binding is immediate. Readiness is deliberately scheduled by the CLI
+		// hook relay after this hook process exits: Claude fires SessionStart
+		// before its interactive composer is able to retain input.
 		if b, ok := claudeSessionBody(in.TranscriptPath, in.SessionID, in.Source, in.SessionTitle); ok {
-			return [][]byte{b, ready}
+			return [][]byte{b}
 		}
-		return [][]byte{ready}
 	case "UserPromptSubmit":
 		// /rename fires no hook of its own — it only appends a custom-title
 		// line to the transcript. Refresh the title here (custom-title wins in

--- a/packages/adapter/adapters/claude_hook_test.go
+++ b/packages/adapter/adapters/claude_hook_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -317,5 +318,24 @@ func TestClaudeHookCommand_UserCannotWipeHooks(t *testing.T) {
 	}
 	if n := sessionStartHookCount(mergedSettings(t, out)); n != 1 {
 		t.Fatalf("gmux SessionStart hook must survive hooks:null, got %d", n)
+	}
+}
+
+func TestClaudeHookCommand_InvalidSettingsPreserved(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "missing.json")
+	for _, args := range [][]string{
+		{"claude", "--settings"},
+		{"claude", "--settings="},
+		{"claude", "--settings", missing, "--model", "opus"},
+		{"claude", "--settings", `{not-json}`, "--model", "opus"},
+	} {
+		original := append([]string(nil), args...)
+		out, ok := (&Claude{}).HookCommand(args, "/usr/bin/gmux")
+		if ok {
+			t.Errorf("invalid settings unexpectedly injected: %v", args)
+		}
+		if !reflect.DeepEqual(out, original) {
+			t.Errorf("invalid settings changed argv: got %v want %v", out, original)
+		}
 	}
 }

--- a/packages/adapter/adapters/claude_hook_test.go
+++ b/packages/adapter/adapters/claude_hook_test.go
@@ -40,8 +40,8 @@ func TestClaudeHookBodies_SessionStartBindsWithTitleSlug(t *testing.T) {
 		"source":          "resume",
 	})
 	got := decodeBodies(t, ClaudeHookBodies(in))
-	if len(got) != 1 {
-		t.Fatalf("want 1 body, got %d", len(got))
+	if len(got) != 2 || got[1]["op"] != "ready" {
+		t.Fatalf("want bind then ready, got %v", got)
 	}
 	b := got[0]
 	if b["op"] != "session" || b["path"] != tr || b["id"] != "uuid-1" || b["reason"] != "resume" {
@@ -139,10 +139,12 @@ func TestClaudeHookBodies_UnknownEventNil(t *testing.T) {
 	}
 }
 
-func TestClaudeHookBodies_NoTranscriptNoBind(t *testing.T) {
-	// SessionStart without a transcript path has nothing authoritative to bind.
-	if got := ClaudeHookBodies([]byte(`{"hook_event_name":"SessionStart"}`)); got != nil {
-		t.Fatalf("no transcript → no bind, got %v", got)
+func TestClaudeHookBodies_NoTranscriptStillReady(t *testing.T) {
+	// Fresh sessions have no transcript before the first prompt. They must still
+	// admit semantic input or prompt --new would deadlock.
+	got := decodeBodies(t, ClaudeHookBodies([]byte(`{"hook_event_name":"SessionStart"}`)))
+	if len(got) != 1 || got[0]["op"] != "ready" {
+		t.Fatalf("no transcript → ready only, got %v", got)
 	}
 }
 

--- a/packages/adapter/adapters/claude_hook_test.go
+++ b/packages/adapter/adapters/claude_hook_test.go
@@ -108,10 +108,19 @@ func TestClaudeHookBodies_PromptSubmitRefreshesRenamedTitle(t *testing.T) {
 
 func TestClaudeHookBodies_StopRefreshesThenEnds(t *testing.T) {
 	tr := writeClaudeTranscript(t)
-	in, _ := json.Marshal(map[string]string{"hook_event_name": "Stop", "transcript_path": tr})
+	f, err := os.OpenFile(tr, os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = f.WriteString(`{"type":"assistant","message":{"role":"assistant","content":[{"type":"thinking","thinking":"secret"},{"type":"text","text":"visible final"}]}}` + "\n")
+	_ = f.Close()
+	in, _ := json.Marshal(map[string]string{"hook_event_name": "Stop", "transcript_path": tr, "last_assistant_message": "hook-authoritative final"})
 	got := decodeBodies(t, ClaudeHookBodies(in))
 	if len(got) != 2 || got[0]["op"] != "session" || got[1]["op"] != "turn" || got[1]["outcome"] != "completed" {
 		t.Fatalf("Stop → [session, turn end completed], got %v", got)
+	}
+	if got[1]["output"] != "hook-authoritative final" {
+		t.Fatalf("terminal output missing or leaked thinking: %v", got[1])
 	}
 }
 

--- a/packages/adapter/adapters/claude_hook_test.go
+++ b/packages/adapter/adapters/claude_hook_test.go
@@ -41,8 +41,8 @@ func TestClaudeHookBodies_SessionStartBindsWithTitleSlug(t *testing.T) {
 		"source":          "resume",
 	})
 	got := decodeBodies(t, ClaudeHookBodies(in))
-	if len(got) != 2 || got[1]["op"] != "ready" {
-		t.Fatalf("want bind then ready, got %v", got)
+	if len(got) != 1 {
+		t.Fatalf("want one bind body, got %v", got)
 	}
 	b := got[0]
 	if b["op"] != "session" || b["path"] != tr || b["id"] != "uuid-1" || b["reason"] != "resume" {
@@ -140,12 +140,11 @@ func TestClaudeHookBodies_UnknownEventNil(t *testing.T) {
 	}
 }
 
-func TestClaudeHookBodies_NoTranscriptStillReady(t *testing.T) {
-	// Fresh sessions have no transcript before the first prompt. They must still
-	// admit semantic input or prompt --new would deadlock.
-	got := decodeBodies(t, ClaudeHookBodies([]byte(`{"hook_event_name":"SessionStart"}`)))
-	if len(got) != 1 || got[0]["op"] != "ready" {
-		t.Fatalf("no transcript → ready only, got %v", got)
+func TestClaudeHookBodies_NoTranscriptNoBind(t *testing.T) {
+	// Fresh sessions have no transcript before the first prompt. The CLI relay
+	// schedules readiness independently of these translated bind bodies.
+	if got := ClaudeHookBodies([]byte(`{"hook_event_name":"SessionStart"}`)); got != nil {
+		t.Fatalf("no transcript → no bind body, got %v", got)
 	}
 }
 

--- a/packages/adapter/adapters/claude_test.go
+++ b/packages/adapter/adapters/claude_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/gmuxapp/gmux/packages/adapter"
@@ -84,13 +85,27 @@ func TestClaudeImplementsCapabilities(t *testing.T) {
 	if _, ok := a.(adapter.Resumer); !ok {
 		t.Fatal("should implement Resumer")
 	}
-	// Deliberately NOT an AgentActionEncoder: gmux's semantic agent
-	// actions (ADR 0027) ship for pi only. claude's turn-control
-	// keystrokes are unverified, and guessing them would send
-	// wrong-meaning bytes under a semantic label. Raw `gmux send`
-	// remains available.
-	if _, ok := a.(adapter.AgentActionEncoder); ok {
-		t.Fatal("should NOT implement AgentActionEncoder yet")
+	if _, ok := a.(adapter.AgentActionEncoder); !ok {
+		t.Fatal("should implement AgentActionEncoder")
+	}
+	if _, ok := a.(adapter.AgentLauncher); !ok {
+		t.Fatal("should implement AgentLauncher")
+	}
+}
+
+func TestClaudeAgentActionsAndLaunch(t *testing.T) {
+	c := NewClaude()
+	for _, action := range []adapter.AgentAction{adapter.ActionSend, adapter.ActionSendAfterTurn} {
+		if got, ok := c.EncodeAction(action); !ok || got != "\r" {
+			t.Fatalf("action %v = %q, %v; want CR, true", action, got, ok)
+		}
+	}
+	if got, ok := c.EncodeAction(adapter.ActionInterrupt); !ok || got != "\x03" {
+		t.Fatalf("interrupt = %q, %v; want Ctrl+C, true", got, ok)
+	}
+	argv, ok := c.LaunchCommand(adapter.LaunchOptions{Model: "sonnet", Name: "review"})
+	if !ok || strings.Join(argv, " ") != "claude --model sonnet --name review" {
+		t.Fatalf("launch = %v, %v", argv, ok)
 	}
 }
 


### PR DESCRIPTION
## Summary
- enable Claude Code semantic launch, prompt, follow-up, steer, and cancel through the common readiness-gated runner contract
- add Claude transcript/exchange rendering for result-bearing waits and `gmux agent logs`, excluding thinking, tool results, metadata, and sidechains
- emit adapter readiness on `SessionStart`, including fresh sessions without a transcript

## Parity / implementation notes
- launch uses native `claude --model` and `--name`; prompts never ride argv
- submit uses Claude's Enter binding; cancel uses reserved/non-rebindable Ctrl+C rather than context-sensitive Escape
- existing authoritative `UserPromptSubmit` / `Stop` / `StopFailure` / `SessionEnd` lifecycle continues to classify completion, failure, and interruption
- existing resume UUID lineage and transparent runner restart remain unchanged
- malformed live transcript tails are ignored; persisted visible assistant iterations provide active partial reports
- Claude has no stable hook field distinguishing permission/user-answer waits from other open-turn activity, so gmux truthfully leaves these active rather than reporting a false settled state

## Shared-contract impact
One shared runner test removes Claude from the deliberately-unsupported adapter list. No protocol, endpoint, CLI, status schema, or shared adapter interface changed. This should integrate independently of the parallel Codex adapter work; the likely conflict is only that unsupported-adapter test list.

## Test evidence
Passed:
- `go test ./packages/adapter/adapters ./cli/gmux/internal/ptyserver ./cli/gmux/cmd/gmux`
- all packages in `cli/gmux`, `packages/{adapter,paths,scrollback,socklease,sessionenv,workspace}`, and `services/gmuxd`

The repository-wide module loop reached existing environment-sensitive e2e failures: daemon startup timeout and restart HTTP 500 in `tests/e2e`; all preceding module suites passed.
