### PR TITLE
fix(peering): promote and same-peer reparent for peer sessions

### DIFF
--- a/apps/gmux-web/src/family.test.ts
+++ b/apps/gmux-web/src/family.test.ts
@@ -165,15 +165,44 @@ describe('task-family projection', () => {
       expect(promotionAction(selfie, [selfie], placed)).toBeNull()
     })
 
-    it('never offers mutations on peer-projected sessions', () => {
-      // The daemon refuses promote/demote for sessions it does not own
-      // (local_only) — network peers and Local/devcontainer peers alike.
+    it('offers promote/demote on peer-projected sessions, placed by their host folder', () => {
+      // Promote is reparent-to-null on the owning daemon — a same-peer
+      // mutation the local daemon forwards there. What the menu still owes
+      // is a real sidebar row, which for a peer session is the host's
+      // reference folder (`project.peer`), not a local project of the same
+      // slug.
       const root = agent('root', undefined, { peer: 'devbox' })
       const child = agent('child', 'root', { peer: 'devbox' })
       const promoted = agent('promoted', 'root', { peer: 'devbox', parent_session_id: undefined })
       const snapshot = [root, child, promoted]
-      expect(promotionAction(child, snapshot, placed)).toBeNull()
-      expect(promotionAction(promoted, snapshot, placed)).toBeNull()
+      const reference = [{ slug: 'p', peer: 'devbox', match: [] }]
+      expect(promotionAction(child, snapshot, reference)).toEqual({ kind: 'promote', parent: root })
+      expect(promotionAction(promoted, snapshot, reference)).toEqual({ kind: 'demote', parent: root })
+      // Local project of the same slug is a different folder: the peer row
+      // would not appear in it, so the action is blocked, not offered.
+      expect(promotionAction(child, snapshot, placed)).toEqual({
+        kind: 'promote', parent: root, blocked: 'no-project',
+      })
+      // A Local peer (devcontainer) is stamped by this host, so its rows
+      // bucket into the local folder (ADR 0025).
+      expect(promotionAction(child, snapshot, placed, name => name === 'devbox'))
+        .toEqual({ kind: 'promote', parent: root })
+    })
+
+    it('never offers a family that would span two daemons', () => {
+      // A family lives on one daemon: `parent_session_id` drives that
+      // daemon's ordering, dismissal and suppression. Return to family is
+      // the only verb that names a target, so it is the only one that can
+      // ask for a cross-host edge — and it refuses.
+      const localRoot = agent('root')
+      const peerPromoted = agent('promoted', 'root', { peer: 'devbox', parent_session_id: undefined })
+      expect(promotionAction(peerPromoted, [localRoot, peerPromoted], placed)).toBeNull()
+      const peerRoot = agent('proot', undefined, { peer: 'devbox' })
+      const localPromoted = agent('lpromoted', 'proot', { parent_session_id: undefined })
+      expect(promotionAction(localPromoted, [peerRoot, localPromoted], placed)).toBeNull()
+      // Two different peers are just as cross-host as peer/local.
+      const otherPeerChild = agent('other', 'proot', { peer: 'box2', parent_session_id: undefined })
+      expect(promotionAction(otherPeerChild, [peerRoot, otherPeerChild], placed)).toBeNull()
     })
 
     it('offers nothing to plain roots, orphans and cycle members', () => {

--- a/apps/gmux-web/src/family.ts
+++ b/apps/gmux-web/src/family.ts
@@ -210,11 +210,14 @@ export function familyAncestors(selected: Session, source: FamilySource): Sessio
  * Eligibility mirrors the projection's own edge rule (`familyIndex`), so the
  * menu can never offer a mutation whose result the sidebar wouldn't show:
  *
- *  - peer-projected sessions (network peers and Local/devcontainer peers
- *    alike) get nothing: the daemon refuses promote/demote for sessions it
- *    doesn't own (`local_only`), so offering the verb would be a lie;
- *  - a family child (cycle-safe, parent local and a semantic agent) can be
- *    promoted — but only if the resulting root row has
+ *  - a peer-projected session is offered the same verbs as a local one: the
+ *    edge belongs to the owning daemon, and the local daemon forwards the
+ *    mutation there (`parent_session_id` is a same-daemon pointer either way).
+ *    Only a family that would span daemons is refused, and neither verb can
+ *    ask for that: promote clears the edge, and Return to family targets the
+ *    launch parent, which is required below to be on the same host;
+ *  - a family child (cycle-safe, parent a semantic agent on the same host)
+ *    can be promoted — but only if the resulting root row has
  *    the same real stamp-backed placement the sidebar uses. A matching rule
  *    alone is not enough: `buildProjectFolders` buckets only stamped rows,
  *    including retained-dead sessions. The daemon deliberately has no
@@ -232,24 +235,29 @@ export type PromotionAction =
   | { readonly kind: 'promote'; readonly parent: Session; readonly blocked?: 'no-project' }
   | { readonly kind: 'demote'; readonly parent: Session; readonly blocked?: 'no-project' }
 
-/** The exact stamp-backed predicate used by `buildProjectFolders` for local
- * rows. Routing can serialize a disclaimed match, but that is not enough for
- * this menu: after a promotion/demotion the user must have a sidebar row too. */
-function hasSidebarPlacement(session: Session, projects: ProjectItem[]): boolean {
-  return sidebarProjectForSession(session, projects) !== null
+/** The exact stamp-backed predicate used by `buildProjectFolders`, for local
+ * and peer-owned rows alike. Routing can serialize a disclaimed match, but
+ * that is not enough for this menu: after a promotion/demotion the user must
+ * have a sidebar row too. */
+function hasSidebarPlacement(
+  session: Session,
+  projects: ProjectItem[],
+  isLocalPeer?: (peerName: string) => boolean,
+): boolean {
+  return sidebarProjectForSession(session, projects, isLocalPeer) !== null
 }
 
 export function promotionAction(
   session: Session,
   source: FamilySource,
   projects: ProjectItem[],
+  isLocalPeer?: (peerName: string) => boolean,
 ): PromotionAction | null {
-  if (session.peer) return null
   const index = indexFor(source)
   if (index.childIds.has(session.id)) {
     const parent = index.byId.get(session.parent_session_id!)
     if (!parent) return null
-    const placeable = hasSidebarPlacement(session, projects)
+    const placeable = hasSidebarPlacement(session, projects, isLocalPeer)
     return placeable
       ? { kind: 'promote', parent }
       : { kind: 'promote', parent, blocked: 'no-project' }
@@ -258,7 +266,11 @@ export function promotionAction(
   if (session.parent_session_id) return null
   if (!session.launched_from_session_id || session.launched_from_session_id === session.id) return null
   const parent = index.byId.get(session.launched_from_session_id)
-  if (!parent || parent.semantic_agent !== true || parent.peer) return null
+  // One family, one daemon: the launch parent must be owned by the same host
+  // as the session. (For a peer session both sides carry the same `peer`
+  // label, since the projection namespaces provenance with the parent edge.)
+  if (!parent || parent.semantic_agent !== true
+    || (parent.peer ?? '') !== (session.peer ?? '')) return null
 
   // Test the projection produced by reparenting to the launch parent. This
   // catches an unplaced ancestor even when the immediate target is placed.
@@ -267,7 +279,7 @@ export function promotionAction(
       ? { ...candidate, parent_session_id: parent.id }
       : candidate)
   const returnedRoot = familyRoot(session, returnedSessions)
-  return hasSidebarPlacement(returnedRoot, projects)
+  return hasSidebarPlacement(returnedRoot, projects, isLocalPeer)
     ? { kind: 'demote', parent }
     : { kind: 'demote', parent, blocked: 'no-project' }
 }

--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -23,7 +23,7 @@ import {
   acknowledgePromotionAnnouncement, activityMap, beginPromotion, connState, 
   dismissSession, familyActivityById, health, 
   initStore, isPromotionAnnouncementDelivered,keybinds, 
-  keyboardOpen, macCommandIsCtrl,navigate, navigateToSession,peers, projects,promoteSession, promotionAnnouncements,
+  keyboardOpen, localPeerNames, macCommandIsCtrl,navigate, navigateToSession,peers, projects,promoteSession, promotionAnnouncements,
   promotionPending, reparentSession,restartSession, resumeSession, retrySSE, selected, selectedId, sessionDotState, 
   sessionStaleness, 
   sessions, setNavigate, settlePromotion, sseRetryAvailable, tabHref,terminalFindOpen, 
@@ -403,12 +403,14 @@ function SessionMenu({ session, onRestart, onResume, resuming }: {
   const showStale = action?.id === 'restart' && !!staleKind
 
   // Presentation promotion (ADR 0026 §8). Eligibility mirrors the family
-  // projection's own edge rule and is null for peer-projected sessions, so
-  // the menu never offers a mutation the daemon would refuse. The `⋮` menu
+  // projection's own edge rule, so the menu never offers a mutation the
+  // daemon would refuse. Peer-owned sessions are included: the local daemon
+  // forwards the mutation to the host that owns the family. The `⋮` menu
   // is deliberately the only surface carrying these verbs: it exists for
   // every session view (desktop and mobile, alive and dead), and a promoted
   // session — no longer a family member — has no family panel to demote from.
-  const promotion = promotionAction(session, sessions.value, projects.value)
+  const promotion = promotionAction(session, sessions.value, projects.value,
+    name => localPeerNames.value.has(name))
   // In-flight guard: the menu closes on activation, but reopening it before
   // the authoritative snapshot lands would offer the same verb again — a
   // second POST per click (reproduced in e2e). The entry lives in the

--- a/apps/gmux-web/src/projects.ts
+++ b/apps/gmux-web/src/projects.ts
@@ -67,9 +67,16 @@ export function isSessionVisibleInProject(session: Session, _project: ProjectIte
 export function sidebarProjectForSession(
   session: Session,
   projects: ProjectItem[],
+  isLocalPeer?: (peerName: string) => boolean,
 ): ProjectItem | null {
-  if (!session.project_slug || session.peer) return null
-  return projects.find(project => !project.peer && project.slug === session.project_slug) ?? null
+  if (!session.project_slug) return null
+  // Same owner key `buildProjectFolders` buckets by: a peer session lands in
+  // its host's reference folder, while a Local peer (devcontainer) is stamped
+  // by this host and lands in a local folder (ADR 0025).
+  const sessionPeer = session.peer ?? ''
+  const ownerPeer = sessionPeer !== '' && !isLocalPeer?.(sessionPeer) ? sessionPeer : ''
+  return projects.find(project =>
+    (project.peer ?? '') === ownerPeer && project.slug === session.project_slug) ?? null
 }
 
 export function matchSession(

--- a/cli/gmux/cmd/gmux/actions.go
+++ b/cli/gmux/cmd/gmux/actions.go
@@ -311,10 +311,25 @@ func lookupInPool(pool []cliSession, ref string) (*cliSession, []cliSession) {
 // cannot occur and make the authoritative id@peer reference ambiguous.
 var validPeerName = regexp.MustCompile(`^[a-z0-9]+(?:-[a-z0-9]+)*$`)
 
+// ownerLabel names the daemon that owns a session, for messages that have to
+// say why two sessions cannot be in one family.
+func ownerLabel(peer string) string {
+	if peer == "" {
+		return "this daemon"
+	}
+	return fmt.Sprintf("peer %q", peer)
+}
+
 // displayID returns the one canonical user-visible session address: the full
 // ID, qualified with @peer when the session is remote.
 func displayID(s cliSession) string {
 	if s.Peer == "" {
+		return s.ID
+	}
+	// The daemon already hands peer sessions out under their namespaced ID
+	// ("id@peer"); qualifying again would print "id@peer@peer" and name a
+	// peer-of-a-peer that doesn't exist.
+	if suffix := "@" + s.Peer; strings.HasSuffix(s.ID, suffix) {
 		return s.ID
 	}
 	return s.ID + "@" + s.Peer
@@ -476,14 +491,6 @@ func cmdReparentMutation(ref, parentRef string, promote bool) int {
 		fmt.Fprintln(os.Stderr, "gmux:", err)
 		return 1
 	}
-	verb := "reparent"
-	if promote {
-		verb = "promote"
-	}
-	if sess.Peer != "" {
-		fmt.Fprintf(os.Stderr, "gmux: %s requires a session owned by this daemon; run gmux on the owning host\n", verb)
-		return 1
-	}
 	var parentID any
 	if !promote {
 		parent, resolveErr := resolveSession(parentRef)
@@ -491,8 +498,14 @@ func cmdReparentMutation(ref, parentRef string, promote bool) int {
 			fmt.Fprintln(os.Stderr, "gmux:", resolveErr)
 			return 1
 		}
-		if parent.Peer != "" {
-			fmt.Fprintln(os.Stderr, "gmux: parent session must be owned by this daemon; cross-peer reparenting is not supported")
+		// A family lives on one daemon. Both ends must therefore be owned by
+		// the same host: this daemon, or the same peer. Peer-owned pairs are
+		// legitimate and the daemon forwards them to their owner; a mixed
+		// pair is the one real refusal.
+		if parent.Peer != sess.Peer {
+			fmt.Fprintf(os.Stderr,
+				"gmux: cross-peer reparenting is not supported: %s is owned by %s and %s by %s; a task family cannot span daemons\n",
+				displayID(sess), ownerLabel(sess.Peer), displayID(parent), ownerLabel(parent.Peer))
 			return 1
 		}
 		parentID = parent.ID

--- a/cli/gmux/cmd/gmux/actions_test.go
+++ b/cli/gmux/cmd/gmux/actions_test.go
@@ -551,3 +551,85 @@ func sortedKeys(m map[string]json.RawMessage) []string {
 	sort.Strings(ks)
 	return ks
 }
+
+// Promoting a peer session is a same-peer mutation: the session stays on its
+// daemon, only its parent pointer changes. The CLI must therefore address the
+// owning daemon through the local one (the daemon forwards it) instead of
+// refusing on the client side. Same for moving a peer child under another
+// parent on that same peer.
+func TestReparentPeerSessionsAddressTheOwningDaemon(t *testing.T) {
+	sessions := []cliSession{
+		{ID: "kid@box", Peer: "box", Adapter: "shell", Alive: true, Slug: "kid"},
+		{ID: "boss@box", Peer: "box", Adapter: "pi", Alive: true, Slug: "boss"},
+		{ID: "local1", Adapter: "pi", Alive: true, Slug: "local"},
+	}
+	t.Run("promote", func(t *testing.T) {
+		d := startStubDaemon(t, sessions)
+		d.on(func(w http.ResponseWriter, _ *http.Request) { writeEnvelope(w, 200, map[string]any{}) })
+		out := captureStdout(t, func() {
+			if code := cmdPromote("kid@box"); code != 0 {
+				t.Fatalf("exit=%d", code)
+			}
+		})
+		got := d.lastRequest(t)
+		if got.path != "/v1/sessions/kid@box/reparent" || got.body != `{"parent_session_id":null}` {
+			t.Fatalf("request=%#v", got)
+		}
+		if !strings.Contains(out, "promoted kid@box to a root") {
+			t.Fatalf("stdout=%q", out)
+		}
+	})
+	t.Run("same-peer reparent", func(t *testing.T) {
+		d := startStubDaemon(t, sessions)
+		d.on(func(w http.ResponseWriter, _ *http.Request) { writeEnvelope(w, 200, map[string]any{}) })
+		if code := captureStdoutCode(t, func() int { return cmdReparent("kid@box", "boss@box") }); code != 0 {
+			t.Fatalf("exit=%d", code)
+		}
+		got := d.lastRequest(t)
+		// The parent is named in the viewer's namespace; translating it into
+		// the owner's is the daemon's job (one place, one rule).
+		if got.path != "/v1/sessions/kid@box/reparent" || got.body != `{"parent_session_id":"boss@box"}` {
+			t.Fatalf("request=%#v", got)
+		}
+	})
+	t.Run("cross-peer refused before any request", func(t *testing.T) {
+		for _, pair := range [][2]string{{"kid@box", "local1"}, {"local1", "boss@box"}} {
+			d := startStubDaemon(t, sessions)
+			var code int
+			err := captureStderr(t, func() { code = cmdReparent(pair[0], pair[1]) })
+			if code == 0 {
+				t.Fatalf("%v accepted", pair)
+			}
+			if !strings.Contains(err, "cross-peer reparenting is not supported") {
+				t.Fatalf("stderr=%q", err)
+			}
+			d.mu.Lock()
+			n := len(d.requests)
+			d.mu.Unlock()
+			if n != 0 {
+				t.Fatalf("%v sent %d request(s)", pair, n)
+			}
+		}
+	})
+}
+
+func captureStdoutCode(t *testing.T, fn func() int) int {
+	t.Helper()
+	code := 1
+	captureStdout(t, func() { code = fn() })
+	return code
+}
+
+// A peer session's wire id is already namespaced; qualifying it again would
+// print "id@peer@peer" and name a peer of a peer.
+func TestDisplayIDDoesNotDoubleQualifyPeerSessions(t *testing.T) {
+	if got := displayID(cliSession{ID: "kid@box", Peer: "box"}); got != "kid@box" {
+		t.Fatalf("displayID=%q", got)
+	}
+	if got := displayID(cliSession{ID: "kid", Peer: "box"}); got != "kid@box" {
+		t.Fatalf("displayID=%q", got)
+	}
+	if got := displayID(cliSession{ID: "kid"}); got != "kid" {
+		t.Fatalf("displayID=%q", got)
+	}
+}

--- a/cli/gmux/cmd/gmux/help.go
+++ b/cli/gmux/cmd/gmux/help.go
@@ -233,7 +233,8 @@ then escalates to SIGKILL. The session stays listed
   gmux promote <id>
 
 Severs the current family edge. The session gets independent family grouping,
-budget ownership, and recursive dismissal. Local sessions only. Undo by
+budget ownership, and recursive dismissal. Works on a peer session too
+(id@peer): the request is forwarded to the daemon that owns it. Undo by
 reparenting it under its former parent.
 `,
 
@@ -242,8 +243,9 @@ reparenting it under its former parent.
   gmux reparent <id> <parent-id>
 
 Changes family grouping, budget ownership, and recursive dismissal. Both
-sessions must be local to this daemon; self-parenting and cycles are refused.
-Use 'gmux promote <id>' to make the session a root again.
+sessions must be owned by the same daemon — both local, or both on the same
+peer (id@peer); a family cannot span hosts. Self-parenting and cycles are
+refused. Use 'gmux promote <id>' to make the session a root again.
 `,
 
 	"edit": `gmux edit: open a file in a managed editor session

--- a/docs/task-family-ui.md
+++ b/docs/task-family-ui.md
@@ -17,17 +17,31 @@ presentation roots and cannot be hidden accidentally.
 `gmux promote <id>` severs the current edge and makes a session a root;
 `gmux reparent <id> <parent-id>` moves it under another session. The web UI
 exposes the same pair in the session's `⋮` menu ("Promote to root" /
-"Return to family", `promotionAction` in `family.ts`), offered only for
-daemon-owned sessions and only while the return target resolves locally as a
-semantic agent. Promote is blocked (visible, disabled, with the reason) when no
+"Return to family", `promotionAction` in `family.ts`), offered while the
+return target resolves as a semantic agent owned by the same host as the
+session. Promote is blocked (visible, disabled, with the reason) when no
 project places the session: an unplaced root has no sidebar row and no routable
 URL, and the daemon deliberately gives parentage no say in project matching.
 Return to family is blocked the same way when the resulting family root has no
 stamp-backed placement, so an outside-project parent cannot strand the selected
 child. Promotion re-roots the active-subagent budget under the promoted session
-and removes its notification suppressor. Both mutations are local-only;
-self-parenting, ancestor cycles, and cross-peer reassignment are rejected
-transactionally.
+and removes its notification suppressor. Self-parenting and ancestor cycles
+are rejected transactionally by the owning store.
+
+Both mutations work on peer-projected sessions, because neither is cross-peer:
+promote is reparent-to-null and a peer session's parent pointer is a pointer
+within its own daemon. The viewer never writes a peer projection — it forwards
+`POST /v1/sessions/{id@peer}/reparent` to the owning daemon under that peer's
+credentials, translating the requested parent out of the viewer's namespace
+(`id@peer` → `id`) on the way. The one genuine refusal is a family that would
+span daemons: a peer child under a local parent, a local child under a peer
+parent, or two different peers. `parent_session_id` drives one daemon's
+ordering scopes, recursive dismissal and notification suppression, none of
+which can cross a host boundary, so both the CLI and the daemon refuse it
+(`cross_peer`) and the menu never offers it. Peer placement follows the
+sidebar: a promoted peer row needs a reference folder for its host's project
+(Settings → “From other hosts”), otherwise the verb is blocked with the same
+no-project reason as a local unplaced row.
 
 The daemon derives `semantic_agent` from the existing
 `adapter.ConversationSource` capability. It covers the conversation-backed Pi,

--- a/e2e/tests/peer-promote.spec.ts
+++ b/e2e/tests/peer-promote.spec.ts
@@ -1,0 +1,294 @@
+import { test, expect } from '@playwright/test'
+import { spawn, spawnSync, type ChildProcess } from 'child_process'
+import * as fs from 'fs'
+import * as net from 'net'
+import * as os from 'os'
+import * as path from 'path'
+import { gotoSession, openApp, pollUntil } from '../helpers'
+
+/**
+ * Promote to root for a **peer** session, end to end through two real
+ * daemons.
+ *
+ * Promote is reparent-to-null (single-axis families), and for a peer session
+ * that is a same-peer mutation: the session never leaves its own daemon, only
+ * its parent pointer changes. The viewer must therefore offer the verb and
+ * forward it to the owning daemon — never apply it to the local projection,
+ * and never refuse it as if it were cross-peer.
+ *
+ * The spec runs a second, disposable daemon (the "spoke") in its own tmpdir,
+ * state dir, HOME and port, peers the e2e daemon (the "hub") to it, and builds
+ * the family on the spoke: stub `claude` parent + shell child inheriting
+ * GMUX_SESSION_ID. Every assertion about the mutation is read from the
+ * SPOKE's own API, which is the authority for its sessions' parentage.
+ */
+
+const ROOT = path.resolve(__dirname, '..', '..')
+const GMUX = path.join(ROOT, 'bin', 'gmux')
+const GMUXD = path.join(ROOT, 'bin', 'gmuxd')
+const SPOKE_TOKEN = 'ab'.padEnd(64, '0')
+
+type WireSession = {
+  id: string
+  alive: boolean
+  peer?: string
+  cwd?: string
+  title?: string
+  adapter?: string
+  parent_session_id?: string
+  launched_from_session_id?: string
+  semantic_agent?: boolean
+}
+
+function hub(): { base: string; headers: Record<string, string> } {
+  const port = process.env.GMUXD_TEST_PORT
+  const token = process.env.GMUX_TEST_TOKEN
+  if (!port || !token) throw new Error('global-setup did not run')
+  return { base: `http://127.0.0.1:${port}`, headers: { Authorization: `Bearer ${token}` } }
+}
+
+async function request(
+  target: { base: string; headers: Record<string, string> },
+  method: string,
+  pathname: string,
+  body?: unknown,
+): Promise<{ status: number; body: any }> {
+  const resp = await fetch(`${target.base}${pathname}`, {
+    method,
+    headers: body === undefined ? target.headers : { ...target.headers, 'Content-Type': 'application/json' },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  })
+  let parsed: any
+  try { parsed = await resp.json() } catch { /* non-JSON */ }
+  return { status: resp.status, body: parsed }
+}
+
+let spokePort = 0
+let spokeProc: ChildProcess | undefined
+let spokeTmp = ''
+let spokeEnv: Record<string, string> = {}
+let hubEnv: Record<string, string> = {}
+const spokeProcs: ChildProcess[] = []
+
+let peerName = ''
+let parentId = ''
+let childId = ''
+let childTitle = ''
+
+function spoke(): { base: string; headers: Record<string, string> } {
+  return { base: `http://127.0.0.1:${spokePort}`, headers: { Authorization: `Bearer ${SPOKE_TOKEN}` } }
+}
+
+async function spokeSessions(): Promise<WireSession[]> {
+  const { body } = await request(spoke(), 'GET', '/v1/sessions')
+  return (body?.data ?? []) as WireSession[]
+}
+
+async function hubSessions(): Promise<WireSession[]> {
+  const { body } = await request(hub(), 'GET', '/v1/sessions')
+  return (body?.data ?? []) as WireSession[]
+}
+
+/** The authority for the family edge: the daemon that owns the session. */
+async function spokeParentOf(id: string): Promise<string | undefined> {
+  return (await spokeSessions()).find(s => s.id === id)?.parent_session_id
+}
+
+async function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer()
+    srv.listen(0, '127.0.0.1', () => {
+      const port = (srv.address() as net.AddressInfo).port
+      srv.close(() => resolve(port))
+    })
+    srv.on('error', reject)
+  })
+}
+
+test.describe.configure({ mode: 'serial' })
+
+test.beforeAll(async () => {
+  test.setTimeout(120_000)
+  spokeTmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gmux-e2e-spoke-'))
+  spokePort = await freePort()
+  const dirs = {
+    sockets: path.join(spokeTmp, 'sockets'),
+    config: path.join(spokeTmp, 'config', 'gmux'),
+    state: path.join(spokeTmp, 'state'),
+    home: path.join(spokeTmp, 'home'),
+    workspace: path.join(spokeTmp, 'workspace'),
+    stub: path.join(spokeTmp, 'stub-bin'),
+  }
+  for (const dir of Object.values(dirs)) fs.mkdirSync(dir, { recursive: true })
+  fs.writeFileSync(path.join(dirs.config, 'host.toml'),
+    `port = ${spokePort}\n\n[discovery]\ndevcontainers = false\n\n[tailscale]\nenabled = false\n`)
+  // Same trick as the local promote spec: the adapter registry resolves on
+  // the command basename, so a `claude` stub is a semantic agent.
+  fs.writeFileSync(path.join(dirs.stub, 'claude'), '#!/bin/sh\necho stub agent ready\nexec sleep 600\n')
+  fs.chmodSync(path.join(dirs.stub, 'claude'), 0o755)
+
+  spokeEnv = {
+    PATH: `${dirs.stub}:${process.env.PATH || ''}`,
+    HOME: dirs.home,
+    TERM: 'xterm-256color',
+    GMUX_SOCKET_DIR: dirs.sockets,
+    GMUXD_TOKEN: SPOKE_TOKEN,
+    XDG_CONFIG_HOME: path.join(spokeTmp, 'config'),
+    XDG_STATE_HOME: dirs.state,
+  }
+  // The hub's env, for driving the CLI against the e2e daemon.
+  hubEnv = {
+    PATH: process.env.PATH || '',
+    HOME: process.env.GMUX_TEST_HOME!,
+    TERM: 'xterm-256color',
+    GMUX_SOCKET_DIR: path.join(JSON.parse(
+      fs.readFileSync(path.join(os.tmpdir(), 'gmux-e2e-state.json'), 'utf-8')).tmpDir, 'sockets'),
+    GMUXD_TOKEN: process.env.GMUX_TEST_TOKEN!,
+    XDG_CONFIG_HOME: path.join(JSON.parse(
+      fs.readFileSync(path.join(os.tmpdir(), 'gmux-e2e-state.json'), 'utf-8')).tmpDir, 'config'),
+    XDG_STATE_HOME: path.join(JSON.parse(
+      fs.readFileSync(path.join(os.tmpdir(), 'gmux-e2e-state.json'), 'utf-8')).tmpDir, 'state'),
+  }
+
+  spokeProc = spawn(GMUXD, ['run'], { env: spokeEnv, stdio: ['ignore', 'pipe', 'pipe'], detached: true })
+  spokeProc.stderr?.on('data', (d: Buffer) => { if (process.env.DEBUG) process.stderr.write(`[spoke] ${d}`) })
+  await pollUntil(async () => {
+    try { return (await fetch(`http://127.0.0.1:${spokePort}/v1/health`, { headers: spoke().headers })).ok }
+    catch { return false }
+  }, { timeoutMs: 20_000, description: 'spoke daemon healthy' })
+
+  // The spoke owns its project catalog; the hub will reference it by slug.
+  expect((await request(spoke(), 'PUT', '/v1/projects',
+    { items: [{ slug: 'spoke-project', match: [{ path: dirs.workspace }] }] })).status).toBe(200)
+
+  spokeProcs.push(spawn(GMUX, ['--', 'claude'],
+    { env: spokeEnv, cwd: dirs.workspace, stdio: ['ignore', 'pipe', 'pipe'], detached: true }))
+  const parent = await pollUntil(async () =>
+    (await spokeSessions()).find(s => s.alive && s.adapter === 'claude'),
+  { timeoutMs: 20_000, description: 'spoke stub claude registered' })
+  parentId = parent.id
+  expect(parent.semantic_agent, 'stub claude parent must be a semantic agent').toBe(true)
+
+  spokeProcs.push(spawn(GMUX, ['--', 'sh', '-c', 'echo peer child ready; sleep 600'],
+    { env: { ...spokeEnv, GMUX_SESSION_ID: parentId }, cwd: dirs.workspace, stdio: ['ignore', 'pipe', 'pipe'], detached: true }))
+  const child = await pollUntil(async () =>
+    (await spokeSessions()).find(s => s.alive && s.parent_session_id === parentId),
+  { timeoutMs: 20_000, description: 'spoke family child registered' })
+  childId = child.id
+  childTitle = child.title || 'sh'
+
+  // Peer the hub to the spoke. The daemon assigns the peer name.
+  const added = await request(hub(), 'POST', '/v1/peers',
+    { url: `http://127.0.0.1:${spokePort}`, token: SPOKE_TOKEN })
+  expect(added.status).toBe(200)
+  peerName = added.body?.peer?.Name
+  expect(peerName, 'peer name assigned by the hub').toBeTruthy()
+
+  // Reference the spoke's project so its rows have a hub-side folder — the
+  // same thing the Settings "From other hosts" list does. Without it the
+  // promoted row would have nowhere to live and the menu would (correctly)
+  // block the verb.
+  expect((await request(hub(), 'PUT', '/v1/projects', {
+    items: [
+      { slug: 'test-project', match: [{ path: process.env.GMUX_TEST_WORKSPACE! }] },
+      { slug: 'spoke-project', peer: peerName },
+    ],
+  })).status).toBe(200)
+
+  // Wait for the hub's projection: namespaced ids, namespaced family edges.
+  await pollUntil(async () => {
+    const row = (await hubSessions()).find(s => s.id === `${childId}@${peerName}`)
+    return row?.parent_session_id === `${parentId}@${peerName}`
+      && row?.launched_from_session_id === `${parentId}@${peerName}`
+  }, { timeoutMs: 20_000, description: 'hub projects the peer family with namespaced edges' })
+})
+
+test.afterAll(async () => {
+  // Restore the hub's seeded catalog and drop the peer, so sibling specs see
+  // the daemon they expect.
+  await request(hub(), 'PUT', '/v1/projects',
+    { items: [{ slug: 'test-project', match: [{ path: process.env.GMUX_TEST_WORKSPACE! }] }] }).catch(() => {})
+  if (peerName) await request(hub(), 'DELETE', `/v1/peers/${peerName}`).catch(() => {})
+  for (const proc of spokeProcs) {
+    if (proc.pid) { try { process.kill(-proc.pid, 'SIGKILL') } catch { /* gone */ } }
+  }
+  if (spokeProc?.pid) { try { process.kill(-spokeProc.pid, 'SIGKILL') } catch { /* gone */ } }
+  await new Promise(r => setTimeout(r, 300))
+  if (spokeTmp) fs.rmSync(spokeTmp, { recursive: true, force: true })
+})
+
+test('the ⋮ menu promotes a peer child and returns it to its family', async ({ page }) => {
+  test.setTimeout(90_000)
+  await openApp(page)
+  await gotoSession(page, `${childId}@${peerName}`)
+
+  const childRow = page.locator('.session-item')
+    .filter({ has: page.locator(`.session-title:text-is("${childTitle}")`) })
+  await expect(page.locator('.family-slot.selected')).toHaveCount(1)
+  await expect(childRow).toHaveCount(0)
+
+  await page.locator('.session-menu-trigger').click()
+  const item = page.locator('.session-menu-promotion')
+  await expect(item).toContainText('Promote to root')
+  await expect(item).not.toHaveAttribute('aria-disabled', 'true')
+  await item.click()
+
+  // Authoritative check on the OWNING daemon: the edge was cleared there,
+  // not faked in the viewer's projection.
+  await expect.poll(() => spokeParentOf(childId), { timeout: 15_000 }).toBeUndefined()
+  await expect(page.locator('[data-promotion-status]')).toHaveText('Promoted to root.')
+  await expect(childRow).toHaveCount(1)
+  await expect(page.locator('.xterm')).toBeVisible()
+
+  // And back: Return to family resolves the peer's launch provenance, which
+  // only works because the projection namespaces it with the parent edge.
+  await page.locator('.session-menu-trigger').click()
+  const back = page.locator('.session-menu-promotion')
+  await expect(back).toContainText('Return to family')
+  await back.click()
+  await expect.poll(() => spokeParentOf(childId), { timeout: 15_000 }).toBe(parentId)
+  await expect(page.locator('[data-promotion-status]')).toHaveText('Returned to family.')
+})
+
+test('the CLI promotes and reparents a peer child through the local daemon', async () => {
+  test.setTimeout(60_000)
+  const gmux = (...args: string[]) => spawnSync(GMUX, args, { env: hubEnv, encoding: 'utf-8' })
+
+  const promote = gmux('promote', `${childId}@${peerName}`)
+  expect(promote.stderr + promote.stdout).toContain('promoted')
+  expect(promote.status).toBe(0)
+  await expect.poll(() => spokeParentOf(childId), { timeout: 15_000 }).toBeUndefined()
+
+  // Same-peer reparent is legitimate under one-daemon families: the parent
+  // reference is translated into the owner's namespace by the daemon.
+  const reparent = gmux('reparent', `${childId}@${peerName}`, `${parentId}@${peerName}`)
+  expect(reparent.stderr + reparent.stdout).toContain('reparented')
+  expect(reparent.status).toBe(0)
+  await expect.poll(() => spokeParentOf(childId), { timeout: 15_000 }).toBe(parentId)
+})
+
+test('a family that would span two daemons is still refused, in both directions', async () => {
+  test.setTimeout(60_000)
+  const localId = process.env.GMUX_TEST_SESSION_ID!
+
+  // Peer child under a local parent.
+  const inbound = await request(hub(), 'POST', `/v1/sessions/${childId}@${peerName}/reparent`,
+    { parent_session_id: localId })
+  expect(inbound.status).toBe(400)
+  expect(inbound.body?.error?.code).toBe('cross_peer')
+
+  // Local child under a peer parent.
+  const outbound = await request(hub(), 'POST', `/v1/sessions/${localId}/reparent`,
+    { parent_session_id: `${parentId}@${peerName}` })
+  expect(outbound.status).toBe(400)
+  expect(outbound.body?.error?.code).toBe('cross_peer')
+
+  // Neither daemon moved anything.
+  expect(await spokeParentOf(childId)).toBe(parentId)
+  expect((await hubSessions()).find(s => s.id === localId)?.parent_session_id).toBeUndefined()
+
+  // The CLI refuses before any request leaves.
+  const cli = spawnSync(GMUX, ['reparent', `${childId}@${peerName}`, localId], { env: hubEnv, encoding: 'utf-8' })
+  expect(cli.status).toBe(1)
+  expect(cli.stderr).toContain('cross-peer reparenting is not supported')
+})

--- a/services/gmuxd/cmd/gmuxd/reparent_peer.go
+++ b/services/gmuxd/cmd/gmuxd/reparent_peer.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/peering"
+)
+
+// codeCrossPeer — the requested parent lives on a different daemon than the
+// child. A family is one daemon's structure (ADR 0026): `parent_session_id`
+// drives that daemon's ordering scopes, recursive dismissal, and notification
+// suppression, none of which can span hosts. This is the one genuine refusal
+// in the reparent family; it is not a forwarding limitation.
+const codeCrossPeer = "cross_peer"
+
+// rewritePeerReparentBody translates a reparent request addressed to a
+// peer-owned child from the viewer's namespace into the owning daemon's own
+// namespace, so the hub can forward it instead of refusing it.
+//
+// Promoting to root IS reparenting to null (single-axis families, #505), and
+// for a peer session that is a same-peer operation: the session never leaves
+// its daemon, only its parent pointer changes. The same holds for moving a
+// peer child under another parent on that same peer. What cannot work — and
+// stays refused — is a family spanning two daemons, in either direction.
+//
+// childPeer is the peer name the child ID resolved to. Returns the body to
+// forward, or a non-empty (code, message) pair to refuse with.
+//
+// Unknown keys are preserved so a later, additive field on this route keeps
+// working across a hub/spoke version skew: only the parent reference is
+// rewritten.
+func rewritePeerReparentBody(body []byte, childPeer string) (forward []byte, code, message string) {
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, "bad_request", "invalid JSON"
+	}
+	raw, present := payload["parent_session_id"]
+	if !present {
+		return nil, "bad_request", "parent_session_id is required (use null to clear)"
+	}
+	// Promote-to-root: no reference to translate, nothing cross-peer about it.
+	if string(raw) == "null" {
+		return body, "", ""
+	}
+	var parentID string
+	if err := json.Unmarshal(raw, &parentID); err != nil || parentID == "" {
+		return nil, "bad_request", "parent_session_id must be a session id or null"
+	}
+	parentOriginal, parentPeer := peering.ParseID(parentID)
+	if parentPeer != childPeer {
+		where := "this daemon"
+		if parentPeer != "" {
+			where = fmt.Sprintf("peer %q", parentPeer)
+		}
+		return nil, codeCrossPeer, fmt.Sprintf(
+			"cross-peer reparenting is not supported: the child is owned by peer %q and the requested parent by %s; a task family cannot span daemons",
+			childPeer, where)
+	}
+	rewritten, err := json.Marshal(parentOriginal)
+	if err != nil {
+		return nil, "bad_request", "parent_session_id must be a session id or null"
+	}
+	payload["parent_session_id"] = rewritten
+	out, err := json.Marshal(payload)
+	if err != nil {
+		return nil, "bad_request", "invalid request body"
+	}
+	return out, "", ""
+}

--- a/services/gmuxd/cmd/gmuxd/reparent_peer_test.go
+++ b/services/gmuxd/cmd/gmuxd/reparent_peer_test.go
@@ -1,0 +1,211 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/centralstore"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/config"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/peering"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/sessioncoord"
+	central "github.com/gmuxapp/gmux/services/gmuxd/internal/snapshot/central"
+)
+
+// Translation is the whole of the peer-reparent policy: what crosses the
+// boundary, in whose namespace, and what is refused.
+func TestRewritePeerReparentBody(t *testing.T) {
+	for _, tc := range []struct {
+		name, body, childPeer, wantForward, wantCode string
+	}{
+		// Promote-to-root is reparent-to-null: no reference to translate and
+		// nothing cross-peer about it.
+		{"promote", `{"parent_session_id":null}`, "box", `{"parent_session_id":null}`, ""},
+		{"same peer parent", `{"parent_session_id":"p@box"}`, "box", `{"parent_session_id":"p"}`, ""},
+		// A hub two hops out addresses the far session as p@mid@box; the next
+		// hop keeps resolving its own suffix.
+		{"chained peer parent", `{"parent_session_id":"p@mid@box"}`, "box", `{"parent_session_id":"p@mid"}`, ""},
+		{"local parent", `{"parent_session_id":"p"}`, "box", "", codeCrossPeer},
+		{"other peer parent", `{"parent_session_id":"p@other"}`, "box", "", codeCrossPeer},
+		{"missing field", `{}`, "box", "", "bad_request"},
+		{"empty parent", `{"parent_session_id":""}`, "box", "", "bad_request"},
+		{"non-string parent", `{"parent_session_id":3}`, "box", "", "bad_request"},
+		{"invalid json", `{`, "box", "", "bad_request"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			forward, code, message := rewritePeerReparentBody([]byte(tc.body), tc.childPeer)
+			if code != tc.wantCode {
+				t.Fatalf("code=%q message=%q, want %q", code, message, tc.wantCode)
+			}
+			if tc.wantCode != "" {
+				if message == "" {
+					t.Fatal("a refusal owes a reason")
+				}
+				return
+			}
+			var got, want map[string]any
+			if err := json.Unmarshal(forward, &got); err != nil {
+				t.Fatalf("forwarded body is not JSON: %v", err)
+			}
+			if err := json.Unmarshal([]byte(tc.wantForward), &want); err != nil {
+				t.Fatal(err)
+			}
+			gotJSON, _ := json.Marshal(got)
+			wantJSON, _ := json.Marshal(want)
+			if string(gotJSON) != string(wantJSON) {
+				t.Fatalf("forwarded %s, want %s", gotJSON, wantJSON)
+			}
+		})
+	}
+}
+
+// An additive field on this route must survive the hub's rewrite rather than
+// being dropped on the way to the owning daemon.
+func TestRewritePeerReparentBodyKeepsUnknownFields(t *testing.T) {
+	forward, code, _ := rewritePeerReparentBody([]byte(`{"parent_session_id":"p@box","future":42}`), "box")
+	if code != "" {
+		t.Fatalf("code=%q", code)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(forward, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got["parent_session_id"] != "p" || got["future"] != float64(42) {
+		t.Fatalf("forwarded %v", got)
+	}
+}
+
+type spokeReparent struct {
+	mu   sync.Mutex
+	path string
+	body string
+}
+
+func (s *spokeReparent) record(path, body string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.path, s.body = path, body
+}
+
+func (s *spokeReparent) seen() (string, string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.path, s.body
+}
+
+// The hub must not apply a peer session's family edge to its own projection,
+// and must not refuse it either: the request belongs to the owning daemon,
+// under that peer's own credentials.
+func TestPeerReparentIsForwardedToOwner(t *testing.T) {
+	seen := &spokeReparent{}
+	spoke := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		seen.record(r.URL.Path, string(body))
+		if r.Header.Get("Authorization") != "Bearer tok" {
+			http.Error(w, "auth", http.StatusUnauthorized)
+			return
+		}
+		writeJSON(w, map[string]any{"ok": true, "data": map[string]any{}})
+	}))
+	defer spoke.Close()
+	pm := peering.NewProjectionManager(
+		[]config.PeerConfig{{Name: "box", URL: spoke.URL, Token: "tok"}}, "self", nil, peering.EventHooks{})
+
+	post := func(id, body string) *httptest.ResponseRecorder {
+		recorder := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/v1/sessions/"+id+"/reparent", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		handleCentralSessionAction(recorder, req, nil, newSSEFanout(), nil, pm, nil, "", nil)
+		return recorder
+	}
+
+	// Promote a peer child: forwarded verbatim, addressed by the owner's ID.
+	if response := post("kid@box", `{"parent_session_id":null}`); response.Code != http.StatusOK {
+		t.Fatalf("promote code=%d body=%s", response.Code, response.Body.String())
+	}
+	if path, body := seen.seen(); path != "/v1/sessions/kid/reparent" || body != `{"parent_session_id":null}` {
+		t.Fatalf("spoke saw path=%q body=%q", path, body)
+	}
+
+	// Same-peer reparent: legitimate, with the parent translated out of the
+	// viewer's namespace.
+	if response := post("kid@box", `{"parent_session_id":"boss@box"}`); response.Code != http.StatusOK {
+		t.Fatalf("reparent code=%d body=%s", response.Code, response.Body.String())
+	}
+	path, body := seen.seen()
+	if path != "/v1/sessions/kid/reparent" {
+		t.Fatalf("spoke saw path=%q", path)
+	}
+	var forwarded map[string]any
+	if err := json.Unmarshal([]byte(body), &forwarded); err != nil {
+		t.Fatalf("spoke saw %q: %v", body, err)
+	}
+	if forwarded["parent_session_id"] != "boss" {
+		t.Fatalf("spoke saw parent %v, want the peer-local id", forwarded["parent_session_id"])
+	}
+
+	// Cross-peer stays refused, and never reaches the wire.
+	seen.record("", "")
+	response := post("kid@box", `{"parent_session_id":"local-boss"}`)
+	if response.Code != http.StatusBadRequest || !strings.Contains(response.Body.String(), codeCrossPeer) {
+		t.Fatalf("cross-peer code=%d body=%s", response.Code, response.Body.String())
+	}
+	if path, _ := seen.seen(); path != "" {
+		t.Fatalf("refused request still forwarded to %q", path)
+	}
+	if response := post("kid@box", `{"parent_session_id":"other@elsewhere"}`); response.Code != http.StatusBadRequest ||
+		!strings.Contains(response.Body.String(), codeCrossPeer) {
+		t.Fatalf("other-peer code=%d body=%s", response.Code, response.Body.String())
+	}
+	if path, _ := seen.seen(); path != "" {
+		t.Fatalf("refused request still forwarded to %q", path)
+	}
+	// A GET is not a mutation; it must not be proxied as one.
+	recorder := httptest.NewRecorder()
+	handleCentralSessionAction(recorder, httptest.NewRequest(http.MethodGet, "/v1/sessions/kid@box/reparent", nil),
+		nil, newSSEFanout(), nil, pm, nil, "", nil)
+	if recorder.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("GET code=%d", recorder.Code)
+	}
+}
+
+// The mirror image: a local child cannot join a peer's family. The refusal
+// must say so instead of surfacing as "that parent does not exist here".
+func TestLocalReparentUnderPeerParentIsRefusedAsCrossPeer(t *testing.T) {
+	ctx := context.Background()
+	store, err := centralstore.Open(ctx, t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	if _, _, err := store.InsertSession(ctx, centralstore.NewSession{
+		ID: "a", Adapter: "shell", Command: []string{"sh"}, CreatedAt: 1}); err != nil {
+		t.Fatal(err)
+	}
+	coord := sessioncoord.New(nil, nil, store, nil, nil)
+	boot := &Bootstrap{Store: store, Coordinator: coord, Composer: central.New(store, nil, nil)}
+	pm := peering.NewProjectionManager(
+		[]config.PeerConfig{{Name: "box", URL: "http://127.0.0.1:1"}}, "self", nil, peering.EventHooks{})
+
+	recorder := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/sessions/a/reparent", strings.NewReader(`{"parent_session_id":"boss@box"}`))
+	req.Header.Set("Content-Type", "application/json")
+	handleCentralSessionAction(recorder, req, boot, newSSEFanout(), nil, pm, nil, "", nil)
+	if recorder.Code != http.StatusBadRequest || !strings.Contains(recorder.Body.String(), codeCrossPeer) {
+		t.Fatalf("code=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+
+	// Promoting a local session with a peer roster present is untouched.
+	recorder = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPost, "/v1/sessions/a/reparent", strings.NewReader(`{"parent_session_id":null}`))
+	req.Header.Set("Content-Type", "application/json")
+	handleCentralSessionAction(recorder, req, boot, newSSEFanout(), nil, pm, nil, "", nil)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("local promote code=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+}

--- a/services/gmuxd/cmd/gmuxd/serve_central.go
+++ b/services/gmuxd/cmd/gmuxd/serve_central.go
@@ -1138,9 +1138,28 @@ func handleCentralSessionAction(w http.ResponseWriter, r *http.Request, boot *Bo
 	}
 	if peerManager != nil && action != "" {
 		if peer, originalID := peerManager.FindPeer(sessionID); peer != nil {
+			// Reparent (including promote-to-root, which is reparent-to-null)
+			// is forwarded to the owning daemon, never applied to the local
+			// projection: the mutation belongs to the host that owns the
+			// family, and the peer's own token custody carries it there.
+			// Only a family that would span daemons is refused — see
+			// rewritePeerReparentBody.
 			if action == "reparent" {
-				writeError(w, http.StatusBadRequest, codeLocalOnly, fmt.Sprintf(
-					"%s is only available for sessions owned by this daemon; run gmux on the owning host", action))
+				if r.Method != http.MethodPost {
+					writeError(w, http.StatusMethodNotAllowed, "bad_request", "method not allowed")
+					return
+				}
+				body, err := io.ReadAll(io.LimitReader(r.Body, 4097))
+				if err != nil || len(body) > 4096 {
+					writeError(w, http.StatusBadRequest, "bad_request", "invalid request body")
+					return
+				}
+				forward, code, message := rewritePeerReparentBody(body, peer.Config.Name)
+				if code != "" {
+					writeError(w, http.StatusBadRequest, code, message)
+					return
+				}
+				peer.ForwardBody(w, r, originalID, action, forward)
 				return
 			}
 			// Semantic agent actions are local-only in this slice (ADR 0027).
@@ -1191,6 +1210,16 @@ func handleCentralSessionAction(w http.ResponseWriter, r *http.Request, boot *Bo
 			if err = json.Unmarshal(rawParent, &parentID); err != nil || parentID == "" {
 				writeError(w, http.StatusBadRequest, "bad_request", "parent_session_id must be a session id or null")
 				return
+			}
+			// A local child cannot join a peer's family either: same refusal,
+			// stated as such instead of surfacing as "parent does not exist".
+			if peerManager != nil {
+				if peerParent, _ := peerManager.FindPeer(parentID); peerParent != nil {
+					writeError(w, http.StatusBadRequest, codeCrossPeer, fmt.Sprintf(
+						"cross-peer reparenting is not supported: the child is owned by this daemon and the requested parent by peer %q; a task family cannot span daemons",
+						peerParent.Config.Name))
+					return
+				}
 			}
 			value := centralstore.SessionID(parentID)
 			parent = &value

--- a/services/gmuxd/internal/apiclient/client.go
+++ b/services/gmuxd/internal/apiclient/client.go
@@ -234,6 +234,16 @@ func (c *Client) ForwardAction(w http.ResponseWriter, r *http.Request, sessionID
 	c.proxyHTTP(w, r, path)
 }
 
+// ForwardActionBody is ForwardAction with a caller-supplied request
+// body, for the actions whose payload must be rewritten before it
+// crosses the peer boundary (reparent: a parent reference is named in
+// the viewer's namespace and has to arrive in the owner's).
+func (c *Client) ForwardActionBody(w http.ResponseWriter, r *http.Request, sessionID, action string, body []byte) {
+	r.Body = io.NopCloser(bytes.NewReader(body))
+	r.ContentLength = int64(len(body))
+	c.ForwardAction(w, r, sessionID, action)
+}
+
 // ForwardPath proxies an HTTP request to the spoke at the given
 // absolute path. The path must include the leading slash ("/v1/...").
 // Method, body, status, headers and Content-Type are preserved.

--- a/services/gmuxd/internal/peering/peer.go
+++ b/services/gmuxd/internal/peering/peer.go
@@ -200,6 +200,14 @@ func (p *Peer) Forward(w http.ResponseWriter, r *http.Request, originalID, actio
 	p.api.ForwardAction(w, r, originalID, action)
 }
 
+// ForwardBody forwards a session action with a rewritten request body.
+// Used for reparent, whose parent reference names a session in the
+// viewer's namespace and must reach the owner in the owner's own
+// namespace (promote-to-root carries no reference and forwards as-is).
+func (p *Peer) ForwardBody(w http.ResponseWriter, r *http.Request, originalID, action string, body []byte) {
+	p.api.ForwardActionBody(w, r, originalID, action, body)
+}
+
 // ForwardLaunch sends a launch request to the spoke. The top-level
 // "peer" field is stripped before forwarding so the spoke treats the
 // request as a local launch.
@@ -791,6 +799,15 @@ func (p *Peer) applySessionsSnapshot(input any) {
 		if sess.ParentSessionID != "" {
 			if _, parentPeer := ParseID(sess.ParentSessionID); parentPeer == "" {
 				sess.ParentSessionID = NamespaceID(sess.ParentSessionID, p.Config.Name)
+			}
+		}
+		// Launch provenance is a session reference in the same namespace as
+		// the parent edge, and the viewer resolves it the same way (Return to
+		// family). Left bare it would name nothing here — or worse, collide
+		// with a local session ID.
+		if sess.LaunchedFromSessionID != "" {
+			if _, fromPeer := ParseID(sess.LaunchedFromSessionID); fromPeer == "" {
+				sess.LaunchedFromSessionID = NamespaceID(sess.LaunchedFromSessionID, p.Config.Name)
 			}
 		}
 		sess.Peer = p.Config.Name

--- a/services/gmuxd/internal/peering/peering_test.go
+++ b/services/gmuxd/internal/peering/peering_test.go
@@ -1427,3 +1427,37 @@ func TestApplySessionsSnapshot_BroadcastsOnRealChange(t *testing.T) {
 		t.Error("155mk8b7@server should be dead after update")
 	}
 }
+
+// Family references enter the viewer's namespace with the session that owns
+// them. `launched_from_session_id` is one of those references — the web menu
+// resolves it to offer Return to family — so a bare id would name nothing
+// here, or worse collide with a local session's id.
+func TestApplySessionsSnapshot_NamespacesFamilyReferences(t *testing.T) {
+	sink := newMockSink()
+	p := newPeer(config.PeerConfig{Name: "server"}, sink, nil)
+
+	p.applySessionsSnapshot([]SessionProjection{
+		{ID: "kid", Adapter: "shell", Alive: true, ParentSessionID: "boss", LaunchedFromSessionID: "boss"},
+		// Already qualified: the origin means a host of its own, so it must
+		// not become "far@mid@server".
+		{ID: "promoted", Adapter: "pi", Alive: true, LaunchedFromSessionID: "far@mid"},
+	})
+
+	kid, ok := sink.findSession("server", "kid@server")
+	if !ok {
+		t.Fatal("kid@server not found in sink")
+	}
+	if kid.ParentSessionID != "boss@server" {
+		t.Errorf("parent = %q, want %q", kid.ParentSessionID, "boss@server")
+	}
+	if kid.LaunchedFromSessionID != "boss@server" {
+		t.Errorf("launched_from = %q, want %q", kid.LaunchedFromSessionID, "boss@server")
+	}
+	promoted, ok := sink.findSession("server", "promoted@server")
+	if !ok {
+		t.Fatal("promoted@server not found in sink")
+	}
+	if promoted.LaunchedFromSessionID != "far@mid" {
+		t.Errorf("launched_from = %q, want it retained", promoted.LaunchedFromSessionID)
+	}
+}


### PR DESCRIPTION
## Report

"Promote to root" was unavailable for **peer** sessions (owned by a peered remote daemon, shown in the local web UI). Per #505 promote *is* reparent-to-null and cross-peer reparent is refused because a family cannot span daemons — but promoting a peer session is a **same-peer** operation: the session stays on its daemon, only its parent pointer changes.

## Where it was blocked (all three, independently)

| # | Layer | Pre-fix | Behavior |
|---|---|---|---|
| a | Web UI | `family.ts:247` `if (session.peer) return null` | menu item absent (promote *and* Return to family) |
| b | Hub daemon | `serve_central.go:1141` `action == "reparent"` → `local_only` | never forwarded |
| c | Owning daemon | — | **accepted all along** (control step in the repro) |
| d | CLI | `actions.go:483` `sess.Peer != ""` | exit 1, no request sent |

Secondary defects found while reproducing:

* `peering/peer.go` namespaced `parent_session_id` but **not** `launched_from_session_id`, so a peer child's launch provenance arrived bare (`q72napnv` instead of `q72napnv@aquilo`) — Return to family could not resolve it, and a bare id can collide with a local session id.
* Cross-peer reparent was refused only *by accident* (via those blanket refusals); the local-child/peer-parent direction fell through to the store and answered `404 "child and parent sessions must exist on this daemon"`.
* `displayID` double-qualified peer sessions (`kid@box@box`) — the wire id is already namespaced.

## Fix

One rule, stated once per layer: **a family lives on one daemon; both ends must be owned by the same host, and that host executes the mutation.**

- `reparent_peer.go` (new): `rewritePeerReparentBody` translates the requested parent out of the viewer's namespace (`boss@box` → `boss`), passes `null` through (promote names nothing), preserves unknown keys (additive wire), handles chained peers (`p@mid@box` → `p@mid`), and returns `cross_peer` when the parent is local or on another peer.
- `serve_central.go`: the peer branch forwards `reparent` (method-checked, 4 KiB-limited) via `Peer.ForwardBody` — to the owning daemon, under that peer's own token, honoring peering directionality and token custody. Nothing is applied to the local projection. The local branch answers `cross_peer` when the parent resolves to a peer.
- `peering/peer.go` + `apiclient/client.go`: `ForwardBody`/`ForwardActionBody` (same shape as the existing `ForwardLaunch` body rewrite). `launched_from_session_id` namespaced with the parent-edge rule.
- CLI: peer veto replaced by owner-equality (`parent.Peer != sess.Peer`); peer refs go to the local daemon which forwards, so exactly one place knows the translation rule. `displayID` no longer double-qualifies.
- Web: fixed in the **shared** capability computation, not the menu item — `sidebarProjectForSession` now answers for peer rows using the same owner key `buildProjectFolders` buckets by (reference folder, or the local folder for a Local/devcontainer peer). `promotionAction` drops the `peer` veto and requires the Return-to-family target to be on the same host, which refuses peer↔peer and peer↔local edges in the UI too.
- Docs: `docs/task-family-ui.md` and `gmux promote|reparent --help` no longer claim these mutations are local-only.

**Cross-peer refusal is not weakened** — it is now explicit, in both directions, at the CLI, the hub's peer branch and the hub's local branch. Wire is additive: no field changes, one new error code (`cross_peer`). A new CLI against an old hub still gets a clear `local_only`; a new hub talks to an old spoke over the unchanged `/reparent` route.

## Evidence

Two disposable daemons (own ports/tokens/`XDG_*`/`HOME`/socket dirs), peered hub→spoke, stub-`claude` parent + shell child family on the spoke:

```
before:  HUB promote peer child → 400 local_only     SPOKE promote own child → 200 (control)
         CLI gmux promote kid@aquilo → "promote requires a session owned by this daemon"
         hub projection: launched_from=9n2ecndi      ← bare, unresolvable
after:   HUB promote / same-peer reparent → 200      (spoke's own edge changed)
         peer child + local parent → 400 cross_peer  local child + peer parent → 400 cross_peer
         CLI promote/reparent id@aquilo → exit 0     CLI cross-peer → exit 1 with the reason
         hub projection: launched_from=9n2ecndi@aquilo
```

## Verification

- Go `-race`: `cmd/gmuxd`, `internal/peering`, `internal/apiclient`, `internal/sessioncoord`, `internal/centralstore`, whole `cli/gmux` module — green. New: body-translation table (incl. chained peers, unknown-field preservation), forwarding against a real httptest spoke (owner path, translated parent, bearer auth, refusals never reaching the wire, GET → 405), local↔peer refusal, provenance namespacing, CLI peer promote/reparent + cross-peer refusal, `displayID`.
- Web: vitest 867 passed, `tsc --noEmit` clean, biome clean. `family.test.ts` swaps the old "never offers mutations on peer-projected sessions" case for the peer-placement matrix plus "never offers a family that would span two daemons".
- Playwright: full suite **113 passed** with the rebuilt bundle, including new `e2e/tests/peer-promote.spec.ts` — spins a second disposable spoke daemon, peers it live, then covers promote of a peer child **via the ⋮ menu** (asserted against the *spoke's own* API), Return to family back, **via the CLI**, and the negative cross-peer refusals. Non-vacuous: the UI test fails at the `.session-menu-promotion` assertion against the pre-fix bundle.

## Residual risks

- A promoted peer root needs a *reference* folder for its host's project (Settings → "From other hosts"); without one the verb is offered **blocked** with the existing "Needs a project" reason (correct per ADR 0026 §8, but a new place to meet that message).
- `isLocalPeer` is threaded from `main.tsx` only; a future caller of `sidebarProjectForSession` that omits it would treat a devcontainer row as peer-owned. `routing.ts` is unaffected.
- Chained hubs rely on each hop applying the same rule (unit-covered, not covered by a three-daemon test).
- Forwarded requests inherit `apiclient`'s 10 s action timeout: a slow spoke surfaces as `502 peer unavailable` though the mutation may have landed — same pre-existing property as every other forwarded action.