### PR TITLE
feat(web): scroll-anchor addon — follow/anchored viewport modes for streaming output

### DIFF
--- a/apps/gmux-web/moon.yml
+++ b/apps/gmux-web/moon.yml
@@ -1,28 +1,34 @@
 language: javascript
 
+# No deps on protocol:build / scroll-anchor:build: both workspace packages
+# resolve from TypeScript source in-repo (see their package.json), so no
+# task ordering is required to consume them. Their own build/lint tasks
+# still run via the `:build` / `:lint` fan-out, which keeps the publishable
+# dist output compiling in CI. The package sources are declared as inputs
+# instead: the deps were also this project's cache-invalidation channel,
+# and dropping them without this would let moon serve a stale gmux-web
+# build when only package source changed.
 tasks:
   dev:
     command: pnpm exec vite
-    deps:
-      - protocol:build
-      - scroll-anchor:build
     preset: server
   build:
     command: pnpm exec vite build
-    deps:
-      - protocol:build
-      - scroll-anchor:build
     inputs:
       - "src/**/*"
       - "index.html"
       - "vite.config.ts"
+      - "/packages/protocol/src/**/*"
+      - "/packages/scroll-anchor/src/**/*"
   test:
     command: pnpm exec vitest run --passWithNoTests
-    deps:
-      - protocol:build
-      - scroll-anchor:build
+    inputs:
+      - "**/*"
+      - "/packages/protocol/src/**/*"
+      - "/packages/scroll-anchor/src/**/*"
   lint:
     command: pnpm exec tsc --noEmit
-    deps:
-      - protocol:build
-      - scroll-anchor:build
+    inputs:
+      - "**/*"
+      - "/packages/protocol/src/**/*"
+      - "/packages/scroll-anchor/src/**/*"

--- a/apps/gmux-web/moon.yml
+++ b/apps/gmux-web/moon.yml
@@ -5,11 +5,13 @@ tasks:
     command: pnpm exec vite
     deps:
       - protocol:build
+      - scroll-anchor:build
     preset: server
   build:
     command: pnpm exec vite build
     deps:
       - protocol:build
+      - scroll-anchor:build
     inputs:
       - "src/**/*"
       - "index.html"
@@ -18,7 +20,9 @@ tasks:
     command: pnpm exec vitest run --passWithNoTests
     deps:
       - protocol:build
+      - scroll-anchor:build
   lint:
     command: pnpm exec tsc --noEmit
     deps:
       - protocol:build
+      - scroll-anchor:build

--- a/apps/gmux-web/package.json
+++ b/apps/gmux-web/package.json
@@ -16,6 +16,7 @@
     "@fontsource/jetbrains-mono": "^5.2.8",
     "@fontsource/source-sans-3": "^5.2.9",
     "@gmux/protocol": "workspace:*",
+    "@gmux/scroll-anchor": "workspace:*",
     "@preact/signals": "^2.9.0",
     "@trpc/client": "^11.6.0",
     "@xterm/addon-fit": "0.12.0-beta.288",

--- a/apps/gmux-web/src/terminal-io.test.ts
+++ b/apps/gmux-web/src/terminal-io.test.ts
@@ -94,15 +94,35 @@ describe('createTerminalIO', () => {
     expect(done).toHaveBeenCalledTimes(1)
   })
 
-  it('defers and coalesces resize while synchronized output is active', () => {
-    let syncActive = true
-    const h = makeHarness(() => syncActive)
+  it('defers and coalesces resize between split BSU and ESU writes', () => {
+    let busy = true
+    const h = makeHarness(() => busy)
     h.io.reset(1)
+    h.io.enqueue(enc('\x1b[?2026hpartial'), 1)
+    h.flushOne()
     h.io.requestResize({ cols: 80, rows: 24 }, 1)
     h.io.requestResize({ cols: 100, rows: 30 }, 1)
     expect(h.resizes).toEqual([])
-    syncActive = false
+    h.io.enqueue(enc('rest\x1b[?2026l'), 1)
+    h.flushOne()
+    expect(h.resizes).toEqual([])
+    busy = false
     h.io.syncStateChanged()
     expect(h.resizes).toEqual([{ cols: 100, rows: 30 }])
+  })
+
+  it('keeps resize deferred through the post-wipe re-resolution window', () => {
+    let busy = true
+    const h = makeHarness(() => busy)
+    h.io.reset(1)
+    h.io.requestResize({ cols: 120, rows: 40 }, 1)
+    expect(h.resizes).toEqual([])
+    // ESU has closed, but the addon's combined busy fence remains true until
+    // its deterministic restore and rendering catch-up have completed.
+    h.io.syncStateChanged()
+    expect(h.resizes).toEqual([])
+    busy = false
+    h.io.syncStateChanged()
+    expect(h.resizes).toEqual([{ cols: 120, rows: 40 }])
   })
 })

--- a/apps/gmux-web/src/terminal-io.test.ts
+++ b/apps/gmux-web/src/terminal-io.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it, vi } from 'vitest'
+import { ScrollAnchorAddon } from '@gmux/scroll-anchor'
 import { createTerminalIO } from './terminal-io'
 
 const enc = (s: string) => new TextEncoder().encode(s)
 
-function makeHarness(isSyncActive: () => boolean = () => false) {
+function makeHarness(isBusy: () => boolean = () => false) {
   const writes: string[] = []
   const resizes: Array<{ cols: number, rows: number }> = []
   const pending: Array<() => void> = []
@@ -13,7 +14,7 @@ function makeHarness(isSyncActive: () => boolean = () => false) {
       pending.push(() => callback?.())
     },
     resize(cols, rows) { resizes.push({ cols, rows }) },
-  }, { isSyncActive })
+  }, { isBusy })
   return {
     io, writes, resizes,
     flushOne() {
@@ -107,7 +108,7 @@ describe('createTerminalIO', () => {
     h.flushOne()
     expect(h.resizes).toEqual([])
     busy = false
-    h.io.syncStateChanged()
+    h.io.busyStateChanged()
     expect(h.resizes).toEqual([{ cols: 100, rows: 30 }])
   })
 
@@ -119,10 +120,72 @@ describe('createTerminalIO', () => {
     expect(h.resizes).toEqual([])
     // ESU has closed, but the addon's combined busy fence remains true until
     // its deterministic restore and rendering catch-up have completed.
-    h.io.syncStateChanged()
+    h.io.busyStateChanged()
     expect(h.resizes).toEqual([])
     busy = false
-    h.io.syncStateChanged()
+    h.io.busyStateChanged()
     expect(h.resizes).toEqual([{ cols: 120, rows: 40 }])
   })
+
+  it('defers a real addon-integrated resize through ED3 and its rAF', () => {
+    let viewportY = 20
+    let baseY = 20
+    const raf = { current: null as FrameRequestCallback | null }
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => { raf.current = callback; return 1 })
+    const scrollListeners = new Set<() => void>()
+    const parsedListeners = new Set<() => void>()
+    const handlers = new Map<string, (params: Array<number | number[]>) => boolean>()
+    const resizes: Array<{ cols: number, rows: number }> = []
+    const active = {
+      type: 'normal',
+      get viewportY() { return viewportY },
+      get baseY() { return baseY },
+      getLine() { return { translateToString: () => 'anchor line' } },
+    }
+    const terminal = {
+      element: new EventTarget(),
+      rows: 10,
+      buffer: { active },
+      parser: {
+        registerCsiHandler(id: { prefix?: string, final: string }, handler: (params: Array<number | number[]>) => boolean) {
+          const key = `${id.prefix ?? ''}${id.final}`
+          handlers.set(key, handler)
+          return { dispose: () => handlers.delete(key) }
+        },
+      },
+      onScroll(listener: () => void) { scrollListeners.add(listener); return { dispose: () => scrollListeners.delete(listener) } },
+      onWriteParsed(listener: () => void) { parsedListeners.add(listener); return { dispose: () => parsedListeners.delete(listener) } },
+      scrollToLine(line: number) { viewportY = Math.min(line, baseY); for (const listener of scrollListeners) listener() },
+      scrollToBottom() { viewportY = baseY; for (const listener of scrollListeners) listener() },
+      write(_data: Uint8Array, callback?: () => void) { callback?.() },
+      resize(cols: number, rows: number) { resizes.push({ cols, rows }) },
+    }
+    const addon = new ScrollAnchorAddon()
+    addon.activate(terminal as any)
+    const io = createTerminalIO(terminal, { isBusy: () => addon.busy })
+    addon.onBusyChange(() => io.busyStateChanged())
+    io.reset(1)
+
+    terminal.element.dispatchEvent(new Event('wheel'))
+    viewportY = 10
+    for (const listener of scrollListeners) listener()
+    handlers.get('?h')?.([2026])
+    handlers.get('J')?.([3])
+    viewportY = 0
+    baseY = 12
+    handlers.get('?l')?.([2026])
+    for (const listener of parsedListeners) listener()
+
+    io.requestResize({ cols: 120, rows: 40 }, 1)
+    expect(addon.syncActive).toBe(false)
+    expect(addon.busy).toBe(true)
+    expect(resizes).toEqual([])
+    expect(raf.current).not.toBeNull()
+    raf.current?.(0)
+    expect(addon.busy).toBe(false)
+    expect(resizes).toEqual([{ cols: 120, rows: 40 }])
+    addon.dispose()
+    vi.unstubAllGlobals()
+  })
+
 })

--- a/apps/gmux-web/src/terminal-io.test.ts
+++ b/apps/gmux-web/src/terminal-io.test.ts
@@ -1,256 +1,47 @@
 import { describe, expect, it, vi } from 'vitest'
-import { createTerminalIO, type ScrollAccessor } from './terminal-io'
-import { BSU, CSI_3J, ESU } from './replay'
+import { createTerminalIO } from './terminal-io'
 
-function makeHarness() {
-  const writes: Array<string> = []
+const enc = (s: string) => new TextEncoder().encode(s)
+
+function makeHarness(isSyncActive: () => boolean = () => false) {
+  const writes: string[] = []
   const resizes: Array<{ cols: number, rows: number }> = []
   const pending: Array<() => void> = []
-
   const io = createTerminalIO({
     write(data, callback) {
       writes.push(typeof data === 'string' ? data : new TextDecoder().decode(data))
       pending.push(() => callback?.())
     },
-    resize(cols, rows) {
-      resizes.push({ cols, rows })
-    },
-  })
-
+    resize(cols, rows) { resizes.push({ cols, rows }) },
+  }, { isSyncActive })
   return {
-    io,
-    writes,
-    resizes,
+    io, writes, resizes,
     flushOne() {
-      const cb = pending.shift()
-      if (!cb) throw new Error('no pending write callback')
-      cb()
+      const callback = pending.shift()
+      if (!callback) throw new Error('no pending write callback')
+      callback()
     },
-    flushAll() {
-      while (pending.length) pending.shift()?.()
-    },
+    flushAll() { while (pending.length) pending.shift()?.() },
   }
