### PR TITLE
fix(adapter): align Claude and Codex conversation rendering

### DIFF
--- a/packages/adapter/adapters/claude_conversation.go
+++ b/packages/adapter/adapters/claude_conversation.go
@@ -17,12 +17,14 @@ var (
 // JSONL transcript. Tool results are encoded as user-role messages, so role
 // alone is deliberately not enough to establish a user exchange boundary.
 type claudeConversationEntry struct {
-	Type        string `json:"type"`
-	UUID        string `json:"uuid"`
-	ParentUUID  string `json:"parentUuid"`
-	IsMeta      bool   `json:"isMeta"`
-	IsSidechain bool   `json:"isSidechain"`
-	Message     *struct {
+	Type             string `json:"type"`
+	UUID             string `json:"uuid"`
+	ParentUUID       string `json:"parentUuid"`
+	IsMeta           bool   `json:"isMeta"`
+	IsSidechain      bool   `json:"isSidechain"`
+	IsCompactSummary bool   `json:"isCompactSummary"`
+	Message          *struct {
+		ID      string          `json:"id"`
 		Role    string          `json:"role"`
 		Content json.RawMessage `json:"content"`
 	} `json:"message"`
@@ -48,6 +50,10 @@ func readClaudeEntries(ref string) ([]claudeConversationEntry, error) {
 	return claudeActiveBranch(linear), nil
 }
 
+func (entry claudeConversationEntry) hidden() bool {
+	return entry.IsMeta || entry.IsSidechain || entry.IsCompactSummary
+}
+
 // claudeActiveBranch follows Claude's native parent-linked history from the
 // final persisted node. Rewind/fork leaves abandoned messages in the JSONL;
 // rendering file order would disclose and misattribute that abandoned branch.
@@ -69,13 +75,13 @@ func claudeActiveBranch(linear []claudeConversationEntry) []claudeConversationEn
 	if !hasParents {
 		return linear
 	}
-	// Sidechain/meta records can be UUID-linked and trail the visible main
-	// conversation while subagent/bookkeeping work is appended. They remain in
-	// byID because a later main record may name one as an ancestor, but they
-	// must never replace the latest eligible main-conversation leaf.
+	// Hidden records can be UUID-linked and trail the visible main
+	// conversation while bookkeeping work is appended. They remain in byID
+	// because a later main record may name one as an ancestor, but they must
+	// never replace the latest eligible main-conversation leaf.
 	leaf := claudeConversationEntry{}
 	for i := len(linear) - 1; i >= 0; i-- {
-		if linear[i].UUID != "" && !linear[i].IsSidechain && !linear[i].IsMeta {
+		if linear[i].UUID != "" && !linear[i].hidden() {
 			leaf = linear[i]
 			break
 		}
@@ -131,7 +137,7 @@ func renderClaudeContent(raw json.RawMessage) (text, prose string, userBoundary 
 				userBoundary = true
 			}
 		case "tool_use":
-			parts = append(parts, formatPiToolCall(block.Name, block.Input))
+			parts = append(parts, formatToolCall(block.Name, block.Input))
 		case "image":
 			parts = append(parts, "[image]")
 			userBoundary = true
@@ -140,25 +146,207 @@ func renderClaudeContent(raw json.RawMessage) (text, prose string, userBoundary 
 	return strings.Join(parts, "\n\n"), strings.Join(proseParts, "\n\n"), userBoundary
 }
 
+type claudeInjectedUserForm uint8
+
+const (
+	claudeNotInjected claudeInjectedUserForm = iota
+	claudeCommandCaveat
+	claudeCommand
+	claudeCommandOutput
+)
+
+// claudeInjectedUserMatchers mirrors the flag-less local-command forms emitted
+// by Claude Code. Claude Code is closed-source; these names come from the
+// official 2.1.220 binary's slash/local-command tag vocabulary and were checked
+// against persisted ~/.claude/projects transcript shapes. Content shape alone
+// is intentionally insufficient: an exact XML wrapper can be a legitimate user
+// prompt. Suppression additionally requires Claude's observed parent-linked
+// caveat -> command -> output provenance chain.
+var claudeInjectedUserMatchers = []struct {
+	form  claudeInjectedUserForm
+	match func(string) bool
+}{
+	{claudeCommandCaveat, claudeWrapped("local-command-caveat")}, // local command model caveat
+	{claudeCommand, isClaudeCommandRecord},                       // command-name + command-message + command-args
+	{claudeCommandOutput, claudeWrapped("local-command-stdout")}, // local command result renderer
+	{claudeCommandOutput, claudeWrapped("local-command-stderr")}, // local command result renderer
+}
+
+func claudeInjectedForm(raw json.RawMessage) claudeInjectedUserForm {
+	var text string
+	if json.Unmarshal(raw, &text) != nil {
+		return claudeNotInjected
+	}
+	text = strings.TrimSpace(text)
+	for _, registered := range claudeInjectedUserMatchers {
+		if registered.match(text) {
+			return registered.form
+		}
+	}
+	return claudeNotInjected
+}
+
+func isClaudeInjectedUserRecord(entries []claudeConversationEntry, index int) bool {
+	if index < 0 || index >= len(entries) || entries[index].Message == nil {
+		return false
+	}
+	switch claudeInjectedForm(entries[index].Message.Content) {
+	case claudeCommand:
+		return isProvenClaudeCommand(entries, index)
+	case claudeCommandOutput:
+		// Multiple stdout/stderr records may form one linked output chain. Walk
+		// through only registered output forms until reaching its command.
+		for index > 0 {
+			previous := index - 1
+			if entries[previous].Message == nil || !claudeEntriesLinked(entries[index], entries[previous]) {
+				return false
+			}
+			switch claudeInjectedForm(entries[previous].Message.Content) {
+			case claudeCommand:
+				return isProvenClaudeCommand(entries, previous)
+			case claudeCommandOutput:
+				index = previous
+			default:
+				return false
+			}
+		}
+	}
+	return false
+}
+
+func isProvenClaudeCommand(entries []claudeConversationEntry, index int) bool {
+	if index <= 0 || entries[index].Message == nil ||
+		claudeInjectedForm(entries[index].Message.Content) != claudeCommand {
+		return false
+	}
+	caveat := entries[index-1]
+	return caveat.IsMeta && caveat.Message != nil &&
+		claudeInjectedForm(caveat.Message.Content) == claudeCommandCaveat &&
+		claudeEntriesLinked(entries[index], caveat)
+}
+
+func claudeEntriesLinked(child, parent claudeConversationEntry) bool {
+	return child.ParentUUID != "" && parent.UUID != "" && child.ParentUUID == parent.UUID
+}
+
+func claudeWrapped(tag string) func(string) bool {
+	return func(s string) bool {
+		return strings.HasPrefix(s, "<"+tag+">") && strings.HasSuffix(s, "</"+tag+">")
+	}
+}
+
+func isClaudeCommandRecord(s string) bool {
+	for _, tag := range []string{"command-name", "command-message", "command-args"} {
+		prefix, suffix := "<"+tag+">", "</"+tag+">"
+		if !strings.HasPrefix(s, prefix) {
+			return false
+		}
+		end := strings.Index(s[len(prefix):], suffix)
+		if end < 0 {
+			return false
+		}
+		s = strings.TrimSpace(s[len(prefix)+end+len(suffix):])
+	}
+	return s == ""
+}
+
+type claudeResponse struct {
+	text  []string
+	prose []string
+}
+
+type claudeResponseGroup struct {
+	responses []claudeResponse
+	byID      map[string]int
+}
+
+func (g *claudeResponseGroup) add(id, text, prose string) {
+	index := -1
+	if id != "" {
+		if g.byID == nil {
+			g.byID = make(map[string]int)
+		}
+		if found, ok := g.byID[id]; ok {
+			index = found
+		} else {
+			index = len(g.responses)
+			g.byID[id] = index
+		}
+	}
+	// Legacy combined records have no message.id and each represent one
+	// completed response. Current split records share an id across blocks.
+	if index < 0 {
+		index = len(g.responses)
+	}
+	if index == len(g.responses) {
+		g.responses = append(g.responses, claudeResponse{})
+	}
+	if text != "" {
+		g.responses[index].text = append(g.responses[index].text, text)
+	}
+	if prose != "" {
+		g.responses[index].prose = append(g.responses[index].prose, prose)
+	}
+}
+
+func (g *claudeResponseGroup) reset() {
+	g.responses = nil
+	g.byID = nil
+}
+
+// projectClaudeConversation groups the current one-record-per-content-block
+// format by message.id while retaining compatibility with legacy combined
+// records. Grouping is scoped to a real user boundary; hidden/tool-result
+// records may interleave split blocks without creating or ending a response.
+func projectClaudeConversation(entries []claudeConversationEntry) ([]adapter.ConversationMessage, []adapter.Exchange) {
+	var messages []adapter.ConversationMessage
+	var exchanges []adapter.Exchange
+	var responses claudeResponseGroup
+
+	flushResponses := func() {
+		for _, response := range responses.responses {
+			text := strings.Join(response.text, "\n\n")
+			prose := strings.Join(response.prose, "\n\n")
+			if text != "" {
+				messages = append(messages, adapter.ConversationMessage{Role: "assistant", Text: text, Prose: prose})
+			}
+			if len(exchanges) != 0 {
+				ex := &exchanges[len(exchanges)-1]
+				ex.Iterations++
+				ex.Terminal = prose // deliberately replace, including with empty
+			}
+		}
+		responses.reset()
+	}
+
+	for index, entry := range entries {
+		if entry.hidden() || entry.Message == nil || (entry.Type != "user" && entry.Type != "assistant") {
+			continue
+		}
+		text, prose, boundary := renderClaudeContent(entry.Message.Content)
+		switch entry.Type {
+		case "user":
+			if !boundary || isClaudeInjectedUserRecord(entries, index) {
+				continue
+			}
+			flushResponses()
+			messages = append(messages, adapter.ConversationMessage{Role: entry.Message.Role, Text: text, Prose: prose})
+			exchanges = append(exchanges, adapter.Exchange{Ordinal: uint64(len(exchanges) + 1), User: text})
+		case "assistant":
+			responses.add(entry.Message.ID, text, prose)
+		}
+	}
+	flushResponses()
+	return messages, exchanges
+}
+
 func (c *Claude) RenderConversation(ref string) ([]adapter.ConversationMessage, error) {
 	entries, err := readClaudeEntries(ref)
 	if err != nil {
 		return nil, err
 	}
-	var out []adapter.ConversationMessage
-	for _, entry := range entries {
-		if entry.IsMeta || entry.IsSidechain || entry.Message == nil || (entry.Type != "user" && entry.Type != "assistant") {
-			continue
-		}
-		text, prose, boundary := renderClaudeContent(entry.Message.Content)
-		if entry.Type == "user" && !boundary { // tool_result message
-			continue
-		}
-		if text != "" {
-			out = append(out, adapter.ConversationMessage{Role: entry.Message.Role, Text: text, Prose: prose})
-		}
-	}
-	return out, nil
+	messages, _ := projectClaudeConversation(entries)
+	return messages, nil
 }
 
 func (c *Claude) RenderConversationExchanges(ref string) ([]adapter.Exchange, error) {
@@ -166,24 +354,6 @@ func (c *Claude) RenderConversationExchanges(ref string) ([]adapter.Exchange, er
 	if err != nil {
 		return nil, err
 	}
-	var out []adapter.Exchange
-	for _, entry := range entries {
-		if entry.IsMeta || entry.IsSidechain || entry.Message == nil {
-			continue
-		}
-		text, prose, boundary := renderClaudeContent(entry.Message.Content)
-		switch entry.Type {
-		case "user":
-			if boundary {
-				out = append(out, adapter.Exchange{Ordinal: uint64(len(out) + 1), User: text})
-			}
-		case "assistant":
-			if len(out) > 0 {
-				out[len(out)-1].Iterations++
-				// Only the latest assistant API iteration can be terminal prose.
-				out[len(out)-1].Terminal = prose
-			}
-		}
-	}
-	return out, nil
+	_, exchanges := projectClaudeConversation(entries)
+	return exchanges, nil
 }

--- a/packages/adapter/adapters/claude_conversation_test.go
+++ b/packages/adapter/adapters/claude_conversation_test.go
@@ -46,6 +46,134 @@ func TestClaudeConversationExchanges(t *testing.T) {
 	}
 }
 
+func TestClaudeCurrentSplitResponsesGroupByMessageID(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "split.jsonl")
+	// Claude Code 2.1.220 persists one record per content block. Records from
+	// one completed API response share message.id even when bookkeeping records
+	// interleave them.
+	transcript := `{"type":"user","message":{"role":"user","content":"go"}}
+{"uuid":"a1","type":"assistant","message":{"id":"msg-a","role":"assistant","content":[{"type":"thinking","thinking":"secret"}]}}
+{"type":"progress","message":{"role":"assistant","content":"ignored bookkeeping"}}
+{"uuid":"a2","type":"assistant","message":{"id":"msg-a","role":"assistant","content":[{"type":"text","text":"Checking"}]}}
+{"uuid":"a3","type":"assistant","message":{"id":"msg-a","role":"assistant","content":[{"type":"tool_use","name":"Read","input":{"file_path":"a.go"}}]}}
+{"uuid":"b1","type":"assistant","message":{"id":"msg-b","role":"assistant","content":[{"type":"text","text":"Answer prose"}]}}
+{"uuid":"b2","type":"assistant","message":{"id":"msg-b","role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"go test ./..."}}]}}`
+	if err := os.WriteFile(path, []byte(transcript), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	ex, err := NewClaude().RenderConversationExchanges(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ex) != 1 || ex[0].Iterations != 2 || ex[0].Terminal != "Answer prose" {
+		t.Fatalf("split exchange = %#v", ex)
+	}
+
+	messages, err := NewClaude().RenderConversation(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(messages) != 3 || messages[1].Text != "Checking\n\n[tool] Read {\"file_path\":\"a.go\"}" ||
+		messages[2].Text != "Answer prose\n\n[tool] Bash {\"command\":\"go test ./...\"}" || messages[2].Prose != "Answer prose" {
+		t.Fatalf("split messages = %#v", messages)
+	}
+}
+
+func TestClaudeMissingMessageIDsRemainLegacyResponseBoundaries(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "legacy.jsonl")
+	transcript := `{"type":"user","message":{"role":"user","content":"go"}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"first"},{"type":"tool_use","name":"Read","input":{}}]}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"second"}]}}`
+	if err := os.WriteFile(path, []byte(transcript), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ex, err := NewClaude().RenderConversationExchanges(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ex) != 1 || ex[0].Iterations != 2 || ex[0].Terminal != "second" {
+		t.Fatalf("legacy exchange = %#v", ex)
+	}
+}
+
+func TestClaudeInjectedCommandRegistryRequiresProvenance(t *testing.T) {
+	command := "<command-name>/compact</command-name>\n<command-message>compact</command-message>\n<command-args></command-args>"
+	for _, tc := range []struct {
+		name   string
+		output string
+	}{
+		{name: "command only"},
+		{name: "stdout", output: "<local-command-stdout>bookkeeping output</local-command-stdout>"},
+		{name: "stderr", output: "<local-command-stderr>bookkeeping error</local-command-stderr>"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "commands.jsonl")
+			transcript := `{"uuid":"user","type":"user","message":{"role":"user","content":"real prompt"}}
+{"uuid":"assistant","parentUuid":"user","type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"answer"}]}}
+{"uuid":"caveat","parentUuid":"assistant","type":"user","isMeta":true,"message":{"role":"user","content":"<local-command-caveat>generated caveat</local-command-caveat>"}}
+` + `{"uuid":"command","parentUuid":"caveat","type":"user","isMeta":false,"message":{"role":"user","content":` + quoteJSON(command) + `}}`
+			if tc.output != "" {
+				transcript += "\n" + `{"uuid":"output","parentUuid":"command","type":"user","isMeta":false,"message":{"role":"user","content":` + quoteJSON(tc.output) + `}}`
+			}
+			if err := os.WriteFile(path, []byte(transcript), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			ex, err := NewClaude().RenderConversationExchanges(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(ex) != 1 || ex[0].User != "real prompt" || ex[0].Terminal != "answer" {
+				t.Fatalf("proven injected command leaked: %#v", ex)
+			}
+			messages, err := NewClaude().RenderConversation(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(messages) != 2 {
+				t.Fatalf("proven injected command leaked into conversation: %#v", messages)
+			}
+		})
+	}
+}
+
+func TestClaudeAmbiguousCommandShapesRemainUserPrompts(t *testing.T) {
+	prompts := []string{
+		"<command-name>/compact</command-name>\n<command-message>compact</command-message>\n<command-args></command-args>",
+		"<local-command-stdout>user-owned example</local-command-stdout>",
+		"<local-command-stderr>user-owned example</local-command-stderr>",
+		"<local-command-caveat>user-owned example</local-command-caveat>",
+		"<bash-input>echo user-owned</bash-input>",
+		"<command-name>explain this element</command-name>",
+		"<local-command-stdout>unterminated example",
+		"prefix <local-command-stdout>example</local-command-stdout>",
+	}
+	for _, prompt := range prompts {
+		t.Run(prompt, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "ambiguous.jsonl")
+			transcript := `{"uuid":"prompt","type":"user","message":{"role":"user","content":` + quoteJSON(prompt) + `}}
+{"uuid":"answer","parentUuid":"prompt","type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"answer"}]}}`
+			if err := os.WriteFile(path, []byte(transcript), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			ex, err := NewClaude().RenderConversationExchanges(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(ex) != 1 || ex[0].User != prompt || ex[0].Terminal != "answer" {
+				t.Fatalf("legitimate prompt erased: %#v", ex)
+			}
+			messages, err := NewClaude().RenderConversation(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(messages) != 2 || messages[0].Text != prompt {
+				t.Fatalf("legitimate prompt erased from conversation: %#v", messages)
+			}
+		})
+	}
+}
+
 func TestClaudeConversationUsesActiveParentBranch(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "branched.jsonl")
 	transcript := `{"uuid":"u1","parentUuid":null,"type":"user","message":{"role":"user","content":"root"}}
@@ -73,6 +201,7 @@ func TestClaudeConversationIgnoresTrailingHiddenLeaves(t *testing.T) {
 	}{
 		{"sidechain", `{"uuid":"side","parentUuid":"u1","type":"assistant","isSidechain":true,"message":{"role":"assistant","content":[{"type":"text","text":"private sidechain"}]}}`},
 		{"meta", `{"uuid":"meta","parentUuid":"u1","type":"user","isMeta":true,"message":{"role":"user","content":"hidden metadata"}}`},
+		{"compact summary", `{"uuid":"compact","parentUuid":"u1","type":"user","isCompactSummary":true,"message":{"role":"user","content":"hidden compact summary"}}`},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			path := filepath.Join(t.TempDir(), "hidden-tail.jsonl")

--- a/packages/adapter/adapters/claude_test.go
+++ b/packages/adapter/adapters/claude_test.go
@@ -84,13 +84,11 @@ func TestClaudeImplementsCapabilities(t *testing.T) {
 	if _, ok := a.(adapter.Resumer); !ok {
 		t.Fatal("should implement Resumer")
 	}
-	// Deliberately NOT an AgentActionEncoder: gmux's semantic agent
-	// actions (ADR 0027) ship for pi only. claude's turn-control
-	// keystrokes are unverified, and guessing them would send
-	// wrong-meaning bytes under a semantic label. Raw `gmux send`
-	// remains available.
+	// Deliberately NOT an AgentActionEncoder: interactive adapters never
+	// expose gmux's semantic steer action. Raw `gmux send` remains available;
+	// ACP mode will provide typed control separately.
 	if _, ok := a.(adapter.AgentActionEncoder); ok {
-		t.Fatal("should NOT implement AgentActionEncoder yet")
+		t.Fatal("interactive Claude must not implement AgentActionEncoder")
 	}
 }
 

--- a/packages/adapter/adapters/codex_conversation.go
+++ b/packages/adapter/adapters/codex_conversation.go
@@ -26,7 +26,7 @@ func (c *Codex) RenderConversation(ref string) ([]adapter.ConversationMessage, e
 		if item.Text == "" {
 			continue
 		}
-		out = append(out, adapter.ConversationMessage{Role: item.Role, Text: item.Text, Prose: item.Text})
+		out = append(out, adapter.ConversationMessage{Role: item.Role, Text: item.Text, Prose: item.Prose})
 	}
 	return out, nil
 }
@@ -63,8 +63,9 @@ func (c *Codex) RenderConversationExchanges(ref string) ([]adapter.Exchange, err
 }
 
 type codexMessage struct {
-	Role string
-	Text string
+	Role  string
+	Text  string
+	Prose string
 }
 
 type codexRollout struct {
@@ -75,11 +76,13 @@ type codexRollout struct {
 type codexRecord struct {
 	Type    string `json:"type"`
 	Payload struct {
-		Type    string          `json:"type"`
-		Role    string          `json:"role"`
-		Content json.RawMessage `json:"content"`
-		Delta   string          `json:"delta"`
-		Info    json.RawMessage `json:"info"`
+		Type      string          `json:"type"`
+		Role      string          `json:"role"`
+		Content   json.RawMessage `json:"content"`
+		Name      string          `json:"name"`
+		Arguments json.RawMessage `json:"arguments"`
+		Delta     string          `json:"delta"`
+		Info      json.RawMessage `json:"info"`
 	} `json:"payload"`
 }
 
@@ -122,25 +125,35 @@ func readCodexRollout(ref string) (codexRollout, error) {
 			pendingDelta.Reset()
 			continue
 		}
-		if entry.Type != "response_item" || entry.Payload.Type != "message" ||
+		if entry.Type != "response_item" {
+			continue
+		}
+		if entry.Payload.Type == "function_call" {
+			out.messages = append(out.messages, codexMessage{
+				Role: "assistant",
+				Text: formatToolCall(entry.Payload.Name, codexToolArguments(entry.Payload.Arguments)),
+			})
+			continue
+		}
+		if entry.Payload.Type != "message" ||
 			(entry.Payload.Role != "user" && entry.Payload.Role != "assistant") {
 			continue
 		}
-		text := codexMessageText(entry.Payload.Role, entry.Payload.Content)
+		text, prose := codexMessageText(entry.Payload.Role, entry.Payload.Content)
 		if entry.Payload.Role == "user" {
 			// Never carry unfinished response prose across a new user boundary.
 			responseProse = nil
 			pendingDelta.Reset()
-			out.messages = append(out.messages, codexMessage{Role: "user", Text: text})
+			out.messages = append(out.messages, codexMessage{Role: "user", Text: text, Prose: prose})
 			out.exchanges = append(out.exchanges, codexMessage{Role: "user", Text: text})
 			continue
 		}
 
 		pendingDelta.Reset() // canonical completed text supersedes legacy deltas
-		out.messages = append(out.messages, codexMessage{Role: "assistant", Text: text})
+		out.messages = append(out.messages, codexMessage{Role: "assistant", Text: text, Prose: prose})
 		if hasResponseMarkers {
-			if text != "" {
-				responseProse = append(responseProse, text)
+			if prose != "" {
+				responseProse = append(responseProse, prose)
 			}
 		} else {
 			// Compatibility for older rollouts without response markers: their
@@ -150,7 +163,7 @@ func readCodexRollout(ref string) (codexRollout, error) {
 	}
 	if pendingDelta.Len() != 0 {
 		text := pendingDelta.String()
-		out.messages = append(out.messages, codexMessage{Role: "assistant", Text: text})
+		out.messages = append(out.messages, codexMessage{Role: "assistant", Text: text, Prose: text})
 		if !hasResponseMarkers {
 			out.exchanges = append(out.exchanges, codexMessage{Role: "response", Text: text})
 		}
@@ -166,16 +179,30 @@ func isCodexResponseMarker(entry codexRecord) bool {
 	return info != "" && info != "null"
 }
 
-func codexMessageText(role string, raw json.RawMessage) string {
+func codexToolArguments(raw json.RawMessage) json.RawMessage {
+	// Codex persists function-call arguments as a JSON string containing the
+	// original JSON object, unlike pi and Claude which persist the object.
+	var decoded string
+	if json.Unmarshal(raw, &decoded) == nil {
+		return json.RawMessage(decoded)
+	}
+	return raw
+}
+
+func codexMessageText(role string, raw json.RawMessage) (text, prose string) {
 	var blocks []struct {
 		Type string `json:"type"`
 		Text string `json:"text"`
 	}
 	if json.Unmarshal(raw, &blocks) != nil {
-		return ""
+		return "", ""
 	}
-	var parts []string
+	var parts, proseParts []string
 	for _, block := range blocks {
+		if role == "user" && block.Type == "input_image" {
+			parts = append(parts, "[image]")
+			continue
+		}
 		want := "output_text"
 		if role == "user" {
 			want = "input_text"
@@ -184,6 +211,7 @@ func codexMessageText(role string, raw json.RawMessage) string {
 			continue
 		}
 		parts = append(parts, block.Text)
+		proseParts = append(proseParts, block.Text)
 	}
-	return strings.Join(parts, "\n\n")
+	return strings.Join(parts, "\n\n"), strings.Join(proseParts, "\n\n")
 }

--- a/packages/adapter/adapters/codex_conversation_test.go
+++ b/packages/adapter/adapters/codex_conversation_test.go
@@ -157,6 +157,59 @@ func TestCodexContextLookalikesRemainPublicUserPrompts(t *testing.T) {
 	}
 }
 
+func TestCodexImageInputsEstablishUserBoundaries(t *testing.T) {
+	t.Run("image only", func(t *testing.T) {
+		path := writeCodexJSONL(t,
+			`{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_image","image_url":"data:image/png;base64,secret"}]}}`,
+			codexAssistant("seen"), codexCompletedResponse,
+		)
+		ex, err := NewCodex().RenderConversationExchanges(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(ex) != 1 || ex[0].User != "[image]" || ex[0].Terminal != "seen" {
+			t.Fatalf("image exchange = %#v", ex)
+		}
+		messages, err := NewCodex().RenderConversation(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(messages) != 2 || messages[0].Text != "[image]" || messages[0].Prose != "" {
+			t.Fatalf("image conversation = %#v", messages)
+		}
+	})
+
+	t.Run("mixed text and image", func(t *testing.T) {
+		path := writeCodexJSONL(t,
+			`{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"inspect"},{"type":"input_image","image_url":"https://example.invalid/secret"}]}}`,
+			codexAssistant("seen"), codexCompletedResponse,
+		)
+		ex, err := NewCodex().RenderConversationExchanges(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(ex) != 1 || ex[0].User != "inspect\n\n[image]" {
+			t.Fatalf("mixed image exchange = %#v", ex)
+		}
+	})
+}
+
+func TestCodexConversationRendersToolCallsWithoutResults(t *testing.T) {
+	path := writeCodexJSONL(t,
+		codexUser("go"),
+		`{"type":"response_item","payload":{"type":"function_call","name":"shell","arguments":"{\"command\":\"go test ./...\"}"}}`,
+		`{"type":"response_item","payload":{"type":"function_call_output","output":"private payload"}}`,
+		codexCompletedResponse,
+	)
+	messages, err := NewCodex().RenderConversation(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(messages) != 2 || messages[1].Text != `[tool] shell {"command":"go test ./..."}` || messages[1].Prose != "" {
+		t.Fatalf("tool conversation = %#v", messages)
+	}
+}
+
 func TestCodexExchangeMalformedPartialAndLegacyFallback(t *testing.T) {
 	path := writeCodexJSONL(t,
 		codexUser("go"),

--- a/packages/adapter/adapters/codex_test.go
+++ b/packages/adapter/adapters/codex_test.go
@@ -80,13 +80,11 @@ func TestCodexImplementsCapabilities(t *testing.T) {
 	if _, ok := a.(adapter.Resumer); !ok {
 		t.Fatal("should implement Resumer")
 	}
-	// Deliberately NOT an AgentActionEncoder: gmux's semantic agent
-	// actions (ADR 0027) ship for pi only. codex's turn-control
-	// keystrokes are unverified, and guessing them would send
-	// wrong-meaning bytes under a semantic label. Raw `gmux send`
-	// remains available.
+	// Deliberately NOT an AgentActionEncoder: interactive adapters never
+	// expose gmux's semantic steer action. Raw `gmux send` remains available;
+	// ACP mode will provide typed control separately.
 	if _, ok := a.(adapter.AgentActionEncoder); ok {
-		t.Fatal("should NOT implement AgentActionEncoder yet")
+		t.Fatal("interactive Codex must not implement AgentActionEncoder")
 	}
 }
 

--- a/packages/adapter/adapters/pi_conversation.go
+++ b/packages/adapter/adapters/pi_conversation.go
@@ -170,7 +170,7 @@ func renderPiExchangeContent(content json.RawMessage) (text, prose string) {
 				proseParts = append(proseParts, b.Text)
 			}
 		case "toolCall":
-			parts = append(parts, formatPiToolCall(b.Name, b.Arguments))
+			parts = append(parts, formatToolCall(b.Name, b.Arguments))
 		case "image":
 			parts = append(parts, "[image]")
 		}
@@ -218,7 +218,7 @@ func renderPiContent(content json.RawMessage) (text, prose string) {
 				proseParts = append(proseParts, t)
 			}
 		case "toolCall":
-			parts = append(parts, formatPiToolCall(b.Name, b.Arguments))
+			parts = append(parts, formatToolCall(b.Name, b.Arguments))
 		case "image":
 			parts = append(parts, "[image]")
 		}
@@ -233,11 +233,11 @@ func renderPiContent(content json.RawMessage) (text, prose string) {
 // the conversation the transcript exists to surface.
 const maxToolArgChars = 120
 
-// formatPiToolCall renders a tool call as a compact single line:
+// formatToolCall renders a tool call as a compact single line:
 // "[tool] <name> <compact-json-args>". Plain text, no markdown
 // emphasis or inline code — arguments are arbitrary bytes (shell
 // commands full of backticks), so any markdown wrapping would break.
-func formatPiToolCall(name string, args json.RawMessage) string {
+func formatToolCall(name string, args json.RawMessage) string {
 	if name == "" {
 		name = "?"
 	}

--- a/packages/adapter/adapters/pi_conversation_test.go
+++ b/packages/adapter/adapters/pi_conversation_test.go
@@ -129,12 +129,12 @@ func TestRenderConversationMissingFile(t *testing.T) {
 	}
 }
 
-// TestFormatPiToolCallTruncatesArgs: tool arguments (edit bodies, long
+// TestFormatToolCallTruncatesArgs: tool arguments (edit bodies, long
 // shell commands) are capped so tool lines stay one-line context, and
 // no markdown wrapping is added around the arbitrary argument bytes.
-func TestFormatPiToolCallTruncatesArgs(t *testing.T) {
+func TestFormatToolCallTruncatesArgs(t *testing.T) {
 	long := strings.Repeat("x", 500)
-	got := formatPiToolCall("edit", []byte(`{"text":"`+long+`"}`))
+	got := formatToolCall("edit", []byte(`{"text":"`+long+`"}`))
 	if !strings.HasPrefix(got, "[tool] edit {\"text\":\"xxx") {
 		t.Fatalf("prefix: got %q", got)
 	}
@@ -146,10 +146,10 @@ func TestFormatPiToolCallTruncatesArgs(t *testing.T) {
 	}
 
 	// No-arg and empty-arg calls render bare.
-	if got := formatPiToolCall("ls", nil); got != "[tool] ls" {
+	if got := formatToolCall("ls", nil); got != "[tool] ls" {
 		t.Fatalf("nil args: got %q", got)
 	}
-	if got := formatPiToolCall("ls", []byte(`{}`)); got != "[tool] ls" {
+	if got := formatToolCall("ls", []byte(`{}`)); got != "[tool] ls" {
 		t.Fatalf("empty args: got %q", got)
 	}
 }


### PR DESCRIPTION
## Summary

Follow-up to the cross-adapter consistency review of the observational renderers introduced in #448 and #450.

- group current Claude Code split content-block records by `message.id`, while preserving legacy combined-record behavior
- preserve terminal prose from final responses that mix prose and tools, and count iterations per completed response
- render Codex `input_image` blocks as `[image]` boundaries
- filter Claude's complete slash/local-command bookkeeping forms through an upstream-traceable registry, including compact summaries
- show compact Codex `[tool]` lines without exposing tool-result payloads
- rename the shared tool formatter and remove stale “yet” wording from permanent negative capability tests

No pi rendering behavior changes. Claude and Codex remain observational/interactive adapters and still do not expose `AgentActionEncoder`.

## Iteration contract

F1 deliberately defines the storage-side iteration unit the future ACP runner must match: **one iteration is one completed model response**, not one persisted content block, prose fragment, or tool call. Terminal prose is aggregated within the final response and replaced with empty only for a final response with no prose.

## Validation

- `go test -race ./packages/adapter/...`
- `go test -race ./services/gmuxd/cmd/gmuxd ./cli/gmux/internal/ptyserver`
- `go vet ./packages/adapter/... ./services/gmuxd/cmd/gmuxd ./cli/gmux/internal/ptyserver`
- content-silent rendering of 14 local Claude transcripts and 66 local Codex rollouts, with zero errors
- structural comparison of Claude iteration totals against distinct per-exchange `message.id` groups (and one response per legacy missing-ID record), all matching

## Deferred review finding

The stale `/v1/capabilities` adapter list remains unchanged. Its unused legacy array does not say which capability it represents; changing names would preserve the name-implies-capability defect. It should be removed or replaced by an explicitly versioned capability matrix in a daemon API change.


## Greptile follow-up

Greptile's inline finding about exact wrapper-only user prompts was **valid**. Claude provides stronger provenance than content shape alone in the current 2.1.220 transcript format: generated records form a UUID/`parentUuid` chain from an `isMeta:true` `<local-command-caveat>` record to the composite `<command-name>`/`<command-message>`/`<command-args>` record and then to local stdout/stderr records. The filter now requires that full registered-form + parent-linked provenance; exact wrapper or command-shaped user prompts without it remain visible in both public projections. Regression tests cover both the proven generated chain and realistic parent-linked user-owned exact wrappers. A content-silent scan confirmed every locally observed generated command/output form has this provenance.
