### PR TITLE
fix(test): read scrollback through daemon broker

### DIFF
--- a/packages/adapter/adapters/claude_integration_test.go
+++ b/packages/adapter/adapters/claude_integration_test.go
@@ -30,13 +30,13 @@ func claudeSendAndWait(t *testing.T, g *testutil.Gmuxd, send func(string), sessI
 	t.Helper()
 	// Claude shows a trust prompt for new workspaces — dismiss it.
 	s, _ := g.GetSession(sessID)
-	g.WaitForScrollback(s.SocketPath, "trust", 15*time.Second)
+	g.WaitForScrollback(s.ID, "trust", 15*time.Second)
 	send("\r") // accept "Yes, I trust this folder"
 	time.Sleep(3 * time.Second)
 	send("say hi\r")
 
 	sess, _ := g.GetSession(sessID)
-	g.WaitForScrollback(sess.SocketPath, "say hi", 10*time.Second)
+	g.WaitForScrollback(sess.ID, "say hi", 10*time.Second)
 
 	// Wait for file attribution.
 	g.WaitForSession(sessID, func(s testutil.Session) bool {
@@ -92,7 +92,7 @@ func TestClaudeSecondTurnKeepsTitle(t *testing.T) {
 	send("say goodbye\r")
 
 	gSess, _ := g.GetSession(sess.ID)
-	g.WaitForScrollback(gSess.SocketPath, "goodbye", 60*time.Second)
+	g.WaitForScrollback(gSess.ID, "goodbye", 60*time.Second)
 	time.Sleep(3 * time.Second)
 
 	second, _ := g.GetSession(sess.ID)

--- a/packages/adapter/adapters/codex_integration_test.go
+++ b/packages/adapter/adapters/codex_integration_test.go
@@ -28,12 +28,12 @@ func codexSendAndWait(t *testing.T, g *testutil.Gmuxd, send func(string), sessID
 	t.Helper()
 	// Codex shows a trust prompt for new workspaces — dismiss it.
 	s, _ := g.GetSession(sessID)
-	g.WaitForScrollback(s.SocketPath, "trust", 15*time.Second)
+	g.WaitForScrollback(s.ID, "trust", 15*time.Second)
 	time.Sleep(1 * time.Second)
 	send("\r") // accept "Yes, continue"
 
 	// Wait for Codex prompt to appear (post-trust).
-	g.WaitForScrollback(s.SocketPath, "Codex", 15*time.Second)
+	g.WaitForScrollback(s.ID, "Codex", 15*time.Second)
 	time.Sleep(2 * time.Second)
 
 	// Type message and submit.
@@ -95,7 +95,7 @@ func TestCodexSecondTurnKeepsTitle(t *testing.T) {
 	send("say goodbye\r")
 
 	gSess, _ := g.GetSession(sess.ID)
-	g.WaitForScrollback(gSess.SocketPath, "goodbye", 60*time.Second)
+	g.WaitForScrollback(gSess.ID, "goodbye", 60*time.Second)
 	time.Sleep(3 * time.Second)
 
 	second, _ := g.GetSession(sess.ID)

--- a/packages/adapter/adapters/pi_integration_test.go
+++ b/packages/adapter/adapters/pi_integration_test.go
@@ -36,11 +36,11 @@ func sendAndWaitForTurn(t *testing.T, g *testutil.Gmuxd, send func(string), sess
 
 	// Verify pi received the input by checking scrollback.
 	sess, _ := g.GetSession(sessID)
-	g.WaitForScrollback(sess.SocketPath, "say hi", 10*time.Second)
+	g.WaitForScrollback(sess.ID, "say hi", 10*time.Second)
 
 	// Wait for the turn to produce output (scrollback will change when
 	// the assistant responds). Pi's scrollback grows as the response streams.
-	g.WaitForScrollback(sess.SocketPath, "Hi", 60*time.Second)
+	g.WaitForScrollback(sess.ID, "Hi", 60*time.Second)
 
 	// Wait for file attribution (pi writes the full turn to JSONL after completion).
 	g.WaitForSession(sessID, func(s testutil.Session) bool {
@@ -121,7 +121,7 @@ func TestPiSecondTurnKeepsTitle(t *testing.T) {
 
 	// Wait for second response.
 	gSess, _ := g.GetSession(sess.ID)
-	g.WaitForScrollback(gSess.SocketPath, "goodbye", 60*time.Second)
+	g.WaitForScrollback(gSess.ID, "goodbye", 60*time.Second)
 
 	// Brief wait for file to be written and parsed.
 	time.Sleep(3 * time.Second)

--- a/packages/adapter/adapters/scrollback_integration_test.go
+++ b/packages/adapter/adapters/scrollback_integration_test.go
@@ -38,12 +38,12 @@ func TestScrollbackPiConversation(t *testing.T) {
 
 	// Wait for pi to process and respond.
 	s, _ := g.GetSession(sess.ID)
-	g.WaitForScrollback(s.SocketPath, "pineapple", 60*time.Second)
+	g.WaitForScrollback(s.ID, "pineapple", 60*time.Second)
 
 	// Give time for the full response to render.
 	time.Sleep(5 * time.Second)
 
-	text := testutil.ReadScrollback(t, sess.SocketPath)
+	text := g.ReadScrollback(sess.ID)
 	t.Logf("scrollback (%d chars):\n%s", len(text), text)
 
 	// The scrollback must contain the user's prompt text.
@@ -73,15 +73,15 @@ func TestScrollbackPiMultiTurn(t *testing.T) {
 	time.Sleep(2 * time.Second)
 	send("say the word strawberry exactly once\r")
 	s, _ := g.GetSession(sess.ID)
-	g.WaitForScrollback(s.SocketPath, "strawberry", 60*time.Second)
+	g.WaitForScrollback(s.ID, "strawberry", 60*time.Second)
 	time.Sleep(5 * time.Second)
 
 	// Second turn.
 	send("now say the word watermelon exactly once\r")
-	g.WaitForScrollback(s.SocketPath, "watermelon", 60*time.Second)
+	g.WaitForScrollback(s.ID, "watermelon", 60*time.Second)
 	time.Sleep(5 * time.Second)
 
-	text := testutil.ReadScrollback(t, s.SocketPath)
+	text := g.ReadScrollback(s.ID)
 	t.Logf("scrollback (%d chars):\n%s", len(text), text)
 
 	// Both turn contents should be present.
@@ -109,10 +109,10 @@ func TestScrollbackPiNoSpinnerFrames(t *testing.T) {
 	time.Sleep(2 * time.Second)
 	send("say hello in one sentence\r")
 	s, _ := g.GetSession(sess.ID)
-	g.WaitForScrollback(s.SocketPath, "hello", 60*time.Second)
+	g.WaitForScrollback(s.ID, "hello", 60*time.Second)
 	time.Sleep(5 * time.Second)
 
-	text := testutil.ReadScrollback(t, s.SocketPath)
+	text := g.ReadScrollback(s.ID)
 
 	// Spinner characters should not appear in the normalized scrollback.
 	// These are the Braille spinner frames pi uses.
@@ -156,7 +156,7 @@ func TestScrollbackShellPreservesOutput(t *testing.T) {
 	send("echo MARKER_GAMMA_789\r")
 	time.Sleep(2 * time.Second)
 
-	text := testutil.ReadScrollback(t, sess.SocketPath)
+	text := g.ReadScrollback(sess.ID)
 	t.Logf("scrollback: %s", text)
 
 	for _, marker := range []string{"MARKER_ALPHA_123", "MARKER_BETA_456", "MARKER_GAMMA_789"} {
@@ -185,7 +185,7 @@ func TestScrollbackShellClearDiscardsOldContent(t *testing.T) {
 	send("echo AFTER_CLEAR_MARKER\r")
 	time.Sleep(2 * time.Second)
 
-	text := testutil.ReadScrollback(t, sess.SocketPath)
+	text := g.ReadScrollback(sess.ID)
 	t.Logf("scrollback: %s", text)
 
 	// Post-clear content must be present.

--- a/packages/adapter/adapters/shell_integration_test.go
+++ b/packages/adapter/adapters/shell_integration_test.go
@@ -29,15 +29,37 @@ func TestShellWSInput(t *testing.T) {
 
 	deadline := time.Now().Add(10 * time.Second)
 	for time.Now().Before(deadline) {
-		text := testutil.ReadScrollback(t, sess.SocketPath)
+		text := g.ReadScrollback(sess.ID)
 		if strings.Contains(text, "GMUX_TEST_MARKER_42") {
 			t.Log("WS input verified — marker found in scrollback")
 			return
 		}
 		time.Sleep(300 * time.Millisecond)
 	}
-	text := testutil.ReadScrollback(t, sess.SocketPath)
+	text := g.ReadScrollback(sess.ID)
 	t.Fatalf("marker not found in scrollback:\n%s", text)
+}
+
+// TestHarnessScrollbackBroker guards the harness's dependency on gmuxd's
+// public text-rendering scrollback contract. The runner deliberately has no
+// scrollback HTTP route; this must cross the real isolated daemon and read its
+// persisted PTY byte stream through ?tail=N.
+func TestHarnessScrollbackBroker(t *testing.T) {
+	g := testutil.StartGmuxd(t)
+	sess := g.Launch([]string{"bash"}, t.TempDir())
+	send, _ := g.ConnectSession(sess.ID)
+
+	const marker = "GMUX_BROKER_SCROLLBACK_MARKER"
+	send("printf '\\033[32m" + marker + "\\033[0m\\n'\r")
+	g.WaitForScrollback(sess.ID, marker, 10*time.Second)
+
+	text := g.ReadScrollback(sess.ID)
+	if !strings.Contains(text, marker) {
+		t.Fatalf("daemon scrollback text missing marker: %q", text)
+	}
+	if strings.Contains(text, "\x1b[32m") {
+		t.Fatalf("daemon tail returned raw PTY bytes instead of rendered text: %q", text)
+	}
 }
 
 // TestShellKill verifies /kill terminates an interactive shell session.
@@ -115,7 +137,7 @@ func TestShellRestart(t *testing.T) {
 	send("echo GMUX_RESTART_MARKER\r")
 	deadline := time.Now().Add(10 * time.Second)
 	for time.Now().Before(deadline) {
-		text := testutil.ReadScrollback(t, after.SocketPath)
+		text := g.ReadScrollback(after.ID)
 		if strings.Contains(text, "GMUX_RESTART_MARKER") {
 			return
 		}

--- a/packages/adapter/adapters/testutil/harness.go
+++ b/packages/adapter/adapters/testutil/harness.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -83,7 +84,7 @@ func StartGmuxd(t *testing.T) *Gmuxd {
 		[]byte(fmt.Sprintf("port = %d\n", port)), 0o644)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	cmd := exec.CommandContext(ctx, gmuxdBin)
+	cmd := exec.CommandContext(ctx, gmuxdBin, "run")
 	cmd.Env = append(os.Environ(),
 		fmt.Sprintf("GMUX_SOCKET_DIR=%s", socketDir),
 		fmt.Sprintf("XDG_CONFIG_HOME=%s", configDir),
@@ -115,7 +116,10 @@ func StartGmuxd(t *testing.T) *Gmuxd {
 		cmd.Wait()
 	})
 
-	waitForSocket(t, gmuxdSock, 5*time.Second)
+	// Cold startup may index a large real adapter conversation history before
+	// binding listeners. The state/socket dirs are isolated, but adapter-native
+	// history is intentionally read from the user's configured tools.
+	waitForSocket(t, gmuxdSock, 30*time.Second)
 	return g
 }
 
@@ -331,17 +335,6 @@ func waitForSocket(t *testing.T, sockPath string, timeout time.Duration) {
 	t.Fatalf("timed out waiting for gmuxd on socket %s", sockPath)
 }
 
-func unixClient(socketPath string) *http.Client {
-	return &http.Client{
-		Transport: &http.Transport{
-			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
-				return net.Dial("unix", socketPath)
-			},
-		},
-		Timeout: 3 * time.Second,
-	}
-}
-
 // RequireBinary skips the test if the binary is not on PATH.
 func RequireBinary(t *testing.T, name string) {
 	t.Helper()
@@ -350,56 +343,74 @@ func RequireBinary(t *testing.T, name string) {
 	}
 }
 
-// ReadScrollback reads the terminal scrollback text from a session's runner.
-func ReadScrollback(t *testing.T, socketPath string) string {
-	t.Helper()
-	client := unixClient(socketPath)
-	resp, err := client.Get("http://localhost/scrollback/text")
+// readScrollback reads the daemon's supported plain-text scrollback view.
+// A large tail preserves the integration harness's whole-buffer behavior while
+// still using the public broker contract that works for live, dead, and peer
+// session refs. The raw endpoint is intentionally not used: its body is the
+// binary PTY byte stream, while harness callers search rendered text.
+func (g *Gmuxd) readScrollback(sessionRef string) (string, error) {
+	const harnessTailLines = 100_000
+	endpoint := fmt.Sprintf("http://localhost/v1/sessions/%s/scrollback?tail=%d",
+		url.PathEscape(sessionRef), harnessTailLines)
+	resp, err := g.client.Get(endpoint)
 	if err != nil {
-		return ""
+		return "", err
 	}
 	defer resp.Body.Close()
-	data, _ := io.ReadAll(resp.Body)
-	return string(data)
+	data, readErr := io.ReadAll(resp.Body)
+	if readErr != nil {
+		return "", fmt.Errorf("read scrollback response: %w", readErr)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("scrollback status %d: %.500s", resp.StatusCode, data)
+	}
+	if contentType := resp.Header.Get("Content-Type"); !strings.HasPrefix(contentType, "text/plain") {
+		return "", fmt.Errorf("scrollback content type %q, want text/plain", contentType)
+	}
+	return string(data), nil
+}
+
+// ReadScrollback reads rendered terminal text through gmuxd's public
+// /v1/sessions/<ref>/scrollback?tail=N endpoint.
+func (g *Gmuxd) ReadScrollback(sessionRef string) string {
+	g.t.Helper()
+	text, err := g.readScrollback(sessionRef)
+	if err != nil {
+		g.t.Fatalf("read scrollback for %s: %v", sessionRef, err)
+	}
+	return text
 }
 
 // WaitForScrollback polls scrollback until it contains the expected string.
-func (g *Gmuxd) WaitForScrollback(socketPath, substr string, timeout time.Duration) {
+func (g *Gmuxd) WaitForScrollback(sessionRef, substr string, timeout time.Duration) {
 	g.t.Helper()
 	deadline := time.Now().Add(timeout)
+	var text string
+	var lastErr error
 	for time.Now().Before(deadline) {
-		text := ReadScrollback(g.t, socketPath)
-		if strings.Contains(text, substr) {
+		text, lastErr = g.readScrollback(sessionRef)
+		if lastErr == nil && strings.Contains(text, substr) {
 			return
 		}
 		time.Sleep(300 * time.Millisecond)
 	}
-	text := ReadScrollback(g.t, socketPath)
-	g.t.Fatalf("timeout waiting for %q in scrollback. Got:\n%.500s", substr, text)
+	g.t.Fatalf("timeout waiting for %q in session %s scrollback (last error: %v). Got:\n%.500s", substr, sessionRef, lastErr, text)
 }
 
 // WaitForOutput polls the session's scrollback until it contains non-trivial
 // content (indicating the TUI has rendered). Returns the scrollback text.
-func (g *Gmuxd) WaitForOutput(sessionID string, timeout time.Duration) string {
+func (g *Gmuxd) WaitForOutput(sessionRef string, timeout time.Duration) string {
 	g.t.Helper()
-	sess, ok := g.GetSession(sessionID)
-	if !ok {
-		g.t.Fatalf("session %s not found", sessionID)
-	}
 	deadline := time.Now().Add(timeout)
+	var lastErr error
 	for time.Now().Before(deadline) {
-		client := unixClient(sess.SocketPath)
-		resp, err := client.Get("http://localhost/scrollback/text")
-		if err == nil {
-			data, _ := io.ReadAll(resp.Body)
-			resp.Body.Close()
-			text := strings.TrimSpace(string(data))
-			if len(text) > 10 { // non-trivial output
-				return text
-			}
+		text, err := g.readScrollback(sessionRef)
+		lastErr = err
+		if err == nil && len(strings.TrimSpace(text)) > 10 {
+			return text
 		}
 		time.Sleep(500 * time.Millisecond)
 	}
-	g.t.Fatalf("timeout waiting for output from session %s", sessionID)
+	g.t.Fatalf("timeout waiting for output from session %s (last error: %v)", sessionRef, lastErr)
 	return ""
 }


### PR DESCRIPTION
## Summary

- replace the adapter integration harness's removed runner `GET /scrollback/text` calls with gmuxd's supported `GET /v1/sessions/<ref>/scrollback?tail=N` text contract
- pass session refs rather than private runner socket paths, preserving live/dead/peer routing and surfacing transport, HTTP, body-read, and content-type failures
- restore real harness startup with `gmuxd run` and sufficient cold-start readiness time
- add a real isolated-daemon shell regression proving ANSI PTY bytes are rendered through the broker as plain text

## Root cause

The runner endpoint was intentionally removed in #315 with no compatibility route when authoritative agent hooks replaced scrollback inference. The integration-tagged harness remained stale, and its helper swallowed request failures as empty output. Normal Go tests do not compile/run these external-tool integration paths. The harness had also drifted to a bare `gmuxd` invocation, so current real integration runs could not reach the stale request.

A repository-wide search found no other executable `/scrollback/text` calls and no sibling stale runner HTTP calls in this harness. The remaining literal is intentional migration documentation.

## Contract

The daemon broker owns persisted scrollback reads. Without `tail`, it returns raw `application/octet-stream` PTY bytes; with `tail=N`, it renders `text/plain`, including cursor overwrite/ANSI handling. It supports live and dead local sessions and forwards peer refs. The harness needs searchable text, so it uses the latter.

## Validation

- `cd packages/adapter && go test -run '^$' -tags integration ./adapters/...`
- `cd packages/adapter && go test ./...`
- `cd services/gmuxd && go test ./cmd/gmuxd -run 'Scrollback' -count=1`
- `cd cli/gmux && go test ./cmd/gmux -run 'Tail|TerminalExcerpt' -count=1`
- `./scripts/build.sh --skip-frontend`
- `cd packages/adapter && go test -tags integration -v -timeout 90s -run '^TestHarnessScrollbackBroker$' ./adapters`
- broader shell run: migrated `TestShellWSInput`, new broker regression, and `TestShellKill` passed; unrelated existing fish output-threshold and non-resumable shell restart tests failed and are not changed here
