### PR TITLE
feat: session promote, demote, and reparent

### DIFF
--- a/apps/gmux-web/src/family.test.ts
+++ b/apps/gmux-web/src/family.test.ts
@@ -37,6 +37,21 @@ describe('task-family projection', () => {
     expect(descendantTree(child, sessions).session).toBe(child)
   })
 
+  it('reprojects against a reassigned or cleared direct parent', () => {
+    const first = agent('first')
+    const second = agent('second')
+    const child = agent('child', 'first')
+    expect(familyRoot(child, [first, second, child])).toBe(first)
+
+    const reparented = { ...child, parent_session_id: 'second' }
+    expect(familyRoot(reparented, [first, second, reparented])).toBe(second)
+    expect(isFamilyChild(reparented, [first, second, reparented])).toBe(true)
+
+    const cleared = { ...child, parent_session_id: undefined }
+    expect(familyRoot(cleared, [first, second, cleared])).toBe(cleared)
+    expect(isFamilyChild(cleared, [first, second, cleared])).toBe(false)
+  })
+
   it('shows family controls only when a real edge exists', () => {
     const root = agent('root')
     const child = agent('child', 'root')

--- a/cli/gmux/cmd/gmux/actions.go
+++ b/cli/gmux/cmd/gmux/actions.go
@@ -459,6 +459,65 @@ func cmdKill(ref string) int {
 	return 0
 }
 
+func cmdSession(cmd *command) int {
+	sess, err := resolveSession(cmd.ref)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "gmux:", err)
+		return 1
+	}
+	if sess.Peer != "" {
+		fmt.Fprintln(os.Stderr, "gmux: session family mutations require a session owned by this daemon; run gmux on the owning host")
+		return 1
+	}
+
+	body := "{}"
+	if cmd.sessionSub == "reparent" {
+		var parentID any
+		if !cmd.clearParent {
+			parent, resolveErr := resolveSession(cmd.parentRef)
+			if resolveErr != nil {
+				fmt.Fprintln(os.Stderr, "gmux:", resolveErr)
+				return 1
+			}
+			if parent.Peer != "" {
+				fmt.Fprintln(os.Stderr, "gmux: parent session must be owned by this daemon; cross-peer reparenting is not supported")
+				return 1
+			}
+			parentID = parent.ID
+		}
+		encoded, marshalErr := json.Marshal(map[string]any{"parent_session_id": parentID})
+		if marshalErr != nil {
+			fmt.Fprintln(os.Stderr, "gmux:", marshalErr)
+			return 1
+		}
+		body = string(encoded)
+	}
+
+	url := gmuxdBaseURL() + "/v1/sessions/" + sess.ID + "/" + cmd.sessionSub
+	resp, err := gmuxdClient().Post(url, "application/json", strings.NewReader(body))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "gmux:", err)
+		return 1
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		responseBody, _ := io.ReadAll(resp.Body)
+		fmt.Fprintf(os.Stderr, "gmux: session %s failed: %s: %s\n", cmd.sessionSub, resp.Status, strings.TrimSpace(string(responseBody)))
+		return 1
+	}
+	switch {
+	case cmd.sessionSub == "reparent" && cmd.clearParent:
+		fmt.Printf("cleared parent of %s\n", displayID(sess))
+	case cmd.sessionSub == "reparent":
+		fmt.Printf("reparented %s under %s\n", displayID(sess), cmd.parentRef)
+	case cmd.sessionSub == "promote":
+		fmt.Printf("promoted %s to root\n", displayID(sess))
+	default:
+		fmt.Printf("demoted %s\n", displayID(sess))
+	}
+	return 0
+}
+
 // cmdTail implements `gmux tail <id> [-n N]`: the last n lines of the
 // session's terminal output, for any session, always.
 //

