### PR TITLE
perf(gmuxd): run startup conversation indexing in the background

### DIFF
--- a/services/gmuxd/cmd/gmuxd/conversations_http.go
+++ b/services/gmuxd/cmd/gmuxd/conversations_http.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/conversations"
+)
+
+// handleConversationLookup serves GET /v1/conversations/{adapter}/{slug}.
+//
+// While the startup snapshot is still running, a lookup miss is ambiguous —
+// the conversation may simply not have been scanned yet — so the handler
+// answers 503 "indexing" with Retry-After instead of a false 404. Completeness
+// is read BEFORE the lookup: only a miss against an index that was already
+// complete when the request started is an authoritative 404. Reading it after
+// the miss could race the final adapter's upsert + completeness flip and
+// 404 a conversation that is in the index by the time the response is
+// written; with this order, the worst case is one extra retryable 503.
+func handleConversationLookup(convIndex *conversations.Index) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		adapterName := r.PathValue("adapter")
+		slug := r.PathValue("slug")
+		complete := convIndex.SnapshotComplete()
+		info, ok := convIndex.Lookup(adapterName, slug)
+		if !ok {
+			if !complete {
+				w.Header().Set("Retry-After", "2")
+				writeError(w, http.StatusServiceUnavailable, "indexing", "conversation index is still loading; retry shortly")
+				return
+			}
+			writeError(w, http.StatusNotFound, "not_found", "conversation not found")
+			return
+		}
+		writeJSON(w, map[string]any{"ok": true, "data": map[string]any{"slug": info.Slug, "adapter": info.Adapter, "title": info.Title, "cwd": info.Cwd, "resume_command": info.ResumeCommand, "created": info.Created}})
+	}
+}
+
+// conversationIndexHealth is the /v1/health "conversation_index" payload:
+// transport readiness must not imply complete conversation discovery, so the
+// scan's state is reported explicitly.
+func conversationIndexHealth(convIndex *conversations.Index) map[string]any {
+	status := "indexing"
+	if convIndex.SnapshotComplete() {
+		status = "ready"
+	}
+	return map[string]any{"status": status, "indexed": convIndex.Count()}
+}

--- a/services/gmuxd/cmd/gmuxd/conversations_http_test.go
+++ b/services/gmuxd/cmd/gmuxd/conversations_http_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/conversations"
+)
+
+// Covers the HTTP surface of async indexing: 503+Retry-After for misses while
+// the snapshot runs, 200 for entries indexed so far, 404 only once complete,
+// and the health conversation_index payload in both states.
+func TestConversationLookupAndHealthDuringIndexing(t *testing.T) {
+	// Isolate every adapter root so Snapshot() below scans an empty corpus
+	// and just flips completeness.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PI_CODING_AGENT_DIR", filepath.Join(home, ".pi", "agent"))
+	t.Setenv("CODEX_HOME", filepath.Join(home, ".codex"))
+
+	idx := conversations.New()
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /v1/conversations/{adapter}/{slug}", handleConversationLookup(idx))
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	get := func(t *testing.T, slug string) (int, http.Header, map[string]any) {
+		t.Helper()
+		resp, err := http.Get(srv.URL + "/v1/conversations/pi/" + slug)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		var body map[string]any
+		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+			t.Fatal(err)
+		}
+		return resp.StatusCode, resp.Header, body
+	}
+	errCode := func(body map[string]any) string {
+		e, _ := body["error"].(map[string]any)
+		code, _ := e["code"].(string)
+		return code
+	}
+
+	// --- indexing in progress (snapshot not complete) ---
+	if h := conversationIndexHealth(idx); h["status"] != "indexing" || h["indexed"] != 0 {
+		t.Fatalf("health during indexing = %v", h)
+	}
+	status, hdr, body := get(t, "no-such-slug")
+	if status != http.StatusServiceUnavailable || errCode(body) != "indexing" {
+		t.Fatalf("miss during indexing: status=%d body=%v (want 503/indexing)", status, body)
+	}
+	if hdr.Get("Retry-After") == "" {
+		t.Fatal("503 during indexing must carry Retry-After")
+	}
+
+	// Entries already scanned serve immediately, mid-indexing.
+	idx.Upsert(conversations.Info{ConversationID: "conv-1", Slug: "hello-world", Adapter: "pi", Title: "Hello World", Cwd: "/tmp/x", Ref: "/tmp/x/conv-1.jsonl", ResumeCommand: []string{"pi", "--resume", "conv-1"}, Created: time.Unix(1700000000, 0)})
+	status, _, body = get(t, "hello-world")
+	if status != http.StatusOK {
+		t.Fatalf("indexed entry during indexing: status=%d body=%v (want 200)", status, body)
+	}
+	if data, _ := body["data"].(map[string]any); data["title"] != "Hello World" || data["adapter"] != "pi" {
+		t.Fatalf("payload = %v", body["data"])
+	}
+	if h := conversationIndexHealth(idx); h["status"] != "indexing" || h["indexed"] != 1 {
+		t.Fatalf("health mid-indexing = %v", h)
+	}
+
+	// --- snapshot complete (empty adapter roots; flips completeness) ---
+	idx.Snapshot()
+	if !idx.SnapshotComplete() {
+		t.Fatal("Snapshot did not mark completeness")
+	}
+	if h := conversationIndexHealth(idx); h["status"] != "ready" || h["indexed"] != 1 {
+		t.Fatalf("health after indexing = %v", h)
+	}
+	status, _, body = get(t, "no-such-slug")
+	if status != http.StatusNotFound || errCode(body) != "not_found" {
+		t.Fatalf("miss after indexing: status=%d body=%v (want 404/not_found)", status, body)
+	}
+	if status, _, _ = get(t, "hello-world"); status != http.StatusOK {
+		t.Fatalf("indexed entry after indexing: status=%d (want 200)", status)
+	}
+}

