### PR TITLE
perf(web): incremental reconciliation of protocol-3 session snapshots

### DIFF
--- a/apps/gmux-web/src/family.test.ts
+++ b/apps/gmux-web/src/family.test.ts
@@ -412,3 +412,53 @@ describe('childTrailTitle', () => {
     expect(childTrailTitle(root, [root], mid)).toBe('root › mid')
   })
 })
+
+describe('familyIndex incremental patching (structural sharing)', () => {
+  it('re-keys the cache on patch: the old array must rebuild, never alias the patched index', () => {
+    // The in-place patch mutates the previous snapshot's index maps to
+    // describe the *new* array. The WeakMap entry for the old array is
+    // deleted at that moment; if a mutant drops that delete, asking for the
+    // old array's index again would hand back the patched (aliased) maps,
+    // whose rows belong to the new snapshot (stale reads). Unreachable from today's
+    // production call sites (they always pass the live sessions.value), but
+    // pinned here so a future call-site refactor can't silently regress.
+    const root = agent('root')
+    const child = agent('child', 'root', { unread: false })
+    const prev = [root, child]
+    const prevIndex = familyIndex(prev)
+    expect(prevIndex.byId.get('child')).toBe(child)
+
+    // Replaced-rows-only successor with family facts intact → patched, and
+    // the same index object is re-keyed onto the new array.
+    const childFlipped = { ...child, unread: true, unread_token: 'tok' }
+    const next = [root, childFlipped]
+    const nextIndex = familyIndex(next)
+    expect(nextIndex).toBe(prevIndex)
+    expect(nextIndex.byId.get('child')).toBe(childFlipped)
+
+    // Asking for the old array again must yield an index that describes
+    // exactly its own rows. (Mechanically it may be the same object patched
+    // back — the ping-pong re-patch — which is fine; what the deleted cache
+    // entry guarantees is that it can never be served *stale*, still holding
+    // the new snapshot's rows. A mutant dropping the delete returns the
+    // aliased index with `childFlipped` here and fails.)
+    const rebuilt = familyIndex(prev)
+    expect(rebuilt.byId.get('child')).toBe(child)
+    expect(rebuilt.rootById.get('child')).toBe(root)
+
+    // And the ping-pong stays coherent: querying the new array again after
+    // the old one was re-indexed still yields an index of the new rows.
+    expect(familyIndex(next).byId.get('child')).toBe(childFlipped)
+  })
+
+  it('family-fact changes rebuild instead of patching', () => {
+    const root = agent('root')
+    const child = agent('child', 'root')
+    const prev = [root, child]
+    const prevIndex = familyIndex(prev)
+    const next = [root, { ...child, parent_session_id: undefined }]
+    const nextIndex = familyIndex(next)
+    expect(nextIndex).not.toBe(prevIndex)
+    expect(nextIndex.childIds.has('child')).toBe(false)
+  })
+})

--- a/apps/gmux-web/src/family.ts
+++ b/apps/gmux-web/src/family.ts
@@ -1,7 +1,8 @@
+import { sessionPresentationState } from './presentation'
 import { sidebarProjectForSession } from './projects'
+import { diffReplacedRows, FAMILY_FACT_KEYS, factsUnchanged } from './reconcile'
 // Type-only: erased at emit, so `family.ts` stays runtime-free of the store.
 import type { DotState } from './store'
-import { sessionPresentationState } from './presentation'
 import type { ProjectItem, Session } from './types'
 
 /** Resolve one potential task-family edge without trusting the rest of the
@@ -80,13 +81,58 @@ export function createFamilyIndex(sessions: readonly Session[]): FamilyIndex {
   return { byId, childIds, childrenByParent, rootById }
 }
 
+/** The most recently indexed snapshot, kept for incremental patching: the
+ * protocol-3 steady state is a full-list replacement whose rows are mostly
+ * the *same objects* after snapshot reconciliation (see reconcile.ts), so the
+ * previous index can usually be patched in O(changed + N identity checks)
+ * instead of re-walking every ancestry. */
+let lastIndexed: { sessions: readonly Session[]; index: FamilyIndex } | null = null
+
+/** Patch `index` (built for `prev`) in place so it describes `next`, or
+ * return null when `next` is not a replaced-rows-only successor of `prev`
+ * with all family facts (parentage, agent-ness, recency ordering keys)
+ * preserved. Mutation is safe because the caller re-keys the cache: the
+ * entry for `prev` is deleted, so a later `familyIndex(prev)` rebuilds
+ * rather than seeing the patched maps. */
+function patchFamilyIndex(
+  prev: readonly Session[],
+  index: FamilyIndex,
+  next: readonly Session[],
+): FamilyIndex | null {
+  const replaced = diffReplacedRows(prev, next)
+  if (!replaced || !factsUnchanged(replaced, FAMILY_FACT_KEYS)) return null
+  if (replaced.size === 0) return index
+  const byId = index.byId as Map<string, Session>
+  for (const n of replaced.values()) byId.set(n.id, n)
+  // Root pointers and child lists hold row objects; swap replaced ones.
+  // Topology and sort order are unchanged (family facts held).
+  const rootById = index.rootById as Map<string, Session>
+  for (const [id, root] of rootById) {
+    const n = replaced.get(root)
+    if (n) rootById.set(id, n)
+  }
+  for (const children of (index.childrenByParent as Map<string, Session[]>).values()) {
+    for (let i = 0; i < children.length; i++) {
+      const n = replaced.get(children[i])
+      if (n) children[i] = n
+    }
+  }
+  return index
+}
+
 /** Return the projection index cached for this exact session-list snapshot. */
 export function familyIndex(sessions: readonly Session[]): FamilyIndex {
   const cached = familyIndexCache.get(sessions)
   if (cached) return cached
-  const created = createFamilyIndex(sessions)
-  familyIndexCache.set(sessions, created)
-  return created
+  let index: FamilyIndex | null = null
+  if (lastIndexed && lastIndexed.sessions !== sessions) {
+    index = patchFamilyIndex(lastIndexed.sessions, lastIndexed.index, sessions)
+    if (index) familyIndexCache.delete(lastIndexed.sessions)
+  }
+  index ??= createFamilyIndex(sessions)
+  familyIndexCache.set(sessions, index)
+  lastIndexed = { sessions, index }
+  return index
 }
 
 type FamilySource = readonly Session[] | FamilyIndex

