### PR TITLE
docs(adr): ADR 0033 drive modes & capability boundaries + ADR 0034 model resolution

### DIFF
--- a/UBIQUITOUS_LANGUAGE.md
+++ b/UBIQUITOUS_LANGUAGE.md
@@ -13,6 +13,9 @@ This file defines current v2 terminology. Historical ADRs may use superseded `st
 | **Conversation ID** | Stable adapter-reported identity extracted by `DescribeConversation`; indexed with adapter as `(adapter, conversationID)`. | Tool ID |
 | **Conversation Ref** | Opaque adapter-scoped locator persisted in `conversation_file` for compatibility. Only the adapter interprets it. | File path as identity |
 | **Launch parent** | Immutable session ID of the session that launched this one. Records provenance independently of presentation promotion. | UI parent only |
+| **Harness** | The agent tool a session runs — pi, claude, codex. Names the session identity in the canonical spec `model:effort@harness`; one adapter per harness. | Backend, adapter (as identity) |
+| **Drive mode** | How gmux hosts and drives a harness: terminal (PTY) or ACP. Capabilities attach to the (harness, mode) pair; for driven launches the mode is capability-determined, never a preference. | Backend, session kind |
+| **In-scope models** | The model list a harness's own picker offers, as configured in the harness itself and reported by its adapter. The shorthand-resolution corpus and web model picker source. | gmux-side model catalog, allowlist in gmux config |
 
 ## Session lifecycle
 

--- a/docs/adr/0027-semantic-agent-cli-and-result-bearing-wait.md
+++ b/docs/adr/0027-semantic-agent-cli-and-result-bearing-wait.md
@@ -85,9 +85,9 @@ the capability they use; complete adapter support is a release/documentation
 policy, not a composite `AgentAdapter` marker. Peer forwarding and Claude/Codex
 support are follow-ups. *(Amended 2026-08-02 by
 [ADR 0033](0033-session-backends-and-semantic-capability-boundaries.md):
-the Claude/Codex follow-up is an ACP session backend, not this terminal
-path — their terminal sessions stay interactive-only and refuse semantic
-verbs.)*
+the Claude/Codex follow-up is the ACP drive mode, not this terminal path —
+their terminal-mode sessions stay interactive-only and refuse semantic
+verbs, steer permanently.)*
 
 ### 2. `send` is raw; semantic actions belong to `agent`
 

--- a/docs/adr/0027-semantic-agent-cli-and-result-bearing-wait.md
+++ b/docs/adr/0027-semantic-agent-cli-and-result-bearing-wait.md
@@ -83,7 +83,11 @@ ADR does not claim public ACP server conformance.
 The initial tracer is deliberately **local-only and pi-only**. Commands check
 the capability they use; complete adapter support is a release/documentation
 policy, not a composite `AgentAdapter` marker. Peer forwarding and Claude/Codex
-support are follow-ups.
+support are follow-ups. *(Amended 2026-08-02 by
+[ADR 0033](0033-session-backends-and-semantic-capability-boundaries.md):
+the Claude/Codex follow-up is an ACP session backend, not this terminal
+path — their terminal sessions stay interactive-only and refuse semantic
+verbs.)*
 
 ### 2. `send` is raw; semantic actions belong to `agent`
 

--- a/docs/adr/0027-semantic-agent-cli-and-result-bearing-wait.md
+++ b/docs/adr/0027-semantic-agent-cli-and-result-bearing-wait.md
@@ -84,7 +84,7 @@ The initial tracer is deliberately **local-only and pi-only**. Commands check
 the capability they use; complete adapter support is a release/documentation
 policy, not a composite `AgentAdapter` marker. Peer forwarding and Claude/Codex
 support are follow-ups. *(Amended 2026-08-02 by
-[ADR 0033](0033-session-backends-and-semantic-capability-boundaries.md):
+[ADR 0033](0033-session-drive-modes-and-semantic-capability-boundaries.md):
 the Claude/Codex follow-up is the ACP drive mode, not this terminal path —
 their terminal-mode sessions stay interactive-only and refuse semantic
 verbs, steer permanently.)*

--- a/docs/adr/0033-session-backends-and-semantic-capability-boundaries.md
+++ b/docs/adr/0033-session-backends-and-semantic-capability-boundaries.md
@@ -1,0 +1,297 @@
+# ADR 0033: session backends and semantic capability boundaries
+
+**Status:** Accepted
+**Date:** 2026-08-02
+**Related:** ADR 0009 (verb-first CLI), ADR 0013 (codex authoritative state via hooks), ADR 0015 (hook translation at the agent side), ADR 0021 (ACP as the normalized conversation schema), ADR 0023 (unified turn model), ADR 0027 (semantic agent CLI and result-bearing wait), ADR 0028 (CLI output channels), ADR 0029 (agent sessions abstract runner residency), ADR 0030 (exchange-oriented reads and observational wait), ADR 0031 (session ID issuance), ADR 0032 (session input doors)
+**Amends:** ADR 0027 §1 (the "Claude/Codex support are follow-ups" clause — the follow-up is an ACP backend, not the terminal path)
+
+## Context
+
+ADR 0027–0032 define gmux's semantic agent contract: readiness-gated prompt
+delivery with `--follow-up`/`--steer` preconditions, cancel, source-asserted
+turn boundaries, result-bearing observational wait, and exchange-structured
+reads. Pi implements the full contract through its terminal runner. ADR 0027
+§1 recorded Claude and Codex support as follow-ups, and two PRs attempted to
+deliver exactly that — the same contract, through each tool's interactive
+terminal plus its hook system and native conversation storage:
+
+- **PR #438 (Claude, `feat/claude-agent-interface`, head `14034503`).** The
+  code passed adversarial review and CI: four review rounds closed
+  active-branch reconstruction (parent-linked `uuid`/`parentUuid` traversal
+  with abandoned-branch and sidechain privacy), image-only exchange
+  boundaries, non-destructive settings injection, and reachable launch
+  routing. It was then **closed at a live manual gate**. Driving the real
+  Claude TUI showed the interactive terminal is not an automation transport:
+  trust/onboarding modals appear before the composer accepts input at all;
+  readiness could only be approximated with arbitrary elapsed-time delays,
+  because no event distinguishes "painted" from "accepting input"; whether
+  Enter submits depends on focus, vim-mode, and rebindable keybindings;
+  permission dialogs change what the same keys mean mid-turn; and obtaining
+  the result required a compensating second observational wait after the hook
+  reported the turn closed. Every one of these is a property of a UI built
+  for a human with eyes, not a defect gmux code could fix.
+- **PR #439 (Codex, `feat/agent-interface-codex`, head `96edd0d9`).** Blocked
+  in review on two structural findings, both deterministic from the
+  production event translation and verified against upstream Codex source:
+  Codex's hooks **never emit semantic readiness** (no event corresponds to
+  "the composer will accept a prompt"), so every readiness-gated action times
+  out before delivery; and its turn events carry **no identity, boundary, or
+  output facts** — no `turn_seq`, no trigger, no iteration or user-boundary
+  events, no terminal output, and upstream `StopRequest` carries no outcome —
+  so the daemon correctly serves such live waits result-free and a
+  synchronous `gmux agent prompt` can never render the exchange report the
+  public contract promises. These are upstream interface properties, not
+  implementation bugs.
+
+The two failures have one shape. The semantic contract needs facts the
+transport must assert: readiness before delivery, submission as intent rather
+than a keystroke that might mean something else today, and a settled boundary
+that carries the result (ADR 0027's 2026-07-28 amendment). Pi's terminal
+satisfies this because **gmux controls both sides of that interface** — the
+in-repo pi extension asserts readiness, boundaries, injections, and results
+from inside the agent, and pi's composer semantics are ours to keep stable.
+Claude's and Codex's terminals are foreign UIs: their keybindings, modals,
+and hook vocabularies are owned upstream, optimized for humans, and free to
+change without notice. Emulating a user against them yields a contract whose
+every clause rests on an unfalsifiable timing or keybinding assumption.
+
+Meanwhile ADR 0021 already anticipated ACP-native, terminal-less adapters,
+and draft PR #388 holds the gmux-native conversation UI seam (streaming
+text/thinking/tool-calls). ACP is the interface Claude and Codex *do* offer
+for automation: structured prompts, streaming updates, tool calls, permission
+requests, and cancellation — asserted facts, not scraped ones.
+
+## Decision
+
+### 1. Capabilities attach to the session backend, not the harness name
+
+A session's capability set is determined by **backend** — the transport and
+contract through which gmux hosts the agent — not by which agent runs inside.
+"A Claude session" is not one thing: a Claude **terminal** session and a
+Claude **ACP** session are different session kinds with different capability
+sets, different configuration surfaces, and potentially different identity
+and lifecycle semantics. Adapter names stop implying capabilities; the
+backend a session was created on decides what gmux may claim about it.
+
+Two backends exist under this ADR:
+
+- **Terminal backend** — the existing PTY session: a real process on a
+  durable PTY, attachable, raw-sendable, tailable, with whatever
+  *observational* facts the adapter's hook/extension and native storage
+  trustworthily provide (ADR 0011/0013/0015). Semantic control on this
+  backend requires the ADR 0027 contract to be source-asserted, which today
+  only pi's in-repo extension does.
+- **ACP backend (planned)** — a runner speaking the Agent Client Protocol to
+  a terminal-less agent process: structured prompt turns, streaming
+  `session/update`, tool calls, permission requests, cancellation, and
+  stable completion boundaries, normalized per ADR 0021 and rendered in
+  gmux-native UI (PR #388 is the seam). No PTY exists; there is nothing to
+  attach to and no screen to tail.
+
+### 2. Claude and Codex terminal sessions are interactive-only
+
+`gmux -- claude` and `gmux -- codex` remain plain interactive terminal
+sessions. They keep everything the terminal backend honestly provides:
+launch, attach, raw `send`, `tail`, hook-driven active/idle status, titles,
+attribution, retention, resume-by-relaunch, and observational transcript
+reads from native storage where implemented. They gain no semantic control:
+`gmux agent prompt` (including `--follow-up`/`--steer`), `gmux agent cancel`,
+and `gmux agent prompt --new --adapter claude|codex` refuse these sessions.
+
+`gmux wait` remains universal (ADR 0027 §11): it synchronizes on any
+session's activity, including hook-observed Claude/Codex turns, with the
+fidelity the hooks actually provide (Codex's outcome-less `Stop` stays
+coarse, per ADR 0013). It is result-bearing only where the backend asserts
+results; on Claude/Codex terminal sessions it never fabricates an exchange
+report from a screen.
+
+### 3. Refusal is explicit, permanent-shaped, and names the working path
+
+A semantic action against a terminal session whose adapter does not
+source-assert the contract fails **before any delivery**, with an error that
+names the backend boundary rather than a transient condition:
+
+```text
+gmux: claude terminal sessions are interactive-only; semantic control
+requires a Claude ACP session (not yet available). Use gmux send / gmux tail
+to drive this session, or gmux attach to take over.
+```
+
+The refusal is a capability fact in the `unsupported_adapter` family of the
+established error taxonomy (ADR 0027's 2026-07-27 amendment): checked and
+reported before readiness, activity, or residency, because "this session
+kind cannot do that" is permanent and actionable while the others are
+transient. It never degrades to raw input — a semantic verb must not
+silently become keystrokes (ADR 0027 §3's loud-failure rule applies at this
+boundary too). Once the ACP backend exists, the parenthetical points at how
+to create the capable session kind instead.
+
+### 4. Claude/Codex semantic control is delivered on the ACP backend
+
+The ADR 0027–0030 contract for Claude and Codex — launch, prompt, follow-up,
+steer, cancel, result-bearing wait, exchange logs — is implemented by the
+upcoming ACP runner, where readiness is protocol initialization, submission
+is a `session/prompt` request, completion is a protocol response, results
+arrive as structured updates, and permission requests are first-class events
+rather than key-stealing dialogs. ADR 0027 §4's forward reference ("future
+ACP-native runners set ready after protocol initialization") becomes the
+plan of record for these harnesses.
+
+An ACP session is **not a pretend terminal**. gmux does not synthesize a PTY
+around it, `attach` and `tail` do not apply, and its UI is the gmux-native
+conversation view. Where the semantic contract and ACP's expressiveness
+disagree, the resolution is designed in the ACP runner work with honest
+degradation (decision 7's open questions), never by falling back to terminal
+emulation.
+
+### 5. Pi remains terminal-first with full semantic control
+
+Pi keeps its terminal backend and its complete semantic capability set. This
+is the rule of decision 1 applied, not an exception to it: pi's terminal
+*is* part of its product value — extensions, custom renderers, direct human
+intervention mid-session — and the in-repo extension gives gmux both sides
+of the interface, which is exactly the condition under which a terminal can
+source-assert the contract. No pi ACP session is planned; nothing here
+precludes one later, as its own session kind under the same rule.
+
+### 6. The product rule
+
+**Use the native terminal when the terminal is part of the agent's value;
+use ACP when the terminal is merely a UI around an automatable agent.** For
+pi the terminal is the product surface. For Claude and Codex the terminal is
+one client of an agent that offers a structured protocol for exactly the
+control gmux wants; automating the human client instead of speaking the
+protocol was the category error both PRs paid for.
+
+### 7. Capability matrix
+
+Capabilities by harness × backend. "Refused" is decision 3's explicit error;
+"n/a" means the surface does not exist on that backend.
+
+| Capability | pi · terminal | claude · terminal | codex · terminal | claude/codex · ACP (planned) |
+|---|---|---|---|---|
+| launch (`gmux --` / `-d` / launcher) | yes | yes | yes | yes (ACP runner spawn) |
+| attach / raw `send` / `tail` | yes | yes | yes | n/a (no PTY; gmux-native UI) |
+| hook/event status (active/idle, error) | yes (extension) | yes (hooks) | yes (hooks ≥ 0.135, coarse Stop) | yes (protocol events) |
+| titles, attribution, retention, resume-by-relaunch | yes | yes | yes | per ACP session identity (open) |
+| observational transcript reads (`agent logs`) | yes | salvage pending (see Consequences) | salvage pending | yes (normalized updates/storage) |
+| `gmux wait` synchronization | yes | yes (hook fidelity) | yes (hook fidelity, outcome-less Stop) | yes |
+| result-bearing wait / exchange report | yes | refused / no result claim | refused / no result claim | yes |
+| `agent prompt` (plain / `--follow-up` / `--steer`) | yes | refused | refused | yes (steer expressibility open) |
+| `agent cancel` | yes | refused | refused | yes (`session/cancel`) |
+| `agent prompt --new` | yes | refused | refused | yes |
+
+### 8. Non-goals
+
+- **No live backend switching.** A session is created on one backend and
+  stays there for its lifetime. There is no "upgrade this terminal session
+  to ACP" or the reverse.
+- **No transparent conversion.** A terminal conversation and an ACP
+  conversation may differ in identity, configuration (settings/MCP/plugins
+  loading), and lifecycle semantics; gmux does not claim that continuing one
+  as the other preserves meaning, and does not attempt it.
+- **No pretend PTY for ACP sessions**, and no revival of TUI emulation for
+  Claude/Codex under any flag.
+- **No inferred semantics on the terminal backend.** PTY output is
+  presentation data (ADR 0027 §9); no amount of screen parsing promotes a
+  terminal session into a semantically controllable one.
+
+## Consequences
+
+- **Claude/Codex semantic control is consciously blocked on the ACP backend
+  landing.** We prefer the correct feature when ACP lands over a fragile TUI
+  emulator now. The two-step interactive route (`gmux -d -- claude`, then
+  `gmux send`/attach) keeps working throughout, as does hook-driven status.
+- **Salvage: the observational work survives.** PR #438's review-hardened
+  transcript pieces — parent-linked active-branch reconstruction with
+  sidechain/meta privacy filtering, image-only boundaries, non-destructive
+  settings/hook injection — and PR #439's rollout JSONL renderer are
+  extraction candidates for follow-up PRs *without semantic-control claims*:
+  they serve `agent logs`-style reads and status fidelity on the terminal
+  backend, where storage parsing is trustworthy even though driving the TUI
+  is not.
+- **ADR 0027 §1 is amended.** "Peer forwarding and Claude/Codex support are
+  follow-ups" now reads with this ADR's split: the follow-up for Claude/Codex
+  is the ACP backend, and the terminal backend never grows their semantic
+  verbs. ADR 0027's 2026-07-28 adapter-contract clause ("claude/codex do not
+  become result-bearing") is confirmed and made permanent for the terminal
+  backend. No other existing doc was found claiming terminal semantic
+  support for Claude/Codex: the website adapter/integration pages describe
+  only observational hooks, status, titles, and resume, which remain true.
+- **Session kinds become a real axis.** Stores, the CLI, and the web UI will
+  eventually need to distinguish a Claude terminal session from a Claude ACP
+  session (naming, launchers, capability checks). That design belongs to the
+  ACP runner work; this ADR fixes only that the axis exists and that
+  capability checks key on it.
+- **Error-message wording gains a second boundary.** Alongside ADR 0029's
+  activity-vocabulary rule, semantic refusals on terminal Claude/Codex name
+  the backend, not a missing feature flag or a "dead" anything.
+
+## Open questions deferred to the ACP implementation
+
+An ACP contract spike is running in parallel (`.grove/acp-contract-spike/`),
+building a coverage matrix of the ADR 0027–0032 contract against the ACP
+spec, `claude-code-acp`, and Codex's ACP support. Its findings are **pending
+input** to the ACP runner design; this ADR does not wait for them. Deferred:
+
+- **Steer vs follow-up expressibility.** Whether ACP can distinguish
+  mid-turn steering from a queued follow-up per adapter, and the honest
+  degradation if not (refuse `--steer`? cancel-and-reprompt with the
+  semantics stated?).
+- **Result boundaries and taxonomy mapping.** Whether each adapter's turn
+  completion reliably carries final content, and how
+  cancellation/API-error/process-death map onto ADR 0027 §8's
+  completed/interrupted/error.
+- **Waiting-on-user.** Whether permission requests and user questions are
+  distinguishable from active work well enough to surface as a first-class
+  state.
+- **Resume and identity.** `session/load` support per adapter, identity
+  stability across gmux restarts, and how ACP session identity composes with
+  ADR 0029's resumable-conversation handle.
+- **Configuration parity.** How close an ACP session's settings/MCP/plugin
+  surface comes to the interactive tool, and how the difference is stated to
+  users (decision 8's no-transparent-conversion rule is the floor).
+- **Privacy.** Whether hidden reasoning is excluded or marked in updates,
+  and how that composes with ADR 0030's rendering rules.
+
+## Alternatives considered
+
+### Keep hardening the terminal automation path
+
+Rejected. Both PRs demonstrated the failure is structural, not residual: for
+Claude every fix (readiness delays, focus/keybinding assumptions,
+modal handling) replaced one unverifiable timing assumption with another,
+against an interface whose owner may change any of it in a patch release;
+for Codex the required facts (readiness, turn identity, results) do not
+exist in the interface at all. A contract built on those foundations would
+be ADR 0027's loud-failure principle inverted — quiet lies instead of loud
+errors.
+
+### Headless one-shot modes (`claude -p`, `codex exec`) as the semantic backend
+
+Rejected as the backend. One-shot invocations discard the durable session:
+no follow-up queue, no steering, no mid-turn observation, no
+permission-request surface, and a fresh process per prompt. ACP is the
+structured, session-holding version of the same idea and is what these
+vendors maintain for programmatic clients.
+
+### Wait for upstream hooks to grow readiness/outcome facts
+
+Rejected as a plan. Hook vocabularies are upstream property with no
+committed timeline, and even a complete hook set still leaves *delivery*
+running through the TUI's focus/modal/keybinding surface — hooks fix
+observation, not control. Hooks remain the terminal backend's observational
+channel; if they improve, observation improves, and nothing here changes.
+
+### Attach capabilities to the adapter with per-verb feature flags
+
+Rejected. It encodes the false premise that "a Claude session" is one thing
+with a feature list, and invites exactly the drift this ADR closes: an
+adapter flag flipped on for a backend that cannot honor it. The backend is
+the unit that has a contract; capabilities follow it.
+
+### Refuse Claude/Codex semantic verbs silently or degrade to raw send
+
+Rejected outright. Degrading a semantic verb to keystrokes is the
+old-runner hazard of ADR 0027 §3 reintroduced deliberately; silent refusal
+teaches callers nothing. The error names the boundary and the working path.

--- a/docs/adr/0033-session-backends-and-semantic-capability-boundaries.md
+++ b/docs/adr/0033-session-backends-and-semantic-capability-boundaries.md
@@ -401,8 +401,8 @@ the `initialize` handshakes exercised live. Answers adopted here:
 Genuinely open, deferred to the runner work (and the follow-up ADRs named):
 
 - **The session-spec resolver** (decision 5): shorthand matching over usable
-  catalogs, recency tiebreak, `preferred_backends` semantics and default
-  order — a follow-up ADR.
+  catalogs, recency tiebreak, and `preferred_backends` semantics are decided
+  by ADR 0034; catalog wire shape and preference identifiers remain open there.
 - **Permission policy defaults and UI**: auto-allow/allow-safe/ask tiers,
   timeout behavior, ADR 0018 notification shape.
 - **Adapter distribution and binary policy**: bundling vs `npx`, pin cadence,

--- a/docs/adr/0033-session-backends-and-semantic-capability-boundaries.md
+++ b/docs/adr/0033-session-backends-and-semantic-capability-boundaries.md
@@ -219,17 +219,17 @@ Driven launches address what the caller actually chooses — a model, an
 effort, and a harness to run them in — with one spec syntax:
 
 ```text
