### PR TITLE
feat: add root-led agent families

### DIFF
--- a/apps/gmux-web/src/family-drawer.tsx
+++ b/apps/gmux-web/src/family-drawer.tsx
@@ -1,0 +1,123 @@
+import { useEffect, useRef } from 'preact/hooks'
+import { familyNavigation, projectFamily, type FamilyNode } from './family'
+import { viewToPath } from './routing'
+import { projects, sessions, tabHref } from './store'
+import type { Session } from './types'
+
+function hrefFor(session: Session): string | undefined {
+  const path = viewToPath({ kind: 'session', sessionId: session.id }, projects.value, sessions.value)
+  return path ? tabHref(path) : undefined
+}
+
+function FamilyRow({ node, selectedId, depth }: {
+  node: FamilyNode
+  selectedId: string
+  depth: number
+}) {
+  const session = node.session
+  const href = hrefFor(session)
+  return (
+    <li>
+      <a
+        class={`family-row${session.id === selectedId ? ' selected' : ''}${session.alive ? '' : ' inactive'}`}
+        style={{ paddingLeft: `${12 + depth * 18}px` }}
+        href={href}
+        aria-current={session.id === selectedId ? 'page' : undefined}
+        tabIndex={session.id === selectedId ? 0 : undefined}
+      >
+        <span class={`family-row-dot${session.status?.active ? ' active' : ''}`} aria-hidden="true" />
+        <span class="family-row-title">{session.title}</span>
+        <span class="family-row-kind">{session.adapter}</span>
+      </a>
+      {node.children.length > 0 && (
+        <ul>{node.children.map(child => (
+          <FamilyRow key={child.session.id} node={child} selectedId={selectedId} depth={depth + 1} />
+        ))}</ul>
+      )}
+    </li>
+  )
+}
+
+export function FamilyDrawer({ selected, onClose, triggerRef }: {
+  selected: Session
+  onClose: () => void
+  triggerRef: { current: HTMLButtonElement | null }
+}) {
+  const drawerRef = useRef<HTMLDivElement>(null)
+  const projection = projectFamily(selected, sessions.value)
+  // Promotion intentionally defers provenance: promoted sessions present as
+  // roots even though parent_session_id remains immutable on the wire.
+  const navigation = familyNavigation(selected, sessions.value)
+
+  useEffect(() => {
+    const drawer = drawerRef.current
+    drawer?.focus()
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        onClose()
+        triggerRef.current?.focus()
+        return
+      }
+      if (event.key !== 'Tab' || !drawer) return
+      const focusable = [...drawer.querySelectorAll<HTMLElement>('a[href], button:not([disabled])')]
+      if (focusable.length === 0) { event.preventDefault(); drawer.focus(); return }
+      const first = focusable[0]
+      const last = focusable[focusable.length - 1]
+      if (event.shiftKey && document.activeElement === first) { event.preventDefault(); last.focus() }
+      else if (!event.shiftKey && document.activeElement === last) { event.preventDefault(); first.focus() }
+    }
+    document.addEventListener('keydown', onKeyDown)
+    return () => document.removeEventListener('keydown', onKeyDown)
+  }, [onClose, triggerRef])
+
+  // Main App normally focuses the terminal after session navigation. While
+  // this modal remains open, reclaim focus onto the newly-selected row so
+  // keyboard users can traverse the family without the drawer closing or
+  // focus escaping behind it.
+  useEffect(() => {
+    let inner = 0
+    const outer = requestAnimationFrame(() => {
+      inner = requestAnimationFrame(() => {
+        drawerRef.current?.querySelector<HTMLElement>('[aria-current="page"]')?.focus()
+      })
+    })
+    return () => { cancelAnimationFrame(outer); cancelAnimationFrame(inner) }
+  }, [selected.id])
+
+  const navButton = (label: string, session: Session) => {
+    const href = hrefFor(session)
+    return href ? <a class="family-nav-button" href={href}>{label}</a> : null
+  }
+
+  return (
+    <div id="agent-family-drawer" class="family-drawer" role="dialog" aria-modal="true" aria-label="Agent family" tabIndex={-1} ref={drawerRef}>
+      <div class="family-drawer-heading">
+        <strong>Agent family</strong>
+        <div class="family-drawer-nav">
+          {navigation.parent && navButton('Parent', navigation.parent)}
+          {navigation.root && navButton('Root', navigation.root)}
+          <button class="family-drawer-close" type="button" aria-label="Close agent family" onClick={() => {
+            onClose()
+            triggerRef.current?.focus()
+          }}>×</button>
+        </div>
+      </div>
+      {projection.ancestors.length > 0 && (
+        <ol class="family-spine" aria-label="Ancestors">
+          {projection.ancestors.map((ancestor, index) => (
+            <li key={ancestor.id}>
+              <a href={hrefFor(ancestor)}>{ancestor.title}</a>
+              {index < projection.ancestors.length - 1 && <span aria-hidden="true">›</span>}
+            </li>
+          ))}
+        </ol>
+      )}
+      <ul class="family-tree">
+        {projection.siblingTrees.map(node => (
+          <FamilyRow key={node.session.id} node={node} selectedId={selected.id} depth={0} />
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/apps/gmux-web/src/family.test.ts
+++ b/apps/gmux-web/src/family.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+import { descendantTree, familyNavigation, familyRoot, hasFamily, isFamilyChild, projectFamily } from './family'
+import { makeSession } from './test-helpers'
+
+const agent = (id: string, parent?: string, extra = {}) => makeSession({
+  id, cwd: '/p', title: id, parent_session_id: parent, semantic_agent: true, ...extra,
+})
+
+describe('task-family projection', () => {
+  it('uses semantic capability and promotion to distinguish presentation roots', () => {
+    const root = agent('root')
+    const child = agent('child', 'root')
+    const shell = makeSession({ id: 'shell', cwd: '/p', parent_session_id: 'root', adapter: 'shell' })
+    const promoted = agent('promoted', 'root', { promoted_to_root: true })
+    const sessions = [root, child, shell, promoted]
+    expect(isFamilyChild(child, sessions)).toBe(true)
+    expect(isFamilyChild(shell, sessions)).toBe(false)
+    expect(isFamilyChild(promoted, sessions)).toBe(false)
+    expect(familyRoot(child, [root, child])).toBe(root)
+    expect(familyRoot(promoted, [root, promoted])).toBe(promoted)
+  })
+
+  it.each([
+    ['semantic child with shell parent', agent('child', 'shell'), makeSession({ id: 'shell', cwd: '/p', adapter: 'shell' })],
+    ['shell child with semantic parent', makeSession({ id: 'child', cwd: '/p', adapter: 'shell', parent_session_id: 'parent' }), agent('parent')],
+    ['semantic child with missing parent', agent('orphan', 'missing'), undefined],
+  ])('keeps %s as a visible root', (_name, child, parent) => {
+    const sessions = parent ? [parent, child] : [child]
+    expect(isFamilyChild(child, sessions)).toBe(false)
+    expect(familyRoot(child, sessions)).toBe(child)
+    expect(descendantTree(child, sessions).session).toBe(child)
+  })
+
+  it('shows family controls only when a real edge exists', () => {
+    const root = agent('root')
+    const child = agent('child', 'root')
+    const orphan = agent('orphan', 'missing')
+    expect(hasFamily(root, [root, child, orphan])).toBe(true)
+    expect(hasFamily(child, [root, child, orphan])).toBe(true)
+    expect(hasFamily(orphan, [root, child, orphan])).toBe(false)
+  })
+
+  it('fails malformed ancestry cycles open instead of hiding their members', () => {
+    const a = agent('a', 'b')
+    const b = agent('b', 'a')
+    const descendant = agent('descendant', 'a')
+    const snapshot = [a, b, descendant]
+    expect(snapshot.map(s => isFamilyChild(s, snapshot))).toEqual([false, false, false])
+    expect(snapshot.map(s => familyRoot(s, snapshot).id)).toEqual(['a', 'b', 'descendant'])
+  })
+
+  it('derives non-duplicated parent/root header navigation', () => {
+    const root = agent('root')
+    const parent = agent('parent', 'root')
+    const child = agent('child', 'parent')
+    expect(familyNavigation(parent, [root, parent])).toEqual({ parent: root, root: undefined })
+    expect(familyNavigation(child, [root, parent, child])).toEqual({ parent, root })
+  })
+
+  it('keeps a promoted agent full descendant subtree as a new family', () => {
+    const root = agent('root')
+    const promoted = agent('promoted', 'root', { promoted_to_root: true })
+    const grandchild = agent('grandchild', 'promoted')
+    expect(descendantTree(root, [root, promoted, grandchild]).children).toEqual([])
+    expect(descendantTree(promoted, [root, promoted, grandchild]).children[0]?.session).toBe(grandchild)
+  })
+
+  it('projects a child ancestor spine and only its own sibling level trees', () => {
+    const root = agent('root')
+    const aunt = agent('aunt', 'root')
+    const parent = agent('parent', 'root')
+    const selected = agent('selected', 'parent')
+    const sibling = agent('sibling', 'parent')
+    const niece = agent('niece', 'sibling')
+    const p = projectFamily(selected, [root, aunt, parent, selected, sibling, niece])
+    expect(p.ancestors.map(s => s.id)).toEqual(['root', 'parent'])
+    expect(p.siblingTrees.map(n => n.session.id).sort()).toEqual(['selected', 'sibling'])
+    expect(p.siblingTrees.flatMap(n => n.children).map(n => n.session.id)).toEqual(['niece'])
+    expect(p.siblingTrees.some(n => n.session.id === 'aunt')).toBe(false)
+  })
+})

--- a/apps/gmux-web/src/family.ts
+++ b/apps/gmux-web/src/family.ts
@@ -1,0 +1,143 @@
+import type { Session } from './types'
+
+/** Resolve one potential task-family edge without trusting the rest of the
+ * ancestry. Both endpoints must be semantic agents; unresolved provenance is
+ * not a presentation edge. Promotion breaks only the presentation edge without
+ * erasing parent_session_id provenance. */
+function potentialFamilyParent(session: Session, byId: ReadonlyMap<string, Session>): Session | undefined {
+  if (session.semantic_agent !== true
+    || session.promoted_to_root === true
+    || !session.parent_session_id
+    || session.parent_session_id === session.id) return undefined
+  const parent = byId.get(session.parent_session_id)
+  return parent?.semantic_agent === true ? parent : undefined
+}
+
+/** Resolve whether this session has a safe direct task-family edge. Malformed
+ * snapshots can contain ancestry cycles even though the daemon rejects them at
+ * registration. Every edge whose ancestry reaches a cycle fails open, keeping
+ * all affected sessions visible rather than filtering the whole component. */
+export function isFamilyChild(session: Session, sessions: readonly Session[]): boolean {
+  const byId = new Map(sessions.map(candidate => [candidate.id, candidate]))
+  if (!potentialFamilyParent(session, byId)) return false
+  const seen = new Set<string>()
+  let current: Session | undefined = session
+  while (current) {
+    if (seen.has(current.id)) return false
+    seen.add(current.id)
+    current = potentialFamilyParent(current, byId)
+  }
+  return true
+}
+
+export function familyRoot(session: Session, sessions: readonly Session[]): Session {
+  const byId = new Map(sessions.map(s => [s.id, s]))
+  const seen = new Set<string>()
+  let current = session
+  while (isFamilyChild(current, sessions) && !seen.has(current.id)) {
+    seen.add(current.id)
+    const parent = byId.get(current.parent_session_id!)
+    if (!parent) break
+    current = parent
+  }
+  return current
+}
+
+export function familyRootId(id: string | null, sessions: readonly Session[]): string | null {
+  if (!id) return null
+  const session = sessions.find(s => s.id === id)
+  return session ? familyRoot(session, sessions).id : id
+}
+
+export interface FamilyNavigation {
+  parent?: Session
+  root?: Session
+}
+
+/** True when the selected session belongs to a family with at least one real
+ * presentation edge. Orphans and standalone semantic agents stay ordinary
+ * roots and therefore do not get family controls. */
+export function hasFamily(session: Session, sessions: readonly Session[]): boolean {
+  if (isFamilyChild(session, sessions)) return true
+  return sessions.some(candidate =>
+    candidate.parent_session_id === session.id && isFamilyChild(candidate, sessions),
+  )
+}
+
+/** Header/drawer navigation for a genuinely nested family member. Root is
+ * omitted when it would duplicate Parent. Promoted sessions and unresolved
+ * provenance intentionally expose neither control. */
+export function familyNavigation(selected: Session, sessions: readonly Session[]): FamilyNavigation {
+  if (!isFamilyChild(selected, sessions)) return {}
+  const parent = sessions.find(s => s.id === selected.parent_session_id)
+  if (!parent) return {}
+  const root = familyRoot(selected, sessions)
+  return { parent, root: root.id !== parent.id ? root : undefined }
+}
+
+export interface FamilyNode {
+  session: Session
+  children: FamilyNode[]
+}
+
+function byRecency(a: Session, b: Session): number {
+  const at = a.last_output_at || a.created_at
+  const bt = b.last_output_at || b.created_at
+  return bt.localeCompare(at) || a.id.localeCompare(b.id)
+}
+
+/** Complete descendant tree for a presentation root. Promoted descendants are
+ * intentionally excluded: each starts a new family, while provenance remains
+ * available on the raw session. */
+export function descendantTree(root: Session, sessions: readonly Session[]): FamilyNode {
+  const childrenByParent = new Map<string, Session[]>()
+  for (const candidate of sessions) {
+    if (!isFamilyChild(candidate, sessions)) continue
+    const children = childrenByParent.get(candidate.parent_session_id!) ?? []
+    children.push(candidate)
+    childrenByParent.set(candidate.parent_session_id!, children)
+  }
+  const build = (session: Session, spine: Set<string>): FamilyNode => {
+    const nextSpine = new Set(spine).add(session.id)
+    const children = (childrenByParent.get(session.id) ?? [])
+      .filter(child => !nextSpine.has(child.id))
+      .sort(byRecency)
+      .map(child => build(child, nextSpine))
+    return { session, children }
+  }
+  return build(root, new Set())
+}
+
+/** Drawer projection. Roots see their tree. A child sees its ancestor spine,
+ * then the complete trees rooted at its own sibling level (including itself),
+ * rather than unrelated siblings of each ancestor. */
+export interface FamilyDrawerProjection {
+  root: Session
+  ancestors: Session[]
+  siblingTrees: FamilyNode[]
+}
+
+export function projectFamily(selected: Session, sessions: readonly Session[]): FamilyDrawerProjection {
+  const byId = new Map(sessions.map(s => [s.id, s]))
+  const root = familyRoot(selected, sessions)
+  if (root.id === selected.id) {
+    return { root, ancestors: [], siblingTrees: [descendantTree(root, sessions)] }
+  }
+
+  const reverse: Session[] = []
+  const seen = new Set<string>([selected.id])
+  let cursor = selected
+  while (isFamilyChild(cursor, sessions)) {
+    const parent = byId.get(cursor.parent_session_id!)
+    if (!parent || seen.has(parent.id)) break
+    reverse.push(parent)
+    seen.add(parent.id)
+    cursor = parent
+  }
+  const parent = reverse[0]
+  const ancestors = reverse.reverse()
+  const siblings = sessions
+    .filter(s => isFamilyChild(s, sessions) && s.parent_session_id === parent?.id)
+    .sort(byRecency)
+  return { root, ancestors, siblingTrees: siblings.map(s => descendantTree(s, sessions)) }
+}

--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -13,6 +13,8 @@ import { Sidebar } from './sidebar'
 import { usePresence } from './use-presence'
 import { lifecycleAction } from './session-actions'
 import { MenuButton } from './menu-button'
+import { FamilyDrawer } from './family-drawer'
+import { familyNavigation, hasFamily } from './family'
 
 import type { Session } from './types'
 import { SettingsModal } from './settings'
@@ -176,6 +178,14 @@ function MainHeader({ session, onRestart, onResume, resuming }: {
   onResume?: (id: string) => void
   resuming?: boolean
 }) {
+  const [familyOpen, setFamilyOpen] = useState(false)
+  const familyTriggerRef = useRef<HTMLButtonElement>(null)
+  const closeFamily = useCallback(() => setFamilyOpen(false), [])
+  const showFamily = session ? hasFamily(session, sessions.value) : false
+  useEffect(() => {
+    if (!showFamily) setFamilyOpen(false)
+  }, [showFamily])
+
   if (!session) {
     return (
       <div class="main-header">
@@ -187,10 +197,41 @@ function MainHeader({ session, onRestart, onResume, resuming }: {
   }
 
   const shortCwd = session.cwd.replace(/^\/home\/[^/]+/, '~')
+  const familyNav = familyNavigation(session, sessions.value)
 
   return (
     <div class={`main-header ${keyboardOpen.value ? 'keyboard-collapsed' : ''}`}>
       <div class="main-header-left">
+        {showFamily && (
+          <button
+            ref={familyTriggerRef}
+            class="family-pill"
+            type="button"
+            aria-expanded={familyOpen}
+            aria-controls="agent-family-drawer"
+            onClick={() => setFamilyOpen(open => !open)}
+          >
+            Agents / Family
+          </button>
+        )}
+        {familyNav.parent && (
+          <button
+            class="family-header-nav"
+            type="button"
+            aria-label={`Go to parent agent: ${familyNav.parent.title}`}
+            title={`Parent: ${familyNav.parent.title}`}
+            onClick={() => navigateToSession(familyNav.parent!.id)}
+          >↑</button>
+        )}
+        {familyNav.root && (
+          <button
+            class="family-header-nav"
+            type="button"
+            aria-label={`Go to root agent: ${familyNav.root.title}`}
+            title={`Root: ${familyNav.root.title}`}
+            onClick={() => navigateToSession(familyNav.root!.id)}
+          >⌂</button>
+        )}
         <div class="main-header-title">
           {session.title}
         </div>
@@ -202,6 +243,9 @@ function MainHeader({ session, onRestart, onResume, resuming }: {
         <HeaderStatusChip session={session} resuming={resuming} />
         <SessionMenu session={session} onRestart={onRestart} onResume={onResume} resuming={resuming} />
       </div>
+      {showFamily && familyOpen && (
+        <FamilyDrawer selected={session} onClose={closeFamily} triggerRef={familyTriggerRef} />
+      )}
     </div>
   )
 }

--- a/apps/gmux-web/src/projects.ts
+++ b/apps/gmux-web/src/projects.ts
@@ -328,6 +328,11 @@ export function countUnmatchedActive(
  * renders on the session row so the user knows it's a container
  * session.
  */
+export interface TemporaryPresentationPlacement {
+  ownerPeer: string
+  slug: string
+}
+
 export function buildProjectFolders(
   projects: ProjectItem[],
   sessions: Session[],
@@ -337,6 +342,13 @@ export function buildProjectFolders(
   // `peer` is a frozen viewer-owned label, so references bucket/label by
   // it directly; this only sets the unresolved flag. Omitted ⇒ present.
   isPresent?: (peer: string, nodeId?: string) => boolean,
+  // Presentation roots that must remain locatable (for example when a live
+  // child is selected but its root itself is inactive).
+  forceVisible?: ReadonlySet<string>,
+  // Ephemeral placement for an unstamped presentation root whose relevant
+  // child already resolves to a folder. This affects only this projection;
+  // the root's authoritative project/peer facts remain untouched.
+  temporaryPlacements?: ReadonlyMap<string, TemporaryPresentationPlacement>,
 ): Folder[] {
   // Bucket every stamped session by `${ownerPeer}::${slug}`.
   // ownerPeer is '' for sessions owned by the viewer (local sessions,
@@ -351,7 +363,11 @@ export function buildProjectFolders(
   }
 
   for (const s of sessions) {
-    if (!s.project_slug) continue // unstamped: surfaces via discovery only
+    if (!s.project_slug) {
+      const temporary = temporaryPlacements?.get(s.id)
+      if (temporary) bucket(temporary.ownerPeer, temporary.slug, s)
+      continue // all other unstamped sessions surface via discovery only
+    }
     const sessionPeer = s.peer ?? ''
     const ownerPeer = sessionPeer && !(isLocalPeer?.(sessionPeer))
       ? sessionPeer
@@ -368,7 +384,7 @@ export function buildProjectFolders(
     const ownerPeer = project.peer ?? ''
     const unresolved = ownerPeer !== '' && !!isPresent && !isPresent(ownerPeer, project.node_id)
     const ss = buckets.get(`${ownerPeer}::${project.slug}`) ?? []
-    const visible = ss.filter(s => s.alive || s.resumable === true)
+    const visible = ss.filter(s => s.alive || s.resumable === true || forceVisible?.has(s.id))
     visible.sort(compareFolderSessions)
     placeChildSessions(visible)
     // Owned: derive launchCwd from the project's first path rule.

--- a/apps/gmux-web/src/routing.test.ts
+++ b/apps/gmux-web/src/routing.test.ts
@@ -273,6 +273,46 @@ describe('resolveSessionFromPath', () => {
   })
 })
 
+describe('task-family project routing', () => {
+  const projects: ProjectItem[] = [{ slug: 'root-project', match: [{ path: '/root' }] }, { slug: 'child-project', match: [{ path: '/child' }] }]
+  const root = makeSession({ id: 'root', cwd: '/root', adapter: 'pi', slug: 'root', project_slug: 'root-project', semantic_agent: true })
+  const child = makeSession({ id: 'child', cwd: '/child', adapter: 'pi', slug: 'child', parent_session_id: 'root', semantic_agent: true, project_slug: 'child-project' })
+
+  it('serializes and resolves an unpromoted child in its root project', () => {
+    expect(viewToPath({ kind: 'session', sessionId: 'child' }, projects, [root, child])).toBe('/root-project/pi/child')
+    expect(resolveViewFromPath('/root-project/pi/child', projects, [root, child])).toEqual({ kind: 'session', sessionId: 'child' })
+  })
+
+  it('uses normal matching without root fallback after promotion', () => {
+    const promoted = { ...child, promoted_to_root: true }
+    expect(viewToPath({ kind: 'session', sessionId: 'child' }, projects, [root, promoted])).toBe('/child-project/pi/child')
+    expect(resolveViewFromPath('/root-project/pi/child', projects, [root, promoted])).toEqual({ kind: 'home' })
+  })
+
+  it('detects slug collisions in the root project namespace', () => {
+    const sibling = { ...child, id: 'sibling', project_slug: 'elsewhere' }
+    expect(hasSessionSlugCollision(child, [root, child, sibling], projects)).toBe(true)
+    expect(viewToPath({ kind: 'session', sessionId: 'child' }, projects, [root, child, sibling])).toBe('/root-project/pi/~child')
+  })
+
+  it('round-trips peer-owner and local children that serialize without a host segment', () => {
+    const peerProjects: ProjectItem[] = [{ slug: 'peer-project', peer: 'tower' }]
+    const peerRoot = makeSession({ id: 'root@tower', peer: 'tower', cwd: '/root', adapter: 'pi', slug: 'root', project_slug: 'peer-project', semantic_agent: true })
+    const ownerChild = makeSession({ id: 'owner@tower', peer: 'tower', cwd: '/owner', adapter: 'pi', slug: 'same', parent_session_id: peerRoot.id, semantic_agent: true })
+    const localChild = makeSession({ id: 'local', cwd: '/local', adapter: 'pi', slug: 'same', parent_session_id: peerRoot.id, semantic_agent: true })
+    const snapshot = [peerRoot, ownerChild, localChild]
+
+    for (const [session, path] of [
+      [ownerChild, '/@tower/peer-project/pi/~owner@tower'],
+      [localChild, '/@tower/peer-project/pi/~local'],
+    ] as const) {
+      expect(hasSessionSlugCollision(session, snapshot, peerProjects)).toBe(true)
+      expect(viewToPath({ kind: 'session', sessionId: session.id }, peerProjects, snapshot)).toBe(path)
+      expect(resolveViewFromPath(path, peerProjects, snapshot)).toEqual({ kind: 'session', sessionId: session.id })
+    }
+  })
+})
+
 describe('resolveViewFromPath', () => {
   const projects: ProjectItem[] = [
     { slug: 'gmux', match: [{ remote: 'github.com/gmuxapp/gmux' }, { path: '/dev/gmux' }] },

--- a/apps/gmux-web/src/routing.ts
+++ b/apps/gmux-web/src/routing.ts
@@ -3,8 +3,9 @@
 // Maps between URL paths and the app's view model. Pure functions with
 // no side effects or signal dependencies.
 
-import type { Session, ProjectItem } from './types'
+import { familyRoot } from './family'
 import { matchSession } from './projects'
+import type { ProjectItem, Session } from './types'
 
 // --- URL parsing ---
 
@@ -104,15 +105,19 @@ export function resolveSessionFromPath(
   // (used when a local folder contains adopted peer sessions).
   const filterHost = parsed.host
   const projectSessions = sessions.filter(s => {
+    // Unpromoted children are presented in their root's project. Promotion
+    // makes familyRoot return the session itself, so normal matching applies
+    // with no provenance fallback.
+    const presentation = familyRoot(s, sessions)
     if (parsed.projectPeer) {
-      // Peer-owned project: trust the stamp.
-      if (s.peer !== parsed.projectPeer) return false
-      if (s.project_slug !== parsed.project) return false
+      // Peer-owned project: trust the presentation root's stamp.
+      if (presentation.peer !== parsed.projectPeer) return false
+      if (presentation.project_slug !== parsed.project) return false
     } else {
       // Local project: claimed-local OR disclaimed-adopted.
-      const claimedHere = !s.peer && s.project_slug === parsed.project
-      const adoptedHere = !s.project_slug
-        && matchSession(s, projects)?.slug === parsed.project
+      const claimedHere = !presentation.peer && presentation.project_slug === parsed.project
+      const adoptedHere = !presentation.project_slug
+        && matchSession(presentation, projects)?.slug === parsed.project
       if (!claimedHere && !adoptedHere) return false
     }
     if (filterHost !== undefined && s.peer !== filterHost) return false
@@ -220,16 +225,30 @@ export function resolveViewFromPath(
  */
 export function hasSessionSlugCollision(session: Session, sessions: Session[], projects: ProjectItem[]): boolean {
   if (!session.slug) return false
-  const namespace = session.peer && session.project_slug
-    ? `peer:${session.peer}:${session.project_slug}`
-    : `local:${session.project_slug ?? matchSession(session, projects)?.slug ?? ''}`
-  return sessions.some(s => {
-    if (s.id === session.id || s.peer !== session.peer || s.adapter !== session.adapter || s.slug !== session.slug) return false
-    const otherNamespace = s.peer && s.project_slug
-      ? `peer:${s.peer}:${s.project_slug}`
-      : `local:${s.project_slug ?? matchSession(s, projects)?.slug ?? ''}`
-    return namespace === otherNamespace
-  })
+  // A family child routes through its presentation root's project while
+  // retaining its own host/adapter/slug. Collision detection must use that
+  // same namespace or two children can serialize to one ambiguous URL.
+  const namespace = (candidate: Session): string => {
+    const presentation = familyRoot(candidate, sessions)
+    if (presentation.peer && presentation.project_slug) {
+      // Match sessionPath's actual mid-path host segment. Both an owner-hosted
+      // child (peer === project owner) and a local child (peer absent) omit it,
+      // so they share one URL namespace and must collide on equal slugs.
+      const serializedHost = candidate.peer && candidate.peer !== presentation.peer
+        ? candidate.peer
+        : ''
+      return `peer:${presentation.peer}:${presentation.project_slug}:host:${serializedHost}`
+    }
+    const projectSlug = presentation.project_slug ?? matchSession(presentation, projects)?.slug ?? ''
+    return `local:${projectSlug}:host:${candidate.peer ?? ''}`
+  }
+  const targetNamespace = namespace(session)
+  return sessions.some(candidate =>
+    candidate.id !== session.id
+    && candidate.adapter === session.adapter
+    && candidate.slug === session.slug
+    && namespace(candidate) === targetNamespace,
+  )
 }
 
 export function viewToPath(
@@ -243,17 +262,18 @@ export function viewToPath(
     case 'session': {
       const sess = sessions.find(s => s.id === view.sessionId)
       if (!sess) return null
-      // Peer-owned project (ADR 0002): URL is peer-prefixed; session
-      // lives on the project's owner.
-      if (sess.project_slug && sess.peer) {
-        return sessionPath(sess.project_slug, sess, sess.peer, hasSessionSlugCollision(sess, sessions, projects))
+      const presentation = familyRoot(sess, sessions)
+      // Peer-owned project (ADR 0002): URL is peer-prefixed; a nested
+      // session keeps its own adapter/slug but uses the root's project.
+      if (presentation.project_slug && presentation.peer) {
+        return sessionPath(presentation.project_slug, sess, presentation.peer, hasSessionSlugCollision(sess, sessions, projects))
       }
       // Local-claimed: project owner is the viewer.
-      if (sess.project_slug && !sess.peer) {
-        return sessionPath(sess.project_slug, sess, undefined, hasSessionSlugCollision(sess, sessions, projects))
+      if (presentation.project_slug && !presentation.peer) {
+        return sessionPath(presentation.project_slug, sess, undefined, hasSessionSlugCollision(sess, sessions, projects))
       }
       // Disclaimed: viewer's match rules decide the local folder.
-      const project = matchSession(sess, projects)
+      const project = matchSession(presentation, projects)
       if (!project) return null
       return sessionPath(project.slug, sess, undefined, hasSessionSlugCollision(sess, sessions, projects))
     }

--- a/apps/gmux-web/src/sidebar.tsx
+++ b/apps/gmux-web/src/sidebar.tsx
@@ -13,7 +13,7 @@ import { reorderKeysForFolder } from './projects'
 import { LaunchButton } from './launcher'
 import { useArrivalPulse } from './use-arrival-pulse'
 import {
-  folders, selectedId, sessions,
+  folders, familySelectedId, sessions,
   activityMap, projects, connState, health, peers,
   collapsedFolders, toggleFolderCollapsed,
   updateProjects, reorderSessions,
@@ -551,7 +551,7 @@ export function Sidebar({
   // Read signals; component re-renders only when these values change.
   const foldersVal = folders.value
   const projectsVal = projects.value
-  const selId = selectedId.value
+  const selId = familySelectedId.value
   const am = activityMap.value
   const peerStatus = peerStatusByName.value
   const mode = sidebarMode.value

--- a/apps/gmux-web/src/store.test.ts
+++ b/apps/gmux-web/src/store.test.ts
@@ -5,7 +5,7 @@ import {
   markSessionRead, dismissSession, reorderSessions, resumeSession, killSession,
   handleActivity, isSessionActive, isSessionFading, activityMap,
   sessionStaleness, peers, peerAppearance, peerStatusByName,
-  isSessionUnavailable, urlPath, urlSearch, urlHash, filteredSessions, sidebarSessions, selectedId, folders,
+  isSessionUnavailable, urlPath, urlSearch, urlHash, filteredSessions, sidebarSessions, selectedId, familySelectedId, folders,
   navigateToSession, setNavigate, navigate, tabHref, initStore,
   applyPending, _rawSessions, _setRawWorld, _pendingMutations,
   applySessionsSnapshot,
@@ -264,6 +264,92 @@ describe('sidebar views share one membership (Projects == Activity)', () => {
     setAliveOnly(false)
   })
   afterEach(() => setAliveOnly(false))
+
+  it('hides agent children from both views and selects their root row', () => {
+    _rawSessions.value = [
+      makeSession({ id: 'root', cwd: '/p', adapter: 'pi', slug: 'root', project_slug: 'proj', semantic_agent: true, alive: false, resumable: false }),
+      makeSession({ id: 'child', cwd: '/other', adapter: 'pi', slug: 'child', project_slug: 'proj', semantic_agent: true, parent_session_id: 'root' }),
+      makeSession({ id: 'helper', cwd: '/p', adapter: 'shell', slug: 'helper', project_slug: 'proj', parent_session_id: 'root' }),
+    ]
+    urlPath.value = '/proj/pi/child'
+    expect(folderIds()).toEqual(['helper', 'root'])
+    expect(ids(sidebarActivity.value)).toEqual(['helper', 'root'])
+    expect(familySelectedId.value).toBe('root')
+  })
+
+  it('projects normalized peer family facts as one viewer-visible root row', () => {
+    _setRawWorld({
+      projects: [{ slug: 'proj', peer: 'tower' }],
+      peers: [{ name: 'tower', url: '', status: 'connected', session_count: 2 }],
+    })
+    const now = new Date().toISOString()
+    _rawSessions.value = [
+      makeSession({ id: 'root@tower', peer: 'tower', cwd: '/p', adapter: 'pi', slug: 'root', project_slug: 'proj', semantic_agent: true, last_output_at: now }),
+      makeSession({ id: 'child@tower', peer: 'tower', cwd: '/p', adapter: 'pi', slug: 'child', project_slug: 'proj', semantic_agent: true, parent_session_id: 'root@tower', last_output_at: now }),
+    ]
+    expect(folderIds()).toEqual(['root@tower'])
+    expect(ids(sidebarActivity.value)).toEqual(['root@tower'])
+    expect(homePartition.value.flatMap(bucket => bucket.sessions.map(s => s.id))).toEqual(['root@tower'])
+  })
+
+  it('temporarily places an unstamped root from its relevant child folder', () => {
+    const root = makeSession({ id: 'root', cwd: '/p', adapter: 'pi', slug: 'root', semantic_agent: true, alive: false, resumable: false })
+    const child = makeSession({ id: 'child', cwd: '/p', adapter: 'pi', slug: 'child', project_slug: 'proj', semantic_agent: true, parent_session_id: 'root', alive: true })
+    _rawSessions.value = [root, child]
+
+    expect(folders.value.map(folder => [folder.slug, ...folder.sessions.map(s => s.id)])).toEqual([['proj', 'root']])
+    expect(ids(sidebarActivity.value)).toEqual(['root'])
+    expect(_rawSessions.value.find(s => s.id === 'root')?.project_slug).toBeUndefined()
+
+    _rawSessions.value = [{ ...root, project_slug: 'proj' }, child]
+    expect(folders.value.map(folder => [folder.slug, ...folder.sessions.map(s => s.id)])).toEqual([['proj', 'root']])
+    expect(ids(sidebarActivity.value)).toEqual(['root'])
+    expect(folders.value[0]?.sessions[0]?.project_slug).toBe('proj')
+  })
+
+  it('keeps a dead root visible while a live child makes its family relevant', () => {
+    _rawSessions.value = [
+      makeSession({ id: 'root', cwd: '/p', adapter: 'pi', slug: 'root', project_slug: 'proj', semantic_agent: true, alive: false, resumable: false }),
+      makeSession({ id: 'child', cwd: '/p', adapter: 'pi', slug: 'child', project_slug: 'proj', semantic_agent: true, parent_session_id: 'root', alive: true }),
+    ]
+    expect(folderIds()).toEqual(['root'])
+    expect(ids(sidebarActivity.value)).toEqual(['root'])
+  })
+
+  it('resolves family edges against the full snapshot under a tab filter', () => {
+    _setRawWorld({ projects: [
+      { slug: 'root-project', match: [{ path: '/root' }] },
+      { slug: 'child-project', match: [{ path: '/child' }] },
+    ], peers: [] })
+    _rawSessions.value = [
+      makeSession({ id: 'root', cwd: '/root', adapter: 'pi', slug: 'root', project_slug: 'root-project', semantic_agent: true, alive: false, resumable: false }),
+      makeSession({ id: 'child', cwd: '/child', adapter: 'pi', slug: 'child', project_slug: 'child-project', semantic_agent: true, parent_session_id: 'root', alive: true }),
+    ]
+    urlSearch.value = '?filter=child-project'
+    expect(folderIds()).toEqual(['root'])
+  })
+
+  it('keeps malformed cycle members reachable in the sidebar and Home', () => {
+    const now = new Date().toISOString()
+    _rawSessions.value = [
+      makeSession({ id: 'a', cwd: '/p', adapter: 'pi', slug: 'a', project_slug: 'proj', semantic_agent: true, parent_session_id: 'b', last_output_at: now }),
+      makeSession({ id: 'b', cwd: '/p', adapter: 'pi', slug: 'b', project_slug: 'proj', semantic_agent: true, parent_session_id: 'a', last_output_at: now }),
+    ]
+    expect(folderIds()).toEqual(['a', 'b'])
+    expect(homePartition.value.flatMap(bucket => bucket.sessions.map(s => s.id)).sort()).toEqual(['a', 'b'])
+  })
+
+  it('never hides unresolved or non-agent launch-parent edges', () => {
+    _rawSessions.value = [
+      makeSession({ id: 'agent-parent', cwd: '/p', adapter: 'pi', project_slug: 'proj', semantic_agent: true }),
+      makeSession({ id: 'shell-child', cwd: '/p', adapter: 'shell', project_slug: 'proj', parent_session_id: 'agent-parent' }),
+      makeSession({ id: 'shell-parent', cwd: '/p', adapter: 'shell', project_slug: 'proj' }),
+      makeSession({ id: 'agent-under-shell', cwd: '/p', adapter: 'pi', project_slug: 'proj', semantic_agent: true, parent_session_id: 'shell-parent' }),
+      makeSession({ id: 'orphan', cwd: '/p', adapter: 'pi', project_slug: 'proj', semantic_agent: true, parent_session_id: 'missing' }),
+    ]
+    expect(folderIds()).toEqual(['agent-parent', 'agent-under-shell', 'orphan', 'shell-child', 'shell-parent'])
+    expect(ids(sidebarActivity.value)).toEqual(folderIds())
+  })
 
   it('Activity lists exactly the sessions the folders do (alive, resumable, dead-selected)', () => {
     _rawSessions.value = [
@@ -1517,6 +1603,18 @@ describe('parseConnectURL', () => {
 
   it('returns null for non-URL input so the separate token field is used', () => {
     expect(parseConnectURL('gmux-host')).toBeNull()
+  })
+})
+
+describe('family wire mapping', () => {
+  it('preserves parent provenance, semantic capability, and promotion', () => {
+    const parsed = SessionSchema.parse({
+      id: 'child', alive: true, parent_session_id: 'root',
+      semantic_agent: true, promoted_to_root: true,
+    })
+    expect(toUISession(parsed)).toMatchObject({
+      parent_session_id: 'root', semantic_agent: true, promoted_to_root: true,
+    })
   })
 })
 

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -18,7 +18,8 @@ import type { Session, ProjectItem, DiscoveredProject, PeerInfo, PeerProject, La
 import type { View } from './routing'
 import { resolveViewFromPath, viewToPath } from './routing'
 import { navigateWithReload } from './version-watch'
-import { buildProjectFolders, discoverProjects } from './projects'
+import { buildProjectFolders, discoverProjects, type TemporaryPresentationPlacement } from './projects'
+import { familyRootId, isFamilyChild } from './family'
 import { referencePresence, unresolvedReferences, removeReferenceItems, removeHostReferenceItems, type UnresolvedHost } from './references'
 import { parseFilterParam, formatFilterParam, sessionMatchesFilter, type Selector } from './tab-filter'
 import { pushError } from './toasts'
@@ -602,12 +603,44 @@ export const unresolvedHosts = computed<UnresolvedHost[]>(
  *  set behind `unreadCount` (a global signal that must ignore the
  *  ?project=/?cwd= view filter). */
 function foldersFrom(ss: Session[]): Folder[] {
+  const forceVisible = new Set<string>()
+  const temporaryPlacements = new Map<string, TemporaryPresentationPlacement>()
+  const selectedRoot = familyRootId(selectedId.value, sessions.value)
+  if (selectedRoot) forceVisible.add(selectedRoot)
+  for (const candidate of ss) {
+    if (isFamilyChild(candidate, sessions.value)) {
+      const rootId = familyRootId(candidate.id, sessions.value)
+      if (!rootId) continue
+      forceVisible.add(rootId)
+      const root = sessions.value.find(session => session.id === rootId)
+      if (root?.project_slug || !candidate.project_slug) continue
+      const sessionPeer = candidate.peer ?? ''
+      const ownerPeer = sessionPeer && !localPeerNames.value.has(sessionPeer) ? sessionPeer : ''
+      const resolves = projects.value.some(project =>
+        project.slug === candidate.project_slug && (project.peer ?? '') === ownerPeer,
+      )
+      if (!resolves) continue
+      const placement = { ownerPeer, slug: candidate.project_slug }
+      const previous = temporaryPlacements.get(rootId)
+      // A malformed/transitional family can briefly report children in more
+      // than one folder. Pick a stable projection until the root stamp lands.
+      if (!previous || `${placement.ownerPeer}::${placement.slug}` < `${previous.ownerPeer}::${previous.slug}`) {
+        temporaryPlacements.set(rootId, placement)
+      }
+    }
+  }
   return buildProjectFolders(
     projects.value,
-    ss,
+    // Sidebar rows are family roots. Unpromoted semantic-agent children are
+    // navigable in the family drawer but have no independent project row.
+    // Resolve edges against the complete snapshot, not this tab-filtered
+    // subset. A filtered-out parent must not turn its child into a fake root.
+    ss.filter(s => !isFamilyChild(s, sessions.value)),
     (name) => localPeerNames.value.has(name),
     _rawWorld.value.peerProjects,
     referencePresence(peers.value),
+    forceVisible,
+    temporaryPlacements,
   )
 }
 
@@ -633,16 +666,31 @@ export const sidebarSessions = computed(() => {
   const base = filteredSessions.value.filter(s =>
     s.id === sel || (onlyAlive ? s.alive : s.alive || s.resumable),
   )
-  // The selected session may be absent from `filteredSessions` entirely
-  // (the `?filter=` excluded it); add it back from the full list.
-  if (sel && !base.some(s => s.id === sel)) {
-    const s = sessions.value.find(x => x.id === sel)
-    if (s) return [...base, s]
+  // Every relevant child keeps its presentation root locatable, even when the
+  // root is dead or outside the tab filter. The child itself is later removed
+  // from folders; this turns an active subtree into its single root-led row.
+  const out = [...base]
+  for (const candidate of base) {
+    const rootId = familyRootId(candidate.id, sessions.value)
+    const root = sessions.value.find(s => s.id === rootId)
+    if (root && !out.some(s => s.id === root.id)) out.push(root)
   }
-  return base
+  // The selected session may be absent from `filteredSessions` entirely.
+  // Add both it and its family root for stable selected-row highlighting.
+  if (sel) {
+    const selectedSession = sessions.value.find(x => x.id === sel)
+    if (selectedSession && !out.some(s => s.id === selectedSession.id)) out.push(selectedSession)
+    const rootId = familyRootId(sel, sessions.value)
+    const root = sessions.value.find(s => s.id === rootId)
+    if (root && !out.some(s => s.id === root.id)) out.push(root)
+  }
+  return out
 })
 
 export const folders = computed(() => foldersFrom(sidebarSessions.value))
+
+/** Sidebar selection follows a nested session to its presentation root row. */
+export const familySelectedId = computed(() => familyRootId(selectedId.value, sessions.value))
 
 /** Activity-grouped arrangement of the sessions that Projects can
  *  actually place in folders. In particular, recovered sessions may be
@@ -975,7 +1023,7 @@ export const homePartition = computed(() =>
   // Alive only — dead/resumable corpses live in the sidebar's Activity
   // view, not the dashboard. Home renders only the non-`dated` buckets
   // (see home.tsx), keeping it a recent-activity view.
-  partitionByDay(filteredSessions.value.filter(s => s.alive), Date.now()),
+  partitionByDay(filteredSessions.value.filter(s => s.alive && !isFamilyChild(s, sessions.value)), Date.now()),
 )
 
 // ── Mutators ────────────────────────────────────────────────────────────────
@@ -989,6 +1037,11 @@ export function toUISession(s: ProtocolSession): Session {
     workspace_root: s.workspace_root ?? undefined,
     remotes: s.remotes ?? undefined,
     adapter: s.adapter ?? 'shell',
+    // Preserve launch provenance and server-owned family semantics. These were
+    // previously dropped by this protocol → UI mapper.
+    parent_session_id: s.parent_session_id,
+    semantic_agent: s.semantic_agent,
+    promoted_to_root: s.promoted_to_root,
     alive: s.alive,
     pid: s.pid ?? null,
     exit_code: s.exit_code ?? null,

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -1959,6 +1959,7 @@ body {
 .main-panel {
   flex: 1;
   display: flex;
+  position: relative;
   flex-direction: column;
   min-width: 0;
   min-height: 0;
@@ -2038,6 +2039,74 @@ body {
 .main-header-status.working { color: var(--accent); }
 .main-header-status.error   { color: var(--status-error); }
 .main-header-status.ended   { color: var(--text-muted); }
+
+.family-pill,
+.family-nav-button {
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--bg-surface);
+  color: var(--text-secondary);
+  font: 600 11px/1 'Source Sans 3', sans-serif;
+  padding: 6px 9px;
+  cursor: pointer;
+  text-decoration: none;
+  white-space: nowrap;
+}
+.family-pill { flex-shrink: 0; }
+.family-pill:hover,
+.family-pill[aria-expanded="true"],
+.family-nav-button:hover { color: var(--text); border-color: var(--text-muted); }
+.family-header-nav {
+  width: 24px;
+  height: 24px;
+  flex: 0 0 24px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 24px;
+  padding: 0;
+}
+.family-header-nav:hover { background: var(--bg-hover); color: var(--text); }
+.family-pill:focus-visible,
+.family-header-nav:focus-visible,
+.family-nav-button:focus-visible,
+.family-row:focus-visible,
+.family-drawer-close:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+.family-drawer {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  z-index: 40;
+  max-height: min(65vh, 520px);
+  overflow: auto;
+  background: color-mix(in srgb, var(--bg-surface) 96%, transparent);
+  border-bottom: 1px solid var(--border);
+  box-shadow: 0 14px 30px rgba(0, 0, 0, 0.28);
+  padding: 12px 16px 16px;
+}
+.family-drawer-heading { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+.family-drawer-nav { display: flex; align-items: center; gap: 7px; }
+.family-drawer-close { border: 0; background: transparent; color: var(--text-muted); cursor: pointer; font-size: 20px; }
+.family-spine,
+.family-tree,
+.family-tree ul { list-style: none; margin: 0; padding: 0; }
+.family-spine { display: flex; gap: 6px; align-items: center; padding: 10px 4px 8px; font-size: 12px; color: var(--text-muted); }
+.family-spine li { display: flex; gap: 6px; align-items: center; }
+.family-spine a { color: var(--text-secondary); text-decoration: none; }
+.family-tree { border-top: 1px solid var(--border); padding-top: 6px; }
+.family-row { min-height: 34px; display: flex; align-items: center; gap: 8px; padding: 6px 10px; border-radius: 5px; color: var(--text-secondary); text-decoration: none; }
+.family-row:hover { background: var(--bg-hover); color: var(--text); }
+.family-row.selected { background: var(--bg-selected); color: var(--text); }
+.family-row.inactive { opacity: 0.65; }
+.family-row-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--text-muted); flex: 0 0 auto; }
+.family-row-dot.active { background: var(--accent); box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 20%, transparent); }
+.family-row-title { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.family-row-kind { margin-left: auto; color: var(--text-muted); font-size: 11px; }
 
 /* Session actions menu */
 

--- a/apps/gmux-web/src/types.ts
+++ b/apps/gmux-web/src/types.ts
@@ -29,6 +29,10 @@ export interface Session {
    * the sidebar: the child renders directly under its parent.
    */
   parent_session_id?: string
+  /** Server-derived semantic agent capability; never inferred from adapter names. */
+  semantic_agent?: boolean
+  /** Sticky presentation root flag. Does not erase parent_session_id provenance. */
+  promoted_to_root?: boolean
   alive: boolean
   pid: number | null
   exit_code: number | null

--- a/cli/gmux/cmd/gmux/run.go
+++ b/cli/gmux/cmd/gmux/run.go
@@ -178,7 +178,19 @@ func processGroupExists(pgid int) bool {
 // attach is false, the session is spawned detached from the tty and
 // this call returns immediately once the session is running, leaving
 // the session visible in the gmux UI.
+func inheritLaunchParent(dir runDirectives, getenv func(string) string) runDirectives {
+	// A fresh nested launch inherits immutable provenance from the runner
+	// environment. Explicit callers such as `gmux edit` may already provide the
+	// same fact; resume/restart must never acquire a new parent.
+	if dir.ParentSessionID == "" && dir.ResumeID == "" {
+		dir.ParentSessionID = getenv("GMUX_SESSION_ID")
+	}
+	return dir
+}
+
 func runSession(args []string, attach bool, dir runDirectives) {
+	dir = inheritLaunchParent(dir, os.Getenv)
+
 	// Resolve the adapter up front so we can short-circuit one-shot, non-session
 	// invocations (e.g. `pi update`, `pi list`) before any session machinery.
 	// These are not interactive sessions: exec them directly so they behave

--- a/cli/gmux/cmd/gmux/run_test.go
+++ b/cli/gmux/cmd/gmux/run_test.go
@@ -10,6 +10,24 @@ import (
 	"github.com/gmuxapp/gmux/packages/adapter"
 )
 
+func TestInheritLaunchParentOnlyForFreshUnboundLaunch(t *testing.T) {
+	getenv := func(name string) string {
+		if name != "GMUX_SESSION_ID" {
+			t.Fatalf("unexpected env lookup %q", name)
+		}
+		return "parent"
+	}
+	if got := inheritLaunchParent(runDirectives{}, getenv).ParentSessionID; got != "parent" {
+		t.Fatalf("fresh nested launch parent=%q, want parent", got)
+	}
+	if got := inheritLaunchParent(runDirectives{ParentSessionID: "explicit"}, getenv).ParentSessionID; got != "explicit" {
+		t.Fatalf("explicit parent overwritten: %q", got)
+	}
+	if got := inheritLaunchParent(runDirectives{ResumeID: "existing"}, getenv).ParentSessionID; got != "" {
+		t.Fatalf("resume acquired parent %q", got)
+	}
+}
+
 func TestExplicitResumeIDNeverFallsBackToPhantomSession(t *testing.T) {
 	if mayRetrySessionID("1juyvpd8", ptyserver.ErrSocketInUse) {
 		t.Fatal("explicit resume collision would mint an unrelated session id")

--- a/docs/task-family-ui.md
+++ b/docs/task-family-ui.md
@@ -1,0 +1,25 @@
+# Task-family UI integration seam
+
+Task-family presentation uses durable `launch_parent_id` (wire:
+`parent_session_id`) without mutating launch provenance. `promoted_to_root`
+breaks only the presentation edge.
+
+A resolved launch-parent relationship is a family edge only when both the child
+and its direct parent carry `semantic_agent: true`. Missing parents, shells,
+editors, and terminal helpers therefore remain presentation roots and cannot be
+hidden accidentally.
+
+The daemon derives `semantic_agent` from the existing
+`adapter.ConversationSource` capability. This is the same semantic distinction
+used by notification suppression and covers the conversation-backed Pi,
+Claude, and Codex adapters without a frontend adapter-name list. Shell remains
+false.
+
+## Unresolved capability seam
+
+`ConversationSource` describes conversation-backed agents rather than being a
+dedicated family-membership marker. A future semantic agent with no persistent
+conversation source will present as a root. If that case arrives, the adapter
+package should gain a dedicated semantic-agent capability and all semantic
+consumers should migrate together; do not patch it in the frontend with
+adapter-name inference.

--- a/packages/protocol/src/session.ts
+++ b/packages/protocol/src/session.ts
@@ -21,6 +21,11 @@ export const SessionSchema = z.object({
   // $EDITOR inside an existing session). The UI places the child
   // directly under its parent in the sidebar.
   parent_session_id: z.string().optional(),
+  // True when the adapter exposes gmux's conversation-backed semantic-agent
+  // capability. Both endpoints must be true for a task-family edge.
+  semantic_agent: z.boolean().optional().default(false),
+  // Sticky presentation override. Launch provenance remains intact.
+  promoted_to_root: z.boolean().optional().default(false),
   alive: z.boolean(),
   pid: z.number().optional().nullable(),
   exit_code: z.number().optional().nullable(),

--- a/services/gmuxd/cmd/gmuxd/bootstrap_adapters.go
+++ b/services/gmuxd/cmd/gmuxd/bootstrap_adapters.go
@@ -19,6 +19,14 @@ import (
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/sessioncoord"
 )
 
+// semanticAgentAdapter is the shared server-side classification used by task
+// families and notification semantics. ConversationSource is the existing
+// capability that distinguishes conversation-backed agents from shells.
+func semanticAgentAdapter(a adapter.Adapter) bool {
+	_, ok := a.(adapter.ConversationSource)
+	return ok
+}
+
 // productionEndpointSource enumerates both current and legacy runner dirs.
 type productionEndpointSource struct{}
 

--- a/services/gmuxd/cmd/gmuxd/bootstrap_adapters_test.go
+++ b/services/gmuxd/cmd/gmuxd/bootstrap_adapters_test.go
@@ -32,6 +32,31 @@ func (baseOnlyAdapter) Discover() bool                  { return true }
 func (baseOnlyAdapter) Match([]string) bool             { return false }
 func (baseOnlyAdapter) Env(adapter.EnvContext) []string { return nil }
 
+type conversationSourceAdapter struct{ baseOnlyAdapter }
+
+func (conversationSourceAdapter) SnapshotConversations(adapter.ConversationSink) {}
+func (conversationSourceAdapter) WatchConversations(ctx context.Context, _ adapter.ConversationSink) error {
+	return ctx.Err()
+}
+
+func TestSemanticAgentAdapterUsesConversationSource(t *testing.T) {
+	if semanticAgentAdapter(baseOnlyAdapter{name: "shell"}) {
+		t.Fatal("base/shell adapter classified as semantic agent")
+	}
+	if !semanticAgentAdapter(conversationSourceAdapter{baseOnlyAdapter{name: "codex"}}) {
+		t.Fatal("conversation source not classified as semantic agent")
+	}
+	for _, name := range []string{"pi", "claude", "codex"} {
+		a := adapters.FindByAdapter(name)
+		if a == nil || !semanticAgentAdapter(a) {
+			t.Errorf("built-in %s must be a semantic agent via ConversationSource", name)
+		}
+	}
+	if semanticAgentAdapter(adapters.DefaultFallback()) {
+		t.Fatal("built-in shell must remain non-semantic")
+	}
+}
+
 func withAdapters(t *testing.T, values ...adapter.Adapter) {
 	t.Helper()
 	old := adapters.All

--- a/services/gmuxd/cmd/gmuxd/bootstrap_peering_composed_test.go
+++ b/services/gmuxd/cmd/gmuxd/bootstrap_peering_composed_test.go
@@ -65,6 +65,53 @@ func eventually(t *testing.T, f func() bool) {
 	t.Fatal("condition did not become true")
 }
 
+func TestComposedPeerFamilyFactsReachViewerWire(t *testing.T) {
+	spoke := newComposedSpoke(t, []peering.SessionProjection{
+		{ID: "root", Adapter: "pi", Alive: true, SemanticAgent: true},
+		{ID: "child", Adapter: "pi", Alive: true, ParentSessionID: "root", SemanticAgent: true},
+		{ID: "promoted", Adapter: "pi", Alive: true, ParentSessionID: "root", SemanticAgent: true, PromotedToRoot: true},
+		{ID: "cross", Adapter: "pi", Alive: true, ParentSessionID: "external@tower", SemanticAgent: true},
+	})
+	mgr := peering.NewProjectionManager([]config.PeerConfig{{Name: "box", URL: spoke.URL}}, "self", nil, peering.EventHooks{})
+	adapter := &centralPeerAdapter{manager: mgr}
+	mgr.Start()
+	defer mgr.Stop()
+
+	var byID map[string]struct {
+		parent             string
+		semantic, promoted bool
+	}
+	eventually(t, func() bool {
+		rows := adapter.PeerSessions()
+		if len(rows) != 4 {
+			return false
+		}
+		byID = make(map[string]struct {
+			parent             string
+			semantic, promoted bool
+		}, len(rows))
+		for _, row := range rows {
+			byID[row.ID] = struct {
+				parent             string
+				semantic, promoted bool
+			}{row.ParentSessionID, row.SemanticAgent, row.PromotedToRoot}
+		}
+		return true
+	})
+	if got := byID["root@box"]; !got.semantic || got.parent != "" {
+		t.Fatalf("root viewer wire facts = %#v", got)
+	}
+	if got := byID["child@box"]; !got.semantic || got.parent != "root@box" || got.promoted {
+		t.Fatalf("child viewer wire facts = %#v", got)
+	}
+	if got := byID["promoted@box"]; !got.semantic || got.parent != "root@box" || !got.promoted {
+		t.Fatalf("promoted viewer wire facts = %#v", got)
+	}
+	if got := byID["cross@box"]; !got.semantic || got.parent != "external@tower" {
+		t.Fatalf("cross-host parent viewer wire facts = %#v", got)
+	}
+}
+
 func TestComposedPeerActivityReachesCoordinatorOutcomeWithoutLegacySink(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/services/gmuxd/cmd/gmuxd/bootstrap_runner_adapters.go
+++ b/services/gmuxd/cmd/gmuxd/bootstrap_runner_adapters.go
@@ -255,6 +255,10 @@ func (productionRunnerClient) Meta(ctx context.Context, endpoint string) (sessio
 		return sessioncoord.RunnerMeta{}, fmt.Errorf("runner /meta: missing id or adapter")
 	}
 	reg := centralstore.RunnerRegistration{ID: centralstore.SessionID(s.ID), Adapter: s.Adapter, Alive: s.Alive, CreatedAt: parseMillis(s.CreatedAt), ObservedAt: centralstore.UnixMillis(time.Now().UnixMilli())}
+	if s.ParentSessionID != "" {
+		parent := centralstore.SessionID(s.ParentSessionID)
+		reg.LaunchParentID = &parent
+	}
 	reg.Facts = runnerMetaFacts(s)
 	// Prefer the header: it is stamped by the same middleware that stamps the
 	// subscription response, so the two comparisons cannot disagree because
@@ -291,6 +295,7 @@ type runnerMetaWire struct {
 	Subtitle        string            `json:"subtitle"`
 	Command         []string          `json:"command"`
 	Remotes         map[string]string `json:"remotes"`
+	ParentSessionID string            `json:"parent_session_id"`
 	Status          *struct {
 		Active      bool `json:"active"`
 		Error       bool `json:"error"`

--- a/services/gmuxd/cmd/gmuxd/bootstrap_runner_adapters_test.go
+++ b/services/gmuxd/cmd/gmuxd/bootstrap_runner_adapters_test.go
@@ -73,6 +73,20 @@ func waitForRunnerConns(t *testing.T, tracker *runnerConnTracker, want int64) {
 	}
 }
 
+func TestProductionRunnerMetaPreservesLaunchParent(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/meta", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"id":"child","adapter":"pi","alive":true,"created_at":"2026-01-01T00:00:00Z","parent_session_id":"parent"}`)
+	})
+	meta, err := (productionRunnerClient{}).Meta(context.Background(), unixRunner(t, mux))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if meta.Registration.LaunchParentID == nil || *meta.Registration.LaunchParentID != "parent" {
+		t.Fatalf("launch parent lost at runner boundary: %#v", meta.Registration.LaunchParentID)
+	}
+}
+
 func TestProductionRunnerMetaClosesConnections(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/meta", func(w http.ResponseWriter, _ *http.Request) {

--- a/services/gmuxd/cmd/gmuxd/notify_central.go
+++ b/services/gmuxd/cmd/gmuxd/notify_central.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/gmuxapp/gmux/packages/adapter/adapters"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/presence"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/sessioncoord"
 	"nhooyr.io/websocket"
@@ -37,12 +38,15 @@ func defaultNotifyConfig() notifyConfig {
 }
 
 type notifySessionSnapshot struct {
-	Active      bool
-	Interrupted bool
-	Unread      bool
-	Alive       bool
-	Title       string
-	Start       string
+	Active        bool
+	Interrupted   bool
+	Unread        bool
+	Alive         bool
+	Title         string
+	Start         string
+	ParentID      string
+	Promoted      bool
+	SemanticAgent bool
 }
 
 type pendingCentralNotif struct {
@@ -63,15 +67,30 @@ type centralNotifyRouter struct {
 	presence *presence.Table
 	config   notifyConfig
 
-	mu        sync.Mutex
-	prevState map[string]notifySessionSnapshot
-	pending   map[string]*pendingCentralNotif
-	active    map[string]activeCentralNotif
-	nextID    int
+	// deliveryMu linearizes a timer's complete pending→active→send transition
+	// with cancellation. Without it, cancellation can observe the gap after a
+	// timer dequeues pending attention but before it records/sends the active
+	// notification.
+	deliveryMu         sync.Mutex
+	mu                 sync.Mutex
+	prevState          map[string]notifySessionSnapshot
+	suppressedInactive map[string]bool
+	pending            map[string]*pendingCentralNotif
+	active             map[string]activeCentralNotif
+	nextID             int
+
+	// These are deterministic test seams for the cancellation interleaving.
+	// Production leaves both nil.
+	afterPendingDequeue func()
+	beforeCancelLock    func()
 }
 
 func newCentralNotifyRouter(p *presence.Table, cfg notifyConfig) *centralNotifyRouter {
-	return &centralNotifyRouter{presence: p, config: cfg, prevState: make(map[string]notifySessionSnapshot), pending: make(map[string]*pendingCentralNotif), active: make(map[string]activeCentralNotif)}
+	return &centralNotifyRouter{
+		presence: p, config: cfg,
+		prevState: make(map[string]notifySessionSnapshot), suppressedInactive: make(map[string]bool),
+		pending: make(map[string]*pendingCentralNotif), active: make(map[string]activeCentralNotif),
+	}
 }
 
 func (r *centralNotifyRouter) Run(ctx context.Context, seed []sessioncoord.Outcome, events <-chan sessioncoord.Outcome) {
@@ -104,6 +123,11 @@ func notifySnapshot(o sessioncoord.Outcome) notifySessionSnapshot {
 		snap.Unread = o.Session.Unread
 		snap.Title = o.Session.Title
 		snap.Start = fmtMillisPtr(o.Session.StartedAt)
+		snap.Promoted = o.Session.PromotedToRoot
+		snap.SemanticAgent = semanticAgentAdapter(adapters.FindByAdapter(o.Session.Adapter))
+		if o.Session.LaunchParentID != nil {
+			snap.ParentID = string(*o.Session.LaunchParentID)
+		}
 	}
 	return snap
 }
@@ -112,6 +136,7 @@ func (r *centralNotifyRouter) handleOutcome(o sessioncoord.Outcome) {
 	if o.Type == sessioncoord.OutcomeRemoved {
 		r.mu.Lock()
 		delete(r.prevState, string(o.ID))
+		delete(r.suppressedInactive, string(o.ID))
 		r.mu.Unlock()
 		return
 	}
@@ -123,13 +148,39 @@ func (r *centralNotifyRouter) handleOutcome(o sessioncoord.Outcome) {
 	r.mu.Lock()
 	prev, existed := r.prevState[id]
 	r.prevState[id] = cur
+	transitionedInactive := existed && prev.Active && !cur.Active
+	// Suppression is decided at the committed child transition using only the
+	// direct parent's latest committed outcome already observed by this router.
+	// A later parent outcome never retroactively changes this decision. This is
+	// intentionally one hop: an inactive/missing direct parent ends the lookup.
+	if cur.Active {
+		// A new turn gets a fresh completion decision.
+		delete(r.suppressedInactive, id)
+	} else if transitionedInactive {
+		delete(r.suppressedInactive, id)
+		if cur.SemanticAgent && !cur.Promoted && cur.ParentID != "" {
+			parent, parentExists := r.prevState[cur.ParentID]
+			r.suppressedInactive[id] = parentExists && parent.SemanticAgent && parent.Active
+		}
+	}
+	// Runner facts can arrive in separate committed outcomes (for example the
+	// inactive edge before the final unread bit). Once this completion was
+	// suppressed, keep all later attention for that inactive turn suppressed;
+	// parent inactivity or fact ordering must not resurrect it.
+	suppress := !cur.Active && r.suppressedInactive[id]
 	r.mu.Unlock()
 	if !existed {
 		return
 	}
+	if suppress {
+		// Remove attention already pending for this child as well as the
+		// completion/unread attention carried by this outcome.
+		r.CancelForSession(id)
+		return
+	}
 	// An intentional stop is not a completion (ADR 0027): no "finished"
 	// notification for a turn the user themselves ended.
-	if prev.Active && !cur.Active && cur.Alive && !cur.Interrupted {
+	if transitionedInactive && cur.Alive && !cur.Interrupted {
 		r.scheduleNotification(id, "finished", cur.Title, formatFinishedBodyCentral(cur.Start))
 	}
 	if !prev.Unread && cur.Unread {
@@ -186,6 +237,8 @@ func (r *centralNotifyRouter) scheduleNotification(sessionID, notifType, title, 
 }
 
 func (r *centralNotifyRouter) firePending(sessionID string) {
+	r.deliveryMu.Lock()
+	defer r.deliveryMu.Unlock()
 	r.mu.Lock()
 	p, ok := r.pending[sessionID]
 	if !ok {
@@ -206,6 +259,9 @@ func (r *centralNotifyRouter) firePending(sessionID string) {
 		return
 	}
 	r.mu.Unlock()
+	if r.afterPendingDequeue != nil {
+		r.afterPendingDequeue()
+	}
 	if r.presence.AnyFocused() || r.presence.AnyViewing(sessionID) {
 		return
 	}
@@ -239,6 +295,8 @@ func (r *centralNotifyRouter) fireCoalesced(count int) {
 }
 
 func (r *centralNotifyRouter) CancelAllPending() {
+	r.deliveryMu.Lock()
+	defer r.deliveryMu.Unlock()
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	for sid, p := range r.pending {
@@ -248,6 +306,11 @@ func (r *centralNotifyRouter) CancelAllPending() {
 }
 
 func (r *centralNotifyRouter) CancelForSession(sessionID string) {
+	if r.beforeCancelLock != nil {
+		r.beforeCancelLock()
+	}
+	r.deliveryMu.Lock()
+	defer r.deliveryMu.Unlock()
 	r.mu.Lock()
 	if p, ok := r.pending[sessionID]; ok {
 		p.timer.Stop()

--- a/services/gmuxd/cmd/gmuxd/notify_central_parent_test.go
+++ b/services/gmuxd/cmd/gmuxd/notify_central_parent_test.go
@@ -1,0 +1,238 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/centralstore"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/presence"
+)
+
+func newParentNotifyTestRouter(t *testing.T) *centralNotifyRouter {
+	t.Helper()
+	r := newCentralNotifyRouter(presence.New(presence.Callbacks{}), notifyConfig{
+		GracePeriod:   time.Hour,
+		IdleThreshold: time.Minute,
+	})
+	t.Cleanup(r.CancelAllPending)
+	return r
+}
+
+func notifyRow(adapterName string, active bool, parent string, promoted bool) centralstore.Session {
+	row := centralstore.Session{Adapter: adapterName, Active: active, PromotedToRoot: promoted}
+	if parent != "" {
+		id := centralstore.SessionID(parent)
+		row.LaunchParentID = &id
+	}
+	return row
+}
+
+func hasPendingNotification(r *centralNotifyRouter, id string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	_, ok := r.pending[id]
+	return ok
+}
+
+// These cases drive the committed-outcome consumer directly. Their ordering is
+// the race contract: a child's close observes parent outcomes handled before
+// it; parent outcomes handled afterward do not revise that close's decision.
+func TestCentralNotifyDirectParentSuppression(t *testing.T) {
+	tests := []struct {
+		name string
+		seed []struct {
+			id  string
+			row centralstore.Session
+		}
+		child       centralstore.Session
+		wantPending bool
+	}{
+		{
+			name:        "root",
+			child:       notifyRow("pi", true, "", false),
+			wantPending: true,
+		},
+		{
+			name: "active direct parent",
+			seed: []struct {
+				id  string
+				row centralstore.Session
+			}{{"parent", notifyRow("pi", true, "", false)}},
+			child:       notifyRow("pi", true, "parent", false),
+			wantPending: false,
+		},
+		{
+			name: "inactive direct parent",
+			seed: []struct {
+				id  string
+				row centralstore.Session
+			}{{"parent", notifyRow("pi", false, "", false)}},
+			child:       notifyRow("pi", true, "parent", false),
+			wantPending: true,
+		},
+		{
+			name: "active grandparent with inactive direct parent",
+			seed: []struct {
+				id  string
+				row centralstore.Session
+			}{
+				{"grandparent", notifyRow("pi", true, "", false)},
+				{"parent", notifyRow("pi", false, "grandparent", false)},
+			},
+			child:       notifyRow("pi", true, "parent", false),
+			wantPending: true,
+		},
+		{
+			name: "promoted child",
+			seed: []struct {
+				id  string
+				row centralstore.Session
+			}{{"parent", notifyRow("pi", true, "", false)}},
+			child:       notifyRow("pi", true, "parent", true),
+			wantPending: true,
+		},
+		{
+			name:        "missing parent",
+			child:       notifyRow("pi", true, "missing", false),
+			wantPending: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := newParentNotifyTestRouter(t)
+			for _, seed := range tc.seed {
+				r.handleOutcome(upsertOutcome(seed.id, seed.row))
+			}
+			r.handleOutcome(upsertOutcome("child", tc.child))
+			closed := tc.child
+			closed.Active = false
+			r.handleOutcome(upsertOutcome("child", closed))
+			if got := hasPendingNotification(r, "child"); got != tc.wantPending {
+				t.Fatalf("pending child notification = %v, want %v", got, tc.wantPending)
+			}
+		})
+	}
+}
+
+func TestCentralNotifyNonAgentLaunchesRemainRoots(t *testing.T) {
+	r := newParentNotifyTestRouter(t)
+	r.handleOutcome(upsertOutcome("parent", notifyRow("pi", true, "", false)))
+	r.handleOutcome(upsertOutcome("shell-child", notifyRow("shell", true, "parent", false)))
+	r.handleOutcome(upsertOutcome("shell-child", notifyRow("shell", false, "parent", false)))
+	if !hasPendingNotification(r, "shell-child") {
+		t.Fatal("a shell with launch provenance must retain root notification behavior")
+	}
+
+	r = newParentNotifyTestRouter(t)
+	r.handleOutcome(upsertOutcome("shell-parent", notifyRow("shell", true, "", false)))
+	r.handleOutcome(upsertOutcome("agent-child", notifyRow("pi", true, "shell-parent", false)))
+	r.handleOutcome(upsertOutcome("agent-child", notifyRow("pi", false, "shell-parent", false)))
+	if !hasPendingNotification(r, "agent-child") {
+		t.Fatal("a non-agent launch parent must not become an agent management boundary")
+	}
+}
+
+func TestCentralNotifyCancellationLinearizesWithPendingDelivery(t *testing.T) {
+	r := newParentNotifyTestRouter(t)
+	r.presence.Add(&presence.Client{ID: "viewer", NotificationPermission: "granted"})
+	r.scheduleNotification("child", "finished", "Child", "Task finished")
+
+	dequeued := make(chan struct{})
+	releaseDelivery := make(chan struct{})
+	cancelAttempted := make(chan struct{})
+	r.afterPendingDequeue = func() {
+		close(dequeued)
+		<-releaseDelivery
+	}
+	r.beforeCancelLock = func() { close(cancelAttempted) }
+	fireDone := make(chan struct{})
+	go func() {
+		r.firePending("child")
+		close(fireDone)
+	}()
+	<-dequeued // timer has deleted pending but has not inserted/sent active
+	cancelDone := make(chan struct{})
+	go func() {
+		r.CancelForSession("child")
+		close(cancelDone)
+	}()
+	<-cancelAttempted // cancellation is now contending with that exact gap
+	close(releaseDelivery)
+	select {
+	case <-fireDone:
+	case <-time.After(time.Second):
+		t.Fatal("pending delivery did not finish")
+	}
+	select {
+	case <-cancelDone:
+	case <-time.After(time.Second):
+		t.Fatal("cancellation did not finish")
+	}
+	r.mu.Lock()
+	_, pending := r.pending["child"]
+	active := len(r.active)
+	r.mu.Unlock()
+	if pending || active != 0 {
+		t.Fatalf("attention survived serialized cancellation: pending=%v active=%d", pending, active)
+	}
+}
+
+func TestCentralNotifySuppressionCancelsExistingChildAttention(t *testing.T) {
+	r := newParentNotifyTestRouter(t)
+	r.handleOutcome(upsertOutcome("parent", notifyRow("pi", true, "", false)))
+	child := notifyRow("pi", true, "parent", false)
+	r.handleOutcome(upsertOutcome("child", child))
+	withUnread := child
+	withUnread.Unread = true
+	r.handleOutcome(upsertOutcome("child", withUnread))
+	if !hasPendingNotification(r, "child") {
+		t.Fatal("test setup did not schedule child unread attention")
+	}
+	closed := withUnread
+	closed.Active = false
+	r.handleOutcome(upsertOutcome("child", closed))
+	if hasPendingNotification(r, "child") {
+		t.Fatal("managed completion must cancel existing child attention")
+	}
+}
+
+func TestCentralNotifySuppressionSurvivesLateUnreadOutcome(t *testing.T) {
+	r := newParentNotifyTestRouter(t)
+	r.handleOutcome(upsertOutcome("parent", notifyRow("pi", true, "", false)))
+	child := notifyRow("pi", true, "parent", false)
+	r.handleOutcome(upsertOutcome("child", child))
+	closed := child
+	closed.Active = false
+	r.handleOutcome(upsertOutcome("child", closed))
+	lateUnread := closed
+	lateUnread.Unread = true
+	r.handleOutcome(upsertOutcome("child", lateUnread))
+	if hasPendingNotification(r, "child") {
+		t.Fatal("late unread fact resurrected permanently suppressed child attention")
+	}
+}
+
+func TestCentralNotifySuppressionUsesParentStateAtChildCommit(t *testing.T) {
+	t.Run("parent closes before child", func(t *testing.T) {
+		r := newParentNotifyTestRouter(t)
+		r.handleOutcome(upsertOutcome("parent", notifyRow("pi", true, "", false)))
+		r.handleOutcome(upsertOutcome("child", notifyRow("pi", true, "parent", false)))
+		r.handleOutcome(upsertOutcome("parent", notifyRow("pi", false, "", false)))
+		r.handleOutcome(upsertOutcome("child", notifyRow("pi", false, "parent", false)))
+		if !hasPendingNotification(r, "child") {
+			t.Fatal("child committed after parent became inactive must notify")
+		}
+	})
+
+	t.Run("parent closes after child", func(t *testing.T) {
+		r := newParentNotifyTestRouter(t)
+		r.handleOutcome(upsertOutcome("parent", notifyRow("pi", true, "", false)))
+		r.handleOutcome(upsertOutcome("child", notifyRow("pi", true, "parent", false)))
+		r.handleOutcome(upsertOutcome("child", notifyRow("pi", false, "parent", false)))
+		r.handleOutcome(upsertOutcome("parent", notifyRow("pi", false, "", false)))
+		if hasPendingNotification(r, "child") {
+			t.Fatal("later parent inactivity must not retroactively notify the child")
+		}
+	})
+}

--- a/services/gmuxd/cmd/gmuxd/production_spawner_test.go
+++ b/services/gmuxd/cmd/gmuxd/production_spawner_test.go
@@ -27,7 +27,7 @@ func TestRunnerMetaWireJSONFieldTable(t *testing.T) {
 		{"WorkspaceRoot", "workspace_root"}, {"Slug", "slug"},
 		{"ShellTitle", "shell_title"}, {"AdapterTitle", "adapter_title"},
 		{"Subtitle", "subtitle"}, {"Command", "command"}, {"Remotes", "remotes"},
-		{"Status", "status"}, {"Unread", "unread"},
+		{"ParentSessionID", "parent_session_id"}, {"Status", "status"}, {"Unread", "unread"},
 		{"TerminalCols", "terminal_cols"}, {"TerminalRows", "terminal_rows"},
 	}
 	typeOf := reflect.TypeOf(runnerMetaWire{})
@@ -40,7 +40,7 @@ func TestRunnerMetaWireJSONFieldTable(t *testing.T) {
 			t.Errorf("field[%d]=%s json:%q, want %s json:%q", i, field.Name, field.Tag.Get("json"), entry.field, entry.tag)
 		}
 	}
-	status := typeOf.Field(19).Type.Elem()
+	status := typeOf.Field(20).Type.Elem()
 	if status.NumField() != 3 ||
 		status.Field(0).Name != "Active" || status.Field(0).Tag.Get("json") != "active" ||
 		status.Field(1).Name != "Error" || status.Field(1).Tag.Get("json") != "error" ||

--- a/services/gmuxd/cmd/gmuxd/serve_central.go
+++ b/services/gmuxd/cmd/gmuxd/serve_central.go
@@ -234,7 +234,7 @@ func serveCentral(stderr io.Writer, replace bool) int {
 		return h
 	}
 
-	converter := &wire.Converter{Titlers: make(map[string]func([]string) string), ResumeCommand: func(adapterName, ref string) []string {
+	converter := &wire.Converter{Titlers: make(map[string]func([]string) string), SemanticAgents: make(map[string]bool), ResumeCommand: func(adapterName, ref string) []string {
 		legacy := &compatSession{Adapter: adapterName, ConversationRef: ref}
 		return discovery.ResolveResumeCommandFor(legacy.Adapter, legacy.ConversationRef)
 	}, IsLocalPeer: func(name string) bool { return peerManager != nil && peerManager.IsLocalPeer(name) }}
@@ -242,10 +242,16 @@ func serveCentral(stderr io.Writer, replace bool) int {
 		if titler, ok := a.(adapter.CommandTitler); ok {
 			converter.Titlers[a.Name()] = titler.CommandTitle
 		}
+		if semanticAgentAdapter(a) {
+			converter.SemanticAgents[a.Name()] = true
+		}
 	}
 	if fallback := adapters.DefaultFallback(); fallback != nil {
 		if titler, ok := fallback.(adapter.CommandTitler); ok {
 			converter.Titlers[fallback.Name()] = titler.CommandTitle
+		}
+		if semanticAgentAdapter(fallback) {
+			converter.SemanticAgents[fallback.Name()] = true
 		}
 	}
 

--- a/services/gmuxd/internal/centralstore/domain_test.go
+++ b/services/gmuxd/internal/centralstore/domain_test.go
@@ -865,6 +865,10 @@ func TestPromotionAndParentProjectTransitions(t *testing.T) {
 	if got := rootOrder(t, s, p1); !reflect.DeepEqual(got, []string{"l:root", "l:child", "l:parent"}) {
 		t.Fatalf("promoted roots=%v", got)
 	}
+	promoted, ok, err := s.Session(ctx, "child")
+	if err != nil || !ok || promoted.LaunchParentID == nil || *promoted.LaunchParentID != "parent" || !promoted.PromotedToRoot {
+		t.Fatalf("promotion lost provenance: child=%#v ok=%v err=%v", promoted, ok, err)
+	}
 	idx = 0
 	result, err = s.SetPromotion(ctx, "child", false, &idx)
 	if err != nil || result.SessionVersion != 3 {

--- a/services/gmuxd/internal/peering/peer.go
+++ b/services/gmuxd/internal/peering/peer.go
@@ -562,6 +562,15 @@ func (p *Peer) applySessionsSnapshot(input any) {
 			continue
 		}
 		sess.ID = NamespaceID(sess.ID, p.Config.Name)
+		// Bare parent IDs are owned by the same origin as the child and must
+		// enter the viewer namespace with it. Already-qualified references name
+		// another host (or were explicitly qualified by the origin), so retain
+		// them rather than manufacturing parent@other@this-peer.
+		if sess.ParentSessionID != "" {
+			if _, parentPeer := ParseID(sess.ParentSessionID); parentPeer == "" {
+				sess.ParentSessionID = NamespaceID(sess.ParentSessionID, p.Config.Name)
+			}
+		}
 		sess.Peer = p.Config.Name
 		sess.SocketPath = ""
 		out = append(out, sess)

--- a/services/gmuxd/internal/peering/projection.go
+++ b/services/gmuxd/internal/peering/projection.go
@@ -15,6 +15,8 @@ type SessionProjection struct {
 	WorkspaceRoot   string            `json:"workspace_root,omitempty"`
 	Remotes         map[string]string `json:"remotes,omitempty"`
 	ParentSessionID string            `json:"parent_session_id,omitempty"`
+	SemanticAgent   bool              `json:"semantic_agent,omitempty"`
+	PromotedToRoot  bool              `json:"promoted_to_root,omitempty"`
 	Alive           bool              `json:"alive"`
 	Pid             int               `json:"pid,omitempty"`
 	ExitCode        *int              `json:"exit_code,omitempty"`

--- a/services/gmuxd/internal/peering/projection_equal_test.go
+++ b/services/gmuxd/internal/peering/projection_equal_test.go
@@ -16,6 +16,25 @@ import (
 
 func intPtr(v int) *int { return &v }
 
+func TestProjectionFamilyFactsSurviveCloneAndDriveEquality(t *testing.T) {
+	original := SessionProjection{ID: "child@box", ParentSessionID: "root@box", SemanticAgent: true, PromotedToRoot: true}
+	cloned := cloneProjection(original)
+	if cloned.ParentSessionID != original.ParentSessionID || !cloned.SemanticAgent || !cloned.PromotedToRoot {
+		t.Fatalf("family facts lost in clone: %#v", cloned)
+	}
+	for _, mutate := range []func(*SessionProjection){
+		func(row *SessionProjection) { row.ParentSessionID = "other@box" },
+		func(row *SessionProjection) { row.SemanticAgent = false },
+		func(row *SessionProjection) { row.PromotedToRoot = false },
+	} {
+		changed := cloned
+		mutate(&changed)
+		if projectionsEqual([]SessionProjection{original}, []SessionProjection{changed}) {
+			t.Fatalf("family fact change reported equal: before=%#v after=%#v", original, changed)
+		}
+	}
+}
+
 // Ordering: ADR 0001 gives deterministic wire ordering today, but an
 // order-sensitive gate would turn any future reordering into a permanent loop.
 func TestProjectionsEqualIsOrderInsensitive(t *testing.T) {

--- a/services/gmuxd/internal/snapshot/wire/convert.go
+++ b/services/gmuxd/internal/snapshot/wire/convert.go
@@ -28,6 +28,10 @@ type Converter struct {
 	// IsLocalPeer reports whether a peer name is a Local peer (an
 	// extension of this host whose project stamps the parent owns).
 	IsLocalPeer func(name string) bool
+	// SemanticAgents is keyed by adapter name and is populated from the
+	// existing adapter.ConversationSource capability, matching notification
+	// semantics. The web UI must not guess from an adapter-name allowlist.
+	SemanticAgents map[string]bool
 }
 
 // resolveTitle reproduces store.resolveTitle's precedence exactly:
@@ -73,6 +77,8 @@ func (c *Converter) session(row central.SessionRow) Session {
 		Command:         v.Command,
 		Cwd:             v.CWD,
 		Adapter:         v.Adapter,
+		SemanticAgent:   c.SemanticAgents[v.Adapter],
+		PromotedToRoot:  v.PromotedToRoot,
 		WorkspaceRoot:   v.WorkspaceRoot,
 		Remotes:         v.Remotes,
 		Alive:           row.Alive,

--- a/services/gmuxd/internal/snapshot/wire/convert_test.go
+++ b/services/gmuxd/internal/snapshot/wire/convert_test.go
@@ -36,6 +36,18 @@ func place(row *central.SessionRow, slug, scope string, pos int) {
 	row.SessionView.Placement = &centralstore.SessionPlacement{ProjectSlug: slug, SiblingScope: scope, Position: pos}
 }
 
+func TestSessionConversionPreservesFamilyFacts(t *testing.T) {
+	parent := centralstore.SessionID("parent")
+	got := (&Converter{SemanticAgents: map[string]bool{"pi": true}}).session(central.SessionRow{
+		SessionView: centralstore.SessionView{Session: centralstore.Session{
+			ID: "child", Adapter: "pi", CreatedAt: 1, LaunchParentID: &parent, PromotedToRoot: true,
+		}},
+	})
+	if got.ParentSessionID != "parent" || !got.SemanticAgent || !got.PromotedToRoot {
+		t.Fatalf("family facts dropped: %#v", got)
+	}
+}
+
 // TestTitlePrecedence pins the resolveTitle chain against the production
 // precedence (store.resolveTitle): adapter title > shell title >
 // CommandTitler(command) > adapter name.

--- a/services/gmuxd/internal/snapshot/wire/equivalence/equivalence_test.go
+++ b/services/gmuxd/internal/snapshot/wire/equivalence/equivalence_test.go
@@ -16,9 +16,14 @@ import (
 // fdExcluded reports whether a JSON path is one of the accepted FD-* diffs
 // excluded from the structural comparison (design §8): project_index
 // (FD-1), the timestamp fields (FD-4 — asserted separately by
-// parse-and-compare), and the world health session counts (FD-6).
+// parse-and-compare), the world health session counts (FD-6), and task-family
+// facts added after the legacy production composer was retired. Those family
+// fields are covered directly by wire converter tests; the legacy store has no
+// promoted bit or adapter capability map with which to produce them.
 func fdExcluded(path string) bool {
 	switch {
+	case strings.HasSuffix(path, ".semantic_agent"), strings.HasSuffix(path, ".promoted_to_root"):
+		return true
 	case strings.HasSuffix(path, ".project_index"):
 		return true
 	case strings.HasSuffix(path, ".created_at"), strings.HasSuffix(path, ".started_at"),

--- a/services/gmuxd/internal/snapshot/wire/wire.go
+++ b/services/gmuxd/internal/snapshot/wire/wire.go
@@ -54,6 +54,8 @@ type Session struct {
 	WorkspaceRoot   string            `json:"workspace_root,omitempty"`
 	Remotes         map[string]string `json:"remotes,omitempty"`
 	ParentSessionID string            `json:"parent_session_id,omitempty"`
+	SemanticAgent   bool              `json:"semantic_agent,omitempty"`
+	PromotedToRoot  bool              `json:"promoted_to_root,omitempty"`
 	Alive           bool              `json:"alive"`
 	Pid             int               `json:"pid,omitempty"`
 	ExitCode        *int              `json:"exit_code,omitempty"`


### PR DESCRIPTION
## Summary

Add root-led task-family navigation for semantic agent sessions and suppress redundant completion attention for children still managed by an active parent.

### Web UI

- Treat a session as a family child only when its resolved direct parent and the child both carry the server-derived `semantic_agent` capability, the child is unpromoted, and the IDs differ.
- Keep shells, shell-parent/child edges, missing-parent orphans, and promoted sessions visible as roots.
- Show one root-titled row per family across Projects, Activity, and Home; selecting a child highlights the root row, and a relevant child keeps a dead root locatable.
- Route children through the presentation root's project while retaining the selected child's host/adapter/slug.
- Add an Agents / Family header pill, compact Parent/Root controls, and an overlay drawer with ancestor/sibling/descendant context. The drawer remains open across family navigation and restores focus to the selected row.
- Preserve immutable launch provenance; `promoted_to_root` only breaks the presentation edge.

### Daemon notifications

- On a semantic child Active → Inactive transition, suppress user-facing completion/unread attention only when its direct semantic-agent parent is Active in the committed outcome stream.
- Cancel existing pending attention for the child when suppression applies.
- Do not recurse through missing/inactive parents; promoted children and shell endpoints retain root notification behavior.
- A later parent transition does not retroactively revise the child's committed suppression decision.

## Integration notes

- **#436 routing:** kept centralized `navigate()` / `tabHref()` tab-param carrying and sidebar-mode repair. Family serialization is implemented inside the current `viewToPath` / `resolveViewFromPath` model. Slug-collision detection now uses the same root-project namespace as family routing.
- **#448 / #450 adapter capability changes:** `semantic_agent` is derived on the server from `adapter.ConversationSource`, not adapter-name inference in the frontend. Tests pin Pi, Claude, and Codex as semantic and shell as non-semantic, including the current Codex rollout adapter.
- Family membership is resolved against the complete snapshot rather than a tab-filtered subset, so filtering cannot manufacture an orphan or expose a child row.
- Snapshot equivalence excludes the new post-cutover family fields from the retired legacy composer comparison; direct converter tests pin their wire behavior.

### ACP seam

`ConversationSource` is currently the shared semantic-agent capability and covers terminal-backed Pi/Claude/Codex sessions. A future ACP-mode semantic session without a persistent conversation source will report false and present as a root. This PR intentionally does not hard-code ACP or adapter names; if that mode needs family membership, the adapter package should gain a dedicated semantic-agent capability and migrate both UI-wire and notification consumers together. See `docs/task-family-ui.md`.

## Review amendments

- Preserve `semantic_agent` and `promoted_to_root` through peer projection, cloning, equality, and viewer-wire conversion.
- Namespace bare peer parent references with the child while retaining already-qualified cross-host references; an SSE peer-snapshot → viewer-wire integration test pins the full path.
- Fail malformed frontend ancestry cycles open so every affected session remains reachable in both sidebar and Home.
- Serialize pending → active → send delivery with per-session cancellation; a deterministic interleaving test pauses after dequeue and proves cancellation wins without residual active attention.
- Temporarily place an unstamped presentation root in a relevant child's resolved folder without mutating authoritative root stamping; before/after recovery tests pin Projects and Activity reachability.
- Model peer-owned slug collisions on the actually serialized host segment, including owner-host and local children that both omit that segment; both shapes have ID-qualified round-trip tests.
- Live-gate fix: fresh nested launches now inherit `GMUX_SESSION_ID` as immutable launch provenance (but resume/restart never do), and the production runner `/meta` boundary preserves it into `RunnerRegistration`.
- Live-gate fix: a managed completion suppression decision persists across later fact outcomes for the same inactive turn, so a late unread bit cannot resurrect child attention; the marker resets only on the next active turn.

## Test evidence

- `pnpm --dir apps/gmux-web test` — 33 files / 640 tests passed
- `pnpm moon run gmux-web:lint`
- `pnpm moon run protocol:lint`
- focused central notification tests
- `go test ./services/gmuxd/...`
- `go test ./cli/gmux/...`
- `go test -race -count=1 ./cli/gmux/cmd/gmux ./services/gmuxd/cmd/gmuxd ./services/gmuxd/internal/peering ./services/gmuxd/internal/centralstore ./services/gmuxd/internal/snapshot/wire ./services/gmuxd/internal/snapshot/wire/equivalence`

## Browser verification

Verified desktop and 390×844 mobile/touch mock views without touching the production daemon:

- root-only Projects/Activity membership, dead-root retention, and orphan visibility
- Home child suppression
- nested Parent/Root controls without duplicate Root
- ancestor/sibling/descendant drawer projection
- drawer persistence and selected-row focus restoration across navigation
- below-header overlay behavior with no horizontal overflow or terminal resize
