### PR TITLE
fix(build): support direct Go 1.27 invocations

### DIFF
--- a/services/gmuxd/go.mod
+++ b/services/gmuxd/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/gaissmai/bart v0.26.1 // indirect
-	github.com/go-json-experiment/json v0.0.0-20250813024750-ebf49471dced // indirect
+	github.com/go-json-experiment/json v0.0.0-20260820222146-c27c302e5fc3 // indirect
 	github.com/godbus/dbus/v5 v5.1.1-0.20230522191255-76236955d466 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/google/btree v1.1.3 // indirect

--- a/services/gmuxd/go.sum
+++ b/services/gmuxd/go.sum
@@ -63,8 +63,8 @@ github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj2
 github.com/gaissmai/bart v0.26.1 h1:+w4rnLGNlA2GDVn382Tfe3jOsK5vOr5n4KmigJ9lbTo=
 github.com/gaissmai/bart v0.26.1/go.mod h1:GREWQfTLRWz/c5FTOsIw+KkscuFkIV5t8Rp7Nd1Td5c=
 github.com/github/fakeca v0.1.0 h1:Km/MVOFvclqxPM9dZBC4+QE564nU4gz4iZ0D9pMw28I=
-github.com/go-json-experiment/json v0.0.0-20250813024750-ebf49471dced h1:Q311OHjMh/u5E2TITc++WlTP5We0xNseRMkHDyvhW7I=
-github.com/go-json-experiment/json v0.0.0-20250813024750-ebf49471dced/go.mod h1:TiCD2a1pcmjd7YnhGH0f/zKNcCD06B029pHhzV23c2M=
+github.com/go-json-experiment/json v0.0.0-20260820222146-c27c302e5fc3 h1:UADEEmDKgfXbtnGJZ97beY5XLo9ZechG1nlU4KnRrkE=
+github.com/go-json-experiment/json v0.0.0-20260820222146-c27c302e5fc3/go.mod h1:tphK2c80bpPhMOI4v6bIc2xWywPfbqi1Z06+RcrMkDg=
 github.com/go-ole/go-ole v1.3.0 h1:Dt6ye7+vXGIKZ7Xtk4s6/xVdGDQynvom7xCFEdWr6uE=
 github.com/go4org/plan9netshell v0.0.0-20250324183649-788daa080737 h1:cf60tHxREO3g1nroKr2osU3JWZsJzkfi7rEg+oAB0Lo=
 github.com/godbus/dbus/v5 v5.1.1-0.20230522191255-76236955d466 h1:sQspH8M4niEijh3PFscJRLDnkL547IeP7kpPe3uUhEg=


### PR DESCRIPTION
## Summary

- update the indirect `go-json-experiment/json` dependency pulled in through Tailscale
- use its stabilized `encoding/json/v2` API mirror, which compiles under both Go 1.26.1 and Go 1.27
- retain the exact Go 1.26.1 release/build pin and existing drift guard

## Root cause

The `toolchain go1.26.1` directive is a minimum under automatic toolchain selection, so an ambient Go 1.27 is not downgraded. The old JSON experiment revision aliases `SkipFunc` and `DiscardUnknownMembers`, which Go 1.27 removed. gmux does not import this module directly; `go mod why` traces it through `internal/tsauth -> tailscale.com/client/tailscale -> tailscale.com/types/opt`.

## Verification

- reproduced the pre-fix plain-build failure with ambient `go1.27.0-X:nodwarf5`
- plain `go build ./cmd/gmuxd/` and `go test ./...` pass with `GOTOOLCHAIN` unset
- explicit Go 1.26.1 gmuxd build/test passes
- all app and `packages/*` suites pass on Go 1.26.1
- all app and `packages/*` race suites pass on ambient Go 1.27
- `go vet ./...` passes across all app/package modules
- plain moon gmux/gmuxd build tasks pass
- `./scripts/build.sh --skip-frontend` passes with Go 1.26.1
- `./scripts/go-toolchain.sh` passes and emits `go1.26.1`
- CI/release setup-go steps remain single-sourced from `go.work`

Go 1.27 direct-invocation compatibility is real with this change; Go 1.26.1 remains the reproducible release/CI toolchain.
