### PR TITLE
feat(peering): stream bounded atomic session bootstrap

### DIFF
--- a/.memory/report-semantic-session-stream.md
+++ b/.memory/report-semantic-session-stream.md
@@ -19,8 +19,9 @@ framing. This does not implement archive/live-set selection.
 A row larger than 48 KiB no longer aborts or closes the stream. The sender omits
 only that row, emits a bounded diagnostic with a fixed reason and safe identity
 (IDs over 128 bytes become `sha256:<digest>`), and completes `ready` for every
-other row. The browser publishes a persistent omitted-session count with safe
-ID/reason details; a later clean bootstrap clears it. Peers retain each bounded
+other row. The browser publishes a persistent exact omitted-session total with
+at most 256 safe ID/reason details; the sender's counted summary cannot consume
+or be dropped by the detail cap, and a later clean bootstrap clears both. Peers retain each bounded
 diagnostic for the transaction and log it. This handles the confirmed old-spoke
 amplification schedule: a new hub accepts a legacy row up to its 1 MiB
 compatibility ceiling, then quarantines that row rather than bricking its

--- a/.memory/report-semantic-session-stream.md
+++ b/.memory/report-semantic-session-stream.md
@@ -19,9 +19,12 @@ framing. This does not implement archive/live-set selection.
 A row larger than 48 KiB no longer aborts or closes the stream. The sender omits
 only that row, emits a bounded diagnostic with a fixed reason and safe identity
 (IDs over 128 bytes become `sha256:<digest>`), and completes `ready` for every
-other row. This handles the confirmed old-spoke amplification schedule: a new
-hub accepts a legacy row up to its 1 MiB compatibility ceiling, then quarantines
-that row rather than bricking its browser or downstream peer projection.
+other row. The browser publishes a persistent omitted-session count with safe
+ID/reason details; a later clean bootstrap clears it. Peers retain each bounded
+diagnostic for the transaction and log it. This handles the confirmed old-spoke
+amplification schedule: a new hub accepts a legacy row up to its 1 MiB
+compatibility ceiling, then quarantines that row rather than bricking its
+browser or downstream peer projection.
 
 Likely row-size causes are `command`, `cwd`, `remotes`, `title`, `subtitle`,
 `socket_path`, and `conversation_file`. Rows contain no scrollback/transcript.
@@ -47,9 +50,12 @@ queued as a later full replacement. The handler serializes all of N through
 `ready` before reading N+1.
 
 Epochs must increase strictly within one transport in both browser and peer
-receivers. Duplicate/older begin events are ignored without destroying a newer
-in-flight transaction; stale batch/ready cannot publish. Disconnect releases
-staging and resets epoch history, allowing the next transport to restart at 1.
+receivers. The first accepted session event also locks the transport to legacy
+or protocol 3, so a legacy injection cannot reset v3 replay protection and v3
+cannot take over a legacy-only connection. Duplicate/older begin events are
+ignored without destroying a newer in-flight transaction; stale batch/ready
+cannot publish. Disconnect releases staging and resets mode/epoch history,
+allowing the next transport to restart at 1.
 Browser tests prove release by sending batch+ready without a new begin after an
 error; the partial rows do not publish.
 
@@ -83,24 +89,14 @@ the accumulated event remain bounded.
 
 ## `snapshot.world` scope
 
-World remains a single semantic object, separate from session rows. It now has
-an explicit **512 KiB JSON sender maximum**, below the Go transport's 1 MiB
-ceiling. Oversize/encode failure emits a small `snapshot.world.error`; no
-unbounded world line is written. Browser updates retain the previous world; an
-initial error exposes safe empty defaults so session availability is preserved.
-
-The realistic transport-seam fixture includes 1,000 memberships across 50
-projects, path/remote match rules, 20 peers, health, launchers, peer projects,
-and peer discovery. It measures **26,177 bytes**, about 5% of the explicit
-maximum. The earlier synthetic ID-only fixture was rejected as insufficient.
-
-I did not semantically fragment world: at gmux's documented supported scale
-(single user, dozens of sessions/peers; ADR 0001 explicitly says the snapshot
-model is unsuitable for thousands), the composed stress fixture is 20× below
-the sender maximum. Arbitrarily large operator metadata is now rejected before
-the transport rather than producing an unbounded SSE line. Claims are narrowed:
-48 KiB applies to protocol-3 session events; world has its separate 512 KiB
-maximum; transitional protocol-2 sessions retain the 1 MiB client ceiling.
+World remains the pre-existing single event, separate from session rows. This PR
+adds no world cap/error behavior and makes no endpoint-wide boundedness claim:
+48 KiB applies only to protocol-3 session events. This preserves protocol-2 old
+tabs and deep-link hydration exactly. The realistic shape fixture (1,000
+memberships across 50 projects, match rules, 20 peers, health, launchers, peer
+projects, and discovery) remains only a size characterization (**26,177
+bytes**), not a supported maximum. World semantic framing is a separate future
+design if production evidence demonstrates it.
 
 ## Reproduction and measurements
 
@@ -131,14 +127,14 @@ diagnostic cap) and does not affect healthy fixtures.
   `internal/sessionstream/sessionstream_test.go`
 - standard multiline SSE parsing and line/aggregate limits:
   `internal/sseclient/client_test.go`
-- peer reconnect, diagnostics-through-ready, overflow recovery, monotonic epoch,
-  old-spoke-large-row amplification:
+- peer reconnect, retained diagnostics-through-ready, overflow recovery,
+  monotonic epoch, mixed-mode rollback, old-spoke-large-row amplification:
   `internal/peering/session_stream_test.go`
-- browser explicit negotiation, legacy fallback, real disconnect release,
-  monotonic epoch, degraded ready:
+- browser explicit negotiation, legacy-only fallback, protocol-mode lock, real
+  disconnect release, monotonic epoch, persistent degraded-ready warning:
   `apps/gmux-web/src/sse-reconnect.test.ts`
-- subscription boundary, compatibility matrix, realistic world transport bound,
-  oversized-world diagnostic:
+- subscription boundary, compatibility matrix, realistic world-size
+  characterization:
   `cmd/gmuxd/session_stream_boundary_test.go`
 - transaction-wide deadline/cancellation:
   `cmd/gmuxd/sse_transaction_test.go`
@@ -153,5 +149,5 @@ diagnostic cap) and does not affect healthy fixtures.
   remain inspectable/actionable through one-shot CLI/REST paths.
 - Transitional protocol-2 session frames are still single events for one
   release; the new client bounds them at 1 MiB.
-- World is bounded rejection rather than fragmentation. If supported deployment
-  scale grows near 512 KiB, it should gain its own semantic row transaction.
+- World framing and limits are deliberately unchanged and require a separate
+  design if real-world evidence demonstrates an oversized world path.

--- a/.memory/report-semantic-session-stream.md
+++ b/.memory/report-semantic-session-stream.md
@@ -1,141 +1,157 @@
-# Bounded semantic session stream
+# Bounded semantic session stream — amended after review
 
-## Summary
+## Protocol
 
-Protocol 3 replaces each unbounded `snapshot.sessions` SSE event with a
-transaction of complete semantic rows:
+A protocol-3 session replacement is one transaction:
 
 1. `snapshot.sessions.begin {version:3,epoch}`
-2. zero or more `snapshot.sessions.batch {epoch,sessions:[...]}`
-3. `snapshot.sessions.ready {epoch}`
+2. zero or more `snapshot.sessions.batch {epoch,sessions:[...]}` events
+3. zero or more non-fatal `snapshot.sessions.error` row diagnostics
+4. `snapshot.sessions.ready {epoch}`
 
-Receivers stage batches privately and replace the visible projection only at
-`ready`. This applies to initial hydration and the existing coalesced full-list
-replacements after mutations. It deliberately does not select an archive or a
-bounded live set; a future implementation can change which rows are enumerated
-without changing framing.
+Batches contain complete semantic rows and have a 48 KiB JSON payload maximum.
+Receivers stage privately and replace the visible set only at the matching
+`ready`. Initial hydration and later coalesced full replacements use the same
+framing. This does not implement archive/live-set selection.
 
-## Bounds and failure behavior
+## Availability and bounds
 
-- Maximum JSON payload per session-stream event: **48 KiB (49,152 bytes)**.
-  This leaves 16 KiB below the default 64 KiB Scanner token for SSE syntax,
-  envelope growth, and intermediary metadata.
-- Rows are JSON-encoded independently and never byte-split.
-- One row which cannot fit causes encoding to fail before `begin` is sent. The
-  server emits a bounded `snapshot.sessions.error`, logs the row ID, and closes
-  that response. The receiver discards staging and retains the previous ready
-  set. Likely unbounded fields are `command`, `cwd`, `remotes`, `title`,
-  `subtitle`, `socket_path`, and `conversation_file`. Session rows contain no
-  scrollback or transcript content.
-- Receiver staging is capped at 100,000 rows and 64 MiB.
-- The Go SSE Scanner line ceiling is bounded at 1 MiB, up from 256 KiB. This
-  admits the measured 1,000-row protocol-2 frame during mixed-version operation.
-  Protocol 3 does not rely on that increase. Lines above it return a protocol
-  error before unbounded growth.
+A row larger than 48 KiB no longer aborts or closes the stream. The sender omits
+only that row, emits a bounded diagnostic with a fixed reason and safe identity
+(IDs over 128 bytes become `sha256:<digest>`), and completes `ready` for every
+other row. This handles the confirmed old-spoke amplification schedule: a new
+hub accepts a legacy row up to its 1 MiB compatibility ceiling, then quarantines
+that row rather than bricking its browser or downstream peer projection.
 
-## Consistency boundary
+Likely row-size causes are `command`, `cwd`, `remotes`, `title`, `subtitle`,
+`socket_path`, and `conversation_file`. Rows contain no scrollback/transcript.
+They are never truncated or arbitrary-byte-split.
 
-`sseFanout.Subscribe` takes the same mutex as `BroadcastFrames`, installs the
-subscriber, and copies the current full projection before releasing it. A
-mutation therefore falls on exactly one side of the boundary:
+Sender and receiver use symmetric transaction limits:
 
-- before capture: reflected by baseline epoch N; or
-- after capture: queued as a later full replacement epoch N+1.
+- 100,000 staged rows
+- 64 MiB receiver encoded staging
+- sender accepts at most 63 MiB of row JSON, reserving 1 MiB for batch envelopes
+- at most 256 individual diagnostics, followed by one bounded summary
+- Go SSE line/event accumulation ceiling: 1 MiB for transitional protocol 2
 
-The HTTP handler serially writes all events for one epoch, including `ready`,
-before reading the next fanout message. A concurrent mutation cannot overtake
-baseline readiness. The bounded fanout may drop intermediate full replacements
-for a slow subscriber, but retains a later authoritative replacement, matching
-ADR 0001's existing latest-only semantics. Activity remains intentionally
-lossy.
+A malformed/overflow transaction is abandoned without changing visible state.
+A strictly newer begin starts cleanly, so rejection does not create permanent
+staleness. Correct senders remain inside receiver bounds.
 
-Staging belongs to one transport connection in the Go peer. Browser staging is
-cleared on EventSource error and reset by every begin marker. Disconnect before
-ready therefore cannot expose or carry partial rows into reconnect.
+## Epoch and consistency schedules
+
+`fanout.Subscribe` installs the subscriber and captures its baseline under the
+same mutex as publication. A mutation is either included in baseline epoch N or
+queued as a later full replacement. The handler serializes all of N through
+`ready` before reading N+1.
+
+Epochs must increase strictly within one transport in both browser and peer
+receivers. Duplicate/older begin events are ignored without destroying a newer
+in-flight transaction; stale batch/ready cannot publish. Disconnect releases
+staging and resets epoch history, allowing the next transport to restart at 1.
+Browser tests prove release by sending batch+ready without a new begin after an
+error; the partial rows do not publish.
+
+The complete session transaction has one 10-second write deadline. Cancellation
+is checked between fragment writes. The deadline is cleared after completion,
+so timeout no longer multiplies by event count.
 
 ## Compatibility
 
-Browser assets are daemon-served/version-locked and always receive protocol 3.
-New peer clients request `?as=peer&session_stream=3`.
+Protocol 3 is explicit for all consumers:
 
-- New hub -> old spoke: the old daemon ignores the query parameter and sends
-  legacy `snapshot.sessions`; the new hub still handles it authoritatively.
-- Old hub -> new spoke: absence of `session_stream=3` selects the legacy event.
-- New hub -> new spoke: bounded begin/batch/ready events.
-- Unknown requested versions select legacy fallback rather than guessing.
+- current browser: `/v1/events?session_stream=3`
+- current peer: `/v1/events?as=peer&session_stream=3`
+- unversioned browser tab/custom consumer: transitional protocol-2
+  `snapshot.sessions`
+- old peer omitting the marker: protocol 2
+- new hub to old spoke: old spoke ignores the marker; new hub accepts protocol 2
+- unknown requested version: legacy fallback rather than guessing
 
-Thus mixed peers do not silently ignore/misparse new event names. The legacy
-fallback remains intrinsically unbounded and can still exceed an old peer's
-Scanner limit for very large sets; retaining wire compatibility and fixing an
-old binary's parser cannot both be guaranteed by the new spoke.
+The new browser also retains a legacy listener defensively. An old tab opened
+across a daemon upgrade requests no marker and therefore continues receiving the
+event it understands rather than silently freezing.
 
-## Oversized-path inspection
+## SSE parser
 
-`snapshot.sessions` and `snapshot.world` are distinct frames. The actual large
-row projection is `snapshot.sessions`; peer subscriptions suppress world
-entirely. `snapshot.world` carries project membership IDs but no session rows.
-With 1,000 eight-character IDs in one project its encoded payload measured
-**11,110 bytes**, below the session event budget. World framing was therefore
-left unchanged.
+The Go SSE client now follows event boundaries: all `data:` fields are
+accumulated, joined with `\n`, and dispatched once at the blank line. Field order
+is unconstrained, no-event blocks use type `message`, comments do not terminate
+an event, and empty/no-data blocks do not dispatch. Both individual lines and
+the accumulated event remain bounded.
+
+## `snapshot.world` scope
+
+World remains a single semantic object, separate from session rows. It now has
+an explicit **512 KiB JSON sender maximum**, below the Go transport's 1 MiB
+ceiling. Oversize/encode failure emits a small `snapshot.world.error`; no
+unbounded world line is written. Browser updates retain the previous world; an
+initial error exposes safe empty defaults so session availability is preserved.
+
+The realistic transport-seam fixture includes 1,000 memberships across 50
+projects, path/remote match rules, 20 peers, health, launchers, peer projects,
+and peer discovery. It measures **26,177 bytes**, about 5% of the explicit
+maximum. The earlier synthetic ID-only fixture was rejected as insufficient.
+
+I did not semantically fragment world: at gmux's documented supported scale
+(single user, dozens of sessions/peers; ADR 0001 explicitly says the snapshot
+model is unsuitable for thousands), the composed stress fixture is 20× below
+the sender maximum. Arbitrarily large operator metadata is now rejected before
+the transport rather than producing an unbounded SSE line. Claims are narrowed:
+48 KiB applies to protocol-3 session events; world has its separate 512 KiB
+maximum; transitional protocol-2 sessions retain the 1 MiB client ceiling.
 
 ## Reproduction and measurements
 
-Before code changes, a realistic 1,000-row projection (commands, cwd/workspace,
-remotes, title/subtitle, socket path, conversation reference, runner/project
-metadata; no transcripts) produced:
+Pre-change realistic fixture:
 
 ```
 legacy payload=860535 frame=860568 max_line=860541 events=1
 lines=1 err=bufio.Scanner: token too long
 ```
 
-The checked-in deterministic Go fixture (slightly narrower but still realistic)
-measures old versus protocol 3:
+Checked-in 1,000-row fixture:
 
-| metric | old full event | protocol 3 |
+| metric | old | protocol 3 |
 |---|---:|---:|
-| rows | 1,000 | 1,000 |
-| maximum JSON event payload | 687,678 B | 48,889 B |
-| total SSE bytes | 687,711 B | 688,721 B |
-| event count | 1 | 17 |
-| serialization latency (median of 5 benchmark runs) | ~1.47 ms | ~2.71 ms |
+| max session JSON event | 687,678 B | 48,889 B |
+| total session SSE bytes | 687,711 B | 688,721 B |
+| session event count | 1 | 17 |
+| median serialization, 3 runs | ~1.30 ms | ~1.77 ms |
 
-Total wire overhead is 1,010 bytes (~0.15%). Serialization adds ~1.24 ms on the
-fixture. On a local/in-memory initial synchronization this is the measured
-latency delta; real links are dominated by transferring the same ~689 KiB, while
-the receiver intentionally exposes the set at the final ready marker rather
-than incrementally. Benchmark command:
-
-```
-go test -run '^$' -bench BenchmarkInitialSync1000 -benchmem -count=5 ./internal/sessionstream
-```
+Wire overhead is 1,010 bytes (~0.15%). The measured local serialization delta is
+~0.47 ms. Quarantine adds one bounded diagnostic per bad row (subject to the
+diagnostic cap) and does not affect healthy fixtures.
 
 ## Evidence map
 
-- Legacy >64 KiB reproduction, empty/one/many rows, event bounds,
-  oversized-single-row failure, byte/event measurements:
+- bounds, empty/one/many, legacy Scanner reproduction, quarantine, safe IDs,
+  sender/receiver limit symmetry, measurements:
   `internal/sessionstream/sessionstream_test.go`
-- Scanner compatibility acceptance and hard ceiling:
+- standard multiline SSE parsing and line/aggregate limits:
   `internal/sseclient/client_test.go`
-- Browser disconnect/reconnect and mutation staging:
-  `apps/gmux-web/src/sse-reconnect.test.ts`
-- Peer disconnect, reconnect, atomic readiness, mutation epoch, legacy spoke:
+- peer reconnect, diagnostics-through-ready, overflow recovery, monotonic epoch,
+  old-spoke-large-row amplification:
   `internal/peering/session_stream_test.go`
-- Subscribe/publication boundary, browser/peer version selection, world size:
+- browser explicit negotiation, legacy fallback, real disconnect release,
+  monotonic epoch, degraded ready:
+  `apps/gmux-web/src/sse-reconnect.test.ts`
+- subscription boundary, compatibility matrix, realistic world transport bound,
+  oversized-world diagnostic:
   `cmd/gmuxd/session_stream_boundary_test.go`
-- Real server event order and matched world:
-  `cmd/gmuxd/serve_switch_integration_test.go`
+- transaction-wide deadline/cancellation:
+  `cmd/gmuxd/sse_transaction_test.go`
+- production initial event contract:
+  `cmd/gmuxd/production_container_e2e_test.go`
 
 ## Open tradeoffs
 
-- Full session sets are still re-enumerated after mutations. This PR bounds
-  transport frames and atomic application; it does not implement deltas,
-  archive/live-set selection, resumable epochs, or server-side replay.
-- A single semantic row over 48 KiB is rejected rather than split. A future
-  protocol could model specific large fields semantically, but arbitrary-byte
-  checkpointing is intentionally avoided.
-- `snapshot.world` remains one event. The measured many-session path is small;
-  independently unbounded project/peer metadata may warrant its own semantic
-  framing if real deployments approach the Scanner ceiling.
-- Browser EventSource provides no custom negotiation headers; this is safe only
-  because the browser bundle and daemon are served/versioned together.
+- Every mutation still re-enumerates the full selected set; no delta/replay or
+  archive/live-set policy is introduced.
+- Quarantined rows are absent from the SSE projection until they shrink. They
+  remain inspectable/actionable through one-shot CLI/REST paths.
+- Transitional protocol-2 session frames are still single events for one
+  release; the new client bounds them at 1 MiB.
+- World is bounded rejection rather than fragmentation. If supported deployment
+  scale grows near 512 KiB, it should gain its own semantic row transaction.

--- a/.memory/report-semantic-session-stream.md
+++ b/.memory/report-semantic-session-stream.md
@@ -1,0 +1,141 @@
+# Bounded semantic session stream
+
+## Summary
+
+Protocol 3 replaces each unbounded `snapshot.sessions` SSE event with a
+transaction of complete semantic rows:
+
+1. `snapshot.sessions.begin {version:3,epoch}`
+2. zero or more `snapshot.sessions.batch {epoch,sessions:[...]}`
+3. `snapshot.sessions.ready {epoch}`
+
+Receivers stage batches privately and replace the visible projection only at
+`ready`. This applies to initial hydration and the existing coalesced full-list
+replacements after mutations. It deliberately does not select an archive or a
+bounded live set; a future implementation can change which rows are enumerated
+without changing framing.
+
+## Bounds and failure behavior
+
+- Maximum JSON payload per session-stream event: **48 KiB (49,152 bytes)**.
+  This leaves 16 KiB below the default 64 KiB Scanner token for SSE syntax,
+  envelope growth, and intermediary metadata.
+- Rows are JSON-encoded independently and never byte-split.
+- One row which cannot fit causes encoding to fail before `begin` is sent. The
+  server emits a bounded `snapshot.sessions.error`, logs the row ID, and closes
+  that response. The receiver discards staging and retains the previous ready
+  set. Likely unbounded fields are `command`, `cwd`, `remotes`, `title`,
+  `subtitle`, `socket_path`, and `conversation_file`. Session rows contain no
+  scrollback or transcript content.
+- Receiver staging is capped at 100,000 rows and 64 MiB.
+- The Go SSE Scanner line ceiling is bounded at 1 MiB, up from 256 KiB. This
+  admits the measured 1,000-row protocol-2 frame during mixed-version operation.
+  Protocol 3 does not rely on that increase. Lines above it return a protocol
+  error before unbounded growth.
+
+## Consistency boundary
+
+`sseFanout.Subscribe` takes the same mutex as `BroadcastFrames`, installs the
+subscriber, and copies the current full projection before releasing it. A
+mutation therefore falls on exactly one side of the boundary:
+
+- before capture: reflected by baseline epoch N; or
+- after capture: queued as a later full replacement epoch N+1.
+
+The HTTP handler serially writes all events for one epoch, including `ready`,
+before reading the next fanout message. A concurrent mutation cannot overtake
+baseline readiness. The bounded fanout may drop intermediate full replacements
+for a slow subscriber, but retains a later authoritative replacement, matching
+ADR 0001's existing latest-only semantics. Activity remains intentionally
+lossy.
+
+Staging belongs to one transport connection in the Go peer. Browser staging is
+cleared on EventSource error and reset by every begin marker. Disconnect before
+ready therefore cannot expose or carry partial rows into reconnect.
+
+## Compatibility
+
+Browser assets are daemon-served/version-locked and always receive protocol 3.
+New peer clients request `?as=peer&session_stream=3`.
+
+- New hub -> old spoke: the old daemon ignores the query parameter and sends
+  legacy `snapshot.sessions`; the new hub still handles it authoritatively.
+- Old hub -> new spoke: absence of `session_stream=3` selects the legacy event.
+- New hub -> new spoke: bounded begin/batch/ready events.
+- Unknown requested versions select legacy fallback rather than guessing.
+
+Thus mixed peers do not silently ignore/misparse new event names. The legacy
+fallback remains intrinsically unbounded and can still exceed an old peer's
+Scanner limit for very large sets; retaining wire compatibility and fixing an
+old binary's parser cannot both be guaranteed by the new spoke.
+
+## Oversized-path inspection
+
+`snapshot.sessions` and `snapshot.world` are distinct frames. The actual large
+row projection is `snapshot.sessions`; peer subscriptions suppress world
+entirely. `snapshot.world` carries project membership IDs but no session rows.
+With 1,000 eight-character IDs in one project its encoded payload measured
+**11,110 bytes**, below the session event budget. World framing was therefore
+left unchanged.
+
+## Reproduction and measurements
+
+Before code changes, a realistic 1,000-row projection (commands, cwd/workspace,
+remotes, title/subtitle, socket path, conversation reference, runner/project
+metadata; no transcripts) produced:
+
+```
+legacy payload=860535 frame=860568 max_line=860541 events=1
+lines=1 err=bufio.Scanner: token too long
+```
+
+The checked-in deterministic Go fixture (slightly narrower but still realistic)
+measures old versus protocol 3:
+
+| metric | old full event | protocol 3 |
+|---|---:|---:|
+| rows | 1,000 | 1,000 |
+| maximum JSON event payload | 687,678 B | 48,889 B |
+| total SSE bytes | 687,711 B | 688,721 B |
+| event count | 1 | 17 |
+| serialization latency (median of 5 benchmark runs) | ~1.47 ms | ~2.71 ms |
+
+Total wire overhead is 1,010 bytes (~0.15%). Serialization adds ~1.24 ms on the
+fixture. On a local/in-memory initial synchronization this is the measured
+latency delta; real links are dominated by transferring the same ~689 KiB, while
+the receiver intentionally exposes the set at the final ready marker rather
+than incrementally. Benchmark command:
+
+```
+go test -run '^$' -bench BenchmarkInitialSync1000 -benchmem -count=5 ./internal/sessionstream
+```
+
+## Evidence map
+
+- Legacy >64 KiB reproduction, empty/one/many rows, event bounds,
+  oversized-single-row failure, byte/event measurements:
+  `internal/sessionstream/sessionstream_test.go`
+- Scanner compatibility acceptance and hard ceiling:
+  `internal/sseclient/client_test.go`
+- Browser disconnect/reconnect and mutation staging:
+  `apps/gmux-web/src/sse-reconnect.test.ts`
+- Peer disconnect, reconnect, atomic readiness, mutation epoch, legacy spoke:
+  `internal/peering/session_stream_test.go`
+- Subscribe/publication boundary, browser/peer version selection, world size:
+  `cmd/gmuxd/session_stream_boundary_test.go`
+- Real server event order and matched world:
+  `cmd/gmuxd/serve_switch_integration_test.go`
+
+## Open tradeoffs
+
+- Full session sets are still re-enumerated after mutations. This PR bounds
+  transport frames and atomic application; it does not implement deltas,
+  archive/live-set selection, resumable epochs, or server-side replay.
+- A single semantic row over 48 KiB is rejected rather than split. A future
+  protocol could model specific large fields semantically, but arbitrary-byte
+  checkpointing is intentionally avoided.
+- `snapshot.world` remains one event. The measured many-session path is small;
+  independently unbounded project/peer metadata may warrant its own semantic
+  framing if real deployments approach the Scanner ceiling.
+- Browser EventSource provides no custom negotiation headers; this is safe only
+  because the browser bundle and daemon are served/versioned together.

