### PR TITLE
feat(web): show process lifecycle on the $, and settle the family rows

### DIFF
--- a/apps/gmux-web/src/family-drawer.tsx
+++ b/apps/gmux-web/src/family-drawer.tsx
@@ -49,10 +49,11 @@ function FamilyRow({ node, selectedId, depth, expanded, view, now, onToggle }: {
         href={hrefFor(session)}
         aria-current={session.id === selectedId ? 'page' : undefined}
       >
-        {/* `$` is process identity, always cyan. Agent attention never
-          * recolors it; lifecycle is structural in the processes view. */}
+        {/* `$` is process identity; its one state is lifecycle — lit
+          * while running, dimmed when finished. Agent attention never
+          * recolors it. */}
         {process
-          ? <span class="family-proc" aria-hidden="true">$</span>
+          ? <span class={`family-proc${isRunningProcess(session) ? '' : ' done'}`} aria-hidden="true">$</span>
           : <span class={`session-dot-indicator ${dot}`} aria-hidden="true" />}
         <span class="family-row-title">{session.title}</span>
         {/* Levels are ordered by this timestamp, so it has to be on
@@ -294,7 +295,7 @@ function ProcessRow({ entry, selectedId, now }: {
         href={hrefFor(session)}
         aria-current={session.id === selectedId ? 'page' : undefined}
       >
-        <span class="family-proc" aria-hidden="true">$</span>
+        <span class={`family-proc${isRunningProcess(session) ? '' : ' done'}`} aria-hidden="true">$</span>
         <span class="family-row-title">{session.title}</span>
         <span class="family-process-parent">{parent.title}</span>
         <span class="family-row-age">{formatAge(session.last_output_at ?? session.created_at, now)}</span>

--- a/apps/gmux-web/src/family.test.ts
+++ b/apps/gmux-web/src/family.test.ts
@@ -326,10 +326,16 @@ describe('member row glyph', () => {
     id: 'k', cwd: '/p', title: 'kid', semantic_agent: true, parent_session_id: 'root', ...over,
   })
 
-  it('gives a process one stable $ in every state', () => {
+  it('gives a process one stable $ in every state, carrying lifecycle', () => {
     // Shape alone says “process”; agent attention never recolors it.
-    expect(familyMemberGlyph(proc(), 'none')).toEqual({ kind: 'process' })
-    expect(familyMemberGlyph(proc(), 'working')).toEqual({ kind: 'process' })
+    // The one fact the $ does carry is lifecycle: running or not.
+    expect(familyMemberGlyph(proc(), 'none')).toEqual({ kind: 'process', running: false })
+    expect(familyMemberGlyph(proc(), 'working')).toEqual({ kind: 'process', running: false })
+    expect(familyMemberGlyph(proc({ status: { active: true } }), 'none'))
+      .toEqual({ kind: 'process', running: true })
+    // Dead is never running, whatever the last status said.
+    expect(familyMemberGlyph(proc({ status: { active: true }, alive: false }), 'none'))
+      .toEqual({ kind: 'process', running: false })
   })
 
   it('keeps a named agent\'s attention on its dot', () => {
@@ -337,8 +343,8 @@ describe('member row glyph', () => {
       const glyph = familyMemberGlyph(kid(), state)
       expect(glyph).toEqual({ kind: 'dot', state })
     }
-    expect(familyMemberGlyph(proc({ unread: true }), 'unread')).toEqual({ kind: 'process' })
-    expect(familyMemberGlyph(proc({ status: { error: true } }), 'error')).toEqual({ kind: 'process' })
+    expect(familyMemberGlyph(proc({ unread: true }), 'unread')).toEqual({ kind: 'process', running: false })
+    expect(familyMemberGlyph(proc({ status: { error: true } }), 'error')).toEqual({ kind: 'process', running: false })
   })
 
   it('falls back to the branch only for an agent with nothing to say', () => {

--- a/apps/gmux-web/src/family.ts
+++ b/apps/gmux-web/src/family.ts
@@ -263,14 +263,16 @@ function byRecency(a: Session, b: Session): number {
 
 /** What the member row's glyph column shows. Agent state lives on its
  * dot; `$` is stable process identity and is never recolored as agent
- * attention. An agent with nothing to report falls back to the branch. */
+ * attention — but it does carry the one process fact, lifecycle:
+ * running is lit, finished is dimmed. An agent with nothing to report
+ * shows nothing. */
 export type MemberGlyph =
-  | { readonly kind: 'process' }
+  | { readonly kind: 'process'; readonly running: boolean }
   | { readonly kind: 'dot'; readonly state: Exclude<DotState, 'none'> }
   | { readonly kind: 'branch' }
 
 export function familyMemberGlyph(member: Session, dot: DotState): MemberGlyph {
-  if (isProcessSession(member)) return { kind: 'process' }
+  if (isProcessSession(member)) return { kind: 'process', running: isRunningProcess(member) }
   return dot === 'none' ? { kind: 'branch' } : { kind: 'dot', state: dot }
 }
 

--- a/apps/gmux-web/src/sidebar.tsx
+++ b/apps/gmux-web/src/sidebar.tsx
@@ -412,17 +412,16 @@ function FamilyEntry({
               title={slotTrail}
               onClick={() => onClick?.()}
             >
-              {/* One fixed-width glyph column, always filled: the member's
-                * status, its `$` if it's a process, or the branch arrow when
-                * there's nothing to report. The arrow is what a quiet member
-                * looks like — it marks the row as hanging off the root, and
-                * it keeps the title from sliding sideways when state
-                * arrives or clears. */}
+              {/* One fixed-width glyph column: the member's status, or
+                * its `$` if it's a process. A quiet member shows nothing —
+                * the family button beside the row already says it hangs
+                * off the root, and a filler arrow next to that icon read
+                * as a second, mysterious control. */}
               {glyph?.kind === 'process'
-                ? <span class="family-glyph family-proc" aria-hidden="true">$</span>
+                ? <span class={`family-glyph family-proc${glyph.running ? '' : ' done'}`} aria-hidden="true">$</span>
                 : glyph?.kind === 'dot'
                 ? <span class={`family-glyph session-dot-indicator ${glyph.state}`} aria-hidden="true" />
-                : <span class="family-glyph family-branch" aria-hidden="true">↳</span>}
+                : null}
               <span class="family-slot-title">{member.title}</span>
             </a>
           )}

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -221,14 +221,13 @@ body {
   color: var(--text);
 }
 .sidebar-view-btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
-/* Touch: put the switch above the logo/header row so both pieces of
- * sidebar navigation stay together. Flex order avoids moving the node;
- * the larger targets and safe-area padding are mobile-only. */
+/* Touch: the header row (logo) docks to the bottom for thumb reach
+ * (order 3, further down), so the switch slots in right above it —
+ * both pieces of sidebar navigation stay together, inside the same
+ * reach. Flex order avoids moving the node; the larger targets are
+ * mobile-only. */
 @media (pointer: coarse) {
-  .sidebar-view-toggle {
-    order: -1;
-    padding: calc(6px + env(safe-area-inset-top, 0px)) 8px 4px;
-  }
+  .sidebar-view-toggle { order: 2; }
   .sidebar-view-btn { min-height: 34px; font-size: 13px; }
 }
 
@@ -1137,6 +1136,11 @@ body {
   align-items: center;
   gap: 2px;
   min-width: 0;
+  /* Tucked up under the root: without this the row sits as far from
+     its own root as from the next entry below, and the family reads
+     as two unrelated rows. The pull-up eats into the root row's
+     bottom padding (whitespace, not content). */
+  margin-top: -4px;
   padding: 1px 8px 3px calc(var(--family-indent) - var(--family-btn-pad));
 }
 
@@ -1146,13 +1150,6 @@ body {
   flex: 0 0 7px;
   width: 7px;
   text-align: center;
-}
-/* What a quiet member looks like: no state to report, so the column
-   shows the branch instead. */
-.family-branch {
-  color: var(--text-muted);
-  font-size: 10px;
-  line-height: 1;
 }
 /* The activity line's own glyph: the family mark, same as the header's
    trigger. Slightly larger than the 7px glyph column and centered on
@@ -1277,9 +1274,11 @@ body {
   gap: 5px;
   flex: 0 0 auto;
 }
-/* The `$`: process identity, always cyan on a process itself. Agent
-   attention and command exit status never recolor it; running versus
-   finished is expressed by summaries and the process view's sections.
+/* The `$`: process identity. Its one state is lifecycle — a running
+   process is lit cyan and set bold, a finished one dims to muted at
+   regular weight, the same filled-versus-faded language as the status
+   dots but in ink. Agent attention and command exit status never
+   recolor it.
 
    Vocabulary only: no box. The sidebar pairs it with `.family-glyph`,
    which owns the fixed column there, and repeating those properties
@@ -1289,7 +1288,12 @@ body {
   font-family: 'Fira Code', monospace;
   font-size: 11px;
   line-height: 1;
+  font-weight: 600;
   color: var(--accent);
+}
+.family-proc.done {
+  font-weight: 400;
+  color: var(--text-muted);
 }
 /* The panel has no glyph-column class of its own, so it gives the `$`
    the same box its status dots occupy. */

--- a/apps/gmux-web/src/terminal-input.ts
+++ b/apps/gmux-web/src/terminal-input.ts
@@ -9,7 +9,10 @@ export function canSendTerminalInput(
   currentConnection: TerminalInputConnection | null,
   expectedConnection: TerminalInputConnection | null,
   currentSessionId: string,
-): boolean {
+  // A type predicate, not just a boolean: passing means the expected
+  // connection is the current one and the current one is non-null, so
+  // callers can use their captured connection without re-checking.
+): expectedConnection is TerminalInputConnection {
   return inputClaimed
     && currentConnection !== null
     && currentConnection === expectedConnection

--- a/apps/gmux-web/src/terminal.tsx
+++ b/apps/gmux-web/src/terminal.tsx
@@ -525,6 +525,7 @@ export function TerminalView({
     if (!term || !shell) return null
     const dims = measureTerminalFit(term, shell)
     setViewportSize(dims); viewportSizeRef.current = dims
+    if (!dims) return null
     applyOwnedResize(dims, false)
     return dims
   }, [applyOwnedResize])

--- a/e2e/tests/family-entry-interaction.spec.ts
+++ b/e2e/tests/family-entry-interaction.spec.ts
@@ -438,8 +438,11 @@ test.describe('the family line and the panel tally', () => {
     await expect(page.locator('.family-process-section h3')).toHaveText(['Running · 1', 'Finished · 1'])
     const glyphs = page.locator('.family-process-list .family-proc')
     await expect(glyphs).toHaveCount(2)
+    // The $ never changes shape between rows, but it does carry the one
+    // process fact: the running row's glyph is lit, the finished row's is
+    // dimmed — two lifecycles, two tones.
     const colors = await glyphs.evaluateAll(nodes => nodes.map(node => getComputedStyle(node).color))
-    expect(new Set(colors).size, 'every process row uses one identity colour').toBe(1)
+    expect(new Set(colors).size, 'running and finished use distinct tones').toBe(2)
   })
 
   test('agent-state filters do not pin the selected process into their rows', async ({ page }) => {
@@ -472,9 +475,11 @@ test.describe('the family line and the panel tally', () => {
     await page.locator('.family-trigger').click()
     const control = page.locator('.family-count').filter({ hasText: 'processes' })
     await expect(control).toHaveAccessibleName('Processes')
+    // Nothing runs here, so every $ in sight is quiet: the history control
+    // and the finished rows share the same dimmed tone.
     const processColor = await control.locator('.family-proc').evaluate(node => getComputedStyle(node).color)
     const rowColor = await page.locator('.family-row.process .family-proc').first().evaluate(node => getComputedStyle(node).color)
-    expect(processColor, 'the history control is quiet').not.toBe(rowColor)
+    expect(processColor, 'finished history is uniformly quiet').toBe(rowColor)
     await control.click()
     await expect(page.locator('.family-process-section h3')).toHaveText(['Finished · 28'])
     const list = page.locator('.family-process-list')

--- a/services/gmuxd/tools/production-e2e.Dockerfile
+++ b/services/gmuxd/tools/production-e2e.Dockerfile
@@ -2,6 +2,9 @@ FROM golang:1.26-bookworm
 WORKDIR /src
 COPY go.work go.work.sum ./
 COPY packages ./packages
+# packages/scrollback and cli/gmux replace charmbracelet/x/vt with this
+# vendored copy; without it every `go build` in the image dangles.
+COPY third_party ./third_party
 COPY cli/gmux ./cli/gmux
 COPY services/gmuxd ./services/gmuxd
 RUN cd services/gmuxd && go build -trimpath -o /opt/gmuxd ./cmd/gmuxd \


### PR DESCRIPTION
Sidebar/panel tweaks plus a CI repair, two commits:

**feat(web): show process lifecycle on the `$`, and settle the family rows**
- The `$` now carries the one process fact, lifecycle: running is cyan and bold, finished dims to muted at regular weight — the status dots' filled-versus-faded language, in ink. `familyMemberGlyph` derives it once so the member slot, panel tree and process view agree; summaries already counted only running processes.
- A quiet member row drops the `↳` filler: the family button beside it already says it hangs off the root, and a second glyph next to that icon read as a mysterious extra control.
- The subordinate row tucks up under its root (−4px): it used to sit as far from its own root as from the next entry below, which made the family read as two unrelated rows. The pull-up eats only the root row's bottom padding, so row heights and the no-layout-shift guarantee hold.
- Docks the mobile Projects/Activity toggle where it belongs: the sidebar header sits at the *bottom* on touch (thumb reach), so the toggle slots in right above the gmux logo instead of floating alone at the top.

**fix(web): repair the terminal type errors shipped to main**
`canSendTerminalInput` soundly implies the caller's captured connection is current and non-null, so it becomes a type predicate; `announceViewportClaim` declines an unmeasurable viewport before applying the resize (the guard `fitAndResize` already had). Fixes the four tsc errors breaking the Lint/build/test CI job on main since #501.