### PR TITLE
fix(terminal): checkpoint replay fidelity — reflow history, declared geometry, claim announce

### DIFF
--- a/apps/gmux-web/src/terminal-checkpoint-geometry.test.ts
+++ b/apps/gmux-web/src/terminal-checkpoint-geometry.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { resolveCheckpointGeometry } from './terminal-checkpoint-geometry'
+
+describe('resolveCheckpointGeometry', () => {
+  it('prefers the checkpoint-declared columns', () => {
+    expect(resolveCheckpointGeometry({ cols: 79, rows: 25 }, 80, 81)).toEqual({ cols: 79, rows: 25 })
+  })
+
+  it('falls back through session, cached, and default columns for old runners', () => {
+    expect(resolveCheckpointGeometry({ rows: 25 }, 90, 91)).toEqual({ cols: 90, rows: 25 })
+    expect(resolveCheckpointGeometry({ rows: 25 }, null, 91)).toEqual({ cols: 91, rows: 25 })
+    expect(resolveCheckpointGeometry({ rows: 25 })).toEqual({ cols: 80, rows: 25 })
+  })
+})

--- a/apps/gmux-web/src/terminal-checkpoint-geometry.ts
+++ b/apps/gmux-web/src/terminal-checkpoint-geometry.ts
@@ -1,0 +1,24 @@
+export interface TerminalGeometry {
+  cols: number
+  rows: number
+}
+
+interface CheckpointGeometryMetadata {
+  cols?: unknown
+  rows?: unknown
+}
+
+/** Resolve the geometry at which a checkpoint frame was rendered. */
+export function resolveCheckpointGeometry(
+  metadata: CheckpointGeometryMetadata | null,
+  sessionCols?: number | null,
+  cachedCols?: number | null,
+): TerminalGeometry | null {
+  if (!metadata || !Number.isInteger(metadata.rows) || (metadata.rows as number) <= 0) return null
+  const declaredCols = Number.isInteger(metadata.cols) && (metadata.cols as number) > 0
+    ? metadata.cols as number
+    : null
+  const cols = declaredCols ?? sessionCols ?? cachedCols ?? 80
+  if (!Number.isInteger(cols) || cols <= 0) return null
+  return { cols, rows: metadata.rows as number }
+}

--- a/apps/gmux-web/src/terminal-io-reconnect-order.test.ts
+++ b/apps/gmux-web/src/terminal-io-reconnect-order.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { createTerminalIO } from './terminal-io'
+
+const enc = (text: string) => new TextEncoder().encode(text)
+
+describe('TerminalIO reconnect checkpoint ordering', () => {
+  it('keeps coalescible resizes outside the declared-geometry frame transaction', () => {
+    const events: string[] = []
+    const writeCompletions: Array<() => void> = []
+    const io = createTerminalIO({
+      resize(cols, rows) { events.push(`resize:${cols}x${rows}`) },
+      write(data, callback) {
+        events.push(`write:${new TextDecoder().decode(data as Uint8Array)}`)
+        writeCompletions.push(() => callback?.())
+      },
+    })
+    io.reset(1)
+
+    // Reconnect onopen may re-sync cached session metadata first.
+    io.requestResize({ cols: 120, rows: 40 }, 1)
+    // The checkpoint is an ordered resize + frame transaction.
+    io.enqueueResizeThenMany({ cols: 79, rows: 25 }, [enc('frame-1'), enc('frame-2')], 1)
+    // A concurrent viewport change enters the coalescible resize slot while
+    // the first frame write is still parsing.
+    io.requestResize({ cols: 140, rows: 50 }, 1)
+
+    expect(events).toEqual([
+      'resize:120x40',
+      'resize:79x25',
+      'write:frame-1',
+    ])
+    writeCompletions.shift()?.()
+    expect(events).toEqual([
+      'resize:120x40',
+      'resize:79x25',
+      'write:frame-1',
+      'write:frame-2',
+    ])
+    writeCompletions.shift()?.()
+    expect(events).toEqual([
+      'resize:120x40',
+      'resize:79x25',
+      'write:frame-1',
+      'write:frame-2',
+      'resize:140x50',
+    ])
+  })
+})

--- a/apps/gmux-web/src/terminal-io.test.ts
+++ b/apps/gmux-web/src/terminal-io.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it, vi } from 'vitest'
 import { ScrollAnchorAddon } from '@gmux/scroll-anchor'
+import { describe, expect, it, vi } from 'vitest'
 import { createTerminalIO } from './terminal-io'
 
 const enc = (s: string) => new TextEncoder().encode(s)
