### PR TITLE
fix(web): recover SSE after fatal transport failures

### DIFF
--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -24,9 +24,9 @@ import {
   dismissSession, familyActivityById, health, 
   initStore, isPromotionAnnouncementDelivered,keybinds, 
   keyboardOpen, macCommandIsCtrl,navigate, navigateToSession,peers, projects,promoteSession, promotionAnnouncements,
-  promotionPending, reparentSession,restartSession, resumeSession, selected, selectedId, sessionDotState, 
+  promotionPending, reparentSession,restartSession, resumeSession, retrySSE, selected, selectedId, sessionDotState, 
   sessionStaleness, 
-  sessions, setNavigate, settlePromotion, tabHref,terminalFindOpen, 
+  sessions, setNavigate, settlePromotion, sseRetryAvailable, tabHref,terminalFindOpen, 
   terminalOptions, terminalScrolledUp, terminalScrollToBottom,urlHash,
   urlPath, urlSearch, view, 
 } from './store'
@@ -976,17 +976,19 @@ function App() {
 
   // App-level reconnecting cue for the SSE control-plane. Distinct from
   // the per-terminal WS pill: it covers the sidebar / home / project
-  // views where no terminal WS is active. When a terminal *is* attached
-  // its own "Connection lost, reconnecting…" pill already owns the
-  // offline cue for that view, so we suppress this one to avoid a
-  // doubled-up message on the same screen.
-  const showReconnecting = connVal === 'reconnecting' && !(selectedVal && canAttach)
+  // views where no terminal WS is active. An exhausted SSE retry remains
+  // visible even beside a terminal so the manual retry is never hidden.
+  const showReconnecting = connVal === 'reconnecting' && (!(selectedVal && canAttach) || sseRetryAvailable.value)
 
   return (
     <div class="app-layout">
       {showReconnecting && (
         <div class="reconnecting-pill app-reconnecting-pill" role="status">
-          Connection lost, reconnecting…
+          {sseRetryAvailable.value ? (
+            <>
+              Connection lost. <button type="button" onClick={() => retrySSE()}>Retry</button>
+            </>
+          ) : 'Connection lost, reconnecting…'}
         </div>
       )}
       <Sidebar
@@ -1025,7 +1027,7 @@ function App() {
             <div class="state-icon" style={{ color: 'var(--status-error)' }}>⚠</div>
             <div class="state-title">Connection failed</div>
             <div class="state-subtitle">Could not reach gmuxd. Is it running?</div>
-            <button class="btn btn-primary" style={{ marginTop: 12 }} onClick={() => location.reload()}>
+            <button class="btn btn-primary" style={{ marginTop: 12 }} onClick={() => retrySSE()}>
               Retry
             </button>
           </div>

--- a/apps/gmux-web/src/sse-store-lifecycle.test.ts
+++ b/apps/gmux-web/src/sse-store-lifecycle.test.ts
@@ -143,6 +143,34 @@ describe('SSE store lifecycle wiring', () => {
     cleanup()
   })
 
+  it('treats delivered frames as liveness, so a long-lived tab pays no bootstrap', () => {
+    const { sources, cleanup, wake } = install()
+    sources[0].bootstrap(1)
+
+    // The daemon sends a session-activity frame (and a heartbeat) on a live
+    // stream. A tab open for hours is the normal case: if only the open
+    // counted as liveness, every wake past the threshold would re-send the
+    // full sessions transaction and world frame.
+    for (let i = 0; i < 5; i++) {
+      vi.advanceTimersByTime(50_000)
+      sources[0].emit('session-activity', { id: 'sess-1' })
+      wake()
+      vi.advanceTimersByTime(1_000)
+      vi.runOnlyPendingTimers()
+    }
+    expect(sources).toHaveLength(1)
+    expect(sources[0].closed).toBe(false)
+    expect(connState.value).toBe('connected')
+
+    // Frames stop for longer than the threshold: the next wake revalidates.
+    vi.advanceTimersByTime(61_000)
+    wake()
+    vi.advanceTimersByTime(1_000)
+    vi.runOnlyPendingTimers()
+    expect(sources).toHaveLength(2)
+    cleanup()
+  })
+
   it('replaces a stale stream on a wake and stages the new epoch atomically', () => {
     const { sources, cleanup, wake } = install()
     sources[0].bootstrap(1)

--- a/apps/gmux-web/src/sse-store-lifecycle.test.ts
+++ b/apps/gmux-web/src/sse-store-lifecycle.test.ts
@@ -1,0 +1,212 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { connState, initStore, sseRetryAvailable } from './store'
+
+class FakeSource {
+  static instances: FakeSource[] = []
+  readyState = 0
+  closed = false
+  private listeners = new Map<string, ((event: MessageEvent) => void)[]>()
+
+  constructor() {
+    FakeSource.instances.push(this)
+  }
+
+  addEventListener(type: string, listener: (event: MessageEvent) => void) {
+    this.listeners.set(type, [...(this.listeners.get(type) ?? []), listener])
+  }
+
+  close() {
+    this.closed = true
+    this.readyState = 2
+  }
+
+  emit(type: string, data: unknown = {}) {
+    if (type === 'open') this.readyState = 1
+    const event = { data: JSON.stringify(data) } as MessageEvent
+    for (const listener of this.listeners.get(type) ?? []) listener(event)
+  }
+
+  /** Deliver a complete protocol-3 bootstrap, as the daemon does on subscribe. */
+  bootstrap(epoch: number) {
+    this.emit('open')
+    this.emit('snapshot.sessions.begin', { version: 3, epoch })
+    this.emit('snapshot.sessions.ready', { epoch })
+  }
+}
+
+class FakeEventTarget {
+  listeners = new Map<string, (() => void)[]>()
+  addEventListener = (type: string, listener: () => void) => {
+    this.listeners.set(type, [...(this.listeners.get(type) ?? []), listener])
+  }
+  removeEventListener = (type: string, listener: () => void) => {
+    this.listeners.set(type, (this.listeners.get(type) ?? []).filter(fn => fn !== listener))
+  }
+  dispatch(type: string) {
+    for (const listener of this.listeners.get(type) ?? []) listener()
+  }
+}
+
+type FakeDocument = FakeEventTarget & { visibilityState: DocumentVisibilityState }
+
+function install() {
+  vi.useFakeTimers()
+  vi.setSystemTime(1_000)
+  FakeSource.instances = []
+  const doc = new FakeEventTarget() as FakeDocument
+  doc.visibilityState = 'visible'
+  const win = new FakeEventTarget()
+  vi.stubGlobal('document', doc)
+  vi.stubGlobal('window', win)
+  vi.stubGlobal('EventSource', FakeSource as unknown as typeof EventSource)
+  vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({}) } as Response)))
+  const cleanup = initStore()
+  /** One logical wake: the browser delivers all four signals, in any order. */
+  const wake = () => {
+    doc.dispatch('visibilitychange')
+    win.dispatch('pageshow')
+    doc.dispatch('resume')
+    win.dispatch('online')
+  }
+  return { doc, win, cleanup, wake, sources: FakeSource.instances }
+}
+
+describe('SSE store lifecycle wiring', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+
+  it('coalesces a wake into at most one revalidation and skips a healthy stream', () => {
+    const { sources, cleanup, wake, doc, win } = install()
+    sources[0].bootstrap(1)
+    expect(connState.value).toBe('connected')
+
+    wake()
+    vi.advanceTimersByTime(999)
+    expect(sources).toHaveLength(1)
+    vi.advanceTimersByTime(1)
+    // The stream is open and recently active: no new full bootstrap is paid.
+    expect(sources).toHaveLength(1)
+
+    doc.visibilityState = 'hidden'
+    win.dispatch('online')
+    doc.dispatch('resume')
+    vi.advanceTimersByTime(5_000)
+    expect(sources).toHaveLength(1)
+
+    cleanup()
+    doc.visibilityState = 'visible'
+    wake()
+    vi.advanceTimersByTime(5_000)
+    expect(sources).toHaveLength(1)
+  })
+
+  it('does not arm any work from a hidden-tab online event', () => {
+    const { sources, cleanup, wake, doc, win } = install()
+    sources[0].bootstrap(1)
+    vi.advanceTimersByTime(120_000)
+
+    doc.visibilityState = 'hidden'
+    win.dispatch('online')
+    vi.advanceTimersByTime(500)
+    // Becoming visible later fires visibilitychange, which is the wake that
+    // matters. The hidden `online` must not have left a timer behind.
+    doc.visibilityState = 'visible'
+    vi.advanceTimersByTime(600)
+    expect(sources).toHaveLength(1)
+    expect(sources[0].closed).toBe(false)
+
+    wake()
+    vi.advanceTimersByTime(1_000)
+    vi.runOnlyPendingTimers()
+    expect(sources).toHaveLength(2)
+    cleanup()
+  })
+
+  it('does not revalidate when the tab is hidden again inside the debounce window', () => {
+    const { sources, cleanup, wake, doc } = install()
+    sources[0].bootstrap(1)
+    vi.advanceTimersByTime(120_000)
+
+    wake()
+    doc.visibilityState = 'hidden'
+    vi.advanceTimersByTime(5_000)
+    expect(sources).toHaveLength(1)
+    expect(sources[0].closed).toBe(false)
+
+    doc.visibilityState = 'visible'
+    wake()
+    vi.advanceTimersByTime(1_000)
+    vi.runOnlyPendingTimers()
+    expect(sources).toHaveLength(2)
+    cleanup()
+  })
+
+  it('replaces a stale stream on a wake and stages the new epoch atomically', () => {
+    const { sources, cleanup, wake } = install()
+    sources[0].bootstrap(1)
+    // Past the staleness threshold: an OPEN readyState is not proof that the
+    // TCP stream still delivers bytes after a mobile suspend.
+    vi.advanceTimersByTime(120_000)
+    wake()
+    vi.advanceTimersByTime(1_000)
+    expect(sources[0].closed).toBe(true)
+    expect(connState.value).toBe('reconnecting')
+    vi.runOnlyPendingTimers()
+    expect(sources).toHaveLength(2)
+    sources[1].bootstrap(1)
+    expect(connState.value).toBe('connected')
+    cleanup()
+  })
+
+  it('ignores an error from a source the supervisor already replaced', () => {
+    const { sources, cleanup, wake } = install()
+    sources[0].bootstrap(1)
+    vi.advanceTimersByTime(120_000)
+    wake()
+    vi.advanceTimersByTime(1_000)
+    vi.runOnlyPendingTimers()
+    expect(sources).toHaveLength(2)
+    sources[1].bootstrap(2)
+    expect(connState.value).toBe('connected')
+
+    // The replaced source's late error must not reset the live transport's
+    // staging or park the UI in 'reconnecting' with no retry pending.
+    sources[0].emit('error')
+    expect(connState.value).toBe('connected')
+    expect(sseRetryAvailable.value).toBe(false)
+    expect(sources).toHaveLength(2)
+    cleanup()
+  })
+
+  it('recovers on a wake after the whole retry budget was exhausted', () => {
+    const { sources, cleanup, wake } = install()
+    sources[0].bootstrap(1)
+
+    // A daemon that keeps failing: every replacement source errors at once.
+    // The supervisor's 60 s budget must run out and stop on its own.
+    for (let i = 0; i < 400 && !sseRetryAvailable.value; i++) {
+      sources[sources.length - 1].emit('error')
+      vi.advanceTimersByTime(10_000)
+    }
+    expect(sseRetryAvailable.value).toBe(true)
+    const exhaustedCount = sources.length
+    expect(exhaustedCount).toBeLessThan(40)
+
+    // Idle: an exhausted supervisor must not spin in the background.
+    vi.advanceTimersByTime(600_000)
+    expect(sources).toHaveLength(exhaustedCount)
+
+    // The phone comes back minutes later. No tap: the wake alone must open a
+    // new source against the now-healthy daemon.
+    wake()
+    vi.advanceTimersByTime(1_000)
+    vi.runOnlyPendingTimers()
+    expect(sources.length).toBeGreaterThan(exhaustedCount)
+    sources[sources.length - 1].bootstrap(3)
+    expect(connState.value).toBe('connected')
+    expect(sseRetryAvailable.value).toBe(false)
+    cleanup()
+  })
+})

