### PR TITLE
fix(peering): surface spoke session-stream omissions in the hub world projection

### DIFF
--- a/apps/gmux-web/src/sidebar.tsx
+++ b/apps/gmux-web/src/sidebar.tsx
@@ -24,7 +24,7 @@ import {
   unreadCount, localHostLabel, unresolvedHosts, duplicateConversationFiles,
   sidebarActivity, sidebarMode, setSidebarMode,
   activeSelectors, removeSelector, setHostFilter,
-  aliveOnly, setAliveOnly, tabHref, navigate, sessionStreamWarnings, sessionStreamOmittedTotal,
+  aliveOnly, setAliveOnly, tabHref, navigate, sessionStreamWarnings, sessionStreamOmittedTotal, peerStreamOmissions, peerOmittedTotal,
   type DotState,
 } from './store'
 import { HostSuffix } from './host-suffix'
@@ -913,9 +913,11 @@ export function Sidebar({
   const totalVisible = foldersVal.reduce((n, f) => n + f.sessions.length, 0)
   const connected = connState.value === 'connected'
   const streamWarnings = sessionStreamWarnings.value
-  const omittedSessionCount = sessionStreamOmittedTotal.value
+  const localOmittedCount = sessionStreamOmittedTotal.value
+  const peerOmissions = peerStreamOmissions.value
+  const omittedSessionCount = localOmittedCount + peerOmittedTotal.value
   const detailedOmittedCount = streamWarnings.reduce((sum, warning) => sum + warning.count, 0)
-  const suppressedOmittedCount = Math.max(0, omittedSessionCount - detailedOmittedCount)
+  const suppressedOmittedCount = Math.max(0, localOmittedCount - detailedOmittedCount)
   const hasProjects = projectsVal.length > 0
   const isOnlyHomeProject = projectsVal.length === 1
     && projectsVal[0].slug === 'home'
@@ -962,6 +964,7 @@ export function Sidebar({
               title={[
                 ...streamWarnings.map(w => `${w.id}: ${w.message || w.code}`),
                 ...(suppressedOmittedCount > 0 ? [`${suppressedOmittedCount} additional omitted sessions`] : []),
+                ...peerOmissions.map(o => `${o.peer}: ${o.count} ${o.count === 1 ? 'session' : 'sessions'} omitted upstream`),
               ].join('\n')}
             >
               ⚠ {omittedSessionCount} {omittedSessionCount === 1 ? 'session is' : 'sessions are'} omitted from the live list

--- a/apps/gmux-web/src/store.test.ts
+++ b/apps/gmux-web/src/store.test.ts
@@ -8,7 +8,7 @@ import {
   familyActivityById, familyDotById, familySelectedId, familySlotById, filteredSessions,
   folders, handleActivity, homePartition, initStore, isSessionActive, isSessionFading,
   isSessionUnavailable, killSession, localHostLabel, markSessionRead, navigate,
-  navigateToSession, ownDotState, parseConnectURL, peerAppearance, peerStatusByName, peers,
+  navigateToSession, ownDotState, parseConnectURL, peerAppearance, peerOmittedTotal, peerStatusByName, peerStreamOmissions, peers,
   projects, promoteSession, promotionAnnouncements, promotionPending,
   PROMOTION_PENDING_TTL_MS, reconcilePromotionPending, removeSession, reorderSessions,
   reparentSession, resumeSession, selectedFamilyChild, selectedId, sessions, sessionsLoaded,
@@ -2356,5 +2356,46 @@ describe('conversation_file (duplicate-open warning)', () => {
     const dups = duplicateConversationFiles.value
     expect(dups.has('/conv.jsonl')).toBe(true)
     expect(dups.has('/other.jsonl')).toBe(false)
+  })
+})
+
+describe('peerStreamOmissions', () => {
+  afterEach(() => { _setRawWorld({ peers: [] }) })
+
+  it('surfaces per-peer upstream omission counts and their total', () => {
+    _setRawWorld({ peers: [
+      { name: 'complete', url: '', status: 'connected', session_count: 3 },
+      { name: 'lossy', url: '', status: 'connected', session_count: 1, sessions_omitted: 6287, sessions_omitted_codes: { transaction_limit: 256, diagnostics_suppressed: 6031 } },
+      { name: 'big-row', url: '', status: 'connected', session_count: 2, sessions_omitted: 1, sessions_omitted_codes: { row_too_large: 1 } },
+    ] })
+    expect(peerStreamOmissions.value).toEqual([
+      { peer: 'lossy', count: 6287 },
+      { peer: 'big-row', count: 1 },
+    ])
+    expect(peerOmittedTotal.value).toBe(6288)
+  })
+
+  it('rejects absent, zero, negative, and non-integer counts', () => {
+    _setRawWorld({ peers: [
+      { name: 'a', url: '', status: 'connected', session_count: 0 },
+      { name: 'b', url: '', status: 'connected', session_count: 0, sessions_omitted: 0 },
+      { name: 'c', url: '', status: 'connected', session_count: 0, sessions_omitted: -4 },
+      { name: 'd', url: '', status: 'connected', session_count: 0, sessions_omitted: 1.5 },
+      { name: 'e', url: '', status: 'connected', session_count: 0, sessions_omitted: Number.MAX_SAFE_INTEGER + 2 },
+    ] })
+    expect(peerStreamOmissions.value).toEqual([])
+    expect(peerOmittedTotal.value).toBe(0)
+  })
+
+  it('clears when a later world snapshot drops the marker', () => {
+    _setRawWorld({ peers: [
+      { name: 'lossy', url: '', status: 'connected', session_count: 1, sessions_omitted: 2 },
+    ] })
+    expect(peerOmittedTotal.value).toBe(2)
+    _setRawWorld({ peers: [
+      { name: 'lossy', url: '', status: 'connected', session_count: 1 },
+    ] })
+    expect(peerOmittedTotal.value).toBe(0)
+    expect(peerStreamOmissions.value).toEqual([])
   })
 })

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -237,6 +237,22 @@ export const duplicateConversationFiles = computed<Set<string>>(() => {
   return dups
 })
 export const peers = computed<PeerInfo[]>(() => _rawWorld.value.peers)
+
+/**
+ * Per-peer session-stream omission markers from the world snapshot.
+ * A hub daemon stamps peers[].sessions_omitted when a spoke's last committed
+ * protocol-3 transaction quarantined rows at the sender, meaning that peer's
+ * sessions in the merged list are knowingly incomplete. Bounded server-side;
+ * defensively re-validated here because the values cross a trust boundary.
+ */
+export const peerStreamOmissions = computed<{ peer: string, count: number }[]>(() =>
+  peers.value
+    .map(p => ({ peer: p.name, count: p.sessions_omitted ?? 0 }))
+    .filter(o => Number.isSafeInteger(o.count) && o.count > 0))
+
+/** Total sessions omitted upstream across all peers. */
+export const peerOmittedTotal = computed<number>(() =>
+  peerStreamOmissions.value.reduce((n, o) => n + o.count, 0))
 export const health = computed<HealthData | null>(() => _rawWorld.value.health)
 export const launchers = computed<LauncherDef[]>(() => _rawWorld.value.launchers)
 export const defaultLauncher = computed<string>(() => _rawWorld.value.defaultLauncher)

--- a/apps/gmux-web/src/types.ts
+++ b/apps/gmux-web/src/types.ts
@@ -201,6 +201,15 @@ export interface PeerInfo {
   status: string // 'connected' | 'connecting' | 'disconnected' | 'offline' (connecting treated as disconnected in UI)
   session_count: number
   last_error?: string
+  /**
+   * Number of session rows this peer's last committed protocol-3 stream
+   * transaction quarantined at the sender (row_too_large, transaction_limit,
+   * …). Non-zero means the peer's sessions in the merged list are knowingly
+   * incomplete. Absent on older daemons and when the projection is complete.
+   */
+  sessions_omitted?: number
+  /** Bounded per-code breakdown of sessions_omitted. */
+  sessions_omitted_codes?: Record<string, number>
   version?: string
   default_launcher?: string
   launchers?: LauncherDef[]

--- a/docs/adr/0001-snapshot-push-protocol.md
+++ b/docs/adr/0001-snapshot-push-protocol.md
@@ -251,8 +251,13 @@ row that cannot fit is omitted, identified safely (long IDs become SHA-256
 identities), and does not prevent the rest of the set becoming ready. Browsers
 show a persistent omitted-session total and at most 256 safe details until a
 later complete bootstrap clears it. A non-droppable counted summary keeps the
-total exact above the detail cap; peers retain bounded diagnostics for the
-transaction and log them. Likely causes are unusually large `command`, `cwd`, `remotes`, `title`, `subtitle`,
+total exact above the detail cap. A hub receiving diagnostics on its peer
+stream accumulates an exact omitted total (with a bounded per-code breakdown,
+both clamped against hostile senders) and, when the transaction commits,
+publishes it as `peers[].sessions_omitted` / `sessions_omitted_codes` in its
+own `snapshot.world`, so downstream browsers can flag the merged projection as
+knowingly incomplete instead of the loss dying in a hub log line. A clean
+ready or a legacy single-frame snapshot clears the marker. Likely causes are unusually large `command`, `cwd`, `remotes`, `title`, `subtitle`,
 `socket_path`, or `conversation_file` fields. Session rows do not contain
 scrollback or transcripts. Sender and receiver share 100,000-row / 64 MiB
 transaction bounds, with sender envelope headroom. A rejected malformed

--- a/services/gmuxd/internal/peering/manager.go
+++ b/services/gmuxd/internal/peering/manager.go
@@ -326,6 +326,7 @@ func (m *Manager) PeerStatus() []PeerInfo {
 			Local:        mp.peer.Config.Local,
 			Source:       mp.peer.Config.Source,
 		}
+		info.SessionsOmitted, info.SessionsOmittedCodes = mp.peer.SessionOmissions()
 		if h, ok := mp.peer.CachedHealth(); ok {
 			info.Version = h.Version
 			info.DefaultLauncher = h.DefaultLauncher
@@ -429,6 +430,15 @@ func (s managerProjectionSink) RemovePeerSessions(peer string) { s.m.removePeerS
 func (s managerProjectionSink) PeerWorldChanged(name string) {
 	if s.m.sink != nil {
 		s.m.sink.PeerWorldChanged(name)
+	}
+	// Mirror onStatus: the production central path builds the manager with
+	// sink == nil and recomposes snapshot.world only via hooks.PeerWorldDirty,
+	// so a world-relevant peer change (e.g. an omission marker set/clear from
+	// setSessionOmissions) must fire the hook too or it never reaches
+	// browsers. Callers are change-gated, so this cannot re-open the
+	// reciprocal recompose loop.
+	if s.m.hooks.PeerWorldDirty != nil {
+		s.m.hooks.PeerWorldDirty()
 	}
 }
 func (s managerProjectionSink) AliveSessionCount(peer string) int {

--- a/services/gmuxd/internal/peering/peer.go
+++ b/services/gmuxd/internal/peering/peer.go
@@ -48,6 +48,13 @@ type Peer struct {
 	// (host-authoritative; see SpokeDiscovered). Refreshed alongside
 	// cachedProjects in fetchProjects.
 	cachedDiscovered []SpokeDiscovered
+	// sessionsOmitted / sessionsOmittedCodes carry the omission accounting of
+	// the peer's last committed protocol-3 session transaction. Non-zero means
+	// the projection currently held for this peer is knowingly incomplete
+	// (rows quarantined at the sender). Cleared by a clean ready or a legacy
+	// snapshot; retained across disconnects, matching the retained rows.
+	sessionsOmitted      int
+	sessionsOmittedCodes map[string]int
 
 	// onStatus is called when connection state changes.
 	onStatus func(name string, status Status)
@@ -136,6 +143,40 @@ func (p *Peer) LastError() string {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 	return p.lastError
+}
+
+// SessionOmissions returns the omission accounting of the last committed
+// session transaction: how many rows the spoke reported as quarantined
+// (omitted from the projection) and a bounded per-code breakdown. Zero means
+// the held projection is complete as far as the spoke reported.
+func (p *Peer) SessionOmissions() (int, map[string]int) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	if p.sessionsOmitted == 0 {
+		return 0, nil
+	}
+	codes := make(map[string]int, len(p.sessionsOmittedCodes))
+	for code, count := range p.sessionsOmittedCodes {
+		codes[code] = count
+	}
+	return p.sessionsOmitted, codes
+}
+
+// setSessionOmissions records a committed transaction's omission summary and,
+// when it changes, marks the world projection dirty so hub subscribers see
+// the incompleteness without waiting for an unrelated world event.
+func (p *Peer) setSessionOmissions(total int, codes map[string]int) {
+	if total <= 0 {
+		total, codes = 0, nil
+	}
+	p.mu.Lock()
+	changed := p.sessionsOmitted != total || !reflect.DeepEqual(p.sessionsOmittedCodes, codes)
+	p.sessionsOmitted = total
+	p.sessionsOmittedCodes = codes
+	p.mu.Unlock()
+	if changed && p.sink != nil {
+		p.sink.PeerWorldChanged(p.Config.Name)
+	}
 }
 
 func (p *Peer) setStatus(s Status) {
@@ -479,16 +520,30 @@ const (
 	sessionStreamLegacy
 	sessionStreamV3
 	maxPeerSessionDiagnostics = 256
+	// maxPeerOmissionCodes bounds the per-code omission breakdown a peer
+	// transaction can accumulate. Codes come from the remote sender, so both
+	// the number of distinct codes and each code string are clamped; overflow
+	// folds into the "other" bucket. The total and every per-code entry
+	// saturate together at MaxStagedRows (the largest omission a bounded
+	// transaction can express), so the breakdown always sums to the total.
+	maxPeerOmissionCodes   = 8
+	maxPeerOmissionCodeLen = 64
 )
 
 type peerSessionBootstrap struct {
-	mode        sessionStreamMode
-	epoch       uint64
-	lastEpoch   uint64
-	active      bool
-	rows        []SessionProjection
-	bytes       int
-	diagnostics []sessionstream.Error
+	mode      sessionStreamMode
+	epoch     uint64
+	lastEpoch uint64
+	active    bool
+	rows      []SessionProjection
+	bytes     int
+	// diagnostics keeps bounded per-row detail for logging; omittedTotal and
+	// omittedCodes carry the exact accounting (including counted summaries
+	// past the detail cap) that ready publishes into the peer's world
+	// projection.
+	diagnostics  []sessionstream.Error
+	omittedTotal int
+	omittedCodes map[string]int
 }
 
 func (s *peerSessionBootstrap) abandon() {
@@ -497,6 +552,38 @@ func (s *peerSessionBootstrap) abandon() {
 	s.rows = nil
 	s.bytes = 0
 	s.diagnostics = nil
+	s.omittedTotal = 0
+	s.omittedCodes = nil
+}
+
+func (s *peerSessionBootstrap) recordOmission(code string, count int) {
+	if count < 1 {
+		count = 1
+	}
+	// Saturate against the shared headroom so the total and the per-code
+	// breakdown always receive the same effective increment: the codes map
+	// sums exactly to omittedTotal, and neither can exceed MaxStagedRows no
+	// matter how many error events a hostile sender streams.
+	if headroom := sessionstream.MaxStagedRows - s.omittedTotal; count > headroom {
+		count = headroom
+	}
+	if count == 0 {
+		return
+	}
+	s.omittedTotal += count
+	if code == "" {
+		code = "row_omitted"
+	}
+	if len(code) > maxPeerOmissionCodeLen {
+		code = code[:maxPeerOmissionCodeLen]
+	}
+	if s.omittedCodes == nil {
+		s.omittedCodes = make(map[string]int)
+	}
+	if _, known := s.omittedCodes[code]; !known && len(s.omittedCodes) >= maxPeerOmissionCodes {
+		code = "other"
+	}
+	s.omittedCodes[code] += count
 }
 
 func (p *Peer) handleStreamEvent(ctx context.Context, eventType string, data []byte, staging *peerSessionBootstrap) {
@@ -546,8 +633,13 @@ func (p *Peer) handleStreamEvent(ctx context.Context, eventType string, data []b
 			return
 		}
 		rows := staging.rows
+		omittedTotal, omittedCodes := staging.omittedTotal, staging.omittedCodes
 		staging.abandon()
 		p.applySessionsSnapshot(rows)
+		// Publish this transaction's omission accounting after the surviving
+		// rows commit, so the hub's world projection can surface that the
+		// remote list is incomplete instead of losing it in a log line.
+		p.setSessionOmissions(omittedTotal, omittedCodes)
 		return
 	case sessionstream.EventError:
 		// Diagnostics quarantine individual rows; they do not invalidate the
@@ -565,8 +657,14 @@ func (p *Peer) handleStreamEvent(ctx context.Context, eventType string, data []b
 			message = message[:512] + "…"
 		}
 		diagnostic.ID, diagnostic.Message = id, message
-		if staging.active && diagnostic.Epoch == staging.epoch && len(staging.diagnostics) < maxPeerSessionDiagnostics {
-			staging.diagnostics = append(staging.diagnostics, diagnostic)
+		if staging.active && diagnostic.Epoch == staging.epoch {
+			// Detail is capped, but the counted total is exact: the sender's
+			// diagnostics_suppressed summary arrives after the detail cap is
+			// full and must still be accounted.
+			staging.recordOmission(diagnostic.Code, diagnostic.Count)
+			if len(staging.diagnostics) < maxPeerSessionDiagnostics {
+				staging.diagnostics = append(staging.diagnostics, diagnostic)
+			}
 		}
 		log.Printf("peering: %s: session %q omitted: %q (%s, count=%d)", p.Config.Name, id, message, diagnostic.Code, max(diagnostic.Count, 1))
 		return
@@ -583,6 +681,9 @@ func (p *Peer) handleStreamEvent(ctx context.Context, eventType string, data []b
 		staging.abandon()
 		staging.mode = sessionStreamLegacy
 		p.applySessionsSnapshot(payload.Sessions)
+		// A legacy single-frame snapshot has no omission channel: it is by
+		// definition complete, so clear any prior incompleteness marker.
+		p.setSessionOmissions(0, nil)
 		return
 	}
 	p.handleEvent(ctx, eventType, data)

--- a/services/gmuxd/internal/peering/peering.go
+++ b/services/gmuxd/internal/peering/peering.go
@@ -126,6 +126,15 @@ type PeerInfo struct {
 	Status          string        `json:"status"`
 	SessionCount    int           `json:"session_count"`
 	LastError       string        `json:"last_error,omitempty"`
+	// SessionsOmitted is the number of session rows the peer's last committed
+	// protocol-3 transaction quarantined at the sender (e.g. row_too_large,
+	// transaction_limit). Non-zero means this peer's sessions in the merged
+	// projection are knowingly incomplete. SessionsOmittedCodes is a bounded
+	// per-code breakdown; counts are exact even past the per-row diagnostic
+	// detail cap. Older daemons never set these fields; older browsers ignore
+	// them.
+	SessionsOmitted      int            `json:"sessions_omitted,omitempty"`
+	SessionsOmittedCodes map[string]int `json:"sessions_omitted_codes,omitempty"`
 	Version         string        `json:"version,omitempty"`
 	DefaultLauncher string        `json:"default_launcher,omitempty"`
 	Launchers       []LauncherDef `json:"launchers,omitempty"`

--- a/services/gmuxd/internal/peering/session_stream_test.go
+++ b/services/gmuxd/internal/peering/session_stream_test.go
@@ -3,6 +3,7 @@ package peering
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -219,5 +220,228 @@ func TestPeerAcceptsLegacySnapshotFromOldSpoke(t *testing.T) {
 	got := sink.replaced["old"]
 	if len(got) != 1 || got[0].ID != "legacy@old" {
 		t.Fatalf("visible=%+v", got)
+	}
+}
+
+// countWorldEvents returns how many PeerWorldChanged notifications the mock
+// sink captured for a peer name.
+func countWorldEvents(sink *mockSink, name string) int {
+	sink.mu.Lock()
+	defer sink.mu.Unlock()
+	n := 0
+	for _, ev := range sink.worldEvents {
+		if ev == name {
+			n++
+		}
+	}
+	return n
+}
+
+// TestPeerOmissionAccountingIsExactAndReachesWorldProjection reproduces the
+// aggregate-overflow shape end to end on the peer seam: 256 individual
+// diagnostics plus a counted diagnostics_suppressed summary (the sender's
+// 257th error event) must commit alongside the surviving rows and surface as
+// an exact per-peer omission count in both world projections, instead of
+// dying in a log line.
+func TestPeerOmissionAccountingIsExactAndReachesWorldProjection(t *testing.T) {
+	sink := newMockSink()
+	mgr := NewProjectionManager([]config.PeerConfig{{Name: "spoke", URL: "http://spoke"}}, "test-host", sink, EventHooks{})
+	p := mgr.GetPeer("spoke")
+	stage := peerSessionBootstrap{}
+	ctx := context.Background()
+
+	p.handleStreamEvent(ctx, sessionstream.EventBegin, streamData(t, sessionstream.Begin{Version: 3, Epoch: 1}), &stage)
+	p.handleStreamEvent(ctx, sessionstream.EventBatch, streamData(t, sessionstream.Batch[SessionProjection]{Epoch: 1, Sessions: []SessionProjection{{ID: "survivor"}}}), &stage)
+	for i := 0; i < 256; i++ {
+		p.handleStreamEvent(ctx, sessionstream.EventError, streamData(t, sessionstream.Error{Epoch: 1, Code: "transaction_limit", ID: "gone", Message: "omitted", Count: 1}), &stage)
+	}
+	p.handleStreamEvent(ctx, sessionstream.EventError, streamData(t, sessionstream.Error{Epoch: 1, Code: "diagnostics_suppressed", Message: "6031 additional omitted session rows were not individually reported", Count: 6031}), &stage)
+
+	// Nothing published before ready: no partial projection, no omission marker.
+	if total, _ := p.SessionOmissions(); total != 0 {
+		t.Fatalf("omissions visible before ready: %d", total)
+	}
+	p.handleStreamEvent(ctx, sessionstream.EventReady, streamData(t, sessionstream.Ready{Epoch: 1}), &stage)
+
+	if got := sink.replaced["spoke"]; len(got) != 1 || got[0].ID != "survivor@spoke" {
+		t.Fatalf("survivors=%+v", got)
+	}
+	total, codes := p.SessionOmissions()
+	if total != 256+6031 {
+		t.Fatalf("total=%d, want exact 6287", total)
+	}
+	if codes["transaction_limit"] != 256 || codes["diagnostics_suppressed"] != 6031 {
+		t.Fatalf("codes=%v", codes)
+	}
+	for _, info := range mgr.WorldProjection().Peers {
+		if info.Name == "spoke" && (info.SessionsOmitted != 6287 || info.SessionsOmittedCodes["transaction_limit"] != 256) {
+			t.Fatalf("world projection=%+v", info)
+		}
+	}
+	for _, info := range mgr.PeerStatus() {
+		if info.Name == "spoke" && info.SessionsOmitted != 6287 {
+			t.Fatalf("peer status=%+v", info)
+		}
+	}
+	if countWorldEvents(sink, "spoke") != 1 {
+		t.Fatalf("worldEvents=%v, want exactly one change notification", sink.worldEvents)
+	}
+
+	// A clean later transaction clears the incompleteness marker and notifies
+	// the world exactly once more; a second identical clean ready is silent.
+	commitClean := func(epoch uint64) {
+		p.handleStreamEvent(ctx, sessionstream.EventBegin, streamData(t, sessionstream.Begin{Version: 3, Epoch: epoch}), &stage)
+		p.handleStreamEvent(ctx, sessionstream.EventBatch, streamData(t, sessionstream.Batch[SessionProjection]{Epoch: epoch, Sessions: []SessionProjection{{ID: "survivor"}}}), &stage)
+		p.handleStreamEvent(ctx, sessionstream.EventReady, streamData(t, sessionstream.Ready{Epoch: epoch}), &stage)
+	}
+	commitClean(2)
+	if total, codes := p.SessionOmissions(); total != 0 || codes != nil {
+		t.Fatalf("omissions not cleared: %d %v", total, codes)
+	}
+	after := countWorldEvents(sink, "spoke")
+	commitClean(3)
+	if countWorldEvents(sink, "spoke") != after {
+		t.Fatalf("unchanged clean ready fired a world notification")
+	}
+}
+
+// TestPeerOmissionCountsAreBoundedAgainstHostileSenders clamps count and code
+// abuse from a remote sender: negative/zero counts count as one row, huge and
+// repeated counts saturate at the transaction row bound, code cardinality
+// folds into "other", oversized code strings are truncated, and the per-code
+// breakdown always sums exactly to the published total.
+func TestPeerOmissionCountsAreBoundedAgainstHostileSenders(t *testing.T) {
+	sink := newMockSink()
+	p := &Peer{Config: config.PeerConfig{Name: "spoke"}, sink: sink}
+	stage := peerSessionBootstrap{}
+	ctx := context.Background()
+	longCode := strings.Repeat("c", 500)
+	p.handleStreamEvent(ctx, sessionstream.EventBegin, streamData(t, sessionstream.Begin{Version: 3, Epoch: 1}), &stage)
+	p.handleStreamEvent(ctx, sessionstream.EventError, streamData(t, sessionstream.Error{Epoch: 1, Code: "neg", Count: -5}), &stage)
+	p.handleStreamEvent(ctx, sessionstream.EventError, streamData(t, sessionstream.Error{Epoch: 1, Code: longCode, Count: 1}), &stage)
+	for i := 0; i < 20; i++ {
+		p.handleStreamEvent(ctx, sessionstream.EventError, streamData(t, sessionstream.Error{Epoch: 1, Code: fmt.Sprintf("code-%d", i), Count: 1}), &stage)
+	}
+	// A hostile sender streaming huge counts indefinitely: every event past
+	// saturation must be a no-op for total AND codes alike.
+	for i := 0; i < 3; i++ {
+		p.handleStreamEvent(ctx, sessionstream.EventError, streamData(t, sessionstream.Error{Epoch: 1, Code: longCode, Count: 1 << 60}), &stage)
+	}
+	p.handleStreamEvent(ctx, sessionstream.EventReady, streamData(t, sessionstream.Ready{Epoch: 1}), &stage)
+
+	total, codes := p.SessionOmissions()
+	if total != sessionstream.MaxStagedRows {
+		t.Fatalf("total=%d, want saturation at MaxStagedRows", total)
+	}
+	if codes["neg"] != 1 {
+		t.Fatalf("negative count not clamped to 1: %v", codes)
+	}
+	if len(codes) > maxPeerOmissionCodes+1 { // bounded set + "other" bucket
+		t.Fatalf("code cardinality unbounded: %v", codes)
+	}
+	if codes["other"] == 0 {
+		t.Fatalf("overflow codes not folded into other: %v", codes)
+	}
+	sum := 0
+	for code, count := range codes {
+		if len(code) > maxPeerOmissionCodeLen {
+			t.Fatalf("code %q exceeds length bound", code)
+		}
+		if count < 0 || count > sessionstream.MaxStagedRows {
+			t.Fatalf("code %q count %d outside [0, MaxStagedRows]", code, count)
+		}
+		sum += count
+	}
+	if sum != total {
+		t.Fatalf("per-code sum %d != total %d (breakdown must be internally consistent)", sum, total)
+	}
+	// The oversized code string was truncated into a bounded named entry, and
+	// the repeated huge-count events for the same code received exactly the
+	// remaining headroom once — not 3× an unclamped accumulation.
+	if got := codes[longCode[:maxPeerOmissionCodeLen]]; got != sessionstream.MaxStagedRows-21 {
+		t.Fatalf("saturating truncated-code count=%d, want %d", got, sessionstream.MaxStagedRows-21)
+	}
+	// Codes past the cardinality cap folded into "other" (code-6..19).
+	if codes["other"] != 14 {
+		t.Fatalf("other bucket=%d, want 14: %v", codes["other"], codes)
+	}
+}
+
+// TestPeerOmissionChangeFiresPeerWorldDirtyHook wires the manager exactly like
+// the production central path (sink == nil, EventHooks only) and commits a
+// lossy transaction whose survivor set is identical to the previous epoch, so
+// the ReplacePeerSessions no-op suppression cannot recompose the world. Both
+// the SET and the CLEAR of the omission marker must fire PeerWorldDirty, or
+// browsers on a quiet hub never see the marker change.
+func TestPeerOmissionChangeFiresPeerWorldDirtyHook(t *testing.T) {
+	worldDirty := 0
+	mgr := NewProjectionManager([]config.PeerConfig{{Name: "spoke", URL: "http://spoke"}}, "test-host",
+		nil, EventHooks{PeerWorldDirty: func() { worldDirty++ }})
+	p := mgr.GetPeer("spoke")
+	stage := peerSessionBootstrap{}
+	ctx := context.Background()
+	commit := func(epoch uint64, lossy bool) {
+		p.handleStreamEvent(ctx, sessionstream.EventBegin, streamData(t, sessionstream.Begin{Version: 3, Epoch: epoch}), &stage)
+		p.handleStreamEvent(ctx, sessionstream.EventBatch, streamData(t, sessionstream.Batch[SessionProjection]{Epoch: epoch, Sessions: []SessionProjection{{ID: "survivor"}}}), &stage)
+		if lossy {
+			p.handleStreamEvent(ctx, sessionstream.EventError, streamData(t, sessionstream.Error{Epoch: epoch, Code: "row_too_large", ID: "big", Count: 1}), &stage)
+		}
+		p.handleStreamEvent(ctx, sessionstream.EventReady, streamData(t, sessionstream.Ready{Epoch: epoch}), &stage)
+	}
+
+	commit(1, false) // baseline projection, complete
+	base := worldDirty
+	commit(2, true) // identical survivors, marker SET
+	if worldDirty != base+1 {
+		t.Fatalf("omission marker SET fired PeerWorldDirty %d times, want 1 (production hooks path)", worldDirty-base)
+	}
+	for _, info := range mgr.WorldProjection().Peers {
+		if info.Name == "spoke" && info.SessionsOmitted != 1 {
+			t.Fatalf("marker not visible in world projection: %+v", info)
+		}
+	}
+	commit(3, true) // unchanged marker: silent, no redundant recompose
+	if worldDirty != base+1 {
+		t.Fatalf("unchanged marker fired PeerWorldDirty (%d extra)", worldDirty-base-1)
+	}
+	commit(4, false) // identical survivors, marker CLEAR
+	if worldDirty != base+2 {
+		t.Fatalf("omission marker CLEAR fired PeerWorldDirty %d times, want 1 (production hooks path)", worldDirty-base-1)
+	}
+	if total, _ := p.SessionOmissions(); total != 0 {
+		t.Fatalf("marker not cleared: %d", total)
+	}
+}
+
+// TestPeerOmissionMarkerLifecycle: an abandoned transaction leaks nothing, a
+// legacy snapshot (complete by definition) clears a stale marker.
+func TestPeerOmissionMarkerLifecycle(t *testing.T) {
+	sink := newMockSink()
+	p := &Peer{Config: config.PeerConfig{Name: "spoke"}, sink: sink}
+	stage := peerSessionBootstrap{}
+	ctx := context.Background()
+
+	// Diagnostics inside a transaction that never reaches ready must not
+	// surface: the committed projection they described never became visible.
+	p.handleStreamEvent(ctx, sessionstream.EventBegin, streamData(t, sessionstream.Begin{Version: 3, Epoch: 1}), &stage)
+	p.handleStreamEvent(ctx, sessionstream.EventError, streamData(t, sessionstream.Error{Epoch: 1, Code: "row_too_large", ID: "x", Count: 1}), &stage)
+	stage = peerSessionBootstrap{lastEpoch: stage.lastEpoch} // disconnect drops staging
+	if total, _ := p.SessionOmissions(); total != 0 {
+		t.Fatalf("abandoned transaction leaked omissions: %d", total)
+	}
+
+	// A committed marker survives until replaced…
+	p.handleStreamEvent(ctx, sessionstream.EventBegin, streamData(t, sessionstream.Begin{Version: 3, Epoch: 2}), &stage)
+	p.handleStreamEvent(ctx, sessionstream.EventError, streamData(t, sessionstream.Error{Epoch: 2, Code: "row_too_large", ID: "x", Count: 1}), &stage)
+	p.handleStreamEvent(ctx, sessionstream.EventReady, streamData(t, sessionstream.Ready{Epoch: 2}), &stage)
+	if total, _ := p.SessionOmissions(); total != 1 {
+		t.Fatalf("marker not committed: %d", total)
+	}
+
+	// …and a legacy single-frame snapshot on a fresh connection clears it.
+	stage = peerSessionBootstrap{}
+	p.handleStreamEvent(ctx, "snapshot.sessions", streamData(t, sseSnapshotSessions{Sessions: []SessionProjection{{ID: "legacy"}}}), &stage)
+	if total, codes := p.SessionOmissions(); total != 0 || codes != nil {
+		t.Fatalf("legacy snapshot did not clear marker: %d %v", total, codes)
 	}
 }

--- a/services/gmuxd/internal/peering/world.go
+++ b/services/gmuxd/internal/peering/world.go
@@ -19,6 +19,7 @@ func (m *Manager) WorldProjection() WorldProjection {
 			}
 		}
 		i := PeerInfo{Name: name, URL: mp.peer.Config.URL, Status: mp.peer.Status().String(), SessionCount: alive, LastError: mp.peer.LastError(), Local: mp.peer.Config.Local, Source: mp.peer.Config.Source}
+		i.SessionsOmitted, i.SessionsOmittedCodes = mp.peer.SessionOmissions()
 		if h, ok := mp.peer.CachedHealth(); ok {
 			i.Version = h.Version
 			i.DefaultLauncher = h.DefaultLauncher


### PR DESCRIPTION
## Problem

Protocol 3 is fail-open by design: rows a sender cannot ship (`row_too_large` > 48 KiB, `transaction_limit` past the 100k-row / 64 MiB bounds, encode failures) are quarantined with bounded diagnostics and `ready` still commits the survivors. Browsers surface this via the persistent omitted-sessions banner — but on the **peer hop** the diagnostics only reached `log.Printf` and were discarded at `ready`. A hub therefore presented a merged projection that silently missed remote rows. Worse, the peer-side 256-entry diagnostic detail cap could swallow the sender's `diagnostics_suppressed` counted summary (it arrives as the 257th error event), so even the total was lost.

Verified against the frontend-sync assessment's reproductions: aggregate overflow (63,713 committed / 6,287 omitted with exact 256+6031 accounting), the >48 KiB single-row exile (reachable today via unbounded `command`/`title`/`remotes`), and the peer-hop loss.

## Fix (narrow, protocol-3 compatible)

- Peer staging now accumulates an **exact omitted total** and a bounded per-code breakdown separately from the capped detail list, so counted summaries past the cap are never lost. Counts clamp to `MaxStagedRows`; code cardinality (8 + `other`) and length (64) clamp against hostile senders.
- On `ready`, after the surviving rows commit atomically, the summary is published on the `Peer` and — when it changes — marks the world projection dirty. It surfaces as additive optional fields `peers[].sessions_omitted` / `sessions_omitted_codes` in `snapshot.world` and `/v1/health` (`WorldProjection` + `PeerStatus`).
- A clean `ready` or a legacy single-frame snapshot clears the marker; an abandoned transaction leaks nothing; the marker persists across disconnects, matching the retained rows.
- Browser folds peer omissions into the existing sidebar omitted-sessions banner with per-host detail lines (`host: N sessions omitted upstream`), defensively re-validating counts.

## Decisions

- **Quarantine, not truncation**: oversized rows stay omitted-but-counted. Truncating summary fields at projection time would silently alter authoritative session data consumers rely on (resume commands, cwd); schema-bounded summary rows are protocol 4's job (see sync report addendum §C.1). Diagnostics continue to carry only bounded identities (SHA-256 for long IDs), never row contents.
- **Compatibility**: purely additive `omitempty` JSON fields; old peers never see them (peers don't receive `snapshot.world`), old browsers ignore them; sessionstream wire format and 48 KiB envelope untouched.

## Tests

- Go (`internal/peering`, race-clean): exact end-to-end accounting through `WorldProjection`/`PeerStatus` incl. suppressed summary; hostile-sender clamps; marker lifecycle (abandon / persist / legacy clear); exactly-once world notification.
- Web (vitest): `peerStreamOmissions`/`peerOmittedTotal` projection, rejection of absent/zero/negative/non-integer/unsafe counts, clearing on later snapshots.
- Mutation checks: dropping counted totals, suppressing the world notification, skipping the legacy clear, and weakening the browser-side validation each fail a test.

`GOTOOLCHAIN=go1.26.1 go test -race ./...` (gmuxd), full vitest suite (778), `tsc --noEmit`, biome — all green.