### PR TITLE
fix(web): label the mobile Shift+Tab key as ⇧tab

### DIFF
--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -555,7 +555,13 @@ const IconDown  = () => <svg viewBox="0 0 14 14" width="16" height="16" {...S}><
 const IconLeft  = () => <svg viewBox="0 0 14 14" width="16" height="16" {...S}><path d="M10 7H4m0 0 3-3M4 7l3 3"/></svg>
 const IconRight = () => <svg viewBox="0 0 14 14" width="16" height="16" {...S}><path d="M4 7h6m0 0-3-3m3 3-3 3"/></svg>
 
-const IconBackTab  = () => <svg viewBox="0 0 24 18" width="22" height="16" {...S}><path d="M5 6V2m0 0L3 4m2-2 2 2"/><line x1="10" y1="7" x2="10" y2="15"/><path d="M19 11h-6m0 0 3-3m-3 3 3 3"/></svg>
+// Shift-key glyph for the Shift+Tab key, which reads as "⇧tab": one drawn
+// modifier mark plus the same lowercase word style as esc/tab/ctrl/alt. It is
+// drawn rather than typed as U+21E7 because none of the bundled Source Sans 3
+// subsets covers that codepoint (they carry ↑/↓ but nothing in the shift/tab
+// range), so a literal ⇧ would fall back to an OS font with foreign weight
+// and metrics.
+const IconShift = () => <svg viewBox="0 0 12 14" width="11" height="12" aria-hidden="true" {...S}><path d="M6 2 1.6 6.6h2.3v4.2h4.2V6.6h2.3z"/></svg>
 const IconWordLeft  = () => <svg viewBox="0 0 18 14" width="20" height="16" {...S}><line x1="3.5" y1="3" x2="3.5" y2="11"/><path d="M13 7H6m0 0 3-3M6 7l3 3"/></svg>
 const IconWordRight = () => <svg viewBox="0 0 18 14" width="20" height="16" {...S}><line x1="14.5" y1="3" x2="14.5" y2="11"/><path d="M5 7h7m0 0-3-3m3 3-3 3"/></svg>
 const IconSend = () => <svg viewBox="0 0 14 14" width="16" height="16" fill="currentColor" stroke="none"><path d="M3 2.5l8 4.5-8 4.5V8.5L7.5 7 3 5.5z"/></svg>
