### PR TITLE
feat(web): clarify family process activity and selection

### DIFF
--- a/apps/gmux-web/src/family-drawer-model.test.ts
+++ b/apps/gmux-web/src/family-drawer-model.test.ts
@@ -447,18 +447,6 @@ describe('filtering by a state the tally counts', () => {
     expect(rows.filter(r => /^root:\+\d+ more$/.test(r))).toHaveLength(1)
   })
 
-  it('shows an agent every command it is running, once you ask for commands', () => {
-    // The one-command-per-agent rule is triage too, and the filter is
-    // the question triage was guessing at.
-    const shells = Array.from({ length: 5 }, (_, i) => ago(1 + i, `sh-${i}`, 'agent', {
-      semantic_agent: undefined, adapter: 'shell', status: { active: true },
-    }))
-    const snapshot = [ago(0, 'root', undefined), ago(0.5, 'agent', 'root'), ...shells]
-    const tree = projectFamily(snapshot[0], snapshot).tree
-    const rows = renderedLines(tree, visibleFamilyRows(tree, { filter: 'running' }))
-    for (const shell of shells) expect(rows).toContain(shell.id)
-  })
-
   it('shows the whole family again with no filter', () => {
     const snapshot = family()
     const tree = projectFamily(snapshot[0], snapshot).tree

--- a/apps/gmux-web/src/family-drawer.tsx
+++ b/apps/gmux-web/src/family-drawer.tsx
@@ -1,13 +1,15 @@
 import { useEffect, useRef, useState } from 'preact/hooks'
 import {
-  familySegments, familyStateOf, isProcessSession, projectFamily,
+  familySegments, familyStateOf, isProcessSession, isRunningProcess, projectFamily,
   type FamilyNode, type FamilyState,
 } from './family'
-import { splitLevel, visibleFamilyRows, type FamilyView } from './family-drawer-model'
+import {
+  FAMILY_ROW_BUDGET, splitLevel, visibleFamilyRows, type FamilyView,
+} from './family-drawer-model'
 import { viewToPath } from './routing'
 import { formatAge } from './session-row'
 import {
-  activityMap, cancelSession, familyActivityById, killSession, markSessionRead,
+  activityMap, cancelSession, familyActivityById, markSessionRead,
   projects, sessions, sessionDotState, tabHref,
 } from './store'
 import { pushError } from './toasts'
@@ -45,12 +47,10 @@ function FamilyRow({ node, selectedId, depth, expanded, view, now, onToggle }: {
         href={hrefFor(session)}
         aria-current={session.id === selectedId ? 'page' : undefined}
       >
-        {/* A process keeps its `$` shape and carries state as colour —
-          * the glyph column is the only place this row's state appears,
-          * so a `$` that can't say `unread` would hide a member the
-          * tally counts and the `waiting` filter shows. */}
+        {/* `$` is process identity, always cyan. Agent attention never
+          * recolors it; lifecycle is structural in the processes view. */}
         {process
-          ? <span class={`family-proc ${dot}`} aria-hidden="true">$</span>
+          ? <span class="family-proc" aria-hidden="true">$</span>
           : <span class={`session-dot-indicator ${dot}`} aria-hidden="true" />}
         <span class="family-row-title">{session.title}</span>
         {/* Levels are ordered by this timestamp, so it has to be on
@@ -153,9 +153,9 @@ function membersInState(tree: FamilyNode, state: FamilyState): Session[] {
  *
  * The destructive verbs carry their target count, because the rows on
  * screen are NOT the whole story: the line budget still folds a big
- * family, so "Stop all" under a filter matching 200 processes reaches
- * every one of them, including those behind `+N more`. Acting on the
- * filter rather than the viewport is the right behaviour — a fold is
+ * family, so “Interrupt all” reaches every matching agent, including
+ * those behind `+N more`. Acting on the filter rather than the viewport
+ * is the right behaviour — a fold is
  * the panel's economy, not a selection — but then the blast radius has
  * to be in the label you are about to click.
  *
@@ -174,7 +174,6 @@ type FamilyAction = {
 const FAMILY_ACTIONS: Partial<Record<FamilyState, FamilyAction>> = {
   waiting: { label: () => 'Mark all read', run: markSessionRead },
   error: { label: () => 'Mark all read', run: markSessionRead },
-  running: { label: n => `Stop all ${n}`, run: id => killSession(id, { quiet: true }) },
   active: { label: n => `Interrupt all ${n}`, run: id => cancelSession(id, { quiet: true }) },
 }
 
@@ -198,41 +197,41 @@ async function runBulk(action: FamilyAction, targets: readonly Session[]): Promi
   if (failed > 0) pushError(`${failed} of ${targets.length} did not respond`)
 }
 
-/** The header's tally, in the turn model's own words (ADR 0023: a
- * session is active, idle, or waiting on you) and the sidebar's own
- * dots. `working` is the CSS token for the active dot; the fact behind
- * it is `status.active`, so it reads `active` here. `unread` is how the
- * wire spells "waiting on you", shortened to `waiting` because it sits
- * beside three other segments.
- *
- * Each segment names a state and shows the glyph the rows use for it, so
- * the header and the tree can be read against each other without
- * translating — including the `$`, because a family is routinely mostly
- * processes and "3 active" reads very differently depending on whether
- * that means subagents thinking or shells running. `all` gets no glyph
- * or count: it isn't a state, it's the absence of the question — and it
- * goes first because it's the position the panel opens in. The family's
- * size was the one fact the old `total` carried, and members mostly
- * accumulate; the folds' `+N more` already says how much lies below.
- *
- * Counted over the root's descendants, root excluded — the standard
- * family numbers, shared with the header pill and the sidebar line.
- * The root's own dot is on its pinned row directly beneath: it speaks
- * for itself, and counting it here would make this tally the one place
- * quoting a different number for the same dots. */
-function CountsLine({ rootId, filter, onFilter }: {
+/** Agent-state tallies plus one process-type control, all over the root's
+ * descendants with the root excluded. Agent controls filter exactly the state
+ * they count. The process control is deliberately different: its optional
+ * number counts running processes, while pressing it opens all process
+ * history. `all` is the absence of either question and carries no count. */
+type FamilyFilter = FamilyState | 'processes'
+
+function processCount(tree: FamilyNode): number {
+  let count = 0
+  const visit = (node: FamilyNode) => {
+    if (isProcessSession(node.session)) count++
+    for (const child of node.children) visit(child)
+  }
+  for (const child of tree.children) visit(child)
+  return count
+}
+
+function CountsLine({ rootId, tree, filter, onFilter }: {
   rootId: string
-  filter: FamilyState | null
-  onFilter: (state: FamilyState | null) => void
+  tree: FamilyNode
+  filter: FamilyFilter | null
+  onFilter: (state: FamilyFilter | null) => void
 }) {
   const activity = familyActivityById.value.get(rootId)
-  const tally = (state: FamilyState | null, active: boolean, children: preact.ComponentChildren) => (
+  const processes = processCount(tree)
+  const running = activity?.running ?? 0
+  const tally = (state: FamilyFilter | null, active: boolean, children: preact.ComponentChildren,
+    label?: string) => (
     <button
       key={state ?? 'all'}
       type="button"
       // A tally you can press is a filter; pressing the one that's on
       // turns it off, so the panel never traps you in a view.
       class={`family-count${state === 'error' || state === 'waiting' ? ' family-count-attention' : ''}${active ? ' active' : ''}`}
+      aria-label={label}
       aria-pressed={active}
       onClick={() => onFilter(active ? null : state)}
     >
@@ -242,17 +241,134 @@ function CountsLine({ rootId, filter, onFilter }: {
   return (
     <div class="family-counts">
       {tally(null, filter === null, 'all')}
-      {familySegments(activity).map(segment => tally(segment.state, filter === segment.state, (
+      {familySegments(activity).filter(segment => segment.state !== 'running').map(segment =>
+        tally(segment.state, filter === segment.state, (
+          <>
+            <span class={`session-dot-indicator ${segment.dot}`} aria-hidden="true" />
+            {segment.count} {segment.state}
+          </>
+        )))}
+      {processes > 0 && tally('processes', filter === 'processes', (
         <>
-          {segment.dot
-            ? <span class={`session-dot-indicator ${segment.dot}`} aria-hidden="true" />
-            : <span class="family-proc working" aria-hidden="true">$</span>}
-          {/* The state's own name is the label: `running`, not a second
-            * `active` — one turn model (ADR 0023), but a command runs
-            * where an agent works. */}
-          {segment.count} {segment.state}
+          <span class={`family-proc family-proc-filter${running > 0 ? '' : ' quiet'}`} aria-hidden="true">$</span>
+          {running > 0 ? `${running} running` : 'processes'}
         </>
-      )))}
+      ), running > 0 ? `Processes, ${running} running` : 'Processes')}
+    </div>
+  )
+}
+
+interface ProcessEntry {
+  session: Session
+  parent: Session
+}
+
+function familyProcesses(tree: FamilyNode): ProcessEntry[] {
+  const out: ProcessEntry[] = []
+  const visit = (node: FamilyNode) => {
+    for (const child of node.children) {
+      if (isProcessSession(child.session)) out.push({ session: child.session, parent: node.session })
+      visit(child)
+    }
+  }
+  visit(tree)
+  return out.sort((a, b) => {
+    const at = a.session.last_output_at ?? a.session.created_at
+    const bt = b.session.last_output_at ?? b.session.created_at
+    return bt.localeCompare(at) || a.session.id.localeCompare(b.session.id)
+  })
+}
+
+function ProcessRow({ entry, selectedId, now }: {
+  entry: ProcessEntry
+  selectedId: string
+  now: number
+}) {
+  const { session, parent } = entry
+  return (
+    <li>
+      <a
+        class={`family-row process${session.id === selectedId ? ' selected' : ''}`}
+        href={hrefFor(session)}
+        aria-current={session.id === selectedId ? 'page' : undefined}
+      >
+        <span class="family-proc" aria-hidden="true">$</span>
+        <span class="family-row-title">{session.title}</span>
+        <span class="family-process-parent">{parent.title}</span>
+        <span class="family-row-age">{formatAge(session.last_output_at ?? session.created_at, now)}</span>
+      </a>
+    </li>
+  )
+}
+
+function processSlice(entries: readonly ProcessEntry[], limit: number, selectedId: string): ProcessEntry[] {
+  if (entries.length <= limit) return [...entries]
+  const shown = entries.slice(0, limit)
+  const selected = entries.find(entry => entry.session.id === selectedId)
+  if (!selected || shown.includes(selected) || limit === 0) return shown
+  // A selection beyond the recency slice is an explicit pin, not a row
+  // silently substituted into the tail: lead with it, then keep recency order
+  // among the remaining budget.
+  return [selected, ...entries.slice(0, limit - 1)]
+}
+
+function ProcessSection({ name, entries, limit, expanded, selectedId, now, onToggle }: {
+  name: 'Running' | 'Finished'
+  entries: readonly ProcessEntry[]
+  limit: number
+  expanded: boolean
+  selectedId: string
+  now: number
+  onToggle: () => void
+}) {
+  if (entries.length === 0) return null
+  const foldable = entries.length > limit
+  const open = expanded && foldable
+  const shown = open ? [...entries] : processSlice(entries, limit, selectedId)
+  const hidden = entries.length - shown.length
+  return (
+    <section class="family-process-section">
+      <h3>{name} <span aria-hidden="true">·</span> {entries.length}</h3>
+      <ul class="family-process-list">
+        {shown.map(entry => <ProcessRow key={entry.session.id} entry={entry} selectedId={selectedId} now={now} />)}
+        {foldable && (
+          <li>
+            <button type="button" class="family-more" aria-expanded={open} onClick={onToggle}>
+              <span class="family-more-chevron" aria-hidden="true">{open ? '▴' : '▸'}</span>
+              {open ? 'show fewer' : `+${hidden} more`}
+            </button>
+          </li>
+        )}
+      </ul>
+    </section>
+  )
+}
+
+function ProcessesView({ tree, selectedId, expanded, now, onToggle }: {
+  tree: FamilyNode
+  selectedId: string
+  expanded: ReadonlySet<string>
+  now: number
+  onToggle: (key: string) => void
+}) {
+  const processes = familyProcesses(tree)
+  const running = processes.filter(({ session }) => isRunningProcess(session))
+  const finished = processes.filter(({ session }) => !isRunningProcess(session))
+  // The selected process owns one budget line in its lifecycle section.
+  // If running work would otherwise consume the whole budget, displace one
+  // running row so a selected finished process never vanishes behind its fold.
+  const selectedFinished = finished.some(({ session }) => session.id === selectedId)
+  const runningLimit = Math.max(0, FAMILY_ROW_BUDGET - (selectedFinished ? 1 : 0))
+  const initialRunning = Math.min(running.length, runningLimit)
+  const finishedLimit = Math.max(0, FAMILY_ROW_BUDGET - initialRunning)
+  return (
+    <div class="family-processes">
+      <ProcessSection name="Running" entries={running} limit={runningLimit}
+        expanded={expanded.has('process:running')} selectedId={selectedId} now={now}
+        onToggle={() => onToggle('process:running')} />
+      <ProcessSection name="Finished" entries={finished} limit={finishedLimit}
+        expanded={expanded.has('process:finished')} selectedId={selectedId} now={now}
+        onToggle={() => onToggle('process:finished')} />
     </div>
   )
 }
@@ -275,7 +391,7 @@ export function FamilyDrawer({ selected, onClose, triggerRef }: {
   const [expanded, setExpanded] = useState<ReadonlySet<string>>(new Set())
   // Per-open, like the expansion state beside it: a filter is a way of
   // looking at the family right now, not a preference about it.
-  const [filter, setFilter] = useState<FamilyState | null>(null)
+  const [filter, setFilter] = useState<FamilyFilter | null>(null)
   const [busy, setBusy] = useState(false)
   const toggle = (key: string) => {
     setExpanded(prev => {
@@ -339,52 +455,66 @@ export function FamilyDrawer({ selected, onClose, triggerRef }: {
   // Promotion intentionally defers provenance: promoted sessions present as
   // roots even though parent_session_id remains immutable on the wire.
   const projection = projectFamily(selected, sessions.value)
-  // Your own path, root to selection: the budget may fold anything but this.
-  const pinned = new Set([...projection.ancestors.map(a => a.id), selected.id])
-  const view = visibleFamilyRows(projection.tree, { pinned, filter })
-  const action = filter ? FAMILY_ACTIONS[filter] : undefined
-  const targets = filter && action ? membersInState(projection.tree, filter) : []
+  const stateFilter = filter === 'processes' ? null : filter
+  // Structural agent ancestors remain context under a state filter, but a
+  // selected process does not: error/waiting/active are agent-only views.
+  // The dedicated process view pins selected processes within its own budget.
+  const pinSelected = !(stateFilter && isProcessSession(selected))
+  const pinned = new Set([
+    ...projection.ancestors.map(a => a.id),
+    ...(pinSelected ? [selected.id] : []),
+  ])
+  const view = visibleFamilyRows(projection.tree, { pinned, filter: stateFilter })
+  const action = stateFilter ? FAMILY_ACTIONS[stateFilter] : undefined
+  const targets = stateFilter && action ? membersInState(projection.tree, stateFilter) : []
   // One clock for the whole paint, so sibling ages can't disagree.
   const now = Date.now()
   return (
     <div id="agent-family-drawer" class="family-drawer" role="dialog" aria-label="Session family" ref={panelRef}>
       <div class="family-drawer-head">
-        <CountsLine rootId={projection.root.id} filter={filter} onFilter={setFilter} />
-        {action && targets.length > 0 && (
-          <button
-            type="button"
-            class="family-mark-read"
-            // Disabled while in flight: the verbs are individually
-            // idempotent-or-tolerant, but a second click would re-run
-            // the whole family and double any toast it earns.
-            disabled={busy}
-            onClick={() => {
-              setBusy(true)
-              runBulk(action, targets).finally(() => { setBusy(false) })
-            }}
-          >
-            {action.label(targets.length)}
-          </button>
-        )}
+        <CountsLine rootId={projection.root.id} tree={projection.tree} filter={filter} onFilter={setFilter} />
+        {/* Reserve the verb's column even when no filter owns one. The tally
+          * then receives the same width before and after a press, so neither
+          * it nor the drawer changes height when the button appears. */}
+        <div class="family-action-slot">
+          {action && targets.length > 0 && (
+            <button
+              type="button"
+              class="family-mark-read"
+              // Disabled while in flight: the verbs are individually
+              // idempotent-or-tolerant, but a second click would re-run
+              // the whole family and double any toast it earns.
+              disabled={busy}
+              onClick={() => {
+                setBusy(true)
+                runBulk(action, targets).finally(() => { setBusy(false) })
+              }}
+            >
+              {action.label(targets.length)}
+            </button>
+          )}
+        </div>
       </div>
       <div class="family-drawer-scroll">
-        {/* The root is a row, not a level: wrapping it in `LevelRows`
-          * keyed the outer level by the root's own id — the same key
-          * its children's level uses — so expanding the children put a
-          * second, orphan `show fewer` under the whole tree. It could
-          * never fold anyway; the root is admitted before anything
-          * competes for the budget. */}
-        <ul class="family-tree">
-          <FamilyRow
-            node={projection.tree}
-            selectedId={selected.id}
-            depth={0}
-            expanded={expanded}
-            view={view}
-            now={now}
-            onToggle={toggle}
-          />
-        </ul>
+        {filter === 'processes'
+          ? <ProcessesView tree={projection.tree} selectedId={selected.id} expanded={expanded} now={now} onToggle={toggle} />
+          : (
+            /* The root is a row, not a level: wrapping it in `LevelRows`
+             * keyed the outer level by the root's own id — the same key
+             * its children's level uses — so expanding the children put a
+             * second, orphan `show fewer` under the whole tree. */
+            <ul class="family-tree">
+              <FamilyRow
+                node={projection.tree}
+                selectedId={selected.id}
+                depth={0}
+                expanded={expanded}
+                view={view}
+                now={now}
+                onToggle={toggle}
+              />
+            </ul>
+          )}
       </div>
     </div>
   )

--- a/apps/gmux-web/src/family.test.ts
+++ b/apps/gmux-web/src/family.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
-  descendantTree, familyAncestors, familyIndex, familySegments,
+  descendantTree, familyAncestors, familyIndex, familySegments, familyStateOf,
   childTrailTitle, familyActivityLabel, familyRoot, hasFamily, type FamilyActivity,
   familyMemberGlyph, isFamilyChild, projectFamily, promotionAction, promotionCopy,
 } from './family'
@@ -8,6 +8,21 @@ import { makeSession } from './test-helpers'
 
 const agent = (id: string, parent?: string, extra = {}) => makeSession({
   id, cwd: '/p', title: id, parent_session_id: parent, semantic_agent: true, project_slug: 'p', ...extra,
+})
+
+describe('family overview state', () => {
+  it('keeps process history out of agent attention', () => {
+    const process = (extra = {}) => makeSession({ id: 'proc', cwd: '/p', adapter: 'shell', semantic_agent: false, ...extra })
+    expect(familyStateOf(process({ alive: true, status: { active: true } }))).toBe('running')
+    expect(familyStateOf(process({ alive: false, unread: true, status: { error: true } }))).toBeNull()
+    expect(familyStateOf(process({ alive: true, unread: true, status: { active: false, error: true } }))).toBeNull()
+  })
+
+  it('retains the agent turn vocabulary and precedence', () => {
+    expect(familyStateOf(agent('error', undefined, { alive: true, unread: true, status: { error: true } }))).toBe('error')
+    expect(familyStateOf(agent('active', undefined, { alive: true, unread: true, status: { active: true } }))).toBe('active')
+    expect(familyStateOf(agent('waiting', undefined, { unread: true }))).toBe('waiting')
+  })
 })
 
 describe('task-family projection', () => {
@@ -309,26 +324,19 @@ describe('member row glyph', () => {
     id: 'k', cwd: '/p', title: 'kid', semantic_agent: true, parent_session_id: 'root', ...over,
   })
 
-  it('gives a process its $ in every state', () => {
-    // Shape says "process" at a glance; state rides along as the glyph's
-    // own state rather than replacing it.
-    expect(familyMemberGlyph(proc(), 'none')).toEqual({ kind: 'process', state: 'none' })
-    expect(familyMemberGlyph(proc(), 'working')).toEqual({ kind: 'process', state: 'working' })
+  it('gives a process one stable $ in every state', () => {
+    // Shape alone says “process”; agent attention never recolors it.
+    expect(familyMemberGlyph(proc(), 'none')).toEqual({ kind: 'process' })
+    expect(familyMemberGlyph(proc(), 'working')).toEqual({ kind: 'process' })
   })
 
-  it('never drops a named member\'s attention on the floor', () => {
-    // The activity line subtracts whoever this row names, so the row is
-    // the only place its state can appear. A glyph that answered 'branch'
-    // or a stateless '$' for an unread member would report it nowhere.
-    for (const member of [proc({ unread: true }), kid({ unread: true })]) {
-      const glyph = familyMemberGlyph(member, 'unread')
-      expect(glyph.kind).not.toBe('branch')
-      expect('state' in glyph && glyph.state).toBe('unread')
+  it('keeps a named agent\'s attention on its dot', () => {
+    for (const state of ['unread', 'error'] as const) {
+      const glyph = familyMemberGlyph(kid(), state)
+      expect(glyph).toEqual({ kind: 'dot', state })
     }
-    for (const member of [proc({ status: { active: true, error: true } }), kid({ status: { active: true, error: true } })]) {
-      const glyph = familyMemberGlyph(member, 'error')
-      expect('state' in glyph && glyph.state).toBe('error')
-    }
+    expect(familyMemberGlyph(proc({ unread: true }), 'unread')).toEqual({ kind: 'process' })
+    expect(familyMemberGlyph(proc({ status: { error: true } }), 'error')).toEqual({ kind: 'process' })
   })
 
   it('falls back to the branch only for an agent with nothing to say', () => {

--- a/apps/gmux-web/src/family.ts
+++ b/apps/gmux-web/src/family.ts
@@ -260,23 +260,16 @@ function byRecency(a: Session, b: Session): number {
   return bt.localeCompare(at) || a.id.localeCompare(b.id)
 }
 
-/** What the member row's glyph column shows, given the member and the
- *  dot state the sidebar computed for it.
- *
- *  The column is always occupied, and — this is the load-bearing part —
- *  it is the only place *this* member's state is shown: the summary
- *  line below counts it among many, which tells you something needs
- *  you but never which row. A glyph that can't express `unread` makes
- *  the named member the one you cannot see. So a process keeps its `$`
- *  shape but carries state as colour, and an agent with nothing to
- *  report falls back to the branch. */
+/** What the member row's glyph column shows. Agent state lives on its
+ * dot; `$` is stable process identity and is never recolored as agent
+ * attention. An agent with nothing to report falls back to the branch. */
 export type MemberGlyph =
-  | { readonly kind: 'process'; readonly state: DotState }
+  | { readonly kind: 'process' }
   | { readonly kind: 'dot'; readonly state: Exclude<DotState, 'none'> }
   | { readonly kind: 'branch' }
 
 export function familyMemberGlyph(member: Session, dot: DotState): MemberGlyph {
-  if (isProcessSession(member)) return { kind: 'process', state: dot }
+  if (isProcessSession(member)) return { kind: 'process' }
   return dot === 'none' ? { kind: 'branch' } : { kind: 'dot', state: dot }
 }
 
@@ -286,28 +279,33 @@ export function isProcessSession(session: Session): boolean {
   return session.semantic_agent !== true
 }
 
-/** The one state a member is counted under — and, since the panel's
- * tally doubles as its filter, the one state it can be filtered by.
- *
- * The tally and the filter must be the same rule or the panel lies:
- * pressing `3 error` and getting four rows is worse than not being able
- * to press it. So both derive from here, and the precedence is the
- * dot's own: error, then a running turn, then waiting on you. */
+/** The process lifecycle fact shared by summaries and the process view. */
+export function isRunningProcess(session: Session): boolean {
+  return isProcessSession(session) && session.alive && session.status?.active === true
+}
+
+/** The one overview state a member contributes. Agent turn state and
+ * process lifecycle are different axes: agents can need attention or be
+ * active; a process contributes only while it is running. Its unread output
+ * and exit status belong to the launching agent and terminal, not to family
+ * attention. The drawer's `processes` control is consequently a type filter,
+ * separate from these state buckets. */
 export type FamilyState = 'error' | 'active' | 'running' | 'waiting'
 
 export function familyStateOf(session: Session): FamilyState | null {
+  if (isProcessSession(session)) return isRunningProcess(session) ? 'running' : null
   if (session.alive && session.status?.error) return 'error'
-  if (session.alive && session.status?.active) return isProcessSession(session) ? 'running' : 'active'
+  if (session.alive && session.status?.active) return 'active'
   if (session.unread) return 'waiting'
   return null
 }
 
 /** The standard family numbers: what the descendants of one
  * presentation root are doing right now, one bucket per canonical
- * state, each member counted once by `familyStateOf`. Every surface
- * that summarizes a family — the sidebar line, the header pill, the
- * panel tally — quotes this shape and nothing else, so the same dots
- * can never wear different numbers. Idle members are deliberately not
+ * state, each contributing member counted once by `familyStateOf`.
+ * Sidebar and header summaries quote this shape directly. The panel quotes
+ * its agent segments directly, then uses `running` as the live count on its
+ * broader process-history control. Idle members are deliberately not
  * counted: the summaries exist to surface live work, not take a
  * census. */
 export type FamilyActivity = Readonly<Record<FamilyState, number>>

--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -230,10 +230,10 @@ function MainHeader({ session, onRestart, onResume, resuming }: {
 }
 
 /** The family panel's trigger: a pill wearing the standard family
- * segments — `familySegments` over `familyActivityById`, the same
- * derivation and display order as the sidebar's line and the panel's
- * tally, so the same dots never wear different numbers or a different
- * order anywhere. Nothing here depends on which session you are
+ * summary segments — `familySegments` over `familyActivityById`, exactly
+ * the same derivation and display order as the sidebar's line. The panel
+ * reuses the agent segments and turns the running segment into its broader
+ * process-history control. Nothing here depends on which session you are
  * viewing: the count is a fact about the family, not the viewport. A
  * family with nothing to report shows the tree icon instead; no count
  * with it, because the segments' numbers are news and a quiet family

--- a/apps/gmux-web/src/mock-data/sessions/demo-family.ts
+++ b/apps/gmux-web/src/mock-data/sessions/demo-family.ts
@@ -64,8 +64,8 @@ export const DEMO_FAMILY: MockSession[] = [
     id: 'famApromoted', title: 'promoted research spike', parent_session_id: 'famAroot',
     promoted_to_root: true, last_output_at: ago(15),
   }),
-  // Process-only family: the summary line drops the empty segment and
-  // reads just "2 processes".
+  // Process-only family: summaries report the one running command; the
+  // panel's process filter also reveals the finished command.
   fam({ id: 'famBroot', title: 'build watcher agent', last_output_at: ago(90) }),
   fam({
     id: 'famBproc1', title: 'vite build --watch', parent_session_id: 'famBroot',
@@ -75,6 +75,39 @@ export const DEMO_FAMILY: MockSession[] = [
   fam({
     id: 'famBproc2', title: 'gofmt -l ./...', parent_session_id: 'famBroot',
     semantic_agent: false, adapter: 'shell', command: ['gofmt'], unread: true, last_output_at: ago(9),
+  }),
+  // Finished-only process family: no running summary outside the panel;
+  // inside it, the gray `$ processes` control opens Finished directly.
+  fam({ id: 'famQroot', title: 'quiet task runner', last_output_at: ago(150) }),
+  fam({
+    id: 'famQproc1', title: 'pnpm lint', parent_session_id: 'famQroot',
+    semantic_agent: false, adapter: 'shell', command: ['pnpm', 'lint'],
+    unread: true, last_output_at: ago(140),
+  }),
+  fam({
+    id: 'famQproc2', title: 'go test ./...', parent_session_id: 'famQroot',
+    semantic_agent: false, adapter: 'shell', command: ['go', 'test', './...'],
+    last_output_at: ago(145),
+  }),
+  // Enough history to prove the Finished section keeps its own fold.
+  ...Array.from({ length: 26 }, (_, i) => fam({
+    id: `famQhist${String(i).padStart(2, '0')}`,
+    title: `historical task ${i + 1}`,
+    parent_session_id: 'famQroot', semantic_agent: false, adapter: 'shell',
+    command: ['task', String(i + 1)], last_output_at: ago(150 + i),
+  })),
+  // A saturated running section plus one selected finished process proves
+  // that selection displaces a running row rather than vanishing at budget 0.
+  fam({ id: 'famSroot', title: 'saturated task runner', last_output_at: ago(210) }),
+  ...Array.from({ length: 25 }, (_, i) => fam({
+    id: `famSrun${String(i).padStart(2, '0')}`,
+    title: `running task ${i + 1}`,
+    parent_session_id: 'famSroot', semantic_agent: false, adapter: 'shell',
+    command: ['watch', String(i + 1)], status: { active: true }, last_output_at: ago(180 + i),
+  })),
+  fam({
+    id: 'famSfinished', title: 'selected finished task', parent_session_id: 'famSroot',
+    semantic_agent: false, adapter: 'shell', command: ['task', 'done'], last_output_at: ago(209),
   }),
   // A child working outside every project (no stamp, no matching rule):
   // promoting it would give it no sidebar row and no routable URL, so the

--- a/apps/gmux-web/src/sidebar.tsx
+++ b/apps/gmux-web/src/sidebar.tsx
@@ -290,7 +290,7 @@ function FamilyActivityLine({
           <span key={segment.state} class="family-activity-seg">
             {segment.dot
               ? <span class={`family-glyph session-dot-indicator ${segment.dot}`} />
-              : <span class="family-glyph family-proc working">$</span>}
+              : <span class="family-glyph family-proc">$</span>}
             {segment.count}
           </span>
         ))}
@@ -300,9 +300,10 @@ function FamilyActivityLine({
   )
 }
 
-/** The sidebar's family entry: a root row, the one family member kept
- *  beneath it — the member you're viewing, or the last one you did —
- *  and a line counting the family beneath the root.
+/** The sidebar's family entry: a root row, one member beneath it while
+ *  this family owns selection, and a line counting the family. The member is
+ *  the selection itself, or the last-viewed member while the root is selected;
+ *  it disappears as soon as selection leaves the family.
  *
  *  Selection and hit areas nest, the way the sessions do:
  *   - the group is the root's area. Hovering anywhere in it highlights
@@ -404,7 +405,7 @@ function FamilyEntry({
             * it keeps the title from sliding sideways when state
             * arrives or clears. */}
           {glyph?.kind === 'process'
-            ? <span class={`family-glyph family-proc ${glyph.state}`} aria-hidden="true">$</span>
+            ? <span class="family-glyph family-proc" aria-hidden="true">$</span>
             : glyph?.kind === 'dot'
             ? <span class={`family-glyph session-dot-indicator ${glyph.state}`} aria-hidden="true" />
             : <span class="family-glyph family-branch" aria-hidden="true">↳</span>}

--- a/apps/gmux-web/src/store.test.ts
+++ b/apps/gmux-web/src/store.test.ts
@@ -1446,20 +1446,27 @@ describe('unreadCount (sidebar-only attention blip)', () => {
 
   it('counts live and retained-dead unread sessions stamped into a folder', () => {
     _rawSessions.value = [
-      makeSession({ id: 'a', cwd: '/work', alive: true, unread: true, project_slug: 'proj' }),
-      makeSession({ id: 'b', cwd: '/work', alive: true, unread: false, project_slug: 'proj' }),
-      makeSession({ id: 'c', cwd: '/work', alive: false, resumable: true, unread: true, project_slug: 'proj' }),
+      makeSession({ id: 'a', cwd: '/work', alive: true, unread: true, semantic_agent: true, project_slug: 'proj' }),
+      makeSession({ id: 'b', cwd: '/work', alive: true, unread: false, semantic_agent: true, project_slug: 'proj' }),
+      makeSession({ id: 'c', cwd: '/work', alive: false, resumable: true, unread: true, semantic_agent: true, project_slug: 'proj' }),
     ]
     expect(unreadCount.value).toBe(2)
   })
 
+  it('keeps unread on a standalone process because its row is visible', () => {
+    _rawSessions.value = [
+      makeSession({ id: 'shell', cwd: '/work', adapter: 'shell', unread: true, project_slug: 'proj' }),
+    ]
+    expect(unreadCount.value).toBe(1)
+  })
+
   it('excludes the currently-selected session', () => {
     _rawSessions.value = [
-      makeSession({ id: 'a', cwd: '/work', adapter: 'shell', slug: 'aa', alive: true, unread: true, project_slug: 'proj' }),
-      makeSession({ id: 'b', cwd: '/work', adapter: 'shell', slug: 'bb', alive: true, unread: true, project_slug: 'proj' }),
+      makeSession({ id: 'a', cwd: '/work', adapter: 'pi', slug: 'aa', alive: true, unread: true, semantic_agent: true, project_slug: 'proj' }),
+      makeSession({ id: 'b', cwd: '/work', adapter: 'pi', slug: 'bb', alive: true, unread: true, semantic_agent: true, project_slug: 'proj' }),
     ]
     expect(unreadCount.value).toBe(2)
-    urlPath.value = '/proj/shell/aa'
+    urlPath.value = '/proj/pi/aa'
     expect(selectedId.value).toBe('a')
     expect(unreadCount.value).toBe(1)
   })
@@ -1471,9 +1478,10 @@ describe('unreadCount (sidebar-only attention blip)', () => {
       makeSession({ id: 'proc', cwd: '/work', parent_session_id: 'root', alive: true, unread: true }),
       makeSession({ id: 'dead-child', cwd: '/work', adapter: 'pi', semantic_agent: true, parent_session_id: 'root', alive: false, unread: true }),
     ]
-    // Children have no folder row of their own; the root row stands in and
-    // must ping for both live children and the retained-dead unread child.
-    expect(unreadCount.value).toBe(3)
+    // Children have no folder row of their own; the root row stands in for
+    // unread agents. Process output remains consumable but is not agent
+    // attention, so the unread process does not light the family or badge.
+    expect(unreadCount.value).toBe(2)
   })
 
   it('excludes the selected child from its root roll-up', () => {
@@ -1501,8 +1509,8 @@ describe('unreadCount (sidebar-only attention blip)', () => {
       peers: [],
     })
     _rawSessions.value = [
-      makeSession({ id: 'in', cwd: '/work', alive: true, unread: true, project_slug: 'proj' }),
-      makeSession({ id: 'out', cwd: '/other', alive: true, unread: true, project_slug: 'other' }),
+      makeSession({ id: 'in', cwd: '/work', alive: true, unread: true, semantic_agent: true, project_slug: 'proj' }),
+      makeSession({ id: 'out', cwd: '/other', alive: true, unread: true, semantic_agent: true, project_slug: 'other' }),
     ]
     expect(unreadCount.value).toBe(2)
     urlSearch.value = '?filter=proj'
@@ -1533,8 +1541,9 @@ describe('familyDotById (family-aggregated row dot)', () => {
       pi('unread-child', { parent_session_id: 'root', unread: true }),
       makeSession({ id: 'proc', cwd: '/work', parent_session_id: 'root', status: { active: true, error: true } }),
     ]
-    // error (process!) > working > unread; the root row shows the max.
-    expect(familyDotById.value.get('root')).toBe('error')
+    // Process state never becomes an agent-style root dot; the active agent
+    // wins over the waiting agent, while the process gets a `$` summary.
+    expect(familyDotById.value.get('root')).toBe('working')
     expect(familyDotById.value.get('working-child')).toBeUndefined()
   })
 
@@ -1716,144 +1725,86 @@ describe('sidebar family entry derivations', () => {
     })
   })
 
-  describe('familySlotById (the one member a family entry shows)', () => {
+  describe('familySlotById (the selected family’s one member row)', () => {
     beforeEach(() => { recentFamilyChildren.value = [] })
 
     const slot = (rootId: string) => familySlotById.value.get(rootId)
-
-    it('is empty for a family you have never descended into', () => {
-      _rawSessions.value = [agent('root'), agent('kid', { parent_session_id: 'root' })]
-      expect(familySlotById.value.size).toBe(0)
-    })
+    const family = () => [
+      agent('root', { slug: 'rooty' }),
+      agent('kid', { slug: 'kiddo', parent_session_id: 'root' }),
+      agent('elsewhere', { slug: 'far' }),
+    ]
 
     it('shows the selected member, marked as current', () => {
-      _rawSessions.value = [
-        agent('root', { slug: 'rooty' }),
-        agent('kid', { slug: 'kiddo', parent_session_id: 'root' }),
-      ]
+      _rawSessions.value = family()
       urlPath.value = '/proj/pi/kiddo'
       expect(slot('root')).toMatchObject({ selected: true })
       expect(slot('root')?.session.id).toBe('kid')
     })
 
-    it('keeps the member as a way back after you navigate to the root', () => {
-      _rawSessions.value = [
-        agent('root', { slug: 'rooty' }),
-        agent('kid', { slug: 'kiddo', parent_session_id: 'root' }),
-      ]
+    it('shows the remembered member while the root is selected', () => {
+      _rawSessions.value = family()
+      rememberFamilyChild('kid')
+      urlPath.value = '/proj/pi/rooty'
+      expect(slot('root')).toMatchObject({ selected: false })
+      expect(slot('root')?.session.id).toBe('kid')
+    })
+
+    it('drops the member immediately when selection leaves the family', () => {
+      _rawSessions.value = family()
       rememberFamilyChild('kid')
       urlPath.value = '/proj/pi/rooty'
       expect(slot('root')?.session.id).toBe('kid')
-      // No longer current: it is a memory, not the selection.
-      expect(slot('root')?.selected).toBe(false)
-    })
-
-    it('keeps it after you leave the family entirely', () => {
-      _rawSessions.value = [
-        agent('root'),
-        agent('kid', { parent_session_id: 'root' }),
-        agent('elsewhere', { slug: 'far' }),
-      ]
-      rememberFamilyChild('kid')
       urlPath.value = '/proj/pi/far'
+      expect(familySlotById.value.size).toBe(0)
+      // The memory survives so returning to the root restores its way back.
+      expect(recentFamilyChildren.value).toEqual(['kid'])
+      urlPath.value = '/proj/pi/rooty'
       expect(slot('root')?.session.id).toBe('kid')
     })
 
-    it('gives the slot to the selection over an older visit', () => {
+    it('selection wins over an older remembered sibling', () => {
       _rawSessions.value = [
-        agent('root'),
+        agent('root', { slug: 'rooty' }),
         agent('a', { slug: 'aa', parent_session_id: 'root' }),
         agent('b', { slug: 'bb', parent_session_id: 'root' }),
       ]
       rememberFamilyChild('a')
       urlPath.value = '/proj/pi/bb'
-      expect(slot('root')?.session.id).toBe('b')
-      expect(slot('root')?.selected).toBe(true)
-    })
-
-    it('keeps only the most recent visit per family (one slot)', () => {
-      _rawSessions.value = [
-        agent('root'),
-        agent('a', { parent_session_id: 'root' }),
-        agent('b', { parent_session_id: 'root' }),
-      ]
-      rememberFamilyChild('a')
-      rememberFamilyChild('b')
-      expect(familySlotById.value.size).toBe(1)
+      expect(slot('root')).toMatchObject({ selected: true })
       expect(slot('root')?.session.id).toBe('b')
     })
 
-    it('drops a member that left the family: promoted or reparented', () => {
-      _rawSessions.value = [
-        agent('root'),
-        agent('kid', { parent_session_id: 'root' }),
-        agent('other'),
-      ]
+    it('resolves validity and alive-only only while the root asks for its memory', () => {
+      _rawSessions.value = family()
       rememberFamilyChild('kid')
+      urlPath.value = '/proj/pi/rooty'
+      _rawSessions.value = _rawSessions.value.map(s =>
+        s.id === 'kid' ? { ...s, alive: false, resumable: true } : s)
       expect(slot('root')?.session.id).toBe('kid')
-      // Promotion gives it its own sidebar row; a duplicate would lie.
-      _rawSessions.value = _rawSessions.value.map(s =>
-        s.id === 'kid' ? { ...s, promoted_to_root: true } : s)
-      expect(familySlotById.value.size).toBe(0)
-      // Reparenting moves the memory to the new family, no re-keying.
-      _rawSessions.value = _rawSessions.value.map(s =>
-        s.id === 'kid' ? { ...s, promoted_to_root: false, parent_session_id: 'other' } : s)
-      expect(slot('other')?.session.id).toBe('kid')
-      expect(familySlotById.value.has('root')).toBe(false)
-    })
-
-    it('drops a member that is gone, or a corpse you cannot reopen', () => {
-      _rawSessions.value = [agent('root'), agent('kid', { parent_session_id: 'root' })]
-      rememberFamilyChild('kid')
-      _rawSessions.value = _rawSessions.value.map(s =>
-        s.id === 'kid' ? { ...s, alive: false, resumable: false } : s)
-      expect(familySlotById.value.size).toBe(0)
-      // Resumable corpses stay: they are still a way back.
-      _rawSessions.value = _rawSessions.value.map(s =>
-        s.id === 'kid' ? { ...s, resumable: true } : s)
-      expect(slot('root')?.session.id).toBe('kid')
-      // …unless the alive-only toggle is hiding dead sessions.
       setAliveOnly(true)
       expect(familySlotById.value.size).toBe(0)
       setAliveOnly(false)
-    })
-
-    it('never shows a member that vanished from the snapshot', () => {
-      _rawSessions.value = [agent('root'), agent('kid', { parent_session_id: 'root' })]
-      rememberFamilyChild('kid')
-      _rawSessions.value = [agent('root')]
+      _rawSessions.value = _rawSessions.value.map(s =>
+        s.id === 'kid' ? { ...s, promoted_to_root: true } : s)
       expect(familySlotById.value.size).toBe(0)
-      // The id is still remembered; only its resolution failed. If the
-      // session comes back (peer reconnect), so does the row.
-      expect(recentFamilyChildren.value).toEqual(['kid'])
     })
 
-    it('remembers a bounded number of families, most recent first', () => {
-      const sessions: Session[] = []
+    it('keeps one bounded memory per family without rendering inactive families', () => {
+      const snapshot: Session[] = []
       for (let i = 0; i < 7; i++) {
-        sessions.push(agent(`root${i}`), agent(`kid${i}`, { parent_session_id: `root${i}` }))
+        snapshot.push(
+          agent(`root${i}`, { slug: `root-${i}` }),
+          agent(`kid${i}`, { parent_session_id: `root${i}` }),
+        )
       }
-      _rawSessions.value = sessions
+      _rawSessions.value = snapshot
       for (let i = 0; i < 7; i++) rememberFamilyChild(`kid${i}`)
-      // Cap is 5; the two oldest families lost their memory.
       expect(recentFamilyChildren.value).toEqual(['kid6', 'kid5', 'kid4', 'kid3', 'kid2'])
-      expect(familySlotById.value.size).toBe(5)
-      expect(familySlotById.value.has('root0')).toBe(false)
-    })
-
-    it('keeps one member per family, so one family cannot evict the rest', () => {
-      _rawSessions.value = [
-        agent('rootA'), agent('rootB'),
-        ...['a0', 'a1', 'a2', 'a3', 'a4'].map(id => agent(id, { parent_session_id: 'rootA' })),
-        agent('b0', { parent_session_id: 'rootB' }),
-      ]
-      rememberFamilyChild('b0')
-      for (const id of ['a0', 'a1', 'a2', 'a3', 'a4']) rememberFamilyChild(id)
-      // Family A occupies exactly one entry however many members you
-      // bounce through, so B's way back survives.
-      expect(recentFamilyChildren.value).toEqual(['a4', 'b0'])
-      expect(slot('rootA')?.session.id).toBe('a4')
-      expect(slot('rootB')?.session.id).toBe('b0')
+      expect(familySlotById.value.size).toBe(0)
+      urlPath.value = '/proj/pi/root-6'
+      expect(familySlotById.value.size).toBe(1)
+      expect(slot('root6')?.session.id).toBe('kid6')
     })
 
     it('is idempotent for the member already at the head', () => {

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -20,7 +20,7 @@ import { resolveViewFromPath, viewToPath } from './routing'
 import { navigateWithReload } from './version-watch'
 import { buildProjectFolders, discoverProjects, type TemporaryPresentationPlacement } from './projects'
 import {
-  familyAncestors, familyIndex, familyRootId, familyStateOf, isFamilyChild, promotionAction,
+  familyAncestors, familyIndex, familyRootId, familyStateOf, isFamilyChild, isProcessSession, promotionAction,
   type FamilyActivity,
 } from './family'
 import { referencePresence, unresolvedReferences, removeReferenceItems, removeHostReferenceItems, type UnresolvedHost } from './references'
@@ -898,10 +898,10 @@ export const backgroundActivity = computed((): DotState => {
  * session into at most one folder, so summing across folders needs no
  * dedup.
  *
- * Family children have no folder row of their own — their presentation
- * root stands in — so each folder-visible root also counts its unread
- * descendants, alive or retained-dead. Without this, an unread child is invisible: no
- * logo blink, no hamburger badge.
+ * Agent family children have no folder row of their own — their
+ * presentation root stands in — so each folder-visible root also counts
+ * unread agent descendants, alive or retained-dead. Process unread remains
+ * consumable but is task history, not an attention blip.
  *
  * Scoped to the tab's `?filter=` selectors: a tab pinned to a project
  * or host shouldn't blink for sessions outside its scope (another tab
@@ -912,13 +912,18 @@ export const unreadCount = computed(() => {
   const index = familyIndex(sessions.value)
   const childUnread = new Map<string, number>()
   for (const s of sessions.value) {
-    if (s.id === sel || !s.unread || !index.childIds.has(s.id)) continue
+    // Process output remains unread for explicit consumption, but command
+    // completion is not agent attention and must not light the family's row.
+    if (s.id === sel || !s.unread || isProcessSession(s) || !index.childIds.has(s.id)) continue
     const rootId = index.rootById.get(s.id)?.id
     if (rootId) childUnread.set(rootId, (childUnread.get(rootId) ?? 0) + 1)
   }
   let n = 0
   for (const f of foldersFrom(filteredSessions.value)) {
     for (const s of f.sessions) {
+      // A standalone process owns its own visible row, so its unread output
+      // still badges normally. Only agent-owned process children disappear
+      // behind a family root and are excluded by `childUnread` above.
       if (s.id !== sel && s.unread) n++
       n += childUnread.get(s.id) ?? 0
     }
@@ -930,10 +935,10 @@ const DOT_RANK: Record<DotState, number> = { none: 0, fading: 1, active: 2, unre
 
 /** Family-aggregated dot state, keyed by presentation-root session id.
  *
- * A root's sidebar/dashboard row stands in for its whole family, so the
- * row's dot must reflect the highest-precedence state among the root and
- * every descendant (agents and processes alike) — otherwise a working or
- * unread child is invisible outside the drawer.
+ * A root's sidebar/dashboard row stands in for its agent family, so the
+ * row's dot reflects the highest-precedence agent state among the root and
+ * descendants. Processes use the separate running `$` summary; their state
+ * never becomes an agent-style aggregate dot.
  *
  * Selection muting happens per member before aggregation: the selected
  * session's own error/unread is dropped ("you're already looking at it"),
@@ -947,6 +952,10 @@ export const familyDotById = computed<ReadonlyMap<string, DotState>>(() => {
   const map = new Map<string, DotState>()
   for (const s of sessions.value) {
     const rootId = index.rootById.get(s.id)?.id ?? s.id
+    // A process child contributes through the separate running `$` summary,
+    // never through the agent-style aggregate dot. Standalone processes keep
+    // their own row state because no family root stands in for them.
+    if (isProcessSession(s) && rootId !== s.id) continue
     let own = sessionDotState(s, am)
     if (s.id === sel && (own === 'error' || own === 'unread')) own = 'none'
     const prev = map.get(rootId)
@@ -1028,12 +1037,12 @@ export function rememberFamilyChild(id: string): void {
   recentFamilyChildren.value = [id, ...others].slice(0, MAX_RECENT_FAMILY_CHILDREN)
 }
 
-/** The one family member a root's sidebar entry shows below itself.
+/** The one member shown beneath the selected family's root.
  *
- * Selection wins: while you're inside a family member, that member is
- * the slot (and says so). Otherwise the most recently visited member
- * that still resolves takes it — the way back to what you were doing.
- * Roots you've never descended into have no slot and stay one row. */
+ * While a member is selected, it is the slot. While the root is selected,
+ * that family's most recently visited member is the way back. The moment
+ * selection leaves the family, its member row disappears; promotion now
+ * provides the persistent root-level affordance for work that needs one. */
 export interface FamilySlot {
   readonly session: Session
   /** True when this member is the current selection. */
@@ -1047,19 +1056,28 @@ export const familySlotById = computed<ReadonlyMap<string, FamilySlot>>(() => {
   const onlyAlive = aliveOnly.value
   const map = new Map<string, FamilySlot>()
   const sel = selectedFamilyChild.value
-  if (sel) map.set(sel.rootId, { session: sel.session, ancestors: sel.ancestors, selected: true })
+  if (sel) {
+    map.set(sel.rootId, { session: sel.session, ancestors: sel.ancestors, selected: true })
+    return map
+  }
+
+  // A remembered member appears only while its own root is selected.
+  const selected = index.byId.get(selectedId.value ?? '')
+  const selectedRootId = selected ? index.rootById.get(selected.id)?.id : undefined
+  if (!selected || selectedRootId !== selected.id) return map
+
   for (const id of recentFamilyChildren.value) {
     const session = index.byId.get(id)
     // Gone, promoted to its own row, or reparented out of this family.
     if (!session || !index.childIds.has(id)) continue
     const rootId = index.rootById.get(id)?.id
     if (!rootId || rootId === id) continue
-    // Selection, or a more recent visit, already owns this family's slot.
-    if (map.has(rootId)) continue
+    if (rootId !== selected.id) continue
     // A corpse you can't reopen is not a way back; alive-only hides the
     // resumable ones too, matching the rest of the list.
     if (!session.alive && (onlyAlive || !session.resumable)) continue
     map.set(rootId, { session, ancestors: familyAncestors(session, index), selected: false })
+    break
   }
   return map
 })

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -1199,10 +1199,9 @@ body {
   gap: 5px;
   flex: 0 0 auto;
 }
-/* The `$`: a process where an agent shows a status dot. Shape (not
-   just colour) distinguishes them, so the cue survives tiny sizes and
-   colour blindness — and it carries the same state vocabulary the dots
-   do, in the glyph's own colour, wherever it appears.
+/* The `$`: process identity, always cyan on a process itself. Agent
+   attention and command exit status never recolor it; running versus
+   finished is expressed by summaries and the process view's sections.
 
    Vocabulary only: no box. The sidebar pairs it with `.family-glyph`,
    which owns the fixed column there, and repeating those properties
@@ -1212,7 +1211,7 @@ body {
   font-family: 'Fira Code', monospace;
   font-size: 11px;
   line-height: 1;
-  color: var(--text-muted);
+  color: var(--accent);
 }
 /* The panel has no glyph-column class of its own, so it gives the `$`
    the same box its status dots occupy. */
@@ -1221,9 +1220,7 @@ body {
   width: 7px; /* match .session-dot-indicator for title alignment */
   text-align: center;
 }
-.family-proc.working { color: var(--accent); }
-.family-proc.unread { color: var(--unread); }
-.family-proc.error { color: var(--status-error); }
+.family-proc-filter.quiet { color: var(--text-muted); }
 
 /* States that belong to the root row are the whole entry's states —
    it's one entry, so it dims, drags and takes a drop line as a unit. */
@@ -2343,7 +2340,7 @@ body {
 
 .family-trigger-proc {
   font: 600 11px/1 'Source Sans 3', sans-serif;
-  color: var(--active);
+  color: var(--accent);
 }
 
 /* Ancestor breadcrumbs in the title row: quiet path prefix, each crumb a
@@ -2419,16 +2416,11 @@ body {
    * not 4px shy of it. */
   left: 16px;
   z-index: 100;
-  width: max-content;
-  /* Wide enough that filtering doesn't reflow the panel underneath the
-     buttons you're pressing: a filter narrows the content (fewer, often
-     shorter rows), and with `max-content` the panel used to lurch with
-     it. One min-width absorbs most of that, and gives the head room so
-     the action button isn't shoulder-to-shoulder with the tally. */
-  min-width: 440px;
-  /* Wider than it was: the panel now shows the whole family from the
-     root, so deep rows pay for their indentation out of this budget. */
-  max-width: min(560px, calc(100vw - 24px));
+  /* One constrained width: filtering must not shrink the card beneath the
+     control being pressed, and the whole-family tree needs room for depth. */
+  width: min(560px, calc(100vw - 24px));
+  min-width: 0;
+  max-width: none;
   max-height: min(65vh, 520px);
   display: flex;
   flex-direction: column;
@@ -2441,12 +2433,18 @@ body {
 .family-drawer-head {
   flex: 0 0 auto;
   display: flex;
-  align-items: baseline;
+  align-items: center;
   gap: 18px;
-  padding: 10px 14px 8px;
+  min-height: 43px;
+  padding: 8px 14px;
   border-bottom: 1px solid var(--border);
 }
 .family-drawer-head .family-counts { flex: 1 1 auto; }
+.family-action-slot {
+  flex: 0 0 96px;
+  display: flex;
+  justify-content: flex-end;
+}
 /* Quiet until wanted: it sits beside a counts line that is itself the
    reason to press it, so it needs to be findable, not loud. */
 .family-mark-read {
@@ -2458,6 +2456,7 @@ body {
   color: var(--text-muted);
   font: 400 11px/1.4 'Source Sans 3', sans-serif;
   cursor: pointer;
+  white-space: nowrap;
 }
 .family-mark-read:hover { color: var(--text); border-color: var(--text-muted); }
 .family-drawer-scroll { flex: 1 1 auto; overflow: auto; padding: 6px 8px 8px; }
@@ -2479,6 +2478,7 @@ body {
   display: inline-flex;
   align-items: center;
   gap: 6px;
+  min-height: 24px;
   padding: 2px 7px;
   margin: -2px 0;
   border: 1px solid transparent;
@@ -2497,6 +2497,26 @@ body {
 }
 .family-count:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
 .family-count-attention { color: var(--unread); font-weight: 600; }
+.family-process-section + .family-process-section { margin-top: 8px; }
+.family-process-section h3 {
+  margin: 0;
+  padding: 6px 10px 3px;
+  color: var(--text-muted);
+  font: 600 11px/1.4 'Source Sans 3', sans-serif;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+.family-process-list { list-style: none; margin: 0; padding: 0; }
+.family-process-parent {
+  min-width: 0;
+  max-width: 34%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-muted);
+  font-size: 11px;
+}
+.family-process-parent::before { content: 'from '; }
 .family-tree,
 .family-tree ul { list-style: none; margin: 0; padding: 0; }
 .family-row { min-height: 34px; display: flex; align-items: center; gap: 8px; padding: 6px 10px; border-radius: 5px; color: var(--text-secondary); text-decoration: none; }

--- a/docs/task-family-ui.md
+++ b/docs/task-family-ui.md
@@ -39,32 +39,112 @@ The header speaks one control language: ghost icon buttons (borderless,
 `--bg-hover` on hover, sized to the ⋮ menu trigger). For family members
 the title row is the ancestor breadcrumb — `[family icon] ●root › ●parent
 › title` — where each crumb is a ghost link carrying that ancestor's live
-`sessionDotState` dot; the current session stays a plain bold title (its
-state lives in the status chip). Depth > 3 collapses the middle to a
-static `…`. On narrow screens the crumbs wrap onto their own row above
-the title. The family trigger (3-node tree SVG) shows the family's
-aggregated dot as a corner badge and toggles the panel; there is no cwd,
-no member count, and no separate parent/root buttons.
+`sessionDotState` dot; the current session stays a plain bold title. Depth > 3
+collapses the middle to a static `…`. On narrow screens the crumbs wrap onto
+their own row above the title. The family trigger (3-node tree SVG) toggles the
+panel; there is no cwd, member count, or separate parent/root button.
 
-The panel is a non-modal popover in the ⋮ dropdown's visual language
-(width `max-content` clamped 320–440px on desktop, full-width sheet on
-mobile). It closes on outside mousedown, Escape, or the trigger; clicking
-a row navigates without closing it. Content is a counts line (`N error ·
-N working · N unread · N total`, dot-precedence tallies) plus the family
-tree. Every children level is one flat list in sidebar activity-mode
-order: recency of `last_output_at ?? created_at`, no status buckets, no
-alive/dead distinction — state is only the row's five-state dot. The
-panel renders live; like the sidebar, a row moves only when new output
-arrives. Levels are capped at 15 rows behind a two-state `+N more` /
-`show fewer` summary keyed per parent (recency does the triage: unread
-members have recent output by definition, so they surface within the
-cap while long-dead noise sinks below the fold).
+The panel is a non-modal popover in the ⋮ dropdown's visual language. It closes
+on outside pointerdown, Escape, or its trigger; clicking a row navigates without
+closing it. The root is always present, followed by a line-budgeted family tree
+with per-level `+N more` / `show fewer` folds. Ordinary tree order is recency of
+`last_output_at ?? created_at`; state does not otherwise reorder the tree.
 
-Outside the panel a root row stands in for its whole family:
-`familyDotById` aggregates the highest-precedence member dot onto the
+Outside the panel a root row stands in for its whole family. For agent
+members, `familyDotById` aggregates the highest-precedence dot onto the
 presentation root, and `unreadCount` adds unread descendants (alive or
-retained-dead) to their folder-visible root. Processes render with a `$` glyph
-in place of the dot.
+retained-dead) to their folder-visible root. Process unread contributes to
+neither aggregation; running processes use the separate `$` summary described
+below.
+
+### Proposed process filter and glyph language
+
+Agent turn state and process lifecycle are different axes. A completed process
+may have unseen output, and it may have exited non-zero, but neither fact makes
+it an agent “waiting on you” or an overview error: the agent that launched the
+command owns its outcome. Like a task runner, the family overview presents a
+process as either **running** or **finished**. Exit codes remain available on the
+process's own terminal surface, not in family summaries or filters.
+
+The panel's filter bar has these controls when their population exists:
+
+- **all** — unchanged: show the ordinary family tree, agents and processes
+  together, subject to the panel's normal line budget and folds;
+- **N error** — agents with errors only;
+- **N waiting** — waiting agents only;
+- **N active** — active agents only;
+- **$ N running** — when one or more processes are running; or
+- **$ processes** — when process sessions exist but none is running.
+
+The root is excluded from these counts, as it is from the standard family
+numbers today; its own state remains visible on its row. “Processes exist”
+includes retained finished sessions for as long as they remain in the family
+snapshot. A process is running exactly while `alive && status.active`; every
+other process in the snapshot is finished for this overview, including a live
+shell at its prompt and a process that exited non-zero.
+
+The last two labels are two presentations of one **processes** filter. Pressing
+either shows all process sessions, not only the running subset. When present,
+the number is specifically the number currently running; it is not the number
+of rows the filter will return. The process control is never attention-styled.
+The filters do partition the descendants for overview purposes: error, waiting,
+and active contain agents only; processes contains processes only. An agent in
+error follows the existing state precedence and appears in one agent-state
+filter.
+
+The processes view is a flat task list rather than a family tree. Each row names
+its parent agent as secondary context so repeated commands from different
+agents remain distinguishable. It uses `last_output_at ?? created_at`, newest
+first, under two subheadings:
+
+1. **Running · N** — running processes;
+2. **Finished · N** — non-running processes.
+
+Omit an empty section. Thus a family with no running processes opens directly
+on **Finished**, while a family whose processes are all running has no
+**Finished** heading. The ordinary **all** tree remains structural; this flat,
+running-first rule applies only to the processes filter.
+
+The existing total member-row budget still bounds the processes view. Running
+rows are admitted first, then finished rows. Each nonempty section keeps its
+heading and, when folded, its own `+N more` control; headings do not consume the
+member-row budget. Expanding a section reveals all of that section in the same
+way as expanding a tree level today. A folded Finished section therefore
+remains visible and reachable even when running processes consume the initial
+row budget.
+
+`$` always identifies a process; a filled dot identifies agent state. Process
+error, unread, active-agent, and waiting-agent colors never recolor `$` or add a
+family-overview status marker. Its color has surface-specific presence
+semantics:
+
+- in summaries outside the filter bar, render a cyan `$` only when at least one
+  process is currently running; render no process glyph when none is running;
+- on the **processes** filter control, `$` is cyan while at least one process is
+  running and gray otherwise. The gray form says “process history is
+  available,” not “a gray process state”;
+- wherever an individual process is represented by `$`, including **all** and
+  **processes** rows, keep the glyph cyan whether the process is running or
+  finished.
+
+Accessible summary text follows the same presence rule: announce “N running
+processes” only when at least one is running. The gray control's accessible
+name is “Processes”; the cyan counting form is “Processes, N running,” so both
+lead with the population the control opens rather than implying its number is
+the result count.
+
+A process may remain unread internally for notification delivery and explicit
+consumption, but process unread never contributes to family/root attention
+presentation—even if a prior command remains unread while that process starts
+another. In particular, it contributes neither to `familyDotById` nor to the
+sidebar's `unreadCount`, and it produces no waiting count, filled waiting dot,
+process summary, unread section, or unread marker in the processes view.
+Running processes contribute only the running-process summary, not an
+agent-style aggregate dot.
+
+Bulk actions continue to follow the active filter. Waiting and error retain
+**Mark all read** for agents. The processes filter has no bulk action: it is a
+task history/type view, not an attention queue.
 
 ## Attention and consumption
 

--- a/docs/task-family-ui.md
+++ b/docs/task-family-ui.md
@@ -50,9 +50,14 @@ closing it. The root is always present, followed by a line-budgeted family tree
 with per-level `+N more` / `show fewer` folds. Ordinary tree order is recency of
 `last_output_at ?? created_at`; state does not otherwise reorder the tree.
 
-Outside the panel a root row stands in for its whole family. For agent
-members, `familyDotById` aggregates the highest-precedence dot onto the
-presentation root, and `unreadCount` adds unread descendants (alive or
+Outside the panel a root row stands in for its whole family. One member row is
+shown beneath it only while that family owns selection: the selected member, or
+the family's last-viewed member while its root is selected. It disappears as
+soon as selection leaves the family; a member that needs a persistent row can
+be promoted to a root.
+
+For agent members, `familyDotById` aggregates the highest-precedence dot onto
+the presentation root, and `unreadCount` adds unread descendants (alive or
 retained-dead) to their folder-visible root. Process unread contributes to
 neither aggregation; running processes use the separate `$` summary described
 below.
@@ -95,7 +100,9 @@ filter.
 The processes view is a flat task list rather than a family tree. Each row names
 its parent agent as secondary context so repeated commands from different
 agents remain distinguishable. It uses `last_output_at ?? created_at`, newest
-first, under two subheadings:
+first, under two subheadings. The selected process is pinned before the row
+budget; if it falls outside its section's recency slice, it leads that section
+and the remaining admitted rows retain recency order:
 
 1. **Running · N** — running processes;
 2. **Finished · N** — non-running processes.
@@ -133,13 +140,15 @@ name is “Processes”; the cyan counting form is “Processes, N running,” s
 lead with the population the control opens rather than implying its number is
 the result count.
 
-A process may remain unread internally for notification delivery and explicit
-consumption, but process unread never contributes to family/root attention
-presentation—even if a prior command remains unread while that process starts
-another. In particular, it contributes neither to `familyDotById` nor to the
-sidebar's `unreadCount`, and it produces no waiting count, filled waiting dot,
-process summary, unread section, or unread marker in the processes view.
-Running processes contribute only the running-process summary, not an
+An agent-owned family process may remain unread internally for notification
+delivery and explicit consumption, but its unread state never contributes to
+family/root attention presentation—even if a prior command remains unread
+while that process starts another. In particular, it contributes neither to
+`familyDotById` nor to the family's roll-up in the sidebar's `unreadCount`, and
+it produces no waiting count, filled waiting dot, process summary, unread
+section, or unread marker in the processes view. A standalone process still
+owns a visible sidebar row and badges its own unread output normally. Running
+family processes contribute only the running-process summary, not an
 agent-style aggregate dot.
 
 Bulk actions continue to follow the active filter. Waiting and error retain

--- a/e2e/tests/family-entry-interaction.spec.ts
+++ b/e2e/tests/family-entry-interaction.spec.ts
@@ -78,11 +78,26 @@ test.describe('sidebar family entry', () => {
     // Leaving the family closes its drawer, and coming back does not
     // pop it open again: open-ness is a statement about the present,
     // not a preference to be remembered.
-    await familyEntry(page, 'orchestrator').locator('.family-slot').click()
+    await familyEntry(page, 'orchestrator').locator('.session-item').first().click()
     await expect(page.locator('#agent-family-drawer')).toBeHidden()
     await page.goBack()
     await expect(page).toHaveURL(/~famBroot/)
     await expect(page.locator('#agent-family-drawer')).toBeHidden()
+  })
+
+  test('the member row exists only while its family owns selection', async ({ page }) => {
+    await openMockSidebar(page, '/my-project/claude/~fam2kid')
+    const family = familyEntry(page, 'orchestrator')
+    await expect(family.locator('.family-slot')).toHaveCount(1)
+
+    await page.locator('.session-item').filter({ hasText: 'design landing page' }).click()
+    await expect(family.locator('.family-slot')).toHaveCount(0)
+
+    // Selecting the root restores the remembered way back; leaving did not
+    // erase the memory, it only stopped rendering an inactive family's row.
+    await family.locator('.session-item').first().click()
+    await expect(family.locator('.family-slot')).toHaveCount(1)
+    await expect(family.locator('.family-slot')).toContainText('wire up the protocol adapter layer')
   })
 
   test('a drop anywhere on the entry reorders exactly once', async ({ page }) => {
@@ -240,13 +255,15 @@ test.describe('the family line and the panel tally', () => {
     await expect(page.locator('.family-row.selected')).toHaveCount(1)
     await expect(page.locator('.family-row[aria-current="page"]')).toBeVisible()
 
-    // A filter for a state nothing on your spine is in still keeps you.
+    // Processes are a type filter, not a state filter: it leaves the tree
+    // for a flat task-runner view containing both running and finished work.
     await tally('running').click()
     await expect(tally('error')).toHaveAttribute('aria-pressed', 'false')
-    const running = await titles()
-    expect(running.some(t => t.includes('pnpm test'))).toBe(true)
-    expect(running.some(t => t.startsWith('investigate a really long descendant'))).toBe(false)
-    await expect(page.locator('.family-row[aria-current="page"]')).toBeVisible()
+    const processes = await titles()
+    expect(processes.some(t => t.includes('pnpm test'))).toBe(true)
+    expect(processes.some(t => t.startsWith('investigate a really long descendant'))).toBe(false)
+    await expect(page.locator('.family-process-section h3').first()).toContainText('Running')
+    await expect(page.locator('.family-row[aria-current="page"]')).toHaveCount(0)
 
     // Pressing the live filter clears it; so does `all`.
     await tally('running').click()
@@ -266,13 +283,19 @@ test.describe('the family line and the panel tally', () => {
     const action = page.locator('.family-mark-read')
 
     // No filter, no verb: a bulk action only exists while you are
-    // looking at the complete list of what it will touch.
+    // looking at the complete list of what it will touch. Reserving one
+    // stable header height keeps the tree from jumping when the verb appears.
     await expect(action).toHaveCount(0)
+    const head = page.locator('.family-drawer-head')
+    const heightWithoutAction = await head.evaluate(node => node.getBoundingClientRect().height)
+    await tally('waiting').click()
+    await expect(action).toBeVisible()
+    expect(await head.evaluate(node => node.getBoundingClientRect().height)).toBe(heightWithoutAction)
+    await tally('all').click()
 
     const expected: [string, RegExp][] = [
       ['waiting', /^Mark all read$/],
       ['error', /^Mark all read$/],
-      ['running', /^Stop all \d+$/],
       ['active', /^Interrupt all \d+$/],
     ]
     for (const [state, verb] of expected) {
@@ -298,14 +321,12 @@ test.describe('the family line and the panel tally', () => {
     // `error`, precedence keeps it out of this verb's reach.
     expect(hits.read.every(path => path.includes('fam1kid'))).toBe(true)
 
-    // Stop all → /kill, and only the running process.
+    // Processes are history, not an attention queue; even while one is
+    // running, the type filter has no bulk verb.
     await tally('all').click()
     await tally('running').click()
-    await expect(action).toHaveText(/^Stop all \d+$/)
-    await action.click()
-    await expect.poll(() => hits.kill.length).toBe(1)
-    expect(hits.kill[0]).toContain('fam0proc')
-    expect(hits.cancel).toHaveLength(0)
+    await expect(action).toHaveCount(0)
+    expect(hits.kill).toHaveLength(0)
 
     // Interrupt all → /cancel, on the active agents and nothing else.
     await tally('all').click()
@@ -319,7 +340,7 @@ test.describe('the family line and the panel tally', () => {
     expect(hits.cancel.every(path => !path.includes('fam0root'))).toBe(true)
     expect(hits.cancel.some(path => path.includes('fam2kid'))).toBe(true)
     expect(hits.cancel.every(path => !path.includes('fam0proc'))).toBe(true)
-    expect(hits.kill).toHaveLength(1)
+    expect(hits.kill).toHaveLength(0)
   })
 
   test('a bulk verb names its blast radius, including folded members', async ({ page }) => {
@@ -381,21 +402,66 @@ test.describe('the family line and the panel tally', () => {
     expect(tallyCount('active')).toBeGreaterThan(0)
   })
 
-  test('a process row wears the state the tally counted it under', async ({ page }) => {
-    // famBroot is a process-only family: one running command, one that
-    // finished with output you have not seen. The `$` is the only place
-    // that row's state can appear, so a stateless glyph would leave the
-    // member the tally counts — and the `waiting` filter shows —
-    // unmarked on screen.
+  test('the processes filter separates running work from finished history', async ({ page }) => {
+    // famBroot is process-only: one running command and one finished with
+    // unread output. Unread completion is not agent attention, so the control
+    // names only the running count while opening both lifecycle sections.
     await openMockSidebar(page, '/my-project/claude/~famBroot')
     await page.locator('.family-trigger').click()
-    const glyphs = await page.locator('.family-row').evaluateAll(rows => rows.map(row => ({
-      title: row.querySelector('.family-row-title')?.textContent ?? '',
-      glyph: row.querySelector('.family-proc')?.className ?? null,
-    })))
-    const gofmt = glyphs.find(g => g.title.startsWith('gofmt'))
-    expect(gofmt?.glyph, 'the waiting process is marked as waiting').toContain('unread')
-    const build = glyphs.find(g => g.title.startsWith('vite build'))
-    expect(build?.glyph, 'and the running one as running').toContain('working')
+    const counts = page.locator('.family-counts')
+    await expect(counts).not.toContainText('waiting')
+    const processes = counts.locator('.family-count').filter({ hasText: 'running' })
+    await expect(processes).toHaveAccessibleName('Processes, 1 running')
+    await processes.click()
+    await expect(page.locator('.family-process-section h3')).toHaveText(['Running · 1', 'Finished · 1'])
+    const glyphs = page.locator('.family-process-list .family-proc')
+    await expect(glyphs).toHaveCount(2)
+    const colors = await glyphs.evaluateAll(nodes => nodes.map(node => getComputedStyle(node).color))
+    expect(new Set(colors).size, 'every process row uses one identity colour').toBe(1)
+  })
+
+  test('agent-state filters do not pin the selected process into their rows', async ({ page }) => {
+    await openMockSidebar(page, '/my-project/shell/~fam0proc')
+    await page.locator('.family-trigger').click()
+    const error = page.locator('.family-count').filter({ hasText: 'error' })
+    await error.click()
+    await expect(page.locator('.family-row.process')).toHaveCount(0)
+    await expect(page.locator('.family-row[aria-current="page"]')).toHaveCount(0)
+  })
+
+  test('a selected finished process keeps one line when running fills the budget', async ({ page }) => {
+    await openMockSidebar(page, '/my-project/shell/~famSfinished')
+    await page.locator('.family-trigger').click()
+    await page.locator('.family-count').filter({ hasText: 'running' }).click()
+    const running = page.locator('.family-process-section').filter({ hasText: 'Running' })
+    const finished = page.locator('.family-process-section').filter({ hasText: 'Finished' })
+    await expect(running.locator('.family-row')).toHaveCount(24)
+    await expect(running.locator('.family-more')).toHaveText(/\+1 more/)
+    await expect(finished.locator('.family-row')).toHaveCount(1)
+    await expect(finished.locator('.family-row')).toHaveAttribute('aria-current', 'page')
+    await expect(page.locator('.family-process-list .family-row')).toHaveCount(25)
+  })
+
+  test('a finished-only family offers quiet process history without a summary', async ({ page }) => {
+    await openMockSidebar(page, '/my-project/claude/~famQroot')
+    // Nothing is running, so the header remains the quiet family icon rather
+    // than advertising process activity.
+    await expect(page.locator('.family-trigger-proc')).toHaveCount(0)
+    await page.locator('.family-trigger').click()
+    const control = page.locator('.family-count').filter({ hasText: 'processes' })
+    await expect(control).toHaveAccessibleName('Processes')
+    const processColor = await control.locator('.family-proc').evaluate(node => getComputedStyle(node).color)
+    const rowColor = await page.locator('.family-row.process .family-proc').first().evaluate(node => getComputedStyle(node).color)
+    expect(processColor, 'the history control is quiet').not.toBe(rowColor)
+    await control.click()
+    await expect(page.locator('.family-process-section h3')).toHaveText(['Finished · 28'])
+    const list = page.locator('.family-process-list')
+    await expect(list.locator('.family-row')).toHaveCount(25)
+    await expect(list.locator('.family-more')).toHaveText(/\+3 more/)
+    await expect(list.locator('.family-more')).toHaveAttribute('aria-expanded', 'false')
+    await list.locator('.family-more').click()
+    await expect(list.locator('.family-row')).toHaveCount(28)
+    await expect(list.locator('.family-more')).toHaveText(/show fewer/)
+    await expect(list.locator('.family-more')).toHaveAttribute('aria-expanded', 'true')
   })
 })

--- a/e2e/tests/promote-demote-menu.spec.ts
+++ b/e2e/tests/promote-demote-menu.spec.ts
@@ -29,6 +29,14 @@ async function openMenu(page: Page) {
   await page.locator('.session-menu-dropdown').waitFor()
 }
 
+async function returnToFamilyMember(page: Page) {
+  const family = page.locator('.session-family').filter({ hasText: 'orchestrator' })
+  // Inactive families no longer retain a member row: select the root first,
+  // then use the remembered member that appears beneath it.
+  await family.locator('.session-item').first().click()
+  await family.locator('.family-slot').filter({ hasText: 'wire up the protocol' }).click()
+}
+
 test.describe('promote/demote in the ⋮ session menu (mock fixtures)', () => {
   test('a family child offers Promote to root, and the copy keeps ownership', async ({ page }) => {
     // fam2kid's organizational parent is fam1kid ("implement drawer").
@@ -231,7 +239,7 @@ test.describe('promote/demote in the ⋮ session menu (mock fixtures)', () => {
     expect(posts).toEqual(['A', 'B'])
 
     // And A's own item re-armed exactly where its failure toast points.
-    await page.locator('.session-item, .family-slot').filter({ hasText: 'wire up the protocol' }).first().click()
+    await returnToFamilyMember(page)
     await expect(page).toHaveURL(/~fam2kid/)
     await openMenu(page)
     await expect(promotionItem(page)).toBeEnabled()
@@ -252,7 +260,7 @@ test.describe('promote/demote in the ⋮ session menu (mock fixtures)', () => {
     await expect.poll(() => posts).toHaveLength(1)
 
     await page.locator('.session-item').filter({ hasText: 'promoted research spike' }).click()
-    await page.locator('.family-slot').filter({ hasText: 'wire up the protocol' }).click()
+    await returnToFamilyMember(page)
     await expect(page).toHaveURL(/~fam2kid/)
     await openMenu(page)
     const item = promotionItem(page)
@@ -283,7 +291,7 @@ test.describe('promote/demote in the ⋮ session menu (mock fixtures)', () => {
       store.applySessionsSnapshot(current.map(s => s.id === 'fam2kid' ? { ...s, promoted_to_root: true } : s))
       store.applySessionsSnapshot(current.map(s => s.id === 'fam2kid' ? { ...s, promoted_to_root: false } : s))
     })
-    await page.locator('.family-slot').filter({ hasText: 'wire up the protocol' }).click()
+    await returnToFamilyMember(page)
     await expect(page).toHaveURL(/~fam2kid/)
     await openMenu(page)
     await expect(promotionItem(page)).toBeEnabled()


### PR DESCRIPTION
## Summary

- separate agent attention from process lifecycle in family summaries and filters
- show process history as Running / Finished sections with stable cyan process glyphs
- exclude agent-owned process unread/error state from family attention while preserving standalone process badges
- keep the family filter header and drawer geometry stable when bulk actions appear
- show the sidebar member row only while its family owns selection

## Design

Updates `docs/task-family-ui.md` with the process-filter vocabulary, summary presence rules, attention semantics, row budget/folding, and selected-family member-slot behavior.

## Verification

- TypeScript and Biome clean
- 763 Vitest tests passed
- 84/85 full Playwright tests passed; the final disconnect test hit its pre-existing full-suite daemon teardown race and passed in isolation
- affected family, promotion/demotion, process-budget, and slot-transition browser tests pass
- interactive Chromium/DevTools pass against installed `?mock`: selected member → unrelated session → root → member, including Back/Forward and DOM/ARIA checks
- independent Opus low and Sol low reviews; both accepted the amended implementation after delta review

User-facing change reviewed iteratively with rendered screenshots and explicitly approved for squash merge.