### PR TITLE
docs: rewrite README as a short overview with hero screenshots

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,4 +48,13 @@ moon run :lint    # all lint/typecheck
 
 ## Project structure
 
-See [README.md](README.md) for workspace layout and the [website docs](apps/website/src/content/docs/) for architecture, protocol specs, and guides.
+| Path | Language | Purpose |
+|------|----------|---------|
+| `cli/gmux` | Go | Session launcher — PTY, WebSocket, runner |
+| `services/gmuxd` | Go | Machine daemon — discovery, state store, WS proxy, embedded web UI |
+| `packages/*` | Go | Shared libraries — adapters, paths, scrollback, session env |
+| `apps/gmux-web` | TypeScript/Preact | Browser UI — sidebar, terminal, header bar |
+| `packages/protocol` | TypeScript | Shared schemas, zod-validated |
+| `apps/website` | Astro/Starlight | Documentation site ([gmux.app](https://gmux.app)) |
+
+See the [architecture docs](https://gmux.app/architecture/) and the [develop guides](apps/website/src/content/docs/develop/) for how the pieces fit together.

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Sessions are grouped into **projects** by working directory — manage the proje
 - **Full terminal** — xterm.js with WebSocket transport, the same terminal emulator as VS Code
 - **~1 MiB persisted scrollback** — replays instantly on reconnect, survives runner exit, no lost context
 - **Flicker-free switching** — DEC 2026 synchronized output renders session swaps in a single frame
-- **Session lifecycle** — live status, exit codes, kill from the UI; supported adapter conversations remain resumable
+- **Session lifecycle** — live status, exit codes, kill from the UI; dead sessions stay resumable (agent conversations continue, other commands re-run)
 - **Reconnecting** — tab away, come back, the terminal is right where you left it
 - **Editor tabs** — `gmux edit <file>` opens a managed editor session; works as `$EDITOR` (blocks and propagates the exit code, so `git commit` just works)
 

--- a/README.md
+++ b/README.md
@@ -1,187 +1,76 @@
 # gmux
 
-**Keep tabs on every AI agent, test runner, and long-running process across your machines. Work from your desktop, steer from your phone.**
+**Start at your desk. Steer from your phone.**
 
-Launch any command as a managed session. gmux gives you a live, interactive terminal for each one — grouped by project, with real-time status updates pushed to your browser. When an agent needs input, you'll know. When tests fail, you'll see it. Switch to your phone and the same view is there, ready for you to course-correct.
+gmux runs coding agents — and any long-running command — in persistent sessions across your machines, aggregated into one live dashboard. Watch every agent, attach a full terminal to any session from any device, and get notified the moment one needs you.
 
-No Electron, no desktop app. Just a browser and two small binaries.
+No Electron, no desktop app, no tmux underneath. Two small Go binaries and a web UI.
+
+<table>
+  <tr>
+    <td width="72%"><img src="apps/website/src/assets/hero-desktop.png" alt="gmux dashboard on desktop — live sessions across machines, grouped by project, ordered by recent activity" /></td>
+    <td width="28%"><img src="apps/website/src/assets/hero-mobile.png" alt="The same session attached from a phone — full terminal with a mobile key row" /></td>
+  </tr>
+</table>
 
 ## Install
 
 ```bash
-brew install gmuxapp/tap/gmux
+brew install gmuxapp/tap/gmux                # macOS
+curl -sSfL https://gmux.app/install.sh | sh  # Linux
 ```
 
-Or download from [GitHub Releases](https://github.com/gmuxapp/gmux/releases).
+Or download a binary from [GitHub Releases](https://github.com/gmuxapp/gmux/releases).
 
 ## Quick start
 
 ```bash
-gmux -- pi                 # launch a coding agent
-gmux -- npm run dev       # launch any long-running command
-gmux -d -- make build      # detached; prints the session id
-gmux open                  # open the UI
+gmux -- pi              # launch a coding agent
+gmux -- npm run dev     # or any long-running command
+gmux -d -- make build   # detached; prints the session id
+gmux open               # open the dashboard
 ```
 
-Open the dashboard — all three sessions are there, grouped by project, with live status indicators. Click one to attach a full terminal. The same xterm.js that powers the VS Code terminal, running in your browser.
+The daemon starts automatically on first use; there's nothing else to set up. Click a session to attach a live terminal — xterm.js, the same emulator that powers VS Code. **[Getting started →](https://gmux.app/getting-started/)**
 
-The daemon (`gmuxd`) starts automatically on first use. There's nothing else to set up. Power users alias `gm='gmux --'`. For daemon lifecycle commands, run `gmux daemon status` (see `gmux help`).
+## Highlights
 
-## How it works
+- **Agents report their own state** — pi, Claude Code, and Codex get a small hook injected at launch and report their conversation, title, and active/idle state themselves. No output scraping. [Integrations →](https://gmux.app/integrations/claude-code/)
+- **Built for orchestration** — a machine-oriented CLI (`gmux agent`, `gmux wait`, `gmux ls --json`, tmux-compatible `send-keys`) with stable exit codes, so scripts and agents can drive other agents. [Orchestrating agents →](https://gmux.app/orchestrating-agents/)
+- **Full terminal, anywhere** — persisted scrollback that replays on reconnect, flicker-free session switching, find-in-terminal, and a phone UI that's actually usable. [Using the UI →](https://gmux.app/using-the-ui/)
+- **Sessions outlive processes** — exit codes and terminal history stick around; agent conversations resume, other commands re-run. [Sessions →](https://gmux.app/using-the-ui/#sessions)
+- **Multi-machine** — connect hosts with token-authenticated peering and see every machine's sessions in one sidebar; devcontainers are discovered automatically. [Multi-machine →](https://gmux.app/multi-machine/)
+- **Remote access built in** — `gmux remote` serves the dashboard over your tailnet with HTTPS, no ports to open. [Remote access →](https://gmux.app/remote-access/)
+- **Editor tabs** — `gmux edit <file>` works as `$EDITOR`, so `git commit` inside a session opens a managed tab and blocks until you're done.
 
-```mermaid
-graph LR
-    subgraph "Per session"
-        gmux1["gmux\nPTY · WebSocket · adapter"]
-    end
+## Scripting & agents
 
-    subgraph "Per machine"
-        gmuxd["gmuxd\ndiscovery · cache · proxy"]
-    end
-
-    subgraph Browser
-        web["gmux-web\nsidebar · terminal"]
-    end
-
-    gmux1 -- "Unix socket" --> gmuxd
-    gmuxd -- "HTTP · SSE · WS" --> web
-```
-
-**`gmux`** wraps any command in a managed session. It allocates a PTY, serves a WebSocket for terminal access, and runs an **adapter** that understands what the child process is doing. For agent tools (pi, Claude Code, Codex), gmux installs a small hook into the agent so the agent itself reports its state — active, idle, which conversation it holds — authoritatively, with no output scraping. A generic command gets alive/dead/activity tracking out of the box.
-
-**`gmuxd`** runs once per machine (auto-started by `gmux`). SQLite is authoritative for durable session rows, project placement, ordering, and manual peers. Live runners remain authoritative for runtime facts such as liveness and current status; gmuxd merges that runtime overlay into SQLite-backed snapshots, proxies WebSocket connections, and pushes updates via SSE. Authentication and bootstrap files also live under gmux's state/config directories.
-
-**`gmux-web`** is the browser UI. The sidebar groups sessions into projects, with status dots that pulse when something needs attention. The terminal is xterm.js — the same battle-tested terminal emulator that powers VS Code's integrated terminal — with synchronized output for flicker-free session switching and ~1 MiB of persisted scrollback that replays instantly on reconnect.
-
-## What you see
-
-```
-┌─────────────────────────────────────┐
-│ gmux                             ⚙  │
-│                                     │
-│ ▼ myapp                        ● 2  │
-│                                     │
-│   ● fix auth bug               now  │
-│     working · pi                    │
-│                                     │
-│   ● test watcher             2m ago │
-│     npm run dev                     │
-│                                     │
-│ ▼ gmux                         ● 1  │
-│                                     │
-│   ● bootstrap                  5m   │
-│     unread · pi                     │
-│                                     │
-│ ▸ docs                         ○ 1  │
-└─────────────────────────────────────┘
-```
-
-Sessions are grouped into **projects** by working directory — manage the project list in Settings, where gmux also suggests directories it discovered from past sessions. Each project's status dot reflects the most urgent session inside it.
-
-## Features
-
-### Sessions
-- **Launch anything** — `gmux -- <command>` wraps any process in a managed session
-- **Full terminal** — xterm.js with WebSocket transport, the same terminal emulator as VS Code
-- **~1 MiB persisted scrollback** — replays instantly on reconnect, survives runner exit, no lost context
-- **Flicker-free switching** — DEC 2026 synchronized output renders session swaps in a single frame
-- **Session lifecycle** — live status, exit codes, kill from the UI; dead sessions stay resumable (agent conversations continue, other commands re-run)
-- **Reconnecting** — tab away, come back, the terminal is right where you left it
-- **Editor tabs** — `gmux edit <file>` opens a managed editor session; works as `$EDITOR` (blocks and propagates the exit code, so `git commit` just works)
-
-### Adapters — session-level intelligence
-Adapters teach gmux how to work with specific tools. They're compiled into the binary and selected automatically by command name.
-
-- **Auto-detection** — `gmux -- pi` recognizes pi and activates the pi adapter. No flags needed.
-- **Authoritative agent status** — pi, Claude Code, and Codex report session identity, titles, and active/idle state through the tools' own hook mechanisms, injected per launch
-- **Child awareness** — any tool can self-report status via `PUT /status` on `$GMUX_SOCKET`, no adapter required
-- **Graceful fallback** — unknown commands get the shell adapter
-
-### Scripting & agents
-gmux is a full CLI, designed to compose into scripts and agent workflows:
+gmux composes into scripts and agent workflows:
 
 ```bash
-id=$(gmux -d -- pi)                     # launch detached, capture the id
-gmux send --wait --timeout 600 "$id" 'refactor the auth module' Enter  # send, block until the turn ends
-gmux tail "$id" -n 50                   # read the plain-text terminal tail
+id=$(gmux agent prompt --new --no-wait 'refactor the auth module')  # launch, capture the id
+gmux wait "$id"        # block until the turn ends, print the exchange report
+gmux tail -n 50 "$id"  # read the plain-text terminal tail
 ```
 
-`gmux ls --json` gives agents a machine-readable session list; `gmux send-keys -t` is tmux-compatible. See the [scripting guide](apps/website/src/content/docs/integrations/scripts-and-agents.md).
-
-### Multi-machine
-Run gmux on each machine, then connect them: `gmux auth` on the remote host prints a connect URL you paste into **Settings → Hosts → Connect to host**. Next add wanted projects under **Settings → Projects → From other hosts**; connecting a network host alone does not add its sessions to the sidebar. Peers authenticate with bearer tokens, and remote sessions are addressed as `<id>@<peer>`. Devcontainers running the gmux feature are discovered automatically. See [Multi-machine](apps/website/src/content/docs/multi-machine.md).
-
-### UI
-- **Activity by recency** — the home screen orders live sessions by recent output and groups them by calendar day
-- **Project grouping** — sessions group into projects by working directory; manage the list in Settings
-- **Find in terminal** — Cmd/Ctrl+F searches the terminal buffer
-- **Mobile responsive** — same URL on your phone; a dedicated toolbar, keyboard handling, and long-press link actions
-- **URL routing** — every project and session has a stable URL you can bookmark
-- **Customizable theme** — dark theme with a Windows Terminal–compatible terminal palette (`theme.jsonc`)
-
-### Architecture
-- **Split authority** — SQLite owns durable daemon state; live runners own runtime facts that gmuxd overlays onto stored rows
-- **No external dependencies** — no tmux, no screen, no abduco. Two Go binaries and a web app.
-- **Web-first** — works on desktop, tablet, phone. Same URL everywhere.
-- **Zero config** — run `gmux -- <command>`, open a browser
-
-## Extensibility
-
-- **Adapters** (Go, compiled in) — recognize commands, launch presets, titles, resume, hook-driven status
-- **Child self-reporting** — any process can `PUT /status` on `$GMUX_SOCKET` to set active/error state, no adapter required
-
-## Development
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for prerequisites and setup.
-
-```bash
-pnpm install      # JS dependencies
-pnpm dev          # start all services with watch/HMR
-```
-
-### Monorepo layout
-
-```mermaid
-graph TB
-    subgraph "CLI"
-        gmux2["cli/gmux\nGo — PTY, WebSocket, runner"]
-    end
-
-    subgraph "Daemon"
-        gmuxd1["services/gmuxd\nGo — discovery, cache, proxy"]
-    end
-
-    subgraph "Web"
-        web["apps/gmux-web\nPreact — sidebar, terminal"]
-        proto["packages/protocol\nTypeScript — zod schemas"]
-        proto --> web
-    end
-
-    gmux2 -- "Unix socket" --> gmuxd1
-    gmuxd1 -- "REST + SSE + WS" --> web
-```
-
-| Path | Language | Purpose |
-|------|----------|---------|
-| `cli/gmux` | Go | Session launcher — PTY, WebSocket, runner |
-| `services/gmuxd` | Go | Machine daemon — discovery, cache, WS proxy, embedded web UI |
-| `packages/*` | Go | Shared libraries — adapters, paths, scrollback, session env |
-| `apps/gmux-web` | TypeScript/Preact | Browser UI — sidebar, terminal, header bar |
-| `packages/protocol` | TypeScript | Shared schemas, zod-validated |
-| `apps/website` | Astro/Starlight | Documentation site |
+See the [scripting guide](https://gmux.app/integrations/scripts-and-agents/) and the [CLI reference](https://gmux.app/reference/cli/).
 
 ## Docs
 
-Documentation lives in the [website](apps/website/src/content/docs/):
+Full documentation lives at **[gmux.app](https://gmux.app/getting-started/)**: [architecture](https://gmux.app/architecture/), [configuration](https://gmux.app/configuration/), [security model](https://gmux.app/security/), [devcontainers](https://gmux.app/devcontainers/), [running in Docker](https://gmux.app/running-in-docker/), [changelog](https://gmux.app/changelog/), and more.
 
-- [Getting Started](apps/website/src/content/docs/getting-started.mdx) — install and first session
-- [Architecture](apps/website/src/content/docs/architecture.md) — runtime structure (gmux, gmuxd, web UI)
-- [CLI Reference](apps/website/src/content/docs/reference/cli.md) — every verb and flag
-- [Multi-machine](apps/website/src/content/docs/multi-machine.md) — connecting hosts
-- [Session Schema](apps/website/src/content/docs/develop/session-schema.md) — metadata model
-- [Adapter Architecture](apps/website/src/content/docs/develop/adapter-architecture.md) — how adapters work
-- [Security](apps/website/src/content/docs/security.md) — threat model and safeguards
-- [Remote Access](apps/website/src/content/docs/remote-access.md) — `gmux remote` / Tailscale setup
+## Community
+
+Questions, feedback, show & tell: [Discord](https://discord.gg/Mg6EJHFZxu) · [GitHub Issues](https://github.com/gmuxapp/gmux/issues)
+
+## Development
+
+```bash
+pnpm install   # JS dependencies
+pnpm dev       # start all services with watch/HMR
+```
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for prerequisites, workspace layout, and how the pieces fit together.
 
 ## License
 

--- a/apps/website/src/content/docs/changelog.mdx
+++ b/apps/website/src/content/docs/changelog.mdx
@@ -44,7 +44,7 @@ The biggest release yet, and the first with breaking changes. 2.0 makes agent st
 
 ### Agents can now orchestrate other agents
 
-The new machine-oriented `gmux agent` surface launches, prompts, observes, and cancels subagents without scraping terminal output. `gmux agent prompt --new --no-wait` prints an addressable session as soon as readiness, delivery, and admission complete, without waiting for the turn to finish; `gmux wait <id>...` waits on several agents concurrently and prints source-attributed exchange reports in argument order. Stable exit codes and delivery errors distinguish completed work, agent failure, interruption, timeout, safe retry, and indeterminate delivery — enough structure to build reliable agent swarms from shell scripts and other tools. See **[Orchestrating agents](https://gmux.app/orchestrating-agents/)** for the complete workflow.
+The new machine-oriented `gmux agent` surface launches, prompts, observes, and cancels subagents without scraping terminal output. `gmux agent prompt --new --no-wait` returns an addressable session once the prompt is admitted, without waiting for the turn to finish; `gmux wait <id>...` waits on several agents concurrently and prints source-attributed exchange reports in argument order. Stable exit codes and delivery errors distinguish completed work, agent failure, interruption, timeout, safe retry, and indeterminate delivery — enough structure to build reliable agent swarms from shell scripts and other tools. See **[Orchestrating agents](https://gmux.app/orchestrating-agents/)** for the complete workflow.
 
 ### A rebuilt web app
 

--- a/apps/website/src/content/docs/migrating-to-2.md
+++ b/apps/website/src/content/docs/migrating-to-2.md
@@ -12,7 +12,7 @@ gmux 2.0 is a breaking release. It starts with a clean SQLite state store; it do
 1. Upgrade every machine (and rebuild devcontainers) **together** — 2.0 hosts can't peer with 1.x hosts.
 2. Update scripts and muscle memory to the verb-first CLI: `gmux -- <cmd>` to run, `gmux open` for the UI, `gmux ls/attach/send/wait/kill` instead of flags.
 3. Re-add each remote host with its connect URL (**Settings → Hosts → Connect to host**, using `gmux auth` on that host), then add the projects you want under **Settings → Projects → From other hosts**.
-4. Recreate local projects. Running 1.x sessions can re-register, but dead history, project order, references, and connected hosts do not carry over.
+4. Recreate local projects. Restart any sessions that were running under 1.x — they, along with dead history, project order, references, and connected hosts, do not carry over.
 5. If you parse gmux JSON: `kind` → `adapter`, `session_file` → `conversation_file`.
 
 ---

--- a/apps/website/src/content/docs/reference/cli.md
+++ b/apps/website/src/content/docs/reference/cli.md
@@ -50,7 +50,7 @@ already inside a gmux session:
 | stdin | stdout | Inside `GMUX=1`? | Behavior |
 | ----- | ------ | ---------------- | -------- |
 | TTY | TTY | no | Attach interactively: forward terminal input, Ctrl-C, and resize; print no session ID. |
-| TTY | TTY | yes | Auto-detach to avoid nested PTYs; print the session ID on stdout. |
+| TTY | TTY | yes | Auto-detach to avoid nested PTYs; print a confirmation message on stderr (no session ID — use `gmux -d` to capture one). |
 | any other combination | any other combination | either | Headless foreground: block, stream merged PTY output to stdout, print the session ID on stderr, and propagate the child exit code. Launcher stdin is not forwarded; use `gmux send` for input. |
 
 The headless row is the canonical shape for scripts and agent harnesses:

--- a/apps/website/src/content/docs/security.md
+++ b/apps/website/src/content/docs/security.md
@@ -115,7 +115,7 @@ For container deployments, the `GMUXD_TOKEN` environment variable can seed the t
 
 The file remains the primary storage. Environment variables are inherited by child processes, visible in `/proc/*/environ`, and tend to appear in CI logs and Docker inspect output. CLI flags show up in `ps` and shell history. A file with `0600` permissions is the smallest attack surface for a long-lived secret. The env var is a provisioning convenience for containers, not a replacement for the file.
 
-The [`examples/`](https://github.com/gmuxapp/gmux/tree/main/examples) directory has ready-to-run Docker Compose setups showing how to handle auth in common deployment scenarios: [Tailscale](/running-in-docker/#tailscale-recommended), [WireGuard](/running-in-docker/#wireguard), and [Traefik with OIDC](/running-in-docker/#reverse-proxy-with-oidc-traefik-pocketid).
+The [`examples/`](https://github.com/gmuxapp/gmux/tree/main/examples) directory has ready-to-run Docker Compose setups showing how to handle auth in common deployment scenarios: [Tailscale](/running-in-docker/#tailscale-recommended), [WireGuard](/running-in-docker/#wireguard), and [Traefik with OIDC](/running-in-docker/#reverse-proxy-with-oidc-traefik--pocketid).
 
 **For easy access from other devices**, use [Tailscale remote access](/remote-access). It gives you HTTPS with automatic certificates and cryptographic identity verification; access still requires the host's token (run `gmux auth` to get its connect URL).
 

--- a/apps/website/src/content/docs/using-the-ui.md
+++ b/apps/website/src/content/docs/using-the-ui.md
@@ -69,7 +69,7 @@ Each project has host-local **match rules** that determine which sessions belong
 You can manage projects at any time in **Settings → Projects** (gear button in the sidebar header, or the `?settings` URL parameter):
 
 - **Your projects**: configured projects with their match rules. Drag to reorder, click **×** to remove.
-- **Discovered**: local directories gmux noticed from active sessions that don't match any project. Type to filter, click **Add**, or enter a local path manually.
+- **Discovered**: directories gmux noticed from active sessions that don't match any project — including directories advertised by connected network hosts for their own unmatched sessions. Type to filter, click **Add**, or enter a local path manually.
 - **From other hosts**: projects advertised by connected network hosts. Add a reference here before that project's sessions appear in this dashboard.
 
 ## Sessions

--- a/docs/adr/0012-defer-relational-storage-migration.md
+++ b/docs/adr/0012-defer-relational-storage-migration.md
@@ -6,6 +6,7 @@
 > stores. ADR 0026 later replaced that decision with authoritative SQLite for
 > daemon-owned state. The body below is preserved as the rationale at the time,
 > not as current implementation guidance.
+
 **Date:** 2026-06-16
 **Related:** ADR 0002 (project ownership; share-nothing peering), ADR 0010 /
 ADR 0011 (authoritative attribution + runner-owned state)


### PR DESCRIPTION
Stacked on #446 (the first commit here is that PR; merge it first and this shrinks to one commit).

Rewrites the README as a short overview that hands off to gmux.app, per the discussion after the #437 review:

- **Why short instead of aligned**: the long README duplicated website prose and demonstrably rotted — both #437 accuracy passes had to fix stale claims in it. And its doc links pointed at raw in-repo `.md`/`.mdx` files whose internal `/slug/` links break when browsed on GitHub. The website is built, link-checked, and canonical; the README now sells in 30 seconds and links out.
- **Image**: uses the existing auto-captured hero screenshots (`apps/website/src/assets/hero-{desktop,mobile}.png`, regenerated by `capture-hero.mjs` from mock mode), side by side — desktop dashboard + phone terminal, echoing the site hero. They stay in sync with the UI by construction.
- **What stays**: install (now including the Linux `install.sh` one-liner, which the README was missing), quick start, seven highlight bullets each linking to the relevant gmux.app page, the agent-orchestration snippet (now using the documented `gmux agent prompt --new --no-wait` / `gmux wait` flow), Discord + issues, dev quick-start.
- **What moves**: the monorepo layout table moves into CONTRIBUTING.md's "Project structure" section, which previously pointed back at the README for it. The mermaid diagrams, ASCII sidebar art, and long feature/architecture sections are dropped in favor of gmux.app links.

All gmux.app links (including anchors) verified against a fresh site build; the `gmux tail` snippet was corrected to flag-before-id order along the way.