### PR TITLE
feat(adapter): render Codex rollout exchanges for agent logs

### DIFF
--- a/packages/adapter/adapters/codex.go
+++ b/packages/adapter/adapters/codex.go
@@ -610,14 +610,101 @@ func extractCodexUserText(raw json.RawMessage) string {
 	return ""
 }
 
-// isCodexSystemContext returns true if the text looks like Codex's
-// injected system context rather than the user's actual prompt.
+// codexContextualUserMatchers mirrors Codex's contextual-user-message registry
+// rather than guessing from XML-looking text. Keep this list synchronized with
+// codex-rs/core/src/context/contextual_user_message.rs. The matcher source for
+// each registered form is named beside it so additions upstream are auditable.
+var codexContextualUserMatchers = []func(string) bool{
+	isCodexAgentsInstructions,             // context/user_instructions.rs
+	codexWrapped("environment_context"),   // context/world_state/environment.rs
+	isCodexPermissionsContext,             // context/world_state/permissions.rs
+	codexWrapped("skill"),                 // core-skills/src/skill_instructions.rs
+	codexWrapped("skills_instructions"),   // protocol/src/protocol.rs (legacy)
+	codexWrapped("user_shell_command"),    // context/user_shell_command.rs
+	codexWrapped("turn_aborted"),          // context/turn_aborted.rs
+	codexWrapped("subagent_notification"), // context/subagent_notification.rs
+	isCodexHookPrompt,                     // protocol/src/items.rs
+	isCodexInternalModelContext,           // context/internal_model_context.rs
+	codexWrapped("recommended_plugins"),   // context/recommended_plugins_instructions.rs
+	isCodexLegacyUnifiedExecWarning,       // context/legacy_unified_exec_process_limit_warning.rs
+	isCodexLegacyApplyPatchWarning,        // context/legacy_apply_patch_exec_command_warning.rs
+	isCodexLegacyModelMismatchWarning,     // context/legacy_model_mismatch_warning.rs
+}
+
+// isCodexSystemContext recognizes only complete upstream-generated forms. It
+// deliberately retains unknown XML and broad prefix lookalikes as user prompts.
 func isCodexSystemContext(s string) bool {
-	// Codex injects several system blocks before the user's actual prompt.
-	return strings.HasPrefix(s, "<permissions") ||
-		strings.HasPrefix(s, "<environment_context>") ||
-		strings.HasPrefix(s, "# AGENTS.md") ||
-		strings.HasPrefix(s, "<turn_aborted>")
+	s = strings.TrimSpace(s)
+	for _, matcher := range codexContextualUserMatchers {
+		if matcher(s) {
+			return true
+		}
+	}
+	return false
+}
+
+func codexWrapped(tag string) func(string) bool {
+	return func(s string) bool {
+		return strings.HasPrefix(s, "<"+tag+">") && strings.HasSuffix(s, "</"+tag+">")
+	}
+}
+
+func isCodexAgentsInstructions(s string) bool {
+	return strings.HasPrefix(s, "# AGENTS.md instructions") &&
+		strings.Contains(s, "\n<INSTRUCTIONS>") && strings.HasSuffix(s, "</INSTRUCTIONS>")
+}
+
+func isCodexPermissionsContext(s string) bool {
+	return codexWrapped("permissions")(s) ||
+		(strings.HasPrefix(s, "<permissions instructions>") && strings.HasSuffix(s, "</permissions instructions>"))
+}
+
+func isCodexHookPrompt(s string) bool {
+	const prefix = `<hook_prompt hook_run_id="`
+	if !strings.HasPrefix(s, prefix) {
+		return false
+	}
+	rest := s[len(prefix):]
+	end := strings.Index(rest, `">`)
+	return end > 0 && strings.HasSuffix(rest[end+2:], "</hook_prompt>")
+}
+
+func isCodexInternalModelContext(s string) bool {
+	if codexWrapped("goal_context")(s) { // legacy accepted by current Codex
+		return true
+	}
+	const prefix = `<codex_internal_context source="`
+	if !strings.HasPrefix(s, prefix) {
+		return false
+	}
+	rest := s[len(prefix):]
+	end := strings.Index(rest, `">`)
+	if end <= 0 || !validCodexContextSource(rest[:end]) {
+		return false
+	}
+	return strings.HasSuffix(rest[end+2:], "</codex_internal_context>")
+}
+
+func validCodexContextSource(source string) bool {
+	for i, r := range source {
+		if (r < 'a' || r > 'z') && (i == 0 || (r < '0' || r > '9') && r != '_') {
+			return false
+		}
+	}
+	return source != ""
+}
+
+func isCodexLegacyUnifiedExecWarning(s string) bool {
+	return strings.HasPrefix(s, "Warning: The maximum number of unified exec processes you can keep open is")
+}
+
+func isCodexLegacyApplyPatchWarning(s string) bool {
+	return strings.HasPrefix(s, "Warning: apply_patch was requested via ") &&
+		strings.HasSuffix(s, "Use the apply_patch tool instead of exec_command.")
+}
+
+func isCodexLegacyModelMismatchWarning(s string) bool {
+	return strings.HasPrefix(s, "Warning: Your account was flagged for potentially high-risk cyber activity")
 }
 
 // --- ConversationSource ---