--- a/services/gmuxd/cmd/gmuxd/serve_central.go
+++ b/services/gmuxd/cmd/gmuxd/serve_central.go
@@ -222,11 +222,10 @@ func serveCentral(stderr io.Writer, replace bool) int {
 		defer bounded.Stop()
 	}
 
-	// Conversation discovery reads and parses the complete on-disk history.
-	// Do it only after ownership is settled: autostart contenders that find a
-	// healthy incumbent must yield without paying this multi-second cost.
-	convIndex.Snapshot()
-	log.Printf("conversations: indexed %d conversations", convIndex.Count())
+	// Conversation discovery (convIndex.StartSnapshot below, after the source
+	// watchers start) is deferred until listeners are about to bind: it reads
+	// and parses the complete on-disk history — tens of seconds on large
+	// corpora — and must block neither takeover ordering nor first requests.
 
 	var peerManager *peering.Manager
 	var tsListener *tsauth.Listener
@@ -397,7 +396,11 @@ func serveCentral(stderr io.Writer, replace bool) int {
 			if launchers == nil {
 				launchers = []peering.LauncherDef{}
 			}
-			data := map[string]any{"service": health.Service, "version": health.Version, "pid": os.Getpid(), "node_id": health.NodeID, "status": health.Status, "hostname": health.Hostname, "listen": health.Listen, "peers": peers, "sessions": health.Sessions, "runner_hash": health.RunnerHash, "default_launcher": health.DefaultLauncher, "launchers": launchers}
+			convStatus := "indexing"
+			if convIndex.SnapshotComplete() {
+				convStatus = "ready"
+			}
+			data := map[string]any{"service": health.Service, "version": health.Version, "pid": os.Getpid(), "node_id": health.NodeID, "status": health.Status, "hostname": health.Hostname, "listen": health.Listen, "peers": peers, "sessions": health.Sessions, "runner_hash": health.RunnerHash, "default_launcher": health.DefaultLauncher, "launchers": launchers, "conversation_index": map[string]any{"status": convStatus, "indexed": convIndex.Count()}}
 			if health.TailscaleURL != "" {
 				data["tailscale_url"] = health.TailscaleURL
 			}
@@ -635,6 +638,14 @@ func serveCentral(stderr io.Writer, replace bool) int {
 			slug := r.PathValue("slug")
 			info, ok := convIndex.Lookup(adapterName, slug)
 			if !ok {
+				if !convIndex.SnapshotComplete() {
+					// The startup scan hasn't covered this ref yet; "absent" is
+					// not knowable. Tell the client to retry instead of 404ing
+					// a conversation that exists on disk.
+					w.Header().Set("Retry-After", "2")
+					writeError(w, http.StatusServiceUnavailable, "indexing", "conversation index is still loading; retry shortly")
+					return
+				}
 				writeError(w, http.StatusNotFound, "not_found", "conversation not found")
 				return
 			}
@@ -993,6 +1004,26 @@ func serveCentral(stderr io.Writer, replace bool) int {
 	})
 
 	boot.StartOwnedTriggers(TriggerConfig{Tick: productionEndpointSchedule(daemonCtx, 30*time.Second), ConversationDeleted: productionConversationDeletionSource(daemonCtx, convIndex), PeerSessionsChanged: nil, PeerWorldChanged: nil, Activity: func(o sessioncoord.Outcome) { fanout.BroadcastActivity(string(o.ID)) }})
+
+	// Conversation discovery runs in the background so the listeners below
+	// bind promptly; on a large corpus the synchronous scan blocked startup
+	// for tens of seconds. Ordering invariants: (a) ownership is settled far
+	// above (bootstrapOwnership), so autostart contenders that yield to a
+	// healthy incumbent never pay this cost (#460/#461 unchanged); (b) the
+	// source watchers are already running (StartOwnedTriggers above), so a
+	// conversation created or changed during the scan is observed rather than
+	// lost — strictly narrower than the old snapshot-then-watch gap. Sessions
+	// serve immediately from centralstore (titles stay runner-reported
+	// last-known-good, #508 — this index never writes the store) and gain
+	// resume commands progressively: each adapter completion re-marks the
+	// composer dirty so subscribers see the enrichment without reconnecting.
+	convIndexStarted := time.Now()
+	convIndex.StartSnapshot(daemonCtx, conversations.DefaultSnapshotWorkers, func(string) {
+		boot.Composer.MarkDirty(true, false)
+	}, func() {
+		log.Printf("conversations: indexed %d conversations in %s", convIndex.Count(), time.Since(convIndexStarted).Round(time.Millisecond))
+		boot.Composer.MarkDirty(true, false)
+	})
 
 	authedHandler := netauth.Middleware(authToken, commonMux)
 	sock := paths.SocketPath()

--- a/services/gmuxd/cmd/gmuxd/serve_central.go
+++ b/services/gmuxd/cmd/gmuxd/serve_central.go
@@ -396,11 +396,7 @@ func serveCentral(stderr io.Writer, replace bool) int {
 			if launchers == nil {
 				launchers = []peering.LauncherDef{}
 			}
-			convStatus := "indexing"
-			if convIndex.SnapshotComplete() {
-				convStatus = "ready"
-			}
-			data := map[string]any{"service": health.Service, "version": health.Version, "pid": os.Getpid(), "node_id": health.NodeID, "status": health.Status, "hostname": health.Hostname, "listen": health.Listen, "peers": peers, "sessions": health.Sessions, "runner_hash": health.RunnerHash, "default_launcher": health.DefaultLauncher, "launchers": launchers, "conversation_index": map[string]any{"status": convStatus, "indexed": convIndex.Count()}}
+			data := map[string]any{"service": health.Service, "version": health.Version, "pid": os.Getpid(), "node_id": health.NodeID, "status": health.Status, "hostname": health.Hostname, "listen": health.Listen, "peers": peers, "sessions": health.Sessions, "runner_hash": health.RunnerHash, "default_launcher": health.DefaultLauncher, "launchers": launchers, "conversation_index": conversationIndexHealth(convIndex)}
 			if health.TailscaleURL != "" {
 				data["tailscale_url"] = health.TailscaleURL
 			}
@@ -633,24 +629,7 @@ func serveCentral(stderr io.Writer, replace bool) int {
 			}
 			writeJSON(w, map[string]any{"ok": true, "data": sessions})
 		})
