### PR TITLE
fix(web): replay initial checkpoint before viewport claim

### DIFF
--- a/apps/gmux-web/src/terminal-input.test.ts
+++ b/apps/gmux-web/src/terminal-input.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from 'vitest'
+import { canSendTerminalInput, type TerminalInputConnection } from './terminal-input'
+
+function connection(sessionId = 'session', readyState = 1): TerminalInputConnection {
+  return { sessionId, ws: { readyState } }
+}
+
+describe('canSendTerminalInput', () => {
+  test('drops input while the initial claim is fenced', () => {
+    const current = connection()
+    expect(canSendTerminalInput(false, current, current, 'session')).toBe(false)
+  })
+
+  test('allows input for the claimed current open connection', () => {
+    const current = connection()
+    expect(canSendTerminalInput(true, current, current, 'session')).toBe(true)
+  })
+
+  test('drops a capability holding a stale connection identity', () => {
+    const stale = connection()
+    const current = connection()
+    expect(canSendTerminalInput(true, current, stale, 'session')).toBe(false)
+  })
+
+  test('drops input for a closed socket', () => {
+    const current = connection('session', 3)
+    expect(canSendTerminalInput(true, current, current, 'session')).toBe(false)
+  })
+})

--- a/apps/gmux-web/src/terminal-input.ts
+++ b/apps/gmux-web/src/terminal-input.ts
@@ -1,0 +1,18 @@
+export interface TerminalInputConnection {
+  readonly sessionId: string
+  readonly ws: { readonly readyState: number }
+}
+
+/** Shared send-time gate for every terminal user-byte capability. */
+export function canSendTerminalInput(
+  inputClaimed: boolean,
+  currentConnection: TerminalInputConnection | null,
+  expectedConnection: TerminalInputConnection | null,
+  currentSessionId: string,
+): boolean {
+  return inputClaimed
+    && currentConnection !== null
+    && currentConnection === expectedConnection
+    && currentConnection.sessionId === currentSessionId
+    && currentConnection.ws.readyState === 1 // WebSocket.OPEN
+}

--- a/apps/gmux-web/src/terminal-io.test.ts
+++ b/apps/gmux-web/src/terminal-io.test.ts
@@ -85,13 +85,20 @@ describe('createTerminalIO', () => {
     expect(h.resizes).toEqual([{ cols: 80, rows: 24 }])
   })
 