--- a/apps/gmux-web/src/sse-supervisor.test.ts
+++ b/apps/gmux-web/src/sse-supervisor.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createSSESupervisor, type SSESource } from './sse-supervisor'
+
+class FakeSource implements SSESource {
+  readyState = 0
+  closed = false
+  private listeners = new Map<string, ((event: MessageEvent) => void)[]>()
+
+  addEventListener(type: string, listener: (event: MessageEvent) => void) {
+    this.listeners.set(type, [...(this.listeners.get(type) ?? []), listener])
+  }
+
+  close() {
+    this.closed = true
+    this.readyState = 2
+  }
+
+  emit(type: 'open' | 'error') {
+    if (type === 'open') this.readyState = 1
+    for (const listener of this.listeners.get(type) ?? []) listener(new MessageEvent(type))
+  }
+}
+
+describe('SSE supervisor', () => {
+  afterEach(() => vi.useRealTimers())
+
+  function setup(options: Partial<Parameters<typeof createSSESupervisor>[0]> = {}) {
+    const sources: FakeSource[] = []
+    const supervisor = createSSESupervisor({
+      connect: callbacks => {
+        const source = new FakeSource()
+        source.addEventListener('open', callbacks.opened)
+        source.addEventListener('error', callbacks.failed)
+        sources.push(source)
+        return source
+      },
+      random: () => 0.5,
+      ...options,
+    })
+    return { supervisor, sources }
+  }
+
+  it('replaces a source after a fatal error instead of trusting native retry', () => {
+    vi.useFakeTimers()
+    const scheduled = vi.fn()
+    const { supervisor, sources } = setup({ onRetryScheduled: scheduled })
+
+    supervisor.start()
+    sources[0].emit('error')
+    expect(sources[0].closed).toBe(true)
+    expect(scheduled).toHaveBeenCalledTimes(1)
+    expect(sources).toHaveLength(1)
+
+    vi.advanceTimersByTime(499)
+    expect(sources).toHaveLength(1)
+    vi.advanceTimersByTime(1)
+    expect(sources).toHaveLength(2)
+  })
+
+  it('ignores events from a superseded source and cancels pending work on stop', () => {
+    vi.useFakeTimers()
+    const { supervisor, sources } = setup()
+    supervisor.start()
+    sources[0].emit('error')
+    supervisor.revalidate()
+    expect(sources[0].closed).toBe(true)
+    expect(sources).toHaveLength(1)
+    vi.advanceTimersByTime(0)
+    expect(sources).toHaveLength(2)
+
+    sources[0].emit('error')
+    expect(sources).toHaveLength(2)
+    supervisor.stop()
+    sources[1].emit('error')
+    vi.runAllTimers()
+    expect(sources).toHaveLength(2)
+  })
+
+  it('resets the retry budget after a successful open', () => {
+    vi.useFakeTimers()
+    const exhausted = vi.fn()
+    const { supervisor, sources } = setup({ maxRetryDurationMs: 1000, onExhausted: exhausted })
+    supervisor.start()
+    sources[0].emit('error')
+    vi.advanceTimersByTime(500)
+    sources[1].emit('open')
+    sources[1].emit('error')
+    vi.advanceTimersByTime(500)
+    expect(sources).toHaveLength(3)
+    expect(exhausted).not.toHaveBeenCalled()
+  })
+
+  it('stops automatic retries at the deadline and reports manual retry availability', () => {
+    vi.useFakeTimers()
+    const exhausted = vi.fn()
+    const { supervisor, sources } = setup({ maxRetryDurationMs: 1000, onExhausted: exhausted })
+    supervisor.start()
+    sources[0].emit('error')
+    vi.advanceTimersByTime(500)
+    sources[1].emit('error')
+    vi.advanceTimersByTime(999)
+    expect(exhausted).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(1)
+    // The second failed attempt's backoff would fire at t=1500, but the
+    // deadline is checked before opening another source. No polling timer is
+    // needed and no post-deadline attempt is created.
+    expect(sources).toHaveLength(2)
+    expect(exhausted).toHaveBeenCalledTimes(1)
+    expect(sources[1].closed).toBe(true)
+
+    supervisor.retry()
+    vi.advanceTimersByTime(0)
+    expect(sources).toHaveLength(3)
+  })
+
+  it('revalidates an OPEN source on resume without polling in the quiet path', () => {
+    vi.useFakeTimers()
+    const { supervisor, sources } = setup()
+    supervisor.start()
+    sources[0].emit('open')
+    supervisor.revalidate()
+    expect(sources[0].closed).toBe(true)
+    vi.advanceTimersByTime(0)
+    expect(sources).toHaveLength(2)
+  })
+})

--- a/apps/gmux-web/src/sse-supervisor.test.ts
+++ b/apps/gmux-web/src/sse-supervisor.test.ts
@@ -15,7 +15,7 @@ class FakeSource implements SSESource {
     this.readyState = 2
   }
 
