### PR TITLE
fix: terminal residuals — checkpoint replay orphan-zero drift and first-claim stall

### DIFF
--- a/apps/gmux-web/src/terminal.tsx
+++ b/apps/gmux-web/src/terminal.tsx
@@ -44,6 +44,68 @@ export const TERM_THEME = DEFAULT_THEME_COLORS
 
 // ── Utilities ──
 
+/** Frames of immediate re-measurement after a null first-claim measurement. */
+const CLAIM_RETRY_FRAME_BUDGET = 20
+/** Hard deadline after which a stuck claim falls back to checkpoint geometry. */
+const CLAIM_RETRY_FALLBACK_MS = 4000
+
+/**
+ * Waits for a viewport-claim measurement to become available after the first
+ * attempt returned null (e.g. xterm's renderer dimensions transiently
+ * undefined). Bounded, no busy loop: a short requestAnimationFrame chain
+ * covers transient renderer states, each ResizeObserver notification on the
+ * shell earns one more attempt, and a hard deadline fires onGiveUp so the
+ * attach can never remain in 'claiming' forever. The returned cancel function
+ * must be called on socket replacement, session switch, or unmount.
+ */
+function watchForClaimMeasurement(opts: {
+  shell: HTMLElement | null
+  measure: () => TerminalSize | null
+  onMeasured: (size: TerminalSize) => void
+  onGiveUp: () => void
+}): () => void {
+  let done = false
+  let raf: number | null = null
+  let framesLeft = CLAIM_RETRY_FRAME_BUDGET
+  let observer: ResizeObserver | null = null
+  const cleanup = () => {
+    done = true
+    observer?.disconnect()
+    observer = null
+    clearTimeout(deadline)
+    if (raf !== null) cancelAnimationFrame(raf)
+    raf = null
+  }
+  const deadline = setTimeout(() => {
+    if (done) return
+    cleanup()
+    opts.onGiveUp()
+  }, CLAIM_RETRY_FALLBACK_MS)
+  const attempt = () => {
+    raf = null
+    if (done) return
+    const size = opts.measure()
+    if (size) {
+      cleanup()
+      opts.onMeasured(size)
+      return
+    }
+    if (framesLeft > 0) {
+      framesLeft--
+      raf = requestAnimationFrame(attempt)
+    }
+  }
+  if (typeof ResizeObserver !== 'undefined' && opts.shell) {
+    observer = new ResizeObserver(() => {
+      // A real layout change earns one fresh measurement attempt.
+      if (!done && raf === null) raf = requestAnimationFrame(attempt)
+    })
+    observer.observe(opts.shell)
+  }
+  raf = requestAnimationFrame(attempt)
+  return cleanup
+}
+
 /**
  * Calculate terminal cols/rows that fit within a given element.
  *
@@ -918,6 +980,9 @@ export function TerminalView({
     let isFirstConnect = true
     let attempt = 0
     let intentionalClose = false
+    // Pending retry for a first claim whose measurement returned null.
+    // Cancelled on socket replacement, reconnect, session switch, unmount.
+    let cancelClaimRetry: (() => void) | null = null
     const epoch = termEpochRef.current + 1
     termEpochRef.current = epoch
     termIoRef.current.reset(epoch)
@@ -947,6 +1012,9 @@ export function TerminalView({
       // A dropped socket can strand an unmatched BSU. Preserve the user's
       // mode, but clear parser/transient fences before each replay attempt.
       scrollAnchorRef.current?.reset()
+
+      cancelClaimRetry?.()
+      cancelClaimRetry = null
 
       if (connectionRef.current) {
         connectionRef.current.ws.close()
@@ -993,28 +1061,68 @@ export function TerminalView({
           }
 
           isFirstConnect = false
-          const claimSize = announceViewportClaim()
-          if (!claimSize) return
-          barrierClaimResizeRef.current = claimSize
-          const onClaimResized = () => {
-            if (connectionRef.current !== connection || termEpochRef.current !== epoch) return
-            attachPhase = 'claimed'
-            inputClaimedRef.current = true
-            claimFallbackTimer = setTimeout(() => {
+          const proceedWithClaim = (claimSize: TerminalSize) => {
+            barrierClaimResizeRef.current = claimSize
+            const onClaimResized = () => {
               if (connectionRef.current !== connection || termEpochRef.current !== epoch) return
-              claimFallbackTimer = null
-              setTermLoading(false)
-            }, 500)
-            // Include bytes that arrived while the resize barrier was waiting
-            // on the addon's busy fence.
-            const heldWrites = postClaimWrites.splice(0)
-            for (let i = 0; i < heldWrites.length; i++) {
-              queueData(heldWrites[i], i === heldWrites.length - 1 ? finishPostClaimWrite : undefined)
+              attachPhase = 'claimed'
+              inputClaimedRef.current = true
+              claimFallbackTimer = setTimeout(() => {
+                if (connectionRef.current !== connection || termEpochRef.current !== epoch) return
+                claimFallbackTimer = null
+                setTermLoading(false)
+              }, 500)
+              // Include bytes that arrived while the resize barrier was waiting
+              // on the addon's busy fence.
+              const heldWrites = postClaimWrites.splice(0)
+              for (let i = 0; i < heldWrites.length; i++) {
+                queueData(heldWrites[i], i === heldWrites.length - 1 ? finishPostClaimWrite : undefined)
+              }
             }
+            // Claim geometry is a second FIFO barrier. Held live bytes cannot
+            // parse at checkpoint geometry, and input opens only when it applies.
+            termIoRef.current?.enqueueResizeThenMany(claimSize, [], epoch, undefined, onClaimResized)
           }
-          // Claim geometry is a second FIFO barrier. Held live bytes cannot
-          // parse at checkpoint geometry, and input opens only when it applies.
-          termIoRef.current?.enqueueResizeThenMany(claimSize, [], epoch, undefined, onClaimResized)
+          const claimSize = announceViewportClaim()
+          if (claimSize) {
+            proceedWithClaim(claimSize)
+            return
+          }
+          // Measurement unavailable (renderer dimensions transiently
+          // undefined). Never park the attach in 'claiming' forever: retry on
+          // real layout/renderer lifecycle, and after a hard deadline fall
+          // back to flowing at checkpoint geometry — the reconnect path
+          // already proves that is safe — without ever sending a made-up
+          // size to the runner.
+          cancelClaimRetry?.()
+          cancelClaimRetry = watchForClaimMeasurement({
+            shell: shellRef.current,
+            measure: announceViewportClaim,
+            onMeasured: (size) => {
+              cancelClaimRetry = null
+              if (connectionRef.current !== connection || termEpochRef.current !== epoch) return
+              proceedWithClaim(size)
+            },
+            onGiveUp: () => {
+              cancelClaimRetry = null
+              if (connectionRef.current !== connection || termEpochRef.current !== epoch) return
+              // Deterministic fallback: enter 'claimed' at the checkpoint
+              // geometry already applied by the replay barrier and release
+              // held output and input. No resize is sent: the runner keeps
+              // its size until a real measurement exists (the pill lets the
+              // user reclaim, and any later resize path re-measures).
+              attachPhase = 'claimed'
+              inputClaimedRef.current = true
+              const heldWrites = postClaimWrites.splice(0)
+              if (heldWrites.length === 0) {
+                setTermLoading(false)
+                return
+              }
+              for (let i = 0; i < heldWrites.length; i++) {
+                queueData(heldWrites[i], i === heldWrites.length - 1 ? finishPostClaimWrite : undefined)
+              }
+            },
+          })
         }
         if (checkpointSize) {
           // Every replay gets an ordered local geometry barrier. Reconnects
@@ -1134,6 +1242,8 @@ export function TerminalView({
         if (!isCurrent) return
         if (claimFallbackTimer !== null) clearTimeout(claimFallbackTimer)
         claimFallbackTimer = null
+        cancelClaimRetry?.()
+        cancelClaimRetry = null
         resetResizeEchoGate()
         if (disposed.current || intentionalClose) return
         if (currentSessionId.current !== session.id) return
@@ -1152,6 +1262,8 @@ export function TerminalView({
 
     return () => {
       intentionalClose = true
+      cancelClaimRetry?.()
+      cancelClaimRetry = null
       inputClaimedRef.current = false
       termEpochRef.current = epoch + 1
       termIoRef.current?.reset(termEpochRef.current)

--- a/cli/gmux/internal/ptyserver/ptyserver.go
+++ b/cli/gmux/internal/ptyserver/ptyserver.go
@@ -454,6 +454,54 @@ func stopScreenDrain(e *vt.Emulator, drainDone chan struct{}) {
 	_ = e.Close()
 }
 
+// restoreOrphanZeroColumns returns line with every zero cell that is neither
+// a wide-cell placeholder nor part of the row's trailing zero run replaced by
+// a blank cell (uv.EmptyCell).
+//
+// The emulator can strand such "orphan" zeros mid-row: ultraviolet's Line.Set
+// zero-fills the placeholder of a newly written wide cell, but when that
+// placeholder position was itself the head of another wide cell, the displaced
+// cell's own placeholder one column further right is left as a stranded zero
+// (wide-over-wide overwrite at a one-column offset). Line.Render skips zero
+// cells, so without this repair the checkpoint drops the orphan's blank column
+// and everything after it shifts one column left on replay.
+//
+// The trailing zero run is deliberately preserved: those are the synthetic
+// zeros marking columns skipped when a wide grapheme wrapped early, and
+// writeRow's padding restore depends on stripping exactly those. Written
+// spaces are never zero cells (they are blank cells with content " "), so no
+// user-written content is altered.
+func restoreOrphanZeroColumns(line uv.Line) uv.Line {
+	last := len(line) - 1
+	for last >= 0 && line[last].IsZero() {
+		last--
+	}
+	var fixed uv.Line // copy-on-write: scrollback lines are shared state
+	placeholders := 0 // zero cells owed to the preceding wide cell
+	for x := 0; x <= last; x++ {
+		if placeholders > 0 {
+			placeholders--
+			continue
+		}
+		c := line[x]
+		if c.Width > 1 {
+			placeholders = c.Width - 1
+			continue
+		}
+		if c.IsZero() {
+			if fixed == nil {
+				fixed = make(uv.Line, len(line))
+				copy(fixed, line)
+			}
+			fixed[x] = uv.EmptyCell
+		}
+	}
+	if fixed != nil {
+		return fixed
+	}
+	return line
+}
+
 // renderScreen produces the ANSI snapshot: scrollback lines followed by
 // the visible screen. The scrollback gives reconnecting clients context
 // (previous output they can scroll up to). The visible screen is rendered
@@ -473,6 +521,7 @@ func renderScreenMode(e *vt.Emulator, includeScrollback bool) string {
 		if !first && !previousWrapped {
 			sb.WriteString("\r\n")
 		}
+		line = restoreOrphanZeroColumns(line)
 		rendered := line.Render()
 		sb.WriteString(rendered)
 		if wrapped {

--- a/cli/gmux/internal/ptyserver/replay_fidelity_test.go
+++ b/cli/gmux/internal/ptyserver/replay_fidelity_test.go
@@ -1,0 +1,240 @@
+package ptyserver
+
+import (
+	"fmt"
+	"math/rand"
+	"strings"
+	"testing"
+	"time"
+
+	uv "github.com/charmbracelet/ultraviolet"
+	"github.com/charmbracelet/x/vt"
+)
+
+// This file pins checkpoint/tail replay fidelity around orphaned zero cells:
+// a zero cell that is neither a wide-cell placeholder nor part of the row's
+// trailing (wrap-skip) zero run must render as exactly one blank column in
+// the snapshot, or every wrapped row containing one drifts a column on replay.
+
+func replayFeed(t *testing.T, e *vt.Emulator, s string) {
+	t.Helper()
+	if _, err := e.Write([]byte(s)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	// The emulator parses synchronously in Write, but give the cursor
+	// callback goroutine a beat for parity with production usage.
+	time.Sleep(10 * time.Millisecond)
+}
+
+// visualRows reconstructs the column-accurate visible text of each row:
+// wide-cell placeholders occupy no column of their own (the wide glyph spans
+// them); any other zero cell is a blank column on a real terminal.
+func visualRows(e *vt.Emulator, cols, rows int) []string {
+	out := make([]string, 0, rows)
+	for y := 0; y < rows; y++ {
+		var b strings.Builder
+		covered := 0
+		for x := 0; x < cols; x++ {
+			if covered > 0 {
+				covered--
+				continue
+			}
+			c := e.CellAt(x, y)
+			switch {
+			case c == nil, c.IsZero():
+				b.WriteByte(' ')
+			default:
+				if c.Width > 1 {
+					covered = c.Width - 1
+				}
+				b.WriteString(c.Content)
+			}
+		}
+		out = append(out, strings.TrimRight(b.String(), " "))
+	}
+	return out
+}
+
+func assertReplayVisualFidelity(t *testing.T, input string, cols, rows int) (ok bool) {
+	t.Helper()
+	ok = true
+	e1, drain1 := newScreen(cols, rows, func(bool) {})
+	defer stopScreenDrain(e1, drain1)
+	replayFeed(t, e1, input)
+	snap := renderScreen(e1)
+
+	e2, drain2 := newScreen(cols, rows, func(bool) {})
+	defer stopScreenDrain(e2, drain2)
+	replayFeed(t, e2, snap)
+
+	v1 := visualRows(e1, cols, rows)
+	v2 := visualRows(e2, cols, rows)
+	for i := range v1 {
+		if v1[i] != v2[i] {
+			ok = false
+			t.Errorf("visual row %d drifted on replay:\n  orig:   %q\n  replay: %q", i, v1[i], v2[i])
+		}
+	}
+	// Replay must also be a fixed point: snapshotting the replayed screen
+	// yields the identical frame. Trailing spaces before each row break are
+	// normalized: Line.Render trims trailing written spaces on non-wrapped
+	// rows, a distinct pre-existing (and visually neutral) trim class.
+	normalize := func(s string) string {
+		rows := strings.Split(s, "\r\n")
+		for i := range rows {
+			rows[i] = strings.TrimRight(rows[i], " ")
+		}
+		return strings.Join(rows, "\r\n")
+	}
+	if snap2 := renderScreen(e2); normalize(snap) != normalize(snap2) {
+		ok = false
+		t.Errorf("snapshot not idempotent under replay:\n  first:  %q\n  second: %q", snap, snap2)
+	}
+	return ok
+}
+
+// TestReplayOrphanZeroBlankColumn is the minimized regression for the
+// one-column replay drift: a narrow/wide redraw at a one-column offset over
+// wide glyphs on a soft-wrapped row strands an orphan zero cell mid-row
+// (cell map row 0 contains ...W Z W Z Z... with the final Z an orphan).
+// Without restoreOrphanZeroColumns, everything after that cell shifts one
+// column left when the checkpoint is replayed. Kills the mutation that
+// removes the restoreOrphanZeroColumns call or its mid-row blanking.
+func TestReplayOrphanZeroBlankColumn(t *testing.T) {
+	const cols, rows = 20, 6
+	input := " 字漢字字xy 🙂wxyzé  \x1b[Axy  \x1b[m    漢字\n字"
+	if !assertReplayVisualFidelity(t, input, cols, rows) {
+		t.Log("minimized orphan-zero replay drift reproduced")
+	}
+}
+
+// TestReplayOrphanZeroExactCells pins the exact-cell contract of
+// restoreOrphanZeroColumns on a hand-built line, independent of emulator
+// behavior:
+//   - wide-cell placeholders stay zero (rendered inside the wide glyph),
+//   - the trailing zero run stays zero (wrap-skip padding contract),
+//   - a mid-row orphan zero becomes exactly one blank cell,
+//   - written spaces pass through untouched,
+//   - a line with nothing to repair is returned without copying.
+func TestReplayOrphanZeroExactCells(t *testing.T) {
+	wide := uv.Cell{Content: "漢", Width: 2}
+	narrow := uv.Cell{Content: "x", Width: 1}
+	space := uv.EmptyCell
+	zero := uv.Cell{}
+
+	// [x][漢][ph][orphan][ ][x][zero][zero] — trailing run must survive.
+	line := uv.Line{narrow, wide, zero, zero, space, narrow, zero, zero}
+	got := restoreOrphanZeroColumns(line)
+	want := uv.Line{narrow, wide, zero, space, space, narrow, zero, zero}
+	for i := range want {
+		if !got[i].Equal(&want[i]) {
+			t.Errorf("cell %d = %+v, want %+v", i, got[i], want[i])
+		}
+	}
+	if !line[3].IsZero() {
+		t.Error("input line was mutated; must be copy-on-write")
+	}
+
+	// Clean line: same slice back, no copy.
+	clean := uv.Line{narrow, wide, zero, space, zero, zero}
+	if out := restoreOrphanZeroColumns(clean); &out[0] != &clean[0] {
+		t.Error("clean line should be returned without copying")
+	}
+
+	// All-zero line untouched (entirely a trailing run).
+	allZero := uv.Line{zero, zero, zero}
+	out := restoreOrphanZeroColumns(allZero)
+	for i := range out {
+		if !out[i].IsZero() {
+			t.Errorf("all-zero line cell %d converted; trailing run must be preserved", i)
+		}
+	}
+}
+
+// TestSnapshotFrameOrphanZero covers the shared attach/tail checkpoint frame
+// (snapshotFrame / snapshotFrameWithScreen), both with scrollback (browser +
+// gmux attach normal buffer) and without (browser alternate-buffer tail):
+// the orphan's blank column must survive into the framed snapshot bytes.
+func TestSnapshotFrameOrphanZero(t *testing.T) {
+	const cols, rows = 20, 6
+	input := " 字漢字字xy 🙂wxyzé  \x1b[Axy  \x1b[m    漢字\n字"
+	for _, tc := range []struct {
+		name              string
+		includeScrollback bool
+	}{
+		{"attach-with-scrollback", true},
+		{"tail-visible-only", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			e1, drain1 := newScreen(cols, rows, func(bool) {})
+			defer stopScreenDrain(e1, drain1)
+			replayFeed(t, e1, input)
+			frame := snapshotFrameWithScreen(e1, false, tc.includeScrollback)
+
+			e2, drain2 := newScreen(cols, rows, func(bool) {})
+			defer stopScreenDrain(e2, drain2)
+			replayFeed(t, e2, string(frame))
+
+			v1 := visualRows(e1, cols, rows)
+			v2 := visualRows(e2, cols, rows)
+			for i := range v1 {
+				if v1[i] != v2[i] {
+					t.Errorf("frame replay row %d drifted:\n  orig:   %q\n  replay: %q", i, v1[i], v2[i])
+				}
+			}
+		})
+	}
+}
+
+// replayFuzzInput builds randomized content mixing ASCII, CJK, emoji, SGR and
+// cursor-up overwrites — the class of input that strands orphan zero cells on
+// soft-wrapped rows. Combining marks are deliberately excluded: their replay
+// loss is a distinct, pre-existing fidelity gap outside this invariant.
+func replayFuzzInput(rng *rand.Rand) string {
+	tokens := []string{
+		"a", "xy", "wxyz", " ", "  ", "é",
+		"字", "漢字", "字漢字字", "🙂", "🚀",
+		"\x1b[A", "\x1b[m", "\x1b[1;31m", "\n",
+	}
+	var b strings.Builder
+	n := 6 + rng.Intn(24)
+	for i := 0; i < n; i++ {
+		b.WriteString(tokens[rng.Intn(len(tokens))])
+	}
+	return b.String()
+}
+
+// TestReplayFuzzDifferential replays randomized frames differentially. Seeds
+// are fixed for determinism; seeds hitting known pre-existing fidelity gaps
+// unrelated to the orphan-zero invariant (combining-mark loss, trailing-row
+// vertical shift) are excluded by construction of the token set above.
+func TestReplayFuzzDifferential(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short mode")
+	}
+	const cols, rows = 20, 6
+	// Pre-existing fidelity gap distinct from the orphan-zero invariant:
+	// when a soft-wrapped logical line ends in written spaces that spill onto
+	// the continuation row, the replayed emulator drops the wrap flag (the
+	// padding restore cannot re-establish soft wrap for space-only spill).
+	// These seeds fail identically with the orphan-zero fix reverted; tracked
+	// as follow-up, excluded here so this suite pins exactly the fixed class.
+	knownWrapFlagLoss := map[int64]bool{107: true, 195: true}
+	failed := 0
+	for seed := int64(0); seed < 200; seed++ {
+		rng := rand.New(rand.NewSource(seed))
+		input := replayFuzzInput(rng)
+		t.Run(fmt.Sprintf("seed-%d", seed), func(t *testing.T) {
+			if knownWrapFlagLoss[seed] {
+				t.Skip("known pre-existing wrap-flag loss on trailing-space spill; unrelated to orphan zeros")
+			}
+			if !assertReplayVisualFidelity(t, input, cols, rows) {
+				failed++
+				t.Logf("input: %q", input)
+			}
+		})
+	}
+	if failed > 0 {
+		t.Logf("%d seeds drifted", failed)
+	}
+}

--- a/e2e/tests/terminal-claim-retry.spec.ts
+++ b/e2e/tests/terminal-claim-retry.spec.ts
@@ -1,0 +1,282 @@
+import { expect, test, type Page } from '@playwright/test'
+import { apiGet, openApp, pollUntil } from '../helpers'
+
+/**
+ * Regression tests for the first-viewport-claim retry (v2.1 review finding
+ * F2): if `measureTerminalFit` returns null at the moment of the first claim
+ * (e.g. xterm renderer dimensions transiently undefined), the attach must
+ * never stay parked in 'claiming' — output buffered and input dropped forever.
+ *
+ * Contract under test:
+ *  - a later real measurement (layout/renderer lifecycle) completes the claim,
+ *  - a permanently-null measurement falls back to flowing at checkpoint
+ *    geometry within a bounded deadline, without sending any made-up size,
+ *  - reconnect and session switch cancel the pending retry cleanly,
+ *  - input stays closed while unclaimed and opens on recovery.
+ *
+ * The null measurement is forced by shadowing `term.dimensions` with an
+ * instance getter (the only known trigger lives inside xterm internals);
+ * everything downstream of measureTerminalFit is exercised for real.
+ */
+
+const FALLBACK_MS = 4000 // keep in sync with CLAIM_RETRY_FALLBACK_MS in terminal.tsx
+
+async function launchSession(page: Page, command: string): Promise<string> {
+  const cwd = process.env.GMUX_TEST_WORKSPACE!
+  const before = await apiGet<{ data: Array<{ id: string }> }>('/v1/sessions')
+  const known = new Set(before.body.data.map(s => s.id))
+  const launched = await page.evaluate(async ({ command, cwd }) => {
+    const r = await fetch('/v1/launch', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ command: ['bash', '-c', command], cwd }) })
+    return { ok: r.ok, text: await r.text() }
+  }, { command, cwd })
+  expect(launched.ok, launched.text).toBe(true)
+  return pollUntil(async () => {
+    const r = await apiGet<{ data: Array<{ id: string, alive: boolean }> }>('/v1/sessions')
+    return r.body.data.find(s => s.alive && !known.has(s.id))?.id
+  }, { timeoutMs: 10_000, description: 'claim-retry session' })
+}
+
+function tickerCommand(tag: string): string {
+  return `echo MARKER_${tag}; i=0; while true; do i=$((i+1)); echo TICK_${tag}_$i; sleep 0.3; done`
+}
+
+/**
+ * Gate WS message delivery so the test can shadow `term.dimensions` after
+ * mount but before the checkpoint replay lands (the claim runs on replay
+ * completion, so this is the only deterministic interposition point).
+ */
+function installWsGate(page: Page) {
+  return page.addInitScript(() => {
+    const Orig = window.WebSocket
+    // @ts-expect-error test shim
+    window.WebSocket = class extends Orig {
+      constructor(url: string, protos?: string | string[]) {
+        super(url, protos)
+        if (!String(url).includes('/ws/')) return
+        ;(window as any).__testWs = this
+        const q: MessageEvent[] = []
+        let held = true
+        let handler: ((ev: MessageEvent) => void) | null = null
+        Object.defineProperty(this, 'onmessage', {
+          set: (h) => { handler = h },
+          get: () => handler,
+        })
+        this.addEventListener('message', (ev) => {
+          // Record the checkpoint geometry the runner declared for this
+          // frame: the fallback claim must leave local xterm geometry
+          // exactly there (the replay barrier's size), never a made-up one.
+          if (typeof (ev as MessageEvent).data === 'string') {
+            try {
+              const msg = JSON.parse((ev as MessageEvent).data)
+              if (msg?.type === 'terminal_checkpoint' && Number.isInteger(msg.cols) && Number.isInteger(msg.rows)) {
+                ;(window as any).__ckptGeom = { cols: msg.cols, rows: msg.rows }
+              }
+            } catch { /* binary/terminal bytes */ }
+          }
+          if (held) q.push(ev as MessageEvent)
+          else handler?.call(this, ev as MessageEvent)
+        })
+        ;(window as any).__releaseWs = () => {
+          held = false
+          while (q.length) handler?.call(this, q.shift()!)
+        }
+      }
+    }
+  })
+}
+
+async function navigate(page: Page, sessionId: string) {
+  await page.waitForFunction((id) => {
+    const nav = (window as any).__gmuxNavigateToSession
+    return typeof nav === 'function' && nav(id) === true
+  }, sessionId, { timeout: 10_000 })
+  await page.locator('.xterm').waitFor({ state: 'visible', timeout: 5_000 })
+}
+
+async function bufferText(page: Page): Promise<string> {
+  return page.evaluate(() => {
+    const buf = (window as any).__gmuxTerm.buffer.active
+    let t = ''
+    for (let y = 0; y < buf.length; y++) t += (buf.getLine(y)?.translateToString(true) ?? '') + '\n'
+    return t
+  })
+}
+
+function maxTick(text: string, tag: string): number {
+  const nums = (text.match(new RegExp(`TICK_${tag}_(\\d+)`, 'g')) || []).map(m => parseInt(m.slice(6 + tag.length), 10))
+  return nums.length ? Math.max(...nums) : 0
+}
+
+/** Shadow term.dimensions with undefined → measureTerminalFit returns null. */
+async function forceNullMeasurement(page: Page) {
+  await page.waitForFunction(() => (window as any).__gmuxTerm && (window as any).__testWs && (window as any).__releaseWs)
+  await page.evaluate(() => {
+    const term = (window as any).__gmuxTerm
+    Object.defineProperty(term, 'dimensions', { get: () => undefined, configurable: true })
+    ;(window as any).__releaseWs()
+  })
+}
+
+async function restoreMeasurement(page: Page) {
+  await page.evaluate(() => { delete (window as any).__gmuxTerm.dimensions })
+}
+
+async function terminalCols(sessionId: string): Promise<number | undefined> {
+  const r = await apiGet<{ data: Array<{ id: string, terminal_cols?: number }> }>('/v1/sessions')
+  return r.body.data.find(s => s.id === sessionId)?.terminal_cols
+}
+
+test('null first claim recovers via a later real measurement (resize lifecycle)', async ({ page }) => {
+  await installWsGate(page)
+  await openApp(page)
+  const id = await launchSession(page, tickerCommand('R'))
+  await navigate(page, id)
+  await forceNullMeasurement(page)
+
+  // Stall begins: replay rendered, live ticks held, spinner up. Wait past
+  // the immediate rAF re-measurement budget so recovery must come from the
+  // ResizeObserver lifecycle, not the initial frame chain. Ticks rendered so
+  // far came from the checkpoint; held live ticks must not render.
+  await page.waitForTimeout(400)
+  const base = maxTick(await bufferText(page), 'R')
+  await page.waitForTimeout(1000)
+  expect(maxTick(await bufferText(page), 'R')).toBeLessThanOrEqual(base + 1)
+  await expect(page.locator('.terminal-loading')).toHaveCount(1)
+
+  // Measurement becomes available again; a real layout change triggers the
+  // retry. Recovery must beat the fallback deadline (proving it came from
+  // the measured ResizeObserver path), and the claim must be the *measured*
+  // size — verify the runner adopted this browser's geometry.
+  await restoreMeasurement(page)
+  await page.setViewportSize({ width: 1000, height: 700 })
+
+  await expect(page.locator('.terminal-loading')).toHaveCount(0, { timeout: 2_000 })
+  await pollUntil(async () => {
+    const text = await bufferText(page)
+    return maxTick(text, 'R') > base + 3 ? text : null
+  }, { timeoutMs: 5_000, description: 'live output flows after measured recovery' })
+
+  const xtermCols = await page.evaluate(() => (window as any).__gmuxTerm.cols as number)
+  await pollUntil(async () => (await terminalCols(id)) === xtermCols || undefined,
+    { timeoutMs: 5_000, description: 'runner adopted the measured claim size' })
+
+  // Input opened with the claim.
+  await page.locator('.xterm').click()
+  await page.keyboard.type('echo INPUT_OK_R\n')
+  await pollUntil(async () => (await bufferText(page)).includes('INPUT_OK_R') || undefined,
+    { timeoutMs: 5_000, description: 'input echoes after measured recovery' })
+})
+
+test('permanently-null measurement falls back within the deadline; input reopens; no bogus size sent', async ({ page }) => {
+  await installWsGate(page)
+  await openApp(page)
+  const id = await launchSession(page, tickerCommand('P'))
+  // A fresh session has no terminal_cols until some client sends a resize;
+  // capture whatever the runner reports (possibly undefined) as baseline.
+  const colsBefore = await terminalCols(id)
+  await navigate(page, id)
+  await forceNullMeasurement(page)
+
+  // While unclaimed, typed input must be dropped, not queued.
+  await page.waitForTimeout(500)
+  await page.locator('.xterm').click({ force: true }) // spinner overlays the grid
+  await page.keyboard.type('echo INPUT_DROPPED_P\n')
+
+  // Bounded: the deterministic fallback flips to claimed within the deadline
+  // and releases held output — despite measurement staying null forever.
+  await pollUntil(async () => {
+    const text = await bufferText(page)
+    return maxTick(text, 'P') >= 8 ? text : null
+  }, { timeoutMs: FALLBACK_MS + 4_000, description: 'live output flows after fallback claim' })
+  await expect(page.locator('.terminal-loading')).toHaveCount(0)
+
+  // Load-bearing: the fallback must leave the local xterm grid exactly at
+  // the checkpoint geometry the runner declared for the replayed frame —
+  // proceeding with any fake/measured-less local geometry would resize the
+  // grid away from the frame it just parsed.
+  const geom = await page.evaluate(() => ({
+    ckpt: (window as any).__ckptGeom as { cols: number, rows: number } | undefined,
+    cols: (window as any).__gmuxTerm.cols as number,
+    rows: (window as any).__gmuxTerm.rows as number,
+  }))
+  expect(geom.ckpt, 'runner did not declare checkpoint geometry').toBeTruthy()
+  expect({ cols: geom.cols, rows: geom.rows }).toEqual(geom.ckpt)
+
+  // Pre-claim input never reached the shell; post-fallback input echoes.
+  await page.locator('.xterm').click()
+  await page.keyboard.type('echo INPUT_OK_P\n')
+  const text = await pollUntil(async () => {
+    const t = await bufferText(page)
+    return t.includes('INPUT_OK_P') ? t : null
+  }, { timeoutMs: 5_000, description: 'input echoes after fallback claim' })
+  expect(text).not.toContain('INPUT_DROPPED_P')
+
+  // No claim was ever sent: the runner keeps its original geometry.
+  expect(await terminalCols(id)).toBe(colsBefore)
+})
+
+test('socket bounce during pending retry cancels it and reconnect flows claimed', async ({ page }) => {
+  await installWsGate(page)
+  await openApp(page)
+  const id = await launchSession(page, tickerCommand('B'))
+  await navigate(page, id)
+  await forceNullMeasurement(page)
+  await page.waitForTimeout(800)
+  await expect(page.locator('.terminal-loading')).toHaveCount(1)
+
+  // Bounce the socket while the retry is pending (before the deadline).
+  await page.evaluate(() => {
+    ;(window as any).__testWsOld = (window as any).__testWs
+    ;(window as any).__testWs.close()
+  })
+  await page.waitForFunction(() => (window as any).__testWs !== (window as any).__testWsOld, undefined, { timeout: 15_000 })
+  await page.evaluate(() => (window as any).__releaseWs())
+
+  // Reconnect enters 'claimed' (no reclaim); output flows even though the
+  // measurement is still null. The cancelled retry must not fire later —
+  // watch through the old deadline window for anomalies.
+  await pollUntil(async () => {
+    const text = await bufferText(page)
+    return maxTick(text, 'B') >= 8 ? text : null
+  }, { timeoutMs: 15_000, description: 'live output flows after reconnect' })
+  await page.waitForTimeout(FALLBACK_MS + 500)
+  await expect(page.locator('.terminal-loading')).toHaveCount(0)
+  const t1 = maxTick(await bufferText(page), 'B')
+  await page.waitForTimeout(1_000)
+  expect(maxTick(await bufferText(page), 'B')).toBeGreaterThan(t1)
+})
+
+test('session switch during pending retry cancels it; stale claim never lands', async ({ page }) => {
+  await installWsGate(page)
+  await openApp(page)
+  const idA = await launchSession(page, tickerCommand('A'))
+  const idB = await launchSession(page, tickerCommand('C'))
+  const colsABefore = await terminalCols(idA) // possibly undefined pre-claim
+
+  await navigate(page, idA)
+  await forceNullMeasurement(page)
+  await page.waitForTimeout(800)
+  await expect(page.locator('.terminal-loading')).toHaveCount(1)
+
+  // Switch sessions while A's retry is pending; restore measurement so B's
+  // fresh connect claims normally on the same xterm instance.
+  await restoreMeasurement(page)
+  await page.evaluate(() => { (window as any).__testWsOld = (window as any).__testWs })
+  await navigate(page, idB)
+  // The gate rebinds per socket: wait for B's socket to exist before
+  // releasing, or we'd release A's stale gate and hold B's forever.
+  await page.waitForFunction(() => (window as any).__testWs !== (window as any).__testWsOld, undefined, { timeout: 15_000 })
+  await page.evaluate(() => (window as any).__releaseWs())
+
+  await pollUntil(async () => {
+    const text = await bufferText(page)
+    return maxTick(text, 'C') >= 5 ? text : null
+  }, { timeoutMs: 15_000, description: 'session B attaches and flows' })
+  await expect(page.locator('.terminal-loading')).toHaveCount(0)
+
+  // A's cancelled retry must not fire after its deadline would have passed:
+  // no fallback claim against A, no size ever sent to A's runner.
+  await page.waitForTimeout(FALLBACK_MS + 500)
+  expect(await terminalCols(idA)).toBe(colsABefore)
+  expect(maxTick(await bufferText(page), 'A')).toBe(0)
+})