-  it('runs completion after the final enqueueMany chunk', () => {
+  it('applies enqueueResizeThenMany before writes and completes after its final chunk', () => {
     const h = makeHarness()
     const done = vi.fn()
+    const resized = vi.fn()
     h.io.reset(1)
-    h.io.enqueueMany([enc('a'), enc('b'), enc('c')], 1, done)
+    h.io.enqueueResizeThenMany({ cols: 80, rows: 25 }, [enc('a'), enc('b'), enc('c')], 1, done, resized)
+    // A later coalescible request cannot overwrite the ordered barrier.
+    h.io.requestResize({ cols: 114, rows: 44 }, 1)
+    expect(h.resizes).toEqual([{ cols: 80, rows: 25 }])
+    expect(resized).toHaveBeenCalledTimes(1)
+    expect(h.writes).toEqual(['a'])
     h.flushAll()
     expect(h.writes).toEqual(['a', 'b', 'c'])
+    expect(h.resizes).toEqual([{ cols: 80, rows: 25 }, { cols: 114, rows: 44 }])
     expect(done).toHaveBeenCalledTimes(1)
   })
 

--- a/apps/gmux-web/src/terminal-io.ts
+++ b/apps/gmux-web/src/terminal-io.ts
@@ -8,11 +8,9 @@ export interface TerminalSize {
   rows: number
 }
 
-interface QueueItem {
-  epoch: number
-  data: Uint8Array
-  onWritten?: () => void
-}
+type QueueItem =
+  | { epoch: number, kind: 'write', data: Uint8Array, onWritten?: () => void }
+  | { epoch: number, kind: 'resize', size: TerminalSize, onApplied?: () => void }
 
 export interface TerminalIOOptions {
   /** Current synchronized-output/wipe-resolution fence owned by the addon. */
@@ -23,6 +21,8 @@ export interface TerminalIO {
   reset(epoch: number): void
   enqueue(data: Uint8Array, epoch: number, onWritten?: () => void): void
   enqueueMany(chunks: Uint8Array[], epoch: number, onWritten?: () => void): void
+  /** Queue an ordered resize barrier immediately before these writes. */
+  enqueueResizeThenMany(size: TerminalSize, chunks: Uint8Array[], epoch: number, onWritten?: () => void, onResized?: () => void): void
   requestResize(size: TerminalSize, epoch: number): void
   /** Reconsider a resize after the addon's combined busy fence changes. */
   busyStateChanged(): void
@@ -50,8 +50,17 @@ export function createTerminalIO(term: TerminalWriter, options: TerminalIOOption
     if (writeInFlight) return
     dropStaleFront()
 
-    const next = queue.shift()
-    if (next) {
+    const next = queue[0]
+    if (next?.kind === 'resize') {
+      if (options.isBusy?.()) return
+      queue.shift()
+      term.resize(next.size.cols, next.size.rows)
+      if (next.epoch === currentEpoch) next.onApplied?.()
+      pump()
+      return
+    }
+    if (next?.kind === 'write') {
+      queue.shift()
       writeInFlight = true
       term.write(next.data, () => {
         writeInFlight = false
@@ -79,14 +88,23 @@ export function createTerminalIO(term: TerminalWriter, options: TerminalIOOption
 
     enqueue(data: Uint8Array, epoch: number, onWritten?: () => void) {
       if (epoch !== currentEpoch) return
-      queue.push({ epoch, data, onWritten })
+      queue.push({ epoch, kind: 'write', data, onWritten })
       pump()
     },
 
     enqueueMany(chunks: Uint8Array[], epoch: number, onWritten?: () => void) {
       if (epoch !== currentEpoch || chunks.length === 0) return
       for (let i = 0; i < chunks.length; i++) {
-        queue.push({ epoch, data: chunks[i], onWritten: i === chunks.length - 1 ? onWritten : undefined })
+        queue.push({ epoch, kind: 'write', data: chunks[i], onWritten: i === chunks.length - 1 ? onWritten : undefined })
+      }
+      pump()
+    },
+
+    enqueueResizeThenMany(size: TerminalSize, chunks: Uint8Array[], epoch: number, onWritten?: () => void, onResized?: () => void) {
+      if (epoch !== currentEpoch) return
+      queue.push({ epoch, kind: 'resize', size, onApplied: onResized })
+      for (let i = 0; i < chunks.length; i++) {
+        queue.push({ epoch, kind: 'write', data: chunks[i], onWritten: i === chunks.length - 1 ? onWritten : undefined })
       }
       pump()
     },

--- a/apps/gmux-web/src/terminal-resize.test.ts
+++ b/apps/gmux-web/src/terminal-resize.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, test } from 'vitest'
-import { decideViewportResize, sameSize } from './terminal-resize'
+import { decideViewportResize, sameSize, shouldQueueResizeEcho } from './terminal-resize'
 
 describe('sameSize', () => {
-  test('matches identical sizes', () => {
-    expect(sameSize({ cols: 80, rows: 24 }, { cols: 80, rows: 24 })).toBe(true)
+  test('matches identical sizes and suppresses an echo already applied by a claim barrier', () => {
+    const claim = { cols: 80, rows: 24 }
+    expect(sameSize(claim, { cols: 80, rows: 24 })).toBe(true)
+    expect(shouldQueueResizeEcho({ cols: 80, rows: 24 }, claim)).toBe(false)
+    expect(shouldQueueResizeEcho({ cols: 81, rows: 24 }, claim)).toBe(true)
+    expect(shouldQueueResizeEcho(claim, null)).toBe(true)
   })
 
   test('rejects nulls and mismatches', () => {

--- a/apps/gmux-web/src/terminal-resize.ts
+++ b/apps/gmux-web/src/terminal-resize.ts
@@ -4,6 +4,11 @@ export function sameSize(a: TerminalSize | null, b: TerminalSize | null): boolea
   return a != null && b != null && a.cols === b.cols && a.rows === b.rows
 }
 
+/** A claim barrier already applied its matching echo to xterm. */
+export function shouldQueueResizeEcho(applied: TerminalSize, barrierClaim: TerminalSize | null): boolean {
+  return !sameSize(applied, barrierClaim)
+}
+
 /**
  * Decide how a viewport change should affect terminal sizing.
  *

--- a/apps/gmux-web/src/terminal.tsx
+++ b/apps/gmux-web/src/terminal.tsx
@@ -16,9 +16,10 @@ import { BSU, createReplayBuffer, ESU, startsWith } from './replay'
 import type { ResolvedTerminalOptions } from './settings-schema'
 import { terminalFindOpen, terminalScrolledUp, terminalScrollToBottom } from './store'
 import { TerminalFindBar } from './terminal-find'
+import { canSendTerminalInput } from './terminal-input'
 import { createTerminalIO, type TerminalSize } from './terminal-io'
 import { type LinkInfo, linkAtPoint, openLinkAtPoint } from './terminal-link'
-import { decideViewportResize, sameSize } from './terminal-resize'
+import { decideViewportResize, sameSize, shouldQueueResizeEcho } from './terminal-resize'
 import { pressedBufferRow, readTerminalText } from './terminal-text'
 import { TerminalTextSheet } from './terminal-text-sheet'
 import { pushError } from './toasts'
@@ -358,6 +359,8 @@ export function TerminalView({
   const scrollAnchorRef = useRef<ScrollAnchorAddon | null>(null)
   const searchAddonRef = useRef<SearchAddon | null>(null)
   const termEpochRef = useRef(0)
+  // Drop initial-attach input until replay and viewport claim commit.
+  const inputClaimedRef = useRef(false)
 
   // True once the terminal's font is downloaded; gates xterm mount.
   // See the preload effect below for why this matters.
@@ -380,6 +383,9 @@ export function TerminalView({
   // must not trigger effect re-runs but need current values.
   const viewportSizeRef = useRef<TerminalSize | null>(null)
   const ptySizeRef = useRef<TerminalSize | null>(null)
+  // A claim resize is a FIFO barrier rather than a pending resize. Its echo
+  // releases ownership gating but must not resize xterm a second time.
+  const barrierClaimResizeRef = useRef<TerminalSize | null>(null)
   const resizeEchoGateRef = useRef<{
     awaitingEcho: TerminalSize | null
     dirty: boolean
@@ -412,6 +418,7 @@ export function TerminalView({
     const gate = resizeEchoGateRef.current
     if (gate.timer !== null) clearTimeout(gate.timer)
     gate.awaitingEcho = null
+    barrierClaimResizeRef.current = null
     gate.dirty = false
     gate.timer = null
   }, [])
@@ -422,6 +429,7 @@ export function TerminalView({
 
     if (gate.timer !== null) clearTimeout(gate.timer)
     gate.awaitingEcho = null
+    if (sameSize(barrierClaimResizeRef.current, applied)) barrierClaimResizeRef.current = null
     gate.timer = null
 
     if (!gate.dirty) return
@@ -429,14 +437,14 @@ export function TerminalView({
     processViewportResizeRef.current?.(true)
   }, [])
 
-  const applyOwnedResize = useCallback((size: TerminalSize) => {
+  const applyOwnedResize = useCallback((size: TerminalSize, queueTerminalResize = true) => {
     const prevPty = ptySizeRef.current
 
     // Optimistically sync ptySize so the pill hides immediately, before the
     // server echoes the resize back. Without this, ptySize would lag behind
     // viewportSize for one round-trip, causing a spurious pill flash.
     setPtySize(size); ptySizeRef.current = size
-    queueResize(size)
+    if (queueTerminalResize) queueResize(size)
 
     if (sameSize(prevPty, size)) return
 
@@ -507,6 +515,18 @@ export function TerminalView({
     if (!dims) return
 
     applyOwnedResize(dims)
+  }, [applyOwnedResize])
+
+  // Announce ownership without occupying TerminalIO's coalescible resize
+  // slot. Initial attach queues this size as a FIFO barrier before held output.
+  const announceViewportClaim = useCallback((): TerminalSize | null => {
+    const term = termRef.current
+    const shell = shellRef.current
+    if (!term || !shell) return null
+    const dims = measureTerminalFit(term, shell)
+    setViewportSize(dims); viewportSizeRef.current = dims
+    applyOwnedResize(dims, false)
+    return dims
   }, [applyOwnedResize])
 
   const focusTerminal = useCallback(() => {
@@ -633,13 +653,12 @@ export function TerminalView({
       const bin = atob(b64)
       const bytes = new Uint8Array(bin.length)
       for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i)
-      termIoRef.current?.enqueue(bytes, termEpochRef.current)
+      termIoRef.current?.enqueue(bytes, termEpochRef.current, () => setTermLoading(false))
     }
 
     const sendRawInput = (data: string) => {
       const connection = connectionRef.current
-      if (!connection || connection.sessionId !== currentSessionId.current
-          || connection.ws.readyState !== WebSocket.OPEN) return
+      if (!canSendTerminalInput(inputClaimedRef.current, connectionRef.current, connection, currentSessionId.current)) return
       // Only re-assert focus if the terminal already had it (keyboard
       // open). Grabbing focus unconditionally would pop the on-screen
       // keyboard on every toolbar key, even when it was closed — the
@@ -669,15 +688,12 @@ export function TerminalView({
     }
     const getPasteDestination = (): PasteDestination | null => {
       const connection = connectionRef.current
-      if (!connection || connection.sessionId !== currentSessionId.current
-          || connection.ws.readyState !== WebSocket.OPEN) return null
+      if (!canSendTerminalInput(inputClaimedRef.current, connectionRef.current, connection, currentSessionId.current)) return null
       return {
         sessionId: connection.sessionId,
         bracketedPasteMode: term.modes.bracketedPasteMode,
         send(text) {
-          if (connectionRef.current !== connection
-              || currentSessionId.current !== connection.sessionId
-              || connection.ws.readyState !== WebSocket.OPEN) return false
+          if (!canSendTerminalInput(inputClaimedRef.current, connectionRef.current, connection, currentSessionId.current)) return false
           connection.ws.send(new TextEncoder().encode(text))
           return true
         },
@@ -980,6 +996,7 @@ export function TerminalView({
     termEpochRef.current = epoch
     termIoRef.current.reset(epoch)
     scrollAnchorRef.current?.reset()
+    inputClaimedRef.current = false
 
     const sessionChanged = terminalSessionId.current !== null
       && terminalSessionId.current !== session.id
@@ -1016,12 +1033,65 @@ export function TerminalView({
       // staged; the existing screen remains visible during failed attempts.
       let checkpointAlt: boolean | null = null
       let checkpointMargins: CheckpointMargins | null = null
+      // Keep post-checkpoint bytes out of TerminalIO until the initial replay
+      // has committed and xterm has claimed the browser geometry.
+      let attachPhase: 'replay' | 'claiming' | 'claimed' = isFirstConnect ? 'replay' : 'claimed'
+      const postClaimWrites: Uint8Array[] = []
+      let claimFallbackTimer: ReturnType<typeof setTimeout> | null = null
+      const finishPostClaimWrite = () => {
+        if (claimFallbackTimer !== null) clearTimeout(claimFallbackTimer)
+        claimFallbackTimer = null
+        setTermLoading(false)
+      }
       const replay = createReplayBuffer((chunks) => {
         const prepared = prepareBrowserCheckpoint(chunks, checkpointAlt, checkpointMargins)
-        queueMany(prepared, () => {
+        const claiming = attachPhase === 'replay'
+        if (claiming) attachPhase = 'claiming'
+        // Newly launched sessions can reach the WS before their first SSE
+        // dimensions. The runner's pre-resize default is 80 columns; sessions
+        // with an established geometry carry it in session/resize metadata.
+        const cols = sessionRef.current.terminal_cols ?? ptySizeRef.current?.cols ?? 80
+        const rows = checkpointMargins?.rows
+        const checkpointSize = claiming && cols && rows ? { cols, rows } : null
+        const onReplayed = () => {
+          if (connectionRef.current !== connection || termEpochRef.current !== epoch) return
           scrollAnchorRef.current?.follow()
-          setTermLoading(false)
-        })
+          if (!claiming) {
+            setTermLoading(false)
+            return
+          }
+
+          isFirstConnect = false
+          const claimSize = announceViewportClaim()
+          if (!claimSize) return
+          barrierClaimResizeRef.current = claimSize
+          const onClaimResized = () => {
+            if (connectionRef.current !== connection || termEpochRef.current !== epoch) return
+            attachPhase = 'claimed'
+            inputClaimedRef.current = true
+            claimFallbackTimer = setTimeout(() => {
+              if (connectionRef.current !== connection || termEpochRef.current !== epoch) return
+              claimFallbackTimer = null
+              setTermLoading(false)
+            }, 500)
+            // Include bytes that arrived while the resize barrier was waiting
+            // on the addon's busy fence.
+            const heldWrites = postClaimWrites.splice(0)
+            for (let i = 0; i < heldWrites.length; i++) {
+              queueData(heldWrites[i], i === heldWrites.length - 1 ? finishPostClaimWrite : undefined)
+            }
+          }
+          // Claim geometry is a second FIFO barrier. Held live bytes cannot
+          // parse at checkpoint geometry, and input opens only when it applies.
+          termIoRef.current?.enqueueResizeThenMany(claimSize, [], epoch, undefined, onClaimResized)
+        }
+        if (checkpointSize) {
+          // This ordered barrier resizes xterm before the first checkpoint
+          // byte; a later viewport claim cannot overwrite it.
+          termIoRef.current?.enqueueResizeThenMany(checkpointSize, prepared, epoch, onReplayed)
+        } else {
+          queueMany(prepared, onReplayed)
+        }
       })
 
       const wsProtocol = location.protocol === 'https:' ? 'wss:' : 'ws:'
@@ -1035,30 +1105,22 @@ export function TerminalView({
         attempt = 0
         setWsState('open')
 
-        if (!isFirstConnect) {
-          // Reconnect: re-sync ptySize from session metadata in case a
-          // terminal_resize WS event was missed during the drop. Session
-          // metadata is updated via SSE independently, so it may be
-          // fresher than our cached ptySize after a network blip.
-          resetResizeEchoGate()
-          const sess = sessionRef.current
-          if (sess.terminal_cols && sess.terminal_rows) {
-            const cached = ptySizeRef.current
-            if (!cached || cached.cols !== sess.terminal_cols || cached.rows !== sess.terminal_rows) {
-              const size = { cols: sess.terminal_cols, rows: sess.terminal_rows }
-              setPtySize(size); ptySizeRef.current = size
-              queueResize(size)
-            }
-          }
-          return
-        }
-        isFirstConnect = false
+        if (isFirstConnect) return
+        inputClaimedRef.current = true
 
-        // First connect for this session: claim ownership by fitting the PTY
-        // to our viewport. fitAndResize measures, sets viewport+pty
-        // optimistically, and sends the resize over this ws (connectionRef was set
-        // above).
-        fitAndResize()
+        // Reconnect: re-sync ptySize from session metadata in case a
+        // terminal_resize WS event was missed during the drop. Reconnects
+        // deliberately never reclaim the viewport.
+        resetResizeEchoGate()
+        const sess = sessionRef.current
+        if (sess.terminal_cols && sess.terminal_rows) {
+          const cached = ptySizeRef.current
+          if (!cached || cached.cols !== sess.terminal_cols || cached.rows !== sess.terminal_rows) {
+            const size = { cols: sess.terminal_cols, rows: sess.terminal_rows }
+            setPtySize(size); ptySizeRef.current = size
+            queueResize(size)
+          }
+        }
       }
 
       ws.onmessage = (ev) => {
@@ -1096,7 +1158,7 @@ export function TerminalView({
               if (cols && rows) {
                 const size = { cols, rows }
                 setPtySize(size); ptySizeRef.current = size
-                queueResize(size)
+                if (shouldQueueResizeEcho(size, barrierClaimResizeRef.current)) queueResize(size)
                 releaseResizeEchoGate(size)
               }
               return
@@ -1110,7 +1172,8 @@ export function TerminalView({
             replay.push(data)
             return
           }
-          queueData(data, () => setTermLoading(false))
+          if (attachPhase === 'claiming') postClaimWrites.push(data)
+          else queueData(data, attachPhase === 'claimed' ? finishPostClaimWrite : () => setTermLoading(false))
           return
         }
 
@@ -1123,7 +1186,8 @@ export function TerminalView({
           return
         }
 
-        queueData(data, () => setTermLoading(false))
+        if (attachPhase === 'claiming') postClaimWrites.push(data)
+        else queueData(data, attachPhase === 'claimed' ? finishPostClaimWrite : () => setTermLoading(false))
       }
 
       ws.onclose = () => {
@@ -1135,6 +1199,8 @@ export function TerminalView({
         const isCurrent = connectionRef.current === connection
         setWsState(prev => wsStateOnClose(prev, isCurrent))
         if (!isCurrent) return
+        if (claimFallbackTimer !== null) clearTimeout(claimFallbackTimer)
+        claimFallbackTimer = null
         resetResizeEchoGate()
         if (disposed.current || intentionalClose) return
         if (currentSessionId.current !== session.id) return
@@ -1153,6 +1219,7 @@ export function TerminalView({
 
     return () => {
       intentionalClose = true
+      inputClaimedRef.current = false
       termEpochRef.current = epoch + 1
       termIoRef.current?.reset(termEpochRef.current)
       scrollAnchorRef.current?.reset()
@@ -1162,7 +1229,7 @@ export function TerminalView({
       connectionRef.current?.ws.close()
       connectionRef.current = null
     }
-  }, [fitAndResize, queueData, queueMany, queueResize, releaseResizeEchoGate, resetResizeEchoGate, session.id, fontReady])
+  }, [announceViewportClaim, queueData, queueMany, queueResize, releaseResizeEchoGate, resetResizeEchoGate, session.id, fontReady])
 
   // Pill is purely derived from size mismatch. No "driving" flag: we claim
   // on every fresh session select (first ws.onopen), and fitAndResize sets

--- a/e2e/tests/initial-checkpoint-geometry.spec.ts
+++ b/e2e/tests/initial-checkpoint-geometry.spec.ts
@@ -1,0 +1,145 @@
+import { test, expect, type Page } from '@playwright/test'
+import { openApp, gotoSession } from '../helpers'
+
+async function installAttachProbe(page: Page, checkpointDelay = 200) {
+  await page.addInitScript((delay) => {
+    ;(window as any).__checkpointRows = null
+    ;(window as any).__attachEvents = [] as Array<Record<string, unknown>>
+    ;(window as any).__inputSends = [] as string[]
+    const Native = window.WebSocket
+    const Wrapped = function (...args: ConstructorParameters<typeof WebSocket>) {
+      const ws = new Native(...args)
+      let productionHandler: ((this: WebSocket, ev: MessageEvent) => unknown) | null = null
+      Object.defineProperty(ws, 'onmessage', {
+        configurable: true,
+        get: () => productionHandler,
+        set: handler => { productionHandler = handler },
+      })
+      ws.addEventListener('message', event => {
+        if (typeof event.data === 'string') {
+          try {
+            const message = JSON.parse(event.data)
+            if (message.type === 'terminal_checkpoint') (window as any).__checkpointRows = message.rows
+          } catch {}
+        }
+        // Hold the binary checkpoint long enough to install xterm probes and
+        // deterministically attempt input during the replay phase.
+        setTimeout(() => productionHandler?.call(ws, event), typeof event.data === 'string' ? 0 : delay)
+      })
+      const nativeSend = ws.send.bind(ws)
+      ws.send = ((data: string | ArrayBufferLike | Blob | ArrayBufferView) => {
+        if (ArrayBuffer.isView(data)) {
+          ;(window as any).__inputSends.push(new TextDecoder().decode(data as ArrayBufferView<ArrayBuffer>).toString())
+        }
+        nativeSend(data as never)
+      }) as typeof ws.send
+      return ws
+    } as unknown as typeof WebSocket
+    Object.assign(Wrapped, Native)
+    Wrapped.prototype = Native.prototype
+    ;(window as any).WebSocket = Wrapped
+
+    const probe = setInterval(() => {
+      const term = (window as any).__gmuxTerm
+      if (!term || (term as any).__attachProbeInstalled) return
+      ;(term as any).__attachProbeInstalled = true
+      const resize = term.resize.bind(term)
+      term.resize = (cols: number, rows: number) => {
+        ;(window as any).__attachEvents.push({ kind: 'resize', cols, rows, at: performance.now() })
+        resize(cols, rows)
+      }
+      const write = term.write.bind(term)
+      term.write = (data: string | Uint8Array, callback?: () => void) => {
+        const text = typeof data === 'string' ? data : new TextDecoder().decode(data)
+        const status = /STATUS ROWS=(\d+) COLS=(\d+)/.exec(text)
+        const liveRedraw = status !== null && Number(status[1]) > 25
+          && Number(status[1]) === term.rows && Number(status[2]) === term.cols
+        ;(window as any).__attachEvents.push({ kind: 'write', cols: term.cols, rows: term.rows,
+          liveRedraw, at: performance.now() })
+        write(data, callback)
+      }
+      clearInterval(probe)
+    }, 1)
+  }, checkpointDelay)
+}
+
+async function launchRowsProgram(page: Page, suppressWinch: boolean) {
+  await openApp(page)
+  const cwd = process.env.GMUX_TEST_WORKSPACE!
+  const marker = suppressWinch ? 'CASE-SUPPRESSED' : 'CASE-CONVERGES'
+  const draw = `draw() { read -r rows cols < <(stty size); frame=$( { printf '\\033[2J\\033[H'; for i in $(seq 1 $((rows-1))); do printf '\\033[%d;1HROW-%03d' "$i" "$i"; done; printf '\\033[1;10H${marker}'; printf '\\033[%d;1HSTATUS ROWS=%d COLS=%d' "$rows" "$rows" "$cols"; } ); printf '%s' "$frame"; }`
+  const command = suppressWinch
+    ? `stty -echo; ${draw}; draw; trap '' WINCH; while :; do sleep 1; done`
+    : `stty -echo; ${draw}; draw; last_rows=$rows; last_cols=$cols; while :; do read -r now_rows now_cols < <(stty size); if [ "$now_rows:$now_cols" != "$last_rows:$last_cols" ]; then draw; break; fi; sleep 0.05; done; while :; do sleep 1; done`
+  const launched = await page.evaluate(async ({ command, cwd }) => {
+    const r = await fetch('/v1/launch', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ command: ['bash', '-c', command], cwd }) })
+    return { ok: r.ok, text: await r.text() }
+  }, { command, cwd })
+  expect(launched.ok, launched.text).toBe(true)
+  const link = page.locator('a').filter({ hasText: marker }).first()
+  await link.waitFor({ state: 'visible', timeout: 10_000 })
+  const id = (await link.getAttribute('href'))!.split('~').pop()!
+  await gotoSession(page, id)
+}
+
+function terminalState() {
+  const t = (window as any).__gmuxTerm
+  const lines = Array.from({ length: t.rows }, (_, i) => t.buffer.active.getLine(i)?.translateToString(true) ?? '') as string[]
+  const statusRow = lines.findIndex(line => line.includes('STATUS ROWS='))
+  return { checkpointRows: (window as any).__checkpointRows as number, termRows: t.rows as number, termCols: t.cols as number,
+    statusRow, blankTail: lines.slice(statusRow + 1).filter(line => line === '').length, bottom: lines.at(-1),
+    loading: document.querySelector('.terminal-loading') !== null }
+}
+
+test('checkpoint geometry and input are fenced before viewport claim', async ({ page }) => {
+  await installAttachProbe(page, 3000)
+  await launchRowsProgram(page, true)
+  await page.locator('.xterm-helper-textarea').focus()
+  // Prove the delayed binary has not reached production before exercising
+  // the input fence; otherwise these assertions would be post-claim vacuous.
+  expect(await page.evaluate(() => (window as any).__attachEvents)).toEqual([])
+  await page.keyboard.type('X')
+  await expect.poll(() => page.evaluate(() => (window as any).__attachEvents.length)).toBeGreaterThan(1)
+  await expect.poll(() => page.evaluate(terminalState)).toMatchObject({ checkpointRows: 25, statusRow: 24 })
+  await page.waitForTimeout(100)
+
+  const evidence = await page.evaluate(() => ({ events: (window as any).__attachEvents, sends: (window as any).__inputSends }))
+  const checkpointWrite = evidence.events.find((event: any) => event.kind === 'write') as any
+  const checkpointResize = evidence.events.findIndex((event: any) => event.kind === 'resize' && event.cols === 80 && event.rows === 25)
+  const writeIndex = evidence.events.indexOf(checkpointWrite)
+  const claimResize = evidence.events.findIndex((event: any, i: number) => i > writeIndex && event.kind === 'resize' && event.rows > 25)
+  expect(checkpointResize, JSON.stringify(evidence.events)).toBeGreaterThanOrEqual(0)
+  expect(checkpointResize).toBeLessThan(writeIndex)
+  expect(checkpointWrite).toMatchObject({ cols: 80, rows: 25 })
+  expect(claimResize).toBeGreaterThan(writeIndex)
+  expect(evidence.sends).not.toContain('X')
+
+  // A non-redrawing child is released by the bounded fallback, rather than
+  // leaving an input-fenced loading screen forever. Input is accepted only
+  // after the local claim has committed.
+  await expect(page.locator('.terminal-loading')).not.toBeVisible({ timeout: 2_000 })
+  await page.keyboard.type('Y')
+  await expect.poll(() => page.evaluate(() => (window as any).__inputSends)).toContain('Y')
+})
+
+test('real post-claim redraw parses only after the claim resize', async ({ page }) => {
+  await installAttachProbe(page)
+  await launchRowsProgram(page, false)
+  await expect.poll(() => page.evaluate(terminalState), { timeout: 10_000 }).toMatchObject({ loading: false, blankTail: 0 })
+  const observed = await page.evaluate(terminalState)
+  expect(observed.bottom).toBe(`STATUS ROWS=${observed.termRows} COLS=${observed.termCols}`)
+  expect(observed.statusRow).toBe(observed.termRows - 1)
+
+  const events = await page.evaluate(() => (window as any).__attachEvents) as Array<any>
+  const checkpointResize = events.findIndex(event => event.kind === 'resize' && event.cols === 80 && event.rows === 25)
+  const checkpointWrite = events.findIndex(event => event.kind === 'write' && event.cols === 80 && event.rows === 25)
+  const claimResize = events.findIndex(event => event.kind === 'resize' && event.cols === observed.termCols && event.rows === observed.termRows)
+  const liveWrite = events.findIndex(event => event.kind === 'write' && event.liveRedraw === true)
+  expect(checkpointResize).toBeGreaterThanOrEqual(0)
+  expect(checkpointResize).toBeLessThan(checkpointWrite)
+  expect(claimResize).toBeGreaterThan(checkpointWrite)
+  expect(liveWrite).toBeGreaterThan(claimResize)
+  // Busy-fence claim ordering itself is pinned deterministically by the
+  // enqueueResizeThenMany unit test; this E2E uses only the real child's
+  // WINCH redraw and proves production checkpoint/claim/live sequencing.
+})


### PR DESCRIPTION
## Problem

On first browser attach, `TerminalView` claimed the viewport (`fitAndResize`) from `ws.onopen` before the runner's checkpoint replayed. The runner snapshots its emulator at the old PTY geometry (e.g. 80x25) before processing the browser resize, so the checkpoint rendered into an already-resized xterm (e.g. 114x44), leaving real blank buffer rows below the last checkpoint line until the child app happened to redraw. Slow-redrawing TUIs (or any child ignoring WINCH) showed a broken bottom region indefinitely. This is also why `shrinkForReconnect`'s redraw nudge was unreliable.

Deterministically reproduced with a WINCH-suppressed child: checkpoint 25 rows into a 44-row xterm → 19 genuinely blank rows (verified via buffer contents, not screenshots).

## Fix: replay-then-claim

- First connection: checkpoint replays behind an ordered TerminalIO resize barrier at checkpoint geometry, then a second barrier claims the browser viewport; held live bytes are admitted only after the claim resize applies.
- User input (keyboard, toolbar, paste, uploads) is fenced by a shared `canSendTerminalInput` predicate until the claim commits.
- A resize echo matching the barrier-applied claim size no longer queues a duplicate resize.
- Loading overlay clears on the first post-claim committed write, with a 500ms bounded fallback for children that never redraw.
- Reconnects keep the no-reclaim contract; all callbacks epoch/connection-fenced.

## Testing

- New real-daemon E2E `initial-checkpoint-geometry.spec.ts`: asserts checkpoint-resize-before-checkpoint-bytes and claim-resize-before-live-write ordering; fails on revert.
- New unit coverage: TerminalIO FIFO resize barrier, echo-after-barrier suppression, input gate predicate.
- vitest 752/752; full Playwright suite 96/96 (rebased on #500).
- Five rounds of independent adversarial review; all findings resolved.