### PR TITLE
docs(adr): define driven-launch model resolution

### DIFF
--- a/docs/adr/0033-session-backends-and-semantic-capability-boundaries.md
+++ b/docs/adr/0033-session-backends-and-semantic-capability-boundaries.md
@@ -401,8 +401,8 @@ the `initialize` handshakes exercised live. Answers adopted here:
 Genuinely open, deferred to the runner work (and the follow-up ADRs named):
 
 - **The session-spec resolver** (decision 5): shorthand matching over usable
-  catalogs, recency tiebreak, `preferred_backends` semantics and default
-  order — a follow-up ADR.
+  catalogs, recency tiebreak, and `preferred_backends` semantics are decided
+  by ADR 0034; catalog wire shape and preference identifiers remain open there.
 - **Permission policy defaults and UI**: auto-allow/allow-safe/ask tiers,
   timeout behavior, ADR 0018 notification shape.
 - **Adapter distribution and binary policy**: bundling vs `npx`, pin cadence,

--- a/docs/adr/0033-session-backends-and-semantic-capability-boundaries.md
+++ b/docs/adr/0033-session-backends-and-semantic-capability-boundaries.md
@@ -219,17 +219,17 @@ Driven launches address what the caller actually chooses — a model, an
 effort, and a harness to run them in — with one spec syntax:
 
 ```text
-gmux agent prompt --new anthropic/claude-fable-5:low@pi 'review this branch'
+gmux agent prompt --new --model anthropic/claude-fable-5:low@pi 'review this branch'
 ```
 
 `model:effort@harness` is the canonical long-term surface for driven
-launches, replacing the `--adapter` + `--model` flag pair as those verbs
-mature. The harness names the identity (decision 1); the drive mode is not
-part of the spec — gmux selects it per the harness's available backends and
-the user's `preferred_backends` configuration (shipped with a sane default
-order). Every component is optional shorthand in practice: the **resolver**
+launches, carried by `--model` and replacing the separate `--adapter` flag
+as those verbs mature (the positional argument remains the session address,
+per ADR 0027/0031). The harness names the identity (decision 1); the drive
+mode is not part of the spec — gmux selects it per the harness's available
+modes. Every component is optional shorthand in practice: the **resolver**
 — unique whole-token shorthand matching over the usable catalogs, recency
-tiebreak, and the `preferred_backends` semantics — is deliberately **not
+tiebreak, and the `preferred_harnesses` semantics — is deliberately **not
 specified here** and is reserved for a follow-up ADR. This ADR fixes only
 the canonical shape and that resolution operates over (harness, mode) pairs
 whose capability sets this document defines.
@@ -401,8 +401,8 @@ the `initialize` handshakes exercised live. Answers adopted here:
 Genuinely open, deferred to the runner work (and the follow-up ADRs named):
 
 - **The session-spec resolver** (decision 5): shorthand matching over usable
-  catalogs, recency tiebreak, and `preferred_backends` semantics are decided
-  by ADR 0034; catalog wire shape and preference identifiers remain open there.
+  catalogs, recency tiebreak, and `preferred_harnesses` semantics are decided
+  by ADR 0034; catalog wire shape remains open there.
 - **Permission policy defaults and UI**: auto-allow/allow-safe/ask tiers,
   timeout behavior, ADR 0018 notification shape.
 - **Adapter distribution and binary policy**: bundling vs `npx`, pin cadence,

--- a/docs/adr/0033-session-backends-and-semantic-capability-boundaries.md
+++ b/docs/adr/0033-session-backends-and-semantic-capability-boundaries.md
@@ -226,8 +226,9 @@ gmux agent prompt --new --model anthropic/claude-fable-5:low@pi 'review this bra
 launches, carried by `--model` and replacing the separate `--adapter` flag
 as those verbs mature (the positional argument remains the session address,
 per ADR 0027/0031). The harness names the identity (decision 1); the drive
-mode is not part of the spec — gmux selects it per the harness's available
-modes. Every component is optional shorthand in practice: the **resolver**
+mode is not part of the spec and is not a preference: a driven launch uses
+the mode in which the harness supports driven launch per the capability
+matrix (decision 9) — ACP for claude/codex, terminal for pi. Every component is optional shorthand in practice: the **resolver**
 — unique whole-token shorthand matching over the usable catalogs, recency
 tiebreak, and the `preferred_harnesses` semantics — is deliberately **not
 specified here** and is reserved for a follow-up ADR. This ADR fixes only

--- a/docs/adr/0034-driven-launch-model-resolution.md
+++ b/docs/adr/0034-driven-launch-model-resolution.md
@@ -66,15 +66,19 @@ advances — never an ambiguous guess.
    complete token of the model name (`sol` matches `gpt-5.6-sol`, not
    `solar`). This is **partial-name specification, not fuzzy matching** — no
    substring, prefix, or edit-distance search. A unique match resolves.