--- a/cli/gmux/cmd/gmux/cli.go
+++ b/cli/gmux/cmd/gmux/cli.go
@@ -26,6 +26,7 @@ const (
 	modeSendKeys               // gmux send-keys -t <id> ... (tmux-compat)
 	modeWait                   // gmux wait <id>...
 	modeAgent                  // gmux agent prompt|cancel|output <id>
+	modeSession                // gmux session promote|demote|reparent <id>
 	modeEdit                   // gmux edit [file]
 	modeEditChild              // (internal) gmux __edit-child [file]
 	modeDaemon                 // gmux daemon <start|stop|restart|status|log-path|state ...>
@@ -79,6 +80,11 @@ type command struct {
 	agentModel  string  // --new only: model selector for the launch
 	agentName   string  // --new only: session display name for the launch
 
+	// session (modeSession)
+	sessionSub  string // promote|demote|reparent
+	parentRef   string // reparent target; empty with --clear
+	clearParent bool
+
 	// help
 	helpTopic string // "agent", "agent prompt", ... ("" = full usage)
 
@@ -104,12 +110,11 @@ type command struct {
 // "did you mean?" hints and to distinguish a removed flag from a stray
 // command in the error-only migration shim.
 //
-// `agent` is a namespace group, not a new bare verb: it grows under
-// `gmux agent <verb>` exactly as decision 9 prescribes, which is why adding it
-// does not reopen the frozen top-level list — it extends it by one group.
+// `agent` and `session` are namespace groups, not bare action verbs. They grow
+// under `gmux <group> <verb>` without reopening the frozen action list.
 var reservedVerbs = []string{
 	"open", "ls", "attach", "tail", "kill", "send", "send-keys",
-	"wait", "agent", "edit", "daemon", "auth", "remote", "version", "help",
+	"wait", "agent", "session", "edit", "daemon", "auth", "remote", "version", "help",
 }
 
 // removedFlags maps every pre-2.0 action flag to the verb that replaced
@@ -173,6 +178,8 @@ func parseCLI(args []string) (*command, error) {
 			switch {
 			case rest[0] == "agent":
 				return &command{mode: modeHelp, helpTopic: strings.TrimSpace("agent " + strings.Join(rest[1:], " "))}, nil
+			case rest[0] == "session":
+				return &command{mode: modeHelp, helpTopic: "session"}, nil
 			case rest[0] == "daemon":
 				return &command{mode: modeDaemon, daemonArgs: []string{"help"}}, nil
 			case helpTopicExists(rest[0]):
@@ -211,6 +218,12 @@ func parseCLI(args []string) (*command, error) {
 			// A mistake inside the namespace prints the namespace guide,
 			// not the top-level synopsis.
 			return nil, &usageError{topic: "agent", err: err}
+		}
+		return c, nil
+	case "session":
+		c, err := parseSession(rest)
+		if err != nil {
+			return nil, &usageError{topic: "session", err: err}
 		}
 		return c, nil
 	case "edit":
@@ -305,6 +318,49 @@ func dispatchVerb(topic string, args []string, parse func([]string) (*command, e
 		return nil, &usageError{topic: topic, err: err}
 	}
 	return c, nil
+}
+
+func parseSession(args []string) (*command, error) {
+	if len(args) == 0 || isHelpToken(args[0]) {
+		return &command{mode: modeHelp, helpTopic: "session"}, nil
+	}
+	cmd := &command{mode: modeSession, sessionSub: args[0]}
+	switch cmd.sessionSub {
+	case "promote", "demote":
+		if len(args) != 2 {
+			return nil, fmt.Errorf("session %s requires a session id", cmd.sessionSub)
+		}
+		cmd.ref = args[1]
+	case "reparent":
+		positional := make([]string, 0, 2)
+		for _, arg := range args[1:] {
+			switch {
+			case arg == "--clear":
+				if cmd.clearParent {
+					return nil, errors.New("session reparent: --clear specified more than once")
+				}
+				cmd.clearParent = true
+			case strings.HasPrefix(arg, "-"):
+				return nil, fmt.Errorf("session reparent: unknown flag %q", arg)
+			default:
+				positional = append(positional, arg)
+			}
+		}
+		if cmd.clearParent {
+			if len(positional) != 1 {
+				return nil, errors.New("session reparent --clear requires one session id and no parent id")
+			}
+			cmd.ref = positional[0]
+		} else {
+			if len(positional) != 2 {
+				return nil, errors.New("session reparent requires a session id and parent id (or --clear)")
+			}
+			cmd.ref, cmd.parentRef = positional[0], positional[1]
+		}
+	default:
+		return nil, fmt.Errorf("unknown session command %q (expected promote, demote, or reparent)", cmd.sessionSub)
+	}
+	return cmd, nil
 }
 
 func parseLs(args []string) (*command, error) {

--- a/cli/gmux/cmd/gmux/cli_test.go
+++ b/cli/gmux/cmd/gmux/cli_test.go
@@ -92,6 +92,24 @@ func TestParseCLI(t *testing.T) {
 					t.Errorf("ref = %q", c.ref)
 				}
 			}},
+		{name: "session promote", args: []string{"session", "promote", "abc"}, wantMode: modeSession,
+			check: func(t *testing.T, c *command) {
+				if c.sessionSub != "promote" || c.ref != "abc" {
+					t.Errorf("session command=%#v", c)
+				}
+			}},
+		{name: "session reparent", args: []string{"session", "reparent", "abc", "root"}, wantMode: modeSession,
+			check: func(t *testing.T, c *command) {
+				if c.sessionSub != "reparent" || c.ref != "abc" || c.parentRef != "root" || c.clearParent {
+					t.Errorf("session command=%#v", c)
+				}
+			}},
+		{name: "session reparent clear", args: []string{"session", "reparent", "abc", "--clear"}, wantMode: modeSession,
+			check: func(t *testing.T, c *command) {
+				if c.ref != "abc" || !c.clearParent || c.parentRef != "" {
+					t.Errorf("session command=%#v", c)
+				}
+			}},
 
 		{name: "tail defaults to 100 lines", args: []string{"tail", "abc"}, wantMode: modeTail,
 			check: func(t *testing.T, c *command) {
@@ -315,6 +333,8 @@ func TestHelpAliases(t *testing.T) {
 		{[]string{"ls", "-h"}, "ls"},
 		{[]string{"attach", "--help"}, "attach"},
 		{[]string{"kill", "?"}, "kill"},
+		{[]string{"session", "--help"}, "session"},
+		{[]string{"help", "session"}, "session"},
 		{[]string{"edit", "--help"}, "edit"},
 		{[]string{"send-keys", "--help"}, "send-keys"},
 	}
@@ -370,6 +390,8 @@ func TestUsageErrorsCarryTheirTopic(t *testing.T) {
 		{[]string{"tail"}, "tail"},
 		{[]string{"agent", "frobnicate"}, "agent"},
 		{[]string{"agent", "prompt"}, "agent"},
+		{[]string{"session", "reparent", "abc"}, "session"},
+		{[]string{"session", "promote"}, "session"},
 		{[]string{"prompt", "hi"}, "agent"},
 		{[]string{"cancel", "abc"}, "agent"},
 	}
@@ -404,6 +426,7 @@ func TestUsageErrorsCarryTheirTopic(t *testing.T) {
 	for topic, want := range map[string]string{
 		"":             "run 'gmux --help' for usage",
 		"wait":         "run 'gmux wait --help' for usage",
+		"session":      "run 'gmux session --help' for usage",
 		"send":         "run 'gmux send --help' for usage",
 		"agent":        "run 'gmux agent --help' for usage",
 		"agent prompt": "run 'gmux agent --help' for usage",

--- a/cli/gmux/cmd/gmux/help.go
+++ b/cli/gmux/cmd/gmux/help.go
@@ -33,6 +33,7 @@ Sessions (local by default; address a peer with <id>@<peer>):
   gmux send <id> <text> [Key...]    type text and keys into the terminal (raw)
   gmux wait <id>... [--timeout|-t N] block until turns end; print reports
   gmux kill <id>                    terminate a session
+  gmux session --help               promote, demote, or reparent sessions
 
 Editing (usable as $EDITOR; blocks until the editor closes):
   gmux edit [file]                  open a file for the user to inspect or edit
@@ -220,6 +221,22 @@ timeout. A local signal prints '[Wait interrupted; agent remains active]' and ex
 Sends SIGHUP to the session's child process group, waits up to two seconds,
 then escalates to SIGKILL. The session stays listed
 ('gmux ls') with its exit code, and its output remains readable.
+`,
+
+	"session": `gmux session: change task-family ownership
+
+  gmux session promote <id>                present a child as a root
+  gmux session demote <id>                 restore normal child presentation
+  gmux session reparent <id> <parent-id>   assign a new direct parent
+  gmux session reparent <id> --clear       clear the direct parent
+
+Promotion is sticky presentation state: it preserves the organizational
+parent while giving the session full root visibility and notification behavior.
+Demotion clears that presentation override.
+
+Reparenting changes the parent used by family grouping, recursive dismissal,
+and child-notification suppression. Both sessions must exist on this daemon;
+self-parenting, cycles, and cross-peer reassignment are refused.
 `,
 
 	"edit": `gmux edit: open a file in a managed editor session

--- a/cli/gmux/cmd/gmux/main.go
+++ b/cli/gmux/cmd/gmux/main.go
@@ -74,6 +74,8 @@ func main() {
 		os.Exit(cmdWait(cmd.waitRefs, cmd.timeout, cmd.forText, cmd.forRegex, cmd.quiet))
 	case modeAgent:
 		os.Exit(cmdAgent(cmd))
+	case modeSession:
+		os.Exit(cmdSession(cmd))
 	case modeEdit:
 		runEdit(cmd.editFile)
 	case modeEditChild:

--- a/docs/acp-host-program.md
+++ b/docs/acp-host-program.md
@@ -174,8 +174,9 @@ best-effort (v2's `messageId` makes it exact).
 The ACP runner must carry the same session facts the PTY runner does:
 
 - **Launch parent provenance**: inherit `GMUX_SESSION_ID` at driven launch
-  into `ParentSessionID`, through runner state, `/meta`, and registration
-  (`launch_parent_id`); resume/restart never acquires a new parent.
+  into `ParentSessionID`, through runner state and `/meta`. Registration copies
+  it into both organizational `parent_session_id` and write-once
+  `launched_from_session_id`; resume/restart changes neither.
 - **`semantic_agent`** derives from `adapter.ConversationSource` — Claude
   and Codex adapters already implement it, so ACP-mode sessions
   participate in family edges and child-notification suppression

--- a/docs/adr/0009-verb-first-cli-and-frozen-top-level-namespace.md
+++ b/docs/adr/0009-verb-first-cli-and-frozen-top-level-namespace.md
@@ -43,6 +43,8 @@ For 2.0 we unify on a single **verb-first** grammar fronted by the
    verbs:
    - `gmux daemon start|stop|restart|status|log-path` — daemon process
      lifecycle (was the `gmuxd` verbs).
+   - `gmux session promote|demote|reparent …` — explicit task-family
+     presentation and ownership mutations.
    - future groups (e.g. `gmux peer …`) as needed.
    `auth` and `remote` remain top-level (rare, deliberate, setup-time).
    Adding a new top-level verb is a breaking change requiring a major
@@ -73,7 +75,7 @@ For 2.0 we unify on a single **verb-first** grammar fronted by the
    that infra already invokes.)
 
 7. **Daemon auto-start is intent-driven.** Session verbs (`open`, `ls`,
-   `attach`, `tail`, `send`, `wait`, `kill`, and `gmux -- <cmd>`)
+   `attach`, `tail`, `send`, `wait`, `kill`, `gmux session …`, and `gmux -- <cmd>`)
    auto-start `gmuxd` when it is down — the daemon is a *stateful broker*
    that rehydrates dead sessions from disk, so even `ls`/`tail` on a cold
    machine have something to serve. `gmux daemon status` and bare `gmux`

--- a/docs/adr/0026-authoritative-sqlite-state-store.md
+++ b/docs/adr/0026-authoritative-sqlite-state-store.md
@@ -144,25 +144,34 @@ ADR 0025's complete host-ownership model is preserved:
 
 Placement is recalculated at existing discovery/registration points and, in a later feature, when runner/adapter common state reports a CWD/workspace change or project rules change. A project change removes the old placement and appends the session to its newly derived project transactionally. Users do not manually move sessions between projects.
 
-Ordering within a project is durable user state. It uses dense, zero-based integer positions among display siblings. The schema uses an explicit non-null sibling-scope key for roots and grouped children, avoiding SQLite's nullable-unique-index hole. Promotion, unpromotion, project reassignment, dismissal, and parent deletion rewrite every affected old/new scope to its canonical `0..n-1` order in one collision-safe transaction. Fractional ranks and linked-list ordering are rejected: they optimize writes that are negligible at sidebar scale while adding exhaustion/rebalancing or integrity complexity.
+Ordering within a project is durable user state. It uses dense, zero-based integer positions among display siblings. The schema uses an explicit non-null sibling-scope key for roots and grouped children, avoiding SQLite's nullable-unique-index hole. Promotion, unpromotion, explicit reparenting, project reassignment, dismissal, and parent deletion rewrite every affected old/new scope to its canonical `0..n-1` order in one collision-safe transaction. Reparenting closes the old direct-parent scope and appends to the new scope atomically. Fractional ranks and linked-list ordering are rejected: they optimize writes that are negligible at sidebar scale while adding exhaustion/rebalancing or integrity complexity.
 
 Dismissed sessions have no placement or preserved order. If they register again, they are newly assigned at the normal bottom.
 
 ### 8. Parent-child provenance supports arbitrary depth
 
-A nullable parent-session ID records the session that launched a session. Every genuinely new nested `gmux` launch automatically captures the inherited `GMUX_SESSION_ID`; resume/restart retain their existing identity semantics. This is intentionally not a foreign key: the PTY child starts before the parent's asynchronous daemon registration completes, so a child may durably register first. The private domain API keeps the relationship immutable, rejects cycles as missing parents arrive, and owns deletion repair.
+Two nullable IDs deliberately separate responsibility from history:
 
-The adjacency model permits arbitrary depth because subagents may launch subagents. Initial product behavior only passively groups recorded relationships; no closure table, materialized path, or general subtree editor is introduced.
+- `parent_session_id` is the organizational edge. A genuinely new nested `gmux` launch initializes it from inherited `GMUX_SESSION_ID`, but it is mutable only through the explicit reparent domain operation. All family grouping, root hiding, notification suppression, recursive dismissal, ordering scopes, and peer projections read this field.
+- `launched_from_session_id` is the write-once historical fact recording which session launched this one. Registration initializes it from the same inherited parent. Resume, restart, re-observation, reparenting, and deletion repair never mutate it. It is excluded from REST, SSE, and ordinary projections and is visible only through state export or direct database inspection.
 
-Parentage records launch provenance while both rows are retained; it is immutable during that lifetime and dismissal does not alter it. `promoted_to_root` is separate, sticky, user-authored presentation state:
+**All behavior reads `parent_session_id`; `launched_from_session_id` is a historical record with no code consumer.** State export is the diagnostic visibility seam, not product behavior.
 
-- when true, the session renders as a project root without losing its launch parent;
+The IDs are intentionally not foreign keys: the PTY child starts before the parent's asynchronous daemon registration completes, so a child may durably register first. The adjacency model permits arbitrary depth because subagents may launch subagents; no closure table or materialized path is introduced.
+
+The explicit reparent operation may assign any retained session on the same daemon as direct parent, or clear the edge. In one transaction it verifies that child and requested parent exist, rejects self-parenting, walks the requested parent's ancestor chain to reject cycles, bumps the child's row version, and rewrites both old and new sibling scopes densely. Cross-peer reparenting is refused. Recursive dismissal follows the current organizational edges, so reparenting transfers subtree responsibility as well as presentation.
+
+The motivating orchestration workflow is to launch worker sessions, launch a reviewer session, then reparent the workers under the reviewer so it owns their attention. Arbitrary ownership trees are therefore an orchestration primitive rather than an accidental record of process launch order. Reparenting also changes which parent's activity suppresses child notifications.
+
+`promoted_to_root` remains separate, sticky, user-authored presentation state:
+
+- when true, the session renders as a project root without losing its organizational parent and receives full root visibility and notification semantics;
 - when false, it groups beneath its parent only when both are visible in the same derived project;
-- sessions whose parent resolves to another project render as roots while retaining provenance.
+- sessions whose parent resolves to another project render as roots while retaining both stored facts.
 
-A parent and child derive projects independently; parentage does not override CWD/workspace matching. Dragging can reorder siblings and promote/unpromote relative to the original parent, but arbitrary adoption under an unrelated parent is out of scope.
+A parent and child derive projects independently; parentage does not override CWD/workspace matching. Dragging may reorder siblings and promote/unpromote without rewriting `parent_session_id`; explicit reparenting is the sole adoption operation.
 
-Dismissing a parent recursively dismisses its descendants. Permanently reconciling away a parent does not delete resumable descendants; the deletion transaction explicitly clears its direct children's parent IDs, makes them genuine roots, and intentionally forgets that deleted relationship. Their own descendant relationships remain intact.
+Dismissing a parent recursively dismisses descendants reachable through current `parent_session_id` edges. Permanently reconciling away a parent does not delete resumable descendants; the deletion transaction clears its direct children's parent edges and makes them genuine roots. Their own descendant edges remain intact. Deletion repair never touches `launched_from_session_id`, so launch history survives deletion of the launching session.
 
 ### 9. Cross-entity changes are domain transactions
 

--- a/docs/task-family-ui.md
+++ b/docs/task-family-ui.md
@@ -1,13 +1,20 @@
 # Task-family UI integration seam
 
-Task-family presentation uses durable `launch_parent_id` (wire:
-`parent_session_id`) without mutating launch provenance. `promoted_to_root`
-breaks only the presentation edge.
+Task-family presentation uses durable `parent_session_id` as its organizational
+edge. `launched_from_session_id` is write-once launch history and is never sent
+to the frontend. `promoted_to_root` breaks only the presentation edge; it does
+not erase either stored fact.
 
-A resolved launch-parent relationship is a family edge when its direct parent
-carries `semantic_agent: true`; the child may be an agent or any other process
-session. Missing parents and children of shells, editors, or terminal helpers
-remain presentation roots and cannot be hidden accidentally.
+A resolved parent relationship is a family edge when its direct parent carries
+`semantic_agent: true`; the child may be an agent or any other process session.
+Missing parents and children of shells, editors, or terminal helpers remain
+presentation roots and cannot be hidden accidentally.
+
+`gmux session promote|demote` exposes the sticky presentation override.
+`gmux session reparent <id> <parent-id>` (or `--clear`) changes the direct
+parent used by this projection, recursive dismissal, and child-notification
+suppression. Both rows must exist on the local daemon; self-parenting, ancestor
+cycles, and cross-peer reassignment are rejected transactionally.
 
 The daemon derives `semantic_agent` from the existing
 `adapter.ConversationSource` capability. This is the same semantic distinction

--- a/services/gmuxd/cmd/gmuxd/bootstrap_runner_adapters.go
+++ b/services/gmuxd/cmd/gmuxd/bootstrap_runner_adapters.go
@@ -264,7 +264,7 @@ func (productionRunnerClient) Meta(ctx context.Context, endpoint string) (sessio
 	reg := centralstore.RunnerRegistration{ID: centralstore.SessionID(s.ID), Adapter: s.Adapter, DriveMode: s.DriveMode, Alive: s.Alive, CreatedAt: parseMillis(s.CreatedAt), ObservedAt: centralstore.UnixMillis(time.Now().UnixMilli())}
 	if s.ParentSessionID != "" {
 		parent := centralstore.SessionID(s.ParentSessionID)
-		reg.LaunchParentID = &parent
+		reg.ParentSessionID = &parent
 	}
 	reg.Facts = runnerMetaFacts(s)
 	// Prefer the header: it is stamped by the same middleware that stamps the

--- a/services/gmuxd/cmd/gmuxd/bootstrap_runner_adapters_test.go
+++ b/services/gmuxd/cmd/gmuxd/bootstrap_runner_adapters_test.go
@@ -83,8 +83,8 @@ func TestProductionRunnerMetaPreservesLaunchParent(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if meta.Registration.LaunchParentID == nil || *meta.Registration.LaunchParentID != "parent" {
-		t.Fatalf("launch parent lost at runner boundary: %#v", meta.Registration.LaunchParentID)
+	if meta.Registration.ParentSessionID == nil || *meta.Registration.ParentSessionID != "parent" {
+		t.Fatalf("launch parent lost at runner boundary: %#v", meta.Registration.ParentSessionID)
 	}
 }
 

--- a/services/gmuxd/cmd/gmuxd/central_helpers.go
+++ b/services/gmuxd/cmd/gmuxd/central_helpers.go
@@ -457,8 +457,8 @@ func projectSessionTreeRows(rows []centralstore.Session, root centralstore.Sessi
 	for i := range rows {
 		row := &rows[i]
 		byID[row.ID] = i
-		if row.LaunchParentID != nil {
-			byParent[*row.LaunchParentID] = append(byParent[*row.LaunchParentID], row.ID)
+		if row.ParentSessionID != nil {
+			byParent[*row.ParentSessionID] = append(byParent[*row.ParentSessionID], row.ID)
 		}
 	}
 	if _, present := byID[root]; !present {

--- a/services/gmuxd/cmd/gmuxd/central_helpers_family_test.go
+++ b/services/gmuxd/cmd/gmuxd/central_helpers_family_test.go
@@ -13,10 +13,10 @@ func TestProjectSessionTreeRowsBreadthFirst(t *testing.T) {
 	childA := centralstore.SessionID("child-a")
 	rows := []centralstore.Session{
 		{ID: "unrelated"},
-		{ID: childB, LaunchParentID: &root},
-		{ID: "grandchild", LaunchParentID: &childA},
+		{ID: childB, ParentSessionID: &root},
+		{ID: "grandchild", ParentSessionID: &childA},
 		{ID: root},
-		{ID: childA, LaunchParentID: &root},
+		{ID: childA, ParentSessionID: &root},
 	}
 
 	got, err := projectSessionTreeRows(rows, root)
@@ -42,8 +42,8 @@ func BenchmarkProjectSessionTreeRows(b *testing.B) {
 	rows = append(rows, centralstore.Session{ID: root})
 	for i := 0; i < 500; i++ {
 		rows = append(rows, centralstore.Session{
-			ID:             centralstore.SessionID(fmt.Sprintf("child-%04d", i)),
-			LaunchParentID: &root,
+			ID:              centralstore.SessionID(fmt.Sprintf("child-%04d", i)),
+			ParentSessionID: &root,
 		})
 	}
 	for i := 0; i < 499; i++ {

--- a/services/gmuxd/cmd/gmuxd/notify_central.go
+++ b/services/gmuxd/cmd/gmuxd/notify_central.go
@@ -125,8 +125,8 @@ func notifySnapshot(o sessioncoord.Outcome) notifySessionSnapshot {
 		snap.Start = fmtMillisPtr(o.Session.StartedAt)
 		snap.Promoted = o.Session.PromotedToRoot
 		snap.SemanticAgent = semanticAgentAdapter(adapters.FindByAdapter(o.Session.Adapter))
-		if o.Session.LaunchParentID != nil {
-			snap.ParentID = string(*o.Session.LaunchParentID)
+		if o.Session.ParentSessionID != nil {
+			snap.ParentID = string(*o.Session.ParentSessionID)
 		}
 	}
 	return snap

--- a/services/gmuxd/cmd/gmuxd/notify_central_parent_test.go
+++ b/services/gmuxd/cmd/gmuxd/notify_central_parent_test.go
@@ -22,7 +22,7 @@ func notifyRow(adapterName string, active bool, parent string, promoted bool) ce
 	row := centralstore.Session{Adapter: adapterName, Active: active, PromotedToRoot: promoted}
 	if parent != "" {
 		id := centralstore.SessionID(parent)
-		row.LaunchParentID = &id
+		row.ParentSessionID = &id
 	}
 	return row
 }

--- a/services/gmuxd/cmd/gmuxd/serve_central.go
+++ b/services/gmuxd/cmd/gmuxd/serve_central.go
@@ -1099,7 +1099,7 @@ func handleCentralSessionAction(w http.ResponseWriter, r *http.Request, boot *Bo
 			value := centralstore.SessionID(parentID)
 			parent = &value
 		}
-		result, err := boot.Store.SetSessionParent(r.Context(), sid, parent)
+		_, err = boot.Coordinator.SetSessionParent(r.Context(), sid, parent)
 		switch {
 		case errors.Is(err, centralstore.ErrSessionNotFound):
 			writeError(w, http.StatusNotFound, "not_found", "child and parent sessions must exist on this daemon")
@@ -1113,9 +1113,6 @@ func handleCentralSessionAction(w http.ResponseWriter, r *http.Request, boot *Bo
 		case err != nil:
 			writeError(w, http.StatusInternalServerError, "internal", err.Error())
 			return
-		}
-		if result.Changed {
-			boot.Composer.Invalidate(result)
 		}
 		writeJSON(w, map[string]any{"ok": true, "data": map[string]any{}})
 	case "attach":

--- a/services/gmuxd/cmd/gmuxd/serve_central.go
+++ b/services/gmuxd/cmd/gmuxd/serve_central.go
@@ -1024,6 +1024,11 @@ func handleCentralSessionAction(w http.ResponseWriter, r *http.Request, boot *Bo
 	}
 	if peerManager != nil && action != "" {
 		if peer, originalID := peerManager.FindPeer(sessionID); peer != nil {
+			if action == "promote" || action == "demote" || action == "reparent" {
+				writeError(w, http.StatusBadRequest, codeLocalOnly, fmt.Sprintf(
+					"%s is only available for sessions owned by this daemon; run gmux on the owning host", action))
+				return
+			}
 			// Semantic agent actions are local-only in this slice (ADR 0027).
 			// Refusing is not a limitation to paper over: forwarding would run
 			// an agent on another host under a contract (readiness, admission,
@@ -1046,6 +1051,73 @@ func handleCentralSessionAction(w http.ResponseWriter, r *http.Request, boot *Bo
 	sess, ok := visibleSession(frames.Sessions, sessionID)
 	sid := centralstore.SessionID(sessionID)
 	switch action {
+	case "promote", "demote":
+		if r.Method != http.MethodPost {
+			writeError(w, http.StatusMethodNotAllowed, "bad_request", "method not allowed")
+			return
+		}
+		result, err := boot.Store.SetPromotion(r.Context(), sid, action == "promote", nil)
+		if errors.Is(err, centralstore.ErrSessionNotFound) {
+			writeError(w, http.StatusNotFound, "not_found", "session not found")
+			return
+		}
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "internal", err.Error())
+			return
+		}
+		if result.Changed {
+			boot.Composer.Invalidate(result)
+		}
+		writeJSON(w, map[string]any{"ok": true, "data": map[string]any{}})
+	case "reparent":
+		if r.Method != http.MethodPost {
+			writeError(w, http.StatusMethodNotAllowed, "bad_request", "method not allowed")
+			return
+		}
+		body, err := io.ReadAll(io.LimitReader(r.Body, 4097))
+		if err != nil || len(body) > 4096 {
+			writeError(w, http.StatusBadRequest, "bad_request", "invalid request body")
+			return
+		}
+		var payload map[string]json.RawMessage
+		if err = json.Unmarshal(body, &payload); err != nil {
+			writeError(w, http.StatusBadRequest, "bad_request", "invalid JSON")
+			return
+		}
+		rawParent, present := payload["parent_session_id"]
+		if !present {
+			writeError(w, http.StatusBadRequest, "bad_request", "parent_session_id is required (use null to clear)")
+			return
+		}
+		var parent *centralstore.SessionID
+		if !bytes.Equal(bytes.TrimSpace(rawParent), []byte("null")) {
+			var parentID string
+			if err = json.Unmarshal(rawParent, &parentID); err != nil || parentID == "" {
+				writeError(w, http.StatusBadRequest, "bad_request", "parent_session_id must be a session id or null")
+				return
+			}
+			value := centralstore.SessionID(parentID)
+			parent = &value
+		}
+		result, err := boot.Store.SetSessionParent(r.Context(), sid, parent)
+		switch {
+		case errors.Is(err, centralstore.ErrSessionNotFound):
+			writeError(w, http.StatusNotFound, "not_found", "child and parent sessions must exist on this daemon")
+			return
+		case errors.Is(err, centralstore.ErrSessionParentSelf):
+			writeError(w, http.StatusConflict, "self_parent", err.Error())
+			return
+		case errors.Is(err, centralstore.ErrSessionParentCycle):
+			writeError(w, http.StatusConflict, "parent_cycle", err.Error())
+			return
+		case err != nil:
+			writeError(w, http.StatusInternalServerError, "internal", err.Error())
+			return
+		}
+		if result.Changed {
+			boot.Composer.Invalidate(result)
+		}
+		writeJSON(w, map[string]any{"ok": true, "data": map[string]any{}})
 	case "attach":
 		if r.Method != http.MethodPost {
 			writeError(w, http.StatusMethodNotAllowed, "bad_request", "method not allowed")

--- a/services/gmuxd/cmd/gmuxd/session_family_actions_test.go
+++ b/services/gmuxd/cmd/gmuxd/session_family_actions_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/centralstore"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/sessioncoord"
 	central "github.com/gmuxapp/gmux/services/gmuxd/internal/snapshot/central"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/snapshot/wire"
 )
@@ -30,7 +31,8 @@ func TestSessionFamilyMutationHTTPRoundTrip(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	boot := &Bootstrap{Store: store, Composer: central.New(store, nil, nil)}
+	coord := sessioncoord.New(nil, nil, store, nil, nil)
+	boot := &Bootstrap{Store: store, Coordinator: coord, Composer: central.New(store, nil, nil)}
 	fanout := newSSEFanout()
 	post := func(path, body string) *httptest.ResponseRecorder {
 		t.Helper()
@@ -120,7 +122,8 @@ func TestSessionReparentHTTPValidation(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	boot := &Bootstrap{Store: store, Composer: central.New(store, nil, nil)}
+	coord := sessioncoord.New(nil, nil, store, nil, nil)
+	boot := &Bootstrap{Store: store, Coordinator: coord, Composer: central.New(store, nil, nil)}
 	request := func(id, body string) *httptest.ResponseRecorder {
 		recorder := httptest.NewRecorder()
 		handleCentralSessionAction(recorder, httptest.NewRequest(http.MethodPost, "/v1/sessions/"+id+"/reparent", strings.NewReader(body)), boot, newSSEFanout(), nil, nil, nil, "")

--- a/services/gmuxd/cmd/gmuxd/session_family_actions_test.go
+++ b/services/gmuxd/cmd/gmuxd/session_family_actions_test.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/centralstore"
+	central "github.com/gmuxapp/gmux/services/gmuxd/internal/snapshot/central"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/snapshot/wire"
+)
+
+func TestSessionFamilyMutationHTTPRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	store, err := centralstore.Open(ctx, t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	root := centralstore.SessionID("root")
+	for _, row := range []centralstore.NewSession{
+		{ID: root, Adapter: "pi", Command: []string{"pi"}, CreatedAt: 1},
+		{ID: "other", Adapter: "pi", Command: []string{"pi"}, CreatedAt: 2},
+		{ID: "child", Adapter: "pi", Command: []string{"pi"}, CreatedAt: 3, ParentSessionID: &root},
+	} {
+		if _, _, err := store.InsertSession(ctx, row); err != nil {
+			t.Fatal(err)
+		}
+	}
+	boot := &Bootstrap{Store: store, Composer: central.New(store, nil, nil)}
+	fanout := newSSEFanout()
+	post := func(path, body string) *httptest.ResponseRecorder {
+		t.Helper()
+		recorder := httptest.NewRecorder()
+		request := httptest.NewRequest(http.MethodPost, path, strings.NewReader(body))
+		handleCentralSessionAction(recorder, request, boot, fanout, nil, nil, nil, "")
+		return recorder
+	}
+
+	if response := post("/v1/sessions/child/promote", `{}`); response.Code != http.StatusOK {
+		t.Fatalf("promote status=%d body=%s", response.Code, response.Body.String())
+	}
+	row, _, _ := store.Session(ctx, "child")
+	if !row.PromotedToRoot || row.ParentSessionID == nil || *row.ParentSessionID != "root" {
+		t.Fatalf("promotion did not preserve parent: %#v", row)
+	}
+	if response := post("/v1/sessions/child/demote", `{}`); response.Code != http.StatusOK {
+		t.Fatalf("demote status=%d body=%s", response.Code, response.Body.String())
+	}
+	row, _, _ = store.Session(ctx, "child")
+	if row.PromotedToRoot || row.ParentSessionID == nil || *row.ParentSessionID != "root" {
+		t.Fatalf("demotion did not restore child presentation: %#v", row)
+	}
+
+	if response := post("/v1/sessions/child/reparent", `{"parent_session_id":"other"}`); response.Code != http.StatusOK {
+		t.Fatalf("reparent status=%d body=%s", response.Code, response.Body.String())
+	}
+	row, _, _ = store.Session(ctx, "child")
+	if row.ParentSessionID == nil || *row.ParentSessionID != "other" || launchedFromExport(t, store, "child") != "root" {
+		t.Fatalf("reparented row=%#v launched_from=%q", row, launchedFromExport(t, store, "child"))
+	}
+
+	batch, err := central.RenderAll(ctx, store, central.RuntimeSourceFunc(func() map[centralstore.SessionID]central.RuntimeFacts { return nil }), nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	projected := (&wire.Converter{Titlers: map[string]func([]string) string{}, SemanticAgents: map[string]bool{"pi": true}}).Sessions(batch.Sessions, batch.Projects, nil)
+	var child wire.Session
+	for _, session := range projected.Sessions {
+		if session.ID == "child" {
+			child = session
+		}
+	}
+	if child.ID == "" || child.ParentSessionID != "other" || !child.SemanticAgent {
+		t.Fatalf("daemon family projection=%#v", child)
+	}
+	encoded, err := json.Marshal(map[string]any{"ok": true, "data": projected.Sessions})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(encoded), "launched_from_session_id") {
+		t.Fatalf("historical launch provenance leaked onto snapshot/REST wire: %s", encoded)
+	}
+
+	if response := post("/v1/sessions/child/reparent", `{"parent_session_id":null}`); response.Code != http.StatusOK {
+		t.Fatalf("clear status=%d body=%s", response.Code, response.Body.String())
+	}
+	row, _, _ = store.Session(ctx, "child")
+	if row.ParentSessionID != nil || launchedFromExport(t, store, "child") != "root" {
+		t.Fatalf("clear changed launch provenance: %#v launched_from=%q", row, launchedFromExport(t, store, "child"))
+	}
+}
+
+func launchedFromExport(t *testing.T, store *centralstore.Store, id centralstore.SessionID) string {
+	t.Helper()
+	state, err := store.ExportState(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, session := range state.Sessions {
+		if session.ID == id && session.LaunchedFromSessionID != nil {
+			return string(*session.LaunchedFromSessionID)
+		}
+	}
+	return ""
+}
+
+func TestSessionReparentHTTPValidation(t *testing.T) {
+	ctx := context.Background()
+	store, err := centralstore.Open(ctx, t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	for _, id := range []centralstore.SessionID{"a", "b"} {
+		if _, _, err := store.InsertSession(ctx, centralstore.NewSession{ID: id, Adapter: "shell", Command: []string{"sh"}, CreatedAt: 1}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	boot := &Bootstrap{Store: store, Composer: central.New(store, nil, nil)}
+	request := func(id, body string) *httptest.ResponseRecorder {
+		recorder := httptest.NewRecorder()
+		handleCentralSessionAction(recorder, httptest.NewRequest(http.MethodPost, "/v1/sessions/"+id+"/reparent", strings.NewReader(body)), boot, newSSEFanout(), nil, nil, nil, "")
+		return recorder
+	}
+	if response := request("a", `{"parent_session_id":"a"}`); response.Code != http.StatusConflict || !strings.Contains(response.Body.String(), "self_parent") {
+		t.Fatalf("self response=%d %s", response.Code, response.Body.String())
+	}
+	if response := request("a", `{"parent_session_id":"missing"}`); response.Code != http.StatusNotFound {
+		t.Fatalf("missing response=%d %s", response.Code, response.Body.String())
+	}
+	if response := request("a", `{}`); response.Code != http.StatusBadRequest {
+		t.Fatalf("missing field response=%d %s", response.Code, response.Body.String())
+	}
+	if response := request("a", `{"parent_session_id":"b"}`); response.Code != http.StatusOK {
+		t.Fatal(response.Body.String())
+	}
+	if response := request("b", `{"parent_session_id":"a"}`); response.Code != http.StatusConflict || !strings.Contains(response.Body.String(), "parent_cycle") {
+		t.Fatalf("cycle response=%d %s", response.Code, response.Body.String())
+	}
+}

--- a/services/gmuxd/internal/centralstore/admin.go
+++ b/services/gmuxd/internal/centralstore/admin.go
@@ -250,12 +250,12 @@ func domainInvariantFindings(ctx context.Context, tx *sql.Tx, q *db.Queries) ([]
 	// sidebar-scale state (do not put it on a hot path).
 	cyclic, err := stringColumn(ctx, tx, `
 		WITH RECURSIVE anc(start, cur) AS (
-			SELECT id, launch_parent_id FROM local_sessions
-			WHERE launch_parent_id IS NOT NULL
+			SELECT id, parent_session_id FROM local_sessions
+			WHERE parent_session_id IS NOT NULL
 			UNION
-			SELECT a.start, s.launch_parent_id
+			SELECT a.start, s.parent_session_id
 			FROM anc a JOIN local_sessions s ON s.id = a.cur
-			WHERE s.launch_parent_id IS NOT NULL
+			WHERE s.parent_session_id IS NOT NULL
 		)
 		SELECT DISTINCT start FROM anc WHERE cur = start ORDER BY start`)
 	if err != nil {
@@ -436,12 +436,19 @@ type PlacementExport struct {
 	Position            int64
 }
 
+// SessionExport is the state-tool-only session projection. Launch provenance
+// deliberately does not enter the ordinary Session model or behavioral paths.
+type SessionExport struct {
+	Session
+	LaunchedFromSessionID *SessionID
+}
+
 // StateExport is the raw, deterministic-ordered data for
 // `gmux daemon state export`. Peers are pre-redacted (RedactedManualPeer);
 // URL userinfo scrubbing and JSON shaping are statetool's job.
 type StateExport struct {
 	SchemaVersion int64
-	Sessions      []Session // ALL rows, dismissed included, sorted by ID
+	Sessions      []SessionExport // ALL rows, dismissed included, sorted by ID
 	Catalog       ProjectCatalog
 	Placements    []PlacementExport
 	Peers         []RedactedManualPeer // sorted by name
@@ -463,13 +470,18 @@ func (s *Store) ExportState(ctx context.Context) (StateExport, error) {
 	if err != nil {
 		return StateExport{}, err
 	}
-	out.Sessions = make([]Session, 0, len(rows))
+	out.Sessions = make([]SessionExport, 0, len(rows))
 	for _, r := range rows {
 		v, convErr := sessionFromDB(r)
 		if convErr != nil {
 			return StateExport{}, convErr
 		}
-		out.Sessions = append(out.Sessions, v)
+		exported := SessionExport{Session: v}
+		if r.LaunchedFromSessionID.Valid {
+			id := SessionID(r.LaunchedFromSessionID.String)
+			exported.LaunchedFromSessionID = &id
+		}
+		out.Sessions = append(out.Sessions, exported)
 	}
 	sort.Slice(out.Sessions, func(i, j int) bool { return out.Sessions[i].ID < out.Sessions[j].ID })
 

--- a/services/gmuxd/internal/centralstore/admin_test.go
+++ b/services/gmuxd/internal/centralstore/admin_test.go
@@ -84,8 +84,8 @@ func TestEmbeddedSchemaVersionMatchesOpenedDatabase(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if head != got || head != 2 {
-		t.Fatalf("embedded head %d vs opened %d; want schema head 2 (v2: drive_mode)", head, got)
+	if head != got || head != 3 {
+		t.Fatalf("embedded head %d vs opened %d; want schema head 3", head, got)
 	}
 }
 
@@ -162,8 +162,8 @@ func TestCheckStateLaunchCycle(t *testing.T) {
 	// The immutability trigger blocks rewrites at runtime; a corrupt
 	// database has no such guarantee, so drop it and manufacture a cycle.
 	exec(t, s,
-		"DROP TRIGGER local_sessions_launch_parent_immutable_update",
-		"UPDATE local_sessions SET launch_parent_id = 'b' WHERE id = 'a'",
+		"DROP TRIGGER local_sessions_parent_no_cycle_update",
+		"UPDATE local_sessions SET parent_session_id = 'b' WHERE id = 'a'",
 	)
 	requireFinding(t, checkFindings(t, s), "launch_cycle")
 }

--- a/services/gmuxd/internal/centralstore/catalogreplace.go
+++ b/services/gmuxd/internal/centralstore/catalogreplace.go
@@ -162,10 +162,10 @@ func (s *Store) ReplaceProjectCatalogAndRematch(ctx context.Context, input []Pro
 		case matched:
 			// Placement was cascade-deleted with its entry; re-place.
 			rec := &placementRec{project: int64(project), local: r.local, parent: func() string {
-				if sess.LaunchParentID == nil {
+				if sess.ParentSessionID == nil {
 					return ""
 				}
-				return string(*sess.LaunchParentID)
+				return string(*sess.ParentSessionID)
 			}(), created: int64(sess.CreatedAt), promoted: sess.PromotedToRoot, isNew: true}
 			all = append(all, rec)
 			survivors["l:"+r.local] = rec

--- a/services/gmuxd/internal/centralstore/catalogreplace_test.go
+++ b/services/gmuxd/internal/centralstore/catalogreplace_test.go
@@ -12,7 +12,7 @@ func addSessionCwd(t *testing.T, s *Store, id, parent, cwd string, created UnixM
 	v := NewSession{ID: SessionID(id), Adapter: "shell", Command: []string{"sh"}, CWD: cwd, Remotes: map[string]string{}, CreatedAt: created}
 	if parent != "" {
 		p := SessionID(parent)
-		v.LaunchParentID = &p
+		v.ParentSessionID = &p
 	}
 	out, _, err := s.InsertSession(context.Background(), v)
 	if err != nil {

--- a/services/gmuxd/internal/centralstore/dismiss.go
+++ b/services/gmuxd/internal/centralstore/dismiss.go
@@ -58,8 +58,8 @@ func (s *Store) DismissSessionTree(ctx context.Context, root SessionID, at UnixM
 			return nil, MutationResult{}, convErr
 		}
 		byID[v.ID] = v
-		if v.LaunchParentID != nil {
-			children[*v.LaunchParentID] = append(children[*v.LaunchParentID], v.ID)
+		if v.ParentSessionID != nil {
+			children[*v.ParentSessionID] = append(children[*v.ParentSessionID], v.ID)
 		}
 	}
 	if _, ok := byID[root]; !ok {

--- a/services/gmuxd/internal/centralstore/dismiss_test.go
+++ b/services/gmuxd/internal/centralstore/dismiss_test.go
@@ -11,7 +11,7 @@ func regWithParent(id, parent, cwd string, at UnixMillis) RunnerRegistration {
 	r := registration(id, "shell", cwd, true, at)
 	if parent != "" {
 		p := SessionID(parent)
-		r.LaunchParentID = &p
+		r.ParentSessionID = &p
 	}
 	return r
 }
@@ -63,8 +63,8 @@ func TestDismissSessionTreeRecursive(t *testing.T) {
 	}
 	// Hidden, not forgotten: row, provenance, and history retained.
 	after := mustSession(t, s, "c")
-	if after.LaunchParentID == nil || *after.LaunchParentID != "p" {
-		t.Fatalf("launch provenance lost: %#v", after.LaunchParentID)
+	if after.ParentSessionID == nil || *after.ParentSessionID != "p" {
+		t.Fatalf("launch provenance lost: %#v", after.ParentSessionID)
 	}
 	if after.CreatedAt != before.CreatedAt || after.Version != before.Version+1 {
 		t.Fatalf("history lost: before=%#v after=%#v", before, after)
@@ -226,7 +226,7 @@ func TestUndismissalResurfacesAsRootWhenParentDismissed(t *testing.T) {
 	if p == nil || p.scope != "r" || p.pos != 1 { // appended after surviving root "x"
 		t.Fatalf("child must resurface as appended root: %#v", p)
 	}
-	if v := mustSession(t, s, "c"); v.LaunchParentID == nil || *v.LaunchParentID != "p" {
+	if v := mustSession(t, s, "c"); v.ParentSessionID == nil || *v.ParentSessionID != "p" {
 		t.Fatalf("provenance must survive undismissal: %#v", v)
 	}
 }
@@ -254,7 +254,7 @@ func TestUndismissalResurfacesUnderVisibleParent(t *testing.T) {
 }
 
 // Parent deletion promotes surviving direct children to genuine roots by
-// clearing launch_parent_id only. The sticky promoted_to_root bit is
+// clearing parent_session_id only. The sticky promoted_to_root bit is
 // user-authored presentation state and is neither set nor cleared by
 // deletion; grandchildren keep their own provenance.
 func TestParentDeletionPromotesChildrenAsGenuineRoots(t *testing.T) {
@@ -284,8 +284,8 @@ func TestParentDeletionPromotesChildrenAsGenuineRoots(t *testing.T) {
 	c1 := mustSession(t, s, "c1")
 	c2 := mustSession(t, s, "c2")
 	g := mustSession(t, s, "g")
-	if c1.LaunchParentID != nil || c2.LaunchParentID != nil {
-		t.Fatalf("children parents not cleared: %#v %#v", c1.LaunchParentID, c2.LaunchParentID)
+	if c1.ParentSessionID != nil || c2.ParentSessionID != nil {
+		t.Fatalf("children parents not cleared: %#v %#v", c1.ParentSessionID, c2.ParentSessionID)
 	}
 	if !c1.PromotedToRoot {
 		t.Fatal("existing sticky promotion must survive parent deletion")
@@ -293,8 +293,8 @@ func TestParentDeletionPromotesChildrenAsGenuineRoots(t *testing.T) {
 	if c2.PromotedToRoot {
 		t.Fatal("deletion must not fabricate a sticky promotion")
 	}
-	if g.LaunchParentID == nil || *g.LaunchParentID != "c2" {
-		t.Fatalf("grandchild provenance must survive: %#v", g.LaunchParentID)
+	if g.ParentSessionID == nil || *g.ParentSessionID != "c2" {
+		t.Fatalf("grandchild provenance must survive: %#v", g.ParentSessionID)
 	}
 	// Root scope repaired densely across all affected scopes; grandchild
 	// stays grouped under its (now root) parent.

--- a/services/gmuxd/internal/centralstore/dismiss_test.go
+++ b/services/gmuxd/internal/centralstore/dismiss_test.go
@@ -78,6 +78,27 @@ func TestDismissSessionTreeRecursive(t *testing.T) {
 	}
 }
 
+func TestDismissSessionTreeFollowsReparentedOwnership(t *testing.T) {
+	ctx := context.Background()
+	s := openKernelStore(t)
+	treeFixture(t, s)
+	x := SessionID("x")
+	if _, err := s.SetSessionParent(ctx, "c", &x); err != nil {
+		t.Fatal(err)
+	}
+
+	dismissed, _, err := s.DismissSessionTree(ctx, "x", 500)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(dismissed, []SessionID{"x", "c", "g"}) {
+		t.Fatalf("dismissed reparented tree=%v", dismissed)
+	}
+	if mustSession(t, s, "p").DismissedAt != nil {
+		t.Fatal("former parent dismissed with reparented subtree")
+	}
+}
+
 func TestDismissSessionTreeRepairsChildSiblingScope(t *testing.T) {
 	ctx := context.Background()
 	s := openKernelStore(t)

--- a/services/gmuxd/internal/centralstore/domain.go
+++ b/services/gmuxd/internal/centralstore/domain.go
@@ -114,7 +114,9 @@ var (
 	ErrStaleVersion = errors.New("centralstore: stale row version")
 	// ErrSessionNotFound marks a mutation targeting a session row that does
 	// not exist. Session() keeps its (value, ok, err) shape instead.
-	ErrSessionNotFound = errors.New("centralstore: session not found")
+	ErrSessionNotFound    = errors.New("centralstore: session not found")
+	ErrSessionParentSelf  = errors.New("centralstore: session cannot parent itself")
+	ErrSessionParentCycle = errors.New("centralstore: session parent cycle")
 	// ErrCatalogHasPlacements marks the bootstrap-only catalog boundary. This
 	// primitive cannot authoritatively rematch subjects once placement exists.
 	ErrCatalogHasPlacements = errors.New("centralstore: catalog replacement requires zero placements")
@@ -1548,6 +1550,92 @@ func (s *Store) ReorderSiblingScopes(ctx context.Context, reorders []SiblingReor
 	// Both kinds: the new positions are read back as session-row
 	// project_index stamps (see the note in place()).
 	return MutationResult{Changed: changedAny, SessionsDirty: changedAny, WorldDirty: changedAny}, nil
+}
+
+// SetSessionParent is the sole operation that may mutate the organizational
+// parent edge. Validation, the version bump, and sibling-order repair happen
+// in one transaction so snapshots can never observe a partial move.
+func (s *Store) SetSessionParent(ctx context.Context, id SessionID, parent *SessionID) (MutationResult, error) {
+	if id == "" {
+		return MutationResult{}, ErrSessionNotFound
+	}
+	tx, err := s.database.BeginTx(ctx, nil)
+	if err != nil {
+		return MutationResult{}, err
+	}
+	defer tx.Rollback()
+	q := s.queries.WithTx(tx)
+
+	row, err := q.GetSession(ctx, string(id))
+	if errors.Is(err, sql.ErrNoRows) {
+		return MutationResult{}, ErrSessionNotFound
+	}
+	if err != nil {
+		return MutationResult{}, err
+	}
+	if parent != nil && (*parent == "" || *parent == id) {
+		if parent != nil && *parent == id {
+			return MutationResult{}, ErrSessionParentSelf
+		}
+		return MutationResult{}, ErrSessionNotFound
+	}
+
+	if parent != nil {
+		cursor := *parent
+		seen := map[SessionID]bool{}
+		for {
+			if cursor == id || seen[cursor] {
+				return MutationResult{}, ErrSessionParentCycle
+			}
+			seen[cursor] = true
+			ancestor, getErr := q.GetSession(ctx, string(cursor))
+			if errors.Is(getErr, sql.ErrNoRows) {
+				if cursor == *parent {
+					return MutationResult{}, ErrSessionNotFound
+				}
+				break // an inherited parent may not have registered yet
+			}
+			if getErr != nil {
+				return MutationResult{}, getErr
+			}
+			if !ancestor.ParentSessionID.Valid {
+				break
+			}
+			cursor = SessionID(ancestor.ParentSessionID.String)
+		}
+	}
+
+	value := sql.NullString{}
+	if parent != nil {
+		value = nullString(string(*parent))
+	}
+	n, err := q.SetSessionParent(ctx, db.SetSessionParentParams{
+		ParentSessionID: value, ID: string(id), ParentSessionID_2: value,
+	})
+	if err != nil {
+		return MutationResult{}, err
+	}
+	if n == 0 {
+		if err = tx.Commit(); err != nil {
+			return MutationResult{}, err
+		}
+		return MutationResult{SessionVersion: RowVersion(row.RowVersion)}, nil
+	}
+
+	all, err := placements(ctx, q)
+	if err != nil {
+		return MutationResult{}, err
+	}
+	if _, err = rewritePlacements(ctx, q, all, nil, s.beforePlacementFinalize); err != nil {
+		return MutationResult{}, err
+	}
+	if err = tx.Commit(); err != nil {
+		return MutationResult{}, err
+	}
+	return MutationResult{
+		Changed: true, SessionVersion: RowVersion(row.RowVersion + 1),
+		SessionsDirty: true, WorldDirty: true,
+	}, nil
 }
 
 func (s *Store) SetPromotion(ctx context.Context, id SessionID, promoted bool, index *int) (MutationResult, error) {

--- a/services/gmuxd/internal/centralstore/domain.go
+++ b/services/gmuxd/internal/centralstore/domain.go
@@ -56,7 +56,7 @@ type Session struct {
 	StartedAt, ExitedAt, LastActivityAt, DismissedAt *UnixMillis
 	ExitCode                                         *int
 	TerminalCols, TerminalRows                       *uint16
-	LaunchParentID                                   *SessionID
+	ParentSessionID                                  *SessionID
 	PromotedToRoot                                   bool
 }
 
@@ -81,7 +81,7 @@ type NewSession struct {
 	LastActivityAt             *UnixMillis
 	ExitCode                   *int
 	TerminalCols, TerminalRows *uint16
-	LaunchParentID             *SessionID
+	ParentSessionID            *SessionID
 }
 
 // NullablePatch has three states: zero means unchanged, Set stores a value,
@@ -266,7 +266,7 @@ func validateNewSession(v NewSession) error {
 	if v.CreatedAt < 0 {
 		return errors.New("centralstore: created timestamp must be non-negative")
 	}
-	if v.LaunchParentID != nil && (*v.LaunchParentID == "" || *v.LaunchParentID == v.ID) {
+	if v.ParentSessionID != nil && (*v.ParentSessionID == "" || *v.ParentSessionID == v.ID) {
 		return errors.New("centralstore: invalid launch parent")
 	}
 	for name, x := range map[string]*UnixMillis{"started timestamp": v.StartedAt, "exited timestamp": v.ExitedAt, "activity timestamp": v.LastActivityAt} {
@@ -381,9 +381,9 @@ func sessionFromDB(v db.LocalSession) (Session, error) {
 	if (out.TerminalCols == nil) != (out.TerminalRows == nil) {
 		return Session{}, errors.New("centralstore: corrupt terminal pair")
 	}
-	if v.LaunchParentID.Valid {
-		x := SessionID(v.LaunchParentID.String)
-		out.LaunchParentID = &x
+	if v.ParentSessionID.Valid {
+		x := SessionID(v.ParentSessionID.String)
+		out.ParentSessionID = &x
 	}
 	out.Title = deriveTitle(out)
 	return out, nil
@@ -412,12 +412,13 @@ func (s *Store) InsertSession(ctx context.Context, v NewSession) (Session, Mutat
 		return Session{}, MutationResult{}, err
 	}
 	v.SlugBase, v.Slug = candidate.SlugBase, candidate.Slug
-	row, err := q.InsertSession(ctx, db.InsertSessionParams{ID: string(v.ID), Adapter: v.Adapter, DriveMode: normalizeDriveMode(v.DriveMode), ConversationRef: nullString(v.ConversationRef), CommandJson: cmd, Cwd: v.CWD, WorkspaceRoot: nullString(v.WorkspaceRoot), RemotesJson: rem, Slug: nullString(v.Slug), SlugBase: nullString(v.SlugBase), ShellTitle: nullString(v.ShellTitle), AdapterTitle: nullString(v.AdapterTitle), Subtitle: nullString(v.Subtitle), Active: boolInt(v.Active), Interrupted: boolInt(v.Interrupted), Unread: boolInt(v.Unread), HasError: boolInt(v.Error), StatusReported: boolInt(v.StatusReported || v.Active || v.Error || v.Interrupted), CreatedAtMs: int64(v.CreatedAt), StartedAtMs: nullMillis(v.StartedAt), ExitedAtMs: nullMillis(v.ExitedAt), LastActivityAtMs: nullMillis(v.LastActivityAt), ExitCode: nullInt(v.ExitCode), TerminalCols: nullUint(v.TerminalCols), TerminalRows: nullUint(v.TerminalRows), LaunchParentID: func() sql.NullString {
-		if v.LaunchParentID == nil {
+	parent := func() sql.NullString {
+		if v.ParentSessionID == nil {
 			return sql.NullString{}
 		}
-		return nullString(string(*v.LaunchParentID))
-	}()})
+		return nullString(string(*v.ParentSessionID))
+	}()
+	row, err := q.InsertSession(ctx, db.InsertSessionParams{ID: string(v.ID), Adapter: v.Adapter, DriveMode: normalizeDriveMode(v.DriveMode), ConversationRef: nullString(v.ConversationRef), CommandJson: cmd, Cwd: v.CWD, WorkspaceRoot: nullString(v.WorkspaceRoot), RemotesJson: rem, Slug: nullString(v.Slug), SlugBase: nullString(v.SlugBase), ShellTitle: nullString(v.ShellTitle), AdapterTitle: nullString(v.AdapterTitle), Subtitle: nullString(v.Subtitle), Active: boolInt(v.Active), Interrupted: boolInt(v.Interrupted), Unread: boolInt(v.Unread), HasError: boolInt(v.Error), StatusReported: boolInt(v.StatusReported || v.Active || v.Error || v.Interrupted), CreatedAtMs: int64(v.CreatedAt), StartedAtMs: nullMillis(v.StartedAt), ExitedAtMs: nullMillis(v.ExitedAt), LastActivityAtMs: nullMillis(v.LastActivityAt), ExitCode: nullInt(v.ExitCode), TerminalCols: nullUint(v.TerminalCols), TerminalRows: nullUint(v.TerminalRows), ParentSessionID: parent, LaunchedFromSessionID: parent})
 	if err != nil {
 		return Session{}, MutationResult{}, fmt.Errorf("centralstore: insert session: %w", err)
 	}
@@ -1113,7 +1114,7 @@ func placements(ctx context.Context, q *db.Queries) ([]*placementRec, error) {
 		}
 		r := &placementRec{id: x.ID, project: x.ProjectEntryID, local: x.LocalSessionID.String, peer: x.LocalPeerKey.String, session: x.PeerSessionID.String, parent: x.PeerParentSessionID.String, scope: x.SiblingScope, pos: x.Position, created: x.LocalCreatedAtMs, promoted: x.LocalPromotedToRoot == 1, oldProject: x.ProjectEntryID, oldScope: x.SiblingScope, oldPos: x.Position}
 		if r.local != "" {
-			r.parent = x.LaunchParentID.String
+			r.parent = x.ParentSessionID.String
 		}
 		out = append(out, r)
 	}
@@ -1405,7 +1406,7 @@ func (s *Store) place(ctx context.Context, sub SubjectRef, project ProjectEntryI
 			return MutationResult{}, e
 		}
 		if target == nil {
-			target = &placementRec{project: int64(project), local: string(sub.LocalSessionID), parent: facts.LaunchParentID.String, created: facts.CreatedAtMs, promoted: facts.PromotedToRoot == 1, isNew: true}
+			target = &placementRec{project: int64(project), local: string(sub.LocalSessionID), parent: facts.ParentSessionID.String, created: facts.CreatedAtMs, promoted: facts.PromotedToRoot == 1, isNew: true}
 			all = append(all, target)
 		}
 	} else {

--- a/services/gmuxd/internal/centralstore/domain_test.go
+++ b/services/gmuxd/internal/centralstore/domain_test.go
@@ -30,7 +30,7 @@ func addSessionAt(t *testing.T, s *Store, id, parent string, created UnixMillis)
 	v := NewSession{ID: SessionID(id), Adapter: "shell", Command: []string{"sh"}, CWD: "/tmp", Remotes: map[string]string{}, CreatedAt: created, ShellTitle: "shell title"}
 	if parent != "" {
 		p := SessionID(parent)
-		v.LaunchParentID = &p
+		v.ParentSessionID = &p
 	}
 	out, result, err := s.InsertSession(context.Background(), v)
 	if err != nil {
@@ -102,14 +102,14 @@ func TestChildFirstAndLaterParentCycle(t *testing.T) {
 	ctx := context.Background()
 	s := openKernelStore(t)
 	child := addSession(t, s, "child", "parent")
-	if child.LaunchParentID == nil || *child.LaunchParentID != "parent" {
+	if child.ParentSessionID == nil || *child.ParentSessionID != "parent" {
 		t.Fatalf("parent not preserved: %#v", child)
 	}
 	addSession(t, s, "parent", "")
 	s2 := openKernelStore(t)
 	addSession(t, s2, "a", "b")
 	p := SessionID("a")
-	_, _, err := s2.InsertSession(ctx, NewSession{ID: "b", Adapter: "shell", Command: []string{}, CWD: "/", Remotes: map[string]string{}, CreatedAt: 1, LaunchParentID: &p})
+	_, _, err := s2.InsertSession(ctx, NewSession{ID: "b", Adapter: "shell", Command: []string{}, CWD: "/", Remotes: map[string]string{}, CreatedAt: 1, ParentSessionID: &p})
 	if err == nil {
 		t.Fatal("cycle insertion succeeded")
 	}
@@ -482,10 +482,10 @@ func TestLaunchParentUpdateTriggerRejectsRebind(t *testing.T) {
 	s := openKernelStore(t)
 	addSession(t, s, "parent", "")
 	addSession(t, s, "child", "parent")
-	if _, err := s.database.ExecContext(ctx, `UPDATE local_sessions SET launch_parent_id='child' WHERE id='parent'`); err == nil {
+	if _, err := s.database.ExecContext(ctx, `UPDATE local_sessions SET parent_session_id='child' WHERE id='parent'`); err == nil {
 		t.Fatal("non-NULL launch parent update accepted")
 	}
-	if _, err := s.database.ExecContext(ctx, `UPDATE local_sessions SET launch_parent_id=NULL WHERE id='child'`); err != nil {
+	if _, err := s.database.ExecContext(ctx, `UPDATE local_sessions SET parent_session_id=NULL WHERE id='child'`); err != nil {
 		t.Fatalf("NULL-ing launch parent rejected: %v", err)
 	}
 }
@@ -866,7 +866,7 @@ func TestPromotionAndParentProjectTransitions(t *testing.T) {
 		t.Fatalf("promoted roots=%v", got)
 	}
 	promoted, ok, err := s.Session(ctx, "child")
-	if err != nil || !ok || promoted.LaunchParentID == nil || *promoted.LaunchParentID != "parent" || !promoted.PromotedToRoot {
+	if err != nil || !ok || promoted.ParentSessionID == nil || *promoted.ParentSessionID != "parent" || !promoted.PromotedToRoot {
 		t.Fatalf("promotion lost provenance: child=%#v ok=%v err=%v", promoted, ok, err)
 	}
 	idx = 0
@@ -916,11 +916,11 @@ func TestPlacedParentRemovalPreservesGrandchildAndOrdering(t *testing.T) {
 		t.Fatalf("grandchild scope=%v", got)
 	}
 	child, ok, err := s.Session(ctx, "child")
-	if err != nil || !ok || child.Version != 2 || child.LaunchParentID != nil {
+	if err != nil || !ok || child.Version != 2 || child.ParentSessionID != nil {
 		t.Fatalf("child=%#v ok=%v err=%v", child, ok, err)
 	}
 	grand, ok, err := s.Session(ctx, "grand")
-	if err != nil || !ok || grand.Version != 1 || grand.LaunchParentID == nil || *grand.LaunchParentID != "child" {
+	if err != nil || !ok || grand.Version != 1 || grand.ParentSessionID == nil || *grand.ParentSessionID != "child" {
 		t.Fatalf("grand=%#v ok=%v err=%v", grand, ok, err)
 	}
 	assertKernelInvariants(t, s)
@@ -961,7 +961,7 @@ func TestParentRemovalAndConcurrentObservedVersionWinner(t *testing.T) {
 		t.Fatal(err)
 	}
 	child, ok, err := s.Session(ctx, "c")
-	if err != nil || !ok || child.LaunchParentID != nil || child.Version != 2 {
+	if err != nil || !ok || child.ParentSessionID != nil || child.Version != 2 {
 		t.Fatalf("child=%#v err=%v", child, err)
 	}
 	addSession(t, s, "race", "")
@@ -1085,7 +1085,7 @@ func assertKernelInvariants(t *testing.T, s *Store) {
 	if bad != 0 {
 		t.Fatalf("rule ownership/xor violations=%d", bad)
 	}
-	if err = s.database.QueryRowContext(ctx, `WITH RECURSIVE chain(start,id) AS (SELECT id,launch_parent_id FROM local_sessions WHERE launch_parent_id IS NOT NULL UNION SELECT chain.start,s.launch_parent_id FROM chain JOIN local_sessions s ON s.id=chain.id WHERE s.launch_parent_id IS NOT NULL) SELECT COUNT(*) FROM chain WHERE start=id`).Scan(&bad); err != nil {
+	if err = s.database.QueryRowContext(ctx, `WITH RECURSIVE chain(start,id) AS (SELECT id,parent_session_id FROM local_sessions WHERE parent_session_id IS NOT NULL UNION SELECT chain.start,s.parent_session_id FROM chain JOIN local_sessions s ON s.id=chain.id WHERE s.parent_session_id IS NOT NULL) SELECT COUNT(*) FROM chain WHERE start=id`).Scan(&bad); err != nil {
 		t.Fatal(err)
 	}
 	if bad != 0 {

--- a/services/gmuxd/internal/centralstore/domain_test.go
+++ b/services/gmuxd/internal/centralstore/domain_test.go
@@ -2,6 +2,7 @@ package centralstore
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -687,6 +688,99 @@ func TestPromotionNoopVersionAndExplicitOrder(t *testing.T) {
 	if got.Version != 2 {
 		t.Fatalf("rollback changed version: %d", got.Version)
 	}
+}
+
+func TestSessionReparentValidationOrderingAndProvenance(t *testing.T) {
+	ctx := context.Background()
+	s := openKernelStore(t)
+	project := addProject(t, s)
+	oldParent := addSession(t, s, "old", "")
+	addSession(t, s, "new", "")
+	for _, row := range []struct{ id, parent string }{
+		{"a", "old"}, {"b", "old"}, {"c", "old"}, {"n1", "new"},
+	} {
+		addSession(t, s, row.id, row.parent)
+	}
+	for _, id := range []SessionID{"old", "new", "a", "b", "c", "n1"} {
+		if _, err := s.PlaceLocalSession(ctx, id, project); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	newParent := SessionID("new")
+	result, err := s.SetSessionParent(ctx, "b", &newParent)
+	if err != nil || !result.Changed || !result.SessionsDirty || result.SessionVersion != 2 {
+		t.Fatalf("reparent result=%#v err=%v", result, err)
+	}
+	if got := scopeOrder(t, s, project, "c:l:old"); !reflect.DeepEqual(got, []string{"l:a", "l:c"}) {
+		t.Fatalf("old sibling scope=%v", got)
+	}
+	if got := scopeOrder(t, s, project, "c:l:new"); !reflect.DeepEqual(got, []string{"l:n1", "l:b"}) {
+		t.Fatalf("new sibling scope=%v", got)
+	}
+	b := mustSession(t, s, "b")
+	if b.ParentSessionID == nil || *b.ParentSessionID != "new" || launchedFromID(t, s, "b") != "old" {
+		t.Fatalf("reparented b=%#v launched_from=%q", b, launchedFromID(t, s, "b"))
+	}
+	if _, err := s.database.ExecContext(ctx, `UPDATE local_sessions SET launched_from_session_id='new' WHERE id='b'`); err == nil {
+		t.Fatal("launched_from_session_id was mutable")
+	}
+
+	result, err = s.SetSessionParent(ctx, "b", nil)
+	if err != nil || !result.Changed || result.SessionVersion != 3 {
+		t.Fatalf("clear result=%#v err=%v", result, err)
+	}
+	if got := rootOrder(t, s, project); !reflect.DeepEqual(got, []string{"l:old", "l:new", "l:b"}) {
+		t.Fatalf("cleared roots=%v", got)
+	}
+	result, err = s.SetSessionParent(ctx, "b", nil)
+	if err != nil || result.Changed || result.SessionVersion != 3 {
+		t.Fatalf("repeat clear result=%#v err=%v", result, err)
+	}
+
+	self := SessionID("b")
+	if _, err = s.SetSessionParent(ctx, "b", &self); !errors.Is(err, ErrSessionParentSelf) {
+		t.Fatalf("self-parent err=%v", err)
+	}
+	missing := SessionID("missing")
+	if _, err = s.SetSessionParent(ctx, "b", &missing); !errors.Is(err, ErrSessionNotFound) {
+		t.Fatalf("missing parent err=%v", err)
+	}
+	if _, err = s.SetSessionParent(ctx, "missing", nil); !errors.Is(err, ErrSessionNotFound) {
+		t.Fatalf("missing child err=%v", err)
+	}
+
+	addSession(t, s, "x", "a")
+	addSession(t, s, "y", "x")
+	y := SessionID("y")
+	if _, err = s.SetSessionParent(ctx, "old", &y); !errors.Is(err, ErrSessionParentCycle) {
+		t.Fatalf("deep cycle err=%v", err)
+	}
+
+	if _, err = s.SetSessionParent(ctx, "b", &newParent); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = s.RemoveSessionAtVersion(ctx, "old", oldParent.Version); err != nil {
+		t.Fatal(err)
+	}
+	b = mustSession(t, s, "b")
+	if b.ParentSessionID == nil || *b.ParentSessionID != "new" || launchedFromID(t, s, "b") != "old" {
+		t.Fatalf("historical launch fact did not survive parent deletion: %#v launched_from=%q", b, launchedFromID(t, s, "b"))
+	}
+	a := mustSession(t, s, "a")
+	if a.ParentSessionID != nil || launchedFromID(t, s, "a") != "old" {
+		t.Fatalf("deletion repair changed launch provenance: %#v launched_from=%q", a, launchedFromID(t, s, "a"))
+	}
+	assertKernelInvariants(t, s)
+}
+
+func launchedFromID(t *testing.T, s *Store, id SessionID) string {
+	t.Helper()
+	var launched sql.NullString
+	if err := s.database.QueryRow(`SELECT launched_from_session_id FROM local_sessions WHERE id = ?`, id).Scan(&launched); err != nil {
+		t.Fatal(err)
+	}
+	return launched.String
 }
 
 func TestReorderValidatesProjectParentAndDuplicates(t *testing.T) {

--- a/services/gmuxd/internal/centralstore/evict_test.go
+++ b/services/gmuxd/internal/centralstore/evict_test.go
@@ -23,7 +23,7 @@ func evictFixture(t *testing.T, s *Store) Session {
 	parent := SessionID("loser")
 	child := registration("child", "pi", "/one", false, 12)
 	child.Facts.ExitedAt = NullablePatch[UnixMillis]{Set: ptr(UnixMillis(13))}
-	child.LaunchParentID = &parent
+	child.ParentSessionID = &parent
 	if _, _, err = s.RegisterRunner(ctx, child); err != nil {
 		t.Fatal(err)
 	}
@@ -63,7 +63,7 @@ func TestRegisterRunnerEvictsTakeoverLosers(t *testing.T) {
 	// The loser's child was promoted to a genuine root: parent cleared,
 	// sticky promotion untouched, its own row retained.
 	child := mustSession(t, s, "child")
-	if child.LaunchParentID != nil || child.PromotedToRoot {
+	if child.ParentSessionID != nil || child.PromotedToRoot {
 		t.Fatalf("child not promoted to genuine root: %#v", child)
 	}
 	// Placement scope is densely renormalized: loser's placement is gone,
@@ -114,7 +114,7 @@ func TestRegisterRunnerEvictionSkipsStaleAndMissingLosers(t *testing.T) {
 		t.Fatal("stale eviction must be skipped, not applied")
 	}
 	child := mustSession(t, s, "child")
-	if child.LaunchParentID == nil || *child.LaunchParentID != "loser" {
+	if child.ParentSessionID == nil || *child.ParentSessionID != "loser" {
 		t.Fatalf("skipped eviction must not clear child parents: %#v", child)
 	}
 }
@@ -169,7 +169,7 @@ func TestRegisterRunnerEvictionRollsBackAtomically(t *testing.T) {
 		t.Fatal("rollback must not leave the winner row")
 	}
 	child := mustSession(t, s, "child")
-	if child.LaunchParentID == nil {
+	if child.ParentSessionID == nil {
 		t.Fatal("rollback must restore child provenance")
 	}
 	if p := localPlacement(t, s, "loser"); p == nil {
@@ -191,7 +191,7 @@ func TestRegisterRunnerEvictingOwnLaunchParent(t *testing.T) {
 
 	parent := SessionID("loser")
 	winner := registration("winner", "pi", "/one", true, 20)
-	winner.LaunchParentID = &parent
+	winner.ParentSessionID = &parent
 	ref := "conv-a"
 	winner.Facts.ConversationRef = &ref
 	winner.Evict = []TakeoverEviction{{ID: "loser", Version: loser.Version}}
@@ -199,12 +199,12 @@ func TestRegisterRunnerEvictingOwnLaunchParent(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got.LaunchParentID != nil {
-		t.Fatalf("returned session must not name the deleted loser as parent: %#v", got.LaunchParentID)
+	if got.ParentSessionID != nil {
+		t.Fatalf("returned session must not name the deleted loser as parent: %#v", got.ParentSessionID)
 	}
 	committed := mustSession(t, s, "winner")
-	if committed.LaunchParentID != nil {
-		t.Fatalf("committed parent=%#v", committed.LaunchParentID)
+	if committed.ParentSessionID != nil {
+		t.Fatalf("committed parent=%#v", committed.ParentSessionID)
 	}
 	if got.Version != committed.Version || result.SessionVersion != committed.Version {
 		t.Fatalf("returned=%d result=%d committed=%d", got.Version, result.SessionVersion, committed.Version)
@@ -243,7 +243,7 @@ func TestRegisterRunnerEvictionOfDismissedLoser(t *testing.T) {
 	}
 	// The dismissed child stays dismissed but becomes a genuine root.
 	child := mustSession(t, s, "child")
-	if child.LaunchParentID != nil || child.DismissedAt == nil {
+	if child.ParentSessionID != nil || child.DismissedAt == nil {
 		t.Fatalf("child=%#v", child)
 	}
 }

--- a/services/gmuxd/internal/centralstore/internal/db/models.go
+++ b/services/gmuxd/internal/centralstore/internal/db/models.go
@@ -14,35 +14,36 @@ type CentralstoreMetadatum struct {
 }
 
 type LocalSession struct {
-	ID               string
-	RowVersion       int64
-	Adapter          string
-	ConversationRef  sql.NullString
-	CommandJson      string
-	Cwd              string
-	WorkspaceRoot    sql.NullString
-	RemotesJson      string
-	Slug             sql.NullString
-	SlugBase         sql.NullString
-	ShellTitle       sql.NullString
-	AdapterTitle     sql.NullString
-	Subtitle         sql.NullString
-	Active           int64
-	Interrupted      int64
-	Unread           int64
-	HasError         int64
-	StatusReported   int64
-	CreatedAtMs      int64
-	StartedAtMs      sql.NullInt64
-	ExitedAtMs       sql.NullInt64
-	LastActivityAtMs sql.NullInt64
-	DismissedAtMs    sql.NullInt64
-	ExitCode         sql.NullInt64
-	TerminalCols     sql.NullInt64
-	TerminalRows     sql.NullInt64
-	LaunchParentID   sql.NullString
-	PromotedToRoot   int64
-	DriveMode        string
+	ID                    string
+	RowVersion            int64
+	Adapter               string
+	ConversationRef       sql.NullString
+	CommandJson           string
+	Cwd                   string
+	WorkspaceRoot         sql.NullString
+	RemotesJson           string
+	Slug                  sql.NullString
+	SlugBase              sql.NullString
+	ShellTitle            sql.NullString
+	AdapterTitle          sql.NullString
+	Subtitle              sql.NullString
+	Active                int64
+	Interrupted           int64
+	Unread                int64
+	HasError              int64
+	StatusReported        int64
+	CreatedAtMs           int64
+	StartedAtMs           sql.NullInt64
+	ExitedAtMs            sql.NullInt64
+	LastActivityAtMs      sql.NullInt64
+	DismissedAtMs         sql.NullInt64
+	ExitCode              sql.NullInt64
+	TerminalCols          sql.NullInt64
+	TerminalRows          sql.NullInt64
+	ParentSessionID       sql.NullString
+	PromotedToRoot        int64
+	DriveMode             string
+	LaunchedFromSessionID sql.NullString
 }
 
 type ManualPeer struct {

--- a/services/gmuxd/internal/centralstore/internal/db/query.sql
+++ b/services/gmuxd/internal/centralstore/internal/db/query.sql
@@ -11,8 +11,8 @@ INSERT INTO local_sessions (
     remotes_json, slug, slug_base, shell_title, adapter_title, subtitle,
     active, interrupted, unread, has_error, status_reported, created_at_ms, started_at_ms,
     exited_at_ms, last_activity_at_ms, exit_code, terminal_cols, terminal_rows,
-    launch_parent_id
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    parent_session_id, launched_from_session_id
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 RETURNING *;
 
 -- name: GetSession :one
@@ -65,8 +65,8 @@ DELETE FROM project_placements WHERE local_session_id = ?;
 
 -- name: ClearDirectChildParents :execrows
 UPDATE local_sessions
-SET launch_parent_id = NULL, row_version = row_version + 1
-WHERE launch_parent_id = ?;
+SET parent_session_id = NULL, row_version = row_version + 1
+WHERE parent_session_id = ?;
 
 -- name: DeleteSessionAtVersion :execrows
 DELETE FROM local_sessions WHERE id = ? AND row_version = ?;
@@ -126,13 +126,13 @@ SELECT p.id, p.project_entry_id, p.local_session_id, p.local_peer_key,
        p.peer_session_id, p.peer_parent_session_id, p.sibling_scope, p.position,
        COALESCE(s.created_at_ms, 0) AS local_created_at_ms,
        COALESCE(s.promoted_to_root, 0) AS local_promoted_to_root,
-       s.launch_parent_id
+       s.parent_session_id
 FROM project_placements p
 LEFT JOIN local_sessions s ON s.id = p.local_session_id
 ORDER BY p.project_entry_id, p.sibling_scope, p.position, p.id;
 
 -- name: LocalSessionPlacementFacts :one
-SELECT created_at_ms, promoted_to_root, launch_parent_id
+SELECT created_at_ms, promoted_to_root, parent_session_id
 FROM local_sessions WHERE id = ?;
 
 -- name: ParkPlacement :execrows

--- a/services/gmuxd/internal/centralstore/internal/db/query.sql
+++ b/services/gmuxd/internal/centralstore/internal/db/query.sql
@@ -76,6 +76,11 @@ UPDATE local_sessions
 SET promoted_to_root = ?, row_version = row_version + 1
 WHERE id = ? AND promoted_to_root <> ?;
 
+-- name: SetSessionParent :execrows
+UPDATE local_sessions
+SET parent_session_id = ?, row_version = row_version + 1
+WHERE id = ? AND parent_session_id IS NOT ?;
+
 -- name: ListProjectEntries :many
 SELECT * FROM project_entries ORDER BY sidebar_order;
 

--- a/services/gmuxd/internal/centralstore/internal/db/query.sql.go
+++ b/services/gmuxd/internal/centralstore/internal/db/query.sql.go
@@ -31,12 +31,12 @@ func (q *Queries) AcknowledgeSessionAtVersion(ctx context.Context, arg Acknowled
 
 const clearDirectChildParents = `-- name: ClearDirectChildParents :execrows
 UPDATE local_sessions
-SET launch_parent_id = NULL, row_version = row_version + 1
-WHERE launch_parent_id = ?
+SET parent_session_id = NULL, row_version = row_version + 1
+WHERE parent_session_id = ?
 `
 
-func (q *Queries) ClearDirectChildParents(ctx context.Context, launchParentID sql.NullString) (int64, error) {
-	result, err := q.db.ExecContext(ctx, clearDirectChildParents, launchParentID)
+func (q *Queries) ClearDirectChildParents(ctx context.Context, parentSessionID sql.NullString) (int64, error) {
+	result, err := q.db.ExecContext(ctx, clearDirectChildParents, parentSessionID)
 	if err != nil {
 		return 0, err
 	}
@@ -237,7 +237,7 @@ func (q *Queries) GetMetadata(ctx context.Context, key string) (string, error) {
 }
 
 const getSession = `-- name: GetSession :one
-SELECT id, row_version, adapter, conversation_ref, command_json, cwd, workspace_root, remotes_json, slug, slug_base, shell_title, adapter_title, subtitle, active, interrupted, unread, has_error, status_reported, created_at_ms, started_at_ms, exited_at_ms, last_activity_at_ms, dismissed_at_ms, exit_code, terminal_cols, terminal_rows, launch_parent_id, promoted_to_root, drive_mode FROM local_sessions WHERE id = ?
+SELECT id, row_version, adapter, conversation_ref, command_json, cwd, workspace_root, remotes_json, slug, slug_base, shell_title, adapter_title, subtitle, active, interrupted, unread, has_error, status_reported, created_at_ms, started_at_ms, exited_at_ms, last_activity_at_ms, dismissed_at_ms, exit_code, terminal_cols, terminal_rows, parent_session_id, promoted_to_root, drive_mode, launched_from_session_id FROM local_sessions WHERE id = ?
 `
 
 func (q *Queries) GetSession(ctx context.Context, id string) (LocalSession, error) {
@@ -270,9 +270,10 @@ func (q *Queries) GetSession(ctx context.Context, id string) (LocalSession, erro
 		&i.ExitCode,
 		&i.TerminalCols,
 		&i.TerminalRows,
-		&i.LaunchParentID,
+		&i.ParentSessionID,
 		&i.PromotedToRoot,
 		&i.DriveMode,
+		&i.LaunchedFromSessionID,
 	)
 	return i, err
 }
@@ -435,38 +436,39 @@ INSERT INTO local_sessions (
     remotes_json, slug, slug_base, shell_title, adapter_title, subtitle,
     active, interrupted, unread, has_error, status_reported, created_at_ms, started_at_ms,
     exited_at_ms, last_activity_at_ms, exit_code, terminal_cols, terminal_rows,
-    launch_parent_id
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-RETURNING id, row_version, adapter, conversation_ref, command_json, cwd, workspace_root, remotes_json, slug, slug_base, shell_title, adapter_title, subtitle, active, interrupted, unread, has_error, status_reported, created_at_ms, started_at_ms, exited_at_ms, last_activity_at_ms, dismissed_at_ms, exit_code, terminal_cols, terminal_rows, launch_parent_id, promoted_to_root, drive_mode
+    parent_session_id, launched_from_session_id
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+RETURNING id, row_version, adapter, conversation_ref, command_json, cwd, workspace_root, remotes_json, slug, slug_base, shell_title, adapter_title, subtitle, active, interrupted, unread, has_error, status_reported, created_at_ms, started_at_ms, exited_at_ms, last_activity_at_ms, dismissed_at_ms, exit_code, terminal_cols, terminal_rows, parent_session_id, promoted_to_root, drive_mode, launched_from_session_id
 `
 
 type InsertSessionParams struct {
-	ID               string
-	Adapter          string
-	DriveMode        string
-	ConversationRef  sql.NullString
-	CommandJson      string
-	Cwd              string
-	WorkspaceRoot    sql.NullString
-	RemotesJson      string
-	Slug             sql.NullString
-	SlugBase         sql.NullString
-	ShellTitle       sql.NullString
-	AdapterTitle     sql.NullString
-	Subtitle         sql.NullString
-	Active           int64
-	Interrupted      int64
-	Unread           int64
-	HasError         int64
-	StatusReported   int64
-	CreatedAtMs      int64
-	StartedAtMs      sql.NullInt64
-	ExitedAtMs       sql.NullInt64
-	LastActivityAtMs sql.NullInt64
-	ExitCode         sql.NullInt64
-	TerminalCols     sql.NullInt64
-	TerminalRows     sql.NullInt64
-	LaunchParentID   sql.NullString
+	ID                    string
+	Adapter               string
+	DriveMode             string
+	ConversationRef       sql.NullString
+	CommandJson           string
+	Cwd                   string
+	WorkspaceRoot         sql.NullString
+	RemotesJson           string
+	Slug                  sql.NullString
+	SlugBase              sql.NullString
+	ShellTitle            sql.NullString
+	AdapterTitle          sql.NullString
+	Subtitle              sql.NullString
+	Active                int64
+	Interrupted           int64
+	Unread                int64
+	HasError              int64
+	StatusReported        int64
+	CreatedAtMs           int64
+	StartedAtMs           sql.NullInt64
+	ExitedAtMs            sql.NullInt64
+	LastActivityAtMs      sql.NullInt64
+	ExitCode              sql.NullInt64
+	TerminalCols          sql.NullInt64
+	TerminalRows          sql.NullInt64
+	ParentSessionID       sql.NullString
+	LaunchedFromSessionID sql.NullString
 }
 
 func (q *Queries) InsertSession(ctx context.Context, arg InsertSessionParams) (LocalSession, error) {
@@ -496,7 +498,8 @@ func (q *Queries) InsertSession(ctx context.Context, arg InsertSessionParams) (L
 		arg.ExitCode,
 		arg.TerminalCols,
 		arg.TerminalRows,
-		arg.LaunchParentID,
+		arg.ParentSessionID,
+		arg.LaunchedFromSessionID,
 	)
 	var i LocalSession
 	err := row.Scan(
@@ -526,9 +529,10 @@ func (q *Queries) InsertSession(ctx context.Context, arg InsertSessionParams) (L
 		&i.ExitCode,
 		&i.TerminalCols,
 		&i.TerminalRows,
-		&i.LaunchParentID,
+		&i.ParentSessionID,
 		&i.PromotedToRoot,
 		&i.DriveMode,
+		&i.LaunchedFromSessionID,
 	)
 	return i, err
 }
@@ -574,7 +578,7 @@ SELECT p.id, p.project_entry_id, p.local_session_id, p.local_peer_key,
        p.peer_session_id, p.peer_parent_session_id, p.sibling_scope, p.position,
        COALESCE(s.created_at_ms, 0) AS local_created_at_ms,
        COALESCE(s.promoted_to_root, 0) AS local_promoted_to_root,
-       s.launch_parent_id
+       s.parent_session_id
 FROM project_placements p
 LEFT JOIN local_sessions s ON s.id = p.local_session_id
 ORDER BY p.project_entry_id, p.sibling_scope, p.position, p.id
@@ -591,7 +595,7 @@ type ListPlacementsRow struct {
 	Position            int64
 	LocalCreatedAtMs    int64
 	LocalPromotedToRoot int64
-	LaunchParentID      sql.NullString
+	ParentSessionID     sql.NullString
 }
 
 func (q *Queries) ListPlacements(ctx context.Context) ([]ListPlacementsRow, error) {
@@ -614,7 +618,7 @@ func (q *Queries) ListPlacements(ctx context.Context) ([]ListPlacementsRow, erro
 			&i.Position,
 			&i.LocalCreatedAtMs,
 			&i.LocalPromotedToRoot,
-			&i.LaunchParentID,
+			&i.ParentSessionID,
 		); err != nil {
 			return nil, err
 		}
@@ -700,7 +704,7 @@ func (q *Queries) ListProjectRules(ctx context.Context) ([]ProjectMatchRule, err
 }
 
 const listSessions = `-- name: ListSessions :many
-SELECT id, row_version, adapter, conversation_ref, command_json, cwd, workspace_root, remotes_json, slug, slug_base, shell_title, adapter_title, subtitle, active, interrupted, unread, has_error, status_reported, created_at_ms, started_at_ms, exited_at_ms, last_activity_at_ms, dismissed_at_ms, exit_code, terminal_cols, terminal_rows, launch_parent_id, promoted_to_root, drive_mode FROM local_sessions ORDER BY id
+SELECT id, row_version, adapter, conversation_ref, command_json, cwd, workspace_root, remotes_json, slug, slug_base, shell_title, adapter_title, subtitle, active, interrupted, unread, has_error, status_reported, created_at_ms, started_at_ms, exited_at_ms, last_activity_at_ms, dismissed_at_ms, exit_code, terminal_cols, terminal_rows, parent_session_id, promoted_to_root, drive_mode, launched_from_session_id FROM local_sessions ORDER BY id
 `
 
 func (q *Queries) ListSessions(ctx context.Context) ([]LocalSession, error) {
@@ -739,9 +743,10 @@ func (q *Queries) ListSessions(ctx context.Context) ([]LocalSession, error) {
 			&i.ExitCode,
 			&i.TerminalCols,
 			&i.TerminalRows,
-			&i.LaunchParentID,
+			&i.ParentSessionID,
 			&i.PromotedToRoot,
 			&i.DriveMode,
+			&i.LaunchedFromSessionID,
 		); err != nil {
 			return nil, err
 		}
@@ -757,20 +762,20 @@ func (q *Queries) ListSessions(ctx context.Context) ([]LocalSession, error) {
 }
 
 const localSessionPlacementFacts = `-- name: LocalSessionPlacementFacts :one
-SELECT created_at_ms, promoted_to_root, launch_parent_id
+SELECT created_at_ms, promoted_to_root, parent_session_id
 FROM local_sessions WHERE id = ?
 `
 
 type LocalSessionPlacementFactsRow struct {
-	CreatedAtMs    int64
-	PromotedToRoot int64
-	LaunchParentID sql.NullString
+	CreatedAtMs     int64
+	PromotedToRoot  int64
+	ParentSessionID sql.NullString
 }
 
 func (q *Queries) LocalSessionPlacementFacts(ctx context.Context, id string) (LocalSessionPlacementFactsRow, error) {
 	row := q.db.QueryRowContext(ctx, localSessionPlacementFacts, id)
 	var i LocalSessionPlacementFactsRow
-	err := row.Scan(&i.CreatedAtMs, &i.PromotedToRoot, &i.LaunchParentID)
+	err := row.Scan(&i.CreatedAtMs, &i.PromotedToRoot, &i.ParentSessionID)
 	return i, err
 }
 

--- a/services/gmuxd/internal/centralstore/internal/db/query.sql.go
+++ b/services/gmuxd/internal/centralstore/internal/db/query.sql.go
@@ -892,6 +892,26 @@ func (q *Queries) SetPromotion(ctx context.Context, arg SetPromotionParams) (int
 	return result.RowsAffected()
 }
 
+const setSessionParent = `-- name: SetSessionParent :execrows
+UPDATE local_sessions
+SET parent_session_id = ?, row_version = row_version + 1
+WHERE id = ? AND parent_session_id IS NOT ?
+`
+
+type SetSessionParentParams struct {
+	ParentSessionID   sql.NullString
+	ID                string
+	ParentSessionID_2 sql.NullString
+}
+
+func (q *Queries) SetSessionParent(ctx context.Context, arg SetSessionParentParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, setSessionParent, arg.ParentSessionID, arg.ID, arg.ParentSessionID_2)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 const sweepSessionDead = `-- name: SweepSessionDead :execrows
 UPDATE local_sessions
 SET exited_at_ms = ?1,

--- a/services/gmuxd/internal/centralstore/migrations/00003_session_parent_provenance.sql
+++ b/services/gmuxd/internal/centralstore/migrations/00003_session_parent_provenance.sql
@@ -1,0 +1,108 @@
+-- +goose Up
+
+-- ADR 0026 §8 amendment. The v1 launch_parent_id column carried the behavioral
+-- parent edge. Rename it to match that role, then preserve the best available
+-- launch provenance for existing rows by copying their current parent.
+ALTER TABLE local_sessions RENAME COLUMN launch_parent_id TO parent_session_id;
+ALTER TABLE local_sessions ADD COLUMN launched_from_session_id TEXT;
+UPDATE local_sessions SET launched_from_session_id = parent_session_id;
+
+DROP TRIGGER local_sessions_launch_parent_no_cycle_insert;
+DROP TRIGGER local_sessions_launch_parent_immutable_update;
+
+-- +goose StatementBegin
+CREATE TRIGGER local_sessions_parent_no_cycle_insert
+BEFORE INSERT ON local_sessions
+WHEN NEW.parent_session_id IS NOT NULL
+BEGIN
+    WITH RECURSIVE ancestors(id) AS (
+        SELECT NEW.parent_session_id
+        UNION
+        SELECT s.parent_session_id
+        FROM local_sessions AS s
+        JOIN ancestors AS a ON s.id = a.id
+        WHERE s.parent_session_id IS NOT NULL
+    )
+    SELECT CASE WHEN EXISTS (
+        SELECT 1 FROM ancestors WHERE id = NEW.id
+    ) THEN RAISE(ABORT, 'session parent cycle') END;
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER local_sessions_parent_no_cycle_update
+BEFORE UPDATE OF parent_session_id ON local_sessions
+WHEN NEW.parent_session_id IS NOT NULL AND OLD.parent_session_id IS NOT NEW.parent_session_id
+BEGIN
+    WITH RECURSIVE ancestors(id) AS (
+        SELECT NEW.parent_session_id
+        UNION
+        SELECT s.parent_session_id
+        FROM local_sessions AS s
+        JOIN ancestors AS a ON s.id = a.id
+        WHERE s.parent_session_id IS NOT NULL
+    )
+    SELECT CASE WHEN EXISTS (
+        SELECT 1 FROM ancestors WHERE id = NEW.id
+    ) THEN RAISE(ABORT, 'session parent cycle') END;
+END;
+-- +goose StatementEnd
+
+-- Launch provenance is captured once on insert and survives every parent
+-- mutation and deletion repair.
+-- +goose StatementBegin
+CREATE TRIGGER local_sessions_launched_from_immutable_update
+BEFORE UPDATE OF launched_from_session_id ON local_sessions
+WHEN OLD.launched_from_session_id IS NOT NEW.launched_from_session_id
+BEGIN
+    SELECT RAISE(ABORT, 'launched-from session is immutable');
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER local_sessions_launched_from_valid_insert
+BEFORE INSERT ON local_sessions
+WHEN NEW.launched_from_session_id IS NOT NULL AND
+     (length(NEW.launched_from_session_id) = 0 OR NEW.launched_from_session_id = NEW.id)
+BEGIN
+    SELECT RAISE(ABORT, 'invalid launched-from session');
+END;
+-- +goose StatementEnd
+
+-- +goose Down
+
+DROP TRIGGER local_sessions_launched_from_valid_insert;
+DROP TRIGGER local_sessions_launched_from_immutable_update;
+DROP TRIGGER local_sessions_parent_no_cycle_update;
+DROP TRIGGER local_sessions_parent_no_cycle_insert;
+
+ALTER TABLE local_sessions DROP COLUMN launched_from_session_id;
+ALTER TABLE local_sessions RENAME COLUMN parent_session_id TO launch_parent_id;
+
+-- +goose StatementBegin
+CREATE TRIGGER local_sessions_launch_parent_no_cycle_insert
+BEFORE INSERT ON local_sessions
+WHEN NEW.launch_parent_id IS NOT NULL
+BEGIN
+    WITH RECURSIVE ancestors(id) AS (
+        SELECT NEW.launch_parent_id
+        UNION
+        SELECT s.launch_parent_id
+        FROM local_sessions AS s
+        JOIN ancestors AS a ON s.id = a.id
+        WHERE s.launch_parent_id IS NOT NULL
+    )
+    SELECT CASE WHEN EXISTS (
+        SELECT 1 FROM ancestors WHERE id = NEW.id
+    ) THEN RAISE(ABORT, 'launch parent cycle') END;
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER local_sessions_launch_parent_immutable_update
+BEFORE UPDATE OF launch_parent_id ON local_sessions
+WHEN NEW.launch_parent_id IS NOT NULL
+BEGIN
+    SELECT RAISE(ABORT, 'launch parent can only be cleared');
+END;
+-- +goose StatementEnd

--- a/services/gmuxd/internal/centralstore/placeunplaced.go
+++ b/services/gmuxd/internal/centralstore/placeunplaced.go
@@ -75,10 +75,10 @@ func (s *Store) PlaceUnplacedSessions(ctx context.Context, ids []SessionID, at U
 			continue
 		}
 		rec := &placementRec{project: int64(project), local: string(sess.ID), parent: func() string {
-			if sess.LaunchParentID == nil {
+			if sess.ParentSessionID == nil {
 				return ""
 			}
-			return string(*sess.LaunchParentID)
+			return string(*sess.ParentSessionID)
 		}(), created: int64(sess.CreatedAt), promoted: sess.PromotedToRoot, isNew: true}
 		all = append(all, rec)
 		placed[string(sess.ID)] = true

--- a/services/gmuxd/internal/centralstore/register.go
+++ b/services/gmuxd/internal/centralstore/register.go
@@ -30,11 +30,11 @@ type RunnerRegistration struct {
 	// The singleton coordinator must serialize lifecycle operations and prove
 	// its reservation is still current immediately before this call. The
 	// generation itself remains runtime-only and is never persisted.
-	NewGeneration  bool
-	CreatedAt      UnixMillis
-	LaunchParentID *SessionID
-	ObservedAt     UnixMillis
-	Facts          RunnerFacts
+	NewGeneration   bool
+	CreatedAt       UnixMillis
+	ParentSessionID *SessionID
+	ObservedAt      UnixMillis
+	Facts           RunnerFacts
 	// Evict is the conversation-takeover loser set: dead retained rows whose
 	// conversation the registering live runner covers (same opaque ref, or an
 	// ancestor per the adapter's lineage — resolved by the coordinator, which
@@ -102,7 +102,7 @@ func (s *Store) RegisterRunner(ctx context.Context, reg RunnerRegistration) (Ses
 	if reg.CreatedAt < 0 || reg.ObservedAt < 0 {
 		return Session{}, MutationResult{}, errors.New("centralstore: registration timestamps must be non-negative")
 	}
-	if reg.LaunchParentID != nil && (*reg.LaunchParentID == "" || *reg.LaunchParentID == reg.ID) {
+	if reg.ParentSessionID != nil && (*reg.ParentSessionID == "" || *reg.ParentSessionID == reg.ID) {
 		return Session{}, MutationResult{}, errors.New("centralstore: invalid launch parent")
 	}
 	if err := validateRunnerFacts(reg.Facts); err != nil {
@@ -194,12 +194,14 @@ func (s *Store) RegisterRunner(ctx context.Context, reg RunnerRegistration) (Ses
 	}
 
 	if isNew {
+		launchedFrom := cloneSessionID(reg.ParentSessionID)
 		current = Session{
 			ID: reg.ID, Adapter: reg.Adapter, DriveMode: normalizeDriveMode(reg.DriveMode), CreatedAt: reg.CreatedAt,
-			Command: []string{}, Remotes: map[string]string{}, LaunchParentID: cloneSessionID(reg.LaunchParentID),
+			Command: []string{}, Remotes: map[string]string{},
+			ParentSessionID: cloneSessionID(reg.ParentSessionID),
 		}
-		if current.LaunchParentID != nil && evictedIDs[*current.LaunchParentID] {
-			current.LaunchParentID = nil
+		if current.ParentSessionID != nil && evictedIDs[*current.ParentSessionID] {
+			current.ParentSessionID = nil
 		}
 		if err = mergeRunnerFacts(&current, reg.Facts); err != nil {
 			return Session{}, MutationResult{}, err
@@ -226,11 +228,18 @@ func (s *Store) RegisterRunner(ctx context.Context, reg RunnerRegistration) (Ses
 			Slug: nullString(current.Slug), SlugBase: nullString(current.SlugBase), ShellTitle: nullString(current.ShellTitle), AdapterTitle: nullString(current.AdapterTitle), Subtitle: nullString(current.Subtitle),
 			Active: boolInt(current.Active), Interrupted: boolInt(current.Interrupted), Unread: boolInt(current.Unread), HasError: boolInt(current.Error), StatusReported: boolInt(current.StatusReported), CreatedAtMs: int64(current.CreatedAt),
 			StartedAtMs: nullMillis(current.StartedAt), ExitedAtMs: nullMillis(current.ExitedAt), LastActivityAtMs: nullMillis(current.LastActivityAt), ExitCode: nullInt(current.ExitCode),
-			TerminalCols: nullUint(current.TerminalCols), TerminalRows: nullUint(current.TerminalRows), LaunchParentID: func() sql.NullString {
-				if current.LaunchParentID == nil {
+			TerminalCols: nullUint(current.TerminalCols), TerminalRows: nullUint(current.TerminalRows),
+			ParentSessionID: func() sql.NullString {
+				if current.ParentSessionID == nil {
 					return sql.NullString{}
 				}
-				return nullString(string(*current.LaunchParentID))
+				return nullString(string(*current.ParentSessionID))
+			}(),
+			LaunchedFromSessionID: func() sql.NullString {
+				if launchedFrom == nil {
+					return sql.NullString{}
+				}
+				return nullString(string(*launchedFrom))
 			}(),
 		})
 		if err != nil {
@@ -346,8 +355,8 @@ func orderTakeoverEvictions(ctx context.Context, q *db.Queries, evictions []Take
 	}
 	parent := make(map[SessionID]SessionID, len(rows))
 	for _, row := range rows {
-		if row.LaunchParentID.Valid {
-			parent[SessionID(row.ID)] = SessionID(row.LaunchParentID.String)
+		if row.ParentSessionID.Valid {
+			parent[SessionID(row.ID)] = SessionID(row.ParentSessionID.String)
 		}
 	}
 	depths := make(map[SessionID]int, len(evictions))
@@ -680,10 +689,10 @@ func rematchRegistration(ctx context.Context, q *db.Queries, fault func() error,
 	project := int64(project64)
 	if target == nil {
 		target = &placementRec{project: project, local: string(current.ID), parent: func() string {
-			if current.LaunchParentID == nil {
+			if current.ParentSessionID == nil {
 				return ""
 			}
-			return string(*current.LaunchParentID)
+			return string(*current.ParentSessionID)
 		}(), created: int64(current.CreatedAt), promoted: current.PromotedToRoot, isNew: true}
 		all = append(all, target)
 	} else {

--- a/services/gmuxd/internal/centralstore/register_test.go
+++ b/services/gmuxd/internal/centralstore/register_test.go
@@ -103,7 +103,7 @@ func TestRegisterRunnerSameIDPreservesHistoryAndNoop(t *testing.T) {
 	cat := registrationCatalog(t, s)
 	parent := SessionID("original-parent")
 	first := registration("same", "shell", "/one", false, 10)
-	first.LaunchParentID = &parent
+	first.ParentSessionID = &parent
 	first.Facts.ExitedAt = NullablePatch[UnixMillis]{Set: ptr(UnixMillis(12))}
 	first.Facts.ExitCode = NullablePatch[int]{Set: ptr(3)}
 	got, _, err := s.RegisterRunner(ctx, first)
@@ -118,12 +118,13 @@ func TestRegisterRunnerSameIDPreservesHistoryAndNoop(t *testing.T) {
 
 	otherParent := SessionID("replacement-parent")
 	resume := registration("same", "shell", "/one", true, 99)
-	resume.LaunchParentID = &otherParent
+	resume.ParentSessionID = &otherParent
 	got, result, err := s.RegisterRunner(ctx, resume)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got.CreatedAt != 10 || got.LaunchParentID == nil || *got.LaunchParentID != parent || !got.PromotedToRoot || got.ExitedAt != nil || got.ExitCode != nil {
+	if got.CreatedAt != 10 || got.ParentSessionID == nil || *got.ParentSessionID != parent ||
+		!got.PromotedToRoot || got.ExitedAt != nil || got.ExitCode != nil {
 		t.Fatalf("history not preserved/live exit not cleared: %#v", got)
 	}
 	if result.SessionVersion != 3 || !result.SessionsDirty || result.WorldDirty {
@@ -515,7 +516,7 @@ func TestRegisterRunnerChildBeforeParentRegroups(t *testing.T) {
 	cat := registrationCatalog(t, s)
 	parent := SessionID("parent")
 	child := registration("child", "shell", "/one", true, 1)
-	child.LaunchParentID = &parent
+	child.ParentSessionID = &parent
 	if _, _, err := s.RegisterRunner(ctx, child); err != nil {
 		t.Fatal(err)
 	}
@@ -539,14 +540,14 @@ func TestRegisterRunnerMissingParentCycleRejectsExactly(t *testing.T) {
 	registrationCatalog(t, s)
 	b := SessionID("b")
 	a := registration("a", "shell", "/one", true, 1)
-	a.LaunchParentID = &b
+	a.ParentSessionID = &b
 	before, _, err := s.RegisterRunner(ctx, a)
 	if err != nil {
 		t.Fatal(err)
 	}
 	aID := SessionID("a")
 	cycle := registration("b", "shell", "/one", true, 2)
-	cycle.LaunchParentID = &aID
+	cycle.ParentSessionID = &aID
 	if _, _, err = s.RegisterRunner(ctx, cycle); err == nil {
 		t.Fatal("missing-parent cycle registration succeeded")
 	}
@@ -565,7 +566,7 @@ func TestRegisterRunnerDifferentProjectParentAndChildRemainRoots(t *testing.T) {
 	cat := registrationCatalog(t, s)
 	parent := SessionID("parent")
 	child := registration("child", "shell", "/two", true, 1)
-	child.LaunchParentID = &parent
+	child.ParentSessionID = &parent
 	if _, _, err := s.RegisterRunner(ctx, child); err != nil {
 		t.Fatal(err)
 	}
@@ -587,7 +588,7 @@ func TestRegisterRunnerMultipleChildrenBeforeParentKeepOrder(t *testing.T) {
 	parent := SessionID("parent")
 	for i, id := range []string{"first", "second", "third"} {
 		child := registration(id, "shell", "/one", true, UnixMillis(i+1))
-		child.LaunchParentID = &parent
+		child.ParentSessionID = &parent
 		if _, _, err := s.RegisterRunner(ctx, child); err != nil {
 			t.Fatal(err)
 		}
@@ -835,7 +836,7 @@ func TestTakeoverSlugAllocationInteractingEvictionsNeverLeaveClearedSurvivor(t *
 			}
 
 			bReg := registration("loser-b", "pi", "/work", false, 3)
-			bReg.LaunchParentID = &a.ID
+			bReg.ParentSessionID = &a.ID
 			bReg.Facts.Slug = &bBase
 			bReg.Facts.ExitedAt.Set = ptr(UnixMillis(4))
 			b, _, err := s.RegisterRunner(ctx, bReg)
@@ -886,7 +887,7 @@ func TestTakeoverSlugAllocationTopologicalEvictions(t *testing.T) {
 			registerLoser := func(id, slug string, parent *SessionID, at UnixMillis) {
 				t.Helper()
 				reg := registration(id, "pi", "/work", false, at)
-				reg.LaunchParentID = parent
+				reg.ParentSessionID = parent
 				reg.Facts.Slug = &slug
 				reg.Facts.ExitedAt.Set = ptr(at + 1)
 				row, _, err := s.RegisterRunner(ctx, reg)
@@ -942,10 +943,10 @@ func TestOrderTakeoverEvictionsRejectsCorruptParentCycle(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	if _, err := s.database.ExecContext(ctx, `DROP TRIGGER local_sessions_launch_parent_immutable_update`); err != nil {
+	if _, err := s.database.ExecContext(ctx, `DROP TRIGGER local_sessions_parent_no_cycle_update`); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := s.database.ExecContext(ctx, `UPDATE local_sessions SET launch_parent_id = CASE id WHEN 'cycle-a' THEN 'cycle-b' ELSE 'cycle-a' END`); err != nil {
+	if _, err := s.database.ExecContext(ctx, `UPDATE local_sessions SET parent_session_id = CASE id WHEN 'cycle-a' THEN 'cycle-b' ELSE 'cycle-a' END`); err != nil {
 		t.Fatal(err)
 	}
 	_, err := orderTakeoverEvictions(ctx, s.queries, []TakeoverEviction{{ID: "cycle-a", Version: 1}, {ID: "cycle-b", Version: 1}})

--- a/services/gmuxd/internal/centralstore/release_safety_test.go
+++ b/services/gmuxd/internal/centralstore/release_safety_test.go
@@ -223,6 +223,36 @@ DROP TABLE v2_upgrade_marker;
 	}
 }
 
+func TestV3MigrationBackfillsLaunchProvenance(t *testing.T) {
+	ctx := context.Background()
+	dir := filepath.Join(t.TempDir(), "state")
+	database := createReleasedV1Database(t, dir)
+	if _, err := database.ExecContext(ctx, `
+		INSERT INTO local_sessions
+		(id, adapter, command_json, cwd, remotes_json, created_at_ms, launch_parent_id)
+		VALUES ('child', 'shell', '["sh"]', '/', '{}', 2, 'parent')`); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	store, err := Open(ctx, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	var parent, launchedFrom sql.NullString
+	if err := store.database.QueryRowContext(ctx, `
+		SELECT parent_session_id, launched_from_session_id
+		FROM local_sessions WHERE id='child'`).Scan(&parent, &launchedFrom); err != nil {
+		t.Fatal(err)
+	}
+	if !parent.Valid || parent.String != "parent" || !launchedFrom.Valid || launchedFrom.String != "parent" {
+		t.Fatalf("migrated parent/provenance = %#v / %#v", parent, launchedFrom)
+	}
+}
+
 func TestMigrationBackupFailureRefusesUpgrade(t *testing.T) {
 	ctx := context.Background()
 	dir := filepath.Join(t.TempDir(), "state")
@@ -331,22 +361,27 @@ func TestOpenRejectsCommittedMigrationForeignKeyViolation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	v3, err := fs.ReadFile(migrationFiles, "migrations/00003_session_parent_provenance.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
 	files := fstest.MapFS{
-		"migrations/00001_initial_schema.sql": {Data: v1},
-		"migrations/00002_drive_mode.sql":     {Data: v2},
-		"migrations/00003_orphan.sql":         {Data: []byte("-- +goose NO TRANSACTION\n-- +goose Up\nCREATE TABLE migration_parent (id INTEGER PRIMARY KEY);\nCREATE TABLE migration_child (parent_id INTEGER REFERENCES migration_parent(id));\nPRAGMA foreign_keys=OFF;\nINSERT INTO migration_child VALUES (99);\nPRAGMA foreign_keys=ON;\n")},
+		"migrations/00001_initial_schema.sql":            {Data: v1},
+		"migrations/00002_drive_mode.sql":                {Data: v2},
+		"migrations/00003_session_parent_provenance.sql": {Data: v3},
+		"migrations/00004_orphan.sql":                    {Data: []byte("-- +goose NO TRANSACTION\n-- +goose Up\nCREATE TABLE migration_parent (id INTEGER PRIMARY KEY);\nCREATE TABLE migration_child (parent_id INTEGER REFERENCES migration_parent(id));\nPRAGMA foreign_keys=OFF;\nINSERT INTO migration_child VALUES (99);\nPRAGMA foreign_keys=ON;\n")},
 	}
 	_, err = openWithMigrationFS(ctx, dir, files)
 	if !errors.Is(err, ErrForeignKeyIntegrity) {
 		t.Fatalf("open error = %v, want ErrForeignKeyIntegrity", err)
 	}
-	backups, globErr := filepath.Glob(filepath.Join(dir, "backups", "state-pre-migration-v2-to-v3-*.db"))
+	backups, globErr := filepath.Glob(filepath.Join(dir, "backups", "state-pre-migration-v3-to-v4-*.db"))
 	if globErr != nil || len(backups) != 1 || !strings.Contains(err.Error(), backups[0]) {
 		t.Fatalf("error/backups = %v / %v / %v; want retained path in post-migration diagnostic", err, backups, globErr)
 	}
 	database := openReleaseTestDB(t, DatabasePath(dir))
 	defer database.Close()
-	assertDBVersion(t, database, 3)
+	assertDBVersion(t, database, 4)
 }
 
 func TestQuickCheckFailureCarriesMigrationBackupPath(t *testing.T) {

--- a/services/gmuxd/internal/centralstore/store_test.go
+++ b/services/gmuxd/internal/centralstore/store_test.go
@@ -26,8 +26,8 @@ func TestOpenFreshAndReopen(t *testing.T) {
 	if got, want := store.database.Stats().MaxOpenConnections, 1; got != want {
 		t.Fatalf("MaxOpenConnections = %d, want %d", got, want)
 	}
-	if version, err := store.SchemaVersion(ctx); err != nil || version != 2 {
-		t.Fatalf("schema version = %d, %v; want 2 (v2: drive_mode)", version, err)
+	if version, err := store.SchemaVersion(ctx); err != nil || version != 3 {
+		t.Fatalf("schema version = %d, %v; want 3", version, err)
 	}
 	if err := store.queries.PutMetadata(ctx, db.PutMetadataParams{Key: "kept", Value: "yes"}); err != nil {
 		t.Fatal(err)

--- a/services/gmuxd/internal/sessioncoord/coordinator.go
+++ b/services/gmuxd/internal/sessioncoord/coordinator.go
@@ -232,10 +232,12 @@ type Coordinator struct {
 	// double-spawning or double-killing. See lifecycle.go.
 	ops map[centralstore.SessionID]*LifecycleClaim
 
-	// beforeDismissLock is a test-only synchronization seam: when set, it is
-	// called immediately before Dismiss attempts the lifecycle mutex, letting
-	// serialization tests deterministically observe "blocked at the mutex".
-	beforeDismissLock func()
+	// beforeDismissLock and beforeReparentLock are test-only synchronization
+	// seams: when set, they are called immediately before the operation attempts
+	// the lifecycle mutex, letting serialization tests deterministically observe
+	// "blocked at the mutex".
+	beforeDismissLock  func()
+	beforeReparentLock func()
 
 	// outcomes is the post-commit outcome bus (see outcomes.go). It has its
 	// own lock; publishing never runs under the lifecycle mutex.

--- a/services/gmuxd/internal/sessioncoord/dismiss.go
+++ b/services/gmuxd/internal/sessioncoord/dismiss.go
@@ -51,8 +51,8 @@ func (c *Coordinator) Dismiss(ctx context.Context, root centralstore.SessionID) 
 	children := make(map[centralstore.SessionID][]centralstore.SessionID)
 	for _, s := range sessions {
 		byID[s.ID] = s
-		if s.LaunchParentID != nil {
-			children[*s.LaunchParentID] = append(children[*s.LaunchParentID], s.ID)
+		if s.ParentSessionID != nil {
+			children[*s.ParentSessionID] = append(children[*s.ParentSessionID], s.ID)
 		}
 	}
 	if _, ok := byID[root]; !ok {

--- a/services/gmuxd/internal/sessioncoord/dismiss_test.go
+++ b/services/gmuxd/internal/sessioncoord/dismiss_test.go
@@ -255,6 +255,182 @@ func TestDismissSerializesWithRegisterCommitWindow(t *testing.T) {
 	}
 }
 
+// gatedLifecycleStore exposes the point after Dismiss has checked its durable
+// subtree and runtime liveness but before DismissSessionTree commits. Reparent
+// entry is separately observable so the tests prove it is parked on the
+// coordinator mutex rather than merely not scheduled yet.
+type gatedLifecycleStore struct {
+	*centralstore.Store
+	dismissEntered  chan struct{}
+	dismissRelease  chan struct{}
+	reparentEntered chan struct{}
+}
+
+func (s *gatedLifecycleStore) DismissSessionTree(ctx context.Context, root centralstore.SessionID, at centralstore.UnixMillis) ([]centralstore.SessionID, centralstore.MutationResult, error) {
+	close(s.dismissEntered)
+	<-s.dismissRelease
+	return s.Store.DismissSessionTree(ctx, root, at)
+}
+
+func (s *gatedLifecycleStore) SetSessionParent(ctx context.Context, id centralstore.SessionID, parent *centralstore.SessionID) (centralstore.MutationResult, error) {
+	close(s.reparentEntered)
+	return s.Store.SetSessionParent(ctx, id, parent)
+}
+
+func newGatedLifecycleCoord(t *testing.T, rows ...centralstore.NewSession) (*Coordinator, *gatedLifecycleStore) {
+	t.Helper()
+	ctx := context.Background()
+	store, err := centralstore.Open(ctx, t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	for _, row := range rows {
+		if _, _, err := store.InsertSession(ctx, row); err != nil {
+			t.Fatal(err)
+		}
+	}
+	gated := &gatedLifecycleStore{
+		Store:           store,
+		dismissEntered:  make(chan struct{}),
+		dismissRelease:  make(chan struct{}),
+		reparentEntered: make(chan struct{}),
+	}
+	return New(nil, nil, gated, &fakeDirtySink{}, nil,
+		WithClock(func() centralstore.UnixMillis { return 777 })), gated
+}
+
+// TestReparentSerializesWithDismissMoveIn reproduces the previously unsafe
+// schedule: a live root is adopted after Dismiss has checked an unrelated
+// dead root but before its subtree transaction. Reparent must wait until the
+// dismissal commits, leaving the live session visible.
+func TestReparentSerializesWithDismissMoveIn(t *testing.T) {
+	ctx := context.Background()
+	coord, store := newGatedLifecycleCoord(t,
+		centralstore.NewSession{ID: "root", Adapter: "shell", CreatedAt: 1},
+		centralstore.NewSession{ID: "live", Adapter: "shell", CreatedAt: 2},
+	)
+	coord.registry.install(registryEntry{Runtime: Runtime{SessionID: "live", Generation: 1}, dead: make(chan struct{})})
+
+	dismissDone := make(chan struct {
+		ids []centralstore.SessionID
+		err error
+	}, 1)
+	go func() {
+		ids, err := coord.Dismiss(ctx, "root")
+		dismissDone <- struct {
+			ids []centralstore.SessionID
+			err error
+		}{ids, err}
+	}()
+	<-store.dismissEntered
+	released := false
+	defer func() {
+		if !released {
+			close(store.dismissRelease)
+		}
+	}()
+
+	atMutex := make(chan struct{})
+	coord.beforeReparentLock = func() { close(atMutex) }
+	parent := centralstore.SessionID("root")
+	reparentDone := make(chan error, 1)
+	go func() {
+		_, err := coord.SetSessionParent(ctx, "live", &parent)
+		reparentDone <- err
+	}()
+	<-atMutex
+	select {
+	case <-store.reparentEntered:
+		t.Fatal("reparent entered the store inside dismissal's checked-subtree window")
+	case err := <-reparentDone:
+		t.Fatalf("reparent finished inside dismissal's checked-subtree window: %v", err)
+	default:
+	}
+
+	close(store.dismissRelease)
+	released = true
+	dismissed := <-dismissDone
+	if dismissed.err != nil || !reflect.DeepEqual(dismissed.ids, []centralstore.SessionID{"root"}) {
+		t.Fatalf("Dismiss: ids=%v err=%v", dismissed.ids, dismissed.err)
+	}
+	if err := <-reparentDone; err != nil {
+		t.Fatalf("SetSessionParent: %v", err)
+	}
+	<-store.reparentEntered
+	live, ok, err := store.Session(ctx, "live")
+	if err != nil || !ok {
+		t.Fatalf("live session lookup: ok=%v err=%v", ok, err)
+	}
+	if live.DismissedAt != nil {
+		t.Fatalf("live session was hidden: dismissed_at=%v", *live.DismissedAt)
+	}
+	if _, installed := coord.registry.current("live"); !installed {
+		t.Fatal("live generation disappeared")
+	}
+}
+
+// TestReparentSerializesWithDismissMoveOut proves the inverse schedule cannot
+// silently narrow the subtree the user confirmed: moving a checked child out
+// waits until both checked rows have been dismissed.
+func TestReparentSerializesWithDismissMoveOut(t *testing.T) {
+	ctx := context.Background()
+	root := centralstore.SessionID("root")
+	coord, store := newGatedLifecycleCoord(t,
+		centralstore.NewSession{ID: root, Adapter: "shell", CreatedAt: 1},
+		centralstore.NewSession{ID: "child", Adapter: "shell", CreatedAt: 2, ParentSessionID: &root},
+	)
+
+	dismissDone := make(chan struct {
+		ids []centralstore.SessionID
+		err error
+	}, 1)
+	go func() {
+		ids, err := coord.Dismiss(ctx, root)
+		dismissDone <- struct {
+			ids []centralstore.SessionID
+			err error
+		}{ids, err}
+	}()
+	<-store.dismissEntered
+	released := false
+	defer func() {
+		if !released {
+			close(store.dismissRelease)
+		}
+	}()
+
+	atMutex := make(chan struct{})
+	coord.beforeReparentLock = func() { close(atMutex) }
+	reparentDone := make(chan error, 1)
+	go func() {
+		_, err := coord.SetSessionParent(ctx, "child", nil)
+		reparentDone <- err
+	}()
+	<-atMutex
+	select {
+	case <-store.reparentEntered:
+		t.Fatal("move-out entered the store inside dismissal's checked-subtree window")
+	case err := <-reparentDone:
+		t.Fatalf("move-out finished inside dismissal's checked-subtree window: %v", err)
+	default:
+	}
+
+	close(store.dismissRelease)
+	released = true
+	dismissed := <-dismissDone
+	if dismissed.err != nil || !reflect.DeepEqual(dismissed.ids, []centralstore.SessionID{"root", "child"}) {
+		t.Fatalf("Dismiss: ids=%v err=%v", dismissed.ids, dismissed.err)
+	}
+	if err := <-reparentDone; err != nil {
+		t.Fatalf("SetSessionParent: %v", err)
+	}
+	child, ok, err := store.Session(ctx, "child")
+	if err != nil || !ok || child.DismissedAt == nil {
+		t.Fatalf("checked child escaped dismissal: row=%#v ok=%v err=%v", child, ok, err)
+	}
+}
+
 func TestRemoveCommitsAndPublishes(t *testing.T) {
 	dur := newFakeDurable(0)
 	var gotVersion centralstore.RowVersion

--- a/services/gmuxd/internal/sessioncoord/dismiss_test.go
+++ b/services/gmuxd/internal/sessioncoord/dismiss_test.go
@@ -20,7 +20,7 @@ func treeSessions(exitless ...centralstore.SessionID) []centralstore.Session {
 		s := centralstore.Session{ID: id, Adapter: "shell", Version: 1}
 		if parent != "" {
 			p := parent
-			s.LaunchParentID = &p
+			s.ParentSessionID = &p
 		}
 		if !noExit[id] {
 			at := centralstore.UnixMillis(100)

--- a/services/gmuxd/internal/sessioncoord/outcomes.go
+++ b/services/gmuxd/internal/sessioncoord/outcomes.go
@@ -240,7 +240,7 @@ func cloneOutcomeSession(s *centralstore.Session) *centralstore.Session {
 	clone.ExitCode = cloneOutcomePtr(s.ExitCode)
 	clone.TerminalCols = cloneOutcomePtr(s.TerminalCols)
 	clone.TerminalRows = cloneOutcomePtr(s.TerminalRows)
-	clone.LaunchParentID = cloneOutcomePtr(s.LaunchParentID)
+	clone.ParentSessionID = cloneOutcomePtr(s.ParentSessionID)
 	return &clone
 }
 

--- a/services/gmuxd/internal/sessioncoord/outcomes_test.go
+++ b/services/gmuxd/internal/sessioncoord/outcomes_test.go
@@ -544,7 +544,7 @@ func aliasTestSession(id centralstore.SessionID, version centralstore.RowVersion
 		ID: id, Version: version, Title: title,
 		Command: []string{"cmd", "arg"}, Remotes: map[string]string{"origin": "url"},
 		StartedAt: &started, ExitedAt: &exited, LastActivityAt: &activity, DismissedAt: &dismissed,
-		ExitCode: &exitCode, TerminalCols: &cols, TerminalRows: &rows, LaunchParentID: &parent,
+		ExitCode: &exitCode, TerminalCols: &cols, TerminalRows: &rows, ParentSessionID: &parent,
 	}
 }
 
@@ -559,7 +559,7 @@ func corruptAliasSession(s *centralstore.Session) {
 	*s.ExitCode = 15
 	*s.TerminalCols = 16
 	*s.TerminalRows = 17
-	*s.LaunchParentID = "mutated-parent"
+	*s.ParentSessionID = "mutated-parent"
 }
 
 // TestOutcomeBusEventProjectionSnapshotOwned reproduces both event alias
@@ -672,7 +672,7 @@ func TestCloneOutcomeSessionOwnsEveryReferenceField(t *testing.T) {
 	allowed := map[string]bool{
 		"Command": true, "Remotes": true, "StartedAt": true, "ExitedAt": true,
 		"LastActivityAt": true, "DismissedAt": true, "ExitCode": true,
-		"TerminalCols": true, "TerminalRows": true, "LaunchParentID": true,
+		"TerminalCols": true, "TerminalRows": true, "ParentSessionID": true,
 	}
 	typ := reflect.TypeOf(centralstore.Session{})
 	for i := range typ.NumField() {

--- a/services/gmuxd/internal/sessioncoord/reparent.go
+++ b/services/gmuxd/internal/sessioncoord/reparent.go
@@ -1,0 +1,35 @@
+package sessioncoord
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/centralstore"
+)
+
+// SetSessionParent mutates the organizational parent edge while holding the
+// lifecycle mutex. Dismiss holds the same mutex from its subtree/liveness
+// check through DismissSessionTree, so a reparent cannot change the checked
+// subtree before the dismissal transaction commits.
+//
+// The central store remains the sole owner of transaction, cycle-validation,
+// version, and sibling-order semantics.
+func (c *Coordinator) SetSessionParent(ctx context.Context, id centralstore.SessionID, parent *centralstore.SessionID) (centralstore.MutationResult, error) {
+	if c.beforeReparentLock != nil {
+		c.beforeReparentLock()
+	}
+	c.mu.Lock()
+	reparenter, ok := c.durable.(interface {
+		SetSessionParent(context.Context, centralstore.SessionID, *centralstore.SessionID) (centralstore.MutationResult, error)
+	})
+	if !ok {
+		c.mu.Unlock()
+		return centralstore.MutationResult{}, fmt.Errorf("sessioncoord: durable store does not support session reparenting")
+	}
+	result, err := reparenter.SetSessionParent(ctx, id, parent)
+	c.mu.Unlock()
+	if err == nil {
+		c.publish(ctx, result)
+	}
+	return result, err
+}

--- a/services/gmuxd/internal/snapshot/wire/convert.go
+++ b/services/gmuxd/internal/snapshot/wire/convert.go
@@ -125,8 +125,8 @@ func (c *Converter) session(row central.SessionRow) Session {
 	if v.StatusReported {
 		out.Status = &Status{Active: v.Active, Error: v.Error, Interrupted: v.Interrupted}
 	}
-	if v.LaunchParentID != nil {
-		out.ParentSessionID = string(*v.LaunchParentID)
+	if v.ParentSessionID != nil {
+		out.ParentSessionID = string(*v.ParentSessionID)
 	}
 	if v.TerminalCols != nil {
 		out.TerminalCols = *v.TerminalCols

--- a/services/gmuxd/internal/snapshot/wire/convert_test.go
+++ b/services/gmuxd/internal/snapshot/wire/convert_test.go
@@ -40,7 +40,7 @@ func TestSessionConversionPreservesFamilyFacts(t *testing.T) {
 	parent := centralstore.SessionID("parent")
 	got := (&Converter{SemanticAgents: map[string]bool{"pi": true}}).session(central.SessionRow{
 		SessionView: centralstore.SessionView{Session: centralstore.Session{
-			ID: "child", Adapter: "pi", CreatedAt: 1, LaunchParentID: &parent, PromotedToRoot: true,
+			ID: "child", Adapter: "pi", CreatedAt: 1, ParentSessionID: &parent, PromotedToRoot: true,
 		}},
 	})
 	if got.ParentSessionID != "parent" || !got.SemanticAgent || !got.PromotedToRoot {

--- a/services/gmuxd/internal/snapshot/wire/decompose_test.go
+++ b/services/gmuxd/internal/snapshot/wire/decompose_test.go
@@ -54,7 +54,7 @@ func newRoundTripFixture(t *testing.T) *roundTripFixture {
 	insert(centralstore.NewSession{ID: "18wnzse2", Adapter: "claude", CWD: "/work", CreatedAt: 2, Slug: "fix-auth"})
 	insert(centralstore.NewSession{ID: "10cel6cx", Adapter: "shell", CWD: "/work", CreatedAt: 3})
 	parent := centralstore.SessionID("1mw5c5n9")
-	insert(centralstore.NewSession{ID: "10yeqnxg", Adapter: "shell", CWD: "/work", CreatedAt: 4, LaunchParentID: &parent})
+	insert(centralstore.NewSession{ID: "10yeqnxg", Adapter: "shell", CWD: "/work", CreatedAt: 4, ParentSessionID: &parent})
 	if _, err := s.UpsertLocalPeerPlacement(ctx, centralstore.LocalPeerSubject{PeerKey: "box", SessionID: "cont-1"}, proj); err != nil {
 		t.Fatal(err)
 	}
@@ -170,7 +170,7 @@ func TestGoldenRoundTripPartialRequest(t *testing.T) {
 func TestGoldenRoundTripChildScope(t *testing.T) {
 	f := newRoundTripFixture(t)
 	parent := centralstore.SessionID("1mw5c5n9")
-	if _, _, err := f.store.InsertSession(f.ctx, centralstore.NewSession{ID: "1dy2rn04", Adapter: "shell", CWD: "/work", CreatedAt: 5, LaunchParentID: &parent}); err != nil {
+	if _, _, err := f.store.InsertSession(f.ctx, centralstore.NewSession{ID: "1dy2rn04", Adapter: "shell", CWD: "/work", CreatedAt: 5, ParentSessionID: &parent}); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := f.store.PlaceLocalSession(f.ctx, "1dy2rn04", f.proj); err != nil {

--- a/services/gmuxd/internal/snapshot/wire/equivalence/fixtures.go
+++ b/services/gmuxd/internal/snapshot/wire/equivalence/fixtures.go
@@ -376,7 +376,7 @@ func RenderCentral(t *testing.T, w *World) (wire.Frames, *wire.Cache) {
 		}
 		if f.Parent != "" {
 			p := centralstore.SessionID(f.Parent)
-			ns.LaunchParentID = &p
+			ns.ParentSessionID = &p
 		}
 		if _, _, err := db.InsertSession(ctx, ns); err != nil {
 			t.Fatal(err)

--- a/services/gmuxd/internal/statetool/export.go
+++ b/services/gmuxd/internal/statetool/export.go
@@ -24,33 +24,34 @@ type ExportDoc struct {
 // dismissed rows included (hidden-not-forgotten). Timestamps stay Unix-ms
 // integers: export is a diagnostic inventory, not the ADR 0001 wire shape.
 type ExportSession struct {
-	ID              string            `json:"id"`
-	Adapter         string            `json:"adapter"`
-	DriveMode       string            `json:"drive_mode,omitempty"`
-	ConversationRef string            `json:"conversation_ref,omitempty"`
-	Command         []string          `json:"command"`
-	CWD             string            `json:"cwd"`
-	WorkspaceRoot   string            `json:"workspace_root,omitempty"`
-	Remotes         map[string]string `json:"remotes"`
-	Slug            string            `json:"slug,omitempty"`
-	ShellTitle      string            `json:"shell_title,omitempty"`
-	AdapterTitle    string            `json:"adapter_title,omitempty"`
-	Subtitle        string            `json:"subtitle,omitempty"`
-	Active          bool              `json:"active"`
-	Interrupted     bool              `json:"interrupted"`
-	Unread          bool              `json:"unread"`
-	Error           bool              `json:"error"`
-	StatusReported  bool              `json:"status_reported"`
-	CreatedAtMs     int64             `json:"created_at_ms"`
-	StartedAtMs     *int64            `json:"started_at_ms,omitempty"`
-	ExitedAtMs      *int64            `json:"exited_at_ms,omitempty"`
-	LastActivityMs  *int64            `json:"last_activity_at_ms,omitempty"`
-	DismissedAtMs   *int64            `json:"dismissed_at_ms,omitempty"`
-	ExitCode        *int              `json:"exit_code,omitempty"`
-	TerminalCols    *uint16           `json:"terminal_cols,omitempty"`
-	TerminalRows    *uint16           `json:"terminal_rows,omitempty"`
-	LaunchParentID  string            `json:"launch_parent_id,omitempty"`
-	PromotedToRoot  bool              `json:"promoted_to_root"`
+	ID                    string            `json:"id"`
+	Adapter               string            `json:"adapter"`
+	DriveMode             string            `json:"drive_mode,omitempty"`
+	ConversationRef       string            `json:"conversation_ref,omitempty"`
+	Command               []string          `json:"command"`
+	CWD                   string            `json:"cwd"`
+	WorkspaceRoot         string            `json:"workspace_root,omitempty"`
+	Remotes               map[string]string `json:"remotes"`
+	Slug                  string            `json:"slug,omitempty"`
+	ShellTitle            string            `json:"shell_title,omitempty"`
+	AdapterTitle          string            `json:"adapter_title,omitempty"`
+	Subtitle              string            `json:"subtitle,omitempty"`
+	Active                bool              `json:"active"`
+	Interrupted           bool              `json:"interrupted"`
+	Unread                bool              `json:"unread"`
+	Error                 bool              `json:"error"`
+	StatusReported        bool              `json:"status_reported"`
+	CreatedAtMs           int64             `json:"created_at_ms"`
+	StartedAtMs           *int64            `json:"started_at_ms,omitempty"`
+	ExitedAtMs            *int64            `json:"exited_at_ms,omitempty"`
+	LastActivityMs        *int64            `json:"last_activity_at_ms,omitempty"`
+	DismissedAtMs         *int64            `json:"dismissed_at_ms,omitempty"`
+	ExitCode              *int              `json:"exit_code,omitempty"`
+	TerminalCols          *uint16           `json:"terminal_cols,omitempty"`
+	TerminalRows          *uint16           `json:"terminal_rows,omitempty"`
+	ParentSessionID       string            `json:"parent_session_id,omitempty"`
+	LaunchedFromSessionID string            `json:"launched_from_session_id,omitempty"`
+	PromotedToRoot        bool              `json:"promoted_to_root"`
 }
 
 // ExportProject is one catalog entry in sidebar order.
@@ -133,7 +134,7 @@ func Export(ctx context.Context, store *centralstore.Store) (ExportDoc, error) {
 	return doc, nil
 }
 
-func exportSession(s centralstore.Session) ExportSession {
+func exportSession(s centralstore.SessionExport) ExportSession {
 	out := ExportSession{
 		ID: string(s.ID), Adapter: s.Adapter, DriveMode: s.DriveMode, ConversationRef: s.ConversationRef,
 		Command: append([]string{}, s.Command...),
@@ -154,8 +155,11 @@ func exportSession(s centralstore.Session) ExportSession {
 	for name, u := range s.Remotes {
 		out.Remotes[name] = RedactURLUserinfo(u)
 	}
-	if s.LaunchParentID != nil {
-		out.LaunchParentID = string(*s.LaunchParentID)
+	if s.ParentSessionID != nil {
+		out.ParentSessionID = string(*s.ParentSessionID)
+	}
+	if s.LaunchedFromSessionID != nil {
+		out.LaunchedFromSessionID = string(*s.LaunchedFromSessionID)
 	}
 	return out
 }

--- a/services/gmuxd/internal/statetool/statetool_test.go
+++ b/services/gmuxd/internal/statetool/statetool_test.go
@@ -38,10 +38,15 @@ func seed(t *testing.T, s *centralstore.Store) {
 		t.Fatal(err)
 	}
 	for _, id := range []string{"beta", "alpha"} {
+		var parent *centralstore.SessionID
+		if id == "alpha" {
+			beta := centralstore.SessionID("beta")
+			parent = &beta
+		}
 		if _, _, err := s.InsertSession(ctx, centralstore.NewSession{
 			ID: centralstore.SessionID(id), Adapter: "shell", Command: []string{"sh"},
 			CWD: "/proj", Remotes: map[string]string{"origin": "https://user:secret@git.example/repo.git"},
-			CreatedAt: 1,
+			CreatedAt: 1, ParentSessionID: parent,
 		}); err != nil {
 			t.Fatal(err)
 		}
@@ -99,6 +104,9 @@ func TestExportIsRedactedAndDeterministic(t *testing.T) {
 	}
 	if doc.Sessions[0].Remotes["origin"] != "https://REDACTED@git.example/repo.git" {
 		t.Fatalf("remote not scrubbed: %+v", doc.Sessions[0].Remotes)
+	}
+	if doc.Sessions[0].ParentSessionID != "beta" || doc.Sessions[0].LaunchedFromSessionID != "beta" {
+		t.Fatalf("parent provenance not exported: %+v", doc.Sessions[0])
 	}
 	if len(doc.Projects) != 1 || doc.Projects[0].Slug != "proj" || len(doc.Placements) != 2 {
 		t.Fatalf("projects/placements = %+v / %+v", doc.Projects, doc.Placements)


### PR DESCRIPTION
## Summary
- split mutable organizational `parent_session_id` from write-once `launched_from_session_id` launch history in schema v3
- add transactional reparenting with existence, self-parent, deep-cycle, version, dismissal, and dense sibling-order guarantees
- expose promote, demote, and reparent through additive HTTP endpoints and `gmux session ...`
- amend ADR 0026 and CLI/family documentation for ownership-tree orchestration

No UI behavior or notification-path logic is added. Existing family and notification projections consume the organizational parent field.

## Tests
- `pnpm exec moon run :build :test`
- `pnpm lint`
- `pnpm exec moon run gmuxd:check-centralstore-generated gmuxd:check-centralstore-cross-build`
- targeted centralstore, statetool, sessioncoord, gmuxd HTTP, CLI, and web family projection tests
