### PR TITLE
feat(web): open the family panel from its sidebar indicator

### DIFF
--- a/apps/gmux-web/src/family-drawer-state.ts
+++ b/apps/gmux-web/src/family-drawer-state.ts
@@ -1,0 +1,14 @@
+import { signal } from '@preact/signals'
+
+/** A sidebar family button can ask the header-owned drawer to open.
+ * Carry the root rather than a boolean: navigation and rendering are
+ * asynchronous, so the request waits until the header belongs to the
+ * family that was actually pressed instead of flashing the old one. */
+export const familyDrawerRequest = signal<string | null>(null)
+
+export function requestFamilyDrawer(rootId: string) {
+  // Clear first so pressing the same already-open family after closing
+  // it is still a new signal update.
+  familyDrawerRequest.value = null
+  familyDrawerRequest.value = rootId
+}

--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -15,6 +15,7 @@ import { usePresence } from './use-presence'
 import { lifecycleAction } from './session-actions'
 import { MenuButton } from './menu-button'
 import { FamilyDrawer } from './family-drawer'
+import { familyDrawerRequest } from './family-drawer-state'
 import { familyAncestors, familyRoot, familySegments, hasFamily, promotionAction, promotionCopy } from './family'
 import { FamilyIcon } from './family-icon'
 