-3. **Recency selects among multiple matches**: the match most recently
-   launched through gmux wins. Ties without usable history (e.g. never-used
-   matches) fall to `preferred_harnesses` order across harnesses; if still
-   ambiguous, fail listing the canonical candidates — an agent retries
-   cheaply with a longer token. History never introduces a candidate the
-   corpus did not offer.
-4. **Effort default**: when effort is omitted, use the resolved model's most
+3. **Harness preference narrows first**: when matches span multiple
+   harnesses (the same model is often in scope in several), only the
+   matches from the highest-ranked harness in `preferred_harnesses` remain.
+   The shorthand never launches via a lower-ranked harness while a
+   higher-ranked one offers a match — use canonical `@harness` to override.
+4. **Recency selects among the remaining matches**: the one most recently
+   launched through gmux wins. With no usable history and multiple
+   remaining matches, fail listing the canonical candidates — an agent
+   retries cheaply with a longer token. History never introduces a
+   candidate the corpus did not offer.
+5. **Effort default**: when effort is omitted, use the resolved model's most
    recent gmux launch effort; otherwise the harness default.
-5. **Echo and freeze**: the resolved canonical form is printed at launch and
+6. **Echo and freeze**: the resolved canonical form is printed at launch and
    recorded in the session's durable state. Nothing ever re-resolves.
 
 A shorthand reaching no candidate fails with an error asking for a model.
@@ -82,16 +86,17 @@ There is no implicit default model.
 
 ### Configuration
 
-One new key: `preferred_harnesses`, an ordered preference used only for the
-no-history tie above, shipped with a sane default covering all supported
-harnesses so zero-config works. A future `default_model` may be added;
+One new key: `preferred_harnesses`, the ordered harness preference of rung
+3, shipped with a sane default covering all supported harnesses so
+zero-config works. It is per-user intent: one user routes shorthand `fable`
+via pi, another via claude, each without canonical specs. A future `default_model` may be added;
 initially an underspecified launch fails and asks.
 
 ### Stability convention
 
 Shorthand is a human/agent ergonomic affordance: `fable` means "the fable I
-last used", and switches to a new release only when the caller picks it once
-(canonically or via the picker). The echo makes each resolution visible and
+last used, via my preferred harness that offers it", and switches to a new
+release only when the caller picks it once (canonically or via the picker). The echo makes each resolution visible and
 the frozen record makes it auditable. Automation needing reproducibility
 uses the canonical form.
 

--- a/docs/adr/0034-driven-launch-model-resolution.md
+++ b/docs/adr/0034-driven-launch-model-resolution.md
@@ -7,198 +7,119 @@
 ## Context
 
 ADR 0033 defines `model:effort@harness` as the canonical session spec for
-driven launches and reserves shorthand resolution for this ADR. A caller should
-be able to ask for the current member of a model family without maintaining an
-alias every time a provider releases a version. That convenience must not make
-a launch depend on an arbitrary fuzzy match.
+driven launches and reserves shorthand resolution for this ADR. Callers want
+"the latest fable" to work without maintaining an alias per release; that
+convenience must not rest on arbitrary fuzzy matching.
 
-Pi's current matching demonstrates the failure. It selects the first fuzzy
-match across every model it knows, so `fable` can resolve to
-`amazon-bedrock/fable` even when the user has never configured Amazon Bedrock.
-The resulting launch fails. The shorthand is not the underlying problem: the
-candidate corpus admitted unusable models, and the match had no trustworthy
-ambiguity boundary.
+Pi's current behavior shows the failure: it picks the first fuzzy match across
+every model it knows, so `fable` can resolve to `amazon-bedrock/fable` — a
+provider the user never configured — and the launch fails. The corpus was
+wrong, not the shorthand idea.
 
-Resolution is also host-dependent. A driven launch may target another host,
-where installed harnesses and configured providers differ from the caller's.
-The same catalog data is needed by the web UI's new-session model picker; the
-CLI and UI must not invent separate availability rules.
+Resolution is host-dependent (installed harnesses and configured providers
+differ per host), and the same catalog data must drive the web UI model
+picker.
 
 ## Decision
 
 ### Scope
 
-Resolution applies only when gmux chooses the launch command: semantic/driven
-launches, including `gmux agent prompt --new`, and the web UI new-session flow.
-It runs daemon-side at launch time against the target host.
+Resolution applies only where gmux chooses the launch command: driven
+launches (`gmux agent prompt --new --model <spec>`) and the web UI
+new-session flow. It runs daemon-side at launch time against the target
+host. Interactive `gmux -- <harness>` is untouched.
 
-Interactive passthrough launch, `gmux -- <harness>`, is unchanged. gmux does not
-reinterpret a command the user supplied.
+### Candidate corpus: usable models only
 
-### Candidate corpus
+Shorthand resolution considers only models that are **usable** on the target
+host at resolution time: harness installed, provider configured and
+authenticated, model not deprecated. Unconfigured providers drop out before
+matching — the structural fix for the Bedrock failure.
 
