### PR TITLE
fix(adapter): render Claude observational logs safely

### DIFF
--- a/packages/adapter/adapters/claude_conversation.go
+++ b/packages/adapter/adapters/claude_conversation.go
@@ -1,0 +1,189 @@
+package adapters
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+
+	"github.com/gmuxapp/gmux/packages/adapter"
+)
+
+var (
+	_ adapter.ConversationRenderer         = (*Claude)(nil)
+	_ adapter.ConversationExchangeRenderer = (*Claude)(nil)
+)
+
+// claudeConversationEntry is the stable subset of Claude Code's append-only
+// JSONL transcript. Tool results are encoded as user-role messages, so role
+// alone is deliberately not enough to establish a user exchange boundary.
+type claudeConversationEntry struct {
+	Type        string `json:"type"`
+	UUID        string `json:"uuid"`
+	ParentUUID  string `json:"parentUuid"`
+	IsMeta      bool   `json:"isMeta"`
+	IsSidechain bool   `json:"isSidechain"`
+	Message     *struct {
+		Role    string          `json:"role"`
+		Content json.RawMessage `json:"content"`
+	} `json:"message"`
+}
+
+func readClaudeEntries(ref string) ([]claudeConversationEntry, error) {
+	data, err := os.ReadFile(ref)
+	if err != nil {
+		return nil, err
+	}
+	var linear []claudeConversationEntry
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		var entry claudeConversationEntry
+		// A transcript can be observed while its final line is being appended.
+		if json.Unmarshal([]byte(line), &entry) != nil {
+			continue
+		}
+		linear = append(linear, entry)
+	}
+	return claudeActiveBranch(linear), nil
+}
+
+// claudeActiveBranch follows Claude's native parent-linked history from the
+// final persisted node. Rewind/fork leaves abandoned messages in the JSONL;
+// rendering file order would disclose and misattribute that abandoned branch.
+// Older transcripts without parent links remain linear.
+func claudeActiveBranch(linear []claudeConversationEntry) []claudeConversationEntry {
+	if len(linear) == 0 {
+		return nil
+	}
+	hasParents := false
+	byID := make(map[string]claudeConversationEntry, len(linear))
+	for _, entry := range linear {
+		if entry.ParentUUID != "" {
+			hasParents = true
+		}
+		if entry.UUID != "" {
+			byID[entry.UUID] = entry
+		}
+	}
+	if !hasParents {
+		return linear
+	}
+	// Sidechain/meta records can be UUID-linked and trail the visible main
+	// conversation while subagent/bookkeeping work is appended. They remain in
+	// byID because a later main record may name one as an ancestor, but they
+	// must never replace the latest eligible main-conversation leaf.
+	leaf := claudeConversationEntry{}
+	for i := len(linear) - 1; i >= 0; i-- {
+		if linear[i].UUID != "" && !linear[i].IsSidechain && !linear[i].IsMeta {
+			leaf = linear[i]
+			break
+		}
+	}
+	if leaf.UUID == "" {
+		return linear
+	}
+	var reverse []claudeConversationEntry
+	seen := make(map[string]bool)
+	for cur := leaf; cur.UUID != "" && !seen[cur.UUID]; {
+		reverse = append(reverse, cur)
+		seen[cur.UUID] = true
+		if cur.ParentUUID == "" {
+			break
+		}
+		next, ok := byID[cur.ParentUUID]
+		if !ok {
+			break
+		}
+		cur = next
+	}
+	for left, right := 0, len(reverse)-1; left < right; left, right = left+1, right-1 {
+		reverse[left], reverse[right] = reverse[right], reverse[left]
+	}
+	return reverse
+}
+
+// renderClaudeContent returns a visible rendering, its prose-only subset, and
+// whether the content establishes a real user boundary. Thinking and tool
+// results are never exposed; tool use is represented compactly without its
+// result payload.
+func renderClaudeContent(raw json.RawMessage) (text, prose string, userBoundary bool) {
+	var s string
+	if json.Unmarshal(raw, &s) == nil {
+		return s, s, s != ""
+	}
+	var blocks []struct {
+		Type  string          `json:"type"`
+		Text  string          `json:"text"`
+		Name  string          `json:"name"`
+		Input json.RawMessage `json:"input"`
+	}
+	if json.Unmarshal(raw, &blocks) != nil {
+		return "", "", false
+	}
+	var parts, proseParts []string
+	for _, block := range blocks {
+		switch block.Type {
+		case "text":
+			if block.Text != "" {
+				parts = append(parts, block.Text)
+				proseParts = append(proseParts, block.Text)
+				userBoundary = true
+			}
+		case "tool_use":
+			parts = append(parts, formatPiToolCall(block.Name, block.Input))
+		case "image":
+			parts = append(parts, "[image]")
+			userBoundary = true
+		}
+	}
+	return strings.Join(parts, "\n\n"), strings.Join(proseParts, "\n\n"), userBoundary
+}
+
+func (c *Claude) RenderConversation(ref string) ([]adapter.ConversationMessage, error) {
+	entries, err := readClaudeEntries(ref)
+	if err != nil {
+		return nil, err
+	}
+	var out []adapter.ConversationMessage
+	for _, entry := range entries {
+		if entry.IsMeta || entry.IsSidechain || entry.Message == nil || (entry.Type != "user" && entry.Type != "assistant") {
+			continue
+		}
+		text, prose, boundary := renderClaudeContent(entry.Message.Content)
+		if entry.Type == "user" && !boundary { // tool_result message
+			continue
+		}
+		if text != "" {
+			out = append(out, adapter.ConversationMessage{Role: entry.Message.Role, Text: text, Prose: prose})
+		}
+	}
+	return out, nil
+}
+
+func (c *Claude) RenderConversationExchanges(ref string) ([]adapter.Exchange, error) {
+	entries, err := readClaudeEntries(ref)
+	if err != nil {
+		return nil, err
+	}
+	var out []adapter.Exchange
+	for _, entry := range entries {
+		if entry.IsMeta || entry.IsSidechain || entry.Message == nil {
+			continue
+		}
+		text, prose, boundary := renderClaudeContent(entry.Message.Content)
+		switch entry.Type {
+		case "user":
+			if boundary {
+				out = append(out, adapter.Exchange{Ordinal: uint64(len(out) + 1), User: text})
+			}
+		case "assistant":
+			if len(out) > 0 {
+				out[len(out)-1].Iterations++
+				// Only the latest assistant API iteration can be terminal prose.
+				out[len(out)-1].Terminal = prose
+			}
+		}
+	}
+	return out, nil
+}

