### PR TITLE
perf(gmuxd): minimum coalescing window for SSE sessions broadcasts

### DIFF
--- a/services/gmuxd/cmd/gmuxd/bootstrap.go
+++ b/services/gmuxd/cmd/gmuxd/bootstrap.go
@@ -153,6 +153,12 @@ type BootstrapConfig struct {
 	SemanticAgent                  func(string) bool
 	RunnerBudget, ConvergeDeadline time.Duration
 	RetryInitial, RetryMaximum     time.Duration
+	// ComposeMinInterval is the composer's minimum coalescing window
+	// between composition passes. Zero means the production default
+	// (central.DefaultMinComposeInterval); negative disables the window
+	// entirely (integration fixtures that drive many sequential awaited
+	// mutations keep pre-window immediacy).
+	ComposeMinInterval time.Duration
 }
 
 // Bootstrap is the fully constructed, still-inert production graph. Store is
@@ -244,7 +250,11 @@ func newBootstrap(cfg BootstrapConfig) (*Bootstrap, error) {
 		}
 		return out
 	})
-	composer := central.New(cfg.Store, runtimeSource, sink, central.WithVerdictSource(verdictSource), central.WithPeerSource(cfg.Peers), central.WithErrorSink(centralErrorAdapter{cfg.Errors}))
+	minInterval := cfg.ComposeMinInterval
+	if minInterval == 0 {
+		minInterval = central.DefaultMinComposeInterval
+	}
+	composer := central.New(cfg.Store, runtimeSource, sink, central.WithVerdictSource(verdictSource), central.WithPeerSource(cfg.Peers), central.WithErrorSink(centralErrorAdapter{cfg.Errors}), central.WithMinComposeInterval(minInterval))
 	b.Composer = composer
 	b.Runtime = runtimeSource
 	b.Verdicts = verdictSource

