### PR TITLE
docs: pin 2.1 interface stability boundaries from the release audit

### DIFF
--- a/apps/gmux-web/src/family-drawer.tsx
+++ b/apps/gmux-web/src/family-drawer.tsx
@@ -455,8 +455,9 @@ export function FamilyDrawer({ selected, onClose, triggerRef }: {
     return () => { cancelAnimationFrame(outer); cancelAnimationFrame(inner) }
   }, [selected.id])
 
-  // Promotion intentionally defers provenance: promoted sessions present as
-  // roots even though parent_session_id remains immutable on the wire.
+  // Promotion is structural: promote clears parent_session_id on the wire,
+  // so promoted sessions are roots here by that edge alone. The immutable
+  // launched_from_session_id keeps the provenance “Return to family” uses.
   const projection = projectFamily(selected, sessions.value)
   const stateFilter = filter === 'processes' ? null : filter
   // Structural agent ancestors remain context under a state filter, but a

--- a/apps/gmux-web/src/terminal-checkpoint.test.ts
+++ b/apps/gmux-web/src/terminal-checkpoint.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest'
+import { BSU, ESU } from './replay'
+import { CHECKPOINT_WIRE_RESET, prepareBrowserCheckpoint } from './terminal-checkpoint'
+
+const encoder = new TextEncoder()
+const decoder = new TextDecoder()
+
+const SGR_RESET = '\x1b[0m'
+const WIRE_RESET = decoder.decode(CHECKPOINT_WIRE_RESET)
+const bsu = decoder.decode(BSU)
+const esu = decoder.decode(ESU)
+
+/** Build a runner-shaped shared attach frame: BSU + reset + repaint + CUP + DECTCEM + ESU. */
+function sharedFrame(repaint: string, cursor = '\x1b[5;7H', visibility = '\x1b[?25h'): Uint8Array {
+  return encoder.encode(bsu + WIRE_RESET + repaint + cursor + visibility + esu)
+}
+
+function prepare(frame: Uint8Array, alt: boolean | null, margins: { top: number, bottom: number, rows: number } | null): string {
+  const out = prepareBrowserCheckpoint([frame], alt, margins)
+  expect(out).toHaveLength(1)
+  return decoder.decode(out[0])
+}
+
+describe('prepareBrowserCheckpoint version skew', () => {
+  // An older runner never sends the `terminal_checkpoint` metadata frame, so
+  // the browser learns neither the active buffer nor the margins. The
+  // checkpoint must stay non-destructive: SGR reset prepended, nothing else
+  // invented (no ?1049 buffer switch, no DECSTBM).
+  it('falls back non-destructively when no checkpoint metadata arrived', () => {
+    const frame = sharedFrame('hello')
+    const prepared = prepare(frame, null, null)
+    expect(prepared).toBe(SGR_RESET + decoder.decode(frame))
+    expect(prepared).not.toContain('\x1b[?1049')
+  })
+
+  it('treats metadata without margins as a legacy checkpoint', () => {
+    const frame = sharedFrame('hello')
+    const prepared = prepare(frame, false, null)
+    expect(prepared).toBe(SGR_RESET + decoder.decode(frame))
+  })
+
+  it('rejects invalid margins and keeps the legacy fallback', () => {
+    const frame = sharedFrame('hello')
+    for (const margins of [
+      { top: 0, bottom: 24, rows: 24 }, // top below DECSTBM's 1-based floor
+      { top: 5, bottom: 30, rows: 24 }, // bottom beyond the screen
+      { top: 10, bottom: 10, rows: 24 }, // equal bounds on a multi-row screen
+    ]) {
+      expect(prepare(frame, false, margins)).toBe(SGR_RESET + decoder.decode(frame))
+    }
+  })
+
+  it('prepends only the SGR reset to frames without a BSU prefix', () => {
+    const frame = encoder.encode('plain output')
+    const prepared = prepare(frame, true, { top: 1, bottom: 24, rows: 24 })
+    expect(prepared).toBe(`${SGR_RESET}plain output`)
+  })
+
+  it('passes empty chunk lists through untouched', () => {
+    expect(prepareBrowserCheckpoint([], true, { top: 1, bottom: 24, rows: 24 })).toEqual([])
+  })
+})
+
+describe('prepareBrowserCheckpoint with authoritative metadata', () => {
+  it('selects the normal buffer and restores margins before the cursor tail', () => {
+    const prepared = prepare(sharedFrame('body'), false, { top: 2, bottom: 20, rows: 24 })
+    expect(prepared).toBe(
+      bsu + SGR_RESET + '\x1b[?1049l' + WIRE_RESET + 'body' + '\x1b[2;20r' + '\x1b[5;7H\x1b[?25h' + esu,
+    )
+  })
+
+  it('selects the alternate buffer when the checkpoint says so', () => {
+    const prepared = prepare(sharedFrame('tui'), true, { top: 1, bottom: 24, rows: 24 })
+    expect(prepared).toContain('\x1b[?1049h')
+    expect(prepared).toContain('\x1b[1;24r')
+  })
+
+  it('represents a one-row terminal as the full-screen margin reset', () => {
+    const prepared = prepare(sharedFrame('x'), false, { top: 1, bottom: 1, rows: 1 })
+    expect(prepared).toContain('x\x1b[r\x1b[5;7H')
+    expect(prepared).not.toContain('\x1b[1;1r')
+  })
+
+  it('preserves a hidden-cursor tail verbatim', () => {
+    const prepared = prepare(sharedFrame('body', '\x1b[1;1H', '\x1b[?25l'), false, { top: 1, bottom: 24, rows: 24 })
+    expect(prepared.endsWith('\x1b[1;1H\x1b[?25l' + esu)).toBe(true)
+  })
+
+  it('falls back when the frame tail is not the anchored CUP/DECTCEM shape', () => {
+    const frame = encoder.encode(bsu + WIRE_RESET + 'body with no tail' + esu)
+    const prepared = prepare(frame, false, { top: 1, bottom: 24, rows: 24 })
+    expect(prepared).toBe(SGR_RESET + decoder.decode(frame))
+  })
+})