--- a/packages/adapter/adapters/claude_conversation_test.go
+++ b/packages/adapter/adapters/claude_conversation_test.go
@@ -1,0 +1,127 @@
+package adapters
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestClaudeConversationExchanges(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	transcript := `{"type":"user","message":{"role":"user","content":" fix it "}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"thinking","thinking":"secret"},{"type":"text","text":"Checking"},{"type":"tool_use","name":"Read","input":{"file_path":"a.go"}}]}}
+{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"1","content":"private file contents"}]}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Done exactly"}]}}
+{"type":"user","isMeta":true,"message":{"role":"user","content":"synthetic"}}
+{"type":"assistant","isSidechain":true,"message":{"role":"assistant","content":[{"type":"text","text":"subagent private"}]}}
+{"type":"user","message":{"role":"user","content":[{"type":"text","text":" follow up "},{"type":"image","source":{}}]}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"thinking","thinking":"still secret"},{"type":"tool_use","name":"Bash","input":{"command":"go test ./..."}}]}}
+{partial`
+	if err := os.WriteFile(path, []byte(transcript), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	ex, err := NewClaude().RenderConversationExchanges(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ex) != 2 {
+		t.Fatalf("exchanges = %#v", ex)
+	}
+	if ex[0].User != " fix it " || ex[0].Iterations != 2 || ex[0].Terminal != "Done exactly" {
+		t.Fatalf("first exchange = %#v", ex[0])
+	}
+	if ex[1].User != " follow up \n\n[image]" || ex[1].Iterations != 1 || ex[1].Terminal != "" {
+		t.Fatalf("second exchange = %#v", ex[1])
+	}
+
+	msgs, err := NewClaude().RenderConversation(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, msg := range msgs {
+		if msg.Text == "private file contents" || msg.Text == "secret" || msg.Text == "subagent private" {
+			t.Fatalf("private content leaked: %#v", msgs)
+		}
+	}
+}
+
+func TestClaudeConversationUsesActiveParentBranch(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "branched.jsonl")
+	transcript := `{"uuid":"u1","parentUuid":null,"type":"user","message":{"role":"user","content":"root"}}
+{"uuid":"a-old","parentUuid":"u1","type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"old"}]}}
+{"uuid":"u-old","parentUuid":"a-old","type":"user","message":{"role":"user","content":"abandoned private text"}}
+{"uuid":"a-new","parentUuid":"u1","type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"active"}]}}
+{"uuid":"u-new","parentUuid":"a-new","type":"user","message":{"role":"user","content":"active followup"}}
+{"uuid":"a-end","parentUuid":"u-new","type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"done"}]}}`
+	if err := os.WriteFile(path, []byte(transcript), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ex, err := NewClaude().RenderConversationExchanges(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ex) != 2 || ex[0].User != "root" || ex[0].Terminal != "active" || ex[1].User != "active followup" || ex[1].Terminal != "done" {
+		t.Fatalf("active exchanges = %#v", ex)
+	}
+}
+
+func TestClaudeConversationIgnoresTrailingHiddenLeaves(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		tail string
+	}{
+		{"sidechain", `{"uuid":"side","parentUuid":"u1","type":"assistant","isSidechain":true,"message":{"role":"assistant","content":[{"type":"text","text":"private sidechain"}]}}`},
+		{"meta", `{"uuid":"meta","parentUuid":"u1","type":"user","isMeta":true,"message":{"role":"user","content":"hidden metadata"}}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "hidden-tail.jsonl")
+			transcript := `{"uuid":"u1","parentUuid":null,"type":"user","message":{"role":"user","content":"root"}}
+{"uuid":"main","parentUuid":"u1","type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"main answer"}]}}
+` + tc.tail
+			if err := os.WriteFile(path, []byte(transcript), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			ex, err := NewClaude().RenderConversationExchanges(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(ex) != 1 || ex[0].Iterations != 1 || ex[0].Terminal != "main answer" {
+				t.Fatalf("trailing hidden leaf erased main tail: %#v", ex)
+			}
+		})
+	}
+}
+
+func TestClaudeConversationRetainsHiddenTraversalAncestors(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "hidden-ancestor.jsonl")
+	transcript := `{"uuid":"u1","parentUuid":null,"type":"user","message":{"role":"user","content":"root"}}
+{"uuid":"hidden","parentUuid":"u1","type":"assistant","isSidechain":true,"message":{"role":"assistant","content":[{"type":"text","text":"private"}]}}
+{"uuid":"main","parentUuid":"hidden","type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"visible continuation"}]}}`
+	if err := os.WriteFile(path, []byte(transcript), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ex, err := NewClaude().RenderConversationExchanges(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ex) != 1 || ex[0].Iterations != 1 || ex[0].Terminal != "visible continuation" {
+		t.Fatalf("hidden ancestor broke traversal: %#v", ex)
+	}
+}
+
+func TestClaudeImageOnlyUserIsExchangeBoundary(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "image.jsonl")
+	transcript := `{"type":"user","message":{"role":"user","content":[{"type":"image","source":{"type":"base64","data":"secret"}}]}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"seen"}]}}`
+	if err := os.WriteFile(path, []byte(transcript), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ex, err := NewClaude().RenderConversationExchanges(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ex) != 1 || ex[0].User != "[image]" || ex[0].Terminal != "seen" {
+		t.Fatalf("image exchange = %#v", ex)
+	}
+}

--- a/packages/adapter/adapters/claude_hook.go
+++ b/packages/adapter/adapters/claude_hook.go
@@ -2,6 +2,8 @@ package adapters
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -31,7 +33,10 @@ func (c *Claude) HookCommand(args []string, selfBin string) ([]string, bool) {
 	if i < 0 || selfBin == "" {
 		return args, false
 	}
-	tail, userSettings := extractClaudeSettings(args[i+1:])
+	tail, userSettings, err := extractClaudeSettings(args[i+1:])
+	if err != nil {
+		return args, false
+	}
 	settingsJSON, err := buildClaudeSettings(selfBin, userSettings)
 	if err != nil {
 		return args, false
@@ -59,7 +64,7 @@ func claudeBinaryIndex(args []string) int {
 // extractClaudeSettings removes `--settings <value>` / `--settings=<value>`
 // pairs from tokens, returning the filtered tokens and the collected values.
 // Stops at a bare `--` so a positional prompt is never misread as a flag value.
-func extractClaudeSettings(tokens []string) (filtered, values []string) {
+func extractClaudeSettings(tokens []string) (filtered, values []string, err error) {
 	for i := 0; i < len(tokens); i++ {
 		tok := tokens[i]
 		if tok == "--" {
@@ -68,17 +73,22 @@ func extractClaudeSettings(tokens []string) (filtered, values []string) {
 		}
 		switch {
 		case tok == "--settings":
-			if i+1 < len(tokens) {
-				values = append(values, tokens[i+1])
-				i++
+			if i+1 >= len(tokens) || tokens[i+1] == "--" {
+				return nil, nil, errors.New("claude --settings requires a value")
 			}
+			values = append(values, tokens[i+1])
+			i++
 		case strings.HasPrefix(tok, "--settings="):
-			values = append(values, strings.TrimPrefix(tok, "--settings="))
+			value := strings.TrimPrefix(tok, "--settings=")
+			if value == "" {
+				return nil, nil, errors.New("claude --settings requires a value")
+			}
+			values = append(values, value)
 		default:
 			filtered = append(filtered, tok)
 		}
 	}
-	return filtered, values
+	return filtered, values, nil
 }
 
 // buildClaudeSettings returns the inline JSON for `--settings`: gmux's session
@@ -86,9 +96,11 @@ func extractClaudeSettings(tokens []string) (filtered, values []string) {
 func buildClaudeSettings(selfBin string, userSettings []string) (string, error) {
 	var base any = claudeGmuxHooks(selfBin)
 	for _, us := range userSettings {
-		if obj, ok := parseClaudeSettings(us); ok {
-			base = mergeClaudeSettings(base, obj)
+		obj, err := parseClaudeSettings(us)
+		if err != nil {
+			return "", fmt.Errorf("invalid Claude settings %q: %w", us, err)
 		}
+		base = mergeClaudeSettings(base, obj)
 	}
 	out, err := json.Marshal(base)
 	if err != nil {
@@ -138,7 +150,7 @@ func claudeGmuxHooks(selfBin string) map[string]any {
 
 // parseClaudeSettings interprets a user `--settings` value as inline JSON
 // (starts with `{`) or a path to a JSON file.
-func parseClaudeSettings(value string) (map[string]any, bool) {
+func parseClaudeSettings(value string) (map[string]any, error) {
 	trimmed := strings.TrimSpace(value)
 	var data []byte
 	if strings.HasPrefix(trimmed, "{") {
@@ -146,15 +158,15 @@ func parseClaudeSettings(value string) (map[string]any, bool) {
 	} else {
 		b, err := os.ReadFile(trimmed)
 		if err != nil {
-			return nil, false
+			return nil, err
 		}
 		data = b
 	}
 	var obj map[string]any
 	if err := json.Unmarshal(data, &obj); err != nil {
-		return nil, false
+		return nil, err
 	}
-	return obj, true
+	return obj, nil
 }
 
 // mergeClaudeSettings deep-merges over onto base. Objects merge recursively;

--- a/packages/adapter/adapters/claude_hook_test.go
+++ b/packages/adapter/adapters/claude_hook_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -315,5 +316,24 @@ func TestClaudeHookCommand_UserCannotWipeHooks(t *testing.T) {
 	}
 	if n := sessionStartHookCount(mergedSettings(t, out)); n != 1 {
 		t.Fatalf("gmux SessionStart hook must survive hooks:null, got %d", n)
+	}
+}
+
+func TestClaudeHookCommand_InvalidSettingsPreserved(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "missing.json")
+	for _, args := range [][]string{
+		{"claude", "--settings"},
+		{"claude", "--settings="},
+		{"claude", "--settings", missing, "--model", "opus"},
+		{"claude", "--settings", `{not-json}`, "--model", "opus"},
+	} {
+		original := append([]string(nil), args...)
+		out, ok := (&Claude{}).HookCommand(args, "/usr/bin/gmux")
+		if ok {
+			t.Errorf("invalid settings unexpectedly injected: %v", args)
+		}
+		if !reflect.DeepEqual(out, original) {
+			t.Errorf("invalid settings changed argv: got %v want %v", out, original)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Re-scopes the observationally useful subset of closed #438 without adding Claude semantic control.

- render Claude JSONL as exchanges for `gmux agent logs`, including partial and completed turns
- reconstruct only the active parent-linked branch while retaining hidden traversal ancestors
- suppress thinking, tool-result payloads, metadata, sidechains, malformed/truncated records, and compact tool calls
- treat image-only user turns as exchange boundaries
- preserve the original Claude argv when hook settings are missing, unreadable, or malformed

Claude remains an interactive terminal adapter: this does **not** add `AgentActionEncoder`, `AgentLauncher`, a launch selector, or semantic readiness behavior. Existing adapter capability tests continue to pin that Claude does not support semantic agent actions. Existing resume/identity lineage on main is unchanged.

## Test evidence

- `go test ./packages/adapter/adapters ./cli/gmux/cmd/gmux ./cli/gmux/internal/ptyserver`
- `go test -race ./packages/adapter/adapters ./cli/gmux/cmd/gmux ./cli/gmux/internal/ptyserver`
- Claude branch/image/settings regressions with `-count=20`
- all Go workspace module suites passed except `tests/e2e`: its daemon startup timed out and the subsequent login-env restart returned 500