-Shorthand resolution considers only **usable** catalog entries. A model is
-usable when, on the target host at resolution time:
-
-- the backend that can launch it is installed;
-- its provider is configured and authenticated; and
-- the model is not deprecated.
-
-Unavailable backends and providers therefore disappear before matching. This
-is the structural correction for the Bedrock failure: a provider the user
-cannot launch can never win shorthand resolution.
-
-Each backend capable of discovery advertises a model catalog containing:
-
-- canonical model identity;
-- usability status on that host;
-- version ordering, by release date or an explicit backend ordering;
-- model-family grouping;
-- the harness/drive information needed to launch it; and
-- backend-specific selection facts, including pi's scoped/featured marker
-  where applicable.
-
-Codex's `model/list` and Claude's model and effort config options establish that
-a catalog capability is feasible, but do not fix its wire shape. A backend
-that cannot provide a catalog degrades safely: its models remain launchable by
-exact canonical spec, but the backend contributes no candidates to token or
-history-based resolution. The same advertised catalogs feed the web model
+The corpus comes from a new adapter capability: a **model catalog** carrying
+canonical model identity, usability status, version ordering (release date or
+explicit), model-family grouping, and adapter-specific selection facts such as
+pi's scoped/featured flag. (Feasible today: Codex exposes `model/list`; Claude
+exposes model and effort as config options.) An adapter without a catalog
+degrades gracefully: its models resolve only via exact canonical spec and
+contribute no shorthand candidates. The same catalogs feed the web model
 picker, so picker visibility and shorthand eligibility share one source of
 truth.
 
-### Deterministic resolution ladder
+### Resolution ladder
 
-The resolver evaluates the following ladder in order. Each rung either produces
-a trustworthy result, fails explicitly, or advances; it never falls through
-after making an ambiguous choice.
+Deterministic; each rung produces a trustworthy result, fails explicitly, or
+advances — never an ambiguous guess.
 
-1. **Exact canonical form.** A complete spec such as
-   `anthropic/claude-fable-5:low@pi` is accepted verbatim. gmux performs no
-   model, effort, or harness inference. Ordinary launch validation can still
-   report that its explicitly named backend or credentials are unavailable.
-2. **Unique whole-token match over usable models.** A shorthand must equal a
-   complete token in a usable model name. Token boundaries are punctuation
-   boundaries in the catalog identity: `sol` matches `gpt-5.6-sol`, but does
-   not match `solar`. This is **partial-name specification, not fuzzy
-   matching**: there is no substring, prefix, edit-distance, or similarity
-   search.
-   - If all matches are members of one declared model family, select the
-     latest member by catalog version ordering. Thus `fable` advances from
-     fable 5 to fable 6 without an alias edit.
-   - If that family is available through multiple otherwise-equivalent launch
-     backends, select according to `preferred_backends`.
-   - If matches span distinct families, fail and list the canonical candidates.
-     gmux never guesses across families. A human can choose; an agent can retry
-     cheaply with another token or a canonical spec.
-3. **History as a constrained tiebreak and effort default.** Usage history has
-   exactly two responsibilities: it supplies the most recently used thinking
-   effort for the resolved model when effort was omitted, and breaks a tie
-   among candidates that remain otherwise equal. The most recent applicable
-   launch wins; frequency is irrelevant. History never introduces a candidate
-   absent from the current usable catalog and never overrides a family or
-   backend preference decision.
-4. **Echo and freeze.** Before launch, gmux prints the fully resolved canonical
-   `model:effort@harness` form. It records that same value in session metadata.
-   The session is thereafter bound to that value: resume, reads, and later
-   operations never re-run shorthand resolution.
+1. **Exact canonical form** (`anthropic/claude-fable-5:low@pi`) is used
+   verbatim, with no inference. Ordinary launch validation still applies.
+2. **Unique whole-token match** over the usable corpus: the shorthand must
+   equal a complete token of the model name (`sol` matches `gpt-5.6-sol`, not
+   `solar`). This is **partial-name specification, not fuzzy matching** — no
+   substring, prefix, or edit-distance search.
+   - Matches within one model family → pick the latest by catalog version
+     ordering, so `fable` tracks new releases with zero maintenance.
+   - Same family launchable through multiple harnesses →
+     `preferred_harnesses` order wins.
+   - Matches spanning distinct families → fail, listing the canonical
+     candidates. An agent retries cheaply with a longer token.
+3. **History** has exactly two jobs: default thinking effort for the resolved
+   model (its most recent launch) and tiebreak among otherwise-equal
+   candidates (recency, never frequency). History never introduces a
+   candidate the catalog did not offer.
+4. **Echo and freeze**: the resolved canonical form is printed at launch and
+   recorded in the session's durable state. Nothing ever re-resolves.
 
-If the supplied shorthand reaches no usable candidate, resolution fails with an
-error asking for a model and, where useful, naming discoverable choices. There
-is no implicit global default model in this decision.
+A shorthand reaching no usable candidate fails with an error asking for a
+model. There is no implicit default model.
 
 ### Configuration
 
-The only new configuration is `preferred_backends`, an ordered preference used
-when the same family has otherwise-equivalent usable launch choices. gmux ships
-a sane order covering every supported choice, so zero-config resolution works;
-choices unavailable on the target host naturally drop out with the corpus.
-
-A future `default_model` may remove the need to supply any model. It is omitted
-initially: an underspecified launch fails and asks for a model rather than
-silently acquiring a product-wide default.
+One new key: `preferred_harnesses`, an ordered preference shipped with a sane
+default covering all supported harnesses, so zero-config works — unavailable
+harnesses drop out of the corpus naturally. A future `default_model` may be
+added; initially an underspecified launch fails and asks.
 
 ### Stability convention
 