-		mux.HandleFunc("GET /v1/conversations/{adapter}/{slug}", func(w http.ResponseWriter, r *http.Request) {
-			adapterName := r.PathValue("adapter")
-			slug := r.PathValue("slug")
-			info, ok := convIndex.Lookup(adapterName, slug)
-			if !ok {
-				if !convIndex.SnapshotComplete() {
-					// The startup scan hasn't covered this ref yet; "absent" is
-					// not knowable. Tell the client to retry instead of 404ing
-					// a conversation that exists on disk.
-					w.Header().Set("Retry-After", "2")
-					writeError(w, http.StatusServiceUnavailable, "indexing", "conversation index is still loading; retry shortly")
-					return
-				}
-				writeError(w, http.StatusNotFound, "not_found", "conversation not found")
-				return
-			}
-			writeJSON(w, map[string]any{"ok": true, "data": map[string]any{"slug": info.Slug, "adapter": info.Adapter, "title": info.Title, "cwd": info.Cwd, "resume_command": info.ResumeCommand, "created": info.Created}})
-		})
+		mux.HandleFunc("GET /v1/conversations/{adapter}/{slug}", handleConversationLookup(convIndex))
 		// Read-only, non-reserving preflight for client-minted IDs. Absence is
 		// advisory; POST /v1/register repeats the check under the coordinator's
 		// lifecycle fence to close the race.

