### PR TITLE
perf(gmuxd): skip indexing in autostart contenders

### DIFF
--- a/services/gmuxd/cmd/gmuxd/serve_central.go
+++ b/services/gmuxd/cmd/gmuxd/serve_central.go
@@ -234,10 +234,7 @@ func serveCentral(stderr io.Writer, replace bool) int {
 		return h
 	}
 
-	converter := &wire.Converter{Titlers: make(map[string]func([]string) string), SemanticAgents: make(map[string]bool), ResumeCommand: func(adapterName, ref string) []string {
-		legacy := &compatSession{Adapter: adapterName, ConversationRef: ref}
-		return discovery.ResolveResumeCommandFor(legacy.Adapter, legacy.ConversationRef)
-	}, IsLocalPeer: func(name string) bool { return peerManager != nil && peerManager.IsLocalPeer(name) }}
+	converter := &wire.Converter{Titlers: make(map[string]func([]string) string), SemanticAgents: make(map[string]bool), ResumeCommand: convIndex.LookupResumeCommand, IsLocalPeer: func(name string) bool { return peerManager != nil && peerManager.IsLocalPeer(name) }}
 	for _, a := range adapters.All {
 		if titler, ok := a.(adapter.CommandTitler); ok {
 			converter.Titlers[a.Name()] = titler.CommandTitle

--- a/services/gmuxd/cmd/gmuxd/serve_central.go
+++ b/services/gmuxd/cmd/gmuxd/serve_central.go
@@ -83,8 +83,6 @@ func serveCentral(stderr io.Writer, replace bool) int {
 	peerTransport := tsauth.NewRoutedTransport()
 	stateDir := paths.StateDir()
 	convIndex := conversations.New()
-	convIndex.Snapshot()
-	log.Printf("conversations: indexed %d conversations", convIndex.Count())
 
 	nodeID, err := nodeid.LoadOrCreate(stateDir)
 	if err != nil {
@@ -177,6 +175,12 @@ func serveCentral(stderr io.Writer, replace bool) int {
 	if bounded := installBoundedLog(stderr, paths.DaemonLogPath(), defaultLogLimit); bounded != nil {
 		defer bounded.Stop()
 	}
+
+	// Conversation discovery reads and parses the complete on-disk history.
+	// Do it only after ownership is settled: autostart contenders that find a
+	// healthy incumbent must yield without paying this multi-second cost.
+	convIndex.Snapshot()
+	log.Printf("conversations: indexed %d conversations", convIndex.Count())
 
 	var peerManager *peering.Manager
 	var tsListener *tsauth.Listener

--- a/services/gmuxd/cmd/gmuxd/serve_takeover_policy_test.go
+++ b/services/gmuxd/cmd/gmuxd/serve_takeover_policy_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 	"time"
 
@@ -49,8 +50,23 @@ func TestServeRefusesToReplaceHealthySameVersionIncumbent(t *testing.T) {
 	sock := paths.SocketPath()
 	waitUntil(t, 10*time.Second, func() bool { return unixipc.Healthy(sock) }, "incumbent never became healthy")
 
+	// Point any new invocation's Pi source at a FIFO. Reading it would block,
+	// making this an ordering guard: a same-version challenger must complete
+	// the incumbent precheck before attempting the expensive conversation
+	// snapshot. The incumbent's watcher already captured the original root.
+	blockedAgentDir := filepath.Join(base, "blocked-agent")
+	blockedSessions := filepath.Join(blockedAgentDir, "sessions")
+	if err := os.MkdirAll(blockedSessions, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fifo := filepath.Join(blockedSessions, "would-block.jsonl")
+	if err := syscall.Mkfifo(fifo, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PI_CODING_AGENT_DIR", blockedAgentDir)
+
 	// Same version (both "dev" in tests), no --replace: must yield exit 0
-	// quickly and leave the incumbent running.
+	// quickly, without opening the FIFO, and leave the incumbent running.
 	challenger := make(chan int, 1)
 	go func() { challenger <- serveCentral(io.Discard, false) }()
 	select {
@@ -63,6 +79,9 @@ func TestServeRefusesToReplaceHealthySameVersionIncumbent(t *testing.T) {
 	}
 	if !unixipc.Healthy(sock) {
 		t.Fatal("incumbent was disturbed by the non-replace challenger")
+	}
+	if err := os.Remove(fifo); err != nil {
+		t.Fatal(err)
 	}
 
 	// Explicit --replace must shut the incumbent down and take over.

--- a/services/gmuxd/internal/conversations/index.go
+++ b/services/gmuxd/internal/conversations/index.go
@@ -215,7 +215,9 @@ func (idx *Index) Scan(a adapter.Adapter, ref string) string {
 
 	convInfo, err := desc.DescribeConversation(ref)
 	if err != nil {
-		idx.setResumeCommand(a.Name(), ref, nil)
+		// Keep stale-good state on transient descriptor failures, matching the
+		// main metadata index. A source Remove event is the authoritative
+		// signal that clears both entries.
 		return ""
 	}
 

--- a/services/gmuxd/internal/conversations/index.go
+++ b/services/gmuxd/internal/conversations/index.go
@@ -44,6 +44,10 @@ type Index struct {
 	byKey map[string]Info
 	// byConversationID maps "adapter/conversationID" → internal key for reverse lookup.
 	byConversationID map[string]string
+	// resumeByRef caches the adapter-derived resume command while the
+	// conversation source is indexing the ref. Rendering the session list is
+	// a hot read path and must not re-read every dead conversation transcript.
+	resumeByRef map[string][]string
 }
 
 // New creates an empty index.
@@ -51,6 +55,7 @@ func New() *Index {
 	return &Index{
 		byKey:            make(map[string]Info),
 		byConversationID: make(map[string]string),
+		resumeByRef:      make(map[string][]string),
 	}
 }
 
@@ -60,6 +65,26 @@ func indexKey(adapterName, slug string) string {
 
 func convKey(adapterName, conversationID string) string {
 	return adapterName + "/" + conversationID
+}
+
+func refKey(adapterName, ref string) string {
+	return adapterName + "/" + ref
+}
+
+// LookupResumeCommand returns the command derived when the conversation ref
+// was last observed by its source. Snapshot populates this cache synchronously
+// before the daemon starts serving, and source upserts keep it current. The
+// returned slice is a copy so callers cannot mutate index state.
+func (idx *Index) LookupResumeCommand(adapterName, ref string) []string {
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
+	return append([]string(nil), idx.resumeByRef[refKey(adapterName, ref)]...)
+}
+
+func (idx *Index) setResumeCommand(adapterName, ref string, command []string) {
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
+	idx.resumeByRef[refKey(adapterName, ref)] = append([]string(nil), command...)
 }
 
 // Lookup returns the conversation info for an (adapter, key) pair.
@@ -190,8 +215,18 @@ func (idx *Index) Scan(a adapter.Adapter, ref string) string {
 
 	convInfo, err := desc.DescribeConversation(ref)
 	if err != nil {
+		idx.setResumeCommand(a.Name(), ref, nil)
 		return ""
 	}
+
+	var cmd []string
+	if resumer, ok := a.(adapter.Resumer); ok {
+		cmd = resumer.ResumeCommand(convInfo)
+	}
+	// Cache before the metadata/index eligibility checks below. The wire
+	// command contract depends only on ConversationDescriber + Resumer, while
+	// the URL index additionally requires cwd/title metadata.
+	idx.setResumeCommand(a.Name(), ref, cmd)
 
 	if convInfo.Cwd == "" {
 		return ""
@@ -205,14 +240,10 @@ func (idx *Index) Scan(a adapter.Adapter, ref string) string {
 		key = adapter.Slugify(convInfo.ID)
 	}
 
-	var cmd []string
-	if resumer, ok := a.(adapter.Resumer); ok {
+	if _, ok := a.(adapter.Resumer); ok && len(cmd) == 0 {
 		// An empty command means the adapter considers this conversation
 		// non-resumable (empty/corrupted), so it stays out of the index.
-		cmd = resumer.ResumeCommand(convInfo)
-		if len(cmd) == 0 {
-			return ""
-		}
+		return ""
 	}
 
 	info := Info{
@@ -241,6 +272,9 @@ func (idx *Index) Remove(adapterName, conversationID string) bool {
 		return false
 	}
 	delete(idx.byConversationID, tk)
+	if info, exists := idx.byKey[indexKey(adapterName, key)]; exists {
+		delete(idx.resumeByRef, refKey(adapterName, info.Ref))
+	}
 	delete(idx.byKey, indexKey(adapterName, key))
 	return true
 }
@@ -261,6 +295,7 @@ func (idx *Index) Remove(adapterName, conversationID string) bool {
 func (idx *Index) RemoveByRef(adapterName, ref string) bool {
 	idx.mu.Lock()
 	defer idx.mu.Unlock()
+	delete(idx.resumeByRef, refKey(adapterName, ref))
 	for key, info := range idx.byKey {
 		if info.Adapter != adapterName || info.Ref != ref {
 			continue

--- a/services/gmuxd/internal/conversations/opaque_ref_test.go
+++ b/services/gmuxd/internal/conversations/opaque_ref_test.go
@@ -2,6 +2,7 @@ package conversations
 
 import (
 	"errors"
+	"strconv"
 	"testing"
 	"time"
 
@@ -164,6 +165,42 @@ func TestScan_ResumableDescribesOnce(t *testing.T) {
 	}
 	if a.describes != 1 {
 		t.Errorf("DescribeConversation called %d times, want exactly 1", a.describes)
+	}
+}
+
+// TestLookupResumeCommandDoesNotRedescribe is the list-path scaling guard.
+// Conversation sources pay the descriptor I/O once when indexing; arbitrarily
+// many session renders are pure cache reads rather than transcript reads.
+func TestLookupResumeCommandDoesNotRedescribe(t *testing.T) {
+	const sessions = 1000
+	a := &dbAdapter{rows: make(map[string]adapter.ConversationInfo, sessions)}
+	idx := New()
+	for i := range sessions {
+		n := strconv.Itoa(i)
+		ref := "row:" + n
+		a.rows[ref] = adapter.ConversationInfo{ID: "conv-" + n, Slug: "session-" + n, Cwd: "/home/u/proj", MessageCount: 2}
+		idx.Scan(a, ref)
+	}
+	if a.describes != sessions {
+		t.Fatalf("indexing caused %d DescribeConversation calls, want %d", a.describes, sessions)
+	}
+
+	// This loop models conversion of 1000 distinct dead session rows.
+	for i := range sessions {
+		n := strconv.Itoa(i)
+		cmd := idx.LookupResumeCommand("dbtool", "row:"+n)
+		if len(cmd) != 3 || cmd[2] != "conv-"+n {
+			t.Fatalf("LookupResumeCommand(%d) = %v, want cached resume command", i, cmd)
+		}
+		cmd[0] = "mutated"
+	}
+	if a.describes != sessions {
+		t.Fatalf("rendering %d dead sessions caused descriptor I/O: calls=%d, want %d indexing calls", sessions, a.describes, sessions)
+	}
+
+	idx.RemoveByRef("dbtool", "row:7")
+	if cmd := idx.LookupResumeCommand("dbtool", "row:7"); len(cmd) != 0 {
+		t.Fatalf("removed ref retained resume command %v", cmd)
 	}
 }
 

--- a/services/gmuxd/internal/conversations/opaque_ref_test.go
+++ b/services/gmuxd/internal/conversations/opaque_ref_test.go
@@ -123,6 +123,31 @@ func TestScan_DescribeFailureNotIndexed(t *testing.T) {
 	}
 }
 
+func TestScan_DescribeFailurePreservesCachedResumeCommand(t *testing.T) {
+	a := &dbAdapter{rows: map[string]adapter.ConversationInfo{
+		"row:7": {ID: "conv-7", Slug: "seven", Cwd: "/home/u/proj", MessageCount: 2},
+	}}
+	idx := New()
+	if slug := idx.Scan(a, "row:7"); slug != "seven" {
+		t.Fatalf("initial Scan slug = %q, want seven", slug)
+	}
+
+	delete(a.rows, "row:7") // transient descriptor failure on the next upsert
+	if slug := idx.Scan(a, "row:7"); slug != "" {
+		t.Fatalf("failed rescan slug = %q, want empty", slug)
+	}
+	if cmd := idx.LookupResumeCommand("dbtool", "row:7"); len(cmd) != 3 || cmd[2] != "conv-7" {
+		t.Fatalf("failed rescan replaced stale-good command with %v", cmd)
+	}
+
+	if !idx.RemoveByRef("dbtool", "row:7") {
+		t.Fatal("RemoveByRef returned false after transient failure")
+	}
+	if cmd := idx.LookupResumeCommand("dbtool", "row:7"); len(cmd) != 0 {
+		t.Fatalf("RemoveByRef retained resume command %v", cmd)
+	}
+}
+
 // TestScan_NonResumableNotIndexed pins the caller side of the Resumer
 // contract: a conversation that describes cleanly but whose adapter returns
 // no resume command is not indexed and yields no slug. It also pins the


### PR DESCRIPTION
## Summary

- defer the full conversation-history snapshot until after daemon state/socket ownership is settled
- let same-version autostart contenders yield before reading and parsing 2,366 conversations
- add an integration guard whose challenger would block on a FIFO conversation if snapshotting happened before the incumbent precheck

This is stacked on #458, which owns the pre-agreed list-endpoint scope and removes the investigation's primary recurring cost (session rendering reparsing every dead transcript). This PR addresses the separate startup/autostart amplification found by the daemon-wide profile.

## Investigation evidence

The live daemon had 1,430 durable local rows (1,415 exited; 964 non-dismissed) and had performed 2.9 TB of logical reads in about 25 hours. On a copied-state scratch daemon, 30 health renders in 30 seconds consumed 52.95 CPU-seconds; 45.63 seconds (86.2%) was `Converter.session -> ResolveResumeCommandFor -> Pi.DescribeConversation`. #458 fixes that shared converter path.

Independently, `convIndex.Snapshot()` ran before `bootstrapOwnership`'s healthy-incumbent precheck. The live log contained 216 `conversations: indexed` lines, including 4-8 identical lines in the same second: every autostart contender paid the complete history scan before yielding. Scratch startup attributed 3.77 GB of allocations to the initial conversation snapshot.

## Before / after (~950 visible sessions)

Fixture: SQLite online backup of the live state, 1,426 durable rows / about 960 visible rows, 2,366 indexed conversations; isolated state/config/socket/port. A healthy fixed incumbent was running, then a same-version challenger was timed.

| Challenger | Wall | User CPU | System CPU | Conversation scan |
|---|---:|---:|---:|---|
| Before | 7.791 s | 7.875 s | 0.738 s | 2,366 conversations |
| After | 0.041 s | 0.020 s | 0.003 s | none |

That is a 99.5% wall-time reduction for losing autostart contenders. Actual successful daemon startup semantics are unchanged: the snapshot still completes synchronously before the index is consumed or listeners serve requests.

For completeness, with #458 underneath this PR, the same 30-render profile falls from 52.95 to 0.72 CPU-seconds (-98.6%) and logical reads during the run fall to 0.80 MB.

## UI / wire observation

A 20-second read-only live SSE capture contained one initial 826,490-byte sessions snapshot, one 14,728-byte world snapshot, and 43 tiny activity events; it did not show periodic full-world broadcasts. Evidence points to daemon CPU/GC starvation from transcript reparsing, with the large initial frame adding reconnect/browser work. Wire redesign remains out of scope.

## Validation

- `pnpm moon run gmuxd:test gmuxd:lint`
- takeover integration guard verifies a healthy challenger exits without opening a blocking conversation FIFO

Depends on #458.
