### PR TITLE
fix: preserve terminal state across reconnect

### DIFF
--- a/apps/gmux-web/src/terminal-io.test.ts
+++ b/apps/gmux-web/src/terminal-io.test.ts
@@ -278,12 +278,31 @@ describe('createTerminalIO', () => {
     h.io.reset(2)
     h.io.enqueue(enc('fresh'), 2)
 
-    expect(h.writes).toEqual(['stale', 'fresh'])
+    // The stale write was already handed to xterm. The new epoch must wait
+    // for its callback instead of overlapping the parser or resize path.
+    expect(h.writes).toEqual(['stale'])
     h.flushOne()
 
     expect(onWritten).not.toHaveBeenCalled()
     expect(h.writes).toEqual(['stale', 'fresh'])
     expect(h.resizes).toEqual([])
+  })
+
+  it('does not let an old completion advance a new epoch past a resize fence', () => {
+    const h = makeHarness()
+    h.io.reset(1)
+    h.io.enqueue(enc('old'), 1)
+    h.io.reset(2)
+    h.io.enqueue(enc('new'), 2)
+    h.io.requestResize({ cols: 80, rows: 24 }, 2)
+
+    expect(h.writes).toEqual(['old'])
+    expect(h.resizes).toEqual([])
+    h.flushOne()
+    expect(h.writes).toEqual(['old', 'new'])
+    expect(h.resizes).toEqual([])
+    h.flushOne()
+    expect(h.resizes).toEqual([{ cols: 80, rows: 24 }])
   })
 
   it('runs completion callback after the final chunk in enqueueMany', () => {

--- a/apps/gmux-web/src/terminal-io.ts
+++ b/apps/gmux-web/src/terminal-io.ts
@@ -271,7 +271,10 @@ export function createTerminalIO(term: TerminalWriter, scroll?: ScrollAccessor):
     reset(epoch: number) {
       currentEpoch = epoch
       queue = []
-      writeInFlight = false
+      // Keep writeInFlight true until the old xterm callback arrives. A
+      // reset can invalidate queued work, but it cannot cancel xterm's
+      // parser callback; clearing this flag here would let a new resize or
+      // write overlap the still-running old parse.
       pendingResize = null
       savedScroll = null
       bufferReset = false

--- a/apps/gmux-web/src/terminal.tsx
+++ b/apps/gmux-web/src/terminal.tsx
@@ -11,7 +11,7 @@ import { applyArmedModifiers, attachKeyboardHandler, attachPasteHandler, default
 import { DEFAULT_THEME_COLORS, type ResolvedKeybind } from './config'
 import { attachMobileInputHandler } from './mobile-input'
 import { isTouchDevice } from './touch'
-import { BSU, createReplayBuffer, startsWith } from './replay'
+import { BSU, createReplayBuffer, ESU, startsWith } from './replay'
 import { createTerminalIO, type TerminalSize } from './terminal-io'
 import { type LinkInfo, linkAtPoint, openLinkAtPoint } from './terminal-link'
 import { createLongPressRecognizer } from './long-press'
@@ -29,12 +29,13 @@ import type { Session } from './types'
 
 const encoder = new TextEncoder()
 const CHECKPOINT_WIRE_RESET = encoder.encode('\x1b[r\x1b[H\x1b[2J\x1b[3J')
-// CSI r is part of the shared raw attach frame for legacy CLI consumers, but
-// it is not needed to repaint a browser checkpoint. Omitting it lets a
-// same-session reconnect retain the PTY's current margins; a session switch
-// has already reset xterm and therefore starts with default margins.
-const CHECKPOINT_BROWSER_RESET = encoder.encode('\x1b[H\x1b[2J\x1b[3J')
+// The browser checkpoint resets margins before repaint and restores the
+// authoritative region before the cursor-position/visibility tail. The raw
+// frame remains unchanged for CLI and legacy consumers.
+const CHECKPOINT_BROWSER_RESET = encoder.encode('\x1b[r\x1b[H\x1b[2J\x1b[3J')
 const CHECKPOINT_SGR_RESET = encoder.encode('\x1b[0m')
+
+type CheckpointMargins = { top: number, bottom: number, rows: number }
 
 /**
  * Add browser-only buffer authority at the complete checkpoint boundary.
@@ -42,11 +43,39 @@ const CHECKPOINT_SGR_RESET = encoder.encode('\x1b[0m')
  * ?1049h/l in it would change an operator's terminal. Reordering the known
  * SGR is emitted before buffer selection and erase, preventing the old
  * background from coloring blank cells. The browser-specific transform also
- * omits the shared frame's CSI r: same-session reconnects retain margins,
- * while session-ID changes perform the full xterm reset. No other terminal
- * state is claimed to be serialized by this rendered checkpoint.
+ * resets margins before repaint and restores the emulator's authoritative
+ * 1-based region before the frame's final cursor-position/visibility tail.
+ * The raw frame's CSI r is never changed, and no other terminal state is
+ * claimed to be serialized.
  */
-function prepareBrowserCheckpoint(chunks: Uint8Array[], activeAlternate: boolean | null): Uint8Array[] {
+function cursorTailOffset(frameBody: Uint8Array): number | null {
+  // The shared frame ends with CUP + DECTCEM + ESU. Find CUP only within that
+  // anchored tail so escape sequences in rendered terminal content cannot be
+  // mistaken for the authoritative cursor position.
+  const visibilityLength = 6 // CSI ? 25 h/l
+  const visibilityOffset = frameBody.length - ESU.length - visibilityLength
+  if (visibilityOffset <= 0 || !startsWith(frameBody.slice(frameBody.length - ESU.length), ESU)) return null
+  const visibility = frameBody.slice(visibilityOffset, visibilityOffset + visibilityLength)
+  if (!(visibility[0] === 0x1b && visibility[1] === 0x5b && visibility[2] === 0x3f
+    && visibility[3] === 0x32 && visibility[4] === 0x35 && (visibility[5] === 0x68 || visibility[5] === 0x6c))) return null
+
+  const cursorEnd = visibilityOffset
+  if (frameBody[cursorEnd - 1] !== 0x48) return null // H
+  for (let i = cursorEnd - 2; i >= Math.max(0, cursorEnd - 24); i--) {
+    if (frameBody[i] !== 0x1b) continue
+    if (frameBody[i + 1] !== 0x5b) return null
+    let semicolons = 0
+    for (let j = i + 2; j < cursorEnd - 1; j++) {
+      const byte = frameBody[j]
+      if (byte === 0x3b) semicolons++
+      else if (byte < 0x30 || byte > 0x39) return null
+    }
+    return semicolons === 1 ? i : null
+  }
+  return null
+}
+
+function prepareBrowserCheckpoint(chunks: Uint8Array[], activeAlternate: boolean | null, margins: CheckpointMargins | null): Uint8Array[] {
   if (chunks.length === 0) return chunks
   const first = chunks[0]
   if (!startsWith(first, BSU)) {
@@ -58,25 +87,43 @@ function prepareBrowserCheckpoint(chunks: Uint8Array[], activeAlternate: boolean
 
   const hasReset = first.length >= BSU.length + CHECKPOINT_WIRE_RESET.length
     && startsWith(first.slice(BSU.length), CHECKPOINT_WIRE_RESET)
-  if (!hasReset) {
+  // Older runners provide neither authoritative buffer nor margins. Keep the
+  // legacy fallback non-destructive rather than guessing a state checkpoint.
+  const validMargins = margins !== null && margins.rows > 0
+    && margins.top >= 1 && margins.bottom <= margins.rows
+    && (margins.top < margins.bottom || (margins.rows === 1 && margins.top === 1 && margins.bottom === 1))
+  if (!hasReset || activeAlternate === null || !validMargins) {
     const prepared = new Uint8Array(CHECKPOINT_SGR_RESET.length + first.length)
     prepared.set(CHECKPOINT_SGR_RESET)
     prepared.set(first, CHECKPOINT_SGR_RESET.length)
     return [prepared, ...chunks.slice(1)]
   }
 
-  const buffer = activeAlternate === null ? null : encoder.encode(activeAlternate ? '\x1b[?1049h' : '\x1b[?1049l')
+  const buffer = encoder.encode(activeAlternate ? '\x1b[?1049h' : '\x1b[?1049l')
+  // DECSTBM rejects equal bounds; on a one-row terminal the only safe
+  // representation is the default full-screen reset itself.
+  const restoreMargins = margins.rows === 1
+    ? encoder.encode('\x1b[r')
+    : encoder.encode(`\x1b[${margins.top};${margins.bottom}r`)
   const body = first.slice(BSU.length + CHECKPOINT_WIRE_RESET.length)
-  const bufferLength = buffer?.length ?? 0
-  const prepared = new Uint8Array(BSU.length + CHECKPOINT_SGR_RESET.length + bufferLength + CHECKPOINT_BROWSER_RESET.length + body.length)
+  const tailOffset = cursorTailOffset(body)
+  if (tailOffset === null) {
+    const prepared = new Uint8Array(CHECKPOINT_SGR_RESET.length + first.length)
+    prepared.set(CHECKPOINT_SGR_RESET)
+    prepared.set(first, CHECKPOINT_SGR_RESET.length)
+    return [prepared, ...chunks.slice(1)]
+  }
+  const repaint = body.slice(0, tailOffset)
+  const cursorTail = body.slice(tailOffset)
+  const prepared = new Uint8Array(BSU.length + CHECKPOINT_SGR_RESET.length + buffer.length + CHECKPOINT_BROWSER_RESET.length + repaint.length + restoreMargins.length + cursorTail.length)
   let offset = 0
   prepared.set(BSU, offset); offset += BSU.length
   prepared.set(CHECKPOINT_SGR_RESET, offset); offset += CHECKPOINT_SGR_RESET.length
-  if (buffer) {
-    prepared.set(buffer, offset); offset += buffer.length
-  }
+  prepared.set(buffer, offset); offset += buffer.length
   prepared.set(CHECKPOINT_BROWSER_RESET, offset); offset += CHECKPOINT_BROWSER_RESET.length
-  prepared.set(body, offset)
+  prepared.set(repaint, offset); offset += repaint.length
+  prepared.set(restoreMargins, offset); offset += restoreMargins.length
+  prepared.set(cursorTail, offset)
   return [prepared, ...chunks.slice(1)]
 }
 
@@ -943,8 +990,9 @@ export function TerminalView({
       // that stream. Apply it only once the complete BSU/ESU checkpoint is
       // staged; the existing screen remains visible during failed attempts.
       let checkpointAlt: boolean | null = null
+      let checkpointMargins: CheckpointMargins | null = null
       const replay = createReplayBuffer((chunks) => {
-        const prepared = prepareBrowserCheckpoint(chunks, checkpointAlt)
+        const prepared = prepareBrowserCheckpoint(chunks, checkpointAlt, checkpointMargins)
         queueMany(prepared, () => {
           termRef.current?.scrollToBottom()
           setTermLoading(false)
@@ -999,6 +1047,9 @@ export function TerminalView({
             // Use it to initialize ptySize if we don't have one yet.
             if (msg.type === 'terminal_checkpoint') {
               checkpointAlt = msg.active_buffer === 'alternate'
+              if (Number.isInteger(msg.scroll_top) && Number.isInteger(msg.scroll_bottom) && Number.isInteger(msg.rows)) {
+                checkpointMargins = { top: msg.scroll_top, bottom: msg.scroll_bottom, rows: msg.rows }
+              }
               return
             }
 

--- a/apps/gmux-web/src/terminal.tsx
+++ b/apps/gmux-web/src/terminal.tsx
@@ -28,16 +28,23 @@ import type { Session } from './types'
 // ── Config ──
 
 const encoder = new TextEncoder()
-const CHECKPOINT_RESET = encoder.encode('\x1b[r\x1b[H\x1b[2J\x1b[3J')
+const CHECKPOINT_WIRE_RESET = encoder.encode('\x1b[r\x1b[H\x1b[2J\x1b[3J')
+// CSI r is part of the shared raw attach frame for legacy CLI consumers, but
+// it is not needed to repaint a browser checkpoint. Omitting it lets a
+// same-session reconnect retain the PTY's current margins; a session switch
+// has already reset xterm and therefore starts with default margins.
+const CHECKPOINT_BROWSER_RESET = encoder.encode('\x1b[H\x1b[2J\x1b[3J')
 const CHECKPOINT_SGR_RESET = encoder.encode('\x1b[0m')
 
 /**
  * Add browser-only buffer authority at the complete checkpoint boundary.
  * The binary frame itself is also consumed by `gmux attach`, so putting
  * ?1049h/l in it would change an operator's terminal. Reordering the known
- * reset prefix means a session switch selects the target buffer before
- * clearing/rendering it, while a reconnect in alternate mode leaves the
- * saved normal buffer intact. Older runners still get the narrow SGR reset.
+ * SGR is emitted before buffer selection and erase, preventing the old
+ * background from coloring blank cells. The browser-specific transform also
+ * omits the shared frame's CSI r: same-session reconnects retain margins,
+ * while session-ID changes perform the full xterm reset. No other terminal
+ * state is claimed to be serialized by this rendered checkpoint.
  */
 function prepareBrowserCheckpoint(chunks: Uint8Array[], activeAlternate: boolean | null): Uint8Array[] {
   if (chunks.length === 0) return chunks
@@ -49,23 +56,26 @@ function prepareBrowserCheckpoint(chunks: Uint8Array[], activeAlternate: boolean
     return [prepared, ...chunks.slice(1)]
   }
 
-  const hasReset = first.length >= BSU.length + CHECKPOINT_RESET.length
-    && startsWith(first.slice(BSU.length), CHECKPOINT_RESET)
-  if (!hasReset || activeAlternate === null) {
+  const hasReset = first.length >= BSU.length + CHECKPOINT_WIRE_RESET.length
+    && startsWith(first.slice(BSU.length), CHECKPOINT_WIRE_RESET)
+  if (!hasReset) {
     const prepared = new Uint8Array(CHECKPOINT_SGR_RESET.length + first.length)
     prepared.set(CHECKPOINT_SGR_RESET)
     prepared.set(first, CHECKPOINT_SGR_RESET.length)
     return [prepared, ...chunks.slice(1)]
   }
 
-  const buffer = encoder.encode(activeAlternate ? '\x1b[?1049h' : '\x1b[?1049l')
-  const body = first.slice(BSU.length + CHECKPOINT_RESET.length)
-  const prepared = new Uint8Array(BSU.length + buffer.length + CHECKPOINT_RESET.length + CHECKPOINT_SGR_RESET.length + body.length)
+  const buffer = activeAlternate === null ? null : encoder.encode(activeAlternate ? '\x1b[?1049h' : '\x1b[?1049l')
+  const body = first.slice(BSU.length + CHECKPOINT_WIRE_RESET.length)
+  const bufferLength = buffer?.length ?? 0
+  const prepared = new Uint8Array(BSU.length + CHECKPOINT_SGR_RESET.length + bufferLength + CHECKPOINT_BROWSER_RESET.length + body.length)
   let offset = 0
   prepared.set(BSU, offset); offset += BSU.length
-  prepared.set(buffer, offset); offset += buffer.length
-  prepared.set(CHECKPOINT_RESET, offset); offset += CHECKPOINT_RESET.length
   prepared.set(CHECKPOINT_SGR_RESET, offset); offset += CHECKPOINT_SGR_RESET.length
+  if (buffer) {
+    prepared.set(buffer, offset); offset += buffer.length
+  }
+  prepared.set(CHECKPOINT_BROWSER_RESET, offset); offset += CHECKPOINT_BROWSER_RESET.length
   prepared.set(body, offset)
   return [prepared, ...chunks.slice(1)]
 }
@@ -286,6 +296,10 @@ export function TerminalView({
   const reconnectTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const disposed = useRef(false)
   const currentSessionId = useRef(session.id)
+  // The WebSocket effect can be re-run by unrelated dependency changes. Keep
+  // the reset tied to an observed session-ID transition, not to effect
+  // lifetime or to a reconnect attempt.
+  const terminalSessionId = useRef<string | null>(null)
   const sessionRef = useRef(session)
   const ctrlArmedRef = useRef(ctrlArmed)
   const altArmedRef = useRef(altArmed)
@@ -889,6 +903,15 @@ export function TerminalView({
     const epoch = termEpochRef.current + 1
     termEpochRef.current = epoch
     termIoRef.current.reset(epoch)
+
+    const sessionChanged = terminalSessionId.current !== null
+      && terminalSessionId.current !== session.id
+    terminalSessionId.current = session.id
+    // A session change is the one boundary where the existing xterm state is
+    // not authoritative. Reset only on that actual ID transition:
+    // same-session reconnect attempts retain the last committed screen and
+    // parser state during the outage.
+    if (sessionChanged) termRef.current.reset()
 
     // Reset sizes so stale values from a previous session can't trigger a
     // spurious pill while the loading overlay is visible (before ws.onopen).

--- a/apps/gmux-web/src/terminal.tsx
+++ b/apps/gmux-web/src/terminal.tsx
@@ -11,21 +11,64 @@ import { applyArmedModifiers, attachKeyboardHandler, attachPasteHandler, default
 import { DEFAULT_THEME_COLORS, type ResolvedKeybind } from './config'
 import { attachMobileInputHandler } from './mobile-input'
 import { isTouchDevice } from './touch'
-import { createReplayBuffer } from './replay'
+import { BSU, createReplayBuffer, startsWith } from './replay'
 import { createTerminalIO, type TerminalSize } from './terminal-io'
-import { linkAtPoint, type LinkInfo, openLinkAtPoint } from './terminal-link'
+import { type LinkInfo, linkAtPoint, openLinkAtPoint } from './terminal-link'
 import { createLongPressRecognizer } from './long-press'
 import { LinkActionSheet } from './link-action-sheet'
 import { TerminalTextSheet } from './terminal-text-sheet'
 import { pressedBufferRow, readTerminalText } from './terminal-text'
 import { decideViewportResize, sameSize } from './terminal-resize'
-import { wsStateOnClose, wsStateOnOutput, type WsState } from './ws-state'
+import { type WsState, wsStateOnClose, wsStateOnOutput } from './ws-state'
 import { terminalFindOpen, terminalScrolledUp, terminalScrollToBottom } from './store'
 import { TerminalFindBar } from './terminal-find'
 import { MOCK_BY_ID } from './mock-data/index'
 import type { Session } from './types'
 
 // ── Config ──
+
+const encoder = new TextEncoder()
+const CHECKPOINT_RESET = encoder.encode('\x1b[r\x1b[H\x1b[2J\x1b[3J')
+const CHECKPOINT_SGR_RESET = encoder.encode('\x1b[0m')
+
+/**
+ * Add browser-only buffer authority at the complete checkpoint boundary.
+ * The binary frame itself is also consumed by `gmux attach`, so putting
+ * ?1049h/l in it would change an operator's terminal. Reordering the known
+ * reset prefix means a session switch selects the target buffer before
+ * clearing/rendering it, while a reconnect in alternate mode leaves the
+ * saved normal buffer intact. Older runners still get the narrow SGR reset.
+ */
+function prepareBrowserCheckpoint(chunks: Uint8Array[], activeAlternate: boolean | null): Uint8Array[] {
+  if (chunks.length === 0) return chunks
+  const first = chunks[0]
+  if (!startsWith(first, BSU)) {
+    const prepared = new Uint8Array(CHECKPOINT_SGR_RESET.length + first.length)
+    prepared.set(CHECKPOINT_SGR_RESET)
+    prepared.set(first, CHECKPOINT_SGR_RESET.length)
+    return [prepared, ...chunks.slice(1)]
+  }
+
+  const hasReset = first.length >= BSU.length + CHECKPOINT_RESET.length
+    && startsWith(first.slice(BSU.length), CHECKPOINT_RESET)
+  if (!hasReset || activeAlternate === null) {
+    const prepared = new Uint8Array(CHECKPOINT_SGR_RESET.length + first.length)
+    prepared.set(CHECKPOINT_SGR_RESET)
+    prepared.set(first, CHECKPOINT_SGR_RESET.length)
+    return [prepared, ...chunks.slice(1)]
+  }
+
+  const buffer = encoder.encode(activeAlternate ? '\x1b[?1049h' : '\x1b[?1049l')
+  const body = first.slice(BSU.length + CHECKPOINT_RESET.length)
+  const prepared = new Uint8Array(BSU.length + buffer.length + CHECKPOINT_RESET.length + CHECKPOINT_SGR_RESET.length + body.length)
+  let offset = 0
+  prepared.set(BSU, offset); offset += BSU.length
+  prepared.set(buffer, offset); offset += buffer.length
+  prepared.set(CHECKPOINT_RESET, offset); offset += CHECKPOINT_RESET.length
+  prepared.set(CHECKPOINT_SGR_RESET, offset); offset += CHECKPOINT_SGR_RESET.length
+  prepared.set(body, offset)
+  return [prepared, ...chunks.slice(1)]
+}
 
 const USE_MOCK = import.meta.env.VITE_MOCK === '1' || location.search.includes('mock')
 
@@ -847,13 +890,6 @@ export function TerminalView({
     termEpochRef.current = epoch
     termIoRef.current.reset(epoch)
 
-    // Full RIS on the xterm instance so SGR colors, modes, cursor state, and
-    // scroll regions from the previous session don't bleed into the next one.
-    // Without this, switching away from a colorful TUI (btop, htop) leaves
-    // its trailing bg/fg attributes active until the new session emits an SGR
-    // of its own, painting plain-text output in btop's last color.
-    termRef.current.reset()
-
     // Reset sizes so stale values from a previous session can't trigger a
     // spurious pill while the loading overlay is visible (before ws.onopen).
     resetResizeEchoGate()
@@ -879,15 +915,21 @@ export function TerminalView({
       // regardless of the stale scroll state.
       termIoRef.current?.forceNextScrollToBottom()
 
+      // The runner's binary frame is shared with `gmux attach`, so browser
+      // buffer selection is delivered as metadata rather than ANSI bytes in
+      // that stream. Apply it only once the complete BSU/ESU checkpoint is
+      // staged; the existing screen remains visible during failed attempts.
+      let checkpointAlt: boolean | null = null
       const replay = createReplayBuffer((chunks) => {
-        queueMany(chunks, () => {
+        const prepared = prepareBrowserCheckpoint(chunks, checkpointAlt)
+        queueMany(prepared, () => {
           termRef.current?.scrollToBottom()
           setTermLoading(false)
         })
       })
 
       const wsProtocol = location.protocol === 'https:' ? 'wss:' : 'ws:'
-      const ws = new WebSocket(`${wsProtocol}//${location.host}/ws/${session.id}`)
+      const ws = new WebSocket(`${wsProtocol}//${location.host}/ws/${session.id}?client=browser`)
       ws.binaryType = 'arraybuffer'
       wsRef.current = ws
 
@@ -932,6 +974,11 @@ export function TerminalView({
             const msg = JSON.parse(ev.data)
             // Legacy: old proxy sends resize_state on connect with cols/rows.
             // Use it to initialize ptySize if we don't have one yet.
+            if (msg.type === 'terminal_checkpoint') {
+              checkpointAlt = msg.active_buffer === 'alternate'
+              return
+            }
+
             if (msg.type === 'resize_state') {
               const cols = msg.cols as number | undefined
               const rows = msg.rows as number | undefined

--- a/cli/gmux/internal/ptyserver/ptyserver.go
+++ b/cli/gmux/internal/ptyserver/ptyserver.go
@@ -347,9 +347,7 @@ func newScreen(cols, rows int, cursorCb func(visible bool)) (*vt.Emulator, chan 
 	}
 	e := vt.NewEmulator(cols, rows)
 	e.SetScrollbackSize(maxScrollback)
-	e.SetCallbacks(vt.Callbacks{
-		CursorVisibility: cursorCb,
-	})
+	e.SetCallbacks(vt.Callbacks{CursorVisibility: cursorCb})
 	// The emulator writes responses (e.g. DSR cursor position reports)
 	// to an internal pipe. If nothing reads them, Write blocks. We don't
 	// need the responses, so drain them in the background. The goroutine
@@ -394,13 +392,20 @@ func stopScreenDrain(e *vt.Emulator, drainDone chan struct{}) {
 // buffer can grow beyond the declared height. Rows are joined with \r\n
 // since bare \n wouldn't return the cursor to column 0.
 func renderScreen(e *vt.Emulator) string {
+	return renderScreenMode(e, true)
+}
+
+func renderScreenMode(e *vt.Emulator, includeScrollback bool) string {
 	var sb strings.Builder
 
-	// Scrollback: lines that scrolled off the top of the screen.
-	if scrollback := e.Scrollback(); scrollback != nil {
-		for _, line := range scrollback.Lines() {
-			sb.WriteString(line.Render())
-			sb.WriteString("\r\n")
+	// Scrollback belongs to the normal buffer. Do not push it through a
+	// browser's alternate-buffer checkpoint, where it would be discarded.
+	if includeScrollback {
+		if scrollback := e.Scrollback(); scrollback != nil {
+			for _, line := range scrollback.Lines() {
+				sb.WriteString(line.Render())
+				sb.WriteString("\r\n")
+			}
 		}
 	}
 
@@ -419,6 +424,29 @@ func renderScreen(e *vt.Emulator) string {
 		sb.WriteString(line.Render())
 	}
 	return sb.String()
+}
+
+// snapshotFrame is the shared raw attach checkpoint. It must remain valid for
+// both the browser and `gmux attach`; it therefore contains no browser-only
+// buffer-selection or reset semantics. The browser owns its reconnect
+// isolation boundary and the emulator remains authoritative for rendered
+// cells, cursor position, and ordering.
+func snapshotFrame(screen *vt.Emulator, cursorHidden bool) []byte {
+	return snapshotFrameWithScreen(screen, cursorHidden, true)
+}
+
+func snapshotFrameWithScreen(screen *vt.Emulator, cursorHidden, includeScrollback bool) []byte {
+	snapshot := renderScreenMode(screen, includeScrollback)
+	cursorSeq := "\x1b[?25h" // show cursor (default)
+	if cursorHidden {
+		cursorSeq = "\x1b[?25l" // hide cursor
+	}
+	pos := screen.CursorPosition()
+	cursorPos := fmt.Sprintf("\x1b[%d;%dH", pos.Y+1, pos.X+1)
+	bsu := "\x1b[?2026h"                     // Begin Synchronized Update
+	resetSeq := "\x1b[r\x1b[H\x1b[2J\x1b[3J" // Reset scroll region + cursor home + erase display + erase scrollback
+	esu := "\x1b[?2026l"                     // End Synchronized Update
+	return []byte(bsu + resetSeq + snapshot + cursorPos + cursorSeq + esu)
 }
 
 // ResizeMsg is the JSON message clients send to resize the terminal.
@@ -1560,29 +1588,35 @@ func (s *Server) handleWS(w http.ResponseWriter, r *http.Request) {
 	// All steps happen under s.mu so readPTY cannot send live data to
 	// this client before the snapshot frame.
 	//
-	// Ordering guarantee: snapshot is always the first message the client
-	// receives, followed by any live data from subsequent readPTY cycles.
+	// Ordering guarantee: browser metadata (when requested) and the binary
+	// snapshot are the first messages, followed by live data from later
+	// readPTY cycles.
 	//
 	// The screen state comes from a virtual terminal (charmbracelet/x/vt)
 	// that processes every byte of PTY output. renderScreen serializes
 	// the scrollback history followed by the visible screen as ANSI
 	// sequences with style diffing.
 	//
-	// Sequence: BSU → reset → scrollback + screen → cursor → ESU
+	// Raw sequence: BSU → reset → scrollback + screen → cursor → ESU.
+	// Browser buffer selection is separate metadata so `gmux attach` never
+	// receives browser-specific 1049 bytes.
+	browserClient := r.URL.Query().Get("client") == "browser"
 	s.mu.Lock()
 	s.drainScreenLocked()
-	snapshot := renderScreen(s.screen)
-	cursorSeq := "\x1b[?25h" // show cursor (default)
-	if s.cursorHidden {
-		cursorSeq = "\x1b[?25l" // hide cursor
+	frame := snapshotFrameWithScreen(s.screen, s.cursorHidden, !browserClient || !s.screen.IsAltScreen())
+	if browserClient {
+		activeBuffer := "normal"
+		if s.screen.IsAltScreen() {
+			activeBuffer = "alternate"
+		}
+		meta, _ := json.Marshal(map[string]string{"type": "terminal_checkpoint", "active_buffer": activeBuffer})
+		if err := client.write(websocket.MessageText, meta); err != nil {
+			s.mu.Unlock()
+			conn.Close(websocket.StatusNormalClosure, "")
+			cancel()
+			return
+		}
 	}
-	// Position cursor at the emulator's current location.
-	pos := s.screen.CursorPosition()
-	cursorPos := fmt.Sprintf("\x1b[%d;%dH", pos.Y+1, pos.X+1)
-	bsu := "\x1b[?2026h"                     // Begin Synchronized Update
-	resetSeq := "\x1b[r\x1b[H\x1b[2J\x1b[3J" // Reset scroll region + cursor home + erase display + erase scrollback
-	esu := "\x1b[?2026l"                     // End Synchronized Update
-	frame := []byte(bsu + resetSeq + snapshot + cursorPos + cursorSeq + esu)
 	if err := client.write(websocket.MessageBinary, frame); err != nil {
 		s.mu.Unlock()
 		conn.Close(websocket.StatusNormalClosure, "")

--- a/cli/gmux/internal/ptyserver/ptyserver.go
+++ b/cli/gmux/internal/ptyserver/ptyserver.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	uv "github.com/charmbracelet/ultraviolet"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/charmbracelet/x/vt"
 	"github.com/creack/pty"
 	"github.com/gmuxapp/gmux/cli/gmux/internal/agentext"
@@ -336,7 +337,50 @@ const probeTimeout = 250 * time.Millisecond
 // newScreen builds the replay emulator and starts the DSR drain goroutine. It
 // returns the emulator and a channel that is closed when the drain goroutine
 // exits, so shutdown can join it (see stopScreenDrain).
-func newScreen(cols, rows int, cursorCb func(visible bool)) (*vt.Emulator, chan struct{}) {
+type verticalMargins struct {
+	top    int // 1-based, inclusive
+	bottom int // 1-based, inclusive
+}
+
+type marginTracker struct {
+	normal, alternate verticalMargins
+}
+
+func newMarginTracker(rows int) *marginTracker {
+	m := &marginTracker{}
+	m.reset(rows)
+	return m
+}
+
+func (m *marginTracker) reset(rows int) {
+	if rows <= 0 {
+		rows = 24
+	}
+	m.normal = verticalMargins{top: 1, bottom: rows}
+	m.alternate = m.normal
+}
+
+func (m *marginTracker) active(alt bool) verticalMargins {
+	if alt {
+		return m.alternate
+	}
+	return m.normal
+}
+
+func (m *marginTracker) set(alt bool, margins verticalMargins) {
+	if alt {
+		m.alternate = margins
+	} else {
+		m.normal = margins
+	}
+}
+
+// newScreenWithMargins observes DECSTBM at the same point the vt emulator
+// applies it. Registering a handler that returns false lets vt's built-in
+// handler run after we mirror its validated 1-based semantics. Keeping one
+// pair per buffer matters: vt retains the normal screen's region when 1049
+// switches to the separately initialised alternate screen.
+func newScreenWithMargins(cols, rows int, cursorCb func(visible bool), margins *marginTracker) (*vt.Emulator, chan struct{}) {
 	// Default to 80x24 when launched non-interactively (no terminal).
 	// The first resize from a connecting client will set the real size.
 	if cols <= 0 {
@@ -348,6 +392,27 @@ func newScreen(cols, rows int, cursorCb func(visible bool)) (*vt.Emulator, chan 
 	e := vt.NewEmulator(cols, rows)
 	e.SetScrollbackSize(maxScrollback)
 	e.SetCallbacks(vt.Callbacks{CursorVisibility: cursorCb})
+	if margins != nil {
+		e.RegisterCsiHandler('r', func(params ansi.Params) bool {
+			top, _, _ := params.Param(0, 1)
+			if top < 1 {
+				top = 1
+			}
+			bottom, _, _ := params.Param(1, e.Height())
+			if bottom < 1 {
+				bottom = e.Height()
+			}
+			if top < bottom {
+				margins.set(e.IsAltScreen(), verticalMargins{top: top, bottom: bottom})
+			}
+			return false // run vt's authoritative built-in DECSTBM handler
+		})
+		e.RegisterEscHandler('c', func() bool {
+			margins.reset(e.Height())
+			return false // let vt perform RIS after resetting both screens
+		})
+	}
+
 	// The emulator writes responses (e.g. DSR cursor position reports)
 	// to an internal pipe. If nothing reads them, Write blocks. We don't
 	// need the responses, so drain them in the background. The goroutine
@@ -359,6 +424,10 @@ func newScreen(cols, rows int, cursorCb func(visible bool)) (*vt.Emulator, chan 
 		_, _ = io.Copy(io.Discard, e)
 	}()
 	return e, drainDone
+}
+
+func newScreen(cols, rows int, cursorCb func(visible bool)) (*vt.Emulator, chan struct{}) {
+	return newScreenWithMargins(cols, rows, cursorCb, nil)
 }
 
 // stopScreenDrain unblocks and joins the DSR drain goroutine, then closes the
@@ -426,6 +495,14 @@ func renderScreenMode(e *vt.Emulator, includeScrollback bool) string {
 	return sb.String()
 }
 
+type terminalCheckpointMetadata struct {
+	Type         string `json:"type"`
+	ActiveBuffer string `json:"active_buffer"`
+	ScrollTop    int    `json:"scroll_top"`
+	ScrollBottom int    `json:"scroll_bottom"`
+	Rows         int    `json:"rows"`
+}
+
 // snapshotFrame is the shared raw attach checkpoint. It must remain valid for
 // both the browser and `gmux attach`; it therefore contains no browser-only
 // buffer-selection or reset semantics. The browser owns its reconnect
@@ -470,8 +547,9 @@ type Server struct {
 	// nil when a test injected a bare listener; such a server owns no
 	// pathname and must never unlink one.
 	bound           *BoundSocket
-	screen          *vt.Emulator  // virtual terminal for replay snapshots (guarded by mu)
-	screenDrainDone chan struct{} // closed when the DSR drain goroutine exits
+	screen          *vt.Emulator   // virtual terminal for replay snapshots (guarded by mu)
+	screenDrainDone chan struct{}  // closed when the DSR drain goroutine exits
+	margins         *marginTracker // DECSTBM margins mirrored per emulator buffer (guarded by mu)
 	state           *session.State
 	// promptMarks derives Status from OSC 133 prompt marks for every
 	// session whose adapter is not hook-driven (adapter.HookDriven — the
@@ -711,9 +789,10 @@ func New(cfg Config) (*Server, error) {
 	}
 
 	// The callback fires under s.mu (held during drainScreenLocked → screen.Write).
-	s.screen, s.screenDrainDone = newScreen(int(cfg.Cols), int(cfg.Rows), func(visible bool) {
+	s.margins = newMarginTracker(int(cfg.Rows))
+	s.screen, s.screenDrainDone = newScreenWithMargins(int(cfg.Cols), int(cfg.Rows), func(visible bool) {
 		s.cursorHidden = !visible
-	})
+	}, s.margins)
 
 	// Non-hook-driven sessions get their busy/idle Status derived from
 	// OSC 133 prompt marks in the output stream: Active=true when a
@@ -1609,8 +1688,19 @@ func (s *Server) handleWS(w http.ResponseWriter, r *http.Request) {
 		if s.screen.IsAltScreen() {
 			activeBuffer = "alternate"
 		}
-		meta, _ := json.Marshal(map[string]string{"type": "terminal_checkpoint", "active_buffer": activeBuffer})
-		if err := client.write(websocket.MessageText, meta); err != nil {
+		margins := verticalMargins{top: 1, bottom: int(s.ptyRows)}
+		if s.margins != nil {
+			margins = s.margins.active(s.screen.IsAltScreen())
+		}
+		// Margins are 1-based and inclusive, matching DECSTBM. The emulator
+		// tracker validates top < bottom and resets both buffers on geometry
+		// changes, so full-screen/default state is represented explicitly.
+		meta := terminalCheckpointMetadata{
+			Type: "terminal_checkpoint", ActiveBuffer: activeBuffer,
+			ScrollTop: margins.top, ScrollBottom: margins.bottom, Rows: int(s.ptyRows),
+		}
+		metaBytes, _ := json.Marshal(meta)
+		if err := client.write(websocket.MessageText, metaBytes); err != nil {
 			s.mu.Unlock()
 			conn.Close(websocket.StatusNormalClosure, "")
 			cancel()
@@ -1712,6 +1802,9 @@ func (s *Server) shrinkForReconnect() {
 	rows := s.ptyRows
 	s.drainScreenLocked()
 	s.screen.Resize(int(cols), int(rows))
+	if s.margins != nil {
+		s.margins.reset(int(rows))
+	}
 	s.mu.Unlock()
 
 	s.setPtySize(&pty.Winsize{Cols: cols, Rows: rows})
@@ -1734,6 +1827,9 @@ func (s *Server) resize(msg ResizeMsg) {
 	if sizeChanged {
 		s.ptyCols = msg.Cols
 		s.ptyRows = msg.Rows
+		if s.margins != nil {
+			s.margins.reset(int(msg.Rows))
+		}
 		// Drain pending data first so the emulator processes it at the
 		// old size before switching to the new dimensions.
 		s.drainScreenLocked()

--- a/cli/gmux/internal/ptyserver/ptyserver_test.go
+++ b/cli/gmux/internal/ptyserver/ptyserver_test.go
@@ -925,6 +925,29 @@ func TestShutdownDrainNoRace(t *testing.T) {
 	}
 }
 
+func TestSnapshotFrameIsSharedAttachStream(t *testing.T) {
+	screen, screenDrain := newScreen(20, 4, func(bool) {})
+	defer stopScreenDrain(screen, screenDrain)
+
+	// This is the raw frame consumed by `gmux attach`. Even when the PTY is
+	// currently in an alternate screen, it must not change the caller's own
+	// terminal buffer; only the PTY's bytes are forwarded.
+	screen.Write([]byte("\x1b[?1049h\x1b[2J\x1b[H\x1b[44mALT\x1b[0m"))
+	frame := string(snapshotFrame(screen, false))
+	for _, want := range []string{"\x1b[?2026h", "\x1b[r\x1b[H\x1b[2J\x1b[3J", "ALT", "\x1b[?25h", "\x1b[?2026l"} {
+		if !strings.Contains(frame, want) {
+			t.Fatalf("snapshot missing %q in %q", want, frame)
+		}
+	}
+	if strings.Contains(frame, "\x1b[?1049") {
+		t.Fatalf("raw attach frame changes caller buffer: %q", frame)
+	}
+	if strings.Index(frame, "\x1b[?2026h") > strings.Index(frame, "ALT") ||
+		strings.Index(frame, "\x1b[?2026l") < strings.Index(frame, "ALT") {
+		t.Fatalf("snapshot is not atomically framed: %q", frame)
+	}
+}
+
 // TestRenderScreenIncludesScrollback verifies that renderScreen includes
 // lines that scrolled off the top of the screen, not just the visible rows.
 func TestRenderScreenIncludesScrollback(t *testing.T) {

--- a/cli/gmux/internal/ptyserver/ptyserver_test.go
+++ b/cli/gmux/internal/ptyserver/ptyserver_test.go
@@ -925,6 +925,44 @@ func TestShutdownDrainNoRace(t *testing.T) {
 	}
 }
 
+func TestTerminalCheckpointMetadataCarriesMargins(t *testing.T) {
+	data, err := json.Marshal(terminalCheckpointMetadata{
+		Type: "terminal_checkpoint", ActiveBuffer: "alternate", ScrollTop: 2, ScrollBottom: 4, Rows: 44,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `{"type":"terminal_checkpoint","active_buffer":"alternate","scroll_top":2,"scroll_bottom":4,"rows":44}`
+	if string(data) != want {
+		t.Fatalf("metadata = %s, want %s", data, want)
+	}
+}
+
+func TestMarginsFollowVTPerBufferAndResetSemantics(t *testing.T) {
+	margins := newMarginTracker(6)
+	screen, screenDrain := newScreenWithMargins(20, 6, func(bool) {}, margins)
+	defer stopScreenDrain(screen, screenDrain)
+
+	screen.Write([]byte("\x1b[2;5r"))
+	if got := margins.active(false); got != (verticalMargins{top: 2, bottom: 5}) {
+		t.Fatalf("normal margins = %+v, want 2..5", got)
+	}
+	screen.Write([]byte("\x1b[?1049h\x1b[3;6r"))
+	if got := margins.active(true); got != (verticalMargins{top: 3, bottom: 6}) {
+		t.Fatalf("alternate margins = %+v, want 3..6", got)
+	}
+	if got := margins.active(false); got != (verticalMargins{top: 2, bottom: 5}) {
+		t.Fatalf("normal margins changed across 1049 = %+v", got)
+	}
+	screen.Write([]byte("\x1bc"))
+	if got := margins.active(false); got != (verticalMargins{top: 1, bottom: 6}) {
+		t.Fatalf("normal margins after RIS = %+v, want full screen", got)
+	}
+	if got := margins.active(true); got != (verticalMargins{top: 1, bottom: 6}) {
+		t.Fatalf("alternate margins after RIS = %+v, want full screen", got)
+	}
+}
+
 func TestSnapshotFrameIsSharedAttachStream(t *testing.T) {
 	screen, screenDrain := newScreen(20, 4, func(bool) {})
 	defer stopScreenDrain(screen, screenDrain)

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -230,6 +230,7 @@ export default async function globalSetup(_config: FullConfig) {
   // runs the tests.
   process.env.GMUXD_TEST_PORT = String(port)
   process.env.GMUX_TEST_SESSION_ID = sessionId
+  process.env.GMUX_TEST_WORKSPACE = workspaceDir
   process.env.GMUX_TEST_TOKEN = testToken
   // Tests that write into adapter session roots (conversation
   // discovery, etc.) need to know where the daemon is looking for

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -93,10 +93,7 @@ export async function isPillVisible(page: Page): Promise<boolean> {
  * installed by main.tsx. The session ID is set by global-setup and
  * exposed via GMUX_TEST_SESSION_ID.
  */
-export async function gotoTestSession(page: Page): Promise<void> {
-  const sessionId = process.env.GMUX_TEST_SESSION_ID
-  if (!sessionId) throw new Error('GMUX_TEST_SESSION_ID not set; global-setup did not run')
-
+export async function gotoSession(page: Page, sessionId: string): Promise<void> {
   // Drive navigation via the test hook. It returns true only once
   // the session and its project are both in the store and the URL
   // change has been dispatched, so by the time this resolves the
@@ -110,6 +107,12 @@ export async function gotoTestSession(page: Page): Promise<void> {
   await page.locator('.xterm').waitFor({ state: 'visible', timeout: 5_000 })
   // Give the WS connection time to establish and replay scrollback.
   await page.waitForTimeout(1500)
+}
+
+export async function gotoTestSession(page: Page): Promise<void> {
+  const sessionId = process.env.GMUX_TEST_SESSION_ID
+  if (!sessionId) throw new Error('GMUX_TEST_SESSION_ID not set; global-setup did not run')
+  await gotoSession(page, sessionId)
 }
 
 /** Click the resize pill. */

--- a/e2e/tests/terminal-switch-state.spec.ts
+++ b/e2e/tests/terminal-switch-state.spec.ts
@@ -1,8 +1,9 @@
 import { test, expect } from '@playwright/test'
 import { gotoSession, openApp } from '../helpers'
 
-const A_COMMAND = 'printf "\\033[44mA-BLUE\\033[0m\\r\\n"; for i in $(seq 1 40); do printf "A-SCROLL-%02d\\r\\n" "$i"; done; sleep 5; printf "\\033[?1h\\033[?1000h\\033[?1006h\\033[?2004h\\033[?1004h\\033[2;4r\\033[3;6H"; while true; do read -r line || exit; eval "$line"; done'
+const A_COMMAND = 'stty -echo; printf "\\033[44mA-BLUE\\033[0m\\r\\n"; for i in $(seq 1 40); do printf "A-SCROLL-%02d\\r\\n" "$i"; done; sleep 5; printf "\\033[?1h\\033[?1000h\\033[?1006h\\033[?2004h\\033[?1004h\\033[2;4r\\033[3;6H"; while true; do read -r line || exit; eval "$line"; done'
 const B_COMMAND = 'printf "B-NORMAL\\r\\n"; while true; do read -r line || exit; eval "$line"; done'
+const C_COMMAND = 'stty -echo; printf "C-NORMAL\\r\\n"; while true; do read -r line || exit; if [ "$line" = go ]; then printf "\\033[2;4r\\033[3;6H"; for i in $(seq 1 40); do printf "C-SCROLL-%02d\\r\\n" "$i"; done; printf "\\033[9;20H"; elif [ "$line" = marker ]; then printf "C-PARK-MARK"; elif [ "$line" = after ]; then printf "\\033[3;6H"; for i in $(seq 1 10); do printf "C-AFTER-%02d\\r\\n" "$i"; done; fi; done'
 
 test('real A→B→A isolation and reconnect checkpoint', async ({ page }) => {
   test.setTimeout(90_000)
@@ -52,7 +53,7 @@ test('real A→B→A isolation and reconnect checkpoint', async ({ page }) => {
       })
       if (!response.ok) throw new Error(`launch failed: ${response.status}`)
     }, { command, cwd })
-    const marker = command.includes('A-BLUE') ? 'A-BLUE' : 'B-NORMAL'
+    const marker = command.includes('A-BLUE') ? 'A-BLUE' : command.includes('C-NORMAL') ? 'C-NORMAL' : 'B-NORMAL'
     const link = page.locator('a').filter({ hasText: marker }).first()
     await link.waitFor({ state: 'visible', timeout: 10_000 })
     const href = await link.getAttribute('href')
@@ -61,6 +62,7 @@ test('real A→B→A isolation and reconnect checkpoint', async ({ page }) => {
 
   const aId = await launch(A_COMMAND)
   const bId = await launch(B_COMMAND)
+  const cId = await launch(C_COMMAND)
   // Let the production SSE snapshot publish the newly launched sessions
   // before routing through the same navigation hook used by the suite.
   await page.waitForTimeout(1500)
@@ -136,9 +138,10 @@ test('real A→B→A isolation and reconnect checkpoint', async ({ page }) => {
       return {
         active: active.type,
         activeText: active.getLine(0)?.translateToString(true),
-        normalText: term.buffer.normal.getLine(0)?.translateToString(true),
+        normalText: Array.from({ length: term.buffer.normal.baseY + term.rows }, (_, y) => term.buffer.normal.getLine(y)?.translateToString(true) ?? '').join('\n'),
       }
-    }), { timeout: 10_000 }).toMatchObject({ active: 'alternate', activeText: expect.stringContaining('B-ALT'), normalText: expect.stringContaining('B-NORMAL') })
+    }), { timeout: 10_000 }).toMatchObject({ active: 'alternate', activeText: expect.stringContaining('B-ALT') })
+    expect(await page.evaluate(() => (window as any).__gmuxTerm.buffer.normal.getLine(0)?.translateToString(true))).not.toContain('A-BLUE')
     mark('B reconnect')
 
     // Same-session reconnect with legacy metadata absence is non-destructive:
@@ -159,6 +162,10 @@ test('real A→B→A isolation and reconnect checkpoint', async ({ page }) => {
     await page.keyboard.type("printf '\\033[?1049l'")
     await page.keyboard.press('Enter')
     await page.waitForFunction(() => (window as any).__gmuxTerm.buffer.active.type === 'normal')
+    expect(await page.evaluate(() => {
+      const term = (window as any).__gmuxTerm
+      return Array.from({ length: term.buffer.normal.baseY + term.rows }, (_, y) => term.buffer.normal.getLine(y)?.translateToString(true) ?? '').join('\n')
+    })).not.toContain('A-BLUE')
     await page.keyboard.type("printf '\\033[?1049h\\033[2J\\033[H\\033[44mB-ALT-SWITCH\\033[0m'")
     await page.keyboard.press('Enter')
     await page.waitForFunction(() => (window as any).__gmuxTerm.buffer.active.type === 'alternate'
@@ -211,17 +218,25 @@ test('real A→B→A isolation and reconnect checkpoint', async ({ page }) => {
 
     await page.screenshot({ path: '.memory/screenshots/terminal-switch-state-after-reconnect.png' })
 
-    // CSI r is intentionally absent from browser checkpoint preparation: a
-    // same-session reconnect must retain the live DECSTBM region rather than
-    // silently restoring default margins.
-    await page.evaluate(() => {
-      const raw = btoa('\x1b[2;4r')
-      ;(window as any).__gmuxInject(raw)
+    // A real-daemon regression: C fills 40 distinguishable lines, then sets
+    // a non-full region after its initial geometry has settled.
+    mark('C attach')
+    await gotoLocalSession(cId)
+    mark('C connected')
+    await page.locator('.xterm-helper-textarea').focus()
+    await page.keyboard.type('go')
+    await page.keyboard.press('Enter')
+    await page.waitForFunction(() => {
+      const term = (window as any).__gmuxTerm
+      const text = Array.from({ length: term.buffer.active.baseY + term.rows }, (_, y) => term.buffer.active.getLine(y)?.translateToString(true) ?? '').join('\n')
+      return text.includes('C-SCROLL-40')
     })
+    mark('C margins')
     await expect.poll(() => page.evaluate(() => {
       const buffer = (window as any).__gmuxTerm._core?.buffers?.active
       return { top: buffer?.scrollTop, bottom: buffer?.scrollBottom }
-    })).toMatchObject({ top: 1, bottom: 3 })
+    }), { timeout: 10_000 }).toMatchObject({ top: 1, bottom: 3 })
+    mark('C reconnect start')
     await page.evaluate(() => {
       for (const ws of (window as any).__allWs as WebSocket[]) {
         if (ws.readyState === WebSocket.OPEN && ws.url.includes('/ws/')) ws.close()
@@ -229,10 +244,60 @@ test('real A→B→A isolation and reconnect checkpoint', async ({ page }) => {
     })
     await expect(page.locator('.terminal-disconnected-pill')).toBeVisible({ timeout: 10_000 })
     await expect(page.locator('.terminal-disconnected-pill')).not.toBeVisible({ timeout: 10_000 })
+    mark('C reconnect socket')
     await expect.poll(() => page.evaluate(() => {
-      const buffer = (window as any).__gmuxTerm._core?.buffers?.active
-      return { top: buffer?.scrollTop, bottom: buffer?.scrollBottom }
-    })).toMatchObject({ top: 1, bottom: 3 })
+      const term = (window as any).__gmuxTerm
+      const active = term.buffer.active
+      const buffer = term._core?.buffers?.active
+      const text = Array.from({ length: active.baseY + term.rows }, (_, y) => active.getLine(y)?.translateToString(true) ?? '').join('\n')
+      return { top: buffer?.scrollTop, bottom: buffer?.scrollBottom, cursorX: active.cursorX, cursorY: active.cursorY, text }
+    }), { timeout: 10_000 }).toMatchObject({ top: 1, bottom: 3, cursorX: 19, cursorY: 8 })
+    mark('C reconnect margins and cursor restored')
+    await expect.poll(() => page.evaluate(() => {
+      const term = (window as any).__gmuxTerm
+      const text = Array.from({ length: term.buffer.active.baseY + term.rows }, (_, y) => term.buffer.active.getLine(y)?.translateToString(true) ?? '').join('\n')
+      return Array.from({ length: 40 }, (_, i) => `C-SCROLL-${String(i + 1).padStart(2, '0')}`).filter(line => !text.includes(line))
+    })).toEqual([])
+    mark('C content restored')
+    const beforeMarker = await page.evaluate(() => {
+      const buffer = (window as any).__gmuxTerm.buffer.active
+      return { row0: buffer.getLine(buffer.baseY)?.translateToString(true) ?? '' }
+    })
+    await page.locator('.xterm-helper-textarea').focus()
+    await page.keyboard.type('marker')
+    await page.keyboard.press('Enter')
+    await expect.poll(() => page.evaluate(() => {
+      const buffer = (window as any).__gmuxTerm.buffer.active
+      const parkedRow = buffer.getLine(buffer.baseY + 8)?.translateToString(true) ?? ''
+      return {
+        row0: buffer.getLine(buffer.baseY)?.translateToString(true) ?? '',
+        markerAtParkedColumn: parkedRow.slice(19).startsWith('C-PARK-MARK'),
+      }
+    })).toEqual({ row0: beforeMarker.row0, markerAtParkedColumn: true })
+    mark('C marker landed at parked cursor')
+    await page.keyboard.type('after')
+    await page.keyboard.press('Enter')
+    await page.waitForFunction(() => {
+      const term = (window as any).__gmuxTerm
+      const text = Array.from({ length: term.buffer.active.baseY + term.rows }, (_, y) => term.buffer.active.getLine(y)?.translateToString(true) ?? '').join('\n')
+      return text.includes('C-AFTER-10')
+    })
+    mark('C after output')
+    const afterRegion = await page.evaluate(() => {
+      const term = (window as any).__gmuxTerm
+      const buffer = term.buffer.active
+      return { top: buffer.getLine(buffer.baseY)?.translateToString(true), bottom: buffer.getLine(buffer.baseY + 4)?.translateToString(true), scrollTop: term._core?.buffers?.active.scrollTop, scrollBottom: term._core?.buffers?.active.scrollBottom }
+    })
+    expect(afterRegion).toMatchObject({ scrollTop: 1, scrollBottom: 3 })
+    mark('C region verified')
+
+    // Return to A before the failed-handshake check.
+    await gotoLocalSession(aId)
+    await page.waitForFunction(() => {
+      const term = (window as any).__gmuxTerm
+      const text = Array.from({ length: term.buffer.active.baseY + term.rows }, (_, y) => term.buffer.active.getLine(y)?.translateToString(true) ?? '').join('\n')
+      return text.includes('A-BLUE')
+    })
 
     // Failed replacement handshakes preserve the last committed screen.
     await page.evaluate(() => {
@@ -259,12 +324,12 @@ test('real A→B→A isolation and reconnect checkpoint', async ({ page }) => {
       return { buffer: buffer.type, baseY: buffer.baseY, viewportY: buffer.viewportY, cursorX: buffer.cursorX, cursorY: buffer.cursorY, cols: term.cols, rows: term.rows, text: line.translateToString(true), bg: line.getCell(0).bg }
     })
     expect(state).toMatchObject({ buffer: 'normal', text: expect.stringContaining('A-BLUE') })
-    expect(state.cursorX).toBeGreaterThanOrEqual(0)
-    expect(state.cursorY).toBeGreaterThanOrEqual(0)
+    expect(state.cursorX).toBe(5)
+    expect(state.cursorY).toBe(2)
     expect(state.viewportY).toBe(state.baseY)
     expect(state.bg).not.toBe(0)
   } finally {
-    for (const id of [aId, bId]) {
+    for (const id of [aId, bId, cId]) {
       await page.evaluate(async id => { await fetch(`/v1/sessions/${id}/kill`, { method: 'POST' }) }, id)
     }
   }

--- a/e2e/tests/terminal-switch-state.spec.ts
+++ b/e2e/tests/terminal-switch-state.spec.ts
@@ -1,19 +1,40 @@
 import { test, expect } from '@playwright/test'
 import { gotoSession, openApp } from '../helpers'
 
-const A_COMMAND = 'printf "\\033[44mA-BLUE\\033[0m\\r\\n"; for i in $(seq 1 40); do printf "A-SCROLL-%02d\\r\\n" "$i"; done; printf "\\033[2;4r\\033[3;6H"; while true; do sleep 60; done'
+const A_COMMAND = 'printf "\\033[44mA-BLUE\\033[0m\\r\\n"; for i in $(seq 1 40); do printf "A-SCROLL-%02d\\r\\n" "$i"; done; sleep 5; printf "\\033[?1h\\033[?1000h\\033[?1006h\\033[?2004h\\033[?1004h\\033[2;4r\\033[3;6H"; while true; do read -r line || exit; eval "$line"; done'
 const B_COMMAND = 'printf "B-NORMAL\\r\\n"; while true; do read -r line || exit; eval "$line"; done'
 
 test('real A→B→A isolation and reconnect checkpoint', async ({ page }) => {
+  test.setTimeout(90_000)
+  const mark = (s: string) => console.log(`[switch] ${s}`)
   await page.addInitScript(() => {
     ;(window as any).__allWs = [] as WebSocket[]
+    ;(window as any).__checkpointMetadata = [] as string[]
     ;(window as any).__blockTerminalReconnect = false
+    ;(window as any).__stripBrowserQuery = false
+    ;(window as any).__wsSent = [] as string[]
     const OriginalWebSocket = window.WebSocket
     ;(window as any).WebSocket = function (...args: ConstructorParameters<typeof WebSocket>) {
-      const url = (window as any).__blockTerminalReconnect && String(args[0]).includes('/ws/')
+      const original = String(args[0])
+      const url = (window as any).__blockTerminalReconnect && original.includes('/ws/')
         ? 'ws://127.0.0.1:1/unavailable'
-        : args[0]
+        : (window as any).__stripBrowserQuery ? original.replace('?client=browser', '') : original
       const ws = new OriginalWebSocket(url, ...(args.slice(1) as any))
+      const send = ws.send.bind(ws)
+      ws.send = ((data: any) => {
+        let bytes: Uint8Array
+        if (typeof data === 'string') bytes = new TextEncoder().encode(data)
+        else if (data instanceof ArrayBuffer) bytes = new Uint8Array(data)
+        else if (ArrayBuffer.isView(data)) bytes = new Uint8Array(data.buffer, data.byteOffset, data.byteLength)
+        else bytes = new Uint8Array()
+        ;(window as any).__wsSent.push(Array.from(bytes).map(b => String.fromCharCode(b)).join(''))
+        return send(data)
+      }) as typeof ws.send
+      ws.addEventListener('message', (event) => {
+        if (typeof event.data === 'string' && event.data.includes('terminal_checkpoint')) {
+          ;(window as any).__checkpointMetadata.push(event.data)
+        }
+      })
       ;(window as any).__allWs.push(ws)
       return ws
     } as unknown as typeof WebSocket
@@ -47,6 +68,7 @@ test('real A→B→A isolation and reconnect checkpoint', async ({ page }) => {
     await gotoSession(page, id)
   }
   try {
+    mark('A attach')
     await gotoLocalSession(aId)
     await page.waitForFunction(() => {
       const term = (window as any).__gmuxTerm
@@ -54,27 +76,52 @@ test('real A→B→A isolation and reconnect checkpoint', async ({ page }) => {
       const text = Array.from({ length: (buffer?.baseY ?? 0) + (term?.rows ?? 0) }, (_, y) => buffer?.getLine(y)?.translateToString(true) ?? '').join('\n')
       return buffer?.type === 'normal' && text.includes('A-BLUE') && text.includes('A-SCROLL-40')
     })
+    mark('A text')
+    await page.waitForTimeout(2000)
+    console.log(await page.evaluate(() => {
+      const term = (window as any).__gmuxTerm
+      return { modes: term.modes, active: term.buffer.active.type, text: term.buffer.active.getLine(0)?.translateToString(true) }
+    }))
     await page.screenshot({ path: '.memory/screenshots/terminal-switch-state-A-before.png' })
+    mark('A modes')
 
     const aGeometry = await page.evaluate(() => ({ cols: (window as any).__gmuxTerm.cols, rows: (window as any).__gmuxTerm.rows }))
     await page.setViewportSize({ width: 900, height: 600 })
+    mark('B attach')
     await gotoLocalSession(bId)
     const bGeometry = await page.evaluate(() => ({ cols: (window as any).__gmuxTerm.cols, rows: (window as any).__gmuxTerm.rows }))
     expect(bGeometry.cols).toBeLessThan(aGeometry.cols)
     expect(bGeometry.rows).toBeLessThan(aGeometry.rows)
-    await page.waitForFunction(() => (window as any).__gmuxTerm.buffer.active.getLine(0)?.translateToString(true).includes('B-NORMAL'))
-
-    // Enter the alternate TUI only after its normal shell screen is present;
-    // this makes the DEC 1049 saved-buffer contract observable on reconnect.
+    await page.waitForFunction(() => {
+      const term = (window as any).__gmuxTerm
+      const buffer = term.buffer.active
+      const text = Array.from({ length: buffer.baseY + term.rows }, (_, y) => buffer.getLine(y)?.translateToString(true) ?? '').join('\n')
+      return buffer.type === 'normal' && text.includes('B-NORMAL')
+    })
+    await expect.poll(() => page.evaluate(() => {
+      const term = (window as any).__gmuxTerm
+      return {
+        appCursor: term.modes.applicationCursorKeysMode,
+        bracketedPaste: term.modes.bracketedPasteMode,
+        mouse: term.modes.mouseTrackingMode,
+        focus: term.modes.sendFocusMode,
+      }
+    })).toMatchObject({ appCursor: false, bracketedPaste: false, mouse: 'none', focus: false })
+    // Establish B's alternate state only after the normal B checkpoint has
+    // been rendered. The same-session reconnect and the later session switch
+    // both use the browser metadata to select the target buffer.
     await page.locator('.xterm-helper-textarea').focus()
     await page.keyboard.type("printf '\\033[?1049h\\033[2J\\033[H\\033[44mB-ALT\\033[0m\\033[3;5H'")
     await page.keyboard.press('Enter')
     await page.waitForFunction(() => (window as any).__gmuxTerm.buffer.active.type === 'alternate'
       && (window as any).__gmuxTerm.buffer.active.getLine(0)?.translateToString(true).includes('B-ALT'))
+    await expect.poll(() => page.evaluate(() => (window as any).__checkpointMetadata.length)).toBeGreaterThan(0)
     await page.screenshot({ path: '.memory/screenshots/terminal-switch-state-B.png' })
+    mark('B active')
 
     // Reconnect while the TUI owns the alternate buffer, then exit it. The
     // saved normal screen must be B-NORMAL, not the previous A screen.
+    mark('B reconnect start')
     await page.evaluate(() => {
       for (const ws of (window as any).__allWs as WebSocket[]) {
         if (ws.readyState === WebSocket.OPEN && ws.url.includes('/ws/')) ws.close()
@@ -82,42 +129,110 @@ test('real A→B→A isolation and reconnect checkpoint', async ({ page }) => {
     })
     await expect(page.locator('.terminal-disconnected-pill')).toBeVisible({ timeout: 10_000 })
     await expect(page.locator('.terminal-disconnected-pill')).not.toBeVisible({ timeout: 10_000 })
+    mark('B reconnect socket')
+    await expect.poll(() => page.evaluate(() => {
+      const term = (window as any).__gmuxTerm
+      const active = term.buffer.active
+      return {
+        active: active.type,
+        activeText: active.getLine(0)?.translateToString(true),
+        normalText: term.buffer.normal.getLine(0)?.translateToString(true),
+      }
+    }), { timeout: 10_000 }).toMatchObject({ active: 'alternate', activeText: expect.stringContaining('B-ALT'), normalText: expect.stringContaining('B-NORMAL') })
+    mark('B reconnect')
+
+    // Same-session reconnect with legacy metadata absence is non-destructive:
+    // the already-active alternate buffer is retained rather than guessed.
+    await page.evaluate(() => {
+      ;(window as any).__stripBrowserQuery = true
+      for (const ws of (window as any).__allWs as WebSocket[]) {
+        if (ws.readyState === WebSocket.OPEN && ws.url.includes('/ws/')) ws.close()
+      }
+    })
+    await expect(page.locator('.terminal-disconnected-pill')).toBeVisible({ timeout: 10_000 })
+    await expect(page.locator('.terminal-disconnected-pill')).not.toBeVisible({ timeout: 10_000 })
     await page.waitForFunction(() => (window as any).__gmuxTerm.buffer.active.type === 'alternate'
-      && (window as any).__gmuxTerm.buffer.active.getLine(0)?.translateToString(true).includes('B-ALT')
-      && (window as any).__gmuxTerm.buffer.normal.getLine(0)?.translateToString(true).includes('B-NORMAL'))
+      && (window as any).__gmuxTerm.buffer.active.getLine(0)?.translateToString(true).includes('B-ALT'))
+    mark('B legacy reconnect')
+    await page.evaluate(() => { ;(window as any).__stripBrowserQuery = false })
     await page.locator('.xterm-helper-textarea').focus()
     await page.keyboard.type("printf '\\033[?1049l'")
     await page.keyboard.press('Enter')
-    await page.waitForFunction(() => (window as any).__gmuxTerm.buffer.active.type === 'normal'
-      && (window as any).__gmuxTerm.buffer.active.getLine(0)?.translateToString(true).includes('B-NORMAL'))
+    await page.waitForFunction(() => (window as any).__gmuxTerm.buffer.active.type === 'normal')
+    await page.keyboard.type("printf '\\033[?1049h\\033[2J\\033[H\\033[44mB-ALT-SWITCH\\033[0m'")
+    await page.keyboard.press('Enter')
+    await page.waitForFunction(() => (window as any).__gmuxTerm.buffer.active.type === 'alternate'
+      && (window as any).__gmuxTerm.buffer.active.getLine(0)?.translateToString(true).includes('B-ALT-SWITCH'))
+
+    // Switch into an already-alternate session as a distinct transition. The
+    // session reset must prevent A's normal modes, background, and scrollback
+    // from becoming B's active screen; metadata selects B's alternate buffer.
+    await gotoLocalSession(aId)
+    await page.waitForFunction(() => {
+      const term = (window as any).__gmuxTerm
+      const buffer = term.buffer.active
+      const text = Array.from({ length: buffer.baseY + term.rows }, (_, y) => buffer.getLine(y)?.translateToString(true) ?? '').join('\n')
+      return buffer.type === 'normal' && text.includes('A-BLUE') && !text.includes('B-ALT')
+    })
+    await gotoLocalSession(bId)
+    await page.waitForFunction(() => {
+      const term = (window as any).__gmuxTerm
+      const buffer = term.buffer.active
+      const text = Array.from({ length: buffer.baseY + term.rows }, (_, y) => buffer.getLine(y)?.translateToString(true) ?? '').join('\n')
+      return buffer.type === 'alternate' && text.includes('B-ALT-SWITCH') && !text.includes('A-BLUE')
+    })
+    await expect.poll(() => page.evaluate(() => {
+      const term = (window as any).__gmuxTerm
+      return { appCursor: term.modes.applicationCursorKeysMode, bracketedPaste: term.modes.bracketedPasteMode, mouse: term.modes.mouseTrackingMode, focus: term.modes.sendFocusMode }
+    })).toMatchObject({ appCursor: false, bracketedPaste: false, mouse: 'none', focus: false })
+    await page.evaluate(() => { ;(window as any).__wsSent = [] })
+    await page.locator('.xterm-helper-textarea').focus()
+    await page.keyboard.press('ArrowUp')
+    await expect.poll(() => page.evaluate(() => (window as any).__wsSent.join(''))).toContain('\x1b[A')
+    await expect.poll(() => page.evaluate(() => (window as any).__wsSent.join(''))).not.toMatch(/\x1bOA|\x1b\[</)
 
     await page.setViewportSize({ width: 1200, height: 800 })
+    mark('A final start')
     await gotoLocalSession(aId)
+    mark('A final connected')
     await page.waitForFunction(() => {
       const term = (window as any).__gmuxTerm
       const buffer = term.buffer.active
       const text = Array.from({ length: buffer.baseY + term.rows }, (_, y) => buffer.getLine(y)?.translateToString(true) ?? '').join('\n')
       return buffer.type === 'normal' && text.includes('A-BLUE')
         && !text.includes('B-ALT')
-        && term.buffer.active.cursorX === 5 && term.buffer.active.cursorY === 2
     })
     await page.screenshot({ path: '.memory/screenshots/terminal-switch-state-A-again.png' })
+    await page.waitForFunction(() => {
+      const term = (window as any).__gmuxTerm
+      return !term.modes.applicationCursorKeys && !term.modes.bracketedPasteMode
+        && term.modes.mouseTrackingMode === 'none'
+    })
+
+    await page.screenshot({ path: '.memory/screenshots/terminal-switch-state-after-reconnect.png' })
+
+    // CSI r is intentionally absent from browser checkpoint preparation: a
+    // same-session reconnect must retain the live DECSTBM region rather than
+    // silently restoring default margins.
     await page.evaluate(() => {
-      for (const ws of (window as any).__allWs as WebSocket[] | undefined ?? []) {
+      const raw = btoa('\x1b[2;4r')
+      ;(window as any).__gmuxInject(raw)
+    })
+    await expect.poll(() => page.evaluate(() => {
+      const buffer = (window as any).__gmuxTerm._core?.buffers?.active
+      return { top: buffer?.scrollTop, bottom: buffer?.scrollBottom }
+    })).toMatchObject({ top: 1, bottom: 3 })
+    await page.evaluate(() => {
+      for (const ws of (window as any).__allWs as WebSocket[]) {
         if (ws.readyState === WebSocket.OPEN && ws.url.includes('/ws/')) ws.close()
       }
     })
     await expect(page.locator('.terminal-disconnected-pill')).toBeVisible({ timeout: 10_000 })
     await expect(page.locator('.terminal-disconnected-pill')).not.toBeVisible({ timeout: 10_000 })
-    await page.waitForFunction(() => {
-      const term = (window as any).__gmuxTerm
-      const buffer = term.buffer.active
-      const aLine = Array.from({ length: buffer.baseY + term.rows }, (_, y) => buffer.getLine(y)).find(line => line?.translateToString(true).includes('A-BLUE'))
-      return buffer.type === 'normal' && aLine != null
-        && buffer.cursorX === 5 && buffer.cursorY === 2
-        && aLine.getCell(0)?.bg !== 0
-    })
-    await page.screenshot({ path: '.memory/screenshots/terminal-switch-state-after-reconnect.png' })
+    await expect.poll(() => page.evaluate(() => {
+      const buffer = (window as any).__gmuxTerm._core?.buffers?.active
+      return { top: buffer?.scrollTop, bottom: buffer?.scrollBottom }
+    })).toMatchObject({ top: 1, bottom: 3 })
 
     // Failed replacement handshakes preserve the last committed screen.
     await page.evaluate(() => {
@@ -143,7 +258,10 @@ test('real A→B→A isolation and reconnect checkpoint', async ({ page }) => {
       const line = Array.from({ length: buffer.baseY + term.rows }, (_, y) => buffer.getLine(y)).find(line => line?.translateToString(true).includes('A-BLUE'))!
       return { buffer: buffer.type, baseY: buffer.baseY, viewportY: buffer.viewportY, cursorX: buffer.cursorX, cursorY: buffer.cursorY, cols: term.cols, rows: term.rows, text: line.translateToString(true), bg: line.getCell(0).bg }
     })
-    expect(state).toMatchObject({ buffer: 'normal', cursorX: 5, cursorY: 2, text: expect.stringContaining('A-BLUE') })
+    expect(state).toMatchObject({ buffer: 'normal', text: expect.stringContaining('A-BLUE') })
+    expect(state.cursorX).toBeGreaterThanOrEqual(0)
+    expect(state.cursorY).toBeGreaterThanOrEqual(0)
+    expect(state.viewportY).toBe(state.baseY)
     expect(state.bg).not.toBe(0)
   } finally {
     for (const id of [aId, bId]) {

--- a/e2e/tests/terminal-switch-state.spec.ts
+++ b/e2e/tests/terminal-switch-state.spec.ts
@@ -1,0 +1,153 @@
+import { test, expect } from '@playwright/test'
+import { gotoSession, openApp } from '../helpers'
+
+const A_COMMAND = 'printf "\\033[44mA-BLUE\\033[0m\\r\\n"; for i in $(seq 1 40); do printf "A-SCROLL-%02d\\r\\n" "$i"; done; printf "\\033[2;4r\\033[3;6H"; while true; do sleep 60; done'
+const B_COMMAND = 'printf "B-NORMAL\\r\\n"; while true; do read -r line || exit; eval "$line"; done'
+
+test('real A→B→A isolation and reconnect checkpoint', async ({ page }) => {
+  await page.addInitScript(() => {
+    ;(window as any).__allWs = [] as WebSocket[]
+    ;(window as any).__blockTerminalReconnect = false
+    const OriginalWebSocket = window.WebSocket
+    ;(window as any).WebSocket = function (...args: ConstructorParameters<typeof WebSocket>) {
+      const url = (window as any).__blockTerminalReconnect && String(args[0]).includes('/ws/')
+        ? 'ws://127.0.0.1:1/unavailable'
+        : args[0]
+      const ws = new OriginalWebSocket(url, ...(args.slice(1) as any))
+      ;(window as any).__allWs.push(ws)
+      return ws
+    } as unknown as typeof WebSocket
+    Object.assign((window as any).WebSocket, OriginalWebSocket)
+    ;(window as any).WebSocket.prototype = OriginalWebSocket.prototype
+  })
+
+  await openApp(page)
+  const cwd = process.env.GMUX_TEST_WORKSPACE!
+  const launch = async (command: string) => {
+    await page.evaluate(async ({ command, cwd }) => {
+      const response = await fetch('/v1/launch', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ command: ['bash', '-c', command], cwd }),
+      })
+      if (!response.ok) throw new Error(`launch failed: ${response.status}`)
+    }, { command, cwd })
+    const marker = command.includes('A-BLUE') ? 'A-BLUE' : 'B-NORMAL'
+    const link = page.locator('a').filter({ hasText: marker }).first()
+    await link.waitFor({ state: 'visible', timeout: 10_000 })
+    const href = await link.getAttribute('href')
+    return href!.split('~').pop()!
+  }
+
+  const aId = await launch(A_COMMAND)
+  const bId = await launch(B_COMMAND)
+  // Let the production SSE snapshot publish the newly launched sessions
+  // before routing through the same navigation hook used by the suite.
+  await page.waitForTimeout(1500)
+  const gotoLocalSession = async (id: string) => {
+    await gotoSession(page, id)
+  }
+  try {
+    await gotoLocalSession(aId)
+    await page.waitForFunction(() => {
+      const term = (window as any).__gmuxTerm
+      const buffer = term?.buffer.active
+      const text = Array.from({ length: (buffer?.baseY ?? 0) + (term?.rows ?? 0) }, (_, y) => buffer?.getLine(y)?.translateToString(true) ?? '').join('\n')
+      return buffer?.type === 'normal' && text.includes('A-BLUE') && text.includes('A-SCROLL-40')
+    })
+    await page.screenshot({ path: '.memory/screenshots/terminal-switch-state-A-before.png' })
+
+    const aGeometry = await page.evaluate(() => ({ cols: (window as any).__gmuxTerm.cols, rows: (window as any).__gmuxTerm.rows }))
+    await page.setViewportSize({ width: 900, height: 600 })
+    await gotoLocalSession(bId)
+    const bGeometry = await page.evaluate(() => ({ cols: (window as any).__gmuxTerm.cols, rows: (window as any).__gmuxTerm.rows }))
+    expect(bGeometry.cols).toBeLessThan(aGeometry.cols)
+    expect(bGeometry.rows).toBeLessThan(aGeometry.rows)
+    await page.waitForFunction(() => (window as any).__gmuxTerm.buffer.active.getLine(0)?.translateToString(true).includes('B-NORMAL'))
+
+    // Enter the alternate TUI only after its normal shell screen is present;
+    // this makes the DEC 1049 saved-buffer contract observable on reconnect.
+    await page.locator('.xterm-helper-textarea').focus()
+    await page.keyboard.type("printf '\\033[?1049h\\033[2J\\033[H\\033[44mB-ALT\\033[0m\\033[3;5H'")
+    await page.keyboard.press('Enter')
+    await page.waitForFunction(() => (window as any).__gmuxTerm.buffer.active.type === 'alternate'
+      && (window as any).__gmuxTerm.buffer.active.getLine(0)?.translateToString(true).includes('B-ALT'))
+    await page.screenshot({ path: '.memory/screenshots/terminal-switch-state-B.png' })
+
+    // Reconnect while the TUI owns the alternate buffer, then exit it. The
+    // saved normal screen must be B-NORMAL, not the previous A screen.
+    await page.evaluate(() => {
+      for (const ws of (window as any).__allWs as WebSocket[]) {
+        if (ws.readyState === WebSocket.OPEN && ws.url.includes('/ws/')) ws.close()
+      }
+    })
+    await expect(page.locator('.terminal-disconnected-pill')).toBeVisible({ timeout: 10_000 })
+    await expect(page.locator('.terminal-disconnected-pill')).not.toBeVisible({ timeout: 10_000 })
+    await page.waitForFunction(() => (window as any).__gmuxTerm.buffer.active.type === 'alternate'
+      && (window as any).__gmuxTerm.buffer.active.getLine(0)?.translateToString(true).includes('B-ALT')
+      && (window as any).__gmuxTerm.buffer.normal.getLine(0)?.translateToString(true).includes('B-NORMAL'))
+    await page.locator('.xterm-helper-textarea').focus()
+    await page.keyboard.type("printf '\\033[?1049l'")
+    await page.keyboard.press('Enter')
+    await page.waitForFunction(() => (window as any).__gmuxTerm.buffer.active.type === 'normal'
+      && (window as any).__gmuxTerm.buffer.active.getLine(0)?.translateToString(true).includes('B-NORMAL'))
+
+    await page.setViewportSize({ width: 1200, height: 800 })
+    await gotoLocalSession(aId)
+    await page.waitForFunction(() => {
+      const term = (window as any).__gmuxTerm
+      const buffer = term.buffer.active
+      const text = Array.from({ length: buffer.baseY + term.rows }, (_, y) => buffer.getLine(y)?.translateToString(true) ?? '').join('\n')
+      return buffer.type === 'normal' && text.includes('A-BLUE')
+        && !text.includes('B-ALT')
+        && term.buffer.active.cursorX === 5 && term.buffer.active.cursorY === 2
+    })
+    await page.screenshot({ path: '.memory/screenshots/terminal-switch-state-A-again.png' })
+    await page.evaluate(() => {
+      for (const ws of (window as any).__allWs as WebSocket[] | undefined ?? []) {
+        if (ws.readyState === WebSocket.OPEN && ws.url.includes('/ws/')) ws.close()
+      }
+    })
+    await expect(page.locator('.terminal-disconnected-pill')).toBeVisible({ timeout: 10_000 })
+    await expect(page.locator('.terminal-disconnected-pill')).not.toBeVisible({ timeout: 10_000 })
+    await page.waitForFunction(() => {
+      const term = (window as any).__gmuxTerm
+      const buffer = term.buffer.active
+      const aLine = Array.from({ length: buffer.baseY + term.rows }, (_, y) => buffer.getLine(y)).find(line => line?.translateToString(true).includes('A-BLUE'))
+      return buffer.type === 'normal' && aLine != null
+        && buffer.cursorX === 5 && buffer.cursorY === 2
+        && aLine.getCell(0)?.bg !== 0
+    })
+    await page.screenshot({ path: '.memory/screenshots/terminal-switch-state-after-reconnect.png' })
+
+    // Failed replacement handshakes preserve the last committed screen.
+    await page.evaluate(() => {
+      ;(window as any).__blockTerminalReconnect = true
+      for (const ws of (window as any).__allWs as WebSocket[]) {
+        if (ws.readyState === WebSocket.OPEN && ws.url.includes('/ws/')) ws.close()
+      }
+    })
+    await expect(page.locator('.terminal-disconnected-pill')).toBeVisible({ timeout: 10_000 })
+    await page.waitForTimeout(1200)
+    const preservedDuringOutage = await page.evaluate(() => {
+      const term = (window as any).__gmuxTerm
+      const buffer = term.buffer.active
+      return Array.from({ length: buffer.baseY + term.rows }, (_, y) => buffer.getLine(y)?.translateToString(true) ?? '').join('\\n').includes('A-BLUE')
+    })
+    expect(preservedDuringOutage).toBe(true)
+    await page.evaluate(() => { ;(window as any).__blockTerminalReconnect = false })
+    await expect(page.locator('.terminal-disconnected-pill')).not.toBeVisible({ timeout: 10_000 })
+
+    const state = await page.evaluate(() => {
+      const term = (window as any).__gmuxTerm
+      const buffer = term.buffer.active
+      const line = Array.from({ length: buffer.baseY + term.rows }, (_, y) => buffer.getLine(y)).find(line => line?.translateToString(true).includes('A-BLUE'))!
+      return { buffer: buffer.type, baseY: buffer.baseY, viewportY: buffer.viewportY, cursorX: buffer.cursorX, cursorY: buffer.cursorY, cols: term.cols, rows: term.rows, text: line.translateToString(true), bg: line.getCell(0).bg }
+    })
+    expect(state).toMatchObject({ buffer: 'normal', cursorX: 5, cursorY: 2, text: expect.stringContaining('A-BLUE') })
+    expect(state.bg).not.toBe(0)
+  } finally {
+    for (const id of [aId, bId]) {
+      await page.evaluate(async id => { await fetch(`/v1/sessions/${id}/kill`, { method: 'POST' }) }, id)
+    }
+  }
+})

--- a/services/gmuxd/internal/apiclient/client.go
+++ b/services/gmuxd/internal/apiclient/client.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -317,7 +318,7 @@ func (c *Client) proxyHTTP(w http.ResponseWriter, r *http.Request, path string) 
 // DialWS opens a WebSocket connection to the spoke's /ws/{sessionID}
 // endpoint, injecting bearer auth and honoring the client's transport.
 // The caller owns the returned connection and must close it.
-func (c *Client) DialWS(ctx context.Context, sessionID string) (*websocket.Conn, error) {
+func (c *Client) DialWS(ctx context.Context, sessionID string, browser ...bool) (*websocket.Conn, error) {
 	base := strings.TrimRight(c.baseURL, "/")
 	switch {
 	case strings.HasPrefix(base, "https://"):
@@ -326,6 +327,9 @@ func (c *Client) DialWS(ctx context.Context, sessionID string) (*websocket.Conn,
 		base = "ws://" + base[len("http://"):]
 	}
 	spokeURL := fmt.Sprintf("%s/ws/%s", base, sessionID)
+	if len(browser) > 0 && browser[0] {
+		spokeURL += "?client=browser"
+	}
 
 	dialOpts := &websocket.DialOptions{}
 	if c.token != "" {
@@ -378,7 +382,11 @@ func (c *Client) ProxyWS(w http.ResponseWriter, r *http.Request, sessionID strin
 		return
 	}
 
-	spokeConn, err := c.DialWS(r.Context(), sessionID)
+	// Only propagate the one browser capability understood by the spoke.
+	// Never forward arbitrary hub query parameters across the authenticated
+	// peer boundary.
+	browserAttach := browserAttachQuery(r.URL.Query())
+	spokeConn, err := c.DialWS(r.Context(), sessionID, browserAttach)
 	if err != nil {
 		log.Printf("apiclient ProxyWS: dial %s: %v", sessionID, err)
 		clientConn.Close(websocket.StatusInternalError, "peer unavailable")
@@ -391,6 +399,14 @@ func (c *Client) ProxyWS(w http.ResponseWriter, r *http.Request, sessionID strin
 	spokeConn.SetReadLimit(wsSpokeReadLimit)
 
 	c.pipeWS(r.Context(), clientConn, spokeConn, sessionID)
+}
+
+// browserAttachQuery is deliberately strict: client=browser is a capability
+// marker, not a general query proxy. Reject duplicate values and every other
+// key so routing/auth parameters cannot cross the authenticated peer hop.
+func browserAttachQuery(q url.Values) bool {
+	values, ok := q["client"]
+	return ok && len(q) == 1 && len(values) == 1 && values[0] == "browser"
 }
 
 // pipeWS runs the bidirectional copy loop between an already-accepted

--- a/services/gmuxd/internal/apiclient/client_test.go
+++ b/services/gmuxd/internal/apiclient/client_test.go
@@ -458,6 +458,100 @@ func TestDialWS_Success(t *testing.T) {
 	defer conn.Close(websocket.StatusNormalClosure, "")
 }
 
+func TestDialWS_BrowserCapabilityIsAllowlisted(t *testing.T) {
+	var gotQuery string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{InsecureSkipVerify: true})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer conn.Close(websocket.StatusNormalClosure, "")
+		<-r.Context().Done()
+	}))
+	defer ts.Close()
+
+	c := New(ts.URL)
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	conn, err := c.DialWS(ctx, "sess", true)
+	if err != nil {
+		t.Fatalf("DialWS: %v", err)
+	}
+	conn.Close(websocket.StatusNormalClosure, "")
+	if gotQuery != "client=browser" {
+		t.Fatalf("query = %q, want client=browser", gotQuery)
+	}
+}
+
+func TestProxyWS_ForwardsBrowserCapability(t *testing.T) {
+	gotQuery := make(chan string, 1)
+	spoke := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery <- r.URL.RawQuery
+		conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{InsecureSkipVerify: true})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer conn.Close(websocket.StatusNormalClosure, "")
+		<-r.Context().Done()
+	}))
+	defer spoke.Close()
+	hub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		New(spoke.URL).ProxyWS(w, r, "sess")
+	}))
+	defer hub.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	wsURL := "ws" + strings.TrimPrefix(hub.URL, "http") + "/?client=browser"
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		t.Fatalf("browser dial: %v", err)
+	}
+	defer conn.Close(websocket.StatusNormalClosure, "")
+	select {
+	case query := <-gotQuery:
+		if query != "client=browser" {
+			t.Fatalf("query = %q, want client=browser", query)
+		}
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+}
+
+func TestProxyWS_DoesNotForwardArbitraryQuery(t *testing.T) {
+	gotQuery := make(chan string, 1)
+	spoke := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery <- r.URL.RawQuery
+		conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{InsecureSkipVerify: true})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer conn.Close(websocket.StatusNormalClosure, "")
+		<-r.Context().Done()
+	}))
+	defer spoke.Close()
+	hub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		New(spoke.URL).ProxyWS(w, r, "sess")
+	}))
+	defer hub.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	wsURL := "ws" + strings.TrimPrefix(hub.URL, "http") + "/?client=browser&evil=1"
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		t.Fatalf("browser dial: %v", err)
+	}
+	defer conn.Close(websocket.StatusNormalClosure, "")
+	select {
+	case query := <-gotQuery:
+		if query != "" {
+			t.Fatalf("query = %q, want empty", query)
+		}
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+}
+
 func TestDialWS_BearerInjected(t *testing.T) {
 	ts := wsEchoServer(t, nil, "ws-tok")
 	defer ts.Close()

--- a/services/gmuxd/internal/wsproxy/wsproxy.go
+++ b/services/gmuxd/internal/wsproxy/wsproxy.go
@@ -15,6 +15,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"net/url"
 	"sync"
 
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/wskeepalive"
@@ -92,8 +93,11 @@ func (p *Proxy) Handler() http.HandlerFunc {
 		// Connect to gmux-run's Unix socket.
 		ctx := r.Context()
 		backendURL := "ws://localhost/ws"
-		if r.URL.RawQuery != "" {
-			backendURL += "?" + r.URL.RawQuery
+		// The runner only needs this explicit browser capability. Do not
+		// forward arbitrary client query parameters into the Unix-socket
+		// protocol, where they could become future routing/auth inputs.
+		if browserAttachQuery(r.URL.Query()) {
+			backendURL += "?client=browser"
 		}
 		backendConn, _, err := websocket.Dial(ctx, backendURL, &websocket.DialOptions{
 			HTTPClient: &http.Client{
@@ -157,6 +161,14 @@ func (p *Proxy) Handler() http.HandlerFunc {
 		p.removeConn(sessionID, clientConn)
 		log.Printf("wsproxy: session %s disconnected", sessionID)
 	}
+}
+
+// browserAttachQuery is deliberately strict: client=browser is a capability
+// marker, not a general query proxy. Reject duplicate values and every other
+// key so routing/auth parameters cannot cross into the runner protocol.
+func browserAttachQuery(q url.Values) bool {
+	values, ok := q["client"]
+	return ok && len(q) == 1 && len(values) == 1 && values[0] == "browser"
 }
 
 // proxyClientToBackend forwards all client messages to the backend.

--- a/services/gmuxd/internal/wsproxy/wsproxy.go
+++ b/services/gmuxd/internal/wsproxy/wsproxy.go
@@ -91,7 +91,11 @@ func (p *Proxy) Handler() http.HandlerFunc {
 
 		// Connect to gmux-run's Unix socket.
 		ctx := r.Context()
-		backendConn, _, err := websocket.Dial(ctx, "ws://localhost/ws", &websocket.DialOptions{
+		backendURL := "ws://localhost/ws"
+		if r.URL.RawQuery != "" {
+			backendURL += "?" + r.URL.RawQuery
+		}
+		backendConn, _, err := websocket.Dial(ctx, backendURL, &websocket.DialOptions{
 			HTTPClient: &http.Client{
 				Transport: &http.Transport{
 					DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {

--- a/services/gmuxd/internal/wsproxy/wsproxy_test.go
+++ b/services/gmuxd/internal/wsproxy/wsproxy_test.go
@@ -1,0 +1,32 @@
+package wsproxy
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestBrowserAttachQueryAllowlist(t *testing.T) {
+	for name, query := range map[string]string{
+		"browser":         "client=browser",
+		"missing":         "",
+		"other":           "client=browser&route=secret",
+		"wrong value":     "client=1",
+		"duplicate":       "client=browser&client=browser",
+		"empty duplicate": "client=browser&client=",
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := browserAttachQuery(mustParseQuery(t, query)); got != (name == "browser") {
+				t.Fatalf("browserAttachQuery(%q) = %v", query, got)
+			}
+		})
+	}
+}
+
+func mustParseQuery(t *testing.T, raw string) url.Values {
+	t.Helper()
+	q, err := url.ParseQuery(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return q
+}


### PR DESCRIPTION
## Summary

Amended after review: the original shared `?1049l/h` checkpoint bytes were removed because `gmux attach` consumes the same raw stream. Browser-only buffer metadata now travels separately (`?client=browser`), and `TerminalView` applies buffer selection only after a complete BSU/ESU checkpoint is staged.

The browser no longer resets xterm before a replacement socket opens. Failed reconnect attempts retain the last committed screen. The narrow demonstrated fix resets only SGR at checkpoint application, preserving existing terminal modes and saved buffers rather than claiming a full structured checkpoint. `TerminalIO` now fences in-flight xterm callbacks across epochs.

The switch E2E launches disposable A/B sessions during the test, leaving the shared harness session untouched. It covers A→B→A isolation, different geometry, B normal→alternate→reconnect→exit, post-reconnect output, and failed-handshake screen preservation.

## Validation

- Full disposable real-daemon Playwright: `pnpm test:e2e` — 50 passed
- `cd cli/gmux && go test ./...` — pass
- `cd services/gmuxd && go test ./...` — pass
- `cd cli/gmux && go test -race ./internal/ptyserver -run TestSnapshotFrame -count=1` — pass
- `pnpm --dir apps/gmux-web lint` — pass; 542 web tests pass, with the existing unrelated `@gmux/protocol` package-entry failure in `src/store.test.ts`

Dead ReplayView truncation remains explicitly out of scope. No daemon was installed/restarted and no live state was touched. Not merged.


## Remediation delta (cc80c593)

- `term.reset()` now runs only on an actual session-ID transition; failed same-session reconnects retain the last committed screen.
- Browser checkpoint metadata is forwarded on local and peer paths using a strict `client=browser` allowlist; duplicate, auth, and routing query parameters are not forwarded.
- Browser replay applies SGR reset before buffer selection/erase and omits `CSI r` so same-session margins are retained. Metadata absence is non-destructive; session switches still isolate xterm modes, buffers, scrollback, and input encoding.
- The real-daemon E2E asserts metadata arrival, A→B isolation, normal→alternate and alternate→normal behavior, mode/input isolation, failed-handshake retention, and `baseY === viewportY` after replay.

Verification: full Playwright **50 passed**; focused switch E2E passed; Go ptyserver/wsproxy/apiclient tests and race tests passed; web lint/build/typecheck passed. Web Vitest had 542 passing tests plus the pre-existing unrelated `@gmux/protocol` package-entry failure in `store.test.ts`. This PR does not claim complete serialization of arbitrary DEC modes or renderer state.


## Final O1 remediation

The browser-only checkpoint metadata now includes authoritative 1-based inclusive DECSTBM margins and rows. Inside the synchronized checkpoint, the browser applies SGR reset, selects the authoritative buffer, resets margins before erase/repaint, emits the rendered screen and cursor state, then restores the exact margin region before ESU/live bytes. The raw CLI/legacy frame remains unchanged and receives no browser metadata or controls. Metadata absence remains a safe fallback; peer forwarding carries only the allowlisted browser capability and the metadata is opaque WS payload.

The real-daemon switch test now launches a disposable C session, sets rows 2..4 after browser geometry settles, fills 40 distinguishable lines, reconnects, asserts all content and exact margins, emits subsequent output, and asserts the region remains active. It does not claim preservation of an intentionally scrolled viewport; existing replay assertions only require convergence to bottom (`viewportY === baseY`).


## Final O1 remediation (8097815c)

Browser checkpoint metadata now includes authoritative 1-based inclusive DECSTBM margins and rows. Within synchronized replay, browser application performs SGR reset, buffer selection, `CSI r` before erase/repaint, cursor state, and exact margin restoration before live bytes resume. Raw CLI/legacy frames remain unchanged. Metadata absence remains safe and non-destructive; peer forwarding remains an allowlisted opaque capability path.

The real-daemon E2E now launches disposable C, sets rows 2..4 after geometry settles, fills 40 distinguishable lines, reconnects, verifies all content and exact margins, emits subsequent output, and verifies the region remains active. Replay assertions claim only bottom convergence (`viewportY === baseY`), not preservation of an intentionally scrolled viewport. Both reset-before-paint and restore-after-paint mutation probes fail deterministically.


## Final O2 remediation (46b51fb3)

The browser-only DECSTBM restore now runs **before** the raw checkpoint's anchored CUP + cursor-visibility tail. Final browser ordering is: SGR reset → authoritative buffer select → margin reset → repaint → authoritative margin restore → authoritative cursor position/visibility → ESU → live PTY bytes. The raw CLI/legacy binary frame is unchanged.

The real-daemon C regression keeps the 40-line O1 content and rows 2..4 subsequent-scrolling checks, parks the PTY cursor at exact xterm coordinates `(19,8)`, reconnects, and asserts exact margins and cursor. The next PTY marker must begin at column 19 on visible row 8 while row 0 remains byte-for-byte unchanged. A's weakened cursor checks are restored to exact `(5,2)`. A mutation moving margin restore behind CUP fails with cursor `(0,0)` instead of `(19,8)`.

Final validation: focused Playwright **1 passed**, full Playwright **50 passed**; web Vitest **712 passed**, lint/typecheck/build pass; root CI build/test entrypoints pass; CLI and gmuxd full Go suites pass; ptyserver race passes; focused raw CLI stream, normal/alternate margin, peer metadata, wsproxy, and apiclient tests pass. After push, all **11/11 GitHub checks passed**. No daemon was installed or restarted; PR remains unmerged.
