### PR TITLE
fix(website): refine landing copy and mobile wrapping

### DIFF
--- a/apps/website/src/pages/index.astro
+++ b/apps/website/src/pages/index.astro
@@ -132,7 +132,7 @@ import Topology from '../components/Topology.astro'
   <section class="section harness-section">
     <div class="section-inner harness-layout">
       <div>
-        <h2>The best agent keeps changing.<br />Your workflow doesn’t.</h2>
+        <h2>The best agent keeps changing.<br />The way you work shouldn’t have to.</h2>
         <p class="section-lead">Use different coding agents side by side. Stay in control while choosing the best one for each job.</p>
       </div>
       <div class="harness-brands" aria-label="Supported coding agents">
@@ -1218,7 +1218,6 @@ import Topology from '../components/Topology.astro'
     }
 
     .hero-sub {
-      max-width: 36ch;
       font-size: 1rem;
     }
 


### PR DESCRIPTION
## Summary

- widen compact hero copy to use the available column and avoid orphaning “reach”
- replace “Your workflow doesn’t” with “The way you work shouldn’t have to”

## Validation

- `pnpm --filter @gmux/website build` (43 pages)
- checked 320px, 390px, 430px, 740px, 1024px, and 1440px viewports
- verified zero horizontal overflow
