### PR TITLE
feat(daemon): expose runner recovery progress after restart

### DIFF
--- a/services/gmuxd/cmd/gmuxd/bootstrap.go
+++ b/services/gmuxd/cmd/gmuxd/bootstrap.go
@@ -317,6 +317,14 @@ func (b *Bootstrap) Converge(ctx context.Context) ([]string, error) {
 	if err := b.Coordinator.BeginConvergence(ctx); err != nil {
 		return nil, err
 	}
+	return b.convergeOpen(ctx)
+}
+
+// convergeOpen completes a window already opened by BeginConvergence. The
+// production server uses this seam to guarantee the expected durable count is
+// known before binding local health, then performs runner I/O concurrently
+// with route construction.
+func (b *Bootstrap) convergeOpen(ctx context.Context) ([]string, error) {
 	endpoints, err := b.cfg.Endpoints.Endpoints(ctx)
 	if err != nil {
 		return nil, err

--- a/services/gmuxd/cmd/gmuxd/serve_central.go
+++ b/services/gmuxd/cmd/gmuxd/serve_central.go
@@ -260,6 +260,10 @@ func serveCentral(stderr io.Writer, replace bool) int {
 			tsFQDN = tsListener.FQDN()
 		}
 		h := central.HealthInfo{Service: "gmuxd", Version: version, NodeID: nodeID, Status: "ready", Hostname: identity.Resolve(tsFQDN, osHost), Listen: tcpAddr, RunnerHash: discovery.ExpectedRunnerHash, DefaultLauncher: launchConfig.DefaultLauncher, Launchers: append([]peering.LauncherDef(nil), peerLaunchers...), Peers: currentPeers(peerManager)}
+		if boot != nil {
+			r := boot.Coordinator.RecoveryState()
+			h.SessionRecovery = &central.SessionRecovery{Status: r.Status, Expected: r.Expected, Recovered: r.Recovered}
+		}
 		if tsListener != nil {
 			d := tsListener.Diag()
 			h.Tailscale = &d
@@ -327,16 +331,27 @@ func serveCentral(stderr io.Writer, replace bool) int {
 	}
 	peerManager.Start()
 	defer peerManager.Stop()
+	daemonCtx, daemonCancel := context.WithCancel(context.Background())
+	defer daemonCancel()
 
-	endpoints, err := boot.Converge(context.Background())
-	if err != nil {
+	// Recover surviving runners concurrently with route construction. The Unix
+	// listener binds below before this result is awaited, so local health/CLI
+	// consumers can observe partial recovery instead of mistaking it for an
+	// authoritative empty world. The existing convergence deadline remains the
+	// lifecycle boundary; this changes no registration or sweep semantics.
+	type convergenceResult struct {
+		endpoints []string
+		err       error
+	}
+	if err := boot.Coordinator.BeginConvergence(daemonCtx); err != nil {
 		_, _ = fmt.Fprintf(stderr, "gmuxd: %v\n", err)
 		return 1
 	}
-	if err := boot.StartPostConvergence(context.Background(), endpoints); err != nil {
-		_, _ = fmt.Fprintf(stderr, "gmuxd: %v\n", err)
-		return 1
-	}
+	convergence := make(chan convergenceResult, 1)
+	go func() {
+		endpoints, err := boot.convergeOpen(daemonCtx)
+		convergence <- convergenceResult{endpoints: endpoints, err: err}
+	}()
 
 	seed, events, cancelNotify, err := boot.SubscribeOutcomes(context.Background())
 	if err != nil {
@@ -345,8 +360,6 @@ func serveCentral(stderr io.Writer, replace bool) int {
 	}
 	defer cancelNotify()
 	notifier = newCentralNotifyRouter(presenceTable, defaultNotifyConfig())
-	daemonCtx, daemonCancel := context.WithCancel(context.Background())
-	defer daemonCancel()
 	if cfg.Notifications.Ntfy.Enabled {
 		hostname, _ := os.Hostname()
 		ntfyCfg := cfg.Notifications.Ntfy
@@ -397,6 +410,9 @@ func serveCentral(stderr io.Writer, replace bool) int {
 				launchers = []peering.LauncherDef{}
 			}
 			data := map[string]any{"service": health.Service, "version": health.Version, "pid": os.Getpid(), "node_id": health.NodeID, "status": health.Status, "hostname": health.Hostname, "listen": health.Listen, "peers": peers, "sessions": health.Sessions, "runner_hash": health.RunnerHash, "default_launcher": health.DefaultLauncher, "launchers": launchers, "conversation_index": conversationIndexHealth(convIndex)}
+			if health.SessionRecovery != nil {
+				data["session_recovery"] = health.SessionRecovery
+			}
 			if health.TailscaleURL != "" {
 				data["tailscale_url"] = health.TailscaleURL
 			}
@@ -982,6 +998,36 @@ func serveCentral(stderr io.Writer, replace bool) int {
 		go daemonCancel()
 	})
 
+	// Bind the local control plane while bounded runner convergence is still in
+	// progress. Store-direct GETs are safe here; lifecycle mutations already
+	// honor ErrConvergencePending for rows whose liveness is not yet known.
+	sock := paths.SocketPath()
+	sockLn, err := unixipc.Listen(sock)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "gmuxd: %v\n", err)
+		daemonCancel()
+		return 1
+	}
+	defer sockLn.Close()
+	sockSrv := &http.Server{Handler: unixMux}
+	go func() {
+		if err := sockSrv.Serve(sockLn); err != nil && err != http.ErrServerClosed {
+			log.Printf("unix socket listener: %v", err)
+		}
+	}()
+
+	converged := <-convergence
+	if converged.err != nil {
+		_, _ = fmt.Fprintf(stderr, "gmuxd: %v\n", converged.err)
+		daemonCancel()
+		return 1
+	}
+	if err := boot.StartPostConvergence(daemonCtx, converged.endpoints); err != nil {
+		_, _ = fmt.Fprintf(stderr, "gmuxd: %v\n", err)
+		daemonCancel()
+		return 1
+	}
+
 	boot.StartOwnedTriggers(TriggerConfig{Tick: productionEndpointSchedule(daemonCtx, 30*time.Second), ConversationDeleted: productionConversationDeletionSource(daemonCtx, convIndex), PeerSessionsChanged: nil, PeerWorldChanged: nil, Activity: func(o sessioncoord.Outcome) { fanout.BroadcastActivity(string(o.ID)) }})
 
 	// Conversation discovery runs in the background so the listeners below
@@ -1005,20 +1051,6 @@ func serveCentral(stderr io.Writer, replace bool) int {
 	})
 
 	authedHandler := netauth.Middleware(authToken, commonMux)
-	sock := paths.SocketPath()
-	sockLn, err := unixipc.Listen(sock)
-	if err != nil {
-		_, _ = fmt.Fprintf(stderr, "gmuxd: %v\n", err)
-		daemonCancel()
-		return 1
-	}
-	defer sockLn.Close()
-	sockSrv := &http.Server{Handler: unixMux}
-	go func() {
-		if err := sockSrv.Serve(sockLn); err != nil && err != http.ErrServerClosed {
-			log.Printf("unix socket listener: %v", err)
-		}
-	}()
 	tcpLn, err := net.Listen("tcp", tcpAddr)
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "gmuxd: tcp listener on %s: %v\n", tcpAddr, err)

--- a/services/gmuxd/cmd/gmuxd/serve_switch_integration_test.go
+++ b/services/gmuxd/cmd/gmuxd/serve_switch_integration_test.go
@@ -114,7 +114,7 @@ func readFirstSSEEvent(t *testing.T, sc *bufio.Scanner) (string, []byte) {
 	return "", nil
 }
 
-func TestServeCentralWaitsForConvergenceBeforeListenersAndServesSQLiteState(t *testing.T) {
+func TestServeCentralExposesRecoveryBeforeConvergenceAndServesSQLiteState(t *testing.T) {
 	base, err := os.MkdirTemp("", "s5-switch-")
 	if err != nil {
 		t.Fatal(err)
@@ -142,6 +142,21 @@ func TestServeCentralWaitsForConvergenceBeforeListenersAndServesSQLiteState(t *t
 		t.Fatal(err)
 	}
 
+	// Seed the row exactly as the previous daemon leaves an alive runner: no
+	// exited timestamp. The replacement knows this expected population as soon
+	// as BeginConvergence reads SQLite.
+	seed, err := centralstore.Open(context.Background(), paths.StateDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err = seed.InsertSession(context.Background(), centralstore.NewSession{ID: "1dehpbm1", Adapter: "shell", Command: []string{"/bin/sh"}, Remotes: map[string]string{}, CreatedAt: 1}); err != nil {
+		seed.Close()
+		t.Fatal(err)
+	}
+	if err := seed.Close(); err != nil {
+		t.Fatal(err)
+	}
+
 	metaGate := make(chan struct{})
 	runnerSock := filepath.Join(paths.SessionSocketDir(), "runner-switch.sock")
 	runner := startFakeRunnerServer(t, runnerSock, metaGate, map[string]any{
@@ -163,8 +178,27 @@ func TestServeCentralWaitsForConvergenceBeforeListenersAndServesSQLiteState(t *t
 	go func() { done <- serveCentral(io.Discard, true) }()
 
 	sock := paths.SocketPath()
-	if unixipc.Healthy(sock) {
-		t.Fatal("daemon became healthy before convergence was released")
+	waitUntil(t, 10*time.Second, func() bool { return unixipc.Healthy(sock) }, "daemon did not expose local health during convergence")
+	client := unixipc.Client(sock)
+	healthResp, err := client.Get("http://localhost/v1/health")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var health struct {
+		Data struct {
+			SessionRecovery struct {
+				Status              string `json:"status"`
+				Expected, Recovered int
+			} `json:"session_recovery"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(healthResp.Body).Decode(&health); err != nil {
+		healthResp.Body.Close()
+		t.Fatal(err)
+	}
+	healthResp.Body.Close()
+	if got := health.Data.SessionRecovery; got.Status != "recovering" || got.Expected != 1 || got.Recovered != 0 {
+		t.Fatalf("recovery health before runner release = %+v", got)
 	}
 	if conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), 100*time.Millisecond); err == nil {
 		_ = conn.Close()
@@ -172,9 +206,23 @@ func TestServeCentralWaitsForConvergenceBeforeListenersAndServesSQLiteState(t *t
 	}
 
 	close(metaGate)
-	waitUntil(t, 10*time.Second, func() bool { return unixipc.Healthy(sock) }, "daemon never became healthy after convergence")
+	waitUntil(t, 10*time.Second, func() bool {
+		resp, err := client.Get("http://localhost/v1/health")
+		if err != nil {
+			return false
+		}
+		defer resp.Body.Close()
+		var h struct {
+			Data struct {
+				SessionRecovery struct {
+					Status              string `json:"status"`
+					Expected, Recovered int
+				} `json:"session_recovery"`
+			} `json:"data"`
+		}
+		return json.NewDecoder(resp.Body).Decode(&h) == nil && h.Data.SessionRecovery.Status == "ready" && h.Data.SessionRecovery.Expected == 1 && h.Data.SessionRecovery.Recovered == 1
+	}, "daemon recovery never reached ready")
 
-	client := unixipc.Client(sock)
 	resp, err := client.Get("http://localhost/v1/sessions")
 	if err != nil {
 		t.Fatal(err)

--- a/services/gmuxd/internal/sessioncoord/convergence.go
+++ b/services/gmuxd/internal/sessioncoord/convergence.go
@@ -90,7 +90,10 @@ func (c *Coordinator) FinishConvergence(ctx context.Context, at centralstore.Uni
 		return centralstore.MutationResult{}, err
 	}
 	c.convergeClosed = true
-	c.convergeCandidates = nil
+	// Keep the candidate set as immutable startup provenance. Lifecycle code
+	// keys window openness on convergeClosed, while health can continue to
+	// derive how many of the runners expected at daemon replacement are
+	// currently installed without maintaining a second counter.
 	close(c.converged)
 	seq := c.outcomes.allocSeq() // stamp before releasing c.mu
 	c.mu.Unlock()
@@ -100,6 +103,36 @@ func (c *Coordinator) FinishConvergence(ctx context.Context, at centralstore.Uni
 		c.emitOutcomes(ctx, seq, sweep...)
 	}
 	return result, nil
+}
+
+// RecoveryState is the restart recovery projection derived from the durable
+// rows that were alive at bind time and the runners currently installed in the
+// runtime registry. The existing convergence close is the bounded terminal
+// transition: FinishConvergence marks every unclaimed row dead before Status
+// becomes ready.
+type RecoveryState struct {
+	Status    string `json:"status"`
+	Expected  int    `json:"expected"`
+	Recovered int    `json:"recovered"`
+}
+
+func (c *Coordinator) RecoveryState() RecoveryState {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	status := "ready"
+	// With no previously-alive local rows there is nothing to recover. Runner
+	// endpoint discovery may still be in flight (for brand-new runners), but it
+	// must not make an empty daemon advertise a recovery phase or flap readiness.
+	if !c.convergeClosed && len(c.convergeCandidates) > 0 {
+		status = "recovering"
+	}
+	recovered := 0
+	for id := range c.convergeCandidates {
+		if _, live := c.registry.current(id); live {
+			recovered++
+		}
+	}
+	return RecoveryState{Status: status, Expected: len(c.convergeCandidates), Recovered: recovered}
 }
 
 // Converged is the startup convergence barrier-completion signal. The

--- a/services/gmuxd/internal/sessioncoord/convergence_test.go
+++ b/services/gmuxd/internal/sessioncoord/convergence_test.go
@@ -143,6 +143,91 @@ func TestConvergenceSweepsRunnerWhoseStreamDroppedDuringWindow(t *testing.T) {
 	}
 }
 
+func TestRecoveryStateFreshDaemonReadyImmediatelyWithoutFlap(t *testing.T) {
+	ctx := context.Background()
+	durable := newFakeDurable(0)
+	c := New(nil, newFakeClient(RunnerMeta{}), durable, nil, nil)
+
+	if err := c.BeginConvergence(ctx); err != nil {
+		t.Fatal(err)
+	}
+	want := RecoveryState{Status: "ready", Expected: 0, Recovered: 0}
+	for i := 0; i < 3; i++ {
+		if got := c.RecoveryState(); got != want {
+			t.Fatalf("open empty recovery state[%d] = %+v, want %+v", i, got, want)
+		}
+	}
+	if _, err := c.FinishConvergence(ctx, 500); err != nil {
+		t.Fatal(err)
+	}
+	if got := c.RecoveryState(); got != want {
+		t.Fatalf("empty recovery flapped at terminal close: got %+v, want %+v", got, want)
+	}
+}
+
+func TestRecoveryStateOnlyRemoteAndDeadSessionsReadyImmediately(t *testing.T) {
+	ctx := context.Background()
+	durable := newFakeDurable(0)
+	durable.listSessions = func() ([]centralstore.Session, error) {
+		// Durable.ListSessions is local-only: remote sessions live in the peer
+		// world projection and therefore contribute no recovery candidates.
+		// The local rows present here are already terminal.
+		return []centralstore.Session{exitedSession("1fpaqea0", 1), exitedSession("1ve25bnc", 2)}, nil
+	}
+	c := New(nil, newFakeClient(RunnerMeta{}), durable, nil, nil)
+
+	if err := c.BeginConvergence(ctx); err != nil {
+		t.Fatal(err)
+	}
+	want := RecoveryState{Status: "ready", Expected: 0, Recovered: 0}
+	if got := c.RecoveryState(); got != want {
+		t.Fatalf("remote/dead-only recovery state = %+v, want %+v", got, want)
+	}
+	if _, err := c.FinishConvergence(ctx, 500); err != nil {
+		t.Fatal(err)
+	}
+	if got := c.RecoveryState(); got != want {
+		t.Fatalf("remote/dead-only recovery flapped at terminal close: got %+v, want %+v", got, want)
+	}
+}
+
+func TestRecoveryStateDerivesProgressAndTerminalTransition(t *testing.T) {
+	ctx := context.Background()
+	liveID := sid(6)
+	missingID := centralstore.SessionID("1ve25bnc")
+	durable := newFakeDurable(1)
+	durable.listSessions = func() ([]centralstore.Session, error) {
+		return []centralstore.Session{exitedNilSession(liveID, 1), exitedNilSession(missingID, 2), exitedSession("1fpaqea0", 3)}, nil
+	}
+	durable.registerResult = func(centralstore.RunnerRegistration) (centralstore.Session, centralstore.MutationResult, error) {
+		return exitedNilSession(liveID, 1), centralstore.MutationResult{SessionVersion: 1}, nil
+	}
+	client := newFakeClient(RunnerMeta{Registration: centralstore.RunnerRegistration{ID: liveID, Adapter: "shell", Alive: true}})
+	c := New(nil, client, durable, nil, nil)
+
+	if err := c.BeginConvergence(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if got := c.RecoveryState(); got != (RecoveryState{Status: "recovering", Expected: 2, Recovered: 0}) {
+		t.Fatalf("initial recovery state = %+v", got)
+	}
+	if _, err := c.Register(ctx, RegisterRequest{Endpoint: "sock"}); err != nil {
+		t.Fatal(err)
+	}
+	if got := c.RecoveryState(); got != (RecoveryState{Status: "recovering", Expected: 2, Recovered: 1}) {
+		t.Fatalf("partial recovery state = %+v", got)
+	}
+	if _, err := c.FinishConvergence(ctx, 500); err != nil {
+		t.Fatal(err)
+	}
+	if got := c.RecoveryState(); got != (RecoveryState{Status: "ready", Expected: 2, Recovered: 1}) {
+		t.Fatalf("terminal recovery state = %+v", got)
+	}
+	if len(durable.swept) != 1 || len(durable.swept[0]) != 1 || durable.swept[0][0] != missingID {
+		t.Fatalf("terminal transition did not sweep missing runner: %#v", durable.swept)
+	}
+}
+
 func TestConvergenceWindowLifecycleContract(t *testing.T) {
 	ctx := context.Background()
 	durable := newFakeDurable(0)

--- a/services/gmuxd/internal/snapshot/central/health.go
+++ b/services/gmuxd/internal/snapshot/central/health.go
@@ -35,10 +35,20 @@ type HealthInfo struct {
 	UpdateAvailable string             `json:"update_available,omitempty"`
 	Peers           []peering.PeerInfo `json:"peers,omitempty"`
 	Sessions        SessionCounts      `json:"sessions"`
+	// SessionRecovery makes a daemon replacement's bounded runner convergence
+	// visible. Optional preserves the additive health covenant for producers
+	// that do not have a local lifecycle coordinator (fixtures and peers).
+	SessionRecovery *SessionRecovery `json:"session_recovery,omitempty"`
 	// RunnerHash is the sha256 of the gmux runner binary on disk.
 	RunnerHash      string                `json:"runner_hash,omitempty"`
 	DefaultLauncher string                `json:"default_launcher"`
 	Launchers       []peering.LauncherDef `json:"launchers"`
+}
+
+type SessionRecovery struct {
+	Status    string `json:"status"`
+	Expected  int    `json:"expected"`
+	Recovered int    `json:"recovered"`
 }
 
 // SessionCounts is the health session summary. Per FD-6 it is derived from


### PR DESCRIPTION
## Summary

- expose additive `session_recovery: {status, expected, recovered}` in health and typed world health
- derive restart progress from SQLite rows alive at replacement and installed runner generations
- bind the local control plane during the existing bounded convergence window, while preserving its dead-row sweep and all lifecycle semantics

## Recovery trace

Surviving runners keep serving their Unix sockets; the replacement daemon enumerates them and performs subscribe-first registration. The captured 45s gap is a 10s per-runner bootstrap timeout followed by the first 30s periodic discovery retry. This change makes the partial population explicit and uses the existing convergence sweep as the terminal `ready` transition.

No retry tuning was included: the evidence does not establish why prior-version runners withheld the first `/events` handshake, and changing subscribe-first ordering or retry behavior without a transport-level reproduction is not low-risk.

## Tests

- `GOTOOLCHAIN=go1.26.1 go test ./internal/sessioncoord ./internal/snapshot/central ./cmd/gmuxd`
- `GOTOOLCHAIN=go1.26.1 go test -race ./...` (from `services/gmuxd`)
- integration coverage for a persisted alive row and surviving gated runner (`recovering 0/1` → `ready 1/1`)