--- a/apps/gmux-web/src/sidebar.tsx
+++ b/apps/gmux-web/src/sidebar.tsx
@@ -21,7 +21,7 @@ import {
   unreadCount, localHostLabel, unresolvedHosts, duplicateConversationFiles,
   sidebarActivity, sidebarMode, setSidebarMode,
   activeSelectors, removeSelector, setHostFilter,
-  aliveOnly, setAliveOnly, tabHref, sessionStreamWarnings,
+  aliveOnly, setAliveOnly, tabHref, sessionStreamWarnings, sessionStreamOmittedTotal,
   type DotState,
 } from './store'
 import { HostSuffix } from './host-suffix'
@@ -643,7 +643,9 @@ export function Sidebar({
   const totalVisible = foldersVal.reduce((n, f) => n + f.sessions.length, 0)
   const connected = connState.value === 'connected'
   const streamWarnings = sessionStreamWarnings.value
-  const omittedSessionCount = streamWarnings.reduce((sum, warning) => sum + warning.count, 0)
+  const omittedSessionCount = sessionStreamOmittedTotal.value
+  const detailedOmittedCount = streamWarnings.reduce((sum, warning) => sum + warning.count, 0)
+  const suppressedOmittedCount = Math.max(0, omittedSessionCount - detailedOmittedCount)
   const hasProjects = projectsVal.length > 0
   const isOnlyHomeProject = projectsVal.length === 1
     && projectsVal[0].slug === 'home'
@@ -682,11 +684,14 @@ export function Sidebar({
             * background can act as a fixed backdrop behind it (see the
             * cavity in styles.css). Purely presentational. */}
           <div class="sidebar-list">
-          {streamWarnings.length > 0 && (
+          {omittedSessionCount > 0 && (
             <div
               class="sidebar-stream-warning"
               role="status"
-              title={streamWarnings.map(w => `${w.id || 'unknown'}: ${w.message || w.code}`).join('\n')}
+              title={[
+                ...streamWarnings.map(w => `${w.id}: ${w.message || w.code}`),
+                ...(suppressedOmittedCount > 0 ? [`${suppressedOmittedCount} additional omitted sessions`] : []),
+              ].join('\n')}
             >
               ⚠ {omittedSessionCount} {omittedSessionCount === 1 ? 'session is' : 'sessions are'} omitted from the live list
             </div>

--- a/apps/gmux-web/src/sidebar.tsx
+++ b/apps/gmux-web/src/sidebar.tsx
@@ -21,7 +21,7 @@ import {
   unreadCount, localHostLabel, unresolvedHosts, duplicateConversationFiles,
   sidebarActivity, sidebarMode, setSidebarMode,
   activeSelectors, removeSelector, setHostFilter,
-  aliveOnly, setAliveOnly, tabHref,
+  aliveOnly, setAliveOnly, tabHref, sessionStreamWarnings,
   type DotState,
 } from './store'
 import { HostSuffix } from './host-suffix'
@@ -642,6 +642,8 @@ export function Sidebar({
   // sidebarSessions), so this is just the visible session count.
   const totalVisible = foldersVal.reduce((n, f) => n + f.sessions.length, 0)
   const connected = connState.value === 'connected'
+  const streamWarnings = sessionStreamWarnings.value
+  const omittedSessionCount = streamWarnings.reduce((sum, warning) => sum + warning.count, 0)
   const hasProjects = projectsVal.length > 0
   const isOnlyHomeProject = projectsVal.length === 1
     && projectsVal[0].slug === 'home'
@@ -680,6 +682,15 @@ export function Sidebar({
             * background can act as a fixed backdrop behind it (see the
             * cavity in styles.css). Purely presentational. */}
           <div class="sidebar-list">
+          {streamWarnings.length > 0 && (
+            <div
+              class="sidebar-stream-warning"
+              role="status"
+              title={streamWarnings.map(w => `${w.id || 'unknown'}: ${w.message || w.code}`).join('\n')}
+            >
+              ⚠ {omittedSessionCount} {omittedSessionCount === 1 ? 'session is' : 'sessions are'} omitted from the live list
+            </div>
+          )}
           {mode === 'projects' && selectors.length > 0
             && foldersVal.every(f => f.sessions.length === 0
               && !folderMatchesFilter(f, selectors, health.value?.hostname)) && (

--- a/apps/gmux-web/src/sse-reconnect.test.ts
+++ b/apps/gmux-web/src/sse-reconnect.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { _rawSessions, connState, initStore } from './store'
+import { _rawSessions, connState, initStore, sessionStreamWarnings } from './store'
 
 // A minimal EventSource stand-in that lets the test drive the listeners
 // initStore registers (the `error` handler and the snapshot handlers).
@@ -60,13 +60,27 @@ describe('SSE reconnecting state', () => {
     expect(source().url).toBe('/v1/events?session_stream=3')
   })
 
-  it('accepts the transitional legacy replacement if protocol negotiation is stripped', () => {
+  it('accepts the transitional legacy replacement on a legacy-only transport', () => {
     cleanup = initStore()
     source().emit('snapshot.sessions', { sessions: [
       { id: 'legacy', adapter: 'shell', alive: true, status: null, unread: false, unread_token: '' },
     ] })
     expect(_rawSessions.value.map(s => s.id)).toEqual(['legacy'])
     expect(connState.value).toBe('connected')
+    // Once legacy is selected, protocol 3 cannot take over this transport.
+    ready(1, [{ id: 'replayed', adapter: 'shell', alive: true, status: null, unread: false, unread_token: '' }])
+    expect(_rawSessions.value.map(s => s.id)).toEqual(['legacy'])
+  })
+
+  it('locks a negotiated transport to protocol 3 across legacy injection and stale replay', () => {
+    cleanup = initStore()
+    ready(1, [{ id: 'old', adapter: 'shell', alive: true, status: null, unread: false, unread_token: '' }])
+    ready(2, [{ id: 'new', adapter: 'shell', alive: true, status: null, unread: false, unread_token: '' }])
+    source().emit('snapshot.sessions', { sessions: [
+      { id: 'legacy-current', adapter: 'shell', alive: true, status: null, unread: false, unread_token: '' },
+    ] })
+    ready(1, [{ id: 'replayed-old', adapter: 'shell', alive: true, status: null, unread: false, unread_token: '' }])
+    expect(_rawSessions.value.map(s => s.id)).toEqual(['new'])
   })
 
   it('goes to error when the initial connect drops before any snapshot', () => {
@@ -141,6 +155,11 @@ describe('SSE reconnecting state', () => {
     source().emit('snapshot.sessions.ready', { epoch: 1 })
     expect(_rawSessions.value.map(s => s.id)).toEqual(['good'])
     expect(connState.value).toBe('connected')
+    expect(sessionStreamWarnings.value).toEqual([
+      { code: 'row_too_large', id: 'bad', message: 'omitted', count: 1 },
+    ])
+    ready(2, [{ id: 'good', adapter: 'shell', alive: true, status: null, unread: false, unread_token: '' }])
+    expect(sessionStreamWarnings.value).toEqual([])
   })
 
   it('publishes a mutation captured during bootstrap only at its later ready', () => {

--- a/apps/gmux-web/src/sse-reconnect.test.ts
+++ b/apps/gmux-web/src/sse-reconnect.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { connState, initStore } from './store'
+import { _rawSessions, connState, initStore } from './store'
 
 // A minimal EventSource stand-in that lets the test drive the listeners
 // initStore registers (the `error` handler and the snapshot handlers).
@@ -49,6 +49,12 @@ describe('SSE reconnecting state', () => {
     return FakeEventSource.instances[0]
   }
 
+  function ready(epoch = 1, sessions: unknown[] = []) {
+    source().emit('snapshot.sessions.begin', { version: 3, epoch })
+    if (sessions.length > 0) source().emit('snapshot.sessions.batch', { epoch, sessions })
+    source().emit('snapshot.sessions.ready', { epoch })
+  }
+
   it('goes to error when the initial connect drops before any snapshot', () => {
     cleanup = initStore()
     expect(connState.value).toBe('connecting')
@@ -58,8 +64,8 @@ describe('SSE reconnecting state', () => {
 
   it('goes to reconnecting (not error) when an established stream drops', () => {
     cleanup = initStore()
-    // First snapshot establishes the connection.
-    source().emit('snapshot.sessions', { sessions: [] })
+    // First ready marker establishes the connection.
+    ready()
     expect(connState.value).toBe('connected')
     // The established stream drops: transient, not a hard failure.
     source().emit('error')
@@ -68,10 +74,44 @@ describe('SSE reconnecting state', () => {
 
   it('clears back to connected once the next snapshot arrives', () => {
     cleanup = initStore()
-    source().emit('snapshot.sessions', { sessions: [] })
+    ready()
     source().emit('error')
     expect(connState.value).toBe('reconnecting')
-    source().emit('snapshot.sessions', { sessions: [] })
+    ready(2)
     expect(connState.value).toBe('connected')
+  })
+
+  it('discards an interrupted bootstrap without exposing partial rows', () => {
+    cleanup = initStore()
+    ready(1, [{ id: 'old', adapter: 'shell', alive: true, status: null, unread: false, unread_token: '' }])
+    source().emit('snapshot.sessions.begin', { version: 3, epoch: 2 })
+    source().emit('snapshot.sessions.batch', { epoch: 2, sessions: [
+      { id: 'partial', adapter: 'shell', alive: true, status: null, unread: false, unread_token: '' },
+    ] })
+    expect(_rawSessions.value.map(s => s.id)).toEqual(['old'])
+    source().emit('error')
+    expect(_rawSessions.value.map(s => s.id)).toEqual(['old'])
+    ready(3, [{ id: 'fresh', adapter: 'shell', alive: true, status: null, unread: false, unread_token: '' }])
+    expect(_rawSessions.value.map(s => s.id)).toEqual(['fresh'])
+  })
+
+  it('publishes a mutation captured during bootstrap only at its later ready', () => {
+    cleanup = initStore()
+    source().emit('snapshot.sessions.begin', { version: 3, epoch: 1 })
+    source().emit('snapshot.sessions.batch', { epoch: 1, sessions: [
+      { id: 's', title: 'before', adapter: 'shell', alive: true, status: null, unread: false, unread_token: '' },
+    ] })
+    // The fanout captures this replacement after subscribe; it is serialized
+    // after epoch 1 and cannot overtake epoch 1's ready marker.
+    source().emit('snapshot.sessions.ready', { epoch: 1 })
+    expect(_rawSessions.value.map(s => s.title)).toEqual(['before'])
+    source().emit('snapshot.sessions.begin', { version: 3, epoch: 2 })
+    source().emit('snapshot.sessions.batch', { epoch: 2, sessions: [
+      { id: 's', title: 'after', adapter: 'shell', alive: true, status: null, unread: false, unread_token: '' },
+    ] })
+    expect(_rawSessions.value.map(s => s.title)).toEqual(['before'])
+    source().emit('snapshot.sessions.ready', { epoch: 2 })
+    expect(_rawSessions.value).toHaveLength(1)
+    expect(_rawSessions.value[0].title).toBe('after')
   })
 })

--- a/apps/gmux-web/src/sse-reconnect.test.ts
+++ b/apps/gmux-web/src/sse-reconnect.test.ts
@@ -55,6 +55,20 @@ describe('SSE reconnecting state', () => {
     source().emit('snapshot.sessions.ready', { epoch })
   }
 
+  it('explicitly requests protocol 3', () => {
+    cleanup = initStore()
+    expect(source().url).toBe('/v1/events?session_stream=3')
+  })
+
+  it('accepts the transitional legacy replacement if protocol negotiation is stripped', () => {
+    cleanup = initStore()
+    source().emit('snapshot.sessions', { sessions: [
+      { id: 'legacy', adapter: 'shell', alive: true, status: null, unread: false, unread_token: '' },
+    ] })
+    expect(_rawSessions.value.map(s => s.id)).toEqual(['legacy'])
+    expect(connState.value).toBe('connected')
+  })
+
   it('goes to error when the initial connect drops before any snapshot', () => {
     cleanup = initStore()
     expect(connState.value).toBe('connecting')
@@ -91,8 +105,42 @@ describe('SSE reconnecting state', () => {
     expect(_rawSessions.value.map(s => s.id)).toEqual(['old'])
     source().emit('error')
     expect(_rawSessions.value.map(s => s.id)).toEqual(['old'])
-    ready(3, [{ id: 'fresh', adapter: 'shell', alive: true, status: null, unread: false, unread_token: '' }])
+    // No replacement begin: if the error handler retained staging, these two
+    // events would publish "partial". They must be inert and release it.
+    source().emit('snapshot.sessions.batch', { epoch: 2, sessions: [] })
+    source().emit('snapshot.sessions.ready', { epoch: 2 })
+    expect(_rawSessions.value.map(s => s.id)).toEqual(['old'])
+    // Epochs restart on the new transport.
+    ready(1, [{ id: 'fresh', adapter: 'shell', alive: true, status: null, unread: false, unread_token: '' }])
     expect(_rawSessions.value.map(s => s.id)).toEqual(['fresh'])
+  })
+
+  it('ignores duplicate and stale epochs without rolling back or destroying newer staging', () => {
+    cleanup = initStore()
+    ready(1, [{ id: 'old', adapter: 'shell', alive: true, status: null, unread: false, unread_token: '' }])
+    ready(2, [{ id: 'new', adapter: 'shell', alive: true, status: null, unread: false, unread_token: '' }])
+    ready(1, [{ id: 'replayed', adapter: 'shell', alive: true, status: null, unread: false, unread_token: '' }])
+    expect(_rawSessions.value.map(s => s.id)).toEqual(['new'])
+
+    source().emit('snapshot.sessions.begin', { version: 3, epoch: 3 })
+    source().emit('snapshot.sessions.begin', { version: 3, epoch: 2 })
+    source().emit('snapshot.sessions.batch', { epoch: 3, sessions: [
+      { id: 'newest', adapter: 'shell', alive: true, status: null, unread: false, unread_token: '' },
+    ] })
+    source().emit('snapshot.sessions.ready', { epoch: 3 })
+    expect(_rawSessions.value.map(s => s.id)).toEqual(['newest'])
+  })
+
+  it('keeps a degraded epoch valid after a quarantined-row diagnostic', () => {
+    cleanup = initStore()
+    source().emit('snapshot.sessions.begin', { version: 3, epoch: 1 })
+    source().emit('snapshot.sessions.batch', { epoch: 1, sessions: [
+      { id: 'good', adapter: 'shell', alive: true, status: null, unread: false, unread_token: '' },
+    ] })
+    source().emit('snapshot.sessions.error', { epoch: 1, code: 'row_too_large', id: 'bad', message: 'omitted' })
+    source().emit('snapshot.sessions.ready', { epoch: 1 })
+    expect(_rawSessions.value.map(s => s.id)).toEqual(['good'])
+    expect(connState.value).toBe('connected')
   })
 
   it('publishes a mutation captured during bootstrap only at its later ready', () => {

--- a/apps/gmux-web/src/sse-reconnect.test.ts
+++ b/apps/gmux-web/src/sse-reconnect.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { _rawSessions, connState, initStore, sessionStreamWarnings } from './store'
+import {
+  _rawSessions, appendSessionStreamWarning, connState, initStore,
+  sessionStreamOmittedTotal, sessionStreamWarnings,
+} from './store'
 
 // A minimal EventSource stand-in that lets the test drive the listeners
 // initStore registers (the `error` handler and the snapshot handlers).
@@ -158,8 +161,28 @@ describe('SSE reconnecting state', () => {
     expect(sessionStreamWarnings.value).toEqual([
       { code: 'row_too_large', id: 'bad', message: 'omitted', count: 1 },
     ])
+    expect(sessionStreamOmittedTotal.value).toBe(1)
     ready(2, [{ id: 'good', adapter: 'shell', alive: true, status: null, unread: false, unread_token: '' }])
     expect(sessionStreamWarnings.value).toEqual([])
+    expect(sessionStreamOmittedTotal.value).toBe(0)
+  })
+
+  it('keeps the exact omitted total above the bounded detail cap', () => {
+    cleanup = initStore()
+    source().emit('snapshot.sessions.begin', { version: 3, epoch: 1 })
+    for (let i = 0; i < 256; i++) {
+      appendSessionStreamWarning(1, {
+        id: `safe-${i}`, code: 'row_too_large', message: 'omitted', count: 1,
+      })
+    }
+    // The sender emits this no-ID summary after its 256 detailed diagnostics.
+    // It must update the total even though it cannot consume a detail slot.
+    appendSessionStreamWarning(1, {
+      id: '', code: 'diagnostics_suppressed', message: '44 additional rows omitted', count: 44,
+    })
+    source().emit('snapshot.sessions.ready', { epoch: 1 })
+    expect(sessionStreamOmittedTotal.value).toBe(300)
+    expect(sessionStreamWarnings.value).toHaveLength(256)
   })
 
   it('publishes a mutation captured during bootstrap only at its later ready', () => {

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -246,6 +246,7 @@ effect(() => {
 // Local-only UI state (never sourced from the wire).
 export type SessionStreamWarning = { id: string, code: string, message: string, count: number }
 export const sessionStreamWarnings = signal<SessionStreamWarning[]>([])
+export const sessionStreamOmittedTotal = signal(0)
 export const sessionsLoaded = signal(false)
 /**
  * Whether the leading-edge `snapshot.world` (projects, peers, health)
@@ -1217,6 +1218,7 @@ type SessionsBootstrap = {
   rows: ProtocolSession[]
   bytes: number
   warnings: SessionStreamWarning[]
+  omittedTotal: number
 }
 
 type SessionStreamMode = 'unknown' | 'legacy' | 'v3'
@@ -1237,7 +1239,7 @@ export function beginSessionsBootstrap(version: number, epoch: number): void {
   if (epoch <= lastSessionEpoch) return
   sessionStreamMode = 'v3'
   lastSessionEpoch = epoch
-  sessionsBootstrap = { epoch, rows: [], bytes: 0, warnings: [] }
+  sessionsBootstrap = { epoch, rows: [], bytes: 0, warnings: [], omittedTotal: 0 }
 }
 
 export function appendSessionsBootstrap(epoch: number, rows: ProtocolSession[], encodedBytes = 0): void {
@@ -1253,15 +1255,22 @@ export function appendSessionsBootstrap(epoch: number, rows: ProtocolSession[], 
 
 export function appendSessionStreamWarning(epoch: number, warning: SessionStreamWarning): void {
   if (sessionStreamMode !== 'v3' || !sessionsBootstrap || sessionsBootstrap.epoch !== epoch) return
-  if (sessionsBootstrap.warnings.length < 256) sessionsBootstrap.warnings.push(warning)
+  const count = Number.isSafeInteger(warning.count) && warning.count > 0 ? warning.count : 1
+  sessionsBootstrap.omittedTotal = Math.min(Number.MAX_SAFE_INTEGER, sessionsBootstrap.omittedTotal + count)
+  // Keep safe per-row detail bounded. The sender's final counted summary has
+  // no ID and updates omittedTotal even after this list reaches its cap.
+  if (warning.id && sessionsBootstrap.warnings.length < 256) {
+    sessionsBootstrap.warnings.push({ ...warning, count })
+  }
 }
 
 export function readySessionsBootstrap(epoch: number): boolean {
   if (!sessionsBootstrap || sessionsBootstrap.epoch !== epoch) return false
-  const { rows, warnings } = sessionsBootstrap
+  const { rows, warnings, omittedTotal } = sessionsBootstrap
   sessionsBootstrap = null
   applySessionsSnapshot(rows.map(toUISession))
   sessionStreamWarnings.value = warnings
+  sessionStreamOmittedTotal.value = omittedTotal
   return true
 }
 
@@ -1843,6 +1852,7 @@ export function initStore(): () => void {
   // Missed deltas don't matter: each snapshot is a full replacement.
   resetSessionsTransport()
   sessionStreamWarnings.value = []
+  sessionStreamOmittedTotal.value = 0
   const source = new EventSource('/v1/events?session_stream=3')
   source.addEventListener('error', () => {
     // A transport reconnect starts a new epoch. Never retain unpublished
@@ -1918,6 +1928,7 @@ export function initStore(): () => void {
       discardSessionsBootstrap()
       applySessionsSnapshot((envelope.sessions ?? []).map(toUISession))
       sessionStreamWarnings.value = []
+      sessionStreamOmittedTotal.value = 0
     } catch (err) {
       console.warn('snapshot.sessions: bad event', err)
     }

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -1190,10 +1190,10 @@ function commitWithSlugRewrite(
 }
 
 /**
- * Apply a wholesale `snapshot.sessions` payload (protocol 2 / ADR 0001):
+ * Apply one ready wholesale session replacement (ADR 0001 protocol 3):
  * the daemon re-sends the *entire* session list on any session state
- * change, and we replace `_rawSessions` in one shot rather than patching
- * individual entries.
+ * change as bounded batches, and the ready handler replaces `_rawSessions`
+ * in one shot rather than exposing batches or patching individual entries.
  *
  * Because the replacement is wholesale, a slug change on the currently
  * viewed session (a rename, or a pi `/resume` that swaps the active
@@ -1206,6 +1206,55 @@ function commitWithSlugRewrite(
  * the new slug in place instead of the stale slug failing to resolve and
  * booting the user back home.
  */
+const SESSION_STREAM_VERSION = 3
+const MAX_STAGED_SESSION_ROWS = 100_000
+const MAX_STAGED_SESSION_BYTES = 64 * 1024 * 1024
+
+type SessionsBootstrap = {
+  epoch: number
+  rows: ProtocolSession[]
+  bytes: number
+}
+
+let sessionsBootstrap: SessionsBootstrap | null = null
+
+/** Protocol-3 bootstrap helpers are exported for deterministic reconnect and
+ * atomic-visibility tests. Production calls them only from EventSource. */
+export function beginSessionsBootstrap(version: number, epoch: number): void {
+  sessionsBootstrap = version === SESSION_STREAM_VERSION && Number.isSafeInteger(epoch)
+    ? { epoch, rows: [], bytes: 0 }
+    : null
+}
+
+export function appendSessionsBootstrap(epoch: number, rows: ProtocolSession[], encodedBytes = 0): void {
+  if (!sessionsBootstrap || sessionsBootstrap.epoch !== epoch) {
+    sessionsBootstrap = null
+    return
+  }
+  if (sessionsBootstrap.rows.length + rows.length > MAX_STAGED_SESSION_ROWS
+      || sessionsBootstrap.bytes + encodedBytes > MAX_STAGED_SESSION_BYTES) {
+    sessionsBootstrap = null
+    return
+  }
+  sessionsBootstrap.rows.push(...rows)
+  sessionsBootstrap.bytes += encodedBytes
+}
+
+export function readySessionsBootstrap(epoch: number): boolean {
+  if (!sessionsBootstrap || sessionsBootstrap.epoch !== epoch) {
+    sessionsBootstrap = null
+    return false
+  }
+  const rows = sessionsBootstrap.rows
+  sessionsBootstrap = null
+  applySessionsSnapshot(rows.map(toUISession))
+  return true
+}
+
+export function discardSessionsBootstrap(): void {
+  sessionsBootstrap = null
+}
+
 export function applySessionsSnapshot(list: Session[]): void {
   // Detect newly-arrived IDs vs the previous snapshot so a pending launch
   // (just-POSTed /v1/launch awaiting an id) can navigate to its session as
@@ -1774,6 +1823,9 @@ export function initStore(): () => void {
   // Missed deltas don't matter: each snapshot is a full replacement.
   const source = new EventSource('/v1/events')
   source.addEventListener('error', () => {
+    // A transport reconnect starts a new epoch. Never retain unpublished
+    // rows from the interrupted response.
+    discardSessionsBootstrap()
     // Browser EventSource auto-reconnects; flag the UI as degraded
     // until the next snapshot arrives. `sessionsLoaded` stays true
     // once it has flipped, so reconnect doesn't blank the sidebar.
@@ -1787,17 +1839,44 @@ export function initStore(): () => void {
     else if (connState.value === 'connected') connState.value = 'reconnecting'
   })
 
-  // Protocol 2 (ADR 0001). The server pushes two snapshot kinds plus
-  // bare activity. We replace `_rawSessions` and `_rawWorld`
-  // wholesale on each snapshot; the projection layer derives
-  // everything else.
-  source.addEventListener('snapshot.sessions', (e) => {
+  // Protocol 3 streams complete semantic rows into private staging. No row
+  // becomes visible until the matching ready marker atomically replaces the
+  // projection. A later epoch is an ordinary full replacement too.
+  source.addEventListener('snapshot.sessions.begin', (e) => {
     try {
-      const envelope = JSON.parse(e.data) as { sessions?: ProtocolSession[] }
-      applySessionsSnapshot((envelope.sessions ?? []).map(toUISession))
+      const { version, epoch } = JSON.parse(e.data) as { version: number, epoch: number }
+      beginSessionsBootstrap(version, epoch)
     } catch (err) {
-      console.warn('snapshot.sessions: bad event', err)
+      discardSessionsBootstrap()
+      console.warn('snapshot.sessions.begin: bad event', err)
     }
+  })
+
+  source.addEventListener('snapshot.sessions.batch', (e) => {
+    try {
+      const { epoch, sessions: rows } = JSON.parse(e.data) as { epoch: number, sessions: ProtocolSession[] }
+      if (!Array.isArray(rows)) throw new Error('sessions must be an array')
+      appendSessionsBootstrap(epoch, rows, e.data.length)
+    } catch (err) {
+      discardSessionsBootstrap()
+      console.warn('snapshot.sessions.batch: bad event', err)
+    }
+  })
+
+  source.addEventListener('snapshot.sessions.ready', (e) => {
+    try {
+      const { epoch } = JSON.parse(e.data) as { epoch: number }
+      if (!readySessionsBootstrap(epoch)) console.warn('snapshot.sessions.ready: no matching bootstrap')
+    } catch (err) {
+      discardSessionsBootstrap()
+      console.warn('snapshot.sessions.ready: bad event', err)
+    }
+  })
+
+  source.addEventListener('snapshot.sessions.error', (e) => {
+    discardSessionsBootstrap()
+    connState.value = sessionsLoaded.value ? 'reconnecting' : 'error'
+    console.warn('snapshot.sessions.error:', e.data)
   })
 
   source.addEventListener('snapshot.world', (e) => {

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -1217,20 +1217,24 @@ type SessionsBootstrap = {
 }
 
 let sessionsBootstrap: SessionsBootstrap | null = null
+let lastSessionEpoch = 0
 
 /** Protocol-3 bootstrap helpers are exported for deterministic reconnect and
  * atomic-visibility tests. Production calls them only from EventSource. */
 export function beginSessionsBootstrap(version: number, epoch: number): void {
-  sessionsBootstrap = version === SESSION_STREAM_VERSION && Number.isSafeInteger(epoch)
-    ? { epoch, rows: [], bytes: 0 }
-    : null
-}
-
-export function appendSessionsBootstrap(epoch: number, rows: ProtocolSession[], encodedBytes = 0): void {
-  if (!sessionsBootstrap || sessionsBootstrap.epoch !== epoch) {
+  if (version !== SESSION_STREAM_VERSION || !Number.isSafeInteger(epoch) || epoch <= 0) {
     sessionsBootstrap = null
     return
   }
+  // Epochs are strictly increasing within one EventSource transport. Ignore
+  // replay without destroying a newer transaction already in flight.
+  if (epoch <= lastSessionEpoch) return
+  lastSessionEpoch = epoch
+  sessionsBootstrap = { epoch, rows: [], bytes: 0 }
+}
+
+export function appendSessionsBootstrap(epoch: number, rows: ProtocolSession[], encodedBytes = 0): void {
+  if (!sessionsBootstrap || sessionsBootstrap.epoch !== epoch) return
   if (sessionsBootstrap.rows.length + rows.length > MAX_STAGED_SESSION_ROWS
       || sessionsBootstrap.bytes + encodedBytes > MAX_STAGED_SESSION_BYTES) {
     sessionsBootstrap = null
@@ -1241,10 +1245,7 @@ export function appendSessionsBootstrap(epoch: number, rows: ProtocolSession[], 
 }
 
 export function readySessionsBootstrap(epoch: number): boolean {
-  if (!sessionsBootstrap || sessionsBootstrap.epoch !== epoch) {
-    sessionsBootstrap = null
-    return false
-  }
+  if (!sessionsBootstrap || sessionsBootstrap.epoch !== epoch) return false
   const rows = sessionsBootstrap.rows
   sessionsBootstrap = null
   applySessionsSnapshot(rows.map(toUISession))
@@ -1253,6 +1254,11 @@ export function readySessionsBootstrap(epoch: number): boolean {
 
 export function discardSessionsBootstrap(): void {
   sessionsBootstrap = null
+}
+
+export function resetSessionsTransport(): void {
+  sessionsBootstrap = null
+  lastSessionEpoch = 0
 }
 
 export function applySessionsSnapshot(list: Session[]): void {
@@ -1821,11 +1827,12 @@ export function initStore(): () => void {
   // both kinds (sessions, world) immediately on subscribe, so we
   // don't need a bulk-GET prefetch on first load or on reconnect.
   // Missed deltas don't matter: each snapshot is a full replacement.
-  const source = new EventSource('/v1/events')
+  resetSessionsTransport()
+  const source = new EventSource('/v1/events?session_stream=3')
   source.addEventListener('error', () => {
     // A transport reconnect starts a new epoch. Never retain unpublished
     // rows from the interrupted response.
-    discardSessionsBootstrap()
+    resetSessionsTransport()
     // Browser EventSource auto-reconnects; flag the UI as degraded
     // until the next snapshot arrives. `sessionsLoaded` stays true
     // once it has flipped, so reconnect doesn't blank the sidebar.
@@ -1874,9 +1881,22 @@ export function initStore(): () => void {
   })
 
   source.addEventListener('snapshot.sessions.error', (e) => {
-    discardSessionsBootstrap()
-    connState.value = sessionsLoaded.value ? 'reconnecting' : 'error'
+    // A diagnostic quarantines one row but does not invalidate the epoch.
+    // ready still atomically publishes every row which fit.
     console.warn('snapshot.sessions.error:', e.data)
+  })
+
+  // Transitional fallback for a proxy or one-release-old daemon which ignores
+  // the explicit protocol marker. Old tabs request no marker and receive this
+  // event from a new daemon as well.
+  source.addEventListener('snapshot.sessions', (e) => {
+    try {
+      resetSessionsTransport()
+      const envelope = JSON.parse(e.data) as { sessions?: ProtocolSession[] }
+      applySessionsSnapshot((envelope.sessions ?? []).map(toUISession))
+    } catch (err) {
+      console.warn('snapshot.sessions: bad event', err)
+    }
   })
 
   source.addEventListener('snapshot.world', (e) => {
@@ -1905,6 +1925,14 @@ export function initStore(): () => void {
     } catch (err) {
       console.warn('snapshot.world: bad event', err)
     }
+  })
+
+  source.addEventListener('snapshot.world.error', (e) => {
+    // World remains one explicitly bounded semantic object. Retain a prior
+    // world on update failure; on initial hydration expose the safe empty
+    // defaults so an oversized operator configuration does not brick sessions.
+    if (!worldLoaded.value) worldLoaded.value = true
+    console.warn('snapshot.world.error:', e.data)
   })
 
   source.addEventListener('session-activity', (e) => {

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -244,6 +244,8 @@ effect(() => {
 })
 
 // Local-only UI state (never sourced from the wire).
+export type SessionStreamWarning = { id: string, code: string, message: string, count: number }
+export const sessionStreamWarnings = signal<SessionStreamWarning[]>([])
 export const sessionsLoaded = signal(false)
 /**
  * Whether the leading-edge `snapshot.world` (projects, peers, health)
@@ -1214,8 +1216,11 @@ type SessionsBootstrap = {
   epoch: number
   rows: ProtocolSession[]
   bytes: number
+  warnings: SessionStreamWarning[]
 }
 
+type SessionStreamMode = 'unknown' | 'legacy' | 'v3'
+let sessionStreamMode: SessionStreamMode = 'unknown'
 let sessionsBootstrap: SessionsBootstrap | null = null
 let lastSessionEpoch = 0
 
@@ -1226,11 +1231,13 @@ export function beginSessionsBootstrap(version: number, epoch: number): void {
     sessionsBootstrap = null
     return
   }
+  if (sessionStreamMode === 'legacy') return
   // Epochs are strictly increasing within one EventSource transport. Ignore
   // replay without destroying a newer transaction already in flight.
   if (epoch <= lastSessionEpoch) return
+  sessionStreamMode = 'v3'
   lastSessionEpoch = epoch
-  sessionsBootstrap = { epoch, rows: [], bytes: 0 }
+  sessionsBootstrap = { epoch, rows: [], bytes: 0, warnings: [] }
 }
 
 export function appendSessionsBootstrap(epoch: number, rows: ProtocolSession[], encodedBytes = 0): void {
@@ -1244,11 +1251,17 @@ export function appendSessionsBootstrap(epoch: number, rows: ProtocolSession[], 
   sessionsBootstrap.bytes += encodedBytes
 }
 
+export function appendSessionStreamWarning(epoch: number, warning: SessionStreamWarning): void {
+  if (sessionStreamMode !== 'v3' || !sessionsBootstrap || sessionsBootstrap.epoch !== epoch) return
+  if (sessionsBootstrap.warnings.length < 256) sessionsBootstrap.warnings.push(warning)
+}
+
 export function readySessionsBootstrap(epoch: number): boolean {
   if (!sessionsBootstrap || sessionsBootstrap.epoch !== epoch) return false
-  const rows = sessionsBootstrap.rows
+  const { rows, warnings } = sessionsBootstrap
   sessionsBootstrap = null
   applySessionsSnapshot(rows.map(toUISession))
+  sessionStreamWarnings.value = warnings
   return true
 }
 
@@ -1257,6 +1270,7 @@ export function discardSessionsBootstrap(): void {
 }
 
 export function resetSessionsTransport(): void {
+  sessionStreamMode = 'unknown'
   sessionsBootstrap = null
   lastSessionEpoch = 0
 }
@@ -1828,6 +1842,7 @@ export function initStore(): () => void {
   // don't need a bulk-GET prefetch on first load or on reconnect.
   // Missed deltas don't matter: each snapshot is a full replacement.
   resetSessionsTransport()
+  sessionStreamWarnings.value = []
   const source = new EventSource('/v1/events?session_stream=3')
   source.addEventListener('error', () => {
     // A transport reconnect starts a new epoch. Never retain unpublished
@@ -1882,7 +1897,13 @@ export function initStore(): () => void {
 
   source.addEventListener('snapshot.sessions.error', (e) => {
     // A diagnostic quarantines one row but does not invalidate the epoch.
-    // ready still atomically publishes every row which fit.
+    // It becomes a persistent sidebar warning when ready commits this epoch.
+    try {
+      const diagnostic = JSON.parse(e.data) as SessionStreamWarning & { epoch: number }
+      appendSessionStreamWarning(diagnostic.epoch, {
+        id: diagnostic.id ?? '', code: diagnostic.code ?? 'row_omitted', message: diagnostic.message ?? 'session row omitted', count: diagnostic.count ?? 1,
+      })
+    } catch { /* malformed diagnostics cannot invalidate staging */ }
     console.warn('snapshot.sessions.error:', e.data)
   })
 
@@ -1891,9 +1912,12 @@ export function initStore(): () => void {
   // event from a new daemon as well.
   source.addEventListener('snapshot.sessions', (e) => {
     try {
-      resetSessionsTransport()
+      if (sessionStreamMode === 'v3') return
       const envelope = JSON.parse(e.data) as { sessions?: ProtocolSession[] }
+      sessionStreamMode = 'legacy'
+      discardSessionsBootstrap()
       applySessionsSnapshot((envelope.sessions ?? []).map(toUISession))
+      sessionStreamWarnings.value = []
     } catch (err) {
       console.warn('snapshot.sessions: bad event', err)
     }
@@ -1925,14 +1949,6 @@ export function initStore(): () => void {
     } catch (err) {
       console.warn('snapshot.world: bad event', err)
     }
-  })
-
-  source.addEventListener('snapshot.world.error', (e) => {
-    // World remains one explicitly bounded semantic object. Retain a prior
-    // world on update failure; on initial hydration expose the safe empty
-    // defaults so an oversized operator configuration does not brick sessions.
-    if (!worldLoaded.value) worldLoaded.value = true
-    console.warn('snapshot.world.error:', e.data)
   })
 
   source.addEventListener('session-activity', (e) => {

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -1243,7 +1243,18 @@ body {
   .session-close-btn { opacity: 1; }
 }
 
-/* ── Sidebar empty state ── */
+/* ── Sidebar stream warning / empty state ── */
+.sidebar-stream-warning {
+  margin: 8px 10px 4px;
+  padding: 8px 10px;
+  border: 1px solid color-mix(in srgb, var(--warning, #d08770) 45%, transparent);
+  border-radius: 6px;
+  color: var(--warning, #d08770);
+  background: color-mix(in srgb, var(--warning, #d08770) 10%, transparent);
+  font-size: 11px;
+  line-height: 1.35;
+}
+
 .sidebar-hint {
   padding: 12px 16px;
   font-size: 12px;

--- a/apps/website/src/content/docs/architecture.md
+++ b/apps/website/src/content/docs/architecture.md
@@ -105,7 +105,7 @@ Served by `gmuxd` on a Unix socket (local IPC) and a TCP listener (default `127.
 | `GET /v1/conversations/{adapter}/{slug}` | Conversation lookup for resume |
 | `POST /v1/peers` / `DELETE /v1/peers/{name}` | Add / remove a peer host |
 | `POST /v1/register` / `POST /v1/deregister` | Runner registration fast path |
-| `GET /v1/events` | SSE: `snapshot.sessions`, `snapshot.world`, `session-activity` (ADR 0001) |
+| `GET /v1/events?session_stream=3` | SSE: bounded atomic `snapshot.sessions.{begin,batch,ready}`, row diagnostics, `snapshot.world`, `session-activity` (ADR 0001); unversioned requests temporarily retain legacy `snapshot.sessions` |
 | `/v1/peers/{peer}/...` | Forward an allowlisted write to a peer (ADR 0002) |
 | `GET /v1/health` | Daemon health, version, launchers, peer status |
 | `WS /ws/{id}` | Terminal WebSocket proxy |

--- a/apps/website/src/content/docs/develop/session-schema.md
+++ b/apps/website/src/content/docs/develop/session-schema.md
@@ -38,7 +38,7 @@ Two paths: the runner's `GET /meta` endpoint (polled by discovery) and its SSE `
 
 ### gmuxd → frontend
 
-gmuxd exposes the aggregated state to the browser via `GET /v1/events` (SSE). Session state arrives as coalesced `snapshot.sessions` full-replacement snapshots (ADR 0001); `session-activity` is forwarded as a bare signal. `GET /v1/sessions` remains for CLI/scripting. A wire-conversion layer controls which fields are serialized in both: internal fields are excluded, their derived outputs included instead.
+gmuxd exposes aggregated state to the browser via `GET /v1/events?session_stream=3` (SSE). Coalesced full replacements use bounded `snapshot.sessions.begin` / complete-row `.batch` / atomic `.ready` transactions (ADR 0001); a non-fatal `.error` identifies an omitted oversized row. `session-activity` is forwarded as a bare signal. Unversioned consumers temporarily retain legacy `snapshot.sessions`, and `GET /v1/sessions` remains for CLI/scripting. A wire-conversion layer controls which fields are serialized: internal fields are excluded, their derived outputs included instead.
 
 ### Field map
 

--- a/apps/website/src/content/docs/develop/state-management.md
+++ b/apps/website/src/content/docs/develop/state-management.md
@@ -114,13 +114,13 @@ Staleness (the "outdated" badge) is **frontend-derived**: the UI compares each s
 
 ## Frontend architecture
 
-The frontend is a projection of backend state. Session state arrives exclusively via a single `EventSource('/v1/events')` (protocol 2, ADR 0001):
+The frontend is a projection of backend state. Session state arrives exclusively via `EventSource('/v1/events?session_stream=3')` (ADR 0001):
 
-1. `snapshot.sessions` — full replacement of the session list (a leading-edge snapshot arrives on connect, so there is no bulk-GET prefetch)
-2. `snapshot.world` — projects, peers, health, launchers, peer projects
-3. `session-activity` — bare `{id}` ping, lossy by design
+1. `snapshot.sessions.begin` / `.batch` / `.ready` — complete semantic rows are staged in bounded batches and replace the visible list atomically at ready. A `.error` diagnostic means one oversized row was omitted; the remaining epoch still becomes ready.
+2. `snapshot.world` — one semantic object containing projects, peers, health, launchers, and peer projects, explicitly capped at 512 KiB; `.error` retains the prior world.
+3. `session-activity` — bare `{id}` ping, lossy by design.
 
-Reconnect is trivial: the browser's `EventSource` auto-reconnects, and since every snapshot is a full replacement, missed deltas don't matter. (`GET /v1/sessions` still exists for the CLI and scripts.)
+Reconnect discards unpublished staging and restarts from a leading-edge full replacement, so missed updates do not matter. Epochs increase strictly within each transport. Unversioned custom consumers and old tabs temporarily receive protocol-2 `snapshot.sessions`; `GET /v1/sessions` remains for the CLI and scripts.
 
 Mutations use a bounded **optimistic overlay**: mark-read, dismiss, and reorder are stacked as pending mutations and replayed on top of incoming raw snapshots until the server echoes them back or a 5-second TTL expires. The UI feels instant, and a failed action self-heals back to server truth (plus an error toast).
 

--- a/apps/website/src/content/docs/develop/state-management.md
+++ b/apps/website/src/content/docs/develop/state-management.md
@@ -117,10 +117,10 @@ Staleness (the "outdated" badge) is **frontend-derived**: the UI compares each s
 The frontend is a projection of backend state. Session state arrives exclusively via `EventSource('/v1/events?session_stream=3')` (ADR 0001):
 
 1. `snapshot.sessions.begin` / `.batch` / `.ready` — complete semantic rows are staged in bounded batches and replace the visible list atomically at ready. A `.error` diagnostic means one oversized row was omitted; the remaining epoch still becomes ready.
-2. `snapshot.world` — one semantic object containing projects, peers, health, launchers, and peer projects, explicitly capped at 512 KiB; `.error` retains the prior world.
+2. `snapshot.world` — projects, peers, health, launchers, and peer projects. It remains a separate protocol-2 full replacement; the 48 KiB session-event bound does not apply to world.
 3. `session-activity` — bare `{id}` ping, lossy by design.
 
-Reconnect discards unpublished staging and restarts from a leading-edge full replacement, so missed updates do not matter. Epochs increase strictly within each transport. Unversioned custom consumers and old tabs temporarily receive protocol-2 `snapshot.sessions`; `GET /v1/sessions` remains for the CLI and scripts.
+Reconnect discards unpublished staging and restarts from a leading-edge full replacement, so missed updates do not matter. Epochs increase strictly and the first accepted session protocol locks each transport against mixed-mode rollback. A quarantined row produces a persistent sidebar warning until a later clean bootstrap. Unversioned custom consumers and old tabs temporarily receive protocol-2 `snapshot.sessions`; `GET /v1/sessions` remains for the CLI and scripts.
 
 Mutations use a bounded **optimistic overlay**: mark-read, dismiss, and reorder are stacked as pending mutations and replayed on top of incoming raw snapshots until the server echoes them back or a 5-second TTL expires. The UI feels instant, and a failed action self-heals back to server truth (plus an error toast).
 

--- a/apps/website/src/content/docs/migrating-to-2.md
+++ b/apps/website/src/content/docs/migrating-to-2.md
@@ -120,9 +120,9 @@ A peer's name is now frozen at first contact (ADR 0017): renaming a machine does
 
 The daemon accepts the legacy runner `session_file` event for one release (dropped in v2.1) but writes/emits only the new names. The `GMUX_ADAPTER` env var is unchanged (it was already named that in 1.6). URL path segments (`/project/pi/slug`) are unchanged, so bookmarks keep working — though a Claude `/rename` now moves the slug with the title.
 
-### Wire protocol v2
+### Wire protocol v2 and bounded session stream v3
 
-Custom consumers of the daemon SSE stream: the per-event `session-upsert`/`session-remove` surface and bulk-GET prefetch are gone. Subscribe to `GET /v1/events` and consume full-replacement `snapshot.sessions` / `snapshot.world` payloads plus lossy `session-activity` pings. `GET /v1/sessions` remains for one-shot listing.
+Custom consumers of the daemon SSE stream: the per-event `session-upsert`/`session-remove` surface and bulk-GET prefetch are gone. Unversioned `GET /v1/events` retains the full-replacement `snapshot.sessions` event for one transitional release. New consumers should request `GET /v1/events?session_stream=3` and stage `snapshot.sessions.begin` plus complete-row `snapshot.sessions.batch` events until the matching `snapshot.sessions.ready`; `snapshot.sessions.error` reports an omitted oversized row without invalidating the transaction. `snapshot.world` and lossy `session-activity` remain separate. `GET /v1/sessions` remains for one-shot listing.
 
 ### Same-origin enforcement
 

--- a/apps/website/src/content/docs/multi-machine.md
+++ b/apps/website/src/content/docs/multi-machine.md
@@ -112,7 +112,7 @@ The hub connects to these public gmuxd endpoints on each spoke:
 
 | Endpoint | Purpose |
 |----------|---------|
-| `GET /v1/events?as=peer` | SSE snapshot stream — full `snapshot.sessions` on connect and on every change |
+| `GET /v1/events?as=peer&session_stream=3` | SSE snapshot stream — bounded begin/batch/ready full replacement on connect and every change; old peers omitting the version temporarily receive legacy `snapshot.sessions` |
 | `GET /v1/projects` | Spoke's projects + discovered list (refreshed on `projects-update` events) |
 | `GET /v1/health` | Version, hostname, node ID, available launchers |
 | `POST /v1/launch` | Forward launch requests |

--- a/docs/adr/0001-snapshot-push-protocol.md
+++ b/docs/adr/0001-snapshot-push-protocol.md
@@ -227,6 +227,55 @@ HTTP action responses and SSE snapshots arrive on independent
 channels. A 200 OK can land before the snapshot reflecting the
 action's effect. The optimistic overlay covers the gap.
 
+## Amendment: bounded semantic session replacement (protocol 3)
+
+A full `snapshot.sessions` JSON line grows without bound. At roughly 1,000
+ordinary session rows it is hundreds of KiB, exceeding both the 64 KiB default
+`bufio.Scanner` token and the former 256 KiB compatibility ceiling. Protocol 3
+keeps the full-replacement semantics of this ADR but frames each replacement as
+a transaction:
+
+1. `snapshot.sessions.begin` — `{version:3, epoch}` resets private receiver
+   staging.
+2. Zero or more `snapshot.sessions.batch` events — `{epoch,sessions:[...]}`.
+   Batches contain complete session rows and have a 48 KiB JSON payload limit.
+3. `snapshot.sessions.ready` — `{epoch}` atomically replaces the visible set
+   with staging (including the empty set).
+4. `snapshot.sessions.error` reports a rejected replacement; receivers discard
+   staging and retain the previous ready set.
+
+The 48 KiB budget is 16 KiB below Scanner's 64 KiB default, leaving room for
+SSE syntax and future envelope metadata. Rows are not byte-fragmented. A single
+row that cannot fit fails the replacement before `begin` is emitted; likely
+causes are unusually large `command`, `cwd`, `remotes`, `title`, `subtitle`,
+`socket_path`, or `conversation_file` fields. Session rows do not contain
+scrollback or transcripts. Receivers additionally cap unpublished staging at
+100,000 rows / 64 MiB. Go SSE clients retain a bounded 1 MiB line ceiling only
+for protocol-2 compatibility (enough for the measured 1,000-row legacy frame).
+
+`Subscribe` installs the fanout subscriber and captures its full baseline while
+holding the same mutex used by publication. Consequently, a mutation is either
+in the baseline epoch or queued as a later full replacement. One connection
+serializes every begin/batch/ready transaction, so a later replacement cannot
+overtake readiness. Disconnect destroys connection-local staging; reconnect
+starts from a fresh baseline.
+
+Browser assets are daemon-served and always use protocol 3. Peer clients request
+`?as=peer&session_stream=3`. A new hub also accepts the legacy
+`snapshot.sessions` response from an old spoke. A new spoke sends legacy
+`snapshot.sessions` when an old hub omits `session_stream=3`; this fallback may
+still be large, but it cannot be silently misparsed. Unknown requested protocol
+versions use the legacy fallback rather than guessing.
+
+After `ready`, ordinary publication semantics are unchanged: each mutation
+still produces a coalesced full replacement, now transactionally batched. This
+amendment does not implement archive/live-set selection; a future implementation
+changes which complete rows enter a transaction, not its framing.
+
+`snapshot.world` remains a separate event and does not carry session rows. It
+can carry project membership IDs; the 1,000-session measurement remains below
+the session-event budget, so changing world framing is outside this amendment.
+
 ## Consequences
 
 ### Positive

--- a/docs/adr/0001-snapshot-push-protocol.md
+++ b/docs/adr/0001-snapshot-push-protocol.md
@@ -249,9 +249,10 @@ The 48 KiB budget is 16 KiB below Scanner's 64 KiB default, leaving room for
 SSE syntax and future envelope metadata. Rows are not byte-fragmented. A single
 row that cannot fit is omitted, identified safely (long IDs become SHA-256
 identities), and does not prevent the rest of the set becoming ready. Browsers
-show a persistent omitted-session count and safe details until a later complete
-bootstrap clears it; peers retain the bounded diagnostic for the transaction
-and log it. Likely causes are unusually large `command`, `cwd`, `remotes`, `title`, `subtitle`,
+show a persistent omitted-session total and at most 256 safe details until a
+later complete bootstrap clears it. A non-droppable counted summary keeps the
+total exact above the detail cap; peers retain bounded diagnostics for the
+transaction and log them. Likely causes are unusually large `command`, `cwd`, `remotes`, `title`, `subtitle`,
 `socket_path`, or `conversation_file` fields. Session rows do not contain
 scrollback or transcripts. Sender and receiver share 100,000-row / 64 MiB
 transaction bounds, with sender envelope headroom. A rejected malformed

--- a/docs/adr/0001-snapshot-push-protocol.md
+++ b/docs/adr/0001-snapshot-push-protocol.md
@@ -248,8 +248,10 @@ a transaction:
 The 48 KiB budget is 16 KiB below Scanner's 64 KiB default, leaving room for
 SSE syntax and future envelope metadata. Rows are not byte-fragmented. A single
 row that cannot fit is omitted, identified safely (long IDs become SHA-256
-identities), and does not prevent the rest of the set becoming ready. Likely
-causes are unusually large `command`, `cwd`, `remotes`, `title`, `subtitle`,
+identities), and does not prevent the rest of the set becoming ready. Browsers
+show a persistent omitted-session count and safe details until a later complete
+bootstrap clears it; peers retain the bounded diagnostic for the transaction
+and log it. Likely causes are unusually large `command`, `cwd`, `remotes`, `title`, `subtitle`,
 `socket_path`, or `conversation_file` fields. Session rows do not contain
 scrollback or transcripts. Sender and receiver share 100,000-row / 64 MiB
 transaction bounds, with sender envelope headroom. A rejected malformed
@@ -262,9 +264,11 @@ holding the same mutex used by publication. Consequently, a mutation is either
 in the baseline epoch or queued as a later full replacement. One connection
 serializes every begin/batch/ready transaction, so a later replacement cannot
 overtake readiness. Receivers require epochs to increase strictly within one
-transport, so replayed begin/batch/ready sequences cannot roll state back.
-Disconnect destroys connection-local staging and resets epoch history;
-reconnect starts from a fresh baseline.
+transport, so replayed begin/batch/ready sequences cannot roll state back. The
+first accepted session event locks that transport to legacy or protocol 3; a
+legacy injection cannot reset protocol-3 replay protection. Disconnect destroys
+connection-local staging and resets mode/epoch history; reconnect starts from a
+fresh baseline.
 
 The current browser explicitly requests `?session_stream=3`; peer clients
 request `?as=peer&session_stream=3`. For one transitional release, an
@@ -279,14 +283,12 @@ still produces a coalesced full replacement, now transactionally batched. This
 amendment does not implement archive/live-set selection; a future implementation
 changes which complete rows enter a transaction, not its framing.
 
-`snapshot.world` remains a separate semantic object and does not carry session
-rows. It has an explicit 512 KiB JSON payload maximum (below the Go transport's
-1 MiB line ceiling). An oversized world emits bounded `snapshot.world.error`;
-receivers retain the previous world, or expose safe empty defaults on initial
-hydration. A realistic composed fixture with 1,000 memberships, 50 projects,
-match rules, 20 peers, launchers, health, peer projects, and discovery is
-measured at the transport seam. This is a larger bound than the 48 KiB session
-batch budget, not a claim that every endpoint event is below 48 KiB.
+`snapshot.world` remains a separate event and does not carry session rows. This
+amendment makes no world-size or endpoint-wide boundedness claim: 48 KiB applies
+only to protocol-3 session events. A realistic 1,000-membership world is retained
+as a size characterization, not a supported maximum. World framing belongs in a
+separate design if production evidence demonstrates the need; protocol-2 world
+semantics remain unchanged in this transition.
 
 ## Consequences
 

--- a/docs/adr/0001-snapshot-push-protocol.md
+++ b/docs/adr/0001-snapshot-push-protocol.md
@@ -241,40 +241,52 @@ a transaction:
    Batches contain complete session rows and have a 48 KiB JSON payload limit.
 3. `snapshot.sessions.ready` — `{epoch}` atomically replaces the visible set
    with staging (including the empty set).
-4. `snapshot.sessions.error` reports a rejected replacement; receivers discard
-   staging and retain the previous ready set.
+4. `snapshot.sessions.error` is a non-fatal bounded diagnostic for one
+   quarantined row. The epoch remains valid and `ready` publishes every row
+   which fit.
 
 The 48 KiB budget is 16 KiB below Scanner's 64 KiB default, leaving room for
 SSE syntax and future envelope metadata. Rows are not byte-fragmented. A single
-row that cannot fit fails the replacement before `begin` is emitted; likely
+row that cannot fit is omitted, identified safely (long IDs become SHA-256
+identities), and does not prevent the rest of the set becoming ready. Likely
 causes are unusually large `command`, `cwd`, `remotes`, `title`, `subtitle`,
 `socket_path`, or `conversation_file` fields. Session rows do not contain
-scrollback or transcripts. Receivers additionally cap unpublished staging at
-100,000 rows / 64 MiB. Go SSE clients retain a bounded 1 MiB line ceiling only
-for protocol-2 compatibility (enough for the measured 1,000-row legacy frame).
+scrollback or transcripts. Sender and receiver share 100,000-row / 64 MiB
+transaction bounds, with sender envelope headroom. A rejected malformed
+transaction can recover at the next strictly newer begin. Go SSE clients retain
+a bounded 1 MiB line ceiling only for protocol-2 compatibility (enough for the
+measured 1,000-row legacy frame).
 
 `Subscribe` installs the fanout subscriber and captures its full baseline while
 holding the same mutex used by publication. Consequently, a mutation is either
 in the baseline epoch or queued as a later full replacement. One connection
 serializes every begin/batch/ready transaction, so a later replacement cannot
-overtake readiness. Disconnect destroys connection-local staging; reconnect
-starts from a fresh baseline.
+overtake readiness. Receivers require epochs to increase strictly within one
+transport, so replayed begin/batch/ready sequences cannot roll state back.
+Disconnect destroys connection-local staging and resets epoch history;
+reconnect starts from a fresh baseline.
 
-Browser assets are daemon-served and always use protocol 3. Peer clients request
-`?as=peer&session_stream=3`. A new hub also accepts the legacy
-`snapshot.sessions` response from an old spoke. A new spoke sends legacy
-`snapshot.sessions` when an old hub omits `session_stream=3`; this fallback may
-still be large, but it cannot be silently misparsed. Unknown requested protocol
-versions use the legacy fallback rather than guessing.
+The current browser explicitly requests `?session_stream=3`; peer clients
+request `?as=peer&session_stream=3`. For one transitional release, an
+unversioned browser tab, peer, or custom consumer receives legacy
+`snapshot.sessions`. This lets a tab opened before a daemon upgrade reconnect
+without silently freezing. A new hub also accepts a legacy response from an old
+spoke. Unknown requested protocol versions use the legacy fallback rather than
+guessing.
 
 After `ready`, ordinary publication semantics are unchanged: each mutation
 still produces a coalesced full replacement, now transactionally batched. This
 amendment does not implement archive/live-set selection; a future implementation
 changes which complete rows enter a transaction, not its framing.
 
-`snapshot.world` remains a separate event and does not carry session rows. It
-can carry project membership IDs; the 1,000-session measurement remains below
-the session-event budget, so changing world framing is outside this amendment.
+`snapshot.world` remains a separate semantic object and does not carry session
+rows. It has an explicit 512 KiB JSON payload maximum (below the Go transport's
+1 MiB line ceiling). An oversized world emits bounded `snapshot.world.error`;
+receivers retain the previous world, or expose safe empty defaults on initial
+hydration. A realistic composed fixture with 1,000 memberships, 50 projects,
+match rules, 20 peers, launchers, health, peer projects, and discovery is
+measured at the transport seam. This is a larger bound than the 48 KiB session
+batch budget, not a claim that every endpoint event is below 48 KiB.
 
 ## Consequences
 

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -715,35 +715,7 @@ func isAllowedPeerProxyPath(method, sub string) bool {
 	return false
 }
 
-const (
-	sseWriteTimeout      = 10 * time.Second
-	maxWorldEventPayload = 512 * 1024
-)
-
-type worldStreamError struct {
-	Code    string `json:"code"`
-	Message string `json:"message"`
-	Size    int    `json:"size,omitempty"`
-	Limit   int    `json:"limit"`
-}
-
-// sendWorldSSEFrame enforces an explicit bound on the still-single semantic
-// world object. Oversize keeps the stream available and sends a bounded
-// diagnostic; the browser retains its previous world projection.
-func sendWorldSSEFrame(rc *http.ResponseController, w io.Writer, payload any) error {
-	data, err := json.Marshal(payload)
-	if err == nil && len(data) <= maxWorldEventPayload {
-		return sendSSEBytesFrame(rc, w, "snapshot.world", data)
-	}
-	diagnostic := worldStreamError{Code: "world_too_large", Message: "world snapshot omitted; previous world remains visible", Limit: maxWorldEventPayload}
-	if err != nil {
-		diagnostic.Code = "world_encode_failed"
-	} else {
-		diagnostic.Size = len(data)
-	}
-	diagnosticData, _ := json.Marshal(diagnostic)
-	return sendSSEBytesFrame(rc, w, "snapshot.world.error", diagnosticData)
-}
+const sseWriteTimeout = 10 * time.Second
 
 func sendSSEFrame(rc *http.ResponseController, w io.Writer, event string, payload any) error {
 	_ = rc.SetWriteDeadline(time.Now().Add(sseWriteTimeout))

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gmuxapp/gmux/packages/adapter/adapters"
 	"github.com/gmuxapp/gmux/packages/paths"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/peering"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/sessionstream"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/unixipc"
 	qrterminal "github.com/mdp/qrterminal/v3"
 )
@@ -647,6 +648,14 @@ func snapshotPumpRoute(eventType string) (pushSessions, pushWorld bool) {
 	return false, false
 }
 
+// useSemanticSessionStream selects protocol 3 only by explicit request.
+// Browser code requests it in the EventSource URL; unversioned custom clients
+// and old tabs retain protocol 2 for one transitional release. Peers use the
+// same explicit marker.
+func useSemanticSessionStream(_ bool, requested string) bool {
+	return requested == "3"
+}
+
 // shouldForwardActivity decides whether a session-activity event
 // should be sent to a given SSE subscriber.
 //
@@ -660,10 +669,6 @@ func snapshotPumpRoute(eventType string) (pushSessions, pushWorld bool) {
 //     daemon sees, including namespaced activity that hubs have
 //     re-broadcast from network peers — the UI renders all of those
 //     sessions and needs the indicator updates.
-func useSemanticSessionStream(asPeer bool, requested string) bool {
-	return !asPeer || requested == "3"
-}
-
 func shouldForwardActivity(asPeer bool, sessionID string, isLocalPeer func(string) bool) bool {
 	if !asPeer {
 		return true
@@ -710,10 +715,35 @@ func isAllowedPeerProxyPath(method, sub string) bool {
 	return false
 }
 
-// sessionLastActive returns the timestamp used to sort discovered
-// suggestions by recency: the session's last_output_at, falling back
-// to created_at when no activity has been recorded yet.
-const sseWriteTimeout = 10 * time.Second
+const (
+	sseWriteTimeout      = 10 * time.Second
+	maxWorldEventPayload = 512 * 1024
+)
+
+type worldStreamError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+	Size    int    `json:"size,omitempty"`
+	Limit   int    `json:"limit"`
+}
+
+// sendWorldSSEFrame enforces an explicit bound on the still-single semantic
+// world object. Oversize keeps the stream available and sends a bounded
+// diagnostic; the browser retains its previous world projection.
+func sendWorldSSEFrame(rc *http.ResponseController, w io.Writer, payload any) error {
+	data, err := json.Marshal(payload)
+	if err == nil && len(data) <= maxWorldEventPayload {
+		return sendSSEBytesFrame(rc, w, "snapshot.world", data)
+	}
+	diagnostic := worldStreamError{Code: "world_too_large", Message: "world snapshot omitted; previous world remains visible", Limit: maxWorldEventPayload}
+	if err != nil {
+		diagnostic.Code = "world_encode_failed"
+	} else {
+		diagnostic.Size = len(data)
+	}
+	diagnosticData, _ := json.Marshal(diagnostic)
+	return sendSSEBytesFrame(rc, w, "snapshot.world.error", diagnosticData)
+}
 
 func sendSSEFrame(rc *http.ResponseController, w io.Writer, event string, payload any) error {
 	_ = rc.SetWriteDeadline(time.Now().Add(sseWriteTimeout))
@@ -725,10 +755,35 @@ func sendSSEFrame(rc *http.ResponseController, w io.Writer, event string, payloa
 
 func sendSSEBytesFrame(rc *http.ResponseController, w io.Writer, event string, data []byte) error {
 	_ = rc.SetWriteDeadline(time.Now().Add(sseWriteTimeout))
-	if _, err := fmt.Fprintf(w, "event: %s\ndata: %s\n\n", event, data); err != nil {
+	if err := writeSSEBytes(w, event, data); err != nil {
 		return err
 	}
 	return rc.Flush()
+}
+
+// sendSSETransaction applies one deadline to the complete begin/batch/ready
+// write. A fragmented replacement therefore has the same 10-second stall bound
+// as the old single frame rather than multiplying the timeout per fragment.
+func sendSSETransaction(ctx context.Context, rc *http.ResponseController, w io.Writer, events []sessionstream.Event) error {
+	_ = rc.SetWriteDeadline(time.Now().Add(sseWriteTimeout))
+	defer func() { _ = rc.SetWriteDeadline(time.Time{}) }()
+	for _, event := range events {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := writeSSEBytes(w, event.Type, event.Data); err != nil {
+			return err
+		}
+		if err := rc.Flush(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeSSEBytes(w io.Writer, event string, data []byte) error {
+	_, err := fmt.Fprintf(w, "event: %s\ndata: %s\n\n", event, data)
+	return err
 }
 
 // sendSSEComment writes a heartbeat comment frame (":") with a fresh

--- a/services/gmuxd/cmd/gmuxd/main.go
+++ b/services/gmuxd/cmd/gmuxd/main.go
@@ -660,6 +660,10 @@ func snapshotPumpRoute(eventType string) (pushSessions, pushWorld bool) {
 //     daemon sees, including namespaced activity that hubs have
 //     re-broadcast from network peers — the UI renders all of those
 //     sessions and needs the indicator updates.
+func useSemanticSessionStream(asPeer bool, requested string) bool {
+	return !asPeer || requested == "3"
+}
+
 func shouldForwardActivity(asPeer bool, sessionID string, isLocalPeer func(string) bool) bool {
 	if !asPeer {
 		return true
@@ -714,6 +718,14 @@ const sseWriteTimeout = 10 * time.Second
 func sendSSEFrame(rc *http.ResponseController, w io.Writer, event string, payload any) error {
 	_ = rc.SetWriteDeadline(time.Now().Add(sseWriteTimeout))
 	if err := sendSSE(w, event, payload); err != nil {
+		return err
+	}
+	return rc.Flush()
+}
+
+func sendSSEBytesFrame(rc *http.ResponseController, w io.Writer, event string, data []byte) error {
+	_ = rc.SetWriteDeadline(time.Now().Add(sseWriteTimeout))
+	if _, err := fmt.Fprintf(w, "event: %s\ndata: %s\n\n", event, data); err != nil {
 		return err
 	}
 	return rc.Flush()

--- a/services/gmuxd/cmd/gmuxd/production_container_e2e_test.go
+++ b/services/gmuxd/cmd/gmuxd/production_container_e2e_test.go
@@ -395,7 +395,7 @@ func scenarioUnreadRestart(t *testing.T, bin string) {
 	}
 }
 func assertInitialSSE(t *testing.T, e *prodEnv, id string, unread bool) {
-	req, _ := http.NewRequest(http.MethodGet, "http://localhost/v1/events", nil)
+	req, _ := http.NewRequest(http.MethodGet, "http://localhost/v1/events?session_stream=3", nil)
 	ctx, c := context.WithTimeout(context.Background(), 3*time.Second)
 	defer c()
 	resp, err := unixipc.Client(e.socket()).Do(req.WithContext(ctx))
@@ -405,33 +405,58 @@ func assertInitialSSE(t *testing.T, e *prodEnv, id string, unread bool) {
 	defer resp.Body.Close()
 	sc := bufio.NewScanner(resp.Body)
 	name, data := readSSE(t, sc)
-	if name != "snapshot.sessions" {
+	if name != "snapshot.sessions.begin" {
 		t.Fatalf("first SSE=%q", name)
 	}
-	var sf struct {
-		Sessions []struct {
-			ID     string `json:"id"`
-			Unread bool   `json:"unread"`
-		} `json:"sessions"`
+	var begin struct {
+		Epoch uint64 `json:"epoch"`
 	}
-	if err := json.Unmarshal(data, &sf); err != nil {
-		t.Fatal(err)
+	if err := json.Unmarshal(data, &begin); err != nil || begin.Epoch == 0 {
+		t.Fatalf("bad begin %s: %v", data, err)
 	}
 	found := false
-	for _, s := range sf.Sessions {
-		if s.ID == id {
-			found = true
-			if s.Unread != unread {
-				t.Fatalf("SSE unread=%v want %v", s.Unread, unread)
+	for {
+		name, data = readSSE(t, sc)
+		if name == "snapshot.sessions.ready" {
+			var ready struct {
+				Epoch uint64 `json:"epoch"`
+			}
+			if err := json.Unmarshal(data, &ready); err != nil || ready.Epoch != begin.Epoch {
+				t.Fatalf("bad ready %s: %v", data, err)
+			}
+			break
+		}
+		if name == "snapshot.sessions.error" {
+			continue
+		}
+		if name != "snapshot.sessions.batch" {
+			t.Fatalf("bootstrap SSE=%q", name)
+		}
+		var sf struct {
+			Epoch    uint64 `json:"epoch"`
+			Sessions []struct {
+				ID     string `json:"id"`
+				Unread bool   `json:"unread"`
+			} `json:"sessions"`
+		}
+		if err := json.Unmarshal(data, &sf); err != nil || sf.Epoch != begin.Epoch {
+			t.Fatalf("bad batch %s: %v", data, err)
+		}
+		for _, s := range sf.Sessions {
+			if s.ID == id {
+				found = true
+				if s.Unread != unread {
+					t.Fatalf("SSE unread=%v want %v", s.Unread, unread)
+				}
 			}
 		}
 	}
 	if !found {
-		t.Fatalf("first sessions frame omitted %s: %s", id, data)
+		t.Fatalf("session bootstrap omitted %s", id)
 	}
 	name, data = readSSE(t, sc)
 	if name != "snapshot.world" {
-		t.Fatalf("second SSE=%q", name)
+		t.Fatalf("post-ready SSE=%q", name)
 	}
 	var world map[string]json.RawMessage
 	if err := json.Unmarshal(data, &world); err != nil {

--- a/services/gmuxd/cmd/gmuxd/serve_central.go
+++ b/services/gmuxd/cmd/gmuxd/serve_central.go
@@ -38,6 +38,7 @@ import (
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/projects"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/sessioncoord"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/sessionmeta"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/sessionstream"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/sleep"
 	central "github.com/gmuxapp/gmux/services/gmuxd/internal/snapshot/central"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/snapshot/wire"
@@ -829,18 +830,42 @@ func serveCentral(stderr io.Writer, replace bool) int {
 			w.Header().Set("Connection", "keep-alive")
 			rc := http.NewResponseController(w)
 			asPeer := r.URL.Query().Get("as") == "peer"
+			// Browser assets are served by this daemon and therefore always use
+			// protocol 3. Peers explicitly opt in; an old peer omits the marker
+			// and receives protocol 2's snapshot.sessions fallback rather than
+			// silently ignoring the new event names.
+			semanticSessions := useSemanticSessionStream(asPeer, r.URL.Query().Get("session_stream"))
 			initial, ch, cancel := fanout.Subscribe()
 			defer cancel()
 			isLocalPeer := func(name string) bool { return peerManager != nil && peerManager.IsLocalPeer(name) }
+			var sessionEpoch uint64
 			sendSessions := func(payload *wire.SessionsPayload) error {
 				if payload == nil {
 					return nil
 				}
 				if asPeer {
 					filtered := payload.FilterOwned(isLocalPeer)
-					return sendSSEFrame(rc, w, "snapshot.sessions", filtered)
+					payload = &filtered
 				}
-				return sendSSEFrame(rc, w, "snapshot.sessions", payload)
+				if !semanticSessions {
+					return sendSSEFrame(rc, w, "snapshot.sessions", payload)
+				}
+				sessionEpoch++
+				events, encodeErr := sessionstream.Encode(sessionEpoch, payload.Sessions, func(s wire.Session) string { return s.ID })
+				if encodeErr != nil {
+					log.Printf("session stream: refusing epoch %d: %v", sessionEpoch, encodeErr)
+					errorEvent := sessionstream.ErrorEvent(encodeErr)
+					if sendErr := sendSSEBytesFrame(rc, w, errorEvent.Type, errorEvent.Data); sendErr != nil {
+						return sendErr
+					}
+					return encodeErr
+				}
+				for _, event := range events {
+					if err := sendSSEBytesFrame(rc, w, event.Type, event.Data); err != nil {
+						return err
+					}
+				}
+				return nil
 			}
 			if err := sendSessions(initial.Sessions); err != nil {
 				return

--- a/services/gmuxd/cmd/gmuxd/serve_central.go
+++ b/services/gmuxd/cmd/gmuxd/serve_central.go
@@ -830,10 +830,9 @@ func serveCentral(stderr io.Writer, replace bool) int {
 			w.Header().Set("Connection", "keep-alive")
 			rc := http.NewResponseController(w)
 			asPeer := r.URL.Query().Get("as") == "peer"
-			// Browser assets are served by this daemon and therefore always use
-			// protocol 3. Peers explicitly opt in; an old peer omits the marker
-			// and receives protocol 2's snapshot.sessions fallback rather than
-			// silently ignoring the new event names.
+			// Protocol 3 is explicit for every consumer. The current browser adds
+			// the marker; an old tab, peer, or custom consumer omits it and gets
+			// protocol 2 for one transitional release.
 			semanticSessions := useSemanticSessionStream(asPeer, r.URL.Query().Get("session_stream"))
 			initial, ch, cancel := fanout.Subscribe()
 			defer cancel()
@@ -853,19 +852,9 @@ func serveCentral(stderr io.Writer, replace bool) int {
 				sessionEpoch++
 				events, encodeErr := sessionstream.Encode(sessionEpoch, payload.Sessions, func(s wire.Session) string { return s.ID })
 				if encodeErr != nil {
-					log.Printf("session stream: refusing epoch %d: %v", sessionEpoch, encodeErr)
-					errorEvent := sessionstream.ErrorEvent(encodeErr)
-					if sendErr := sendSSEBytesFrame(rc, w, errorEvent.Type, errorEvent.Data); sendErr != nil {
-						return sendErr
-					}
 					return encodeErr
 				}
-				for _, event := range events {
-					if err := sendSSEBytesFrame(rc, w, event.Type, event.Data); err != nil {
-						return err
-					}
-				}
-				return nil
+				return sendSSETransaction(r.Context(), rc, w, events)
 			}
 			if err := sendSessions(initial.Sessions); err != nil {
 				return
@@ -880,7 +869,7 @@ func serveCentral(stderr io.Writer, replace bool) int {
 					h.Sessions = counts
 					initial.World.Health = &h
 				}
-				if err := sendSSEFrame(rc, w, "snapshot.world", initial.World); err != nil {
+				if err := sendWorldSSEFrame(rc, w, initial.World); err != nil {
 					return
 				}
 			}
@@ -919,7 +908,7 @@ func serveCentral(stderr io.Writer, replace bool) int {
 						continue
 					}
 					if msg.Frames.World != nil {
-						if err := sendSSEFrame(rc, w, "snapshot.world", msg.Frames.World); err != nil {
+						if err := sendWorldSSEFrame(rc, w, msg.Frames.World); err != nil {
 							return
 						}
 					}

--- a/services/gmuxd/cmd/gmuxd/serve_central.go
+++ b/services/gmuxd/cmd/gmuxd/serve_central.go
@@ -869,7 +869,7 @@ func serveCentral(stderr io.Writer, replace bool) int {
 					h.Sessions = counts
 					initial.World.Health = &h
 				}
-				if err := sendWorldSSEFrame(rc, w, initial.World); err != nil {
+				if err := sendSSEFrame(rc, w, "snapshot.world", initial.World); err != nil {
 					return
 				}
 			}
@@ -908,7 +908,7 @@ func serveCentral(stderr io.Writer, replace bool) int {
 						continue
 					}
 					if msg.Frames.World != nil {
-						if err := sendWorldSSEFrame(rc, w, msg.Frames.World); err != nil {
+						if err := sendSSEFrame(rc, w, "snapshot.world", msg.Frames.World); err != nil {
 							return
 						}
 					}

--- a/services/gmuxd/cmd/gmuxd/serve_switch_integration_test.go
+++ b/services/gmuxd/cmd/gmuxd/serve_switch_integration_test.go
@@ -255,10 +255,21 @@ func TestServeCentralWaitsForConvergenceBeforeListenersAndServesSQLiteState(t *t
 	defer resp.Body.Close()
 	scanner := bufio.NewScanner(resp.Body)
 	event, data := readFirstSSEEvent(t, scanner)
-	if event != "snapshot.sessions" {
-		t.Fatalf("first SSE event=%q, want snapshot.sessions", event)
+	if event != "snapshot.sessions.begin" {
+		t.Fatalf("first SSE event=%q, want snapshot.sessions.begin", event)
+	}
+	var begin struct {
+		Epoch uint64 `json:"epoch"`
+	}
+	if err := json.Unmarshal(data, &begin); err != nil || begin.Epoch == 0 {
+		t.Fatalf("bad begin: %s (%v)", data, err)
+	}
+	event, data = readFirstSSEEvent(t, scanner)
+	if event != "snapshot.sessions.batch" {
+		t.Fatalf("second SSE event=%q, want snapshot.sessions.batch", event)
 	}
 	var sessionsFrame struct {
+		Epoch    uint64 `json:"epoch"`
 		Sessions []struct {
 			ID string `json:"id"`
 		} `json:"sessions"`
@@ -266,12 +277,22 @@ func TestServeCentralWaitsForConvergenceBeforeListenersAndServesSQLiteState(t *t
 	if err := json.Unmarshal(data, &sessionsFrame); err != nil {
 		t.Fatal(err)
 	}
-	if len(sessionsFrame.Sessions) != 1 || sessionsFrame.Sessions[0].ID != "1dehpbm1" {
-		t.Fatalf("unexpected snapshot.sessions frame: %s", data)
+	if sessionsFrame.Epoch != begin.Epoch || len(sessionsFrame.Sessions) != 1 || sessionsFrame.Sessions[0].ID != "1dehpbm1" {
+		t.Fatalf("unexpected snapshot.sessions.batch frame: %s", data)
+	}
+	event, data = readFirstSSEEvent(t, scanner)
+	if event != "snapshot.sessions.ready" {
+		t.Fatalf("third SSE event=%q, want snapshot.sessions.ready", event)
+	}
+	var ready struct {
+		Epoch uint64 `json:"epoch"`
+	}
+	if err := json.Unmarshal(data, &ready); err != nil || ready.Epoch != begin.Epoch {
+		t.Fatalf("bad ready: %s (%v)", data, err)
 	}
 	event, data = readFirstSSEEvent(t, scanner)
 	if event != "snapshot.world" {
-		t.Fatalf("second SSE event=%q, want matched snapshot.world", event)
+		t.Fatalf("fourth SSE event=%q, want matched snapshot.world", event)
 	}
 	var worldFrame map[string]json.RawMessage
 	if err := json.Unmarshal(data, &worldFrame); err != nil {

--- a/services/gmuxd/cmd/gmuxd/serve_switch_integration_test.go
+++ b/services/gmuxd/cmd/gmuxd/serve_switch_integration_test.go
@@ -346,9 +346,13 @@ func TestServeCentralWaitsForConvergenceBeforeListenersAndServesSQLiteState(t *t
 	}
 	legacyScanner := bufio.NewScanner(legacyResp.Body)
 	legacyEvent, _ := readFirstSSEEvent(t, legacyScanner)
-	legacyResp.Body.Close()
 	if legacyEvent != "snapshot.sessions" {
 		t.Fatalf("legacy first SSE=%q", legacyEvent)
+	}
+	legacyEvent, _ = readFirstSSEEvent(t, legacyScanner)
+	legacyResp.Body.Close()
+	if legacyEvent != "snapshot.world" {
+		t.Fatalf("legacy second SSE=%q", legacyEvent)
 	}
 
 	if !unixipc.Shutdown(sock) {

--- a/services/gmuxd/cmd/gmuxd/serve_switch_integration_test.go
+++ b/services/gmuxd/cmd/gmuxd/serve_switch_integration_test.go
@@ -244,7 +244,7 @@ func TestServeCentralWaitsForConvergenceBeforeListenersAndServesSQLiteState(t *t
 		t.Fatalf("invalid PUT changed catalog: %+v", catalog.Projects)
 	}
 
-	req, err := http.NewRequest(http.MethodGet, "http://localhost/v1/events", nil)
+	req, err := http.NewRequest(http.MethodGet, "http://localhost/v1/events?session_stream=3", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -332,6 +332,23 @@ func TestServeCentralWaitsForConvergenceBeforeListenersAndServesSQLiteState(t *t
 	}
 	if defLauncher != "shell" {
 		t.Fatalf("snapshot.world default_launcher=%q, want shell: %s", defLauncher, data)
+	}
+
+	// One-release compatibility: an old tab/custom consumer sends no marker
+	// and must still receive the event name it understands.
+	legacyReq, err := http.NewRequest(http.MethodGet, "http://localhost/v1/events", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacyResp, err := client.Do(legacyReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacyScanner := bufio.NewScanner(legacyResp.Body)
+	legacyEvent, _ := readFirstSSEEvent(t, legacyScanner)
+	legacyResp.Body.Close()
+	if legacyEvent != "snapshot.sessions" {
+		t.Fatalf("legacy first SSE=%q", legacyEvent)
 	}
 
 	if !unixipc.Shutdown(sock) {

--- a/services/gmuxd/cmd/gmuxd/session_stream_boundary_test.go
+++ b/services/gmuxd/cmd/gmuxd/session_stream_boundary_test.go
@@ -3,9 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"net/http"
-	"net/http/httptest"
-	"strings"
 	"testing"
 	"time"
 
@@ -63,46 +60,14 @@ func realisticThousandSessionWorld() wire.WorldPayload {
 	}
 }
 
-func TestRealisticComposedWorldBoundAtTransportSeam(t *testing.T) {
-	world := realisticThousandSessionWorld()
-	data, err := json.Marshal(world)
+func TestRealisticComposedWorldSizeCharacterization(t *testing.T) {
+	// Characterization only: this session-bootstrap PR intentionally does not
+	// impose a world maximum or claim world transport framing.
+	data, err := json.Marshal(realisticThousandSessionWorld())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(data) > maxWorldEventPayload {
-		t.Fatalf("realistic world=%d limit=%d", len(data), maxWorldEventPayload)
-	}
-
-	recorder := httptest.NewRecorder()
-	if err := sendWorldSSEFrame(http.NewResponseController(recorder), recorder, &world); err != nil {
-		t.Fatal(err)
-	}
-	for _, line := range strings.Split(recorder.Body.String(), "\n") {
-		if len(line) > maxWorldEventPayload+len("data: ") {
-			t.Fatalf("transport line=%d", len(line))
-		}
-	}
-	if !strings.Contains(recorder.Body.String(), "event: snapshot.world\n") {
-		t.Fatal("world event not emitted")
-	}
-	t.Logf("realistic composed 1000-session world payload=%d, explicit limit=%d", len(data), maxWorldEventPayload)
-}
-
-func TestOversizedWorldEmitsBoundedDiagnosticNotPayload(t *testing.T) {
-	world := wire.WorldPayload{Projects: []wire.ProjectItem{{Slug: strings.Repeat("x", maxWorldEventPayload)}}}
-	recorder := httptest.NewRecorder()
-	if err := sendWorldSSEFrame(http.NewResponseController(recorder), recorder, &world); err != nil {
-		t.Fatal(err)
-	}
-	body := recorder.Body.String()
-	if !strings.Contains(body, "event: snapshot.world.error\n") || strings.Contains(body, "event: snapshot.world\n") {
-		t.Fatalf("unexpected transport output prefix: %.120s", body)
-	}
-	for _, line := range strings.Split(body, "\n") {
-		if len(line) > 1024 {
-			t.Fatalf("diagnostic line unexpectedly large: %d", len(line))
-		}
-	}
+	t.Logf("realistic composed 1000-session world payload=%d", len(data))
 }
 
 // Subscribe captures the baseline and installs the subscriber under the same

--- a/services/gmuxd/cmd/gmuxd/session_stream_boundary_test.go
+++ b/services/gmuxd/cmd/gmuxd/session_stream_boundary_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/sessionstream"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/snapshot/wire"
+)
+
+// Subscribe captures the baseline and installs the subscriber under the same
+// mutex BroadcastFrames uses. This deterministic boundary is what lets the
+// handler finish baseline epoch N and then deliver a concurrently committed
+// replacement as epoch N+1 without a lost mutation.
+func TestSessionStreamVersionCompatibility(t *testing.T) {
+	if !useSemanticSessionStream(false, "") {
+		t.Fatal("version-locked browser must receive protocol 3")
+	}
+	if useSemanticSessionStream(true, "") {
+		t.Fatal("old peer must receive legacy fallback")
+	}
+	if !useSemanticSessionStream(true, "3") {
+		t.Fatal("new peer did not opt into protocol 3")
+	}
+	if useSemanticSessionStream(true, "99") {
+		t.Fatal("unknown peer protocol must not be guessed")
+	}
+}
+
+func TestThousandSessionWorldIsSeparateAndBounded(t *testing.T) {
+	ids := make([]string, 1000)
+	for i := range ids {
+		ids[i] = fmt.Sprintf("%08x", i)
+	}
+	world := wire.WorldPayload{Projects: []wire.ProjectItem{{Slug: "large", Sessions: ids}}}
+	data, err := json.Marshal(world)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(data) > sessionstream.MaxEventPayload {
+		t.Fatalf("snapshot.world payload=%d exceeds session event budget=%d", len(data), sessionstream.MaxEventPayload)
+	}
+	if string(data) == "" {
+		t.Fatal("empty world encoding")
+	}
+	t.Logf("1000-session snapshot.world payload=%d (membership IDs only; no session rows)", len(data))
+}
+
+func TestFanoutSubscribeSnapshotBoundary(t *testing.T) {
+	f := newSSEFanout()
+	f.BroadcastFrames(wire.Frames{Sessions: &wire.SessionsPayload{Sessions: []wire.Session{{ID: "before"}}}})
+	initial, ch, cancel := f.Subscribe()
+	defer cancel()
+	if got := initial.Sessions.Sessions[0].ID; got != "before" {
+		t.Fatalf("initial=%q", got)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		f.BroadcastFrames(wire.Frames{Sessions: &wire.SessionsPayload{Sessions: []wire.Session{{ID: "after"}}}})
+		close(done)
+	}()
+	select {
+	case msg := <-ch:
+		if got := msg.Frames.Sessions.Sessions[0].ID; got != "after" {
+			t.Fatalf("queued=%q", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("mutation after subscribe was lost")
+	}
+	<-done
+}

--- a/services/gmuxd/cmd/gmuxd/session_stream_boundary_test.go
+++ b/services/gmuxd/cmd/gmuxd/session_stream_boundary_test.go
@@ -3,20 +3,23 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
-	"github.com/gmuxapp/gmux/services/gmuxd/internal/sessionstream"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/peering"
+	central "github.com/gmuxapp/gmux/services/gmuxd/internal/snapshot/central"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/snapshot/wire"
 )
 
-// Subscribe captures the baseline and installs the subscriber under the same
-// mutex BroadcastFrames uses. This deterministic boundary is what lets the
-// handler finish baseline epoch N and then deliver a concurrently committed
-// replacement as epoch N+1 without a lost mutation.
 func TestSessionStreamVersionCompatibility(t *testing.T) {
-	if !useSemanticSessionStream(false, "") {
-		t.Fatal("version-locked browser must receive protocol 3")
+	if useSemanticSessionStream(false, "") {
+		t.Fatal("unversioned browser/custom consumer must receive transitional legacy stream")
+	}
+	if !useSemanticSessionStream(false, "3") {
+		t.Fatal("new browser did not opt into protocol 3")
 	}
 	if useSemanticSessionStream(true, "") {
 		t.Fatal("old peer must receive legacy fallback")
@@ -29,25 +32,83 @@ func TestSessionStreamVersionCompatibility(t *testing.T) {
 	}
 }
 
-func TestThousandSessionWorldIsSeparateAndBounded(t *testing.T) {
-	ids := make([]string, 1000)
-	for i := range ids {
-		ids[i] = fmt.Sprintf("%08x", i)
+func realisticThousandSessionWorld() wire.WorldPayload {
+	projects := make([]wire.ProjectItem, 50)
+	for i := range projects {
+		ids := make([]string, 20)
+		for j := range ids {
+			ids[j] = fmt.Sprintf("%08x", i*20+j)
+		}
+		projects[i] = wire.ProjectItem{
+			Slug:     fmt.Sprintf("project-%02d", i),
+			Match:    []wire.MatchRule{{Path: fmt.Sprintf("/home/user/dev/project-%02d", i)}, {Remote: fmt.Sprintf("github.com/example/project-%02d", i), Exact: true}},
+			Sessions: ids,
+			NodeID:   "node-local",
+		}
 	}
-	world := wire.WorldPayload{Projects: []wire.ProjectItem{{Slug: "large", Sessions: ids}}}
+	peers := make([]peering.PeerInfo, 20)
+	peerProjects := make(map[string][]peering.SpokeProject, len(peers))
+	peerDiscovered := make(map[string][]peering.SpokeDiscovered, len(peers))
+	for i := range peers {
+		name := fmt.Sprintf("peer-%02d", i)
+		peers[i] = peering.PeerInfo{Name: name, URL: "https://" + name + ".example", Status: "connected", SessionCount: 50, Version: "2.1.0", NodeID: "node-" + name}
+		peerProjects[name] = []peering.SpokeProject{{Slug: "gmux", LaunchCwd: "/home/user/dev/gmux"}}
+		peerDiscovered[name] = []peering.SpokeDiscovered{{SuggestedSlug: "work", Remote: "github.com/example/work", Paths: []string{"/home/user/work"}, SessionCount: 3, ActiveCount: 1}}
+	}
+	launchers := []peering.LauncherDef{{ID: "shell", Label: "Shell", Command: []string{"gmux", "new"}, Available: true}, {ID: "pi", Label: "Pi", Command: []string{"gmux", "agent"}, Available: true}}
+	return wire.WorldPayload{
+		Projects: projects, Peers: peers,
+		Health:    &central.HealthInfo{Service: "gmuxd", Version: "2.1.0", NodeID: "node-local", Status: "ready", Hostname: "workstation", Sessions: central.SessionCounts{LocalAlive: 667, Dead: 333}},
+		Launchers: launchers, DefaultLauncher: "shell", PeerProjects: peerProjects, PeerDiscovered: peerDiscovered,
+	}
+}
+
+func TestRealisticComposedWorldBoundAtTransportSeam(t *testing.T) {
+	world := realisticThousandSessionWorld()
 	data, err := json.Marshal(world)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(data) > sessionstream.MaxEventPayload {
-		t.Fatalf("snapshot.world payload=%d exceeds session event budget=%d", len(data), sessionstream.MaxEventPayload)
+	if len(data) > maxWorldEventPayload {
+		t.Fatalf("realistic world=%d limit=%d", len(data), maxWorldEventPayload)
 	}
-	if string(data) == "" {
-		t.Fatal("empty world encoding")
+
+	recorder := httptest.NewRecorder()
+	if err := sendWorldSSEFrame(http.NewResponseController(recorder), recorder, &world); err != nil {
+		t.Fatal(err)
 	}
-	t.Logf("1000-session snapshot.world payload=%d (membership IDs only; no session rows)", len(data))
+	for _, line := range strings.Split(recorder.Body.String(), "\n") {
+		if len(line) > maxWorldEventPayload+len("data: ") {
+			t.Fatalf("transport line=%d", len(line))
+		}
+	}
+	if !strings.Contains(recorder.Body.String(), "event: snapshot.world\n") {
+		t.Fatal("world event not emitted")
+	}
+	t.Logf("realistic composed 1000-session world payload=%d, explicit limit=%d", len(data), maxWorldEventPayload)
 }
 
+func TestOversizedWorldEmitsBoundedDiagnosticNotPayload(t *testing.T) {
+	world := wire.WorldPayload{Projects: []wire.ProjectItem{{Slug: strings.Repeat("x", maxWorldEventPayload)}}}
+	recorder := httptest.NewRecorder()
+	if err := sendWorldSSEFrame(http.NewResponseController(recorder), recorder, &world); err != nil {
+		t.Fatal(err)
+	}
+	body := recorder.Body.String()
+	if !strings.Contains(body, "event: snapshot.world.error\n") || strings.Contains(body, "event: snapshot.world\n") {
+		t.Fatalf("unexpected transport output prefix: %.120s", body)
+	}
+	for _, line := range strings.Split(body, "\n") {
+		if len(line) > 1024 {
+			t.Fatalf("diagnostic line unexpectedly large: %d", len(line))
+		}
+	}
+}
+
+// Subscribe captures the baseline and installs the subscriber under the same
+// mutex BroadcastFrames uses. This deterministic boundary is what lets the
+// handler finish baseline epoch N and then deliver a concurrently committed
+// replacement as epoch N+1 without a lost mutation.
 func TestFanoutSubscribeSnapshotBoundary(t *testing.T) {
 	f := newSSEFanout()
 	f.BroadcastFrames(wire.Frames{Sessions: &wire.SessionsPayload{Sessions: []wire.Session{{ID: "before"}}}})

--- a/services/gmuxd/cmd/gmuxd/sse_transaction_test.go
+++ b/services/gmuxd/cmd/gmuxd/sse_transaction_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/sessionstream"
+)
+
+type transactionWriter struct {
+	header    http.Header
+	body      bytes.Buffer
+	deadlines []time.Time
+	flushes   int
+	onFlush   func(int)
+}
+
+func (w *transactionWriter) Header() http.Header {
+	if w.header == nil {
+		w.header = make(http.Header)
+	}
+	return w.header
+}
+func (*transactionWriter) WriteHeader(int)               {}
+func (w *transactionWriter) Write(p []byte) (int, error) { return w.body.Write(p) }
+func (w *transactionWriter) SetWriteDeadline(deadline time.Time) error {
+	w.deadlines = append(w.deadlines, deadline)
+	return nil
+}
+func (w *transactionWriter) FlushError() error {
+	w.flushes++
+	if w.onFlush != nil {
+		w.onFlush(w.flushes)
+	}
+	return nil
+}
+
+func TestSessionTransactionUsesOneDeadlineAndChecksCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	w := &transactionWriter{onFlush: func(n int) {
+		if n == 1 {
+			cancel()
+		}
+	}}
+	events := []sessionstream.Event{{Type: "one", Data: []byte(`{"n":1}`)}, {Type: "two", Data: []byte(`{"n":2}`)}}
+	err := sendSSETransaction(ctx, http.NewResponseController(w), w, events)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err=%v", err)
+	}
+	if w.flushes != 1 || bytes.Contains(w.body.Bytes(), []byte("event: two")) {
+		t.Fatalf("flushes=%d body=%s", w.flushes, w.body.String())
+	}
+	if len(w.deadlines) != 2 || w.deadlines[0].IsZero() || !w.deadlines[1].IsZero() {
+		t.Fatalf("deadlines=%v, want one transaction deadline then clear", w.deadlines)
+	}
+}

--- a/services/gmuxd/internal/apiclient/client.go
+++ b/services/gmuxd/internal/apiclient/client.go
@@ -127,9 +127,12 @@ func (c *Client) Events() *sseclient.Client {
 		opts = append(opts, sseclient.WithIdleTimeout(c.streamIdleTimeout))
 	}
 	// `?as=peer` instructs the spoke to filter to owned sessions and
-	// suppress snapshot.world (ADR 0001). The hub composes its own
-	// world view from local state and union of peer feeds.
-	return sseclient.New(c.baseURL+"/v1/events?as=peer", opts...)
+	// suppress snapshot.world (ADR 0001). session_stream=3 explicitly opts
+	// into bounded begin/batch/ready framing. Old daemons ignore the unknown
+	// parameter and continue sending snapshot.sessions, which this client
+	// still accepts; new daemons use the absence of the marker to serve old
+	// peers their legacy fallback.
+	return sseclient.New(c.baseURL+"/v1/events?as=peer&session_stream=3", opts...)
 }
 
 // GetHealth fetches GET /v1/health and returns the Data field of the

--- a/services/gmuxd/internal/apiclient/session_stream_test.go
+++ b/services/gmuxd/internal/apiclient/session_stream_test.go
@@ -1,0 +1,28 @@
+package apiclient
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/sseclient"
+)
+
+func TestEventsExplicitlyNegotiatesBoundedSessionStream(t *testing.T) {
+	var as, stream string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		as = r.URL.Query().Get("as")
+		stream = r.URL.Query().Get("session_stream")
+		w.Header().Set("Content-Type", "text/event-stream")
+	}))
+	defer server.Close()
+	err := New(server.URL).Events().Subscribe(context.Background(), nil, func(sseclient.Event) {})
+	if !errors.Is(err, sseclient.ErrStreamEnded) {
+		t.Fatalf("Subscribe=%v", err)
+	}
+	if as != "peer" || stream != "3" {
+		t.Fatalf("query as=%q session_stream=%q", as, stream)
+	}
+}

--- a/services/gmuxd/internal/peering/peer.go
+++ b/services/gmuxd/internal/peering/peer.go
@@ -473,32 +473,48 @@ type sseSnapshotSessions struct {
 }
 
 type peerSessionBootstrap struct {
-	epoch  uint64
-	active bool
-	rows   []SessionProjection
-	bytes  int
+	epoch     uint64
+	lastEpoch uint64
+	active    bool
+	rows      []SessionProjection
+	bytes     int
+}
+
+func (s *peerSessionBootstrap) abandon() {
+	s.epoch = 0
+	s.active = false
+	s.rows = nil
+	s.bytes = 0
 }
 
 func (p *Peer) handleStreamEvent(ctx context.Context, eventType string, data []byte, staging *peerSessionBootstrap) {
 	switch eventType {
 	case sessionstream.EventBegin:
 		var begin sessionstream.Begin
-		if err := json.Unmarshal(data, &begin); err != nil || begin.Version != sessionstream.ProtocolVersion {
-			*staging = peerSessionBootstrap{}
+		if err := json.Unmarshal(data, &begin); err != nil || begin.Version != sessionstream.ProtocolVersion || begin.Epoch == 0 {
+			staging.abandon()
 			log.Printf("peering: %s: bad session bootstrap begin", p.Config.Name)
 			return
 		}
-		*staging = peerSessionBootstrap{epoch: begin.Epoch, active: true}
+		if begin.Epoch <= staging.lastEpoch {
+			// Ignore replay without destroying a newer in-flight transaction.
+			log.Printf("peering: %s: stale session bootstrap epoch %d (last %d)", p.Config.Name, begin.Epoch, staging.lastEpoch)
+			return
+		}
+		staging.abandon()
+		staging.epoch = begin.Epoch
+		staging.lastEpoch = begin.Epoch
+		staging.active = true
 		return
 	case sessionstream.EventBatch:
 		var batch sessionstream.Batch[SessionProjection]
 		if err := json.Unmarshal(data, &batch); err != nil || !staging.active || batch.Epoch != staging.epoch {
-			*staging = peerSessionBootstrap{}
+			staging.abandon()
 			log.Printf("peering: %s: bad or out-of-epoch session bootstrap batch", p.Config.Name)
 			return
 		}
 		if len(staging.rows)+len(batch.Sessions) > sessionstream.MaxStagedRows || staging.bytes+len(data) > sessionstream.MaxStagedBytes {
-			*staging = peerSessionBootstrap{}
+			staging.abandon()
 			log.Printf("peering: %s: session bootstrap exceeds staging limit", p.Config.Name)
 			return
 		}
@@ -508,17 +524,30 @@ func (p *Peer) handleStreamEvent(ctx context.Context, eventType string, data []b
 	case sessionstream.EventReady:
 		var ready sessionstream.Ready
 		if err := json.Unmarshal(data, &ready); err != nil || !staging.active || ready.Epoch != staging.epoch {
-			*staging = peerSessionBootstrap{}
+			staging.abandon()
 			log.Printf("peering: %s: bad or out-of-epoch session bootstrap ready", p.Config.Name)
 			return
 		}
 		rows := staging.rows
-		*staging = peerSessionBootstrap{}
+		staging.abandon()
 		p.applySessionsSnapshot(rows)
 		return
 	case sessionstream.EventError:
-		*staging = peerSessionBootstrap{}
-		log.Printf("peering: %s: spoke rejected session bootstrap: %s", p.Config.Name, data)
+		// Diagnostics quarantine individual rows; they do not invalidate the
+		// transaction or prevent the remaining rows from reaching ready.
+		var diagnostic sessionstream.Error
+		if err := json.Unmarshal(data, &diagnostic); err != nil {
+			log.Printf("peering: %s: bad session bootstrap diagnostic", p.Config.Name)
+			return
+		}
+		id, message := diagnostic.ID, diagnostic.Message
+		if len(id) > 256 {
+			id = id[:256] + "…"
+		}
+		if len(message) > 512 {
+			message = message[:512] + "…"
+		}
+		log.Printf("peering: %s: session %q omitted: %q (%s)", p.Config.Name, id, message, diagnostic.Code)
 		return
 	case "snapshot.sessions":
 		// Protocol-2 response from an older spoke. It is authoritative and

--- a/services/gmuxd/internal/peering/peer.go
+++ b/services/gmuxd/internal/peering/peer.go
@@ -472,12 +472,23 @@ type sseSnapshotSessions struct {
 	Sessions []SessionProjection `json:"sessions"`
 }
 
+type sessionStreamMode uint8
+
+const (
+	sessionStreamUnknown sessionStreamMode = iota
+	sessionStreamLegacy
+	sessionStreamV3
+	maxPeerSessionDiagnostics = 256
+)
+
 type peerSessionBootstrap struct {
-	epoch     uint64
-	lastEpoch uint64
-	active    bool
-	rows      []SessionProjection
-	bytes     int
+	mode        sessionStreamMode
+	epoch       uint64
+	lastEpoch   uint64
+	active      bool
+	rows        []SessionProjection
+	bytes       int
+	diagnostics []sessionstream.Error
 }
 
 func (s *peerSessionBootstrap) abandon() {
@@ -485,11 +496,16 @@ func (s *peerSessionBootstrap) abandon() {
 	s.active = false
 	s.rows = nil
 	s.bytes = 0
+	s.diagnostics = nil
 }
 
 func (p *Peer) handleStreamEvent(ctx context.Context, eventType string, data []byte, staging *peerSessionBootstrap) {
 	switch eventType {
 	case sessionstream.EventBegin:
+		if staging.mode == sessionStreamLegacy {
+			log.Printf("peering: %s: ignoring protocol-3 begin on legacy session stream", p.Config.Name)
+			return
+		}
 		var begin sessionstream.Begin
 		if err := json.Unmarshal(data, &begin); err != nil || begin.Version != sessionstream.ProtocolVersion || begin.Epoch == 0 {
 			staging.abandon()
@@ -502,6 +518,7 @@ func (p *Peer) handleStreamEvent(ctx context.Context, eventType string, data []b
 			return
 		}
 		staging.abandon()
+		staging.mode = sessionStreamV3
 		staging.epoch = begin.Epoch
 		staging.lastEpoch = begin.Epoch
 		staging.active = true
@@ -547,12 +564,26 @@ func (p *Peer) handleStreamEvent(ctx context.Context, eventType string, data []b
 		if len(message) > 512 {
 			message = message[:512] + "…"
 		}
-		log.Printf("peering: %s: session %q omitted: %q (%s)", p.Config.Name, id, message, diagnostic.Code)
+		diagnostic.ID, diagnostic.Message = id, message
+		if staging.active && diagnostic.Epoch == staging.epoch && len(staging.diagnostics) < maxPeerSessionDiagnostics {
+			staging.diagnostics = append(staging.diagnostics, diagnostic)
+		}
+		log.Printf("peering: %s: session %q omitted: %q (%s, count=%d)", p.Config.Name, id, message, diagnostic.Code, max(diagnostic.Count, 1))
 		return
 	case "snapshot.sessions":
-		// Protocol-2 response from an older spoke. It is authoritative and
-		// cannot be combined with a partial protocol-3 transaction.
-		*staging = peerSessionBootstrap{}
+		if staging.mode == sessionStreamV3 {
+			log.Printf("peering: %s: ignoring legacy snapshot on protocol-3 session stream", p.Config.Name)
+			return
+		}
+		var payload sseSnapshotSessions
+		if err := json.Unmarshal(data, &payload); err != nil {
+			log.Printf("peering: %s: bad snapshot.sessions: %v", p.Config.Name, err)
+			return
+		}
+		staging.abandon()
+		staging.mode = sessionStreamLegacy
+		p.applySessionsSnapshot(payload.Sessions)
+		return
 	}
 	p.handleEvent(ctx, eventType, data)
 }

--- a/services/gmuxd/internal/peering/peer.go
+++ b/services/gmuxd/internal/peering/peer.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/apiclient"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/config"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/sessionstream"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/sseclient"
 )
 
@@ -421,6 +422,9 @@ func (p *Peer) run(ctx context.Context) {
 // established (used to decide whether to reset backoff).
 func (p *Peer) subscribe(ctx context.Context, onConnected func()) error {
 	sse := p.api.Events()
+	// Staging belongs to one transport connection. If it disconnects before
+	// ready, this local value disappears and no partial projection is visible.
+	var bootstrap peerSessionBootstrap
 
 	err := sse.Subscribe(ctx,
 		func() {
@@ -437,7 +441,7 @@ func (p *Peer) subscribe(ctx context.Context, onConnected func()) error {
 			p.fetchProjects(ctx)
 		},
 		func(ev sseclient.Event) {
-			p.handleEvent(ctx, ev.Type, ev.Data)
+			p.handleStreamEvent(ctx, ev.Type, ev.Data, &bootstrap)
 		},
 	)
 
@@ -466,6 +470,62 @@ type sseActivity struct {
 // sseSnapshotSessions is the wire format for snapshot.sessions.
 type sseSnapshotSessions struct {
 	Sessions []SessionProjection `json:"sessions"`
+}
+
+type peerSessionBootstrap struct {
+	epoch  uint64
+	active bool
+	rows   []SessionProjection
+	bytes  int
+}
+
+func (p *Peer) handleStreamEvent(ctx context.Context, eventType string, data []byte, staging *peerSessionBootstrap) {
+	switch eventType {
+	case sessionstream.EventBegin:
+		var begin sessionstream.Begin
+		if err := json.Unmarshal(data, &begin); err != nil || begin.Version != sessionstream.ProtocolVersion {
+			*staging = peerSessionBootstrap{}
+			log.Printf("peering: %s: bad session bootstrap begin", p.Config.Name)
+			return
+		}
+		*staging = peerSessionBootstrap{epoch: begin.Epoch, active: true}
+		return
+	case sessionstream.EventBatch:
+		var batch sessionstream.Batch[SessionProjection]
+		if err := json.Unmarshal(data, &batch); err != nil || !staging.active || batch.Epoch != staging.epoch {
+			*staging = peerSessionBootstrap{}
+			log.Printf("peering: %s: bad or out-of-epoch session bootstrap batch", p.Config.Name)
+			return
+		}
+		if len(staging.rows)+len(batch.Sessions) > sessionstream.MaxStagedRows || staging.bytes+len(data) > sessionstream.MaxStagedBytes {
+			*staging = peerSessionBootstrap{}
+			log.Printf("peering: %s: session bootstrap exceeds staging limit", p.Config.Name)
+			return
+		}
+		staging.rows = append(staging.rows, batch.Sessions...)
+		staging.bytes += len(data)
+		return
+	case sessionstream.EventReady:
+		var ready sessionstream.Ready
+		if err := json.Unmarshal(data, &ready); err != nil || !staging.active || ready.Epoch != staging.epoch {
+			*staging = peerSessionBootstrap{}
+			log.Printf("peering: %s: bad or out-of-epoch session bootstrap ready", p.Config.Name)
+			return
+		}
+		rows := staging.rows
+		*staging = peerSessionBootstrap{}
+		p.applySessionsSnapshot(rows)
+		return
+	case sessionstream.EventError:
+		*staging = peerSessionBootstrap{}
+		log.Printf("peering: %s: spoke rejected session bootstrap: %s", p.Config.Name, data)
+		return
+	case "snapshot.sessions":
+		// Protocol-2 response from an older spoke. It is authoritative and
+		// cannot be combined with a partial protocol-3 transaction.
+		*staging = peerSessionBootstrap{}
+	}
+	p.handleEvent(ctx, eventType, data)
 }
 
 // isForwardedFromKnownOrigin checks whether a session ID (before

--- a/services/gmuxd/internal/peering/session_stream_test.go
+++ b/services/gmuxd/internal/peering/session_stream_test.go
@@ -109,7 +109,10 @@ func TestPeerDiagnosticDoesNotInvalidateReady(t *testing.T) {
 	ctx := context.Background()
 	p.handleStreamEvent(ctx, sessionstream.EventBegin, streamData(t, sessionstream.Begin{Version: 3, Epoch: 1}), &stage)
 	p.handleStreamEvent(ctx, sessionstream.EventBatch, streamData(t, sessionstream.Batch[SessionProjection]{Epoch: 1, Sessions: []SessionProjection{{ID: "good"}}}), &stage)
-	p.handleStreamEvent(ctx, sessionstream.EventError, streamData(t, sessionstream.Error{Epoch: 1, Code: "row_too_large", ID: "bad", Message: "omitted"}), &stage)
+	p.handleStreamEvent(ctx, sessionstream.EventError, streamData(t, sessionstream.Error{Epoch: 1, Code: "row_too_large", ID: "bad", Message: "omitted", Count: 1}), &stage)
+	if len(stage.diagnostics) != 1 || stage.diagnostics[0].ID != "bad" || stage.diagnostics[0].Count != 1 {
+		t.Fatalf("retained diagnostics=%+v", stage.diagnostics)
+	}
 	p.handleStreamEvent(ctx, sessionstream.EventReady, streamData(t, sessionstream.Ready{Epoch: 1}), &stage)
 	if got := sink.replaced["spoke"]; len(got) != 1 || got[0].ID != "good@spoke" {
 		t.Fatalf("visible=%+v", got)
@@ -140,6 +143,25 @@ func TestPeerRejectsNonIncreasingEpochWithoutRollback(t *testing.T) {
 	p.handleStreamEvent(ctx, sessionstream.EventReady, streamData(t, sessionstream.Ready{Epoch: 3}), &stage)
 	if got := sink.replaced["spoke"]; len(got) != 1 || got[0].ID != "newest@spoke" {
 		t.Fatalf("in-flight epoch destroyed: %+v", got)
+	}
+}
+
+func TestPeerLocksProtocol3AgainstLegacyInjectionAndStaleReplay(t *testing.T) {
+	sink := newMockSink()
+	p := &Peer{Config: config.PeerConfig{Name: "spoke"}, sink: sink}
+	stage := peerSessionBootstrap{}
+	ctx := context.Background()
+	commit := func(epoch uint64, id string) {
+		p.handleStreamEvent(ctx, sessionstream.EventBegin, streamData(t, sessionstream.Begin{Version: 3, Epoch: epoch}), &stage)
+		p.handleStreamEvent(ctx, sessionstream.EventBatch, streamData(t, sessionstream.Batch[SessionProjection]{Epoch: epoch, Sessions: []SessionProjection{{ID: id}}}), &stage)
+		p.handleStreamEvent(ctx, sessionstream.EventReady, streamData(t, sessionstream.Ready{Epoch: epoch}), &stage)
+	}
+	commit(1, "old")
+	commit(2, "new")
+	p.handleStreamEvent(ctx, "snapshot.sessions", streamData(t, sseSnapshotSessions{Sessions: []SessionProjection{{ID: "legacy-current"}}}), &stage)
+	commit(1, "replayed-old")
+	if got := sink.replaced["spoke"]; len(got) != 1 || got[0].ID != "new@spoke" {
+		t.Fatalf("mixed-mode rollback: %+v", got)
 	}
 }
 
@@ -187,9 +209,13 @@ func TestPeerAcceptsLegacySnapshotFromOldSpoke(t *testing.T) {
 	p := &Peer{Config: config.PeerConfig{Name: "old"}, sink: sink}
 	stage := peerSessionBootstrap{active: true, epoch: 9, rows: []SessionProjection{{ID: "partial"}}}
 	p.handleStreamEvent(context.Background(), "snapshot.sessions", streamData(t, sseSnapshotSessions{Sessions: []SessionProjection{{ID: "legacy"}}}), &stage)
-	if stage.active {
-		t.Fatal("legacy replacement did not discard partial protocol-3 staging")
+	if stage.active || stage.mode != sessionStreamLegacy {
+		t.Fatalf("legacy replacement did not lock legacy mode: %+v", stage)
 	}
+	// A protocol-3 begin on the same legacy connection is ignored.
+	p.handleStreamEvent(context.Background(), sessionstream.EventBegin, streamData(t, sessionstream.Begin{Version: 3, Epoch: 1}), &stage)
+	p.handleStreamEvent(context.Background(), sessionstream.EventBatch, streamData(t, sessionstream.Batch[SessionProjection]{Epoch: 1, Sessions: []SessionProjection{{ID: "replayed"}}}), &stage)
+	p.handleStreamEvent(context.Background(), sessionstream.EventReady, streamData(t, sessionstream.Ready{Epoch: 1}), &stage)
 	got := sink.replaced["old"]
 	if len(got) != 1 || got[0].ID != "legacy@old" {
 		t.Fatalf("visible=%+v", got)

--- a/services/gmuxd/internal/peering/session_stream_test.go
+++ b/services/gmuxd/internal/peering/session_stream_test.go
@@ -3,6 +3,7 @@ package peering
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/config"
@@ -91,6 +92,94 @@ func TestPeerRejectsBootstrapBeyondAggregateMemoryBound(t *testing.T) {
 	if len(sink.replaced) != 0 {
 		t.Fatal("overflow became visible")
 	}
+	// A rejected transaction is not permanent staleness: the next strictly
+	// newer begin starts cleanly and can reach ready.
+	p.handleStreamEvent(context.Background(), sessionstream.EventBegin, streamData(t, sessionstream.Begin{Version: 3, Epoch: 2}), &stage)
+	p.handleStreamEvent(context.Background(), sessionstream.EventBatch, streamData(t, sessionstream.Batch[SessionProjection]{Epoch: 2, Sessions: []SessionProjection{{ID: "recovered"}}}), &stage)
+	p.handleStreamEvent(context.Background(), sessionstream.EventReady, streamData(t, sessionstream.Ready{Epoch: 2}), &stage)
+	if got := sink.replaced["spoke"]; len(got) != 1 || got[0].ID != "recovered@spoke" {
+		t.Fatalf("recovery=%+v", got)
+	}
+}
+
+func TestPeerDiagnosticDoesNotInvalidateReady(t *testing.T) {
+	sink := newMockSink()
+	p := &Peer{Config: config.PeerConfig{Name: "spoke"}, sink: sink}
+	stage := peerSessionBootstrap{}
+	ctx := context.Background()
+	p.handleStreamEvent(ctx, sessionstream.EventBegin, streamData(t, sessionstream.Begin{Version: 3, Epoch: 1}), &stage)
+	p.handleStreamEvent(ctx, sessionstream.EventBatch, streamData(t, sessionstream.Batch[SessionProjection]{Epoch: 1, Sessions: []SessionProjection{{ID: "good"}}}), &stage)
+	p.handleStreamEvent(ctx, sessionstream.EventError, streamData(t, sessionstream.Error{Epoch: 1, Code: "row_too_large", ID: "bad", Message: "omitted"}), &stage)
+	p.handleStreamEvent(ctx, sessionstream.EventReady, streamData(t, sessionstream.Ready{Epoch: 1}), &stage)
+	if got := sink.replaced["spoke"]; len(got) != 1 || got[0].ID != "good@spoke" {
+		t.Fatalf("visible=%+v", got)
+	}
+}
+
+func TestPeerRejectsNonIncreasingEpochWithoutRollback(t *testing.T) {
+	sink := newMockSink()
+	p := &Peer{Config: config.PeerConfig{Name: "spoke"}, sink: sink}
+	stage := peerSessionBootstrap{}
+	ctx := context.Background()
+	commit := func(epoch uint64, id string) {
+		p.handleStreamEvent(ctx, sessionstream.EventBegin, streamData(t, sessionstream.Begin{Version: 3, Epoch: epoch}), &stage)
+		p.handleStreamEvent(ctx, sessionstream.EventBatch, streamData(t, sessionstream.Batch[SessionProjection]{Epoch: epoch, Sessions: []SessionProjection{{ID: id}}}), &stage)
+		p.handleStreamEvent(ctx, sessionstream.EventReady, streamData(t, sessionstream.Ready{Epoch: epoch}), &stage)
+	}
+	commit(1, "old")
+	commit(2, "new")
+	commit(1, "replayed")
+	if got := sink.replaced["spoke"]; len(got) != 1 || got[0].ID != "new@spoke" {
+		t.Fatalf("projection rolled back: %+v", got)
+	}
+
+	// A stale begin must not destroy a newer in-flight epoch either.
+	p.handleStreamEvent(ctx, sessionstream.EventBegin, streamData(t, sessionstream.Begin{Version: 3, Epoch: 3}), &stage)
+	p.handleStreamEvent(ctx, sessionstream.EventBegin, streamData(t, sessionstream.Begin{Version: 3, Epoch: 2}), &stage)
+	p.handleStreamEvent(ctx, sessionstream.EventBatch, streamData(t, sessionstream.Batch[SessionProjection]{Epoch: 3, Sessions: []SessionProjection{{ID: "newest"}}}), &stage)
+	p.handleStreamEvent(ctx, sessionstream.EventReady, streamData(t, sessionstream.Ready{Epoch: 3}), &stage)
+	if got := sink.replaced["spoke"]; len(got) != 1 || got[0].ID != "newest@spoke" {
+		t.Fatalf("in-flight epoch destroyed: %+v", got)
+	}
+}
+
+func TestOldSpokeLargeRowIsQuarantinedWhenNewHubStreamsToBrowser(t *testing.T) {
+	sink := newMockSink()
+	p := &Peer{Config: config.PeerConfig{Name: "old"}, sink: sink}
+	large := SessionProjection{ID: "large", Command: []string{strings.Repeat("x", 60*1024)}}
+	stage := peerSessionBootstrap{}
+	p.handleStreamEvent(context.Background(), "snapshot.sessions", streamData(t, sseSnapshotSessions{Sessions: []SessionProjection{large}}), &stage)
+	mirrored := sink.replaced["old"]
+	if len(mirrored) != 1 {
+		t.Fatalf("old-spoke projection=%+v", mirrored)
+	}
+	rows := append([]SessionProjection{{ID: "local"}}, mirrored...)
+	events, err := sessionstream.Encode(1, rows, func(row SessionProjection) string { return row.ID })
+	if err != nil {
+		t.Fatal(err)
+	}
+	var batches, diagnostics, ready int
+	for _, event := range events {
+		switch event.Type {
+		case sessionstream.EventBatch:
+			batches++
+		case sessionstream.EventError:
+			diagnostics++
+		case sessionstream.EventReady:
+			ready++
+		}
+	}
+	if batches != 1 || diagnostics != 1 || ready != 1 {
+		t.Fatalf("events=%v", eventTypesForPeerTest(events))
+	}
+}
+
+func eventTypesForPeerTest(events []sessionstream.Event) []string {
+	out := make([]string, len(events))
+	for i := range events {
+		out[i] = events[i].Type
+	}
+	return out
 }
 
 func TestPeerAcceptsLegacySnapshotFromOldSpoke(t *testing.T) {

--- a/services/gmuxd/internal/peering/session_stream_test.go
+++ b/services/gmuxd/internal/peering/session_stream_test.go
@@ -1,0 +1,108 @@
+package peering
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/config"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/sessionstream"
+)
+
+func streamData(t *testing.T, value any) []byte {
+	t.Helper()
+	data, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}
+
+func TestPeerSessionBootstrapIsAtomicAndDisconnectLocal(t *testing.T) {
+	sink := newMockSink()
+	p := &Peer{Config: config.PeerConfig{Name: "spoke"}, sink: sink}
+	ctx := context.Background()
+	stage := peerSessionBootstrap{}
+
+	p.handleStreamEvent(ctx, sessionstream.EventBegin, streamData(t, sessionstream.Begin{Version: 3, Epoch: 1}), &stage)
+	p.handleStreamEvent(ctx, sessionstream.EventBatch, streamData(t, sessionstream.Batch[SessionProjection]{Epoch: 1, Sessions: []SessionProjection{{ID: "partial"}}}), &stage)
+	if _, visible := sink.replaced["spoke"]; visible {
+		t.Fatal("partial bootstrap became visible before ready")
+	}
+
+	// A disconnect drops the connection-local staging value. The next
+	// connection starts from zero and cannot complete epoch 1.
+	stage = peerSessionBootstrap{}
+	p.handleStreamEvent(ctx, sessionstream.EventReady, streamData(t, sessionstream.Ready{Epoch: 1}), &stage)
+	if _, visible := sink.replaced["spoke"]; visible {
+		t.Fatal("interrupted bootstrap became visible")
+	}
+
+	p.handleStreamEvent(ctx, sessionstream.EventBegin, streamData(t, sessionstream.Begin{Version: 3, Epoch: 1}), &stage)
+	p.handleStreamEvent(ctx, sessionstream.EventBatch, streamData(t, sessionstream.Batch[SessionProjection]{Epoch: 1, Sessions: []SessionProjection{{ID: "fresh"}}}), &stage)
+	p.handleStreamEvent(ctx, sessionstream.EventReady, streamData(t, sessionstream.Ready{Epoch: 1}), &stage)
+	got := sink.replaced["spoke"]
+	if len(got) != 1 || got[0].ID != "fresh@spoke" {
+		t.Fatalf("visible=%+v, want fresh replacement", got)
+	}
+}
+
+func TestPeerMutationEpochAppliesAfterPriorReadyExactlyOnce(t *testing.T) {
+	sink := newMockSink()
+	p := &Peer{Config: config.PeerConfig{Name: "spoke"}, sink: sink}
+	stage := peerSessionBootstrap{}
+	ctx := context.Background()
+	emit := func(epoch uint64, title string) {
+		p.handleStreamEvent(ctx, sessionstream.EventBegin, streamData(t, sessionstream.Begin{Version: 3, Epoch: epoch}), &stage)
+		p.handleStreamEvent(ctx, sessionstream.EventBatch, streamData(t, sessionstream.Batch[SessionProjection]{Epoch: epoch, Sessions: []SessionProjection{{ID: "s", Title: title}}}), &stage)
+	}
+	emit(1, "before")
+	if len(sink.replaced) != 0 {
+		t.Fatal("rows visible before first ready")
+	}
+	p.handleStreamEvent(ctx, sessionstream.EventReady, streamData(t, sessionstream.Ready{Epoch: 1}), &stage)
+	if got := sink.replaced["spoke"]; len(got) != 1 || got[0].Title != "before" {
+		t.Fatalf("first visible=%+v", got)
+	}
+
+	// A mutation captured by the fanout while epoch 1 was being written is
+	// queued as epoch 2. It cannot overtake epoch 1's ready and stays staged
+	// until its own ready.
+	emit(2, "after")
+	if got := sink.replaced["spoke"]; got[0].Title != "before" {
+		t.Fatalf("mutation exposed before ready: %+v", got)
+	}
+	p.handleStreamEvent(ctx, sessionstream.EventReady, streamData(t, sessionstream.Ready{Epoch: 2}), &stage)
+	got := sink.replaced["spoke"]
+	if len(got) != 1 || got[0].Title != "after" {
+		t.Fatalf("visible=%+v", got)
+	}
+}
+
+func TestPeerRejectsBootstrapBeyondAggregateMemoryBound(t *testing.T) {
+	sink := newMockSink()
+	p := &Peer{Config: config.PeerConfig{Name: "spoke"}, sink: sink}
+	stage := peerSessionBootstrap{active: true, epoch: 1, bytes: sessionstream.MaxStagedBytes}
+	p.handleStreamEvent(context.Background(), sessionstream.EventBatch,
+		streamData(t, sessionstream.Batch[SessionProjection]{Epoch: 1, Sessions: []SessionProjection{{ID: "overflow"}}}), &stage)
+	if stage.active || len(stage.rows) != 0 {
+		t.Fatalf("staging not discarded: %+v", stage)
+	}
+	if len(sink.replaced) != 0 {
+		t.Fatal("overflow became visible")
+	}
+}
+
+func TestPeerAcceptsLegacySnapshotFromOldSpoke(t *testing.T) {
+	sink := newMockSink()
+	p := &Peer{Config: config.PeerConfig{Name: "old"}, sink: sink}
+	stage := peerSessionBootstrap{active: true, epoch: 9, rows: []SessionProjection{{ID: "partial"}}}
+	p.handleStreamEvent(context.Background(), "snapshot.sessions", streamData(t, sseSnapshotSessions{Sessions: []SessionProjection{{ID: "legacy"}}}), &stage)
+	if stage.active {
+		t.Fatal("legacy replacement did not discard partial protocol-3 staging")
+	}
+	got := sink.replaced["old"]
+	if len(got) != 1 || got[0].ID != "legacy@old" {
+		t.Fatalf("visible=%+v", got)
+	}
+}

--- a/services/gmuxd/internal/sessionstream/sessionstream.go
+++ b/services/gmuxd/internal/sessionstream/sessionstream.go
@@ -1,12 +1,13 @@
 // Package sessionstream defines protocol 3's bounded, semantic session-list
-// framing. A sender emits begin, one or more batches of complete rows, then
-// ready. Receivers stage rows and replace their visible projection only at
-// ready.
+// framing. A sender emits begin, bounded batches of complete rows, optional
+// bounded diagnostics for quarantined rows, then ready. Receivers expose only
+// the rows committed by ready.
 package sessionstream
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"fmt"
 )
 
@@ -19,18 +20,20 @@ const (
 	EventError = "snapshot.sessions.error"
 
 	// MaxEventPayload is deliberately below bufio.Scanner's 64 KiB default.
-	// The 48 KiB budget leaves 16 KiB for the SSE "data: " prefix, event line,
-	// proxies which add metadata, and modest future envelope growth. Rows are
-	// never split: a row which cannot fit in one batch is rejected.
+	// The 48 KiB budget leaves 16 KiB for the SSE prefix, event line, proxies,
+	// and modest future envelope growth. Rows are never split.
 	MaxEventPayload = 48 * 1024
 
-	// MaxStagedRows and MaxStagedBytes bound a receiver's unpublished staging
-	// memory even when the sender is faulty or hostile.
-	MaxStagedRows  = 100_000
-	MaxStagedBytes = 64 * 1024 * 1024
+	// MaxStagedRows and MaxStagedBytes are shared sender/receiver transaction
+	// bounds. The sender reserves aggregateEnvelopeReserve for batch envelopes,
+	// so a correct transaction always fits the receiver's exact encoded-byte
+	// accounting.
+	MaxStagedRows            = 100_000
+	MaxStagedBytes           = 64 * 1024 * 1024
+	aggregateEnvelopeReserve = 1024 * 1024
+	maxDiagnostics           = 256
+	maxDiagnosticIdentity    = 128
 )
-
-var ErrRowTooLarge = errors.New("session stream row too large")
 
 type Event struct {
 	Type string
@@ -51,13 +54,19 @@ type Ready struct {
 	Epoch uint64 `json:"epoch"`
 }
 
+// Error is a non-fatal diagnostic. The named row was omitted, but the epoch
+// remains valid and ready commits every other row.
 type Error struct {
+	Epoch   uint64 `json:"epoch"`
 	Code    string `json:"code"`
+	ID      string `json:"id,omitempty"`
 	Message string `json:"message"`
 }
 
 // Encode builds a complete replacement transaction. Every batch contains
 // whole semantic rows and every event payload is at most MaxEventPayload.
+// Rows which cannot safely participate are quarantined with bounded diagnostic
+// events; they never prevent ready from publishing the remaining projection.
 func Encode[T any](epoch uint64, rows []T, rowID func(T) string) ([]Event, error) {
 	begin, err := marshalBounded(EventBegin, Begin{Version: ProtocolVersion, Epoch: epoch})
 	if err != nil {
@@ -78,25 +87,48 @@ func Encode[T any](epoch uint64, rows []T, rowID func(T) string) ([]Event, error
 	}
 	batch := newBatch()
 	batchRows := 0
+	acceptedRows := 0
+	acceptedJSONBytes := 0
+	diagnostics := 0
+	suppressedDiagnostics := 0
 	flush := func() {
 		data := append(batch, suffix...)
 		events = append(events, Event{Type: EventBatch, Data: data})
 		batch = newBatch()
 		batchRows = 0
 	}
+	addDiagnostic := func(id, code, message string) {
+		if diagnostics >= maxDiagnostics {
+			suppressedDiagnostics++
+			return
+		}
+		event, marshalErr := marshalBounded(EventError, Error{Epoch: epoch, Code: code, ID: safeIdentity(id), Message: message})
+		if marshalErr == nil { // fixed-size fields make this defensive only
+			events = append(events, event)
+			diagnostics++
+		}
+	}
+
 	for _, row := range rows {
+		id := rowID(row)
 		encoded, marshalErr := json.Marshal(row)
 		if marshalErr != nil {
-			return nil, fmt.Errorf("session stream: encode row %q: %w", rowID(row), marshalErr)
+			addDiagnostic(id, "row_encode_failed", "session row could not be encoded and was omitted")
+			continue
+		}
+		if len(prefix)+len(encoded)+len(suffix) > MaxEventPayload {
+			addDiagnostic(id, "row_too_large", fmt.Sprintf("session row encoded to %d bytes and exceeds the %d-byte event limit; row omitted", len(encoded), MaxEventPayload))
+			continue
+		}
+		if transactionWouldOverflow(acceptedRows, acceptedJSONBytes, len(encoded)) {
+			addDiagnostic(id, "transaction_limit", "session row exceeds the bounded transaction row/byte limit and was omitted")
+			continue
 		}
 		separator := 0
 		if batchRows > 0 {
 			separator = 1
 		}
 		if len(batch)+separator+len(encoded)+len(suffix) > MaxEventPayload {
-			if batchRows == 0 {
-				return nil, fmt.Errorf("%w: session %q cannot fit the %d-byte event payload limit (large command, cwd, remotes, title, subtitle, socket_path, or conversation_file fields can cause this)", ErrRowTooLarge, rowID(row), MaxEventPayload)
-			}
 			flush()
 		}
 		if batchRows > 0 {
@@ -104,23 +136,31 @@ func Encode[T any](epoch uint64, rows []T, rowID func(T) string) ([]Event, error
 		}
 		batch = append(batch, encoded...)
 		batchRows++
+		acceptedRows++
+		acceptedJSONBytes += len(encoded)
 	}
 	if batchRows > 0 {
 		flush()
 	}
+	if suppressedDiagnostics > 0 {
+		event, marshalErr := marshalBounded(EventError, Error{Epoch: epoch, Code: "diagnostics_suppressed", Message: fmt.Sprintf("%d additional omitted session rows were not individually reported", suppressedDiagnostics)})
+		if marshalErr == nil {
+			events = append(events, event)
+		}
+	}
 	return append(events, ready), nil
 }
 
-func ErrorEvent(err error) Event {
-	message := err.Error()
-	// A malformed/unbounded ID can be part of the diagnostic. Keep the error
-	// frame bounded independently of the rejected row.
-	const maxMessageBytes = 4 * 1024
-	if len(message) > maxMessageBytes {
-		message = message[:maxMessageBytes] + "…"
+func transactionWouldOverflow(rows, encodedBytes, nextRowBytes int) bool {
+	return rows >= MaxStagedRows || encodedBytes+nextRowBytes > MaxStagedBytes-aggregateEnvelopeReserve
+}
+
+func safeIdentity(id string) string {
+	if len(id) <= maxDiagnosticIdentity {
+		return id
 	}
-	data, _ := json.Marshal(Error{Code: "session_row_too_large", Message: message})
-	return Event{Type: EventError, Data: data}
+	digest := sha256.Sum256([]byte(id))
+	return "sha256:" + hex.EncodeToString(digest[:])
 }
 
 func marshalBounded(eventType string, value any) (Event, error) {

--- a/services/gmuxd/internal/sessionstream/sessionstream.go
+++ b/services/gmuxd/internal/sessionstream/sessionstream.go
@@ -1,0 +1,135 @@
+// Package sessionstream defines protocol 3's bounded, semantic session-list
+// framing. A sender emits begin, one or more batches of complete rows, then
+// ready. Receivers stage rows and replace their visible projection only at
+// ready.
+package sessionstream
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+const (
+	ProtocolVersion = 3
+
+	EventBegin = "snapshot.sessions.begin"
+	EventBatch = "snapshot.sessions.batch"
+	EventReady = "snapshot.sessions.ready"
+	EventError = "snapshot.sessions.error"
+
+	// MaxEventPayload is deliberately below bufio.Scanner's 64 KiB default.
+	// The 48 KiB budget leaves 16 KiB for the SSE "data: " prefix, event line,
+	// proxies which add metadata, and modest future envelope growth. Rows are
+	// never split: a row which cannot fit in one batch is rejected.
+	MaxEventPayload = 48 * 1024
+
+	// MaxStagedRows and MaxStagedBytes bound a receiver's unpublished staging
+	// memory even when the sender is faulty or hostile.
+	MaxStagedRows  = 100_000
+	MaxStagedBytes = 64 * 1024 * 1024
+)
+
+var ErrRowTooLarge = errors.New("session stream row too large")
+
+type Event struct {
+	Type string
+	Data []byte
+}
+
+type Begin struct {
+	Version int    `json:"version"`
+	Epoch   uint64 `json:"epoch"`
+}
+
+type Batch[T any] struct {
+	Epoch    uint64 `json:"epoch"`
+	Sessions []T    `json:"sessions"`
+}
+
+type Ready struct {
+	Epoch uint64 `json:"epoch"`
+}
+
+type Error struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+// Encode builds a complete replacement transaction. Every batch contains
+// whole semantic rows and every event payload is at most MaxEventPayload.
+func Encode[T any](epoch uint64, rows []T, rowID func(T) string) ([]Event, error) {
+	begin, err := marshalBounded(EventBegin, Begin{Version: ProtocolVersion, Epoch: epoch})
+	if err != nil {
+		return nil, err
+	}
+	ready, err := marshalBounded(EventReady, Ready{Epoch: epoch})
+	if err != nil {
+		return nil, err
+	}
+
+	events := []Event{begin}
+	prefix := []byte(fmt.Sprintf(`{"epoch":%d,"sessions":[`, epoch))
+	suffix := []byte("]}")
+	newBatch := func() []byte {
+		batch := make([]byte, len(prefix), MaxEventPayload)
+		copy(batch, prefix)
+		return batch
+	}
+	batch := newBatch()
+	batchRows := 0
+	flush := func() {
+		data := append(batch, suffix...)
+		events = append(events, Event{Type: EventBatch, Data: data})
+		batch = newBatch()
+		batchRows = 0
+	}
+	for _, row := range rows {
+		encoded, marshalErr := json.Marshal(row)
+		if marshalErr != nil {
+			return nil, fmt.Errorf("session stream: encode row %q: %w", rowID(row), marshalErr)
+		}
+		separator := 0
+		if batchRows > 0 {
+			separator = 1
+		}
+		if len(batch)+separator+len(encoded)+len(suffix) > MaxEventPayload {
+			if batchRows == 0 {
+				return nil, fmt.Errorf("%w: session %q cannot fit the %d-byte event payload limit (large command, cwd, remotes, title, subtitle, socket_path, or conversation_file fields can cause this)", ErrRowTooLarge, rowID(row), MaxEventPayload)
+			}
+			flush()
+		}
+		if batchRows > 0 {
+			batch = append(batch, ',')
+		}
+		batch = append(batch, encoded...)
+		batchRows++
+	}
+	if batchRows > 0 {
+		flush()
+	}
+	return append(events, ready), nil
+}
+
+func ErrorEvent(err error) Event {
+	message := err.Error()
+	// A malformed/unbounded ID can be part of the diagnostic. Keep the error
+	// frame bounded independently of the rejected row.
+	const maxMessageBytes = 4 * 1024
+	if len(message) > maxMessageBytes {
+		message = message[:maxMessageBytes] + "…"
+	}
+	data, _ := json.Marshal(Error{Code: "session_row_too_large", Message: message})
+	return Event{Type: EventError, Data: data}
+}
+
+func marshalBounded(eventType string, value any) (Event, error) {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return Event{}, err
+	}
+	if len(data) > MaxEventPayload {
+		return Event{}, fmt.Errorf("session stream: %s payload is %d bytes (limit %d)", eventType, len(data), MaxEventPayload)
+	}
+	return Event{Type: eventType, Data: data}, nil
+}

--- a/services/gmuxd/internal/sessionstream/sessionstream.go
+++ b/services/gmuxd/internal/sessionstream/sessionstream.go
@@ -61,6 +61,7 @@ type Error struct {
 	Code    string `json:"code"`
 	ID      string `json:"id,omitempty"`
 	Message string `json:"message"`
+	Count   int    `json:"count,omitempty"`
 }
 
 // Encode builds a complete replacement transaction. Every batch contains
@@ -102,7 +103,7 @@ func Encode[T any](epoch uint64, rows []T, rowID func(T) string) ([]Event, error
 			suppressedDiagnostics++
 			return
 		}
-		event, marshalErr := marshalBounded(EventError, Error{Epoch: epoch, Code: code, ID: safeIdentity(id), Message: message})
+		event, marshalErr := marshalBounded(EventError, Error{Epoch: epoch, Code: code, ID: safeIdentity(id), Message: message, Count: 1})
 		if marshalErr == nil { // fixed-size fields make this defensive only
 			events = append(events, event)
 			diagnostics++
@@ -143,7 +144,7 @@ func Encode[T any](epoch uint64, rows []T, rowID func(T) string) ([]Event, error
 		flush()
 	}
 	if suppressedDiagnostics > 0 {
-		event, marshalErr := marshalBounded(EventError, Error{Epoch: epoch, Code: "diagnostics_suppressed", Message: fmt.Sprintf("%d additional omitted session rows were not individually reported", suppressedDiagnostics)})
+		event, marshalErr := marshalBounded(EventError, Error{Epoch: epoch, Code: "diagnostics_suppressed", Message: fmt.Sprintf("%d additional omitted session rows were not individually reported", suppressedDiagnostics), Count: suppressedDiagnostics})
 		if marshalErr == nil {
 			events = append(events, event)
 		}

--- a/services/gmuxd/internal/sessionstream/sessionstream_test.go
+++ b/services/gmuxd/internal/sessionstream/sessionstream_test.go
@@ -161,6 +161,40 @@ func TestEncodeQuarantinesOversizedRowAndCompletesReady(t *testing.T) {
 	}
 }
 
+func TestEncodeDiagnosticSummaryPreservesTotalAboveDetailCap(t *testing.T) {
+	rows := make([]testRow, 300)
+	huge := strings.Repeat("x", MaxEventPayload)
+	for i := range rows {
+		rows[i] = fixtureRows(1)[0]
+		rows[i].ID = fmt.Sprintf("oversized-%03d", i)
+		rows[i].Command = []string{huge}
+	}
+	events, err := Encode(1, rows, func(r testRow) string { return r.ID })
+	if err != nil {
+		t.Fatal(err)
+	}
+	details, total := 0, 0
+	var summary Error
+	for _, event := range events {
+		if event.Type != EventError {
+			continue
+		}
+		var diagnostic Error
+		if err := json.Unmarshal(event.Data, &diagnostic); err != nil {
+			t.Fatal(err)
+		}
+		total += diagnostic.Count
+		if diagnostic.ID != "" {
+			details++
+		} else {
+			summary = diagnostic
+		}
+	}
+	if details != maxDiagnostics || total != len(rows) || summary.Code != "diagnostics_suppressed" || summary.Count != 44 {
+		t.Fatalf("details=%d total=%d summary=%+v", details, total, summary)
+	}
+}
+
 func TestSenderLimitsAreStrictlyInsideReceiverLimits(t *testing.T) {
 	if transactionWouldOverflow(MaxStagedRows-1, 0, 1) {
 		t.Fatal("last supported row rejected")

--- a/services/gmuxd/internal/sessionstream/sessionstream_test.go
+++ b/services/gmuxd/internal/sessionstream/sessionstream_test.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -126,18 +125,68 @@ func TestEncodeLargeCorpusBoundsEveryEventAndMeasures(t *testing.T) {
 	t.Logf("1000 rows: old max event=%d total=%d events=1; new max event=%d total=%d events=%d", len(legacy), oldTotal, maxPayload, total, len(events))
 }
 
-func TestEncodeRejectsOversizedSingleSemanticRow(t *testing.T) {
-	row := fixtureRows(1)[0]
-	row.Command = []string{strings.Repeat("x", MaxEventPayload)}
-	events, err := Encode(1, []testRow{row}, func(r testRow) string { return r.ID })
-	if !errors.Is(err, ErrRowTooLarge) || len(events) != 0 {
-		t.Fatalf("events=%d err=%v, want ErrRowTooLarge and no partial stream", len(events), err)
+func TestEncodeQuarantinesOversizedRowAndCompletesReady(t *testing.T) {
+	good := fixtureRows(1)[0]
+	bad := fixtureRows(1)[0]
+	bad.ID = strings.Repeat("unsafe-id", 40)
+	bad.Command = []string{strings.Repeat("x", MaxEventPayload)}
+	events, err := Encode(1, []testRow{bad, good}, func(r testRow) string { return r.ID })
+	if err != nil {
+		t.Fatal(err)
 	}
-	for _, field := range []string{"command", "conversation_file"} {
-		if !strings.Contains(err.Error(), field) {
-			t.Errorf("error does not identify %s: %v", field, err)
+	if events[0].Type != EventBegin || events[len(events)-1].Type != EventReady {
+		t.Fatalf("events=%v", eventTypes(events))
+	}
+	var gotRows int
+	var diagnostic Error
+	for _, event := range events {
+		switch event.Type {
+		case EventBatch:
+			var batch Batch[testRow]
+			if err := json.Unmarshal(event.Data, &batch); err != nil {
+				t.Fatal(err)
+			}
+			gotRows += len(batch.Sessions)
+		case EventError:
+			if err := json.Unmarshal(event.Data, &diagnostic); err != nil {
+				t.Fatal(err)
+			}
 		}
 	}
+	if gotRows != 1 || diagnostic.Code != "row_too_large" || !strings.HasPrefix(diagnostic.ID, "sha256:") {
+		t.Fatalf("rows=%d diagnostic=%+v", gotRows, diagnostic)
+	}
+	if len(streamData(t, diagnostic)) > MaxEventPayload {
+		t.Fatal("diagnostic is not bounded")
+	}
+}
+
+func TestSenderLimitsAreStrictlyInsideReceiverLimits(t *testing.T) {
+	if transactionWouldOverflow(MaxStagedRows-1, 0, 1) {
+		t.Fatal("last supported row rejected")
+	}
+	if !transactionWouldOverflow(MaxStagedRows, 0, 1) {
+		t.Fatal("row-count limit not enforced")
+	}
+	acceptedLimit := MaxStagedBytes - aggregateEnvelopeReserve
+	if transactionWouldOverflow(0, acceptedLimit-1, 1) {
+		t.Fatal("last supported byte rejected")
+	}
+	if !transactionWouldOverflow(0, acceptedLimit, 1) {
+		t.Fatal("aggregate byte limit not enforced")
+	}
+	if aggregateEnvelopeReserve < MaxEventPayload {
+		t.Fatal("no envelope safety margin")
+	}
+}
+
+func streamData(t *testing.T, value any) []byte {
+	t.Helper()
+	data, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
 }
 
 func BenchmarkInitialSync1000(b *testing.B) {

--- a/services/gmuxd/internal/sessionstream/sessionstream_test.go
+++ b/services/gmuxd/internal/sessionstream/sessionstream_test.go
@@ -153,7 +153,7 @@ func TestEncodeQuarantinesOversizedRowAndCompletesReady(t *testing.T) {
 			}
 		}
 	}
-	if gotRows != 1 || diagnostic.Code != "row_too_large" || !strings.HasPrefix(diagnostic.ID, "sha256:") {
+	if gotRows != 1 || diagnostic.Code != "row_too_large" || diagnostic.Count != 1 || !strings.HasPrefix(diagnostic.ID, "sha256:") {
 		t.Fatalf("rows=%d diagnostic=%+v", gotRows, diagnostic)
 	}
 	if len(streamData(t, diagnostic)) > MaxEventPayload {

--- a/services/gmuxd/internal/sessionstream/sessionstream_test.go
+++ b/services/gmuxd/internal/sessionstream/sessionstream_test.go
@@ -1,0 +1,173 @@
+package sessionstream
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+type testRow struct {
+	ID               string            `json:"id"`
+	CreatedAt        string            `json:"created_at"`
+	Command          []string          `json:"command"`
+	Cwd              string            `json:"cwd"`
+	Adapter          string            `json:"adapter"`
+	WorkspaceRoot    string            `json:"workspace_root"`
+	Remotes          map[string]string `json:"remotes"`
+	SemanticAgent    bool              `json:"semantic_agent"`
+	Alive            bool              `json:"alive"`
+	PID              int               `json:"pid"`
+	Title            string            `json:"title"`
+	Subtitle         string            `json:"subtitle"`
+	UnreadToken      string            `json:"unread_token"`
+	SocketPath       string            `json:"socket_path"`
+	Slug             string            `json:"slug"`
+	ConversationFile string            `json:"conversation_file"`
+	RunnerVersion    string            `json:"runner_version"`
+	BinaryHash       string            `json:"binary_hash"`
+	ProjectSlug      string            `json:"project_slug"`
+	ProjectIndex     int               `json:"project_index"`
+}
+
+func fixtureRows(n int) []testRow {
+	rows := make([]testRow, n)
+	for i := range rows {
+		id := fmt.Sprintf("%08x", i)
+		rows[i] = testRow{
+			ID: id, CreatedAt: "2026-08-09T12:00:00Z",
+			Command: []string{"pi", "--mode", "rpc", "work on semantic session streaming"},
+			Cwd:     fmt.Sprintf("/home/user/dev/project-%d", i%25), Adapter: "pi",
+			WorkspaceRoot: fmt.Sprintf("/home/user/dev/project-%d", i%25),
+			Remotes:       map[string]string{"origin": "github.com/gmuxapp/gmux"}, SemanticAgent: true,
+			Alive: i%3 != 0, PID: 10000 + i, Title: fmt.Sprintf("Implement production task %d", i),
+			Subtitle: "Working through tests and review feedback", UnreadToken: "token-" + id,
+			SocketPath: "/run/user/1000/gmux/" + id + ".sock", Slug: fmt.Sprintf("production-task-%d", i),
+			ConversationFile: "/home/user/.pi/agent/sessions/" + id + ".jsonl",
+			RunnerVersion:    "2.1.0", BinaryHash: "abcdef0123456789",
+			ProjectSlug: fmt.Sprintf("project-%d", i%25), ProjectIndex: i / 25,
+		}
+	}
+	return rows
+}
+
+func TestLegacySnapshotReproducesDefaultScannerFailure(t *testing.T) {
+	payload, err := json.Marshal(struct {
+		Sessions []testRow `json:"sessions"`
+	}{fixtureRows(1000)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	frame := append([]byte("event: snapshot.sessions\ndata: "), payload...)
+	frame = append(frame, '\n', '\n')
+	scanner := bufio.NewScanner(bytes.NewReader(frame))
+	for scanner.Scan() {
+	}
+	if scanner.Err() == nil || !strings.Contains(scanner.Err().Error(), "token too long") {
+		t.Fatalf("legacy scanner error=%v, want token too long (payload=%d)", scanner.Err(), len(payload))
+	}
+}
+
+func TestEncodeEmptyAndOneRow(t *testing.T) {
+	for _, rows := range [][]testRow{nil, fixtureRows(1)} {
+		events, err := Encode(7, rows, func(r testRow) string { return r.ID })
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := 2
+		if len(rows) == 1 {
+			want = 3
+		}
+		if len(events) != want || events[0].Type != EventBegin || events[len(events)-1].Type != EventReady {
+			t.Fatalf("events=%v, want begin/[batch]/ready", eventTypes(events))
+		}
+	}
+}
+
+func TestEncodeLargeCorpusBoundsEveryEventAndMeasures(t *testing.T) {
+	rows := fixtureRows(1000)
+	legacy, err := json.Marshal(struct {
+		Sessions []testRow `json:"sessions"`
+	}{rows})
+	if err != nil {
+		t.Fatal(err)
+	}
+	events, err := Encode(1, rows, func(r testRow) string { return r.ID })
+	if err != nil {
+		t.Fatal(err)
+	}
+	maxPayload, total := 0, 0
+	var gotRows int
+	for _, event := range events {
+		if len(event.Data) > MaxEventPayload {
+			t.Fatalf("%s payload=%d exceeds %d", event.Type, len(event.Data), MaxEventPayload)
+		}
+		lineBytes := len("data: ") + len(event.Data)
+		if lineBytes >= bufio.MaxScanTokenSize {
+			t.Fatalf("%s SSE data line=%d is not below Scanner's %d-byte default", event.Type, lineBytes, bufio.MaxScanTokenSize)
+		}
+		maxPayload = max(maxPayload, len(event.Data))
+		total += len("event: ") + len(event.Type) + 1 + lineBytes + 2
+		if event.Type == EventBatch {
+			var batch Batch[testRow]
+			if err := json.Unmarshal(event.Data, &batch); err != nil {
+				t.Fatal(err)
+			}
+			gotRows += len(batch.Sessions)
+		}
+	}
+	if gotRows != len(rows) {
+		t.Fatalf("decoded rows=%d want %d", gotRows, len(rows))
+	}
+	oldTotal := len("event: snapshot.sessions\ndata: \n\n") + len(legacy)
+	t.Logf("1000 rows: old max event=%d total=%d events=1; new max event=%d total=%d events=%d", len(legacy), oldTotal, maxPayload, total, len(events))
+}
+
+func TestEncodeRejectsOversizedSingleSemanticRow(t *testing.T) {
+	row := fixtureRows(1)[0]
+	row.Command = []string{strings.Repeat("x", MaxEventPayload)}
+	events, err := Encode(1, []testRow{row}, func(r testRow) string { return r.ID })
+	if !errors.Is(err, ErrRowTooLarge) || len(events) != 0 {
+		t.Fatalf("events=%d err=%v, want ErrRowTooLarge and no partial stream", len(events), err)
+	}
+	for _, field := range []string{"command", "conversation_file"} {
+		if !strings.Contains(err.Error(), field) {
+			t.Errorf("error does not identify %s: %v", field, err)
+		}
+	}
+}
+
+func BenchmarkInitialSync1000(b *testing.B) {
+	rows := fixtureRows(1000)
+	b.Run("legacy-single-event", func(b *testing.B) {
+		for b.Loop() {
+			data, err := json.Marshal(struct {
+				Sessions []testRow `json:"sessions"`
+			}{rows})
+			if err != nil {
+				b.Fatal(err)
+			}
+			_ = data
+		}
+	})
+	b.Run("semantic-batches", func(b *testing.B) {
+		for b.Loop() {
+			events, err := Encode(1, rows, func(r testRow) string { return r.ID })
+			if err != nil {
+				b.Fatal(err)
+			}
+			_ = events
+		}
+	})
+}
+
+func eventTypes(events []Event) []string {
+	out := make([]string, len(events))
+	for i := range events {
+		out[i] = events[i].Type
+	}
+	return out
+}

--- a/services/gmuxd/internal/sseclient/client.go
+++ b/services/gmuxd/internal/sseclient/client.go
@@ -201,13 +201,10 @@ func New(url string, opts ...Option) *Client {
 //   - context.Canceled / DeadlineExceeded: ctx was cancelled.
 //   - wrapped network/protocol error: everything else.
 //
-// Comment lines (lines starting with ':') are consumed silently.
-// Lines that don't match "event: " or "data: " are ignored, per the
-// SSE spec.
-//
-// Events with no "data:" line are silently dropped. Lines with
-// "data:" but no preceding "event:" are also dropped (the current
-// event type is required to dispatch).
+// Comment lines (lines starting with ':') are consumed silently. Data lines
+// are accumulated until the blank event boundary and joined with newlines.
+// A block without an event field dispatches as the standard "message" type;
+// blocks with no data field are dropped.
 func (c *Client) Subscribe(ctx context.Context, connected func(), handler func(Event)) error {
 	if handler == nil {
 		panic("sseclient: handler must not be nil")
@@ -279,7 +276,24 @@ func (c *Client) Subscribe(ctx context.Context, connected func(), handler func(E
 	}
 	scanner.Buffer(make([]byte, 0, initSize), c.bufSize)
 
-	var currentEvent string
+	var (
+		currentEvent string
+		dataLines    []string
+		eventBytes   int
+		eventErr     error
+	)
+	dispatch := func() {
+		if len(dataLines) > 0 {
+			eventType := currentEvent
+			if eventType == "" {
+				eventType = "message"
+			}
+			handler(Event{Type: eventType, Data: []byte(strings.Join(dataLines, "\n"))})
+		}
+		currentEvent = ""
+		dataLines = dataLines[:0]
+		eventBytes = 0
+	}
 	for scanner.Scan() {
 		if idleTimer != nil {
 			idleTimer.Reset(c.idleTimeout)
@@ -289,34 +303,45 @@ func (c *Client) Subscribe(ctx context.Context, connected func(), handler func(E
 		}
 
 		line := scanner.Text()
-		switch {
-		case line == "":
-			// Spec: empty line terminates event. We already dispatch on
-			// data: lines, so this is a no-op. Reset currentEvent to
-			// avoid stale dispatches across event boundaries.
-			currentEvent = ""
-		case strings.HasPrefix(line, ":"):
-			// Comment line (server-pushed keepalive). Ignore.
-		case strings.HasPrefix(line, "event: "):
-			currentEvent = strings.TrimPrefix(line, "event: ")
-		case strings.HasPrefix(line, "event:"):
-			// Spec-compliant form without the space.
-			currentEvent = strings.TrimPrefix(line, "event:")
-		case strings.HasPrefix(line, "data: "):
-			if currentEvent == "" {
-				continue
+		if line == "" {
+			dispatch()
+			continue
+		}
+		if strings.HasPrefix(line, ":") {
+			continue
+		}
+		field, value, found := strings.Cut(line, ":")
+		if !found {
+			value = ""
+		}
+		if strings.HasPrefix(value, " ") {
+			value = value[1:]
+		}
+		switch field {
+		case "event":
+			currentEvent = value
+		case "data":
+			added := len(value)
+			if len(dataLines) > 0 {
+				added++
 			}
-			handler(Event{Type: currentEvent, Data: []byte(strings.TrimPrefix(line, "data: "))})
-		case strings.HasPrefix(line, "data:"):
-			if currentEvent == "" {
-				continue
+			if eventBytes+added > c.bufSize {
+				eventErr = fmt.Errorf("sse event data exceeds %d-byte limit", c.bufSize)
+				break
 			}
-			handler(Event{Type: currentEvent, Data: []byte(strings.TrimPrefix(line, "data:"))})
+			dataLines = append(dataLines, value)
+			eventBytes += added
 		default:
-			// Unknown line type (id:, retry:, custom). Ignore per spec.
+			// id, retry, and extension fields are intentionally not surfaced.
+		}
+		if eventErr != nil {
+			break
 		}
 	}
 
+	if eventErr != nil {
+		return eventErr
+	}
 	if err := scanner.Err(); err != nil {
 		// Caller cancel takes priority over any ambient errors.
 		if ctxErr := ctx.Err(); ctxErr != nil {

--- a/services/gmuxd/internal/sseclient/client.go
+++ b/services/gmuxd/internal/sseclient/client.go
@@ -28,10 +28,12 @@ import (
 	"time"
 )
 
-// Default buffer size for SSE event decoding. Matches the size used
-// by peering's hand-rolled scanner prior to extraction. Large enough
-// to accept gmuxd session-upsert payloads with long command arrays.
-const defaultBufferSize = 256 * 1024
+// DefaultMaxLineBytes is a bounded compatibility ceiling for legacy peers
+// which still send one full snapshot.sessions data line. Protocol 3 frames
+// are capped at 48 KiB; 1 MiB admits the measured 1,000-row legacy fixture as
+// defense in depth for version skew, not as the primary framing mechanism. A
+// larger line is rejected before unbounded allocation.
+const DefaultMaxLineBytes = 1024 * 1024
 
 // ErrStreamEnded is returned by Subscribe when the server closed the
 // stream cleanly (no error from the scanner, EOF). Callers use this
@@ -100,8 +102,8 @@ func WithTransport(t http.RoundTripper) Option {
 	}
 }
 
-// WithBufferSize sets the maximum size of a single SSE event payload.
-// Defaults to 256 KiB. Events larger than this cause Subscribe to
+// WithBufferSize sets the maximum size of a single SSE line.
+// Defaults to DefaultMaxLineBytes. Events larger than this cause Subscribe to
 // return a protocol error.
 func WithBufferSize(n int) Option {
 	return func(c *Client) {
@@ -175,7 +177,7 @@ func New(url string, opts ...Option) *Client {
 	c := &Client{
 		url:     url,
 		headers: make(http.Header),
-		bufSize: defaultBufferSize,
+		bufSize: DefaultMaxLineBytes,
 	}
 	c.headers.Set("Accept", "text/event-stream")
 	for _, opt := range opts {

--- a/services/gmuxd/internal/sseclient/client_test.go
+++ b/services/gmuxd/internal/sseclient/client_test.go
@@ -315,6 +315,33 @@ func TestSubscribe_StreamEnded(t *testing.T) {
 	}
 }
 
+func TestSubscribe_DefaultCompatibilityCeilingIsBounded(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		size      int
+		wantEvent bool
+	}{
+		{name: "measured-size legacy frame above former 256KiB ceiling", size: 900 * 1024, wantEvent: true},
+		{name: "reject above bounded 1MiB ceiling", size: 1200 * 1024, wantEvent: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newSSEServer(t)
+			s.setFrames("event: legacy\ndata: " + strings.Repeat("x", tc.size) + "\n\n")
+			if tc.wantEvent {
+				events, _ := waitForEvents(t, New(s.URL), 1, time.Second)
+				if len(events) != 1 {
+					t.Fatalf("events=%d, want 1", len(events))
+				}
+				return
+			}
+			err := New(s.URL).Subscribe(context.Background(), nil, func(Event) {})
+			if err == nil || errors.Is(err, ErrStreamEnded) {
+				t.Fatalf("err=%v, want bounded protocol error", err)
+			}
+		})
+	}
+}
+
 func TestSubscribe_OversizedEvent(t *testing.T) {
 	// A single data: line larger than the buffer must produce a
 	// protocol error, not silent truncation. Use a small buffer so

--- a/services/gmuxd/internal/sseclient/client_test.go
+++ b/services/gmuxd/internal/sseclient/client_test.go
@@ -357,11 +357,17 @@ func TestSubscribe_OversizedEvent(t *testing.T) {
 	}
 }
 
+func TestSubscribe_MultilineAggregateRemainsBounded(t *testing.T) {
+	s := newSSEServer(t)
+	s.setFrames("event: big\ndata: " + strings.Repeat("a", 300) + "\ndata: " + strings.Repeat("b", 300) + "\n\n")
+	err := New(s.URL, WithBufferSize(512)).Subscribe(context.Background(), nil, func(Event) {})
+	if err == nil || errors.Is(err, ErrStreamEnded) {
+		t.Fatalf("err=%v, want aggregate protocol error", err)
+	}
+}
+
 func TestSubscribe_EventWithoutData(t *testing.T) {
-	// An "event:" line with no "data:" line is per-spec a no-op event
-	// (dispatched as MessageEvent with empty data on the browser).
-	// Our decoder requires a data: line to fire the handler, matching
-	// the behavior of the peering decoder it replaces.
+	// An event block with no data field is a no-op under the SSE model.
 	s := newSSEServer(t)
 	s.setFrames(
 		"event: ghost\n\n",
@@ -378,22 +384,23 @@ func TestSubscribe_EventWithoutData(t *testing.T) {
 	}
 }
 
-func TestSubscribe_DataWithoutEvent(t *testing.T) {
-	// A "data:" line with no preceding "event:" line has no dispatch
-	// target and must be dropped. Again matches peering's behavior.
+func TestSubscribe_DataWithoutEventUsesMessageType(t *testing.T) {
 	s := newSSEServer(t)
-	s.setFrames(
-		"data: orphan\n\n",
-		"event: real\ndata: payload\n\n",
-	)
-
-	c := New(s.URL)
-	events, _ := waitForEvents(t, c, 1, 500*time.Millisecond)
-	if len(events) != 1 {
-		t.Fatalf("got %d events, want 1", len(events))
+	s.setFrames("data: payload\n\n")
+	events, _ := waitForEvents(t, New(s.URL), 1, 500*time.Millisecond)
+	if len(events) != 1 || events[0].Type != "message" || string(events[0].Data) != "payload" {
+		t.Fatalf("events=%+v, want message/payload", events)
 	}
-	if events[0].Type != "real" || string(events[0].Data) != "payload" {
-		t.Errorf("event = %+v, want {real payload}", events[0])
+}
+
+func TestSubscribe_MultilineDataDispatchesOnceAtBlankLine(t *testing.T) {
+	s := newSSEServer(t)
+	// Field order is unconstrained: data may precede event, comments do not
+	// terminate a block, and one optional space after ':' is stripped.
+	s.setFrames("data:first\n: comment\nevent: joined\ndata: second\ndata:\n\n")
+	events, _ := waitForEvents(t, New(s.URL), 1, 500*time.Millisecond)
+	if len(events) != 1 || events[0].Type != "joined" || string(events[0].Data) != "first\nsecond\n" {
+		t.Fatalf("events=%+v, want one joined multiline event", events)
 	}
 }
 


### PR DESCRIPTION
## Summary

- replace unbounded protocol-3 session snapshots with 48 KiB begin/batch/ready transactions of complete rows
- quarantine only an oversized row, emit a bounded safe diagnostic, and complete ready for the remaining projection
- show persistent omitted-session warnings in the sidebar until a later clean bootstrap
- stage browser/peer rows atomically, enforce strictly increasing epochs, and lock each transport to its first accepted session protocol
- explicitly negotiate protocol 3 for current browsers and peers while retaining unversioned protocol 2 for old tabs/custom consumers for one release
- implement standard multiline SSE parsing with bounded line and aggregate memory

This removes the oversized initial/full-list **session** frame. It does not implement archive/live-set selection or change `snapshot.world` framing.

## Protocol and consistency

A protocol-3 replacement is:

1. `snapshot.sessions.begin {version:3,epoch}`
2. zero or more `snapshot.sessions.batch {epoch,sessions:[...]}` events
3. zero or more non-fatal `snapshot.sessions.error` row diagnostics
4. `snapshot.sessions.ready {epoch}`

Batches contain complete rows and are at most 48 KiB JSON. Receivers publish only at matching ready. `fanout.Subscribe` captures/install-subscribes under the publication mutex, so a racing mutation is either in baseline N or queued after N's ready.

Epochs increase strictly per transport. The first accepted session event locks that transport to legacy or protocol 3: protocol-3 -> injected legacy -> stale protocol-3 cannot roll back, and protocol 3 cannot take over a legacy-only connection. Disconnect releases staging and resets mode/epoch history. One 10-second deadline covers the complete transaction, with cancellation checks between writes.

## Availability, diagnostics, and bounds

A >48 KiB row is omitted rather than split or allowed to brick every reconnect. Its diagnostic uses a fixed reason and safe ID (long IDs become SHA-256 identities); ready commits every other row. This includes the old-spoke-large-row -> new-hub -> browser/downstream schedule.

The browser displays a persistent sidebar warning with an exact omitted total and at most 256 safe ID/reason details. A counted summary cannot be dropped by the detail cap (300 omitted reports 300 while rendering 256 identifiers). A later clean bootstrap clears both. Peers retain bounded diagnostics for the transaction and log bounded details/count. Diagnostics never become fake session rows and never prevent ready.

- session event: 48 KiB maximum
- sender/receiver transaction: 100,000 rows / 64 MiB, with 1 MiB sender envelope reserve
- diagnostics: 256 individual plus one counted summary
- Go SSE line and accumulated event: 1 MiB transitional ceiling

Malformed/overflow transactions retain prior visible state and recover at the next newer begin. Session rows contain no transcripts/scrollback.

## Transitional compatibility

- current browser: `/v1/events?session_stream=3`
- current peer: `/v1/events?as=peer&session_stream=3`
- old tab/custom non-peer consumer without a marker: legacy `snapshot.sessions`
- old peer without marker: legacy `snapshot.sessions`
- new hub -> old spoke: legacy response accepted
- unknown marker: legacy fallback, never guessed

The new browser also retains a defensive legacy listener. Protocol-2 old-browser behavior remains unchanged: an unversioned connection receives `snapshot.sessions` followed by the ordinary `snapshot.world` event. The new browser's mode lock prevents mixed-mode replay.

## SSE and world scope

The Go SSE parser accumulates all `data:` fields, joins with newline, and dispatches once at the blank boundary; field ordering, comments, default `message` events, line limits, and aggregate limits are tested.

`snapshot.world` is deliberately unchanged. This PR makes no endpoint-wide boundedness claim: 48 KiB applies only to protocol-3 session events. A realistic 1,000-membership/50-project/20-peer fixture remains as a **26,177 B characterization only**, not a maximum. World semantic framing is a separate future design if production evidence demonstrates it.

## Measurements (1,000 realistic session rows)

| metric | old | bounded stream |
|---|---:|---:|
| max session JSON event | 687,678 B | 48,889 B |
| total session SSE bytes | 687,711 B | 688,721 B |
| events | 1 | 17 |
| median serialization (3 runs) | ~1.30 ms | ~1.77 ms |

Wire overhead is 1,010 B (~0.15%); local serialization adds ~0.47 ms. The pre-change reproduction generated an 860,541-byte `data:` line and `bufio.Scanner: token too long`.

Full design/evidence: `.memory/report-semantic-session-stream.md`.

## Validation

Passed locally:

- full `go test ./...` in `services/gmuxd`
- `go test -race` across sessionstream, sseclient, apiclient, peering, sessioncoord, centralstore, store, snapshot, and `cmd/gmuxd`
- actual `services/gmuxd/tools/production-e2e.sh` container gate
- gmux-web full suite: 667 tests; typecheck and production build
- protocol build/tests
- website generated-reference + Astro build
- Biome lint, `go vet ./...`, centralstore generated check and CGO-free cross-build
- focused mixed-mode rollback schedules in peer and browser
- protocol-2 legacy-only sessions + unchanged world sequence
- persistent exact diagnostic total above the 256-detail cap and clean-bootstrap clearance
- oversized-row amplification, stale epochs, disconnect release, multiline SSE, aggregate parser bound, and transaction deadline schedules

All CI checks passed on the prior remediation head; this head reruns the same required workflow set.

## Open tradeoffs

- mutations still re-enumerate the full selected set; no archive/live-set, delta, or replay work is claimed
- quarantined rows remain available through CLI/REST but are absent from SSE until they shrink; the UI now makes that degradation explicit
- transitional protocol-2 sessions remain single frames for one release, bounded at 1 MiB on new Go clients
- world framing and limits are intentionally unchanged and require a separate design if real production evidence demonstrates need

