### PR TITLE
feat: session promote and reparent

### DIFF
--- a/apps/gmux-web/src/family.test.ts
+++ b/apps/gmux-web/src/family.test.ts
@@ -37,6 +37,20 @@ describe('task-family projection', () => {
     expect(descendantTree(child, sessions).session).toBe(child)
   })
 
+  it('reprojects against the reassigned direct parent', () => {
+    const first = agent('first')
+    const second = agent('second')
+    const child = agent('child', 'first')
+    expect(familyRoot(child, [first, second, child])).toBe(first)
+
+    const reparented = { ...child, parent_session_id: 'second' }
+    expect(familyRoot(reparented, [first, second, reparented])).toBe(second)
+    expect(isFamilyChild(reparented, [first, second, reparented])).toBe(true)
+
+    const cleared = { ...child, parent_session_id: undefined }
+    expect(familyRoot(cleared, [first, second, cleared])).toBe(cleared)
+  })
+
   it('shows family controls only when a real edge exists', () => {
     const root = agent('root')
     const child = agent('child', 'root')

--- a/cli/gmux/cmd/gmux/actions.go
+++ b/cli/gmux/cmd/gmux/actions.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -445,6 +446,70 @@ func cmdKill(ref string) int {
 		return 1
 	}
 	fmt.Printf("killed %s\n", displayID(sess))
+	return 0
+}
+
+// cmdSession implements local-daemon family mutations. Cross-peer mutation is
+// intentionally refused: parent identity and cycle validation are one SQLite
+// transaction on the daemon that owns both rows.
+func cmdSession(cmd *command) int {
+	sess, err := resolveSession(cmd.ref)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "gmux:", err)
+		return 1
+	}
+	if sess.Peer != "" {
+		fmt.Fprintln(os.Stderr, "gmux: session family mutations require a session owned by this daemon; run gmux on the owning host")
+		return 1
+	}
+
+	action := cmd.sessionSub
+	var body []byte
+	if action == "parent" {
+		var parentID any
+		if !cmd.clearParent {
+			parent, resolveErr := resolveSession(cmd.parentRef)
+			if resolveErr != nil {
+				fmt.Fprintln(os.Stderr, "gmux:", resolveErr)
+				return 1
+			}
+			if parent.Peer != "" {
+				fmt.Fprintln(os.Stderr, "gmux: parent session must be owned by this daemon; cross-peer reparenting is not supported")
+				return 1
+			}
+			parentID = parent.ID
+		}
+		body, err = json.Marshal(map[string]any{"parent_session_id": parentID})
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "gmux:", err)
+			return 1
+		}
+	} else {
+		body = []byte("{}")
+	}
+
+	url := gmuxdBaseURL() + "/v1/sessions/" + sess.ID + "/" + action
+	resp, err := gmuxdClient().Post(url, "application/json", bytes.NewReader(body))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "gmux:", err)
+		return 1
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		responseBody, _ := io.ReadAll(resp.Body)
+		fmt.Fprintf(os.Stderr, "gmux: session %s failed: %s: %s\n", action, resp.Status, strings.TrimSpace(string(responseBody)))
+		return 1
+	}
+	switch {
+	case action == "parent" && cmd.clearParent:
+		fmt.Printf("cleared parent of %s\n", displayID(sess))
+	case action == "parent":
+		fmt.Printf("parented %s under %s\n", displayID(sess), cmd.parentRef)
+	case action == "promote":
+		fmt.Printf("promoted %s to root\n", displayID(sess))
+	default:
+		fmt.Printf("demoted %s\n", displayID(sess))
+	}
 	return 0
 }
 