-gmux agent prompt --new anthropic/claude-fable-5:low@pi 'review this branch'
+gmux agent prompt --new --model anthropic/claude-fable-5:low@pi 'review this branch'
 ```
 
 `model:effort@harness` is the canonical long-term surface for driven
-launches, replacing the `--adapter` + `--model` flag pair as those verbs
-mature. The harness names the identity (decision 1); the drive mode is not
-part of the spec — gmux selects it per the harness's available backends and
-the user's `preferred_backends` configuration (shipped with a sane default
-order). Every component is optional shorthand in practice: the **resolver**
+launches, carried by `--model` and replacing the separate `--adapter` flag
+as those verbs mature (the positional argument remains the session address,
+per ADR 0027/0031). The harness names the identity (decision 1); the drive
+mode is not part of the spec — gmux selects it per the harness's available
+modes. Every component is optional shorthand in practice: the **resolver**
 — unique whole-token shorthand matching over the usable catalogs, recency
-tiebreak, and the `preferred_backends` semantics — is deliberately **not
+tiebreak, and the `preferred_harnesses` semantics — is deliberately **not
 specified here** and is reserved for a follow-up ADR. This ADR fixes only
 the canonical shape and that resolution operates over (harness, mode) pairs
 whose capability sets this document defines.
@@ -401,8 +401,8 @@ the `initialize` handshakes exercised live. Answers adopted here:
 Genuinely open, deferred to the runner work (and the follow-up ADRs named):
 
 - **The session-spec resolver** (decision 5): shorthand matching over usable
-  catalogs, recency tiebreak, and `preferred_backends` semantics are decided
-  by ADR 0034; catalog wire shape and preference identifiers remain open there.
+  catalogs, recency tiebreak, and `preferred_harnesses` semantics are decided
+  by ADR 0034; catalog wire shape remains open there.
 - **Permission policy defaults and UI**: auto-allow/allow-safe/ask tiers,
   timeout behavior, ADR 0018 notification shape.
 - **Adapter distribution and binary policy**: bundling vs `npx`, pin cadence,

--- a/docs/adr/0033-session-backends-and-semantic-capability-boundaries.md
+++ b/docs/adr/0033-session-backends-and-semantic-capability-boundaries.md
@@ -2,8 +2,8 @@
 
 **Status:** Accepted
 **Date:** 2026-08-02
-**Related:** ADR 0009 (verb-first CLI), ADR 0013 (codex authoritative state via hooks), ADR 0015 (hook translation at the agent side), ADR 0021 (ACP as the normalized conversation schema), ADR 0023 (unified turn model), ADR 0027 (semantic agent CLI and result-bearing wait), ADR 0028 (CLI output channels), ADR 0029 (agent sessions abstract runner residency), ADR 0030 (exchange-oriented reads and observational wait), ADR 0031 (session ID issuance), ADR 0032 (session input doors)
-**Amends:** ADR 0027 §1 (the "Claude/Codex support are follow-ups" clause — the follow-up is an ACP backend, not the terminal path)
+**Related:** ADR 0009 (verb-first CLI), ADR 0013 (codex authoritative state via hooks), ADR 0015 (hook translation at the agent side), ADR 0021 (ACP as the normalized conversation schema), ADR 0022 (adapter-opaque conversation refs), ADR 0023 (unified turn model), ADR 0027 (semantic agent CLI and result-bearing wait), ADR 0028 (CLI output channels), ADR 0029 (agent sessions abstract runner residency), ADR 0030 (exchange-oriented reads and observational wait), ADR 0031 (session ID issuance), ADR 0032 (session input doors)
+**Amends:** ADR 0027 §1 (the "Claude/Codex support are follow-ups" clause — the follow-up is the ACP drive mode, not the terminal path)
 
 ## Context
 
@@ -55,217 +55,392 @@ and hook vocabularies are owned upstream, optimized for humans, and free to
 change without notice. Emulating a user against them yields a contract whose
 every clause rests on an unfalsifiable timing or keybinding assumption.
 
-Meanwhile ADR 0021 already anticipated ACP-native, terminal-less adapters,
-and draft PR #388 holds the gmux-native conversation UI seam (streaming
-text/thinking/tool-calls). ACP is the interface Claude and Codex *do* offer
-for automation: structured prompts, streaming updates, tool calls, permission
-requests, and cancellation — asserted facts, not scraped ones.
+ACP is the interface Claude and Codex *do* offer for automation. ADR 0021
+already anticipated ACP-native, terminal-less operation, and draft PR #388
+holds the gmux-native conversation UI seam (streaming
+text/thinking/tool-calls). An ACP contract spike (report of 2026-08-02,
+`.grove/acp-contract-spike/`) then verified the ground truth against the
+protocol (v1 stable, v2 draft) and both current first-party adapters
+(`claude-agent-acp` 0.64.0, `codex-acp` 1.1.8, live `initialize` handshakes
+plus pinned-source analysis): ACP as implemented can express essentially the
+whole `gmux agent` contract — **including mid-turn steering distinct from a
+queued follow-up**, via the `_session/steering` extension both adapters
+implement and advertise. Readiness is the `initialize` response instead of
+elapsed-time guesses; submission is a JSON-RPC request instead of
+focus-dependent keystrokes; turn completion is the `session/prompt` response
+instead of a compensating wait; and permission dialogs are requests gmux
+answers instead of key semantics changing underneath a blind writer. Every
+failure cited in the #438/#439 post-mortems has a structural fix here.
 
 ## Decision
 
-### 1. Capabilities attach to the session backend, not the harness name
+### 1. The harness is the identity; capabilities attach to the (harness, mode) pair
 
-A session's capability set is determined by **backend** — the transport and
-contract through which gmux hosts the agent — not by which agent runs inside.
-"A Claude session" is not one thing: a Claude **terminal** session and a
-Claude **ACP** session are different session kinds with different capability
-sets, different configuration surfaces, and potentially different identity
-and lifecycle semantics. Adapter names stop implying capabilities; the
-backend a session was created on decides what gmux may claim about it.
+A session's identity is its **harness** — pi, claude, codex — plus its gmux
+session id and the harness's native conversation. There is one adapter per
+harness. What varies is the **drive mode**: the backend through which gmux
+hosts and drives that harness. Two backends exist:
 
-Two backends exist under this ADR:
+- **Terminal mode** — the existing PTY session: a real process on a durable
+  PTY, attachable, raw-sendable, tailable, with whatever *observational*
+  facts the adapter's hook/extension and native storage trustworthily
+  provide (ADR 0011/0013/0015). Semantic control in this mode requires the
+  ADR 0027 contract to be source-asserted, which today only pi's in-repo
+  extension does.
+- **ACP mode (planned)** — a runner speaking the Agent Client Protocol to a
+  terminal-less agent process: `initialize` as the readiness barrier,
+  `session/new`/`session/load`, structured prompt turns, streaming
+  `session/update` (natively ADR 0021's schema), tool calls, permission
+  requests, cancellation, and the `session/prompt` response as the stable
+  completion boundary, rendered in gmux-native UI (PR #388 is the seam). No
+  PTY exists; there is no screen to tail and nothing to attach to.
 
-- **Terminal backend** — the existing PTY session: a real process on a
-  durable PTY, attachable, raw-sendable, tailable, with whatever
-  *observational* facts the adapter's hook/extension and native storage
-  trustworthily provide (ADR 0011/0013/0015). Semantic control on this
-  backend requires the ADR 0027 contract to be source-asserted, which today
-  only pi's in-repo extension does.
-- **ACP backend (planned)** — a runner speaking the Agent Client Protocol to
-  a terminal-less agent process: structured prompt turns, streaming
-  `session/update`, tool calls, permission requests, cancellation, and
-  stable completion boundaries, normalized per ADR 0021 and rendered in
-  gmux-native UI (PR #388 is the seam). No PTY exists; there is nothing to
-  attach to and no screen to tail.
+Capabilities are a property of the **(harness, mode) pair**, not of the
+harness name alone and not of the mode alone. "A Claude session" is one
+identity — one harness, one native conversation store, one gmux session id —
+that at any moment is being driven in one mode; which verbs it supports
+follows from the pair. Adapter names stop implying capabilities.
 
-### 2. Claude and Codex terminal sessions are interactive-only
+Internally this is a per-adapter seam, not a second adapter: alongside the
+existing terminal seams (argv/hook translation, storage renderers), an
+adapter that supports ACP mode implements a "how to drive this harness via
+ACP" interface — adapter process/argv, initialize expectations, extension
+capabilities to honor (`_meta.steering.supported`), and native-storage
+mapping so both modes read the same conversations. Modeling `claude` and
+`claude-acp` as separate adapters or session kinds is explicitly rejected:
+it would fragment one conversation identity across two names, duplicate
+catalogs and configuration, and turn mode conversion (decision 6) into a
+cross-identity migration.
+
+### 2. Claude and Codex terminal-mode sessions are interactive-only
 
 `gmux -- claude` and `gmux -- codex` remain plain interactive terminal
-sessions. They keep everything the terminal backend honestly provides:
-launch, attach, raw `send`, `tail`, hook-driven active/idle status, titles,
+sessions. They keep everything terminal mode honestly provides: launch,
+attach, raw `send`, `tail`, hook-driven active/idle status, titles,
 attribution, retention, resume-by-relaunch, and observational transcript
-reads from native storage where implemented. They gain no semantic control:
-`gmux agent prompt` (including `--follow-up`/`--steer`), `gmux agent cancel`,
-and `gmux agent prompt --new --adapter claude|codex` refuse these sessions.
+reads from native storage (the review-hardened renderers salvaged from the
+closed PRs — see Consequences). They gain no semantic control in this mode:
+`gmux agent prompt` (plain and `--follow-up`), `gmux agent cancel`, and
+driven launches targeting terminal-mode Claude/Codex refuse, and `--steer`
+refuses **permanently** (decision 3).
 
 `gmux wait` remains universal (ADR 0027 §11): it synchronizes on any
 session's activity, including hook-observed Claude/Codex turns, with the
 fidelity the hooks actually provide (Codex's outcome-less `Stop` stays
-coarse, per ADR 0013). It is result-bearing only where the backend asserts
+coarse, per ADR 0013). It is result-bearing only where the mode asserts
 results; on Claude/Codex terminal sessions it never fabricates an exchange
 report from a screen.
 
-### 3. Refusal is explicit, permanent-shaped, and names the working path
+### 3. Refusal is explicit, names the boundary, and states the remedy
 
-A semantic action against a terminal session whose adapter does not
+A semantic action against a terminal-mode session whose adapter does not
 source-assert the contract fails **before any delivery**, with an error that
-names the backend boundary rather than a transient condition:
+names the mode boundary rather than a transient condition:
 
 ```text
 gmux: claude terminal sessions are interactive-only; semantic control
