### PR TITLE
fix(peering): harden reconciliation and surface adapter errors

### DIFF
--- a/services/gmuxd/cmd/gmuxd/bootstrap_peering_adapters.go
+++ b/services/gmuxd/cmd/gmuxd/bootstrap_peering_adapters.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/centralstore"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/config"
@@ -54,11 +55,17 @@ func (a *centralPeerAdapter) PeerSessions() []wire.Session {
 	rows := a.manager.SessionProjections()
 	out := make([]wire.Session, 0, len(rows))
 	for _, r := range rows {
-		b, _ := json.Marshal(r)
-		var s wire.Session
-		if json.Unmarshal(b, &s) == nil {
-			out = append(out, s)
+		b, err := json.Marshal(r)
+		if err != nil {
+			log.Printf("peering: %s: marshal session projection %s: %v", r.Peer, r.ID, err)
+			continue
 		}
+		var s wire.Session
+		if err := json.Unmarshal(b, &s); err != nil {
+			log.Printf("peering: %s: convert session projection %s: %v", r.Peer, r.ID, err)
+			continue
+		}
+		out = append(out, s)
 	}
 	return out
 }
@@ -91,7 +98,11 @@ func (a *centralPeerAdapter) hooks() peering.EventHooks {
 		LocalPeerConnected: func(_ string, rows []peering.SessionProjection) { a.assign(rows) },
 		LocalPeerDisconnected: func(name string) {
 			r, err := a.store.PruneLocalPeer(context.Background(), centralstore.PeerKey(name))
-			if err == nil && r.Changed {
+			if err != nil {
+				log.Printf("peering: %s: prune local peer placements: %v", name, err)
+				return
+			}
+			if r.Changed {
 				a.dirty(r.SessionsDirty, r.WorldDirty)
 			}
 		},
@@ -101,6 +112,7 @@ func (a *centralPeerAdapter) assign(rows []peering.SessionProjection) {
 	ctx := context.Background()
 	snap, err := a.store.ReadSnapshot(ctx, centralstore.SnapshotQuery{IncludeProjects: true})
 	if err != nil {
+		log.Printf("peering: read projects for local peer assignment: %v", err)
 		return
 	}
 	entries := make([]projectmatch.Entry, 0, len(snap.Projects))
@@ -122,8 +134,9 @@ func (a *centralPeerAdapter) assign(rows []peering.SessionProjection) {
 		if !ok {
 			continue
 		}
-		r, e := a.store.UpsertLocalPeerPlacement(ctx, centralstore.LocalPeerSubject{PeerKey: centralstore.PeerKey(s.Peer), SessionID: peeringOriginalID(s.ID), ParentSessionID: peeringOriginalID(s.ParentSessionID)}, ids[i])
-		if e != nil {
+		r, err := a.store.UpsertLocalPeerPlacement(ctx, centralstore.LocalPeerSubject{PeerKey: centralstore.PeerKey(s.Peer), SessionID: peeringOriginalID(s.ID), ParentSessionID: peeringOriginalID(s.ParentSessionID)}, ids[i])
+		if err != nil {
+			log.Printf("peering: %s: assign local peer session %s: %v", s.Peer, peeringOriginalID(s.ID), err)
 			continue
 		}
 		combined.Changed = combined.Changed || r.Changed
@@ -146,23 +159,18 @@ func reconcileManualPeers(ctx context.Context, st *centralstore.Store, mgr *peer
 		desired[p.Name] = p
 	}
 	for _, info := range mgr.PeerStatus() {
-		p, ok := desired[info.Name]
-		if !ok {
+		if _, ok := desired[info.Name]; !ok {
 			mgr.RemovePeer(info.Name)
-			continue
 		}
-		live := mgr.GetPeer(info.Name)
-		if live.Config.URL != p.URL || live.Config.Token != p.Token {
-			mgr.RemovePeer(info.Name)
-			mgr.AddPeer(config.PeerConfig{Name: p.Name, URL: p.URL, Token: p.Token})
-		}
-		delete(desired, info.Name)
 	}
+	// Ensure every durable row after removals. EnsurePeer serializes the config
+	// comparison and any generation replacement with concurrent peer mutations,
+	// so a stale pointer cannot make this pass skip a now-absent desired peer.
 	for _, p := range desired {
 		if p.Name == "" {
 			return fmt.Errorf("manual peer has empty name")
 		}
-		mgr.AddPeer(config.PeerConfig{Name: p.Name, URL: p.URL, Token: p.Token})
+		mgr.EnsurePeer(config.PeerConfig{Name: p.Name, URL: p.URL, Token: p.Token})
 	}
 	return nil
 }

--- a/services/gmuxd/cmd/gmuxd/bootstrap_peering_composed_test.go
+++ b/services/gmuxd/cmd/gmuxd/bootstrap_peering_composed_test.go
@@ -17,6 +17,22 @@ import (
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/sessioncoord"
 )
 
+type blockingPeerStatusSink struct {
+	entered chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (s *blockingPeerStatusSink) ReplacePeerSessions(string, []peering.SessionProjection) {}
+func (s *blockingPeerStatusSink) RemovePeerSessions(string)                               {}
+func (s *blockingPeerStatusSink) SessionActivity(string)                                  {}
+func (s *blockingPeerStatusSink) PeerWorldChanged(string)                                 {}
+func (s *blockingPeerStatusSink) AliveSessionCount(string) int {
+	s.once.Do(func() { close(s.entered) })
+	<-s.release
+	return 0
+}
+
 type composedSpoke struct {
 	*httptest.Server
 	connected chan struct{}
@@ -206,6 +222,56 @@ func TestComposedLocalPeerConnectAssignsAndTransientDisconnectPrunes(t *testing.
 	}
 	if prunes != 1 {
 		t.Fatalf("durable prune dirty notifications=%d, after disconnect=%v", prunes, dirt[baseline:])
+	}
+}
+
+func TestReconcileManualPeersToleratesConcurrentRemoval(t *testing.T) {
+	ctx := context.Background()
+	st, err := centralstore.Open(ctx, t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	if _, _, _, err := st.UpsertManualPeer(ctx, centralstore.ManualPeerSpec{Name: "box", URL: "http://box", Token: "secret"}, 1); err != nil {
+		t.Fatal(err)
+	}
+
+	// PeerStatus holds the manager read lock while consulting the sink. Queue a
+	// removal there so it runs after reconcile snapshots the runtime but before
+	// reconcile ensures every desired config, reproducing the later TOCTOU
+	// ordering from the review deterministically.
+	sink := &blockingPeerStatusSink{entered: make(chan struct{}), release: make(chan struct{})}
+	mgr := peering.NewProjectionManager([]config.PeerConfig{{Name: "box", URL: "http://box", Token: "secret"}}, "self", sink, peering.EventHooks{})
+	reconcileDone := make(chan error, 1)
+	go func() {
+		var err error
+		defer func() {
+			if r := recover(); r != nil {
+				err = fmt.Errorf("reconcile panicked: %v", r)
+			}
+			reconcileDone <- err
+		}()
+		err = reconcileManualPeers(ctx, st, mgr)
+	}()
+	<-sink.entered
+	removeStarted := make(chan struct{})
+	removeDone := make(chan struct{})
+	go func() {
+		close(removeStarted)
+		mgr.RemovePeer("box")
+		close(removeDone)
+	}()
+	<-removeStarted
+	// Let RemovePeer queue for the manager lock before reconciliation resumes.
+	time.Sleep(10 * time.Millisecond)
+	close(sink.release)
+
+	if err := <-reconcileDone; err != nil {
+		t.Fatal(err)
+	}
+	<-removeDone
+	if p := mgr.GetPeer("box"); p == nil || p.Config.Token != "secret" {
+		t.Fatalf("durable peer was not restored after concurrent removal: %v", p)
 	}
 }
 

--- a/services/gmuxd/internal/peering/manager.go
+++ b/services/gmuxd/internal/peering/manager.go
@@ -10,6 +10,9 @@ import (
 
 // Manager orchestrates connections to all configured spoke peers.
 type Manager struct {
+	// mutationMu serializes peer lifecycle mutations across the periods where
+	// mu must be released to stop a connection and wait for its callbacks.
+	mutationMu         sync.Mutex
 	mu                 sync.RWMutex
 	peers              map[string]*managedPeer
 	sink               ProjectionSink
@@ -198,6 +201,12 @@ func (m *Manager) Stop() {
 // AddPeer registers a new peer and starts its connection. If a peer
 // with the same name already exists, AddPeer is a no-op.
 func (m *Manager) AddPeer(cfg config.PeerConfig, opts ...PeerOption) {
+	m.mutationMu.Lock()
+	defer m.mutationMu.Unlock()
+	m.addPeer(cfg, opts...)
+}
+
+func (m *Manager) addPeer(cfg config.PeerConfig, opts ...PeerOption) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -217,11 +226,38 @@ func (m *Manager) AddPeer(cfg config.PeerConfig, opts ...PeerOption) {
 	}
 }
 
+// EnsurePeer atomically ensures that cfg is the installed peer generation.
+// A changed generation is fully stopped and cleaned up before its replacement
+// starts; concurrent AddPeer, RemovePeer, and EnsurePeer calls cannot observe
+// and act on a stale generation between the comparison and replacement.
+func (m *Manager) EnsurePeer(cfg config.PeerConfig) {
+	m.mutationMu.Lock()
+	defer m.mutationMu.Unlock()
+
+	m.mu.RLock()
+	mp := m.peers[cfg.Name]
+	unchanged := mp != nil && mp.peer.Config == cfg
+	m.mu.RUnlock()
+	if unchanged {
+		return
+	}
+	if mp != nil {
+		m.removePeer(cfg.Name)
+	}
+	m.addPeer(cfg)
+}
+
 // RemovePeer stops a peer connection, waits for its goroutine to finish,
 // and removes all its sessions from the store. If OnPeerRemoved is set,
 // it fires after store cleanup so the caller can run additional cleanup
 // (e.g. PruneNamespacedKeys for a destroyed devcontainer).
 func (m *Manager) RemovePeer(name string) {
+	m.mutationMu.Lock()
+	defer m.mutationMu.Unlock()
+	m.removePeer(name)
+}
+
+func (m *Manager) removePeer(name string) {
 	m.mu.Lock()
 	mp, ok := m.peers[name]
 	if !ok {

--- a/services/gmuxd/internal/peering/peer.go
+++ b/services/gmuxd/internal/peering/peer.go
@@ -260,6 +260,7 @@ func (p *Peer) fetchProjects(ctx context.Context) {
 	p.cachedProjects = projects
 	p.cachedDiscovered = discovered
 	p.projectsLoaded = true
+	status := p.status
 	p.mu.Unlock()
 	// Second reciprocal feedback loop: the hub sets projects-update on
 	// every world frame it ships to ?as=peer subscribers, so a mutual
@@ -285,7 +286,7 @@ func (p *Peer) fetchProjects(ctx context.Context) {
 		return
 	}
 	if p.onStatus != nil {
-		p.onStatus(p.Config.Name, p.status)
+		p.onStatus(p.Config.Name, status)
 	}
 }
 

--- a/services/gmuxd/internal/peering/peer_status_race_test.go
+++ b/services/gmuxd/internal/peering/peer_status_race_test.go
@@ -1,0 +1,54 @@
+package peering
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/config"
+)
+
+// TestFetchProjectsStatusCallbackConcurrent exercises the status read used by
+// fetchProjects while the connection loop updates that status. Run with
+// -race: the callback path must take the same lock as every other status read.
+func TestFetchProjectsStatusCallbackConcurrent(t *testing.T) {
+	var response atomic.Uint64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n := response.Add(1)
+		fmt.Fprintf(w, `{"configured":[{"slug":"project-%d"}]}`, n)
+	}))
+	defer server.Close()
+
+	var callbacks atomic.Int64
+	peer := newPeer(config.PeerConfig{Name: "box", URL: server.URL}, nil, func(_ string, status Status) {
+		callbacks.Add(int64(status) + 1)
+	})
+	stop := make(chan struct{})
+	var writer sync.WaitGroup
+	writer.Add(1)
+	go func() {
+		defer writer.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				peer.setStatus(StatusConnecting)
+				peer.setStatus(StatusDisconnected)
+			}
+		}
+	}()
+
+	for range 50 {
+		peer.fetchProjects(context.Background())
+	}
+	close(stop)
+	writer.Wait()
+	if callbacks.Load() == 0 {
+		t.Fatal("status callback was not exercised")
+	}
+}


### PR DESCRIPTION
## Summary

- tolerate a peer disappearing between `PeerStatus` and `GetPeer` during concurrent manual-peer reconciliation, then restore it from durable state
- read the project-refresh status callback value under `Peer.mu`
- log peer projection conversion, local-placement prune/read, and placement-upsert failures instead of silently dropping them

## Evidence trail

This addresses the aggregator-verified peering findings from `.memory/AGGREGATE.md`:

- Tier A #1 / reports 312 and 143: `reconcileManualPeers` could nil-deref after concurrent `RemovePeer`
- Tier B #9 / report 130: `fetchProjects` read `p.status` outside `p.mu`
- Tier B #17 / reports 143 and 312: adapter errors were silently ignored

The reconciliation regression test queues `RemovePeer` behind the read lock held by `PeerStatus`, forcing it to win before the subsequent `GetPeer`. Against the old implementation it fails with:

```
reconcile panicked: runtime error: invalid memory address or nil pointer dereference
```

The status callback test continuously updates peer status while project refresh callbacks run and is included in the race suite.

## Verification

- `go test ./services/gmuxd/cmd/gmuxd ./services/gmuxd/internal/peering`
- `go test -race ./services/gmuxd/cmd/gmuxd ./services/gmuxd/internal/peering`
- `go test ./services/gmuxd/cmd/gmuxd -run TestReconcileManualPeersToleratesConcurrentRemoval -count=20`
- `pnpm test`
