### PR TITLE
refactor(web): the open family drawer is state, not a message

### DIFF
--- a/apps/gmux-web/src/family-drawer-state.ts
+++ b/apps/gmux-web/src/family-drawer-state.ts
@@ -1,14 +1,12 @@
 import { signal } from '@preact/signals'
 
-/** A sidebar family button can ask the header-owned drawer to open.
- * Carry the root rather than a boolean: navigation and rendering are
- * asynchronous, so the request waits until the header belongs to the
- * family that was actually pressed instead of flashing the old one. */
-export const familyDrawerRequest = signal<string | null>(null)
-
-export function requestFamilyDrawer(rootId: string) {
-  // Clear first so pressing the same already-open family after closing
-  // it is still a new signal update.
-  familyDrawerRequest.value = null
-  familyDrawerRequest.value = rootId
-}
+/** The family whose drawer is open, by root id — null when none is.
+ *
+ * One fact with one owner: whoever wants the drawer (header trigger,
+ * sidebar indicator) writes the root here, and the header shows the
+ * drawer while the selected session belongs to that family. The
+ * comparison *is* the old "wait until navigation lands" logic — a
+ * sidebar press on another family writes the root and navigates, and
+ * the drawer appears exactly when the header catches up, with no
+ * request to deliver, consume, or re-arm. */
+export const familyDrawerRoot = signal<string | null>(null)

