### PR TITLE
feat: add session drive-mode axis and ADR 0033 capability refusals

### DIFF
--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -376,7 +376,10 @@ function SessionMenu({ session, onRestart, onResume, resuming }: {
           <div class="session-menu-section-title">Session info</div>
           <div class="session-menu-row">
             <span class="session-menu-label">Adapter</span>
-            <span class="session-menu-value">{session.adapter}</span>
+            <span class="session-menu-value">
+              {session.adapter}
+              {session.drive_mode === 'acp' ? ' (acp)' : ''}
+            </span>
           </div>
           <div class="session-menu-row">
             <span class="session-menu-label">Version</span>

--- a/apps/gmux-web/src/types.ts
+++ b/apps/gmux-web/src/types.ts
@@ -24,6 +24,12 @@ export interface Session {
   remotes?: Record<string, string>
   adapter: string
   /**
+   * Drive mode (ADR 0033): how gmux hosts this harness. Absent means
+   * terminal; 'acp' sessions have no PTY. Server-derived; never inferred
+   * from adapter names.
+   */
+  drive_mode?: 'terminal' | 'acp'
+  /**
    * Session this one was spawned from (e.g. `gmux edit` invoked as
    * $EDITOR inside an existing session). Drives adjacent placement in
    * the sidebar: the child renders directly under its parent.

--- a/cli/gmux/cmd/gmux/actions.go
+++ b/cli/gmux/cmd/gmux/actions.go
@@ -20,10 +20,14 @@ import (
 // session is the subset of gmuxd's Session model that the CLI cares
 // about. Defined locally to avoid pulling in the gmuxd store package.
 type cliSession struct {
-	ID            string `json:"id"`
-	Peer          string `json:"peer,omitempty"`
-	Cwd           string `json:"cwd,omitempty"`
-	Adapter       string `json:"adapter"`
+	ID      string `json:"id"`
+	Peer    string `json:"peer,omitempty"`
+	Cwd     string `json:"cwd,omitempty"`
+	Adapter string `json:"adapter"`
+	// DriveMode is how gmux hosts this harness (ADR 0033). Absent on the
+	// wire means terminal; "acp" sessions have no PTY. Round-trips through
+	// `gmux ls --json` so scripts can see the mode axis.
+	DriveMode     string `json:"drive_mode,omitempty"`
 	Alive         bool   `json:"alive"`
 	Pid           int    `json:"pid,omitempty"`
 	Title         string `json:"title,omitempty"`
@@ -369,7 +373,14 @@ func cmdList(all bool, asJSON bool) int {
 		if title == "" {
 			title = strings.Join(s.Command, " ")
 		}
-		row := [5]string{id, status, s.Adapter, title, s.Cwd}
+		// The mode rides the adapter cell rather than adding a column: it
+		// is exceptional (terminal is the default and stays unmarked), and
+		// a copy-pasteable table should not grow a column for it.
+		adapterCell := s.Adapter
+		if s.DriveMode == "acp" {
+			adapterCell += " (acp)"
+		}
+		row := [5]string{id, status, adapterCell, title, s.Cwd}
 		rows = append(rows, row)
 		if n := len(row[0]); n > idW {
 			idW = n
@@ -514,6 +525,14 @@ func fetchScrollback(sess cliSession, n int) ([]byte, int) {
 		if resp.StatusCode == http.StatusNotFound {
 			fmt.Fprintf(os.Stderr, "gmux: session %s not found\n", displayID(sess))
 			return nil, 1
+		}
+		if resp.StatusCode == http.StatusUnprocessableEntity {
+			// A capability refusal (e.g. an ACP session has no terminal
+			// screen, ADR 0033) arrives with a self-contained message.
+			if msg := extractMessage(body); msg != "" {
+				fmt.Fprintf(os.Stderr, "gmux: %s\n", msg)
+				return nil, 1
+			}
 		}
 		fmt.Fprintf(os.Stderr, "gmux: tail failed: %s: %s\n", resp.Status, strings.TrimSpace(string(body)))
 		return nil, 1

--- a/cli/gmux/cmd/gmux/attach.go
+++ b/cli/gmux/cmd/gmux/attach.go
@@ -31,6 +31,14 @@ func cmdAttach(ref string) int {
 		return 1
 	}
 
+	// An ACP session has no PTY at all (ADR 0033): the terminal WebSocket
+	// would fail with a cryptic upgrade error, so name the boundary and the
+	// surfaces that do exist.
+	if sess.DriveMode == "acp" {
+		fmt.Fprintln(os.Stderr, "gmux: this is an ACP session; there is no terminal to attach. The web view renders the conversation, and 'gmux agent prompt' drives it")
+		return 1
+	}
+
 	// A dead session has no backend socket for gmuxd to dial, so the WS
 	// upgrade would fail with a cryptic "backend unavailable". Surface the
 	// real reason up front and point the user at the UI where they can

--- a/cli/gmux/internal/ptyserver/incarnation_test.go
+++ b/cli/gmux/internal/ptyserver/incarnation_test.go
@@ -94,6 +94,11 @@ func TestIncarnationIsReportedOnEveryResponseAndInMeta(t *testing.T) {
 	if _, ok := meta["id"]; !ok {
 		t.Error("/meta lost its existing fields")
 	}
+	// A PTY runner IS terminal mode (ADR 0033): the drive mode is spliced
+	// beside the incarnation so registration can persist the axis.
+	if got, _ := meta["drive_mode"].(string); got != "terminal" {
+		t.Errorf("/meta drive_mode = %q, want terminal", got)
+	}
 
 	// The stream reports it too, in headers, before any event is sent.
 	req, _ := http.NewRequest(http.MethodGet, "http://x/events", nil)

--- a/cli/gmux/internal/ptyserver/ptyserver.go
+++ b/cli/gmux/internal/ptyserver/ptyserver.go
@@ -990,17 +990,19 @@ func (s *Server) handleMeta(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	// Splice the incarnation in rather than adding it to session.State: the
-	// nonce belongs to this runner process, not to the session, and State is
-	// the session's own document. Decoding to RawMessage keeps every existing
-	// field byte-identical.
-	if s.incarnation != "" {
-		var obj map[string]json.RawMessage
-		if json.Unmarshal(data, &obj) == nil {
+	// Splice runner-process facts in rather than adding them to
+	// session.State: the incarnation nonce and the drive mode belong to this
+	// runner process (a PTY runner IS terminal mode, ADR 0033), not to the
+	// session document. Decoding to RawMessage keeps every existing field
+	// byte-identical.
+	var obj map[string]json.RawMessage
+	if json.Unmarshal(data, &obj) == nil {
+		if s.incarnation != "" {
 			obj["incarnation"], _ = json.Marshal(s.incarnation)
-			if merged, mErr := json.Marshal(obj); mErr == nil {
-				data = merged
-			}
+		}
+		obj["drive_mode"], _ = json.Marshal(adapter.DriveModeTerminal)
+		if merged, mErr := json.Marshal(obj); mErr == nil {
+			data = merged
 		}
 	}
 	w.Header().Set("Content-Type", "application/json")

--- a/packages/adapter/adapters/claude.go
+++ b/packages/adapter/adapters/claude.go
@@ -60,6 +60,11 @@ func (c *Claude) Match(cmd []string) bool {
 // Env returns no extra environment variables.
 func (c *Claude) Env(_ adapter.EnvContext) []string { return nil }
 
+// SupportsACPDrive reports that the Claude harness has an ACP drive mode
+// (ADR 0033): semantic control is delivered by the ACP runner, so terminal
+// refusals name the mode boundary rather than a missing capability.
+func (c *Claude) SupportsACPDrive() bool { return true }
+
 func (c *Claude) Launchers() []adapter.Launcher {
 	return []adapter.Launcher{{
 		ID:          "claude",

--- a/packages/adapter/adapters/codex.go
+++ b/packages/adapter/adapters/codex.go
@@ -77,6 +77,11 @@ func (c *Codex) Match(cmd []string) bool {
 // Env returns no extra environment variables.
 func (c *Codex) Env(_ adapter.EnvContext) []string { return nil }
 
+// SupportsACPDrive reports that the Codex harness has an ACP drive mode
+// (ADR 0033): semantic control is delivered by the ACP runner, so terminal
+// refusals name the mode boundary rather than a missing capability.
+func (c *Codex) SupportsACPDrive() bool { return true }
+
 func (c *Codex) Launchers() []adapter.Launcher {
 	return []adapter.Launcher{{
 		ID:          "codex",

--- a/packages/adapter/drivemode.go
+++ b/packages/adapter/drivemode.go
@@ -1,0 +1,47 @@
+package adapter
+
+// Drive modes (ADR 0033). A session's identity is its harness (adapter) plus
+// its gmux session id; the drive mode is how gmux hosts and drives that
+// harness. Capabilities attach to the (harness, mode) pair, never to the
+// adapter name alone.
+const (
+	// DriveModeTerminal is the existing PTY session: attachable,
+	// raw-sendable, tailable. Semantic control requires the ADR 0027
+	// contract to be source-asserted, which only pi's in-repo extension
+	// does.
+	DriveModeTerminal = "terminal"
+	// DriveModeACP is a runner speaking the Agent Client Protocol to a
+	// terminal-less agent process. No PTY exists; there is no screen to
+	// tail and nothing to attach to.
+	DriveModeACP = "acp"
+)
+
+// ValidDriveMode reports whether s names a known drive mode. The empty
+// string is not valid: callers that accept older wire payloads normalize
+// absence to DriveModeTerminal themselves, at the boundary where the
+// payload's age is known.
+func ValidDriveMode(s string) bool {
+	return s == DriveModeTerminal || s == DriveModeACP
+}
+
+// ACPDrivable marks adapters whose harness has an ACP drive mode
+// (ADR 0033 §1) — today claude and codex, whose first-party ACP adapters
+// the contract spike verified.
+//
+// Slice-0 consumer: refusal wording. A semantic verb against a
+// terminal-mode session of an ACP-drivable harness names the mode boundary
+// ("interactive-only; semantic control requires ACP mode") instead of the
+// generic "no semantic agent actions", because for these harnesses a
+// correct mode exists. The full "how to drive this harness via ACP" seam
+// (adapter process, initialize expectations, native-storage ref mapping)
+// lands with the ACP runner and will extend this interface.
+type ACPDrivable interface {
+	// SupportsACPDrive reports that the harness can be driven in ACP mode.
+	SupportsACPDrive() bool
+}
+
+// SupportsACPDrive reports whether a's harness has an ACP drive mode.
+func SupportsACPDrive(a Adapter) bool {
+	d, ok := a.(ACPDrivable)
+	return ok && d.SupportsACPDrive()
+}

--- a/packages/protocol/src/session.ts
+++ b/packages/protocol/src/session.ts
@@ -17,6 +17,10 @@ export const SessionSchema = z.object({
   workspace_root: z.string().optional(),
   remotes: z.record(z.string()).optional(),
   adapter: z.string().default('shell'),
+  // Drive mode (ADR 0033): how gmux hosts this harness. Absent on the
+  // wire means terminal (the pre-mode shape); 'acp' sessions have no PTY
+  // and render the conversation view instead of a terminal.
+  drive_mode: z.enum(['terminal', 'acp']).optional().default('terminal'),
   // Session this one was spawned from (e.g. `gmux edit` invoked as
   // $EDITOR inside an existing session). The UI places the child
   // directly under its parent in the sidebar.

--- a/services/gmuxd/cmd/gmuxd/agent_actions.go
+++ b/services/gmuxd/cmd/gmuxd/agent_actions.go
@@ -365,6 +365,14 @@ func handleAgentPromptCentral(w http.ResponseWriter, r *http.Request, deps agent
 		writeError(w, http.StatusNotFound, "not_found", "session not found")
 		return
 	}
+	// The (adapter, drive mode) capability boundary is checked before
+	// residency, readiness, and activity (ADR 0033 §3): it is the one
+	// permanent-shaped refusal, and checking it here keeps transparent
+	// resume from spawning an interactive session just to be refused.
+	if status, code, msg := semanticModeGate(row, req.Mode); status != 0 {
+		writeError(w, status, code, msg)
+		return
+	}
 	runtime, live := deps.live(sid)
 	resumed := false
 	if !live {
@@ -578,13 +586,19 @@ func handleAgentCancelCentral(w http.ResponseWriter, r *http.Request, deps agent
 	// A store failure is not a missing session: reporting 404 for a broken read
 	// would tell the caller their session is gone on the strength of a database
 	// error.
-	_, found, err := deps.store.Session(r.Context(), sid)
+	row, found, err := deps.store.Session(r.Context(), sid)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal", err.Error())
 		return
 	}
 	if !found {
 		writeError(w, http.StatusNotFound, "not_found", "session not found")
+		return
+	}
+	// Capability before residency/activity (ADR 0033 §3): "this mode cannot
+	// cancel" is permanent-shaped; "no turn to cancel" is transient.
+	if status, code, msg := semanticModeGate(row, opCancel); status != 0 {
+		writeError(w, status, code, msg)
 		return
 	}
 	runtime, live := deps.live(sid)

--- a/services/gmuxd/cmd/gmuxd/agent_mode_gate.go
+++ b/services/gmuxd/cmd/gmuxd/agent_mode_gate.go
@@ -1,0 +1,101 @@
+package main
+
+// agent_mode_gate.go — the ADR 0033 capability boundary for semantic agent
+// actions, checked at the daemon BEFORE residency, readiness, or activity.
+//
+// "This session in this mode cannot do that" is a permanent-shaped fact:
+// unlike a dead runner or a busy agent, no retry and no resume changes it.
+// Checking it first also keeps transparent resume honest — without this
+// gate, prompting a dead terminal claude session would spawn a real Claude
+// TUI just to be refused by its runner one round-trip later.
+//
+// The runner keeps its own capability refusal (unsupported_adapter) as
+// defense in depth; this gate exists so the refusal happens before any
+// side effect and can name the mode boundary, which only the daemon —
+// holding the session row's drive mode — can word correctly.
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/gmuxapp/gmux/packages/adapter"
+	"github.com/gmuxapp/gmux/packages/adapter/adapters"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/centralstore"
+)
+
+// codeUnsupportedMode is the ADR 0033 §3 refusal: the harness has semantic
+// support, but not in this session's drive mode. It is a sibling of
+// unsupported_adapter (same 422, same permanent shape, checked in the same
+// position); it is a distinct code because the message names a mode
+// boundary, not a missing capability, and the CLI must not append the
+// generic "no semantic support yet" hint to a boundary that is — for
+// steer — permanent by design.
+const codeUnsupportedMode = "unsupported_mode"
+
+// codeNoTerminal is the inverse boundary: a PTY surface (raw input, the
+// terminal WebSocket, scrollback/tail) addressed at an ACP-mode session,
+// where no terminal exists at all (ADR 0033: "n/a", not "refused"). The
+// message names the surfaces that do exist — the conversation view,
+// gmux agent prompt, gmux agent logs.
+const codeNoTerminal = "no_terminal"
+
+// agentActionSteer distinguishes the permanently-refused steer wording from
+// the convertible prompt/follow-up/cancel wording. Cancel reuses the
+// non-steer message: like prompt, it gains a correct home in ACP mode.
+func steerAction(mode string) bool { return mode == modeSteer }
+
+// semanticModeGate is the production gate: adapter lookup by the row's
+// recorded name, verdict from the pure refusal function below.
+func semanticModeGate(row centralstore.Session, action string) (int, string, string) {
+	return semanticModeRefusal(adapters.FindByAdapter(row.Adapter), row.Adapter, row.DriveMode, action)
+}
+
+// semanticModeRefusal reports why a semantic action against a session of
+// this (adapter, drive mode) pair is refused, as (status, code, message),
+// or a zero status when the action may proceed to delivery.
+//
+//   - An unknown adapter name defers, in either mode: the daemon must not
+//     invent a capability verdict for an adapter it cannot see; the runner
+//     refuses (or, pre-ACP-runner, fails loudly as outdated).
+//   - ACP mode passes only for harnesses that HAVE an ACP drive mode
+//     (claude, codex): capabilities attach to the (harness, mode) pair,
+//     so a known pair like (pi, acp) or (shell, acp) — which nothing can
+//     legitimately register today — is refused explicitly rather than
+//     granted semantic delivery by mode alone.
+//   - Terminal mode with an AgentActionEncoder (pi) passes.
+//   - Terminal mode of an ACP-drivable harness (claude, codex) is refused
+//     naming the mode boundary (ADR 0033 §3): steer permanently, the rest
+//     until explicit mode conversion exists.
+//   - Everything else (shell, editors) is refused with the adapter-level
+//     message the runner would also give.
+func semanticModeRefusal(a adapter.Adapter, name, driveMode, action string) (status int, code, msg string) {
+	if a == nil {
+		return 0, "", ""
+	}
+	if driveMode == centralstore.DriveModeACP {
+		if adapter.SupportsACPDrive(a) {
+			return 0, "", ""
+		}
+		return http.StatusUnprocessableEntity, codeUnsupportedMode, fmt.Sprintf(
+			"%s has no ACP drive mode; this session's recorded mode does not exist for its harness, so semantic actions are refused rather than guessed at",
+			name)
+	}
+	if _, ok := a.(adapter.AgentActionEncoder); ok {
+		return 0, "", ""
+	}
+	if adapter.SupportsACPDrive(a) {
+		if steerAction(action) {
+			return http.StatusUnprocessableEntity, codeUnsupportedMode, fmt.Sprintf(
+				"%s terminal sessions are interactive-only, and steering a foreign terminal is permanently unsupported: a mid-turn dialog can change what keystrokes mean. Use gmux attach to intervene by hand; ACP-mode %s sessions steer as a first-class request",
+				name, name)
+		}
+		return http.StatusUnprocessableEntity, codeUnsupportedMode, fmt.Sprintf(
+			"%s terminal sessions are interactive-only; semantic control requires the session in ACP mode. Use gmux send / gmux tail to drive this session, or gmux attach to take over",
+			name)
+	}
+	// Mirrors the runner's unsupported_adapter refusal
+	// (cli/gmux/internal/ptyserver/actions.go) so callers see one code for
+	// one fact regardless of which layer answered first.
+	return http.StatusUnprocessableEntity, codeUnsupportedAdapter, fmt.Sprintf(
+		"adapter %s has no semantic agent actions; use raw input instead", name)
+}

--- a/services/gmuxd/cmd/gmuxd/agent_mode_gate_test.go
+++ b/services/gmuxd/cmd/gmuxd/agent_mode_gate_test.go
@@ -1,0 +1,270 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gmuxapp/gmux/packages/adapter/adapters"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/centralstore"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/sessioncoord"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/sessionmeta"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/snapshot/wire"
+)
+
+// The pure verdict table: which (adapter, drive mode, action) pairs pass to
+// delivery and which are refused with which code. Adapters are looked up by
+// name through the production path so the table breaks if an adapter's
+// capability set changes underneath it.
+func TestSemanticModeRefusalTable(t *testing.T) {
+	tests := []struct {
+		name       string
+		adapter    string
+		driveMode  string
+		action     string
+		wantStatus int
+		wantCode   string
+		wantIn     string
+	}{
+		{"pi terminal prompt passes", "pi", "terminal", modePrompt, 0, "", ""},
+		{"pi terminal steer passes", "pi", "terminal", modeSteer, 0, "", ""},
+		{"claude terminal prompt refused at the mode boundary", "claude", "terminal", modePrompt,
+			http.StatusUnprocessableEntity, codeUnsupportedMode, "interactive-only; semantic control requires the session in ACP mode"},
+		{"claude terminal follow-up refused at the mode boundary", "claude", "terminal", modeFollowUp,
+			http.StatusUnprocessableEntity, codeUnsupportedMode, "gmux send / gmux tail"},
+		{"claude terminal steer refused permanently", "claude", "terminal", modeSteer,
+			http.StatusUnprocessableEntity, codeUnsupportedMode, "permanently unsupported"},
+		{"claude terminal cancel refused at the mode boundary", "claude", "terminal", opCancel,
+			http.StatusUnprocessableEntity, codeUnsupportedMode, "interactive-only"},
+		{"codex terminal steer refused permanently", "codex", "terminal", modeSteer,
+			http.StatusUnprocessableEntity, codeUnsupportedMode, "permanently unsupported"},
+		{"codex terminal prompt refused at the mode boundary", "codex", "terminal", modePrompt,
+			http.StatusUnprocessableEntity, codeUnsupportedMode, "ACP mode"},
+		{"shell terminal prompt refused as unsupported adapter", "shell", "terminal", modePrompt,
+			http.StatusUnprocessableEntity, codeUnsupportedAdapter, "no semantic agent actions"},
+		// ACP mode passes only for harnesses that HAVE an ACP drive mode:
+		// their runner owns the semantic verbs.
+		{"claude acp prompt passes", "claude", "acp", modePrompt, 0, "", ""},
+		{"claude acp steer passes", "claude", "acp", modeSteer, 0, "", ""},
+		{"codex acp cancel passes", "codex", "acp", opCancel, 0, "", ""},
+		// A known (harness, acp) pair whose harness has no ACP mode is a
+		// contradiction, refused explicitly — mode alone grants nothing.
+		{"pi acp prompt refused", "pi", "acp", modePrompt,
+			http.StatusUnprocessableEntity, codeUnsupportedMode, "no ACP drive mode"},
+		{"pi acp steer refused", "pi", "acp", modeSteer,
+			http.StatusUnprocessableEntity, codeUnsupportedMode, "no ACP drive mode"},
+		{"shell acp prompt refused", "shell", "acp", modePrompt,
+			http.StatusUnprocessableEntity, codeUnsupportedMode, "no ACP drive mode"},
+		// Unknown adapters defer in either mode: the daemon must not invent
+		// a verdict for an adapter it cannot see.
+		{"unknown adapter passes to the runner", "mystery", "terminal", modePrompt, 0, "", ""},
+		{"unknown adapter defers in acp mode too", "mystery", "acp", modePrompt, 0, "", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			status, code, msg := semanticModeRefusal(adapters.FindByAdapter(tc.adapter), tc.adapter, tc.driveMode, tc.action)
+			if status != tc.wantStatus || code != tc.wantCode {
+				t.Fatalf("verdict = (%d, %q, %q), want (%d, %q)", status, code, msg, tc.wantStatus, tc.wantCode)
+			}
+			if tc.wantIn != "" && !strings.Contains(msg, tc.wantIn) {
+				t.Fatalf("message %q missing %q", msg, tc.wantIn)
+			}
+			if status != 0 && !strings.Contains(msg, tc.adapter) {
+				t.Fatalf("message %q does not name the harness %q", msg, tc.adapter)
+			}
+		})
+	}
+}
+
+// The boundary is checked BEFORE residency (ADR 0033 §3): a prompt against a
+// dead terminal claude session must be refused without resuming — without
+// the gate, transparent resume would spawn a real interactive Claude TUI
+// just to be refused by its runner one round-trip later.
+func TestPromptTerminalClaudeRefusedBeforeResume(t *testing.T) {
+	exited := centralstore.UnixMillis(2)
+	h := newAgentHarness(t, centralstore.NewSession{
+		ID: "c", Adapter: "claude", CWD: "/", Command: []string{"claude"}, ExitedAt: &exited,
+	})
+	h.setLive(func(centralstore.SessionID) (sessioncoord.Runtime, bool) { return sessioncoord.Runtime{}, false })
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/sessions/c/prompt",
+		strings.NewReader(`{"prompt":"hi","mode":"prompt"}`))
+	req.Header.Set("Content-Type", "application/json")
+	handleAgentPromptCentral(rec, req, h.deps(), "c")
+
+	got := parseRecorded(t, rec)
+	if got.code != http.StatusUnprocessableEntity || got.errCode() != codeUnsupportedMode {
+		t.Fatalf("code=%d body=%v, want 422/%s", got.code, got.body, codeUnsupportedMode)
+	}
+	select {
+	case id := <-h.resumes:
+		t.Fatalf("refusal resumed session %s; the capability boundary must precede residency", id)
+	default:
+	}
+	if h.subs.Load() != 0 {
+		t.Fatal("refusal subscribed to outcomes; the boundary must precede the delivery machinery")
+	}
+}
+
+// Cancel against a live terminal codex session is refused at the same
+// boundary, before the runner is consulted at all.
+func TestCancelTerminalCodexRefusedAtModeBoundary(t *testing.T) {
+	h := newAgentHarness(t, centralstore.NewSession{
+		ID: "x", Adapter: "codex", CWD: "/", Command: []string{"codex"},
+	})
+	rec := httptest.NewRecorder()
+	handleAgentCancelCentral(rec, httptest.NewRequest(http.MethodPost, "/v1/sessions/x/cancel", nil), h.deps(), "x")
+	got := parseRecorded(t, rec)
+	if got.code != http.StatusUnprocessableEntity || got.errCode() != codeUnsupportedMode {
+		t.Fatalf("code=%d body=%v, want 422/%s", got.code, got.body, codeUnsupportedMode)
+	}
+	select {
+	case ep := <-h.cancels:
+		t.Fatalf("refusal reached the runner at %s", ep)
+	case <-time.After(10 * time.Millisecond):
+	}
+}
+
+// PTY surfaces against an ACP-mode session answer no_terminal, naming the
+// surfaces that do exist. These sessions have no PTY at all (ADR 0033:
+// "n/a", not "refused"), so raw input, attach, and scrollback must not
+// reach a runner or a broker.
+func TestPTYSurfacesRefusedOnACPSession(t *testing.T) {
+	ctx := context.Background()
+	st, err := centralstore.Open(ctx, t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	if _, _, err := st.InsertSession(ctx, centralstore.NewSession{
+		ID: "a1", Adapter: "claude", DriveMode: "acp", CWD: "/", Command: []string{}, CreatedAt: 1,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	boot := &Bootstrap{Store: st, Registry: sessioncoord.NewRegistry()}
+	fanout := newSSEFanout()
+	dirs := sessionmeta.New(t.TempDir())
+
+	for _, tc := range []struct {
+		name string
+		req  *http.Request
+		want string // substring naming the working surface
+	}{
+		{"input", httptest.NewRequest(http.MethodPost, "/v1/sessions/a1/input", strings.NewReader("keys")), "gmux agent prompt"},
+		{"attach", httptest.NewRequest(http.MethodPost, "/v1/sessions/a1/attach", nil), "conversation"},
+		{"scrollback", httptest.NewRequest(http.MethodGet, "/v1/sessions/a1/scrollback", nil), "gmux agent logs"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			handleCentralSessionAction(rec, tc.req, boot, fanout, &wire.Converter{}, nil, dirs, "/usr/bin/gmux")
+			got := parseRecorded(t, rec)
+			if got.code != http.StatusUnprocessableEntity || got.errCode() != codeNoTerminal {
+				t.Fatalf("code=%d body=%v, want 422/%s", got.code, got.body, codeNoTerminal)
+			}
+			if msg := got.errMessage(); !strings.Contains(msg, "ACP session") || !strings.Contains(msg, tc.want) {
+				t.Fatalf("message %q must name the boundary and point at %q", msg, tc.want)
+			}
+		})
+	}
+}
+
+// /ws/{id} regression: the terminal-WebSocket backend must be refused for an
+// ACP session from the AUTHORITATIVE store, even when the composed fanout
+// snapshot is empty/stale and the live registry holds an endpoint —
+// exactly the state immediately after an ACP registration. The old
+// snapshot-only check fell through to the registry and attempted a
+// terminal proxy against a runner that has no PTY.
+func TestTerminalWSEndpointRefusesACPSessionFromStore(t *testing.T) {
+	ctx := context.Background()
+	st, err := centralstore.Open(ctx, t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	sock := filepath.Join(t.TempDir(), "acp-runner.sock")
+	runners := &bootstrapRunners{
+		metas: map[string]sessioncoord.RunnerMeta{sock: {PID: 77, Incarnation: "inc-acp", Registration: centralstore.RunnerRegistration{
+			ID: "w1acp000", Adapter: "claude", DriveMode: "acp", Alive: true, CreatedAt: 1, ObservedAt: 1,
+		}}},
+		blocked: map[string]bool{},
+	}
+	reg := sessioncoord.NewRegistry()
+	coord := sessioncoord.New(reg, runners, st, nil, nil)
+	t.Cleanup(coord.Close)
+	if _, err := coord.Register(ctx, sessioncoord.RegisterRequest{Endpoint: sock}); err != nil {
+		t.Fatal(err)
+	}
+	if _, live := registryRuntime(reg, "w1acp000"); !live {
+		t.Fatal("test premise broken: registry must hold a live endpoint")
+	}
+
+	// Empty fanout: the snapshot has not composed this session yet.
+	endpoint, err := terminalWSEndpoint(ctx, st, reg, newSSEFanout(), "w1acp000")
+	if err == nil || endpoint != "" {
+		t.Fatalf("resolved %q, %v; want ACP refusal", endpoint, err)
+	}
+	if !strings.Contains(err.Error(), "ACP session") {
+		t.Fatalf("error %q must name the ACP boundary", err)
+	}
+
+	// A terminal session with a live endpoint still resolves.
+	sock2 := filepath.Join(t.TempDir(), "pty-runner.sock")
+	runners.metas[sock2] = sessioncoord.RunnerMeta{PID: 78, Incarnation: "inc-pty", Registration: centralstore.RunnerRegistration{
+		ID: "w2pty000", Adapter: "pi", Alive: true, CreatedAt: 1, ObservedAt: 1,
+	}}
+	if _, err := coord.Register(ctx, sessioncoord.RegisterRequest{Endpoint: sock2}); err != nil {
+		t.Fatal(err)
+	}
+	endpoint, err = terminalWSEndpoint(ctx, st, reg, newSSEFanout(), "w2pty000")
+	if err != nil || endpoint != sock2 {
+		t.Fatalf("resolved %q, %v; want %q", endpoint, err, sock2)
+	}
+}
+
+// A store failure must refuse the terminal-WS backend conservatively: no
+// endpoint may be resolved when the session's mode cannot be established.
+func TestTerminalWSEndpointRefusesOnStoreFailure(t *testing.T) {
+	ctx := context.Background()
+	st, err := centralstore.Open(ctx, t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = st.Close() // every read now fails
+	endpoint, err := terminalWSEndpoint(ctx, st, sessioncoord.NewRegistry(), newSSEFanout(), "s1")
+	if err == nil || endpoint != "" {
+		t.Fatalf("resolved %q, %v; want conservative refusal", endpoint, err)
+	}
+	if !strings.Contains(err.Error(), "could not be verified") {
+		t.Fatalf("error %q must state the mode could not be verified", err)
+	}
+}
+
+// Raw input must not proceed to a live endpoint when the store cannot
+// establish the session's mode: a store failure is an internal error, not a
+// bypass of the safety boundary.
+func TestInputRefusesOnStoreFailure(t *testing.T) {
+	ctx := context.Background()
+	st, err := centralstore.Open(ctx, t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := st.InsertSession(ctx, centralstore.NewSession{
+		ID: "b1", Adapter: "claude", DriveMode: "acp", CWD: "/", Command: []string{}, CreatedAt: 1,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	_ = st.Close() // every read now fails
+	boot := &Bootstrap{Store: st, Registry: sessioncoord.NewRegistry()}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/sessions/b1/input", strings.NewReader("keys"))
+	handleCentralSessionAction(rec, req, boot, newSSEFanout(), &wire.Converter{}, nil, sessionmeta.New(t.TempDir()), "/usr/bin/gmux")
+	got := parseRecorded(t, rec)
+	if got.code != http.StatusInternalServerError || got.errCode() != "internal" {
+		t.Fatalf("code=%d body=%v, want 500/internal", got.code, got.body)
+	}
+}

--- a/services/gmuxd/cmd/gmuxd/bootstrap_runner_adapters.go
+++ b/services/gmuxd/cmd/gmuxd/bootstrap_runner_adapters.go
@@ -261,7 +261,7 @@ func (productionRunnerClient) Meta(ctx context.Context, endpoint string) (sessio
 	if s.ID == "" || s.Adapter == "" {
 		return sessioncoord.RunnerMeta{}, fmt.Errorf("runner /meta: missing id or adapter")
 	}
-	reg := centralstore.RunnerRegistration{ID: centralstore.SessionID(s.ID), Adapter: s.Adapter, Alive: s.Alive, CreatedAt: parseMillis(s.CreatedAt), ObservedAt: centralstore.UnixMillis(time.Now().UnixMilli())}
+	reg := centralstore.RunnerRegistration{ID: centralstore.SessionID(s.ID), Adapter: s.Adapter, DriveMode: s.DriveMode, Alive: s.Alive, CreatedAt: parseMillis(s.CreatedAt), ObservedAt: centralstore.UnixMillis(time.Now().UnixMilli())}
 	if s.ParentSessionID != "" {
 		parent := centralstore.SessionID(s.ParentSessionID)
 		reg.LaunchParentID = &parent
@@ -286,6 +286,7 @@ type runnerMetaWire struct {
 	ID              string            `json:"id"`
 	Incarnation     string            `json:"incarnation"`
 	Adapter         string            `json:"adapter"`
+	DriveMode       string            `json:"drive_mode"` // empty (older runner) = terminal
 	Kind            string            `json:"kind"`
 	Alive           bool              `json:"alive"`
 	CreatedAt       string            `json:"created_at"`

--- a/services/gmuxd/cmd/gmuxd/central_helpers.go
+++ b/services/gmuxd/cmd/gmuxd/central_helpers.go
@@ -417,6 +417,32 @@ func registryRuntime(reg *sessioncoord.Registry, id centralstore.SessionID) (ses
 	return sessioncoord.Runtime{}, false
 }
 
+// terminalWSEndpoint resolves the runner backend for the terminal
+// WebSocket (/ws/{id}). The drive-mode boundary is answered from the
+// AUTHORITATIVE store, not the composed fanout snapshot: immediately after
+// an ACP registration the snapshot can lag (or be empty), and falling
+// through to the live registry endpoint would attempt a terminal proxy
+// against a runner that has no PTY (ADR 0033). A store failure refuses
+// conservatively: a backend must not be resolved when the session's mode
+// cannot be established.
+func terminalWSEndpoint(ctx context.Context, st *centralstore.Store, reg *sessioncoord.Registry, fanout *sseFanout, sessionID string) (string, error) {
+	sid := centralstore.SessionID(sessionID)
+	row, found, err := st.Session(ctx, sid)
+	if err != nil {
+		return "", fmt.Errorf("session %s drive mode could not be verified: %v", sessionID, err)
+	}
+	if found && row.DriveMode == centralstore.DriveModeACP {
+		return "", fmt.Errorf("session %s is an ACP session; there is no terminal to attach", sessionID)
+	}
+	if e, ok := registryRuntime(reg, sid); ok {
+		return e.Endpoint, nil
+	}
+	if _, ok := visibleSession(fanout.Current().Sessions, sessionID); ok {
+		return "", fmt.Errorf("session %s has no socket", sessionID)
+	}
+	return "", fmt.Errorf("session %s not found", sessionID)
+}
+
 func sessionTreeRows(ctx context.Context, st *centralstore.Store, root centralstore.SessionID) ([]centralstore.Session, error) {
 	rows, err := st.ListSessions(ctx)
 	if err != nil {
@@ -493,6 +519,9 @@ func wireSessionFromStore(row centralstore.Session, reg *sessioncoord.Registry) 
 		ID:        string(row.ID),
 		CreatedAt: fmtMillis(row.CreatedAt),
 		Adapter:   row.Adapter,
+	}
+	if row.DriveMode != centralstore.DriveModeTerminal {
+		out.DriveMode = row.DriveMode
 	}
 	if row.TerminalCols != nil {
 		out.TerminalCols = *row.TerminalCols

--- a/services/gmuxd/cmd/gmuxd/production_spawner_test.go
+++ b/services/gmuxd/cmd/gmuxd/production_spawner_test.go
@@ -19,7 +19,7 @@ import (
 func TestRunnerMetaWireJSONFieldTable(t *testing.T) {
 	want := []struct{ field, tag string }{
 		{"ID", "id"}, {"Incarnation", "incarnation"},
-		{"Adapter", "adapter"}, {"Kind", "kind"},
+		{"Adapter", "adapter"}, {"DriveMode", "drive_mode"}, {"Kind", "kind"},
 		{"Alive", "alive"}, {"CreatedAt", "created_at"},
 		{"StartedAt", "started_at"}, {"ExitCode", "exit_code"},
 		{"ExitedAt", "exited_at"}, {"PID", "pid"},
@@ -41,7 +41,7 @@ func TestRunnerMetaWireJSONFieldTable(t *testing.T) {
 			t.Errorf("field[%d]=%s json:%q, want %s json:%q", i, field.Name, field.Tag.Get("json"), entry.field, entry.tag)
 		}
 	}
-	status := typeOf.Field(22).Type.Elem()
+	status := typeOf.Field(23).Type.Elem()
 	if status.NumField() != 3 ||
 		status.Field(0).Name != "Active" || status.Field(0).Tag.Get("json") != "active" ||
 		status.Field(1).Name != "Error" || status.Field(1).Tag.Get("json") != "error" ||

--- a/services/gmuxd/cmd/gmuxd/serve_central.go
+++ b/services/gmuxd/cmd/gmuxd/serve_central.go
@@ -778,13 +778,7 @@ func serveCentral(stderr io.Writer, replace bool) int {
 				}
 			}
 			proxy := wsproxy.New(func(sessionID string) (string, error) {
-				if e, ok := registryRuntime(boot.Registry, centralstore.SessionID(sessionID)); ok {
-					return e.Endpoint, nil
-				}
-				if _, ok := visibleSession(fanout.Current().Sessions, sessionID); ok {
-					return "", fmt.Errorf("session %s has no socket", sessionID)
-				}
-				return "", fmt.Errorf("session %s not found", sessionID)
+				return terminalWSEndpoint(r.Context(), boot.Store, boot.Registry, fanout, sessionID)
 			}, centralSizer{fanout: fanout})
 			proxy.Handler()(w, r)
 		})
@@ -1058,8 +1052,14 @@ func handleCentralSessionAction(w http.ResponseWriter, r *http.Request, boot *Bo
 			return
 		}
 		// Store-direct existence check (ADR 0026 §2a).
-		if _, found, err := boot.Store.Session(r.Context(), sid); err != nil || !found {
+		row, found, err := boot.Store.Session(r.Context(), sid)
+		if err != nil || !found {
 			writeError(w, http.StatusNotFound, "not_found", "session not found")
+			return
+		}
+		if row.DriveMode == centralstore.DriveModeACP {
+			writeError(w, http.StatusUnprocessableEntity, codeNoTerminal,
+				"this is an ACP session; there is no terminal to attach. The web view renders the conversation, and gmux agent prompt drives it")
 			return
 		}
 		socketPath := ""
@@ -1154,6 +1154,20 @@ func handleCentralSessionAction(w http.ResponseWriter, r *http.Request, boot *Bo
 			writeError(w, http.StatusMethodNotAllowed, "bad_request", "method not allowed")
 			return
 		}
+		// Store-direct mode check (ADR 0033): an ACP session has no PTY to
+		// write into, and that fact must not depend on snapshot freshness.
+		// A store failure refuses rather than proceeds: bytes must not reach
+		// a live endpoint whose mode could not be established.
+		row, found, storeErr := boot.Store.Session(r.Context(), sid)
+		if storeErr != nil {
+			writeError(w, http.StatusInternalServerError, "internal", storeErr.Error())
+			return
+		}
+		if found && row.DriveMode == centralstore.DriveModeACP {
+			writeError(w, http.StatusUnprocessableEntity, codeNoTerminal,
+				"this is an ACP session; there is no terminal to type into. Use gmux agent prompt to drive it")
+			return
+		}
 		runtime, live := registryRuntime(boot.Registry, sid)
 		if !live {
 			writeError(w, http.StatusConflict, "not_running", "session is not running")
@@ -1186,6 +1200,11 @@ func handleCentralSessionAction(w http.ResponseWriter, r *http.Request, boot *Bo
 				ok = true
 				sess = wireSessionFromStore(row, boot.Registry)
 			}
+		}
+		if ok && sess.DriveMode == centralstore.DriveModeACP {
+			writeError(w, http.StatusUnprocessableEntity, codeNoTerminal,
+				"this is an ACP session; there is no terminal screen. Use gmux agent logs to read the conversation")
+			return
 		}
 		scrollbackBrokerHandlerCentral(w, r, sessionID, sess, ok, sessionDirs.SessionDir)
 	case "conversation":

--- a/services/gmuxd/internal/centralstore/admin_test.go
+++ b/services/gmuxd/internal/centralstore/admin_test.go
@@ -84,8 +84,8 @@ func TestEmbeddedSchemaVersionMatchesOpenedDatabase(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if head != got || head != 1 {
-		t.Fatalf("embedded head %d vs opened %d; want release baseline 1", head, got)
+	if head != got || head != 2 {
+		t.Fatalf("embedded head %d vs opened %d; want schema head 2 (v2: drive_mode)", head, got)
 	}
 }
 

--- a/services/gmuxd/internal/centralstore/domain.go
+++ b/services/gmuxd/internal/centralstore/domain.go
@@ -22,10 +22,22 @@ type SessionID string
 type ProjectEntryID int64
 type PeerKey string
 
+// Drive modes (ADR 0033). Mirrored from packages/adapter rather than
+// imported: centralstore is a leaf persistence package and the mode names
+// are a wire/schema contract, exactly like the status booleans.
+const (
+	DriveModeTerminal = "terminal"
+	DriveModeACP      = "acp"
+)
+
 type Session struct {
-	ID                                                        SessionID
-	Version                                                   RowVersion
-	Adapter, ConversationRef                                  string
+	ID                       SessionID
+	Version                  RowVersion
+	Adapter, ConversationRef string
+	// DriveMode is how gmux hosts this harness (ADR 0033): "terminal" or
+	// "acp". Durable because a retained session resumes in the mode it was
+	// registered in; capability checks key on the (Adapter, DriveMode) pair.
+	DriveMode                                                 string
 	Command                                                   []string
 	CWD, WorkspaceRoot                                        string
 	Remotes                                                   map[string]string
@@ -51,8 +63,10 @@ type Session struct {
 // NewSession contains only facts legal at registration. New registrations are
 // always visible, unpromoted, and start at row version one.
 type NewSession struct {
-	ID                                       SessionID
-	Adapter, ConversationRef                 string
+	ID                       SessionID
+	Adapter, ConversationRef string
+	// DriveMode defaults to terminal when empty (older callers).
+	DriveMode                                string
 	Command                                  []string
 	CWD, WorkspaceRoot                       string
 	Remotes                                  map[string]string
@@ -217,6 +231,25 @@ func validateTerminal(cols, rows *uint16) error {
 	}
 	return nil
 }
+
+// validateDriveMode accepts a known drive mode or empty (normalized to
+// terminal at insert). An unknown mode is refused rather than defaulted: a
+// caller naming a mode this store does not understand must be told, not
+// silently registered as a terminal session.
+func validateDriveMode(s string) error {
+	if s == "" || s == DriveModeTerminal || s == DriveModeACP {
+		return nil
+	}
+	return fmt.Errorf("centralstore: unknown drive mode %q", s)
+}
+
+func normalizeDriveMode(s string) string {
+	if s == "" {
+		return DriveModeTerminal
+	}
+	return s
+}
+
 func validateExitLifecycle(exitedAt *UnixMillis, exitCode *int) error {
 	if exitCode != nil && exitedAt == nil {
 		return errors.New("centralstore: exit code requires exited timestamp")
@@ -226,6 +259,9 @@ func validateExitLifecycle(exitedAt *UnixMillis, exitCode *int) error {
 func validateNewSession(v NewSession) error {
 	if v.ID == "" || v.Adapter == "" {
 		return errors.New("centralstore: session id and adapter required")
+	}
+	if err := validateDriveMode(v.DriveMode); err != nil {
+		return err
 	}
 	if v.CreatedAt < 0 {
 		return errors.New("centralstore: created timestamp must be non-negative")
@@ -263,7 +299,7 @@ func marshalWhole(command []string, remotes map[string]string) (string, string, 
 }
 
 func sessionFromDB(v db.LocalSession) (Session, error) {
-	out := Session{ID: SessionID(v.ID), Version: RowVersion(v.RowVersion), Adapter: v.Adapter, ConversationRef: v.ConversationRef.String, CWD: v.Cwd, WorkspaceRoot: v.WorkspaceRoot.String, Slug: v.Slug.String, SlugBase: v.SlugBase.String, ShellTitle: v.ShellTitle.String, AdapterTitle: v.AdapterTitle.String, Subtitle: v.Subtitle.String, CreatedAt: UnixMillis(v.CreatedAtMs)}
+	out := Session{ID: SessionID(v.ID), Version: RowVersion(v.RowVersion), Adapter: v.Adapter, DriveMode: v.DriveMode, ConversationRef: v.ConversationRef.String, CWD: v.Cwd, WorkspaceRoot: v.WorkspaceRoot.String, Slug: v.Slug.String, SlugBase: v.SlugBase.String, ShellTitle: v.ShellTitle.String, AdapterTitle: v.AdapterTitle.String, Subtitle: v.Subtitle.String, CreatedAt: UnixMillis(v.CreatedAtMs)}
 	if v.RowVersion < 1 || v.CreatedAtMs < 0 {
 		return Session{}, errors.New("centralstore: corrupt session numeric value")
 	}
@@ -376,7 +412,7 @@ func (s *Store) InsertSession(ctx context.Context, v NewSession) (Session, Mutat
 		return Session{}, MutationResult{}, err
 	}
 	v.SlugBase, v.Slug = candidate.SlugBase, candidate.Slug
-	row, err := q.InsertSession(ctx, db.InsertSessionParams{ID: string(v.ID), Adapter: v.Adapter, ConversationRef: nullString(v.ConversationRef), CommandJson: cmd, Cwd: v.CWD, WorkspaceRoot: nullString(v.WorkspaceRoot), RemotesJson: rem, Slug: nullString(v.Slug), SlugBase: nullString(v.SlugBase), ShellTitle: nullString(v.ShellTitle), AdapterTitle: nullString(v.AdapterTitle), Subtitle: nullString(v.Subtitle), Active: boolInt(v.Active), Interrupted: boolInt(v.Interrupted), Unread: boolInt(v.Unread), HasError: boolInt(v.Error), StatusReported: boolInt(v.StatusReported || v.Active || v.Error || v.Interrupted), CreatedAtMs: int64(v.CreatedAt), StartedAtMs: nullMillis(v.StartedAt), ExitedAtMs: nullMillis(v.ExitedAt), LastActivityAtMs: nullMillis(v.LastActivityAt), ExitCode: nullInt(v.ExitCode), TerminalCols: nullUint(v.TerminalCols), TerminalRows: nullUint(v.TerminalRows), LaunchParentID: func() sql.NullString {
+	row, err := q.InsertSession(ctx, db.InsertSessionParams{ID: string(v.ID), Adapter: v.Adapter, DriveMode: normalizeDriveMode(v.DriveMode), ConversationRef: nullString(v.ConversationRef), CommandJson: cmd, Cwd: v.CWD, WorkspaceRoot: nullString(v.WorkspaceRoot), RemotesJson: rem, Slug: nullString(v.Slug), SlugBase: nullString(v.SlugBase), ShellTitle: nullString(v.ShellTitle), AdapterTitle: nullString(v.AdapterTitle), Subtitle: nullString(v.Subtitle), Active: boolInt(v.Active), Interrupted: boolInt(v.Interrupted), Unread: boolInt(v.Unread), HasError: boolInt(v.Error), StatusReported: boolInt(v.StatusReported || v.Active || v.Error || v.Interrupted), CreatedAtMs: int64(v.CreatedAt), StartedAtMs: nullMillis(v.StartedAt), ExitedAtMs: nullMillis(v.ExitedAt), LastActivityAtMs: nullMillis(v.LastActivityAt), ExitCode: nullInt(v.ExitCode), TerminalCols: nullUint(v.TerminalCols), TerminalRows: nullUint(v.TerminalRows), LaunchParentID: func() sql.NullString {
 		if v.LaunchParentID == nil {
 			return sql.NullString{}
 		}

--- a/services/gmuxd/internal/centralstore/drivemode_test.go
+++ b/services/gmuxd/internal/centralstore/drivemode_test.go
@@ -1,0 +1,84 @@
+package centralstore
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// The drive-mode axis (ADR 0033): persisted at registration, defaulted to
+// terminal for older runners, refused when unknown, and immutable across
+// re-registration (mode changes only through explicit conversion).
+func TestRegisterRunnerDriveMode(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("acp mode persists", func(t *testing.T) {
+		s := openTestStore(t)
+		row, _, err := s.RegisterRunner(ctx, RunnerRegistration{
+			ID: "a", Adapter: "claude", DriveMode: DriveModeACP, Alive: true, CreatedAt: 1, ObservedAt: 1,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if row.DriveMode != DriveModeACP {
+			t.Fatalf("DriveMode = %q, want acp", row.DriveMode)
+		}
+		read, ok, err := s.Session(ctx, "a")
+		if err != nil || !ok || read.DriveMode != DriveModeACP {
+			t.Fatalf("read = %+v, %v, %v; want persisted acp mode", read, ok, err)
+		}
+	})
+
+	t.Run("empty mode normalizes to terminal", func(t *testing.T) {
+		s := openTestStore(t)
+		row, _, err := s.RegisterRunner(ctx, RunnerRegistration{
+			ID: "b", Adapter: "pi", Alive: true, CreatedAt: 1, ObservedAt: 1,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if row.DriveMode != DriveModeTerminal {
+			t.Fatalf("DriveMode = %q, want terminal default", row.DriveMode)
+		}
+	})
+
+	t.Run("unknown mode is refused, never defaulted", func(t *testing.T) {
+		s := openTestStore(t)
+		_, _, err := s.RegisterRunner(ctx, RunnerRegistration{
+			ID: "c", Adapter: "pi", DriveMode: "telepathy", Alive: true, CreatedAt: 1, ObservedAt: 1,
+		})
+		if err == nil {
+			t.Fatal("unknown drive mode accepted")
+		}
+	})
+
+	t.Run("re-registration under a different mode is refused", func(t *testing.T) {
+		s := openTestStore(t)
+		if _, _, err := s.RegisterRunner(ctx, RunnerRegistration{
+			ID: "d", Adapter: "claude", DriveMode: DriveModeTerminal, Alive: true, CreatedAt: 1, ObservedAt: 1,
+		}); err != nil {
+			t.Fatal(err)
+		}
+		_, _, err := s.RegisterRunner(ctx, RunnerRegistration{
+			ID: "d", Adapter: "claude", DriveMode: DriveModeACP, Alive: true, CreatedAt: 2, ObservedAt: 2,
+		})
+		if !errors.Is(err, ErrDriveModeMismatch) {
+			t.Fatalf("err = %v, want ErrDriveModeMismatch", err)
+		}
+	})
+
+	t.Run("insert validates and defaults like registration", func(t *testing.T) {
+		s := openTestStore(t)
+		row, _, err := s.InsertSession(ctx, NewSession{ID: "e", Adapter: "codex", DriveMode: DriveModeACP, CWD: "/", CreatedAt: 1})
+		if err != nil || row.DriveMode != DriveModeACP {
+			t.Fatalf("row=%+v err=%v, want acp", row, err)
+		}
+		if _, _, err := s.InsertSession(ctx, NewSession{ID: "f", Adapter: "codex", DriveMode: "nope", CWD: "/", CreatedAt: 1}); err == nil {
+			t.Fatal("unknown drive mode accepted at insert")
+		}
+		plain, _, err := s.InsertSession(ctx, NewSession{ID: "g", Adapter: "shell", CWD: "/", CreatedAt: 1})
+		if err != nil || plain.DriveMode != DriveModeTerminal {
+			t.Fatalf("row=%+v err=%v, want terminal default", plain, err)
+		}
+	})
+}

--- a/services/gmuxd/internal/centralstore/internal/db/models.go
+++ b/services/gmuxd/internal/centralstore/internal/db/models.go
@@ -42,6 +42,7 @@ type LocalSession struct {
 	TerminalRows     sql.NullInt64
 	LaunchParentID   sql.NullString
 	PromotedToRoot   int64
+	DriveMode        string
 }
 
 type ManualPeer struct {

--- a/services/gmuxd/internal/centralstore/internal/db/query.sql
+++ b/services/gmuxd/internal/centralstore/internal/db/query.sql
@@ -7,12 +7,12 @@ SELECT value FROM centralstore_metadata WHERE key = ?;
 
 -- name: InsertSession :one
 INSERT INTO local_sessions (
-    id, adapter, conversation_ref, command_json, cwd, workspace_root,
+    id, adapter, drive_mode, conversation_ref, command_json, cwd, workspace_root,
     remotes_json, slug, slug_base, shell_title, adapter_title, subtitle,
     active, interrupted, unread, has_error, status_reported, created_at_ms, started_at_ms,
     exited_at_ms, last_activity_at_ms, exit_code, terminal_cols, terminal_rows,
     launch_parent_id
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 RETURNING *;
 
 -- name: GetSession :one

--- a/services/gmuxd/internal/centralstore/internal/db/query.sql.go
+++ b/services/gmuxd/internal/centralstore/internal/db/query.sql.go
@@ -237,7 +237,7 @@ func (q *Queries) GetMetadata(ctx context.Context, key string) (string, error) {
 }
 
 const getSession = `-- name: GetSession :one
-SELECT id, row_version, adapter, conversation_ref, command_json, cwd, workspace_root, remotes_json, slug, slug_base, shell_title, adapter_title, subtitle, active, interrupted, unread, has_error, status_reported, created_at_ms, started_at_ms, exited_at_ms, last_activity_at_ms, dismissed_at_ms, exit_code, terminal_cols, terminal_rows, launch_parent_id, promoted_to_root FROM local_sessions WHERE id = ?
+SELECT id, row_version, adapter, conversation_ref, command_json, cwd, workspace_root, remotes_json, slug, slug_base, shell_title, adapter_title, subtitle, active, interrupted, unread, has_error, status_reported, created_at_ms, started_at_ms, exited_at_ms, last_activity_at_ms, dismissed_at_ms, exit_code, terminal_cols, terminal_rows, launch_parent_id, promoted_to_root, drive_mode FROM local_sessions WHERE id = ?
 `
 
 func (q *Queries) GetSession(ctx context.Context, id string) (LocalSession, error) {
@@ -272,6 +272,7 @@ func (q *Queries) GetSession(ctx context.Context, id string) (LocalSession, erro
 		&i.TerminalRows,
 		&i.LaunchParentID,
 		&i.PromotedToRoot,
+		&i.DriveMode,
 	)
 	return i, err
 }
@@ -430,18 +431,19 @@ func (q *Queries) InsertProjectRule(ctx context.Context, arg InsertProjectRulePa
 
 const insertSession = `-- name: InsertSession :one
 INSERT INTO local_sessions (
-    id, adapter, conversation_ref, command_json, cwd, workspace_root,
+    id, adapter, drive_mode, conversation_ref, command_json, cwd, workspace_root,
     remotes_json, slug, slug_base, shell_title, adapter_title, subtitle,
     active, interrupted, unread, has_error, status_reported, created_at_ms, started_at_ms,
     exited_at_ms, last_activity_at_ms, exit_code, terminal_cols, terminal_rows,
     launch_parent_id
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-RETURNING id, row_version, adapter, conversation_ref, command_json, cwd, workspace_root, remotes_json, slug, slug_base, shell_title, adapter_title, subtitle, active, interrupted, unread, has_error, status_reported, created_at_ms, started_at_ms, exited_at_ms, last_activity_at_ms, dismissed_at_ms, exit_code, terminal_cols, terminal_rows, launch_parent_id, promoted_to_root
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+RETURNING id, row_version, adapter, conversation_ref, command_json, cwd, workspace_root, remotes_json, slug, slug_base, shell_title, adapter_title, subtitle, active, interrupted, unread, has_error, status_reported, created_at_ms, started_at_ms, exited_at_ms, last_activity_at_ms, dismissed_at_ms, exit_code, terminal_cols, terminal_rows, launch_parent_id, promoted_to_root, drive_mode
 `
 
 type InsertSessionParams struct {
 	ID               string
 	Adapter          string
+	DriveMode        string
 	ConversationRef  sql.NullString
 	CommandJson      string
 	Cwd              string
@@ -471,6 +473,7 @@ func (q *Queries) InsertSession(ctx context.Context, arg InsertSessionParams) (L
 	row := q.db.QueryRowContext(ctx, insertSession,
 		arg.ID,
 		arg.Adapter,
+		arg.DriveMode,
 		arg.ConversationRef,
 		arg.CommandJson,
 		arg.Cwd,
@@ -525,6 +528,7 @@ func (q *Queries) InsertSession(ctx context.Context, arg InsertSessionParams) (L
 		&i.TerminalRows,
 		&i.LaunchParentID,
 		&i.PromotedToRoot,
+		&i.DriveMode,
 	)
 	return i, err
 }
@@ -696,7 +700,7 @@ func (q *Queries) ListProjectRules(ctx context.Context) ([]ProjectMatchRule, err
 }
 
 const listSessions = `-- name: ListSessions :many
-SELECT id, row_version, adapter, conversation_ref, command_json, cwd, workspace_root, remotes_json, slug, slug_base, shell_title, adapter_title, subtitle, active, interrupted, unread, has_error, status_reported, created_at_ms, started_at_ms, exited_at_ms, last_activity_at_ms, dismissed_at_ms, exit_code, terminal_cols, terminal_rows, launch_parent_id, promoted_to_root FROM local_sessions ORDER BY id
+SELECT id, row_version, adapter, conversation_ref, command_json, cwd, workspace_root, remotes_json, slug, slug_base, shell_title, adapter_title, subtitle, active, interrupted, unread, has_error, status_reported, created_at_ms, started_at_ms, exited_at_ms, last_activity_at_ms, dismissed_at_ms, exit_code, terminal_cols, terminal_rows, launch_parent_id, promoted_to_root, drive_mode FROM local_sessions ORDER BY id
 `
 
 func (q *Queries) ListSessions(ctx context.Context) ([]LocalSession, error) {
@@ -737,6 +741,7 @@ func (q *Queries) ListSessions(ctx context.Context) ([]LocalSession, error) {
 			&i.TerminalRows,
 			&i.LaunchParentID,
 			&i.PromotedToRoot,
+			&i.DriveMode,
 		); err != nil {
 			return nil, err
 		}

--- a/services/gmuxd/internal/centralstore/migrations/00002_drive_mode.sql
+++ b/services/gmuxd/internal/centralstore/migrations/00002_drive_mode.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+
+-- Drive mode (ADR 0033): how gmux hosts this harness — 'terminal' (the PTY
+-- runner) or 'acp' (the terminal-less ACP runner). Durable because a
+-- retained session resumes in the mode it was registered in; it changes
+-- only through the explicit relaunch-conversion operation. Every session
+-- registered before this migration was a terminal session, so the backfill
+-- default is exact, not a guess.
+ALTER TABLE local_sessions
+    ADD COLUMN drive_mode TEXT NOT NULL DEFAULT 'terminal'
+        CHECK (drive_mode IN ('terminal', 'acp'));

--- a/services/gmuxd/internal/centralstore/register.go
+++ b/services/gmuxd/internal/centralstore/register.go
@@ -17,7 +17,13 @@ import (
 type RunnerRegistration struct {
 	ID      SessionID
 	Adapter string
-	Alive   bool
+	// DriveMode is the registering runner's drive mode (ADR 0033). Empty
+	// (an older runner) normalizes to terminal. Like Adapter it is part of
+	// the session's identity: a re-registration under a different mode is
+	// refused — mode changes only through the explicit relaunch-conversion
+	// operation, which owns its own registration provenance.
+	DriveMode string
+	Alive     bool
 	// NewGeneration is coordinator provenance: for an existing row, this
 	// observation belongs to a newly reserved replacement/resume/restart
 	// generation rather than a startup re-observation of the same runner.
@@ -68,6 +74,10 @@ type RunnerFacts struct {
 
 var (
 	ErrAdapterMismatch = errors.New("centralstore: runner adapter mismatch")
+	// ErrDriveModeMismatch marks a runner registering an existing session
+	// under a different drive mode than the row records. No implicit mode
+	// conversion: ADR 0033 makes conversion an explicit relaunch operation.
+	ErrDriveModeMismatch = errors.New("centralstore: runner drive-mode mismatch")
 	// ErrInvalidEviction marks a takeover eviction that is structurally
 	// illegal: an eviction on a dead registration (only a live binder may
 	// take over), an empty loser ID, or a self-eviction.
@@ -85,6 +95,9 @@ var (
 func (s *Store) RegisterRunner(ctx context.Context, reg RunnerRegistration) (Session, MutationResult, error) {
 	if reg.ID == "" || reg.Adapter == "" {
 		return Session{}, MutationResult{}, errors.New("centralstore: session id and adapter required")
+	}
+	if err := validateDriveMode(reg.DriveMode); err != nil {
+		return Session{}, MutationResult{}, err
 	}
 	if reg.CreatedAt < 0 || reg.ObservedAt < 0 {
 		return Session{}, MutationResult{}, errors.New("centralstore: registration timestamps must be non-negative")
@@ -134,6 +147,9 @@ func (s *Store) RegisterRunner(ctx context.Context, reg RunnerRegistration) (Ses
 		if before.Adapter != reg.Adapter {
 			return Session{}, MutationResult{SessionVersion: before.Version}, ErrAdapterMismatch
 		}
+		if before.DriveMode != normalizeDriveMode(reg.DriveMode) {
+			return Session{}, MutationResult{SessionVersion: before.Version}, ErrDriveModeMismatch
+		}
 	}
 	// Every dead generation must carry an explicit exit timestamp: a
 	// replacement generation because it must never inherit the previous
@@ -179,7 +195,7 @@ func (s *Store) RegisterRunner(ctx context.Context, reg RunnerRegistration) (Ses
 
 	if isNew {
 		current = Session{
-			ID: reg.ID, Adapter: reg.Adapter, CreatedAt: reg.CreatedAt,
+			ID: reg.ID, Adapter: reg.Adapter, DriveMode: normalizeDriveMode(reg.DriveMode), CreatedAt: reg.CreatedAt,
 			Command: []string{}, Remotes: map[string]string{}, LaunchParentID: cloneSessionID(reg.LaunchParentID),
 		}
 		if current.LaunchParentID != nil && evictedIDs[*current.LaunchParentID] {
@@ -205,7 +221,7 @@ func (s *Store) RegisterRunner(ctx context.Context, reg RunnerRegistration) (Ses
 			return Session{}, MutationResult{}, marshalErr
 		}
 		raw, err = q.InsertSession(ctx, db.InsertSessionParams{
-			ID: string(current.ID), Adapter: current.Adapter, ConversationRef: nullString(current.ConversationRef),
+			ID: string(current.ID), Adapter: current.Adapter, DriveMode: current.DriveMode, ConversationRef: nullString(current.ConversationRef),
 			CommandJson: cmd, Cwd: current.CWD, WorkspaceRoot: nullString(current.WorkspaceRoot), RemotesJson: rem,
 			Slug: nullString(current.Slug), SlugBase: nullString(current.SlugBase), ShellTitle: nullString(current.ShellTitle), AdapterTitle: nullString(current.AdapterTitle), Subtitle: nullString(current.Subtitle),
 			Active: boolInt(current.Active), Interrupted: boolInt(current.Interrupted), Unread: boolInt(current.Unread), HasError: boolInt(current.Error), StatusReported: boolInt(current.StatusReported), CreatedAtMs: int64(current.CreatedAt),

--- a/services/gmuxd/internal/centralstore/release_safety_test.go
+++ b/services/gmuxd/internal/centralstore/release_safety_test.go
@@ -27,6 +27,17 @@ func TestReleasedV1MigrationChecksum(t *testing.T) {
 	}
 }
 
+func TestV2MigrationChecksum(t *testing.T) {
+	data, err := fs.ReadFile(migrationFiles, "migrations/00002_drive_mode.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	const want = "c004c3ea7098fd7348151f0eca97ecac8736dbd575f625e13ce7533bb6faa6e5"
+	if got := fmt.Sprintf("%x", sha256.Sum256(data)); got != want {
+		t.Fatalf("v2 migration changed: sha256=%s, want %s; migrations are immutable once merged — add a new one instead", got, want)
+	}
+}
+
 func TestNewerSchemaRefusedWithoutMutation(t *testing.T) {
 	ctx := context.Background()
 	dir := filepath.Join(t.TempDir(), "state")
@@ -316,21 +327,26 @@ func TestOpenRejectsCommittedMigrationForeignKeyViolation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	v2, err := fs.ReadFile(migrationFiles, "migrations/00002_drive_mode.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
 	files := fstest.MapFS{
 		"migrations/00001_initial_schema.sql": {Data: v1},
-		"migrations/00002_orphan.sql":         {Data: []byte("-- +goose NO TRANSACTION\n-- +goose Up\nCREATE TABLE migration_parent (id INTEGER PRIMARY KEY);\nCREATE TABLE migration_child (parent_id INTEGER REFERENCES migration_parent(id));\nPRAGMA foreign_keys=OFF;\nINSERT INTO migration_child VALUES (99);\nPRAGMA foreign_keys=ON;\n")},
+		"migrations/00002_drive_mode.sql":     {Data: v2},
+		"migrations/00003_orphan.sql":         {Data: []byte("-- +goose NO TRANSACTION\n-- +goose Up\nCREATE TABLE migration_parent (id INTEGER PRIMARY KEY);\nCREATE TABLE migration_child (parent_id INTEGER REFERENCES migration_parent(id));\nPRAGMA foreign_keys=OFF;\nINSERT INTO migration_child VALUES (99);\nPRAGMA foreign_keys=ON;\n")},
 	}
 	_, err = openWithMigrationFS(ctx, dir, files)
 	if !errors.Is(err, ErrForeignKeyIntegrity) {
 		t.Fatalf("open error = %v, want ErrForeignKeyIntegrity", err)
 	}
-	backups, globErr := filepath.Glob(filepath.Join(dir, "backups", "state-pre-migration-v1-to-v2-*.db"))
+	backups, globErr := filepath.Glob(filepath.Join(dir, "backups", "state-pre-migration-v2-to-v3-*.db"))
 	if globErr != nil || len(backups) != 1 || !strings.Contains(err.Error(), backups[0]) {
 		t.Fatalf("error/backups = %v / %v / %v; want retained path in post-migration diagnostic", err, backups, globErr)
 	}
 	database := openReleaseTestDB(t, DatabasePath(dir))
 	defer database.Close()
-	assertDBVersion(t, database, 2)
+	assertDBVersion(t, database, 3)
 }
 
 func TestQuickCheckFailureCarriesMigrationBackupPath(t *testing.T) {

--- a/services/gmuxd/internal/centralstore/store_test.go
+++ b/services/gmuxd/internal/centralstore/store_test.go
@@ -26,8 +26,8 @@ func TestOpenFreshAndReopen(t *testing.T) {
 	if got, want := store.database.Stats().MaxOpenConnections, 1; got != want {
 		t.Fatalf("MaxOpenConnections = %d, want %d", got, want)
 	}
-	if version, err := store.SchemaVersion(ctx); err != nil || version != 1 {
-		t.Fatalf("schema version = %d, %v; want 1", version, err)
+	if version, err := store.SchemaVersion(ctx); err != nil || version != 2 {
+		t.Fatalf("schema version = %d, %v; want 2 (v2: drive_mode)", version, err)
 	}
 	if err := store.queries.PutMetadata(ctx, db.PutMetadataParams{Key: "kept", Value: "yes"}); err != nil {
 		t.Fatal(err)

--- a/services/gmuxd/internal/peering/projection.go
+++ b/services/gmuxd/internal/peering/projection.go
@@ -12,6 +12,7 @@ type SessionProjection struct {
 	Command         []string          `json:"command,omitempty"`
 	Cwd             string            `json:"cwd,omitempty"`
 	Adapter         string            `json:"adapter"`
+	DriveMode       string            `json:"drive_mode,omitempty"`
 	WorkspaceRoot   string            `json:"workspace_root,omitempty"`
 	Remotes         map[string]string `json:"remotes,omitempty"`
 	ParentSessionID string            `json:"parent_session_id,omitempty"`

--- a/services/gmuxd/internal/snapshot/wire/convert.go
+++ b/services/gmuxd/internal/snapshot/wire/convert.go
@@ -52,6 +52,16 @@ func (c *Converter) resolveTitle(s centralstore.Session) string {
 	return s.Adapter
 }
 
+// wireDriveMode keeps the terminal default off the wire: the pre-mode
+// shape had no field, so terminal (and a legacy empty value) stays absent
+// and only "acp" is emitted. Consumers treat absence as terminal.
+func wireDriveMode(s string) string {
+	if s == centralstore.DriveModeTerminal {
+		return ""
+	}
+	return s
+}
+
 // fmtMillis converts a durable Unix-ms stamp to the wire's RFC3339 form.
 // time.RFC3339 has no fractional-second component, so this matches the
 // production nowRFC3339 second precision (FD-4).
@@ -93,6 +103,7 @@ func (c *Converter) session(row central.SessionRow) Session {
 		Command:         v.Command,
 		Cwd:             v.CWD,
 		Adapter:         v.Adapter,
+		DriveMode:       wireDriveMode(v.DriveMode),
 		SemanticAgent:   c.SemanticAgents[v.Adapter],
 		PromotedToRoot:  v.PromotedToRoot,
 		WorkspaceRoot:   v.WorkspaceRoot,

--- a/services/gmuxd/internal/snapshot/wire/convert_test.go
+++ b/services/gmuxd/internal/snapshot/wire/convert_test.go
@@ -48,6 +48,25 @@ func TestSessionConversionPreservesFamilyFacts(t *testing.T) {
 	}
 }
 
+// The drive mode rides the wire only when it is not the terminal default:
+// the pre-mode wire shape had no field, so terminal (and a legacy empty
+// value) stays byte-identical and only "acp" is emitted (ADR 0033).
+func TestSessionConversionDriveMode(t *testing.T) {
+	conv := &Converter{}
+	for mode, want := range map[string]string{
+		centralstore.DriveModeTerminal: "",
+		"":                             "",
+		centralstore.DriveModeACP:      "acp",
+	} {
+		got := conv.session(central.SessionRow{SessionView: centralstore.SessionView{Session: centralstore.Session{
+			ID: "s", Adapter: "claude", DriveMode: mode, CreatedAt: 1,
+		}}})
+		if got.DriveMode != want {
+			t.Fatalf("DriveMode(%q) = %q, want %q", mode, got.DriveMode, want)
+		}
+	}
+}
+
 func TestSessionConversionRedactsRemoteUserinfo(t *testing.T) {
 	localRemotes := map[string]string{
 		"origin": "https://user:token@git.example/acme/repo.git",

--- a/services/gmuxd/internal/snapshot/wire/wire.go
+++ b/services/gmuxd/internal/snapshot/wire/wire.go
@@ -51,6 +51,7 @@ type Session struct {
 	Command         []string          `json:"command,omitempty"`
 	Cwd             string            `json:"cwd,omitempty"`
 	Adapter         string            `json:"adapter"`
+	DriveMode       string            `json:"drive_mode,omitempty"` // ADR 0033; omitted = terminal
 	WorkspaceRoot   string            `json:"workspace_root,omitempty"`
 	Remotes         map[string]string `json:"remotes,omitempty"`
 	ParentSessionID string            `json:"parent_session_id,omitempty"`

--- a/services/gmuxd/internal/statetool/export.go
+++ b/services/gmuxd/internal/statetool/export.go
@@ -26,6 +26,7 @@ type ExportDoc struct {
 type ExportSession struct {
 	ID              string            `json:"id"`
 	Adapter         string            `json:"adapter"`
+	DriveMode       string            `json:"drive_mode,omitempty"`
 	ConversationRef string            `json:"conversation_ref,omitempty"`
 	Command         []string          `json:"command"`
 	CWD             string            `json:"cwd"`
@@ -134,7 +135,7 @@ func Export(ctx context.Context, store *centralstore.Store) (ExportDoc, error) {
 
 func exportSession(s centralstore.Session) ExportSession {
 	out := ExportSession{
-		ID: string(s.ID), Adapter: s.Adapter, ConversationRef: s.ConversationRef,
+		ID: string(s.ID), Adapter: s.Adapter, DriveMode: s.DriveMode, ConversationRef: s.ConversationRef,
 		Command: append([]string{}, s.Command...),
 		CWD:     s.CWD, WorkspaceRoot: s.WorkspaceRoot,
 		Remotes: map[string]string{},


### PR DESCRIPTION
<!-- prose-start -->
<!-- prose-end -->

Slice 0 of the ACP host program (`docs/acp-host-program.md`, #455/#465): the drive-mode session axis and the honest ADR 0033 capability refusals. No ACP code — this is the boundary work everything else keys on.

**Mode axis**
- `drive_mode` (`terminal`|`acp`) as a durable session fact: schema migration v2 (v1 stays frozen; backfill default `terminal` is exact — every pre-migration session was a terminal session), `RunnerRegistration`/`NewSession` validation (unknown modes refused, never defaulted), immutable across re-registration (`ErrDriveModeMismatch` — conversion is a future explicit operation).
- PTY runner `/meta` splices `drive_mode: "terminal"` beside the incarnation; gmuxd registration persists it.
- Wire: `drive_mode` emitted only when not terminal (pre-mode shape stays byte-identical); protocol zod schema defaults absence to `terminal`; peering projection carries it; statetool export includes it.
- Display: `gmux ls` marks the adapter cell `claude (acp)` and round-trips `drive_mode` in `--json`; web session menu shows `adapter (acp)`.

**Refusals (final copy, per the program's settled decision 3)**
- New daemon-side gate for `agent prompt/cancel`, checked **before residency/readiness/activity** — so prompting a dead terminal claude session no longer transparently resumes a real Claude TUI just to be refused by its runner one round-trip later.
- Terminal claude/codex: `unsupported_mode` (422) naming the mode boundary — ADR 0033 §3 wording; `--steer` gets the permanent variant. Shell/editors keep the runner's `unsupported_adapter` wording, now pre-delivery. Unknown adapters pass through: the daemon never invents a capability verdict. The runner's own refusal stays as defense in depth.
- ACP-mode sessions (representable in tests; producible from slice 1): PTY surfaces answer `no_terminal` naming the working surface — raw input → `gmux agent prompt`, scrollback/tail → `gmux agent logs`, attach/terminal-WS → the web conversation view. CLI `attach` refuses client-side with the same copy; `tail`/`send` surface the daemon message.
- New `adapter.ACPDrivable` capability marker (claude, codex) — slice-0 consumer is the refusal wording, per the "every advertised capability has a consumer in a shipped slice" rule.

Tests: verdict table over the production adapter lookup, refusal-precedes-resume, cancel at the boundary, PTY-surface refusals on an ACP row, drive-mode persistence/mismatch/validation, wire emission rules, `/meta` splice, migration checksums (v2 frozen alongside v1).