--- a/apps/gmux-web/src/reconcile-differential.test.ts
+++ b/apps/gmux-web/src/reconcile-differential.test.ts
@@ -1,0 +1,292 @@
+/** Differential/property tests: the incremental (structurally shared,
+ * memo-fast-pathed) projections must produce exactly the same *values* as a
+ * non-incremental recompute, across randomized mutation sequences applied
+ * through the production snapshot path (`applySessionsSnapshot`, i.e. what a
+ * protocol-3 ready commit calls), including row removal, insertion, reorder,
+ * family moves, peer merges, and full epoch resets through the protocol-3
+ * begin/batch/ready staging.
+ *
+ * Every step re-encodes ALL rows (fresh object identities, like the server
+ * does), so the equality fast path — not accidental identity — is what's
+ * under test. The reference (`_uncachedProjections`) runs the same pure
+ * building blocks with a freshly built family index and no memos.
+ *
+ * A second suite pins the identity/rerender contract: an identical
+ * re-encoded snapshot must not change any projection identity (zero signal
+ * recomputation propagates), and a one-row flip must change only the
+ * affected slices.
+ */
+
+import type { Session as ProtocolSession } from '@gmux/protocol'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { familyIndex } from './family'
+import {
+  _pendingMutations, _rawSessions, _setRawWorld, _uncachedProjections,appendSessionsBootstrap, 
+  applySessionsSnapshot, beginSessionsBootstrap,
+  type DayBucket, familyActivityById, familyDotById, folders, homePartition,
+  readySessionsBootstrap, resetSessionsTransport, sessions, sessionsLoaded,
+  sidebarActivity, sidebarSessions, unreadCount, urlHash, urlPath, urlSearch,
+  worldLoaded,
+} from './store'
+import { makeFixtureWorld, mulberry32 } from './store-perf-fixture'
+import type { Folder, Session } from './types'
+
+;(globalThis as { window?: unknown }).window ??= globalThis
+
+// Pinned clock: partition buckets are day-relative, and the differential
+// comparison recomputes them at "now". Mid-January keeps the fixture's
+// 14-day activity window spread across today/named/dated buckets.
+const NOW = Date.parse('2026-01-12T15:00:00Z')
+
+beforeEach(() => {
+  vi.useFakeTimers({ now: NOW })
+  resetSessionsTransport()
+  _rawSessions.value = []
+  _pendingMutations.value = []
+  _setRawWorld({ projects: [], peers: [], peerProjects: {} })
+  sessionsLoaded.value = true
+  worldLoaded.value = true
+  urlPath.value = '/'
+  urlSearch.value = ''
+  urlHash.value = ''
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+/** Server-side re-encode: same values, all-new identities. */
+function reencode(s: Session): Session {
+  return {
+    ...s,
+    command: [...s.command],
+    remotes: s.remotes ? { ...s.remotes } : s.remotes,
+    status: s.status ? { ...s.status } : s.status,
+  }
+}
+
+const bucketsComparable = (bs: DayBucket[]) =>
+  bs.map(b => ({ label: b.label, kind: b.kind, sessions: b.sessions }))
+
+const foldersComparable = (fs: Folder[]) =>
+  fs.map(f => ({ ...f }))
+
+function expectProjectionsMatchUncached() {
+  const ref = _uncachedProjections(Date.now())
+  // Deep value equality against the uncached recompute. Same snapshot row
+  // objects flow through both, so element identity holds too.
+  expect(sidebarSessions.value).toEqual(ref.sidebarSessions)
+  for (let i = 0; i < ref.sidebarSessions.length; i++) {
+    expect(sidebarSessions.value[i]).toBe(ref.sidebarSessions[i])
+  }
+  expect(foldersComparable(folders.value)).toEqual(foldersComparable(ref.folders))
+  expect(unreadCount.value).toBe(ref.unreadCount)
+  expect(bucketsComparable(sidebarActivity.value)).toEqual(bucketsComparable(ref.sidebarActivity))
+  expect(bucketsComparable(homePartition.value)).toEqual(bucketsComparable(ref.homePartition))
+  // The patched family index must describe exactly the current snapshot.
+  const idx = familyIndex(sessions.value)
+  for (const s of sessions.value) expect(idx.byId.get(s.id)).toBe(s)
+  void familyDotById.value
+  void familyActivityById.value
+}
+
+let epoch = 1000
+
+/** Full epoch reset through the protocol-3 staging path: begin → batches →
+ * ready, exactly like an SSE reconnect replaying the world. */
+function commitViaProtocol(rows: Session[]) {
+  beginSessionsBootstrap(3, ++epoch)
+  const mid = Math.floor(rows.length / 2)
+  appendSessionsBootstrap(epoch, rows.slice(0, mid) as unknown as ProtocolSession[], 1)
+  appendSessionsBootstrap(epoch, rows.slice(mid) as unknown as ProtocolSession[], 1)
+  expect(readySessionsBootstrap(epoch)).toBe(true)
+}
+
+describe('incremental projections ≡ uncached recompute (randomized sequences)', () => {
+  for (const seed of [11, 29, 47, 101]) {
+    it(`mutation sequence seed=${seed}`, () => {
+      const rnd = mulberry32(seed * 104729)
+      const n = 150 + Math.floor(rnd() * 250)
+      const w = makeFixtureWorld(seed, n)
+      _setRawWorld({
+        projects: w.projects, peers: w.peers, peerProjects: w.peerProjects,
+        health: { hostname: 'localbox' } as never,
+      })
+      applySessionsSnapshot(w.sessions.map(reencode))
+      expectProjectionsMatchUncached()
+
+      let rows = sessions.value.slice()
+      const pickIdx = () => Math.floor(rnd() * rows.length)
+      let counter = 0
+
+      for (let step = 0; step < 60; step++) {
+        // Every step ships a full re-encoded snapshot (protocol semantics).
+        rows = rows.map(reencode)
+        const op = rnd()
+        const i = pickIdx()
+        const t = rows[i]
+        if (op < 0.2) {
+          // content-only flips: unread, title, status
+          const r = rnd()
+          rows[i] = r < 0.4
+            ? { ...t, unread: !t.unread, unread_token: `tok-${counter++}` }
+            : r < 0.7
+              ? { ...t, title: `title ${counter++}`, subtitle: `sub ${counter}` }
+              : { ...t, status: { active: rnd() < 0.5, error: rnd() < 0.3 } }
+        } else if (op < 0.3) {
+          // activity bump (moves partition buckets / ordering)
+          rows[i] = { ...t, last_output_at: new Date(NOW - Math.floor(rnd() * 12 * 86400_000)).toISOString() }
+        } else if (op < 0.4) {
+          // lifecycle: death/resurrection
+          rows[i] = t.alive
+            ? { ...t, alive: false, resumable: rnd() < 0.5, status: null, exited_at: new Date(NOW).toISOString() }
+            : { ...t, alive: true, resumable: false, exited_at: null }
+        } else if (op < 0.5) {
+          // family move: reparent to a random row, or promote to root
+          const parent = rows[pickIdx()]
+          rows[i] = rnd() < 0.3
+            ? { ...t, parent_session_id: undefined }
+            : { ...t, parent_session_id: parent.id }
+        } else if (op < 0.58) {
+          rows[i] = { ...t, semantic_agent: t.semantic_agent ? undefined : true }
+        } else if (op < 0.68) {
+          // peer merge/move: reassign owning host, as a hub picking up a
+          // spoke's rows (or dropping them back to local)
+          const peers = [undefined, 'hostA', 'hostB', 'devbox'] as const
+          rows[i] = { ...t, peer: peers[Math.floor(rnd() * peers.length)] }
+        } else if (op < 0.76) {
+          // project restamp / reorder within folder
+          rows[i] = rnd() < 0.5
+            ? { ...t, project_slug: `p${Math.floor(rnd() * 10)}`, project_index: Math.floor(rnd() * 10) }
+            : { ...t, project_index: Math.floor(rnd() * 10) }
+        } else if (op < 0.84) {
+          // removal
+          rows.splice(i, 1)
+        } else if (op < 0.9) {
+          // insertion (new session appears)
+          rows.splice(Math.floor(rnd() * (rows.length + 1)), 0,
+            { ...reencode(t), id: `new-${seed}-${counter++}`, parent_session_id: undefined })
+        } else if (op < 0.96) {
+          // reorder: server-side placement shuffle
+          for (let k = rows.length - 1; k > 0; k--) {
+            const j = Math.floor(rnd() * (k + 1))
+            ;[rows[k], rows[j]] = [rows[j], rows[k]]
+          }
+        } else {
+          // epoch reset: full replay through begin/batch/ready staging
+          resetSessionsTransport()
+          commitViaProtocol(rows)
+          expectProjectionsMatchUncached()
+          rows = sessions.value.slice()
+          continue
+        }
+        applySessionsSnapshot(rows.slice())
+        expectProjectionsMatchUncached()
+        rows = sessions.value.slice()
+      }
+    })
+  }
+})
+
+describe('identity preservation (rerender/recompute granularity)', () => {
+  function load(n: number) {
+    const w = makeFixtureWorld(1234, n)
+    _setRawWorld({
+      projects: w.projects, peers: w.peers, peerProjects: w.peerProjects,
+      health: { hostname: 'localbox' } as never,
+    })
+    applySessionsSnapshot(w.sessions.map(reencode))
+    return w
+  }
+
+  it('an identical re-encoded snapshot is a complete no-op: zero recomputation propagates', () => {
+    load(1500)
+    const before = {
+      raw: _rawSessions.value,
+      sidebar: sidebarSessions.value,
+      folders: folders.value,
+      unread: unreadCount.value,
+      activity: sidebarActivity.value,
+      home: homePartition.value,
+      dots: familyDotById.value,
+      index: familyIndex(sessions.value),
+    }
+    // Count actual signal recomputations via subscriptions.
+    let notified = 0
+    const disposers = [sidebarSessions, folders, sidebarActivity, homePartition].map(sig =>
+      sig.subscribe(() => { notified++ }))
+    notified = 0 // discard the initial subscription callbacks
+    applySessionsSnapshot(_rawSessions.value.map(reencode))
+    expect(_rawSessions.value).toBe(before.raw) // array identity preserved
+    expect(sidebarSessions.value).toBe(before.sidebar)
+    expect(folders.value).toBe(before.folders)
+    expect(unreadCount.value).toBe(before.unread)
+    expect(sidebarActivity.value).toBe(before.activity)
+    expect(homePartition.value).toBe(before.home)
+    expect(familyDotById.value).toBe(before.dots)
+    expect(familyIndex(sessions.value)).toBe(before.index)
+    expect(notified).toBe(0)
+    for (const d of disposers) d()
+  })
+
+  it('a one-row flip changes only the affected projection slices', () => {
+    const w = load(1500)
+    const beforeRaw = _rawSessions.value
+    const beforeFolders = folders.value
+    const beforeSidebar = sidebarSessions.value
+    const beforeActivity = sidebarActivity.value
+    const beforeIndex = familyIndex(sessions.value)
+
+    const next = _rawSessions.value.map(reencode)
+    const idx = next.findIndex(s => s.id === w.mutationTargetId)
+    next[idx] = { ...next[idx], unread: !next[idx].unread, unread_token: 'flip' }
+    applySessionsSnapshot(next)
+
+    // Raw: every row but the flipped one keeps identity.
+    const raw = _rawSessions.value
+    expect(raw).not.toBe(beforeRaw)
+    let changedRows = 0
+    for (let i = 0; i < raw.length; i++) if (raw[i] !== beforeRaw[i]) changedRows++
+    expect(changedRows).toBe(1)
+    const newRow = raw[idx]
+
+    // Family index is patched, not rebuilt (unread is not a family fact).
+    expect(familyIndex(sessions.value)).toBe(beforeIndex)
+
+    // Sidebar list: replaced-only substitution.
+    const sidebar = sidebarSessions.value
+    let changedSidebar = 0
+    for (let i = 0; i < sidebar.length; i++) if (sidebar[i] !== beforeSidebar[i]) changedSidebar++
+    expect(changedSidebar).toBe(1)
+
+    // Folders: only the folder containing the flipped row gets a new object;
+    // every other Folder (and its sessions array) keeps identity, so
+    // identity-memoized folder components skip N-1 folders.
+    const fs = folders.value
+    expect(fs.length).toBe(beforeFolders.length)
+    const changedFolders = fs.filter((f, i) => f !== beforeFolders[i])
+    expect(changedFolders.length).toBe(1)
+    expect(changedFolders[0].sessions).toContain(newRow)
+
+    // Day buckets: only the bucket holding the flipped row changed.
+    const bs = sidebarActivity.value
+    const changedBuckets = bs.filter((b, i) => b !== beforeActivity[i])
+    expect(changedBuckets.length).toBe(1)
+    expect(changedBuckets[0].sessions).toContain(newRow)
+  })
+
+  it('fact changes disable the fast path (a mutant reusing structure must fail)', () => {
+    load(800)
+    const beforeFolders = folders.value
+    // Restamp one row into a different project: folder membership must move.
+    const next = _rawSessions.value.map(reencode)
+    const i = next.findIndex(s => !s.peer && s.project_slug === 'p1' && !s.parent_session_id && s.alive)
+    expect(i).toBeGreaterThanOrEqual(0)
+    next[i] = { ...next[i], project_slug: 'p2', project_index: 0 }
+    applySessionsSnapshot(next)
+    const ref = _uncachedProjections(Date.now())
+    expect(foldersComparable(folders.value)).toEqual(foldersComparable(ref.folders))
+    expect(folders.value.find(f => f.key === '::p2')!.sessions.map(s => s.id))
+      .not.toEqual(beforeFolders.find(f => f.key === '::p2')!.sessions.map(s => s.id))
+  })
+})

--- a/apps/gmux-web/src/reconcile-differential.test.ts
+++ b/apps/gmux-web/src/reconcile-differential.test.ts
@@ -103,10 +103,20 @@ function commitViaProtocol(rows: Session[]) {
 }
 
 describe('incremental projections ≡ uncached recompute (randomized sequences)', () => {
+  // CI budget: every step runs the full uncached oracle (O(N·projections))
+  // plus deep toEqual diffs, and CI runners measured ~15–25× slower than a
+  // dev machine (seed=29 took 17 s on CI at the original N=150–400 while
+  // running ~0.6 s locally). Coverage lives in the *operation mix* and step
+  // count, not in N — every structural shape (families, peers, transitional
+  // placements, strays) exists in the fixture well below N=100 — so the
+  // worlds are kept small (N≈60–160, still multi-host with dozens of
+  // families) and each seed gets an explicit 30 s timeout: ~120 ms locally
+  // × 25 CI factor ≈ 3 s, a 10× margin.
+  const DIFF_TEST_TIMEOUT_MS = 30_000
   for (const seed of [11, 29, 47, 101]) {
-    it(`mutation sequence seed=${seed}`, () => {
+    it(`mutation sequence seed=${seed}`, { timeout: DIFF_TEST_TIMEOUT_MS }, () => {
       const rnd = mulberry32(seed * 104729)
-      const n = 150 + Math.floor(rnd() * 250)
+      const n = 60 + Math.floor(rnd() * 100)
       const w = makeFixtureWorld(seed, n)
       _setRawWorld({
         projects: w.projects, peers: w.peers, peerProjects: w.peerProjects,
@@ -119,7 +129,7 @@ describe('incremental projections ≡ uncached recompute (randomized sequences)'
       const pickIdx = () => Math.floor(rnd() * rows.length)
       let counter = 0
 
-      for (let step = 0; step < 60; step++) {
+      for (let step = 0; step < 50; step++) {
         // Every step ships a full re-encoded snapshot (protocol semantics).
         rows = rows.map(reencode)
         const op = rnd()
@@ -273,6 +283,34 @@ describe('identity preservation (rerender/recompute granularity)', () => {
     const changedBuckets = bs.filter((b, i) => b !== beforeActivity[i])
     expect(changedBuckets.length).toBe(1)
     expect(changedBuckets[0].sessions).toContain(newRow)
+  })
+
+  it('identical re-broadcast after midnight refreshes day-partition labels', () => {
+    // Reviewer-minimized regression (review-pr-518.md F2): with structural
+    // sharing, a byte-identical snapshot commits as an identity no-op, so
+    // day-relative labels must depend on an explicit clock input instead of
+    // riding on array-identity churn. Production trigger: SSE reconnect
+    // replaying an unchanged world after the machine slept across local
+    // midnight. Failed at 15575d6f; passed at parent d893a120.
+    load(40)
+    const labelsBefore = {
+      activity: sidebarActivity.value.map(b => b.label),
+      home: homePartition.value.map(b => b.label),
+    }
+    vi.setSystemTime(NOW + 24 * 60 * 60 * 1000)
+    applySessionsSnapshot(_rawSessions.value.map(reencode))
+    // The oracle recomputes at the new clock; the incremental path must agree.
+    const ref = _uncachedProjections(Date.now())
+    expect(bucketsComparable(sidebarActivity.value)).toEqual(bucketsComparable(ref.sidebarActivity))
+    expect(bucketsComparable(homePartition.value)).toEqual(bucketsComparable(ref.homePartition))
+    // And the day actually moved: yesterday's bucket appears, labels shift.
+    expect(sidebarActivity.value.map(b => b.label)).not.toEqual(labelsBefore.activity)
+    expect(homePartition.value.map(b => b.label)).not.toEqual(labelsBefore.home)
+    expect(sidebarActivity.value.some(b => b.label === 'Yesterday')).toBe(true)
+    // Everything not day-relative stays a no-op: rows and folders keep identity.
+    const raw = _rawSessions.value
+    applySessionsSnapshot(raw.map(reencode))
+    expect(_rawSessions.value).toBe(raw)
   })
 
   it('fact changes disable the fast path (a mutant reusing structure must fail)', () => {

--- a/apps/gmux-web/src/reconcile.test.ts
+++ b/apps/gmux-web/src/reconcile.test.ts
@@ -1,0 +1,227 @@
+/** Unit + mutation-hardening tests for snapshot reconciliation.
+ *
+ * The equality fast path is the dangerous part of structural sharing: a
+ * comparator that ignores a field would *reuse* a row that actually changed,
+ * and the UI would silently stop updating that field. These tests flip every
+ * `Session` field (and every nested `status`/`command`/`remotes` variant)
+ * and assert the changed row is never reused — a mutant comparator that
+ * drops any field check fails here deterministically.
+ */
+import { describe, expect, it } from 'vitest'
+import {
+  diffReplacedRows, factsUnchanged, reconcileSessions, SESSION_KEYS,
+  sessionRowEquals, substituteRows,
+} from './reconcile'
+import type { Session } from './types'
+
+/** Fully populated row: every optional field present, so a mutant that only
+ * compares "fields that happen to be set" still gets caught per field. */
+function fullRow(id: string): Session {
+  return {
+    id,
+    peer: 'hostA',
+    created_at: '2026-01-01T00:00:00Z',
+    command: ['pi', '--flag'],
+    cwd: '/work/p1',
+    workspace_root: '/work',
+    remotes: { origin: 'git@x:y.git' },
+    adapter: 'pi',
+    drive_mode: 'terminal',
+    parent_session_id: 'parent-1',
+    launched_from_session_id: 'launcher-1',
+    semantic_agent: true,
+    alive: true,
+    pid: 42,
+    exit_code: null,
+    started_at: '2026-01-01T00:00:01Z',
+    exited_at: null,
+    title: 'a title',
+    subtitle: 'a subtitle',
+    status: { active: true, error: false, interrupted: false },
+    unread: false,
+    unread_token: 'tok-1',
+    resumable: true,
+    last_output_at: '2026-01-02T00:00:00Z',
+    socket_path: '/tmp/s.sock',
+    terminal_cols: 80,
+    terminal_rows: 24,
+    slug: 'a-title',
+    conversation_file: '/conv/1.jsonl',
+    runner_version: '1.2.3',
+    binary_hash: 'abc',
+    project_slug: 'p1',
+    project_index: 3,
+  }
+}
+
+/** Re-encode: what the server does every snapshot — same values, all-new
+ * object identities (including nested ones). */
+function reencode(s: Session): Session {
+  return {
+    ...s,
+    command: [...s.command],
+    remotes: s.remotes ? { ...s.remotes } : s.remotes,
+    status: s.status ? { ...s.status } : s.status,
+  }
+}
+
+/** One changed variant per field (plus extra nested variants below). */
+function mutate(base: Session, key: keyof Session): Session {
+  const next = reencode(base)
+  const v = base[key]
+  let changed: unknown
+  switch (typeof v) {
+    case 'string': changed = `${v}-changed`; break
+    case 'boolean': changed = !v; break
+    case 'number': changed = (v as number) + 1; break
+    default:
+      if (key === 'command') changed = [...base.command, 'extra']
+      else if (key === 'remotes') changed = { ...base.remotes, upstream: 'new' }
+      else if (key === 'status') changed = { ...base.status!, active: !base.status!.active }
+      else if (v === null || v === undefined) {
+        // Nullable scalar: give it a value of the field's type.
+        changed = key === 'pid' || key === 'exit_code' ? 7 : '2026-02-02T00:00:00Z'
+      } else changed = `${String(v)}-changed`
+  }
+  ;(next as unknown as Record<string, unknown>)[key as string] = changed
+  return next
+}
+
+describe('sessionRowEquals', () => {
+  it('re-encoded identical rows are equal', () => {
+    const a = fullRow('s1')
+    expect(sessionRowEquals(a, reencode(a))).toBe(true)
+  })
+
+  it('sparse rows (optionals absent) equal their re-encode', () => {
+    const sparse: Session = {
+      id: 's', created_at: 'c', command: [], cwd: '', adapter: 'shell',
+      alive: false, pid: null, exit_code: 1, started_at: 'c', exited_at: 'e',
+      title: 't', subtitle: '', status: null, unread: false, socket_path: '',
+    }
+    expect(sessionRowEquals(sparse, reencode(sparse))).toBe(true)
+    expect(sessionRowEquals(sparse, { ...sparse, status: { active: false } })).toBe(false)
+    expect(sessionRowEquals({ ...sparse, remotes: { a: 'b' } }, sparse)).toBe(false)
+  })
+
+  // Mutation hardening: every field, one at a time. A comparator mutant that
+  // stops checking any field fails the corresponding case.
+  for (const key of SESSION_KEYS) {
+    it(`detects a change in '${String(key)}'`, () => {
+      const a = fullRow('s1')
+      const b = mutate(a, key)
+      expect(b).not.toEqual(a) // the mutation itself must be real
+      expect(sessionRowEquals(a, b)).toBe(false)
+      expect(sessionRowEquals(b, a)).toBe(false)
+    })
+  }
+
+  it('detects nested variants: command element, remotes value/removal, status flags', () => {
+    const a = fullRow('s1')
+    expect(sessionRowEquals(a, { ...reencode(a), command: ['pi', '--other'] })).toBe(false)
+    expect(sessionRowEquals(a, { ...reencode(a), remotes: { origin: 'other' } })).toBe(false)
+    expect(sessionRowEquals(a, { ...reencode(a), remotes: {} })).toBe(false)
+    expect(sessionRowEquals(a, { ...reencode(a), remotes: undefined })).toBe(false)
+    expect(sessionRowEquals(a, { ...reencode(a), status: { ...a.status!, error: true } })).toBe(false)
+    expect(sessionRowEquals(a, { ...reencode(a), status: { ...a.status!, interrupted: true } })).toBe(false)
+    expect(sessionRowEquals(a, { ...reencode(a), status: null })).toBe(false)
+  })
+})
+
+describe('reconcileSessions', () => {
+  const rows = [fullRow('a'), { ...fullRow('b'), peer: undefined }, fullRow('c')]
+
+  it('returns the previous array identity for an identical re-encode', () => {
+    expect(reconcileSessions(rows, rows.map(reencode))).toBe(rows)
+  })
+
+  it('reuses unchanged row objects, keeps the changed row fresh', () => {
+    const incoming = rows.map(reencode)
+    incoming[1] = { ...incoming[1], unread: true, unread_token: 'flip' }
+    const out = reconcileSessions(rows, incoming)
+    expect(out).not.toBe(rows)
+    expect(out[0]).toBe(rows[0])
+    expect(out[2]).toBe(rows[2])
+    // Mutation guard: the changed row must NOT be the previous object.
+    expect(out[1]).not.toBe(rows[1])
+    expect(out[1]).toBe(incoming[1])
+    expect(out).toEqual(incoming) // full-replace semantics preserved exactly
+  })
+
+  it('every single-field mutant yields a fresh row object (never reused)', () => {
+    for (const key of SESSION_KEYS) {
+      const incoming = rows.map(reencode)
+      incoming[0] = mutate(rows[0], key)
+      const out = reconcileSessions(rows, incoming)
+      expect(out[0], `field ${String(key)}`).not.toBe(rows[0])
+      expect(out[0], `field ${String(key)}`).toEqual(incoming[0])
+      expect(out).toEqual(incoming)
+    }
+  })
+
+  it('reorder keeps row identities but returns a new array in the new order', () => {
+    const incoming = [reencode(rows[2]), reencode(rows[0]), reencode(rows[1])]
+    const out = reconcileSessions(rows, incoming)
+    expect(out).not.toBe(rows)
+    expect(out.map(s => s.id)).toEqual(['c', 'a', 'b'])
+    expect(out[0]).toBe(rows[2])
+    expect(out[1]).toBe(rows[0])
+  })
+
+  it('removal / addition produce a new array; survivors keep identity', () => {
+    const removed = reconcileSessions(rows, [reencode(rows[0]), reencode(rows[2])])
+    expect(removed.map(s => s.id)).toEqual(['a', 'c'])
+    expect(removed[0]).toBe(rows[0])
+    const added = reconcileSessions(rows, [...rows.map(reencode), fullRow('d')])
+    expect(added.length).toBe(4)
+    expect(added[1]).toBe(rows[1])
+    expect(added[3].id).toBe('d')
+  })
+
+  it('empty previous snapshot passes the incoming list through', () => {
+    const incoming = rows.map(reencode)
+    expect(reconcileSessions([], incoming)).toEqual(incoming)
+  })
+})
+
+describe('diffReplacedRows / substituteRows', () => {
+  const rows = [fullRow('a'), fullRow('b'), fullRow('c')]
+
+  it('identical arrays diff to an empty replacement map', () => {
+    expect(diffReplacedRows(rows, rows)!.size).toBe(0)
+    expect(diffReplacedRows(rows, [...rows])!.size).toBe(0)
+  })
+
+  it('replaced-only successor yields the old→new map', () => {
+    const next = [...rows]
+    next[1] = { ...rows[1], unread: true }
+    const d = diffReplacedRows(rows, next)!
+    expect(d.size).toBe(1)
+    expect(d.get(rows[1])).toBe(next[1])
+  })
+
+  it('structural changes (reorder, removal, addition, id swap) return null', () => {
+    expect(diffReplacedRows(rows, [rows[1], rows[0], rows[2]])).toBeNull()
+    expect(diffReplacedRows(rows, rows.slice(0, 2))).toBeNull()
+    expect(diffReplacedRows(rows, [...rows, fullRow('d')])).toBeNull()
+    expect(diffReplacedRows(rows, [rows[0], fullRow('x'), rows[2]])).toBeNull()
+  })
+
+  it('factsUnchanged rejects a replaced pair that moved a listed fact', () => {
+    const next = [...rows]
+    next[0] = { ...rows[0], alive: !rows[0].alive }
+    const d = diffReplacedRows(rows, next)!
+    expect(factsUnchanged(d, ['alive'])).toBe(false)
+    expect(factsUnchanged(d, ['unread'])).toBe(true)
+  })
+
+  it('substituteRows preserves array identity when nothing in it changed', () => {
+    const replaced = new Map([[rows[1], { ...rows[1], unread: true }]])
+    const untouched = [rows[0], rows[2]]
+    expect(substituteRows(untouched, replaced)).toBe(untouched)
+    const touched = substituteRows(rows, replaced)
+    expect(touched).not.toBe(rows)
+    expect(touched[1]).toBe(replaced.get(rows[1]))
+    expect(touched[0]).toBe(rows[0])
+  })
+})

--- a/apps/gmux-web/src/reconcile.ts
+++ b/apps/gmux-web/src/reconcile.ts
@@ -1,0 +1,224 @@
+/** Structural sharing for protocol-3 session snapshots (incremental frontend
+ * reconciliation).
+ *
+ * The wire semantics are wholesale replacement: every committed transaction
+ * delivers the *entire* session list, re-encoded server-side, so every row
+ * arrives as a fresh object even when nothing about it changed. Before this
+ * module, `_rawSessions` swallowed that array verbatim, which meant every
+ * projection (folders, day partitions, family index, …) saw N brand-new row
+ * identities per commit and rebuilt from scratch — a one-row flip cost
+ * exactly a cold rebuild (93 ms @10k, see
+ * report-combined-resource-gains.md).
+ *
+ * Equality strategy (explicit, because JSON identity cannot work — rows are
+ * re-encoded per snapshot): a field-by-field structural comparison over the
+ * closed UI `Session` shape produced by `toUISession`. There is no version /
+ * updated_at field on the wire that proves a row unchanged, so the comparator
+ * inspects every field, including the nested `status`, `command` and
+ * `remotes` values. The field lists are checked against `keyof Session` at
+ * compile time (`SessionKeyExhaustiveness` below), so adding a field to the
+ * type without teaching the comparator is a build error — a comparator that
+ * silently ignores a field would wrongly reuse a changed row.
+ *
+ * Cost: one O(row) comparison per row per snapshot — O(N) total with a small
+ * constant (measured ~1 ms @10k rows, see the reconcile bench). Parsing
+ * stays O(N) regardless; the win is that everything *downstream* of the raw
+ * signal can now use object identity as a cheap "provably unchanged" test
+ * and patch only the affected slices.
+ *
+ * This is purely an optimization layer over identical semantics: the
+ * reconciled array is deep-equal to the incoming snapshot, atomic-commit
+ * behavior and epoch handling are untouched.
+ */
+
+import type { Session, SessionStatus } from './types'
+
+// ── Field inventory ──────────────────────────────────────────────────────────
+//
+// Scalar fields compared with `!==`. Nested fields (`command`, `remotes`,
+// `status`) get bespoke comparisons below. The `SessionKeyExhaustiveness`
+// alias fails to compile if `Session` grows a key not listed in either set.
+
+const SESSION_SCALAR_KEYS = [
+  'id', 'peer', 'created_at', 'cwd', 'workspace_root', 'adapter', 'drive_mode',
+  'parent_session_id', 'launched_from_session_id', 'semantic_agent', 'alive',
+  'pid', 'exit_code', 'started_at', 'exited_at', 'title', 'subtitle', 'unread',
+  'unread_token', 'resumable', 'last_output_at', 'socket_path',
+  'terminal_cols', 'terminal_rows', 'slug', 'conversation_file',
+  'runner_version', 'binary_hash', 'project_slug', 'project_index',
+] as const satisfies readonly (keyof Session)[]
+
+const SESSION_NESTED_KEYS = ['command', 'remotes', 'status'] as const satisfies readonly (keyof Session)[]
+
+type CoveredKey = typeof SESSION_SCALAR_KEYS[number] | typeof SESSION_NESTED_KEYS[number]
+// Compile-time exhaustiveness: if `Session` gains a field the comparator
+// doesn't know, this alias becomes non-`never` and the assignment errors.
+type MissingSessionKey = Exclude<keyof Session, CoveredKey>
+const _sessionKeysExhaustive: MissingSessionKey extends never ? true : never = true
+void _sessionKeysExhaustive
+
+const STATUS_KEYS = ['active', 'error', 'interrupted'] as const satisfies readonly (keyof SessionStatus)[]
+type MissingStatusKey = Exclude<keyof SessionStatus, typeof STATUS_KEYS[number]>
+const _statusKeysExhaustive: MissingStatusKey extends never ? true : never = true
+void _statusKeysExhaustive
+
+/** Exported for the mutation-hardening test, which flips every field and
+ * asserts the fast path never reuses a changed row. */
+export const SESSION_KEYS: readonly (keyof Session)[] = [...SESSION_SCALAR_KEYS, ...SESSION_NESTED_KEYS]
+
+function statusEquals(a: SessionStatus | null, b: SessionStatus | null): boolean {
+  if (a === b) return true
+  if (!a || !b) return false
+  for (const k of STATUS_KEYS) if (a[k] !== b[k]) return false
+  return true
+}
+
+function commandEquals(a: readonly string[], b: readonly string[]): boolean {
+  if (a === b) return true
+  if (a.length !== b.length) return false
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false
+  return true
+}
+
+function remotesEquals(a: Record<string, string> | undefined, b: Record<string, string> | undefined): boolean {
+  if (a === b) return true
+  if (!a || !b) return false
+  const ak = Object.keys(a)
+  if (ak.length !== Object.keys(b).length) return false
+  for (const k of ak) if (a[k] !== b[k]) return false
+  return true
+}
+
+/** Deep structural equality over the closed UI Session shape. */
+export function sessionRowEquals(a: Session, b: Session): boolean {
+  if (a === b) return true
+  for (const k of SESSION_SCALAR_KEYS) if (a[k] !== b[k]) return false
+  return commandEquals(a.command, b.command)
+    && remotesEquals(a.remotes, b.remotes)
+    && statusEquals(a.status, b.status)
+}
+
+// ── Snapshot reconciliation ──────────────────────────────────────────────────
+
+/**
+ * Reconcile an incoming wholesale snapshot against the previous one:
+ *  - a row deep-equal to the previous row with the same id keeps the
+ *    *previous* object identity;
+ *  - if every row is reused and positions match, the previous *array*
+ *    identity is returned, so a byte-identical re-encode is a signal no-op.
+ *
+ * The returned array is always deep-equal to `next` (order and content come
+ * from `next`; only object identities are borrowed from `prev`), so
+ * full-replace semantics are preserved exactly.
+ */
+export function reconcileSessions(prev: readonly Session[], next: readonly Session[]): Session[] {
+  if (prev === next) return next as Session[]
+  const prevById = new Map<string, Session>()
+  for (const p of prev) prevById.set(p.id, p)
+  const out = new Array<Session>(next.length)
+  let identical = prev.length === next.length
+  for (let i = 0; i < next.length; i++) {
+    const n = next[i]
+    const p = prevById.get(n.id)
+    if (p && sessionRowEquals(p, n)) {
+      out[i] = p
+      if (identical && prev[i] !== p) identical = false
+    } else {
+      out[i] = n
+      identical = false
+    }
+  }
+  return identical ? (prev as Session[]) : out
+}
+
+// ── Identity diffing for projection fast paths ───────────────────────────────
+
+const EMPTY_REPLACED: ReadonlyMap<Session, Session> = new Map()
+
+/**
+ * Identity diff of two session lists. Returns the old→new object map when
+ * `next` differs from `prev` only by *replaced rows* (same length, same ids
+ * in the same positions, some object identities swapped); returns `null` for
+ * any structural change (insert, removal, reorder, id change) — callers must
+ * then take their full non-incremental path.
+ */
+export function diffReplacedRows(
+  prev: readonly Session[],
+  next: readonly Session[],
+): ReadonlyMap<Session, Session> | null {
+  if (prev === next) return EMPTY_REPLACED
+  if (prev.length !== next.length) return null
+  let replaced: Map<Session, Session> | null = null
+  for (let i = 0; i < next.length; i++) {
+    const p = prev[i]
+    const n = next[i]
+    if (p === n) continue
+    if (p.id !== n.id) return null
+    replaced ??= new Map()
+    replaced.set(p, n)
+  }
+  return replaced ?? EMPTY_REPLACED
+}
+
+// ── Fact subsets: which fields a projection's *structure* reads ─────────────
+//
+// A projection fast path may substitute new row objects into its previous
+// output only when every replaced row kept the facts that projection's
+// shape (membership, bucketing, ordering) is derived from. Fields not
+// listed here may change freely — they only alter row *content*, which the
+// substitution carries through. Each list is pinned by the differential
+// property test (`reconcile-differential.test.ts`): dropping a needed fact
+// makes randomized mutation sequences diverge from the uncached reference.
+
+/** Family topology + child ordering: `createFamilyIndex` reads parentage and
+ * agent-ness; `byRecency` orders children by output/creation stamps. */
+export const FAMILY_FACT_KEYS = [
+  'parent_session_id', 'semantic_agent', 'last_output_at', 'created_at',
+] as const satisfies readonly (keyof Session)[]
+
+/** Sidebar membership facts (`sidebarSessions`): liveness + resumability
+ * decide list membership; family facts decide which roots get pulled in. */
+export const SIDEBAR_FACT_KEYS = [
+  'alive', 'resumable', ...FAMILY_FACT_KEYS,
+] as const satisfies readonly (keyof Session)[]
+
+/** Folder structure facts (`foldersFrom`/`buildProjectFolders`): bucketing
+ * (project_slug, peer), visibility (alive/resumable), ordering
+ * (project_index, created_at), family placement (parent/semantic edges,
+ * temporary placements from stamped children). */
+export const PLACEMENT_FACT_KEYS = [
+  'project_slug', 'project_index', 'peer', 'alive', 'resumable', ...FAMILY_FACT_KEYS,
+] as const satisfies readonly (keyof Session)[]
+
+/** Day-partition facts (`partitionByDay`): bucket key and in-bucket order
+ * derive from the activity timestamp (last_output_at ?? created_at). */
+export const ACTIVITY_FACT_KEYS = [
+  'last_output_at', 'created_at',
+] as const satisfies readonly (keyof Session)[]
+
+/** True when every replaced (old→new) pair kept all the given facts. */
+export function factsUnchanged(
+  replaced: ReadonlyMap<Session, Session>,
+  keys: readonly (keyof Session)[],
+): boolean {
+  for (const [oldRow, newRow] of replaced) {
+    for (const k of keys) if (oldRow[k] !== newRow[k]) return false
+  }
+  return true
+}
+
+/** Substitute replaced row objects into a previous output list. Returns the
+ * previous array identity untouched when it contains none of the replaced
+ * rows (so unaffected slices keep identity and memoized consumers skip). */
+export function substituteRows(
+  rows: readonly Session[],
+  replaced: ReadonlyMap<Session, Session>,
+): readonly Session[] {
+  if (replaced.size === 0) return rows
+  let touched = false
+  for (const s of rows) {
+    if (replaced.has(s)) { touched = true; break }
+  }
+  if (!touched) return rows
+  return rows.map(s => replaced.get(s) ?? s)
+}

--- a/apps/gmux-web/src/store-projections.test.ts
+++ b/apps/gmux-web/src/store-projections.test.ts
@@ -324,11 +324,18 @@ describe('projection performance regression (fixture seed=1234)', () => {
     expect(sidebarSessions.value).toBe(a)
     expect(folders.value).toBe(b)
     expect(unreadCount.value).toBe(c)
-    // A one-session mutation swaps the array: exactly one new index.
+    // An array swap with identical row objects is patched incrementally
+    // (reconcile.ts): the previous index is re-keyed onto the new array
+    // rather than rebuilt — still exactly one live index.
     _rawSessions.value = _rawSessions.value.slice()
     const after = familyIndex(sessions.value)
-    expect(after).not.toBe(before)
+    expect(after).toBe(before)
     void [sidebarSessions.value, folders.value, unreadCount.value]
     expect(familyIndex(sessions.value)).toBe(after)
+    // A genuine row replacement (new object, changed family fact) rebuilds.
+    const next = _rawSessions.value.slice()
+    next[0] = { ...next[0], parent_session_id: next[0].parent_session_id ? undefined : next[1]?.id }
+    _rawSessions.value = next
+    expect(familyIndex(sessions.value)).not.toBe(after)
   })
 })

--- a/apps/gmux-web/src/store.bench.ts
+++ b/apps/gmux-web/src/store.bench.ts
@@ -12,11 +12,26 @@
  */
 import { bench, describe } from 'vitest'
 import {
-  _rawSessions, _setRawWorld, familyActivityById, familyDotById, folders,
+  _rawSessions, _setRawWorld, applySessionsSnapshot, familyActivityById, familyDotById, folders,
   homePartition, sessionsLoaded, sidebarActivity, sidebarSessions, unreadCount,
   urlPath, worldLoaded,
 } from './store'
 import { makeFixtureWorld } from './store-perf-fixture'
+import type { Session } from './types'
+
+/** Server-side re-encode: same values, all-new object identities. Cold and
+ * snapshot benches must go through this — with structural sharing, replaying
+ * the *same* row objects would short-circuit into the fast path and measure
+ * nothing. The map itself costs ~2–6 ms @10k–30k and is charged to the
+ * benches that use it (it models the per-snapshot decode allocation). */
+function reencode(rows: readonly Session[]): Session[] {
+  return rows.map(s => ({
+    ...s,
+    command: [...s.command],
+    remotes: s.remotes ? { ...s.remotes } : s.remotes,
+    status: s.status ? { ...s.status } : s.status,
+  }))
+}
 
 function readAll(): unknown {
   return [
@@ -36,7 +51,8 @@ for (const n of [1000, 10000, 30000]) {
       sessionsLoaded.value = true
       worldLoaded.value = true
       urlPath.value = '/'
-      _rawSessions.value = w.sessions.slice()
+      // Fresh identities every iteration: a genuinely cold rebuild.
+      _rawSessions.value = reencode(w.sessions)
       readAll()
     })
 
@@ -46,6 +62,33 @@ for (const n of [1000, 10000, 30000]) {
       const next = _rawSessions.value.length === n ? _rawSessions.value.slice() : w.sessions.slice()
       next[idx] = { ...next[idx], unread: (flip++ & 1) === 0, unread_token: `flip-${flip}` }
       _rawSessions.value = next
+      readAll()
+    })
+
+    // The full protocol-3 commit seam: a re-encoded wholesale snapshot with
+    // one changed row, through applySessionsSnapshot (reconciliation cost
+    // included). This is what one storm frame costs the browser post-parse.
+    let snapFlip = 0
+    bench('one-row flip via re-encoded snapshot commit', () => {
+      const next = reencode(_rawSessions.value.length === n ? _rawSessions.value : w.sessions)
+      const idx = next.findIndex(s => s.id === w.mutationTargetId)
+      next[idx] = { ...next[idx], unread: (snapFlip++ & 1) === 0, unread_token: `snap-${snapFlip}` }
+      applySessionsSnapshot(next)
+      readAll()
+    })
+
+    bench('identical re-encoded snapshot commit (no-op reconcile)', () => {
+      applySessionsSnapshot(reencode(_rawSessions.value.length === n ? _rawSessions.value : w.sessions))
+      readAll()
+    })
+
+    // Structural churn defeats every fast path (row count changes → the
+    // identity diff is null → full non-incremental rebuild). Pins that the
+    // slow path did not regress under the added diff/reconcile attempts.
+    bench('one-row remove/re-add via snapshot commit (full rebuild path)', () => {
+      const cur = _rawSessions.value.length >= n - 1 ? _rawSessions.value : w.sessions
+      const next = reencode(cur.length === n ? cur.slice(0, -1) : [...cur, w.sessions[n - 1]])
+      applySessionsSnapshot(next)
       readAll()
     })
   })

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -17,13 +17,16 @@ import type { Session as ProtocolSession } from '@gmux/protocol'
 import { batch, computed, effect, signal, untracked } from '@preact/signals'
 import { buildTerminalOptions, fetchFrontendConfig, type ResolvedKeybind, resolveKeybinds } from './config'
 import {
-  familyAncestors, familyIndex, familyRootId, familyStateOf, isFamilyChild, isProcessSession, promotionAction,
-  type FamilyActivity,
+  createFamilyIndex, 
+  type FamilyActivity, type FamilyIndex,familyAncestors, familyIndex, familyRootId, familyStateOf, isProcessSession, promotionAction,
 } from './family'
-import { isWaitingPresentation, sessionPresentationState, type SessionPresentationState } from './presentation'
-
 import { MOCK_SESSIONS, mockWorld } from './mock-data/index'
+import { isWaitingPresentation, type SessionPresentationState, sessionPresentationState } from './presentation'
 import { buildProjectFolders, discoverProjects, type TemporaryPresentationPlacement } from './projects'
+import {
+  ACTIVITY_FACT_KEYS, diffReplacedRows, factsUnchanged, PLACEMENT_FACT_KEYS,
+  reconcileSessions, SIDEBAR_FACT_KEYS, substituteRows,
+} from './reconcile'
 import { referencePresence, removeHostReferenceItems, removeReferenceItems, type UnresolvedHost, unresolvedReferences } from './references'
 import type { View } from './routing'
 import { resolveViewFromPath, viewToPath } from './routing'
@@ -653,11 +656,7 @@ export const unresolvedHosts = computed<UnresolvedHost[]>(
  *  visible `folders` (filtered by URL params) and the unfiltered folder
  *  set behind `unreadCount` (a global signal that must ignore the
  *  ?project=/?cwd= view filter). */
-function foldersFrom(ss: Session[]): Folder[] {
-  // One family index per session-list identity (WeakMap-cached), shared with
-  // every other projection of the same snapshot: root/membership lookups are
-  // O(1) here instead of a linear scan per session.
-  const index = familyIndex(sessions.value)
+function foldersWith(ss: readonly Session[], index: FamilyIndex): Folder[] {
   const forceVisible = new Set<string>()
   const temporaryPlacements = new Map<string, TemporaryPresentationPlacement>()
   const selectedRoot = familyRootId(selectedId.value, index)
@@ -686,7 +685,7 @@ function foldersFrom(ss: Session[]): Folder[] {
     // navigable in the family drawer but have no independent project row.
     // Resolve edges against the complete snapshot, not this tab-filtered
     // subset. A filtered-out parent must not turn its child into a fake root.
-    ss.filter(s => !index.childIds.has(s.id)),
+    ss.filter(s => !index.childIds.has(s.id)) as Session[],
     (name) => localPeerNames.value.has(name),
     _rawWorld.value.peerProjects,
     referencePresence(peers.value),
@@ -694,6 +693,113 @@ function foldersFrom(ss: Session[]): Folder[] {
     temporaryPlacements,
   )
 }
+
+// ── Incremental projection memos (structural sharing; see reconcile.ts) ─────
+//
+// After snapshot reconciliation, the protocol-3 steady state reaching these
+// projections is "same rows, a few object identities replaced". Each heavy
+// projection keeps its last (input, deps, output); when the new input is a
+// replaced-rows-only successor whose replaced rows kept that projection's
+// structure facts, the previous output is patched by object substitution —
+// O(changed + affected slices) — instead of rebuilt. Any structural change
+// (insert/remove/reorder, a fact change, a dep change) falls through to the
+// full rebuild, so output values are always identical to the uncached path
+// (pinned by reconcile-differential.test.ts).
+
+function sameDeps(a: readonly unknown[], b: readonly unknown[]): boolean {
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false
+  return true
+}
+
+function substituteFolders(prev: Folder[], replaced: ReadonlyMap<Session, Session>): Folder[] {
+  if (replaced.size === 0) return prev
+  let changed = false
+  const next = prev.map(f => {
+    const swapped = substituteRows(f.sessions, replaced)
+    if (swapped === f.sessions) return f
+    changed = true
+    return { ...f, sessions: swapped as Session[] }
+  })
+  return changed ? next : prev
+}
+
+/** Everything `foldersWith` reads besides the session rows themselves. Any
+ * identity change here disables the fast path for one recompute. */
+function foldersDeps(): readonly unknown[] {
+  return [
+    projects.value, peers.value, _rawWorld.value.peerProjects,
+    localPeerNames.value, projectKeys.value, selectedId.value,
+  ]
+}
+
+function makeFoldersMemo(): (ss: readonly Session[]) => Folder[] {
+  let last: {
+    input: readonly Session[]; all: readonly Session[]
+    deps: readonly unknown[]; out: Folder[]
+  } | null = null
+  return (ss: readonly Session[]): Folder[] => {
+    const all = sessions.value
+    const deps = foldersDeps()
+    if (last && sameDeps(last.deps, deps)) {
+      // Folder structure reads the *whole* snapshot (family edges, roots of
+      // filtered-out children), so the facts must hold for every replaced
+      // row in `sessions`, not just those in `ss`. The `ss` diff proves
+      // membership/order of the input list is unchanged; substitution then
+      // carries the replaced row objects into the previous folder slices.
+      const dAll = diffReplacedRows(last.all, all)
+      if (dAll && factsUnchanged(dAll, PLACEMENT_FACT_KEYS) && diffReplacedRows(last.input, ss)) {
+        const out = substituteFolders(last.out, dAll)
+        last = { input: ss, all, deps, out }
+        return out
+      }
+    }
+    const out = foldersWith(ss, familyIndex(all))
+    last = { input: ss, all, deps, out }
+    return out
+  }
+}
+
+// One memo per call site: `folders` (sidebar-scoped input) and `unreadCount`
+// (filter-scoped input) see different lists and must not evict each other.
+const sidebarFoldersMemo = makeFoldersMemo()
+const unreadFoldersMemo = makeFoldersMemo()
+
+function substituteBuckets(prev: DayBucket[], replaced: ReadonlyMap<Session, Session>): DayBucket[] {
+  if (replaced.size === 0) return prev
+  let changed = false
+  const next = prev.map(b => {
+    const swapped = substituteRows(b.sessions, replaced)
+    if (swapped === b.sessions) return b
+    changed = true
+    return { ...b, sessions: swapped as Session[] }
+  })
+  return changed ? next : prev
+}
+
+/** Memoized `partitionByDay`: bucket keys and in-bucket order derive only
+ * from the activity timestamps, so replaced rows that kept them slot into
+ * the previous buckets by substitution. Day-scoped: crossing local midnight
+ * invalidates (labels and bucket keys move). */
+function makePartitionMemo(): (input: readonly Session[], now: number) => DayBucket[] {
+  let last: { input: readonly Session[]; todayMid: number; out: DayBucket[] } | null = null
+  return (input: readonly Session[], now: number): DayBucket[] => {
+    const todayMid = localMidnight(now)
+    if (last && last.todayMid === todayMid) {
+      const d = diffReplacedRows(last.input, input)
+      if (d && factsUnchanged(d, ACTIVITY_FACT_KEYS)) {
+        const out = substituteBuckets(last.out, d)
+        last = { input, todayMid, out }
+        return out
+      }
+    }
+    const out = partitionByDay(input, now)
+    last = { input, todayMid, out }
+    return out
+  }
+}
+
+const sidebarActivityMemo = makePartitionMemo()
+const homePartitionMemo = makePartitionMemo()
 
 /** The single source of truth for which sessions are eligible for the
  *  sidebar. Projects places this list into configured folders; Activity
@@ -711,10 +817,9 @@ function foldersFrom(ss: Session[]): Folder[] {
  *  Distinct from routing: `view` / `selectedId` resolve against the full
  *  `sessions` (filter-blind), so a filter never evicts the open
  *  terminal; rule 4 only ever *adds* the selected session back here. */
-export const sidebarSessions = computed(() => {
+function sidebarSessionsWith(index: FamilyIndex): Session[] {
   const sel = selectedId.value
   const onlyAlive = aliveOnly.value
-  const index = familyIndex(sessions.value)
   const base = filteredSessions.value.filter(s =>
     s.id === sel || (onlyAlive ? s.alive : s.alive || s.resumable),
   )
@@ -740,9 +845,37 @@ export const sidebarSessions = computed(() => {
     if (rootId) push(index.byId.get(rootId))
   }
   return out
+}
+
+let lastSidebarMemo: {
+  filtered: readonly Session[]; all: readonly Session[]
+  sel: string | null; onlyAlive: boolean; out: Session[]
+} | null = null
+
+export const sidebarSessions = computed(() => {
+  const sel = selectedId.value
+  const onlyAlive = aliveOnly.value
+  const all = sessions.value
+  const filtered = filteredSessions.value
+  const m = lastSidebarMemo
+  if (m && m.sel === sel && m.onlyAlive === onlyAlive) {
+    // Fast path: same rows with some identities replaced, membership facts
+    // (liveness, resumability, family edges) intact, filter membership
+    // unchanged (the `filtered` diff proves it). Output is the previous
+    // list with the replaced objects substituted.
+    const dAll = diffReplacedRows(m.all, all)
+    if (dAll && factsUnchanged(dAll, SIDEBAR_FACT_KEYS) && diffReplacedRows(m.filtered, filtered)) {
+      const out = substituteRows(m.out, dAll) as Session[]
+      lastSidebarMemo = { filtered, all, sel, onlyAlive, out }
+      return out
+    }
+  }
+  const out = sidebarSessionsWith(familyIndex(all))
+  lastSidebarMemo = { filtered, all, sel, onlyAlive, out }
+  return out
 })
 
-export const folders = computed(() => foldersFrom(sidebarSessions.value))
+export const folders = computed(() => sidebarFoldersMemo(sidebarSessions.value))
 
 /** Sidebar selection follows a nested session to its presentation root row. */
 export const familySelectedId = computed(() => familyRootId(selectedId.value, sessions.value))
@@ -758,7 +891,7 @@ export const familySelectedId = computed(() => familyRootId(selectedId.value, se
  *  Day-groups the full set (alive + dead/resumable, any age), so the
  *  Activity view lists exactly what Projects does. */
 export const sidebarActivity = computed(() =>
-  partitionByDay(folders.value.flatMap(folder => folder.sessions), Date.now()),
+  sidebarActivityMemo(folders.value.flatMap(folder => folder.sessions), Date.now()),
 )
 
 // ── Sidebar view mode ───────────────────────────────────────────────────────
@@ -944,9 +1077,8 @@ export const backgroundActivity = computed((): DotState => {
  * or host shouldn't blink for sessions outside its scope (another tab
  * or a notification covers those). Within the scope it's built from
  * folder-bucketed sessions so unstamped strays can't ping. */
-export const unreadCount = computed(() => {
+function unreadCountWith(index: FamilyIndex, folderList: Folder[]): number {
   const sel = selectedId.value
-  const index = familyIndex(sessions.value)
   const childUnread = new Map<string, number>()
   for (const s of sessions.value) {
     // Process output remains unread for explicit consumption, but command
@@ -956,7 +1088,7 @@ export const unreadCount = computed(() => {
     if (rootId) childUnread.set(rootId, (childUnread.get(rootId) ?? 0) + 1)
   }
   let n = 0
-  for (const f of foldersFrom(filteredSessions.value)) {
+  for (const f of folderList) {
     for (const s of f.sessions) {
       // A standalone process owns its own visible row, so its unread output
       // still badges normally. Only agent-owned process children disappear
@@ -966,7 +1098,10 @@ export const unreadCount = computed(() => {
     }
   }
   return n
-})
+}
+
+export const unreadCount = computed(() =>
+  unreadCountWith(familyIndex(sessions.value), unreadFoldersMemo(filteredSessions.value)))
 
 /** Aggregate precedence intentionally differs from a session's own semantic
  * derivation only for waiting-error attention: it outranks an active sibling
@@ -1133,14 +1268,24 @@ function localMidnight(t: number): number {
   return new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime()
 }
 
+// Per-row memo: Date.parse dominated the partition sorts (O(N log N) parses
+// per recompute). Structural sharing keeps row identities stable across
+// snapshots, so the WeakMap hits for every unchanged row — and a replaced
+// row is a new object, so a moved timestamp can never read a stale entry.
+const outputTimeCache = new WeakMap<Session, number>()
+
 function outputTimeMs(s: Session): number {
+  const hit = outputTimeCache.get(s)
+  if (hit !== undefined) return hit
   // last_output_at is canonical when present (daemon-stamped when the
   // session last produced unseen output). For sessions that never went
   // unread, fall back to created_at so they sort relative to peers
   // rather than landing at the epoch.
   const stamp = s.last_output_at ?? s.created_at
   const t = Date.parse(stamp)
-  return Number.isFinite(t) ? t : 0
+  const v = Number.isFinite(t) ? t : 0
+  outputTimeCache.set(s, v)
+  return v
 }
 
 function byActivityDesc(a: Session, b: Session): number {
@@ -1222,14 +1367,18 @@ export function partitionByDay(all: readonly Session[], now: number): DayBucket[
   return out
 }
 
-export const homePartition = computed(() =>
+export const homePartition = computed(() => {
   // Home is its own curated surface: scoped to the tab's `?filter=` but
   // independent of the sidebar's list rules (alive-only, selected-pin).
   // Alive only — dead/resumable corpses live in the sidebar's Activity
   // view, not the dashboard. Home renders only the non-`dated` buckets
   // (see home.tsx), keeping it a recent-activity view.
-  partitionByDay(filteredSessions.value.filter(s => s.alive && !isFamilyChild(s, sessions.value)), Date.now()),
-)
+  const index = familyIndex(sessions.value)
+  return homePartitionMemo(
+    filteredSessions.value.filter(s => s.alive && !index.childIds.has(s.id)),
+    Date.now(),
+  )
+})
 
 // ── Mutators ────────────────────────────────────────────────────────────────
 
@@ -1436,6 +1585,34 @@ export function readySessionsBootstrap(epoch: number): boolean {
   return true
 }
 
+/**
+ * Non-incremental reference projections for the differential tests: the same
+ * pure building blocks the computeds use, but with a freshly built family
+ * index and no memo fast paths. Output values (not identities) from the
+ * production computeds must always deep-equal these.
+ */
+export function _uncachedProjections(now = Date.now()): {
+  sidebarSessions: Session[]
+  folders: Folder[]
+  unreadCount: number
+  sidebarActivity: DayBucket[]
+  homePartition: DayBucket[]
+} {
+  const index = createFamilyIndex(sessions.value)
+  const sidebar = sidebarSessionsWith(index)
+  const folderList = foldersWith(sidebar, index)
+  return {
+    sidebarSessions: sidebar,
+    folders: folderList,
+    unreadCount: unreadCountWith(index, foldersWith(filteredSessions.value, index)),
+    sidebarActivity: partitionByDay(folderList.flatMap(f => f.sessions), now),
+    homePartition: partitionByDay(
+      filteredSessions.value.filter(s => s.alive && !index.childIds.has(s.id)),
+      now,
+    ),
+  }
+}
+
 export function discardSessionsBootstrap(): void {
   sessionsBootstrap = null
 }
@@ -1447,6 +1624,13 @@ export function resetSessionsTransport(): void {
 }
 
 export function applySessionsSnapshot(list: Session[]): void {
+  // Structural sharing (reconcile.ts): rows are re-encoded server-side every
+  // snapshot, so reuse the previous row *objects* wherever the incoming row
+  // is deep-equal — and the previous array identity when nothing changed at
+  // all. Semantics are still wholesale replacement (the reconciled array is
+  // deep-equal to `list`); this only lets projections use identity as a
+  // provably-unchanged test and patch O(changed) instead of rebuilding O(N).
+  list = reconcileSessions(_rawSessions.peek(), list)
   // Detect newly-arrived IDs vs the previous snapshot so a pending launch
   // (just-POSTed /v1/launch awaiting an id) can navigate to its session as
   // soon as the daemon publishes it. Computed before we commit the new

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -801,6 +801,27 @@ function makePartitionMemo(): (input: readonly Session[], now: number) => DayBuc
 const sidebarActivityMemo = makePartitionMemo()
 const homePartitionMemo = makePartitionMemo()
 
+/**
+ * Local-midnight timestamp the day-partition projections depend on.
+ *
+ * Pre-reconciliation, `partitionByDay`'s day-relative labels ("Today",
+ * "Yesterday", "Last <weekday>") were re-evaluated on every snapshot commit
+ * because the array identity always changed. With structural sharing, an
+ * identical re-encoded snapshot (e.g. an SSE reconnect replaying an
+ * unchanged world after laptop wake) commits as a signal no-op — so the
+ * partitions must carry their clock input as an explicit dependency instead
+ * of riding on array-identity churn. `refreshDayBoundary()` runs at the
+ * snapshot commit seam and writes only when the local day actually moved,
+ * so identical snapshots stay O(reconcile) with zero recomputation except
+ * the (necessary) partition re-evaluation across midnight.
+ */
+const dayBoundary = signal(localMidnight(Date.now()))
+
+function refreshDayBoundary(): void {
+  const mid = localMidnight(Date.now())
+  if (mid !== dayBoundary.value) dayBoundary.value = mid
+}
+
 /** The single source of truth for which sessions are eligible for the
  *  sidebar. Projects places this list into configured folders; Activity
  *  rearranges that placed set, so unstamped/unreferenced sessions that
@@ -890,9 +911,11 @@ export const familySelectedId = computed(() => familyRootId(selectedId.value, se
  *
  *  Day-groups the full set (alive + dead/resumable, any age), so the
  *  Activity view lists exactly what Projects does. */
-export const sidebarActivity = computed(() =>
-  sidebarActivityMemo(folders.value.flatMap(folder => folder.sessions), Date.now()),
-)
+export const sidebarActivity = computed(() => {
+  // Clock dependency: recompute when the local day moves (see dayBoundary).
+  void dayBoundary.value
+  return sidebarActivityMemo(folders.value.flatMap(folder => folder.sessions), Date.now())
+})
 
 // ── Sidebar view mode ───────────────────────────────────────────────────────
 //
@@ -1368,6 +1391,8 @@ export function partitionByDay(all: readonly Session[], now: number): DayBucket[
 }
 
 export const homePartition = computed(() => {
+  // Clock dependency: recompute when the local day moves (see dayBoundary).
+  void dayBoundary.value
   // Home is its own curated surface: scoped to the tab's `?filter=` but
   // independent of the sidebar's list rules (alive-only, selected-pin).
   // Alive only — dead/resumable corpses live in the sidebar's Activity
@@ -1631,6 +1656,9 @@ export function applySessionsSnapshot(list: Session[]): void {
   // deep-equal to `list`); this only lets projections use identity as a
   // provably-unchanged test and patch O(changed) instead of rebuilding O(N).
   list = reconcileSessions(_rawSessions.peek(), list)
+  // Even a fully-reused (identity no-op) snapshot must refresh day-relative
+  // partitions when local midnight has passed since the last commit.
+  refreshDayBoundary()
   // Detect newly-arrived IDs vs the previous snapshot so a pending launch
   // (just-POSTed /v1/launch awaiting an id) can navigate to its session as
   // soon as the daemon publishes it. Computed before we commit the new


### PR DESCRIPTION
## Problem

Post-#512, projections are indexed but not incremental: every protocol-3 `ready` commit replaces `_rawSessions` wholesale, so **a one-row flip costs exactly a cold recompose** — 93 ms @10k rows, 354 ms @30k (see `report-combined-resource-gains.md`, bottleneck #2). Rows are re-encoded server-side each snapshot, so no object identity survives the wire and every projection (familyIndex, folders, day partitions, …) rebuilds O(N) per frame.

## Approach: structural sharing over identical semantics

Wire protocol, epochs, and the atomic begin/batch/ready staging are untouched. Reconciliation happens at the one commit seam (`applySessionsSnapshot`):

- **Row equality strategy** (`reconcile.ts`): there is no version/updated_at field to prove a row unchanged, and JSON identity can't work (server re-encodes), so a **field-by-field structural comparison** over the closed UI `Session` shape, compile-time exhaustive against `keyof Session` (a new field that the comparator doesn't cover is a build error). Cost ~O(N) with a small constant; parsing stays O(N) as accepted.
- **Commit**: deep-equal rows keep their previous object identity; a fully unchanged snapshot keeps the previous *array* identity (signal no-op).
- **familyIndex**: patched in place + re-keyed when only row identities changed with family facts intact, instead of re-walking every ancestry.
- **Projection fast paths** (`sidebarSessions`, `folders`, `unreadCount`, `sidebarActivity`, `homePartition`): identity-diff the input; when it is a replaced-rows-only successor whose replaced rows kept that projection's structure facts, substitute the new objects into the previous output. Untouched folders/day-buckets keep identity, so identity-memoized consumers skip them → **O(changed + affected projection slices)**. Any insert/remove/reorder/fact change falls back to the full rebuild.
- `outputTimeMs` (`Date.parse`) memoized per row object — also speeds the cold path.

## Benchmarks (i7-9700K, Node 24, vitest bench, fixture seed=1234, mean ms; before = `d893a120`)

| bench | 1k before→after | 10k before→after | 30k before→after |
|---|---|---|---|
| one-row flip → all projections | 6.8 → **0.35** (19×) | 96.7 → **5.6** (17×) | 362 → **23** (16×) |
| one-row flip via re-encoded snapshot commit | 7.5 → 2.2 | 99.5 → **24** | 386 → **~90** (p75) |
| identical re-encoded snapshot commit | 7.7 → 1.8 | 99.0 → 19 | 375 → 62 |
| one-row remove/re-add (full rebuild path) | 7.8 → 5.0 | 101 → 54 | 376 → 267 |
| cold snapshot | 8.2 → 2.6 | 99.4 → 37 | 372 → 140 |

Order-of-magnitude drop at 10k+ on the flip path; the full-rebuild (structural churn) path is *faster*, not regressed. The snapshot-commit benches include an in-bench re-encode of all rows modeling the decode allocation.

**Recompute/rerender granularity** (pinned by tests): an identical re-encoded snapshot propagates **zero** signal notifications; a one-row flip changes exactly 1 row identity, 1 Folder object, 1 day bucket, and patches (not rebuilds) the family index.

## Correctness

- `reconcile-differential.test.ts`: randomized mutation sequences through the production commit path (and through protocol-3 begin/batch/ready epoch resets) — content flips, activity bumps, deaths/resurrections, **family moves, peer merges, project restamps, removals, insertions, reorders** — must project exactly equal to an uncached non-incremental recompute at every step.
- `reconcile.test.ts`: mutation-hardening — flips **every** `Session` field (plus nested `status`/`command`/`remotes` variants) and asserts a changed row is never reused; a comparator mutant that drops any field check fails deterministically.
- Full web suite: 844 tests green; existing #512 differential suite untouched (one assertion updated: an identical array swap now correctly *reuses* the family index).