-Shorthand is a human and agent ergonomic affordance, not a reproducibility
-mechanism. Its meaning may intentionally advance when a new family member is
-released. The launch echo makes that choice visible and session metadata makes
-it auditable and permanent for that session. Automation requiring a stable
-choice uses the canonical form.
+Shorthand is a human/agent ergonomic affordance; its meaning legitimately
+advances when a new family member releases. The echo makes that visible and
+the frozen record makes it auditable. Automation needing reproducibility uses
+the canonical form.
 
 ## Consequences
 
-- Unconfigured providers cannot capture shorthand matches. Catalog usability,
-  rather than match ranking, enforces that property.
-- Family shorthand follows new releases without user-maintained configuration.
-  This depends on accurate family identity and version order from catalogs.
-- Ambiguity is cheap and explicit. Distinct-family matches return candidates
-  instead of embedding an unstable heuristic in a launch.
-- Multi-host launches resolve where they execute, so the target host's actual
-  installation and credentials govern availability.
-- CLI launches and the web picker consume the same catalog capability and
-  should agree about what can be launched.
-- A shorthand may resolve differently across time or hosts by design. The
-  canonical launch echo and frozen metadata are therefore required contract,
-  not optional diagnostics.
-- Backends without discovery support remain usable through canonical specs and
-  do not weaken resolution for other backends.
+- Resolution happens on the target host, so its actual installation and
+  credentials govern availability in multi-host launches.
+- Echo + freeze are required contract, not diagnostics: a shorthand may
+  resolve differently across time and hosts by design.
+- Family shorthand correctness depends on accurate family identity and
+  version ordering in catalogs (see open questions).
+- CLI resolution and the web picker consume one catalog capability and cannot
+  disagree about what is launchable.
 
 ## Rejected alternatives
 
-### User-maintained aliases
-
-Rejected. Aliases drift, require maintenance for every release, and fail the
-core requirement that “latest fable” keep working without a config edit. A
-canonical form already serves users who want a pinned name.
-
-### Auto-populate preference configuration from usage
-
-Rejected. This would create self-modifying configuration the user never wrote.
-History remains runtime data with the two narrow responsibilities above;
-configuration remains an explicit statement of preference.
-
-### Most-common-usage ranking
-
-Rejected. Frequency entrenches old choices and makes outcomes depend on an
-opaque lifetime count. Only recency may break an otherwise-equal tie or default
-effort.
-
-### Silent cross-backend or cross-provider fallback
-
-Rejected. A different backend or provider can change capabilities,
-configuration, billing, and privacy boundaries. Preference may choose among
-catalog-declared equivalent offerings; gmux does not silently reinterpret an
-unavailable explicit choice or cross an ambiguity boundary. It fails and lists
-candidates.
-
-### Substring or edit-distance fuzzy matching
-
-Rejected. These searches admit accidental neighbors and make the winner depend
-on catalog contents and ordering. Whole-token equality has a stable,
-explainable boundary.
-
-### Let history expand the catalog
-
-Rejected. A previously usable model may be removed, deprecated, logged out, or
-unavailable on the target host. Historical use is not evidence of present
-launchability.
+- **User-maintained aliases** — drift, require an edit per release, and fail
+  the "latest fable without config" requirement.
+- **Auto-populated preferences from usage** — self-modifying configuration
+  the user never wrote; history stays runtime data with its two narrow jobs.
+- **Most-common-usage ranking** — frequency entrenches old choices; recency
+  only, as tiebreaker.
+- **Silent cross-harness or cross-provider fallback** — changes capabilities,
+  configuration, and privacy semantics; fail with candidates instead.
+- **Substring/edit-distance fuzzy matching** — admits accidental neighbors;
+  whole-token equality has a stable, explainable boundary.
+- **History expanding the catalog** — past use is not evidence of present
+  launchability.
 
 ## Open questions
 
-- **Cross-backend family identity:** is family grouping declared by each
-  backend, reconciled in a shared registry, or inferred? Naming inference is a
-  material design risk: selecting the latest fable requires knowing that fable
-  5 and fable 6 belong to one family, including when different backends expose
-  them.
-- **Catalog wire shape:** request/response framing, refresh and invalidation,
-  authentication failure representation, version-order fields, and capability
-  negotiation remain implementation work.
-- **Pi scoping:** how pi's scoped/featured model list maps to usability and
-  ranking without creating a second candidate policy remains open.
-- **Existing-session model changes:** whether this resolver also serves
-  `gmux agent prompt` when an existing session permits changing model is not
-  decided here; this ADR governs launch selection.
-- **Backend preference identifiers:** ADR 0033 uses “backend” for terminal/ACP
-  drive modes while model availability can also span harnesses/providers. The
-  concrete values and equivalence key for `preferred_backends` must be fixed
-  with the catalog schema without changing the ordering rule above.
+- **Cross-harness model-family identity** — the one real design risk: "latest
+  fable" requires knowing fable-5 and fable-6 are one family, including when
+  different harnesses expose them. Declared per adapter, reconciled centrally,
+  or inferred from naming?
+- **Catalog capability wire shape**: framing, refresh/invalidation, and how
+  pi's scoped-model list maps to usability and ranking.
+- Whether this resolver also powers `gmux agent prompt` on existing sessions
+  that permit changing model; this ADR governs launch selection only.

