### PR TITLE
feat(web): filter the family panel by state, act on it in bulk, and quote one set of family numbers everywhere

### DIFF
--- a/apps/gmux-web/src/family-drawer-model.test.ts
+++ b/apps/gmux-web/src/family-drawer-model.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { FAMILY_LEVEL_CAP, splitLevel } from './family-drawer-model'
-import { projectFamily } from './family'
+import {
+  FAMILY_ROW_BUDGET, FAMILY_ROW_FLOOR, FAMILY_STALE_AFTER_MS, splitLevel, visibleFamilyRows,
+} from './family-drawer-model'
+import { projectFamily, type FamilyNode } from './family'
 import { makeSession } from './test-helpers'
 
 const at = (minute: number) => `2026-08-04T10:${String(minute).padStart(2, '0')}:00Z`
@@ -8,77 +10,239 @@ const root = makeSession({
   id: 'root', cwd: '/p', title: 'root', semantic_agent: true,
   created_at: at(0), last_output_at: at(1),
 })
-const child = (id: string, minute: number) => makeSession({
-  id, cwd: '/p', title: id, parent_session_id: 'root', semantic_agent: true,
+const child = (id: string, minute: number, parent = 'root') => makeSession({
+  id, cwd: '/p', title: id, parent_session_id: parent, semantic_agent: true,
   created_at: at(0), last_output_at: at(minute),
 })
 
 function rootChildren(count: number) {
   const snapshot = [root, ...Array.from({ length: count }, (_, i) => child(`c-${i}`, 59 - i))]
-  return projectFamily(root, snapshot).tree.children
+  return projectFamily(root, snapshot).tree
 }
 
-describe('panel level split (cap + summary row)', () => {
-  it('shows small levels in full with no summary row', () => {
-    const nodes = rootChildren(FAMILY_LEVEL_CAP)
-    expect(splitLevel(nodes, 'root', new Set())).toEqual({ shown: nodes, summary: null })
+/** Every line the panel would draw, walking the budget the way the
+ * component does. Summary rows are lines too — that is the whole point
+ * of the budget — so they are counted here as `+N more`. */
+function renderedLines(tree: FamilyNode, visible: ReadonlySet<string>): string[] {
+  const out: string[] = []
+  const walk = (node: FamilyNode) => {
+    out.push(node.session.id)
+    const { shown, summary } = splitLevel(node.children, node.session.id, new Set(), visible)
+    for (const kid of shown) walk(kid)
+    if (summary) out.push(`${node.session.id}:${summary.label}`)
+  }
+  walk(tree)
+  return out
+}
+
+describe('the panel draws at most a screenful, whatever the family looks like', () => {
+  it('shows a small family whole, with no summary rows', () => {
+    const tree = rootChildren(6)
+    const visible = visibleFamilyRows(tree)
+    expect(renderedLines(tree, visible)).toHaveLength(7)
+    expect(splitLevel(tree.children, 'root', new Set(), visible).summary).toBeNull()
   })
 
-  it('caps an over-full level at the most recent 15 behind "+N more"', () => {
-    const nodes = rootChildren(40)
-    const { shown, summary } = splitLevel(nodes, 'root', new Set())
-    expect(shown.map(n => n.session.id)).toEqual(nodes.slice(0, 15).map(n => n.session.id))
-    expect(summary).toEqual({ key: 'root', expanded: false, label: '+25 more' })
+  it('bounds a wide family and folds the rest into "+N more"', () => {
+    const tree = rootChildren(40)
+    const visible = visibleFamilyRows(tree)
+    const rows = renderedLines(tree, visible)
+    expect(rows).toHaveLength(FAMILY_ROW_BUDGET)
+    const { shown, summary } = splitLevel(tree.children, 'root', new Set(), visible)
+    expect(summary).toEqual({ key: 'root', expanded: false, label: `+${40 - shown.length} more` })
   })
 
-  it('expands two-state per parent: everything plus "show fewer"', () => {
-    const nodes = rootChildren(40)
-    const { shown, summary } = splitLevel(nodes, 'root', new Set(['root']))
-    expect(shown).toHaveLength(40)
-    expect(summary).toEqual({ key: 'root', expanded: true, label: 'show fewer' })
-    // Another parent's expansion state does not leak into this level.
-    expect(splitLevel(nodes, 'root', new Set(['other-parent'])).shown).toHaveLength(15)
+  it('bounds a deep family too, where a per-level cap bounded nothing', () => {
+    // A chain nine deep with three children each: the shape that used to
+    // render two hundred rows under a fifteen-per-level cap.
+    const snapshot = [root]
+    let parents = ['root']
+    for (let depth = 0; depth < 9; depth++) {
+      const next: string[] = []
+      for (const parent of parents) {
+        for (let i = 0; i < 3; i++) {
+          const id = `d${depth}-${parent}-${i}`
+          snapshot.push(child(id, 59 - depth, parent))
+          next.push(id)
+        }
+      }
+      parents = next.slice(0, 2) // keep the fixture from exploding
+    }
+    const tree = projectFamily(root, snapshot).tree
+    expect(renderedLines(tree, visibleFamilyRows(tree)).length).toBeLessThanOrEqual(FAMILY_ROW_BUDGET)
+  })
+
+  it('ranks across branches, so a stale branch loses to newer work elsewhere', () => {
+    // Two only-children: one recent, one stale. A per-level cap never
+    // folded either — each was the sole row of its level.
+    const snapshot = [
+      root,
+      child('busy', 59), child('busy-kid', 58, 'busy'),
+      child('stale', 5), child('stale-kid', 4, 'stale'),
+    ]
+    const tree = projectFamily(root, snapshot).tree
+    const rows = renderedLines(tree, visibleFamilyRows(tree, new Set(), 4))
+    expect(rows).toContain('busy')
+    expect(rows).toContain('busy-kid')
+    // The stale branch folds whole, which a per-level cap could never
+    // do: each of these is an only child, alone on its level, and a cap
+    // per level never folds a level of one.
+    expect(rows).not.toContain('stale')
+    expect(rows).not.toContain('stale-kid')
+    expect(rows).toContain('root:+1 more')
+    expect(rows).toHaveLength(4)
   })
 })
 
 describe('the row you are on is never behind the fold', () => {
-  it('keeps a pinned member that recency would have folded away', () => {
-    const nodes = rootChildren(40)
-    const stale = nodes[nodes.length - 1].session.id // oldest, deep below the cap
-    const { shown, summary } = splitLevel(nodes, 'root', new Set(), new Set([stale]))
-    expect(shown.map(n => n.session.id)).toContain(stale)
-    // A pinned row spends a slot rather than widening the level, so the
-    // panel's height doesn't jump around as you navigate.
-    expect(shown).toHaveLength(FAMILY_LEVEL_CAP)
-    expect(summary).toEqual({ key: 'root', expanded: false, label: '+25 more' })
-  })
-
-  it('keeps recency order rather than floating the pinned row to the top', () => {
-    const nodes = rootChildren(40)
-    const stale = nodes[nodes.length - 1].session.id
-    const { shown } = splitLevel(nodes, 'root', new Set(), new Set([stale]))
-    const order = shown.map(n => nodes.findIndex(x => x.session.id === n.session.id))
-    expect(order).toEqual([...order].sort((a, b) => a - b))
-    expect(shown[shown.length - 1].session.id).toBe(stale)
-  })
-
   it('renders the whole spine of a deep selection, quiet ancestors included', () => {
     // The realistic shape: an orchestrator with many subagents goes quiet
     // while the one you're in does the talking, so its parent ranks last
-    // on recency — exactly the row the cap would drop.
-    const kids = Array.from({ length: 20 }, (_, i) => child(`mid-${i}`, 59 - i))
+    // on recency — exactly the row a budget would spend elsewhere.
+    const kids = Array.from({ length: 40 }, (_, i) => child(`mid-${i}`, 59 - i))
     const quietParent = kids[kids.length - 1]
+    // Quiet itself, too: you're reading it, not running it. Nothing
+    // about this branch earns its way onto the screen on recency.
     const selected = makeSession({
       id: 'selected', cwd: '/p', title: 'selected', semantic_agent: true,
-      parent_session_id: quietParent.id, created_at: at(0), last_output_at: at(59),
+      parent_session_id: quietParent.id, created_at: at(0), last_output_at: at(3),
     })
-    const snapshot = [root, ...kids, selected]
-    const projection = projectFamily(selected, snapshot)
+    const projection = projectFamily(selected, [root, ...kids, selected])
     const pinned = new Set([...projection.ancestors.map(a => a.id), selected.id])
-    const { shown } = splitLevel(projection.tree.children, 'root', new Set(), pinned)
-    expect(shown.map(n => n.session.id)).toContain(quietParent.id)
-    // Without the pin the spine — and with it the selected row — vanishes.
-    const unpinned = splitLevel(projection.tree.children, 'root', new Set())
-    expect(unpinned.shown.map(n => n.session.id)).not.toContain(quietParent.id)
+    const rows = renderedLines(projection.tree, visibleFamilyRows(projection.tree, pinned))
+    expect(rows).toContain(quietParent.id)
+    expect(rows).toContain('selected')
+    // Without the pin, the spine — and with it the selected row — goes.
+    const unpinned = renderedLines(projection.tree, visibleFamilyRows(projection.tree))
+    expect(unpinned).not.toContain(quietParent.id)
+  })
+
+  it('spends budget on the spine rather than widening past it', () => {
+    const kids = Array.from({ length: 40 }, (_, i) => child(`mid-${i}`, 59 - i))
+    const quiet = kids[kids.length - 1]
+    const selected = makeSession({
+      id: 'selected', cwd: '/p', title: 'selected', semantic_agent: true,
+      parent_session_id: quiet.id, created_at: at(0), last_output_at: at(2),
+    })
+    const projection = projectFamily(selected, [root, ...kids, selected])
+    const pinned = new Set([...projection.ancestors.map(a => a.id), selected.id])
+    const visible = visibleFamilyRows(projection.tree, pinned)
+    expect(renderedLines(projection.tree, visible)).toHaveLength(FAMILY_ROW_BUDGET)
+  })
+})
+
+describe('level rows', () => {
+  it('keeps recency order rather than floating kept rows to the top', () => {
+    const tree = rootChildren(40)
+    const nodes = tree.children
+    const visible = visibleFamilyRows(tree, new Set([nodes[nodes.length - 1].session.id]))
+    const { shown } = splitLevel(nodes, 'root', new Set(), visible)
+    const order = shown.map(n => nodes.findIndex(x => x.session.id === n.session.id))
+    expect(order).toEqual([...order].sort((a, b) => a - b))
+    expect(shown[shown.length - 1].session.id).toBe(nodes[nodes.length - 1].session.id)
+  })
+
+  it('expands two-state per parent: everything plus "show fewer"', () => {
+    const tree = rootChildren(40)
+    const visible = visibleFamilyRows(tree)
+    const { shown, summary } = splitLevel(tree.children, 'root', new Set(['root']), visible)
+    expect(shown).toHaveLength(40)
+    expect(summary).toEqual({ key: 'root', expanded: true, label: 'show fewer' })
+    // Another parent's expansion state does not leak into this level.
+    expect(splitLevel(tree.children, 'root', new Set(['other-parent']), visible).shown.length)
+      .toBeLessThan(40)
+  })
+})
+
+describe('finished work folds itself away', () => {
+  const day = (hour: number, id: string, parent?: string) => makeSession({
+    id, cwd: '/p', title: id, parent_session_id: parent, semantic_agent: true,
+    created_at: '2026-08-04T00:00:00Z',
+    last_output_at: new Date(Date.parse('2026-08-04T20:00:00Z') - hour * 3600_000).toISOString(),
+  })
+
+  it('folds a branch that finished long before the rest of the family', () => {
+    // Plenty of budget left; the branch is dropped for being over, not
+    // for being in the way. Enough live siblings to clear the floor, so
+    // the fold is staleness talking and not the top-up.
+    const live = Array.from({ length: 10 }, (_, i) => day(0.1 * i, `fresh-${i}`, 'root'))
+    const snapshot = [day(0, 'root'), ...live, day(20, 'yesterday', 'root')]
+    const tree = projectFamily(snapshot[0], snapshot).tree
+    const rows = renderedLines(tree, visibleFamilyRows(tree))
+    expect(rows).toContain('fresh-0')
+    expect(rows).not.toContain('yesterday')
+    expect(rows).toContain('root:+1 more')
+  })
+
+  it('keeps an old family whole, because it is only old by the clock', () => {
+    // Everything stopped days ago. Staleness is measured from the
+    // family's own newest output, so nothing here is stale relative to
+    // anything else and the panel still shows the family.
+    const snapshot = [day(72, 'root'), day(72.2, 'a', 'root'), day(73, 'b', 'root')]
+    const tree = projectFamily(snapshot[0], snapshot).tree
+    const rows = renderedLines(tree, visibleFamilyRows(tree))
+    expect(rows).toEqual(expect.arrayContaining(['root', 'a', 'b']))
+  })
+
+  it('judges a branch by its liveliest member, not by its head', () => {
+    // The orchestrator went quiet hours ago; its subagent is mid-
+    // sentence. Judging the parent on its own output would fold both.
+    const snapshot = [day(0, 'root'), day(20, 'quiet', 'root'), day(0.1, 'talking', 'quiet')]
+    const tree = projectFamily(snapshot[0], snapshot).tree
+    const rows = renderedLines(tree, visibleFamilyRows(tree))
+    expect(rows).toEqual(expect.arrayContaining(['quiet', 'talking']))
+  })
+
+  it('keeps your own spine however stale it is', () => {
+    const snapshot = [day(0, 'root'), day(40, 'old', 'root'), day(41, 'older', 'old')]
+    const projection = projectFamily(snapshot[2], snapshot)
+    const pinned = new Set([...projection.ancestors.map(a => a.id), 'older'])
+    const rows = renderedLines(projection.tree, visibleFamilyRows(projection.tree, pinned))
+    expect(rows).toEqual(expect.arrayContaining(['old', 'older']))
+  })
+
+  it('folds nothing when the window is wider than the family', () => {
+    const snapshot = [day(0, 'root'), day(5, 'a', 'root'), day(20, 'b', 'root')]
+    const tree = projectFamily(snapshot[0], snapshot).tree
+    const wide = visibleFamilyRows(tree, new Set(), FAMILY_ROW_BUDGET, 48 * 3600_000)
+    expect(renderedLines(tree, wide)).toEqual(expect.arrayContaining(['a', 'b']))
+    // …and the default window is narrower than that, or the constant is
+    // doing nothing.
+    expect(FAMILY_STALE_AFTER_MS).toBeLessThan(48 * 3600_000)
+  })
+})
+
+describe('the floor', () => {
+  const hoursAgo = (hour: number, id: string, parent?: string) => makeSession({
+    id, cwd: '/p', title: id, parent_session_id: parent, semantic_agent: true,
+    created_at: '2026-08-04T00:00:00Z',
+    last_output_at: new Date(Date.parse('2026-08-04T20:00:00Z') - hour * 3600_000).toISOString(),
+  })
+
+  it('still maps a family whose work all finished before the window', () => {
+    // The root spoke recently; everything it did is hours older. Pure
+    // staleness would leave one row and a "+N more" — true, and no use
+    // to anyone trying to get back to a session.
+    const kids = Array.from({ length: 12 }, (_, i) => hoursAgo(10 + i * 0.1, `k-${i}`, 'root'))
+    const snapshot = [hoursAgo(0, 'root'), ...kids]
+    const tree = projectFamily(snapshot[0], snapshot).tree
+    const rows = renderedLines(tree, visibleFamilyRows(tree))
+    expect(rows.length).toBeGreaterThanOrEqual(FAMILY_ROW_FLOOR)
+    // Topped up most-recent-first, like everything else here.
+    expect(rows).toContain('k-0')
+    expect(rows).not.toContain('k-11')
+  })
+
+  it('does not pad a family that is simply small', () => {
+    const snapshot = [hoursAgo(0, 'root'), hoursAgo(0.1, 'only', 'root')]
+    const tree = projectFamily(snapshot[0], snapshot).tree
+    expect(renderedLines(tree, visibleFamilyRows(tree))).toEqual(['root', 'only'])
+  })
+
+  it('never lifts the panel past the budget', () => {
+    const kids = Array.from({ length: 60 }, (_, i) => hoursAgo(10 + i * 0.01, `k-${i}`, 'root'))
+    const tree = projectFamily(kids[0], [hoursAgo(0, 'root'), ...kids]).tree
+    const rows = renderedLines(tree, visibleFamilyRows(tree, new Set(), 5, FAMILY_STALE_AFTER_MS, 40))
+    expect(rows.length).toBeLessThanOrEqual(5)
   })
 })

--- a/apps/gmux-web/src/family-drawer-model.test.ts
+++ b/apps/gmux-web/src/family-drawer-model.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
-  FAMILY_ROW_BUDGET, FAMILY_ROW_FLOOR, FAMILY_STALE_AFTER_MS, splitLevel, visibleFamilyRows,
+  FAMILY_PROCESS_STALE_AFTER_MS, FAMILY_ROW_BUDGET, FAMILY_ROW_FLOOR, FAMILY_STALE_AFTER_MS,
+  splitLevel, visibleFamilyRows,
 } from './family-drawer-model'
 import { projectFamily, type FamilyNode } from './family'
 import { makeSession } from './test-helpers'
@@ -166,12 +167,14 @@ describe('finished work folds itself away', () => {
     // for being in the way. Enough live siblings to clear the floor, so
     // the fold is staleness talking and not the top-up.
     const live = Array.from({ length: 10 }, (_, i) => day(0.1 * i, `fresh-${i}`, 'root'))
-    const snapshot = [day(0, 'root'), ...live, day(20, 'yesterday', 'root')]
+    // Two of them: folding one lone leaf would save no line, so the
+    // panel would rightly draw it instead of counting it.
+    const snapshot = [day(0, 'root'), ...live, day(20, 'yesterday', 'root'), day(21, 'earlier', 'root')]
     const tree = projectFamily(snapshot[0], snapshot).tree
     const rows = renderedLines(tree, visibleFamilyRows(tree))
     expect(rows).toContain('fresh-0')
     expect(rows).not.toContain('yesterday')
-    expect(rows).toContain('root:+1 more')
+    expect(rows).toContain('root:+2 more')
   })
 
   it('keeps an old family whole, because it is only old by the clock', () => {
@@ -244,5 +247,111 @@ describe('the floor', () => {
     const tree = projectFamily(kids[0], [hoursAgo(0, 'root'), ...kids]).tree
     const rows = renderedLines(tree, visibleFamilyRows(tree, new Set(), 5, FAMILY_STALE_AFTER_MS, 40))
     expect(rows.length).toBeLessThanOrEqual(5)
+  })
+})
+
+describe("an agent's commands are a log, not a level", () => {
+  const ago = (minutes: number, id: string, parent: string | undefined, process: boolean) => makeSession({
+    id, cwd: '/p', title: id, parent_session_id: parent, semantic_agent: !process,
+    created_at: '2026-08-04T00:00:00Z',
+    last_output_at: new Date(Date.parse('2026-08-04T20:00:00Z') - minutes * 60_000).toISOString(),
+  })
+
+  it('shows an agent the command it is running, not the ten before it', () => {
+    // The observed shape: one agent with a wall of near-identical shell
+    // lines, drowning every other branch in the family.
+    const shells = Array.from({ length: 10 }, (_, i) => ago(2 + i, `sh-${i}`, 'busy', true))
+    const others = Array.from({ length: 5 }, (_, i) => ago(3 + i, `agent-${i}`, 'root', false))
+    const snapshot = [ago(0, 'root', undefined, false), ago(1, 'busy', 'root', false), ...shells, ...others]
+    const tree = projectFamily(snapshot[0], snapshot).tree
+    const rows = renderedLines(tree, visibleFamilyRows(tree))
+    expect(rows).toContain('sh-0')
+    expect(rows.filter(r => r.startsWith('sh-') && !r.includes(':'))).toHaveLength(1)
+    // The freed lines go to the rest of the family, which is the point.
+    expect(rows).toEqual(expect.arrayContaining(['agent-0', 'agent-4']))
+    // Nothing is lost: the remainder is one click away on its own level.
+    expect(rows).toContain('busy:+9 more')
+  })
+
+  it('gives each agent its own command', () => {
+    const snapshot = [
+      ago(0, 'root', undefined, false),
+      ago(1, 'a', 'root', false), ago(2, 'a-sh', 'a', true),
+      ago(3, 'b', 'root', false), ago(4, 'b-sh', 'b', true),
+    ]
+    const tree = projectFamily(snapshot[0], snapshot).tree
+    expect(renderedLines(tree, visibleFamilyRows(tree))).toEqual(
+      expect.arrayContaining(['a-sh', 'b-sh']),
+    )
+  })
+
+  it('drops a command that stopped talking, well before an agent would', () => {
+    const stale = FAMILY_PROCESS_STALE_AFTER_MS / 60_000 + 30
+    // Enough live siblings that the floor's top-up never runs; this is
+    // triage talking, not an empty panel being padded.
+    const live = Array.from({ length: 10 }, (_, i) => ago(1 + i * 0.1, `live-${i}`, 'root', false))
+    const snapshot = [
+      ago(0, 'root', undefined, false),
+      ...live,
+      ago(stale, 'quiet-agent', 'root', false),
+      // Two stale commands, so folding them is a real saving; one alone
+      // would cost the same line folded or drawn, and be drawn.
+      ago(stale, 'old-command', 'root', true),
+      ago(stale + 1, 'older-command', 'root', true),
+    ]
+    const tree = projectFamily(snapshot[0], snapshot).tree
+    const rows = renderedLines(tree, visibleFamilyRows(tree))
+    // Same age, different verdict: the agent is still worth a line at
+    // ninety minutes, the finished command is not.
+    expect(FAMILY_PROCESS_STALE_AFTER_MS).toBeLessThan(FAMILY_STALE_AFTER_MS)
+    expect(rows).toContain('quiet-agent')
+    expect(rows).not.toContain('old-command')
+  })
+
+  it('still maps a family that is nothing but commands', () => {
+    // 248 processes to 8 agents is a real family here. One command per
+    // agent would leave this one two rows deep, so the floor's top-up
+    // drops that rule too: a command log beats a blank panel.
+    const shells = Array.from({ length: 30 }, (_, i) => ago(2 + i * 0.1, `sh-${i}`, 'root', true))
+    const tree = projectFamily(shells[0], [ago(0, 'root', undefined, false), ...shells]).tree
+    expect(renderedLines(tree, visibleFamilyRows(tree)).length).toBeGreaterThanOrEqual(FAMILY_ROW_FLOOR)
+  })
+})
+
+describe('a summary that saves no space is not drawn', () => {
+  const ago = (minutes: number, id: string, parent: string | undefined, process = false) => makeSession({
+    id, cwd: '/p', title: id, parent_session_id: parent, semantic_agent: !process,
+    created_at: '2026-08-04T00:00:00Z',
+    last_output_at: new Date(Date.parse('2026-08-04T20:00:00Z') - minutes * 60_000).toISOString(),
+  })
+
+  it('names the last hidden command instead of counting it', () => {
+    // Two commands under one agent: the one-command rule would hide the
+    // second behind a "+1 more" that occupies the very line the command
+    // would have — costing the same and saying less.
+    const snapshot = [
+      ago(0, 'root', undefined), ago(1, 'agent', 'root'),
+      ago(2, 'sh-a', 'agent', true), ago(3, 'sh-b', 'agent', true),
+    ]
+    const tree = projectFamily(snapshot[0], snapshot).tree
+    const rows = renderedLines(tree, visibleFamilyRows(tree))
+    expect(rows).toEqual(['root', 'agent', 'sh-a', 'sh-b'])
+    expect(rows.some(r => r.includes('more'))).toBe(false)
+  })
+
+  it('still counts a hidden subtree, which is not the same bargain', () => {
+    // The lone hidden row here has children of its own, so drawing it
+    // raises a summary underneath: two lines for what a summary says in
+    // one. The count stays.
+    const stale = FAMILY_STALE_AFTER_MS / 60_000 + 60
+    const live = Array.from({ length: 10 }, (_, i) => ago(1 + i * 0.1, `live-${i}`, 'root'))
+    const snapshot = [
+      ago(0, 'root', undefined), ...live,
+      ago(stale, 'old', 'root'), ago(stale + 1, 'older', 'old'), ago(stale + 2, 'oldest', 'old'),
+    ]
+    const tree = projectFamily(snapshot[0], snapshot).tree
+    const rows = renderedLines(tree, visibleFamilyRows(tree))
+    expect(rows).toContain('root:+1 more')
+    expect(rows).not.toContain('old')
   })
 })

--- a/apps/gmux-web/src/family-drawer-model.test.ts
+++ b/apps/gmux-web/src/family-drawer-model.test.ts
@@ -31,7 +31,7 @@ function renderedLines(tree: FamilyNode, view: FamilyView): string[] {
     out.push(node.session.id)
     const { shown, summary } = splitLevel(node.children, node.session.id, new Set(), view)
     for (const kid of shown) walk(kid)
-    if (summary) out.push(`${node.session.id}:${summary.label}`)
+    if (summary) out.push(`${node.session.id}:${summary}`)
   }
   walk(tree)
   return out
@@ -51,7 +51,7 @@ describe('the panel draws at most a screenful, whatever the family looks like', 
     const rows = renderedLines(tree, view)
     expect(rows).toHaveLength(FAMILY_ROW_BUDGET)
     const { shown, summary } = splitLevel(tree.children, 'root', new Set(), view)
-    expect(summary).toEqual({ key: 'root', expanded: false, label: `+${40 - shown.length} more` })
+    expect(summary).toBe(`+${40 - shown.length} more`)
   })
 
   it('bounds a deep family too, where a per-level cap bounded nothing', () => {
@@ -149,10 +149,19 @@ describe('level rows', () => {
     const view = visibleFamilyRows(tree)
     const { shown, summary } = splitLevel(tree.children, 'root', new Set(['root']), view)
     expect(shown).toHaveLength(40)
-    expect(summary).toEqual({ key: 'root', expanded: true, label: 'show fewer' })
+    expect(summary).toBe('show fewer')
     // Another parent's expansion state does not leak into this level.
     expect(splitLevel(tree.children, 'root', new Set(['other-parent']), view).shown.length)
       .toBeLessThan(40)
+  })
+
+  it('offers no control when the level has nothing folded', () => {
+    // Reachable by expanding a level and then filtering it down to
+    // what already fits: `show fewer` would then take nothing away.
+    const tree = rootChildren(3)
+    const view = visibleFamilyRows(tree)
+    expect(splitLevel(tree.children, 'root', new Set(), view).summary).toBeNull()
+    expect(splitLevel(tree.children, 'root', new Set(['root']), view).summary).toBeNull()
   })
 })
 

--- a/apps/gmux-web/src/family-drawer-model.test.ts
+++ b/apps/gmux-web/src/family-drawer-model.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import {
   FAMILY_PROCESS_STALE_AFTER_MS, FAMILY_ROW_BUDGET, FAMILY_ROW_FLOOR, FAMILY_STALE_AFTER_MS,
-  splitLevel, visibleFamilyRows,
+  splitLevel, visibleFamilyRows, type FamilyView,
 } from './family-drawer-model'
 import { projectFamily, type FamilyNode } from './family'
 import { makeSession } from './test-helpers'
+import type { Session } from './types'
 
 const at = (minute: number) => `2026-08-04T10:${String(minute).padStart(2, '0')}:00Z`
 const root = makeSession({
@@ -24,11 +25,11 @@ function rootChildren(count: number) {
 /** Every line the panel would draw, walking the budget the way the
  * component does. Summary rows are lines too — that is the whole point
  * of the budget — so they are counted here as `+N more`. */
-function renderedLines(tree: FamilyNode, visible: ReadonlySet<string>): string[] {
+function renderedLines(tree: FamilyNode, view: FamilyView): string[] {
   const out: string[] = []
   const walk = (node: FamilyNode) => {
     out.push(node.session.id)
-    const { shown, summary } = splitLevel(node.children, node.session.id, new Set(), visible)
+    const { shown, summary } = splitLevel(node.children, node.session.id, new Set(), view)
     for (const kid of shown) walk(kid)
     if (summary) out.push(`${node.session.id}:${summary.label}`)
   }
@@ -39,17 +40,17 @@ function renderedLines(tree: FamilyNode, visible: ReadonlySet<string>): string[]
 describe('the panel draws at most a screenful, whatever the family looks like', () => {
   it('shows a small family whole, with no summary rows', () => {
     const tree = rootChildren(6)
-    const visible = visibleFamilyRows(tree)
-    expect(renderedLines(tree, visible)).toHaveLength(7)
-    expect(splitLevel(tree.children, 'root', new Set(), visible).summary).toBeNull()
+    const view = visibleFamilyRows(tree)
+    expect(renderedLines(tree, view)).toHaveLength(7)
+    expect(splitLevel(tree.children, 'root', new Set(), view).summary).toBeNull()
   })
 
   it('bounds a wide family and folds the rest into "+N more"', () => {
     const tree = rootChildren(40)
-    const visible = visibleFamilyRows(tree)
-    const rows = renderedLines(tree, visible)
+    const view = visibleFamilyRows(tree)
+    const rows = renderedLines(tree, view)
     expect(rows).toHaveLength(FAMILY_ROW_BUDGET)
-    const { shown, summary } = splitLevel(tree.children, 'root', new Set(), visible)
+    const { shown, summary } = splitLevel(tree.children, 'root', new Set(), view)
     expect(summary).toEqual({ key: 'root', expanded: false, label: `+${40 - shown.length} more` })
   })
 
@@ -82,7 +83,7 @@ describe('the panel draws at most a screenful, whatever the family looks like', 
       child('stale', 5), child('stale-kid', 4, 'stale'),
     ]
     const tree = projectFamily(root, snapshot).tree
-    const rows = renderedLines(tree, visibleFamilyRows(tree, new Set(), 4))
+    const rows = renderedLines(tree, visibleFamilyRows(tree, { budget: 4 }))
     expect(rows).toContain('busy')
     expect(rows).toContain('busy-kid')
     // The stale branch folds whole, which a per-level cap could never
@@ -110,7 +111,7 @@ describe('the row you are on is never behind the fold', () => {
     })
     const projection = projectFamily(selected, [root, ...kids, selected])
     const pinned = new Set([...projection.ancestors.map(a => a.id), selected.id])
-    const rows = renderedLines(projection.tree, visibleFamilyRows(projection.tree, pinned))
+    const rows = renderedLines(projection.tree, visibleFamilyRows(projection.tree, { pinned }))
     expect(rows).toContain(quietParent.id)
     expect(rows).toContain('selected')
     // Without the pin, the spine — and with it the selected row — goes.
@@ -127,8 +128,8 @@ describe('the row you are on is never behind the fold', () => {
     })
     const projection = projectFamily(selected, [root, ...kids, selected])
     const pinned = new Set([...projection.ancestors.map(a => a.id), selected.id])
-    const visible = visibleFamilyRows(projection.tree, pinned)
-    expect(renderedLines(projection.tree, visible)).toHaveLength(FAMILY_ROW_BUDGET)
+    const view = visibleFamilyRows(projection.tree, { pinned })
+    expect(renderedLines(projection.tree, view)).toHaveLength(FAMILY_ROW_BUDGET)
   })
 })
 
@@ -136,8 +137,8 @@ describe('level rows', () => {
   it('keeps recency order rather than floating kept rows to the top', () => {
     const tree = rootChildren(40)
     const nodes = tree.children
-    const visible = visibleFamilyRows(tree, new Set([nodes[nodes.length - 1].session.id]))
-    const { shown } = splitLevel(nodes, 'root', new Set(), visible)
+    const view = visibleFamilyRows(tree, { pinned: new Set([nodes[nodes.length - 1].session.id]) })
+    const { shown } = splitLevel(nodes, 'root', new Set(), view)
     const order = shown.map(n => nodes.findIndex(x => x.session.id === n.session.id))
     expect(order).toEqual([...order].sort((a, b) => a - b))
     expect(shown[shown.length - 1].session.id).toBe(nodes[nodes.length - 1].session.id)
@@ -145,12 +146,12 @@ describe('level rows', () => {
 
   it('expands two-state per parent: everything plus "show fewer"', () => {
     const tree = rootChildren(40)
-    const visible = visibleFamilyRows(tree)
-    const { shown, summary } = splitLevel(tree.children, 'root', new Set(['root']), visible)
+    const view = visibleFamilyRows(tree)
+    const { shown, summary } = splitLevel(tree.children, 'root', new Set(['root']), view)
     expect(shown).toHaveLength(40)
     expect(summary).toEqual({ key: 'root', expanded: true, label: 'show fewer' })
     // Another parent's expansion state does not leak into this level.
-    expect(splitLevel(tree.children, 'root', new Set(['other-parent']), visible).shown.length)
+    expect(splitLevel(tree.children, 'root', new Set(['other-parent']), view).shown.length)
       .toBeLessThan(40)
   })
 })
@@ -200,14 +201,14 @@ describe('finished work folds itself away', () => {
     const snapshot = [day(0, 'root'), day(40, 'old', 'root'), day(41, 'older', 'old')]
     const projection = projectFamily(snapshot[2], snapshot)
     const pinned = new Set([...projection.ancestors.map(a => a.id), 'older'])
-    const rows = renderedLines(projection.tree, visibleFamilyRows(projection.tree, pinned))
+    const rows = renderedLines(projection.tree, visibleFamilyRows(projection.tree, { pinned }))
     expect(rows).toEqual(expect.arrayContaining(['old', 'older']))
   })
 
   it('folds nothing when the window is wider than the family', () => {
     const snapshot = [day(0, 'root'), day(5, 'a', 'root'), day(20, 'b', 'root')]
     const tree = projectFamily(snapshot[0], snapshot).tree
-    const wide = visibleFamilyRows(tree, new Set(), FAMILY_ROW_BUDGET, 48 * 3600_000)
+    const wide = visibleFamilyRows(tree, { staleAfterMs: 48 * 3600_000 })
     expect(renderedLines(tree, wide)).toEqual(expect.arrayContaining(['a', 'b']))
     // …and the default window is narrower than that, or the constant is
     // doing nothing.
@@ -245,7 +246,7 @@ describe('the floor', () => {
   it('never lifts the panel past the budget', () => {
     const kids = Array.from({ length: 60 }, (_, i) => hoursAgo(10 + i * 0.01, `k-${i}`, 'root'))
     const tree = projectFamily(kids[0], [hoursAgo(0, 'root'), ...kids]).tree
-    const rows = renderedLines(tree, visibleFamilyRows(tree, new Set(), 5, FAMILY_STALE_AFTER_MS, 40))
+    const rows = renderedLines(tree, visibleFamilyRows(tree, { budget: 5, floor: 40 }))
     expect(rows.length).toBeLessThanOrEqual(5)
   })
 })
@@ -353,5 +354,106 @@ describe('a summary that saves no space is not drawn', () => {
     const rows = renderedLines(tree, visibleFamilyRows(tree))
     expect(rows).toContain('root:+1 more')
     expect(rows).not.toContain('old')
+  })
+})
+
+describe('filtering by a state the tally counts', () => {
+  const ago = (minutes: number, id: string, parent: string | undefined, extra: Partial<Session> = {}) =>
+    makeSession({
+      id, cwd: '/p', title: id, parent_session_id: parent, semantic_agent: true,
+      created_at: '2026-08-04T00:00:00Z',
+      last_output_at: new Date(Date.parse('2026-08-04T20:00:00Z') - minutes * 60_000).toISOString(),
+      ...extra,
+    })
+  const errored = { status: { active: true, error: true } } as const
+  const waiting = { unread: true } as const
+
+  /** A family with something of each state, plus filler to make the
+   * budget and the staleness rules bite. */
+  const family = () => {
+    const noise = Array.from({ length: 20 }, (_, i) => ago(1 + i * 0.1, `noise-${i}`, 'root'))
+    return [
+      ago(0, 'root', undefined),
+      ...noise,
+      ago(2, 'boom', 'root', errored),
+      // Old enough that the panel's own triage would fold it away — and
+      // buried under an equally stale parent, so the free-leaf pass
+      // can't rescue it by accident: only the filter itself reaches it.
+      ago(48 * 60, 'old-branch', 'root'),
+      ago(48 * 60, 'ancient-boom', 'old-branch', errored),
+      ago(3, 'quiet', 'root'),
+      ago(4, 'deep-boom', 'quiet', errored),
+      ago(5, 'said-something', 'root', waiting),
+    ]
+  }
+
+  it('shows every member in the state, and nothing else that has one', () => {
+    const snapshot = family()
+    const tree = projectFamily(snapshot[0], snapshot).tree
+    const rows = renderedLines(tree, visibleFamilyRows(tree, { filter: 'error' }))
+    expect(rows).toEqual(expect.arrayContaining(['boom', 'deep-boom', 'ancient-boom']))
+    expect(rows).not.toContain('said-something')
+    expect(rows).not.toContain('noise-0')
+    // The filter counts as the triage, so staleness stops guessing:
+    // asked for the errors, you get the two-day-old one too.
+  })
+
+  it('keeps the ancestors that reach a match, and says so', () => {
+    // `quiet` is in no state at all; it is how `deep-boom` is reachable.
+    const snapshot = family()
+    const tree = projectFamily(snapshot[0], snapshot).tree
+    const rows = renderedLines(tree, visibleFamilyRows(tree, { filter: 'error' }))
+    expect(rows).toContain('quiet')
+    expect(rows.indexOf('quiet')).toBeLessThan(rows.indexOf('deep-boom'))
+  })
+
+  it('keeps the row you are standing on, whatever the filter says', () => {
+    const snapshot = family()
+    const projection = projectFamily(snapshot.find(s => s.id === 'said-something')!, snapshot)
+    const pinned = new Set([...projection.ancestors.map(a => a.id), 'said-something'])
+    const rows = renderedLines(projection.tree, visibleFamilyRows(projection.tree, {
+      pinned, filter: 'error',
+    }))
+    expect(rows).toContain('said-something')
+    expect(rows).toContain('boom')
+  })
+
+  it('counts only matches in `+N more`, never the rows it excluded', () => {
+    // Twenty non-matching siblings are not "more errors" — offering to
+    // expand them would contradict the question the filter asked.
+    const snapshot = family()
+    const tree = projectFamily(snapshot[0], snapshot).tree
+    const view = visibleFamilyRows(tree, { filter: 'error' })
+    expect(splitLevel(tree.children, 'root', new Set(), view).summary).toBeNull()
+    const rows = renderedLines(tree, view)
+    expect(rows.some(r => r.includes('more'))).toBe(false)
+  })
+
+  it('still obeys the line budget when a filter matches half the family', () => {
+    const many = Array.from({ length: 60 }, (_, i) => ago(1 + i * 0.01, `boom-${i}`, 'root', errored))
+    const snapshot = [ago(0, 'root', undefined), ...many]
+    const tree = projectFamily(snapshot[0], snapshot).tree
+    const rows = renderedLines(tree, visibleFamilyRows(tree, { filter: 'error' }))
+    expect(rows.length).toBeLessThanOrEqual(FAMILY_ROW_BUDGET)
+    expect(rows.filter(r => /^root:\+\d+ more$/.test(r))).toHaveLength(1)
+  })
+
+  it('shows an agent every command it is running, once you ask for commands', () => {
+    // The one-command-per-agent rule is triage too, and the filter is
+    // the question triage was guessing at.
+    const shells = Array.from({ length: 5 }, (_, i) => ago(1 + i, `sh-${i}`, 'agent', {
+      semantic_agent: undefined, adapter: 'shell', status: { active: true },
+    }))
+    const snapshot = [ago(0, 'root', undefined), ago(0.5, 'agent', 'root'), ...shells]
+    const tree = projectFamily(snapshot[0], snapshot).tree
+    const rows = renderedLines(tree, visibleFamilyRows(tree, { filter: 'running' }))
+    for (const shell of shells) expect(rows).toContain(shell.id)
+  })
+
+  it('shows the whole family again with no filter', () => {
+    const snapshot = family()
+    const tree = projectFamily(snapshot[0], snapshot).tree
+    const rows = renderedLines(tree, visibleFamilyRows(tree, { filter: null }))
+    expect(rows).toContain('noise-0')
   })
 })

--- a/apps/gmux-web/src/family-drawer-model.test.ts
+++ b/apps/gmux-web/src/family-drawer-model.test.ts
@@ -457,3 +457,35 @@ describe('filtering by a state the tally counts', () => {
     expect(rows).toContain('noise-0')
   })
 })
+
+describe('the budget charges only for folds that get drawn', () => {
+  const at = (minutes: number, id: string, parent: string | undefined, extra: Partial<Session> = {}) =>
+    makeSession({
+      id, cwd: '/p', title: id, parent_session_id: parent, semantic_agent: true,
+      created_at: '2026-08-04T00:00:00Z',
+      last_output_at: new Date(Date.parse('2026-08-04T20:00:00Z') - minutes * 60_000).toISOString(),
+      ...extra,
+    })
+
+  it("doesn't spend budget on summaries a filter will never render", () => {
+    // Three branches, each hiding 50 idle children behind two errors.
+    // Under the filter those children are not on offer, so `splitLevel`
+    // renders no summary for them — charging a fold line per branch
+    // anyway spends budget on rows that never appear, and the branches
+    // that come last pay for it. Branch-consecutive recency matters:
+    // the line a finished branch gives back is what admits the next.
+    const start: Record<string, number> = { a: 1, b: 1.5, c: 2 }
+    const snapshot = [at(0, 'root', undefined)]
+    for (const branch of ['a', 'b', 'c']) {
+      snapshot.push(at(start[branch], branch, 'root'))
+      snapshot.push(at(start[branch] + 1.5, `${branch}1`, branch, { status: { active: true, error: true } }))
+      snapshot.push(at(start[branch] + 1.6, `${branch}2`, branch, { status: { active: true, error: true } }))
+      for (let i = 0; i < 50; i++) snapshot.push(at(20 + i, `${branch}-idle-${i}`, branch))
+    }
+    const tree = projectFamily(snapshot[0], snapshot).tree
+    // Budget 9 buys nine lines of errors; charging for the three
+    // phantom summaries buys seven and folds branch b away entirely.
+    expect(renderedLines(tree, visibleFamilyRows(tree, { filter: 'error', budget: 9 })))
+      .toEqual(['root', 'a', 'a1', 'a2', 'b', 'b1', 'b2', 'c', 'c:+2 more'])
+  })
+})

--- a/apps/gmux-web/src/family-drawer-model.ts
+++ b/apps/gmux-web/src/family-drawer-model.ts
@@ -1,4 +1,4 @@
-import { isProcessSession, type FamilyNode } from './family'
+import { familyStateOf, isProcessSession, type FamilyNode, type FamilyState } from './family'
 
 /** When a member last said anything, as a timestamp. */
 function activityOf(node: FamilyNode): number {
@@ -58,6 +58,29 @@ export interface LevelSplit {
   summary: { key: string; expanded: boolean; label: string } | null
 }
 
+export interface FamilyView {
+  /** Rows to draw. */
+  readonly visible: ReadonlySet<string>
+  /** Rows that were allowed to compete for the budget — everyone when
+   * nothing is filtered, and only the matches (plus the structure that
+   * reaches them) when something is. `+N more` counts against this, so
+   * a filter's folds never offer to expand what the filter excluded. */
+  readonly universe: ReadonlySet<string>
+}
+
+export interface FamilyViewOptions {
+  /** Your own spine, root to selection: never folded, never filtered
+   * out. You are standing on it, and a map that omits where you are is
+   * a map of somewhere else. */
+  pinned?: ReadonlySet<string>
+  /** Show only members in this state, or everyone. */
+  filter?: FamilyState | null
+  budget?: number
+  floor?: number
+  staleAfterMs?: number
+  processStaleAfterMs?: number
+}
+
 /** Choose the rows worth the panel's budget: the most recent members of
  * the family, plus whatever structure it takes to reach them.
  *
@@ -86,12 +109,16 @@ export interface LevelSplit {
  * that stood in for it. */
 export function visibleFamilyRows(
   tree: FamilyNode,
-  pinned: ReadonlySet<string> = new Set(),
-  budget: number = FAMILY_ROW_BUDGET,
-  staleAfterMs: number = FAMILY_STALE_AFTER_MS,
-  floor: number = FAMILY_ROW_FLOOR,
-  processStaleAfterMs: number = FAMILY_PROCESS_STALE_AFTER_MS,
-): ReadonlySet<string> {
+  options: FamilyViewOptions = {},
+): FamilyView {
+  const {
+    pinned = new Set<string>(),
+    filter = null,
+    budget = FAMILY_ROW_BUDGET,
+    floor = FAMILY_ROW_FLOOR,
+    staleAfterMs = FAMILY_STALE_AFTER_MS,
+    processStaleAfterMs = FAMILY_PROCESS_STALE_AFTER_MS,
+  } = options
   const parentOf = new Map<string, string>()
   const nodeById = new Map<string, FamilyNode>()
   const flat: FamilyNode[] = []
@@ -114,6 +141,27 @@ export function visibleFamilyRows(
   const familyNewest = subtreeNewest.get(tree.session.id) ?? 0
   const staleBefore = familyNewest - staleAfterMs
   const processStaleBefore = familyNewest - processStaleAfterMs
+
+  // A filter answers a question the panel's own triage was guessing at,
+  // so the guessing stops: asked for the errors, you get every error,
+  // stale or not, however many commands one agent ran. What survives is
+  // the line budget, because a filter can still match three hundred
+  // members.
+  //
+  // Structure comes along: an unmatched ancestor is how a match is
+  // reachable, and a row you cannot see the parent of is a claim about
+  // the family that the panel can't back up.
+  const universe = new Set<string>([tree.session.id, ...pinned])
+  if (filter) {
+    for (const node of flat) {
+      if (familyStateOf(node.session) !== filter) continue
+      for (let id: string | undefined = node.session.id; id && !universe.has(id); id = parentOf.get(id)) {
+        universe.add(id)
+      }
+    }
+  } else {
+    for (const node of flat) universe.add(node.session.id)
+  }
 
   const visible = new Set<string>()
   const shownKids = new Map<string, number>()
@@ -171,7 +219,7 @@ export function visibleFamilyRows(
   const fill = (ceiling: number, triage: boolean) => {
     for (const node of byRecency) {
       const id = node.session.id
-      if (visible.has(id)) continue
+      if (visible.has(id) || !universe.has(id)) continue
       // Stale branches fold whole rather than spending the budget on the
       // tail of finished work. They stay reachable behind `+N more`:
       // this is the panel declining to volunteer them, not hiding them.
@@ -203,10 +251,17 @@ export function visibleFamilyRows(
     }
   }
 
-  fill(budget, true)
+  // Triage — staleness and one-command-per-agent — is the panel guessing
+  // what you want to see. A filter is you saying it, so triage turns off
+  // wholesale: asked for the errors, you get the two-day-old one on a
+  // branch nothing else has touched, not a fold where it should be.
+  fill(budget, !filter)
   // Then top the panel back up to the floor with whatever is left, most
   // recent first — a family that finished yesterday still gets a map.
-  if (lines < floor) fill(Math.min(floor, budget), false)
+  // Not while filtering: there the panel was asked a question, and
+  // padding the answer with rows that don't match is answering a
+  // different one.
+  if (!filter && lines < floor) fill(Math.min(floor, budget), false)
 
   // Finally, draw every row that costs nothing: the last hidden leaf of
   // a level, whose summary occupies exactly the line the row would. No
@@ -218,15 +273,16 @@ export function visibleFamilyRows(
     changed = false
     for (const node of byRecency) {
       const id = node.session.id
-      if (visible.has(id) || node.children.length > 0) continue
+      if (visible.has(id) || node.children.length > 0 || !universe.has(id)) continue
       const parent = parentOf.get(id)
       if (parent === undefined || !visible.has(parent)) continue
-      if ((shownKids.get(parent) ?? 0) + 1 !== (nodeById.get(parent)?.children.length ?? 0)) continue
+      const eligibleKids = nodeById.get(parent)?.children.filter(c => universe.has(c.session.id)).length ?? 0
+      if ((shownKids.get(parent) ?? 0) + 1 !== eligibleKids) continue
       admit(id)
       changed = true
     }
   }
-  return visible
+  return { visible, universe }
 }
 
 /** Apply the budget to one children level: what the panel renders.
@@ -239,15 +295,20 @@ export function splitLevel(
   nodes: readonly FamilyNode[],
   parentId: string,
   expanded: ReadonlySet<string>,
-  visible: ReadonlySet<string>,
+  view: FamilyView,
 ): LevelSplit {
+  // `+N more` and `show fewer` both count against the universe, not the
+  // level: under a filter, the rows it excluded were never on offer, so
+  // counting them would advertise an expansion that contradicts what
+  // was asked for.
+  const eligible = nodes.filter(node => view.universe.has(node.session.id))
   if (expanded.has(parentId)) {
-    return { shown: nodes, summary: { key: parentId, expanded: true, label: 'show fewer' } }
+    return { shown: eligible, summary: { key: parentId, expanded: true, label: 'show fewer' } }
   }
-  const shown = nodes.filter(node => visible.has(node.session.id))
-  if (shown.length === nodes.length) return { shown, summary: null }
+  const shown = eligible.filter(node => view.visible.has(node.session.id))
+  if (shown.length === eligible.length) return { shown, summary: null }
   return {
     shown,
-    summary: { key: parentId, expanded: false, label: `+${nodes.length - shown.length} more` },
+    summary: { key: parentId, expanded: false, label: `+${eligible.length - shown.length} more` },
   }
 }

--- a/apps/gmux-web/src/family-drawer-model.ts
+++ b/apps/gmux-web/src/family-drawer-model.ts
@@ -163,15 +163,31 @@ export function visibleFamilyRows(
     for (const node of flat) universe.add(node.session.id)
   }
 
+  /** How many of a node's children could be drawn at all. Under a
+   * filter this is not `children.length`: a level whose excluded
+   * children are all hidden renders no summary (see `splitLevel`), so
+   * charging a fold line for them would spend budget on a row that
+   * never appears and push real matches out of the panel. Computed
+   * once — recomputing it per candidate made the free-leaf pass
+   * quadratic in a wide level. */
+  const eligibleKids = new Map<string, number>()
+  for (const node of flat) {
+    eligibleKids.set(node.session.id,
+      node.children.reduce((n, child) => n + (universe.has(child.session.id) ? 1 : 0), 0))
+  }
+
   const visible = new Set<string>()
   const shownKids = new Map<string, number>()
-  /** Agents already showing a command, so the rest of theirs stay in the
-   * fold rather than pushing other branches off the panel. */
-  const commandShown = new Set<string>()
+  /** Commands currently drawn per agent, so the rest of an agent's stay
+   * in the fold rather than pushing other branches off the panel. A
+   * count, not a set: a speculative admission that the budget rejects
+   * must leave no trace, or an agent with no visible command at all
+   * would go on suppressing its own siblings. */
+  const shownProcs = new Map<string, number>()
   /** Lines drawn so far: visible rows plus one per folded level. */
   let lines = 0
   const folds = (id: string) =>
-    (nodeById.get(id)?.children.length ?? 0) > (shownKids.get(id) ?? 0) ? 1 : 0
+    (eligibleKids.get(id) ?? 0) > (shownKids.get(id) ?? 0) ? 1 : 0
 
   /** Draw one row whose parent is already drawn, keeping the line count
    * honest: it may retire its parent's summary and may raise one of its
@@ -185,7 +201,7 @@ export function visibleFamilyRows(
     }
     visible.add(id)
     if (isProcessSession(nodeById.get(id)?.session ?? tree.session) && parent !== undefined) {
-      commandShown.add(parent)
+      shownProcs.set(parent, (shownProcs.get(parent) ?? 0) + 1)
     }
     lines += 1 + folds(id)
   }
@@ -195,6 +211,9 @@ export function visibleFamilyRows(
     lines -= 1 + folds(id)
     const parent = parentOf.get(id)
     if (parent === undefined) return
+    if (isProcessSession(nodeById.get(id)?.session ?? tree.session)) {
+      shownProcs.set(parent, (shownProcs.get(parent) ?? 0) - 1)
+    }
     const before = folds(parent)
     shownKids.set(parent, (shownKids.get(parent) ?? 0) - 1)
     lines += folds(parent) - before
@@ -231,7 +250,7 @@ export function visibleFamilyRows(
       // of a family that is 248 processes to 8 agents.
       if (triage && isProcessSession(node.session)) {
         const parent = parentOf.get(id)
-        if (parent !== undefined && commandShown.has(parent)) continue
+        if (parent !== undefined && (shownProcs.get(parent) ?? 0) > 0) continue
         if ((subtreeNewest.get(id) ?? 0) < processStaleBefore) continue
       }
       // A row costs its own line plus every ancestor still missing: an
@@ -276,8 +295,7 @@ export function visibleFamilyRows(
       if (visible.has(id) || node.children.length > 0 || !universe.has(id)) continue
       const parent = parentOf.get(id)
       if (parent === undefined || !visible.has(parent)) continue
-      const eligibleKids = nodeById.get(parent)?.children.filter(c => universe.has(c.session.id)).length ?? 0
-      if ((shownKids.get(parent) ?? 0) + 1 !== eligibleKids) continue
+      if ((shownKids.get(parent) ?? 0) + 1 !== (eligibleKids.get(parent) ?? 0)) continue
       admit(id)
       changed = true
     }

--- a/apps/gmux-web/src/family-drawer-model.ts
+++ b/apps/gmux-web/src/family-drawer-model.ts
@@ -1,45 +1,205 @@
 import type { FamilyNode } from './family'
 
-/** Per-level visible-row cap before a `+N more` summary row takes over.
- * Recency ordering does the triage that status buckets used to: unread
- * members have recent output by definition, so they surface within the
- * cap while long-dead noise sinks below the fold. */
-export const FAMILY_LEVEL_CAP = 15
+/** When a member last said anything, as a timestamp. */
+function activityOf(node: FamilyNode): number {
+  return Date.parse(node.session.last_output_at || node.session.created_at) || 0
+}
+
+/** How many rows the panel will draw before folding the rest behind
+ * per-level `+N more` summaries.
+ *
+ * A budget for the whole tree, not a cap per level: real families are
+ * 70–600 members and deep, so a per-level cap bounds nothing — fifteen
+ * rows a level across nine levels is still two hundred rows. Budgeting
+ * the tree bounds the panel by construction, whatever shape the family
+ * turns out to have.
+ *
+ * Twenty-five is roughly a screenful; past that you are scrolling a map
+ * instead of reading one. */
+export const FAMILY_ROW_BUDGET = 25
+
+/** The panel never folds itself below this many lines.
+ *
+ * Staleness is a cliff by nature: a family whose last burst ended a
+ * little over the window shows nothing but its root, which is a true
+ * statement about liveness and a useless map for getting anywhere. The
+ * floor keeps the most recent members on screen even when all of them
+ * are finished work. */
+export const FAMILY_ROW_FLOOR = 8
+
+/** How far back from a family's own newest activity a branch may be and
+ * still be worth a line, in milliseconds.
+ *
+ * Measured from the family rather than the clock, because families are
+ * bursty: one does all its work inside an afternoon, so an absolute
+ * cutoff either keeps every row or empties the panel depending on which
+ * side of the line that afternoon fell. Relative to the family's newest
+ * output, both a family working now and one that stopped on Tuesday
+ * show the same thing — the tail of what it was doing — and a family
+ * that has been quiet throughout stays whole, because everything in it
+ * is equally recent by its own standard.
+ *
+ * Six hours is about a working session: long enough to keep the branch
+ * you had running before lunch, short enough to fold yesterday's. */
+export const FAMILY_STALE_AFTER_MS = 6 * 60 * 60 * 1000
 
 export interface LevelSplit {
   shown: readonly FamilyNode[]
-  /** Present iff the level exceeds the cap: the two-state summary row. */
+  /** Present iff the level has rows the budget folded away. */
   summary: { key: string; expanded: boolean; label: string } | null
 }
 
-/** Apply the cap to one children level: what the panel actually renders.
- * Expansion is keyed per parent id and two-state — expanding shows the
- * whole level plus `show fewer`, never an incremental ladder.
+/** Choose the rows worth the panel's budget: the most recent members of
+ * the family, plus whatever structure it takes to reach them.
  *
- * `pinned` is the spine of the session you're viewing. Those rows are
- * never folded away, whatever their recency: the panel projects the
- * whole family from the root, so every level between you and the root
- * is now capped, and a quiet parent — the ordinary state of an
- * orchestrator whose subagent is doing the talking — would otherwise
- * take your own row down with it. A pinned row costs one slot of the
- * cap rather than widening it, so the level's height stays put. */
+ * Recency does the triage that status buckets used to — unread members
+ * have recent output by definition, so they surface — and doing it
+ * across the whole family rather than per level is what makes an old
+ * branch fold: it loses to newer work everywhere else in the tree, not
+ * merely to its own siblings.
+ *
+ * Deliberately *not* an age threshold. Families turn out to be bursty:
+ * one does all its work inside a couple of hours, so a cutoff anywhere
+ * near that burst either keeps every row or hides every row, and the
+ * two families on either side of the line look nothing alike. A rank
+ * cuts the same noise without a number that means something different
+ * to every family.
+ *
+ * `pinned` is your own spine, root to selection; it is seeded before
+ * anything competes for the budget, so the row you are standing on and
+ * the path that explains it are never the rows that get folded.
+ *
+ * The budget counts *lines*, not members: a `+N more` occupies the
+ * screen exactly like the row it replaces, so folding is only ever a
+ * saving when it hides two rows or more. Charging the fold makes that
+ * arithmetic automatic — a member that completes its level and has no
+ * children of its own is free, because drawing it retires the summary
+ * that stood in for it. */
+export function visibleFamilyRows(
+  tree: FamilyNode,
+  pinned: ReadonlySet<string> = new Set(),
+  budget: number = FAMILY_ROW_BUDGET,
+  staleAfterMs: number = FAMILY_STALE_AFTER_MS,
+  floor: number = FAMILY_ROW_FLOOR,
+): ReadonlySet<string> {
+  const parentOf = new Map<string, string>()
+  const nodeById = new Map<string, FamilyNode>()
+  const flat: FamilyNode[] = []
+  /** Newest output anywhere in a node's subtree: what decides whether a
+   * branch is stale. Judging a parent by its own output alone would
+   * fold the quiet orchestrator whose subagent is mid-sentence. */
+  const subtreeNewest = new Map<string, number>()
+  const walk = (node: FamilyNode): number => {
+    flat.push(node)
+    nodeById.set(node.session.id, node)
+    let newest = activityOf(node)
+    for (const child of node.children) {
+      parentOf.set(child.session.id, node.session.id)
+      newest = Math.max(newest, walk(child))
+    }
+    subtreeNewest.set(node.session.id, newest)
+    return newest
+  }
+  walk(tree)
+  const familyNewest = subtreeNewest.get(tree.session.id) ?? 0
+  const staleBefore = familyNewest - staleAfterMs
+
+  const visible = new Set<string>()
+  const shownKids = new Map<string, number>()
+  /** Lines drawn so far: visible rows plus one per folded level. */
+  let lines = 0
+  const folds = (id: string) =>
+    (nodeById.get(id)?.children.length ?? 0) > (shownKids.get(id) ?? 0) ? 1 : 0
+
+  /** Draw one row whose parent is already drawn, keeping the line count
+   * honest: it may retire its parent's summary and may raise one of its
+   * own. */
+  const admit = (id: string) => {
+    const parent = parentOf.get(id)
+    if (parent !== undefined) {
+      const before = folds(parent)
+      shownKids.set(parent, (shownKids.get(parent) ?? 0) + 1)
+      lines -= before - folds(parent)
+    }
+    visible.add(id)
+    lines += 1 + folds(id)
+  }
+  /** Exact inverse of `admit`, in reverse order of admission. */
+  const withdraw = (id: string) => {
+    visible.delete(id)
+    lines -= 1 + folds(id)
+    const parent = parentOf.get(id)
+    if (parent === undefined) return
+    const before = folds(parent)
+    shownKids.set(parent, (shownKids.get(parent) ?? 0) - 1)
+    lines += folds(parent) - before
+  }
+
+  // The root, then your own spine, before anything competes for a line.
+  admit(tree.session.id)
+  for (const node of flat) {
+    if (node.session.id !== tree.session.id && pinned.has(node.session.id)) admit(node.session.id)
+  }
+
+  // Levels arrive in recency order (`projectFamily` sorts them), so a
+  // depth-first flatten is already ordered by recency within each
+  // branch; sort across branches to rank the family as a whole.
+  const byRecency = [...flat].sort((a, b) =>
+    activityOf(b) - activityOf(a) || a.session.id.localeCompare(b.session.id))
+
+  /** `triage` is the ordinary pass, where staleness applies. The top-up
+   * that follows drops it: it runs only when the panel would otherwise
+   * be emptier than a glance, and at that point a finished branch beats
+   * a blank panel. */
+  const fill = (ceiling: number, triage: boolean) => {
+    for (const node of byRecency) {
+      const id = node.session.id
+      if (visible.has(id)) continue
+      // Stale branches fold whole rather than spending the budget on the
+      // tail of finished work. They stay reachable behind `+N more`:
+      // this is the panel declining to volunteer them, not hiding them.
+      if (triage && (subtreeNewest.get(id) ?? 0) < staleBefore) continue
+      // A row costs its own line plus every ancestor still missing: an
+      // unreachable row would be a lie about the shape of the family.
+      const spine: string[] = []
+      for (let cursor: string | undefined = id; cursor && !visible.has(cursor); cursor = parentOf.get(cursor)) {
+        spine.push(cursor)
+      }
+      spine.reverse()
+      // Costing a spine exactly means walking it: an ancestor's summary
+      // is retired by the very child that follows it. So admit, then
+      // take it back if the whole path didn't fit.
+      for (const ancestor of spine) admit(ancestor)
+      if (lines > ceiling) {
+        for (const ancestor of [...spine].reverse()) withdraw(ancestor)
+      }
+    }
+  }
+
+  fill(budget, true)
+  // Then top the panel back up to the floor with whatever is left, most
+  // recent first — a family that finished yesterday still gets a map.
+  if (lines < floor) fill(Math.min(floor, budget), false)
+  return visible
+}
+
+/** Apply the budget to one children level: what the panel renders.
+ *
+ * Expansion is keyed per parent id and two-state — expanding shows the
+ * whole level plus `show fewer`, never an incremental ladder. Rows keep
+ * the recency order they arrived in; the budget only decides which of
+ * them survive. */
 export function splitLevel(
   nodes: readonly FamilyNode[],
   parentId: string,
   expanded: ReadonlySet<string>,
-  pinned: ReadonlySet<string> = new Set(),
+  visible: ReadonlySet<string>,
 ): LevelSplit {
-  if (nodes.length <= FAMILY_LEVEL_CAP) return { shown: nodes, summary: null }
-  const isExpanded = expanded.has(parentId)
-  if (isExpanded) return { shown: nodes, summary: { key: parentId, expanded: true, label: 'show fewer' } }
-  // Keep recency order: choose which rows survive, then render them in
-  // the order they already had.
-  const keep = new Set(nodes.filter(n => pinned.has(n.session.id)).map(n => n.session.id))
-  for (const node of nodes) {
-    if (keep.size >= FAMILY_LEVEL_CAP) break
-    keep.add(node.session.id)
+  if (expanded.has(parentId)) {
+    return { shown: nodes, summary: { key: parentId, expanded: true, label: 'show fewer' } }
   }
-  const shown = nodes.filter(n => keep.has(n.session.id))
+  const shown = nodes.filter(node => visible.has(node.session.id))
+  if (shown.length === nodes.length) return { shown, summary: null }
   return {
     shown,
     summary: { key: parentId, expanded: false, label: `+${nodes.length - shown.length} more` },

--- a/apps/gmux-web/src/family-drawer-model.ts
+++ b/apps/gmux-web/src/family-drawer-model.ts
@@ -55,7 +55,11 @@ export const FAMILY_PROCESS_STALE_AFTER_MS = 60 * 60 * 1000
 export interface LevelSplit {
   shown: readonly FamilyNode[]
   /** Present iff the level has rows the budget folded away. */
-  summary: { key: string; expanded: boolean; label: string } | null
+  /** The fold control's text, or null when the level has nothing
+   * folded. Whether it's expanded and which level it toggles are the
+   * caller's own `expanded` and `parentId` — restating them here only
+   * created two ways to know one thing. */
+  summary: string | null
 }
 
 export interface FamilyView {
@@ -200,7 +204,9 @@ export function visibleFamilyRows(
       lines -= before - folds(parent)
     }
     visible.add(id)
-    if (isProcessSession(nodeById.get(id)?.session ?? tree.session) && parent !== undefined) {
+    // Every id here came from the walk, so the node is present: no
+    // fallback, which would have quietly typed a process as an agent.
+    if (parent !== undefined && isProcessSession(nodeById.get(id)!.session)) {
       shownProcs.set(parent, (shownProcs.get(parent) ?? 0) + 1)
     }
     lines += 1 + folds(id)
@@ -211,7 +217,7 @@ export function visibleFamilyRows(
     lines -= 1 + folds(id)
     const parent = parentOf.get(id)
     if (parent === undefined) return
-    if (isProcessSession(nodeById.get(id)?.session ?? tree.session)) {
+    if (isProcessSession(nodeById.get(id)!.session)) {
       shownProcs.set(parent, (shownProcs.get(parent) ?? 0) - 1)
     }
     const before = folds(parent)
@@ -292,7 +298,10 @@ export function visibleFamilyRows(
     changed = false
     for (const node of byRecency) {
       const id = node.session.id
-      if (visible.has(id) || node.children.length > 0 || !universe.has(id)) continue
+      // "Leaf" means leaf *of the view*: under a filter, a node whose
+      // children were all excluded raises no summary of its own, so it
+      // is exactly as free as a childless one.
+      if (visible.has(id) || (eligibleKids.get(id) ?? 0) > 0 || !universe.has(id)) continue
       const parent = parentOf.get(id)
       if (parent === undefined || !visible.has(parent)) continue
       if ((shownKids.get(parent) ?? 0) + 1 !== (eligibleKids.get(parent) ?? 0)) continue
@@ -320,13 +329,20 @@ export function splitLevel(
   // counting them would advertise an expansion that contradicts what
   // was asked for.
   const eligible = nodes.filter(node => view.universe.has(node.session.id))
-  if (expanded.has(parentId)) {
-    return { shown: eligible, summary: { key: parentId, expanded: true, label: 'show fewer' } }
-  }
   const shown = eligible.filter(node => view.visible.has(node.session.id))
-  if (shown.length === eligible.length) return { shown, summary: null }
-  return {
-    shown,
-    summary: { key: parentId, expanded: false, label: `+${eligible.length - shown.length} more` },
+  const folded = eligible.length - shown.length
+  // Expanded levels show everything eligible — but only offer `show
+  // fewer` if collapsing would actually hide something. A filter
+  // applied after an expansion can shrink a level to nothing folded,
+  // and a control that visibly does nothing is worse than no control.
+  //
+  // Safe only because `visibleFamilyRows` knows nothing about
+  // `expanded`: `folded` is therefore invariant under expanding, so
+  // this can never strand a reader inside an expanded level with no
+  // way back. Teach the budget about expansion and this becomes a
+  // trap.
+  if (expanded.has(parentId)) {
+    return { shown: eligible, summary: folded > 0 ? 'show fewer' : null }
   }
+  return { shown, summary: folded > 0 ? `+${folded} more` : null }
 }

--- a/apps/gmux-web/src/family-drawer-model.ts
+++ b/apps/gmux-web/src/family-drawer-model.ts
@@ -1,4 +1,4 @@
-import type { FamilyNode } from './family'
+import { isProcessSession, type FamilyNode } from './family'
 
 /** When a member last said anything, as a timestamp. */
 function activityOf(node: FamilyNode): number {
@@ -43,6 +43,15 @@ export const FAMILY_ROW_FLOOR = 8
  * you had running before lunch, short enough to fold yesterday's. */
 export const FAMILY_STALE_AFTER_MS = 6 * 60 * 60 * 1000
 
+/** The same, for a process rather than an agent.
+ *
+ * A process is a command an agent ran, and a command is only interesting
+ * while it is the thing the agent is doing. An hour on from its last
+ * output it is a line in a log, and the panel is not a log — which is
+ * why processes also get only one row per agent (see `visibleFamilyRows`)
+ * rather than one each. */
+export const FAMILY_PROCESS_STALE_AFTER_MS = 60 * 60 * 1000
+
 export interface LevelSplit {
   shown: readonly FamilyNode[]
   /** Present iff the level has rows the budget folded away. */
@@ -81,6 +90,7 @@ export function visibleFamilyRows(
   budget: number = FAMILY_ROW_BUDGET,
   staleAfterMs: number = FAMILY_STALE_AFTER_MS,
   floor: number = FAMILY_ROW_FLOOR,
+  processStaleAfterMs: number = FAMILY_PROCESS_STALE_AFTER_MS,
 ): ReadonlySet<string> {
   const parentOf = new Map<string, string>()
   const nodeById = new Map<string, FamilyNode>()
@@ -103,9 +113,13 @@ export function visibleFamilyRows(
   walk(tree)
   const familyNewest = subtreeNewest.get(tree.session.id) ?? 0
   const staleBefore = familyNewest - staleAfterMs
+  const processStaleBefore = familyNewest - processStaleAfterMs
 
   const visible = new Set<string>()
   const shownKids = new Map<string, number>()
+  /** Agents already showing a command, so the rest of theirs stay in the
+   * fold rather than pushing other branches off the panel. */
+  const commandShown = new Set<string>()
   /** Lines drawn so far: visible rows plus one per folded level. */
   let lines = 0
   const folds = (id: string) =>
@@ -122,6 +136,9 @@ export function visibleFamilyRows(
       lines -= before - folds(parent)
     }
     visible.add(id)
+    if (isProcessSession(nodeById.get(id)?.session ?? tree.session) && parent !== undefined) {
+      commandShown.add(parent)
+    }
     lines += 1 + folds(id)
   }
   /** Exact inverse of `admit`, in reverse order of admission. */
@@ -147,10 +164,10 @@ export function visibleFamilyRows(
   const byRecency = [...flat].sort((a, b) =>
     activityOf(b) - activityOf(a) || a.session.id.localeCompare(b.session.id))
 
-  /** `triage` is the ordinary pass, where staleness applies. The top-up
-   * that follows drops it: it runs only when the panel would otherwise
-   * be emptier than a glance, and at that point a finished branch beats
-   * a blank panel. */
+  /** `triage` is the ordinary pass: staleness applies, and an agent
+   * shows one command. The top-up that follows drops both rules — it
+   * runs only when the panel would otherwise be emptier than a glance,
+   * and at that point a stale command beats a blank panel. */
   const fill = (ceiling: number, triage: boolean) => {
     for (const node of byRecency) {
       const id = node.session.id
@@ -159,6 +176,16 @@ export function visibleFamilyRows(
       // tail of finished work. They stay reachable behind `+N more`:
       // this is the panel declining to volunteer them, not hiding them.
       if (triage && (subtreeNewest.get(id) ?? 0) < staleBefore) continue
+      // An agent's commands are a log, and the panel shows the top of
+      // it: the one it is running now, while it is still running it.
+      // The rest stay in the level's fold, one click away, instead of
+      // spending a whole panel on one agent's shell history — the shape
+      // of a family that is 248 processes to 8 agents.
+      if (triage && isProcessSession(node.session)) {
+        const parent = parentOf.get(id)
+        if (parent !== undefined && commandShown.has(parent)) continue
+        if ((subtreeNewest.get(id) ?? 0) < processStaleBefore) continue
+      }
       // A row costs its own line plus every ancestor still missing: an
       // unreachable row would be a lie about the shape of the family.
       const spine: string[] = []
@@ -180,6 +207,25 @@ export function visibleFamilyRows(
   // Then top the panel back up to the floor with whatever is left, most
   // recent first — a family that finished yesterday still gets a map.
   if (lines < floor) fill(Math.min(floor, budget), false)
+
+  // Finally, draw every row that costs nothing: the last hidden leaf of
+  // a level, whose summary occupies exactly the line the row would. No
+  // rule above is worth a `+1 more` that saves no space and names
+  // nobody, and admitting one can free the next, so this runs to a
+  // fixed point. Line count cannot rise here — each of these retires
+  // the summary it replaces.
+  for (let changed = true; changed;) {
+    changed = false
+    for (const node of byRecency) {
+      const id = node.session.id
+      if (visible.has(id) || node.children.length > 0) continue
+      const parent = parentOf.get(id)
+      if (parent === undefined || !visible.has(parent)) continue
+      if ((shownKids.get(parent) ?? 0) + 1 !== (nodeById.get(parent)?.children.length ?? 0)) continue
+      admit(id)
+      changed = true
+    }
+  }
   return visible
 }
 

--- a/apps/gmux-web/src/family-drawer.tsx
+++ b/apps/gmux-web/src/family-drawer.tsx
@@ -10,6 +10,7 @@ import {
   activityMap, cancelSession, killSession, markSessionRead,
   projects, sessions, sessionDotState, tabHref,
 } from './store'
+import { pushError } from './toasts'
 import type { Session } from './types'
 
 function hrefFor(session: Session): string | undefined {
@@ -134,20 +135,55 @@ function membersInState(tree: FamilyNode, state: FamilyState): Session[] {
 }
 
 /** The one bulk action each filter's members admit. There is no ambient
- * action: a verb only appears once its filter is on, so you are looking
- * at the complete list of what it will touch before the button exists —
- * that, not a confirm dialog, is the safety for the destructive ones.
+ * action: a verb only appears once its filter is on, so the panel is
+ * already showing that state and nothing else before the button exists.
+ *
+ * The destructive verbs carry their target count, because the rows on
+ * screen are NOT the whole story: the line budget still folds a big
+ * family, so "Stop all" under a filter matching 200 processes reaches
+ * every one of them, including those behind `+N more`. Acting on the
+ * filter rather than the viewport is the right behaviour — a fold is
+ * the panel's economy, not a selection — but then the blast radius has
+ * to be in the label you are about to click.
  *
  * `error` shares the waiting verb because acknowledging is all you can
  * do in bulk to an error — `markSessionRead` clears the error flag — and
  * error's precedence means an errored member never surfaces under
  * `waiting`. There is no action for `all`: no single verb answers
  * everything. */
-const FAMILY_ACTIONS: Partial<Record<FamilyState, { label: string; run: (id: string) => unknown }>> = {
-  waiting: { label: 'Mark all read', run: markSessionRead },
-  error: { label: 'Mark all read', run: markSessionRead },
-  running: { label: 'Stop all', run: killSession },
-  active: { label: 'Interrupt all', run: cancelSession },
+type FamilyAction = {
+  label: (n: number) => string
+  run: (id: string) => unknown
+  /** Verbs that can fail per member and report once at the end. */
+  aggregate?: boolean
+}
+const FAMILY_ACTIONS: Partial<Record<FamilyState, FamilyAction>> = {
+  waiting: { label: () => 'Mark all read', run: markSessionRead },
+  error: { label: () => 'Mark all read', run: markSessionRead },
+  running: { label: n => `Stop all ${n}`, run: id => killSession(id, { quiet: true }), aggregate: true },
+  active: { label: n => `Interrupt all ${n}`, run: id => cancelSession(id, { quiet: true }), aggregate: true },
+}
+
+/** Run a bulk verb over a family's worth of members.
+ *
+ * Bounded concurrency: a family runs to several hundred, and firing
+ * that many fetches at once buys nothing (the browser queues them per
+ * host anyway) while making the failure report arrive in one lump at
+ * the end regardless. Failures are counted, not toasted individually —
+ * see `quiet` in the store — so a daemon that is simply down produces
+ * one line instead of two hundred. */
+async function runBulk(action: FamilyAction, targets: readonly Session[]): Promise<void> {
+  const queue = [...targets]
+  let failed = 0
+  const worker = async () => {
+    for (let next = queue.shift(); next !== undefined; next = queue.shift()) {
+      if ((await action.run(next.id)) === false) failed++
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(8, queue.length) }, worker))
+  if (action.aggregate && failed > 0) {
+    pushError(`${failed} of ${targets.length} did not respond`)
+  }
 }
 
 /** The header's tally, in the turn model's own words (ADR 0023: a
@@ -241,6 +277,7 @@ export function FamilyDrawer({ selected, onClose, triggerRef }: {
   // Per-open, like the expansion state beside it: a filter is a way of
   // looking at the family right now, not a preference about it.
   const [filter, setFilter] = useState<FamilyState | null>(null)
+  const [busy, setBusy] = useState(false)
   const toggle = (key: string) => {
     setExpanded(prev => {
       const next = new Set(prev)
@@ -313,13 +350,16 @@ export function FamilyDrawer({ selected, onClose, triggerRef }: {
           <button
             type="button"
             class="family-mark-read"
-            // Iterating is the whole implementation: mark-read is
-            // optimistic and token-bound, kill and cancel are one POST
-            // each, and every call is idempotent-or-tolerant, so a
-            // member that changes state mid-flight loses nothing.
-            onClick={() => { for (const session of targets) action.run(session.id) }}
+            // Disabled while in flight: the verbs are individually
+            // idempotent-or-tolerant, but a second click would re-run
+            // the whole family and double any toast it earns.
+            disabled={busy}
+            onClick={() => {
+              setBusy(true)
+              runBulk(action, targets).finally(() => { setBusy(false) })
+            }}
           >
-            {action.label}
+            {action.label(targets.length)}
           </button>
         )}
       </div>

--- a/apps/gmux-web/src/family-drawer.tsx
+++ b/apps/gmux-web/src/family-drawer.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'preact/hooks'
 import { familyCounts, isProcessSession, projectFamily, type FamilyNode } from './family'
-import { splitLevel } from './family-drawer-model'
+import { splitLevel, visibleFamilyRows } from './family-drawer-model'
 import { viewToPath } from './routing'
 import { formatAge } from './session-row'
 import { activityMap, projects, sessions, sessionDotState, tabHref } from './store'
@@ -11,13 +11,13 @@ function hrefFor(session: Session): string | undefined {
   return path ? tabHref(path) : undefined
 }
 
-function FamilyRow({ node, selectedId, depth, expanded, pinned, now, onToggle }: {
+function FamilyRow({ node, selectedId, depth, expanded, visible, now, onToggle }: {
   node: FamilyNode
   selectedId: string
   depth: number
   expanded: ReadonlySet<string>
-  /** Your own spine: rows the level cap must never fold away. */
-  pinned: ReadonlySet<string>
+  /** The rows the panel's budget chose to draw. */
+  visible: ReadonlySet<string>
   /** Render-time clock, passed down so every row in one paint agrees. */
   now: number
   onToggle: (key: string) => void
@@ -56,7 +56,7 @@ function FamilyRow({ node, selectedId, depth, expanded, pinned, now, onToggle }:
             selectedId={selectedId}
             depth={depth + 1}
             expanded={expanded}
-            pinned={pinned}
+            visible={visible}
             now={now}
             onToggle={onToggle}
           />
@@ -68,17 +68,17 @@ function FamilyRow({ node, selectedId, depth, expanded, pinned, now, onToggle }:
 
 /** One children level: capped rows plus a two-state summary row
  * (`+N more` / `show fewer`) keyed per parent. */
-function LevelRows({ nodes, parentId, selectedId, depth, expanded, pinned, now, onToggle }: {
+function LevelRows({ nodes, parentId, selectedId, depth, expanded, visible, now, onToggle }: {
   nodes: readonly FamilyNode[]
   parentId: string
   selectedId: string
   depth: number
   expanded: ReadonlySet<string>
-  pinned: ReadonlySet<string>
+  visible: ReadonlySet<string>
   now: number
   onToggle: (key: string) => void
 }) {
-  const { shown, summary } = splitLevel(nodes, parentId, expanded, pinned)
+  const { shown, summary } = splitLevel(nodes, parentId, expanded, visible)
   return (
     <>
       {shown.map(node => (
@@ -88,7 +88,7 @@ function LevelRows({ nodes, parentId, selectedId, depth, expanded, pinned, now, 
           selectedId={selectedId}
           depth={depth}
           expanded={expanded}
-          pinned={pinned}
+          visible={visible}
           now={now}
           onToggle={onToggle}
         />
@@ -206,8 +206,9 @@ export function FamilyDrawer({ selected, onClose, triggerRef }: {
   // Promotion intentionally defers provenance: promoted sessions present as
   // roots even though parent_session_id remains immutable on the wire.
   const projection = projectFamily(selected, sessions.value)
-  // Your own path, root to selection: the cap may fold anything but this.
+  // Your own path, root to selection: the budget may fold anything but this.
   const pinned = new Set([...projection.ancestors.map(a => a.id), selected.id])
+  const visible = visibleFamilyRows(projection.tree, pinned)
   // One clock for the whole paint, so sibling ages can't disagree.
   const now = Date.now()
   return (
@@ -223,7 +224,7 @@ export function FamilyDrawer({ selected, onClose, triggerRef }: {
             selectedId={selected.id}
             depth={0}
             expanded={expanded}
-            pinned={pinned}
+            visible={visible}
             now={now}
             onToggle={toggle}
           />

--- a/apps/gmux-web/src/family-drawer.tsx
+++ b/apps/gmux-web/src/family-drawer.tsx
@@ -102,7 +102,10 @@ function LevelRows({ nodes, parentId, selectedId, depth, expanded, pinned, now, 
             aria-expanded={summary.expanded}
             onClick={() => onToggle(summary.key)}
           >
-            <span class="family-more-chevron" aria-hidden="true">{summary.expanded ? '▾' : '▸'}</span>
+            {/* The summary sits below the rows it controls, so collapsing
+              * takes them back upwards: `▴`, not the `▾` that would point
+              * at the empty space where nothing is about to happen. */}
+            <span class="family-more-chevron" aria-hidden="true">{summary.expanded ? '▴' : '▸'}</span>
             {summary.label}
           </button>
         </li>

--- a/apps/gmux-web/src/family-drawer.tsx
+++ b/apps/gmux-web/src/family-drawer.tsx
@@ -1,12 +1,15 @@
 import { useEffect, useRef, useState } from 'preact/hooks'
 import {
-  familyCounts, isProcessSession, projectFamily,
+  familyCounts, familyStateOf, isProcessSession, projectFamily,
   type FamilyNode, type FamilyState,
 } from './family'
 import { splitLevel, visibleFamilyRows, type FamilyView } from './family-drawer-model'
 import { viewToPath } from './routing'
 import { formatAge } from './session-row'
-import { activityMap, markSessionRead, projects, sessions, sessionDotState, tabHref } from './store'
+import {
+  activityMap, cancelSession, killSession, markSessionRead,
+  projects, sessions, sessionDotState, tabHref,
+} from './store'
 import type { Session } from './types'
 
 function hrefFor(session: Session): string | undefined {
@@ -117,18 +120,34 @@ function LevelRows({ nodes, parentId, selectedId, depth, expanded, view, now, on
   )
 }
 
-/** Every member with something outstanding, in one pass over the tree.
- * `markSessionRead` clears the error flag alongside the unread one, so
- * both belong here — the button answers the counts line, and the counts
- * line counts both. */
-function unreadMembers(tree: FamilyNode): Session[] {
+/** Every member the given filter matches — the same `familyStateOf`
+ * rule the tally counts by and the tree filters by, so the action the
+ * header offers acts on exactly the rows the panel is showing. */
+function membersInState(tree: FamilyNode, state: FamilyState): Session[] {
   const out: Session[] = []
   const visit = (node: FamilyNode) => {
-    if (node.session.unread || node.session.status?.error) out.push(node.session)
+    if (familyStateOf(node.session) === state) out.push(node.session)
     for (const child of node.children) visit(child)
   }
   visit(tree)
   return out
+}
+
+/** The one bulk action each filter's members admit. There is no ambient
+ * action: a verb only appears once its filter is on, so you are looking
+ * at the complete list of what it will touch before the button exists —
+ * that, not a confirm dialog, is the safety for the destructive ones.
+ *
+ * `error` shares the waiting verb because acknowledging is all you can
+ * do in bulk to an error — `markSessionRead` clears the error flag — and
+ * error's precedence means an errored member never surfaces under
+ * `waiting`. There is no action for `all`: no single verb answers
+ * everything. */
+const FAMILY_ACTIONS: Partial<Record<FamilyState, { label: string; run: (id: string) => unknown }>> = {
+  waiting: { label: 'Mark all read', run: markSessionRead },
+  error: { label: 'Mark all read', run: markSessionRead },
+  running: { label: 'Stop all', run: killSession },
+  active: { label: 'Interrupt all', run: cancelSession },
 }
 
 /** The header's tally, in the turn model's own words (ADR 0023: a
@@ -142,8 +161,11 @@ function unreadMembers(tree: FamilyNode): Session[] {
  * the header and the tree can be read against each other without
  * translating — including the `$`, because a family is routinely mostly
  * processes and "3 active" reads very differently depending on whether
- * that means subagents thinking or shells running. `total` gets no
- * glyph: it isn't a state. */
+ * that means subagents thinking or shells running. `all` gets no glyph
+ * or count: it isn't a state, it's the absence of the question — and it
+ * goes first because it's the position the panel opens in. The family's
+ * size was the one fact the old `total` carried, and members mostly
+ * accumulate; the folds' `+N more` already says how much lies below. */
 function CountsLine({ tree, filter, onFilter }: {
   tree: FamilyNode
   filter: FamilyState | null
@@ -151,15 +173,15 @@ function CountsLine({ tree, filter, onFilter }: {
 }) {
   const counts = familyCounts([tree])
   const segments: {
-    key: FamilyState | 'total'
+    key: FamilyState | 'all'
     dot?: string
     process?: boolean
-    count: number
+    count?: number
     label: string
     cls?: string
-  }[] = []
-  // Same precedence the dot itself resolves by: error, then active,
-  // then waiting. Processes follow the agents they belong to.
+  }[] = [{ key: 'all', label: 'all' }]
+  // Then the same precedence the dot itself resolves by: error, then
+  // active, then waiting. Processes follow the agents they belong to.
   if (counts.error > 0) {
     segments.push({ key: 'error', dot: 'error', count: counts.error, label: 'error', cls: 'attention' })
   }
@@ -175,13 +197,10 @@ function CountsLine({ tree, filter, onFilter }: {
   if (counts.unread > 0) {
     segments.push({ key: 'waiting', dot: 'unread', count: counts.unread, label: 'waiting', cls: 'attention' })
   }
-  // `total` is the way back: it's already the count of everyone, so it
-  // doubles as "no filter" rather than needing a clear button of its own.
-  segments.push({ key: 'total', count: counts.total, label: 'total' })
   return (
     <div class="family-counts">
       {segments.map(segment => {
-        const state = segment.key === 'total' ? null : segment.key
+        const state = segment.key === 'all' ? null : segment.key
         const active = filter === state
         return (
           <button
@@ -195,7 +214,7 @@ function CountsLine({ tree, filter, onFilter }: {
           >
             {segment.dot && <span class={`session-dot-indicator ${segment.dot}`} aria-hidden="true" />}
             {segment.process && <span class="family-row-proc working" aria-hidden="true">$</span>}
-            {segment.count} {segment.label}
+            {segment.count !== undefined && `${segment.count} `}{segment.label}
           </button>
         )
       })}
@@ -282,23 +301,25 @@ export function FamilyDrawer({ selected, onClose, triggerRef }: {
   // Your own path, root to selection: the budget may fold anything but this.
   const pinned = new Set([...projection.ancestors.map(a => a.id), selected.id])
   const view = visibleFamilyRows(projection.tree, { pinned, filter })
-  const outstanding = unreadMembers(projection.tree)
+  const action = filter ? FAMILY_ACTIONS[filter] : undefined
+  const targets = filter && action ? membersInState(projection.tree, filter) : []
   // One clock for the whole paint, so sibling ages can't disagree.
   const now = Date.now()
   return (
     <div id="agent-family-drawer" class="family-drawer" role="dialog" aria-label="Session family" ref={panelRef}>
       <div class="family-drawer-head">
         <CountsLine tree={projection.tree} filter={filter} onFilter={setFilter} />
-        {outstanding.length > 0 && (
+        {action && targets.length > 0 && (
           <button
             type="button"
             class="family-mark-read"
-            // Iterating is the whole implementation: `markSessionRead` is
-            // optimistic and token-bound, so the panel clears instantly
-            // and a member that speaks again mid-flight keeps its dot.
-            onClick={() => { for (const session of outstanding) markSessionRead(session.id) }}
+            // Iterating is the whole implementation: mark-read is
+            // optimistic and token-bound, kill and cancel are one POST
+            // each, and every call is idempotent-or-tolerant, so a
+            // member that changes state mid-flight loses nothing.
+            onClick={() => { for (const session of targets) action.run(session.id) }}
           >
-            Mark all read
+            {action.label}
           </button>
         )}
       </div>

--- a/apps/gmux-web/src/family-drawer.tsx
+++ b/apps/gmux-web/src/family-drawer.tsx
@@ -135,19 +135,35 @@ function unreadMembers(tree: FamilyNode): Session[] {
  * wire spells "waiting on you", shortened to `waiting` because it sits
  * beside three other segments.
  *
- * Each segment names a state and shows the dot the rows use for it, so
+ * Each segment names a state and shows the glyph the rows use for it, so
  * the header and the tree can be read against each other without
- * translating. `total` gets no dot: it isn't a state. */
+ * translating — including the `$`, because a family is routinely mostly
+ * processes and "3 active" reads very differently depending on whether
+ * that means subagents thinking or shells running. `total` gets no
+ * glyph: it isn't a state. */
 function CountsLine({ tree }: { tree: FamilyNode }) {
   const counts = familyCounts([tree])
-  const segments: { key: string; dot?: string; count: number; label: string; cls?: string }[] = []
+  const segments: {
+    key: string
+    dot?: string
+    process?: boolean
+    count: number
+    label: string
+    cls?: string
+  }[] = []
   // Same precedence the dot itself resolves by: error, then active,
-  // then waiting.
+  // then waiting. Processes follow the agents they belong to.
   if (counts.error > 0) {
     segments.push({ key: 'error', dot: 'error', count: counts.error, label: 'error', cls: 'attention' })
   }
-  if (counts.working > 0) {
-    segments.push({ key: 'active', dot: 'working', count: counts.working, label: 'active' })
+  if (counts.workingAgents > 0) {
+    segments.push({ key: 'active', dot: 'working', count: counts.workingAgents, label: 'active' })
+  }
+  if (counts.workingProcesses > 0) {
+    // `running`, not `active`: one turn model (ADR 0023), but a command
+    // runs where an agent works, and this codebase already says
+    // "running process" in the sidebar's own summary.
+    segments.push({ key: 'running', process: true, count: counts.workingProcesses, label: 'running' })
   }
   if (counts.unread > 0) {
     segments.push({ key: 'waiting', dot: 'unread', count: counts.unread, label: 'waiting', cls: 'attention' })
@@ -161,6 +177,7 @@ function CountsLine({ tree }: { tree: FamilyNode }) {
           class={`family-count${segment.cls ? ` family-count-${segment.cls}` : ''}`}
         >
           {segment.dot && <span class={`session-dot-indicator ${segment.dot}`} aria-hidden="true" />}
+          {segment.process && <span class="family-row-proc working" aria-hidden="true">$</span>}
           {segment.count} {segment.label}
         </span>
       ))}

--- a/apps/gmux-web/src/family-drawer.tsx
+++ b/apps/gmux-web/src/family-drawer.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useRef, useState } from 'preact/hooks'
-import { familyCounts, isProcessSession, projectFamily, type FamilyNode } from './family'
-import { splitLevel, visibleFamilyRows } from './family-drawer-model'
+import {
+  familyCounts, isProcessSession, projectFamily,
+  type FamilyNode, type FamilyState,
+} from './family'
+import { splitLevel, visibleFamilyRows, type FamilyView } from './family-drawer-model'
 import { viewToPath } from './routing'
 import { formatAge } from './session-row'
 import { activityMap, markSessionRead, projects, sessions, sessionDotState, tabHref } from './store'
@@ -11,13 +14,13 @@ function hrefFor(session: Session): string | undefined {
   return path ? tabHref(path) : undefined
 }
 
-function FamilyRow({ node, selectedId, depth, expanded, visible, now, onToggle }: {
+function FamilyRow({ node, selectedId, depth, expanded, view, now, onToggle }: {
   node: FamilyNode
   selectedId: string
   depth: number
   expanded: ReadonlySet<string>
-  /** The rows the panel's budget chose to draw. */
-  visible: ReadonlySet<string>
+  /** What the panel's budget chose to draw, and what it chose from. */
+  view: FamilyView
   /** Render-time clock, passed down so every row in one paint agrees. */
   now: number
   onToggle: (key: string) => void
@@ -56,7 +59,7 @@ function FamilyRow({ node, selectedId, depth, expanded, visible, now, onToggle }
             selectedId={selectedId}
             depth={depth + 1}
             expanded={expanded}
-            visible={visible}
+            view={view}
             now={now}
             onToggle={onToggle}
           />
@@ -68,17 +71,17 @@ function FamilyRow({ node, selectedId, depth, expanded, visible, now, onToggle }
 
 /** One children level: capped rows plus a two-state summary row
  * (`+N more` / `show fewer`) keyed per parent. */
-function LevelRows({ nodes, parentId, selectedId, depth, expanded, visible, now, onToggle }: {
+function LevelRows({ nodes, parentId, selectedId, depth, expanded, view, now, onToggle }: {
   nodes: readonly FamilyNode[]
   parentId: string
   selectedId: string
   depth: number
   expanded: ReadonlySet<string>
-  visible: ReadonlySet<string>
+  view: FamilyView
   now: number
   onToggle: (key: string) => void
 }) {
-  const { shown, summary } = splitLevel(nodes, parentId, expanded, visible)
+  const { shown, summary } = splitLevel(nodes, parentId, expanded, view)
   return (
     <>
       {shown.map(node => (
@@ -88,7 +91,7 @@ function LevelRows({ nodes, parentId, selectedId, depth, expanded, visible, now,
           selectedId={selectedId}
           depth={depth}
           expanded={expanded}
-          visible={visible}
+          view={view}
           now={now}
           onToggle={onToggle}
         />
@@ -141,10 +144,14 @@ function unreadMembers(tree: FamilyNode): Session[] {
  * processes and "3 active" reads very differently depending on whether
  * that means subagents thinking or shells running. `total` gets no
  * glyph: it isn't a state. */
-function CountsLine({ tree }: { tree: FamilyNode }) {
+function CountsLine({ tree, filter, onFilter }: {
+  tree: FamilyNode
+  filter: FamilyState | null
+  onFilter: (state: FamilyState | null) => void
+}) {
   const counts = familyCounts([tree])
   const segments: {
-    key: string
+    key: FamilyState | 'total'
     dot?: string
     process?: boolean
     count: number
@@ -168,19 +175,30 @@ function CountsLine({ tree }: { tree: FamilyNode }) {
   if (counts.unread > 0) {
     segments.push({ key: 'waiting', dot: 'unread', count: counts.unread, label: 'waiting', cls: 'attention' })
   }
+  // `total` is the way back: it's already the count of everyone, so it
+  // doubles as "no filter" rather than needing a clear button of its own.
   segments.push({ key: 'total', count: counts.total, label: 'total' })
   return (
     <div class="family-counts">
-      {segments.map(segment => (
-        <span
-          key={segment.key}
-          class={`family-count${segment.cls ? ` family-count-${segment.cls}` : ''}`}
-        >
-          {segment.dot && <span class={`session-dot-indicator ${segment.dot}`} aria-hidden="true" />}
-          {segment.process && <span class="family-row-proc working" aria-hidden="true">$</span>}
-          {segment.count} {segment.label}
-        </span>
-      ))}
+      {segments.map(segment => {
+        const state = segment.key === 'total' ? null : segment.key
+        const active = filter === state
+        return (
+          <button
+            key={segment.key}
+            type="button"
+            // A tally you can press is a filter; pressing the one that's
+            // on turns it off, so the panel never traps you in a view.
+            class={`family-count${segment.cls ? ` family-count-${segment.cls}` : ''}${active ? ' active' : ''}`}
+            aria-pressed={active}
+            onClick={() => onFilter(active ? null : state)}
+          >
+            {segment.dot && <span class={`session-dot-indicator ${segment.dot}`} aria-hidden="true" />}
+            {segment.process && <span class="family-row-proc working" aria-hidden="true">$</span>}
+            {segment.count} {segment.label}
+          </button>
+        )
+      })}
     </div>
   )
 }
@@ -201,6 +219,9 @@ export function FamilyDrawer({ selected, onClose, triggerRef }: {
 }) {
   const panelRef = useRef<HTMLDivElement>(null)
   const [expanded, setExpanded] = useState<ReadonlySet<string>>(new Set())
+  // Per-open, like the expansion state beside it: a filter is a way of
+  // looking at the family right now, not a preference about it.
+  const [filter, setFilter] = useState<FamilyState | null>(null)
   const toggle = (key: string) => {
     setExpanded(prev => {
       const next = new Set(prev)
@@ -260,14 +281,14 @@ export function FamilyDrawer({ selected, onClose, triggerRef }: {
   const projection = projectFamily(selected, sessions.value)
   // Your own path, root to selection: the budget may fold anything but this.
   const pinned = new Set([...projection.ancestors.map(a => a.id), selected.id])
-  const visible = visibleFamilyRows(projection.tree, pinned)
+  const view = visibleFamilyRows(projection.tree, { pinned, filter })
   const outstanding = unreadMembers(projection.tree)
   // One clock for the whole paint, so sibling ages can't disagree.
   const now = Date.now()
   return (
     <div id="agent-family-drawer" class="family-drawer" role="dialog" aria-label="Session family" ref={panelRef}>
       <div class="family-drawer-head">
-        <CountsLine tree={projection.tree} />
+        <CountsLine tree={projection.tree} filter={filter} onFilter={setFilter} />
         {outstanding.length > 0 && (
           <button
             type="button"
@@ -289,7 +310,7 @@ export function FamilyDrawer({ selected, onClose, triggerRef }: {
             selectedId={selected.id}
             depth={0}
             expanded={expanded}
-            visible={visible}
+            view={view}
             now={now}
             onToggle={toggle}
           />

--- a/apps/gmux-web/src/family-drawer.tsx
+++ b/apps/gmux-web/src/family-drawer.tsx
@@ -3,7 +3,7 @@ import { familyCounts, isProcessSession, projectFamily, type FamilyNode } from '
 import { splitLevel, visibleFamilyRows } from './family-drawer-model'
 import { viewToPath } from './routing'
 import { formatAge } from './session-row'
-import { activityMap, projects, sessions, sessionDotState, tabHref } from './store'
+import { activityMap, markSessionRead, projects, sessions, sessionDotState, tabHref } from './store'
 import type { Session } from './types'
 
 function hrefFor(session: Session): string | undefined {
@@ -114,6 +114,20 @@ function LevelRows({ nodes, parentId, selectedId, depth, expanded, visible, now,
   )
 }
 
+/** Every member with something outstanding, in one pass over the tree.
+ * `markSessionRead` clears the error flag alongside the unread one, so
+ * both belong here — the button answers the counts line, and the counts
+ * line counts both. */
+function unreadMembers(tree: FamilyNode): Session[] {
+  const out: Session[] = []
+  const visit = (node: FamilyNode) => {
+    if (node.session.unread || node.session.status?.error) out.push(node.session)
+    for (const child of node.children) visit(child)
+  }
+  visit(tree)
+  return out
+}
+
 function CountsLine({ tree }: { tree: FamilyNode }) {
   const counts = familyCounts([tree])
   const segments: { text: string; cls?: string }[] = []
@@ -209,12 +223,25 @@ export function FamilyDrawer({ selected, onClose, triggerRef }: {
   // Your own path, root to selection: the budget may fold anything but this.
   const pinned = new Set([...projection.ancestors.map(a => a.id), selected.id])
   const visible = visibleFamilyRows(projection.tree, pinned)
+  const outstanding = unreadMembers(projection.tree)
   // One clock for the whole paint, so sibling ages can't disagree.
   const now = Date.now()
   return (
     <div id="agent-family-drawer" class="family-drawer" role="dialog" aria-label="Session family" ref={panelRef}>
       <div class="family-drawer-head">
         <CountsLine tree={projection.tree} />
+        {outstanding.length > 0 && (
+          <button
+            type="button"
+            class="family-mark-read"
+            // Iterating is the whole implementation: `markSessionRead` is
+            // optimistic and token-bound, so the panel clears instantly
+            // and a member that speaks again mid-flight keeps its dot.
+            onClick={() => { for (const session of outstanding) markSessionRead(session.id) }}
+          >
+            Mark all read
+          </button>
+        )}
       </div>
       <div class="family-drawer-scroll">
         <ul class="family-tree">

--- a/apps/gmux-web/src/family-drawer.tsx
+++ b/apps/gmux-web/src/family-drawer.tsx
@@ -1,13 +1,13 @@
 import { useEffect, useRef, useState } from 'preact/hooks'
 import {
-  familyCounts, familyStateOf, isProcessSession, projectFamily,
+  familySegments, familyStateOf, isProcessSession, NO_FAMILY_ACTIVITY, projectFamily,
   type FamilyNode, type FamilyState,
 } from './family'
 import { splitLevel, visibleFamilyRows, type FamilyView } from './family-drawer-model'
 import { viewToPath } from './routing'
 import { formatAge } from './session-row'
 import {
-  activityMap, cancelSession, killSession, markSessionRead,
+  activityMap, cancelSession, familyActivityById, killSession, markSessionRead,
   projects, sessions, sessionDotState, tabHref,
 } from './store'
 import { pushError } from './toasts'
@@ -211,58 +211,39 @@ async function runBulk(action: FamilyAction, targets: readonly Session[]): Promi
  * The root's own dot is on its pinned row directly beneath: it speaks
  * for itself, and counting it here would make this tally the one place
  * quoting a different number for the same dots. */
-function CountsLine({ tree, filter, onFilter }: {
-  tree: FamilyNode
+function CountsLine({ rootId, filter, onFilter }: {
+  rootId: string
   filter: FamilyState | null
   onFilter: (state: FamilyState | null) => void
 }) {
-  const counts = familyCounts(tree.children)
-  const segments: {
-    key: FamilyState | 'all'
-    dot?: string
-    process?: boolean
-    count?: number
-    label: string
-    cls?: string
-  }[] = [{ key: 'all', label: 'all' }]
-  // Then the same precedence the dot itself resolves by: error, then
-  // active, then waiting. Processes follow the agents they belong to.
-  if (counts.error > 0) {
-    segments.push({ key: 'error', dot: 'error', count: counts.error, label: 'error', cls: 'attention' })
-  }
-  if (counts.workingAgents > 0) {
-    segments.push({ key: 'active', dot: 'working', count: counts.workingAgents, label: 'active' })
-  }
-  if (counts.workingProcesses > 0) {
-    // `running`, not `active`: one turn model (ADR 0023), but a command
-    // runs where an agent works, and this codebase already says
-    // "running process" in the sidebar's own summary.
-    segments.push({ key: 'running', process: true, count: counts.workingProcesses, label: 'running' })
-  }
-  if (counts.unread > 0) {
-    segments.push({ key: 'waiting', dot: 'unread', count: counts.unread, label: 'waiting', cls: 'attention' })
-  }
+  const activity = familyActivityById.value.get(rootId) ?? NO_FAMILY_ACTIVITY
+  const tally = (state: FamilyState | null, active: boolean, children: preact.ComponentChildren) => (
+    <button
+      key={state ?? 'all'}
+      type="button"
+      // A tally you can press is a filter; pressing the one that's on
+      // turns it off, so the panel never traps you in a view.
+      class={`family-count${state === 'error' || state === 'waiting' ? ' family-count-attention' : ''}${active ? ' active' : ''}`}
+      aria-pressed={active}
+      onClick={() => onFilter(active ? null : state)}
+    >
+      {children}
+    </button>
+  )
   return (
     <div class="family-counts">
-      {segments.map(segment => {
-        const state = segment.key === 'all' ? null : segment.key
-        const active = filter === state
-        return (
-          <button
-            key={segment.key}
-            type="button"
-            // A tally you can press is a filter; pressing the one that's
-            // on turns it off, so the panel never traps you in a view.
-            class={`family-count${segment.cls ? ` family-count-${segment.cls}` : ''}${active ? ' active' : ''}`}
-            aria-pressed={active}
-            onClick={() => onFilter(active ? null : state)}
-          >
-            {segment.dot && <span class={`session-dot-indicator ${segment.dot}`} aria-hidden="true" />}
-            {segment.process && <span class="family-row-proc working" aria-hidden="true">$</span>}
-            {segment.count !== undefined && `${segment.count} `}{segment.label}
-          </button>
-        )
-      })}
+      {tally(null, filter === null, 'all')}
+      {familySegments(activity).map(segment => tally(segment.state, filter === segment.state, (
+        <>
+          {segment.dot
+            ? <span class={`session-dot-indicator ${segment.dot}`} aria-hidden="true" />
+            : <span class="family-row-proc working" aria-hidden="true">$</span>}
+          {/* The state's own name is the label: `running`, not a second
+            * `active` — one turn model (ADR 0023), but a command runs
+            * where an agent works. */}
+          {segment.count} {segment.state}
+        </>
+      )))}
     </div>
   )
 }
@@ -354,7 +335,7 @@ export function FamilyDrawer({ selected, onClose, triggerRef }: {
   return (
     <div id="agent-family-drawer" class="family-drawer" role="dialog" aria-label="Session family" ref={panelRef}>
       <div class="family-drawer-head">
-        <CountsLine tree={projection.tree} filter={filter} onFilter={setFilter} />
+        <CountsLine rootId={projection.root.id} filter={filter} onFilter={setFilter} />
         {action && targets.length > 0 && (
           <button
             type="button"

--- a/apps/gmux-web/src/family-drawer.tsx
+++ b/apps/gmux-web/src/family-drawer.tsx
@@ -122,15 +122,18 @@ function LevelRows({ nodes, parentId, selectedId, depth, expanded, view, now, on
 }
 
 /** Every member the given filter matches — the same `familyStateOf`
- * rule the tally counts by and the tree filters by, so the action the
- * header offers acts on exactly the rows the panel is showing. */
+ * rule the tally counts by, over the same population it counts: the
+ * root's descendants, never the root. The tally, the verb's label, and
+ * the verb's targets must quote one number, and the root is not the
+ * family's to act on — you act on the root by visiting it, which is
+ * usually where you are standing. */
 function membersInState(tree: FamilyNode, state: FamilyState): Session[] {
   const out: Session[] = []
   const visit = (node: FamilyNode) => {
     if (familyStateOf(node.session) === state) out.push(node.session)
     for (const child of node.children) visit(child)
   }
-  visit(tree)
+  for (const child of tree.children) visit(child)
   return out
 }
 
@@ -201,13 +204,19 @@ async function runBulk(action: FamilyAction, targets: readonly Session[]): Promi
  * or count: it isn't a state, it's the absence of the question — and it
  * goes first because it's the position the panel opens in. The family's
  * size was the one fact the old `total` carried, and members mostly
- * accumulate; the folds' `+N more` already says how much lies below. */
+ * accumulate; the folds' `+N more` already says how much lies below.
+ *
+ * Counted over the root's descendants, root excluded — the standard
+ * family numbers, shared with the header pill and the sidebar line.
+ * The root's own dot is on its pinned row directly beneath: it speaks
+ * for itself, and counting it here would make this tally the one place
+ * quoting a different number for the same dots. */
 function CountsLine({ tree, filter, onFilter }: {
   tree: FamilyNode
   filter: FamilyState | null
   onFilter: (state: FamilyState | null) => void
 }) {
-  const counts = familyCounts([tree])
+  const counts = familyCounts(tree.children)
   const segments: {
     key: FamilyState | 'all'
     dot?: string

--- a/apps/gmux-web/src/family-drawer.tsx
+++ b/apps/gmux-web/src/family-drawer.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'preact/hooks'
 import {
-  familySegments, familyStateOf, isProcessSession, NO_FAMILY_ACTIVITY, projectFamily,
+  familySegments, familyStateOf, isProcessSession, projectFamily,
   type FamilyNode, type FamilyState,
 } from './family'
 import { splitLevel, visibleFamilyRows, type FamilyView } from './family-drawer-model'
@@ -45,8 +45,12 @@ function FamilyRow({ node, selectedId, depth, expanded, view, now, onToggle }: {
         href={hrefFor(session)}
         aria-current={session.id === selectedId ? 'page' : undefined}
       >
+        {/* A process keeps its `$` shape and carries state as colour —
+          * the glyph column is the only place this row's state appears,
+          * so a `$` that can't say `unread` would hide a member the
+          * tally counts and the `waiting` filter shows. */}
         {process
-          ? <span class={`family-row-proc${session.alive && session.status?.active ? ' working' : ''}`} aria-hidden="true">$</span>
+          ? <span class={`family-proc ${dot}`} aria-hidden="true">$</span>
           : <span class={`session-dot-indicator ${dot}`} aria-hidden="true" />}
         <span class="family-row-title">{session.title}</span>
         {/* Levels are ordered by this timestamp, so it has to be on
@@ -106,14 +110,14 @@ function LevelRows({ nodes, parentId, selectedId, depth, expanded, view, now, on
             type="button"
             class="family-more"
             style={{ paddingLeft: `${12 + depth * 18}px` }}
-            aria-expanded={summary.expanded}
-            onClick={() => onToggle(summary.key)}
+            aria-expanded={expanded.has(parentId)}
+            onClick={() => onToggle(parentId)}
           >
             {/* The summary sits below the rows it controls, so collapsing
               * takes them back upwards: `▴`, not the `▾` that would point
               * at the empty space where nothing is about to happen. */}
-            <span class="family-more-chevron" aria-hidden="true">{summary.expanded ? '▴' : '▸'}</span>
-            {summary.label}
+            <span class="family-more-chevron" aria-hidden="true">{expanded.has(parentId) ? '▴' : '▸'}</span>
+            {summary}
           </button>
         </li>
       )}
@@ -121,8 +125,14 @@ function LevelRows({ nodes, parentId, selectedId, depth, expanded, view, now, on
   )
 }
 
-/** Every member the given filter matches — the same `familyStateOf`
- * rule the tally counts by, over the same population it counts: the
+/** Every member the given filter matches — the twin of
+ * `familyActivityById`, which counts what this collects. They agree
+ * because both start from the same family membership with the root
+ * excluded and neither filters further; a filter added to one alone
+ * would put a number on a button that touches a different set.
+ *
+ * The same `familyStateOf` rule the tally counts by, over the same
+ * population it counts: the
  * root's descendants, never the root. The tally, the verb's label, and
  * the verb's targets must quote one number, and the root is not the
  * family's to act on — you act on the root by visiting it, which is
@@ -156,15 +166,16 @@ function membersInState(tree: FamilyNode, state: FamilyState): Session[] {
  * everything. */
 type FamilyAction = {
   label: (n: number) => string
+  /** Returns false for a member that failed, so `runBulk` can report
+   * once at the end. `markSessionRead` returns nothing: it is
+   * optimistic and fire-and-forget, so it has no failure to count. */
   run: (id: string) => unknown
-  /** Verbs that can fail per member and report once at the end. */
-  aggregate?: boolean
 }
 const FAMILY_ACTIONS: Partial<Record<FamilyState, FamilyAction>> = {
   waiting: { label: () => 'Mark all read', run: markSessionRead },
   error: { label: () => 'Mark all read', run: markSessionRead },
-  running: { label: n => `Stop all ${n}`, run: id => killSession(id, { quiet: true }), aggregate: true },
-  active: { label: n => `Interrupt all ${n}`, run: id => cancelSession(id, { quiet: true }), aggregate: true },
+  running: { label: n => `Stop all ${n}`, run: id => killSession(id, { quiet: true }) },
+  active: { label: n => `Interrupt all ${n}`, run: id => cancelSession(id, { quiet: true }) },
 }
 
 /** Run a bulk verb over a family's worth of members.
@@ -184,9 +195,7 @@ async function runBulk(action: FamilyAction, targets: readonly Session[]): Promi
     }
   }
   await Promise.all(Array.from({ length: Math.min(8, queue.length) }, worker))
-  if (action.aggregate && failed > 0) {
-    pushError(`${failed} of ${targets.length} did not respond`)
-  }
+  if (failed > 0) pushError(`${failed} of ${targets.length} did not respond`)
 }
 
 /** The header's tally, in the turn model's own words (ADR 0023: a
@@ -216,7 +225,7 @@ function CountsLine({ rootId, filter, onFilter }: {
   filter: FamilyState | null
   onFilter: (state: FamilyState | null) => void
 }) {
-  const activity = familyActivityById.value.get(rootId) ?? NO_FAMILY_ACTIVITY
+  const activity = familyActivityById.value.get(rootId)
   const tally = (state: FamilyState | null, active: boolean, children: preact.ComponentChildren) => (
     <button
       key={state ?? 'all'}
@@ -237,7 +246,7 @@ function CountsLine({ rootId, filter, onFilter }: {
         <>
           {segment.dot
             ? <span class={`session-dot-indicator ${segment.dot}`} aria-hidden="true" />
-            : <span class="family-row-proc working" aria-hidden="true">$</span>}
+            : <span class="family-proc working" aria-hidden="true">$</span>}
           {/* The state's own name is the label: `running`, not a second
             * `active` — one turn model (ADR 0023), but a command runs
             * where an agent works. */}
@@ -354,10 +363,15 @@ export function FamilyDrawer({ selected, onClose, triggerRef }: {
         )}
       </div>
       <div class="family-drawer-scroll">
+        {/* The root is a row, not a level: wrapping it in `LevelRows`
+          * keyed the outer level by the root's own id — the same key
+          * its children's level uses — so expanding the children put a
+          * second, orphan `show fewer` under the whole tree. It could
+          * never fold anyway; the root is admitted before anything
+          * competes for the budget. */}
         <ul class="family-tree">
-          <LevelRows
-            nodes={[projection.tree]}
-            parentId={projection.root.id}
+          <FamilyRow
+            node={projection.tree}
             selectedId={selected.id}
             depth={0}
             expanded={expanded}

--- a/apps/gmux-web/src/family-drawer.tsx
+++ b/apps/gmux-web/src/family-drawer.tsx
@@ -128,19 +128,40 @@ function unreadMembers(tree: FamilyNode): Session[] {
   return out
 }
 
+/** The header's tally, in the turn model's own words (ADR 0023: a
+ * session is active, idle, or waiting on you) and the sidebar's own
+ * dots. `working` is the CSS token for the active dot; the fact behind
+ * it is `status.active`, so it reads `active` here. `unread` is how the
+ * wire spells "waiting on you", shortened to `waiting` because it sits
+ * beside three other segments.
+ *
+ * Each segment names a state and shows the dot the rows use for it, so
+ * the header and the tree can be read against each other without
+ * translating. `total` gets no dot: it isn't a state. */
 function CountsLine({ tree }: { tree: FamilyNode }) {
   const counts = familyCounts([tree])
-  const segments: { text: string; cls?: string }[] = []
-  if (counts.error > 0) segments.push({ text: `${counts.error} error`, cls: 'attention' })
-  if (counts.working > 0) segments.push({ text: `${counts.working} working` })
-  if (counts.unread > 0) segments.push({ text: `${counts.unread} unread`, cls: 'attention' })
-  segments.push({ text: `${counts.total} total` })
+  const segments: { key: string; dot?: string; count: number; label: string; cls?: string }[] = []
+  // Same precedence the dot itself resolves by: error, then active,
+  // then waiting.
+  if (counts.error > 0) {
+    segments.push({ key: 'error', dot: 'error', count: counts.error, label: 'error', cls: 'attention' })
+  }
+  if (counts.working > 0) {
+    segments.push({ key: 'active', dot: 'working', count: counts.working, label: 'active' })
+  }
+  if (counts.unread > 0) {
+    segments.push({ key: 'waiting', dot: 'unread', count: counts.unread, label: 'waiting', cls: 'attention' })
+  }
+  segments.push({ key: 'total', count: counts.total, label: 'total' })
   return (
     <div class="family-counts">
-      {segments.map((segment, index) => (
-        <span key={segment.text} class={segment.cls ? `family-count-${segment.cls}` : undefined}>
-          {index > 0 && <span class="family-count-sep" aria-hidden="true"> · </span>}
-          {segment.text}
+      {segments.map(segment => (
+        <span
+          key={segment.key}
+          class={`family-count${segment.cls ? ` family-count-${segment.cls}` : ''}`}
+        >
+          {segment.dot && <span class={`session-dot-indicator ${segment.dot}`} aria-hidden="true" />}
+          {segment.count} {segment.label}
         </span>
       ))}
     </div>

--- a/apps/gmux-web/src/family-icon.tsx
+++ b/apps/gmux-web/src/family-icon.tsx
@@ -1,0 +1,14 @@
+/** The family mark: several nodes, one structure. Shared by every
+ * surface that summarizes a family — the header's trigger and the
+ * sidebar's activity line — so "this is about the family beneath"
+ * is always said with the same picture. */
+export function FamilyIcon({ class: cls }: { class?: string }) {
+  return (
+    <svg class={cls} viewBox="0 0 16 16" aria-hidden="true">
+      <path d="M8 5.5v2M8 7.5c0 1.5-3.5 1-3.5 3M8 7.5c0 1.5 3.5 1 3.5 3" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" />
+      <circle cx="8" cy="3.75" r="1.9" fill="none" stroke="currentColor" stroke-width="1.3" />
+      <circle cx="4.5" cy="12" r="1.9" fill="none" stroke="currentColor" stroke-width="1.3" />
+      <circle cx="11.5" cy="12" r="1.9" fill="none" stroke="currentColor" stroke-width="1.3" />
+    </svg>
+  )
+}

--- a/apps/gmux-web/src/family.bench.ts
+++ b/apps/gmux-web/src/family.bench.ts
@@ -1,5 +1,5 @@
 import { bench, describe } from 'vitest'
-import { createFamilyIndex, familyCounts, projectFamily } from './family'
+import { createFamilyIndex, projectFamily } from './family'
 import { makeSession } from './test-helpers'
 
 const agent = (id: string, parent?: string) => makeSession({
@@ -30,7 +30,4 @@ describe('family projection (1,000 sessions / 500 children)', () => {
     projectFamily(children[250], index)
   })
 
-  bench('project and count the selected child panel', () => {
-    familyCounts([projectFamily(children[250], index).tree])
-  })
 })

--- a/apps/gmux-web/src/family.test.ts
+++ b/apps/gmux-web/src/family.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import {
-  descendantTree, familyAncestors, familyIndex, familySegments, familyStateOf,
-  childTrailTitle, familyActivityLabel, familyRoot, hasFamily, hasFamilyActivity,
-  familyMemberGlyph, isFamilyChild, NO_FAMILY_ACTIVITY, projectFamily,
+  descendantTree, familyAncestors, familyIndex, familySegments,
+  childTrailTitle, familyActivityLabel, familyRoot, hasFamily, type FamilyActivity,
+  familyMemberGlyph, isFamilyChild, projectFamily,
 } from './family'
 import { makeSession } from './test-helpers'
 
@@ -155,30 +155,6 @@ describe('flat panel projection', () => {
       .toEqual(['newest-dead', 'mid-idle', 'created-only', 'old-working'])
   })
 
-  it('tallies the counts line by dot precedence over all panel members', () => {
-    const root = agent('root')
-    const sessions = [
-      root,
-      member('working', { status: { active: true } }),
-      member('working-unread', { status: { active: true }, unread: true }),
-      member('errored', { status: { active: true, error: true } }),
-      member('dead-unread', { alive: false, unread: true }),
-      member('grandchild-unread', { parent_session_id: 'working', unread: true }),
-      member('proc-working', { semantic_agent: undefined, adapter: 'shell', status: { active: true } }),
-      member('dead-viewed', { alive: false }),
-    ]
-    // Each member counted once under its highest-precedence state: the
-    // working-unread agent is active (dot precedence), the dead unread
-    // one is waiting (not alive-gated), and processes run rather than
-    // work. The root and the quiet members land nowhere: idle is not a
-    // bucket, and the root is not a descendant.
-    const counted = sessions.filter(s => s.id !== 'root').map(s => familyStateOf(s))
-    expect(counted.filter(state => state === 'error')).toHaveLength(1)
-    expect(counted.filter(state => state === 'active')).toHaveLength(2)
-    expect(counted.filter(state => state === 'running')).toHaveLength(1)
-    expect(counted.filter(state => state === 'waiting')).toHaveLength(2)
-    expect(counted.filter(state => state === null)).toHaveLength(1)
-  })
 })
 
 describe('member row glyph', () => {
@@ -218,26 +194,29 @@ describe('member row glyph', () => {
 })
 
 describe('family activity line', () => {
-  const activity = (over = {}) => ({ ...NO_FAMILY_ACTIVITY, ...over })
+  const activity = (over: Partial<FamilyActivity> = {}): FamilyActivity =>
+    ({ error: 0, waiting: 0, active: 0, running: 0, ...over })
 
-  it('shows nothing for an idle family', () => {
-    expect(hasFamilyActivity(NO_FAMILY_ACTIVITY)).toBe(false)
+  it('has no segments for an idle family, or for one with no entry at all', () => {
+    expect(familySegments(activity())).toEqual([])
+    // A quiet family is absent from the activity map entirely, and that
+    // absence is the same fact as "nothing to report".
+    expect(familySegments(undefined)).toEqual([])
   })
 
-  it('shows for any single non-zero state', () => {
-    expect(hasFamilyActivity(activity({ error: 1 }))).toBe(true)
-    expect(hasFamilyActivity(activity({ waiting: 1 }))).toBe(true)
-    expect(hasFamilyActivity(activity({ active: 1 }))).toBe(true)
-    expect(hasFamilyActivity(activity({ running: 1 }))).toBe(true)
+  it('gives every state a segment', () => {
+    for (const state of ['error', 'waiting', 'active', 'running'] as const) {
+      expect(familySegments(activity({ [state]: 1 })).map(s => s.state)).toEqual([state])
+    }
   })
 
   it('orders segments attention-first, and drops the zeros', () => {
     // One display order for every surface: the members that need you
     // (error, waiting) before the ambient work (active, running), so
     // what survives a narrow clip is what matters.
-    expect(familySegments(activity({ running: 3, waiting: 2, error: 1, active: 4 })).map((s: { state: string }) => s.state))
+    expect(familySegments(activity({ running: 3, waiting: 2, error: 1, active: 4 })).map(s => s.state))
       .toEqual(['error', 'waiting', 'active', 'running'])
-    expect(familySegments(activity({ running: 3, error: 1 })).map((s: { state: string }) => s.state))
+    expect(familySegments(activity({ running: 3, error: 1 })).map(s => s.state))
       .toEqual(['error', 'running'])
     // The glyph table is the vocabulary: dots for states that have
     // them, and the running state's null dot is the `$`.

--- a/apps/gmux-web/src/family.test.ts
+++ b/apps/gmux-web/src/family.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
-  descendantTree, familyAncestors, familyCounts, familyIndex,
+  descendantTree, familyAncestors, familyIndex, familySegments, familyStateOf,
   childTrailTitle, familyActivityLabel, familyRoot, hasFamily, hasFamilyActivity,
   familyMemberGlyph, isFamilyChild, NO_FAMILY_ACTIVITY, projectFamily,
 } from './family'
@@ -167,30 +167,17 @@ describe('flat panel projection', () => {
       member('proc-working', { semantic_agent: undefined, adapter: 'shell', status: { active: true } }),
       member('dead-viewed', { alive: false }),
     ]
-    const tree = projectFamily(root, sessions).tree
     // Each member counted once under its highest-precedence state: the
-    // working-unread agent is working (dot precedence), the dead unread
-    // one is unread (not alive-gated), processes count like anyone else,
-    // and the root + quiet members only land in the total.
-    expect(familyCounts([tree])).toEqual({
-      error: 1, workingAgents: 2, workingProcesses: 1, unread: 2, total: 8,
-    })
-  })
-
-  it('counts the same family from anywhere inside it', () => {
-    const root = agent('root')
-    const parent = member('parent')
-    const selected = member('selected', { parent_session_id: 'parent' })
-    const sibling = member('sibling', { parent_session_id: 'parent', alive: false })
-    const snapshot = [root, parent, selected, sibling]
-    const fromRoot = familyCounts([projectFamily(root, snapshot).tree])
-    const fromDeep = familyCounts([projectFamily(selected, snapshot).tree])
-    // One scope, so the line reads the same on every row you visit —
-    // and the root is one of the members it counts.
-    expect(fromDeep).toEqual(fromRoot)
-    expect(fromRoot).toEqual({
-      error: 0, workingAgents: 0, workingProcesses: 0, unread: 0, total: 4,
-    })
+    // working-unread agent is active (dot precedence), the dead unread
+    // one is waiting (not alive-gated), and processes run rather than
+    // work. The root and the quiet members land nowhere: idle is not a
+    // bucket, and the root is not a descendant.
+    const counted = sessions.filter(s => s.id !== 'root').map(s => familyStateOf(s))
+    expect(counted.filter(state => state === 'error')).toHaveLength(1)
+    expect(counted.filter(state => state === 'active')).toHaveLength(2)
+    expect(counted.filter(state => state === 'running')).toHaveLength(1)
+    expect(counted.filter(state => state === 'waiting')).toHaveLength(2)
+    expect(counted.filter(state => state === null)).toHaveLength(1)
   })
 })
 
@@ -239,18 +226,32 @@ describe('family activity line', () => {
 
   it('shows for any single non-zero state', () => {
     expect(hasFamilyActivity(activity({ error: 1 }))).toBe(true)
-    expect(hasFamilyActivity(activity({ unread: 1 }))).toBe(true)
-    expect(hasFamilyActivity(activity({ workingAgents: 1 }))).toBe(true)
-    expect(hasFamilyActivity(activity({ workingProcesses: 1 }))).toBe(true)
+    expect(hasFamilyActivity(activity({ waiting: 1 }))).toBe(true)
+    expect(hasFamilyActivity(activity({ active: 1 }))).toBe(true)
+    expect(hasFamilyActivity(activity({ running: 1 }))).toBe(true)
+  })
+
+  it('orders segments attention-first, and drops the zeros', () => {
+    // One display order for every surface: the members that need you
+    // (error, waiting) before the ambient work (active, running), so
+    // what survives a narrow clip is what matters.
+    expect(familySegments(activity({ running: 3, waiting: 2, error: 1, active: 4 })).map((s: { state: string }) => s.state))
+      .toEqual(['error', 'waiting', 'active', 'running'])
+    expect(familySegments(activity({ running: 3, error: 1 })).map((s: { state: string }) => s.state))
+      .toEqual(['error', 'running'])
+    // The glyph table is the vocabulary: dots for states that have
+    // them, and the running state's null dot is the `$`.
+    expect(familySegments(activity({ running: 1 }))[0].dot).toBeNull()
+    expect(familySegments(activity({ waiting: 1 }))[0].dot).toBe('unread')
   })
 
   it('spells the glyph row out for screen readers, attention first', () => {
-    expect(familyActivityLabel(activity({ error: 1, unread: 2, workingAgents: 1, workingProcesses: 3 })))
+    expect(familyActivityLabel(activity({ error: 1, waiting: 2, active: 1, running: 3 })))
       .toBe('In this family: 1 member with an error, 2 members waiting on you, 1 active subagent, 3 running processes')
   })
 
   it('omits zero states from the label', () => {
-    expect(familyActivityLabel(activity({ unread: 1 })))
+    expect(familyActivityLabel(activity({ waiting: 1 })))
       .toBe('In this family: 1 member waiting on you')
   })
 })

--- a/apps/gmux-web/src/family.test.ts
+++ b/apps/gmux-web/src/family.test.ts
@@ -172,7 +172,9 @@ describe('flat panel projection', () => {
     // working-unread agent is working (dot precedence), the dead unread
     // one is unread (not alive-gated), processes count like anyone else,
     // and the root + quiet members only land in the total.
-    expect(familyCounts([tree])).toEqual({ error: 1, working: 3, unread: 2, total: 8 })
+    expect(familyCounts([tree])).toEqual({
+      error: 1, workingAgents: 2, workingProcesses: 1, unread: 2, total: 8,
+    })
   })
 
   it('counts the same family from anywhere inside it', () => {
@@ -186,7 +188,9 @@ describe('flat panel projection', () => {
     // One scope, so the line reads the same on every row you visit —
     // and the root is one of the members it counts.
     expect(fromDeep).toEqual(fromRoot)
-    expect(fromRoot).toEqual({ error: 0, working: 0, unread: 0, total: 4 })
+    expect(fromRoot).toEqual({
+      error: 0, workingAgents: 0, workingProcesses: 0, unread: 0, total: 4,
+    })
   })
 })
 

--- a/apps/gmux-web/src/family.test.ts
+++ b/apps/gmux-web/src/family.test.ts
@@ -246,12 +246,12 @@ describe('family activity line', () => {
 
   it('spells the glyph row out for screen readers, attention first', () => {
     expect(familyActivityLabel(activity({ error: 1, unread: 2, workingAgents: 1, workingProcesses: 3 })))
-      .toBe('Also in this family: 1 member with an error, 2 unread members, 1 working subagent, 3 running processes')
+      .toBe('In this family: 1 member with an error, 2 members waiting on you, 1 active subagent, 3 running processes')
   })
 
   it('omits zero states from the label', () => {
     expect(familyActivityLabel(activity({ unread: 1 })))
-      .toBe('Also in this family: 1 unread member')
+      .toBe('In this family: 1 member waiting on you')
   })
 })
 

--- a/apps/gmux-web/src/family.ts
+++ b/apps/gmux-web/src/family.ts
@@ -168,12 +168,12 @@ function byRecency(a: Session, b: Session): number {
  *  dot state the sidebar computed for it.
  *
  *  The column is always occupied, and — this is the load-bearing part —
- *  it is the *only* place a named member's state can appear, because
- *  the activity line subtracts whoever the row names. A glyph that
- *  can't express `unread` therefore doesn't just look plainer; it drops
- *  that member's attention entirely: counted nowhere, shown nowhere.
- *  So a process keeps its `$` shape but carries state as colour, and an
- *  agent with nothing to report falls back to the branch. */
+ *  it is the only place *this* member's state is shown: the summary
+ *  line below counts it among many, which tells you something needs
+ *  you but never which row. A glyph that can't express `unread` makes
+ *  the named member the one you cannot see. So a process keeps its `$`
+ *  shape but carries state as colour, and an agent with nothing to
+ *  report falls back to the branch. */
 export type MemberGlyph =
   | { readonly kind: 'process'; readonly state: DotState }
   | { readonly kind: 'dot'; readonly state: Exclude<DotState, 'none'> }
@@ -216,27 +216,31 @@ export function familyStateOf(session: Session): FamilyState | null {
  * census. */
 export type FamilyActivity = Readonly<Record<FamilyState, number>>
 
-export const NO_FAMILY_ACTIVITY: FamilyActivity = {
-  error: 0, waiting: 0, active: 0, running: 0,
-}
-
-/** True when a family has something worth a summary line. */
-export function hasFamilyActivity(activity: FamilyActivity): boolean {
-  return activity.error > 0 || activity.waiting > 0
-    || activity.active > 0 || activity.running > 0
-}
-
-/** One segment per non-zero state, in the one display order every
+/** How each state presents itself, in the one display order every
  * surface uses: attention first (error, then waiting — the members
  * that need you), ambient work after (active agents, then running
  * commands). Narrow surfaces clip from the right, so what survives a
  * clip is what matters; bucketing precedence is `familyStateOf`'s
  * concern, display order is this one's.
  *
- * `dot` is the CSS token the rows themselves wear (`unread` is how the
- * app spells "waiting on you"); `running` wears the `$` glyph instead
- * of a dot, exactly like its rows. This table is the vocabulary —
- * surfaces decide typography, never what a state looks like. */
+ * One row per state, carrying everything a summary needs to say it:
+ * the dot CSS token the rows themselves wear (`unread` is how the app
+ * spells "waiting on you"; `null` means the `$` glyph, exactly like a
+ * process row), and the words for readers who get the sentence instead
+ * of the glyphs. Surfaces choose typography — never what a state looks
+ * like, is called, or comes before. */
+const FAMILY_DISPLAY = [
+  { state: 'error', dot: 'error', phrase: (n: number) => `${plural(n, 'member')} with an error` },
+  { state: 'waiting', dot: 'unread', phrase: (n: number) => `${plural(n, 'member')} waiting on you` },
+  { state: 'active', dot: 'working', phrase: (n: number) => plural(n, 'active subagent') },
+  { state: 'running', dot: null, phrase: (n: number) => plural(n, 'running process') },
+] as const
+
+/** 'process' takes -es; everything else here takes -s. */
+function plural(n: number, word: string): string {
+  return `${n} ${word}${n === 1 ? '' : word.endsWith('s') ? 'es' : 's'}`
+}
+
 export interface FamilySegment {
   readonly state: FamilyState
   /** Dot CSS token, or null for the `$`-glyphed running state. */
@@ -244,30 +248,23 @@ export interface FamilySegment {
   readonly count: number
 }
 
-export function familySegments(activity: FamilyActivity): FamilySegment[] {
-  const order = [
-    { state: 'error', dot: 'error' },
-    { state: 'waiting', dot: 'unread' },
-    { state: 'active', dot: 'working' },
-    { state: 'running', dot: null },
-  ] as const
-  return order
+/** One segment per non-zero state. Takes the raw map entry, so a
+ * family with no activity at all (absent from the map) is simply no
+ * segments rather than a constant every caller has to remember. */
+export function familySegments(activity: FamilyActivity | undefined): FamilySegment[] {
+  if (!activity) return []
+  return FAMILY_DISPLAY
     .filter(({ state }) => activity[state] > 0)
     .map(({ state, dot }) => ({ state, dot, count: activity[state] }))
 }
 
-/** Spoken form of the activity segments, which are otherwise pure
- * glyphs — the turn model's words (waiting on you, active), not the
- * wire's field names. */
+/** Spoken form of the segments, which are otherwise pure glyphs — the
+ * turn model's words (waiting on you, active), not the wire's field
+ * names, and in the same order the glyphs appear. */
 export function familyActivityLabel(activity: FamilyActivity): string {
-  const parts: string[] = []
-  // 'process' takes -es; everything else here takes -s.
-  const plural = (n: number, word: string) =>
-    `${n} ${word}${n === 1 ? '' : word.endsWith('s') ? 'es' : 's'}`
-  if (activity.error > 0) parts.push(`${plural(activity.error, 'member')} with an error`)
-  if (activity.waiting > 0) parts.push(`${plural(activity.waiting, 'member')} waiting on you`)
-  if (activity.active > 0) parts.push(plural(activity.active, 'active subagent'))
-  if (activity.running > 0) parts.push(plural(activity.running, 'running process'))
+  const parts = FAMILY_DISPLAY
+    .filter(({ state }) => activity[state] > 0)
+    .map(({ state, phrase }) => phrase(activity[state]))
   return `In this family: ${parts.join(', ')}`
 }
 
@@ -312,11 +309,11 @@ export function descendantTree(root: Session, source: FamilySource): FamilyNode 
  * mean something different on every row you visit. Now one scope holds
  * wherever you stand: the same members, the same counts.
  *
- * That is *membership*, not aggregation. The three family surfaces
- * still summarise this set differently on purpose — the trigger badge
- * mutes what you're looking at, the sidebar line subtracts the member
- * its own row names, and this panel counts every row it draws, because
- * it draws them all.
+ * That is *membership*. Aggregation is one rule now, shared by every
+ * surface (`familyActivityById` + `familySegments`): the root's
+ * descendants, one bucket per state. The surfaces once each subtracted
+ * whatever they happened to name, which made the same glyphs quote a
+ * different number depending on where you stood.
  *
  * `ancestors` stays for callers that want the spine on its own (the
  * header crumbs); the tree already contains those rows. */
@@ -335,6 +332,3 @@ export function projectFamily(selected: Session, source: FamilySource): FamilyDr
     tree: descendantTree(root, index),
   }
 }
-
-
-

--- a/apps/gmux-web/src/family.ts
+++ b/apps/gmux-web/src/family.ts
@@ -315,19 +315,34 @@ export interface FamilyCounts {
   total: number
 }
 
+/** The one state a member is counted under — and, since the panel's
+ * tally doubles as its filter, the one state it can be filtered by.
+ *
+ * The tally and the filter must be the same rule or the panel lies:
+ * pressing `3 error` and getting four rows is worse than not being able
+ * to press it. So both derive from here, and the precedence is the
+ * dot's own: error, then a running turn, then waiting on you. */
+export type FamilyState = 'error' | 'active' | 'running' | 'waiting'
+
+export function familyStateOf(session: Session): FamilyState | null {
+  if (session.alive && session.status?.error) return 'error'
+  if (session.alive && session.status?.active) return isProcessSession(session) ? 'running' : 'active'
+  if (session.unread) return 'waiting'
+  return null
+}
+
 export function familyCounts(trees: readonly FamilyNode[]): FamilyCounts {
   const counts: FamilyCounts = {
     error: 0, workingAgents: 0, workingProcesses: 0, unread: 0, total: 0,
   }
   const visit = (node: FamilyNode) => {
-    const s = node.session
     counts.total++
-    if (s.alive && s.status?.error) counts.error++
-    else if (s.alive && s.status?.active) {
-      if (isProcessSession(s)) counts.workingProcesses++
-      else counts.workingAgents++
+    switch (familyStateOf(node.session)) {
+      case 'error': counts.error++; break
+      case 'active': counts.workingAgents++; break
+      case 'running': counts.workingProcesses++; break
+      case 'waiting': counts.unread++; break
     }
-    else if (s.unread) counts.unread++
     for (const child of node.children) visit(child)
   }
   for (const tree of trees) visit(tree)

--- a/apps/gmux-web/src/family.ts
+++ b/apps/gmux-web/src/family.ts
@@ -190,47 +190,84 @@ export function isProcessSession(session: Session): boolean {
   return session.semantic_agent !== true
 }
 
-/** What a family is *doing right now*, counted over the descendants of
- * one presentation root. Idle members are deliberately not counted: the
- * sidebar line exists to surface live work, not to take a census.
+/** The one state a member is counted under — and, since the panel's
+ * tally doubles as its filter, the one state it can be filtered by.
  *
- * Every counted member lands in exactly one bucket, under the same
- * precedence `sessionDotState` uses (error > working > unread), so the
- * line and the family drawer can never disagree. */
-export interface FamilyActivity {
-  /** Alive members whose last turn failed. */
-  readonly error: number
-  /** Members with output you haven't seen. */
-  readonly unread: number
-  /** Semantic-agent members mid-turn ("subagents"). */
-  readonly workingAgents: number
-  /** Non-agent members running a command ("processes"). */
-  readonly workingProcesses: number
+ * The tally and the filter must be the same rule or the panel lies:
+ * pressing `3 error` and getting four rows is worse than not being able
+ * to press it. So both derive from here, and the precedence is the
+ * dot's own: error, then a running turn, then waiting on you. */
+export type FamilyState = 'error' | 'active' | 'running' | 'waiting'
+
+export function familyStateOf(session: Session): FamilyState | null {
+  if (session.alive && session.status?.error) return 'error'
+  if (session.alive && session.status?.active) return isProcessSession(session) ? 'running' : 'active'
+  if (session.unread) return 'waiting'
+  return null
 }
+
+/** The standard family numbers: what the descendants of one
+ * presentation root are doing right now, one bucket per canonical
+ * state, each member counted once by `familyStateOf`. Every surface
+ * that summarizes a family — the sidebar line, the header pill, the
+ * panel tally — quotes this shape and nothing else, so the same dots
+ * can never wear different numbers. Idle members are deliberately not
+ * counted: the summaries exist to surface live work, not take a
+ * census. */
+export type FamilyActivity = Readonly<Record<FamilyState, number>>
 
 export const NO_FAMILY_ACTIVITY: FamilyActivity = {
-  error: 0, unread: 0, workingAgents: 0, workingProcesses: 0,
+  error: 0, waiting: 0, active: 0, running: 0,
 }
 
-/** True when a family has something worth a second sidebar line. */
+/** True when a family has something worth a summary line. */
 export function hasFamilyActivity(activity: FamilyActivity): boolean {
-  return activity.error > 0 || activity.unread > 0
-    || activity.workingAgents > 0 || activity.workingProcesses > 0
+  return activity.error > 0 || activity.waiting > 0
+    || activity.active > 0 || activity.running > 0
 }
 
-/** Spoken form of the activity line, which is otherwise pure glyphs.
- * The standard family numbers: everyone beneath the root, in the turn
- * model's words — waiting on you, active — matching the panel tally's
- * vocabulary rather than the wire's field names. */
+/** One segment per non-zero state, in the one display order every
+ * surface uses: attention first (error, then waiting — the members
+ * that need you), ambient work after (active agents, then running
+ * commands). Narrow surfaces clip from the right, so what survives a
+ * clip is what matters; bucketing precedence is `familyStateOf`'s
+ * concern, display order is this one's.
+ *
+ * `dot` is the CSS token the rows themselves wear (`unread` is how the
+ * app spells "waiting on you"); `running` wears the `$` glyph instead
+ * of a dot, exactly like its rows. This table is the vocabulary —
+ * surfaces decide typography, never what a state looks like. */
+export interface FamilySegment {
+  readonly state: FamilyState
+  /** Dot CSS token, or null for the `$`-glyphed running state. */
+  readonly dot: 'error' | 'unread' | 'working' | null
+  readonly count: number
+}
+
+export function familySegments(activity: FamilyActivity): FamilySegment[] {
+  const order = [
+    { state: 'error', dot: 'error' },
+    { state: 'waiting', dot: 'unread' },
+    { state: 'active', dot: 'working' },
+    { state: 'running', dot: null },
+  ] as const
+  return order
+    .filter(({ state }) => activity[state] > 0)
+    .map(({ state, dot }) => ({ state, dot, count: activity[state] }))
+}
+
+/** Spoken form of the activity segments, which are otherwise pure
+ * glyphs — the turn model's words (waiting on you, active), not the
+ * wire's field names. */
 export function familyActivityLabel(activity: FamilyActivity): string {
   const parts: string[] = []
   // 'process' takes -es; everything else here takes -s.
   const plural = (n: number, word: string) =>
     `${n} ${word}${n === 1 ? '' : word.endsWith('s') ? 'es' : 's'}`
   if (activity.error > 0) parts.push(`${plural(activity.error, 'member')} with an error`)
-  if (activity.unread > 0) parts.push(`${plural(activity.unread, 'member')} waiting on you`)
-  if (activity.workingAgents > 0) parts.push(plural(activity.workingAgents, 'active subagent'))
-  if (activity.workingProcesses > 0) parts.push(plural(activity.workingProcesses, 'running process'))
+  if (activity.waiting > 0) parts.push(`${plural(activity.waiting, 'member')} waiting on you`)
+  if (activity.active > 0) parts.push(plural(activity.active, 'active subagent'))
+  if (activity.running > 0) parts.push(plural(activity.running, 'running process'))
   return `In this family: ${parts.join(', ')}`
 }
 
@@ -299,53 +336,5 @@ export function projectFamily(selected: Session, source: FamilySource): FamilyDr
   }
 }
 
-/** Status totals for the panel's counts line, over every family member
- * the panel shows — which is now the whole family, root included. Each
- * member is tallied once under its dot-precedence state so the line and
- * the row dots can never disagree. */
-export interface FamilyCounts {
-  error: number
-  /** Semantic-agent members mid-turn. */
-  workingAgents: number
-  /** Non-agent members running a command. Split from the agents for the
-   * same reason the rows carry different glyphs: three subagents
-   * thinking and three shells running are different news, and a family
-   * is routinely mostly shells. */
-  workingProcesses: number
-  unread: number
-  total: number
-}
 
-/** The one state a member is counted under — and, since the panel's
- * tally doubles as its filter, the one state it can be filtered by.
- *
- * The tally and the filter must be the same rule or the panel lies:
- * pressing `3 error` and getting four rows is worse than not being able
- * to press it. So both derive from here, and the precedence is the
- * dot's own: error, then a running turn, then waiting on you. */
-export type FamilyState = 'error' | 'active' | 'running' | 'waiting'
 
-export function familyStateOf(session: Session): FamilyState | null {
-  if (session.alive && session.status?.error) return 'error'
-  if (session.alive && session.status?.active) return isProcessSession(session) ? 'running' : 'active'
-  if (session.unread) return 'waiting'
-  return null
-}
-
-export function familyCounts(trees: readonly FamilyNode[]): FamilyCounts {
-  const counts: FamilyCounts = {
-    error: 0, workingAgents: 0, workingProcesses: 0, unread: 0, total: 0,
-  }
-  const visit = (node: FamilyNode) => {
-    counts.total++
-    switch (familyStateOf(node.session)) {
-      case 'error': counts.error++; break
-      case 'active': counts.workingAgents++; break
-      case 'running': counts.workingProcesses++; break
-      case 'waiting': counts.unread++; break
-    }
-    for (const child of node.children) visit(child)
-  }
-  for (const tree of trees) visit(tree)
-  return counts
-}

--- a/apps/gmux-web/src/family.ts
+++ b/apps/gmux-web/src/family.ts
@@ -304,18 +304,29 @@ export function projectFamily(selected: Session, source: FamilySource): FamilyDr
  * the row dots can never disagree. */
 export interface FamilyCounts {
   error: number
-  working: number
+  /** Semantic-agent members mid-turn. */
+  workingAgents: number
+  /** Non-agent members running a command. Split from the agents for the
+   * same reason the rows carry different glyphs: three subagents
+   * thinking and three shells running are different news, and a family
+   * is routinely mostly shells. */
+  workingProcesses: number
   unread: number
   total: number
 }
 
 export function familyCounts(trees: readonly FamilyNode[]): FamilyCounts {
-  const counts: FamilyCounts = { error: 0, working: 0, unread: 0, total: 0 }
+  const counts: FamilyCounts = {
+    error: 0, workingAgents: 0, workingProcesses: 0, unread: 0, total: 0,
+  }
   const visit = (node: FamilyNode) => {
     const s = node.session
     counts.total++
     if (s.alive && s.status?.error) counts.error++
-    else if (s.alive && s.status?.active) counts.working++
+    else if (s.alive && s.status?.active) {
+      if (isProcessSession(s)) counts.workingProcesses++
+      else counts.workingAgents++
+    }
     else if (s.unread) counts.unread++
     for (const child of node.children) visit(child)
   }

--- a/apps/gmux-web/src/family.ts
+++ b/apps/gmux-web/src/family.ts
@@ -218,19 +218,20 @@ export function hasFamilyActivity(activity: FamilyActivity): boolean {
     || activity.workingAgents > 0 || activity.workingProcesses > 0
 }
 
-/** Spoken form of the `+` line, which is otherwise pure glyphs. It
- * counts the members the entry does *not* name, so it reads as an
- * addition to the rows above it. */
+/** Spoken form of the activity line, which is otherwise pure glyphs.
+ * The standard family numbers: everyone beneath the root, in the turn
+ * model's words — waiting on you, active — matching the panel tally's
+ * vocabulary rather than the wire's field names. */
 export function familyActivityLabel(activity: FamilyActivity): string {
   const parts: string[] = []
   // 'process' takes -es; everything else here takes -s.
   const plural = (n: number, word: string) =>
     `${n} ${word}${n === 1 ? '' : word.endsWith('s') ? 'es' : 's'}`
   if (activity.error > 0) parts.push(`${plural(activity.error, 'member')} with an error`)
-  if (activity.unread > 0) parts.push(plural(activity.unread, 'unread member'))
-  if (activity.workingAgents > 0) parts.push(plural(activity.workingAgents, 'working subagent'))
+  if (activity.unread > 0) parts.push(`${plural(activity.unread, 'member')} waiting on you`)
+  if (activity.workingAgents > 0) parts.push(plural(activity.workingAgents, 'active subagent'))
   if (activity.workingProcesses > 0) parts.push(plural(activity.workingProcesses, 'running process'))
-  return `Also in this family: ${parts.join(', ')}`
+  return `In this family: ${parts.join(', ')}`
 }
 
 /** Hover title for the sidebar's selected-child row: the path from the

--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -14,7 +14,8 @@ import { usePresence } from './use-presence'
 import { lifecycleAction } from './session-actions'
 import { MenuButton } from './menu-button'
 import { FamilyDrawer } from './family-drawer'
-import { familyAncestors, familyCounts, familyStateOf, hasFamily, projectFamily } from './family'
+import { familyAncestors, familyCounts, hasFamily, projectFamily } from './family'
+import { FamilyIcon } from './family-icon'
 
 import type { Session } from './types'
 import { SettingsModal } from './settings'
@@ -224,33 +225,23 @@ function MainHeader({ session, onRestart, onResume, resuming }: {
   )
 }
 
-/** The family panel's trigger: a pill speaking the same segment
- * vocabulary as the sidebar's activity line and the panel's tally —
- * dot + count per state, in dot precedence order — so it previews the
- * tally it opens onto and the three can never disagree (they share
- * `familyCounts`). A family with nothing to report shows the tree
- * icon instead — several nodes, one structure — which stays readable
- * at header size where dot-built substitutes turned to specks. No
- * count with it: the segments' numbers are news, a quiet family has
- * none, and its size waits one click away behind this very button. */
+/** The family panel's trigger: a pill speaking the standard family
+ * numbers — every descendant of the root, the root excluded — as dot +
+ * count segments in dot precedence order. The sidebar's activity line
+ * and the panel's tally quote the same rule, so the same dots never
+ * wear different numbers, and nothing here depends on which session
+ * you happen to be viewing: the count is a fact about the family, not
+ * the viewport. The root is never orphaned by its exclusion — it
+ * speaks for itself wherever it appears in person. A family with
+ * nothing to report shows the tree icon instead; no count with it,
+ * because the segments' numbers are news and a quiet family has none. */
 function FamilyTrigger({ session, open, triggerRef, onToggle }: {
   session: Session
   open: boolean
   triggerRef: { current: HTMLButtonElement | null }
   onToggle: () => void
 }) {
-  const counts = familyCounts([projectFamily(session, sessions.value).tree])
-  // The rest of the family, not the whole of it: the header already
-  // names this session, and its state is the view itself — same rule as
-  // the sidebar's activity line, which counts only the members its
-  // entry hasn't named. Without this, your own error knocks on the
-  // door of the room you are standing in.
-  switch (familyStateOf(session)) {
-    case 'error': counts.error--; break
-    case 'active': counts.workingAgents--; break
-    case 'running': counts.workingProcesses--; break
-    case 'waiting': counts.unread--; break
-  }
+  const counts = familyCounts(projectFamily(session, sessions.value).tree.children)
   const segments: { key: string; dot?: string; proc?: boolean; count: number }[] = []
   if (counts.error > 0) segments.push({ key: 'error', dot: 'error', count: counts.error })
   if (counts.workingAgents > 0) segments.push({ key: 'active', dot: 'working', count: counts.workingAgents })
@@ -275,14 +266,7 @@ function FamilyTrigger({ session, open, triggerRef, onToggle }: {
             {segment.count}
           </span>
         ))
-        : (
-          <svg class="family-trigger-icon" viewBox="0 0 16 16" aria-hidden="true">
-            <path d="M8 5.5v2M8 7.5c0 1.5-3.5 1-3.5 3M8 7.5c0 1.5 3.5 1 3.5 3" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" />
-            <circle cx="8" cy="3.75" r="1.9" fill="none" stroke="currentColor" stroke-width="1.3" />
-            <circle cx="4.5" cy="12" r="1.9" fill="none" stroke="currentColor" stroke-width="1.3" />
-            <circle cx="11.5" cy="12" r="1.9" fill="none" stroke="currentColor" stroke-width="1.3" />
-          </svg>
-        )}
+        : <FamilyIcon class="family-trigger-icon" />}
     </button>
   )
 }

--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -14,7 +14,7 @@ import { usePresence } from './use-presence'
 import { lifecycleAction } from './session-actions'
 import { MenuButton } from './menu-button'
 import { FamilyDrawer } from './family-drawer'
-import { familyAncestors, familyRoot, familySegments, hasFamily, NO_FAMILY_ACTIVITY } from './family'
+import { familyAncestors, familyRoot, familySegments, hasFamily } from './family'
 import { FamilyIcon } from './family-icon'
 
 import type { Session } from './types'
@@ -241,7 +241,7 @@ function FamilyTrigger({ session, open, triggerRef, onToggle }: {
   onToggle: () => void
 }) {
   const rootId = familyRoot(session, sessions.value).id
-  const segments = familySegments(familyActivityById.value.get(rootId) ?? NO_FAMILY_ACTIVITY)
+  const segments = familySegments(familyActivityById.value.get(rootId))
   return (
     <button
       ref={triggerRef}

--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -14,7 +14,7 @@ import { usePresence } from './use-presence'
 import { lifecycleAction } from './session-actions'
 import { MenuButton } from './menu-button'
 import { FamilyDrawer } from './family-drawer'
-import { familyAncestors, familyCounts, hasFamily, projectFamily } from './family'
+import { familyAncestors, familyRoot, familySegments, hasFamily, NO_FAMILY_ACTIVITY } from './family'
 import { FamilyIcon } from './family-icon'
 
 import type { Session } from './types'
@@ -32,7 +32,7 @@ import {
   urlPath, urlSearch, urlHash,
   initStore, setNavigate, navigate, navigateToSession,
   dismissSession, resumeSession, restartSession,
-  sessionStaleness, sessionDotState, activityMap, tabHref,
+  sessionStaleness, sessionDotState, activityMap, familyActivityById, tabHref,
 } from './store'
 import { viewToPath } from './routing'
 
@@ -225,28 +225,23 @@ function MainHeader({ session, onRestart, onResume, resuming }: {
   )
 }
 
-/** The family panel's trigger: a pill speaking the standard family
- * numbers — every descendant of the root, the root excluded — as dot +
- * count segments in dot precedence order. The sidebar's activity line
- * and the panel's tally quote the same rule, so the same dots never
- * wear different numbers, and nothing here depends on which session
- * you happen to be viewing: the count is a fact about the family, not
- * the viewport. The root is never orphaned by its exclusion — it
- * speaks for itself wherever it appears in person. A family with
- * nothing to report shows the tree icon instead; no count with it,
- * because the segments' numbers are news and a quiet family has none. */
+/** The family panel's trigger: a pill wearing the standard family
+ * segments — `familySegments` over `familyActivityById`, the same
+ * derivation and display order as the sidebar's line and the panel's
+ * tally, so the same dots never wear different numbers or a different
+ * order anywhere. Nothing here depends on which session you are
+ * viewing: the count is a fact about the family, not the viewport. A
+ * family with nothing to report shows the tree icon instead; no count
+ * with it, because the segments' numbers are news and a quiet family
+ * has none. */
 function FamilyTrigger({ session, open, triggerRef, onToggle }: {
   session: Session
   open: boolean
   triggerRef: { current: HTMLButtonElement | null }
   onToggle: () => void
 }) {
-  const counts = familyCounts(projectFamily(session, sessions.value).tree.children)
-  const segments: { key: string; dot?: string; proc?: boolean; count: number }[] = []
-  if (counts.error > 0) segments.push({ key: 'error', dot: 'error', count: counts.error })
-  if (counts.workingAgents > 0) segments.push({ key: 'active', dot: 'working', count: counts.workingAgents })
-  if (counts.workingProcesses > 0) segments.push({ key: 'running', proc: true, count: counts.workingProcesses })
-  if (counts.unread > 0) segments.push({ key: 'waiting', dot: 'unread', count: counts.unread })
+  const rootId = familyRoot(session, sessions.value).id
+  const segments = familySegments(familyActivityById.value.get(rootId) ?? NO_FAMILY_ACTIVITY)
   return (
     <button
       ref={triggerRef}
@@ -260,9 +255,10 @@ function FamilyTrigger({ session, open, triggerRef, onToggle }: {
     >
       {segments.length > 0
         ? segments.map(segment => (
-          <span key={segment.key} class="family-trigger-seg">
-            {segment.dot && <span class={`session-dot-indicator ${segment.dot}`} aria-hidden="true" />}
-            {segment.proc && <span class="family-trigger-proc" aria-hidden="true">$</span>}
+          <span key={segment.state} class="family-trigger-seg">
+            {segment.dot
+              ? <span class={`session-dot-indicator ${segment.dot}`} aria-hidden="true" />
+              : <span class="family-trigger-proc" aria-hidden="true">$</span>}
             {segment.count}
           </span>
         ))

--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -272,19 +272,26 @@ function HeaderCrumbs({ session }: { session: Session }) {
   const am = activityMap.value
   return (
     <nav class="header-crumbs" aria-label="Ancestor agents">
-      {shown.map((ancestor) => (
-        <Fragment key={ancestor?.id ?? 'gap'}>
-          {ancestor
-            ? (
-              <a class="header-crumb" href={sessionHref(ancestor)}>
-                <span class={`session-dot-indicator ${sessionDotState(ancestor, am)}`} aria-hidden="true" />
-                <span class="header-crumb-title">{ancestor.title}</span>
-              </a>
-            )
-            : <span class="header-crumb-gap" title="More ancestors in the family panel">…</span>}
-          <span class="header-crumb-sep" aria-hidden="true">›</span>
-        </Fragment>
-      ))}
+      {shown.map((ancestor) => {
+        const dot = ancestor ? sessionDotState(ancestor, am) : 'none'
+        return (
+          <Fragment key={ancestor?.id ?? 'gap'}>
+            {ancestor
+              ? (
+                <a class="header-crumb" href={sessionHref(ancestor)}>
+                  {/* The sidebar's `none` dot is an invisible placeholder
+                    * that holds a column; a crumb has no column, so a
+                    * quiet ancestor would just wear a permanent hole
+                    * where its dot should be. */}
+                  {dot !== 'none' && <span class={`session-dot-indicator ${dot}`} aria-hidden="true" />}
+                  <span class="header-crumb-title">{ancestor.title}</span>
+                </a>
+              )
+              : <span class="header-crumb-gap" title="More ancestors in the family panel">…</span>}
+            <span class="header-crumb-sep" aria-hidden="true">›</span>
+          </Fragment>
+        )
+      })}
     </nav>
   )
 }
@@ -294,10 +301,12 @@ function sessionHref(session: Session): string | undefined {
   return path ? tabHref(path) : undefined
 }
 
-/** Session status in the header, one chip slot for both states: alive shows
- * Working…/Error, dead shows Exited (N). While a resume is in flight the
- * dead chip flips to the busy label — the menu closes on click, so this
- * chip is the visible feedback until the session comes alive. */
+/** Session status in the header — only states that need the header to
+ * say something the view doesn't already: Error, and the resume-in-
+ * flight busy label (the menu closes on click, so this chip is the
+ * visible feedback until the session comes alive). A dead session gets
+ * no chip: a replay view is unmistakably an ended session, and the chip
+ * only restated it. */
 function HeaderStatusChip({ session, resuming }: {
   session: Session
   resuming?: boolean
@@ -311,11 +320,7 @@ function HeaderStatusChip({ session, resuming }: {
         </div>
       )
     }
-    return (
-      <div class="main-header-status ended">
-        {session.exit_code != null ? `Exited (${session.exit_code})` : 'Exited'}
-      </div>
-    )
+    return null
   }
   // A live "Working…" chip is redundant with the session's own dot
   // indicator, so only the error state earns a header chip here.

--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -14,7 +14,7 @@ import { usePresence } from './use-presence'
 import { lifecycleAction } from './session-actions'
 import { MenuButton } from './menu-button'
 import { FamilyDrawer } from './family-drawer'
-import { familyAncestors, familyRoot, hasFamily } from './family'
+import { familyAncestors, familyCounts, familyStateOf, hasFamily, projectFamily } from './family'
 
 import type { Session } from './types'
 import { SettingsModal } from './settings'
@@ -31,7 +31,7 @@ import {
   urlPath, urlSearch, urlHash,
   initStore, setNavigate, navigate, navigateToSession,
   dismissSession, resumeSession, restartSession,
-  sessionStaleness, sessionDotState, activityMap, familyDotById, tabHref,
+  sessionStaleness, sessionDotState, activityMap, tabHref,
 } from './store'
 import { viewToPath } from './routing'
 
@@ -224,18 +224,38 @@ function MainHeader({ session, onRestart, onResume, resuming }: {
   )
 }
 
-/** The family panel's trigger: a ghost icon button (3-node tree) with a
- * corner badge showing the family's aggregated dot state — same roll-up
- * the sidebar row shows, so background family activity is visible without
- * opening the panel. */
+/** The family panel's trigger: a pill speaking the same segment
+ * vocabulary as the sidebar's activity line and the panel's tally —
+ * dot + count per state, in dot precedence order — so it previews the
+ * tally it opens onto and the three can never disagree (they share
+ * `familyCounts`). A family with nothing to report shows the tree
+ * icon instead — several nodes, one structure — which stays readable
+ * at header size where dot-built substitutes turned to specks. No
+ * count with it: the segments' numbers are news, a quiet family has
+ * none, and its size waits one click away behind this very button. */
 function FamilyTrigger({ session, open, triggerRef, onToggle }: {
   session: Session
   open: boolean
   triggerRef: { current: HTMLButtonElement | null }
   onToggle: () => void
 }) {
-  const rootId = familyRoot(session, sessions.value).id
-  const dot = familyDotById.value.get(rootId) ?? 'none'
+  const counts = familyCounts([projectFamily(session, sessions.value).tree])
+  // The rest of the family, not the whole of it: the header already
+  // names this session, and its state is the view itself — same rule as
+  // the sidebar's activity line, which counts only the members its
+  // entry hasn't named. Without this, your own error knocks on the
+  // door of the room you are standing in.
+  switch (familyStateOf(session)) {
+    case 'error': counts.error--; break
+    case 'active': counts.workingAgents--; break
+    case 'running': counts.workingProcesses--; break
+    case 'waiting': counts.unread--; break
+  }
+  const segments: { key: string; dot?: string; proc?: boolean; count: number }[] = []
+  if (counts.error > 0) segments.push({ key: 'error', dot: 'error', count: counts.error })
+  if (counts.workingAgents > 0) segments.push({ key: 'active', dot: 'working', count: counts.workingAgents })
+  if (counts.workingProcesses > 0) segments.push({ key: 'running', proc: true, count: counts.workingProcesses })
+  if (counts.unread > 0) segments.push({ key: 'waiting', dot: 'unread', count: counts.unread })
   return (
     <button
       ref={triggerRef}
@@ -247,13 +267,22 @@ function FamilyTrigger({ session, open, triggerRef, onToggle }: {
       aria-controls="agent-family-drawer"
       onClick={onToggle}
     >
-      <svg class="family-trigger-icon" viewBox="0 0 16 16" aria-hidden="true">
-        <path d="M8 5.5v2M8 7.5c0 1.5-3.5 1-3.5 3M8 7.5c0 1.5 3.5 1 3.5 3" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" />
-        <circle cx="8" cy="3.75" r="1.9" fill="none" stroke="currentColor" stroke-width="1.3" />
-        <circle cx="4.5" cy="12" r="1.9" fill="none" stroke="currentColor" stroke-width="1.3" />
-        <circle cx="11.5" cy="12" r="1.9" fill="none" stroke="currentColor" stroke-width="1.3" />
-      </svg>
-      {dot !== 'none' && <span class={`family-trigger-badge session-dot-indicator ${dot}`} aria-hidden="true" />}
+      {segments.length > 0
+        ? segments.map(segment => (
+          <span key={segment.key} class="family-trigger-seg">
+            {segment.dot && <span class={`session-dot-indicator ${segment.dot}`} aria-hidden="true" />}
+            {segment.proc && <span class="family-trigger-proc" aria-hidden="true">$</span>}
+            {segment.count}
+          </span>
+        ))
+        : (
+          <svg class="family-trigger-icon" viewBox="0 0 16 16" aria-hidden="true">
+            <path d="M8 5.5v2M8 7.5c0 1.5-3.5 1-3.5 3M8 7.5c0 1.5 3.5 1 3.5 3" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" />
+            <circle cx="8" cy="3.75" r="1.9" fill="none" stroke="currentColor" stroke-width="1.3" />
+            <circle cx="4.5" cy="12" r="1.9" fill="none" stroke="currentColor" stroke-width="1.3" />
+            <circle cx="11.5" cy="12" r="1.9" fill="none" stroke="currentColor" stroke-width="1.3" />
+          </svg>
+        )}
     </button>
   )
 }

--- a/apps/gmux-web/src/replay-view.tsx
+++ b/apps/gmux-web/src/replay-view.tsx
@@ -38,8 +38,7 @@ type ReplayState =
  * sessions, so muscle memory finds it there too. Promoting it out of
  * an implicit sidebar click means clicking a dead session navigates to
  * its scrollback first, and any state-changing action is a deliberate
- * second click. Exit status is header chrome (MainHeader's "Exited"
- * chip), not repeated here.
+ * second click.
  *
  * On touch the bar also carries the sidebar ☰: dead sessions render no
  * mobile key bar (a full set of dead keys just to carry ☰ reads as

--- a/apps/gmux-web/src/sidebar.tsx
+++ b/apps/gmux-web/src/sidebar.tsx
@@ -8,6 +8,7 @@
 import { useState, useCallback, useRef, useEffect } from 'preact/hooks'
 import { needsReveal } from './sidebar-reveal'
 import { hasSessionSlugCollision, sessionPath, viewToPath } from './routing'
+import { FamilyIcon } from './family-icon'
 import { selectorLabel, folderMatchesFilter, type Selector } from './tab-filter'
 import { reorderKeysForFolder } from './projects'
 import { LaunchButton } from './launcher'
@@ -234,17 +235,15 @@ function SessionItem({
  *  running process — each segment dropped at zero. It's a count, not a
  *  destination, so it has no target of its own; like the rest of the
  *  entry's slack it belongs to the group, which selects the root. */
-function FamilyActivityLine({ activity, nested }: { activity: FamilyActivity; nested: boolean }) {
+function FamilyActivityLine({ activity }: { activity: FamilyActivity }) {
   const label = familyActivityLabel(activity)
   return (
-    <div class={`family-sub family-activity${nested ? ' nested' : ''}`} title={label}>
-      {/* `+`: these are the members the entry hasn't named. When a
-        * member row sits above, the line steps in by one glyph column
-        * so the `+` lands under that member's title — the row reads as
-        * "and these as well", added to the one named above rather than
-        * hanging off the root beside it. With no member row there is
-        * nothing to add to, so it stays in the glyph column. */}
-      <span class="family-glyph family-plus" aria-hidden="true">+</span>
+    <div class="family-sub family-activity" title={label}>
+      {/* The family mark, same as the header's trigger: this line is
+        * the standard family numbers — everyone beneath the root — not
+        * "the others", so it anchors to the root's glyph column rather
+        * than indenting under whichever member row happens to be shown. */}
+      <span class="family-glyph" aria-hidden="true"><FamilyIcon class="family-activity-icon" /></span>
       {/* Glyphs are decoration; the sentence carries the meaning. */}
       <span class="family-activity-glyphs" aria-hidden="true">
         {activity.error > 0 && (
@@ -382,7 +381,7 @@ function FamilyEntry({
           <span class="family-slot-title">{member.title}</span>
         </a>
       )}
-      {hasFamilyActivity(activity) && <FamilyActivityLine activity={activity} nested={member !== undefined} />}
+      {hasFamilyActivity(activity) && <FamilyActivityLine activity={activity} />}
     </div>
   )
 }

--- a/apps/gmux-web/src/sidebar.tsx
+++ b/apps/gmux-web/src/sidebar.tsx
@@ -29,7 +29,7 @@ import {
 import { HostSuffix } from './host-suffix'
 import { SessionRow } from './session-row'
 import {
-  childTrailTitle, familyActivityLabel, familyMemberGlyph, hasFamilyActivity,
+  childTrailTitle, familyActivityLabel, familyMemberGlyph, familySegments, hasFamilyActivity,
   NO_FAMILY_ACTIVITY, type FamilyActivity,
 } from './family'
 import type { Session, Folder } from './types'
@@ -246,30 +246,14 @@ function FamilyActivityLine({ activity }: { activity: FamilyActivity }) {
       <span class="family-glyph" aria-hidden="true"><FamilyIcon class="family-activity-icon" /></span>
       {/* Glyphs are decoration; the sentence carries the meaning. */}
       <span class="family-activity-glyphs" aria-hidden="true">
-        {activity.error > 0 && (
-          <span class="family-activity-seg">
-            <span class="family-glyph session-dot-indicator error" />
-            {activity.error}
+        {familySegments(activity).map(segment => (
+          <span key={segment.state} class="family-activity-seg">
+            {segment.dot
+              ? <span class={`family-glyph session-dot-indicator ${segment.dot}`} />
+              : <span class="family-glyph family-child-proc working">$</span>}
+            {segment.count}
           </span>
-        )}
-        {activity.unread > 0 && (
-          <span class="family-activity-seg">
-            <span class="family-glyph session-dot-indicator unread" />
-            {activity.unread}
-          </span>
-        )}
-        {activity.workingAgents > 0 && (
-          <span class="family-activity-seg">
-            <span class="family-glyph session-dot-indicator working" />
-            {activity.workingAgents}
-          </span>
-        )}
-        {activity.workingProcesses > 0 && (
-          <span class="family-activity-seg">
-            <span class="family-glyph family-child-proc working">$</span>
-            {activity.workingProcesses}
-          </span>
-        )}
+        ))}
       </span>
       <span class="sr-only">{label}</span>
     </div>

--- a/apps/gmux-web/src/sidebar.tsx
+++ b/apps/gmux-web/src/sidebar.tsx
@@ -29,8 +29,8 @@ import {
 import { HostSuffix } from './host-suffix'
 import { SessionRow } from './session-row'
 import {
-  childTrailTitle, familyActivityLabel, familyMemberGlyph, familySegments, hasFamilyActivity,
-  NO_FAMILY_ACTIVITY, type FamilyActivity,
+  childTrailTitle, familyActivityLabel, familyMemberGlyph, familySegments,
+  type FamilyActivity,
 } from './family'
 import type { Session, Folder } from './types'
 
@@ -164,9 +164,10 @@ function SessionItem({
   onDragOver?: () => void
   onDragEnd?: () => void
 }) {
-  // Selection muting ("nothing is unread if you're already looking at it")
-  // happens per family member inside `familyDotById`, so a sibling child's
-  // attention still surfaces here while you view another member.
+  // The row's own status, muted for selection ("nothing is unread if
+  // you're already looking at it") by `ownDotState` — a root row shows
+  // the root's state, never a roll-up of its children's, so a working
+  // child cannot masquerade as a working root.
   const dotState = resuming ? 'working' : rawDotState
   const arrival = useArrivalPulse(dotState)
   const sleeping = !session.alive && session.resumable
@@ -235,7 +236,12 @@ function SessionItem({
  *  running process — each segment dropped at zero. It's a count, not a
  *  destination, so it has no target of its own; like the rest of the
  *  entry's slack it belongs to the group, which selects the root. */
-function FamilyActivityLine({ activity }: { activity: FamilyActivity }) {
+function FamilyActivityLine({ activity }: { activity: FamilyActivity | undefined }) {
+  // `familyActivityById` holds an entry only when something is non-zero,
+  // so absence is the whole of "nothing to report" — one spelling of
+  // the question, here, instead of one per call site.
+  if (!activity) return null
+  const segments = familySegments(activity)
   const label = familyActivityLabel(activity)
   return (
     <div class="family-sub family-activity" title={label}>
@@ -246,11 +252,11 @@ function FamilyActivityLine({ activity }: { activity: FamilyActivity }) {
       <span class="family-glyph" aria-hidden="true"><FamilyIcon class="family-activity-icon" /></span>
       {/* Glyphs are decoration; the sentence carries the meaning. */}
       <span class="family-activity-glyphs" aria-hidden="true">
-        {familySegments(activity).map(segment => (
+        {segments.map(segment => (
           <span key={segment.state} class="family-activity-seg">
             {segment.dot
               ? <span class={`family-glyph session-dot-indicator ${segment.dot}`} />
-              : <span class="family-glyph family-child-proc working">$</span>}
+              : <span class="family-glyph family-proc working">$</span>}
             {segment.count}
           </span>
         ))}
@@ -262,7 +268,7 @@ function FamilyActivityLine({ activity }: { activity: FamilyActivity }) {
 
 /** The sidebar's family entry: a root row, the one family member kept
  *  beneath it — the member you're viewing, or the last one you did —
- *  and a line counting everyone else.
+ *  and a line counting the family beneath the root.
  *
  *  Selection and hit areas nest, the way the sessions do:
  *   - the group is the root's area. Hovering anywhere in it highlights
@@ -275,10 +281,13 @@ function FamilyActivityLine({ activity }: { activity: FamilyActivity }) {
  *     *which row*, so selecting a member keeps the group lit and moves
  *     the bar down to it.
  *
- *  Two more rules hold the content together: the root row's dot is the
- *  root session's own status, so a working child never masquerades as a
- *  working root; and each member is represented exactly once, named by
- *  a row or counted on the line, never both.
+ *  One more rule holds the content together: the root row's dot is the
+ *  root session's own status, so a working child never masquerades as
+ *  a working root. The line, by contrast, is a summary and may well
+ *  include the member named above it — the standard family numbers are
+ *  a fact about the family, the same on every surface, and subtracting
+ *  whatever a surface happens to name made them wobble with unrelated
+ *  state (see `familyActivityById`).
  */
 function FamilyEntry({
   selected,
@@ -299,7 +308,7 @@ function FamilyEntry({
   slotHref?: string
   /** Root › … › member trail, for the member row's hover title. */
   slotTrail?: string
-  activity: FamilyActivity
+  activity: FamilyActivity | undefined
   onClick?: () => void
   /** Reorder drop target for the whole group, not just the root row. */
   onDragOver?: () => void
@@ -309,9 +318,10 @@ function FamilyEntry({
 }) {
   const member = slot?.session
   // One decision, made in `family.ts` so it can be tested: which glyph
-  // this member gets, and what state it carries. The row is the only
-  // place a named member's state can appear — the activity line
-  // subtracts it — so the glyph has to be able to say `unread`.
+  // this member gets, and what state it carries. This row is the only
+  // place this member is named, so its glyph has to be able to say
+  // `unread` — the line below counts it among many, but a count is not
+  // a way to see which member needs you.
   const glyph = member
     ? familyMemberGlyph(member, ownDotState(member, activityMap.value, selectedId.value))
     : null
@@ -358,14 +368,14 @@ function FamilyEntry({
             * it keeps the title from sliding sideways when state
             * arrives or clears. */}
           {glyph?.kind === 'process'
-            ? <span class={`family-glyph family-child-proc ${glyph.state}`} aria-hidden="true">$</span>
+            ? <span class={`family-glyph family-proc ${glyph.state}`} aria-hidden="true">$</span>
             : glyph?.kind === 'dot'
             ? <span class={`family-glyph session-dot-indicator ${glyph.state}`} aria-hidden="true" />
             : <span class="family-glyph family-branch" aria-hidden="true">↳</span>}
           <span class="family-slot-title">{member.title}</span>
         </a>
       )}
-      {hasFamilyActivity(activity) && <FamilyActivityLine activity={activity} />}
+      <FamilyActivityLine activity={activity} />
     </div>
   )
 }
@@ -509,7 +519,7 @@ function FolderGroup({
       <div class="folder-sessions">
         {shown.map((s, i) => {
           const href = tabHref(sessionPath(folder.slug, s, folder.peer, hasSessionSlugCollision(s, sessions.value, projects.value)))
-          const activity = activityById.get(s.id) ?? NO_FAMILY_ACTIVITY
+          const activity = activityById.get(s.id)
           const slot = slots.get(s.id)
           const item = (
             <SessionItem
@@ -536,7 +546,7 @@ function FolderGroup({
             />
           )
           // No member to name and nothing else to count: one plain row.
-          if (!slot && !hasFamilyActivity(activity)) return item
+          if (!slot && !activity) return item
           return (
             <FamilyEntry
               key={s.id}

--- a/apps/gmux-web/src/sidebar.tsx
+++ b/apps/gmux-web/src/sidebar.tsx
@@ -234,14 +234,17 @@ function SessionItem({
  *  running process — each segment dropped at zero. It's a count, not a
  *  destination, so it has no target of its own; like the rest of the
  *  entry's slack it belongs to the group, which selects the root. */
-function FamilyActivityLine({ activity }: { activity: FamilyActivity }) {
+function FamilyActivityLine({ activity, nested }: { activity: FamilyActivity; nested: boolean }) {
   const label = familyActivityLabel(activity)
   return (
-    <div class="family-sub family-activity" title={label}>
-      {/* Same branch glyph, same column as the member row's: this row
-        * hangs off the root too, and says so whether or not anything
-        * here is highlighted. */}
-      <span class="family-glyph family-branch" aria-hidden="true">↳</span>
+    <div class={`family-sub family-activity${nested ? ' nested' : ''}`} title={label}>
+      {/* `+`: these are the members the entry hasn't named. When a
+        * member row sits above, the line steps in by one glyph column
+        * so the `+` lands under that member's title — the row reads as
+        * "and these as well", added to the one named above rather than
+        * hanging off the root beside it. With no member row there is
+        * nothing to add to, so it stays in the glyph column. */}
+      <span class="family-glyph family-plus" aria-hidden="true">+</span>
       {/* Glyphs are decoration; the sentence carries the meaning. */}
       <span class="family-activity-glyphs" aria-hidden="true">
         {activity.error > 0 && (
@@ -379,7 +382,7 @@ function FamilyEntry({
           <span class="family-slot-title">{member.title}</span>
         </a>
       )}
-      {hasFamilyActivity(activity) && <FamilyActivityLine activity={activity} />}
+      {hasFamilyActivity(activity) && <FamilyActivityLine activity={activity} nested={member !== undefined} />}
     </div>
   )
 }

--- a/apps/gmux-web/src/store.test.ts
+++ b/apps/gmux-web/src/store.test.ts
@@ -1350,17 +1350,18 @@ describe('sidebar family entry derivations', () => {
       expect(familyActivityById.value.get('kid')).toBeUndefined()
     })
 
-    it('ignores members the alive-only filter is hiding', () => {
+    it('counts the same with the alive-only filter on or off', () => {
       _rawSessions.value = [
         agent('root'),
         agent('live', { parent_session_id: 'root', unread: true }),
         agent('dead', { parent_session_id: 'root', unread: true, alive: false, resumable: true }),
       ]
       expect(familyActivityById.value.get('root')?.unread).toBe(2)
-      // The line counts what the list shows: a filtered-out member's
-      // unread would point at a row that isn't there.
+      // The standard family numbers are a fact about the family, not
+      // the viewport: the toggle hides rows, and the panel one click
+      // away shows the hidden member regardless, so the count stands.
       setAliveOnly(true)
-      expect(familyActivityById.value.get('root')?.unread).toBe(1)
+      expect(familyActivityById.value.get('root')?.unread).toBe(2)
       setAliveOnly(false)
     })
 
@@ -1389,49 +1390,35 @@ describe('sidebar family entry derivations', () => {
 
     beforeEach(() => { recentFamilyChildren.value = [] })
 
-    it('never counts the member the slot row already names', () => {
+    it('holds the same numbers whichever member the slot row names', () => {
       _rawSessions.value = [
         agent('root'),
         agent('a', { slug: 'aa', parent_session_id: 'root', unread: true }),
         agent('b', { slug: 'bb', parent_session_id: 'root', unread: true }),
       ]
       expect(familyActivityById.value.get('root')?.unread).toBe(2)
-      // Viewing 'a' gives it the slot row, so only the sibling is left
-      // for the `+` line: one member, one representation.
+      // Viewing 'a' names it on the slot row; the count does not budge.
+      // A summary may include what is separately visible — the panel's
+      // tally counts the rows below it too — and subtracting the slot
+      // made this number wobble with which member you last visited.
       urlPath.value = '/proj/pi/aa'
-      expect(familyActivityById.value.get('root')?.unread).toBe(1)
-      // Working members are no different — the slot row carries their
-      // dot, so counting them too would double them up.
+      expect(familyActivityById.value.get('root')?.unread).toBe(2)
       _rawSessions.value = _rawSessions.value.map(s =>
         s.id === 'a' ? { ...s, unread: false, status: { active: true } } : s)
       expect(familyActivityById.value.get('root')).toEqual({
-        error: 0, unread: 1, workingAgents: 0, workingProcesses: 0,
+        error: 0, unread: 1, workingAgents: 1, workingProcesses: 0,
       })
     })
 
-    it('stops counting a member you merely visited, not just the selected one', () => {
+    it('keeps the line when the only activity is the named member', () => {
       _rawSessions.value = [
         agent('root', { slug: 'rooty' }),
-        agent('a', { slug: 'aa', parent_session_id: 'root', status: { active: true } }),
-      ]
-      urlPath.value = '/proj/pi/aa'
-      rememberFamilyChild('a') // what the recorder effect does on a visit
-      expect(familyActivityById.value.has('root')).toBe(false)
-      // Back on the root, 'a' keeps the slot row as the way back — and
-      // stays out of the count, because it is still named.
-      urlPath.value = '/proj/pi/rooty'
-      expect(familySlotById.value.get('root')?.session.id).toBe('a')
-      expect(familyActivityById.value.has('root')).toBe(false)
-    })
-
-    it('drops the whole line when the only activity is the named member', () => {
-      _rawSessions.value = [
-        agent('root'),
         agent('a', { slug: 'aa', parent_session_id: 'root', unread: true }),
       ]
-      expect(familyActivityById.value.has('root')).toBe(true)
       urlPath.value = '/proj/pi/aa'
-      expect(familyActivityById.value.has('root')).toBe(false)
+      rememberFamilyChild('a')
+      expect(familySlotById.value.get('root')?.session.id).toBe('a')
+      expect(familyActivityById.value.get('root')?.unread).toBe(1)
     })
 
     it('gives a promoted descendant its own counts, not its old family\u2019s', () => {

--- a/apps/gmux-web/src/store.test.ts
+++ b/apps/gmux-web/src/store.test.ts
@@ -1987,6 +1987,42 @@ describe('pending mutations overlay', () => {
       expect(out[1].unread).toBe(true)
     })
 
+    it('applies a mark-read per session in one pass, whatever the pile', () => {
+      // "Mark all read" stacks one mutation per family member, and this
+      // overlay is replayed on every recompute in the app until the
+      // server echoes them back. A pass per mutation made that cost
+      // mutations x sessions.
+      const sess = Array.from({ length: 200 }, (_, i) =>
+        makeSession({ id: `s${i}`, unread: true, unread_token: `t${i}` }))
+      const pending: PendingMutation[] = sess.map(s => (
+        { kind: 'mark-read', id: s.id, token: s.unread_token ?? '', at: 0 }))
+      const out = applyPending(sess, pending)
+      expect(out.every(s => !s.unread)).toBe(true)
+      expect(out).toHaveLength(200)
+    })
+
+    it('honours each token separately when several are in flight for one session', () => {
+      // The token binds a mark to the state it was issued against, so a
+      // session that spoke again escapes the older mark rather than
+      // being silenced by it.
+      const sess = [makeSession({ id: 'a', unread: true, unread_token: 'new' })]
+      const out = applyPending(sess, [
+        { kind: 'mark-read', id: 'a', token: 'stale', at: 0 },
+        { kind: 'mark-read', id: 'a', token: 'new', at: 0 },
+      ])
+      expect(out[0].unread).toBe(false)
+      const stillUnread = applyPending(sess, [{ kind: 'mark-read', id: 'a', token: 'stale', at: 0 }])
+      expect(stillUnread[0].unread).toBe(true)
+    })
+
+    it('dismissal wins over a mark-read for the same session, either order', () => {
+      const sess = [makeSession({ id: 'a', unread: true, unread_token: '' })]
+      const read: PendingMutation = { kind: 'mark-read', id: 'a', token: '', at: 0 }
+      const gone: PendingMutation = { kind: 'dismiss', id: 'a', at: 0 }
+      expect(applyPending(sess, [read, gone])).toEqual([])
+      expect(applyPending(sess, [gone, read])).toEqual([])
+    })
+
     it('dismiss removes the targeted session', () => {
       const sess = [makeSession({ id: 'a' }), makeSession({ id: 'b' })]
       const out = applyPending(sess, [{ kind: 'dismiss', id: 'a', at: 0 }])

--- a/apps/gmux-web/src/store.test.ts
+++ b/apps/gmux-web/src/store.test.ts
@@ -1344,7 +1344,7 @@ describe('sidebar family entry derivations', () => {
         proc('p2', 'grandkid', { status: { active: true }, unread: true }),
       ]
       expect(familyActivityById.value.get('root')).toEqual({
-        error: 1, unread: 1, workingAgents: 2, workingProcesses: 2,
+        error: 1, waiting: 1, active: 2, running: 2,
       })
       // The root's own working state is never in its family's counts.
       expect(familyActivityById.value.get('kid')).toBeUndefined()
@@ -1356,12 +1356,12 @@ describe('sidebar family entry derivations', () => {
         agent('live', { parent_session_id: 'root', unread: true }),
         agent('dead', { parent_session_id: 'root', unread: true, alive: false, resumable: true }),
       ]
-      expect(familyActivityById.value.get('root')?.unread).toBe(2)
+      expect(familyActivityById.value.get('root')?.waiting).toBe(2)
       // The standard family numbers are a fact about the family, not
       // the viewport: the toggle hides rows, and the panel one click
       // away shows the hidden member regardless, so the count stands.
       setAliveOnly(true)
-      expect(familyActivityById.value.get('root')?.unread).toBe(2)
+      expect(familyActivityById.value.get('root')?.waiting).toBe(2)
       setAliveOnly(false)
     })
 
@@ -1384,7 +1384,7 @@ describe('sidebar family entry derivations', () => {
         agent('unseen', { parent_session_id: 'root', alive: false, unread: true }),
       ]
       expect(familyActivityById.value.get('root')).toEqual({
-        error: 0, unread: 1, workingAgents: 0, workingProcesses: 0,
+        error: 0, waiting: 1, active: 0, running: 0,
       })
     })
 
@@ -1396,17 +1396,17 @@ describe('sidebar family entry derivations', () => {
         agent('a', { slug: 'aa', parent_session_id: 'root', unread: true }),
         agent('b', { slug: 'bb', parent_session_id: 'root', unread: true }),
       ]
-      expect(familyActivityById.value.get('root')?.unread).toBe(2)
+      expect(familyActivityById.value.get('root')?.waiting).toBe(2)
       // Viewing 'a' names it on the slot row; the count does not budge.
       // A summary may include what is separately visible — the panel's
       // tally counts the rows below it too — and subtracting the slot
       // made this number wobble with which member you last visited.
       urlPath.value = '/proj/pi/aa'
-      expect(familyActivityById.value.get('root')?.unread).toBe(2)
+      expect(familyActivityById.value.get('root')?.waiting).toBe(2)
       _rawSessions.value = _rawSessions.value.map(s =>
         s.id === 'a' ? { ...s, unread: false, status: { active: true } } : s)
       expect(familyActivityById.value.get('root')).toEqual({
-        error: 0, unread: 1, workingAgents: 1, workingProcesses: 0,
+        error: 0, waiting: 1, active: 1, running: 0,
       })
     })
 
@@ -1418,7 +1418,7 @@ describe('sidebar family entry derivations', () => {
       urlPath.value = '/proj/pi/aa'
       rememberFamilyChild('a')
       expect(familySlotById.value.get('root')?.session.id).toBe('a')
-      expect(familyActivityById.value.get('root')?.unread).toBe(1)
+      expect(familyActivityById.value.get('root')?.waiting).toBe(1)
     })
 
     it('gives a promoted descendant its own counts, not its old family\u2019s', () => {
@@ -1428,7 +1428,7 @@ describe('sidebar family entry derivations', () => {
         proc('p', 'kid', { status: { active: true } }),
       ]
       expect(familyActivityById.value.has('root')).toBe(false)
-      expect(familyActivityById.value.get('kid')?.workingProcesses).toBe(1)
+      expect(familyActivityById.value.get('kid')?.running).toBe(1)
     })
   })
 

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -1082,21 +1082,15 @@ export const familySlotById = computed<ReadonlyMap<string, FamilySlot>>(() => {
  * map: no line, nothing to say. */
 export const familyActivityById = computed<ReadonlyMap<string, FamilyActivity>>(() => {
   const index = familyIndex(sessions.value)
-  const map = new Map<string, { error: number; unread: number; workingAgents: number; workingProcesses: number }>()
+  const map = new Map<string, { error: number; waiting: number; active: number; running: number }>()
   for (const s of sessions.value) {
     if (!index.childIds.has(s.id)) continue
     const rootId = index.rootById.get(s.id)?.id
     if (!rootId || rootId === s.id) continue
-    let bucket: keyof FamilyActivity
-    switch (familyStateOf(s)) {
-      case 'error': bucket = 'error'; break
-      case 'active': bucket = 'workingAgents'; break
-      case 'running': bucket = 'workingProcesses'; break
-      case 'waiting': bucket = 'unread'; break
-      default: continue
-    }
-    const entry = map.get(rootId) ?? { error: 0, unread: 0, workingAgents: 0, workingProcesses: 0 }
-    entry[bucket]++
+    const state = familyStateOf(s)
+    if (!state) continue
+    const entry = map.get(rootId) ?? { error: 0, waiting: 0, active: 0, running: 0 }
+    entry[state]++
     map.set(rootId, entry)
   }
   return map

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -1779,7 +1779,7 @@ async function errorMessageFromResponse(resp: Response): Promise<string> {
  * on failure. A network reject counts as "not succeeded" for rollback,
  * even though it's silent toast-wise.
  */
-async function postAction(endpoint: string, label = 'Action', body?: Record<string, unknown>): Promise<boolean> {
+async function postAction(endpoint: string, label = 'Action', body?: Record<string, unknown>, quiet = false): Promise<boolean> {
   try {
     const resp = await fetch(endpoint, {
       method: 'POST',
@@ -1789,7 +1789,10 @@ async function postAction(endpoint: string, label = 'Action', body?: Record<stri
       } : {}),
     })
     if (!resp.ok) {
-      pushError(`${label} failed: ${await errorMessageFromResponse(resp)}`)
+      // `quiet` is for bulk callers: one toast per failed member turns a
+      // daemon hiccup during "Stop all" into two hundred toasts, so they
+      // take the boolean and report once.
+      if (!quiet) pushError(`${label} failed: ${await errorMessageFromResponse(resp)}`)
       return false
     }
     return true
@@ -1804,8 +1807,8 @@ async function postAction(endpoint: string, label = 'Action', body?: Record<stri
 // toast fires, instead of waiting out a timeout. Note these promises never
 // reject — postAction converts all failures into `false` — so `.catch()`
 // on them is dead code; branch on the boolean instead.
-export function killSession(sessionId: string): Promise<boolean> {
-  return postAction(`/v1/sessions/${sessionId}/kill`, 'Kill')
+export function killSession(sessionId: string, opts?: { quiet?: boolean }): Promise<boolean> {
+  return postAction(`/v1/sessions/${sessionId}/kill`, 'Kill', undefined, opts?.quiet)
 }
 
 /** Interrupt an agent's current turn (POST /cancel — the daemon's word;
@@ -1816,11 +1819,11 @@ export function killSession(sessionId: string): Promise<boolean> {
  * means the agent finished between your click and the wire. For the
  * bulk caller iterating a family that race is routine, and the outcome
  * is the one the click asked for — the agent is no longer mid-turn. */
-export async function cancelSession(sessionId: string): Promise<boolean> {
+export async function cancelSession(sessionId: string, opts?: { quiet?: boolean }): Promise<boolean> {
   try {
     const resp = await fetch(`/v1/sessions/${sessionId}/cancel`, { method: 'POST' })
     if (resp.ok || resp.status === 409) return true
-    pushError(`Interrupt failed: ${await errorMessageFromResponse(resp)}`)
+    if (!opts?.quiet) pushError(`Interrupt failed: ${await errorMessageFromResponse(resp)}`)
     return false
   } catch {
     console.debug(`/v1/sessions/${sessionId}/cancel: network error (suppressed toast)`)

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -20,7 +20,7 @@ import { resolveViewFromPath, viewToPath } from './routing'
 import { navigateWithReload } from './version-watch'
 import { buildProjectFolders, discoverProjects, type TemporaryPresentationPlacement } from './projects'
 import {
-  familyAncestors, familyIndex, familyRootId, isFamilyChild, isProcessSession,
+  familyAncestors, familyIndex, familyRootId, familyStateOf, isFamilyChild,
   type FamilyActivity,
 } from './family'
 import { referencePresence, unresolvedReferences, removeReferenceItems, removeHostReferenceItems, type UnresolvedHost } from './references'
@@ -1064,42 +1064,37 @@ export const familySlotById = computed<ReadonlyMap<string, FamilySlot>>(() => {
   return map
 })
 
-/** What the *rest* of each family is doing, keyed by presentation-root id.
+/** What each family is doing, keyed by presentation-root id: the
+ * standard family numbers — every descendant of the root, the root
+ * excluded, bucketed once each by `familyStateOf` — the same rule and
+ * the same population as the header pill and the panel tally, so the
+ * same dots never wear different numbers anywhere.
  *
- * The sidebar entry names two members: the root, on its own row with
- * its own dot, and the slot member below it. This is everyone else —
- * hence the `+` the row leads with. One invariant holds the entry
- * together: every family member is represented exactly once, either by
- * name or by a number, so a subagent you're watching can't show up as
- * both a row and a count.
+ * Deliberately a fact about the family, not the viewport: the line
+ * does not subtract the slot member named beneath it (a summary may
+ * include what is separately visible — the panel's tally counts the
+ * rows below it too) and does not subtract members the alive-only
+ * toggle hides (the panel one click away shows them regardless). Both
+ * subtractions used to make this number wobble with unrelated view
+ * state, which read as the count being wrong.
  *
- * Members are tallied once each under dot precedence (error > working
- * > unread). Idle members are not counted and roots with nothing else
- * happening are absent from the map: no line, nothing to say. */
+ * Idle members are not counted and quiet families are absent from the
+ * map: no line, nothing to say. */
 export const familyActivityById = computed<ReadonlyMap<string, FamilyActivity>>(() => {
   const index = familyIndex(sessions.value)
-  const named = familySlotById.value
-  const onlyAlive = aliveOnly.value
   const map = new Map<string, { error: number; unread: number; workingAgents: number; workingProcesses: number }>()
   for (const s of sessions.value) {
     if (!index.childIds.has(s.id)) continue
     const rootId = index.rootById.get(s.id)?.id
     if (!rootId || rootId === s.id) continue
-    // The line counts what the list would show you. With alive-only on,
-    // a dead member is filtered out of the sidebar, so reporting its
-    // unread here would point at a row that isn't there.
-    if (onlyAlive && !s.alive) continue
-    // Already named by the slot row above: counting it too would show
-    // one member twice, and claim attention its own dot already carries.
-    if (named.get(rootId)?.session.id === s.id) continue
     let bucket: keyof FamilyActivity
-    if (s.alive && s.status?.error) {
-      bucket = 'error'
-    } else if (s.alive && s.status?.active) {
-      bucket = isProcessSession(s) ? 'workingProcesses' : 'workingAgents'
-    } else if (s.unread) {
-      bucket = 'unread'
-    } else continue
+    switch (familyStateOf(s)) {
+      case 'error': bucket = 'error'; break
+      case 'active': bucket = 'workingAgents'; break
+      case 'running': bucket = 'workingProcesses'; break
+      case 'waiting': bucket = 'unread'; break
+      default: continue
+    }
     const entry = map.get(rootId) ?? { error: 0, unread: 0, workingAgents: 0, workingProcesses: 0 }
     entry[bucket]++
     map.set(rootId, entry)

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -137,22 +137,35 @@ export function applyPending(
   pending: PendingMutation[],
 ): Session[] {
   if (pending.length === 0) return rawSessions
-  let sess = rawSessions
+  // Indexed, then one pass: "mark all read" on a family stacks a
+  // mutation per member, and a pass each would make every recompute in
+  // the app cost mutations × sessions until the server echoed them back
+  // — measurably, ~3ms a recompute for 250 of them over 1500 sessions.
+  //
+  // Order between the two kinds doesn't survive the rewrite, and
+  // doesn't need to: for one id, dismissal wins either way round —
+  // marking a removed session read is a no-op, and dismissing a
+  // read-marked one still removes it.
+  const readTokens = new Map<string, Set<string>>()
+  const dismissed = new Set<string>()
   for (const m of pending) {
-    switch (m.kind) {
-      case 'mark-read':
-        sess = sess.map(s => s.id !== m.id || (s.unread_token ?? '') !== m.token ? s : ({
-          ...s,
-          unread: false,
-          status: s.status?.error ? { ...s.status, error: false } : s.status,
-        }))
-        break
-      case 'dismiss':
-        sess = sess.filter(s => s.id !== m.id)
-        break
+    if (m.kind === 'dismiss') dismissed.add(m.id)
+    else {
+      // Several tokens can be in flight for one session; each only
+      // applies to the state it was issued against.
+      const tokens = readTokens.get(m.id)
+      if (tokens) tokens.add(m.token)
+      else readTokens.set(m.id, new Set([m.token]))
     }
   }
-  return sess
+  const out: Session[] = []
+  for (const s of rawSessions) {
+    if (dismissed.has(s.id)) continue
+    out.push(readTokens.get(s.id)?.has(s.unread_token ?? '')
+      ? { ...s, unread: false, status: s.status?.error ? { ...s.status, error: false } : s.status }
+      : s)
+  }
+  return out
 }
 
 /** True when the raw state already reflects the mutation, so replaying

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -1808,6 +1808,26 @@ export function killSession(sessionId: string): Promise<boolean> {
   return postAction(`/v1/sessions/${sessionId}/kill`, 'Kill')
 }
 
+/** Interrupt an agent's current turn (POST /cancel — the daemon's word;
+ * the UI says "interrupt", ADR 0023's word for ending a turn early).
+ *
+ * A 409 is swallowed rather than toasted: cancel is live-and-active
+ * only, enforced by the runner at delivery, so "no turn to cancel"
+ * means the agent finished between your click and the wire. For the
+ * bulk caller iterating a family that race is routine, and the outcome
+ * is the one the click asked for — the agent is no longer mid-turn. */
+export async function cancelSession(sessionId: string): Promise<boolean> {
+  try {
+    const resp = await fetch(`/v1/sessions/${sessionId}/cancel`, { method: 'POST' })
+    if (resp.ok || resp.status === 409) return true
+    pushError(`Interrupt failed: ${await errorMessageFromResponse(resp)}`)
+    return false
+  } catch {
+    console.debug(`/v1/sessions/${sessionId}/cancel: network error (suppressed toast)`)
+    return false
+  }
+}
+
 export function dismissSession(sessionId: string): Promise<void> {
   // Optimistic dismissal: hide the session locally now, and retract
   // immediately if the server rejects — so the toast and the row

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -1078,8 +1078,9 @@ export const familySlotById = computed<ReadonlyMap<string, FamilySlot>>(() => {
  * subtractions used to make this number wobble with unrelated view
  * state, which read as the count being wrong.
  *
- * Idle members are not counted and quiet families are absent from the
- * map: no line, nothing to say. */
+ * Idle members are not counted, and an entry exists if and only if
+ * some count is non-zero — a quiet family is absent from the map, and
+ * `undefined` is the whole of "nothing to report" for every caller. */
 export const familyActivityById = computed<ReadonlyMap<string, FamilyActivity>>(() => {
   const index = familyIndex(sessions.value)
   const map = new Map<string, { error: number; waiting: number; active: number; running: number }>()
@@ -1768,16 +1769,17 @@ async function errorMessageFromResponse(resp: Response): Promise<string> {
  * on failure. A network reject counts as "not succeeded" for rollback,
  * even though it's silent toast-wise.
  */
-async function postAction(endpoint: string, label = 'Action', body?: Record<string, unknown>, quiet = false): Promise<boolean> {
+async function postAction(endpoint: string, label = 'Action', opts: {
+  /** Suppress the per-call toast; the caller reports once instead. */
+  quiet?: boolean
+  /** One more status to treat as success, for endpoints where a
+   * rejection is the outcome the caller asked for anyway. */
+  alsoOk?: number
+} = {}): Promise<boolean> {
+  const { quiet = false, alsoOk } = opts
   try {
-    const resp = await fetch(endpoint, {
-      method: 'POST',
-      ...(body ? {
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body),
-      } : {}),
-    })
-    if (!resp.ok) {
+    const resp = await fetch(endpoint, { method: 'POST' })
+    if (!resp.ok && resp.status !== alsoOk) {
       // `quiet` is for bulk callers: one toast per failed member turns a
       // daemon hiccup during "Stop all" into two hundred toasts, so they
       // take the boolean and report once.
@@ -1797,7 +1799,7 @@ async function postAction(endpoint: string, label = 'Action', body?: Record<stri
 // reject — postAction converts all failures into `false` — so `.catch()`
 // on them is dead code; branch on the boolean instead.
 export function killSession(sessionId: string, opts?: { quiet?: boolean }): Promise<boolean> {
-  return postAction(`/v1/sessions/${sessionId}/kill`, 'Kill', undefined, opts?.quiet)
+  return postAction(`/v1/sessions/${sessionId}/kill`, 'Kill', { quiet: opts?.quiet })
 }
 
 /** Interrupt an agent's current turn (POST /cancel — the daemon's word;
@@ -1808,16 +1810,10 @@ export function killSession(sessionId: string, opts?: { quiet?: boolean }): Prom
  * means the agent finished between your click and the wire. For the
  * bulk caller iterating a family that race is routine, and the outcome
  * is the one the click asked for — the agent is no longer mid-turn. */
-export async function cancelSession(sessionId: string, opts?: { quiet?: boolean }): Promise<boolean> {
-  try {
-    const resp = await fetch(`/v1/sessions/${sessionId}/cancel`, { method: 'POST' })
-    if (resp.ok || resp.status === 409) return true
-    if (!opts?.quiet) pushError(`Interrupt failed: ${await errorMessageFromResponse(resp)}`)
-    return false
-  } catch {
-    console.debug(`/v1/sessions/${sessionId}/cancel: network error (suppressed toast)`)
-    return false
-  }
+export function cancelSession(sessionId: string, opts?: { quiet?: boolean }): Promise<boolean> {
+  return postAction(`/v1/sessions/${sessionId}/cancel`, 'Interrupt', {
+    quiet: opts?.quiet, alsoOk: 409,
+  })
 }
 
 export function dismissSession(sessionId: string): Promise<void> {

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -2390,9 +2390,22 @@ body {
 }
 .family-mark-read:hover { color: var(--text); border-color: var(--text-muted); }
 .family-drawer-scroll { flex: 1 1 auto; overflow: auto; padding: 6px 8px 8px; }
+/* One segment per state, each carrying the dot the rows use for it, so
+   the header reads as a key to the tree below rather than a separate
+   vocabulary. Spacing does the separating that a `·` used to. */
 .family-counts {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 4px 14px;
   font: 400 12px/1.4 'Source Sans 3', sans-serif;
   color: var(--text-muted);
+}
+.family-count {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-variant-numeric: tabular-nums;
 }
 .family-count-attention { color: var(--unread); font-weight: 600; }
 .family-tree,

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -1162,16 +1162,31 @@ body {
   gap: 5px;
   flex: 0 0 auto;
 }
-.family-child-proc {
+/* The `$`: a process where an agent shows a status dot. Shape (not
+   just colour) distinguishes them, so the cue survives tiny sizes and
+   colour blindness — and it carries the same state vocabulary the dots
+   do, in the glyph's own colour, wherever it appears.
+
+   Vocabulary only: no box. The sidebar pairs it with `.family-glyph`,
+   which owns the fixed column there, and repeating those properties
+   here would silently outrank that class by source order — the exact
+   drift this merge existed to end. */
+.family-proc {
   font-family: 'Fira Code', monospace;
   font-size: 11px;
   line-height: 1;
   color: var(--text-muted);
 }
-.family-child-proc.working { color: var(--accent); }
-/* The rest of the dot vocabulary, in the `$`'s colour. */
-.family-child-proc.unread { color: var(--unread); }
-.family-child-proc.error { color: var(--status-error); }
+/* The panel has no glyph-column class of its own, so it gives the `$`
+   the same box its status dots occupy. */
+.family-row .family-proc {
+  flex: 0 0 auto;
+  width: 7px; /* match .session-dot-indicator for title alignment */
+  text-align: center;
+}
+.family-proc.working { color: var(--accent); }
+.family-proc.unread { color: var(--unread); }
+.family-proc.error { color: var(--status-error); }
 
 /* States that belong to the root row are the whole entry's states —
    it's one entry, so it dims, drags and takes a drop line as a unit. */
@@ -2464,18 +2479,6 @@ body {
 .family-row { min-height: 34px; display: flex; align-items: center; gap: 8px; padding: 6px 10px; border-radius: 5px; color: var(--text-secondary); text-decoration: none; }
 .family-row:hover { background: var(--bg-hover); color: var(--text); }
 .family-row.selected { background: var(--bg-selected); color: var(--text); }
-/* Processes: a mono $ glyph where agents show a status dot, muted title.
- * Shape (not just color) distinguishes them from agents, so the cue
- * survives tiny sizes and color blindness. */
-.family-row-proc {
-  flex: 0 0 auto;
-  width: 7px; /* match .session-dot-indicator for title alignment */
-  font-family: 'Fira Code', monospace;
-  font-size: 11px;
-  line-height: 1;
-  color: var(--text-muted);
-}
-.family-row-proc.working { color: var(--accent); }
 .family-row.process .family-row-title { color: var(--text-muted); }
 .family-row-title { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 /* Age: the key every level is sorted by, so it stays on screen. Tabular

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -2354,7 +2354,12 @@ body {
   left: 16px;
   z-index: 100;
   width: max-content;
-  min-width: 320px;
+  /* Wide enough that filtering doesn't reflow the panel underneath the
+     buttons you're pressing: a filter narrows the content (fewer, often
+     shorter rows), and with `max-content` the panel used to lurch with
+     it. One min-width absorbs most of that, and gives the head room so
+     the action button isn't shoulder-to-shoulder with the tally. */
+  min-width: 440px;
   /* Wider than it was: the panel now shows the whole family from the
      root, so deep rows pay for their indentation out of this budget. */
   max-width: min(560px, calc(100vw - 24px));
@@ -2371,7 +2376,7 @@ body {
   flex: 0 0 auto;
   display: flex;
   align-items: baseline;
-  gap: 10px;
+  gap: 18px;
   padding: 10px 14px 8px;
   border-bottom: 1px solid var(--border);
 }

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -1077,11 +1077,18 @@ body {
   font-size: 10px;
   line-height: 1;
 }
-/* The activity line's own glyph: everyone the entry didn't name. */
-.family-plus {
+/* The activity line's own glyph: the family mark, same as the header's
+   trigger. Slightly larger than the 7px glyph column and centered on
+   it — a 7px tree is a smudge — but the column's own width is what
+   keeps the numbers aligned with member glyphs above. */
+.family-activity-icon {
+  width: 12px;
+  height: 12px;
+  display: block;
+  /* Centered on the 7px glyph column: auto margins can't go negative,
+     so split the 5px overflow explicitly. */
+  margin: 0 -2.5px;
   color: var(--text-muted);
-  font-size: 11px;
-  line-height: 1;
 }
 
 /* Member row: the family member you're viewing, or the last one you
@@ -1124,11 +1131,11 @@ body {
   min-width: 0;
 }
 
-/* Activity line: everyone the entry doesn't name by row, one segment
-   per state, each dropped at zero. No target of its own — it's part of
-   the group's area, so it takes the group's hover and selects the
-   root. Numbers sit a touch under the title size; the glyphs keep
-   their standard sizes. */
+/* Activity line: the standard family numbers — everyone beneath the
+   root — one segment per state, each dropped at zero. No target of its
+   own: it's part of the group's area, so it takes the group's hover
+   and selects the root. Numbers sit a touch under the title size; the
+   glyphs keep their standard sizes. */
 .family-activity {
   padding-top: 1px;
   padding-bottom: 4px;
@@ -1136,12 +1143,6 @@ body {
   font-size: 12.5px;
   line-height: 1.3;
   font-variant-numeric: tabular-nums;
-}
-/* Stepped in by one glyph column (7px glyph + 6px gap) when a member
-   row sits above, so the `+` starts under that member's title: these
-   are members in addition to the one named, not siblings of it. */
-.family-activity.nested {
-  padding-left: 42px;
 }
 .family-activity-glyphs {
   display: flex;

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -2258,7 +2258,6 @@ body {
 
 .main-header-status.working { color: var(--accent); }
 .main-header-status.error   { color: var(--status-error); }
-.main-header-status.ended   { color: var(--text-muted); }
 
 /* Family trigger: a ghost icon button in the header's one control
  * language (borderless, bg-hover, sized to match .session-menu-trigger).
@@ -2301,11 +2300,23 @@ body {
   display: flex;
   align-items: center;
   gap: 2px;
-  min-width: 0;
-  /* Ancestors yield space before the current session's title does, and
-   * when even their minimums overflow the clip falls on the root end
-   * (justify-content: flex-end) so the immediate parent stays readable. */
-  flex-shrink: 2;
+  /* Explicit `min-content`, not `auto`: with `overflow: hidden` the
+   * flexbox automatic minimum computes to zero, so the strip — 4ch
+   * crumb floors and all — collapsed to nothing under a long title.
+   * min-content is bounded here because the crumbs cap at three (root ›
+   * … › parent), so the strip refuses to shrink past ~120px and the
+   * title, whose min-width is 0, yields instead. */
+  min-width: min-content;
+  /* Shrink no faster than the title: where the selected session is is
+   * at least as important as what it's called, and a shrink factor of 2
+   * here let any long title erase the ancestors entirely. The per-crumb
+   * title floor below is what actually guarantees their survival — flex
+   * weighting alone cannot, because a long title's flex basis dwarfs
+   * the crumbs' and takes nearly everything regardless of factors. When
+   * even the floors overflow, the clip falls on the root end
+   * (justify-content: flex-end) so the immediate parent stays readable
+   * until the mobile layout gives the crumbs their own row. */
+  flex-shrink: 1;
   justify-content: flex-end;
   overflow: hidden;
   /* Match the 26px control row so crumb text shares the title's center. */
@@ -2328,10 +2339,12 @@ body {
 .header-crumb:hover { background: var(--bg-hover); color: var(--text); }
 .header-crumb-title {
   max-width: 18ch;
-  /* No min-width: a floor here makes the crumb strip's min-content exceed
-   * its box on medium widths, and the overflow clips crumbs mid-glyph.
-   * Ellipsis-to-nothing degrades; hard clipping just looks broken. */
-  min-width: 0;
+  /* A small floor, so a crumb degrades to `ter…` and stops, instead of
+   * ellipsizing to nothing and leaving a bare dot — or less. Kept just
+   * big enough to be legible: every ch of floor here widens the band of
+   * medium widths where the strip's min-content exceeds its box and the
+   * root end clips mid-glyph. */
+  min-width: 4ch;
   overflow: hidden;
   text-overflow: ellipsis;
 }

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -1074,6 +1074,12 @@ body {
   font-size: 10px;
   line-height: 1;
 }
+/* The activity line's own glyph: everyone the entry didn't name. */
+.family-plus {
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 1;
+}
 
 /* Member row: the family member you're viewing, or the last one you
    did. Title-sized and title-coloured in every state — a peer of the
@@ -1127,6 +1133,12 @@ body {
   font-size: 12.5px;
   line-height: 1.3;
   font-variant-numeric: tabular-nums;
+}
+/* Stepped in by one glyph column (7px glyph + 6px gap) when a member
+   row sits above, so the `+` starts under that member's title: these
+   are members in addition to the one named, not siblings of it. */
+.family-activity.nested {
+  padding-left: 42px;
 }
 .family-activity-glyphs {
   display: flex;

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -2397,16 +2397,34 @@ body {
   display: flex;
   align-items: center;
   flex-wrap: wrap;
-  gap: 4px 14px;
+  gap: 2px 6px;
   font: 400 12px/1.4 'Source Sans 3', sans-serif;
   color: var(--text-muted);
 }
+/* Each tally is also the filter for its own state, so it looks like
+   something you can press without shouting: no chrome until you point
+   at it, a filled pill once it's on. */
 .family-count {
   display: inline-flex;
   align-items: center;
   gap: 6px;
+  padding: 2px 7px;
+  margin: -2px 0;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  background: transparent;
+  color: inherit;
+  font: inherit;
   font-variant-numeric: tabular-nums;
+  cursor: pointer;
 }
+.family-count:hover { border-color: var(--border); }
+.family-count.active {
+  background: var(--bg-selected);
+  border-color: var(--border);
+  color: var(--text);
+}
+.family-count:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
 .family-count-attention { color: var(--unread); font-weight: 600; }
 .family-tree,
 .family-tree ul { list-style: none; margin: 0; padding: 0; }

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -741,19 +741,22 @@ body {
 
 .session-dot-indicator.working {
   background: transparent;
-  border: 1.5px solid var(--accent);
+  /* A hair thicker than the 1.5px it grew up with: hollow rings read
+     thinner than the filled dots they sit beside, and at 7px the ring
+     was dropping below legibility on low-DPI screens. */
+  border: 1.75px solid var(--accent);
   animation: subtle-pulse 2.5s ease-in-out infinite;
 }
 
 .session-dot-indicator.active {
   background: transparent;
-  border: 1.5px solid var(--active);
+  border: 1.75px solid var(--active);
   animation: subtle-pulse 3s ease-in-out infinite;
 }
 
 .session-dot-indicator.fading {
   background: transparent;
-  border: 1.5px solid var(--active);
+  border: 1.75px solid var(--active);
   animation: dot-fade-out 800ms ease-out forwards;
 }
 
@@ -2171,7 +2174,7 @@ body {
 
 .session-dot.working {
   background: transparent;
-  border: 1.5px solid var(--accent);
+  border: 1.75px solid var(--accent);
 }
 .session-dot.error   { background: var(--status-error); }
 .session-dot.idle    { background: var(--text-muted); }
@@ -2263,34 +2266,45 @@ body {
  * language (borderless, bg-hover, sized to match .session-menu-trigger).
  * The corner badge repeats the family's aggregated dot state so
  * background family activity is visible without opening the panel. */
+/* A pill, bordered like the panel's tally buttons so it reads as one
+ * coherent button rather than a strip of dots that happens to be
+ * clickable. Never shrinks: it is the densest thing in the row, and
+ * the title yields instead. */
 .family-trigger {
-  position: relative;
-  width: 26px;
   height: 26px;
   flex-shrink: 0;
-  border: 0;
-  border-radius: 4px;
-  background: transparent;
-  color: var(--text-muted);
-  cursor: pointer;
   display: flex;
   align-items: center;
-  justify-content: center;
-  padding: 0;
-  transition: background 0.1s, color 0.1s;
+  gap: 8px;
+  padding: 0 9px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text-secondary);
+  font: 500 12px/1 'Source Sans 3', sans-serif;
+  font-variant-numeric: tabular-nums;
+  cursor: pointer;
+  transition: background 0.1s, color 0.1s, border-color 0.1s;
 }
 .family-trigger:hover,
-.family-trigger[aria-expanded="true"] { background: var(--bg-hover); color: var(--text); }
+.family-trigger[aria-expanded="true"] {
+  background: var(--bg-hover);
+  color: var(--text);
+  border-color: var(--border-strong);
+}
+.family-trigger-seg {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+/* The sidebar's own glyphs at the sidebar's own size, so the button
+ * reads as the same sentence relocated, not a new dialect. */
+/* The quiet family wears the tree icon: several nodes, one structure. */
 .family-trigger-icon { width: 16px; height: 16px; display: block; }
-/* 7px like every other status dot in the app — a one-off 6px dot reads as
- * a rendering artifact next to the sidebar's dots. */
-.family-trigger-badge {
-  position: absolute;
-  top: 2px;
-  right: 2px;
-  width: 7px;
-  height: 7px;
-  pointer-events: none;
+
+.family-trigger-proc {
+  font: 600 11px/1 'Source Sans 3', sans-serif;
+  color: var(--active);
 }
 
 /* Ancestor breadcrumbs in the title row: quiet path prefix, each crumb a

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -2355,7 +2355,28 @@ body {
   box-shadow: 0 8px 24px oklch(0% 0 0 / 0.4);
 }
 /* The counts line stays put; only the tree scrolls. */
-.family-drawer-head { flex: 0 0 auto; padding: 10px 14px 8px; border-bottom: 1px solid var(--border); }
+.family-drawer-head {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  padding: 10px 14px 8px;
+  border-bottom: 1px solid var(--border);
+}
+.family-drawer-head .family-counts { flex: 1 1 auto; }
+/* Quiet until wanted: it sits beside a counts line that is itself the
+   reason to press it, so it needs to be findable, not loud. */
+.family-mark-read {
+  flex: 0 0 auto;
+  padding: 2px 8px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-muted);
+  font: 400 11px/1.4 'Source Sans 3', sans-serif;
+  cursor: pointer;
+}
+.family-mark-read:hover { color: var(--text); border-color: var(--text-muted); }
 .family-drawer-scroll { flex: 1 1 auto; overflow: auto; padding: 6px 8px 8px; }
 .family-counts {
   font: 400 12px/1.4 'Source Sans 3', sans-serif;

--- a/e2e/tests/family-entry-interaction.spec.ts
+++ b/e2e/tests/family-entry-interaction.spec.ts
@@ -241,11 +241,11 @@ test.describe('the family line and the panel tally', () => {
     // looking at the complete list of what it will touch.
     await expect(action).toHaveCount(0)
 
-    const expected: [string, string][] = [
-      ['waiting', 'Mark all read'],
-      ['error', 'Mark all read'],
-      ['running', 'Stop all'],
-      ['active', 'Interrupt all'],
+    const expected: [string, RegExp][] = [
+      ['waiting', /^Mark all read$/],
+      ['error', /^Mark all read$/],
+      ['running', /^Stop all \d+$/],
+      ['active', /^Interrupt all \d+$/],
     ]
     for (const [state, verb] of expected) {
       await tally(state).click()
@@ -254,18 +254,54 @@ test.describe('the family line and the panel tally', () => {
       await expect(action).toHaveCount(0)
     }
 
-    // The waiting action still acts — and only on the waiting members.
-    const reads: string[] = []
-    await page.route('**/v1/sessions/**/read*', route => {
-      reads.push(route.request().url())
-      route.fulfill({ status: 200, body: '{}' })
-    })
+    // Each verb hits its own endpoint, with its own state's members.
+    const hits: Record<string, string[]> = { read: [], kill: [], cancel: [] }
+    for (const verb of ['read', 'kill', 'cancel']) {
+      await page.route(`**/v1/sessions/**/${verb}*`, route => {
+        hits[verb].push(new URL(route.request().url()).pathname)
+        route.fulfill({ status: 200, body: '{}' })
+      })
+    }
+
     await tally('waiting').click()
     await action.click()
-    await expect.poll(() => reads.length).toBeGreaterThan(0)
-    // Only fam1kid is `waiting` in this family: the errored member is
-    // under `error`, precedence keeps it out of this verb's reach.
-    expect(reads.every(url => url.includes('fam1kid'))).toBe(true)
+    await expect.poll(() => hits.read.length).toBeGreaterThan(0)
+    // Only fam1kid is `waiting` here: the errored member is under
+    // `error`, precedence keeps it out of this verb's reach.
+    expect(hits.read.every(path => path.includes('fam1kid'))).toBe(true)
+
+    // Stop all → /kill, and only the running process.
+    await tally('all').click()
+    await tally('running').click()
+    await expect(action).toHaveText(/^Stop all \d+$/)
+    await action.click()
+    await expect.poll(() => hits.kill.length).toBe(1)
+    expect(hits.kill[0]).toContain('fam0proc')
+    expect(hits.cancel).toHaveLength(0)
+
+    // Interrupt all → /cancel, on the active agents and nothing else.
+    await tally('all').click()
+    await tally('active').click()
+    await expect(action).toHaveText(/^Interrupt all \d+$/)
+    await action.click()
+    await expect.poll(() => hits.cancel.length).toBeGreaterThan(0)
+    expect(hits.cancel.some(path => path.includes('fam0root'))).toBe(true)
+    expect(hits.cancel.every(path => !path.includes('fam0proc'))).toBe(true)
+    expect(hits.kill).toHaveLength(1)
+  })
+
+  test('a bulk verb names its blast radius, including folded members', async ({ page }) => {
+    // The panel's budget folds a big family, but the verb acts on the
+    // filter, not the viewport — so the count in the label is the only
+    // honest statement of what the click will touch.
+    await openMockSidebar(page, '/my-project/claude/~fam2kid')
+    await page.locator('[aria-controls="agent-family-drawer"]').first().click()
+    const counts = page.locator('.family-counts')
+    await counts.waitFor()
+    const tally = (label: string) => counts.locator('.family-count').filter({ hasText: label })
+    await tally('active').click()
+    const tallied = Number((await tally('active').textContent())?.match(/\d+/)?.[0])
+    await expect(page.locator('.family-mark-read')).toHaveText(`Interrupt all ${tallied}`)
   })
 
   test('ancestors survive a long title, and quiet crumbs carry no dot hole', async ({ page }) => {

--- a/e2e/tests/family-entry-interaction.spec.ts
+++ b/e2e/tests/family-entry-interaction.spec.ts
@@ -162,7 +162,7 @@ test.describe('the family line and the panel tally', () => {
     const segments = await counts.locator('.family-count').evaluateAll(nodes => nodes.map(n => ({
       text: n.textContent?.replace(/\s+/g, ' ').trim(),
       dot: n.querySelector('.session-dot-indicator')?.className ?? null,
-      proc: n.querySelector('.family-row-proc')?.textContent ?? null,
+      proc: n.querySelector('.family-proc')?.textContent ?? null,
     })))
     for (const segment of segments) {
       if (segment.text === 'all') {
@@ -350,5 +350,23 @@ test.describe('the family line and the panel tally', () => {
     expect(segCount('unread')).toBe(tallyCount('waiting'))
     expect(segCount('$')).toBe(tallyCount('running'))
     expect(tallyCount('active')).toBeGreaterThan(0)
+  })
+
+  test('a process row wears the state the tally counted it under', async ({ page }) => {
+    // famBroot is a process-only family: one running command, one that
+    // finished with output you have not seen. The `$` is the only place
+    // that row's state can appear, so a stateless glyph would leave the
+    // member the tally counts — and the `waiting` filter shows —
+    // unmarked on screen.
+    await openMockSidebar(page, '/my-project/claude/~famBroot')
+    await page.locator('[aria-controls="agent-family-drawer"]').first().click()
+    const glyphs = await page.locator('.family-row').evaluateAll(rows => rows.map(row => ({
+      title: row.querySelector('.family-row-title')?.textContent ?? '',
+      glyph: row.querySelector('.family-proc')?.className ?? null,
+    })))
+    const gofmt = glyphs.find(g => g.title.startsWith('gofmt'))
+    expect(gofmt?.glyph, 'the waiting process is marked as waiting').toContain('unread')
+    const build = glyphs.find(g => g.title.startsWith('vite build'))
+    expect(build?.glyph, 'and the running one as running').toContain('working')
   })
 })

--- a/e2e/tests/family-entry-interaction.spec.ts
+++ b/e2e/tests/family-entry-interaction.spec.ts
@@ -267,4 +267,22 @@ test.describe('the family line and the panel tally', () => {
     // under `error`, precedence keeps it out of this verb's reach.
     expect(reads.every(url => url.includes('fam1kid'))).toBe(true)
   })
+
+  test('ancestors survive a long title, and quiet crumbs carry no dot hole', async ({ page }) => {
+    // fam4kid: three ancestors (shown as root › … › parent) and a title
+    // long enough to want every pixel the crumbs have.
+    await page.setViewportSize({ width: 800, height: 700 })
+    await openMockSidebar(page, '/my-project/claude/~fam4kid')
+    const crumbs = page.locator('.header-crumb')
+    await expect(crumbs).toHaveCount(2)
+    // Survival means being readable, not merely attached: each crumb
+    // title keeps real width even while the long title is ellipsizing.
+    for (const width of await crumbs.locator('.header-crumb-title')
+      .evaluateAll(nodes => nodes.map(n => n.getBoundingClientRect().width))) {
+      expect(width).toBeGreaterThan(20)
+    }
+    // A quiet ancestor gets no dot at all — the sidebar's invisible
+    // `none` placeholder would be a permanent hole in a crumb.
+    expect(await page.locator('.header-crumb .session-dot-indicator.none').count()).toBe(0)
+  })
 })

--- a/e2e/tests/family-entry-interaction.spec.ts
+++ b/e2e/tests/family-entry-interaction.spec.ts
@@ -108,40 +108,39 @@ test.describe('sidebar family entry', () => {
 })
 
 test.describe('the family line and the panel tally', () => {
-  test('the plus lines up with what it adds to', async ({ page }) => {
+  test('the family mark anchors to the glyph column, member row or not', async ({ page }) => {
     await openMockSidebar(page, '/my-project/claude/~fam2kid')
     const geometry = await page.evaluate(() => {
       const read = (entry: Element) => {
         const slot = entry.querySelector('.family-slot')
-        const plus = entry.querySelector('.family-activity .family-plus')
-        if (!plus) return null
+        const mark = entry.querySelector('.family-activity .family-activity-icon')
+        if (!mark) return null
         return {
-          plusText: plus.textContent,
-          plusX: Math.round(plus.getBoundingClientRect().x),
-          memberGlyphX: slot
-            ? Math.round(slot.querySelector('.family-glyph')!.getBoundingClientRect().x)
-            : null,
-          memberTitleX: slot
-            ? Math.round(slot.querySelector('.family-slot-title')!.getBoundingClientRect().x)
+          markCX: Math.round(mark.getBoundingClientRect().x + mark.getBoundingClientRect().width / 2),
+          memberGlyphCX: slot
+            ? Math.round(
+              slot.querySelector('.family-glyph')!.getBoundingClientRect().x
+                + slot.querySelector('.family-glyph')!.getBoundingClientRect().width / 2,
+            )
             : null,
         }
       }
       return [...document.querySelectorAll('.session-family')].map(read).filter(Boolean)
     })
 
-    const withMember = geometry.filter(g => g!.memberTitleX !== null)
-    const withoutMember = geometry.filter(g => g!.memberTitleX === null)
+    const withMember = geometry.filter(g => g!.memberGlyphCX !== null)
+    const withoutMember = geometry.filter(g => g!.memberGlyphCX === null)
     expect(withMember.length, 'a family with a member row on screen').toBeGreaterThan(0)
     expect(withoutMember.length, 'a family without one').toBeGreaterThan(0)
 
-    for (const g of geometry) expect(g!.plusText).toBe('+')
-    // Under the member's title: these are members in addition to the one
-    // named above, so the line starts where that name starts.
-    for (const g of withMember) expect(g!.plusX).toBe(g!.memberTitleX)
-    // With nothing above to add to, it stays in the glyph column, level
-    // with where a member's status would be.
-    const glyphColumn = withMember[0]!.memberGlyphX
-    for (const g of withoutMember) expect(g!.plusX).toBe(glyphColumn)
+    // The line is the standard family numbers — everyone beneath the
+    // root — not "the others", so it anchors to the root's glyph column
+    // and stays put whatever member row happens to be shown above it.
+    // (The old `+` indented under the member's title, because it meant
+    // "in addition to the one named"; that meaning is gone.)
+    const columns = new Set(geometry.map(g => g!.markCX))
+    expect(columns.size, 'one column for every family, slot row or not').toBe(1)
+    for (const g of withMember) expect(g!.markCX).toBe(g!.memberGlyphCX)
   })
 
   test("the panel's tally names states in the turn model's words", async ({ page }) => {
@@ -285,7 +284,11 @@ test.describe('the family line and the panel tally', () => {
     await expect(action).toHaveText(/^Interrupt all \d+$/)
     await action.click()
     await expect.poll(() => hits.cancel.length).toBeGreaterThan(0)
-    expect(hits.cancel.some(path => path.includes('fam0root'))).toBe(true)
+    // Never the root: the tally counts descendants only, the label
+    // quotes the tally, and the verb touches what the label counted.
+    // You act on the root by visiting it.
+    expect(hits.cancel.every(path => !path.includes('fam0root'))).toBe(true)
+    expect(hits.cancel.some(path => path.includes('fam2kid'))).toBe(true)
     expect(hits.cancel.every(path => !path.includes('fam0proc'))).toBe(true)
     expect(hits.kill).toHaveLength(1)
   })
@@ -334,17 +337,18 @@ test.describe('the family line and the panel tally', () => {
     expect(segs.length).toBeGreaterThan(1)
     await trigger.click()
     const tally = await page.locator('.family-count').allTextContents()
-    // Same derivation on both sides of the click, minus yourself: the
-    // header names fam2kid and fam2kid is active, so the button reports
-    // one active fewer than the panel — your own state is the view, not
-    // news arriving from the family. Every other count matches exactly.
+    // The standard family numbers on both sides of the click: every
+    // descendant of the root, the root excluded, whoever is viewing.
+    // Exactly equal — the button is the tally's preview, and the same
+    // dots must never wear different numbers.
     const tallyCount = (label: string) =>
       Number(tally.find(t => t.includes(label))?.match(/\d+/)?.[0] ?? 0)
     const segCount = (dot: string) =>
       Number(segs.find(s => s.dot?.includes(dot))?.count?.replace(/\D/g, '') ?? 0)
-    expect(segCount('working')).toBe(tallyCount('active') - 1)
+    expect(segCount('working')).toBe(tallyCount('active'))
     expect(segCount('error')).toBe(tallyCount('error'))
     expect(segCount('unread')).toBe(tallyCount('waiting'))
     expect(segCount('$')).toBe(tallyCount('running'))
+    expect(tallyCount('active')).toBeGreaterThan(0)
   })
 })

--- a/e2e/tests/family-entry-interaction.spec.ts
+++ b/e2e/tests/family-entry-interaction.spec.ts
@@ -285,4 +285,30 @@ test.describe('the family line and the panel tally', () => {
     // `none` placeholder would be a permanent hole in a crumb.
     expect(await page.locator('.header-crumb .session-dot-indicator.none').count()).toBe(0)
   })
+
+  test('the header trigger previews the tally it opens onto', async ({ page }) => {
+    await openMockSidebar(page, '/my-project/claude/~fam2kid')
+    const trigger = page.locator('.family-trigger')
+    // Segments, not the old icon-and-badge: dot + count per state, in
+    // the same order the panel's tally will list them.
+    const segs = await trigger.locator('.family-trigger-seg').evaluateAll(nodes => nodes.map(n => ({
+      count: n.textContent?.trim(),
+      dot: n.querySelector('.session-dot-indicator')?.className ?? n.querySelector('.family-trigger-proc')?.textContent,
+    })))
+    expect(segs.length).toBeGreaterThan(1)
+    await trigger.click()
+    const tally = await page.locator('.family-count').allTextContents()
+    // Same derivation on both sides of the click, minus yourself: the
+    // header names fam2kid and fam2kid is active, so the button reports
+    // one active fewer than the panel — your own state is the view, not
+    // news arriving from the family. Every other count matches exactly.
+    const tallyCount = (label: string) =>
+      Number(tally.find(t => t.includes(label))?.match(/\d+/)?.[0] ?? 0)
+    const segCount = (dot: string) =>
+      Number(segs.find(s => s.dot?.includes(dot))?.count?.replace(/\D/g, '') ?? 0)
+    expect(segCount('working')).toBe(tallyCount('active') - 1)
+    expect(segCount('error')).toBe(tallyCount('error'))
+    expect(segCount('unread')).toBe(tallyCount('waiting'))
+    expect(segCount('$')).toBe(tallyCount('running'))
+  })
 })

--- a/e2e/tests/family-entry-interaction.spec.ts
+++ b/e2e/tests/family-entry-interaction.spec.ts
@@ -106,3 +106,41 @@ test.describe('sidebar family entry', () => {
     }
   })
 })
+
+test.describe('the family line and the panel tally', () => {
+  test('the plus lines up with what it adds to', async ({ page }) => {
+    await openMockSidebar(page, '/my-project/claude/~fam2kid')
+    const geometry = await page.evaluate(() => {
+      const read = (entry: Element) => {
+        const slot = entry.querySelector('.family-slot')
+        const plus = entry.querySelector('.family-activity .family-plus')
+        if (!plus) return null
+        return {
+          plusText: plus.textContent,
+          plusX: Math.round(plus.getBoundingClientRect().x),
+          memberGlyphX: slot
+            ? Math.round(slot.querySelector('.family-glyph')!.getBoundingClientRect().x)
+            : null,
+          memberTitleX: slot
+            ? Math.round(slot.querySelector('.family-slot-title')!.getBoundingClientRect().x)
+            : null,
+        }
+      }
+      return [...document.querySelectorAll('.session-family')].map(read).filter(Boolean)
+    })
+
+    const withMember = geometry.filter(g => g!.memberTitleX !== null)
+    const withoutMember = geometry.filter(g => g!.memberTitleX === null)
+    expect(withMember.length, 'a family with a member row on screen').toBeGreaterThan(0)
+    expect(withoutMember.length, 'a family without one').toBeGreaterThan(0)
+
+    for (const g of geometry) expect(g!.plusText).toBe('+')
+    // Under the member's title: these are members in addition to the one
+    // named above, so the line starts where that name starts.
+    for (const g of withMember) expect(g!.plusX).toBe(g!.memberTitleX)
+    // With nothing above to add to, it stays in the glyph column, level
+    // with where a member's status would be.
+    const glyphColumn = withMember[0]!.memberGlyphX
+    for (const g of withoutMember) expect(g!.plusX).toBe(glyphColumn)
+  })
+})

--- a/e2e/tests/family-entry-interaction.spec.ts
+++ b/e2e/tests/family-entry-interaction.spec.ts
@@ -161,15 +161,27 @@ test.describe('the family line and the panel tally', () => {
     const segments = await counts.locator('.family-count').evaluateAll(nodes => nodes.map(n => ({
       text: n.textContent?.replace(/\s+/g, ' ').trim(),
       dot: n.querySelector('.session-dot-indicator')?.className ?? null,
+      proc: n.querySelector('.family-row-proc')?.textContent ?? null,
     })))
     for (const segment of segments) {
       if (/total/.test(segment.text ?? '')) {
-        expect(segment.dot, 'total is not a state, so it gets no dot').toBeNull()
+        expect(segment.dot, 'total is not a state, so it gets no glyph').toBeNull()
+        expect(segment.proc).toBeNull()
         continue
       }
-      expect(segment.text).toMatch(/^\d+ (error|active|waiting)$/)
-      expect(segment.dot).toMatch(/session-dot-indicator (error|working|unread)/)
+      expect(segment.text).toMatch(/^\$?\d+ (error|active|running|waiting)$/)
+      // Running commands are counted apart from thinking agents and wear
+      // the same `$` their rows do, because a family is routinely mostly
+      // processes and one number for both hides that.
+      if (/running/.test(segment.text ?? '')) {
+        expect(segment.proc).toBe('$')
+        expect(segment.dot).toBeNull()
+      } else {
+        expect(segment.dot).toMatch(/session-dot-indicator (error|working|unread)/)
+        expect(segment.proc).toBeNull()
+      }
     }
+    expect(segments.some(s => /running/.test(s.text ?? '')), 'a running process in the fixtures').toBe(true)
     expect(segments.some(s => /waiting|active|error/.test(s.text ?? ''))).toBe(true)
   })
 })

--- a/e2e/tests/family-entry-interaction.spec.ts
+++ b/e2e/tests/family-entry-interaction.spec.ts
@@ -154,7 +154,9 @@ test.describe('the family line and the panel tally', () => {
     // token `working` is the active dot; the header says what the turn
     // model says (ADR 0023), not what the fields are called.
     expect(await counts.textContent()).not.toMatch(/unread|working/)
-    await expect(counts.locator('.family-count').last()).toHaveText(/\d+ total/)
+    // `all` — the absence of a filter — goes first, where the panel
+    // opens, and carries no count: it isn't a state being tallied.
+    await expect(counts.locator('.family-count').first()).toHaveText('all')
 
     // Every state segment carries the dot its rows carry, so the header
     // reads as a key to the tree rather than a second vocabulary.
@@ -164,8 +166,8 @@ test.describe('the family line and the panel tally', () => {
       proc: n.querySelector('.family-row-proc')?.textContent ?? null,
     })))
     for (const segment of segments) {
-      if (/total/.test(segment.text ?? '')) {
-        expect(segment.dot, 'total is not a state, so it gets no glyph').toBeNull()
+      if (segment.text === 'all') {
+        expect(segment.dot, 'all is not a state, so it gets no glyph').toBeNull()
         expect(segment.proc).toBeNull()
         continue
       }
@@ -218,12 +220,51 @@ test.describe('the family line and the panel tally', () => {
     expect(running.some(t => t.startsWith('investigate a really long descendant'))).toBe(false)
     await expect(page.locator('.family-row[aria-current="page"]')).toBeVisible()
 
-    // Pressing the live filter clears it; so does `total`.
+    // Pressing the live filter clears it; so does `all`.
     await tally('running').click()
     expect(await titles()).toEqual(unfiltered)
     await tally('error').click()
     expect((await titles()).length).toBeLessThan(unfiltered.length)
-    await tally('total').click()
+    await tally('all').click()
     expect(await titles()).toEqual(unfiltered)
+  })
+
+  test('each filter offers its own bulk action, and none is ambient', async ({ page }) => {
+    await openMockSidebar(page, '/my-project/claude/~fam2kid')
+    await page.locator('[aria-controls="agent-family-drawer"]').first().click()
+    const counts = page.locator('.family-counts')
+    await counts.waitFor()
+    const tally = (label: string) => counts.locator('.family-count').filter({ hasText: label })
+    const action = page.locator('.family-mark-read')
+
+    // No filter, no verb: a bulk action only exists while you are
+    // looking at the complete list of what it will touch.
+    await expect(action).toHaveCount(0)
+
+    const expected: [string, string][] = [
+      ['waiting', 'Mark all read'],
+      ['error', 'Mark all read'],
+      ['running', 'Stop all'],
+      ['active', 'Interrupt all'],
+    ]
+    for (const [state, verb] of expected) {
+      await tally(state).click()
+      await expect(action).toHaveText(verb)
+      await tally('all').click()
+      await expect(action).toHaveCount(0)
+    }
+
+    // The waiting action still acts — and only on the waiting members.
+    const reads: string[] = []
+    await page.route('**/v1/sessions/**/read*', route => {
+      reads.push(route.request().url())
+      route.fulfill({ status: 200, body: '{}' })
+    })
+    await tally('waiting').click()
+    await action.click()
+    await expect.poll(() => reads.length).toBeGreaterThan(0)
+    // Only fam1kid is `waiting` in this family: the errored member is
+    // under `error`, precedence keeps it out of this verb's reach.
+    expect(reads.every(url => url.includes('fam1kid'))).toBe(true)
   })
 })

--- a/e2e/tests/family-entry-interaction.spec.ts
+++ b/e2e/tests/family-entry-interaction.spec.ts
@@ -184,4 +184,46 @@ test.describe('the family line and the panel tally', () => {
     expect(segments.some(s => /running/.test(s.text ?? '')), 'a running process in the fixtures').toBe(true)
     expect(segments.some(s => /waiting|active|error/.test(s.text ?? ''))).toBe(true)
   })
+
+  test('each tally filters the tree to its own state, and back', async ({ page }) => {
+    // Standing on an `active` member, so the `error` filter excludes the
+    // very row you're on — the case that has to keep working.
+    await openMockSidebar(page, '/my-project/claude/~fam2kid')
+    await page.locator('[aria-controls="agent-family-drawer"]').first().click()
+    const counts = page.locator('.family-counts')
+    await counts.waitFor()
+    const rows = page.locator('.family-row')
+    const titles = () => rows.evaluateAll(nodes =>
+      nodes.map(n => n.querySelector('.family-row-title')?.textContent ?? ''))
+    const tally = (label: string) => counts.locator('.family-count').filter({ hasText: label })
+
+    const unfiltered = await titles()
+    expect(unfiltered.length).toBeGreaterThan(4)
+
+    await tally('error').click()
+    await expect(tally('error')).toHaveAttribute('aria-pressed', 'true')
+    const errored = await titles()
+    expect(errored.length).toBeLessThan(unfiltered.length)
+    expect(errored.some(t => t.startsWith('investigate a really long descendant'))).toBe(true)
+    // Everything still on screen is either the error, an ancestor that
+    // reaches it, or you.
+    await expect(page.locator('.family-row.selected')).toHaveCount(1)
+    await expect(page.locator('.family-row[aria-current="page"]')).toBeVisible()
+
+    // A filter for a state nothing on your spine is in still keeps you.
+    await tally('running').click()
+    await expect(tally('error')).toHaveAttribute('aria-pressed', 'false')
+    const running = await titles()
+    expect(running.some(t => t.includes('pnpm test'))).toBe(true)
+    expect(running.some(t => t.startsWith('investigate a really long descendant'))).toBe(false)
+    await expect(page.locator('.family-row[aria-current="page"]')).toBeVisible()
+
+    // Pressing the live filter clears it; so does `total`.
+    await tally('running').click()
+    expect(await titles()).toEqual(unfiltered)
+    await tally('error').click()
+    expect((await titles()).length).toBeLessThan(unfiltered.length)
+    await tally('total').click()
+    expect(await titles()).toEqual(unfiltered)
+  })
 })

--- a/e2e/tests/family-entry-interaction.spec.ts
+++ b/e2e/tests/family-entry-interaction.spec.ts
@@ -143,4 +143,33 @@ test.describe('the family line and the panel tally', () => {
     const glyphColumn = withMember[0]!.memberGlyphX
     for (const g of withoutMember) expect(g!.plusX).toBe(glyphColumn)
   })
+
+  test("the panel's tally names states in the turn model's words", async ({ page }) => {
+    await openMockSidebar(page, '/my-project/claude/~fam2kid')
+    await page.locator('[aria-controls="agent-family-drawer"]').first().click()
+    const counts = page.locator('.family-counts')
+    await counts.waitFor()
+
+    // `unread` on the wire is "waiting on you" to a reader, and the CSS
+    // token `working` is the active dot; the header says what the turn
+    // model says (ADR 0023), not what the fields are called.
+    expect(await counts.textContent()).not.toMatch(/unread|working/)
+    await expect(counts.locator('.family-count').last()).toHaveText(/\d+ total/)
+
+    // Every state segment carries the dot its rows carry, so the header
+    // reads as a key to the tree rather than a second vocabulary.
+    const segments = await counts.locator('.family-count').evaluateAll(nodes => nodes.map(n => ({
+      text: n.textContent?.replace(/\s+/g, ' ').trim(),
+      dot: n.querySelector('.session-dot-indicator')?.className ?? null,
+    })))
+    for (const segment of segments) {
+      if (/total/.test(segment.text ?? '')) {
+        expect(segment.dot, 'total is not a state, so it gets no dot').toBeNull()
+        continue
+      }
+      expect(segment.text).toMatch(/^\d+ (error|active|waiting)$/)
+      expect(segment.dot).toMatch(/session-dot-indicator (error|working|unread)/)
+    }
+    expect(segments.some(s => /waiting|active|error/.test(s.text ?? ''))).toBe(true)
+  })
 })


### PR DESCRIPTION
Follow-up stack to #478, refining the family panel and the header around it.

## The panel
- **Line budget over per-level caps** (#4931efb): the panel charges rows *and* `+N more` summaries against one whole-tree budget, with relative staleness (6h against the family's newest output) and an 8-row floor so finished families keep a map. Real families: 97→8, 595→8, all-live 270→25 lines.
- **Current command, not command log** (16dbfd9): triage shows one running process per agent; history stays behind the ordinary folds.
- **Mark a whole family read** (b777c58) — plus an indexed optimistic overlay (08525b8) so 250 pending marks recompute in ~1ms instead of ~64ms.
- **Tally in the turn model's words** (b9ffad4, 1f91fda): icon-led segments — `● N error · ○ N active · $ N running · ● N waiting` — running commands counted apart from thinking agents.
- **The tally is the filter** (ec9398d): pressing a segment shows those members, their reaching ancestors, and your own pinned spine — nothing else. Filter and count derive from one rule (`familyStateOf`), so `3 error` can never show four rows. A filter turns triage off wholesale: asked for the errors, you get the two-day-old one.
- **Each filter has its verb** (ce1c7a9): `waiting`/`error` → Mark all read, `running` → Stop all, `active` → Interrupt all (the daemon's `/cancel`, 409-tolerant for bulk races). No verb is ambient: it only exists while you're looking at the complete list of what it touches. `all` leads the segments and is the way back.
- **Steady width** (3d2c514): 440px min-width so filtering doesn't reflow the panel under the buttons being pressed.

## The header
- **Crumbs that survive** (003232c): 4ch per-crumb floors + explicit `min-content` on the strip (flexbox's automatic minimum computes to zero under `overflow: hidden`), verified against an 8,496-char title. Quiet ancestors no longer wear a hole where a dot would be; the `Exited (N)` chip is gone.
- **The family button speaks in dots** (c71ab40): segments previewing the tally it opens — minus yourself, since your state is the view — and the tree icon when the rest of the family has nothing to report. Hollow rings app-wide get a quarter-pixel more stroke.

Every commit is independently verified (736 unit tests, 53 e2e); interaction and geometry are mutation-proven in Playwright against `?mock` fixtures, and scale-tested against real 100–1000-member families.