### PR TITLE
fix(web): bind image paste to session connection

### DIFF
--- a/apps/gmux-web/src/keyboard.test.ts
+++ b/apps/gmux-web/src/keyboard.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest'
-import { applyArmedModifiers, ctrlSequenceFor, formatPasteText, pickBinaryDataTransferItem } from './keyboard'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { applyArmedModifiers, ctrlSequenceFor, formatPasteText, handlePasteAction, type PasteDestination, pickBinaryDataTransferItem } from './keyboard'
 
 // Build an array-like stand-in for DataTransferItemList. Vitest runs in
 // node by default, where the real DOM type isn't available; a plain
@@ -13,6 +13,92 @@ function makeItems(
   })
   return list as unknown as DataTransferItemList
 }
+
+afterEach(() => vi.unstubAllGlobals())
+
+function destination(sessionId: string, send: (text: string) => boolean): PasteDestination {
+  return { sessionId, bracketedPasteMode: false, send }
+}
+
+function binaryClipboard(getType: () => Promise<Blob>): Clipboard {
+  return {
+    read: async () => [{ types: ['image/png'], getType }],
+  } as unknown as Clipboard
+}
+
+describe('paste destination binding', () => {
+  it('uses one namespaced destination for both upload and delivery', async () => {
+    const sent: string[] = []
+    let requestURL = ''
+    vi.stubGlobal('navigator', { clipboard: binaryClipboard(async () => new Blob(['png'], { type: 'image/png' })) })
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      requestURL = url
+      return new Response(JSON.stringify({ ok: true, data: { path: '/tmp/b.png' } }))
+    }))
+
+    await handlePasteAction(destination('abc@paste-container', text => { sent.push(text); return true }), vi.fn())
+
+    expect(requestURL).toBe('/v1/sessions/abc%40paste-container/clipboard')
+    expect(sent).toEqual(['/tmp/b.png'])
+  })
+
+  it('does not inject a delayed A upload after its connection is replaced', async () => {
+    let finish!: (response: Response) => void
+    vi.stubGlobal('navigator', { clipboard: binaryClipboard(async () => new Blob(['png'])) })
+    vi.stubGlobal('fetch', vi.fn(() => new Promise<Response>(resolve => { finish = resolve })))
+    let currentConnection = 'A'
+    const sent: string[] = []
+    const feedback = vi.fn()
+    const action = handlePasteAction(destination('A', text => {
+      if (currentConnection !== 'A') return false
+      sent.push(text)
+      return true
+    }), feedback)
+
+    await vi.waitFor(() => expect(finish).toBeTypeOf('function'))
+    currentConnection = 'B'
+    finish(new Response(JSON.stringify({ ok: true, data: { path: '/tmp/a.png' } })))
+    await action
+
+    expect(sent).toEqual([])
+    expect(feedback).toHaveBeenCalledWith('error', 'Paste cancelled: terminal connection changed')
+  })
+
+  it('does not use a replacement socket for stale completion', async () => {
+    let connection = {}
+    const captured = connection
+    const sent: string[] = []
+    vi.stubGlobal('navigator', { clipboard: binaryClipboard(async () => new Blob(['png'])) })
+    vi.stubGlobal('fetch', vi.fn(async () => {
+      connection = {}
+      return new Response(JSON.stringify({ ok: true, data: { path: '/tmp/stale.png' } }))
+    }))
+    const feedback = vi.fn()
+
+    await handlePasteAction(destination('A', text => {
+      if (connection !== captured) return false
+      sent.push(text)
+      return true
+    }), feedback)
+
+    expect(sent).toEqual([])
+    expect(feedback).toHaveBeenCalledWith('error', expect.stringContaining('connection changed'))
+  })
+
+  it('surfaces ClipboardItem.getType failure without uploading or sending', async () => {
+    const fetch = vi.fn()
+    const send = vi.fn(() => true)
+    const feedback = vi.fn()
+    vi.stubGlobal('navigator', { clipboard: binaryClipboard(async () => { throw new Error('gone') }) })
+    vi.stubGlobal('fetch', fetch)
+
+    await handlePasteAction(destination('A', send), feedback)
+
+    expect(fetch).not.toHaveBeenCalled()
+    expect(send).not.toHaveBeenCalled()
+    expect(feedback).toHaveBeenCalledWith('error', 'Paste failed: could not read clipboard item')
+  })
+})
 
 describe('pickBinaryDataTransferItem', () => {
   it('returns the first file with a non-text MIME', () => {

--- a/apps/gmux-web/src/keyboard.ts
+++ b/apps/gmux-web/src/keyboard.ts
@@ -12,20 +12,30 @@
  */
 import type { Terminal } from '@xterm/xterm'
 import {
+  firstBinaryType,
+  type UploadResult,
+  uploadClipboardBlob,
+} from './clipboard-upload'
+import {
   eventMatchesKeybind,
   IS_MAC,
   keyComboToSequence,
   type ResolvedKeybind,
 } from './config'
-import {
-  firstBinaryType,
-  uploadClipboardBlob,
-  type UploadResult,
-} from './clipboard-upload'
 import { selectionToText } from './selection'
 import { terminalFindOpen } from './store'
 
 type SendFn = (data: string) => void
+
+/** Immutable terminal connection capability captured at a paste gesture. */
+export interface PasteDestination {
+  readonly sessionId: string
+  readonly bracketedPasteMode: boolean
+  /** Sends only while the exact captured connection is still current and open. */
+  send(text: string): boolean
+}
+
+export type GetPasteDestination = () => PasteDestination | null
 
 /**
  * Detect a touch-primary device (coarse pointer).
@@ -77,19 +87,25 @@ export const defaultPasteFeedback: PasteFeedback = (kind, message) => {
  * input bytes to type into the PTY on success, or null on failure (after
  * surfacing the error via feedback).
  */
-async function uploadAndFormatPath(
+async function uploadAndSendPath(
   blob: Blob,
-  sessionId: string,
-  bracketedPasteMode: boolean,
+  destination: PasteDestination,
   feedback: PasteFeedback,
-): Promise<string | null> {
-  const result: UploadResult = await uploadClipboardBlob(blob, sessionId)
+): Promise<void> {
+  const result: UploadResult = await uploadClipboardBlob(blob, destination.sessionId)
   if (!result.ok) {
     feedback('error', pasteErrorMessage(result.error))
-    return null
+    return
   }
-  feedback('info', `Pasted to ${result.path}`)
-  return formatPasteText(result.path, bracketedPasteMode)
+  if (!destination.send(formatPasteText(result.path, destination.bracketedPasteMode))) {
+    feedback('error', 'Paste cancelled: terminal connection changed')
+  }
+}
+
+function sendPaste(destination: PasteDestination, text: string, feedback: PasteFeedback): void {
+  if (!destination.send(formatPasteText(text, destination.bracketedPasteMode))) {
+    feedback('error', 'Paste cancelled: terminal connection changed')
+  }
 }
 
 function pasteErrorMessage(code: string): string {
@@ -114,10 +130,9 @@ function pasteErrorMessage(code: string): string {
 export function attachKeyboardHandler(
   term: Terminal,
   send: SendFn,
-  sendRaw: SendFn,
   keybinds: ResolvedKeybind[],
   macCommandIsCtrl = false,
-  sessionId = '',
+  getPasteDestination: GetPasteDestination = () => null,
   onPasteFeedback: PasteFeedback = defaultPasteFeedback,
 ): void {
   term.attachCustomKeyEventHandler((ev: KeyboardEvent) => {
@@ -151,7 +166,7 @@ export function attachKeyboardHandler(
 
       for (const kb of keybinds) {
         if (!eventMatchesKeybind(virtualMods, kb)) continue
-        const handled = executeAction(kb, term, send, sendRaw, sessionId, onPasteFeedback)
+        const handled = executeAction(kb, term, send, getPasteDestination, onPasteFeedback)
         if (handled) { ev.preventDefault(); return false }
       }
 
@@ -169,7 +184,7 @@ export function attachKeyboardHandler(
       // For shift+enter we need to block all event types (keydown, keypress,
       // keyup) to prevent the Kitty keyboard protocol sequence from leaking.
       if (kb.baseKey === 'enter' && kb.shift) {
-        if (ev.type === 'keydown') executeAction(kb, term, send, sendRaw, sessionId, onPasteFeedback)
+        if (ev.type === 'keydown') executeAction(kb, term, send, getPasteDestination, onPasteFeedback)
         ev.preventDefault()
         return false
       }
@@ -177,7 +192,7 @@ export function attachKeyboardHandler(
       // For other bindings, only act on keydown.
       if (ev.type !== 'keydown') return true
 
-      const handled = executeAction(kb, term, send, sendRaw, sessionId, onPasteFeedback)
+      const handled = executeAction(kb, term, send, getPasteDestination, onPasteFeedback)
       if (handled) {
         // Prevent browser default (e.g. Cmd+Left navigating back on Mac).
         // xterm.js does not call preventDefault when the custom handler
@@ -196,15 +211,13 @@ export function attachKeyboardHandler(
  * (not passed to xterm), false if xterm should still process it.
  *
  * `send` is the input channel (may apply mobile ctrl/alt arm modifiers).
- * `sendRaw` bypasses modifier logic, used by paste to avoid corrupting
- * clipboard content.
+ * Paste uses its captured destination capability to bypass modifier logic.
  */
 function executeAction(
   kb: ResolvedKeybind,
   term: Terminal,
   send: SendFn,
-  sendRaw: SendFn,
-  sessionId: string,
+  getPasteDestination: GetPasteDestination,
   onPasteFeedback: PasteFeedback,
 ): boolean {
   switch (kb.action) {
@@ -244,17 +257,18 @@ function executeAction(
       // Inspect the clipboard for binary content first; binary always
       // wins over text (see PRD). Falls back to readText() when only
       // text/* representations are present, preserving prior behavior.
-      // Both branches use sendRaw to bypass mobile ctrl/alt arm logic.
+      // Both branches use the destination capability directly, bypassing
+      // mobile ctrl/alt arm logic.
       //
       // Requires clipboard-read permission in a secure context. The
       // keydown counts as a user gesture. Permission denial is reported
       // via onPasteFeedback so users see why nothing happened.
-      void handlePasteAction({
-        sessionId,
-        bracketedPasteMode: term.modes.bracketedPasteMode,
-        feedback: onPasteFeedback,
-        emit: sendRaw,
-      })
+      const destination = getPasteDestination()
+      if (!destination) {
+        onPasteFeedback('error', 'Paste failed: no active terminal connection')
+        return true
+      }
+      void handlePasteAction(destination, onPasteFeedback)
       return true
     }
 
@@ -431,18 +445,13 @@ export function formatPasteText(text: string, bracketedPasteMode: boolean): stri
  * - We need to own the bracketed-paste / newline conversion ourselves so it is
  *   always correct regardless of what mobile modifier state is active.
  *
- * The `sendRaw` parameter must be sendRawInput (not sendInput) so that
- * paste is never transformed by the ctrl/alt modifier logic. The name
- * encodes the contract: the keybind paste action takes the same care
- * (see executeAction's `case 'paste'`).
+ * The destination's send capability bypasses ctrl/alt modifier logic.
  *
  * Returns a cleanup function.
  */
 export function attachPasteHandler(
-  term: Terminal,
   container: HTMLElement,
-  sendRaw: SendFn,
-  sessionId = '',
+  getPasteDestination: GetPasteDestination,
   onPasteFeedback: PasteFeedback = defaultPasteFeedback,
 ): () => void {
   const handler = (ev: ClipboardEvent) => {
@@ -462,12 +471,12 @@ export function attachPasteHandler(
         onPasteFeedback('error', 'Paste failed: could not read clipboard item')
         return
       }
-      if (!sessionId) {
-        onPasteFeedback('error', 'Paste failed: no session bound')
+      const destination = getPasteDestination()
+      if (!destination) {
+        onPasteFeedback('error', 'Paste failed: no active terminal connection')
         return
       }
-      void uploadAndFormatPath(blob, sessionId, term.modes.bracketedPasteMode, onPasteFeedback)
-        .then(out => { if (out !== null) sendRaw(out) })
+      void uploadAndSendPath(blob, destination, onPasteFeedback)
       return
     }
 
@@ -478,7 +487,12 @@ export function attachPasteHandler(
     ev.stopPropagation()
     ev.preventDefault()
 
-    sendRaw(formatPasteText(text, term.modes.bracketedPasteMode))
+    const destination = getPasteDestination()
+    if (!destination) {
+      onPasteFeedback('error', 'Paste failed: no active terminal connection')
+      return
+    }
+    sendPaste(destination, text, onPasteFeedback)
   }
 
   container.addEventListener('paste', handler, { capture: true })
@@ -523,13 +537,10 @@ export function pickBinaryDataTransferItem(items: DataTransferItemList): DataTra
  * inspect-and-route logic as the keybind path. Without this, the mobile
  * button would be text-only.
  */
-export async function handlePasteAction(args: {
-  sessionId: string
-  bracketedPasteMode: boolean
-  feedback: PasteFeedback
-  emit: SendFn
-}): Promise<void> {
-  const { sessionId, bracketedPasteMode, feedback, emit } = args
+export async function handlePasteAction(
+  destination: PasteDestination,
+  feedback: PasteFeedback = defaultPasteFeedback,
+): Promise<void> {
   const reader = navigator.clipboard
 
   if (typeof reader?.read === 'function') {
@@ -544,22 +555,29 @@ export async function handlePasteAction(args: {
       for (const item of items) {
         const binMime = firstBinaryType(item.types)
         if (!binMime) continue
-        const blob = await item.getType(binMime)
-        if (!sessionId) {
-          feedback('error', 'Paste failed: no session bound')
+        let blob: Blob
+        try {
+          blob = await item.getType(binMime)
+        } catch (err) {
+          feedback('error', 'Paste failed: could not read clipboard item')
+          console.warn('Paste failed: could not read clipboard item.', err)
           return
         }
-        const out = await uploadAndFormatPath(blob, sessionId, bracketedPasteMode, feedback)
-        if (out !== null) emit(out)
+        await uploadAndSendPath(blob, destination, feedback)
         return
       }
       // No binary; extract text from the items we already have so we
       // don't trigger a second clipboard permission prompt.
       for (const item of items) {
         if (!item.types.includes('text/plain')) continue
-        const blob = await item.getType('text/plain')
-        const text = await blob.text()
-        if (text) emit(formatPasteText(text, bracketedPasteMode))
+        try {
+          const blob = await item.getType('text/plain')
+          const text = await blob.text()
+          if (text) sendPaste(destination, text, feedback)
+        } catch (err) {
+          feedback('error', 'Paste failed: could not read clipboard item')
+          console.warn('Paste failed: could not read clipboard item.', err)
+        }
         return
       }
       return // clipboard had only types we don't handle
@@ -568,7 +586,7 @@ export async function handlePasteAction(args: {
 
   try {
     const text = await reader.readText()
-    if (text) emit(formatPasteText(text, bracketedPasteMode))
+    if (text) sendPaste(destination, text, feedback)
   } catch (err) {
     feedback('error', 'Paste failed: clipboard access denied')
     console.warn('Paste failed: clipboard access denied.', err)

--- a/apps/gmux-web/src/terminal.tsx
+++ b/apps/gmux-web/src/terminal.tsx
@@ -1,29 +1,30 @@
-import { useCallback, useEffect, useRef, useState } from 'preact/hooks'
-import { Terminal } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
 import { ImageAddon } from '@xterm/addon-image'
-import { WebLinksAddon } from '@xterm/addon-web-links'
 import { SearchAddon } from '@xterm/addon-search'
-import type { ResolvedTerminalOptions } from './settings-schema'
-import { loadWebglRenderer } from './webgl-renderer'
-import { refreshAtlasWhenIconFontLoads } from './nerd-font'
-import { applyArmedModifiers, attachKeyboardHandler, attachPasteHandler, defaultPasteFeedback, handlePasteAction } from './keyboard'
+import { WebLinksAddon } from '@xterm/addon-web-links'
+import { Terminal } from '@xterm/xterm'
+import { useCallback, useEffect, useRef, useState } from 'preact/hooks'
 import { DEFAULT_THEME_COLORS, type ResolvedKeybind } from './config'
-import { attachMobileInputHandler } from './mobile-input'
-import { isTouchDevice } from './touch'
-import { BSU, createReplayBuffer, ESU, startsWith } from './replay'
-import { createTerminalIO, type TerminalSize } from './terminal-io'
-import { type LinkInfo, linkAtPoint, openLinkAtPoint } from './terminal-link'
-import { createLongPressRecognizer } from './long-press'
+import { applyArmedModifiers, attachKeyboardHandler, attachPasteHandler, handlePasteAction, type PasteDestination } from './keyboard'
 import { LinkActionSheet } from './link-action-sheet'
-import { TerminalTextSheet } from './terminal-text-sheet'
-import { pressedBufferRow, readTerminalText } from './terminal-text'
-import { decideViewportResize, sameSize } from './terminal-resize'
-import { type WsState, wsStateOnClose, wsStateOnOutput } from './ws-state'
+import { createLongPressRecognizer } from './long-press'
+import { attachMobileInputHandler } from './mobile-input'
+import { MOCK_BY_ID } from './mock-data/index'
+import { refreshAtlasWhenIconFontLoads } from './nerd-font'
+import { BSU, createReplayBuffer, ESU, startsWith } from './replay'
+import type { ResolvedTerminalOptions } from './settings-schema'
 import { terminalFindOpen, terminalScrolledUp, terminalScrollToBottom } from './store'
 import { TerminalFindBar } from './terminal-find'
-import { MOCK_BY_ID } from './mock-data/index'
+import { createTerminalIO, type TerminalSize } from './terminal-io'
+import { type LinkInfo, linkAtPoint, openLinkAtPoint } from './terminal-link'
+import { decideViewportResize, sameSize } from './terminal-resize'
+import { pressedBufferRow, readTerminalText } from './terminal-text'
+import { TerminalTextSheet } from './terminal-text-sheet'
+import { pushError } from './toasts'
+import { isTouchDevice } from './touch'
 import type { Session } from './types'
+import { loadWebglRenderer } from './webgl-renderer'
+import { type WsState, wsStateOnClose, wsStateOnOutput } from './ws-state'
 
 // ── Config ──
 
@@ -36,6 +37,7 @@ const CHECKPOINT_BROWSER_RESET = encoder.encode('\x1b[r\x1b[H\x1b[2J\x1b[3J')
 const CHECKPOINT_SGR_RESET = encoder.encode('\x1b[0m')
 
 type CheckpointMargins = { top: number, bottom: number, rows: number }
+type SessionConnection = { readonly sessionId: string, readonly ws: WebSocket }
 
 /**
  * Add browser-only buffer authority at the complete checkpoint boundary.
@@ -339,7 +341,8 @@ export function TerminalView({
   const shellRef = useRef<HTMLDivElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
   const termRef = useRef<Terminal | null>(null)
-  const wsRef = useRef<WebSocket | null>(null)
+  // Session ID and socket form one atomic connection identity.
+  const connectionRef = useRef<SessionConnection | null>(null)
   const reconnectTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const disposed = useRef(false)
   const currentSessionId = useRef(session.id)
@@ -439,7 +442,7 @@ export function TerminalView({
     // viewport event. The server echo for this exact size re-opens the gate.
     resetResizeEchoGate()
 
-    const ws = wsRef.current
+    const ws = connectionRef.current?.ws
     if (!ws || ws.readyState !== WebSocket.OPEN) return
 
     announceResize(ws, size)
@@ -639,14 +642,15 @@ export function TerminalView({
     }
 
     const sendRawInput = (data: string) => {
-      const ws = wsRef.current
-      if (!ws || ws.readyState !== WebSocket.OPEN) return
+      const connection = connectionRef.current
+      if (!connection || connection.sessionId !== currentSessionId.current
+          || connection.ws.readyState !== WebSocket.OPEN) return
       // Only re-assert focus if the terminal already had it (keyboard
       // open). Grabbing focus unconditionally would pop the on-screen
       // keyboard on every toolbar key, even when it was closed — the
       // whole point of the toolbar is to work with the keyboard down.
       const hadFocus = document.activeElement === term.textarea
-      ws.send(new TextEncoder().encode(data))
+      connection.ws.send(new TextEncoder().encode(data))
       if (hadFocus) term.focus()
     }
 
@@ -659,24 +663,43 @@ export function TerminalView({
 
     onInputReady?.(sendRawInput)
     terminalScrollToBottom.value = () => term.scrollToBottom()
-    // The paste trigger reads bracketedPasteMode and the clipboard fresh
-    // on every invocation: bracketed mode flips at runtime as TUIs come
-    // and go, and the clipboard contents are obviously volatile. Sharing
-    // handlePasteAction with the keybind path means long-press paste gets
-    // binary-paste support without divergent code.
-    pasteActionRef.current = () => {
-      void handlePasteAction({
-        sessionId: session.id,
+    const pasteFeedback = (kind: 'info' | 'error', message: string) => {
+      if (kind === 'error') {
+        console.warn('[paste]', message)
+        pushError(message)
+      }
+    }
+    const getPasteDestination = (): PasteDestination | null => {
+      const connection = connectionRef.current
+      if (!connection || connection.sessionId !== currentSessionId.current
+          || connection.ws.readyState !== WebSocket.OPEN) return null
+      return {
+        sessionId: connection.sessionId,
         bracketedPasteMode: term.modes.bracketedPasteMode,
-        feedback: defaultPasteFeedback,
-        emit: sendRawInput,
-      })
+        send(text) {
+          if (connectionRef.current !== connection
+              || currentSessionId.current !== connection.sessionId
+              || connection.ws.readyState !== WebSocket.OPEN) return false
+          connection.ws.send(new TextEncoder().encode(text))
+          return true
+        },
+      }
+    }
+    // Every gesture acquires one immutable session/socket capability. The
+    // keybind, DOM paste, and mobile sheet paths therefore share routing.
+    pasteActionRef.current = () => {
+      const destination = getPasteDestination()
+      if (!destination) {
+        pasteFeedback('error', 'Paste failed: no active terminal connection')
+        return
+      }
+      void handlePasteAction(destination, pasteFeedback)
     }
     onFocusReady?.(() => focusTerminalInput(term))
 
     const dataDisposable = term.onData((data) => sendInput(data))
-    attachKeyboardHandler(term, sendInput, sendRawInput, keybinds, macCommandIsCtrl, session.id)
-    const disposePasteHandler = attachPasteHandler(term, containerRef.current!, sendRawInput, session.id)
+    attachKeyboardHandler(term, sendInput, keybinds, macCommandIsCtrl, getPasteDestination, pasteFeedback)
+    const disposePasteHandler = attachPasteHandler(containerRef.current!, getPasteDestination, pasteFeedback)
     const disposeMobileHandler = attachMobileInputHandler(term, containerRef.current!, sendRawInput)
 
     // OSC 52 clipboard: applications (e.g. pi /copy) write
@@ -922,8 +945,8 @@ export function TerminalView({
       terminalFindOpen.value = false
       searchAddonRef.current = null
       if (reconnectTimer.current) clearTimeout(reconnectTimer.current)
-      wsRef.current?.close()
-      wsRef.current = null
+      connectionRef.current?.ws.close()
+      connectionRef.current = null
       onInputReady?.(null)
       pasteActionRef.current = null
       onFocusReady?.(null)
@@ -972,9 +995,9 @@ export function TerminalView({
     function connect() {
       if (disposed.current) return
 
-      if (wsRef.current) {
-        wsRef.current.close()
-        wsRef.current = null
+      if (connectionRef.current) {
+        connectionRef.current.ws.close()
+        connectionRef.current = null
       }
 
       // Tell the scroll preservation layer to force-scroll-to-bottom for
@@ -1002,10 +1025,11 @@ export function TerminalView({
       const wsProtocol = location.protocol === 'https:' ? 'wss:' : 'ws:'
       const ws = new WebSocket(`${wsProtocol}//${location.host}/ws/${session.id}?client=browser`)
       ws.binaryType = 'arraybuffer'
-      wsRef.current = ws
+      const connection: SessionConnection = { sessionId: session.id, ws }
+      connectionRef.current = connection
 
       ws.onopen = () => {
-        if (wsRef.current !== ws) return
+        if (connectionRef.current !== connection) return
         attempt = 0
         setWsState('open')
 
@@ -1030,13 +1054,13 @@ export function TerminalView({
 
         // First connect for this session: claim ownership by fitting the PTY
         // to our viewport. fitAndResize measures, sets viewport+pty
-        // optimistically, and sends the resize over this ws (wsRef was set
+        // optimistically, and sends the resize over this ws (connectionRef was set
         // above).
         fitAndResize()
       }
 
       ws.onmessage = (ev) => {
-        if (wsRef.current !== ws) return
+        if (connectionRef.current !== connection) return
         // Safety net: live output proves the connection works. Never show the
         // disconnected pill while data is flowing on the current socket.
         setWsState(wsStateOnOutput)
@@ -1106,7 +1130,7 @@ export function TerminalView({
         // fires *after* the replacement socket opened, and marking the
         // connection 'lost' then would leave the pill stuck on screen
         // forever while the live socket streams output behind it.
-        const isCurrent = wsRef.current === ws
+        const isCurrent = connectionRef.current === connection
         setWsState(prev => wsStateOnClose(prev, isCurrent))
         if (!isCurrent) return
         resetResizeEchoGate()
@@ -1132,8 +1156,8 @@ export function TerminalView({
       if (reconnectTimer.current) clearTimeout(reconnectTimer.current)
       reconnectTimer.current = null
       resetResizeEchoGate()
-      wsRef.current?.close()
-      wsRef.current = null
+      connectionRef.current?.ws.close()
+      connectionRef.current = null
     }
   }, [fitAndResize, queueData, queueMany, queueResize, releaseResizeEchoGate, resetResizeEchoGate, session.id, fontReady])
 

--- a/e2e/tests/terminal-paste.spec.ts
+++ b/e2e/tests/terminal-paste.spec.ts
@@ -28,6 +28,19 @@ async function dispatchPaste(page: Page, text: string): Promise<void> {
   }, text)
 }
 
+/** Dispatch a synthetic binary paste through the production DOM handler. */
+async function dispatchBinaryPaste(page: Page, size: number): Promise<void> {
+  await page.evaluate((bytes) => {
+    const container = document.querySelector('.terminal-container') as HTMLElement | null
+    if (!container) throw new Error('.terminal-container not found')
+    const dt = new DataTransfer()
+    dt.items.add(new File([new Uint8Array(bytes)], 'clipboard.png', { type: 'image/png' }))
+    container.dispatchEvent(
+      new ClipboardEvent('paste', { bubbles: true, cancelable: true, clipboardData: dt }),
+    )
+  }, size)
+}
+
 /** Drain and return all binary WS sends recorded since the last drain. */
 async function drainCaptured(page: Page): Promise<string[]> {
   return page.evaluate(() => {
@@ -62,14 +75,23 @@ test.describe('terminal paste', () => {
     // Instrument WebSocket.prototype.send BEFORE the page loads so we capture
     // every binary send from the very first connection.
     await page.addInitScript(() => {
-      const origSend = WebSocket.prototype.send
+      const NativeWebSocket = WebSocket
+      const origSend = NativeWebSocket.prototype.send
       ;(window as any).__wsCaptured = [] as string[]
-      WebSocket.prototype.send = function (data: unknown) {
+      ;(window as any).__wsInstances = [] as WebSocket[]
+      NativeWebSocket.prototype.send = function (data: unknown) {
         if (data instanceof Uint8Array) {
           ;(window as any).__wsCaptured.push(new TextDecoder().decode(data))
         }
         return origSend.apply(this, [data as any])
       }
+      window.WebSocket = new Proxy(NativeWebSocket, {
+        construct(Target, args) {
+          const ws = Reflect.construct(Target, args) as WebSocket
+          ;(window as any).__wsInstances.push(ws)
+          return ws
+        },
+      })
     })
 
     await openApp(page)
@@ -156,6 +178,63 @@ test.describe('terminal paste', () => {
     expect(captured.some(s => s.includes('\x1b[201~injected'))).toBe(false)
 
     await resetBracketedPasteMode(page)
+  })
+
+  // ── Binary failure feedback ─────────────────────────────────────────────────
+
+  test('delayed image upload is cancelled after its socket is replaced', async ({ page }) => {
+    let releaseUpload!: () => void
+    const uploadMayFinish = new Promise<void>(resolve => { releaseUpload = resolve })
+    let uploadPending!: () => void
+    const sawPendingUpload = new Promise<void>(resolve => { uploadPending = resolve })
+    await page.route('**/v1/sessions/*/clipboard', async route => {
+      uploadPending()
+      await uploadMayFinish
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ ok: true, data: { path: '/tmp/socket-replaced.png' } }),
+      })
+    })
+
+    await dispatchBinaryPaste(page, 3)
+    await sawPendingUpload
+    const originalIndex = await page.evaluate(() => {
+      const sockets = (window as any).__wsInstances as WebSocket[]
+      const index = sockets.findLastIndex(ws => ws.url.includes('/ws/') && ws.readyState === WebSocket.OPEN)
+      if (index < 0) throw new Error('no open terminal WebSocket')
+      sockets[index].close()
+      return index
+    })
+    await expect.poll(() => page.evaluate(index => {
+      const sockets = (window as any).__wsInstances as WebSocket[]
+      return sockets.some((ws, i) => i > index && ws.url.includes('/ws/') && ws.readyState === WebSocket.OPEN)
+    }, originalIndex)).toBe(true)
+    await page.evaluate(index => {
+      const sockets = (window as any).__wsInstances as WebSocket[]
+      // Keep the stale socket's state check non-vacuous: cancellation must be
+      // enforced by connection object identity, not merely CLOSED state. If
+      // that production guard is removed, the send attempt does not report
+      // cancellation, so the expected cancellation toast never appears.
+      Object.defineProperty(sockets[index], 'readyState', {
+        configurable: true,
+        get: () => WebSocket.OPEN,
+      })
+    }, originalIndex)
+
+    await drainCaptured(page)
+    releaseUpload()
+
+    await expect(page.getByText('Paste cancelled: terminal connection changed')).toBeVisible()
+    await expect.poll(async () => (await drainCaptured(page)).some(data => data.includes('/tmp/socket-replaced.png')))
+      .toBe(false)
+  })
+
+  test('oversize binary paste is not injected and shows a toast', async ({ page }) => {
+    await dispatchBinaryPaste(page, 10 * 1024 * 1024 + 1)
+
+    await expect(page.getByText('Clipboard item too large (limit 10MB)')).toBeVisible()
+    expect(await drainCaptured(page)).toEqual([])
   })
 
   // ── No double-paste ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- bind each paste gesture to one immutable namespaced session/WebSocket connection capability
- reject delayed image-paste completions after a session switch or socket replacement instead of sending the old host's path through the current terminal
- acquire paste destinations fresh for keyboard, DOM, and mobile entry points
- surface upload, clipboard, and stale-connection failures through the existing toast UI
- keep existing peer forwarding and daemon-owned `/tmp` file materialization unchanged

## Root cause

The stable terminal setup captured the initially mounted session ID for the clipboard upload, while upload completion sent through mutable `wsRef.current`. After switching sessions—or while an upload was in flight—this could upload on host A and inject host A's returned path into host B's PTY.

The new `SessionConnection` atomically pairs the namespaced session ID with its concrete WebSocket. `PasteDestination.send` only succeeds while that exact connection remains current and open.

## Tests

- `pnpm --dir apps/gmux-web exec vitest run src/keyboard.test.ts src/clipboard-upload.test.ts` — 44 passed
- `pnpm --dir apps/gmux-web lint` — passed
- `pnpm exec biome check apps/gmux-web/src/keyboard.ts apps/gmux-web/src/keyboard.test.ts apps/gmux-web/src/terminal.tsx e2e/tests/terminal-paste.spec.ts` — passed
- `pnpm exec playwright test --config e2e/playwright.config.ts e2e/tests/terminal-paste.spec.ts` — 9 passed; repeated successfully
- production-guard mutation probe — new socket-replacement E2E failed as expected, then passed after restoring the guard
- `pnpm lint` — passed
- `pnpm build` — passed
- `pnpm test` — web and other tasks passed, but the local aggregate command was stopped by `TestPiSubcommandsMatchHelp`: this environment sets `FORCE_COLOR`, so installed `pi --help` ignored the test's `NO_COLOR` and its parser found no subcommands. This is unrelated to the changed files.
