### PR TITLE
fix(web): ignore collapsed terminal resize measurements

### DIFF
--- a/apps/gmux-web/src/terminal-fit.test.ts
+++ b/apps/gmux-web/src/terminal-fit.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { terminalGridSize } from './terminal-resize'
+
+describe('terminalGridSize', () => {
+  it('rejects a viewport that cannot fit the minimum grid', () => {
+    expect(terminalGridSize(0, 200, 10, 20)).toBeNull()
+    expect(terminalGridSize(19, 200, 10, 20)).toBeNull()
+    expect(terminalGridSize(200, 19, 10, 20)).toBeNull()
+  })
+
+  it('calculates a usable grid at the minimum boundary', () => {
+    expect(terminalGridSize(20, 20, 10, 20)).toEqual({ cols: 2, rows: 1 })
+  })
+
+  it('supports overlay row rounding', () => {
+    expect(terminalGridSize(85, 45, 10, 20, Math.ceil)).toEqual({ cols: 8, rows: 3 })
+  })
+})

--- a/apps/gmux-web/src/terminal-resize.ts
+++ b/apps/gmux-web/src/terminal-resize.ts
@@ -1,5 +1,22 @@
 import type { TerminalSize } from './terminal-io'
 
+export function terminalGridSize(
+  availW: number,
+  availH: number,
+  cellWidth: number,
+  cellHeight: number,
+  roundRows: (value: number) => number = Math.floor,
+): TerminalSize | null {
+  // A flex child can transiently collapse to zero while the desktop window is
+  // narrowed past the fixed sidebar. Do not turn that unmeasurable state into
+  // a real 2-column PTY resize: wait for the next usable layout measurement.
+  if (availW < cellWidth * 2 || availH < cellHeight) return null
+  return {
+    cols: Math.max(2, Math.floor(availW / cellWidth)),
+    rows: Math.max(1, roundRows(availH / cellHeight)),
+  }
+}
+
 export function sameSize(a: TerminalSize | null, b: TerminalSize | null): boolean {
   return a != null && b != null && a.cols === b.cols && a.rows === b.rows
 }

--- a/apps/gmux-web/src/terminal.tsx
+++ b/apps/gmux-web/src/terminal.tsx
@@ -18,7 +18,7 @@ import { createLongPressRecognizer } from './long-press'
 import { LinkActionSheet } from './link-action-sheet'
 import { TerminalTextSheet } from './terminal-text-sheet'
 import { pressedBufferRow, readTerminalText } from './terminal-text'
-import { decideViewportResize, sameSize } from './terminal-resize'
+import { decideViewportResize, sameSize, terminalGridSize } from './terminal-resize'
 import { wsStateOnClose, wsStateOnOutput, type WsState } from './ws-state'
 import { terminalFindOpen, terminalScrolledUp, terminalScrollToBottom } from './store'
 import { TerminalFindBar } from './terminal-find'
@@ -90,8 +90,15 @@ function measureTerminalFit(
   const availW = shellEl.offsetWidth - padX - reserveWidth
   const availH = shellEl.offsetHeight - padY - overlayBar
 
-  let cols = Math.max(2, Math.floor(availW / dims.css.cell.width))
-  let rows = Math.max(1, (overlayBar > 0 ? Math.ceil : Math.floor)(availH / dims.css.cell.height))
+  const grid = terminalGridSize(
+    availW,
+    availH,
+    dims.css.cell.width,
+    dims.css.cell.height,
+    overlayBar > 0 ? Math.ceil : Math.floor,
+  )
+  if (!grid) return null
+  let { cols, rows } = grid
 
   // Guard against 1px overflow: xterm computes screen width as
   // Math.round(device.cell.width * cols / dpr). Because css.cell.width is


### PR DESCRIPTION
## Summary
- reject terminal fit measurements that cannot contain the minimum grid
- prevent a transient zero-width main panel from resizing a live PTY to two columns
- cover collapsed, boundary, and overlay-rounded dimensions

## Corrected investigation scope
The reported garbled screenshot is a **dead-session ReplayView** (the Resume button proves this), so this PR does not claim to fix that screenshot. I reproduced replay of a captured Claude trust prompt at its recorded geometry and it rendered correctly; without the affected raw scrollback plus recorded dimensions, changing replay/reflow would be speculative and risky for cursor-addressed TUI output.

Pressing `2` worked: Claude’s trust prompt maps option 2 to “No, exit”, explaining why the session became dead. Fresh-profile focus and first-command delivery pass end-to-end in Chromium against an isolated daemon. Linux Playwright WebKit could not launch on this host due an ICU symbol mismatch, so the user’s Safari/app-shell path remains unverified.

The fix retained here is independently valid: the fixed desktop sidebar can transiently consume all available width, and the old fit calculation converted a non-positive width into an announced 2-column live PTY resize. It now waits for a usable measurement.

## Tests
- `pnpm exec vitest run src/terminal-fit.test.ts src/terminal-resize.test.ts`
- `pnpm exec tsc --noEmit`
- targeted Biome lint
- isolated Chromium E2E: fresh navigation focused xterm and the first typed command reached shell scrollback