### PR TITLE
perf(web): index sidebar projections so large session lists stay responsive

### DIFF
--- a/apps/gmux-web/src/store-perf-fixture.ts
+++ b/apps/gmux-web/src/store-perf-fixture.ts
@@ -1,0 +1,155 @@
+/** Deterministic synthetic worlds for the store-projection differential and
+ * performance tests (`store-projections.test.ts`, `store.bench.ts`).
+ *
+ * Mirrors the corpus shape from the frontend-sync assessment probes:
+ * multiple hosts (one Local devcontainer peer), ~50 projects plus peer
+ * references, ~10% task-family children (with grandchildren), retained-dead
+ * sessions, unread flags, unstamped strays, unresolvable stamps, and
+ * transitional families (stamped child under an unstamped root — the
+ * temporary-placement path in `foldersFrom`).
+ *
+ * Everything is seeded (Mulberry32) so a fixture is exactly reproducible:
+ * the same (seed, n) pair always yields byte-identical worlds, which lets
+ * perf numbers in reports/benches reference "fixture seed=S n=N" precisely.
+ */
+import type { PeerInfo, ProjectItem, Session } from './types'
+
+export interface FixtureWorld {
+  sessions: Session[]
+  projects: ProjectItem[]
+  peers: PeerInfo[]
+  peerProjects: Record<string, { slug: string; launch_cwd?: string }[]>
+  /** A mid-list family child id, for selection-dependent projections. */
+  selectedChildId: string
+  /** A root session id whose unread bit the mutation benches flip. */
+  mutationTargetId: string
+}
+
+/** Mulberry32 — tiny, high-quality-enough seeded PRNG. */
+export function mulberry32(seed: number): () => number {
+  let a = seed >>> 0
+  return () => {
+    a = (a + 0x6D2B79F5) | 0
+    let t = Math.imul(a ^ (a >>> 15), 1 | a)
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+const HOSTS = ['', '', '', 'hostA', 'hostB', 'hostC', 'devbox'] as const
+
+export function makeFixtureWorld(seed: number, n: number): FixtureWorld {
+  const rnd = mulberry32(seed)
+  const pick = <T,>(arr: readonly T[]): T => arr[Math.floor(rnd() * arr.length)]
+
+  const projectCount = Math.max(5, Math.min(50, Math.floor(n / 20)))
+  const projects: ProjectItem[] = []
+  for (let i = 0; i < projectCount; i++) {
+    projects.push({ slug: `p${i}`, match: [{ path: `~/work/p${i}` }] })
+  }
+  // References to peer-owned projects (hostA/hostB own a few slugs each).
+  for (const peer of ['hostA', 'hostB']) {
+    for (let i = 0; i < 4; i++) {
+      projects.push({ slug: `${peer.toLowerCase()}-r${i}`, peer, node_id: `node-${peer}` })
+    }
+  }
+  const peers: PeerInfo[] = [
+    { name: 'hostA', url: 'http://a', status: 'connected', session_count: 0, node_id: 'node-hostA' } as PeerInfo,
+    { name: 'hostB', url: 'http://b', status: 'connected', session_count: 0, node_id: 'node-hostB' } as PeerInfo,
+    { name: 'hostC', url: 'http://c', status: 'disconnected', session_count: 0 },
+    { name: 'devbox', url: 'http://d', status: 'connected', session_count: 0, local: true },
+  ]
+  const peerProjects: FixtureWorld['peerProjects'] = {
+    hostA: [0, 1, 2].map(i => ({ slug: `hosta-r${i}`, launch_cwd: `/peer/a${i}` })),
+    // hosta-r3 / hostb-r3 stay dangling (connected peer, slug removed upstream).
+    hostB: [0, 1, 2].map(i => ({ slug: `hostb-r${i}`, launch_cwd: `/peer/b${i}` })),
+  }
+
+  const baseMs = Date.parse('2026-01-01T00:00:00Z')
+  const iso = (offsetSec: number) => new Date(baseMs + offsetSec * 1000).toISOString()
+
+  const sessions: Session[] = []
+  const roots: Session[] = []
+  const mk = (id: string, over: Partial<Session>): Session => ({
+    id,
+    created_at: iso(Math.floor(rnd() * 86400 * 14)),
+    command: ['pi'],
+    cwd: `~/work/p${Math.floor(rnd() * projectCount)}`,
+    adapter: rnd() < 0.7 ? 'pi' : 'shell',
+    alive: true,
+    pid: 1,
+    exit_code: null,
+    started_at: iso(0),
+    exited_at: null,
+    title: `session ${id}`,
+    subtitle: '',
+    status: null,
+    unread: false,
+    socket_path: '/tmp/s.sock',
+    ...over,
+  })
+
+  for (let i = 0; i < n; i++) {
+    const id = `s${i}`
+    const host = pick(HOSTS)
+    const asChild = roots.length > 0 && rnd() < 0.12
+    const alive = rnd() < 0.7
+    const resumable = !alive && rnd() < 0.5
+    const unread = rnd() < 0.15
+    const over: Partial<Session> = {
+      alive,
+      resumable,
+      unread,
+      unread_token: unread ? `tok-${id}` : undefined,
+      exited_at: alive ? null : iso(Math.floor(rnd() * 86400 * 14)),
+      last_output_at: rnd() < 0.9 ? iso(Math.floor(rnd() * 86400 * 14)) : undefined,
+      status: rnd() < 0.5 ? { active: rnd() < 0.5, error: rnd() < 0.1 } : null,
+      semantic_agent: rnd() < 0.6 ? true : undefined,
+    }
+    if (host) over.peer = host
+    if (asChild) {
+      // Parent must share the child's host for realistic families, but a few
+      // malformed cross-host edges keep the cycle/fail-open paths honest.
+      const parent = rnd() < 0.95
+        ? roots[Math.floor(rnd() * roots.length)]
+        : sessions[Math.floor(rnd() * sessions.length)]
+      over.parent_session_id = parent.id
+      if ((parent.peer ?? '') === host || rnd() < 0.3) {
+        // Most children are unstamped; some carry a stamp while their root
+        // does not (transitional family → temporary placement), and some
+        // carry a stamp that resolves to no project at all.
+        const r = rnd()
+        if (r < 0.25) over.project_slug = `p${Math.floor(rnd() * projectCount)}`
+        else if (r < 0.3) over.project_slug = 'no-such-project'
+      }
+    } else {
+      // Roots: mostly stamped; ~10% unstamped (discovery-only), a few stamped
+      // with slugs the viewer doesn't know.
+      const r = rnd()
+      if (r < 0.82) {
+        if (host === 'hostA' || host === 'hostB') {
+          over.project_slug = `${host.toLowerCase()}-r${Math.floor(rnd() * 4)}`
+        } else {
+          over.project_slug = `p${Math.floor(rnd() * projectCount)}`
+        }
+        over.project_index = Math.floor(rnd() * 10)
+      } else if (r < 0.88) {
+        over.project_slug = 'unknown-slug'
+      }
+    }
+    const s = mk(id, over)
+    sessions.push(s)
+    if (!asChild && s.semantic_agent && rnd() < 0.5) roots.push(s)
+  }
+
+  const firstChild = sessions.find(s => s.parent_session_id)
+  const firstStampedRoot = sessions.find(s => !s.parent_session_id && s.project_slug?.startsWith('p'))
+  return {
+    sessions,
+    projects,
+    peers,
+    peerProjects,
+    selectedChildId: firstChild?.id ?? sessions[0]?.id ?? '',
+    mutationTargetId: firstStampedRoot?.id ?? sessions[0]?.id ?? '',
+  }
+}

--- a/apps/gmux-web/src/store-projections.test.ts
+++ b/apps/gmux-web/src/store-projections.test.ts
@@ -1,0 +1,334 @@
+/** Differential tests for the normalized (Map/Set-indexed) sidebar
+ * projections against the pre-optimization reference algorithms.
+ *
+ * The production computeds (`sidebarSessions`, `folders`, `unreadCount`)
+ * were rewritten from linear-scan-per-session (`Array.find` inside loops,
+ * quadratic at scale) to shared `familyIndex` lookups. These tests pin the
+ * rewrite to the old behavior: the reference implementations below are the
+ * previous store code, verbatim modulo extraction into functions, and every
+ * randomized world must project identically through both.
+ *
+ * Worlds come from the seeded generator in `store-perf-fixture.ts` (multi
+ * host, family edges incl. malformed ones, unstamped strays, transitional
+ * families, unresolvable stamps), crossed with the view state that the
+ * projections read: tab filter, alive-only toggle, and selection (none /
+ * root / family child / dismissed-by-filter).
+ */
+import { beforeEach, describe, expect, it } from 'vitest'
+import { familyIndex, familyRoot, familyRootId, isFamilyChild, isProcessSession } from './family'
+import { buildProjectFolders, type TemporaryPresentationPlacement } from './projects'
+import { referencePresence } from './references'
+import {
+  _pendingMutations, _rawSessions, _setRawWorld, aliveOnly, filteredSessions, folders,
+  localPeerNames, projects, peers, selected, selectedId, sessions, sessionsLoaded, setAliveOnly,
+  sidebarSessions, unreadCount, urlHash, urlPath, urlSearch, worldLoaded,
+} from './store'
+import type { Folder, Session } from './types'
+import { makeFixtureWorld, mulberry32 } from './store-perf-fixture'
+
+// ── Reference implementations: the pre-optimization store code ──────────────
+
+function referenceSidebarSessions(): Session[] {
+  const sel = selectedId.value
+  const onlyAlive = aliveOnly.value
+  const base = filteredSessions.value.filter(s =>
+    s.id === sel || (onlyAlive ? s.alive : s.alive || s.resumable),
+  )
+  const out = [...base]
+  for (const candidate of base) {
+    const rootId = familyRootId(candidate.id, sessions.value)
+    const root = sessions.value.find(s => s.id === rootId)
+    if (root && !out.some(s => s.id === root.id)) out.push(root)
+  }
+  if (sel) {
+    const selectedSession = sessions.value.find(x => x.id === sel)
+    if (selectedSession && !out.some(s => s.id === selectedSession.id)) out.push(selectedSession)
+    const rootId = familyRootId(sel, sessions.value)
+    const root = sessions.value.find(s => s.id === rootId)
+    if (root && !out.some(s => s.id === root.id)) out.push(root)
+  }
+  return out
+}
+
+function referenceFoldersFrom(ss: Session[]): Folder[] {
+  const forceVisible = new Set<string>()
+  const temporaryPlacements = new Map<string, TemporaryPresentationPlacement>()
+  const selectedRoot = familyRootId(selectedId.value, sessions.value)
+  if (selectedRoot) forceVisible.add(selectedRoot)
+  for (const candidate of ss) {
+    if (isFamilyChild(candidate, sessions.value)) {
+      const rootId = familyRootId(candidate.id, sessions.value)
+      if (!rootId) continue
+      forceVisible.add(rootId)
+      const root = sessions.value.find(session => session.id === rootId)
+      if (root?.project_slug || !candidate.project_slug) continue
+      const sessionPeer = candidate.peer ?? ''
+      const ownerPeer = sessionPeer && !localPeerNames.value.has(sessionPeer) ? sessionPeer : ''
+      const resolves = projects.value.some(project =>
+        project.slug === candidate.project_slug && (project.peer ?? '') === ownerPeer,
+      )
+      if (!resolves) continue
+      const placement = { ownerPeer, slug: candidate.project_slug }
+      const previous = temporaryPlacements.get(rootId)
+      if (!previous || `${placement.ownerPeer}::${placement.slug}` < `${previous.ownerPeer}::${previous.slug}`) {
+        temporaryPlacements.set(rootId, placement)
+      }
+    }
+  }
+  return buildProjectFolders(
+    projects.value,
+    ss.filter(s => !isFamilyChild(s, sessions.value)),
+    (name) => localPeerNames.value.has(name),
+    // Matches the store's private `_rawWorld.value.peerProjects` — the test
+    // world round-trips it through `_setRawWorld`.
+    worldPeerProjects,
+    referencePresence(peers.value),
+    forceVisible,
+    temporaryPlacements,
+  )
+}
+
+let worldPeerProjects: Record<string, { slug: string; launch_cwd?: string }[]> = {}
+
+function referenceUnreadCount(): number {
+  const sel = selectedId.value
+  const childUnread = new Map<string, number>()
+  for (const s of sessions.value) {
+    if (s.id === sel || !s.unread || isProcessSession(s) || !isFamilyChild(s, sessions.value)) continue
+    // The pre-optimization code read `index.rootById.get(s.id)?.id`;
+    // `familyRootId` is that same lookup.
+    const rootId = familyRootId(s.id, sessions.value)
+    if (rootId) childUnread.set(rootId, (childUnread.get(rootId) ?? 0) + 1)
+  }
+  let n = 0
+  for (const f of referenceFoldersFrom(filteredSessions.value)) {
+    for (const s of f.sessions) {
+      if (s.id !== sel && s.unread) n++
+      n += childUnread.get(s.id) ?? 0
+    }
+  }
+  return n
+}
+
+// ── Harness ──────────────────────────────────────────────────────────────────
+
+function loadWorld(seed: number, n: number) {
+  const w = makeFixtureWorld(seed, n)
+  worldPeerProjects = w.peerProjects
+  _rawSessions.value = w.sessions
+  _setRawWorld({
+    projects: w.projects,
+    peers: w.peers,
+    peerProjects: w.peerProjects,
+    health: { hostname: 'localbox' } as never,
+  })
+  sessionsLoaded.value = true
+  worldLoaded.value = true
+  return w
+}
+
+/** Select a session through the URL, the way the app does. Returns whether
+ * the selection actually resolved (fixture worlds don't guarantee every
+ * shape is addressable). */
+function selectViaUrl(s: Session | undefined): boolean {
+  if (!s || s.peer) return false
+  const root = familyRoot(s, sessions.value)
+  if (root.peer || !root.project_slug || !projects.value.some(p => !p.peer && p.slug === root.project_slug)) return false
+  urlPath.value = `/${root.project_slug}/${s.adapter}/~${s.id}`
+  return selectedId.value === s.id
+}
+
+function foldersComparable(fs: Folder[]) {
+  return fs.map(f => ({
+    key: f.key,
+    launchCwd: f.launchCwd,
+    missing: f.missing,
+    unresolved: f.unresolved,
+    sessions: f.sessions.map(s => s.id),
+  }))
+}
+
+function expectProjectionsMatchReference() {
+  const actual = sidebarSessions.value
+  const reference = referenceSidebarSessions()
+  expect(actual.map(s => s.id)).toEqual(reference.map(s => s.id))
+  // Row *identity* must hold too (`toBe` per element, not deep equality):
+  // both projections must hand out the exact snapshot session objects, so
+  // downstream identity-keyed caches and === comparisons keep working.
+  for (let i = 0; i < actual.length; i++) expect(actual[i]).toBe(reference[i])
+  expect(foldersComparable(folders.value)).toEqual(foldersComparable(referenceFoldersFrom(sidebarSessions.value)))
+  expect(unreadCount.value).toBe(referenceUnreadCount())
+  // `selected` is load-bearing for the whole session view: when the URL
+  // addresses a session, it must be the exact snapshot object, never null.
+  const sel = selectedId.value
+  if (sel) expect(selected.value).toBe(sessions.value.find(s => s.id === sel) ?? null)
+  else expect(selected.value).toBeNull()
+}
+
+// `selected` mirrors itself onto `window.__gmuxSession` for debugging; give
+// the node test environment a window object so reading it is possible.
+;(globalThis as { window?: unknown }).window ??= globalThis
+
+beforeEach(() => {
+  _rawSessions.value = []
+  _setRawWorld({ projects: [], peers: [], peerProjects: {} })
+  _pendingMutations.value = []
+  sessionsLoaded.value = false
+  worldLoaded.value = false
+  urlPath.value = '/'
+  urlSearch.value = ''
+  urlHash.value = ''
+  setAliveOnly(false)
+})
+
+describe('normalized projections ≡ reference algorithms (property)', () => {
+  const seeds = [1, 2, 3, 5, 8, 13, 21, 42]
+  for (const seed of seeds) {
+    it(`randomized world seed=${seed}`, () => {
+      const rnd = mulberry32(seed * 7919)
+      const n = 50 + Math.floor(rnd() * 450)
+      const w = loadWorld(seed, n)
+
+      // 1. no selection, no filter
+      expectProjectionsMatchReference()
+
+      // 2. alive-only toggle
+      setAliveOnly(true)
+      expectProjectionsMatchReference()
+      setAliveOnly(false)
+
+      // 3. tab filter narrowed to one project, then one host
+      urlSearch.value = '?filter=p1'
+      expectProjectionsMatchReference()
+      urlSearch.value = '?filter=*%40hostA'
+      expectProjectionsMatchReference()
+      urlSearch.value = ''
+
+      // 4. select a family child (root row must stand in), then its root
+      const child = w.sessions.find(s => s.parent_session_id && !s.peer)
+      if (selectViaUrl(child)) {
+        expectProjectionsMatchReference()
+        urlSearch.value = '?filter=p2'
+        expectProjectionsMatchReference()
+        setAliveOnly(true)
+        expectProjectionsMatchReference()
+        setAliveOnly(false)
+        urlSearch.value = ''
+      }
+      const root = w.sessions.find(s => !s.parent_session_id && !s.peer && s.project_slug?.startsWith('p'))
+      if (selectViaUrl(root)) expectProjectionsMatchReference()
+
+      // 5. random single-session mutations (unread flips, deaths, title runs)
+      for (let i = 0; i < 20; i++) {
+        const idx = Math.floor(rnd() * w.sessions.length)
+        const next = _rawSessions.value.slice()
+        const target = next[idx]
+        const kind = rnd()
+        next[idx] = kind < 0.5
+          ? { ...target, unread: !target.unread, unread_token: `flip-${i}` }
+          : kind < 0.8
+            ? { ...target, alive: false, resumable: rnd() < 0.5, exited_at: '2026-01-02T00:00:00Z' }
+            : { ...target, title: `mut ${i}` }
+        _rawSessions.value = next
+        expectProjectionsMatchReference()
+      }
+
+      // 6. removal and addition
+      _rawSessions.value = _rawSessions.value.filter((_, i) => i % 17 !== 3)
+      expectProjectionsMatchReference()
+    })
+  }
+
+  it('selected hands out the exact snapshot session for the addressed URL', () => {
+    loadWorld(3, 200)
+    // A local stamped root is always URL-addressable; the fixture guarantees
+    // plenty. A projection mutant that loses the session (returns null or a
+    // copy) must fail here deterministically, not only via random worlds.
+    const root = sessions.value.find(s =>
+      !s.peer && !s.parent_session_id && /^p\d+$/.test(s.project_slug ?? '')
+      && projects.value.some(p => !p.peer && p.slug === s.project_slug))
+    expect(root).toBeDefined()
+    expect(selectViaUrl(root)).toBe(true)
+    expect(selected.value).toBe(root)
+    expect(sidebarSessions.value).toContain(root)
+
+    // Family-child selection: exact child object, root row stands in.
+    const child = sessions.value.find(s => s.parent_session_id && selectViaUrl(s))
+    if (child) {
+      expect(selected.value).toBe(child)
+      const childRoot = familyRoot(child, sessions.value)
+      expect(sidebarSessions.value).toContain(childRoot)
+    }
+
+    urlPath.value = '/'
+    expect(selected.value).toBeNull()
+  })
+
+  it('degenerate worlds: empty, single, all-children-of-one-root', () => {
+    loadWorld(99, 0)
+    expectProjectionsMatchReference()
+
+    loadWorld(99, 1)
+    expectProjectionsMatchReference()
+
+    const w = loadWorld(4, 60)
+    const root: Session = { ...w.sessions[0], id: 'root', parent_session_id: undefined, semantic_agent: true, peer: undefined, project_slug: 'p1', unread: true }
+    const kids = Array.from({ length: 40 }, (_, i): Session => ({
+      ...w.sessions[i % w.sessions.length],
+      id: `kid${i}`,
+      parent_session_id: i === 0 ? 'root' : `kid${i - 1}`,
+      semantic_agent: true,
+      peer: undefined,
+      project_slug: i % 3 === 0 ? 'p2' : undefined,
+      unread: i % 2 === 0,
+    }))
+    _rawSessions.value = [root, ...kids]
+    expectProjectionsMatchReference()
+  })
+})
+
+describe('projection performance regression (fixture seed=1234)', () => {
+  /** One-session mutation must not trigger quadratic rework. Calibration
+   * (2019 desktop i7-9700K, 24 repeated best-of-3 runs): optimized 29–37 ms,
+   * pre-optimization O(N²) algorithms 1,200–1,487 ms. 400 ms is >10× headroom
+   * over the optimized cost for slow CI machines while sitting 3× below the
+   * old implementation's floor, so a reintroduced O(N²) scan fails hard. */
+  it('one-session mutation derived cost at 10k sessions stays linear-ish', () => {
+    const w = loadWorld(1234, 10000)
+    const readAll = () => [sidebarSessions.value, folders.value, unreadCount.value]
+    readAll() // cold build outside the measured window
+    let best = Infinity
+    for (let run = 0; run < 3; run++) {
+      const idx = w.sessions.findIndex(s => s.id === w.mutationTargetId)
+      const next = _rawSessions.value.slice()
+      next[idx] = { ...next[idx], unread: !next[idx].unread, unread_token: `flip-${run}` }
+      _rawSessions.value = next
+      const t0 = performance.now()
+      readAll()
+      best = Math.min(best, performance.now() - t0)
+    }
+    expect(best).toBeLessThan(400)
+  }, 120000)
+
+  it('computeds share one family index per snapshot (no duplicate index builds)', () => {
+    // `familyIndex` is WeakMap-cached per session-array identity. Reading
+    // every projection must reuse one FamilyIndex object per snapshot, and
+    // signal memoization must keep projection identity stable until the
+    // snapshot array changes.
+    loadWorld(7, 500)
+    const before = familyIndex(sessions.value)
+    const a = sidebarSessions.value
+    const b = folders.value
+    const c = unreadCount.value
+    expect(familyIndex(sessions.value)).toBe(before)
+    expect(sidebarSessions.value).toBe(a)
+    expect(folders.value).toBe(b)
+    expect(unreadCount.value).toBe(c)
+    // A one-session mutation swaps the array: exactly one new index.
+    _rawSessions.value = _rawSessions.value.slice()
+    const after = familyIndex(sessions.value)
+    expect(after).not.toBe(before)
+    void [sidebarSessions.value, folders.value, unreadCount.value]
+    expect(familyIndex(sessions.value)).toBe(after)
+  })
+})

--- a/apps/gmux-web/src/store.bench.ts
+++ b/apps/gmux-web/src/store.bench.ts
@@ -1,0 +1,52 @@
+/** Projection benchmarks over the exact worlds from `store-perf-fixture.ts`
+ * (seed 1234). Run with `npx vitest bench src/store.bench.ts`.
+ *
+ * Two shapes per corpus size:
+ *   - cold: fresh snapshot array → every projection rebuilt from scratch,
+ *   - one-session mutation: the protocol-3 steady state (a full-list
+ *     replacement that differs in a single row's unread bit).
+ *
+ * Reference numbers (i7-9700K, Node 24) before/after the slice-0
+ * normalization — see report-optimize-frontend-projections.md:
+ *   n=10k  mutation  1,514 ms → ~99 ms;  n=30k  16,026 ms → ~350 ms.
+ */
+import { bench, describe } from 'vitest'
+import {
+  _rawSessions, _setRawWorld, familyActivityById, familyDotById, folders,
+  homePartition, sessionsLoaded, sidebarActivity, sidebarSessions, unreadCount,
+  urlPath, worldLoaded,
+} from './store'
+import { makeFixtureWorld } from './store-perf-fixture'
+
+function readAll(): unknown {
+  return [
+    sidebarSessions.value, folders.value, unreadCount.value, sidebarActivity.value,
+    familyDotById.value, familyActivityById.value, homePartition.value,
+  ]
+}
+
+for (const n of [1000, 10000, 30000]) {
+  const w = makeFixtureWorld(1234, n)
+  describe(`store projections, ${n} sessions (fixture seed=1234)`, () => {
+    bench('cold snapshot → all projections', () => {
+      _setRawWorld({
+        projects: w.projects, peers: w.peers, peerProjects: w.peerProjects,
+        health: { hostname: 'localbox' } as never,
+      })
+      sessionsLoaded.value = true
+      worldLoaded.value = true
+      urlPath.value = '/'
+      _rawSessions.value = w.sessions.slice()
+      readAll()
+    })
+
+    let flip = 0
+    bench('one-session unread flip → all projections', () => {
+      const idx = w.sessions.findIndex(s => s.id === w.mutationTargetId)
+      const next = _rawSessions.value.length === n ? _rawSessions.value.slice() : w.sessions.slice()
+      next[idx] = { ...next[idx], unread: (flip++ & 1) === 0, unread_token: `flip-${flip}` }
+      _rawSessions.value = next
+      readAll()
+    })
+  })
+}

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -616,6 +616,16 @@ export const localPeerNames = computed<ReadonlySet<string>>(() => {
   return set
 })
 
+/** Folder identity keys (`${ownerPeer}::${slug}`) for every catalog entry.
+ *  Shared O(1) membership index for the per-session "does this stamp resolve
+ *  to a folder?" checks in `foldersFrom`; recomputed only when the project
+ *  catalog changes, never per snapshot. */
+const projectKeys = computed<ReadonlySet<string>>(() => {
+  const set = new Set<string>()
+  for (const project of projects.value) set.add(`${project.peer ?? ''}::${project.slug}`)
+  return set
+})
+
 /** Distinct referenced host names absent from the roster. Drives the
  *  Hosts-tab "Referenced but not found" group and the gear pip — a
  *  node_id/name membership check against the roster (ADR 0017). */
@@ -628,29 +638,29 @@ export const unresolvedHosts = computed<UnresolvedHost[]>(
  *  set behind `unreadCount` (a global signal that must ignore the
  *  ?project=/?cwd= view filter). */
 function foldersFrom(ss: Session[]): Folder[] {
+  // One family index per session-list identity (WeakMap-cached), shared with
+  // every other projection of the same snapshot: root/membership lookups are
+  // O(1) here instead of a linear scan per session.
+  const index = familyIndex(sessions.value)
   const forceVisible = new Set<string>()
   const temporaryPlacements = new Map<string, TemporaryPresentationPlacement>()
-  const selectedRoot = familyRootId(selectedId.value, sessions.value)
+  const selectedRoot = familyRootId(selectedId.value, index)
   if (selectedRoot) forceVisible.add(selectedRoot)
   for (const candidate of ss) {
-    if (isFamilyChild(candidate, sessions.value)) {
-      const rootId = familyRootId(candidate.id, sessions.value)
-      if (!rootId) continue
-      forceVisible.add(rootId)
-      const root = sessions.value.find(session => session.id === rootId)
-      if (root?.project_slug || !candidate.project_slug) continue
+    if (index.childIds.has(candidate.id)) {
+      const root = index.rootById.get(candidate.id)
+      if (!root) continue
+      forceVisible.add(root.id)
+      if (root.project_slug || !candidate.project_slug) continue
       const sessionPeer = candidate.peer ?? ''
       const ownerPeer = sessionPeer && !localPeerNames.value.has(sessionPeer) ? sessionPeer : ''
-      const resolves = projects.value.some(project =>
-        project.slug === candidate.project_slug && (project.peer ?? '') === ownerPeer,
-      )
-      if (!resolves) continue
+      if (!projectKeys.value.has(`${ownerPeer}::${candidate.project_slug}`)) continue
       const placement = { ownerPeer, slug: candidate.project_slug }
-      const previous = temporaryPlacements.get(rootId)
+      const previous = temporaryPlacements.get(root.id)
       // A malformed/transitional family can briefly report children in more
       // than one folder. Pick a stable projection until the root stamp lands.
       if (!previous || `${placement.ownerPeer}::${placement.slug}` < `${previous.ownerPeer}::${previous.slug}`) {
-        temporaryPlacements.set(rootId, placement)
+        temporaryPlacements.set(root.id, placement)
       }
     }
   }
@@ -660,7 +670,7 @@ function foldersFrom(ss: Session[]): Folder[] {
     // navigable in the family drawer but have no independent project row.
     // Resolve edges against the complete snapshot, not this tab-filtered
     // subset. A filtered-out parent must not turn its child into a fake root.
-    ss.filter(s => !isFamilyChild(s, sessions.value)),
+    ss.filter(s => !index.childIds.has(s.id)),
     (name) => localPeerNames.value.has(name),
     _rawWorld.value.peerProjects,
     referencePresence(peers.value),
@@ -688,26 +698,30 @@ function foldersFrom(ss: Session[]): Folder[] {
 export const sidebarSessions = computed(() => {
   const sel = selectedId.value
   const onlyAlive = aliveOnly.value
+  const index = familyIndex(sessions.value)
   const base = filteredSessions.value.filter(s =>
     s.id === sel || (onlyAlive ? s.alive : s.alive || s.resumable),
   )
+  // Membership set mirrors `out` so dedup is O(1) per push instead of an
+  // `out.some` scan per candidate (the old quadratic hot spot).
+  const out = [...base]
+  const outIds = new Set<string>()
+  for (const s of base) outIds.add(s.id)
+  const push = (s: Session | undefined) => {
+    if (s && !outIds.has(s.id)) { outIds.add(s.id); out.push(s) }
+  }
   // Every relevant child keeps its presentation root locatable, even when the
   // root is dead or outside the tab filter. The child itself is later removed
   // from folders; this turns an active subtree into its single root-led row.
-  const out = [...base]
   for (const candidate of base) {
-    const rootId = familyRootId(candidate.id, sessions.value)
-    const root = sessions.value.find(s => s.id === rootId)
-    if (root && !out.some(s => s.id === root.id)) out.push(root)
+    push(index.rootById.get(candidate.id))
   }
   // The selected session may be absent from `filteredSessions` entirely.
   // Add both it and its family root for stable selected-row highlighting.
   if (sel) {
-    const selectedSession = sessions.value.find(x => x.id === sel)
-    if (selectedSession && !out.some(s => s.id === selectedSession.id)) out.push(selectedSession)
-    const rootId = familyRootId(sel, sessions.value)
-    const root = sessions.value.find(s => s.id === rootId)
-    if (root && !out.some(s => s.id === root.id)) out.push(root)
+    push(index.byId.get(sel))
+    const rootId = familyRootId(sel, index)
+    if (rootId) push(index.byId.get(rootId))
   }
   return out
 })
@@ -872,7 +886,7 @@ export const selectedId = computed(() =>
 export const selected = computed(() => {
   const id = selectedId.value
   if (!id) return null
-  const s = sessions.value.find(s => s.id === id) ?? null
+  const s = familyIndex(sessions.value).byId.get(id) ?? null
   // Expose on window for debugging.
   ;(window as any).__gmuxSession = s
   return s


### PR DESCRIPTION
Slice S0 of the frontend sync architecture assessment: a pure client-side algorithmic fix, no wire/protocol change, no new dependencies.

## What

`sidebarSessions`, `foldersFrom`, and `unreadCount` in `store.ts` ran `Array.find` / `Array.some` / `projects.some` inside per-session loops, making every derived recompute quadratic — and protocol 3 delivers every one-session mutation as a full snapshot, so a single unread flip cost the same as a cold load (~1.5 s main-thread stall at 10k retained sessions, ~16 s at 30k).

This replaces those scans with the already-existing WeakMap-cached `familyIndex` (`byId` / `rootById` / `childIds` Maps+Sets, one build per snapshot shared by all computeds) plus a new memoized `projectKeys` set, and a `Set`-based dedup in `sidebarSessions`. `selected` also uses the index. Output is bit-identical; ordering, folder semantics, family ownership/temporary placements, filtering, peer ownership, and unread/error attention are all preserved.

## Numbers (i7-9700K, Node 24, fixture `makeFixtureWorld(seed=1234, n)`, `--expose-gc`)

One-session mutation → all projections (`sidebarSessions`, `folders`, `unreadCount`, `sidebarActivity`, `familyDotById`, `familyActivityById`, `homePartition`):

| n | before | after | cold before | cold after | heap Δ |
|---|---|---|---|---|---|
| 1,000 | 22.2 ms | 10.6 ms | 30.6 ms | 19.8 ms | 0.4 MB (unchanged) |
| 10,000 | 1,513.7 ms | 103.9 ms | 1,104.7 ms | 113.2 ms | 1.5 MB (unchanged) |
| 30,000 | 16,026.0 ms | 378.8 ms | 16,502.7 ms | 360.6 ms | −2.4 MB (unchanged) |

Scaling is now ~linear (10k→30k ≈ 3.6×).

## Tests

- **`store-projections.test.ts`** — differential/property suite: the pre-optimization algorithms are kept verbatim as reference implementations and every randomized seeded world (multi-host, family edges incl. malformed, unstamped strays, transitional families, unresolvable stamps; crossed with tab filters, alive-only, root/child selection, 20 random single-session mutations, removals) must project identically through both. Mutation-tested: deleting one line of the new code fails 8 assertions.
- Perf regression test: best-of-3 one-mutation derived cost at 10k sessions < 800 ms (old code ≈ 1.5 s, new ≈ 100 ms — wide margins on both sides for CI stability) + a family-index sharing/memoization identity test.
- **`store.bench.ts`** — `vitest bench` at 1k/10k/30k (cold + one-session mutation) over the same fixture.
- Full web suite (786 tests), `tsc --noEmit`, biome lint, vite build, and Playwright `harness` / `sidebar-view-toggle` / `family-entry-interaction` / `promote-demote-menu` (35 passed) all green.

Ref: `.memory/report-frontend-sync-architecture.md` §7 slice S0 / addendum §B (assessment measured ~1,800× at 30k on the two projections alone; end-to-end here is ~42× because the remaining linear work — view resolution, day partitioning, folder sort — now dominates).