### PR TITLE
feat(web): family drawer noise reduction and status roll-up

### DIFF
--- a/apps/gmux-web/src/family-drawer-model.test.ts
+++ b/apps/gmux-web/src/family-drawer-model.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest'
+import { splitGroup, syncDrawer, toggleDrawerGroup, groupKey } from './family-drawer-model'
+import type { Session } from './types'
+import { makeSession } from './test-helpers'
+
+const at = (minute: number) => `2026-08-04T10:${String(minute).padStart(2, '0')}:00Z`
+const root = makeSession({
+  id: 'root', cwd: '/p', title: 'root', semantic_agent: true,
+  created_at: at(0), last_output_at: at(1),
+})
+const child = (id: string, extra: Partial<Session> = {}) => makeSession({
+  id, cwd: '/p', title: id, parent_session_id: 'root', semantic_agent: true,
+  created_at: at(0), last_output_at: at(1), ...extra,
+})
+const procChild = (id: string, extra: Partial<Session> = {}) => makeSession({
+  id, cwd: '/p', title: id, parent_session_id: 'root', adapter: 'shell',
+  created_at: at(0), last_output_at: at(1), ...extra,
+})
+
+/** The root-selected drawer has one top-level group containing the root
+ * node; its children groups are what the drawer body renders. */
+function childGroups(model: ReturnType<typeof syncDrawer>) {
+  return model.projection.groups[0].nodes[0].groups
+}
+
+describe('drawer model: frozen ordering with explicit refresh', () => {
+  it('ignores ordinary live updates but re-projects on group toggle', () => {
+    const mover = child('mover')
+    const before = [root, mover, child('idle-friend')]
+    const model = syncDrawer(null, root, before)
+    expect(childGroups(model).map(g => g.bucket)).toEqual(['idle'])
+
+    // Live update: `mover` starts working. An ordinary re-render syncs
+    // against the new snapshot and MUST return the same frozen model —
+    // no auto-reorder under the cursor.
+    const after = [root, { ...mover, status: { active: true } }, child('idle-friend')]
+    const synced = syncDrawer(model, root, after)
+    expect(synced).toBe(model)
+    expect(childGroups(synced).map(g => g.bucket)).toEqual(['idle'])
+
+    // Explicit user action: toggling any group re-projects from current
+    // facts — `mover` now leads a working group.
+    const toggled = toggleDrawerGroup(synced, root, after, groupKey('root', 'idle'))
+    expect(toggled).not.toBe(synced)
+    expect(childGroups(toggled).map(g => g.bucket)).toEqual(['working', 'idle'])
+    expect(childGroups(toggled)[0].nodes.map(n => n.session.id)).toEqual(['mover'])
+  })
+
+  it('tracks expansion per (parent, bucket) across toggles and selection changes', () => {
+    const snapshot = [root, ...Array.from({ length: 5 }, (_, i) => child(`dead-${i}`, { alive: false }))]
+    let model = syncDrawer(null, root, snapshot)
+    const key = groupKey('root', 'finished')
+    model = toggleDrawerGroup(model, root, snapshot, key)
+    expect(model.expanded.has(key)).toBe(true)
+    // Selecting another family member re-projects but keeps expansion.
+    const other = snapshot[1]
+    const reselected = syncDrawer(model, other, snapshot)
+    expect(reselected).not.toBe(model)
+    expect(reselected.expanded.has(key)).toBe(true)
+    // Toggling again collapses back (two-state, no increments).
+    const collapsed = toggleDrawerGroup(reselected, other, snapshot, key)
+    expect(collapsed.expanded.has(key)).toBe(false)
+  })
+})
+
+describe('drawer model: rendered caps and summary rows', () => {
+  it('applies the 20/10/3 caps to what is actually shown', () => {
+    const snapshot = [
+      root,
+      ...Array.from({ length: 25 }, (_, i) => child(`work-${i}`, { status: { active: true } })),
+      ...Array.from({ length: 14 }, (_, i) => child(`idle-${i}`)),
+      ...Array.from({ length: 10 }, (_, i) => child(`dead-${i}`, { alive: false })),
+    ]
+    const model = syncDrawer(null, root, snapshot)
+    const groups = childGroups(model)
+    expect(groups.map(g => g.bucket)).toEqual(['working', 'idle', 'finished'])
+    const splits = groups.map(g => splitGroup(g, 'root', model.expanded))
+    expect(splits.map(s => s.shown.length)).toEqual([20, 10, 3])
+    expect(splits.map(s => s.summary?.label)).toEqual(['+5 more working', '+4 idle', '+7 finished'])
+  })
+
+  it('never caps attention', () => {
+    const snapshot = [root, ...Array.from({ length: 30 }, (_, i) => child(`u-${i}`, { unread: true }))]
+    const model = syncDrawer(null, root, snapshot)
+    const [attention] = childGroups(model)
+    expect(attention.bucket).toBe('attention')
+    const split = splitGroup(attention, 'root', model.expanded)
+    expect(split.shown.length).toBe(30)
+    expect(split.summary).toBeNull()
+  })
+
+  it('shows everything plus "show fewer" once expanded', () => {
+    const snapshot = [root, ...Array.from({ length: 9 }, (_, i) => child(`dead-${i}`, { alive: false }))]
+    let model = syncDrawer(null, root, snapshot)
+    const key = groupKey('root', 'finished')
+    model = toggleDrawerGroup(model, root, snapshot, key)
+    const split = splitGroup(childGroups(model)[0], 'root', model.expanded)
+    expect(split.shown.length).toBe(9)
+    expect(split.summary).toEqual({ key, expanded: true, label: 'show fewer' })
+  })
+
+  it('words mixed hidden agents and processes as two facts', () => {
+    // Agents sort before processes within a bucket, so the 3 visible
+    // finished rows are agents; hidden = 4 agents + 2 processes.
+    const snapshot = [
+      root,
+      ...Array.from({ length: 7 }, (_, i) => child(`dead-${i}`, { alive: false })),
+      ...Array.from({ length: 2 }, (_, i) => procChild(`proc-${i}`, { alive: false })),
+    ]
+    const model = syncDrawer(null, root, snapshot)
+    const split = splitGroup(childGroups(model)[0], 'root', model.expanded)
+    expect(split.shown.every(n => !n.process)).toBe(true)
+    expect(split.summary?.label).toBe('+4 finished · 2 processes done')
+  })
+
+  it('gives process-only remainders their own noun', () => {
+    const done = [root, ...Array.from({ length: 5 }, (_, i) => procChild(`proc-${i}`, { alive: false }))]
+    const doneModel = syncDrawer(null, root, done)
+    expect(splitGroup(childGroups(doneModel)[0], 'root', doneModel.expanded).summary?.label)
+      .toBe('+2 processes done')
+
+    const running = [root, ...Array.from({ length: 12 }, (_, i) => procChild(`proc-${i}`))]
+    const runningModel = syncDrawer(null, root, running)
+    // Live shells report no agent status; they land in idle (cap 10).
+    expect(splitGroup(childGroups(runningModel)[0], 'root', runningModel.expanded).summary?.label)
+      .toBe('+2 processes')
+  })
+})

--- a/apps/gmux-web/src/family-drawer-model.ts
+++ b/apps/gmux-web/src/family-drawer-model.ts
@@ -1,0 +1,108 @@
+import {
+  bucketedFamily, familyNavigation, FAMILY_GROUP_CAPS,
+  type BucketedFamilyProjection, type FamilyBucket, type FamilyBucketGroup,
+  type FamilyBucketNode, type FamilyNavigation,
+} from './family'
+import type { Session } from './types'
+
+/** The drawer's frozen state: one projection held for as long as the same
+ * session stays selected, so live status updates repaint rows in place but
+ * never re-sort the list while the user is reading it. Expansion state is
+ * keyed per (parent, bucket) and survives selection changes while the
+ * drawer stays open; the component unmount (drawer close) discards it. */
+export interface DrawerModel {
+  selectedId: string
+  projection: BucketedFamilyProjection
+  navigation: FamilyNavigation
+  expanded: ReadonlySet<string>
+}
+
+function projectDrawer(
+  selected: Session,
+  snapshot: readonly Session[],
+  expanded: ReadonlySet<string>,
+): DrawerModel {
+  return {
+    selectedId: selected.id,
+    projection: bucketedFamily(selected, snapshot),
+    navigation: familyNavigation(selected, snapshot),
+    expanded,
+  }
+}
+
+/** Freeze rule: while the selection is unchanged, newer snapshots must NOT
+ * re-project (rows would reorder under the cursor). A selection change is
+ * an explicit user action and re-projects, carrying expansion state over. */
+export function syncDrawer(
+  model: DrawerModel | null,
+  selected: Session,
+  snapshot: readonly Session[],
+): DrawerModel {
+  if (model && model.selectedId === selected.id) return model
+  return projectDrawer(selected, snapshot, model?.expanded ?? new Set())
+}
+
+/** Expansion/collapse is the other explicit user action: flip the one
+ * (parent, bucket) key and re-project from *current* session facts, so the
+ * revealed (or re-capped) group reflects reality instead of the stale
+ * membership captured when the drawer opened. */
+export function toggleDrawerGroup(
+  model: DrawerModel,
+  selected: Session,
+  snapshot: readonly Session[],
+  key: string,
+): DrawerModel {
+  const expanded = new Set(model.expanded)
+  if (expanded.has(key)) expanded.delete(key)
+  else expanded.add(key)
+  return projectDrawer(selected, snapshot, expanded)
+}
+
+export function groupKey(parentId: string, bucket: FamilyBucket): string {
+  return `${parentId}:${bucket}`
+}
+
+function processNoun(count: number): string {
+  return count === 1 ? 'process' : 'processes'
+}
+
+/** Wording for a collapsed group's summary row. Agents get the bucket noun,
+ * processes their own, so `+547 finished · 12 processes done` reads as two
+ * facts instead of one blurred count. */
+function summaryLabel(bucket: FamilyBucket, agents: number, processes: number): string {
+  const parts: string[] = []
+  if (agents > 0) {
+    parts.push(bucket === 'working' ? `+${agents} more working` : `+${agents} ${bucket}`)
+  }
+  if (processes > 0) {
+    parts.push(`${agents > 0 ? '' : '+'}${processes} ${processNoun(processes)}${bucket === 'finished' ? ' done' : ''}`)
+  }
+  return parts.join(' · ')
+}
+
+export interface GroupSplit {
+  shown: FamilyBucketNode[]
+  /** Present iff the group exceeds its cap: the two-state summary row. */
+  summary: { key: string; expanded: boolean; label: string } | null
+}
+
+/** Apply the per-bucket cap to one group: what the drawer actually renders.
+ * Attention is never capped (`Infinity`); other groups show their first
+ * `cap` rows plus a `+N …` summary, or everything plus `show fewer`. */
+export function splitGroup(
+  group: FamilyBucketGroup,
+  parentId: string,
+  expanded: ReadonlySet<string>,
+): GroupSplit {
+  const cap = FAMILY_GROUP_CAPS[group.bucket]
+  if (group.nodes.length <= cap) return { shown: group.nodes, summary: null }
+  const key = groupKey(parentId, group.bucket)
+  const isExpanded = expanded.has(key)
+  const shown = isExpanded ? group.nodes : group.nodes.slice(0, cap)
+  const hidden = group.nodes.slice(shown.length)
+  const hiddenAgents = hidden.filter(node => !node.process).length
+  const label = isExpanded
+    ? 'show fewer'
+    : summaryLabel(group.bucket, hiddenAgents, hidden.length - hiddenAgents)
+  return { shown, summary: { key, expanded: isExpanded, label } }
+}

