### PR TITLE
fix: separate session error outcome from unread attention

### DIFF
--- a/apps/gmux-web/src/family-drawer-model.test.ts
+++ b/apps/gmux-web/src/family-drawer-model.test.ts
@@ -374,7 +374,7 @@ describe('filtering by a state the tally counts', () => {
       last_output_at: new Date(Date.parse('2026-08-04T20:00:00Z') - minutes * 60_000).toISOString(),
       ...extra,
     })
-  const errored = { status: { active: true, error: true } } as const
+  const errored = { unread: true, status: { active: false, error: true } } as const
   const waiting = { unread: true } as const
 
   /** A family with something of each state, plus filler to make the
@@ -475,8 +475,8 @@ describe('the budget charges only for folds that get drawn', () => {
     const snapshot = [at(0, 'root', undefined)]
     for (const branch of ['a', 'b', 'c']) {
       snapshot.push(at(start[branch], branch, 'root'))
-      snapshot.push(at(start[branch] + 1.5, `${branch}1`, branch, { status: { active: true, error: true } }))
-      snapshot.push(at(start[branch] + 1.6, `${branch}2`, branch, { status: { active: true, error: true } }))
+      snapshot.push(at(start[branch] + 1.5, `${branch}1`, branch, { unread: true, status: { active: false, error: true } }))
+      snapshot.push(at(start[branch] + 1.6, `${branch}2`, branch, { unread: true, status: { active: false, error: true } }))
       for (let i = 0; i < 50; i++) snapshot.push(at(20 + i, `${branch}-idle-${i}`, branch))
     }
     const tree = projectFamily(snapshot[0], snapshot).tree

--- a/apps/gmux-web/src/family-drawer.test.ts
+++ b/apps/gmux-web/src/family-drawer.test.ts
@@ -1,0 +1,26 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { familyDrawerDotState } from './family-drawer'
+import { activityMap } from './store'
+import type { Session } from './types'
+
+function session(status: Session['status'], unread = true): Session {
+  return {
+    id: 'selected', created_at: '2026-01-01T00:00:00Z', command: [], cwd: '',
+    adapter: 'pi', alive: true, pid: null, exit_code: null,
+    started_at: '2026-01-01T00:00:00Z', exited_at: null, title: 'selected',
+    subtitle: '', status, unread, unread_token: 'token', resumable: false,
+    socket_path: '',
+  }
+}
+
+describe('family drawer selected dot', () => {
+  beforeEach(() => { activityMap.value = new Map() })
+
+  it.each([
+    ['waiting', session(null), 'none'],
+    ['waiting-error', session({ active: false, error: true }), 'none'],
+    ['active-error', session({ active: true, error: true }), 'active-error'],
+  ] as const)('%s', (_name, selected, expected) => {
+    expect(familyDrawerDotState(selected, selected.id)).toBe(expected)
+  })
+})

--- a/apps/gmux-web/src/family-drawer.tsx
+++ b/apps/gmux-web/src/family-drawer.tsx
@@ -9,11 +9,15 @@ import {
 import { viewToPath } from './routing'
 import { formatAge } from './session-row'
 import {
-  activityMap, cancelSession, familyActivityById, markSessionRead,
-  projects, sessions, sessionDotState, tabHref,
+  activityMap, cancelSession, familyActivityById, markSessionRead, ownDotState,
+  projects, sessions, tabHref,
 } from './store'
 import { pushError } from './toasts'
 import type { Session } from './types'
+
+export function familyDrawerDotState(session: Session, selectedId: string) {
+  return ownDotState(session, activityMap.value, selectedId)
+}
 
 function hrefFor(session: Session): string | undefined {
   const path = viewToPath({ kind: 'session', sessionId: session.id }, projects.value, sessions.value)
@@ -33,12 +37,10 @@ function FamilyRow({ node, selectedId, depth, expanded, view, now, onToggle }: {
 }) {
   const session = node.session
   const process = isProcessSession(session)
-  // No selection muting here, unlike the sidebar: the panel is a map of
-  // the family, and a map that blanks the row you're standing on would
-  // claim "1 error" in the counts line with no errored row in sight.
-  // (Viewing a session clears its unread/error flags server-side anyway,
-  // so the dot settles on its own a beat later.)
-  const dot = sessionDotState(session, activityMap.value)
+  // Selection acknowledges only waiting attention; durable error remains.
+  // Match every other navigation surface by muting selected waiting and
+  // waiting-error states while retaining selected active/active-error status.
+  const dot = familyDrawerDotState(session, selectedId)
   return (
     <li>
       <a

--- a/apps/gmux-web/src/family.test.ts
+++ b/apps/gmux-web/src/family.test.ts
@@ -21,6 +21,8 @@ describe('family overview state', () => {
   it('retains the agent turn vocabulary and precedence', () => {
     expect(familyStateOf(agent('error', undefined, { alive: true, unread: true, status: { error: true } }))).toBe('error')
     expect(familyStateOf(agent('active', undefined, { alive: true, unread: true, status: { active: true } }))).toBe('active')
+    expect(familyStateOf(agent('retry', undefined, { alive: true, unread: true, status: { active: true, error: true } }))).toBe('active')
+    expect(familyStateOf(agent('acked-error', undefined, { alive: true, unread: false, status: { active: false, error: true } }))).toBeNull()
     expect(familyStateOf(agent('waiting', undefined, { unread: true }))).toBe('waiting')
   })
 })

--- a/apps/gmux-web/src/family.ts
+++ b/apps/gmux-web/src/family.ts
@@ -2,6 +2,7 @@ import type { ProjectItem, Session } from './types'
 // Type-only: erased at emit, so `family.ts` stays runtime-free of the store.
 import type { DotState } from './store'
 import { sidebarProjectForSession } from './projects'
+import { sessionPresentationState } from './presentation'
 
 /** Resolve one potential task-family edge without trusting the rest of the
  * ancestry. The parent must be a semantic agent; its child may be any session.
@@ -294,10 +295,13 @@ export type FamilyState = 'error' | 'active' | 'running' | 'waiting'
 
 export function familyStateOf(session: Session): FamilyState | null {
   if (isProcessSession(session)) return isRunningProcess(session) ? 'running' : null
-  if (session.alive && session.status?.error) return 'error'
-  if (session.alive && session.status?.active) return 'active'
-  if (session.unread) return 'waiting'
-  return null
+  switch (sessionPresentationState(session)) {
+    case 'active':
+    case 'active-error': return 'active'
+    case 'waiting-error': return 'error'
+    case 'waiting': return 'waiting'
+    case 'none': return null
+  }
 }
 
 /** The standard family numbers: what the descendants of one

--- a/apps/gmux-web/src/mock-data/sessions/demo-family.ts
+++ b/apps/gmux-web/src/mock-data/sessions/demo-family.ts
@@ -1,5 +1,5 @@
 // Agent families for mock mode: a 5-deep chain (exercises the header's
-// collapsed `…` crumb, every dot state, and a long title) plus a shallow
+// collapsed `…` crumb, every attention state, and a long title) plus a shallow
 // long-titled pair (crumb truncation). Without these, `?mock` has no
 // family at all and the header breadcrumbs / family panel can't be seen.
 import { type MockSession, ago } from '../types'
@@ -34,12 +34,16 @@ function fam(over: Partial<MockSession> & Pick<MockSession, 'id' | 'title'>): Mo
 export const DEMO_FAMILY: MockSession[] = [
   fam({ id: 'fam0root', title: 'orchestrator', last_output_at: ago(40), status: { active: true } }),
   fam({ id: 'fam1kid', title: 'implement drawer', parent_session_id: 'fam0root', unread: true, last_output_at: ago(2) }),
-  fam({ id: 'fam2kid', title: 'wire up the protocol adapter layer end to end', parent_session_id: 'fam1kid', status: { active: true }, last_output_at: ago(1) }),
+  // Active-error is a transient retry: the selected row stays in the active
+  // family bucket but renders the same hollow active ring in red.
+  fam({ id: 'fam2kid', title: 'wire up the protocol adapter layer end to end', parent_session_id: 'fam1kid', status: { active: true, error: true }, last_output_at: ago(1) }),
   fam({ id: 'fam3kid', title: 'refactor session store', parent_session_id: 'fam2kid', last_output_at: ago(20) }),
   fam({
     id: 'fam4kid',
     title: 'investigate a really long descendant title that should truncate somewhere sensible',
-    parent_session_id: 'fam3kid', status: { active: false, error: true }, last_output_at: ago(5),
+    // An unread terminal error supplies filterable waiting-error attention;
+    // error without unread is an acknowledged outcome and has no family bucket.
+    parent_session_id: 'fam3kid', status: { active: false, error: true }, unread: true, last_output_at: ago(5),
   }),
   // Processes owned by agents in the chain: the sidebar's family
   // activity row counts a running one under `$` (subagents get a dot),

--- a/apps/gmux-web/src/presentation.test.ts
+++ b/apps/gmux-web/src/presentation.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { sessionPresentationState } from './presentation'
+
+const bools = [false, true] as const
+
+describe('sessionPresentationState', () => {
+  it('exhaustively derives the finite presentation contract', () => {
+    const expected = new Map([
+      ['000', 'none'], ['001', 'waiting'],
+      ['010', 'none'], ['011', 'waiting-error'],
+      ['100', 'active'], ['101', 'active'],
+      ['110', 'active-error'], ['111', 'active-error'],
+    ])
+    for (const active of bools) for (const error of bools) for (const unread of bools) {
+      const key = `${+active}${+error}${+unread}`
+      expect(sessionPresentationState({ status: { active, error }, unread }), key)
+        .toBe(expected.get(key))
+    }
+  })
+})

--- a/apps/gmux-web/src/presentation.ts
+++ b/apps/gmux-web/src/presentation.ts
@@ -1,0 +1,23 @@
+import type { Session } from './types'
+
+/** Canonical semantic presentation state for every session status/attention
+ * surface. Active is current status and takes precedence over consumable
+ * unread attention; durable error only colors whichever of those exists. */
+export type SessionPresentationState =
+  | 'none'
+  | 'active'
+  | 'active-error'
+  | 'waiting'
+  | 'waiting-error'
+
+export function sessionPresentationState(
+  session: Pick<Session, 'status' | 'unread'>,
+): SessionPresentationState {
+  if (session.status?.active) return session.status.error ? 'active-error' : 'active'
+  if (session.unread) return session.status?.error ? 'waiting-error' : 'waiting'
+  return 'none'
+}
+
+export function isWaitingPresentation(state: SessionPresentationState): boolean {
+  return state === 'waiting' || state === 'waiting-error'
+}

