### PR TITLE
fix(peering): add shared cross-tailnet Tailscale hosts

### DIFF
--- a/services/gmuxd/cmd/gmuxd/peers_test.go
+++ b/services/gmuxd/cmd/gmuxd/peers_test.go
@@ -2,10 +2,71 @@ package main
 
 import (
 	"context"
+	"errors"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
+	"time"
+
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/tsauth"
+	"tailscale.com/ipn/ipnstate"
 )
+
+type retryPeerClient struct {
+	mu    sync.Mutex
+	calls int
+}
+
+func (c *retryPeerClient) Status(context.Context) (*ipnstate.Status, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.calls++
+	if c.calls == 1 {
+		return nil, errors.New("transient status failure")
+	}
+	return &ipnstate.Status{MagicDNSSuffix: "tailnet.ts.net."}, nil
+}
+
+func (*retryPeerClient) DialTCP(context.Context, string, uint16) (net.Conn, error) {
+	return nil, errors.New("not used")
+}
+
+type markerTransport struct{}
+
+func (markerTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	return &http.Response{StatusCode: http.StatusOK, Header: http.Header{"X-Route": []string{"tsnet"}}, Body: http.NoBody}, nil
+}
+
+func TestConvergeTailnetPeerTransportRetriesSuffix(t *testing.T) {
+	transport := tsauth.NewRoutedTransport()
+	client := &retryPeerClient{}
+	retry := make(chan time.Time, 2)
+	reconnected := make(chan struct{}, 2)
+	done := make(chan struct{})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		convergeTailnetPeerTransport(ctx, transport, "", markerTransport{}, client, func() { reconnected <- struct{}{} }, retry)
+		close(done)
+	}()
+	<-reconnected // embedded client installed immediately despite empty suffix
+	retry <- time.Now()
+	retry <- time.Now()
+	<-reconnected // suffix converged after transient failure
+
+	req, _ := http.NewRequest(http.MethodGet, "https://host.tailnet.ts.net/v1/health", nil)
+	resp, err := transport.RoundTrip(req)
+	if err != nil || resp.Header.Get("X-Route") != "tsnet" {
+		t.Fatalf("same-tailnet route did not converge: resp=%v err=%v", resp, err)
+	}
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("convergence did not finish")
+	}
+}
 
 // probePeerHealth is the contract the add-peer flow relies on: it must
 // reach /v1/health, forward the bearer token, and pull node_id + name

--- a/services/gmuxd/cmd/gmuxd/serve_central.go
+++ b/services/gmuxd/cmd/gmuxd/serve_central.go
@@ -88,6 +88,36 @@ func registerGetProjectsRoute(mux *http.ServeMux, render func(*http.Request) (wi
 	})
 }
 
