### PR TITLE
feat(web): rework the sidebar family entry and show the whole family in the panel

### DIFF
--- a/apps/gmux-web/src/family-drawer-model.test.ts
+++ b/apps/gmux-web/src/family-drawer-model.test.ts
@@ -15,7 +15,7 @@ const child = (id: string, minute: number) => makeSession({
 
 function rootChildren(count: number) {
   const snapshot = [root, ...Array.from({ length: count }, (_, i) => child(`c-${i}`, 59 - i))]
-  return projectFamily(root, snapshot).siblingTrees[0].children
+  return projectFamily(root, snapshot).tree.children
 }
 
 describe('panel level split (cap + summary row)', () => {
@@ -38,5 +38,47 @@ describe('panel level split (cap + summary row)', () => {
     expect(summary).toEqual({ key: 'root', expanded: true, label: 'show fewer' })
     // Another parent's expansion state does not leak into this level.
     expect(splitLevel(nodes, 'root', new Set(['other-parent'])).shown).toHaveLength(15)
+  })
+})
+
+describe('the row you are on is never behind the fold', () => {
+  it('keeps a pinned member that recency would have folded away', () => {
+    const nodes = rootChildren(40)
+    const stale = nodes[nodes.length - 1].session.id // oldest, deep below the cap
+    const { shown, summary } = splitLevel(nodes, 'root', new Set(), new Set([stale]))
+    expect(shown.map(n => n.session.id)).toContain(stale)
+    // A pinned row spends a slot rather than widening the level, so the
+    // panel's height doesn't jump around as you navigate.
+    expect(shown).toHaveLength(FAMILY_LEVEL_CAP)
+    expect(summary).toEqual({ key: 'root', expanded: false, label: '+25 more' })
+  })
+
+  it('keeps recency order rather than floating the pinned row to the top', () => {
+    const nodes = rootChildren(40)
+    const stale = nodes[nodes.length - 1].session.id
+    const { shown } = splitLevel(nodes, 'root', new Set(), new Set([stale]))
+    const order = shown.map(n => nodes.findIndex(x => x.session.id === n.session.id))
+    expect(order).toEqual([...order].sort((a, b) => a - b))
+    expect(shown[shown.length - 1].session.id).toBe(stale)
+  })
+
+  it('renders the whole spine of a deep selection, quiet ancestors included', () => {
+    // The realistic shape: an orchestrator with many subagents goes quiet
+    // while the one you're in does the talking, so its parent ranks last
+    // on recency — exactly the row the cap would drop.
+    const kids = Array.from({ length: 20 }, (_, i) => child(`mid-${i}`, 59 - i))
+    const quietParent = kids[kids.length - 1]
+    const selected = makeSession({
+      id: 'selected', cwd: '/p', title: 'selected', semantic_agent: true,
+      parent_session_id: quietParent.id, created_at: at(0), last_output_at: at(59),
+    })
+    const snapshot = [root, ...kids, selected]
+    const projection = projectFamily(selected, snapshot)
+    const pinned = new Set([...projection.ancestors.map(a => a.id), selected.id])
+    const { shown } = splitLevel(projection.tree.children, 'root', new Set(), pinned)
+    expect(shown.map(n => n.session.id)).toContain(quietParent.id)
+    // Without the pin the spine — and with it the selected row — vanishes.
+    const unpinned = splitLevel(projection.tree.children, 'root', new Set())
+    expect(unpinned.shown.map(n => n.session.id)).not.toContain(quietParent.id)
   })
 })

--- a/apps/gmux-web/src/family-drawer-model.ts
+++ b/apps/gmux-web/src/family-drawer-model.ts
@@ -14,15 +14,34 @@ export interface LevelSplit {
 
 /** Apply the cap to one children level: what the panel actually renders.
  * Expansion is keyed per parent id and two-state — expanding shows the
- * whole level plus `show fewer`, never an incremental ladder. */
+ * whole level plus `show fewer`, never an incremental ladder.
+ *
+ * `pinned` is the spine of the session you're viewing. Those rows are
+ * never folded away, whatever their recency: the panel projects the
+ * whole family from the root, so every level between you and the root
+ * is now capped, and a quiet parent — the ordinary state of an
+ * orchestrator whose subagent is doing the talking — would otherwise
+ * take your own row down with it. A pinned row costs one slot of the
+ * cap rather than widening it, so the level's height stays put. */
 export function splitLevel(
   nodes: readonly FamilyNode[],
   parentId: string,
   expanded: ReadonlySet<string>,
+  pinned: ReadonlySet<string> = new Set(),
 ): LevelSplit {
   if (nodes.length <= FAMILY_LEVEL_CAP) return { shown: nodes, summary: null }
   const isExpanded = expanded.has(parentId)
-  const shown = isExpanded ? nodes : nodes.slice(0, FAMILY_LEVEL_CAP)
-  const label = isExpanded ? 'show fewer' : `+${nodes.length - shown.length} more`
-  return { shown, summary: { key: parentId, expanded: isExpanded, label } }
+  if (isExpanded) return { shown: nodes, summary: { key: parentId, expanded: true, label: 'show fewer' } }
+  // Keep recency order: choose which rows survive, then render them in
+  // the order they already had.
+  const keep = new Set(nodes.filter(n => pinned.has(n.session.id)).map(n => n.session.id))
+  for (const node of nodes) {
+    if (keep.size >= FAMILY_LEVEL_CAP) break
+    keep.add(node.session.id)
+  }
+  const shown = nodes.filter(n => keep.has(n.session.id))
+  return {
+    shown,
+    summary: { key: parentId, expanded: false, label: `+${nodes.length - shown.length} more` },
+  }
 }

--- a/apps/gmux-web/src/family-drawer.tsx
+++ b/apps/gmux-web/src/family-drawer.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'preact/hooks'
 import { familyCounts, isProcessSession, projectFamily, type FamilyNode } from './family'
 import { splitLevel } from './family-drawer-model'
 import { viewToPath } from './routing'
+import { formatAge } from './session-row'
 import { activityMap, projects, sessions, sessionDotState, tabHref } from './store'
 import type { Session } from './types'
 
@@ -10,17 +11,25 @@ function hrefFor(session: Session): string | undefined {
   return path ? tabHref(path) : undefined
 }
 
-function FamilyRow({ node, selectedId, depth, expanded, onToggle }: {
+function FamilyRow({ node, selectedId, depth, expanded, pinned, now, onToggle }: {
   node: FamilyNode
   selectedId: string
   depth: number
   expanded: ReadonlySet<string>
+  /** Your own spine: rows the level cap must never fold away. */
+  pinned: ReadonlySet<string>
+  /** Render-time clock, passed down so every row in one paint agrees. */
+  now: number
   onToggle: (key: string) => void
 }) {
   const session = node.session
   const process = isProcessSession(session)
-  const rawDot = sessionDotState(session, activityMap.value)
-  const dot = session.id === selectedId && (rawDot === 'error' || rawDot === 'unread') ? 'none' : rawDot
+  // No selection muting here, unlike the sidebar: the panel is a map of
+  // the family, and a map that blanks the row you're standing on would
+  // claim "1 error" in the counts line with no errored row in sight.
+  // (Viewing a session clears its unread/error flags server-side anyway,
+  // so the dot settles on its own a beat later.)
+  const dot = sessionDotState(session, activityMap.value)
   return (
     <li>
       <a
@@ -33,7 +42,11 @@ function FamilyRow({ node, selectedId, depth, expanded, onToggle }: {
           ? <span class={`family-row-proc${session.alive && session.status?.active ? ' working' : ''}`} aria-hidden="true">$</span>
           : <span class={`session-dot-indicator ${dot}`} aria-hidden="true" />}
         <span class="family-row-title">{session.title}</span>
-        <span class="family-row-kind">{session.adapter}</span>
+        {/* Levels are ordered by this timestamp, so it has to be on
+          * screen: sorting by an invisible key reads as no order at
+          * all. It replaces the adapter label, which repeated the same
+          * word down the whole panel and duplicated the `$` glyph. */}
+        <span class="family-row-age">{formatAge(session.last_output_at ?? session.created_at, now)}</span>
       </a>
       {node.children.length > 0 && (
         <ul>
@@ -43,6 +56,8 @@ function FamilyRow({ node, selectedId, depth, expanded, onToggle }: {
             selectedId={selectedId}
             depth={depth + 1}
             expanded={expanded}
+            pinned={pinned}
+            now={now}
             onToggle={onToggle}
           />
         </ul>
@@ -53,15 +68,17 @@ function FamilyRow({ node, selectedId, depth, expanded, onToggle }: {
 
 /** One children level: capped rows plus a two-state summary row
  * (`+N more` / `show fewer`) keyed per parent. */
-function LevelRows({ nodes, parentId, selectedId, depth, expanded, onToggle }: {
+function LevelRows({ nodes, parentId, selectedId, depth, expanded, pinned, now, onToggle }: {
   nodes: readonly FamilyNode[]
   parentId: string
   selectedId: string
   depth: number
   expanded: ReadonlySet<string>
+  pinned: ReadonlySet<string>
+  now: number
   onToggle: (key: string) => void
 }) {
-  const { shown, summary } = splitLevel(nodes, parentId, expanded)
+  const { shown, summary } = splitLevel(nodes, parentId, expanded, pinned)
   return (
     <>
       {shown.map(node => (
@@ -71,6 +88,8 @@ function LevelRows({ nodes, parentId, selectedId, depth, expanded, onToggle }: {
           selectedId={selectedId}
           depth={depth}
           expanded={expanded}
+          pinned={pinned}
+          now={now}
           onToggle={onToggle}
         />
       ))}
@@ -92,8 +111,8 @@ function LevelRows({ nodes, parentId, selectedId, depth, expanded, onToggle }: {
   )
 }
 
-function CountsLine({ trees }: { trees: readonly FamilyNode[] }) {
-  const counts = familyCounts(trees)
+function CountsLine({ tree }: { tree: FamilyNode }) {
+  const counts = familyCounts([tree])
   const segments: { text: string; cls?: string }[] = []
   if (counts.error > 0) segments.push({ text: `${counts.error} error`, cls: 'attention' })
   if (counts.working > 0) segments.push({ text: `${counts.working} working` })
@@ -114,9 +133,12 @@ function CountsLine({ trees }: { trees: readonly FamilyNode[] }) {
 /** The family panel: a non-modal popover anchored under the header's family
  * trigger, matching the ⋮ menu's behavior — closes on outside mousedown and
  * Escape, no focus trap. Clicking a row navigates without closing it so a
- * family can be traversed in place. Renders live (sidebar activity-mode
- * semantics): rows re-sort only when new output arrives, which is the same
- * stability bar the sidebar meets. */
+ * family can be traversed in place.
+ *
+ * Shows the whole family from the root, wherever you're standing, with
+ * every level ordered by recency — the same rule as the sidebar's
+ * activity feed, and the same stability bar: rows move only when new
+ * output arrives, never because you acted on one. */
 export function FamilyDrawer({ selected, onClose, triggerRef }: {
   selected: Session
   onClose: () => void
@@ -161,7 +183,12 @@ export function FamilyDrawer({ selected, onClose, triggerRef }: {
     let inner = 0
     const outer = requestAnimationFrame(() => {
       inner = requestAnimationFrame(() => {
-        panelRef.current?.querySelector<HTMLElement>('[aria-current="page"]')?.focus()
+        const row = panelRef.current?.querySelector<HTMLElement>('[aria-current="page"]')
+        // Whole-family scope means your row can open below the fold, so
+        // bring it into view before taking focus (focus alone would
+        // scroll it to an arbitrary edge).
+        row?.scrollIntoView({ block: 'nearest' })
+        row?.focus({ preventScroll: true })
       })
     })
     return () => { cancelAnimationFrame(outer); cancelAnimationFrame(inner) }
@@ -170,19 +197,25 @@ export function FamilyDrawer({ selected, onClose, triggerRef }: {
   // Promotion intentionally defers provenance: promoted sessions present as
   // roots even though parent_session_id remains immutable on the wire.
   const projection = projectFamily(selected, sessions.value)
+  // Your own path, root to selection: the cap may fold anything but this.
+  const pinned = new Set([...projection.ancestors.map(a => a.id), selected.id])
+  // One clock for the whole paint, so sibling ages can't disagree.
+  const now = Date.now()
   return (
     <div id="agent-family-drawer" class="family-drawer" role="dialog" aria-label="Session family" ref={panelRef}>
       <div class="family-drawer-head">
-        <CountsLine trees={projection.siblingTrees} />
+        <CountsLine tree={projection.tree} />
       </div>
       <div class="family-drawer-scroll">
         <ul class="family-tree">
           <LevelRows
-            nodes={projection.siblingTrees}
-            parentId={projection.ancestors[projection.ancestors.length - 1]?.id ?? projection.root.id}
+            nodes={[projection.tree]}
+            parentId={projection.root.id}
             selectedId={selected.id}
             depth={0}
             expanded={expanded}
+            pinned={pinned}
+            now={now}
             onToggle={toggle}
           />
         </ul>

--- a/apps/gmux-web/src/family-drawer.tsx
+++ b/apps/gmux-web/src/family-drawer.tsx
@@ -131,8 +131,8 @@ function CountsLine({ tree }: { tree: FamilyNode }) {
 }
 
 /** The family panel: a non-modal popover anchored under the header's family
- * trigger, matching the ⋮ menu's behavior — closes on outside mousedown and
- * Escape, no focus trap. Clicking a row navigates without closing it so a
+ * trigger, matching the ⋮ menu's behavior — closes on an outside
+ * pointerdown and Escape, no focus trap. Clicking a row navigates without closing it so a
  * family can be traversed in place.
  *
  * Shows the whole family from the root, wherever you're standing, with
@@ -162,17 +162,23 @@ export function FamilyDrawer({ selected, onClose, triggerRef }: {
       onClose()
       triggerRef.current?.focus()
     }
-    const onMouseDown = (event: MouseEvent) => {
+    // pointerdown, not mousedown: the terminal's touch handlers
+    // preventDefault on several gesture paths, which suppresses the
+    // browser's synthesized mouse cascade — so a tap on the terminal
+    // never reached a mousedown listener and the panel stayed open over
+    // the session you were tapping back into. pointerdown fires ahead of
+    // touchstart and can't be cancelled by it.
+    const onPointerDown = (event: PointerEvent) => {
       const target = event.target as Node
       if (panelRef.current?.contains(target)) return
       if (triggerRef.current?.contains(target)) return // trigger's own click toggles
       onClose()
     }
     document.addEventListener('keydown', onKey)
-    document.addEventListener('mousedown', onMouseDown)
+    document.addEventListener('pointerdown', onPointerDown)
     return () => {
       document.removeEventListener('keydown', onKey)
-      document.removeEventListener('mousedown', onMouseDown)
+      document.removeEventListener('pointerdown', onPointerDown)
     }
   }, [onClose, triggerRef])
 

--- a/apps/gmux-web/src/family.bench.ts
+++ b/apps/gmux-web/src/family.bench.ts
@@ -31,6 +31,6 @@ describe('family projection (1,000 sessions / 500 children)', () => {
   })
 
   bench('project and count the selected child panel', () => {
-    familyCounts(projectFamily(children[250], index).siblingTrees)
+    familyCounts([projectFamily(children[250], index).tree])
   })
 })

--- a/apps/gmux-web/src/family.test.ts
+++ b/apps/gmux-web/src/family.test.ts
@@ -100,9 +100,12 @@ describe('task-family projection', () => {
     const niece = agent('niece', 'sibling')
     const p = projectFamily(selected, [root, aunt, parent, selected, sibling, niece])
     expect(p.ancestors.map(s => s.id)).toEqual(['root', 'parent'])
-    expect(p.siblingTrees.map(n => n.session.id).sort()).toEqual(['selected', 'sibling'])
-    expect(p.siblingTrees.flatMap(n => n.children).map(n => n.session.id)).toEqual(['niece'])
-    expect(p.siblingTrees.some(n => n.session.id === 'aunt')).toBe(false)
+    // The whole family, from the root — including the branch the
+    // selection isn't on. Standing deeper must never show you less.
+    expect(p.tree.session.id).toBe('root')
+    expect(p.tree.children.map(n => n.session.id).sort()).toEqual(['aunt', 'parent'])
+    const parentNode = p.tree.children.find(n => n.session.id === 'parent')
+    expect(parentNode?.children.map(n => n.session.id).sort()).toEqual(['selected', 'sibling'])
   })
 
   it('indexes a large snapshot once across projection callers', () => {
@@ -118,7 +121,7 @@ describe('task-family projection', () => {
     })
 
     expect(familyIndex(snapshot)).toBe(familyIndex(snapshot))
-    expect(projectFamily(children[250], snapshot).siblingTrees).toHaveLength(500)
+    expect(projectFamily(children[250], snapshot).tree.children).toHaveLength(500)
     expect(familyRoot(children[250], snapshot)).toBe(root)
     expect(hasFamily(root, snapshot)).toBe(true)
     expect(isFamilyChild(children[250], snapshot)).toBe(true)
@@ -145,7 +148,7 @@ describe('flat panel projection', () => {
       member('mid-idle', { last_output_at: at(30) }),
       member('created-only', { last_output_at: undefined, created_at: at(20) }),
     ]
-    const rootNode = projectFamily(root, sessions).siblingTrees[0]
+    const rootNode = projectFamily(root, sessions).tree
     // Pure recency — status (working/dead/unread) must not reorder rows;
     // a session with no output yet sorts by creation time.
     expect(rootNode.children.map(n => n.session.id))
@@ -164,23 +167,26 @@ describe('flat panel projection', () => {
       member('proc-working', { semantic_agent: undefined, adapter: 'shell', status: { active: true } }),
       member('dead-viewed', { alive: false }),
     ]
-    const trees = projectFamily(root, sessions).siblingTrees
+    const tree = projectFamily(root, sessions).tree
     // Each member counted once under its highest-precedence state: the
     // working-unread agent is working (dot precedence), the dead unread
     // one is unread (not alive-gated), processes count like anyone else,
     // and the root + quiet members only land in the total.
-    expect(familyCounts(trees)).toEqual({ error: 1, working: 3, unread: 2, total: 8 })
+    expect(familyCounts([tree])).toEqual({ error: 1, working: 3, unread: 2, total: 8 })
   })
 
-  it('counts only the sibling-level trees for a nested selection', () => {
+  it('counts the same family from anywhere inside it', () => {
     const root = agent('root')
     const parent = member('parent')
     const selected = member('selected', { parent_session_id: 'parent' })
     const sibling = member('sibling', { parent_session_id: 'parent', alive: false })
-    const projection = projectFamily(selected, [root, parent, selected, sibling])
-    expect(projection.ancestors.map(s => s.id)).toEqual(['root', 'parent'])
-    // Ancestors are breadcrumb context in the header, not counted rows.
-    expect(familyCounts(projection.siblingTrees)).toEqual({ error: 0, working: 0, unread: 0, total: 2 })
+    const snapshot = [root, parent, selected, sibling]
+    const fromRoot = familyCounts([projectFamily(root, snapshot).tree])
+    const fromDeep = familyCounts([projectFamily(selected, snapshot).tree])
+    // One scope, so the line reads the same on every row you visit —
+    // and the root is one of the members it counts.
+    expect(fromDeep).toEqual(fromRoot)
+    expect(fromRoot).toEqual({ error: 0, working: 0, unread: 0, total: 4 })
   })
 })
 

--- a/apps/gmux-web/src/family.test.ts
+++ b/apps/gmux-web/src/family.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   descendantTree, familyAncestors, familyCounts, familyIndex,
   childTrailTitle, familyActivityLabel, familyRoot, hasFamily, hasFamilyActivity,
-  isFamilyChild, NO_FAMILY_ACTIVITY, projectFamily,
+  familyMemberGlyph, isFamilyChild, NO_FAMILY_ACTIVITY, projectFamily,
 } from './family'
 import { makeSession } from './test-helpers'
 
@@ -181,6 +181,42 @@ describe('flat panel projection', () => {
     expect(projection.ancestors.map(s => s.id)).toEqual(['root', 'parent'])
     // Ancestors are breadcrumb context in the header, not counted rows.
     expect(familyCounts(projection.siblingTrees)).toEqual({ error: 0, working: 0, unread: 0, total: 2 })
+  })
+})
+
+describe('member row glyph', () => {
+  const proc = (over = {}) => makeSession({
+    id: 'p', cwd: '/p', title: 'tail -f', adapter: 'shell', parent_session_id: 'root', ...over,
+  })
+  const kid = (over = {}) => makeSession({
+    id: 'k', cwd: '/p', title: 'kid', semantic_agent: true, parent_session_id: 'root', ...over,
+  })
+
+  it('gives a process its $ in every state', () => {
+    // Shape says "process" at a glance; state rides along as the glyph's
+    // own state rather than replacing it.
+    expect(familyMemberGlyph(proc(), 'none')).toEqual({ kind: 'process', state: 'none' })
+    expect(familyMemberGlyph(proc(), 'working')).toEqual({ kind: 'process', state: 'working' })
+  })
+
+  it('never drops a named member\'s attention on the floor', () => {
+    // The activity line subtracts whoever this row names, so the row is
+    // the only place its state can appear. A glyph that answered 'branch'
+    // or a stateless '$' for an unread member would report it nowhere.
+    for (const member of [proc({ unread: true }), kid({ unread: true })]) {
+      const glyph = familyMemberGlyph(member, 'unread')
+      expect(glyph.kind).not.toBe('branch')
+      expect('state' in glyph && glyph.state).toBe('unread')
+    }
+    for (const member of [proc({ status: { active: true, error: true } }), kid({ status: { active: true, error: true } })]) {
+      const glyph = familyMemberGlyph(member, 'error')
+      expect('state' in glyph && glyph.state).toBe('error')
+    }
+  })
+
+  it('falls back to the branch only for an agent with nothing to say', () => {
+    expect(familyMemberGlyph(kid(), 'none')).toEqual({ kind: 'branch' })
+    expect(familyMemberGlyph(kid(), 'working')).toEqual({ kind: 'dot', state: 'working' })
   })
 })
 

--- a/apps/gmux-web/src/family.test.ts
+++ b/apps/gmux-web/src/family.test.ts
@@ -200,12 +200,12 @@ describe('family activity line', () => {
 
   it('spells the glyph row out for screen readers, attention first', () => {
     expect(familyActivityLabel(activity({ error: 1, unread: 2, workingAgents: 1, workingProcesses: 3 })))
-      .toBe('Family: 1 member with an error, 2 unread members, 1 working subagent, 3 running processes. Open the family tree.')
+      .toBe('Family: 1 member with an error, 2 unread members, 1 working subagent, 3 running processes')
   })
 
   it('omits zero states from the label', () => {
     expect(familyActivityLabel(activity({ unread: 1 })))
-      .toBe('Family: 1 unread member. Open the family tree.')
+      .toBe('Family: 1 unread member')
   })
 })
 

--- a/apps/gmux-web/src/family.test.ts
+++ b/apps/gmux-web/src/family.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import {
   descendantTree, familyAncestors, familyCounts, familyIndex,
-  familyRoot, hasFamily, isFamilyChild, projectFamily,
+  childTrailTitle, familyActivityLabel, familyRoot, hasFamily, hasFamilyActivity,
+  isFamilyChild, NO_FAMILY_ACTIVITY, projectFamily,
 } from './family'
 import { makeSession } from './test-helpers'
 
@@ -180,5 +181,51 @@ describe('flat panel projection', () => {
     expect(projection.ancestors.map(s => s.id)).toEqual(['root', 'parent'])
     // Ancestors are breadcrumb context in the header, not counted rows.
     expect(familyCounts(projection.siblingTrees)).toEqual({ error: 0, working: 0, unread: 0, total: 2 })
+  })
+})
+
+describe('family activity line', () => {
+  const activity = (over = {}) => ({ ...NO_FAMILY_ACTIVITY, ...over })
+
+  it('shows nothing for an idle family', () => {
+    expect(hasFamilyActivity(NO_FAMILY_ACTIVITY)).toBe(false)
+  })
+
+  it('shows for any single non-zero state', () => {
+    expect(hasFamilyActivity(activity({ error: 1 }))).toBe(true)
+    expect(hasFamilyActivity(activity({ unread: 1 }))).toBe(true)
+    expect(hasFamilyActivity(activity({ workingAgents: 1 }))).toBe(true)
+    expect(hasFamilyActivity(activity({ workingProcesses: 1 }))).toBe(true)
+  })
+
+  it('spells the glyph row out for screen readers, attention first', () => {
+    expect(familyActivityLabel(activity({ error: 1, unread: 2, workingAgents: 1, workingProcesses: 3 })))
+      .toBe('Family: 1 member with an error, 2 unread members, 1 working subagent, 3 running processes. Open the family tree.')
+  })
+
+  it('omits zero states from the label', () => {
+    expect(familyActivityLabel(activity({ unread: 1 })))
+      .toBe('Family: 1 unread member. Open the family tree.')
+  })
+})
+
+describe('childTrailTitle', () => {
+  const root = agent('root')
+  const mid = agent('mid', 'root')
+  const leaf = agent('leaf', 'mid')
+
+  it('reads root › … › child for a deep descendant', () => {
+    const sessions = [root, mid, leaf]
+    expect(childTrailTitle(root, familyAncestors(leaf, sessions), leaf)).toBe('root › mid › leaf')
+  })
+
+  it('collapses to root › child for a direct child', () => {
+    const sessions = [root, mid]
+    expect(childTrailTitle(root, familyAncestors(mid, sessions), mid)).toBe('root › mid')
+  })
+
+  it('never repeats the root when the spine already starts with it', () => {
+    // familyAncestors is root-first; the trail must not print it twice.
+    expect(childTrailTitle(root, [root], mid)).toBe('root › mid')
   })
 })

--- a/apps/gmux-web/src/family.test.ts
+++ b/apps/gmux-web/src/family.test.ts
@@ -200,12 +200,12 @@ describe('family activity line', () => {
 
   it('spells the glyph row out for screen readers, attention first', () => {
     expect(familyActivityLabel(activity({ error: 1, unread: 2, workingAgents: 1, workingProcesses: 3 })))
-      .toBe('Family: 1 member with an error, 2 unread members, 1 working subagent, 3 running processes')
+      .toBe('Also in this family: 1 member with an error, 2 unread members, 1 working subagent, 3 running processes')
   })
 
   it('omits zero states from the label', () => {
     expect(familyActivityLabel(activity({ unread: 1 })))
-      .toBe('Family: 1 unread member')
+      .toBe('Also in this family: 1 unread member')
   })
 })
 

--- a/apps/gmux-web/src/family.ts
+++ b/apps/gmux-web/src/family.ts
@@ -196,8 +196,9 @@ export function hasFamilyActivity(activity: FamilyActivity): boolean {
     || activity.workingAgents > 0 || activity.workingProcesses > 0
 }
 
-/** Spoken form of the icon row, which is otherwise pure glyphs. Folded
- * into the root row's accessible name — the row it lives in. */
+/** Spoken form of the `+` line, which is otherwise pure glyphs. It
+ * counts the members the entry does *not* name, so it reads as an
+ * addition to the rows above it. */
 export function familyActivityLabel(activity: FamilyActivity): string {
   const parts: string[] = []
   // 'process' takes -es; everything else here takes -s.
@@ -207,7 +208,7 @@ export function familyActivityLabel(activity: FamilyActivity): string {
   if (activity.unread > 0) parts.push(plural(activity.unread, 'unread member'))
   if (activity.workingAgents > 0) parts.push(plural(activity.workingAgents, 'working subagent'))
   if (activity.workingProcesses > 0) parts.push(plural(activity.workingProcesses, 'running process'))
-  return `Family: ${parts.join(', ')}`
+  return `Also in this family: ${parts.join(', ')}`
 }
 
 /** Hover title for the sidebar's selected-child row: the path from the

--- a/apps/gmux-web/src/family.ts
+++ b/apps/gmux-web/src/family.ts
@@ -264,32 +264,44 @@ export function descendantTree(root: Session, source: FamilySource): FamilyNode 
   return build(root)
 }
 
-/** Drawer projection. Roots see their tree. A child sees its ancestor spine,
- * then the complete trees rooted at its own sibling level (including itself),
- * rather than unrelated siblings of each ancestor. */
+/** Panel projection: the whole family, from the root, wherever you're
+ * standing in it.
+ *
+ * It used to scope to your own sibling level, which meant the panel
+ * showed less the deeper you went — five levels down it showed one row,
+ * the session you were already looking at. Depth is exactly when you
+ * need the map, and a scope that shifts under you makes the counts line
+ * mean something different on every row you visit. Now one scope holds
+ * wherever you stand: the same members, the same counts.
+ *
+ * That is *membership*, not aggregation. The three family surfaces
+ * still summarise this set differently on purpose — the trigger badge
+ * mutes what you're looking at, the sidebar line subtracts the member
+ * its own row names, and this panel counts every row it draws, because
+ * it draws them all.
+ *
+ * `ancestors` stays for callers that want the spine on its own (the
+ * header crumbs); the tree already contains those rows. */
 export interface FamilyDrawerProjection {
   root: Session
   ancestors: Session[]
-  siblingTrees: FamilyNode[]
+  tree: FamilyNode
 }
 
 export function projectFamily(selected: Session, source: FamilySource): FamilyDrawerProjection {
   const index = indexFor(source)
   const root = familyRoot(selected, index)
-  if (root.id === selected.id) {
-    return { root, ancestors: [], siblingTrees: [descendantTree(root, index)] }
+  return {
+    root,
+    ancestors: familyAncestors(selected, index),
+    tree: descendantTree(root, index),
   }
-
-  const ancestors = familyAncestors(selected, index)
-  const parent = ancestors[ancestors.length - 1]
-  const siblings = parent ? index.childrenByParent.get(parent.id) ?? [] : []
-  return { root, ancestors, siblingTrees: siblings.map(s => descendantTree(s, index)) }
 }
 
-/** Status totals for the panel's counts line, over every family member the
- * panel shows (processes included, ancestors excluded — they live in the
- * header breadcrumbs). Each member is tallied once under its dot-precedence
- * state so the line and the row dots can never disagree. */
+/** Status totals for the panel's counts line, over every family member
+ * the panel shows — which is now the whole family, root included. Each
+ * member is tallied once under its dot-precedence state so the line and
+ * the row dots can never disagree. */
 export interface FamilyCounts {
   error: number
   working: number

--- a/apps/gmux-web/src/family.ts
+++ b/apps/gmux-web/src/family.ts
@@ -168,6 +168,61 @@ export function isProcessSession(session: Session): boolean {
   return session.semantic_agent !== true
 }
 
+/** What a family is *doing right now*, counted over the descendants of
+ * one presentation root. Idle members are deliberately not counted: the
+ * sidebar line exists to surface live work, not to take a census.
+ *
+ * Every counted member lands in exactly one bucket, under the same
+ * precedence `sessionDotState` uses (error > working > unread), so the
+ * line and the family drawer can never disagree. */
+export interface FamilyActivity {
+  /** Alive members whose last turn failed. */
+  readonly error: number
+  /** Members with output you haven't seen. */
+  readonly unread: number
+  /** Semantic-agent members mid-turn ("subagents"). */
+  readonly workingAgents: number
+  /** Non-agent members running a command ("processes"). */
+  readonly workingProcesses: number
+}
+
+export const NO_FAMILY_ACTIVITY: FamilyActivity = {
+  error: 0, unread: 0, workingAgents: 0, workingProcesses: 0,
+}
+
+/** True when a family has something worth a second sidebar line. */
+export function hasFamilyActivity(activity: FamilyActivity): boolean {
+  return activity.error > 0 || activity.unread > 0
+    || activity.workingAgents > 0 || activity.workingProcesses > 0
+}
+
+/** Accessible name for the icon row, which is otherwise pure glyphs. */
+export function familyActivityLabel(activity: FamilyActivity): string {
+  const parts: string[] = []
+  // 'process' takes -es; everything else here takes -s.
+  const plural = (n: number, word: string) =>
+    `${n} ${word}${n === 1 ? '' : word.endsWith('s') ? 'es' : 's'}`
+  if (activity.error > 0) parts.push(`${plural(activity.error, 'member')} with an error`)
+  if (activity.unread > 0) parts.push(plural(activity.unread, 'unread member'))
+  if (activity.workingAgents > 0) parts.push(plural(activity.workingAgents, 'working subagent'))
+  if (activity.workingProcesses > 0) parts.push(plural(activity.workingProcesses, 'running process'))
+  return `Family: ${parts.join(', ')}. Open the family tree.`
+}
+
+/** Hover title for the sidebar's selected-child row: the path from the
+ * family's root row down to the selected member, e.g.
+ * `orchestrator › implement drawer › wire up the adapter`. `ancestors`
+ * is the root-first spine from `familyAncestors` (its first entry is
+ * the root itself), so a direct child collapses to `root › child`. */
+export function childTrailTitle(
+  root: Session,
+  ancestors: readonly Session[],
+  child: Session,
+): string {
+  const middle = ancestors.filter(a => a.id !== root.id).map(a => a.title)
+  return [root.title, ...middle, child.title].join(' › ')
+}
+
 /** Complete descendant tree for a presentation root. Promoted descendants are
  * intentionally excluded: each starts a new family, while provenance remains
  * available on the raw session. */

--- a/apps/gmux-web/src/family.ts
+++ b/apps/gmux-web/src/family.ts
@@ -1,4 +1,6 @@
 import type { Session } from './types'
+// Type-only: erased at emit, so `family.ts` stays runtime-free of the store.
+import type { DotState } from './store'
 
 /** Resolve one potential task-family edge without trusting the rest of the
  * ancestry. The parent must be a semantic agent; its child may be any session.
@@ -160,6 +162,26 @@ function byRecency(a: Session, b: Session): number {
   const at = a.last_output_at || a.created_at
   const bt = b.last_output_at || b.created_at
   return bt.localeCompare(at) || a.id.localeCompare(b.id)
+}
+
+/** What the member row's glyph column shows, given the member and the
+ *  dot state the sidebar computed for it.
+ *
+ *  The column is always occupied, and — this is the load-bearing part —
+ *  it is the *only* place a named member's state can appear, because
+ *  the activity line subtracts whoever the row names. A glyph that
+ *  can't express `unread` therefore doesn't just look plainer; it drops
+ *  that member's attention entirely: counted nowhere, shown nowhere.
+ *  So a process keeps its `$` shape but carries state as colour, and an
+ *  agent with nothing to report falls back to the branch. */
+export type MemberGlyph =
+  | { readonly kind: 'process'; readonly state: DotState }
+  | { readonly kind: 'dot'; readonly state: Exclude<DotState, 'none'> }
+  | { readonly kind: 'branch' }
+
+export function familyMemberGlyph(member: Session, dot: DotState): MemberGlyph {
+  if (isProcessSession(member)) return { kind: 'process', state: dot }
+  return dot === 'none' ? { kind: 'branch' } : { kind: 'dot', state: dot }
 }
 
 /** A family member whose parent is a semantic agent but who is not one

--- a/apps/gmux-web/src/family.ts
+++ b/apps/gmux-web/src/family.ts
@@ -196,7 +196,8 @@ export function hasFamilyActivity(activity: FamilyActivity): boolean {
     || activity.workingAgents > 0 || activity.workingProcesses > 0
 }
 
-/** Accessible name for the icon row, which is otherwise pure glyphs. */
+/** Spoken form of the icon row, which is otherwise pure glyphs. Folded
+ * into the root row's accessible name — the row it lives in. */
 export function familyActivityLabel(activity: FamilyActivity): string {
   const parts: string[] = []
   // 'process' takes -es; everything else here takes -s.
@@ -206,7 +207,7 @@ export function familyActivityLabel(activity: FamilyActivity): string {
   if (activity.unread > 0) parts.push(plural(activity.unread, 'unread member'))
   if (activity.workingAgents > 0) parts.push(plural(activity.workingAgents, 'working subagent'))
   if (activity.workingProcesses > 0) parts.push(plural(activity.workingProcesses, 'running process'))
-  return `Family: ${parts.join(', ')}. Open the family tree.`
+  return `Family: ${parts.join(', ')}`
 }
 
 /** Hover title for the sidebar's selected-child row: the path from the

--- a/apps/gmux-web/src/launcher.tsx
+++ b/apps/gmux-web/src/launcher.tsx
@@ -174,19 +174,22 @@ export function LaunchButton({ className, onLaunch, beforeLaunch, cwd, peer }: L
     })
   }
 
-  // Close on outside click
+  // Close on outside press. pointerdown rather than mousedown, for the
+  // same reason as the other two popovers: touch gestures that
+  // preventDefault kill the synthesized mouse cascade, and an outside
+  // press that never arrives leaves the menu stranded.
   useEffect(() => {
     if (state !== 'open') return
-    const handler = (e: MouseEvent) => {
+    const handler = (e: PointerEvent) => {
       const t = e.target as Node
       if (containerRef.current?.contains(t)) return
       if (menuRef.current?.contains(t)) return
       setState('idle')
     }
-    const timer = setTimeout(() => document.addEventListener('mousedown', handler), 0)
+    const timer = setTimeout(() => document.addEventListener('pointerdown', handler), 0)
     return () => {
       clearTimeout(timer)
-      document.removeEventListener('mousedown', handler)
+      document.removeEventListener('pointerdown', handler)
     }
   }, [state])
 

--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -32,6 +32,7 @@ import {
   initStore, setNavigate, navigate, navigateToSession,
   dismissSession, resumeSession, restartSession,
   sessionStaleness, sessionDotState, activityMap, familyDotById, tabHref,
+  familyPanelOpen,
 } from './store'
 import { viewToPath } from './routing'
 
@@ -179,12 +180,14 @@ function MainHeader({ session, onRestart, onResume, resuming }: {
   onResume?: (id: string) => void
   resuming?: boolean
 }) {
-  const [familyOpen, setFamilyOpen] = useState(false)
+  // Open state lives in the store: the sidebar's family activity row
+  // opens this same panel (see familyPanelOpen).
+  const familyOpen = familyPanelOpen.value
   const familyTriggerRef = useRef<HTMLButtonElement>(null)
-  const closeFamily = useCallback(() => setFamilyOpen(false), [])
+  const closeFamily = useCallback(() => { familyPanelOpen.value = false }, [])
   const showFamily = session ? hasFamily(session, sessions.value) : false
   useEffect(() => {
-    if (!showFamily) setFamilyOpen(false)
+    if (!showFamily) familyPanelOpen.value = false
   }, [showFamily])
 
   if (!session) {
@@ -205,7 +208,7 @@ function MainHeader({ session, onRestart, onResume, resuming }: {
             session={session}
             open={familyOpen}
             triggerRef={familyTriggerRef}
-            onToggle={() => setFamilyOpen(open => !open)}
+            onToggle={() => { familyPanelOpen.value = !familyPanelOpen.value }}
           />
         )}
         {showFamily && <HeaderCrumbs session={session} />}

--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -32,7 +32,6 @@ import {
   initStore, setNavigate, navigate, navigateToSession,
   dismissSession, resumeSession, restartSession,
   sessionStaleness, sessionDotState, activityMap, familyDotById, tabHref,
-  familyPanelOpen,
 } from './store'
 import { viewToPath } from './routing'
 
@@ -180,14 +179,12 @@ function MainHeader({ session, onRestart, onResume, resuming }: {
   onResume?: (id: string) => void
   resuming?: boolean
 }) {
-  // Open state lives in the store: the sidebar's family activity row
-  // opens this same panel (see familyPanelOpen).
-  const familyOpen = familyPanelOpen.value
+  const [familyOpen, setFamilyOpen] = useState(false)
   const familyTriggerRef = useRef<HTMLButtonElement>(null)
-  const closeFamily = useCallback(() => { familyPanelOpen.value = false }, [])
+  const closeFamily = useCallback(() => { setFamilyOpen(false) }, [])
   const showFamily = session ? hasFamily(session, sessions.value) : false
   useEffect(() => {
-    if (!showFamily) familyPanelOpen.value = false
+    if (!showFamily) setFamilyOpen(false)
   }, [showFamily])
 
   if (!session) {
@@ -208,7 +205,7 @@ function MainHeader({ session, onRestart, onResume, resuming }: {
             session={session}
             open={familyOpen}
             triggerRef={familyTriggerRef}
-            onToggle={() => { familyPanelOpen.value = !familyPanelOpen.value }}
+            onToggle={() => { setFamilyOpen(v => !v) }}
           />
         )}
         {showFamily && <HeaderCrumbs session={session} />}

--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -349,18 +349,21 @@ function SessionMenu({ session, onRestart, onResume, resuming }: {
     : healthVal
   const staleKind = sessionStaleness(session, compareTarget)
 
-  // Close on outside click or Escape.
+  // Close on outside press or Escape. pointerdown rather than mousedown:
+  // the terminal cancels the synthesized mouse cascade on its touch
+  // gestures, so a tap into the terminal would otherwise leave this menu
+  // open on top of it (see FamilyDrawer for the same fix).
   useEffect(() => {
     if (!open) return
     const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setOpen(false) }
-    const onClick = (e: MouseEvent) => {
+    const onPointerDown = (e: PointerEvent) => {
       if (menuRef.current && !menuRef.current.contains(e.target as Node)) setOpen(false)
     }
     document.addEventListener('keydown', onKey)
-    document.addEventListener('mousedown', onClick)
+    document.addEventListener('pointerdown', onPointerDown)
     return () => {
       document.removeEventListener('keydown', onKey)
-      document.removeEventListener('mousedown', onClick)
+      document.removeEventListener('pointerdown', onPointerDown)
     }
   }, [open])
 

--- a/apps/gmux-web/src/mock-data/sessions/demo-family.ts
+++ b/apps/gmux-web/src/mock-data/sessions/demo-family.ts
@@ -41,7 +41,32 @@ export const DEMO_FAMILY: MockSession[] = [
     title: 'investigate a really long descendant title that should truncate somewhere sensible',
     parent_session_id: 'fam3kid', status: { active: false, error: true }, last_output_at: ago(5),
   }),
+  // Processes owned by agents in the chain: the sidebar's family
+  // activity row counts a running one under `$` (subagents get a dot),
+  // and the family drawer shows them with the same `$` glyph.
+  fam({
+    id: 'fam0proc', title: 'pnpm test --watch', parent_session_id: 'fam0root',
+    semantic_agent: false, adapter: 'shell', command: ['pnpm', 'test'],
+    status: { active: true }, last_output_at: ago(3),
+  }),
+  fam({
+    id: 'fam1proc', title: 'tail -f daemon.log', parent_session_id: 'fam1kid',
+    semantic_agent: false, adapter: 'shell', command: ['tail', '-f', 'daemon.log'],
+    last_output_at: ago(30),
+  }),
   // Long-titled one-parent chain (shallow case).
   fam({ id: 'famAroot', title: 'a genuinely very long root agent title for truncation checks', last_output_at: ago(60) }),
   fam({ id: 'famAkid', title: 'child of the long-titled root with its own long title', parent_session_id: 'famAroot', unread: true, last_output_at: ago(4) }),
+  // Process-only family: the summary line drops the empty segment and
+  // reads just "2 processes".
+  fam({ id: 'famBroot', title: 'build watcher agent', last_output_at: ago(90) }),
+  fam({
+    id: 'famBproc1', title: 'vite build --watch', parent_session_id: 'famBroot',
+    semantic_agent: false, adapter: 'shell', command: ['vite', 'build'],
+    status: { active: true }, last_output_at: ago(11),
+  }),
+  fam({
+    id: 'famBproc2', title: 'gofmt -l ./...', parent_session_id: 'famBroot',
+    semantic_agent: false, adapter: 'shell', command: ['gofmt'], unread: true, last_output_at: ago(9),
+  }),
 ]

--- a/apps/gmux-web/src/session-row.tsx
+++ b/apps/gmux-web/src/session-row.tsx
@@ -58,8 +58,9 @@ export interface SessionRowProps {
 
 /** Compact "Nm" / "Nh" / "Nd" relative-time for the full row's age.
  *  Sub-minute collapses to "now" so a fresh row doesn't tick every
- *  second. */
-function formatAge(stampIso: string | undefined, now: number): string | null {
+ *  second. Shared with the family panel, which sorts by the same
+ *  timestamp and so has to show it. */
+export function formatAge(stampIso: string | undefined, now: number): string | null {
   if (!stampIso) return null
   const t = Date.parse(stampIso)
   if (!Number.isFinite(t)) return null

--- a/apps/gmux-web/src/sidebar.tsx
+++ b/apps/gmux-web/src/sidebar.tsx
@@ -7,7 +7,7 @@
 
 import { useState, useCallback, useRef, useEffect } from 'preact/hooks'
 import { needsReveal } from './sidebar-reveal'
-import { hasSessionSlugCollision, sessionPath } from './routing'
+import { hasSessionSlugCollision, sessionPath, viewToPath } from './routing'
 import { selectorLabel, folderMatchesFilter, type Selector } from './tab-filter'
 import { reorderKeysForFolder } from './projects'
 import { LaunchButton } from './launcher'
@@ -17,7 +17,8 @@ import {
   activityMap, projects, connState, health, peers,
   collapsedFolders, toggleFolderCollapsed,
   updateProjects, reorderSessions,
-  peerStatusByName, isSessionUnavailable, localPeerNames, sessionDotState, familyDotById,
+  peerStatusByName, isSessionUnavailable, localPeerNames, ownDotState, selectedId,
+  familyActivityById, selectedFamilyChild, familyPanelOpen,
   unreadCount, localHostLabel, unresolvedHosts, duplicateConversationFiles,
   sidebarActivity, sidebarMode, setSidebarMode,
   activeSelectors, removeSelector, setHostFilter,
@@ -26,6 +27,10 @@ import {
 } from './store'
 import { HostSuffix } from './host-suffix'
 import { SessionRow } from './session-row'
+import {
+  childTrailTitle, familyActivityLabel, hasFamilyActivity, isProcessSession,
+  NO_FAMILY_ACTIVITY, type FamilyActivity,
+} from './family'
 import type { Session, Folder } from './types'
 
 // ── Types ──
@@ -108,6 +113,13 @@ function DevcontainerMarker({ peer }: { peer: string }) {
       <path d="M4 3.5v6 M6 3.5v6 M8 3.5v6" />
     </svg>
   )
+}
+
+/** Deep link to any session by id (the child rows can't reuse the
+ *  folder's slug: a descendant may live in another project). */
+function sessionHref(session: Session): string | undefined {
+  const path = viewToPath({ kind: 'session', sessionId: session.id }, projects.value, sessions.value)
+  return path ? tabHref(path) : undefined
 }
 
 function reorder<T>(arr: T[], from: number, to: number): T[] {
@@ -216,6 +228,115 @@ function SessionItem({
   )
 }
 
+/** The sidebar's family entry: one root row plus, indented under the
+ *  root title, an optional selected-child row and an activity row.
+ *
+ *  Four rules hold this together:
+ *   - the root row's dot is the *root session's own* status, so a
+ *     working child never masquerades as a working root;
+ *   - the activity row speaks in the sidebar's existing dot vocabulary
+ *     — error, unread, working subagent, running process — and only
+ *     appears when at least one of them is non-zero. An idle family
+ *     adds no line at all;
+ *   - selection highlight lives on the card, not the inner rows, so a
+ *     selected child reads as "this family, this member" instead of a
+ *     standalone sidebar item, while the row under the pointer still
+ *     highlights as the click target;
+ *   - a root with no descendants renders no card at all — standalone
+ *     sessions stay exactly as compact as before.
+ */
+function FamilyEntry({
+  selected,
+  activity,
+  rootHref,
+  child,
+  childHref,
+  childPath,
+  onClick,
+  onOpenTree,
+  children,
+}: {
+  selected: boolean
+  activity: FamilyActivity
+  /** The root row's own href; the activity row navigates there too. */
+  rootHref: string
+  /** Selected descendant of this root, when the selection is a child. */
+  child?: Session
+  childHref?: string
+  /** Root › … › child trail, for the child row's hover title. */
+  childPath?: string
+  onClick?: () => void
+  /** Click on the activity row: select the root and open the tree. */
+  onOpenTree?: () => void
+  /** The root's own `SessionItem`. */
+  children: preact.ComponentChildren
+}) {
+  const childDot = child ? ownDotState(child, activityMap.value, child.id) : 'none'
+  const showActivity = hasFamilyActivity(activity)
+  // The branch glyph marks the first sub-row only; the second aligns
+  // under it with an empty span of the same width.
+  const branch = (first: boolean) => (
+    <span class="family-sub-branch" aria-hidden="true">{first ? '↳' : ''}</span>
+  )
+  return (
+    <div class={`session-family${selected ? ' selected' : ''}`}>
+      {children}
+      {child && (
+        <a
+          class="family-sub-row family-selected-child"
+          href={childHref}
+          aria-current="page"
+          title={childPath}
+          onClick={() => onClick?.()}
+        >
+          {branch(true)}
+          {/* No reserved dot column: a quiet member spends the space on
+            * its title instead. */}
+          {isProcessSession(child)
+            ? <span class={`family-child-proc${child.alive && child.status?.active ? ' working' : ''}`} aria-hidden="true">$</span>
+            : childDot !== 'none' && <span class={`session-dot-indicator ${childDot}`} aria-hidden="true" />}
+          <span class="family-child-title">{child.title}</span>
+        </a>
+      )}
+      {showActivity && (
+        <a
+          class="family-sub-row family-activity"
+          href={rootHref}
+          aria-label={familyActivityLabel(activity)}
+          title={familyActivityLabel(activity)}
+          onClick={() => { onOpenTree?.(); onClick?.() }}
+        >
+          {branch(!child)}
+          {activity.error > 0 && (
+            <span class="family-activity-seg">
+              <span class="session-dot-indicator error" aria-hidden="true" />
+              {activity.error}
+            </span>
+          )}
+          {activity.unread > 0 && (
+            <span class="family-activity-seg">
+              <span class="session-dot-indicator unread" aria-hidden="true" />
+              {activity.unread}
+            </span>
+          )}
+          {activity.workingAgents > 0 && (
+            <span class="family-activity-seg">
+              <span class="session-dot-indicator working" aria-hidden="true" />
+              {activity.workingAgents}
+            </span>
+          )}
+          {activity.workingProcesses > 0 && (
+            <span class="family-activity-seg">
+              <span class="family-child-proc working" aria-hidden="true">$</span>
+              {activity.workingProcesses}
+            </span>
+          )}
+        </a>
+      )}
+    </div>
+  )
+}
+
 function FolderGroup({
   folder,
   selId,
@@ -237,6 +358,12 @@ function FolderGroup({
   onClick?: () => void
 }) {
   const [drag, setDrag] = useState<DragState | null>(null)
+  // Snapshot-wide family derivations, read once per folder render. All
+  // three are O(n) maps built once per session-list identity in the
+  // store, so a folder's rows stay O(rows) lookups.
+  const activityById = familyActivityById.value
+  const selChild = selectedFamilyChild.value
+  const rawSelId = selectedId.value
 
   const handleDragStart = useCallback((idx: number) => {
     setDrag({ from: idx, over: idx })
@@ -347,25 +474,51 @@ function FolderGroup({
       </div>
       {shown.length > 0 && (
       <div class="folder-sessions">
-        {shown.map((s, i) => (
-          <SessionItem
-            key={s.id}
-            session={s}
-            href={tabHref(sessionPath(folder.slug, s, folder.peer, hasSessionSlugCollision(s, sessions.value, projects.value)))}
-            selected={selId === s.id}
-            resuming={resumingId === s.id}
-            dotState={familyDotById.value.get(s.id) ?? sessionDotState(s, am)}
-            unavailable={isSessionUnavailable(s, peerStatus)}
-            showHostMarker={mixedHosts}
-            dragging={drag !== null && s.id === visible[drag.from]?.id}
-            dropTarget={drag !== null && drag.over === i && drag.from !== i}
-            onClose={() => onCloseSession(s)}
-            onClick={onClick}
-            onDragStart={dragDisabled ? undefined : () => handleDragStart(i)}
-            onDragOver={dragDisabled ? undefined : () => handleDragOver(i)}
-            onDragEnd={dragDisabled ? undefined : () => handleDragEnd(visible)}
-          />
-        ))}
+        {shown.map((s, i) => {
+          const href = tabHref(sessionPath(folder.slug, s, folder.peer, hasSessionSlugCollision(s, sessions.value, projects.value)))
+          const item = (
+            <SessionItem
+              key={s.id}
+              session={s}
+              href={href}
+              selected={selId === s.id}
+              resuming={resumingId === s.id}
+              // Root row = root's own status. The family roll-up lives on
+              // the summary line below it (see FamilyEntry).
+              dotState={ownDotState(s, am, rawSelId)}
+              unavailable={isSessionUnavailable(s, peerStatus)}
+              showHostMarker={mixedHosts}
+              dragging={drag !== null && s.id === visible[drag.from]?.id}
+              dropTarget={drag !== null && drag.over === i && drag.from !== i}
+              onClose={() => onCloseSession(s)}
+              onClick={onClick}
+              onDragStart={dragDisabled ? undefined : () => handleDragStart(i)}
+              onDragOver={dragDisabled ? undefined : () => handleDragOver(i)}
+              onDragEnd={dragDisabled ? undefined : () => handleDragEnd(visible)}
+            />
+          )
+          const activity = activityById.get(s.id) ?? NO_FAMILY_ACTIVITY
+          const child = selChild?.rootId === s.id ? selChild.session : undefined
+          // No selected child and nothing happening: a plain row. This
+          // is every standalone session and every idle family.
+          if (!child && !hasFamilyActivity(activity)) return item
+          const childPath = child ? childTrailTitle(s, selChild?.ancestors ?? [], child) : undefined
+          return (
+            <FamilyEntry
+              key={s.id}
+              selected={selId === s.id}
+              activity={activity}
+              rootHref={href}
+              child={child}
+              childHref={child ? sessionHref(child) : undefined}
+              childPath={childPath}
+              onClick={onClick}
+              onOpenTree={() => { familyPanelOpen.value = true }}
+            >
+              {item}
+            </FamilyEntry>
+          )
+        })}
       </div>
       )}
     </div>

--- a/apps/gmux-web/src/sidebar.tsx
+++ b/apps/gmux-web/src/sidebar.tsx
@@ -28,7 +28,7 @@ import {
 import { HostSuffix } from './host-suffix'
 import { SessionRow } from './session-row'
 import {
-  childTrailTitle, familyActivityLabel, hasFamilyActivity, isProcessSession,
+  childTrailTitle, familyActivityLabel, familyMemberGlyph, hasFamilyActivity,
   NO_FAMILY_ACTIVITY, type FamilyActivity,
 } from './family'
 import type { Session, Folder } from './types'
@@ -242,25 +242,25 @@ function FamilyActivityLine({ activity }: { activity: FamilyActivity }) {
       <span class="family-activity-glyphs" aria-hidden="true">
         {activity.error > 0 && (
           <span class="family-activity-seg">
-            <span class="session-dot-indicator error" />
+            <span class="family-glyph session-dot-indicator error" />
             {activity.error}
           </span>
         )}
         {activity.unread > 0 && (
           <span class="family-activity-seg">
-            <span class="session-dot-indicator unread" />
+            <span class="family-glyph session-dot-indicator unread" />
             {activity.unread}
           </span>
         )}
         {activity.workingAgents > 0 && (
           <span class="family-activity-seg">
-            <span class="session-dot-indicator working" />
+            <span class="family-glyph session-dot-indicator working" />
             {activity.workingAgents}
           </span>
         )}
         {activity.workingProcesses > 0 && (
           <span class="family-activity-seg">
-            <span class="family-child-proc working">$</span>
+            <span class="family-glyph family-child-proc working">$</span>
             {activity.workingProcesses}
           </span>
         )}
@@ -318,7 +318,13 @@ function FamilyEntry({
   children: preact.ComponentChildren
 }) {
   const member = slot?.session
-  const dot = member ? ownDotState(member, activityMap.value, selectedId.value) : 'none'
+  // One decision, made in `family.ts` so it can be tested: which glyph
+  // this member gets, and what state it carries. The row is the only
+  // place a named member's state can appear — the activity line
+  // subtracts it — so the glyph has to be able to say `unread`.
+  const glyph = member
+    ? familyMemberGlyph(member, ownDotState(member, activityMap.value, selectedId.value))
+    : null
   return (
     // Not focusable on purpose: the group's own rows are the keyboard
     // targets, and this only hands the pointer the slack between them,
@@ -355,11 +361,17 @@ function FamilyEntry({
           title={slotTrail}
           onClick={() => onClick?.()}
         >
-          {/* No reserved dot column: a quiet member spends the space on
-            * its title instead. */}
-          {isProcessSession(member)
-            ? <span class={`family-child-proc${member.alive && member.status?.active ? ' working' : ''}`} aria-hidden="true">$</span>
-            : dot !== 'none' && <span class={`session-dot-indicator ${dot}`} aria-hidden="true" />}
+          {/* One fixed-width glyph column, always filled: the member's
+            * status, its `$` if it's a process, or the branch arrow when
+            * there's nothing to report. The arrow is what a quiet member
+            * looks like — it marks the row as hanging off the root, and
+            * it keeps the title from sliding sideways when state
+            * arrives or clears. */}
+          {glyph?.kind === 'process'
+            ? <span class={`family-glyph family-child-proc ${glyph.state}`} aria-hidden="true">$</span>
+            : glyph?.kind === 'dot'
+            ? <span class={`family-glyph session-dot-indicator ${glyph.state}`} aria-hidden="true" />
+            : <span class="family-glyph family-branch" aria-hidden="true">↳</span>}
           <span class="family-slot-title">{member.title}</span>
         </a>
       )}

--- a/apps/gmux-web/src/sidebar.tsx
+++ b/apps/gmux-web/src/sidebar.tsx
@@ -18,7 +18,7 @@ import {
   collapsedFolders, toggleFolderCollapsed,
   updateProjects, reorderSessions,
   peerStatusByName, isSessionUnavailable, localPeerNames, ownDotState, selectedId,
-  familyActivityById, familySlotById, familyPanelOpen, type FamilySlot,
+  familyActivityById, familySlotById, type FamilySlot,
   unreadCount, localHostLabel, unresolvedHosts, duplicateConversationFiles,
   sidebarActivity, sidebarMode, setSidebarMode,
   activeSelectors, removeSelector, setHostFilter,
@@ -139,7 +139,6 @@ function SessionItem({
   dropTarget,
   unavailable,
   showHostMarker,
-  meta,
   onClose,
   onClick,
   onDragStart,
@@ -157,13 +156,9 @@ function SessionItem({
   unavailable?: boolean
   /** Folder spans multiple hosts; render this session's host marker. */
   showHostMarker?: boolean
-  /** Second line inside this row (family activity). Part of the row's
-   *  own link: one target, one hover, one thing in the a11y tree. */
-  meta?: preact.ComponentChildren
   onClose?: () => void
-  /** Extra side-effects on click (e.g. close mobile sidebar). The event
-   *  lets a caller react to *where* in the row the click landed. */
-  onClick?: (event: MouseEvent) => void
+  /** Extra side-effects on click (e.g. close mobile sidebar). */
+  onClick?: () => void
   onDragStart?: () => void
   onDragOver?: () => void
   onDragEnd?: () => void
@@ -190,9 +185,7 @@ function SessionItem({
       class={cls}
       href={href}
       draggable={canDrag && !!onDragStart}
-      onClick={(e) => {
-        onClick?.(e)
-      }}
+      onClick={() => { onClick?.() }}
       onAuxClick={(e) => { if (e.button === 1 && onClose) { e.preventDefault(); onClose() } }}
       onDragStart={(e) => {
         e.dataTransfer!.effectAllowed = 'move'
@@ -214,7 +207,6 @@ function SessionItem({
         <div class="session-title-row">
           <span class="session-title">{session.title}</span>
         </div>
-        {meta}
         {duplicateOpen && (
           <div class="session-meta">
             <span class="session-dup-warning" title="This conversation is open in more than one tab">⚠ open elsewhere</span>
@@ -234,21 +226,19 @@ function SessionItem({
   )
 }
 
-/** The family activity line: the second line *inside* a root row, in
- *  the sidebar's own dot vocabulary — error, unread, working subagent,
- *  running process — each segment dropped at zero. It belongs to the
- *  root's link rather than being its own hit area: one target, one
- *  hover, one entry in the a11y tree. Clicking it still opens the
- *  family tree (see FolderGroup) because you clearly asked about the
- *  family, but it lands you on the root either way. */
+/** The `+` line: what the family entry does *not* name, in the
+ *  sidebar's own dot vocabulary — error, unread, working subagent,
+ *  running process — each segment dropped at zero. It's the last thing
+ *  hanging off the trunk, and it's inert: a count is a fact, not a
+ *  destination, and the rows above it are where you'd go.
+ */
 function FamilyActivityLine({ activity }: { activity: FamilyActivity }) {
   const label = familyActivityLabel(activity)
   return (
-    <>
-      {/* Glyphs are decoration; the sentence below carries the meaning
-        * into the root link's accessible name. */}
-      <div class="family-activity" aria-hidden="true" title={label}>
-        <span class="family-branch">↳</span>
+    <div class="family-sub family-activity" title={label}>
+      {/* Glyphs are decoration; the sentence carries the meaning. */}
+      <span class="family-activity-glyphs" aria-hidden="true">
+        <span class="family-plus">+</span>
         {activity.error > 0 && (
           <span class="family-activity-seg">
             <span class="session-dot-indicator error" />
@@ -273,62 +263,65 @@ function FamilyActivityLine({ activity }: { activity: FamilyActivity }) {
             {activity.workingProcesses}
           </span>
         )}
-      </div>
+      </span>
       <span class="sr-only">{label}</span>
-    </>
+    </div>
   )
 }
 
-/** The sidebar's family entry: a root row with one family member kept
- *  beneath it — the member you're viewing, or the last one you did.
+/** The sidebar's family entry: a root row, the one family member kept
+ *  beneath it — the member you're viewing, or the last one you did —
+ *  and a `+` line counting everyone else.
  *
  *  Three rules hold this together:
  *   - the root row's dot is the *root session's own* status, so a
  *     working child never masquerades as a working root;
- *   - the slot row is the way back into the family. It's a real link of
- *     its own, but the selection highlight lives on the card, so it
- *     reads as "this family, this member" rather than a standalone
- *     sidebar item;
- *   - exactly one member ever shows. A second one would grow this into
- *     the family tree, which is a different surface.
+ *   - each member is represented exactly once: named by a row, or
+ *     counted on the `+` line, never both;
+ *   - selection is drawn on the row you selected, like any other
+ *     sidebar item. What binds the rows into one entry is the trunk
+ *     down the gutter, which is always there — including for the idle
+ *     family that has nothing to report.
  */
 function FamilyEntry({
-  selected,
   slot,
   slotHref,
   slotTrail,
+  activity,
   onClick,
   children,
 }: {
-  selected: boolean
-  slot: FamilySlot
+  slot?: FamilySlot
   slotHref?: string
   /** Root › … › member trail, for the slot row's hover title. */
   slotTrail?: string
+  activity: FamilyActivity
   onClick?: () => void
   /** The root's own `SessionItem`. */
   children: preact.ComponentChildren
 }) {
-  const member = slot.session
-  const dot = ownDotState(member, activityMap.value, selectedId.value)
+  const member = slot?.session
+  const dot = member ? ownDotState(member, activityMap.value, selectedId.value) : 'none'
   return (
-    <div class={`session-family${selected ? ' selected' : ''}`}>
+    <div class="session-family">
       {children}
-      <a
-        class={`family-slot${slot.selected ? ' current' : ''}`}
-        href={slotHref}
-        aria-current={slot.selected ? 'page' : undefined}
-        title={slotTrail}
-        onClick={() => onClick?.()}
-      >
-        <span class="family-branch" aria-hidden="true">↳</span>
-        {/* No reserved dot column: a quiet member spends the space on
-          * its title instead. */}
-        {isProcessSession(member)
-          ? <span class={`family-child-proc${member.alive && member.status?.active ? ' working' : ''}`} aria-hidden="true">$</span>
-          : dot !== 'none' && <span class={`session-dot-indicator ${dot}`} aria-hidden="true" />}
-        <span class="family-slot-title">{member.title}</span>
-      </a>
+      {member && (
+        <a
+          class={`family-sub family-slot${slot.selected ? ' selected' : ''}`}
+          href={slotHref}
+          aria-current={slot.selected ? 'page' : undefined}
+          title={slotTrail}
+          onClick={() => onClick?.()}
+        >
+          {/* No reserved dot column: a quiet member spends the space on
+            * its title instead. */}
+          {isProcessSession(member)
+            ? <span class={`family-child-proc${member.alive && member.status?.active ? ' working' : ''}`} aria-hidden="true">$</span>
+            : dot !== 'none' && <span class={`session-dot-indicator ${dot}`} aria-hidden="true" />}
+          <span class="family-slot-title">{member.title}</span>
+        </a>
+      )}
+      {hasFamilyActivity(activity) && <FamilyActivityLine activity={activity} />}
     </div>
   )
 }
@@ -479,39 +472,34 @@ function FolderGroup({
               key={s.id}
               session={s}
               href={href}
-              selected={selId === s.id}
+              // `selId` maps a selected descendant onto its root row.
+              // The entry now draws that selection on the member's own
+              // row instead, so the root row only lights up for itself.
+              selected={selId === s.id && !slot?.selected}
               resuming={resumingId === s.id}
               // Root row = root's own status. The family roll-up lives on
               // the summary line below it (see FamilyEntry).
               dotState={ownDotState(s, am, rawSelId)}
               unavailable={isSessionUnavailable(s, peerStatus)}
               showHostMarker={mixedHosts}
-              meta={hasFamilyActivity(activity) ? <FamilyActivityLine activity={activity} /> : undefined}
               dragging={drag !== null && s.id === visible[drag.from]?.id}
               dropTarget={drag !== null && drag.over === i && drag.from !== i}
               onClose={() => onCloseSession(s)}
-              // Clicking the activity line asked about the family, so
-              // bring the tree up with it. Every click still lands on
-              // the root: same link, same destination.
-              onClick={(e) => {
-                if ((e.target as HTMLElement | null)?.closest('.family-activity')) familyPanelOpen.value = true
-                onClick?.()
-              }}
+              onClick={onClick}
               onDragStart={dragDisabled ? undefined : () => handleDragStart(i)}
               onDragOver={dragDisabled ? undefined : () => handleDragOver(i)}
               onDragEnd={dragDisabled ? undefined : () => handleDragEnd(visible)}
             />
           )
-          // No remembered/selected member: the row stands alone (its
-          // activity line, if any, is already inside it).
-          if (!slot) return item
+          // Nothing to hang off a trunk: the row stands alone.
+          if (!slot && !hasFamilyActivity(activity)) return item
           return (
             <FamilyEntry
               key={s.id}
-              selected={selId === s.id}
               slot={slot}
-              slotHref={sessionHref(slot.session)}
-              slotTrail={childTrailTitle(s, slot.ancestors, slot.session)}
+              slotHref={slot && sessionHref(slot.session)}
+              slotTrail={slot && childTrailTitle(s, slot.ancestors, slot.session)}
+              activity={activity}
               onClick={onClick}
             >
               {item}

--- a/apps/gmux-web/src/sidebar.tsx
+++ b/apps/gmux-web/src/sidebar.tsx
@@ -22,7 +22,7 @@ import {
   unreadCount, localHostLabel, unresolvedHosts, duplicateConversationFiles,
   sidebarActivity, sidebarMode, setSidebarMode,
   activeSelectors, removeSelector, setHostFilter,
-  aliveOnly, setAliveOnly, tabHref, sessionStreamWarnings, sessionStreamOmittedTotal,
+  aliveOnly, setAliveOnly, tabHref, navigate, sessionStreamWarnings, sessionStreamOmittedTotal,
   type DotState,
 } from './store'
 import { HostSuffix } from './host-suffix'
@@ -193,7 +193,10 @@ function SessionItem({
         onDragStart?.()
       }}
       onDragOver={(e) => { e.preventDefault(); e.dataTransfer!.dropEffect = 'move'; onDragOver?.() }}
-      onDrop={(e) => { e.preventDefault(); onDragEnd?.() }}
+      // Family entries wrap this row in a group that is itself a drop
+      // target; without this the drop runs both handlers in one dispatch,
+      // before a re-render can clear `drag`, and the reorder is sent twice.
+      onDrop={(e) => { e.preventDefault(); e.stopPropagation(); onDragEnd?.() }}
       onDragEnd={onDragEnd}
     >
       {unavailable
@@ -226,19 +229,17 @@ function SessionItem({
   )
 }
 
-/** The `+` line: what the family entry does *not* name, in the
+/** The activity line: what the entry does *not* name by row, in the
  *  sidebar's own dot vocabulary — error, unread, working subagent,
- *  running process — each segment dropped at zero. It's the last thing
- *  hanging off the trunk, and it's inert: a count is a fact, not a
- *  destination, and the rows above it are where you'd go.
- */
+ *  running process — each segment dropped at zero. It's a count, not a
+ *  destination, so it has no target of its own; like the rest of the
+ *  entry's slack it belongs to the group, which selects the root. */
 function FamilyActivityLine({ activity }: { activity: FamilyActivity }) {
   const label = familyActivityLabel(activity)
   return (
     <div class="family-sub family-activity" title={label}>
       {/* Glyphs are decoration; the sentence carries the meaning. */}
       <span class="family-activity-glyphs" aria-hidden="true">
-        <span class="family-plus">+</span>
         {activity.error > 0 && (
           <span class="family-activity-seg">
             <span class="session-dot-indicator error" />
@@ -271,39 +272,80 @@ function FamilyActivityLine({ activity }: { activity: FamilyActivity }) {
 
 /** The sidebar's family entry: a root row, the one family member kept
  *  beneath it — the member you're viewing, or the last one you did —
- *  and a `+` line counting everyone else.
+ *  and a line counting everyone else.
  *
- *  Three rules hold this together:
- *   - the root row's dot is the *root session's own* status, so a
- *     working child never masquerades as a working root;
- *   - each member is represented exactly once: named by a row, or
- *     counted on the `+` line, never both;
- *   - selection is drawn on the row you selected, like any other
- *     sidebar item. What binds the rows into one entry is the trunk
- *     down the gutter, which is always there — including for the idle
- *     family that has nothing to report.
+ *  Selection and hit areas nest, the way the sessions do:
+ *   - the group is the root's area. Hovering anywhere in it highlights
+ *     the whole group, and any click that doesn't land on the member
+ *     row selects the root — including the counts line and the slack
+ *     around it, which have nothing better to do;
+ *   - the member row is its own area inside that one, with its own
+ *     highlight a tone above the group's;
+ *   - the background says *which family* you're in, the accent bar says
+ *     *which row*, so selecting a member keeps the group lit and moves
+ *     the bar down to it.
+ *
+ *  Two more rules hold the content together: the root row's dot is the
+ *  root session's own status, so a working child never masquerades as a
+ *  working root; and each member is represented exactly once, named by
+ *  a row or counted on the line, never both.
  */
 function FamilyEntry({
+  selected,
+  rootHref,
   slot,
   slotHref,
   slotTrail,
   activity,
   onClick,
+  onDragOver,
+  onDragEnd,
   children,
 }: {
+  /** Something in this family is selected — root or member. */
+  selected: boolean
+  rootHref: string
   slot?: FamilySlot
   slotHref?: string
-  /** Root › … › member trail, for the slot row's hover title. */
+  /** Root › … › member trail, for the member row's hover title. */
   slotTrail?: string
   activity: FamilyActivity
   onClick?: () => void
+  /** Reorder drop target for the whole group, not just the root row. */
+  onDragOver?: () => void
+  onDragEnd?: () => void
   /** The root's own `SessionItem`. */
   children: preact.ComponentChildren
 }) {
   const member = slot?.session
   const dot = member ? ownDotState(member, activityMap.value, selectedId.value) : 'none'
   return (
-    <div class="session-family">
+    // Not focusable on purpose: the group's own rows are the keyboard
+    // targets, and this only hands the pointer the slack between them,
+    // which leads somewhere those rows already go.
+    <div
+      class={`session-family${selected ? ' selected' : ''}`}
+      onClick={(e) => {
+        // Anything with its own target keeps it (root row, member row,
+        // close button); the leftovers fall through to the root.
+        if ((e.target as HTMLElement | null)?.closest('a, button')) return
+        // The slack is a convenience, not a link, so it declines every
+        // gesture a link would answer differently: a modified click
+        // wants a new tab or a download, and a click that ends a text
+        // selection wants the text, not a navigation. Doing otherwise
+        // makes the entry feel like it grabs at the pointer.
+        if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return
+        if (!(getSelection()?.isCollapsed ?? true)) return
+        e.preventDefault()
+        navigate(rootHref)
+        onClick?.()
+      }}
+      // A family entry is one reorder target. Without this the drop is
+      // only accepted over the root row, so the taller the entry grows
+      // the more of it silently refuses the drag.
+      onDragOver={onDragOver && ((e) => { e.preventDefault(); e.dataTransfer!.dropEffect = 'move'; onDragOver() })}
+      onDrop={onDragEnd && ((e) => { e.preventDefault(); onDragEnd() })}
+    >
       {children}
       {member && (
         <a
@@ -491,11 +533,15 @@ function FolderGroup({
               onDragEnd={dragDisabled ? undefined : () => handleDragEnd(visible)}
             />
           )
-          // Nothing to hang off a trunk: the row stands alone.
+          // No member to name and nothing else to count: one plain row.
           if (!slot && !hasFamilyActivity(activity)) return item
           return (
             <FamilyEntry
               key={s.id}
+              selected={selId === s.id}
+              rootHref={href}
+              onDragOver={dragDisabled ? undefined : () => handleDragOver(i)}
+              onDragEnd={dragDisabled ? undefined : () => handleDragEnd(visible)}
               slot={slot}
               slotHref={slot && sessionHref(slot.session)}
               slotTrail={slot && childTrailTitle(s, slot.ancestors, slot.session)}

--- a/apps/gmux-web/src/sidebar.tsx
+++ b/apps/gmux-web/src/sidebar.tsx
@@ -18,7 +18,7 @@ import {
   collapsedFolders, toggleFolderCollapsed,
   updateProjects, reorderSessions,
   peerStatusByName, isSessionUnavailable, localPeerNames, ownDotState, selectedId,
-  familyActivityById, selectedFamilyChild, familyPanelOpen,
+  familyActivityById, familySlotById, familyPanelOpen, type FamilySlot,
   unreadCount, localHostLabel, unresolvedHosts, duplicateConversationFiles,
   sidebarActivity, sidebarMode, setSidebarMode,
   activeSelectors, removeSelector, setHostFilter,
@@ -139,6 +139,7 @@ function SessionItem({
   dropTarget,
   unavailable,
   showHostMarker,
+  meta,
   onClose,
   onClick,
   onDragStart,
@@ -156,9 +157,13 @@ function SessionItem({
   unavailable?: boolean
   /** Folder spans multiple hosts; render this session's host marker. */
   showHostMarker?: boolean
+  /** Second line inside this row (family activity). Part of the row's
+   *  own link: one target, one hover, one thing in the a11y tree. */
+  meta?: preact.ComponentChildren
   onClose?: () => void
-  /** Extra side-effects on click (e.g. close mobile sidebar). */
-  onClick?: () => void
+  /** Extra side-effects on click (e.g. close mobile sidebar). The event
+   *  lets a caller react to *where* in the row the click landed. */
+  onClick?: (event: MouseEvent) => void
   onDragStart?: () => void
   onDragOver?: () => void
   onDragEnd?: () => void
@@ -185,8 +190,8 @@ function SessionItem({
       class={cls}
       href={href}
       draggable={canDrag && !!onDragStart}
-      onClick={() => {
-        onClick?.()
+      onClick={(e) => {
+        onClick?.(e)
       }}
       onAuxClick={(e) => { if (e.button === 1 && onClose) { e.preventDefault(); onClose() } }}
       onDragStart={(e) => {
@@ -209,6 +214,7 @@ function SessionItem({
         <div class="session-title-row">
           <span class="session-title">{session.title}</span>
         </div>
+        {meta}
         {duplicateOpen && (
           <div class="session-meta">
             <span class="session-dup-warning" title="This conversation is open in more than one tab">⚠ open elsewhere</span>
@@ -228,111 +234,101 @@ function SessionItem({
   )
 }
 
-/** The sidebar's family entry: one root row plus, indented under the
- *  root title, an optional selected-child row and an activity row.
+/** The family activity line: the second line *inside* a root row, in
+ *  the sidebar's own dot vocabulary — error, unread, working subagent,
+ *  running process — each segment dropped at zero. It belongs to the
+ *  root's link rather than being its own hit area: one target, one
+ *  hover, one entry in the a11y tree. Clicking it still opens the
+ *  family tree (see FolderGroup) because you clearly asked about the
+ *  family, but it lands you on the root either way. */
+function FamilyActivityLine({ activity }: { activity: FamilyActivity }) {
+  const label = familyActivityLabel(activity)
+  return (
+    <>
+      {/* Glyphs are decoration; the sentence below carries the meaning
+        * into the root link's accessible name. */}
+      <div class="family-activity" aria-hidden="true" title={label}>
+        <span class="family-branch">↳</span>
+        {activity.error > 0 && (
+          <span class="family-activity-seg">
+            <span class="session-dot-indicator error" />
+            {activity.error}
+          </span>
+        )}
+        {activity.unread > 0 && (
+          <span class="family-activity-seg">
+            <span class="session-dot-indicator unread" />
+            {activity.unread}
+          </span>
+        )}
+        {activity.workingAgents > 0 && (
+          <span class="family-activity-seg">
+            <span class="session-dot-indicator working" />
+            {activity.workingAgents}
+          </span>
+        )}
+        {activity.workingProcesses > 0 && (
+          <span class="family-activity-seg">
+            <span class="family-child-proc working">$</span>
+            {activity.workingProcesses}
+          </span>
+        )}
+      </div>
+      <span class="sr-only">{label}</span>
+    </>
+  )
+}
+
+/** The sidebar's family entry: a root row with one family member kept
+ *  beneath it — the member you're viewing, or the last one you did.
  *
- *  Four rules hold this together:
+ *  Three rules hold this together:
  *   - the root row's dot is the *root session's own* status, so a
  *     working child never masquerades as a working root;
- *   - the activity row speaks in the sidebar's existing dot vocabulary
- *     — error, unread, working subagent, running process — and only
- *     appears when at least one of them is non-zero. An idle family
- *     adds no line at all;
- *   - selection highlight lives on the card, not the inner rows, so a
- *     selected child reads as "this family, this member" instead of a
- *     standalone sidebar item, while the row under the pointer still
- *     highlights as the click target;
- *   - a root with no descendants renders no card at all — standalone
- *     sessions stay exactly as compact as before.
+ *   - the slot row is the way back into the family. It's a real link of
+ *     its own, but the selection highlight lives on the card, so it
+ *     reads as "this family, this member" rather than a standalone
+ *     sidebar item;
+ *   - exactly one member ever shows. A second one would grow this into
+ *     the family tree, which is a different surface.
  */
 function FamilyEntry({
   selected,
-  activity,
-  rootHref,
-  child,
-  childHref,
-  childPath,
+  slot,
+  slotHref,
+  slotTrail,
   onClick,
-  onOpenTree,
   children,
 }: {
   selected: boolean
-  activity: FamilyActivity
-  /** The root row's own href; the activity row navigates there too. */
-  rootHref: string
-  /** Selected descendant of this root, when the selection is a child. */
-  child?: Session
-  childHref?: string
-  /** Root › … › child trail, for the child row's hover title. */
-  childPath?: string
+  slot: FamilySlot
+  slotHref?: string
+  /** Root › … › member trail, for the slot row's hover title. */
+  slotTrail?: string
   onClick?: () => void
-  /** Click on the activity row: select the root and open the tree. */
-  onOpenTree?: () => void
   /** The root's own `SessionItem`. */
   children: preact.ComponentChildren
 }) {
-  const childDot = child ? ownDotState(child, activityMap.value, child.id) : 'none'
-  const showActivity = hasFamilyActivity(activity)
-  // The branch glyph marks the first sub-row only; the second aligns
-  // under it with an empty span of the same width.
-  const branch = (first: boolean) => (
-    <span class="family-sub-branch" aria-hidden="true">{first ? '↳' : ''}</span>
-  )
+  const member = slot.session
+  const dot = ownDotState(member, activityMap.value, selectedId.value)
   return (
     <div class={`session-family${selected ? ' selected' : ''}`}>
       {children}
-      {child && (
-        <a
-          class="family-sub-row family-selected-child"
-          href={childHref}
-          aria-current="page"
-          title={childPath}
-          onClick={() => onClick?.()}
-        >
-          {branch(true)}
-          {/* No reserved dot column: a quiet member spends the space on
-            * its title instead. */}
-          {isProcessSession(child)
-            ? <span class={`family-child-proc${child.alive && child.status?.active ? ' working' : ''}`} aria-hidden="true">$</span>
-            : childDot !== 'none' && <span class={`session-dot-indicator ${childDot}`} aria-hidden="true" />}
-          <span class="family-child-title">{child.title}</span>
-        </a>
-      )}
-      {showActivity && (
-        <a
-          class="family-sub-row family-activity"
-          href={rootHref}
-          aria-label={familyActivityLabel(activity)}
-          title={familyActivityLabel(activity)}
-          onClick={() => { onOpenTree?.(); onClick?.() }}
-        >
-          {branch(!child)}
-          {activity.error > 0 && (
-            <span class="family-activity-seg">
-              <span class="session-dot-indicator error" aria-hidden="true" />
-              {activity.error}
-            </span>
-          )}
-          {activity.unread > 0 && (
-            <span class="family-activity-seg">
-              <span class="session-dot-indicator unread" aria-hidden="true" />
-              {activity.unread}
-            </span>
-          )}
-          {activity.workingAgents > 0 && (
-            <span class="family-activity-seg">
-              <span class="session-dot-indicator working" aria-hidden="true" />
-              {activity.workingAgents}
-            </span>
-          )}
-          {activity.workingProcesses > 0 && (
-            <span class="family-activity-seg">
-              <span class="family-child-proc working" aria-hidden="true">$</span>
-              {activity.workingProcesses}
-            </span>
-          )}
-        </a>
-      )}
+      <a
+        class={`family-slot${slot.selected ? ' current' : ''}`}
+        href={slotHref}
+        aria-current={slot.selected ? 'page' : undefined}
+        title={slotTrail}
+        onClick={() => onClick?.()}
+      >
+        <span class="family-branch" aria-hidden="true">↳</span>
+        {/* No reserved dot column: a quiet member spends the space on
+          * its title instead. */}
+        {isProcessSession(member)
+          ? <span class={`family-child-proc${member.alive && member.status?.active ? ' working' : ''}`} aria-hidden="true">$</span>
+          : dot !== 'none' && <span class={`session-dot-indicator ${dot}`} aria-hidden="true" />}
+        <span class="family-slot-title">{member.title}</span>
+      </a>
     </div>
   )
 }
@@ -362,7 +358,7 @@ function FolderGroup({
   // three are O(n) maps built once per session-list identity in the
   // store, so a folder's rows stay O(rows) lookups.
   const activityById = familyActivityById.value
-  const selChild = selectedFamilyChild.value
+  const slots = familySlotById.value
   const rawSelId = selectedId.value
 
   const handleDragStart = useCallback((idx: number) => {
@@ -476,6 +472,8 @@ function FolderGroup({
       <div class="folder-sessions">
         {shown.map((s, i) => {
           const href = tabHref(sessionPath(folder.slug, s, folder.peer, hasSessionSlugCollision(s, sessions.value, projects.value)))
+          const activity = activityById.get(s.id) ?? NO_FAMILY_ACTIVITY
+          const slot = slots.get(s.id)
           const item = (
             <SessionItem
               key={s.id}
@@ -488,32 +486,33 @@ function FolderGroup({
               dotState={ownDotState(s, am, rawSelId)}
               unavailable={isSessionUnavailable(s, peerStatus)}
               showHostMarker={mixedHosts}
+              meta={hasFamilyActivity(activity) ? <FamilyActivityLine activity={activity} /> : undefined}
               dragging={drag !== null && s.id === visible[drag.from]?.id}
               dropTarget={drag !== null && drag.over === i && drag.from !== i}
               onClose={() => onCloseSession(s)}
-              onClick={onClick}
+              // Clicking the activity line asked about the family, so
+              // bring the tree up with it. Every click still lands on
+              // the root: same link, same destination.
+              onClick={(e) => {
+                if ((e.target as HTMLElement | null)?.closest('.family-activity')) familyPanelOpen.value = true
+                onClick?.()
+              }}
               onDragStart={dragDisabled ? undefined : () => handleDragStart(i)}
               onDragOver={dragDisabled ? undefined : () => handleDragOver(i)}
               onDragEnd={dragDisabled ? undefined : () => handleDragEnd(visible)}
             />
           )
-          const activity = activityById.get(s.id) ?? NO_FAMILY_ACTIVITY
-          const child = selChild?.rootId === s.id ? selChild.session : undefined
-          // No selected child and nothing happening: a plain row. This
-          // is every standalone session and every idle family.
-          if (!child && !hasFamilyActivity(activity)) return item
-          const childPath = child ? childTrailTitle(s, selChild?.ancestors ?? [], child) : undefined
+          // No remembered/selected member: the row stands alone (its
+          // activity line, if any, is already inside it).
+          if (!slot) return item
           return (
             <FamilyEntry
               key={s.id}
               selected={selId === s.id}
-              activity={activity}
-              rootHref={href}
-              child={child}
-              childHref={child ? sessionHref(child) : undefined}
-              childPath={childPath}
+              slot={slot}
+              slotHref={sessionHref(slot.session)}
+              slotTrail={childTrailTitle(s, slot.ancestors, slot.session)}
               onClick={onClick}
-              onOpenTree={() => { familyPanelOpen.value = true }}
             >
               {item}
             </FamilyEntry>

--- a/apps/gmux-web/src/sidebar.tsx
+++ b/apps/gmux-web/src/sidebar.tsx
@@ -238,6 +238,10 @@ function FamilyActivityLine({ activity }: { activity: FamilyActivity }) {
   const label = familyActivityLabel(activity)
   return (
     <div class="family-sub family-activity" title={label}>
+      {/* Same branch glyph, same column as the member row's: this row
+        * hangs off the root too, and says so whether or not anything
+        * here is highlighted. */}
+      <span class="family-glyph family-branch" aria-hidden="true">↳</span>
       {/* Glyphs are decoration; the sentence carries the meaning. */}
       <span class="family-activity-glyphs" aria-hidden="true">
         {activity.error > 0 && (

--- a/apps/gmux-web/src/store.test.ts
+++ b/apps/gmux-web/src/store.test.ts
@@ -1387,26 +1387,44 @@ describe('sidebar family entry derivations', () => {
       })
     })
 
-    it('mutes the selected member\u2019s attention but keeps its work', () => {
+    beforeEach(() => { recentFamilyChildren.value = [] })
+
+    it('never counts the member the slot row already names', () => {
       _rawSessions.value = [
         agent('root'),
         agent('a', { slug: 'aa', parent_session_id: 'root', unread: true }),
         agent('b', { slug: 'bb', parent_session_id: 'root', unread: true }),
       ]
+      expect(familyActivityById.value.get('root')?.unread).toBe(2)
+      // Viewing 'a' gives it the slot row, so only the sibling is left
+      // for the `+` line: one member, one representation.
       urlPath.value = '/proj/pi/aa'
-      expect(selectedId.value).toBe('a')
-      // Only the sibling still counts as unread.
       expect(familyActivityById.value.get('root')?.unread).toBe(1)
-      // A selected member that is *working* still counts: you can watch
-      // it work.
+      // Working members are no different — the slot row carries their
+      // dot, so counting them too would double them up.
       _rawSessions.value = _rawSessions.value.map(s =>
         s.id === 'a' ? { ...s, unread: false, status: { active: true } } : s)
       expect(familyActivityById.value.get('root')).toEqual({
-        error: 0, unread: 1, workingAgents: 1, workingProcesses: 0,
+        error: 0, unread: 1, workingAgents: 0, workingProcesses: 0,
       })
     })
 
-    it('drops the whole entry when the only activity is the selected member', () => {
+    it('stops counting a member you merely visited, not just the selected one', () => {
+      _rawSessions.value = [
+        agent('root', { slug: 'rooty' }),
+        agent('a', { slug: 'aa', parent_session_id: 'root', status: { active: true } }),
+      ]
+      urlPath.value = '/proj/pi/aa'
+      rememberFamilyChild('a') // what the recorder effect does on a visit
+      expect(familyActivityById.value.has('root')).toBe(false)
+      // Back on the root, 'a' keeps the slot row as the way back — and
+      // stays out of the count, because it is still named.
+      urlPath.value = '/proj/pi/rooty'
+      expect(familySlotById.value.get('root')?.session.id).toBe('a')
+      expect(familyActivityById.value.has('root')).toBe(false)
+    })
+
+    it('drops the whole line when the only activity is the named member', () => {
       _rawSessions.value = [
         agent('root'),
         agent('a', { slug: 'aa', parent_session_id: 'root', unread: true }),

--- a/apps/gmux-web/src/store.test.ts
+++ b/apps/gmux-web/src/store.test.ts
@@ -13,6 +13,7 @@ import {
   view, duplicateConversationFiles,
   sidebarMode, setSidebarMode, setFilterSelectors, setHostFilter, homePartition,
   sidebarActivity, setAliveOnly, familyDotById, createViewConsumptionTracker,
+  familyActivityById, selectedFamilyChild, ownDotState,
 } from './store'
 import { SessionSchema } from '@gmux/protocol'
 import type { PendingMutation } from './store'
@@ -1309,6 +1310,201 @@ describe('familyDotById (family-aggregated row dot)', () => {
     expect(familyDotById.value.get('root')).toBe('unread')
     _rawSessions.value = _rawSessions.value.map(s => s.id === 'b' ? { ...s, unread: false } : s)
     expect(familyDotById.value.get('root')).toBe('none')
+  })
+})
+
+describe('sidebar family entry derivations', () => {
+  beforeEach(() => {
+    _rawSessions.value = []
+    _setRawWorld({ projects: [{ slug: 'proj', match: [{ path: '/work' }] }], peers: [] })
+    sessionsLoaded.value = true
+    worldLoaded.value = true
+    urlPath.value = '/'
+    activityMap.value = new Map()
+  })
+
+  const agent = (id: string, extra: Partial<Session> = {}) => makeSession({
+    id, cwd: '/work', adapter: 'pi', semantic_agent: true, project_slug: 'proj', ...extra,
+  })
+  const proc = (id: string, parent: string, extra: Partial<Session> = {}) => makeSession({
+    id, cwd: '/work', adapter: 'shell', parent_session_id: parent, project_slug: 'proj', ...extra,
+  })
+
+  describe('familyActivityById (live activity counts)', () => {
+    it('buckets every descendant once, by dot precedence, kind-split for working', () => {
+      _rawSessions.value = [
+        agent('root', { status: { active: true } }),
+        agent('kid', { parent_session_id: 'root', status: { active: true } }),
+        agent('grandkid', { parent_session_id: 'kid', status: { active: true } }),
+        // Error wins over its own unread; working wins over unread.
+        agent('boom', { parent_session_id: 'root', status: { active: false, error: true }, unread: true }),
+        agent('waiting', { parent_session_id: 'root', unread: true }),
+        proc('p1', 'root', { status: { active: true } }),
+        proc('p2', 'grandkid', { status: { active: true }, unread: true }),
+      ]
+      expect(familyActivityById.value.get('root')).toEqual({
+        error: 1, unread: 1, workingAgents: 2, workingProcesses: 2,
+      })
+      // The root's own working state is never in its family's counts.
+      expect(familyActivityById.value.get('kid')).toBeUndefined()
+    })
+
+    it('ignores members the alive-only filter is hiding', () => {
+      _rawSessions.value = [
+        agent('root'),
+        agent('live', { parent_session_id: 'root', unread: true }),
+        agent('dead', { parent_session_id: 'root', unread: true, alive: false, resumable: true }),
+      ]
+      expect(familyActivityById.value.get('root')?.unread).toBe(2)
+      // The line counts what the list shows: a filtered-out member's
+      // unread would point at a row that isn't there.
+      setAliveOnly(true)
+      expect(familyActivityById.value.get('root')?.unread).toBe(1)
+      setAliveOnly(false)
+    })
+
+    it('omits idle families entirely (no line, no entry)', () => {
+      _rawSessions.value = [
+        agent('root'),
+        agent('kid', { parent_session_id: 'root' }),
+        proc('p', 'root'),
+      ]
+      expect(familyActivityById.value.has('root')).toBe(false)
+    })
+
+    it('ignores a dead member that is merely alive-gated', () => {
+      // status.active/error only count while alive; unread still does,
+      // matching sessionDotState's vocabulary.
+      _rawSessions.value = [
+        agent('root'),
+        agent('zombie', { parent_session_id: 'root', alive: false, status: { active: true } }),
+        agent('gone', { parent_session_id: 'root', alive: false, status: { active: false, error: true } }),
+        agent('unseen', { parent_session_id: 'root', alive: false, unread: true }),
+      ]
+      expect(familyActivityById.value.get('root')).toEqual({
+        error: 0, unread: 1, workingAgents: 0, workingProcesses: 0,
+      })
+    })
+
+    it('mutes the selected member\u2019s attention but keeps its work', () => {
+      _rawSessions.value = [
+        agent('root'),
+        agent('a', { slug: 'aa', parent_session_id: 'root', unread: true }),
+        agent('b', { slug: 'bb', parent_session_id: 'root', unread: true }),
+      ]
+      urlPath.value = '/proj/pi/aa'
+      expect(selectedId.value).toBe('a')
+      // Only the sibling still counts as unread.
+      expect(familyActivityById.value.get('root')?.unread).toBe(1)
+      // A selected member that is *working* still counts: you can watch
+      // it work.
+      _rawSessions.value = _rawSessions.value.map(s =>
+        s.id === 'a' ? { ...s, unread: false, status: { active: true } } : s)
+      expect(familyActivityById.value.get('root')).toEqual({
+        error: 0, unread: 1, workingAgents: 1, workingProcesses: 0,
+      })
+    })
+
+    it('drops the whole entry when the only activity is the selected member', () => {
+      _rawSessions.value = [
+        agent('root'),
+        agent('a', { slug: 'aa', parent_session_id: 'root', unread: true }),
+      ]
+      expect(familyActivityById.value.has('root')).toBe(true)
+      urlPath.value = '/proj/pi/aa'
+      expect(familyActivityById.value.has('root')).toBe(false)
+    })
+
+    it('gives a promoted descendant its own counts, not its old family\u2019s', () => {
+      _rawSessions.value = [
+        agent('root'),
+        agent('kid', { parent_session_id: 'root', promoted_to_root: true }),
+        proc('p', 'kid', { status: { active: true } }),
+      ]
+      expect(familyActivityById.value.has('root')).toBe(false)
+      expect(familyActivityById.value.get('kid')?.workingProcesses).toBe(1)
+    })
+  })
+
+  describe('root-dot semantics', () => {
+    it('shows the root\u2019s own status, never the family roll-up', () => {
+      _rawSessions.value = [
+        agent('root', { unread: true }),
+        agent('kid', { parent_session_id: 'root', status: { active: true, error: true } }),
+      ]
+      const root = sessions.value.find(s => s.id === 'root')!
+      // The aggregate would say "error"; the row dot stays the root's own.
+      expect(familyDotById.value.get('root')).toBe('error')
+      expect(ownDotState(root, activityMap.value, selectedId.value)).toBe('unread')
+    })
+
+    it('mutes the root\u2019s own attention while the root is selected', () => {
+      _rawSessions.value = [agent('root', { slug: 'rooty', unread: true }), agent('kid', { parent_session_id: 'root' })]
+      const root = () => sessions.value.find(s => s.id === 'root')!
+      expect(ownDotState(root(), activityMap.value, selectedId.value)).toBe('unread')
+      urlPath.value = '/proj/pi/rooty'
+      expect(selectedId.value).toBe('root')
+      expect(ownDotState(root(), activityMap.value, selectedId.value)).toBe('none')
+    })
+
+    it('keeps working/active states visible while selected (only attention mutes)', () => {
+      _rawSessions.value = [agent('root', { slug: 'rooty', status: { active: true } })]
+      urlPath.value = '/proj/pi/rooty'
+      const root = sessions.value.find(s => s.id === 'root')!
+      expect(ownDotState(root, activityMap.value, selectedId.value)).toBe('working')
+    })
+  })
+
+  describe('selectedFamilyChild (selected-child projection)', () => {
+    it('is null when nothing or a root is selected', () => {
+      _rawSessions.value = [agent('root', { slug: 'rooty' }), agent('kid', { slug: 'kiddo', parent_session_id: 'root' })]
+      expect(selectedFamilyChild.value).toBeNull()
+      urlPath.value = '/proj/pi/rooty'
+      expect(selectedFamilyChild.value).toBeNull()
+    })
+
+    it('reports the child, its root row, and the ancestor trail', () => {
+      _rawSessions.value = [
+        agent('root', { slug: 'rooty', title: 'orchestrator' }),
+        agent('kid', { slug: 'kiddo', parent_session_id: 'root', title: 'implement' }),
+        agent('grandkid', { slug: 'grandkiddo', parent_session_id: 'kid', title: 'refactor' }),
+      ]
+      urlPath.value = '/proj/pi/grandkiddo'
+      const projection = selectedFamilyChild.value!
+      expect(projection.session.id).toBe('grandkid')
+      expect(projection.rootId).toBe('root')
+      // Root first, immediate parent last — the sidebar renders the
+      // trail as a hover title on the child row.
+      expect(projection.ancestors.map(a => a.id)).toEqual(['root', 'kid'])
+    })
+
+    it('follows a selected process child too', () => {
+      _rawSessions.value = [agent('root'), proc('p', 'root', { slug: 'pp', title: 'pnpm test' })]
+      urlPath.value = '/proj/shell/pp'
+      expect(selectedFamilyChild.value?.session.id).toBe('p')
+      expect(selectedFamilyChild.value?.rootId).toBe('root')
+    })
+
+    it('is null for a promoted child (it owns a sidebar row of its own)', () => {
+      _rawSessions.value = [
+        agent('root', { slug: 'rooty' }),
+        agent('kid', { slug: 'kiddo', parent_session_id: 'root', promoted_to_root: true }),
+      ]
+      urlPath.value = '/proj/pi/kiddo'
+      expect(selectedId.value).toBe('kid')
+      expect(selectedFamilyChild.value).toBeNull()
+      expect(familySelectedId.value).toBe('kid')
+    })
+
+    it('keeps the sidebar row selection on the root while a child is selected', () => {
+      _rawSessions.value = [
+        agent('root', { slug: 'rooty' }),
+        agent('kid', { slug: 'kiddo', parent_session_id: 'root' }),
+      ]
+      urlPath.value = '/proj/pi/kiddo'
+      expect(familySelectedId.value).toBe('root')
+      expect(selectedFamilyChild.value?.session.id).toBe('kid')
+    })
   })
 })
 

--- a/apps/gmux-web/src/store.test.ts
+++ b/apps/gmux-web/src/store.test.ts
@@ -14,6 +14,7 @@ import {
   sidebarMode, setSidebarMode, setFilterSelectors, setHostFilter, homePartition,
   sidebarActivity, setAliveOnly, familyDotById, createViewConsumptionTracker,
   familyActivityById, selectedFamilyChild, ownDotState,
+  familySlotById, recentFamilyChildren, rememberFamilyChild,
 } from './store'
 import { SessionSchema } from '@gmux/protocol'
 import type { PendingMutation } from './store'
@@ -1455,6 +1456,154 @@ describe('sidebar family entry derivations', () => {
     })
   })
 
+  describe('familySlotById (the one member a family entry shows)', () => {
+    beforeEach(() => { recentFamilyChildren.value = [] })
+
+    const slot = (rootId: string) => familySlotById.value.get(rootId)
+
+    it('is empty for a family you have never descended into', () => {
+      _rawSessions.value = [agent('root'), agent('kid', { parent_session_id: 'root' })]
+      expect(familySlotById.value.size).toBe(0)
+    })
+
+    it('shows the selected member, marked as current', () => {
+      _rawSessions.value = [
+        agent('root', { slug: 'rooty' }),
+        agent('kid', { slug: 'kiddo', parent_session_id: 'root' }),
+      ]
+      urlPath.value = '/proj/pi/kiddo'
+      expect(slot('root')).toMatchObject({ selected: true })
+      expect(slot('root')?.session.id).toBe('kid')
+    })
+
+    it('keeps the member as a way back after you navigate to the root', () => {
+      _rawSessions.value = [
+        agent('root', { slug: 'rooty' }),
+        agent('kid', { slug: 'kiddo', parent_session_id: 'root' }),
+      ]
+      rememberFamilyChild('kid')
+      urlPath.value = '/proj/pi/rooty'
+      expect(slot('root')?.session.id).toBe('kid')
+      // No longer current: it is a memory, not the selection.
+      expect(slot('root')?.selected).toBe(false)
+    })
+
+    it('keeps it after you leave the family entirely', () => {
+      _rawSessions.value = [
+        agent('root'),
+        agent('kid', { parent_session_id: 'root' }),
+        agent('elsewhere', { slug: 'far' }),
+      ]
+      rememberFamilyChild('kid')
+      urlPath.value = '/proj/pi/far'
+      expect(slot('root')?.session.id).toBe('kid')
+    })
+
+    it('gives the slot to the selection over an older visit', () => {
+      _rawSessions.value = [
+        agent('root'),
+        agent('a', { slug: 'aa', parent_session_id: 'root' }),
+        agent('b', { slug: 'bb', parent_session_id: 'root' }),
+      ]
+      rememberFamilyChild('a')
+      urlPath.value = '/proj/pi/bb'
+      expect(slot('root')?.session.id).toBe('b')
+      expect(slot('root')?.selected).toBe(true)
+    })
+
+    it('keeps only the most recent visit per family (one slot)', () => {
+      _rawSessions.value = [
+        agent('root'),
+        agent('a', { parent_session_id: 'root' }),
+        agent('b', { parent_session_id: 'root' }),
+      ]
+      rememberFamilyChild('a')
+      rememberFamilyChild('b')
+      expect(familySlotById.value.size).toBe(1)
+      expect(slot('root')?.session.id).toBe('b')
+    })
+
+    it('drops a member that left the family: promoted or reparented', () => {
+      _rawSessions.value = [
+        agent('root'),
+        agent('kid', { parent_session_id: 'root' }),
+        agent('other'),
+      ]
+      rememberFamilyChild('kid')
+      expect(slot('root')?.session.id).toBe('kid')
+      // Promotion gives it its own sidebar row; a duplicate would lie.
+      _rawSessions.value = _rawSessions.value.map(s =>
+        s.id === 'kid' ? { ...s, promoted_to_root: true } : s)
+      expect(familySlotById.value.size).toBe(0)
+      // Reparenting moves the memory to the new family, no re-keying.
+      _rawSessions.value = _rawSessions.value.map(s =>
+        s.id === 'kid' ? { ...s, promoted_to_root: false, parent_session_id: 'other' } : s)
+      expect(slot('other')?.session.id).toBe('kid')
+      expect(familySlotById.value.has('root')).toBe(false)
+    })
+
+    it('drops a member that is gone, or a corpse you cannot reopen', () => {
+      _rawSessions.value = [agent('root'), agent('kid', { parent_session_id: 'root' })]
+      rememberFamilyChild('kid')
+      _rawSessions.value = _rawSessions.value.map(s =>
+        s.id === 'kid' ? { ...s, alive: false, resumable: false } : s)
+      expect(familySlotById.value.size).toBe(0)
+      // Resumable corpses stay: they are still a way back.
+      _rawSessions.value = _rawSessions.value.map(s =>
+        s.id === 'kid' ? { ...s, resumable: true } : s)
+      expect(slot('root')?.session.id).toBe('kid')
+      // …unless the alive-only toggle is hiding dead sessions.
+      setAliveOnly(true)
+      expect(familySlotById.value.size).toBe(0)
+      setAliveOnly(false)
+    })
+
+    it('never shows a member that vanished from the snapshot', () => {
+      _rawSessions.value = [agent('root'), agent('kid', { parent_session_id: 'root' })]
+      rememberFamilyChild('kid')
+      _rawSessions.value = [agent('root')]
+      expect(familySlotById.value.size).toBe(0)
+      // The id is still remembered; only its resolution failed. If the
+      // session comes back (peer reconnect), so does the row.
+      expect(recentFamilyChildren.value).toEqual(['kid'])
+    })
+
+    it('remembers a bounded number of families, most recent first', () => {
+      const sessions: Session[] = []
+      for (let i = 0; i < 7; i++) {
+        sessions.push(agent(`root${i}`), agent(`kid${i}`, { parent_session_id: `root${i}` }))
+      }
+      _rawSessions.value = sessions
+      for (let i = 0; i < 7; i++) rememberFamilyChild(`kid${i}`)
+      // Cap is 5; the two oldest families lost their memory.
+      expect(recentFamilyChildren.value).toEqual(['kid6', 'kid5', 'kid4', 'kid3', 'kid2'])
+      expect(familySlotById.value.size).toBe(5)
+      expect(familySlotById.value.has('root0')).toBe(false)
+    })
+
+    it('keeps one member per family, so one family cannot evict the rest', () => {
+      _rawSessions.value = [
+        agent('rootA'), agent('rootB'),
+        ...['a0', 'a1', 'a2', 'a3', 'a4'].map(id => agent(id, { parent_session_id: 'rootA' })),
+        agent('b0', { parent_session_id: 'rootB' }),
+      ]
+      rememberFamilyChild('b0')
+      for (const id of ['a0', 'a1', 'a2', 'a3', 'a4']) rememberFamilyChild(id)
+      // Family A occupies exactly one entry however many members you
+      // bounce through, so B's way back survives.
+      expect(recentFamilyChildren.value).toEqual(['a4', 'b0'])
+      expect(slot('rootA')?.session.id).toBe('a4')
+      expect(slot('rootB')?.session.id).toBe('b0')
+    })
+
+    it('is idempotent for the member already at the head', () => {
+      rememberFamilyChild('a')
+      const first = recentFamilyChildren.value
+      rememberFamilyChild('a')
+      expect(recentFamilyChildren.value).toBe(first)
+    })
+  })
+
   describe('selectedFamilyChild (selected-child projection)', () => {
     it('is null when nothing or a root is selected', () => {
       _rawSessions.value = [agent('root', { slug: 'rooty' }), agent('kid', { slug: 'kiddo', parent_session_id: 'root' })]
@@ -1680,6 +1829,28 @@ describe('sidebar-mode repair effect (initStore)', () => {
     cleanup = null
     setNavigate(() => {/* no-op */})
     vi.unstubAllGlobals()
+  })
+
+  it('records the family member you are viewing (the recorder effect runs)', () => {
+    // Every other MRU test calls rememberFamilyChild directly, which
+    // proves the list but not the wiring. This one pins the wiring: an
+    // effect registered by initStore, above the mock-mode early return
+    // that would otherwise leave it dead in ?mock previews.
+    _setRawWorld({ projects: [{ slug: 'proj', match: [{ path: '/work' }] }], peers: [] })
+    sessionsLoaded.value = true
+    worldLoaded.value = true
+    _rawSessions.value = [
+      makeSession({ id: 'root', slug: 'rooty', cwd: '/work', adapter: 'pi', semantic_agent: true, project_slug: 'proj' }),
+      makeSession({ id: 'kid', slug: 'kiddo', cwd: '/work', adapter: 'pi', semantic_agent: true, project_slug: 'proj', parent_session_id: 'root' }),
+    ]
+    recentFamilyChildren.value = []
+    // A resolvable selection wakes the mark-as-read effect, which reads
+    // `selected` — and that computed pokes `window` for debugging.
+    vi.stubGlobal('window', {})
+    cleanup = initStore()
+    urlPath.value = '/proj/pi/kiddo'
+    expect(selectedFamilyChild.value?.session.id).toBe('kid')
+    expect(recentFamilyChildren.value).toEqual(['kid'])
   })
 
   it('rewrites a stale ?sidebar entry in place; the signal never adopts from the URL', () => {
@@ -1961,5 +2132,36 @@ describe('conversation_file (duplicate-open warning)', () => {
     const dups = duplicateConversationFiles.value
     expect(dups.has('/conv.jsonl')).toBe(true)
     expect(dups.has('/other.jsonl')).toBe(false)
+  })
+})
+
+describe('mock-mode boot (?mock)', () => {
+  // `?mock` is the surface design work is reviewed on, and initStore
+  // returns early for it — anything registered below that return is dead
+  // in mock previews while looking perfectly wired in production. The
+  // recorder effect was, once. This boots a *fresh* store module with
+  // ?mock in the URL, which is the only way to see that difference.
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.resetModules()
+  })
+
+  it('records the family member you are viewing in a mock preview too', async () => {
+    vi.stubGlobal('location', { search: '?mock', hash: '', pathname: '/' })
+    vi.stubGlobal('window', {})
+    vi.resetModules()
+    const store = await import('./store')
+    // Stand in for the router: the store navigates through this.
+    store.setNavigate((url: string) => { store.urlPath.value = url.split('?')[0] })
+    const cleanup = store.initStore()
+    try {
+      const kid = store.sessions.value.find(s => s.parent_session_id && s.semantic_agent)
+      expect(kid, 'the mock fixtures should contain a family child').toBeDefined()
+      store.navigateToSession(kid!.id)
+      expect(store.selectedFamilyChild.value?.session.id).toBe(kid!.id)
+      expect(store.recentFamilyChildren.value).toEqual([kid!.id])
+    } finally {
+      cleanup()
+    }
   })
 })

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -19,7 +19,10 @@ import type { View } from './routing'
 import { resolveViewFromPath, viewToPath } from './routing'
 import { navigateWithReload } from './version-watch'
 import { buildProjectFolders, discoverProjects, type TemporaryPresentationPlacement } from './projects'
-import { familyIndex, familyRootId, isFamilyChild } from './family'
+import {
+  familyAncestors, familyIndex, familyRootId, isFamilyChild, isProcessSession,
+  type FamilyActivity,
+} from './family'
 import { referencePresence, unresolvedReferences, removeReferenceItems, removeHostReferenceItems, type UnresolvedHost } from './references'
 import { parseFilterParam, formatFilterParam, sessionMatchesFilter, type Selector } from './tab-filter'
 import { pushError } from './toasts'
@@ -938,6 +941,93 @@ export const familyDotById = computed<ReadonlyMap<string, DotState>>(() => {
   }
   return map
 })
+
+/** Dot state for a single session's *own* status, with the same
+ *  "you're already looking at it" muting `familyDotById` applies per
+ *  member. The sidebar's Projects rows use this so a family root's
+ *  primary dot always answers "how is the root itself doing?" — the
+ *  family's own attention is carried separately by
+ *  `familyActivityById` on the family activity row. */
+export function ownDotState(
+  session: Session,
+  am: ReadonlyMap<string, 'active' | 'fading'>,
+  sel: string | null,
+): DotState {
+  const own = sessionDotState(session, am)
+  return session.id === sel && (own === 'error' || own === 'unread') ? 'none' : own
+}
+
+/** What each family is doing right now, keyed by presentation-root id.
+ *
+ * Descendants only — the root answers for itself through its own row
+ * dot. Members are tallied once each under dot precedence (error >
+ * working > unread), and the selected member's error/unread is muted
+ * exactly as it is on the dots ("nothing is unread if you're already
+ * looking at it"), so the icon row can never claim attention the dots
+ * don't. Idle members are not counted and roots with nothing happening
+ * are absent from the map: their sidebar entry stays a single row. */
+export const familyActivityById = computed<ReadonlyMap<string, FamilyActivity>>(() => {
+  const sel = selectedId.value
+  const onlyAlive = aliveOnly.value
+  const index = familyIndex(sessions.value)
+  const map = new Map<string, { error: number; unread: number; workingAgents: number; workingProcesses: number }>()
+  for (const s of sessions.value) {
+    if (!index.childIds.has(s.id)) continue
+    const rootId = index.rootById.get(s.id)?.id
+    if (!rootId || rootId === s.id) continue
+    // The line counts what the list would show you. With alive-only on,
+    // a dead member is filtered out of the sidebar, so reporting its
+    // unread here would point at a row that isn't there.
+    if (onlyAlive && !s.alive) continue
+    const muted = s.id === sel
+    let bucket: keyof FamilyActivity
+    if (s.alive && s.status?.error) {
+      if (muted) continue
+      bucket = 'error'
+    } else if (s.alive && s.status?.active) {
+      bucket = isProcessSession(s) ? 'workingProcesses' : 'workingAgents'
+    } else if (s.unread && !muted) {
+      bucket = 'unread'
+    } else continue
+    const entry = map.get(rootId) ?? { error: 0, unread: 0, workingAgents: 0, workingProcesses: 0 }
+    entry[bucket]++
+    map.set(rootId, entry)
+  }
+  return map
+})
+
+/** The selected session projected onto its family's sidebar row.
+ *
+ * Non-null only when the selection is a family *child*: the sidebar row
+ * belongs to the root, so the row has to say which member you're
+ * actually looking at. `ancestors` is root-first, immediate parent last
+ * (empty for a direct child of the root) and lets a deep descendant
+ * render its path without a second tree. */
+export interface SelectedFamilyChild {
+  readonly session: Session
+  readonly rootId: string
+  readonly ancestors: readonly Session[]
+}
+
+export const selectedFamilyChild = computed<SelectedFamilyChild | null>(() => {
+  const sel = selectedId.value
+  if (!sel) return null
+  const index = familyIndex(sessions.value)
+  const session = index.byId.get(sel)
+  if (!session || !index.childIds.has(sel)) return null
+  const rootId = index.rootById.get(sel)?.id
+  if (!rootId || rootId === sel) return null
+  return { session, rootId, ancestors: familyAncestors(session, index) }
+})
+
+/** Whether the header's family tree panel is open.
+ *
+ * Owned here rather than in `MainHeader`'s local state because two
+ * surfaces open the same panel: its own trigger, and the sidebar's
+ * family activity row (which navigates to the root *and* opens the
+ * tree in one click). The header still owns closing it, and clears
+ * this whenever the selected session has no family. */
+export const familyPanelOpen = signal(false)
 
 // ── Home dashboard partitioning ─────────────────────────────────────────────
 //

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -1020,6 +1020,76 @@ export const selectedFamilyChild = computed<SelectedFamilyChild | null>(() => {
   return { session, rootId, ancestors: familyAncestors(session, index) }
 })
 
+/** Family children this tab has visited, most recent first.
+ *
+ * The sidebar keeps one slot per family for "the member I was just
+ * looking at", so you can get back to a subagent after navigating to
+ * its root. Only ids are stored: whether an id still *resolves* to a
+ * live family child is derived on every read (see `familySlotById`),
+ * so promotion, reparenting and session death need no cleanup pass.
+ * Ephemeral by design — "recently viewed" shouldn't outlive the tab
+ * that did the viewing. */
+export const recentFamilyChildren = signal<readonly string[]>([])
+
+/** Cap on the MRU list. `rememberFamilyChild` keeps one member per
+ * family, so this bounds how many *families* keep a remembered row:
+ * visiting a sixth family's member evicts the least recent family. */
+const MAX_RECENT_FAMILY_CHILDREN = 5
+
+/** Record a visit. Idempotent for the current head, so the recorder
+ * effect can run on every snapshot without churning the signal.
+ *
+ * One member per family, because the entry only ever shows one: keeping
+ * a sibling too would let a single family fill the list and evict other
+ * families' rows without ever showing a second row of its own. Reads
+ * `sessions` with `peek` — the caller is an effect that already tracks
+ * the selection this resolves. */
+export function rememberFamilyChild(id: string): void {
+  const prev = recentFamilyChildren.peek()
+  if (prev[0] === id) return
+  const index = familyIndex(sessions.peek())
+  const rootOf = (member: string) => index.rootById.get(member)?.id
+  const root = rootOf(id)
+  const others = prev.filter(x => x !== id && (root === undefined || rootOf(x) !== root))
+  recentFamilyChildren.value = [id, ...others].slice(0, MAX_RECENT_FAMILY_CHILDREN)
+}
+
+/** The one family member a root's sidebar entry shows below itself.
+ *
+ * Selection wins: while you're inside a family member, that member is
+ * the slot (and says so). Otherwise the most recently visited member
+ * that still resolves takes it — the way back to what you were doing.
+ * Roots you've never descended into have no slot and stay one row. */
+export interface FamilySlot {
+  readonly session: Session
+  /** True when this member is the current selection. */
+  readonly selected: boolean
+  /** Root-first spine, for the row's hover trail. */
+  readonly ancestors: readonly Session[]
+}
+
+export const familySlotById = computed<ReadonlyMap<string, FamilySlot>>(() => {
+  const index = familyIndex(sessions.value)
+  const onlyAlive = aliveOnly.value
+  const map = new Map<string, FamilySlot>()
+  const sel = selectedFamilyChild.value
+  if (sel) map.set(sel.rootId, { session: sel.session, ancestors: sel.ancestors, selected: true })
+  for (const id of recentFamilyChildren.value) {
+    const session = index.byId.get(id)
+    // Gone, promoted to its own row, or reparented out of this family.
+    if (!session || !index.childIds.has(id)) continue
+    const rootId = index.rootById.get(id)?.id
+    if (!rootId || rootId === id) continue
+    // Selection, or a more recent visit, already owns this family's slot.
+    if (map.has(rootId)) continue
+    // A corpse you can't reopen is not a way back; alive-only hides the
+    // resumable ones too, matching the rest of the list.
+    if (!session.alive && (onlyAlive || !session.resumable)) continue
+    map.set(rootId, { session, ancestors: familyAncestors(session, index), selected: false })
+  }
+  return map
+})
+
 /** Whether the header's family tree panel is open.
  *
  * Owned here rather than in `MainHeader`'s local state because two
@@ -1900,6 +1970,16 @@ export function initStore(): () => void {
     }
   })
   cleanups.push(disposeSidebarRepair)
+
+  // Remember the family member you're viewing, so its family's sidebar
+  // entry can offer the way back after you navigate to the root. Pure
+  // UI history with no transport dependency, so it registers above the
+  // mock-mode early return below — ?mock previews this behavior too.
+  const disposeRecentChild = effect(() => {
+    const child = selectedFamilyChild.value
+    if (child) rememberFamilyChild(child.session.id)
+  })
+  cleanups.push(disposeRecentChild)
 
   if (USE_MOCK) {
     const localHost = new URLSearchParams(location.search).get('host')

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -947,7 +947,7 @@ export const familyDotById = computed<ReadonlyMap<string, DotState>>(() => {
  *  member. The sidebar's Projects rows use this so a family root's
  *  primary dot always answers "how is the root itself doing?" — the
  *  family's own attention is carried separately by
- *  `familyActivityById` on the family activity row. */
+ *  `familyActivityById` on the family's `+` line. */
 export function ownDotState(
   session: Session,
   am: ReadonlyMap<string, 'active' | 'fading'>,
@@ -956,45 +956,6 @@ export function ownDotState(
   const own = sessionDotState(session, am)
   return session.id === sel && (own === 'error' || own === 'unread') ? 'none' : own
 }
-
-/** What each family is doing right now, keyed by presentation-root id.
- *
- * Descendants only — the root answers for itself through its own row
- * dot. Members are tallied once each under dot precedence (error >
- * working > unread), and the selected member's error/unread is muted
- * exactly as it is on the dots ("nothing is unread if you're already
- * looking at it"), so the icon row can never claim attention the dots
- * don't. Idle members are not counted and roots with nothing happening
- * are absent from the map: their sidebar entry stays a single row. */
-export const familyActivityById = computed<ReadonlyMap<string, FamilyActivity>>(() => {
-  const sel = selectedId.value
-  const onlyAlive = aliveOnly.value
-  const index = familyIndex(sessions.value)
-  const map = new Map<string, { error: number; unread: number; workingAgents: number; workingProcesses: number }>()
-  for (const s of sessions.value) {
-    if (!index.childIds.has(s.id)) continue
-    const rootId = index.rootById.get(s.id)?.id
-    if (!rootId || rootId === s.id) continue
-    // The line counts what the list would show you. With alive-only on,
-    // a dead member is filtered out of the sidebar, so reporting its
-    // unread here would point at a row that isn't there.
-    if (onlyAlive && !s.alive) continue
-    const muted = s.id === sel
-    let bucket: keyof FamilyActivity
-    if (s.alive && s.status?.error) {
-      if (muted) continue
-      bucket = 'error'
-    } else if (s.alive && s.status?.active) {
-      bucket = isProcessSession(s) ? 'workingProcesses' : 'workingAgents'
-    } else if (s.unread && !muted) {
-      bucket = 'unread'
-    } else continue
-    const entry = map.get(rootId) ?? { error: 0, unread: 0, workingAgents: 0, workingProcesses: 0 }
-    entry[bucket]++
-    map.set(rootId, entry)
-  }
-  return map
-})
 
 /** The selected session projected onto its family's sidebar row.
  *
@@ -1090,14 +1051,48 @@ export const familySlotById = computed<ReadonlyMap<string, FamilySlot>>(() => {
   return map
 })
 
-/** Whether the header's family tree panel is open.
+/** What the *rest* of each family is doing, keyed by presentation-root id.
  *
- * Owned here rather than in `MainHeader`'s local state because two
- * surfaces open the same panel: its own trigger, and the sidebar's
- * family activity row (which navigates to the root *and* opens the
- * tree in one click). The header still owns closing it, and clears
- * this whenever the selected session has no family. */
-export const familyPanelOpen = signal(false)
+ * The sidebar entry names two members: the root, on its own row with
+ * its own dot, and the slot member below it. This is everyone else —
+ * hence the `+` the row leads with. One invariant holds the entry
+ * together: every family member is represented exactly once, either by
+ * name or by a number, so a subagent you're watching can't show up as
+ * both a row and a count.
+ *
+ * Members are tallied once each under dot precedence (error > working
+ * > unread). Idle members are not counted and roots with nothing else
+ * happening are absent from the map: no line, nothing to say. */
+export const familyActivityById = computed<ReadonlyMap<string, FamilyActivity>>(() => {
+  const index = familyIndex(sessions.value)
+  const named = familySlotById.value
+  const onlyAlive = aliveOnly.value
+  const map = new Map<string, { error: number; unread: number; workingAgents: number; workingProcesses: number }>()
+  for (const s of sessions.value) {
+    if (!index.childIds.has(s.id)) continue
+    const rootId = index.rootById.get(s.id)?.id
+    if (!rootId || rootId === s.id) continue
+    // The line counts what the list would show you. With alive-only on,
+    // a dead member is filtered out of the sidebar, so reporting its
+    // unread here would point at a row that isn't there.
+    if (onlyAlive && !s.alive) continue
+    // Already named by the slot row above: counting it too would show
+    // one member twice, and claim attention its own dot already carries.
+    if (named.get(rootId)?.session.id === s.id) continue
+    let bucket: keyof FamilyActivity
+    if (s.alive && s.status?.error) {
+      bucket = 'error'
+    } else if (s.alive && s.status?.active) {
+      bucket = isProcessSession(s) ? 'workingProcesses' : 'workingAgents'
+    } else if (s.unread) {
+      bucket = 'unread'
+    } else continue
+    const entry = map.get(rootId) ?? { error: 0, unread: 0, workingAgents: 0, workingProcesses: 0 }
+    entry[bucket]++
+    map.set(rootId, entry)
+  }
+  return map
+})
 
 // ── Home dashboard partitioning ─────────────────────────────────────────────
 //

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -10,6 +10,19 @@ code {
   border-radius: 4px;
 }
 
+/* Visually hidden, still announced. */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
 :root {
   /* Surfaces — widened gaps for clearer distinction */
   --bg: oklch(12% 0.015 250);
@@ -988,12 +1001,11 @@ body {
 }
 
 /* ── Sidebar family entry ──
-   An active family is one sidebar entry: the root row, an optional
-   selected-child row, and an activity row. The card owns selection and
-   the ambient hover so the stack reads as a unit — inner rows drop
-   their own selected background and accent bar (they'd draw a second
-   card inside this one) — while the row actually under the pointer
-   steps up one tone so the click target stays unambiguous. */
+   A family is one sidebar entry. The activity line lives *inside* the
+   root row (same link, same hover, one thing in the a11y tree); the
+   slot row below it — the member you're viewing, or the last one you
+   viewed — is its own link, but the card owns selection so the pair
+   never reads as two unrelated sidebar items. */
 .session-family {
   position: relative;
   border-radius: 3px;
@@ -1017,79 +1029,67 @@ body {
 .session-family .session-item.selected {
   background: none;
 }
+.session-family .session-item.selected::before {
+  display: none;
+}
 /* One tone above the card in each state (card: --bg-hover /
    --bg-selected), so the row under the pointer is unmistakable
    without breaking the card apart. */
 .session-family .session-item:hover,
-.session-family .family-sub-row:hover {
+.session-family .family-slot:hover {
   background: oklch(26% 0.02 250);
 }
 .session-family.selected .session-item:hover,
-.session-family.selected .family-sub-row:hover {
+.session-family.selected .family-slot:hover {
   background: oklch(30% 0.02 250);
-}
-.session-family .session-item.selected::before {
-  display: none;
 }
 .session-family .session-item {
   padding-bottom: 2px;
 }
 
-/* Sub-rows hang off the root title, not the status-dot column: the
-   branch glyph starts where the title does (14px pad + 7px dot + 8px
-   gap = 29px). They span the full card so hovering one highlights a
-   row, not a text fragment. */
-.family-sub-row {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  min-width: 0;
-  padding: 3px 8px 3px 29px;
-  text-decoration: none;
-  color: var(--text);
-  font-size: 14px;
-  line-height: 1.35;
-  border-radius: 3px;
+/* A two-line row centers its dot over both lines; pin it to the title. */
+.session-item:has(.family-activity) {
+  align-items: flex-start;
 }
-.family-sub-row:last-child {
-  margin-bottom: 4px;
+.session-item:has(.family-activity) > .session-dot-indicator {
+  margin-top: 6px;
 }
-.family-sub-branch {
+.session-item:has(.family-activity) > .session-close-btn {
+  /* Absolutely positioned at 50% of the row; pin it to the title line
+     instead so it doesn't drift down when the activity line appears. */
+  top: 5px;
+  transform: none;
+}
+
+/* Branch glyph, shared by the activity line and the slot row: same
+   muted tone as the counts it introduces. */
+.family-branch {
   flex: 0 0 auto;
   width: 9px;
-  color: var(--text-muted);
-  opacity: 0.55;
+  color: var(--text-secondary);
   font-size: 10px;
   line-height: 1;
 }
-/* A quiet member reserves no dot column — the title takes the space. */
-.family-child-proc {
-  flex: 0 0 auto;
-  width: 7px;
-  font-family: 'Fira Code', monospace;
-  font-size: 11px;
-  line-height: 1;
-  color: var(--text-muted);
-}
-.family-child-proc.working { color: var(--accent); }
-.family-child-title {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  min-width: 0;
-}
-/* Activity row: dot/ring/$ glyph + count, one segment per state, each
-   dropped at zero. Clicking it selects the root and opens the tree. */
+
+/* Activity line: dot/ring/$ glyph + count, one segment per state, each
+   dropped at zero. Numbers sit a touch under the title size; the
+   glyphs keep their standard sizes. */
 .family-activity {
+  display: flex;
+  align-items: center;
   gap: 10px;
+  min-width: 0;
+  padding-top: 1px;
+  color: var(--text-secondary);
+  font-size: 12.5px;
+  line-height: 1.3;
+  font-variant-numeric: tabular-nums;
   /* Four segments only overflow on an extremely narrow sidebar; clip
-     rather than spill past the card. Attention states come first, so
+     rather than spill past the row. Attention states come first, so
      what survives the clip is what matters. */
   overflow: hidden;
-  color: var(--text-secondary);
-  font-variant-numeric: tabular-nums;
 }
-.family-activity .family-sub-branch {
+.family-activity .family-branch {
   margin-right: -4px;
 }
 .family-activity-seg {
@@ -1099,9 +1099,46 @@ body {
   flex: 0 0 auto;
 }
 
+/* Slot row: the family member you're viewing, or the last one you did.
+   Title-sized, because it's a peer of the root row you navigate to —
+   hangs off the root title column (14px pad + 7px dot + 8px gap). */
+.family-slot {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  padding: 3px 8px 3px 29px;
+  margin-bottom: 4px;
+  text-decoration: none;
+  color: var(--text);
+  font-size: 14px;
+  line-height: 1.35;
+  border-radius: 3px;
+}
+/* A remembered member is a memory, not a state: quieter than the one
+   you're actually in. */
+.family-slot:not(.current) .family-slot-title {
+  color: var(--text-secondary);
+}
+.family-child-proc {
+  flex: 0 0 auto;
+  width: 7px;
+  font-family: 'Fira Code', monospace;
+  font-size: 11px;
+  line-height: 1;
+  color: var(--text-muted);
+}
+.family-child-proc.working { color: var(--accent); }
+.family-slot-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
 /* States that belong to the root row are the whole card's states — the
    card is one entry, so it dims, drags and takes a drop line as a unit. */
-.session-family:has(.session-item.unavailable) .family-sub-row {
+.session-family:has(.session-item.unavailable) .family-slot {
   opacity: 0.55;
 }
 .session-family:has(.session-item.session-dragging) {
@@ -3076,8 +3113,8 @@ body {
     padding: 8px 10px 8px 14px;
   }
 
-  /* Family sub-rows are real tap targets on touch. */
-  .family-sub-row {
+  /* The slot row is a real tap target on touch. */
+  .family-slot {
     padding-top: 9px;
     padding-bottom: 9px;
   }

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -1047,9 +1047,10 @@ body {
   z-index: 1;
 }
 
-/* Sub-rows share one fixed indent, so the member row's glyph and the
-   activity line's first glyph form a single column under the root
-   title (14px pad + 7px dot + 8px gap). */
+/* Sub-rows share one fixed indent: a glyph column under the root title
+   (14px pad + 7px dot + 8px gap), then content. The member row puts
+   its status there and the activity line its branch, so the two rows
+   line up on both columns. */
 .family-sub {
   position: relative;
   display: flex;
@@ -1130,7 +1131,9 @@ body {
 .family-activity-glyphs {
   display: flex;
   align-items: center;
-  gap: 10px;
+  /* Tight enough that all four segments clear a 150px sidebar, which
+     is the narrowest the pane goes. */
+  gap: 8px;
   min-width: 0;
   /* Four segments only overflow on an extremely narrow sidebar; clip
      rather than spill past the row. Attention states come first, so

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -2343,7 +2343,9 @@ body {
   z-index: 100;
   width: max-content;
   min-width: 320px;
-  max-width: min(440px, calc(100vw - 24px));
+  /* Wider than it was: the panel now shows the whole family from the
+     root, so deep rows pay for their indentation out of this budget. */
+  max-width: min(560px, calc(100vw - 24px));
   max-height: min(65vh, 520px);
   display: flex;
   flex-direction: column;
@@ -2379,7 +2381,16 @@ body {
 .family-row-proc.working { color: var(--accent); }
 .family-row.process .family-row-title { color: var(--text-muted); }
 .family-row-title { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.family-row-kind { margin-left: auto; color: var(--text-muted); font-size: 11px; }
+/* Age: the key every level is sorted by, so it stays on screen. Tabular
+   figures keep the column from wobbling as rows tick over. */
+.family-row-age {
+  margin-left: auto;
+  padding-left: 8px;
+  flex: 0 0 auto;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
 /* Collapsed-group summary row: a ghost row, quieter than real rows. */
 .family-more {
   min-height: 30px;

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -1011,6 +1011,9 @@ body {
 .session-family {
   position: relative;
   border-radius: 3px;
+  /* The whole group selects the root, so all of it reads as clickable —
+     the activity line and the slack included. */
+  cursor: pointer;
 }
 .session-family:hover {
   background: var(--bg-hover);
@@ -1026,7 +1029,9 @@ body {
   background: none;
 }
 
-/* Sub-rows hang under the root title (14px pad + 7px dot + 8px gap). */
+/* Sub-rows share one fixed indent, so the member row's glyph and the
+   activity line's first glyph form a single column under the root
+   title (14px pad + 7px dot + 8px gap). */
 .family-sub {
   position: relative;
   display: flex;
@@ -1034,6 +1039,21 @@ body {
   gap: 6px;
   min-width: 0;
   padding: 3px 8px 3px 29px;
+}
+
+/* Every glyph in that column occupies the same width, whatever it is,
+   so nothing shifts horizontally when a member's state changes. */
+.family-glyph {
+  flex: 0 0 7px;
+  width: 7px;
+  text-align: center;
+}
+/* What a quiet member looks like: no state to report, so the column
+   shows the branch instead. */
+.family-branch {
+  color: var(--text-muted);
+  font-size: 10px;
+  line-height: 1;
 }
 
 /* Member row: the family member you're viewing, or the last one you
@@ -1106,14 +1126,15 @@ body {
   flex: 0 0 auto;
 }
 .family-child-proc {
-  flex: 0 0 auto;
-  width: 7px;
   font-family: 'Fira Code', monospace;
   font-size: 11px;
   line-height: 1;
   color: var(--text-muted);
 }
 .family-child-proc.working { color: var(--accent); }
+/* The rest of the dot vocabulary, in the `$`'s colour. */
+.family-child-proc.unread { color: var(--unread); }
+.family-child-proc.error { color: var(--status-error); }
 
 /* States that belong to the root row are the whole entry's states —
    it's one entry, so it dims, drags and takes a drop line as a unit. */

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -1022,11 +1022,29 @@ body {
   background: var(--bg-selected);
 }
 /* The root row doesn't paint itself: hovering or selecting it *is*
-   hovering or selecting the group. Its accent bar stays — that's the
-   part that belongs to the row rather than to the family. */
+   hovering or selecting the group. */
 .session-family .session-item:hover,
 .session-family .session-item.selected {
   background: none;
+}
+/* Nor does it draw its own bar. Selecting the root selects the whole
+   family, so the bar spans the group; it narrows to a single row only
+   when a member takes the selection off the root. */
+.session-family .session-item.selected::before {
+  display: none;
+}
+.session-family:has(> .session-item.selected)::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 4px;
+  bottom: 4px;
+  width: 2px;
+  background: var(--accent);
+  border-radius: 0 1px 1px 0;
+  /* Above the member row's own background, which spans the full width
+     and would otherwise paint over the group's bar. */
+  z-index: 1;
 }
 
 /* Sub-rows share one fixed indent, so the member row's glyph and the

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -975,9 +975,6 @@ body {
   transition: background 0.1s, color 0.1s, opacity 0.15s;
   padding: 0;
 }
-/* The family card owns hover, so hovering its summary line must still
-   reveal the root row's close button. */
-.session-family:hover .session-close-btn,
 .session-item:hover .session-close-btn,
 .session-item.selected .session-close-btn,
 .session-row:hover .session-close-btn,
@@ -1001,124 +998,138 @@ body {
 }
 
 /* ── Sidebar family entry ──
-   A family is one sidebar entry. The activity line lives *inside* the
-   root row (same link, same hover, one thing in the a11y tree); the
-   slot row below it — the member you're viewing, or the last one you
-   viewed — is its own link, but the card owns selection so the pair
-   never reads as two unrelated sidebar items. */
+   A family is one sidebar entry: a root row, the member you're viewing
+   (or last viewed), and a `+` line for everyone else. What binds them
+   is the trunk down the gutter, not a highlight — selection is drawn on
+   the row you selected, exactly as it is anywhere else in the list. */
 .session-family {
   position: relative;
-  border-radius: 3px;
-}
-.session-family:hover {
-  background: var(--bg-hover);
-}
-.session-family.selected {
-  background: var(--bg-selected);
-}
-.session-family.selected::before {
-  content: '';
-  position: absolute;
-  left: 0;
-  top: 4px;
-  bottom: 4px;
-  width: 2px;
-  background: var(--accent);
-  border-radius: 0 1px 1px 0;
-}
-.session-family .session-item.selected {
-  background: none;
-}
-.session-family .session-item.selected::before {
-  display: none;
-}
-/* One tone above the card in each state (card: --bg-hover /
-   --bg-selected), so the row under the pointer is unmistakable
-   without breaking the card apart. */
-.session-family .session-item:hover,
-.session-family .family-slot:hover {
-  background: oklch(26% 0.02 250);
-}
-.session-family.selected .session-item:hover,
-.session-family.selected .family-slot:hover {
-  background: oklch(30% 0.02 250);
-}
-.session-family .session-item {
   padding-bottom: 2px;
 }
 
-/* A two-line row centers its dot over both lines; pin it to the title. */
-.session-item:has(.family-activity) {
-  align-items: flex-start;
-}
-.session-item:has(.family-activity) > .session-dot-indicator {
-  margin-top: 6px;
-}
-.session-item:has(.family-activity) > .session-close-btn {
-  /* Absolutely positioned at 50% of the row; pin it to the title line
-     instead so it doesn't drift down when the activity line appears. */
-  top: 5px;
-  transform: none;
-}
-
-/* Branch glyph, shared by the activity line and the slot row: same
-   muted tone as the counts it introduces. */
-.family-branch {
-  flex: 0 0 auto;
-  width: 9px;
-  color: var(--text-secondary);
-  font-size: 10px;
-  line-height: 1;
-}
-
-/* Activity line: dot/ring/$ glyph + count, one segment per state, each
-   dropped at zero. Numbers sit a touch under the title size; the
-   glyphs keep their standard sizes. */
-.family-activity {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  min-width: 0;
-  padding-top: 1px;
-  color: var(--text-secondary);
-  font-size: 12.5px;
-  line-height: 1.3;
-  font-variant-numeric: tabular-nums;
-  /* Four segments only overflow on an extremely narrow sidebar; clip
-     rather than spill past the row. Attention states come first, so
-     what survives the clip is what matters. */
-  overflow: hidden;
-}
-.family-activity .family-branch {
-  margin-right: -4px;
-}
-.family-activity-seg {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  flex: 0 0 auto;
-}
-
-/* Slot row: the family member you're viewing, or the last one you did.
-   Title-sized, because it's a peer of the root row you navigate to —
-   hangs off the root title column (14px pad + 7px dot + 8px gap). */
-.family-slot {
+/* Sub-rows hang off a hairline trunk running down the dot column
+   (14px pad + 7px dot, so its centre is 17.5px). The trunk is painted
+   as a background image rather than a pseudo-element: ::before is the
+   selection bar and ::after is the elbow, and a background can't cover
+   the bar the way a pseudo-element would. State rules below must use
+   `background-color`, never the `background` shorthand, or they wipe
+   the trunk out. */
+.family-sub {
+  position: relative;
   display: flex;
   align-items: center;
   gap: 6px;
   min-width: 0;
   padding: 3px 8px 3px 29px;
-  margin-bottom: 4px;
+  background-image: linear-gradient(var(--border), var(--border));
+  background-repeat: no-repeat;
+  background-position: 17px 0;
+  background-size: 1px 100%;
+}
+/* The last sub-row terminates the trunk at its elbow instead of
+   letting it run out of the bottom of the entry. */
+.family-sub:last-child {
+  background-size: 1px 50%;
+}
+
+/* The trunk starts just under the root row's dot rather than at the
+   first sub-row's top edge, so it reads as hanging off the root. A
+   background can't paint outside its own box, so this segment belongs
+   to the root row — and only exists when something hangs off it. */
+.session-family:has(.family-sub) > .session-item::after {
+  content: '';
+  position: absolute;
+  left: 17px;
+  /* Tracks the dot's centre, so it stays clear of the dot whatever the
+     row's height (touch padding, second line, taller status icons). */
+  top: 50%;
+  margin-top: 6px;
+  bottom: 0;
+  width: 1px;
+  background: var(--border);
+}
+
+/* Elbow into the row, stopping short of the dot/glyph column. */
+.family-sub::after {
+  content: '';
+  position: absolute;
+  left: 17px;
+  top: 50%;
+  width: 6px;
+  height: 1px;
+  background: var(--border);
+}
+
+/* Slot row: the family member you're viewing, or the last one you did.
+   Title-sized and title-coloured in every state — a peer of the root
+   row you navigate to, so only the background says which is selected. */
+.family-slot {
   text-decoration: none;
   color: var(--text);
   font-size: 14px;
   line-height: 1.35;
   border-radius: 3px;
 }
-/* A remembered member is a memory, not a state: quieter than the one
-   you're actually in. */
-.family-slot:not(.current) .family-slot-title {
+.family-slot:hover {
+  background-color: var(--bg-hover);
+}
+.family-slot.selected {
+  background-color: var(--bg-selected);
+}
+/* Same 2px accent bar as any selected sidebar item. It sits on the row
+   that owns the selection, so the row's own background can't cover it. */
+.family-slot.selected::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 2px;
+  bottom: 2px;
+  width: 2px;
+  background: var(--accent);
+  border-radius: 0 1px 1px 0;
+}
+.family-slot-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+/* `+` line: everyone the entry doesn't name, one segment per state,
+   each dropped at zero. Inert — a count is a fact, not a destination —
+   so it takes no hover. Numbers sit a touch under the title size; the
+   glyphs keep their standard sizes. */
+.family-activity {
+  padding-top: 1px;
+  padding-bottom: 3px;
   color: var(--text-secondary);
+  font-size: 12.5px;
+  line-height: 1.3;
+  font-variant-numeric: tabular-nums;
+  cursor: default;
+}
+.family-activity-glyphs {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+  /* Four segments only overflow on an extremely narrow sidebar; clip
+     rather than spill past the row. Attention states come first, so
+     what survives the clip is what matters. */
+  overflow: hidden;
+}
+.family-plus {
+  flex: 0 0 auto;
+  margin-right: -4px;
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1;
+}
+.family-activity-seg {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  flex: 0 0 auto;
 }
 .family-child-proc {
   flex: 0 0 auto;
@@ -1129,16 +1140,10 @@ body {
   color: var(--text-muted);
 }
 .family-child-proc.working { color: var(--accent); }
-.family-slot-title {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  min-width: 0;
-}
 
-/* States that belong to the root row are the whole card's states — the
-   card is one entry, so it dims, drags and takes a drop line as a unit. */
-.session-family:has(.session-item.unavailable) .family-slot {
+/* States that belong to the root row are the whole entry's states —
+   it's one entry, so it dims, drags and takes a drop line as a unit. */
+.session-family:has(.session-item.unavailable) .family-sub {
   opacity: 0.55;
 }
 .session-family:has(.session-item.session-dragging) {
@@ -1154,13 +1159,6 @@ body {
   box-shadow: none;
 }
 
-/* Keyboard focus must be visible on the inner links even though the
-   card carries the selected background. */
-.session-family a:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: -2px;
-  border-radius: 3px;
-}
 
 /* Session drag-to-reorder */
 .session-item.session-dragging {
@@ -3117,6 +3115,11 @@ body {
   .family-slot {
     padding-top: 9px;
     padding-bottom: 9px;
+  }
+  /* Keep the elbow on the dot's line, not the padding's midpoint. */
+  .family-activity {
+    padding-top: 4px;
+    padding-bottom: 6px;
   }
 }
 

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -975,6 +975,9 @@ body {
   transition: background 0.1s, color 0.1s, opacity 0.15s;
   padding: 0;
 }
+/* The group owns hover, so pointing anywhere in a family entry must
+   still reveal the root row's close button. */
+.session-family:hover .session-close-btn,
 .session-item:hover .session-close-btn,
 .session-item.selected .session-close-btn,
 .session-row:hover .session-close-btn,
@@ -999,21 +1002,31 @@ body {
 
 /* ── Sidebar family entry ──
    A family is one sidebar entry: a root row, the member you're viewing
-   (or last viewed), and a `+` line for everyone else. What binds them
-   is the trunk down the gutter, not a highlight — selection is drawn on
-   the row you selected, exactly as it is anywhere else in the list. */
+   (or last viewed), and a line counting everyone else. Hit areas and
+   highlights nest. The group is the root's area — it takes the hover
+   and carries the "you are in this family" background — and the member
+   row is its own area inside it, one tone above. The accent bar is the
+   only thing that marks a single row, so it moves between the root and
+   the member while the group stays lit either way. */
 .session-family {
   position: relative;
-  padding-bottom: 2px;
+  border-radius: 3px;
+}
+.session-family:hover {
+  background: var(--bg-hover);
+}
+.session-family.selected {
+  background: var(--bg-selected);
+}
+/* The root row doesn't paint itself: hovering or selecting it *is*
+   hovering or selecting the group. Its accent bar stays — that's the
+   part that belongs to the row rather than to the family. */
+.session-family .session-item:hover,
+.session-family .session-item.selected {
+  background: none;
 }
 
-/* Sub-rows hang off a hairline trunk running down the dot column
-   (14px pad + 7px dot, so its centre is 17.5px). The trunk is painted
-   as a background image rather than a pseudo-element: ::before is the
-   selection bar and ::after is the elbow, and a background can't cover
-   the bar the way a pseudo-element would. State rules below must use
-   `background-color`, never the `background` shorthand, or they wipe
-   the trunk out. */
+/* Sub-rows hang under the root title (14px pad + 7px dot + 8px gap). */
 .family-sub {
   position: relative;
   display: flex;
@@ -1021,48 +1034,15 @@ body {
   gap: 6px;
   min-width: 0;
   padding: 3px 8px 3px 29px;
-  background-image: linear-gradient(var(--border), var(--border));
-  background-repeat: no-repeat;
-  background-position: 17px 0;
-  background-size: 1px 100%;
-}
-/* The last sub-row terminates the trunk at its elbow instead of
-   letting it run out of the bottom of the entry. */
-.family-sub:last-child {
-  background-size: 1px 50%;
 }
 
-/* The trunk starts just under the root row's dot rather than at the
-   first sub-row's top edge, so it reads as hanging off the root. A
-   background can't paint outside its own box, so this segment belongs
-   to the root row — and only exists when something hangs off it. */
-.session-family:has(.family-sub) > .session-item::after {
-  content: '';
-  position: absolute;
-  left: 17px;
-  /* Tracks the dot's centre, so it stays clear of the dot whatever the
-     row's height (touch padding, second line, taller status icons). */
-  top: 50%;
-  margin-top: 6px;
-  bottom: 0;
-  width: 1px;
-  background: var(--border);
-}
-
-/* Elbow into the row, stopping short of the dot/glyph column. */
-.family-sub::after {
-  content: '';
-  position: absolute;
-  left: 17px;
-  top: 50%;
-  width: 6px;
-  height: 1px;
-  background: var(--border);
-}
-
-/* Slot row: the family member you're viewing, or the last one you did.
-   Title-sized and title-coloured in every state — a peer of the root
-   row you navigate to, so only the background says which is selected. */
+/* Member row: the family member you're viewing, or the last one you
+   did. Title-sized and title-coloured in every state — a peer of the
+   root row you navigate to, so only the background says where you are.
+   Its highlight sits one tone above the group's in both states, so the
+   row under the pointer is unmistakable without breaking the entry
+   apart. --bg-hover/--bg-surface read as a dent inside a selected
+   group, hence the explicit tones. */
 .family-slot {
   text-decoration: none;
   color: var(--text);
@@ -1071,13 +1051,14 @@ body {
   border-radius: 3px;
 }
 .family-slot:hover {
-  background-color: var(--bg-hover);
+  background: oklch(26% 0.02 250);
 }
+.session-family.selected .family-slot:hover,
 .family-slot.selected {
-  background-color: var(--bg-selected);
+  background: oklch(30% 0.02 250);
 }
-/* Same 2px accent bar as any selected sidebar item. It sits on the row
-   that owns the selection, so the row's own background can't cover it. */
+/* Same 2px bar as any selected sidebar item, on the row that owns the
+   selection — the group's background can't cover it there. */
 .family-slot.selected::before {
   content: '';
   position: absolute;
@@ -1095,18 +1076,18 @@ body {
   min-width: 0;
 }
 
-/* `+` line: everyone the entry doesn't name, one segment per state,
-   each dropped at zero. Inert — a count is a fact, not a destination —
-   so it takes no hover. Numbers sit a touch under the title size; the
-   glyphs keep their standard sizes. */
+/* Activity line: everyone the entry doesn't name by row, one segment
+   per state, each dropped at zero. No target of its own — it's part of
+   the group's area, so it takes the group's hover and selects the
+   root. Numbers sit a touch under the title size; the glyphs keep
+   their standard sizes. */
 .family-activity {
   padding-top: 1px;
-  padding-bottom: 3px;
+  padding-bottom: 4px;
   color: var(--text-secondary);
   font-size: 12.5px;
   line-height: 1.3;
   font-variant-numeric: tabular-nums;
-  cursor: default;
 }
 .family-activity-glyphs {
   display: flex;
@@ -1117,13 +1098,6 @@ body {
      rather than spill past the row. Attention states come first, so
      what survives the clip is what matters. */
   overflow: hidden;
-}
-.family-plus {
-  flex: 0 0 auto;
-  margin-right: -4px;
-  color: var(--text-muted);
-  font-size: 12px;
-  line-height: 1;
 }
 .family-activity-seg {
   display: inline-flex;
@@ -1157,6 +1131,14 @@ body {
 }
 .session-family .session-item.session-drop-target {
   box-shadow: none;
+}
+
+/* Keyboard focus must be visible on the member row even though the
+   group carries the background. */
+.session-family a:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+  border-radius: 3px;
 }
 
 
@@ -3111,15 +3093,14 @@ body {
     padding: 8px 10px 8px 14px;
   }
 
-  /* The slot row is a real tap target on touch. */
+  /* The member row is a real tap target on touch. */
   .family-slot {
     padding-top: 9px;
     padding-bottom: 9px;
   }
-  /* Keep the elbow on the dot's line, not the padding's midpoint. */
   .family-activity {
-    padding-top: 4px;
-    padding-bottom: 6px;
+    padding-top: 3px;
+    padding-bottom: 7px;
   }
 }
 

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -962,6 +962,9 @@ body {
   transition: background 0.1s, color 0.1s, opacity 0.15s;
   padding: 0;
 }
+/* The family card owns hover, so hovering its summary line must still
+   reveal the root row's close button. */
+.session-family:hover .session-close-btn,
 .session-item:hover .session-close-btn,
 .session-item.selected .session-close-btn,
 .session-row:hover .session-close-btn,
@@ -982,6 +985,144 @@ body {
  * .session-close-btn class, so one rule hides both in screenshots. */
 .mock-mode .session-close-btn {
   display: none;
+}
+
+/* ── Sidebar family entry ──
+   An active family is one sidebar entry: the root row, an optional
+   selected-child row, and an activity row. The card owns selection and
+   the ambient hover so the stack reads as a unit — inner rows drop
+   their own selected background and accent bar (they'd draw a second
+   card inside this one) — while the row actually under the pointer
+   steps up one tone so the click target stays unambiguous. */
+.session-family {
+  position: relative;
+  border-radius: 3px;
+}
+.session-family:hover {
+  background: var(--bg-hover);
+}
+.session-family.selected {
+  background: var(--bg-selected);
+}
+.session-family.selected::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 4px;
+  bottom: 4px;
+  width: 2px;
+  background: var(--accent);
+  border-radius: 0 1px 1px 0;
+}
+.session-family .session-item.selected {
+  background: none;
+}
+/* One tone above the card in each state (card: --bg-hover /
+   --bg-selected), so the row under the pointer is unmistakable
+   without breaking the card apart. */
+.session-family .session-item:hover,
+.session-family .family-sub-row:hover {
+  background: oklch(26% 0.02 250);
+}
+.session-family.selected .session-item:hover,
+.session-family.selected .family-sub-row:hover {
+  background: oklch(30% 0.02 250);
+}
+.session-family .session-item.selected::before {
+  display: none;
+}
+.session-family .session-item {
+  padding-bottom: 2px;
+}
+
+/* Sub-rows hang off the root title, not the status-dot column: the
+   branch glyph starts where the title does (14px pad + 7px dot + 8px
+   gap = 29px). They span the full card so hovering one highlights a
+   row, not a text fragment. */
+.family-sub-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  padding: 3px 8px 3px 29px;
+  text-decoration: none;
+  color: var(--text);
+  font-size: 14px;
+  line-height: 1.35;
+  border-radius: 3px;
+}
+.family-sub-row:last-child {
+  margin-bottom: 4px;
+}
+.family-sub-branch {
+  flex: 0 0 auto;
+  width: 9px;
+  color: var(--text-muted);
+  opacity: 0.55;
+  font-size: 10px;
+  line-height: 1;
+}
+/* A quiet member reserves no dot column — the title takes the space. */
+.family-child-proc {
+  flex: 0 0 auto;
+  width: 7px;
+  font-family: 'Fira Code', monospace;
+  font-size: 11px;
+  line-height: 1;
+  color: var(--text-muted);
+}
+.family-child-proc.working { color: var(--accent); }
+.family-child-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+/* Activity row: dot/ring/$ glyph + count, one segment per state, each
+   dropped at zero. Clicking it selects the root and opens the tree. */
+.family-activity {
+  gap: 10px;
+  /* Four segments only overflow on an extremely narrow sidebar; clip
+     rather than spill past the card. Attention states come first, so
+     what survives the clip is what matters. */
+  overflow: hidden;
+  color: var(--text-secondary);
+  font-variant-numeric: tabular-nums;
+}
+.family-activity .family-sub-branch {
+  margin-right: -4px;
+}
+.family-activity-seg {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  flex: 0 0 auto;
+}
+
+/* States that belong to the root row are the whole card's states — the
+   card is one entry, so it dims, drags and takes a drop line as a unit. */
+.session-family:has(.session-item.unavailable) .family-sub-row {
+  opacity: 0.55;
+}
+.session-family:has(.session-item.session-dragging) {
+  opacity: 0.4;
+}
+.session-family:has(.session-item.session-drop-target) {
+  box-shadow: inset 0 -2px 0 0 var(--accent);
+}
+.session-family .session-item.session-dragging {
+  opacity: 1;
+}
+.session-family .session-item.session-drop-target {
+  box-shadow: none;
+}
+
+/* Keyboard focus must be visible on the inner links even though the
+   card carries the selected background. */
+.session-family a:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+  border-radius: 3px;
 }
 
 /* Session drag-to-reorder */
@@ -2933,6 +3074,12 @@ body {
 
   .session-item {
     padding: 8px 10px 8px 14px;
+  }
+
+  /* Family sub-rows are real tap targets on touch. */
+  .family-sub-row {
+    padding-top: 9px;
+    padding-bottom: 9px;
   }
 }
 

--- a/e2e/tests/family-entry-interaction.spec.ts
+++ b/e2e/tests/family-entry-interaction.spec.ts
@@ -1,0 +1,108 @@
+import { test, expect } from '@playwright/test'
+import { openApp } from '../helpers'
+
+/**
+ * The sidebar's family entry is one clickable group with its own rows
+ * inside it, and none of that lives in a testable unit: it is markup,
+ * event targets and browser gesture semantics. These are the behaviours
+ * that broke in review, each of which a unit test structurally cannot
+ * see.
+ *
+ * Runs against `?mock`, so the fixtures are the bundled demo family
+ * rather than daemon state: deterministic, and the same data the design
+ * work was done against.
+ */
+
+/** `?mock` boots the frontend on bundled fixtures; auth still applies. */
+async function openMockSidebar(page: import('@playwright/test').Page, path: string) {
+  await openApp(page, `${path}?mock`)
+  await page.waitForSelector('.sidebar-list')
+  await page.locator('.session-family').first().waitFor()
+}
+
+const familyEntry = (page: import('@playwright/test').Page, title: string) =>
+  page.locator('.session-family').filter({ hasText: title })
+
+test.describe('sidebar family entry', () => {
+  test('the slack around the rows selects the root, but declines link gestures', async ({ page }) => {
+    await openMockSidebar(page, '/my-project/claude/~fam2kid')
+    const entry = familyEntry(page, 'build watcher agent')
+    const slack = entry.locator('.family-activity')
+
+    // 1. An ordinary click on the counts line lands on the root: the
+    //    whole group is the root's hit area.
+    await slack.click()
+    await expect(page).toHaveURL(/~famBroot/)
+
+    // 2. A modified click is a link gesture (new tab, download, range
+    //    select). The slack is not a link, so it declines rather than
+    //    quietly doing something else.
+    await openMockSidebar(page, '/my-project/claude/~fam2kid')
+    await familyEntry(page, 'build watcher agent').locator('.family-activity').click({ modifiers: ['Control'] })
+    await expect(page).toHaveURL(/~fam2kid/)
+
+    // 3. A click that ends a text selection wants the text, not a
+    //    navigation.
+    const line = familyEntry(page, 'build watcher agent').locator('.family-activity')
+    const box = (await line.boundingBox())!
+    await page.mouse.move(box.x + 4, box.y + box.height / 2)
+    await page.mouse.down()
+    await page.mouse.move(box.x + box.width - 8, box.y + box.height / 2, { steps: 10 })
+    await page.mouse.up()
+    await expect(page).toHaveURL(/~fam2kid/)
+
+    // 4. The rows themselves still own their own clicks.
+    await familyEntry(page, 'orchestrator').locator('.family-slot').click()
+    await expect(page).toHaveURL(/~fam2kid/)
+  })
+
+  test('a drop anywhere on the entry reorders exactly once', async ({ page }) => {
+    await openMockSidebar(page, '/my-project/claude/~fam2kid')
+
+    // The group is a drop target as well as the root row, so a drop on
+    // the root row can reach both handlers in one dispatch. Count the
+    // reorder requests rather than trusting the resulting order: two
+    // identical PATCHes produce the right order and the wrong number of
+    // writes (and two error toasts when the daemon says no).
+    const reorders: string[] = []
+    await page.route('**/sessions', async (route) => {
+      const req = route.request()
+      if (req.method() === 'PATCH') reorders.push(req.postData() ?? '')
+      await route.fulfill({ status: 200, body: '{}' })
+    })
+
+    // Dispatch the browser's own event sequence, bubbling as it really
+    // does, and count the writes. Two things can go wrong and neither
+    // shows up in the resulting order: a sub-row can refuse the drop
+    // outright (before the group took drag handlers, only the root row
+    // preventDefault()ed the dragover, so the lower two thirds of a
+    // three-row entry silently rejected the drag), and a drop on the
+    // root row can run both the row's handler and the group's in one
+    // dispatch — sending the same reorder twice, and toasting twice
+    // when the daemon rejects it.
+    // One event per step, with a beat between them: the handlers keep
+    // drag state in component state, so a whole sequence dispatched in
+    // a single tick never sees its own dragstart.
+    const fire = (type: string, selector: string, within: string) => page.evaluate(({ type, selector, within }) => {
+      const entry = [...document.querySelectorAll('.session-family')]
+        .find(e => e.textContent?.includes(within))!
+      const el = entry.querySelector(selector)!
+      const ev = new DragEvent(type, { bubbles: true, cancelable: true, dataTransfer: new DataTransfer() })
+      el.dispatchEvent(ev)
+      return ev.defaultPrevented
+    }, { type, selector, within })
+
+    for (const target of ['.session-item', '.family-activity']) {
+      reorders.length = 0
+      await fire('dragstart', '.session-item', 'orchestrator')
+      await page.waitForTimeout(100)
+      expect(await fire('dragover', target, 'build watcher agent'), `dragover accepted over ${target}`).toBe(true)
+      await page.waitForTimeout(100)
+      await fire('drop', target, 'build watcher agent')
+      await page.waitForTimeout(250)
+      expect(reorders.length, `reorder writes for a drop on ${target}`).toBe(1)
+      await fire('dragend', '.session-item', 'orchestrator')
+      await page.waitForTimeout(100)
+    }
+  })
+})

--- a/e2e/tests/popover-touch-dismiss.spec.ts
+++ b/e2e/tests/popover-touch-dismiss.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from '@playwright/test'
+import { openApp, gotoTestSession } from '../helpers'
+
+/**
+ * Regression guard: header popovers must close when you tap back into
+ * the terminal on a touch device.
+ *
+ * They used to close on a document `mousedown`, which works for a mouse
+ * but not for a tap on the terminal: `terminal.tsx` registers
+ * capture-phase, non-passive touch handlers that `preventDefault()` on
+ * several gesture paths, and that suppresses the browser's synthesized
+ * mouse cascade. The `mousedown` simply never arrived, so the popover
+ * stayed open on top of the session you were tapping into — while a tap
+ * anywhere else (header, sidebar) dismissed it normally, which is what
+ * made the bug look like a focus or keyboard problem.
+ *
+ * `pointerdown` is dispatched before `touchstart` and can't be cancelled
+ * by it, so it survives whatever the terminal does with the gesture.
+ * This can't be caught by a unit test: it depends on real browser
+ * event-cascade suppression, not on our own listener logic.
+ */
+test.use({ hasTouch: true })
+
+test.describe('touch dismissal of header popovers', () => {
+  test('the session menu closes when you tap into the terminal', async ({ page }) => {
+    await openApp(page)
+    await gotoTestSession(page)
+
+    const menu = page.locator('.session-menu-dropdown')
+    await page.locator('.session-menu-trigger').click()
+    await expect(menu).toBeVisible()
+
+    // Tap inside the terminal — the gesture whose synthesized mouse
+    // events the terminal suppresses.
+    const screen = await page.locator('.xterm-screen').boundingBox()
+    if (!screen) throw new Error('terminal screen has no box')
+    await page.touchscreen.tap(screen.x + screen.width / 2, screen.y + screen.height * 0.7)
+
+    await expect(menu).toBeHidden()
+  })
+
+  test('a tap outside the terminal still dismisses it', async ({ page }) => {
+    await openApp(page)
+    await gotoTestSession(page)
+
+    const menu = page.locator('.session-menu-dropdown')
+    await page.locator('.session-menu-trigger').click()
+    await expect(menu).toBeVisible()
+
+    // The header is an ordinary element with no touch handling, so this
+    // path worked before the fix and must keep working after it.
+    await page.touchscreen.tap(300, 20)
+    await expect(menu).toBeHidden()
+  })
+})


### PR DESCRIPTION
Reworks the sidebar's agent-family entry so a family reads as one thing, and makes the family panel show the family.

## Sidebar entry

A family is one entry: the root row, the member you're viewing (or last viewed), and a line counting everyone else.

- **Root dot is the root's own status.** It used to carry the family roll-up, so a working subagent made an idle root look busy. The roll-up moved to its own line.
- **The member row persists.** After you navigate to the root, or away entirely, the member you were just in stays as one click back. Only visited ids are remembered (in memory, capped, per tab); whether one still resolves to a live family child is derived on every read, so promotion, reparenting and session death need no cleanup pass.
- **Each member is represented exactly once** — named by a row or counted on the line, never both. The counts and the member row can't disagree.
- **Hit areas and highlights nest.** The group is the root's area (hover, background, and any click that misses the member row); the member row is its own area inside it. The background says which family, the accent bar says which row — so the bar spans the group when the root is selected and narrows to the member when it isn't.
- **A fixed glyph column** shows status, `$` for a process, or the branch arrow when there's nothing to report, so titles stop sliding when state arrives.

## Family panel

- **Whole family, from the root, wherever you stand.** It used to scope to your own sibling level, so it showed *less* the deeper you went: five levels down it listed one row — the session you were already looking at. "The family" now means the same thing in the panel, the sidebar entry and the trigger badge.
- **Ages replace the adapter label**, which repeated the same word down the panel. Levels were already ordered by recency; nothing said so, and sorting by an invisible key reads as no order at all.
- **The selected row keeps its dot.** A map that blanks the row you're standing on would claim `1 error` with no errored row in sight.

## Touch fix

Header popovers (family panel, session ⋮, launcher) close on an outside **pointerdown**, not mousedown. `terminal.tsx` registers capture-phase, non-passive touch handlers that `preventDefault()`, which suppresses the browser's synthesized mouse cascade — so tapping back into the terminal left the popover covering the session you tapped into. `pointerdown` is dispatched ahead of `touchstart` and can't be cancelled by it. Covered by an e2e regression test (`e2e/tests/popover-touch-dismiss.spec.ts`), confirmed to fail against the old listener.

## Verification

700 unit tests across 34 files, `tsc --noEmit`, biome `--error-on-warnings`, `vite build`, and the family bench profile unchanged. Behavior verified on desktop, a 150px sidebar, and emulated touch.
