### PR TITLE
perf(gmuxd): encode each SSE sessions broadcast once, shared across subscribers

### DIFF
--- a/services/gmuxd/cmd/gmuxd/central_helpers.go
+++ b/services/gmuxd/cmd/gmuxd/central_helpers.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/peering"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/projects"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/sessioncoord"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/sessionstream"
 	central "github.com/gmuxapp/gmux/services/gmuxd/internal/snapshot/central"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/snapshot/wire"
 )
@@ -33,15 +34,89 @@ func decodeProjectState(body []byte) (projects.State, error) {
 
 type fanoutMessage struct {
 	Frames         wire.Frames
+	SessionsEncode *sessionEncodeMemo // non-nil iff Frames.Sessions is
 	ActivityID     string
 	ProjectsUpdate bool
 }
 
 type sseFanout struct {
 	mu       sync.Mutex
+	epoch    uint64 // protocol-3 epoch source; advanced under mu so per-subscriber delivery order matches epoch order
 	sessions *wire.SessionsPayload
 	world    *wire.WorldPayload
 	subs     map[chan fanoutMessage]struct{}
+}
+
+// sessionEncodeMemo encodes one broadcast sessions payload at most once per
+// (filter class × protocol) and shares the result across every SSE
+// subscriber. Before this, encode ran per subscriber per snapshot — the
+// dominant storm cost at O(N × rate × subscribers).
+//
+// Safe because BroadcastFrames fans the identical *wire.SessionsPayload out
+// to every subscriber and no consumer mutates it (the fanout caches its own
+// deep copy; peer subscribers narrow via FilterOwned, which allocates).
+// The protocol-3 epoch is drawn eagerly under the fanout mutex, so any two
+// broadcasts observed by one connection carry strictly increasing epochs
+// regardless of which subscriber triggers encoding first.
+type sessionEncodeMemo struct {
+	epoch   uint64
+	payload *wire.SessionsPayload
+
+	mu           sync.Mutex
+	peerFiltered *wire.SessionsPayload
+	proto2       map[bool][]byte               // peer-filtered? -> marshaled payload
+	proto3       map[bool][]sessionstream.Event // peer-filtered? -> transaction events
+}
+
+func newSessionEncodeMemo(epoch uint64, payload *wire.SessionsPayload) *sessionEncodeMemo {
+	if payload == nil {
+		return nil
+	}
+	return &sessionEncodeMemo{epoch: epoch, payload: payload, proto2: map[bool][]byte{}, proto3: map[bool][]sessionstream.Event{}}
+}
+
+func (m *sessionEncodeMemo) payloadForLocked(peer bool, isLocalPeer func(string) bool) *wire.SessionsPayload {
+	if !peer {
+		return m.payload
+	}
+	if m.peerFiltered == nil {
+		filtered := m.payload.FilterOwned(isLocalPeer)
+		m.peerFiltered = &filtered
+	}
+	return m.peerFiltered
+}
+
+// Proto2 returns the marshaled snapshot.sessions body for the subscriber's
+// filter class, encoding it on first use.
+func (m *sessionEncodeMemo) Proto2(peer bool, isLocalPeer func(string) bool) ([]byte, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if data, ok := m.proto2[peer]; ok {
+		return data, nil
+	}
+	data, err := json.Marshal(m.payloadForLocked(peer, isLocalPeer))
+	if err != nil {
+		return nil, err
+	}
+	m.proto2[peer] = data
+	return data, nil
+}
+
+// Proto3 returns the protocol-3 transaction events for the subscriber's
+// filter class, encoding them on first use.
+func (m *sessionEncodeMemo) Proto3(peer bool, isLocalPeer func(string) bool) ([]sessionstream.Event, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if events, ok := m.proto3[peer]; ok {
+		return events, nil
+	}
+	p := m.payloadForLocked(peer, isLocalPeer)
+	events, err := sessionstream.Encode(m.epoch, p.Sessions, func(s wire.Session) string { return s.ID })
+	if err != nil {
+		return nil, err
+	}
+	m.proto3[peer] = events
+	return events, nil
 }
 
 func newSSEFanout() *sseFanout { return &sseFanout{subs: make(map[chan fanoutMessage]struct{})} }
@@ -85,12 +160,14 @@ func (f *sseFanout) currentLocked() wire.Frames {
 	return out
 }
 
-func (f *sseFanout) Subscribe() (wire.Frames, <-chan fanoutMessage, func()) {
+func (f *sseFanout) Subscribe() (fanoutMessage, <-chan fanoutMessage, func()) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	ch := make(chan fanoutMessage, 32)
 	f.subs[ch] = struct{}{}
-	initial := f.currentLocked()
+	frames := f.currentLocked()
+	f.epoch++
+	initial := fanoutMessage{Frames: frames, SessionsEncode: newSessionEncodeMemo(f.epoch, frames.Sessions)}
 	cancel := func() {
 		f.mu.Lock()
 		defer f.mu.Unlock()
@@ -134,7 +211,8 @@ func (f *sseFanout) BroadcastFrames(frames wire.Frames) {
 		}
 		f.world = &copy
 	}
-	msg := fanoutMessage{Frames: frames, ProjectsUpdate: frames.World != nil}
+	f.epoch++
+	msg := fanoutMessage{Frames: frames, SessionsEncode: newSessionEncodeMemo(f.epoch, frames.Sessions), ProjectsUpdate: frames.World != nil}
 	for ch := range f.subs {
 		fanoutEnqueue(ch, msg)
 	}

--- a/services/gmuxd/cmd/gmuxd/serve_central.go
+++ b/services/gmuxd/cmd/gmuxd/serve_central.go
@@ -39,7 +39,6 @@ import (
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/projects"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/sessioncoord"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/sessionmeta"
-	"github.com/gmuxapp/gmux/services/gmuxd/internal/sessionstream"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/sleep"
 	central "github.com/gmuxapp/gmux/services/gmuxd/internal/snapshot/central"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/snapshot/wire"
@@ -902,39 +901,42 @@ func serveCentral(stderr io.Writer, replace bool) int {
 			initial, ch, cancel := fanout.Subscribe()
 			defer cancel()
 			isLocalPeer := func(name string) bool { return peerManager != nil && peerManager.IsLocalPeer(name) }
-			var sessionEpoch uint64
-			sendSessions := func(payload *wire.SessionsPayload) error {
-				if payload == nil {
+			// Encoding is shared across subscribers: every broadcast carries one
+			// memo, and the first subscriber to reach it encodes for its filter
+			// class × protocol; the rest reuse the bytes. Epochs are allocated
+			// by the fanout under its mutex, so they are strictly increasing in
+			// each connection's delivery order.
+			sendSessions := func(memo *sessionEncodeMemo) error {
+				if memo == nil {
 					return nil
 				}
-				if asPeer {
-					filtered := payload.FilterOwned(isLocalPeer)
-					payload = &filtered
-				}
 				if !semanticSessions {
-					return sendSSEFrame(rc, w, "snapshot.sessions", payload)
+					data, encodeErr := memo.Proto2(asPeer, isLocalPeer)
+					if encodeErr != nil {
+						return encodeErr
+					}
+					return sendSSEBytesFrame(rc, w, "snapshot.sessions", data)
 				}
-				sessionEpoch++
-				events, encodeErr := sessionstream.Encode(sessionEpoch, payload.Sessions, func(s wire.Session) string { return s.ID })
+				events, encodeErr := memo.Proto3(asPeer, isLocalPeer)
 				if encodeErr != nil {
 					return encodeErr
 				}
 				return sendSSETransaction(r.Context(), rc, w, events)
 			}
-			if err := sendSessions(initial.Sessions); err != nil {
+			if err := sendSessions(initial.SessionsEncode); err != nil {
 				return
 			}
-			if !asPeer && initial.World != nil {
+			if !asPeer && initial.Frames.World != nil {
 				// Same staleness as /v1/health: the cached world frame's
 				// health counts predate any liveness-only batches. Legacy
 				// composed the initial snapshot at subscribe time; refresh
 				// the counts (on the fanout's private copy) to match.
-				if counts, ok := freshHealthCounts(initial); ok && initial.World.Health != nil {
-					h := *initial.World.Health
+				if counts, ok := freshHealthCounts(initial.Frames); ok && initial.Frames.World.Health != nil {
+					h := *initial.Frames.World.Health
 					h.Sessions = counts
-					initial.World.Health = &h
+					initial.Frames.World.Health = &h
 				}
-				if err := sendSSEFrame(rc, w, "snapshot.world", initial.World); err != nil {
+				if err := sendSSEFrame(rc, w, "snapshot.world", initial.Frames.World); err != nil {
 					return
 				}
 			}
@@ -961,7 +963,7 @@ func serveCentral(stderr io.Writer, replace bool) int {
 						}
 						continue
 					}
-					if err := sendSessions(msg.Frames.Sessions); err != nil {
+					if err := sendSessions(msg.SessionsEncode); err != nil {
 						return
 					}
 					if asPeer {

--- a/services/gmuxd/cmd/gmuxd/session_stream_boundary_test.go
+++ b/services/gmuxd/cmd/gmuxd/session_stream_boundary_test.go
@@ -79,7 +79,7 @@ func TestFanoutSubscribeSnapshotBoundary(t *testing.T) {
 	f.BroadcastFrames(wire.Frames{Sessions: &wire.SessionsPayload{Sessions: []wire.Session{{ID: "before"}}}})
 	initial, ch, cancel := f.Subscribe()
 	defer cancel()
-	if got := initial.Sessions.Sessions[0].ID; got != "before" {
+	if got := initial.Frames.Sessions.Sessions[0].ID; got != "before" {
 		t.Fatalf("initial=%q", got)
 	}
 

--- a/services/gmuxd/cmd/gmuxd/sse_encode_bench_test.go
+++ b/services/gmuxd/cmd/gmuxd/sse_encode_bench_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/snapshot/wire"
+)
+
+// realisticSessionsPayload mirrors the ~660–720 B/session rows measured by
+// the system resource profile.
+func realisticSessionsPayload(n int) *wire.SessionsPayload {
+	rows := make([]wire.Session, n)
+	for i := range rows {
+		id := fmt.Sprintf("%08x%08x", i, i*2654435761)
+		rows[i] = wire.Session{
+			ID: id, CreatedAt: "2026-08-30T12:00:00Z", Command: []string{"gmux", "agent", "--resume", id},
+			Cwd: fmt.Sprintf("/home/user/dev/project-%02d/src", i%40), Adapter: "pi",
+			WorkspaceRoot: fmt.Sprintf("/home/user/dev/project-%02d", i%40),
+			Remotes:       map[string]string{"origin": fmt.Sprintf("github.com/example/project-%02d", i%40)},
+			Alive:         i%10 == 0, Pid: 10000 + i, Title: fmt.Sprintf("Fix the flaky retry loop in worker %d", i),
+			Subtitle: "waiting for review", Status: &wire.Status{Active: i%10 == 0},
+			Unread: i%5 == 0, UnreadToken: fmt.Sprintf("tok-%d", i), Resumable: i%10 != 0,
+			SocketPath: "/run/user/1000/gmux/" + id + ".sock", TerminalCols: 190, TerminalRows: 48,
+			Slug: fmt.Sprintf("fix-flaky-retry-%d", i), ConversationRef: "/home/user/.pi/sessions/" + id + ".jsonl",
+			RunnerVersion: "2.1.0", BinaryHash: "sha256:0011223344556677", ProjectSlug: fmt.Sprintf("project-%02d", i%40),
+			ProjectIndex: i % 20, LastOutputAt: "2026-08-30T12:34:56Z",
+		}
+	}
+	return &wire.SessionsPayload{Sessions: rows}
+}
+
+// BenchmarkSSEBroadcastEncode measures the encode work one broadcast costs
+// across k concurrent subscribers (the storm hot path: every committed
+// mutation pays this once per coalesced pass).
+func BenchmarkSSEBroadcastEncode(b *testing.B) {
+	for _, n := range []int{1000, 10000} {
+		payload := realisticSessionsPayload(n)
+		for _, subs := range []int{1, 10} {
+			b.Run(fmt.Sprintf("proto2/n=%d/subs=%d", n, subs), func(b *testing.B) {
+				b.ReportAllocs()
+				var epoch uint64
+				for b.Loop() {
+					epoch++
+					memo := newSessionEncodeMemo(epoch, payload)
+					for s := 0; s < subs; s++ {
+						if _, err := memo.Proto2(false, nil); err != nil {
+							b.Fatal(err)
+						}
+					}
+				}
+			})
+			b.Run(fmt.Sprintf("proto3/n=%d/subs=%d", n, subs), func(b *testing.B) {
+				b.ReportAllocs()
+				var epoch uint64
+				for b.Loop() {
+					epoch++
+					memo := newSessionEncodeMemo(epoch, payload)
+					for s := 0; s < subs; s++ {
+						if _, err := memo.Proto3(false, nil); err != nil {
+							b.Fatal(err)
+						}
+					}
+				}
+			})
+		}
+	}
+}

--- a/services/gmuxd/cmd/gmuxd/sse_encode_memo_test.go
+++ b/services/gmuxd/cmd/gmuxd/sse_encode_memo_test.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"sync"
+	"testing"
+
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/snapshot/wire"
+)
+
+// One broadcast must be encoded at most once per (filter class × protocol),
+// and every subscriber of a class must receive the identical bytes the
+// per-subscriber encode used to produce.
+func TestSessionEncodeMemoSharesIdenticalFrames(t *testing.T) {
+	payload := &wire.SessionsPayload{Sessions: []wire.Session{
+		{ID: "own", Adapter: "shell"},
+		{ID: "dc@devbox", Peer: "devbox", Adapter: "shell"},
+		{ID: "mirror@remote", Peer: "remote", Adapter: "shell"},
+	}}
+	isLocalPeer := func(name string) bool { return name == "devbox" }
+	memo := newSessionEncodeMemo(7, payload)
+
+	full, err := memo.Proto2(false, isLocalPeer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, _ := json.Marshal(payload)
+	if !bytes.Equal(full, want) {
+		t.Fatalf("proto2 browser bytes diverge from direct marshal:\n%s\n%s", full, want)
+	}
+	again, _ := memo.Proto2(false, isLocalPeer)
+	if &full[0] != &again[0] {
+		t.Fatal("proto2 browser frame re-encoded instead of shared")
+	}
+
+	peer, err := memo.Proto2(true, isLocalPeer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var filtered wire.SessionsPayload
+	if err := json.Unmarshal(peer, &filtered); err != nil {
+		t.Fatal(err)
+	}
+	if len(filtered.Sessions) != 2 || filtered.Sessions[0].ID != "own" || filtered.Sessions[1].ID != "dc@devbox" {
+		t.Fatalf("peer class must keep own + Local-peer rows only: %s", peer)
+	}
+
+	e1, err := memo.Proto3(false, isLocalPeer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	e2, _ := memo.Proto3(false, isLocalPeer)
+	if len(e1) == 0 || len(e1) != len(e2) || &e1[0].Data[0] != &e2[0].Data[0] {
+		t.Fatal("proto3 events re-encoded instead of shared")
+	}
+	if !bytes.Contains(e1[0].Data, []byte(`"epoch":7`)) {
+		t.Fatalf("proto3 begin must carry the broadcast epoch: %s", e1[0].Data)
+	}
+	p3peer, err := memo.Proto3(true, isLocalPeer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(bytes.Join([][]byte{p3peer[0].Data, p3peer[1].Data}, nil), []byte("mirror@remote")) {
+		t.Fatal("proto3 peer class leaked a network-peer mirror row")
+	}
+}
+
+// Epochs are drawn under the fanout mutex at broadcast/subscribe time, so
+// each connection observes strictly increasing epochs in delivery order —
+// even when a later broadcast is encoded first by another subscriber.
+func TestFanoutEpochStrictlyIncreasingPerSubscriber(t *testing.T) {
+	f := newSSEFanout()
+	f.BroadcastFrames(wire.Frames{Sessions: &wire.SessionsPayload{Sessions: []wire.Session{{ID: "seed"}}}})
+	initial, ch, cancel := f.Subscribe()
+	defer cancel()
+	if initial.SessionsEncode == nil {
+		t.Fatal("initial snapshot must carry an encode memo")
+	}
+	last := initial.SessionsEncode.epoch
+	for i := 0; i < 3; i++ {
+		f.BroadcastFrames(wire.Frames{Sessions: &wire.SessionsPayload{Sessions: []wire.Session{{ID: "seed"}}}})
+		msg := <-ch
+		if msg.SessionsEncode == nil {
+			t.Fatal("broadcast must carry an encode memo")
+		}
+		// Encode lazily *after* a later broadcast already exists elsewhere:
+		// epoch order must still match delivery order.
+		if msg.SessionsEncode.epoch <= last {
+			t.Fatalf("epoch not strictly increasing: %d after %d", msg.SessionsEncode.epoch, last)
+		}
+		last = msg.SessionsEncode.epoch
+	}
+}
+
+// Concurrent subscribers racing to encode the same broadcast must all get a
+// consistent result (exercised with -race in CI).
+func TestSessionEncodeMemoConcurrentEncode(t *testing.T) {
+	payload := realisticSessionsPayload(200)
+	memo := newSessionEncodeMemo(1, payload)
+	isLocalPeer := func(string) bool { return false }
+	var wg sync.WaitGroup
+	errs := make(chan error, 40)
+	for i := 0; i < 40; i++ {
+		peer := i%2 == 0
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := memo.Proto2(peer, isLocalPeer); err != nil {
+				errs <- err
+			}
+			if _, err := memo.Proto3(peer, isLocalPeer); err != nil {
+				errs <- err
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Implements optimization #2 from the system resource profile (`.grove/profile-system-resources`): `sessionstream.Encode`/`json.Marshal` ran **per SSE subscriber per snapshot**, although `BroadcastFrames` fans the identical `*wire.SessionsPayload` pointer to every subscriber (verified: the fanout deep-copies only its own cache, no consumer mutates the broadcast payload, `FilterOwned` allocates). Each broadcast now carries a `sessionEncodeMemo` keyed by (filter class: browser/peer × protocol: 2/3); the first subscriber encodes, the rest reuse the bytes.

**Epoch semantics:** the protocol-3 epoch moves from a per-connection counter to a fanout-global counter advanced eagerly under the fanout mutex (lazy draw could invert epochs between subscribers). Because `Subscribe` and `BroadcastFrames` serialize on the same mutex, every connection still observes strictly increasing epochs in delivery order, including across drop-oldest queue skips. Both receivers only require strictly increasing positive epochs and reset on reconnect (web `store.ts`, peering `TestPeerRejectsNonIncreasingEpochWithoutRollback`).

`BenchmarkSSEBroadcastEncode`, one broadcast of realistic ~700 B rows (i7-9700K):

| | before | after |
|---|---|---|
| proto3 n=10k subs=10 | 209 ms, 226 MB, 502k allocs | 20.6 ms, 22.6 MB, 50k allocs |
| proto2 n=10k subs=10 | 164 ms, 91.7 MB, 300k allocs | 17.0 ms, 10.7 MB, 30k allocs |
| subs=1 | unchanged | unchanged |

Per-broadcast encode cost is now independent of subscriber/peer/tab count — this removes the per-subscriber multiplier of the profile's #1 storm term at zero latency or protocol change.

New coverage: byte-identity + single-encode sharing, peer-filter correctness on both protocols, per-subscriber epoch monotonicity across the subscribe boundary, and a 40-goroutine concurrent-encode race test. Validation: full `cmd/gmuxd` suite under `-race`, plus the isolated container e2e (`tools/production-e2e.sh`) on the tree merged with #515 — all green. Independent of #515.