--- a/services/gmuxd/internal/conversations/async_snapshot_test.go
+++ b/services/gmuxd/internal/conversations/async_snapshot_test.go
@@ -1,0 +1,265 @@
+package conversations
+
+import (
+	"context"
+	"reflect"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gmuxapp/gmux/packages/adapter"
+)
+
+// fakeConvAdapter is a synthetic ConversationSource + ConversationDescriber +
+// Resumer. Refs encode "id|title|cwd" so DescribeConversation is pure.
+type fakeConvAdapter struct {
+	name     string
+	refs     []string
+	delay    time.Duration // per-snapshot artificial scan duration
+	inFlight *atomic.Int32 // shared across adapters: concurrent snapshots
+	maxSeen  *atomic.Int32 // shared: high-water mark of inFlight
+}
+
+func (f *fakeConvAdapter) Name() string                        { return f.name }
+func (f *fakeConvAdapter) Discover() bool                      { return true }
+func (f *fakeConvAdapter) Match([]string) bool                 { return false }
+func (f *fakeConvAdapter) Env(adapter.EnvContext) []string     { return nil }
+func (f *fakeConvAdapter) SnapshotConversations(sink adapter.ConversationSink) {
+	if f.inFlight != nil {
+		n := f.inFlight.Add(1)
+		for {
+			m := f.maxSeen.Load()
+			if n <= m || f.maxSeen.CompareAndSwap(m, n) {
+				break
+			}
+		}
+		defer f.inFlight.Add(-1)
+	}
+	if f.delay > 0 {
+		time.Sleep(f.delay)
+	}
+	for _, ref := range f.refs {
+		sink.Upsert(ref)
+	}
+}
+func (f *fakeConvAdapter) WatchConversations(ctx context.Context, _ adapter.ConversationSink) error {
+	<-ctx.Done()
+	return ctx.Err()
+}
+func (f *fakeConvAdapter) DescribeConversation(ref string) (*adapter.ConversationInfo, error) {
+	parts := strings.SplitN(ref, "|", 3)
+	return &adapter.ConversationInfo{
+		ID:      parts[0],
+		Title:   parts[1],
+		Slug:    adapter.Slugify(parts[1]),
+		Cwd:     parts[2],
+		Created: time.Unix(1700000000, 0),
+	}, nil
+}
+func (f *fakeConvAdapter) ResumeCommand(info *adapter.ConversationInfo) []string {
+	return []string{f.name, "--resume", info.ID}
+}
+
+func withFakeAdapters(t *testing.T, fakes []*fakeConvAdapter) {
+	t.Helper()
+	prev := allAdapters
+	allAdapters = func() []adapter.Adapter {
+		out := make([]adapter.Adapter, len(fakes))
+		for i, f := range fakes {
+			out[i] = f
+		}
+		return out
+	}
+	t.Cleanup(func() { allAdapters = prev })
+}
+
+func makeFakes(n, refsPer int, delay time.Duration) ([]*fakeConvAdapter, *atomic.Int32) {
+	var inFlight, maxSeen atomic.Int32
+	fakes := make([]*fakeConvAdapter, n)
+	for i := range fakes {
+		name := "fake" + string(rune('a'+i))
+		refs := make([]string, refsPer)
+		for j := range refs {
+			id := name + "-conv-" + string(rune('0'+j))
+			refs[j] = id + "|Title " + id + "|/tmp/" + name
+		}
+		fakes[i] = &fakeConvAdapter{name: name, refs: refs, delay: delay, inFlight: &inFlight, maxSeen: &maxSeen}
+	}
+	return fakes, &maxSeen
+}
+
+// Bounded concurrency: with 4 sources and 2 workers, at most 2 snapshot scans
+// are ever in flight; onComplete fires exactly once after all of them, and
+// only then does SnapshotComplete report true.
+func TestStartSnapshotBoundedConcurrency(t *testing.T) {
+	fakes, maxSeen := makeFakes(4, 3, 40*time.Millisecond)
+	withFakeAdapters(t, fakes)
+
+	idx := New()
+	if idx.SnapshotComplete() {
+		t.Fatal("fresh index must not report snapshot complete")
+	}
+	done := make(chan struct{})
+	var adapterDone atomic.Int32
+	idx.StartSnapshot(context.Background(), 2, func(string) { adapterDone.Add(1) }, func() { close(done) })
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("StartSnapshot did not complete")
+	}
+	if got := maxSeen.Load(); got > 2 {
+		t.Fatalf("concurrency bound violated: %d scans in flight (want <= 2)", got)
+	}
+	if got := adapterDone.Load(); got != 4 {
+		t.Fatalf("onAdapterIndexed calls = %d, want 4", got)
+	}
+	if !idx.SnapshotComplete() {
+		t.Fatal("SnapshotComplete false after onComplete")
+	}
+	if idx.Count() != 12 {
+		t.Fatalf("indexed %d conversations, want 12", idx.Count())
+	}
+}
+
+// Differential: the async snapshot converges to exactly the state the
+// synchronous blocking Snapshot produces for the same sources.
+func TestStartSnapshotDifferentialWithBlockingSnapshot(t *testing.T) {
+	fakes, _ := makeFakes(3, 5, 0)
+	// Force a slug collision across adapters' shared logic within one adapter.
+	fakes[0].refs = append(fakes[0].refs, "dup-1|Same Title|/tmp/x", "dup-2|Same Title|/tmp/y")
+	withFakeAdapters(t, fakes)
+
+	blocking := New()
+	blocking.Snapshot()
+
+	async := New()
+	done := make(chan struct{})
+	async.StartSnapshot(context.Background(), 2, nil, func() { close(done) })
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("StartSnapshot did not complete")
+	}
+
+	sortInfos := func(in []Info) []Info {
+		sort.Slice(in, func(i, j int) bool {
+			if in[i].Adapter != in[j].Adapter {
+				return in[i].Adapter < in[j].Adapter
+			}
+			return in[i].ConversationID < in[j].ConversationID
+		})
+		return in
+	}
+	want, got := sortInfos(blocking.All()), sortInfos(async.All())
+	// Collision suffix assignment is arrival-order-dependent (-2 goes to the
+	// second arrival); with concurrent scans either dup may get the suffix.
+	// Compare identity on everything except which twin got suffixed: both
+	// twins must exist, with distinct keys drawn from the same suffix set.
+	normalize := func(infos []Info) ([]Info, map[string][]string) {
+		keys := map[string][]string{}
+		out := make([]Info, 0, len(infos))
+		for _, info := range infos {
+			base := strings.TrimSuffix(strings.TrimSuffix(info.Key, "-2"), "-3")
+			keys[info.Adapter+"/"+base] = append(keys[info.Adapter+"/"+base], info.Key)
+			info.Key = base
+			info.Slug = strings.TrimSuffix(strings.TrimSuffix(info.Slug, "-2"), "-3")
+			out = append(out, info)
+		}
+		for _, v := range keys {
+			sort.Strings(v)
+		}
+		return out, keys
+	}
+	wantN, wantKeys := normalize(want)
+	gotN, gotKeys := normalize(got)
+	if !reflect.DeepEqual(wantN, gotN) {
+		t.Fatalf("async index state diverged from blocking snapshot:\nblocking: %+v\nasync:    %+v", wantN, gotN)
+	}
+	if !reflect.DeepEqual(wantKeys, gotKeys) {
+		t.Fatalf("key/suffix sets diverged:\nblocking: %v\nasync:    %v", wantKeys, gotKeys)
+	}
+	// Resume commands must be resolvable for every ref in both.
+	for _, f := range fakes {
+		for _, ref := range f.refs {
+			if len(async.LookupResumeCommand(f.name, ref)) == 0 {
+				t.Fatalf("async index missing resume command for %s/%s", f.name, ref)
+			}
+		}
+	}
+}
+
+// Watcher events racing the startup scan (the production topology: watchers
+// start before StartSnapshot) must not duplicate or lose conversations —
+// Upsert is keyed by adapter-native conversation ID.
+func TestStartSnapshotConcurrentSourceEvents(t *testing.T) {
+	fakes, _ := makeFakes(2, 20, 10*time.Millisecond)
+	withFakeAdapters(t, fakes)
+
+	idx := New()
+	done := make(chan struct{})
+	idx.StartSnapshot(context.Background(), 2, nil, func() { close(done) })
+
+	// Simulate watchers re-upserting every ref plus brand-new refs while the
+	// scan is running.
+	extra := make(map[string][]string)
+	for _, f := range fakes {
+		extra[f.name] = []string{f.name + "-live-1|Live One|/tmp/live", f.name + "-live-2|Live Two|/tmp/live"}
+	}
+	var wg sync.WaitGroup
+	for _, f := range fakes {
+		for i := 0; i < 4; i++ {
+			wg.Add(1)
+			go func(f *fakeConvAdapter) {
+				defer wg.Done()
+				for _, ref := range append(append([]string(nil), f.refs...), extra[f.name]...) {
+					idx.Scan(f, ref)
+				}
+			}(f)
+		}
+	}
+	wg.Wait()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("StartSnapshot did not complete")
+	}
+
+	// 2 adapters x (20 snapshot + 2 live) unique conversation IDs.
+	if idx.Count() != 44 {
+		t.Fatalf("indexed %d conversations, want 44 (duplicate or lost entries)", idx.Count())
+	}
+	for _, f := range fakes {
+		for _, ref := range append(append([]string(nil), f.refs...), extra[f.name]...) {
+			id := strings.SplitN(ref, "|", 2)[0]
+			if idx.LookupByConversationID(f.name, id) == "" {
+				t.Fatalf("conversation %s/%s lost", f.name, id)
+			}
+		}
+	}
+}
+
+// A context cancelled before scans run must leave the snapshot incomplete:
+// the index may be partial and must not advertise authority over absence.
+func TestStartSnapshotCancelledContext(t *testing.T) {
+	fakes, _ := makeFakes(2, 2, 0)
+	withFakeAdapters(t, fakes)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	idx := New()
+	completed := make(chan struct{})
+	idx.StartSnapshot(ctx, 1, nil, func() { close(completed) })
+
+	select {
+	case <-completed:
+		t.Fatal("onComplete fired despite cancelled context")
+	case <-time.After(200 * time.Millisecond):
+	}
+	if idx.SnapshotComplete() {
+		t.Fatal("cancelled snapshot must not report complete")
+	}
+}

