### PR TITLE
fix(adapter): re-watch removed-then-recreated directories

### DIFF
--- a/packages/adapter/filewatch/filewatch.go
+++ b/packages/adapter/filewatch/filewatch.go
@@ -63,7 +63,16 @@ func Watch(ctx context.Context, root, suffix string, emit func(Event)) error {
 		}
 	}
 
-	tw := &treeWatcher{w: w, suffix: suffix, emit: emit, watched: map[string]bool{}}
+	root = filepath.Clean(root)
+	tw := &treeWatcher{w: w, root: root, suffix: suffix, emit: emit, watched: map[string]bool{}}
+
+	// Keep watching the root's parent so removal of root itself does not leave
+	// us with no watch from which to observe its recreation.
+	if parent := filepath.Dir(root); parent != root {
+		if err := w.Add(parent); err != nil {
+			log.Printf("filewatch: watch root parent %s: %v", parent, err)
+		}
+	}
 	tw.addTree(root)
 
 	for {
@@ -89,6 +98,7 @@ func Watch(ctx context.Context, root, suffix string, emit func(Event)) error {
 // treeWatcher is owned by a single Watch goroutine; no locking needed.
 type treeWatcher struct {
 	w       *fsnotify.Watcher
+	root    string
 	suffix  string
 	emit    func(Event)
 	watched map[string]bool
@@ -119,6 +129,21 @@ func (t *treeWatcher) addTree(root string) {
 }
 
 func (t *treeWatcher) handle(ev fsnotify.Event) {
+	// The parent watch exists only to observe root being recreated; ignore its
+	// unrelated events.
+	if !pathWithin(t.root, ev.Name) {
+		return
+	}
+
+	// Removing or renaming a watched directory removes its kernel watch. Prune
+	// it and all watched descendants so a later Create can install fresh ones.
+	if ev.Has(fsnotify.Remove) || ev.Has(fsnotify.Rename) {
+		if t.watched[ev.Name] {
+			t.forgetTree(ev.Name)
+			return
+		}
+	}
+
 	// A newly-created directory: watch it and catch up any files that already
 	// landed inside (recurse for `mkdir -p a/b/c`).
 	if ev.Has(fsnotify.Create) {
@@ -146,4 +171,17 @@ func (t *treeWatcher) handle(ev fsnotify.Event) {
 	case ev.Has(fsnotify.Create), ev.Has(fsnotify.Write):
 		t.emit(Event{Path: ev.Name})
 	}
+}
+
+func (t *treeWatcher) forgetTree(root string) {
+	for dir := range t.watched {
+		if pathWithin(root, dir) {
+			delete(t.watched, dir)
+		}
+	}
+}
+
+func pathWithin(root, path string) bool {
+	rel, err := filepath.Rel(root, path)
+	return err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }

--- a/packages/adapter/filewatch/filewatch_test.go
+++ b/packages/adapter/filewatch/filewatch_test.go
@@ -82,6 +82,72 @@ func TestWatchCatchesUpNewSubdir(t *testing.T) {
 	waitFor(t, events, func(e Event) bool { return e.Path == path && !e.Removed })
 }
 
+// writeUntilObserved polls by writing path until the watcher reports it. This
+// avoids depending on a fixed delay for the Watch goroutine to install watches.
+func writeUntilObserved(t *testing.T, events <-chan Event, path string) {
+	t.Helper()
+	deadline := time.NewTimer(5 * time.Second)
+	defer deadline.Stop()
+	poll := time.NewTicker(10 * time.Millisecond)
+	defer poll.Stop()
+
+	for {
+		select {
+		case e := <-events:
+			if e.Path == path && !e.Removed {
+				return
+			}
+		case <-poll.C:
+			write(t, path)
+		case <-deadline.C:
+			t.Fatalf("timed out waiting for event for %s", path)
+		}
+	}
+}
+
+func TestWatchRewatchesRecreatedSubdir(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "sessions")
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	events := make(chan Event, 256)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go Watch(ctx, root, ".jsonl", func(e Event) { events <- e })
+
+	writeUntilObserved(t, events, filepath.Join(dir, "before.jsonl"))
+	if err := os.RemoveAll(dir); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeUntilObserved(t, events, filepath.Join(dir, "after.jsonl"))
+}
+
+func TestWatchRewatchesRecreatedRoot(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "sessions")
+	if err := os.Mkdir(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	events := make(chan Event, 256)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go Watch(ctx, root, ".jsonl", func(e Event) { events <- e })
+
+	writeUntilObserved(t, events, filepath.Join(root, "before.jsonl"))
+	if err := os.RemoveAll(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeUntilObserved(t, events, filepath.Join(root, "after.jsonl"))
+}
+
 func TestWatchStopsOnCancel(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)


### PR DESCRIPTION
## Summary

- prune removed or renamed directories (and descendants) from filewatch's watch bookkeeping so recreated paths get fresh fsnotify watches
- keep a watch on the configured root's parent so removing and recreating the root itself is recoverable
- ignore unrelated events observed through that parent watch
- add integration regressions for both recreated subdirectories and the configured root

## Evidence

A live Linux/fsnotify probe confirmed that `rmdir` emits `REMOVE` for the watched directory and removes it from `Watcher.WatchList`; recreating the path emits only `CREATE` through the parent watch. `rename` similarly emits `RENAME` and drops the original watch. The old bookkeeping retained those paths, so `addWatch` skipped re-adding them.

Both new tests were also run against the pre-fix implementation and failed after their 5-second polling deadlines:

- `TestWatchRewatchesRecreatedSubdir`
- `TestWatchRewatchesRecreatedRoot`

No file-level watches exist in this package; file rename/remove event reporting remains unchanged. Directory `Remove` and `Rename` now share the same pruning path.

## Test plan

- `go test ./filewatch -count=20`
- `go test -race ./filewatch`
- `pnpm moon run adapter:test`
- `pnpm moon run adapter:lint`