+// convergeTailnetPeerTransport installs the embedded LocalAPI client
+// immediately, even when ready-time suffix discovery failed, then retries the
+// suffix independently so same-tailnet routing also converges without restart.
+func convergeTailnetPeerTransport(ctx context.Context, transport *tsauth.RoutedTransport, suffix string, rt http.RoundTripper, client tsauth.PeerClient, reconnect func(), retry <-chan time.Time) {
+	transport.SetTailnet(suffix, rt, client)
+	if reconnect != nil {
+		reconnect()
+	}
+	for suffix == "" {
+		select {
+		case <-ctx.Done():
+			return
+		case <-retry:
+		}
+		statusCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		status, err := client.Status(statusCtx)
+		cancel()
+		if err != nil {
+			continue
+		}
+		suffix = tsauth.StatusMagicDNSSuffix(status)
+		if suffix != "" {
+			transport.SetTailnet(suffix, rt, client)
+			if reconnect != nil {
+				reconnect()
+			}
+		}
+	}
+}
+
 func serveCentral(stderr io.Writer, replace bool) int {
 	// This must remain the first operation. A candidate that will yield must do
 	// no bootstrap work against the incumbent it was spawned to replace.
@@ -1013,10 +1043,14 @@ func serveCentral(stderr io.Writer, replace bool) int {
 		tsListener = tsauth.Start(tsauth.Config{Hostname: tsSeed, Allow: cfg.Tailscale.Allow}, stateDir, authedHandler)
 		defer tsListener.Shutdown()
 		go func(l *tsauth.Listener) {
-			<-l.Ready()
-			if suffix := l.MagicDNSSuffix(); suffix != "" {
-				peerTransport.SetTailnet(suffix, l.Transport())
+			select {
+			case <-l.Ready():
+			case <-daemonCtx.Done():
+				return
 			}
+			ticker := time.NewTicker(2 * time.Second)
+			defer ticker.Stop()
+			convergeTailnetPeerTransport(daemonCtx, peerTransport, l.MagicDNSSuffix(), l.Transport(), l.LocalClient(), peerManager.ReconnectAll, ticker.C)
 		}(tsListener)
 	}
 	shutdownCh := make(chan struct{})

--- a/services/gmuxd/internal/tsauth/transport.go
+++ b/services/gmuxd/internal/tsauth/transport.go
@@ -1,55 +1,102 @@
 package tsauth
 
 import (
+	"context"
+	"fmt"
+	"net"
 	"net/http"
+	"net/netip"
 	"strings"
 	"sync"
+	"time"
+
+	"tailscale.com/ipn/ipnstate"
+	"tailscale.com/net/tsaddr"
 )
 
-// RoutedTransport is an http.RoundTripper that routes requests for hosts
-// under the local tailnet's MagicDNS suffix through a tsnet-backed
-// transport, and everything else through the fallback (default) transport.
-//
-// It exists to solve a timing problem: the peering manager is constructed
-// at startup, but the tsnet listener becomes ready much later (tailscale
-// login can take minutes). A single shared RoutedTransport is handed to
-// all peers and the health probe up front; once tsnet is ready, SetTailnet
-// installs the suffix and dialer atomically, and peers on the tailnet pick
-// up tsnet routing on their next request without re-construction.
-//
-// A host on a *different* tailnet (reachable only via system tailscaled)
-// won't match the local suffix and keeps the default transport, as before.
+// PeerClient is the supported LocalAPI seam used both to inspect a tailscaled
+// netmap and to dial through that same tailscaled instance. Binding membership
+// and dialing to one client avoids assuming a kernel TUN route exists (tsnet
+// and userspace-networking nodes deliberately do not provide one).
+type PeerClient interface {
+	Status(context.Context) (*ipnstate.Status, error)
+	DialTCP(context.Context, string, uint16) (net.Conn, error)
+}
+
+type statusClient interface {
+	Status(context.Context) (*ipnstate.Status, error)
+}
+
+func statusWithTimeout(ctx context.Context, client statusClient, timeout time.Duration) (*ipnstate.Status, error) {
+	statusCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	return client.Status(statusCtx)
+}
+
+type contextDialer interface {
+	DialContext(context.Context, string, string) (net.Conn, error)
+}
+
+// RoutedTransport routes local-tailnet MagicDNS names through embedded tsnet.
+// Foreign .ts.net names remain on the system network, but when system DNS does
+// not know a shared node their address is taken from system tailscaled's
+// LocalAPI. The URL host is never rewritten, preserving TLS verification/SNI.
 type RoutedTransport struct {
 	fallback http.RoundTripper
+	foreign  http.RoundTripper
 
 	mu     sync.RWMutex
-	suffix string // local tailnet MagicDNS suffix, e.g. "tailnet.ts.net"
+	suffix string
 	tsnet  http.RoundTripper
 }
 
-// NewRoutedTransport returns a RoutedTransport that sends everything
-// through http.DefaultTransport until SetTailnet is called.
+// NewRoutedTransport starts with ordinary network behavior. Once gmux's
+// embedded tsnet is ready, SetTailnet installs its LocalAPI client for exact
+// foreign-peer membership and dialing. gmux deliberately does not depend on a
+// separate system tailscaled, whose identity/state may be unrelated or stale.
 func NewRoutedTransport() *RoutedTransport {
-	return &RoutedTransport{fallback: http.DefaultTransport}
+	return newRoutedTransport(http.DefaultTransport, nil, &net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+	})
 }
 
-// SetTailnet installs the tailnet MagicDNS suffix and the tsnet-backed
-// transport. Safe to call from any goroutine; requests in flight keep
-// whichever transport they already selected.
-func (t *RoutedTransport) SetTailnet(suffix string, rt http.RoundTripper) {
-	suffix = normalizeHost(suffix)
+func newRoutedTransport(fallback http.RoundTripper, client PeerClient, dialer contextDialer) *RoutedTransport {
+	t := &RoutedTransport{fallback: fallback}
+	if base, ok := fallback.(*http.Transport); ok {
+		exact := base.Clone()
+		// An HTTP proxy would have to resolve the foreign MagicDNS name and
+		// DialContext would see only the proxy address. Exact netmap members
+		// therefore bypass proxies; unknown names retain fallback behavior.
+		exact.Proxy = nil
+		// Re-check LocalAPI and establish a fresh socket for every request.
+		// Long-lived SSE requests are unaffected, while later REST/reconnect
+		// requests cannot reuse a socket admitted under stale map state.
+		exact.DisableKeepAlives = true
+		exact.DialContext = (&peerAddressDialer{fallback: dialer}).DialContext
+		t.foreign = &foreignPeerTransport{fallback: fallback, exact: exact, client: client}
+	}
+	return t
+}
+
+// SetTailnet installs the local tailnet suffix, embedded-tsnet transport, and
+// its LocalAPI client atomically. Foreign shared peers are then resolved and
+// dialed through embedded tsnet. A nil client retains the currently installed
+// client; this is useful when only later suffix discovery is being updated.
+func (t *RoutedTransport) SetTailnet(suffix string, rt http.RoundTripper, client PeerClient) {
 	t.mu.Lock()
-	t.suffix = suffix
+	t.suffix = normalizeHost(suffix)
 	t.tsnet = rt
+	if foreign, ok := t.foreign.(*foreignPeerTransport); ok && client != nil {
+		foreign.setClient(client)
+	}
 	t.mu.Unlock()
 }
 
-// RoundTrip implements http.RoundTripper.
 func (t *RoutedTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	return t.pick(req.URL.Hostname()).RoundTrip(req)
 }
 
-// pick returns the transport to use for the given request host.
 func (t *RoutedTransport) pick(host string) http.RoundTripper {
 	t.mu.RLock()
 	suffix, ts := t.suffix, t.tsnet
@@ -57,13 +104,12 @@ func (t *RoutedTransport) pick(host string) http.RoundTripper {
 	if ts != nil && hostOnTailnet(host, suffix) {
 		return ts
 	}
+	if t.foreign != nil && isTSNetName(host) {
+		return t.foreign
+	}
 	return t.fallback
 }
 
-// hostOnTailnet reports whether host falls under the MagicDNS suffix:
-// either a label under it ("gmux.tailnet.ts.net" for "tailnet.ts.net")
-// or the suffix itself. Comparison is case-insensitive and ignores
-// trailing dots.
 func hostOnTailnet(host, suffix string) bool {
 	if suffix == "" {
 		return false
@@ -72,7 +118,279 @@ func hostOnTailnet(host, suffix string) bool {
 	return host == suffix || strings.HasSuffix(host, "."+suffix)
 }
 
-// normalizeHost lowercases and strips any trailing dot from a DNS name.
+func isTSNetName(host string) bool {
+	host = normalizeHost(host)
+	return strings.HasSuffix(host, ".ts.net") && host != "ts.net"
+}
+
 func normalizeHost(h string) string {
-	return strings.ToLower(strings.TrimSuffix(strings.TrimSpace(h), "."))
+	return strings.ToLower(strings.TrimRight(strings.TrimSpace(h), "."))
+}
+
+const (
+	peerStatusFreshFor = 2 * time.Second
+	peerStatusStaleFor = 30 * time.Second
+)
+
+type statusFlight struct {
+	generation uint64
+	done       chan struct{}
+	status     *ipnstate.Status
+	err        error
+}
+
+type foreignPeerTransport struct {
+	fallback http.RoundTripper
+	exact    http.RoundTripper
+
+	mu         sync.Mutex
+	client     PeerClient
+	generation uint64
+	cached     *ipnstate.Status
+	cachedAt   time.Time
+	cachedGen  uint64
+	inflight   *statusFlight
+	now        func() time.Time
+}
+
+func (t *foreignPeerTransport) setClient(client PeerClient) {
+	t.mu.Lock()
+	t.client = client
+	t.generation++
+	t.cached = nil
+	t.cachedAt = time.Time{}
+	t.cachedGen = 0
+	t.mu.Unlock()
+}
+
+func (t *foreignPeerTransport) currentClient() (PeerClient, uint64) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.client, t.generation
+}
+
+func (t *foreignPeerTransport) clock() time.Time {
+	if t.now != nil {
+		return t.now()
+	}
+	return time.Now()
+}
+
+func (t *foreignPeerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	client, generation := t.currentClient()
+	if client == nil {
+		return t.fallback.RoundTrip(req)
+	}
+	status, err := t.peerStatus(req.Context(), client, generation)
+	if err != nil {
+		// Once embedded tsnet is authoritative, never send a peer bearer token
+		// to a DNS result we could not verify against its netmap.
+		return nil, fmt.Errorf("tailscale peer status unavailable: %w", err)
+	}
+	peers := exactPeers(status, req.URL.Hostname())
+	if len(peers) == 0 {
+		// Unknown names never receive privileged address substitution or proxy
+		// bypass. Preserve ordinary routing for legitimate public/system-DNS
+		// .ts.net URLs; HTTPS still verifies the original hostname before any
+		// bearer-token request is delivered.
+		return t.fallback.RoundTrip(req)
+	}
+	if len(peers) > 1 {
+		return nil, fmt.Errorf("tailscale peer %q is ambiguous in the local netmap", normalizeHost(req.URL.Hostname()))
+	}
+	peer := peers[0]
+	if !peer.Online {
+		// Fail closed: falling through DNS could reach a different endpoint
+		// under a name tailscaled identifies as this currently-offline peer.
+		return nil, fmt.Errorf("tailscale peer %q is offline (last seen %s)", normalizeHost(req.URL.Hostname()), peer.LastSeen.Format(time.RFC3339))
+	}
+	ips := usableIPs(peer.TailscaleIPs)
+	if len(ips) == 0 {
+		return nil, fmt.Errorf("tailscale peer %q has no dialable Tailscale address", normalizeHost(req.URL.Hostname()))
+	}
+	ctx := context.WithValue(req.Context(), peerAddressesKey{}, peerDialTarget{client: client, ips: ips})
+	clone := req.Clone(ctx)
+	return t.exact.RoundTrip(clone)
+}
+
+// peerStatus coalesces concurrent reconnect bursts and tolerates a short
+// LocalAPI/backend stall using a recent immutable snapshot. Membership may be
+// at most peerStatusStaleFor old; beyond that, callers fail closed.
+func (t *foreignPeerTransport) peerStatus(ctx context.Context, client PeerClient, generation uint64) (*ipnstate.Status, error) {
+	now := t.clock()
+	t.mu.Lock()
+	if t.cached != nil && t.cachedGen == generation && now.Sub(t.cachedAt) <= peerStatusFreshFor {
+		status := t.cached
+		t.mu.Unlock()
+		return status, nil
+	}
+	flight := t.inflight
+	leader := flight == nil || flight.generation != generation
+	if leader {
+		flight = &statusFlight{generation: generation, done: make(chan struct{})}
+		t.inflight = flight
+	}
+	t.mu.Unlock()
+
+	if leader {
+		// The shared refresh must not inherit whichever request happened to
+		// become leader; one canceled peer must not poison healthy waiters.
+		go t.refreshPeerStatus(client, generation, flight)
+	}
+	select {
+	case <-flight.done:
+		return flight.status, flight.err
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func (t *foreignPeerTransport) refreshPeerStatus(client PeerClient, generation uint64, flight *statusFlight) {
+	status, err := statusWithTimeout(context.Background(), client, 5*time.Second)
+	finishedAt := t.clock()
+	t.mu.Lock()
+	if err == nil {
+		if t.generation == generation {
+			t.cached = status
+			t.cachedAt = finishedAt
+			t.cachedGen = generation
+		}
+		flight.status = status
+	} else if t.cached != nil && t.cachedGen == generation && finishedAt.Sub(t.cachedAt) <= peerStatusStaleFor {
+		flight.status = t.cached
+		flight.err = nil
+	} else {
+		flight.err = err
+	}
+	if t.inflight == flight {
+		t.inflight = nil
+	}
+	close(flight.done)
+	t.mu.Unlock()
+}
+
+type peerAddressesKey struct{}
+
+type peerDialTarget struct {
+	client PeerClient
+	ips    []netip.Addr
+}
+
+type peerAddressDialer struct {
+	fallback contextDialer
+}
+
+func (d *peerAddressDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	_, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return d.fallback.DialContext(ctx, network, address)
+	}
+	target, _ := ctx.Value(peerAddressesKey{}).(peerDialTarget)
+	if target.client == nil || len(target.ips) == 0 {
+		return d.fallback.DialContext(ctx, network, address)
+	}
+	return dialAny(ctx, localAPIDialer{client: target.client}, network, port, target.ips)
+}
+
+type localAPIDialer struct{ client PeerClient }
+
+func (d localAPIDialer) DialContext(ctx context.Context, _ string, address string) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return nil, err
+	}
+	portNumber, err := net.LookupPort("tcp", port)
+	if err != nil || portNumber < 1 || portNumber > 65535 {
+		return nil, fmt.Errorf("invalid peer port %q", port)
+	}
+	// Persistent SSE requests do not carry a connect deadline. Bound the
+	// LocalAPI upgrade/dial phase like http.DefaultTransport's dialer; the
+	// returned connection outlives this setup context.
+	dialCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	return d.client.DialTCP(dialCtx, host, uint16(portNumber))
+}
+
+type dialResult struct {
+	conn net.Conn
+	err  error
+}
+
+// dialAny races all current Tailscale addresses. This gives dual-stack peers
+// the same essential property as net.Dialer's Happy Eyeballs implementation:
+// a blackholed address cannot consume the request's entire deadline before a
+// reachable address family is attempted.
+func dialAny(ctx context.Context, dialer contextDialer, network, port string, ips []netip.Addr) (net.Conn, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	results := make(chan dialResult, len(ips))
+	for _, ip := range ips {
+		ip := ip
+		go func() {
+			conn, err := dialer.DialContext(ctx, network, net.JoinHostPort(ip.String(), port))
+			results <- dialResult{conn: conn, err: err}
+		}()
+	}
+	var errs []string
+	for i := 0; i < len(ips); i++ {
+		select {
+		case result := <-results:
+			if result.err == nil {
+				cancel()
+				// Losing racers can also have connected before cancellation;
+				// drain and close them rather than leaking sockets.
+				drainDialResults(results, len(ips)-i-1)
+				return result.conn, nil
+			}
+			errs = append(errs, result.err.Error())
+		case <-ctx.Done():
+			// A dial can complete successfully concurrently with cancellation.
+			// Every result not returned to the caller must still be closed.
+			drainDialResults(results, len(ips)-i)
+			return nil, ctx.Err()
+		}
+	}
+	return nil, fmt.Errorf("dial failed: %s", strings.Join(errs, "; "))
+}
+
+func drainDialResults(results <-chan dialResult, count int) {
+	if count == 0 {
+		return
+	}
+	go func() {
+		for range count {
+			result := <-results
+			if result.conn != nil {
+				_ = result.conn.Close()
+			}
+		}
+	}()
+}
+
+func exactPeers(status *ipnstate.Status, host string) []*ipnstate.PeerStatus {
+	if status == nil {
+		return nil
+	}
+	want := normalizeHost(host)
+	var found []*ipnstate.PeerStatus
+	for _, peer := range status.Peer {
+		if peer != nil && normalizeHost(peer.DNSName) == want {
+			found = append(found, peer)
+		}
+	}
+	return found
+}
+
+func usableIPs(addrs []netip.Addr) []netip.Addr {
+	out := make([]netip.Addr, 0, len(addrs))
+	seen := make(map[netip.Addr]bool, len(addrs))
+	for _, addr := range addrs {
+		addr = addr.Unmap()
+		if !addr.IsValid() || !tsaddr.IsTailscaleIP(addr) || seen[addr] {
+			continue
+		}
+		seen[addr] = true
+		out = append(out, addr)
+	}
+	return out
 }

--- a/services/gmuxd/internal/tsauth/transport_test.go
+++ b/services/gmuxd/internal/tsauth/transport_test.go
@@ -1,9 +1,29 @@
 package tsauth
 
 import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+	"net"
 	"net/http"
+	"net/http/httptest"
+	"net/netip"
 	"net/url"
+	"strings"
+	"sync"
 	"testing"
+	"time"
+
+	"tailscale.com/ipn/ipnstate"
+	"tailscale.com/types/key"
 )
 
 type stubRT struct{ name string }
@@ -21,51 +41,53 @@ func reqFor(t *testing.T, rawURL string) *http.Request {
 	return &http.Request{URL: u}
 }
 
-// A RoutedTransport with no tailnet configured must send everything —
-// including .ts.net hosts — through the fallback, so behavior before
-// tsnet is ready matches the pre-#281 default-transport path.
-func TestRoutedTransport_FallbackBeforeReady(t *testing.T) {
+// Before embedded tsnet is ready, foreign .ts.net names enter the foreign
+// transport but its nil client delegates to ordinary DNS/proxy behavior.
+func TestRoutedTransport_RoutingBeforeEmbeddedReady(t *testing.T) {
 	fallback := &stubRT{name: "fallback"}
-	rt := &RoutedTransport{fallback: fallback}
+	foreign := &stubRT{name: "foreign"}
+	rt := &RoutedTransport{fallback: fallback, foreign: foreign}
 
-	for _, u := range []string{
-		"https://gmux.tailnet.ts.net",
-		"http://192.168.1.10:9999",
-		"http://localhost:9999",
+	for _, tc := range []struct {
+		url  string
+		want http.RoundTripper
+	}{
+		{"https://gmux.tailnet.ts.net", foreign},
+		{"http://192.168.1.10:9999", fallback},
+		{"http://localhost:9999", fallback},
 	} {
-		if got := rt.pick(reqFor(t, u).URL.Hostname()); got != fallback {
-			t.Errorf("pick(%s) before SetTailnet: got tsnet route, want fallback", u)
+		if got := rt.pick(reqFor(t, tc.url).URL.Hostname()); got != tc.want {
+			t.Errorf("pick(%s) before SetTailnet = %T, want %T", tc.url, got, tc.want)
 		}
 	}
 }
 
-// After SetTailnet, only hosts under the local tailnet's MagicDNS suffix
-// route through tsnet; raw IPs, LAN names, and hosts on a *different*
-// tailnet keep the default transport (issue #281 acceptance).
+// After SetTailnet, local-suffix names use embedded tsnet, foreign .ts.net
+// names use exact LocalAPI membership, and ordinary hosts keep the fallback.
 func TestRoutedTransport_SuffixRouting(t *testing.T) {
 	fallback := &stubRT{name: "fallback"}
+	foreign := &stubRT{name: "foreign"}
 	ts := &stubRT{name: "tsnet"}
-	rt := &RoutedTransport{fallback: fallback}
-	rt.SetTailnet("tailnet.ts.net", ts)
+	rt := &RoutedTransport{fallback: fallback, foreign: foreign}
+	rt.SetTailnet("tailnet.ts.net", ts, nil)
 
 	cases := []struct {
-		url    string
-		wantTS bool
+		url  string
+		want http.RoundTripper
 	}{
-		{"https://gmux.tailnet.ts.net", true},
-		{"https://gmux.tailnet.ts.net:443", true},
-		{"https://GMUX.TAILNET.TS.NET", true},     // case-insensitive
-		{"https://gmux.tailnet.ts.net./v1", true}, // trailing dot
-		{"https://other.othernet.ts.net", false},  // different tailnet
-		{"https://evil-tailnet.ts.net", false},    // suffix must match on a label boundary
-		{"http://192.168.1.10:9999", false},
-		{"http://localhost:9999", false},
-		{"http://nas.lan:9999", false},
+		{"https://gmux.tailnet.ts.net", ts},
+		{"https://gmux.tailnet.ts.net:443", ts},
+		{"https://GMUX.TAILNET.TS.NET", ts},
+		{"https://gmux.tailnet.ts.net./v1", ts},
+		{"https://other.othernet.ts.net", foreign},
+		{"https://evil-tailnet.ts.net", foreign},
+		{"http://192.168.1.10:9999", fallback},
+		{"http://localhost:9999", fallback},
+		{"http://nas.lan:9999", fallback},
 	}
 	for _, c := range cases {
-		got := rt.pick(reqFor(t, c.url).URL.Hostname())
-		if (got == ts) != c.wantTS {
-			t.Errorf("pick(%s): tsnet=%v, want %v", c.url, got == ts, c.wantTS)
+		if got := rt.pick(reqFor(t, c.url).URL.Hostname()); got != c.want {
+			t.Errorf("pick(%s) = %T, want %T", c.url, got, c.want)
 		}
 	}
 }
@@ -73,11 +95,12 @@ func TestRoutedTransport_SuffixRouting(t *testing.T) {
 // RoundTrip must dispatch to whichever transport pick selects — the
 // routing decision is worthless if the actual request path ignores it.
 func TestRoutedTransport_RoundTripDispatch(t *testing.T) {
-	rt := &RoutedTransport{fallback: &stubRT{name: "fallback"}}
-	rt.SetTailnet("tailnet.ts.net", &stubRT{name: "tsnet"})
+	rt := &RoutedTransport{fallback: &stubRT{name: "fallback"}, foreign: &stubRT{name: "foreign"}}
+	rt.SetTailnet("tailnet.ts.net", &stubRT{name: "tsnet"}, nil)
 
 	for _, c := range []struct{ url, want string }{
 		{"https://gmux.tailnet.ts.net/v1/health", "tsnet"},
+		{"https://gmux.othernet.ts.net/v1/health", "foreign"},
 		{"http://192.168.1.10:9999/v1/health", "fallback"},
 	} {
 		resp, err := rt.RoundTrip(reqFor(t, c.url))
@@ -95,9 +118,519 @@ func TestRoutedTransport_RoundTripDispatch(t *testing.T) {
 func TestRoutedTransport_NormalizesSuffix(t *testing.T) {
 	ts := &stubRT{name: "tsnet"}
 	rt := NewRoutedTransport()
-	rt.SetTailnet("Tailnet.ts.net.", ts)
+	rt.SetTailnet("Tailnet.ts.net.", ts, nil)
 
 	if got := rt.pick("gmux.tailnet.ts.net"); got != ts {
 		t.Errorf("suffix with trailing dot/case: got fallback, want tsnet")
+	}
+}
+
+type fakeStatusClient struct {
+	mu         sync.Mutex
+	status     *ipnstate.Status
+	err        error
+	calls      int
+	dial       contextDialer
+	statusFunc func(context.Context) (*ipnstate.Status, error)
+}
+
+func (f *fakeStatusClient) Status(ctx context.Context) (*ipnstate.Status, error) {
+	f.mu.Lock()
+	f.calls++
+	fn, status, err := f.statusFunc, f.status, f.err
+	f.mu.Unlock()
+	if fn != nil {
+		return fn(ctx)
+	}
+	return status, err
+}
+
+func (f *fakeStatusClient) DialTCP(ctx context.Context, host string, port uint16) (net.Conn, error) {
+	f.mu.Lock()
+	dial := f.dial
+	f.mu.Unlock()
+	if dial == nil {
+		return nil, errors.New("unexpected LocalAPI dial")
+	}
+	return dial.DialContext(ctx, "tcp", net.JoinHostPort(host, fmt.Sprint(port)))
+}
+
+func peerStatus(entries ...*ipnstate.PeerStatus) *ipnstate.Status {
+	st := &ipnstate.Status{Peer: make(map[key.NodePublic]*ipnstate.PeerStatus)}
+	for _, p := range entries {
+		st.Peer[key.NewNode().Public()] = p
+	}
+	return st
+}
+
+type recordingDialer struct {
+	mu        sync.Mutex
+	addresses []string
+	err       error
+}
+
+func (d *recordingDialer) DialContext(_ context.Context, _, address string) (net.Conn, error) {
+	d.mu.Lock()
+	d.addresses = append(d.addresses, address)
+	d.mu.Unlock()
+	if d.err != nil {
+		return nil, d.err
+	}
+	a, b := net.Pipe()
+	_ = b.Close()
+	return a, nil
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func TestForeignPeerExactMembershipAndNormalization(t *testing.T) {
+	member := &ipnstate.PeerStatus{DNSName: "FT.Tail95157A.ts.net.", Online: true, TailscaleIPs: []netip.Addr{netip.MustParseAddr("100.64.0.8")}}
+	status := peerStatus(member)
+	if got := exactPeers(status, "ft.tail95157a.ts.net..."); len(got) != 1 || got[0] != member {
+		t.Fatalf("normalized exact match = %v", got)
+	}
+	// Mutation guard: suffix/substring membership would incorrectly match
+	// this populated-map near miss.
+	if got := exactPeers(status, "tail95157a.ts.net"); len(got) != 0 {
+		t.Fatalf("near-miss name matched peer: %v", got)
+	}
+}
+
+func TestForeignPeerMapRefresh(t *testing.T) {
+	status := &fakeStatusClient{status: peerStatus(&ipnstate.PeerStatus{DNSName: "ft.foreign.ts.net.", Online: true, TailscaleIPs: []netip.Addr{netip.MustParseAddr("100.64.0.8")}})}
+	var selected [][]netip.Addr
+	exact := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		target := r.Context().Value(peerAddressesKey{}).(peerDialTarget)
+		selected = append(selected, append([]netip.Addr(nil), target.ips...))
+		return &http.Response{StatusCode: http.StatusOK, Header: make(http.Header), Body: http.NoBody, Request: r}, nil
+	})
+	now := time.Unix(100, 0)
+	foreign := &foreignPeerTransport{client: status, exact: exact, fallback: &stubRT{name: "fallback"}, now: func() time.Time { return now }}
+	req := reqFor(t, "https://ft.foreign.ts.net/v1/health")
+	if _, err := foreign.RoundTrip(req); err != nil {
+		t.Fatal(err)
+	}
+	status.mu.Lock()
+	status.status = peerStatus(&ipnstate.PeerStatus{DNSName: "ft.foreign.ts.net.", Online: true, TailscaleIPs: []netip.Addr{netip.MustParseAddr("100.64.0.9")}})
+	status.mu.Unlock()
+	now = now.Add(peerStatusFreshFor + time.Millisecond)
+	if _, err := foreign.RoundTrip(req); err != nil {
+		t.Fatal(err)
+	}
+	if len(selected) != 2 || selected[0][0].String() != "100.64.0.8" || selected[1][0].String() != "100.64.0.9" {
+		t.Fatalf("selected maps = %v", selected)
+	}
+}
+
+func TestForeignPeerSecurityAndFailureModes(t *testing.T) {
+	cases := []struct {
+		name               string
+		status             *ipnstate.Status
+		statusErr          error
+		wantRoute, wantErr string
+	}{
+		{name: "unknown falls back", status: peerStatus(), wantRoute: "fallback"},
+		{name: "LocalAPI unavailable fails closed", statusErr: errors.New("no localapi"), wantErr: "status unavailable"},
+		{name: "offline rejects stale IP", status: peerStatus(&ipnstate.PeerStatus{DNSName: "ft.foreign.ts.net.", Online: false, TailscaleIPs: []netip.Addr{netip.MustParseAddr("100.64.0.8")}}), wantErr: "offline"},
+		{name: "duplicate DNS rejects", status: peerStatus(
+			&ipnstate.PeerStatus{DNSName: "ft.foreign.ts.net.", Online: true, TailscaleIPs: []netip.Addr{netip.MustParseAddr("100.64.0.8")}},
+			&ipnstate.PeerStatus{DNSName: "FT.FOREIGN.TS.NET", Online: true, TailscaleIPs: []netip.Addr{netip.MustParseAddr("100.64.0.9")}}), wantErr: "ambiguous"},
+		{name: "non-Tailscale address rejects", status: peerStatus(&ipnstate.PeerStatus{DNSName: "ft.foreign.ts.net.", Online: true, TailscaleIPs: []netip.Addr{netip.MustParseAddr("127.0.0.1")}}), wantErr: "no dialable"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			exactCalled := false
+			foreign := &foreignPeerTransport{
+				client:   &fakeStatusClient{status: tc.status, err: tc.statusErr},
+				fallback: &stubRT{name: "fallback"},
+				exact: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+					exactCalled = true
+					return &http.Response{StatusCode: 200, Header: make(http.Header), Body: http.NoBody, Request: r}, nil
+				}),
+			}
+			resp, err := foreign.RoundTrip(reqFor(t, "https://ft.foreign.ts.net/v1/health"))
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("err=%v, want %q", err, tc.wantErr)
+				}
+				if exactCalled {
+					t.Fatal("rejected peer reached exact transport")
+				}
+				return
+			}
+			if err != nil || resp.Header.Get("X-Stub") != tc.wantRoute || exactCalled {
+				t.Fatalf("resp=%v err=%v exact=%v", resp, err, exactCalled)
+			}
+		})
+	}
+}
+
+func TestDialAnyRacesIPv6AndIPv4(t *testing.T) {
+	started := make(chan string, 2)
+	release := make(chan struct{})
+	dialer := dialFunc(func(ctx context.Context, _, address string) (net.Conn, error) {
+		started <- address
+		if strings.HasPrefix(address, "[") {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}
+		<-release
+		a, b := net.Pipe()
+		_ = b.Close()
+		return a, nil
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	type result struct {
+		conn net.Conn
+		err  error
+	}
+	done := make(chan result, 1)
+	go func() {
+		c, err := dialAny(ctx, dialer, "tcp", "443", []netip.Addr{netip.MustParseAddr("fd7a:115c:a1e0::8"), netip.MustParseAddr("100.64.0.8")})
+		done <- result{c, err}
+	}()
+	got := []string{<-started, <-started}
+	close(release)
+	r := <-done
+	if r.err != nil {
+		t.Fatal(r.err)
+	}
+	_ = r.conn.Close()
+	if len(got) != 2 {
+		t.Fatalf("tried %v, want both families", got)
+	}
+}
+
+func TestRoutedTransportForeignPeerPreservesTLSHostnameAndSNI(t *testing.T) {
+	const host = "ft.tail95157a.ts.net"
+	cert, roots := dnsCertificate(t, host)
+	var gotSNI string
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write([]byte("ok")) }))
+	srv.TLS = &tls.Config{Certificates: []tls.Certificate{cert}, GetConfigForClient: func(hi *tls.ClientHelloInfo) (*tls.Config, error) {
+		gotSNI = hi.ServerName
+		return nil, nil
+	}}
+	srv.StartTLS()
+	defer srv.Close()
+	serverAddr := srv.Listener.Addr().String()
+
+	base := http.DefaultTransport.(*http.Transport).Clone()
+	base.TLSClientConfig = &tls.Config{RootCAs: roots}
+	status := &fakeStatusClient{status: peerStatus(&ipnstate.PeerStatus{DNSName: host + ".", Online: true, TailscaleIPs: []netip.Addr{netip.MustParseAddr("100.64.0.8")}})}
+	dial := dialFunc(func(ctx context.Context, network, _ string) (net.Conn, error) {
+		return (&net.Dialer{}).DialContext(ctx, network, serverAddr)
+	})
+	status.dial = dial
+	rt := newRoutedTransport(base, status, dial)
+	resp, err := (&http.Client{Transport: rt}).Get("https://" + host + "/v1/health")
+	if err != nil {
+		t.Fatalf("verified request: %v", err)
+	}
+	_ = resp.Body.Close()
+	if gotSNI != host {
+		t.Fatalf("SNI=%q, want %q", gotSNI, host)
+	}
+
+	// Mutation probe: removing the DNS SAN / changing the original hostname
+	// must fail verification. This proves routing did not silently disable TLS.
+	_, err = (&http.Client{Transport: rt}).Get("https://wrong.tail95157a.ts.net/v1/health")
+	if err == nil {
+		t.Fatal("wrong TLS hostname unexpectedly verified")
+	}
+}
+
+type dialFunc func(context.Context, string, string) (net.Conn, error)
+
+func (f dialFunc) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	return f(ctx, network, address)
+}
+
+func dnsCertificate(t *testing.T, host string) (tls.Certificate, *x509.CertPool) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now()
+	tmpl := &x509.Certificate{SerialNumber: big.NewInt(1), Subject: pkix.Name{CommonName: host}, DNSNames: []string{host}, NotBefore: now.Add(-time.Hour), NotAfter: now.Add(time.Hour), KeyUsage: x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment, ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}, BasicConstraintsValid: true, IsCA: true}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+	cert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		t.Fatal(err)
+	}
+	roots := x509.NewCertPool()
+	roots.AppendCertsFromPEM(certPEM)
+	return cert, roots
+}
+
+func TestForeignExactPeerBypassesProxyButUnknownKeepsFallback(t *testing.T) {
+	base := http.DefaultTransport.(*http.Transport).Clone()
+	base.Proxy = func(*http.Request) (*url.URL, error) { return url.Parse("http://proxy.invalid:8080") }
+	rt := newRoutedTransport(base, &fakeStatusClient{status: peerStatus()}, &net.Dialer{})
+	foreign, ok := rt.foreign.(*foreignPeerTransport)
+	if !ok {
+		t.Fatalf("foreign transport type = %T", rt.foreign)
+	}
+	exact, ok := foreign.exact.(*http.Transport)
+	if !ok || exact.Proxy != nil {
+		t.Fatal("exact netmap route did not bypass proxy")
+	}
+	if foreign.fallback != base || base.Proxy == nil {
+		t.Fatal("unknown-name fallback lost proxy configuration")
+	}
+}
+
+func TestSetTailnetSwitchesForeignMembershipAndDialToEmbeddedClient(t *testing.T) {
+	const foreignHost = "ft.tail95157a.ts.net"
+	system := &fakeStatusClient{status: peerStatus()}
+	embedded := &fakeStatusClient{status: peerStatus(&ipnstate.PeerStatus{
+		DNSName: foreignHost + ".", Online: true,
+		TailscaleIPs: []netip.Addr{netip.MustParseAddr("100.125.29.31")},
+	})}
+	base := http.DefaultTransport.(*http.Transport).Clone()
+	rt := newRoutedTransport(base, system, &net.Dialer{})
+	foreign := rt.foreign.(*foreignPeerTransport)
+	foreign.fallback = &stubRT{name: "fallback"}
+	foreign.exact = roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		target := r.Context().Value(peerAddressesKey{}).(peerDialTarget)
+		if target.client != embedded || len(target.ips) != 1 || target.ips[0].String() != "100.125.29.31" {
+			t.Fatalf("dial target = %#v", target)
+		}
+		return &http.Response{StatusCode: http.StatusOK, Header: http.Header{"X-Stub": []string{"embedded"}}, Body: http.NoBody, Request: r}, nil
+	})
+
+	req := reqFor(t, "https://"+foreignHost+"/v1/health")
+	resp, err := rt.RoundTrip(req)
+	if err != nil || resp.Header.Get("X-Stub") != "fallback" {
+		t.Fatalf("before embedded ready: route=%q err=%v", resp.Header.Get("X-Stub"), err)
+	}
+	// A transient ready-time suffix failure must not prevent the foreign
+	// membership+dial client from switching to embedded tsnet.
+	rt.SetTailnet("", &stubRT{name: "tsnet"}, embedded)
+	resp, err = rt.RoundTrip(req)
+	if err != nil || resp.Header.Get("X-Stub") != "embedded" {
+		t.Fatalf("after embedded ready: route=%q err=%v", resp.Header.Get("X-Stub"), err)
+	}
+	if system.calls != 1 || embedded.calls != 1 {
+		t.Fatalf("status calls system=%d embedded=%d", system.calls, embedded.calls)
+	}
+}
+
+func TestForeignPeerPreReadyFallsBackButAuthoritativeFailureDoesNot(t *testing.T) {
+	fallback := &stubRT{name: "fallback"}
+	req := reqFor(t, "https://ft.foreign.ts.net/v1/health")
+	preReady := &foreignPeerTransport{fallback: fallback, exact: &stubRT{name: "exact"}}
+	resp, err := preReady.RoundTrip(req)
+	if err != nil || resp.Header.Get("X-Stub") != "fallback" {
+		t.Fatalf("pre-ready route=%v err=%v", resp, err)
+	}
+
+	hung := &fakeStatusClient{statusFunc: func(ctx context.Context) (*ipnstate.Status, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}}
+	authoritative := &foreignPeerTransport{fallback: fallback, exact: &stubRT{name: "exact"}, client: hung}
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	_, err = authoritative.RoundTrip(req.WithContext(ctx))
+	if err == nil || !strings.Contains(err.Error(), "status unavailable") {
+		t.Fatalf("authoritative status err=%v", err)
+	}
+}
+
+func TestDialAnyCancellationClosesLateConnections(t *testing.T) {
+	const racers = 2
+	started := make(chan struct{}, racers)
+	peers := make(chan net.Conn, racers)
+	dialer := dialFunc(func(ctx context.Context, _, _ string) (net.Conn, error) {
+		started <- struct{}{}
+		<-ctx.Done()
+		a, b := net.Pipe()
+		peers <- b
+		return a, nil
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := dialAny(ctx, dialer, "tcp", "443", []netip.Addr{netip.MustParseAddr("100.64.0.8"), netip.MustParseAddr("100.64.0.9")})
+		done <- err
+	}()
+	<-started
+	<-started
+	cancel()
+	if err := <-done; !errors.Is(err, context.Canceled) {
+		t.Fatalf("dialAny err=%v", err)
+	}
+	for range racers {
+		peer := <-peers
+		_ = peer.SetReadDeadline(time.Now().Add(time.Second))
+		if _, err := peer.Read(make([]byte, 1)); !errors.Is(err, io.EOF) {
+			t.Fatalf("late connection was not closed: %v", err)
+		}
+		_ = peer.Close()
+	}
+}
+
+func TestStatusWithTimeoutUnblocksReadyTimeDiscovery(t *testing.T) {
+	client := &fakeStatusClient{statusFunc: func(ctx context.Context) (*ipnstate.Status, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}}
+	started := time.Now()
+	_, err := statusWithTimeout(context.Background(), client, 25*time.Millisecond)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("status err=%v", err)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("status timeout took %v", elapsed)
+	}
+}
+
+func TestNewRoutedTransportDoesNotDependOnSystemTailscaled(t *testing.T) {
+	rt := NewRoutedTransport()
+	foreign := rt.foreign.(*foreignPeerTransport)
+	if client, _ := foreign.currentClient(); client != nil {
+		t.Fatalf("initial foreign client = %T, want nil until embedded tsnet is ready", client)
+	}
+}
+
+func TestStatusMagicDNSSuffix(t *testing.T) {
+	status := &ipnstate.Status{
+		MagicDNSSuffix: "legacy.ts.net.",
+		CurrentTailnet: &ipnstate.TailnetStatus{MagicDNSSuffix: "Current.TS.NET."},
+	}
+	if got := StatusMagicDNSSuffix(status); got != "Current.TS.NET" {
+		t.Fatalf("suffix=%q", got)
+	}
+	if got := StatusMagicDNSSuffix(nil); got != "" {
+		t.Fatalf("nil suffix=%q", got)
+	}
+}
+
+func TestForeignPeerStatusCoalescesConcurrentReconnects(t *testing.T) {
+	started := make(chan struct{}, 1)
+	release := make(chan struct{})
+	client := &fakeStatusClient{statusFunc: func(context.Context) (*ipnstate.Status, error) {
+		started <- struct{}{}
+		<-release
+		return peerStatus(
+			&ipnstate.PeerStatus{DNSName: "one.foreign.ts.net.", Online: true, TailscaleIPs: []netip.Addr{netip.MustParseAddr("100.64.0.8")}},
+			&ipnstate.PeerStatus{DNSName: "two.foreign.ts.net.", Online: true, TailscaleIPs: []netip.Addr{netip.MustParseAddr("100.64.0.9")}},
+		), nil
+	}}
+	exact := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusOK, Header: make(http.Header), Body: http.NoBody, Request: r}, nil
+	})
+	foreign := &foreignPeerTransport{fallback: &stubRT{name: "fallback"}, exact: exact, client: client}
+	errs := make(chan error, 2)
+	for _, host := range []string{"one.foreign.ts.net", "two.foreign.ts.net"} {
+		host := host
+		go func() {
+			_, err := foreign.RoundTrip(reqFor(t, "https://"+host+"/v1/events"))
+			errs <- err
+		}()
+	}
+	<-started
+	client.mu.Lock()
+	calls := client.calls
+	client.mu.Unlock()
+	if calls != 1 {
+		t.Fatalf("concurrent status calls=%d, want 1", calls)
+	}
+	close(release)
+	for range 2 {
+		if err := <-errs; err != nil {
+			t.Fatal(err)
+		}
+	}
+	client.mu.Lock()
+	calls = client.calls
+	client.mu.Unlock()
+	if calls != 1 {
+		t.Fatalf("total status calls=%d, want 1", calls)
+	}
+}
+
+func TestForeignPeerStatusServesBoundedStaleSnapshot(t *testing.T) {
+	now := time.Unix(100, 0)
+	client := &fakeStatusClient{status: peerStatus(&ipnstate.PeerStatus{DNSName: "ft.foreign.ts.net.", Online: true})}
+	foreign := &foreignPeerTransport{client: client, now: func() time.Time { return now }}
+	_, generation := foreign.currentClient()
+	first, err := foreign.peerStatus(context.Background(), client, generation)
+	if err != nil || first == nil {
+		t.Fatalf("initial status=%v err=%v", first, err)
+	}
+	client.mu.Lock()
+	client.err = errors.New("backend busy")
+	client.status = nil
+	client.mu.Unlock()
+	now = now.Add(peerStatusFreshFor + time.Millisecond)
+	stale, err := foreign.peerStatus(context.Background(), client, generation)
+	if err != nil || stale != first {
+		t.Fatalf("bounded stale status=%v err=%v", stale, err)
+	}
+	now = time.Unix(100, 0).Add(peerStatusStaleFor + time.Millisecond)
+	if _, err := foreign.peerStatus(context.Background(), client, generation); err == nil || !strings.Contains(err.Error(), "backend busy") {
+		t.Fatalf("expired stale err=%v", err)
+	}
+}
+
+func TestForeignPeerClientSwapInvalidatesStatusCache(t *testing.T) {
+	now := time.Unix(100, 0)
+	clientA := &fakeStatusClient{status: peerStatus()}
+	clientB := &fakeStatusClient{status: peerStatus()}
+	foreign := &foreignPeerTransport{client: clientA, now: func() time.Time { return now }}
+	_, generationA := foreign.currentClient()
+	if _, err := foreign.peerStatus(context.Background(), clientA, generationA); err != nil {
+		t.Fatal(err)
+	}
+	foreign.setClient(clientB)
+	_, generationB := foreign.currentClient()
+	if _, err := foreign.peerStatus(context.Background(), clientB, generationB); err != nil {
+		t.Fatal(err)
+	}
+	if clientA.calls != 1 || clientB.calls != 1 {
+		t.Fatalf("status calls A=%d B=%d", clientA.calls, clientB.calls)
+	}
+}
+
+func TestForeignPeerStatusLeaderCancellationDoesNotPoisonWaiter(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	client := &fakeStatusClient{statusFunc: func(ctx context.Context) (*ipnstate.Status, error) {
+		close(started)
+		select {
+		case <-release:
+			return peerStatus(), nil
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}}
+	foreign := &foreignPeerTransport{client: client}
+	_, generation := foreign.currentClient()
+	leaderCtx, cancelLeader := context.WithCancel(context.Background())
+	leaderDone := make(chan error, 1)
+	go func() { _, err := foreign.peerStatus(leaderCtx, client, generation); leaderDone <- err }()
+	<-started
+	waiterDone := make(chan error, 1)
+	go func() { _, err := foreign.peerStatus(context.Background(), client, generation); waiterDone <- err }()
+	cancelLeader()
+	if err := <-leaderDone; !errors.Is(err, context.Canceled) {
+		t.Fatalf("leader err=%v", err)
+	}
+	close(release)
+	if err := <-waiterDone; err != nil {
+		t.Fatalf("waiter inherited leader cancellation: %v", err)
+	}
+	if client.calls != 1 {
+		t.Fatalf("status calls=%d, want 1", client.calls)
 	}
 }

--- a/services/gmuxd/internal/tsauth/tsauth.go
+++ b/services/gmuxd/internal/tsauth/tsauth.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"tailscale.com/client/tailscale"
+	"tailscale.com/ipn/ipnstate"
 	"tailscale.com/tsnet"
 )
 