### PR DESCRIPTION
Narrow fixes for the two independently verified terminal residuals from the post-2.1 general review (F1/F2), verified on `origin/main` @ 5f0efcd8.

## F1 — checkpoint/tail replay one-column drift (ptyserver)

A wide glyph written over the second half of another wide glyph strands an orphaned zero cell mid-row (ultraviolet `Line.Set` never repairs the displaced cell's placeholder). `Line.Render` skips zero cells, so the checkpoint dropped that blank column and the wrapped-row padding restore re-added it at the row end — everything after the orphan shifted one column left on browser reattach / `gmux attach`.

**Fix (render-time, smallest safe invariant):** in `writeRow`, any zero cell that is neither a wide-cell placeholder nor part of the row's trailing (wrap-skip) zero run now renders as exactly one blank cell. Trailing synthetic zeros and written spaces are untouched, preserving the existing padding contract. Copy-on-write: shared scrollback lines are never mutated.

**Tests:** exact-cell unit contract, minimized emulator repro (` 字漢字字xy 🙂wxyzé  \x1b[Axy…` @20×6), attach + tail `snapshotFrame` coverage, 200-seed randomized differential replay fuzz. Fixes 4 of the 6 baseline-failing fuzz seeds; the remaining 2 are a distinct pre-existing wrap-flag-loss class (fail identically without this fix), skipped with justification. Mutation-checked: reverting the repair fails the minimized, frame, and fuzz tests.

## F2 — first viewport claim parked in 'claiming' forever (web)

If `measureTerminalFit` returned null at the first claim (xterm renderer dimensions transiently undefined), `attachPhase` stayed `'claiming'` forever: output buffered unbounded in `postClaimWrites`, input dropped, loading overlay intercepting all pointer events until a socket bounce.

**Fix:** bounded retry driven by real measurable lifecycle — a short `requestAnimationFrame` chain for transient renderer states plus one attempt per `ResizeObserver` notification on the shell (no busy loop), with a hard 4s deadline that falls back deterministically to flowing at the checkpoint geometry already applied by the replay barrier (the reconnect path proves this safe), opening input without ever sending a made-up size. The pending retry is cancelled on socket replacement, reconnect, session switch, and unmount, with stale connection/epoch guards. Replay-before-claim ordering unchanged.

**Tests (real browser, real gmuxd):** forced-null then measured recovery via resize lifecycle (runner adopts the measured size), permanently-null bounded fallback (input reopens, pre-claim input dropped, no size sent), socket bounce and session switch cancelling the pending retry. Mutation-checked: restoring the old `if (!claimSize) return` bail-out fails the first two specs.

## Verification

- `go test [-race] ./internal/ptyserver` — green
- `third_party/vt` `go test [-race] ./...` — green
- gmux-web `tsc --noEmit` + vitest (775) — green
- full Playwright e2e — 104/104 green