--- a/docs/adr/0034-driven-launch-model-resolution.md
+++ b/docs/adr/0034-driven-launch-model-resolution.md
@@ -1,0 +1,204 @@
+# ADR 0034: driven-launch model resolution
+
+**Status:** Accepted
+**Date:** 2026-08-02
+**Related:** ADR 0027 (semantic agent CLI), ADR 0029 (agent sessions abstract runner residency), ADR 0033 (session backends, capability boundaries, and canonical session spec)
+
+## Context
+
+ADR 0033 defines `model:effort@harness` as the canonical session spec for
+driven launches and reserves shorthand resolution for this ADR. A caller should
+be able to ask for the current member of a model family without maintaining an
+alias every time a provider releases a version. That convenience must not make
+a launch depend on an arbitrary fuzzy match.
+
+Pi's current matching demonstrates the failure. It selects the first fuzzy
+match across every model it knows, so `fable` can resolve to
+`amazon-bedrock/fable` even when the user has never configured Amazon Bedrock.
+The resulting launch fails. The shorthand is not the underlying problem: the
+candidate corpus admitted unusable models, and the match had no trustworthy
+ambiguity boundary.
+
+Resolution is also host-dependent. A driven launch may target another host,
+where installed harnesses and configured providers differ from the caller's.
+The same catalog data is needed by the web UI's new-session model picker; the
+CLI and UI must not invent separate availability rules.
+
+## Decision
+
+### Scope
+
+Resolution applies only when gmux chooses the launch command: semantic/driven
+launches, including `gmux agent prompt --new`, and the web UI new-session flow.
+It runs daemon-side at launch time against the target host.
+
+Interactive passthrough launch, `gmux -- <harness>`, is unchanged. gmux does not
+reinterpret a command the user supplied.
+
+### Candidate corpus
+
+Shorthand resolution considers only **usable** catalog entries. A model is
+usable when, on the target host at resolution time:
+
+- the backend that can launch it is installed;
+- its provider is configured and authenticated; and
+- the model is not deprecated.
+
+Unavailable backends and providers therefore disappear before matching. This
+is the structural correction for the Bedrock failure: a provider the user
+cannot launch can never win shorthand resolution.
+
+Each backend capable of discovery advertises a model catalog containing:
+
+- canonical model identity;
+- usability status on that host;
+- version ordering, by release date or an explicit backend ordering;
+- model-family grouping;
+- the harness/drive information needed to launch it; and
+- backend-specific selection facts, including pi's scoped/featured marker
+  where applicable.
+
+Codex's `model/list` and Claude's model and effort config options establish that
+a catalog capability is feasible, but do not fix its wire shape. A backend
+that cannot provide a catalog degrades safely: its models remain launchable by
+exact canonical spec, but the backend contributes no candidates to token or
+history-based resolution. The same advertised catalogs feed the web model
+picker, so picker visibility and shorthand eligibility share one source of
+truth.
+
+### Deterministic resolution ladder
+
+The resolver evaluates the following ladder in order. Each rung either produces
+a trustworthy result, fails explicitly, or advances; it never falls through
+after making an ambiguous choice.
+
+1. **Exact canonical form.** A complete spec such as
+   `anthropic/claude-fable-5:low@pi` is accepted verbatim. gmux performs no
+   model, effort, or harness inference. Ordinary launch validation can still
+   report that its explicitly named backend or credentials are unavailable.
+2. **Unique whole-token match over usable models.** A shorthand must equal a
+   complete token in a usable model name. Token boundaries are punctuation
+   boundaries in the catalog identity: `sol` matches `gpt-5.6-sol`, but does
+   not match `solar`. This is **partial-name specification, not fuzzy
+   matching**: there is no substring, prefix, edit-distance, or similarity
+   search.
+   - If all matches are members of one declared model family, select the
+     latest member by catalog version ordering. Thus `fable` advances from
+     fable 5 to fable 6 without an alias edit.
+   - If that family is available through multiple otherwise-equivalent launch
+     backends, select according to `preferred_backends`.
+   - If matches span distinct families, fail and list the canonical candidates.
+     gmux never guesses across families. A human can choose; an agent can retry
+     cheaply with another token or a canonical spec.
+3. **History as a constrained tiebreak and effort default.** Usage history has
+   exactly two responsibilities: it supplies the most recently used thinking
+   effort for the resolved model when effort was omitted, and breaks a tie
+   among candidates that remain otherwise equal. The most recent applicable
+   launch wins; frequency is irrelevant. History never introduces a candidate
+   absent from the current usable catalog and never overrides a family or
+   backend preference decision.
+4. **Echo and freeze.** Before launch, gmux prints the fully resolved canonical
+   `model:effort@harness` form. It records that same value in session metadata.
+   The session is thereafter bound to that value: resume, reads, and later
+   operations never re-run shorthand resolution.
+
+If the supplied shorthand reaches no usable candidate, resolution fails with an
+error asking for a model and, where useful, naming discoverable choices. There
+is no implicit global default model in this decision.
+
+### Configuration
+
+The only new configuration is `preferred_backends`, an ordered preference used
+when the same family has otherwise-equivalent usable launch choices. gmux ships
+a sane order covering every supported choice, so zero-config resolution works;
+choices unavailable on the target host naturally drop out with the corpus.
+
+A future `default_model` may remove the need to supply any model. It is omitted
+initially: an underspecified launch fails and asks for a model rather than
+silently acquiring a product-wide default.
+
+### Stability convention
+
+Shorthand is a human and agent ergonomic affordance, not a reproducibility
+mechanism. Its meaning may intentionally advance when a new family member is
+released. The launch echo makes that choice visible and session metadata makes
+it auditable and permanent for that session. Automation requiring a stable
+choice uses the canonical form.
+
+## Consequences
+
+- Unconfigured providers cannot capture shorthand matches. Catalog usability,
+  rather than match ranking, enforces that property.
+- Family shorthand follows new releases without user-maintained configuration.
+  This depends on accurate family identity and version order from catalogs.
+- Ambiguity is cheap and explicit. Distinct-family matches return candidates
+  instead of embedding an unstable heuristic in a launch.
+- Multi-host launches resolve where they execute, so the target host's actual
+  installation and credentials govern availability.
+- CLI launches and the web picker consume the same catalog capability and
+  should agree about what can be launched.
+- A shorthand may resolve differently across time or hosts by design. The
+  canonical launch echo and frozen metadata are therefore required contract,
+  not optional diagnostics.
+- Backends without discovery support remain usable through canonical specs and
+  do not weaken resolution for other backends.
+
+## Rejected alternatives
+
+### User-maintained aliases
+
+Rejected. Aliases drift, require maintenance for every release, and fail the
+core requirement that “latest fable” keep working without a config edit. A
+canonical form already serves users who want a pinned name.
+
+### Auto-populate preference configuration from usage
+
+Rejected. This would create self-modifying configuration the user never wrote.
+History remains runtime data with the two narrow responsibilities above;
+configuration remains an explicit statement of preference.
+
+### Most-common-usage ranking
+
+Rejected. Frequency entrenches old choices and makes outcomes depend on an
+opaque lifetime count. Only recency may break an otherwise-equal tie or default
+effort.
+
+### Silent cross-backend or cross-provider fallback
+
+Rejected. A different backend or provider can change capabilities,
+configuration, billing, and privacy boundaries. Preference may choose among
+catalog-declared equivalent offerings; gmux does not silently reinterpret an
+unavailable explicit choice or cross an ambiguity boundary. It fails and lists
+candidates.
+
+### Substring or edit-distance fuzzy matching
+
+Rejected. These searches admit accidental neighbors and make the winner depend
+on catalog contents and ordering. Whole-token equality has a stable,
+explainable boundary.
+
+### Let history expand the catalog
+
+Rejected. A previously usable model may be removed, deprecated, logged out, or
+unavailable on the target host. Historical use is not evidence of present
+launchability.
+
+## Open questions
+
+- **Cross-backend family identity:** is family grouping declared by each
+  backend, reconciled in a shared registry, or inferred? Naming inference is a
+  material design risk: selecting the latest fable requires knowing that fable
+  5 and fable 6 belong to one family, including when different backends expose
+  them.
+- **Catalog wire shape:** request/response framing, refresh and invalidation,
+  authentication failure representation, version-order fields, and capability
+  negotiation remain implementation work.
+- **Pi scoping:** how pi's scoped/featured model list maps to usability and
+  ranking without creating a second candidate policy remains open.
+- **Existing-session model changes:** whether this resolver also serves
+  `gmux agent prompt` when an existing session permits changing model is not
+  decided here; this ADR governs launch selection.
+- **Backend preference identifiers:** ADR 0033 uses “backend” for terminal/ACP
+  drive modes while model availability can also span harnesses/providers. The
+  concrete values and equivalence key for `preferred_backends` must be fixed
+  with the catalog schema without changing the ordering rule above.