-}
-
-/**
- * Simulates xterm's scroll buffer behavior for testing scroll preservation.
- *
- * Models viewportY/baseY and the effect of scrollback eviction: when
- * scrollback is full, adding lines evicts from the top and decrements
- * viewportY so the same content stays visible.
- */
-function makeScrollHarness(opts: { scrollbackLimit: number; rows: number }) {
-  const { scrollbackLimit, rows } = opts
-  let totalLines = rows // start with one screenful
-  let viewportY = 0
-  let baseY = 0
-
-  const scrollToLineCalls: number[] = []
-  const scrollToBottomCalls: number[] = [] // tracks call count
-  // Per-line content for anchor-matching tests. y → visible text. Lines
-  // not in the map return null from getLine() (the production accessor
-  // also returns null for empty / trivial lines).
-  const lineContent = new Map<number, string>()
-
-  const scroll: ScrollAccessor = {
-    getState: () => ({ viewportY, baseY, rows }),
-    scrollToLine(line: number) {
-      scrollToLineCalls.push(line)
-      viewportY = Math.max(0, Math.min(line, baseY))
-    },
-    scrollToBottom() {
-      scrollToBottomCalls.push(baseY)
-      viewportY = baseY
-    },
-    getLine(y: number): string | null {
-      return lineContent.get(y) ?? null
-    },
-  }
-
-  const writes: string[] = []
-  const pending: Array<() => void> = []
-  // rAF callbacks queued by the production code
-  const rafQueue: Array<() => void> = []
-
-  // Stub requestAnimationFrame/cancelAnimationFrame for deterministic tests.
-  let rafId = 0
-  const rafMap = new Map<number, () => void>()
-  vi.stubGlobal('requestAnimationFrame', (cb: () => void) => {
-    const id = ++rafId
-    rafMap.set(id, cb)
-    rafQueue.push(cb)
-    return id
-  })
-  vi.stubGlobal('cancelAnimationFrame', (id: number) => {
-    const cb = rafMap.get(id)
-    if (cb) {
-      rafMap.delete(id)
-      const idx = rafQueue.indexOf(cb)
-      if (idx >= 0) rafQueue.splice(idx, 1)
-    }
-  })
-
-  const resizeCalls: Array<{ cols: number; rows: number }> = []
-  /** Optional callback to simulate xterm's resize side-effects (e.g. viewportY changes). */
-  let onResize: ((cols: number, rows: number) => void) | null = null
-
-  const io = createTerminalIO(
-    {
-      write(data, callback) {
-        writes.push(typeof data === 'string' ? data : new TextDecoder().decode(data))
-        pending.push(() => callback?.())
-      },
-      resize(cols, rows) {
-        resizeCalls.push({ cols, rows })
-        onResize?.(cols, rows)
-      },
-    },
-    scroll,
-  )
-
-  return {
-    io,
-    writes,
-    scroll,
-    scrollToLineCalls,
-    scrollToBottomCalls,
-    resizeCalls,
-    /** Set a callback to simulate xterm viewport side-effects during resize. */
-    set onResize(fn: ((cols: number, rows: number) => void) | null) { onResize = fn },
-
-    /** Current scroll state (convenience). */
-    get viewportY() { return viewportY },
-    get baseY() { return baseY },
-
-    /** Simulate the user scrolling to a specific line. */
-    userScrollTo(line: number) {
-      viewportY = Math.max(0, Math.min(line, baseY))
-    },
-
-    /** Simulate the user scrolling to the bottom. */
-    userScrollToBottom() {
-      viewportY = baseY
-    },
-
-    /**
-     * Simulate xterm processing `\x1b[3J` (clear scrollback): both ybase
-     * and ydisp reset to 0, scrollback content is gone, only the visible
-     * rows remain. Call between enqueue and flushOne to model an agent
-     * (eg pi) wiping scrollback inside a BSU/ESU block.
-     */
-    clearScrollback() {
-      totalLines = rows
-      baseY = 0
-      viewportY = 0
-      lineContent.clear()
-    },
-
-    /** Set the visible text of the buffer line at `y`. */
-    setLine(y: number, text: string) {
-      lineContent.set(y, text)
-    },
-
-    /**
-     * Simulate xterm processing new output lines, including scrollback
-     * eviction. Call this between enqueue and flushOne to model what xterm
-     * does during write().
-     */
-    addLines(count: number) {
-      totalLines += count
-      const overflow = totalLines - (scrollbackLimit + rows)
-      if (overflow > 0) {
-        const evicted = overflow
-        totalLines = scrollbackLimit + rows
-        baseY = scrollbackLimit
-        // xterm decrements viewportY when lines are evicted
-        viewportY = Math.max(0, viewportY - evicted)
-      } else {
-        baseY = Math.max(0, totalLines - rows)
-      }
-    },
-
-    /**
-     * Flush one pending write callback. Optionally simulate xterm adding
-     * lines (scrollback eviction) as part of the write processing.
-     */
-    flushOne(linesAdded = 0) {
-      const cb = pending.shift()
-      if (!cb) throw new Error('no pending write callback')
-      // Simulate xterm processing the write: adjust buffer state
-      if (linesAdded > 0) this.addLines(linesAdded)
-      cb()
-    },
-
-    /**
-     * Run all queued rAF callbacks (our scroll restore runs here).
-     *
-     * Note: xterm's viewport catch-up after ESU does NOT change ydisp; it
-     * only updates the DOM scrollTop to reflect the existing ydisp (with
-     * _suppressOnScrollHandler to prevent feedback). So we don't simulate
-     * any ydisp snap here; the buffer state from flushOne is already final.
-     */
-    flushRAF() {
-      const queue = [...rafQueue]
-      rafQueue.length = 0
-      rafMap.clear()
-      for (const cb of queue) cb()
-    },
-
-    cleanup() {
-      vi.unstubAllGlobals()
-    },
-  }
-}
-
-const enc = (s: string) => new TextEncoder().encode(s)
-
-/** Wrap payload in BSU + ESU markers. */
-function wrapBSU(payload: string): Uint8Array {
-  const payloadBytes = enc(payload)
-  const result = new Uint8Array(BSU.length + payloadBytes.length + ESU.length)
-  result.set(BSU, 0)
-  result.set(payloadBytes, BSU.length)
-  result.set(ESU, BSU.length + payloadBytes.length)
-  return result
-}
-
-/** Wrap payload in BSU + \x1b[3J + ESU markers (pi-style redraw). */
-function wrapBSUWithClear(payload: string): Uint8Array {
-  const payloadBytes = enc(payload)
-  const result = new Uint8Array(BSU.length + CSI_3J.length + payloadBytes.length + ESU.length)
-  let offset = 0
-  result.set(BSU, offset); offset += BSU.length
-  result.set(CSI_3J, offset); offset += CSI_3J.length
-  result.set(payloadBytes, offset); offset += payloadBytes.length
-  result.set(ESU, offset)
-  return result
 }
 
 describe('createTerminalIO', () => {
   it('serializes writes one at a time', () => {
     const h = makeHarness()
     h.io.reset(1)
-
     h.io.enqueue(enc('a'), 1)
     h.io.enqueue(enc('b'), 1)
     h.io.enqueue(enc('c'), 1)
-
     expect(h.writes).toEqual(['a'])
-
-    h.flushOne()
-    expect(h.writes).toEqual(['a', 'b'])
-
-    h.flushOne()
-    expect(h.writes).toEqual(['a', 'b', 'c'])
+    h.flushOne(); expect(h.writes).toEqual(['a', 'b'])
+    h.flushOne(); expect(h.writes).toEqual(['a', 'b', 'c'])
   })
 
   it('waits for queued writes before resizing', () => {
     const h = makeHarness()
     h.io.reset(1)
-
     h.io.enqueue(enc('hello'), 1)
     h.io.requestResize({ cols: 120, rows: 40 }, 1)
-
     expect(h.resizes).toEqual([])
     h.flushOne()
     expect(h.resizes).toEqual([{ cols: 120, rows: 40 }])
@@ -259,11 +50,9 @@ describe('createTerminalIO', () => {
   it('coalesces to the latest pending resize', () => {
     const h = makeHarness()
     h.io.reset(1)
-
     h.io.enqueue(enc('hello'), 1)
     h.io.requestResize({ cols: 100, rows: 30 }, 1)
     h.io.requestResize({ cols: 140, rows: 50 }, 1)
-
     h.flushOne()
     expect(h.resizes).toEqual([{ cols: 140, rows: 50 }])
   })
@@ -271,18 +60,13 @@ describe('createTerminalIO', () => {
   it('drops stale queued writes and resizes after epoch reset', () => {
     const h = makeHarness()
     const onWritten = vi.fn()
-
     h.io.reset(1)
     h.io.enqueue(enc('stale'), 1, onWritten)
     h.io.requestResize({ cols: 90, rows: 20 }, 1)
     h.io.reset(2)
     h.io.enqueue(enc('fresh'), 2)
-
-    // The stale write was already handed to xterm. The new epoch must wait
-    // for its callback instead of overlapping the parser or resize path.
     expect(h.writes).toEqual(['stale'])
     h.flushOne()
-
     expect(onWritten).not.toHaveBeenCalled()
     expect(h.writes).toEqual(['stale', 'fresh'])
     expect(h.resizes).toEqual([])
@@ -290,14 +74,9 @@ describe('createTerminalIO', () => {
 
   it('does not let an old completion advance a new epoch past a resize fence', () => {
     const h = makeHarness()
-    h.io.reset(1)
-    h.io.enqueue(enc('old'), 1)
-    h.io.reset(2)
-    h.io.enqueue(enc('new'), 2)
+    h.io.reset(1); h.io.enqueue(enc('old'), 1)
+    h.io.reset(2); h.io.enqueue(enc('new'), 2)
     h.io.requestResize({ cols: 80, rows: 24 }, 2)
-
-    expect(h.writes).toEqual(['old'])
-    expect(h.resizes).toEqual([])
     h.flushOne()
     expect(h.writes).toEqual(['old', 'new'])
     expect(h.resizes).toEqual([])
@@ -305,698 +84,25 @@ describe('createTerminalIO', () => {
     expect(h.resizes).toEqual([{ cols: 80, rows: 24 }])
   })
 
-  it('runs completion callback after the final chunk in enqueueMany', () => {
+  it('runs completion after the final enqueueMany chunk', () => {
     const h = makeHarness()
     const done = vi.fn()
     h.io.reset(1)
-
     h.io.enqueueMany([enc('a'), enc('b'), enc('c')], 1, done)
     h.flushAll()
-
     expect(h.writes).toEqual(['a', 'b', 'c'])
     expect(done).toHaveBeenCalledTimes(1)
   })
-})
 
-describe('scroll preservation across BSU/ESU', () => {
-  it('stays at bottom when user was at the bottom', () => {
-    const h = makeScrollHarness({ scrollbackLimit: 100, rows: 25 })
+  it('defers and coalesces resize while synchronized output is active', () => {
+    let syncActive = true
+    const h = makeHarness(() => syncActive)
     h.io.reset(1)
-    h.addLines(50) // baseY=50, totalLines=75
-    h.userScrollToBottom() // viewportY=50
-
-    h.io.enqueue(wrapBSU('output'), 1)
-    h.flushOne(5) // 5 new lines, baseY=55
-    h.flushRAF()
-
-    expect(h.scrollToBottomCalls.length).toBeGreaterThan(0)
-    expect(h.viewportY).toBe(h.baseY)
-    h.cleanup()
-  })
-
-  it('restores scroll position when user is scrolled up, no overflow', () => {
-    const h = makeScrollHarness({ scrollbackLimit: 100, rows: 25 })
-    h.io.reset(1)
-    h.addLines(50) // baseY=50
-    h.userScrollTo(20) // user looking at line 20
-
-    h.io.enqueue(wrapBSU('output'), 1)
-    // xterm processes: 5 new lines, no overflow. baseY=55, viewportY stays 20.
-    h.flushOne(5)
-    h.flushRAF()
-
-    // Should restore to 20 (the post-parse value), not jump to bottom.
-    expect(h.viewportY).toBe(20)
-    h.cleanup()
-  })
-
-  it('adjusts scroll position when scrollback overflows', () => {
-    const h = makeScrollHarness({ scrollbackLimit: 100, rows: 25 })
-    h.io.reset(1)
-    // Fill to capacity: 125 total lines, baseY=100
-    h.addLines(100)
-    expect(h.baseY).toBe(100)
-
-    h.userScrollTo(50) // user looking at line 50
-
-    h.io.enqueue(wrapBSU('output'), 1)
-    // xterm processes: 10 new lines, all overflow (scrollback full).
-    // baseY stays 100, viewportY decremented by 10 to 40.
-    h.flushOne(10)
-    expect(h.baseY).toBe(100)
-
-    // The write callback captures viewportY=40 (xterm's adjusted value).
-    h.flushRAF()
-
-    expect(h.viewportY).toBe(40)
-    h.cleanup()
-  })
-
-  it('handles multiple BSU/ESU cycles with progressive overflow', () => {
-    const h = makeScrollHarness({ scrollbackLimit: 100, rows: 25 })
-    h.io.reset(1)
-    h.addLines(100) // at capacity, baseY=100
-    h.userScrollTo(60)
-
-    // First BSU/ESU: 5 lines overflow
-    h.io.enqueue(wrapBSU('batch1'), 1)
-    h.flushOne(5)
-    h.flushRAF()
-    expect(h.viewportY).toBe(55) // shifted down by 5
-
-    // Second BSU/ESU: 5 more lines overflow
-    h.io.enqueue(wrapBSU('batch2'), 1)
-    h.flushOne(5)
-    h.flushRAF()
-    expect(h.viewportY).toBe(50) // shifted down by another 5
-
-    // Third BSU/ESU: 5 more lines overflow
-    h.io.enqueue(wrapBSU('batch3'), 1)
-    h.flushOne(5)
-    h.flushRAF()
-    expect(h.viewportY).toBe(45) // shifted down by another 5
-
-    h.cleanup()
-  })
-
-  it('clamps viewportY to 0 when evictions exceed original position', () => {
-    const h = makeScrollHarness({ scrollbackLimit: 100, rows: 25 })
-    h.io.reset(1)
-    h.addLines(100) // at capacity, baseY=100
-    h.userScrollTo(5) // near the top
-
-    h.io.enqueue(wrapBSU('lots of output'), 1)
-    // 20 lines overflow, but viewportY was only 5: clamped to 0
-    h.flushOne(20)
-    h.flushRAF()
-
-    expect(h.viewportY).toBe(0)
-    h.cleanup()
-  })
-
-  it('handles BSU and ESU split across separate chunks', () => {
-    const h = makeScrollHarness({ scrollbackLimit: 100, rows: 25 })
-    h.io.reset(1)
-    h.addLines(100)
-    h.userScrollTo(50)
-
-    // BSU in first chunk
-    const bsuChunk = new Uint8Array([...BSU, ...enc('partial')])
-    // ESU in second chunk
-    const esuChunk = new Uint8Array([...enc('rest'), ...ESU])
-
-    h.io.enqueue(bsuChunk, 1)
-    h.flushOne(3) // 3 lines, viewportY adjusted to 47
-
-    h.io.enqueue(esuChunk, 1)
-    h.flushOne(3) // 3 more lines, viewportY adjusted to 44
-    h.flushRAF()
-
-    expect(h.viewportY).toBe(44)
-    h.cleanup()
-  })
-
-  it('after scrollback wipe, restores user\'s distance from bottom when new buffer is large enough', () => {
-    // The user was reading 3 lines above the latest content (eg the
-    // last line of pi's previous turn). Pi ends a turn with
-    // \x1b[3J + redraw, scrollback gets rebuilt to ~15 lines. The
-    // user's pre-BSU absolute line is gone, but their *intent* ("keep
-    // me 3 lines above the newest content") is preserved.
-    const h = makeScrollHarness({ scrollbackLimit: 5000, rows: 40 })
-    h.io.reset(1)
-    h.addLines(200)            // baseY=200
-    h.userScrollTo(197)        // 3 lines above the bottom
-    expect(h.baseY - h.viewportY).toBe(3)
-
-    h.io.enqueue(wrapBSUWithClear('redraw'), 1)
-    h.clearScrollback()
-    h.addLines(15)             // new baseY=15, plenty of room for distance=3
-    h.flushOne(0)
-    h.flushRAF()
-
-    // Distance preserved: viewportY == baseY - 3.
-    expect(h.scrollToLineCalls).toContain(h.baseY - 3)
-    expect(h.scrollToBottomCalls.length).toBe(0)
-    expect(h.baseY - h.viewportY).toBe(3)
-    h.cleanup()
-  })
-
-  it('after scrollback wipe, snaps to bottom when distance exceeds new buffer', () => {
-    // The pi end-of-turn shape from the e2e fixture: user was reading
-    // far back in scrollback (100 lines above the bottom), the new
-    // buffer is only ~15 lines, so the user's intent has nowhere to
-    // anchor. Snap to bottom: nothing else is meaningful.
-    const h = makeScrollHarness({ scrollbackLimit: 5000, rows: 40 })
-    h.io.reset(1)
-    h.addLines(200)
-    h.userScrollTo(100)        // 100 lines above the bottom
-    expect(h.baseY - h.viewportY).toBe(100)
-
-    h.io.enqueue(wrapBSUWithClear('redraw'), 1)
-    h.clearScrollback()
-    h.addLines(15)             // new baseY=15, distance(100) > baseY
-    h.flushOne(0)
-    h.flushRAF()
-
-    // Pre-fix bug: scrollToLine(min(adjustedY=0, baseY=15)) = 0 (top).
-    // Post-fix: prevDistanceFromBottom (100) > new baseY (15) → bottom.
-    expect(h.scrollToBottomCalls.length).toBeGreaterThan(0)
-    expect(h.viewportY).toBe(h.baseY)
-    h.cleanup()
-  })
-
-  it('does not snap to bottom when baseY simply grows from 0', () => {
-    // First-ever output to a fresh terminal: baseY transitions from 0
-    // upward. snap.prevBaseY=0 must NOT trigger the wipe branch
-    // (baseY=N > prevBaseY=0, so the existing scrolled-up restore path
-    // applies as normal).
-    const h = makeScrollHarness({ scrollbackLimit: 100, rows: 25 })
-    h.io.reset(1)
-    expect(h.baseY).toBe(0)
-
-    h.io.enqueue(wrapBSU('first output'), 1)
-    h.flushOne(40)             // baseY now 15 (40 lines, 25 rows visible)
-    h.flushRAF()
-
-    // No wipe happened, just growth. The user was implicitly at bottom
-    // (viewportY=0=baseY=0 pre-BSU), so the wasAtBottom branch fires.
-    expect(h.viewportY).toBe(h.baseY)
-    h.cleanup()
-  })
-
-  it('after scrollback wipe, jumps to the line whose content matches the user\'s anchor', () => {
-    // The user is reading a recognizable line ("ERROR: cannot find
-    // foo"). The agent emits a wipe + redraw, the same line reappears
-    // in the new buffer at a different position. Anchor-match wins
-    // over distance restoration.
-    const h = makeScrollHarness({ scrollbackLimit: 5000, rows: 40 })
-    h.io.reset(1)
-    h.addLines(200)
-    h.userScrollTo(150)
-    h.setLine(150, 'ERROR: cannot find foo')
-    expect(h.baseY - h.viewportY).toBe(50)
-
-    h.io.enqueue(wrapBSUWithClear('redraw'), 1)
-    h.clearScrollback()
-    h.addLines(80)
-    // Same line lands at a different y after the redraw.
-    h.setLine(60, 'ERROR: cannot find foo')
-    h.flushOne(0)
-    h.flushRAF()
-
-    // Anchor matched at y=60: scroll there, no bottom snap.
-    expect(h.scrollToLineCalls).toContain(60)
-    expect(h.scrollToBottomCalls.length).toBe(0)
-    expect(h.viewportY).toBe(60)
-    h.cleanup()
-  })
-
-  it('after scrollback wipe with multiple anchor matches, picks the one closest to prevDistanceFromBottom', () => {
-    // The anchor line appears three times in the redraw. The match
-    // closest to the user's pre-wipe distance from the bottom (5)
-    // wins. The winning y is deliberately chosen so it differs from
-    // the distance-fallback position (baseY - prevDistance = 15),
-    // so a regression that disables anchor matching is caught here.
-    const h = makeScrollHarness({ scrollbackLimit: 5000, rows: 40 })
-    h.io.reset(1)
-    h.addLines(50)
-    h.userScrollTo(45)         // distance = 5
-    h.setLine(45, 'session ready')
-    expect(h.baseY - h.viewportY).toBe(5)
-
-    h.io.enqueue(wrapBSUWithClear('redraw'), 1)
-    h.clearScrollback()
-    h.addLines(20)             // new baseY=20
-    h.setLine(12, 'session ready')  // distance: 8, |8-5|=3
-    h.setLine(16, 'session ready')  // distance: 4, |4-5|=1 ← winner
-    h.setLine(18, 'session ready')  // distance: 2, |2-5|=3
-    h.flushOne(0)
-    h.flushRAF()
-
-    // y=16 is the closest match. Distance fallback would have given
-    // y=15, so this assertion is sensitive to anchor matching being
-    // active rather than coincidentally matching the fallback.
-    expect(h.scrollToLineCalls).toContain(16)
-    expect(h.viewportY).toBe(16)
-    h.cleanup()
-  })
-
-  it('after scrollback wipe, falls back to distance restoration when anchor is null', () => {
-    // The user was on a trivial line so getLine returned null and
-    // savedScroll.prevAnchorLine is null. We fall through to the
-    // distance restoration path.
-    const h = makeScrollHarness({ scrollbackLimit: 5000, rows: 40 })
-    h.io.reset(1)
-    h.addLines(50)
-    h.userScrollTo(47)         // distance = 3
-    // Deliberately NOT calling setLine: getLine returns null (the
-    // production accessor's filter for trivial lines).
-
-    h.io.enqueue(wrapBSUWithClear('redraw'), 1)
-    h.clearScrollback()
-    h.addLines(20)             // new baseY=20
-    h.setLine(17, 'unrelated content')  // present but won't match anything
-    h.flushOne(0)
-    h.flushRAF()
-
-    // No anchor captured → distance fallback: 20 - 3 = 17.
-    expect(h.scrollToLineCalls).toContain(17)
-    expect(h.viewportY).toBe(17)
-    h.cleanup()
-  })
-
-  it('after scrollback wipe, anchor in visible region snaps to bottom with the anchor still in view', () => {
-    // Mid-distance scenario: the user was scrolled up just a few
-    // lines, reading streaming output. After the wipe their anchor
-    // line ends up in the visible region of the new buffer, not
-    // scrollback. `scrollToLine` clamps to baseY, so the best we
-    // can do is `scrollToBottom` and let the anchor sit somewhere
-    // in the visible region rather than disappearing entirely or
-    // landing the user at distance restoration's chosen y where
-    // the anchor may be off-screen.
-    //
-    // Concretely: pre-wipe distance = 5. Post-wipe baseY = 5 with
-    // the anchor placed at y = 20 (visible region [5, 44]). With
-    // the search bounded to [0, baseY] (the previous behavior),
-    // anchor matching would miss and distance restoration would
-    // land the user at viewportY = 0. With the search extended to
-    // the full buffer, we land at viewportY = baseY = 5, with the
-    // anchor visible at offset 15 of the viewport. The two
-    // viewportY values differ, so this test catches a regression
-    // that re-narrows the search range.
-    const h = makeScrollHarness({ scrollbackLimit: 5000, rows: 40 })
-    h.io.reset(1)
-    h.addLines(50)
-    h.userScrollTo(45)         // distance = 5
-    h.setLine(45, 'streaming-target')
-    expect(h.baseY - h.viewportY).toBe(5)
-
-    h.io.enqueue(wrapBSUWithClear('redraw'), 1)
-    h.clearScrollback()
-    h.addLines(5)              // new baseY=5; total = baseY+rows = 45
-    h.setLine(20, 'streaming-target')  // y=20 in visible region [5, 44]
-    h.flushOne(0)
-    h.flushRAF()
-
-    // Visible-region match → restoreY = min(20, 5) = 5 (= at-bottom).
-    expect(h.scrollToLineCalls).toContain(5)
-    expect(h.viewportY).toBe(5)
-    h.cleanup()
-  })
-
-  it('after scrollback wipe with both scrollback and visible matches, picks by closeness to prevDistanceFromBottom', () => {
-    // Anchor appears in both regions. The user's pre-wipe distance
-    // (1) is close to the visible match's restore-distance (0,
-    // since visible matches force scrollToBottom) and far from the
-    // scrollback match's restore-distance (13). Tiebreaker picks
-    // the visible match.
-    //
-    // Without the full-buffer search, the visible match would never
-    // be considered, the scrollback match would win by default,
-    // and viewportY would land at 2 instead of baseY (= 15). The
-    // two outcomes differ, so this catches a regression that
-    // re-narrows the search range.
-    const h = makeScrollHarness({ scrollbackLimit: 5000, rows: 40 })
-    h.io.reset(1)
-    h.addLines(50)
-    h.userScrollTo(49)         // distance = 1 (just barely scrolled up)
-    h.setLine(49, 'shared-line')
-    expect(h.baseY - h.viewportY).toBe(1)
-
-    h.io.enqueue(wrapBSUWithClear('redraw'), 1)
-    h.clearScrollback()
-    h.addLines(15)             // new baseY=15; visible region [15, 54]
-    h.setLine(2, 'shared-line')   // scrollback: restoreY=2,  restoreDistance=13, diff=12
-    h.setLine(30, 'shared-line')  // visible:    restoreY=15, restoreDistance=0,  diff=1
-    h.flushOne(0)
-    h.flushRAF()
-
-    // Visible match wins because its restore-distance is closer to
-    // the pre-wipe distance.
-    expect(h.scrollToLineCalls).toContain(15)
-    expect(h.viewportY).toBe(15)
-    h.cleanup()
-  })
-
-  it('after scrollback wipe, falls back to distance when anchor does not match anywhere', () => {
-    // The agent's redraw doesn't include the user's pre-wipe content
-    // (eg pi's status-bar-only redraw vs the user reading prior
-    // conversation output). Distance restoration takes over.
-    const h = makeScrollHarness({ scrollbackLimit: 5000, rows: 40 })
-    h.io.reset(1)
-    h.addLines(50)
-    h.userScrollTo(47)         // distance = 3
-    h.setLine(47, 'previous turn output line')
-
-    h.io.enqueue(wrapBSUWithClear('redraw'), 1)
-    h.clearScrollback()
-    h.addLines(20)             // new baseY=20
-    h.setLine(10, 'pi status bar version 0.70.2')  // wholly different
-    h.flushOne(0)
-    h.flushRAF()
-
-    // No match → distance fallback: 20 - 3 = 17.
-    expect(h.scrollToLineCalls).toContain(17)
-    expect(h.viewportY).toBe(17)
-    h.cleanup()
-  })
-
-  it('after \\x1b[3J + redraw growing baseY past prevBaseY, restores distance from bottom (not adjustedY)', () => {
-    // Discriminator regression test. The pre-fix code used a
-    // `baseY < prevBaseY` heuristic to detect buffer-reset frames; it
-    // missed redraws that grow baseY past its pre-frame value, falling
-    // through to the else branch (line-based restore via adjustedY).
-    //
-    // The crucial assumption modeled here — verified end-to-end by
-    // the matching e2e test in `e2e/tests/terminal-scroll.spec.ts`
-    // ("BSU + clear-scrollback + redraw growing baseY") — is that
-    // real xterm's `viewportY` post-parse is 0 when `\x1b[3J` resets
-    // `ydisp` mid-frame and `isUserScrolling` is true. The harness
-    // simulates that here with `userScrollTo(0)` after `addLines`.
-    //
-    // What this test pins: given a frame whose bytes contain \x1b[3J
-    // and a post-parse adjustedY of 0, the restore lands
-    // `prevDistanceFromBottom` rows above the new bottom, NOT at
-    // `min(adjustedY, baseY) = 0`.
-    const h = makeScrollHarness({ scrollbackLimit: 5000, rows: 40 })
-    h.io.reset(1)
-    h.addLines(100)            // prevBaseY = 100
-    h.userScrollTo(97)         // distance = 3
-
-    h.io.enqueue(wrapBSUWithClear('redraw'), 1)
-    h.clearScrollback()        // \x1b[3J: ydisp=0, ybase=0
-    h.addLines(200)            // long redraw: new baseY = 160 (> prevBaseY)
-    h.userScrollTo(0)          // model adjustedY = 0 (broken line tracking)
-    expect(h.baseY).toBeGreaterThan(100)
-    h.flushOne(0)
-    h.flushRAF()
-
-    // Distance preserved: 3 rows above the new bottom.
-    expect(h.viewportY).toBe(h.baseY - 3)
-    h.cleanup()
-  })
-
-  it('after non-redraw streaming (no \\x1b[3J), honors xterm\'s eviction-tracked viewportY', () => {
-    // Plain shell / `tail -f` semantics: the user is reading a specific
-    // line. New lines stream in below; eviction kicks in; xterm decrements
-    // ydisp to keep the same line visible. The BSU/ESU restore path must
-    // honor xterm's adjustedY here, NOT pull the user toward the bottom.
-    //
-    // This pins the requirement that distance-from-bottom is *only* used
-    // when \x1b[3J is present in the chunk; without it, line-based restore
-    // wins.
-    const h = makeScrollHarness({ scrollbackLimit: 100, rows: 25 })
-    h.io.reset(1)
-    h.addLines(100)            // at capacity, baseY=100
-    h.userScrollTo(97)         // distance = 3, reading a specific line
-
-    h.io.enqueue(wrapBSU('streaming output'), 1)
-    // 10 lines stream in: full overflow, baseY stays 100, xterm decrements
-    // viewportY by 10 to 87 to keep the same content visible.
-    h.flushOne(10)
-    h.flushRAF()
-
-    // Line-based restore: viewportY = adjustedY = 87. Distance from bottom
-    // grew from 3 to 13, which is what xterm-style eviction tracking gives.
-    // A distance-based restore would have put viewportY at 97 (still 3
-    // from bottom), losing the user's line. We don't want that here.
-    expect(h.viewportY).toBe(87)
-    h.cleanup()
-  })
-
-  it('detects \\x1b[3J across split BSU / 3J / ESU chunks', () => {
-    // Pi can split a redraw across multiple WS frames: BSU in one
-    // chunk, \x1b[3J + payload in another, ESU in a third. The
-    // discriminator must OR-accumulate \x1b[3J presence across every
-    // chunk while savedScroll is set, otherwise the restore falls
-    // back to line-based and we get the same "jump to middle" bug.
-    const h = makeScrollHarness({ scrollbackLimit: 5000, rows: 40 })
-    h.io.reset(1)
-    h.addLines(100)
-    h.userScrollTo(97)         // distance = 3
-
-    // Chunk A: just BSU.
-    h.io.enqueue(new Uint8Array([...BSU]), 1)
-    h.flushOne(0)
-
-    // Chunk B: \x1b[3J + redraw payload (no ESU yet). The clear
-    // happens here, simulated by mutating harness state.
-    const clearChunk = new Uint8Array([...CSI_3J, ...enc('redraw')])
-    h.io.enqueue(clearChunk, 1)
-    h.clearScrollback()
-    h.addLines(200)            // grow baseY past prevBaseY
-    h.userScrollTo(0)          // xterm pinned ydisp at 0
-    h.flushOne(0)
-
-    // Chunk C: just ESU.
-    h.io.enqueue(new Uint8Array([...ESU]), 1)
-    h.flushOne(0)
-    h.flushRAF()
-
-    // Distance-based restore: 3 rows above the new bottom. Without
-    // the OR-accumulation, this would land at 0 (line-based on the
-    // pinned adjustedY).
-    expect(h.viewportY).toBe(h.baseY - 3)
-    h.cleanup()
-  })
-
-  it('does not interfere with non-BSU/ESU writes', () => {
-    const h = makeScrollHarness({ scrollbackLimit: 100, rows: 25 })
-    h.io.reset(1)
-    h.addLines(50)
-    h.userScrollTo(20)
-
-    // Regular write (no BSU/ESU)
-    h.io.enqueue(enc('regular output'), 1)
-    h.flushOne(5)
-
-    // No rAF should have been scheduled
-    expect(h.scrollToLineCalls.length).toBe(0)
-    expect(h.scrollToBottomCalls.length).toBe(0)
-    // viewportY should be whatever xterm set it to (20, adjusted for no overflow)
-    expect(h.viewportY).toBe(20)
-    h.cleanup()
-  })
-
-  it('preserves position when near but not at the bottom', () => {
-    const h = makeScrollHarness({ scrollbackLimit: 100, rows: 25 })
-    h.io.reset(1)
-    h.addLines(50) // baseY=50
-    h.userScrollTo(48) // 2 rows above bottom
-
-    h.io.enqueue(wrapBSU('output'), 1)
-    h.flushOne(5)
-    h.flushRAF()
-
-    // Not exactly at bottom, so scroll position should be preserved.
-    // With the old <= 3 threshold this snapped to bottom; now it
-    // respects the user's explicit scroll-up.
-    expect(h.viewportY).toBe(48)
-    h.cleanup()
-  })
-
-  it('respects user scrolling to bottom between write callback and rAF', () => {
-    const h = makeScrollHarness({ scrollbackLimit: 100, rows: 25 })
-    h.io.reset(1)
-    h.addLines(100)
-    h.userScrollTo(50) // scrolled up
-
-    h.io.enqueue(wrapBSU('output'), 1)
-    h.flushOne(5) // viewportY adjusted to 45
-
-    // User scrolls to bottom AFTER the write callback captured adjustedY=45
-    // but BEFORE the rAF fires.
-    h.userScrollToBottom()
-    expect(h.viewportY).toBe(h.baseY) // confirm at bottom
-
-    h.flushRAF()
-
-    // Should respect the user's scroll-to-bottom, not yank back to 45.
-    expect(h.viewportY).toBe(h.baseY)
-    expect(h.scrollToBottomCalls.length).toBeGreaterThan(0)
-    h.cleanup()
-  })
-
-  it('defers resize between split BSU and ESU chunks', () => {
-    const h = makeScrollHarness({ scrollbackLimit: 100, rows: 25 })
-    h.io.reset(1)
-    h.addLines(100) // at capacity, baseY=100
-    h.userScrollTo(50)
-
-    // Simulate xterm's resize resetting viewportY to 0 (reflow side-effect).
-    h.onResize = () => { h.userScrollTo(0) }
-
-    // BSU in first chunk (no ESU yet)
-    const bsuChunk = new Uint8Array([...BSU, ...enc('partial')])
-    h.io.enqueue(bsuChunk, 1)
-    h.flushOne(3) // viewportY adjusted to 47
-
-    // A resize arrives while queue is empty (between BSU and ESU).
-    // Without the fix, pump() would process it now, resetting viewportY
-    // to 0 before the ESU capture, corrupting adjustedY.
-    h.io.requestResize({ cols: 80, rows: 20 }, 1)
-
-    // The resize should NOT have been applied yet (savedScroll is set).
-    expect(h.resizeCalls).toEqual([])
-    expect(h.viewportY).toBe(47)
-
-    // ESU in second chunk
-    const esuChunk = new Uint8Array([...enc('rest'), ...ESU])
-    h.io.enqueue(esuChunk, 1)
-    h.flushOne(3) // viewportY adjusted to 44
-
-    // Still no resize (restoreRAF is now pending).
-    expect(h.resizeCalls).toEqual([])
-
-    // rAF: restores scroll to the correct position (44), then flushes
-    // the deferred resize. The resize side-effect changes viewportY after.
-    h.flushRAF()
-
-    // Scroll restore targeted the correct line (44), not 0.
-    expect(h.scrollToLineCalls).toContain(44)
-    // The resize was applied after scroll restore, not before.
-    expect(h.resizeCalls).toEqual([{ cols: 80, rows: 20 }])
-
-    h.cleanup()
-  })
-
-  it('defers resize between ESU write-callback and restore rAF', () => {
-    const h = makeScrollHarness({ scrollbackLimit: 100, rows: 25 })
-    h.io.reset(1)
-    h.addLines(100)
-    h.userScrollTo(50)
-
-    // Simulate xterm's resize resetting viewportY to 0 (reflow side-effect).
-    h.onResize = () => { h.userScrollTo(0) }
-
-    // Single chunk with BSU + content + ESU
-    h.io.enqueue(wrapBSU('output'), 1)
-    h.flushOne(5) // viewportY adjusted to 45
-
-    // Resize arrives after ESU write-callback but before rAF fires.
-    // Without the fix, pump() would process it now since the queue is
-    // empty and savedScroll was just cleared.
-    h.io.requestResize({ cols: 80, rows: 20 }, 1)
-
-    // The resize should NOT have been applied yet (restoreRAF pending).
-    expect(h.resizeCalls).toEqual([])
-    expect(h.viewportY).toBe(45)
-
-    // rAF restores scroll, then flushes the deferred resize.
-    h.flushRAF()
-
-    // Scroll was restored to 45 BEFORE resize ran. Resize then ran and
-    // reset viewportY to 0, but that's expected: the resize legitimately
-    // changes layout. The important thing is the scroll restore wasn't
-    // corrupted by a resize that snuck in before it could run.
-    expect(h.resizeCalls).toEqual([{ cols: 80, rows: 20 }])
-
-    h.cleanup()
-  })
-
-  it('processes resize normally when no BSU/ESU is in flight', () => {
-    const h = makeScrollHarness({ scrollbackLimit: 100, rows: 25 })
-    h.io.reset(1)
-    h.addLines(50)
-    h.userScrollTo(20)
-
-    // Regular write (no BSU/ESU), then resize.
-    h.io.enqueue(enc('output'), 1)
-    h.flushOne(0)
-
-    h.io.requestResize({ cols: 120, rows: 40 }, 1)
-    // Resize should fire immediately (no BSU/ESU block, no pending rAF).
-    expect(h.resizeCalls).toEqual([{ cols: 120, rows: 40 }])
-
-    h.cleanup()
-  })
-
-  it('forceNextScrollToBottom overrides scroll-up during replay', () => {
-    const h = makeScrollHarness({ scrollbackLimit: 100, rows: 25 })
-    h.io.reset(1)
-    h.addLines(50) // baseY=50
-    h.userScrollTo(10) // user was scrolled way up (stale from previous session)
-
-    // Simulate what terminal.tsx does before enqueuing replay:
-    h.io.forceNextScrollToBottom()
-
-    h.io.enqueue(wrapBSU('replay-frame'), 1)
-    h.flushOne(5)
-    h.flushRAF()
-
-    // Even though the user was scrolled up, the force flag makes
-    // the BSU handler treat it as wasAtBottom=true.
-    expect(h.scrollToBottomCalls.length).toBeGreaterThan(0)
-    expect(h.viewportY).toBe(h.baseY)
-    h.cleanup()
-  })
-
-  it('forceNextScrollToBottom only applies to the next BSU, not subsequent ones', () => {
-    const h = makeScrollHarness({ scrollbackLimit: 100, rows: 25 })
-    h.io.reset(1)
-    h.addLines(50)
-    h.userScrollTo(10)
-
-    h.io.forceNextScrollToBottom()
-
-    // First BSU: force-scrolls to bottom.
-    h.io.enqueue(wrapBSU('replay'), 1)
-    h.flushOne(5)
-    h.flushRAF()
-    expect(h.viewportY).toBe(h.baseY)
-
-    // User scrolls up again.
-    h.userScrollTo(20)
-
-    // Second BSU: force is consumed, so user's scroll is preserved.
-    h.io.enqueue(wrapBSU('live-update'), 1)
-    h.flushOne(3)
-    h.flushRAF()
-    expect(h.viewportY).toBe(20)
-    h.cleanup()
-  })
-
-  it('resets scroll state on epoch change', () => {
-    const h = makeScrollHarness({ scrollbackLimit: 100, rows: 25 })
-    h.io.reset(1)
-    h.addLines(100)
-    h.userScrollTo(50)
-
-    // Start a BSU block
-    h.io.enqueue(new Uint8Array([...BSU, ...enc('data')]), 1)
-    h.flushOne(2)
-
-    // Reset epoch before ESU arrives
-    h.io.reset(2)
-
-    // Send ESU under old epoch (should be ignored since data doesn't arrive)
-    // Send new data under new epoch
-    h.io.enqueue(enc('new session'), 2)
-    h.flushOne(0)
-
-    // No scroll restore should have happened
-    expect(h.scrollToLineCalls.length).toBe(0)
-    expect(h.scrollToBottomCalls.length).toBe(0)
-    h.cleanup()
+    h.io.requestResize({ cols: 80, rows: 24 }, 1)
+    h.io.requestResize({ cols: 100, rows: 30 }, 1)
+    expect(h.resizes).toEqual([])
+    syncActive = false
+    h.io.syncStateChanged()
+    expect(h.resizes).toEqual([{ cols: 100, rows: 30 }])
   })
 })

--- a/apps/gmux-web/src/terminal-io.test.ts
+++ b/apps/gmux-web/src/terminal-io.test.ts
@@ -177,7 +177,9 @@ describe('createTerminalIO', () => {
     for (const listener of parsedListeners) listener()
 
     io.requestResize({ cols: 120, rows: 40 }, 1)
-    expect(addon.syncActive).toBe(false)
+    // ESU already closed DEC 2026 here: the fence stays shut only because the
+    // addon still owes a post-ED3 re-resolution, which is the whole reason
+    // terminal-io gates on `busy` rather than synchronized output alone.
     expect(addon.busy).toBe(true)
     expect(resizes).toEqual([])
     expect(raf.current).not.toBeNull()

--- a/apps/gmux-web/src/terminal-io.ts
+++ b/apps/gmux-web/src/terminal-io.ts
@@ -1,5 +1,3 @@
-import { BSU, CSI_3J, ESU, containsSequence, startsWith } from './replay'
-
 export interface TerminalWriter {
   write(data: string | Uint8Array, callback?: () => void): void
   resize(cols: number, rows: number): void
@@ -10,227 +8,42 @@ export interface TerminalSize {
   rows: number
 }
 
-/**
- * Provides scroll-state access so TerminalIO can save/restore viewport
- * position across synchronized output (BSU/ESU) blocks.
- */
-export interface ScrollAccessor {
-  /**
-   * `viewportY` is the buffer row at the top of the visible region;
-   * `baseY` is the largest valid `viewportY` (ie at-bottom). The total
-   * buffer occupies `[0, baseY + rows)` so that `getLine(y)` is
-   * meaningful across that whole range — anchor matching needs to
-   * search the visible region too, not just scrollback, since a line
-   * we saw pre-wipe can land in either area post-wipe.
-   */
-  getState(): { viewportY: number; baseY: number; rows: number }
-  scrollToLine(line: number): void
-  scrollToBottom(): void
-  /**
-   * Read the visible text of the buffer line at `y` (post-trim, no ANSI
-   * codes). Returns null if the line doesn't exist or is too trivial to
-   * use as a scroll-restore anchor. "Too trivial" deliberately filters
-   * out empty / whitespace-only / very short lines so a wipe-and-redraw
-   * doesn't snap the user to the first stretch of separators it finds.
-   */
-  getLine(y: number): string | null
-}
-
 interface QueueItem {
   epoch: number
   data: Uint8Array
   onWritten?: () => void
 }
 
+export interface TerminalIOOptions {
+  /** Current DEC 2026 state, owned by the scroll-anchor addon. */
+  isSyncActive?: () => boolean
+}
+
 export interface TerminalIO {
   reset(epoch: number): void
-  /** Mark the next BSU/ESU block as a replay: scroll to bottom unconditionally. */
-  forceNextScrollToBottom(): void
   enqueue(data: Uint8Array, epoch: number, onWritten?: () => void): void
   enqueueMany(chunks: Uint8Array[], epoch: number, onWritten?: () => void): void
   requestResize(size: TerminalSize, epoch: number): void
+  /** Reconsider a resize deferred behind a synchronized-output block. */
+  syncStateChanged(): void
   hasPendingWork(): boolean
 }
 
 /**
  * Serializes xterm writes and resizes so resize only happens when the parser
  * is idle. This avoids xterm async-parser races (eg image addon + resize).
- *
- * Scroll preservation: when a write chunk contains BSU (Begin Synchronized
- * Update), we note whether the user was at the bottom. When the chunk
- * containing ESU (End Synchronized Update) is written, we capture xterm's
- * post-parse viewportY (which already accounts for scrollback evictions),
- * then restore it on the next animation frame. This prevents screen redraws
- * from disrupting the user's scroll position while correctly tracking content
- * that shifts as old lines fall off the scrollback buffer.
+ * Resizes are also held across DEC 2026 synchronized output; the addon owns
+ * parser-level sequence observation so framing does not depend on WS chunks.
  */
-export function createTerminalIO(term: TerminalWriter, scroll?: ScrollAccessor): TerminalIO {
+export function createTerminalIO(term: TerminalWriter, options: TerminalIOOptions = {}): TerminalIO {
   let currentEpoch = 0
   let queue: QueueItem[] = []
   let writeInFlight = false
   let pendingResize: (TerminalSize & { epoch: number }) | null = null
 
-  // Scroll preservation across BSU/ESU blocks.
-  // wasAtBottom, prevDistanceFromBottom, prevAnchorLine are saved at BSU
-  // time; the post-parse viewportY is captured later at ESU
-  // write-callback time, after xterm has adjusted viewportY for any
-  // scrollback evictions.
-  //
-  // The buffer-reset branch (block contains `\x1b[3J`, ie pi-style end-
-  // of-turn redraw) tries three anchors in order, falling through on
-  // each miss:
-  //
-  //   1. prevAnchorLine — the visible text the user was reading. If the
-  //      redraw still contains that line we know exactly where the user
-  //      wants to be. Multiple matches are tiebroken by closeness to
-  //      prevDistanceFromBottom, so common lines (eg "✓ done") still
-  //      land somewhere reasonable.
-  //   2. prevDistanceFromBottom — if the new buffer has room, restore
-  //      the user's pre-redraw distance from the bottom. Loses the
-  //      identity of the line they were reading but keeps their intent
-  //      ("N lines above the latest content").
-  //   3. scrollToBottom — nothing else is meaningful.
-  //
-  // Why byte-presence of \x1b[3J rather than a baseY-shrink heuristic:
-  // \x1b[3J resets ydisp/ybase to 0 mid-frame, breaking the line-
-  // tracking invariant that the else branch's adjustedY relies on. A
-  // shrinking baseY is one symptom but not the only one: pi can also
-  // emit \x1b[3J followed by a long redraw that grows baseY past its
-  // pre-frame value, in which case adjustedY is still corrupt (pinned at
-  // 0 because isUserScrolling stays true through the synchronized
-  // block). Detecting the cause directly catches both shapes.
-  let savedScroll: {
-    wasAtBottom: boolean
-    prevDistanceFromBottom: number
-    prevAnchorLine: string | null
-  } | null = null
-  // OR-accumulated across every chunk while savedScroll is set: BSU
-  // chunk, intermediate chunks, and the ESU chunk. Cleared alongside
-  // savedScroll. Only meaningful when savedScroll is non-null.
-  let bufferReset = false
-  let restoreRAF: number | null = null
-
-  // When true, the next BSU/ESU block will scroll to bottom unconditionally
-  // instead of trying to preserve scroll position. Set during replay so the
-  // initial snapshot always lands at the bottom.
-  let forceScrollToBottom = false
-
   const dropStaleFront = () => {
-    while (queue.length && queue[0].epoch !== currentEpoch) {
-      queue.shift()
-    }
-    if (pendingResize && pendingResize.epoch !== currentEpoch) {
-      pendingResize = null
-    }
-  }
-
-  /** Save scroll state if this chunk starts or contains BSU. */
-  const maybeSaveScroll = (data: Uint8Array): void => {
-    if (!scroll || savedScroll) return // already saved, or no accessor
-    if (startsWith(data, BSU) || containsSequence(data, BSU)) {
-      const { viewportY, baseY } = scroll.getState()
-      const distance = Math.max(0, baseY - viewportY)
-      if (forceScrollToBottom) {
-        savedScroll = {
-          wasAtBottom: true,
-          prevDistanceFromBottom: 0,
-          prevAnchorLine: null,
-        }
-        forceScrollToBottom = false
-      } else {
-        // Strict equality: only consider the user "at bottom" if the
-        // viewport is exactly at the end. A loose threshold (e.g. <= 3)
-        // would fight the user's scroll intent during rapid TUI redraws.
-        const wasAtBottom = viewportY >= baseY
-        savedScroll = {
-          wasAtBottom,
-          prevDistanceFromBottom: distance,
-          // Only capture the anchor when scrolled up: at-bottom always
-          // wants scrollToBottom and never reaches the search.
-          prevAnchorLine: wasAtBottom ? null : scroll.getLine(viewportY),
-        }
-      }
-    }
-  }
-
-  /**
-   * OR-accumulate `\x1b[3J` presence across every chunk while a BSU/ESU
-   * block is open. Called for every pumped chunk; covers the BSU chunk
-   * itself (common: pi sends BSU + 3J + redraw + ESU all in one frame),
-   * intermediate chunks, and the ESU chunk. Cleared alongside
-   * `savedScroll` in `maybeRestoreScroll` and `reset`.
-   */
-  const maybeMarkBufferReset = (data: Uint8Array): void => {
-    if (!savedScroll || bufferReset) return
-    if (containsSequence(data, CSI_3J)) bufferReset = true
-  }
-
-  /**
-   * If this chunk contains ESU, schedule a scroll restore on the next
-   * animation frame. xterm defers its viewport sync during synchronized
-   * output, so we must restore AFTER that deferred sync runs.
-   *
-   * We capture viewportY HERE (in the write callback, after xterm has parsed
-   * the data) rather than at BSU time. This is critical: xterm adjusts
-   * viewportY during parsing when scrollback lines are evicted, so the
-   * post-parse value correctly accounts for content that shifted out of the
-   * buffer. Using the pre-BSU value would restore a stale position, causing
-   * the viewport to drift as old lines are evicted.
-   */
-  const maybeRestoreScroll = (data: Uint8Array): void => {
-    if (!scroll || !savedScroll) return
-    if (!containsSequence(data, ESU)) return
-
-    const snap = savedScroll
-    const wasBufferReset = bufferReset
-    savedScroll = null
-    bufferReset = false
-
-    // Capture the adjusted viewportY now, after xterm has processed the
-    // data (including any scrollback evictions) but before the deferred
-    // viewport DOM sync runs.
-    const { viewportY: adjustedY } = scroll.getState()
-
-    // Cancel any previous pending restore (e.g. nested BSU/ESU).
-    if (restoreRAF !== null) cancelAnimationFrame(restoreRAF)
-
-    restoreRAF = requestAnimationFrame(() => {
-      restoreRAF = null
-      const { viewportY, baseY, rows } = scroll.getState()
-      if (snap.wasAtBottom || viewportY >= baseY) {
-        // Was at bottom before BSU, or user/code scrolled to bottom during
-        // the BSU block — stay there.
-        scroll.scrollToBottom()
-      } else if (wasBufferReset) {
-        // The block contained `\x1b[3J`. xterm reset ybase/ydisp to 0
-        // mid-parse, so adjustedY is unreliable: it can point at the top
-        // of a rebuilt buffer regardless of where the user actually was.
-        //
-        // We try three anchors in order, falling through on each miss
-        // (rationale on the savedScroll declaration above).
-        const anchorY = snap.prevAnchorLine !== null
-          ? findAnchorMatch(scroll, snap.prevAnchorLine, baseY, rows, snap.prevDistanceFromBottom)
-          : null
-        if (anchorY !== null) {
-          scroll.scrollToLine(anchorY)
-        } else if (snap.prevDistanceFromBottom <= baseY) {
-          scroll.scrollToLine(baseY - snap.prevDistanceFromBottom)
-        } else {
-          scroll.scrollToBottom()
-        }
-      } else {
-        // User was scrolled up and the block was a plain streaming
-        // update (no \x1b[3J). Restore the post-parse position, clamped
-        // to the current buffer range. adjustedY (captured after xterm
-        // processed the data) already accounts for scrollback evictions,
-        // so the user's specific line stays visible — what `tail -f`
-        // and other append-only streams need.
-        scroll.scrollToLine(Math.min(adjustedY, baseY))
-      }
-      // Flush any resize that was deferred while the BSU/ESU block or
-      // restore rAF was in progress.
-      pump()
-    })
+    while (queue.length && queue[0].epoch !== currentEpoch) queue.shift()
+    if (pendingResize && pendingResize.epoch !== currentEpoch) pendingResize = null
   }
 
   const pump = () => {
@@ -240,10 +53,7 @@ export function createTerminalIO(term: TerminalWriter, scroll?: ScrollAccessor):
     const next = queue.shift()
     if (next) {
       writeInFlight = true
-      maybeSaveScroll(next.data)
-      maybeMarkBufferReset(next.data)
       term.write(next.data, () => {
-        maybeRestoreScroll(next.data)
         writeInFlight = false
         if (next.epoch === currentEpoch) next.onWritten?.()
         pump()
@@ -251,16 +61,7 @@ export function createTerminalIO(term: TerminalWriter, scroll?: ScrollAccessor):
       return
     }
 
-    // Defer resize while a BSU/ESU block is in progress (savedScroll set)
-    // or a scroll-restore rAF is pending. A resize between BSU and ESU
-    // (when they arrive in separate WebSocket messages) would change
-    // viewportY, causing the ESU restore to capture a post-resize position
-    // instead of the user's actual scroll position. Similarly, a resize
-    // between the ESU write-callback and the restore rAF would invalidate
-    // the captured adjustedY. The deferred resize is flushed from the rAF
-    // callback after scroll is restored.
-    if (pendingResize && pendingResize.epoch === currentEpoch
-        && !savedScroll && restoreRAF === null) {
+    if (pendingResize && pendingResize.epoch === currentEpoch && !options.isSyncActive?.()) {
       const { cols, rows } = pendingResize
       pendingResize = null
       term.resize(cols, rows)
@@ -271,22 +72,9 @@ export function createTerminalIO(term: TerminalWriter, scroll?: ScrollAccessor):
     reset(epoch: number) {
       currentEpoch = epoch
       queue = []
-      // Keep writeInFlight true until the old xterm callback arrives. A
-      // reset can invalidate queued work, but it cannot cancel xterm's
-      // parser callback; clearing this flag here would let a new resize or
-      // write overlap the still-running old parse.
+      // An in-flight xterm parse cannot be cancelled. Its old callback keeps
+      // the fence closed until it arrives, preventing overlap with new work.
       pendingResize = null
-      savedScroll = null
-      bufferReset = false
-      forceScrollToBottom = false
-      if (restoreRAF !== null) {
-        cancelAnimationFrame(restoreRAF)
-        restoreRAF = null
-      }
-    },
-
-    forceNextScrollToBottom() {
-      forceScrollToBottom = true
     },
 
     enqueue(data: Uint8Array, epoch: number, onWritten?: () => void) {
@@ -309,57 +97,11 @@ export function createTerminalIO(term: TerminalWriter, scroll?: ScrollAccessor):
       pump()
     },
 
+    syncStateChanged() { pump() },
+
     hasPendingWork() {
       dropStaleFront()
       return writeInFlight || queue.length > 0 || (!!pendingResize && pendingResize.epoch === currentEpoch)
     },
   }
-}
-
-/**
- * Find the best post-wipe scroll target whose line content matches the
- * pre-wipe anchor.
- *
- * Searches the **whole buffer**, not just `[0, baseY]`. A match at
- * `y > baseY` lives in the visible region, so we can't position the
- * viewport's top there directly (`scrollToLine` clamps to `baseY`),
- * but `scrollToBottom` keeps the line in the viewport at offset
- * `y - baseY`, which is the user's anchor visibly preserved.
- *
- * The restore target for a match at `y` is therefore `min(y, baseY)`:
- *
- *   - scrollback match (`y <= baseY`): anchor lands at the top of the
- *     viewport, exactly where the user had it.
- *   - visible-region match (`y > baseY`): viewport snaps to the bottom
- *     and the anchor sits somewhere inside the visible region, still
- *     readable.
- *
- * Tiebreak by closeness to the pre-wipe `distanceFromBottom`. Multiple
- * visible-region matches all collapse to the same target (`baseY`)
- * with the same restore-distance (`0`); among scrollback matches we
- * prefer the one whose `baseY - y` is closest to the captured
- * distance, so the user's relative scroll position is preserved when
- * possible.
- */
-function findAnchorMatch(
-  scroll: ScrollAccessor,
-  anchor: string,
-  baseY: number,
-  rows: number,
-  prevDistanceFromBottom: number,
-): number | null {
-  let best: number | null = null
-  let bestDiff = Number.POSITIVE_INFINITY
-  const totalLines = baseY + rows
-  for (let y = 0; y < totalLines; y++) {
-    if (scroll.getLine(y) !== anchor) continue
-    const restoreY = Math.min(y, baseY)
-    const restoreDistance = baseY - restoreY
-    const diff = Math.abs(restoreDistance - prevDistanceFromBottom)
-    if (diff < bestDiff) {
-      best = restoreY
-      bestDiff = diff
-    }
-  }
-  return best
 }

--- a/apps/gmux-web/src/terminal-io.ts
+++ b/apps/gmux-web/src/terminal-io.ts
@@ -26,7 +26,6 @@ export interface TerminalIO {
   requestResize(size: TerminalSize, epoch: number): void
   /** Reconsider a resize after the addon's combined busy fence changes. */
   busyStateChanged(): void
-  hasPendingWork(): boolean
 }
 
 /**
@@ -99,10 +98,5 @@ export function createTerminalIO(term: TerminalWriter, options: TerminalIOOption
     },
 
     busyStateChanged() { pump() },
-
-    hasPendingWork() {
-      dropStaleFront()
-      return writeInFlight || queue.length > 0 || (!!pendingResize && pendingResize.epoch === currentEpoch)
-    },
   }
 }

--- a/apps/gmux-web/src/terminal-io.ts
+++ b/apps/gmux-web/src/terminal-io.ts
@@ -15,8 +15,8 @@ interface QueueItem {
 }
 
 export interface TerminalIOOptions {
-  /** Current DEC 2026 state, owned by the scroll-anchor addon. */
-  isSyncActive?: () => boolean
+  /** Current synchronized-output/wipe-resolution fence owned by the addon. */
+  isBusy?: () => boolean
 }
 
 export interface TerminalIO {
@@ -24,16 +24,17 @@ export interface TerminalIO {
   enqueue(data: Uint8Array, epoch: number, onWritten?: () => void): void
   enqueueMany(chunks: Uint8Array[], epoch: number, onWritten?: () => void): void
   requestResize(size: TerminalSize, epoch: number): void
-  /** Reconsider a resize deferred behind a synchronized-output block. */
-  syncStateChanged(): void
+  /** Reconsider a resize after the addon's combined busy fence changes. */
+  busyStateChanged(): void
   hasPendingWork(): boolean
 }
 
 /**
  * Serializes xterm writes and resizes so resize only happens when the parser
  * is idle. This avoids xterm async-parser races (eg image addon + resize).
- * Resizes are also held across DEC 2026 synchronized output; the addon owns
- * parser-level sequence observation so framing does not depend on WS chunks.
+ * Resizes are also held across DEC 2026 synchronized output and post-ED3
+ * re-resolution; the addon owns that combined busy fence so framing does not
+ * depend on WebSocket chunks and resize cannot race its viewport catch-up.
  */
 export function createTerminalIO(term: TerminalWriter, options: TerminalIOOptions = {}): TerminalIO {
   let currentEpoch = 0
@@ -61,7 +62,7 @@ export function createTerminalIO(term: TerminalWriter, options: TerminalIOOption
       return
     }
 
-    if (pendingResize && pendingResize.epoch === currentEpoch && !options.isSyncActive?.()) {
+    if (pendingResize && pendingResize.epoch === currentEpoch && !options.isBusy?.()) {
       const { cols, rows } = pendingResize
       pendingResize = null
       term.resize(cols, rows)
@@ -97,7 +98,7 @@ export function createTerminalIO(term: TerminalWriter, options: TerminalIOOption
       pump()
     },
 
-    syncStateChanged() { pump() },
+    busyStateChanged() { pump() },
 
     hasPendingWork() {
       dropStaleFront()

--- a/apps/gmux-web/src/terminal.tsx
+++ b/apps/gmux-web/src/terminal.tsx
@@ -618,6 +618,10 @@ export function TerminalView({
     setViewportSize(initialVp); viewportSizeRef.current = initialVp
     termRef.current = term
     termIoRef.current = createTerminalIO(term, {
+      // LOAD-BEARING: this must be `busy`, not `syncActive`. ED3 closes DEC
+      // 2026 before the addon's onWriteParsed + rAF viewport catch-up; using
+      // syncActive lets resize race that restore. The real-addon integration
+      // regression is in terminal-io.test.ts ("through ED3 and its rAF").
       isBusy: () => scrollAnchor.busy,
     })
     const busyDisposable = scrollAnchor.onBusyChange((busy) => {

--- a/apps/gmux-web/src/terminal.tsx
+++ b/apps/gmux-web/src/terminal.tsx
@@ -618,10 +618,6 @@ export function TerminalView({
     setViewportSize(initialVp); viewportSizeRef.current = initialVp
     termRef.current = term
     termIoRef.current = createTerminalIO(term, {
-      // LOAD-BEARING: this must be `busy`, not `syncActive`. ED3 closes DEC
-      // 2026 before the addon's onWriteParsed + rAF viewport catch-up; using
-      // syncActive lets resize race that restore. The real-addon integration
-      // regression is in terminal-io.test.ts ("through ED3 and its rAF").
       isBusy: () => scrollAnchor.busy,
     })
     const busyDisposable = scrollAnchor.onBusyChange((busy) => {
@@ -661,10 +657,10 @@ export function TerminalView({
     }
 
     onInputReady?.(sendRawInput)
-    terminalScrollToBottom.value = () => {
-      scrollAnchor.follow()
-      term.scrollToBottom()
-    }
+    // follow() scrolls to the bottom itself; adding term.scrollToBottom()
+    // here would only fire a second, animated scroll for the addon to
+    // recognize and suppress.
+    terminalScrollToBottom.value = () => scrollAnchor.follow()
     const pasteFeedback = (kind: 'info' | 'error', message: string) => {
       if (kind === 'error') {
         console.warn('[paste]', message)
@@ -1024,7 +1020,6 @@ export function TerminalView({
         const prepared = prepareBrowserCheckpoint(chunks, checkpointAlt, checkpointMargins)
         queueMany(prepared, () => {
           scrollAnchorRef.current?.follow()
-          termRef.current?.scrollToBottom()
           setTermLoading(false)
         })
       })
@@ -1233,10 +1228,7 @@ export function TerminalView({
         <button
           type="button"
           class="terminal-scroll-end"
-          onClick={() => {
-            scrollAnchorRef.current?.follow()
-            termRef.current?.scrollToBottom()
-          }}
+          onClick={() => scrollAnchorRef.current?.follow()}
           title="Scroll to bottom"
         >
           End ↓

--- a/apps/gmux-web/src/terminal.tsx
+++ b/apps/gmux-web/src/terminal.tsx
@@ -618,10 +618,10 @@ export function TerminalView({
     setViewportSize(initialVp); viewportSizeRef.current = initialVp
     termRef.current = term
     termIoRef.current = createTerminalIO(term, {
-      isSyncActive: () => scrollAnchor.syncActive,
+      isSyncActive: () => scrollAnchor.busy,
     })
-    const syncDisposable = scrollAnchor.onSyncActiveChange((active) => {
-      if (!active) termIoRef.current?.syncStateChanged()
+    const busyDisposable = scrollAnchor.onBusyChange((busy) => {
+      if (!busy) termIoRef.current?.syncStateChanged()
     })
     ;(window as any).__gmuxTerm = term
     ;(window as any).__gmuxScrollAnchor = scrollAnchor
@@ -943,7 +943,7 @@ export function TerminalView({
       osc52Disposable.dispose()
       dataDisposable.dispose()
       scrollDisposable.dispose()
-      syncDisposable.dispose()
+      busyDisposable.dispose()
       terminalScrolledUp.value = false
       terminalScrollToBottom.value = null
       terminalFindOpen.value = false
@@ -979,6 +979,7 @@ export function TerminalView({
     const epoch = termEpochRef.current + 1
     termEpochRef.current = epoch
     termIoRef.current.reset(epoch)
+    scrollAnchorRef.current?.reset()
 
     const sessionChanged = terminalSessionId.current !== null
       && terminalSessionId.current !== session.id
@@ -1000,16 +1001,14 @@ export function TerminalView({
 
     function connect() {
       if (disposed.current) return
+      // A dropped socket can strand an unmatched BSU. Preserve the user's
+      // mode, but clear parser/transient fences before each replay attempt.
+      scrollAnchorRef.current?.reset()
 
       if (connectionRef.current) {
         connectionRef.current.ws.close()
         connectionRef.current = null
       }
-
-      // Replays are authoritative session snapshots. Explicitly enter follow
-      // mode before their BSU/ESU framing so stale scroll intent from the
-      // previous screen cannot survive the checkpoint wipe.
-      scrollAnchorRef.current?.follow()
 
       // The runner's binary frame is shared with `gmux attach`, so browser
       // buffer selection is delivered as metadata rather than ANSI bytes in
@@ -1157,6 +1156,7 @@ export function TerminalView({
       intentionalClose = true
       termEpochRef.current = epoch + 1
       termIoRef.current?.reset(termEpochRef.current)
+      scrollAnchorRef.current?.reset()
       if (reconnectTimer.current) clearTimeout(reconnectTimer.current)
       reconnectTimer.current = null
       resetResizeEchoGate()
@@ -1229,7 +1229,10 @@ export function TerminalView({
         <button
           type="button"
           class="terminal-scroll-end"
-          onClick={() => termRef.current?.scrollToBottom()}
+          onClick={() => {
+            scrollAnchorRef.current?.follow()
+            termRef.current?.scrollToBottom()
+          }}
           title="Scroll to bottom"
         >
           End ↓

--- a/apps/gmux-web/src/terminal.tsx
+++ b/apps/gmux-web/src/terminal.tsx
@@ -618,10 +618,10 @@ export function TerminalView({
     setViewportSize(initialVp); viewportSizeRef.current = initialVp
     termRef.current = term
     termIoRef.current = createTerminalIO(term, {
-      isSyncActive: () => scrollAnchor.busy,
+      isBusy: () => scrollAnchor.busy,
     })
     const busyDisposable = scrollAnchor.onBusyChange((busy) => {
-      if (!busy) termIoRef.current?.syncStateChanged()
+      if (!busy) termIoRef.current?.busyStateChanged()
     })
     ;(window as any).__gmuxTerm = term
     ;(window as any).__gmuxScrollAnchor = scrollAnchor

--- a/apps/gmux-web/src/terminal.tsx
+++ b/apps/gmux-web/src/terminal.tsx
@@ -1,3 +1,4 @@
+import { ScrollAnchorAddon } from '@gmux/scroll-anchor'
 import { FitAddon } from '@xterm/addon-fit'
 import { ImageAddon } from '@xterm/addon-image'
 import { SearchAddon } from '@xterm/addon-search'
@@ -354,6 +355,7 @@ export function TerminalView({
   const ctrlArmedRef = useRef(ctrlArmed)
   const altArmedRef = useRef(altArmed)
   const termIoRef = useRef<ReturnType<typeof createTerminalIO> | null>(null)
+  const scrollAnchorRef = useRef<ScrollAnchorAddon | null>(null)
   const searchAddonRef = useRef<SearchAddon | null>(null)
   const termEpochRef = useRef(0)
 
@@ -600,6 +602,11 @@ export function TerminalView({
     term.loadAddon(searchAddon)
     searchAddonRef.current = searchAddon
     term.open(containerRef.current)
+    // Load after open so the addon can observe wheel/touch intent on
+    // terminal.element as well as parser-level output sequences.
+    const scrollAnchor = new ScrollAnchorAddon()
+    term.loadAddon(scrollAnchor)
+    scrollAnchorRef.current = scrollAnchor
     loadWebglRenderer(term)
     // The Nerd Font icon fallback loads lazily; refresh the glyph atlas once
     // it arrives so icons rasterized as tofu beforehand get redrawn.
@@ -611,25 +618,13 @@ export function TerminalView({
     setViewportSize(initialVp); viewportSizeRef.current = initialVp
     termRef.current = term
     termIoRef.current = createTerminalIO(term, {
-      getState() {
-        const buf = term.buffer.active
-        return { viewportY: buf.viewportY, baseY: buf.baseY, rows: term.rows }
-      },
-      scrollToLine(line: number) { term.scrollToLine(line) },
-      scrollToBottom() { term.scrollToBottom() },
-      getLine(y: number): string | null {
-        const line = term.buffer.active.getLine(y)
-        if (!line) return null
-        const text = line.translateToString(true)
-        // Filter trivial anchors so a wipe-and-redraw doesn't snap the
-        // user to the first stretch of separators or whitespace it
-        // finds. Four visible chars is enough to be distinctive without
-        // excluding short but meaningful lines ("DONE", "PASS", etc.).
-        if (text.trim().length < 4) return null
-        return text
-      },
+      isSyncActive: () => scrollAnchor.syncActive,
+    })
+    const syncDisposable = scrollAnchor.onSyncActiveChange((active) => {
+      if (!active) termIoRef.current?.syncStateChanged()
     })
     ;(window as any).__gmuxTerm = term
+    ;(window as any).__gmuxScrollAnchor = scrollAnchor
     // Test-only inject hook: pumps bytes through the same path as ws.onmessage
     // (createTerminalIO.enqueue) bypassing the WebSocket and replay buffer.
     // Used by e2e/tests/terminal-scroll.spec.ts to exercise scroll preservation
@@ -662,7 +657,10 @@ export function TerminalView({
     }
 
     onInputReady?.(sendRawInput)
-    terminalScrollToBottom.value = () => term.scrollToBottom()
+    terminalScrollToBottom.value = () => {
+      scrollAnchor.follow()
+      term.scrollToBottom()
+    }
     const pasteFeedback = (kind: 'info' | 'error', message: string) => {
       if (kind === 'error') {
         console.warn('[paste]', message)
@@ -687,6 +685,11 @@ export function TerminalView({
     }
     // Every gesture acquires one immutable session/socket capability. The
     // keybind, DOM paste, and mobile sheet paths therefore share routing.
+    // The paste trigger reads bracketedPasteMode and the clipboard fresh
+    // on every invocation: bracketed mode flips at runtime as TUIs come
+    // and go, and the clipboard contents are obviously volatile. Sharing
+    // handlePasteAction with the keybind path means long-press paste gets
+    // binary-paste support without divergent code.
     pasteActionRef.current = () => {
       const destination = getPasteDestination()
       if (!destination) {
@@ -940,10 +943,12 @@ export function TerminalView({
       osc52Disposable.dispose()
       dataDisposable.dispose()
       scrollDisposable.dispose()
+      syncDisposable.dispose()
       terminalScrolledUp.value = false
       terminalScrollToBottom.value = null
       terminalFindOpen.value = false
       searchAddonRef.current = null
+      scrollAnchorRef.current = null
       if (reconnectTimer.current) clearTimeout(reconnectTimer.current)
       connectionRef.current?.ws.close()
       connectionRef.current = null
@@ -951,6 +956,7 @@ export function TerminalView({
       pasteActionRef.current = null
       onFocusReady?.(null)
       if ((window as any).__gmuxTerm === term) (window as any).__gmuxTerm = null
+      ;(window as any).__gmuxScrollAnchor = null
       ;(window as any).__gmuxInject = null
       disposeIconFontWatch()
       term.dispose()
@@ -1000,13 +1006,10 @@ export function TerminalView({
         connectionRef.current = null
       }
 
-      // Tell the scroll preservation layer to force-scroll-to-bottom for
-      // the replay frame. This avoids the "jump to top" bug: xterm's
-      // isUserScrolling flag can persist from the previous session, and
-      // \x1b[3J resets ybase/ydisp to 0 without clearing that flag. The
-      // force flag makes the BSU/ESU handler treat it as wasAtBottom=true
-      // regardless of the stale scroll state.
-      termIoRef.current?.forceNextScrollToBottom()
+      // Replays are authoritative session snapshots. Explicitly enter follow
+      // mode before their BSU/ESU framing so stale scroll intent from the
+      // previous screen cannot survive the checkpoint wipe.
+      scrollAnchorRef.current?.follow()
 
       // The runner's binary frame is shared with `gmux attach`, so browser
       // buffer selection is delivered as metadata rather than ANSI bytes in
@@ -1017,6 +1020,7 @@ export function TerminalView({
       const replay = createReplayBuffer((chunks) => {
         const prepared = prepareBrowserCheckpoint(chunks, checkpointAlt, checkpointMargins)
         queueMany(prepared, () => {
+          scrollAnchorRef.current?.follow()
           termRef.current?.scrollToBottom()
           setTermLoading(false)
         })

--- a/apps/gmux-web/src/terminal.tsx
+++ b/apps/gmux-web/src/terminal.tsx
@@ -657,9 +657,9 @@ export function TerminalView({
     }
 
     onInputReady?.(sendRawInput)
-    // follow() scrolls to the bottom itself; adding term.scrollToBottom()
-    // here would only fire a second, animated scroll for the addon to
-    // recognize and suppress.
+    // follow() already scrolls to the bottom, so a second term.scrollToBottom()
+    // here would compute a zero delta and only add a scroll event for the addon
+    // to classify.
     terminalScrollToBottom.value = () => scrollAnchor.follow()
     const pasteFeedback = (kind: 'info' | 'error', message: string) => {
       if (kind === 'error') {

--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.4.7/schema.json",
   "files": {
-    "includes": ["apps/gmux-web/src/**", "packages/protocol/src/**"]
+    "includes": ["apps/gmux-web/src/**", "packages/protocol/src/**", "packages/scroll-anchor/src/**"]
   },
   "linter": {
     "enabled": true,

--- a/e2e/tests/terminal-resize.spec.ts
+++ b/e2e/tests/terminal-resize.spec.ts
@@ -59,7 +59,65 @@ test.describe('terminal resize', () => {
 })
 
 test.describe('terminal resize — reconnect', () => {
-  test('reconnect after network blip does not re-claim', async ({ page, context }) => {
+  test('does not yank a scrolled-up reader until reconnect replay completes', async ({ page }) => {
+    await page.addInitScript(() => {
+      ;(window as any).__allWs = [] as WebSocket[]
+      ;(window as any).__blockTerminalReconnect = false
+      const OriginalWebSocket = window.WebSocket
+      ;(window as any).WebSocket = function (...args: ConstructorParameters<typeof WebSocket>) {
+        const original = String(args[0])
+        const url = (window as any).__blockTerminalReconnect && original.includes('/ws/')
+          ? 'ws://127.0.0.1:1/unavailable'
+          : original
+        const ws = new OriginalWebSocket(url, ...(args.slice(1) as any))
+        ;(window as any).__allWs.push(ws)
+        return ws
+      } as unknown as typeof WebSocket
+      Object.assign((window as any).WebSocket, OriginalWebSocket)
+      ;(window as any).WebSocket.prototype = OriginalWebSocket.prototype
+    })
+
+    await openApp(page)
+    await gotoTestSession(page)
+    const payload = Array.from({ length: 200 }, (_, i) => `reconnect-seed-${i}\r\n`).join('')
+    await page.evaluate((encoded) => (window as any).__gmuxInject(encoded), Buffer.from(payload).toString('base64'))
+    await page.waitForTimeout(200)
+    const box = await page.locator('.xterm').boundingBox()
+    if (!box) throw new Error('xterm has no bounding box')
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2)
+    for (let i = 0; i < 5; i++) await page.mouse.wheel(0, -120)
+    const before = await page.evaluate(() => {
+      const buffer = (window as any).__gmuxTerm.buffer.active
+      return { viewportY: buffer.viewportY, baseY: buffer.baseY }
+    })
+    expect(before.viewportY).toBeLessThan(before.baseY)
+
+    await page.evaluate(() => {
+      ;(window as any).__blockTerminalReconnect = true
+      for (const ws of (window as any).__allWs as WebSocket[]) {
+        if (ws.readyState === WebSocket.OPEN) ws.close()
+      }
+    })
+    await expect(page.locator('.terminal-disconnected-pill')).toBeVisible({ timeout: 10_000 })
+    await page.waitForTimeout(800)
+    const during = await page.evaluate(() => {
+      const buffer = (window as any).__gmuxTerm.buffer.active
+      return { viewportY: buffer.viewportY, baseY: buffer.baseY }
+    })
+    expect(during.viewportY).toBeLessThan(during.baseY)
+    expect(during.viewportY).toBe(before.viewportY)
+
+    await page.evaluate(() => { (window as any).__blockTerminalReconnect = false })
+    await expect(page.locator('.terminal-disconnected-pill')).not.toBeVisible({ timeout: 10_000 })
+    await page.waitForTimeout(1000)
+    const after = await page.evaluate(() => {
+      const buffer = (window as any).__gmuxTerm.buffer.active
+      return { viewportY: buffer.viewportY, baseY: buffer.baseY }
+    })
+    expect(after.viewportY).toBe(after.baseY)
+  })
+
+  test('reconnect after network blip does not re-claim', async ({ page }) => {
     // Instrument WS.send and expose a helper to force-close WebSockets,
     // since context.setOffline doesn't immediately sever WS connections.
     await page.addInitScript(() => {

--- a/e2e/tests/terminal-scroll.spec.ts
+++ b/e2e/tests/terminal-scroll.spec.ts
@@ -89,6 +89,21 @@ async function scrollToBottom(page: Page): Promise<void> {
   await page.evaluate(() => (window as any).__gmuxTerm.scrollToBottom())
 }
 
+/** Mark a programmatic test setup scroll as wheel intent for the addon. */
+async function userScrollToLine(page: Page, line: number): Promise<void> {
+  const box = await page.locator('.xterm').boundingBox()
+  if (!box) throw new Error('xterm has no bounding box')
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2)
+  // A real wheel event establishes anchored mode; the absolute scroll that
+  // follows only makes each legacy contract's buffer geometry deterministic.
+  for (let i = 0; i < 3; i++) {
+    await page.mouse.wheel(0, -120)
+    await page.waitForTimeout(30)
+  }
+  await page.waitForFunction(() => (window as any).__gmuxScrollAnchor?.mode === 'anchored')
+  await page.evaluate((target) => (window as any).__gmuxTerm.scrollToLine(target), line)
+}
+
 test.describe('terminal scrollback (jump-to-top bug)', () => {
   test.beforeEach(async ({ page }) => {
     await openApp(page)
@@ -281,7 +296,7 @@ test.describe('terminal scrollback (jump-to-top bug)', () => {
 
     // Scroll up by 20 lines. We pick an absolute line halfway up.
     const target = Math.max(1, baseline.baseY - 20)
-    await page.evaluate((line) => (window as any).__gmuxTerm.scrollToLine(line), target)
+    await userScrollToLine(page, target)
     const beforeBurst = await getScroll(page)
     expect(beforeBurst.viewportY).toBe(target)
     expect(beforeBurst.viewportY).toBeLessThan(beforeBurst.baseY)
@@ -427,7 +442,7 @@ test.describe('terminal scrollback (jump-to-top bug)', () => {
 
     // Scroll up well into the seeded backscroll.
     const target = Math.floor(baseline.baseY / 2)
-    await page.evaluate((line) => (window as any).__gmuxTerm.scrollToLine(line), target)
+    await userScrollToLine(page, target)
     const beforeBurst = await getScroll(page)
     expect(beforeBurst.viewportY).toBe(target)
 
@@ -471,7 +486,7 @@ test.describe('terminal scrollback (jump-to-top bug)', () => {
 
     const distance = 3
     const target = baseline.baseY - distance
-    await page.evaluate((line) => (window as any).__gmuxTerm.scrollToLine(line), target)
+    await userScrollToLine(page, target)
     const beforeBurst = await getScroll(page)
     expect(beforeBurst.baseY - beforeBurst.viewportY).toBe(distance)
 
@@ -527,7 +542,7 @@ test.describe('terminal scrollback (jump-to-top bug)', () => {
     // contract under test is content matching, not seed numbering.
     const distance = 10
     const targetY = baseline.baseY - distance
-    await page.evaluate((line) => (window as any).__gmuxTerm.scrollToLine(line), targetY)
+    await userScrollToLine(page, targetY)
     const beforeBurst = await getScroll(page)
     expect(beforeBurst.viewportY).toBe(targetY)
     const targetText = await page.evaluate((y) => {
@@ -592,7 +607,7 @@ test.describe('terminal scrollback (jump-to-top bug)', () => {
 
     const distance = 5
     const targetY = baseline.baseY - distance
-    await page.evaluate((line) => (window as any).__gmuxTerm.scrollToLine(line), targetY)
+    await userScrollToLine(page, targetY)
     const targetText = await page.evaluate((y) => {
       const term = (window as any).__gmuxTerm
       const line = term.buffer.active.getLine(y)
@@ -683,7 +698,7 @@ test.describe('terminal scrollback (jump-to-top bug)', () => {
     const preWipeDistance = preWipeBaseY - targetY
     expect(preWipeDistance).toBeGreaterThan(15)
 
-    await page.evaluate((line) => (window as any).__gmuxTerm.scrollToLine(line), targetY)
+    await userScrollToLine(page, targetY)
     const beforeBurst = await getScroll(page)
     expect(beforeBurst.viewportY).toBe(targetY)
 
@@ -752,7 +767,7 @@ test.describe('terminal scrollback (jump-to-top bug)', () => {
     // dramatic in the assertion message.
     const distance = 3
     const target = baseline.baseY - distance
-    await page.evaluate((line) => (window as any).__gmuxTerm.scrollToLine(line), target)
+    await userScrollToLine(page, target)
     const beforeBurst = await getScroll(page)
     expect(beforeBurst.baseY - beforeBurst.viewportY).toBe(distance)
     const prevBaseY = beforeBurst.baseY

--- a/e2e/tests/terminal-wheel.spec.ts
+++ b/e2e/tests/terminal-wheel.spec.ts
@@ -21,7 +21,7 @@ async function wheelSamples(page: Page, count: number): Promise<number[]> {
   const box = await page.locator('.xterm').boundingBox()
   if (!box) throw new Error('xterm has no bounding box')
   await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2)
-  const samples: number[] = []
+  const samples: number[] = [(await scroll(page)).viewportY]
   for (let i = 0; i < count; i++) {
     await page.mouse.wheel(0, -120)
     samples.push((await scroll(page)).viewportY)
@@ -30,7 +30,7 @@ async function wheelSamples(page: Page, count: number): Promise<number[]> {
   return samples
 }
 
-async function startBurstSession(): Promise<{ process: ChildProcess, sessionId: string, trigger: string, dir: string, env: NodeJS.ProcessEnv }> {
+async function startBurstSession(): Promise<{ process: ChildProcess, sessionId: string, trigger: string, stop: string, dir: string, env: NodeJS.ProcessEnv }> {
   const state = JSON.parse(readFileSync(STATE_FILE, 'utf8')) as { tmpDir: string, token: string }
   const before = await apiGet<{ data: Array<{ id: string }> }>('/v1/sessions')
   const existingIds = new Set(before.body.data.map(item => item.id))
@@ -38,12 +38,13 @@ async function startBurstSession(): Promise<{ process: ChildProcess, sessionId: 
   const dir = join(workspace, `wheel-${Date.now()}-${Math.random().toString(16).slice(2)}`)
   mkdirSync(dir, { recursive: true })
   const trigger = join(dir, 'trigger')
+  const stop = join(dir, 'stop')
   const script = join(dir, 'gen.sh')
   writeFileSync(script, `#!/usr/bin/env bash
 for i in $(seq 1 400); do printf 'seed-line-%04d\\r\\n' "$i"; done
 while [ ! -e "${trigger}" ]; do sleep 0.01; done
 i=0
-while [ "$i" -lt 240 ]; do
+while [ ! -e "${stop}" ]; do
   printf '\\033[?2026h'
   for j in $(seq 1 5); do printf 'burst-%04d-%d\\r\\n' "$i" "$j"; done
   printf '\\033[?2026l'
@@ -70,10 +71,11 @@ while true; do sleep 60; done
     const response = await apiGet<{ data: Array<{ id: string, alive: boolean }> }>('/v1/sessions')
     return response.body.data.find(item => item.alive && !existingIds.has(item.id))?.id
   }, { timeoutMs: 10_000, description: 'burst session' })
-  return { process: child, sessionId, trigger, dir, env }
+  return { process: child, sessionId, trigger, stop, dir, env }
 }
 
-function stopBurstSession(session: { process: ChildProcess, sessionId: string, dir: string, env: NodeJS.ProcessEnv }): void {
+function stopBurstSession(session: { process: ChildProcess, sessionId: string, stop: string, dir: string, env: NodeJS.ProcessEnv }): void {
+  writeFileSync(session.stop, '')
   try { execFileSync(join(ROOT, 'bin/gmux'), ['kill', session.sessionId], { env: session.env }) } catch { /* already exited */ }
   if (session.process.pid) {
     try { process.kill(-session.process.pid, 'SIGTERM') } catch { /* already exited */ }
@@ -86,9 +88,6 @@ test.describe.serial('terminal wheel under live synchronized output', () => {
 
   test.beforeEach(async ({ page }) => {
     burst = await startBurstSession()
-    // A live write prompts the runner to publish the browser checkpoint;
-    // keep enough 30 Hz bursts after navigation for the wheel phase itself.
-    writeFileSync(burst.trigger, '')
     await openApp(page)
     await gotoSession(page, burst.sessionId)
     await page.waitForFunction(() => {
@@ -103,17 +102,22 @@ test.describe.serial('terminal wheel under live synchronized output', () => {
   test.afterEach(() => { if (burst) stopBurstSession(burst) })
 
   test('wheel-up escapes bottom during 30 Hz BSU/ESU bursts', async ({ page }) => {
+    const before = await scroll(page)
+    writeFileSync(burst.trigger, '')
     const samples = await wheelSamples(page, 25)
-    const netUp = samples[0] - samples.at(-1)!
-    expect(netUp).toBeGreaterThan(40)
+    const after = await scroll(page)
+    expect(after.baseY).toBeGreaterThan(before.baseY)
+    expect(samples[0] - samples.at(-1)!).toBeGreaterThan(40)
   })
 
   test('an anchored viewport is not dragged and further wheel input moves it', async ({ page }) => {
     const initial = await wheelSamples(page, 12)
     expect(initial[0] - initial.at(-1)!).toBeGreaterThan(20)
     const beforeLoad = await scroll(page)
+    writeFileSync(burst.trigger, '')
     await page.waitForTimeout(300)
     const beforeMore = await scroll(page)
+    expect(beforeMore.baseY).toBeGreaterThan(beforeLoad.baseY)
     expect(Math.abs(beforeMore.viewportY - beforeLoad.viewportY)).toBeLessThanOrEqual(3)
     const more = await wheelSamples(page, 10)
     expect(more[0] - more.at(-1)!).toBeGreaterThan(15)

--- a/e2e/tests/terminal-wheel.spec.ts
+++ b/e2e/tests/terminal-wheel.spec.ts
@@ -1,0 +1,131 @@
+import { expect, test, type Page } from '@playwright/test'
+import { execFileSync, spawn, type ChildProcess } from 'node:child_process'
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { apiGet, gotoSession, openApp, pollUntil } from '../helpers'
+
+const ROOT = resolve(__dirname, '../..')
+const STATE_FILE = join(tmpdir(), 'gmux-e2e-state.json')
+
+type Scroll = { viewportY: number, baseY: number }
+
+async function scroll(page: Page): Promise<Scroll> {
+  return page.evaluate(() => {
+    const buffer = (window as any).__gmuxTerm.buffer.active
+    return { viewportY: buffer.viewportY, baseY: buffer.baseY }
+  })
+}
+
+async function wheelSamples(page: Page, count: number): Promise<number[]> {
+  const box = await page.locator('.xterm').boundingBox()
+  if (!box) throw new Error('xterm has no bounding box')
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2)
+  const samples: number[] = []
+  for (let i = 0; i < count; i++) {
+    await page.mouse.wheel(0, -120)
+    samples.push((await scroll(page)).viewportY)
+    await page.waitForTimeout(60)
+  }
+  return samples
+}
+
+async function startBurstSession(): Promise<{ process: ChildProcess, sessionId: string, trigger: string, dir: string, env: NodeJS.ProcessEnv }> {
+  const state = JSON.parse(readFileSync(STATE_FILE, 'utf8')) as { tmpDir: string, token: string }
+  const before = await apiGet<{ data: Array<{ id: string }> }>('/v1/sessions')
+  const existingIds = new Set(before.body.data.map(item => item.id))
+  const workspace = process.env.GMUX_TEST_WORKSPACE!
+  const dir = join(workspace, `wheel-${Date.now()}-${Math.random().toString(16).slice(2)}`)
+  mkdirSync(dir, { recursive: true })
+  const trigger = join(dir, 'trigger')
+  const script = join(dir, 'gen.sh')
+  writeFileSync(script, `#!/usr/bin/env bash
+for i in $(seq 1 400); do printf 'seed-line-%04d\\r\\n' "$i"; done
+while [ ! -e "${trigger}" ]; do sleep 0.01; done
+i=0
+while [ "$i" -lt 240 ]; do
+  printf '\\033[?2026h'
+  for j in $(seq 1 5); do printf 'burst-%04d-%d\\r\\n' "$i" "$j"; done
+  printf '\\033[?2026l'
+  i=$((i + 1))
+  sleep 0.03
+done
+while true; do sleep 60; done
+`)
+  const env = {
+    ...process.env,
+    GMUX_SOCKET_DIR: join(state.tmpDir, 'sockets'),
+    GMUXD_TOKEN: state.token,
+    HOME: join(state.tmpDir, 'home'),
+    XDG_CONFIG_HOME: join(state.tmpDir, 'config'),
+    XDG_STATE_HOME: join(state.tmpDir, 'state'),
+  }
+  const child = spawn(join(ROOT, 'bin/gmux'), ['--', 'bash', script], {
+    cwd: workspace,
+    env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    detached: true,
+  })
+  const sessionId = await pollUntil(async () => {
+    const response = await apiGet<{ data: Array<{ id: string, alive: boolean }> }>('/v1/sessions')
+    return response.body.data.find(item => item.alive && !existingIds.has(item.id))?.id
+  }, { timeoutMs: 10_000, description: 'burst session' })
+  return { process: child, sessionId, trigger, dir, env }
+}
+
+function stopBurstSession(session: { process: ChildProcess, sessionId: string, dir: string, env: NodeJS.ProcessEnv }): void {
+  try { execFileSync(join(ROOT, 'bin/gmux'), ['kill', session.sessionId], { env: session.env }) } catch { /* already exited */ }
+  if (session.process.pid) {
+    try { process.kill(-session.process.pid, 'SIGTERM') } catch { /* already exited */ }
+  }
+  rmSync(session.dir, { recursive: true, force: true })
+}
+
+test.describe.serial('terminal wheel under live synchronized output', () => {
+  let burst: Awaited<ReturnType<typeof startBurstSession>>
+
+  test.beforeEach(async ({ page }) => {
+    burst = await startBurstSession()
+    // A live write prompts the runner to publish the browser checkpoint;
+    // keep enough 30 Hz bursts after navigation for the wheel phase itself.
+    writeFileSync(burst.trigger, '')
+    await openApp(page)
+    await gotoSession(page, burst.sessionId)
+    await page.waitForFunction(() => {
+      const buffer = (window as any).__gmuxTerm?.buffer.active
+      return buffer && buffer.baseY > 300
+    }, undefined, { timeout: 15_000 }).catch(async error => {
+      throw new Error(`${error.message}; cli=${burst.sessionId}; state=${JSON.stringify(await scroll(page))}; url=${page.url()}`)
+    })
+    await page.evaluate(() => (window as any).__gmuxTerm.scrollToBottom())
+  })
+
+  test.afterEach(() => { if (burst) stopBurstSession(burst) })
+
+  test('wheel-up escapes bottom during 30 Hz BSU/ESU bursts', async ({ page }) => {
+    const samples = await wheelSamples(page, 25)
+    const netUp = samples[0] - samples.at(-1)!
+    expect(netUp).toBeGreaterThan(40)
+  })
+
+  test('an anchored viewport is not dragged and further wheel input moves it', async ({ page }) => {
+    const initial = await wheelSamples(page, 12)
+    expect(initial[0] - initial.at(-1)!).toBeGreaterThan(20)
+    const beforeLoad = await scroll(page)
+    await page.waitForTimeout(300)
+    const beforeMore = await scroll(page)
+    expect(Math.abs(beforeMore.viewportY - beforeLoad.viewportY)).toBeLessThanOrEqual(3)
+    const more = await wheelSamples(page, 10)
+    expect(more[0] - more.at(-1)!).toBeGreaterThan(15)
+  })
+
+  test('bare ED3 restores an anchored viewport after redraw', async ({ page }) => {
+    await wheelSamples(page, 10)
+    const redraw = '\x1b[2J\x1b[H\x1b[3J' + Array.from({ length: 100 }, (_, i) => `redraw-${i}\r\n`).join('')
+    await page.evaluate((encoded) => (window as any).__gmuxInject(encoded), Buffer.from(redraw).toString('base64'))
+    await page.waitForTimeout(200)
+    const after = await scroll(page)
+    expect(after.baseY).toBeGreaterThan(0)
+    expect(after.viewportY).toBeGreaterThan(0)
+  })
+})

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -3,8 +3,24 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "main": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts"
+    }
+  },
+  "main": "src/index.ts",
   "types": "src/index.ts",
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts"
+  },
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "test": "vitest run --passWithNoTests",

--- a/packages/scroll-anchor/README.md
+++ b/packages/scroll-anchor/README.md
@@ -1,0 +1,27 @@
+# @gmux/scroll-anchor
+
+An xterm.js addon that separates two terminal scroll modes:
+
+- **following** keeps the viewport at the newest output;
+- **anchored** lets xterm preserve the user's viewport natively while output streams, and restores a content/distance anchor after `CSI 3 J` clears scrollback.
+
+Wheel and touch movement enter anchored mode. Reaching the bottom, or calling `follow()`, returns to following mode. The addon also exposes DEC 2026 synchronized-output state and a combined `busy` fence for integrations that must defer terminal resizes through post-wipe viewport synchronization.
+
+```ts
+import { ScrollAnchorAddon } from '@gmux/scroll-anchor'
+
+const addon = new ScrollAnchorAddon()
+terminal.open(element)
+terminal.loadAddon(addon)
+
+// Session/replay boundaries and an explicit End action:
+addon.follow()
+```
+
+## Current input coverage
+
+Wheel and touch scrolling are observed directly. Keyboard scrollback that does not land at the bottom is not identified as user intent in v1. Scrollbar drags are recognized structurally when they land at the bottom, but a drag to another scrollback position does not enter anchored mode.
+
+## xterm compatibility note
+
+Programmatic following uses `scrollToBottom(true)` to disable smooth scrolling. The gmux xterm fork supports this optional argument, although its generated public declaration still has the upstream zero-argument signature; the addon contains a narrow cast for that mismatch. Other xterm builds ignore extra JavaScript arguments, but consumers should verify their desired smooth-scroll behavior.

--- a/packages/scroll-anchor/README.md
+++ b/packages/scroll-anchor/README.md
@@ -5,7 +5,7 @@ An xterm.js addon that separates two terminal scroll modes:
 - **following** keeps the viewport at the newest output;
 - **anchored** lets xterm preserve the user's viewport natively while output streams, and restores a content/distance anchor after `CSI 3 J` clears scrollback.
 
-Wheel and touch movement enter anchored mode. Reaching the bottom, or calling `follow()`, returns to following mode. The addon also exposes DEC 2026 synchronized-output state and a combined `busy` fence for integrations that must defer terminal resizes through post-wipe viewport synchronization.
+Wheel and touch movement enter anchored mode. Reaching the bottom, or calling `follow()`, returns to following mode. The addon also exposes a `busy` fence for integrations that must defer terminal resizes through DEC 2026 synchronized output and post-wipe viewport synchronization.
 
 ```ts
 import { ScrollAnchorAddon } from '@gmux/scroll-anchor'
@@ -27,9 +27,9 @@ Two timing limitations are accepted for this version:
 - With `smoothScrollDuration > 0`, parsed output can land between a wheel event and its first animation frame. Parsing clears the intent latch, so that notch can be reverted; the default duration of `0` is unaffected. A follow-up could correlate latch expiry with xterm's pending scroll animation instead of `onWriteParsed`.
 - During an ED3 wipe-resolution fence, scrollbar or keyboard arrival at bottom does not enter following mode because an output-driven transient also reports 0/0. Explicit wheel/touch intent at bottom is still recognized.
 
-## xterm compatibility note
+## Smooth scrolling
 
-Programmatic following uses `scrollToBottom(true)` to disable smooth scrolling. The gmux xterm fork supports this optional argument, although its generated public declaration still has the upstream zero-argument signature; the addon contains a narrow cast for that mismatch. Other xterm builds ignore extra JavaScript arguments, but consumers should verify their desired smooth-scroll behavior.
+Programmatic following calls the public `Terminal.scrollToBottom()`, which takes no arguments: xterm's public wrapper does not forward the internal `disableSmoothScroll` flag, so following animates whenever `smoothScrollDuration` is non-zero. With the default of `0` the viewport moves synchronously. See the limitations above for the behavior that non-zero durations imply.
 
 ## Monorepo development
 

--- a/packages/scroll-anchor/README.md
+++ b/packages/scroll-anchor/README.md
@@ -38,3 +38,7 @@ No build step is needed to consume this package in-repo. `main`, `types` and `ex
 Pointing the default entries at `dist/` instead breaks any path that does not run this package's build first — the goreleaser release hook invokes vite directly, bypassing moon, and fails with `Failed to resolve entry for package`.
 
 `pnpm -C packages/scroll-anchor build` still produces `dist/` for publication and as a type check.
+
+Publishing must go through `pnpm publish`: the `publishConfig` entry swap is a pnpm feature that `npm publish` ignores. `src/` ships in the tarball as insurance, but an npm-published package would still resolve to TypeScript source.
+
+During `pnpm dev`, edits to this package hot-reload the module, but the live `Terminal` keeps the parser and scroll handlers registered by the previous addon instance — reload the page for addon changes to take effect.

--- a/packages/scroll-anchor/README.md
+++ b/packages/scroll-anchor/README.md
@@ -25,3 +25,7 @@ Wheel and touch scrolling are observed directly. Keyboard scrollback that does n
 ## xterm compatibility note
 
 Programmatic following uses `scrollToBottom(true)` to disable smooth scrolling. The gmux xterm fork supports this optional argument, although its generated public declaration still has the upstream zero-argument signature; the addon contains a narrow cast for that mismatch. Other xterm builds ignore extra JavaScript arguments, but consumers should verify their desired smooth-scroll behavior.
+
+## Monorepo development
+
+The package's types point at the publishable `dist/index.d.ts`. Build it before running gmux-web TypeScript directly: `pnpm -C packages/scroll-anchor build` followed by `pnpm -C apps/gmux-web lint`. Moon tasks encode this dependency automatically.

--- a/packages/scroll-anchor/README.md
+++ b/packages/scroll-anchor/README.md
@@ -33,4 +33,8 @@ Programmatic following uses `scrollToBottom(true)` to disable smooth scrolling. 
 
 ## Monorepo development
 
-The package's types point at the publishable `dist/index.d.ts`. Build it before running gmux-web TypeScript directly: `pnpm -C packages/scroll-anchor build` followed by `pnpm -C apps/gmux-web lint`. Moon tasks encode this dependency automatically.
+No build step is needed to consume this package in-repo. `main`, `types` and `exports` point at TypeScript source, so vite, vitest, tsc, moon, goreleaser and docker all resolve it without depending on task ordering. `publishConfig` swaps those entries to the compiled `dist/` output at publish time, so published consumers still get JavaScript plus declarations.
+
+Pointing the default entries at `dist/` instead breaks any path that does not run this package's build first — the goreleaser release hook invokes vite directly, bypassing moon, and fails with `Failed to resolve entry for package`.
+
+`pnpm -C packages/scroll-anchor build` still produces `dist/` for publication and as a type check.

--- a/packages/scroll-anchor/README.md
+++ b/packages/scroll-anchor/README.md
@@ -18,9 +18,14 @@ terminal.loadAddon(addon)
 addon.follow()
 ```
 
-## Current input coverage
+## Current input coverage and accepted limitations
 
 Wheel and touch scrolling are observed directly. Keyboard scrollback that does not land at the bottom is not identified as user intent in v1. Scrollbar drags are recognized structurally when they land at the bottom, but a drag to another scrollback position does not enter anchored mode.
+
+Two timing limitations are accepted for this version:
+
+- With `smoothScrollDuration > 0`, parsed output can land between a wheel event and its first animation frame. Parsing clears the intent latch, so that notch can be reverted; the default duration of `0` is unaffected. A follow-up could correlate latch expiry with xterm's pending scroll animation instead of `onWriteParsed`.
+- During an ED3 wipe-resolution fence, scrollbar or keyboard arrival at bottom does not enter following mode because an output-driven transient also reports 0/0. Explicit wheel/touch intent at bottom is still recognized.
 
 ## xterm compatibility note
 

--- a/packages/scroll-anchor/moon.yml
+++ b/packages/scroll-anchor/moon.yml
@@ -1,0 +1,15 @@
+language: javascript
+
+tasks:
+  dev:
+    command: pnpm exec tsc --watch --preserveWatchOutput -p tsconfig.json
+    preset: server
+  build:
+    command: pnpm exec tsc -p tsconfig.json
+    inputs:
+      - "src/**/*"
+      - "tsconfig.json"
+  test:
+    command: pnpm exec vitest run
+  lint:
+    command: pnpm exec tsc --noEmit

--- a/packages/scroll-anchor/moon.yml
+++ b/packages/scroll-anchor/moon.yml
@@ -9,6 +9,8 @@ tasks:
     inputs:
       - "src/**/*"
       - "tsconfig.json"
+    outputs:
+      - "dist"
   test:
     command: pnpm exec vitest run
   lint:

--- a/packages/scroll-anchor/package.json
+++ b/packages/scroll-anchor/package.json
@@ -7,6 +7,7 @@
   "type": "module",
   "files": [
     "dist",
+    "src",
     "README.md"
   ],
   "exports": {

--- a/packages/scroll-anchor/package.json
+++ b/packages/scroll-anchor/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@gmux/scroll-anchor",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "src/index.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "vitest run",
+    "lint": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "@xterm/xterm": "*"
+  },
+  "devDependencies": {
+    "@xterm/xterm": "github:gmuxapp/xterm.js#v6.1.0-beta.288-gmux.5",
+    "typescript": "^5.8.2",
+    "vitest": "^3.0.7"
+  }
+}

--- a/packages/scroll-anchor/package.json
+++ b/packages/scroll-anchor/package.json
@@ -9,7 +9,6 @@
     "dist",
     "README.md"
   ],
-  "//": "In-repo consumers resolve TypeScript source: no build step and no task ordering is required for vite, vitest, tsc, moon, goreleaser or docker to consume this package. `publishConfig` swaps the entry points to the compiled output when the package is actually published, so a published consumer still gets JS + .d.ts. Pointing the default entries at dist instead makes every build path that doesn't run `scroll-anchor:build` first fail with 'Failed to resolve entry for package' (the goreleaser before-hook calls vite directly, bypassing moon).",
   "exports": {
     ".": {
       "types": "./src/index.ts",

--- a/packages/scroll-anchor/package.json
+++ b/packages/scroll-anchor/package.json
@@ -1,10 +1,22 @@
 {
   "name": "@gmux/scroll-anchor",
   "version": "0.1.0",
+  "description": "Follow and content-anchor scroll modes for xterm.js terminals",
+  "license": "MIT",
   "private": true,
   "type": "module",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
   "main": "dist/index.js",
-  "types": "src/index.ts",
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "test": "vitest run",

--- a/packages/scroll-anchor/package.json
+++ b/packages/scroll-anchor/package.json
@@ -9,14 +9,25 @@
     "dist",
     "README.md"
   ],
+  "//": "In-repo consumers resolve TypeScript source: no build step and no task ordering is required for vite, vitest, tsc, moon, goreleaser or docker to consume this package. `publishConfig` swaps the entry points to the compiled output when the package is actually published, so a published consumer still gets JS + .d.ts. Pointing the default entries at dist instead makes every build path that doesn't run `scroll-anchor:build` first fail with 'Failed to resolve entry for package' (the goreleaser before-hook calls vite directly, bypassing moon).",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "types": "./src/index.ts",
+      "import": "./src/index.ts"
     }
   },
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts"
+  },
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "test": "vitest run",

--- a/packages/scroll-anchor/src/index.test.ts
+++ b/packages/scroll-anchor/src/index.test.ts
@@ -203,6 +203,40 @@ describe('ScrollAnchorAddon', () => {
     expect(h.addon.mode).toBe('anchored')
   })
 
+  it('expires no-op wheel intent before an unrelated later scroll', () => {
+    const frames: FrameRequestCallback[] = []
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => { frames.push(callback); return frames.length })
+    const h = makeHarness()
+    h.setBuffer(20, 20)
+    h.armIntent()
+    frames.shift()?.(0)
+    frames.shift()?.(16)
+    h.outputScroll(10)
+    expect(h.addon.mode).toBe('following')
+    vi.unstubAllGlobals()
+  })
+
+  it('clears stale wheel intent when output is parsed before any scroll', () => {
+    const h = makeHarness()
+    h.setBuffer(20, 20)
+    h.armIntent()
+    h.parsed()
+    h.outputScroll(10)
+    expect(h.addon.mode).toBe('following')
+  })
+
+  it('suppresses an asynchronously delivered addon scroll before a later user scroll', async () => {
+    const h = makeHarness()
+    h.setBuffer(20, 20)
+    h.armIntent()
+    ;(h.addon as any).runProgrammaticScroll(() => h.setBuffer(10, 20))
+    await new Promise(resolve => setTimeout(resolve, 1))
+    h.emitScroll()
+    expect(h.addon.mode).toBe('following')
+    h.outputScroll(8)
+    expect(h.addon.mode).toBe('following')
+  })
+
   it('follows structurally when a non-wheel scroll lands at bottom', () => {
     const h = makeHarness()
     h.setBuffer(20, 20)
@@ -210,6 +244,39 @@ describe('ScrollAnchorAddon', () => {
     expect(h.addon.mode).toBe('anchored')
     h.outputScroll(20)
     expect(h.addon.mode).toBe('following')
+  })
+
+  it('does not structurally follow on a transient at-bottom wipe scroll', () => {
+    const h = makeHarness()
+    h.setBuffer(20, 20)
+    h.userScroll(10)
+    h.csi('J', [3])
+    h.outputScroll(0)
+    expect(h.addon.mode).toBe('anchored')
+  })
+
+  it('preserves progressive eviction adjustment without programmatic scrolling', () => {
+    const h = makeHarness()
+    h.setBuffer(60, 100)
+    h.userScroll(60)
+    h.setBuffer(55, 100)
+    h.parsed()
+    expect(h.addon.mode).toBe('anchored')
+    expect(h.scrollToLine).not.toHaveBeenCalled()
+    h.setBuffer(50, 100)
+    h.parsed()
+    expect(h.scrollToLine).not.toHaveBeenCalled()
+  })
+
+  it('allows xterm to clamp an evicted anchor to zero', () => {
+    const h = makeHarness()
+    h.setBuffer(5, 100)
+    h.userScroll(5)
+    h.setBuffer(0, 100)
+    h.parsed()
+    expect(h.addon.mode).toBe('anchored')
+    expect(h.scrollToLine).not.toHaveBeenCalled()
+    expect(h.scrollToBottom).not.toHaveBeenCalled()
   })
 
   it('preserves a near-bottom user anchor', () => {

--- a/packages/scroll-anchor/src/index.test.ts
+++ b/packages/scroll-anchor/src/index.test.ts
@@ -309,29 +309,34 @@ describe('ScrollAnchorAddon', () => {
   it('treats repeated BSU as idempotent and one ESU closes it', () => {
     const h = makeHarness()
     const changes: boolean[] = []
-    h.addon.onSyncActiveChange(active => { changes.push(active) })
+    h.addon.onBusyChange(busy => { changes.push(busy) })
     h.csi('?h', [2026])
     h.csi('?h', [[2026]])
-    expect(h.addon.syncActive).toBe(true)
+    expect(h.addon.busy).toBe(true)
+    // ONE close for two opens. xterm's mode set is idempotent, so the stream
+    // considers synchronized output finished here and the fence must open.
+    // A depth counter would sit at 1 and starve every later resize for the
+    // lifetime of the session, which is the bug this boolean replaced.
     h.csi('?l', [2026])
-    h.csi('?l', [2026])
-    expect(h.addon.syncActive).toBe(false)
+    expect(h.addon.busy).toBe(false)
+    // One open, one close: no duplicate events to churn hosts either.
     expect(changes).toEqual([true, false])
   })
 
   it('reset clears unmatched sync, wipe, snapshot, and latched intent', () => {
     const h = makeHarness()
-    const sync: boolean[] = []
-    h.addon.onSyncActiveChange(active => { sync.push(active) })
+    const busy: boolean[] = []
+    h.addon.onBusyChange(value => { busy.push(value) })
     h.setBuffer(20, 20)
     h.userScroll(10)
     h.csi('?h', [2026])
     h.csi('J', [3])
     h.armIntent()
     h.addon.reset()
-    expect(h.addon.syncActive).toBe(false)
+    // An epoch reset drops the ESU chunk, so reset must reopen the fence
+    // itself or every later resize is starved for the session's lifetime.
     expect(h.addon.busy).toBe(false)
-    expect(sync).toEqual([true, false])
+    expect(busy).toEqual([true, false])
     h.outputScroll(8)
     expect(h.addon.mode).toBe('anchored')
     h.parsed()

--- a/packages/scroll-anchor/src/index.test.ts
+++ b/packages/scroll-anchor/src/index.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it, vi } from 'vitest'
+import { resolveScrollAnchor, ScrollAnchorAddon, type ScrollAnchorSnapshot } from './index.js'
+
+function buffer(lines: Array<string | null>, baseY: number, rows: number) {
+  return { baseY, rows, getLine: (y: number) => lines[y] ?? null }
+}
+
+describe('resolveScrollAnchor', () => {
+  const snap = (line: string | null, distanceFromBottom: number): ScrollAnchorSnapshot => ({ line, distanceFromBottom })
+
+  it('matches content across the whole buffer', () => {
+    const lines = Array<string | null>(30).fill(null)
+    lines[7] = 'recognizable line'
+    expect(resolveScrollAnchor(snap('recognizable line', 2), buffer(lines, 20, 10))).toBe(7)
+  })
+
+  it('tiebreaks repeated content by distance from bottom', () => {
+    const lines = Array<string | null>(30).fill(null)
+    lines[12] = lines[16] = lines[18] = 'session ready'
+    expect(resolveScrollAnchor(snap('session ready', 5), buffer(lines, 20, 10))).toBe(16)
+  })
+
+  it('maps a visible-region match to bottom', () => {
+    const lines = Array<string | null>(45).fill(null)
+    lines[20] = 'visible anchor'
+    expect(resolveScrollAnchor(snap('visible anchor', 5), buffer(lines, 5, 40))).toBe(5)
+  })
+
+  it('falls back to distance for null or missing anchors', () => {
+    expect(resolveScrollAnchor(snap(null, 3), buffer([], 20, 40))).toBe(17)
+    expect(resolveScrollAnchor(snap('gone', 3), buffer([], 20, 40))).toBe(17)
+  })
+
+  it('falls back to bottom when distance no longer fits', () => {
+    expect(resolveScrollAnchor(snap(null, 100), buffer([], 15, 40))).toBe(15)
+  })
+})
+
+function makeHarness() {
+  const element = new EventTarget()
+  const lines = new Map<number, string>()
+  const scrollListeners = new Set<() => void>()
+  const writeListeners = new Set<() => void>()
+  const csi = new Map<string, (params: Array<number | number[]>) => boolean>()
+  let viewportY = 0
+  let baseY = 0
+  let type: 'normal' | 'alternate' = 'normal'
+  const scrollToLine = vi.fn((line: number) => { viewportY = Math.max(0, Math.min(line, baseY)) })
+  const scrollToBottom = vi.fn(() => { viewportY = baseY })
+  const disposable = (set: Set<() => void>, cb: () => void) => ({ dispose: () => set.delete(cb) })
+  const active = {
+    get type() { return type },
+    get viewportY() { return viewportY },
+    get baseY() { return baseY },
+    getLine(y: number) {
+      const text = lines.get(y)
+      return text === undefined ? undefined : { translateToString: () => text }
+    },
+  }
+  const terminal = {
+    element,
+    rows: 10,
+    buffer: { active },
+    scrollToLine,
+    scrollToBottom,
+    onScroll(cb: () => void) { scrollListeners.add(cb); return disposable(scrollListeners, cb) },
+    onWriteParsed(cb: () => void) { writeListeners.add(cb); return disposable(writeListeners, cb) },
+    parser: {
+      registerCsiHandler(id: { prefix?: string, final: string }, cb: (params: Array<number | number[]>) => boolean) {
+        const key = `${id.prefix ?? ''}${id.final}`
+        csi.set(key, cb)
+        return { dispose: () => csi.delete(key) }
+      },
+    },
+  }
+  const addon = new ScrollAnchorAddon()
+  addon.activate(terminal as any)
+
+  return {
+    addon,
+    lines,
+    scrollToLine,
+    scrollToBottom,
+    setBuffer(vy: number, by: number) { viewportY = vy; baseY = by },
+    userScroll(line: number, event = 'wheel') {
+      element.dispatchEvent(new Event(event))
+      viewportY = Math.max(0, Math.min(line, baseY))
+      for (const cb of scrollListeners) cb()
+    },
+    outputScroll(line: number) {
+      viewportY = Math.max(0, Math.min(line, baseY))
+      for (const cb of scrollListeners) cb()
+    },
+    csi(key: string, params: Array<number | number[]>) { csi.get(key)?.(params) },
+    parsed() { for (const cb of writeListeners) cb() },
+    setAlternate(value: boolean) { type = value ? 'alternate' : 'normal' },
+  }
+}
+
+describe('ScrollAnchorAddon', () => {
+  it('keeps following across output and wipes', () => {
+    const h = makeHarness()
+    h.setBuffer(20, 20)
+    h.csi('?h', [2026])
+    h.setBuffer(0, 25)
+    h.csi('J', [3])
+    h.csi('?l', [[2026]])
+    h.parsed()
+    expect(h.addon.mode).toBe('following')
+    expect(h.scrollToBottom).toHaveBeenCalledTimes(1)
+  })
+
+  it('anchors when the user wheels up in an open block and never re-pins', () => {
+    const h = makeHarness()
+    h.setBuffer(20, 20)
+    h.csi('?h', [2026])
+    h.userScroll(12)
+    h.setBuffer(12, 25)
+    h.csi('?l', [2026])
+    h.parsed()
+    expect(h.addon.mode).toBe('anchored')
+    expect(h.scrollToBottom).not.toHaveBeenCalled()
+    expect(h.scrollToLine).not.toHaveBeenCalled()
+  })
+
+  it('does not revert a wheel between block close and write resolution', () => {
+    const h = makeHarness()
+    h.setBuffer(20, 20)
+    h.csi('?h', [2026])
+    h.csi('?l', [2026])
+    h.userScroll(11)
+    h.parsed()
+    expect(h.addon.mode).toBe('anchored')
+    expect(h.scrollToBottom).not.toHaveBeenCalled()
+  })
+
+  it('performs zero programmatic scrolls for anchored streaming without a wipe', () => {
+    const h = makeHarness()
+    h.setBuffer(20, 20)
+    h.userScroll(10)
+    h.setBuffer(10, 25)
+    h.outputScroll(10)
+    h.parsed()
+    expect(h.scrollToLine).not.toHaveBeenCalled()
+    expect(h.scrollToBottom).not.toHaveBeenCalled()
+  })
+
+  it('re-resolves a bare ED3 outside synchronized output', () => {
+    const h = makeHarness()
+    h.setBuffer(20, 20)
+    h.lines.set(15, 'anchor-worthy line')
+    h.userScroll(15)
+    h.csi('J', [3])
+    h.lines.clear()
+    h.lines.set(8, 'anchor-worthy line')
+    h.setBuffer(0, 12)
+    h.parsed()
+    expect(h.scrollToLine).toHaveBeenCalledWith(8)
+  })
+
+  it('uses distance after a wipe when the top line is trivial', () => {
+    const h = makeHarness()
+    h.setBuffer(17, 20)
+    h.lines.set(17, '---')
+    h.userScroll(17)
+    h.csi('J', [3])
+    h.setBuffer(0, 10)
+    h.parsed()
+    expect(h.scrollToLine).toHaveBeenCalledWith(7)
+  })
+
+  it('suspends transitions and enforcement in the alternate buffer', () => {
+    const h = makeHarness()
+    h.setBuffer(20, 20)
+    h.setAlternate(true)
+    h.userScroll(10)
+    h.setBuffer(0, 20)
+    h.parsed()
+    expect(h.addon.mode).toBe('following')
+    expect(h.scrollToBottom).not.toHaveBeenCalled()
+  })
+})

--- a/packages/scroll-anchor/src/index.test.ts
+++ b/packages/scroll-anchor/src/index.test.ts
@@ -251,6 +251,9 @@ describe('ScrollAnchorAddon', () => {
     h.setBuffer(20, 20)
     h.userScroll(10)
     h.csi('J', [3])
+    // Real ED3 transient: xterm briefly reports ydisp=0/ybase=0. Without the
+    // busy guard this looks structurally at-bottom and incorrectly follows.
+    h.setBuffer(0, 0)
     h.outputScroll(0)
     expect(h.addon.mode).toBe('anchored')
   })

--- a/packages/scroll-anchor/src/index.test.ts
+++ b/packages/scroll-anchor/src/index.test.ts
@@ -45,8 +45,15 @@ function makeHarness() {
   let viewportY = 0
   let baseY = 0
   let type: 'normal' | 'alternate' = 'normal'
-  const scrollToLine = vi.fn((line: number) => { viewportY = Math.max(0, Math.min(line, baseY)) })
-  const scrollToBottom = vi.fn(() => { viewportY = baseY })
+  const emitScroll = () => { for (const cb of scrollListeners) cb() }
+  const scrollToLine = vi.fn((line: number) => {
+    viewportY = Math.max(0, Math.min(line, baseY))
+    emitScroll()
+  })
+  const scrollToBottom = vi.fn(() => {
+    viewportY = baseY
+    emitScroll()
+  })
   const disposable = (set: Set<() => void>, cb: () => void) => ({ dispose: () => set.delete(cb) })
   const active = {
     get type() { return type },
@@ -82,18 +89,27 @@ function makeHarness() {
     scrollToLine,
     scrollToBottom,
     setBuffer(vy: number, by: number) { viewportY = vy; baseY = by },
+    armIntent(event = 'wheel') { element.dispatchEvent(new Event(event)) },
     userScroll(line: number, event = 'wheel') {
       element.dispatchEvent(new Event(event))
       viewportY = Math.max(0, Math.min(line, baseY))
-      for (const cb of scrollListeners) cb()
+      emitScroll()
+    },
+    async asyncUserScroll(line: number) {
+      element.dispatchEvent(new Event('wheel'))
+      viewportY = Math.max(0, Math.min(line, baseY))
+      await new Promise(resolve => setTimeout(resolve, 1))
+      emitScroll()
     },
     outputScroll(line: number) {
       viewportY = Math.max(0, Math.min(line, baseY))
-      for (const cb of scrollListeners) cb()
+      emitScroll()
     },
+    emitScroll,
     csi(key: string, params: Array<number | number[]>) { csi.get(key)?.(params) },
     parsed() { for (const cb of writeListeners) cb() },
     setAlternate(value: boolean) { type = value ? 'alternate' : 'normal' },
+    listenerCount() { return scrollListeners.size + writeListeners.size + csi.size },
   }
 }
 
@@ -178,5 +194,147 @@ describe('ScrollAnchorAddon', () => {
     h.parsed()
     expect(h.addon.mode).toBe('following')
     expect(h.scrollToBottom).not.toHaveBeenCalled()
+  })
+
+  it('keeps wheel intent latched until an asynchronous onScroll', async () => {
+    const h = makeHarness()
+    h.setBuffer(20, 20)
+    await h.asyncUserScroll(12)
+    expect(h.addon.mode).toBe('anchored')
+  })
+
+  it('follows structurally when a non-wheel scroll lands at bottom', () => {
+    const h = makeHarness()
+    h.setBuffer(20, 20)
+    h.userScroll(10)
+    expect(h.addon.mode).toBe('anchored')
+    h.outputScroll(20)
+    expect(h.addon.mode).toBe('following')
+  })
+
+  it('preserves a near-bottom user anchor', () => {
+    const h = makeHarness()
+    h.setBuffer(20, 20)
+    h.userScroll(18)
+    h.setBuffer(18, 25)
+    h.parsed()
+    expect(h.addon.mode).toBe('anchored')
+    expect(h.scrollToBottom).not.toHaveBeenCalled()
+    expect(h.scrollToLine).not.toHaveBeenCalled()
+  })
+
+  it('follow scrolls immediately and emits mode changes once', () => {
+    const h = makeHarness()
+    const modes: string[] = []
+    h.addon.onModeChange(mode => { modes.push(mode) })
+    h.setBuffer(20, 20)
+    h.userScroll(10)
+    h.addon.follow()
+    h.addon.follow()
+    expect(modes).toEqual(['anchored', 'following'])
+    expect(h.scrollToBottom).toHaveBeenCalledTimes(2)
+    expect(h.addon.mode).toBe('following')
+  })
+
+  it('treats repeated BSU as idempotent and one ESU closes it', () => {
+    const h = makeHarness()
+    const changes: boolean[] = []
+    h.addon.onSyncActiveChange(active => { changes.push(active) })
+    h.csi('?h', [2026])
+    h.csi('?h', [[2026]])
+    expect(h.addon.syncActive).toBe(true)
+    h.csi('?l', [2026])
+    h.csi('?l', [2026])
+    expect(h.addon.syncActive).toBe(false)
+    expect(changes).toEqual([true, false])
+  })
+
+  it('reset clears unmatched sync, wipe, snapshot, and latched intent', () => {
+    const h = makeHarness()
+    const sync: boolean[] = []
+    h.addon.onSyncActiveChange(active => { sync.push(active) })
+    h.setBuffer(20, 20)
+    h.userScroll(10)
+    h.csi('?h', [2026])
+    h.csi('J', [3])
+    h.armIntent()
+    h.addon.reset()
+    expect(h.addon.syncActive).toBe(false)
+    expect(h.addon.busy).toBe(false)
+    expect(sync).toEqual([true, false])
+    h.outputScroll(8)
+    expect(h.addon.mode).toBe('anchored')
+    h.parsed()
+    expect(h.scrollToLine).not.toHaveBeenCalled()
+  })
+
+  it('only treats ED3 when 3 is the first parameter', () => {
+    const h = makeHarness()
+    h.setBuffer(20, 20)
+    h.userScroll(10)
+    h.csi('J', [2, 3])
+    h.setBuffer(0, 10)
+    h.parsed()
+    expect(h.scrollToLine).not.toHaveBeenCalled()
+  })
+
+  it('keeps busy true through the wipe rAF and honors user bottom intent', () => {
+    let raf: FrameRequestCallback | null = null
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => { raf = callback; return 1 })
+    vi.stubGlobal('cancelAnimationFrame', () => { raf = null })
+    const h = makeHarness()
+    const busy: boolean[] = []
+    h.addon.onBusyChange(value => { busy.push(value) })
+    h.setBuffer(20, 20)
+    h.userScroll(10)
+    h.csi('J', [3])
+    h.setBuffer(0, 12)
+    h.parsed()
+    expect(h.addon.busy).toBe(true)
+    expect(busy).toEqual([true])
+    h.userScroll(12)
+    expect(h.addon.mode).toBe('following')
+    expect(h.addon.busy).toBe(false)
+    expect(raf).toBeNull()
+    expect(busy).toEqual([true, false])
+    vi.unstubAllGlobals()
+  })
+
+  it('emits busy false only after the wipe rendering catch-up', () => {
+    let raf: FrameRequestCallback | null = null
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => { raf = callback; return 1 })
+    const h = makeHarness()
+    const busy: boolean[] = []
+    h.addon.onBusyChange(value => { busy.push(value) })
+    h.setBuffer(20, 20)
+    h.userScroll(10)
+    h.csi('?h', [2026])
+    h.csi('J', [3])
+    h.setBuffer(0, 12)
+    h.csi('?l', [2026])
+    h.parsed()
+    expect(h.addon.busy).toBe(true)
+    expect(busy).toEqual([true])
+    raf?.(0)
+    expect(h.addon.busy).toBe(false)
+    expect(busy).toEqual([true, false])
+    vi.unstubAllGlobals()
+  })
+
+  it('dispose cancels pending work and removes listeners', () => {
+    let cancelled = false
+    vi.stubGlobal('requestAnimationFrame', () => 7)
+    vi.stubGlobal('cancelAnimationFrame', (id: number) => { cancelled = id === 7 })
+    const h = makeHarness()
+    h.setBuffer(20, 20)
+    h.userScroll(10)
+    h.csi('J', [3])
+    h.setBuffer(0, 12)
+    h.parsed()
+    expect(h.listenerCount()).toBeGreaterThan(0)
+    h.addon.dispose()
+    expect(cancelled).toBe(true)
+    expect(h.listenerCount()).toBe(0)
+    vi.unstubAllGlobals()
   })
 })

--- a/packages/scroll-anchor/src/index.ts
+++ b/packages/scroll-anchor/src/index.ts
@@ -1,0 +1,233 @@
+import type { IDisposable, IEvent, ITerminalAddon, Terminal } from '@xterm/xterm'
+
+export type ScrollAnchorMode = 'following' | 'anchored'
+
+export interface ScrollAnchorSnapshot {
+  line: string | null
+  distanceFromBottom: number
+}
+
+export interface ScrollAnchorOptions {
+  /** Filter for anchor-worthy lines. Default: trimmed length >= 4. */
+  isAnchorLine?: (text: string) => boolean
+}
+
+export interface ScrollAnchorBuffer {
+  baseY: number
+  rows: number
+  getLine(y: number): string | null
+}
+
+/** Resolve a pre-wipe snapshot against a post-wipe buffer. */
+export function resolveScrollAnchor(snapshot: ScrollAnchorSnapshot, buffer: ScrollAnchorBuffer): number {
+  if (snapshot.line !== null) {
+    let best: number | null = null
+    let bestDiff = Number.POSITIVE_INFINITY
+    for (let y = 0; y < buffer.baseY + buffer.rows; y++) {
+      if (buffer.getLine(y) !== snapshot.line) continue
+      const target = Math.min(y, buffer.baseY)
+      const diff = Math.abs(buffer.baseY - target - snapshot.distanceFromBottom)
+      if (diff < bestDiff) {
+        best = target
+        bestDiff = diff
+      }
+    }
+    if (best !== null) return best
+  }
+
+  return snapshot.distanceFromBottom <= buffer.baseY
+    ? buffer.baseY - snapshot.distanceFromBottom
+    : buffer.baseY
+}
+
+class EventEmitter<T> implements IDisposable {
+  private listeners = new Set<(value: T) => void>()
+  readonly event: IEvent<T> = (listener) => {
+    this.listeners.add(listener)
+    return { dispose: () => this.listeners.delete(listener) }
+  }
+
+  fire(value: T): void {
+    for (const listener of this.listeners) listener(value)
+  }
+
+  dispose(): void {
+    this.listeners.clear()
+  }
+}
+
+function hasParam(params: readonly (number | readonly number[])[], expected: number): boolean {
+  return params.some(value => Array.isArray(value) ? value.includes(expected) : value === expected)
+}
+
+/** Keeps an xterm viewport following output until wheel/touch intent anchors it. */
+export class ScrollAnchorAddon implements ITerminalAddon {
+  private terminal: Terminal | null = null
+  private disposables: IDisposable[] = []
+  private readonly modeEmitter = new EventEmitter<ScrollAnchorMode>()
+  private readonly syncEmitter = new EventEmitter<boolean>()
+  private currentMode: ScrollAnchorMode = 'following'
+  private snapshot: ScrollAnchorSnapshot = { line: null, distanceFromBottom: 0 }
+  private userIntent = false
+  private userIntentTimer: ReturnType<typeof setTimeout> | null = null
+  private wipePending = false
+  private wipeSyncRAF: number | null = null
+  private userScrollVersion = 0
+  private syncDepth = 0
+  private wasAlternate = false
+  private readonly isAnchorLine: (text: string) => boolean
+
+  readonly onModeChange: IEvent<ScrollAnchorMode> = this.modeEmitter.event
+  readonly onSyncActiveChange: IEvent<boolean> = this.syncEmitter.event
+
+  constructor(options: ScrollAnchorOptions = {}) {
+    this.isAnchorLine = options.isAnchorLine ?? (text => text.trim().length >= 4)
+  }
+
+  get mode(): ScrollAnchorMode { return this.currentMode }
+  get syncActive(): boolean { return this.syncDepth > 0 }
+
+  activate(terminal: Terminal): void {
+    if (this.terminal) throw new Error('ScrollAnchorAddon is already active')
+    this.terminal = terminal
+    this.wasAlternate = terminal.buffer.active.type === 'alternate'
+
+    const armUserIntent = () => {
+      if (this.isAlternate()) return
+      this.userIntent = true
+      if (this.userIntentTimer !== null) clearTimeout(this.userIntentTimer)
+      this.userIntentTimer = setTimeout(() => {
+        this.userIntent = false
+        this.userIntentTimer = null
+      }, 0)
+    }
+    terminal.element?.addEventListener('wheel', armUserIntent, { capture: true, passive: true })
+    terminal.element?.addEventListener('touchmove', armUserIntent, { capture: true, passive: true })
+    this.disposables.push({ dispose: () => {
+      terminal.element?.removeEventListener('wheel', armUserIntent, true)
+      terminal.element?.removeEventListener('touchmove', armUserIntent, true)
+    } })
+
+    this.disposables.push(terminal.onScroll(() => {
+      if (!this.userIntent || this.isAlternate()) return
+      this.userIntent = false
+      this.userScrollVersion++
+      if (this.userIntentTimer !== null) {
+        clearTimeout(this.userIntentTimer)
+        this.userIntentTimer = null
+      }
+      const buffer = terminal.buffer.active
+      if (buffer.viewportY < buffer.baseY) {
+        this.snapshot = this.captureSnapshot()
+        this.setMode('anchored')
+      } else {
+        this.setMode('following')
+      }
+    }))
+
+    const observeSync = (opening: boolean) => (params: any): boolean => {
+      if (!hasParam(params, 2026)) return false
+      const before = this.syncActive
+      this.syncDepth = opening ? this.syncDepth + 1 : Math.max(0, this.syncDepth - 1)
+      if (before !== this.syncActive) this.syncEmitter.fire(this.syncActive)
+      return false
+    }
+    this.disposables.push(terminal.parser.registerCsiHandler({ prefix: '?', final: 'h' }, observeSync(true)))
+    this.disposables.push(terminal.parser.registerCsiHandler({ prefix: '?', final: 'l' }, observeSync(false)))
+    this.disposables.push(terminal.parser.registerCsiHandler({ final: 'J' }, (params: any) => {
+      if (!hasParam(params, 3) || this.isAlternate() || this.currentMode !== 'anchored') return false
+      // ED3 runs after parser hooks and destroys line identity, so refresh now.
+      this.snapshot = this.captureSnapshot()
+      this.wipePending = true
+      return false
+    }))
+
+    this.disposables.push(terminal.onWriteParsed(() => this.afterWriteParsed()))
+  }
+
+  follow(): void {
+    this.setMode('following')
+    if (!this.terminal || this.isAlternate()) return
+    this.scrollToBottomWithoutAnimation(this.terminal)
+  }
+
+  dispose(): void {
+    for (const disposable of this.disposables.splice(0)) disposable.dispose()
+    if (this.userIntentTimer !== null) clearTimeout(this.userIntentTimer)
+    if (this.wipeSyncRAF !== null && typeof cancelAnimationFrame !== 'undefined') cancelAnimationFrame(this.wipeSyncRAF)
+    this.userIntentTimer = null
+    this.wipeSyncRAF = null
+    this.userIntent = false
+    this.terminal = null
+    this.modeEmitter.dispose()
+    this.syncEmitter.dispose()
+  }
+
+  private afterWriteParsed(): void {
+    const terminal = this.terminal
+    if (!terminal) return
+    const alternate = this.isAlternate()
+    if (alternate) {
+      this.wasAlternate = true
+      return
+    }
+    if (this.wasAlternate) this.wasAlternate = false
+
+    if (this.wipePending && !this.syncActive && this.currentMode === 'anchored') {
+      this.wipePending = false
+      const buffer = terminal.buffer.active
+      const target = resolveScrollAnchor(this.snapshot, {
+        baseY: buffer.baseY,
+        rows: terminal.rows,
+        getLine: y => buffer.getLine(y)?.translateToString(true) ?? null,
+      })
+      terminal.scrollToLine(target)
+      // The gmux xterm fork applies synchronized-output viewport DOM state
+      // after onWriteParsed. Repeat only if no newer user scroll occurred;
+      // this is a rendering catch-up, never permission to override intent.
+      if (typeof requestAnimationFrame !== 'undefined') {
+        const version = this.userScrollVersion
+        this.wipeSyncRAF = requestAnimationFrame(() => {
+          this.wipeSyncRAF = null
+          if (this.terminal === terminal && this.currentMode === 'anchored'
+            && this.userScrollVersion === version && !this.isAlternate()) {
+            terminal.scrollToLine(target)
+          }
+        })
+      }
+      return
+    }
+
+    if (this.currentMode === 'following') {
+      const buffer = terminal.buffer.active
+      if (buffer.viewportY < buffer.baseY) this.scrollToBottomWithoutAnimation(terminal)
+    }
+  }
+
+  private scrollToBottomWithoutAnimation(terminal: Terminal): void {
+    // gmux's xterm fork accepts this optional public behavior flag even though
+    // its generated declaration still exposes the upstream zero-arg shape.
+    ;(terminal.scrollToBottom as (disableSmoothScroll?: boolean) => void)(true)
+  }
+
+  private captureSnapshot(): ScrollAnchorSnapshot {
+    const terminal = this.terminal
+    if (!terminal) return { line: null, distanceFromBottom: 0 }
+    const buffer = terminal.buffer.active
+    const text = buffer.getLine(buffer.viewportY)?.translateToString(true) ?? null
+    return {
+      line: text !== null && this.isAnchorLine(text) ? text : null,
+      distanceFromBottom: Math.max(0, buffer.baseY - buffer.viewportY),
+    }
+  }
+
+  private isAlternate(): boolean {
+    return this.terminal?.buffer.active.type === 'alternate'
+  }
+
+  private setMode(mode: ScrollAnchorMode): void {
+    if (this.currentMode === mode) return
+    this.currentMode = mode
+    this.modeEmitter.fire(mode)
+  }
+}

--- a/packages/scroll-anchor/src/index.ts
+++ b/packages/scroll-anchor/src/index.ts
@@ -77,7 +77,8 @@ export class ScrollAnchorAddon implements ITerminalAddon {
   private currentMode: ScrollAnchorMode = 'following'
   private snapshot: ScrollAnchorSnapshot = { line: null, distanceFromBottom: 0 }
   private userIntent = false
-  private programmaticScroll = false
+  private userIntentExpiryRAF: number | null = null
+  private pendingProgrammaticScrolls = 0
   private wipePending = false
   private wipeSyncRAF: number | null = null
   private syncMode = false
@@ -101,7 +102,11 @@ export class ScrollAnchorAddon implements ITerminalAddon {
     this.terminal = terminal
 
     const armUserIntent = () => {
-      if (!this.isAlternate()) this.userIntent = true
+      if (this.isAlternate()) return
+      // Fresh input supersedes any addon scroll that produced no onScroll.
+      this.pendingProgrammaticScrolls = 0
+      this.userIntent = true
+      this.scheduleIntentExpiry()
     }
     terminal.element?.addEventListener('wheel', armUserIntent, { capture: true, passive: true })
     terminal.element?.addEventListener('touchmove', armUserIntent, { capture: true, passive: true })
@@ -133,7 +138,7 @@ export class ScrollAnchorAddon implements ITerminalAddon {
   }
 
   follow(): void {
-    this.userIntent = false
+    this.clearUserIntent()
     this.cancelWipeResolution()
     this.setMode('following')
     if (!this.terminal || this.isAlternate()) return
@@ -148,8 +153,8 @@ export class ScrollAnchorAddon implements ITerminalAddon {
     this.syncMode = false
     this.wipePending = false
     this.snapshot = { line: null, distanceFromBottom: 0 }
-    this.userIntent = false
-    this.programmaticScroll = false
+    this.clearUserIntent()
+    this.pendingProgrammaticScrolls = 0
     if (wasSyncActive) this.syncEmitter.fire(false)
     this.fireBusyChange(wasBusy)
   }
@@ -165,17 +170,24 @@ export class ScrollAnchorAddon implements ITerminalAddon {
 
   private handleScroll(): void {
     const terminal = this.terminal
-    if (!terminal || this.isAlternate() || this.programmaticScroll) return
+    if (!terminal || this.isAlternate()) return
     const buffer = terminal.buffer.active
 
+    if (this.pendingProgrammaticScrolls > 0) {
+      this.pendingProgrammaticScrolls--
+      this.clearUserIntent()
+      return
+    }
+
     if (this.userIntent) {
-      this.userIntent = false
+      this.clearUserIntent()
       // User intent always supersedes a pending post-wipe rendering catch-up.
       this.cancelWipeResolution()
       if (buffer.viewportY >= buffer.baseY) {
         this.setMode('following')
       } else {
-        this.snapshot = this.captureSnapshot()
+        // Anchor identity is captured immediately before ED3; ordinary
+        // streaming relies on xterm's native eviction-adjusted viewport.
         this.setMode('anchored')
       }
       return
@@ -184,11 +196,17 @@ export class ScrollAnchorAddon implements ITerminalAddon {
     // Bottom is structural follow intent for keyboard input, scrollbar drags,
     // and application settings such as scrollOnUserInput. During ED3 the
     // buffer transiently reports 0/0, so ignore that output-driven event while
-    // wipe re-resolution is fenced.
+    // wipe re-resolution is fenced. Other destructive resets (RIS or a
+    // scrollback-size change) intentionally have no identity snapshot and may
+    // therefore drop an anchored viewport into following mode.
     if (!this.busy && buffer.viewportY >= buffer.baseY) this.setMode('following')
   }
 
   private afterWriteParsed(): void {
+    // A write-driven scroll cannot belong to an earlier wheel/touch event or
+    // an addon scroll from a previous parse cycle.
+    this.clearUserIntent()
+    this.pendingProgrammaticScrolls = 0
     const terminal = this.terminal
     if (!terminal || this.isAlternate()) return
 
@@ -259,8 +277,35 @@ export class ScrollAnchorAddon implements ITerminalAddon {
   }
 
   private runProgrammaticScroll(action: () => void): void {
-    this.programmaticScroll = true
-    try { action() } finally { this.programmaticScroll = false }
+    // The fork can deliver the resulting onScroll on a later animation frame.
+    // Keep one suppression token per call until those events arrive.
+    this.pendingProgrammaticScrolls++
+    try {
+      action()
+    } catch (error) {
+      this.pendingProgrammaticScrolls--
+      throw error
+    }
+  }
+
+  private clearUserIntent(): void {
+    this.userIntent = false
+    if (this.userIntentExpiryRAF !== null && typeof cancelAnimationFrame !== 'undefined') {
+      cancelAnimationFrame(this.userIntentExpiryRAF)
+    }
+    this.userIntentExpiryRAF = null
+  }
+
+  private scheduleIntentExpiry(): void {
+    if (this.userIntentExpiryRAF !== null || typeof requestAnimationFrame === 'undefined') return
+    // Two frames cover xterm's first smooth-scroll tick without allowing a
+    // no-op wheel to arm unrelated SearchAddon/output scrolling indefinitely.
+    this.userIntentExpiryRAF = requestAnimationFrame(() => {
+      this.userIntentExpiryRAF = requestAnimationFrame(() => {
+        this.userIntentExpiryRAF = null
+        this.userIntent = false
+      })
+    })
   }
 
   private scrollToBottomWithoutAnimation(terminal: Terminal): void {

--- a/packages/scroll-anchor/src/index.ts
+++ b/packages/scroll-anchor/src/index.ts
@@ -72,7 +72,6 @@ export class ScrollAnchorAddon implements ITerminalAddon {
   private terminal: Terminal | null = null
   private disposables: IDisposable[] = []
   private readonly modeEmitter = new EventEmitter<ScrollAnchorMode>()
-  private readonly syncEmitter = new EventEmitter<boolean>()
   private readonly busyEmitter = new EventEmitter<boolean>()
   private currentMode: ScrollAnchorMode = 'following'
   private snapshot: ScrollAnchorSnapshot = { line: null, distanceFromBottom: 0 }
@@ -85,8 +84,12 @@ export class ScrollAnchorAddon implements ITerminalAddon {
   private readonly isAnchorLine: (text: string) => boolean
 
   readonly onModeChange: IEvent<ScrollAnchorMode> = this.modeEmitter.event
-  readonly onSyncActiveChange: IEvent<boolean> = this.syncEmitter.event
-  /** Fires for the combined sync/wipe fence used to defer terminal resizes. */
+  /**
+   * Fires for the fence a host must respect before resizing the terminal.
+   * Deliberately the only fence on the public API: it already covers DEC 2026
+   * and post-ED3 re-resolution, and exposing the narrower synchronized-output
+   * flag alongside it only invites hosts to pick the one that races.
+   */
   readonly onBusyChange: IEvent<boolean> = this.busyEmitter.event
 
   constructor(options: ScrollAnchorOptions = {}) {
@@ -94,7 +97,6 @@ export class ScrollAnchorAddon implements ITerminalAddon {
   }
 
   get mode(): ScrollAnchorMode { return this.currentMode }
-  get syncActive(): boolean { return this.syncMode }
   get busy(): boolean { return this.syncMode || this.wipePending || this.wipeSyncRAF !== null }
 
   activate(terminal: Terminal): void {
@@ -148,14 +150,12 @@ export class ScrollAnchorAddon implements ITerminalAddon {
   /** Clear parser/transient state at an epoch boundary without changing mode. */
   reset(): void {
     const wasBusy = this.busy
-    const wasSyncActive = this.syncMode
     this.cancelWipeRAF()
     this.syncMode = false
     this.wipePending = false
     this.snapshot = { line: null, distanceFromBottom: 0 }
     this.clearUserIntent()
     this.pendingProgrammaticScrolls = 0
-    if (wasSyncActive) this.syncEmitter.fire(false)
     this.fireBusyChange(wasBusy)
   }
 
@@ -164,7 +164,6 @@ export class ScrollAnchorAddon implements ITerminalAddon {
     for (const disposable of this.disposables.splice(0)) disposable.dispose()
     this.terminal = null
     this.modeEmitter.dispose()
-    this.syncEmitter.dispose()
     this.busyEmitter.dispose()
   }
 
@@ -210,7 +209,7 @@ export class ScrollAnchorAddon implements ITerminalAddon {
     const terminal = this.terminal
     if (!terminal || this.isAlternate()) return
 
-    if (this.wipePending && !this.syncActive) {
+    if (this.wipePending && !this.syncMode) {
       if (this.currentMode !== 'anchored') {
         const wasBusy = this.busy
         this.wipePending = false
@@ -252,10 +251,12 @@ export class ScrollAnchorAddon implements ITerminalAddon {
   }
 
   private setSyncActive(active: boolean): void {
-    if (this.syncMode === active) return
+    // A boolean, never a depth counter: xterm's mode set is idempotent, so a
+    // stream that opens DEC 2026 twice and closes it once has finished
+    // synchronized output. Counting depth leaves the fence latched and
+    // starves every later resize for the lifetime of the session.
     const wasBusy = this.busy
     this.syncMode = active
-    this.syncEmitter.fire(active)
     this.fireBusyChange(wasBusy)
   }
 

--- a/packages/scroll-anchor/src/index.ts
+++ b/packages/scroll-anchor/src/index.ts
@@ -144,7 +144,7 @@ export class ScrollAnchorAddon implements ITerminalAddon {
     this.cancelWipeResolution()
     this.setMode('following')
     if (!this.terminal || this.isAlternate()) return
-    this.runProgrammaticScroll(() => this.scrollToBottomWithoutAnimation(this.terminal!))
+    this.runProgrammaticScroll(() => this.terminal!.scrollToBottom())
   }
 
   /** Clear parser/transient state at an epoch boundary without changing mode. */
@@ -245,7 +245,7 @@ export class ScrollAnchorAddon implements ITerminalAddon {
     if (this.currentMode === 'following') {
       const buffer = terminal.buffer.active
       if (buffer.viewportY < buffer.baseY) {
-        this.runProgrammaticScroll(() => this.scrollToBottomWithoutAnimation(terminal))
+        this.runProgrammaticScroll(() => terminal.scrollToBottom())
       }
     }
   }
@@ -307,12 +307,6 @@ export class ScrollAnchorAddon implements ITerminalAddon {
         this.userIntent = false
       })
     })
-  }
-
-  private scrollToBottomWithoutAnimation(terminal: Terminal): void {
-    // gmux's xterm fork accepts this optional public behavior flag even though
-    // its generated declaration still exposes the upstream zero-arg shape.
-    ;(terminal.scrollToBottom as (disableSmoothScroll?: boolean) => void)(true)
   }
 
   private captureSnapshot(): ScrollAnchorSnapshot {

--- a/packages/scroll-anchor/src/index.ts
+++ b/packages/scroll-anchor/src/index.ts
@@ -18,6 +18,8 @@ export interface ScrollAnchorBuffer {
   getLine(y: number): string | null
 }
 
+type CsiParams = Array<number | number[]>
+
 /** Resolve a pre-wipe snapshot against a post-wipe buffer. */
 export function resolveScrollAnchor(snapshot: ScrollAnchorSnapshot, buffer: ScrollAnchorBuffer): number {
   if (snapshot.line !== null) {
@@ -56,8 +58,13 @@ class EventEmitter<T> implements IDisposable {
   }
 }
 
-function hasParam(params: readonly (number | readonly number[])[], expected: number): boolean {
+function containsParam(params: CsiParams, expected: number): boolean {
   return params.some(value => Array.isArray(value) ? value.includes(expected) : value === expected)
+}
+
+function firstParam(params: CsiParams): number {
+  const first = params[0] ?? 0
+  return Array.isArray(first) ? (first[0] ?? 0) : first
 }
 
 /** Keeps an xterm viewport following output until wheel/touch intent anchors it. */
@@ -66,40 +73,35 @@ export class ScrollAnchorAddon implements ITerminalAddon {
   private disposables: IDisposable[] = []
   private readonly modeEmitter = new EventEmitter<ScrollAnchorMode>()
   private readonly syncEmitter = new EventEmitter<boolean>()
+  private readonly busyEmitter = new EventEmitter<boolean>()
   private currentMode: ScrollAnchorMode = 'following'
   private snapshot: ScrollAnchorSnapshot = { line: null, distanceFromBottom: 0 }
   private userIntent = false
-  private userIntentTimer: ReturnType<typeof setTimeout> | null = null
+  private programmaticScroll = false
   private wipePending = false
   private wipeSyncRAF: number | null = null
-  private userScrollVersion = 0
-  private syncDepth = 0
-  private wasAlternate = false
+  private syncMode = false
   private readonly isAnchorLine: (text: string) => boolean
 
   readonly onModeChange: IEvent<ScrollAnchorMode> = this.modeEmitter.event
   readonly onSyncActiveChange: IEvent<boolean> = this.syncEmitter.event
+  /** Fires for the combined sync/wipe fence used to defer terminal resizes. */
+  readonly onBusyChange: IEvent<boolean> = this.busyEmitter.event
 
   constructor(options: ScrollAnchorOptions = {}) {
     this.isAnchorLine = options.isAnchorLine ?? (text => text.trim().length >= 4)
   }
 
   get mode(): ScrollAnchorMode { return this.currentMode }
-  get syncActive(): boolean { return this.syncDepth > 0 }
+  get syncActive(): boolean { return this.syncMode }
+  get busy(): boolean { return this.syncMode || this.wipePending || this.wipeSyncRAF !== null }
 
   activate(terminal: Terminal): void {
     if (this.terminal) throw new Error('ScrollAnchorAddon is already active')
     this.terminal = terminal
-    this.wasAlternate = terminal.buffer.active.type === 'alternate'
 
     const armUserIntent = () => {
-      if (this.isAlternate()) return
-      this.userIntent = true
-      if (this.userIntentTimer !== null) clearTimeout(this.userIntentTimer)
-      this.userIntentTimer = setTimeout(() => {
-        this.userIntent = false
-        this.userIntentTimer = null
-      }, 0)
+      if (!this.isAlternate()) this.userIntent = true
     }
     terminal.element?.addEventListener('wheel', armUserIntent, { capture: true, passive: true })
     terminal.element?.addEventListener('touchmove', armUserIntent, { capture: true, passive: true })
@@ -108,37 +110,22 @@ export class ScrollAnchorAddon implements ITerminalAddon {
       terminal.element?.removeEventListener('touchmove', armUserIntent, true)
     } })
 
-    this.disposables.push(terminal.onScroll(() => {
-      if (!this.userIntent || this.isAlternate()) return
-      this.userIntent = false
-      this.userScrollVersion++
-      if (this.userIntentTimer !== null) {
-        clearTimeout(this.userIntentTimer)
-        this.userIntentTimer = null
-      }
-      const buffer = terminal.buffer.active
-      if (buffer.viewportY < buffer.baseY) {
-        this.snapshot = this.captureSnapshot()
-        this.setMode('anchored')
-      } else {
-        this.setMode('following')
-      }
-    }))
+    this.disposables.push(terminal.onScroll(() => this.handleScroll()))
 
-    const observeSync = (opening: boolean) => (params: any): boolean => {
-      if (!hasParam(params, 2026)) return false
-      const before = this.syncActive
-      this.syncDepth = opening ? this.syncDepth + 1 : Math.max(0, this.syncDepth - 1)
-      if (before !== this.syncActive) this.syncEmitter.fire(this.syncActive)
+    const observeSync = (active: boolean) => (params: CsiParams): boolean => {
+      if (containsParam(params, 2026)) this.setSyncActive(active)
       return false
     }
     this.disposables.push(terminal.parser.registerCsiHandler({ prefix: '?', final: 'h' }, observeSync(true)))
     this.disposables.push(terminal.parser.registerCsiHandler({ prefix: '?', final: 'l' }, observeSync(false)))
-    this.disposables.push(terminal.parser.registerCsiHandler({ final: 'J' }, (params: any) => {
-      if (!hasParam(params, 3) || this.isAlternate() || this.currentMode !== 'anchored') return false
-      // ED3 runs after parser hooks and destroys line identity, so refresh now.
+    this.disposables.push(terminal.parser.registerCsiHandler({ final: 'J' }, (params: CsiParams) => {
+      if (firstParam(params) !== 3 || this.isAlternate() || this.currentMode !== 'anchored') return false
+      const wasBusy = this.busy
+      this.cancelWipeRAF()
+      // ED3 destroys line identity after parser hooks, so refresh beforehand.
       this.snapshot = this.captureSnapshot()
       this.wipePending = true
+      this.fireBusyChange(wasBusy)
       return false
     }))
 
@@ -146,62 +133,134 @@ export class ScrollAnchorAddon implements ITerminalAddon {
   }
 
   follow(): void {
+    this.userIntent = false
+    this.cancelWipeResolution()
     this.setMode('following')
     if (!this.terminal || this.isAlternate()) return
-    this.scrollToBottomWithoutAnimation(this.terminal)
+    this.runProgrammaticScroll(() => this.scrollToBottomWithoutAnimation(this.terminal!))
+  }
+
+  /** Clear parser/transient state at an epoch boundary without changing mode. */
+  reset(): void {
+    const wasBusy = this.busy
+    const wasSyncActive = this.syncMode
+    this.cancelWipeRAF()
+    this.syncMode = false
+    this.wipePending = false
+    this.snapshot = { line: null, distanceFromBottom: 0 }
+    this.userIntent = false
+    this.programmaticScroll = false
+    if (wasSyncActive) this.syncEmitter.fire(false)
+    this.fireBusyChange(wasBusy)
   }
 
   dispose(): void {
+    this.reset()
     for (const disposable of this.disposables.splice(0)) disposable.dispose()
-    if (this.userIntentTimer !== null) clearTimeout(this.userIntentTimer)
-    if (this.wipeSyncRAF !== null && typeof cancelAnimationFrame !== 'undefined') cancelAnimationFrame(this.wipeSyncRAF)
-    this.userIntentTimer = null
-    this.wipeSyncRAF = null
-    this.userIntent = false
     this.terminal = null
     this.modeEmitter.dispose()
     this.syncEmitter.dispose()
+    this.busyEmitter.dispose()
+  }
+
+  private handleScroll(): void {
+    const terminal = this.terminal
+    if (!terminal || this.isAlternate() || this.programmaticScroll) return
+    const buffer = terminal.buffer.active
+
+    if (this.userIntent) {
+      this.userIntent = false
+      // User intent always supersedes a pending post-wipe rendering catch-up.
+      this.cancelWipeResolution()
+      if (buffer.viewportY >= buffer.baseY) {
+        this.setMode('following')
+      } else {
+        this.snapshot = this.captureSnapshot()
+        this.setMode('anchored')
+      }
+      return
+    }
+
+    // Bottom is structural follow intent for keyboard input, scrollbar drags,
+    // and application settings such as scrollOnUserInput. During ED3 the
+    // buffer transiently reports 0/0, so ignore that output-driven event while
+    // wipe re-resolution is fenced.
+    if (!this.busy && buffer.viewportY >= buffer.baseY) this.setMode('following')
   }
 
   private afterWriteParsed(): void {
     const terminal = this.terminal
-    if (!terminal) return
-    const alternate = this.isAlternate()
-    if (alternate) {
-      this.wasAlternate = true
-      return
-    }
-    if (this.wasAlternate) this.wasAlternate = false
+    if (!terminal || this.isAlternate()) return
 
-    if (this.wipePending && !this.syncActive && this.currentMode === 'anchored') {
-      this.wipePending = false
+    if (this.wipePending && !this.syncActive) {
+      if (this.currentMode !== 'anchored') {
+        const wasBusy = this.busy
+        this.wipePending = false
+        this.fireBusyChange(wasBusy)
+        return
+      }
+
       const buffer = terminal.buffer.active
       const target = resolveScrollAnchor(this.snapshot, {
         baseY: buffer.baseY,
         rows: terminal.rows,
         getLine: y => buffer.getLine(y)?.translateToString(true) ?? null,
       })
-      terminal.scrollToLine(target)
-      // The gmux xterm fork applies synchronized-output viewport DOM state
-      // after onWriteParsed. Repeat only if no newer user scroll occurred;
-      // this is a rendering catch-up, never permission to override intent.
+      const wasBusy = this.busy
+      this.cancelWipeRAF()
+      this.wipePending = false
+      this.runProgrammaticScroll(() => terminal.scrollToLine(target))
+
+      // The gmux xterm fork applies synchronized-output viewport state after
+      // onWriteParsed. Keep the resize fence through one rendering catch-up.
       if (typeof requestAnimationFrame !== 'undefined') {
-        const version = this.userScrollVersion
         this.wipeSyncRAF = requestAnimationFrame(() => {
+          const wasRAFBusy = this.busy
+          this.runProgrammaticScroll(() => terminal.scrollToLine(target))
           this.wipeSyncRAF = null
-          if (this.terminal === terminal && this.currentMode === 'anchored'
-            && this.userScrollVersion === version && !this.isAlternate()) {
-            terminal.scrollToLine(target)
-          }
+          this.fireBusyChange(wasRAFBusy)
         })
       }
+      this.fireBusyChange(wasBusy)
       return
     }
 
     if (this.currentMode === 'following') {
       const buffer = terminal.buffer.active
-      if (buffer.viewportY < buffer.baseY) this.scrollToBottomWithoutAnimation(terminal)
+      if (buffer.viewportY < buffer.baseY) {
+        this.runProgrammaticScroll(() => this.scrollToBottomWithoutAnimation(terminal))
+      }
     }
+  }
+
+  private setSyncActive(active: boolean): void {
+    if (this.syncMode === active) return
+    const wasBusy = this.busy
+    this.syncMode = active
+    this.syncEmitter.fire(active)
+    this.fireBusyChange(wasBusy)
+  }
+
+  private cancelWipeResolution(): void {
+    const wasBusy = this.busy
+    this.cancelWipeRAF()
+    this.wipePending = false
+    this.fireBusyChange(wasBusy)
+  }
+
+  private cancelWipeRAF(): void {
+    if (this.wipeSyncRAF === null) return
+    if (typeof cancelAnimationFrame !== 'undefined') cancelAnimationFrame(this.wipeSyncRAF)
+    this.wipeSyncRAF = null
+  }
+
+  private fireBusyChange(previous: boolean): void {
+    if (previous !== this.busy) this.busyEmitter.fire(this.busy)
+  }
+
+  private runProgrammaticScroll(action: () => void): void {
+    this.programmaticScroll = true
+    try { action() } finally { this.programmaticScroll = false }
   }
 
   private scrollToBottomWithoutAnimation(terminal: Terminal): void {

--- a/packages/scroll-anchor/tsconfig.json
+++ b/packages/scroll-anchor/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,6 +122,18 @@ importers:
         specifier: ^3.0.7
         version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(tsx@4.21.0)
 
+  packages/scroll-anchor:
+    devDependencies:
+      '@xterm/xterm':
+        specifier: github:gmuxapp/xterm.js#v6.1.0-beta.288-gmux.5
+        version: https://codeload.github.com/gmuxapp/xterm.js/tar.gz/baeffe1f08c007e194c842b0f913665a48643c19
+      typescript:
+        specifier: ^5.8.2
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.7
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(tsx@4.21.0)
+
 packages:
 
   '@antfu/install-pkg@1.1.0':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       '@gmux/protocol':
         specifier: workspace:*
         version: link:../../packages/protocol
+      '@gmux/scroll-anchor':
+        specifier: workspace:*
+        version: link:../../packages/scroll-anchor
       '@preact/signals':
         specifier: ^2.9.0
         version: 2.9.0(preact@10.29.0)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -19,8 +19,10 @@ mkdir -p "$BIN"
 # ── Frontend ──
 
 if [ "$skip_frontend" = false ]; then
+  echo "→ Building frontend packages…"
+  pnpm -C "$ROOT/packages/scroll-anchor" build
   echo "→ Building frontend…"
-  (cd "$ROOT/apps/gmux-web" && npx vite build)
+  pnpm -C "$ROOT/apps/gmux-web" exec vite build
 
   # Copy dist into the go:embed directory
   rm -rf "$WEB_EMBED/assets" "$WEB_EMBED/favicon.svg" "$WEB_EMBED/manifest.json"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -19,8 +19,6 @@ mkdir -p "$BIN"
 # ── Frontend ──
 
 if [ "$skip_frontend" = false ]; then
-  echo "→ Building frontend packages…"
-  pnpm -C "$ROOT/packages/scroll-anchor" build
   echo "→ Building frontend…"
   pnpm -C "$ROOT/apps/gmux-web" exec vite build
 


### PR DESCRIPTION
## Problem

Mouse-wheel scrolling during streaming agent output was nearly unusable: wheel-up notches were undone (viewport yanked back to bottom), movement was absorbed mid-stream, and `\x1b[3J` outside a BSU/ESU block jumped the viewport to the top and pinned it there.

An evidence-first investigation (real disposable daemon, real Chromium, real PTY bursts, mutation probes) traced all symptoms to the snapshot/restore scroll-preservation layer in `terminal-io.ts`: stale `wasAtBottom`/`adjustedY` snapshots raced against user wheel input in the BSU→ESU→rAF windows. At ~30 blocks/s, 25 wheel-up notches produced **net downward** movement (-41 lines); with only the restore calls no-op'd, identical load gave normal scrolling (+76). Pre-existing since v2.0.0 (`a1a190b6`, `f0f0fd90`).

## Change

Replace snapshot/restore with an explicit mode state machine in a new standalone xterm addon, **`@gmux/scroll-anchor`** (`packages/scroll-anchor`, public xterm API only — designed for eventual publication/upstreaming):

- `following` (pinned to bottom) | `anchored` (user is reading; snapshot = line identity + distance)
- Only user intent (wheel/touch, latched until its scroll arrives, correlated via onWriteParsed expiry) transitions the mode; output never moves the viewport except through mode re-resolution
- DEC 2026 (BSU/ESU) and ED3 observed via parser hooks (pre-mutation anchor capture), not byte scanning
- Anchored + streaming ⇒ **zero programmatic scrolls** (xterm holds position natively); anchored + wipe ⇒ pure `resolveScrollAnchor` (content match → distance → bottom, same policy as before)
- `busy` fence drives resize deferral; `reset()` wired to session/epoch boundaries; alt-buffer suspended

gmux-web: `terminal-io.ts` loses all scroll logic (~290 lines) and keeps write serialization + resize deferral; End button / replay / reconnect route through `follow()`/`reset()`. Reconnect no longer yanks a scrolled-up reader on failed attempts.

## Verification

- 28 addon unit tests incl. mutation-hardened regressions (mid-block wheel-up, async intent, own-scroll suppression, transient-wipe follow guard, ED3 `params[0]`, sync latch/reset)
- New real-daemon e2e: `terminal-wheel.spec.ts` (30 Hz BSU bursts + real wheel, absolute-movement assertions), bare-ED3, reconnect-while-scrolled; full suite **94/94**
- 748 gmux-web unit tests, biome+tsc, cold `moon run :build`
- Review swarm: 3 independent reviewers (broad, xterm-races, test-quality/mutation-matrix), 3 fix rounds; final mutation matrix 13/14 killed (survivor mitigated with load-bearing comment)

## Known accepted limitations (documented in package README)

- `smoothScrollDuration > 0` (non-default): output parsed between a wheel event and its first animation frame can still eat that notch
- Scrollbar/keyboard arrival at bottom during a wipe-resolution fence doesn't enter following (wheel/touch does)
- Keyboard-scrollback intent not captured (v1 gap)

Follow-ups tracked: stalled-BSU watchdog, hidden-tab rAF fence, fork PR exposing scroll source on `onScroll`, upstream ED3 `isUserScrolling` bug report, package extraction/publication.