@@ -659,7 +665,7 @@ function MobileTerminalBar({
     <div class="mobile-bottom-bar" role="toolbar" aria-label="Terminal keys" onMouseDown={keepFocus}>
       <MenuButton variant="bar" onMenu={onMenu} />
       <button class="mobile-bottom-action mk-esc" disabled={!canSend} aria-label="Escape" onClick={() => sendKey('\x1b')} title="Escape"><span class="mkey-face">esc</span></button>
-      <button class="mobile-bottom-action mk-shift-tab" disabled={!canSend} aria-label="Shift+Tab (BackTab)" onClick={() => sendKey(keyComboToSequence('shift+tab'))} title="Shift+Tab (BackTab)"><span class="mkey-face"><IconBackTab /></span></button>
+      <button class="mobile-bottom-action mk-shift-tab" disabled={!canSend} aria-label="Shift+Tab (BackTab)" onClick={() => sendKey(keyComboToSequence('shift+tab'))} title="Shift+Tab (BackTab)"><span class="mkey-face"><IconShift />tab</span></button>
       <button class="mobile-bottom-action mk-tab" disabled={!canSend} aria-label="Tab" onClick={() => sendKey('\t')} title="Tab"><span class="mkey-face">tab</span></button>
       <button class={`${armedClass(ctrlArmed)} mk-ctrl`} disabled={!canSend} aria-pressed={ctrlArmed} onClick={onToggleCtrl} title={ctrlArmed ? 'Ctrl armed for next key' : 'Arm Ctrl'}><span class="mkey-face">ctrl</span></button>
       <button class={`${armedClass(altArmed)} mk-alt`} disabled={!canSend} aria-pressed={altArmed} onClick={onToggleAlt} title={altArmed ? 'Alt armed for next key' : 'Arm Alt'}><span class="mkey-face">alt</span></button>

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -3538,6 +3538,14 @@ body {
     padding: 0 4px;
   }
 
+  /* Shift+Tab is the one key that pairs a drawn modifier glyph with a word
+     ("⇧tab"), so it needs the one thing a single glyph or a single word does
+     not: a hair of space between them. The pair measures 31px against a 40.3px
+     cell on the narrowest supported phone (320px). */
+  .mk-shift-tab .mkey-face {
+    gap: 1px;
+  }
+
   /* Waiting dot on the hamburger menu button. Only the waiting (unread)
      state is surfaced; working/active are deliberately omitted.
      Pseudo-elements don't expand the hit-box, so taps outside the button

--- a/e2e/tests/mobile-shift-tab.spec.ts
+++ b/e2e/tests/mobile-shift-tab.spec.ts
@@ -149,6 +149,10 @@ test.describe('mobile Shift+Tab keyboard', () => {
     expect(safeAreaContract.left).toContain('env(safe-area-inset-left')
     expect(safeAreaContract.right).toContain('env(safe-area-inset-right')
 
+    // Pin the narrowest phone explicitly rather than inheriting whatever the
+    // loop above ended on: the assertions below are only tight at 320px, and
+    // reordering that list must not silently relax them.
+    await page.setViewportSize({ width: 320, height: 568 })
     await page.addStyleTag({ content: '.mobile-bottom-bar { --mobile-safe-area-left: 24px; --mobile-safe-area-right: 28px; }' })
     const safe = await page.evaluate(() => {
       const bar = document.querySelector('.mobile-bottom-bar')!.getBoundingClientRect()
@@ -158,5 +162,56 @@ test.describe('mobile Shift+Tab keyboard', () => {
     })
     expect(safe.menu.x).toBeGreaterThanOrEqual(24)
     expect(safe.send.right).toBeLessThanOrEqual(safe.width - 28)
+
+    // Side insets shrink every cell, and ⇧tab is the widest label in the bar,
+    // so it is the first one that would spill: 3px of total headroom here.
+    const inset = await page.evaluate(() => {
+      const face = document.querySelector('.mk-shift-tab .mkey-face') as HTMLElement
+      const range = document.createRange()
+      range.selectNodeContents(face)
+      return { content: range.getBoundingClientRect().width, cell: document.querySelector('.mk-shift-tab')!.getBoundingClientRect().width }
+    })
+    expect(inset.content).toBeLessThan(inset.cell)
+  })
+
+  test('keeps the ⇧tab label on one line, within its cell, in a bundled font', async ({ page }) => {
+    for (const [width, height] of [
+      [320, 568],
+      [390, 844],
+      [700, 390],
+      [844, 390],
+    ] as const) {
+      await page.setViewportSize({ width, height })
+      await page.waitForTimeout(100)
+      const label = await page.evaluate(() => {
+        const face = document.querySelector('.mk-shift-tab .mkey-face') as HTMLElement
+        const range = document.createRange()
+        range.selectNodeContents(face)
+        const content = range.getBoundingClientRect()
+        const cell = document.querySelector('.mk-shift-tab')!.getBoundingClientRect()
+        return {
+          // Geometry of the painted content, not of the flex box: a wrapped
+          // label doubles its height while the box keeps the row height, and a
+          // displaced one moves out of the cell while keeping its size.
+          content: { top: content.top, right: content.right, bottom: content.bottom, left: content.left, height: content.height },
+          cell: { top: cell.top, right: cell.right, bottom: cell.bottom, left: cell.left },
+          text: face.textContent ?? '',
+          glyphs: face.querySelectorAll('svg').length,
+        }
+      })
+      // One line: a 13px line box is 18px tall, wrapping to two is ~32px.
+      expect(label.content.height).toBeLessThan(24)
+      // Contained by the key's *painted* cell on both axes — not merely by the
+      // hit area, which deliberately overhangs it by half the key gap.
+      expect(label.content.left).toBeGreaterThanOrEqual(label.cell.left)
+      expect(label.content.right).toBeLessThanOrEqual(label.cell.right)
+      expect(label.content.top).toBeGreaterThanOrEqual(label.cell.top)
+      expect(label.content.bottom).toBeLessThanOrEqual(label.cell.bottom)
+      // The modifier mark must stay a drawn glyph: no bundled Source Sans 3
+      // subset covers U+21E7, so a literal ⇧/⇤ would silently fall back to an
+      // OS font with foreign weight and per-platform metrics.
+      expect(label.glyphs).toBe(1)
+      expect(label.text).toBe('tab')
+    }
   })
 })


### PR DESCRIPTION
## Summary

The Shift+Tab key added in #480 rendered as a bespoke SVG (up-arrow + bar + left-arrow). At 22×16px it was
unreadable, and it was built from the same strokes as the word-left key two cells away on the same row, so it
read as cursor motion rather than as a named key combination. The toolbar otherwise splits cleanly: **words for
named keys** (`esc`, `tab`, `ctrl`, `alt`), **glyphs for directional motion** (arrows, word-jumps, send).

This labels the key **`⇧tab`** — one drawn modifier mark plus the bar's own lowercase word style — which puts it
back on the "named key" side of that split.

- The shift mark is an inline SVG in the toolbar's shared stroke style, **not** U+21E7. No bundled Source Sans 3
  subset covers that codepoint (they carry ↑/↓ but nothing in the shift/tab range), so a literal `⇧` would fall
  back to an OS font with foreign weight and per-platform metrics. Verified by cmap inspection of the shipped
  WOFF2 files, not assumed.
- **Emitted bytes are untouched**: `keyComboToSequence('shift+tab')` still sends `ESC [ Z` = `0x1b 0x5b 0x5a`,
  once per tap, no repeat handlers.
- Accessible name stays `Shift+Tab (BackTab)`. The bar only renders behind `pointer: coarse`, so its `title` is
  effectively never hovered — the name is the only place the terminal term survives.
- No adaptive relabeling: identical at every breakpoint and under safe-area insets, matching the bar's existing
  "keys never relabel" rule.

Measured on the mock route at all four viewport classes: label **31×18px** against **40.3 / 50.3 / 58.4 /
59.7px** cells, one line everywhere, hit target unchanged (45.3×45px on the narrowest phone, wider above it).

## Alternatives considered

`shtab`, `sh-tab`, `shift tab`, a two-line `shift`/`tab` stack, literal `⇤`, literal `⇧tab`, and keeping a
corrected icon were all prototyped in the real toolbar and compared at 320×568 / 390×844 / 700×390 / 844×390.
`shift tab` is 46px against a 50.3px cell and wraps at 320. The literal-Unicode options render from an OS
fallback (see above). `shtab`/`sh-tab` are consistent but need a decoding pass and read as *shell*. Full
comparison table and screenshots in `.memory/report-mobile-shift-tab-label.md`.

## Browser regression

`e2e/tests/mobile-shift-tab.spec.ts` gains one test that pins the label at all four viewport classes:

- one line (content height, not box height — a wrapped label doubles the former while the latter is fixed);
- containment inside the **painted cell** on all four sides, not merely inside the hit area, which deliberately
  overhangs it by half the key gap;
- exactly one drawn glyph beside the text node `tab`.

Its safe-area block now pins 320×568 explicitly and checks the label against the cell that synthetic 24/28px
insets shrink to 34px — `⇧tab` is the widest label in the bar and would be the first to spill.

Every assertion was mutation-verified to fail against a matching regression: a two-word label (wraps), a larger
label (outgrows the cell), a face translated on either axis (containment), a literal `⇧` (glyph count), a
widened `gap` under insets (safe-area guard), an `<img>` swapped for the SVG, and a reordered viewport loop
(the guard stays at 320px).

## Tests

- `npx playwright test --config e2e/playwright.config.ts` ✅ — 82 tests
- focused `mobile-shift-tab.spec.ts` ✅ — 3 tests
- `pnpm --filter @gmux/web test` ✅ — 766 tests
- `tsc --noEmit` ✅ · `biome lint --error-on-warnings` ✅

## Review

Three independent reviewers (broad correctness/design fidelity, accessibility + cross-platform rendering, test
quality) reviewed this in isolated workspaces; all findings are addressed in the commit:

- the accessible name lost `(BackTab)` while the `title` that was supposed to carry it is unreachable on a
  coarse-pointer-only bar → name restored, justification corrected;
- the code comment claimed the font has "no arrow block at all" → false, U+2191/U+2193 are in the latin subset
  (and the hamburger's `☰` already falls back today) → claim narrowed to U+21E7;
- a `white-space: nowrap` declaration was inert (flex items cannot wrap and `tab` is one word) → deleted rather
  than papered over with a computed-style assertion;
- the first version of the test measured overflow and width but not placement, and its Latin-1 regex could
  never fail → replaced with four-sided geometric containment;
- the new inset assertion depended on the viewport loop's ordering → the viewport is now pinned explicitly.

## Visual evidence

- `.memory/screenshots/compare-{320x568,390x844,700x390,844x390}.png` — 8 labelled candidates each, real toolbar
- `.memory/screenshots/implemented/shipped-{320x568,390x844,700x390,844x390}.png` — shipped result
- `.memory/screenshots/context-*__A-current-icon.png` vs `context-*__D-svgshift-tab.png` — before/after in context
- `.memory/report-mobile-shift-tab-label.md` — current-state critique, comparison table, spec, test plan

## Observed but out of scope

`.mobile-bottom-action:disabled { opacity: 0.35 }` (styles.css) creates a stacking context on the button, which
the neighbouring comment explicitly forbids ("no filter/opacity/z-index or it would trap both layers"). With the
bar disabled, the upper row renders dimmer than the lower one because the face drops below the terminal layer.
Pre-existing, affects `esc`/`tab` identically, untouched here.