@@ -74,6 +75,19 @@ func (l *Listener) FQDN() string { return l.fqdn }
 // "tailnet.ts.net") once the listener is ready. Returns "" if tailscale
 // hasn't connected yet or MagicDNS is disabled.
 func (l *Listener) MagicDNSSuffix() string { return l.magicSuffix }
+
+// StatusMagicDNSSuffix extracts and normalizes the authoritative suffix from a
+// LocalAPI status response, preferring CurrentTailnet over the legacy field.
+func StatusMagicDNSSuffix(status *ipnstate.Status) string {
+	if status == nil {
+		return ""
+	}
+	suffix := status.MagicDNSSuffix
+	if status.CurrentTailnet != nil && status.CurrentTailnet.MagicDNSSuffix != "" {
+		suffix = status.CurrentTailnet.MagicDNSSuffix
+	}
+	return strings.TrimSuffix(suffix, ".")
+}
 
 // Diag returns diagnostic status about the Tailscale connection.
 // Safe to call at any time, including before the listener is ready.
@@ -180,17 +194,16 @@ func (l *Listener) run(handler http.Handler) {
 
 	// Resolve the full tailnet FQDN so users know exactly what to type.
 	fqdn := l.cfg.Hostname
-	if status, err := lc.Status(context.Background()); err == nil {
+	// Identity/suffix discovery must not hold Ready closed indefinitely. The
+	// caller installs the LocalClient even on timeout and retries suffix
+	// convergence independently.
+	if status, err := statusWithTimeout(context.Background(), lc, 5*time.Second); err == nil {
 		if status.Self != nil {
 			if dnsName := strings.TrimSuffix(status.Self.DNSName, "."); dnsName != "" {
 				fqdn = dnsName
 			}
 		}
-		suffix := status.MagicDNSSuffix
-		if status.CurrentTailnet != nil && status.CurrentTailnet.MagicDNSSuffix != "" {
-			suffix = status.CurrentTailnet.MagicDNSSuffix
-		}
-		l.magicSuffix = strings.TrimSuffix(suffix, ".")
+		l.magicSuffix = StatusMagicDNSSuffix(status)
 	}
 	l.fqdn = fqdn
 	close(l.ready)


### PR DESCRIPTION
## Problem

A Tailscale node shared from another tailnet is present in a tailscaled netmap, but its foreign MagicDNS name can be NXDOMAIN through systemd-resolved. `POST /v1/peers` consequently failed its authenticated health probe before persistence. The shared routed transport handled only the embedded tsnet node's own MagicDNS suffix, so persisted peering failed the same way.

Resolving the netmap name to an IP was insufficient: dialing that IP with `net.Dialer` assumes a healthy kernel TUN route. gmux's embedded tsnet uses userspace networking and must perform the dial itself.

## Fix

- Once embedded tsnet is ready, bind foreign shared-peer membership and dialing to the **same** supported `LocalClient`: `Status` requires an exact current netmap member and `DialTCP` carries the connection through embedded tsnet.
- Before readiness, retain ordinary DNS/proxy behavior with no explicit dependency on a separate system tailscaled whose identity or state may be stale.
- Keep the request URL hostname unchanged, preserving TLS certificate verification and SNI.
- Install the embedded client even if ready-time MagicDNS suffix discovery transiently fails; retry suffix convergence independently and reconnect peers when routing becomes available.
- Bound pre-ready and request-time LocalAPI status calls, plus persistent connection setup.
- Coalesce simultaneous reconnect status reads behind a 2-second immutable netmap snapshot; tolerate transient LocalAPI stalls with a last-known-good snapshot for at most 30 seconds, then fail closed with the real LocalAPI error rather than misleading DNS fallback.
- Reject offline, addressless, non-Tailscale-address, and duplicate-name map entries. Normalize case and trailing dots safely.
- Race IPv4/IPv6 addresses and close all losing or late-cancelled connections.
- Exact netmap peers bypass HTTP proxies that cannot resolve their MagicDNS names. Unknown names and unavailable LocalAPI retain ordinary DNS/proxy behavior.
- Same-tailnet embedded-tsnet routing and non-Tailscale LAN/IP/public routing remain unchanged.
- The health probe and `peering.Manager` continue sharing this transport, so initial validation and subsequent SSE/API connections have identical capability.

No blind persistence, TLS bypass, shell command, or weakening of token authentication is introduced.

## History

ADR 0008 / #280 removed netmap-backed autodiscovery while retaining authenticated health-before-persistence. #281 / #369 fixed only same-tailnet embedded-tsnet routing and explicitly left foreign tailnets on the default transport. Earlier prerelease success came from the removed discovery/netmap path, not offline persistence.

## Verification

- Reproduced the original NXDOMAIN path and the follow-up raw-IP timeout caused by relying on the kernel route.
- Confirmed the installed build can add and connect `ft.tail95157a.ts.net` through embedded tsnet.
- `go test -race ./internal/tsauth ./internal/peering ./cmd/gmuxd`
- `go test ./...` in `services/gmuxd`
- Deterministic tests cover exact membership and near misses, NXDOMAIN/fallback behavior, client switching, transient suffix failures, case/trailing dots, proxies, IPv4/IPv6, offline/stale and duplicate peers, map refresh, LocalAPI timeout/unavailability, cancellation cleanup, TLS verification and SNI.
- Independent final adversarial reviews with `anthropic/claude-opus-5:low` and `openai-codex/gpt-5.6-sol:low` both returned **integrate** with no merge-blocking findings.
- All GitHub checks pass.


