### PR TITLE
perf(gmuxd): cache resume commands for session lists

### DIFF
--- a/services/gmuxd/cmd/gmuxd/serve_central.go
+++ b/services/gmuxd/cmd/gmuxd/serve_central.go
@@ -234,10 +234,7 @@ func serveCentral(stderr io.Writer, replace bool) int {
 		return h
 	}
 
-	converter := &wire.Converter{Titlers: make(map[string]func([]string) string), SemanticAgents: make(map[string]bool), ResumeCommand: func(adapterName, ref string) []string {
-		legacy := &compatSession{Adapter: adapterName, ConversationRef: ref}
-		return discovery.ResolveResumeCommandFor(legacy.Adapter, legacy.ConversationRef)
-	}, IsLocalPeer: func(name string) bool { return peerManager != nil && peerManager.IsLocalPeer(name) }}
+	converter := &wire.Converter{Titlers: make(map[string]func([]string) string), SemanticAgents: make(map[string]bool), ResumeCommand: convIndex.LookupResumeCommand, IsLocalPeer: func(name string) bool { return peerManager != nil && peerManager.IsLocalPeer(name) }}
 	for _, a := range adapters.All {
 		if titler, ok := a.(adapter.CommandTitler); ok {
 			converter.Titlers[a.Name()] = titler.CommandTitle

--- a/services/gmuxd/internal/conversations/index.go
+++ b/services/gmuxd/internal/conversations/index.go
@@ -215,7 +215,9 @@ func (idx *Index) Scan(a adapter.Adapter, ref string) string {
 
 	convInfo, err := desc.DescribeConversation(ref)
 	if err != nil {
-		idx.setResumeCommand(a.Name(), ref, nil)
+		// Keep stale-good state on transient descriptor failures, matching the
+		// main metadata index. A source Remove event is the authoritative
+		// signal that clears both entries.
 		return ""
 	}
 

--- a/services/gmuxd/internal/conversations/index.go
+++ b/services/gmuxd/internal/conversations/index.go
@@ -44,6 +44,10 @@ type Index struct {
 	byKey map[string]Info
 	// byConversationID maps "adapter/conversationID" → internal key for reverse lookup.
 	byConversationID map[string]string
+	// resumeByRef caches the adapter-derived resume command while the
+	// conversation source is indexing the ref. Rendering the session list is
+	// a hot read path and must not re-read every dead conversation transcript.
+	resumeByRef map[string][]string
 }
 
 // New creates an empty index.
@@ -51,6 +55,7 @@ func New() *Index {
 	return &Index{
 		byKey:            make(map[string]Info),
 		byConversationID: make(map[string]string),
+		resumeByRef:      make(map[string][]string),
 	}
 }
 
@@ -60,6 +65,26 @@ func indexKey(adapterName, slug string) string {
 
 func convKey(adapterName, conversationID string) string {
 	return adapterName + "/" + conversationID
+}
+
+func refKey(adapterName, ref string) string {
+	return adapterName + "/" + ref
+}
+
+// LookupResumeCommand returns the command derived when the conversation ref
+// was last observed by its source. Snapshot populates this cache synchronously
+// before the daemon starts serving, and source upserts keep it current. The
+// returned slice is a copy so callers cannot mutate index state.
+func (idx *Index) LookupResumeCommand(adapterName, ref string) []string {
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
+	return append([]string(nil), idx.resumeByRef[refKey(adapterName, ref)]...)
+}
+
+func (idx *Index) setResumeCommand(adapterName, ref string, command []string) {
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
+	idx.resumeByRef[refKey(adapterName, ref)] = append([]string(nil), command...)
 }
 
 // Lookup returns the conversation info for an (adapter, key) pair.
@@ -190,8 +215,18 @@ func (idx *Index) Scan(a adapter.Adapter, ref string) string {
 
 	convInfo, err := desc.DescribeConversation(ref)
 	if err != nil {
+		idx.setResumeCommand(a.Name(), ref, nil)
 		return ""
 	}
+
+	var cmd []string
+	if resumer, ok := a.(adapter.Resumer); ok {
+		cmd = resumer.ResumeCommand(convInfo)
+	}
+	// Cache before the metadata/index eligibility checks below. The wire
+	// command contract depends only on ConversationDescriber + Resumer, while
+	// the URL index additionally requires cwd/title metadata.
+	idx.setResumeCommand(a.Name(), ref, cmd)
 
 	if convInfo.Cwd == "" {
 		return ""
@@ -205,14 +240,10 @@ func (idx *Index) Scan(a adapter.Adapter, ref string) string {
 		key = adapter.Slugify(convInfo.ID)
 	}
 
-	var cmd []string
-	if resumer, ok := a.(adapter.Resumer); ok {
+	if _, ok := a.(adapter.Resumer); ok && len(cmd) == 0 {
 		// An empty command means the adapter considers this conversation
 		// non-resumable (empty/corrupted), so it stays out of the index.
-		cmd = resumer.ResumeCommand(convInfo)
-		if len(cmd) == 0 {
-			return ""
-		}
+		return ""
 	}
 
 	info := Info{
@@ -241,6 +272,9 @@ func (idx *Index) Remove(adapterName, conversationID string) bool {
 		return false
 	}
 	delete(idx.byConversationID, tk)
+	if info, exists := idx.byKey[indexKey(adapterName, key)]; exists {
+		delete(idx.resumeByRef, refKey(adapterName, info.Ref))
+	}
 	delete(idx.byKey, indexKey(adapterName, key))
 	return true
 }
@@ -261,6 +295,7 @@ func (idx *Index) Remove(adapterName, conversationID string) bool {
 func (idx *Index) RemoveByRef(adapterName, ref string) bool {
 	idx.mu.Lock()
 	defer idx.mu.Unlock()
+	delete(idx.resumeByRef, refKey(adapterName, ref))
 	for key, info := range idx.byKey {
 		if info.Adapter != adapterName || info.Ref != ref {
 			continue

--- a/services/gmuxd/internal/conversations/opaque_ref_test.go
+++ b/services/gmuxd/internal/conversations/opaque_ref_test.go
@@ -2,6 +2,7 @@ package conversations
 
 import (
 	"errors"
+	"strconv"
 	"testing"
 	"time"
 
@@ -164,6 +165,42 @@ func TestScan_ResumableDescribesOnce(t *testing.T) {
 	}
 	if a.describes != 1 {
 		t.Errorf("DescribeConversation called %d times, want exactly 1", a.describes)
+	}
+}
+
+// TestLookupResumeCommandDoesNotRedescribe is the list-path scaling guard.
+// Conversation sources pay the descriptor I/O once when indexing; arbitrarily
+// many session renders are pure cache reads rather than transcript reads.
+func TestLookupResumeCommandDoesNotRedescribe(t *testing.T) {
+	const sessions = 1000
+	a := &dbAdapter{rows: make(map[string]adapter.ConversationInfo, sessions)}
+	idx := New()
+	for i := range sessions {
+		n := strconv.Itoa(i)
+		ref := "row:" + n
+		a.rows[ref] = adapter.ConversationInfo{ID: "conv-" + n, Slug: "session-" + n, Cwd: "/home/u/proj", MessageCount: 2}
+		idx.Scan(a, ref)
+	}
+	if a.describes != sessions {
+		t.Fatalf("indexing caused %d DescribeConversation calls, want %d", a.describes, sessions)
+	}
+
+	// This loop models conversion of 1000 distinct dead session rows.
+	for i := range sessions {
+		n := strconv.Itoa(i)
+		cmd := idx.LookupResumeCommand("dbtool", "row:"+n)
+		if len(cmd) != 3 || cmd[2] != "conv-"+n {
+			t.Fatalf("LookupResumeCommand(%d) = %v, want cached resume command", i, cmd)
+		}
+		cmd[0] = "mutated"
+	}
+	if a.describes != sessions {
+		t.Fatalf("rendering %d dead sessions caused descriptor I/O: calls=%d, want %d indexing calls", sessions, a.describes, sessions)
+	}
+
+	idx.RemoveByRef("dbtool", "row:7")
+	if cmd := idx.LookupResumeCommand("dbtool", "row:7"); len(cmd) != 0 {
+		t.Fatalf("removed ref retained resume command %v", cmd)
 	}
 }
 

--- a/services/gmuxd/internal/conversations/opaque_ref_test.go
+++ b/services/gmuxd/internal/conversations/opaque_ref_test.go
@@ -123,6 +123,31 @@ func TestScan_DescribeFailureNotIndexed(t *testing.T) {
 	}
 }
 
+func TestScan_DescribeFailurePreservesCachedResumeCommand(t *testing.T) {
+	a := &dbAdapter{rows: map[string]adapter.ConversationInfo{
+		"row:7": {ID: "conv-7", Slug: "seven", Cwd: "/home/u/proj", MessageCount: 2},
+	}}
+	idx := New()
+	if slug := idx.Scan(a, "row:7"); slug != "seven" {
+		t.Fatalf("initial Scan slug = %q, want seven", slug)
+	}
+
+	delete(a.rows, "row:7") // transient descriptor failure on the next upsert
+	if slug := idx.Scan(a, "row:7"); slug != "" {
+		t.Fatalf("failed rescan slug = %q, want empty", slug)
+	}
+	if cmd := idx.LookupResumeCommand("dbtool", "row:7"); len(cmd) != 3 || cmd[2] != "conv-7" {
+		t.Fatalf("failed rescan replaced stale-good command with %v", cmd)
+	}
+
+	if !idx.RemoveByRef("dbtool", "row:7") {
+		t.Fatal("RemoveByRef returned false after transient failure")
+	}
+	if cmd := idx.LookupResumeCommand("dbtool", "row:7"); len(cmd) != 0 {
+		t.Fatalf("RemoveByRef retained resume command %v", cmd)
+	}
+}
+
 // TestScan_NonResumableNotIndexed pins the caller side of the Resumer
 // contract: a conversation that describes cleanly but whose adapter returns
 // no resume command is not indexed and yields no slug. It also pins the


### PR DESCRIPTION
## Summary

- cache adapter-derived resume commands in the conversation index while sources already describe each transcript
- render session-list commands from that in-memory index instead of re-reading every dead conversation JSONL
- clear cached commands with conversation removals and return defensive copies
- add a 1,000-distinct-session regression test proving list-time lookups do not invoke `DescribeConversation`

## Profiling / measurements

Fixture: this host's production state, ~994 sessions (~947 dead local sessions). The dead pi sessions referenced 798 distinct JSONL transcripts totaling **249 MiB**.

Before (warm production daemon):

- direct `GET /v1/sessions` over the Unix socket: **3.665s**
- `gmux ls --json`: **5.768s** in the sampled run (the daemon endpoint alone accounts for the scaling defect)

Root cause: wire conversion called `discovery.ResolveResumeCommandFor` for every dead session with a conversation ref. For pi, that calls `DescribeConversation`, whose `os.ReadFile` + full JSONL parse re-read all 798 transcripts on every list request.

After (scratch daemon built from this branch, isolated copied state, 997 sessions), five direct endpoint runs:

- **34ms, 28ms, 27ms, 30ms, 33ms**

This leaves `gmux ls` / `gmux ls --all` comfortably subsecond at ~1,000 sessions; both consume the same endpoint and their client-side filtering/sorting is in-memory. For the 947 sessions that were dead in both snapshots, the before/after rendered commands had **0 differences**.

The web UI's composed session snapshots use the same wire converter, so it shared the transcript re-read during snapshot recomposition. This change improves that path too; its HTTP/SSE delivery itself is cache-backed.

## Validation

- `pnpm moon run gmuxd:test`
- `pnpm moon run gmuxd:lint`
- scratch-daemon runtime measurement above (no binaries installed over the live daemon)
