### PR TITLE
fix(gmuxd): retain conversation titles across restarts

### DIFF
--- a/services/gmuxd/cmd/gmuxd/bootstrap_runner_adapters.go
+++ b/services/gmuxd/cmd/gmuxd/bootstrap_runner_adapters.go
@@ -330,22 +330,21 @@ type runnerMetaWire struct {
 func runnerMetaFacts(s runnerMetaWire) centralstore.RunnerFacts {
 	// Conversation metadata is a last-known-good materialized projection of
 	// the adapter-owned conversation. A runner can register before its hook has
-	// rebound (all of these strings are then empty), so empty /meta values are
-	// unobserved rather than authoritative clears. A later non-empty
-	// conversation_file event is the rebind boundary; centralstore clears the
-	// previous conversation's metadata there before applying the new facts.
-	// Live meta events remain tri-state and can still carry an explicit empty.
+	// rebound (the ref and metadata are all empty), so that pre-bind snapshot is
+	// unobserved rather than an authoritative clear. Once the ref is non-empty,
+	// the whole metadata snapshot is authoritative, including empty clears.
+	// A later different conversation_file event is the rebind boundary;
+	// centralstore clears the previous conversation's metadata there before
+	// applying facts for the new binding.
 	f := centralstore.RunnerFacts{CWD: &s.CWD, WorkspaceRoot: &s.WorkspaceRoot, ShellTitle: &s.ShellTitle, Command: &s.Command, Remotes: &s.Remotes}
 	if s.ConversationRef != "" {
+		// Once the runner is positively bound, its metadata snapshot is
+		// authoritative even when a value is empty: a clear that happened while
+		// gmuxd was disconnected must converge on registration. Only the
+		// pre-bind empty-ref window treats these fields as unobserved.
 		f.ConversationRef = &s.ConversationRef
-	}
-	if s.Slug != "" {
 		f.Slug = &s.Slug
-	}
-	if s.AdapterTitle != "" {
 		f.AdapterTitle = &s.AdapterTitle
-	}
-	if s.Subtitle != "" {
 		f.Subtitle = &s.Subtitle
 	}
 	if s.Status != nil {

--- a/services/gmuxd/cmd/gmuxd/bootstrap_runner_adapters.go
+++ b/services/gmuxd/cmd/gmuxd/bootstrap_runner_adapters.go
@@ -328,7 +328,26 @@ type runnerMetaWire struct {
 }
 
 func runnerMetaFacts(s runnerMetaWire) centralstore.RunnerFacts {
-	f := centralstore.RunnerFacts{ConversationRef: &s.ConversationRef, CWD: &s.CWD, WorkspaceRoot: &s.WorkspaceRoot, Slug: &s.Slug, ShellTitle: &s.ShellTitle, AdapterTitle: &s.AdapterTitle, Subtitle: &s.Subtitle, Command: &s.Command, Remotes: &s.Remotes}
+	// Conversation metadata is a last-known-good materialized projection of
+	// the adapter-owned conversation. A runner can register before its hook has
+	// rebound (all of these strings are then empty), so empty /meta values are
+	// unobserved rather than authoritative clears. A later non-empty
+	// conversation_file event is the rebind boundary; centralstore clears the
+	// previous conversation's metadata there before applying the new facts.
+	// Live meta events remain tri-state and can still carry an explicit empty.
+	f := centralstore.RunnerFacts{CWD: &s.CWD, WorkspaceRoot: &s.WorkspaceRoot, ShellTitle: &s.ShellTitle, Command: &s.Command, Remotes: &s.Remotes}
+	if s.ConversationRef != "" {
+		f.ConversationRef = &s.ConversationRef
+	}
+	if s.Slug != "" {
+		f.Slug = &s.Slug
+	}
+	if s.AdapterTitle != "" {
+		f.AdapterTitle = &s.AdapterTitle
+	}
+	if s.Subtitle != "" {
+		f.Subtitle = &s.Subtitle
+	}
 	if s.Status != nil {
 		f.Active = &s.Status.Active
 		f.Error = &s.Status.Error

--- a/services/gmuxd/cmd/gmuxd/bootstrap_runner_adapters_test.go
+++ b/services/gmuxd/cmd/gmuxd/bootstrap_runner_adapters_test.go
@@ -144,6 +144,18 @@ func TestRunnerMetaFactsTreatsUnboundConversationMetadataAsUnobserved(t *testing
 		f.Slug == nil || *f.Slug != "fix-auth" {
 		t.Fatalf("positive conversation metadata not projected: %+v", f)
 	}
+
+	// A bound snapshot is authoritative as a whole. Empty values here are
+	// clears that may have happened while gmuxd was disconnected.
+	f = runnerMetaFacts(runnerMetaWire{
+		ConversationRef: "/conversations/a.jsonl",
+		Command:         []string{"pi"}, Remotes: map[string]string{},
+	})
+	if f.AdapterTitle == nil || *f.AdapterTitle != "" ||
+		f.Subtitle == nil || *f.Subtitle != "" ||
+		f.Slug == nil || *f.Slug != "" {
+		t.Fatalf("bound empty metadata did not project authoritative clears: %+v", f)
+	}
 }
 
 func TestProductionRunnerMetaClosesConnections(t *testing.T) {

--- a/services/gmuxd/cmd/gmuxd/bootstrap_runner_adapters_test.go
+++ b/services/gmuxd/cmd/gmuxd/bootstrap_runner_adapters_test.go
@@ -119,6 +119,33 @@ func TestProductionRunnerDeadMetadataSurvivesMetaAndReplay(t *testing.T) {
 	}
 }
 
+func TestRunnerMetaFactsTreatsUnboundConversationMetadataAsUnobserved(t *testing.T) {
+	f := runnerMetaFacts(runnerMetaWire{
+		CWD: "/work", WorkspaceRoot: "/work", ShellTitle: "",
+		Command: []string{"pi"}, Remotes: map[string]string{},
+	})
+	if f.ConversationRef != nil || f.AdapterTitle != nil || f.Subtitle != nil || f.Slug != nil {
+		t.Fatalf("empty pre-hook metadata became authoritative patches: %+v", f)
+	}
+	// Shell title is generation-local rather than conversation-local: an
+	// empty replacement-runner snapshot deliberately clears the old OSC title.
+	if f.ShellTitle == nil || *f.ShellTitle != "" {
+		t.Fatalf("shell title lost generation-local clear semantics: %+v", f)
+	}
+
+	f = runnerMetaFacts(runnerMetaWire{
+		ConversationRef: "/conversations/a.jsonl", AdapterTitle: "Fix auth",
+		Subtitle: "working", Slug: "fix-auth", ShellTitle: "shell",
+		Command: []string{"pi"}, Remotes: map[string]string{},
+	})
+	if f.ConversationRef == nil || *f.ConversationRef != "/conversations/a.jsonl" ||
+		f.AdapterTitle == nil || *f.AdapterTitle != "Fix auth" ||
+		f.Subtitle == nil || *f.Subtitle != "working" ||
+		f.Slug == nil || *f.Slug != "fix-auth" {
+		t.Fatalf("positive conversation metadata not projected: %+v", f)
+	}
+}
+
 func TestProductionRunnerMetaClosesConnections(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/meta", func(w http.ResponseWriter, _ *http.Request) {

--- a/services/gmuxd/internal/centralstore/domain.go
+++ b/services/gmuxd/internal/centralstore/domain.go
@@ -542,7 +542,12 @@ func (s *Store) applyCommonFacts(ctx context.Context, id SessionID, observed Row
 	previousSlugBase := v.SlugBase
 	if p.ConversationRef != nil {
 		if *p.ConversationRef != "" && *p.ConversationRef != v.ConversationRef {
+			// A positive different ref is the conversation authority boundary.
+			// Status and adapter-derived display metadata belong to the old
+			// conversation and must not leak into the new one. Facts carried by
+			// this same observation are applied below after the clear.
 			v.Active, v.Error, v.Interrupted, v.StatusReported = false, false, false, false
+			v.AdapterTitle, v.Subtitle, v.Slug, v.SlugBase = "", "", "", ""
 		}
 		v.ConversationRef = *p.ConversationRef
 	}

--- a/services/gmuxd/internal/centralstore/register.go
+++ b/services/gmuxd/internal/centralstore/register.go
@@ -480,9 +480,12 @@ func validateRunnerFacts(f RunnerFacts) error {
 func mergeRunnerFacts(v *Session, f RunnerFacts) error {
 	if f.ConversationRef != nil {
 		if *f.ConversationRef != "" && *f.ConversationRef != v.ConversationRef {
-			// Terminal status is conversation-local. Clear it on the authoritative
-			// rebind before applying any status facts carried by this same update.
+			// Status and adapter-derived display metadata are conversation-local.
+			// Clear both on the authoritative non-empty rebind before applying any
+			// facts carried by this same update. Registration snapshots omit an
+			// empty/unbound ref, so only a positive different ref reaches here.
 			v.Active, v.Error, v.Interrupted, v.StatusReported = false, false, false, false
+			v.AdapterTitle, v.Subtitle, v.Slug, v.SlugBase = "", "", "", ""
 		}
 		v.ConversationRef = *f.ConversationRef
 	}

--- a/services/gmuxd/internal/centralstore/register_test.go
+++ b/services/gmuxd/internal/centralstore/register_test.go
@@ -97,6 +97,73 @@ func TestRegisterRunnerNewLiveAndFastDead(t *testing.T) {
 	}
 }
 
+func TestRegisterRunnerRetainsConversationMetadataUntilAuthoritativeRebind(t *testing.T) {
+	ctx := context.Background()
+	s := openKernelStore(t)
+	ref, title, subtitle, slug := "/conversations/a.jsonl", "Fix auth", "working", "fix-auth"
+	first := registration("session", "pi", "/work", true, 1)
+	first.Facts.ConversationRef = &ref
+	first.Facts.AdapterTitle = &title
+	first.Facts.Subtitle = &subtitle
+	first.Facts.Slug = &slug
+	if _, _, err := s.RegisterRunner(ctx, first); err != nil {
+		t.Fatal(err)
+	}
+
+	// A replacement runner registers before its adapter hook binds. The wire
+	// projection represents its empty /meta metadata as unobserved facts.
+	empty := ""
+	unbound := registration("session", "pi", "/work", true, 2)
+	unbound.NewGeneration = true
+	got, _, err := s.RegisterRunner(ctx, unbound)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ConversationRef != ref || got.AdapterTitle != title || got.Subtitle != subtitle || got.Slug != slug {
+		t.Fatalf("unbound replacement lost conversation metadata: %#v", got)
+	}
+
+	// A transient same-ref parse represented as no positive display facts has
+	// the same stale-while-revalidate semantics.
+	same := registration("session", "pi", "/work", true, 3)
+	same.Facts.ConversationRef = &ref
+	got, _, err = s.RegisterRunner(ctx, same)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.AdapterTitle != title || got.Subtitle != subtitle || got.Slug != slug {
+		t.Fatalf("same-ref refresh lost conversation metadata: %#v", got)
+	}
+
+	// A positive same-ref refresh remains authoritative.
+	renamed, renamedSlug := "Auth repaired", "auth-repaired"
+	same.Facts.AdapterTitle = &renamed
+	same.Facts.Slug = &renamedSlug
+	got, _, err = s.RegisterRunner(ctx, same)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.AdapterTitle != renamed || got.Slug != renamedSlug {
+		t.Fatalf("positive refresh not applied: %#v", got)
+	}
+
+	// A different non-empty ref is an authoritative rebind. Empty metadata
+	// belongs to the new untitled conversation and must clear A's cache.
+	refB := "/conversations/b.jsonl"
+	rebound := registration("session", "pi", "/work", true, 4)
+	rebound.Facts.ConversationRef = &refB
+	rebound.Facts.AdapterTitle = &empty
+	rebound.Facts.Subtitle = &empty
+	rebound.Facts.Slug = &empty
+	got, _, err = s.RegisterRunner(ctx, rebound)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ConversationRef != refB || got.AdapterTitle != "" || got.Subtitle != "" || got.Slug != "" || got.SlugBase != "" {
+		t.Fatalf("authoritative rebind retained stale metadata: %#v", got)
+	}
+}
+
 func TestRegisterRunnerTriStateFactsAndActivityTransitions(t *testing.T) {
 	ctx := context.Background()
 	s := openKernelStore(t)

--- a/services/gmuxd/internal/centralstore/register_test.go
+++ b/services/gmuxd/internal/centralstore/register_test.go
@@ -112,7 +112,6 @@ func TestRegisterRunnerRetainsConversationMetadataUntilAuthoritativeRebind(t *te
 
 	// A replacement runner registers before its adapter hook binds. The wire
 	// projection represents its empty /meta metadata as unobserved facts.
-	empty := ""
 	unbound := registration("session", "pi", "/work", true, 2)
 	unbound.NewGeneration = true
 	got, _, err := s.RegisterRunner(ctx, unbound)
@@ -147,14 +146,12 @@ func TestRegisterRunnerRetainsConversationMetadataUntilAuthoritativeRebind(t *te
 		t.Fatalf("positive refresh not applied: %#v", got)
 	}
 
-	// A different non-empty ref is an authoritative rebind. Empty metadata
-	// belongs to the new untitled conversation and must clear A's cache.
+	// A different non-empty ref is an authoritative rebind. The production
+	// pre-registration reducer drops A's metadata facts at this boundary, so
+	// this ref-only update must clear A's cache by itself.
 	refB := "/conversations/b.jsonl"
 	rebound := registration("session", "pi", "/work", true, 4)
 	rebound.Facts.ConversationRef = &refB
-	rebound.Facts.AdapterTitle = &empty
-	rebound.Facts.Subtitle = &empty
-	rebound.Facts.Slug = &empty
 	got, _, err = s.RegisterRunner(ctx, rebound)
 	if err != nil {
 		t.Fatal(err)

--- a/services/gmuxd/internal/centralstore/runner_observation_test.go
+++ b/services/gmuxd/internal/centralstore/runner_observation_test.go
@@ -39,6 +39,44 @@ func TestApplyRunnerObservationAdvancesVersionActivityAndRejectsStale(t *testing
 	}
 }
 
+func TestApplyRunnerObservationRebindClearsConversationMetadata(t *testing.T) {
+	ctx := context.Background()
+	s := openKernelStore(t)
+	refA, title, subtitle, slug, shell := "A", "Title A", "subtitle A", "title-a", "terminal"
+	reg := registration("rebind-event", "pi", "/one", true, 10)
+	reg.Facts.ConversationRef = &refA
+	reg.Facts.AdapterTitle = &title
+	reg.Facts.Subtitle = &subtitle
+	reg.Facts.Slug = &slug
+	reg.Facts.ShellTitle = &shell
+	row, _, err := s.RegisterRunner(ctx, reg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	refB := "B"
+	result, err := s.ApplyRunnerObservation(ctx, RunnerObservation{
+		ID: row.ID, ObservedVersion: row.Version, ObservedAt: 20,
+		Facts: RunnerFacts{ConversationRef: &refB, ResetStatus: true},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, ok, err := s.Session(ctx, row.ID)
+	if err != nil || !ok {
+		t.Fatalf("Session: ok=%v err=%v", ok, err)
+	}
+	if got.ConversationRef != refB || got.AdapterTitle != "" || got.Subtitle != "" || got.Slug != "" || got.SlugBase != "" {
+		t.Fatalf("live rebind retained old conversation metadata: %#v", got)
+	}
+	if got.ShellTitle != shell {
+		t.Fatalf("conversation rebind cleared generation-local shell title: %#v", got)
+	}
+	if !result.Changed || !result.SessionsDirty {
+		t.Fatalf("result=%+v", result)
+	}
+}
+
 func TestApplyRunnerObservationNoopDoesNotDirty(t *testing.T) {
 	s := openKernelStore(t)
 	row, _, err := s.RegisterRunner(context.Background(), registration("noop-event", "shell", "/one", true, 10))

--- a/services/gmuxd/internal/sessioncoord/coordinator.go
+++ b/services/gmuxd/internal/sessioncoord/coordinator.go
@@ -829,6 +829,18 @@ loop:
 }
 
 func reduce(reg *centralstore.RunnerRegistration, ev RunnerEvent) {
+	// Buffered events are folded into the registration snapshot before the
+	// first durable commit. Preserve the conversation boundary while doing so:
+	// if /meta described A and a later replay/live event rebinds to B, A's
+	// title/subtitle/slug facts must not survive beside B's ref in the flattened
+	// registration. Later metadata events for B can populate them again.
+	if ev.Facts.ConversationRef != nil && *ev.Facts.ConversationRef != "" &&
+		reg.Facts.ConversationRef != nil && *reg.Facts.ConversationRef != "" &&
+		*ev.Facts.ConversationRef != *reg.Facts.ConversationRef {
+		reg.Facts.AdapterTitle = nil
+		reg.Facts.Subtitle = nil
+		reg.Facts.Slug = nil
+	}
 	_ = mergeFacts(&reg.Facts, ev.Facts)
 	if ev.Alive != nil {
 		reg.Alive = *ev.Alive

--- a/services/gmuxd/internal/sessioncoord/coordinator_test.go
+++ b/services/gmuxd/internal/sessioncoord/coordinator_test.go
@@ -115,6 +115,35 @@ func (c *freshRunnerClient) Meta(context.Context, string) (RunnerMeta, error) {
 	return c.meta, nil
 }
 
+func TestReducePreservesBufferedConversationRebindBoundary(t *testing.T) {
+	refA, refB := "A", "B"
+	titleA, subtitleA, slugA := "Title A", "subtitle A", "title-a"
+	reg := centralstore.RunnerRegistration{Facts: centralstore.RunnerFacts{
+		ConversationRef: &refA, AdapterTitle: &titleA, Subtitle: &subtitleA, Slug: &slugA,
+	}}
+
+	// /meta described A, then a conversation_file(B) event arrived before the
+	// registration commit. Flattening must not pair B's ref with A's metadata.
+	reduce(&reg, RunnerEvent{Facts: centralstore.RunnerFacts{ConversationRef: &refB}})
+	if reg.Facts.ConversationRef == nil || *reg.Facts.ConversationRef != refB {
+		t.Fatalf("rebind ref not reduced: %+v", reg.Facts)
+	}
+	if reg.Facts.AdapterTitle != nil || reg.Facts.Subtitle != nil || reg.Facts.Slug != nil {
+		t.Fatalf("buffered rebind retained A metadata beside B ref: %+v", reg.Facts)
+	}
+
+	// A later B metadata event is ordered after the boundary and must survive.
+	titleB, subtitleB, slugB := "Title B", "subtitle B", "title-b"
+	reduce(&reg, RunnerEvent{Facts: centralstore.RunnerFacts{
+		AdapterTitle: &titleB, Subtitle: &subtitleB, Slug: &slugB,
+	}})
+	if reg.Facts.AdapterTitle == nil || *reg.Facts.AdapterTitle != titleB ||
+		reg.Facts.Subtitle == nil || *reg.Facts.Subtitle != subtitleB ||
+		reg.Facts.Slug == nil || *reg.Facts.Slug != slugB {
+		t.Fatalf("post-rebind metadata not reduced: %+v", reg.Facts)
+	}
+}
+
 func TestDirectRegistrationRejectsDurableIDButDiscoveryRemainsExempt(t *testing.T) {
 	id := centralstore.SessionID("abcd1234")
 	client := newFakeClient(liveMeta(id, "pi", ""))


### PR DESCRIPTION
## Summary

- preserve last-known-good adapter title, subtitle, conversation ref, and slug when a replacement runner registers before its adapter hook binds
- treat metadata from a positively bound runner as authoritative, including explicit empty clears
- clear conversation-local display metadata on both registration-time and live conversation rebinds while retaining generation-local shell titles
- preserve conversation boundaries when pre-registration `/meta` and buffered rebind events are reduced into one registration

## Root cause

Runner `/meta` represented the pre-hook state with empty strings. Registration projected those values as authoritative patches and overwrote durable conversation metadata. The first fix also exposed adjacent rebind-ordering cases: live rebinds did not clear old metadata, and buffered events could flatten conversation A's title beside conversation B's ref.

## Verification

- `go test ./internal/centralstore ./internal/sessioncoord ./cmd/gmuxd` from `services/gmuxd`
- three independent `openai-codex/gpt-5.6-sol:low` delta reviewers
- final mutation review removed the registration rebind clear and confirmed the ref-only regression test fails

## Semantics

The adapter-owned conversation remains authoritative. SQLite stores a last-known-good materialized projection for retained/offline sessions and transient transcript unavailability. An empty ref means the runner has not bound yet; a non-empty ref makes its metadata snapshot authoritative. A different non-empty ref is the boundary that clears the previous conversation's cached metadata.
