### PR TITLE
ci: parallelize checks and reuse Go caches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,6 @@ jobs:
     # One source of truth: run the same pnpm entrypoints developers run
     # locally. The actual commands live once in moon.yml (moon discovers
     # projects from the workspace globs), so CI can't drift from local.
-    # `pnpm lint` = biome (--error-on-warnings, matching the root script)
-    # + `moon run :lint`; build/test fan out the same way.
     env:
       GOWORK: ${{ github.workspace }}/go.work
     steps:
@@ -56,6 +54,33 @@ jobs:
       - name: Test
         run: pnpm test
 
+  central-store-checks:
+    name: Central store generated + cross-build
+    runs-on: ubuntu-latest
+    env:
+      GOWORK: ${{ github.workspace }}/go.work
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          # These are moon tasks and need the default-branch baseline.
+          fetch-depth: 0
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: "1.26"
+          cache-dependency-path: |
+            **/go.sum
+            go.work.sum
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: "22"
+
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
       # Central-store (ADR 0026) gates that the pnpm test/build/lint fan-out
       # does not cover: they live under distinct moon task names, so they
       # must be invoked explicitly. All are Docker-free and fast.
@@ -65,10 +90,23 @@ jobs:
       - name: Central store — CGO-free cross-build (linux/darwin × amd64/arm64)
         run: pnpm exec moon run gmuxd:check-centralstore-cross-build
 
+  central-store-race:
+    name: Central store race detector
+    runs-on: ubuntu-latest
+    env:
+      GOWORK: ${{ github.workspace }}/go.work
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: "1.26"
+          cache-dependency-path: |
+            **/go.sum
+            go.work.sum
+
       # Race detector on the concurrency-critical central-store machinery
       # (coordinator, snapshot composer, peering projection, daemon entry).
-      # These packages carried the bulk of the lifecycle/ordering review;
-      # the plain `pnpm test` run above is race-free.
       - name: Central store — race detector (hot packages)
         working-directory: services/gmuxd
         run: go test -race ./internal/sessioncoord ./internal/snapshot/central ./internal/peering ./cmd/gmuxd
@@ -105,6 +143,9 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: "1.26"
+          cache-dependency-path: |
+            **/go.sum
+            go.work.sum
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -63,27 +63,15 @@ jobs:
             echo "subject=${subject}"
           } >> "$GITHUB_OUTPUT"
 
+      # Use the same dependency-keyed Go cache as main CI. Caches created by
+      # the default branch are visible to PRs, unlike caches scoped to other
+      # pull-request merge refs.
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: "1.26"
-          # We manage the Go caches explicitly below (the go.work workspace
-          # has no root go.sum, so setup-go's default cache no-ops anyway).
-          cache: false
-
-      # Persist GOCACHE + the module cache so incremental PR pushes don't
-      # recompile the std lib for all four cross-compile targets from
-      # scratch. Key on go.sum + Go sources; restore-keys fall back to the
-      # nearest prior cache on a miss.
-      - name: Cache Go build + modules
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-gobuild-${{ hashFiles('**/go.sum', 'go.work.sum') }}-${{ hashFiles('**/*.go') }}
-          restore-keys: |
-            ${{ runner.os }}-gobuild-${{ hashFiles('**/go.sum', 'go.work.sum') }}-
-            ${{ runner.os }}-gobuild-
+          cache-dependency-path: |
+            **/go.sum
+            go.work.sum
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:


### PR DESCRIPTION
## Summary

- split independent lint/build/test, central-store verification, and race-detector gates into parallel jobs
- use main-visible dependency-keyed Go caches for PR snapshot builds
- fix the E2E Go workspace cache dependency path

No checks, artifacts, or blocking coverage are removed; only workflow caching and parallelism change.

## Baseline

20 recently merged PRs:
- full suite / CI critical path: 7.8m median, 8.0m p75
- PR Build: 4.55m median, 5.22m p75
- runner queue: 2–5s median

## Validation

- `pnpm exec prettier --check .github/workflows/ci.yml .github/workflows/pr-build.yml`
- this PR's Actions runs will provide the after measurement
