### PR TITLE
fix(cli): use neutral language for command wait reports

### DIFF
--- a/.memory/report-wait-neutral-language.md
+++ b/.memory/report-wait-neutral-language.md
@@ -1,0 +1,57 @@
+# gmux `wait` neutral-language report
+
+## Result
+
+- Branch: `fix/wait-neutral-language`
+- PR: #479 — https://github.com/gmuxapp/gmux/pull/479
+- Implementation commit SHA: `8926a9947f2157589261760f026efc19ecfbdc5f`
+
+## Before / after
+
+Ordinary command and process sessions previously entered the agent exchange renderer for every non-predicate conclusion:
+
+| Outcome | Before | After |
+| --- | --- | --- |
+| completed without an exchange frame | `[No exchanges yet]` | `[Session activity completed]` |
+| intentionally interrupted | `[No exchanges yet]` + `[Agent interrupted]` | `[Session activity interrupted]` |
+| failed | `[No exchanges yet]` + `[Agent failed: …]` | `[Session activity failed: …]` |
+| authoritative timeout | `[No exchanges yet]` + `[Wait timed out after Ns; agent active, no completed iterations yet...]` | `[Wait timed out after Ns; session remains active]` |
+| local SIGINT/SIGTERM | `[Wait interrupted; agent remains active]` | `[Wait interrupted; session activity continues]` |
+| generic runner loss | `[Agent failed: agent activity was lost]` | agent waits retain that wording; ordinary waits use `[Session activity failed: session process exited before the activity completed]` |
+
+Identified agent sessions (`pi`, `claude`, and `codex`) retain exchange reports and useful agent wording such as `[AGENT]: …`, `[Agent interrupted]`, and `[Wait timed out …; agent active, …]`.
+
+## Mechanism trace
+
+1. `cmdWait` resolves every reference to `cliSession` before arming waits. That projection includes the adapter, so the CLI can distinguish known agent adapters without adding state or changing the API.
+2. Single and multi-session waits call `waitSession` concurrently and buffer each report. Reports are flushed in argument order with headers for multi-wait. Exit aggregation remains failure/timeout > interruption > completion.
+3. `waitSession` posts to `/v1/sessions/{id}/wait`. Predicate matches remain output-free; predicate timeout/exit diagnostics remain on stderr. HTTP/protocol/resolve errors and daemon error envelopes keep their existing stderr paths.
+4. Successful `idle` and `died` conclusions and authoritative 408 timeout payloads now pass through `renderWait`. Known agent sessions continue to `renderExchangeWait`; ordinary sessions receive neutral outcome markers. Quiet mode and unread acknowledgement behavior are unchanged.
+5. Local hard-deadline fallback already used neutral `[Wait timed out …; session state unknown]` language and remains unchanged.
+6. Multi-wait signal handling now selects agent wording only when every observed session is an identified agent. Ordinary or mixed groups use the neutral signal notice; buffered settlement reports remain suppressed after a signal.
+7. Synchronous `gmux agent prompt` still calls the agent exchange renderer and agent signal notice directly. `send --wait` is quiet and only consumes the shared exit mapping.
+8. gmuxd derives process exit, closed-turn, interruption, error, and runner-death conclusions in `terminalReason` / `writeWaitConclusion`. Its generic runner-loss frame no longer hardcodes an agent diagnostic; the unchanged `runner_died` cause lets the CLI render agent or ordinary-session language from the resolved session type. Agent-action API errors remain agent-specific because those endpoints are agent-only.
+9. `gmux wait` has no JSON output mode (`wait --json` is rejected), so no JSON CLI rendering contract changed. API fields and outcome vocabulary are unchanged.
+
+## Files changed
+
+- `cli/gmux/cmd/gmux/wait.go` — session-aware wait rendering and neutral ordinary-session outcomes.
+- `cli/gmux/cmd/gmux/waitsignal.go` — neutral signal notice for ordinary/mixed waits.
+- `cli/gmux/cmd/gmux/actions.go` — passes the non-agent mode through the quiet shared verdict path.
+- `services/gmuxd/cmd/gmuxd/serve_central.go` — leaves generic runner loss as a typed cause for session-aware CLI rendering.
+- `cli/gmux/cmd/gmux/exchange_report_test.go` — table-driven ordinary/agent outcome coverage.
+- `cli/gmux/cmd/gmux/wait_multi_test.go` — single and multi ordinary-command integration coverage.
+- `cli/gmux/cmd/gmux/waitsignal_test.go` — neutral command-wait signal coverage.
+- `services/gmuxd/cmd/gmuxd/exchange_wait_test.go` — asserts generic runner-loss frames do not override the typed cause with fixed wording.
+- `cli/gmux/cmd/gmux/help.go` and `apps/website/src/content/docs/reference/cli.md` — relevant help/reference contract updates.
+
+## Tests
+
+Passed:
+
+```text
+go test ./cli/gmux/cmd/gmux ./packages/adapter/... ./services/gmuxd/cmd/gmuxd -run 'Wait|ExchangeReport|RunnerLoss' -count=1
+go test ./cli/gmux/... ./packages/adapter/... ./services/gmuxd/...
+```
+
+The focused tests cover agent and ordinary outcomes (snapshot/completed/interrupted/error/timeout), quiet output, single/multi buffered reporting, predicates and process exit paths already present in the suite, local deadline fallback, signals, unread acknowledgements, version-skew/protocol errors, and the daemon runner-loss message.

