### PR TITLE
perf(gmuxd): index registration slug allocation and placement scope resolution

### DIFF
--- a/services/gmuxd/internal/centralstore/admin.go
+++ b/services/gmuxd/internal/centralstore/admin.go
@@ -209,8 +209,9 @@ func domainInvariantFindings(ctx context.Context, tx *sql.Tx, q *db.Queries) ([]
 	if err != nil {
 		return nil, fmt.Errorf("centralstore: placement read: %w", err)
 	}
+	idx := indexPlacements(all)
 	for _, r := range all {
-		if want := desiredScope(all, r); r.scope != want {
+		if want := desiredScope(idx, r); r.scope != want {
 			add("scope_mismatch", "placement %s stores sibling scope %q but recomputes to %q", recKey(r), r.scope, want)
 		}
 	}

--- a/services/gmuxd/internal/centralstore/domain.go
+++ b/services/gmuxd/internal/centralstore/domain.go
@@ -1160,7 +1160,20 @@ func recKey(r *placementRec) string {
 	}
 	return "p:" + escape(r.peer) + ":" + escape(r.session)
 }
-func desiredScope(all []*placementRec, r *placementRec) string {
+// placementKeyIndex answers "is recKey k placed in project p" in O(1). Built
+// once per pass so desiredScope stays O(1) per record instead of scanning
+// every placement (O(P²) per rewrite once children exist).
+type placementKeyIndex map[scopeKey]struct{}
+
+func indexPlacements(all []*placementRec) placementKeyIndex {
+	idx := make(placementKeyIndex, len(all))
+	for _, p := range all {
+		idx[scopeKey{p.project, recKey(p)}] = struct{}{}
+	}
+	return idx
+}
+
+func desiredScope(idx placementKeyIndex, r *placementRec) string {
 	parentKey := ""
 	if r.local != "" && r.parent != "" {
 		parentKey = "l:" + r.parent
@@ -1170,10 +1183,8 @@ func desiredScope(all []*placementRec, r *placementRec) string {
 	if parentKey == "" {
 		return "r"
 	}
-	for _, p := range all {
-		if p.project == r.project && recKey(p) == parentKey {
-			return "c:" + parentKey
-		}
+	if _, ok := idx[scopeKey{r.project, parentKey}]; ok {
+		return "c:" + parentKey
 	}
 	return "r"
 }
@@ -1194,8 +1205,9 @@ func normalizePlacements(ctx context.Context, q *db.Queries, fault func() error)
 func rewritePlacements(ctx context.Context, q *db.Queries, all []*placementRec, explicit map[scopeKey][]*placementRec, fault func() error) (bool, error) {
 	final := map[scopeKey][]*placementRec{}
 	affected := map[scopeKey]bool{}
+	idx := indexPlacements(all)
 	for _, r := range all {
-		newScope := desiredScope(all, r)
+		newScope := desiredScope(idx, r)
 		old := scopeKey{r.oldProject, r.oldScope}
 		next := scopeKey{r.project, newScope}
 		if r.isNew || old != next {
@@ -1455,7 +1467,7 @@ func (s *Store) place(ctx context.Context, sub SubjectRef, project ProjectEntryI
 			return MutationResult{}, err
 		}
 	}
-	scope := desiredScope(all, target)
+	scope := desiredScope(indexPlacements(all), target)
 	if !target.isNew && oldProject == target.project && oldParent == target.parent && target.oldScope == scope {
 		if err = tx.Commit(); err != nil {
 			return MutationResult{}, err
@@ -1512,19 +1524,14 @@ func (s *Store) ReorderSiblingScopes(ctx context.Context, reorders []SiblingReor
 		if err != nil {
 			return MutationResult{}, err
 		}
+		idx := indexPlacements(all)
 		scope := "r"
 		if parent.Subject != nil {
 			if err = validateSubject(*parent.Subject); err != nil {
 				return MutationResult{}, err
 			}
 			parentKey := subjectKey(*parent.Subject)
-			found := false
-			for _, r := range all {
-				if r.project == int64(project) && recKey(r) == parentKey {
-					found = true
-					break
-				}
-			}
+			_, found := idx[scopeKey{int64(project), parentKey}]
 			if !found {
 				return MutationResult{}, errors.New("centralstore: reorder parent is not placed in project")
 			}
@@ -1534,7 +1541,7 @@ func (s *Store) ReorderSiblingScopes(ctx context.Context, reorders []SiblingReor
 		by := map[string]*placementRec{}
 		var current []*placementRec
 		for _, r := range all {
-			if r.project == k.project && desiredScope(all, r) == scope {
+			if r.project == k.project && desiredScope(idx, r) == scope {
 				by[recKey(r)] = r
 				current = append(current, r)
 			}

--- a/services/gmuxd/internal/centralstore/hotpath_bench_test.go
+++ b/services/gmuxd/internal/centralstore/hotpath_bench_test.go
@@ -1,0 +1,174 @@
+package centralstore
+
+// Hot-path benchmarks for the daemon registration/placement write path.
+// They pin the costs identified by the system resource profile:
+//
+//   - slug allocation used to run a full-table ListSessions hydration per
+//     registration carrying a slug proposal (O(N) per call, O(N²) bulk);
+//   - desiredScope used to scan every placement per placement per
+//     rewritePlacements pass (O(P²) per insert/remove once children exist).
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+)
+
+func openBenchStore(b *testing.B) *Store {
+	b.Helper()
+	s, err := Open(context.Background(), filepath.Join(b.TempDir(), "state"))
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Cleanup(func() {
+		if err := s.Close(); err != nil {
+			b.Error(err)
+		}
+	})
+	return s
+}
+
+// seedSluggedSessions inserts n sessions, each occupying a distinct slug on
+// the "shell" adapter.
+func seedSluggedSessions(b *testing.B, s *Store, n int) {
+	b.Helper()
+	ctx := context.Background()
+	for i := 0; i < n; i++ {
+		v := NewSession{
+			ID: SessionID(fmt.Sprintf("seed-%06d", i)), Adapter: "shell",
+			Command: []string{"sh"}, CWD: "/tmp", Remotes: map[string]string{},
+			CreatedAt: 1, SlugBase: fmt.Sprintf("seed-slug-%06d", i),
+		}
+		if _, _, err := s.InsertSession(ctx, v); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkRegisterRunnerSlugAllocation re-registers one session with a fresh
+// slug proposal per iteration against a table of n slug-occupied rows. Table
+// size stays fixed; only the allocation cost is exercised.
+func BenchmarkRegisterRunnerSlugAllocation(b *testing.B) {
+	for _, n := range []int{100, 2000} {
+		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
+			ctx := context.Background()
+			s := openBenchStore(b)
+			seedSluggedSessions(b, s, n)
+			reg := registrationB("bench-target", "shell", "/tmp", true, 10)
+			if _, _, err := s.RegisterRunner(ctx, reg); err != nil {
+				b.Fatal(err)
+			}
+			i := 0
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				i++
+				slug := fmt.Sprintf("bench-slug-%09d", i)
+				r := registrationB("bench-target", "shell", "/tmp", true, 10)
+				r.Facts.Slug = &slug
+				if _, _, err := s.RegisterRunner(ctx, r); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkRegisterRunnerSlugContended forces suffix probing: every iteration
+// proposes an already-taken base so allocation must walk to a free "-k".
+func BenchmarkRegisterRunnerSlugContended(b *testing.B) {
+	ctx := context.Background()
+	s := openBenchStore(b)
+	// 50 sessions occupying taken, taken-2..taken-50.
+	for i := 0; i < 50; i++ {
+		slug := "taken"
+		if i > 0 {
+			slug = fmt.Sprintf("taken-%d", i+1)
+		}
+		v := NewSession{ID: SessionID(fmt.Sprintf("c-%03d", i)), Adapter: "shell", Command: []string{"sh"}, CWD: "/tmp", Remotes: map[string]string{}, CreatedAt: 1, Slug: slug, SlugBase: slug}
+		if _, _, err := s.InsertSession(ctx, v); err != nil {
+			b.Fatal(err)
+		}
+	}
+	if _, _, err := s.RegisterRunner(ctx, registrationB("bench-target", "shell", "/tmp", true, 10)); err != nil {
+		b.Fatal(err)
+	}
+	i := 0
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		i++
+		// Alternate between two contended bases so replay short-circuit
+		// (same base twice) never hides the probe.
+		base := "taken"
+		if i%2 == 0 {
+			base = "taken-2"
+		}
+		r := registrationB("bench-target", "shell", "/tmp", true, 10)
+		r.Facts.Slug = &base
+		if _, _, err := s.RegisterRunner(ctx, r); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func registrationB(id, adapter, cwd string, alive bool, at UnixMillis) RunnerRegistration {
+	cmd := []string{"sh"}
+	remotes := map[string]string{}
+	return RunnerRegistration{
+		ID: SessionID(id), Adapter: adapter, Alive: alive, CreatedAt: at, ObservedAt: at,
+		Facts: RunnerFacts{CWD: &cwd, Command: &cmd, Remotes: &remotes},
+	}
+}
+
+// BenchmarkInsertSessionPlacementHeavy measures one InsertSession +
+// RemoveSessionAtVersion pair (each renormalizes placements) against p
+// placed sessions, half of which are children (parented placements are the
+// path that made desiredScope O(P) per record).
+func BenchmarkInsertSessionPlacementHeavy(b *testing.B) {
+	for _, p := range []int{100, 2000} {
+		b.Run(fmt.Sprintf("p=%d", p), func(b *testing.B) {
+			ctx := context.Background()
+			s := openBenchStore(b)
+			if _, _, err := s.ReplaceProjectCatalog(ctx, []ProjectEntrySpec{{Owned: &OwnedProjectSpec{Slug: "p", Rules: []MatchRule{{Path: "/proj"}}}}}, 0); err != nil {
+				b.Fatal(err)
+			}
+			// Roots then children: registration auto-places rows whose cwd
+			// matches the project rule.
+			for i := 0; i < p/2; i++ {
+				root := registrationB(fmt.Sprintf("root-%05d", i), "shell", "/proj", true, UnixMillis(10+i))
+				if _, _, err := s.RegisterRunner(ctx, root); err != nil {
+					b.Fatal(err)
+				}
+				child := registrationB(fmt.Sprintf("child-%05d", i), "shell", "/proj", true, UnixMillis(10+i))
+				pid := SessionID(fmt.Sprintf("root-%05d", i))
+				child.ParentSessionID = &pid
+				if _, _, err := s.RegisterRunner(ctx, child); err != nil {
+					b.Fatal(err)
+				}
+			}
+			all, err := placements(ctx, s.queries)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if len(all) < p {
+				b.Fatalf("expected >=%d placements, got %d", p, len(all))
+			}
+			i := 0
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				i++
+				id := SessionID(fmt.Sprintf("bench-%09d", i))
+				out, _, err := s.InsertSession(ctx, NewSession{ID: id, Adapter: "shell", Command: []string{"sh"}, CWD: "/proj", Remotes: map[string]string{}, CreatedAt: 1})
+				if err != nil {
+					b.Fatal(err)
+				}
+				if _, err := s.RemoveSessionAtVersion(ctx, id, out.Version); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/services/gmuxd/internal/centralstore/internal/db/query.sql
+++ b/services/gmuxd/internal/centralstore/internal/db/query.sql
@@ -21,6 +21,13 @@ SELECT * FROM local_sessions WHERE id = ?;
 -- name: ListSessions :many
 SELECT * FROM local_sessions ORDER BY id;
 
+-- name: ListAdapterSlugs :many
+-- Slug-occupancy probe for allocation. The predicate matches the partial
+-- unique index local_sessions_adapter_slug_unique_idx, so this is an index
+-- range scan instead of a full-table hydration.
+SELECT id, slug FROM local_sessions
+WHERE adapter = ? AND slug IS NOT NULL AND slug <> '';
+
 -- name: SessionVersion :one
 SELECT row_version FROM local_sessions WHERE id = ?;
 

--- a/services/gmuxd/internal/centralstore/internal/db/query.sql.go
+++ b/services/gmuxd/internal/centralstore/internal/db/query.sql.go
@@ -559,6 +559,42 @@ func (q *Queries) InsertSession(ctx context.Context, arg InsertSessionParams) (L
 	return i, err
 }
 
+const listAdapterSlugs = `-- name: ListAdapterSlugs :many
+SELECT id, slug FROM local_sessions
+WHERE adapter = ? AND slug IS NOT NULL AND slug <> ''
+`
+
+type ListAdapterSlugsRow struct {
+	ID   string
+	Slug sql.NullString
+}
+
+// Slug-occupancy probe for allocation. The predicate matches the partial
+// unique index local_sessions_adapter_slug_unique_idx, so this is an index
+// range scan instead of a full-table hydration.
+func (q *Queries) ListAdapterSlugs(ctx context.Context, adapter string) ([]ListAdapterSlugsRow, error) {
+	rows, err := q.db.QueryContext(ctx, listAdapterSlugs, adapter)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListAdapterSlugsRow
+	for rows.Next() {
+		var i ListAdapterSlugsRow
+		if err := rows.Scan(&i.ID, &i.Slug); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listManualPeers = `-- name: ListManualPeers :many
 SELECT id, row_version, name, url, token, node_id, created_at_ms, updated_at_ms FROM manual_peers ORDER BY id
 `

--- a/services/gmuxd/internal/centralstore/register.go
+++ b/services/gmuxd/internal/centralstore/register.go
@@ -421,13 +421,13 @@ func allocateSessionSlug(ctx context.Context, q *db.Queries, current *Session, p
 	if proposed == previousBase && current.Slug != "" {
 		return nil
 	}
-	rows, err := q.ListSessions(ctx)
+	rows, err := q.ListAdapterSlugs(ctx, current.Adapter)
 	if err != nil {
 		return err
 	}
 	occupied := make(map[string]struct{}, len(rows))
 	for _, row := range rows {
-		if row.ID != string(current.ID) && row.Adapter == current.Adapter && row.Slug.Valid && row.Slug.String != "" {
+		if row.ID != string(current.ID) {
 			occupied[row.Slug.String] = struct{}{}
 		}
 	}

--- a/services/gmuxd/internal/centralstore/register_test.go
+++ b/services/gmuxd/internal/centralstore/register_test.go
@@ -688,6 +688,40 @@ func TestSessionSlugAllocationAndReplayIdempotence(t *testing.T) {
 	}
 }
 
+// Slug uniqueness is scoped per adapter (partial unique index on
+// (adapter, slug)); the occupancy probe must not treat another adapter's
+// slug as taken, and must still see every occupied slug on its own adapter.
+func TestSessionSlugAllocationAdapterScoped(t *testing.T) {
+	ctx := context.Background()
+	s := openKernelStore(t)
+	base := "same-name"
+
+	a := registration("a", "pi", "/work", true, 10)
+	a.Facts.Slug = &base
+	gotA, _, err := s.RegisterRunner(ctx, a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b := registration("b", "claude", "/work", true, 20)
+	b.Facts.Slug = &base
+	gotB, _, err := s.RegisterRunner(ctx, b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotA.Slug != base || gotB.Slug != base {
+		t.Fatalf("cross-adapter slugs must not collide: a=%q b=%q", gotA.Slug, gotB.Slug)
+	}
+	c := registration("c", "pi", "/work", true, 30)
+	c.Facts.Slug = &base
+	gotC, _, err := s.RegisterRunner(ctx, c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotC.Slug != base+"-2" {
+		t.Fatalf("same-adapter collision must suffix: got %q", gotC.Slug)
+	}
+}
+
 func TestConcurrentSessionSlugAllocation(t *testing.T) {
 	ctx := context.Background()
 	s := openKernelStore(t)


### PR DESCRIPTION
Implements the two store-write hot-path fixes from the system resource profile (`.grove/profile-system-resources`), each evidence-backed by new committed benchmarks (i7-9700K, `-benchtime 20x`):

**Indexed slug occupancy probe** — `allocateSessionSlug` hydrated the full `local_sessions` table per registration carrying a slug proposal (O(N) per call, O(N²) restart convergence). New sqlc query `ListAdapterSlugs` selects only `(id, slug)` on the owning adapter, matching the existing partial unique index. Allocation semantics unchanged; the unique index still enforces the invariant.

| BenchmarkRegisterRunnerSlugAllocation | before | after |
|---|---|---|
| n=2000 | 8.75 ms/op, 5.25 MB, 34.5k allocs | 1.82 ms/op, 0.60 MB, 10.4k allocs |

**O(1) desiredScope** — `rewritePlacements` ran a linear scan per placement (O(P²) per insert/remove/prune once parented placements exist). A `(project, recKey)` set is now built once per pass; also applied to the `ReorderSiblings` scans and `CheckState`'s scope audit (pure lookup refactor).

| BenchmarkInsertSessionPlacementHeavy | before | after |
|---|---|---|
| p=2000 | 90.1 ms/op, 53 MB, 3.04M allocs | 12.1 ms/op, 5.4 MB, 46k allocs |

New coverage: `TestSessionSlugAllocationAdapterScoped` (guards the `adapter = ?` predicate) plus the two benchmark suites. Validation: full gmuxd `go test ./...`, `-race` on centralstore/cmd/gmuxd/peering/snapshot/sessionstream, `tools/check-centralstore-generated.sh`, and the isolated container e2e (`tools/production-e2e.sh`) — all green.