-requires a Claude ACP session (not yet available). Use gmux send / gmux tail
-to drive this session, or gmux attach to take over.
+requires the session in ACP mode. Use gmux send / gmux tail to drive this
+session, or gmux attach to take over.
 ```
 
 The refusal is a capability fact in the `unsupported_adapter` family of the
 established error taxonomy (ADR 0027's 2026-07-27 amendment): checked and
-reported before readiness, activity, or residency, because "this session
-kind cannot do that" is permanent and actionable while the others are
-transient. It never degrades to raw input — a semantic verb must not
-silently become keystrokes (ADR 0027 §3's loud-failure rule applies at this
-boundary too). Once the ACP backend exists, the parenthetical points at how
-to create the capable session kind instead.
+reported before readiness, activity, or residency, because "this session in
+this mode cannot do that" is permanent-shaped and actionable while the
+others are transient. It never degrades to raw input — a semantic verb must
+not silently become keystrokes (ADR 0027 §3's loud-failure rule applies at
+this boundary too).
 
-### 4. Claude/Codex semantic control is delivered on the ACP backend
+The refusals are not all the same shape:
+
+- **`prompt` and `--follow-up` are refused initially, with a documented
+  future path.** Delivering work has a correct mode available; once mode
+  conversion (decision 6) and the ACP runner exist, an explicit
+  `--convert` flag may perform the idle-gated convert-then-deliver as one
+  command. This stays opt-in and explicit — a plain prompt never converts a
+  session's mode as a side effect.
+- **`--steer` is refused permanently on terminal mode.** Steering means
+  injecting text into a turn that is *right now* mutating the screen and its
+  key semantics — the exact moment a Claude permission dialog can appear and
+  turn the submission Enter into "approve whatever is on screen". There is
+  no future flag that makes that safe. The remedies are stated in the error:
+  attach and type (a human can see the dialog), or convert the session to
+  ACP mode, where steering is a first-class request.
+
+### 4. Claude/Codex semantic control is delivered in ACP mode
 
 The ADR 0027–0030 contract for Claude and Codex — launch, prompt, follow-up,
 steer, cancel, result-bearing wait, exchange logs — is implemented by the
-upcoming ACP runner, where readiness is protocol initialization, submission
-is a `session/prompt` request, completion is a protocol response, results
-arrive as structured updates, and permission requests are first-class events
-rather than key-stealing dialogs. ADR 0027 §4's forward reference ("future
-ACP-native runners set ready after protocol initialization") becomes the
-plan of record for these harnesses.
+upcoming ACP runner, on the mechanics the spike verified:
+
+- **Readiness** is the `initialize` round-trip; session existence is the
+  `session/new`/`session/load` response. No elapsed-time policy.
+- **Steer** is the `_session/steering` extension (not v1 core), gated at
+  runtime on `InitializeResponse._meta.steering.supported` — advertised by
+  both current adapters, verified live. Its injection semantics match pi's
+  merged loop ("one loop is one turn", ADR 0027's 2026-07-28 amendment), so
+  ADR 0030's observational wait needs no changes in kind. Where the
+  capability is absent or a raced idle steer starts a new turn, gmux reports
+  honestly rather than pretending.
+- **Follow-up** is serialized **uniformly in the gmux runner**: at most one
+  outstanding `session/prompt` per session, queued follow-ups delivered on
+  idle. Claude's adapter-native prompt queueing exists but is deliberately
+  not used as the mechanism — the two adapters differ (Codex leaves
+  concurrent prompts undefined), and one runner-side queue keeps behavior
+  adapter-independent and preserves "follow-up on idle acts like plain
+  prompt".
+- **Cancel** is `session/cancel`, with the spec-required `cancelled` stop
+  reason mapping to gmux's *interrupted*.
+- **Turn close** is the `session/prompt` JSON-RPC response; because updates
+  and the response share one ordered pipe, ADR 0027 §9's
+  content-before-turn-end barrier holds by transport construction. The v1
+  response carries only a stop reason, so **gmux assembles the result** from
+  the typed update stream (terminal prose, iteration segmentation at
+  tool/thought boundaries) — the same class of work the pi extension does,
+  from typed events instead of a PTY.
+- **Waiting-on-user is first-class**: a pending `session/request_permission`
+  or elicitation *is* the waiting state, distinguishable from active work —
+  the exact fact #438 could not get from Claude hooks. The corollary is a
+  genuinely new obligation: **gmux is the ACP client and must own the
+  permission-answering policy** (auto-allow / allow-safe / ask, surfaced
+  through ADR 0018 notifications and the web UI, with a default and timeout
+  story before unattended orchestration is safe).
 
 An ACP session is **not a pretend terminal**. gmux does not synthesize a PTY
-around it, `attach` and `tail` do not apply, and its UI is the gmux-native
-conversation view. Where the semantic contract and ACP's expressiveness
-disagree, the resolution is designed in the ACP runner work with honest
-degradation (decision 7's open questions), never by falling back to terminal
-emulation.
+around it, `attach`/`tail` do not apply (their exact CLI behavior for
+terminal-less sessions is an open question below), and its UI is the
+gmux-native conversation view. Where the semantic contract and ACP's
+expressiveness disagree, the resolution is designed in the ACP runner work
+with honest degradation, never by falling back to terminal emulation.
 
-### 5. Pi remains terminal-first with full semantic control
+### 5. The canonical session spec is `model:effort@harness`
 
-Pi keeps its terminal backend and its complete semantic capability set. This
-is the rule of decision 1 applied, not an exception to it: pi's terminal
-*is* part of its product value — extensions, custom renderers, direct human
+Driven launches address what the caller actually chooses — a model, an
+effort, and a harness to run them in — with one spec syntax:
+
+```text
+gmux agent prompt --new anthropic/claude-fable-5:low@pi 'review this branch'
+```
+
+`model:effort@harness` is the canonical long-term surface for driven
+launches, replacing the `--adapter` + `--model` flag pair as those verbs
+mature. The harness names the identity (decision 1); the drive mode is not
+part of the spec — gmux selects it per the harness's available backends and
+the user's `preferred_backends` configuration (shipped with a sane default
+order). Every component is optional shorthand in practice: the **resolver**
+— unique whole-token shorthand matching over the usable catalogs, recency
+tiebreak, and the `preferred_backends` semantics — is deliberately **not
+specified here** and is reserved for a follow-up ADR. This ADR fixes only
+the canonical shape and that resolution operates over (harness, mode) pairs
+whose capability sets this document defines.
+
+### 6. Mode conversion is an explicit relaunch, never a live switch
+
+A session's drive mode can change through one lifecycle operation:
+**"Relaunch as ACP" / "Relaunch as Terminal"**. It keeps the same gmux
+session id and the same harness conversation, ends the current incarnation,
+and starts one in the other mode using the **harness's native resume**
+(`session/load` on the ACP side; `--resume`-style relaunch on the terminal
+side) — the same continuation both tools perform themselves. It is not live
+switching: there is no moment where one conversation is served by both
+modes, and no implicit conversion ever happens as a side effect of another
+verb (the future `--convert` of decision 3 is this operation, invoked
+explicitly).
+
+Preconditions and honesty requirements:
+
+- **Idle-gated.** Conversion waits for the current activity to settle
+  (ADR 0023's turn axis); it never tears down a mid-turn incarnation.
+- **Confirmed.** The user (or the flag-bearing caller) confirms a prompt
+  that enumerates what may be lost: unsubmitted composer text, and any
+  in-flight UI state the native resume does not carry.
+- **Version-skew warning for Claude.** The ACP adapter runs the SDK-bundled
+  Claude binary, not the user's installed CLI (spike risk 5), so a converted
+  session may continue under a different Claude Code version than the
+  terminal it left; the confirmation says so. (`CODEX_PATH` lets Codex run
+  the user's binary; a corresponding `CLAUDE_CODE_EXECUTABLE` policy is an
+  ACP-runner design question.)
+- **Composer preservation is future work**, best-effort by construction:
+  for third-party TUIs a `$EDITOR`-hotkey capture (open the composer content
+  in an editor gmux can read) is the candidate; for pi, a native extension
+  command can return the draft exactly. Until then the confirmation names
+  the composer as at-risk.
+
+### 7. Pi remains terminal-first with full semantic control
+
+Pi keeps its terminal mode and its complete semantic capability set. This is
+decision 1's rule applied, not an exception to it: pi's terminal *is* part
+of its product value — extensions, custom renderers, direct human
 intervention mid-session — and the in-repo extension gives gmux both sides
 of the interface, which is exactly the condition under which a terminal can
-source-assert the contract. No pi ACP session is planned; nothing here
-precludes one later, as its own session kind under the same rule.
+source-assert the contract. No pi ACP mode is planned; nothing here
+precludes one later, as a second mode of the same adapter under the same
+rule.
 
-### 6. The product rule
+### 8. The product rule
 
 **Use the native terminal when the terminal is part of the agent's value;
 use ACP when the terminal is merely a UI around an automatable agent.** For
 pi the terminal is the product surface. For Claude and Codex the terminal is
 one client of an agent that offers a structured protocol for exactly the
 control gmux wants; automating the human client instead of speaking the
-protocol was the category error both PRs paid for.
+protocol was the category error both closed PRs paid for.
 
-### 7. Capability matrix
+### 9. Capability matrix
 
-Capabilities by harness × backend. "Refused" is decision 3's explicit error;
-"n/a" means the surface does not exist on that backend.
+Capabilities by (harness, mode). "Refused" is decision 3's explicit error;
+"n/a" means the surface does not exist in that mode. ACP-mode columns are
+planned, on the spike's verified mechanics.
 
-| Capability | pi · terminal | claude · terminal | codex · terminal | claude/codex · ACP (planned) |
-|---|---|---|---|---|
-| launch (`gmux --` / `-d` / launcher) | yes | yes | yes | yes (ACP runner spawn) |
-| attach / raw `send` / `tail` | yes | yes | yes | n/a (no PTY; gmux-native UI) |
-| hook/event status (active/idle, error) | yes (extension) | yes (hooks) | yes (hooks ≥ 0.135, coarse Stop) | yes (protocol events) |
-| titles, attribution, retention, resume-by-relaunch | yes | yes | yes | per ACP session identity (open) |
-| observational transcript reads (`agent logs`) | yes | salvage pending (see Consequences) | salvage pending | yes (normalized updates/storage) |
-| `gmux wait` synchronization | yes | yes (hook fidelity) | yes (hook fidelity, outcome-less Stop) | yes |
-| result-bearing wait / exchange report | yes | refused / no result claim | refused / no result claim | yes |
-| `agent prompt` (plain / `--follow-up` / `--steer`) | yes | refused | refused | yes (steer expressibility open) |
-| `agent cancel` | yes | refused | refused | yes (`session/cancel`) |
-| `agent prompt --new` | yes | refused | refused | yes |
+| Capability | pi · terminal | claude · terminal | codex · terminal | claude · ACP (planned) | codex · ACP (planned) |
+|---|---|---|---|---|---|
+| launch (`gmux --` / `-d` / launcher) | yes | yes | yes | yes (ACP runner spawn) | yes |
+| driven launch (`prompt --new`, session spec §5) | yes | refused | refused | yes | yes |
+| attach / raw `send` / `tail` | yes | yes | yes | n/a (no PTY; gmux-native conversation UI) | n/a |
+| observational status (active/idle, error) | yes (extension) | yes (hooks) | yes (hooks ≥ 0.135, coarse Stop) | yes (protocol events) | yes |
+| waiting-on-user, distinguishable | yes | no (hooks cannot) | no | yes (permission/elicitation requests) | yes |
+| titles, attribution, retention, resume | yes | yes | yes | yes (`session/load`, stable ids) | yes |
+| observational reads (`agent logs`, native storage) | yes | yes (#448) | yes (#450) | yes (same native storage) | yes |
+| `gmux wait` synchronization | yes | yes (hook fidelity) | yes (hook fidelity) | yes | yes |
+| result-bearing wait / exchange report | yes | refused / no result claim | refused / no result claim | yes (gmux-assembled, v1) | yes |
+| `agent prompt` (plain / `--follow-up`) | yes | refused (future: explicit `--convert`) | refused (future: explicit `--convert`) | yes (runner-serialized queue) | yes |
+| `agent prompt --steer` | yes | **refused permanently** | **refused permanently** | yes (`_session/steering`, capability-gated) | yes |
+| `agent cancel` | yes | refused | refused | yes (`session/cancel`) | yes |
+| explicit mode relaunch (§6) | n/a (single mode) | → ACP (planned) | → ACP (planned) | → terminal (planned) | → terminal (planned) |
 
-### 8. Non-goals
+### 10. Non-goals
 
-- **No live backend switching.** A session is created on one backend and
-  stays there for its lifetime. There is no "upgrade this terminal session
-  to ACP" or the reverse.
-- **No transparent conversion.** A terminal conversation and an ACP
-  conversation may differ in identity, configuration (settings/MCP/plugins
-  loading), and lifecycle semantics; gmux does not claim that continuing one
-  as the other preserves meaning, and does not attempt it.
+- **No live mode switching.** One incarnation, one mode; conversion is a
+  full relaunch under decision 6's gates, never a hot handover.
+- **No implicit conversion.** No verb changes a session's mode as a side
+  effect; the future `--convert` is explicit by name, idle-gated, and
+  confirmed.
+- **No claim of mode equivalence.** The two modes may differ in
+  configuration surface (settings/MCP/plugins loading, binary version) and
+  UI state; conversion states the differences (decision 6) rather than
+  papering over them.
 - **No pretend PTY for ACP sessions**, and no revival of TUI emulation for
   Claude/Codex under any flag.
-- **No inferred semantics on the terminal backend.** PTY output is
-  presentation data (ADR 0027 §9); no amount of screen parsing promotes a
-  terminal session into a semantically controllable one.
+- **No inferred semantics in terminal mode.** PTY output is presentation
+  data (ADR 0027 §9); no amount of screen parsing promotes a terminal
+  session into a semantically controllable one.
 
 ## Consequences
 
-- **Claude/Codex semantic control is consciously blocked on the ACP backend
+- **Claude/Codex semantic control is consciously blocked on the ACP runner
   landing.** We prefer the correct feature when ACP lands over a fragile TUI
   emulator now. The two-step interactive route (`gmux -d -- claude`, then
   `gmux send`/attach) keeps working throughout, as does hook-driven status.
-- **Salvage: the observational work survives.** PR #438's review-hardened
-  transcript pieces — parent-linked active-branch reconstruction with
+- **The observational work survived as salvage.** PR #438's review-hardened
+  Claude transcript pieces (parent-linked active-branch reconstruction,
   sidechain/meta privacy filtering, image-only boundaries, non-destructive
-  settings/hook injection — and PR #439's rollout JSONL renderer are
-  extraction candidates for follow-up PRs *without semantic-control claims*:
-  they serve `agent logs`-style reads and status fidelity on the terminal
-  backend, where storage parsing is trustworthy even though driving the TUI
-  is not.
+  settings/hook injection) landed as PR #448, and PR #439's Codex rollout
+  renderer as PR #450 — observational reads and status fidelity on terminal
+  mode, without semantic-control claims. The same native-storage parsers are
+  the read-without-resume path for ACP-mode sessions (ADR 0029 §3 forbids
+  resuming to read, and `session/load` requires a live adapter process), so
+  their fidelity is shared infrastructure for both modes — and must be
+  regression-tested against adapter/SDK upgrades, since the ACP adapters
+  write the same stores.
 - **ADR 0027 §1 is amended.** "Peer forwarding and Claude/Codex support are
-  follow-ups" now reads with this ADR's split: the follow-up for Claude/Codex
-  is the ACP backend, and the terminal backend never grows their semantic
-  verbs. ADR 0027's 2026-07-28 adapter-contract clause ("claude/codex do not
-  become result-bearing") is confirmed and made permanent for the terminal
-  backend. No other existing doc was found claiming terminal semantic
-  support for Claude/Codex: the website adapter/integration pages describe
-  only observational hooks, status, titles, and resume, which remain true.
-- **Session kinds become a real axis.** Stores, the CLI, and the web UI will
-  eventually need to distinguish a Claude terminal session from a Claude ACP
-  session (naming, launchers, capability checks). That design belongs to the
-  ACP runner work; this ADR fixes only that the axis exists and that
-  capability checks key on it.
-- **Error-message wording gains a second boundary.** Alongside ADR 0029's
-  activity-vocabulary rule, semantic refusals on terminal Claude/Codex name
-  the backend, not a missing feature flag or a "dead" anything.
+  follow-ups" now reads with this ADR's split: the follow-up for
+  Claude/Codex is the ACP drive mode, and terminal mode never grows their
+  steer verb (prompt/follow-up only via explicit conversion). ADR 0027's
+  2026-07-28 adapter-contract clause ("claude/codex do not become
+  result-bearing") is confirmed for terminal mode. No other existing doc was
+  found claiming terminal semantic support for Claude/Codex: the website
+  adapter/integration pages describe only observational hooks, status,
+  titles, and resume, which remain true.
+- **Mode becomes a real session axis.** Stores, the CLI, and the web UI will
+  need to carry and display the drive mode (launchers, capability checks,
+  the conversation-view-vs-terminal split, the relaunch operation). That
+  design belongs to the ACP runner work; this ADR fixes that the axis exists
+  within one harness identity and that capability checks key on the pair.
+- **gmux acquires a permission-answering obligation.** As the ACP client it
+  must answer `session/request_permission`/elicitations; policy, UI, and
+  timeout defaults are prerequisites for unattended ACP orchestration.
+- **Adapter versions become contract surface.** The first-party adapters
+  churn fast (the Codex adapter was replaced wholesale within months; the
+  Claude adapter releases near-daily). Mitigation is decided here: **pinned
+  adapter versions plus a conformance smoke suite** gmux runs against
+  adapter upgrades (initialize capabilities, steer/queue/cancel semantics,
+  taxonomy mapping, storage-parser compatibility).
+- **The v1→v2 protocol transition is contained by design.** ACP v2 (draft)
+  restructures exactly the lifecycle gmux depends on (prompt response
+  becomes acceptance-only; completion via `state_update`; `messageId`
+  upserts). The runner isolates the v1 lifecycle mapping behind one seam so
+  v2 is a mapping change, not a redesign — and v2 would upgrade today's
+  gmux-assembled result heuristics into exact facts.
 
-## Open questions deferred to the ACP implementation
+## Open questions deferred to the ACP runner implementation
 
-An ACP contract spike is running in parallel (`.grove/acp-contract-spike/`),
-building a coverage matrix of the ADR 0027–0032 contract against the ACP
-spec, `claude-code-acp`, and Codex's ACP support. Its findings are **pending
-input** to the ACP runner design; this ADR does not wait for them. Deferred:
+The ACP contract spike answered the questions this ADR's draft had deferred;
+its findings are source-verified against pinned adapter versions, with only
+the `initialize` handshakes exercised live. Answers adopted here:
 
-- **Steer vs follow-up expressibility.** Whether ACP can distinguish
-  mid-turn steering from a queued follow-up per adapter, and the honest
-  degradation if not (refuse `--steer`? cancel-and-reprompt with the
-  semantics stated?).
-- **Result boundaries and taxonomy mapping.** Whether each adapter's turn
-  completion reliably carries final content, and how
-  cancellation/API-error/process-death map onto ADR 0027 §8's
-  completed/interrupted/error.
-- **Waiting-on-user.** Whether permission requests and user questions are
-  distinguishable from active work well enough to surface as a first-class
-  state.
-- **Resume and identity.** `session/load` support per adapter, identity
-  stability across gmux restarts, and how ACP session identity composes with
-  ADR 0029's resumable-conversation handle.
-- **Configuration parity.** How close an ACP session's settings/MCP/plugin
-  surface comes to the interactive tool, and how the difference is stated to
-  users (decision 8's no-transparent-conversion rule is the floor).
-- **Privacy.** Whether hidden reasoning is excluded or marked in updates,
-  and how that composes with ADR 0030's rendering rules.
+- **Steer vs follow-up:** expressible. Steer via the `_session/steering`
+  extension, gated on `_meta.steering.supported`, merging into the running
+  turn like pi's loop; follow-up via **uniform runner-side serialization**
+  (decision 4) despite Claude's native queue, because Codex has none and one
+  queue keeps runner behavior adapter-independent.
+- **Result boundaries:** the prompt response closes the turn with the §9
+  barrier intact; gmux assembles terminal content from the typed stream
+  (v1 has no result payload; tool-only turns are detectably prose-free).
+- **Taxonomy:** `end_turn` → completed; `cancelled` after gmux's own cancel
+  → interrupted; JSON-RPC error (with Claude's structured `errorKind`) →
+  error; stdio EOF with a prompt in flight → error. `refusal`/`max_tokens`/
+  `max_turn_requests` classify as error-with-reason (they end the turn
+  without doing the work).
+- **Waiting-on-user:** first-class via pending permission/elicitation
+  requests; gmux must own the answering policy (decision 4).
+- **Reads without resume:** stay on the native-storage parsers (#448/#450);
+  `session/load` is the resume path, never the read path.
+- **Churn and protocol risk:** adapter pinning + conformance smoke suite;
+  v1 mapping behind one seam for v2 (Consequences).
+
+Genuinely open, deferred to the runner work (and the follow-up ADRs named):
+
+- **The session-spec resolver** (decision 5): shorthand matching over usable
+  catalogs, recency tiebreak, `preferred_backends` semantics and default
+  order — a follow-up ADR.
+- **Permission policy defaults and UI**: auto-allow/allow-safe/ask tiers,
+  timeout behavior, ADR 0018 notification shape.
+- **Adapter distribution and binary policy**: bundling vs `npx`, pin cadence,
+  `CLAUDE_CODE_EXECUTABLE`/`CODEX_PATH` alignment with the user's CLIs
+  (also feeds decision 6's skew warning).
+- **Process topology**: adapter process per session vs shared multiplexed
+  process (failure-domain coupling vs memory).
+- **v1 result-assembly fidelity**: whether iteration counts meet ADR 0030's
+  rendering promises before v2's `messageId`, to be validated at the ACP
+  runner's live gate — which must also exercise steering injection, cancel
+  latency, resume replay, and permission flows (the spike ran handshakes
+  only; the terminal path also looked fine until its live gate).
+- **`gmux tail`/attach behavior for terminal-less sessions**: polite refusal
+  naming `agent logs`/the web view, or a conversation rendering.
+- **Composer capture for conversion** (decision 6): `$EDITOR`-hotkey design
+  for foreign TUIs; pi extension command.
 
 ## Alternatives considered
 
 ### Keep hardening the terminal automation path
 
 Rejected. Both PRs demonstrated the failure is structural, not residual: for
-Claude every fix (readiness delays, focus/keybinding assumptions,
-modal handling) replaced one unverifiable timing assumption with another,
-against an interface whose owner may change any of it in a patch release;
-for Codex the required facts (readiness, turn identity, results) do not
-exist in the interface at all. A contract built on those foundations would
-be ADR 0027's loud-failure principle inverted — quiet lies instead of loud
-errors.
+Claude every fix (readiness delays, focus/keybinding assumptions, modal
+handling) replaced one unverifiable timing assumption with another, against
+an interface whose owner may change any of it in a patch release; for Codex
+the required facts (readiness, turn identity, results) do not exist in the
+interface at all. A contract built on those foundations would be ADR 0027's
+loud-failure principle inverted — quiet lies instead of loud errors.
+
+### Model claude/claude-acp as separate adapters or session kinds
+
+Rejected (an earlier draft of this ADR did exactly this). The conversation,
+its native storage, its titles, and its resume lineage belong to the
+harness; two session kinds would fragment one identity across two names,
+duplicate model catalogs and configuration, make the capability story a
+naming convention instead of a (harness, mode) fact, and turn mode
+conversion into a cross-identity migration with no principled owner for the
+shared conversation.
 
 ### Headless one-shot modes (`claude -p`, `codex exec`) as the semantic backend
 
@@ -280,18 +455,29 @@ vendors maintain for programmatic clients.
 Rejected as a plan. Hook vocabularies are upstream property with no
 committed timeline, and even a complete hook set still leaves *delivery*
 running through the TUI's focus/modal/keybinding surface — hooks fix
-observation, not control. Hooks remain the terminal backend's observational
+observation, not control. Hooks remain terminal mode's observational
 channel; if they improve, observation improves, and nothing here changes.
 
-### Attach capabilities to the adapter with per-verb feature flags
+### Delegate follow-up queueing to Claude's adapter-native queue
 
-Rejected. It encodes the false premise that "a Claude session" is one thing
-with a feature list, and invites exactly the drift this ADR closes: an
-adapter flag flipped on for a backend that cannot honor it. The backend is
-the unit that has a contract; capabilities follow it.
+Rejected. It exists (`_meta.claudeCode.promptQueueing`) and is clean in
+isolation, but Codex's adapter leaves concurrent prompts undefined, and two
+queueing regimes behind one verb is the adapter-dependent behavior this
+namespace exists to prevent. One runner-side queue, drained on idle, gives
+both harnesses the same phenotype and preserves gmux's "follow-up on idle
+acts like plain prompt" rule.
 
 ### Refuse Claude/Codex semantic verbs silently or degrade to raw send
 
-Rejected outright. Degrading a semantic verb to keystrokes is the
-old-runner hazard of ADR 0027 §3 reintroduced deliberately; silent refusal
-teaches callers nothing. The error names the boundary and the working path.
+Rejected outright. Degrading a semantic verb to keystrokes is the old-runner
+hazard of ADR 0027 §3 reintroduced deliberately; silent refusal teaches
+callers nothing. The error names the boundary and the working paths —
+send/attach, or mode conversion once it exists.
+
+### Allow implicit convert-on-prompt instead of an explicit `--convert`
+
+Rejected. A plain prompt that silently relaunches the session in another
+mode would change its binary version (Claude), its configuration surface,
+and its UI affordances as a side effect of delivering text — precisely the
+class of surprise decision 6's confirmation gate exists to prevent. The
+convenience is preserved as an explicit, flag-named opt-in.

--- a/docs/adr/0033-session-backends-and-semantic-capability-boundaries.md
+++ b/docs/adr/0033-session-backends-and-semantic-capability-boundaries.md
@@ -226,8 +226,9 @@ gmux agent prompt --new --model anthropic/claude-fable-5:low@pi 'review this bra
 launches, carried by `--model` and replacing the separate `--adapter` flag
 as those verbs mature (the positional argument remains the session address,
 per ADR 0027/0031). The harness names the identity (decision 1); the drive
-mode is not part of the spec — gmux selects it per the harness's available
-modes. Every component is optional shorthand in practice: the **resolver**
+mode is not part of the spec and is not a preference: a driven launch uses
+the mode in which the harness supports driven launch per the capability
+matrix (decision 9) — ACP for claude/codex, terminal for pi. Every component is optional shorthand in practice: the **resolver**
 — unique whole-token shorthand matching over the usable catalogs, recency
 tiebreak, and the `preferred_harnesses` semantics — is deliberately **not
 specified here** and is reserved for a follow-up ADR. This ADR fixes only

--- a/docs/adr/0033-session-drive-modes-and-semantic-capability-boundaries.md
+++ b/docs/adr/0033-session-drive-modes-and-semantic-capability-boundaries.md
@@ -1,4 +1,4 @@
-# ADR 0033: session backends and semantic capability boundaries
+# ADR 0033: session drive modes and semantic capability boundaries
 
 **Status:** Accepted
 **Date:** 2026-08-02
@@ -78,8 +78,8 @@ failure cited in the #438/#439 post-mortems has a structural fix here.
 
 A session's identity is its **harness** — pi, claude, codex — plus its gmux
 session id and the harness's native conversation. There is one adapter per
-harness. What varies is the **drive mode**: the backend through which gmux
-hosts and drives that harness. Two backends exist:
+harness. What varies is the **drive mode**: how gmux hosts and drives that
+harness. Two drive modes exist:
 
 - **Terminal mode** — the existing PTY session: a real process on a durable
   PTY, attachable, raw-sendable, tailable, with whatever *observational*
@@ -443,9 +443,9 @@ naming convention instead of a (harness, mode) fact, and turn mode
 conversion into a cross-identity migration with no principled owner for the
 shared conversation.
 
-### Headless one-shot modes (`claude -p`, `codex exec`) as the semantic backend
+### Headless one-shot modes (`claude -p`, `codex exec`) as the semantic transport
 
-Rejected as the backend. One-shot invocations discard the durable session:
+Rejected as the transport. One-shot invocations discard the durable session:
 no follow-up queue, no steering, no mid-turn observation, no
 permission-request surface, and a fresh process per prompt. ACP is the
 structured, session-holding version of the same idea and is what these

--- a/docs/adr/0034-driven-launch-model-resolution.md
+++ b/docs/adr/0034-driven-launch-model-resolution.md
@@ -66,15 +66,19 @@ advances — never an ambiguous guess.
    complete token of the model name (`sol` matches `gpt-5.6-sol`, not
    `solar`). This is **partial-name specification, not fuzzy matching** — no
    substring, prefix, or edit-distance search. A unique match resolves.
-3. **Recency selects among multiple matches**: the match most recently
-   launched through gmux wins. Ties without usable history (e.g. never-used
-   matches) fall to `preferred_harnesses` order across harnesses; if still
-   ambiguous, fail listing the canonical candidates — an agent retries
-   cheaply with a longer token. History never introduces a candidate the
-   corpus did not offer.
-4. **Effort default**: when effort is omitted, use the resolved model's most
+3. **Harness preference narrows first**: when matches span multiple
+   harnesses (the same model is often in scope in several), only the
+   matches from the highest-ranked harness in `preferred_harnesses` remain.
+   The shorthand never launches via a lower-ranked harness while a
+   higher-ranked one offers a match — use canonical `@harness` to override.
+4. **Recency selects among the remaining matches**: the one most recently
+   launched through gmux wins. With no usable history and multiple
+   remaining matches, fail listing the canonical candidates — an agent
+   retries cheaply with a longer token. History never introduces a
+   candidate the corpus did not offer.
+5. **Effort default**: when effort is omitted, use the resolved model's most
    recent gmux launch effort; otherwise the harness default.
-5. **Echo and freeze**: the resolved canonical form is printed at launch and
+6. **Echo and freeze**: the resolved canonical form is printed at launch and
    recorded in the session's durable state. Nothing ever re-resolves.
 
 A shorthand reaching no candidate fails with an error asking for a model.
@@ -82,16 +86,17 @@ There is no implicit default model.
 
 ### Configuration
 
-One new key: `preferred_harnesses`, an ordered preference used only for the
-no-history tie above, shipped with a sane default covering all supported
-harnesses so zero-config works. A future `default_model` may be added;
+One new key: `preferred_harnesses`, the ordered harness preference of rung
+3, shipped with a sane default covering all supported harnesses so
+zero-config works. It is per-user intent: one user routes shorthand `fable`
+via pi, another via claude, each without canonical specs. A future `default_model` may be added;
 initially an underspecified launch fails and asks.
 
 ### Stability convention
 
 Shorthand is a human/agent ergonomic affordance: `fable` means "the fable I
-last used", and switches to a new release only when the caller picks it once
-(canonically or via the picker). The echo makes each resolution visible and
+last used, via my preferred harness that offers it", and switches to a new
+release only when the caller picks it once (canonically or via the picker). The echo makes each resolution visible and
 the frozen record makes it auditable. Automation needing reproducibility
 uses the canonical form.
 

--- a/docs/adr/0034-driven-launch-model-resolution.md
+++ b/docs/adr/0034-driven-launch-model-resolution.md
@@ -7,198 +7,119 @@
 ## Context
 
 ADR 0033 defines `model:effort@harness` as the canonical session spec for
-driven launches and reserves shorthand resolution for this ADR. A caller should
-be able to ask for the current member of a model family without maintaining an
-alias every time a provider releases a version. That convenience must not make
-a launch depend on an arbitrary fuzzy match.
+driven launches and reserves shorthand resolution for this ADR. Callers want
+"the latest fable" to work without maintaining an alias per release; that
+convenience must not rest on arbitrary fuzzy matching.
 
-Pi's current matching demonstrates the failure. It selects the first fuzzy
-match across every model it knows, so `fable` can resolve to
-`amazon-bedrock/fable` even when the user has never configured Amazon Bedrock.
-The resulting launch fails. The shorthand is not the underlying problem: the
-candidate corpus admitted unusable models, and the match had no trustworthy
-ambiguity boundary.
+Pi's current behavior shows the failure: it picks the first fuzzy match across
+every model it knows, so `fable` can resolve to `amazon-bedrock/fable` — a
+provider the user never configured — and the launch fails. The corpus was
+wrong, not the shorthand idea.
 
-Resolution is also host-dependent. A driven launch may target another host,
-where installed harnesses and configured providers differ from the caller's.
-The same catalog data is needed by the web UI's new-session model picker; the
-CLI and UI must not invent separate availability rules.
+Resolution is host-dependent (installed harnesses and configured providers
+differ per host), and the same catalog data must drive the web UI model
+picker.
 
 ## Decision
 
 ### Scope
 
-Resolution applies only when gmux chooses the launch command: semantic/driven
-launches, including `gmux agent prompt --new`, and the web UI new-session flow.
-It runs daemon-side at launch time against the target host.
+Resolution applies only where gmux chooses the launch command: driven
+launches (`gmux agent prompt --new --model <spec>`) and the web UI
+new-session flow. It runs daemon-side at launch time against the target
+host. Interactive `gmux -- <harness>` is untouched.
 
-Interactive passthrough launch, `gmux -- <harness>`, is unchanged. gmux does not
-reinterpret a command the user supplied.
+### Candidate corpus: usable models only
 
-### Candidate corpus
+Shorthand resolution considers only models that are **usable** on the target
+host at resolution time: harness installed, provider configured and
+authenticated, model not deprecated. Unconfigured providers drop out before
+matching — the structural fix for the Bedrock failure.
 
-Shorthand resolution considers only **usable** catalog entries. A model is
-usable when, on the target host at resolution time:
-
-- the backend that can launch it is installed;
-- its provider is configured and authenticated; and
-- the model is not deprecated.
-
-Unavailable backends and providers therefore disappear before matching. This
-is the structural correction for the Bedrock failure: a provider the user
-cannot launch can never win shorthand resolution.
-
-Each backend capable of discovery advertises a model catalog containing:
-
-- canonical model identity;
-- usability status on that host;
-- version ordering, by release date or an explicit backend ordering;
-- model-family grouping;
-- the harness/drive information needed to launch it; and
-- backend-specific selection facts, including pi's scoped/featured marker
-  where applicable.
-
-Codex's `model/list` and Claude's model and effort config options establish that
-a catalog capability is feasible, but do not fix its wire shape. A backend
-that cannot provide a catalog degrades safely: its models remain launchable by
-exact canonical spec, but the backend contributes no candidates to token or
-history-based resolution. The same advertised catalogs feed the web model
+The corpus comes from a new adapter capability: a **model catalog** carrying
+canonical model identity, usability status, version ordering (release date or
+explicit), model-family grouping, and adapter-specific selection facts such as
+pi's scoped/featured flag. (Feasible today: Codex exposes `model/list`; Claude
+exposes model and effort as config options.) An adapter without a catalog
+degrades gracefully: its models resolve only via exact canonical spec and
+contribute no shorthand candidates. The same catalogs feed the web model
 picker, so picker visibility and shorthand eligibility share one source of
 truth.
 
-### Deterministic resolution ladder
+### Resolution ladder
 
-The resolver evaluates the following ladder in order. Each rung either produces
-a trustworthy result, fails explicitly, or advances; it never falls through
-after making an ambiguous choice.
+Deterministic; each rung produces a trustworthy result, fails explicitly, or
+advances — never an ambiguous guess.
 
-1. **Exact canonical form.** A complete spec such as
-   `anthropic/claude-fable-5:low@pi` is accepted verbatim. gmux performs no
-   model, effort, or harness inference. Ordinary launch validation can still
-   report that its explicitly named backend or credentials are unavailable.
-2. **Unique whole-token match over usable models.** A shorthand must equal a
-   complete token in a usable model name. Token boundaries are punctuation
-   boundaries in the catalog identity: `sol` matches `gpt-5.6-sol`, but does
-   not match `solar`. This is **partial-name specification, not fuzzy
-   matching**: there is no substring, prefix, edit-distance, or similarity
-   search.
-   - If all matches are members of one declared model family, select the
-     latest member by catalog version ordering. Thus `fable` advances from
-     fable 5 to fable 6 without an alias edit.
-   - If that family is available through multiple otherwise-equivalent launch
-     backends, select according to `preferred_backends`.
-   - If matches span distinct families, fail and list the canonical candidates.
-     gmux never guesses across families. A human can choose; an agent can retry
-     cheaply with another token or a canonical spec.
-3. **History as a constrained tiebreak and effort default.** Usage history has
-   exactly two responsibilities: it supplies the most recently used thinking
-   effort for the resolved model when effort was omitted, and breaks a tie
-   among candidates that remain otherwise equal. The most recent applicable
-   launch wins; frequency is irrelevant. History never introduces a candidate
-   absent from the current usable catalog and never overrides a family or
-   backend preference decision.
-4. **Echo and freeze.** Before launch, gmux prints the fully resolved canonical
-   `model:effort@harness` form. It records that same value in session metadata.
-   The session is thereafter bound to that value: resume, reads, and later
-   operations never re-run shorthand resolution.
+1. **Exact canonical form** (`anthropic/claude-fable-5:low@pi`) is used
+   verbatim, with no inference. Ordinary launch validation still applies.
+2. **Unique whole-token match** over the usable corpus: the shorthand must
+   equal a complete token of the model name (`sol` matches `gpt-5.6-sol`, not
+   `solar`). This is **partial-name specification, not fuzzy matching** — no
+   substring, prefix, or edit-distance search.
+   - Matches within one model family → pick the latest by catalog version
+     ordering, so `fable` tracks new releases with zero maintenance.
+   - Same family launchable through multiple harnesses →
+     `preferred_harnesses` order wins.
+   - Matches spanning distinct families → fail, listing the canonical
+     candidates. An agent retries cheaply with a longer token.
+3. **History** has exactly two jobs: default thinking effort for the resolved
+   model (its most recent launch) and tiebreak among otherwise-equal
+   candidates (recency, never frequency). History never introduces a
+   candidate the catalog did not offer.
+4. **Echo and freeze**: the resolved canonical form is printed at launch and
+   recorded in the session's durable state. Nothing ever re-resolves.
 
-If the supplied shorthand reaches no usable candidate, resolution fails with an
-error asking for a model and, where useful, naming discoverable choices. There
-is no implicit global default model in this decision.
+A shorthand reaching no usable candidate fails with an error asking for a
+model. There is no implicit default model.
 
 ### Configuration
 
-The only new configuration is `preferred_backends`, an ordered preference used
-when the same family has otherwise-equivalent usable launch choices. gmux ships
-a sane order covering every supported choice, so zero-config resolution works;
-choices unavailable on the target host naturally drop out with the corpus.
-
-A future `default_model` may remove the need to supply any model. It is omitted
-initially: an underspecified launch fails and asks for a model rather than
-silently acquiring a product-wide default.
+One new key: `preferred_harnesses`, an ordered preference shipped with a sane
+default covering all supported harnesses, so zero-config works — unavailable
+harnesses drop out of the corpus naturally. A future `default_model` may be
+added; initially an underspecified launch fails and asks.
 
 ### Stability convention
 
-Shorthand is a human and agent ergonomic affordance, not a reproducibility
-mechanism. Its meaning may intentionally advance when a new family member is
-released. The launch echo makes that choice visible and session metadata makes
-it auditable and permanent for that session. Automation requiring a stable
-choice uses the canonical form.
+Shorthand is a human/agent ergonomic affordance; its meaning legitimately
+advances when a new family member releases. The echo makes that visible and
+the frozen record makes it auditable. Automation needing reproducibility uses
+the canonical form.
 
 ## Consequences
 
-- Unconfigured providers cannot capture shorthand matches. Catalog usability,
-  rather than match ranking, enforces that property.
-- Family shorthand follows new releases without user-maintained configuration.
-  This depends on accurate family identity and version order from catalogs.
-- Ambiguity is cheap and explicit. Distinct-family matches return candidates
-  instead of embedding an unstable heuristic in a launch.
-- Multi-host launches resolve where they execute, so the target host's actual
-  installation and credentials govern availability.
-- CLI launches and the web picker consume the same catalog capability and
-  should agree about what can be launched.
-- A shorthand may resolve differently across time or hosts by design. The
-  canonical launch echo and frozen metadata are therefore required contract,
-  not optional diagnostics.
-- Backends without discovery support remain usable through canonical specs and
-  do not weaken resolution for other backends.
+- Resolution happens on the target host, so its actual installation and
+  credentials govern availability in multi-host launches.
+- Echo + freeze are required contract, not diagnostics: a shorthand may
+  resolve differently across time and hosts by design.
+- Family shorthand correctness depends on accurate family identity and
+  version ordering in catalogs (see open questions).
+- CLI resolution and the web picker consume one catalog capability and cannot
+  disagree about what is launchable.
 
 ## Rejected alternatives
 
-### User-maintained aliases
-
-Rejected. Aliases drift, require maintenance for every release, and fail the
-core requirement that “latest fable” keep working without a config edit. A
-canonical form already serves users who want a pinned name.
-
-### Auto-populate preference configuration from usage
-
-Rejected. This would create self-modifying configuration the user never wrote.
-History remains runtime data with the two narrow responsibilities above;
-configuration remains an explicit statement of preference.
-
-### Most-common-usage ranking
-
-Rejected. Frequency entrenches old choices and makes outcomes depend on an
-opaque lifetime count. Only recency may break an otherwise-equal tie or default
-effort.
-
-### Silent cross-backend or cross-provider fallback
-
-Rejected. A different backend or provider can change capabilities,
-configuration, billing, and privacy boundaries. Preference may choose among
-catalog-declared equivalent offerings; gmux does not silently reinterpret an
-unavailable explicit choice or cross an ambiguity boundary. It fails and lists
-candidates.
-
-### Substring or edit-distance fuzzy matching
-
-Rejected. These searches admit accidental neighbors and make the winner depend
-on catalog contents and ordering. Whole-token equality has a stable,
-explainable boundary.
-
-### Let history expand the catalog
-
-Rejected. A previously usable model may be removed, deprecated, logged out, or
-unavailable on the target host. Historical use is not evidence of present
-launchability.
+- **User-maintained aliases** — drift, require an edit per release, and fail
+  the "latest fable without config" requirement.
+- **Auto-populated preferences from usage** — self-modifying configuration
+  the user never wrote; history stays runtime data with its two narrow jobs.
+- **Most-common-usage ranking** — frequency entrenches old choices; recency
+  only, as tiebreaker.
+- **Silent cross-harness or cross-provider fallback** — changes capabilities,
+  configuration, and privacy semantics; fail with candidates instead.
+- **Substring/edit-distance fuzzy matching** — admits accidental neighbors;
+  whole-token equality has a stable, explainable boundary.
+- **History expanding the catalog** — past use is not evidence of present
+  launchability.
 
 ## Open questions
 
-- **Cross-backend family identity:** is family grouping declared by each
-  backend, reconciled in a shared registry, or inferred? Naming inference is a
-  material design risk: selecting the latest fable requires knowing that fable
-  5 and fable 6 belong to one family, including when different backends expose
-  them.
-- **Catalog wire shape:** request/response framing, refresh and invalidation,
-  authentication failure representation, version-order fields, and capability
-  negotiation remain implementation work.
-- **Pi scoping:** how pi's scoped/featured model list maps to usability and
-  ranking without creating a second candidate policy remains open.
-- **Existing-session model changes:** whether this resolver also serves
-  `gmux agent prompt` when an existing session permits changing model is not
-  decided here; this ADR governs launch selection.
-- **Backend preference identifiers:** ADR 0033 uses “backend” for terminal/ACP
-  drive modes while model availability can also span harnesses/providers. The
-  concrete values and equivalence key for `preferred_backends` must be fixed
-  with the catalog schema without changing the ordering rule above.
+- **Cross-harness model-family identity** — the one real design risk: "latest
+  fable" requires knowing fable-5 and fable-6 are one family, including when
+  different harnesses expose them. Declared per adapter, reconciled centrally,
+  or inferred from naming?
+- **Catalog capability wire shape**: framing, refresh/invalidation, and how
+  pi's scoped-model list maps to usability and ranking.
+- Whether this resolver also powers `gmux agent prompt` on existing sessions
+  that permit changing model; this ADR governs launch selection only.

--- a/docs/adr/0034-driven-launch-model-resolution.md
+++ b/docs/adr/0034-driven-launch-model-resolution.md
@@ -2,7 +2,7 @@
 
 **Status:** Accepted
 **Date:** 2026-08-02
-**Related:** ADR 0027 (semantic agent CLI), ADR 0029 (agent sessions abstract runner residency), ADR 0033 (session backends, capability boundaries, and canonical session spec)
+**Related:** ADR 0027 (semantic agent CLI), ADR 0029 (agent sessions abstract runner residency), ADR 0033 (session drive modes, capability boundaries, and canonical session spec)
 
 ## Context
 

--- a/docs/adr/0034-driven-launch-model-resolution.md
+++ b/docs/adr/0034-driven-launch-model-resolution.md
@@ -1,0 +1,204 @@
+# ADR 0034: driven-launch model resolution
+
+**Status:** Accepted
+**Date:** 2026-08-02
+**Related:** ADR 0027 (semantic agent CLI), ADR 0029 (agent sessions abstract runner residency), ADR 0033 (session backends, capability boundaries, and canonical session spec)
+
+## Context
+
+ADR 0033 defines `model:effort@harness` as the canonical session spec for
+driven launches and reserves shorthand resolution for this ADR. A caller should
+be able to ask for the current member of a model family without maintaining an
+alias every time a provider releases a version. That convenience must not make
+a launch depend on an arbitrary fuzzy match.
+
+Pi's current matching demonstrates the failure. It selects the first fuzzy
+match across every model it knows, so `fable` can resolve to
+`amazon-bedrock/fable` even when the user has never configured Amazon Bedrock.
+The resulting launch fails. The shorthand is not the underlying problem: the
+candidate corpus admitted unusable models, and the match had no trustworthy
+ambiguity boundary.
+
+Resolution is also host-dependent. A driven launch may target another host,
+where installed harnesses and configured providers differ from the caller's.
+The same catalog data is needed by the web UI's new-session model picker; the
+CLI and UI must not invent separate availability rules.
+
+## Decision
+
+### Scope
+
+Resolution applies only when gmux chooses the launch command: semantic/driven
+launches, including `gmux agent prompt --new`, and the web UI new-session flow.
+It runs daemon-side at launch time against the target host.
+
+Interactive passthrough launch, `gmux -- <harness>`, is unchanged. gmux does not
+reinterpret a command the user supplied.
+
+### Candidate corpus
+
+Shorthand resolution considers only **usable** catalog entries. A model is
+usable when, on the target host at resolution time:
+
+- the backend that can launch it is installed;
+- its provider is configured and authenticated; and
+- the model is not deprecated.
+
+Unavailable backends and providers therefore disappear before matching. This
+is the structural correction for the Bedrock failure: a provider the user
+cannot launch can never win shorthand resolution.
+
+Each backend capable of discovery advertises a model catalog containing:
+
+- canonical model identity;
+- usability status on that host;
+- version ordering, by release date or an explicit backend ordering;
+- model-family grouping;
+- the harness/drive information needed to launch it; and
+- backend-specific selection facts, including pi's scoped/featured marker
+  where applicable.
+
+Codex's `model/list` and Claude's model and effort config options establish that
+a catalog capability is feasible, but do not fix its wire shape. A backend
+that cannot provide a catalog degrades safely: its models remain launchable by
+exact canonical spec, but the backend contributes no candidates to token or
+history-based resolution. The same advertised catalogs feed the web model
+picker, so picker visibility and shorthand eligibility share one source of
+truth.
+
+### Deterministic resolution ladder
+
+The resolver evaluates the following ladder in order. Each rung either produces
+a trustworthy result, fails explicitly, or advances; it never falls through
+after making an ambiguous choice.
+
+1. **Exact canonical form.** A complete spec such as
+   `anthropic/claude-fable-5:low@pi` is accepted verbatim. gmux performs no
+   model, effort, or harness inference. Ordinary launch validation can still
+   report that its explicitly named backend or credentials are unavailable.
+2. **Unique whole-token match over usable models.** A shorthand must equal a
+   complete token in a usable model name. Token boundaries are punctuation
+   boundaries in the catalog identity: `sol` matches `gpt-5.6-sol`, but does
+   not match `solar`. This is **partial-name specification, not fuzzy
+   matching**: there is no substring, prefix, edit-distance, or similarity
+   search.
+   - If all matches are members of one declared model family, select the
+     latest member by catalog version ordering. Thus `fable` advances from
+     fable 5 to fable 6 without an alias edit.
+   - If that family is available through multiple otherwise-equivalent launch
+     backends, select according to `preferred_backends`.
+   - If matches span distinct families, fail and list the canonical candidates.
+     gmux never guesses across families. A human can choose; an agent can retry
+     cheaply with another token or a canonical spec.
+3. **History as a constrained tiebreak and effort default.** Usage history has
+   exactly two responsibilities: it supplies the most recently used thinking
+   effort for the resolved model when effort was omitted, and breaks a tie
+   among candidates that remain otherwise equal. The most recent applicable
+   launch wins; frequency is irrelevant. History never introduces a candidate
+   absent from the current usable catalog and never overrides a family or
+   backend preference decision.
+4. **Echo and freeze.** Before launch, gmux prints the fully resolved canonical
+   `model:effort@harness` form. It records that same value in session metadata.
+   The session is thereafter bound to that value: resume, reads, and later
+   operations never re-run shorthand resolution.
+
+If the supplied shorthand reaches no usable candidate, resolution fails with an
+error asking for a model and, where useful, naming discoverable choices. There
+is no implicit global default model in this decision.
+
+### Configuration
+
+The only new configuration is `preferred_backends`, an ordered preference used
+when the same family has otherwise-equivalent usable launch choices. gmux ships
+a sane order covering every supported choice, so zero-config resolution works;
+choices unavailable on the target host naturally drop out with the corpus.
+
+A future `default_model` may remove the need to supply any model. It is omitted
+initially: an underspecified launch fails and asks for a model rather than
+silently acquiring a product-wide default.
+
+### Stability convention
+
+Shorthand is a human and agent ergonomic affordance, not a reproducibility
+mechanism. Its meaning may intentionally advance when a new family member is
+released. The launch echo makes that choice visible and session metadata makes
+it auditable and permanent for that session. Automation requiring a stable
+choice uses the canonical form.
+
+## Consequences
+
+- Unconfigured providers cannot capture shorthand matches. Catalog usability,
+  rather than match ranking, enforces that property.
+- Family shorthand follows new releases without user-maintained configuration.
+  This depends on accurate family identity and version order from catalogs.
+- Ambiguity is cheap and explicit. Distinct-family matches return candidates
+  instead of embedding an unstable heuristic in a launch.
+- Multi-host launches resolve where they execute, so the target host's actual
+  installation and credentials govern availability.
+- CLI launches and the web picker consume the same catalog capability and
+  should agree about what can be launched.
+- A shorthand may resolve differently across time or hosts by design. The
+  canonical launch echo and frozen metadata are therefore required contract,
+  not optional diagnostics.
+- Backends without discovery support remain usable through canonical specs and
+  do not weaken resolution for other backends.
+
+## Rejected alternatives
+
+### User-maintained aliases
+
+Rejected. Aliases drift, require maintenance for every release, and fail the
+core requirement that “latest fable” keep working without a config edit. A
+canonical form already serves users who want a pinned name.
+
+### Auto-populate preference configuration from usage
+
+Rejected. This would create self-modifying configuration the user never wrote.
+History remains runtime data with the two narrow responsibilities above;
+configuration remains an explicit statement of preference.
+
+### Most-common-usage ranking
+
+Rejected. Frequency entrenches old choices and makes outcomes depend on an
+opaque lifetime count. Only recency may break an otherwise-equal tie or default
+effort.
+
+### Silent cross-backend or cross-provider fallback
+
+Rejected. A different backend or provider can change capabilities,
+configuration, billing, and privacy boundaries. Preference may choose among
+catalog-declared equivalent offerings; gmux does not silently reinterpret an
+unavailable explicit choice or cross an ambiguity boundary. It fails and lists
+candidates.
+
+### Substring or edit-distance fuzzy matching
+
+Rejected. These searches admit accidental neighbors and make the winner depend
+on catalog contents and ordering. Whole-token equality has a stable,
+explainable boundary.
+
+### Let history expand the catalog
+
+Rejected. A previously usable model may be removed, deprecated, logged out, or
+unavailable on the target host. Historical use is not evidence of present
+launchability.
+
+## Open questions
+
+- **Cross-backend family identity:** is family grouping declared by each
+  backend, reconciled in a shared registry, or inferred? Naming inference is a
+  material design risk: selecting the latest fable requires knowing that fable
+  5 and fable 6 belong to one family, including when different backends expose
+  them.
+- **Catalog wire shape:** request/response framing, refresh and invalidation,
+  authentication failure representation, version-order fields, and capability
+  negotiation remain implementation work.
+- **Pi scoping:** how pi's scoped/featured model list maps to usability and
+  ranking without creating a second candidate policy remains open.
+- **Existing-session model changes:** whether this resolver also serves
+  `gmux agent prompt` when an existing session permits changing model is not
+  decided here; this ADR governs launch selection.
+- **Backend preference identifiers:** ADR 0033 uses “backend” for terminal/ACP
+  drive modes while model availability can also span harnesses/providers. The
+  concrete values and equivalence key for `preferred_backends` must be fixed
+  with the catalog schema without changing the ordering rule above.

--- a/docs/adr/0034-driven-launch-model-resolution.md
+++ b/docs/adr/0034-driven-launch-model-resolution.md
@@ -8,17 +8,21 @@
 
 ADR 0033 defines `model:effort@harness` as the canonical session spec for
 driven launches and reserves shorthand resolution for this ADR. Callers want
-"the latest fable" to work without maintaining an alias per release; that
-convenience must not rest on arbitrary fuzzy matching.
+`fable` to work as a shorthand without maintaining aliases; that convenience
+must not rest on arbitrary fuzzy matching.
 
-Pi's current behavior shows the failure: it picks the first fuzzy match across
-every model it knows, so `fable` can resolve to `amazon-bedrock/fable` — a
-provider the user never configured — and the launch fails. The corpus was
-wrong, not the shorthand idea.
+Pi's current behavior shows the failure: it picks the first fuzzy match
+across every model it knows, so `fable` can resolve to
+`amazon-bedrock/fable` — a provider the user never configured — and the
+launch fails. The corpus was wrong, not the shorthand idea.
 
-Resolution is host-dependent (installed harnesses and configured providers
-differ per host), and the same catalog data must drive the web UI model
-picker.
+Each harness already maintains a user-facing notion of which models its own
+picker offers: pi's scoped-models list (`enabledModels`), Claude's
+`availableModels` settings allowlist over the SDK model list, Codex's
+non-hidden `model/list` catalog. gmux should resolve against that, not
+against a parallel model universe of its own. Resolution is host-dependent
+(installed harnesses and configured providers differ per host), and the same
+data must drive the web UI model picker.
 
 ## Decision
 
@@ -29,22 +33,27 @@ launches (`gmux agent prompt --new --model <spec>`) and the web UI
 new-session flow. It runs daemon-side at launch time against the target
 host. Interactive `gmux -- <harness>` is untouched.
 
-### Candidate corpus: usable models only
+### Candidate corpus: the harness's own in-scope, usable models
 
-Shorthand resolution considers only models that are **usable** on the target
-host at resolution time: harness installed, provider configured and
-authenticated, model not deprecated. Unconfigured providers drop out before
-matching — the structural fix for the Bedrock failure.
+Shorthand resolution considers only models that are, on the target host at
+resolution time:
 
-The corpus comes from a new adapter capability: a **model catalog** carrying
-canonical model identity, usability status, version ordering (release date or
-explicit), model-family grouping, and adapter-specific selection facts such as
-pi's scoped/featured flag. (Feasible today: Codex exposes `model/list`; Claude
-exposes model and effort as config options.) An adapter without a catalog
-degrades gracefully: its models resolve only via exact canonical spec and
-contribute no shorthand candidates. The same catalogs feed the web model
-picker, so picker visibility and shorthand eligibility share one source of
-truth.
+- **in scope for their harness** — the list the harness's own picker would
+  show, as the user configured it in the harness itself (pi's scoped models;
+  Claude's `availableModels` allowlist; Codex's non-hidden catalog); and
+- **usable** — harness installed, provider configured and authenticated.
+
+Unconfigured providers drop out before matching — the structural fix for the
+Bedrock failure. gmux introduces no model-curation surface of its own; scope
+is edited where it already lives, in each harness.
+
+The corpus comes from a new adapter capability: report the harness's
+in-scope model list with canonical identity (`provider/model` where the
+harness has providers), usability status, and available effort levels. An
+adapter without this capability degrades gracefully: its models resolve only
+via exact canonical spec and contribute no shorthand candidates. The same
+lists feed the web model picker, so picker visibility and shorthand
+eligibility share one source of truth.
 
 ### Resolution ladder
 
@@ -53,73 +62,81 @@ advances — never an ambiguous guess.
 
 1. **Exact canonical form** (`anthropic/claude-fable-5:low@pi`) is used
    verbatim, with no inference. Ordinary launch validation still applies.
-2. **Unique whole-token match** over the usable corpus: the shorthand must
-   equal a complete token of the model name (`sol` matches `gpt-5.6-sol`, not
+2. **Whole-token match** over the corpus: the shorthand must equal a
+   complete token of the model name (`sol` matches `gpt-5.6-sol`, not
    `solar`). This is **partial-name specification, not fuzzy matching** — no
-   substring, prefix, or edit-distance search.
-   - Matches within one model family → pick the latest by catalog version
-     ordering, so `fable` tracks new releases with zero maintenance.
-   - Same family launchable through multiple harnesses →
-     `preferred_harnesses` order wins.
-   - Matches spanning distinct families → fail, listing the canonical
-     candidates. An agent retries cheaply with a longer token.
-3. **History** has exactly two jobs: default thinking effort for the resolved
-   model (its most recent launch) and tiebreak among otherwise-equal
-   candidates (recency, never frequency). History never introduces a
-   candidate the catalog did not offer.
-4. **Echo and freeze**: the resolved canonical form is printed at launch and
+   substring, prefix, or edit-distance search. A unique match resolves.
+3. **Recency selects among multiple matches**: the match most recently
+   launched through gmux wins. Ties without usable history (e.g. never-used
+   matches) fall to `preferred_harnesses` order across harnesses; if still
+   ambiguous, fail listing the canonical candidates — an agent retries
+   cheaply with a longer token. History never introduces a candidate the
+   corpus did not offer.
+4. **Effort default**: when effort is omitted, use the resolved model's most
+   recent gmux launch effort; otherwise the harness default.
+5. **Echo and freeze**: the resolved canonical form is printed at launch and
    recorded in the session's durable state. Nothing ever re-resolves.
 
-A shorthand reaching no usable candidate fails with an error asking for a
-model. There is no implicit default model.
+A shorthand reaching no candidate fails with an error asking for a model.
+There is no implicit default model.
 
 ### Configuration
 
-One new key: `preferred_harnesses`, an ordered preference shipped with a sane
-default covering all supported harnesses, so zero-config works — unavailable
-harnesses drop out of the corpus naturally. A future `default_model` may be
-added; initially an underspecified launch fails and asks.
+One new key: `preferred_harnesses`, an ordered preference used only for the
+no-history tie above, shipped with a sane default covering all supported
+harnesses so zero-config works. A future `default_model` may be added;
+initially an underspecified launch fails and asks.
 
 ### Stability convention
 
-Shorthand is a human/agent ergonomic affordance; its meaning legitimately
-advances when a new family member releases. The echo makes that visible and
-the frozen record makes it auditable. Automation needing reproducibility uses
-the canonical form.
+Shorthand is a human/agent ergonomic affordance: `fable` means "the fable I
+last used", and switches to a new release only when the caller picks it once
+(canonically or via the picker). The echo makes each resolution visible and
+the frozen record makes it auditable. Automation needing reproducibility
+uses the canonical form.
 
 ## Consequences
 
-- Resolution happens on the target host, so its actual installation and
-  credentials govern availability in multi-host launches.
+- Resolution happens on the target host, so its actual installation,
+  credentials, and harness-side scope govern availability in multi-host
+  launches.
 - Echo + freeze are required contract, not diagnostics: a shorthand may
   resolve differently across time and hosts by design.
-- Family shorthand correctness depends on accurate family identity and
-  version ordering in catalogs (see open questions).
-- CLI resolution and the web picker consume one catalog capability and cannot
-  disagree about what is launchable.
+- Selection needs no model-family identity or version-ordering knowledge:
+  recency replaces "latest within a family". A newly released model is
+  adopted by using it once, not automatically.
+- CLI resolution and the web picker consume one adapter capability and
+  cannot disagree about what is launchable.
+- gmux launch history becomes resolution input and must be recorded per
+  (model, harness) with effort.
 
 ## Rejected alternatives
 
-- **User-maintained aliases** — drift, require an edit per release, and fail
-  the "latest fable without config" requirement.
+- **User-maintained aliases in gmux** — a second curation surface that
+  drifts from the harness-side scope; scope plus recency covers the need.
+- **Family/version machinery ("latest fable")** — requires cross-harness
+  model-family identity and version ordering that no harness reports today;
+  recency gives a simpler, more predictable meaning with zero new metadata.
 - **Auto-populated preferences from usage** — self-modifying configuration
-  the user never wrote; history stays runtime data with its two narrow jobs.
+  the user never wrote; history stays runtime data.
 - **Most-common-usage ranking** — frequency entrenches old choices; recency
-  only, as tiebreaker.
-- **Silent cross-harness or cross-provider fallback** — changes capabilities,
-  configuration, and privacy semantics; fail with candidates instead.
+  only.
+- **Silent cross-harness or cross-provider fallback** — changes
+  capabilities, configuration, and privacy semantics; fail with candidates
+  instead.
 - **Substring/edit-distance fuzzy matching** — admits accidental neighbors;
   whole-token equality has a stable, explainable boundary.
-- **History expanding the catalog** — past use is not evidence of present
-  launchability.
+- **History expanding the corpus** — past use is not evidence of present
+  scope or launchability.
 
 ## Open questions
 
-- **Cross-harness model-family identity** — the one real design risk: "latest
-  fable" requires knowing fable-5 and fable-6 are one family, including when
-  different harnesses expose them. Declared per adapter, reconciled centrally,
-  or inferred from naming?
-- **Catalog capability wire shape**: framing, refresh/invalidation, and how
-  pi's scoped-model list maps to usability and ranking.
+- **Adapter capability wire shape**: framing, refresh/invalidation, and the
+  per-harness mapping (pi exposes scoped models via RPC; Claude's list
+  requires the SDK/adapter or reading its settings; Codex's `model/list`
+  needs `hidden` filtering).
+- **Adapter-side recency as a cold-start hint**: pi persists a single
+  last-used model/effort default; whether adapters should report it to seed
+  resolution before any gmux history exists.
 - Whether this resolver also powers `gmux agent prompt` on existing sessions
   that permit changing model; this ADR governs launch selection only.


### PR DESCRIPTION
## Summary

Records two architecture decisions (docs-only; no production code changes).

### ADR 0033 — session drive modes and semantic capability boundaries

The decision behind closing PRs #438 and #439, updated with the ACP contract spike findings (`.grove/acp-contract-spike/`, 2026-08-02): **the harness (pi, claude, codex) is the session identity; terminal and ACP are drive modes of one adapter; capabilities attach to the (harness, mode) pair.**

- `gmux -- claude` / `gmux -- codex` remain plain interactive terminal sessions — attach, raw send, tail, hook-driven observational status, native-storage reads (salvage PRs #448/#450). Semantic verbs refuse with an explicit boundary-naming error, never degrading to raw input; `--steer` is **permanently refused** on terminal mode (permission-dialog Enter-hijack hazard).
- Claude/Codex semantic control lands in **ACP mode** on spike-verified mechanics: `initialize` as readiness, steer via the `_session/steering` extension, uniform runner-side follow-up serialization, prompt response as the §9-safe turn close, first-class waiting-on-user via permission requests.
- **Canonical session spec** for driven launches: `model:effort@harness`, carried by `--model` (the positional stays the session address). Drive mode is capability-determined for driven launches (ACP for claude/codex, terminal for pi), never a preference.
- **Explicit mode conversion** via native resume under the same gmux session id — idle-gated, user-confirmed, with a Claude binary version-skew warning. No live switching, no implicit conversion.
- ADR 0027 §1 amended with a pointer note.

### ADR 0034 — driven-launch model resolution

The resolver follow-up ADR 0033 reserves:

- resolution only for driven launches (`prompt --new --model <spec>`) and the web new-session flow; interactive `gmux -- <harness>` untouched; runs daemon-side against the target host
- corpus = **the harness's own in-scope list** (pi scoped models / Claude `availableModels` allowlist / Codex non-hidden `model/list`), filtered to usable — gmux adds no model-curation surface of its own
- deterministic ladder: exact canonical form → whole-token match (partial-name specification, not fuzzy) → **`preferred_harnesses` narrows cross-harness matches first** (fable in scope in both pi and claude launches via the user's preferred one) → **gmux launch recency** among the remaining matches, else fail listing candidates → effort default from history → echo + freeze in durable state
- no family/version machinery: recency replaces "latest within a family"; a new release is adopted by using it once
- rejected: gmux-side aliases, self-modifying config, frequency ranking, silent cross-harness/provider fallback, fuzzy matching

### Terminology

Aligned with UBIQUITOUS_LANGUAGE.md: "backend" retired for drive modes (ADR 0033 retitled/renamed accordingly), `preferred_harnesses` replaces `preferred_backends`, and glossary rows added for **harness**, **drive mode**, and **in-scope models**.

## Notes for review

- Open questions recorded in ADR 0034: adapter capability wire shape (Claude's list needs the SDK/adapter or settings parsing; Codex needs `hidden` filtering), adapter-side recency as a cold-start hint, resolver on existing sessions.
- Acknowledged future work, deliberately not designed here: launch-menu curation (enable/disable/reorder, custom launchables, per-project) and a UI default-launch-mode setting.
- Supersedes and absorbs #451.