--- a/docs/adr/0034-driven-launch-model-resolution.md
+++ b/docs/adr/0034-driven-launch-model-resolution.md
@@ -8,17 +8,21 @@
 
 ADR 0033 defines `model:effort@harness` as the canonical session spec for
 driven launches and reserves shorthand resolution for this ADR. Callers want
-"the latest fable" to work without maintaining an alias per release; that
-convenience must not rest on arbitrary fuzzy matching.
+`fable` to work as a shorthand without maintaining aliases; that convenience
+must not rest on arbitrary fuzzy matching.
 
-Pi's current behavior shows the failure: it picks the first fuzzy match across
-every model it knows, so `fable` can resolve to `amazon-bedrock/fable` — a
-provider the user never configured — and the launch fails. The corpus was
-wrong, not the shorthand idea.
+Pi's current behavior shows the failure: it picks the first fuzzy match
+across every model it knows, so `fable` can resolve to
+`amazon-bedrock/fable` — a provider the user never configured — and the
+launch fails. The corpus was wrong, not the shorthand idea.
 
-Resolution is host-dependent (installed harnesses and configured providers
-differ per host), and the same catalog data must drive the web UI model
-picker.
+Each harness already maintains a user-facing notion of which models its own
+picker offers: pi's scoped-models list (`enabledModels`), Claude's
+`availableModels` settings allowlist over the SDK model list, Codex's
+non-hidden `model/list` catalog. gmux should resolve against that, not
+against a parallel model universe of its own. Resolution is host-dependent
+(installed harnesses and configured providers differ per host), and the same
+data must drive the web UI model picker.
 
 ## Decision
 
