### PR TITLE
fix(snapshot): redact git remote userinfo on session wire

### DIFF
--- a/services/gmuxd/internal/snapshot/wire/convert.go
+++ b/services/gmuxd/internal/snapshot/wire/convert.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/centralstore"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/peering"
 	central "github.com/gmuxapp/gmux/services/gmuxd/internal/snapshot/central"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/statetool"
 )
 
 // Converter holds the pure derivation policy injected at construction:
@@ -65,6 +66,21 @@ func fmtMillisPtr(v *centralstore.UnixMillis) string {
 	return fmtMillis(*v)
 }
 
+// redactRemotes copies a session's remote map while removing URL userinfo.
+// Keeping this at the consumer-facing conversion boundary ensures local and
+// relayed peer sessions have the same wire security posture without mutating
+// the durable or peer projections used for project matching.
+func redactRemotes(remotes map[string]string) map[string]string {
+	if remotes == nil {
+		return nil
+	}
+	out := make(map[string]string, len(remotes))
+	for name, remote := range remotes {
+		out[name] = statetool.RedactURLUserinfo(remote)
+	}
+	return out
+}
+
 // session converts one composed local row: durable projection + runtime
 // overlay + derived title/status/resumable/rewritten command. Placement
 // stamps (project_slug/project_index) are applied by the payload-level
@@ -80,7 +96,7 @@ func (c *Converter) session(row central.SessionRow) Session {
 		SemanticAgent:   c.SemanticAgents[v.Adapter],
 		PromotedToRoot:  v.PromotedToRoot,
 		WorkspaceRoot:   v.WorkspaceRoot,
-		Remotes:         v.Remotes,
+		Remotes:         redactRemotes(v.Remotes),
 		Alive:           row.Alive,
 		ExitCode:        v.ExitCode,
 		StartedAt:       fmtMillisPtr(v.StartedAt),
@@ -164,6 +180,9 @@ func (c *Converter) Sessions(local *central.SessionsPayload, world *central.Proj
 	// durable placement join (or cleared stamps when unplaced).
 	peers := make([]Session, len(peerRows))
 	copy(peers, peerRows)
+	for i := range peers {
+		peers[i].Remotes = redactRemotes(peers[i].Remotes)
+	}
 	placementByPeerKey := map[[2]string]central.LocalPeerPlacementRow{}
 	if world != nil {
 		for _, p := range world.LocalPeerPlacements {

--- a/services/gmuxd/internal/snapshot/wire/convert_test.go
+++ b/services/gmuxd/internal/snapshot/wire/convert_test.go
@@ -48,6 +48,40 @@ func TestSessionConversionPreservesFamilyFacts(t *testing.T) {
 	}
 }
 
+func TestSessionConversionRedactsRemoteUserinfo(t *testing.T) {
+	localRemotes := map[string]string{
+		"origin": "https://user:token@git.example/acme/repo.git",
+		"ssh":    "git@github.com:acme/repo.git",
+	}
+	peerRemotes := map[string]string{
+		"origin": "alice:secret@git.example/peer/repo.git",
+	}
+	local := localRow("local", true, func(r *central.SessionRow) { r.Session.Remotes = localRemotes })
+	peer := Session{ID: "remote@peer", Peer: "peer", Adapter: "shell", Remotes: peerRemotes}
+
+	got := (&Converter{}).Sessions(
+		&central.SessionsPayload{Sessions: []central.SessionRow{local}},
+		&central.ProjectsPayload{},
+		[]Session{peer},
+	)
+	byID := map[string]Session{}
+	for _, session := range got.Sessions {
+		byID[session.ID] = session
+	}
+	if remote := byID["local"].Remotes["origin"]; remote != "https://REDACTED@git.example/acme/repo.git" {
+		t.Fatalf("local remote userinfo reached wire: %q", remote)
+	}
+	if remote := byID["local"].Remotes["ssh"]; remote != "git@github.com:acme/repo.git" {
+		t.Fatalf("userinfo-free SSH remote changed: %q", remote)
+	}
+	if remote := byID["remote@peer"].Remotes["origin"]; remote != "REDACTED@git.example/peer/repo.git" {
+		t.Fatalf("peer remote userinfo reached relayed wire: %q", remote)
+	}
+	if localRemotes["origin"] != "https://user:token@git.example/acme/repo.git" || peerRemotes["origin"] != "alice:secret@git.example/peer/repo.git" {
+		t.Fatal("wire conversion mutated its source projections")
+	}
+}
+
 // TestTitlePrecedence pins the resolveTitle chain against the production
 // precedence (store.resolveTitle): adapter title > shell title >
 // CommandTitler(command) > adapter name.


### PR DESCRIPTION
## Summary
- redact URL userinfo from local session remotes at the sole consumer-facing wire conversion boundary
- apply the same redaction to relayed peer session rows before they are emitted again
- preserve source maps so durable and peer projections remain available for project matching

## Evidence
The local data flow was `centralstore.Session.Remotes` → `snapshot/central.SessionRow` → `snapshot/wire.Converter.session` → `wire.Session.Remotes` → GET `/v1/sessions`, SSE `snapshot.sessions`, and peer subscribers. `Converter.session` previously assigned the map verbatim. Peer rows joined the same payload via `Converter.Sessions` and were also copied verbatim. Both paths now call the existing `statetool.RedactURLUserinfo` helper at that shared serialization boundary.

The state export path already redacts each session remote in `statetool.exportSession`; its behavior is unchanged and remains covered by `TestExportIsRedactedAndDeterministic`. Other remotes-bearing structures are internal matching/durable projections or runner input, not consumer-facing session serialization boundaries.

## Tests
- `pnpm moon run gmuxd:test`
- `pnpm moon run gmuxd:lint`
- regression covers credential-bearing local and relayed peer remotes, userinfo-free SSH remotes, and source-map non-mutation