--- a/packages/adapter/adapters/codex_conversation.go
+++ b/packages/adapter/adapters/codex_conversation.go
@@ -1,0 +1,189 @@
+package adapters
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+
+	"github.com/gmuxapp/gmux/packages/adapter"
+)
+
+var (
+	_ adapter.ConversationRenderer         = (*Codex)(nil)
+	_ adapter.ConversationExchangeRenderer = (*Codex)(nil)
+)
+
+// RenderConversation projects Codex's persisted rollout into visible user and
+// assistant messages. Canonical response_item messages take precedence over
+// legacy persisted deltas, which are used only when no completed message exists.
+func (c *Codex) RenderConversation(ref string) ([]adapter.ConversationMessage, error) {
+	rollout, err := readCodexRollout(ref)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]adapter.ConversationMessage, 0, len(rollout.messages))
+	for _, item := range rollout.messages {
+		if item.Text == "" {
+			continue
+		}
+		out = append(out, adapter.ConversationMessage{Role: item.Role, Text: item.Text, Prose: item.Text})
+	}
+	return out, nil
+}
+
+// RenderConversationExchanges reconstructs user-bounded exchanges. Current
+// Codex rollouts persist a non-null token_count event once for every completed
+// model response, after all of that response's message and tool-call items.
+// That marker—not an individual message or function call—is the iteration
+// boundary. This matters when one response mixes commentary and tools, and
+// when a tool-only final response must clear prose from an earlier response.
+func (c *Codex) RenderConversationExchanges(ref string) ([]adapter.Exchange, error) {
+	rollout, err := readCodexRollout(ref)
+	if err != nil {
+		return nil, err
+	}
+	var out []adapter.Exchange
+	for _, item := range rollout.exchanges {
+		switch item.Role {
+		case "user":
+			if item.Text == "" { // injected context is not an exchange boundary
+				continue
+			}
+			out = append(out, adapter.Exchange{Ordinal: uint64(len(out) + 1), User: item.Text})
+		case "response":
+			if len(out) == 0 {
+				continue
+			}
+			ex := &out[len(out)-1]
+			ex.Iterations++
+			ex.Terminal = item.Text // deliberately replace, including with empty
+		}
+	}
+	return out, nil
+}
+
+type codexMessage struct {
+	Role string
+	Text string
+}
+
+type codexRollout struct {
+	messages  []codexMessage
+	exchanges []codexMessage // roles are user and response
+}
+
+type codexRecord struct {
+	Type    string `json:"type"`
+	Payload struct {
+		Type    string          `json:"type"`
+		Role    string          `json:"role"`
+		Content json.RawMessage `json:"content"`
+		Delta   string          `json:"delta"`
+		Info    json.RawMessage `json:"info"`
+	} `json:"payload"`
+}
+
+func readCodexRollout(ref string) (codexRollout, error) {
+	data, err := os.ReadFile(ref)
+	if err != nil {
+		return codexRollout{}, err
+	}
+	var records []codexRecord
+	hasResponseMarkers := false
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		var entry codexRecord
+		// Rollouts are append-only and may be observed during a partial final
+		// write. Skip malformed and future record shapes without losing history.
+		if json.Unmarshal([]byte(line), &entry) != nil {
+			continue
+		}
+		if isCodexResponseMarker(entry) {
+			hasResponseMarkers = true
+		}
+		records = append(records, entry)
+	}
+
+	var out codexRollout
+	var responseProse []string
+	var pendingDelta strings.Builder
+	for _, entry := range records {
+		if entry.Type == "event_msg" && entry.Payload.Type == "agent_message_content_delta" {
+			// Compatibility only: current Codex classifies these as transient and
+			// does not persist them, but older rollouts may contain them.
+			pendingDelta.WriteString(entry.Payload.Delta)
+			continue
+		}
+		if isCodexResponseMarker(entry) {
+			out.exchanges = append(out.exchanges, codexMessage{Role: "response", Text: strings.Join(responseProse, "\n\n")})
+			responseProse = nil
+			pendingDelta.Reset()
+			continue
+		}
+		if entry.Type != "response_item" || entry.Payload.Type != "message" ||
+			(entry.Payload.Role != "user" && entry.Payload.Role != "assistant") {
+			continue
+		}
+		text := codexMessageText(entry.Payload.Role, entry.Payload.Content)
+		if entry.Payload.Role == "user" {
+			// Never carry unfinished response prose across a new user boundary.
+			responseProse = nil
+			pendingDelta.Reset()
+			out.messages = append(out.messages, codexMessage{Role: "user", Text: text})
+			out.exchanges = append(out.exchanges, codexMessage{Role: "user", Text: text})
+			continue
+		}
+
+		pendingDelta.Reset() // canonical completed text supersedes legacy deltas
+		out.messages = append(out.messages, codexMessage{Role: "assistant", Text: text})
+		if hasResponseMarkers {
+			if text != "" {
+				responseProse = append(responseProse, text)
+			}
+		} else {
+			// Compatibility for older rollouts without response markers: their
+			// persisted assistant messages are the best available boundary.
+			out.exchanges = append(out.exchanges, codexMessage{Role: "response", Text: text})
+		}
+	}
+	if pendingDelta.Len() != 0 {
+		text := pendingDelta.String()
+		out.messages = append(out.messages, codexMessage{Role: "assistant", Text: text})
+		if !hasResponseMarkers {
+			out.exchanges = append(out.exchanges, codexMessage{Role: "response", Text: text})
+		}
+	}
+	return out, nil
+}
+
+func isCodexResponseMarker(entry codexRecord) bool {
+	if entry.Type != "event_msg" || entry.Payload.Type != "token_count" {
+		return false
+	}
+	info := strings.TrimSpace(string(entry.Payload.Info))
+	return info != "" && info != "null"
+}
+
+func codexMessageText(role string, raw json.RawMessage) string {
+	var blocks []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if json.Unmarshal(raw, &blocks) != nil {
+		return ""
+	}
+	var parts []string
+	for _, block := range blocks {
+		want := "output_text"
+		if role == "user" {
+			want = "input_text"
+		}
+		if block.Type != want || block.Text == "" || (role == "user" && isCodexSystemContext(block.Text)) {
+			continue
+		}
+		parts = append(parts, block.Text)
+	}
+	return strings.Join(parts, "\n\n")
+}

