### PR TITLE
style(web): keep native overlay scrollbars, slim only classic ones

### DIFF
--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -57,6 +57,21 @@ const KEYBOARD_PRESENCE_PX = 60
 // Mock mode: hide close buttons and other interactive chrome via CSS.
 if (USE_MOCK) document.documentElement.classList.add('mock-mode')
 
+// Scrollbar flavor: platforms with overlay scrollbars keep them native
+// (styles.css only declares color-scheme so they render dark); hosts
+// whose classic scrollbars consume layout space get the slim custom
+// skin instead. No CSS can tell the two apart, so measure once: a
+// classic scrollbar eats into a probe's client width, an overlay one
+// doesn't. Runs before render, so nothing repaints under the class.
+{
+  const probe = document.createElement('div')
+  probe.style.cssText = 'position:absolute;top:-9999px;width:100px;height:100px;overflow:scroll'
+  document.body.appendChild(probe)
+  if (probe.offsetWidth - probe.clientWidth > 0)
+    document.documentElement.classList.add('classic-scrollbars')
+  probe.remove()
+}
+
 // Debug: __gmuxCopySession() in devtools console
 installCopySession()
 // Debug: whole store namespace for console poking in mock mode.

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -24,6 +24,10 @@ code {
 }
 
 :root {
+  /* Native scrollbars (and form controls) render dark instead of the
+     browser's light default — load-bearing for leaving platform overlay
+     scrollbars alone (see the scrollbar block below). */
+  color-scheme: dark;
   /* Surfaces — widened gaps for clearer distinction */
   --bg: oklch(12% 0.015 250);
   --bg-sidebar: oklch(16.5% 0.015 250);
@@ -37,7 +41,7 @@ code {
   --text-muted: oklch(65% 0.01 250);
 
   /* Borders. Two tiers; the base tier drives dividers, card/button
-   * outlines and scrollbar thumbs, so it needs enough lightness to read
+   * outlines and classic-scrollbar thumbs, so it needs enough lightness to read
    * against the near-black surfaces. --border-strong stays ~6pts above
    * for hover/emphasis separators. */
   --border: oklch(32% 0.015 250);
@@ -79,36 +83,52 @@ code {
 
 /* ── Scrollbars ──
  *
- * One scrollbar style for the whole app, derived from the sidebar's slim
- * thumb but a touch wider and brighter so it's easier to spot and grab.
+ * Scrollbars: the platform's own overlay scrollbars (macOS, iOS,
+ * Android, most Linux desktops) are exactly what we'd design — floating,
+ * thin, appearing on scroll — and :root's color-scheme keeps them dark,
+ * so by default we don't touch them at all. No CSS can distinguish
+ * overlay from classic scrollbars, so a startup probe (see main.tsx)
+ * measures whether scrollbars consume layout space and tags
+ * <html class="classic-scrollbars"> only when they do. Those hosts —
+ * wide, blocking, arrow-adorned — get this slim custom skin instead.
  *
- * Two mechanisms on purpose: Chromium 121+ and Firefox honor the standard
- * scrollbar-width/scrollbar-color properties (and then ignore the
- * ::-webkit-scrollbar pseudos entirely); Safari only understands the
- * webkit pseudos. Each browser picks the one it supports.
- *
- * Keeping the thumb thin also keeps the layout cost of classic
- * (non-overlay) scrollbars small wherever they take up space. */
-* {
-  scrollbar-width: thin;
-  scrollbar-color: var(--border-strong) transparent;
+ * Two mechanisms on purpose, but not both at once: a browser that
+ * understands the ::-webkit-scrollbar pseudos (Chromium, Safari) gets
+ * the fully custom scrollbar — thumb only, no stepper arrows — while
+ * Firefox, which doesn't, gets the standard scrollbar-width/color
+ * properties instead (its thin scrollbar has no buttons either). The
+ * split matters because Chromium 121+ honors the standard properties
+ * too, and once they're set it *ignores* the webkit pseudos — drawing
+ * its native thin scrollbar, arrows included on desktop themes. */
+@supports not selector(::-webkit-scrollbar) {
+  .classic-scrollbars * {
+    scrollbar-width: thin;
+    scrollbar-color: var(--border-strong) transparent;
+  }
 }
-*::-webkit-scrollbar {
+.classic-scrollbars *::-webkit-scrollbar {
   width: 6px;
   height: 6px;
 }
-*::-webkit-scrollbar-track {
+.classic-scrollbars *::-webkit-scrollbar-track {
   background: transparent;
 }
-*::-webkit-scrollbar-thumb {
+.classic-scrollbars *::-webkit-scrollbar-thumb {
   background: var(--border-strong);
   border-radius: 3px;
 }
-*::-webkit-scrollbar-thumb:hover {
+.classic-scrollbars *::-webkit-scrollbar-thumb:hover {
   background: oklch(46% 0.015 250);
 }
-*::-webkit-scrollbar-corner {
+.classic-scrollbars *::-webkit-scrollbar-corner {
   background: transparent;
+}
+/* No stepper arrows, anywhere. Styled scrollbars don't draw them
+ * unless asked, but saying so keeps every theme honest. */
+.classic-scrollbars *::-webkit-scrollbar-button {
+  display: none;
+  width: 0;
+  height: 0;
 }
 
 html, body, #app {


### PR DESCRIPTION
Platform overlay scrollbars (macOS, iOS, Android, most Linux desktops) are exactly what the previous custom skin was imitating — floating, thin, appearing on scroll — so this stops imitating them: `color-scheme: dark` makes native scrollbars (and form controls) render dark, and overlay hosts keep them untouched.

No CSS can distinguish overlay from classic scrollbars, so a one-time startup probe in `main.tsx` measures whether scrollbars consume layout space and tags `<html class="classic-scrollbars">` only when they do. Those hosts — wide, blocking, arrow-adorned — get the slim thumb-only skin, with the standard `scrollbar-width`/`scrollbar-color` properties scoped to non-webkit browsers (`@supports not selector(::-webkit-scrollbar)`) so Chromium never falls back to its native arrow-bearing thin scrollbar, and an explicit `::-webkit-scrollbar-button { display: none }` backstop.