@@ -29,22 +33,27 @@ launches (`gmux agent prompt --new --model <spec>`) and the web UI
 new-session flow. It runs daemon-side at launch time against the target
 host. Interactive `gmux -- <harness>` is untouched.
 
-### Candidate corpus: usable models only
+### Candidate corpus: the harness's own in-scope, usable models
 
-Shorthand resolution considers only models that are **usable** on the target
-host at resolution time: harness installed, provider configured and
-authenticated, model not deprecated. Unconfigured providers drop out before
-matching — the structural fix for the Bedrock failure.
+Shorthand resolution considers only models that are, on the target host at
+resolution time:
 
-The corpus comes from a new adapter capability: a **model catalog** carrying
-canonical model identity, usability status, version ordering (release date or
-explicit), model-family grouping, and adapter-specific selection facts such as
-pi's scoped/featured flag. (Feasible today: Codex exposes `model/list`; Claude
-exposes model and effort as config options.) An adapter without a catalog
-degrades gracefully: its models resolve only via exact canonical spec and
-contribute no shorthand candidates. The same catalogs feed the web model
-picker, so picker visibility and shorthand eligibility share one source of
-truth.
+- **in scope for their harness** — the list the harness's own picker would
+  show, as the user configured it in the harness itself (pi's scoped models;
+  Claude's `availableModels` allowlist; Codex's non-hidden catalog); and
+- **usable** — harness installed, provider configured and authenticated.
+
+Unconfigured providers drop out before matching — the structural fix for the
+Bedrock failure. gmux introduces no model-curation surface of its own; scope
+is edited where it already lives, in each harness.
+
+The corpus comes from a new adapter capability: report the harness's
+in-scope model list with canonical identity (`provider/model` where the
+harness has providers), usability status, and available effort levels. An
+adapter without this capability degrades gracefully: its models resolve only
+via exact canonical spec and contribute no shorthand candidates. The same
+lists feed the web model picker, so picker visibility and shorthand
+eligibility share one source of truth.
 
 ### Resolution ladder
 
@@ -53,73 +62,81 @@ advances — never an ambiguous guess.
 
 1. **Exact canonical form** (`anthropic/claude-fable-5:low@pi`) is used
    verbatim, with no inference. Ordinary launch validation still applies.