--- a/apps/gmux-web/src/terminal-checkpoint.test.ts
+++ b/apps/gmux-web/src/terminal-checkpoint.test.ts
@@ -59,6 +59,24 @@ describe('prepareBrowserCheckpoint version skew', () => {
   it('passes empty chunk lists through untouched', () => {
     expect(prepareBrowserCheckpoint([], true, { top: 1, bottom: 24, rows: 24 })).toEqual([])
   })
+
+  it('treats a BSU frame without the wire reset as legacy', () => {
+    // A frame that opens synchronized update but lacks the runner's reset
+    // preamble is not a state checkpoint; never invent buffer or margins.
+    const frame = encoder.encode(bsu + 'partial output' + esu)
+    const prepared = prepare(frame, false, { top: 1, bottom: 24, rows: 24 })
+    expect(prepared).toBe(SGR_RESET + decoder.decode(frame))
+  })
+
+  it('rewrites only the first chunk and preserves the rest verbatim', () => {
+    const first = sharedFrame('body')
+    const rest = [encoder.encode('later output'), encoder.encode('even later')]
+    const out = prepareBrowserCheckpoint([first, ...rest], false, { top: 2, bottom: 20, rows: 24 })
+    expect(out).toHaveLength(3)
+    expect(decoder.decode(out[0])).toContain('\x1b[?1049l')
+    expect(out[1]).toBe(rest[0])
+    expect(out[2]).toBe(rest[1])
+  })
 })
 
 describe('prepareBrowserCheckpoint with authoritative metadata', () => {

--- a/apps/gmux-web/src/terminal-checkpoint.ts
+++ b/apps/gmux-web/src/terminal-checkpoint.ts
@@ -1,0 +1,109 @@
+import { BSU, ESU, startsWith } from './replay'
+
+// ── Checkpoint framing ──
+//
+// The runner's raw attach checkpoint is shared with `gmux attach`; the
+// browser-only transform below adds buffer authority and margin restoration
+// on top of it, driven by the optional `terminal_checkpoint` metadata frame.
+// Older runners send no metadata frame at all — that skew case must stay
+// non-destructive (plain SGR-reset prepend, no guessed buffer or margins).
+
+const encoder = new TextEncoder()
+export const CHECKPOINT_WIRE_RESET = encoder.encode('\x1b[r\x1b[H\x1b[2J\x1b[3J')
+// The browser checkpoint resets margins before repaint and restores the
+// authoritative region before the cursor-position/visibility tail. The raw
+// frame remains unchanged for CLI and legacy consumers.
+const CHECKPOINT_BROWSER_RESET = encoder.encode('\x1b[r\x1b[H\x1b[2J\x1b[3J')
+const CHECKPOINT_SGR_RESET = encoder.encode('\x1b[0m')
+
+export type CheckpointMargins = { top: number, bottom: number, rows: number }
+
+/**
+ * Add browser-only buffer authority at the complete checkpoint boundary.
+ * The binary frame itself is also consumed by `gmux attach`, so putting
+ * ?1049h/l in it would change an operator's terminal. Reordering the known
+ * SGR is emitted before buffer selection and erase, preventing the old
+ * background from coloring blank cells. The browser-specific transform also
+ * resets margins before repaint and restores the emulator's authoritative
+ * 1-based region before the frame's final cursor-position/visibility tail.
+ * The raw frame's CSI r is never changed, and no other terminal state is
+ * claimed to be serialized.
+ */
+function cursorTailOffset(frameBody: Uint8Array): number | null {
+  // The shared frame ends with CUP + DECTCEM + ESU. Find CUP only within that
+  // anchored tail so escape sequences in rendered terminal content cannot be
+  // mistaken for the authoritative cursor position.
+  const visibilityLength = 6 // CSI ? 25 h/l
+  const visibilityOffset = frameBody.length - ESU.length - visibilityLength
+  if (visibilityOffset <= 0 || !startsWith(frameBody.slice(frameBody.length - ESU.length), ESU)) return null
+  const visibility = frameBody.slice(visibilityOffset, visibilityOffset + visibilityLength)
+  if (!(visibility[0] === 0x1b && visibility[1] === 0x5b && visibility[2] === 0x3f
+    && visibility[3] === 0x32 && visibility[4] === 0x35 && (visibility[5] === 0x68 || visibility[5] === 0x6c))) return null
+
+  const cursorEnd = visibilityOffset
+  if (frameBody[cursorEnd - 1] !== 0x48) return null // H
+  for (let i = cursorEnd - 2; i >= Math.max(0, cursorEnd - 24); i--) {
+    if (frameBody[i] !== 0x1b) continue
+    if (frameBody[i + 1] !== 0x5b) return null
+    let semicolons = 0
+    for (let j = i + 2; j < cursorEnd - 1; j++) {
+      const byte = frameBody[j]
+      if (byte === 0x3b) semicolons++
+      else if (byte < 0x30 || byte > 0x39) return null
+    }
+    return semicolons === 1 ? i : null
+  }
+  return null
+}
+
+export function prepareBrowserCheckpoint(chunks: Uint8Array[], activeAlternate: boolean | null, margins: CheckpointMargins | null): Uint8Array[] {
+  if (chunks.length === 0) return chunks
+  const first = chunks[0]
+  if (!startsWith(first, BSU)) {
+    const prepared = new Uint8Array(CHECKPOINT_SGR_RESET.length + first.length)
+    prepared.set(CHECKPOINT_SGR_RESET)
+    prepared.set(first, CHECKPOINT_SGR_RESET.length)
+    return [prepared, ...chunks.slice(1)]
+  }
+
+  const hasReset = first.length >= BSU.length + CHECKPOINT_WIRE_RESET.length
+    && startsWith(first.slice(BSU.length), CHECKPOINT_WIRE_RESET)
+  // Older runners provide neither authoritative buffer nor margins. Keep the
+  // legacy fallback non-destructive rather than guessing a state checkpoint.
+  const validMargins = margins !== null && margins.rows > 0
+    && margins.top >= 1 && margins.bottom <= margins.rows
+    && (margins.top < margins.bottom || (margins.rows === 1 && margins.top === 1 && margins.bottom === 1))
+  if (!hasReset || activeAlternate === null || !validMargins) {
+    const prepared = new Uint8Array(CHECKPOINT_SGR_RESET.length + first.length)
+    prepared.set(CHECKPOINT_SGR_RESET)
+    prepared.set(first, CHECKPOINT_SGR_RESET.length)
+    return [prepared, ...chunks.slice(1)]
+  }
+
+  const buffer = encoder.encode(activeAlternate ? '\x1b[?1049h' : '\x1b[?1049l')
+  // DECSTBM rejects equal bounds; on a one-row terminal the only safe
+  // representation is the default full-screen reset itself.
+  const restoreMargins = margins.rows === 1
+    ? encoder.encode('\x1b[r')
+    : encoder.encode(`\x1b[${margins.top};${margins.bottom}r`)
+  const body = first.slice(BSU.length + CHECKPOINT_WIRE_RESET.length)
+  const tailOffset = cursorTailOffset(body)
+  if (tailOffset === null) {
+    const prepared = new Uint8Array(CHECKPOINT_SGR_RESET.length + first.length)
+    prepared.set(CHECKPOINT_SGR_RESET)
+    prepared.set(first, CHECKPOINT_SGR_RESET.length)
+    return [prepared, ...chunks.slice(1)]
+  }
+  const repaint = body.slice(0, tailOffset)
+  const cursorTail = body.slice(tailOffset)
+  const prepared = new Uint8Array(BSU.length + CHECKPOINT_SGR_RESET.length + buffer.length + CHECKPOINT_BROWSER_RESET.length + repaint.length + restoreMargins.length + cursorTail.length)
+  let offset = 0
+  prepared.set(BSU, offset); offset += BSU.length
+  prepared.set(CHECKPOINT_SGR_RESET, offset); offset += CHECKPOINT_SGR_RESET.length
+  prepared.set(buffer, offset); offset += buffer.length
+  prepared.set(CHECKPOINT_BROWSER_RESET, offset); offset += CHECKPOINT_BROWSER_RESET.length
+  prepared.set(repaint, offset); offset += repaint.length
+  prepared.set(restoreMargins, offset); offset += restoreMargins.length
+  prepared.set(cursorTail, offset)
+  return [prepared, ...chunks.slice(1)]
+}

--- a/apps/gmux-web/src/terminal.tsx
+++ b/apps/gmux-web/src/terminal.tsx
@@ -12,9 +12,10 @@ import { createLongPressRecognizer } from './long-press'
 import { attachMobileInputHandler } from './mobile-input'
 import { MOCK_BY_ID } from './mock-data/index'
 import { refreshAtlasWhenIconFontLoads } from './nerd-font'
-import { BSU, createReplayBuffer, ESU, startsWith } from './replay'
+import { createReplayBuffer } from './replay'
 import type { ResolvedTerminalOptions } from './settings-schema'
 import { terminalFindOpen, terminalScrolledUp, terminalScrollToBottom } from './store'
+import { type CheckpointMargins, prepareBrowserCheckpoint } from './terminal-checkpoint'
 import { resolveCheckpointGeometry } from './terminal-checkpoint-geometry'
 import { TerminalFindBar } from './terminal-find'
 import { canSendTerminalInput } from './terminal-input'
@@ -31,106 +32,7 @@ import { type WsState, wsStateOnClose, wsStateOnOutput } from './ws-state'
 
 // ── Config ──
 
-const encoder = new TextEncoder()
-const CHECKPOINT_WIRE_RESET = encoder.encode('\x1b[r\x1b[H\x1b[2J\x1b[3J')
-// The browser checkpoint resets margins before repaint and restores the
-// authoritative region before the cursor-position/visibility tail. The raw
-// frame remains unchanged for CLI and legacy consumers.
-const CHECKPOINT_BROWSER_RESET = encoder.encode('\x1b[r\x1b[H\x1b[2J\x1b[3J')
-const CHECKPOINT_SGR_RESET = encoder.encode('\x1b[0m')
-
-type CheckpointMargins = { top: number, bottom: number, rows: number }
 type SessionConnection = { readonly sessionId: string, readonly ws: WebSocket }
-
-/**
- * Add browser-only buffer authority at the complete checkpoint boundary.
- * The binary frame itself is also consumed by `gmux attach`, so putting
- * ?1049h/l in it would change an operator's terminal. Reordering the known
- * SGR is emitted before buffer selection and erase, preventing the old
- * background from coloring blank cells. The browser-specific transform also
- * resets margins before repaint and restores the emulator's authoritative
- * 1-based region before the frame's final cursor-position/visibility tail.
- * The raw frame's CSI r is never changed, and no other terminal state is
- * claimed to be serialized.
- */
-function cursorTailOffset(frameBody: Uint8Array): number | null {
-  // The shared frame ends with CUP + DECTCEM + ESU. Find CUP only within that
-  // anchored tail so escape sequences in rendered terminal content cannot be
-  // mistaken for the authoritative cursor position.
-  const visibilityLength = 6 // CSI ? 25 h/l
-  const visibilityOffset = frameBody.length - ESU.length - visibilityLength
-  if (visibilityOffset <= 0 || !startsWith(frameBody.slice(frameBody.length - ESU.length), ESU)) return null
-  const visibility = frameBody.slice(visibilityOffset, visibilityOffset + visibilityLength)
-  if (!(visibility[0] === 0x1b && visibility[1] === 0x5b && visibility[2] === 0x3f
-    && visibility[3] === 0x32 && visibility[4] === 0x35 && (visibility[5] === 0x68 || visibility[5] === 0x6c))) return null
-
-  const cursorEnd = visibilityOffset
-  if (frameBody[cursorEnd - 1] !== 0x48) return null // H
-  for (let i = cursorEnd - 2; i >= Math.max(0, cursorEnd - 24); i--) {
-    if (frameBody[i] !== 0x1b) continue
-    if (frameBody[i + 1] !== 0x5b) return null
-    let semicolons = 0
-    for (let j = i + 2; j < cursorEnd - 1; j++) {
-      const byte = frameBody[j]
-      if (byte === 0x3b) semicolons++
-      else if (byte < 0x30 || byte > 0x39) return null
-    }
-    return semicolons === 1 ? i : null
-  }
-  return null
-}
-
-function prepareBrowserCheckpoint(chunks: Uint8Array[], activeAlternate: boolean | null, margins: CheckpointMargins | null): Uint8Array[] {
-  if (chunks.length === 0) return chunks
-  const first = chunks[0]
-  if (!startsWith(first, BSU)) {
-    const prepared = new Uint8Array(CHECKPOINT_SGR_RESET.length + first.length)
-    prepared.set(CHECKPOINT_SGR_RESET)
-    prepared.set(first, CHECKPOINT_SGR_RESET.length)
-    return [prepared, ...chunks.slice(1)]
-  }
-
-  const hasReset = first.length >= BSU.length + CHECKPOINT_WIRE_RESET.length
-    && startsWith(first.slice(BSU.length), CHECKPOINT_WIRE_RESET)
-  // Older runners provide neither authoritative buffer nor margins. Keep the
-  // legacy fallback non-destructive rather than guessing a state checkpoint.
-  const validMargins = margins !== null && margins.rows > 0
-    && margins.top >= 1 && margins.bottom <= margins.rows
-    && (margins.top < margins.bottom || (margins.rows === 1 && margins.top === 1 && margins.bottom === 1))
-  if (!hasReset || activeAlternate === null || !validMargins) {
-    const prepared = new Uint8Array(CHECKPOINT_SGR_RESET.length + first.length)
-    prepared.set(CHECKPOINT_SGR_RESET)
-    prepared.set(first, CHECKPOINT_SGR_RESET.length)
-    return [prepared, ...chunks.slice(1)]
-  }
-
-  const buffer = encoder.encode(activeAlternate ? '\x1b[?1049h' : '\x1b[?1049l')
-  // DECSTBM rejects equal bounds; on a one-row terminal the only safe
-  // representation is the default full-screen reset itself.
-  const restoreMargins = margins.rows === 1
-    ? encoder.encode('\x1b[r')
-    : encoder.encode(`\x1b[${margins.top};${margins.bottom}r`)
-  const body = first.slice(BSU.length + CHECKPOINT_WIRE_RESET.length)
-  const tailOffset = cursorTailOffset(body)
-  if (tailOffset === null) {
-    const prepared = new Uint8Array(CHECKPOINT_SGR_RESET.length + first.length)
-    prepared.set(CHECKPOINT_SGR_RESET)
-    prepared.set(first, CHECKPOINT_SGR_RESET.length)
-    return [prepared, ...chunks.slice(1)]
-  }
-  const repaint = body.slice(0, tailOffset)
-  const cursorTail = body.slice(tailOffset)
-  const prepared = new Uint8Array(BSU.length + CHECKPOINT_SGR_RESET.length + buffer.length + CHECKPOINT_BROWSER_RESET.length + repaint.length + restoreMargins.length + cursorTail.length)
-  let offset = 0
-  prepared.set(BSU, offset); offset += BSU.length
-  prepared.set(CHECKPOINT_SGR_RESET, offset); offset += CHECKPOINT_SGR_RESET.length
-  prepared.set(buffer, offset); offset += buffer.length
-  prepared.set(CHECKPOINT_BROWSER_RESET, offset); offset += CHECKPOINT_BROWSER_RESET.length
-  prepared.set(repaint, offset); offset += repaint.length
-  prepared.set(restoreMargins, offset); offset += restoreMargins.length
-  prepared.set(cursorTail, offset)
-  return [prepared, ...chunks.slice(1)]
-}
 
 const USE_MOCK = import.meta.env.VITE_MOCK === '1' || location.search.includes('mock')
 

--- a/apps/website/src/content/docs/develop/session-schema.md
+++ b/apps/website/src/content/docs/develop/session-schema.md
@@ -50,7 +50,7 @@ gmuxd exposes aggregated state to the browser via `GET /v1/events?session_stream
 | `command` | ✓ | ✓ | ✓ | title fallback only |
 | `cwd` | ✓ | ✓ | ✓ | ✓ header, grouping |
 | `adapter` | ✓ | ✓ | ✓ | ✓ adapter badge, URLs |
-| `drive_mode` | — | ✓ | ✓ | ✓ terminal vs. conversation view |
+| `drive_mode` | ✓ | ✓ | ✓ | ✓ terminal vs. conversation view |
 | `semantic_agent` | — | ✓ derived | ✓ | ✓ family-edge eligibility |
 | `peer` | — | ✓ (hub) | ✓ | ✓ host attribution |
 | `parent_session_id` | ✓ | ✓ | ✓ | ✓ family grouping, sidebar placement |
@@ -121,7 +121,7 @@ Internal fields are inputs to derived fields. The API only exposes the derived o
 | Field | Type | Description |
 |-------|------|-------------|
 | `alive` | boolean | Is the process running? Derived from socket reachability. |
-| `pid` | number | Process ID when alive |
+| `pid` | number? | Process ID when alive. Diagnostic; may be absent on any row. |
 | `exit_code` | number? | Exit code when dead |
 | `started_at` | ISO 8601 | When the process was started |
 | `exited_at` | ISO 8601? | When the process exited |
@@ -156,7 +156,7 @@ The stored launch `command` is preserved across exit. Resuming derives a tool-sp
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `socket_path` | string | Runner's Unix socket. The frontend uses this as a truthiness check for attachability; the actual path is unused by the browser. |
+| `socket_path` | string? | Runner's Unix socket. The frontend uses this as a truthiness check for attachability; the actual path is unused by the browser. Diagnostic; may be absent on any row. |
 | `terminal_cols` | number? | Current terminal width. Used for initial sizing on attach. |
 | `terminal_rows` | number? | Current terminal height. |
 
@@ -164,8 +164,8 @@ The stored launch `command` is preserved across exit. Resuming derives a tool-sp
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `runner_version` | string | Version of the runner binary hosting the session. |
-| `binary_hash` | string | sha256 of the runner binary. The frontend compares both against `GET /v1/health` to derive the "outdated" badge (version mismatch, or hash drift in dev). |
+| `runner_version` | string? | Version of the runner binary hosting the session. |
+| `binary_hash` | string? | sha256 of the runner binary. The frontend compares both against `GET /v1/health` to derive the "outdated" badge (version mismatch, or hash drift in dev). |
 
 `pid`, `socket_path`, `runner_version`, and `binary_hash` are origin-local,
 best-effort diagnostics: any of them may be absent on any row, and they carry

--- a/apps/website/src/content/docs/develop/session-schema.md
+++ b/apps/website/src/content/docs/develop/session-schema.md
@@ -50,8 +50,11 @@ gmuxd exposes aggregated state to the browser via `GET /v1/events?session_stream
 | `command` | ✓ | ✓ | ✓ | title fallback only |
 | `cwd` | ✓ | ✓ | ✓ | ✓ header, grouping |
 | `adapter` | ✓ | ✓ | ✓ | ✓ adapter badge, URLs |
+| `drive_mode` | — | ✓ | ✓ | ✓ terminal vs. conversation view |
+| `semantic_agent` | — | ✓ derived | ✓ | ✓ family-edge eligibility |
 | `peer` | — | ✓ (hub) | ✓ | ✓ host attribution |
-| `parent_session_id` | ✓ | ✓ | ✓ | ✓ sidebar placement of editor children |
+| `parent_session_id` | ✓ | ✓ | ✓ | ✓ family grouping, sidebar placement |
+| `launched_from_session_id` | — | ✓ stamped | ✓ | ✓ “Return to family” |
 | `workspace_root` | ✓ | ✓ | ✓ | ✓ project grouping |
 | `remotes` | ✓ | ✓ | ✓ | ✓ project grouping |
 | **Process state** |
@@ -66,6 +69,7 @@ gmuxd exposes aggregated state to the browser via `GET /v1/events?session_stream
 | `subtitle` | ✓ | ✓ | ✓ | — |
 | `status` | ✓ | ✓ | ✓ | ✓ dots, header indicator |
 | `unread` | ✓ | ✓ | ✓ | ✓ dots, tab badge |
+| `unread_token` | ✓ | ✓ | ✓ | ✓ read acknowledgement identity |
 | **Resume & conversations** |
 | `resumable` | — | ✓ derived | ✓ | ✓ sidebar |
 | `conversation_file` | ✓ (hook) | ✓ | ✓ | ✓ duplicate-conversation warning |
@@ -102,7 +106,15 @@ Internal fields are inputs to derived fields. The API only exposes the derived o
 | `workspace_root` | string? | Root of the workspace (jj/git), if detected. Used for project grouping. |
 | `remotes` | map? | Git/jj remote URLs. Used for cross-machine project grouping. |
 | `peer` | string? | Owning gmuxd instance; empty = local. Set by the hub for remote sessions, never by runners. |
-| `parent_session_id` | string? | Session this one was spawned from (`gmux edit` as `$EDITOR`); places the child next to its parent in the sidebar. |
+| `drive_mode` | string | How gmux hosts the harness (ADR 0033): `"terminal"` (PTY) or `"acp"` (terminal-less). Absent on the wire means `terminal`, so older payloads normalize cleanly. |
+| `semantic_agent` | boolean | The adapter exposes gmux's conversation-backed semantic-agent capability; both endpoints of a task-family edge must have it. |
+| `launched_from_session_id` | string? | Immutable launch provenance: the session this one was launched from. Survives every parent mutation; powers “Return to family”. |
+
+### Family edge (mutable)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `parent_session_id` | string? | The session's *current* behavioral parent: family grouping, subagent budget depth, recursive dismissal, and notification suppression all follow this edge. Unlike the fields above it is mutable: `POST /v1/sessions/{id}/reparent` with `{"parent_session_id": "<id>"}` moves the session, and with `{"parent_session_id": null}` promotes it to a root (`gmux promote` / `gmux reparent` are thin wrappers over this endpoint). Local sessions only; cycles, self-parenting, and peer-owned targets are refused. |
 
 ### Process State (owned by gmux, authoritative)
 
@@ -138,6 +150,7 @@ The stored launch `command` is preserved across exit. Resuming derives a tool-sp
 | `subtitle` | string? | Secondary context line. |
 | `status` | Status? | Application-reported status (see below). |
 | `unread` | boolean | Whether this session has unseen activity. |
+| `unread_token` | string | Opaque runner-owned identity of the unseen result. Read acknowledgements name the token they observed so a delayed read cannot clear a newer completion, including across runner replacement. Treat as opaque; compare only for equality. |
 
 ### Terminal
 
@@ -153,6 +166,11 @@ The stored launch `command` is preserved across exit. Resuming derives a tool-sp
 |-------|------|-------------|
 | `runner_version` | string | Version of the runner binary hosting the session. |
 | `binary_hash` | string | sha256 of the runner binary. The frontend compares both against `GET /v1/health` to derive the "outdated" badge (version mismatch, or hash drift in dev). |
+
+`pid`, `socket_path`, `runner_version`, and `binary_hash` are origin-local,
+best-effort diagnostics: any of them may be absent on any row, and they carry
+no meaning outside the owning host. They are not covenanted scripting inputs
+— see [Interface stability](/reference/stability/#diagnostic-session-fields).
 
 ### Status Object (set by child process)
 

--- a/apps/website/src/content/docs/develop/versioning.md
+++ b/apps/website/src/content/docs/develop/versioning.md
@@ -32,7 +32,13 @@ Dev builds (`version=dev`) skip version checking and never replace — this avoi
 
 ## Contract versioning
 
-Breaking API or schema changes require a new version prefix. Non-breaking additions (new optional fields) are fine within a version.
+For the covenanted API surface — the endpoints and schemas documented in the
+public references — breaking changes require a new version prefix. Non-breaking
+additions (new optional fields) are fine within a version. Undocumented
+endpoints under `/v1/` (internal daemon↔CLI plumbing such as launch
+reservations) and surfaces listed as
+[experimental](/reference/stability/#experimental) are exempt: they may change
+without a version bump, which is why external callers must not use them.
 
 ## What is NOT published
 

--- a/apps/website/src/content/docs/develop/versioning.md
+++ b/apps/website/src/content/docs/develop/versioning.md
@@ -32,13 +32,16 @@ Dev builds (`version=dev`) skip version checking and never replace — this avoi
 
 ## Contract versioning
 
-For the covenanted API surface — the endpoints and schemas documented in the
-public references — breaking changes require a new version prefix. Non-breaking
-additions (new optional fields) are fine within a version. Undocumented
-endpoints under `/v1/` (internal daemon↔CLI plumbing such as launch
-reservations) and surfaces listed as
-[experimental](/reference/stability/#experimental) are exempt: they may change
-without a version bump, which is why external callers must not use them.
+For the covenanted API surface — what the
+[Interface stability](/reference/stability/) page covenants — breaking changes
+require a new version prefix. Non-breaking additions (new optional fields) are
+fine within a version. Everything outside the covenant follows the stability
+page instead of this rule: undocumented endpoints under `/v1/` (internal
+daemon↔CLI plumbing such as launch reservations),
+[experimental](/reference/stability/#experimental) surfaces, and
+[diagnostic session fields](/reference/stability/#diagnostic-session-fields)
+may change without a version bump, which is why external callers must not
+build on them.
 
 ## What is NOT published
 

--- a/apps/website/src/content/docs/reference/cli.md
+++ b/apps/website/src/content/docs/reference/cli.md
@@ -656,7 +656,9 @@ this shell's env and cwd, on the local daemon only — and sends the prompt as
 its first work. Pass either a session id or `--new`, never both.
 
 - `--model M` / `--name N` — pi's `--model` and `--name`. Valid **only** with
-  `--new`; without it they are usage errors.
+  `--new`; without it they are usage errors. The flags are stable; the
+  `--model` *value* grammar belongs to the launched adapter and may change
+  with it (see [Interface stability](/reference/stability/#experimental)).
 - `--follow-up` and `--steer` are **refused** with `--new`: a session that does
   not exist yet has no work to queue behind or steer.
 - `--no-wait` and `--timeout` mean what they always mean. `--timeout` bounds

--- a/apps/website/src/content/docs/reference/host-toml.md
+++ b/apps/website/src/content/docs/reference/host-toml.md
@@ -68,6 +68,10 @@ What `gmux agent …` and the web launch flow may do on this host. The budget
 counts semantic agents only, so shell and process children in a family are
 never charged against it.
 
+**Experimental.** The `max_subagents_by_depth` grammar and its budget
+semantics are new and may change incompatibly in a minor release; see
+[Interface stability](/reference/stability/#experimental).
+
 | Field | Type | Default | Range | Description |
 |-------|------|---------|-------|-------------|
 | `max_subagents_by_depth` | `number[]` or `false` | `[-1, 8]` | 1–8 entries; each -1 or 0–1024 | Shared live semantic-agent budget per behavioral root and descendant depth. Only the first entry may be `-1` (unlimited). |
@@ -114,6 +118,10 @@ The bind address is not configurable here — it is the `GMUXD_LISTEN` environme
 Session values must be non-negative.
 
 ### `[notifications.ntfy]`
+
+**Experimental.** These keys and their delivery semantics may change
+incompatibly in a minor release; see
+[Interface stability](/reference/stability/#experimental).
 
 Publishes a privacy-safe notification after gmux's existing completion grace period and presence checks. Publishing is **best effort**: gmux makes one asynchronous request with a short timeout. It does not retry, queue, persist, or replay notifications after restart. A network error, daemon shutdown, or busy publisher may lose a notification. Browser notifications continue independently.
 

--- a/apps/website/src/content/docs/reference/stability.md
+++ b/apps/website/src/content/docs/reference/stability.md
@@ -3,7 +3,7 @@ title: Interface stability
 description: Interfaces covered by the gmux 2.x compatibility covenant.
 ---
 
-This page defines the public interfaces that gmux 2.x keeps compatible. Covenanted interfaces evolve additively: existing variables, files, and keys keep their meaning throughout 2.x.
+This page defines the public interfaces that gmux 2.x keeps compatible. Covenanted interfaces evolve additively: existing variables, files, and keys keep their meaning throughout 2.x. Surfaces listed under [Experimental](#experimental) below are excluded from the covenant until they are moved into it, even where another page documents them.
 
 ## Covenanted for 2.x
 
@@ -42,8 +42,11 @@ resumability, health, or capability support.
 #### Diagnostic session fields
 
 The session fields `pid`, `socket_path`, `runner_version`, and `binary_hash`
-are origin-local diagnostics, not scripting inputs. They keep their JSON type
-while present, but they are best-effort: any of them may be absent on any row,
+— wherever session JSON is served (`gmux ls --json`, the HTTP and SSE session
+payloads, peer projections) — are origin-local diagnostics, not scripting
+inputs. They keep their JSON type
+while present, but they are best-effort: any of them may be absent on any row
+(`binary_hash` never appears in `gmux ls --json` at all),
 they carry no meaning outside the host that owns the session (a `pid` or
 `socket_path` from another host is not usable where you read it), and gmux may
 stop emitting them in a future release without a major version. Do not build
@@ -51,7 +54,7 @@ on them; use `ref`, `alive`, `status`, and the exit-code taxonomy instead.
 
 ### Configuration files
 
-- `host.toml` contains host-local daemon configuration. Existing keys keep their meaning, but the file is strictly validated: unknown keys are rejected to catch mistakes, except for the documented deprecated `tailscale.hostname`, `discovery.tailscale`, and `[[peers]]` shapes, which are ignored with warnings. See the [host.toml reference](/reference/host-toml/#strict-validation) for details. A `host.toml` using keys from a newer gmux release may therefore require the matching daemon version.
+- `host.toml` contains host-local daemon configuration. Existing keys keep their meaning — except the keys listed under [Experimental](#experimental), which are documented for use but not yet covenanted — and the file is strictly validated: unknown keys are rejected to catch mistakes, except for the documented deprecated `tailscale.hostname`, `discovery.tailscale`, and `[[peers]]` shapes, which are ignored with warnings. See the [host.toml reference](/reference/host-toml/#strict-validation) for details. A `host.toml` using keys from a newer gmux release may therefore require the matching daemon version.
 - `settings.jsonc` and `theme.jsonc` contain portable frontend preferences. Their keys evolve additively, and unknown fields are tolerated for forward compatibility.
 
 ## Experimental

--- a/apps/website/src/content/docs/reference/stability.md
+++ b/apps/website/src/content/docs/reference/stability.md
@@ -39,10 +39,41 @@ they do not understand. `ref` remains the authoritative reusable session
 argument; `alive` remains runner liveness only, never activity, success,
 resumability, health, or capability support.
 
+#### Diagnostic session fields
+
+The session fields `pid`, `socket_path`, `runner_version`, and `binary_hash`
+are origin-local diagnostics, not scripting inputs. They keep their JSON type
+while present, but they are best-effort: any of them may be absent on any row,
+they carry no meaning outside the host that owns the session (a `pid` or
+`socket_path` from another host is not usable where you read it), and gmux may
+stop emitting them in a future release without a major version. Do not build
+on them; use `ref`, `alive`, `status`, and the exit-code taxonomy instead.
+
 ### Configuration files
 
 - `host.toml` contains host-local daemon configuration. Existing keys keep their meaning, but the file is strictly validated: unknown keys are rejected to catch mistakes, except for the documented deprecated `tailscale.hostname`, `discovery.tailscale`, and `[[peers]]` shapes, which are ignored with warnings. See the [host.toml reference](/reference/host-toml/#strict-validation) for details. A `host.toml` using keys from a newer gmux release may therefore require the matching daemon version.
 - `settings.jsonc` and `theme.jsonc` contain portable frontend preferences. Their keys evolve additively, and unknown fields are tolerated for forward compatibility.
+
+## Experimental
+
+These surfaces ship in current releases but are still settling. They may
+change incompatibly in a minor release; anything not moved to the covenanted
+list stays experimental rather than becoming stable by shipping.
+
+- **`[notifications.ntfy]`** (`host.toml`): the key names, value grammar, and
+  delivery semantics of best-effort phone notifications.
+- **`agent.max_subagents_by_depth`** (`host.toml`): the depth-array grammar
+  and budget semantics of the active-subagent limit.
+- **`gmux agent prompt --new --model <M>`**: the flag is covenanted; the
+  *value* grammar is owned by the launched adapter (today pi's model selector)
+  and may change with it.
+- **ACP drive mode** (`drive_mode: "acp"`): the enum value is covenanted so
+  clients can recognize it, but ACP-driven sessions themselves — how they are
+  launched, resumed, and rendered — are still under active design (ADR 0033,
+  ADR 0034).
+- **HTTP endpoints not documented in this site's references**, including
+  `/v1/agent-launch-reservations`: internal daemon plumbing that happens to
+  live under `/v1/`; not for external callers.
 
 ## Explicitly not covenanted
 

--- a/services/gmuxd/cmd/gmuxd/active_subagent_routes.go
+++ b/services/gmuxd/cmd/gmuxd/active_subagent_routes.go
@@ -18,6 +18,12 @@ const (
 	codeInvalidSubagentReservation = "invalid_subagent_reservation"
 )
 
+// registerActiveSubagentRoutes registers the launch-admission reservation
+// endpoints. These are internal daemon↔CLI plumbing for the active-subagent
+// budget: they happen to live under /v1/ but are NOT part of the covenanted
+// HTTP surface (see the website's Interface stability page). Their request
+// shape, token lifecycle, and error codes may change in any release; external
+// callers must not depend on them.
 func registerActiveSubagentRoutes(mux *http.ServeMux, coord *sessioncoord.Coordinator) {
 	mux.HandleFunc("POST /v1/agent-launch-reservations", func(w http.ResponseWriter, r *http.Request) {
 		handleActiveSubagentReservation(w, r, coord)


### PR DESCRIPTION
Follow-up to the release-2.1 interface audit (`.memory/report-release-2-1-interface-audit.md`, local). No wire or behavior changes — this PR pins what is stable vs. experimental *before* 2.1 ships it, and closes the one identified test gap.

## What's in here

**Stability covenant (`reference/stability.md`)**
- New *Diagnostic session fields* note: `pid`, `socket_path`, `runner_version`, `binary_hash` are origin-local, best-effort diagnostics — present-field types stay stable, but absence is always legal and they may stop being emitted without a major version. This reserves the freedom stripping them would have bought, without touching the wire (they're `omitempty` everywhere, so skewed peers degrade gracefully).
- New *Experimental* section so these don't silently freeze by shipping: `[notifications.ntfy]`, `agent.max_subagents_by_depth`, the `--model` **value** grammar, ACP drive mode, and undocumented `/v1/` plumbing incl. `/v1/agent-launch-reservations`.

**Reference docs**
- `host-toml.md`: experimental markers on `[agent]` budget and `[notifications.ntfy]`.
- `cli.md`: `--model` flag stable, value grammar adapter-owned.
- `session-schema.md`: documents the 2.1 wire additions that were missing (`drive_mode` incl. absent→`terminal` normalization, `semantic_agent`, `launched_from_session_id`, opaque `unread_token`), gives `parent_session_id` its post-#505 meaning as the mutable family edge, and documents `POST /v1/sessions/{id}/reparent` with `parent_session_id: null` ≡ promote. Adds the diagnostics cross-reference.

**Code (comment only)**
- `active_subagent_routes.go`: doc comment marking the reservation endpoints as non-covenanted internal plumbing.

**Test (the audit's one skew gap)**
- Extracts `prepareBrowserCheckpoint`/`cursorTailOffset` verbatim from `terminal.tsx` into `terminal-checkpoint.ts` and adds 10 unit tests, centrally: a new browser attached to an **old runner that never sends `terminal_checkpoint`** must fall back non-destructively (SGR-reset prepend, no invented `?1049` buffer switch or DECSTBM), plus invalid-margin rejection, one-row DECSTBM special case, and cursor-tail preservation.

## Not in this PR
- Changelog prose for the stdin-preflight behavior change (`gmux -- cmd` now refuses pending launcher stdin): `changelog.mdx` is release-workflow-managed, so that sentence belongs in the `release/next` PR body prose block.

Checks run: `tsc --noEmit`, `vitest` (762 passed), `biome check` on touched files, `go build ./...` in `services/gmuxd`.