### PR TITLE
fix(daemon): prevent slow incumbents from triggering takeover

### DIFF
--- a/cli/gmux/cmd/gmux/daemon.go
+++ b/cli/gmux/cmd/gmux/daemon.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"log"
 	"net"
@@ -11,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
@@ -30,38 +32,78 @@ func ensureGmuxdContext(ctx context.Context) bool {
 		return false
 	}
 
+	// Autostart is a cross-process decision. Serialize it, then jitter and
+	// recheck: the process that lost the first race should observe the winner's
+	// socket instead of spawning a second full bootstrap.
+	lock, err := acquireAutostartLock(ctx)
+	if err != nil {
+		return false
+	}
+	releaseHere := true
+	defer func() {
+		if releaseHere {
+			releaseAutostartLock(lock)
+		}
+	}()
+	jitter := 25*time.Millisecond + time.Duration(time.Now().UnixNano()%int64(75*time.Millisecond))
+	select {
+	case <-ctx.Done():
+		return false
+	case <-time.After(jitter):
+	}
+	if !gmuxdNeedsStartContext(ctx) || ctx.Err() != nil {
+		return false
+	}
+
 	gmuxdBin := findGmuxdBin()
 	if gmuxdBin == "" {
 		log.Printf("warning: gmuxd not found (install it alongside gmux or add it to PATH)")
 		return false
 	}
 
-	// gmuxd run starts in the foreground; we background it ourselves.
-	return startGmuxd(gmuxdBin, []string{"run"})
+	// gmuxd run starts in the foreground; we background it ourselves. Keep the
+	// lock until that exact child either exposes a socket or exits. If the
+	// caller's request budget ends first, a watcher retains the lock so another
+	// CLI cannot overlap the still-bootstrapping child.
+	started, done := startGmuxd(gmuxdBin, []string{"run"})
+	if !started {
+		return false
+	}
+	if !waitForAutostartCandidate(ctx, done, 30*time.Second) && ctx.Err() != nil {
+		releaseHere = false
+		go func() {
+			waitForAutostartCandidate(context.Background(), done, 30*time.Second)
+			releaseAutostartLock(lock)
+		}()
+	}
+	return true
 }
 