@@ -83,6 +83,50 @@ describe('createTerminalIO', () => {
     expect(h.resizes).toEqual([])
     h.flushOne()
     expect(h.resizes).toEqual([{ cols: 80, rows: 24 }])
+  })
+
+  it('holds an ordered resize barrier and its writes behind the busy fence', () => {
+    let busy = true
+    const h = makeHarness(() => busy)
+    h.io.reset(1)
+    h.io.enqueueResizeThenMany({ cols: 80, rows: 25 }, [enc('a'), enc('b')], 1)
+
+    expect(h.resizes).toEqual([])
+    expect(h.writes).toEqual([])
+
+    busy = false
+    h.io.busyStateChanged()
+    expect(h.resizes).toEqual([{ cols: 80, rows: 25 }])
+    expect(h.writes).toEqual(['a'])
+    h.flushOne()
+    expect(h.writes).toEqual(['a', 'b'])
+  })
+
+  it('drops every queued old-epoch payload behind an unfinished write', () => {
+    const h = makeHarness()
+    h.io.reset(1)
+    h.io.enqueueMany([enc('old-in-flight'), enc('old-queued-a'), enc('old-queued-b')], 1)
+    expect(h.writes).toEqual(['old-in-flight'])
+
+    h.io.reset(2)
+    h.io.enqueueMany([enc('new-a'), enc('new-b')], 2)
+    h.flushOne()
+    expect(h.writes).toEqual(['old-in-flight', 'new-a'])
+    h.flushOne()
+    expect(h.writes).toEqual(['old-in-flight', 'new-a', 'new-b'])
+  })
+
+  it('suppresses a resize callback when applying the resize resets its epoch', () => {
+    const onApplied = vi.fn()
+    let io: ReturnType<typeof createTerminalIO>
+    const term = {
+      write(_data: string | Uint8Array, callback?: () => void) { callback?.() },
+      resize() { io.reset(2) },
+    }
+    io = createTerminalIO(term)
+    io.reset(1)
+    io.enqueueResizeThenMany({ cols: 80, rows: 25 }, [], 1, undefined, onApplied)
+    expect(onApplied).not.toHaveBeenCalled()
   })
 
   it('applies enqueueResizeThenMany before writes and completes after its final chunk', () => {

--- a/apps/gmux-web/src/terminal-io.test.ts
+++ b/apps/gmux-web/src/terminal-io.test.ts
@@ -85,6 +85,50 @@ describe('createTerminalIO', () => {
     expect(h.resizes).toEqual([{ cols: 80, rows: 24 }])
   })
 
+  it('holds an ordered resize barrier and its writes behind the busy fence', () => {
+    let busy = true
+    const h = makeHarness(() => busy)
+    h.io.reset(1)
+    h.io.enqueueResizeThenMany({ cols: 80, rows: 25 }, [enc('a'), enc('b')], 1)
+
+    expect(h.resizes).toEqual([])
+    expect(h.writes).toEqual([])
+
+    busy = false
+    h.io.busyStateChanged()
+    expect(h.resizes).toEqual([{ cols: 80, rows: 25 }])
+    expect(h.writes).toEqual(['a'])
+    h.flushOne()
+    expect(h.writes).toEqual(['a', 'b'])
+  })
+
+  it('drops every queued old-epoch payload behind an unfinished write', () => {
+    const h = makeHarness()
+    h.io.reset(1)
+    h.io.enqueueMany([enc('old-in-flight'), enc('old-queued-a'), enc('old-queued-b')], 1)
+    expect(h.writes).toEqual(['old-in-flight'])
+
+    h.io.reset(2)
+    h.io.enqueueMany([enc('new-a'), enc('new-b')], 2)
+    h.flushOne()
+    expect(h.writes).toEqual(['old-in-flight', 'new-a'])
+    h.flushOne()
+    expect(h.writes).toEqual(['old-in-flight', 'new-a', 'new-b'])
+  })
+
+  it('suppresses a resize callback when applying the resize resets its epoch', () => {
+    const onApplied = vi.fn()
+    let io: ReturnType<typeof createTerminalIO>
+    const term = {
+      write(_data: string | Uint8Array, callback?: () => void) { callback?.() },
+      resize() { io.reset(2) },
+    }
+    io = createTerminalIO(term)
+    io.reset(1)
+    io.enqueueResizeThenMany({ cols: 80, rows: 25 }, [], 1, undefined, onApplied)
+    expect(onApplied).not.toHaveBeenCalled()
+  })
+
   it('applies enqueueResizeThenMany before writes and completes after its final chunk', () => {
     const h = makeHarness()
     const done = vi.fn()

--- a/apps/gmux-web/src/terminal.tsx
+++ b/apps/gmux-web/src/terminal.tsx
@@ -16,6 +16,7 @@ import { BSU, createReplayBuffer, ESU, startsWith } from './replay'
 import type { ResolvedTerminalOptions } from './settings-schema'
 import { terminalFindOpen, terminalScrolledUp, terminalScrollToBottom } from './store'
 import { TerminalFindBar } from './terminal-find'
+import { resolveCheckpointGeometry } from './terminal-checkpoint-geometry'
 import { canSendTerminalInput } from './terminal-input'
 import { createTerminalIO, type TerminalSize } from './terminal-io'
 import { type LinkInfo, linkAtPoint, openLinkAtPoint } from './terminal-link'
@@ -1034,6 +1035,7 @@ export function TerminalView({
       // staged; the existing screen remains visible during failed attempts.
       let checkpointAlt: boolean | null = null
       let checkpointMargins: CheckpointMargins | null = null
+      let checkpointCols: number | undefined
       // Keep post-checkpoint bytes out of TerminalIO until the initial replay
       // has committed and xterm has claimed the browser geometry.
       let attachPhase: 'replay' | 'claiming' | 'claimed' = isFirstConnect ? 'replay' : 'claimed'
@@ -1048,12 +1050,16 @@ export function TerminalView({
         const prepared = prepareBrowserCheckpoint(chunks, checkpointAlt, checkpointMargins)
         const claiming = attachPhase === 'replay'
         if (claiming) attachPhase = 'claiming'
-        // Newly launched sessions can reach the WS before their first SSE
-        // dimensions. The runner's pre-resize default is 80 columns; sessions
-        // with an established geometry carry it in session/resize metadata.
-        const cols = sessionRef.current.terminal_cols ?? ptySizeRef.current?.cols ?? 80
-        const rows = checkpointMargins?.rows
-        const checkpointSize = claiming && cols && rows ? { cols, rows } : null
+        // New runners declare the exact geometry used to render this frame.
+        // Fall back to the old metadata chain for rolling upgrades.
+        const checkpointSize = resolveCheckpointGeometry(
+          checkpointMargins ? { cols: checkpointCols, rows: checkpointMargins.rows } : null,
+          sessionRef.current.terminal_cols,
+          ptySizeRef.current?.cols,
+        )
+        if (checkpointSize) {
+          setPtySize(checkpointSize); ptySizeRef.current = checkpointSize
+        }
         const onReplayed = () => {
           if (connectionRef.current !== connection || termEpochRef.current !== epoch) return
           scrollAnchorRef.current?.follow()
@@ -1087,8 +1093,8 @@ export function TerminalView({
           termIoRef.current?.enqueueResizeThenMany(claimSize, [], epoch, undefined, onClaimResized)
         }
         if (checkpointSize) {
-          // This ordered barrier resizes xterm before the first checkpoint
-          // byte; a later viewport claim cannot overwrite it.
+          // Every replay gets an ordered local geometry barrier. Reconnects
+          // do not reclaim or send this checkpoint size back to the runner.
           termIoRef.current?.enqueueResizeThenMany(checkpointSize, prepared, epoch, onReplayed)
         } else {
           queueMany(prepared, onReplayed)
@@ -1136,6 +1142,7 @@ export function TerminalView({
             // Use it to initialize ptySize if we don't have one yet.
             if (msg.type === 'terminal_checkpoint') {
               checkpointAlt = msg.active_buffer === 'alternate'
+              checkpointCols = Number.isInteger(msg.cols) && msg.cols > 0 ? msg.cols : undefined
               if (Number.isInteger(msg.scroll_top) && Number.isInteger(msg.scroll_bottom) && Number.isInteger(msg.rows)) {
                 checkpointMargins = { top: msg.scroll_top, bottom: msg.scroll_bottom, rows: msg.rows }
               }

--- a/apps/gmux-web/src/terminal.tsx
+++ b/apps/gmux-web/src/terminal.tsx
@@ -438,7 +438,7 @@ export function TerminalView({
     processViewportResizeRef.current?.(true)
   }, [])
 
-  const applyOwnedResize = useCallback((size: TerminalSize, queueTerminalResize = true) => {
+  const applyOwnedResize = useCallback((size: TerminalSize, queueTerminalResize = true, announceAlways = false) => {
     const prevPty = ptySizeRef.current
 
     // Optimistically sync ptySize so the pill hides immediately, before the
@@ -447,7 +447,7 @@ export function TerminalView({
     setPtySize(size); ptySizeRef.current = size
     if (queueTerminalResize) queueResize(size)
 
-    if (sameSize(prevPty, size)) return
+    if (!announceAlways && sameSize(prevPty, size)) return
 
     // A new outbound resize supersedes any older echo wait or pending dirty
     // viewport event. The server echo for this exact size re-opens the gate.
@@ -527,7 +527,9 @@ export function TerminalView({
     const dims = measureTerminalFit(term, shell)
     setViewportSize(dims); viewportSizeRef.current = dims
     if (!dims) return null
-    applyOwnedResize(dims, false)
+    // A claim is also the ownership assertion and reconnect-redraw trigger,
+    // so it must reach the runner even when checkpoint and viewport match.
+    applyOwnedResize(dims, false, true)
     return dims
   }, [applyOwnedResize])
 
@@ -1247,6 +1249,7 @@ export function TerminalView({
   // terminal) changes ptySize away from our viewport.
   const showDisconnectedPill = wsState === 'lost'
   const showResizePill = !showDisconnectedPill
+    && !termLoading
     && session.alive
     && ptySize != null && viewportSize != null
     && (viewportSize.cols !== ptySize.cols || viewportSize.rows !== ptySize.rows)

--- a/apps/gmux-web/src/terminal.tsx
+++ b/apps/gmux-web/src/terminal.tsx
@@ -15,6 +15,7 @@ import { refreshAtlasWhenIconFontLoads } from './nerd-font'
 import { BSU, createReplayBuffer, ESU, startsWith } from './replay'
 import type { ResolvedTerminalOptions } from './settings-schema'
 import { terminalFindOpen, terminalScrolledUp, terminalScrollToBottom } from './store'
+import { resolveCheckpointGeometry } from './terminal-checkpoint-geometry'
 import { TerminalFindBar } from './terminal-find'
 import { canSendTerminalInput } from './terminal-input'
 import { createTerminalIO, type TerminalSize } from './terminal-io'
@@ -437,7 +438,7 @@ export function TerminalView({
     processViewportResizeRef.current?.(true)
   }, [])
 
-  const applyOwnedResize = useCallback((size: TerminalSize, queueTerminalResize = true) => {
+  const applyOwnedResize = useCallback((size: TerminalSize, queueTerminalResize = true, announceAlways = false) => {
     const prevPty = ptySizeRef.current
 
     // Optimistically sync ptySize so the pill hides immediately, before the
@@ -446,7 +447,7 @@ export function TerminalView({
     setPtySize(size); ptySizeRef.current = size
     if (queueTerminalResize) queueResize(size)
 
-    if (sameSize(prevPty, size)) return
+    if (!announceAlways && sameSize(prevPty, size)) return
 
     // A new outbound resize supersedes any older echo wait or pending dirty
     // viewport event. The server echo for this exact size re-opens the gate.
@@ -526,7 +527,9 @@ export function TerminalView({
     const dims = measureTerminalFit(term, shell)
     setViewportSize(dims); viewportSizeRef.current = dims
     if (!dims) return null
-    applyOwnedResize(dims, false)
+    // A claim is also the ownership assertion and reconnect-redraw trigger,
+    // so it must reach the runner even when checkpoint and viewport match.
+    applyOwnedResize(dims, false, true)
     return dims
   }, [applyOwnedResize])
 
@@ -1034,6 +1037,7 @@ export function TerminalView({
       // staged; the existing screen remains visible during failed attempts.
       let checkpointAlt: boolean | null = null
       let checkpointMargins: CheckpointMargins | null = null
+      let checkpointCols: number | undefined
       // Keep post-checkpoint bytes out of TerminalIO until the initial replay
       // has committed and xterm has claimed the browser geometry.
       let attachPhase: 'replay' | 'claiming' | 'claimed' = isFirstConnect ? 'replay' : 'claimed'
@@ -1048,12 +1052,16 @@ export function TerminalView({
         const prepared = prepareBrowserCheckpoint(chunks, checkpointAlt, checkpointMargins)
         const claiming = attachPhase === 'replay'
         if (claiming) attachPhase = 'claiming'
-        // Newly launched sessions can reach the WS before their first SSE
-        // dimensions. The runner's pre-resize default is 80 columns; sessions
-        // with an established geometry carry it in session/resize metadata.
-        const cols = sessionRef.current.terminal_cols ?? ptySizeRef.current?.cols ?? 80
-        const rows = checkpointMargins?.rows
-        const checkpointSize = claiming && cols && rows ? { cols, rows } : null
+        // New runners declare the exact geometry used to render this frame.
+        // Fall back to the old metadata chain for rolling upgrades.
+        const checkpointSize = resolveCheckpointGeometry(
+          checkpointMargins ? { cols: checkpointCols, rows: checkpointMargins.rows } : null,
+          sessionRef.current.terminal_cols,
+          ptySizeRef.current?.cols,
+        )
+        if (checkpointSize) {
+          setPtySize(checkpointSize); ptySizeRef.current = checkpointSize
+        }
         const onReplayed = () => {
           if (connectionRef.current !== connection || termEpochRef.current !== epoch) return
           scrollAnchorRef.current?.follow()
@@ -1087,8 +1095,8 @@ export function TerminalView({
           termIoRef.current?.enqueueResizeThenMany(claimSize, [], epoch, undefined, onClaimResized)
         }
         if (checkpointSize) {
-          // This ordered barrier resizes xterm before the first checkpoint
-          // byte; a later viewport claim cannot overwrite it.
+          // Every replay gets an ordered local geometry barrier. Reconnects
+          // do not reclaim or send this checkpoint size back to the runner.
           termIoRef.current?.enqueueResizeThenMany(checkpointSize, prepared, epoch, onReplayed)
         } else {
           queueMany(prepared, onReplayed)
@@ -1136,6 +1144,7 @@ export function TerminalView({
             // Use it to initialize ptySize if we don't have one yet.
             if (msg.type === 'terminal_checkpoint') {
               checkpointAlt = msg.active_buffer === 'alternate'
+              checkpointCols = Number.isInteger(msg.cols) && msg.cols > 0 ? msg.cols : undefined
               if (Number.isInteger(msg.scroll_top) && Number.isInteger(msg.scroll_bottom) && Number.isInteger(msg.rows)) {
                 checkpointMargins = { top: msg.scroll_top, bottom: msg.scroll_bottom, rows: msg.rows }
               }
@@ -1240,6 +1249,7 @@ export function TerminalView({
   // terminal) changes ptySize away from our viewport.
   const showDisconnectedPill = wsState === 'lost'
   const showResizePill = !showDisconnectedPill
+    && !termLoading
     && session.alive
     && ptySize != null && viewportSize != null
     && (viewportSize.cols !== ptySize.cols || viewportSize.rows !== ptySize.rows)

--- a/cli/gmux/internal/ptyserver/ptyserver.go
+++ b/cli/gmux/internal/ptyserver/ptyserver.go
@@ -520,6 +520,7 @@ type terminalCheckpointMetadata struct {
 	ActiveBuffer string `json:"active_buffer"`
 	ScrollTop    int    `json:"scroll_top"`
 	ScrollBottom int    `json:"scroll_bottom"`
+	Cols         int    `json:"cols"`
 	Rows         int    `json:"rows"`
 }
 
@@ -1717,7 +1718,8 @@ func (s *Server) handleWS(w http.ResponseWriter, r *http.Request) {
 		// changes, so full-screen/default state is represented explicitly.
 		meta := terminalCheckpointMetadata{
 			Type: "terminal_checkpoint", ActiveBuffer: activeBuffer,
-			ScrollTop: margins.top, ScrollBottom: margins.bottom, Rows: int(s.ptyRows),
+			ScrollTop: margins.top, ScrollBottom: margins.bottom,
+			Cols: int(s.ptyCols), Rows: int(s.ptyRows),
 		}
 		metaBytes, _ := json.Marshal(meta)
 		if err := client.write(websocket.MessageText, metaBytes); err != nil {

--- a/cli/gmux/internal/ptyserver/ptyserver.go
+++ b/cli/gmux/internal/ptyserver/ptyserver.go
@@ -473,7 +473,16 @@ func renderScreenMode(e *vt.Emulator, includeScrollback bool) string {
 		if !first && !previousWrapped {
 			sb.WriteString("\r\n")
 		}
-		sb.WriteString(line.Render())
+		rendered := line.Render()
+		sb.WriteString(rendered)
+		if wrapped {
+			// A wrapped row consumed every cell. Render trims only trailing
+			// unstyled blanks, so restore those cells before joining the next
+			// row. Styled blanks remain in rendered and need no extra padding.
+			if padding := len(line) - ansi.StringWidth(rendered); padding > 0 {
+				sb.WriteString(strings.Repeat(" ", padding))
+			}
+		}
 		first = false
 		previousWrapped = wrapped
 	}
@@ -488,8 +497,8 @@ func renderScreenMode(e *vt.Emulator, includeScrollback bool) string {
 		}
 	}
 
-	// Visible screen. Line.Render trims unused trailing cells, so joining a
-	// soft wrap never injects viewport padding into the logical line.
+	// Visible rows use the emulator width. Wrapped rows are padded by writeRow;
+	// non-wrapped rows retain Line.Render's trailing-cell trimming.
 	w, h := e.Width(), e.Height()
 	for y := 0; y < h; y++ {
 		line := make(uv.Line, w)

--- a/cli/gmux/internal/ptyserver/ptyserver.go
+++ b/cli/gmux/internal/ptyserver/ptyserver.go
@@ -508,6 +508,7 @@ type terminalCheckpointMetadata struct {
 	ActiveBuffer string `json:"active_buffer"`
 	ScrollTop    int    `json:"scroll_top"`
 	ScrollBottom int    `json:"scroll_bottom"`
+	Cols         int    `json:"cols"`
 	Rows         int    `json:"rows"`
 }
 
@@ -1705,7 +1706,8 @@ func (s *Server) handleWS(w http.ResponseWriter, r *http.Request) {
 		// changes, so full-screen/default state is represented explicitly.
 		meta := terminalCheckpointMetadata{
 			Type: "terminal_checkpoint", ActiveBuffer: activeBuffer,
-			ScrollTop: margins.top, ScrollBottom: margins.bottom, Rows: int(s.ptyRows),
+			ScrollTop: margins.top, ScrollBottom: margins.bottom,
+			Cols: int(s.ptyCols), Rows: int(s.ptyRows),
 		}
 		metaBytes, _ := json.Marshal(meta)
 		if err := client.write(websocket.MessageText, metaBytes); err != nil {

--- a/cli/gmux/internal/ptyserver/ptyserver.go
+++ b/cli/gmux/internal/ptyserver/ptyserver.go
@@ -476,10 +476,13 @@ func renderScreenMode(e *vt.Emulator, includeScrollback bool) string {
 		rendered := line.Render()
 		sb.WriteString(rendered)
 		if wrapped {
-			// A wrapped row consumed every cell. Render trims only trailing
-			// unstyled blanks, so restore those cells before joining the next
-			// row. Styled blanks remain in rendered and need no extra padding.
-			if padding := len(line) - ansi.StringWidth(rendered); padding > 0 {
+			// Restore trimmed written spaces, but not trailing zero cells: those
+			// mark columns skipped when a wide grapheme wrapped early.
+			targetWidth := len(line)
+			for targetWidth > 0 && line[targetWidth-1].IsZero() {
+				targetWidth--
+			}
+			if padding := targetWidth - ansi.StringWidth(rendered); padding > 0 {
 				sb.WriteString(strings.Repeat(" ", padding))
 			}
 		}

--- a/cli/gmux/internal/ptyserver/ptyserver_test.go
+++ b/cli/gmux/internal/ptyserver/ptyserver_test.go
@@ -927,14 +927,14 @@ func TestShutdownDrainNoRace(t *testing.T) {
 	}
 }
 
-func TestTerminalCheckpointMetadataCarriesMargins(t *testing.T) {
+func TestTerminalCheckpointMetadataCarriesGeometryAndMargins(t *testing.T) {
 	data, err := json.Marshal(terminalCheckpointMetadata{
-		Type: "terminal_checkpoint", ActiveBuffer: "alternate", ScrollTop: 2, ScrollBottom: 4, Rows: 44,
+		Type: "terminal_checkpoint", ActiveBuffer: "alternate", ScrollTop: 2, ScrollBottom: 4, Cols: 91, Rows: 44,
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := `{"type":"terminal_checkpoint","active_buffer":"alternate","scroll_top":2,"scroll_bottom":4,"rows":44}`
+	want := `{"type":"terminal_checkpoint","active_buffer":"alternate","scroll_top":2,"scroll_bottom":4,"cols":91,"rows":44}`
 	if string(data) != want {
 		t.Fatalf("metadata = %s, want %s", data, want)
 	}

--- a/cli/gmux/internal/ptyserver/ptyserver_test.go
+++ b/cli/gmux/internal/ptyserver/ptyserver_test.go
@@ -2090,6 +2090,14 @@ func TestSnapshotFrameWrappedRowsRoundTrip(t *testing.T) {
 			}
 
 			frame := snapshotFrameWithScreen(src, false, true)
+			if tc.name == "wide forced wrap" {
+				if !screenContainsCell(src, "界", 2) {
+					t.Fatal("source emulator dropped forced-wrap wide grapheme")
+				}
+				if !strings.Contains(ansi.Strip(string(frame)), "界") {
+					t.Fatalf("checkpoint dropped forced-wrap wide grapheme: %q", frame)
+				}
+			}
 			if tc.name == "boundary spaces" && strings.Contains(ansi.Strip(string(frame)), "quickbrown") {
 				t.Fatalf("checkpoint concatenated words: %q", frame)
 			}
@@ -2101,6 +2109,21 @@ func TestSnapshotFrameWrappedRowsRoundTrip(t *testing.T) {
 			assertScreensEqual(t, src, dst)
 		})
 	}
+}
+
+func screenContainsCell(screen interface {
+	Width() int
+	Height() int
+	CellAt(int, int) *uv.Cell
+}, content string, width int) bool {
+	for y := 0; y < screen.Height(); y++ {
+		for x := 0; x < screen.Width(); x++ {
+			if c := screen.CellAt(x, y); c != nil && c.Content == content && c.Width == width {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func TestSnapshotFrameAfterWidthChangesReflowsWithoutCorruption(t *testing.T) {

--- a/cli/gmux/internal/ptyserver/ptyserver_test.go
+++ b/cli/gmux/internal/ptyserver/ptyserver_test.go
@@ -2103,29 +2103,57 @@ func TestSnapshotFrameWrappedRowsRoundTrip(t *testing.T) {
 	}
 }
 
-func TestSnapshotFrameAfterWidthChangesDoesNotJoinOldWraps(t *testing.T) {
-	text := strings.Repeat("the quick brown fox jumps over the lazy dog ", 7)
-	src, srcDrain := newScreen(80, 8, func(bool) {})
-	defer stopScreenDrain(src, srcDrain)
-	if _, err := src.WriteString(text); err != nil {
-		t.Fatal(err)
+func TestSnapshotFrameAfterWidthChangesReflowsWithoutCorruption(t *testing.T) {
+	words := make([]string, 60)
+	for i := range words {
+		words[i] = fmt.Sprintf("word%02d", i)
 	}
+	sentence := strings.Join(words, " ")
+	for _, tc := range []struct {
+		name           string
+		prefix, suffix string
+	}{
+		{"visible", "", ""},
+		{"scrollback", strings.Repeat("old line\r\n", 5), "\r\n" + strings.Repeat("new line\r\n", 30)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			src, srcDrain := newScreen(80, 25, func(bool) {})
+			defer stopScreenDrain(src, srcDrain)
+			src.SetScrollbackSize(200)
+			if _, err := src.WriteString(tc.prefix + sentence + tc.suffix); err != nil {
+				t.Fatal(err)
+			}
 
-	// Production sequence: content wraps at launch width, browser attachment
-	// widens the non-reflowing buffer, and detach shrinks it by one column.
-	src.Resize(114, 8)
-	src.Resize(113, 8)
-	frame := snapshotFrameWithScreen(src, false, true)
-	if plain := ansi.Strip(string(frame)); strings.Contains(plain, "  ") {
-		t.Fatalf("checkpoint padded an old-width row at the new width: %q", plain)
-	}
+			// Production sequence: launch width, browser claim, then the
+			// detach shrink. Normal history must reflow at both width changes.
+			src.Resize(114, 44)
+			src.Resize(113, 44)
+			frame := snapshotFrameWithScreen(src, false, true)
+			plain := ansi.Strip(string(frame))
+			if !strings.Contains(plain, sentence) {
+				t.Fatalf("checkpoint lost sentence word fidelity: %q", plain)
+			}
+			if strings.Contains(plain, "  ") {
+				t.Fatalf("checkpoint injected interior padding: %q", plain)
+			}
 
-	dst, dstDrain := newScreen(113, 8, func(bool) {})
-	defer stopScreenDrain(dst, dstDrain)
-	if _, err := dst.Write(frame); err != nil {
-		t.Fatal(err)
+			dst, dstDrain := newScreen(113, 44, func(bool) {})
+			defer stopScreenDrain(dst, dstDrain)
+			dst.SetScrollbackSize(200)
+			if _, err := dst.Write(frame); err != nil {
+				t.Fatal(err)
+			}
+			assertScreensEqual(t, src, dst)
+			if src.Scrollback().Len() != dst.Scrollback().Len() {
+				t.Fatalf("scrollback lengths differ: %d != %d", src.Scrollback().Len(), dst.Scrollback().Len())
+			}
+			for i, line := range src.Scrollback().Lines() {
+				if line.Render() != dst.Scrollback().Line(i).Render() || src.Scrollback().Wrapped(i) != dst.Scrollback().Wrapped(i) {
+					t.Fatalf("scrollback row %d differs after replay", i)
+				}
+			}
+		})
 	}
-	assertScreensEqual(t, src, dst)
 }
 
 func assertScreensEqual(t *testing.T, want, got interface {

--- a/cli/gmux/internal/ptyserver/ptyserver_test.go
+++ b/cli/gmux/internal/ptyserver/ptyserver_test.go
@@ -2103,6 +2103,31 @@ func TestSnapshotFrameWrappedRowsRoundTrip(t *testing.T) {
 	}
 }
 
+func TestSnapshotFrameAfterWidthChangesDoesNotJoinOldWraps(t *testing.T) {
+	text := strings.Repeat("the quick brown fox jumps over the lazy dog ", 7)
+	src, srcDrain := newScreen(80, 8, func(bool) {})
+	defer stopScreenDrain(src, srcDrain)
+	if _, err := src.WriteString(text); err != nil {
+		t.Fatal(err)
+	}
+
+	// Production sequence: content wraps at launch width, browser attachment
+	// widens the non-reflowing buffer, and detach shrinks it by one column.
+	src.Resize(114, 8)
+	src.Resize(113, 8)
+	frame := snapshotFrameWithScreen(src, false, true)
+	if plain := ansi.Strip(string(frame)); strings.Contains(plain, "  ") {
+		t.Fatalf("checkpoint padded an old-width row at the new width: %q", plain)
+	}
+
+	dst, dstDrain := newScreen(113, 8, func(bool) {})
+	defer stopScreenDrain(dst, dstDrain)
+	if _, err := dst.Write(frame); err != nil {
+		t.Fatal(err)
+	}
+	assertScreensEqual(t, src, dst)
+}
+
 func assertScreensEqual(t *testing.T, want, got interface {
 	Width() int
 	Height() int

--- a/cli/gmux/internal/ptyserver/ptyserver_test.go
+++ b/cli/gmux/internal/ptyserver/ptyserver_test.go
@@ -926,14 +926,14 @@ func TestShutdownDrainNoRace(t *testing.T) {
 	}
 }
 
-func TestTerminalCheckpointMetadataCarriesMargins(t *testing.T) {
+func TestTerminalCheckpointMetadataCarriesGeometryAndMargins(t *testing.T) {
 	data, err := json.Marshal(terminalCheckpointMetadata{
-		Type: "terminal_checkpoint", ActiveBuffer: "alternate", ScrollTop: 2, ScrollBottom: 4, Rows: 44,
+		Type: "terminal_checkpoint", ActiveBuffer: "alternate", ScrollTop: 2, ScrollBottom: 4, Cols: 91, Rows: 44,
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := `{"type":"terminal_checkpoint","active_buffer":"alternate","scroll_top":2,"scroll_bottom":4,"rows":44}`
+	want := `{"type":"terminal_checkpoint","active_buffer":"alternate","scroll_top":2,"scroll_bottom":4,"cols":91,"rows":44}`
 	if string(data) != want {
 		t.Fatalf("metadata = %s, want %s", data, want)
 	}

--- a/cli/gmux/internal/ptyserver/ptyserver_test.go
+++ b/cli/gmux/internal/ptyserver/ptyserver_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	uv "github.com/charmbracelet/ultraviolet"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/gmuxapp/gmux/cli/gmux/internal/session"
 	"github.com/gmuxapp/gmux/packages/adapter"
@@ -2070,60 +2071,61 @@ func TestRenderScreenSoftWrapRoundTripReflows(t *testing.T) {
 	}
 }
 
-func TestRealScrollbackCheckpointKeepsPiLogicalLines(t *testing.T) {
-	const dir = "/home/mg/.local/state/gmux/sessions/sbsfn5fi"
-	var raw []byte
-	for _, name := range []string{"scrollback.0", "scrollback"} {
-		b, err := os.ReadFile(filepath.Join(dir, name))
-		if err != nil {
-			if os.IsNotExist(err) {
-				continue
+func TestSnapshotFrameWrappedRowsRoundTrip(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"boundary spaces", "the quick brown fox jumps"},
+		{"multiple boundaries", "one two three four five six seven eight nine ten eleven twelve"},
+		{"wide forced wrap", "123456789界XY"},
+		{"styled boundary blank", "123456789\x1b[44m \x1b[0mX"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			src, srcDrain := newScreen(10, 8, func(bool) {})
+			defer stopScreenDrain(src, srcDrain)
+			if _, err := src.WriteString(tc.input); err != nil {
+				t.Fatal(err)
 			}
-			t.Fatal(err)
-		}
-		raw = append(raw, b...)
-	}
-	if len(raw) == 0 {
-		t.Skip("local sbsfn5fi replay data is unavailable")
-	}
 
-	screen, drain := newScreen(114, 44, func(bool) {})
-	defer stopScreenDrain(screen, drain)
-	screen.SetScrollbackSize(2000)
-	if _, err := screen.Write(raw); err != nil {
-		t.Fatal(err)
-	}
-	checkpoint := renderScreen(screen)
-	plain := ansi.Strip(checkpoint)
-
-	// Every non-wrapped visual row ends one serialized logical line; wrapped
-	// rows must not contribute a CRLF. This checks all provenance bits in the
-	// real replay rather than relying only on the inspected samples below.
-	nonWrappedRows := 0
-	if sb := screen.Scrollback(); sb != nil {
-		for i := 0; i < sb.Len(); i++ {
-			if !sb.Wrapped(i) {
-				nonWrappedRows++
+			frame := snapshotFrameWithScreen(src, false, true)
+			if tc.name == "boundary spaces" && strings.Contains(ansi.Strip(string(frame)), "quickbrown") {
+				t.Fatalf("checkpoint concatenated words: %q", frame)
 			}
-		}
+			dst, dstDrain := newScreen(10, 8, func(bool) {})
+			defer stopScreenDrain(dst, dstDrain)
+			if _, err := dst.Write(frame); err != nil {
+				t.Fatal(err)
+			}
+			assertScreensEqual(t, src, dst)
+		})
 	}
-	for y := 0; y < screen.Height(); y++ {
-		if !screen.Wrapped(y) {
-			nonWrappedRows++
-		}
-	}
-	if logicalLines := strings.Count(checkpoint, "\r\n") + 1; logicalLines != nonWrappedRows {
-		t.Fatalf("serialized logical lines=%d, non-wrapped rows=%d", logicalLines, nonWrappedRows)
-	}
+}
 
-	// These were emitted by pi as individual logical lines and each spans
-	// more than one 114-column visual row in this recording.
-	for _, line := range []string{
-		"The stray empties are orphan working-copy commits from each abandon — not on the branch line, never pushed. Branch is 13 clean commits. Pushing:",
-		"The split landed correctly (30fafd2 = scroll-anchor, 72cd036 = protocol) but both carry the same message. Fixingthe second's description:",
-	} {
-		if !strings.Contains(plain, line) {
-			t.Fatalf("checkpoint split known logical line at a visual boundary: %q", line)
+func assertScreensEqual(t *testing.T, want, got interface {
+	Width() int
+	Height() int
+	Wrapped(int) bool
+	CellAt(int, int) *uv.Cell
+	CursorPosition() uv.Position
+}) {
+	t.Helper()
+	if want.Width() != got.Width() || want.Height() != got.Height() {
+		t.Fatalf("screen sizes differ: %dx%d != %dx%d", want.Width(), want.Height(), got.Width(), got.Height())
+	}
+	if want.CursorPosition() != got.CursorPosition() {
+		t.Errorf("cursor differs: want %+v, got %+v", want.CursorPosition(), got.CursorPosition())
+	}
+	for y := 0; y < want.Height(); y++ {
+		if want.Wrapped(y) != got.Wrapped(y) {
+			t.Errorf("row %d wrapped: want %v, got %v", y, want.Wrapped(y), got.Wrapped(y))
+		}
+		for x := 0; x < want.Width(); x++ {
+			wc, gc := want.CellAt(x, y), got.CellAt(x, y)
+			if (wc == nil) != (gc == nil) || (wc != nil && !wc.Equal(gc)) {
+				t.Errorf("cell (%d,%d) differs: want %#v, got %#v", x, y, wc, gc)
+			}
 		}
 	}
 }

--- a/e2e/tests/terminal-reattach-fidelity.spec.ts
+++ b/e2e/tests/terminal-reattach-fidelity.spec.ts
@@ -1,0 +1,121 @@
+import { expect, test, type Page } from '@playwright/test'
+import { apiGet, gotoSession, openApp, pollUntil } from '../helpers'
+
+/**
+ * Composed regression tests for checkpoint replay fidelity (v2.1 review
+ * findings F1/F2 and the reflow follow-up).
+ *
+ * Contract under test: soft-wrapped prose replays with FULL WORD FIDELITY —
+ * no concatenated words (trimmed boundary spaces) and no interior padding
+ * runs (stale-width joins) — across:
+ *  - a first attach whose content wrapped at the runner's pre-claim width,
+ *  - a detach/reattach cycle spanning the runner's reconnect shrink
+ *    (the emulator reflows its normal buffer on width changes), and
+ *  - content that has rotated into scrollback before the width changes.
+ */
+
+const WORDS = ['alpha', 'bravo', 'charlie', 'delta', 'echo', 'foxtrot', 'golf', 'hotel', 'india', 'juliet', 'kilo', 'lima', 'mike', 'november', 'oscar', 'papa']
+
+function sentence(): string {
+  const parts: string[] = []
+  for (let i = 0; i < 60; i++) parts.push(WORDS[i % WORDS.length])
+  return parts.join(' ')
+}
+
+async function launchSession(page: Page, command: string): Promise<string> {
+  const cwd = process.env.GMUX_TEST_WORKSPACE!
+  const before = await apiGet<{ data: Array<{ id: string }> }>('/v1/sessions')
+  const known = new Set(before.body.data.map(s => s.id))
+  const launched = await page.evaluate(async ({ command, cwd }) => {
+    const r = await fetch('/v1/launch', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ command: ['bash', '-c', command], cwd }) })
+    return { ok: r.ok, text: await r.text() }
+  }, { command, cwd })
+  expect(launched.ok, launched.text).toBe(true)
+  return pollUntil(async () => {
+    const r = await apiGet<{ data: Array<{ id: string, alive: boolean }> }>('/v1/sessions')
+    return r.body.data.find(s => s.alive && !known.has(s.id))?.id
+  }, { timeoutMs: 10_000, description: 'fidelity session' })
+}
+
+function wrappedSentenceCommand(scrollbackFiller = 0): string {
+  const filler = scrollbackFiller > 0
+    ? `for i in $(seq 1 ${scrollbackFiller}); do printf 'filler-%03d\\r\\n' "$i"; done; `
+    : ''
+  return `printf '%s\\r\\n' 'MARKER-BEGIN'; printf '%s\\r\\n' '${sentence()}'; printf '%s\\r\\n' 'MARKER-END'; ${filler}while :; do sleep 1; done`
+}
+
+async function waitForText(page: Page, text: string): Promise<void> {
+  await page.waitForFunction((needle) => {
+    const t = (window as any).__gmuxTerm
+    if (!t) return false
+    const buf = t.buffer.active
+    for (let y = 0; y < buf.length; y++) {
+      if (buf.getLine(y)?.translateToString(true).includes(needle)) return true
+    }
+    return false
+  }, text, { timeout: 15_000 })
+}
+
+/** The sentence between the markers, joined across buffer rows unmodified. */
+async function replayedWords(page: Page): Promise<string[]> {
+  const lines = await page.evaluate(() => {
+    const t = (window as any).__gmuxTerm
+    const buf = t.buffer.active
+    const out: string[] = []
+    for (let y = 0; y < buf.length; y++) out.push(buf.getLine(y)?.translateToString(false) ?? '')
+    return out
+  })
+  const begin = lines.findIndex(l => l.includes('MARKER-BEGIN'))
+  const end = lines.findIndex(l => l.includes('MARKER-END'))
+  expect(begin, `markers missing in buffer: begin=${begin} end=${end}`).toBeGreaterThanOrEqual(0)
+  expect(end).toBeGreaterThan(begin)
+  // No trailing-whitespace stripping per row: word fidelity must come from
+  // the replayed cells themselves. Interior padding runs and concatenations
+  // both surface as word-list mismatches.
+  return lines.slice(begin + 1, end).join('').split(/\s+/).filter(Boolean)
+}
+
+async function detachAndReturn(page: Page, id: string): Promise<void> {
+  // Last viewer leaving shrinks the PTY by one column without updating
+  // session metadata — the historical stale-width trap.
+  await page.goto('/')
+  await page.waitForTimeout(1500)
+  await gotoSession(page, id)
+  await waitForText(page, 'MARKER-END')
+  await page.waitForTimeout(500)
+}
+
+test('first attach joins pre-claim wrapped output without corrupting words', async ({ page }) => {
+  await openApp(page)
+  const id = await launchSession(page, wrappedSentenceCommand())
+  await gotoSession(page, id)
+  await waitForText(page, 'MARKER-END')
+  await expect(page.locator('.terminal-loading')).not.toBeVisible({ timeout: 5_000 })
+  await page.waitForTimeout(500)
+
+  expect(await replayedWords(page)).toEqual(sentence().split(' '))
+})
+
+test('reattach after the reconnect shrink preserves word fidelity', async ({ page }) => {
+  await openApp(page)
+  const id = await launchSession(page, wrappedSentenceCommand())
+  await gotoSession(page, id)
+  await waitForText(page, 'MARKER-END')
+  await expect(page.locator('.terminal-loading')).not.toBeVisible({ timeout: 5_000 })
+
+  await detachAndReturn(page, id)
+  expect(await replayedWords(page)).toEqual(sentence().split(' '))
+})
+
+test('wrapped prose in scrollback survives the reconnect shrink', async ({ page }) => {
+  await openApp(page)
+  // Enough filler to push the wrapped sentence well into scrollback before
+  // any width change, so the replay exercises scrollback reflow + join.
+  const id = await launchSession(page, wrappedSentenceCommand(80))
+  await gotoSession(page, id)
+  await waitForText(page, 'filler-080')
+  await expect(page.locator('.terminal-loading')).not.toBeVisible({ timeout: 5_000 })
+
+  await detachAndReturn(page, id)
+  expect(await replayedWords(page)).toEqual(sentence().split(' '))
+})

--- a/e2e/tests/terminal-reattach-geometry.spec.ts
+++ b/e2e/tests/terminal-reattach-geometry.spec.ts
@@ -1,0 +1,123 @@
+import { expect, test, type Page } from '@playwright/test'
+import { apiGet, gotoSession, openApp, pollUntil } from '../helpers'
+
+async function installGeometryProbe(page: Page) {
+  await page.addInitScript(() => {
+    ;(window as any).__checkpointGeometryEvents = []
+    ;(window as any).__geometrySockets = []
+    const Native = window.WebSocket
+    const Wrapped = function (...args: ConstructorParameters<typeof WebSocket>) {
+      const ws = new Native(...args)
+      ;(window as any).__geometrySockets.push(ws)
+      const nativeSend = ws.send.bind(ws)
+      ws.send = ((data: string | ArrayBufferLike | Blob | ArrayBufferView) => {
+        if (typeof data === 'string') {
+          try {
+            const msg = JSON.parse(data)
+            if (msg.type === 'resize') (window as any).__checkpointGeometryEvents.push({ kind: 'server-resize', cols: msg.cols, rows: msg.rows })
+          } catch {}
+        }
+        nativeSend(data as never)
+      }) as typeof ws.send
+      let productionHandler: ((this: WebSocket, ev: MessageEvent) => unknown) | null = null
+      Object.defineProperty(ws, 'onmessage', {
+        configurable: true,
+        get: () => productionHandler,
+        set: handler => { productionHandler = handler },
+      })
+      ws.addEventListener('message', event => {
+        if (typeof event.data === 'string') {
+          try {
+            const msg = JSON.parse(event.data)
+            if (msg.type === 'terminal_checkpoint') {
+              ;(window as any).__checkpointGeometryEvents.push({ kind: 'metadata', cols: msg.cols, rows: msg.rows })
+            }
+          } catch {}
+        }
+        setTimeout(() => productionHandler?.call(ws, event), typeof event.data === 'string' ? 0 : 200)
+      })
+      return ws
+    } as unknown as typeof WebSocket
+    Object.assign(Wrapped, Native)
+    Wrapped.prototype = Native.prototype
+    ;(window as any).WebSocket = Wrapped
+
+    const seen = new WeakSet<object>()
+    setInterval(() => {
+      const term = (window as any).__gmuxTerm
+      if (!term || seen.has(term)) return
+      seen.add(term)
+      const resize = term.resize.bind(term)
+      term.resize = (cols: number, rows: number) => {
+        ;(window as any).__checkpointGeometryEvents.push({ kind: 'resize', cols, rows })
+        resize(cols, rows)
+      }
+      const write = term.write.bind(term)
+      term.write = (data: string | Uint8Array, callback?: () => void) => {
+        ;(window as any).__checkpointGeometryEvents.push({ kind: 'write', cols: term.cols, rows: term.rows })
+        write(data, callback)
+      }
+    }, 1)
+  })
+}
+
+async function launchIdle(page: Page): Promise<string> {
+  const before = await apiGet<{ data: Array<{ id: string }> }>('/v1/sessions')
+  const known = new Set(before.body.data.map(s => s.id))
+  const cwd = process.env.GMUX_TEST_WORKSPACE!
+  const launched = await page.evaluate(async ({ cwd }) => {
+    const r = await fetch('/v1/launch', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ command: ['bash', '-c', "printf 'REATTACH-GEOMETRY\\r\\n'; while :; do sleep 1; done"], cwd }),
+    })
+    return { ok: r.ok, text: await r.text() }
+  }, { cwd })
+  expect(launched.ok, launched.text).toBe(true)
+  return pollUntil(async () => {
+    const r = await apiGet<{ data: Array<{ id: string, alive: boolean }> }>('/v1/sessions')
+    return r.body.data.find(s => s.alive && !known.has(s.id))?.id
+  }, { timeoutMs: 10_000, description: 'reattach geometry session' })
+}
+
+test('reattach replays at the runner-declared shrunken geometry', async ({ page }) => {
+  await installGeometryProbe(page)
+  await openApp(page)
+  const id = await launchIdle(page)
+  await gotoSession(page, id)
+  await expect.poll(() => page.evaluate(() => (window as any).__checkpointGeometryEvents
+    .find((event: any) => event.kind === 'metadata')?.cols)).toBeGreaterThan(1)
+  await expect(page.locator('.terminal-loading')).not.toBeVisible({ timeout: 5_000 })
+  await page.waitForTimeout(500)
+  const before = 100
+  await page.evaluate(({ sessionId, cols }) => {
+    const ws = ((window as any).__geometrySockets as WebSocket[]).find(socket =>
+      socket.url.includes(`/ws/${sessionId}`) && socket.readyState === WebSocket.OPEN)
+    ws?.send(JSON.stringify({ type: 'resize', cols, rows: 25 }))
+  }, { sessionId: id, cols: before })
+  await page.waitForTimeout(200)
+  await page.evaluate((sessionId) => {
+    for (const ws of (window as any).__geometrySockets as WebSocket[]) {
+      if (ws.url.includes(`/ws/${sessionId}`) && ws.readyState === WebSocket.OPEN) ws.close()
+    }
+  }, id)
+  await page.waitForTimeout(50)
+  await page.goto('about:blank')
+  await page.waitForTimeout(1500)
+  await openApp(page)
+  await page.evaluate(() => { (window as any).__checkpointGeometryEvents = [] })
+  await gotoSession(page, id)
+
+  await expect.poll(() => page.evaluate(() => (window as any).__checkpointGeometryEvents
+    .some((event: any) => event.kind === 'write'))).toBe(true)
+  const events = await page.evaluate(() => (window as any).__checkpointGeometryEvents) as Array<any>
+  const metadataIndex = events.findIndex(event => event.kind === 'metadata')
+  const writeIndex = events.findIndex(event => event.kind === 'write')
+  const declared = events[metadataIndex]
+  const barrierIndex = events.findIndex((event, index) => index > metadataIndex && index < writeIndex
+    && event.kind === 'resize' && event.cols === declared.cols && event.rows === declared.rows)
+
+  // The runner metadata is the source of truth for the replay barrier.
+  expect(declared.cols).toBeGreaterThan(1)
+  expect(barrierIndex, JSON.stringify(events)).toBeGreaterThan(metadataIndex)
+  expect(events[writeIndex]).toMatchObject({ cols: declared.cols, rows: declared.rows })
+})

--- a/packages/scroll-anchor/src/index.test.ts
+++ b/packages/scroll-anchor/src/index.test.ts
@@ -225,6 +225,17 @@ describe('ScrollAnchorAddon', () => {
     expect(h.addon.mode).toBe('following')
   })
 
+  it('lets fresh wheel intent supersede a stale programmatic-scroll token', () => {
+    const h = makeHarness()
+    h.setBuffer(20, 20)
+    // Model an addon scroll that xterm clamps/no-ops and therefore never
+    // delivers through onScroll, leaving its suppression token outstanding.
+    ;(h.addon as any).runProgrammaticScroll(() => h.setBuffer(20, 20))
+
+    h.userScroll(12)
+    expect(h.addon.mode).toBe('anchored')
+  })
+
   it('suppresses an asynchronously delivered addon scroll before a later user scroll', async () => {
     const h = makeHarness()
     h.setBuffer(20, 20)
@@ -237,10 +248,13 @@ describe('ScrollAnchorAddon', () => {
     expect(h.addon.mode).toBe('following')
   })
 
-  it('follows structurally when a non-wheel scroll lands at bottom', () => {
+  it('follows structurally only when a non-intent scroll reaches bottom', () => {
     const h = makeHarness()
     h.setBuffer(20, 20)
     h.userScroll(10)
+    expect(h.addon.mode).toBe('anchored')
+
+    h.outputScroll(19)
     expect(h.addon.mode).toBe('anchored')
     h.outputScroll(20)
     expect(h.addon.mode).toBe('following')

--- a/packages/scrollback/scrollback.go
+++ b/packages/scrollback/scrollback.go
@@ -319,7 +319,8 @@ func extractLines(e *vt.Emulator) []string {
 	var rows []row
 	if sb := e.Scrollback(); sb != nil {
 		for i, line := range sb.Lines() {
-			rows = append(rows, row{plainLine(line), sb.Wrapped(i)})
+			wrapped := sb.Wrapped(i)
+			rows = append(rows, row{plainLine(line, wrapped), wrapped})
 		}
 	}
 
@@ -332,7 +333,8 @@ func extractLines(e *vt.Emulator) []string {
 				line[x] = *c
 			}
 		}
-		visible[y] = row{plainLine(line), e.Wrapped(y)}
+		wrapped := e.Wrapped(y)
+		visible[y] = row{plainLine(line, wrapped), wrapped}
 	}
 	end := len(visible)
 	for end > 0 && strings.TrimSpace(visible[end-1].text) == "" {
@@ -355,9 +357,10 @@ func extractLines(e *vt.Emulator) []string {
 	return lines
 }
 
-// plainLine renders a terminal line as plain text (no ANSI styling),
-// right-trimming trailing spaces so short lines don't emit padding.
-func plainLine(line uv.Line) string {
+// plainLine renders a terminal line as plain text (no ANSI styling). Wrapped
+// rows keep their full cell width because every trailing blank was consumed at
+// the wrap boundary; terminating rows still discard unused padding.
+func plainLine(line uv.Line, wrapped bool) string {
 	var b strings.Builder
 	for _, c := range line {
 		if c.Content == "" {
@@ -365,6 +368,9 @@ func plainLine(line uv.Line) string {
 		} else {
 			b.WriteString(c.Content)
 		}
+	}
+	if wrapped {
+		return b.String()
 	}
 	return strings.TrimRight(b.String(), " ")
 }

--- a/packages/scrollback/scrollback.go
+++ b/packages/scrollback/scrollback.go
@@ -363,6 +363,11 @@ func extractLines(e *vt.Emulator) []string {
 func plainLine(line uv.Line, wrapped bool) string {
 	var b strings.Builder
 	for _, c := range line {
+		if c.IsZero() {
+			// Wide-cell placeholders and synthetic early-wrap skips carry no
+			// plain-text content.
+			continue
+		}
 		if c.Content == "" {
 			b.WriteString(" ")
 		} else {

--- a/packages/scrollback/scrollback_test.go
+++ b/packages/scrollback/scrollback_test.go
@@ -670,6 +670,17 @@ func TestRenderTailJoinsSoftWrappedRows(t *testing.T) {
 // The final written space wraps onto a blank continuation row. Trimming that
 // blank visible row leaves a wrap-marked row as the final extracted row, which
 // must still be flushed as a logical line.
+func TestRenderTailOmitsSyntheticWideWrapSkip(t *testing.T) {
+	lines, err := RenderTail(strings.NewReader("abc界X"), 4, 4, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"abc界X"}
+	if !equalLines(lines, want) {
+		t.Fatalf("got %q, want %q", lines, want)
+	}
+}
+
 func TestRenderTailFlushesFinalWrappedRow(t *testing.T) {
 	lines, err := RenderTail(strings.NewReader("123456789  "), 10, 4, 10)
 	if err != nil {

--- a/packages/scrollback/scrollback_test.go
+++ b/packages/scrollback/scrollback_test.go
@@ -651,12 +651,31 @@ func TestRenderTailRaceFreeWithResponses(t *testing.T) {
 }
 
 func TestRenderTailJoinsSoftWrappedRows(t *testing.T) {
-	text := strings.Repeat("wrap-provenance-", 8)
-	lines, err := RenderTail(strings.NewReader(text+"\r\nHARD\r\n"), 40, 8, 10)
+	texts := []string{
+		strings.Repeat("wrap-provenance-", 8),
+		"the quick brown fox jumps over the lazy dog and then crosses another boundary",
+	}
+	for _, text := range texts {
+		lines, err := RenderTail(strings.NewReader(text+"\r\nHARD\r\n"), 10, 16, 10)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := []string{text, "HARD"}
+		if !equalLines(lines, want) {
+			t.Fatalf("got %q, want %q", lines, want)
+		}
+	}
+}
+
+// The final written space wraps onto a blank continuation row. Trimming that
+// blank visible row leaves a wrap-marked row as the final extracted row, which
+// must still be flushed as a logical line.
+func TestRenderTailFlushesFinalWrappedRow(t *testing.T) {
+	lines, err := RenderTail(strings.NewReader("123456789  "), 10, 4, 10)
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := []string{text, "HARD"}
+	want := []string{"123456789 "}
 	if !equalLines(lines, want) {
 		t.Fatalf("got %q, want %q", lines, want)
 	}

--- a/third_party/vt/GMUX-PATCH.md
+++ b/third_party/vt/GMUX-PATCH.md
@@ -18,15 +18,20 @@ intended for upstreaming.
   cursor movement, and controls can cancel phantom state.
 - Full-width insert/delete/scroll operations move bits with their rows;
   partial-width vertical operations clear the affected ambiguous provenance.
-  Whole-row erase/fill and reset clear bits. Resize preserves surviving row
-  bits, matching the underlying buffer's current non-reflowing resize.
+  Whole-row erase/fill and reset clear bits. Height-only resize preserves
+  surviving row bits, but width changes clear all visible-row bits on both
+  screens. The buffer is non-reflowing, so after a width change the old wrap
+  column is unknowable; clearing restores the invariant that every retained
+  bit identifies a wrap at exactly the row's current width, which is required
+  for faithful logical-line joining.
 - Full-width scroll regions carry the discarded rows' bits into normal
   scrollback, matching vt's existing history behavior. Normal and alternate
   screens retain independent visible-row bits; public scrollback remains the
   normal buffer's.
 - `wrap_test.go` covers phantom confirmation/cancellation, DECAWM off,
   bottom-row scrolling, wide and combining graphemes, margins, row edits,
-  alternate-buffer isolation, resize, RIS, and ED3.
+  alternate-buffer isolation, width-change clearing, height-only resize
+  preservation, RIS, and ED3.
 
 No parser, cell, rendering, or hyperlink representation was replaced. In
 particular, `ultraviolet.Cell.Link` and existing ANSI rendering remain intact.

--- a/third_party/vt/GMUX-PATCH.md
+++ b/third_party/vt/GMUX-PATCH.md
@@ -12,25 +12,32 @@ intended for upstreaming.
   `Wrapped(index)` exposes read-only access. The old public `PushN` operation,
   which accepted a metadata-free `RenderBuffer`, is replaced by private,
   screen-aware `pushN`; full-row transfers therefore cannot silently lose wrap
-  provenance. Truncation, resizing, and clearing keep the slices aligned.
+  provenance. Wrapped pushes preserve the complete source row, including
+  trailing blank cells consumed at the wrap boundary; only terminating rows
+  trim unused padding. Truncation, reflow, and clearing keep metadata aligned.
 - `utf8.go` marks a row only when a subsequent grapheme consumes pending
   phantom autowrap. Filling the final cell alone does not mark it because CR,
   cursor movement, and controls can cancel phantom state.
 - Full-width insert/delete/scroll operations move bits with their rows;
   partial-width vertical operations clear the affected ambiguous provenance.
   Whole-row erase/fill and reset clear bits. Height-only resize preserves
-  surviving row bits, but width changes clear all visible-row bits on both
-  screens. The buffer is non-reflowing, so after a width change the old wrap
-  column is unknowable; clearing restores the invariant that every retained
-  bit identifies a wrap at exactly the row's current width, which is required
-  for faithful logical-line joining.
+  surviving row bits. On a width change the normal buffer groups scrollback
+  and visible rows into logical lines, preserves consumed cells and cursor
+  offset, and rewraps them at the new width without splitting wide graphemes.
+  It then repartitions the result between bounded scrollback and the new
+  viewport. This matches xterm.js: non-reflowing history cannot preserve both
+  word and grid fidelity, while reflow ensures every retained wrap bit refers
+  to exactly its row's stored width. The alternate buffer remains
+  non-reflowing and clears its wrap bits on width changes.
 - Full-width scroll regions carry the discarded rows' bits into normal
   scrollback, matching vt's existing history behavior. Normal and alternate
   screens retain independent visible-row bits; public scrollback remains the
   normal buffer's.
 - `wrap_test.go` covers phantom confirmation/cancellation, DECAWM off,
   bottom-row scrolling, wide and combining graphemes, margins, row edits,
-  alternate-buffer isolation, width-change clearing, height-only resize
+  alternate-buffer isolation, normal-buffer reflow across the
+  scrollback/viewport boundary, boundary spaces, wide and styled cells,
+  cursor remapping, blank lines, scrollback bounds, height-only resize
   preservation, RIS, and ED3.
 
 No parser, cell, rendering, or hyperlink representation was replaced. In

--- a/third_party/vt/GMUX-PATCH.md
+++ b/third_party/vt/GMUX-PATCH.md
@@ -15,9 +15,14 @@ intended for upstreaming.
   provenance. Wrapped pushes preserve the complete source row, including
   trailing blank cells consumed at the wrap boundary; only terminating rows
   trim unused padding. Truncation, reflow, and clearing keep metadata aligned.
-- `utf8.go` marks a row only when a subsequent grapheme consumes pending
-  phantom autowrap. Filling the final cell alone does not mark it because CR,
-  cursor movement, and controls can cancel phantom state.
+- `utf8.go` fixes an upstream wide-write bug: with one column remaining,
+  autowrap now moves a width-2 grapheme to the next row instead of passing it
+  to `RenderBuffer` to be clipped and silently lost. The skipped column is an
+  explicit zero cell, distinct from an `EmptyCell` written space. Reflow drops
+  only these trailing synthetic skips and recreates them when a wide grapheme
+  again wraps early. Ordinary pending phantom autowrap is still marked only
+  when a subsequent grapheme consumes it; exactly-fitting wide cells compute
+  phantom state from their post-write edge.
 - Full-width insert/delete/scroll operations move bits with their rows;
   partial-width vertical operations clear the affected ambiguous provenance.
   Whole-row erase/fill and reset clear bits. Height-only resize preserves
@@ -38,7 +43,10 @@ intended for upstreaming.
   alternate-buffer isolation, normal-buffer reflow across the
   scrollback/viewport boundary, boundary spaces, wide and styled cells,
   cursor remapping, blank lines, scrollback bounds, height-only resize
-  preservation, RIS, and ED3.
+  preservation, RIS, and ED3. `BenchmarkReflow2000ScrollbackLines` measured
+  16.1 ms per 2,000-line reflow on an Intel i7-9700K (`-benchtime=5x`).
+  Amortizing repeated reflows caused by `shrinkForReconnect` remains a known
+  follow-up.
 
 No parser, cell, rendering, or hyperlink representation was replaced. In
 particular, `ultraviolet.Cell.Link` and existing ANSI rendering remain intact.

--- a/third_party/vt/emulator.go
+++ b/third_party/vt/emulator.go
@@ -221,9 +221,27 @@ func (e *Emulator) Resize(width int, height int) {
 	x, y := e.scr.CursorPosition()
 	if e.atPhantom {
 		if x < width-1 {
-			e.atPhantom = false
 			x++
 		}
+		e.atPhantom = false
+	}
+
+	oldWidth := e.Width()
+	if oldWidth != width {
+		nx, ny := e.scrs[0].CursorPosition()
+		normalCursor := uv.Pos(nx, ny)
+		if e.scr == &e.scrs[0] {
+			normalCursor = uv.Pos(x, y)
+		}
+		normalCursor = e.scrs[0].reflow(width, height, normalCursor)
+		e.scrs[0].setCursor(normalCursor.X, normalCursor.Y, false)
+		e.scrs[1].Resize(width, height)
+		if e.scr == &e.scrs[0] {
+			x, y = normalCursor.X, normalCursor.Y
+		}
+	} else {
+		e.scrs[0].Resize(width, height)
+		e.scrs[1].Resize(width, height)
 	}
 
 	if y < 0 {
@@ -238,9 +256,6 @@ func (e *Emulator) Resize(width int, height int) {
 	if x >= width {
 		x = width - 1
 	}
-
-	e.scrs[0].Resize(width, height)
-	e.scrs[1].Resize(width, height)
 	e.tabstops = uv.DefaultTabStops(width)
 
 	e.setCursor(x, y)

--- a/third_party/vt/screen.go
+++ b/third_party/vt/screen.go
@@ -88,6 +88,10 @@ func (s *Screen) Height() int {
 
 // Resize resizes the screen.
 func (s *Screen) Resize(width int, height int) {
+	oldWidth := 0
+	if s.buf != nil {
+		oldWidth = s.buf.Width()
+	}
 	if s.buf == nil {
 		s.buf = uv.NewRenderBuffer(width, height)
 	} else {
@@ -95,7 +99,12 @@ func (s *Screen) Resize(width int, height int) {
 		s.buf.Touched = nil
 	}
 	wrapped := make([]bool, height)
-	copy(wrapped, s.wrapped)
+	// RenderBuffer resize is non-reflowing. A width change therefore makes
+	// the old wrap column unknowable; retaining its bit would falsely join
+	// the row at the new width. Height-only resizes preserve row provenance.
+	if oldWidth == width {
+		copy(wrapped, s.wrapped)
+	}
 	s.wrapped = wrapped
 	s.scroll = s.buf.Bounds()
 }

--- a/third_party/vt/screen.go
+++ b/third_party/vt/screen.go
@@ -150,6 +150,10 @@ func (s *Screen) reflow(width, height int, cursor uv.Position) uv.Position {
 		consumed := lineContentLen(row.line)
 		if row.wrapped {
 			consumed = len(row.line)
+			for consumed > 0 && row.line[consumed-1].IsZero() &&
+				!isWidePlaceholder(row.line, consumed-1) {
+				consumed--
+			}
 		}
 		if i == sbLen+cursor.Y {
 			cursorLine = len(logical)
@@ -188,6 +192,9 @@ func (s *Screen) reflow(width, height int, cursor uv.Position) uv.Position {
 					continue
 				}
 				if cellWidth > width-col {
+					for skip := col; skip < width; skip++ {
+						row[skip] = uv.Cell{}
+					}
 					rows = append(rows, sourceRow{line: row, wrapped: true})
 					row, col = uv.NewLine(width), 0
 				}
@@ -228,17 +235,28 @@ func (s *Screen) reflow(width, height int, cursor uv.Position) uv.Position {
 			break
 		}
 		for x := range row.line {
-			cell := row.line[x]
-			if cell.Width == 0 {
-				continue
+			// Rows were assembled with valid wide-cell placeholders already.
+			// Copy raw cells so synthetic zero skips are not normalized back to
+			// EmptyCell and placeholders do not erase their owning wide cell.
+			if dst := s.buf.CellAt(x, y); dst != nil {
+				*dst = row.line[x]
 			}
-			s.buf.SetCell(x, y, &cell)
 		}
 		s.wrapped[y] = row.wrapped
 	}
 	s.scroll = s.buf.Bounds()
 	s.touchArea(s.buf.Bounds())
 	return uv.Pos(cursorCol, cursorRow-windowStart)
+}
+
+func isWidePlaceholder(line uv.Line, index int) bool {
+	for distance := 1; index-distance >= 0; distance++ {
+		width := line[index-distance].Width
+		if width > 0 {
+			return width > distance
+		}
+	}
+	return false
 }
 
 func lineContentLen(line uv.Line) int {

--- a/third_party/vt/screen.go
+++ b/third_party/vt/screen.go
@@ -1,6 +1,8 @@
 package vt
 
 import (
+	"slices"
+
 	uv "github.com/charmbracelet/ultraviolet"
 	"github.com/charmbracelet/x/exp/ordered"
 )
@@ -107,6 +109,145 @@ func (s *Screen) Resize(width int, height int) {
 	}
 	s.wrapped = wrapped
 	s.scroll = s.buf.Bounds()
+}
+
+// reflow resizes the normal screen by rebuilding scrollback and visible rows
+// from logical lines. cursor is relative to the old visible screen.
+func (s *Screen) reflow(width, height int, cursor uv.Position) uv.Position {
+	type sourceRow struct {
+		line    uv.Line
+		wrapped bool
+	}
+	var source []sourceRow
+	sbLen := 0
+	if s.scrollback != nil {
+		sbLen = s.scrollback.Len()
+		for i, line := range s.scrollback.Lines() {
+			source = append(source, sourceRow{slices.Clone(line), s.scrollback.Wrapped(i)})
+		}
+	}
+	lastRow := cursor.Y
+	for y := s.Height() - 1; y >= 0; y-- {
+		if lineContentLen(s.buf.Line(y)) > 0 {
+			lastRow = max(lastRow, y)
+			break
+		}
+	}
+	for y := 0; y <= lastRow && y < s.Height(); y++ {
+		source = append(source, sourceRow{slices.Clone(s.buf.Line(y)), s.Wrapped(y)})
+	}
+	if len(source) == 0 {
+		source = append(source, sourceRow{})
+	}
+
+	type logicalLine struct {
+		cells []uv.Cell
+	}
+	var logical []logicalLine
+	cursorLine, cursorOffset := 0, 0
+	current := logicalLine{}
+	for i, row := range source {
+		consumed := lineContentLen(row.line)
+		if row.wrapped {
+			consumed = len(row.line)
+		}
+		if i == sbLen+cursor.Y {
+			cursorLine = len(logical)
+			cursorOffset = len(current.cells) + min(max(cursor.X, 0), consumed)
+		}
+		current.cells = append(current.cells, row.line[:consumed]...)
+		if !row.wrapped {
+			logical = append(logical, current)
+			current = logicalLine{}
+		}
+	}
+	if len(current.cells) > 0 || source[len(source)-1].wrapped {
+		logical = append(logical, current)
+	}
+	if len(logical) == 0 {
+		logical = append(logical, logicalLine{})
+	}
+	cursorLine = min(cursorLine, len(logical)-1)
+	cursorOffset = min(cursorOffset, len(logical[cursorLine].cells))
+
+	var rows []sourceRow
+	cursorRow, cursorCol := 0, 0
+	for li, line := range logical {
+		lineStart := len(rows)
+		cursorMapped := false
+		if len(line.cells) == 0 {
+			rows = append(rows, sourceRow{line: uv.NewLine(width)})
+		} else {
+			row := uv.NewLine(width)
+			col := 0
+			for i := 0; i < len(line.cells); {
+				cell := line.cells[i]
+				cellWidth := max(cell.Width, 1)
+				if cell.Width == 0 { // placeholder already emitted with its wide cell
+					i++
+					continue
+				}
+				if cellWidth > width-col {
+					rows = append(rows, sourceRow{line: row, wrapped: true})
+					row, col = uv.NewLine(width), 0
+				}
+				if li == cursorLine && !cursorMapped && cursorOffset <= i {
+					cursorRow, cursorCol = len(rows), col
+					cursorMapped = true
+				}
+				row.Set(col, &cell)
+				col += cellWidth
+				i += cellWidth
+				if col == width && i < len(line.cells) {
+					rows = append(rows, sourceRow{line: row, wrapped: true})
+					row, col = uv.NewLine(width), 0
+				}
+			}
+			if li == cursorLine && !cursorMapped {
+				cursorRow, cursorCol = len(rows), min(col, width-1)
+			}
+			rows = append(rows, sourceRow{line: row})
+		}
+		if li == cursorLine && len(line.cells) == 0 {
+			cursorRow, cursorCol = lineStart, 0
+		}
+	}
+
+	windowStart := max(len(rows)-height, 0)
+	windowStart = min(windowStart, cursorRow)
+	if s.scrollback != nil {
+		s.scrollback.Clear()
+		for _, row := range rows[:windowStart] {
+			s.scrollback.PushWrapped(row.line, row.wrapped)
+		}
+	}
+	s.buf = uv.NewRenderBuffer(width, height)
+	s.wrapped = make([]bool, height)
+	for y, row := range rows[windowStart:] {
+		if y >= height {
+			break
+		}
+		for x := range row.line {
+			cell := row.line[x]
+			if cell.Width == 0 {
+				continue
+			}
+			s.buf.SetCell(x, y, &cell)
+		}
+		s.wrapped[y] = row.wrapped
+	}
+	s.scroll = s.buf.Bounds()
+	s.touchArea(s.buf.Bounds())
+	return uv.Pos(cursorCol, cursorRow-windowStart)
+}
+
+func lineContentLen(line uv.Line) int {
+	for i := len(line) - 1; i >= 0; i-- {
+		if !line[i].IsZero() && !line[i].Equal(&uv.EmptyCell) {
+			return i + 1
+		}
+	}
+	return 0
 }
 
 // Width returns the width of the screen.

--- a/third_party/vt/scrollback.go
+++ b/third_party/vt/scrollback.go
@@ -37,19 +37,21 @@ func (s *Scrollback) PushWrapped(line uv.Line, wrapped bool) {
 		return
 	}
 
-	// Find last non-empty cell to trim trailing empty cells.
-	// This helps with wrapping and window resizing.
-	lastNonEmpty := -1
-	for i := len(line) - 1; i >= 0; i-- {
-		c := &line[i]
-		if !c.IsZero() && !c.Equal(&uv.EmptyCell) {
-			lastNonEmpty = i
-			break
+	last := len(line)
+	if !wrapped {
+		// Only a terminating row has unused trailing cells. Every cell of a
+		// wrapped row was consumed at its wrap width, including boundary
+		// spaces and the skipped blank before an early-wrapped wide cell.
+		last = 0
+		for i := len(line) - 1; i >= 0; i-- {
+			c := &line[i]
+			if !c.IsZero() && !c.Equal(&uv.EmptyCell) {
+				last = i + 1
+				break
+			}
 		}
 	}
-
-	// Clone the line content up to and including the last non-empty cell
-	cloned := slices.Clone(line[:lastNonEmpty+1])
+	cloned := slices.Clone(line[:last])
 
 	if len(s.lines) >= s.maxLines {
 		// Remove oldest line and append new one

--- a/third_party/vt/utf8.go
+++ b/third_party/vt/utf8.go
@@ -88,11 +88,33 @@ func (e *Emulator) handleGrapheme(content string, width int) {
 		e.lastChar, _ = utf8.DecodeRuneInString(content)
 	}
 
+	// A wide grapheme with only one column remaining must wrap before it is
+	// written. RenderBuffer clips a wide cell that does not fit, silently
+	// losing it. Zero cells mark the synthetic skipped columns distinctly from
+	// user-written spaces so reflow and checkpoint rendering can omit them.
+	if awm && cell.Width > 1 && x+cell.Width > e.scr.Width() {
+		e.scr.setWrapped(y, true)
+		for skip := x; skip < e.scr.Width(); skip++ {
+			e.scr.SetCell(skip, y, &uv.Cell{})
+		}
+		e.index()
+		_, y = e.scr.CursorPosition()
+		x = 0
+	}
+
 	e.scr.SetCell(x, y, &cell)
 
-	// Handle phantom state at the end of the line
-	e.atPhantom = awm && x >= e.scr.Width()-1
-	if !e.atPhantom {
+	// Handle phantom state from the post-write edge. This matters for a wide
+	// grapheme that exactly fills the final two columns.
+	if awm {
+		e.atPhantom = x+cell.Width >= e.scr.Width()
+		if e.atPhantom {
+			x = e.scr.Width() - 1
+		} else {
+			x += cell.Width
+		}
+	} else {
+		e.atPhantom = false
 		x += cell.Width
 	}
 

--- a/third_party/vt/wrap_test.go
+++ b/third_party/vt/wrap_test.go
@@ -159,16 +159,32 @@ func TestWrapBufferResetAndResize(t *testing.T) {
 			t.Fatal("normal scrollback unavailable")
 		}
 	})
-	t.Run("resize preserves surviving rows", func(t *testing.T) {
+	t.Run("height-only resize preserves surviving rows", func(t *testing.T) {
 		e := NewEmulator(4, 3)
 		write(t, e, "abcde")
-		e.Resize(8, 4)
+		e.Resize(4, 4)
 		if !e.Wrapped(0) {
-			t.Fatal("wider resize lost provenance")
+			t.Fatal("taller resize lost provenance")
 		}
-		e.Resize(3, 2)
+		e.Resize(4, 2)
 		if !e.Wrapped(0) {
-			t.Fatal("narrower resize lost surviving provenance")
+			t.Fatal("shorter resize lost surviving provenance")
+		}
+	})
+	t.Run("width resize clears both buffers", func(t *testing.T) {
+		e := NewEmulator(4, 2)
+		write(t, e, "abcde")
+		write(t, e, "\x1b[?1049habcde")
+		if !e.Wrapped(0) {
+			t.Fatal("alternate buffer missing wrap before resize")
+		}
+		e.Resize(8, 2)
+		if e.Wrapped(0) {
+			t.Fatal("alternate buffer retained wrap across width change")
+		}
+		write(t, e, "\x1b[?1049l")
+		if e.Wrapped(0) {
+			t.Fatal("normal buffer retained wrap across width change")
 		}
 	})
 	t.Run("RIS clears both buffers", func(t *testing.T) {

--- a/third_party/vt/wrap_test.go
+++ b/third_party/vt/wrap_test.go
@@ -62,11 +62,23 @@ func TestWrapScrollsIntoScrollback(t *testing.T) {
 }
 
 func TestWrapWideAndCombiningBoundary(t *testing.T) {
-	t.Run("wide", func(t *testing.T) {
-		e := NewEmulator(4, 2)
-		write(t, e, "abc界X")
-		if !e.Wrapped(0) {
-			t.Fatal("wide boundary did not wrap")
+	t.Run("wide cell is preserved after forced wrap", func(t *testing.T) {
+		for width := 4; width <= 10; width++ {
+			e := NewEmulator(width, 3)
+			prefix := strings.Repeat("a", width-1)
+			write(t, e, prefix+"界X")
+			for x := 0; x < width-1; x++ {
+				assertCell(t, e.CellAt(x, 0), "a", 1)
+			}
+			if c := e.CellAt(width-1, 0); c == nil || !c.IsZero() {
+				t.Fatalf("width %d skipped cell = %#v, want zero", width, c)
+			}
+			if !e.Wrapped(0) {
+				t.Fatalf("width %d forced row is not wrapped", width)
+			}
+			assertCell(t, e.CellAt(0, 1), "界", 2)
+			assertCell(t, e.CellAt(1, 1), "", 0)
+			assertCell(t, e.CellAt(2, 1), "X", 1)
 		}
 	})
 	t.Run("combining", func(t *testing.T) {
@@ -148,6 +160,13 @@ func TestScrollbackWrapTruncation(t *testing.T) {
 	}
 }
 
+func assertCell(t *testing.T, cell *uv.Cell, content string, width int) {
+	t.Helper()
+	if cell == nil || cell.Content != content || cell.Width != width {
+		t.Fatalf("cell = %#v, want content %q width %d", cell, content, width)
+	}
+}
+
 func TestScrollbackPushWrappedTrailingBlanks(t *testing.T) {
 	line := uv.NewLine(4)
 	line.Set(0, &uv.Cell{Content: "x", Width: 1})
@@ -163,6 +182,55 @@ func TestScrollbackPushWrappedTrailingBlanks(t *testing.T) {
 }
 
 func TestNormalBufferWidthReflow(t *testing.T) {
+	t.Run("grow removes synthetic wide skip", func(t *testing.T) {
+		e := NewEmulator(4, 4)
+		write(t, e, "abc界X")
+		e.Resize(8, 4)
+		assertCell(t, e.CellAt(0, 0), "a", 1)
+		assertCell(t, e.CellAt(1, 0), "b", 1)
+		assertCell(t, e.CellAt(2, 0), "c", 1)
+		assertCell(t, e.CellAt(3, 0), "界", 2)
+		assertCell(t, e.CellAt(4, 0), "", 0)
+		assertCell(t, e.CellAt(5, 0), "X", 1)
+		if e.Wrapped(0) {
+			t.Fatal("grown logical line remained wrapped")
+		}
+	})
+
+	t.Run("shrink recreates synthetic wide skip", func(t *testing.T) {
+		e := NewEmulator(10, 4)
+		write(t, e, "12345678界X")
+		e.Resize(9, 4)
+		for x := 0; x < 8; x++ {
+			assertCell(t, e.CellAt(x, 0), string(rune('1'+x)), 1)
+		}
+		if c := e.CellAt(8, 0); c == nil || !c.IsZero() {
+			t.Fatalf("new skipped cell = %#v, want zero", c)
+		}
+		if !e.Wrapped(0) {
+			t.Fatal("early-wide row not marked wrapped after shrink")
+		}
+		assertCell(t, e.CellAt(0, 1), "界", 2)
+		assertCell(t, e.CellAt(1, 1), "", 0)
+		assertCell(t, e.CellAt(2, 1), "X", 1)
+	})
+
+	t.Run("combining and ZWJ graphemes survive forced wrap and reflow", func(t *testing.T) {
+		e := NewEmulator(5, 4)
+		write(t, e, "abcd")
+		e.handleGrapheme("e\u0301", 1)
+		e.handleGrapheme("👩‍💻", 2)
+		e.handleGrapheme("X", 1)
+		assertCell(t, e.CellAt(3, 0), "d", 1)
+		assertCell(t, e.CellAt(4, 0), "é", 1)
+		assertCell(t, e.CellAt(0, 1), "👩‍💻", 2)
+		e.Resize(9, 4)
+		assertCell(t, e.CellAt(4, 0), "é", 1)
+		assertCell(t, e.CellAt(5, 0), "👩‍💻", 2)
+		assertCell(t, e.CellAt(6, 0), "", 0)
+		assertCell(t, e.CellAt(7, 0), "X", 1)
+	})
+
 	t.Run("text spaces wide style cursor and blank lines", func(t *testing.T) {
 		e := NewEmulator(8, 8)
 		write(t, e, "界 ab cdZ\x1b[44m \x1b[0mQ\r\n\r\ntail")
@@ -215,6 +283,19 @@ func TestNormalBufferWidthReflow(t *testing.T) {
 			t.Fatalf("scrollback len = %d, want max 2", e.ScrollbackLen())
 		}
 	})
+}
+
+func BenchmarkReflow2000ScrollbackLines(b *testing.B) {
+	for b.Loop() {
+		b.StopTimer()
+		e := NewEmulator(80, 25)
+		e.SetScrollbackSize(2000)
+		for range 2025 {
+			_, _ = e.WriteString("the quick brown fox jumps over the lazy dog\r\n")
+		}
+		b.StartTimer()
+		e.Resize(79, 25)
+	}
 }
 
 func emulatorLogicalLines(e *Emulator) []string {

--- a/third_party/vt/wrap_test.go
+++ b/third_party/vt/wrap_test.go
@@ -1,6 +1,11 @@
 package vt
 
-import "testing"
+import (
+	"strings"
+	"testing"
+
+	uv "github.com/charmbracelet/ultraviolet"
+)
 
 func write(t *testing.T, e *Emulator, s string) {
 	t.Helper()
@@ -141,6 +146,114 @@ func TestScrollbackWrapTruncation(t *testing.T) {
 	if sb.Len() != 2 || sb.Wrapped(0) || !sb.Wrapped(1) {
 		t.Fatalf("truncated wrap flags are misaligned: len=%d flags=%v,%v", sb.Len(), sb.Wrapped(0), sb.Wrapped(1))
 	}
+}
+
+func TestScrollbackPushWrappedTrailingBlanks(t *testing.T) {
+	line := uv.NewLine(4)
+	line.Set(0, &uv.Cell{Content: "x", Width: 1})
+	sb := NewScrollback(10)
+	sb.PushWrapped(line, true)
+	sb.PushWrapped(line, false)
+	if got := len(sb.Line(0)); got != 4 {
+		t.Fatalf("wrapped row length = %d, want 4", got)
+	}
+	if got := len(sb.Line(1)); got != 1 {
+		t.Fatalf("unwrapped row length = %d, want 1", got)
+	}
+}
+
+func TestNormalBufferWidthReflow(t *testing.T) {
+	t.Run("text spaces wide style cursor and blank lines", func(t *testing.T) {
+		e := NewEmulator(8, 8)
+		write(t, e, "界 ab cdZ\x1b[44m \x1b[0mQ\r\n\r\ntail")
+		e.Resize(11, 8)
+		lines := emulatorLogicalLines(e)
+		if len(lines) < 3 || lines[0] != "界 ab cdZ Q" || lines[1] != "" || lines[2] != "tail" {
+			t.Fatalf("reflowed logical lines = %q", lines)
+		}
+		foundStyledBlank := false
+		for y := 0; y < e.Height(); y++ {
+			for x := 0; x < e.Width(); x++ {
+				if c := e.CellAt(x, y); c != nil && c.Content == " " && c.Style.Bg != nil {
+					foundStyledBlank = true
+				}
+			}
+		}
+		if !foundStyledBlank {
+			t.Fatal("styled blank was lost during reflow")
+		}
+		if got := e.CursorPosition(); got != uv.Pos(4, 2) {
+			t.Fatalf("cursor = %+v, want (4,2)", got)
+		}
+	})
+
+	t.Run("scrollback visible boundary is one logical line", func(t *testing.T) {
+		e := NewEmulator(8, 2)
+		e.SetScrollbackSize(20)
+		text := "one two three four five six seven"
+		write(t, e, text)
+		if e.ScrollbackLen() == 0 || !e.Scrollback().Wrapped(e.ScrollbackLen()-1) {
+			t.Fatal("fixture does not cross the scrollback boundary")
+		}
+		e.Resize(13, 3)
+		if got := strings.Join(emulatorLogicalLines(e), "|"); got != text {
+			t.Fatalf("reflow text = %q, want %q", got, text)
+		}
+		for i, line := range e.Scrollback().Lines() {
+			if e.Scrollback().Wrapped(i) && len(line) != 13 {
+				t.Fatalf("scrollback wrapped row %d width = %d", i, len(line))
+			}
+		}
+	})
+
+	t.Run("scrollback maximum trims oldest reflowed rows", func(t *testing.T) {
+		e := NewEmulator(6, 2)
+		e.SetScrollbackSize(2)
+		write(t, e, "abcdefghijklmnopqrstuv")
+		e.Resize(3, 2)
+		if e.ScrollbackLen() != 2 {
+			t.Fatalf("scrollback len = %d, want max 2", e.ScrollbackLen())
+		}
+	})
+}
+
+func emulatorLogicalLines(e *Emulator) []string {
+	type row struct {
+		line    uv.Line
+		wrapped bool
+	}
+	var rows []row
+	for i, line := range e.Scrollback().Lines() {
+		rows = append(rows, row{line, e.Scrollback().Wrapped(i)})
+	}
+	last := e.CursorPosition().Y
+	for y := e.Height() - 1; y >= 0; y-- {
+		if lineContentLen(e.scr.buf.Line(y)) > 0 {
+			last = max(last, y)
+			break
+		}
+	}
+	for y := 0; y <= last; y++ {
+		rows = append(rows, row{e.scr.buf.Line(y), e.Wrapped(y)})
+	}
+	var out []string
+	var b strings.Builder
+	for _, row := range rows {
+		limit := lineContentLen(row.line)
+		if row.wrapped {
+			limit = len(row.line)
+		}
+		for i := 0; i < limit; i++ {
+			if row.line[i].Width > 0 {
+				b.WriteString(row.line[i].Content)
+			}
+		}
+		if !row.wrapped {
+			out = append(out, strings.TrimRight(b.String(), " "))
+			b.Reset()
+		}
+	}
+	return out
 }
 
 func TestWrapBufferResetAndResize(t *testing.T) {


### PR DESCRIPTION
## Problem

Adversarial integration audit of #500/#502/#503 on main found release-blocking defects:

- **F1 (HIGH):** #503's soft-wrap join rendered rows via `Line.Render()`/`plainLine()`, which trim trailing blank cells — written spaces at wrap boundaries were deleted, silently concatenating words (`the quickbrown foxjumps`) in checkpoint replay, `gmux attach`, and `gmux tail`. Reproduced end-to-end through the production stack.
- **F2:** checkpoint metadata carried `rows` but not `cols`; the browser guessed replay width from session metadata, which `shrinkForReconnect` makes stale by construction — width-sensitive joined frames then re-wrapped wrong with a fixed CUP tail.
- Integration-found: same-size initial claims silently skipped the ownership resize send; and a pre-existing upstream vt bug clipped a width-2 grapheme arriving with one free column at write time (`abc界X` → `abc X`), previously masked by a vacuous round-trip test.

## Fix

- **vt fork: normal-buffer history reflow on width resize** (xterm.js semantics): logical lines regrouped by wrap provenance and re-wrapped at the new width; wide graphemes preserved via explicit zero-cell skip markers distinguishing synthetic padding from written spaces; cursor remapped by logical offset; alt screen non-reflowing. Establishes the invariant "wrap bit ⇒ wrapped at exactly current width" everywhere, making the checkpoint pad-join universally sound. Upstream wide-clip bug fixed at the write path. Measured reflow cost ~17ms/2000 scrollback lines.
- **Checkpoint frames and `gmux tail` preserve boundary cells** (pad to last non-zero cell).
- **`terminal_checkpoint` now declares `cols`**; every replay (reconnects included) resizes to server-declared geometry; legacy width-guess only for old runners.
- **Initial viewport claims always announce**, restoring ownership semantics for same-size claims; resize pill gated on `!termLoading`.

## Testing

- Fork: exact-cell wide/combining/ZWJ regressions, reflow round-trips at multiple widths, provenance mutants verified killed; `GMUX-PATCH.md` updated with the upstream bug and measured costs.
- New E2E: first-attach word fidelity, reattach-across-shrink fidelity (scrollback-resident wrapped prose, no whitespace stripping), reconnect ordering seam test.
- Full solo Playwright **100/100**; vitest 758; go suites green.
- Three rounds of independent adversarial review (two HIGH findings caught and fixed post-authoring); final verdict: approve/integrate.