### PR TITLE
feat(daemon): auto-read supervised successful process exits

### DIFF
--- a/cli/gmux/cmd/gmux/run.go
+++ b/cli/gmux/cmd/gmux/run.go
@@ -732,11 +732,9 @@ func runSession(args []string, attach bool, dir runDirectives) {
 // and waits resolve as "died" (ADR 0023). An explicitly interrupted
 // semantic turn is the exception: exit preserves its existing unread bit.
 //
-// The ordering is load-bearing: the turn-close status and unread
-// events must be emitted before the exit event, so a subscriber (the
-// daemon's wait machinery) that resolves on the first terminal signal
-// it sees observes the closed turn, and the store's exit handling
-// persists the final Status rather than a stale mid-turn one.
+// For a lifetime turn, status, exit, and unread generation are one event so
+// waiters and the daemon cannot observe an attention-bearing intermediate
+// state. OSC prompt-cycle status edges remain separate and unchanged.
 func finalizeSessionState(state *session.State, lifetimeTurnOpen bool, exitCode int) {
 	status := state.StatusSnapshot()
 	if status != nil && status.Interrupted {
@@ -744,10 +742,7 @@ func finalizeSessionState(state *session.State, lifetimeTurnOpen bool, exitCode 
 		return
 	}
 	if lifetimeTurnOpen {
-		// Fuse the token with the idle edge that can resolve a waiter and decide
-		// direct-parent suppression, then publish the plain exit.
-		state.SetStatusUnreadResult(&adapter.Status{Active: false, Error: exitCode != 0})
-		state.SetExited(exitCode)
+		state.SetLifetimeExitedUnreadResult(&adapter.Status{Active: false, Error: exitCode != 0}, exitCode)
 		return
 	}
 	// Hook/OSC sessions may die while still active. Fuse unread with exit so

--- a/cli/gmux/cmd/gmux/run_test.go
+++ b/cli/gmux/cmd/gmux/run_test.go
@@ -61,12 +61,9 @@ func collectEvents(t *testing.T, ch chan session.Event, n int) []session.Event {
 	return got
 }
 
-// TestFinalizeSessionStateClosesLifetimeTurnBeforeExit pins the
-// event ordering the daemon's wait machinery depends on (ADR 0023): a
-// lifetime-turn session's exit must emit the turn-close status and unread
-// generation in ONE event before exit. A subscriber that resolves on the
-// first terminal signal it sees must observe both the closed turn and its
-// result token; the store must also persist the final Status.
+// TestFinalizeSessionStateClosesLifetimeTurnBeforeExit pins the atomic event
+// shape the daemon's wait machinery depends on (ADR 0023): lifetime status,
+// exit, and unread generation are one terminal event.
 func TestFinalizeSessionStateClosesLifetimeTurnBeforeExit(t *testing.T) {
 	st := session.New(session.Config{ID: "1uo92yti", Adapter: "shell"})
 	st.SetStatus(&adapter.Status{Active: true}) // launch state, pre-subscription
@@ -75,9 +72,9 @@ func TestFinalizeSessionStateClosesLifetimeTurnBeforeExit(t *testing.T) {
 
 	finalizeSessionState(st, true, 3)
 
-	got := collectEvents(t, ch, 2)
-	if got[0].Type != "status" || got[1].Type != "exit" {
-		t.Fatalf("events = %+v, want fused status/unread before exit", got)
+	got := collectEvents(t, ch, 1)
+	if got[0].Type != "exit" {
+		t.Fatalf("events = %+v, want one fused lifetime exit", got)
 	}
 	raw, err := json.Marshal(got[0].Data)
 	if err != nil {

--- a/cli/gmux/internal/session/state.go
+++ b/cli/gmux/internal/session/state.go
@@ -194,7 +194,7 @@ func (s *State) SetRunning(pid int) {
 func (s *State) SetExited(exitCode int) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.setExitedLocked(exitCode, false)
+	s.setExitedLocked(exitCode, false, nil)
 }
 
 // SetExitedUnreadResult publishes process completion and its fresh result token
@@ -203,10 +203,22 @@ func (s *State) SetExited(exitCode int) {
 func (s *State) SetExitedUnreadResult(exitCode int) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.setExitedLocked(exitCode, true)
+	s.setExitedLocked(exitCode, true, nil)
 }
 
-func (s *State) setExitedLocked(exitCode int, unread bool) {
+// SetLifetimeExitedUnreadResult atomically closes the synthetic lifetime turn
+// and publishes its process exit with one fresh result generation. Ordinary
+// OSC prompt-cycle closes continue to use status events and are unaffected.
+func (s *State) SetLifetimeExitedUnreadResult(status *adapter.Status, exitCode int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	prev := s.Status
+	s.Status = status
+	s.noteStatusWriteLocked(prev, status)
+	s.setExitedLocked(exitCode, true, status)
+}
+
+func (s *State) setExitedLocked(exitCode int, unread bool, status *adapter.Status) {
 	if unread {
 		s.markUnreadResultStateLocked()
 	}
@@ -214,6 +226,11 @@ func (s *State) setExitedLocked(exitCode int, unread bool) {
 	s.ExitCode = &exitCode
 	s.ExitedAt = time.Now().UTC().Format(time.RFC3339)
 	data := map[string]any{"exit_code": exitCode, "exited_at": s.ExitedAt}
+	if status != nil {
+		data["active"] = status.Active
+		data["error"] = status.Error
+		data["interrupted"] = status.Interrupted
+	}
 	if unread {
 		data["unread"] = true
 		data["unread_token"] = s.UnreadToken

--- a/docs/task-family-ui.md
+++ b/docs/task-family-ui.md
@@ -161,22 +161,26 @@ task history/type view, not an attention queue.
 
 ## Attention and consumption
 
-Unread is independent of durable error outcome: every completed agent turn or
-process command records unread until a consumer reads or acts on that session.
+Unread is independent of durable error outcome. Every completed agent turn
+records unread until a consumer reads or acts on that session. Process commands
+normally do the same, with one supervision exception: a successful process-child
+exit is durably auto-acknowledged when its current direct parent has a live local
+runner. The completion commit records the child as read, so suppression is not
+merely a notification-delivery decision; family roll-ups and later readers also
+observe no unread result.
+
+The exception is deliberately strict and one hop. Semantic agent children,
+failed or interrupted processes, and children whose current direct parent is
+dead, missing, or remote retain unread. A promoted child has no parent and also
+retains unread. The coordinator decides from the durable parent edge and local
+runner registry at completion; concurrent reparenting forces it to re-read and
+retry. This is an instantaneous, one-shot supervision policy: a parent that
+dies just after the child exits does not restore unread, and a parent that
+becomes live later does not retroactively clear it.
+
 Reading clears unread only. An acknowledged inactive error has no presentation
 state; an active error remains a hollow red current-status ring and is not
 family attention.
-
-Notification delivery is suppressed only when the session's current direct
-parent is active when the completion outcome is published. The publisher
-re-reads the session after the completion commit, so a reparent that commits in
-that narrow window can be the parent it observes. A parent-edge change is
-observed and the latch reconsidered on the session's next outcome; promotion
-removes the suppressor once such an outcome arrives. A missing parent fails safe
-as inactive, so the notification is delivered. Agent activity is semantic turn
-activity; terminal activity currently comes from the runner's OSC 133 prompt
-cycle (active command to idle prompt). Suppression is best-effort, one hop, and
-one shot—later parent activity never retro-delivers a suppressed notification.
 
 `gmux wait` (on success), `gmux tail`, `gmux agent logs`, prompts, steering,
 raw sends, and web interaction consume unread. The family panel's bulk

--- a/services/gmuxd/cmd/gmuxd/bootstrap.go
+++ b/services/gmuxd/cmd/gmuxd/bootstrap.go
@@ -202,6 +202,11 @@ func newBootstrap(cfg BootstrapConfig) (*Bootstrap, error) {
 	registry := sessioncoord.NewRegistry()
 	bridge := &composerDirtyBridge{}
 	opts := []sessioncoord.Option{sessioncoord.WithClock(cfg.Clock), sessioncoord.WithRunnerControl(cfg.Control), sessioncoord.WithRunnerSpawner(cfg.Spawner), sessioncoord.WithConversationTakeover(cfg.Resolver), sessioncoord.WithAdapterReconciler(cfg.Reconciler)}
+	if cfg.SemanticAgent != nil {
+		opts = append(opts, sessioncoord.WithProcessChildAutoRead(func(row centralstore.Session) bool {
+			return cfg.SemanticAgent(row.Adapter)
+		}))
+	}
 	if len(cfg.MaxSubagentsByDepth) > 0 || cfg.SubagentBudgetDisabled {
 		rows, err := cfg.Store.ListSessions(context.Background())
 		if err != nil {

--- a/services/gmuxd/cmd/gmuxd/bootstrap_runner_adapters.go
+++ b/services/gmuxd/cmd/gmuxd/bootstrap_runner_adapters.go
@@ -212,6 +212,9 @@ func runnerEventProjection(typ string, raw []byte) (sessioncoord.RunnerEvent, bo
 		var v struct {
 			ExitCode    int     `json:"exit_code"`
 			ExitedAt    string  `json:"exited_at"`
+			Active      *bool   `json:"active"`
+			Error       *bool   `json:"error"`
+			Interrupted *bool   `json:"interrupted"`
 			Unread      *bool   `json:"unread"`
 			UnreadToken *string `json:"unread_token"`
 		}
@@ -227,6 +230,9 @@ func runnerEventProjection(typ string, raw []byte) (sessioncoord.RunnerEvent, bo
 		alive := false
 		f.ExitCode = centralstore.NullablePatch[int]{Set: &v.ExitCode}
 		f.ExitedAt = centralstore.NullablePatch[centralstore.UnixMillis]{Set: &exitedAt}
+		f.Active = v.Active
+		f.Error = v.Error
+		f.Interrupted = v.Interrupted
 		f.Unread = v.Unread
 		f.UnreadToken = v.UnreadToken
 		return sessioncoord.RunnerEvent{ObservedAt: now, Facts: f, Alive: &alive}, true

--- a/services/gmuxd/cmd/gmuxd/bootstrap_runner_adapters_test.go
+++ b/services/gmuxd/cmd/gmuxd/bootstrap_runner_adapters_test.go
@@ -88,6 +88,19 @@ func TestProductionRunnerMetaPreservesLaunchParent(t *testing.T) {
 	}
 }
 
+func TestRunnerEventProjectionKeepsLifetimeStatusAndExitAtomic(t *testing.T) {
+	ev, ok := runnerEventProjection("exit", []byte(`{"exit_code":0,"exited_at":"2026-01-02T03:04:05Z","active":false,"error":false,"interrupted":false,"unread":true,"unread_token":"result-1"}`))
+	if !ok {
+		t.Fatal("fused lifetime exit was rejected")
+	}
+	if ev.Alive == nil || *ev.Alive || ev.Facts.Active == nil || *ev.Facts.Active ||
+		ev.Facts.Error == nil || *ev.Facts.Error || ev.Facts.Interrupted == nil || *ev.Facts.Interrupted ||
+		ev.Facts.Unread == nil || !*ev.Facts.Unread || ev.Facts.UnreadToken == nil || *ev.Facts.UnreadToken != "result-1" ||
+		ev.Facts.ExitCode.Set == nil || *ev.Facts.ExitCode.Set != 0 || ev.Facts.ExitedAt.Set == nil {
+		t.Fatalf("fused lifetime exit facts lost: %+v", ev)
+	}
+}
+
 func TestProductionRunnerDeadMetadataSurvivesMetaAndReplay(t *testing.T) {
 	const exitedAt = "2026-01-02T03:04:05Z"
 	mux := http.NewServeMux()

--- a/services/gmuxd/cmd/gmuxd/notify_central.go
+++ b/services/gmuxd/cmd/gmuxd/notify_central.go
@@ -50,18 +50,20 @@ type notifySessionSnapshot struct {
 }
 
 type pendingCentralNotif struct {
-	sessionID string
-	notifType string
-	title     string
-	body      string
-	adapter   string
-	timer     *time.Timer
-	notifID   string
+	sessionID   string
+	notifType   string
+	title       string
+	body        string
+	adapter     string
+	timer       *time.Timer
+	notifID     string
+	resultToken string
 }
 
 type activeCentralNotif struct {
-	sessionID string
-	clientID  string
+	sessionID   string
+	clientID    string
+	resultToken string
 }
 
 type externalNotifier interface {
@@ -179,6 +181,13 @@ func (r *centralNotifyRouter) handleOutcome(o sessioncoord.Outcome) {
 	// parent edge re-decides the latch.
 	suppress := !cur.Active && r.suppressedInactive[id]
 	r.mu.Unlock()
+	if o.AttentionSuppressed {
+		// This bit is the coordinator's committed lifecycle-serialized decision.
+		// Cancel its exact result plus empty-token attention, which is unscoped.
+		// A mismatched non-empty token identifies an older result and survives.
+		r.cancelForSessionResult(id, cur.UnreadToken)
+		return
+	}
 	if !existed {
 		return
 	}
@@ -197,10 +206,10 @@ func (r *centralNotifyRouter) handleOutcome(o sessioncoord.Outcome) {
 	// An intentional stop is not a completion (ADR 0027): no "finished"
 	// notification for a turn the user themselves ended.
 	if transitionedInactive && cur.Alive && !cur.Interrupted {
-		r.scheduleNotification(id, "finished", cur.Title, formatFinishedBodyCentral(cur.Start), cur.Adapter)
+		r.scheduleNotification(id, "finished", cur.Title, formatFinishedBodyCentral(cur.Start), cur.Adapter, cur.UnreadToken)
 	}
 	if cur.Unread && (releasedBySuppression || !prev.Unread || prev.UnreadToken != cur.UnreadToken) {
-		r.scheduleNotification(id, "unread", cur.Title, "New output", cur.Adapter)
+		r.scheduleNotification(id, "unread", cur.Title, "New output", cur.Adapter, cur.UnreadToken)
 	}
 }
 
@@ -232,7 +241,11 @@ func (r *centralNotifyRouter) genID() string {
 	return fmt.Sprintf("notif-%d", r.nextID)
 }
 
-func (r *centralNotifyRouter) scheduleNotification(sessionID, notifType, title, body, adapter string) {
+func (r *centralNotifyRouter) scheduleNotification(sessionID, notifType, title, body, adapter string, resultTokens ...string) {
+	resultToken := ""
+	if len(resultTokens) > 0 {
+		resultToken = resultTokens[0]
+	}
 	if r.presence.AnyViewing(sessionID) {
 		return
 	}
@@ -248,7 +261,7 @@ func (r *centralNotifyRouter) scheduleNotification(sessionID, notifType, title, 
 		return
 	}
 	notifID := r.genID()
-	p := &pendingCentralNotif{sessionID: sessionID, notifType: notifType, title: title, body: body, adapter: adapter, notifID: notifID}
+	p := &pendingCentralNotif{sessionID: sessionID, notifType: notifType, title: title, body: body, adapter: adapter, notifID: notifID, resultToken: resultToken}
 	p.timer = time.AfterFunc(r.config.GracePeriod, func() { r.firePending(sessionID) })
 	r.pending[sessionID] = p
 }
@@ -296,7 +309,7 @@ func (r *centralNotifyRouter) firePending(sessionID string) {
 	}
 	msg := NotifyMessage{Type: "notify", ID: p.notifID, SessionID: sessionID, Title: p.title, Body: p.body, Tag: sessionID}
 	r.mu.Lock()
-	r.active[p.notifID] = activeCentralNotif{sessionID: sessionID, clientID: target.ID}
+	r.active[p.notifID] = activeCentralNotif{sessionID: sessionID, clientID: target.ID, resultToken: p.resultToken}
 	r.mu.Unlock()
 	sendNotifyJSON(target.Conn, msg)
 	time.AfterFunc(5*time.Minute, func() {
@@ -332,20 +345,31 @@ func (r *centralNotifyRouter) CancelAllPending() {
 	}
 }
 
+func (r *centralNotifyRouter) cancelForSessionResult(sessionID, resultToken string) {
+	if resultToken == "" {
+		return
+	}
+	r.cancelForSession(sessionID, resultToken)
+}
+
 func (r *centralNotifyRouter) CancelForSession(sessionID string) {
+	r.cancelForSession(sessionID, "")
+}
+
+func (r *centralNotifyRouter) cancelForSession(sessionID, resultToken string) {
 	if r.beforeCancelLock != nil {
 		r.beforeCancelLock()
 	}
 	r.deliveryMu.Lock()
 	defer r.deliveryMu.Unlock()
 	r.mu.Lock()
-	if p, ok := r.pending[sessionID]; ok {
+	if p, ok := r.pending[sessionID]; ok && (resultToken == "" || p.resultToken == "" || p.resultToken == resultToken) {
 		p.timer.Stop()
 		delete(r.pending, sessionID)
 	}
 	var cancelIDs []string
 	for id, active := range r.active {
-		if active.sessionID == sessionID {
+		if active.sessionID == sessionID && (resultToken == "" || active.resultToken == "" || active.resultToken == resultToken) {
 			cancelIDs = append(cancelIDs, id)
 			delete(r.active, id)
 		}

--- a/services/gmuxd/cmd/gmuxd/notify_central_autoread_test.go
+++ b/services/gmuxd/cmd/gmuxd/notify_central_autoread_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/centralstore"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/sessioncoord"
+)
+
+func suppressedOutcome(token string) sessioncoord.Outcome {
+	row := notifyRow("shell", false, "parent", false)
+	row.UnreadToken = token
+	at, code := centralstore.UnixMillis(20), 0
+	row.ExitedAt, row.ExitCode = &at, &code
+	return sessioncoord.Outcome{Type: sessioncoord.OutcomeUpserted, ID: "child", Session: &row, AttentionSuppressed: true}
+}
+
+func TestCentralNotifyCommittedAutoReadCancelsOnlyExactResult(t *testing.T) {
+	t.Run("pending exact generation", func(t *testing.T) {
+		r := newParentNotifyTestRouter(t)
+		r.scheduleNotification("child", "unread", "Child", "New output", "shell", "result-2")
+		r.handleOutcome(suppressedOutcome("result-2"))
+		if hasPendingNotification(r, "child") {
+			t.Fatal("committed suppression did not cancel its pending result")
+		}
+	})
+	t.Run("empty token is unscoped and canceled", func(t *testing.T) {
+		r := newParentNotifyTestRouter(t)
+		r.scheduleNotification("child", "finished", "Child", "Finished", "shell")
+		r.active["notif-unscoped"] = activeCentralNotif{sessionID: "child"}
+		r.handleOutcome(suppressedOutcome("result-2"))
+		if hasPendingNotification(r, "child") {
+			t.Fatal("committed suppression did not cancel unscoped pending attention")
+		}
+		if _, ok := r.active["notif-unscoped"]; ok {
+			t.Fatal("committed suppression did not cancel unscoped active attention")
+		}
+	})
+	t.Run("mismatched non-empty older generation survives", func(t *testing.T) {
+		r := newParentNotifyTestRouter(t)
+		r.scheduleNotification("child", "unread", "Child", "New output", "shell", "result-1")
+		r.handleOutcome(suppressedOutcome("result-2"))
+		if !hasPendingNotification(r, "child") {
+			t.Fatal("suppression canceled older result attention")
+		}
+	})
+	t.Run("active exact generation", func(t *testing.T) {
+		r := newParentNotifyTestRouter(t)
+		r.active["notif-exact"] = activeCentralNotif{sessionID: "child", resultToken: "result-2"}
+		r.active["notif-old"] = activeCentralNotif{sessionID: "child", resultToken: "result-1"}
+		r.handleOutcome(suppressedOutcome("result-2"))
+		if _, ok := r.active["notif-exact"]; ok {
+			t.Fatal("committed suppression did not cancel its active result")
+		}
+		if _, ok := r.active["notif-old"]; !ok {
+			t.Fatal("committed suppression canceled older active result")
+		}
+	})
+}
+
+func TestCentralNotifyFailureStillProducesAttention(t *testing.T) {
+	r := newParentNotifyTestRouter(t)
+	row := notifyRow("shell", false, "parent", false)
+	row.Unread, row.UnreadToken = true, "failed-result"
+	r.handleOutcome(upsertOutcome("child", notifyRow("shell", true, "parent", false)))
+	r.handleOutcome(upsertOutcome("child", row))
+	if !hasPendingNotification(r, "child") {
+		t.Fatal("failed exit lost strict attention")
+	}
+}

--- a/services/gmuxd/cmd/gmuxd/process_child_autoread_composed_test.go
+++ b/services/gmuxd/cmd/gmuxd/process_child_autoread_composed_test.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/centralstore"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/presence"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/sessioncoord"
+)
+
+type recordingCoordErrors struct {
+	mu  sync.Mutex
+	err []error
+}
+
+func (s *recordingCoordErrors) Error(_ context.Context, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.err = append(s.err, err)
+}
+func (s *recordingCoordErrors) count() int { s.mu.Lock(); defer s.mu.Unlock(); return len(s.err) }
+func (s *recordingCoordErrors) last() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.err) == 0 {
+		return nil
+	}
+	return s.err[len(s.err)-1]
+}
+
+func TestComposedSupervisedExitReachesNotificationRouter(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	store, err := centralstore.Open(ctx, t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	fleet := newHarnessFleet(0)
+	parent, child := centralstore.SessionID("parent01"), centralstore.SessionID("child001")
+	parentEP, childEP := "parent-runner", "child-runner"
+	parentInc, childInc := "parent-inc", "child-inc"
+	fleet.metas[parentEP] = sessioncoord.RunnerMeta{Incarnation: parentInc, Registration: centralstore.RunnerRegistration{ID: parent, Adapter: "shell", Alive: true, CreatedAt: 1, ObservedAt: 1}}
+	fleet.metas[childEP] = sessioncoord.RunnerMeta{Incarnation: childInc, Registration: centralstore.RunnerRegistration{ID: child, Adapter: "shell", Alive: true, CreatedAt: 2, ObservedAt: 2, ParentSessionID: &parent}}
+	fleet.streams[parentEP] = &harnessStream{events: make(chan sessioncoord.RunnerEvent, 8), incarnation: parentInc}
+	fleet.streams[childEP] = &harnessStream{events: make(chan sessioncoord.RunnerEvent, 8), incarnation: childInc}
+	errs := &recordingCoordErrors{}
+	coord := sessioncoord.New(nil, fleet, store, nil, errs, sessioncoord.WithProcessChildAutoRead(func(centralstore.Session) bool { return false }))
+	defer coord.Close()
+	if _, err := coord.Register(ctx, sessioncoord.RegisterRequest{Endpoint: parentEP, AssertedID: parent}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := coord.Register(ctx, sessioncoord.RegisterRequest{Endpoint: childEP, AssertedID: child}); err != nil {
+		t.Fatal(err)
+	}
+
+	seed, outcomes, unsubscribe, err := coord.SubscribeOutcomesSeed(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer unsubscribe()
+	router := newCentralNotifyRouter(presence.New(presence.Callbacks{}), notifyConfig{GracePeriod: time.Hour, IdleThreshold: time.Minute})
+	defer router.CancelAllPending()
+	go router.Run(ctx, seed, outcomes)
+	router.scheduleNotification(string(child), "unread", "Child", "New output", "shell", "result-1")
+
+	fleet.streams[childEP].events <- successfulExitEventForRouter()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		row, ok, readErr := store.Session(ctx, child)
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		if ok && row.ExitedAt != nil && !row.Unread && !hasPendingNotification(router, string(child)) {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("supervised outcome did not reach router: row=%+v pending=%v lastErr=%v", row, hasPendingNotification(router, string(child)), errs.last())
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if errs.count() != 0 {
+		t.Fatalf("supervised exit reported error: %v", errs.last())
+	}
+}
+
+func successfulExitEventForRouter() sessioncoord.RunnerEvent {
+	active, hasError, interrupted := false, false, false
+	unread, token, at, code, alive := true, "result-1", centralstore.UnixMillis(20), 0, false
+	return sessioncoord.RunnerEvent{ObservedAt: 20, Alive: &alive, Facts: centralstore.RunnerFacts{
+		Active: &active, Error: &hasError, Interrupted: &interrupted,
+		Unread: &unread, UnreadToken: &token,
+		ExitedAt: centralstore.NullablePatch[centralstore.UnixMillis]{Set: &at}, ExitCode: centralstore.NullablePatch[int]{Set: &code},
+	}}
+}
+
+func TestBootstrapNilSemanticClassifierDisablesAutoRead(t *testing.T) {
+	fleet := newHarnessFleet(0)
+	parent, child := centralstore.SessionID("parent01"), centralstore.SessionID("child001")
+	fleet.metas["parent"] = sessioncoord.RunnerMeta{Incarnation: "p-inc", Registration: centralstore.RunnerRegistration{ID: parent, Adapter: "shell", Alive: true, CreatedAt: 1, ObservedAt: 1}}
+	fleet.metas["child"] = sessioncoord.RunnerMeta{Incarnation: "c-inc", Registration: centralstore.RunnerRegistration{ID: child, Adapter: "agent", Alive: true, CreatedAt: 2, ObservedAt: 2, ParentSessionID: &parent}}
+	fleet.streams["parent"] = &harnessStream{events: make(chan sessioncoord.RunnerEvent, 8), incarnation: "p-inc"}
+	fleet.streams["child"] = &harnessStream{events: make(chan sessioncoord.RunnerEvent, 8), incarnation: "c-inc"}
+	store, boot := openHarness(t, t.TempDir(), fleet, nil) // SemanticAgent intentionally nil.
+	defer store.Close()
+	defer boot.Close()
+	ctx := context.Background()
+	if _, err := boot.Coordinator.Register(ctx, sessioncoord.RegisterRequest{Endpoint: "parent", AssertedID: parent}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := boot.Coordinator.Register(ctx, sessioncoord.RegisterRequest{Endpoint: "child", AssertedID: child}); err != nil {
+		t.Fatal(err)
+	}
+	fleet.streams["child"].events <- successfulExitEventForRouter()
+	deadline := time.Now().Add(time.Second)
+	for {
+		row, ok, err := store.Session(ctx, child)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if ok && row.ExitedAt != nil {
+			if !row.Unread {
+				t.Fatal("nil classifier enabled auto-read and classified agent as process")
+			}
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("child exit did not commit")
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func TestComposedFastDeadRegistrationAutoReadsAtomically(t *testing.T) {
+	ctx := context.Background()
+	store, err := centralstore.Open(ctx, t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	fleet := newHarnessFleet(0)
+	parent, child := centralstore.SessionID("parent01"), centralstore.SessionID("child001")
+	fleet.metas["parent"] = sessioncoord.RunnerMeta{Incarnation: "p-inc", Registration: centralstore.RunnerRegistration{ID: parent, Adapter: "shell", Alive: true, CreatedAt: 1, ObservedAt: 1}}
+	fleet.streams["parent"] = &harnessStream{events: make(chan sessioncoord.RunnerEvent, 8), incarnation: "p-inc"}
+	unread, token, active, hasError, interrupted := true, "fast-result", false, false, false
+	code, exited := 0, centralstore.UnixMillis(20)
+	fleet.metas["child"] = sessioncoord.RunnerMeta{Incarnation: "c-inc", Registration: centralstore.RunnerRegistration{ID: child, Adapter: "shell", Alive: false, CreatedAt: 2, ObservedAt: 20, ParentSessionID: &parent, Facts: centralstore.RunnerFacts{
+		Active: &active, Error: &hasError, Interrupted: &interrupted, Unread: &unread, UnreadToken: &token,
+		ExitCode: centralstore.NullablePatch[int]{Set: &code}, ExitedAt: centralstore.NullablePatch[centralstore.UnixMillis]{Set: &exited},
+	}}}
+	fleet.streams["child"] = &harnessStream{events: make(chan sessioncoord.RunnerEvent, 8), incarnation: "c-inc"}
+	coord := sessioncoord.New(nil, fleet, store, nil, nil, sessioncoord.WithProcessChildAutoRead(func(centralstore.Session) bool { return false }))
+	defer coord.Close()
+	if _, err := coord.Register(ctx, sessioncoord.RegisterRequest{Endpoint: "parent", AssertedID: parent}); err != nil {
+		t.Fatal(err)
+	}
+	seed, outcomes, unsubscribe, err := coord.SubscribeOutcomesSeed(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer unsubscribe()
+	router := newCentralNotifyRouter(presence.New(presence.Callbacks{}), notifyConfig{GracePeriod: time.Hour, IdleThreshold: time.Minute})
+	defer router.CancelAllPending()
+	go router.Run(ctx, seed, outcomes)
+	if _, err := coord.Register(ctx, sessioncoord.RegisterRequest{Endpoint: "child", AssertedID: child}); err != nil {
+		t.Fatal(err)
+	}
+	row, ok, err := store.Session(ctx, child)
+	if err != nil || !ok {
+		t.Fatalf("child row: ok=%v err=%v", ok, err)
+	}
+	if row.Unread || row.UnreadToken != token || row.ExitCode == nil || *row.ExitCode != 0 || row.LastActivityAt == nil {
+		t.Fatalf("fast-dead registration was not atomically supervised: %+v", row)
+	}
+	if hasPendingNotification(router, string(child)) {
+		t.Fatal("fast-dead supervised registration leaked attention")
+	}
+}

--- a/services/gmuxd/internal/centralstore/domain.go
+++ b/services/gmuxd/internal/centralstore/domain.go
@@ -113,8 +113,9 @@ type MutationResult struct {
 }
 
 var (
-	ErrStaleVersion       = errors.New("centralstore: stale row version")
-	ErrUnreadTokenChanged = errors.New("centralstore: unread token changed")
+	ErrStaleVersion                = errors.New("centralstore: stale row version")
+	ErrUnreadTokenChanged          = errors.New("centralstore: unread token changed")
+	ErrSuppressionWouldClearUnread = errors.New("centralstore: suppression would clear an older unread result")
 	// ErrSessionNotFound marks a mutation targeting a session row that does
 	// not exist. Session() keeps its (value, ok, err) shape instead.
 	ErrSessionNotFound    = errors.New("centralstore: session not found")
@@ -495,6 +496,10 @@ type RunnerObservation struct {
 	ObservedVersion RowVersion
 	ObservedAt      UnixMillis
 	Facts           RunnerFacts
+	// SuppressUnread commits a fresh runner result generation as already read.
+	// It is completion projection, not acknowledgement: the token, recency, and
+	// error facts are retained. Only the lifecycle coordinator may set it.
+	SuppressUnread bool
 }
 
 // ApplyRunnerObservation conditionally projects runner-owned facts. The
@@ -514,10 +519,19 @@ func (s *Store) ApplyRunnerObservation(ctx context.Context, o RunnerObservation)
 		StartedAt: o.Facts.StartedAt, ExitedAt: o.Facts.ExitedAt, ExitCode: o.Facts.ExitCode,
 		TerminalSize: o.Facts.TerminalSize,
 	}
-	return s.applyCommonFacts(ctx, o.ID, o.ObservedVersion, p, &o.ObservedAt)
+	freshSuppressedResult := false
+	if o.SuppressUnread {
+		if o.Facts.Unread == nil || !*o.Facts.Unread || o.Facts.UnreadToken == nil || *o.Facts.UnreadToken == "" {
+			return MutationResult{}, errors.New("centralstore: suppressed unread requires a fresh unread result")
+		}
+		unread := false
+		p.Unread = &unread
+		freshSuppressedResult = true
+	}
+	return s.applyCommonFacts(ctx, o.ID, o.ObservedVersion, p, &o.ObservedAt, freshSuppressedResult)
 }
 
-func (s *Store) applyCommonFacts(ctx context.Context, id SessionID, observed RowVersion, p CommonFactsPatch, runnerObservedAt *UnixMillis) (MutationResult, error) {
+func (s *Store) applyCommonFacts(ctx context.Context, id SessionID, observed RowVersion, p CommonFactsPatch, runnerObservedAt *UnixMillis, freshSuppressedResult ...bool) (MutationResult, error) {
 	tx, err := s.database.BeginTx(ctx, nil)
 	if err != nil {
 		return MutationResult{}, err
@@ -539,6 +553,9 @@ func (s *Store) applyCommonFacts(ctx context.Context, id SessionID, observed Row
 		return MutationResult{SessionVersion: v.Version}, ErrStaleVersion
 	}
 	before := v
+	if len(freshSuppressedResult) > 0 && freshSuppressedResult[0] && before.Unread {
+		return MutationResult{}, ErrSuppressionWouldClearUnread
+	}
 	previousSlugBase := v.SlugBase
 	if p.ConversationRef != nil {
 		if *p.ConversationRef != "" && *p.ConversationRef != v.ConversationRef {
@@ -600,8 +617,9 @@ func (s *Store) applyCommonFacts(ctx context.Context, id SessionID, observed Row
 	// bumped when a new unread result token arrives, including a completion
 	// while an older result remains unread. Deliberately NOT bumped by plain
 	// active/error transitions or exit.
-	newUnreadResult := v.Unread && (!before.Unread || (p.UnreadToken != nil && before.UnreadToken != v.UnreadToken))
-	if runnerObservedAt != nil && newUnreadResult {
+	newResult := (v.Unread || (len(freshSuppressedResult) > 0 && freshSuppressedResult[0])) &&
+		(!before.Unread || (p.UnreadToken != nil && before.UnreadToken != v.UnreadToken))
+	if runnerObservedAt != nil && newResult {
 		if v.LastActivityAt == nil || *runnerObservedAt > *v.LastActivityAt {
 			x := *runnerObservedAt
 			v.LastActivityAt = &x

--- a/services/gmuxd/internal/centralstore/process_child_autoread_test.go
+++ b/services/gmuxd/internal/centralstore/process_child_autoread_test.go
@@ -1,0 +1,125 @@
+package centralstore
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestSuppressedRunnerResultCommitsTokenRecencyAndPreservesError(t *testing.T) {
+	ctx := context.Background()
+	s := openKernelStore(t)
+	row, _, err := s.RegisterRunner(ctx, registration("supervised", "shell", "/one", true, 10))
+	if err != nil {
+		t.Fatal(err)
+	}
+	unread, hasError, token, exitCode, exitedAt := true, true, "fresh-result", 0, UnixMillis(20)
+	result, err := s.ApplyRunnerObservation(ctx, RunnerObservation{
+		ID: row.ID, ObservedVersion: row.Version, ObservedAt: 20, SuppressUnread: true,
+		Facts: RunnerFacts{
+			Unread: &unread, UnreadToken: &token, Error: &hasError,
+			ExitCode: NullablePatch[int]{Set: &exitCode}, ExitedAt: NullablePatch[UnixMillis]{Set: &exitedAt},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Changed {
+		t.Fatal("suppressed completion did not mutate row")
+	}
+	got, ok, err := s.Session(ctx, row.ID)
+	if err != nil || !ok {
+		t.Fatalf("Session: ok=%v err=%v", ok, err)
+	}
+	if got.Unread || got.UnreadToken != token || !got.Error {
+		t.Fatalf("suppressed completion erased result facts: %+v", got)
+	}
+	if got.LastActivityAt == nil || *got.LastActivityAt != 20 {
+		t.Fatalf("completion recency=%v, want 20", got.LastActivityAt)
+	}
+	if got.ExitCode == nil || *got.ExitCode != 0 || got.ExitedAt == nil || *got.ExitedAt != 20 {
+		t.Fatalf("exit facts not committed atomically: %+v", got)
+	}
+}
+
+func TestSuppressedRunnerResultRequiresFreshGeneration(t *testing.T) {
+	ctx := context.Background()
+	s := openKernelStore(t)
+	row, _, err := s.RegisterRunner(ctx, registration("invalid-suppression", "shell", "/one", true, 10))
+	if err != nil {
+		t.Fatal(err)
+	}
+	unread := true
+	if _, err := s.ApplyRunnerObservation(ctx, RunnerObservation{ID: row.ID, ObservedVersion: row.Version, ObservedAt: 20, SuppressUnread: true, Facts: RunnerFacts{Unread: &unread}}); err == nil {
+		t.Fatal("suppression without a fresh token succeeded")
+	}
+	got, _, _ := s.Session(ctx, row.ID)
+	if got.Version != row.Version || got.Unread {
+		t.Fatalf("invalid suppression changed row: %+v", got)
+	}
+}
+
+func TestSuppressedRunnerResultCannotClearOlderUnread(t *testing.T) {
+	ctx := context.Background()
+	s := openKernelStore(t)
+	row, _, err := s.RegisterRunner(ctx, registration("older-unread", "shell", "/one", true, 10))
+	if err != nil {
+		t.Fatal(err)
+	}
+	olderUnread, olderToken := true, "older-result"
+	result, err := s.ApplyRunnerObservation(ctx, RunnerObservation{ID: row.ID, ObservedVersion: row.Version, ObservedAt: 15, Facts: RunnerFacts{Unread: &olderUnread, UnreadToken: &olderToken}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	newToken := "new-result"
+	if _, err := s.ApplyRunnerObservation(ctx, RunnerObservation{ID: row.ID, ObservedVersion: result.SessionVersion, ObservedAt: 20, SuppressUnread: true, Facts: RunnerFacts{Unread: &olderUnread, UnreadToken: &newToken}}); !errors.Is(err, ErrSuppressionWouldClearUnread) {
+		t.Fatalf("suppression error=%v", err)
+	}
+	got, _, _ := s.Session(ctx, row.ID)
+	if !got.Unread || got.UnreadToken != olderToken || got.Version != result.SessionVersion {
+		t.Fatalf("older attention changed: %+v", got)
+	}
+}
+
+func TestSuppressedFastDeadRegistrationIsAtomic(t *testing.T) {
+	ctx := context.Background()
+	s := openKernelStore(t)
+	reg := registration("fast-dead", "shell", "/one", false, 20)
+	unread, token, code, exited := true, "fast-result", 0, UnixMillis(20)
+	reg.Facts.Unread, reg.Facts.UnreadToken = &unread, &token
+	reg.Facts.ExitCode, reg.Facts.ExitedAt = NullablePatch[int]{Set: &code}, NullablePatch[UnixMillis]{Set: &exited}
+	reg.SuppressUnread = true
+	row, _, err := s.RegisterRunner(ctx, reg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if row.Unread || row.UnreadToken != token || row.ExitCode == nil || *row.ExitCode != 0 || row.LastActivityAt == nil || *row.LastActivityAt != 20 {
+		t.Fatalf("suppressed fast-dead registration lost facts: %+v", row)
+	}
+}
+
+func TestSuppressedFastDeadRegistrationCannotClearExistingUnread(t *testing.T) {
+	ctx := context.Background()
+	s := openKernelStore(t)
+	row, _, err := s.RegisterRunner(ctx, registration("fast-replace", "shell", "/one", true, 10))
+	if err != nil {
+		t.Fatal(err)
+	}
+	olderUnread, olderToken := true, "older"
+	result, err := s.ApplyRunnerObservation(ctx, RunnerObservation{ID: row.ID, ObservedVersion: row.Version, ObservedAt: 15, Facts: RunnerFacts{Unread: &olderUnread, UnreadToken: &olderToken}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	code, exited, fresh := 0, UnixMillis(20), "fresh"
+	reg := registration(string(row.ID), "shell", "/one", false, 20)
+	reg.NewGeneration, reg.SuppressUnread = true, true
+	reg.Facts.Unread, reg.Facts.UnreadToken = &olderUnread, &fresh
+	reg.Facts.ExitCode, reg.Facts.ExitedAt = NullablePatch[int]{Set: &code}, NullablePatch[UnixMillis]{Set: &exited}
+	if _, _, err := s.RegisterRunner(ctx, reg); !errors.Is(err, ErrSuppressionWouldClearUnread) {
+		t.Fatalf("registration suppression error=%v", err)
+	}
+	got, _, _ := s.Session(ctx, row.ID)
+	if !got.Unread || got.UnreadToken != olderToken || got.Version != result.SessionVersion {
+		t.Fatalf("older result changed: %+v", got)
+	}
+}

--- a/services/gmuxd/internal/centralstore/register.go
+++ b/services/gmuxd/internal/centralstore/register.go
@@ -35,6 +35,10 @@ type RunnerRegistration struct {
 	ParentSessionID *SessionID
 	ObservedAt      UnixMillis
 	Facts           RunnerFacts
+	// SuppressUnread commits this registration's fresh terminal result as read.
+	// The coordinator may set it only for a lifecycle-serialized fast-dead
+	// successful process child.
+	SuppressUnread bool
 	// Evict is the conversation-takeover loser set: dead retained rows whose
 	// conversation the registering live runner covers (same opaque ref, or an
 	// ancestor per the adapter's lineage — resolved by the coordinator, which
@@ -108,6 +112,9 @@ func (s *Store) RegisterRunner(ctx context.Context, reg RunnerRegistration) (Ses
 	}
 	if err := validateRunnerFacts(reg.Facts); err != nil {
 		return Session{}, MutationResult{}, err
+	}
+	if reg.SuppressUnread && (reg.Alive || reg.Facts.Unread == nil || !*reg.Facts.Unread || reg.Facts.UnreadToken == nil || *reg.Facts.UnreadToken == "") {
+		return Session{}, MutationResult{}, errors.New("centralstore: suppressed registration requires a fresh dead result")
 	}
 	for _, ev := range reg.Evict {
 		if !reg.Alive {
@@ -207,6 +214,9 @@ func (s *Store) RegisterRunner(ctx context.Context, reg RunnerRegistration) (Ses
 		if err = mergeRunnerFacts(&current, reg.Facts); err != nil {
 			return Session{}, MutationResult{}, err
 		}
+		if reg.SuppressUnread {
+			current.Unread = false
+		}
 		if reg.Facts.Slug != nil {
 			if err = allocateSessionSlug(ctx, q, &current, "", *reg.Facts.Slug); err != nil {
 				return Session{}, MutationResult{}, err
@@ -278,9 +288,15 @@ func (s *Store) RegisterRunner(ctx context.Context, reg RunnerRegistration) (Ses
 			current.StartedAt = nil
 		}
 		genBaseline := current
+		if reg.SuppressUnread && current.Unread {
+			return Session{}, MutationResult{}, ErrSuppressionWouldClearUnread
+		}
 		previousSlugBase := current.SlugBase
 		if err = mergeRunnerFacts(&current, reg.Facts); err != nil {
 			return Session{}, MutationResult{}, err
+		}
+		if reg.SuppressUnread {
+			current.Unread = false
 		}
 		if reg.Facts.Slug != nil {
 			if err = allocateSessionSlug(ctx, q, &current, previousSlugBase, *reg.Facts.Slug); err != nil {

--- a/services/gmuxd/internal/discovery/subscribe.go
+++ b/services/gmuxd/internal/discovery/subscribe.go
@@ -271,7 +271,10 @@ func (sub *Subscriptions) handleEvent(sessionID, socketPath, eventType string, d
 
 	case "exit":
 		var exit struct {
-			ExitCode int `json:"exit_code"`
+			ExitCode    int   `json:"exit_code"`
+			Active      *bool `json:"active"`
+			Error       *bool `json:"error"`
+			Interrupted *bool `json:"interrupted"`
 		}
 		if err := json.Unmarshal(data, &exit); err != nil {
 			log.Printf("subscribe: %s: bad exit event: %v", sessionID, err)
@@ -287,6 +290,24 @@ func (sub *Subscriptions) handleEvent(sessionID, socketPath, eventType string, d
 		sess.Alive = false
 		sess.ExitCode = &exit.ExitCode
 		sess.ExitedAt = time.Now().UTC().Format(time.RFC3339)
+		// New runners may fuse a synthetic lifetime-turn close into exit. Pointer
+		// fields preserve backward compatibility with old plain exit events.
+		if exit.Active != nil || exit.Error != nil || exit.Interrupted != nil {
+			status := store.Status{}
+			if sess.Status != nil {
+				status = *sess.Status
+			}
+			if exit.Active != nil {
+				status.Active = *exit.Active
+			}
+			if exit.Error != nil {
+				status.Error = *exit.Error
+			}
+			if exit.Interrupted != nil {
+				status.Interrupted = *exit.Interrupted
+			}
+			sess.Status = &status
+		}
 		// Let the OnExit hook set the resume command before upsert.
 		if sub.OnExit != nil {
 			sub.OnExit(&sess)

--- a/services/gmuxd/internal/discovery/subscribe_test.go
+++ b/services/gmuxd/internal/discovery/subscribe_test.go
@@ -275,6 +275,18 @@ func TestExitEventPreservesTurnStateThroughResumeDerivation(t *testing.T) {
 	}
 }
 
+func TestFusedLifetimeExitUpdatesOptionalStatus(t *testing.T) {
+	const id = "1fused00"
+	sessions := store.New()
+	sessions.Upsert(store.Session{ID: id, Alive: true, Status: &store.Status{Active: true}})
+	subs := NewSubscriptions(sessions)
+	subs.handleEvent(id, "", "exit", []byte(`{"exit_code":0,"active":false,"error":false,"interrupted":false}`))
+	got, ok := sessions.Get(id)
+	if !ok || got.Alive || got.Status == nil || got.Status.Active || got.Status.Error || got.Status.Interrupted {
+		t.Fatalf("fused exit status not projected: ok=%v session=%+v", ok, got)
+	}
+}
+
 func TestConversationFileEventRecordsPath(t *testing.T) {
 	sessions := store.New()
 	sessions.Upsert(store.Session{ID: "1vshk4fu", Alive: true})

--- a/services/gmuxd/internal/sessioncoord/coordinator.go
+++ b/services/gmuxd/internal/sessioncoord/coordinator.go
@@ -251,6 +251,10 @@ type Coordinator struct {
 	// installed registry generations, never durable active/status flags.
 	activeSubagents *activeSubagentBudget
 
+	// semanticSession classifies durable rows for successful process-exit
+	// supervision. Nil disables the policy (useful for embedders and old tests).
+	semanticSession func(centralstore.Session) bool
+
 	// Startup convergence barrier state (see convergence.go). Guarded by mu.
 	convergeCandidates map[centralstore.SessionID]struct{}
 	convergeClosed     bool
@@ -284,6 +288,13 @@ func WithActiveSubagentBudget(limits []int, disabled bool, semantic func(string)
 	return func(c *Coordinator) {
 		c.activeSubagents = newActiveSubagentBudget(limits, disabled, semantic, initial)
 	}
+}
+
+// WithProcessChildAutoRead enables successful full-exit supervision. The
+// classifier is the server's semantic capability boundary; semantic sessions
+// always retain strict attention.
+func WithProcessChildAutoRead(semantic func(centralstore.Session) bool) Option {
+	return func(c *Coordinator) { c.semanticSession = semantic }
 }
 
 func New(registry *Registry, runners RunnerClient, durable Durable, dirty DirtySink, errSink ErrorSink, opts ...Option) *Coordinator {
@@ -678,6 +689,24 @@ loop:
 		}
 	}
 
+	// A runner can finish between Subscribe and the first durable commit. Give
+	// that fused fast-dead result the same lifecycle-serialized supervision
+	// decision as an ordinary exit event. Durable state supplies the current
+	// organizational parent for existing rows; launch metadata is used only for
+	// a genuinely new row.
+	var registrationPolicyErr error
+	if successfulFastDeadRegistrationCandidate(reg) && c.semanticSession != nil {
+		child := centralstore.Session{ID: id, Adapter: reg.Adapter, DriveMode: reg.DriveMode, ParentSessionID: reg.ParentSessionID}
+		if existing, exists, readErr := c.durable.Session(ctx, id); readErr != nil {
+			registrationPolicyErr = fmt.Errorf("sessioncoord: read fast-dead registration policy state for %s: %w", id, readErr)
+		} else {
+			if exists {
+				child = existing
+			}
+			reg.SuppressUnread = c.supervisedSuccessfulExit(child, reg.Facts)
+		}
+	}
+
 	// Fence the old generation before committing the replacement. From this
 	// point apply's current/advance checks fail for the old generation, so an
 	// in-flight observation cannot commit onto the freshly registered row
@@ -688,6 +717,10 @@ loop:
 	}
 
 	session, outcome, err := c.durable.RegisterRunner(ctx, reg)
+	if errors.Is(err, centralstore.ErrSuppressionWouldClearUnread) {
+		reg.SuppressUnread = false
+		session, outcome, err = c.durable.RegisterRunner(ctx, reg)
+	}
 	if err != nil {
 		if hadOld {
 			c.registry.restore(id, old.Generation)
@@ -802,6 +835,9 @@ loop:
 
 	seq := c.outcomes.allocSeq() // stamp commit order before releasing c.mu
 	phase2Unlock()
+	if registrationPolicyErr != nil {
+		c.reportError(ctx, registrationPolicyErr)
+	}
 
 	// Silent-loss guard: a conversation-bearing registration in an embedding
 	// that never configured takeover would silently forfeit conversation
@@ -817,7 +853,7 @@ loop:
 	// re-entrant dirty sink cannot stall lifecycle transitions.
 	c.publish(ctx, outcome)
 	session.ID = id // the store echoes it; make the outcome self-describing even for sparse fakes
-	c.emitUpserted(session, seq)
+	c.emitUpsertedWithAttention(session, seq, reg.SuppressUnread)
 	if len(reg.Evict) > 0 {
 		evicted := make([]centralstore.SessionID, len(reg.Evict))
 		for i, ev := range reg.Evict {
@@ -910,9 +946,10 @@ func mergeFacts(dst *centralstore.RunnerFacts, src centralstore.RunnerFacts) err
 // the context is canceled. It runs in its own goroutine. On exit it removes
 // the generation entry and cancels the stream.
 //
-// The drain loop does not hold the lifecycle mutex. Registry operations use
-// the registry's own lock. The generation check in registry.advance and
-// registry.remove prevents stale-generation writes from reaching the store.
+// Ordinary observations use only the registry lock. A successful full-exit
+// candidate holds the lifecycle mutex from supervision decision through its
+// durable commit and registry removal; publication and stream teardown occur
+// after unlock. Generation checks prevent stale writes from taking ownership.
 // Close prevents new installed streams, cancels every current stream, and
 // joins all drain workers. Cancellation never synthesizes runner death.
 func (c *Coordinator) Close() {
@@ -1014,8 +1051,9 @@ func (c *Coordinator) drain(ctx context.Context, id centralstore.SessionID, gene
 	}
 }
 
-// apply persists one ordered event for the given generation. It does not hold
-// the lifecycle mutex across the DB call or the dirty sink. On ErrStaleVersion
+// apply persists one ordered event for the given generation. Successful full
+// exit candidates hold the lifecycle mutex through the policy decision and DB
+// commit; publication and stream teardown always occur after unlock. On ErrStaleVersion
 // it advances the local row-version token and retries: once for ordinary
 // events, and up to three times for exit-carrying events (an exit fact or a
 // death), mirroring ensureDurableExit's budget — a generation's death must
@@ -1025,23 +1063,29 @@ func (c *Coordinator) drain(ctx context.Context, id centralstore.SessionID, gene
 // (Alive=false without ExitedAt) are reported but still remove liveness so
 // the registry cannot remain stuck.
 func (c *Coordinator) apply(ctx context.Context, id centralstore.SessionID, generation uint64, ev RunnerEvent) {
-	// Read the current RowVersion under the registry's own lock. No
-	// lifecycle mutex needed on the fast path.
+	candidate := successfulFullExitCandidate(ev) && c.semanticSession != nil
+	lifecycleLocked := candidate
+	if lifecycleLocked {
+		c.mu.Lock()
+	}
+	unlock := func() {
+		if lifecycleLocked {
+			c.mu.Unlock()
+			lifecycleLocked = false
+		}
+	}
+	defer unlock()
+
 	e, ok := c.registry.current(id)
 	if !ok {
 		if !c.registry.fenced(id) {
 			return
 		}
-		// The entry is fenced: a replacement is inside its commit-to-install
-		// window. Fence resolution is bounded by the lifecycle mutex —
-		// Register either restores the old generation (failed replacement)
-		// or installs the new one before unlocking — so briefly acquiring it
-		// waits out the window, then re-check. If the restore made this
-		// generation current again the event must still commit; a failed
-		// replacement must not silently drop in-flight observations of the
-		// still-installed old generation.
-		c.mu.Lock()
-		c.mu.Unlock() //nolint:staticcheck // empty critical section is the point
+		// Waiting on c.mu resolves a replacement's commit-to-install fence.
+		if !lifecycleLocked {
+			c.mu.Lock()
+			c.mu.Unlock() //nolint:staticcheck // empty critical section is the point
+		}
 		e, ok = c.registry.current(id)
 		if !ok {
 			return
@@ -1051,11 +1095,15 @@ func (c *Coordinator) apply(ctx context.Context, id centralstore.SessionID, gene
 		return
 	}
 
-	obs := centralstore.RunnerObservation{
-		ID:              id,
-		ObservedVersion: e.RowVersion,
-		ObservedAt:      ev.ObservedAt,
-		Facts:           ev.Facts,
+	obs := centralstore.RunnerObservation{ID: id, ObservedVersion: e.RowVersion, ObservedAt: ev.ObservedAt, Facts: ev.Facts}
+	var deferredErrors []error
+	if candidate {
+		if row, exists, readErr := c.durable.Session(ctx, id); readErr != nil {
+			deferredErrors = append(deferredErrors, fmt.Errorf("sessioncoord: read successful exit policy state for %s: %w", id, readErr))
+		} else if exists {
+			obs.ObservedVersion = row.Version
+			obs.SuppressUnread = c.supervisedSuccessfulExit(row, ev.Facts)
+		}
 	}
 
 	staleRetries := 1
@@ -1063,27 +1111,74 @@ func (c *Coordinator) apply(ctx context.Context, id centralstore.SessionID, gene
 		staleRetries = 3
 	}
 	result, err := c.durable.ApplyRunnerObservation(ctx, obs)
+	if errors.Is(err, centralstore.ErrSuppressionWouldClearUnread) {
+		obs.SuppressUnread = false
+		result, err = c.durable.ApplyRunnerObservation(ctx, obs)
+	}
 	for retry := 0; err != nil && errors.Is(err, centralstore.ErrStaleVersion) && result.SessionVersion > 0 && retry < staleRetries; retry++ {
-		// The store returned the current version. Advance the local token and
-		// retry with the refreshed version.
 		c.registry.advance(id, generation, result.SessionVersion)
 		e2, ok2 := c.registry.current(id)
 		if !ok2 || e2.Generation != generation {
-			return // generation replaced while retrying
+			unlock()
+			for _, deferredErr := range deferredErrors {
+				c.reportError(ctx, deferredErr)
+			}
+			return
 		}
 		obs.ObservedVersion = e2.RowVersion
+		obs.SuppressUnread = false
+		if candidate {
+			if row, exists, readErr := c.durable.Session(ctx, id); readErr != nil {
+				deferredErrors = append(deferredErrors, fmt.Errorf("sessioncoord: re-read successful exit policy state for %s: %w", id, readErr))
+			} else if exists {
+				obs.ObservedVersion = row.Version
+				obs.SuppressUnread = c.supervisedSuccessfulExit(row, ev.Facts)
+			}
+		}
 		result, err = c.durable.ApplyRunnerObservation(ctx, obs)
+		if errors.Is(err, centralstore.ErrSuppressionWouldClearUnread) {
+			obs.SuppressUnread = false
+			result, err = c.durable.ApplyRunnerObservation(ctx, obs)
+		}
 	}
+
+	// Exit liveness is removed even when persistence fails. The startup sweep
+	// remains the repair authority; a dead process must never stay installed.
 	if err != nil {
+		var removed registryEntry
+		var yes bool
+		if ev.Alive != nil && !*ev.Alive {
+			if !lifecycleLocked {
+				c.mu.Lock()
+			}
+			removed, yes = c.registry.remove(id, generation)
+			if yes && c.activeSubagents != nil {
+				c.activeSubagents.setLive(id, false)
+			}
+			if !lifecycleLocked {
+				c.mu.Unlock()
+			}
+		}
+		unlock()
+		for _, deferredErr := range deferredErrors {
+			c.reportError(ctx, deferredErr)
+		}
 		c.reportError(ctx, fmt.Errorf("sessioncoord: observation failed for session %s gen %d: %w", id, generation, err))
+		if yes {
+			closeEntry(removed)
+		}
 		return
 	}
 
+	attentionSuppressed := obs.SuppressUnread
 	if !c.registry.advance(id, generation, result.SessionVersion) {
-		// Generation replaced (or fenced) while the DB call was in flight. The
-		// commit still happened, so publish it: invalidation is
-		// level-triggered, making publication of a committed outcome always
-		// safe, and it must not depend on the replacement's own publish.
+		// A foreign generation may now own the row. Publish only untagged
+		// invalidation; never attach this generation's suppression decision to a
+		// replacement row.
+		unlock()
+		for _, deferredErr := range deferredErrors {
+			c.reportError(ctx, deferredErr)
+		}
 		c.publish(ctx, result)
 		if result.Changed {
 			c.emitOutcomes(ctx, c.outcomes.allocSeq(), id)
@@ -1091,34 +1186,87 @@ func (c *Coordinator) apply(ctx context.Context, id centralstore.SessionID, gene
 		return
 	}
 
-	// Handle exit event. Alive=false must carry ExitedAt to be well-formed.
-	// A malformed event is reported but does not prevent liveness removal
-	// so the registry cannot remain stuck.
-	if ev.Alive != nil && !*ev.Alive {
-		if ev.Facts.ExitedAt.Set == nil {
-			c.reportError(ctx, fmt.Errorf("sessioncoord: malformed exit event: Alive=false without ExitedAt for session %s gen %d", id, generation))
+	var captured *centralstore.Session
+	var seq uint64
+	if candidate && attentionSuppressed && result.Changed {
+		row, exists, readErr := c.durable.Session(ctx, id)
+		if readErr != nil {
+			deferredErrors = append(deferredErrors, fmt.Errorf("sessioncoord: capture supervised exit outcome for %s: %w", id, readErr))
+		} else if exists && row.Version == result.SessionVersion {
+			captured = &row
 		}
-		// Exit facts committed (advance succeeded) before liveness removed.
-		// Canceling the stream propagates to the bufferEvents goroutine and
-		// the drain context, causing drain to exit its select loop. Admission
-		// and slot release share the lifecycle mutex.
-		c.mu.Lock()
-		removed, yes := c.registry.remove(id, generation)
-		if yes && c.activeSubagents != nil {
-			c.activeSubagents.setLive(id, false)
-		}
-		c.mu.Unlock()
-		if yes {
-			closeEntry(removed)
-		}
+	}
+	if lifecycleLocked && result.Changed {
+		seq = c.outcomes.allocSeq()
 	}
 
-	// Publish outside all locks so a blocking or re-entrant sink cannot
-	// stall the coordinator or deadlock.
-	c.publish(ctx, result)
-	if result.Changed {
-		c.emitOutcomes(ctx, c.outcomes.allocSeq(), id)
+	var removed registryEntry
+	var removedOK bool
+	if ev.Alive != nil && !*ev.Alive {
+		if ev.Facts.ExitedAt.Set == nil {
+			deferredErrors = append(deferredErrors, fmt.Errorf("sessioncoord: malformed exit event: Alive=false without ExitedAt for session %s gen %d", id, generation))
+		}
+		if !lifecycleLocked {
+			c.mu.Lock()
+		}
+		removed, removedOK = c.registry.remove(id, generation)
+		if removedOK && c.activeSubagents != nil {
+			c.activeSubagents.setLive(id, false)
+		}
+		if !lifecycleLocked {
+			c.mu.Unlock()
+		}
 	}
+	unlock()
+
+	for _, deferredErr := range deferredErrors {
+		c.reportError(ctx, deferredErr)
+	}
+	c.publish(ctx, result)
+	if captured != nil {
+		c.outcomes.publish(Outcome{Type: OutcomeUpserted, ID: id, Session: captured, Sequence: seq, AttentionSuppressed: true})
+	} else if result.Changed {
+		if seq == 0 {
+			seq = c.outcomes.allocSeq()
+		}
+		c.emitOutcomes(ctx, seq, id)
+	}
+	// Stream cancellation and body Close may block; neither belongs under the
+	// lifecycle mutex, and publication above must retain a live context.
+	if removedOK {
+		closeEntry(removed)
+	}
+}
+
+// successfulFastDeadRegistrationCandidate requires the result-bearing facts
+// that distinguish a completed process from a merely disconnected runner.
+// ExitedAt may have been synthesized above when a dead registration omitted
+// it; that does not broaden the policy because exit code, unread=true, and a
+// fresh token must still have been reported by the runner.
+func successfulFastDeadRegistrationCandidate(reg centralstore.RunnerRegistration) bool {
+	return !reg.Alive && reg.Facts.ExitedAt.Set != nil && reg.Facts.ExitCode.Set != nil &&
+		*reg.Facts.ExitCode.Set == 0 && reg.Facts.Unread != nil && *reg.Facts.Unread &&
+		reg.Facts.UnreadToken != nil && *reg.Facts.UnreadToken != ""
+}
+
+func successfulFullExitCandidate(ev RunnerEvent) bool {
+	return ev.Alive != nil && !*ev.Alive && ev.Facts.ExitedAt.Set != nil &&
+		ev.Facts.ExitCode.Set != nil && *ev.Facts.ExitCode.Set == 0 &&
+		ev.Facts.Unread != nil && *ev.Facts.Unread &&
+		ev.Facts.UnreadToken != nil && *ev.Facts.UnreadToken != ""
+}
+
+// supervisedSuccessfulExit runs only while c.mu is held. Registry membership
+// is the authority for current local liveness; durable Alive/Active facts are
+// deliberately irrelevant.
+func (c *Coordinator) supervisedSuccessfulExit(child centralstore.Session, facts centralstore.RunnerFacts) bool {
+	if child.Unread || child.Error || child.Interrupted ||
+		(facts.Error != nil && *facts.Error) || (facts.Interrupted != nil && *facts.Interrupted) ||
+		c.semanticSession(child) || child.ParentSessionID == nil {
+		return false
+	}
+	_, alive := c.registry.current(*child.ParentSessionID)
+	return alive
 }
 
 // invalidateVerdict clears a reconciliation verdict and, while a reconcile

--- a/services/gmuxd/internal/sessioncoord/outcomes.go
+++ b/services/gmuxd/internal/sessioncoord/outcomes.go
@@ -48,6 +48,10 @@ type Outcome struct {
 	//
 	// Runtime-only, like Alive and Generation: never a row column.
 	Frame *TurnFrame
+	// AttentionSuppressed identifies the committed successful-exit policy
+	// decision for in-process notification consumers. It is neither durable nor
+	// projected on public/peer wires; Unread remains the durable authority.
+	AttentionSuppressed bool
 }
 
 // outcomeActivityBacklog bounds how many undelivered outcomes a subscriber
@@ -401,12 +405,16 @@ func (c *Coordinator) livenessOf(id centralstore.SessionID) (bool, uint64) {
 // still queued behind it (delivered after) — the subscriber's final state
 // is the newest row either way (review M-2 rides the H-1 watermark).
 func (c *Coordinator) emitUpserted(session centralstore.Session, seq uint64) {
+	c.emitUpsertedWithAttention(session, seq, false)
+}
+
+func (c *Coordinator) emitUpsertedWithAttention(session centralstore.Session, seq uint64, attentionSuppressed bool) {
 	if !c.outcomes.hasSubscribers() {
 		return
 	}
 	alive, generation := c.livenessOf(session.ID)
 	s := session
-	c.outcomes.publish(Outcome{Type: OutcomeUpserted, ID: session.ID, Session: &s, Alive: alive, Generation: generation, Sequence: seq, Frame: c.frameOf(session.ID)})
+	c.outcomes.publish(Outcome{Type: OutcomeUpserted, ID: session.ID, Session: &s, Alive: alive, Generation: generation, Sequence: seq, Frame: c.frameOf(session.ID), AttentionSuppressed: attentionSuppressed})
 }
 
 // emitOutcomes publishes one outcome per ID after a commit: a post-commit

--- a/services/gmuxd/internal/sessioncoord/process_child_autoread_test.go
+++ b/services/gmuxd/internal/sessioncoord/process_child_autoread_test.go
@@ -1,0 +1,282 @@
+package sessioncoord
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/centralstore"
+)
+
+func TestProcessChildAutoReadSuccessfulFullExitPolicy(t *testing.T) {
+	parent := centralstore.SessionID("parent01")
+	other := centralstore.SessionID("parent02")
+	child := centralstore.SessionID("child001")
+	tests := []struct {
+		name           string
+		row            centralstore.Session
+		liveParent     *centralstore.SessionID
+		exitCode       int
+		eventError     bool
+		eventInterrupt bool
+		want           bool
+	}{
+		{name: "live direct shell parent", row: centralstore.Session{ID: child, Adapter: "shell", ParentSessionID: &parent}, liveParent: &parent, want: true},
+		{name: "idle parent still qualifies", row: centralstore.Session{ID: child, Adapter: "shell", ParentSessionID: &parent}, liveParent: &parent, want: true},
+		{name: "current parent not launch provenance", row: centralstore.Session{ID: child, Adapter: "shell", ParentSessionID: &other, LaunchedFromSessionID: &parent}, liveParent: &parent},
+		{name: "missing parent", row: centralstore.Session{ID: child, Adapter: "shell", ParentSessionID: &parent}},
+		{name: "semantic child", row: centralstore.Session{ID: child, Adapter: "agent", ParentSessionID: &parent}, liveParent: &parent},
+		{name: "status error", row: centralstore.Session{ID: child, Adapter: "shell", ParentSessionID: &parent, Error: true}, liveParent: &parent},
+		{name: "interrupted", row: centralstore.Session{ID: child, Adapter: "shell", ParentSessionID: &parent, Interrupted: true}, liveParent: &parent},
+		{name: "prior unread generation", row: centralstore.Session{ID: child, Adapter: "shell", ParentSessionID: &parent, Unread: true, UnreadToken: "older"}, liveParent: &parent},
+		{name: "event error", row: centralstore.Session{ID: child, Adapter: "shell", ParentSessionID: &parent}, liveParent: &parent, eventError: true},
+		{name: "event interrupted", row: centralstore.Session{ID: child, Adapter: "shell", ParentSessionID: &parent}, liveParent: &parent, eventInterrupt: true},
+		{name: "nonzero exit", row: centralstore.Session{ID: child, Adapter: "shell", ParentSessionID: &parent}, liveParent: &parent, exitCode: 7},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.row.Version = 1
+			d := newFakeDurable(1)
+			d.session = func(id centralstore.SessionID) (centralstore.Session, bool, error) { return tc.row, id == child, nil }
+			var got centralstore.RunnerObservation
+			d.applyResult = func(obs centralstore.RunnerObservation) (centralstore.MutationResult, error) {
+				got = obs
+				return centralstore.MutationResult{Changed: true, SessionsDirty: true, SessionVersion: 2}, nil
+			}
+			r := NewRegistry()
+			r.install(registryEntry{Runtime: Runtime{SessionID: child, Generation: 1, RowVersion: 1}, dead: make(chan struct{})})
+			if tc.liveParent != nil {
+				r.install(registryEntry{Runtime: Runtime{SessionID: *tc.liveParent, Generation: 1, RowVersion: 1}, dead: make(chan struct{})})
+			}
+			c := New(r, nil, d, nil, nil, WithProcessChildAutoRead(func(s centralstore.Session) bool { return s.Adapter == "agent" }))
+			unread, token, at, code, alive := true, "result-1", centralstore.UnixMillis(20), tc.exitCode, false
+			facts := centralstore.RunnerFacts{
+				Unread: &unread, UnreadToken: &token,
+				ExitedAt: centralstore.NullablePatch[centralstore.UnixMillis]{Set: &at}, ExitCode: centralstore.NullablePatch[int]{Set: &code},
+			}
+			if tc.eventError {
+				facts.Error = &tc.eventError
+			}
+			if tc.eventInterrupt {
+				facts.Interrupted = &tc.eventInterrupt
+			}
+			c.apply(context.Background(), child, 1, RunnerEvent{ObservedAt: 20, Alive: &alive, Facts: facts})
+			if got.SuppressUnread != tc.want {
+				t.Fatalf("SuppressUnread=%v, want %v; observation=%+v", got.SuppressUnread, tc.want, got)
+			}
+		})
+	}
+}
+
+func TestProcessChildAutoReadPolicyReadFaultStillCommitsAndRemoves(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{name: "read error", err: errors.New("read fault")},
+		{name: "missing row"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			parent, child := centralstore.SessionID("parent01"), centralstore.SessionID("child001")
+			d := newFakeDurable(1)
+			d.session = func(centralstore.SessionID) (centralstore.Session, bool, error) {
+				return centralstore.Session{}, false, tc.err
+			}
+			var applied centralstore.RunnerObservation
+			d.applyResult = func(obs centralstore.RunnerObservation) (centralstore.MutationResult, error) {
+				applied = obs
+				return centralstore.MutationResult{Changed: true, SessionsDirty: true, SessionVersion: 2}, nil
+			}
+			r := NewRegistry()
+			r.install(registryEntry{Runtime: Runtime{SessionID: child, Generation: 1, RowVersion: 1}, dead: make(chan struct{})})
+			r.install(registryEntry{Runtime: Runtime{SessionID: parent, Generation: 1, RowVersion: 1}, dead: make(chan struct{})})
+			errs := &fakeErrorSink{}
+			c := New(r, nil, d, nil, errs, WithProcessChildAutoRead(func(centralstore.Session) bool { return false }))
+			c.apply(context.Background(), child, 1, successfulExitEvent())
+			if applied.ID != child || applied.SuppressUnread {
+				t.Fatalf("exit was dropped or suppressed after policy fault: %+v", applied)
+			}
+			if _, alive := r.current(child); alive {
+				t.Fatal("dead child remained installed")
+			}
+			if tc.err != nil && errs.count() == 0 {
+				t.Fatal("policy read fault was not reported")
+			}
+		})
+	}
+}
+
+func successfulExitEvent() RunnerEvent {
+	unread, token, at, code, alive := true, "result-1", centralstore.UnixMillis(20), 0, false
+	return RunnerEvent{ObservedAt: 20, Alive: &alive, Facts: centralstore.RunnerFacts{
+		Unread: &unread, UnreadToken: &token,
+		ExitedAt: centralstore.NullablePatch[centralstore.UnixMillis]{Set: &at}, ExitCode: centralstore.NullablePatch[int]{Set: &code},
+	}}
+}
+
+func TestSuppressionDecisionNeverTagsReplacementGeneration(t *testing.T) {
+	parent, child := centralstore.SessionID("parent01"), centralstore.SessionID("child001")
+	r := NewRegistry()
+	r.install(registryEntry{Runtime: Runtime{SessionID: child, Generation: 1, RowVersion: 1}, dead: make(chan struct{})})
+	r.install(registryEntry{Runtime: Runtime{SessionID: parent, Generation: 1, RowVersion: 1}, dead: make(chan struct{})})
+	original := centralstore.Session{ID: child, Version: 1, Adapter: "shell", ParentSessionID: &parent}
+	replacement := centralstore.Session{ID: child, Version: 3, Adapter: "shell", Unread: true, UnreadToken: "replacement-result"}
+	replaced := false
+	d := newFakeDurable(1)
+	d.session = func(centralstore.SessionID) (centralstore.Session, bool, error) {
+		if replaced {
+			return replacement, true, nil
+		}
+		return original, true, nil
+	}
+	d.applyResult = func(centralstore.RunnerObservation) (centralstore.MutationResult, error) {
+		replaced = true
+		r.install(registryEntry{Runtime: Runtime{SessionID: child, Generation: 2, RowVersion: 3}, dead: make(chan struct{})})
+		return centralstore.MutationResult{Changed: true, SessionsDirty: true, SessionVersion: 2}, nil
+	}
+	c := New(r, nil, d, nil, nil, WithProcessChildAutoRead(func(centralstore.Session) bool { return false }))
+	events, unsubscribe := c.SubscribeOutcomes()
+	defer unsubscribe()
+	c.apply(context.Background(), child, 1, successfulExitEvent())
+	select {
+	case outcome := <-events:
+		if outcome.AttentionSuppressed || outcome.Generation != 2 || outcome.Session == nil || outcome.Session.UnreadToken != "replacement-result" {
+			t.Fatalf("old decision tagged or obscured replacement outcome: %+v", outcome)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("replacement invalidation outcome not published")
+	}
+}
+
+func TestFastDeadRegistrationAutoReadPolicy(t *testing.T) {
+	parent, child := centralstore.SessionID("parent01"), centralstore.SessionID("child001")
+	for _, tc := range []struct {
+		name        string
+		adapter     string
+		parentAlive bool
+		errorFact   bool
+		exitCode    int
+		want        bool
+	}{
+		{name: "successful process with live parent", adapter: "shell", parentAlive: true, want: true},
+		{name: "semantic agent", adapter: "agent", parentAlive: true},
+		{name: "error fact", adapter: "shell", parentAlive: true, errorFact: true},
+		{name: "nonzero exit", adapter: "shell", parentAlive: true, exitCode: 7},
+		{name: "dead parent", adapter: "shell"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			unread, token, exited := true, "fast-result", centralstore.UnixMillis(20)
+			active, interrupted := false, false
+			reg := centralstore.RunnerRegistration{ID: child, Adapter: tc.adapter, Alive: false, CreatedAt: 1, ObservedAt: 20, ParentSessionID: &parent,
+				Facts: centralstore.RunnerFacts{Active: &active, Error: &tc.errorFact, Interrupted: &interrupted, Unread: &unread, UnreadToken: &token,
+					ExitedAt: centralstore.NullablePatch[centralstore.UnixMillis]{Set: &exited}, ExitCode: centralstore.NullablePatch[int]{Set: &tc.exitCode}}}
+			client := newFakeClient(RunnerMeta{Registration: reg})
+			dur := newFakeDurable(0)
+			r := NewRegistry()
+			if tc.parentAlive {
+				r.install(registryEntry{Runtime: Runtime{SessionID: parent, Generation: 1, RowVersion: 1}, dead: make(chan struct{})})
+			}
+			coord := New(r, client, dur, nil, nil, WithProcessChildAutoRead(func(s centralstore.Session) bool { return s.Adapter == "agent" }))
+			if _, err := coord.Register(context.Background(), RegisterRequest{Endpoint: "fast"}); err != nil {
+				t.Fatal(err)
+			}
+			if len(dur.registered) != 1 || dur.registered[0].SuppressUnread != tc.want {
+				t.Fatalf("registration suppression=%v, want %v; reg=%+v", len(dur.registered) == 1 && dur.registered[0].SuppressUnread, tc.want, dur.registered)
+			}
+		})
+	}
+}
+
+func TestFastDeadRegistrationUsesCurrentDurableParent(t *testing.T) {
+	launchParent, currentParent, child := centralstore.SessionID("parent01"), centralstore.SessionID("parent02"), centralstore.SessionID("child001")
+	c := New(NewRegistry(), nil, nil, nil, nil, WithProcessChildAutoRead(func(centralstore.Session) bool { return false }))
+	c.registry.install(registryEntry{Runtime: Runtime{SessionID: launchParent, Generation: 1}, dead: make(chan struct{})})
+	unread, token := true, "fresh"
+	facts := centralstore.RunnerFacts{Unread: &unread, UnreadToken: &token}
+	row := centralstore.Session{ID: child, Adapter: "shell", ParentSessionID: &currentParent, LaunchedFromSessionID: &launchParent}
+	if c.supervisedSuccessfulExit(row, facts) {
+		t.Fatal("launch parent liveness overrode dead current organizational parent")
+	}
+	c.registry.install(registryEntry{Runtime: Runtime{SessionID: currentParent, Generation: 1}, dead: make(chan struct{})})
+	if !c.supervisedSuccessfulExit(row, facts) {
+		t.Fatal("live current organizational parent did not qualify")
+	}
+	row.Unread, row.UnreadToken = true, "older"
+	if c.supervisedSuccessfulExit(row, facts) {
+		t.Fatal("fast-dead registration would clear a pre-existing unread result")
+	}
+}
+
+func TestFastDeadRegistrationPolicyReadFailureFailsClosed(t *testing.T) {
+	parent, child := centralstore.SessionID("parent01"), centralstore.SessionID("child001")
+	unread, token, code, exited := true, "fast-result", 0, centralstore.UnixMillis(20)
+	reg := centralstore.RunnerRegistration{ID: child, Adapter: "shell", Alive: false, CreatedAt: 1, ObservedAt: 20, ParentSessionID: &parent, Facts: centralstore.RunnerFacts{
+		Unread: &unread, UnreadToken: &token, ExitCode: centralstore.NullablePatch[int]{Set: &code}, ExitedAt: centralstore.NullablePatch[centralstore.UnixMillis]{Set: &exited},
+	}}
+	client := newFakeClient(RunnerMeta{Registration: reg})
+	dur := newFakeDurable(0)
+	dur.session = func(centralstore.SessionID) (centralstore.Session, bool, error) {
+		return centralstore.Session{}, false, errors.New("read fault")
+	}
+	r := NewRegistry()
+	r.install(registryEntry{Runtime: Runtime{SessionID: parent, Generation: 1}, dead: make(chan struct{})})
+	errs := &fakeErrorSink{}
+	coord := New(r, client, dur, nil, errs, WithProcessChildAutoRead(func(centralstore.Session) bool { return false }))
+	if _, err := coord.Register(context.Background(), RegisterRequest{Endpoint: "fast"}); err != nil {
+		t.Fatal(err)
+	}
+	if len(dur.registered) != 1 || dur.registered[0].SuppressUnread {
+		t.Fatalf("faulted policy did not fail closed: %+v", dur.registered)
+	}
+	if errs.count() == 0 {
+		t.Fatal("policy read fault was not reported")
+	}
+}
+
+func TestFastDeadRegistrationSuppressionRetryPreservesOlderOutcome(t *testing.T) {
+	parent, child := centralstore.SessionID("parent01"), centralstore.SessionID("child001")
+	unread, token, code, exited := true, "fresh-result", 0, centralstore.UnixMillis(20)
+	reg := centralstore.RunnerRegistration{ID: child, Adapter: "shell", Alive: false, CreatedAt: 1, ObservedAt: 20, ParentSessionID: &parent, Facts: centralstore.RunnerFacts{
+		Unread: &unread, UnreadToken: &token, ExitCode: centralstore.NullablePatch[int]{Set: &code}, ExitedAt: centralstore.NullablePatch[centralstore.UnixMillis]{Set: &exited},
+	}}
+	client := newFakeClient(RunnerMeta{Registration: reg})
+	dur := newFakeDurable(0)
+	dur.session = func(id centralstore.SessionID) (centralstore.Session, bool, error) {
+		return centralstore.Session{ID: child, Version: 1, Adapter: "shell", ParentSessionID: &parent}, id == child, nil
+	}
+	calls := 0
+	dur.registerResult = func(got centralstore.RunnerRegistration) (centralstore.Session, centralstore.MutationResult, error) {
+		calls++
+		if calls == 1 {
+			if !got.SuppressUnread {
+				t.Fatal("first registration did not attempt qualified suppression")
+			}
+			return centralstore.Session{}, centralstore.MutationResult{}, centralstore.ErrSuppressionWouldClearUnread
+		}
+		if got.SuppressUnread {
+			t.Fatal("retry retained rejected suppression")
+		}
+		return centralstore.Session{ID: child, Version: 2, Adapter: "shell", ParentSessionID: &parent, Unread: true, UnreadToken: "older-result"},
+			centralstore.MutationResult{Changed: true, SessionsDirty: true, SessionVersion: 2}, nil
+	}
+	r := NewRegistry()
+	r.install(registryEntry{Runtime: Runtime{SessionID: parent, Generation: 1}, dead: make(chan struct{})})
+	coord := New(r, client, dur, nil, nil, WithProcessChildAutoRead(func(centralstore.Session) bool { return false }))
+	outcomes, unsubscribe := coord.SubscribeOutcomes()
+	defer unsubscribe()
+	if _, err := coord.Register(context.Background(), RegisterRequest{Endpoint: "fast"}); err != nil {
+		t.Fatal(err)
+	}
+	if calls != 2 {
+		t.Fatalf("registration calls=%d, want suppression plus unsuppressed retry", calls)
+	}
+	select {
+	case outcome := <-outcomes:
+		if outcome.AttentionSuppressed || outcome.Session == nil || !outcome.Session.Unread || outcome.Session.UnreadToken != "older-result" {
+			t.Fatalf("retry outcome lost or tagged older result: %+v", outcome)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("registration retry outcome not published")
+	}
+}


### PR DESCRIPTION
## Summary

- treat successful process-child exits as supervised when their current direct parent has a live local runner
- preserve strict unread attention for agent children, failures, interruptions, missing/dead parents, and pre-existing unread results
- make normal and fast-dead completion paths atomic and race-safe across reparenting, parent death, and runner replacement
- suppress only the matching completion notification while preserving older tokened attention

## Testing

- `GOTOOLCHAIN=go1.26.1 go test ./cli/gmux/... ./services/gmuxd/... -count=1`
- focused `-race` suites covering completion fusion, persistence, registration, coordinator lifecycle races, discovery compatibility, notification cancellation, and composed routing

## Notes

- OSC/prompt-cycle completion semantics are unchanged
- existing retained unread rows are not migrated
- no public wire, frontend, peer protocol, or schema changes