--- a/services/gmuxd/cmd/gmuxd/bootstrap_close_join_test.go
+++ b/services/gmuxd/cmd/gmuxd/bootstrap_close_join_test.go
@@ -18,7 +18,7 @@ func TestBootstrapCloseJoinsOwnedBlockingWorker(t *testing.T) {
 	defer st.Close()
 	entered, release := make(chan struct{}), make(chan struct{})
 	eps := EndpointSourceFunc(func(context.Context) ([]string, error) { close(entered); <-release; return nil, nil })
-	b, err := newBootstrap(BootstrapConfig{Store: st, Runners: &bootstrapRunners{metas: map[string]sessioncoord.RunnerMeta{}, blocked: map[string]bool{}}, Converter: &wire.Converter{}, Endpoints: eps})
+	b, err := newBootstrap(BootstrapConfig{ComposeMinInterval: -1, Store: st, Runners: &bootstrapRunners{metas: map[string]sessioncoord.RunnerMeta{}, blocked: map[string]bool{}}, Converter: &wire.Converter{}, Endpoints: eps})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/services/gmuxd/cmd/gmuxd/bootstrap_discovery_test.go
+++ b/services/gmuxd/cmd/gmuxd/bootstrap_discovery_test.go
@@ -189,7 +189,7 @@ func newDiscoveryHarness(t *testing.T) *discoveryHarness {
 	}
 	t.Cleanup(func() { store.Close() })
 	h := &discoveryHarness{store: store, errs: &recorder{}, notices: &recorder{}, dir: dir}
-	boot, err := newBootstrap(BootstrapConfig{
+	boot, err := newBootstrap(BootstrapConfig{ComposeMinInterval: -1, 
 		Store: store, Runners: productionRunnerClient{}, Control: bootstrapControl{}, Spawner: bootstrapSpawner{},
 		Reconciler: bootstrapReconciler{}, Converter: &wire.Converter{},
 		Endpoints: productionEndpointSource{},
@@ -508,7 +508,7 @@ func TestScanKeepsProbingUnidentifiableEndpointsButReportsOnce(t *testing.T) {
 	}}
 	runners := &bootstrapRunners{metas: map[string]sessioncoord.RunnerMeta{ep: meta}, blocked: map[string]bool{}}
 	errs := &recorder{}
-	boot, err := newBootstrap(BootstrapConfig{
+	boot, err := newBootstrap(BootstrapConfig{ComposeMinInterval: -1, 
 		Store: store, Runners: runners, Control: bootstrapControl{}, Spawner: bootstrapSpawner{},
 		Reconciler: bootstrapReconciler{}, Converter: &wire.Converter{},
 		Endpoints: EndpointSourceFunc(func(context.Context) ([]string, error) { return []string{ep}, nil }),
@@ -548,7 +548,7 @@ func TestScanReportsRepeatedRegistrationFailureOnceOnly(t *testing.T) {
 	const ep = "broken-endpoint" // the fake transport has no meta for it
 	runners := &bootstrapRunners{metas: map[string]sessioncoord.RunnerMeta{}, blocked: map[string]bool{}}
 	errs := &recorder{}
-	boot, err := newBootstrap(BootstrapConfig{
+	boot, err := newBootstrap(BootstrapConfig{ComposeMinInterval: -1, 
 		Store: store, Runners: runners, Control: bootstrapControl{}, Spawner: bootstrapSpawner{},
 		Reconciler: bootstrapReconciler{}, Converter: &wire.Converter{},
 		Endpoints: EndpointSourceFunc(func(context.Context) ([]string, error) { return []string{ep}, nil }),

--- a/services/gmuxd/cmd/gmuxd/bootstrap_harness_test.go
+++ b/services/gmuxd/cmd/gmuxd/bootstrap_harness_test.go
@@ -87,7 +87,7 @@ func openHarness(t *testing.T, dir string, fleet *harnessFleet, frames func(cont
 	if err != nil {
 		t.Fatal(err)
 	}
-	b, err := newBootstrap(BootstrapConfig{Store: s, Runners: fleet, Control: bootstrapControl{}, Spawner: bootstrapSpawner{}, Reconciler: bootstrapReconciler{}, Converter: &wire.Converter{}, Frames: frames, Endpoints: EndpointSourceFunc(func(context.Context) ([]string, error) { return fleet.endpoints(), nil }), Clock: func() centralstore.UnixMillis { return 100 }, RunnerBudget: 30 * time.Millisecond, ConvergeDeadline: 100 * time.Millisecond, RetryInitial: time.Millisecond, RetryMaximum: 2 * time.Millisecond})
+	b, err := newBootstrap(BootstrapConfig{ComposeMinInterval: -1, Store: s, Runners: fleet, Control: bootstrapControl{}, Spawner: bootstrapSpawner{}, Reconciler: bootstrapReconciler{}, Converter: &wire.Converter{}, Frames: frames, Endpoints: EndpointSourceFunc(func(context.Context) ([]string, error) { return fleet.endpoints(), nil }), Clock: func() centralstore.UnixMillis { return 100 }, RunnerBudget: 30 * time.Millisecond, ConvergeDeadline: 100 * time.Millisecond, RetryInitial: time.Millisecond, RetryMaximum: 2 * time.Millisecond})
 	if err != nil {
 		s.Close()
 		t.Fatal(err)

--- a/services/gmuxd/cmd/gmuxd/bootstrap_test.go
+++ b/services/gmuxd/cmd/gmuxd/bootstrap_test.go
@@ -103,7 +103,7 @@ func TestBootstrapReconstructsActiveSubagentBudgetAfterConvergence(t *testing.T)
 	}
 	meta := sessioncoord.RunnerMeta{Registration: centralstore.RunnerRegistration{ID: child, Adapter: "pi", Alive: true, CreatedAt: 2, ObservedAt: 3, ParentSessionID: &root}, Incarnation: "restart-child"}
 	runners := &bootstrapRunners{metas: map[string]sessioncoord.RunnerMeta{"child.sock": meta}, blocked: map[string]bool{}}
-	boot, err := newBootstrap(BootstrapConfig{
+	boot, err := newBootstrap(BootstrapConfig{ComposeMinInterval: -1, 
 		Store: store, Runners: runners, Converter: &wire.Converter{},
 		Endpoints:           EndpointSourceFunc(func(context.Context) ([]string, error) { return []string{"child.sock"}, nil }),
 		MaxSubagentsByDepth: []int{1}, SemanticAgent: func(adapter string) bool { return adapter == "pi" },
@@ -142,7 +142,7 @@ func TestPeriodicScansRejectBeforeConversationTakeoverIO(t *testing.T) {
 	resolver := &bootstrapCountingResolver{}
 	durable := &bootstrapCountingDurable{Durable: store}
 	var reported atomic.Int64
-	boot, err := newBootstrap(BootstrapConfig{
+	boot, err := newBootstrap(BootstrapConfig{ComposeMinInterval: -1, 
 		Store: store, Durable: durable, Runners: runners, Control: bootstrapControl{}, Spawner: bootstrapSpawner{},
 		Resolver: resolver, Reconciler: bootstrapReconciler{}, Converter: &wire.Converter{},
 		Endpoints: EndpointSourceFunc(func(context.Context) ([]string, error) { return []string{endpoint}, nil }),
@@ -256,7 +256,7 @@ func TestBootstrapConvergenceClassifiesCandidatesAndSeedsBus(t *testing.T) {
 	runners := &bootstrapRunners{metas: map[string]sessioncoord.RunnerMeta{
 		"good": {Registration: centralstore.RunnerRegistration{ID: "1g8schlb", Adapter: "shell", Alive: true, CreatedAt: now, ObservedAt: now}},
 	}, blocked: map[string]bool{"slow": true}}
-	b, err := newBootstrap(BootstrapConfig{Store: store, Runners: runners, Control: bootstrapControl{}, Spawner: bootstrapSpawner{}, Reconciler: bootstrapReconciler{}, Converter: &wire.Converter{}, Endpoints: EndpointSourceFunc(func(context.Context) ([]string, error) { return []string{"good", "slow"}, nil }), Clock: func() centralstore.UnixMillis { return now }, RunnerBudget: 100 * time.Millisecond, ConvergeDeadline: 2 * time.Second, RetryInitial: time.Millisecond, RetryMaximum: 2 * time.Millisecond})
+	b, err := newBootstrap(BootstrapConfig{ComposeMinInterval: -1, Store: store, Runners: runners, Control: bootstrapControl{}, Spawner: bootstrapSpawner{}, Reconciler: bootstrapReconciler{}, Converter: &wire.Converter{}, Endpoints: EndpointSourceFunc(func(context.Context) ([]string, error) { return []string{"good", "slow"}, nil }), Clock: func() centralstore.UnixMillis { return now }, RunnerBudget: 100 * time.Millisecond, ConvergeDeadline: 2 * time.Second, RetryInitial: time.Millisecond, RetryMaximum: 2 * time.Millisecond})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/services/gmuxd/cmd/gmuxd/reap_route_test.go
+++ b/services/gmuxd/cmd/gmuxd/reap_route_test.go
@@ -193,7 +193,7 @@ func newReapHarness(t *testing.T, session centralstore.SessionID) (*reapHarness,
 
 	installed := startProtocolRunner(t, dir, "1r6zxosb.sock", session, false)
 	h := &reapHarness{dir: dir}
-	boot, err := newBootstrap(BootstrapConfig{
+	boot, err := newBootstrap(BootstrapConfig{ComposeMinInterval: -1, 
 		Store: store, Runners: productionRunnerClient{}, Control: productionRunnerControl{},
 		Spawner: bootstrapSpawner{}, Reconciler: bootstrapReconciler{}, Converter: &wire.Converter{},
 		Endpoints: EndpointSourceFunc(func(context.Context) ([]string, error) {

--- a/services/gmuxd/cmd/gmuxd/start_triggers_composed_test.go
+++ b/services/gmuxd/cmd/gmuxd/start_triggers_composed_test.go
@@ -126,7 +126,7 @@ func TestStartTriggersFullComposedGraphAndJoinedCancellation(t *testing.T) {
 	frames := make(chan frameKinds, 32)
 	control := &barrierControl{calls: make(chan string, 4)}
 	var callbacks atomic.Int32
-	b, err := newBootstrap(BootstrapConfig{Store: st, Runners: fleet, Control: control, Reconciler: reconciler, Converter: &wire.Converter{}, Endpoints: endpoints, Frames: func(_ context.Context, f wire.Frames) {
+	b, err := newBootstrap(BootstrapConfig{ComposeMinInterval: -1, Store: st, Runners: fleet, Control: control, Reconciler: reconciler, Converter: &wire.Converter{}, Endpoints: endpoints, Frames: func(_ context.Context, f wire.Frames) {
 		callbacks.Add(1)
 		frames <- frameKinds{f.Sessions != nil, f.World != nil}
 	}, Clock: func() centralstore.UnixMillis { return 100 }, RunnerBudget: time.Second, ConvergeDeadline: time.Second})

--- a/services/gmuxd/internal/snapshot/central/composer.go
+++ b/services/gmuxd/internal/snapshot/central/composer.go
@@ -231,6 +231,28 @@ type ErrorSink interface {
 	Error(context.Context, error)
 }
 
+// DefaultMinComposeInterval is the production minimum coalescing window
+// between the starts of two consecutive composition passes.
+//
+// Why a window at all: every composed batch fans a FULL snapshot out to
+// every SSE subscriber (bytes are O(rows × passes × subscribers)), and the
+// browser recomposes its projections per delivered frame. Without a floor,
+// a mutation storm is throttled only by pass duration, which shrinks as N
+// shrinks — small worlds ship the most redundant frames. The window caps
+// storm output at ~4 frames/second regardless of N while the quiet path
+// (first mutation after idle) still composes immediately.
+//
+// Why 250 ms: a composition+encode pass at 10k rows costs ~90–130 ms of
+// daemon work and each delivered frame costs the browser ~93 ms of
+// projection recompute, so any window materially below ~150 ms cannot
+// amortize even one storm frame at scale; and the smallest consumer-side
+// polling cadence that reads the fanout's cached frames (the /wait ticker)
+// is 500 ms, so a 250 ms bound keeps cached-frame staleness under one poll
+// interval. Measured at 2.5k rows × 400 mutations × 10 subscribers this
+// turns ~30 passes into ≤4 with final-state convergence bounded by
+// window + one pass.
+const DefaultMinComposeInterval = 250 * time.Millisecond
+
 // Composer owns the level-triggered dirty state and the single composition
 // goroutine. Construct with New, start with Run, stop with Close.
 type Composer struct {
@@ -243,6 +265,13 @@ type Composer struct {
 	// retryDelay throttles retries after a composition failure so a
 	// persistent store error cannot become a hot loop.
 	retryDelay time.Duration
+	// minInterval is the minimum coalescing window between the starts of
+	// two consecutive composition passes. Zero disables the window (every
+	// dirty signal composes as soon as the single-flight loop is free —
+	// the pre-window behavior). The first pass after an idle period is
+	// never delayed; only sustained bursts coalesce behind the window, and
+	// the trailing edge always composes.
+	minInterval time.Duration
 
 	mu            sync.Mutex
 	dirtySessions bool
@@ -263,6 +292,19 @@ func WithErrorSink(s ErrorSink) Option { return func(c *Composer) { c.errSink = 
 
 // WithRetryDelay overrides the failure retry throttle (tests use ~0).
 func WithRetryDelay(d time.Duration) Option { return func(c *Composer) { c.retryDelay = d } }
+
+// WithMinComposeInterval installs a minimum coalescing window between
+// composition passes (see DefaultMinComposeInterval). d <= 0 disables the
+// window. The default is disabled: production wiring opts in explicitly so
+// unit fixtures keep immediate recomposition unless they test the window.
+func WithMinComposeInterval(d time.Duration) Option {
+	return func(c *Composer) {
+		if d < 0 {
+			d = 0
+		}
+		c.minInterval = d
+	}
+}
 
 // WithVerdictSource installs the adapter-reconciliation verdict overlay for
 // dead rows' Resumable derivation.
@@ -325,6 +367,7 @@ func (c *Composer) Run(ctx context.Context) {
 		return
 	}
 	defer close(c.runDone)
+	var lastPass time.Time
 	for {
 		select {
 		case <-ctx.Done():
@@ -346,6 +389,28 @@ func (c *Composer) Run(ctx context.Context) {
 			if !sessions && !projects {
 				break
 			}
+			// Minimum coalescing window: the first pass after an idle period
+			// (lastPass zero or older than the window) composes immediately —
+			// no added latency on the quiet path. Under a sustained burst,
+			// wait out the remainder of the window so dirt accumulates into
+			// one pass; dirt arriving during the wait is merged below, so the
+			// trailing edge always composes. If shutdown fires during the
+			// wait, the pending dirt is flushed once (never silently dropped
+			// by the window) before Run returns.
+			if c.minInterval > 0 && !lastPass.IsZero() {
+				if wait := c.minInterval - time.Since(lastPass); wait > 0 {
+					if !c.sleepInterruptible(ctx, wait) {
+						s2, p2 := c.takeDirty()
+						c.flushOnShutdown(sessions || s2, projects || p2)
+						return
+					}
+					// Merge dirt that arrived while the window was open so the
+					// pass reflects the latest committed state of every kind.
+					s2, p2 := c.takeDirty()
+					sessions, projects = sessions || s2, projects || p2
+				}
+			}
+			lastPass = time.Now()
 			batch, err := c.compose(ctx, sessions, projects)
 			if err != nil {
 				// No lost dirt: restore the taken kinds, report, and retry
@@ -382,6 +447,47 @@ func (c *Composer) Close() {
 		}
 	})
 	<-c.runDone
+}
+
+// sleepInterruptible waits d, returning false when shutdown (Close or ctx
+// cancellation) fired first.
+func (c *Composer) sleepInterruptible(ctx context.Context, d time.Duration) bool {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-t.C:
+		return true
+	case <-ctx.Done():
+		return false
+	case <-c.done:
+		return false
+	}
+}
+
+// flushOnShutdown composes and emits dirt that was pending behind the
+// coalescing window when shutdown fired. Without this, the window would
+// widen the shutdown race into lost final state: dirt taken before the wait
+// would be dropped where the windowless loop would already have composed
+// it. It runs on a short private context because the caller's context is
+// typically already canceled at this point (Bootstrap cancels before it
+// joins workers); Close waits for Run to return, so the emit is always
+// delivered before Close completes. Best-effort: a compose failure is
+// reported and the dirt is dropped, matching the windowless loop's behavior
+// at shutdown.
+func (c *Composer) flushOnShutdown(sessions, projects bool) {
+	if !sessions && !projects {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	batch, err := c.compose(ctx, sessions, projects)
+	if err != nil {
+		if c.errSink != nil {
+			c.errSink.Error(ctx, err)
+		}
+		return
+	}
+	c.sink.Emit(ctx, batch)
 }
 
 func (c *Composer) takeDirty() (sessions, projects bool) {

--- a/services/gmuxd/internal/snapshot/central/composer_window_test.go
+++ b/services/gmuxd/internal/snapshot/central/composer_window_test.go
@@ -96,6 +96,67 @@ func TestWindowTrailingEdgeComposesWithMergedDirt(t *testing.T) {
 	expectNoBatch(t, sink.out, 50*time.Millisecond)
 }
 
+// awaitParkedInWindowWait proves the composer is inside sleepInterruptible:
+// the previously marked dirt has been TAKEN (both dirty flags clear under
+// c.mu), no wake is pending, exactly `reads` store reads have happened, and
+// nothing new was emitted — the only remaining place the loop can be is the
+// window wait.
+func awaitParkedInWindowWait(t *testing.T, c *Composer, reader *fakeReader, reads int) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		c.mu.Lock()
+		clean := !c.dirtySessions && !c.dirtyProjects && len(c.wake) == 0
+		c.mu.Unlock()
+		if clean && len(reader.calls()) == reads {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("composer never parked inside the window wait")
+		}
+		time.Sleep(200 * time.Microsecond)
+	}
+}
+
+// TestWindowDirtMarkedDuringWaitMergesIntoTrailingPass: dirt of ANOTHER kind
+// marked while the composer is provably parked inside the window wait must
+// be merged into the trailing pass (one cross-kind read within one window),
+// not deferred to a separate pass a window later. Guards the post-wait
+// takeDirty merge in Run.
+func TestWindowDirtMarkedDuringWaitMergesIntoTrailingPass(t *testing.T) {
+	reader := &fakeReader{}
+	sink := &blockingSink{out: make(chan Batch, 8)}
+	window := 300 * time.Millisecond
+	c := New(reader, nil, sink, WithMinComposeInterval(window))
+	startComposer(t, c)
+
+	c.MarkDirty(true, false)
+	first := recvBatch(t, sink.out)
+	if first.Sessions == nil || first.Projects != nil {
+		t.Fatalf("first batch=%#v", first)
+	}
+
+	// Sessions dirt taken immediately after the pass parks the loop in the
+	// window wait; prove it before marking the other kind.
+	c.MarkDirty(true, false)
+	awaitParkedInWindowWait(t, c, reader, 1)
+	c.MarkDirty(false, true) // arrives strictly inside the wait
+
+	start := time.Now()
+	second := recvBatch(t, sink.out)
+	if second.Sessions == nil || second.Projects == nil {
+		t.Fatalf("during-wait dirt not merged into trailing pass: %#v", second)
+	}
+	if elapsed := time.Since(start); elapsed > 2*window {
+		t.Fatalf("trailing pass took %v, want within one window (%v)", elapsed, window)
+	}
+	calls := reader.calls()
+	if len(calls) != 2 || !calls[1].IncludeSessions || !calls[1].IncludeProjects {
+		t.Fatalf("reads=%#v, want exactly one trailing cross-kind read", calls)
+	}
+	expectNoBatch(t, sink.out, 50*time.Millisecond)
+}
+
 // TestWindowShutdownFlushesPendingDirt: Close during the coalescing wait
 // must compose-and-emit the pending dirt before Close returns.
 func TestWindowShutdownFlushesPendingDirt(t *testing.T) {

--- a/services/gmuxd/internal/snapshot/central/composer_window_test.go
+++ b/services/gmuxd/internal/snapshot/central/composer_window_test.go
@@ -1,0 +1,209 @@
+package central
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/centralstore"
+)
+
+// A window far longer than any test runtime: passes behind it never fire on
+// their own, which makes coalescing/flush assertions deterministic.
+const testHugeWindow = time.Hour
+
+// TestWindowQuietPathComposesImmediately: the FIRST dirty signal after start
+// (idle) must compose without waiting out the window, even with a huge one.
+func TestWindowQuietPathComposesImmediately(t *testing.T) {
+	reader := &fakeReader{}
+	sink := &blockingSink{out: make(chan Batch, 8)}
+	c := New(reader, nil, sink, WithMinComposeInterval(testHugeWindow))
+	startComposer(t, c)
+
+	c.MarkDirty(true, false)
+	recvBatch(t, sink.out) // would time out (5s << 1h) if the window applied
+	if calls := reader.calls(); len(calls) != 1 {
+		t.Fatalf("read passes=%d, want 1", len(calls))
+	}
+}
+
+// TestWindowQuietPathAfterIdleComposesImmediately: once the window has
+// elapsed since the previous pass, the next dirty signal is not delayed.
+func TestWindowQuietPathAfterIdleComposesImmediately(t *testing.T) {
+	reader := &fakeReader{}
+	sink := &blockingSink{out: make(chan Batch, 8)}
+	window := 50 * time.Millisecond
+	c := New(reader, nil, sink, WithMinComposeInterval(window))
+	startComposer(t, c)
+
+	c.MarkDirty(true, false)
+	recvBatch(t, sink.out)
+	time.Sleep(3 * window) // go idle past the window
+
+	start := time.Now()
+	c.MarkDirty(true, false)
+	recvBatch(t, sink.out)
+	if elapsed := time.Since(start); elapsed >= window {
+		t.Fatalf("quiet-path compose took %v, want < window (%v)", elapsed, window)
+	}
+}
+
+// TestWindowBurstCoalescesBehindWindow: dirt arriving inside the window
+// after a pass must NOT trigger an immediate recompose.
+func TestWindowBurstCoalescesBehindWindow(t *testing.T) {
+	reader := &fakeReader{}
+	sink := &blockingSink{out: make(chan Batch, 8)}
+	c := New(reader, nil, sink, WithMinComposeInterval(testHugeWindow))
+	startComposer(t, c)
+
+	c.MarkDirty(true, false)
+	recvBatch(t, sink.out)
+	for i := 0; i < 50; i++ {
+		c.MarkDirty(true, false)
+	}
+	expectNoBatch(t, sink.out, 100*time.Millisecond)
+	if calls := reader.calls(); len(calls) != 1 {
+		t.Fatalf("read passes=%d, want 1 (burst held behind window)", len(calls))
+	}
+}
+
+// TestWindowTrailingEdgeComposesWithMergedDirt: dirt held behind the window
+// must compose when the window elapses, merging every kind dirtied while
+// the window was open — no lost final state.
+func TestWindowTrailingEdgeComposesWithMergedDirt(t *testing.T) {
+	reader := &fakeReader{}
+	sink := &blockingSink{out: make(chan Batch, 8)}
+	c := New(reader, nil, sink, WithMinComposeInterval(75*time.Millisecond))
+	startComposer(t, c)
+
+	c.MarkDirty(true, false)
+	first := recvBatch(t, sink.out)
+	if first.Sessions == nil || first.Projects != nil {
+		t.Fatalf("first batch=%#v", first)
+	}
+	// Two kinds dirtied inside the window: the trailing pass must carry both.
+	c.MarkDirty(true, false)
+	c.MarkDirty(false, true)
+	second := recvBatch(t, sink.out)
+	if second.Sessions == nil || second.Projects == nil {
+		t.Fatalf("trailing pass lost merged dirt: %#v", second)
+	}
+	calls := reader.calls()
+	if len(calls) != 2 || !calls[1].IncludeSessions || !calls[1].IncludeProjects {
+		t.Fatalf("reads=%#v, want trailing cross-kind read", calls)
+	}
+	expectNoBatch(t, sink.out, 50*time.Millisecond)
+}
+
+// TestWindowShutdownFlushesPendingDirt: Close during the coalescing wait
+// must compose-and-emit the pending dirt before Close returns.
+func TestWindowShutdownFlushesPendingDirt(t *testing.T) {
+	reader := &fakeReader{}
+	sink := &blockingSink{out: make(chan Batch, 8)}
+	c := New(reader, nil, sink, WithMinComposeInterval(testHugeWindow))
+	startComposer(t, c)
+
+	c.MarkDirty(true, false)
+	recvBatch(t, sink.out)
+	c.MarkDirty(false, true) // held behind the 1h window
+	expectNoBatch(t, sink.out, 50*time.Millisecond)
+
+	c.Close() // must flush the pending projects pass before returning
+	select {
+	case b := <-sink.out:
+		if b.Projects == nil {
+			t.Fatalf("flush batch=%#v, want projects", b)
+		}
+	default:
+		t.Fatal("Close dropped dirt pending behind the window")
+	}
+}
+
+// TestWindowContextCancelFlushesPendingDirt: production shutdown cancels the
+// Run context before Close; the flush must still happen (on its own context)
+// and Run must return.
+func TestWindowContextCancelFlushesPendingDirt(t *testing.T) {
+	reader := &fakeReader{}
+	sink := &blockingSink{out: make(chan Batch, 8)}
+	c := New(reader, nil, sink, WithMinComposeInterval(testHugeWindow))
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { c.Run(ctx); close(done) }()
+	t.Cleanup(c.Close)
+
+	c.MarkDirty(true, false)
+	recvBatch(t, sink.out)
+	c.MarkDirty(true, false)
+	expectNoBatch(t, sink.out, 50*time.Millisecond)
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not stop after cancel")
+	}
+	select {
+	case b := <-sink.out:
+		if b.Sessions == nil {
+			t.Fatalf("flush batch=%#v, want sessions", b)
+		}
+	default:
+		t.Fatal("context cancel dropped dirt pending behind the window")
+	}
+}
+
+// TestWindowZeroDisablesCoalescing: the default (no option) and an explicit
+// non-positive window keep pre-window immediacy.
+func TestWindowZeroDisablesCoalescing(t *testing.T) {
+	reader := &fakeReader{}
+	sink := &blockingSink{out: make(chan Batch, 8)}
+	c := New(reader, nil, sink, WithMinComposeInterval(-1))
+	startComposer(t, c)
+	for i := 0; i < 3; i++ {
+		c.MarkDirty(true, false)
+		recvBatch(t, sink.out)
+	}
+	if calls := reader.calls(); len(calls) != 3 {
+		t.Fatalf("read passes=%d, want 3 (window disabled)", len(calls))
+	}
+}
+
+// TestWindowFlushReadsRuntimeOverlay: the shutdown flush is a real pass, not
+// a replay — it must observe the current runtime/store state.
+func TestWindowFlushReadsRuntimeOverlay(t *testing.T) {
+	reader := &fakeReader{result: func(q centralstore.SnapshotQuery) (centralstore.StoreSnapshot, error) {
+		return centralstore.StoreSnapshot{Sessions: []centralstore.SessionView{{Session: centralstore.Session{ID: "s1"}}}}, nil
+	}}
+	var alive atomic.Bool
+	runtime := RuntimeSourceFunc(func() map[centralstore.SessionID]RuntimeFacts {
+		if !alive.Load() {
+			return nil
+		}
+		return map[centralstore.SessionID]RuntimeFacts{"s1": {PID: 42}}
+	})
+	sink := &blockingSink{out: make(chan Batch, 8)}
+	c := New(reader, runtime, sink, WithMinComposeInterval(testHugeWindow))
+	startComposer(t, c)
+
+	c.MarkDirty(true, false)
+	if b := recvBatch(t, sink.out); b.Sessions.Sessions[0].Alive {
+		t.Fatal("first pass should see dead s1")
+	}
+	alive.Store(true)
+	c.MarkDirty(true, false)
+	// Let the composer consume the wake and park inside the window wait:
+	// the flush guarantee covers dirt held BEHIND the window. (Dirt whose
+	// wake was never consumed keeps the pre-existing Close semantics —
+	// see TestCloseBeforePendingWakeNeverEmits.)
+	expectNoBatch(t, sink.out, 50*time.Millisecond)
+	c.Close()
+	select {
+	case b := <-sink.out:
+		if !b.Sessions.Sessions[0].Alive {
+			t.Fatal("flush pass replayed stale runtime overlay")
+		}
+	default:
+		t.Fatal("Close dropped the pending pass")
+	}
+}


### PR DESCRIPTION
## Problem

Every composed batch fans a **full snapshot** to every SSE subscriber. After #516 fixed the per-subscriber encode CPU, bytes remained the last multiplicative storm term: O(rows × passes × subscribers), throttled only by pass duration — ~450 MB per 400-mutation storm at 10k rows × 10 subscribers (combined-resource-gains re-profile, bottleneck #1).

## Change

A **250 ms minimum coalescing window** between composition-pass starts in `internal/snapshot/central.Composer`:

- **Quiet path unchanged**: the first dirty signal after idle composes immediately — no added latency for single mutations.
- **Bursts coalesce**: dirt arriving inside the window is merged into one trailing pass; the trailing edge always composes, so final-state convergence is bounded by window + one pass.
- **Shutdown flushes**: dirt held behind the window is composed and emitted on a short private context before `Run` returns (`Close` joins it) — the window never loses final state.
- No protocol/framing/epoch changes; drop-oldest fanout semantics untouched.

Wired at bootstrap via `ComposeMinInterval` (0 = production default `central.DefaultMinComposeInterval`, negative disables) following the existing `RunnerBudget`-style knob idiom. Integration fixtures that drive many sequential awaited mutations disable it.

## Measurements (in-process probe: real SQLite store → composer → wire cache → fanout → proto2 memo encode; 400 mutations paced at 1 ms, 10 subscribers)

| rows | window | frames/sub | total SSE | composer+encode CPU | convergence after last mutation |
|---|---|---|---|---|---|
| 2500 | off | 27 | 357 MB | 1.12 s | 44 ms |
| 2500 | 100 ms | 7 | 93 MB | 0.40 s | 73 ms |
| 2500 | **250 ms** | **4** | **53 MB (6.7×)** | **0.31 s (3.6×)** | 220 ms |
| 2500 | 500 ms | 2 | 26 MB | 0.23 s | 132 ms |
| 10000 | off | 8 | 424 MB | 1.21 s | 134 ms |
| 10000 | **250 ms** | **4** | **212 MB (2×)** | **0.70 s** | 304 ms |

Quiet-path single-mutation latency at 2.5k rows: ~26–29 ms with the window **off and on** (identical — dominated by pass cost).

**Why 250 ms**: the knee that meets the ≤4 frames/storm target; below ~150 ms the window can't amortize even one storm frame at 10k (pass+encode ≈ 90–130 ms, browser projection recompute ≈ 93 ms/frame); 250 ms keeps cached-frame staleness under the 500 ms `/wait` fallback poll interval.

## Tests

- New deterministic composer tests (`composer_window_test.go`): quiet-path immediacy (cold + post-idle), burst coalescing, trailing-edge composition with merged cross-kind dirt, shutdown flush (Close and ctx-cancel paths), flush-is-a-real-pass (fresh runtime overlay), zero-window disable. All pass `-race -count=3`.
- Full gmuxd suite green under `-race`; existing composer semantics tests (incl. `TestCloseBeforePendingWakeNeverEmits`) unchanged.
- Full Playwright e2e suite (104 tests) passes with the production window; `/wait` settlement uses coordinator outcomes directly plus a 500 ms fanout poll, both unaffected in kind.