### PR TITLE
refactor(web): quiet the session menu, and hand out the session id

### DIFF
--- a/apps/gmux-web/src/clipboard.ts
+++ b/apps/gmux-web/src/clipboard.ts
@@ -1,0 +1,23 @@
+/** Copy text to the clipboard, honestly: resolves false when it didn't
+ * happen. The async API needs a secure context, and gmux is served
+ * over plain http from peer hosts, so fall back to the textarea +
+ * execCommand path there (same trick the terminal's OSC 52 handler
+ * can't use — it has no user gesture to spend). */
+export async function copyText(text: string): Promise<boolean> {
+  try {
+    await navigator.clipboard.writeText(text)
+    return true
+  } catch {
+    try {
+      const ta = document.createElement('textarea')
+      ta.value = text
+      document.body.appendChild(ta)
+      ta.select()
+      const ok = document.execCommand('copy')
+      document.body.removeChild(ta)
+      return ok
+    } catch {
+      return false
+    }
+  }
+}

--- a/apps/gmux-web/src/family.test.ts
+++ b/apps/gmux-web/src/family.test.ts
@@ -189,29 +189,28 @@ describe('task-family projection', () => {
       expect(promotionCopy(action!).note).toContain('no row of its own')
     })
 
-    it('says that promotion keeps ownership and names the demote target', () => {
+    it('carries no note when the action is offerable — notes are for blockers', () => {
       const root = agent('root', undefined, { title: 'orchestrator' })
       const child = agent('child', 'root')
       const promote = promotionCopy(promotionAction(child, [root, child], placed)!)
       expect(promote.label).toBe('Promote to root')
-      expect(promote.note).toBe('Shows as its own top-level session — orchestrator still owns it')
+      expect(promote.note).toBeUndefined()
       const promoted = agent('promoted', 'root', { promoted_to_root: true })
       const demote = promotionCopy(promotionAction(promoted, [root, promoted], placed)!)
       expect(demote.label).toBe('Return to family')
-      expect(demote.note).toBe('Groups back under orchestrator')
+      expect(demote.note).toBeUndefined()
     })
 
-    it('pins every pending string, label and note, both kinds', () => {
+    it('pins the pending labels, both kinds', () => {
       const root = agent('root', undefined, { title: 'orchestrator' })
       const child = agent('child', 'root')
       const pendingPromote = promotionCopy(promotionAction(child, [root, child], placed)!, true)
       expect(pendingPromote.label).toBe('Promoting…')
-      // The explanation stays: what the click did is still true mid-flight.
-      expect(pendingPromote.note).toBe('Shows as its own top-level session — orchestrator still owns it')
+      expect(pendingPromote.note).toBeUndefined()
       const promoted = agent('promoted', 'root', { promoted_to_root: true })
       const pendingDemote = promotionCopy(promotionAction(promoted, [root, promoted], placed)!, true)
       expect(pendingDemote.label).toBe('Returning…')
-      expect(pendingDemote.note).toBe('Groups back under orchestrator')
+      expect(pendingDemote.note).toBeUndefined()
     })
   })
 

--- a/apps/gmux-web/src/family.ts
+++ b/apps/gmux-web/src/family.ts
@@ -230,12 +230,13 @@ export function promotionAction(
 }
 
 /** The words the menu says for a promotion action. Centralized so every
- * surface (and its tests) quotes one copy: promotion must say that
- * ownership is not severed, and demotion must name the current parent.
+ * surface (and its tests) quotes one copy. A note appears only when the
+ * action is blocked — a disabled item owes its reason, but an offerable
+ * verb explains itself and a subtext under it is noise.
  * `pending` is the in-flight state (same convention as `lifecycleAction`'s
  * resuming labels): the request left, the authoritative snapshot hasn't
  * flipped the projection yet, and the item is busy rather than offerable. */
-export function promotionCopy(action: PromotionAction, pending = false): { label: string; note: string } {
+export function promotionCopy(action: PromotionAction, pending = false): { label: string; note?: string } {
   if (action.blocked === 'no-project') {
     return {
       label: action.kind === 'promote' ? 'Promote to root' : 'Return to family',
@@ -244,14 +245,8 @@ export function promotionCopy(action: PromotionAction, pending = false): { label
         : 'Unavailable: the family root has no project-backed sidebar row. Add one in Settings → Projects before returning this session to its family.',
     }
   }
-  if (pending) {
-    return action.kind === 'promote'
-      ? { label: 'Promoting…', note: `Shows as its own top-level session — ${action.parent.title} still owns it` }
-      : { label: 'Returning…', note: `Groups back under ${action.parent.title}` }
-  }
-  return action.kind === 'promote'
-    ? { label: 'Promote to root', note: `Shows as its own top-level session — ${action.parent.title} still owns it` }
-    : { label: 'Return to family', note: `Groups back under ${action.parent.title}` }
+  if (pending) return { label: action.kind === 'promote' ? 'Promoting…' : 'Returning…' }
+  return { label: action.kind === 'promote' ? 'Promote to root' : 'Return to family' }
 }
 
 export interface FamilyNode {

--- a/apps/gmux-web/src/input-diagnostics.tsx
+++ b/apps/gmux-web/src/input-diagnostics.tsx
@@ -15,6 +15,7 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from 'preact/hooks'
+import { copyText } from './clipboard'
 import { Terminal } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
 import { TERM_THEME } from './terminal'
@@ -241,19 +242,9 @@ export default function InputDiagnostics() {
 
   const handleCopy = useCallback(async () => {
     const report = buildReport(entries)
-    try {
-      await navigator.clipboard.writeText(report)
-      addEntry('info', 'Diagnostics copied to clipboard!')
-    } catch {
-      // Fallback: select a textarea
-      const ta = document.createElement('textarea')
-      ta.value = report
-      document.body.appendChild(ta)
-      ta.select()
-      document.execCommand('copy')
-      document.body.removeChild(ta)
-      addEntry('info', 'Diagnostics copied to clipboard (fallback).')
-    }
+    addEntry('info', await copyText(report)
+      ? 'Diagnostics copied to clipboard!'
+      : 'Copy failed — select the log text manually.')
   }, [entries, addEntry])
 
   const handleClear = useCallback(() => {

--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -26,6 +26,7 @@ import { installCopySession } from './mock-data/export-session'
 import { installVersionWatch } from './version-watch'
 import { ToastHost } from './toast-host'
 import { pushError } from './toasts'
+import { copyText } from './clipboard'
 
 import {
   sessions, connState, selected, selectedId, view, health, peers, projects,
@@ -130,19 +131,7 @@ class ErrorBoundary extends Component<
   }
 
   copyReport = async () => {
-    // Clipboard-then-textarea fallback, matching input-diagnostics so the
-    // copy works in non-secure contexts / older browsers too.
-    try {
-      await navigator.clipboard.writeText(this.state.report)
-    } catch {
-      const ta = document.createElement('textarea')
-      ta.value = this.state.report
-      document.body.appendChild(ta)
-      ta.select()
-      document.execCommand('copy')
-      document.body.removeChild(ta)
-    }
-    this.setState({ copied: true })
+    if (await copyText(this.state.report)) this.setState({ copied: true })
   }
 
   render() {
@@ -326,6 +315,9 @@ function SessionMenu({ session, onRestart, onResume, resuming }: {
   resuming?: boolean
 }) {
   const [open, setOpen] = useState(false)
+  // Copy feedback for the ID row; the trigger resets it on open, so a
+  // reopened menu offers the copy fresh instead of a stale check.
+  const [copied, setCopied] = useState(false)
   const menuRef = useRef<HTMLDivElement>(null)
   const triggerRef = useRef<HTMLButtonElement>(null)
   const healthVal = health.value
@@ -417,7 +409,7 @@ function SessionMenu({ session, onRestart, onResume, resuming }: {
       <button
         ref={triggerRef}
         class={`session-menu-trigger${staleKind ? ' stale' : ''}`}
-        onClick={() => setOpen(!open)}
+        onClick={() => { if (!open) setCopied(false); setOpen(!open) }}
         title="Session actions"
         // The visible content is a bare "⋮" glyph, which is also what a
         // screen reader would announce without this (every other icon
@@ -444,22 +436,12 @@ function SessionMenu({ session, onRestart, onResume, resuming }: {
               Find in terminal
             </button>
           )}
-          {action && actionHandler && (
-            <button
-              class={`session-menu-action${showStale ? ' stale' : ''}`}
-              disabled={action.disabled}
-              onClick={() => { setOpen(false); actionHandler() }}
-            >
-              {action.label}
-              {showStale && <span class="session-menu-action-tag">outdated</span>}
-            </button>
-          )}
           {promotion && promotionWords && (
             <button
               class="session-menu-action session-menu-promotion"
               disabled={promotionInFlight}
               aria-disabled={promotionBlocked ? 'true' : undefined}
-              aria-describedby="session-promotion-note"
+              aria-describedby={promotionWords.note ? 'session-promotion-note' : undefined}
               onClick={e => {
                 if (promotionInFlight || promotionBlocked) {
                   e.preventDefault()
@@ -483,11 +465,45 @@ function SessionMenu({ session, onRestart, onResume, resuming }: {
               }}
             >
               {promotionWords.label}
-              <span id="session-promotion-note" class="session-menu-action-note">{promotionWords.note}</span>
+              {promotionWords.note && (
+                <span id="session-promotion-note" class="session-menu-action-note">{promotionWords.note}</span>
+              )}
+            </button>
+          )}
+          {/* Lifecycle last: Restart/Resume is the heaviest verb here, and a
+            * fixed bottom slot keeps it out of the muscle-memory path of the
+            * lighter actions above. */
+          }
+          {action && actionHandler && (
+            <button
+              class={`session-menu-action${showStale ? ' stale' : ''}`}
+              disabled={action.disabled}
+              onClick={() => { setOpen(false); actionHandler() }}
+            >
+              {action.label}
+              {showStale && <span class="session-menu-action-tag">outdated</span>}
             </button>
           )}
           {(canFind || (action && actionHandler) || promotion) && <div class="session-menu-divider" />}
           <div class="session-menu-section-title">Session info</div>
+          <div class="session-menu-row">
+            <span class="session-menu-label">ID</span>
+            <span class="session-menu-value session-menu-id">
+              {session.id}
+              <button
+                class="session-menu-copy"
+                aria-label="Copy session ID"
+                title="Copy session ID"
+                onClick={() => {
+                  // The check reports the write, not the wish: over plain
+                  // http the async API is missing entirely.
+                  void copyText(session.id).then(ok => { if (ok) setCopied(true) })
+                }}
+              >
+                {copied ? <IconCheck /> : <IconCopy />}
+              </button>
+            </span>
+          </div>
           <div class="session-menu-row">
             <span class="session-menu-label">Adapter</span>
             <span class="session-menu-value">
@@ -512,6 +528,18 @@ function SessionMenu({ session, onRestart, onResume, resuming }: {
     </div>
   )
 }
+
+const IconCopy = () => (
+  <svg viewBox="0 0 14 14" width="12" height="12" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linejoin="round">
+    <rect x="4.5" y="4.5" width="7" height="7" rx="1.5" />
+    <path d="M9.5 3V2.5A1.5 1.5 0 0 0 8 1H3.5A1.5 1.5 0 0 0 2 2.5V8a1.5 1.5 0 0 0 1.5 1.5H3" />
+  </svg>
+)
+const IconCheck = () => (
+  <svg viewBox="0 0 14 14" width="12" height="12" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M2.5 7.5 5.5 10.5 11.5 3.5" />
+  </svg>
+)
 
 // ── Mobile nav icons ─────────────────────────────────────────────────────────
 

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -2697,6 +2697,31 @@ body {
   color: var(--text-secondary);
 }
 
+/* The ID row: monospace value with a minimal inline copy button — icon
+   only, ghost until hovered, sized to disappear into the row. */
+.session-menu-id {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.session-menu-copy {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  border: 0;
+  border-radius: 3px;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+.session-menu-copy:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+
 .session-menu-value.stale {
   color: oklch(80% 0.15 65);
 }

--- a/e2e/tests/promote-demote-menu.spec.ts
+++ b/e2e/tests/promote-demote-menu.spec.ts
@@ -37,10 +37,9 @@ test.describe('promote/demote in the ⋮ session menu (mock fixtures)', () => {
     const item = promotionItem(page)
     await expect(item).toHaveCount(1)
     await expect(item).toContainText('Promote to root')
-    // Promotion must not read as severing ownership: the note names the
-    // parent that keeps the child.
-    await expect(item.locator('.session-menu-action-note'))
-      .toHaveText('Shows as its own top-level session — implement drawer still owns it')
+    // An offerable verb explains itself: subtext is reserved for
+    // blocked actions, which owe their reason.
+    await expect(item.locator('.session-menu-action-note')).toHaveCount(0)
 
     const posts: string[] = []
     await page.route('**/v1/sessions/**', async (route) => {
@@ -67,8 +66,7 @@ test.describe('promote/demote in the ⋮ session menu (mock fixtures)', () => {
     await openMenu(page)
     const item = promotionItem(page)
     await expect(item).toContainText('Return to family')
-    await expect(item.locator('.session-menu-action-note'))
-      .toHaveText('Groups back under a genuinely very long root agent title for truncation checks')
+    await expect(item.locator('.session-menu-action-note')).toHaveCount(0)
 
     const posts: string[] = []
     await page.route('**/v1/sessions/**', async (route) => {


### PR DESCRIPTION
Stacked on #489. Session menu design pass:

- **No subtext on offerable verbs** — "Shows as its own top-level session — X still owns it" restated what Promote already says. Notes are reserved for blocked actions, which owe their reason.
- **Restart/Resume moved to the bottom** of the actions: heaviest verb, fixed last slot.
- **Session ID added to Session info** with a minimal ghost copy-to-clipboard icon button (check on success, resets when the menu reopens).

**Left open for design review — do not merge without approval.**