### PR TITLE
feat(web): iterate on the sidebar family button and the session menu

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,3 +63,8 @@ messages directly. Rules that follow from this:
 - Push changes and create pull requests. Don't commit directly to
   `main`.
 - Use `./scripts/install.sh` when asked to install locally.
+- **Frontend and UI changes are developed iteratively with a human in
+  the loop.** Show the actual rendered result (screenshots against
+  `?mock` fixtures) at each design step, expect several rounds of
+  feedback, and never merge a user-facing change without explicit
+  approval. Visual design decisions are the user's to make.

--- a/apps/gmux-web/src/clipboard.ts
+++ b/apps/gmux-web/src/clipboard.ts
@@ -1,0 +1,23 @@
+/** Copy text to the clipboard, honestly: resolves false when it didn't
+ * happen. The async API needs a secure context, and gmux is served
+ * over plain http from peer hosts, so fall back to the textarea +
+ * execCommand path there (same trick the terminal's OSC 52 handler
+ * can't use — it has no user gesture to spend). */
+export async function copyText(text: string): Promise<boolean> {
+  try {
+    await navigator.clipboard.writeText(text)
+    return true
+  } catch {
+    try {
+      const ta = document.createElement('textarea')
+      ta.value = text
+      document.body.appendChild(ta)
+      ta.select()
+      const ok = document.execCommand('copy')
+      document.body.removeChild(ta)
+      return ok
+    } catch {
+      return false
+    }
+  }
+}

--- a/apps/gmux-web/src/family-drawer-state.ts
+++ b/apps/gmux-web/src/family-drawer-state.ts
@@ -1,14 +1,12 @@
 import { signal } from '@preact/signals'
 
-/** A sidebar family button can ask the header-owned drawer to open.
- * Carry the root rather than a boolean: navigation and rendering are
- * asynchronous, so the request waits until the header belongs to the
- * family that was actually pressed instead of flashing the old one. */
-export const familyDrawerRequest = signal<string | null>(null)
-
-export function requestFamilyDrawer(rootId: string) {
-  // Clear first so pressing the same already-open family after closing
-  // it is still a new signal update.
-  familyDrawerRequest.value = null
-  familyDrawerRequest.value = rootId
-}
+/** The family whose drawer is open, by root id — null when none is.
+ *
+ * One fact with one owner: whoever wants the drawer (header trigger,
+ * sidebar indicator) writes the root here, and the header shows the
+ * drawer while the selected session belongs to that family. The
+ * comparison *is* the old "wait until navigation lands" logic — a
+ * sidebar press on another family writes the root and navigates, and
+ * the drawer appears exactly when the header catches up, with no
+ * request to deliver, consume, or re-arm. */
+export const familyDrawerRoot = signal<string | null>(null)