--- a/apps/gmux-web/src/family-drawer.tsx
+++ b/apps/gmux-web/src/family-drawer.tsx
@@ -1,7 +1,11 @@
-import { useEffect, useRef } from 'preact/hooks'
-import { familyNavigation, projectFamily, type FamilyNode } from './family'
+import { useEffect, useRef, useState } from 'preact/hooks'
+import {
+  bucketedFamily, familyIndex, familyNavigation, FAMILY_GROUP_CAPS,
+  type BucketedFamilyProjection, type FamilyBucket, type FamilyBucketGroup,
+  type FamilyBucketNode, type FamilyNavigation,
+} from './family'
 import { viewToPath } from './routing'
-import { projects, sessions, tabHref } from './store'
+import { activityMap, projects, sessions, sessionDotState, tabHref } from './store'
 import type { Session } from './types'
 
 function hrefFor(session: Session): string | undefined {
@@ -9,32 +13,139 @@ function hrefFor(session: Session): string | undefined {
   return path ? tabHref(path) : undefined
 }
 
-function FamilyRow({ node, selectedId, depth }: {
-  node: FamilyNode
+/** Wording for a collapsed group's summary row. Agents get the bucket noun,
+ * processes their own, so `+547 finished · 12 processes done` reads as two
+ * facts instead of one blurred count. */
+function processNoun(count: number): string {
+  return count === 1 ? 'process' : 'processes'
+}
+
+function summaryLabel(bucket: FamilyBucket, agents: number, processes: number): string {
+  const parts: string[] = []
+  if (agents > 0) {
+    parts.push(bucket === 'working' ? `+${agents} more working` : `+${agents} ${bucket}`)
+  }
+  if (processes > 0) {
+    parts.push(`${agents > 0 ? '' : '+'}${processes} ${processNoun(processes)}${bucket === 'finished' ? ' done' : ''}`)
+  }
+  return parts.join(' · ')
+}
+
+function FamilyRow({ node, selectedId, depth, expanded, onToggle }: {
+  node: FamilyBucketNode
   selectedId: string
   depth: number
+  expanded: ReadonlySet<string>
+  onToggle: (key: string) => void
 }) {
-  const session = node.session
+  // Structure (order, buckets, membership) is frozen while the drawer is
+  // open; each row still reads the live session so dots and titles update
+  // in place without reshuffling the list under the cursor.
+  const session = familyIndex(sessions.value).byId.get(node.session.id) ?? node.session
   const href = hrefFor(session)
+  // Dead rows carry no dot: their group position already says "finished",
+  // and a wall of never-viewed dead children must not glow "unread".
+  const rawDot = session.alive ? sessionDotState(session, activityMap.value) : 'none'
+  const dot = session.id === selectedId && (rawDot === 'error' || rawDot === 'unread') ? 'none' : rawDot
   return (
     <li>
       <a
-        class={`family-row${session.id === selectedId ? ' selected' : ''}${session.alive ? '' : ' inactive'}`}
+        class={`family-row${session.id === selectedId ? ' selected' : ''}${session.alive ? '' : ' inactive'}${node.process ? ' process' : ''}`}
         style={{ paddingLeft: `${12 + depth * 18}px` }}
         href={href}
         aria-current={session.id === selectedId ? 'page' : undefined}
         tabIndex={session.id === selectedId ? 0 : undefined}
       >
-        <span class={`family-row-dot${session.status?.active ? ' active' : ''}`} aria-hidden="true" />
+        {node.process
+          ? <span class={`family-row-proc${session.alive && session.status?.active ? ' working' : ''}`} aria-hidden="true">$</span>
+          : <span class={`session-dot-indicator ${dot}`} aria-hidden="true" />}
         <span class="family-row-title">{session.title}</span>
         <span class="family-row-kind">{session.adapter}</span>
       </a>
-      {node.children.length > 0 && (
-        <ul>{node.children.map(child => (
-          <FamilyRow key={child.session.id} node={child} selectedId={selectedId} depth={depth + 1} />
-        ))}</ul>
+      {node.groups.length > 0 && (
+        <ul>
+          {node.groups.map(group => (
+            <GroupRows
+              key={group.bucket}
+              group={group}
+              parentId={node.session.id}
+              selectedId={selectedId}
+              depth={depth + 1}
+              expanded={expanded}
+              onToggle={onToggle}
+            />
+          ))}
+        </ul>
       )}
     </li>
+  )
+}
+
+/** One bucket group inside a children list: capped rows plus a two-state
+ * summary row (`+N finished` / `show fewer`) keyed per (parent, bucket). */
+function GroupRows({ group, parentId, selectedId, depth, expanded, onToggle }: {
+  group: FamilyBucketGroup
+  parentId: string
+  selectedId: string
+  depth: number
+  expanded: ReadonlySet<string>
+  onToggle: (key: string) => void
+}) {
+  const key = `${parentId}:${group.bucket}`
+  const isExpanded = expanded.has(key)
+  const cap = FAMILY_GROUP_CAPS[group.bucket]
+  const shown = isExpanded ? group.nodes : group.nodes.slice(0, cap)
+  const hidden = group.nodes.slice(shown.length)
+  const collapsible = group.nodes.length > cap
+  const hiddenAgents = hidden.filter(n => !n.process).length
+  const hiddenProcesses = hidden.length - hiddenAgents
+  return (
+    <>
+      {shown.map(node => (
+        <FamilyRow
+          key={node.session.id}
+          node={node}
+          selectedId={selectedId}
+          depth={depth}
+          expanded={expanded}
+          onToggle={onToggle}
+        />
+      ))}
+      {collapsible && (
+        <li>
+          <button
+            type="button"
+            class="family-more"
+            style={{ paddingLeft: `${12 + depth * 18}px` }}
+            aria-expanded={isExpanded}
+            onClick={() => onToggle(key)}
+          >
+            <span class="family-more-chevron" aria-hidden="true">{isExpanded ? '▾' : '▸'}</span>
+            {isExpanded ? 'show fewer' : summaryLabel(group.bucket, hiddenAgents, hiddenProcesses)}
+          </button>
+        </li>
+      )}
+    </>
+  )
+}
+
+function CountsLine({ counts }: { counts: BucketedFamilyProjection['counts'] }) {
+  const segments: { text: string; cls?: string }[] = []
+  if (counts.attention > 0) segments.push({ text: `${counts.attention} need attention`, cls: 'attention' })
+  if (counts.working > 0) segments.push({ text: `${counts.working} working` })
+  if (counts.idle > 0) segments.push({ text: `${counts.idle} idle` })
+  if (counts.finished > 0) segments.push({ text: `${counts.finished} finished` })
+  if (counts.processes > 0) segments.push({ text: `${counts.processes} ${processNoun(counts.processes)}`, cls: 'processes' })
+  if (segments.length === 0) return null
+  return (
+    <div class="family-counts">
+      {segments.map((segment, index) => (
+        <span key={segment.text} class={segment.cls ? `family-count-${segment.cls}` : undefined}>
+          {index > 0 && <span class="family-count-sep" aria-hidden="true"> · </span>}
+          {segment.text}
+        </span>
+      ))}
+    </div>
   )
 }
 
@@ -44,10 +155,32 @@ export function FamilyDrawer({ selected, onClose, triggerRef }: {
   triggerRef: { current: HTMLButtonElement | null }
 }) {
   const drawerRef = useRef<HTMLDivElement>(null)
-  const projection = projectFamily(selected, sessions.value)
-  // Promotion intentionally defers provenance: promoted sessions present as
-  // roots even though parent_session_id remains immutable on the wire.
-  const navigation = familyNavigation(selected, sessions.value)
+  // Two-state expansion per (parent, bucket); resets when the drawer
+  // closes because this component unmounts with it.
+  const [expanded, setExpanded] = useState<ReadonlySet<string>>(new Set())
+  const toggle = (key: string) => setExpanded(prev => {
+    const next = new Set(prev)
+    if (next.has(key)) next.delete(key)
+    else next.add(key)
+    return next
+  })
+
+  // Freeze the projection (ordering, bucketing, membership) for as long as
+  // the same session stays selected: live status updates repaint rows in
+  // place but never re-sort the list while the user is reading it. `peek`
+  // avoids subscribing the projection itself; rows subscribe for repaints.
+  // Promotion intentionally defers provenance: promoted sessions present
+  // as roots even though parent_session_id remains immutable on the wire.
+  const frozenRef = useRef<{ selectedId: string; projection: BucketedFamilyProjection; navigation: FamilyNavigation } | null>(null)
+  if (frozenRef.current?.selectedId !== selected.id) {
+    const snapshot = sessions.peek()
+    frozenRef.current = {
+      selectedId: selected.id,
+      projection: bucketedFamily(selected, snapshot),
+      navigation: familyNavigation(selected, snapshot),
+    }
+  }
+  const { projection, navigation } = frozenRef.current
 
   useEffect(() => {
     const drawer = drawerRef.current
@@ -91,33 +224,46 @@ export function FamilyDrawer({ selected, onClose, triggerRef }: {
   }
 
   return (
-    <div id="agent-family-drawer" class="family-drawer" role="dialog" aria-modal="true" aria-label="Agent family" tabIndex={-1} ref={drawerRef}>
-      <div class="family-drawer-heading">
-        <strong>Agent family</strong>
-        <div class="family-drawer-nav">
-          {navigation.parent && navButton('Parent', navigation.parent)}
-          {navigation.root && navButton('Root', navigation.root)}
-          <button class="family-drawer-close" type="button" aria-label="Close agent family" onClick={() => {
-            onClose()
-            triggerRef.current?.focus()
-          }}>×</button>
+    <div id="agent-family-drawer" class="family-drawer" role="dialog" aria-modal="true" aria-label="Agents" tabIndex={-1} ref={drawerRef}>
+      <div class="family-drawer-head">
+        <div class="family-drawer-heading">
+          <strong>Agents</strong>
+          <div class="family-drawer-nav">
+            {navigation.parent && navButton('Parent', navigation.parent)}
+            {navigation.root && navButton('Root', navigation.root)}
+            <button class="family-drawer-close" type="button" aria-label="Close agents" onClick={() => {
+              onClose()
+              triggerRef.current?.focus()
+            }}>×</button>
+          </div>
         </div>
+        <CountsLine counts={projection.counts} />
+        {projection.ancestors.length > 0 && (
+          <ol class="family-spine" aria-label="Ancestors">
+            {projection.ancestors.map((ancestor, index) => (
+              <li key={ancestor.id}>
+                <a href={hrefFor(ancestor)}>{ancestor.title}</a>
+                {index < projection.ancestors.length - 1 && <span aria-hidden="true">›</span>}
+              </li>
+            ))}
+          </ol>
+        )}
       </div>
-      {projection.ancestors.length > 0 && (
-        <ol class="family-spine" aria-label="Ancestors">
-          {projection.ancestors.map((ancestor, index) => (
-            <li key={ancestor.id}>
-              <a href={hrefFor(ancestor)}>{ancestor.title}</a>
-              {index < projection.ancestors.length - 1 && <span aria-hidden="true">›</span>}
-            </li>
+      <div class="family-drawer-scroll">
+        <ul class="family-tree">
+          {projection.groups.map(group => (
+            <GroupRows
+              key={group.bucket}
+              group={group}
+              parentId={projection.ancestors[projection.ancestors.length - 1]?.id ?? ''}
+              selectedId={selected.id}
+              depth={0}
+              expanded={expanded}
+              onToggle={toggle}
+            />
           ))}
-        </ol>
-      )}
-      <ul class="family-tree">
-        {projection.siblingTrees.map(node => (
-          <FamilyRow key={node.session.id} node={node} selectedId={selected.id} depth={0} />
-        ))}
-      </ul>
+        </ul>
+      </div>
     </div>
   )
 }

--- a/apps/gmux-web/src/family-drawer.tsx
+++ b/apps/gmux-web/src/family-drawer.tsx
@@ -1,9 +1,6 @@
-import { useEffect, useRef, useState } from 'preact/hooks'
-import {
-  bucketedFamily, familyIndex, familyNavigation, FAMILY_GROUP_CAPS,
-  type BucketedFamilyProjection, type FamilyBucket, type FamilyBucketGroup,
-  type FamilyBucketNode, type FamilyNavigation,
-} from './family'
+import { useEffect, useReducer, useRef } from 'preact/hooks'
+import { familyIndex, type FamilyBucketGroup, type FamilyBucketNode } from './family'
+import { splitGroup, syncDrawer, toggleDrawerGroup, type DrawerModel } from './family-drawer-model'
 import { viewToPath } from './routing'
 import { activityMap, projects, sessions, sessionDotState, tabHref } from './store'
 import type { Session } from './types'
@@ -11,24 +8,6 @@ import type { Session } from './types'
 function hrefFor(session: Session): string | undefined {
   const path = viewToPath({ kind: 'session', sessionId: session.id }, projects.value, sessions.value)
   return path ? tabHref(path) : undefined
-}
-
-/** Wording for a collapsed group's summary row. Agents get the bucket noun,
- * processes their own, so `+547 finished · 12 processes done` reads as two
- * facts instead of one blurred count. */
-function processNoun(count: number): string {
-  return count === 1 ? 'process' : 'processes'
-}
-
-function summaryLabel(bucket: FamilyBucket, agents: number, processes: number): string {
-  const parts: string[] = []
-  if (agents > 0) {
-    parts.push(bucket === 'working' ? `+${agents} more working` : `+${agents} ${bucket}`)
-  }
-  if (processes > 0) {
-    parts.push(`${agents > 0 ? '' : '+'}${processes} ${processNoun(processes)}${bucket === 'finished' ? ' done' : ''}`)
-  }
-  return parts.join(' · ')
 }
 
 function FamilyRow({ node, selectedId, depth, expanded, onToggle }: {
@@ -43,9 +22,7 @@ function FamilyRow({ node, selectedId, depth, expanded, onToggle }: {
   // in place without reshuffling the list under the cursor.
   const session = familyIndex(sessions.value).byId.get(node.session.id) ?? node.session
   const href = hrefFor(session)
-  // Dead rows carry no dot: their group position already says "finished",
-  // and a wall of never-viewed dead children must not glow "unread".
-  const rawDot = session.alive ? sessionDotState(session, activityMap.value) : 'none'
+  const rawDot = sessionDotState(session, activityMap.value)
   const dot = session.id === selectedId && (rawDot === 'error' || rawDot === 'unread') ? 'none' : rawDot
   return (
     <li>
@@ -91,14 +68,7 @@ function GroupRows({ group, parentId, selectedId, depth, expanded, onToggle }: {
   expanded: ReadonlySet<string>
   onToggle: (key: string) => void
 }) {
-  const key = `${parentId}:${group.bucket}`
-  const isExpanded = expanded.has(key)
-  const cap = FAMILY_GROUP_CAPS[group.bucket]
-  const shown = isExpanded ? group.nodes : group.nodes.slice(0, cap)
-  const hidden = group.nodes.slice(shown.length)
-  const collapsible = group.nodes.length > cap
-  const hiddenAgents = hidden.filter(n => !n.process).length
-  const hiddenProcesses = hidden.length - hiddenAgents
+  const { shown, summary } = splitGroup(group, parentId, expanded)
   return (
     <>
       {shown.map(node => (
@@ -111,17 +81,17 @@ function GroupRows({ group, parentId, selectedId, depth, expanded, onToggle }: {
           onToggle={onToggle}
         />
       ))}
-      {collapsible && (
+      {summary && (
         <li>
           <button
             type="button"
             class="family-more"
             style={{ paddingLeft: `${12 + depth * 18}px` }}
-            aria-expanded={isExpanded}
-            onClick={() => onToggle(key)}
+            aria-expanded={summary.expanded}
+            onClick={() => onToggle(summary.key)}
           >
-            <span class="family-more-chevron" aria-hidden="true">{isExpanded ? '▾' : '▸'}</span>
-            {isExpanded ? 'show fewer' : summaryLabel(group.bucket, hiddenAgents, hiddenProcesses)}
+            <span class="family-more-chevron" aria-hidden="true">{summary.expanded ? '▾' : '▸'}</span>
+            {summary.label}
           </button>
         </li>
       )}
@@ -129,13 +99,13 @@ function GroupRows({ group, parentId, selectedId, depth, expanded, onToggle }: {
   )
 }
 
-function CountsLine({ counts }: { counts: BucketedFamilyProjection['counts'] }) {
+function CountsLine({ counts }: { counts: DrawerModel['projection']['counts'] }) {
   const segments: { text: string; cls?: string }[] = []
   if (counts.attention > 0) segments.push({ text: `${counts.attention} need attention`, cls: 'attention' })
   if (counts.working > 0) segments.push({ text: `${counts.working} working` })
   if (counts.idle > 0) segments.push({ text: `${counts.idle} idle` })
   if (counts.finished > 0) segments.push({ text: `${counts.finished} finished` })
-  if (counts.processes > 0) segments.push({ text: `${counts.processes} ${processNoun(counts.processes)}`, cls: 'processes' })
+  if (counts.processes > 0) segments.push({ text: `${counts.processes} ${counts.processes === 1 ? 'process' : 'processes'}`, cls: 'processes' })
   if (segments.length === 0) return null
   return (
     <div class="family-counts">
@@ -155,32 +125,23 @@ export function FamilyDrawer({ selected, onClose, triggerRef }: {
   triggerRef: { current: HTMLButtonElement | null }
 }) {
   const drawerRef = useRef<HTMLDivElement>(null)
-  // Two-state expansion per (parent, bucket); resets when the drawer
-  // closes because this component unmounts with it.
-  const [expanded, setExpanded] = useState<ReadonlySet<string>>(new Set())
-  const toggle = (key: string) => setExpanded(prev => {
-    const next = new Set(prev)
-    if (next.has(key)) next.delete(key)
-    else next.add(key)
-    return next
-  })
+  const [, forceRender] = useReducer((n: number) => n + 1, 0)
 
-  // Freeze the projection (ordering, bucketing, membership) for as long as
-  // the same session stays selected: live status updates repaint rows in
-  // place but never re-sort the list while the user is reading it. `peek`
-  // avoids subscribing the projection itself; rows subscribe for repaints.
+  // All freeze/expansion behavior lives in the pure drawer model (see
+  // family-drawer-model.ts): ordinary live updates keep the projection
+  // frozen; selection changes and group toggles re-project from current
+  // facts. `peek` keeps the projection itself unsubscribed; rows read
+  // sessions.value and repaint live. Expansion resets when the drawer
+  // closes because this component unmounts with it.
   // Promotion intentionally defers provenance: promoted sessions present
   // as roots even though parent_session_id remains immutable on the wire.
-  const frozenRef = useRef<{ selectedId: string; projection: BucketedFamilyProjection; navigation: FamilyNavigation } | null>(null)
-  if (frozenRef.current?.selectedId !== selected.id) {
-    const snapshot = sessions.peek()
-    frozenRef.current = {
-      selectedId: selected.id,
-      projection: bucketedFamily(selected, snapshot),
-      navigation: familyNavigation(selected, snapshot),
-    }
+  const modelRef = useRef<DrawerModel | null>(null)
+  modelRef.current = syncDrawer(modelRef.current, selected, sessions.peek())
+  const model = modelRef.current
+  const toggle = (key: string) => {
+    modelRef.current = toggleDrawerGroup(modelRef.current!, selected, sessions.peek(), key)
+    forceRender(0)
   }
-  const { projection, navigation } = frozenRef.current
 
   useEffect(() => {
     const drawer = drawerRef.current
@@ -223,6 +184,7 @@ export function FamilyDrawer({ selected, onClose, triggerRef }: {
     return href ? <a class="family-nav-button" href={href}>{label}</a> : null
   }
 
+  const { projection, navigation } = model
   return (
     <div id="agent-family-drawer" class="family-drawer" role="dialog" aria-modal="true" aria-label="Agents" tabIndex={-1} ref={drawerRef}>
       <div class="family-drawer-head">
@@ -258,7 +220,7 @@ export function FamilyDrawer({ selected, onClose, triggerRef }: {
               parentId={projection.ancestors[projection.ancestors.length - 1]?.id ?? ''}
               selectedId={selected.id}
               depth={0}
-              expanded={expanded}
+              expanded={model.expanded}
               onToggle={toggle}
             />
           ))}

--- a/apps/gmux-web/src/family.bench.ts
+++ b/apps/gmux-web/src/family.bench.ts
@@ -1,5 +1,5 @@
 import { bench, describe } from 'vitest'
-import { createFamilyIndex, projectFamily } from './family'
+import { bucketedFamily, createFamilyIndex, projectFamily } from './family'
 import { makeSession } from './test-helpers'
 
 const agent = (id: string, parent?: string) => makeSession({
@@ -28,5 +28,9 @@ describe('family projection (1,000 sessions / 500 children)', () => {
   const index = createFamilyIndex(sessions)
   bench('project the selected child drawer', () => {
     projectFamily(children[250], index)
+  })
+
+  bench('bucket the selected child drawer', () => {
+    bucketedFamily(children[250], index)
   })
 })

--- a/apps/gmux-web/src/family.test.ts
+++ b/apps/gmux-web/src/family.test.ts
@@ -123,7 +123,7 @@ describe('bucketed drawer projection', () => {
     expect(FAMILY_GROUP_CAPS).toEqual({ attention: Infinity, working: 20, idle: 10, finished: 3 })
   })
 
-  it('derives a session own bucket from error/unread, working, alive, dead', () => {
+  it('derives a session own bucket from the sessionDotState precedence', () => {
     expect(familyBucket(member('e', { status: { active: true, error: true } }))).toBe('attention')
     expect(familyBucket(member('u', { unread: true }))).toBe('attention')
     expect(familyBucket(member('w', { status: { active: true } }))).toBe('working')
@@ -131,8 +131,11 @@ describe('bucketed drawer projection', () => {
     // isn't "waiting on you" yet even if output is unseen.
     expect(familyBucket(member('wu', { status: { active: true }, unread: true }))).toBe('working')
     expect(familyBucket(member('i'))).toBe('idle')
-    // Dead is dead: a never-viewed dead child is noise, not attention.
-    expect(familyBucket(member('du', { alive: false, unread: true }))).toBe('finished')
+    // Unread is not alive-gated: unseen output demands attention even
+    // after the session died.
+    expect(familyBucket(member('du', { alive: false, unread: true }))).toBe('attention')
+    // Error/working are alive-gated (as in sessionDotState); a dead,
+    // fully-viewed session is finished no matter how it ended.
     expect(familyBucket(member('d', { alive: false, status: { active: true, error: true } }))).toBe('finished')
   })
 

--- a/apps/gmux-web/src/family.test.ts
+++ b/apps/gmux-web/src/family.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { descendantTree, familyIndex, familyNavigation, familyRoot, hasFamily, isFamilyChild, projectFamily } from './family'
+import {
+  bucketedFamily, descendantTree, familyAgentCount, familyBucket, familyIndex, familyNavigation,
+  familyRoot, FAMILY_GROUP_CAPS, hasFamily, isFamilyChild, projectFamily,
+  type FamilyBucketGroup,
+} from './family'
 import { makeSession } from './test-helpers'
 
 const agent = (id: string, parent?: string, extra = {}) => makeSession({
@@ -98,8 +102,117 @@ describe('task-family projection', () => {
     expect(familyRoot(children[250], snapshot)).toBe(root)
     expect(hasFamily(root, snapshot)).toBe(true)
     expect(isFamilyChild(children[250], snapshot)).toBe(true)
+    // Bucketing works off the projected trees plus the shared index; it
+    // must not rescan the snapshot array per node.
+    expect(bucketedFamily(children[250], snapshot).groups.length).toBeGreaterThan(0)
     // One indexed pass over 1,000 rows; old per-candidate Map construction
     // performed hundreds of thousands of indexed reads here.
     expect(indexedReads).toBeLessThanOrEqual(snapshot.length + 1)
+  })
+})
+
+describe('bucketed drawer projection', () => {
+  const at = (minute: number) => `2026-08-04T10:${String(minute).padStart(2, '0')}:00Z`
+  const member = (id: string, extra: Partial<Parameters<typeof makeSession>[0]> = {}) => makeSession({
+    id, cwd: '/p', title: id, parent_session_id: 'root', semantic_agent: true,
+    created_at: at(0), last_output_at: at(1), ...extra,
+  })
+  const flat = (group: FamilyBucketGroup) => group.nodes.map(n => n.session.id)
+
+  it('caps groups at ∞/20/10/3', () => {
+    expect(FAMILY_GROUP_CAPS).toEqual({ attention: Infinity, working: 20, idle: 10, finished: 3 })
+  })
+
+  it('derives a session own bucket from error/unread, working, alive, dead', () => {
+    expect(familyBucket(member('e', { status: { active: true, error: true } }))).toBe('attention')
+    expect(familyBucket(member('u', { unread: true }))).toBe('attention')
+    expect(familyBucket(member('w', { status: { active: true } }))).toBe('working')
+    // Dot precedence (working > unread) carries over: still-active work
+    // isn't "waiting on you" yet even if output is unseen.
+    expect(familyBucket(member('wu', { status: { active: true }, unread: true }))).toBe('working')
+    expect(familyBucket(member('i'))).toBe('idle')
+    // Dead is dead: a never-viewed dead child is noise, not attention.
+    expect(familyBucket(member('du', { alive: false, unread: true }))).toBe('finished')
+    expect(familyBucket(member('d', { alive: false, status: { active: true, error: true } }))).toBe('finished')
+  })
+
+  it('partitions a children list into attention/working/idle/finished order', () => {
+    const root = agent('root')
+    const sessions = [
+      root,
+      member('idle-1'),
+      member('dead-1', { alive: false }),
+      member('working-1', { status: { active: true } }),
+      member('unread-1', { unread: true }),
+    ]
+    const projection = bucketedFamily(sessions[0], sessions)
+    // Top level: the root tree is the single (idle-bucketed) node…
+    expect(projection.groups.map(g => g.bucket)).toEqual(['attention'])
+    const rootNode = projection.groups[0].nodes[0]
+    expect(rootNode.session.id).toBe('root')
+    // …whose children carry the four buckets in display order.
+    expect(rootNode.groups.map(g => g.bucket)).toEqual(['attention', 'working', 'idle', 'finished'])
+    expect(rootNode.groups.map(flat)).toEqual([['unread-1'], ['working-1'], ['idle-1'], ['dead-1']])
+    expect(projection.counts).toEqual({ attention: 1, working: 1, idle: 2, finished: 1, processes: 0 })
+  })
+
+  it('hoists a node to its subtree highest-urgency bucket', () => {
+    const root = agent('root')
+    const deadParent = member('dead-parent', { alive: false })
+    const workingGrandchild = member('grandchild', {
+      parent_session_id: 'dead-parent', status: { active: true },
+    })
+    const deadSibling = member('dead-sibling', { alive: false })
+    const projection = bucketedFamily(root, [root, deadParent, workingGrandchild, deadSibling])
+    const rootNode = projection.groups[0].nodes[0]
+    // The dead parent sorts as working — its subtree contains active work —
+    // while the plain dead sibling stays in finished.
+    expect(rootNode.groups.map(g => g.bucket)).toEqual(['working', 'finished'])
+    expect(rootNode.groups.map(flat)).toEqual([['dead-parent'], ['dead-sibling']])
+    // Counts stay status-truth: the hoisted parent still tallies as finished.
+    expect(projection.counts).toEqual({ attention: 0, working: 1, idle: 1, finished: 2, processes: 0 })
+  })
+
+  it('sorts within a bucket: agents before processes, recency, natural title', () => {
+    const root = agent('root')
+    const proc = (id: string, extra = {}) => member(id, { semantic_agent: undefined, adapter: 'shell', ...extra })
+    const sessions = [
+      root,
+      proc('proc-new', { last_output_at: at(50) }),
+      member('agent-old', { last_output_at: at(10) }),
+      member('swarm-10', { last_output_at: at(20) }),
+      member('swarm-9', { last_output_at: at(20) }),
+      member('swarm-100', { last_output_at: at(20) }),
+    ]
+    const rootNode = bucketedFamily(root, sessions).groups[0].nodes[0]
+    expect(rootNode.groups).toHaveLength(1)
+    // Recency beats title; equal recency reads in natural numeric order;
+    // the process sinks below every agent despite being the most recent.
+    expect(flat(rootNode.groups[0])).toEqual(['swarm-9', 'swarm-10', 'swarm-100', 'agent-old', 'proc-new'])
+    expect(rootNode.groups[0].nodes.map(n => n.process)).toEqual([false, false, false, false, true])
+  })
+
+  it('projects the ancestor spine and counts only the sibling-level trees', () => {
+    const root = agent('root')
+    const parent = member('parent')
+    const selected = member('selected', { parent_session_id: 'parent' })
+    const sibling = member('sibling', { parent_session_id: 'parent', alive: false })
+    const projection = bucketedFamily(selected, [root, parent, selected, sibling])
+    expect(projection.ancestors.map(s => s.id)).toEqual(['root', 'parent'])
+    expect(projection.groups.map(g => g.bucket)).toEqual(['idle', 'finished'])
+    // Ancestors are breadcrumb context, not counted rows.
+    expect(projection.counts).toEqual({ attention: 0, working: 0, idle: 1, finished: 1, processes: 0 })
+  })
+
+  it('counts alive agents for the pill, excluding processes and other families', () => {
+    const root = agent('root')
+    const child = member('child')
+    const dead = member('dead', { alive: false })
+    const proc = member('proc', { semantic_agent: undefined, adapter: 'shell' })
+    const stranger = agent('stranger')
+    const sessions = [root, child, dead, proc, stranger]
+    expect(familyAgentCount(child, sessions)).toBe(2)
+    expect(familyAgentCount(root, sessions)).toBe(2)
+    expect(familyAgentCount(stranger, sessions)).toBe(1)
   })
 })

--- a/apps/gmux-web/src/family.ts
+++ b/apps/gmux-web/src/family.ts
@@ -200,15 +200,15 @@ export const FAMILY_GROUP_CAPS: Record<FamilyBucket, number> = {
 
 /** A session's own bucket from its own facts (no subtree inheritance).
  * Follows the `sessionDotState` precedence exactly (error > working >
- * unread) so a row's dot and its group never disagree, with one addition:
- * everything dead is `finished` — a swarm of dead children whose final
- * output was never viewed is noise, not 500 rows of attention (matching
- * `unreadCount`'s alive gate). */
+ * unread, with error/working alive-gated and unread not) so a row's dot
+ * and its group never disagree. In particular a dead session whose final
+ * output was never viewed is `attention`, not `finished` — unseen output
+ * is unseen output regardless of liveness. */
 export function familyBucket(session: Session): FamilyBucket {
-  if (!session.alive) return 'finished'
-  if (session.status?.error) return 'attention'
-  if (session.status?.active) return 'working'
-  return session.unread ? 'attention' : 'idle'
+  if (session.alive && session.status?.error) return 'attention'
+  if (session.alive && session.status?.active) return 'working'
+  if (session.unread) return 'attention'
+  return session.alive ? 'idle' : 'finished'
 }
 
 export interface FamilyBucketNode {

--- a/apps/gmux-web/src/family.ts
+++ b/apps/gmux-web/src/family.ts
@@ -161,6 +161,138 @@ function byRecency(a: Session, b: Session): number {
   return bt.localeCompare(at) || a.id.localeCompare(b.id)
 }
 
+/** A family member whose parent is a semantic agent but who is not one
+ * itself: a process (shell command, watcher, …) owned by an agent. */
+export function isProcessSession(session: Session): boolean {
+  return session.semantic_agent !== true
+}
+
+/** Count of alive semantic agents in the selected session's presentation
+ * family, root included. Drives the header pill's `Agents · N` count;
+ * processes are intentionally excluded so the label stays truthful. */
+export function familyAgentCount(selected: Session, source: FamilySource): number {
+  const index = indexFor(source)
+  const root = familyRoot(selected, index)
+  let count = 0
+  for (const session of index.byId.values()) {
+    if (session.alive
+      && !isProcessSession(session)
+      && (index.rootById.get(session.id) ?? session) === root) count++
+  }
+  return count
+}
+
+// ── Bucketed drawer projection (noise reduction) ────────────────────────────
+
+/** Drawer grouping vocabulary, in display order. `attention` is error or
+ * unread — the reason the user opened the drawer; never capped. */
+export type FamilyBucket = 'attention' | 'working' | 'idle' | 'finished'
+
+const BUCKET_RANK: Record<FamilyBucket, number> = { attention: 0, working: 1, idle: 2, finished: 3 }
+
+/** Per-group visible-row caps before a `+N …` summary row takes over. */
+export const FAMILY_GROUP_CAPS: Record<FamilyBucket, number> = {
+  attention: Infinity,
+  working: 20,
+  idle: 10,
+  finished: 3,
+}
+
+/** A session's own bucket from its own facts (no subtree inheritance).
+ * Follows the `sessionDotState` precedence exactly (error > working >
+ * unread) so a row's dot and its group never disagree, with one addition:
+ * everything dead is `finished` — a swarm of dead children whose final
+ * output was never viewed is noise, not 500 rows of attention (matching
+ * `unreadCount`'s alive gate). */
+export function familyBucket(session: Session): FamilyBucket {
+  if (!session.alive) return 'finished'
+  if (session.status?.error) return 'attention'
+  if (session.status?.active) return 'working'
+  return session.unread ? 'attention' : 'idle'
+}
+
+export interface FamilyBucketNode {
+  session: Session
+  /** Effective bucket: the highest-urgency bucket in this node's subtree.
+   * A dead parent with a working descendant sorts (and stays visible) as
+   * working — noise is only what is transitively noise. */
+  bucket: FamilyBucket
+  process: boolean
+  /** Children partitioned into bucket groups, in display order. */
+  groups: FamilyBucketGroup[]
+}
+
+export interface FamilyBucketGroup {
+  bucket: FamilyBucket
+  nodes: FamilyBucketNode[]
+}
+
+/** Status-truth totals for the heading counts line: agents tallied by their
+ * own bucket (not the hoisted effective one), processes tallied separately. */
+export interface FamilyBucketCounts {
+  attention: number
+  working: number
+  idle: number
+  finished: number
+  processes: number
+}
+
+export interface BucketedFamilyProjection {
+  root: Session
+  ancestors: Session[]
+  groups: FamilyBucketGroup[]
+  counts: FamilyBucketCounts
+}
+
+const titleCollator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' })
+
+function compareBucketNodes(a: FamilyBucketNode, b: FamilyBucketNode): number {
+  // Bucket order, agents before processes, recency, then natural title so
+  // same-batch children (`swarm-425/426/…`) read ordered instead of shuffled.
+  const at = a.session.last_output_at || a.session.created_at
+  const bt = b.session.last_output_at || b.session.created_at
+  return BUCKET_RANK[a.bucket] - BUCKET_RANK[b.bucket]
+    || Number(a.process) - Number(b.process)
+    || (bt < at ? -1 : bt > at ? 1 : 0)
+    || titleCollator.compare(a.session.title, b.session.title)
+    || (a.session.id < b.session.id ? -1 : a.session.id > b.session.id ? 1 : 0)
+}
+
+function groupBucketNodes(nodes: FamilyBucketNode[]): FamilyBucketGroup[] {
+  const sorted = [...nodes].sort(compareBucketNodes)
+  const groups: FamilyBucketGroup[] = []
+  for (const node of sorted) {
+    const last = groups[groups.length - 1]
+    if (last && last.bucket === node.bucket) last.nodes.push(node)
+    else groups.push({ bucket: node.bucket, nodes: [node] })
+  }
+  return groups
+}
+
+function toBucketNode(node: FamilyNode, counts: FamilyBucketCounts): FamilyBucketNode {
+  const children = node.children.map(child => toBucketNode(child, counts))
+  const process = isProcessSession(node.session)
+  const own = familyBucket(node.session)
+  if (process) counts.processes++
+  else counts[own]++
+  let bucket = own
+  for (const child of children) {
+    if (BUCKET_RANK[child.bucket] < BUCKET_RANK[bucket]) bucket = child.bucket
+  }
+  return { session: node.session, bucket, process, groups: groupBucketNodes(children) }
+}
+
+/** `projectFamily` with every children list (the top-level sibling list
+ * included) partitioned into attention → working → idle → finished groups.
+ * One pass over the projected trees on top of the shared snapshot index,
+ * so the whole thing stays O(n) for a snapshot. */
+export function bucketedFamily(selected: Session, source: FamilySource): BucketedFamilyProjection {
+  const base = projectFamily(selected, indexFor(source))
+  const counts: FamilyBucketCounts = { attention: 0, working: 0, idle: 0, finished: 0, processes: 0 }
+  const top = base.siblingTrees.map(tree => toBucketNode(tree, counts))
+  return { root: base.root, ancestors: base.ancestors, groups: groupBucketNodes(top), counts }
+}
+
 /** Complete descendant tree for a presentation root. Promoted descendants are
  * intentionally excluded: each starts a new family, while provenance remains
  * available on the raw session. */

--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -14,7 +14,7 @@ import { usePresence } from './use-presence'
 import { lifecycleAction } from './session-actions'
 import { MenuButton } from './menu-button'
 import { FamilyDrawer } from './family-drawer'
-import { familyNavigation, hasFamily } from './family'
+import { familyAgentCount, familyNavigation, hasFamily } from './family'
 
 import type { Session } from './types'
 import { SettingsModal } from './settings'
@@ -211,7 +211,7 @@ function MainHeader({ session, onRestart, onResume, resuming }: {
             aria-controls="agent-family-drawer"
             onClick={() => setFamilyOpen(open => !open)}
           >
-            Agents / Family
+            Agents · {familyAgentCount(session, sessions.value)}
           </button>
         )}
         {familyNav.parent && (
@@ -230,7 +230,7 @@ function MainHeader({ session, onRestart, onResume, resuming }: {
             aria-label={`Go to root agent: ${familyNav.root.title}`}
             title={`Root: ${familyNav.root.title}`}
             onClick={() => navigateToSession(familyNav.root!.id)}
-          >⌂</button>
+          >⇈</button>
         )}
         <div class="main-header-title">
           {session.title}

--- a/apps/gmux-web/src/session-row.tsx
+++ b/apps/gmux-web/src/session-row.tsx
@@ -22,7 +22,7 @@ import type { Session } from './types'
 import {
   activityMap, peerStatusByName,
   sessionDotState, isSessionUnavailable,
-  duplicateConversationFiles,
+  duplicateConversationFiles, familyDotById,
 } from './store'
 import { useArrivalPulse } from './use-arrival-pulse'
 import { HostSuffix } from './host-suffix'
@@ -104,10 +104,12 @@ export function SessionRow({
   const unavailable = isSessionUnavailable(session, peerStatus)
   const sleeping = !session.alive && session.resumable
 
-  const rawDot = resuming ? 'working' : sessionDotState(session, am)
-  // Selection mutes attention-grabbing dots (mirrors sidebar behavior):
-  // if you're already looking at it, "unread" / "error" aren't useful.
-  const dot = (selected && (rawDot === 'error' || rawDot === 'unread')) ? 'none' : rawDot
+  // Family-aggregated dot: this row stands in for the whole family.
+  // Selection muting ("unread isn't useful if you're looking at it") is
+  // applied per member inside `familyDotById`, mirroring the sidebar.
+  const dot = resuming
+    ? 'working'
+    : familyDotById.value.get(session.id) ?? sessionDotState(session, am)
   const arrival = useArrivalPulse(dot)
 
   const cls = [

--- a/apps/gmux-web/src/sidebar.tsx
+++ b/apps/gmux-web/src/sidebar.tsx
@@ -17,7 +17,7 @@ import {
   activityMap, projects, connState, health, peers,
   collapsedFolders, toggleFolderCollapsed,
   updateProjects, reorderSessions,
-  peerStatusByName, isSessionUnavailable, localPeerNames, sessionDotState,
+  peerStatusByName, isSessionUnavailable, localPeerNames, sessionDotState, familyDotById,
   unreadCount, localHostLabel, unresolvedHosts, duplicateConversationFiles,
   sidebarActivity, sidebarMode, setSidebarMode,
   activeSelectors, removeSelector, setHostFilter,
@@ -151,9 +151,10 @@ function SessionItem({
   onDragOver?: () => void
   onDragEnd?: () => void
 }) {
-  const effectiveDotState = resuming ? 'working' : rawDotState
-  // Nothing is "unread" if you're already looking at it.
-  const dotState = (selected && (effectiveDotState === 'error' || effectiveDotState === 'unread')) ? 'none' : effectiveDotState
+  // Selection muting ("nothing is unread if you're already looking at it")
+  // happens per family member inside `familyDotById`, so a sibling child's
+  // attention still surfaces here while you view another member.
+  const dotState = resuming ? 'working' : rawDotState
   const arrival = useArrivalPulse(dotState)
   const sleeping = !session.alive && session.resumable
   // Same conversation file live in another runner (ADR 0011 N:1).
@@ -353,7 +354,7 @@ function FolderGroup({
             href={tabHref(sessionPath(folder.slug, s, folder.peer, hasSessionSlugCollision(s, sessions.value, projects.value)))}
             selected={selId === s.id}
             resuming={resumingId === s.id}
-            dotState={sessionDotState(s, am)}
+            dotState={familyDotById.value.get(s.id) ?? sessionDotState(s, am)}
             unavailable={isSessionUnavailable(s, peerStatus)}
             showHostMarker={mixedHosts}
             dragging={drag !== null && s.id === visible[drag.from]?.id}

--- a/apps/gmux-web/src/store.test.ts
+++ b/apps/gmux-web/src/store.test.ts
@@ -1241,12 +1241,14 @@ describe('familyDotById (family-aggregated row dot)', () => {
     expect(familyDotById.value.get('solo')).toBe('unread')
   })
 
-  it('ignores dead descendants: a never-viewed dead child must not pin the root', () => {
+  it('lets a never-viewed dead child surface unread on the root', () => {
+    // Unread is not alive-gated in sessionDotState, and the roll-up
+    // follows the same vocabulary: unseen output pings until viewed.
     _rawSessions.value = [
       pi('root'),
       pi('dead-child', { parent_session_id: 'root', alive: false, unread: true }),
     ]
-    expect(familyDotById.value.get('root')).toBe('none')
+    expect(familyDotById.value.get('root')).toBe('unread')
   })
 
   it('mutes only the selected member, not its siblings', () => {

--- a/apps/gmux-web/src/store.test.ts
+++ b/apps/gmux-web/src/store.test.ts
@@ -12,7 +12,7 @@ import {
   toUISession, localHostLabel, parseConnectURL, unreadCount, discovered,
   view, duplicateConversationFiles,
   sidebarMode, setSidebarMode, setFilterSelectors, setHostFilter, homePartition,
-  sidebarActivity, setAliveOnly,
+  sidebarActivity, setAliveOnly, familyDotById,
 } from './store'
 import { SessionSchema } from '@gmux/protocol'
 import type { PendingMutation } from './store'
@@ -1162,6 +1162,31 @@ describe('unreadCount (sidebar-only attention blip)', () => {
     expect(unreadCount.value).toBe(1)
   })
 
+  it('counts alive unread family children toward their folder-visible root', () => {
+    _rawSessions.value = [
+      makeSession({ id: 'root', cwd: '/work', adapter: 'pi', semantic_agent: true, project_slug: 'proj' }),
+      makeSession({ id: 'child', cwd: '/work', adapter: 'pi', semantic_agent: true, parent_session_id: 'root', alive: true, unread: true }),
+      makeSession({ id: 'proc', cwd: '/work', parent_session_id: 'root', alive: true, unread: true }),
+      makeSession({ id: 'dead-child', cwd: '/work', adapter: 'pi', semantic_agent: true, parent_session_id: 'root', alive: false, unread: true }),
+    ]
+    // Children have no folder row of their own; the root row stands in and
+    // must ping for both the unread agent child and the unread process.
+    expect(unreadCount.value).toBe(2)
+  })
+
+  it('excludes the selected child from its root roll-up', () => {
+    _rawSessions.value = [
+      makeSession({ id: 'root', cwd: '/work', adapter: 'pi', slug: 'rooty', semantic_agent: true, project_slug: 'proj' }),
+      makeSession({ id: 'child', cwd: '/work', adapter: 'pi', slug: 'kiddo', semantic_agent: true, parent_session_id: 'root', alive: true, unread: true }),
+      makeSession({ id: 'sibling', cwd: '/work', adapter: 'pi', slug: 'sib', semantic_agent: true, parent_session_id: 'root', alive: true, unread: true }),
+    ]
+    expect(unreadCount.value).toBe(2)
+    urlPath.value = '/proj/pi/kiddo'
+    expect(selectedId.value).toBe('child')
+    // You're looking at `child`; its sibling still pings.
+    expect(unreadCount.value).toBe(1)
+  })
+
   it('is scoped to the tab\u2019s ?filter= selectors', () => {
     // A pinned tab must not blink for sessions outside its scope
     // (another tab or a notification covers those), and must still
@@ -1182,6 +1207,61 @@ describe('unreadCount (sidebar-only attention blip)', () => {
     expect(unreadCount.value).toBe(1)
     urlSearch.value = '?filter=elsewhere'
     expect(unreadCount.value).toBe(0)
+  })
+})
+
+describe('familyDotById (family-aggregated row dot)', () => {
+  beforeEach(() => {
+    _rawSessions.value = []
+    _setRawWorld({ projects: [{ slug: 'proj', match: [{ path: '/work' }] }], peers: [] })
+    sessionsLoaded.value = true
+    worldLoaded.value = true
+    urlPath.value = '/'
+    activityMap.value = new Map()
+  })
+
+  const pi = (id: string, extra: Partial<Session> = {}) => makeSession({
+    id, cwd: '/work', adapter: 'pi', semantic_agent: true, project_slug: 'proj', ...extra,
+  })
+
+  it('rolls the highest-precedence member state up to the presentation root', () => {
+    _rawSessions.value = [
+      pi('root'),
+      pi('working-child', { parent_session_id: 'root', status: { active: true } }),
+      pi('unread-child', { parent_session_id: 'root', unread: true }),
+      makeSession({ id: 'proc', cwd: '/work', parent_session_id: 'root', status: { active: true, error: true } }),
+    ]
+    // error (process!) > working > unread; the root row shows the max.
+    expect(familyDotById.value.get('root')).toBe('error')
+    expect(familyDotById.value.get('working-child')).toBeUndefined()
+  })
+
+  it('keeps standalone sessions at their own dot state', () => {
+    _rawSessions.value = [pi('solo', { unread: true })]
+    expect(familyDotById.value.get('solo')).toBe('unread')
+  })
+
+  it('ignores dead descendants: a never-viewed dead child must not pin the root', () => {
+    _rawSessions.value = [
+      pi('root'),
+      pi('dead-child', { parent_session_id: 'root', alive: false, unread: true }),
+    ]
+    expect(familyDotById.value.get('root')).toBe('none')
+  })
+
+  it('mutes only the selected member, not its siblings', () => {
+    _rawSessions.value = [
+      pi('root', { slug: 'rooty' }),
+      pi('a', { slug: 'aa', parent_session_id: 'root', unread: true }),
+      pi('b', { slug: 'bb', parent_session_id: 'root', unread: true }),
+    ]
+    expect(familyDotById.value.get('root')).toBe('unread')
+    urlPath.value = '/proj/pi/aa'
+    expect(selectedId.value).toBe('a')
+    // `a` is muted (you're looking at it) but `b` still pings the root row.
+    expect(familyDotById.value.get('root')).toBe('unread')
+    _rawSessions.value = _rawSessions.value.map(s => s.id === 'b' ? { ...s, unread: false } : s)
+    expect(familyDotById.value.get('root')).toBe('none')
   })
 })
 

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -929,11 +929,6 @@ export const familyDotById = computed<ReadonlyMap<string, DotState>>(() => {
     const rootId = index.rootById.get(s.id)?.id ?? s.id
     let own = sessionDotState(s, am)
     if (s.id === sel && (own === 'error' || own === 'unread')) own = 'none'
-    // Descendants contribute only while alive: a dead child whose final
-    // output was never viewed must not pin its root's row to "unread"
-    // forever (mirrors unreadCount's alive gate). The root's own state
-    // passes through unchanged, preserving standalone-row behavior.
-    if (s.id !== rootId && !s.alive) own = 'none'
     const prev = map.get(rootId)
     if (prev === undefined || DOT_RANK[own] > DOT_RANK[prev]) map.set(rootId, own)
   }

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -19,7 +19,7 @@ import type { View } from './routing'
 import { resolveViewFromPath, viewToPath } from './routing'
 import { navigateWithReload } from './version-watch'
 import { buildProjectFolders, discoverProjects, type TemporaryPresentationPlacement } from './projects'
-import { familyRootId, isFamilyChild } from './family'
+import { familyIndex, familyRootId, isFamilyChild } from './family'
 import { referencePresence, unresolvedReferences, removeReferenceItems, removeHostReferenceItems, type UnresolvedHost } from './references'
 import { parseFilterParam, formatFilterParam, sessionMatchesFilter, type Selector } from './tab-filter'
 import { pushError } from './toasts'
@@ -878,19 +878,66 @@ export const backgroundActivity = computed((): DotState => {
  * session into at most one folder, so summing across folders needs no
  * dedup.
  *
+ * Family children have no folder row of their own — their presentation
+ * root stands in — so each folder-visible root also counts its alive
+ * unread descendants. Without this, an unread child is invisible: no
+ * logo blink, no hamburger badge.
+ *
  * Scoped to the tab's `?filter=` selectors: a tab pinned to a project
  * or host shouldn't blink for sessions outside its scope (another tab
  * or a notification covers those). Within the scope it's built from
  * folder-bucketed sessions so unstamped strays can't ping. */
 export const unreadCount = computed(() => {
   const sel = selectedId.value
+  const index = familyIndex(sessions.value)
+  const childUnread = new Map<string, number>()
+  for (const s of sessions.value) {
+    if (s.id === sel || !s.alive || !s.unread || !index.childIds.has(s.id)) continue
+    const rootId = index.rootById.get(s.id)?.id
+    if (rootId) childUnread.set(rootId, (childUnread.get(rootId) ?? 0) + 1)
+  }
   let n = 0
   for (const f of foldersFrom(filteredSessions.value)) {
     for (const s of f.sessions) {
       if (s.id !== sel && s.alive && s.unread) n++
+      n += childUnread.get(s.id) ?? 0
     }
   }
   return n
+})
+
+const DOT_RANK: Record<DotState, number> = { none: 0, fading: 1, active: 2, unread: 3, working: 4, error: 5 }
+
+/** Family-aggregated dot state, keyed by presentation-root session id.
+ *
+ * A root's sidebar/dashboard row stands in for its whole family, so the
+ * row's dot must reflect the highest-precedence state among the root and
+ * every descendant (agents and processes alike) — otherwise a working or
+ * unread child is invisible outside the drawer.
+ *
+ * Selection muting happens per member before aggregation: the selected
+ * session's own error/unread is dropped ("you're already looking at it"),
+ * while its siblings' attention states still surface on the root row.
+ * Standalone sessions are their own root, so this map is the single
+ * dot-state source for every root-level row. */
+export const familyDotById = computed<ReadonlyMap<string, DotState>>(() => {
+  const sel = selectedId.value
+  const am = activityMap.value
+  const index = familyIndex(sessions.value)
+  const map = new Map<string, DotState>()
+  for (const s of sessions.value) {
+    const rootId = index.rootById.get(s.id)?.id ?? s.id
+    let own = sessionDotState(s, am)
+    if (s.id === sel && (own === 'error' || own === 'unread')) own = 'none'
+    // Descendants contribute only while alive: a dead child whose final
+    // output was never viewed must not pin its root's row to "unread"
+    // forever (mirrors unreadCount's alive gate). The root's own state
+    // passes through unchanged, preserving standalone-row behavior.
+    if (s.id !== rootId && !s.alive) own = 'none'
+    const prev = map.get(rootId)
+    if (prev === undefined || DOT_RANK[own] > DOT_RANK[prev]) map.set(rootId, own)
+  }
+  return map
 })
 
 // ── Home dashboard partitioning ─────────────────────────────────────────────

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -2083,13 +2083,26 @@ body {
   right: 0;
   z-index: 40;
   max-height: min(65vh, 520px);
-  overflow: auto;
-  background: color-mix(in srgb, var(--bg-surface) 96%, transparent);
+  display: flex;
+  flex-direction: column;
+  /* Opaque: terminal text ghosting through translucency reads as broken
+   * rendering, not intentional layering. */
+  background: var(--bg-surface);
   border-bottom: 1px solid var(--border);
   box-shadow: 0 14px 30px rgba(0, 0, 0, 0.28);
-  padding: 12px 16px 16px;
 }
+/* Heading, counts and ancestor spine stay put; only the tree scrolls, so
+ * the close button and "where am I" context survive a 500-row family. */
+.family-drawer-head { flex: 0 0 auto; padding: 12px 16px 0; }
+.family-drawer-scroll { flex: 1 1 auto; overflow: auto; padding: 0 16px 16px; }
 .family-drawer-heading { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+.family-counts {
+  padding-top: 4px;
+  font: 400 12px/1.4 'Source Sans 3', sans-serif;
+  color: var(--text-muted);
+}
+.family-count-attention { color: var(--unread); font-weight: 600; }
+.family-count-processes { color: var(--text-muted); opacity: 0.8; }
 .family-drawer-nav { display: flex; align-items: center; gap: 7px; }
 .family-drawer-close { border: 0; background: transparent; color: var(--text-muted); cursor: pointer; font-size: 20px; }
 .family-spine,
@@ -2103,10 +2116,40 @@ body {
 .family-row:hover { background: var(--bg-hover); color: var(--text); }
 .family-row.selected { background: var(--bg-selected); color: var(--text); }
 .family-row.inactive { opacity: 0.65; }
-.family-row-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--text-muted); flex: 0 0 auto; }
-.family-row-dot.active { background: var(--accent); box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 20%, transparent); }
+/* Processes: a mono $ glyph where agents show a status dot, muted title.
+ * Shape (not just color) distinguishes them from agents, so the cue
+ * survives tiny sizes and color blindness. */
+.family-row-proc {
+  flex: 0 0 auto;
+  width: 7px; /* match .session-dot-indicator for title alignment */
+  font-family: 'Fira Code', monospace;
+  font-size: 11px;
+  line-height: 1;
+  color: var(--text-muted);
+}
+.family-row-proc.working { color: var(--accent); }
+.family-row.process .family-row-title { color: var(--text-muted); }
 .family-row-title { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .family-row-kind { margin-left: auto; color: var(--text-muted); font-size: 11px; }
+/* Collapsed-group summary row: a ghost row, quieter than real rows. */
+.family-more {
+  min-height: 30px;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 10px;
+  border: 0;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--text-muted);
+  font: 400 12px/1 'Source Sans 3', sans-serif;
+  text-align: left;
+  cursor: pointer;
+}
+.family-more:hover { background: var(--bg-hover); color: var(--text-secondary); }
+.family-more:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.family-more-chevron { flex: 0 0 auto; width: 7px; font-size: 9px; }
 
 /* Session actions menu */
 

--- a/docs/task-family-ui.md
+++ b/docs/task-family-ui.md
@@ -15,6 +15,26 @@ used by notification suppression and covers the conversation-backed Pi,
 Claude, and Codex adapters without a frontend adapter-name list. Shell remains
 false.
 
+## Drawer presentation (noise reduction)
+
+Every children list in the drawer (the top-level sibling list included) is
+partitioned into attention → working → idle → finished groups, ordered by
+the `sessionDotState` precedence so a row's dot and its group never
+disagree; everything dead is `finished` regardless of unread. A node sorts
+into the highest-urgency bucket found in its entire subtree, so collapsed
+summaries can never hide live work. Groups are capped (attention ∞,
+working 20, idle 10, finished 3) behind `+N …` summary rows with
+per-(parent, bucket) expansion that resets when the drawer closes. The
+projection is frozen while the drawer is open: dots update in place, but
+rows never re-sort under the cursor.
+
+Outside the drawer a root row stands in for its whole family:
+`familyDotById` aggregates the highest-precedence member dot onto the
+presentation root, and `unreadCount` adds alive unread descendants to their
+folder-visible root. Dead members never contribute (a never-viewed dead
+child is noise, not attention). Processes render with a `$` glyph and are
+excluded from the header pill's `Agents · N` count.
+
 ## Unresolved capability seam
 
 `ConversationSource` describes conversation-backed agents rather than being a

--- a/docs/task-family-ui.md
+++ b/docs/task-family-ui.md
@@ -18,22 +18,26 @@ false.
 ## Drawer presentation (noise reduction)
 
 Every children list in the drawer (the top-level sibling list included) is
-partitioned into attention → working → idle → finished groups, ordered by
-the `sessionDotState` precedence so a row's dot and its group never
-disagree; everything dead is `finished` regardless of unread. A node sorts
-into the highest-urgency bucket found in its entire subtree, so collapsed
-summaries can never hide live work. Groups are capped (attention ∞,
+partitioned into attention → working → idle → finished groups, classified
+by the `sessionDotState` precedence so a row's dot and its group never
+disagree: error and unread demand attention (unread is not alive-gated —
+unseen output pings until viewed, dead or not), active work is working,
+and only quiet sessions land in idle/finished. A node sorts into the
+highest-urgency bucket found in its entire subtree, so collapsed summaries
+can never hide urgent descendants. Groups are capped (attention ∞,
 working 20, idle 10, finished 3) behind `+N …` summary rows with
 per-(parent, bucket) expansion that resets when the drawer closes. The
-projection is frozen while the drawer is open: dots update in place, but
-rows never re-sort under the cursor.
+projection is frozen against ordinary live updates while the drawer is
+open — dots update in place, rows never re-sort under the cursor — and
+re-projects from current facts on the two explicit user actions: selecting
+another session and expanding/collapsing a group.
 
 Outside the drawer a root row stands in for its whole family:
 `familyDotById` aggregates the highest-precedence member dot onto the
 presentation root, and `unreadCount` adds alive unread descendants to their
-folder-visible root. Dead members never contribute (a never-viewed dead
-child is noise, not attention). Processes render with a `$` glyph and are
-excluded from the header pill's `Agents · N` count.
+folder-visible root (the count keeps its existing alive gate). Processes
+render with a `$` glyph and are excluded from the header pill's
+`Agents · N` count.
 
 ## Unresolved capability seam
 


### PR DESCRIPTION
Implements the P0/P1 findings and the noise-reduction design from the family-UX assessment (follow-up to #453/#462, builds on #463 and #464's process children). Amended per adversarial review round 1 (see thread).

## Noise reduction (the big one)

Every children list in the drawer — the top-level sibling list included — is partitioned into **attention → working → idle → finished** groups:

- **Bucketing follows `sessionDotState` precedence exactly** (error > working > unread; error/working alive-gated, unread not), so a row's dot and its group never disagree. A dead member whose final output was never viewed classifies as *attention* — unseen output pings until viewed.
- **Subtree-max inheritance**: a node sorts into the highest-urgency bucket found in its entire subtree, so a collapsed *finished* summary can never hide an urgent descendant.
- **Caps ∞ / 20 / 10 / 3** (attention/working/idle/finished) behind ghost summary rows (`+66 finished`), two-state expansion keyed per (parent, bucket), reset when the drawer closes.
- **Within a bucket**: agents before processes, recency desc, then natural title sort (`swarm-425/426/…` reads ordered, not shuffled by last-output timestamps).
- **Frozen against ordinary live updates; explicit actions re-project.** The drawer's freeze/expansion behavior lives in a pure model (`family-drawer-model.ts`): live status changes repaint dots in place but never re-sort rows under the cursor; selecting another session or toggling a group re-projects from current session facts.
- **Sticky heading** with status-truth counts (`500 need attention · 4 working · 10 idle · 69 finished · 1 process`); only the tree scrolls.

## Status roll-up outside the drawer (P0)

A root row stands in for its whole family, so it must show the family's state:

- New `familyDotById` computed: aggregates the highest-precedence member dot (`sessionDotState` vocabulary, dead members included — a never-viewed dead child surfaces unread) onto the presentation root; used by both the sidebar row and the dashboard session row. Selection muting is applied per member *before* aggregation — viewing one child no longer mutes a sibling's attention.
- `unreadCount` (logo blink, mobile hamburger badge) now adds alive unread descendants to their folder-visible root (keeps the count's existing alive gate). The tab-title count already scanned raw sessions and needed no change.

## Five-state vocabulary in the drawer (P0)

Drawer rows use the shared `.session-dot-indicator` states via `sessionDotState` (error/working/unread/active/fading), verbatim.

## Process children (#464 presentation)

`$` glyph instead of a dot (teal while running — shape survives color-blindness), muted title, sorted after agents within their bucket, own summary noun (`+12 processes done`), excluded from the pill count.

## P1 polish

- Opaque drawer background (terminal text no longer ghosts through).
- Pill → `Agents · N` (alive agents in the family); drawer heading → "Agents"; header root glyph `⌂` → `⇈`.

## Perf

Projection still builds on the shared O(n) `familyIndex`; the #462 proxy guard also covers `bucketedFamily` (still ≤ n+1 indexed reads). New bench: bucketing the 500-child drawer ~0.9 ms per explicit re-projection.

## Tests

Unit + behavioral: bucket classification per dot precedence, subtree-max hoisting, in-bucket ordering, pill count, roll-up aggregation/muting, `unreadCount` child roll-up, and a drawer-model suite proving (a) live status change does **not** auto-reorder while a group toggle **does** refresh the projection, (b) the rendered 20/10/3 caps are applied by the actual split path with attention uncapped, and (c) mixed hidden agent/process summary wording (`+4 finished · 2 processes done`).

## Screenshots

Live specimen: 578-child family (562 dead `swarm-*`), plus a small normal family (3 agents + 2 processes). Before = pre-change build on the same data. After-shots reflect round-1 spec semantics.

| | Before | After |
|---|---|---|
| Monster family, drawer opened | ![before top](https://raw.githubusercontent.com/gmuxapp/gmux/mgabor/family-drawer-shots/.pr-assets/before-monster-top.png) | ![after top](https://raw.githubusercontent.com/gmuxapp/gmux/mgabor/family-drawer-shots/.pr-assets/after-monster-top.png) |
| Monster family, scrolled to the end | ![before wall](https://raw.githubusercontent.com/gmuxapp/gmux/mgabor/family-drawer-shots/.pr-assets/before-monster-wall.png) (~38 screens, unordered) | ![after summary](https://raw.githubusercontent.com/gmuxapp/gmux/mgabor/family-drawer-shots/.pr-assets/after-monster-summary.png) (grouped; ends at `+66 finished`) |
| Normal family (3 agents, 2 processes) | ![before normal](https://raw.githubusercontent.com/gmuxapp/gmux/mgabor/family-drawer-shots/.pr-assets/before-normal.png) | ![after normal](https://raw.githubusercontent.com/gmuxapp/gmux/mgabor/family-drawer-shots/.pr-assets/after-normal.png) |

<details><summary>More after-shots: expanded finished group, child-selected view, mobile (taken pre-round-1; caps/expansion mechanics unchanged, attention counts smaller than current semantics produce)</summary>

Expanded finished group → ends with `show fewer` (sticky heading holds):
![expanded](https://raw.githubusercontent.com/gmuxapp/gmux/mgabor/family-drawer-shots/.pr-assets/after-monster-expanded.png)

Child selected (spine + Parent, groups at sibling level):
![child](https://raw.githubusercontent.com/gmuxapp/gmux/mgabor/family-drawer-shots/.pr-assets/after-child-view.png)

Mobile (390px):
![mobile](https://raw.githubusercontent.com/gmuxapp/gmux/mgabor/family-drawer-shots/.pr-assets/after-mobile.png)

</details>

Screenshots live on the throwaway `mgabor/family-drawer-shots` branch (not for merge; delete after this PR closes).

**Owner decision point (product, not blocking):** with the approved semantics, attention is uncapped and unread is not alive-gated, so a corpus of hundreds of dead never-viewed children renders ~500 attention rows (see monster after-shot). If that's undesirable, the amendment would be either bulk mark-read tooling or a spec change (dead+unread → finished, as this PR briefly did before round 1 reverted it).
