### PR TITLE
feat(gmuxd): add best-effort ntfy notifications

### DIFF
--- a/apps/website/src/content/docs/planned/mobile-notifications.md
+++ b/apps/website/src/content/docs/planned/mobile-notifications.md
@@ -1,10 +1,10 @@
 ---
-title: Mobile Notifications
-description: Push notifications for mobile — current landscape and planned approach.
+title: Native Mobile Notifications
+description: Native gmux push notifications for mobile — current landscape and planned approach.
 ---
 
-:::note[Not implemented]
-This is a design sketch; nothing here has shipped.
+:::note[ntfy is available]
+gmux can send best-effort completion notifications to an existing [ntfy](https://ntfy.sh/) server and mobile app. See the [`[notifications.ntfy]` host configuration](/reference/host-toml/#notificationsntfy). The native gmux app described below has not shipped.
 :::
 
 ## The problem with Web Push on iOS

--- a/apps/website/src/content/docs/reference/host-toml.md
+++ b/apps/website/src/content/docs/reference/host-toml.md
@@ -33,6 +33,13 @@ devcontainers = true     # subscribe to Docker events, register gmux containers
 # Dead-session scrollback cache target.
 [sessions]
 scrollback_cache_mb = 256
+
+# Optional best-effort phone notifications via ntfy.
+# Use `chmod 600 ~/.config/gmux/host.toml` before enabling.
+[notifications.ntfy]
+enabled = false
+server_url = "https://ntfy.sh"
+topic = "gmux_USE_A_LONG_RANDOM_TOPIC"
 ```
 
 ## Node identity
@@ -86,6 +93,46 @@ The bind address is not configurable here — it is the `GMUXD_LISTEN` environme
 
 Session values must be non-negative.
 
+### `[notifications.ntfy]`
+
+Publishes a privacy-safe notification after gmux's existing completion grace period and presence checks. Publishing is **best effort**: gmux makes one asynchronous request with a short timeout. It does not retry, queue, persist, or replay notifications after restart. A network error, daemon shutdown, or busy publisher may lose a notification. Browser notifications continue independently.
+
+ntfy is configured on the daemon that owns the session. An aggregation host does not publish notifications for sessions projected from another host or devcontainer.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | `boolean` | `false` | Enable ntfy publishing. When enabled, `host.toml` must be readable only by its owner (`0600` or stricter). |
+| `server_url` | `string` | `"https://ntfy.sh"` | ntfy server origin. HTTP(S) only; no credentials, query, fragment, or sub-path. |
+| `topic` | `string` | none | Required when enabled. Use a long random topic; on an open server it acts as a secret. Letters, digits, `_`, and `-`; maximum 64 characters. |
+| `token` | `string` | none | Optional Bearer publish token. Mutually exclusive with Basic auth. HTTPS required. |
+| `username` / `password` | `string` | none | Optional Basic auth pair. Both are required together; HTTPS required. |
+| `priority` | `number` | `3` | ntfy priority from 1 to 5. |
+| `tags` | `string[]` | `[]` | Up to eight ntfy tags. |
+| `click_url` | `string` | none | Optional absolute HTTP(S) dashboard URL opened from the notification. Authentication must not be embedded in it. |
+| `timeout` | duration string | `"5s"` | Total timeout for the single publish attempt; 1–30 seconds. |
+
+The payload identifies only the host, adapter, and opaque session ID. gmux does not send prompts, transcript/output, commands, working directories, project names, or session titles. Credentials, the server URL, topic, payload, and response body are not logged.
+
+Example with a dedicated publish token:
+
+```toml
+[notifications.ntfy]
+enabled = true
+server_url = "https://ntfy.example.net"
+topic = "gmux_Q7f9x2mP4vN8kL3s"
+token = "tk_REPLACE_WITH_A_PUBLISH_ONLY_TOKEN"
+priority = 3
+tags = ["gmux", "white_check_mark"]
+click_url = "https://gmux.example.net/"
+timeout = "5s"
+```
+
+Before restarting gmuxd:
+
+```sh
+chmod 600 ~/.config/gmux/host.toml
+```
+
 ### `[tailscale]`
 
 | Field | Type | Default | Description |
@@ -111,6 +158,7 @@ The config file is strictly validated at startup. gmuxd refuses to start if:
 - **`port` is out of range** (must be 1–65535)
 - **`max_active_subagents` is zero, negative, or above 1024**
 - **A session limit is negative**, or a retention/cache value is too large to convert safely to its runtime duration or byte count
+- **ntfy settings are unsafe or malformed** — including a missing/invalid topic, unsupported URL, mixed authentication modes, credentials over plaintext HTTP, priority/tag/timeout violations, or an enabled config file with group/other permissions
 - **A TOML integer is outside the supported integer range**, or other TOML syntax is invalid
 
 This is intentional. Silent fallback to defaults is dangerous for security settings. See [Security](/security) for the reasoning.

--- a/services/gmuxd/cmd/gmuxd/notify_central.go
+++ b/services/gmuxd/cmd/gmuxd/notify_central.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/ntfy"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/presence"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/sessioncoord"
 	"nhooyr.io/websocket"
@@ -43,6 +44,7 @@ type notifySessionSnapshot struct {
 	UnreadToken string
 	Alive       bool
 	Title       string
+	Adapter     string
 	Start       string
 	ParentID    string
 }
@@ -52,6 +54,7 @@ type pendingCentralNotif struct {
 	notifType string
 	title     string
 	body      string
+	adapter   string
 	timer     *time.Timer
 	notifID   string
 }
@@ -61,9 +64,14 @@ type activeCentralNotif struct {
 	clientID  string
 }
 
+type externalNotifier interface {
+	Notify(ntfy.Message) bool
+}
+
 type centralNotifyRouter struct {
 	presence *presence.Table
 	config   notifyConfig
+	external externalNotifier
 
 	// deliveryMu linearizes a timer's complete pending→active→send transition
 	// with cancellation. Without it, cancellation can observe the gap after a
@@ -121,6 +129,7 @@ func notifySnapshot(o sessioncoord.Outcome) notifySessionSnapshot {
 		snap.Unread = o.Session.Unread
 		snap.UnreadToken = o.Session.UnreadToken
 		snap.Title = o.Session.Title
+		snap.Adapter = o.Session.Adapter
 		snap.Start = fmtMillisPtr(o.Session.StartedAt)
 		if o.Session.LaunchedFromSessionID != nil {
 			snap.ParentID = string(*o.Session.LaunchedFromSessionID)
@@ -184,10 +193,10 @@ func (r *centralNotifyRouter) handleOutcome(o sessioncoord.Outcome) {
 	// An intentional stop is not a completion (ADR 0027): no "finished"
 	// notification for a turn the user themselves ended.
 	if transitionedInactive && cur.Alive && !cur.Interrupted {
-		r.scheduleNotification(id, "finished", cur.Title, formatFinishedBodyCentral(cur.Start))
+		r.scheduleNotification(id, "finished", cur.Title, formatFinishedBodyCentral(cur.Start), cur.Adapter)
 	}
 	if cur.Unread && (!prev.Unread || prev.UnreadToken != cur.UnreadToken) {
-		r.scheduleNotification(id, "unread", cur.Title, "New output")
+		r.scheduleNotification(id, "unread", cur.Title, "New output", cur.Adapter)
 	}
 }
 
@@ -219,7 +228,7 @@ func (r *centralNotifyRouter) genID() string {
 	return fmt.Sprintf("notif-%d", r.nextID)
 }
 
-func (r *centralNotifyRouter) scheduleNotification(sessionID, notifType, title, body string) {
+func (r *centralNotifyRouter) scheduleNotification(sessionID, notifType, title, body, adapter string) {
 	if r.presence.AnyViewing(sessionID) {
 		return
 	}
@@ -230,11 +239,12 @@ func (r *centralNotifyRouter) scheduleNotification(sessionID, notifType, title, 
 			existing.notifType = notifType
 			existing.title = title
 			existing.body = body
+			existing.adapter = adapter
 		}
 		return
 	}
 	notifID := r.genID()
-	p := &pendingCentralNotif{sessionID: sessionID, notifType: notifType, title: title, body: body, notifID: notifID}
+	p := &pendingCentralNotif{sessionID: sessionID, notifType: notifType, title: title, body: body, adapter: adapter, notifID: notifID}
 	p.timer = time.AfterFunc(r.config.GracePeriod, func() { r.firePending(sessionID) })
 	r.pending[sessionID] = p
 }
@@ -268,6 +278,13 @@ func (r *centralNotifyRouter) firePending(sessionID string) {
 	if r.presence.AnyViewing(sessionID) {
 		return
 	}
+	if r.external != nil {
+		kind := ntfy.KindUnread
+		if p.notifType == "finished" {
+			kind = ntfy.KindFinished
+		}
+		r.external.Notify(ntfy.Message{Kind: kind, SessionID: sessionID, Adapter: p.adapter})
+	}
 	target := r.presence.BestNotifyTarget(r.config.IdleThreshold)
 	if target == nil {
 		log.Printf("notify: no target for session %s", sessionID)
@@ -286,6 +303,9 @@ func (r *centralNotifyRouter) firePending(sessionID string) {
 }
 
 func (r *centralNotifyRouter) fireCoalesced(count int) {
+	if r.external != nil {
+		r.external.Notify(ntfy.Message{Kind: ntfy.KindCoalesced, Count: count})
+	}
 	target := r.presence.BestNotifyTarget(r.config.IdleThreshold)
 	if target == nil {
 		log.Printf("notify: no target for coalesced notification (%d sessions)", count)

--- a/services/gmuxd/cmd/gmuxd/notify_central_ntfy_test.go
+++ b/services/gmuxd/cmd/gmuxd/notify_central_ntfy_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/ntfy"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/presence"
+)
+
+type recordingExternalNotifier struct {
+	messages chan ntfy.Message
+}
+
+func (n *recordingExternalNotifier) Notify(message ntfy.Message) bool {
+	n.messages <- message
+	return true
+}
+
+func TestCentralNotifierSendsExternalWithoutBrowserTarget(t *testing.T) {
+	external := &recordingExternalNotifier{messages: make(chan ntfy.Message, 1)}
+	router := newCentralNotifyRouter(presence.New(presence.Callbacks{}), notifyConfig{GracePeriod: time.Hour, IdleThreshold: time.Minute})
+	router.external = external
+	router.scheduleNotification("session-1", "finished", "private prompt title", "private browser body", "pi")
+
+	router.firePending("session-1")
+
+	select {
+	case got := <-external.messages:
+		if got.Kind != ntfy.KindFinished || got.SessionID != "session-1" || got.Adapter != "pi" {
+			t.Fatalf("external message = %+v", got)
+		}
+	default:
+		t.Fatal("external notification was coupled to browser target")
+	}
+}
+
+func TestCentralNotifierSendsCoalescedExternalWithoutBrowserTarget(t *testing.T) {
+	external := &recordingExternalNotifier{messages: make(chan ntfy.Message, 1)}
+	router := newCentralNotifyRouter(presence.New(presence.Callbacks{}), notifyConfig{GracePeriod: time.Hour, IdleThreshold: time.Minute})
+	router.external = external
+	for _, id := range []string{"one", "two", "three"} {
+		router.scheduleNotification(id, "finished", "private", "private", "pi")
+	}
+
+	router.firePending("one")
+
+	select {
+	case got := <-external.messages:
+		if got.Kind != ntfy.KindCoalesced || got.Count != 3 || got.SessionID != "" || got.Adapter != "" {
+			t.Fatalf("external message = %+v", got)
+		}
+	default:
+		t.Fatal("coalesced external notification was not sent")
+	}
+}

--- a/services/gmuxd/cmd/gmuxd/notify_central_parent_test.go
+++ b/services/gmuxd/cmd/gmuxd/notify_central_parent_test.go
@@ -300,7 +300,7 @@ func TestCentralReadRouteWaitsForCommitToInstallFenceBeforeCancellation(t *testi
 	<-fencedStore.committed // durable commit landed; live owner is not installed
 
 	router := newParentNotifyTestRouter(t)
-	router.scheduleNotification(string(id), "unread", "Child", "New output")
+	router.scheduleNotification(string(id), "unread", "Child", "New output", "")
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/v1/sessions/"+string(id)+"/read?token="+token, nil)
 	originalOwnerResolution := acknowledgementRuntime
@@ -360,7 +360,7 @@ func TestCentralReadRouteCancelsFocusedInteractionAttention(t *testing.T) {
 		t.Fatal(err)
 	}
 	r := newParentNotifyTestRouter(t)
-	r.scheduleNotification(string(row.ID), "unread", "Child", "New output")
+	r.scheduleNotification(string(row.ID), "unread", "Child", "New output", "")
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/v1/sessions/child/read?token=", nil)
 	handleCentralSessionAction(rec, req, boot, newSSEFanout(), nil, nil, nil, "", r)
@@ -384,7 +384,7 @@ func TestCentralReadRouteRejectsDelayedAcknowledgementForNewerCompletion(t *test
 		t.Fatal(err)
 	}
 	router := newParentNotifyTestRouter(t)
-	router.scheduleNotification(string(row.ID), "unread", "Child", "New output")
+	router.scheduleNotification(string(row.ID), "unread", "Child", "New output", "")
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/v1/sessions/child/read?token=turn-1", nil)
 	handleCentralSessionAction(rec, req, boot, newSSEFanout(), nil, nil, nil, "", router)
@@ -419,7 +419,7 @@ func TestCentralNotifyUnreadConsumptionCancelsPending(t *testing.T) {
 func TestCentralNotifyCancellationLinearizesWithPendingDelivery(t *testing.T) {
 	r := newParentNotifyTestRouter(t)
 	r.presence.Add(&presence.Client{ID: "viewer", NotificationPermission: "granted"})
-	r.scheduleNotification("child", "finished", "Child", "Task finished")
+	r.scheduleNotification("child", "finished", "Child", "Task finished", "")
 
 	dequeued := make(chan struct{})
 	releaseDelivery := make(chan struct{})

--- a/services/gmuxd/cmd/gmuxd/serve_central.go
+++ b/services/gmuxd/cmd/gmuxd/serve_central.go
@@ -33,6 +33,7 @@ import (
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/identity"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/netauth"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/nodeid"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/ntfy"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/peering"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/presence"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/projects"
@@ -318,6 +319,29 @@ func serveCentral(stderr io.Writer, replace bool) int {
 	notifier = newCentralNotifyRouter(presenceTable, defaultNotifyConfig())
 	daemonCtx, daemonCancel := context.WithCancel(context.Background())
 	defer daemonCancel()
+	if cfg.Notifications.Ntfy.Enabled {
+		hostname, _ := os.Hostname()
+		ntfyCfg := cfg.Notifications.Ntfy
+		publisher, publisherErr := ntfy.New(ntfy.Config{
+			ServerURL: ntfyCfg.ServerURL,
+			Topic:     ntfyCfg.Topic,
+			Token:     ntfyCfg.Token,
+			Username:  ntfyCfg.Username,
+			Password:  ntfyCfg.Password,
+			Priority:  ntfyCfg.Priority,
+			Tags:      append([]string(nil), ntfyCfg.Tags...),
+			ClickURL:  ntfyCfg.ClickURL,
+			Timeout:   time.Duration(ntfyCfg.Timeout),
+			Hostname:  hostname,
+		})
+		if publisherErr != nil {
+			_, _ = fmt.Fprintf(stderr, "gmuxd: %v\n", publisherErr)
+			return 1
+		}
+		defer publisher.Close()
+		notifier.external = publisher
+		log.Printf("ntfy: enabled (best_effort=true)")
+	}
 	go notifier.Run(daemonCtx, seed, events)
 
 	commonMux := http.NewServeMux()

--- a/services/gmuxd/internal/config/config.go
+++ b/services/gmuxd/internal/config/config.go
@@ -12,9 +12,11 @@ import (
 	"log"
 	"math"
 	"net"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 	"time"
 
@@ -30,9 +32,10 @@ type Config struct {
 	// live semantic-agent descendants launched through gmux (default 8).
 	MaxActiveSubagents int `toml:"max_active_subagents"`
 
-	Tailscale TailscaleConfig `toml:"tailscale"`
-	Discovery DiscoveryConfig `toml:"discovery"`
-	Sessions  SessionsConfig  `toml:"sessions"`
+	Tailscale     TailscaleConfig     `toml:"tailscale"`
+	Discovery     DiscoveryConfig     `toml:"discovery"`
+	Sessions      SessionsConfig      `toml:"sessions"`
+	Notifications NotificationsConfig `toml:"notifications"`
 
 	// NOTE: there is no `[[peers]]` array (removed in ADR 0007). Manually
 	// added peers are now runtime state in state.db, managed via the
@@ -90,6 +93,38 @@ type SessionsConfig struct {
 	RetentionDays     int `toml:"retention_days"`
 	RetentionMax      int `toml:"retention_max"`
 	ScrollbackCacheMB int `toml:"scrollback_cache_mb"`
+}
+
+// NotificationsConfig controls external notification sinks.
+type NotificationsConfig struct {
+	Ntfy NtfyConfig `toml:"ntfy"`
+}
+
+// Duration is a TOML string duration such as "5s".
+type Duration time.Duration
+
+// UnmarshalText implements encoding.TextUnmarshaler for TOML strings.
+func (d *Duration) UnmarshalText(text []byte) error {
+	parsed, err := time.ParseDuration(string(text))
+	if err != nil {
+		return err
+	}
+	*d = Duration(parsed)
+	return nil
+}
+
+// NtfyConfig controls best-effort publishing to an ntfy topic.
+type NtfyConfig struct {
+	Enabled   bool     `toml:"enabled"`
+	ServerURL string   `toml:"server_url"`
+	Topic     string   `toml:"topic"`
+	Token     string   `toml:"token"`
+	Username  string   `toml:"username"`
+	Password  string   `toml:"password"`
+	Priority  int      `toml:"priority"`
+	Tags      []string `toml:"tags"`
+	ClickURL  string   `toml:"click_url"`
+	Timeout   Duration `toml:"timeout"`
 }
 
 // TailscaleConfig controls the optional tailscale (tsnet) listener.
@@ -177,7 +212,11 @@ func Load() (Config, error) {
 // tagNameRe matches valid Tailscale ACL tag names: they must start with
 // a letter and contain only lowercase letters, digits, and hyphens.
 // https://tailscale.com/kb/1068/tags
-var tagNameRe = regexp.MustCompile(`^[a-z][a-z0-9-]*$`)
+var (
+	tagNameRe   = regexp.MustCompile(`^[a-z][a-z0-9-]*$`)
+	ntfyTopicRe = regexp.MustCompile(`^[-_A-Za-z0-9]{1,64}$`)
+	ntfyTagRe   = regexp.MustCompile(`^[A-Za-z0-9_+-]{1,64}$`)
+)
 
 func validate(cfg Config) error {
 	// Port range.
@@ -216,7 +255,82 @@ func validate(cfg Config) error {
 		}
 	}
 
+	if err := validateNtfy(cfg.Notifications.Ntfy); err != nil {
+		return err
+	}
 	return nil
+}
+
+func validateNtfy(cfg NtfyConfig) error {
+	server, err := parseNtfyURL("notifications.ntfy.server_url", cfg.ServerURL, false)
+	if err != nil {
+		return err
+	}
+	if cfg.Topic != "" && !ntfyTopicRe.MatchString(cfg.Topic) {
+		return fmt.Errorf("notifications.ntfy.topic must contain 1-64 letters, digits, hyphens, or underscores")
+	}
+	if cfg.Enabled && cfg.Topic == "" {
+		return fmt.Errorf("notifications.ntfy.topic is required when enabled")
+	}
+	if cfg.Token != "" && (cfg.Username != "" || cfg.Password != "") {
+		return fmt.Errorf("notifications.ntfy.token cannot be combined with username/password")
+	}
+	if (cfg.Username == "") != (cfg.Password == "") {
+		return fmt.Errorf("notifications.ntfy.username and password must be set together")
+	}
+	if server.Scheme == "http" && (cfg.Token != "" || cfg.Password != "") {
+		return fmt.Errorf("notifications.ntfy credentials require HTTPS")
+	}
+	if cfg.Priority < 1 || cfg.Priority > 5 {
+		return fmt.Errorf("notifications.ntfy.priority must be between 1 and 5")
+	}
+	if len(cfg.Tags) > 8 {
+		return fmt.Errorf("notifications.ntfy.tags must contain at most 8 tags")
+	}
+	for _, tag := range cfg.Tags {
+		if !ntfyTagRe.MatchString(tag) {
+			return fmt.Errorf("notifications.ntfy.tags must contain only 1-64 letters, digits, plus, hyphen, or underscore characters")
+		}
+	}
+	if cfg.ClickURL != "" {
+		if _, err := parseNtfyURL("notifications.ntfy.click_url", cfg.ClickURL, true); err != nil {
+			return err
+		}
+		if len(cfg.ClickURL) > 2048 {
+			return fmt.Errorf("notifications.ntfy.click_url must be at most 2048 bytes")
+		}
+	}
+	timeout := time.Duration(cfg.Timeout)
+	if timeout < time.Second || timeout > 30*time.Second {
+		return fmt.Errorf("notifications.ntfy.timeout must be between 1s and 30s")
+	}
+	if cfg.Enabled && runtime.GOOS != "windows" {
+		info, err := os.Stat(Path())
+		if err != nil {
+			return fmt.Errorf("notifications.ntfy: checking host.toml permissions: %w", err)
+		}
+		if info.Mode().Perm()&0o077 != 0 {
+			return fmt.Errorf("notifications.ntfy requires host.toml permissions 0600 or stricter")
+		}
+	}
+	return nil
+}
+
+func parseNtfyURL(field, raw string, allowPath bool) (*url.URL, error) {
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return nil, fmt.Errorf("%s must be an absolute HTTP(S) URL", field)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return nil, fmt.Errorf("%s must use HTTP or HTTPS", field)
+	}
+	if u.User != nil || u.RawQuery != "" || u.Fragment != "" {
+		return nil, fmt.Errorf("%s must not contain userinfo, query, or fragment", field)
+	}
+	if !allowPath && u.Path != "" && u.Path != "/" {
+		return nil, fmt.Errorf("%s must not contain a path", field)
+	}
+	return u, nil
 }
 
 // effectiveIntMax returns the largest value that both fits in an int and does
@@ -292,6 +406,11 @@ func defaults() Config {
 			RetentionMax:      200,
 			ScrollbackCacheMB: 256,
 		},
+		Notifications: NotificationsConfig{Ntfy: NtfyConfig{
+			ServerURL: "https://ntfy.sh",
+			Priority:  3,
+			Timeout:   Duration(5 * time.Second),
+		}},
 	}
 }
 

--- a/services/gmuxd/internal/config/config_test.go
+++ b/services/gmuxd/internal/config/config_test.go
@@ -99,6 +99,110 @@ func TestLoadValidatesMaxActiveSubagents(t *testing.T) {
 	}
 }
 
+func TestLoadNtfy(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	writeConfig(t, dir, `
+[notifications.ntfy]
+enabled = true
+server_url = "https://ntfy.example.net"
+topic = "gmux_Q7f9x2mP4vN8kL3s"
+token = "secret-token"
+priority = 4
+tags = ["gmux", "white_check_mark"]
+click_url = "https://gmux.example.net/"
+timeout = "7s"
+`)
+	if err := os.Chmod(Path(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := cfg.Notifications.Ntfy
+	if !got.Enabled || got.ServerURL != "https://ntfy.example.net" || got.Topic != "gmux_Q7f9x2mP4vN8kL3s" || got.Token != "secret-token" {
+		t.Fatalf("ntfy identity/auth not loaded: %+v", got)
+	}
+	if got.Priority != 4 || time.Duration(got.Timeout) != 7*time.Second || strings.Join(got.Tags, ",") != "gmux,white_check_mark" || got.ClickURL != "https://gmux.example.net/" {
+		t.Fatalf("ntfy options not loaded: %+v", got)
+	}
+}
+
+func TestLoadNtfyDefaults(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := cfg.Notifications.Ntfy
+	if got.Enabled || got.ServerURL != "https://ntfy.sh" || got.Priority != 3 || time.Duration(got.Timeout) != 5*time.Second {
+		t.Fatalf("ntfy defaults = %+v", got)
+	}
+}
+
+func TestLoadNtfyValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{"missing topic", `enabled = true`, "topic is required"},
+		{"bad topic", `topic = "spaces are bad"`, "topic must contain"},
+		{"server path", `server_url = "https://example.net/ntfy"`, "must not contain a path"},
+		{"server userinfo", `server_url = "https://user:pass@example.net"`, "must not contain userinfo"},
+		{"bad scheme", `server_url = "ftp://example.net"`, "must use HTTP or HTTPS"},
+		{"mixed auth", "token = \"tok\"\nusername = \"user\"\npassword = \"pass\"", "cannot be combined"},
+		{"half basic auth", `username = "user"`, "must be set together"},
+		{"plaintext bearer", "server_url = \"http://example.net\"\ntoken = \"tok\"", "credentials require HTTPS"},
+		{"bad priority", `priority = 6`, "priority must be between"},
+		{"bad tag", `tags = ["has,comma"]`, "tags must contain only"},
+		{"bad timeout", `timeout = "500ms"`, "timeout must be between"},
+		{"bad click", `click_url = "javascript:alert(1)"`, "absolute HTTP(S)"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			t.Setenv("XDG_CONFIG_HOME", dir)
+			writeConfig(t, dir, "[notifications.ntfy]\n"+tt.body+"\n")
+			_, err := Load()
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("Load() error = %v, want containing %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestLoadNtfyEnabledRequiresPrivateConfig(t *testing.T) {
+	if os.PathSeparator == '\\' {
+		t.Skip("Unix permission semantics")
+	}
+	for _, mode := range []os.FileMode{0o640, 0o604, 0o644} {
+		t.Run(mode.String(), func(t *testing.T) {
+			dir := t.TempDir()
+			t.Setenv("XDG_CONFIG_HOME", dir)
+			writeConfig(t, dir, "[notifications.ntfy]\nenabled = true\ntopic = \"secret_topic\"\n")
+			if err := os.Chmod(Path(), mode); err != nil {
+				t.Fatal(err)
+			}
+
+			_, err := Load()
+			if err == nil || !strings.Contains(err.Error(), "permissions 0600") {
+				t.Fatalf("Load() error = %v, want private-permissions error", err)
+			}
+		})
+	}
+}
+
+func TestLoadNtfyDisabledDoesNotRequirePrivateConfig(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	writeConfig(t, dir, "[notifications.ntfy]\nenabled = false\ntopic = \"secret_topic\"\n")
+	if _, err := Load(); err != nil {
+		t.Fatalf("disabled ntfy config should not require mode 0600: %v", err)
+	}
+}
 func TestLoadSessions(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", dir)

--- a/services/gmuxd/internal/ntfy/publisher.go
+++ b/services/gmuxd/internal/ntfy/publisher.go
@@ -1,0 +1,285 @@
+// Package ntfy publishes privacy-safe, best-effort notifications to ntfy.
+package ntfy
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+	"unicode"
+	"unicode/utf8"
+)
+
+const (
+	defaultConcurrency = 4
+	maxResponseBytes   = 64 << 10
+	busyLogInterval    = time.Minute
+)
+
+// Kind identifies the attention event without carrying session content.
+type Kind string
+
+const (
+	KindFinished  Kind = "finished"
+	KindUnread    Kind = "unread"
+	KindCoalesced Kind = "coalesced"
+)
+
+// Message contains only the privacy-safe facts used by the ntfy formatter.
+type Message struct {
+	Kind      Kind
+	SessionID string
+	Adapter   string
+	Count     int
+}
+
+// Config is the validated ntfy publisher configuration.
+type Config struct {
+	ServerURL string
+	Topic     string
+	Token     string
+	Username  string
+	Password  string
+	Priority  int
+	Tags      []string
+	ClickURL  string
+	Timeout   time.Duration
+	Hostname  string
+}
+
+// Option is a test seam for Publisher construction.
+type Option func(*options)
+
+type options struct {
+	transport   http.RoundTripper
+	logf        func(string, ...any)
+	concurrency int
+}
+
+// WithTransport replaces the HTTP transport. It is intended for tests.
+func WithTransport(transport http.RoundTripper) Option {
+	return func(opts *options) { opts.transport = transport }
+}
+
+// WithLogger replaces the package logger. It is intended for tests.
+func WithLogger(logf func(string, ...any)) Option {
+	return func(opts *options) { opts.logf = logf }
+}
+
+// WithConcurrency replaces the in-flight request limit. It is intended for tests.
+func WithConcurrency(limit int) Option {
+	return func(opts *options) { opts.concurrency = limit }
+}
+
+// Publisher makes at most one asynchronous HTTP attempt per accepted message.
+// It has no waiting queue, retries, or persistent state.
+type Publisher struct {
+	endpoint *url.URL
+	config   Config
+	client   *http.Client
+	logf     func(string, ...any)
+	sem      chan struct{}
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	mu     sync.Mutex
+	closed bool
+	wg     sync.WaitGroup
+
+	lastBusyLog atomic.Int64
+}
+
+// New constructs a publisher without making a network request.
+func New(cfg Config, optionsList ...Option) (*Publisher, error) {
+	server, err := url.Parse(cfg.ServerURL)
+	if err != nil || server.Scheme == "" || server.Host == "" {
+		return nil, errors.New("ntfy: invalid server URL")
+	}
+	endpoint := *server
+	endpoint.Path = "/" + cfg.Topic
+	endpoint.RawPath = ""
+	endpoint.RawQuery = ""
+	endpoint.Fragment = ""
+
+	opts := options{logf: log.Printf, concurrency: defaultConcurrency}
+	if transport, ok := http.DefaultTransport.(*http.Transport); ok {
+		opts.transport = transport.Clone()
+	} else {
+		opts.transport = http.DefaultTransport
+	}
+	for _, option := range optionsList {
+		option(&opts)
+	}
+	if opts.concurrency < 1 {
+		return nil, errors.New("ntfy: concurrency must be positive")
+	}
+	if opts.logf == nil {
+		opts.logf = func(string, ...any) {}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	return &Publisher{
+		endpoint: &endpoint,
+		config:   cfg,
+		client: &http.Client{
+			Transport: opts.transport,
+			Timeout:   cfg.Timeout,
+			CheckRedirect: func(*http.Request, []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		},
+		logf:   opts.logf,
+		sem:    make(chan struct{}, opts.concurrency),
+		ctx:    ctx,
+		cancel: cancel,
+	}, nil
+}
+
+// Notify starts one best-effort publish attempt without waiting for a slot or
+// for HTTP. It returns false when the publisher is closed or all slots are busy.
+func (p *Publisher) Notify(message Message) bool {
+	p.mu.Lock()
+	if p.closed {
+		p.mu.Unlock()
+		return false
+	}
+	select {
+	case p.sem <- struct{}{}:
+		p.wg.Add(1)
+		p.mu.Unlock()
+	case <-p.ctx.Done():
+		p.mu.Unlock()
+		return false
+	default:
+		p.mu.Unlock()
+		p.logBusy()
+		return false
+	}
+
+	go func() {
+		defer func() {
+			<-p.sem
+			p.wg.Done()
+		}()
+		if class := p.publish(p.ctx, message); class != "" {
+			p.logf("ntfy: publish failed class=%s", class)
+		}
+	}()
+	return true
+}
+
+// Close cancels in-flight requests and waits for their goroutines. Future
+// notifications are dropped.
+func (p *Publisher) Close() {
+	p.mu.Lock()
+	if !p.closed {
+		p.closed = true
+		p.cancel()
+	}
+	p.mu.Unlock()
+	p.wg.Wait()
+}
+
+func (p *Publisher) publish(ctx context.Context, message Message) string {
+	title, body := formatMessage(p.config.Hostname, message)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.endpoint.String(), bytes.NewBufferString(body))
+	if err != nil {
+		return "request"
+	}
+	req.Header.Set("Content-Type", "text/plain; charset=utf-8")
+	req.Header.Set("Title", title)
+	req.Header.Set("Priority", strconv.Itoa(p.config.Priority))
+	if len(p.config.Tags) > 0 {
+		req.Header.Set("Tags", strings.Join(p.config.Tags, ","))
+	}
+	if p.config.ClickURL != "" {
+		req.Header.Set("Click", p.config.ClickURL)
+	}
+	if p.config.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+p.config.Token)
+	} else if p.config.Username != "" {
+		req.SetBasicAuth(p.config.Username, p.config.Password)
+	}
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return "canceled"
+		}
+		if errors.Is(err, context.DeadlineExceeded) {
+			return "timeout"
+		}
+		return "network"
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, maxResponseBytes))
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return ""
+	}
+	return "http_" + strconv.Itoa(resp.StatusCode)
+}
+
+func (p *Publisher) logBusy() {
+	now := time.Now().UnixNano()
+	last := p.lastBusyLog.Load()
+	if last != 0 && time.Duration(now-last) < busyLogInterval {
+		return
+	}
+	if p.lastBusyLog.CompareAndSwap(last, now) {
+		p.logf("ntfy: publish dropped class=busy")
+	}
+}
+
+func formatMessage(host string, message Message) (string, string) {
+	host = cleanText(host)
+	if host == "" {
+		host = "this host"
+	}
+	if message.Kind == KindCoalesced {
+		count := message.Count
+		if count < 1 {
+			count = 1
+		}
+		return "gmux", truncateUTF8(fmt.Sprintf("Host %s · %d sessions need attention.", host, count), 512)
+	}
+	adapter := cleanText(message.Adapter)
+	if adapter == "" {
+		adapter = "gmux"
+	}
+	sessionID := cleanText(message.SessionID)
+	title := "gmux: new output"
+	if message.Kind == KindFinished {
+		title = "gmux: task finished"
+	}
+	body := fmt.Sprintf("Host %s · %s session %s needs attention.", host, adapter, sessionID)
+	return truncateUTF8(title, 128), truncateUTF8(body, 512)
+}
+
+func cleanText(value string) string {
+	return strings.TrimSpace(strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) {
+			return ' '
+		}
+		return r
+	}, value))
+}
+
+func truncateUTF8(value string, limit int) string {
+	if len(value) <= limit {
+		return value
+	}
+	value = value[:limit]
+	for !utf8.ValidString(value) {
+		value = value[:len(value)-1]
+	}
+	return value
+}

--- a/services/gmuxd/internal/ntfy/publisher_test.go
+++ b/services/gmuxd/internal/ntfy/publisher_test.go
@@ -1,0 +1,268 @@
+package ntfy
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestPublisherSendsPrivacySafeRequest(t *testing.T) {
+	request := make(chan *http.Request, 1)
+	body := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		data, _ := io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusNoContent)
+		request <- r.Clone(context.Background())
+		body <- string(data)
+	}))
+	defer server.Close()
+
+	publisher := newTestPublisher(t, Config{
+		ServerURL: server.URL,
+		Topic:     "gmux_secret_topic",
+		Token:     "secret-token",
+		Priority:  4,
+		Tags:      []string{"gmux", "white_check_mark"},
+		ClickURL:  "https://gmux.example.net/",
+		Timeout:   time.Second,
+		Hostname:  "desktop",
+	})
+	defer publisher.Close()
+
+	if !publisher.Notify(Message{Kind: KindFinished, SessionID: "1vshk4fu", Adapter: "pi"}) {
+		t.Fatal("Notify() dropped request")
+	}
+
+	select {
+	case got := <-request:
+		if got.Method != http.MethodPost || got.URL.Path != "/gmux_secret_topic" {
+			t.Errorf("request = %s %s", got.Method, got.URL.Path)
+		}
+		if got.Header.Get("Content-Type") != "text/plain; charset=utf-8" {
+			t.Errorf("Content-Type = %q", got.Header.Get("Content-Type"))
+		}
+		if got.Header.Get("Title") != "gmux: task finished" || got.Header.Get("Priority") != "4" {
+			t.Errorf("notification headers = %#v", got.Header)
+		}
+		if got.Header.Get("Tags") != "gmux,white_check_mark" || got.Header.Get("Click") != "https://gmux.example.net/" {
+			t.Errorf("optional headers = %#v", got.Header)
+		}
+		if got.Header.Get("Authorization") != "Bearer secret-token" {
+			t.Errorf("Authorization = %q", got.Header.Get("Authorization"))
+		}
+	case <-time.After(time.Second):
+		t.Fatal("request not received")
+	}
+	if got := <-body; got != "Host desktop · pi session 1vshk4fu needs attention." {
+		t.Errorf("body = %q", got)
+	}
+}
+
+func TestPublisherBasicAuthAndUnread(t *testing.T) {
+	got := make(chan struct {
+		auth  string
+		title string
+		body  string
+	}, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+		got <- struct {
+			auth  string
+			title string
+			body  string
+		}{r.Header.Get("Authorization"), r.Header.Get("Title"), string(body)}
+	}))
+	defer server.Close()
+
+	publisher := newTestPublisher(t, Config{ServerURL: server.URL, Topic: "topic", Username: "user", Password: "pass", Priority: 3, Timeout: time.Second, Hostname: "host"})
+	defer publisher.Close()
+	publisher.Notify(Message{Kind: KindUnread, SessionID: "abc", Adapter: "shell"})
+
+	result := <-got
+	if result.auth != "Basic dXNlcjpwYXNz" || result.title != "gmux: new output" || result.body != "Host host · shell session abc needs attention." {
+		t.Fatalf("request = %+v", result)
+	}
+}
+
+func TestPublisherCoalesced(t *testing.T) {
+	got := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+		got <- r.Header.Get("Title") + "\n" + string(body)
+	}))
+	defer server.Close()
+
+	publisher := newTestPublisher(t, Config{ServerURL: server.URL, Topic: "topic", Priority: 3, Timeout: time.Second, Hostname: "host"})
+	defer publisher.Close()
+	publisher.Notify(Message{Kind: KindCoalesced, Count: 4})
+	if value := <-got; value != "gmux\nHost host · 4 sessions need attention." {
+		t.Fatalf("notification = %q", value)
+	}
+}
+
+func TestPublisherDoesNotFollowRedirectOrRetry(t *testing.T) {
+	var mu sync.Mutex
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requests++
+		mu.Unlock()
+		if r.URL.Path == "/topic" {
+			http.Redirect(w, r, "/credential-target", http.StatusTemporaryRedirect)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+	logs := make(chan string, 1)
+	publisher := newTestPublisher(t, Config{ServerURL: server.URL, Topic: "topic", Token: "secret", Priority: 3, Timeout: time.Second}, WithLogger(func(format string, args ...any) {
+		logs <- fmt.Sprintf(format, args...)
+	}))
+	defer publisher.Close()
+
+	publisher.Notify(Message{Kind: KindUnread, SessionID: "abc"})
+	if logLine := <-logs; logLine != "ntfy: publish failed class=http_307" {
+		t.Fatalf("log = %q", logLine)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if requests != 1 {
+		t.Fatalf("requests = %d, want 1", requests)
+	}
+}
+
+func TestPublisherTimeoutMakesOneAttemptAndRedactsError(t *testing.T) {
+	var mu sync.Mutex
+	requests := 0
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requests++
+		mu.Unlock()
+		<-release
+	}))
+	defer server.Close()
+	defer close(release)
+	logs := make(chan string, 1)
+	publisher := newTestPublisher(t, Config{ServerURL: server.URL, Topic: "secret-topic", Token: "distinctive-token", Priority: 3, Timeout: 30 * time.Millisecond}, WithLogger(func(format string, args ...any) {
+		logs <- fmt.Sprintf(format, args...)
+	}))
+	defer publisher.Close()
+
+	publisher.Notify(Message{Kind: KindUnread, SessionID: "abc"})
+	logLine := <-logs
+	if !strings.Contains(logLine, "class=timeout") || strings.Contains(logLine, "distinctive-token") || strings.Contains(logLine, "secret-topic") {
+		t.Fatalf("unsafe/unexpected log = %q", logLine)
+	}
+	time.Sleep(60 * time.Millisecond)
+	mu.Lock()
+	defer mu.Unlock()
+	if requests != 1 {
+		t.Fatalf("requests = %d, want exactly one", requests)
+	}
+}
+
+func TestPublisherNotifyIsNonBlockingAndCloseCancelsRequest(t *testing.T) {
+	started := make(chan struct{})
+	canceled := make(chan struct{})
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		close(started)
+		<-req.Context().Done()
+		close(canceled)
+		return nil, req.Context().Err()
+	})
+	publisher := newTestPublisher(t, Config{ServerURL: "https://example.test", Topic: "topic", Priority: 3, Timeout: time.Minute}, WithTransport(transport), WithLogger(func(string, ...any) {}))
+
+	returned := make(chan bool, 1)
+	go func() {
+		returned <- publisher.Notify(Message{Kind: KindUnread, SessionID: "first"})
+	}()
+	select {
+	case accepted := <-returned:
+		if !accepted {
+			t.Fatal("Notify() unexpectedly dropped request")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Notify() blocked on HTTP")
+	}
+	<-started
+
+	closed := make(chan struct{})
+	go func() {
+		publisher.Close()
+		close(closed)
+	}()
+	select {
+	case <-canceled:
+	case <-time.After(time.Second):
+		t.Fatal("Close() did not cancel the request")
+	}
+	select {
+	case <-closed:
+	case <-time.After(time.Second):
+		t.Fatal("Close() did not join the request goroutine")
+	}
+}
+
+func TestPublisherDropsWhenBusyWithoutQueueing(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(started)
+		<-release
+	}))
+	defer server.Close()
+	logs := make(chan string, 1)
+	publisher := newTestPublisher(t, Config{ServerURL: server.URL, Topic: "topic", Priority: 3, Timeout: time.Minute}, WithConcurrency(1), WithLogger(func(format string, args ...any) {
+		logs <- fmt.Sprintf(format, args...)
+	}))
+
+	if !publisher.Notify(Message{Kind: KindUnread, SessionID: "first"}) {
+		t.Fatal("first request dropped")
+	}
+	<-started
+	if publisher.Notify(Message{Kind: KindUnread, SessionID: "second"}) {
+		t.Fatal("second request should be dropped, not queued")
+	}
+	if logLine := <-logs; logLine != "ntfy: publish dropped class=busy" {
+		t.Fatalf("log = %q", logLine)
+	}
+	close(release)
+	publisher.Close()
+	if publisher.Notify(Message{Kind: KindUnread, SessionID: "third"}) {
+		t.Fatal("closed publisher accepted request")
+	}
+}
+
+func TestFormatMessageRemovesControlsAndTruncatesUTF8(t *testing.T) {
+	_, body := formatMessage("host\r\nInjected", Message{Kind: KindUnread, SessionID: strings.Repeat("界", 300), Adapter: "pi\nBad"})
+	if strings.ContainsAny(body, "\r\n") {
+		t.Fatalf("body contains control characters: %q", body)
+	}
+	if len(body) > 512 || !strings.Contains(body, "Host host  Injected") {
+		t.Fatalf("body is not safely bounded/cleaned: len=%d body=%q", len(body), body)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func newTestPublisher(t *testing.T, cfg Config, opts ...Option) *Publisher {
+	t.Helper()
+	publisher, err := New(cfg, opts...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return publisher
+}


### PR DESCRIPTION
## Summary

- add optional ntfy publishing after gmux's existing notification grace and presence checks
- publish once asynchronously with no queue, retry, persistence, or restart replay
- keep browser notifications independent and preserve origin-only peer ownership
- validate ntfy URL, topic, authentication, timeout, tags, and owner-only config permissions
- send privacy-safe payloads without prompts, output, commands, paths, or session titles
- document configuration and best-effort delivery semantics

## Testing

- `cd services/gmuxd && go test -timeout 10m ./...`
- `cd services/gmuxd && go test -race -timeout 5m ./internal/config ./internal/ntfy ./cmd/gmuxd`
- `cd services/gmuxd && go vet ./...`
- `pnpm lint`
- `pnpm --filter website build`

Two independent delta reviewers returned **integrate** after concurrency/lifecycle and test-quality review.