--- a/services/gmuxd/internal/conversations/async_snapshot_test.go
+++ b/services/gmuxd/internal/conversations/async_snapshot_test.go
@@ -21,6 +21,13 @@ type fakeConvAdapter struct {
 	delay    time.Duration // per-snapshot artificial scan duration
 	inFlight *atomic.Int32 // shared across adapters: concurrent snapshots
 	maxSeen  *atomic.Int32 // shared: high-water mark of inFlight
+
+	// describeStarted/describeGate, when set, make DescribeConversation
+	// announce entry and then block until the gate closes — a deterministic
+	// stand-in for a slow file read/parse, used to interleave watcher events
+	// with an in-flight scan.
+	describeStarted chan string
+	describeGate    chan struct{}
 }
 
 func (f *fakeConvAdapter) Name() string                        { return f.name }
@@ -50,6 +57,12 @@ func (f *fakeConvAdapter) WatchConversations(ctx context.Context, _ adapter.Conv
 	return ctx.Err()
 }
 func (f *fakeConvAdapter) DescribeConversation(ref string) (*adapter.ConversationInfo, error) {
+	if f.describeStarted != nil {
+		f.describeStarted <- ref
+	}
+	if f.describeGate != nil {
+		<-f.describeGate
+	}
 	parts := strings.SplitN(ref, "|", 3)
 	return &adapter.ConversationInfo{
 		ID:      parts[0],
@@ -240,6 +253,59 @@ func TestStartSnapshotConcurrentSourceEvents(t *testing.T) {
 			}
 		}
 	}
+}
+
+// Reviewer F1 zombie schedule (PR #517): a watcher Remove landing between
+// Scan's unlocked DescribeConversation and its commit must win — otherwise
+// the scan resurrects a deleted conversation and no future event ever clears
+// it. Both variants: the ref was never indexed (startup scan) and the ref was
+// already indexed (rescan).
+func TestScanRemoveRaceDeletionWins(t *testing.T) {
+	const ref = "conv-1|Some Title|/tmp/x"
+
+	run := func(t *testing.T, preIndex bool) {
+		idx := New()
+		plain := &fakeConvAdapter{name: "probe"}
+		if preIndex {
+			if key := idx.Scan(plain, ref); key == "" {
+				t.Fatal("pre-index scan failed")
+			}
+		}
+
+		gated := &fakeConvAdapter{name: "probe", describeStarted: make(chan string, 1), describeGate: make(chan struct{})}
+		done := make(chan string)
+		go func() { done <- idx.Scan(gated, ref) }()
+		<-gated.describeStarted // scan is inside DescribeConversation, no lock held
+
+		// The watcher observes the deletion mid-scan (indexSink.Remove path).
+		removed := idx.RemoveByRef("probe", ref)
+		if preIndex && !removed {
+			t.Fatal("RemoveByRef did not find the pre-indexed entry")
+		}
+
+		close(gated.describeGate) // describe returns; scan tries to commit
+		if key := <-done; key != "" {
+			t.Fatalf("zombie: scan committed key %q after the ref was removed", key)
+		}
+		if n := idx.Count(); n != 0 {
+			t.Fatalf("zombie: %d conversation(s) indexed after removal", n)
+		}
+		if idx.LookupByConversationID("probe", "conv-1") != "" {
+			t.Fatal("zombie: conversation ID resolvable after removal")
+		}
+		if cmd := idx.LookupResumeCommand("probe", ref); len(cmd) != 0 {
+			t.Fatalf("zombie: resume command %v cached after removal", cmd)
+		}
+
+		// A fresh scan after the removal (file re-created) must index again:
+		// the generation guard only drops scans that predate the removal.
+		if key := idx.Scan(plain, ref); key == "" {
+			t.Fatal("post-removal rescan refused to index a re-created conversation")
+		}
+	}
+
+	t.Run("unindexed-ref", func(t *testing.T) { run(t, false) })
+	t.Run("pre-indexed-ref", func(t *testing.T) { run(t, true) })
 }
 
 // A context cancelled before scans run must leave the snapshot incomplete:

