### PR TITLE
feat(web): family header breadcrumbs and floating panel redesign

### DIFF
--- a/apps/gmux-web/src/family-drawer-model.test.ts
+++ b/apps/gmux-web/src/family-drawer-model.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import { splitGroup, syncDrawer, toggleDrawerGroup, groupKey } from './family-drawer-model'
-import type { Session } from './types'
+import { FAMILY_LEVEL_CAP, splitLevel } from './family-drawer-model'
+import { projectFamily } from './family'
 import { makeSession } from './test-helpers'
 
 const at = (minute: number) => `2026-08-04T10:${String(minute).padStart(2, '0')}:00Z`
@@ -8,121 +8,35 @@ const root = makeSession({
   id: 'root', cwd: '/p', title: 'root', semantic_agent: true,
   created_at: at(0), last_output_at: at(1),
 })
-const child = (id: string, extra: Partial<Session> = {}) => makeSession({
+const child = (id: string, minute: number) => makeSession({
   id, cwd: '/p', title: id, parent_session_id: 'root', semantic_agent: true,
-  created_at: at(0), last_output_at: at(1), ...extra,
-})
-const procChild = (id: string, extra: Partial<Session> = {}) => makeSession({
-  id, cwd: '/p', title: id, parent_session_id: 'root', adapter: 'shell',
-  created_at: at(0), last_output_at: at(1), ...extra,
+  created_at: at(0), last_output_at: at(minute),
 })
 
-/** The root-selected drawer has one top-level group containing the root
- * node; its children groups are what the drawer body renders. */
-function childGroups(model: ReturnType<typeof syncDrawer>) {
-  return model.projection.groups[0].nodes[0].groups
+function rootChildren(count: number) {
+  const snapshot = [root, ...Array.from({ length: count }, (_, i) => child(`c-${i}`, 59 - i))]
+  return projectFamily(root, snapshot).siblingTrees[0].children
 }
 
-describe('drawer model: frozen ordering with explicit refresh', () => {
-  it('ignores ordinary live updates but re-projects on group toggle', () => {
-    const mover = child('mover')
-    const before = [root, mover, child('idle-friend')]
-    const model = syncDrawer(null, root, before)
-    expect(childGroups(model).map(g => g.bucket)).toEqual(['idle'])
-
-    // Live update: `mover` starts working. An ordinary re-render syncs
-    // against the new snapshot and MUST return the same frozen model —
-    // no auto-reorder under the cursor.
-    const after = [root, { ...mover, status: { active: true } }, child('idle-friend')]
-    const synced = syncDrawer(model, root, after)
-    expect(synced).toBe(model)
-    expect(childGroups(synced).map(g => g.bucket)).toEqual(['idle'])
-
-    // Explicit user action: toggling any group re-projects from current
-    // facts — `mover` now leads a working group.
-    const toggled = toggleDrawerGroup(synced, root, after, groupKey('root', 'idle'))
-    expect(toggled).not.toBe(synced)
-    expect(childGroups(toggled).map(g => g.bucket)).toEqual(['working', 'idle'])
-    expect(childGroups(toggled)[0].nodes.map(n => n.session.id)).toEqual(['mover'])
+describe('panel level split (cap + summary row)', () => {
+  it('shows small levels in full with no summary row', () => {
+    const nodes = rootChildren(FAMILY_LEVEL_CAP)
+    expect(splitLevel(nodes, 'root', new Set())).toEqual({ shown: nodes, summary: null })
   })
 
-  it('tracks expansion per (parent, bucket) across toggles and selection changes', () => {
-    const snapshot = [root, ...Array.from({ length: 5 }, (_, i) => child(`dead-${i}`, { alive: false }))]
-    let model = syncDrawer(null, root, snapshot)
-    const key = groupKey('root', 'finished')
-    model = toggleDrawerGroup(model, root, snapshot, key)
-    expect(model.expanded.has(key)).toBe(true)
-    // Selecting another family member re-projects but keeps expansion.
-    const other = snapshot[1]
-    const reselected = syncDrawer(model, other, snapshot)
-    expect(reselected).not.toBe(model)
-    expect(reselected.expanded.has(key)).toBe(true)
-    // Toggling again collapses back (two-state, no increments).
-    const collapsed = toggleDrawerGroup(reselected, other, snapshot, key)
-    expect(collapsed.expanded.has(key)).toBe(false)
-  })
-})
-
-describe('drawer model: rendered caps and summary rows', () => {
-  it('applies the 20/10/3 caps to what is actually shown', () => {
-    const snapshot = [
-      root,
-      ...Array.from({ length: 25 }, (_, i) => child(`work-${i}`, { status: { active: true } })),
-      ...Array.from({ length: 14 }, (_, i) => child(`idle-${i}`)),
-      ...Array.from({ length: 10 }, (_, i) => child(`dead-${i}`, { alive: false })),
-    ]
-    const model = syncDrawer(null, root, snapshot)
-    const groups = childGroups(model)
-    expect(groups.map(g => g.bucket)).toEqual(['working', 'idle', 'finished'])
-    const splits = groups.map(g => splitGroup(g, 'root', model.expanded))
-    expect(splits.map(s => s.shown.length)).toEqual([20, 10, 3])
-    expect(splits.map(s => s.summary?.label)).toEqual(['+5 more working', '+4 idle', '+7 finished'])
+  it('caps an over-full level at the most recent 15 behind "+N more"', () => {
+    const nodes = rootChildren(40)
+    const { shown, summary } = splitLevel(nodes, 'root', new Set())
+    expect(shown.map(n => n.session.id)).toEqual(nodes.slice(0, 15).map(n => n.session.id))
+    expect(summary).toEqual({ key: 'root', expanded: false, label: '+25 more' })
   })
 
-  it('never caps attention', () => {
-    const snapshot = [root, ...Array.from({ length: 30 }, (_, i) => child(`u-${i}`, { unread: true }))]
-    const model = syncDrawer(null, root, snapshot)
-    const [attention] = childGroups(model)
-    expect(attention.bucket).toBe('attention')
-    const split = splitGroup(attention, 'root', model.expanded)
-    expect(split.shown.length).toBe(30)
-    expect(split.summary).toBeNull()
-  })
-
-  it('shows everything plus "show fewer" once expanded', () => {
-    const snapshot = [root, ...Array.from({ length: 9 }, (_, i) => child(`dead-${i}`, { alive: false }))]
-    let model = syncDrawer(null, root, snapshot)
-    const key = groupKey('root', 'finished')
-    model = toggleDrawerGroup(model, root, snapshot, key)
-    const split = splitGroup(childGroups(model)[0], 'root', model.expanded)
-    expect(split.shown.length).toBe(9)
-    expect(split.summary).toEqual({ key, expanded: true, label: 'show fewer' })
-  })
-
-  it('words mixed hidden agents and processes as two facts', () => {
-    // Agents sort before processes within a bucket, so the 3 visible
-    // finished rows are agents; hidden = 4 agents + 2 processes.
-    const snapshot = [
-      root,
-      ...Array.from({ length: 7 }, (_, i) => child(`dead-${i}`, { alive: false })),
-      ...Array.from({ length: 2 }, (_, i) => procChild(`proc-${i}`, { alive: false })),
-    ]
-    const model = syncDrawer(null, root, snapshot)
-    const split = splitGroup(childGroups(model)[0], 'root', model.expanded)
-    expect(split.shown.every(n => !n.process)).toBe(true)
-    expect(split.summary?.label).toBe('+4 finished · 2 processes done')
-  })
-
-  it('gives process-only remainders their own noun', () => {
-    const done = [root, ...Array.from({ length: 5 }, (_, i) => procChild(`proc-${i}`, { alive: false }))]
-    const doneModel = syncDrawer(null, root, done)
-    expect(splitGroup(childGroups(doneModel)[0], 'root', doneModel.expanded).summary?.label)
-      .toBe('+2 processes done')
-
-    const running = [root, ...Array.from({ length: 12 }, (_, i) => procChild(`proc-${i}`))]
-    const runningModel = syncDrawer(null, root, running)
-    // Live shells report no agent status; they land in idle (cap 10).
-    expect(splitGroup(childGroups(runningModel)[0], 'root', runningModel.expanded).summary?.label)
-      .toBe('+2 processes')
+  it('expands two-state per parent: everything plus "show fewer"', () => {
+    const nodes = rootChildren(40)
+    const { shown, summary } = splitLevel(nodes, 'root', new Set(['root']))
+    expect(shown).toHaveLength(40)
+    expect(summary).toEqual({ key: 'root', expanded: true, label: 'show fewer' })
+    // Another parent's expansion state does not leak into this level.
+    expect(splitLevel(nodes, 'root', new Set(['other-parent'])).shown).toHaveLength(15)
   })
 })

--- a/apps/gmux-web/src/family-drawer-model.ts
+++ b/apps/gmux-web/src/family-drawer-model.ts
@@ -1,108 +1,28 @@
-import {
-  bucketedFamily, familyNavigation, FAMILY_GROUP_CAPS,
-  type BucketedFamilyProjection, type FamilyBucket, type FamilyBucketGroup,
-  type FamilyBucketNode, type FamilyNavigation,
-} from './family'
-import type { Session } from './types'
+import type { FamilyNode } from './family'
 
-/** The drawer's frozen state: one projection held for as long as the same
- * session stays selected, so live status updates repaint rows in place but
- * never re-sort the list while the user is reading it. Expansion state is
- * keyed per (parent, bucket) and survives selection changes while the
- * drawer stays open; the component unmount (drawer close) discards it. */
-export interface DrawerModel {
-  selectedId: string
-  projection: BucketedFamilyProjection
-  navigation: FamilyNavigation
-  expanded: ReadonlySet<string>
-}
+/** Per-level visible-row cap before a `+N more` summary row takes over.
+ * Recency ordering does the triage that status buckets used to: unread
+ * members have recent output by definition, so they surface within the
+ * cap while long-dead noise sinks below the fold. */
+export const FAMILY_LEVEL_CAP = 15
 
-function projectDrawer(
-  selected: Session,
-  snapshot: readonly Session[],
-  expanded: ReadonlySet<string>,
-): DrawerModel {
-  return {
-    selectedId: selected.id,
-    projection: bucketedFamily(selected, snapshot),
-    navigation: familyNavigation(selected, snapshot),
-    expanded,
-  }
-}
-
-/** Freeze rule: while the selection is unchanged, newer snapshots must NOT
- * re-project (rows would reorder under the cursor). A selection change is
- * an explicit user action and re-projects, carrying expansion state over. */
-export function syncDrawer(
-  model: DrawerModel | null,
-  selected: Session,
-  snapshot: readonly Session[],
-): DrawerModel {
-  if (model && model.selectedId === selected.id) return model
-  return projectDrawer(selected, snapshot, model?.expanded ?? new Set())
-}
-
-/** Expansion/collapse is the other explicit user action: flip the one
- * (parent, bucket) key and re-project from *current* session facts, so the
- * revealed (or re-capped) group reflects reality instead of the stale
- * membership captured when the drawer opened. */
-export function toggleDrawerGroup(
-  model: DrawerModel,
-  selected: Session,
-  snapshot: readonly Session[],
-  key: string,
-): DrawerModel {
-  const expanded = new Set(model.expanded)
-  if (expanded.has(key)) expanded.delete(key)
-  else expanded.add(key)
-  return projectDrawer(selected, snapshot, expanded)
-}
-
-export function groupKey(parentId: string, bucket: FamilyBucket): string {
-  return `${parentId}:${bucket}`
-}
-
-function processNoun(count: number): string {
-  return count === 1 ? 'process' : 'processes'
-}
-
-/** Wording for a collapsed group's summary row. Agents get the bucket noun,
- * processes their own, so `+547 finished · 12 processes done` reads as two
- * facts instead of one blurred count. */
-function summaryLabel(bucket: FamilyBucket, agents: number, processes: number): string {
-  const parts: string[] = []
-  if (agents > 0) {
-    parts.push(bucket === 'working' ? `+${agents} more working` : `+${agents} ${bucket}`)
-  }
-  if (processes > 0) {
-    parts.push(`${agents > 0 ? '' : '+'}${processes} ${processNoun(processes)}${bucket === 'finished' ? ' done' : ''}`)
-  }
-  return parts.join(' · ')
-}
-
-export interface GroupSplit {
-  shown: FamilyBucketNode[]
-  /** Present iff the group exceeds its cap: the two-state summary row. */
+export interface LevelSplit {
+  shown: readonly FamilyNode[]
+  /** Present iff the level exceeds the cap: the two-state summary row. */
   summary: { key: string; expanded: boolean; label: string } | null
 }
 
-/** Apply the per-bucket cap to one group: what the drawer actually renders.
- * Attention is never capped (`Infinity`); other groups show their first
- * `cap` rows plus a `+N …` summary, or everything plus `show fewer`. */
-export function splitGroup(
-  group: FamilyBucketGroup,
+/** Apply the cap to one children level: what the panel actually renders.
+ * Expansion is keyed per parent id and two-state — expanding shows the
+ * whole level plus `show fewer`, never an incremental ladder. */
+export function splitLevel(
+  nodes: readonly FamilyNode[],
   parentId: string,
   expanded: ReadonlySet<string>,
-): GroupSplit {
-  const cap = FAMILY_GROUP_CAPS[group.bucket]
-  if (group.nodes.length <= cap) return { shown: group.nodes, summary: null }
-  const key = groupKey(parentId, group.bucket)
-  const isExpanded = expanded.has(key)
-  const shown = isExpanded ? group.nodes : group.nodes.slice(0, cap)
-  const hidden = group.nodes.slice(shown.length)
-  const hiddenAgents = hidden.filter(node => !node.process).length
-  const label = isExpanded
-    ? 'show fewer'
-    : summaryLabel(group.bucket, hiddenAgents, hidden.length - hiddenAgents)
-  return { shown, summary: { key, expanded: isExpanded, label } }
+): LevelSplit {
+  if (nodes.length <= FAMILY_LEVEL_CAP) return { shown: nodes, summary: null }
+  const isExpanded = expanded.has(parentId)
+  const shown = isExpanded ? nodes : nodes.slice(0, FAMILY_LEVEL_CAP)
+  const label = isExpanded ? 'show fewer' : `+${nodes.length - shown.length} more`
+  return { shown, summary: { key: parentId, expanded: isExpanded, label } }
 }

--- a/apps/gmux-web/src/family-drawer.tsx
+++ b/apps/gmux-web/src/family-drawer.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useReducer, useRef } from 'preact/hooks'
-import { familyIndex, type FamilyBucketGroup, type FamilyBucketNode } from './family'
-import { splitGroup, syncDrawer, toggleDrawerGroup, type DrawerModel } from './family-drawer-model'
+import { useEffect, useRef, useState } from 'preact/hooks'
+import { familyCounts, isProcessSession, projectFamily, type FamilyNode } from './family'
+import { splitLevel } from './family-drawer-model'
 import { viewToPath } from './routing'
 import { activityMap, projects, sessions, sessionDotState, tabHref } from './store'
 import type { Session } from './types'
@@ -11,64 +11,57 @@ function hrefFor(session: Session): string | undefined {
 }
 
 function FamilyRow({ node, selectedId, depth, expanded, onToggle }: {
-  node: FamilyBucketNode
+  node: FamilyNode
   selectedId: string
   depth: number
   expanded: ReadonlySet<string>
   onToggle: (key: string) => void
 }) {
-  // Structure (order, buckets, membership) is frozen while the drawer is
-  // open; each row still reads the live session so dots and titles update
-  // in place without reshuffling the list under the cursor.
-  const session = familyIndex(sessions.value).byId.get(node.session.id) ?? node.session
-  const href = hrefFor(session)
+  const session = node.session
+  const process = isProcessSession(session)
   const rawDot = sessionDotState(session, activityMap.value)
   const dot = session.id === selectedId && (rawDot === 'error' || rawDot === 'unread') ? 'none' : rawDot
   return (
     <li>
       <a
-        class={`family-row${session.id === selectedId ? ' selected' : ''}${session.alive ? '' : ' inactive'}${node.process ? ' process' : ''}`}
+        class={`family-row${session.id === selectedId ? ' selected' : ''}${process ? ' process' : ''}`}
         style={{ paddingLeft: `${12 + depth * 18}px` }}
-        href={href}
+        href={hrefFor(session)}
         aria-current={session.id === selectedId ? 'page' : undefined}
-        tabIndex={session.id === selectedId ? 0 : undefined}
       >
-        {node.process
+        {process
           ? <span class={`family-row-proc${session.alive && session.status?.active ? ' working' : ''}`} aria-hidden="true">$</span>
           : <span class={`session-dot-indicator ${dot}`} aria-hidden="true" />}
         <span class="family-row-title">{session.title}</span>
         <span class="family-row-kind">{session.adapter}</span>
       </a>
-      {node.groups.length > 0 && (
+      {node.children.length > 0 && (
         <ul>
-          {node.groups.map(group => (
-            <GroupRows
-              key={group.bucket}
-              group={group}
-              parentId={node.session.id}
-              selectedId={selectedId}
-              depth={depth + 1}
-              expanded={expanded}
-              onToggle={onToggle}
-            />
-          ))}
+          <LevelRows
+            nodes={node.children}
+            parentId={session.id}
+            selectedId={selectedId}
+            depth={depth + 1}
+            expanded={expanded}
+            onToggle={onToggle}
+          />
         </ul>
       )}
     </li>
   )
 }
 
-/** One bucket group inside a children list: capped rows plus a two-state
- * summary row (`+N finished` / `show fewer`) keyed per (parent, bucket). */
-function GroupRows({ group, parentId, selectedId, depth, expanded, onToggle }: {
-  group: FamilyBucketGroup
+/** One children level: capped rows plus a two-state summary row
+ * (`+N more` / `show fewer`) keyed per parent. */
+function LevelRows({ nodes, parentId, selectedId, depth, expanded, onToggle }: {
+  nodes: readonly FamilyNode[]
   parentId: string
   selectedId: string
   depth: number
   expanded: ReadonlySet<string>
   onToggle: (key: string) => void
 }) {
-  const { shown, summary } = splitGroup(group, parentId, expanded)
+  const { shown, summary } = splitLevel(nodes, parentId, expanded)
   return (
     <>
       {shown.map(node => (
@@ -99,14 +92,13 @@ function GroupRows({ group, parentId, selectedId, depth, expanded, onToggle }: {
   )
 }
 
-function CountsLine({ counts }: { counts: DrawerModel['projection']['counts'] }) {
+function CountsLine({ trees }: { trees: readonly FamilyNode[] }) {
+  const counts = familyCounts(trees)
   const segments: { text: string; cls?: string }[] = []
-  if (counts.attention > 0) segments.push({ text: `${counts.attention} need attention`, cls: 'attention' })
+  if (counts.error > 0) segments.push({ text: `${counts.error} error`, cls: 'attention' })
   if (counts.working > 0) segments.push({ text: `${counts.working} working` })
-  if (counts.idle > 0) segments.push({ text: `${counts.idle} idle` })
-  if (counts.finished > 0) segments.push({ text: `${counts.finished} finished` })
-  if (counts.processes > 0) segments.push({ text: `${counts.processes} ${counts.processes === 1 ? 'process' : 'processes'}`, cls: 'processes' })
-  if (segments.length === 0) return null
+  if (counts.unread > 0) segments.push({ text: `${counts.unread} unread`, cls: 'attention' })
+  segments.push({ text: `${counts.total} total` })
   return (
     <div class="family-counts">
       {segments.map((segment, index) => (
@@ -119,111 +111,80 @@ function CountsLine({ counts }: { counts: DrawerModel['projection']['counts'] })
   )
 }
 
+/** The family panel: a non-modal popover anchored under the header's family
+ * trigger, matching the ⋮ menu's behavior — closes on outside mousedown and
+ * Escape, no focus trap. Clicking a row navigates without closing it so a
+ * family can be traversed in place. Renders live (sidebar activity-mode
+ * semantics): rows re-sort only when new output arrives, which is the same
+ * stability bar the sidebar meets. */
 export function FamilyDrawer({ selected, onClose, triggerRef }: {
   selected: Session
   onClose: () => void
   triggerRef: { current: HTMLButtonElement | null }
 }) {
-  const drawerRef = useRef<HTMLDivElement>(null)
-  const [, forceRender] = useReducer((n: number) => n + 1, 0)
-
-  // All freeze/expansion behavior lives in the pure drawer model (see
-  // family-drawer-model.ts): ordinary live updates keep the projection
-  // frozen; selection changes and group toggles re-project from current
-  // facts. `peek` keeps the projection itself unsubscribed; rows read
-  // sessions.value and repaint live. Expansion resets when the drawer
-  // closes because this component unmounts with it.
-  // Promotion intentionally defers provenance: promoted sessions present
-  // as roots even though parent_session_id remains immutable on the wire.
-  const modelRef = useRef<DrawerModel | null>(null)
-  modelRef.current = syncDrawer(modelRef.current, selected, sessions.peek())
-  const model = modelRef.current
+  const panelRef = useRef<HTMLDivElement>(null)
+  const [expanded, setExpanded] = useState<ReadonlySet<string>>(new Set())
   const toggle = (key: string) => {
-    modelRef.current = toggleDrawerGroup(modelRef.current!, selected, sessions.peek(), key)
-    forceRender(0)
+    setExpanded(prev => {
+      const next = new Set(prev)
+      if (next.has(key)) next.delete(key)
+      else next.add(key)
+      return next
+    })
   }
 
   useEffect(() => {
-    const drawer = drawerRef.current
-    drawer?.focus()
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        event.preventDefault()
-        onClose()
-        triggerRef.current?.focus()
-        return
-      }
-      if (event.key !== 'Tab' || !drawer) return
-      const focusable = [...drawer.querySelectorAll<HTMLElement>('a[href], button:not([disabled])')]
-      if (focusable.length === 0) { event.preventDefault(); drawer.focus(); return }
-      const first = focusable[0]
-      const last = focusable[focusable.length - 1]
-      if (event.shiftKey && document.activeElement === first) { event.preventDefault(); last.focus() }
-      else if (!event.shiftKey && document.activeElement === last) { event.preventDefault(); first.focus() }
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return
+      event.preventDefault()
+      onClose()
+      triggerRef.current?.focus()
     }
-    document.addEventListener('keydown', onKeyDown)
-    return () => document.removeEventListener('keydown', onKeyDown)
+    const onMouseDown = (event: MouseEvent) => {
+      const target = event.target as Node
+      if (panelRef.current?.contains(target)) return
+      if (triggerRef.current?.contains(target)) return // trigger's own click toggles
+      onClose()
+    }
+    document.addEventListener('keydown', onKey)
+    document.addEventListener('mousedown', onMouseDown)
+    return () => {
+      document.removeEventListener('keydown', onKey)
+      document.removeEventListener('mousedown', onMouseDown)
+    }
   }, [onClose, triggerRef])
 
   // Main App normally focuses the terminal after session navigation. While
-  // this modal remains open, reclaim focus onto the newly-selected row so
-  // keyboard users can traverse the family without the drawer closing or
-  // focus escaping behind it.
+  // the panel is open, reclaim focus onto the newly-selected row so keyboard
+  // users can traverse the family without focus escaping behind it.
   useEffect(() => {
     let inner = 0
     const outer = requestAnimationFrame(() => {
       inner = requestAnimationFrame(() => {
-        drawerRef.current?.querySelector<HTMLElement>('[aria-current="page"]')?.focus()
+        panelRef.current?.querySelector<HTMLElement>('[aria-current="page"]')?.focus()
       })
     })
     return () => { cancelAnimationFrame(outer); cancelAnimationFrame(inner) }
   }, [selected.id])
 
-  const navButton = (label: string, session: Session) => {
-    const href = hrefFor(session)
-    return href ? <a class="family-nav-button" href={href}>{label}</a> : null
-  }
-
-  const { projection, navigation } = model
+  // Promotion intentionally defers provenance: promoted sessions present as
+  // roots even though parent_session_id remains immutable on the wire.
+  const projection = projectFamily(selected, sessions.value)
   return (
-    <div id="agent-family-drawer" class="family-drawer" role="dialog" aria-modal="true" aria-label="Agents" tabIndex={-1} ref={drawerRef}>
+    <div id="agent-family-drawer" class="family-drawer" role="dialog" aria-label="Session family" ref={panelRef}>
       <div class="family-drawer-head">
-        <div class="family-drawer-heading">
-          <strong>Agents</strong>
-          <div class="family-drawer-nav">
-            {navigation.parent && navButton('Parent', navigation.parent)}
-            {navigation.root && navButton('Root', navigation.root)}
-            <button class="family-drawer-close" type="button" aria-label="Close agents" onClick={() => {
-              onClose()
-              triggerRef.current?.focus()
-            }}>×</button>
-          </div>
-        </div>
-        <CountsLine counts={projection.counts} />
-        {projection.ancestors.length > 0 && (
-          <ol class="family-spine" aria-label="Ancestors">
-            {projection.ancestors.map((ancestor, index) => (
-              <li key={ancestor.id}>
-                <a href={hrefFor(ancestor)}>{ancestor.title}</a>
-                {index < projection.ancestors.length - 1 && <span aria-hidden="true">›</span>}
-              </li>
-            ))}
-          </ol>
-        )}
+        <CountsLine trees={projection.siblingTrees} />
       </div>
       <div class="family-drawer-scroll">
         <ul class="family-tree">
-          {projection.groups.map(group => (
-            <GroupRows
-              key={group.bucket}
-              group={group}
-              parentId={projection.ancestors[projection.ancestors.length - 1]?.id ?? ''}
-              selectedId={selected.id}
-              depth={0}
-              expanded={model.expanded}
-              onToggle={toggle}
-            />
-          ))}
+          <LevelRows
+            nodes={projection.siblingTrees}
+            parentId={projection.ancestors[projection.ancestors.length - 1]?.id ?? projection.root.id}
+            selectedId={selected.id}
+            depth={0}
+            expanded={expanded}
+            onToggle={toggle}
+          />
         </ul>
       </div>
     </div>

--- a/apps/gmux-web/src/family.bench.ts
+++ b/apps/gmux-web/src/family.bench.ts
@@ -1,5 +1,5 @@
 import { bench, describe } from 'vitest'
-import { bucketedFamily, createFamilyIndex, projectFamily } from './family'
+import { createFamilyIndex, familyCounts, projectFamily } from './family'
 import { makeSession } from './test-helpers'
 
 const agent = (id: string, parent?: string) => makeSession({
@@ -26,11 +26,11 @@ describe('family projection (1,000 sessions / 500 children)', () => {
   })
 
   const index = createFamilyIndex(sessions)
-  bench('project the selected child drawer', () => {
+  bench('project the selected child panel', () => {
     projectFamily(children[250], index)
   })
 
-  bench('bucket the selected child drawer', () => {
-    bucketedFamily(children[250], index)
+  bench('project and count the selected child panel', () => {
+    familyCounts(projectFamily(children[250], index).siblingTrees)
   })
 })

--- a/apps/gmux-web/src/family.test.ts
+++ b/apps/gmux-web/src/family.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
-  bucketedFamily, descendantTree, familyAgentCount, familyBucket, familyIndex, familyNavigation,
-  familyRoot, FAMILY_GROUP_CAPS, hasFamily, isFamilyChild, projectFamily,
-  type FamilyBucketGroup,
+  descendantTree, familyAncestors, familyCounts, familyIndex,
+  familyRoot, hasFamily, isFamilyChild, projectFamily,
 } from './family'
 import { makeSession } from './test-helpers'
 
@@ -55,12 +54,17 @@ describe('task-family projection', () => {
     expect(snapshot.map(s => familyRoot(s, snapshot).id)).toEqual(['a', 'b', 'descendant'])
   })
 
-  it('derives non-duplicated parent/root header navigation', () => {
+  it('derives the breadcrumb ancestor spine, root first', () => {
     const root = agent('root')
     const parent = agent('parent', 'root')
     const child = agent('child', 'parent')
-    expect(familyNavigation(parent, [root, parent])).toEqual({ parent: root, root: undefined })
-    expect(familyNavigation(child, [root, parent, child])).toEqual({ parent, root })
+    const promoted = agent('promoted', 'parent', { promoted_to_root: true })
+    const snapshot = [root, parent, child, promoted]
+    expect(familyAncestors(root, snapshot)).toEqual([])
+    expect(familyAncestors(parent, snapshot).map(s => s.id)).toEqual(['root'])
+    expect(familyAncestors(child, snapshot).map(s => s.id)).toEqual(['root', 'parent'])
+    // Promotion severs the presentation edge: no crumbs, a plain title.
+    expect(familyAncestors(promoted, snapshot)).toEqual([])
   })
 
   it('keeps a promoted agent full descendant subtree as a new family', () => {
@@ -102,120 +106,64 @@ describe('task-family projection', () => {
     expect(familyRoot(children[250], snapshot)).toBe(root)
     expect(hasFamily(root, snapshot)).toBe(true)
     expect(isFamilyChild(children[250], snapshot)).toBe(true)
-    // Bucketing works off the projected trees plus the shared index; it
-    // must not rescan the snapshot array per node.
-    expect(bucketedFamily(children[250], snapshot).groups.length).toBeGreaterThan(0)
+    expect(familyAncestors(children[250], snapshot).map(s => s.id)).toEqual(['root'])
     // One indexed pass over 1,000 rows; old per-candidate Map construction
     // performed hundreds of thousands of indexed reads here.
     expect(indexedReads).toBeLessThanOrEqual(snapshot.length + 1)
   })
 })
 
-describe('bucketed drawer projection', () => {
+describe('flat panel projection', () => {
   const at = (minute: number) => `2026-08-04T10:${String(minute).padStart(2, '0')}:00Z`
   const member = (id: string, extra: Partial<Parameters<typeof makeSession>[0]> = {}) => makeSession({
     id, cwd: '/p', title: id, parent_session_id: 'root', semantic_agent: true,
     created_at: at(0), last_output_at: at(1), ...extra,
   })
-  const flat = (group: FamilyBucketGroup) => group.nodes.map(n => n.session.id)
 
-  it('caps groups at ∞/20/10/3', () => {
-    expect(FAMILY_GROUP_CAPS).toEqual({ attention: Infinity, working: 20, idle: 10, finished: 3 })
-  })
-
-  it('derives a session own bucket from the sessionDotState precedence', () => {
-    expect(familyBucket(member('e', { status: { active: true, error: true } }))).toBe('attention')
-    expect(familyBucket(member('u', { unread: true }))).toBe('attention')
-    expect(familyBucket(member('w', { status: { active: true } }))).toBe('working')
-    // Dot precedence (working > unread) carries over: still-active work
-    // isn't "waiting on you" yet even if output is unseen.
-    expect(familyBucket(member('wu', { status: { active: true }, unread: true }))).toBe('working')
-    expect(familyBucket(member('i'))).toBe('idle')
-    // Unread is not alive-gated: unseen output demands attention even
-    // after the session died.
-    expect(familyBucket(member('du', { alive: false, unread: true }))).toBe('attention')
-    // Error/working are alive-gated (as in sessionDotState); a dead,
-    // fully-viewed session is finished no matter how it ended.
-    expect(familyBucket(member('d', { alive: false, status: { active: true, error: true } }))).toBe('finished')
-  })
-
-  it('partitions a children list into attention/working/idle/finished order', () => {
+  it('orders every children level by recency, like the sidebar activity feed', () => {
     const root = agent('root')
     const sessions = [
       root,
-      member('idle-1'),
-      member('dead-1', { alive: false }),
-      member('working-1', { status: { active: true } }),
-      member('unread-1', { unread: true }),
+      member('old-working', { last_output_at: at(10), status: { active: true } }),
+      member('newest-dead', { last_output_at: at(50), alive: false }),
+      member('mid-idle', { last_output_at: at(30) }),
+      member('created-only', { last_output_at: undefined, created_at: at(20) }),
     ]
-    const projection = bucketedFamily(sessions[0], sessions)
-    // Top level: the root tree is the single (idle-bucketed) node…
-    expect(projection.groups.map(g => g.bucket)).toEqual(['attention'])
-    const rootNode = projection.groups[0].nodes[0]
-    expect(rootNode.session.id).toBe('root')
-    // …whose children carry the four buckets in display order.
-    expect(rootNode.groups.map(g => g.bucket)).toEqual(['attention', 'working', 'idle', 'finished'])
-    expect(rootNode.groups.map(flat)).toEqual([['unread-1'], ['working-1'], ['idle-1'], ['dead-1']])
-    expect(projection.counts).toEqual({ attention: 1, working: 1, idle: 2, finished: 1, processes: 0 })
+    const rootNode = projectFamily(root, sessions).siblingTrees[0]
+    // Pure recency — status (working/dead/unread) must not reorder rows;
+    // a session with no output yet sorts by creation time.
+    expect(rootNode.children.map(n => n.session.id))
+      .toEqual(['newest-dead', 'mid-idle', 'created-only', 'old-working'])
   })
 
-  it('hoists a node to its subtree highest-urgency bucket', () => {
+  it('tallies the counts line by dot precedence over all panel members', () => {
     const root = agent('root')
-    const deadParent = member('dead-parent', { alive: false })
-    const workingGrandchild = member('grandchild', {
-      parent_session_id: 'dead-parent', status: { active: true },
-    })
-    const deadSibling = member('dead-sibling', { alive: false })
-    const projection = bucketedFamily(root, [root, deadParent, workingGrandchild, deadSibling])
-    const rootNode = projection.groups[0].nodes[0]
-    // The dead parent sorts as working — its subtree contains active work —
-    // while the plain dead sibling stays in finished.
-    expect(rootNode.groups.map(g => g.bucket)).toEqual(['working', 'finished'])
-    expect(rootNode.groups.map(flat)).toEqual([['dead-parent'], ['dead-sibling']])
-    // Counts stay status-truth: the hoisted parent still tallies as finished.
-    expect(projection.counts).toEqual({ attention: 0, working: 1, idle: 1, finished: 2, processes: 0 })
-  })
-
-  it('sorts within a bucket: agents before processes, recency, natural title', () => {
-    const root = agent('root')
-    const proc = (id: string, extra = {}) => member(id, { semantic_agent: undefined, adapter: 'shell', ...extra })
     const sessions = [
       root,
-      proc('proc-new', { last_output_at: at(50) }),
-      member('agent-old', { last_output_at: at(10) }),
-      member('swarm-10', { last_output_at: at(20) }),
-      member('swarm-9', { last_output_at: at(20) }),
-      member('swarm-100', { last_output_at: at(20) }),
+      member('working', { status: { active: true } }),
+      member('working-unread', { status: { active: true }, unread: true }),
+      member('errored', { status: { active: true, error: true } }),
+      member('dead-unread', { alive: false, unread: true }),
+      member('grandchild-unread', { parent_session_id: 'working', unread: true }),
+      member('proc-working', { semantic_agent: undefined, adapter: 'shell', status: { active: true } }),
+      member('dead-viewed', { alive: false }),
     ]
-    const rootNode = bucketedFamily(root, sessions).groups[0].nodes[0]
-    expect(rootNode.groups).toHaveLength(1)
-    // Recency beats title; equal recency reads in natural numeric order;
-    // the process sinks below every agent despite being the most recent.
-    expect(flat(rootNode.groups[0])).toEqual(['swarm-9', 'swarm-10', 'swarm-100', 'agent-old', 'proc-new'])
-    expect(rootNode.groups[0].nodes.map(n => n.process)).toEqual([false, false, false, false, true])
+    const trees = projectFamily(root, sessions).siblingTrees
+    // Each member counted once under its highest-precedence state: the
+    // working-unread agent is working (dot precedence), the dead unread
+    // one is unread (not alive-gated), processes count like anyone else,
+    // and the root + quiet members only land in the total.
+    expect(familyCounts(trees)).toEqual({ error: 1, working: 3, unread: 2, total: 8 })
   })
 
-  it('projects the ancestor spine and counts only the sibling-level trees', () => {
+  it('counts only the sibling-level trees for a nested selection', () => {
     const root = agent('root')
     const parent = member('parent')
     const selected = member('selected', { parent_session_id: 'parent' })
     const sibling = member('sibling', { parent_session_id: 'parent', alive: false })
-    const projection = bucketedFamily(selected, [root, parent, selected, sibling])
+    const projection = projectFamily(selected, [root, parent, selected, sibling])
     expect(projection.ancestors.map(s => s.id)).toEqual(['root', 'parent'])
-    expect(projection.groups.map(g => g.bucket)).toEqual(['idle', 'finished'])
-    // Ancestors are breadcrumb context, not counted rows.
-    expect(projection.counts).toEqual({ attention: 0, working: 0, idle: 1, finished: 1, processes: 0 })
-  })
-
-  it('counts alive agents for the pill, excluding processes and other families', () => {
-    const root = agent('root')
-    const child = member('child')
-    const dead = member('dead', { alive: false })
-    const proc = member('proc', { semantic_agent: undefined, adapter: 'shell' })
-    const stranger = agent('stranger')
-    const sessions = [root, child, dead, proc, stranger]
-    expect(familyAgentCount(child, sessions)).toBe(2)
-    expect(familyAgentCount(root, sessions)).toBe(2)
-    expect(familyAgentCount(stranger, sessions)).toBe(1)
+    // Ancestors are breadcrumb context in the header, not counted rows.
+    expect(familyCounts(projection.siblingTrees)).toEqual({ error: 0, working: 0, unread: 0, total: 2 })
   })
 })

--- a/apps/gmux-web/src/family.ts
+++ b/apps/gmux-web/src/family.ts
@@ -125,11 +125,6 @@ export function familyRootId(id: string | null, source: FamilySource): string | 
   return session ? familyRoot(session, index).id : id
 }
 
-export interface FamilyNavigation {
-  parent?: Session
-  root?: Session
-}
-
 /** True when the selected session belongs to a family with at least one real
  * presentation edge. Orphans and standalone semantic agents stay ordinary
  * roots and therefore do not get family controls. */
@@ -138,16 +133,22 @@ export function hasFamily(session: Session, source: FamilySource): boolean {
   return index.childIds.has(session.id) || (index.childrenByParent.get(session.id)?.length ?? 0) > 0
 }
 
-/** Header/drawer navigation for a genuinely nested family member. Root is
- * omitted when it would duplicate Parent. Promoted sessions and unresolved
- * provenance intentionally expose neither control. */
-export function familyNavigation(selected: Session, source: FamilySource): FamilyNavigation {
+/** Ancestor spine for the header breadcrumbs, root first, parent last (the
+ * selected session itself excluded). Empty for roots, promoted sessions and
+ * unresolved provenance — exactly the sessions that show a plain title. */
+export function familyAncestors(selected: Session, source: FamilySource): Session[] {
   const index = indexFor(source)
-  if (!index.childIds.has(selected.id)) return {}
-  const parent = index.byId.get(selected.parent_session_id!)
-  if (!parent) return {}
-  const root = familyRoot(selected, index)
-  return { parent, root: root.id !== parent.id ? root : undefined }
+  const reverse: Session[] = []
+  const seen = new Set<string>([selected.id])
+  let cursor = selected
+  while (index.childIds.has(cursor.id)) {
+    const parent = index.byId.get(cursor.parent_session_id!)
+    if (!parent || seen.has(parent.id)) break
+    reverse.push(parent)
+    seen.add(parent.id)
+    cursor = parent
+  }
+  return reverse.reverse()
 }
 
 export interface FamilyNode {
@@ -165,132 +166,6 @@ function byRecency(a: Session, b: Session): number {
  * itself: a process (shell command, watcher, …) owned by an agent. */
 export function isProcessSession(session: Session): boolean {
   return session.semantic_agent !== true
-}
-
-/** Count of alive semantic agents in the selected session's presentation
- * family, root included. Drives the header pill's `Agents · N` count;
- * processes are intentionally excluded so the label stays truthful. */
-export function familyAgentCount(selected: Session, source: FamilySource): number {
-  const index = indexFor(source)
-  const root = familyRoot(selected, index)
-  let count = 0
-  for (const session of index.byId.values()) {
-    if (session.alive
-      && !isProcessSession(session)
-      && (index.rootById.get(session.id) ?? session) === root) count++
-  }
-  return count
-}
-
-// ── Bucketed drawer projection (noise reduction) ────────────────────────────
-
-/** Drawer grouping vocabulary, in display order. `attention` is error or
- * unread — the reason the user opened the drawer; never capped. */
-export type FamilyBucket = 'attention' | 'working' | 'idle' | 'finished'
-
-const BUCKET_RANK: Record<FamilyBucket, number> = { attention: 0, working: 1, idle: 2, finished: 3 }
-
-/** Per-group visible-row caps before a `+N …` summary row takes over. */
-export const FAMILY_GROUP_CAPS: Record<FamilyBucket, number> = {
-  attention: Infinity,
-  working: 20,
-  idle: 10,
-  finished: 3,
-}
-
-/** A session's own bucket from its own facts (no subtree inheritance).
- * Follows the `sessionDotState` precedence exactly (error > working >
- * unread, with error/working alive-gated and unread not) so a row's dot
- * and its group never disagree. In particular a dead session whose final
- * output was never viewed is `attention`, not `finished` — unseen output
- * is unseen output regardless of liveness. */
-export function familyBucket(session: Session): FamilyBucket {
-  if (session.alive && session.status?.error) return 'attention'
-  if (session.alive && session.status?.active) return 'working'
-  if (session.unread) return 'attention'
-  return session.alive ? 'idle' : 'finished'
-}
-
-export interface FamilyBucketNode {
-  session: Session
-  /** Effective bucket: the highest-urgency bucket in this node's subtree.
-   * A dead parent with a working descendant sorts (and stays visible) as
-   * working — noise is only what is transitively noise. */
-  bucket: FamilyBucket
-  process: boolean
-  /** Children partitioned into bucket groups, in display order. */
-  groups: FamilyBucketGroup[]
-}
-
-export interface FamilyBucketGroup {
-  bucket: FamilyBucket
-  nodes: FamilyBucketNode[]
-}
-
-/** Status-truth totals for the heading counts line: agents tallied by their
- * own bucket (not the hoisted effective one), processes tallied separately. */
-export interface FamilyBucketCounts {
-  attention: number
-  working: number
-  idle: number
-  finished: number
-  processes: number
-}
-
-export interface BucketedFamilyProjection {
-  root: Session
-  ancestors: Session[]
-  groups: FamilyBucketGroup[]
-  counts: FamilyBucketCounts
-}
-
-const titleCollator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' })
-
-function compareBucketNodes(a: FamilyBucketNode, b: FamilyBucketNode): number {
-  // Bucket order, agents before processes, recency, then natural title so
-  // same-batch children (`swarm-425/426/…`) read ordered instead of shuffled.
-  const at = a.session.last_output_at || a.session.created_at
-  const bt = b.session.last_output_at || b.session.created_at
-  return BUCKET_RANK[a.bucket] - BUCKET_RANK[b.bucket]
-    || Number(a.process) - Number(b.process)
-    || (bt < at ? -1 : bt > at ? 1 : 0)
-    || titleCollator.compare(a.session.title, b.session.title)
-    || (a.session.id < b.session.id ? -1 : a.session.id > b.session.id ? 1 : 0)
-}
-
-function groupBucketNodes(nodes: FamilyBucketNode[]): FamilyBucketGroup[] {
-  const sorted = [...nodes].sort(compareBucketNodes)
-  const groups: FamilyBucketGroup[] = []
-  for (const node of sorted) {
-    const last = groups[groups.length - 1]
-    if (last && last.bucket === node.bucket) last.nodes.push(node)
-    else groups.push({ bucket: node.bucket, nodes: [node] })
-  }
-  return groups
-}
-
-function toBucketNode(node: FamilyNode, counts: FamilyBucketCounts): FamilyBucketNode {
-  const children = node.children.map(child => toBucketNode(child, counts))
-  const process = isProcessSession(node.session)
-  const own = familyBucket(node.session)
-  if (process) counts.processes++
-  else counts[own]++
-  let bucket = own
-  for (const child of children) {
-    if (BUCKET_RANK[child.bucket] < BUCKET_RANK[bucket]) bucket = child.bucket
-  }
-  return { session: node.session, bucket, process, groups: groupBucketNodes(children) }
-}
-
-/** `projectFamily` with every children list (the top-level sibling list
- * included) partitioned into attention → working → idle → finished groups.
- * One pass over the projected trees on top of the shared snapshot index,
- * so the whole thing stays O(n) for a snapshot. */
-export function bucketedFamily(selected: Session, source: FamilySource): BucketedFamilyProjection {
-  const base = projectFamily(selected, indexFor(source))
-  const counts: FamilyBucketCounts = { attention: 0, working: 0, idle: 0, finished: 0, processes: 0 }
-  const top = base.siblingTrees.map(tree => toBucketNode(tree, counts))
-  return { root: base.root, ancestors: base.ancestors, groups: groupBucketNodes(top), counts }
 }
 
 /** Complete descendant tree for a presentation root. Promoted descendants are
@@ -326,18 +201,33 @@ export function projectFamily(selected: Session, source: FamilySource): FamilyDr
     return { root, ancestors: [], siblingTrees: [descendantTree(root, index)] }
   }
 
-  const reverse: Session[] = []
-  const seen = new Set<string>([selected.id])
-  let cursor = selected
-  while (index.childIds.has(cursor.id)) {
-    const parent = index.byId.get(cursor.parent_session_id!)
-    if (!parent || seen.has(parent.id)) break
-    reverse.push(parent)
-    seen.add(parent.id)
-    cursor = parent
-  }
-  const parent = reverse[0]
-  const ancestors = reverse.reverse()
+  const ancestors = familyAncestors(selected, index)
+  const parent = ancestors[ancestors.length - 1]
   const siblings = parent ? index.childrenByParent.get(parent.id) ?? [] : []
   return { root, ancestors, siblingTrees: siblings.map(s => descendantTree(s, index)) }
+}
+
+/** Status totals for the panel's counts line, over every family member the
+ * panel shows (processes included, ancestors excluded — they live in the
+ * header breadcrumbs). Each member is tallied once under its dot-precedence
+ * state so the line and the row dots can never disagree. */
+export interface FamilyCounts {
+  error: number
+  working: number
+  unread: number
+  total: number
+}
+
+export function familyCounts(trees: readonly FamilyNode[]): FamilyCounts {
+  const counts: FamilyCounts = { error: 0, working: 0, unread: 0, total: 0 }
+  const visit = (node: FamilyNode) => {
+    const s = node.session
+    counts.total++
+    if (s.alive && s.status?.error) counts.error++
+    else if (s.alive && s.status?.active) counts.working++
+    else if (s.unread) counts.unread++
+    for (const child of node.children) visit(child)
+  }
+  for (const tree of trees) visit(tree)
+  return counts
 }

--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -14,7 +14,7 @@ import { usePresence } from './use-presence'
 import { lifecycleAction } from './session-actions'
 import { MenuButton } from './menu-button'
 import { FamilyDrawer } from './family-drawer'
-import { familyAgentCount, familyNavigation, hasFamily } from './family'
+import { familyAncestors, familyRoot, hasFamily } from './family'
 
 import type { Session } from './types'
 import { SettingsModal } from './settings'
@@ -25,14 +25,15 @@ import { ToastHost } from './toast-host'
 import { pushError } from './toasts'
 
 import {
-  sessions, connState, selected, selectedId, view, health, peers,
+  sessions, connState, selected, selectedId, view, health, peers, projects,
   terminalOptions, keybinds, macCommandIsCtrl,
   keyboardOpen, terminalFindOpen, terminalScrolledUp, terminalScrollToBottom,
   urlPath, urlSearch, urlHash,
   initStore, setNavigate, navigate, navigateToSession,
   dismissSession, resumeSession, restartSession,
-  sessionStaleness,
+  sessionStaleness, sessionDotState, activityMap, familyDotById, tabHref,
 } from './store'
+import { viewToPath } from './routing'
 
 // Lazy-loaded routes (code-split, not bundled with the main app)
 const InputDiagnostics = lazy(() => import('./input-diagnostics'))
@@ -196,47 +197,20 @@ function MainHeader({ session, onRestart, onResume, resuming }: {
     )
   }
 
-  const shortCwd = session.cwd.replace(/^\/home\/[^/]+/, '~')
-  const familyNav = familyNavigation(session, sessions.value)
-
   return (
     <div class={`main-header ${keyboardOpen.value ? 'keyboard-collapsed' : ''}`}>
       <div class="main-header-left">
         {showFamily && (
-          <button
-            ref={familyTriggerRef}
-            class="family-pill"
-            type="button"
-            aria-expanded={familyOpen}
-            aria-controls="agent-family-drawer"
-            onClick={() => setFamilyOpen(open => !open)}
-          >
-            Agents · {familyAgentCount(session, sessions.value)}
-          </button>
+          <FamilyTrigger
+            session={session}
+            open={familyOpen}
+            triggerRef={familyTriggerRef}
+            onToggle={() => setFamilyOpen(open => !open)}
+          />
         )}
-        {familyNav.parent && (
-          <button
-            class="family-header-nav"
-            type="button"
-            aria-label={`Go to parent agent: ${familyNav.parent.title}`}
-            title={`Parent: ${familyNav.parent.title}`}
-            onClick={() => navigateToSession(familyNav.parent!.id)}
-          >↑</button>
-        )}
-        {familyNav.root && (
-          <button
-            class="family-header-nav"
-            type="button"
-            aria-label={`Go to root agent: ${familyNav.root.title}`}
-            title={`Root: ${familyNav.root.title}`}
-            onClick={() => navigateToSession(familyNav.root!.id)}
-          >⇈</button>
-        )}
+        {showFamily && <HeaderCrumbs session={session} />}
         <div class="main-header-title">
           {session.title}
-        </div>
-        <div class="main-header-meta">
-          <span class="main-header-cwd">{shortCwd}</span>
         </div>
       </div>
       <div class="main-header-right">
@@ -248,6 +222,76 @@ function MainHeader({ session, onRestart, onResume, resuming }: {
       )}
     </div>
   )
+}
+
+/** The family panel's trigger: a ghost icon button (3-node tree) with a
+ * corner badge showing the family's aggregated dot state — same roll-up
+ * the sidebar row shows, so background family activity is visible without
+ * opening the panel. */
+function FamilyTrigger({ session, open, triggerRef, onToggle }: {
+  session: Session
+  open: boolean
+  triggerRef: { current: HTMLButtonElement | null }
+  onToggle: () => void
+}) {
+  const rootId = familyRoot(session, sessions.value).id
+  const dot = familyDotById.value.get(rootId) ?? 'none'
+  return (
+    <button
+      ref={triggerRef}
+      class="family-trigger"
+      type="button"
+      aria-label="Session family"
+      title="Session family"
+      aria-expanded={open}
+      aria-controls="agent-family-drawer"
+      onClick={onToggle}
+    >
+      <svg class="family-trigger-icon" viewBox="0 0 16 16" aria-hidden="true">
+        <path d="M8 5.5v2M8 7.5c0 1.5-3.5 1-3.5 3M8 7.5c0 1.5 3.5 1 3.5 3" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" />
+        <circle cx="8" cy="3.75" r="1.9" fill="none" stroke="currentColor" stroke-width="1.3" />
+        <circle cx="4.5" cy="12" r="1.9" fill="none" stroke="currentColor" stroke-width="1.3" />
+        <circle cx="11.5" cy="12" r="1.9" fill="none" stroke="currentColor" stroke-width="1.3" />
+      </svg>
+      {dot !== 'none' && <span class={`family-trigger-badge session-dot-indicator ${dot}`} aria-hidden="true" />}
+    </button>
+  )
+}
+
+/** Ancestor breadcrumbs in the title row: `●root › ●parent › title`. Each
+ * crumb is a live-dotted ghost link; the current session is the plain bold
+ * title that follows (its state lives in the status chip). Depth > 3
+ * collapses the middle to a static `…` — the panel still shows the full
+ * structure. */
+function HeaderCrumbs({ session }: { session: Session }) {
+  const ancestors = familyAncestors(session, sessions.value)
+  if (ancestors.length === 0) return null
+  const shown: (Session | null)[] = ancestors.length > 3
+    ? [ancestors[0], null, ancestors[ancestors.length - 1]]
+    : [...ancestors]
+  const am = activityMap.value
+  return (
+    <nav class="header-crumbs" aria-label="Ancestor agents">
+      {shown.map((ancestor) => (
+        <Fragment key={ancestor?.id ?? 'gap'}>
+          {ancestor
+            ? (
+              <a class="header-crumb" href={sessionHref(ancestor)}>
+                <span class={`session-dot-indicator ${sessionDotState(ancestor, am)}`} aria-hidden="true" />
+                <span class="header-crumb-title">{ancestor.title}</span>
+              </a>
+            )
+            : <span class="header-crumb-gap" title="More ancestors in the family panel">…</span>}
+          <span class="header-crumb-sep" aria-hidden="true">›</span>
+        </Fragment>
+      ))}
+    </nav>
+  )
+}
+
+function sessionHref(session: Session): string | undefined {
+  const path = viewToPath({ kind: 'session', sessionId: session.id }, projects.value, sessions.value)
+  return path ? tabHref(path) : undefined
 }
 
 /** Session status in the header, one chip slot for both states: alive shows

--- a/apps/gmux-web/src/mock-data/index.ts
+++ b/apps/gmux-web/src/mock-data/index.ts
@@ -15,6 +15,7 @@ import codexMigrateConvex from './sessions/codex-migrate'
 import shellOpenclawConfigure from './sessions/shell-openclaw-configure'
 import shellOpenclawLogs from './sessions/shell-openclaw-logs'
 import { DEMO_ACTIVITY } from './sessions/demo-activity'
+import { DEMO_FAMILY } from './sessions/demo-family'
 
 /** All mock sessions. First alive session is auto-selected. */
 export const MOCK_SESSIONS: MockSession[] = [
@@ -26,6 +27,7 @@ export const MOCK_SESSIONS: MockSession[] = [
   shellOpenclawConfigure,
   shellOpenclawLogs,
   ...DEMO_ACTIVITY,
+  ...DEMO_FAMILY,
 ]
 
 /** Mock peers (host roster). Exercises the Hosts-tab groups

--- a/apps/gmux-web/src/mock-data/sessions/demo-family.ts
+++ b/apps/gmux-web/src/mock-data/sessions/demo-family.ts
@@ -1,0 +1,47 @@
+// Agent families for mock mode: a 5-deep chain (exercises the header's
+// collapsed `…` crumb, every dot state, and a long title) plus a shallow
+// long-titled pair (crumb truncation). Without these, `?mock` has no
+// family at all and the header breadcrumbs / family panel can't be seen.
+import { type MockSession, ago } from '../types'
+
+const RST = '\x1b[0m'
+const DIM = '\x1b[2m'
+
+function fam(over: Partial<MockSession> & Pick<MockSession, 'id' | 'title'>): MockSession {
+  return {
+    created_at: ago(120),
+    command: ['claude'],
+    cwd: '/home/user/dev/my-project',
+    workspace_root: '/home/user/dev/my-project',
+    remotes: { origin: 'github.com/acme/my-project' },
+    adapter: 'claude',
+    project_slug: 'my-project',
+    alive: true,
+    pid: 4242,
+    exit_code: null,
+    started_at: ago(120),
+    exited_at: null,
+    subtitle: '',
+    status: { active: false },
+    unread: false,
+    socket_path: '/tmp/gmux-sessions/mock.sock',
+    semantic_agent: true,
+    terminal: `${DIM}(family demo)${RST}`,
+    ...over,
+  }
+}
+
+export const DEMO_FAMILY: MockSession[] = [
+  fam({ id: 'fam0root', title: 'orchestrator', last_output_at: ago(40), status: { active: true } }),
+  fam({ id: 'fam1kid', title: 'implement drawer', parent_session_id: 'fam0root', unread: true, last_output_at: ago(2) }),
+  fam({ id: 'fam2kid', title: 'wire up the protocol adapter layer end to end', parent_session_id: 'fam1kid', status: { active: true }, last_output_at: ago(1) }),
+  fam({ id: 'fam3kid', title: 'refactor session store', parent_session_id: 'fam2kid', last_output_at: ago(20) }),
+  fam({
+    id: 'fam4kid',
+    title: 'investigate a really long descendant title that should truncate somewhere sensible',
+    parent_session_id: 'fam3kid', status: { active: false, error: true }, last_output_at: ago(5),
+  }),
+  // Long-titled one-parent chain (shallow case).
+  fam({ id: 'famAroot', title: 'a genuinely very long root agent title for truncation checks', last_output_at: ago(60) }),
+  fam({ id: 'famAkid', title: 'child of the long-titled root with its own long title', parent_session_id: 'famAroot', unread: true, last_output_at: ago(4) }),
+]

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -1986,8 +1986,11 @@ body {
 
 .main-header-left {
   display: flex;
-  /* Baseline so the bold title and smaller muted cwd align. */
-  align-items: baseline;
+  /* Center, not baseline: the row mixes text (title, crumbs) with boxes
+   * (the family trigger, status dots). Baseline alignment lets a single
+   * text item define the line box, which floated the title ~3px above
+   * every other control once the crumbs landed. */
+  align-items: center;
   gap: 8px;
   min-width: 0;
   overflow: hidden;
@@ -2009,9 +2012,14 @@ body {
   text-overflow: ellipsis;
   white-space: nowrap;
   letter-spacing: -0.01em;
-  display: flex;
-  align-items: center;
-  gap: 8px;
+  /* Block, not flex: text-overflow never applies to a flex container's
+   * anonymous text item, so a flex title hard-clipped mid-glyph instead
+   * of ellipsizing. line-height matches the 26px control row so the
+   * title's box lines up with the trigger and ⋮ button. */
+  display: block;
+  line-height: 26px;
+  min-width: 0;
+  flex: 0 1 auto;
 }
 
 .main-header-status {
@@ -2038,7 +2046,6 @@ body {
   width: 26px;
   height: 26px;
   flex-shrink: 0;
-  align-self: center;
   border: 0;
   border-radius: 4px;
   background: transparent;
@@ -2052,13 +2059,15 @@ body {
 }
 .family-trigger:hover,
 .family-trigger[aria-expanded="true"] { background: var(--bg-hover); color: var(--text); }
-.family-trigger-icon { width: 16px; height: 16px; }
+.family-trigger-icon { width: 16px; height: 16px; display: block; }
+/* 7px like every other status dot in the app — a one-off 6px dot reads as
+ * a rendering artifact next to the sidebar's dots. */
 .family-trigger-badge {
   position: absolute;
-  top: 1px;
-  right: 1px;
-  width: 6px;
-  height: 6px;
+  top: 2px;
+  right: 2px;
+  width: 7px;
+  height: 7px;
   pointer-events: none;
 }
 
@@ -2070,16 +2079,23 @@ body {
   align-items: center;
   gap: 2px;
   min-width: 0;
-  flex-shrink: 1;
+  /* Ancestors yield space before the current session's title does, and
+   * when even their minimums overflow the clip falls on the root end
+   * (justify-content: flex-end) so the immediate parent stays readable. */
+  flex-shrink: 2;
+  justify-content: flex-end;
   overflow: hidden;
-  align-self: center;
+  /* Match the 26px control row so crumb text shares the title's center. */
+  height: 26px;
 }
 .header-crumb {
   display: flex;
   align-items: center;
   gap: 6px;
   min-width: 0;
-  padding: 3px 6px;
+  /* 26px tall like the trigger and ⋮ buttons, so every hover rectangle in
+   * the header row is the same height. */
+  padding: 4px 6px;
   border-radius: 4px;
   color: var(--text-secondary);
   font-size: 13px;
@@ -2089,12 +2105,17 @@ body {
 .header-crumb:hover { background: var(--bg-hover); color: var(--text); }
 .header-crumb-title {
   max-width: 18ch;
+  /* No min-width: a floor here makes the crumb strip's min-content exceed
+   * its box on medium widths, and the overflow clips crumbs mid-glyph.
+   * Ellipsis-to-nothing degrades; hard clipping just looks broken. */
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 .header-crumb-sep,
-.header-crumb-gap { color: var(--text-muted); font-size: 12px; flex-shrink: 0; }
-.header-crumb-gap { padding: 0 2px; }
+.header-crumb-gap { color: var(--text-muted); font-size: 12px; flex-shrink: 0; line-height: 26px; }
+/* Same optical breathing room as a crumb's own 6px padding. */
+.header-crumb-gap { padding: 0 4px; }
 
 .family-trigger:focus-visible,
 .header-crumb:focus-visible,
@@ -2105,7 +2126,9 @@ body {
 .family-drawer {
   position: absolute;
   top: calc(100% + 4px);
-  left: 12px;
+  /* Flush with the trigger button's left edge (the header's own padding),
+   * not 4px shy of it. */
+  left: 16px;
   z-index: 100;
   width: max-content;
   min-width: 320px;
@@ -2857,9 +2880,22 @@ body {
     min-height: var(--header-height);
     padding-top: 4px;
     padding-bottom: 4px;
+    /* Two-row left column: the status chip and ⋮ belong on the title row,
+     * not floating half a row above it. */
+    align-items: flex-end;
   }
-  .main-header:has(.header-crumbs) .main-header-left { flex-wrap: wrap; row-gap: 0; }
-  .header-crumbs { order: -1; width: 100%; flex: 1 0 100%; }
+  .main-header:has(.header-crumbs) .main-header-left {
+    flex-wrap: wrap;
+    row-gap: 2px;
+    width: 100%;
+  }
+  .header-crumbs { order: -1; width: 100%; flex: 0 0 100%; justify-content: flex-start; }
+  /* The trailing separator points at the title; on the wrapped layout the
+   * title is on the next row, so it would dangle at the line end. */
+  .header-crumbs .header-crumb-sep:last-child { display: none; }
+  /* flex-basis: 0 so a long title shrinks inside the trigger's row instead
+   * of wrapping onto a third row of its own. */
+  .main-header:has(.header-crumbs) .main-header-title { flex: 1 1 0; }
 
   /* Full-width sheet instead of a floating card: a 380px popover on a
    * 390px screen is a sheet with sad margins. */

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -2014,20 +2014,6 @@ body {
   gap: 8px;
 }
 
-.main-header-meta {
-  display: flex;
-  align-items: center;
-  gap: 5px;
-  font-size: 12px;
-  color: var(--text-muted);
-}
-
-.main-header-cwd {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
 .main-header-status {
   display: flex;
   align-items: center;
@@ -2043,82 +2029,108 @@ body {
 .main-header-status.error   { color: var(--status-error); }
 .main-header-status.ended   { color: var(--text-muted); }
 
-.family-pill,
-.family-nav-button {
-  border: 1px solid var(--border);
-  border-radius: 999px;
-  background: var(--bg-surface);
-  color: var(--text-secondary);
-  font: 600 11px/1 'Source Sans 3', sans-serif;
-  padding: 6px 9px;
-  cursor: pointer;
-  text-decoration: none;
-  white-space: nowrap;
-}
-.family-pill { flex-shrink: 0; }
-.family-pill:hover,
-.family-pill[aria-expanded="true"],
-.family-nav-button:hover { color: var(--text); border-color: var(--text-muted); }
-.family-header-nav {
-  width: 24px;
-  height: 24px;
-  flex: 0 0 24px;
+/* Family trigger: a ghost icon button in the header's one control
+ * language (borderless, bg-hover, sized to match .session-menu-trigger).
+ * The corner badge repeats the family's aggregated dot state so
+ * background family activity is visible without opening the panel. */
+.family-trigger {
+  position: relative;
+  width: 26px;
+  height: 26px;
+  flex-shrink: 0;
+  align-self: center;
   border: 0;
   border-radius: 4px;
   background: transparent;
   color: var(--text-muted);
   cursor: pointer;
-  font-size: 14px;
-  line-height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   padding: 0;
+  transition: background 0.1s, color 0.1s;
 }
-.family-header-nav:hover { background: var(--bg-hover); color: var(--text); }
-.family-pill:focus-visible,
-.family-header-nav:focus-visible,
-.family-nav-button:focus-visible,
-.family-row:focus-visible,
-.family-drawer-close:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.family-trigger:hover,
+.family-trigger[aria-expanded="true"] { background: var(--bg-hover); color: var(--text); }
+.family-trigger-icon { width: 16px; height: 16px; }
+.family-trigger-badge {
+  position: absolute;
+  top: 1px;
+  right: 1px;
+  width: 6px;
+  height: 6px;
+  pointer-events: none;
+}
 
+/* Ancestor breadcrumbs in the title row: quiet path prefix, each crumb a
+ * ghost link with the ancestor's live status dot. The current session is
+ * the plain bold title that follows. */
+.header-crumbs {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  min-width: 0;
+  flex-shrink: 1;
+  overflow: hidden;
+  align-self: center;
+}
+.header-crumb {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  padding: 3px 6px;
+  border-radius: 4px;
+  color: var(--text-secondary);
+  font-size: 13px;
+  text-decoration: none;
+  white-space: nowrap;
+}
+.header-crumb:hover { background: var(--bg-hover); color: var(--text); }
+.header-crumb-title {
+  max-width: 18ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.header-crumb-sep,
+.header-crumb-gap { color: var(--text-muted); font-size: 12px; flex-shrink: 0; }
+.header-crumb-gap { padding: 0 2px; }
+
+.family-trigger:focus-visible,
+.header-crumb:focus-visible,
+.family-row:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+/* The family panel: a floating popover in the ⋮ dropdown's visual
+ * language, anchored under the trigger at the header's left edge. */
 .family-drawer {
   position: absolute;
-  top: 100%;
-  left: 0;
-  right: 0;
-  z-index: 40;
+  top: calc(100% + 4px);
+  left: 12px;
+  z-index: 100;
+  width: max-content;
+  min-width: 320px;
+  max-width: min(440px, calc(100vw - 24px));
   max-height: min(65vh, 520px);
   display: flex;
   flex-direction: column;
-  /* Opaque: terminal text ghosting through translucency reads as broken
-   * rendering, not intentional layering. */
   background: var(--bg-surface);
-  border-bottom: 1px solid var(--border);
-  box-shadow: 0 14px 30px rgba(0, 0, 0, 0.28);
+  border: 1px solid var(--border-strong);
+  border-radius: 6px;
+  box-shadow: 0 8px 24px oklch(0% 0 0 / 0.4);
 }
-/* Heading, counts and ancestor spine stay put; only the tree scrolls, so
- * the close button and "where am I" context survive a 500-row family. */
-.family-drawer-head { flex: 0 0 auto; padding: 12px 16px 0; }
-.family-drawer-scroll { flex: 1 1 auto; overflow: auto; padding: 0 16px 16px; }
-.family-drawer-heading { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+/* The counts line stays put; only the tree scrolls. */
+.family-drawer-head { flex: 0 0 auto; padding: 10px 14px 8px; border-bottom: 1px solid var(--border); }
+.family-drawer-scroll { flex: 1 1 auto; overflow: auto; padding: 6px 8px 8px; }
 .family-counts {
-  padding-top: 4px;
   font: 400 12px/1.4 'Source Sans 3', sans-serif;
   color: var(--text-muted);
 }
 .family-count-attention { color: var(--unread); font-weight: 600; }
-.family-count-processes { color: var(--text-muted); opacity: 0.8; }
-.family-drawer-nav { display: flex; align-items: center; gap: 7px; }
-.family-drawer-close { border: 0; background: transparent; color: var(--text-muted); cursor: pointer; font-size: 20px; }
-.family-spine,
 .family-tree,
 .family-tree ul { list-style: none; margin: 0; padding: 0; }
-.family-spine { display: flex; gap: 6px; align-items: center; padding: 10px 4px 8px; font-size: 12px; color: var(--text-muted); }
-.family-spine li { display: flex; gap: 6px; align-items: center; }
-.family-spine a { color: var(--text-secondary); text-decoration: none; }
-.family-tree { border-top: 1px solid var(--border); padding-top: 6px; }
 .family-row { min-height: 34px; display: flex; align-items: center; gap: 8px; padding: 6px 10px; border-radius: 5px; color: var(--text-secondary); text-decoration: none; }
 .family-row:hover { background: var(--bg-hover); color: var(--text); }
 .family-row.selected { background: var(--bg-selected); color: var(--text); }
-.family-row.inactive { opacity: 0.65; }
 /* Processes: a mono $ glyph where agents show a status dot, muted title.
  * Shape (not just color) distinguishes them from agents, so the cue
  * survives tiny sizes and color blindness. */
@@ -2837,8 +2849,31 @@ body {
     padding: 0 12px;
   }
 
-  .main-header-meta {
-    display: none;
+  /* Sessions with ancestors get a second, breadcrumb-only row above the
+   * title row; standalone sessions keep the single row. The crumbs
+   * participate in keyboard-collapsed via the header itself. */
+  .main-header:has(.header-crumbs) {
+    height: auto;
+    min-height: var(--header-height);
+    padding-top: 4px;
+    padding-bottom: 4px;
+  }
+  .main-header:has(.header-crumbs) .main-header-left { flex-wrap: wrap; row-gap: 0; }
+  .header-crumbs { order: -1; width: 100%; flex: 1 0 100%; }
+
+  /* Full-width sheet instead of a floating card: a 380px popover on a
+   * 390px screen is a sheet with sad margins. */
+  .family-drawer {
+    top: 100%;
+    left: 0;
+    right: 0;
+    width: auto;
+    min-width: 0;
+    max-width: none;
+    border-left: 0;
+    border-right: 0;
+    border-top: 0;
+    border-radius: 0;
   }
 
   .main-header-status {

--- a/docs/task-family-ui.md
+++ b/docs/task-family-ui.md
@@ -15,29 +15,38 @@ used by notification suppression and covers the conversation-backed Pi,
 Claude, and Codex adapters without a frontend adapter-name list. Shell remains
 false.
 
-## Drawer presentation (noise reduction)
+## Header and panel presentation
 
-Every children list in the drawer (the top-level sibling list included) is
-partitioned into attention → working → idle → finished groups, classified
-by the `sessionDotState` precedence so a row's dot and its group never
-disagree: error and unread demand attention (unread is not alive-gated —
-unseen output pings until viewed, dead or not), active work is working,
-and only quiet sessions land in idle/finished. A node sorts into the
-highest-urgency bucket found in its entire subtree, so collapsed summaries
-can never hide urgent descendants. Groups are capped (attention ∞,
-working 20, idle 10, finished 3) behind `+N …` summary rows with
-per-(parent, bucket) expansion that resets when the drawer closes. The
-projection is frozen against ordinary live updates while the drawer is
-open — dots update in place, rows never re-sort under the cursor — and
-re-projects from current facts on the two explicit user actions: selecting
-another session and expanding/collapsing a group.
+The header speaks one control language: ghost icon buttons (borderless,
+`--bg-hover` on hover, sized to the ⋮ menu trigger). For family members
+the title row is the ancestor breadcrumb — `[family icon] ●root › ●parent
+› title` — where each crumb is a ghost link carrying that ancestor's live
+`sessionDotState` dot; the current session stays a plain bold title (its
+state lives in the status chip). Depth > 3 collapses the middle to a
+static `…`. On narrow screens the crumbs wrap onto their own row above
+the title. The family trigger (3-node tree SVG) shows the family's
+aggregated dot as a corner badge and toggles the panel; there is no cwd,
+no member count, and no separate parent/root buttons.
 
-Outside the drawer a root row stands in for its whole family:
+The panel is a non-modal popover in the ⋮ dropdown's visual language
+(width `max-content` clamped 320–440px on desktop, full-width sheet on
+mobile). It closes on outside mousedown, Escape, or the trigger; clicking
+a row navigates without closing it. Content is a counts line (`N error ·
+N working · N unread · N total`, dot-precedence tallies) plus the family
+tree. Every children level is one flat list in sidebar activity-mode
+order: recency of `last_output_at ?? created_at`, no status buckets, no
+alive/dead distinction — state is only the row's five-state dot. The
+panel renders live; like the sidebar, a row moves only when new output
+arrives. Levels are capped at 15 rows behind a two-state `+N more` /
+`show fewer` summary keyed per parent (recency does the triage: unread
+members have recent output by definition, so they surface within the
+cap while long-dead noise sinks below the fold).
+
+Outside the panel a root row stands in for its whole family:
 `familyDotById` aggregates the highest-precedence member dot onto the
-presentation root, and `unreadCount` adds alive unread descendants to their
-folder-visible root (the count keeps its existing alive gate). Processes
-render with a `$` glyph and are excluded from the header pill's
-`Agents · N` count.
+presentation root, and `unreadCount` adds alive unread descendants to
+their folder-visible root (the count keeps its existing alive gate).
+Processes render with a `$` glyph in place of the dot.
 
 ## Unresolved capability seam
 


### PR DESCRIPTION
Post-#467 redesign of the family surfaces, per design discussion: one header control language, breadcrumbs as the title row, a floating non-modal panel, and sidebar-consistent list semantics.

## Header

- **One control species: ghost icon buttons.** The `Agents · N` pill, the `↑`/`⇈` arrow buttons, and the header cwd are gone. The header's left side is now `[tree icon] ●root › ●parent › title`.
- **The title row is the ancestor breadcrumb.** Each ancestor crumb is a ghost link carrying its live five-state status dot; the current session stays the plain bold title (its state lives in the status chip). Depth > 3 collapses the middle to a static `…`. Crumbs are the only ancestor navigation — parent and root are each one visible click, no drawer needed.
- **Trigger = 3-node tree SVG** in the ⋮ trigger's exact ghost style, held `--bg-hover` while open, with the family's aggregated dot (`familyDotById`) as a corner badge — background family activity shows without opening anything. No count, so the only header text is the path and title.
- **Mobile:** sessions with ancestors get a conditional second row (crumbs above the title); standalone sessions keep one row. Participates in `keyboard-collapsed`.

## Panel

- **Floating popover on desktop** in the ⋮ dropdown's visual language (`--border-strong`, radius 6, same shadow, 4px gap), left-anchored, `max-content` width clamped 320–440px. **Full-width sheet on mobile.**
- **Non-modal, ⋮-menu behavior:** closes on outside mousedown, Escape (focus → trigger), or the trigger; no focus trap. Clicking a row navigates *without* closing, so a family can be traversed in place.
- **List = sidebar activity mode.** Every children level is one flat list ordered by `last_output_at ?? created_at` recency, rendered live — no status buckets, no alive/dead distinction, no frozen projection. State is only the row's five-state dot (`$` glyph still marks processes). Rows move only when new output arrives, the sidebar's own stability bar.
- **Levels cap at 15** behind a two-state `+N more` / `show fewer` summary per parent. Recency does the triage the buckets used to: unread implies recent output, so it surfaces within the cap while long-dead noise sinks.
- **Counts line:** `N error · N working · N unread · N total` — dot-precedence tallies, non-zero segments only.

## Deletions

`familyBucket` / `bucketedFamily` / `FAMILY_GROUP_CAPS`, subtree-max hoisting, the freeze/toggle drawer model, the drawer spine and Parent/Root buttons, `familyAgentCount`, `familyNavigation`, pill/nav-button CSS. Net: −280 lines of src. The #462 O(n) snapshot guard and bench stay, retargeted at the flat projection (~0.06 ms per render for the 500-child family, so live rendering is cheap). Roll-ups outside the panel (`familyDotById`, `unreadCount`) are unchanged.

## Screenshots

| | |
|---|---|
| Header breadcrumbs (2 ancestors, live dots) | ![header](https://raw.githubusercontent.com/gmuxapp/gmux/mgabor/family-drawer-shots/.pr-assets/v2-header-crumbs.png) |
| Panel, small family (root selected) | ![root](https://raw.githubusercontent.com/gmuxapp/gmux/mgabor/family-drawer-shots/.pr-assets/v2-panel-root.png) |
| Panel, 588-child family — top | ![monster](https://raw.githubusercontent.com/gmuxapp/gmux/mgabor/family-drawer-shots/.pr-assets/v2-panel-monster.png) |
| Panel, 588-child family — ends at `+572 more` | ![monster bottom](https://raw.githubusercontent.com/gmuxapp/gmux/mgabor/family-drawer-shots/.pr-assets/v2-panel-monster-bottom.png) |
| Mobile: crumb row + full-width sheet | ![mobile](https://raw.githubusercontent.com/gmuxapp/gmux/mgabor/family-drawer-shots/.pr-assets/v2-mobile-panel.png) |

Screenshots live on the throwaway `mgabor/family-drawer-shots` branch (not for merge).