@@ -187,9 +188,16 @@ function MainHeader({ session, onRestart, onResume, resuming }: {
   const familyTriggerRef = useRef<HTMLButtonElement>(null)
   const closeFamily = useCallback(() => { setFamilyOpen(false) }, [])
   const showFamily = session ? hasFamily(session, sessions.value) : false
+  const requestedFamily = familyDrawerRequest.value
   useEffect(() => {
     if (!showFamily) setFamilyOpen(false)
   }, [showFamily])
+  useEffect(() => {
+    if (!session || !requestedFamily) return
+    if (familyRoot(session, sessions.value).id !== requestedFamily) return
+    setFamilyOpen(true)
+    familyDrawerRequest.value = null
+  }, [session?.id, requestedFamily])
 
   if (!session) {
     return (

--- a/apps/gmux-web/src/sidebar.tsx
+++ b/apps/gmux-web/src/sidebar.tsx
@@ -9,6 +9,7 @@ import { useState, useCallback, useRef, useEffect } from 'preact/hooks'
 import { needsReveal } from './sidebar-reveal'
 import { hasSessionSlugCollision, sessionPath, viewToPath } from './routing'
 import { FamilyIcon } from './family-icon'
+import { requestFamilyDrawer } from './family-drawer-state'
 import { selectorLabel, folderMatchesFilter, type Selector } from './tab-filter'
 import { reorderKeysForFolder } from './projects'
 import { LaunchButton } from './launcher'
@@ -236,7 +237,17 @@ function SessionItem({
  *  running process — each segment dropped at zero. It's a count, not a
  *  destination, so it has no target of its own; like the rest of the
  *  entry's slack it belongs to the group, which selects the root. */
-function FamilyActivityLine({ activity }: { activity: FamilyActivity | undefined }) {
+function FamilyActivityLine({
+  activity,
+  rootId,
+  rootHref,
+  onClick,
+}: {
+  activity: FamilyActivity | undefined
+  rootId: string
+  rootHref: string
+  onClick?: () => void
+}) {
   // `familyActivityById` holds an entry only when something is non-zero,
   // so absence is the whole of "nothing to report" — one spelling of
   // the question, here, instead of one per call site.
@@ -244,7 +255,18 @@ function FamilyActivityLine({ activity }: { activity: FamilyActivity | undefined
   const segments = familySegments(activity)
   const label = familyActivityLabel(activity)
   return (
-    <div class="family-sub family-activity" title={label}>
+    <button
+      type="button"
+      class="family-sub family-activity"
+      title={label}
+      aria-label={`${label}. Open family panel`}
+      aria-controls="agent-family-drawer"
+      onClick={() => {
+        navigate(rootHref)
+        requestFamilyDrawer(rootId)
+        onClick?.()
+      }}
+    >
       {/* The family mark, same as the header's trigger: this line is
         * the standard family numbers — everyone beneath the root — not
         * "the others", so it anchors to the root's glyph column rather
@@ -262,7 +284,7 @@ function FamilyActivityLine({ activity }: { activity: FamilyActivity | undefined
         ))}
       </span>
       <span class="sr-only">{label}</span>
-    </div>
+    </button>
   )
 }
 
@@ -273,10 +295,10 @@ function FamilyActivityLine({ activity }: { activity: FamilyActivity | undefined
  *  Selection and hit areas nest, the way the sessions do:
  *   - the group is the root's area. Hovering anywhere in it highlights
  *     the whole group, and any click that doesn't land on the member
- *     row selects the root — including the counts line and the slack
- *     around it, which have nothing better to do;
- *   - the member row is its own area inside that one, with its own
- *     highlight a tone above the group's;
+ *     row selects the root — including the slack around its nested
+ *     targets, which has nothing better to do;
+ *   - the member row and family-indicator button are their own areas
+ *     inside that one, each with its own hover treatment;
  *   - the background says *which family* you're in, the accent bar says
  *     *which row*, so selecting a member keeps the group lit and moves
  *     the bar down to it.
@@ -291,6 +313,7 @@ function FamilyActivityLine({ activity }: { activity: FamilyActivity | undefined
  */
 function FamilyEntry({
   selected,
+  rootId,
   rootHref,
   slot,
   slotHref,
@@ -303,6 +326,7 @@ function FamilyEntry({
 }: {
   /** Something in this family is selected — root or member. */
   selected: boolean
+  rootId: string
   rootHref: string
   slot?: FamilySlot
   slotHref?: string
@@ -375,7 +399,7 @@ function FamilyEntry({
           <span class="family-slot-title">{member.title}</span>
         </a>
       )}
-      <FamilyActivityLine activity={activity} />
+      <FamilyActivityLine activity={activity} rootId={rootId} rootHref={rootHref} onClick={onClick} />
     </div>
   )
 }
@@ -551,6 +575,7 @@ function FolderGroup({
             <FamilyEntry
               key={s.id}
               selected={selId === s.id}
+              rootId={s.id}
               rootHref={href}
               onDragOver={dragDisabled ? undefined : () => handleDragOver(i)}
               onDragEnd={dragDisabled ? undefined : () => handleDragEnd(visible)}

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -1131,18 +1131,38 @@ body {
   min-width: 0;
 }
 
-/* Activity line: the standard family numbers — everyone beneath the
-   root — one segment per state, each dropped at zero. No target of its
-   own: it's part of the group's area, so it takes the group's hover
-   and selects the root. Numbers sit a touch under the title size; the
-   glyphs keep their standard sizes. */
+/* Activity button: the standard family numbers — everyone beneath the
+   root — one segment per state, each dropped at zero. It is a nested
+   target inside the family's broad hover area and opens the same panel
+   as the header pill. Its transparent resting border reserves the
+   exact geometry of that pill outline, so hovering does not move a
+   glyph. Numbers sit a touch under the title size. */
 .family-activity {
-  padding-top: 1px;
-  padding-bottom: 4px;
+  width: 100%;
+  /* `.family-sub` aligns its content at 29px. The button's own 1px
+     border participates in that offset, so take one pixel back from
+     each horizontal padding rather than moving the family mark. */
+  padding: 1px 7px 4px 28px;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  background: transparent;
   color: var(--text-secondary);
+  font: inherit;
   font-size: 12.5px;
   line-height: 1.3;
   font-variant-numeric: tabular-nums;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.1s, color 0.1s, border-color 0.1s;
+}
+.family-activity:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+  border-color: var(--border-strong);
+}
+.family-activity:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
 }
 .family-activity-glyphs {
   display: flex;

--- a/e2e/tests/family-entry-interaction.spec.ts
+++ b/e2e/tests/family-entry-interaction.spec.ts
@@ -24,36 +24,36 @@ const familyEntry = (page: import('@playwright/test').Page, title: string) =>
   page.locator('.session-family').filter({ hasText: title })
 
 test.describe('sidebar family entry', () => {
-  test('the slack around the rows selects the root, but declines link gestures', async ({ page }) => {
+  test('the indicator is a nested button that opens the family panel', async ({ page }) => {
     await openMockSidebar(page, '/my-project/claude/~fam2kid')
     const entry = familyEntry(page, 'build watcher agent')
-    const slack = entry.locator('.family-activity')
+    const indicator = entry.locator('.family-activity')
 
-    // 1. An ordinary click on the counts line lands on the root: the
-    //    whole group is the root's hit area.
-    await slack.click()
+    await expect(indicator).toHaveJSProperty('tagName', 'BUTTON')
+    await expect(indicator).toHaveAttribute('aria-controls', 'agent-family-drawer')
+
+    // It remains inside the family's broad hit area, but hovering the
+    // nested target gives it the header button's pill treatment.
+    await indicator.hover()
+    const sidebarPill = await indicator.evaluate(el => {
+      const s = getComputedStyle(el)
+      return { borderRadius: s.borderRadius, borderColor: s.borderColor, background: s.backgroundColor }
+    })
+    expect(sidebarPill.borderRadius).toBe('999px')
+    expect(sidebarPill.borderColor).not.toBe('rgba(0, 0, 0, 0)')
+    expect(sidebarPill.background).not.toBe('rgba(0, 0, 0, 0)')
+
+    await indicator.click()
     await expect(page).toHaveURL(/~famBroot/)
+    await expect(page.locator('#agent-family-drawer')).toBeVisible()
 
-    // 2. A modified click is a link gesture (new tab, download, range
-    //    select). The slack is not a link, so it declines rather than
-    //    quietly doing something else.
-    await openMockSidebar(page, '/my-project/claude/~fam2kid')
-    await familyEntry(page, 'build watcher agent').locator('.family-activity').click({ modifiers: ['Control'] })
-    await expect(page).toHaveURL(/~fam2kid/)
-
-    // 3. A click that ends a text selection wants the text, not a
-    //    navigation.
-    const line = familyEntry(page, 'build watcher agent').locator('.family-activity')
-    const box = (await line.boundingBox())!
-    await page.mouse.move(box.x + 4, box.y + box.height / 2)
-    await page.mouse.down()
-    await page.mouse.move(box.x + box.width - 8, box.y + box.height / 2, { steps: 10 })
-    await page.mouse.up()
-    await expect(page).toHaveURL(/~fam2kid/)
-
-    // 4. The rows themselves still own their own clicks.
-    await familyEntry(page, 'orchestrator').locator('.family-slot').click()
-    await expect(page).toHaveURL(/~fam2kid/)
+    // It is a real button rather than a clickable div: keyboard users
+    // can close the panel, return to it, and open it with Enter.
+    await page.locator('.family-trigger').click()
+    await expect(page.locator('#agent-family-drawer')).toBeHidden()
+    await indicator.focus()
+    await page.keyboard.press('Enter')
+    await expect(page.locator('#agent-family-drawer')).toBeVisible()
   })
 
   test('a drop anywhere on the entry reorders exactly once', async ({ page }) => {
@@ -145,7 +145,7 @@ test.describe('the family line and the panel tally', () => {
 
   test("the panel's tally names states in the turn model's words", async ({ page }) => {
     await openMockSidebar(page, '/my-project/claude/~fam2kid')
-    await page.locator('[aria-controls="agent-family-drawer"]').first().click()
+    await page.locator('.family-trigger').click()
     const counts = page.locator('.family-counts')
     await counts.waitFor()
 
@@ -190,7 +190,7 @@ test.describe('the family line and the panel tally', () => {
     // Standing on an `active` member, so the `error` filter excludes the
     // very row you're on — the case that has to keep working.
     await openMockSidebar(page, '/my-project/claude/~fam2kid')
-    await page.locator('[aria-controls="agent-family-drawer"]').first().click()
+    await page.locator('.family-trigger').click()
     const counts = page.locator('.family-counts')
     await counts.waitFor()
     const rows = page.locator('.family-row')
@@ -230,7 +230,7 @@ test.describe('the family line and the panel tally', () => {
 
   test('each filter offers its own bulk action, and none is ambient', async ({ page }) => {
     await openMockSidebar(page, '/my-project/claude/~fam2kid')
-    await page.locator('[aria-controls="agent-family-drawer"]').first().click()
+    await page.locator('.family-trigger').click()
     const counts = page.locator('.family-counts')
     await counts.waitFor()
     const tally = (label: string) => counts.locator('.family-count').filter({ hasText: label })
@@ -298,7 +298,7 @@ test.describe('the family line and the panel tally', () => {
     // filter, not the viewport — so the count in the label is the only
     // honest statement of what the click will touch.
     await openMockSidebar(page, '/my-project/claude/~fam2kid')
-    await page.locator('[aria-controls="agent-family-drawer"]').first().click()
+    await page.locator('.family-trigger').click()
     const counts = page.locator('.family-counts')
     await counts.waitFor()
     const tally = (label: string) => counts.locator('.family-count').filter({ hasText: label })
@@ -359,7 +359,7 @@ test.describe('the family line and the panel tally', () => {
     // member the tally counts — and the `waiting` filter shows —
     // unmarked on screen.
     await openMockSidebar(page, '/my-project/claude/~famBroot')
-    await page.locator('[aria-controls="agent-family-drawer"]').first().click()
+    await page.locator('.family-trigger').click()
     const glyphs = await page.locator('.family-row').evaluateAll(rows => rows.map(row => ({
       title: row.querySelector('.family-row-title')?.textContent ?? '',
       glyph: row.querySelector('.family-proc')?.className ?? null,

--- a/e2e/tests/promote-demote-menu.spec.ts
+++ b/e2e/tests/promote-demote-menu.spec.ts
@@ -350,7 +350,7 @@ test.describe('promote/demote in the ⋮ session menu (mock fixtures)', () => {
     // one derived from the standard family numbers, and the promoted member
     // is out of the tree (it starts its own family).
     await openMock(page, '/my-project/claude/~famAkid')
-    await page.locator('[aria-controls="agent-family-drawer"]').click()
+    await page.locator('.family-trigger').click()
     await page.locator('.family-counts').waitFor()
     const titles = await page.locator('.family-row .family-row-title').allTextContents()
     expect(titles.some(t => t.includes('promoted research spike'))).toBe(false)


### PR DESCRIPTION
## Summary
- make the sidebar family indicator a keyboard-accessible button
- give it a nested pill hover area matching the header family trigger
- navigate to the family root and open its panel when activated
- address open requests by family root so navigation cannot briefly show the previously selected family's panel

## Verification
- 738 unit tests
- TypeScript, Vite, and Biome clean
- 56 Playwright tests
- deterministic `?mock` visual check at desktop width