### PR TITLE
refactor(web): make family subordinate rows selection-exclusive

### DIFF
--- a/apps/gmux-web/src/sidebar.tsx
+++ b/apps/gmux-web/src/sidebar.tsx
@@ -392,9 +392,9 @@ function FamilyEntry({
       {children}
       {member && (
         <a
-          class={`family-sub family-slot${slot.selected ? ' selected' : ''}`}
+          class="family-sub family-slot selected"
           href={slotHref}
-          aria-current={slot.selected ? 'page' : undefined}
+          aria-current="page"
           title={slotTrail}
           onClick={() => onClick?.()}
         >
@@ -566,7 +566,7 @@ function FolderGroup({
               // `selId` maps a selected descendant onto its root row.
               // The entry now draws that selection on the member's own
               // row instead, so the root row only lights up for itself.
-              selected={selId === s.id && !slot?.selected}
+              selected={selId === s.id && !slot}
               resuming={resumingId === s.id}
               // Root row = root's own status. The family roll-up lives on
               // the summary line below it (see FamilyEntry).
@@ -595,7 +595,9 @@ function FolderGroup({
               slot={slot}
               slotHref={slot && sessionHref(slot.session)}
               slotTrail={slot && childTrailTitle(s, slot.ancestors, slot.session)}
-              activity={activity}
+              // One subordinate row only: current-member identity replaces
+              // the family summary while a descendant owns selection.
+              activity={slot ? undefined : activity}
               onClick={onClick}
             >
               {item}

--- a/apps/gmux-web/src/sidebar.tsx
+++ b/apps/gmux-web/src/sidebar.tsx
@@ -232,12 +232,12 @@ function SessionItem({
   )
 }
 
-/** The activity line: what the entry does *not* name by row, in the
- *  sidebar's own dot vocabulary — error, unread, working subagent,
- *  running process — each segment dropped at zero. It's a count, not a
- *  destination, so it has no target of its own; like the rest of the
- *  entry's slack it belongs to the group, which selects the root. */
-function FamilyActivityLine({
+/** The family button: the static opener at the head of the subordinate
+ *  row, carrying the activity segments while nothing in the family is
+ *  selected. The icon never moves — it is the row's fixed identity —
+ *  only what follows it changes: counts inside the button, or the
+ *  member row beside it. */
+function FamilyOpenButton({
   activity,
   rootId,
   rootHref,
@@ -248,16 +248,12 @@ function FamilyActivityLine({
   rootHref: string
   onClick?: () => void
 }) {
-  // `familyActivityById` holds an entry only when something is non-zero,
-  // so absence is the whole of "nothing to report" — one spelling of
-  // the question, here, instead of one per call site.
-  if (!activity) return null
-  const segments = familySegments(activity)
-  const label = familyActivityLabel(activity)
+  const segments = activity ? familySegments(activity) : []
+  const label = activity ? familyActivityLabel(activity) : 'Session family'
   return (
     <button
       type="button"
-      class="family-sub family-activity"
+      class="family-activity"
       title={label}
       aria-label={`${label}. Open family panel`}
       aria-controls="agent-family-drawer"
@@ -283,43 +279,49 @@ function FamilyActivityLine({
         * the standard family numbers — everyone beneath the root — not
         * "the others", so it anchors to the root's glyph column rather
         * than indenting under whichever member row happens to be shown. */}
+      {/* The mark is the whole visible button when a member row sits
+        * beside it — it's the same icon as the header's trigger, so it
+        * already means "family panel" without a suffix. */}
       <span class="family-glyph" aria-hidden="true"><FamilyIcon class="family-activity-icon" /></span>
       {/* Glyphs are decoration; the sentence carries the meaning. */}
-      <span class="family-activity-glyphs" aria-hidden="true">
-        {segments.map(segment => (
-          <span key={segment.state} class="family-activity-seg">
-            {segment.dot
-              ? <span class={`family-glyph session-dot-indicator ${segment.dot}`} />
-              : <span class="family-glyph family-proc">$</span>}
-            {segment.count}
-          </span>
-        ))}
-      </span>
+      {segments.length > 0 && (
+        <span class="family-activity-glyphs" aria-hidden="true">
+          {segments.map(segment => (
+            <span key={segment.state} class="family-activity-seg">
+              {segment.dot
+                ? <span class={`family-glyph session-dot-indicator ${segment.dot}`} />
+                : <span class="family-glyph family-proc">$</span>}
+              {segment.count}
+            </span>
+          ))}
+        </span>
+      )}
       <span class="sr-only">{label}</span>
     </button>
   )
 }
 
-/** The sidebar's family entry: a root row, one member beneath it while
- *  this family owns selection, and a line counting the family. The member is
- *  the selection itself, or the last-viewed member while the root is selected;
- *  it disappears as soon as selection leaves the family.
+/** The sidebar's family entry: a root row and at most one subordinate
+ *  row, led by the static family button. The button carries the family
+ *  counts until a descendant takes selection; then the counts yield to
+ *  the member's own row beside it, and return the moment selection
+ *  leaves the family. No history: the member row *is* the selection.
  *
  *  Selection and hit areas nest, the way the sessions do:
  *   - the group is the root's area. Hovering anywhere in it highlights
  *     the whole group, and any click that doesn't land on the member
  *     row selects the root — including the slack around its nested
  *     targets, which has nothing better to do;
- *   - the member row and family-indicator button are their own areas
- *     inside that one, each with its own hover treatment;
+ *   - the member row and family button are their own areas inside that
+ *     one, each with its own hover treatment;
  *   - the background says *which family* you're in, the accent bar says
  *     *which row*, so selecting a member keeps the group lit and moves
  *     the bar down to it.
  *
  *  One more rule holds the content together: the root row's dot is the
  *  root session's own status, so a working child never masquerades as
- *  a working root. The line, by contrast, is a summary and may well
- *  include the member named above it — the standard family numbers are
+ *  a working root. The counts, by contrast, are a summary and may well
+ *  include the member selected within — the standard family numbers are
  *  a fact about the family, the same on every surface, and subtracting
  *  whatever a surface happens to name made them wobble with unrelated
  *  state (see `familyActivityById`).
@@ -390,29 +392,42 @@ function FamilyEntry({
       onDrop={onDragEnd && ((e) => { e.preventDefault(); onDragEnd() })}
     >
       {children}
-      {member && (
-        <a
-          class="family-sub family-slot selected"
-          href={slotHref}
-          aria-current="page"
-          title={slotTrail}
-          onClick={() => onClick?.()}
-        >
-          {/* One fixed-width glyph column, always filled: the member's
-            * status, its `$` if it's a process, or the branch arrow when
-            * there's nothing to report. The arrow is what a quiet member
-            * looks like — it marks the row as hanging off the root, and
-            * it keeps the title from sliding sideways when state
-            * arrives or clears. */}
-          {glyph?.kind === 'process'
-            ? <span class="family-glyph family-proc" aria-hidden="true">$</span>
-            : glyph?.kind === 'dot'
-            ? <span class={`family-glyph session-dot-indicator ${glyph.state}`} aria-hidden="true" />
-            : <span class="family-glyph family-branch" aria-hidden="true">↳</span>}
-          <span class="family-slot-title">{member.title}</span>
-        </a>
+      {(member || activity) && (
+        <div class="family-sub">
+          {/* The static head of the row: same button in both states, so
+            * the panel's entry point never teleports. Only the content
+            * after it changes — counts inside the button, or the member
+            * row beside it. */}
+          <FamilyOpenButton
+            activity={member ? undefined : activity}
+            rootId={rootId}
+            rootHref={rootHref}
+            onClick={onClick}
+          />
+          {member && (
+            <a
+              class="family-slot selected"
+              href={slotHref}
+              aria-current="page"
+              title={slotTrail}
+              onClick={() => onClick?.()}
+            >
+              {/* One fixed-width glyph column, always filled: the member's
+                * status, its `$` if it's a process, or the branch arrow when
+                * there's nothing to report. The arrow is what a quiet member
+                * looks like — it marks the row as hanging off the root, and
+                * it keeps the title from sliding sideways when state
+                * arrives or clears. */}
+              {glyph?.kind === 'process'
+                ? <span class="family-glyph family-proc" aria-hidden="true">$</span>
+                : glyph?.kind === 'dot'
+                ? <span class={`family-glyph session-dot-indicator ${glyph.state}`} aria-hidden="true" />
+                : <span class="family-glyph family-branch" aria-hidden="true">↳</span>}
+              <span class="family-slot-title">{member.title}</span>
+            </a>
+          )}
+        </div>
       )}
-      <FamilyActivityLine activity={activity} rootId={rootId} rootHref={rootHref} onClick={onClick} />
     </div>
   )
 }
@@ -595,9 +610,7 @@ function FolderGroup({
               slot={slot}
               slotHref={slot && sessionHref(slot.session)}
               slotTrail={slot && childTrailTitle(s, slot.ancestors, slot.session)}
-              // One subordinate row only: current-member identity replaces
-              // the family summary while a descendant owns selection.
-              activity={slot ? undefined : activity}
+              activity={activity}
               onClick={onClick}
             >
               {item}

--- a/apps/gmux-web/src/sidebar.tsx
+++ b/apps/gmux-web/src/sidebar.tsx
@@ -610,14 +610,37 @@ function FolderGroup({
   )
 }
 
-/** Compact popover behind the header's arrange icon. Three concerns,
- *  three lifetimes:
- *    View  — Projects/Activity signal, mirrored to the URL (?sidebar=).
+/** Always-visible Projects/Activity switch: under the header on desktop,
+ *  above the logo/header row on touch layouts (see the coarse-pointer
+ *  rules on .sidebar-view-toggle). Two equal buttons rather than one
+ *  cycling control — a glance answers both where you are and what the
+ *  alternative is. The active fill is the sidebar's selected-row fill:
+ *  "you are here" in the language the rows below already speak. */
+function ViewToggle({ mode }: { mode: 'projects' | 'activity' }) {
+  return (
+    <div class="sidebar-view-toggle" role="group" aria-label="Sidebar view">
+      <button
+        class={`sidebar-view-btn${mode === 'projects' ? ' active' : ''}`}
+        aria-pressed={mode === 'projects'}
+        onClick={() => setSidebarMode('projects')}
+      >Projects</button>
+      <button
+        class={`sidebar-view-btn${mode === 'activity' ? ' active' : ''}`}
+        aria-pressed={mode === 'activity'}
+        onClick={() => setSidebarMode('activity')}
+      >Activity</button>
+    </div>
+  )
+}
+
+/** Compact popover behind the header's arrange icon. Two concerns,
+ *  two lifetimes:
  *    Host  — narrows the tab to one host (`*@host` in ?filter=).
  *    Alive only — hides resumable corpses; sessionStorage (per tab).
- *  One entry point, instant switching — the list is the preview. */
+ *  The Projects/Activity switch moved out to the always-visible
+ *  ViewToggle above. One entry point, instant switching — the list is
+ *  the preview. */
 function ViewMenu({ open, onToggle }: { open: boolean; onToggle: () => void }) {
-  const mode = sidebarMode.value
   const selectors = activeSelectors.value
   // The Host radio reflects a sole `*@host` selector; anything more
   // exotic (project selectors, several hosts) lives in the chip row.
@@ -659,9 +682,6 @@ function ViewMenu({ open, onToggle }: { open: boolean; onToggle: () => void }) {
       )}
       {open && (
         <div class="view-menu" role="menu">
-          <div class="view-menu-label">View</div>
-          <Option checked={mode === 'projects'} label="Projects" onSelect={() => setSidebarMode('projects')} />
-          <Option checked={mode === 'activity'} label="Activity" onSelect={() => setSidebarMode('activity')} />
           <div class="view-menu-label">Host</div>
           <Option checked={currentHost === null && hostSelectors.length === 0} label="All hosts" onSelect={() => setHostFilter(null)} />
           {localName && (
@@ -916,6 +936,7 @@ export function Sidebar({
             {hasUnresolved && <span class="settings-attention-pip" aria-hidden="true" />}
           </button>
         </div>
+        <ViewToggle mode={mode} />
         <FilterChips selectors={selectors} />
         <div class="sidebar-scroll" ref={scrollRef} onClick={() => menuOpen && setMenuOpen(false)}>
           {/* Every row lives on one opaque slab so the scrollport's own

--- a/apps/gmux-web/src/store.test.ts
+++ b/apps/gmux-web/src/store.test.ts
@@ -17,7 +17,7 @@ import {
   sidebarMode, setSidebarMode, setFilterSelectors, setHostFilter, homePartition,
   sidebarActivity, setAliveOnly, familyDotById, createViewConsumptionTracker,
   familyActivityById, selectedFamilyChild, ownDotState,
-  familySlotById, recentFamilyChildren, rememberFamilyChild,
+  familySlotById,
 } from './store'
 import { SessionSchema } from '@gmux/protocol'
 import type { PendingMutation } from './store'
@@ -1652,8 +1652,6 @@ describe('sidebar family entry derivations', () => {
       })
     })
 
-    beforeEach(() => { recentFamilyChildren.value = [] })
-
     it('holds the same numbers whichever member the slot row names', () => {
       _rawSessions.value = [
         agent('root'),
@@ -1674,13 +1672,12 @@ describe('sidebar family entry derivations', () => {
       })
     })
 
-    it('keeps the line when the only activity is the named member', () => {
+    it('keeps deriving complete family facts while a member is selected', () => {
       _rawSessions.value = [
         agent('root', { slug: 'rooty' }),
         agent('a', { slug: 'aa', parent_session_id: 'root', unread: true }),
       ]
       urlPath.value = '/proj/pi/aa'
-      rememberFamilyChild('a')
       expect(familySlotById.value.get('root')?.session.id).toBe('a')
       expect(familyActivityById.value.get('root')?.waiting).toBe(1)
     })
@@ -1726,8 +1723,6 @@ describe('sidebar family entry derivations', () => {
   })
 
   describe('familySlotById (the selected family’s one member row)', () => {
-    beforeEach(() => { recentFamilyChildren.value = [] })
-
     const slot = (rootId: string) => familySlotById.value.get(rootId)
     const family = () => [
       agent('root', { slug: 'rooty' }),
@@ -1735,83 +1730,38 @@ describe('sidebar family entry derivations', () => {
       agent('elsewhere', { slug: 'far' }),
     ]
 
-    it('shows the selected member, marked as current', () => {
+    it('shows exactly the selected member, marked as current', () => {
       _rawSessions.value = family()
       urlPath.value = '/proj/pi/kiddo'
-      expect(slot('root')).toMatchObject({ selected: true })
       expect(slot('root')?.session.id).toBe('kid')
     })
 
-    it('shows the remembered member while the root is selected', () => {
+    it('shows no member while the root is selected', () => {
       _rawSessions.value = family()
-      rememberFamilyChild('kid')
       urlPath.value = '/proj/pi/rooty'
-      expect(slot('root')).toMatchObject({ selected: false })
-      expect(slot('root')?.session.id).toBe('kid')
+      expect(familySlotById.value.size).toBe(0)
     })
 
     it('drops the member immediately when selection leaves the family', () => {
       _rawSessions.value = family()
-      rememberFamilyChild('kid')
-      urlPath.value = '/proj/pi/rooty'
+      urlPath.value = '/proj/pi/kiddo'
       expect(slot('root')?.session.id).toBe('kid')
       urlPath.value = '/proj/pi/far'
       expect(familySlotById.value.size).toBe(0)
-      // The memory survives so returning to the root restores its way back.
-      expect(recentFamilyChildren.value).toEqual(['kid'])
       urlPath.value = '/proj/pi/rooty'
-      expect(slot('root')?.session.id).toBe('kid')
+      expect(familySlotById.value.size).toBe(0)
     })
 
-    it('selection wins over an older remembered sibling', () => {
+    it('switches directly to the newly selected sibling', () => {
       _rawSessions.value = [
         agent('root', { slug: 'rooty' }),
         agent('a', { slug: 'aa', parent_session_id: 'root' }),
         agent('b', { slug: 'bb', parent_session_id: 'root' }),
       ]
-      rememberFamilyChild('a')
+      urlPath.value = '/proj/pi/aa'
+      expect(slot('root')?.session.id).toBe('a')
       urlPath.value = '/proj/pi/bb'
-      expect(slot('root')).toMatchObject({ selected: true })
       expect(slot('root')?.session.id).toBe('b')
-    })
-
-    it('resolves validity and alive-only only while the root asks for its memory', () => {
-      _rawSessions.value = family()
-      rememberFamilyChild('kid')
-      urlPath.value = '/proj/pi/rooty'
-      _rawSessions.value = _rawSessions.value.map(s =>
-        s.id === 'kid' ? { ...s, alive: false, resumable: true } : s)
-      expect(slot('root')?.session.id).toBe('kid')
-      setAliveOnly(true)
-      expect(familySlotById.value.size).toBe(0)
-      setAliveOnly(false)
-      _rawSessions.value = _rawSessions.value.map(s =>
-        s.id === 'kid' ? { ...s, promoted_to_root: true } : s)
-      expect(familySlotById.value.size).toBe(0)
-    })
-
-    it('keeps one bounded memory per family without rendering inactive families', () => {
-      const snapshot: Session[] = []
-      for (let i = 0; i < 7; i++) {
-        snapshot.push(
-          agent(`root${i}`, { slug: `root-${i}` }),
-          agent(`kid${i}`, { parent_session_id: `root${i}` }),
-        )
-      }
-      _rawSessions.value = snapshot
-      for (let i = 0; i < 7; i++) rememberFamilyChild(`kid${i}`)
-      expect(recentFamilyChildren.value).toEqual(['kid6', 'kid5', 'kid4', 'kid3', 'kid2'])
-      expect(familySlotById.value.size).toBe(0)
-      urlPath.value = '/proj/pi/root-6'
-      expect(familySlotById.value.size).toBe(1)
-      expect(slot('root6')?.session.id).toBe('kid6')
-    })
-
-    it('is idempotent for the member already at the head', () => {
-      rememberFamilyChild('a')
-      const first = recentFamilyChildren.value
-      rememberFamilyChild('a')
-      expect(recentFamilyChildren.value).toBe(first)
     })
   })
 
@@ -2040,28 +1990,6 @@ describe('sidebar-mode repair effect (initStore)', () => {
     cleanup = null
     setNavigate(() => {/* no-op */})
     vi.unstubAllGlobals()
-  })
-
-  it('records the family member you are viewing (the recorder effect runs)', () => {
-    // Every other MRU test calls rememberFamilyChild directly, which
-    // proves the list but not the wiring. This one pins the wiring: an
-    // effect registered by initStore, above the mock-mode early return
-    // that would otherwise leave it dead in ?mock previews.
-    _setRawWorld({ projects: [{ slug: 'proj', match: [{ path: '/work' }] }], peers: [] })
-    sessionsLoaded.value = true
-    worldLoaded.value = true
-    _rawSessions.value = [
-      makeSession({ id: 'root', slug: 'rooty', cwd: '/work', adapter: 'pi', semantic_agent: true, project_slug: 'proj' }),
-      makeSession({ id: 'kid', slug: 'kiddo', cwd: '/work', adapter: 'pi', semantic_agent: true, project_slug: 'proj', parent_session_id: 'root' }),
-    ]
-    recentFamilyChildren.value = []
-    // A resolvable selection wakes the mark-as-read effect, which reads
-    // `selected` — and that computed pokes `window` for debugging.
-    vi.stubGlobal('window', {})
-    cleanup = initStore()
-    urlPath.value = '/proj/pi/kiddo'
-    expect(selectedFamilyChild.value?.session.id).toBe('kid')
-    expect(recentFamilyChildren.value).toEqual(['kid'])
   })
 
   it('rewrites a stale ?sidebar entry in place; the signal never adopts from the URL', () => {
@@ -2379,36 +2307,5 @@ describe('conversation_file (duplicate-open warning)', () => {
     const dups = duplicateConversationFiles.value
     expect(dups.has('/conv.jsonl')).toBe(true)
     expect(dups.has('/other.jsonl')).toBe(false)
-  })
-})
-
-describe('mock-mode boot (?mock)', () => {
-  // `?mock` is the surface design work is reviewed on, and initStore
-  // returns early for it — anything registered below that return is dead
-  // in mock previews while looking perfectly wired in production. The
-  // recorder effect was, once. This boots a *fresh* store module with
-  // ?mock in the URL, which is the only way to see that difference.
-  afterEach(() => {
-    vi.unstubAllGlobals()
-    vi.resetModules()
-  })
-
-  it('records the family member you are viewing in a mock preview too', async () => {
-    vi.stubGlobal('location', { search: '?mock', hash: '', pathname: '/' })
-    vi.stubGlobal('window', {})
-    vi.resetModules()
-    const store = await import('./store')
-    // Stand in for the router: the store navigates through this.
-    store.setNavigate((url: string) => { store.urlPath.value = url.split('?')[0] })
-    const cleanup = store.initStore()
-    try {
-      const kid = store.sessions.value.find(s => s.parent_session_id && s.semantic_agent)
-      expect(kid, 'the mock fixtures should contain a family child').toBeDefined()
-      store.navigateToSession(kid!.id)
-      expect(store.selectedFamilyChild.value?.session.id).toBe(kid!.id)
-      expect(store.recentFamilyChildren.value).toEqual([kid!.id])
-    } finally {
-      cleanup()
-    }
   })
 })

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -1003,82 +1003,21 @@ export const selectedFamilyChild = computed<SelectedFamilyChild | null>(() => {
   return { session, rootId, ancestors: familyAncestors(session, index) }
 })
 
-/** Family children this tab has visited, most recent first.
+/** The one member shown beneath a family root.
  *
- * The sidebar keeps one slot per family for "the member I was just
- * looking at", so you can get back to a subagent after navigating to
- * its root. Only ids are stored: whether an id still *resolves* to a
- * live family child is derived on every read (see `familySlotById`),
- * so promotion, reparenting and session death need no cleanup pass.
- * Ephemeral by design — "recently viewed" shouldn't outlive the tab
- * that did the viewing. */
-export const recentFamilyChildren = signal<readonly string[]>([])
-
-/** Cap on the MRU list. `rememberFamilyChild` keeps one member per
- * family, so this bounds how many *families* keep a remembered row:
- * visiting a sixth family's member evicts the least recent family. */
-const MAX_RECENT_FAMILY_CHILDREN = 5
-
-/** Record a visit. Idempotent for the current head, so the recorder
- * effect can run on every snapshot without churning the signal.
- *
- * One member per family, because the entry only ever shows one: keeping
- * a sibling too would let a single family fill the list and evict other
- * families' rows without ever showing a second row of its own. Reads
- * `sessions` with `peek` — the caller is an effect that already tracks
- * the selection this resolves. */
-export function rememberFamilyChild(id: string): void {
-  const prev = recentFamilyChildren.peek()
-  if (prev[0] === id) return
-  const index = familyIndex(sessions.peek())
-  const rootOf = (member: string) => index.rootById.get(member)?.id
-  const root = rootOf(id)
-  const others = prev.filter(x => x !== id && (root === undefined || rootOf(x) !== root))
-  recentFamilyChildren.value = [id, ...others].slice(0, MAX_RECENT_FAMILY_CHILDREN)
-}
-
-/** The one member shown beneath the selected family's root.
- *
- * While a member is selected, it is the slot. While the root is selected,
- * that family's most recently visited member is the way back. The moment
- * selection leaves the family, its member row disappears; promotion now
- * provides the persistent root-level affordance for work that needs one. */
+ * The slot is a direct projection of current selection: it exists only when
+ * a family descendant is selected, and names exactly that descendant. Root
+ * selection and selection outside the family produce no member row. */
 export interface FamilySlot {
   readonly session: Session
-  /** True when this member is the current selection. */
-  readonly selected: boolean
   /** Root-first spine, for the row's hover trail. */
   readonly ancestors: readonly Session[]
 }
 
 export const familySlotById = computed<ReadonlyMap<string, FamilySlot>>(() => {
-  const index = familyIndex(sessions.value)
-  const onlyAlive = aliveOnly.value
   const map = new Map<string, FamilySlot>()
   const sel = selectedFamilyChild.value
-  if (sel) {
-    map.set(sel.rootId, { session: sel.session, ancestors: sel.ancestors, selected: true })
-    return map
-  }
-
-  // A remembered member appears only while its own root is selected.
-  const selected = index.byId.get(selectedId.value ?? '')
-  const selectedRootId = selected ? index.rootById.get(selected.id)?.id : undefined
-  if (!selected || selectedRootId !== selected.id) return map
-
-  for (const id of recentFamilyChildren.value) {
-    const session = index.byId.get(id)
-    // Gone, promoted to its own row, or reparented out of this family.
-    if (!session || !index.childIds.has(id)) continue
-    const rootId = index.rootById.get(id)?.id
-    if (!rootId || rootId === id) continue
-    if (rootId !== selected.id) continue
-    // A corpse you can't reopen is not a way back; alive-only hides the
-    // resumable ones too, matching the rest of the list.
-    if (!session.alive && (onlyAlive || !session.resumable)) continue
-    map.set(rootId, { session, ancestors: familyAncestors(session, index), selected: false })
-    break
-  }
+  if (sel) map.set(sel.rootId, { session: sel.session, ancestors: sel.ancestors })
   return map
 })
 
@@ -2164,16 +2103,6 @@ export function initStore(): () => void {
     }
   })
   cleanups.push(disposeSidebarRepair)
-
-  // Remember the family member you're viewing, so its family's sidebar
-  // entry can offer the way back after you navigate to the root. Pure
-  // UI history with no transport dependency, so it registers above the
-  // mock-mode early return below — ?mock previews this behavior too.
-  const disposeRecentChild = effect(() => {
-    const child = selectedFamilyChild.value
-    if (child) rememberFamilyChild(child.session.id)
-  })
-  cleanups.push(disposeRecentChild)
 
   if (USE_MOCK) {
     const localHost = new URLSearchParams(location.search).get('host')

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -1086,30 +1086,31 @@ body {
   width: 2px;
   background: var(--accent);
   border-radius: 0 1px 1px 0;
-  /* Above the member row's own background, which spans the full width
-     and would otherwise paint over the group's bar. */
-  z-index: 1;
 }
 
-/* Sub-rows share one fixed indent: a glyph column under the root title
-   (14px pad + 7px dot + 8px gap), then content. The member row puts
-   its status there and the activity line its branch, so the two rows
-   line up on both columns. The indent is a variable because the
-   activity button reaches the same column by a different route —
-   see `.family-activity`. */
+/* The subordinate row's indent puts the family button's glyph on the
+   column under the root title (14px pad + 7px dot + 8px gap). The
+   button's own inner padding is subtracted from the indent so its hit
+   area starts at its visible edge and the glyph still lands on the
+   column — derived, so the two can't drift apart. */
 .session-family {
   --family-indent: 29px;
-  /* The activity button's own inner padding, subtracted from the
-     indent so its glyph still lands on the column. */
-  --family-pill-pad: 8px;
+  --family-btn-pad: 8px;
 }
+/* The subordinate row: one per family at most, holding the static
+   family button and, while a descendant owns selection, the member row
+   beside it. The container is not a target — its slack (the gutter and
+   everything right of the content) falls through to the root, like the
+   rest of the entry's slack. The indent stops short of the glyph
+   column by the button's own padding, so the button's hit area starts
+   at its visible edge and the glyph still lands on the column. */
 .family-sub {
   position: relative;
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 2px;
   min-width: 0;
-  padding: 3px 8px 3px var(--family-indent);
+  padding: 1px 8px 3px calc(var(--family-indent) - var(--family-btn-pad));
 }
 
 /* Every glyph in that column occupies the same width, whatever it is,
@@ -1140,14 +1141,23 @@ body {
   color: var(--text-muted);
 }
 
-/* Member row: the family member you're viewing, or the last one you
-   did. Title-sized and title-coloured in every state — a peer of the
-   root row you navigate to, so only the background says where you are.
-   Its highlight sits one tone above the group's in both states, so the
-   row under the pointer is unmistakable without breaking the entry
-   apart. --bg-hover/--bg-surface read as a dent inside a selected
-   group, hence the explicit tones. */
+/* Member row: the family member you're viewing. Title-sized and
+   title-coloured — a peer of the root row you navigate to, so only the
+   background says where you are. Its highlight sits one tone above the
+   group's in both states, so the row under the pointer is unmistakable
+   without breaking the entry apart. --bg-hover/--bg-surface read as a
+   dent inside a selected group, hence the explicit tones. It claims
+   only its content — the slack right of the title stays the root's. */
 .family-slot {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  /* Same height as the family button beside it (see .family-activity),
+     so the row never changes height between its two states. */
+  min-height: 23px;
+  box-sizing: border-box;
+  padding: 1px 8px;
   text-decoration: none;
   color: var(--text);
   font-size: 14px;
@@ -1180,27 +1190,27 @@ body {
   min-width: 0;
 }
 
-/* Activity button: the standard family numbers — everyone beneath the
-   root — one segment per state, each dropped at zero. It is a nested
-   target inside the family's broad hover area and opens the same panel
-   as the header's trigger, but it does not borrow that pill: the
-   sidebar's design language is flat rows with background hovers, so it
-   takes the member row's exact treatment — one tone above the group's,
-   in both states. Unlike that row it is not a navigation target, so it
-   does not claim the full row: the hit area stops where the numbers
-   do, and the slack to the right stays the root's, like the rest of
-   the entry's slack. Numbers sit a touch under the title size. */
+/* The family button: the row's static head — the family mark and an
+   ellipsis — carrying the activity segments while nothing in the
+   family is selected. Same panel as the header's trigger, but it does
+   not borrow that control's fill: the sidebar's design language is
+   flat rows with background hovers, so it takes the member row's exact
+   treatment — one tone above the group's, in both states. It claims
+   only its content: the hit area stops where the numbers (or the …)
+   do, and the slack to the right stays the root's. */
 .family-activity {
-  width: fit-content;
-  /* The row's indent, split: the part before the hit area is margin,
-     the rest is the button's own padding, so the glyph lands on the
-     shared column and the gutter left of it still belongs to the root.
-     Derived, so the two rows cannot drift apart. */
-  --family-pill-inset: calc(var(--family-indent) - var(--family-pill-pad));
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex: 0 0 auto;
+  min-width: 0;
+  /* Match the member row's height: the two states of the row must not
+     shift the list when selection moves. */
+  min-height: 23px;
+  box-sizing: border-box;
   /* Clip, not spill, at the sidebar's narrowest. */
-  max-width: calc(100% - var(--family-pill-inset));
-  margin: 0 0 2px var(--family-pill-inset);
-  padding: 1px var(--family-pill-pad) 2px var(--family-pill-pad);
+  max-width: 100%;
+  padding: 1px var(--family-btn-pad);
   border: 0;
   border-radius: 3px;
   background: transparent;

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -2298,35 +2298,47 @@ body {
   flex: 0 1 auto;
 }
 
-/* Family trigger: a ghost icon button in the header's one control
- * language (borderless, bg-hover, sized to match .session-menu-trigger).
- * The corner badge repeats the family's aggregated dot state so
- * background family activity is visible without opening the panel. */
-/* A pill, bordered like the panel's tally buttons so it reads as one
- * coherent button rather than a strip of dots that happens to be
- * clickable. Never shrinks: it is the densest thing in the row, and
- * the title yields instead. */
+/* One quiet-button language for the family surfaces: a square control
+ * that speaks the sidebar's fill progression — bg-hover to point at it,
+ * bg-selected when it's on — rather than outlines. The trigger, the
+ * panel's tally filters and the bulk action are the same kind of thing,
+ * so they share one rule instead of three near-copies (and none of them
+ * is a pill — that shape belongs to floating status overlays, not
+ * buttons). Only Mark all read keeps a border: a lone text action
+ * beside a sentence needs its shape even at rest. */
+.family-trigger,
+.family-count,
+.family-mark-read {
+  border: 1px solid transparent;
+  border-radius: 4px;
+  background: transparent;
+  font-variant-numeric: tabular-nums;
+  cursor: pointer;
+  transition: background 0.1s, color 0.1s, border-color 0.1s;
+}
+
+/* Family trigger: a soft fill instead of an outline — the header's other
+ * controls are borderless ghosts, so containment does the "one coherent
+ * button" work a border was doing, and hover/open step the fill up the
+ * way the header's other controls do. Never shrinks: it is the densest
+ * thing in the row, and the title yields instead. The corner badge
+ * repeats the family's aggregated dot state so background family
+ * activity is visible without opening the panel. */
 .family-trigger {
   height: 26px;
   flex-shrink: 0;
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 0 9px;
-  border: 1px solid var(--border);
-  border-radius: 999px;
-  background: transparent;
+  padding: 0 8px;
+  background: var(--bg-hover);
   color: var(--text-secondary);
   font: 500 12px/1 'Source Sans 3', sans-serif;
-  font-variant-numeric: tabular-nums;
-  cursor: pointer;
-  transition: background 0.1s, color 0.1s, border-color 0.1s;
 }
 .family-trigger:hover,
 .family-trigger[aria-expanded="true"] {
-  background: var(--bg-hover);
+  background: var(--bg-selected);
   color: var(--text);
-  border-color: var(--border-strong);
 }
 .family-trigger-seg {
   display: flex;
@@ -2450,12 +2462,9 @@ body {
 .family-mark-read {
   flex: 0 0 auto;
   padding: 2px 8px;
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  background: transparent;
+  border-color: var(--border);
   color: var(--text-muted);
   font: 400 11px/1.4 'Source Sans 3', sans-serif;
-  cursor: pointer;
   white-space: nowrap;
 }
 .family-mark-read:hover { color: var(--text); border-color: var(--text-muted); }
@@ -2473,7 +2482,7 @@ body {
 }
 /* Each tally is also the filter for its own state, so it looks like
    something you can press without shouting: no chrome until you point
-   at it, a filled pill once it's on. */
+   at it, a filled square button once it's on. */
 .family-count {
   display: inline-flex;
   align-items: center;
@@ -2481,18 +2490,12 @@ body {
   min-height: 24px;
   padding: 2px 7px;
   margin: -2px 0;
-  border: 1px solid transparent;
-  border-radius: 999px;
-  background: transparent;
   color: inherit;
   font: inherit;
-  font-variant-numeric: tabular-nums;
-  cursor: pointer;
 }
-.family-count:hover { border-color: var(--border); }
+.family-count:hover { background: var(--bg-hover); }
 .family-count.active {
   background: var(--bg-selected);
-  border-color: var(--border);
   color: var(--text);
 }
 .family-count:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -171,6 +171,47 @@ body {
   border-bottom: 1px solid var(--border);
 }
 
+/* Projects/Activity switch: the family-tally language (square, quiet,
+ * sidebar fill progression) stretched into an equal-width pair. Thin on
+ * desktop — one text line, like the rows below it. */
+.sidebar-view-toggle {
+  display: flex;
+  gap: 4px;
+  padding: 6px 8px 4px;
+  flex-shrink: 0;
+}
+.sidebar-view-btn {
+  flex: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 22px;
+  padding: 1px 7px;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-muted);
+  font: 400 12px/1.4 'Source Sans 3', sans-serif;
+  cursor: pointer;
+  transition: background 0.1s, color 0.1s;
+}
+.sidebar-view-btn:hover { background: var(--bg-hover); }
+.sidebar-view-btn.active {
+  background: var(--bg-selected);
+  color: var(--text);
+}
+.sidebar-view-btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+/* Touch: put the switch above the logo/header row so both pieces of
+ * sidebar navigation stay together. Flex order avoids moving the node;
+ * the larger targets and safe-area padding are mobile-only. */
+@media (pointer: coarse) {
+  .sidebar-view-toggle {
+    order: -1;
+    padding: calc(6px + env(safe-area-inset-top, 0px)) 8px 4px;
+  }
+  .sidebar-view-btn { min-height: 34px; font-size: 13px; }
+}
+
 .sidebar-logo {
   font-family: 'Instrument Sans', sans-serif;
   font-size: 18px;

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -618,9 +618,11 @@ body {
 .launch-inline-menu {
   position: fixed;
   background: var(--bg-surface);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4), 0 2px 8px rgba(0, 0, 0, 0.2);
+  /* Same anchored-popover skin as the session ⋮ menu, the family panel
+     and the view menu. */
+  border: 1px solid var(--border-strong);
+  border-radius: 6px;
+  box-shadow: 0 8px 24px oklch(0% 0 0 / 0.4);
   min-width: 180px;
   /* Backstop for the JS re-clamp: never wider than the viewport. */
   max-width: calc(100vw - 16px);
@@ -1333,9 +1335,11 @@ body {
   z-index: 30;
   min-width: 160px;
   background: var(--bg-surface);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  /* One anchored-popover skin, shared with the session ⋮ menu and the
+     family panel: strong border, 6px corners, one shadow. */
+  border: 1px solid var(--border-strong);
+  border-radius: 6px;
+  box-shadow: 0 8px 24px oklch(0% 0 0 / 0.4);
   padding: 4px;
 }
 .view-menu-label {
@@ -1354,7 +1358,8 @@ body {
   padding: 5px 10px 5px 6px;
   border: none;
   background: transparent;
-  color: var(--text-muted);
+  /* Same resting tone as the session ⋮ menu's actions. */
+  color: var(--text-secondary);
   font-size: 13px;
   text-align: left;
   border-radius: 5px;
@@ -1387,7 +1392,9 @@ body {
   color: var(--text);
   background: var(--bg-selected);
   border: 1px solid var(--border);
-  border-radius: 10px;
+  /* Square like the app's other small controls; pills are for floating
+     status overlays. */
+  border-radius: 4px;
   padding: 1px 4px 1px 8px;
   max-width: 100%;
 }

--- a/docs/task-family-ui.md
+++ b/docs/task-family-ui.md
@@ -51,11 +51,13 @@ with per-level `+N more` / `show fewer` folds. Ordinary tree order is recency of
 `last_output_at ?? created_at`; state does not otherwise reorder the tree.
 
 Outside the panel a root row stands in for its whole family and has at most one
-subordinate row. While a descendant is selected, that row names exactly the
-selected member and the icon-number summary is absent. Otherwise no member row
-is shown and the summary appears when the family has reportable activity. Root
-selection never restores a previously viewed member; a member that needs a
-persistent row can be promoted to a root.
+subordinate row, led by a static family button (the family icon) that opens the
+panel. While a descendant is selected, the selected member's row sits beside the
+icon; otherwise the icon-number summary lives inside the button, shown when the
+family has reportable activity. Both states share one
+row height, so selection never shifts the list. Root selection never restores a
+previously viewed member; a member that needs a persistent row can be promoted
+to a root.
 
 For agent members, `familyDotById` aggregates the highest-precedence dot onto
 the presentation root, and `unreadCount` adds unread descendants (alive or

--- a/docs/task-family-ui.md
+++ b/docs/task-family-ui.md
@@ -50,11 +50,12 @@ closing it. The root is always present, followed by a line-budgeted family tree
 with per-level `+N more` / `show fewer` folds. Ordinary tree order is recency of
 `last_output_at ?? created_at`; state does not otherwise reorder the tree.
 
-Outside the panel a root row stands in for its whole family. One member row is
-shown beneath it only while that family owns selection: the selected member, or
-the family's last-viewed member while its root is selected. It disappears as
-soon as selection leaves the family; a member that needs a persistent row can
-be promoted to a root.
+Outside the panel a root row stands in for its whole family and has at most one
+subordinate row. While a descendant is selected, that row names exactly the
+selected member and the icon-number summary is absent. Otherwise no member row
+is shown and the summary appears when the family has reportable activity. Root
+selection never restores a previously viewed member; a member that needs a
+persistent row can be promoted to a root.
 
 For agent members, `familyDotById` aggregates the highest-precedence dot onto
 the presentation root, and `unreadCount` adds unread descendants (alive or

--- a/e2e/tests/family-entry-interaction.spec.ts
+++ b/e2e/tests/family-entry-interaction.spec.ts
@@ -82,15 +82,19 @@ test.describe('sidebar family entry', () => {
     await expect(page.locator('#agent-family-drawer')).toBeHidden()
   })
 
-  test('a selected member replaces the summary as the family’s only subordinate row', async ({ page }) => {
+  test('the family button is static; only the content after it changes', async ({ page }) => {
     await openMockSidebar(page, '/my-project/claude/~fam2kid')
     const family = familyEntry(page, 'orchestrator')
+    // Member selected: the button stays (the panel's entry point never
+    // teleports) but sheds its counts — the member row is the content.
+    await expect(family.locator('.family-activity')).toHaveCount(1)
     await expect(family.locator('.family-slot')).toHaveCount(1)
-    await expect(family.locator('.family-activity')).toHaveCount(0)
+    await expect(family.locator('.family-activity-seg')).toHaveCount(0)
 
     await page.locator('.session-item').filter({ hasText: 'design landing page' }).click()
     await expect(family.locator('.family-slot')).toHaveCount(0)
     await expect(family.locator('.family-activity')).toHaveCount(1)
+    expect(await family.locator('.family-activity-seg').count()).toBeGreaterThan(0)
 
     // Root selection keeps the summary and never resurrects history.
     await family.locator('.session-item').first().click()
@@ -150,24 +154,31 @@ test.describe('sidebar family entry', () => {
 })
 
 test.describe('the family line and the panel tally', () => {
-  test('the family mark anchors to the glyph column and never shares a member row', async ({ page }) => {
+  test('the family mark anchors every subordinate row to one glyph column', async ({ page }) => {
     await openMockSidebar(page, '/my-project/claude/~fam2kid')
     const geometry = await page.evaluate(() => [...document.querySelectorAll('.session-family')].map(entry => {
       const slot = entry.querySelector('.family-slot')
       const mark = entry.querySelector('.family-activity .family-activity-icon')
+      const segs = entry.querySelectorAll('.family-activity-seg').length
       const center = (el: Element | null) => el
         ? Math.round(el.getBoundingClientRect().x + el.getBoundingClientRect().width / 2)
         : null
-      return { memberCX: center(slot?.querySelector('.family-glyph') ?? null), markCX: center(mark) }
+      return { memberCX: center(slot?.querySelector('.family-glyph') ?? null), markCX: center(mark), segs }
     }))
 
     expect(geometry.some(g => g.memberCX !== null), 'the selected family names its member').toBe(true)
-    expect(geometry.some(g => g.markCX !== null), 'inactive families retain their summaries').toBe(true)
+    expect(geometry.some(g => g.segs > 0), 'inactive families retain their summaries').toBe(true)
     for (const g of geometry) {
-      expect(g.memberCX === null || g.markCX === null, 'at most one subordinate row').toBe(true)
+      // The mark is the row's static head: wherever a subordinate row
+      // exists, the mark leads it — and the counts and the member row
+      // never share it (one subordinate row's worth of content).
+      if (g.memberCX !== null || g.segs > 0) expect(g.markCX, 'the mark leads every subordinate row').not.toBeNull()
+      expect(g.memberCX === null || g.segs === 0, 'counts and member never share the row').toBe(true)
+      if (g.memberCX !== null && g.markCX !== null)
+        expect(g.memberCX, 'the member sits after the mark').toBeGreaterThan(g.markCX)
     }
     expect(new Set(geometry.flatMap(g => g.markCX === null ? [] : [g.markCX])).size,
-      'one glyph column for every summary').toBe(1)
+      'one glyph column for every family mark').toBe(1)
   })
 
   test("the panel's tally names states in the turn model's words", async ({ page }) => {

--- a/e2e/tests/family-entry-interaction.spec.ts
+++ b/e2e/tests/family-entry-interaction.spec.ts
@@ -39,12 +39,9 @@ test.describe('sidebar family entry', () => {
       await loc.hover()
       return loc.evaluate(el => getComputedStyle(el).backgroundColor)
     }
-    // Both nested targets wear one treatment, tone-matched to their
-    // group's state — compare within one entry (the selected family
-    // shows both rows; this quiet one shows no member row).
-    const selectedEntry = familyEntry(page, 'orchestrator')
-    expect(await hoverBg(selectedEntry.locator('.family-activity')), 'same hover as the member row above')
-      .toBe(await hoverBg(selectedEntry.locator('.family-slot')))
+    // It uses the sidebar's flat background treatment rather than a
+    // bordered header pill.
+    expect(await hoverBg(indicator)).not.toBe('rgba(0, 0, 0, 0)')
     expect(await indicator.evaluate(el => getComputedStyle(el).borderStyle)).toBe('none')
 
     // The hit area stops where the numbers do: the slack to its right
@@ -85,19 +82,20 @@ test.describe('sidebar family entry', () => {
     await expect(page.locator('#agent-family-drawer')).toBeHidden()
   })
 
-  test('the member row exists only while its family owns selection', async ({ page }) => {
+  test('a selected member replaces the summary as the family’s only subordinate row', async ({ page }) => {
     await openMockSidebar(page, '/my-project/claude/~fam2kid')
     const family = familyEntry(page, 'orchestrator')
     await expect(family.locator('.family-slot')).toHaveCount(1)
+    await expect(family.locator('.family-activity')).toHaveCount(0)
 
     await page.locator('.session-item').filter({ hasText: 'design landing page' }).click()
     await expect(family.locator('.family-slot')).toHaveCount(0)
+    await expect(family.locator('.family-activity')).toHaveCount(1)
 
-    // Selecting the root restores the remembered way back; leaving did not
-    // erase the memory, it only stopped rendering an inactive family's row.
+    // Root selection keeps the summary and never resurrects history.
     await family.locator('.session-item').first().click()
-    await expect(family.locator('.family-slot')).toHaveCount(1)
-    await expect(family.locator('.family-slot')).toContainText('wire up the protocol adapter layer')
+    await expect(family.locator('.family-slot')).toHaveCount(0)
+    await expect(family.locator('.family-activity')).toHaveCount(1)
   })
 
   test('a drop anywhere on the entry reorders exactly once', async ({ page }) => {
@@ -152,39 +150,24 @@ test.describe('sidebar family entry', () => {
 })
 
 test.describe('the family line and the panel tally', () => {
-  test('the family mark anchors to the glyph column, member row or not', async ({ page }) => {
+  test('the family mark anchors to the glyph column and never shares a member row', async ({ page }) => {
     await openMockSidebar(page, '/my-project/claude/~fam2kid')
-    const geometry = await page.evaluate(() => {
-      const read = (entry: Element) => {
-        const slot = entry.querySelector('.family-slot')
-        const mark = entry.querySelector('.family-activity .family-activity-icon')
-        if (!mark) return null
-        return {
-          markCX: Math.round(mark.getBoundingClientRect().x + mark.getBoundingClientRect().width / 2),
-          memberGlyphCX: slot
-            ? Math.round(
-              slot.querySelector('.family-glyph')!.getBoundingClientRect().x
-                + slot.querySelector('.family-glyph')!.getBoundingClientRect().width / 2,
-            )
-            : null,
-        }
-      }
-      return [...document.querySelectorAll('.session-family')].map(read).filter(Boolean)
-    })
+    const geometry = await page.evaluate(() => [...document.querySelectorAll('.session-family')].map(entry => {
+      const slot = entry.querySelector('.family-slot')
+      const mark = entry.querySelector('.family-activity .family-activity-icon')
+      const center = (el: Element | null) => el
+        ? Math.round(el.getBoundingClientRect().x + el.getBoundingClientRect().width / 2)
+        : null
+      return { memberCX: center(slot?.querySelector('.family-glyph') ?? null), markCX: center(mark) }
+    }))
 
-    const withMember = geometry.filter(g => g!.memberGlyphCX !== null)
-    const withoutMember = geometry.filter(g => g!.memberGlyphCX === null)
-    expect(withMember.length, 'a family with a member row on screen').toBeGreaterThan(0)
-    expect(withoutMember.length, 'a family without one').toBeGreaterThan(0)
-
-    // The line is the standard family numbers — everyone beneath the
-    // root — not "the others", so it anchors to the root's glyph column
-    // and stays put whatever member row happens to be shown above it.
-    // (The old `+` indented under the member's title, because it meant
-    // "in addition to the one named"; that meaning is gone.)
-    const columns = new Set(geometry.map(g => g!.markCX))
-    expect(columns.size, 'one column for every family, slot row or not').toBe(1)
-    for (const g of withMember) expect(g!.markCX).toBe(g!.memberGlyphCX)
+    expect(geometry.some(g => g.memberCX !== null), 'the selected family names its member').toBe(true)
+    expect(geometry.some(g => g.markCX !== null), 'inactive families retain their summaries').toBe(true)
+    for (const g of geometry) {
+      expect(g.memberCX === null || g.markCX === null, 'at most one subordinate row').toBe(true)
+    }
+    expect(new Set(geometry.flatMap(g => g.markCX === null ? [] : [g.markCX])).size,
+      'one glyph column for every summary').toBe(1)
   })
 
   test("the panel's tally names states in the turn model's words", async ({ page }) => {

--- a/e2e/tests/promote-demote-menu.spec.ts
+++ b/e2e/tests/promote-demote-menu.spec.ts
@@ -31,10 +31,12 @@ async function openMenu(page: Page) {
 
 async function returnToFamilyMember(page: Page) {
   const family = page.locator('.session-family').filter({ hasText: 'orchestrator' })
-  // Inactive families no longer retain a member row: select the root first,
-  // then use the remembered member that appears beneath it.
+  // Root selection deliberately restores no member history. Its summary is
+  // the route back into the family map; choose the member there.
   await family.locator('.session-item').first().click()
-  await family.locator('.family-slot').filter({ hasText: 'wire up the protocol' }).click()
+  await family.locator('.family-activity').click()
+  await page.locator('#agent-family-drawer .family-row')
+    .filter({ hasText: 'wire up the protocol' }).click()
 }
 
 test.describe('promote/demote in the ⋮ session menu (mock fixtures)', () => {

--- a/e2e/tests/sidebar-view-toggle.spec.ts
+++ b/e2e/tests/sidebar-view-toggle.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from '@playwright/test'
+import { openApp } from '../helpers'
+
+/**
+ * The sidebar's Projects/Activity switch is an always-visible pair of
+ * buttons; the arrange popover no longer carries a View section. These
+ * are markup/interaction facts a unit test cannot see.
+ */
+test.describe('sidebar view toggle', () => {
+  test('switches views, reports state, and owns the concern alone', async ({ page }) => {
+    await openApp(page, '/my-project/claude/~fam2kid?mock')
+    await page.waitForSelector('.sidebar-view-toggle')
+
+    const projects = page.locator('.sidebar-view-btn', { hasText: 'Projects' })
+    const activity = page.locator('.sidebar-view-btn', { hasText: 'Activity' })
+
+    // Projects is the default: pressed, wearing the selected fill.
+    await expect(projects).toHaveAttribute('aria-pressed', 'true')
+    await expect(activity).toHaveAttribute('aria-pressed', 'false')
+    await expect(page.locator('.session-family').first()).toBeVisible()
+
+    // Switching swaps the list, the pressed state, and the URL mirror.
+    await activity.click()
+    await expect(activity).toHaveAttribute('aria-pressed', 'true')
+    await expect(projects).toHaveAttribute('aria-pressed', 'false')
+    await expect(page.locator('.session-row').first()).toBeVisible()
+    await expect(page).toHaveURL(/sidebar=activity/)
+
+    await projects.click()
+    await expect(projects).toHaveAttribute('aria-pressed', 'true')
+    await expect(page.locator('.session-family').first()).toBeVisible()
+
+    // One control per concern: the arrange popover keeps Host and Show
+    // but no longer offers the view radios the toggle replaced.
+    await page.locator('.sidebar-settings-btn[aria-label="List options"]').click()
+    const menu = page.locator('.view-menu')
+    await menu.waitFor()
+    await expect(menu.locator('.view-menu-label').first()).toHaveText('Host')
+    await expect(menu.locator('.view-menu-option', { hasText: 'Projects' })).toHaveCount(0)
+    await expect(menu.locator('.view-menu-option', { hasText: 'Activity' })).toHaveCount(0)
+  })
+})


### PR DESCRIPTION
## Summary

- render exactly one subordinate family row: the selected descendant, or the icon-number summary
- never restore a previously viewed member when selecting its root
- remove the recent-family MRU signal, cap, recorder effect, and validity machinery
- route tests that need to return from a root through the family panel instead of hidden history

## Resulting invariant

- descendant selected: exact selected member row, no summary row
- root or outside-family selected: no member row; summary appears only when activity exists
- quiet family: no subordinate row

## Verification

- TypeScript clean
- Biome clean
- 758 unit tests passed
- 85 Playwright tests passed
- installed locally; `gmuxd` running