--- a/packages/adapter/adapters/codex_conversation_test.go
+++ b/packages/adapter/adapters/codex_conversation_test.go
@@ -1,0 +1,234 @@
+package adapters
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+const codexCompletedResponse = `{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"total_tokens":42}},"rate_limits":null}}`
+
+func TestCodexExchangeProjectionVisibleMessagesOnly(t *testing.T) {
+	path := writeCodexJSONL(t,
+		`{"type":"session_meta","payload":{"id":"abc"}}`,
+		`{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"<environment_context>\nx\n</environment_context>"}]}}`,
+		`{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"do it"}]}}`,
+		`{"type":"event_msg","payload":{"type":"agent_reasoning","text":"private chain of thought"}}`,
+		`{"type":"response_item","payload":{"type":"reasoning","summary":[{"type":"summary_text","text":"also private"}]}}`,
+		`{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"working"}]}}`,
+		`{"type":"response_item","payload":{"type":"function_call","name":"shell","arguments":"secret output"}}`,
+		codexCompletedResponse,
+		`{"type":"event_msg","payload":{"type":"exec_approval_request","command":"danger"}}`,
+		`{"type":"event_msg","payload":{"type":"plan_update","plan":["hidden"]}}`,
+		`{"type":"compacted","payload":{"message":"hidden summary"}}`,
+		`{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"done"}]}}`,
+		codexCompletedResponse,
+	)
+	ex, err := NewCodex().RenderConversationExchanges(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ex) != 1 || ex[0].User != "do it" || ex[0].Iterations != 2 || ex[0].Terminal != "done" {
+		t.Fatalf("%+v", ex)
+	}
+}
+
+func TestCodexResponseBoundaries(t *testing.T) {
+	t.Run("message and multiple tools are one response", func(t *testing.T) {
+		path := writeCodexJSONL(t,
+			codexUser("go"),
+			codexAssistant("I will inspect"),
+			`{"type":"response_item","payload":{"type":"function_call","name":"one"}}`,
+			`{"type":"response_item","payload":{"type":"function_call","name":"two"}}`,
+			codexCompletedResponse,
+		)
+		ex, err := NewCodex().RenderConversationExchanges(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(ex) != 1 || ex[0].Iterations != 1 || ex[0].Terminal != "I will inspect" {
+			t.Fatalf("%+v", ex)
+		}
+	})
+
+	t.Run("tool-only response counts", func(t *testing.T) {
+		path := writeCodexJSONL(t,
+			codexUser("go"),
+			`{"type":"response_item","payload":{"type":"function_call","name":"one"}}`,
+			codexCompletedResponse,
+		)
+		ex, err := NewCodex().RenderConversationExchanges(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(ex) != 1 || ex[0].Iterations != 1 || ex[0].Terminal != "" {
+			t.Fatalf("%+v", ex)
+		}
+	})
+
+	t.Run("tool-only final response clears earlier prose", func(t *testing.T) {
+		path := writeCodexJSONL(t,
+			codexUser("go"), codexAssistant("I will inspect"), codexCompletedResponse,
+			`{"type":"response_item","payload":{"type":"function_call_output","output":"hidden"}}`,
+			`{"type":"response_item","payload":{"type":"function_call","name":"again"}}`,
+			codexCompletedResponse,
+		)
+		ex, err := NewCodex().RenderConversationExchanges(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(ex) != 1 || ex[0].Iterations != 2 || ex[0].Terminal != "" {
+			t.Fatalf("%+v", ex)
+		}
+	})
+
+	t.Run("null token count is not completion", func(t *testing.T) {
+		path := writeCodexJSONL(t,
+			codexUser("go"), codexAssistant("done"),
+			`{"type":"event_msg","payload":{"type":"token_count","info":null,"rate_limits":null}}`,
+			codexCompletedResponse,
+		)
+		ex, err := NewCodex().RenderConversationExchanges(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(ex) != 1 || ex[0].Iterations != 1 || ex[0].Terminal != "done" {
+			t.Fatalf("%+v", ex)
+		}
+	})
+}
+
+func TestCodexContextualUserRegistryIsExcludedByPublicRenderer(t *testing.T) {
+	// One public-renderer fixture per persisted role-user form mirrored in
+	// codexContextualUserMatchers. These are generated shapes, not invented
+	// XML namespaces.
+	contexts := []struct{ name, text string }{
+		{"AGENTS instructions", "# AGENTS.md instructions for /tmp/project\n\n<INSTRUCTIONS>\nhidden\n</INSTRUCTIONS>"},
+		{"environment", "<environment_context>\n<cwd>/tmp</cwd>\n</environment_context>"},
+		{"permissions", "<permissions>\nhidden\n</permissions>"},
+		{"legacy permissions", "<permissions instructions>hidden</permissions instructions>"},
+		{"skill", "<skill>\nsecret instructions\n</skill>"},
+		{"skills instructions", "<skills_instructions>\nhidden\n</skills_instructions>"},
+		{"user shell", "<user_shell_command>\n<command>secret</command>\n</user_shell_command>"},
+		{"turn aborted", "<turn_aborted>\nhidden\n</turn_aborted>"},
+		{"subagent notification", "<subagent_notification>\n{\"status\":\"done\"}\n</subagent_notification>"},
+		{"hook prompt", "<hook_prompt hook_run_id=\"abc-123\">\nhidden hook prompt\n</hook_prompt>"},
+		{"modern internal context", "<codex_internal_context source=\"memory_1\">\nhidden\n</codex_internal_context>"},
+		{"legacy goal context", "<goal_context>\nhidden\n</goal_context>"},
+		{"recommended plugins", "<recommended_plugins>\nhidden\n</recommended_plugins>"},
+		{"legacy unified-exec warning", "Warning: The maximum number of unified exec processes you can keep open is 60 and you currently have 61 processes open. Reuse older processes or close them to prevent automatic pruning of old processes"},
+		{"legacy apply-patch warning", "Warning: apply_patch was requested via exec_command. Use the apply_patch tool instead of exec_command."},
+		{"legacy model-mismatch warning", "Warning: Your account was flagged for potentially high-risk cyber activity and this request was routed to gpt-5.2 as a fallback. To regain access, apply for trusted access."},
+	}
+	for _, context := range contexts {
+		t.Run(context.name, func(t *testing.T) {
+			path := writeCodexJSONL(t,
+				codexUser(context.text), codexUser("real prompt"),
+				codexAssistant("answer"), codexCompletedResponse,
+			)
+			ex, err := NewCodex().RenderConversationExchanges(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(ex) != 1 || ex[0].User != "real prompt" || ex[0].Terminal != "answer" {
+				t.Fatalf("%s leaked or erased boundary: %+v", context.name, ex)
+			}
+		})
+	}
+}
+
+func TestCodexContextLookalikesRemainPublicUserPrompts(t *testing.T) {
+	prompts := []string{
+		"<permissions please explain the deployment steps",
+		"<external_ticket>summarize this ticket</external_ticket>",
+		"<hook_prompt>explain this element</hook_prompt>",
+		"<codex_internal_context source=\"INVALID\">explain this</codex_internal_context>",
+	}
+	for _, prompt := range prompts {
+		t.Run(prompt, func(t *testing.T) {
+			path := writeCodexJSONL(t, codexUser(prompt), codexAssistant("answer"), codexCompletedResponse)
+			ex, err := NewCodex().RenderConversationExchanges(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(ex) != 1 || ex[0].User != prompt {
+				t.Fatalf("legitimate prompt erased: %+v", ex)
+			}
+		})
+	}
+}
+
+func TestCodexExchangeMalformedPartialAndLegacyFallback(t *testing.T) {
+	path := writeCodexJSONL(t,
+		codexUser("go"),
+		codexAssistant("not terminal"),
+		`{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"refusal","text":"not visible"}]}}`,
+		`{"type":"response_item"`,
+	)
+	ex, err := NewCodex().RenderConversationExchanges(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ex) != 1 || ex[0].Iterations != 2 || ex[0].Terminal != "" {
+		t.Fatalf("%+v", ex)
+	}
+}
+
+func TestCodexConversationDoesNotDuplicateEventMessages(t *testing.T) {
+	path := writeCodexJSONL(t,
+		`{"type":"event_msg","payload":{"type":"user_message","message":"hello"}}`,
+		codexUser("hello"),
+		`{"type":"event_msg","payload":{"type":"agent_message","message":"world"}}`,
+		codexAssistant("world"), codexCompletedResponse,
+	)
+	messages, err := NewCodex().RenderConversation(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(messages) != 2 || messages[0].Text != "hello" || messages[1].Text != "world" {
+		t.Fatalf("%+v", messages)
+	}
+}
+
+// Compatibility only: current Codex classifies assistant content deltas as
+// transient and does not persist them. Older rollouts that did persist them
+// can still expose trailing partial prose without duplicating a canonical item.
+func TestCodexConversationLegacyPersistedDeltaCompatibility(t *testing.T) {
+	path := writeCodexJSONL(t,
+		codexUser("go"),
+		`{"type":"event_msg","payload":{"type":"agent_message_content_delta","item_id":"1","delta":"part "}}`,
+		`{"type":"event_msg","payload":{"type":"agent_message_content_delta","item_id":"1","delta":"way"}}`,
+	)
+	ex, err := NewCodex().RenderConversationExchanges(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ex) != 1 || ex[0].Iterations != 1 || ex[0].Terminal != "part way" {
+		t.Fatalf("%+v", ex)
+	}
+
+	path = writeCodexJSONL(t,
+		codexUser("go"),
+		`{"type":"event_msg","payload":{"type":"agent_message_content_delta","item_id":"1","delta":"part"}}`,
+		codexAssistant("complete"),
+	)
+	messages, err := NewCodex().RenderConversation(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(messages) != 2 || messages[1].Text != "complete" {
+		t.Fatalf("%+v", messages)
+	}
+}
+
+func codexUser(text string) string {
+	return `{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":` + quoteJSON(text) + `}]}}`
+}
+
+func codexAssistant(text string) string {
+	return `{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":` + quoteJSON(text) + `}]}}`
+}
+
+func quoteJSON(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}

--- a/packages/adapter/adapters/codex_test.go
+++ b/packages/adapter/adapters/codex_test.go
@@ -293,19 +293,25 @@ func TestExtractCodexUserText(t *testing.T) {
 }
 
 func TestIsCodexSystemContext(t *testing.T) {
-	if !isCodexSystemContext("<permissions instructions>stuff") {
-		t.Error("should detect permissions")
+	for _, context := range []string{
+		"<permissions instructions>stuff</permissions instructions>",
+		"<environment_context>stuff</environment_context>",
+		"# AGENTS.md instructions for /tmp\n<INSTRUCTIONS>stuff</INSTRUCTIONS>",
+		"<turn_aborted>The user aborted</turn_aborted>",
+	} {
+		if !isCodexSystemContext(context) {
+			t.Errorf("should detect complete context %q", context)
+		}
 	}
-	if !isCodexSystemContext("<environment_context>stuff") {
-		t.Error("should detect environment_context")
-	}
-	if !isCodexSystemContext("# AGENTS.md instructions for /tmp") {
-		t.Error("should detect AGENTS.md")
-	}
-	if !isCodexSystemContext("<turn_aborted>The user aborted") {
-		t.Error("should detect turn_aborted")
-	}
-	if isCodexSystemContext("Fix the auth bug") {
-		t.Error("should not flag user text as system context")
+	for _, prompt := range []string{
+		"Fix the auth bug",
+		"<permissions please explain the deployment steps",
+		"<environment_context> is an XML element; explain it",
+		"# AGENTS.md is the heading I want to use",
+		"<turn_aborted> can appear in documentation",
+	} {
+		if isCodexSystemContext(prompt) {
+			t.Errorf("should retain ambiguous user prompt %q", prompt)
+		}
 	}
 }

--- a/services/gmuxd/cmd/gmuxd/exchange_wait_test.go
+++ b/services/gmuxd/cmd/gmuxd/exchange_wait_test.go
@@ -65,6 +65,18 @@ func TestActiveExchangeReconciliationBeforeAndAfterPersistence(t *testing.T) {
 	}
 }
 
+func TestActiveExchangeReconciliationAnonymousHookFrameDoesNotDuplicateBoundary(t *testing.T) {
+	native := []adapter.Exchange{{Ordinal: 1, User: "real persisted prompt", Iterations: 1, Terminal: "stale"}}
+	current := &sessioncoord.TurnCurrent{Exchanges: []sessioncoord.TurnExchange{{User: ""}}}
+	got := reconcileActiveExchanges(native, current)
+	if len(got) != 1 || got[0].User != "real persisted prompt" || got[0].Terminal != "" {
+		t.Fatalf("anonymous hook frame duplicated or corrupted boundary: %+v", got)
+	}
+	if got := reconcileActiveExchanges(nil, current); len(got) != 0 {
+		t.Fatalf("anonymous pre-persistence frame became an empty user exchange: %+v", got)
+	}
+}
+
 func TestActiveExchangeReconciliationEvictionAndHookLag(t *testing.T) {
 	zero := 0
 	var native []adapter.Exchange
@@ -247,8 +259,13 @@ func TestConversationExchangeEndpointMatrix(t *testing.T) {
 	if err := os.WriteFile(conv, []byte("{\"type\":\"message\",\"message\":{\"role\":\"user\",\"content\":\"one\"}}\n{\"type\":\"message\",\"message\":{\"role\":\"assistant\",\"content\":\"a\"}}\n{\"type\":\"message\",\"message\":{\"role\":\"user\",\"content\":\"two\"}}\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
+	codexConv := filepath.Join(dir, "codex.jsonl")
+	if err := os.WriteFile(codexConv, []byte("{\"type\":\"response_item\",\"payload\":{\"type\":\"message\",\"role\":\"user\",\"content\":[{\"type\":\"input_text\",\"text\":\"inspect this\"}]}}\n{\"type\":\"response_item\",\"payload\":{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"observed\"}]}}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
 	for _, sess := range []centralstore.NewSession{
 		{ID: "pi", Adapter: "pi", ConversationRef: conv, Command: []string{"pi"}, CreatedAt: 1},
+		{ID: "codex", Adapter: "codex", ConversationRef: codexConv, Command: []string{"codex"}, CreatedAt: 1},
 		{ID: "shell", Adapter: "shell", Command: []string{"sh"}, CreatedAt: 1},
 	} {
 		if _, _, err := st.InsertSession(ctx, sess); err != nil {
@@ -266,6 +283,9 @@ func TestConversationExchangeEndpointMatrix(t *testing.T) {
 	}
 	if body := check("pi", "?tail=1", 200); !strings.Contains(body, "[1 previous exchange]") || !strings.Contains(body, "[USER]: two") {
 		t.Fatalf("tail report=%q", body)
+	}
+	if body := check("codex", "", 200); !strings.Contains(body, "[USER]: inspect this") || !strings.Contains(body, "observed") {
+		t.Fatalf("codex report=%q", body)
 	}
 	check("pi", "?tail=0", 400)
 	check("pi", "?types=user", 400)

--- a/services/gmuxd/cmd/gmuxd/serve_central.go
+++ b/services/gmuxd/cmd/gmuxd/serve_central.go
@@ -1320,11 +1320,19 @@ func reconcileActiveExchanges(native []adapter.Exchange, current *sessioncoord.T
 		return append([]adapter.Exchange(nil), native...)
 	}
 	if current.PreviousExchanges == nil {
-		// A version-skewed frame cannot be reconciled safely. Prefer the source's
-		// current span over attaching it to an arbitrary persisted equal string.
+		// A version-skewed frame cannot be reconciled positionally. Anonymous
+		// hook-driven adapters (currently Codex) also report an empty user because
+		// raw PTY input has no semantic source bytes. Never append that empty frame
+		// as a duplicate exchange once native storage has the real boundary.
 		out := append([]adapter.Exchange(nil), native...)
 		for _, ex := range current.Exchanges {
+			if ex.User == "" {
+				continue
+			}
 			out = append(out, adapter.Exchange{Ordinal: ex.Ordinal, User: ex.User, Iterations: ex.Iterations})
+		}
+		if len(out) > 0 {
+			out[len(out)-1].Terminal = ""
 		}
 		return out
 	}


### PR DESCRIPTION
## Summary

- render visible user/assistant prose from Codex rollout JSONL for `gmux agent logs`
- count completed model responses from persisted non-null `event_msg.token_count` completion markers, including tool-only responses and mixed commentary/tool responses
- ensure a tool-only final response clears earlier nonterminal commentary
- exclude reasoning, tools, approvals, plans, compaction, generated contextual user fragments, and duplicate event records
- deliberately mirror Codex's contextual-user-message registry, including modern and legacy internal context, exact hook prompts, skills, subagent notifications, AGENTS instructions, and all three registered legacy generated warnings
- match only exact upstream-generated shapes; unknown XML such as `<external_ticket>...</external_ticket>` remains a legitimate user prompt
- tolerate malformed and partially-written JSONL records
- exercise the store-backed Codex conversation endpoint end to end

This salvages only the observational subset of closed #439 against current main. Current main already has Codex rollout discovery, conversation identity binding, and the shared `ConversationSource`/conversation endpoint wiring, so the adapter renderer is the only production integration needed.

## Active prose fidelity

Current Codex classifies `agent_message_content_delta` as transient and does not persist it in rollout files. Therefore store-backed `gmux agent logs` cannot reliably show in-flight partial prose on current Codex; it shows canonical persisted messages and completed-response boundaries. The renderer retains delta handling only as explicit backward compatibility for older rollout files that did persist those events. No current-version active-partial-prose claim is made.

## Explicit non-goals

This does **not** add Codex semantic control: no action encoder, launch selector, readiness, prompt/follow-up/steer/cancel encoding, or synchronous prompt-result claim. Existing tests continue to assert that Codex is unsupported for semantic agent actions. Future Codex semantic control is expected to use an ACP backend.

## Tests

```text
go test ./packages/adapter/adapters ./services/gmuxd/cmd/gmuxd ./cli/gmux/cmd/gmux ./cli/gmux/internal/ptyserver
go test -race ./packages/adapter/adapters ./services/gmuxd/cmd/gmuxd ./cli/gmux/internal/ptyserver
go test ./cli/gmux/... ./packages/adapter/... ./packages/paths/... ./packages/scrollback/... ./packages/socklease/... ./packages/sessionenv/... ./packages/workspace/... ./services/gmuxd/...
```

All pass. Public-renderer fixtures cover every mirrored persisted role-user contextual form and legitimate lookalikes. A content-silent local probe also parsed all 66 available local Codex rollouts successfully; no rollout contents were printed. (`go test ./...` is not valid at this multi-module workspace root, so the workspace modules are listed explicitly.)


## Live install-gate follow-up

A real Codex TUI gate exposed one daemon reconciliation edge after the renderer itself passed: while an anonymous hook-driven turn was active and native storage had already persisted the real user boundary, `agent logs` appended the hook's empty synthetic user as a duplicate exchange. The reconciliation now ignores anonymous empty live boundaries, retains the persisted user text, clears stale terminal prose while active, and has regression coverage. The gate is being rerun on this head.
