### PR TITLE
fix: wave-2 sweep — exit metadata, index slug retention, mock timestamps

### DIFF
--- a/apps/gmux-web/src/mock-data/sessions/codex-refactor-adapters.ts
+++ b/apps/gmux-web/src/mock-data/sessions/codex-refactor-adapters.ts
@@ -33,7 +33,7 @@ export default {
   status: { active: true },
   unread: false,
   project_slug: 'my-project',
-  last_output_at: ago(3),
+  last_output_at: ago(0),
   socket_path: '/tmp/gmux-sessions/1jd5z9sg.sock',
   cursorX: 2,
   cursorY: 70,

--- a/apps/gmux-web/src/mock-data/sessions/demo-activity.ts
+++ b/apps/gmux-web/src/mock-data/sessions/demo-activity.ts
@@ -55,20 +55,24 @@ export const DEMO_ACTIVITY: MockSession[] = [
     cwd: '/home/user/dev/openclaw', workspace_root: '/home/user/dev/openclaw',
     remotes: { origin: 'github.com/acme/openclaw' },
     project_slug: 'openclaw',
+    created_at: ago(60 * 6), started_at: ago(60 * 6),
     last_output_at: ago(60 * 5),
   }),
   demo({
     id: '17i0p4fp', title: 'debug ws reconnect',
+    created_at: ago(60 * 27), started_at: ago(60 * 27),
     last_output_at: ago(60 * 26),
   }),
   demo({
     id: '1f4mvwv1', title: 'shell: profiling',
     adapter: 'shell', command: ['bash'],
+    created_at: ago(60 * 24 * 5), started_at: ago(60 * 24 * 5),
     last_output_at: ago(60 * 24 * 4),
   }),
   demo({
     id: '1eb5auvb', title: 'refactor launcher',
     alive: false, resumable: true, pid: null, exit_code: 0,
+    created_at: ago(60 * 31), started_at: ago(60 * 31),
     exited_at: ago(60 * 30), last_output_at: ago(60 * 30),
   }),
 ]