-  emit(type: 'open' | 'error') {
+  emit(type: 'open' | 'error' | 'message') {
     if (type === 'open') this.readyState = 1
     for (const listener of this.listeners.get(type) ?? []) listener(new MessageEvent(type))
   }
@@ -31,6 +31,7 @@ describe('SSE supervisor', () => {
         const source = new FakeSource()
         source.addEventListener('open', callbacks.opened)
         source.addEventListener('error', callbacks.failed)
+        source.addEventListener('message', callbacks.activity)
         sources.push(source)
         return source
       },
@@ -191,6 +192,60 @@ describe('SSE supervisor', () => {
     vi.advanceTimersByTime(0)
     expect(sources).toHaveLength(3)
     expect(sources[2].closed).toBe(false)
+  })
+
+  it('counts delivered frames as liveness, not just the open', () => {
+    vi.useFakeTimers()
+    const { supervisor, sources } = setup({ staleDurationMs: 1000 })
+    supervisor.start()
+    sources[0].emit('open')
+
+    // A stream that is still delivering frames is alive however long ago it
+    // opened. Without this, every tab open longer than the threshold — the
+    // normal case — would pay a full bootstrap on every wake.
+    for (let i = 0; i < 5; i++) {
+      vi.advanceTimersByTime(900)
+      sources[0].emit('message')
+      supervisor.revalidate()
+      vi.advanceTimersByTime(0)
+    }
+    expect(sources).toHaveLength(1)
+    expect(sources[0].closed).toBe(false)
+
+    // Frames stop: the next wake past the threshold replaces the source.
+    vi.advanceTimersByTime(1001)
+    supervisor.revalidate()
+    vi.advanceTimersByTime(0)
+    expect(sources).toHaveLength(2)
+  })
+
+  it('lets a wake refresh the deadline without collapsing the backoff', () => {
+    vi.useFakeTimers()
+    const { supervisor, sources } = setup({ maxRetryDurationMs: 60_000 })
+    supervisor.start()
+    sources[0].emit('error')
+    vi.advanceTimersByTime(500)
+    sources[1].emit('error')
+    vi.advanceTimersByTime(1000)
+    sources[2].emit('error')
+    vi.advanceTimersByTime(2000)
+    expect(sources).toHaveLength(4)
+
+    // Wakes arriving at the store's debounce ceiling must not drag the retry
+    // rate back to the 500 ms floor.
+    supervisor.revalidate()
+    sources[3].emit('error')
+    vi.advanceTimersByTime(3999)
+    expect(sources).toHaveLength(4)
+    vi.advanceTimersByTime(1)
+    expect(sources).toHaveLength(5)
+
+    // A user's tap is different: it restores the floor.
+    supervisor.retry()
+    vi.advanceTimersByTime(0)
+    sources[5].emit('error')
+    vi.advanceTimersByTime(500)
+    expect(sources).toHaveLength(7)
   })
 
   it('does not replace a recently active source, but revalidates a stale one', () => {

--- a/apps/gmux-web/src/sse-supervisor.test.ts
+++ b/apps/gmux-web/src/sse-supervisor.test.ts
@@ -57,40 +57,125 @@ describe('SSE supervisor', () => {
     expect(sources).toHaveLength(2)
   })
 
-  it('ignores events from a superseded source and cancels pending work on stop', () => {
+  it('ignores a superseded source error without closing the live source or scheduling', () => {
+    vi.useFakeTimers()
+    const scheduled = vi.fn()
+    const { supervisor, sources } = setup({ onRetryScheduled: scheduled })
+    supervisor.start()
+    sources[0].emit('error')
+    expect(scheduled).toHaveBeenCalledTimes(1)
+    vi.advanceTimersByTime(500)
+    expect(sources).toHaveLength(2)
+    sources[1].emit('open')
+
+    // The replaced source's error must not touch the live source's state.
+    sources[0].emit('error')
+    expect(sources[1].closed).toBe(false)
+    expect(scheduled).toHaveBeenCalledTimes(1)
+    vi.runOnlyPendingTimers()
+    expect(sources).toHaveLength(2)
+  })
+
+  it('does not let a late open from a superseded source credit the retry budget', () => {
+    vi.useFakeTimers()
+    const exhausted = vi.fn()
+    const { supervisor, sources } = setup({
+      maxRetryDurationMs: 1000, stableOpenDurationMs: 200, onExhausted: exhausted,
+    })
+    supervisor.start()
+    sources[0].emit('error')
+    vi.advanceTimersByTime(500)
+    expect(sources).toHaveLength(2)
+
+    // A late open belonging to the replaced generation is not evidence that
+    // the live source is healthy: it must not count as a stable open.
+    sources[0].emit('open')
+    vi.advanceTimersByTime(700)
+    sources[1].emit('error')
+    expect(exhausted).toHaveBeenCalledTimes(1)
+    vi.advanceTimersByTime(1000)
+    expect(sources).toHaveLength(2)
+  })
+
+  it('lets a pending retry absorb a wake instead of adding a source', () => {
     vi.useFakeTimers()
     const { supervisor, sources } = setup()
     supervisor.start()
     sources[0].emit('error')
     supervisor.revalidate()
-    expect(sources[0].closed).toBe(true)
-    expect(sources).toHaveLength(1)
     vi.advanceTimersByTime(0)
+    expect(sources).toHaveLength(1)
+    vi.advanceTimersByTime(500)
     expect(sources).toHaveLength(2)
 
-    sources[0].emit('error')
-    expect(sources).toHaveLength(2)
     supervisor.stop()
     sources[1].emit('error')
     vi.runAllTimers()
     expect(sources).toHaveLength(2)
   })
 
-  it('resets the retry budget after a successful open', () => {
+  it('cancels a pending automatic retry when a manual retry replaces it', () => {
+    vi.useFakeTimers()
+    const { supervisor, sources } = setup()
+    supervisor.start()
+    sources[0].emit('error')
+    supervisor.retry()
+    vi.advanceTimersByTime(0)
+    expect(sources).toHaveLength(2)
+    // The superseded backoff timer must not open a second live source.
+    vi.advanceTimersByTime(1000)
+    expect(sources).toHaveLength(2)
+    expect(sources.filter(source => !source.closed)).toHaveLength(1)
+  })
+
+  it('does not stack sources on repeated wakes, but replaces a wedged attempt', () => {
+    vi.useFakeTimers()
+    const { supervisor, sources } = setup({ attemptTimeoutMs: 1000 })
+    supervisor.start()
+    expect(sources[0].readyState).toBe(0)
+    supervisor.revalidate()
+    supervisor.revalidate()
+    vi.advanceTimersByTime(0)
+    expect(sources).toHaveLength(1)
+
+    vi.advanceTimersByTime(1001)
+    supervisor.revalidate()
+    vi.advanceTimersByTime(0)
+    expect(sources).toHaveLength(2)
+    expect(sources[0].closed).toBe(true)
+  })
+
+  it('keeps short-lived opens in the same bounded retry window', () => {
     vi.useFakeTimers()
     const exhausted = vi.fn()
-    const { supervisor, sources } = setup({ maxRetryDurationMs: 1000, onExhausted: exhausted })
+    const { supervisor, sources } = setup({ maxRetryDurationMs: 1000, stableOpenDurationMs: 500, onExhausted: exhausted })
     supervisor.start()
     sources[0].emit('error')
     vi.advanceTimersByTime(500)
     sources[1].emit('open')
+    vi.advanceTimersByTime(100)
+    sources[1].emit('error')
+    vi.advanceTimersByTime(1000)
+    expect(exhausted).toHaveBeenCalledTimes(1)
+    expect(sources).toHaveLength(2)
+  })
+
+  it('resets the retry budget only after a stable open', () => {
+    vi.useFakeTimers()
+    const exhausted = vi.fn()
+    const { supervisor, sources } = setup({ maxRetryDurationMs: 1000, stableOpenDurationMs: 500, onExhausted: exhausted })
+    supervisor.start()
+    sources[0].emit('error')
+    vi.advanceTimersByTime(500)
+    sources[1].emit('open')
+    vi.advanceTimersByTime(500) // stable-open timer credits this source
     sources[1].emit('error')
     vi.advanceTimersByTime(500)
     expect(sources).toHaveLength(3)
     expect(exhausted).not.toHaveBeenCalled()
   })
 
-  it('stops automatic retries at the deadline and reports manual retry availability', () => {
+  it('restarts after a wake even when the previous retry window was exhausted', () => {
     vi.useFakeTimers()
     const exhausted = vi.fn()
     const { supervisor, sources } = setup({ maxRetryDurationMs: 1000, onExhausted: exhausted })
@@ -98,29 +183,30 @@ describe('SSE supervisor', () => {
     sources[0].emit('error')
     vi.advanceTimersByTime(500)
     sources[1].emit('error')
-    vi.advanceTimersByTime(999)
-    expect(exhausted).not.toHaveBeenCalled()
-    vi.advanceTimersByTime(1)
-    // The second failed attempt's backoff would fire at t=1500, but the
-    // deadline is checked before opening another source. No polling timer is
-    // needed and no post-deadline attempt is created.
-    expect(sources).toHaveLength(2)
+    vi.advanceTimersByTime(1000)
     expect(exhausted).toHaveBeenCalledTimes(1)
-    expect(sources[1].closed).toBe(true)
+    expect(sources).toHaveLength(2)
 
-    supervisor.retry()
+    supervisor.revalidate()
     vi.advanceTimersByTime(0)
     expect(sources).toHaveLength(3)
+    expect(sources[2].closed).toBe(false)
   })
 
-  it('revalidates an OPEN source on resume without polling in the quiet path', () => {
+  it('does not replace a recently active source, but revalidates a stale one', () => {
     vi.useFakeTimers()
-    const { supervisor, sources } = setup()
+    const { supervisor, sources } = setup({ staleDurationMs: 1000 })
     supervisor.start()
     sources[0].emit('open')
     supervisor.revalidate()
-    expect(sources[0].closed).toBe(true)
     vi.advanceTimersByTime(0)
+    expect(sources[0].closed).toBe(false)
+    expect(sources).toHaveLength(1)
+
+    vi.advanceTimersByTime(1001)
+    supervisor.revalidate()
+    vi.advanceTimersByTime(0)
+    expect(sources[0].closed).toBe(true)
     expect(sources).toHaveLength(2)
   })
 })

--- a/apps/gmux-web/src/sse-supervisor.ts
+++ b/apps/gmux-web/src/sse-supervisor.ts
@@ -47,7 +47,8 @@ export interface SSESupervisor {
  *  - `revalidate()` (a wake) and `retry()` (a tap) are new information and
  *    always open a fresh window, including after exhaustion — a phone that
  *    returns after ten minutes must recover without a tap. They never stack
- *    sources: a pending retry or an in-flight attempt absorbs the wake.
+ *    sources: a pending retry or an in-flight attempt absorbs the wake. A
+ *    wake refreshes the deadline only; a tap also restores the backoff floor.
  *
  * Lifecycle revalidation replaces only an unhealthy or stale source: after
  * mobile or a frozen tab resumes, an OPEN readyState is not proof that the
@@ -189,9 +190,12 @@ export function createSSESupervisor(options: SSESupervisorOptions): SSESuperviso
       // is expensive on a phone.
       if (source?.readyState === 1 && lastActivityAt !== null
           && now() - lastActivityAt < staleDurationMs) return
-      // A wake or a user intent is new information: it always earns a fresh
-      // bounded window, including after the previous one was exhausted.
-      attempts = 0
+      // A wake is new information: it always earns a fresh bounded window,
+      // including after the previous one was exhausted. It does *not* reset
+      // `attempts`: a tab receiving wakes at the debounce ceiling would then
+      // reconnect at the 500 ms floor forever. The backoff keeps growing
+      // (capped at `maxDelayMs`) and only a user's `retry()` restores the
+      // floor, so self-healing stays immediate while the load stays honest.
       retryStartedAt = null
       // But it must not pile up sources. A pending retry or an attempt still
       // in flight already covers this wake; it now carries the new budget.

--- a/apps/gmux-web/src/sse-supervisor.ts
+++ b/apps/gmux-web/src/sse-supervisor.ts
@@ -1,0 +1,141 @@
+export interface SSESource {
+  readonly readyState: number
+  addEventListener(type: string, listener: (event: MessageEvent) => void): void
+  close(): void
+}
+
+export interface SSESupervisorCallbacks {
+  opened: () => void
+  failed: () => void
+}
+
+export interface SSESupervisorOptions {
+  connect: (callbacks: SSESupervisorCallbacks) => SSESource
+  onRetryScheduled?: () => void
+  onExhausted?: () => void
+  now?: () => number
+  random?: () => number
+  maxRetryDurationMs?: number
+  maxDelayMs?: number
+}
+
+export interface SSESupervisor {
+  start(): void
+  stop(): void
+  retry(): void
+  revalidate(): void
+}
+
+/**
+ * Owns EventSource replacement rather than delegating recovery to the
+ * browser's native retry. Native retry can terminate permanently after a
+ * fatal response (notably 401/503), leaving an EventSource in CLOSED forever.
+ *
+ * Retries are bounded by elapsed time, cancellable, and jittered. A lifecycle
+ * revalidation deliberately replaces even an OPEN source: after mobile or a
+ * frozen tab resumes, an OPEN readyState does not prove the TCP stream still
+ * delivers bytes.
+ */
+export function createSSESupervisor(options: SSESupervisorOptions): SSESupervisor {
+  const now = options.now ?? Date.now
+  const random = options.random ?? Math.random
+  const maxRetryDurationMs = options.maxRetryDurationMs ?? 60_000
+  const maxDelayMs = options.maxDelayMs ?? 8_000
+
+  let source: SSESource | null = null
+  let timer: ReturnType<typeof setTimeout> | null = null
+  let stopped = true
+  let generation = 0
+  let attempts = 0
+  let retryStartedAt: number | null = null
+
+  const clearTimer = () => {
+    if (timer !== null) clearTimeout(timer)
+    timer = null
+  }
+
+  const closeSource = () => {
+    const current = source
+    source = null
+    current?.close()
+  }
+
+  const exhausted = () => {
+    clearTimer()
+    closeSource()
+    options.onExhausted?.()
+  }
+
+  const connect = () => {
+    if (stopped) return
+    clearTimer()
+    if (retryStartedAt !== null && now() - retryStartedAt >= maxRetryDurationMs) {
+      exhausted()
+      return
+    }
+    const myGeneration = ++generation
+    let next: SSESource | null = null
+    next = options.connect({
+      opened: () => {
+        if (stopped || myGeneration !== generation) return
+        attempts = 0
+        retryStartedAt = null
+      },
+      failed: () => {
+        if (stopped || myGeneration !== generation) return
+        closeSource()
+        if (retryStartedAt === null) retryStartedAt = now()
+        const elapsed = now() - retryStartedAt
+        if (elapsed >= maxRetryDurationMs) {
+          exhausted()
+          return
+        }
+        const base = Math.min(500 * Math.pow(2, attempts), maxDelayMs)
+        attempts++
+        // ±20% jitter avoids a set of resumed tabs reconnecting in lockstep.
+        const delay = Math.max(0, Math.round(base * (0.8 + random() * 0.4)))
+        options.onRetryScheduled?.()
+        timer = setTimeout(connect, delay)
+      },
+    })
+    source = next
+  }
+
+  const restart = () => {
+    if (stopped) return
+    generation++
+    clearTimer()
+    closeSource()
+    if (retryStartedAt === null) retryStartedAt = now()
+    options.onRetryScheduled?.()
+    timer = setTimeout(connect, 0)
+  }
+
+  return {
+    start() {
+      if (!stopped) return
+      stopped = false
+      attempts = 0
+      retryStartedAt = null
+      connect()
+    },
+    stop() {
+      stopped = true
+      generation++
+      clearTimer()
+      closeSource()
+    },
+    retry() {
+      if (stopped) return
+      attempts = 0
+      retryStartedAt = null
+      restart()
+    },
+    revalidate() {
+      if (stopped) return
+      // CLOSED and CONNECTING both need an explicit replacement. OPEN is
+      // replaced too: readyState alone cannot expose a dead post-resume TCP.
+      restart()
+    },
+  }
+}

--- a/apps/gmux-web/src/sse-supervisor.ts
+++ b/apps/gmux-web/src/sse-supervisor.ts
@@ -6,17 +6,22 @@ export interface SSESource {
 
 export interface SSESupervisorCallbacks {
   opened: () => void
+  activity: () => void
   failed: () => void
 }
 
 export interface SSESupervisorOptions {
   connect: (callbacks: SSESupervisorCallbacks) => SSESource
+  onFailure?: () => void
   onRetryScheduled?: () => void
   onExhausted?: () => void
   now?: () => number
   random?: () => number
   maxRetryDurationMs?: number
   maxDelayMs?: number
+  stableOpenDurationMs?: number
+  staleDurationMs?: number
+  attemptTimeoutMs?: number
 }
 
 export interface SSESupervisor {
@@ -31,19 +36,38 @@ export interface SSESupervisor {
  * browser's native retry. Native retry can terminate permanently after a
  * fatal response (notably 401/503), leaving an EventSource in CLOSED forever.
  *
- * Retries are bounded by elapsed time, cancellable, and jittered. A lifecycle
- * revalidation deliberately replaces even an OPEN source: after mobile or a
- * frozen tab resumes, an OPEN readyState does not prove the TCP stream still
- * delivers bytes.
+ * Retries are bounded by elapsed time, cancellable, and jittered. The budget
+ * model has three rules:
+ *
+ *  - Only a source that stayed open at least `stableOpenDurationMs` credits
+ *    success. A server that accepts and immediately drops the stream keeps
+ *    consuming one window instead of resetting it on every flap.
+ *  - When the window runs out the supervisor stops entirely: no source, no
+ *    timer, nothing to spin in a background tab. The UI offers a manual retry.
+ *  - `revalidate()` (a wake) and `retry()` (a tap) are new information and
+ *    always open a fresh window, including after exhaustion — a phone that
+ *    returns after ten minutes must recover without a tap. They never stack
+ *    sources: a pending retry or an in-flight attempt absorbs the wake.
+ *
+ * Lifecycle revalidation replaces only an unhealthy or stale source: after
+ * mobile or a frozen tab resumes, an OPEN readyState is not proof that the
+ * TCP stream still delivers bytes, but a stream that delivered bytes moments
+ * ago needs no new (full) bootstrap.
  */
 export function createSSESupervisor(options: SSESupervisorOptions): SSESupervisor {
   const now = options.now ?? Date.now
   const random = options.random ?? Math.random
   const maxRetryDurationMs = options.maxRetryDurationMs ?? 60_000
   const maxDelayMs = options.maxDelayMs ?? 8_000
+  const stableOpenDurationMs = options.stableOpenDurationMs ?? 10_000
+  const staleDurationMs = options.staleDurationMs ?? 60_000
+  const attemptTimeoutMs = options.attemptTimeoutMs ?? 10_000
 
   let source: SSESource | null = null
   let timer: ReturnType<typeof setTimeout> | null = null
+  let lastActivityAt: number | null = null
+  let openedAt: number | null = null
+  let attemptStartedAt = 0
   let stopped = true
   let generation = 0
   let attempts = 0
@@ -55,6 +79,8 @@ export function createSSESupervisor(options: SSESupervisorOptions): SSESuperviso
   }
 
   const closeSource = () => {
+    lastActivityAt = null
+    openedAt = null
     const current = source
     source = null
     current?.close()
@@ -63,6 +89,9 @@ export function createSSESupervisor(options: SSESupervisorOptions): SSESuperviso
   const exhausted = () => {
     clearTimer()
     closeSource()
+    // The exhausted window is deliberately left recorded. Only explicit new
+    // information — `revalidate()` (a wake) or `retry()` (a tap) — clears it
+    // and opens a fresh bounded window; nothing here spins on its own.
     options.onExhausted?.()
   }
 
@@ -74,15 +103,31 @@ export function createSSESupervisor(options: SSESupervisorOptions): SSESuperviso
       return
     }
     const myGeneration = ++generation
+    attemptStartedAt = now()
     let next: SSESource | null = null
+    let failedSynchronously = false
     next = options.connect({
       opened: () => {
         if (stopped || myGeneration !== generation) return
-        attempts = 0
-        retryStartedAt = null
+        lastActivityAt = now()
+        openedAt = now()
+      },
+      activity: () => {
+        if (stopped || myGeneration !== generation) return
+        lastActivityAt = now()
       },
       failed: () => {
+        failedSynchronously = true
         if (stopped || myGeneration !== generation) return
+        options.onFailure?.()
+        // Success is credited only by a source that stayed open long enough
+        // to be worth something. A server that accepts the request and drops
+        // it immediately (open/error flapping) must keep consuming the same
+        // bounded window instead of resetting it on every flap.
+        if (openedAt !== null && now() - openedAt >= stableOpenDurationMs) {
+          attempts = 0
+          retryStartedAt = null
+        }
         closeSource()
         if (retryStartedAt === null) retryStartedAt = now()
         const elapsed = now() - retryStartedAt
@@ -98,6 +143,13 @@ export function createSSESupervisor(options: SSESupervisorOptions): SSESuperviso
         timer = setTimeout(connect, delay)
       },
     })
+    // A test double or an unusual implementation can report failure during
+    // construction, before `source` can be assigned. Do not leak that source
+    // or let its late assignment defeat the generation cancellation.
+    if (failedSynchronously || stopped || myGeneration !== generation) {
+      next?.close()
+      return
+    }
     source = next
   }
 
@@ -106,7 +158,6 @@ export function createSSESupervisor(options: SSESupervisorOptions): SSESuperviso
     generation++
     clearTimer()
     closeSource()
-    if (retryStartedAt === null) retryStartedAt = now()
     options.onRetryScheduled?.()
     timer = setTimeout(connect, 0)
   }
@@ -133,8 +184,20 @@ export function createSSESupervisor(options: SSESupervisorOptions): SSESuperviso
     },
     revalidate() {
       if (stopped) return
-      // CLOSED and CONNECTING both need an explicit replacement. OPEN is
-      // replaced too: readyState alone cannot expose a dead post-resume TCP.
+      // A healthy, recently active source needs no new full bootstrap: a
+      // protocol-3 bootstrap re-sends every session row, so lifecycle churn
+      // is expensive on a phone.
+      if (source?.readyState === 1 && lastActivityAt !== null
+          && now() - lastActivityAt < staleDurationMs) return
+      // A wake or a user intent is new information: it always earns a fresh
+      // bounded window, including after the previous one was exhausted.
+      attempts = 0
+      retryStartedAt = null
+      // But it must not pile up sources. A pending retry or an attempt still
+      // in flight already covers this wake; it now carries the new budget.
+      if (timer !== null) return
+      if (source !== null && source.readyState === 0
+          && now() - attemptStartedAt < attemptTimeoutMs) return
       restart()
     },
   }

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -2435,14 +2435,17 @@ export function initStore(): () => void {
     else if (connState.value === 'connected') connState.value = 'reconnecting'
   }
   const supervisor = createSSESupervisor({
+    onFailure: onTransportFailure,
     connect: callbacks => {
       const next = new EventSource('/v1/events?session_stream=3') as unknown as SSESource
       next.addEventListener('open', callbacks.opened)
-      next.addEventListener('error', () => {
-        onTransportFailure()
-        callbacks.failed()
-      })
-      for (const [type, listener] of sourceBindings) next.addEventListener(type, listener)
+      next.addEventListener('error', callbacks.failed)
+      for (const [type, listener] of sourceBindings) {
+        next.addEventListener(type, event => {
+          callbacks.activity()
+          listener(event)
+        })
+      }
       return next
     },
     onRetryScheduled: () => {
@@ -2561,11 +2564,27 @@ export function initStore(): () => void {
     } catch { /* ignore */ }
   })
 
-  const onVisibilityChange = () => {
-    if (document.visibilityState === 'visible') supervisor.revalidate()
+  let lifecycleTimer: ReturnType<typeof setTimeout> | null = null
+  const isVisible = () => typeof document !== 'undefined' && document.visibilityState === 'visible'
+  const scheduleLifecycleRevalidation = () => {
+    // A single logical wake delivers several of visibilitychange/pageshow/
+    // resume/online, often in separate task turns. One shared debounce
+    // coalesces them into at most one revalidation, and the supervisor then
+    // only replaces a source that is unhealthy or stale: a protocol-3
+    // bootstrap re-sends every session row, so a full reconnect per focus is
+    // expensive on a phone. A hidden tab never revalidates — checked both
+    // when scheduling and when the timer fires, since the tab can be hidden
+    // again inside the debounce window.
+    if (!isVisible() || lifecycleTimer !== null) return
+    lifecycleTimer = setTimeout(() => {
+      lifecycleTimer = null
+      if (!isVisible()) return
+      supervisor.revalidate()
+    }, 1000)
   }
-  const onResume = () => supervisor.revalidate()
-  const onOnline = () => supervisor.revalidate()
+  const onVisibilityChange = () => scheduleLifecycleRevalidation()
+  const onResume = () => scheduleLifecycleRevalidation()
+  const onOnline = () => scheduleLifecycleRevalidation()
   if (typeof document !== 'undefined') {
     document.addEventListener('visibilitychange', onVisibilityChange)
     document.addEventListener('resume', onResume)
@@ -2576,6 +2595,8 @@ export function initStore(): () => void {
   }
   supervisor.start()
   cleanups.push(() => {
+    if (lifecycleTimer !== null) clearTimeout(lifecycleTimer)
+    lifecycleTimer = null
     if (typeof document !== 'undefined') {
       document.removeEventListener('visibilitychange', onVisibilityChange)
       document.removeEventListener('resume', onResume)

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -31,6 +31,7 @@ import { referencePresence, removeHostReferenceItems, removeReferenceItems, type
 import type { View } from './routing'
 import { resolveViewFromPath, viewToPath } from './routing'
 import type { ResolvedTerminalOptions } from './settings-schema'
+import { createSSESupervisor, type SSESource } from './sse-supervisor'
 import { formatFilterParam, parseFilterParam, type Selector, sessionMatchesFilter } from './tab-filter'
 import { pushError } from './toasts'
 import type { DiscoveredProject, Folder, LauncherDef, PeerInfo, PeerProject, ProjectItem, Session } from './types'
@@ -298,11 +299,13 @@ export const sessionsLoaded = signal(false)
 export const worldLoaded = signal(false)
 // 'connecting'   — initial connect, never yet established (full-screen)
 // 'connected'    — live snapshot flowing
-// 'reconnecting' — an *established* stream dropped; EventSource is
-//                  auto-reconnecting. Subtle pill, not full-screen: the
-//                  last snapshot stays on screen (sessionsLoaded holds).
+// 'reconnecting' — an *established* stream dropped; the SSE supervisor is
+//                  retrying. Subtle pill, not full-screen: the last snapshot
+//                  stays on screen (sessionsLoaded holds).
 // 'error'        — initial connect failed (full-screen + Retry)
 export const connState = signal<'connecting' | 'connected' | 'reconnecting' | 'error'>('connecting')
+/** True when automatic SSE retries are exhausted and the user can retry. */
+export const sseRetryAvailable = signal(false)
 
 // Discovered is host-authoritative (ADR 0002/0025): each host runs its
 // own match rules over its own sessions and decides which are
@@ -2336,6 +2339,14 @@ export function navigateToSession(sessionId: string, replace?: boolean): boolean
  * Start the store: connect SSE, fetch initial data, start timers.
  * Call once from the app root.
  */
+let activeSSESupervisor: ReturnType<typeof createSSESupervisor> | null = null
+
+/** Retry the control-plane stream without reloading the application. */
+export function retrySSE(): void {
+  sseRetryAvailable.value = false
+  activeSSESupervisor?.retry()
+}
+
 export function initStore(): () => void {
   const cleanups: (() => void)[] = []
 
@@ -2377,6 +2388,7 @@ export function initStore(): () => void {
       sessionsLoaded.value = true
       worldLoaded.value = true
       connState.value = 'connected'
+      sseRetryAvailable.value = false
       terminalOptions.value = buildTerminalOptions(null, null)
       keybinds.value = resolveKeybinds(null, false)
     })
@@ -2405,31 +2417,56 @@ export function initStore(): () => void {
   // both kinds (sessions, world) immediately on subscribe, so we
   // don't need a bulk-GET prefetch on first load or on reconnect.
   // Missed deltas don't matter: each snapshot is a full replacement.
+  // Reset the negotiated stream state before creating a new supervisor.
   resetSessionsTransport()
   sessionStreamWarnings.value = []
   sessionStreamOmittedTotal.value = 0
-  const source = new EventSource('/v1/events?session_stream=3')
-  source.addEventListener('error', () => {
+  sseRetryAvailable.value = false
+  const sourceBindings: Array<[string, (event: MessageEvent) => void]> = []
+  const addSourceListener = (type: string, listener: (event: MessageEvent) => void) => {
+    sourceBindings.push([type, listener])
+  }
+  const onTransportFailure = () => {
     // A transport reconnect starts a new epoch. Never retain unpublished
     // rows from the interrupted response.
     resetSessionsTransport()
-    // Browser EventSource auto-reconnects; flag the UI as degraded
-    // until the next snapshot arrives. `sessionsLoaded` stays true
-    // once it has flipped, so reconnect doesn't blank the sidebar.
-    //
-    // A drop on the *initial* connect is a hard failure (full-screen +
-    // Retry). A drop on an *established* stream is transient: show a
-    // subtle reconnecting pill and keep the last snapshot on screen
-    // while EventSource retries. The next snapshot flips it back to
-    // 'connected'.
+    sseRetryAvailable.value = false
     if (connState.value === 'connecting') connState.value = 'error'
     else if (connState.value === 'connected') connState.value = 'reconnecting'
+  }
+  const supervisor = createSSESupervisor({
+    connect: callbacks => {
+      const next = new EventSource('/v1/events?session_stream=3') as unknown as SSESource
+      next.addEventListener('open', callbacks.opened)
+      next.addEventListener('error', () => {
+        onTransportFailure()
+        callbacks.failed()
+      })
+      for (const [type, listener] of sourceBindings) next.addEventListener(type, listener)
+      return next
+    },
+    onRetryScheduled: () => {
+      // Revalidation can interrupt a partially delivered transaction without
+      // an EventSource error event, so clear staging for that new transport
+      // just as we do for an observed error.
+      resetSessionsTransport()
+      sseRetryAvailable.value = false
+      if (connState.value === 'connected' || connState.value === 'reconnecting') {
+        connState.value = 'reconnecting'
+      }
+    },
+    onExhausted: () => {
+      // Keep an established snapshot visible, but stop claiming that an
+      // automatic retry is actively pending. The UI exposes a manual retry.
+      sseRetryAvailable.value = true
+      if (!sessionsLoaded.value) connState.value = 'error'
+    },
   })
-
+  activeSSESupervisor = supervisor
   // Protocol 3 streams complete semantic rows into private staging. No row
   // becomes visible until the matching ready marker atomically replaces the
   // projection. A later epoch is an ordinary full replacement too.
-  source.addEventListener('snapshot.sessions.begin', (e) => {
+  addSourceListener('snapshot.sessions.begin', (e) => {
     try {
       const { version, epoch } = JSON.parse(e.data) as { version: number, epoch: number }
       beginSessionsBootstrap(version, epoch)
@@ -2439,7 +2476,7 @@ export function initStore(): () => void {
     }
   })
 
-  source.addEventListener('snapshot.sessions.batch', (e) => {
+  addSourceListener('snapshot.sessions.batch', (e) => {
     try {
       const { epoch, sessions: rows } = JSON.parse(e.data) as { epoch: number, sessions: ProtocolSession[] }
       if (!Array.isArray(rows)) throw new Error('sessions must be an array')
@@ -2450,7 +2487,7 @@ export function initStore(): () => void {
     }
   })
 
-  source.addEventListener('snapshot.sessions.ready', (e) => {
+  addSourceListener('snapshot.sessions.ready', (e) => {
     try {
       const { epoch } = JSON.parse(e.data) as { epoch: number }
       if (!readySessionsBootstrap(epoch)) console.warn('snapshot.sessions.ready: no matching bootstrap')
@@ -2460,7 +2497,7 @@ export function initStore(): () => void {
     }
   })
 
-  source.addEventListener('snapshot.sessions.error', (e) => {
+  addSourceListener('snapshot.sessions.error', (e) => {
     // A diagnostic quarantines one row but does not invalidate the epoch.
     // It becomes a persistent sidebar warning when ready commits this epoch.
     try {
@@ -2475,7 +2512,7 @@ export function initStore(): () => void {
   // Transitional fallback for a proxy or one-release-old daemon which ignores
   // the explicit protocol marker. Old tabs request no marker and receive this
   // event from a new daemon as well.
-  source.addEventListener('snapshot.sessions', (e) => {
+  addSourceListener('snapshot.sessions', (e) => {
     try {
       if (sessionStreamMode === 'v3') return
       const envelope = JSON.parse(e.data) as { sessions?: ProtocolSession[] }
@@ -2489,7 +2526,7 @@ export function initStore(): () => void {
     }
   })
 
-  source.addEventListener('snapshot.world', (e) => {
+  addSourceListener('snapshot.world', (e) => {
     try {
       const env = JSON.parse(e.data) as {
         projects?: ProjectItem[]
@@ -2517,14 +2554,39 @@ export function initStore(): () => void {
     }
   })
 
-  source.addEventListener('session-activity', (e) => {
+  addSourceListener('session-activity', (e) => {
     try {
       const { id } = JSON.parse(e.data)
       if (id) handleActivity(id)
     } catch { /* ignore */ }
   })
 
-  cleanups.push(() => source.close())
+  const onVisibilityChange = () => {
+    if (document.visibilityState === 'visible') supervisor.revalidate()
+  }
+  const onResume = () => supervisor.revalidate()
+  const onOnline = () => supervisor.revalidate()
+  if (typeof document !== 'undefined') {
+    document.addEventListener('visibilitychange', onVisibilityChange)
+    document.addEventListener('resume', onResume)
+  }
+  if (typeof window !== 'undefined') {
+    window.addEventListener('online', onOnline)
+    window.addEventListener('pageshow', onResume)
+  }
+  supervisor.start()
+  cleanups.push(() => {
+    if (typeof document !== 'undefined') {
+      document.removeEventListener('visibilitychange', onVisibilityChange)
+      document.removeEventListener('resume', onResume)
+    }
+    if (typeof window !== 'undefined') {
+      window.removeEventListener('online', onOnline)
+      window.removeEventListener('pageshow', onResume)
+    }
+    supervisor.stop()
+    if (activeSSESupervisor === supervisor) activeSSESupervisor = null
+  })
 
   // URL normalization effect: rewrites the URL when the resolved view
   // differs from the current path (e.g., `/:project` resolves to a

--- a/apps/gmux-web/src/styles.css
+++ b/apps/gmux-web/src/styles.css
@@ -2969,6 +2969,19 @@ body {
   max-width: min(calc(100vw - 24px), 460px);
 }
 
+/* The normal pill is deliberately click-through; an exhausted supervisor
+   adds the one actionable control that must remain clickable. */
+.app-reconnecting-pill button {
+  pointer-events: auto;
+  border: 0;
+  padding: 0;
+  background: transparent;
+  color: inherit;
+  text-decoration: underline;
+  cursor: pointer;
+  font: inherit;
+}
+
 /* ── Find-in-terminal bar ────────────────────────────────────────────────────────
    Floats over the top-right of the terminal (sticky, like the resize
    anchor, so it stays put when the shell scrolls in passive mode). Shares

--- a/apps/gmux-web/src/terminal.tsx
+++ b/apps/gmux-web/src/terminal.tsx
@@ -980,6 +980,7 @@ export function TerminalView({
     let isFirstConnect = true
     let attempt = 0
     let intentionalClose = false
+    let lastWsActivityAt: number | null = null
     // Pending retry for a first claim whose measurement returned null.
     // Cancelled on socket replacement, reconnect, session switch, unmount.
     let cancelClaimRetry: (() => void) | null = null
@@ -1060,11 +1061,11 @@ export function TerminalView({
             return
           }
 
-          isFirstConnect = false
           const proceedWithClaim = (claimSize: TerminalSize) => {
             barrierClaimResizeRef.current = claimSize
             const onClaimResized = () => {
               if (connectionRef.current !== connection || termEpochRef.current !== epoch) return
+              isFirstConnect = false
               attachPhase = 'claimed'
               inputClaimedRef.current = true
               claimFallbackTimer = setTimeout(() => {
@@ -1111,6 +1112,7 @@ export function TerminalView({
               // held output and input. No resize is sent: the runner keeps
               // its size until a real measurement exists (the pill lets the
               // user reclaim, and any later resize path re-measures).
+              isFirstConnect = false
               attachPhase = 'claimed'
               inputClaimedRef.current = true
               const heldWrites = postClaimWrites.splice(0)
@@ -1142,6 +1144,7 @@ export function TerminalView({
       ws.onopen = () => {
         if (connectionRef.current !== connection) return
         attempt = 0
+        lastWsActivityAt = Date.now()
         setWsState('open')
 
         if (isFirstConnect) return
@@ -1166,6 +1169,7 @@ export function TerminalView({
         if (connectionRef.current !== connection) return
         // Safety net: live output proves the connection works. Never show the
         // disconnected pill while data is flowing on the current socket.
+        lastWsActivityAt = Date.now()
         setWsState(wsStateOnOutput)
         if (typeof ev.data === 'string') {
           try {
@@ -1240,6 +1244,7 @@ export function TerminalView({
         setWsState(prev => wsStateOnClose(prev, isCurrent))
         if (isCurrent) onModifiersCancelled()
         if (!isCurrent) return
+        lastWsActivityAt = null
         if (claimFallbackTimer !== null) clearTimeout(claimFallbackTimer)
         claimFallbackTimer = null
         cancelClaimRetry?.()
@@ -1261,6 +1266,8 @@ export function TerminalView({
     const revalidateConnection = () => {
       if (disposed.current || document.visibilityState !== 'visible') return
       const current = connectionRef.current
+      if (current?.ws.readyState === WebSocket.OPEN && lastWsActivityAt !== null
+          && Date.now() - lastWsActivityAt < 60_000) return
       if (!current || current.ws.readyState === WebSocket.CLOSED) {
         if (reconnectTimer.current === null) connect()
         return
@@ -1270,9 +1277,17 @@ export function TerminalView({
       // bounded-delay reconnect path rather than trusting readyState.
       current.ws.close()
     }
-    const onVisibilityChange = () => revalidateConnection()
-    const onResume = () => revalidateConnection()
-    const onOnline = () => revalidateConnection()
+    let lifecycleTimer: ReturnType<typeof setTimeout> | null = null
+    const scheduleLifecycleRevalidation = () => {
+      if (document.visibilityState !== 'visible' || lifecycleTimer !== null) return
+      lifecycleTimer = setTimeout(() => {
+        lifecycleTimer = null
+        revalidateConnection()
+      }, 1000)
+    }
+    const onVisibilityChange = () => scheduleLifecycleRevalidation()
+    const onResume = () => scheduleLifecycleRevalidation()
+    const onOnline = () => scheduleLifecycleRevalidation()
     document.addEventListener('visibilitychange', onVisibilityChange)
     document.addEventListener('resume', onResume)
     window.addEventListener('pageshow', onResume)
@@ -1292,6 +1307,8 @@ export function TerminalView({
       document.removeEventListener('resume', onResume)
       window.removeEventListener('pageshow', onResume)
       window.removeEventListener('online', onOnline)
+      if (lifecycleTimer !== null) clearTimeout(lifecycleTimer)
+      lifecycleTimer = null
       if (reconnectTimer.current) clearTimeout(reconnectTimer.current)
       reconnectTimer.current = null
       resetResizeEchoGate()

--- a/apps/gmux-web/src/terminal.tsx
+++ b/apps/gmux-web/src/terminal.tsx
@@ -1258,6 +1258,26 @@ export function TerminalView({
       }
     }
 
+    const revalidateConnection = () => {
+      if (disposed.current || document.visibilityState !== 'visible') return
+      const current = connectionRef.current
+      if (!current || current.ws.readyState === WebSocket.CLOSED) {
+        if (reconnectTimer.current === null) connect()
+        return
+      }
+      // An OPEN WebSocket can be a suspended, dead TCP after a mobile
+      // background/resume cycle. Closing it hands recovery to the existing
+      // bounded-delay reconnect path rather than trusting readyState.
+      current.ws.close()
+    }
+    const onVisibilityChange = () => revalidateConnection()
+    const onResume = () => revalidateConnection()
+    const onOnline = () => revalidateConnection()
+    document.addEventListener('visibilitychange', onVisibilityChange)
+    document.addEventListener('resume', onResume)
+    window.addEventListener('pageshow', onResume)
+    window.addEventListener('online', onOnline)
+
     connect()
 
     return () => {
@@ -1268,6 +1288,10 @@ export function TerminalView({
       termEpochRef.current = epoch + 1
       termIoRef.current?.reset(termEpochRef.current)
       scrollAnchorRef.current?.reset()
+      document.removeEventListener('visibilitychange', onVisibilityChange)
+      document.removeEventListener('resume', onResume)
+      window.removeEventListener('pageshow', onResume)
+      window.removeEventListener('online', onOnline)
       if (reconnectTimer.current) clearTimeout(reconnectTimer.current)
       reconnectTimer.current = null
       resetResizeEchoGate()

--- a/e2e/tests/reconnect-stability.spec.ts
+++ b/e2e/tests/reconnect-stability.spec.ts
@@ -68,6 +68,20 @@ async function installEventSourceProbe(page: Page): Promise<void> {
   })
 }
 
+async function installWebSocketProbe(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    const Native = window.WebSocket
+    const sockets: any[] = []
+    ;(window as any).__gmuxWebSockets = sockets
+    ;(window as any).WebSocket = class extends Native {
+      constructor(url: string | URL, protocols?: string | string[]) {
+        super(url, protocols)
+        sockets.push(this)
+      }
+    }
+  })
+}
+
 test.describe('SSE reconnect stability', () => {
   test('recovers from a fatal 503 response without a page reload', async ({ page }) => {
     await installEventSourceProbe(page)
@@ -114,6 +128,92 @@ test.describe('SSE reconnect stability', () => {
       undefined,
       { timeout: 5_000 },
     )
+  })
+
+  test('a wake on a healthy stream creates no new EventSource', async ({ page }) => {
+    await installEventSourceProbe(page)
+    await openApp(page)
+    await page.waitForFunction(() => (window as any).__gmuxEventSources?.[0]?.readyState === 1)
+    await page.waitForTimeout(1_000)
+
+    // Every bootstrap re-sends the full sessions transaction and world frame,
+    // which is expensive on cellular at the operator's session count. A phone
+    // unlock delivers several lifecycle signals; none may cost a bootstrap.
+    for (let i = 0; i < 3; i++) {
+      await page.evaluate(() => {
+        window.dispatchEvent(new Event('online'))
+        window.dispatchEvent(new Event('pageshow'))
+        document.dispatchEvent(new Event('visibilitychange'))
+        document.dispatchEvent(new Event('resume'))
+      })
+      await page.waitForTimeout(500)
+    }
+    await page.waitForTimeout(1_500)
+    expect(await page.evaluate(() => (window as any).__gmuxEventSources.length)).toBe(1)
+    await expect(page.locator('.app-reconnecting-pill')).not.toBeVisible()
+  })
+
+  test('wakes automatically after the bounded retry window is exhausted', async ({ page }) => {
+    test.setTimeout(100_000)
+    await installEventSourceProbe(page)
+    await openApp(page)
+    await page.waitForFunction(() => (window as any).__gmuxEventSources?.[0]?.readyState === 1)
+    await page.waitForTimeout(1_000)
+
+    const state = await readState()
+    await page.route('**/v1/events*', route => route.fulfill({
+      status: 503,
+      headers: { 'Content-Type': 'text/plain', 'Retry-After': '1' },
+      body: 'temporarily unavailable',
+    }))
+    process.kill(currentDaemonPid(state), 'SIGTERM')
+
+    // The supervisor's production budget is 60 seconds. Waiting for the
+    // actual exhaustion, rather than changing it through a test hook, proves
+    // a phone returning after a long absence gets a fresh wake budget.
+    const retryButton = page.locator('.app-reconnecting-pill button')
+    await expect(retryButton).toBeVisible({ timeout: 75_000 })
+
+    // Restore the real daemon while the fault is still installed. The wake
+    // below, not a button click, must reopen the exhausted supervisor.
+    await restartDaemon(state)
+    await page.unroute('**/v1/events*')
+    await page.evaluate(() => {
+      window.dispatchEvent(new Event('online'))
+      window.dispatchEvent(new Event('pageshow'))
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+    await expect(retryButton).not.toBeVisible({ timeout: 15_000 })
+    await page.waitForFunction(
+      () => (window as any).__gmuxEventSources.some((s: any) => s.__openStates.includes(1)),
+      undefined,
+      { timeout: 5_000 },
+    )
+    // Exactly one live source: replacement must never leak a parallel stream.
+    expect(await page.evaluate(() => (window as any).__gmuxEventSources
+      .filter((s: any) => s.readyState !== 2).length)).toBe(1)
+  })
+
+  test('terminal WebSocket revalidation avoids healthy churn and detects stale sockets', async ({ page }) => {
+    await installWebSocketProbe(page)
+    await openApp(page)
+    await gotoTestSession(page)
+    const healthyCount = await page.evaluate(() => (window as any).__gmuxWebSockets.length)
+    await page.evaluate(() => window.dispatchEvent(new Event('online')))
+    await page.waitForTimeout(1_200)
+    expect(await page.evaluate(() => (window as any).__gmuxWebSockets.length)).toBe(healthyCount)
+
+    await page.evaluate(() => {
+      const realNow = Date.now.bind(Date)
+      ;(window as any).__gmuxRealDateNow = realNow
+      Date.now = () => realNow() + 61_000
+      window.dispatchEvent(new Event('online'))
+    })
+    await expect.poll(
+      () => page.evaluate(() => (window as any).__gmuxWebSockets.length),
+      { timeout: 5_000 },
+    ).toBeGreaterThan(healthyCount)
+    await page.evaluate(() => { Date.now = (window as any).__gmuxRealDateNow })
   })
 
   test('terminal WebSocket reconnects after the daemon restarts', async ({ page }) => {

--- a/e2e/tests/reconnect-stability.spec.ts
+++ b/e2e/tests/reconnect-stability.spec.ts
@@ -1,0 +1,134 @@
+import { test, expect, type Page } from '@playwright/test'
+import { spawn } from 'child_process'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { gotoTestSession, openApp } from '../helpers'
+
+type E2EState = { pids: number[]; daemonPids?: number[]; tmpDir: string; port: number; token: string }
+const statePath = path.join(os.tmpdir(), 'gmux-e2e-state.json')
+
+async function readState(): Promise<E2EState> {
+  return JSON.parse(await fs.promises.readFile(statePath, 'utf8')) as E2EState
+}
+
+async function restartDaemon(state: E2EState): Promise<void> {
+  const env = {
+    ...process.env,
+    HOME: path.join(state.tmpDir, 'home'),
+    GMUX_SOCKET_DIR: path.join(state.tmpDir, 'sockets'),
+    GMUXD_TOKEN: state.token,
+    XDG_CONFIG_HOME: path.join(state.tmpDir, 'config'),
+    XDG_STATE_HOME: path.join(state.tmpDir, 'state'),
+    TERM: 'xterm-256color',
+  }
+  const daemon = spawn(path.resolve('bin/gmuxd'), ['run'], { env, stdio: 'ignore', detached: true })
+  if (!daemon.pid) throw new Error('gmuxd did not start')
+  state.pids.push(daemon.pid)
+  state.daemonPids = [...(state.daemonPids ?? [state.pids[0]]), daemon.pid]
+  await fs.promises.writeFile(statePath, JSON.stringify(state))
+
+  const start = Date.now()
+  while (Date.now() - start < 15_000) {
+    try {
+      const response = await fetch(`http://127.0.0.1:${state.port}/v1/health`, {
+        headers: { Authorization: `Bearer ${state.token}` }
+      })
+      if (response.ok) return
+    } catch { /* daemon is still starting */ }
+    await new Promise(resolve => setTimeout(resolve, 100))
+  }
+  throw new Error('restarted gmuxd did not become healthy')
+}
+
+function currentDaemonPid(state: E2EState): number {
+  return state.daemonPids?.at(-1) ?? state.pids[0]
+}
+
+async function installEventSourceProbe(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    const Native = window.EventSource
+    const sources: any[] = []
+    ;(window as any).__gmuxEventSources = sources
+    ;(window as any).EventSource = class extends Native {
+      __openStates: number[] = []
+      __errorStates: number[] = []
+      __closes = 0
+      close() {
+        this.__closes++
+        super.close()
+      }
+      constructor(url: string | URL, config?: EventSourceInitDict) {
+        super(url, config)
+        sources.push(this)
+        this.addEventListener('open', () => this.__openStates.push(this.readyState))
+        this.addEventListener('error', () => this.__errorStates.push(this.readyState))
+      }
+    }
+  })
+}
+
+test.describe('SSE reconnect stability', () => {
+  test('recovers from a fatal 503 response without a page reload', async ({ page }) => {
+    await installEventSourceProbe(page)
+    await openApp(page)
+    await page.waitForFunction(() => (window as any).__gmuxEventSources?.[0]?.readyState === 1)
+    // Let both leading-edge snapshots commit so this is the established
+    // stream path (otherwise the initial-connect error screen is expected).
+    await page.waitForTimeout(1_000)
+
+    const state = await readState()
+    await page.route('**/v1/events*', route => route.fulfill({
+      status: 503,
+      headers: { 'Content-Type': 'text/plain', 'Retry-After': '1' },
+      body: 'temporarily unavailable',
+    }))
+    // global setup stores gmuxd first and the shell runner second.
+    process.kill(state.pids[0], 'SIGTERM')
+
+    const pill = page.locator('.app-reconnecting-pill')
+    await page.waitForFunction(
+      () => (window as any).__gmuxEventSources.some((s: any) => s.__errorStates.includes(2)),
+      undefined,
+      { timeout: 20_000 },
+    )
+    await expect(pill).toBeVisible({ timeout: 2_000 })
+    const fatal = await page.evaluate(() => (window as any).__gmuxEventSources.map((s: any) => ({
+      errors: s.__errorStates, state: s.readyState,
+    })))
+    console.log('fatal SSE response:', fatal)
+
+    await page.unroute('**/v1/events*')
+    await restartDaemon(state)
+    try {
+      await expect(pill).not.toBeVisible({ timeout: 20_000 })
+    } catch (error) {
+      console.log('recovery state:', await page.evaluate(() => ({
+        sources: (window as any).__gmuxEventSources.map((s: any) => ({ opens: s.__openStates, errors: s.__errorStates, closes: s.__closes, state: s.readyState })),
+        body: document.body.innerText.slice(0, 300),
+      })))
+      throw error
+    }
+    await page.waitForFunction(
+      () => (window as any).__gmuxEventSources.some((s: any) => s.__openStates.includes(1)),
+      undefined,
+      { timeout: 5_000 },
+    )
+  })
+
+  test('terminal WebSocket reconnects after the daemon restarts', async ({ page }) => {
+    await openApp(page)
+    await gotoTestSession(page)
+    const pill = page.locator('.terminal-disconnected-pill')
+    await expect(pill).not.toBeVisible()
+
+    const state = await readState()
+    // The first test restarted gmuxd and appended its PID; the current
+    // daemon is therefore the last daemon PID in the disposable state.
+    process.kill(currentDaemonPid(state), 'SIGTERM')
+    await expect(pill).toBeVisible({ timeout: 10_000 })
+
+    await restartDaemon(state)
+    await expect(pill).not.toBeVisible({ timeout: 20_000 })
+  })
+})

--- a/e2e/tests/reconnect-stability.spec.ts
+++ b/e2e/tests/reconnect-stability.spec.ts
@@ -24,8 +24,14 @@ async function restartDaemon(state: E2EState): Promise<void> {
   }
   const daemon = spawn(path.resolve('bin/gmuxd'), ['run'], { env, stdio: 'ignore', detached: true })
   if (!daemon.pid) throw new Error('gmuxd did not start')
-  state.pids.push(daemon.pid)
   state.daemonPids = [...(state.daemonPids ?? [state.pids[0]]), daemon.pid]
+  state.pids.push(daemon.pid)
+  // `pids[0]` is the shared "this is the daemon" slot for every other spec
+  // (z-terminal-disconnect signals it to take the backend down). Leaving the
+  // dead original there makes those specs fail with ESRCH, so hand the slot
+  // over to the replacement. Appending as well keeps global teardown killing
+  // every daemon this run started.
+  state.pids[0] = daemon.pid
   await fs.promises.writeFile(statePath, JSON.stringify(state))
 
   const start = Date.now()

--- a/e2e/tests/terminal-claim-retry.spec.ts
+++ b/e2e/tests/terminal-claim-retry.spec.ts
@@ -232,9 +232,11 @@ test('socket bounce during pending retry cancels it and reconnect flows claimed'
   await page.waitForFunction(() => (window as any).__testWs !== (window as any).__testWsOld, undefined, { timeout: 15_000 })
   await page.evaluate(() => (window as any).__releaseWs())
 
-  // Reconnect enters 'claimed' (no reclaim); output flows even though the
-  // measurement is still null. The cancelled retry must not fire later —
-  // watch through the old deadline window for anomalies.
+  // The bounce happened before the claim completed, so the reconnect is
+  // still a first connect: it replays and re-enters the claim path, which
+  // (measurement still null) falls back within the deadline and flows. The
+  // cancelled retry must not fire later — watch through the old deadline
+  // window for anomalies.
   await pollUntil(async () => {
     const text = await bufferText(page)
     return maxTick(text, 'B') >= 8 ? text : null
@@ -244,6 +246,50 @@ test('socket bounce during pending retry cancels it and reconnect flows claimed'
   const t1 = maxTick(await bufferText(page), 'B')
   await page.waitForTimeout(1_000)
   expect(maxTick(await bufferText(page), 'B')).toBeGreaterThan(t1)
+})
+
+test('a bounce inside the claim window still claims the viewport on reconnect', async ({ page }) => {
+  await installWsGate(page)
+  await openApp(page)
+  const id = await launchSession(page, tickerCommand('V'))
+  // A fresh session has no terminal_cols until a client claims it, so the
+  // runner adopting this browser's geometry is only possible via the claim.
+  const colsBefore = await terminalCols(id)
+  await navigate(page, id)
+  await forceNullMeasurement(page)
+  await page.waitForTimeout(800)
+  await expect(page.locator('.terminal-loading')).toHaveCount(1)
+
+  // Bounce the socket *inside* the claim window (this is what a lifecycle
+  // revalidation on a resumed phone does). `isFirstConnect` must still be
+  // true here: it belongs to the claim, not to the replay that precedes it.
+  await page.evaluate(() => {
+    ;(window as any).__testWsOld = (window as any).__testWs
+    ;(window as any).__testWs.close()
+  })
+  await page.waitForFunction(() => (window as any).__testWs !== (window as any).__testWsOld, undefined, { timeout: 15_000 })
+
+  // Restore measurability *silently*: no viewport change, so no
+  // ResizeObserver refit can send a size. The reconnect's own claim is then
+  // the only path that can size the runner.
+  await restoreMeasurement(page)
+  await page.evaluate(() => (window as any).__releaseWs())
+
+  await pollUntil(async () => {
+    const text = await bufferText(page)
+    return maxTick(text, 'V') >= 8 ? text : null
+  }, { timeoutMs: 15_000, description: 'live output flows after the bounce' })
+  await expect(page.locator('.terminal-loading')).toHaveCount(0)
+
+  // The reconnect claimed the browser viewport. Skipping the claim here is
+  // the #514 stall class: the runner would keep checkpoint geometry and the
+  // user would be stuck behind "Sized for another device".
+  const xtermCols = await page.evaluate(() => (window as any).__gmuxTerm.cols as number)
+  expect(xtermCols).toBeGreaterThan(0)
+  expect(xtermCols).not.toBe(colsBefore)
+  await pollUntil(async () => (await terminalCols(id)) === xtermCols || undefined,
+    { timeoutMs: 8_000, description: 'runner adopted the browser viewport after the bounce' })
+  expect(await page.locator('.terminal-resize-overlay').isVisible().catch(() => false)).toBe(false)
 })
 
 test('session switch during pending retry cancels it; stale claim never lands', async ({ page }) => {


### PR DESCRIPTION
## Summary
- reproduce Chromium's permanent `EventSource` CLOSED state after an events-endpoint 503
- replace native EventSource retry with cancellable jittered backoff, a deadline, and manual retry
- revalidate SSE and terminal WebSocket transports on resume/visibility/online lifecycle events

## Reproduced failure modes
- Established SSE + disposable daemon restart + next `/v1/events` response `503 text/plain`: Chromium fired `error`, reached `readyState === 2`, and stayed stuck after the daemon recovered.
- The same fatal behavior was reproduced with a `401 application/json` response, matching auth failure on a subsequent connection.
- CDP offline emulation did not emit an error within the observation window and left `readyState === 1`, demonstrating why lifecycle revalidation cannot trust `OPEN` alone.
- Terminal WebSocket reconnects independently and now also gets lifecycle revalidation.

## Verification
- `pnpm --filter @gmux/web lint`
- `pnpm --filter @gmux/web test` (852 passed)
- `E2E_SKIP_BUILD=1 pnpm exec playwright test e2e/tests/reconnect-stability.spec.ts --config=e2e/playwright.config.ts` (2 passed)
- `./scripts/build.sh`

`cd services/gmuxd && go test ./cmd/gmuxd/...` remains blocked by the existing downloaded `go-json-experiment/json` compile mismatch; the production Go build passes.
