### PR TITLE
feat(daemon): cap local gmux-mediated active semantic-agent descendants per root

### DIFF
--- a/.memory/report-active-subagent-budget.md
+++ b/.memory/report-active-subagent-budget.md
@@ -1,0 +1,125 @@
+# Active-subagent budget implementation report
+
+## Scope and product semantics
+
+This slice adds a host-local default budget for **live semantic-agent descendants per current behavioral/presentation root**. It applies to `gmux agent prompt --new` before runner creation. It deliberately does not add depth limits, historical launch budgets, prompt headers, UI/per-root overrides, peer-distributed quota, `--force`, or a launch queue.
+
+- Root ownership comes only from mutable `parent_session_id` plus `promoted_to_root`; `launched_from_session_id` remains forensic provenance and is never consulted.
+- Reparenting moves the live semantic-agent subtree immediately. Promotion makes the promoted session a root; the promoted session itself is excluded while its semantic-agent descendants use its budget. Demotion rejoins the containing root.
+- Active means an installed, non-fenced local runner generation (live/resident), not an active model turn. Dead/finished retained rows, process/shell children, the root itself, and remote projections are excluded.
+- A slot is reserved before the detached runner process, PTY, session row, unread state, or event exists. Registration atomically converts the receipt to installed liveness. Pre-start or registration failure releases the receipt; normal exit/kill releases it after the exit commit when the generation leaves the registry.
+- A launch without `GMUX_SESSION_ID` is a new root and consumes no descendant slot. An absent parent remains an orphan/new root; gmux does not infer ownership from cwd or the latest session.
+
+## Configuration contract and precedence
+
+`host.toml` has a top-level integer:
+
+```toml
+max_active_subagents = 8
+```
+
+The built-in default is 8. A value in `host.toml` overrides it when gmuxd starts. There is no environment, CLI, UI, or per-root override in this slice. Valid values are 1 through 1024; explicit zero, negatives, larger values, malformed TOML, and wrong types fail startup. The website host.toml reference documents precedence, exact counting, lifecycle, and local-daemon scope.
+
+## Mechanism trace
+
+1. `cmdAgentPromptNew` validates prompt text and launch argv first, then POSTs the actual caller parent (`GMUX_SESSION_ID`, or null) to `/v1/agent-launch-reservations`.
+2. `Coordinator.ReserveActiveSubagent` holds the lifecycle mutex shared by registration, reparent, promotion, dismissal, and budget liveness edges. Its incremental index resolves the current root and checks installed semantic descendants plus outstanding receipts.
+3. A refusal is HTTP 429 with stable code `subagent_limit_reached` and exits the CLI with 1 before spawning. Example:
+
+   ```text
+   gmux: subagent_limit_reached: subagent limit reached for root 1abc234d: 8 of 8 active subagents; run 'gmux ls' to inspect this host's sessions
+   ```
+
+4. An allowed response returns an opaque 128-bit receipt. The parent passes it only to the detached runner through `_GMXINTERNAL_ACTIVE_SUBAGENT_RESERVATION`.
+5. `runSession` captures and unsets that private variable before constructing the agent child's environment, then includes the receipt in `POST /v1/register`.
+6. `Coordinator.Register` claims the receipt before runner I/O, verifies the registered row has the exact admitted direct parent, and under its commit/install mutex consumes the receipt while installing the durable row and live index entry. All error returns release a claimed receipt. The CLI also idempotently DELETEs an unclaimed receipt after any launch return. Unclaimed receipts expire after two minutes as crash recovery (the detached startup budget is 30 seconds).
+7. Registry removal on an exit event or stream drop takes the same lifecycle mutex and removes the live budget entry. Replacement generations update one existing node; fast-dead replacement releases it.
+8. The durable startup snapshot reconstructs parent/promotion/adapter nodes before convergence. Surviving runner registrations repopulate liveness; HTTP routes are installed only after convergence/sweep completes.
+
+The index stores local nodes, child adjacency, cached roots, active counts by root, and short-lived launch receipts. Normal admission is O(1) root lookup plus at most the bounded outstanding receipt set. Ownership changes recompute only the affected subtree. A newly appearing formerly-missing parent also adopts its indexed orphan subtree. Orphans stop at the last present node. Corrupt cycles terminate deterministically at the lexicographically smallest cycle member.
+
+## Race schedules and invariants
+
+- **7/8 simultaneous admission:** 32 goroutines cross one barrier and contend on `Coordinator.mu`; exactly one gets a receipt, 31 get `ErrSubagentLimitReached`. Converting the receipt under the same mutex yields exactly 8 live descendants and zero receipt residue.
+- **8/8 simultaneous admission:** 16 barrier-released goroutines all fail; the receipt map remains empty.
+- **Admission vs reparent/promote/demote:** all serialize on `Coordinator.mu`. Receipts retain the admitted direct parent ID, so resolving their root after an ownership mutation moves them with the caller. Registration resolves the new session against the latest graph.
+- **Admission vs termination:** exit facts commit first; registry removal and active-count decrement happen together under `Coordinator.mu`. Admission sees either occupied-before-removal or free-after-removal.
+- **Registration vs dismissal:** dismissal treats a receipt whose direct parent is in the selected subtree as `ErrSubtreeBusy`; it cannot hide the parent between admission and child registration.
+- **Generation replacement:** a replacement preserves one live node; fast-dead replacement marks it non-live. Stale-generation removal cannot release a newer generation because registry generation matching gates the budget update.
+- **Daemon restart:** durable ownership is loaded first, liveness is reconstructed only from surviving local registrations, and stale exit-less rows are swept before launch routes are served.
+
+## Before/after CLI examples
+
+Below budget, output is unchanged:
+
+```console
+$ gmux agent prompt --new --no-wait 'inspect auth'
+1def567h
+```
+
+At the root limit, no ID is printed because no process/session was created:
+
+```console
+$ gmux agent prompt --new --no-wait 'inspect auth'
+gmux: subagent_limit_reached: subagent limit reached for root 1abc234d: 8 of 8 active subagents; run 'gmux ls' to inspect this host's sessions
+$ echo $?
+1
+```
+
+Independent top-level calls (no behavioral parent) create independent roots and are not rejected by another root's count.
+
+## Measurement
+
+`BenchmarkActiveSubagentAdmission1000Sessions` builds a 1,000-node chain and repeatedly reserves/releases against its deepest parent. Three local runs on linux/amd64 (Intel i7-9700K) measured:
+
+- 259.3 ns/op, 32 B/op, 1 alloc/op
+- 268.6 ns/op, 32 B/op, 1 alloc/op
+- 289.3 ns/op, 32 B/op, 1 alloc/op
+
+This demonstrates admission does not scan/rebuild the 1,000-session graph. The allocation is the cryptographic receipt token.
+
+## Test and build evidence
+
+Focused:
+
+- `go test -race ./services/gmuxd/internal/sessioncoord -run ActiveSubagent -count=3` — pass
+- deterministic root/count table: nested, promoted, reparented, dead, process, remote absence, orphan, cycle
+- registration conversion, normal termination release, registration failure release, restart reconstruction
+- real daemon reservation handler allowed/rejected/release/top-level/validation contracts
+- real CLI reservation HTTP path, structured refusal/exit 1, no spawn on rejection, receipt propagation/release
+- `go test ./services/gmuxd/internal/sessioncoord -run '^$' -bench ActiveSubagentAdmission1000 -benchmem -count=3` — results above
+
+Repository gates run locally:
+
+- `pnpm lint` — pass
+- `pnpm build` — pass
+- full Go tests for `cli/gmux`, `services/gmuxd`, and all packages — pass except the unrelated environment-sensitive `TestPiSubcommandsMatchHelp`, whose installed `pi --help` changed its Commands block; all adapter tests pass with that single probe skipped
+- `pnpm exec moon run gmuxd:check-centralstore-generated` — pass
+- `pnpm exec moon run gmuxd:check-centralstore-cross-build` — pass (linux/darwin × amd64/arm64)
+- `go test -race ./internal/sessioncoord ./internal/snapshot/central ./internal/peering ./cmd/gmuxd` from `services/gmuxd` — pass
+
+No live daemon was installed or restarted.
+
+## PR, revisions, review, and merge
+
+- Branch: `feat/active-subagent-budget`
+- Final implementation SHA: `234891de51f80f028e0a24e63ce79542c4596e67`
+- PR: [#481](https://github.com/gmuxapp/gmux/pull/481), **feat(daemon): cap local gmux-mediated active semantic-agent descendants per root**
+- Three independent read-only reviews used exact pushed SHAs and distinct angles: concurrency/state machine; ownership/config/API; adversarial integration/test quality.
+- Demonstrated findings remediated by the lead:
+  - install-time recheck after reparent/promotion prevents a receipt admitted under one root from overbooking its new root;
+  - reconcile removals and version-conditional takeover outcomes now update only committed projection changes;
+  - absent-node ownership mutations cannot subtract live descendant counts;
+  - transient pre-commit registration failures unclaim the receipt so the ordinary HTTP retry reuses it;
+  - receipt cleanup blocks behind lifecycle traffic rather than best-effort `TryLock`, while a phase-2 panic guard unlocks before re-panicking;
+  - production-handoff coverage now exercises detached receipt env transfer/unsetting, real register JSON, mounted routes, and real-store bootstrap convergence.
+- The reported ordinary `gmux -d -- pi` bypass was withdrawn because settled scope and docs explicitly target all `gmux agent prompt --new` launches, not every generic gmux command launch.
+- Delta reviewers reran their reproductions. Final verdicts were integrate; concurrency probes measured zero stranded receipts after the blocking-cleanup fix.
+- CI for final SHA: all 11 checks green, including lint/build/test, hot-package race, production container E2E, Playwright E2E, generated/cross-build, PR binaries, pi-latest compatibility, release scripts, and policy checks.
+- Merge SHA: pending merge.
+
+## Deferred follow-ups
+
+- Per-root/UI overrides on top of the existing root-keyed index and host-default interface.
+- Optional queued admission, if designed separately; this slice exposes no queueing flag.
+- Any depth policy, historical launch accounting, prompt-header signaling, peer-distributed quotas, or UI tree/list redesign requires a separate product decision and is intentionally absent.

--- a/apps/website/src/content/docs/reference/host-toml.md
+++ b/apps/website/src/content/docs/reference/host-toml.md
@@ -16,6 +16,10 @@ Daemon behavior. gmuxd reads this file once at startup. Create or edit it manual
 # Default: 8790
 port = 8790
 
+# Per behavioral root, cap live semantic-agent descendants launched by gmux.
+# Default: 8
+max_active_subagents = 8
+
 # Optional Tailscale remote access.
 # See the Remote Access guide for setup.
 [tailscale]
@@ -48,6 +52,29 @@ There is **no `[[peers]]` config**. Add a host you want to aggregate sessions fr
 | Field | Type | Default | Range | Description |
 |-------|------|---------|-------|-------------|
 | `port` | `number` | `8790` | 1–65535 | TCP port for the HTTP listener. |
+| `max_active_subagents` | `number` | `8` | 1–1024 | Maximum live semantic-agent descendants per local behavioral root for `gmux agent prompt --new`. |
+
+`max_active_subagents` is a host default read once at daemon startup. A value in
+`host.toml` overrides the built-in default; there is currently no environment,
+CLI, UI, or per-root override. The daemon is the authority only for sessions it
+owns. It does not coordinate a distributed quota with network peers.
+
+The budget follows current family ownership (`parent_session_id` and
+promotion), not immutable launch provenance. Reparenting immediately moves a
+live semantic-agent subtree to its new root's budget. Promoting a session makes
+it a root with an independent budget; demoting it rejoins its containing root.
+The root session itself is never counted. Neither are shell/process children,
+dead retained sessions, or remote projections. Independent top-level `--new`
+launches create independent roots and therefore do not consume another root's
+slots.
+
+A slot is reserved atomically before gmux creates the runner, PTY, or durable
+session row. It becomes a live slot when registration succeeds. A pre-start or
+registration failure releases the reservation; a normal exit or killed runner
+releases the live slot when that generation leaves the daemon's runtime
+registry. "Active" therefore means **live/resident semantic-agent descendant**,
+not merely an agent turn currently producing output. A refusal exits non-zero
+with the stable code `subagent_limit_reached` and suggests `gmux ls`.
 
 The bind address is not configurable here — it is the `GMUXD_LISTEN` environment variable (default `127.0.0.1`). See [Environment variables](/reference/environment/#bind-address).
 
@@ -82,6 +109,7 @@ The config file is strictly validated at startup. gmuxd refuses to start if:
 - **`allow` entries don't contain `@` and don't start with `tag:`**, likely not a valid Tailscale login name or device tag
 - **`allow` tag entries are malformed** — the name after `tag:` must start with a letter and contain only lowercase letters, digits, and hyphens
 - **`port` is out of range** (must be 1–65535)
+- **`max_active_subagents` is zero, negative, or above 1024**
 - **A session limit is negative**, or a retention/cache value is too large to convert safely to its runtime duration or byte count
 - **A TOML integer is outside the supported integer range**, or other TOML syntax is invalid
 

--- a/cli/gmux/cmd/gmux/agent.go
+++ b/cli/gmux/cmd/gmux/agent.go
@@ -417,9 +417,73 @@ func cmdAgentPrompt(ref, mode string, noWait bool, timeoutSecs int, text *string
 	return deliverPrompt(sess, mode, noWait, timeoutSecs, prompt)
 }
 
-// agentLaunchSession spawns a detached session and returns its id. A variable
-// so tests can drive `--new`'s output contract without forking a real agent.
-var agentLaunchSession = launchDetachedSession
+// agentLaunchSession spawns a detached session with the daemon-issued launch
+// receipt and returns its id. A variable keeps the real CLI/API path testable
+// without forking a real agent.
+var agentLaunchSession = launchDetachedSessionReserved
+
+var agentReserveActiveSubagent = reserveActiveSubagent
+var agentReleaseActiveSubagent = releaseActiveSubagent
+
+type agentLaunchAdmissionError struct {
+	code, message string
+}
+
+func (e *agentLaunchAdmissionError) Error() string {
+	if e.code != "" && e.message != "" {
+		return e.code + ": " + e.message
+	}
+	if e.message != "" {
+		return e.message
+	}
+	return "active-subagent launch admission failed"
+}
+
+func reserveActiveSubagent(parent string) (string, error) {
+	ensureGmuxd()
+	body, _ := json.Marshal(map[string]any{"parent_session_id": func() any {
+		if parent == "" {
+			return nil
+		}
+		return parent
+	}()})
+	resp, err := gmuxdClient().Post(gmuxdBaseURL()+"/v1/agent-launch-reservations", "application/json", strings.NewReader(string(body)))
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 300 {
+		code, message := errorCode(raw), extractMessage(raw)
+		if resp.StatusCode == http.StatusNotFound && code == "" {
+			message = "this gmuxd predates active-subagent launch admission; restart it with 'gmux daemon restart'"
+		}
+		return "", &agentLaunchAdmissionError{code: code, message: message}
+	}
+	var env struct {
+		Data struct {
+			Token string `json:"token"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(raw, &env); err != nil || env.Data.Token == "" {
+		return "", errors.New("invalid active-subagent reservation response from gmuxd")
+	}
+	return env.Data.Token, nil
+}
+
+func releaseActiveSubagent(token string) {
+	if token == "" {
+		return
+	}
+	req, err := http.NewRequest(http.MethodDelete, gmuxdBaseURL()+"/v1/agent-launch-reservations/"+token, nil)
+	if err != nil {
+		return
+	}
+	resp, err := gmuxdClient().Do(req)
+	if err == nil {
+		resp.Body.Close()
+	}
+}
 
 // agentLaunchAdapter is the adapter `--new` launches through. The launch is
 // pi-only for now (there is no --adapter flag), exactly like the rest of this
@@ -462,7 +526,13 @@ func cmdAgentPromptNew(model, name string, noWait bool, timeoutSecs int, text *s
 		fmt.Fprintln(os.Stderr, "gmux: start it yourself with 'gmux -d -- <command>' and prompt the id it prints")
 		return waitExitError
 	}
-	id, err := agentLaunchSession(argv)
+	reservation, err := agentReserveActiveSubagent(os.Getenv("GMUX_SESSION_ID"))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "gmux:", err)
+		return waitExitError
+	}
+	defer agentReleaseActiveSubagent(reservation)
+	id, err := agentLaunchSession(argv, reservation)
 	if err != nil {
 		// Nothing was registered, so there is no id to hand back: the caller
 		// paid for nothing and has nothing to clean up.
@@ -872,8 +942,12 @@ intentionally interrupted, and 1 means failure or timeout.
 
 With synchronous --new, the bare session id is printed on stderr the moment the
 session exists and stdout is the report alone. With --new --no-wait, stdout is
-the bare id only. Semantic reads and delivery hide runner residency: an inactive
-conversation is resumed automatically when prompted.
+the bare id only. Before creating a runner, --new reserves one live semantic-
+agent descendant slot against the caller's current behavioral root. The host
+default is max_active_subagents = 8; promoted roots and independent top-level
+launches have independent budgets. 'gmux ls' shows the sessions to inspect when
+the daemon refuses a launch. Semantic reads and delivery hide runner residency:
+an inactive conversation is resumed automatically when prompted.
 `)
 	case "agent cancel":
 		fmt.Fprint(w, `gmux agent cancel — interrupt active agent work

--- a/cli/gmux/cmd/gmux/agent_launch_exchange_test.go
+++ b/cli/gmux/cmd/gmux/agent_launch_exchange_test.go
@@ -2,18 +2,186 @@ package main
 
 import (
 	"errors"
+	"fmt"
+	"io"
 	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 )
+
+func TestReservedDetachedLaunchHelper(t *testing.T) {
+	if os.Getenv("GMUX_TEST_RESERVED_LAUNCH_HELPER") != "1" {
+		return
+	}
+	control := os.NewFile(3, "control")
+	gate := os.NewFile(4, "gate")
+	hold := os.NewFile(5, "hold")
+	if control == nil || gate == nil || hold == nil {
+		os.Exit(90)
+	}
+	if err := os.WriteFile(os.Getenv("GMUX_TEST_RESERVED_LAUNCH_TOKEN_FILE"), []byte(os.Getenv(activeSubagentReservationEnv)), 0o600); err != nil {
+		os.Exit(91)
+	}
+	_, _ = fmt.Fprintf(control, "TARGET %d\n1va8lvdv\n", os.Getpid())
+	_ = control.Close()
+	var token [1]byte
+	if _, err := io.ReadFull(gate, token[:]); err != nil || token[0] != 'G' {
+		os.Exit(92)
+	}
+	_, _ = io.Copy(io.Discard, hold)
+	_ = gate.Close()
+	_ = hold.Close()
+	os.Exit(0)
+}
+
+func TestLaunchDetachedSessionReservedCarriesReceiptBeforeProcessStart(t *testing.T) {
+	old := detachedLaunchCommand
+	t.Cleanup(func() { detachedLaunchCommand = old })
+	t.Setenv("GMUX_TEST_RESERVED_LAUNCH_HELPER", "1")
+	tokenFile := filepath.Join(t.TempDir(), "token")
+	t.Setenv("GMUX_TEST_RESERVED_LAUNCH_TOKEN_FILE", tokenFile)
+	detachedLaunchCommand = func([]string) (*exec.Cmd, *os.File, error) {
+		devNull, err := os.Open(os.DevNull)
+		if err != nil {
+			return nil, nil, err
+		}
+		cmd := exec.Command(os.Args[0], "-test.run=^TestReservedDetachedLaunchHelper$")
+		cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+		cmd.Stdin, cmd.Stdout, cmd.Stderr = devNull, devNull, devNull
+		return cmd, devNull, nil
+	}
+	id, err := launchDetachedSessionReserved([]string{"pi"}, "receipt-123")
+	if err != nil || id != "1va8lvdv" {
+		t.Fatalf("id=%q err=%v", id, err)
+	}
+	raw, err := os.ReadFile(tokenFile)
+	if err != nil || string(raw) != "receipt-123" {
+		t.Fatalf("token=%q err=%v", raw, err)
+	}
+}
+
+func TestTakeActiveSubagentReservationDoesNotLeakToAgentEnvironment(t *testing.T) {
+	t.Setenv(activeSubagentReservationEnv, "receipt")
+	if got := takeActiveSubagentReservation(os.Getenv, os.Unsetenv); got != "receipt" {
+		t.Fatalf("token=%q", got)
+	}
+	if _, present := os.LookupEnv(activeSubagentReservationEnv); present {
+		t.Fatal("receipt remained in process environment")
+	}
+}
 
 func stubAgentLaunch(t *testing.T, id string, err error) *[]string {
 	t.Helper()
 	var got []string
-	old := agentLaunchSession
-	agentLaunchSession = func(argv []string) (string, error) { got = argv; return id, err }
-	t.Cleanup(func() { agentLaunchSession = old })
+	oldLaunch, oldReserve, oldRelease := agentLaunchSession, agentReserveActiveSubagent, agentReleaseActiveSubagent
+	agentReserveActiveSubagent = func(string) (string, error) { return "receipt", nil }
+	agentReleaseActiveSubagent = func(string) {}
+	agentLaunchSession = func(argv []string, token string) (string, error) {
+		if token != "receipt" {
+			t.Fatalf("reservation = %q", token)
+		}
+		got = argv
+		return id, err
+	}
+	t.Cleanup(func() {
+		agentLaunchSession, agentReserveActiveSubagent, agentReleaseActiveSubagent = oldLaunch, oldReserve, oldRelease
+	})
 	return &got
+}
+
+func TestAgentPromptNewAdmissionAPIAndExitCode(t *testing.T) {
+	t.Run("structured limit rejection happens before spawn", func(t *testing.T) {
+		d := startStubDaemon(t, nil)
+		d.on(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/v1/agent-launch-reservations" {
+				t.Fatalf("path = %s", r.URL.Path)
+			}
+			writeErrEnvelope(w, http.StatusTooManyRequests, "subagent_limit_reached", "subagent limit reached for root root: 8 of 8 active subagents; run 'gmux ls' to inspect this host's sessions")
+		})
+		oldLaunch, oldReserve, oldRelease := agentLaunchSession, agentReserveActiveSubagent, agentReleaseActiveSubagent
+		agentReserveActiveSubagent, agentReleaseActiveSubagent = reserveActiveSubagent, releaseActiveSubagent
+		launched := false
+		agentLaunchSession = func([]string, string) (string, error) { launched = true; return "", nil }
+		t.Cleanup(func() {
+			agentLaunchSession, agentReserveActiveSubagent, agentReleaseActiveSubagent = oldLaunch, oldReserve, oldRelease
+		})
+		t.Setenv("GMUX_SESSION_ID", "root")
+		text := "go"
+		var code int
+		stderr := captureStderr(t, func() { code = cmdAgentPromptNew("", "", true, 0, &text) })
+		if code != waitExitError || launched {
+			t.Fatalf("exit=%d launched=%v", code, launched)
+		}
+		if !strings.Contains(stderr, "subagent_limit_reached: subagent limit reached for root root: 8 of 8 active subagents") || !strings.Contains(stderr, "gmux ls") {
+			t.Fatalf("stderr = %q", stderr)
+		}
+	})
+
+	t.Run("allowed receipt reaches launch and is released", func(t *testing.T) {
+		d := startStubDaemon(t, nil)
+		deleted := false
+		d.on(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.Method == http.MethodPost && r.URL.Path == "/v1/agent-launch-reservations":
+				writeEnvelope(w, http.StatusOK, map[string]any{"token": "receipt", "limit": 8})
+			case r.Method == http.MethodDelete && r.URL.Path == "/v1/agent-launch-reservations/receipt":
+				deleted = true
+				w.WriteHeader(http.StatusNoContent)
+			case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/prompt"):
+				writeEnvelope(w, http.StatusAccepted, map[string]any{"admission": "accepted"})
+			default:
+				t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+			}
+		})
+		oldLaunch, oldReserve, oldRelease := agentLaunchSession, agentReserveActiveSubagent, agentReleaseActiveSubagent
+		agentReserveActiveSubagent, agentReleaseActiveSubagent = reserveActiveSubagent, releaseActiveSubagent
+		gotToken := ""
+		agentLaunchSession = func(_ []string, token string) (string, error) { gotToken = token; return "1va8lvdv", nil }
+		t.Cleanup(func() {
+			agentLaunchSession, agentReserveActiveSubagent, agentReleaseActiveSubagent = oldLaunch, oldReserve, oldRelease
+		})
+		text := "go"
+		var code int
+		captureStdout(t, func() { code = cmdAgentPromptNew("", "", true, 0, &text) })
+		if code != 0 || gotToken != "receipt" || !deleted {
+			t.Fatalf("exit=%d token=%q deleted=%v", code, gotToken, deleted)
+		}
+	})
+}
+
+func TestAgentPromptNewLaunchFailureReleasesReservation(t *testing.T) {
+	oldLaunch, oldReserve, oldRelease := agentLaunchSession, agentReserveActiveSubagent, agentReleaseActiveSubagent
+	agentReserveActiveSubagent = func(string) (string, error) { return "receipt", nil }
+	agentLaunchSession = func([]string, string) (string, error) { return "", errors.New("startup failed") }
+	released := ""
+	agentReleaseActiveSubagent = func(token string) { released = token }
+	t.Cleanup(func() {
+		agentLaunchSession, agentReserveActiveSubagent, agentReleaseActiveSubagent = oldLaunch, oldReserve, oldRelease
+	})
+	text := "go"
+	var code int
+	captureStderr(t, func() { code = cmdAgentPromptNew("", "", false, 0, &text) })
+	if code != waitExitError || released != "receipt" {
+		t.Fatalf("exit=%d released=%q", code, released)
+	}
+}
+
+func TestAgentPromptHelpDocumentsActiveSubagentBudget(t *testing.T) {
+	var out strings.Builder
+	printAgentUsage(&out, "agent prompt")
+	text := out.String()
+	for _, want := range []string{"max_active_subagents = 8", "behavioral root", "gmux ls"} {
+		if !strings.Contains(text, want) {
+			t.Errorf("help missing %q:\n%s", want, text)
+		}
+	}
+	if strings.Contains(text, "--wait-for-slot") {
+		t.Fatal("help advertises unimplemented --wait-for-slot")
+	}
 }
 
 func TestAgentPromptNewOutputAndOrphanContracts(t *testing.T) {

--- a/cli/gmux/cmd/gmux/daemon.go
+++ b/cli/gmux/cmd/gmux/daemon.go
@@ -344,12 +344,12 @@ func (o registerOutcome) ok() bool { return o == registerOK }
 // without burning the retry budget. Callers that care about the
 // outcome (the detached (-d) handshake, the orphan-reap path) branch
 // on the returned registerOutcome.
-func registerWithGmuxd(ctx context.Context, sessionID, socketPath string) registerOutcome {
-	return registerWithClient(ctx, gmuxdClient(), sessionID, socketPath, 500*time.Millisecond)
+func registerWithGmuxd(ctx context.Context, sessionID, socketPath, activeSubagentReservation string) registerOutcome {
+	return registerWithClient(ctx, gmuxdClient(), sessionID, socketPath, activeSubagentReservation, 500*time.Millisecond)
 }
 
-func registerWithClient(ctx context.Context, client *http.Client, sessionID, socketPath string, backoff time.Duration) registerOutcome {
-	payload, _ := json.Marshal(map[string]string{"session_id": sessionID, "socket_path": socketPath})
+func registerWithClient(ctx context.Context, client *http.Client, sessionID, socketPath, activeSubagentReservation string, backoff time.Duration) registerOutcome {
+	payload, _ := json.Marshal(map[string]string{"session_id": sessionID, "socket_path": socketPath, "active_subagent_reservation": activeSubagentReservation})
 	for {
 		req, err := http.NewRequestWithContext(ctx, http.MethodPost, gmuxdBaseURL()+"/v1/register", bytes.NewReader(payload))
 		if err != nil {

--- a/cli/gmux/cmd/gmux/register_test.go
+++ b/cli/gmux/cmd/gmux/register_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"net"
 	"net/http"
 	"os"
@@ -64,11 +65,29 @@ func TestRegisterWithGmuxdOutcomes(t *testing.T) {
 			startStubGmuxd(t, tc.status)
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
 			defer cancel()
-			got := registerWithGmuxd(ctx, "1c54cqk8", "/tmp/whatever.sock")
+			got := registerWithGmuxd(ctx, "1c54cqk8", "/tmp/whatever.sock", "")
 			if got != tc.want {
 				t.Errorf("registerWithGmuxd outcome = %d, want %d", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestRegisterWithGmuxdCarriesActiveSubagentReceipt(t *testing.T) {
+	d := startStubDaemon(t, nil)
+	d.on(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) })
+	if got := registerWithGmuxd(context.Background(), "1c54cqk8", "/tmp/whatever.sock", "receipt-123"); got != registerOK {
+		t.Fatalf("outcome = %v", got)
+	}
+	request := d.lastRequest(t)
+	var body struct {
+		Token string `json:"active_subagent_reservation"`
+	}
+	if err := json.Unmarshal([]byte(request.body), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body.Token != "receipt-123" {
+		t.Fatalf("receipt = %q", body.Token)
 	}
 }
 

--- a/cli/gmux/cmd/gmux/registration_budget_test.go
+++ b/cli/gmux/cmd/gmux/registration_budget_test.go
@@ -39,7 +39,7 @@ func TestRegistrationRetriesWithinDeadlineAndClassifiesStatuses(t *testing.T) {
 	})}
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	if got := registerWithClient(ctx, client, "s", "/tmp/s", time.Millisecond); got != registerOK {
+	if got := registerWithClient(ctx, client, "s", "/tmp/s", "", time.Millisecond); got != registerOK {
 		t.Fatalf("outcome %v", got)
 	}
 	if calls != 3 {
@@ -49,7 +49,7 @@ func TestRegistrationRetriesWithinDeadlineAndClassifiesStatuses(t *testing.T) {
 	for _, status := range []int{http.StatusBadRequest, http.StatusUnauthorized, http.StatusFound, http.StatusNoContent} {
 		calls = 0
 		client.Transport = roundTripFunc(func(*http.Request) (*http.Response, error) { calls++; return response(status), nil })
-		if got := registerWithClient(ctx, client, "s", "/tmp/s", time.Millisecond); got != registerFatal {
+		if got := registerWithClient(ctx, client, "s", "/tmp/s", "", time.Millisecond); got != registerFatal {
 			t.Errorf("status %d = %v", status, got)
 		}
 		if calls != 1 {
@@ -68,7 +68,7 @@ func TestRegistrationCancellationReachesRequestAndBackoff(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
 	defer cancel()
 	start := time.Now()
-	if got := registerWithClient(ctx, client, "s", "/tmp/s", time.Second); got != registerUnavailable {
+	if got := registerWithClient(ctx, client, "s", "/tmp/s", "", time.Second); got != registerUnavailable {
 		t.Fatalf("outcome %v", got)
 	}
 	select {
@@ -84,7 +84,7 @@ func TestRegistrationCancellationReachesRequestAndBackoff(t *testing.T) {
 	ctx2, cancel2 := context.WithTimeout(context.Background(), 25*time.Millisecond)
 	defer cancel2()
 	start = time.Now()
-	registerWithClient(ctx2, client, "s", "/tmp/s", time.Second)
+	registerWithClient(ctx2, client, "s", "/tmp/s", "", time.Second)
 	if time.Since(start) > 250*time.Millisecond {
 		t.Fatal("backoff ignored cancellation")
 	}
@@ -312,7 +312,7 @@ func TestForegroundRegistrationCompletesQuicklyWhenDaemonUnavailable(t *testing.
 	ctx, cancel := context.WithTimeout(context.Background(), foregroundRegistrationBudget)
 	defer cancel()
 	start := time.Now()
-	got := registerWithGmuxd(ctx, "18gbpniy", "/tmp/fg-budget-test.sock")
+	got := registerWithGmuxd(ctx, "18gbpniy", "/tmp/fg-budget-test.sock", "")
 	elapsed := time.Since(start)
 
 	if got != registerUnavailable {

--- a/cli/gmux/cmd/gmux/run.go
+++ b/cli/gmux/cmd/gmux/run.go
@@ -35,6 +35,12 @@ import (
 // consume the same clock.
 const detachedStartupBudget = 30 * time.Second
 
+// activeSubagentReservationEnv is private launch provenance carried only from
+// the parent CLI to its runner registration. runSession removes it before the
+// agent process environment is built, so the opaque receipt never reaches the
+// launched model/tool process.
+const activeSubagentReservationEnv = "_GMXINTERNAL_ACTIVE_SUBAGENT_RESERVATION"
+
 // foregroundRegistrationBudget is the best-effort registration window for
 // foreground and nested-gmux launches. These runners are not gate-blocked:
 // the user's command is already running and the local terminal is attached.
@@ -188,8 +194,15 @@ func inheritLaunchParent(dir runDirectives, getenv func(string) string) runDirec
 	return dir
 }
 
+func takeActiveSubagentReservation(getenv func(string) string, unsetenv func(string) error) string {
+	token := getenv(activeSubagentReservationEnv)
+	_ = unsetenv(activeSubagentReservationEnv)
+	return token
+}
+
 func runSession(args []string, attach bool, dir runDirectives) {
 	dir = inheritLaunchParent(dir, os.Getenv)
+	activeSubagentReservation := takeActiveSubagentReservation(os.Getenv, os.Unsetenv)
 
 	// Resolve the adapter up front so we can short-circuit one-shot, non-session
 	// invocations (e.g. `pi update`, `pi list`) before any session machinery.
@@ -580,7 +593,7 @@ func runSession(args []string, attach bool, dir runDirectives) {
 	regDone := make(chan struct{})
 	go func() {
 		defer close(regDone)
-		outcome := registerWithGmuxd(registrationCtx, sessionID, sockPath)
+		outcome := registerWithGmuxd(registrationCtx, sessionID, sockPath, activeSubagentReservation)
 		_ = os.Remove(pendingPath)
 		if outcome == registerIDConflict && !handshakeOwned {
 			log.Printf("gmux: registration refused for %s: session id already exists; child continues unregistered", sessionID)
@@ -932,7 +945,15 @@ func detachedCommand(args []string) (*exec.Cmd, *os.File, error) {
 // never printed and never fatal: callers other than `gmux -d` — notably
 // `gmux agent prompt --new` — need to report it in their own voice.
 func launchDetachedSession(args []string) (string, error) {
-	cmd, devNull, err := detachedCommand(args)
+	return launchDetachedSessionReserved(args, "")
+}
+
+// detachedLaunchCommand is the process-construction seam for the handshake
+// integration test. Production always points at detachedCommand.
+var detachedLaunchCommand = detachedCommand
+
+func launchDetachedSessionReserved(args []string, activeSubagentReservation string) (string, error) {
+	cmd, devNull, err := detachedLaunchCommand(args)
 	if err != nil {
 		return "", err
 	}
@@ -959,6 +980,9 @@ func launchDetachedSession(args []string) (string, error) {
 		handshakeHoldFDEnv+"=5",
 		handshakeDeadlineEnv+"="+fmt.Sprint(deadline.UnixNano()),
 	)
+	if activeSubagentReservation != "" {
+		cmd.Env = append(cmd.Env, activeSubagentReservationEnv+"="+activeSubagentReservation)
+	}
 
 	if err := cmd.Start(); err != nil {
 		return "", fmt.Errorf("failed to start background session: %v", err)

--- a/services/gmuxd/cmd/gmuxd/active_subagent_routes.go
+++ b/services/gmuxd/cmd/gmuxd/active_subagent_routes.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/centralstore"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/sessioncoord"
+)
+
+const (
+	codeSubagentLimitReached       = "subagent_limit_reached"
+	codeInvalidSubagentReservation = "invalid_subagent_reservation"
+)
+
+func registerActiveSubagentRoutes(mux *http.ServeMux, coord *sessioncoord.Coordinator) {
+	mux.HandleFunc("POST /v1/agent-launch-reservations", func(w http.ResponseWriter, r *http.Request) {
+		handleActiveSubagentReservation(w, r, coord)
+	})
+	mux.HandleFunc("DELETE /v1/agent-launch-reservations/{token}", func(w http.ResponseWriter, r *http.Request) {
+		handleActiveSubagentReservationRelease(w, r, coord, r.PathValue("token"))
+	})
+}
+
+func handleActiveSubagentReservation(w http.ResponseWriter, r *http.Request, coord *sessioncoord.Coordinator) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "bad_request", "method not allowed")
+		return
+	}
+	body, err := io.ReadAll(io.LimitReader(r.Body, 4097))
+	if err != nil || len(body) > 4096 {
+		writeError(w, http.StatusBadRequest, "bad_request", "invalid request body")
+		return
+	}
+	var wire struct {
+		ParentSessionID *string `json:"parent_session_id"`
+	}
+	dec := json.NewDecoder(bytes.NewReader(body))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&wire); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", "invalid JSON")
+		return
+	}
+	if err := dec.Decode(&struct{}{}); err != io.EOF {
+		writeError(w, http.StatusBadRequest, "bad_request", "invalid JSON")
+		return
+	}
+	var parent *centralstore.SessionID
+	if wire.ParentSessionID != nil {
+		if *wire.ParentSessionID == "" {
+			writeError(w, http.StatusBadRequest, "bad_request", "parent_session_id must be a session id or null")
+			return
+		}
+		id := centralstore.SessionID(*wire.ParentSessionID)
+		parent = &id
+	}
+	reservation, err := coord.ReserveActiveSubagent(r.Context(), parent)
+	if err != nil {
+		var limit *sessioncoord.SubagentLimitError
+		if errors.As(err, &limit) {
+			message := fmt.Sprintf("subagent limit reached for root %s: %d of %d active subagents; run 'gmux ls' to inspect this host's sessions", limit.Root, limit.Active, limit.Limit)
+			writeError(w, http.StatusTooManyRequests, codeSubagentLimitReached, message)
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "internal", err.Error())
+		return
+	}
+	writeJSON(w, map[string]any{"ok": true, "data": map[string]any{
+		"token": reservation.Token, "root_session_id": reservation.Root,
+		"active": reservation.Active, "limit": reservation.Limit,
+		"expires_at": reservation.ExpiresAt.UTC().Format(time.RFC3339Nano),
+	}})
+}
+
+func handleActiveSubagentReservationRelease(w http.ResponseWriter, r *http.Request, coord *sessioncoord.Coordinator, token string) {
+	if r.Method != http.MethodDelete {
+		writeError(w, http.StatusMethodNotAllowed, "bad_request", "method not allowed")
+		return
+	}
+	if token == "" {
+		writeError(w, http.StatusBadRequest, "bad_request", "reservation token required")
+		return
+	}
+	coord.ReleaseActiveSubagentReservation(token)
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/services/gmuxd/cmd/gmuxd/active_subagent_routes_test.go
+++ b/services/gmuxd/cmd/gmuxd/active_subagent_routes_test.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/centralstore"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/sessioncoord"
+)
+
+func routeBudgetCoordinator(limit int, rows []centralstore.Session) *sessioncoord.Coordinator {
+	return sessioncoord.New(nil, nil, nil, nil, nil,
+		sessioncoord.WithActiveSubagentBudget(limit, func(adapter string) bool { return adapter == "pi" }, rows))
+}
+
+func TestActiveSubagentReservationAPIAllowedAndRejected(t *testing.T) {
+	root := centralstore.SessionID("root")
+	coord := routeBudgetCoordinator(1, []centralstore.Session{{ID: root, Adapter: "shell"}})
+
+	request := func() *httptest.ResponseRecorder {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/v1/agent-launch-reservations", strings.NewReader(`{"parent_session_id":"root"}`))
+		handleActiveSubagentReservation(rec, req, coord)
+		return rec
+	}
+	allowed := request()
+	if allowed.Code != http.StatusOK {
+		t.Fatalf("allowed status=%d body=%s", allowed.Code, allowed.Body.String())
+	}
+	var receipt struct {
+		Data struct {
+			Token  string `json:"token"`
+			Root   string `json:"root_session_id"`
+			Active int    `json:"active"`
+			Limit  int    `json:"limit"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(allowed.Body.Bytes(), &receipt); err != nil {
+		t.Fatal(err)
+	}
+	if receipt.Data.Token == "" || receipt.Data.Root != "root" || receipt.Data.Active != 0 || receipt.Data.Limit != 1 {
+		t.Fatalf("receipt = %+v", receipt.Data)
+	}
+
+	rejected := request()
+	if rejected.Code != http.StatusTooManyRequests {
+		t.Fatalf("rejected status=%d body=%s", rejected.Code, rejected.Body.String())
+	}
+	var envelope struct {
+		Error struct{ Code, Message string } `json:"error"`
+	}
+	if err := json.Unmarshal(rejected.Body.Bytes(), &envelope); err != nil {
+		t.Fatal(err)
+	}
+	if envelope.Error.Code != codeSubagentLimitReached || !strings.Contains(envelope.Error.Message, "subagent limit reached for root root: 1 of 1 active subagents") || !strings.Contains(envelope.Error.Message, "gmux ls") {
+		t.Fatalf("error = %+v", envelope.Error)
+	}
+
+	release := httptest.NewRecorder()
+	handleActiveSubagentReservationRelease(release, httptest.NewRequest(http.MethodDelete, "/", nil), coord, receipt.Data.Token)
+	if release.Code != http.StatusNoContent {
+		t.Fatalf("release status=%d", release.Code)
+	}
+	if again := request(); again.Code != http.StatusOK {
+		t.Fatalf("slot not released: %d %s", again.Code, again.Body.String())
+	}
+}
+
+func TestActiveSubagentReservationMountedProductionMux(t *testing.T) {
+	coord := routeBudgetCoordinator(1, []centralstore.Session{{ID: "root", Adapter: "shell"}})
+	mux := http.NewServeMux()
+	registerActiveSubagentRoutes(mux, coord)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	resp, err := http.Post(server.URL+"/v1/agent-launch-reservations", "application/json", strings.NewReader(`{"parent_session_id":"root"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+}
+
+func TestActiveSubagentReservationAPITopLevelRootsAreIndependent(t *testing.T) {
+	coord := routeBudgetCoordinator(1, nil)
+	for i := 0; i < 20; i++ {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/v1/agent-launch-reservations", strings.NewReader(`{"parent_session_id":null}`))
+		handleActiveSubagentReservation(rec, req, coord)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("top-level launch %d status=%d body=%s", i, rec.Code, rec.Body.String())
+		}
+	}
+}
+
+func TestActiveSubagentReservationAPIStructuredValidation(t *testing.T) {
+	coord := routeBudgetCoordinator(8, nil)
+	for _, body := range []string{`{}`, `{"parent_session_id":""}`, `{"parent_session_id":3}`, `{"parent_session_id":null,"extra":true}`, `{`} {
+		rec := httptest.NewRecorder()
+		handleActiveSubagentReservation(rec, httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body)), coord)
+		if body == `{}` {
+			// Omitted and explicit null both mean no trustworthy behavioral
+			// parent, preserving the existing top-level launch semantics.
+			if rec.Code != http.StatusOK {
+				t.Fatalf("body=%s status=%d", body, rec.Code)
+			}
+			continue
+		}
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("body=%s status=%d response=%s", body, rec.Code, rec.Body.String())
+		}
+	}
+}

--- a/services/gmuxd/cmd/gmuxd/bootstrap.go
+++ b/services/gmuxd/cmd/gmuxd/bootstrap.go
@@ -148,6 +148,8 @@ type BootstrapConfig struct {
 	Notices                        func(context.Context, string)
 	Frames                         func(context.Context, wire.Frames)
 	Clock                          func() centralstore.UnixMillis
+	MaxActiveSubagents             int
+	SemanticAgent                  func(string) bool
 	RunnerBudget, ConvergeDeadline time.Duration
 	RetryInitial, RetryMaximum     time.Duration
 }
@@ -199,6 +201,13 @@ func newBootstrap(cfg BootstrapConfig) (*Bootstrap, error) {
 	registry := sessioncoord.NewRegistry()
 	bridge := &composerDirtyBridge{}
 	opts := []sessioncoord.Option{sessioncoord.WithClock(cfg.Clock), sessioncoord.WithRunnerControl(cfg.Control), sessioncoord.WithRunnerSpawner(cfg.Spawner), sessioncoord.WithConversationTakeover(cfg.Resolver), sessioncoord.WithAdapterReconciler(cfg.Reconciler)}
+	if cfg.MaxActiveSubagents > 0 {
+		rows, err := cfg.Store.ListSessions(context.Background())
+		if err != nil {
+			return nil, fmt.Errorf("bootstrap: initialize active-subagent ownership: %w", err)
+		}
+		opts = append(opts, sessioncoord.WithActiveSubagentBudget(cfg.MaxActiveSubagents, cfg.SemanticAgent, rows))
+	}
 	if cfg.LocalPeers != nil {
 		opts = append(opts, sessioncoord.WithLocalPeerMatchInputs(cfg.LocalPeers))
 	}

--- a/services/gmuxd/cmd/gmuxd/bootstrap_test.go
+++ b/services/gmuxd/cmd/gmuxd/bootstrap_test.go
@@ -86,6 +86,40 @@ func (r *bootstrapCountingResolver) DescribeConversation(context.Context, string
 // The takeover-I/O assertions are the original point of this test and still
 // hold: a rejected registration must not read the session list or resolve
 // conversations.
+func TestBootstrapReconstructsActiveSubagentBudgetAfterConvergence(t *testing.T) {
+	ctx := context.Background()
+	store, err := centralstore.Open(ctx, t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	root := centralstore.SessionID("root0000")
+	child := centralstore.SessionID("child000")
+	if _, _, err := store.InsertSession(ctx, centralstore.NewSession{ID: root, Adapter: "shell", CWD: "/", CreatedAt: 1}); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := store.InsertSession(ctx, centralstore.NewSession{ID: child, Adapter: "pi", CWD: "/", CreatedAt: 2, ParentSessionID: &root}); err != nil {
+		t.Fatal(err)
+	}
+	meta := sessioncoord.RunnerMeta{Registration: centralstore.RunnerRegistration{ID: child, Adapter: "pi", Alive: true, CreatedAt: 2, ObservedAt: 3, ParentSessionID: &root}, Incarnation: "restart-child"}
+	runners := &bootstrapRunners{metas: map[string]sessioncoord.RunnerMeta{"child.sock": meta}, blocked: map[string]bool{}}
+	boot, err := newBootstrap(BootstrapConfig{
+		Store: store, Runners: runners, Converter: &wire.Converter{},
+		Endpoints:          EndpointSourceFunc(func(context.Context) ([]string, error) { return []string{"child.sock"}, nil }),
+		MaxActiveSubagents: 1, SemanticAgent: func(adapter string) bool { return adapter == "pi" },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer boot.Close()
+	if _, err := boot.Converge(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := boot.Coordinator.ReserveActiveSubagent(ctx, &root); !errors.Is(err, sessioncoord.ErrSubagentLimitReached) {
+		t.Fatalf("post-convergence admission = %v, want limit", err)
+	}
+}
+
 func TestPeriodicScansRejectBeforeConversationTakeoverIO(t *testing.T) {
 	ctx := context.Background()
 	store, err := centralstore.Open(ctx, t.TempDir())

--- a/services/gmuxd/cmd/gmuxd/serve_central.go
+++ b/services/gmuxd/cmd/gmuxd/serve_central.go
@@ -270,7 +270,7 @@ func serveCentral(stderr io.Writer, replace bool) int {
 		return discovery.ResolveResumeCommandFor(legacy.Adapter, legacy.ConversationRef)
 	}}
 
-	boot, err = newBootstrap(BootstrapConfig{Store: storeHandle, Runners: productionRunnerClient{}, Control: productionRunnerControl{}, Spawner: spawner, Resolver: productionConversationResolver{}, Reconciler: productionAdapterReconciler{}, LocalPeers: peerAdapter.LocalPeerMatchInputs, Peers: peerAdapter, PeerSessions: peerAdapter, Converter: converter, Endpoints: productionEndpointSource{}, Errors: sessioncoord.ErrorSinkFunc(func(_ context.Context, err error) { log.Printf("gmuxd: %v", err) }), Frames: func(_ context.Context, frames wire.Frames) {
+	boot, err = newBootstrap(BootstrapConfig{Store: storeHandle, Runners: productionRunnerClient{}, Control: productionRunnerControl{}, Spawner: spawner, Resolver: productionConversationResolver{}, Reconciler: productionAdapterReconciler{}, LocalPeers: peerAdapter.LocalPeerMatchInputs, Peers: peerAdapter, PeerSessions: peerAdapter, Converter: converter, Endpoints: productionEndpointSource{}, MaxActiveSubagents: cfg.MaxActiveSubagents, SemanticAgent: func(name string) bool { return converter.SemanticAgents[name] }, Errors: sessioncoord.ErrorSinkFunc(func(_ context.Context, err error) { log.Printf("gmuxd: %v", err) }), Frames: func(_ context.Context, frames wire.Frames) {
 		// The converter builds world.health.launchers but not the top-level
 		// world.launchers/default_launcher that the web UI's "+" menu reads
 		// (parity with the legacy composeWorld). Inject the static launch
@@ -607,6 +607,7 @@ func serveCentral(stderr io.Writer, replace bool) int {
 			}
 			w.WriteHeader(http.StatusNoContent)
 		})
+		registerActiveSubagentRoutes(mux, boot.Coordinator)
 		mux.HandleFunc("POST /v1/register", func(w http.ResponseWriter, r *http.Request) {
 			body, err := io.ReadAll(io.LimitReader(r.Body, 4096))
 			if err != nil {
@@ -614,8 +615,9 @@ func serveCentral(stderr io.Writer, replace bool) int {
 				return
 			}
 			var req struct {
-				SessionID  string `json:"session_id"`
-				SocketPath string `json:"socket_path"`
+				SessionID                 string `json:"session_id"`
+				SocketPath                string `json:"socket_path"`
+				ActiveSubagentReservation string `json:"active_subagent_reservation,omitempty"`
 			}
 			if err := json.Unmarshal(body, &req); err != nil {
 				writeError(w, http.StatusBadRequest, "bad_request", "invalid JSON")
@@ -625,7 +627,17 @@ func serveCentral(stderr io.Writer, replace bool) int {
 				writeError(w, http.StatusBadRequest, "bad_request", "session_id and socket_path required")
 				return
 			}
-			if _, err := boot.Coordinator.Register(r.Context(), sessioncoord.RegisterRequest{Endpoint: req.SocketPath, AssertedID: centralstore.SessionID(req.SessionID)}); err != nil {
+			if _, err := boot.Coordinator.Register(r.Context(), sessioncoord.RegisterRequest{Endpoint: req.SocketPath, AssertedID: centralstore.SessionID(req.SessionID), ActiveSubagentReservation: req.ActiveSubagentReservation}); err != nil {
+				var limit *sessioncoord.SubagentLimitError
+				if errors.As(err, &limit) {
+					message := fmt.Sprintf("subagent limit reached for root %s: %d of %d active subagents; run 'gmux ls' to inspect this host's sessions", limit.Root, limit.Active, limit.Limit)
+					writeError(w, http.StatusTooManyRequests, codeSubagentLimitReached, message)
+					return
+				}
+				if errors.Is(err, sessioncoord.ErrActiveSubagentReservationInvalid) {
+					writeError(w, http.StatusUnprocessableEntity, codeInvalidSubagentReservation, err.Error())
+					return
+				}
 				if errors.Is(err, sessioncoord.ErrSessionIDExists) {
 					writeError(w, http.StatusConflict, "session_id_exists", err.Error())
 					return
@@ -1057,7 +1069,7 @@ func handleCentralSessionAction(w http.ResponseWriter, r *http.Request, boot *Bo
 			writeError(w, http.StatusMethodNotAllowed, "bad_request", "method not allowed")
 			return
 		}
-		result, err := boot.Store.SetPromotion(r.Context(), sid, action == "promote", nil)
+		_, err := boot.Coordinator.SetPromotion(r.Context(), sid, action == "promote", nil)
 		if errors.Is(err, centralstore.ErrSessionNotFound) {
 			writeError(w, http.StatusNotFound, "not_found", "session not found")
 			return
@@ -1066,9 +1078,8 @@ func handleCentralSessionAction(w http.ResponseWriter, r *http.Request, boot *Bo
 			writeError(w, http.StatusInternalServerError, "internal", err.Error())
 			return
 		}
-		if result.Changed {
-			boot.Composer.Invalidate(result)
-		}
+		// Coordinator publishes the committed mutation through the ordinary
+		// dirty bridge after updating budget ownership under the same mutex.
 		writeJSON(w, map[string]any{"ok": true, "data": map[string]any{}})
 	case "reparent":
 		if r.Method != http.MethodPost {

--- a/services/gmuxd/internal/config/config.go
+++ b/services/gmuxd/internal/config/config.go
@@ -26,6 +26,10 @@ type Config struct {
 	// Port is the TCP port for the HTTP listener (default 8790).
 	Port int `toml:"port"`
 
+	// MaxActiveSubagents is the host-default per behavioral-root limit for
+	// live semantic-agent descendants launched through gmux (default 8).
+	MaxActiveSubagents int `toml:"max_active_subagents"`
+
 	Tailscale TailscaleConfig `toml:"tailscale"`
 	Discovery DiscoveryConfig `toml:"discovery"`
 	Sessions  SessionsConfig  `toml:"sessions"`
@@ -180,6 +184,9 @@ func validate(cfg Config) error {
 	if cfg.Port < 1 || cfg.Port > 65535 {
 		return fmt.Errorf("port %d is out of range (1-65535)", cfg.Port)
 	}
+	if cfg.MaxActiveSubagents < 1 || cfg.MaxActiveSubagents > 1024 {
+		return fmt.Errorf("max_active_subagents must be between 1 and 1024")
+	}
 
 	maxRetentionDays := effectiveIntMax(math.MaxInt64 / int64(24*time.Hour))
 	if cfg.Sessions.RetentionDays < 0 || int64(cfg.Sessions.RetentionDays) > maxRetentionDays {
@@ -275,7 +282,8 @@ func isPrivateOrCGNAT(ip net.IP) bool {
 
 func defaults() Config {
 	return Config{
-		Port: 8790,
+		Port:               8790,
+		MaxActiveSubagents: 8,
 		Discovery: DiscoveryConfig{
 			Devcontainers: true,
 		},

--- a/services/gmuxd/internal/config/config_test.go
+++ b/services/gmuxd/internal/config/config_test.go
@@ -20,6 +20,9 @@ func TestLoadDefaults(t *testing.T) {
 	if cfg.Port != 8790 {
 		t.Errorf("port = %d, want 8790", cfg.Port)
 	}
+	if cfg.MaxActiveSubagents != 8 {
+		t.Errorf("max_active_subagents = %d, want 8", cfg.MaxActiveSubagents)
+	}
 	if cfg.Tailscale.Enabled {
 		t.Error("tailscale should be disabled by default")
 	}
@@ -36,6 +39,7 @@ func TestLoadFromFile(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", dir)
 	writeConfig(t, dir, `
 port = 9999
+max_active_subagents = 12
 
 [tailscale]
 enabled = true
@@ -49,11 +53,49 @@ allow = ["alice@github", "bob@github"]
 	if cfg.Port != 9999 {
 		t.Errorf("port = %d, want 9999", cfg.Port)
 	}
+	if cfg.MaxActiveSubagents != 12 {
+		t.Errorf("max_active_subagents = %d, want 12", cfg.MaxActiveSubagents)
+	}
 	if !cfg.Tailscale.Enabled {
 		t.Error("tailscale should be enabled")
 	}
 	if len(cfg.Tailscale.Allow) != 2 {
 		t.Fatalf("allow = %v, want 2 entries", cfg.Tailscale.Allow)
+	}
+}
+
+func TestLoadValidatesMaxActiveSubagents(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		value   string
+		want    int
+		wantErr bool
+	}{
+		{name: "minimum", value: "1", want: 1},
+		{name: "reasonable maximum", value: "1024", want: 1024},
+		{name: "zero", value: "0", wantErr: true},
+		{name: "negative", value: "-1", wantErr: true},
+		{name: "unreasonably large", value: "1025", wantErr: true},
+		{name: "wrong type", value: `"eight"`, wantErr: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			t.Setenv("XDG_CONFIG_HOME", dir)
+			writeConfig(t, dir, "max_active_subagents = "+tt.value+"\n")
+			cfg, err := Load()
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("Load() = %+v, want error", cfg)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if cfg.MaxActiveSubagents != tt.want {
+				t.Fatalf("got %d, want %d", cfg.MaxActiveSubagents, tt.want)
+			}
+		})
 	}
 }
 

--- a/services/gmuxd/internal/sessioncoord/active_subagents.go
+++ b/services/gmuxd/internal/sessioncoord/active_subagents.go
@@ -1,0 +1,453 @@
+package sessioncoord
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/centralstore"
+)
+
+// ErrSubagentLimitReached is the stable admission verdict for a launch whose
+// current behavioral root has no free active-subagent slot.
+var ErrSubagentLimitReached = errors.New("sessioncoord: active subagent limit reached")
+
+var (
+	// ErrActiveSubagentReservationInvalid marks an absent, expired, reused, or
+	// parent-mismatched launch receipt. A runner presenting one must not be
+	// registered as an unbudgeted fallback.
+	ErrActiveSubagentReservationInvalid = errors.New("sessioncoord: invalid active-subagent launch reservation")
+	errLaunchReservationNotFound        = fmt.Errorf("%w: not found, expired, or already claimed", ErrActiveSubagentReservationInvalid)
+	errLaunchReservationMismatch        = fmt.Errorf("%w: parent does not match admission", ErrActiveSubagentReservationInvalid)
+)
+
+const activeSubagentReservationTTL = 2 * time.Minute
+
+// SubagentLimitError carries the machine-readable facts behind
+// ErrSubagentLimitReached.
+type SubagentLimitError struct {
+	Root          centralstore.SessionID
+	Active, Limit int
+}
+
+func (e *SubagentLimitError) Error() string {
+	return fmt.Sprintf("%v for root %s: %d of %d active subagents", ErrSubagentLimitReached, e.Root, e.Active, e.Limit)
+}
+func (e *SubagentLimitError) Unwrap() error { return ErrSubagentLimitReached }
+
+// ActiveSubagentReservation is an admission receipt. Root is empty for a
+// top-level/orphan launch, which starts a root and therefore consumes no
+// descendant slot.
+type ActiveSubagentReservation struct {
+	Token         string
+	Root          centralstore.SessionID
+	Active, Limit int
+	ExpiresAt     time.Time
+}
+
+type activeSubagentNode struct {
+	parent    centralstore.SessionID
+	hasParent bool
+	promoted  bool
+	semantic  bool
+	live      bool
+}
+
+type activeSubagentLaunch struct {
+	parent    centralstore.SessionID
+	hasParent bool
+	expires   time.Time
+	claimedBy centralstore.SessionID
+}
+
+// activeSubagentBudget is guarded by Coordinator.mu. It is an incrementally
+// maintained projection of durable mutable ownership plus runtime liveness.
+// Durable rows provide parent/promotion/adapter facts; only installed local
+// registry generations set live. Remote projections never enter this index.
+type activeSubagentBudget struct {
+	limit        int
+	semantic     func(string) bool
+	nodes        map[centralstore.SessionID]activeSubagentNode
+	children     map[centralstore.SessionID]map[centralstore.SessionID]struct{}
+	roots        map[centralstore.SessionID]centralstore.SessionID
+	activeByRoot map[centralstore.SessionID]int
+	launches     map[string]activeSubagentLaunch
+	now          func() time.Time
+}
+
+func newActiveSubagentBudget(limit int, semantic func(string) bool, rows []centralstore.Session) *activeSubagentBudget {
+	b := &activeSubagentBudget{
+		limit: limit, semantic: semantic,
+		nodes:        make(map[centralstore.SessionID]activeSubagentNode, len(rows)),
+		children:     make(map[centralstore.SessionID]map[centralstore.SessionID]struct{}),
+		roots:        make(map[centralstore.SessionID]centralstore.SessionID, len(rows)),
+		activeByRoot: make(map[centralstore.SessionID]int),
+		launches:     make(map[string]activeSubagentLaunch), now: time.Now,
+	}
+	if b.semantic == nil {
+		b.semantic = func(string) bool { return false }
+	}
+	for _, row := range rows {
+		n := activeSubagentNode{promoted: row.PromotedToRoot, semantic: b.semantic(row.Adapter)}
+		if row.ParentSessionID != nil {
+			n.parent, n.hasParent = *row.ParentSessionID, true
+			b.addChild(n.parent, row.ID)
+		}
+		b.nodes[row.ID] = n
+	}
+	for id := range b.nodes {
+		b.roots[id] = b.resolveRoot(id)
+	}
+	return b
+}
+
+func (b *activeSubagentBudget) addChild(parent, child centralstore.SessionID) {
+	if b.children[parent] == nil {
+		b.children[parent] = make(map[centralstore.SessionID]struct{})
+	}
+	b.children[parent][child] = struct{}{}
+}
+func (b *activeSubagentBudget) removeChild(parent, child centralstore.SessionID) {
+	delete(b.children[parent], child)
+	if len(b.children[parent]) == 0 {
+		delete(b.children, parent)
+	}
+}
+
+// resolveRoot follows current parent/promotion facts. Missing parents make the
+// last present node a root, matching family presentation. Corrupt cycles are
+// collapsed onto their lexicographically smallest member so resolution is
+// bounded and deterministic instead of hanging or splitting one cycle across
+// unrelated budgets.
+func (b *activeSubagentBudget) resolveRoot(start centralstore.SessionID) centralstore.SessionID {
+	path := make([]centralstore.SessionID, 0, 8)
+	seen := make(map[centralstore.SessionID]int)
+	cur := start
+	for {
+		n, ok := b.nodes[cur]
+		if !ok {
+			if len(path) == 0 {
+				return ""
+			}
+			return path[len(path)-1]
+		}
+		if n.promoted || !n.hasParent {
+			return cur
+		}
+		seen[cur] = len(path)
+		path = append(path, cur)
+		if at, cycle := seen[n.parent]; cycle {
+			root := n.parent
+			for _, id := range path[at:] {
+				if id < root {
+					root = id
+				}
+			}
+			return root
+		}
+		if _, exists := b.nodes[n.parent]; !exists {
+			return cur
+		}
+		cur = n.parent
+	}
+}
+
+func (b *activeSubagentBudget) subtree(start centralstore.SessionID) []centralstore.SessionID {
+	out := make([]centralstore.SessionID, 0, 1)
+	seen := map[centralstore.SessionID]bool{}
+	queue := []centralstore.SessionID{start}
+	for len(queue) > 0 {
+		id := queue[0]
+		queue = queue[1:]
+		if seen[id] {
+			continue
+		}
+		seen[id] = true
+		if _, ok := b.nodes[id]; ok {
+			out = append(out, id)
+		}
+		for child := range b.children[id] {
+			queue = append(queue, child)
+		}
+	}
+	return out
+}
+
+func (b *activeSubagentBudget) subtract(ids []centralstore.SessionID) {
+	for _, id := range ids {
+		n := b.nodes[id]
+		root := b.roots[id]
+		if n.live && n.semantic && root != "" && root != id {
+			b.activeByRoot[root]--
+			if b.activeByRoot[root] == 0 {
+				delete(b.activeByRoot, root)
+			}
+		}
+	}
+}
+func (b *activeSubagentBudget) add(ids []centralstore.SessionID) {
+	for _, id := range ids {
+		root := b.resolveRoot(id)
+		b.roots[id] = root
+		n := b.nodes[id]
+		if n.live && n.semantic && root != "" && root != id {
+			b.activeByRoot[root]++
+		}
+	}
+}
+
+func (b *activeSubagentBudget) upsert(row centralstore.Session, live bool) {
+	affected := b.subtree(row.ID)
+	b.subtract(affected)
+	if old, ok := b.nodes[row.ID]; ok && old.hasParent {
+		b.removeChild(old.parent, row.ID)
+	}
+	n := activeSubagentNode{promoted: row.PromotedToRoot, semantic: b.semantic(row.Adapter), live: live}
+	if row.ParentSessionID != nil {
+		n.parent, n.hasParent = *row.ParentSessionID, true
+		b.addChild(n.parent, row.ID)
+	}
+	b.nodes[row.ID] = n
+	if len(affected) == 0 {
+		affected = []centralstore.SessionID{row.ID}
+	}
+	// A formerly missing parent may already have orphan children in the index.
+	seen := make(map[centralstore.SessionID]bool, len(affected))
+	for _, id := range affected {
+		seen[id] = true
+	}
+	for _, id := range b.subtree(row.ID) {
+		if !seen[id] {
+			affected = append(affected, id)
+			seen[id] = true
+		}
+	}
+	b.add(affected)
+}
+
+func (b *activeSubagentBudget) setLive(id centralstore.SessionID, live bool) {
+	n, ok := b.nodes[id]
+	if !ok || n.live == live {
+		return
+	}
+	root := b.roots[id]
+	if n.live && n.semantic && root != "" && root != id {
+		b.activeByRoot[root]--
+		if b.activeByRoot[root] == 0 {
+			delete(b.activeByRoot, root)
+		}
+	}
+	n.live = live
+	b.nodes[id] = n
+	if n.live && n.semantic && root != "" && root != id {
+		b.activeByRoot[root]++
+	}
+}
+
+func (b *activeSubagentBudget) setParent(id centralstore.SessionID, parent *centralstore.SessionID) {
+	n, ok := b.nodes[id]
+	if !ok {
+		return
+	}
+	affected := b.subtree(id)
+	b.subtract(affected)
+	if n.hasParent {
+		b.removeChild(n.parent, id)
+	}
+	n.hasParent = parent != nil
+	if parent != nil {
+		n.parent = *parent
+		b.addChild(*parent, id)
+	} else {
+		n.parent = ""
+	}
+	b.nodes[id] = n
+	b.add(affected)
+}
+
+func (b *activeSubagentBudget) setPromotion(id centralstore.SessionID, promoted bool) {
+	n, ok := b.nodes[id]
+	if !ok {
+		return
+	}
+	affected := b.subtree(id)
+	b.subtract(affected)
+	n.promoted = promoted
+	b.nodes[id] = n
+	b.add(affected)
+}
+
+func (b *activeSubagentBudget) remove(id centralstore.SessionID) {
+	n, ok := b.nodes[id]
+	if !ok {
+		return
+	}
+	affected := b.subtree(id)
+	b.subtract(affected)
+	if n.hasParent {
+		b.removeChild(n.parent, id)
+	}
+	for child := range b.children[id] {
+		cn := b.nodes[child]
+		cn.hasParent, cn.parent = false, ""
+		b.nodes[child] = cn
+	}
+	delete(b.children, id)
+	delete(b.nodes, id)
+	delete(b.roots, id)
+	var survivors []centralstore.SessionID
+	for _, member := range affected {
+		if member != id {
+			survivors = append(survivors, member)
+		}
+	}
+	b.add(survivors)
+}
+
+func (b *activeSubagentBudget) cleanupExpired(now time.Time) {
+	for token, launch := range b.launches {
+		if launch.claimedBy == "" && !now.Before(launch.expires) {
+			delete(b.launches, token)
+		}
+	}
+}
+func (b *activeSubagentBudget) launchRoot(launch activeSubagentLaunch) centralstore.SessionID {
+	if !launch.hasParent {
+		return ""
+	}
+	if _, ok := b.nodes[launch.parent]; !ok {
+		return ""
+	}
+	return b.roots[launch.parent]
+}
+func (b *activeSubagentBudget) reservedAt(root centralstore.SessionID) int {
+	n := 0
+	for _, launch := range b.launches {
+		if b.launchRoot(launch) == root {
+			n++
+		}
+	}
+	return n
+}
+
+func (b *activeSubagentBudget) reserve(parent *centralstore.SessionID) (ActiveSubagentReservation, error) {
+	now := b.now()
+	b.cleanupExpired(now)
+	launch := activeSubagentLaunch{expires: now.Add(activeSubagentReservationTTL)}
+	if parent != nil {
+		launch.parent, launch.hasParent = *parent, true
+	}
+	root := b.launchRoot(launch)
+	active := 0
+	if root != "" {
+		active = b.activeByRoot[root] + b.reservedAt(root)
+		if active >= b.limit {
+			return ActiveSubagentReservation{}, &SubagentLimitError{Root: root, Active: active, Limit: b.limit}
+		}
+	}
+	var raw [16]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return ActiveSubagentReservation{}, err
+	}
+	token := hex.EncodeToString(raw[:])
+	b.launches[token] = launch
+	return ActiveSubagentReservation{Token: token, Root: root, Active: active, Limit: b.limit, ExpiresAt: launch.expires}, nil
+}
+
+func (b *activeSubagentBudget) claim(token string, id centralstore.SessionID) (activeSubagentLaunch, error) {
+	now := b.now()
+	b.cleanupExpired(now)
+	launch, ok := b.launches[token]
+	if !ok || launch.claimedBy != "" || id == "" {
+		return activeSubagentLaunch{}, errLaunchReservationNotFound
+	}
+	launch.claimedBy = id
+	b.launches[token] = launch
+	return launch, nil
+}
+func (b *activeSubagentBudget) validateParent(launch activeSubagentLaunch, parent *centralstore.SessionID) error {
+	if launch.hasParent != (parent != nil) {
+		return errLaunchReservationMismatch
+	}
+	if parent != nil && launch.parent != *parent {
+		return errLaunchReservationMismatch
+	}
+	return nil
+}
+
+// validateClaimedBudget re-checks a claimed receipt against current mutable
+// ownership immediately before the registration commit. reservedAt includes
+// this receipt, so equality with limit is valid; anything greater means its
+// parent moved into a root that was already full after admission.
+func (b *activeSubagentBudget) validateClaimedBudget(launch activeSubagentLaunch) error {
+	root := b.launchRoot(launch)
+	if root == "" {
+		return nil
+	}
+	active := b.activeByRoot[root] + b.reservedAt(root)
+	if active > b.limit {
+		return &SubagentLimitError{Root: root, Active: active - 1, Limit: b.limit}
+	}
+	return nil
+}
+func (b *activeSubagentBudget) release(token string, claimed bool) {
+	launch, ok := b.launches[token]
+	if !ok {
+		return
+	}
+	if claimed && launch.claimedBy == "" {
+		return
+	}
+	if !claimed && launch.claimedBy != "" {
+		return
+	}
+	delete(b.launches, token)
+}
+
+// unclaim restores a receipt after a pre-commit registration failure so the
+// runner's existing retry loop can present the same receipt again. The
+// original expiry remains authoritative and the receipt keeps counting.
+func (b *activeSubagentBudget) unclaim(token string) {
+	launch, ok := b.launches[token]
+	if !ok || launch.claimedBy == "" {
+		return
+	}
+	launch.claimedBy = ""
+	b.launches[token] = launch
+}
+func (b *activeSubagentBudget) hasLaunchFrom(members map[centralstore.SessionID]bool) bool {
+	b.cleanupExpired(b.now())
+	for _, launch := range b.launches {
+		if launch.hasParent && members[launch.parent] {
+			return true
+		}
+	}
+	return false
+}
+
+// ReserveActiveSubagent atomically checks and reserves one gmux-mediated new
+// semantic-agent launch against current mutable ownership.
+func (c *Coordinator) ReserveActiveSubagent(_ context.Context, parent *centralstore.SessionID) (ActiveSubagentReservation, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closing {
+		return ActiveSubagentReservation{}, errors.New("sessioncoord: coordinator closed")
+	}
+	if c.activeSubagents == nil {
+		return ActiveSubagentReservation{}, errors.New("sessioncoord: active-subagent budget is not configured")
+	}
+	return c.activeSubagents.reserve(parent)
+}
+
+// ReleaseActiveSubagentReservation cancels an unclaimed pre-launch receipt.
+// It is idempotent; registration consumes claimed receipts itself.
+func (c *Coordinator) ReleaseActiveSubagentReservation(token string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.activeSubagents != nil {
+		c.activeSubagents.release(token, false)
+	}
+}

--- a/services/gmuxd/internal/sessioncoord/active_subagents_test.go
+++ b/services/gmuxd/internal/sessioncoord/active_subagents_test.go
@@ -1,0 +1,421 @@
+package sessioncoord
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/centralstore"
+)
+
+func budgetSession(id, adapter string, parent *centralstore.SessionID, promoted bool) centralstore.Session {
+	return centralstore.Session{ID: centralstore.SessionID(id), Adapter: adapter, ParentSessionID: parent, PromotedToRoot: promoted}
+}
+
+func budgetParent(id string) *centralstore.SessionID {
+	v := centralstore.SessionID(id)
+	return &v
+}
+
+func TestActiveSubagentRootAndCountTable(t *testing.T) {
+	rows := []centralstore.Session{
+		budgetSession("root", "shell", nil, false),
+		budgetSession("agent", "pi", budgetParent("root"), false),
+		budgetSession("nested", "pi", budgetParent("agent"), false),
+		budgetSession("process", "shell", budgetParent("root"), false),
+		budgetSession("dead", "pi", budgetParent("root"), false),
+		budgetSession("promoted", "pi", budgetParent("root"), true),
+		budgetSession("promoted-child", "pi", budgetParent("promoted"), false),
+		budgetSession("orphan", "pi", budgetParent("remote@peer"), false),
+		budgetSession("orphan-child", "pi", budgetParent("orphan"), false),
+		budgetSession("cycle-a", "pi", budgetParent("cycle-b"), false),
+		budgetSession("cycle-b", "pi", budgetParent("cycle-a"), false),
+		budgetSession("cycle-child", "pi", budgetParent("cycle-b"), false),
+	}
+	b := newActiveSubagentBudget(8, func(adapter string) bool { return adapter == "pi" }, rows)
+	for _, id := range []centralstore.SessionID{"agent", "nested", "process", "promoted", "promoted-child", "orphan", "orphan-child", "cycle-a", "cycle-b", "cycle-child"} {
+		b.setLive(id, true)
+	}
+
+	roots := map[centralstore.SessionID]centralstore.SessionID{
+		"root": "root", "agent": "root", "nested": "root", "process": "root", "dead": "root",
+		"promoted": "promoted", "promoted-child": "promoted",
+		"orphan": "orphan", "orphan-child": "orphan",
+		"cycle-a": "cycle-a", "cycle-b": "cycle-a", "cycle-child": "cycle-a",
+	}
+	for id, want := range roots {
+		if got := b.roots[id]; got != want {
+			t.Errorf("root(%s) = %s, want %s", id, got, want)
+		}
+	}
+	wantCounts := map[centralstore.SessionID]int{"root": 2, "promoted": 1, "orphan": 1, "cycle-a": 2}
+	for root, want := range wantCounts {
+		if got := b.activeByRoot[root]; got != want {
+			t.Errorf("active[%s] = %d, want %d", root, got, want)
+		}
+	}
+	if _, exists := b.nodes["remote@peer"]; exists {
+		t.Fatal("remote projection entered the local budget index")
+	}
+}
+
+func TestActiveSubagentMutableOwnershipTransitions(t *testing.T) {
+	rows := []centralstore.Session{
+		budgetSession("a", "shell", nil, false),
+		budgetSession("b", "shell", nil, false),
+		budgetSession("child", "pi", budgetParent("a"), false),
+		budgetSession("grand", "pi", budgetParent("child"), false),
+	}
+	b := newActiveSubagentBudget(8, func(adapter string) bool { return adapter == "pi" }, rows)
+	b.setLive("child", true)
+	b.setLive("grand", true)
+	if b.activeByRoot["a"] != 2 {
+		t.Fatalf("initial counts = %v", b.activeByRoot)
+	}
+
+	b.setParent("child", budgetParent("b"))
+	if b.activeByRoot["a"] != 0 || b.activeByRoot["b"] != 2 {
+		t.Fatalf("reparent counts = %v", b.activeByRoot)
+	}
+	b.setPromotion("child", true)
+	if b.activeByRoot["b"] != 0 || b.activeByRoot["child"] != 1 {
+		t.Fatalf("promotion counts = %v", b.activeByRoot)
+	}
+	b.setPromotion("child", false)
+	if b.activeByRoot["b"] != 2 || b.activeByRoot["child"] != 0 {
+		t.Fatalf("demotion counts = %v", b.activeByRoot)
+	}
+	b.setLive("grand", false)
+	if b.activeByRoot["b"] != 1 {
+		t.Fatalf("termination counts = %v", b.activeByRoot)
+	}
+}
+
+func coordinatorAtSeven(t *testing.T) *Coordinator {
+	t.Helper()
+	rows := []centralstore.Session{budgetSession("root", "shell", nil, false)}
+	for i := 0; i < 7; i++ {
+		rows = append(rows, budgetSession(fmt.Sprintf("agent-%d", i), "pi", budgetParent("root"), false))
+	}
+	c := New(nil, nil, nil, nil, nil, WithActiveSubagentBudget(8, func(adapter string) bool { return adapter == "pi" }, rows))
+	c.mu.Lock()
+	for i := 0; i < 7; i++ {
+		c.activeSubagents.setLive(centralstore.SessionID(fmt.Sprintf("agent-%d", i)), true)
+	}
+	c.mu.Unlock()
+	return c
+}
+
+func TestConcurrentActiveSubagentAdmissionAtSevenOfEight(t *testing.T) {
+	c := coordinatorAtSeven(t)
+	parent := centralstore.SessionID("root")
+	const attempts = 32
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var successes []ActiveSubagentReservation
+	failures := 0
+	for i := 0; i < attempts; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			reservation, err := c.ReserveActiveSubagent(context.Background(), &parent)
+			mu.Lock()
+			defer mu.Unlock()
+			if err == nil {
+				successes = append(successes, reservation)
+				return
+			}
+			if !errors.Is(err, ErrSubagentLimitReached) {
+				t.Errorf("admission error = %v", err)
+			}
+			failures++
+		}()
+	}
+	close(start)
+	wg.Wait()
+	if len(successes) != 1 || failures != attempts-1 {
+		t.Fatalf("successes=%d failures=%d", len(successes), failures)
+	}
+	c.mu.Lock()
+	if got := len(c.activeSubagents.launches); got != 1 {
+		t.Fatalf("reservation state = %d, want one successful launch only", got)
+	}
+	// Convert the sole receipt into the eighth live descendant, as Register
+	// does under this same mutex, and prove the root never exceeded eight.
+	child := budgetSession("agent-7", "pi", &parent, false)
+	c.activeSubagents.upsert(child, true)
+	c.activeSubagents.release(successes[0].Token, false)
+	if got := c.activeSubagents.activeByRoot[parent]; got != 8 {
+		t.Fatalf("live descendants = %d, want 8", got)
+	}
+	if got := len(c.activeSubagents.launches); got != 0 {
+		t.Fatalf("leaked launch state = %d", got)
+	}
+	c.mu.Unlock()
+}
+
+func TestConcurrentActiveSubagentAdmissionAtEightOfEight(t *testing.T) {
+	c := coordinatorAtSeven(t)
+	parent := centralstore.SessionID("root")
+	c.mu.Lock()
+	c.activeSubagents.upsert(budgetSession("agent-7", "pi", &parent, false), true)
+	c.mu.Unlock()
+
+	const attempts = 16
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	var successes atomic.Int32
+	for i := 0; i < attempts; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			if _, err := c.ReserveActiveSubagent(context.Background(), &parent); err == nil {
+				successes.Add(1)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	if successes.Load() != 0 {
+		t.Fatalf("successes = %d, want 0", successes.Load())
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.activeSubagents.launches) != 0 {
+		t.Fatalf("failed admissions leaked: %d", len(c.activeSubagents.launches))
+	}
+}
+
+func TestReservedLaunchFollowsReparentAndBlocksDismiss(t *testing.T) {
+	rootA, rootB, caller := centralstore.SessionID("root-a"), centralstore.SessionID("root-b"), centralstore.SessionID("caller")
+	rows := []centralstore.Session{
+		{ID: rootA, Adapter: "shell"}, {ID: rootB, Adapter: "shell"},
+		{ID: caller, Adapter: "shell", ParentSessionID: &rootA},
+	}
+	durable := newFakeDurable(0)
+	durable.listSessions = func() ([]centralstore.Session, error) { return rows, nil }
+	coord := New(nil, nil, durable, nil, nil, WithActiveSubagentBudget(1, func(a string) bool { return a == "pi" }, rows))
+	first, err := coord.ReserveActiveSubagent(context.Background(), &caller)
+	if err != nil {
+		t.Fatal(err)
+	}
+	coord.mu.Lock()
+	coord.activeSubagents.setParent(caller, &rootB)
+	coord.mu.Unlock()
+	if _, err := coord.ReserveActiveSubagent(context.Background(), &rootB); !errors.Is(err, ErrSubagentLimitReached) {
+		t.Fatalf("reservation did not move with caller: %v", err)
+	}
+	if _, err := coord.ReserveActiveSubagent(context.Background(), &rootA); err != nil {
+		t.Fatalf("old root did not regain slot: %v", err)
+	}
+	if _, err := coord.Dismiss(context.Background(), caller); !errors.Is(err, ErrSubtreeBusy) {
+		t.Fatalf("dismiss during launch = %v, want ErrSubtreeBusy", err)
+	}
+	coord.ReleaseActiveSubagentReservation(first.Token)
+}
+
+func TestClaimedLaunchRechecksBudgetAfterReparent(t *testing.T) {
+	rootA, rootB, caller := centralstore.SessionID("root-a"), centralstore.SessionID("root-b"), centralstore.SessionID("caller")
+	rows := []centralstore.Session{{ID: rootA, Adapter: "shell"}, {ID: rootB, Adapter: "shell"}, {ID: caller, Adapter: "shell", ParentSessionID: &rootA}, budgetSession("full", "pi", &rootB, false)}
+	b := newActiveSubagentBudget(1, func(a string) bool { return a == "pi" }, rows)
+	b.setLive("full", true)
+	reservation, err := b.reserve(&caller)
+	if err != nil {
+		t.Fatal(err)
+	}
+	launch, err := b.claim(reservation.Token, "child")
+	if err != nil {
+		t.Fatal(err)
+	}
+	b.setParent(caller, &rootB)
+	if err := b.validateClaimedBudget(launch); !errors.Is(err, ErrSubagentLimitReached) {
+		t.Fatalf("reparented claim validation = %v, want limit", err)
+	}
+}
+
+func TestMissingNodeMutationsDoNotCorruptDescendantCounts(t *testing.T) {
+	root, missing, child := centralstore.SessionID("root"), centralstore.SessionID("missing"), centralstore.SessionID("child")
+	b := newActiveSubagentBudget(1, func(a string) bool { return a == "pi" }, []centralstore.Session{{ID: root, Adapter: "shell"}, budgetSession(string(child), "pi", &missing, false)})
+	b.setLive(child, true)
+	before := b.activeByRoot[child]
+	b.setParent(missing, &root)
+	b.setPromotion(missing, true)
+	b.remove(missing)
+	if got := b.activeByRoot[child]; got != before {
+		t.Fatalf("count changed from %d to %d", before, got)
+	}
+}
+
+func TestActiveSubagentLaunchFailureReleasesSlot(t *testing.T) {
+	c := coordinatorAtSeven(t)
+	parent := centralstore.SessionID("root")
+	reservation, err := c.ReserveActiveSubagent(context.Background(), &parent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.ReleaseActiveSubagentReservation(reservation.Token)
+	if _, err := c.ReserveActiveSubagent(context.Background(), &parent); err != nil {
+		t.Fatalf("slot not reusable after pre-start failure: %v", err)
+	}
+}
+
+func TestActiveSubagentRegistrationConsumesAndTerminationReleasesSlot(t *testing.T) {
+	parent := centralstore.SessionID("root0000")
+	childID := centralstore.SessionID("child000")
+	rows := []centralstore.Session{{ID: parent, Adapter: "shell"}}
+	for i := 0; i < 7; i++ {
+		rows = append(rows, budgetSession(fmt.Sprintf("live%04d", i), "pi", &parent, false))
+	}
+	meta := liveMeta(childID, "pi", "")
+	meta.Registration.ParentSessionID = &parent
+	client := newFakeClient(meta)
+	durable := newFakeDurable(0)
+	durable.registerResult = func(centralstore.RunnerRegistration) (centralstore.Session, centralstore.MutationResult, error) {
+		return centralstore.Session{ID: childID, Version: 1, Adapter: "pi", ParentSessionID: &parent}, centralstore.MutationResult{Changed: true, SessionsDirty: true, SessionVersion: 1}, nil
+	}
+	durable.applyResult = func(centralstore.RunnerObservation) (centralstore.MutationResult, error) {
+		return centralstore.MutationResult{Changed: true, SessionsDirty: true, SessionVersion: 2}, nil
+	}
+	coord := New(nil, client, durable, nil, nil, WithActiveSubagentBudget(8, func(a string) bool { return a == "pi" }, rows))
+	coord.mu.Lock()
+	for i := 0; i < 7; i++ {
+		coord.activeSubagents.setLive(centralstore.SessionID(fmt.Sprintf("live%04d", i)), true)
+	}
+	coord.mu.Unlock()
+	reservation, err := coord.ReserveActiveSubagent(context.Background(), &parent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtime, err := coord.Register(context.Background(), RegisterRequest{Endpoint: "ep", AssertedID: childID, ActiveSubagentReservation: reservation.Token})
+	if err != nil {
+		t.Fatal(err)
+	}
+	coord.mu.Lock()
+	if got := coord.activeSubagents.activeByRoot[parent]; got != 8 {
+		t.Fatalf("after register active=%d", got)
+	}
+	if len(coord.activeSubagents.launches) != 0 {
+		t.Fatalf("receipt not consumed: %v", coord.activeSubagents.launches)
+	}
+	coord.mu.Unlock()
+
+	exit := centralstore.UnixMillis(10)
+	alive := false
+	coord.apply(context.Background(), childID, runtime.Generation, RunnerEvent{ObservedAt: exit, Alive: &alive, Facts: centralstore.RunnerFacts{ExitedAt: centralstore.NullablePatch[centralstore.UnixMillis]{Set: &exit}}})
+	coord.mu.Lock()
+	if got := coord.activeSubagents.activeByRoot[parent]; got != 7 {
+		t.Fatalf("after termination active=%d", got)
+	}
+	coord.mu.Unlock()
+}
+
+func TestActiveSubagentRegistrationPanicUnlocksAndPreservesReceipt(t *testing.T) {
+	parent, id := centralstore.SessionID("root0000"), centralstore.SessionID("child000")
+	meta := liveMeta(id, "pi", "")
+	meta.Registration.ParentSessionID = &parent
+	client := newFakeClient(meta)
+	durable := newFakeDurable(0)
+	durable.registerResult = func(centralstore.RunnerRegistration) (centralstore.Session, centralstore.MutationResult, error) {
+		panic("boom")
+	}
+	coord := New(nil, client, durable, nil, nil, WithActiveSubagentBudget(1, func(a string) bool { return a == "pi" }, []centralstore.Session{{ID: parent, Adapter: "shell"}}))
+	reservation, err := coord.ReserveActiveSubagent(context.Background(), &parent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	func() {
+		defer func() {
+			if recover() == nil {
+				t.Fatal("Register did not panic")
+			}
+		}()
+		_, _ = coord.Register(context.Background(), RegisterRequest{Endpoint: "ep", AssertedID: id, ActiveSubagentReservation: reservation.Token})
+	}()
+	// A post-recovery mutex operation must complete, and the original receipt
+	// remains the sole counted reservation rather than leaking a claimed state.
+	coord.mu.Lock()
+	launch := coord.activeSubagents.launches[reservation.Token]
+	coord.mu.Unlock()
+	if launch.claimedBy != "" {
+		t.Fatalf("receipt remained claimed by %s", launch.claimedBy)
+	}
+	coord.ReleaseActiveSubagentReservation(reservation.Token)
+	if _, err := coord.ReserveActiveSubagent(context.Background(), &parent); err != nil {
+		t.Fatalf("coordinator wedged after panic: %v", err)
+	}
+}
+
+func TestActiveSubagentRegistrationFailureReleasesClaimedReceipt(t *testing.T) {
+	parent := centralstore.SessionID("root0000")
+	id := centralstore.SessionID("child000")
+	meta := liveMeta(id, "pi", "")
+	meta.Registration.ParentSessionID = &parent
+	client := newFakeClient(meta)
+	client.metaErr = errors.New("startup meta failed")
+	coord := New(nil, client, newFakeDurable(0), nil, nil,
+		WithActiveSubagentBudget(1, func(a string) bool { return a == "pi" }, []centralstore.Session{{ID: parent, Adapter: "shell"}}))
+	reservation, err := coord.ReserveActiveSubagent(context.Background(), &parent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := coord.Register(context.Background(), RegisterRequest{Endpoint: "ep", AssertedID: id, ActiveSubagentReservation: reservation.Token}); err == nil {
+		t.Fatal("registration unexpectedly succeeded")
+	}
+	// The same receipt may retry after a transient pre-commit failure.
+	client.metaErr = nil
+	client.stream = newFakeStream()
+	client.stream.incarnation = client.meta.Incarnation
+	if _, err := coord.Register(context.Background(), RegisterRequest{Endpoint: "ep", AssertedID: id, ActiveSubagentReservation: reservation.Token}); err != nil {
+		t.Fatalf("receipt was not retryable: %v", err)
+	}
+}
+
+func TestActiveSubagentRestartReconstructsOwnershipFromDurableRows(t *testing.T) {
+	parent := centralstore.SessionID("root0000")
+	child := centralstore.SessionID("child000")
+	rows := []centralstore.Session{
+		{ID: parent, Adapter: "shell"},
+		{ID: child, Adapter: "pi", ParentSessionID: &parent},
+	}
+	meta := liveMeta(child, "pi", "")
+	meta.Registration.ParentSessionID = &parent
+	client := newFakeClient(meta)
+	durable := newFakeDurable(0)
+	durable.registerResult = func(centralstore.RunnerRegistration) (centralstore.Session, centralstore.MutationResult, error) {
+		return centralstore.Session{ID: child, Version: 1, Adapter: "pi", ParentSessionID: &parent}, centralstore.MutationResult{Changed: true, SessionVersion: 1}, nil
+	}
+	coord := New(nil, client, durable, nil, nil, WithActiveSubagentBudget(1, func(a string) bool { return a == "pi" }, rows))
+	if _, err := coord.Register(context.Background(), RegisterRequest{Endpoint: "surviving-runner"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := coord.ReserveActiveSubagent(context.Background(), &parent); !errors.Is(err, ErrSubagentLimitReached) {
+		t.Fatalf("post-restart admission error=%v, want limit", err)
+	}
+}
+
+func BenchmarkActiveSubagentAdmission1000Sessions(b *testing.B) {
+	rows := make([]centralstore.Session, 0, 1000)
+	rows = append(rows, budgetSession("root", "shell", nil, false))
+	parent := centralstore.SessionID("root")
+	for i := 1; i < 1000; i++ {
+		id := fmt.Sprintf("s-%04d", i)
+		rows = append(rows, budgetSession(id, "shell", &parent, false))
+		parent = centralstore.SessionID(id)
+	}
+	budget := newActiveSubagentBudget(8, func(string) bool { return false }, rows)
+	launchParent := parent
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		reservation, err := budget.reserve(&launchParent)
+		if err != nil {
+			b.Fatal(err)
+		}
+		budget.release(reservation.Token, false)
+	}
+}

--- a/services/gmuxd/internal/sessioncoord/coordinator.go
+++ b/services/gmuxd/internal/sessioncoord/coordinator.go
@@ -166,6 +166,9 @@ type RunnerEvent struct {
 
 type RegisterRequest struct {
 	Endpoint string
+	// ActiveSubagentReservation is the opaque receipt issued before a
+	// gmux-mediated agent launch. Empty preserves ordinary registration.
+	ActiveSubagentReservation string
 	// AssertedID is caller-supplied identity for ordinary registration. Unlike
 	// ExpectedID it carries no replacement provenance and needs no claim.
 	AssertedID centralstore.SessionID
@@ -243,6 +246,11 @@ type Coordinator struct {
 	// own lock; publishing never runs under the lifecycle mutex.
 	outcomes outcomeBus
 
+	// activeSubagents is the host-local admission projection for gmux-mediated
+	// semantic-agent launches. It is guarded by mu and derives liveness from
+	// installed registry generations, never durable active/status flags.
+	activeSubagents *activeSubagentBudget
+
 	// Startup convergence barrier state (see convergence.go). Guarded by mu.
 	convergeCandidates map[centralstore.SessionID]struct{}
 	convergeClosed     bool
@@ -267,6 +275,15 @@ func WithRunnerSpawner(rs RunnerSpawner) Option { return func(c *Coordinator) { 
 // is the wall clock in Unix milliseconds.
 func WithClock(now func() centralstore.UnixMillis) Option {
 	return func(c *Coordinator) { c.now = now }
+}
+
+// WithActiveSubagentBudget enables host-local launch admission. initial is a
+// durable ownership snapshot; runtime liveness is populated as surviving
+// runners register during startup convergence.
+func WithActiveSubagentBudget(limit int, semantic func(string) bool, initial []centralstore.Session) Option {
+	return func(c *Coordinator) {
+		c.activeSubagents = newActiveSubagentBudget(limit, semantic, initial)
+	}
 }
 
 func New(registry *Registry, runners RunnerClient, durable Durable, dirty DirtySink, errSink ErrorSink, opts ...Option) *Coordinator {
@@ -302,6 +319,37 @@ func (c *Coordinator) Registry() *Registry { return c.registry }
 // request context aborts Subscribe and Meta before install; it has no effect
 // after the entry is installed.
 func (c *Coordinator) Register(ctx context.Context, req RegisterRequest) (Runtime, error) {
+	var (
+		launchReservation   activeSubagentLaunch
+		reservationClaimed  bool
+		reservationConsumed bool
+	)
+	if req.ActiveSubagentReservation != "" {
+		c.mu.Lock()
+		if c.activeSubagents == nil {
+			c.mu.Unlock()
+			return Runtime{}, ErrActiveSubagentReservationInvalid
+		}
+		var err error
+		launchReservation, err = c.activeSubagents.claim(req.ActiveSubagentReservation, req.AssertedID)
+		c.mu.Unlock()
+		if err != nil {
+			return Runtime{}, err
+		}
+		reservationClaimed = true
+		defer func() {
+			if reservationConsumed {
+				return
+			}
+			// Phase 2's panic guard releases c.mu before re-panicking, so this
+			// cleanup can block behind ordinary lifecycle traffic without ever
+			// self-deadlocking or silently stranding a claimed receipt.
+			c.mu.Lock()
+			c.activeSubagents.unclaim(req.ActiveSubagentReservation)
+			c.mu.Unlock()
+		}()
+	}
+
 	// ── Phase 1: runner I/O outside the lifecycle mutex ──────────────────
 	//
 	// streamCtx governs the installed stream for its full lifetime. During
@@ -396,6 +444,11 @@ func (c *Coordinator) Register(ctx context.Context, req RegisterRequest) (Runtim
 		// Abort before the mutex/fence/commit: no registration side effects.
 		return Runtime{}, fmt.Errorf("%w: expected %s, runner reported %s", ErrResumeIdentityMismatch, req.ExpectedID, id)
 	}
+	if reservationClaimed {
+		if err := c.activeSubagents.validateParent(launchReservation, meta.Registration.ParentSessionID); err != nil {
+			return Runtime{}, err
+		}
+	}
 
 	// Ordinary discovery has now verified the endpoint's claimed identity.
 	// Reject an already-installed generation before durable reads or lineage
@@ -413,16 +466,22 @@ func (c *Coordinator) Register(ctx context.Context, req RegisterRequest) (Runtim
 			return Runtime{}, err
 		}
 		old, hadOld := c.registry.current(id)
+		if hadOld && req.AssertedID != "" && old.Endpoint == req.Endpoint && meta.Incarnation != "" && old.Incarnation == meta.Incarnation {
+			// Discovery may have observed this runner between its bind and
+			// direct registration. Treat the later assertion as an idempotent
+			// acknowledgement only with process-level proof, and consume the
+			// launch receipt so it no longer double-counts the installed child.
+			if reservationClaimed {
+				c.activeSubagents.release(req.ActiveSubagentReservation, true)
+				reservationConsumed = true
+			}
+			c.mu.Unlock()
+			_ = stream.Close()
+			return old.Runtime, nil
+		}
 		c.mu.Unlock()
 		if hadOld {
 			if req.AssertedID != "" {
-				// Discovery may have observed this runner between its bind and
-				// direct registration. Treat the later assertion as an
-				// idempotent acknowledgement only with process-level proof.
-				if old.Endpoint == req.Endpoint && meta.Incarnation != "" && old.Incarnation == meta.Incarnation {
-					_ = stream.Close()
-					return old.Runtime, nil
-				}
 				return old.Runtime, fmt.Errorf("%w: %s", ErrSessionIDExists, id)
 			}
 			return old.Runtime, ErrGenerationActive
@@ -457,20 +516,39 @@ func (c *Coordinator) Register(ctx context.Context, req RegisterRequest) (Runtim
 	// Runner I/O (Subscribe, Meta) must not run inside this section.
 
 	c.mu.Lock()
+	phase2Locked := true
+	phase2Unlock := func() {
+		phase2Locked = false
+		c.mu.Unlock()
+	}
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			if phase2Locked {
+				c.mu.Unlock()
+			}
+			panic(recovered)
+		}
+	}()
 
 	if c.closing {
-		c.mu.Unlock()
+		phase2Unlock()
 		return Runtime{}, errors.New("sessioncoord: coordinator closed")
 	}
 	if err := ctx.Err(); err != nil {
-		c.mu.Unlock()
+		phase2Unlock()
 		return Runtime{}, err
 	}
 
 	if req.Replace || req.ExpectedID != "" {
 		if req.Claim == nil || c.ops[id] != req.Claim {
-			c.mu.Unlock()
+			phase2Unlock()
 			return Runtime{}, fmt.Errorf("%w: %s", ErrReplaceWithoutClaim, id)
+		}
+	}
+	if reservationClaimed {
+		if err := c.activeSubagents.validateClaimedBudget(launchReservation); err != nil {
+			phase2Unlock()
+			return Runtime{}, err
 		}
 	}
 
@@ -480,10 +558,10 @@ func (c *Coordinator) Register(ctx context.Context, req RegisterRequest) (Runtim
 	// handling remains the authoritative transaction boundary.
 	if req.AssertedID != "" && !req.Replace && req.ExpectedID == "" && req.Claim == nil {
 		if _, exists, rowErr := c.durable.Session(ctx, id); rowErr != nil {
-			c.mu.Unlock()
+			phase2Unlock()
 			return Runtime{}, rowErr
 		} else if exists {
-			c.mu.Unlock()
+			phase2Unlock()
 			return Runtime{}, fmt.Errorf("%w: %s", ErrSessionIDExists, id)
 		}
 	}
@@ -492,9 +570,14 @@ func (c *Coordinator) Register(ctx context.Context, req RegisterRequest) (Runtim
 	// the pre-I/O absence check, but only one generation may install.
 	old, hadOld := c.registry.current(id)
 	if hadOld && !req.Replace {
-		c.mu.Unlock()
+		idempotent := req.AssertedID != "" && old.Endpoint == req.Endpoint && meta.Incarnation != "" && old.Incarnation == meta.Incarnation
+		if idempotent && reservationClaimed {
+			c.activeSubagents.release(req.ActiveSubagentReservation, true)
+			reservationConsumed = true
+		}
+		phase2Unlock()
 		if req.AssertedID != "" {
-			if old.Endpoint == req.Endpoint && meta.Incarnation != "" && old.Incarnation == meta.Incarnation {
+			if idempotent {
 				_ = stream.Close()
 				return old.Runtime, nil
 			}
@@ -585,11 +668,11 @@ loop:
 			// confirm absence against the durable row under the mutex.
 			_, exists, rowErr := c.durable.Session(ctx, id)
 			if rowErr != nil {
-				c.mu.Unlock()
+				phase2Unlock()
 				return Runtime{}, rowErr
 			}
 			if !exists {
-				c.mu.Unlock()
+				phase2Unlock()
 				return Runtime{}, fmt.Errorf("%w: %s", ErrConversationOwnedByLive, id)
 			}
 		}
@@ -609,7 +692,7 @@ loop:
 		if hadOld {
 			c.registry.restore(id, old.Generation)
 		}
-		c.mu.Unlock()
+		phase2Unlock()
 		return Runtime{}, err
 	}
 
@@ -689,8 +772,36 @@ loop:
 		}
 	}
 
+	if c.activeSubagents != nil {
+		// Project committed takeover outcomes, not requested candidates:
+		// version-conditional evictions may be skipped. This is O(evictions),
+		// normally zero, and never rebuilds the global graph per launch.
+		for _, candidate := range reg.Evict {
+			row, exists, readErr := c.durable.Session(ctx, candidate.ID)
+			if readErr != nil {
+				// Registration is already committed and installed. Preserve the
+				// pre-commit projection conservatively; a later reconciliation or
+				// restart converges it, and never turn success into a retryable error.
+				c.reportError(ctx, fmt.Errorf("sessioncoord: refresh takeover candidate %s: %w", candidate.ID, readErr))
+				continue
+			}
+			if exists {
+				_, live := c.registry.current(candidate.ID)
+				c.activeSubagents.upsert(row, live)
+			} else {
+				c.activeSubagents.remove(candidate.ID)
+			}
+		}
+		session.ID = id // sparse durable fakes need the identity projected here
+		c.activeSubagents.upsert(session, runtime.Subscribed)
+		if reservationClaimed {
+			c.activeSubagents.release(req.ActiveSubagentReservation, true)
+			reservationConsumed = true
+		}
+	}
+
 	seq := c.outcomes.allocSeq() // stamp commit order before releasing c.mu
-	c.mu.Unlock()
+	phase2Unlock()
 
 	// Silent-loss guard: a conversation-bearing registration in an embedding
 	// that never configured takeover would silently forfeit conversation
@@ -816,10 +927,16 @@ func (c *Coordinator) drain(ctx context.Context, id centralstore.SessionID, gene
 	// generation check regardless.
 	exitObserved := false
 	defer func() {
-		// Remove and close this generation's entry if still current. If
-		// apply already removed it (Alive=false event) remove returns false
-		// and closeEntry is not called — no double-cancel.
-		if e, ok := c.registry.remove(id, generation); ok {
+		// Remove and close this generation's entry if still current. Serialize
+		// the registry edge with budget liveness so admission observes either
+		// the occupied slot or the released slot, never a split state.
+		c.mu.Lock()
+		e, ok := c.registry.remove(id, generation)
+		if ok && c.activeSubagents != nil {
+			c.activeSubagents.setLive(id, false)
+		}
+		c.mu.Unlock()
+		if ok {
 			closeEntry(e)
 		}
 	}()
@@ -971,8 +1088,15 @@ func (c *Coordinator) apply(ctx context.Context, id centralstore.SessionID, gene
 		}
 		// Exit facts committed (advance succeeded) before liveness removed.
 		// Canceling the stream propagates to the bufferEvents goroutine and
-		// the drain context, causing drain to exit its select loop.
-		if removed, yes := c.registry.remove(id, generation); yes {
+		// the drain context, causing drain to exit its select loop. Admission
+		// and slot release share the lifecycle mutex.
+		c.mu.Lock()
+		removed, yes := c.registry.remove(id, generation)
+		if yes && c.activeSubagents != nil {
+			c.activeSubagents.setLive(id, false)
+		}
+		c.mu.Unlock()
+		if yes {
 			closeEntry(removed)
 		}
 	}

--- a/services/gmuxd/internal/sessioncoord/dismiss.go
+++ b/services/gmuxd/internal/sessioncoord/dismiss.go
@@ -72,7 +72,9 @@ func (c *Coordinator) Dismiss(ctx context.Context, root centralstore.SessionID) 
 			}
 		}
 	}
+	memberSet := make(map[centralstore.SessionID]bool, len(members))
 	for _, id := range members {
+		memberSet[id] = true
 		if op, busy := c.ops[id]; busy {
 			c.mu.Unlock()
 			return nil, fmt.Errorf("%w: %s (%s)", ErrSubtreeBusy, id, op)
@@ -85,6 +87,10 @@ func (c *Coordinator) Dismiss(ctx context.Context, root centralstore.SessionID) 
 			c.mu.Unlock()
 			return nil, fmt.Errorf("%w: subtree member %s", ErrConvergencePending, id)
 		}
+	}
+	if c.activeSubagents != nil && c.activeSubagents.hasLaunchFrom(memberSet) {
+		c.mu.Unlock()
+		return nil, fmt.Errorf("%w: active-subagent launch reservation in subtree", ErrSubtreeBusy)
 	}
 
 	dismissed, result, err := c.durable.DismissSessionTree(ctx, root, c.now())
@@ -136,6 +142,9 @@ func (c *Coordinator) Remove(ctx context.Context, id centralstore.SessionID, obs
 	result, err := c.durable.RemoveSessionAtVersion(ctx, id, observed)
 	if err == nil {
 		c.invalidateVerdict(id) // the row is gone; its reconciliation verdict with it
+		if c.activeSubagents != nil {
+			c.activeSubagents.remove(id)
+		}
 	}
 	seq := c.outcomes.allocSeq() // stamp before releasing c.mu
 	c.mu.Unlock()

--- a/services/gmuxd/internal/sessioncoord/reconcile.go
+++ b/services/gmuxd/internal/sessioncoord/reconcile.go
@@ -321,6 +321,9 @@ func (c *Coordinator) Reconcile(ctx context.Context) ([]centralstore.SessionID, 
 			switch {
 			case removeErr == nil:
 				verdictsChanged = c.setVerdict(cand.ID, VerdictUnknown) || verdictsChanged
+				if c.activeSubagents != nil {
+					c.activeSubagents.remove(cand.ID)
+				}
 				removed = append(removed, cand.ID)
 				removedSeqs = append(removedSeqs, c.outcomes.allocSeq()) // stamp under c.mu
 				outcomes = append(outcomes, result)

--- a/services/gmuxd/internal/sessioncoord/reparent.go
+++ b/services/gmuxd/internal/sessioncoord/reparent.go
@@ -27,6 +27,32 @@ func (c *Coordinator) SetSessionParent(ctx context.Context, id centralstore.Sess
 		return centralstore.MutationResult{}, fmt.Errorf("sessioncoord: durable store does not support session reparenting")
 	}
 	result, err := reparenter.SetSessionParent(ctx, id, parent)
+	if err == nil && c.activeSubagents != nil {
+		c.activeSubagents.setParent(id, parent)
+	}
+	c.mu.Unlock()
+	if err == nil {
+		c.publish(ctx, result)
+	}
+	return result, err
+}
+
+// SetPromotion mutates the presentation-root boundary under the same lifecycle
+// mutex as launch admission and reparenting. The central store remains the
+// sole durable authority; the budget index is only a runtime projection.
+func (c *Coordinator) SetPromotion(ctx context.Context, id centralstore.SessionID, promoted bool, index *int) (centralstore.MutationResult, error) {
+	c.mu.Lock()
+	promoter, ok := c.durable.(interface {
+		SetPromotion(context.Context, centralstore.SessionID, bool, *int) (centralstore.MutationResult, error)
+	})
+	if !ok {
+		c.mu.Unlock()
+		return centralstore.MutationResult{}, fmt.Errorf("sessioncoord: durable store does not support session promotion")
+	}
+	result, err := promoter.SetPromotion(ctx, id, promoted, index)
+	if err == nil && c.activeSubagents != nil {
+		c.activeSubagents.setPromotion(id, promoted)
+	}
 	c.mu.Unlock()
 	if err == nil {
 		c.publish(ctx, result)


### PR DESCRIPTION
## Summary

- atomically reserve a host-local slot before every `gmux agent prompt --new` runner/PTY/session creation
- cap live local semantic-agent descendants at the current mutable behavioral/presentation root, defaulting `max_active_subagents` to 8 in `host.toml`
- move accounting with reparent/promote/demote, reconstruct it from durable ownership plus installed local generations, and release on startup failure or termination
- return HTTP 429 / `subagent_limit_reached` with actionable `gmux ls` guidance and CLI exit 1; independent top-level roots remain unlimited relative to each other

This is deliberately local-daemon authority only. It excludes the root, shell/process children, dead retained rows, and remote projections. It adds no per-root/UI override, depth/history budget, force bypass, queueing flag, prompt injection, or peer-distributed quota.

## Mechanism

The daemon maintains an incremental root/count index under the lifecycle mutex shared by registration and mutable ownership actions. A short-lived opaque receipt bridges pre-spawn admission to `/v1/register`; registration validates its exact direct parent and atomically converts it to installed liveness. Failed starts release the receipt, and generation removal releases the live slot.

## Evidence

- deterministic ownership/count tables: nested, promoted, reparented, dead, process, remote absence, orphan, cycle
- barrier-controlled 7/8 and 8/8 concurrent admission tests under `-race`
- registration conversion, startup-failure release, normal termination release, dismissal interlock, restart reconstruction
- real reservation HTTP handler and CLI request/refusal/exit behavior tests
- 1,000-session benchmark: 259–289 ns/op, 32 B/op, 1 alloc/op (no graph scan on admission)
- focused and full Go suites pass
- hot-package race suite passes
- `pnpm lint`, `pnpm build`, generated central-store check, and four-platform CGO-free cross-build pass

The local aggregate `pnpm test` has one unrelated environment-sensitive failure because the host-installed `pi --help` no longer matches `TestPiSubcommandsMatchHelp`; all adapter tests pass with that probe skipped, and all changed/relevant modules pass in full.

Full trace and commands: `.memory/report-active-subagent-budget.md`.