--- a/apps/gmux-web/src/mock-data/sessions/pi-fix-scrollback.ts
+++ b/apps/gmux-web/src/mock-data/sessions/pi-fix-scrollback.ts
@@ -25,7 +25,7 @@ export default {
   status: { active: false },
   unread: false,
   project_slug: 'my-project',
-  last_output_at: ago(24),
+  last_output_at: ago(4),
   socket_path: '/tmp/gmux-sessions/mock.sock',
   terminal: [
     `${GRAY}╭──────────────────────────────────────────────────────╮${RST}`,

--- a/apps/gmux-web/src/mock-data/sessions/shell-openclaw-configure.ts
+++ b/apps/gmux-web/src/mock-data/sessions/shell-openclaw-configure.ts
@@ -22,7 +22,7 @@ export default {
   status: { active: false },
   unread: false,
   project_slug: 'openclaw',
-  last_output_at: ago(38),
+  last_output_at: ago(8),
   socket_path: '/tmp/gmux-sessions/mock.sock',
   terminal: [
     `${GREEN}✓${RST} Configuration written to openclaw.toml`,

--- a/apps/gmux-web/src/mock-data/sessions/shell-openclaw-logs.ts
+++ b/apps/gmux-web/src/mock-data/sessions/shell-openclaw-logs.ts
@@ -22,7 +22,7 @@ export default {
   status: { active: false },
   unread: false,
   project_slug: 'openclaw',
-  last_output_at: ago(51),
+  last_output_at: ago(15),
   socket_path: '/tmp/gmux-sessions/mock.sock',
   mockActive: true,
   terminal: [

--- a/cli/gmux/internal/ptyserver/ptyserver.go
+++ b/cli/gmux/internal/ptyserver/ptyserver.go
@@ -1457,6 +1457,16 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// A dead runner cannot emit another live exit edge. Replay its recorded
+	// exit metadata so a daemon that reconnects after process exit learns the
+	// original code and timestamp rather than treating the runner as merely
+	// unreachable.
+	if code, exitedAt := s.state.ExitSnapshot(); code != nil {
+		if data, err := json.Marshal(map[string]any{"exit_code": *code, "exited_at": exitedAt}); err == nil {
+			fmt.Fprintf(w, "event: exit\ndata: %s\n\n", data)
+		}
+	}
+
 	if file := s.state.ConversationRefSnapshot(); file != "" {
 		if data, err := json.Marshal(map[string]string{"path": file}); err == nil {
 			fmt.Fprintf(w, "event: conversation_file\ndata: %s\n\n", data)

--- a/cli/gmux/internal/ptyserver/turn_frame_test.go
+++ b/cli/gmux/internal/ptyserver/turn_frame_test.go
@@ -203,6 +203,28 @@ func TestTurnFrameReplayedToSubscribers(t *testing.T) {
 	}
 }
 
+func TestExitMetadataReplayedToSubscribers(t *testing.T) {
+	st := session.New(session.Config{ID: "s1", Adapter: "shell"})
+	st.SetExited(23)
+	srv := &Server{state: st}
+	req := httptest.NewRequest("GET", "http://unix/events", nil)
+	ctx, cancel := contextWithImmediateCancel(req)
+	defer cancel()
+	rec := httptest.NewRecorder()
+	srv.handleEvents(rec, req.WithContext(ctx))
+
+	var replay struct {
+		ExitCode int    `json:"exit_code"`
+		ExitedAt string `json:"exited_at"`
+	}
+	if err := json.Unmarshal([]byte(sseData(t, rec.Body.String(), "exit")), &replay); err != nil {
+		t.Fatalf("decode replayed exit: %v", err)
+	}
+	if replay.ExitCode != 23 || replay.ExitedAt == "" {
+		t.Fatalf("replayed exit = %+v", replay)
+	}
+}
+
 // contextWithImmediateCancel gives handleEvents a context that is already done,
 // so it writes its replay snapshot and returns instead of streaming forever.
 func contextWithImmediateCancel(req *http.Request) (context.Context, context.CancelFunc) {

--- a/cli/gmux/internal/session/state.go
+++ b/cli/gmux/internal/session/state.go
@@ -193,7 +193,7 @@ func (s *State) SetExited(exitCode int) {
 	s.Alive = false
 	s.ExitCode = &exitCode
 	s.ExitedAt = time.Now().UTC().Format(time.RFC3339)
-	s.emit(Event{Type: "exit", Data: map[string]int{"exit_code": exitCode}})
+	s.emit(Event{Type: "exit", Data: map[string]any{"exit_code": exitCode, "exited_at": s.ExitedAt}})
 }
 
 // SetUnread marks the session as having unseen output (or clears it).
@@ -619,6 +619,18 @@ func (s *State) MarshalJSON() ([]byte, error) {
 		Title: s.titleLocked(),
 		Alias: (*Alias)(s),
 	})
+}
+
+// ExitSnapshot returns the runner-owned exit metadata for replay to a
+// reconnecting subscriber. A nil code means the session has not exited.
+func (s *State) ExitSnapshot() (*int, string) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.ExitCode == nil {
+		return nil, ""
+	}
+	code := *s.ExitCode
+	return &code, s.ExitedAt
 }
 
 // Subscribe returns a channel that receives events.

--- a/services/gmuxd/cmd/gmuxd/bootstrap_runner_adapters.go
+++ b/services/gmuxd/cmd/gmuxd/bootstrap_runner_adapters.go
@@ -204,14 +204,21 @@ func runnerEventProjection(typ string, raw []byte) (sessioncoord.RunnerEvent, bo
 		f.TerminalSize = centralstore.NullablePatch[centralstore.TerminalSize]{Set: &v}
 	case "exit":
 		var v struct {
-			ExitCode int `json:"exit_code"`
+			ExitCode int    `json:"exit_code"`
+			ExitedAt string `json:"exited_at"`
 		}
 		if json.Unmarshal(raw, &v) != nil {
 			return sessioncoord.RunnerEvent{}, false
 		}
+		exitedAt := now
+		if v.ExitedAt != "" {
+			if t, err := time.Parse(time.RFC3339, v.ExitedAt); err == nil {
+				exitedAt = centralstore.UnixMillis(t.UnixMilli())
+			}
+		}
 		alive := false
 		f.ExitCode = centralstore.NullablePatch[int]{Set: &v.ExitCode}
-		f.ExitedAt = centralstore.NullablePatch[centralstore.UnixMillis]{Set: &now}
+		f.ExitedAt = centralstore.NullablePatch[centralstore.UnixMillis]{Set: &exitedAt}
 		return sessioncoord.RunnerEvent{ObservedAt: now, Facts: f, Alive: &alive}, true
 	case "turn_frame":
 		// A frame update with no status transition to ride: a mid-turn injection,
@@ -283,6 +290,8 @@ type runnerMetaWire struct {
 	Alive           bool              `json:"alive"`
 	CreatedAt       string            `json:"created_at"`
 	StartedAt       string            `json:"started_at"`
+	ExitCode        *int              `json:"exit_code"`
+	ExitedAt        string            `json:"exited_at"`
 	PID             int               `json:"pid"`
 	RunnerVersion   string            `json:"runner_version"`
 	BinaryHash      string            `json:"binary_hash"`
@@ -323,6 +332,15 @@ func runnerMetaFacts(s runnerMetaWire) centralstore.RunnerFacts {
 		if t, perr := time.Parse(time.RFC3339, s.StartedAt); perr == nil {
 			at := centralstore.UnixMillis(t.UnixMilli())
 			f.StartedAt.Set = &at
+		}
+	}
+	if s.ExitCode != nil {
+		f.ExitCode.Set = s.ExitCode
+	}
+	if s.ExitedAt != "" {
+		if t, perr := time.Parse(time.RFC3339, s.ExitedAt); perr == nil {
+			at := centralstore.UnixMillis(t.UnixMilli())
+			f.ExitedAt.Set = &at
 		}
 	}
 	if s.TerminalCols > 0 && s.TerminalRows > 0 {

--- a/services/gmuxd/cmd/gmuxd/bootstrap_runner_adapters_test.go
+++ b/services/gmuxd/cmd/gmuxd/bootstrap_runner_adapters_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/centralstore"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/sessioncoord"
 )
 
@@ -84,6 +85,37 @@ func TestProductionRunnerMetaPreservesLaunchParent(t *testing.T) {
 	}
 	if meta.Registration.LaunchParentID == nil || *meta.Registration.LaunchParentID != "parent" {
 		t.Fatalf("launch parent lost at runner boundary: %#v", meta.Registration.LaunchParentID)
+	}
+}
+
+func TestProductionRunnerDeadMetadataSurvivesMetaAndReplay(t *testing.T) {
+	const exitedAt = "2026-01-02T03:04:05Z"
+	mux := http.NewServeMux()
+	mux.HandleFunc("/meta", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintf(w, `{"id":"dead","adapter":"shell","alive":false,"created_at":"2026-01-01T00:00:00Z","exit_code":23,"exited_at":%q}`, exitedAt)
+	})
+	mux.HandleFunc("/events", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintf(w, "event: exit\ndata: {\"exit_code\":23,\"exited_at\":%q}\n\n", exitedAt)
+	})
+	ep := unixRunner(t, mux)
+	meta, err := (productionRunnerClient{}).Meta(context.Background(), ep)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantExitedAt := centralstore.UnixMillis(time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC).UnixMilli())
+	facts := meta.Registration.Facts
+	if facts.ExitCode.Set == nil || *facts.ExitCode.Set != 23 || facts.ExitedAt.Set == nil || *facts.ExitedAt.Set != wantExitedAt {
+		t.Fatalf("/meta exit facts lost: %+v", facts)
+	}
+
+	stream, err := (productionRunnerClient{}).Subscribe(context.Background(), ep)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stream.Close()
+	event := <-stream.Events()
+	if event.Alive == nil || *event.Alive || event.Facts.ExitCode.Set == nil || *event.Facts.ExitCode.Set != 23 || event.Facts.ExitedAt.Set == nil || *event.Facts.ExitedAt.Set != wantExitedAt {
+		t.Fatalf("SSE replay exit facts lost: %+v", event)
 	}
 }
 

--- a/services/gmuxd/cmd/gmuxd/production_spawner_test.go
+++ b/services/gmuxd/cmd/gmuxd/production_spawner_test.go
@@ -21,7 +21,8 @@ func TestRunnerMetaWireJSONFieldTable(t *testing.T) {
 		{"ID", "id"}, {"Incarnation", "incarnation"},
 		{"Adapter", "adapter"}, {"Kind", "kind"},
 		{"Alive", "alive"}, {"CreatedAt", "created_at"},
-		{"StartedAt", "started_at"}, {"PID", "pid"},
+		{"StartedAt", "started_at"}, {"ExitCode", "exit_code"},
+		{"ExitedAt", "exited_at"}, {"PID", "pid"},
 		{"RunnerVersion", "runner_version"}, {"BinaryHash", "binary_hash"},
 		{"ConversationRef", "conversation_file"}, {"CWD", "cwd"},
 		{"WorkspaceRoot", "workspace_root"}, {"Slug", "slug"},
@@ -40,7 +41,7 @@ func TestRunnerMetaWireJSONFieldTable(t *testing.T) {
 			t.Errorf("field[%d]=%s json:%q, want %s json:%q", i, field.Name, field.Tag.Get("json"), entry.field, entry.tag)
 		}
 	}
-	status := typeOf.Field(20).Type.Elem()
+	status := typeOf.Field(22).Type.Elem()
 	if status.NumField() != 3 ||
 		status.Field(0).Name != "Active" || status.Field(0).Tag.Get("json") != "active" ||
 		status.Field(1).Name != "Error" || status.Field(1).Tag.Get("json") != "error" ||

--- a/services/gmuxd/internal/conversations/index.go
+++ b/services/gmuxd/internal/conversations/index.go
@@ -154,7 +154,12 @@ func (idx *Index) Upsert(info Info) string {
 			return final
 		}
 		ik := indexKey(info.Adapter, existing)
+		previous := idx.byKey[ik]
 		info.Key = existing
+		info.Slug = previous.Slug
+		if info.Title == "" {
+			info.Title = previous.Title
+		}
 		idx.byKey[ik] = info
 		return existing
 	}

--- a/services/gmuxd/internal/conversations/index_test.go
+++ b/services/gmuxd/internal/conversations/index_test.go
@@ -59,6 +59,26 @@ func TestUpsert_UpdateInPlace(t *testing.T) {
 	}
 }
 
+func TestUpsert_TransientEmptySlugPreservesDisplayMetadata(t *testing.T) {
+	idx := New()
+	idx.Upsert(Info{ConversationID: "abc-123", Slug: "fix-auth", Adapter: "pi", Title: "Fix auth"})
+
+	key := idx.Upsert(Info{ConversationID: "abc-123", Adapter: "pi"})
+	if key != "fix-auth" {
+		t.Fatalf("transient empty update key = %q, want fix-auth", key)
+	}
+	info, ok := idx.Lookup("pi", key)
+	if !ok || info.Slug != "fix-auth" || info.Title != "Fix auth" {
+		t.Fatalf("transient empty update lost display metadata: %+v, ok=%v", info, ok)
+	}
+
+	key = idx.Upsert(Info{ConversationID: "abc-123", Slug: "auth-restored", Adapter: "pi", Title: "Auth restored"})
+	info, ok = idx.Lookup("pi", key)
+	if key != "auth-restored" || !ok || info.Slug != "auth-restored" || info.Title != "Auth restored" {
+		t.Fatalf("restored update not applied: key=%q info=%+v ok=%v", key, info, ok)
+	}
+}
+
 func TestUpsert_SlugCollision(t *testing.T) {
 	idx := New()
 	s1 := idx.Upsert(Info{ConversationID: "aaa", Slug: "say-hi", Adapter: "claude"})


### PR DESCRIPTION
## Summary
- preserve runner `exit_code` and `exited_at` through `/meta`, live exit events, and SSE reconnect replay
- retain the last known conversation slug/title during transient empty-slug refreshes
- correct impossible timestamp ordering in mock sessions

## Verification
- `pnpm test`
- `pnpm lint`