### PR TITLE
feat(web): add mobile Shift+Tab terminal key

### DIFF
--- a/apps/gmux-web/src/keybinds.test.ts
+++ b/apps/gmux-web/src/keybinds.test.ts
@@ -64,8 +64,9 @@ describe('keyComboToSequence', () => {
     expect(keyComboToSequence('esc')).toBe('\x1b')
   })
 
-  it('converts tab', () => {
+  it('converts tab and physical Shift+Tab to terminal sequences', () => {
     expect(keyComboToSequence('tab')).toBe('\t')
+    expect(keyComboToSequence('shift+tab')).toBe('\x1b[Z')
   })
 
   it('converts backspace', () => {

--- a/apps/gmux-web/src/keybinds.ts
+++ b/apps/gmux-web/src/keybinds.ts
@@ -218,7 +218,9 @@ export function keyComboToSequence(combo: string): string {
   } else if (baseKey === 'escape' || baseKey === 'esc') {
     seq = '\x1b'
   } else if (baseKey === 'tab') {
-    seq = '\t'
+    // xterm's canonical BackTab/Shift+Tab sequence. Do not synthesize a
+    // browser Tab event: terminal applications expect ESC [ Z as one key.
+    seq = shift && !ctrl && !alt ? '\x1b[Z' : '\t'
   } else if (baseKey === 'backspace') {
     // Ctrl+Backspace: ESC DEL (readline backward-kill-word) so it deletes a
     // word rather than a char. Plain backspace: \x7f (DEL).

--- a/apps/gmux-web/src/keyboard.test.ts
+++ b/apps/gmux-web/src/keyboard.test.ts
@@ -171,6 +171,12 @@ describe('applyArmedModifiers', () => {
     expect(applyArmedModifiers('\x1b[A', true, true).seq).toBe('\x1b[1;7A')   // ctrl+alt+up
   })
 
+  it('encodes armed modifiers on BackTab without splitting the key', () => {
+    expect(applyArmedModifiers('\x1b[Z', false, false).seq).toBe('\x1b[Z')
+    expect(applyArmedModifiers('\x1b[Z', true, false).seq).toBe('\x1b[1;5Z')
+    expect(applyArmedModifiers('\x1b[Z', false, true).seq).toBe('\x1b[1;3Z')
+  })
+
   it('encodes alt+enter as ESC CR', () => {
     expect(applyArmedModifiers('\r', false, true))
       .toEqual({ seq: '\x1b\r', ctrlApplied: false, altApplied: true })

--- a/apps/gmux-web/src/keyboard.ts
+++ b/apps/gmux-web/src/keyboard.ts
@@ -298,7 +298,7 @@ export interface ArmedModifierResult {
  *    CSI-u for uppercase), alt via ESC prefix, both combined when armed
  *    together (legacy ESC + control code; CSI-u modifier bits for
  *    uppercase).
- *  - CSI cursor keys (arrows, Home, End): modifier parameter injection,
+ *  - CSI cursor keys (arrows, Home, End, BackTab): modifier parameter injection,
  *    e.g. \x1b[D + ctrl → \x1b[1;5D (the standard word-left encoding).
  *  - Enter / Tab / Esc: alt uses the universal ESC prefix. Ctrl has no
  *    legacy encoding for these (ctrl+enter is byte-identical to enter),
@@ -319,7 +319,7 @@ export function applyArmedModifiers(
 
   // CSI cursor-key sequences: inject the modifier parameter.
   // biome-ignore lint/suspicious/noControlCharactersInRegex: matching real ESC (\x1b) in terminal control sequences
-  const csi = /^\x1b\[([A-DHF])$/.exec(data)
+  const csi = /^\x1b\[([A-DFHZ])$/.exec(data)
   if (csi) return { seq: `\x1b[1;${mod}${csi[1]}`, ctrlApplied: ctrl, altApplied: alt }
 
   // Enter / Tab / Esc with ctrl involved: CSI-u (no legacy encoding exists).

--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -456,7 +456,7 @@ const IconDown  = () => <svg viewBox="0 0 14 14" width="16" height="16" {...S}><
 const IconLeft  = () => <svg viewBox="0 0 14 14" width="16" height="16" {...S}><path d="M10 7H4m0 0 3-3M4 7l3 3"/></svg>
 const IconRight = () => <svg viewBox="0 0 14 14" width="16" height="16" {...S}><path d="M4 7h6m0 0-3-3m3 3-3 3"/></svg>
 
-const IconBackTab  = () => <svg viewBox="0 0 18 14" width="20" height="16" {...S}><line x1="14.5" y1="3" x2="14.5" y2="11"/><path d="M12 7H5m0 0 3-3M5 7l3 3"/></svg>
+const IconBackTab  = () => <svg viewBox="0 0 24 18" width="22" height="16" {...S}><path d="M5 6V2m0 0L3 4m2-2 2 2"/><line x1="10" y1="7" x2="10" y2="15"/><path d="M19 11h-6m0 0 3-3m-3 3 3 3"/></svg>
 const IconWordLeft  = () => <svg viewBox="0 0 18 14" width="20" height="16" {...S}><line x1="3.5" y1="3" x2="3.5" y2="11"/><path d="M13 7H6m0 0 3-3M6 7l3 3"/></svg>
 const IconWordRight = () => <svg viewBox="0 0 18 14" width="20" height="16" {...S}><line x1="14.5" y1="3" x2="14.5" y2="11"/><path d="M5 7h7m0 0-3-3m3 3-3 3"/></svg>
 const IconSend = () => <svg viewBox="0 0 14 14" width="16" height="16" fill="currentColor" stroke="none"><path d="M3 2.5l8 4.5-8 4.5V8.5L7.5 7 3 5.5z"/></svg>

--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -6,6 +6,7 @@ import '@xterm/xterm/css/xterm.css'
 import './styles.css'
 
 import { applyArmedModifiers } from './keyboard'
+import { keyComboToSequence } from './config'
 import { isTouchDevice } from './touch'
 import { ReplayView } from './replay-view'
 import { TerminalView } from './terminal'
@@ -548,7 +549,7 @@ function MobileTerminalBar({
 
   // The bar is a CSS grid laid out via named areas (.mk-* → grid-area), so the
   // DOM order below is only tab/reading order — the visual arrangement lives
-  // in styles.css. Narrow phones get a 7×2 grid (empty top-left corner;
+  // in styles.css. Narrow phones get a 7×2 grid (Esc sits above the hamburger;
   // scroll-end or empty top-right). Wider viewports (landscape / tablets)
   // collapse to a single row, and the widest step folds the word-jumps back
   // in. Keys never relabel; ctrl/alt only arm + highlight.
@@ -557,8 +558,9 @@ function MobileTerminalBar({
   return (
     <div class="mobile-bottom-bar" role="toolbar" aria-label="Terminal keys" onMouseDown={keepFocus}>
       <MenuButton variant="bar" onMenu={onMenu} />
-      <button class="mobile-bottom-action mk-esc" disabled={!canSend} onClick={() => sendKey('\x1b')} title="Escape"><span class="mkey-face">esc</span></button>
-      <button class="mobile-bottom-action mk-tab" disabled={!canSend} onClick={() => sendKey('\t')} title="Tab"><span class="mkey-face">tab</span></button>
+      <button class="mobile-bottom-action mk-esc" disabled={!canSend} aria-label="Escape" onClick={() => sendKey('\x1b')} title="Escape"><span class="mkey-face">esc</span></button>
+      <button class="mobile-bottom-action mk-shift-tab" disabled={!canSend} aria-label="Shift+Tab (BackTab)" onClick={() => sendKey(keyComboToSequence('shift+tab'))} title="Shift+Tab (BackTab)"><span class="mkey-face">⇧tab</span></button>
+      <button class="mobile-bottom-action mk-tab" disabled={!canSend} aria-label="Tab" onClick={() => sendKey('\t')} title="Tab"><span class="mkey-face">tab</span></button>
       <button class={`${armedClass(ctrlArmed)} mk-ctrl`} disabled={!canSend} aria-pressed={ctrlArmed} onClick={onToggleCtrl} title={ctrlArmed ? 'Ctrl armed for next key' : 'Arm Ctrl'}><span class="mkey-face">ctrl</span></button>
       <button class={`${armedClass(altArmed)} mk-alt`} disabled={!canSend} aria-pressed={altArmed} onClick={onToggleAlt} title={altArmed ? 'Alt armed for next key' : 'Arm Alt'}><span class="mkey-face">alt</span></button>
       <button class="mobile-bottom-action mk-wl" disabled={!canSend} {...repeat(() => sendWord('\x1b[D'), WORD_REPEAT_MS)} title="Word left"><span class="mkey-face"><IconWordLeft /></span></button>

--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -456,6 +456,7 @@ const IconDown  = () => <svg viewBox="0 0 14 14" width="16" height="16" {...S}><
 const IconLeft  = () => <svg viewBox="0 0 14 14" width="16" height="16" {...S}><path d="M10 7H4m0 0 3-3M4 7l3 3"/></svg>
 const IconRight = () => <svg viewBox="0 0 14 14" width="16" height="16" {...S}><path d="M4 7h6m0 0-3-3m3 3-3 3"/></svg>
 
+const IconBackTab  = () => <svg viewBox="0 0 18 14" width="20" height="16" {...S}><line x1="14.5" y1="3" x2="14.5" y2="11"/><path d="M12 7H5m0 0 3-3M5 7l3 3"/></svg>
 const IconWordLeft  = () => <svg viewBox="0 0 18 14" width="20" height="16" {...S}><line x1="3.5" y1="3" x2="3.5" y2="11"/><path d="M13 7H6m0 0 3-3M6 7l3 3"/></svg>
 const IconWordRight = () => <svg viewBox="0 0 18 14" width="20" height="16" {...S}><line x1="14.5" y1="3" x2="14.5" y2="11"/><path d="M5 7h7m0 0-3-3m3 3-3 3"/></svg>
 const IconSend = () => <svg viewBox="0 0 14 14" width="16" height="16" fill="currentColor" stroke="none"><path d="M3 2.5l8 4.5-8 4.5V8.5L7.5 7 3 5.5z"/></svg>
@@ -559,7 +560,7 @@ function MobileTerminalBar({
     <div class="mobile-bottom-bar" role="toolbar" aria-label="Terminal keys" onMouseDown={keepFocus}>
       <MenuButton variant="bar" onMenu={onMenu} />
       <button class="mobile-bottom-action mk-esc" disabled={!canSend} aria-label="Escape" onClick={() => sendKey('\x1b')} title="Escape"><span class="mkey-face">esc</span></button>
-      <button class="mobile-bottom-action mk-shift-tab" disabled={!canSend} aria-label="Shift+Tab (BackTab)" onClick={() => sendKey(keyComboToSequence('shift+tab'))} title="Shift+Tab (BackTab)"><span class="mkey-face">⇧tab</span></button>
+      <button class="mobile-bottom-action mk-shift-tab" disabled={!canSend} aria-label="Shift+Tab (BackTab)" onClick={() => sendKey(keyComboToSequence('shift+tab'))} title="Shift+Tab (BackTab)"><span class="mkey-face"><IconBackTab /></span></button>
       <button class="mobile-bottom-action mk-tab" disabled={!canSend} aria-label="Tab" onClick={() => sendKey('\t')} title="Tab"><span class="mkey-face">tab</span></button>
       <button class={`${armedClass(ctrlArmed)} mk-ctrl`} disabled={!canSend} aria-pressed={ctrlArmed} onClick={onToggleCtrl} title={ctrlArmed ? 'Ctrl armed for next key' : 'Arm Ctrl'}><span class="mkey-face">ctrl</span></button>
       <button class={`${armedClass(altArmed)} mk-alt`} disabled={!canSend} aria-pressed={altArmed} onClick={onToggleAlt} title={altArmed ? 'Alt armed for next key' : 'Arm Alt'}><span class="mkey-face">alt</span></button>

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -3211,7 +3211,7 @@ body {
     grid-template-columns: repeat(7, 1fr);
     grid-template-rows: repeat(2, 40px);
     grid-template-areas:
-      '.    esc  tab  wl  au  wr  end'
+      'esc  stab tab  wl  au  wr  end'
       'menu ctrl alt  al  ad  ar  send';
     /* One knob for spacing: the visual gap between keys. Hitboxes bridge it
        automatically (each .mkey-face extends half of it), so there are no
@@ -3229,6 +3229,7 @@ body {
      only the template (above / below) changes between layouts. */
   .mk-menu { grid-area: menu; }
   .mk-esc  { grid-area: esc; }
+  .mk-shift-tab { grid-area: stab; }
   .mk-tab  { grid-area: tab; }
   .mk-ctrl { grid-area: ctrl; }
   .mk-alt  { grid-area: alt; }
@@ -4033,9 +4034,9 @@ body {
 /* Single row, word-jumps dropped. */
 @media (pointer: coarse) and (min-width: 600px) {
   .mobile-bottom-bar {
-    grid-template-columns: repeat(10, 1fr);
+    grid-template-columns: repeat(11, 1fr);
     grid-template-rows: 40px;
-    grid-template-areas: 'menu esc tab ctrl alt al au ad ar send';
+    grid-template-areas: 'menu esc stab tab ctrl alt al au ad ar send';
   }
   /* Word-jumps aren't part of the single-row layout. */
   .mk-wl,
@@ -4062,8 +4063,8 @@ body {
 /* Wider still: fold the word-jumps back in, flanking the arrow cluster. */
 @media (pointer: coarse) and (min-width: 820px) {
   .mobile-bottom-bar {
-    grid-template-columns: repeat(12, 1fr);
-    grid-template-areas: 'menu esc tab ctrl alt wl al au ad ar wr send';
+    grid-template-columns: repeat(13, 1fr);
+    grid-template-areas: 'menu esc stab tab ctrl alt wl al au ad ar wr send';
   }
   .mk-wl,
   .mk-wr {

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -3380,15 +3380,22 @@ body {
     width: 8px;
     height: 8px;
     border-radius: 50%;
-    /* Keep the status badge attached to the menu face now that Esc sits
-       directly above it; the old overhang would collide with Esc's border. */
-    top: 4px;
-    right: 4px;
+    top: -3px;
+    right: -3px;
     z-index: 3;
     pointer-events: none;
     background: var(--unread);
     /* Ring in the page background so the dot reads cleanly against the button border */
     box-shadow: 0 0 0 1.5px var(--bg-base);
+  }
+
+  /* In the mobile keyboard, Esc now occupies the cell above the menu. Keep
+     this instance's badge inside the menu face so it does not cross that
+     key's painted hit surface. Other MenuButton placements retain the
+     established overhanging badge position above. */
+  .mobile-bottom-bar .mobile-bottom-action.menu-btn.mk-menu.bg-waiting::after {
+    top: 4px;
+    right: 4px;
   }
 
   /* Re-blink when a new session enters the waiting state */

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -3204,7 +3204,7 @@ body {
     left: 0;
     right: 0;
     bottom: 0;
-    /* Phones: 7-column × 2-row grid. The empty top-left corner and the
+    /* Phones: 7-column × 2-row grid. Esc sits above the hamburger; the
        scroll-end / empty top-right simply fall out of the template (no
        placeholder elements needed). */
     display: grid;
@@ -3218,7 +3218,15 @@ body {
        dead gaps between buttons no matter what you set this to. */
     --key-gap: 5px;
     gap: var(--key-gap);
-    padding: 0 4px calc(4px + env(safe-area-inset-bottom));
+    /* Keep the first/last controls inside landscape cutouts as well as the
+       bottom home-indicator inset. The custom properties make the mechanism
+       easy to exercise with synthetic side insets in browser tests. */
+    --mobile-safe-area-left: env(safe-area-inset-left, 0px);
+    --mobile-safe-area-right: env(safe-area-inset-right, 0px);
+    padding-top: 0;
+    padding-right: max(4px, var(--mobile-safe-area-right));
+    padding-bottom: calc(4px + env(safe-area-inset-bottom, 0px));
+    padding-left: max(4px, var(--mobile-safe-area-left));
     background: transparent;
     /* No z-index: the bar must NOT form a stacking context, so its keys'
        borders (z:1) and glyphs (z:3) can sit on either side of the
@@ -3372,8 +3380,10 @@ body {
     width: 8px;
     height: 8px;
     border-radius: 50%;
-    top: -3px;
-    right: -3px;
+    /* Keep the status badge attached to the menu face now that Esc sits
+       directly above it; the old overhang would collide with Esc's border. */
+    top: 4px;
+    right: 4px;
     z-index: 3;
     pointer-events: none;
     background: var(--unread);

--- a/e2e/tests/mobile-shift-tab.spec.ts
+++ b/e2e/tests/mobile-shift-tab.spec.ts
@@ -6,24 +6,25 @@ test.describe('mobile Shift+Tab keyboard', () => {
 
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
-      const sent: number[][] = []
+      const terminalInputs: number[][] = []
       const originalSend = WebSocket.prototype.send
       WebSocket.prototype.send = function (data: string | ArrayBufferLike | Blob | ArrayBufferView) {
-        if (typeof data === 'string') {
-          sent.push([...new TextEncoder().encode(data)])
-        } else if (data instanceof ArrayBuffer) {
-          sent.push([...new Uint8Array(data)])
+        // Terminal input is the binary WebSocket path; resize/control
+        // messages are JSON strings and are intentionally excluded here.
+        let input: number[] | undefined
+        if (data instanceof ArrayBuffer) {
+          input = [...new Uint8Array(data)]
         } else if (ArrayBuffer.isView(data)) {
-          sent.push([...new Uint8Array(data.buffer, data.byteOffset, data.byteLength)])
+          input = [...new Uint8Array(data.buffer, data.byteOffset, data.byteLength)]
         }
+        if (input) terminalInputs.push(input)
         // Keep the shared harness shell pristine: observe the real browser
-        // send call but do not inject BackTab into the fixture's shell input.
-        const bytes = sent.at(-1)
-        if (!(bytes?.length === 3 && bytes[0] === 0x1b && bytes[1] === 0x5b && bytes[2] === 0x5a)) {
+        // input send call but do not inject BackTab into the fixture shell.
+        if (!(input?.length === 3 && input[0] === 0x1b && input[1] === 0x5b && input[2] === 0x5a)) {
           originalSend.call(this, data)
         }
       }
-      ;(window as unknown as { __mobileSent: number[][] }).__mobileSent = sent
+      ;(window as unknown as { __mobileTerminalInputs: number[][] }).__mobileTerminalInputs = terminalInputs
     })
     await openApp(page)
     await gotoTestSession(page)
@@ -36,7 +37,7 @@ test.describe('mobile Shift+Tab keyboard', () => {
     await page.evaluate(() => {
       const textarea = document.querySelector('.xterm-helper-textarea') as HTMLTextAreaElement | null
       textarea?.focus()
-      ;(window as unknown as { __mobileSent: number[][] }).__mobileSent.length = 0
+      ;(window as unknown as { __mobileTerminalInputs: number[][] }).__mobileTerminalInputs.length = 0
     })
     const before = await page.evaluate(() => ({
       active: document.activeElement?.className ?? '',
@@ -53,13 +54,13 @@ test.describe('mobile Shift+Tab keyboard', () => {
     await page.waitForTimeout(100)
 
     const result = await page.evaluate(() => ({
-      sent: (window as unknown as { __mobileSent: number[][] }).__mobileSent,
+      terminalInputs: (window as unknown as { __mobileTerminalInputs: number[][] }).__mobileTerminalInputs,
       active: document.activeElement?.className ?? '',
       ctrl: document.querySelector('.mk-ctrl')?.getAttribute('aria-pressed'),
       alt: document.querySelector('.mk-alt')?.getAttribute('aria-pressed'),
       menuOpen: document.querySelector('.sidebar-overlay.visible') !== null,
     }))
-    expect(result.sent).toEqual([[0x1b, 0x5b, 0x5a]])
+    expect(result.terminalInputs).toEqual([[0x1b, 0x5b, 0x5a]])
     expect(result.active).toBe(before.active)
     expect(result.ctrl).toBe(before.ctrl)
     expect(result.alt).toBe(before.alt)
@@ -88,11 +89,12 @@ test.describe('mobile Shift+Tab keyboard', () => {
         const barRect = bar.getBoundingClientRect()
         const menu = get('.mk-menu')
         const esc = get('.mk-esc')
+        const escFace = get('.mk-esc .mkey-face')
         const stab = get('.mk-shift-tab')
         const tab = get('.mk-tab')
         const dotStyle = getComputedStyle(document.querySelector('.mk-menu')!, '::after')
         const dot = { x: menu.x + menu.width - Number.parseFloat(dotStyle.right) - Number.parseFloat(dotStyle.width), y: menu.y + Number.parseFloat(dotStyle.top), right: menu.x + menu.width - Number.parseFloat(dotStyle.right), bottom: menu.y + Number.parseFloat(dotStyle.top) + Number.parseFloat(dotStyle.height) }
-        return { bar: { x: barRect.x, right: barRect.right }, menu, esc, stab, tab, dot, words: [get('.mk-wl'), get('.mk-wr')], columns: getComputedStyle(bar).gridTemplateColumns.split(' ').length }
+        return { bar: { x: barRect.x, right: barRect.right }, menu, esc, escFace, stab, tab, dot, words: [get('.mk-wl'), get('.mk-wr')], columns: getComputedStyle(bar).gridTemplateColumns.split(' ').length }
       })
       expect(layout.bar.right).toBeLessThanOrEqual(width)
       expect(layout.bar.x).toBeGreaterThanOrEqual(0)
@@ -108,8 +110,8 @@ test.describe('mobile Shift+Tab keyboard', () => {
       expect(layout.dot.x).toBeGreaterThanOrEqual(layout.menu.x)
       expect(layout.dot.bottom).toBeLessThanOrEqual(layout.menu.bottom)
       expect(
-        layout.dot.right <= layout.esc.x || layout.dot.x >= layout.esc.right ||
-        layout.dot.bottom <= layout.esc.y || layout.dot.y >= layout.esc.bottom,
+        layout.dot.right <= layout.escFace.x || layout.dot.x >= layout.escFace.right ||
+        layout.dot.bottom <= layout.escFace.y || layout.dot.y >= layout.escFace.bottom,
       ).toBe(true)
       if (branch === 'portrait' || branch === 'small') {
         expect(layout.columns).toBe(7)
@@ -123,6 +125,29 @@ test.describe('mobile Shift+Tab keyboard', () => {
         expect(layout.words[1].display).not.toBe('none')
       }
     }
+
+    const safeAreaContract = await page.evaluate(() => {
+      const rules: CSSRule[] = []
+      const collect = (items: CSSRuleList) => {
+        for (const rule of items) {
+          rules.push(rule)
+          if ('cssRules' in rule && rule.cssRules) collect(rule.cssRules)
+        }
+      }
+      for (const sheet of document.styleSheets) {
+        try { collect(sheet.cssRules) } catch { /* cross-origin sheets are irrelevant */ }
+      }
+      const rule = rules.find(candidate => candidate instanceof CSSStyleRule && candidate.selectorText === '.mobile-bottom-bar' && candidate.style.getPropertyValue('--mobile-safe-area-left')) as CSSStyleRule | undefined
+      return {
+        left: rule?.style.getPropertyValue('--mobile-safe-area-left'),
+        right: rule?.style.getPropertyValue('--mobile-safe-area-right'),
+      }
+    })
+    // Chromium cannot synthesize env(safe-area-inset-*) values, so pin the
+    // production env-to-custom-property contract separately from the
+    // synthetic geometry test below. Removing either env declaration fails.
+    expect(safeAreaContract.left).toContain('env(safe-area-inset-left')
+    expect(safeAreaContract.right).toContain('env(safe-area-inset-right')
 
     await page.addStyleTag({ content: '.mobile-bottom-bar { --mobile-safe-area-left: 24px; --mobile-safe-area-right: 28px; }' })
     const safe = await page.evaluate(() => {

--- a/e2e/tests/mobile-shift-tab.spec.ts
+++ b/e2e/tests/mobile-shift-tab.spec.ts
@@ -1,0 +1,137 @@
+import { test, expect } from '@playwright/test'
+import { gotoTestSession, openApp } from '../helpers'
+
+test.describe('mobile Shift+Tab keyboard', () => {
+  test.use({ viewport: { width: 390, height: 844 }, isMobile: true, hasTouch: true })
+
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      const sent: number[][] = []
+      const originalSend = WebSocket.prototype.send
+      WebSocket.prototype.send = function (data: string | ArrayBufferLike | Blob | ArrayBufferView) {
+        if (typeof data === 'string') {
+          sent.push([...new TextEncoder().encode(data)])
+        } else if (data instanceof ArrayBuffer) {
+          sent.push([...new Uint8Array(data)])
+        } else if (ArrayBuffer.isView(data)) {
+          sent.push([...new Uint8Array(data.buffer, data.byteOffset, data.byteLength)])
+        }
+        // Keep the shared harness shell pristine: observe the real browser
+        // send call but do not inject BackTab into the fixture's shell input.
+        const bytes = sent.at(-1)
+        if (!(bytes?.length === 3 && bytes[0] === 0x1b && bytes[1] === 0x5b && bytes[2] === 0x5a)) {
+          originalSend.call(this, data)
+        }
+      }
+      ;(window as unknown as { __mobileSent: number[][] }).__mobileSent = sent
+    })
+    await openApp(page)
+    await gotoTestSession(page)
+  })
+
+  test('clicks BackTab once with exact raw bytes and no side effects', async ({ page }) => {
+    const backTab = page.getByRole('button', { name: 'Shift+Tab (BackTab)' })
+    await expect(backTab).toBeVisible()
+
+    await page.evaluate(() => {
+      const textarea = document.querySelector('.xterm-helper-textarea') as HTMLTextAreaElement | null
+      textarea?.focus()
+      ;(window as unknown as { __mobileSent: number[][] }).__mobileSent.length = 0
+    })
+    const before = await page.evaluate(() => ({
+      active: document.activeElement?.className ?? '',
+      ctrl: document.querySelector('.mk-ctrl')?.getAttribute('aria-pressed'),
+      alt: document.querySelector('.mk-alt')?.getAttribute('aria-pressed'),
+    }))
+
+    const box = await backTab.boundingBox()
+    expect(box).not.toBeNull()
+    await page.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2)
+    await page.mouse.down()
+    await page.waitForTimeout(700) // longer than every toolbar repeat delay
+    await page.mouse.up()
+    await page.waitForTimeout(100)
+
+    const result = await page.evaluate(() => ({
+      sent: (window as unknown as { __mobileSent: number[][] }).__mobileSent,
+      active: document.activeElement?.className ?? '',
+      ctrl: document.querySelector('.mk-ctrl')?.getAttribute('aria-pressed'),
+      alt: document.querySelector('.mk-alt')?.getAttribute('aria-pressed'),
+      menuOpen: document.querySelector('.sidebar-overlay.visible') !== null,
+    }))
+    expect(result.sent).toEqual([[0x1b, 0x5b, 0x5a]])
+    expect(result.active).toBe(before.active)
+    expect(result.ctrl).toBe(before.ctrl)
+    expect(result.alt).toBe(before.alt)
+    expect(result.menuOpen).toBe(false)
+  })
+
+  test('keeps responsive ordering, visibility, safe areas, and badge clear', async ({ page }) => {
+    for (const [width, height, branch] of [
+      [390, 844, 'portrait'],
+      [700, 390, 'medium'],
+      [844, 390, 'wide'],
+      [320, 568, 'small'],
+    ] as const) {
+      await page.setViewportSize({ width, height })
+      await page.waitForTimeout(100)
+      const layout = await page.evaluate(() => {
+        // The live shell session is not unread by default; force the existing
+        // status state so the badge-vs-Esc regression is exercised too.
+        document.querySelector('.mk-menu')?.classList.add('bg-waiting')
+        const bar = document.querySelector('.mobile-bottom-bar') as HTMLElement
+        const get = (selector: string) => {
+          const el = document.querySelector(selector) as HTMLElement
+          const r = el.getBoundingClientRect()
+          return { x: r.x, y: r.y, right: r.right, bottom: r.bottom, width: r.width, display: getComputedStyle(el).display }
+        }
+        const barRect = bar.getBoundingClientRect()
+        const menu = get('.mk-menu')
+        const esc = get('.mk-esc')
+        const stab = get('.mk-shift-tab')
+        const tab = get('.mk-tab')
+        const dotStyle = getComputedStyle(document.querySelector('.mk-menu')!, '::after')
+        const dot = { x: menu.x + menu.width - Number.parseFloat(dotStyle.right) - Number.parseFloat(dotStyle.width), y: menu.y + Number.parseFloat(dotStyle.top), right: menu.x + menu.width - Number.parseFloat(dotStyle.right), bottom: menu.y + Number.parseFloat(dotStyle.top) + Number.parseFloat(dotStyle.height) }
+        return { bar: { x: barRect.x, right: barRect.right }, menu, esc, stab, tab, dot, words: [get('.mk-wl'), get('.mk-wr')], columns: getComputedStyle(bar).gridTemplateColumns.split(' ').length }
+      })
+      expect(layout.bar.right).toBeLessThanOrEqual(width)
+      expect(layout.bar.x).toBeGreaterThanOrEqual(0)
+      if (branch === 'portrait' || branch === 'small') {
+        expect(layout.esc.x).toBe(layout.menu.x)
+        expect(layout.esc.y).toBeLessThan(layout.menu.y)
+      } else {
+        expect(layout.esc.x).toBeGreaterThan(layout.menu.x)
+        expect(layout.esc.y).toBe(layout.menu.y)
+      }
+      expect(layout.stab.x).toBeGreaterThan(layout.esc.x)
+      expect(layout.tab.x).toBeGreaterThan(layout.stab.x)
+      expect(layout.dot.x).toBeGreaterThanOrEqual(layout.menu.x)
+      expect(layout.dot.bottom).toBeLessThanOrEqual(layout.menu.bottom)
+      expect(
+        layout.dot.right <= layout.esc.x || layout.dot.x >= layout.esc.right ||
+        layout.dot.bottom <= layout.esc.y || layout.dot.y >= layout.esc.bottom,
+      ).toBe(true)
+      if (branch === 'portrait' || branch === 'small') {
+        expect(layout.columns).toBe(7)
+      } else if (branch === 'medium') {
+        expect(layout.columns).toBe(11)
+        expect(layout.words[0].display).toBe('none')
+        expect(layout.words[1].display).toBe('none')
+      } else {
+        expect(layout.columns).toBe(13)
+        expect(layout.words[0].display).not.toBe('none')
+        expect(layout.words[1].display).not.toBe('none')
+      }
+    }
+
+    await page.addStyleTag({ content: '.mobile-bottom-bar { --mobile-safe-area-left: 24px; --mobile-safe-area-right: 28px; }' })
+    const safe = await page.evaluate(() => {
+      const bar = document.querySelector('.mobile-bottom-bar')!.getBoundingClientRect()
+      const menu = document.querySelector('.mk-menu')!.getBoundingClientRect()
+      const send = document.querySelector('.mk-send')!.getBoundingClientRect()
+      return { bar: { x: bar.x, right: bar.right }, menu: { x: menu.x }, send: { right: send.right }, width: innerWidth }
+    })
+    expect(safe.menu.x).toBeGreaterThanOrEqual(24)
+    expect(safe.send.right).toBeLessThanOrEqual(safe.width - 28)
+  })
+})


### PR DESCRIPTION
## Summary
- Adds an accessible inline-SVG BackTab button to the mobile terminal keyboard.
- Places it in the former Esc slot and moves Esc above the hamburger/menu control in portrait; responsive 600–819 and >=820 layouts retain their intended ordering.
- Uses the canonical key sequence path: `keyComboToSequence('shift+tab')` emits one xterm BackTab sequence, `ESC [ Z` (`\x1b[Z`).
- Preserves existing focus/modifier semantics and single-fire behavior.
- Keeps the hamburger status dot visible and scoped: only the mobile keyboard/menu instance uses the inset badge; home/floating/footer placements retain their established overhang.
- Reserves horizontal safe-area insets in landscape.

## Focused browser regression
`e2e/tests/mobile-shift-tab.spec.ts` uses a real live terminal session and Playwright mobile context. It:
- holds and activates the accessible BackTab control;
- observes terminal-input binary WebSocket frames separately from JSON resize/control frames and asserts exactly one `[0x1b, 0x5b, 0x5a]` payload (`\x1b[Z`), while preventing fixture-shell mutation;
- proves no repeat-on-hold, menu activation, focus change, or Ctrl/Alt latch change;
- compares the unread badge against the actual `.mk-esc .mkey-face` painted rect;
- asserts portrait, 600–819, >=820, and small-phone ordering/visibility;
- asserts the production `env(safe-area-inset-left/right)` → custom-property declarations, plus synthetic 24px/28px side-inset geometry.

Mutation checks confirmed the suite fails when:
- the mobile dot is reverted to `top/right: -3px`;
- either production safe-area `env()` declaration is replaced with a literal.

## Tests
- `pnpm --filter @gmux/protocol build` ✅
- `pnpm --filter @gmux/web test` ✅ — 34 files, 711 tests
- `pnpm --filter @gmux/web lint` ✅
- `pnpm --filter @gmux/web build` ✅
- `pnpm test:e2e` ✅ — 49 tests
- Focused Playwright regression ✅ — 2 tests

## Visual evidence
- `.memory/screenshots/mobile-shift-tab-portrait.png` — 390×844.
- `.memory/screenshots/mobile-shift-tab-landscape.png` — 844×390.
- `.memory/screenshots/mobile-shift-tab-medium.png` — 700×390.
- `.memory/screenshots/mobile-shift-tab-small-phone.png` — 320×568.
- `.memory/screenshots/mobile-shift-tab-landscape-safe-area-synthetic.png` — 844×390 with synthetic 24px left/28px right insets.
- `.memory/report-mobile-shift-tab.md` documents observations and validation.
