### PR TITLE
feat(gmuxd): budget subagents by root depth

### DIFF
--- a/apps/website/src/content/docs/reference/host-toml.md
+++ b/apps/website/src/content/docs/reference/host-toml.md
@@ -16,9 +16,9 @@ Daemon behavior. gmuxd reads this file once at startup. Create or edit it manual
 # Default: 8790
 port = 8790
 
-# Per behavioral root, cap live semantic-agent descendants launched by gmux.
-# Default: 8
-max_active_subagents = 8
+# Per behavioral root, cap live semantic agents at each descendant depth.
+# Direct children are unlimited, grandchildren share 8 slots, deeper spawning is blocked.
+max_subagents_by_depth = [-1, 8]
 
 # Optional Tailscale remote access.
 # See the Remote Access guide for setup.
@@ -59,29 +59,37 @@ There is **no `[[peers]]` config**. Add a host you want to aggregate sessions fr
 | Field | Type | Default | Range | Description |
 |-------|------|---------|-------|-------------|
 | `port` | `number` | `8790` | 1–65535 | TCP port for the HTTP listener. |
-| `max_active_subagents` | `number` | `8` | 1–1024 | Maximum live semantic-agent descendants per local behavioral root for `gmux agent prompt --new`. |
+| `max_subagents_by_depth` | `number[]` or `false` | `[-1, 8]` | 1–8 entries; each -1 or 0–1024 | Shared live semantic-agent budget per behavioral root and descendant depth. Only the first entry may be `-1` (unlimited). |
 
-`max_active_subagents` is a host default read once at daemon startup. A value in
-`host.toml` overrides the built-in default; there is currently no environment,
-CLI, UI, or per-root override. The daemon is the authority only for sessions it
-owns. It does not coordinate a distributed quota with network peers.
+`max_subagents_by_depth` is read once at daemon startup. Array element zero
+caps the root's direct children, element one caps grandchildren, and so on.
+Depths omitted from the array have a limit of zero, so `[-1, 8]` is equivalent
+to `[-1, 8, 0]`: direct children are unlimited, all children collectively
+share eight grandchild slots, and grandchildren cannot spawn agents. Set the
+field to `false` to disable admission protection while retaining launch
+accounting. There is no environment, CLI, UI, or per-root override.
+
+The limits are **shared per behavioral root at each depth**, not repeated for
+every parent. This gives the root's whole swarm an absolute budget for
+autonomous hiring: a recursive instruction propagated to 500 children can
+create at most eight grandchildren under the default, rather than 4,000.
 
 The budget follows current family ownership (`parent_session_id` and
-promotion), not immutable launch provenance. Reparenting immediately moves a
-live semantic-agent subtree to its new root's budget. Promoting a session makes
-it a root with an independent budget; demoting it rejoins its containing root.
-The root session itself is never counted. Neither are shell/process children,
-dead retained sessions, or remote projections. Independent top-level `--new`
-launches create independent roots and therefore do not consume another root's
-slots.
+promotion), not immutable launch provenance. Depth counts every family edge,
+including an intervening shell/process session; only live semantic-agent
+sessions consume slots at the resulting depth. Reparenting moves a live subtree
+and its depth counts immediately. Promoting a session makes it a root with a
+fresh depth budget; demoting it rejoins its containing root. Dead retained
+sessions and remote projections do not consume slots. Independent top-level
+`--new` launches create independent roots.
 
 A slot is reserved atomically before gmux creates the runner, PTY, or durable