--- a/apps/gmux-web/src/store.test.ts
+++ b/apps/gmux-web/src/store.test.ts
@@ -15,7 +15,7 @@ import {
   toUISession, localHostLabel, parseConnectURL, unreadCount, discovered,
   view, duplicateConversationFiles,
   sidebarMode, setSidebarMode, setFilterSelectors, setHostFilter, homePartition,
-  sidebarActivity, setAliveOnly, familyDotById, createViewConsumptionTracker,
+  sidebarActivity, backgroundActivity, setAliveOnly, familyDotById, createViewConsumptionTracker,
   familyActivityById, selectedFamilyChild, ownDotState,
   familySlotById,
 } from './store'
@@ -464,6 +464,28 @@ describe('toUISession project stamp passthrough', () => {
   it('leaves last_output_at undefined when the wire omits it', () => {
     const ui = toUISession({ id: '1vshk4fu', alive: true } as any)
     expect(ui.last_output_at).toBeUndefined()
+  })
+
+  it('normalizes durable active-at-death for local and peer UI rows', () => {
+    const local = toUISession({ id: 'local', alive: false, status: { active: true, error: true } } as any)
+    const peer = toUISession({ id: 'remote@peer', peer: 'peer', alive: false, status: { active: true } } as any)
+    expect(local.status).toEqual({ active: false, error: true })
+    expect(peer.status?.active).toBe(false)
+  })
+
+  it('preserves active and active-error for alive local and peer UI rows', () => {
+    const local = toUISession({ id: 'local', alive: true, status: { active: true } } as any)
+    const peer = toUISession({
+      id: 'remote@peer', peer: 'peer', alive: true, status: { active: true, error: true },
+    } as any)
+    expect(local.status).toEqual({ active: true })
+    expect(peer.status).toEqual({ active: true, error: true })
+  })
+
+  it('normalizes status.active to boolean for malformed missing alive input', () => {
+    const ui = toUISession({ id: 'legacy', status: { active: true, error: true } } as any)
+    expect(ui.status).toEqual({ active: false, error: true })
+    expect(typeof ui.status?.active).toBe('boolean')
   })
 
   it('treats empty-string project_slug as unstamped', () => {
@@ -998,13 +1020,14 @@ describe('markSessionRead', () => {
     expect(sessions.value[0].unread).toBe(false)
   })
 
-  it('clears error flag from status', () => {
+  it('preserves durable error while clearing unread', () => {
     _rawSessions.value = [makeSession({
-      id: '1vshk4fu',
+      id: '1vshk4fu', unread: true, unread_token: 'turn-1',
       status: { active: false, error: true },
     })]
     markSessionRead('1vshk4fu')
-    expect(sessions.value[0].status?.error).toBe(false)
+    expect(sessions.value[0].unread).toBe(false)
+    expect(sessions.value[0].status?.error).toBe(true)
   })
 
   it('does not touch other sessions', () => {
@@ -1066,6 +1089,15 @@ describe('focused view consumption', () => {
     const tracker = createViewConsumptionTracker()
     expect(tracker.selection('child', makeSession({ id: 'child', unread: true, unread_token: 'turn-1' })))
       .toEqual({ id: 'child', token: 'turn-1' })
+  })
+
+  it('does not observe acknowledged durable error as consumable', () => {
+    const tracker = createViewConsumptionTracker()
+    const acknowledgedError = makeSession({
+      id: 'child', unread: false, unread_token: 'turn-1', status: { active: false, error: true },
+    })
+    expect(tracker.selection('child', acknowledgedError)).toBeNull()
+    expect(tracker.interaction('child', acknowledgedError)).toBeNull()
   })
 })
 
@@ -1547,9 +1579,25 @@ describe('familyDotById (family-aggregated row dot)', () => {
     expect(familyDotById.value.get('working-child')).toBeUndefined()
   })
 
+  it('keeps waiting-error attention above an active sibling', () => {
+    _rawSessions.value = [
+      pi('root'),
+      pi('working-child', { parent_session_id: 'root', status: { active: true } }),
+      pi('failed-child', { parent_session_id: 'root', unread: true, status: { active: false, error: true } }),
+    ]
+    // Aggregate precedence is attention-oriented even though each child's own
+    // state still derives current activity before ordinary waiting.
+    expect(familyDotById.value.get('root')).toBe('error')
+  })
+
   it('keeps standalone sessions at their own dot state', () => {
     _rawSessions.value = [pi('solo', { unread: true })]
     expect(familyDotById.value.get('solo')).toBe('unread')
+  })
+
+  it('keeps dead sessions out of the mobile background summary', () => {
+    _rawSessions.value = [pi('dead', { alive: false, unread: true, status: { active: false, error: true } })]
+    expect(backgroundActivity.value).toBe('none')
   })
 
   it('lets a never-viewed dead child surface unread on the root', () => {
@@ -1638,12 +1686,10 @@ describe('sidebar family entry derivations', () => {
       expect(familyActivityById.value.has('root')).toBe(false)
     })
 
-    it('ignores a dead member that is merely alive-gated', () => {
-      // status.active/error only count while alive; unread still does,
-      // matching sessionDotState's vocabulary.
+    it('ignores acknowledged durable error while dead unread still waits', () => {
+      // The wire invariant projects dead historical activity to inactive.
       _rawSessions.value = [
         agent('root'),
-        agent('zombie', { parent_session_id: 'root', alive: false, status: { active: true } }),
         agent('gone', { parent_session_id: 'root', alive: false, status: { active: false, error: true } }),
         agent('unseen', { parent_session_id: 'root', alive: false, unread: true }),
       ]
@@ -1700,8 +1746,8 @@ describe('sidebar family entry derivations', () => {
         agent('kid', { parent_session_id: 'root', status: { active: true, error: true } }),
       ]
       const root = sessions.value.find(s => s.id === 'root')!
-      // The aggregate would say "error"; the row dot stays the root's own.
-      expect(familyDotById.value.get('root')).toBe('error')
+      // Active-error remains current active status; the row dot stays root-own.
+      expect(familyDotById.value.get('root')).toBe('active-error')
       expect(ownDotState(root, activityMap.value, selectedId.value)).toBe('unread')
     })
 
@@ -1714,11 +1760,17 @@ describe('sidebar family entry derivations', () => {
       expect(ownDotState(root(), activityMap.value, selectedId.value)).toBe('none')
     })
 
-    it('keeps working/active states visible while selected (only attention mutes)', () => {
-      _rawSessions.value = [agent('root', { slug: 'rooty', status: { active: true } })]
+    it('applies the family-drawer selection rule to waiting, waiting-error, and active-error', () => {
       urlPath.value = '/proj/pi/rooty'
-      const root = sessions.value.find(s => s.id === 'root')!
-      expect(ownDotState(root, activityMap.value, selectedId.value)).toBe('working')
+      for (const [extra, expected] of [
+        [{ unread: true }, 'none'],
+        [{ unread: true, status: { active: false, error: true } }, 'none'],
+        [{ unread: true, status: { active: true, error: true } }, 'active-error'],
+      ] as const) {
+        _rawSessions.value = [agent('root', { slug: 'rooty', ...extra })]
+        const root = sessions.value.find(s => s.id === 'root')!
+        expect(ownDotState(root, activityMap.value, selectedId.value)).toBe(expected)
+      }
     })
   })
 
@@ -2095,7 +2147,7 @@ describe('pending mutations overlay', () => {
       expect(applyPending(sess, [])).toBe(sess)
     })
 
-    it('mark-read clears unread and status.error on the targeted session', () => {
+    it('mark-read clears unread and preserves durable error on the targeted session', () => {
       const sess = [
         makeSession({ id: 'a', unread: true, status: { active: false, error: true } }),
         makeSession({ id: 'b', unread: true }),
@@ -2103,7 +2155,7 @@ describe('pending mutations overlay', () => {
       const m: PendingMutation = { kind: 'mark-read', id: 'a', token: '', at: 0 }
       const out = applyPending(sess, [m])
       expect(out[0].unread).toBe(false)
-      expect(out[0].status?.error).toBe(false)
+      expect(out[0].status?.error).toBe(true)
       // Untouched session keeps its flags.
       expect(out[1].unread).toBe(true)
     })

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -26,6 +26,7 @@ import {
 import { referencePresence, unresolvedReferences, removeReferenceItems, removeHostReferenceItems, type UnresolvedHost } from './references'
 import { parseFilterParam, formatFilterParam, sessionMatchesFilter, type Selector } from './tab-filter'
 import { pushError } from './toasts'
+import { isWaitingPresentation, sessionPresentationState, type SessionPresentationState } from './presentation'
 
 import { fetchFrontendConfig, buildTerminalOptions, resolveKeybinds, type ResolvedKeybind } from './config'
 import { MOCK_SESSIONS, mockWorld } from './mock-data/index'
@@ -162,7 +163,7 @@ export function applyPending(
   for (const s of rawSessions) {
     if (dismissed.has(s.id)) continue
     out.push(readTokens.get(s.id)?.has(s.unread_token ?? '')
-      ? { ...s, unread: false, status: s.status?.error ? { ...s.status, error: false } : s.status }
+      ? { ...s, unread: false }
       : s)
   }
   return out
@@ -177,7 +178,7 @@ function isResolved(m: PendingMutation, rawSessions: Session[]): boolean {
       const s = rawSessions.find(x => x.id === m.id)
       if (!s) return true
       if ((s.unread_token ?? '') !== m.token) return true
-      return !s.unread && !s.status?.error
+      return !s.unread
     }
     case 'dismiss':
       return !rawSessions.some(s => s.id === m.id)
@@ -380,22 +381,26 @@ export const peerStatusByName = computed<ReadonlyMap<string, string>>(() => {
 
 /** True when a session lives on a peer we can't reach right now.
  *  Local sessions (peer === undefined) are never unavailable. */
-/**
- * Single source of truth for the visual dot state of a session, used
- * by both the sidebar row and the wide dashboard row. Encodes the
- * precedence: error > active > unread > recent terminal activity.
- * The 'working' DotState token is UI/CSS vocabulary for the active dot;
- * the session fact behind it is `status.active`.
- * Selection-aware muting ("unread is suppressed when you're already
- * viewing the session") lives at the call site, not here.
- */
+/** Map the canonical semantic state to the app's established CSS vocabulary. */
+export function presentationDotState(state: SessionPresentationState): DotState {
+  switch (state) {
+    case 'active': return 'working'
+    case 'active-error': return 'active-error'
+    case 'waiting': return 'unread'
+    case 'waiting-error': return 'error'
+    case 'none': return 'none'
+  }
+}
+
+/** Single status/attention derivation used by row, header, family, and mobile
+ * surfaces. Transient terminal activity is only a fallback after semantic
+ * state has resolved to none. */
 export function sessionDotState(
   session: Session,
   am: ReadonlyMap<string, 'active' | 'fading'>,
 ): DotState {
-  if (session.alive && session.status?.error)   return 'error'
-  if (session.alive && session.status?.active) return 'working'
-  if (session.unread)                            return 'unread'
+  const semantic = presentationDotState(sessionPresentationState(session))
+  if (semantic !== 'none') return semantic
   const act = am.get(session.id)
   if (act === 'active') return 'active'
   if (act === 'fading') return 'fading'
@@ -874,18 +879,20 @@ export const selected = computed(() => {
 })
 
 /** Dot state for the mobile hamburger: summarizes background session activity. */
-export type DotState = 'working' | 'error' | 'unread' | 'active' | 'fading' | 'none'
+export type DotState = 'working' | 'active-error' | 'error' | 'unread' | 'active' | 'fading' | 'none'
 
 export const backgroundActivity = computed((): DotState => {
   const sel = selectedId.value
   const am = activityMap.value
-  const others = sessions.value.filter(s => s.id !== sel && s.alive)
-  if (others.some(s => s.status?.error))          return 'error'
-  if (others.some(s => s.status?.active))        return 'working'
-  if (others.some(s => s.unread))                 return 'unread'
-  if (others.some(s => am.get(s.id) === 'active')) return 'active'
-  if (others.some(s => am.get(s.id) === 'fading')) return 'fading'
-  return 'none'
+  let result: DotState = 'none'
+  for (const s of sessions.value) {
+    // Preserve the mobile summary's live-session scope. Current presentation
+    // is derived canonically rather than reading status/error independently.
+    if (s.id === sel || !s.alive) continue
+    const dot = sessionDotState(s, am)
+    if (AGGREGATE_DOT_RANK[dot] > AGGREGATE_DOT_RANK[result]) result = dot
+  }
+  return result
 })
 
 /** Count of unread sessions (excluding selected).
@@ -931,7 +938,13 @@ export const unreadCount = computed(() => {
   return n
 })
 
-const DOT_RANK: Record<DotState, number> = { none: 0, fading: 1, active: 2, unread: 3, working: 4, error: 5 }
+/** Aggregate precedence intentionally differs from a session's own semantic
+ * derivation only for waiting-error attention: it outranks an active sibling
+ * so the failure cannot disappear. Ordinary waiting remains below active,
+ * matching the established family aggregation behavior. */
+const AGGREGATE_DOT_RANK: Record<DotState, number> = {
+  none: 0, fading: 1, active: 2, unread: 3, working: 4, 'active-error': 5, error: 6,
+}
 
 /** Family-aggregated dot state, keyed by presentation-root session id.
  *
@@ -941,8 +954,9 @@ const DOT_RANK: Record<DotState, number> = { none: 0, fading: 1, active: 2, unre
  * never becomes an agent-style aggregate dot.
  *
  * Selection muting happens per member before aggregation: the selected
- * session's own error/unread is dropped ("you're already looking at it"),
- * while its siblings' attention states still surface on the root row.
+ * session's waiting/waiting-error attention is dropped ("you're already
+ * looking at it"), while active/active-error status and sibling attention
+ * still surface on the root row.
  * Standalone sessions are their own root, so this map is the single
  * dot-state source for every root-level row. */
 export const familyDotById = computed<ReadonlyMap<string, DotState>>(() => {
@@ -957,9 +971,9 @@ export const familyDotById = computed<ReadonlyMap<string, DotState>>(() => {
     // their own row state because no family root stands in for them.
     if (isProcessSession(s) && rootId !== s.id) continue
     let own = sessionDotState(s, am)
-    if (s.id === sel && (own === 'error' || own === 'unread')) own = 'none'
+    if (s.id === sel && isWaitingPresentation(sessionPresentationState(s))) own = 'none'
     const prev = map.get(rootId)
-    if (prev === undefined || DOT_RANK[own] > DOT_RANK[prev]) map.set(rootId, own)
+    if (prev === undefined || AGGREGATE_DOT_RANK[own] > AGGREGATE_DOT_RANK[prev]) map.set(rootId, own)
   }
   return map
 })
@@ -976,7 +990,7 @@ export function ownDotState(
   sel: string | null,
 ): DotState {
   const own = sessionDotState(session, am)
-  return session.id === sel && (own === 'error' || own === 'unread') ? 'none' : own
+  return session.id === sel && isWaitingPresentation(sessionPresentationState(session)) ? 'none' : own
 }
 
 /** The selected session projected onto its family's sidebar row.
@@ -1210,7 +1224,10 @@ export function toUISession(s: ProtocolSession): Session {
     exited_at: s.exited_at ?? null,
     title: s.title ?? s.command?.[0] ?? 'session',
     subtitle: s.subtitle ?? '',
-    status: s.status ?? null,
+    // The shared wire preserves durable active-at-death for gmux wait. At the
+    // local+peer UI funnel, project it to current activity and defend against
+    // older/version-skewed peers that can send dead+active snapshots.
+    status: s.status ? { ...s.status, active: Boolean(s.alive && s.status.active) } : null,
     unread: s.unread ?? false,
     unread_token: s.unread_token ?? '',
     resumable: s.resumable ?? false,
@@ -1472,7 +1489,7 @@ type ReadObservation = { id: string; token: string }
 export function createViewConsumptionTracker() {
   let establishedSelection: string | null = null
   const unreadObservation = (id: string | null, sess: Session | null): ReadObservation | null =>
-    id && sess && (sess.unread || sess.status?.error)
+    id && sess?.unread
       ? { id, token: sess.unread_token ?? '' }
       : null
   return {

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -802,13 +802,18 @@ body {
 
 }
 
-.session-dot-indicator.working {
+.session-dot-indicator.working,
+.session-dot-indicator.active-error {
   background: transparent;
   /* A hair thicker than the 1.5px it grew up with: hollow rings read
      thinner than the filled dots they sit beside, and at 7px the ring
      was dropping below legibility on low-DPI screens. */
   border: 1.75px solid var(--accent);
   animation: subtle-pulse 2.5s ease-in-out infinite;
+}
+
+.session-dot-indicator.active-error {
+  border-color: var(--status-error);
 }
 
 .session-dot-indicator.active {
@@ -3810,6 +3815,7 @@ body {
     animation: none;
   }
   .session-dot-indicator.working,
+  .session-dot-indicator.active-error,
   .session-dot-indicator.active,
   .session-dot-indicator.fading,
   .session-dot-indicator.error {

--- a/apps/gmux-web/src/use-arrival-pulse.ts
+++ b/apps/gmux-web/src/use-arrival-pulse.ts
@@ -3,7 +3,7 @@ import { useEffect, useRef, useState } from 'preact/hooks'
 /**
  * Fires the "arriving" CSS animation whenever the dot transitions to 'unread'.
  *
- * Triggers on any state → unread transition (none, active, working, error).
+ * Triggers on any state → unread transition (including active-error).
  *
  * Optional `generation` parameter: when provided, a change in generation
  * while the state is already 'unread' re-fires the animation. Used by the
@@ -11,7 +11,7 @@ import { useEffect, useRef, useState } from 'preact/hooks'
  * draws attention even though the aggregate state stays 'unread'.
  */
 export function useArrivalPulse(
-  currentState: 'working' | 'error' | 'unread' | 'active' | 'fading' | 'none',
+  currentState: 'working' | 'active-error' | 'error' | 'unread' | 'active' | 'fading' | 'none',
   generation?: number,
 ): 'arriving' | null {
   const prevStateRef = useRef(currentState)

--- a/docs/adr/0023-unified-turn-model.md
+++ b/docs/adr/0023-unified-turn-model.md
@@ -62,12 +62,12 @@ Rules:
 3. **Turn close ⇒ unread.** Every genuine working→idle transition sets
    "waiting on you", exactly like an agent's completed turn. The initial
    prompt (launch phase ending) does not. Lifetime-turn exits also set
-   `Status.Error` on a non-zero exit code. Viewing acknowledges: live
-   sessions clear unread through the runner (WS attach), and — because
-   every one-shot now dies unread and has no runner — the daemon clears
-   unread (and the error dot) on *dead* sessions when a client selects
-   them (presence `OnSessionSelected`). `Working` survives the view: it
-   is the turn state at death.
+   `Status.Error` on a non-zero exit code. Viewing acknowledges unread: live
+   sessions clear it through the runner (WS attach), and — because every
+   one-shot now dies unread and has no runner — the daemon clears it on
+   *dead* sessions when a client selects them (presence `OnSessionSelected`).
+   Error remains durable outcome data and is not erased by reading. `Working`
+   survives the view: it is the turn state at death.
 4. **Turn-state-at-death.** The exit event no longer clears `Status`; the
    persisted flag records whether the turn was closed when the process
    exited. This holds across *every* exit path — in particular the
@@ -82,6 +82,13 @@ Rules:
    timing-independent — a wait issued after the death answers the same as
    one that watched it live. The child's own exit code remains a separate
    fact on the session.
+
+   **Projection boundary:** durable state and the shared wire preserve
+   active-at-death because timing-independent waits consume that historical
+   fact. The web UI's protocol-ingestion mapper separately projects dead
+   local and peer rows to inactive for current-status presentation. This is
+   intentionally a UI boundary, not a claim that every generic wire consumer
+   normalizes the durable bit.
 5. **Every session is waitable.** The daemon's `no_idle_signal` 422 (adapter
    allowlist + evidence gate) is deleted. A markless interactive shell is
    `Working` for its whole life, so a wait on it blocks honestly until exit

--- a/docs/task-family-ui.md
+++ b/docs/task-family-ui.md
@@ -78,9 +78,9 @@ The panel's filter bar has these controls when their population exists:
 
 - **all** — unchanged: show the ordinary family tree, agents and processes
   together, subject to the panel's normal line budget and folds;
-- **N error** — agents with errors only;
-- **N waiting** — waiting agents only;
-- **N active** — active agents only;
+- **N error** — inactive agents with unread error outcomes (`waiting-error`);
+- **N waiting** — inactive unread agents without error (`waiting`);
+- **N active** — active agents, including transient retry/rate-limit errors;
 - **$ N running** — when one or more processes are running; or
 - **$ processes** — when process sessions exist but none is running.
 
@@ -160,8 +160,11 @@ task history/type view, not an attention queue.
 
 ## Attention and consumption
 
-Unread is independent of family presentation: every completed agent turn or
+Unread is independent of durable error outcome: every completed agent turn or
 process command records unread until a consumer reads or acts on that session.
+Reading clears unread only. An acknowledged inactive error has no presentation
+state; an active error remains a hollow red current-status ring and is not
+family attention.
 Notification delivery is suppressed only when the direct launch parent is
 active at the committed completion instant. Agent activity is semantic turn
 activity; terminal activity currently comes from the runner's OSC 133 prompt

--- a/e2e/tests/family-entry-interaction.spec.ts
+++ b/e2e/tests/family-entry-interaction.spec.ts
@@ -224,6 +224,34 @@ test.describe('the family line and the panel tally', () => {
     expect(segments.some(s => /waiting|active|error/.test(s.text ?? ''))).toBe(true)
   })
 
+  test('a selected active retry stays active but uses the hollow red ring', async ({ page }) => {
+    await openMockSidebar(page, '/my-project/claude/~fam2kid')
+    await page.locator('.family-trigger').click()
+
+    const retry = page.locator('.family-row[aria-current="page"] .session-dot-indicator')
+    await expect(retry).toHaveClass(/active-error/)
+    const terminalError = page.locator('.family-row').filter({
+      hasText: 'investigate a really long descendant',
+    }).locator('.session-dot-indicator')
+    await expect(terminalError).toHaveClass(/error/)
+
+    const colors = await page.evaluate(() => {
+      const retryDot = document.querySelector('.family-row[aria-current="page"] .session-dot-indicator')
+      const errorRow = [...document.querySelectorAll('.family-row')].find(row =>
+        row.textContent?.includes('investigate a really long descendant'))
+      const errorDot = errorRow?.querySelector('.session-dot-indicator')
+      if (!retryDot || !errorDot) throw new Error('expected retry and terminal-error dots')
+      return {
+        retryBackground: getComputedStyle(retryDot).backgroundColor,
+        retryBorder: getComputedStyle(retryDot).borderColor,
+        errorBackground: getComputedStyle(errorDot).backgroundColor,
+      }
+    })
+    expect(colors.retryBackground).toBe('rgba(0, 0, 0, 0)')
+    expect(colors.retryBorder).toBe(colors.errorBackground)
+    await expect(page.locator('.family-count').filter({ hasText: '1 active' })).toBeVisible()
+  })
+
   test('each tally filters the tree to its own state, and back', async ({ page }) => {
     // Standing on an `active` member, so the `error` filter excludes the
     // very row you're on — the case that has to keep working.

--- a/services/gmuxd/cmd/gmuxd/wait_central_test.go
+++ b/services/gmuxd/cmd/gmuxd/wait_central_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gmuxapp/gmux/packages/scrollback"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/centralstore"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/sessioncoord"
+	central "github.com/gmuxapp/gmux/services/gmuxd/internal/snapshot/central"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/snapshot/wire"
 )
 
@@ -86,6 +87,23 @@ func TestTerminalReasonAndRunEvidenceTable(t *testing.T) {
 	}
 	if !hasRunEvidence(compatSession{}, true) || !hasRunEvidence(compatSession{StartedAt: "x"}, false) || hasRunEvidence(compatSession{}, false) {
 		t.Fatal("run evidence table")
+	}
+}
+
+func TestConvertedDeadActiveSnapshotStillReportsRunnerDied(t *testing.T) {
+	exit := 1
+	row := central.SessionRow{SessionView: centralstore.SessionView{Session: centralstore.Session{
+		ID: "dead", CreatedAt: 1, StartedAt: func() *centralstore.UnixMillis { v := centralstore.UnixMillis(1); return &v }(),
+		ExitCode: &exit, StatusReported: true, Active: true,
+	}}}
+	payload := (&wire.Converter{}).Sessions(&central.SessionsPayload{Sessions: []central.SessionRow{row}}, nil, nil)
+	if len(payload.Sessions) != 1 || payload.Sessions[0].Status == nil || !payload.Sessions[0].Status.Active {
+		t.Fatalf("converter dropped durable active-at-death: %#v", payload.Sessions)
+	}
+	got, done := terminalReason(legacySessionFromWire(payload.Sessions[0]), false)
+	want := waitConclusion{Reason: "died", Outcome: "error", Cause: "runner_died"}
+	if !done || got != want {
+		t.Fatalf("converted wait verdict = %+v,%v; want %+v,true", got, done, want)
 	}
 }
 

--- a/services/gmuxd/internal/centralstore/domain.go
+++ b/services/gmuxd/internal/centralstore/domain.go
@@ -666,7 +666,7 @@ func (s *Store) applyCommonFacts(ctx context.Context, id SessionID, observed Row
 	return MutationResult{Changed: true, SessionVersion: observed + 1, SessionsDirty: true}, nil
 }
 
-// AcknowledgeDeadSession clears the user-facing unread and error indicators.
+// AcknowledgeDeadSession clears unread attention while preserving durable error.
 // Runner liveness is deliberately outside SQLite: the lifecycle coordinator
 // must establish that no runner is live immediately before calling this
 // conditional operation.
@@ -704,7 +704,7 @@ func (s *Store) acknowledgeDeadSession(ctx context.Context, id SessionID, observ
 	if token != nil && current.UnreadToken != *token {
 		return MutationResult{SessionVersion: current.Version}, ErrUnreadTokenChanged
 	}
-	if !current.Unread && !current.Error {
+	if !current.Unread {
 		if err = tx.Commit(); err != nil {
 			return MutationResult{}, err
 		}

--- a/services/gmuxd/internal/centralstore/internal/db/query.sql
+++ b/services/gmuxd/internal/centralstore/internal/db/query.sql
@@ -26,13 +26,13 @@ SELECT row_version FROM local_sessions WHERE id = ?;
 
 -- name: AcknowledgeSessionAtVersion :execrows
 UPDATE local_sessions
-SET unread = 0, has_error = 0, row_version = row_version + 1
-WHERE id = ? AND row_version = ? AND (unread <> 0 OR has_error <> 0);
+SET unread = 0, row_version = row_version + 1
+WHERE id = ? AND row_version = ? AND unread <> 0;
 
 -- name: AcknowledgeSessionTokenAtVersion :execrows
 UPDATE local_sessions
-SET unread = 0, has_error = 0, row_version = row_version + 1
-WHERE id = ? AND row_version = ? AND unread_token = ? AND (unread <> 0 OR has_error <> 0);
+SET unread = 0, row_version = row_version + 1
+WHERE id = ? AND row_version = ? AND unread_token = ? AND unread <> 0;
 
 -- name: UpdateCommonFacts :execrows
 UPDATE local_sessions SET

--- a/services/gmuxd/internal/centralstore/internal/db/query.sql.go
+++ b/services/gmuxd/internal/centralstore/internal/db/query.sql.go
@@ -12,8 +12,8 @@ import (
 
 const acknowledgeSessionAtVersion = `-- name: AcknowledgeSessionAtVersion :execrows
 UPDATE local_sessions
-SET unread = 0, has_error = 0, row_version = row_version + 1
-WHERE id = ? AND row_version = ? AND (unread <> 0 OR has_error <> 0)
+SET unread = 0, row_version = row_version + 1
+WHERE id = ? AND row_version = ? AND unread <> 0
 `
 
 type AcknowledgeSessionAtVersionParams struct {
@@ -31,8 +31,8 @@ func (q *Queries) AcknowledgeSessionAtVersion(ctx context.Context, arg Acknowled
 
 const acknowledgeSessionTokenAtVersion = `-- name: AcknowledgeSessionTokenAtVersion :execrows
 UPDATE local_sessions
-SET unread = 0, has_error = 0, row_version = row_version + 1
-WHERE id = ? AND row_version = ? AND unread_token = ? AND (unread <> 0 OR has_error <> 0)
+SET unread = 0, row_version = row_version + 1
+WHERE id = ? AND row_version = ? AND unread_token = ? AND unread <> 0
 `
 
 type AcknowledgeSessionTokenAtVersionParams struct {

--- a/services/gmuxd/internal/centralstore/read_ack_test.go
+++ b/services/gmuxd/internal/centralstore/read_ack_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 )
 
-func TestAcknowledgeDeadSessionClearsUnreadAndErrorOnly(t *testing.T) {
+func TestAcknowledgeDeadSessionClearsUnreadAndPreservesError(t *testing.T) {
 	ctx := context.Background()
 	s := openKernelStore(t)
 	started := UnixMillis(2)
@@ -38,10 +38,10 @@ func TestAcknowledgeDeadSessionClearsUnreadAndErrorOnly(t *testing.T) {
 	if err != nil || !ok {
 		t.Fatalf("session ok=%v err=%v", ok, err)
 	}
-	if got.Unread || got.Error {
-		t.Fatalf("acknowledgement not applied: %#v", got)
+	if got.Unread || !got.Error {
+		t.Fatalf("acknowledgement did not clear only unread: %#v", got)
 	}
-	before.Unread, before.Error, before.Version = false, false, before.Version+1
+	before.Unread, before.Version = false, before.Version+1
 	if !reflect.DeepEqual(got, before) {
 		t.Fatalf("unrelated facts changed:\n got  %#v\n want %#v", got, before)
 	}
@@ -70,7 +70,7 @@ func TestAcknowledgeDeadSessionSingleIndicatorAndNoop(t *testing.T) {
 		wantChanged    bool
 	}{
 		{name: "unread only", unread: true, wantChanged: true},
-		{name: "error only", failed: true, wantChanged: true},
+		{name: "error only", failed: true},
 		{name: "already acknowledged"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -162,7 +162,7 @@ func TestDeadSessionAcknowledgementDurableTracer(t *testing.T) {
 		t.Fatalf("dead acknowledgement result=%#v attempted=%v err=%v", result, attempted, err)
 	}
 	snapshot, err := s.ListSessions(ctx)
-	if err != nil || len(snapshot) != 1 || snapshot[0].Unread || snapshot[0].Error || !snapshot[0].Active {
+	if err != nil || len(snapshot) != 1 || snapshot[0].Unread || !snapshot[0].Error || !snapshot[0].Active {
 		t.Fatalf("committed snapshot=%#v err=%v", snapshot, err)
 	}
 
@@ -197,7 +197,7 @@ func TestDeadSessionAcknowledgementDurableTracer(t *testing.T) {
 	}
 	defer s.Close()
 	reopened, err := s.ListSessions(ctx)
-	if err != nil || len(reopened) != 1 || reopened[0].Unread || reopened[0].Error || reopened[0].Version != result.SessionVersion {
+	if err != nil || len(reopened) != 1 || reopened[0].Unread || !reopened[0].Error || reopened[0].Version != result.SessionVersion {
 		t.Fatalf("reopened snapshot=%#v result=%#v err=%v", reopened, result, err)
 	}
 }

--- a/services/gmuxd/internal/sessioncoord/acknowledge.go
+++ b/services/gmuxd/internal/sessioncoord/acknowledge.go
@@ -18,8 +18,9 @@ var (
 	ErrAckOwnerChanged = errors.New("sessioncoord: acknowledgement owner changed")
 )
 
-// AcknowledgeDead durably clears the user-facing unread/error indicators of a
-// dead session (the `.../read` route and presence-driven selection clears).
+// AcknowledgeDead durably clears unread attention for a dead session (the
+// `.../read` route and presence-driven selection clear it). Durable error is
+// outcome data and is never consumed by reading.
 //
 // Live sessions are acknowledged by the runner on WS attach — a daemon write
 // would violate runner ownership (ADR 0026 §3). The legacy unconditional form
@@ -78,9 +79,9 @@ func (c *Coordinator) acknowledgeDead(ctx context.Context, id centralstore.Sessi
 			c.mu.Unlock()
 			return fmt.Errorf("%w: %s", centralstore.ErrSessionNotFound, id)
 		}
-		if !s.Unread && !s.Error {
+		if !s.Unread {
 			c.mu.Unlock()
-			return nil // nothing to clear
+			return nil // nothing to clear; error alone is durable outcome data
 		}
 		if s.Version > version {
 			version = s.Version

--- a/services/gmuxd/internal/snapshot/wire/convert.go
+++ b/services/gmuxd/internal/snapshot/wire/convert.go
@@ -124,6 +124,10 @@ func (c *Converter) session(row central.SessionRow) Session {
 	// status_reported fact carries production's Status-pointer nil-ness
 	// (gmux wait derives died-vs-idle from exactly this, ADR 0023).
 	if v.StatusReported {
+		// Active remains the durable active-at-death fact on the shared wire:
+		// gmux wait consumes these snapshots and needs it to distinguish a clean
+		// close from a runner that died mid-turn (ADR 0023). Presentation clients
+		// normalize current activity at their UI boundary.
 		out.Status = &Status{Active: v.Active, Error: v.Error, Interrupted: v.Interrupted}
 	}
 	if v.ParentSessionID != nil {

--- a/services/gmuxd/internal/snapshot/wire/convert_test.go
+++ b/services/gmuxd/internal/snapshot/wire/convert_test.go
@@ -157,6 +157,18 @@ func TestSessionConversionOverlays(t *testing.T) {
 		t.Fatal("alive row must not be resumable")
 	}
 
+	// The shared wire preserves durable turn-state-at-death because wait uses
+	// snapshots to classify a runner death. UI clients normalize liveness at
+	// their presentation boundary.
+	dead := localRow("1vshk4fu", false, func(r *central.SessionRow) {
+		r.Session.Active = true
+		r.Session.Error = true
+	})
+	deadWire := conv.session(dead)
+	if deadWire.Alive || deadWire.Status == nil || !deadWire.Status.Active || !deadWire.Status.Error || !dead.Session.Active {
+		t.Fatalf("dead conversion lost durable active-at-death: durable=%+v wire=%+v", dead.Session, deadWire)
+	}
+
 	// Never-reported status emits null (production Status-pointer parity;
 	// gmux wait derives died-vs-idle from this — not an accepted diff).
 	unreported := localRow("1o6h184m", true, func(r *central.SessionRow) { r.Session.StatusReported = false })
@@ -164,7 +176,7 @@ func TestSessionConversionOverlays(t *testing.T) {
 		t.Fatalf("never-reported status must be null on the wire: %+v", got.Status)
 	}
 
-	dead := localRow("1or99tfj", false, func(r *central.SessionRow) {
+	dead = localRow("1or99tfj", false, func(r *central.SessionRow) {
 		r.Session.ExitedAt = ms(1700000002000)
 		code := 1
 		r.Session.ExitCode = &code


### PR DESCRIPTION
## Summary

- centralize session presentation into `active`, `active-error`, `waiting`, `waiting-error`, and `none`
- render transient active retries as hollow red active state while grouping them as active
- require unread for inactive blue/red attention, so viewing clears attention without erasing durable error outcome
- make live and retained-dead read acknowledgement clear unread only while preserving token/version/incarnation/replacement fencing
- preserve durable active-at-death on the shared wire for timing-independent waits, while normalizing current activity at the UI ingestion boundary
- update family aggregation, drawer selection, mobile/background state, CSS, ADRs, and regression coverage

## State contract

| Current state | Presentation | Family bucket |
|---|---|---|
| active | hollow cyan | active |
| active + error | hollow red | active |
| inactive + unread | filled blue | waiting |
| inactive + unread + error | filled red | error |
| inactive + acknowledged | none | none |

Read acknowledgement changes only `unread`; it never clears `error`.

## Validation

- frontend focused tests: 188 passed
- full frontend: 768 passed; build and warnings-as-errors lint passed
- focused uncached centralstore/sessioncoord/wire/cmd-gmuxd tests passed
- full gmuxd suite and generated SQL consistency passed
- composed central-row → wire → wait regression verifies dead mid-turn remains `died/error/runner_died`
- mutation probes verified wire wait preservation, UI liveness normalization, aggregate precedence, drawer selection suppression, and retained error persistence

## Review

Three independent adversarial reviews covered broad integration, backend persistence/wait races, and frontend surfaces. The initial shared-wire normalization regression and frontend surface issues were fixed and re-reviewed; final verdicts were **integrate**.