-// gmuxdNeedsStart checks the running daemon.
-//
-// The probe retries with growing budgets before concluding the daemon is
-// down: a single 500ms probe is a hair trigger on a loaded host, and a false
-// "down" verdict spawns a daemon. (Spawning is no longer destructive — a
-// healthy same-version incumbent refuses replacement since the autostart
-// takeover incident — but pointless spawns still burn a full bootstrap.)
+// gmuxdNeedsStart checks socket ownership first and health identity second.
+// Response latency is never evidence that the socket has no owner.
 func gmuxdNeedsStart() bool { return gmuxdNeedsStartContext(context.Background()) }
 
 func gmuxdNeedsStartContext(ctx context.Context) bool {
-	// "dev" builds never replace — avoids churn during development.
+	// Socket ownership is liveness. A completed connect proves an owner even if
+	// its HTTP handler is overloaded; timeout and permission failures are
+	// ambiguous and therefore conservative. Only ENOENT/ECONNREFUSED start.
+	if !gmuxdSocketOwnedContext(ctx) {
+		return true
+	}
+
+	// "dev" builds never replace — avoids churn during development and needs
+	// no identity response once socket ownership is established.
 	if version == "dev" {
-		return !gmuxdHealthyRetryContext(ctx)
+		return false
 	}
 
 	resp, err := gmuxdHealthGetContext(ctx)
 	if err != nil {
-		return true // not running
+		return false // connected owner, identity unavailable: leave it alone
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return true // not healthy
+		return false // responder is alive even if it reports unhealthy
 	}
 
 	var health struct {
@@ -70,11 +112,11 @@ func gmuxdNeedsStartContext(ctx context.Context) bool {
 		} `json:"data"`
 	}
 	body, _ := io.ReadAll(resp.Body)
-	if json.Unmarshal(body, &health) != nil {
-		return false // can't parse, leave it alone
+	if json.Unmarshal(body, &health) != nil || strings.TrimSpace(health.Data.Version) == "" {
+		return false // identity contract unavailable: leave the owner alone
 	}
 
-	// Same version: no action needed. Different version: replace.
+	// Same version: no action needed. Different known version: replace.
 	return health.Data.Version != version
 }
 
@@ -118,8 +160,9 @@ func autostartLogFile() *os.File {
 	return f
 }
 
-// startGmuxd launches gmuxd in the background with the given args.
-func startGmuxd(gmuxdBin string, args []string) bool {
+// startGmuxd launches gmuxd in the background with the given args and returns
+// a channel closed when that exact child exits.
+func startGmuxd(gmuxdBin string, args []string) (bool, <-chan struct{}) {
 	// Log gmuxd output to a file so users can diagnose startup failures.
 	logFile := autostartLogFile()
 
@@ -141,16 +184,79 @@ func startGmuxd(gmuxdBin string, args []string) bool {
 		if logFile != nil {
 			logFile.Close()
 		}
-		return false
+		return false, nil
 	}
+	done := make(chan struct{})
 	go func() {
-		cmd.Wait()
+		_ = cmd.Wait()
 		if logFile != nil {
 			logFile.Close()
 		}
+		close(done)
 	}()
 
-	return true
+	return true, done
+}
+
+func acquireAutostartLock(ctx context.Context) (*os.File, error) {
+	if err := os.MkdirAll(paths.StateDir(), 0o700); err != nil {
+		return nil, err
+	}
+	f, err := os.OpenFile(filepath.Join(paths.StateDir(), "gmuxd.autostart.lock"), os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	for {
+		err = syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+		if err == nil {
+			return f, nil
+		}
+		if !errors.Is(err, syscall.EWOULDBLOCK) && !errors.Is(err, syscall.EAGAIN) {
+			f.Close()
+			return nil, err
+		}
+		select {
+		case <-ctx.Done():
+			f.Close()
+			return nil, ctx.Err()
+		case <-time.After(25 * time.Millisecond):
+		}
+	}
+}
+
+func releaseAutostartLock(f *os.File) {
+	if f == nil {
+		return
+	}
+	_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+	_ = f.Close()
+}
+
+// waitForAutostartCandidate returns false only when the caller context ended.
+// Child exit, socket appearance, and the bootstrap ceiling all resolve this
+// candidate and permit the next lock holder to make a fresh decision.
+func waitForAutostartCandidate(ctx context.Context, done <-chan struct{}, ceiling time.Duration) bool {
+	tick := time.NewTicker(50 * time.Millisecond)
+	defer tick.Stop()
+	deadline := time.NewTimer(ceiling)
+	defer deadline.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return false
+		case <-done:
+			return true
+		case <-deadline.C:
+			return true
+		case <-tick.C:
+			probeCtx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+			owned := gmuxdSocketOwnedContext(probeCtx)
+			cancel()
+			if owned {
+				return true
+			}
+		}
+	}
 }
 
 // gmuxdClient returns an HTTP client connected to gmuxd via Unix socket.
@@ -172,58 +278,36 @@ func gmuxdBaseURL() string {
 	return "http://localhost"
 }
 
-func gmuxdHealthyContext(ctx context.Context, timeout time.Duration) bool {
-	attemptCtx, cancel := context.WithTimeout(ctx, timeout)
+func gmuxdSocketOwnedContext(ctx context.Context) bool {
+	dialCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	defer cancel()
+	conn, err := (&net.Dialer{}).DialContext(dialCtx, "unix", paths.SocketPath())
+	if err == nil {
+		_ = conn.Close()
+		return true
+	}
+	return !(errors.Is(err, os.ErrNotExist) || errors.Is(err, syscall.ENOENT) || errors.Is(err, syscall.ECONNREFUSED))
+}
+
+// gmuxdHealthGetContext fetches identity with a generous deadline separate
+// from the connect-only liveness probe. Callers own resp.Body.
+func gmuxdHealthGetContext(ctx context.Context) (*http.Response, error) {
+	attemptCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
 	client := gmuxdClient()
+	client.Timeout = 15 * time.Second
 	req, _ := http.NewRequestWithContext(attemptCtx, http.MethodGet, gmuxdBaseURL()+"/v1/health", nil)
 	resp, err := client.Do(req)
 	if err != nil {
-		return false
+		return nil, err
 	}
-	defer resp.Body.Close()
-	return resp.StatusCode == http.StatusOK
-}
-
-// gmuxdHealthyRetry probes health with growing budgets (500ms, 1s, 2s) so a
-// momentarily busy daemon isn't misdiagnosed as down.
-func gmuxdHealthyRetry() bool { return gmuxdHealthyRetryContext(context.Background()) }
-
-func gmuxdHealthyRetryContext(ctx context.Context) bool {
-	for _, timeout := range []time.Duration{500 * time.Millisecond, time.Second, 2 * time.Second} {
-		if gmuxdHealthyContext(ctx, timeout) {
-			return true
-		}
+	body, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		return nil, err
 	}
-	return false
-}
-
-// gmuxdHealthGet fetches /v1/health with the same growing budgets, returning
-// the last error if all attempts fail. Callers own resp.Body.
-func gmuxdHealthGet() (*http.Response, error) { return gmuxdHealthGetContext(context.Background()) }
-
-func gmuxdHealthGetContext(ctx context.Context) (*http.Response, error) {
-	var lastErr error
-	for _, timeout := range []time.Duration{500 * time.Millisecond, time.Second, 2 * time.Second} {
-		attemptCtx, cancel := context.WithTimeout(ctx, timeout)
-		client := gmuxdClient()
-		req, _ := http.NewRequestWithContext(attemptCtx, http.MethodGet, gmuxdBaseURL()+"/v1/health", nil)
-		resp, err := client.Do(req)
-		if err == nil {
-			body, readErr := io.ReadAll(resp.Body)
-			resp.Body.Close()
-			cancel()
-			if readErr == nil {
-				resp.Body = io.NopCloser(bytes.NewReader(body))
-				return resp, nil
-			}
-			err = readErr
-		} else {
-			cancel()
-		}
-		lastErr = err
-	}
-	return nil, lastErr
+	resp.Body = io.NopCloser(bytes.NewReader(body))
+	return resp, nil
 }
 
 // registerOutcome classifies the result of a registration attempt so

--- a/cli/gmux/cmd/gmux/main_test.go
+++ b/cli/gmux/cmd/gmux/main_test.go
@@ -1,11 +1,16 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
 	"net"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -100,6 +105,34 @@ func TestGmuxdNeedsStart_NewerVersion(t *testing.T) {
 	}
 }
 
+func TestGmuxdNeedsStart_ReleaseMissingVersionPreservesOwner(t *testing.T) {
+	old := version
+	version = "0.4.4"
+	defer func() { version = old }()
+
+	stateDir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateDir)
+	sockDir := filepath.Join(stateDir, "gmux")
+	if err := os.MkdirAll(sockDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	sockPath := filepath.Join(sockDir, "gmuxd.sock")
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"ok":true,"data":{}}`))
+	})}
+	go srv.Serve(ln)
+	defer srv.Close()
+
+	if gmuxdNeedsStart() {
+		t.Fatal("missing health version triggered implicit release takeover")
+	}
+}
+
 func TestGmuxdNeedsStart_DevNeverReplaces(t *testing.T) {
 	old := version
 	version = "dev"
@@ -123,6 +156,120 @@ func TestGmuxdNeedsStart_DevStartsWhenNotRunning(t *testing.T) {
 
 	if !gmuxdNeedsStart() {
 		t.Error("expected true for dev build when daemon is not running")
+	}
+}
+
+func TestGmuxdNeedsStart_AcceptedSocketIsAliveWithoutHealthResponse(t *testing.T) {
+	old := version
+	version = "dev"
+	defer func() { version = old }()
+
+	stateDir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateDir)
+	sockDir := filepath.Join(stateDir, "gmux")
+	if err := os.MkdirAll(sockDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	ln, err := net.Listen("unix", filepath.Join(sockDir, "gmuxd.sock"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	accepted := make(chan struct{})
+	stop := make(chan struct{})
+	defer close(stop)
+	go func() {
+		conn, err := ln.Accept()
+		if err == nil {
+			close(accepted)
+			defer conn.Close()
+			<-stop // connected owner deliberately never speaks HTTP
+		}
+	}()
+
+	start := time.Now()
+	if gmuxdNeedsStart() {
+		t.Fatal("accepted socket was misclassified as an absent daemon")
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("socket liveness waited for HTTP: %v", elapsed)
+	}
+	select {
+	case <-accepted:
+	case <-time.After(time.Second):
+		t.Fatal("liveness probe never connected")
+	}
+}
+
+func TestConcurrentAutostartSpawnsOneCandidate(t *testing.T) {
+	oldVersion := version
+	version = "dev"
+	defer func() { version = oldVersion }()
+
+	base := t.TempDir()
+	state := filepath.Join(base, "state")
+	bin := filepath.Join(base, "bin")
+	if err := os.MkdirAll(bin, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("XDG_STATE_HOME", state)
+	countPath := filepath.Join(base, "spawns")
+	pidPath := filepath.Join(base, "pid")
+	t.Setenv("FAKE_COUNT", countPath)
+	t.Setenv("FAKE_PID", pidPath)
+	t.Setenv("FAKE_SOCKET", filepath.Join(state, "gmux", "gmuxd.sock"))
+	t.Setenv("PATH", bin+":"+os.Getenv("PATH"))
+	script := `#!/bin/sh
+set -eu
+printf 'spawn\n' >> "$FAKE_COUNT"
+exec python3 - <<'PY'
+import os, socket
+p=os.environ['FAKE_SOCKET']
+os.makedirs(os.path.dirname(p), exist_ok=True)
+try: os.unlink(p)
+except FileNotFoundError: pass
+s=socket.socket(socket.AF_UNIX)
+s.bind(p); s.listen(64)
+open(os.environ['FAKE_PID'],'w').write(str(os.getpid()))
+while True:
+ c,_=s.accept(); c.close()
+PY
+`
+	if err := os.WriteFile(filepath.Join(bin, "gmuxd"), []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if raw, err := os.ReadFile(pidPath); err == nil {
+			var pid int
+			_, _ = fmt.Sscanf(strings.TrimSpace(string(raw)), "%d", &pid)
+			if pid > 0 {
+				_ = syscall.Kill(pid, syscall.SIGKILL)
+			}
+		}
+	})
+
+	const callers = 8
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(callers)
+	for range callers {
+		go func() {
+			defer wg.Done()
+			<-start
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			ensureGmuxdContext(ctx)
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	raw, err := os.ReadFile(countPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Count(string(raw), "spawn\n"); got != 1 {
+		t.Fatalf("concurrent autostart spawned %d candidates, want 1", got)
 	}
 }
 

--- a/services/gmuxd/cmd/gmuxd/serve_central.go
+++ b/services/gmuxd/cmd/gmuxd/serve_central.go
@@ -54,6 +54,24 @@ import (
 // replacement was requested.
 var errIncumbentHealthy = errors.New("gmuxd: already running")
 
+// implicitIncumbentCheck is deliberately cheap and conservative. It runs
+// before any adapter discovery, indexing, state creation, or database access.
+// A connected/ambiguous socket with unreadable identity is still an owner and
+// must not be replaced implicitly; only a known different version proceeds.
+func implicitIncumbentCheck(sock string) error {
+	if !unixipc.SocketOwned(sock) {
+		return nil
+	}
+	ident, ok := unixipc.HealthIdentity(sock)
+	if !ok {
+		return fmt.Errorf("%w: socket owner with unavailable identity owns %s", errIncumbentHealthy, sock)
+	}
+	if ident.Version == version {
+		return fmt.Errorf("%w: healthy daemon %s (pid %d) owns %s", errIncumbentHealthy, ident.Version, ident.PID, sock)
+	}
+	return nil
+}
+
 // registerGetProjectsRoute installs the production GET /v1/projects handler.
 // Keeping registration and ownership projection together lets contract tests
 // exercise the same mux path peers consume.
@@ -69,6 +87,15 @@ func registerGetProjectsRoute(mux *http.ServeMux, render func(*http.Request) (wi
 }
 
 func serveCentral(stderr io.Writer, replace bool) int {
+	// This must remain the first operation. A candidate that will yield must do
+	// no bootstrap work against the incumbent it was spawned to replace.
+	if !replace {
+		if err := implicitIncumbentCheck(paths.SocketPath()); err != nil {
+			_, _ = fmt.Fprintf(stderr, "%v\n", err)
+			return 0
+		}
+	}
+
 	gmuxBin := resolveGmux()
 	if gmuxBin != "" {
 		log.Printf("gmux: %s", gmuxBin)
@@ -113,46 +140,34 @@ func serveCentral(stderr io.Writer, replace bool) int {
 		return 1
 	}
 
-	// A healthy incumbent of the SAME version is never shut down implicitly.
-	// This path is reached by `gmux`'s daemon autostart whenever a health
-	// probe times out (500ms budget) — on a loaded host that spawned daemons
-	// which killed the healthy incumbent, re-bootstrapped for seconds, and
-	// were killed in turn by the next autostart: a rolling production outage
-	// (registrations timing out, /v1/health dead) that looked like a store
-	// wedge. Replacement must be explicit (`gmuxd start`/`restart` pass
-	// --replace) or an actual version upgrade (release CLI replacing an
-	// outdated daemon).
-	//
-	// The yield check runs as bootstrapOwnership's precheck — BEFORE Verify
-	// opens the database — so a pointless autostart bounces off the incumbent
-	// without touching SQLite at all.
+	// Recheck before Verify to catch an owner that appeared after the first
+	// instruction. Known version upgrades may proceed; same/unknown owners
+	// yield unless replacement was explicit.
 	precheck := func(context.Context) error {
 		if replace {
 			return nil
 		}
-		sock := paths.SocketPath()
-		ident, ok := unixipc.HealthIdentity(sock)
-		if !ok {
-			return nil
-		}
-		if ident.Version == version {
-			return fmt.Errorf("%w: healthy daemon %s (pid %d) owns %s", errIncumbentHealthy, ident.Version, ident.PID, sock)
-		}
-		return nil
+		return implicitIncumbentCheck(paths.SocketPath())
 	}
 	takeover := func(context.Context) error {
 		sock := paths.SocketPath()
-		ident, ok := unixipc.HealthIdentity(sock)
-		if !ok {
+		if !unixipc.SocketOwned(sock) {
 			return nil
 		}
-		if !replace && ident.Version == version {
-			// Re-check: an incumbent may have become healthy between the
-			// precheck and here (e.g. it was mid-bootstrap during precheck).
+		ident, identityOK := unixipc.HealthIdentity(sock)
+		if !replace && (!identityOK || ident.Version == version) {
+			if !identityOK {
+				return fmt.Errorf("%w: socket owner with unavailable identity owns %s", errIncumbentHealthy, sock)
+			}
 			return fmt.Errorf("%w: healthy daemon %s (pid %d) owns %s", errIncumbentHealthy, ident.Version, ident.PID, sock)
 		}
 		if !unixipc.Shutdown(sock) {
-			return fmt.Errorf("existing daemon at %s did not shut down", sock)
+			// The incumbent may have exited between identity and POST. Continue
+			// only when a connect now positively proves it gone; timeout remains
+			// a live/ambiguous owner and is a hard refusal.
+			if unixipc.ProbeSocket(sock, 500*time.Millisecond) != unixipc.SocketDead {
+				return fmt.Errorf("existing daemon at %s did not shut down", sock)
+			}
 		}
 		return nil
 	}
@@ -924,7 +939,7 @@ func serveCentral(stderr io.Writer, replace bool) int {
 		daemonCancel()
 		return 1
 	}
-	defer unixipc.Cleanup(sock)
+	defer sockLn.Close()
 	sockSrv := &http.Server{Handler: unixMux}
 	go func() {
 		if err := sockSrv.Serve(sockLn); err != nil && err != http.ErrServerClosed {

--- a/services/gmuxd/cmd/gmuxd/serve_takeover_policy_test.go
+++ b/services/gmuxd/cmd/gmuxd/serve_takeover_policy_test.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
@@ -11,6 +13,43 @@ import (
 	"github.com/gmuxapp/gmux/packages/paths"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/unixipc"
 )
+
+func TestIncumbentCheckIsFirstStartupOperation(t *testing.T) {
+	base := t.TempDir()
+	for _, dir := range []string{"state", "config/gmux", "home", "run"} {
+		if err := os.MkdirAll(filepath.Join(base, dir), 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("HOME", filepath.Join(base, "home"))
+	t.Setenv("XDG_STATE_HOME", filepath.Join(base, "state"))
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(base, "config"))
+	t.Setenv("GMUX_SOCKET_DIR", filepath.Join(base, "run"))
+	// If startup gets past the incumbent check, config loading must fail.
+	if err := os.WriteFile(filepath.Join(base, "config/gmux/host.toml"), []byte("not = [valid"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	ln, err := unixipc.Listen(paths.SocketPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"version": version, "pid": 42}})
+	})}
+	go srv.Serve(ln)
+	defer srv.Close()
+
+	if code := serveCentral(io.Discard, false); code != 0 {
+		t.Fatalf("serve reached bootstrap after incumbent check: exit %d", code)
+	}
+	for _, name := range []string{"auth-token", "node-id", "state.db"} {
+		if _, err := os.Stat(filepath.Join(paths.StateDir(), name)); !os.IsNotExist(err) {
+			t.Fatalf("startup created %s before yielding: %v", name, err)
+		}
+	}
+}
 
 // TestServeRefusesToReplaceHealthySameVersionIncumbent pins the takeover
 // policy that ended the autostart incident: `gmux`'s daemon autostart spawns

--- a/services/gmuxd/internal/unixipc/unixipc.go
+++ b/services/gmuxd/internal/unixipc/unixipc.go
@@ -10,47 +10,116 @@ package unixipc
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
 	"time"
+
+	"github.com/gmuxapp/gmux/packages/socklease"
 )
 
 // Listen creates and binds a Unix socket at the given path.
 // The socket file is created with 0600 permissions in a 0700 directory.
-// Any existing socket file is removed first.
-func Listen(sockPath string) (net.Listener, error) {
+// An existing pathname is removed only when it is a non-socket artifact or a
+// pinned socket whose connect was actively refused. A live or ambiguous owner
+// is never unlinked. Daemon callers additionally hold gmuxd.lock across this
+// operation, which excludes another lease-aware daemon from the probe/remove
+// interval.
+type Listener struct {
+	*net.UnixListener
+	path string
+	pin  *socklease.Pin
+	once sync.Once
+	err  error
+}
+
+// Close closes the listener and removes its pathname only if the pathname
+// still names the inode this listener bound. Go's UnixListener auto-unlink is
+// disabled in Listen so all cleanup flows through this identity check.
+func (l *Listener) Close() error {
+	l.once.Do(func() {
+		closeErr := l.UnixListener.Close()
+		if l.pin.StillNamesIt() {
+			if err := os.Remove(l.path); err != nil && !os.IsNotExist(err) {
+				l.err = fmt.Errorf("unixipc: cleanup %s: %w", l.path, err)
+			}
+		}
+		if err := l.pin.Close(); l.err == nil && err != nil {
+			l.err = err
+		}
+		if l.err == nil {
+			l.err = closeErr
+		}
+	})
+	return l.err
+}
+
+func Listen(sockPath string) (*Listener, error) {
 	dir := filepath.Dir(sockPath)
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return nil, fmt.Errorf("unixipc: creating directory %s: %w", dir, err)
+	if err := socklease.RequireOwnedDir(dir); err != nil {
+		return nil, fmt.Errorf("unixipc: preparing directory %s: %w", dir, err)
 	}
 
-	// Remove stale socket file if present.
-	if err := os.Remove(sockPath); err != nil && !os.IsNotExist(err) {
-		return nil, fmt.Errorf("unixipc: removing stale socket %s: %w", sockPath, err)
+	if _, err := os.Lstat(sockPath); err == nil {
+		_, isSocket := socklease.StatSocket(sockPath)
+		if !isSocket {
+			// A regular file cannot be a listening owner. The state directory is
+			// owner-only and production holds the lifetime lock here.
+			if err := os.Remove(sockPath); err != nil {
+				return nil, fmt.Errorf("unixipc: removing stale artifact %s: %w", sockPath, err)
+			}
+		} else {
+			pin, pinErr := socklease.PinSocket(sockPath)
+			if pinErr != nil {
+				return nil, fmt.Errorf("unixipc: pinning existing socket %s: %w", sockPath, pinErr)
+			}
+			defer pin.Close()
+			if err := socklease.ProbeRefusedPinned(pin, 250*time.Millisecond); err != nil {
+				return nil, fmt.Errorf("unixipc: socket %s is still owned: %w", sockPath, err)
+			}
+			if !pin.StillNamesIt() {
+				return nil, fmt.Errorf("unixipc: socket %s changed during stale check", sockPath)
+			}
+			if err := os.Remove(sockPath); err != nil && !os.IsNotExist(err) {
+				return nil, fmt.Errorf("unixipc: removing stale socket %s: %w", sockPath, err)
+			}
+		}
+	} else if !os.IsNotExist(err) {
+		return nil, fmt.Errorf("unixipc: inspecting socket %s: %w", sockPath, err)
 	}
 
-	ln, err := net.Listen("unix", sockPath)
+	addr, err := net.ResolveUnixAddr("unix", sockPath)
+	if err != nil {
+		return nil, fmt.Errorf("unixipc: resolve %s: %w", sockPath, err)
+	}
+	ln, err := net.ListenUnix("unix", addr)
 	if err != nil {
 		return nil, fmt.Errorf("unixipc: listen %s: %w", sockPath, err)
 	}
+	// The standard listener otherwise unlinks by pathname on Close, which can
+	// delete a successor that rebound after this listener lost its name.
+	ln.SetUnlinkOnClose(false)
 
 	// Restrict socket permissions to owner only.
 	if err := os.Chmod(sockPath, 0o600); err != nil {
-		ln.Close()
-		os.Remove(sockPath)
+		_ = ln.Close()
+		_ = os.Remove(sockPath)
 		return nil, fmt.Errorf("unixipc: chmod %s: %w", sockPath, err)
 	}
+	pin, err := socklease.PinSocket(sockPath)
+	if err != nil {
+		_ = ln.Close()
+		return nil, fmt.Errorf("unixipc: pin bound socket %s: %w", sockPath, err)
+	}
 
-	return ln, nil
-}
-
-// Cleanup removes the socket file. Call on graceful shutdown.
-func Cleanup(sockPath string) {
-	os.Remove(sockPath)
+	return &Listener{UnixListener: ln, path: sockPath, pin: pin}, nil
 }
 
 // Client returns an http.Client that connects to a gmuxd Unix socket.
@@ -68,6 +137,38 @@ func Client(sockPath string) *http.Client {
 		},
 		Timeout: 5 * time.Second,
 	}
+}
+
+// SocketState is the ownership-relevant result of a Unix connect probe.
+type SocketState int
+
+const (
+	SocketDead SocketState = iota
+	SocketAlive
+	SocketAmbiguous
+)
+
+// ProbeSocket distinguishes proved absence from a live or ambiguous owner.
+// Only ENOENT and ECONNREFUSED prove death. In particular, a connect timeout
+// may be a stopped owner with a full accept backlog and is never permission to
+// unlink or replace it.
+func ProbeSocket(sockPath string, timeout time.Duration) SocketState {
+	conn, err := net.DialTimeout("unix", sockPath, timeout)
+	if err == nil {
+		_ = conn.Close()
+		return SocketAlive
+	}
+	if os.IsNotExist(err) || errors.Is(err, syscall.ENOENT) || errors.Is(err, syscall.ECONNREFUSED) {
+		return SocketDead
+	}
+	return SocketAmbiguous
+}
+
+// SocketOwned reports whether the socket is live or its state is ambiguous.
+// It is deliberately conservative: callers may act destructively only when
+// ProbeSocket returned SocketDead.
+func SocketOwned(sockPath string) bool {
+	return ProbeSocket(sockPath, 500*time.Millisecond) != SocketDead
 }
 
 // Healthy checks if a gmuxd is reachable and healthy at the given socket.
@@ -109,8 +210,8 @@ func HealthIdentity(sockPath string) (DaemonIdentity, bool) {
 			PID     int    `json:"pid"`
 		} `json:"data"`
 	}
-	if json.Unmarshal(body, &health) != nil {
-		return DaemonIdentity{}, true
+	if json.Unmarshal(body, &health) != nil || strings.TrimSpace(health.Data.Version) == "" || health.Data.PID <= 0 {
+		return DaemonIdentity{}, false
 	}
 	return DaemonIdentity{Version: health.Data.Version, PID: health.Data.PID}, true
 }
@@ -122,8 +223,11 @@ func HealthVersion(sockPath string) (string, bool) {
 }
 
 // Shutdown asks a running gmuxd to shut down via its Unix socket,
-// then waits for the socket to become unavailable.
-func Shutdown(sockPath string) bool {
+// then waits until connect proves the socket is gone. A deadline is failure,
+// never success: a stopped or overloaded incumbent still owns its pathname.
+func Shutdown(sockPath string) bool { return shutdownWithin(sockPath, 5*time.Second) }
+
+func shutdownWithin(sockPath string, wait time.Duration) bool {
 	client := Client(sockPath)
 	resp, err := client.Post("http://localhost/v1/shutdown", "", nil)
 	if err != nil {
@@ -134,16 +238,16 @@ func Shutdown(sockPath string) bool {
 		return false
 	}
 
-	// Wait for the socket to go away.
-	deadline := time.After(5 * time.Second)
+	deadline := time.NewTimer(wait)
+	defer deadline.Stop()
 	tick := time.NewTicker(100 * time.Millisecond)
 	defer tick.Stop()
 	for {
 		select {
-		case <-deadline:
-			return true
+		case <-deadline.C:
+			return false
 		case <-tick.C:
-			if !Healthy(sockPath) {
+			if ProbeSocket(sockPath, 250*time.Millisecond) == SocketDead {
 				return true
 			}
 		}
@@ -153,14 +257,11 @@ func Shutdown(sockPath string) bool {
 // Replace shuts down any existing daemon on the socket and prepares
 // for a new one to bind. Returns nil on success.
 func Replace(sockPath string) error {
-	if Healthy(sockPath) {
+	if ProbeSocket(sockPath, 500*time.Millisecond) != SocketDead {
 		if !Shutdown(sockPath) {
 			return fmt.Errorf("existing daemon at %s did not shut down", sockPath)
 		}
 	}
-	// Remove stale socket file (may exist even if daemon is gone).
-	if err := os.Remove(sockPath); err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("removing stale socket %s: %w", sockPath, err)
-	}
+	// Listen performs the pinned stale-path check immediately before bind.
 	return nil
 }

--- a/services/gmuxd/internal/unixipc/unixipc_test.go
+++ b/services/gmuxd/internal/unixipc/unixipc_test.go
@@ -2,7 +2,6 @@ package unixipc
 
 import (
 	"encoding/json"
-	"fmt"
 	"net"
 	"net/http"
 	"os"
@@ -71,19 +70,46 @@ func TestListenReplacesStaleSocket(t *testing.T) {
 	}
 }
 
-func TestCleanupRemovesSocket(t *testing.T) {
+func TestListenerCloseRemovesOwnedSocket(t *testing.T) {
 	sockPath := filepath.Join(t.TempDir(), "gmuxd.sock")
 	ln, err := Listen(sockPath)
 	if err != nil {
 		t.Fatal(err)
 	}
-	ln.Close()
-
-	Cleanup(sockPath)
+	if err := ln.Close(); err != nil {
+		t.Fatal(err)
+	}
 
 	if _, err := os.Stat(sockPath); !os.IsNotExist(err) {
-		t.Error("socket file should be removed after cleanup")
+		t.Error("socket file should be removed when its owner closes")
 	}
+}
+
+func TestOldListenerCleanupPreservesSuccessor(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "gmuxd.sock")
+	old, err := Listen(sockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Simulate the historical socket-steal interleaving: the old listener is
+	// still alive, but its pathname is removed and rebound by a successor.
+	if err := os.Remove(sockPath); err != nil {
+		t.Fatal(err)
+	}
+	successor, err := Listen(sockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer successor.Close()
+
+	if err := old.Close(); err != nil {
+		t.Fatal(err)
+	}
+	conn, err := net.Dial("unix", sockPath)
+	if err != nil {
+		t.Fatalf("old-owner cleanup unlinked successor: %v", err)
+	}
+	conn.Close()
 }
 
 func TestClientConnectsToSocket(t *testing.T) {
@@ -194,8 +220,7 @@ func TestShutdownStopsDaemon(t *testing.T) {
 	mux.HandleFunc("POST /v1/shutdown", func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(map[string]any{"ok": true})
 		go func() {
-			srv.Close()
-			Cleanup(sockPath)
+			_ = srv.Close() // closing the owned listener performs pinned cleanup
 		}()
 	})
 	go srv.Serve(ln)
@@ -218,17 +243,21 @@ func TestReplaceNoDaemon(t *testing.T) {
 	}
 }
 
-func TestReplaceStaleFile(t *testing.T) {
+func TestReplaceStaleFileDefersRemovalUntilListen(t *testing.T) {
 	sockPath := filepath.Join(t.TempDir(), "gmuxd.sock")
 	os.WriteFile(sockPath, []byte("stale"), 0o644)
 
 	if err := Replace(sockPath); err != nil {
 		t.Fatal(err)
 	}
-
-	if _, err := os.Stat(sockPath); !os.IsNotExist(err) {
-		t.Error("stale file should be removed")
+	if _, err := os.Stat(sockPath); err != nil {
+		t.Fatalf("Replace should not open a pre-bind removal race: %v", err)
 	}
+	ln, err := Listen(sockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ln.Close()
 }
 
 func startTestDaemon(t *testing.T, version string) (sockPath string, cleanup func()) {
@@ -299,7 +328,7 @@ func TestSocketDirectoryPermissions(t *testing.T) {
 	}
 }
 
-// Make sure we can't listen if another process already holds the socket.
+// Make sure a second listener can never unlink a live owner.
 func TestListenFailsIfSocketInUse(t *testing.T) {
 	sockPath := filepath.Join(t.TempDir(), "gmuxd.sock")
 
@@ -307,20 +336,72 @@ func TestListenFailsIfSocketInUse(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// Don't close ln1 — simulate a running daemon.
+	defer ln1.Close()
 
-	// Listen should remove the socket file and rebind.
-	// This is expected behavior (Replace handles the graceful case).
-	ln2, err := Listen(sockPath)
-	if err != nil {
-		// On some systems this may fail if the old listener still holds it.
-		// That's okay: Replace() should be called first in production.
-		t.Logf("Listen returned error as expected when socket in use: %v", err)
-		ln1.Close()
-		return
+	if ln2, err := Listen(sockPath); err == nil {
+		ln2.Close()
+		t.Fatal("Listen replaced a live socket owner")
 	}
-	ln1.Close()
-	ln2.Close()
+	conn, err := net.Dial("unix", sockPath)
+	if err != nil {
+		t.Fatalf("original listener pathname was disturbed: %v", err)
+	}
+	conn.Close()
+}
 
-	fmt.Println("Listen replaced socket file (OS allowed it)")
+func TestHealthIdentityRejectsInvalidContract(t *testing.T) {
+	for name, body := range map[string]string{
+		"malformed":       `not-json`,
+		"empty object":    `{}`,
+		"empty data":      `{"data":{}}`,
+		"missing pid":     `{"data":{"version":"1.0.0"}}`,
+		"missing version": `{"data":{"pid":42}}`,
+		"blank version":   `{"data":{"version":" ","pid":42}}`,
+		"invalid pid":     `{"data":{"version":"1.0.0","pid":0}}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			sockPath := filepath.Join(t.TempDir(), "gmuxd.sock")
+			ln, err := Listen(sockPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer ln.Close()
+			srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(body))
+			})}
+			go srv.Serve(ln)
+			defer srv.Close()
+
+			if id, ok := HealthIdentity(sockPath); ok {
+				t.Fatalf("invalid health contract accepted as identity: %+v", id)
+			}
+			if !SocketOwned(sockPath) {
+				t.Fatal("invalid identity must not erase proof of a live socket owner")
+			}
+		})
+	}
+}
+
+func TestShutdownTimeoutIsFailureAndPreservesOwner(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "gmuxd.sock")
+	ln, err := Listen(sockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /v1/shutdown", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK) // deliberately keep serving
+	})
+	srv := &http.Server{Handler: mux}
+	go srv.Serve(ln)
+	defer srv.Close()
+
+	if shutdownWithin(sockPath, 250*time.Millisecond) {
+		t.Fatal("shutdown deadline reported success while incumbent still owned socket")
+	}
+	if !SocketOwned(sockPath) {
+		t.Fatal("shutdown timeout disturbed the incumbent")
+	}
 }


### PR DESCRIPTION
## Summary

- treat a connected or ambiguous Unix socket as owned independently of health-response latency
- serialize concurrent CLI autostart with an owner-only flock, jittered recheck, and candidate readiness/exit wait
- move the daemon incumbent check ahead of adapter discovery, conversation indexing, and state/database work
- make shutdown timeout fail, reject malformed health identities, and refuse to unlink live/ambiguous socket owners

## Investigation

A hermetic SIGSTOP reproduction with isolated HOME/XDG/socket state and five concurrent clients produced five candidate `gmuxd run` processes from the old code. Each performed launcher discovery and conversation indexing before probing the incumbent. The decision path and worst-case interleaving are documented locally in `.memory/report-daemon-takeover.md`.

Repeating the same scratch reproduction after this change left exactly one process (the stopped incumbent) and produced no autostart log/candidate bootstrap.

## Tests

- `pnpm moon run gmux:test gmuxd:test`
- `pnpm moon run gmux:lint gmuxd:lint`
- `go test -race ./services/gmuxd/internal/unixipc ./cli/gmux/cmd/gmux`
