### PR TITLE
feat(family): processes join the family tree

### DIFF
--- a/apps/gmux-web/src/family.test.ts
+++ b/apps/gmux-web/src/family.test.ts
@@ -7,23 +7,25 @@ const agent = (id: string, parent?: string, extra = {}) => makeSession({
 })
 
 describe('task-family projection', () => {
-  it('uses semantic capability and promotion to distinguish presentation roots', () => {
+  it('groups agent and process children of semantic parents unless promoted', () => {
     const root = agent('root')
     const child = agent('child', 'root')
     const shell = makeSession({ id: 'shell', cwd: '/p', parent_session_id: 'root', adapter: 'shell' })
     const promoted = agent('promoted', 'root', { promoted_to_root: true })
     const sessions = [root, child, shell, promoted]
     expect(isFamilyChild(child, sessions)).toBe(true)
-    expect(isFamilyChild(shell, sessions)).toBe(false)
+    expect(isFamilyChild(shell, sessions)).toBe(true)
     expect(isFamilyChild(promoted, sessions)).toBe(false)
-    expect(familyRoot(child, [root, child])).toBe(root)
-    expect(familyRoot(promoted, [root, promoted])).toBe(promoted)
+    expect(familyRoot(child, sessions)).toBe(root)
+    expect(familyRoot(shell, sessions)).toBe(root)
+    expect(familyRoot(promoted, sessions)).toBe(promoted)
   })
 
   it.each([
     ['semantic child with shell parent', agent('child', 'shell'), makeSession({ id: 'shell', cwd: '/p', adapter: 'shell' })],
-    ['shell child with semantic parent', makeSession({ id: 'child', cwd: '/p', adapter: 'shell', parent_session_id: 'parent' }), agent('parent')],
+    ['shell child with shell parent', makeSession({ id: 'child', cwd: '/p', adapter: 'shell', parent_session_id: 'shell' }), makeSession({ id: 'shell', cwd: '/p', adapter: 'shell' })],
     ['semantic child with missing parent', agent('orphan', 'missing'), undefined],
+    ['process child with missing parent', makeSession({ id: 'orphan-shell', cwd: '/p', adapter: 'shell', parent_session_id: 'missing' }), undefined],
   ])('keeps %s as a visible root', (_name, child, parent) => {
     const sessions = parent ? [parent, child] : [child]
     expect(isFamilyChild(child, sessions)).toBe(false)

--- a/apps/gmux-web/src/family.ts
+++ b/apps/gmux-web/src/family.ts
@@ -1,12 +1,11 @@
 import type { Session } from './types'
 
 /** Resolve one potential task-family edge without trusting the rest of the
- * ancestry. Both endpoints must be semantic agents; unresolved provenance is
- * not a presentation edge. Promotion breaks only the presentation edge without
- * erasing parent_session_id provenance. */
+ * ancestry. The parent must be a semantic agent; its child may be any session.
+ * Unresolved provenance is not a presentation edge. Promotion breaks only the
+ * presentation edge without erasing parent_session_id provenance. */
 function potentialFamilyParent(session: Session, byId: ReadonlyMap<string, Session>): Session | undefined {
-  if (session.semantic_agent !== true
-    || session.promoted_to_root === true
+  if (session.promoted_to_root === true
     || !session.parent_session_id
     || session.parent_session_id === session.id) return undefined
   const parent = byId.get(session.parent_session_id)

--- a/apps/gmux-web/src/store.test.ts
+++ b/apps/gmux-web/src/store.test.ts
@@ -265,15 +265,15 @@ describe('sidebar views share one membership (Projects == Activity)', () => {
   })
   afterEach(() => setAliveOnly(false))
 
-  it('hides agent children from both views and selects their root row', () => {
+  it('hides agent and process children from both views and selects their root row', () => {
     _rawSessions.value = [
       makeSession({ id: 'root', cwd: '/p', adapter: 'pi', slug: 'root', project_slug: 'proj', semantic_agent: true, alive: false, resumable: false }),
       makeSession({ id: 'child', cwd: '/other', adapter: 'pi', slug: 'child', project_slug: 'proj', semantic_agent: true, parent_session_id: 'root' }),
       makeSession({ id: 'helper', cwd: '/p', adapter: 'shell', slug: 'helper', project_slug: 'proj', parent_session_id: 'root' }),
     ]
     urlPath.value = '/proj/pi/child'
-    expect(folderIds()).toEqual(['helper', 'root'])
-    expect(ids(sidebarActivity.value)).toEqual(['helper', 'root'])
+    expect(folderIds()).toEqual(['root'])
+    expect(ids(sidebarActivity.value)).toEqual(['root'])
     expect(familySelectedId.value).toBe('root')
   })
 
@@ -339,7 +339,7 @@ describe('sidebar views share one membership (Projects == Activity)', () => {
     expect(homePartition.value.flatMap(bucket => bucket.sessions.map(s => s.id)).sort()).toEqual(['a', 'b'])
   })
 
-  it('never hides unresolved or non-agent launch-parent edges', () => {
+  it('groups process children only under resolved agent parents', () => {
     _rawSessions.value = [
       makeSession({ id: 'agent-parent', cwd: '/p', adapter: 'pi', project_slug: 'proj', semantic_agent: true }),
       makeSession({ id: 'shell-child', cwd: '/p', adapter: 'shell', project_slug: 'proj', parent_session_id: 'agent-parent' }),
@@ -347,7 +347,7 @@ describe('sidebar views share one membership (Projects == Activity)', () => {
       makeSession({ id: 'agent-under-shell', cwd: '/p', adapter: 'pi', project_slug: 'proj', semantic_agent: true, parent_session_id: 'shell-parent' }),
       makeSession({ id: 'orphan', cwd: '/p', adapter: 'pi', project_slug: 'proj', semantic_agent: true, parent_session_id: 'missing' }),
     ]
-    expect(folderIds()).toEqual(['agent-parent', 'agent-under-shell', 'orphan', 'shell-child', 'shell-parent'])
+    expect(folderIds()).toEqual(['agent-parent', 'agent-under-shell', 'orphan', 'shell-parent'])
     expect(ids(sidebarActivity.value)).toEqual(folderIds())
   })
 

--- a/docs/task-family-ui.md
+++ b/docs/task-family-ui.md
@@ -4,10 +4,10 @@ Task-family presentation uses durable `launch_parent_id` (wire:
 `parent_session_id`) without mutating launch provenance. `promoted_to_root`
 breaks only the presentation edge.
 
-A resolved launch-parent relationship is a family edge only when both the child
-and its direct parent carry `semantic_agent: true`. Missing parents, shells,
-editors, and terminal helpers therefore remain presentation roots and cannot be
-hidden accidentally.
+A resolved launch-parent relationship is a family edge when its direct parent
+carries `semantic_agent: true`; the child may be an agent or any other process
+session. Missing parents and children of shells, editors, or terminal helpers
+remain presentation roots and cannot be hidden accidentally.
 
 The daemon derives `semantic_agent` from the existing
 `adapter.ConversationSource` capability. This is the same semantic distinction

--- a/services/gmuxd/cmd/gmuxd/bootstrap_peering_composed_test.go
+++ b/services/gmuxd/cmd/gmuxd/bootstrap_peering_composed_test.go
@@ -85,6 +85,7 @@ func TestComposedPeerFamilyFactsReachViewerWire(t *testing.T) {
 	spoke := newComposedSpoke(t, []peering.SessionProjection{
 		{ID: "root", Adapter: "pi", Alive: true, SemanticAgent: true},
 		{ID: "child", Adapter: "pi", Alive: true, ParentSessionID: "root", SemanticAgent: true},
+		{ID: "process-child", Adapter: "shell", Alive: true, ParentSessionID: "root"},
 		{ID: "promoted", Adapter: "pi", Alive: true, ParentSessionID: "root", SemanticAgent: true, PromotedToRoot: true},
 		{ID: "cross", Adapter: "pi", Alive: true, ParentSessionID: "external@tower", SemanticAgent: true},
 	})
@@ -99,7 +100,7 @@ func TestComposedPeerFamilyFactsReachViewerWire(t *testing.T) {
 	}
 	eventually(t, func() bool {
 		rows := adapter.PeerSessions()
-		if len(rows) != 4 {
+		if len(rows) != 5 {
 			return false
 		}
 		byID = make(map[string]struct {
@@ -119,6 +120,9 @@ func TestComposedPeerFamilyFactsReachViewerWire(t *testing.T) {
 	}
 	if got := byID["child@box"]; !got.semantic || got.parent != "root@box" || got.promoted {
 		t.Fatalf("child viewer wire facts = %#v", got)
+	}
+	if got := byID["process-child@box"]; got.semantic || got.parent != "root@box" || got.promoted {
+		t.Fatalf("process child viewer wire facts = %#v", got)
 	}
 	if got := byID["promoted@box"]; !got.semantic || got.parent != "root@box" || !got.promoted {
 		t.Fatalf("promoted viewer wire facts = %#v", got)

--- a/services/gmuxd/cmd/gmuxd/notify_central.go
+++ b/services/gmuxd/cmd/gmuxd/notify_central.go
@@ -158,7 +158,7 @@ func (r *centralNotifyRouter) handleOutcome(o sessioncoord.Outcome) {
 		delete(r.suppressedInactive, id)
 	} else if transitionedInactive {
 		delete(r.suppressedInactive, id)
-		if cur.SemanticAgent && !cur.Promoted && cur.ParentID != "" {
+		if !cur.Promoted && cur.ParentID != "" {
 			parent, parentExists := r.prevState[cur.ParentID]
 			r.suppressedInactive[id] = parentExists && parent.SemanticAgent && parent.Active
 		}

--- a/services/gmuxd/cmd/gmuxd/notify_central_parent_test.go
+++ b/services/gmuxd/cmd/gmuxd/notify_central_parent_test.go
@@ -115,21 +115,23 @@ func TestCentralNotifyDirectParentSuppression(t *testing.T) {
 	}
 }
 
-func TestCentralNotifyNonAgentLaunchesRemainRoots(t *testing.T) {
+func TestCentralNotifyProcessChildUsesAgentParentSuppression(t *testing.T) {
 	r := newParentNotifyTestRouter(t)
 	r.handleOutcome(upsertOutcome("parent", notifyRow("pi", true, "", false)))
 	r.handleOutcome(upsertOutcome("shell-child", notifyRow("shell", true, "parent", false)))
 	r.handleOutcome(upsertOutcome("shell-child", notifyRow("shell", false, "parent", false)))
-	if !hasPendingNotification(r, "shell-child") {
-		t.Fatal("a shell with launch provenance must retain root notification behavior")
+	if hasPendingNotification(r, "shell-child") {
+		t.Fatal("a process child must inherit its active agent parent's notification suppression")
 	}
+}
 
-	r = newParentNotifyTestRouter(t)
+func TestCentralNotifyNonAgentParentRemainsRootBoundary(t *testing.T) {
+	r := newParentNotifyTestRouter(t)
 	r.handleOutcome(upsertOutcome("shell-parent", notifyRow("shell", true, "", false)))
-	r.handleOutcome(upsertOutcome("agent-child", notifyRow("pi", true, "shell-parent", false)))
-	r.handleOutcome(upsertOutcome("agent-child", notifyRow("pi", false, "shell-parent", false)))
-	if !hasPendingNotification(r, "agent-child") {
-		t.Fatal("a non-agent launch parent must not become an agent management boundary")
+	r.handleOutcome(upsertOutcome("shell-child", notifyRow("shell", true, "shell-parent", false)))
+	r.handleOutcome(upsertOutcome("shell-child", notifyRow("shell", false, "shell-parent", false)))
+	if !hasPendingNotification(r, "shell-child") {
+		t.Fatal("a non-agent launch parent must not become a family management boundary")
 	}
 }
 


### PR DESCRIPTION
## Summary

- treat any unpromoted session with a resolved direct agent parent as a family child
- hide process children from root-level Projects, Activity, and Home projections while keeping them in the existing family drawer/tree
- apply the existing committed-transition notification suppression and cancellation semantics to process children
- preserve process-child family facts across peer projection and update the family capability documentation

## Before / after

**Before:** A shell or other process launched inside an agent retained `parent_session_id`, but appeared as a separate root in Projects/Activity/Home and could emit its own completion notification while the parent agent was active.

**After:** The process appears under its direct agent parent using the existing family UI and is omitted from root lists. Its completion/unread attention is suppressed when the direct agent parent is active at the child's committed inactive transition. Missing parents, non-agent parents, cycles, and promoted sessions continue to fail open as visible roots.

## Provenance

The generic process launch path already calls `inheritLaunchParent` before adapter resolution and stamps `GMUX_SESSION_ID` into `runDirectives.ParentSessionID`; that value is written to runner session metadata. This covers both `gmux -- <cmd>` and `gmux run` fresh nested launches without changing resume/restart provenance.

## Verification

- `pnpm moon run :test :lint`
- `go test -race ./services/gmuxd/cmd/gmuxd -run 'TestCentralNotify' -count=1`