--- a/services/gmuxd/internal/conversations/index.go
+++ b/services/gmuxd/internal/conversations/index.go
@@ -49,6 +49,13 @@ type Index struct {
 	// conversation source is indexing the ref. Rendering the session list is
 	// a hot read path and must not re-read every dead conversation transcript.
 	resumeByRef map[string][]string
+	// removeGen counts Remove/RemoveByRef events per (adapter, ref). Scan
+	// snapshots it before its unlocked DescribeConversation and commits only
+	// if it is unchanged, so a watcher-observed deletion always beats an
+	// in-flight scan of the same ref — otherwise the scan's late Upsert would
+	// resurrect the deleted conversation until restart (zombie). The map only
+	// grows on removal events (manual rm, rotation), which are rare.
+	removeGen map[string]uint64
 	// snapshotDone flips to true once the initial full snapshot of every
 	// adapter ConversationSource has finished (Snapshot or StartSnapshot).
 	// Until then, a lookup miss means "not indexed yet", not "absent".
@@ -61,6 +68,7 @@ func New() *Index {
 		byKey:            make(map[string]Info),
 		byConversationID: make(map[string]string),
 		resumeByRef:      make(map[string][]string),
+		removeGen:        make(map[string]uint64),
 	}
 }
 
@@ -85,12 +93,6 @@ func (idx *Index) LookupResumeCommand(adapterName, ref string) []string {
 	idx.mu.RLock()
 	defer idx.mu.RUnlock()
 	return append([]string(nil), idx.resumeByRef[refKey(adapterName, ref)]...)
-}
-
-func (idx *Index) setResumeCommand(adapterName, ref string, command []string) {
-	idx.mu.Lock()
-	defer idx.mu.Unlock()
-	idx.resumeByRef[refKey(adapterName, ref)] = append([]string(nil), command...)
 }
 
 // Lookup returns the conversation info for an (adapter, key) pair.
@@ -125,7 +127,11 @@ func (idx *Index) LookupByConversationID(adapterName, conversationID string) str
 func (idx *Index) Upsert(info Info) string {
 	idx.mu.Lock()
 	defer idx.mu.Unlock()
+	return idx.upsertLocked(info)
+}
 