--- a/cli/gmux/cmd/gmux/cli.go
+++ b/cli/gmux/cmd/gmux/cli.go
@@ -26,6 +26,7 @@ const (
 	modeSendKeys               // gmux send-keys -t <id> ... (tmux-compat)
 	modeWait                   // gmux wait <id>...
 	modeAgent                  // gmux agent prompt|cancel|output <id>
+	modeSession                // gmux session parent|promote|demote <id>
 	modeEdit                   // gmux edit [file]
 	modeEditChild              // (internal) gmux __edit-child [file]
 	modeDaemon                 // gmux daemon <start|stop|restart|status|log-path|state ...>
@@ -79,6 +80,11 @@ type command struct {
 	agentModel  string  // --new only: model selector for the launch
 	agentName   string  // --new only: session display name for the launch
 
+	// session (modeSession)
+	sessionSub  string // parent|promote|demote
+	parentRef   string // parent target for `session parent`; empty with --clear
+	clearParent bool
+
 	// help
 	helpTopic string // "agent", "agent prompt", ... ("" = full usage)
 
@@ -104,12 +110,11 @@ type command struct {
 // "did you mean?" hints and to distinguish a removed flag from a stray
 // command in the error-only migration shim.
 //
-// `agent` is a namespace group, not a new bare verb: it grows under
-// `gmux agent <verb>` exactly as decision 9 prescribes, which is why adding it
-// does not reopen the frozen top-level list — it extends it by one group.
+// `agent` and `session` are namespace groups, not new bare action verbs: they
+// grow under `gmux <group> <verb>` without reopening the frozen action list.
 var reservedVerbs = []string{
 	"open", "ls", "attach", "tail", "kill", "send", "send-keys",
-	"wait", "agent", "edit", "daemon", "auth", "remote", "version", "help",
+	"wait", "agent", "session", "edit", "daemon", "auth", "remote", "version", "help",
 }
 
 // removedFlags maps every pre-2.0 action flag to the verb that replaced
@@ -173,6 +178,8 @@ func parseCLI(args []string) (*command, error) {
 			switch {
 			case rest[0] == "agent":
 				return &command{mode: modeHelp, helpTopic: strings.TrimSpace("agent " + strings.Join(rest[1:], " "))}, nil
+			case rest[0] == "session":
+				return &command{mode: modeHelp, helpTopic: "session"}, nil
 			case rest[0] == "daemon":
 				return &command{mode: modeDaemon, daemonArgs: []string{"help"}}, nil
 			case helpTopicExists(rest[0]):
@@ -211,6 +218,12 @@ func parseCLI(args []string) (*command, error) {
 			// A mistake inside the namespace prints the namespace guide,
 			// not the top-level synopsis.
 			return nil, &usageError{topic: "agent", err: err}
+		}
+		return c, nil
+	case "session":
+		c, err := parseSession(rest)
+		if err != nil {
+			return nil, &usageError{topic: "session", err: err}
 		}
 		return c, nil
 	case "edit":
@@ -303,6 +316,49 @@ func dispatchVerb(topic string, args []string, parse func([]string) (*command, e
 			return &command{mode: modeHelp, helpTopic: topic}, nil
 		}
 		return nil, &usageError{topic: topic, err: err}
+	}
+	return c, nil
+}
+
+func parseSession(args []string) (*command, error) {
+	if len(args) == 0 || isHelpToken(args[0]) {
+		return &command{mode: modeHelp, helpTopic: "session"}, nil
+	}
+	c := &command{mode: modeSession, sessionSub: args[0]}
+	switch c.sessionSub {
+	case "promote", "demote":
+		if len(args) != 2 {
+			return nil, fmt.Errorf("session %s requires a session id", c.sessionSub)
+		}
+		c.ref = args[1]
+	case "parent":
+		pos := make([]string, 0, 2)
+		for _, arg := range args[1:] {
+			if arg == "--clear" {
+				if c.clearParent {
+					return nil, errors.New("session parent: --clear specified more than once")
+				}
+				c.clearParent = true
+				continue
+			}
+			if strings.HasPrefix(arg, "-") {
+				return nil, fmt.Errorf("session parent: unknown flag %q", arg)
+			}
+			pos = append(pos, arg)
+		}
+		if c.clearParent {
+			if len(pos) != 1 {
+				return nil, errors.New("session parent --clear requires one session id and no parent id")
+			}
+			c.ref = pos[0]
+		} else {
+			if len(pos) != 2 {
+				return nil, errors.New("session parent requires a session id and parent id (or --clear)")
+			}
+			c.ref, c.parentRef = pos[0], pos[1]
+		}
+	default:
+		return nil, fmt.Errorf("unknown session command %q (expected parent, promote, or demote)", c.sessionSub)
 	}
 	return c, nil
 }

--- a/cli/gmux/cmd/gmux/cli_test.go
+++ b/cli/gmux/cmd/gmux/cli_test.go
@@ -92,6 +92,24 @@ func TestParseCLI(t *testing.T) {
 					t.Errorf("ref = %q", c.ref)
 				}
 			}},
+		{name: "session promote", args: []string{"session", "promote", "abc"}, wantMode: modeSession,
+			check: func(t *testing.T, c *command) {
+				if c.sessionSub != "promote" || c.ref != "abc" {
+					t.Errorf("sub=%q ref=%q", c.sessionSub, c.ref)
+				}
+			}},
+		{name: "session parent", args: []string{"session", "parent", "abc", "root"}, wantMode: modeSession,
+			check: func(t *testing.T, c *command) {
+				if c.sessionSub != "parent" || c.ref != "abc" || c.parentRef != "root" || c.clearParent {
+					t.Errorf("parsed parent mutation: %#v", c)
+				}
+			}},
+		{name: "session parent clear interspersed", args: []string{"session", "parent", "abc", "--clear"}, wantMode: modeSession,
+			check: func(t *testing.T, c *command) {
+				if c.ref != "abc" || !c.clearParent || c.parentRef != "" {
+					t.Errorf("parsed clear mutation: %#v", c)
+				}
+			}},
 
 		{name: "tail defaults to 100 lines", args: []string{"tail", "abc"}, wantMode: modeTail,
 			check: func(t *testing.T, c *command) {
@@ -315,6 +333,8 @@ func TestHelpAliases(t *testing.T) {
 		{[]string{"ls", "-h"}, "ls"},
 		{[]string{"attach", "--help"}, "attach"},
 		{[]string{"kill", "?"}, "kill"},
+		{[]string{"session", "--help"}, "session"},
+		{[]string{"help", "session"}, "session"},
 		{[]string{"edit", "--help"}, "edit"},
 		{[]string{"send-keys", "--help"}, "send-keys"},
 	}
@@ -370,6 +390,8 @@ func TestUsageErrorsCarryTheirTopic(t *testing.T) {
 		{[]string{"tail"}, "tail"},
 		{[]string{"agent", "frobnicate"}, "agent"},
 		{[]string{"agent", "prompt"}, "agent"},
+		{[]string{"session", "parent", "abc"}, "session"},
+		{[]string{"session", "promote"}, "session"},
 		{[]string{"prompt", "hi"}, "agent"},
 		{[]string{"cancel", "abc"}, "agent"},
 	}

--- a/cli/gmux/cmd/gmux/help.go
+++ b/cli/gmux/cmd/gmux/help.go
@@ -33,6 +33,7 @@ Sessions (local by default; address a peer with <id>@<peer>):
   gmux send <id> <text> [Key...]    type text and keys into the terminal (raw)
   gmux wait <id>... [--timeout|-t N] block until turns end; print reports
   gmux kill <id>                    terminate a session
+  gmux session --help               promote, demote, or reparent sessions
 
 Editing (usable as $EDITOR; blocks until the editor closes):
   gmux edit [file]                  open a file for the user to inspect or edit
@@ -220,6 +221,25 @@ timeout. A local signal prints '[Wait interrupted; agent remains active]' and ex
 Sends SIGHUP to the session's child process group, waits up to two seconds,
 then escalates to SIGKILL. The session stays listed
 ('gmux ls') with its exit code, and its output remains readable.
+`,
+
+	"session": `gmux session: change task-family relationships
+
+  gmux session promote <id>              present a child as a root
+  gmux session demote <id>               restore its direct family edge
+  gmux session parent <id> <parent-id>   assign a new direct parent
+  gmux session parent --clear <id>       clear the direct parent
+
+Promotion is sticky user-authored presentation state: it preserves the direct
+parent as provenance while giving the session full root behavior, including
+independent sidebar visibility and notifications. Demotion restores the edge
+when the direct parent is a semantic agent.
+
+Reparenting changes the direct parent used by family grouping and child
+notification suppression. Both sessions must be retained on this daemon;
+self-parenting, cycles, and cross-peer reassignment are refused. A non-agent
+parent is valid provenance but presentation-inert until it has semantic-agent
+capability.
 `,
 
 	"edit": `gmux edit: open a file in a managed editor session

--- a/cli/gmux/cmd/gmux/main.go
+++ b/cli/gmux/cmd/gmux/main.go
@@ -74,6 +74,8 @@ func main() {
 		os.Exit(cmdWait(cmd.waitRefs, cmd.timeout, cmd.forText, cmd.forRegex, cmd.quiet))
 	case modeAgent:
 		os.Exit(cmdAgent(cmd))
+	case modeSession:
+		os.Exit(cmdSession(cmd))
 	case modeEdit:
 		runEdit(cmd.editFile)
 	case modeEditChild:

--- a/docs/adr/0009-verb-first-cli-and-frozen-top-level-namespace.md
+++ b/docs/adr/0009-verb-first-cli-and-frozen-top-level-namespace.md
@@ -43,6 +43,7 @@ For 2.0 we unify on a single **verb-first** grammar fronted by the
    verbs:
    - `gmux daemon start|stop|restart|status|log-path` — daemon process
      lifecycle (was the `gmuxd` verbs).
+   - `gmux session parent|promote|demote …` — explicit task-family mutations;
    - future groups (e.g. `gmux peer …`) as needed.
    `auth` and `remote` remain top-level (rare, deliberate, setup-time).
    Adding a new top-level verb is a breaking change requiring a major
@@ -73,7 +74,7 @@ For 2.0 we unify on a single **verb-first** grammar fronted by the
    that infra already invokes.)
 
 7. **Daemon auto-start is intent-driven.** Session verbs (`open`, `ls`,
-   `attach`, `tail`, `send`, `wait`, `kill`, and `gmux -- <cmd>`)
+   `attach`, `tail`, `send`, `wait`, `kill`, `gmux session …`, and `gmux -- <cmd>`)
    auto-start `gmuxd` when it is down — the daemon is a *stateful broker*
    that rehydrates dead sessions from disk, so even `ls`/`tail` on a cold
    machine have something to serve. `gmux daemon status` and bare `gmux`

--- a/docs/adr/0026-authoritative-sqlite-state-store.md
+++ b/docs/adr/0026-authoritative-sqlite-state-store.md
@@ -144,25 +144,27 @@ ADR 0025's complete host-ownership model is preserved:
 
 Placement is recalculated at existing discovery/registration points and, in a later feature, when runner/adapter common state reports a CWD/workspace change or project rules change. A project change removes the old placement and appends the session to its newly derived project transactionally. Users do not manually move sessions between projects.
 
-Ordering within a project is durable user state. It uses dense, zero-based integer positions among display siblings. The schema uses an explicit non-null sibling-scope key for roots and grouped children, avoiding SQLite's nullable-unique-index hole. Promotion, unpromotion, project reassignment, dismissal, and parent deletion rewrite every affected old/new scope to its canonical `0..n-1` order in one collision-safe transaction. Fractional ranks and linked-list ordering are rejected: they optimize writes that are negligible at sidebar scale while adding exhaustion/rebalancing or integrity complexity.
+Ordering within a project is durable user state. It uses dense, zero-based integer positions among display siblings. The schema uses an explicit non-null sibling-scope key for roots and grouped children, avoiding SQLite's nullable-unique-index hole. Promotion, unpromotion, explicit reparenting, project reassignment, dismissal, and parent deletion rewrite every affected old/new scope to its canonical `0..n-1` order in one collision-safe transaction. Reparenting therefore closes the old direct-parent scope and opens or appends to the new one atomically, with no transient duplicate or gap. Fractional ranks and linked-list ordering are rejected: they optimize writes that are negligible at sidebar scale while adding exhaustion/rebalancing or integrity complexity.
 
 Dismissed sessions have no placement or preserved order. If they register again, they are newly assigned at the normal bottom.
 
 ### 8. Parent-child provenance supports arbitrary depth
 
-A nullable parent-session ID records the session that launched a session. Every genuinely new nested `gmux` launch automatically captures the inherited `GMUX_SESSION_ID`; resume/restart retain their existing identity semantics. This is intentionally not a foreign key: the PTY child starts before the parent's asynchronous daemon registration completes, so a child may durably register first. The private domain API keeps the relationship immutable, rejects cycles as missing parents arrive, and owns deletion repair.
+A nullable parent-session ID initially records the session that launched a session. Every genuinely new nested `gmux` launch automatically captures the inherited `GMUX_SESSION_ID`; resume/restart retain their existing identity semantics. This is intentionally not a foreign key: the PTY child starts before the parent's asynchronous daemon registration completes, so a child may durably register first. Registration, observation, resume, restart, placement, and reconciliation never mutate the relationship implicitly; the domain owns deletion repair.
 
-The adjacency model permits arbitrary depth because subagents may launch subagents. Initial product behavior only passively groups recorded relationships; no closure table, materialized path, or general subtree editor is introduced.
+An explicit user-authored reparent operation is the sole exception to that implicit immutability. It may assign any retained session on the same daemon as direct parent, or clear the edge. In one transaction it verifies that the child and requested parent rows exist, rejects self-parenting, walks the requested parent's ancestor chain to reject cycles, bumps the child's row version, writes the edge, and canonically rewrites both affected sibling scopes. Cross-peer reassignment is refused. Semantic-agent capability remains a projection predicate rather than a storage constraint: an edge to a non-agent parent is valid provenance but presentation-inert.
 
-Parentage records launch provenance while both rows are retained; it is immutable during that lifetime and dismissal does not alter it. `promoted_to_root` is separate, sticky, user-authored presentation state:
+The adjacency model permits arbitrary depth because subagents may launch subagents. No closure table or materialized path is introduced; explicit reparenting is the narrow subtree-edit interface.
+
+Parentage normally records launch provenance while both rows are retained; explicit reparenting deliberately replaces that direct edge, while dismissal alone does not alter it. `promoted_to_root` remains separate, sticky, user-authored presentation state:
 
 - when true, the session renders as a project root without losing its launch parent;
 - when false, it groups beneath its parent only when both are visible in the same derived project;
 - sessions whose parent resolves to another project render as roots while retaining provenance.
 
-A parent and child derive projects independently; parentage does not override CWD/workspace matching. Dragging can reorder siblings and promote/unpromote relative to the original parent, but arbitrary adoption under an unrelated parent is out of scope.
+A parent and child derive projects independently; parentage does not override CWD/workspace matching. Dragging can reorder siblings and promote/unpromote without rewriting the parent edge. Explicit reparenting permits adoption under an unrelated retained parent and changes the direct parent used by family grouping and child-notification suppression.
 
-Dismissing a parent recursively dismisses its descendants. Permanently reconciling away a parent does not delete resumable descendants; the deletion transaction explicitly clears its direct children's parent IDs, makes them genuine roots, and intentionally forgets that deleted relationship. Their own descendant relationships remain intact.
+Dismissing a parent recursively dismisses the descendants reachable through the current direct-parent edges, including explicitly reparented descendants. Permanently reconciling away a parent does not delete resumable descendants; the deletion transaction explicitly clears its direct children's parent IDs, makes them genuine roots, and intentionally forgets that deleted relationship. Their own descendant relationships remain intact.
 
 ### 9. Cross-entity changes are domain transactions
 

--- a/docs/task-family-ui.md
+++ b/docs/task-family-ui.md
@@ -1,13 +1,22 @@
 # Task-family UI integration seam
 
 Task-family presentation uses durable `launch_parent_id` (wire:
-`parent_session_id`) without mutating launch provenance. `promoted_to_root`
-breaks only the presentation edge.
+`parent_session_id`). Normal lifecycle and placement operations never mutate
+this launch provenance; the explicit `gmux session parent` operation may
+reassign or clear the direct edge. `promoted_to_root` breaks only the
+presentation edge and never erases the stored parent.
 
 A resolved launch-parent relationship is a family edge when its direct parent
 carries `semantic_agent: true`; the child may be an agent or any other process
 session. Missing parents and children of shells, editors, or terminal helpers
-remain presentation roots and cannot be hidden accidentally.
+remain presentation roots and cannot be hidden accidentally. Reparenting to a
+non-agent is therefore valid stored provenance but presentation-inert.
+
+`gmux session promote|demote` exposes the existing sticky promotion state.
+`gmux session parent <id> <parent-id>` (or `--clear`) changes the direct parent
+used by this projection and by child-notification suppression. Both rows must
+exist on the local daemon; self-parenting, ancestor cycles, and cross-peer
+reassignment are rejected transactionally.
 
 The daemon derives `semantic_agent` from the existing
 `adapter.ConversationSource` capability. This is the same semantic distinction

--- a/services/gmuxd/cmd/gmuxd/serve_central.go
+++ b/services/gmuxd/cmd/gmuxd/serve_central.go
@@ -1030,6 +1030,11 @@ func handleCentralSessionAction(w http.ResponseWriter, r *http.Request, boot *Bo
 	}
 	if peerManager != nil && action != "" {
 		if peer, originalID := peerManager.FindPeer(sessionID); peer != nil {
+			if action == "parent" || action == "promote" || action == "demote" {
+				writeError(w, http.StatusBadRequest, codeLocalOnly, fmt.Sprintf(
+					"%s is only available for sessions owned by this daemon; run gmux on the owning host", action))
+				return
+			}
 			// Semantic agent actions are local-only in this slice (ADR 0027).
 			// Refusing is not a limitation to paper over: forwarding would run
 			// an agent on another host under a contract (readiness, admission,
@@ -1052,6 +1057,73 @@ func handleCentralSessionAction(w http.ResponseWriter, r *http.Request, boot *Bo
 	sess, ok := visibleSession(frames.Sessions, sessionID)
 	sid := centralstore.SessionID(sessionID)
 	switch action {
+	case "promote", "demote":
+		if r.Method != http.MethodPost {
+			writeError(w, http.StatusMethodNotAllowed, "bad_request", "method not allowed")
+			return
+		}
+		result, err := boot.Store.SetPromotion(r.Context(), sid, action == "promote", nil)
+		if errors.Is(err, centralstore.ErrSessionNotFound) {
+			writeError(w, http.StatusNotFound, "not_found", "session not found")
+			return
+		}
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "internal", err.Error())
+			return
+		}
+		if result.Changed {
+			boot.Composer.Invalidate(result)
+		}
+		writeJSON(w, map[string]any{"ok": true, "data": map[string]any{}})
+	case "parent":
+		if r.Method != http.MethodPost {
+			writeError(w, http.StatusMethodNotAllowed, "bad_request", "method not allowed")
+			return
+		}
+		body, err := io.ReadAll(io.LimitReader(r.Body, 4097))
+		if err != nil || len(body) > 4096 {
+			writeError(w, http.StatusBadRequest, "bad_request", "invalid request body")
+			return
+		}
+		var payload map[string]json.RawMessage
+		if err = json.Unmarshal(body, &payload); err != nil {
+			writeError(w, http.StatusBadRequest, "bad_request", "invalid JSON")
+			return
+		}
+		rawParent, present := payload["parent_session_id"]
+		if !present {
+			writeError(w, http.StatusBadRequest, "bad_request", "parent_session_id is required (use null to clear)")
+			return
+		}
+		var parent *centralstore.SessionID
+		if !bytes.Equal(bytes.TrimSpace(rawParent), []byte("null")) {
+			var parentID string
+			if err = json.Unmarshal(rawParent, &parentID); err != nil || parentID == "" {
+				writeError(w, http.StatusBadRequest, "bad_request", "parent_session_id must be a session id or null")
+				return
+			}
+			value := centralstore.SessionID(parentID)
+			parent = &value
+		}
+		result, err := boot.Store.SetSessionParent(r.Context(), sid, parent)
+		switch {
+		case errors.Is(err, centralstore.ErrSessionNotFound):
+			writeError(w, http.StatusNotFound, "not_found", "child and parent sessions must exist on this daemon")
+			return
+		case errors.Is(err, centralstore.ErrSessionParentSelf):
+			writeError(w, http.StatusConflict, "self_parent", err.Error())
+			return
+		case errors.Is(err, centralstore.ErrSessionParentCycle):
+			writeError(w, http.StatusConflict, "parent_cycle", err.Error())
+			return
+		case err != nil:
+			writeError(w, http.StatusInternalServerError, "internal", err.Error())
+			return
+		}
+		if result.Changed {
+			boot.Composer.Invalidate(result)
+		}
+		writeJSON(w, map[string]any{"ok": true, "data": map[string]any{}})
 	case "attach":
 		if r.Method != http.MethodPost {
 			writeError(w, http.StatusMethodNotAllowed, "bad_request", "method not allowed")

--- a/services/gmuxd/cmd/gmuxd/session_family_actions_test.go
+++ b/services/gmuxd/cmd/gmuxd/session_family_actions_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/centralstore"
+	central "github.com/gmuxapp/gmux/services/gmuxd/internal/snapshot/central"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/snapshot/wire"
+)
+
+func TestSessionFamilyMutationHTTPRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	st, err := centralstore.Open(ctx, t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	for _, row := range []centralstore.NewSession{
+		{ID: "root", Adapter: "pi", Command: []string{"pi"}, CreatedAt: 1},
+		{ID: "other", Adapter: "pi", Command: []string{"pi"}, CreatedAt: 2},
+		{ID: "child", Adapter: "pi", Command: []string{"pi"}, CreatedAt: 3, LaunchParentID: sessionIDPtr("root")},
+	} {
+		if _, _, err := st.InsertSession(ctx, row); err != nil {
+			t.Fatal(err)
+		}
+	}
+	boot := &Bootstrap{Store: st, Composer: central.New(st, nil, nil)}
+	fanout := newSSEFanout()
+	post := func(path, body string) *httptest.ResponseRecorder {
+		t.Helper()
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(body))
+		handleCentralSessionAction(rec, req, boot, fanout, nil, nil, nil, "")
+		return rec
+	}
+
+	if rec := post("/v1/sessions/child/promote", `{}`); rec.Code != http.StatusOK {
+		t.Fatalf("promote status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	row, _, _ := st.Session(ctx, "child")
+	if !row.PromotedToRoot || row.LaunchParentID == nil || *row.LaunchParentID != "root" {
+		t.Fatalf("promotion did not preserve provenance: %#v", row)
+	}
+	if rec := post("/v1/sessions/child/demote", `{}`); rec.Code != http.StatusOK {
+		t.Fatalf("demote status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	row, _, _ = st.Session(ctx, "child")
+	if row.PromotedToRoot || row.LaunchParentID == nil || *row.LaunchParentID != "root" {
+		t.Fatalf("demotion did not restore edge: %#v", row)
+	}
+
+	if rec := post("/v1/sessions/child/parent", `{"parent_session_id":"other"}`); rec.Code != http.StatusOK {
+		t.Fatalf("reparent status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	row, _, _ = st.Session(ctx, "child")
+	if row.LaunchParentID == nil || *row.LaunchParentID != "other" {
+		t.Fatalf("reparent not stored: %#v", row)
+	}
+	batch, err := central.RenderAll(ctx, st, central.RuntimeSourceFunc(func() map[centralstore.SessionID]central.RuntimeFacts { return nil }), nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	projected := (&wire.Converter{Titlers: map[string]func([]string) string{}, SemanticAgents: map[string]bool{"pi": true}}).Sessions(batch.Sessions, batch.Projects, nil)
+	foundProjected := false
+	for _, session := range projected.Sessions {
+		if session.ID == "child" {
+			foundProjected = true
+			if session.ParentSessionID != "other" || !session.SemanticAgent {
+				t.Fatalf("daemon family projection=%#v", session)
+			}
+		}
+	}
+	if !foundProjected {
+		t.Fatal("child absent from daemon projection")
+	}
+	if rec := post("/v1/sessions/child/parent", `{"parent_session_id":null}`); rec.Code != http.StatusOK {
+		t.Fatalf("clear status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	row, _, _ = st.Session(ctx, "child")
+	if row.LaunchParentID != nil {
+		t.Fatalf("clear not stored: %#v", row)
+	}
+}
+
+func TestSessionParentHTTPValidation(t *testing.T) {
+	ctx := context.Background()
+	st, err := centralstore.Open(ctx, t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	for _, id := range []centralstore.SessionID{"a", "b"} {
+		if _, _, err := st.InsertSession(ctx, centralstore.NewSession{ID: id, Adapter: "shell", Command: []string{"sh"}, CreatedAt: 1}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	boot := &Bootstrap{Store: st, Composer: central.New(st, nil, nil)}
+	fanout := newSSEFanout()
+	request := func(id, body string) *httptest.ResponseRecorder {
+		rec := httptest.NewRecorder()
+		handleCentralSessionAction(rec, httptest.NewRequest(http.MethodPost, "/v1/sessions/"+id+"/parent", strings.NewReader(body)), boot, fanout, nil, nil, nil, "")
+		return rec
+	}
+	if rec := request("a", `{"parent_session_id":"a"}`); rec.Code != http.StatusConflict || !strings.Contains(rec.Body.String(), "self_parent") {
+		t.Fatalf("self response=%d %s", rec.Code, rec.Body.String())
+	}
+	if rec := request("a", `{"parent_session_id":"missing"}`); rec.Code != http.StatusNotFound {
+		t.Fatalf("missing response=%d %s", rec.Code, rec.Body.String())
+	}
+	if rec := request("a", `{}`); rec.Code != http.StatusBadRequest {
+		t.Fatalf("missing field response=%d %s", rec.Code, rec.Body.String())
+	}
+	if rec := request("a", `{"parent_session_id":"b"}`); rec.Code != http.StatusOK {
+		t.Fatal(rec.Body.String())
+	}
+	if rec := request("b", `{"parent_session_id":"a"}`); rec.Code != http.StatusConflict || !strings.Contains(rec.Body.String(), "parent_cycle") {
+		t.Fatalf("cycle response=%d %s", rec.Code, rec.Body.String())
+	}
+}
+
+func sessionIDPtr(id centralstore.SessionID) *centralstore.SessionID { return &id }

--- a/services/gmuxd/internal/centralstore/admin_test.go
+++ b/services/gmuxd/internal/centralstore/admin_test.go
@@ -84,8 +84,8 @@ func TestEmbeddedSchemaVersionMatchesOpenedDatabase(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if head != got || head != 1 {
-		t.Fatalf("embedded head %d vs opened %d; want release baseline 1", head, got)
+	if head != got || head != 2 {
+		t.Fatalf("embedded head %d vs opened %d; want schema head 2", head, got)
 	}
 }
 
@@ -159,10 +159,10 @@ func TestCheckStateLaunchCycle(t *testing.T) {
 	s, _ := openAdminStore(t)
 	addSession(t, s, "a", "")
 	addSession(t, s, "b", "a")
-	// The immutability trigger blocks rewrites at runtime; a corrupt
-	// database has no such guarantee, so drop it and manufacture a cycle.
+	// The update-cycle trigger blocks corrupt rewrites at runtime; drop it
+	// to manufacture corruption that the administrative checker must find.
 	exec(t, s,
-		"DROP TRIGGER local_sessions_launch_parent_immutable_update",
+		"DROP TRIGGER local_sessions_launch_parent_no_cycle_update",
 		"UPDATE local_sessions SET launch_parent_id = 'b' WHERE id = 'a'",
 	)
 	requireFinding(t, checkFindings(t, s), "launch_cycle")

--- a/services/gmuxd/internal/centralstore/dismiss_test.go
+++ b/services/gmuxd/internal/centralstore/dismiss_test.go
@@ -36,6 +36,27 @@ func treeFixture(t *testing.T, s *Store) {
 	mustRegister(t, s, regWithParent("x", "", "/one", 40))
 }
 
+func TestDismissSessionTreeFollowsExplicitReparent(t *testing.T) {
+	ctx := context.Background()
+	s := openKernelStore(t)
+	treeFixture(t, s)
+	x := SessionID("x")
+	if _, err := s.SetSessionParent(ctx, "c", &x); err != nil {
+		t.Fatal(err)
+	}
+
+	dismissed, _, err := s.DismissSessionTree(ctx, "x", 450)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(dismissed, []SessionID{"x", "c", "g"}) {
+		t.Fatalf("dismissed reparented tree=%v", dismissed)
+	}
+	if mustSession(t, s, "p").DismissedAt != nil {
+		t.Fatal("former parent was dismissed with reparented subtree")
+	}
+}
+
 func TestDismissSessionTreeRecursive(t *testing.T) {
 	ctx := context.Background()
 	s := openKernelStore(t)

--- a/services/gmuxd/internal/centralstore/domain.go
+++ b/services/gmuxd/internal/centralstore/domain.go
@@ -100,7 +100,9 @@ var (
 	ErrStaleVersion = errors.New("centralstore: stale row version")
 	// ErrSessionNotFound marks a mutation targeting a session row that does
 	// not exist. Session() keeps its (value, ok, err) shape instead.
-	ErrSessionNotFound = errors.New("centralstore: session not found")
+	ErrSessionNotFound    = errors.New("centralstore: session not found")
+	ErrSessionParentSelf  = errors.New("centralstore: session cannot parent itself")
+	ErrSessionParentCycle = errors.New("centralstore: session parent cycle")
 	// ErrCatalogHasPlacements marks the bootstrap-only catalog boundary. This
 	// primitive cannot authoritatively rematch subjects once placement exists.
 	ErrCatalogHasPlacements = errors.New("centralstore: catalog replacement requires zero placements")
@@ -1511,6 +1513,92 @@ func (s *Store) ReorderSiblingScopes(ctx context.Context, reorders []SiblingReor
 	// Both kinds: the new positions are read back as session-row
 	// project_index stamps (see the note in place()).
 	return MutationResult{Changed: changedAny, SessionsDirty: changedAny, WorldDirty: changedAny}, nil
+}
+
+// SetSessionParent reassigns the direct provenance edge used by family
+// projection. An edge to any retained local session is valid; whether it is
+// presentation-active is derived separately from the direct parent's semantic
+// agent capability. This keeps non-agent provenance storable but inert.
+func (s *Store) SetSessionParent(ctx context.Context, id SessionID, parent *SessionID) (MutationResult, error) {
+	if id == "" {
+		return MutationResult{}, ErrSessionNotFound
+	}
+	tx, err := s.database.BeginTx(ctx, nil)
+	if err != nil {
+		return MutationResult{}, err
+	}
+	defer tx.Rollback()
+	q := s.queries.WithTx(tx)
+	row, err := q.GetSession(ctx, string(id))
+	if errors.Is(err, sql.ErrNoRows) {
+		return MutationResult{}, ErrSessionNotFound
+	}
+	if err != nil {
+		return MutationResult{}, err
+	}
+	if parent != nil && *parent == "" {
+		return MutationResult{}, ErrSessionNotFound
+	}
+	if parent != nil && *parent == id {
+		return MutationResult{}, ErrSessionParentSelf
+	}
+
+	if parent != nil {
+		cursor := *parent
+		seen := map[SessionID]bool{}
+		for cursor != "" {
+			if cursor == id || seen[cursor] {
+				return MutationResult{}, ErrSessionParentCycle
+			}
+			seen[cursor] = true
+			ancestor, getErr := q.GetSession(ctx, string(cursor))
+			if errors.Is(getErr, sql.ErrNoRows) {
+				// The requested direct parent must exist. Older provenance edges
+				// may point at a parent that has not registered yet; that inert
+				// tail cannot introduce a cycle back to this retained row.
+				if cursor == *parent {
+					return MutationResult{}, ErrSessionNotFound
+				}
+				break
+			}
+			if getErr != nil {
+				return MutationResult{}, getErr
+			}
+			if !ancestor.LaunchParentID.Valid {
+				break
+			}
+			cursor = SessionID(ancestor.LaunchParentID.String)
+		}
+	}
+
+	parentValue := ""
+	if parent != nil {
+		parentValue = string(*parent)
+	}
+	nullParent := nullString(parentValue)
+	n, err := q.SetSessionParent(ctx, db.SetSessionParentParams{
+		LaunchParentID: nullParent, ID: string(id), LaunchParentID_2: nullParent,
+	})
+	if err != nil {
+		return MutationResult{}, err
+	}
+	if n == 0 {
+		if err = tx.Commit(); err != nil {
+			return MutationResult{}, err
+		}
+		return MutationResult{SessionVersion: RowVersion(row.RowVersion)}, nil
+	}
+	all, err := placements(ctx, q)
+	if err != nil {
+		return MutationResult{}, err
+	}
+	if _, err = rewritePlacements(ctx, q, all, nil, s.beforePlacementFinalize); err != nil {
+		return MutationResult{}, err
+	}
+	if err = tx.Commit(); err != nil {
+		return MutationResult{}, err
+	}
+	return MutationResult{Changed: true, SessionVersion: RowVersion(row.RowVersion + 1), SessionsDirty: true, WorldDirty: true}, nil
 }
 
 func (s *Store) SetPromotion(ctx context.Context, id SessionID, promoted bool, index *int) (MutationResult, error) {

--- a/services/gmuxd/internal/centralstore/domain_test.go
+++ b/services/gmuxd/internal/centralstore/domain_test.go
@@ -689,6 +689,71 @@ func TestPromotionNoopVersionAndExplicitOrder(t *testing.T) {
 	}
 }
 
+func TestSessionReparentValidationAndRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	s := openKernelStore(t)
+	p := addProject(t, s)
+	addSession(t, s, "root", "")
+	addSession(t, s, "other", "")
+	addSession(t, s, "child", "root")
+	for _, id := range []SessionID{"root", "other", "child"} {
+		if _, err := s.PlaceLocalSession(ctx, id, p); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	other := SessionID("other")
+	r, err := s.SetSessionParent(ctx, "child", &other)
+	if err != nil || !r.Changed || !r.SessionsDirty || !r.WorldDirty || r.SessionVersion != 2 {
+		t.Fatalf("reparent=%#v err=%v", r, err)
+	}
+	child, ok, err := s.Session(ctx, "child")
+	if err != nil || !ok || child.LaunchParentID == nil || *child.LaunchParentID != other {
+		t.Fatalf("reparented child=%#v ok=%v err=%v", child, ok, err)
+	}
+	if got := scopeOrder(t, s, p, "c:l:other"); !reflect.DeepEqual(got, []string{"l:child"}) {
+		t.Fatalf("new direct-parent scope=%v", got)
+	}
+
+	r, err = s.SetSessionParent(ctx, "child", nil)
+	if err != nil || !r.Changed || r.SessionVersion != 3 {
+		t.Fatalf("clear parent=%#v err=%v", r, err)
+	}
+	child, _, _ = s.Session(ctx, "child")
+	if child.LaunchParentID != nil {
+		t.Fatalf("parent not cleared: %#v", child)
+	}
+	if got := rootOrder(t, s, p); !reflect.DeepEqual(got, []string{"l:root", "l:other", "l:child"}) {
+		t.Fatalf("cleared child roots=%v", got)
+	}
+
+	self := SessionID("root")
+	if _, err = s.SetSessionParent(ctx, "root", &self); !errors.Is(err, ErrSessionParentSelf) {
+		t.Fatalf("self-parent err=%v", err)
+	}
+	missing := SessionID("missing")
+	if _, err = s.SetSessionParent(ctx, "child", &missing); !errors.Is(err, ErrSessionNotFound) {
+		t.Fatalf("missing parent err=%v", err)
+	}
+	if _, err = s.SetSessionParent(ctx, "missing", nil); !errors.Is(err, ErrSessionNotFound) {
+		t.Fatalf("missing child err=%v", err)
+	}
+
+	childID := SessionID("child")
+	if _, err = s.SetSessionParent(ctx, "other", &childID); err != nil {
+		t.Fatal(err)
+	}
+	otherID := SessionID("other")
+	if _, err = s.SetSessionParent(ctx, "child", &otherID); !errors.Is(err, ErrSessionParentCycle) {
+		t.Fatalf("cycle err=%v", err)
+	}
+	child, _, _ = s.Session(ctx, "child")
+	if child.LaunchParentID != nil || child.Version != 3 {
+		t.Fatalf("cycle rejection mutated child: %#v", child)
+	}
+	assertKernelInvariants(t, s)
+}
+
 func TestReorderValidatesProjectParentAndDuplicates(t *testing.T) {
 	ctx := context.Background()
 	s := openKernelStore(t)

--- a/services/gmuxd/internal/centralstore/internal/db/query.sql
+++ b/services/gmuxd/internal/centralstore/internal/db/query.sql
@@ -76,6 +76,11 @@ UPDATE local_sessions
 SET promoted_to_root = ?, row_version = row_version + 1
 WHERE id = ? AND promoted_to_root <> ?;
 
+-- name: SetSessionParent :execrows
+UPDATE local_sessions
+SET launch_parent_id = ?, row_version = row_version + 1
+WHERE id = ? AND launch_parent_id IS NOT ?;
+
 -- name: ListProjectEntries :many
 SELECT * FROM project_entries ORDER BY sidebar_order;
 

--- a/services/gmuxd/internal/centralstore/internal/db/query.sql.go
+++ b/services/gmuxd/internal/centralstore/internal/db/query.sql.go
@@ -882,6 +882,26 @@ func (q *Queries) SetPromotion(ctx context.Context, arg SetPromotionParams) (int
 	return result.RowsAffected()
 }
 
+const setSessionParent = `-- name: SetSessionParent :execrows
+UPDATE local_sessions
+SET launch_parent_id = ?, row_version = row_version + 1
+WHERE id = ? AND launch_parent_id IS NOT ?
+`
+
+type SetSessionParentParams struct {
+	LaunchParentID   sql.NullString
+	ID               string
+	LaunchParentID_2 sql.NullString
+}
+
+func (q *Queries) SetSessionParent(ctx context.Context, arg SetSessionParentParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, setSessionParent, arg.LaunchParentID, arg.ID, arg.LaunchParentID_2)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 const sweepSessionDead = `-- name: SweepSessionDead :execrows
 UPDATE local_sessions
 SET exited_at_ms = ?1,

--- a/services/gmuxd/internal/centralstore/migrations/00002_explicit_session_reparent.sql
+++ b/services/gmuxd/internal/centralstore/migrations/00002_explicit_session_reparent.sql
@@ -1,0 +1,38 @@
+-- +goose Up
+
+-- ADR 0026 §8 amendment: lifecycle paths still leave launch_parent_id alone,
+-- but the explicit domain reparent operation may replace it after validating
+-- both retained rows. Keep cycle prevention as a database invariant too.
+DROP TRIGGER local_sessions_launch_parent_immutable_update;
+
+-- +goose StatementBegin
+CREATE TRIGGER local_sessions_launch_parent_no_cycle_update
+BEFORE UPDATE OF launch_parent_id ON local_sessions
+WHEN NEW.launch_parent_id IS NOT NULL AND OLD.launch_parent_id IS NOT NEW.launch_parent_id
+BEGIN
+    WITH RECURSIVE ancestors(id) AS (
+        SELECT NEW.launch_parent_id
+        UNION
+        SELECT s.launch_parent_id
+        FROM local_sessions AS s
+        JOIN ancestors AS a ON s.id = a.id
+        WHERE s.launch_parent_id IS NOT NULL
+    )
+    SELECT CASE WHEN EXISTS (
+        SELECT 1 FROM ancestors WHERE id = NEW.id
+    ) THEN RAISE(ABORT, 'launch parent cycle') END;
+END;
+-- +goose StatementEnd
+
+-- +goose Down
+
+DROP TRIGGER local_sessions_launch_parent_no_cycle_update;
+
+-- +goose StatementBegin
+CREATE TRIGGER local_sessions_launch_parent_immutable_update
+BEFORE UPDATE OF launch_parent_id ON local_sessions
+WHEN NEW.launch_parent_id IS NOT NULL
+BEGIN
+    SELECT RAISE(ABORT, 'launch parent can only be cleared');
+END;
+-- +goose StatementEnd

--- a/services/gmuxd/internal/centralstore/register_test.go
+++ b/services/gmuxd/internal/centralstore/register_test.go
@@ -942,7 +942,7 @@ func TestOrderTakeoverEvictionsRejectsCorruptParentCycle(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	if _, err := s.database.ExecContext(ctx, `DROP TRIGGER local_sessions_launch_parent_immutable_update`); err != nil {
+	if _, err := s.database.ExecContext(ctx, `DROP TRIGGER local_sessions_launch_parent_no_cycle_update`); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := s.database.ExecContext(ctx, `UPDATE local_sessions SET launch_parent_id = CASE id WHEN 'cycle-a' THEN 'cycle-b' ELSE 'cycle-a' END`); err != nil {

--- a/services/gmuxd/internal/centralstore/release_safety_test.go
+++ b/services/gmuxd/internal/centralstore/release_safety_test.go
@@ -316,21 +316,26 @@ func TestOpenRejectsCommittedMigrationForeignKeyViolation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	v2, err := fs.ReadFile(migrationFiles, "migrations/00002_explicit_session_reparent.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
 	files := fstest.MapFS{
-		"migrations/00001_initial_schema.sql": {Data: v1},
-		"migrations/00002_orphan.sql":         {Data: []byte("-- +goose NO TRANSACTION\n-- +goose Up\nCREATE TABLE migration_parent (id INTEGER PRIMARY KEY);\nCREATE TABLE migration_child (parent_id INTEGER REFERENCES migration_parent(id));\nPRAGMA foreign_keys=OFF;\nINSERT INTO migration_child VALUES (99);\nPRAGMA foreign_keys=ON;\n")},
+		"migrations/00001_initial_schema.sql":            {Data: v1},
+		"migrations/00002_explicit_session_reparent.sql": {Data: v2},
+		"migrations/00003_orphan.sql":                    {Data: []byte("-- +goose NO TRANSACTION\n-- +goose Up\nCREATE TABLE migration_parent (id INTEGER PRIMARY KEY);\nCREATE TABLE migration_child (parent_id INTEGER REFERENCES migration_parent(id));\nPRAGMA foreign_keys=OFF;\nINSERT INTO migration_child VALUES (99);\nPRAGMA foreign_keys=ON;\n")},
 	}
 	_, err = openWithMigrationFS(ctx, dir, files)
 	if !errors.Is(err, ErrForeignKeyIntegrity) {
 		t.Fatalf("open error = %v, want ErrForeignKeyIntegrity", err)
 	}
-	backups, globErr := filepath.Glob(filepath.Join(dir, "backups", "state-pre-migration-v1-to-v2-*.db"))
+	backups, globErr := filepath.Glob(filepath.Join(dir, "backups", "state-pre-migration-v2-to-v3-*.db"))
 	if globErr != nil || len(backups) != 1 || !strings.Contains(err.Error(), backups[0]) {
 		t.Fatalf("error/backups = %v / %v / %v; want retained path in post-migration diagnostic", err, backups, globErr)
 	}
 	database := openReleaseTestDB(t, DatabasePath(dir))
 	defer database.Close()
-	assertDBVersion(t, database, 2)
+	assertDBVersion(t, database, 3)
 }
 
 func TestQuickCheckFailureCarriesMigrationBackupPath(t *testing.T) {

--- a/services/gmuxd/internal/centralstore/store_test.go
+++ b/services/gmuxd/internal/centralstore/store_test.go
@@ -26,8 +26,8 @@ func TestOpenFreshAndReopen(t *testing.T) {
 	if got, want := store.database.Stats().MaxOpenConnections, 1; got != want {
 		t.Fatalf("MaxOpenConnections = %d, want %d", got, want)
 	}
-	if version, err := store.SchemaVersion(ctx); err != nil || version != 1 {
-		t.Fatalf("schema version = %d, %v; want 1", version, err)
+	if version, err := store.SchemaVersion(ctx); err != nil || version != 2 {
+		t.Fatalf("schema version = %d, %v; want 2", version, err)
 	}
 	if err := store.queries.PutMetadata(ctx, db.PutMetadataParams{Key: "kept", Value: "yes"}); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Summary
- expose the existing sticky `promoted_to_root` state through additive daemon actions and `gmux session promote|demote`
- add transactional direct-parent reassignment/clearing with existence, local-owner, self-parent, and cycle validation plus dense placement normalization
- amend ADR 0026 for explicit reparenting and document the family/notification semantics

## Test plan
- `go test ./internal/centralstore ./cmd/gmuxd`
- `go test ./cmd/gmux`
- `pnpm moon run gmux-web:test gmux-web:lint gmux:test gmuxd:check-centralstore-generated gmuxd:lint`