--- a/apps/website/src/content/docs/reference/cli.md
+++ b/apps/website/src/content/docs/reference/cli.md
@@ -225,8 +225,8 @@ forwarding the bytes, it can't mistake the previous turn's idle state for the
 reply — unlike the racy `gmux send X Enter && gmux wait X` composition.
 `send --wait` shares the 0/1/2 verdict with `gmux wait`, but **not** the
 first-signal 128+N report/re-arm behavior: a local SIGINT or SIGTERM triggers
-ordinary process signal handling, not the `[Wait interrupted; agent remains
-active]` handler that `gmux wait` and `gmux agent prompt` install. The flags
+ordinary process signal handling, not the first-signal notice handler that
+`gmux wait` and `gmux agent prompt` install. The flags
 precede the id:
 
 ```bash
@@ -292,8 +292,8 @@ use its own codes.)
   agent stopped it)
 - `1` — anything else: the activity failed, the `--timeout` elapsed, the
   session exited before its output matched, or the command was misused
-- `128+N` — a first local SIGINT/SIGTERM stopped **the wait**, not the agent
-  (see below)
+- `128+N` — a first local SIGINT/SIGTERM stopped **the wait**, not the observed
+  session activity (see below)
 
 **A failed command fails its wait — only for lifetime turns.** A session whose
 turn is its whole lifetime (`gmux -d -- make build`, a shell *without* OSC 133
@@ -312,11 +312,14 @@ prompt comes back, whether the command succeeded or failed, and
 shell command's result, run it as its own session (`gmux -- make build`, whose
 exit code is propagated) rather than typing it into an interactive shell.
 
-**The report.** For a renderer-capable agent (pi today), `wait` prints an
-**exchange report** on stdout — the same document `agent prompt` and
-`agent logs` render (see [Agent sessions](#agent-sessions) for the format):
-what was asked, every further user message that entered the loop, how many
-iterations of work each caused, and the terminal response.
+**The report.** Ordinary command and process sessions use neutral activity
+markers such as `[Session activity completed]`, `[Session activity interrupted]`,
+and `[Session activity failed: <reason>]`. For a renderer-capable agent (pi
+today), `wait` instead prints an **exchange report** on stdout — the same
+document `agent prompt` and `agent logs` render (see
+[Agent sessions](#agent-sessions) for the format): what was asked, every further
+user message that entered the loop, how many iterations of work each caused,
+and the terminal response.
 
 A live report is carried within an honest transport budget. An activity that
 outgrows it never loses its outcome or terminal content, but display material
@@ -364,8 +367,10 @@ job; here is the bad news": an interrupted activity's report ends
 (exit 1). An authoritative timeout report ends
 `[Wait timed out after Ns; agent active, N iterations so far...]` (exit 1); if
 the whole-call deadline wins before that report arrives, gmux instead prints
-`[Wait timed out after Ns; session state unknown]`. In either case the agent
-keeps running. stderr is reserved for gmux's **inability** to produce
+`[Wait timed out after Ns; session state unknown]`. An ordinary session's
+authoritative timeout instead says
+`[Wait timed out after Ns; session remains active]`. In every case the observed
+session keeps running. stderr is reserved for gmux's **inability** to produce
 the report at all: an unknown session, an unsupported adapter, a daemon or
 protocol failure. A pre-arm resolution failure exits 1 with empty stdout, as
 does the applicable single-session inability-to-report case. Once a
@@ -392,27 +397,24 @@ fabricated verdict. To gate on an activity you are about to trigger, use
 `gmux agent prompt` or `gmux send --wait`, which arm the wait before
 delivering anything.
 
-**Signals.** A first `^C` (or SIGTERM) stops **the wait**, not the agent: gmux
-prints exactly
-
-```
-[Wait interrupted; agent remains active]
-```
-
-and exits `128+N`. The line is deliberately fact-free — until the wait
-completes, the CLI has received no exchange facts to report, and it states
-only what it knows rather than guessing; read the conversation with
-`gmux agent logs` afterwards. A second signal terminates immediately. Under
-`--quiet` the first signal prints nothing either — exit `128+N`,
-verdict-only. `gmux wait <id>` re-arms.
+**Signals.** A first `^C` (or SIGTERM) stops **the wait**, not the observed
+activity. An all-agent wait prints `[Wait interrupted; agent remains active]`;
+an ordinary or mixed-session wait prints
+`[Wait interrupted; session activity continues]`. It then exits `128+N`.
+The line is deliberately fact-free — until the wait completes, the CLI has
+received no outcome facts to report, and it states only what it knows rather
+than guessing. A second signal terminates immediately. Under `--quiet` the
+first signal prints nothing either — exit `128+N`, verdict-only. `gmux wait
+<id>` re-arms.
 
 Shell/process sessions and agents without rendered conversation history are
-still perfectly waitable. A non-quiet bare wait prints the exchange format's
-minimal status markers (typically `[No exchanges yet]`, plus an outcome marker
-for failure, interruption, or timeout) rather than terminal output; it does
-not silently produce an empty stream. Output-condition waits are the
-result-free exception: they synchronize and exit by the verdict without a
-report. Use `--quiet` to suppress all bare-wait report or marker output.
+still perfectly waitable. A non-quiet ordinary-session wait prints the neutral
+session-activity markers described above rather than terminal output. An agent
+without conversation history prints the exchange format's minimal markers,
+typically `[No exchanges yet]` plus an outcome marker for failure,
+interruption, or timeout. Output-condition waits are the result-free exception:
+they synchronize and exit by the verdict without a report. Use `--quiet` to
+suppress all bare-wait report or marker output.
 
 **Output conditions.** Instead of the idle signal, wait until specific text
 appears in the session's output:

--- a/cli/gmux/cmd/gmux/actions.go
+++ b/cli/gmux/cmd/gmux/actions.go
@@ -791,7 +791,7 @@ func postInput(sess cliSession, body io.Reader, query string) int {
 		fmt.Fprintln(os.Stderr, "gmux: decode send --wait response:", err)
 		return 1
 	}
-	return reportWaitResult(env.Data, false, true, io.Discard)
+	return reportWaitResult(env.Data, false, true, false, io.Discard)
 }
 
 // maxSendBytes caps the number of bytes read from stdin for a single

--- a/cli/gmux/cmd/gmux/exchange_report_test.go
+++ b/cli/gmux/cmd/gmux/exchange_report_test.go
@@ -79,7 +79,7 @@ func TestAgentPromptGrammarMatrix(t *testing.T) {
 func TestWaitVersionSkewTruncationDiagnosticsAndPartialLabels(t *testing.T) {
 	var out bytes.Buffer
 	stderr := captureStderr(t, func() {
-		if code := reportTurnConclusion(waitResult{}, false, &out); code != waitExitError {
+		if code := reportTurnConclusion(waitResult{}, false, true, &out); code != waitExitError {
 			t.Fatalf("missing outcome exit=%d", code)
 		}
 	})
@@ -93,7 +93,9 @@ func TestWaitVersionSkewTruncationDiagnosticsAndPartialLabels(t *testing.T) {
 		{"old timeout", func(out *bytes.Buffer) int {
 			return renderExchangeWait(waitResult{Reason: "timeout"}, false, 3, "", out)
 		}},
-		{"old died", func(out *bytes.Buffer) int { return reportWaitResult(waitResult{Reason: "died"}, false, false, out) }},
+		{"old died", func(out *bytes.Buffer) int {
+			return reportWaitResult(waitResult{Reason: "died"}, false, false, true, out)
+		}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			var oldOut bytes.Buffer
@@ -108,11 +110,11 @@ func TestWaitVersionSkewTruncationDiagnosticsAndPartialLabels(t *testing.T) {
 		})
 	}
 	var predicateOut bytes.Buffer
-	if code := reportWaitResult(waitResult{Reason: "matched"}, true, false, &predicateOut); code != waitExitOK || predicateOut.Len() != 0 {
+	if code := reportWaitResult(waitResult{Reason: "matched"}, true, false, true, &predicateOut); code != waitExitOK || predicateOut.Len() != 0 {
 		t.Fatalf("matched predicate exit=%d out=%q", code, predicateOut.String())
 	}
 	predicateErr := captureStderr(t, func() {
-		if code := reportWaitResult(waitResult{Reason: "died"}, true, false, &predicateOut); code != waitExitError {
+		if code := reportWaitResult(waitResult{Reason: "died"}, true, false, true, &predicateOut); code != waitExitError {
 			t.Fatalf("died predicate exit=%d", code)
 		}
 	})
@@ -121,11 +123,11 @@ func TestWaitVersionSkewTruncationDiagnosticsAndPartialLabels(t *testing.T) {
 	}
 
 	out.Reset()
-	if code := reportTurnConclusion(waitResult{Outcome: waitOutcomeSnapshot, Exchanges: []adapter.Exchange{{User: "history"}}}, false, &out); code != waitExitOK || !strings.Contains(out.String(), "[USER]: history") {
+	if code := reportTurnConclusion(waitResult{Outcome: waitOutcomeSnapshot, Exchanges: []adapter.Exchange{{User: "history"}}}, false, true, &out); code != waitExitOK || !strings.Contains(out.String(), "[USER]: history") {
 		t.Fatalf("current snapshot exit=%d out=%q", code, out.String())
 	}
 	out.Reset()
-	if code := reportTurnConclusion(waitResult{Outcome: waitOutcomeSnapshot}, false, &out); code != waitExitOK || out.String() != "[No exchanges yet]\n" {
+	if code := reportTurnConclusion(waitResult{Outcome: waitOutcomeSnapshot}, false, true, &out); code != waitExitOK || out.String() != "[No exchanges yet]\n" {
 		t.Fatalf("empty snapshot exit=%d out=%q", code, out.String())
 	}
 
@@ -252,6 +254,71 @@ func TestWaitExitTaxonomyAndSignalFormatting(t *testing.T) {
 	report := string(adapter.RenderExchangeReport(adapter.ExchangeReport{Outcome: adapter.ExchangeWaitSignal}))
 	if !strings.Contains(report, "[Wait interrupted; agent remains active") {
 		t.Fatalf("signal report=%q", report)
+	}
+}
+
+func TestWaitSessionClassification(t *testing.T) {
+	for _, tc := range []struct {
+		adapter string
+		agent   bool
+	}{{"pi", true}, {"claude", true}, {"codex", true}, {"shell", false}, {"editor", false}, {"", false}} {
+		if got := isAgentSession(cliSession{Adapter: tc.adapter}); got != tc.agent {
+			t.Errorf("adapter %q agent=%v, want %v", tc.adapter, got, tc.agent)
+		}
+	}
+}
+
+func TestWaitRunnerLossUsesSessionAppropriateLanguage(t *testing.T) {
+	res := waitResult{Outcome: waitOutcomeError, Cause: causeRunnerDied}
+	for _, tc := range []struct {
+		agent bool
+		want  string
+	}{{true, "[Agent failed: agent activity was lost]"}, {false, "[Session activity failed: session process exited before the activity completed]"}} {
+		var out bytes.Buffer
+		if code := renderWait(res, false, 0, "", tc.agent, &out); code != waitExitError || !strings.Contains(out.String(), tc.want) {
+			t.Errorf("agent=%v exit=%d report=%q, want %q", tc.agent, code, out.String(), tc.want)
+		}
+	}
+}
+
+func TestWaitRenderingUsesSessionAppropriateLanguage(t *testing.T) {
+	outcomes := []struct {
+		outcome      string
+		agentMarker  string
+		sharedMarker string
+		code         int
+	}{
+		{waitOutcomeSnapshot, "[No exchanges yet]", "[Session inactive]", 0},
+		{waitOutcomeCompleted, "[AGENT]: done", "[Session activity completed]", 0},
+		{waitOutcomeInterrupted, "[Agent interrupted]", "[Session activity interrupted]", 2},
+		{waitOutcomeError, "[Agent failed: provider failed]", "[Session activity failed: provider failed]", 1},
+		{outcomeTimeout, "[Wait timed out after 9s; agent active", "[Wait timed out after 9s; session remains active]", 1},
+	}
+	for _, tc := range outcomes {
+		for _, agent := range []bool{false, true} {
+			name := map[bool]string{false: "command", true: "agent"}[agent] + "/" + tc.outcome
+			t.Run(name, func(t *testing.T) {
+				var out bytes.Buffer
+				res := waitResult{Outcome: tc.outcome, Diagnostic: "provider failed"}
+				if agent && tc.outcome != waitOutcomeSnapshot {
+					res.Output = "done"
+					res.Exchanges = []adapter.Exchange{{User: "ask", Iterations: 1}}
+				}
+				if code := renderWait(res, false, 9, "", agent, &out); code != tc.code {
+					t.Fatalf("exit=%d want=%d", code, tc.code)
+				}
+				marker := tc.sharedMarker
+				if agent {
+					marker = tc.agentMarker
+				}
+				if !strings.Contains(out.String(), marker) {
+					t.Fatalf("report=%q, want %q", out.String(), marker)
+				}
+				if !agent && strings.Contains(strings.ToLower(out.String()), "agent") {
+					t.Fatalf("command report uses agent language: %q", out.String())
+				}
+			})
+		}
 	}
 }
 

--- a/cli/gmux/cmd/gmux/help.go
+++ b/cli/gmux/cmd/gmux/help.go
@@ -218,11 +218,11 @@ For renderer-capable agents, prints an exchange-structured report on stdout.
 Steers, follow-ups, and human instructions are additional user boundaries and
 do not end the wait. A late wait immediately reports the latest exchange.
 Timeout, interruption, and activity failure are valid stdout reports; the exit
-code is the verdict. --quiet suppresses reports. Predicate and non-agent waits
-keep synchronization-only behavior.
+code is the verdict. --quiet suppresses reports. Non-agent sessions use neutral
+session-activity markers; predicate waits remain synchronization-only.
 
 Exit codes: 0 completed/matched, 2 intentionally interrupted, 1 failure or
-timeout. A local signal prints '[Wait interrupted; agent remains active]' and exits 128+N.
+timeout. A local signal says the observed agent or sessions remain active and exits 128+N.
 `,
 
 	"kill": `gmux kill: terminate a session

--- a/cli/gmux/cmd/gmux/wait.go
+++ b/cli/gmux/cmd/gmux/wait.go
@@ -16,6 +16,7 @@ import (
 	"unicode"
 
 	"github.com/gmuxapp/gmux/packages/adapter"
+	"github.com/gmuxapp/gmux/packages/adapter/adapters"
 )
 
 // The global gmux exit taxonomy (ADR 0027 §8). It is deliberately small
@@ -142,7 +143,11 @@ func cmdWait(refs []string, timeoutSecs int, forText, forRegex string, quiet boo
 		}
 	}
 
-	stopNotice, signalObserved := observeInterruptedWait(os.Stdout, quiet)
+	agentWait := true
+	for _, sess := range sessions {
+		agentWait = agentWait && isAgentSession(sess)
+	}
+	stopNotice, signalObserved := observeInterruptedWait(os.Stdout, quiet, agentWait)
 	var wg sync.WaitGroup
 	wg.Add(len(sessions))
 	for i := range sessions {
@@ -193,6 +198,7 @@ func cmdWait(refs []string, timeoutSecs int, forText, forRegex string, quiet boo
 // process-wide signal notice.
 func waitSession(ctx context.Context, sess cliSession, timeoutSecs int, serverTimeout time.Duration, forText, forRegex string, quiet bool, stdout io.Writer) int {
 	predicate := forText != "" || forRegex != ""
+	agent := isAgentSession(sess)
 	if timeoutSecs > 0 && serverTimeout < time.Millisecond {
 		return reportLocalWaitTimeout(predicate, quiet, timeoutSecs, stdout)
 	}
@@ -255,7 +261,7 @@ func waitSession(ctx context.Context, sess cliSession, timeoutSecs int, serverTi
 		if timeoutSecs > 0 && waitInvocationExpired(ctx) {
 			return reportLocalWaitTimeout(predicate, quiet, timeoutSecs, stdout)
 		}
-		code := reportWaitResult(env.Data, predicate, quiet, stdout)
+		code := reportWaitResult(env.Data, predicate, quiet, agent, stdout)
 		if code == waitExitOK {
 			if err := consumeSession(sess, env.Data.UnreadToken); err != nil {
 				fmt.Fprintf(os.Stderr, "gmux: wait could not mark %s read: %v\n", displayID(sess), err)
@@ -281,7 +287,7 @@ func waitSession(ctx context.Context, sess cliSession, timeoutSecs int, serverTi
 		if timeoutSecs > 0 && waitInvocationExpired(ctx) {
 			return reportLocalWaitTimeout(false, quiet, timeoutSecs, stdout)
 		}
-		return renderExchangeWait(env.Data, quiet, timeoutSecs, "", stdout)
+		return renderWait(env.Data, quiet, timeoutSecs, "", agent, stdout)
 	case http.StatusUnprocessableEntity:
 		// Current daemons only send 422 on the send --wait path
 		// (input_no_submit); older daemons also rejected sessions
@@ -359,7 +365,7 @@ type waitResult struct {
 // which one hit a limitation: `send --wait` shares every exit decision here but
 // is deliberately result-free, so telling its caller the daemon "predates
 // result-bearing waits" would describe a feature they did not ask for.
-func reportWaitResult(res waitResult, predicate, quiet bool, stdout io.Writer) int {
+func reportWaitResult(res waitResult, predicate, quiet, agent bool, stdout io.Writer) int {
 	switch res.Reason {
 	case "matched":
 		// Predicate waits are synchronization-only; matched bytes remain in the
@@ -370,7 +376,7 @@ func reportWaitResult(res waitResult, predicate, quiet bool, stdout io.Writer) i
 			fmt.Fprintln(os.Stderr, "gmux: the session exited before its output matched")
 			return waitExitError
 		}
-		return renderExchangeWait(res, quiet, 0, "", stdout)
+		return renderWait(res, quiet, 0, "", agent, stdout)
 	case "idle":
 		if predicate {
 			// A predicate wait resolves on "matched" or "died" only;
@@ -378,7 +384,7 @@ func reportWaitResult(res waitResult, predicate, quiet bool, stdout io.Writer) i
 			fmt.Fprintf(os.Stderr, "gmux: unexpected wait reason %q for an output condition\n", res.Reason)
 			return waitExitError
 		}
-		return reportTurnConclusion(res, quiet, stdout)
+		return reportTurnConclusion(res, quiet, agent, stdout)
 	default:
 		fmt.Fprintf(os.Stderr, "gmux: unexpected wait reason %q\n", res.Reason)
 		return waitExitError
@@ -391,8 +397,44 @@ func reportWaitResult(res waitResult, predicate, quiet bool, stdout io.Writer) i
 // predates turn conclusions always resolves a closed turn as bare "idle", and
 // silently treating that as success would report a failed or interrupted turn as
 // a clean one — under exit 0, with no result. Fail loudly and name the fix.
-func reportTurnConclusion(res waitResult, quiet bool, stdout io.Writer) int {
-	return renderExchangeWait(res, quiet, 0, "", stdout)
+func reportTurnConclusion(res waitResult, quiet, agent bool, stdout io.Writer) int {
+	return renderWait(res, quiet, 0, "", agent, stdout)
+}
+
+func isAgentSession(sess cliSession) bool {
+	_, ok := adapters.FindByAdapter(sess.Adapter).(adapter.ConversationExchangeRenderer)
+	return ok
+}
+
+func renderWait(res waitResult, quiet bool, timeoutSecs int, submitted string, agent bool, stdout io.Writer) int {
+	if agent {
+		return renderExchangeWait(res, quiet, timeoutSecs, submitted, stdout)
+	}
+	if res.Outcome == "" {
+		fmt.Fprintln(os.Stderr, "gmux: daemon response has no turn outcome; restart gmuxd to resolve version skew")
+		return waitExitError
+	}
+	exit := waitExitOK
+	marker := ""
+	switch res.Outcome {
+	case waitOutcomeSnapshot:
+		marker = "[Session inactive]"
+	case waitOutcomeCompleted:
+		marker = "[Session activity completed]"
+	case waitOutcomeInterrupted:
+		marker, exit = "[Session activity interrupted]", waitExitInterrupted
+	case waitOutcomeError:
+		marker, exit = "[Session activity failed: "+failureReason(res, false)+"]", waitExitError
+	case outcomeTimeout:
+		marker, exit = fmt.Sprintf("[Wait timed out after %ds; session remains active]", timeoutSecs), waitExitError
+	default:
+		fmt.Fprintf(os.Stderr, "gmux: unexpected turn outcome %q\n", res.Outcome)
+		return waitExitError
+	}
+	if !quiet {
+		fmt.Fprintln(stdout, marker)
+	}
+	return exit
 }
 
 func renderExchangeWait(res waitResult, quiet bool, timeoutSecs int, submitted string, stdout io.Writer) int {
@@ -440,7 +482,7 @@ func renderExchangeWait(res waitResult, quiet bool, timeoutSecs int, submitted s
 	}
 	if !quiet {
 		_, _ = stdout.Write(adapter.RenderExchangeReport(adapter.ExchangeReport{
-			Exchanges: exchanges, Outcome: outcome, Diagnostic: failureReason(res), UnscopedTerminal: unscopedTerminal,
+			Exchanges: exchanges, Outcome: outcome, Diagnostic: failureReason(res, true), UnscopedTerminal: unscopedTerminal,
 			TerminalPartial:   res.TerminalPartial || (res.Output != "" && outcome != adapter.ExchangeCompleted && outcome != adapter.ExchangeSnapshot),
 			TerminalTruncated: res.Truncated, TimeoutSeconds: timeoutSecs,
 			OmittedExchanges: res.OmittedExchanges, OmittedBytes: res.OmittedBytes,
@@ -457,12 +499,15 @@ func valueOrZero(v *int) int {
 	return 0
 }
 
-func failureReason(res waitResult) string {
+func failureReason(res waitResult, agent bool) string {
 	if res.Diagnostic != "" {
 		return res.Diagnostic
 	}
 	if res.Cause == causeRunnerDied {
-		return "agent activity was lost"
+		if agent {
+			return "agent activity was lost"
+		}
+		return "session process exited before the activity completed"
 	}
 	if res.Cause != "" {
 		return res.Cause

--- a/cli/gmux/cmd/gmux/wait_multi_test.go
+++ b/cli/gmux/cmd/gmux/wait_multi_test.go
@@ -69,6 +69,29 @@ func TestWaitMultiConcurrentAndArgvOrderedHeaders(t *testing.T) {
 	}
 }
 
+func TestWaitCommandSessionsUseNeutralReportsSingleAndMulti(t *testing.T) {
+	for _, refs := range [][]string{{"alpha"}, {"alpha", "beta"}} {
+		t.Run(strconv.Itoa(len(refs)), func(t *testing.T) {
+			sessions := waitTestSessions()
+			for i := range sessions {
+				sessions[i].Adapter = "shell"
+			}
+			d := startStubDaemon(t, sessions)
+			d.on(func(w http.ResponseWriter, _ *http.Request) {
+				writeEnvelope(w, http.StatusOK, map[string]any{"reason": "idle", "outcome": waitOutcomeCompleted})
+			})
+			var code int
+			stdout := captureStdout(t, func() { code = cmdWait(refs, 0, "", "", false) })
+			if code != 0 || strings.Count(stdout, "[Session activity completed]") != len(refs) {
+				t.Fatalf("exit=%d stdout=%q", code, stdout)
+			}
+			if strings.Contains(strings.ToLower(stdout), "agent") || strings.Contains(stdout, "[No exchanges yet]") {
+				t.Fatalf("command report uses agent/exchange language: %q", stdout)
+			}
+		})
+	}
+}
+
 func TestWaitSingleKeepsHeaderlessOutput(t *testing.T) {
 	d := startStubDaemon(t, waitTestSessions())
 	d.on(func(w http.ResponseWriter, _ *http.Request) { writeWaitOutcome(w, waitOutcomeCompleted, "done") })

--- a/cli/gmux/cmd/gmux/waitsignal.go
+++ b/cli/gmux/cmd/gmux/waitsignal.go
@@ -49,7 +49,7 @@ import (
 // The returned function uninstalls the handler; callers defer it so a
 // long-running process (the test binary) does not accumulate handlers.
 func noticeInterruptedWait(out io.Writer, quiet bool) func() {
-	stop, observed := observeInterruptedWait(out, quiet)
+	stop, observed := observeInterruptedWait(out, quiet, true)
 	return func() {
 		stop()
 		select {
@@ -66,7 +66,7 @@ func noticeInterruptedWait(out io.Writer, quiet bool) func() {
 // addition to the ordinary stop function it exposes the first observed signal
 // so the caller can suppress buffered reports while the asynchronous death
 // path is still completing (notably when SIGINT was inherited as ignored).
-func observeInterruptedWait(out io.Writer, quiet bool) (func(), <-chan os.Signal) {
+func observeInterruptedWait(out io.Writer, quiet, agent bool) (func(), <-chan os.Signal) {
 	ch := make(chan os.Signal, 2)
 	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
 	done := make(chan struct{})
@@ -78,7 +78,11 @@ func observeInterruptedWait(out io.Writer, quiet bool) (func(), <-chan os.Signal
 			noticeDone := make(chan struct{})
 			go func() {
 				if !quiet {
-					_, _ = out.Write(adapter.RenderExchangeReport(adapter.ExchangeReport{Outcome: adapter.ExchangeWaitSignal}))
+					if agent {
+						_, _ = out.Write(adapter.RenderExchangeReport(adapter.ExchangeReport{Outcome: adapter.ExchangeWaitSignal}))
+					} else {
+						_, _ = io.WriteString(out, "[Wait interrupted; session activity continues]\n")
+					}
 				}
 				close(noticeDone)
 			}()

--- a/cli/gmux/cmd/gmux/waitsignal_test.go
+++ b/cli/gmux/cmd/gmux/waitsignal_test.go
@@ -47,13 +47,33 @@ func TestWaitSignalWritesStdoutAndDiesWithShellStatus(t *testing.T) {
 	}
 }
 
+func TestCommandWaitSignalUsesNeutralLanguage(t *testing.T) {
+	oldDie := dieFromSignal
+	dieFromSignal = func(os.Signal) {}
+	t.Cleanup(func() { dieFromSignal = oldDie })
+
+	var out bytes.Buffer
+	stop, observed := observeInterruptedWait(&out, false, false)
+	p, _ := os.FindProcess(os.Getpid())
+	_ = p.Signal(syscall.SIGINT)
+	select {
+	case <-observed:
+	case <-time.After(time.Second):
+		t.Fatal("signal was not observed")
+	}
+	stop()
+	if got := out.String(); got != "[Wait interrupted; session activity continues]\n" {
+		t.Fatalf("notice=%q", got)
+	}
+}
+
 func TestWaitSignalStopJoinsNoticeWriteBeforePublishing(t *testing.T) {
 	oldDie := dieFromSignal
 	dieFromSignal = func(os.Signal) {}
 	t.Cleanup(func() { dieFromSignal = oldDie })
 
 	writer := blockingSignalWriter{started: make(chan struct{}), release: make(chan struct{})}
-	stop, observed := observeInterruptedWait(writer, false)
+	stop, observed := observeInterruptedWait(writer, false, true)
 	p, _ := os.FindProcess(os.Getpid())
 	_ = p.Signal(syscall.SIGINT)
 	select {
@@ -97,7 +117,7 @@ func TestWaitSignalSecondSignalBypassesBlockedNotice(t *testing.T) {
 	t.Cleanup(func() { dieFromSignal, exitImmediately = oldDie, oldExit })
 
 	writer := blockingSignalWriter{started: make(chan struct{}), release: make(chan struct{})}
-	stop, _ := observeInterruptedWait(writer, false)
+	stop, _ := observeInterruptedWait(writer, false, true)
 	p, _ := os.FindProcess(os.Getpid())
 	_ = p.Signal(syscall.SIGINT)
 	select {

--- a/services/gmuxd/cmd/gmuxd/exchange_wait_test.go
+++ b/services/gmuxd/cmd/gmuxd/exchange_wait_test.go
@@ -45,7 +45,7 @@ func TestObservationalPromptWaitIgnoresInstructionsUntilSourceClose(t *testing.T
 func TestRunnerLossPartialRefusesStaleExchange(t *testing.T) {
 	frame := &sessioncoord.TurnFrame{Current: &sessioncoord.TurnCurrent{TurnSeq: 9, Exchanges: []sessioncoord.TurnExchange{{Ordinal: 1, User: "repeat"}}}}
 	close := runnerLossClose(frame)
-	if close == nil || close.Output != "" || len(close.Exchanges) != 1 {
+	if close == nil || close.Output != "" || len(close.Exchanges) != 1 || close.Diagnostic != "" {
 		t.Fatalf("%+v", close)
 	}
 }

--- a/services/gmuxd/cmd/gmuxd/serve_central.go
+++ b/services/gmuxd/cmd/gmuxd/serve_central.go
@@ -1759,7 +1759,7 @@ func runnerLossClose(frame *sessioncoord.TurnFrame) *sessioncoord.TurnClose {
 	// can select an old answer), so the honest degraded report carries no partial.
 	return &sessioncoord.TurnClose{TurnSeq: cur.TurnSeq, Outcome: outcomeError, PreviousExchanges: cur.PreviousExchanges,
 		Exchanges: append([]sessioncoord.TurnExchange(nil), cur.Exchanges...), OmittedExchanges: cur.OmittedExchanges,
-		OmittedBytes: cur.OmittedBytes, Diagnostic: "agent activity was lost"}
+		OmittedBytes: cur.OmittedBytes}
 }
 
 func writeLateExchangeWait(w http.ResponseWriter, sess centralstore.Session, frame *sessioncoord.TurnFrame) {


### PR DESCRIPTION
## Summary
- render ordinary command/process wait outcomes with neutral session language
- retain exchange/agent wording for identified agent sessions
- neutralize universal runner-loss and signal notices and document the output contract

## Tests
- `go test ./cli/gmux/cmd/gmux ./packages/adapter/... ./services/gmuxd/cmd/gmuxd -run 'Wait|ExchangeReport|RunnerLoss' -count=1`\n- `go test ./cli/gmux/... ./packages/adapter/... ./services/gmuxd/...`