### PR TITLE
fix(build): pin exact Go toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,13 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: "1.26"
+          go-version-file: go.work
           cache-dependency-path: |
             **/go.sum
             go.work.sum
+
+      - name: Verify Go toolchain pins
+        run: ./scripts/go-toolchain.sh
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
@@ -67,7 +70,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: "1.26"
+          go-version-file: go.work
           cache-dependency-path: |
             **/go.sum
             go.work.sum
@@ -100,7 +103,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: "1.26"
+          go-version-file: go.work
           cache-dependency-path: |
             **/go.sum
             go.work.sum
@@ -142,7 +145,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: "1.26"
+          go-version-file: go.work
           cache-dependency-path: |
             **/go.sum
             go.work.sum

--- a/.github/workflows/pi-compat.yml
+++ b/.github/workflows/pi-compat.yml
@@ -36,7 +36,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: "1.26"
+          go-version-file: go.work
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -68,7 +68,7 @@ jobs:
       # pull-request merge refs.
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: "1.26"
+          go-version-file: go.work
           cache-dependency-path: |
             **/go.sum
             go.work.sum

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: "1.26"
+          go-version-file: go.work
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:

--- a/cli/gmux/go.mod
+++ b/cli/gmux/go.mod
@@ -2,6 +2,8 @@ module github.com/gmuxapp/gmux/cli/gmux
 
 go 1.26
 
+toolchain go1.26.1
+
 require (
 	github.com/creack/pty v1.1.24
 	golang.org/x/term v0.41.0

--- a/go.work
+++ b/go.work
@@ -1,5 +1,7 @@
 go 1.26.1
 
+toolchain go1.26.1
+
 use (
 	./cli/gmux
 	./packages/adapter

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -7,6 +7,18 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 BIN="$ROOT/bin"
 WEB_EMBED="$ROOT/services/gmuxd/cmd/gmuxd/web"
 
+# A toolchain directive is a preferred minimum under GOTOOLCHAIN=auto; a newer
+# ambient Go can still win. Builds must use the repository's exact toolchain.
+GO_TOOLCHAIN="$("$ROOT/scripts/go-toolchain.sh")"
+export GOTOOLCHAIN="$GO_TOOLCHAIN"
+if ! GO_VERSION="$(go version 2>&1)"; then
+  echo "error: required Go toolchain $GO_TOOLCHAIN is unavailable." >&2
+  echo "The go command could not find or download it:" >&2
+  echo "$GO_VERSION" >&2
+  exit 1
+fi
+echo "→ Using $GO_VERSION"
+
 skip_frontend=false
 for arg in "$@"; do
   case "$arg" in

--- a/scripts/go-toolchain.sh
+++ b/scripts/go-toolchain.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Print the repository's exact Go toolchain after checking duplicated module pins.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+GO_TOOLCHAIN="$(awk '$1 == "toolchain" { print $2; exit }' "$ROOT/go.work")"
+if [[ ! "$GO_TOOLCHAIN" =~ ^go[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "error: go.work must declare an exact 'toolchain goX.Y.Z' version" >&2
+  exit 1
+fi
+
+for module in cli/gmux services/gmuxd; do
+  module_toolchain="$(awk '$1 == "toolchain" { print $2; exit }' "$ROOT/$module/go.mod")"
+  if [[ "$module_toolchain" != "$GO_TOOLCHAIN" ]]; then
+    echo "error: $module/go.mod toolchain '${module_toolchain:-<missing>}' does not match go.work toolchain '$GO_TOOLCHAIN'" >&2
+    exit 1
+  fi
+done
+
+printf '%s\n' "$GO_TOOLCHAIN"

--- a/services/gmuxd/go.mod
+++ b/services/gmuxd/go.mod
@@ -2,6 +2,8 @@ module github.com/gmuxapp/gmux/services/gmuxd
 
 go 1.26.1
 
+toolchain go1.26.1
+
 require (
 	github.com/BurntSushi/toml v1.6.0
 	github.com/fsnotify/fsnotify v1.9.0

--- a/services/gmuxd/tools/production-e2e.Dockerfile
+++ b/services/gmuxd/tools/production-e2e.Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.26-bookworm
+ARG GO_VERSION
+FROM golang:${GO_VERSION}-bookworm
 WORKDIR /src
 COPY go.work go.work.sum ./
 COPY packages ./packages

--- a/services/gmuxd/tools/production-e2e.sh
+++ b/services/gmuxd/tools/production-e2e.sh
@@ -4,7 +4,9 @@ root=$(cd "$(dirname "$0")/../../.." && pwd)
 image=${GMUX_E2E_IMAGE:-gmux-production-e2e:local}
 profile=${GMUX_E2E_PROFILE:-fast}
 case "$profile" in fast|extended) ;; *) echo 'GMUX_E2E_PROFILE must be fast or extended' >&2; exit 2;; esac
-docker build -f "$root/services/gmuxd/tools/production-e2e.Dockerfile" -t "$image" "$root"
+go_toolchain=$("$root/scripts/go-toolchain.sh")
+docker build --build-arg "GO_VERSION=${go_toolchain#go}" \
+  -f "$root/services/gmuxd/tools/production-e2e.Dockerfile" -t "$image" "$root"
 docker run --rm --network=none --pids-limit=512 --read-only \
   --tmpfs /e2e:rw,nosuid,nodev,mode=0700 --tmpfs /tmp:rw,exec,nosuid,nodev \
   -e HOME=/e2e/home -e XDG_STATE_HOME=/e2e/state -e XDG_CONFIG_HOME=/e2e/config -e XDG_RUNTIME_DIR=/e2e/run \


### PR DESCRIPTION
## Summary
- declare Go 1.26.1 as the preferred workspace/application toolchain
- make release/install builds select that exact toolchain, with an early actionable failure if it cannot be obtained
- source every `setup-go` version from `go.work` so CI and GoReleaser do not drift to another patch

## Why
With ambient experimental Go 1.27 and `GOTOOLCHAIN=auto`, the pinned `go-json-experiment/json` dependency does not compile. A `toolchain` directive by itself is insufficient because `auto` permits a newer ambient compiler to win, so the build script must request the exact toolchain.

## Verification
- reproduced the dependency compile failure on `go1.27.0-X:nodwarf5`
- `env -u GOTOOLCHAIN ./scripts/build.sh --skip-frontend` uses and builds with `go1.26.1`
- tested unavailable-toolchain diagnostic
- ran `go test ./...` in every module listed by `go.work`

No install or daemon/live-state operation was performed.