-session row. It becomes a live slot when registration succeeds. A pre-start or
-registration failure releases the reservation; a normal exit or killed runner
-releases the live slot when that generation leaves the daemon's runtime
-registry. "Active" therefore means **live/resident semantic-agent descendant**,
-not merely an agent turn currently producing output. A refusal exits non-zero
-with the stable code `subagent_limit_reached` and suggests `gmux ls`.
+session row. It becomes a live slot when registration succeeds. Failures and
+runner exits release it. "Active" means **live/resident semantic-agent
+session**, not merely a turn producing output. A refusal exits non-zero with
+the stable code `subagent_limit_reached`, identifies the root and depth, and
+suggests `gmux ls`. The daemon owns only local admission; it does not coordinate
+a distributed quota with network peers.
 
 The bind address is not configurable here — it is the `GMUXD_LISTEN` environment variable (default `127.0.0.1`). See [Environment variables](/reference/environment/#bind-address).
 
@@ -156,7 +164,7 @@ The config file is strictly validated at startup. gmuxd refuses to start if:
 - **`allow` entries don't contain `@` and don't start with `tag:`**, likely not a valid Tailscale login name or device tag
 - **`allow` tag entries are malformed** — the name after `tag:` must start with a letter and contain only lowercase letters, digits, and hyphens
 - **`port` is out of range** (must be 1–65535)
-- **`max_active_subagents` is zero, negative, or above 1024**
+- **`max_subagents_by_depth` is `true`, is not an integer array or `false`, is empty, has over eight entries, has an entry above 1024, or uses `-1` after the first entry**
 - **A session limit is negative**, or a retention/cache value is too large to convert safely to its runtime duration or byte count
 - **ntfy settings are unsafe or malformed** — including a missing/invalid topic, unsupported URL, mixed authentication modes, credentials over plaintext HTTP, priority/tag/timeout violations, or an enabled config file with group/other permissions
 - **A TOML integer is outside the supported integer range**, or other TOML syntax is invalid

--- a/cli/gmux/cmd/gmux/agent.go
+++ b/cli/gmux/cmd/gmux/agent.go
@@ -943,10 +943,11 @@ intentionally interrupted, and 1 means failure or timeout.
 With synchronous --new, the bare session id is printed on stderr the moment the
 session exists and stdout is the report alone. With --new --no-wait, stdout is
 the bare id only. Before creating a runner, --new reserves one live semantic-
-agent descendant slot against the caller's current behavioral root. The host
-default is max_active_subagents = 8; promoted roots and independent top-level
-launches have independent budgets. 'gmux ls' shows the sessions to inspect when
-the daemon refuses a launch. Semantic reads and delivery hide runner residency:
+agent slot at its depth below the caller's current behavioral root. The host
+default allows unlimited direct children, eight shared grandchildren, and no
+deeper descendants. Promoted roots and independent top-level launches have
+independent budgets. 'gmux ls' shows the sessions to inspect when the daemon
+refuses a launch. Semantic reads and delivery hide runner residency:
 an inactive conversation is resumed automatically when prompted.
 `)
 	case "agent cancel":

--- a/cli/gmux/cmd/gmux/agent_launch_exchange_test.go
+++ b/cli/gmux/cmd/gmux/agent_launch_exchange_test.go
@@ -100,7 +100,7 @@ func TestAgentPromptNewAdmissionAPIAndExitCode(t *testing.T) {
 			if r.URL.Path != "/v1/agent-launch-reservations" {
 				t.Fatalf("path = %s", r.URL.Path)
 			}
-			writeErrEnvelope(w, http.StatusTooManyRequests, "subagent_limit_reached", "subagent limit reached for root root: 8 of 8 active subagents; run 'gmux ls' to inspect this host's sessions")
+			writeErrEnvelope(w, http.StatusTooManyRequests, "subagent_limit_reached", "subagent limit reached at depth 2 for root root: 8 of 8 autonomous subagents at this depth; run 'gmux ls' to see who holds the slots")
 		})
 		oldLaunch, oldReserve, oldRelease := agentLaunchSession, agentReserveActiveSubagent, agentReleaseActiveSubagent
 		agentReserveActiveSubagent, agentReleaseActiveSubagent = reserveActiveSubagent, releaseActiveSubagent
@@ -116,7 +116,7 @@ func TestAgentPromptNewAdmissionAPIAndExitCode(t *testing.T) {
 		if code != waitExitError || launched {
 			t.Fatalf("exit=%d launched=%v", code, launched)
 		}
-		if !strings.Contains(stderr, "subagent_limit_reached: subagent limit reached for root root: 8 of 8 active subagents") || !strings.Contains(stderr, "gmux ls") {
+		if !strings.Contains(stderr, "subagent_limit_reached: subagent limit reached at depth 2 for root root: 8 of 8 autonomous subagents") || !strings.Contains(stderr, "gmux ls") {
 			t.Fatalf("stderr = %q", stderr)
 		}
 	})
@@ -174,7 +174,7 @@ func TestAgentPromptHelpDocumentsActiveSubagentBudget(t *testing.T) {
 	var out strings.Builder
 	printAgentUsage(&out, "agent prompt")
 	text := out.String()
-	for _, want := range []string{"max_active_subagents = 8", "behavioral root", "gmux ls"} {
+	for _, want := range []string{"unlimited direct children", "shared grandchildren", "behavioral root", "gmux ls"} {
 		if !strings.Contains(text, want) {
 			t.Errorf("help missing %q:\n%s", want, text)
 		}

--- a/services/gmuxd/cmd/gmuxd/active_subagent_routes.go
+++ b/services/gmuxd/cmd/gmuxd/active_subagent_routes.go
@@ -63,8 +63,7 @@ func handleActiveSubagentReservation(w http.ResponseWriter, r *http.Request, coo
 	if err != nil {
 		var limit *sessioncoord.SubagentLimitError
 		if errors.As(err, &limit) {
-			message := fmt.Sprintf("subagent limit reached for root %s: %d of %d active subagents; run 'gmux ls' to inspect this host's sessions", limit.Root, limit.Active, limit.Limit)
-			writeError(w, http.StatusTooManyRequests, codeSubagentLimitReached, message)
+			writeError(w, http.StatusTooManyRequests, codeSubagentLimitReached, formatSubagentLimitMessage(limit))
 			return
 		}
 		writeError(w, http.StatusInternalServerError, "internal", err.Error())
@@ -72,9 +71,16 @@ func handleActiveSubagentReservation(w http.ResponseWriter, r *http.Request, coo
 	}
 	writeJSON(w, map[string]any{"ok": true, "data": map[string]any{
 		"token": reservation.Token, "root_session_id": reservation.Root,
-		"active": reservation.Active, "limit": reservation.Limit,
+		"depth": reservation.Depth, "active": reservation.Active, "limit": reservation.Limit,
 		"expires_at": reservation.ExpiresAt.UTC().Format(time.RFC3339Nano),
 	}})
+}
+
+func formatSubagentLimitMessage(limit *sessioncoord.SubagentLimitError) string {
+	if limit.Limit == 0 {
+		return fmt.Sprintf("subagent limit reached at depth %d for root %s: sessions at this depth may not spawn subagents on this host; ask a human to extend the limit or promote this subtree to its own root", limit.Depth, limit.Root)
+	}
+	return fmt.Sprintf("subagent limit reached at depth %d for root %s: %d of %d autonomous subagents at this depth; run 'gmux ls' to see who holds the slots, dismiss finished sessions, or ask a human to raise this host's limit or promote this subtree to its own root", limit.Depth, limit.Root, limit.Active, limit.Limit)
 }
 
 func handleActiveSubagentReservationRelease(w http.ResponseWriter, r *http.Request, coord *sessioncoord.Coordinator, token string) {

--- a/services/gmuxd/cmd/gmuxd/active_subagent_routes_test.go
+++ b/services/gmuxd/cmd/gmuxd/active_subagent_routes_test.go
@@ -13,7 +13,7 @@ import (
 
 func routeBudgetCoordinator(limit int, rows []centralstore.Session) *sessioncoord.Coordinator {
 	return sessioncoord.New(nil, nil, nil, nil, nil,
-		sessioncoord.WithActiveSubagentBudget(limit, func(adapter string) bool { return adapter == "pi" }, rows))
+		sessioncoord.WithActiveSubagentBudget([]int{limit}, false, func(adapter string) bool { return adapter == "pi" }, rows))
 }
 
 func TestActiveSubagentReservationAPIAllowedAndRejected(t *testing.T) {
@@ -34,6 +34,7 @@ func TestActiveSubagentReservationAPIAllowedAndRejected(t *testing.T) {
 		Data struct {
 			Token  string `json:"token"`
 			Root   string `json:"root_session_id"`
+			Depth  int    `json:"depth"`
 			Active int    `json:"active"`
 			Limit  int    `json:"limit"`
 		} `json:"data"`
@@ -41,7 +42,7 @@ func TestActiveSubagentReservationAPIAllowedAndRejected(t *testing.T) {
 	if err := json.Unmarshal(allowed.Body.Bytes(), &receipt); err != nil {
 		t.Fatal(err)
 	}
-	if receipt.Data.Token == "" || receipt.Data.Root != "root" || receipt.Data.Active != 0 || receipt.Data.Limit != 1 {
+	if receipt.Data.Token == "" || receipt.Data.Root != "root" || receipt.Data.Depth != 1 || receipt.Data.Active != 0 || receipt.Data.Limit != 1 {
 		t.Fatalf("receipt = %+v", receipt.Data)
 	}
 
@@ -55,7 +56,7 @@ func TestActiveSubagentReservationAPIAllowedAndRejected(t *testing.T) {
 	if err := json.Unmarshal(rejected.Body.Bytes(), &envelope); err != nil {
 		t.Fatal(err)
 	}
-	if envelope.Error.Code != codeSubagentLimitReached || !strings.Contains(envelope.Error.Message, "subagent limit reached for root root: 1 of 1 active subagents") || !strings.Contains(envelope.Error.Message, "gmux ls") {
+	if envelope.Error.Code != codeSubagentLimitReached || !strings.Contains(envelope.Error.Message, "subagent limit reached at depth 1 for root root: 1 of 1 autonomous subagents") || !strings.Contains(envelope.Error.Message, "gmux ls") {
 		t.Fatalf("error = %+v", envelope.Error)
 	}
 
@@ -66,6 +67,15 @@ func TestActiveSubagentReservationAPIAllowedAndRejected(t *testing.T) {
 	}
 	if again := request(); again.Code != http.StatusOK {
 		t.Fatalf("slot not released: %d %s", again.Code, again.Body.String())
+	}
+}
+
+func TestFormatSubagentLimitMessageAtBlockedDepth(t *testing.T) {
+	message := formatSubagentLimitMessage(&sessioncoord.SubagentLimitError{Root: "root", Depth: 3, Limit: 0})
+	for _, want := range []string{"depth 3", "root root", "may not spawn subagents", "ask a human"} {
+		if !strings.Contains(message, want) {
+			t.Errorf("message %q missing %q", message, want)
+		}
 	}
 }
 

--- a/services/gmuxd/cmd/gmuxd/bootstrap.go
+++ b/services/gmuxd/cmd/gmuxd/bootstrap.go
@@ -148,7 +148,8 @@ type BootstrapConfig struct {
 	Notices                        func(context.Context, string)
 	Frames                         func(context.Context, wire.Frames)
 	Clock                          func() centralstore.UnixMillis
-	MaxActiveSubagents             int
+	MaxSubagentsByDepth            []int
+	SubagentBudgetDisabled         bool
 	SemanticAgent                  func(string) bool
 	RunnerBudget, ConvergeDeadline time.Duration
 	RetryInitial, RetryMaximum     time.Duration
@@ -201,12 +202,12 @@ func newBootstrap(cfg BootstrapConfig) (*Bootstrap, error) {
 	registry := sessioncoord.NewRegistry()
 	bridge := &composerDirtyBridge{}
 	opts := []sessioncoord.Option{sessioncoord.WithClock(cfg.Clock), sessioncoord.WithRunnerControl(cfg.Control), sessioncoord.WithRunnerSpawner(cfg.Spawner), sessioncoord.WithConversationTakeover(cfg.Resolver), sessioncoord.WithAdapterReconciler(cfg.Reconciler)}
-	if cfg.MaxActiveSubagents > 0 {
+	if len(cfg.MaxSubagentsByDepth) > 0 || cfg.SubagentBudgetDisabled {
 		rows, err := cfg.Store.ListSessions(context.Background())
 		if err != nil {
 			return nil, fmt.Errorf("bootstrap: initialize active-subagent ownership: %w", err)
 		}
-		opts = append(opts, sessioncoord.WithActiveSubagentBudget(cfg.MaxActiveSubagents, cfg.SemanticAgent, rows))
+		opts = append(opts, sessioncoord.WithActiveSubagentBudget(cfg.MaxSubagentsByDepth, cfg.SubagentBudgetDisabled, cfg.SemanticAgent, rows))
 	}
 	if cfg.LocalPeers != nil {
 		opts = append(opts, sessioncoord.WithLocalPeerMatchInputs(cfg.LocalPeers))

--- a/services/gmuxd/cmd/gmuxd/bootstrap_test.go
+++ b/services/gmuxd/cmd/gmuxd/bootstrap_test.go
@@ -105,8 +105,8 @@ func TestBootstrapReconstructsActiveSubagentBudgetAfterConvergence(t *testing.T)
 	runners := &bootstrapRunners{metas: map[string]sessioncoord.RunnerMeta{"child.sock": meta}, blocked: map[string]bool{}}
 	boot, err := newBootstrap(BootstrapConfig{
 		Store: store, Runners: runners, Converter: &wire.Converter{},
-		Endpoints:          EndpointSourceFunc(func(context.Context) ([]string, error) { return []string{"child.sock"}, nil }),
-		MaxActiveSubagents: 1, SemanticAgent: func(adapter string) bool { return adapter == "pi" },
+		Endpoints:           EndpointSourceFunc(func(context.Context) ([]string, error) { return []string{"child.sock"}, nil }),
+		MaxSubagentsByDepth: []int{1}, SemanticAgent: func(adapter string) bool { return adapter == "pi" },
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/services/gmuxd/cmd/gmuxd/serve_central.go
+++ b/services/gmuxd/cmd/gmuxd/serve_central.go
@@ -271,7 +271,7 @@ func serveCentral(stderr io.Writer, replace bool) int {
 		return discovery.ResolveResumeCommandFor(legacy.Adapter, legacy.ConversationRef)
 	}}
 
-	boot, err = newBootstrap(BootstrapConfig{Store: storeHandle, Runners: productionRunnerClient{}, Control: productionRunnerControl{}, Spawner: spawner, Resolver: productionConversationResolver{}, Reconciler: productionAdapterReconciler{}, LocalPeers: peerAdapter.LocalPeerMatchInputs, Peers: peerAdapter, PeerSessions: peerAdapter, Converter: converter, Endpoints: productionEndpointSource{}, MaxActiveSubagents: cfg.MaxActiveSubagents, SemanticAgent: func(name string) bool { return converter.SemanticAgents[name] }, Errors: sessioncoord.ErrorSinkFunc(func(_ context.Context, err error) { log.Printf("gmuxd: %v", err) }), Frames: func(_ context.Context, frames wire.Frames) {
+	boot, err = newBootstrap(BootstrapConfig{Store: storeHandle, Runners: productionRunnerClient{}, Control: productionRunnerControl{}, Spawner: spawner, Resolver: productionConversationResolver{}, Reconciler: productionAdapterReconciler{}, LocalPeers: peerAdapter.LocalPeerMatchInputs, Peers: peerAdapter, PeerSessions: peerAdapter, Converter: converter, Endpoints: productionEndpointSource{}, MaxSubagentsByDepth: cfg.MaxSubagentsByDepth.Values, SubagentBudgetDisabled: cfg.MaxSubagentsByDepth.Disabled, SemanticAgent: func(name string) bool { return converter.SemanticAgents[name] }, Errors: sessioncoord.ErrorSinkFunc(func(_ context.Context, err error) { log.Printf("gmuxd: %v", err) }), Frames: func(_ context.Context, frames wire.Frames) {
 		// The converter builds world.health.launchers but not the top-level
 		// world.launchers/default_launcher that the web UI's "+" menu reads
 		// (parity with the legacy composeWorld). Inject the static launch
@@ -654,8 +654,7 @@ func serveCentral(stderr io.Writer, replace bool) int {
 			if _, err := boot.Coordinator.Register(r.Context(), sessioncoord.RegisterRequest{Endpoint: req.SocketPath, AssertedID: centralstore.SessionID(req.SessionID), ActiveSubagentReservation: req.ActiveSubagentReservation}); err != nil {
 				var limit *sessioncoord.SubagentLimitError
 				if errors.As(err, &limit) {
-					message := fmt.Sprintf("subagent limit reached for root %s: %d of %d active subagents; run 'gmux ls' to inspect this host's sessions", limit.Root, limit.Active, limit.Limit)
-					writeError(w, http.StatusTooManyRequests, codeSubagentLimitReached, message)
+					writeError(w, http.StatusTooManyRequests, codeSubagentLimitReached, formatSubagentLimitMessage(limit))
 					return
 				}
 				if errors.Is(err, sessioncoord.ErrActiveSubagentReservationInvalid) {

--- a/services/gmuxd/internal/config/config.go
+++ b/services/gmuxd/internal/config/config.go
@@ -28,9 +28,9 @@ type Config struct {
 	// Port is the TCP port for the HTTP listener (default 8790).
 	Port int `toml:"port"`
 
-	// MaxActiveSubagents is the host-default per behavioral-root limit for
-	// live semantic-agent descendants launched through gmux (default 8).
-	MaxActiveSubagents int `toml:"max_active_subagents"`
+	// MaxSubagentsByDepth is the per-behavioral-root budget at each descendant
+	// depth. False disables admission checks while retaining accounting.
+	MaxSubagentsByDepth SubagentDepthLimits `toml:"max_subagents_by_depth"`
 
 	Tailscale     TailscaleConfig     `toml:"tailscale"`
 	Discovery     DiscoveryConfig     `toml:"discovery"`
@@ -98,6 +98,36 @@ type SessionsConfig struct {
 // NotificationsConfig controls external notification sinks.
 type NotificationsConfig struct {
 	Ntfy NtfyConfig `toml:"ntfy"`
+}
+
+// SubagentDepthLimits accepts either an integer array or false in TOML.
+type SubagentDepthLimits struct {
+	Disabled bool
+	Values   []int
+}
+
+func (l *SubagentDepthLimits) UnmarshalTOML(value any) error {
+	switch v := value.(type) {
+	case bool:
+		if v {
+			return fmt.Errorf("expected an array like [-1, 8] or false")
+		}
+		l.Disabled, l.Values = true, nil
+		return nil
+	case []any:
+		values := make([]int, len(v))
+		for i, raw := range v {
+			n, ok := raw.(int64)
+			if !ok {
+				return fmt.Errorf("entry %d must be an integer", i)
+			}
+			values[i] = int(n)
+		}
+		l.Disabled, l.Values = false, values
+		return nil
+	default:
+		return fmt.Errorf("expected an array like [-1, 8] or false")
+	}
 }
 
 // Duration is a TOML string duration such as "5s".
@@ -223,8 +253,19 @@ func validate(cfg Config) error {
 	if cfg.Port < 1 || cfg.Port > 65535 {
 		return fmt.Errorf("port %d is out of range (1-65535)", cfg.Port)
 	}
-	if cfg.MaxActiveSubagents < 1 || cfg.MaxActiveSubagents > 1024 {
-		return fmt.Errorf("max_active_subagents must be between 1 and 1024")
+	if !cfg.MaxSubagentsByDepth.Disabled {
+		limits := cfg.MaxSubagentsByDepth.Values
+		if len(limits) == 0 || len(limits) > 8 {
+			return fmt.Errorf("max_subagents_by_depth must contain between 1 and 8 entries")
+		}
+		for i, limit := range limits {
+			if limit == -1 && i == 0 {
+				continue
+			}
+			if limit < 0 || limit > 1024 {
+				return fmt.Errorf("max_subagents_by_depth entry %d must be between 0 and 1024; only the first entry may be -1", i)
+			}
+		}
 	}
 
 	maxRetentionDays := effectiveIntMax(math.MaxInt64 / int64(24*time.Hour))
@@ -396,8 +437,10 @@ func isPrivateOrCGNAT(ip net.IP) bool {
 
 func defaults() Config {
 	return Config{
-		Port:               8790,
-		MaxActiveSubagents: 8,
+		Port: 8790,
+		MaxSubagentsByDepth: SubagentDepthLimits{
+			Values: []int{-1, 8},
+		},
 		Discovery: DiscoveryConfig{
 			Devcontainers: true,
 		},

--- a/services/gmuxd/internal/config/config_test.go
+++ b/services/gmuxd/internal/config/config_test.go
@@ -20,8 +20,8 @@ func TestLoadDefaults(t *testing.T) {
 	if cfg.Port != 8790 {
 		t.Errorf("port = %d, want 8790", cfg.Port)
 	}
-	if cfg.MaxActiveSubagents != 8 {
-		t.Errorf("max_active_subagents = %d, want 8", cfg.MaxActiveSubagents)
+	if got := fmt.Sprint(cfg.MaxSubagentsByDepth.Values); got != "[-1 8]" || cfg.MaxSubagentsByDepth.Disabled {
+		t.Errorf("max_subagents_by_depth = %+v, want [-1 8]", cfg.MaxSubagentsByDepth)
 	}
 	if cfg.Tailscale.Enabled {
 		t.Error("tailscale should be disabled by default")
@@ -39,7 +39,7 @@ func TestLoadFromFile(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", dir)
 	writeConfig(t, dir, `
 port = 9999
-max_active_subagents = 12
+max_subagents_by_depth = [64, 12]
 
 [tailscale]
 enabled = true
@@ -53,8 +53,8 @@ allow = ["alice@github", "bob@github"]
 	if cfg.Port != 9999 {
 		t.Errorf("port = %d, want 9999", cfg.Port)
 	}
-	if cfg.MaxActiveSubagents != 12 {
-		t.Errorf("max_active_subagents = %d, want 12", cfg.MaxActiveSubagents)
+	if got := fmt.Sprint(cfg.MaxSubagentsByDepth.Values); got != "[64 12]" {
+		t.Errorf("max_subagents_by_depth = %v, want [64 12]", cfg.MaxSubagentsByDepth.Values)
 	}
 	if !cfg.Tailscale.Enabled {
 		t.Error("tailscale should be enabled")
@@ -64,24 +64,29 @@ allow = ["alice@github", "bob@github"]
 	}
 }
 
-func TestLoadValidatesMaxActiveSubagents(t *testing.T) {
+func TestLoadValidatesMaxSubagentsByDepth(t *testing.T) {
 	for _, tt := range []struct {
-		name    string
-		value   string
-		want    int
-		wantErr bool
+		name, value string
+		want        string
+		wantOff     bool
+		wantErr     bool
 	}{
-		{name: "minimum", value: "1", want: 1},
-		{name: "reasonable maximum", value: "1024", want: 1024},
-		{name: "zero", value: "0", wantErr: true},
-		{name: "negative", value: "-1", wantErr: true},
-		{name: "unreasonably large", value: "1025", wantErr: true},
-		{name: "wrong type", value: `"eight"`, wantErr: true},
+		{name: "default shape", value: "[-1, 8]", want: "[-1 8]"},
+		{name: "finite root", value: "[64, 8, 0]", want: "[64 8 0]"},
+		{name: "strict", value: "[0]", want: "[0]"},
+		{name: "disabled", value: "false", want: "[]", wantOff: true},
+		{name: "true", value: "true", wantErr: true},
+		{name: "empty", value: "[]", wantErr: true},
+		{name: "scalar", value: "8", wantErr: true},
+		{name: "negative after first", value: "[8, -1]", wantErr: true},
+		{name: "too large", value: "[-1, 1025]", wantErr: true},
+		{name: "too deep", value: "[1,2,3,4,5,6,7,8,9]", wantErr: true},
+		{name: "wrong entry type", value: `[-1, "eight"]`, wantErr: true},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			dir := t.TempDir()
 			t.Setenv("XDG_CONFIG_HOME", dir)
-			writeConfig(t, dir, "max_active_subagents = "+tt.value+"\n")
+			writeConfig(t, dir, "max_subagents_by_depth = "+tt.value+"\n")
 			cfg, err := Load()
 			if tt.wantErr {
 				if err == nil {
@@ -92,8 +97,8 @@ func TestLoadValidatesMaxActiveSubagents(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if cfg.MaxActiveSubagents != tt.want {
-				t.Fatalf("got %d, want %d", cfg.MaxActiveSubagents, tt.want)
+			if got := fmt.Sprint(cfg.MaxSubagentsByDepth.Values); got != tt.want || cfg.MaxSubagentsByDepth.Disabled != tt.wantOff {
+				t.Fatalf("got %+v, want values=%s disabled=%v", cfg.MaxSubagentsByDepth, tt.want, tt.wantOff)
 			}
 		})
 	}

--- a/services/gmuxd/internal/sessioncoord/active_subagents.go
+++ b/services/gmuxd/internal/sessioncoord/active_subagents.go
@@ -30,11 +30,12 @@ const activeSubagentReservationTTL = 2 * time.Minute
 // ErrSubagentLimitReached.
 type SubagentLimitError struct {
 	Root          centralstore.SessionID
+	Depth         int
 	Active, Limit int
 }
 
 func (e *SubagentLimitError) Error() string {
-	return fmt.Sprintf("%v for root %s: %d of %d active subagents", ErrSubagentLimitReached, e.Root, e.Active, e.Limit)
+	return fmt.Sprintf("%v at depth %d for root %s: %d of %d autonomous subagents", ErrSubagentLimitReached, e.Depth, e.Root, e.Active, e.Limit)
 }
 func (e *SubagentLimitError) Unwrap() error { return ErrSubagentLimitReached }
 
@@ -44,6 +45,7 @@ func (e *SubagentLimitError) Unwrap() error { return ErrSubagentLimitReached }
 type ActiveSubagentReservation struct {
 	Token         string
 	Root          centralstore.SessionID
+	Depth         int
 	Active, Limit int
 	ExpiresAt     time.Time
 }
@@ -67,25 +69,36 @@ type activeSubagentLaunch struct {
 // maintained projection of durable mutable ownership plus runtime liveness.
 // Durable rows provide parent/promotion/adapter facts; only installed local
 // registry generations set live. Remote projections never enter this index.
-type activeSubagentBudget struct {
-	limit        int
-	semantic     func(string) bool
-	nodes        map[centralstore.SessionID]activeSubagentNode
-	children     map[centralstore.SessionID]map[centralstore.SessionID]struct{}
-	roots        map[centralstore.SessionID]centralstore.SessionID
-	activeByRoot map[centralstore.SessionID]int
-	launches     map[string]activeSubagentLaunch
-	now          func() time.Time
+type activeSubagentPlacement struct {
+	root  centralstore.SessionID
+	depth int
 }
 
-func newActiveSubagentBudget(limit int, semantic func(string) bool, rows []centralstore.Session) *activeSubagentBudget {
+type activeSubagentCountKey struct {
+	root  centralstore.SessionID
+	depth int
+}
+
+type activeSubagentBudget struct {
+	limits        []int
+	disabled      bool
+	semantic      func(string) bool
+	nodes         map[centralstore.SessionID]activeSubagentNode
+	children      map[centralstore.SessionID]map[centralstore.SessionID]struct{}
+	placements    map[centralstore.SessionID]activeSubagentPlacement
+	activeByDepth map[activeSubagentCountKey]int
+	launches      map[string]activeSubagentLaunch
+	now           func() time.Time
+}
+
+func newActiveSubagentBudget(limits []int, disabled bool, semantic func(string) bool, rows []centralstore.Session) *activeSubagentBudget {
 	b := &activeSubagentBudget{
-		limit: limit, semantic: semantic,
-		nodes:        make(map[centralstore.SessionID]activeSubagentNode, len(rows)),
-		children:     make(map[centralstore.SessionID]map[centralstore.SessionID]struct{}),
-		roots:        make(map[centralstore.SessionID]centralstore.SessionID, len(rows)),
-		activeByRoot: make(map[centralstore.SessionID]int),
-		launches:     make(map[string]activeSubagentLaunch), now: time.Now,
+		limits: append([]int(nil), limits...), disabled: disabled, semantic: semantic,
+		nodes:         make(map[centralstore.SessionID]activeSubagentNode, len(rows)),
+		children:      make(map[centralstore.SessionID]map[centralstore.SessionID]struct{}),
+		placements:    make(map[centralstore.SessionID]activeSubagentPlacement, len(rows)),
+		activeByDepth: make(map[activeSubagentCountKey]int),
+		launches:      make(map[string]activeSubagentLaunch), now: time.Now,
 	}
 	if b.semantic == nil {
 		b.semantic = func(string) bool { return false }
@@ -99,7 +112,7 @@ func newActiveSubagentBudget(limit int, semantic func(string) bool, rows []centr
 		b.nodes[row.ID] = n
 	}
 	for id := range b.nodes {
-		b.roots[id] = b.resolveRoot(id)
+		b.placements[id] = b.resolvePlacement(id)
 	}
 	return b
 }
@@ -155,6 +168,36 @@ func (b *activeSubagentBudget) resolveRoot(start centralstore.SessionID) central
 	}
 }
 
+func (b *activeSubagentBudget) resolvePlacement(start centralstore.SessionID) activeSubagentPlacement {
+	root := b.resolveRoot(start)
+	if root == "" {
+		return activeSubagentPlacement{}
+	}
+	depth := 0
+	cur := start
+	seen := make(map[centralstore.SessionID]bool)
+	for cur != root {
+		if seen[cur] {
+			return activeSubagentPlacement{root: root}
+		}
+		seen[cur] = true
+		n, ok := b.nodes[cur]
+		if !ok || !n.hasParent {
+			return activeSubagentPlacement{root: root}
+		}
+		cur = n.parent
+		depth++
+	}
+	return activeSubagentPlacement{root: root, depth: depth}
+}
+
+func (b *activeSubagentBudget) cap(depth int) int {
+	if depth < 1 || depth > len(b.limits) {
+		return 0
+	}
+	return b.limits[depth-1]
+}
+
 func (b *activeSubagentBudget) subtree(start centralstore.SessionID) []centralstore.SessionID {
 	out := make([]centralstore.SessionID, 0, 1)
 	seen := map[centralstore.SessionID]bool{}
@@ -179,22 +222,23 @@ func (b *activeSubagentBudget) subtree(start centralstore.SessionID) []centralst
 func (b *activeSubagentBudget) subtract(ids []centralstore.SessionID) {
 	for _, id := range ids {
 		n := b.nodes[id]
-		root := b.roots[id]
-		if n.live && n.semantic && root != "" && root != id {
-			b.activeByRoot[root]--
-			if b.activeByRoot[root] == 0 {
-				delete(b.activeByRoot, root)
+		p := b.placements[id]
+		if n.live && n.semantic && p.root != "" && p.depth >= 1 {
+			key := activeSubagentCountKey{root: p.root, depth: p.depth}
+			b.activeByDepth[key]--
+			if b.activeByDepth[key] == 0 {
+				delete(b.activeByDepth, key)
 			}
 		}
 	}
 }
 func (b *activeSubagentBudget) add(ids []centralstore.SessionID) {
 	for _, id := range ids {
-		root := b.resolveRoot(id)
-		b.roots[id] = root
+		p := b.resolvePlacement(id)
+		b.placements[id] = p
 		n := b.nodes[id]
-		if n.live && n.semantic && root != "" && root != id {
-			b.activeByRoot[root]++
+		if n.live && n.semantic && p.root != "" && p.depth >= 1 {
+			b.activeByDepth[activeSubagentCountKey{root: p.root, depth: p.depth}]++
 		}
 	}
 }
@@ -233,17 +277,18 @@ func (b *activeSubagentBudget) setLive(id centralstore.SessionID, live bool) {
 	if !ok || n.live == live {
 		return
 	}
-	root := b.roots[id]
-	if n.live && n.semantic && root != "" && root != id {
-		b.activeByRoot[root]--
-		if b.activeByRoot[root] == 0 {
-			delete(b.activeByRoot, root)
+	p := b.placements[id]
+	key := activeSubagentCountKey{root: p.root, depth: p.depth}
+	if n.live && n.semantic && p.root != "" && p.depth >= 1 {
+		b.activeByDepth[key]--
+		if b.activeByDepth[key] == 0 {
+			delete(b.activeByDepth, key)
 		}
 	}
 	n.live = live
 	b.nodes[id] = n
-	if n.live && n.semantic && root != "" && root != id {
-		b.activeByRoot[root]++
+	if n.live && n.semantic && p.root != "" && p.depth >= 1 {
+		b.activeByDepth[key]++
 	}
 }
 
@@ -297,7 +342,7 @@ func (b *activeSubagentBudget) remove(id centralstore.SessionID) {
 	}
 	delete(b.children, id)
 	delete(b.nodes, id)
-	delete(b.roots, id)
+	delete(b.placements, id)
 	var survivors []centralstore.SessionID
 	for _, member := range affected {
 		if member != id {
@@ -314,19 +359,20 @@ func (b *activeSubagentBudget) cleanupExpired(now time.Time) {
 		}
 	}
 }
-func (b *activeSubagentBudget) launchRoot(launch activeSubagentLaunch) centralstore.SessionID {
+func (b *activeSubagentBudget) launchPlacement(launch activeSubagentLaunch) activeSubagentPlacement {
 	if !launch.hasParent {
-		return ""
+		return activeSubagentPlacement{}
 	}
-	if _, ok := b.nodes[launch.parent]; !ok {
-		return ""
+	p, ok := b.placements[launch.parent]
+	if !ok {
+		return activeSubagentPlacement{}
 	}
-	return b.roots[launch.parent]
+	return activeSubagentPlacement{root: p.root, depth: p.depth + 1}
 }
-func (b *activeSubagentBudget) reservedAt(root centralstore.SessionID) int {
+func (b *activeSubagentBudget) reservedAt(want activeSubagentPlacement) int {
 	n := 0
 	for _, launch := range b.launches {
-		if b.launchRoot(launch) == root {
+		if b.launchPlacement(launch) == want {
 			n++
 		}
 	}
@@ -340,12 +386,16 @@ func (b *activeSubagentBudget) reserve(parent *centralstore.SessionID) (ActiveSu
 	if parent != nil {
 		launch.parent, launch.hasParent = *parent, true
 	}
-	root := b.launchRoot(launch)
-	active := 0
-	if root != "" {
-		active = b.activeByRoot[root] + b.reservedAt(root)
-		if active >= b.limit {
-			return ActiveSubagentReservation{}, &SubagentLimitError{Root: root, Active: active, Limit: b.limit}
+	placement := b.launchPlacement(launch)
+	active, limit := 0, 0
+	if placement.root != "" {
+		limit = b.cap(placement.depth)
+		active = b.activeByDepth[activeSubagentCountKey{root: placement.root, depth: placement.depth}] + b.reservedAt(placement)
+		if b.disabled {
+			limit = -1
+		}
+		if limit != -1 && active >= limit {
+			return ActiveSubagentReservation{}, &SubagentLimitError{Root: placement.root, Depth: placement.depth, Active: active, Limit: limit}
 		}
 	}
 	var raw [16]byte
@@ -354,7 +404,7 @@ func (b *activeSubagentBudget) reserve(parent *centralstore.SessionID) (ActiveSu
 	}
 	token := hex.EncodeToString(raw[:])
 	b.launches[token] = launch
-	return ActiveSubagentReservation{Token: token, Root: root, Active: active, Limit: b.limit, ExpiresAt: launch.expires}, nil
+	return ActiveSubagentReservation{Token: token, Root: placement.root, Depth: placement.depth, Active: active, Limit: limit, ExpiresAt: launch.expires}, nil
 }
 
 func (b *activeSubagentBudget) claim(token string, id centralstore.SessionID) (activeSubagentLaunch, error) {
@@ -383,16 +433,24 @@ func (b *activeSubagentBudget) validateParent(launch activeSubagentLaunch, paren
 // this receipt, so equality with limit is valid; anything greater means its
 // parent moved into a root that was already full after admission.
 func (b *activeSubagentBudget) validateClaimedBudget(launch activeSubagentLaunch) error {
-	root := b.launchRoot(launch)
-	if root == "" {
+	if b.disabled {
 		return nil
 	}
-	active := b.activeByRoot[root] + b.reservedAt(root)
-	if active > b.limit {
-		return &SubagentLimitError{Root: root, Active: active - 1, Limit: b.limit}
+	placement := b.launchPlacement(launch)
+	if placement.root == "" {
+		return nil
+	}
+	limit := b.cap(placement.depth)
+	if limit == -1 {
+		return nil
+	}
+	active := b.activeByDepth[activeSubagentCountKey{root: placement.root, depth: placement.depth}] + b.reservedAt(placement)
+	if active > limit {
+		return &SubagentLimitError{Root: placement.root, Depth: placement.depth, Active: active - 1, Limit: limit}
 	}
 	return nil
 }
+
 func (b *activeSubagentBudget) release(token string, claimed bool) {
 	launch, ok := b.launches[token]
 	if !ok {

--- a/services/gmuxd/internal/sessioncoord/active_subagents_test.go
+++ b/services/gmuxd/internal/sessioncoord/active_subagents_test.go
@@ -35,7 +35,7 @@ func TestActiveSubagentRootAndCountTable(t *testing.T) {
 		budgetSession("cycle-b", "pi", budgetParent("cycle-a"), false),
 		budgetSession("cycle-child", "pi", budgetParent("cycle-b"), false),
 	}
-	b := newActiveSubagentBudget(8, func(adapter string) bool { return adapter == "pi" }, rows)
+	b := newActiveSubagentBudget([]int{8}, false, func(adapter string) bool { return adapter == "pi" }, rows)
 	for _, id := range []centralstore.SessionID{"agent", "nested", "process", "promoted", "promoted-child", "orphan", "orphan-child", "cycle-a", "cycle-b", "cycle-child"} {
 		b.setLive(id, true)
 	}
@@ -47,14 +47,18 @@ func TestActiveSubagentRootAndCountTable(t *testing.T) {
 		"cycle-a": "cycle-a", "cycle-b": "cycle-a", "cycle-child": "cycle-a",
 	}
 	for id, want := range roots {
-		if got := b.roots[id]; got != want {
+		if got := b.placements[id].root; got != want {
 			t.Errorf("root(%s) = %s, want %s", id, got, want)
 		}
 	}
-	wantCounts := map[centralstore.SessionID]int{"root": 2, "promoted": 1, "orphan": 1, "cycle-a": 2}
-	for root, want := range wantCounts {
-		if got := b.activeByRoot[root]; got != want {
-			t.Errorf("active[%s] = %d, want %d", root, got, want)
+	wantCounts := map[activeSubagentCountKey]int{
+		{root: "root", depth: 1}: 1, {root: "root", depth: 2}: 1,
+		{root: "promoted", depth: 1}: 1, {root: "orphan", depth: 1}: 1,
+		{root: "cycle-a", depth: 1}: 1, {root: "cycle-a", depth: 2}: 1,
+	}
+	for key, want := range wantCounts {
+		if got := b.activeByDepth[key]; got != want {
+			t.Errorf("active[%s,%d] = %d, want %d", key.root, key.depth, got, want)
 		}
 	}
 	if _, exists := b.nodes["remote@peer"]; exists {
@@ -69,28 +73,69 @@ func TestActiveSubagentMutableOwnershipTransitions(t *testing.T) {
 		budgetSession("child", "pi", budgetParent("a"), false),
 		budgetSession("grand", "pi", budgetParent("child"), false),
 	}
-	b := newActiveSubagentBudget(8, func(adapter string) bool { return adapter == "pi" }, rows)
+	b := newActiveSubagentBudget([]int{8}, false, func(adapter string) bool { return adapter == "pi" }, rows)
 	b.setLive("child", true)
 	b.setLive("grand", true)
-	if b.activeByRoot["a"] != 2 {
-		t.Fatalf("initial counts = %v", b.activeByRoot)
+	if b.activeByDepth[activeSubagentCountKey{root: "a", depth: 1}] != 1 || b.activeByDepth[activeSubagentCountKey{root: "a", depth: 2}] != 1 {
+		t.Fatalf("initial counts = %v", b.activeByDepth)
 	}
 
 	b.setParent("child", budgetParent("b"))
-	if b.activeByRoot["a"] != 0 || b.activeByRoot["b"] != 2 {
-		t.Fatalf("reparent counts = %v", b.activeByRoot)
+	if b.activeByDepth[activeSubagentCountKey{root: "a", depth: 1}] != 0 || b.activeByDepth[activeSubagentCountKey{root: "b", depth: 1}] != 1 || b.activeByDepth[activeSubagentCountKey{root: "b", depth: 2}] != 1 {
+		t.Fatalf("reparent counts = %v", b.activeByDepth)
 	}
 	b.setPromotion("child", true)
-	if b.activeByRoot["b"] != 0 || b.activeByRoot["child"] != 1 {
-		t.Fatalf("promotion counts = %v", b.activeByRoot)
+	if b.activeByDepth[activeSubagentCountKey{root: "b", depth: 1}] != 0 || b.activeByDepth[activeSubagentCountKey{root: "child", depth: 1}] != 1 {
+		t.Fatalf("promotion counts = %v", b.activeByDepth)
 	}
 	b.setPromotion("child", false)
-	if b.activeByRoot["b"] != 2 || b.activeByRoot["child"] != 0 {
-		t.Fatalf("demotion counts = %v", b.activeByRoot)
+	if b.activeByDepth[activeSubagentCountKey{root: "b", depth: 1}] != 1 || b.activeByDepth[activeSubagentCountKey{root: "b", depth: 2}] != 1 || b.activeByDepth[activeSubagentCountKey{root: "child", depth: 1}] != 0 {
+		t.Fatalf("demotion counts = %v", b.activeByDepth)
 	}
 	b.setLive("grand", false)
-	if b.activeByRoot["b"] != 1 {
-		t.Fatalf("termination counts = %v", b.activeByRoot)
+	if b.activeByDepth[activeSubagentCountKey{root: "b", depth: 1}] != 1 || b.activeByDepth[activeSubagentCountKey{root: "b", depth: 2}] != 0 {
+		t.Fatalf("termination counts = %v", b.activeByDepth)
+	}
+}
+
+func TestDepthBudgetDefaultShapeAndOptOut(t *testing.T) {
+	root := centralstore.SessionID("root")
+	rows := []centralstore.Session{{ID: root, Adapter: "shell"}}
+	for i := 0; i < 50; i++ {
+		rows = append(rows, budgetSession(fmt.Sprintf("child-%d", i), "pi", &root, false))
+	}
+	b := newActiveSubagentBudget([]int{-1, 8}, false, func(a string) bool { return a == "pi" }, rows)
+	for i := 0; i < 50; i++ {
+		b.setLive(centralstore.SessionID(fmt.Sprintf("child-%d", i)), true)
+	}
+	if _, err := b.reserve(&root); err != nil {
+		t.Fatalf("direct child should be unlimited: %v", err)
+	}
+	for i := 0; i < 8; i++ {
+		parent := centralstore.SessionID(fmt.Sprintf("child-%d", i))
+		if _, err := b.reserve(&parent); err != nil {
+			t.Fatalf("grandchild %d: %v", i, err)
+		}
+	}
+	parent := centralstore.SessionID("child-8")
+	if _, err := b.reserve(&parent); !errors.Is(err, ErrSubagentLimitReached) {
+		t.Fatalf("ninth shared grandchild = %v, want limit", err)
+	}
+
+	grandchild := budgetSession("grandchild", "pi", budgetParent("child-0"), false)
+	b.upsert(grandchild, true)
+	grandchildID := centralstore.SessionID("grandchild")
+	if _, err := b.reserve(&grandchildID); !errors.Is(err, ErrSubagentLimitReached) {
+		t.Fatalf("implicit trailing zero = %v, want limit", err)
+	}
+
+	off := newActiveSubagentBudget([]int{-1, 8}, true, func(a string) bool { return a == "pi" }, append(rows, grandchild))
+	disabledReservation, err := off.reserve(&grandchildID)
+	if err != nil {
+		t.Fatalf("disabled budget refused launch: %v", err)
+	}
+	if disabledReservation.Limit != -1 {
+		t.Fatalf("disabled reservation limit = %d, want -1", disabledReservation.Limit)
 	}
 }
 
@@ -100,7 +145,7 @@ func coordinatorAtSeven(t *testing.T) *Coordinator {
 	for i := 0; i < 7; i++ {
 		rows = append(rows, budgetSession(fmt.Sprintf("agent-%d", i), "pi", budgetParent("root"), false))
 	}
-	c := New(nil, nil, nil, nil, nil, WithActiveSubagentBudget(8, func(adapter string) bool { return adapter == "pi" }, rows))
+	c := New(nil, nil, nil, nil, nil, WithActiveSubagentBudget([]int{8}, false, func(adapter string) bool { return adapter == "pi" }, rows))
 	c.mu.Lock()
 	for i := 0; i < 7; i++ {
 		c.activeSubagents.setLive(centralstore.SessionID(fmt.Sprintf("agent-%d", i)), true)
@@ -150,13 +195,56 @@ func TestConcurrentActiveSubagentAdmissionAtSevenOfEight(t *testing.T) {
 	child := budgetSession("agent-7", "pi", &parent, false)
 	c.activeSubagents.upsert(child, true)
 	c.activeSubagents.release(successes[0].Token, false)
-	if got := c.activeSubagents.activeByRoot[parent]; got != 8 {
+	if got := c.activeSubagents.activeByDepth[activeSubagentCountKey{root: parent, depth: 1}]; got != 8 {
 		t.Fatalf("live descendants = %d, want 8", got)
 	}
 	if got := len(c.activeSubagents.launches); got != 0 {
 		t.Fatalf("leaked launch state = %d", got)
 	}
 	c.mu.Unlock()
+}
+
+func TestConcurrentSiblingAdmissionSharesGrandchildPool(t *testing.T) {
+	root := centralstore.SessionID("root")
+	rows := []centralstore.Session{{ID: root, Adapter: "shell"}}
+	for i := 0; i < 32; i++ {
+		parent := centralstore.SessionID(fmt.Sprintf("parent-%d", i))
+		rows = append(rows, budgetSession(string(parent), "pi", &root, false))
+		if i < 7 {
+			rows = append(rows, budgetSession(fmt.Sprintf("grand-%d", i), "pi", &parent, false))
+		}
+	}
+	c := New(nil, nil, nil, nil, nil, WithActiveSubagentBudget([]int{-1, 8}, false, func(a string) bool { return a == "pi" }, rows))
+	c.mu.Lock()
+	for i := 0; i < 7; i++ {
+		c.activeSubagents.setLive(centralstore.SessionID(fmt.Sprintf("grand-%d", i)), true)
+	}
+	c.mu.Unlock()
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	var successes atomic.Int32
+	for i := 0; i < 32; i++ {
+		parent := centralstore.SessionID(fmt.Sprintf("parent-%d", i))
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			if _, err := c.ReserveActiveSubagent(context.Background(), &parent); err == nil {
+				successes.Add(1)
+			} else {
+				var limit *SubagentLimitError
+				if !errors.As(err, &limit) || limit.Depth != 2 {
+					t.Errorf("admission error = %v", err)
+				}
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	if successes.Load() != 1 {
+		t.Fatalf("successes = %d, want 1 shared slot", successes.Load())
+	}
 }
 
 func TestConcurrentActiveSubagentAdmissionAtEightOfEight(t *testing.T) {
@@ -193,14 +281,16 @@ func TestConcurrentActiveSubagentAdmissionAtEightOfEight(t *testing.T) {
 }
 
 func TestReservedLaunchFollowsReparentAndBlocksDismiss(t *testing.T) {
-	rootA, rootB, caller := centralstore.SessionID("root-a"), centralstore.SessionID("root-b"), centralstore.SessionID("caller")
+	rootA, rootB := centralstore.SessionID("root-a"), centralstore.SessionID("root-b")
+	caller, callerA := centralstore.SessionID("caller"), centralstore.SessionID("caller-a")
 	rows := []centralstore.Session{
 		{ID: rootA, Adapter: "shell"}, {ID: rootB, Adapter: "shell"},
 		{ID: caller, Adapter: "shell", ParentSessionID: &rootA},
+		{ID: callerA, Adapter: "shell", ParentSessionID: &rootA},
 	}
 	durable := newFakeDurable(0)
 	durable.listSessions = func() ([]centralstore.Session, error) { return rows, nil }
-	coord := New(nil, nil, durable, nil, nil, WithActiveSubagentBudget(1, func(a string) bool { return a == "pi" }, rows))
+	coord := New(nil, nil, durable, nil, nil, WithActiveSubagentBudget([]int{-1, 1}, false, func(a string) bool { return a == "pi" }, rows))
 	first, err := coord.ReserveActiveSubagent(context.Background(), &caller)
 	if err != nil {
 		t.Fatal(err)
@@ -208,10 +298,10 @@ func TestReservedLaunchFollowsReparentAndBlocksDismiss(t *testing.T) {
 	coord.mu.Lock()
 	coord.activeSubagents.setParent(caller, &rootB)
 	coord.mu.Unlock()
-	if _, err := coord.ReserveActiveSubagent(context.Background(), &rootB); !errors.Is(err, ErrSubagentLimitReached) {
+	if _, err := coord.ReserveActiveSubagent(context.Background(), &caller); !errors.Is(err, ErrSubagentLimitReached) {
 		t.Fatalf("reservation did not move with caller: %v", err)
 	}
-	if _, err := coord.ReserveActiveSubagent(context.Background(), &rootA); err != nil {
+	if _, err := coord.ReserveActiveSubagent(context.Background(), &callerA); err != nil {
 		t.Fatalf("old root did not regain slot: %v", err)
 	}
 	if _, err := coord.Dismiss(context.Background(), caller); !errors.Is(err, ErrSubtreeBusy) {
@@ -222,8 +312,9 @@ func TestReservedLaunchFollowsReparentAndBlocksDismiss(t *testing.T) {
 
 func TestClaimedLaunchRechecksBudgetAfterReparent(t *testing.T) {
 	rootA, rootB, caller := centralstore.SessionID("root-a"), centralstore.SessionID("root-b"), centralstore.SessionID("caller")
-	rows := []centralstore.Session{{ID: rootA, Adapter: "shell"}, {ID: rootB, Adapter: "shell"}, {ID: caller, Adapter: "shell", ParentSessionID: &rootA}, budgetSession("full", "pi", &rootB, false)}
-	b := newActiveSubagentBudget(1, func(a string) bool { return a == "pi" }, rows)
+	coordinator := centralstore.SessionID("coordinator")
+	rows := []centralstore.Session{{ID: rootA, Adapter: "shell"}, {ID: rootB, Adapter: "shell"}, {ID: caller, Adapter: "shell", ParentSessionID: &rootA}, {ID: coordinator, Adapter: "shell", ParentSessionID: &rootB}, budgetSession("full", "pi", &coordinator, false)}
+	b := newActiveSubagentBudget([]int{-1, 1}, false, func(a string) bool { return a == "pi" }, rows)
 	b.setLive("full", true)
 	reservation, err := b.reserve(&caller)
 	if err != nil {
@@ -241,13 +332,13 @@ func TestClaimedLaunchRechecksBudgetAfterReparent(t *testing.T) {
 
 func TestMissingNodeMutationsDoNotCorruptDescendantCounts(t *testing.T) {
 	root, missing, child := centralstore.SessionID("root"), centralstore.SessionID("missing"), centralstore.SessionID("child")
-	b := newActiveSubagentBudget(1, func(a string) bool { return a == "pi" }, []centralstore.Session{{ID: root, Adapter: "shell"}, budgetSession(string(child), "pi", &missing, false)})
+	b := newActiveSubagentBudget([]int{1}, false, func(a string) bool { return a == "pi" }, []centralstore.Session{{ID: root, Adapter: "shell"}, budgetSession(string(child), "pi", &missing, false)})
 	b.setLive(child, true)
-	before := b.activeByRoot[child]
+	before := b.activeByDepth[activeSubagentCountKey{root: child, depth: 1}]
 	b.setParent(missing, &root)
 	b.setPromotion(missing, true)
 	b.remove(missing)
-	if got := b.activeByRoot[child]; got != before {
+	if got := b.activeByDepth[activeSubagentCountKey{root: child, depth: 1}]; got != before {
 		t.Fatalf("count changed from %d to %d", before, got)
 	}
 }
@@ -282,7 +373,7 @@ func TestActiveSubagentRegistrationConsumesAndTerminationReleasesSlot(t *testing
 	durable.applyResult = func(centralstore.RunnerObservation) (centralstore.MutationResult, error) {
 		return centralstore.MutationResult{Changed: true, SessionsDirty: true, SessionVersion: 2}, nil
 	}
-	coord := New(nil, client, durable, nil, nil, WithActiveSubagentBudget(8, func(a string) bool { return a == "pi" }, rows))
+	coord := New(nil, client, durable, nil, nil, WithActiveSubagentBudget([]int{8}, false, func(a string) bool { return a == "pi" }, rows))
 	coord.mu.Lock()
 	for i := 0; i < 7; i++ {
 		coord.activeSubagents.setLive(centralstore.SessionID(fmt.Sprintf("live%04d", i)), true)
@@ -297,7 +388,7 @@ func TestActiveSubagentRegistrationConsumesAndTerminationReleasesSlot(t *testing
 		t.Fatal(err)
 	}
 	coord.mu.Lock()
-	if got := coord.activeSubagents.activeByRoot[parent]; got != 8 {
+	if got := coord.activeSubagents.activeByDepth[activeSubagentCountKey{root: parent, depth: 1}]; got != 8 {
 		t.Fatalf("after register active=%d", got)
 	}
 	if len(coord.activeSubagents.launches) != 0 {
@@ -309,7 +400,7 @@ func TestActiveSubagentRegistrationConsumesAndTerminationReleasesSlot(t *testing
 	alive := false
 	coord.apply(context.Background(), childID, runtime.Generation, RunnerEvent{ObservedAt: exit, Alive: &alive, Facts: centralstore.RunnerFacts{ExitedAt: centralstore.NullablePatch[centralstore.UnixMillis]{Set: &exit}}})
 	coord.mu.Lock()
-	if got := coord.activeSubagents.activeByRoot[parent]; got != 7 {
+	if got := coord.activeSubagents.activeByDepth[activeSubagentCountKey{root: parent, depth: 1}]; got != 7 {
 		t.Fatalf("after termination active=%d", got)
 	}
 	coord.mu.Unlock()
@@ -324,7 +415,7 @@ func TestActiveSubagentRegistrationPanicUnlocksAndPreservesReceipt(t *testing.T)
 	durable.registerResult = func(centralstore.RunnerRegistration) (centralstore.Session, centralstore.MutationResult, error) {
 		panic("boom")
 	}
-	coord := New(nil, client, durable, nil, nil, WithActiveSubagentBudget(1, func(a string) bool { return a == "pi" }, []centralstore.Session{{ID: parent, Adapter: "shell"}}))
+	coord := New(nil, client, durable, nil, nil, WithActiveSubagentBudget([]int{1}, false, func(a string) bool { return a == "pi" }, []centralstore.Session{{ID: parent, Adapter: "shell"}}))
 	reservation, err := coord.ReserveActiveSubagent(context.Background(), &parent)
 	if err != nil {
 		t.Fatal(err)
@@ -359,7 +450,7 @@ func TestActiveSubagentRegistrationFailureReleasesClaimedReceipt(t *testing.T) {
 	client := newFakeClient(meta)
 	client.metaErr = errors.New("startup meta failed")
 	coord := New(nil, client, newFakeDurable(0), nil, nil,
-		WithActiveSubagentBudget(1, func(a string) bool { return a == "pi" }, []centralstore.Session{{ID: parent, Adapter: "shell"}}))
+		WithActiveSubagentBudget([]int{1}, false, func(a string) bool { return a == "pi" }, []centralstore.Session{{ID: parent, Adapter: "shell"}}))
 	reservation, err := coord.ReserveActiveSubagent(context.Background(), &parent)
 	if err != nil {
 		t.Fatal(err)
@@ -390,7 +481,7 @@ func TestActiveSubagentRestartReconstructsOwnershipFromDurableRows(t *testing.T)
 	durable.registerResult = func(centralstore.RunnerRegistration) (centralstore.Session, centralstore.MutationResult, error) {
 		return centralstore.Session{ID: child, Version: 1, Adapter: "pi", ParentSessionID: &parent}, centralstore.MutationResult{Changed: true, SessionVersion: 1}, nil
 	}
-	coord := New(nil, client, durable, nil, nil, WithActiveSubagentBudget(1, func(a string) bool { return a == "pi" }, rows))
+	coord := New(nil, client, durable, nil, nil, WithActiveSubagentBudget([]int{1}, false, func(a string) bool { return a == "pi" }, rows))
 	if _, err := coord.Register(context.Background(), RegisterRequest{Endpoint: "surviving-runner"}); err != nil {
 		t.Fatal(err)
 	}
@@ -408,7 +499,7 @@ func BenchmarkActiveSubagentAdmission1000Sessions(b *testing.B) {
 		rows = append(rows, budgetSession(id, "shell", &parent, false))
 		parent = centralstore.SessionID(id)
 	}
-	budget := newActiveSubagentBudget(8, func(string) bool { return false }, rows)
+	budget := newActiveSubagentBudget([]int{8}, false, func(string) bool { return false }, rows)
 	launchParent := parent
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/services/gmuxd/internal/sessioncoord/coordinator.go
+++ b/services/gmuxd/internal/sessioncoord/coordinator.go
@@ -280,9 +280,9 @@ func WithClock(now func() centralstore.UnixMillis) Option {
 // WithActiveSubagentBudget enables host-local launch admission. initial is a
 // durable ownership snapshot; runtime liveness is populated as surviving
 // runners register during startup convergence.
-func WithActiveSubagentBudget(limit int, semantic func(string) bool, initial []centralstore.Session) Option {
+func WithActiveSubagentBudget(limits []int, disabled bool, semantic func(string) bool, initial []centralstore.Session) Option {
 	return func(c *Coordinator) {
-		c.activeSubagents = newActiveSubagentBudget(limit, semantic, initial)
+		c.activeSubagents = newActiveSubagentBudget(limits, disabled, semantic, initial)
 	}
 }
 


### PR DESCRIPTION
## Summary

- replace the scalar root-wide subagent cap with `max_subagents_by_depth`
- default to unlimited root children, eight shared grandchildren, and zero deeper descendants (`[-1, 8]`)
- accept `false` as an enforcement opt-out while retaining reservation accounting
- track live semantic agents and launch receipts per behavioral root and family depth
- preserve atomic admission and install-time rechecks across reparenting and promotion
- return depth-aware refusal errors and document the configuration model

## Why

The previous scalar cap conflated deliberate root fanout with autonomous cascades, blocking legitimate root swarms. A shared per-depth pool keeps root orchestration unconstrained while placing an absolute bound on correlated recursive spawning below it.

## Validation

- all Go module test suites pass after rebasing onto latest `main`
- independent adversarial reviews by `openai-codex/gpt-5.6-sol:low` and `anthropic/claude-opus-5:low`; both concluded **integrate** after review fixes
- includes concurrent sibling admission, reparent/promotion, restart, receipt lifecycle, config validation, opt-out, and implicit trailing-zero tests