-2. **Unique whole-token match** over the usable corpus: the shorthand must
-   equal a complete token of the model name (`sol` matches `gpt-5.6-sol`, not
+2. **Whole-token match** over the corpus: the shorthand must equal a
+   complete token of the model name (`sol` matches `gpt-5.6-sol`, not
    `solar`). This is **partial-name specification, not fuzzy matching** — no
-   substring, prefix, or edit-distance search.
-   - Matches within one model family → pick the latest by catalog version
-     ordering, so `fable` tracks new releases with zero maintenance.
-   - Same family launchable through multiple harnesses →
-     `preferred_harnesses` order wins.
-   - Matches spanning distinct families → fail, listing the canonical
-     candidates. An agent retries cheaply with a longer token.
-3. **History** has exactly two jobs: default thinking effort for the resolved
-   model (its most recent launch) and tiebreak among otherwise-equal
-   candidates (recency, never frequency). History never introduces a
-   candidate the catalog did not offer.
-4. **Echo and freeze**: the resolved canonical form is printed at launch and
+   substring, prefix, or edit-distance search. A unique match resolves.
+3. **Recency selects among multiple matches**: the match most recently
+   launched through gmux wins. Ties without usable history (e.g. never-used
+   matches) fall to `preferred_harnesses` order across harnesses; if still
+   ambiguous, fail listing the canonical candidates — an agent retries
+   cheaply with a longer token. History never introduces a candidate the
+   corpus did not offer.
+4. **Effort default**: when effort is omitted, use the resolved model's most
+   recent gmux launch effort; otherwise the harness default.
+5. **Echo and freeze**: the resolved canonical form is printed at launch and
    recorded in the session's durable state. Nothing ever re-resolves.
 
-A shorthand reaching no usable candidate fails with an error asking for a
-model. There is no implicit default model.
+A shorthand reaching no candidate fails with an error asking for a model.
+There is no implicit default model.
 
 ### Configuration
 
-One new key: `preferred_harnesses`, an ordered preference shipped with a sane
-default covering all supported harnesses, so zero-config works — unavailable
-harnesses drop out of the corpus naturally. A future `default_model` may be
-added; initially an underspecified launch fails and asks.
+One new key: `preferred_harnesses`, an ordered preference used only for the
+no-history tie above, shipped with a sane default covering all supported
+harnesses so zero-config works. A future `default_model` may be added;
+initially an underspecified launch fails and asks.
 
 ### Stability convention
 
-Shorthand is a human/agent ergonomic affordance; its meaning legitimately
-advances when a new family member releases. The echo makes that visible and
-the frozen record makes it auditable. Automation needing reproducibility uses
-the canonical form.
+Shorthand is a human/agent ergonomic affordance: `fable` means "the fable I
+last used", and switches to a new release only when the caller picks it once
+(canonically or via the picker). The echo makes each resolution visible and
+the frozen record makes it auditable. Automation needing reproducibility
+uses the canonical form.
 
 ## Consequences
 
-- Resolution happens on the target host, so its actual installation and
-  credentials govern availability in multi-host launches.
+- Resolution happens on the target host, so its actual installation,
+  credentials, and harness-side scope govern availability in multi-host
+  launches.
 - Echo + freeze are required contract, not diagnostics: a shorthand may
   resolve differently across time and hosts by design.
-- Family shorthand correctness depends on accurate family identity and
-  version ordering in catalogs (see open questions).
-- CLI resolution and the web picker consume one catalog capability and cannot
-  disagree about what is launchable.
+- Selection needs no model-family identity or version-ordering knowledge:
+  recency replaces "latest within a family". A newly released model is
+  adopted by using it once, not automatically.
+- CLI resolution and the web picker consume one adapter capability and
+  cannot disagree about what is launchable.
+- gmux launch history becomes resolution input and must be recorded per
+  (model, harness) with effort.
 
 ## Rejected alternatives
 
-- **User-maintained aliases** — drift, require an edit per release, and fail
-  the "latest fable without config" requirement.
+- **User-maintained aliases in gmux** — a second curation surface that
+  drifts from the harness-side scope; scope plus recency covers the need.
+- **Family/version machinery ("latest fable")** — requires cross-harness
+  model-family identity and version ordering that no harness reports today;
+  recency gives a simpler, more predictable meaning with zero new metadata.
 - **Auto-populated preferences from usage** — self-modifying configuration
-  the user never wrote; history stays runtime data with its two narrow jobs.
+  the user never wrote; history stays runtime data.
 - **Most-common-usage ranking** — frequency entrenches old choices; recency
-  only, as tiebreaker.
-- **Silent cross-harness or cross-provider fallback** — changes capabilities,
-  configuration, and privacy semantics; fail with candidates instead.
+  only.
+- **Silent cross-harness or cross-provider fallback** — changes
+  capabilities, configuration, and privacy semantics; fail with candidates
+  instead.
 - **Substring/edit-distance fuzzy matching** — admits accidental neighbors;
   whole-token equality has a stable, explainable boundary.
-- **History expanding the catalog** — past use is not evidence of present
-  launchability.
+- **History expanding the corpus** — past use is not evidence of present
+  scope or launchability.
 
 ## Open questions
 
-- **Cross-harness model-family identity** — the one real design risk: "latest
-  fable" requires knowing fable-5 and fable-6 are one family, including when
-  different harnesses expose them. Declared per adapter, reconciled centrally,
-  or inferred from naming?
-- **Catalog capability wire shape**: framing, refresh/invalidation, and how
-  pi's scoped-model list maps to usability and ranking.
+- **Adapter capability wire shape**: framing, refresh/invalidation, and the
+  per-harness mapping (pi exposes scoped models via RPC; Claude's list
+  requires the SDK/adapter or reading its settings; Codex's `model/list`
+  needs `hidden` filtering).
+- **Adapter-side recency as a cold-start hint**: pi persists a single
+  last-used model/effort default; whether adapters should report it to seed
+  resolution before any gmux history exists.
 - Whether this resolver also powers `gmux agent prompt` on existing sessions
   that permit changing model; this ADR governs launch selection only.


### PR DESCRIPTION
## Summary

Adds ADR 0034, the resolver follow-up reserved by ADR 0033, aligned with UBIQUITOUS_LANGUAGE.md:

- resolution only for driven launches (`prompt --new --model <spec>`) and the web new-session flow; interactive `gmux -- <harness>` untouched
- corpus = **the harness's own in-scope list** (pi scoped models / Claude `availableModels` allowlist / Codex non-hidden `model/list`), filtered to usable (installed, provider authenticated) on the target host — gmux adds no curation surface of its own
- deterministic ladder: exact canonical form → whole-token match (partial-name specification, not fuzzy) → **`preferred_harnesses` narrows cross-harness matches first** (fable in scope in both pi and claude launches via the user's preferred one) → **gmux launch recency** among the remaining matches, else fail listing candidates → effort default from history → echo + freeze in durable state
- **supersedes the earlier "latest within a family" design**: recency replaces family identity + version ordering entirely (confirmed with maintainer); a new release is adopted by using it once
- adapter capability: report the in-scope model list with identity, usability, and effort levels; canonical-only graceful degradation without it; same list feeds the web picker

Also amends ADR 0033 decision 5 in this stack:
- **syntax fix**: the spec rides `--model` (`gmux agent prompt --new --model anthropic/claude-fable-5:low@pi '...'`); the positional argument stays the session address
- **terminology**: `preferred_backends` → `preferred_harnesses`; drive mode stated as capability-determined (ACP for claude/codex, terminal for pi), not a preference

## Flagged items

1. **"backend" throughout 0033** (decision 1, title included) conflicts with UBIQUITOUS_LANGUAGE.md's adapter/harness vocabulary. Only resolver-adjacent lines are fixed here; a full terminology pass belongs in #449.
2. **Adapter-side recency is thin** (pi: single last-used default; Claude/Codex: none), so recency means gmux's own launch history; adapter-reported recency stays an open cold-start question.
3. Launch-menu curation (enable/disable/reorder adapters, custom launchables, per-project) and a UI default-launch-mode setting are acknowledged future work, deliberately not designed here.

Docs-only. Stacked on #449.