+// upsertLocked is Upsert's body; must be called with idx.mu held.
+func (idx *Index) upsertLocked(info Info) string {
 	// Callers that construct Info directly historically supplied only Slug.
 	// Keep that shorthand for titled conversations.
 	if info.Key == "" {
@@ -236,6 +242,11 @@ func (idx *Index) Scan(a adapter.Adapter, ref string) string {
 		return ""
 	}
 
+	// Snapshot the ref's removal generation before the unlocked describe:
+	// a Remove event that lands while the file is being read/parsed must
+	// win over this scan's results (commitScanLocked re-checks it).
+	gen := idx.refGeneration(a.Name(), ref)
+
 	convInfo, err := desc.DescribeConversation(ref)
 	if err != nil {
 		// Keep stale-good state on transient descriptor failures, matching the
@@ -248,13 +259,12 @@ func (idx *Index) Scan(a adapter.Adapter, ref string) string {
 	if resumer, ok := a.(adapter.Resumer); ok {
 		cmd = resumer.ResumeCommand(convInfo)
 	}
-	// Cache before the metadata/index eligibility checks below. The wire
-	// command contract depends only on ConversationDescriber + Resumer, while
-	// the URL index additionally requires cwd/title metadata.
-	idx.setResumeCommand(a.Name(), ref, cmd)
 
-	if convInfo.Cwd == "" {
-		return ""
+	addToIndex := convInfo.Cwd != ""
+	if _, ok := a.(adapter.Resumer); ok && len(cmd) == 0 {
+		// An empty command means the adapter considers this conversation
+		// non-resumable (empty/corrupted), so it stays out of the index.
+		addToIndex = false
 	}
 
 	displaySlug := convInfo.Slug
@@ -263,12 +273,6 @@ func (idx *Index) Scan(a adapter.Adapter, ref string) string {
 		// Untitled conversations still need an internal unique lookup key
 		// for UUID deep links, but that fallback must not surface as a URL slug.
 		key = adapter.Slugify(convInfo.ID)
-	}
-
-	if _, ok := a.(adapter.Resumer); ok && len(cmd) == 0 {
-		// An empty command means the adapter considers this conversation
-		// non-resumable (empty/corrupted), so it stays out of the index.
-		return ""
 	}
 
 	info := Info{
@@ -283,7 +287,32 @@ func (idx *Index) Scan(a adapter.Adapter, ref string) string {
 		Created:        convInfo.Created,
 		LastActivity:   convInfo.LastActivity,
 	}
-	return idx.Upsert(info)
+
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
+	if idx.removeGen[refKey(a.Name(), ref)] != gen {
+		// The ref was removed while this scan was describing it; the removal
+		// is authoritative. Committing anyway would resurrect a deleted
+		// conversation with no future event to clear it.
+		return ""
+	}
+	// Cache the resume command before the index eligibility checks above
+	// decided addToIndex. The wire command contract depends only on
+	// ConversationDescriber + Resumer, while the URL index additionally
+	// requires cwd/title metadata. Both writes happen under one lock hold so
+	// a Remove can never land between them.
+	idx.resumeByRef[refKey(a.Name(), ref)] = append([]string(nil), cmd...)
+	if !addToIndex {
+		return ""
+	}
+	return idx.upsertLocked(info)
+}
+
+// refGeneration returns the current removal generation for (adapter, ref).
+func (idx *Index) refGeneration(adapterName, ref string) uint64 {
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
+	return idx.removeGen[refKey(adapterName, ref)]
 }
 
 // Remove deletes a conversation from the index by conversation ID.
@@ -299,6 +328,7 @@ func (idx *Index) Remove(adapterName, conversationID string) bool {
 	delete(idx.byConversationID, tk)
 	if info, exists := idx.byKey[indexKey(adapterName, key)]; exists {
 		delete(idx.resumeByRef, refKey(adapterName, info.Ref))
+		idx.removeGen[refKey(adapterName, info.Ref)]++
 	}
 	delete(idx.byKey, indexKey(adapterName, key))
 	return true
@@ -320,6 +350,10 @@ func (idx *Index) Remove(adapterName, conversationID string) bool {
 func (idx *Index) RemoveByRef(adapterName, ref string) bool {
 	idx.mu.Lock()
 	defer idx.mu.Unlock()
+	// Bump the removal generation even when nothing is indexed yet: the
+	// entry may be mid-scan (describe in flight), and that scan's commit
+	// must observe this removal and drop its result.
+	idx.removeGen[refKey(adapterName, ref)]++
 	delete(idx.resumeByRef, refKey(adapterName, ref))
 	for key, info := range idx.byKey {
 		if info.Adapter != adapterName || info.Ref != ref {

--- a/services/gmuxd/internal/conversations/index.go
+++ b/services/gmuxd/internal/conversations/index.go
@@ -15,6 +15,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/gmuxapp/gmux/packages/adapter"
@@ -48,6 +49,10 @@ type Index struct {
 	// conversation source is indexing the ref. Rendering the session list is
 	// a hot read path and must not re-read every dead conversation transcript.
 	resumeByRef map[string][]string
+	// snapshotDone flips to true once the initial full snapshot of every
+	// adapter ConversationSource has finished (Snapshot or StartSnapshot).
+	// Until then, a lookup miss means "not indexed yet", not "absent".
+	snapshotDone atomic.Bool
 }
 
 // New creates an empty index.
@@ -72,9 +77,10 @@ func refKey(adapterName, ref string) string {
 }
 
 // LookupResumeCommand returns the command derived when the conversation ref
-// was last observed by its source. Snapshot populates this cache synchronously
-// before the daemon starts serving, and source upserts keep it current. The
-// returned slice is a copy so callers cannot mutate index state.
+// was last observed by its source. The startup snapshot populates this cache
+// progressively (it may still be running while the daemon serves — see
+// SnapshotComplete), and source upserts keep it current. The returned slice
+// is a copy so callers cannot mutate index state.
 func (idx *Index) LookupResumeCommand(adapterName, ref string) []string {
 	idx.mu.RLock()
 	defer idx.mu.RUnlock()
@@ -189,6 +195,18 @@ func (idx *Index) uniqueSlugLocked(adapterName, slug, conversationID string) str
 		}
 		slug = base + "-" + strconv.Itoa(i)
 	}
+}
+
+// SnapshotComplete reports whether the initial full snapshot across all
+// adapter ConversationSources has finished. While false, a lookup miss is
+// ambiguous: the conversation may simply not have been scanned yet, so
+// callers should surface "index still loading" instead of a hard not-found.
+func (idx *Index) SnapshotComplete() bool {
+	return idx.snapshotDone.Load()
+}
+
+func (idx *Index) markSnapshotComplete() {
+	idx.snapshotDone.Store(true)
 }
 
 // Count returns the number of indexed conversations.

--- a/services/gmuxd/internal/conversations/sources.go
+++ b/services/gmuxd/internal/conversations/sources.go
@@ -4,10 +4,15 @@ import (
 	"context"
 	"errors"
 	"log"
+	"sync"
 
 	"github.com/gmuxapp/gmux/packages/adapter"
 	"github.com/gmuxapp/gmux/packages/adapter/adapters"
 )
+
+// allAdapters is the adapter enumeration seam; overridden in tests to
+// exercise snapshot scheduling with synthetic sources.
+var allAdapters = adapters.AllAdapters
 
 // indexSink bridges one adapter's ConversationSource to the index.
 // onRemoved, if set, additionally observes every conversation-gone event —
@@ -36,11 +41,73 @@ func (s indexSink) Remove(ref string) {
 // Snapshot populates the index from every adapter ConversationSource.
 // Synchronous; call once at startup before consumers read the index.
 func (idx *Index) Snapshot() {
-	for _, a := range adapters.AllAdapters() {
+	for _, a := range allAdapters() {
 		if src, ok := a.(adapter.ConversationSource); ok {
 			src.SnapshotConversations(indexSink{idx: idx, a: a})
 		}
 	}
+	idx.markSnapshotComplete()
+}
+
+// DefaultSnapshotWorkers bounds how many adapter snapshot scans run
+// concurrently in StartSnapshot. Each scan is one adapter's full-history
+// walk+parse (file I/O heavy); two in flight overlaps the large corpora
+// without saturating the disk during daemon startup.
+const DefaultSnapshotWorkers = 2
+
+// StartSnapshot populates the index from every adapter ConversationSource in
+// the background, with at most `workers` adapter scans in flight, and returns
+// immediately. Conversations become visible progressively as each ref is
+// scanned; onAdapterIndexed (if non-nil) runs after each adapter's scan
+// completes, and onComplete (if non-nil) runs once after all adapters finish
+// — at which point SnapshotComplete reports true. Callbacks run on snapshot
+// goroutines and must be cheap and concurrency-safe.
+//
+// StartSnapshot is safe to run while WatchSources is feeding the same index:
+// Index mutations are mutex-serialized and Upsert is keyed by adapter-native
+// conversation ID, so a ref observed by both the scan and a watcher resolves
+// to one entry (last describe wins — both describe the same file). Cancelling
+// ctx before an adapter's scan starts skips it and leaves the snapshot
+// incomplete; an in-progress scan is not interruptible (the adapter API has
+// no context) but the daemon is exiting anyway.
+func (idx *Index) StartSnapshot(ctx context.Context, workers int, onAdapterIndexed func(adapterName string), onComplete func()) {
+	if workers < 1 {
+		workers = 1
+	}
+	sem := make(chan struct{}, workers)
+	var wg sync.WaitGroup
+	for _, a := range allAdapters() {
+		src, ok := a.(adapter.ConversationSource)
+		if !ok {
+			continue
+		}
+		wg.Add(1)
+		go func(a adapter.Adapter, src adapter.ConversationSource) {
+			defer wg.Done()
+			select {
+			case sem <- struct{}{}:
+			case <-ctx.Done():
+				return
+			}
+			defer func() { <-sem }()
+			src.SnapshotConversations(indexSink{idx: idx, a: a})
+			if onAdapterIndexed != nil {
+				onAdapterIndexed(a.Name())
+			}
+		}(a, src)
+	}
+	go func() {
+		wg.Wait()
+		if ctx.Err() != nil {
+			// Shutdown raced the scan: at least one adapter may have been
+			// skipped, so the index must not advertise completeness.
+			return
+		}
+		idx.markSnapshotComplete()
+		if onComplete != nil {
+			onComplete()
+		}
+	}()
 }
 
 // WatchSources starts every adapter ConversationSource in its own goroutine,
@@ -49,7 +116,7 @@ func (idx *Index) Snapshot() {
 // to disappear — whether or not it was indexed. cmd/gmuxd wires this to
 // retire dead sessions backed by the deleted conversation.
 func (idx *Index) WatchSources(ctx context.Context, onRemoved func(adapterName, ref string)) {
-	for _, a := range adapters.AllAdapters() {
+	for _, a := range allAdapters() {
 		src, ok := a.(adapter.ConversationSource)
 		if !ok {
 			continue


### PR DESCRIPTION
## Problem

Startup conversation discovery (`convIndex.Snapshot()`) synchronously walked and fully parsed every adapter conversation before any listener bound. On a real 2786-conversation corpus that blocked first `/v1/health`, SSE bootstrap, CLI `gmux start` readiness, and every REST route for **33 s** (system resource profile §1, risk #5). The cost scales with the user's conversation history, not gmux state.

## Change

Bind listeners promptly; index in the background with bounded concurrency:

- **`Index.StartSnapshot(ctx, workers, onAdapterIndexed, onComplete)`** scans adapter `ConversationSource`s on background goroutines, at most 2 adapter scans in flight. It starts *after* `StartOwnedTriggers`, so the source watchers are already running — a conversation created/changed during the scan is observed rather than lost (strictly narrower than the old snapshot-then-watch gap). Ownership settlement (`bootstrapOwnership`) still precedes discovery, so autostart contenders that yield to a healthy incumbent pay nothing (#460/#461 semantics unchanged).
- **Coherent intermediate state:** sessions serve immediately from centralstore — titles stay runner-reported last-known-good (#508; this index never writes the store) — and gain resume commands progressively. Each adapter completion marks the composer dirty, so SSE subscribers see the enrichment without reconnecting.
- **Explicit signals:** `/v1/health` gains `conversation_index: {status: indexing|ready, indexed}`; `/v1/conversations/{adapter}/{slug}` answers `503 indexing` + `Retry-After` instead of a false 404 while the scan hasn't established authority over absence; found entries serve immediately.
- **No races:** index mutations remain mutex-serialized and `Upsert` is keyed by adapter-native conversation ID, so watcher events racing the scan neither duplicate nor lose entries. A snapshot interrupted by shutdown never reports complete. The index is memory-only, so a restart mid-indexing simply rescans.

## Proof (3000×200 KB synthetic pi corpus, isolated HOME/state, warm cache)

| metric | blocking (main) | this PR |
|---|---|---|
| spawn → first `/v1/health` 200 | 4.15 s | **0.06 s** |
| SSE `/v1/events` first frame after bind | 8 ms | 8 ms |
| background index complete | — | 4.1 s (`indexed 3000 in 4.07s`) |

- **Differential:** after both daemons finish indexing, all 3000 `/v1/conversations/pi/<slug>` responses are byte-identical between blocking and async binaries (0 mismatches).
- **Mid-indexing restart:** `kill -9` at ~1 s, restart → converges to `{status: ready, indexed: 3000}`.
- **Intermediate state observed live:** health during scan reported `{indexing, indexed: 17}`; unknown slug returned `503 indexing`, then `404` post-completion; known slug `200`.
- **Race coverage:** new tests for bounded concurrency, blocking/async differential state (incl. slug-collision suffixes), concurrent watcher-style upserts during the scan (no dup/lost of 44 IDs), and cancelled-context incompleteness. `go test -race -count=3 ./services/gmuxd/internal/conversations/` and `go test -race ./services/gmuxd/cmd/gmuxd/` pass; full `./services/gmuxd/...` green.

Follows the phase-1 rollout ("A: serve-first, async full index, explicit status") recommended by the adapter-reindex startup assessment; the durable adapter-owned index (phase C) remains future work.