--- a/apps/gmux-web/src/family-drawer.tsx
+++ b/apps/gmux-web/src/family-drawer.tsx
@@ -302,7 +302,12 @@ export function FamilyDrawer({ selected, onClose, triggerRef }: {
     const onPointerDown = (event: PointerEvent) => {
       const target = event.target as Node
       if (panelRef.current?.contains(target)) return
-      if (triggerRef.current?.contains(target)) return // trigger's own click toggles
+      // Anything that declares itself a control of this drawer (the
+      // header trigger, the sidebar indicator) toggles on its own
+      // click — closing here on the pointerdown would flip the drawer
+      // shut a beat early, and the control's click would reopen it.
+      const el = target instanceof Element ? target : target.parentElement
+      if (el?.closest('[aria-controls="agent-family-drawer"]')) return
       onClose()
     }
     document.addEventListener('keydown', onKey)

--- a/apps/gmux-web/src/family.test.ts
+++ b/apps/gmux-web/src/family.test.ts
@@ -189,29 +189,28 @@ describe('task-family projection', () => {
       expect(promotionCopy(action!).note).toContain('no row of its own')
     })
 
-    it('says that promotion keeps ownership and names the demote target', () => {
+    it('carries no note when the action is offerable — notes are for blockers', () => {
       const root = agent('root', undefined, { title: 'orchestrator' })
       const child = agent('child', 'root')
       const promote = promotionCopy(promotionAction(child, [root, child], placed)!)
       expect(promote.label).toBe('Promote to root')
-      expect(promote.note).toBe('Shows as its own top-level session — orchestrator still owns it')
+      expect(promote.note).toBeUndefined()
       const promoted = agent('promoted', 'root', { promoted_to_root: true })
       const demote = promotionCopy(promotionAction(promoted, [root, promoted], placed)!)
       expect(demote.label).toBe('Return to family')
-      expect(demote.note).toBe('Groups back under orchestrator')
+      expect(demote.note).toBeUndefined()
     })
 
-    it('pins every pending string, label and note, both kinds', () => {
+    it('pins the pending labels, both kinds', () => {
       const root = agent('root', undefined, { title: 'orchestrator' })
       const child = agent('child', 'root')
       const pendingPromote = promotionCopy(promotionAction(child, [root, child], placed)!, true)
       expect(pendingPromote.label).toBe('Promoting…')
-      // The explanation stays: what the click did is still true mid-flight.
-      expect(pendingPromote.note).toBe('Shows as its own top-level session — orchestrator still owns it')
+      expect(pendingPromote.note).toBeUndefined()
       const promoted = agent('promoted', 'root', { promoted_to_root: true })
       const pendingDemote = promotionCopy(promotionAction(promoted, [root, promoted], placed)!, true)
       expect(pendingDemote.label).toBe('Returning…')
-      expect(pendingDemote.note).toBe('Groups back under orchestrator')
+      expect(pendingDemote.note).toBeUndefined()
     })
   })
 

--- a/apps/gmux-web/src/family.ts
+++ b/apps/gmux-web/src/family.ts
@@ -230,12 +230,13 @@ export function promotionAction(
 }
 
 /** The words the menu says for a promotion action. Centralized so every
- * surface (and its tests) quotes one copy: promotion must say that
- * ownership is not severed, and demotion must name the current parent.
+ * surface (and its tests) quotes one copy. A note appears only when the
+ * action is blocked — a disabled item owes its reason, but an offerable
+ * verb explains itself and a subtext under it is noise.
  * `pending` is the in-flight state (same convention as `lifecycleAction`'s
  * resuming labels): the request left, the authoritative snapshot hasn't
  * flipped the projection yet, and the item is busy rather than offerable. */
-export function promotionCopy(action: PromotionAction, pending = false): { label: string; note: string } {
+export function promotionCopy(action: PromotionAction, pending = false): { label: string; note?: string } {
   if (action.blocked === 'no-project') {
     return {
       label: action.kind === 'promote' ? 'Promote to root' : 'Return to family',
@@ -244,14 +245,8 @@ export function promotionCopy(action: PromotionAction, pending = false): { label
         : 'Unavailable: the family root has no project-backed sidebar row. Add one in Settings → Projects before returning this session to its family.',
     }
   }
-  if (pending) {
-    return action.kind === 'promote'
-      ? { label: 'Promoting…', note: `Shows as its own top-level session — ${action.parent.title} still owns it` }
-      : { label: 'Returning…', note: `Groups back under ${action.parent.title}` }
-  }
-  return action.kind === 'promote'
-    ? { label: 'Promote to root', note: `Shows as its own top-level session — ${action.parent.title} still owns it` }
-    : { label: 'Return to family', note: `Groups back under ${action.parent.title}` }
+  if (pending) return { label: action.kind === 'promote' ? 'Promoting…' : 'Returning…' }
+  return { label: action.kind === 'promote' ? 'Promote to root' : 'Return to family' }
 }
 
 export interface FamilyNode {

--- a/apps/gmux-web/src/input-diagnostics.tsx
+++ b/apps/gmux-web/src/input-diagnostics.tsx
@@ -15,6 +15,7 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from 'preact/hooks'
+import { copyText } from './clipboard'
 import { Terminal } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
 import { TERM_THEME } from './terminal'
@@ -241,19 +242,9 @@ export default function InputDiagnostics() {
 
   const handleCopy = useCallback(async () => {
     const report = buildReport(entries)
-    try {
-      await navigator.clipboard.writeText(report)
-      addEntry('info', 'Diagnostics copied to clipboard!')
-    } catch {
-      // Fallback: select a textarea
-      const ta = document.createElement('textarea')
-      ta.value = report
-      document.body.appendChild(ta)
-      ta.select()
-      document.execCommand('copy')
-      document.body.removeChild(ta)
-      addEntry('info', 'Diagnostics copied to clipboard (fallback).')
-    }
+    addEntry('info', await copyText(report)
+      ? 'Diagnostics copied to clipboard!'
+      : 'Copy failed — select the log text manually.')
   }, [entries, addEntry])
 
   const handleClear = useCallback(() => {

--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -15,7 +15,7 @@ import { usePresence } from './use-presence'
 import { lifecycleAction } from './session-actions'
 import { MenuButton } from './menu-button'
 import { FamilyDrawer } from './family-drawer'
-import { familyDrawerRequest } from './family-drawer-state'
+import { familyDrawerRoot } from './family-drawer-state'
 import { familyAncestors, familyRoot, familySegments, hasFamily, promotionAction, promotionCopy } from './family'
 import { FamilyIcon } from './family-icon'
 
@@ -173,20 +173,25 @@ function MainHeader({ session, onRestart, onResume, resuming }: {
   onResume?: (id: string) => void
   resuming?: boolean
 }) {
-  const [familyOpen, setFamilyOpen] = useState(false)
   const familyTriggerRef = useRef<HTMLButtonElement>(null)
-  const closeFamily = useCallback(() => { setFamilyOpen(false) }, [])
   const showFamily = session ? hasFamily(session, sessions.value) : false
-  const requestedFamily = familyDrawerRequest.value
+  const rootId = session && showFamily ? familyRoot(session, sessions.value).id : null
+  // Open-ness is a comparison, not stored state: the drawer shows while
+  // the selected session belongs to the family named in the signal.
+  const familyOpen = rootId !== null && familyDrawerRoot.value === rootId
+  const closeFamily = useCallback(() => { familyDrawerRoot.value = null }, [])
+  // Leaving the family closes its drawer — otherwise returning later
+  // would pop it back open. Keyed to what the header *is* (its session
+  // and that session's family), never to the signal: a sidebar press on
+  // another family writes the signal before navigating, and that moment
+  // moves neither dependency, so the press survives the trip. Anything
+  // that genuinely moves the header — navigation, or a reparent that
+  // changes this session's root under it — settles the signal here.
   useEffect(() => {
-    if (!showFamily) setFamilyOpen(false)
-  }, [showFamily])
-  useEffect(() => {
-    if (!session || !requestedFamily) return
-    if (familyRoot(session, sessions.value).id !== requestedFamily) return
-    setFamilyOpen(true)
-    familyDrawerRequest.value = null
-  }, [session?.id, requestedFamily])
+    if (familyDrawerRoot.value !== null && familyDrawerRoot.value !== rootId) {
+      familyDrawerRoot.value = null
+    }
+  }, [session?.id, rootId])
 
   if (!session) {
     return (
@@ -206,7 +211,7 @@ function MainHeader({ session, onRestart, onResume, resuming }: {
             session={session}
             open={familyOpen}
             triggerRef={familyTriggerRef}
-            onToggle={() => { setFamilyOpen(v => !v) }}
+            onToggle={() => { familyDrawerRoot.value = familyOpen ? null : rootId }}
           />
         )}
         {showFamily && <HeaderCrumbs session={session} />}

--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -26,6 +26,7 @@ import { installCopySession } from './mock-data/export-session'
 import { installVersionWatch } from './version-watch'
 import { ToastHost } from './toast-host'
 import { pushError } from './toasts'
+import { copyText } from './clipboard'
 
 import {
   sessions, connState, selected, selectedId, view, health, peers, projects,
@@ -130,19 +131,7 @@ class ErrorBoundary extends Component<
   }
 
   copyReport = async () => {
-    // Clipboard-then-textarea fallback, matching input-diagnostics so the
-    // copy works in non-secure contexts / older browsers too.
-    try {
-      await navigator.clipboard.writeText(this.state.report)
-    } catch {
-      const ta = document.createElement('textarea')
-      ta.value = this.state.report
-      document.body.appendChild(ta)
-      ta.select()
-      document.execCommand('copy')
-      document.body.removeChild(ta)
-    }
-    this.setState({ copied: true })
+    if (await copyText(this.state.report)) this.setState({ copied: true })
   }
 
   render() {
@@ -326,6 +315,9 @@ function SessionMenu({ session, onRestart, onResume, resuming }: {
   resuming?: boolean
 }) {
   const [open, setOpen] = useState(false)
+  // Copy feedback for the ID row; the trigger resets it on open, so a
+  // reopened menu offers the copy fresh instead of a stale check.
+  const [copied, setCopied] = useState(false)
   const menuRef = useRef<HTMLDivElement>(null)
   const triggerRef = useRef<HTMLButtonElement>(null)
   const healthVal = health.value
@@ -417,7 +409,7 @@ function SessionMenu({ session, onRestart, onResume, resuming }: {
       <button
         ref={triggerRef}
         class={`session-menu-trigger${staleKind ? ' stale' : ''}`}
-        onClick={() => setOpen(!open)}
+        onClick={() => { if (!open) setCopied(false); setOpen(!open) }}
         title="Session actions"
         // The visible content is a bare "⋮" glyph, which is also what a
         // screen reader would announce without this (every other icon
@@ -444,22 +436,12 @@ function SessionMenu({ session, onRestart, onResume, resuming }: {
               Find in terminal
             </button>
           )}
-          {action && actionHandler && (
-            <button
-              class={`session-menu-action${showStale ? ' stale' : ''}`}
-              disabled={action.disabled}
-              onClick={() => { setOpen(false); actionHandler() }}
-            >
-              {action.label}
-              {showStale && <span class="session-menu-action-tag">outdated</span>}
-            </button>
-          )}
           {promotion && promotionWords && (
             <button
               class="session-menu-action session-menu-promotion"
               disabled={promotionInFlight}
               aria-disabled={promotionBlocked ? 'true' : undefined}
-              aria-describedby="session-promotion-note"
+              aria-describedby={promotionWords.note ? 'session-promotion-note' : undefined}
               onClick={e => {
                 if (promotionInFlight || promotionBlocked) {
                   e.preventDefault()
@@ -483,11 +465,45 @@ function SessionMenu({ session, onRestart, onResume, resuming }: {
               }}
             >
               {promotionWords.label}
-              <span id="session-promotion-note" class="session-menu-action-note">{promotionWords.note}</span>
+              {promotionWords.note && (
+                <span id="session-promotion-note" class="session-menu-action-note">{promotionWords.note}</span>
+              )}
+            </button>
+          )}
+          {/* Lifecycle last: Restart/Resume is the heaviest verb here, and a
+            * fixed bottom slot keeps it out of the muscle-memory path of the
+            * lighter actions above. */
+          }
+          {action && actionHandler && (
+            <button
+              class={`session-menu-action${showStale ? ' stale' : ''}`}
+              disabled={action.disabled}
+              onClick={() => { setOpen(false); actionHandler() }}
+            >
+              {action.label}
+              {showStale && <span class="session-menu-action-tag">outdated</span>}
             </button>
           )}
           {(canFind || (action && actionHandler) || promotion) && <div class="session-menu-divider" />}
           <div class="session-menu-section-title">Session info</div>
+          <div class="session-menu-row">
+            <span class="session-menu-label">ID</span>
+            <span class="session-menu-value session-menu-id">
+              {session.id}
+              <button
+                class="session-menu-copy"
+                aria-label="Copy session ID"
+                title="Copy session ID"
+                onClick={() => {
+                  // The check reports the write, not the wish: over plain
+                  // http the async API is missing entirely.
+                  void copyText(session.id).then(ok => { if (ok) setCopied(true) })
+                }}
+              >
+                {copied ? <IconCheck /> : <IconCopy />}
+              </button>
+            </span>
+          </div>
           <div class="session-menu-row">
             <span class="session-menu-label">Adapter</span>
             <span class="session-menu-value">
@@ -512,6 +528,18 @@ function SessionMenu({ session, onRestart, onResume, resuming }: {
     </div>
   )
 }
+
+const IconCopy = () => (
+  <svg viewBox="0 0 14 14" width="12" height="12" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linejoin="round">
+    <rect x="4.5" y="4.5" width="7" height="7" rx="1.5" />
+    <path d="M9.5 3V2.5A1.5 1.5 0 0 0 8 1H3.5A1.5 1.5 0 0 0 2 2.5V8a1.5 1.5 0 0 0 1.5 1.5H3" />
+  </svg>
+)
+const IconCheck = () => (
+  <svg viewBox="0 0 14 14" width="12" height="12" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M2.5 7.5 5.5 10.5 11.5 3.5" />
+  </svg>
+)
 
 // ── Mobile nav icons ─────────────────────────────────────────────────────────
 

--- a/apps/gmux-web/src/sidebar.tsx
+++ b/apps/gmux-web/src/sidebar.tsx
@@ -9,7 +9,7 @@ import { useState, useCallback, useRef, useEffect } from 'preact/hooks'
 import { needsReveal } from './sidebar-reveal'
 import { hasSessionSlugCollision, sessionPath, viewToPath } from './routing'
 import { FamilyIcon } from './family-icon'
-import { requestFamilyDrawer } from './family-drawer-state'
+import { familyDrawerRoot } from './family-drawer-state'
 import { selectorLabel, folderMatchesFilter, type Selector } from './tab-filter'
 import { reorderKeysForFolder } from './projects'
 import { LaunchButton } from './launcher'
@@ -262,8 +262,20 @@ function FamilyActivityLine({
       aria-label={`${label}. Open family panel`}
       aria-controls="agent-family-drawer"
       onClick={() => {
+        // A second press dismisses: if the panel is already open and
+        // there is nowhere left to navigate, the press can only mean
+        // "put it away". While elsewhere in the family it navigates to
+        // the root instead, and the open drawer simply follows.
+        if (familyDrawerRoot.value === rootId && selectedId.value === rootId) {
+          familyDrawerRoot.value = null
+          return
+        }
+        // Name the family first, then go: the header opens the drawer
+        // when it arrives somewhere that family owns. Stating the want
+        // before the trip also keeps it true if navigation ever became
+        // synchronous — the arrival would already agree with it.
+        familyDrawerRoot.value = rootId
         navigate(rootHref)
-        requestFamilyDrawer(rootId)
         onClick?.()
       }}
     >

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -1134,17 +1134,23 @@ body {
 /* Activity button: the standard family numbers — everyone beneath the
    root — one segment per state, each dropped at zero. It is a nested
    target inside the family's broad hover area and opens the same panel
-   as the header pill. Its transparent resting border reserves the
-   exact geometry of that pill outline, so hovering does not move a
-   glyph. Numbers sit a touch under the title size. */
+   as the header's trigger, but it does not borrow that pill: the
+   sidebar's design language is flat rows with background hovers, so it
+   takes the member row's exact treatment — one tone above the group's,
+   in both states. Unlike that row it is not a navigation target, so it
+   does not claim the full row: the hit area stops where the numbers
+   do, and the slack to the right stays the root's, like the rest of
+   the entry's slack. Numbers sit a touch under the title size. */
 .family-activity {
-  width: 100%;
-  /* `.family-sub` aligns its content at 29px. The button's own 1px
-     border participates in that offset, so take one pixel back from
-     each horizontal padding rather than moving the family mark. */
-  padding: 1px 7px 4px 28px;
-  border: 1px solid transparent;
-  border-radius: 999px;
+  width: fit-content;
+  /* Clip, not spill, at the sidebar's narrowest. */
+  max-width: calc(100% - 21px);
+  /* `.family-sub` puts the glyph column at 29px; reach it with margin
+     + padding (21 + 8) so the gutter stays outside the hit area. */
+  margin: 0 0 2px 21px;
+  padding: 1px 8px 2px 8px;
+  border: 0;
+  border-radius: 3px;
   background: transparent;
   color: var(--text-secondary);
   font: inherit;
@@ -1153,12 +1159,12 @@ body {
   font-variant-numeric: tabular-nums;
   text-align: left;
   cursor: pointer;
-  transition: background 0.1s, color 0.1s, border-color 0.1s;
 }
 .family-activity:hover {
-  background: var(--bg-hover);
-  color: var(--text);
-  border-color: var(--border-strong);
+  background: oklch(26% 0.02 250);
+}
+.session-family.selected .family-activity:hover {
+  background: oklch(30% 0.02 250);
 }
 .family-activity:focus-visible {
   outline: 2px solid var(--accent);

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -2697,6 +2697,31 @@ body {
   color: var(--text-secondary);
 }
 
+/* The ID row: monospace value with a minimal inline copy button — icon
+   only, ghost until hovered, sized to disappear into the row. */
+.session-menu-id {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.session-menu-copy {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  border: 0;
+  border-radius: 3px;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+.session-menu-copy:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+
 .session-menu-value.stale {
   color: oklch(80% 0.15 65);
 }

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -1053,14 +1053,22 @@ body {
 /* Sub-rows share one fixed indent: a glyph column under the root title
    (14px pad + 7px dot + 8px gap), then content. The member row puts
    its status there and the activity line its branch, so the two rows
-   line up on both columns. */
+   line up on both columns. The indent is a variable because the
+   activity button reaches the same column by a different route —
+   see `.family-activity`. */
+.session-family {
+  --family-indent: 29px;
+  /* The activity button's own inner padding, subtracted from the
+     indent so its glyph still lands on the column. */
+  --family-pill-pad: 8px;
+}
 .family-sub {
   position: relative;
   display: flex;
   align-items: center;
   gap: 6px;
   min-width: 0;
-  padding: 3px 8px 3px 29px;
+  padding: 3px 8px 3px var(--family-indent);
 }
 
 /* Every glyph in that column occupies the same width, whatever it is,
@@ -1143,12 +1151,15 @@ body {
    the entry's slack. Numbers sit a touch under the title size. */
 .family-activity {
   width: fit-content;
+  /* The row's indent, split: the part before the hit area is margin,
+     the rest is the button's own padding, so the glyph lands on the
+     shared column and the gutter left of it still belongs to the root.
+     Derived, so the two rows cannot drift apart. */
+  --family-pill-inset: calc(var(--family-indent) - var(--family-pill-pad));
   /* Clip, not spill, at the sidebar's narrowest. */
-  max-width: calc(100% - 21px);
-  /* `.family-sub` puts the glyph column at 29px; reach it with margin
-     + padding (21 + 8) so the gutter stays outside the hit area. */
-  margin: 0 0 2px 21px;
-  padding: 1px 8px 2px 8px;
+  max-width: calc(100% - var(--family-pill-inset));
+  margin: 0 0 2px var(--family-pill-inset);
+  padding: 1px var(--family-pill-pad) 2px var(--family-pill-pad);
   border: 0;
   border-radius: 3px;
   background: transparent;

--- a/e2e/tests/family-entry-interaction.spec.ts
+++ b/e2e/tests/family-entry-interaction.spec.ts
@@ -32,16 +32,29 @@ test.describe('sidebar family entry', () => {
     await expect(indicator).toHaveJSProperty('tagName', 'BUTTON')
     await expect(indicator).toHaveAttribute('aria-controls', 'agent-family-drawer')
 
-    // It remains inside the family's broad hit area, but hovering the
-    // nested target gives it the header button's pill treatment.
-    await indicator.hover()
-    const sidebarPill = await indicator.evaluate(el => {
-      const s = getComputedStyle(el)
-      return { borderRadius: s.borderRadius, borderColor: s.borderColor, background: s.backgroundColor }
-    })
-    expect(sidebarPill.borderRadius).toBe('999px')
-    expect(sidebarPill.borderColor).not.toBe('rgba(0, 0, 0, 0)')
-    expect(sidebarPill.background).not.toBe('rgba(0, 0, 0, 0)')
+    // It remains inside the family's broad hit area, and hovering the
+    // nested target answers in the sidebar's own language: the member
+    // row's background treatment, not the header's bordered pill.
+    const hoverBg = async (loc: typeof indicator) => {
+      await loc.hover()
+      return loc.evaluate(el => getComputedStyle(el).backgroundColor)
+    }
+    // Both nested targets wear one treatment, tone-matched to their
+    // group's state — compare within one entry (the selected family
+    // shows both rows; this quiet one shows no member row).
+    const selectedEntry = familyEntry(page, 'orchestrator')
+    expect(await hoverBg(selectedEntry.locator('.family-activity')), 'same hover as the member row above')
+      .toBe(await hoverBg(selectedEntry.locator('.family-slot')))
+    expect(await indicator.evaluate(el => getComputedStyle(el).borderStyle)).toBe('none')
+
+    // The hit area stops where the numbers do: the slack to its right
+    // belongs to the root, like the rest of the entry's slack — a
+    // click there must select the root without opening the panel.
+    const rowBox = (await entry.boundingBox())!
+    const buttonBox = (await indicator.boundingBox())!
+    await page.mouse.click(rowBox.x + rowBox.width - 12, buttonBox.y + buttonBox.height / 2)
+    await expect(page).toHaveURL(/~famBroot/)
+    await expect(page.locator('#agent-family-drawer')).toBeHidden()
 
     await indicator.click()
     await expect(page).toHaveURL(/~famBroot/)

--- a/e2e/tests/family-entry-interaction.spec.ts
+++ b/e2e/tests/family-entry-interaction.spec.ts
@@ -67,6 +67,22 @@ test.describe('sidebar family entry', () => {
     await indicator.focus()
     await page.keyboard.press('Enter')
     await expect(page.locator('#agent-family-drawer')).toBeVisible()
+
+    // With the panel open and nowhere left to navigate, a second press
+    // is a dismissal — the indicator toggles rather than insists.
+    await indicator.click()
+    await expect(page.locator('#agent-family-drawer')).toBeHidden()
+    await indicator.click()
+    await expect(page.locator('#agent-family-drawer')).toBeVisible()
+
+    // Leaving the family closes its drawer, and coming back does not
+    // pop it open again: open-ness is a statement about the present,
+    // not a preference to be remembered.
+    await familyEntry(page, 'orchestrator').locator('.family-slot').click()
+    await expect(page.locator('#agent-family-drawer')).toBeHidden()
+    await page.goBack()
+    await expect(page).toHaveURL(/~famBroot/)
+    await expect(page.locator('#agent-family-drawer')).toBeHidden()
   })
 
   test('a drop anywhere on the entry reorders exactly once', async ({ page }) => {

--- a/e2e/tests/promote-demote-menu.spec.ts
+++ b/e2e/tests/promote-demote-menu.spec.ts
@@ -37,10 +37,9 @@ test.describe('promote/demote in the ⋮ session menu (mock fixtures)', () => {
     const item = promotionItem(page)
     await expect(item).toHaveCount(1)
     await expect(item).toContainText('Promote to root')
-    // Promotion must not read as severing ownership: the note names the
-    // parent that keeps the child.
-    await expect(item.locator('.session-menu-action-note'))
-      .toHaveText('Shows as its own top-level session — implement drawer still owns it')
+    // An offerable verb explains itself: subtext is reserved for
+    // blocked actions, which owe their reason.
+    await expect(item.locator('.session-menu-action-note')).toHaveCount(0)
 
     const posts: string[] = []
     await page.route('**/v1/sessions/**', async (route) => {
@@ -67,8 +66,7 @@ test.describe('promote/demote in the ⋮ session menu (mock fixtures)', () => {
     await openMenu(page)
     const item = promotionItem(page)
     await expect(item).toContainText('Return to family')
-    await expect(item.locator('.session-menu-action-note'))
-      .toHaveText('Groups back under a genuinely very long root agent title for truncation checks')
+    await expect(item.locator('.session-menu-action-note')).toHaveCount(0)
 
     const posts: string[] = []
     await page.route('**/v1/sessions/**', async (route) => {


### PR DESCRIPTION
Design-review iteration on #488's sidebar family indicator, plus a session-menu pass. Three commits, one per concern (absorbs #490 and #491):

### The sidebar family indicator speaks the sidebar's language
- No bordered pill: flat background hover, the member row's exact treatment, tone-matched to the group's selected state.
- No text-colour shift on hover (the content is live status dots; brightening numbers beside blinking glyphs reads as a state change).
- Hit area stops where the numbers do — the slack right of them selects the root, like the rest of the entry's slack, ending accidental panel opens.

### The session menu, quieted
- Offerable verbs carry no subtext; notes are reserved for blocked actions, which owe their reason.
- Restart/Resume moved to a fixed bottom slot.
- Session info leads with the session ID + a minimal ghost copy button. This exposed the app's third copy-to-clipboard implementation as the only dishonest one — all three now share `copyText()` with the textarea fallback, and the check reports the write, not the wish.

### The open family drawer is state, not a message
- `familyDrawerRoot` (the family whose drawer is open) replaces the request-signal handshake and the header's local boolean; the drawer renders while the selected session belongs to that family, which *is* the old "wait until navigation lands" logic.
- Leaving a family closes its drawer; returning doesn't reopen it (effect keyed to session arrival, so it can't eat a cross-family press mid-navigation).
- The indicator is now an honest toggle: panel open + nowhere to navigate ⇒ dismiss. The drawer's outside-close ignores pointerdowns on anything declaring `aria-controls` for it, so a control's own click isn't pre-empted.

### Process
Adds to AGENTS.md: frontend/UI changes are developed iteratively with a human in the loop and never merged without explicit approval.

766 unit + 81 e2e green per commit. **Awaiting design approval before merge.**