--- a/apps/gmux-web/src/family-drawer.tsx
+++ b/apps/gmux-web/src/family-drawer.tsx
@@ -302,7 +302,12 @@ export function FamilyDrawer({ selected, onClose, triggerRef }: {
     const onPointerDown = (event: PointerEvent) => {
       const target = event.target as Node
       if (panelRef.current?.contains(target)) return
-      if (triggerRef.current?.contains(target)) return // trigger's own click toggles
+      // Anything that declares itself a control of this drawer (the
+      // header trigger, the sidebar indicator) toggles on its own
+      // click — closing here on the pointerdown would flip the drawer
+      // shut a beat early, and the control's click would reopen it.
+      const el = target instanceof Element ? target : target.parentElement
+      if (el?.closest('[aria-controls="agent-family-drawer"]')) return
       onClose()
     }
     document.addEventListener('keydown', onKey)

--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -15,7 +15,7 @@ import { usePresence } from './use-presence'
 import { lifecycleAction } from './session-actions'
 import { MenuButton } from './menu-button'
 import { FamilyDrawer } from './family-drawer'
-import { familyDrawerRequest } from './family-drawer-state'
+import { familyDrawerRoot } from './family-drawer-state'
 import { familyAncestors, familyRoot, familySegments, hasFamily, promotionAction, promotionCopy } from './family'
 import { FamilyIcon } from './family-icon'
 
@@ -184,20 +184,23 @@ function MainHeader({ session, onRestart, onResume, resuming }: {
   onResume?: (id: string) => void
   resuming?: boolean
 }) {
-  const [familyOpen, setFamilyOpen] = useState(false)
   const familyTriggerRef = useRef<HTMLButtonElement>(null)
-  const closeFamily = useCallback(() => { setFamilyOpen(false) }, [])
   const showFamily = session ? hasFamily(session, sessions.value) : false
-  const requestedFamily = familyDrawerRequest.value
+  const rootId = session && showFamily ? familyRoot(session, sessions.value).id : null
+  // Open-ness is a comparison, not stored state: the drawer shows while
+  // the selected session belongs to the family named in the signal.
+  const familyOpen = rootId !== null && familyDrawerRoot.value === rootId
+  const closeFamily = useCallback(() => { familyDrawerRoot.value = null }, [])
+  // Leaving the family closes its drawer — otherwise returning later
+  // would pop it back open. Keyed to session *arrival* rather than the
+  // render loop: a sidebar press on another family writes the signal
+  // before navigating, and clearing on the pre-navigation mismatch
+  // would eat the press.
   useEffect(() => {
-    if (!showFamily) setFamilyOpen(false)
-  }, [showFamily])
-  useEffect(() => {
-    if (!session || !requestedFamily) return
-    if (familyRoot(session, sessions.value).id !== requestedFamily) return
-    setFamilyOpen(true)
-    familyDrawerRequest.value = null
-  }, [session?.id, requestedFamily])
+    if (familyDrawerRoot.value !== null && familyDrawerRoot.value !== rootId) {
+      familyDrawerRoot.value = null
+    }
+  }, [session?.id])
 
   if (!session) {
     return (
@@ -217,7 +220,7 @@ function MainHeader({ session, onRestart, onResume, resuming }: {
             session={session}
             open={familyOpen}
             triggerRef={familyTriggerRef}
-            onToggle={() => { setFamilyOpen(v => !v) }}
+            onToggle={() => { familyDrawerRoot.value = familyOpen ? null : rootId }}
           />
         )}
         {showFamily && <HeaderCrumbs session={session} />}

--- a/apps/gmux-web/src/sidebar.tsx
+++ b/apps/gmux-web/src/sidebar.tsx
@@ -9,7 +9,7 @@ import { useState, useCallback, useRef, useEffect } from 'preact/hooks'
 import { needsReveal } from './sidebar-reveal'
 import { hasSessionSlugCollision, sessionPath, viewToPath } from './routing'
 import { FamilyIcon } from './family-icon'
-import { requestFamilyDrawer } from './family-drawer-state'
+import { familyDrawerRoot } from './family-drawer-state'
 import { selectorLabel, folderMatchesFilter, type Selector } from './tab-filter'
 import { reorderKeysForFolder } from './projects'
 import { LaunchButton } from './launcher'
@@ -262,8 +262,16 @@ function FamilyActivityLine({
       aria-label={`${label}. Open family panel`}
       aria-controls="agent-family-drawer"
       onClick={() => {
+        // A second press dismisses: if the panel is already open and
+        // there is nowhere left to navigate, the press can only mean
+        // "put it away". While elsewhere in the family it navigates to
+        // the root instead, and the open drawer simply follows.
+        if (familyDrawerRoot.value === rootId && selectedId.value === rootId) {
+          familyDrawerRoot.value = null
+          return
+        }
         navigate(rootHref)
-        requestFamilyDrawer(rootId)
+        familyDrawerRoot.value = rootId
         onClick?.()
       }}
     >

--- a/e2e/tests/family-entry-interaction.spec.ts
+++ b/e2e/tests/family-entry-interaction.spec.ts
@@ -67,6 +67,22 @@ test.describe('sidebar family entry', () => {
     await indicator.focus()
     await page.keyboard.press('Enter')
     await expect(page.locator('#agent-family-drawer')).toBeVisible()
+
+    // With the panel open and nowhere left to navigate, a second press
+    // is a dismissal — the indicator toggles rather than insists.
+    await indicator.click()
+    await expect(page.locator('#agent-family-drawer')).toBeHidden()
+    await indicator.click()
+    await expect(page.locator('#agent-family-drawer')).toBeVisible()
+
+    // Leaving the family closes its drawer, and coming back does not
+    // pop it open again: open-ness is a statement about the present,
+    // not a preference to be remembered.
+    await familyEntry(page, 'orchestrator').locator('.family-slot').click()
+    await expect(page.locator('#agent-family-drawer')).toBeHidden()
+    await page.goBack()
+    await expect(page).toHaveURL(/~famBroot/)
+    await expect(page.locator('#agent-family-drawer')).toBeHidden()
   })
 
   test('a drop anywhere on the entry reorders exactly once', async ({ page }) => {


### PR DESCRIPTION
Stacked on #489; the deferred cleanup from the #488 design discussion.

Replaces the request-signal handshake (post → effect waits → match → consume → re-arm via null double-write) and the header's local `useState` with one fact: `familyDrawerRoot`, the family whose drawer is open. The drawer renders while the selected session belongs to that family — the comparison *is* the old "wait until navigation lands" logic.

One deliberate effect remains, keyed to session arrival: leaving a family closes its drawer (a pure derivation would pop it back open on return). Keying it to arrival rather than the render loop is what keeps it from eating a cross-family press mid-navigation; the existing e2e covers that press, and assertions pin leave-closes + no-reopen-on-return.

State also makes the sidebar indicator an honest toggle (a one-shot request couldn't express this): with the panel open and nowhere left to navigate, a second press dismisses it. The drawer's outside-close ignores pointerdowns on anything declaring `aria-controls` for it — closing on the pointerdown flipped the drawer shut a beat before the control's click, which then reopened it.

**Left open for review.**