### PR TITLE
fix: rerun dead shell sessions instead of refusing the relaunch the UI offered

### DIFF
--- a/apps/gmux-web/src/main.tsx
+++ b/apps/gmux-web/src/main.tsx
@@ -16,7 +16,7 @@ import { MenuButton } from './menu-button'
 import { installCopySession } from './mock-data/export-session'
 import { ReplayView } from './replay-view'
 import { viewToPath } from './routing'
-import { lifecycleAction } from './session-actions'
+import { lifecycleAction, type RelaunchVerb } from './session-actions'
 import { SettingsModal } from './settings'
 import { Sidebar } from './sidebar'
 import {
@@ -182,7 +182,7 @@ class ErrorBoundary extends Component<
 function MainHeader({ session, onRestart, onResume, resuming }: {
   session: Session | null
   onRestart?: () => void
-  onResume?: (id: string) => void
+  onResume?: (id: string, verb?: RelaunchVerb) => void
   resuming?: boolean
 }) {
   const familyTriggerRef = useRef<HTMLButtonElement>(null)
@@ -328,7 +328,7 @@ function sessionHref(session: Session): string | undefined {
 function SessionMenu({ session, onRestart, onResume, resuming }: {
   session: Session
   onRestart?: () => void
-  onResume?: (id: string) => void
+  onResume?: (id: string, verb?: RelaunchVerb) => void
   resuming?: boolean
 }) {
   const [open, setOpen] = useState(false)
@@ -398,7 +398,7 @@ function SessionMenu({ session, onRestart, onResume, resuming }: {
   // button in ReplayView's action bar.
   const action = lifecycleAction(session, resuming)
   const actionHandler = action?.id === 'restart' ? onRestart
-    : action?.id === 'resume' && onResume ? () => onResume(session.id)
+    : action?.id === 'relaunch' && onResume ? () => onResume(session.id, action.verb)
     : undefined
   const showStale = action?.id === 'restart' && !!staleKind
 
@@ -888,13 +888,16 @@ function App() {
     dismissSession(session.id)
   }, [])
 
-  const handleResume = useCallback((id: string) => {
+  // The verb comes from the daemon's verdict (session.relaunch) so a failed
+  // rerun of a shell doesn't toast "Resume failed" for an action the UI
+  // labelled "Rerun".
+  const handleResume = useCallback((id: string, verb: RelaunchVerb = 'resume') => {
     setResumingId(id)
     // resumeSession never rejects (postAction converts failures to false
     // and surfaces the toast itself); branch on the boolean to clear the
     // "resuming…" spinner immediately on rejection instead of letting it
     // linger until the 10s timeout.
-    void resumeSession(id).then(ok => {
+    void resumeSession(id, verb).then(ok => {
       if (!ok) setResumingId(prev => prev === id ? null : prev)
     })
   }, [])

--- a/apps/gmux-web/src/mock-data/sessions/demo-activity.ts
+++ b/apps/gmux-web/src/mock-data/sessions/demo-activity.ts
@@ -71,7 +71,10 @@ export const DEMO_ACTIVITY: MockSession[] = [
   }),
   demo({
     id: '1eb5auvb', title: 'refactor launcher',
-    alive: false, resumable: true, pid: null, exit_code: 0,
+    // A dead claude session with a recorded conversation: the daemon would
+    // answer "resume" here, so the mock carries the same verdict the wire
+    // does (the UI never re-derives the verb from the adapter name).
+    alive: false, resumable: true, relaunch: 'resume', pid: null, exit_code: 0,
     created_at: ago(60 * 31), started_at: ago(60 * 31),
     exited_at: ago(60 * 30), last_output_at: ago(60 * 30),
   }),

--- a/apps/gmux-web/src/reconcile.ts
+++ b/apps/gmux-web/src/reconcile.ts
@@ -43,7 +43,7 @@ const SESSION_SCALAR_KEYS = [
   'id', 'peer', 'created_at', 'cwd', 'workspace_root', 'adapter', 'drive_mode',
   'parent_session_id', 'launched_from_session_id', 'semantic_agent', 'alive',
   'pid', 'exit_code', 'started_at', 'exited_at', 'title', 'subtitle', 'unread',
-  'unread_token', 'resumable', 'last_output_at', 'socket_path',
+  'unread_token', 'resumable', 'relaunch', 'last_output_at', 'socket_path',
   'terminal_cols', 'terminal_rows', 'slug', 'conversation_file',
   'runner_version', 'binary_hash', 'project_slug', 'project_index',
 ] as const satisfies readonly (keyof Session)[]

--- a/apps/gmux-web/src/replay-view.tsx
+++ b/apps/gmux-web/src/replay-view.tsx
@@ -8,7 +8,7 @@ import { loadWebglRenderer } from './webgl-renderer'
 import type { Session } from './types'
 import { fetchScrollback, type ScrollbackResult } from './replay-fetch'
 import { JumpToBottom } from './jump-to-bottom'
-import { lifecycleAction } from './session-actions'
+import { lifecycleAction, type RelaunchVerb } from './session-actions'
 import { MenuButton } from './menu-button'
 import { isTouchDevice } from './touch'
 
@@ -32,8 +32,8 @@ type ReplayState =
  * see main.tsx for the routing.
  *
  * The action bar at the bottom carries the *primary* lifecycle action
- * for a dead session: Resume / Rerun (see lifecycleAction for the
- * agent-vs-rerun split). The same action is deliberately mirrored in
+ * for a dead session: Resume / Rerun (the owning daemon picks the verb;
+ * see lifecycleAction). The same action is deliberately mirrored in
  * the header SessionMenu — that's where Restart lives for alive
  * sessions, so muscle memory finds it there too. Promoting it out of
  * an implicit sidebar click means clicking a dead session navigates to
@@ -57,7 +57,7 @@ export function ReplayView({
 }: {
   session: Session
   terminalOptions: ITerminalOptions
-  onResume?: (id: string) => void
+  onResume?: (id: string, verb?: RelaunchVerb) => void
   resuming?: boolean
   onMenu?: () => void
 }) {
@@ -156,7 +156,7 @@ export function ReplayView({
   }, [session.id])
 
   const action = lifecycleAction(session, !!resuming)
-  const resumeShown = action?.id === 'resume' && !!onResume
+  const resumeShown = action?.id === 'relaunch' && !!onResume
   const menuShown = !!onMenu && isTouchDevice()
 
   return (
@@ -193,7 +193,7 @@ export function ReplayView({
               type="button"
               class="btn btn-primary"
               disabled={action!.disabled}
-              onClick={() => onResume!(session.id)}
+              onClick={() => onResume!(session.id, action!.verb)}
             >
               {action!.shortLabel}
             </button>

--- a/apps/gmux-web/src/session-actions.test.ts
+++ b/apps/gmux-web/src/session-actions.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect } from 'vitest'
-import { lifecycleAction } from './session-actions'
+import { lifecycleAction, relaunchDirectoryNotice, relaunchVerb } from './session-actions'
 
-const sess = (over: Partial<{ alive: boolean; resumable: boolean; adapter: string }>) => ({
+const sess = (over: Partial<{
+  alive: boolean; resumable: boolean; adapter: string; relaunch: string
+}>) => ({
   alive: false,
   resumable: false,
   adapter: 'shell',
@@ -19,38 +21,81 @@ describe('lifecycleAction', () => {
     expect(lifecycleAction(sess({ alive: true, resumable: true }))!.id).toBe('restart')
   })
 
-  it('dead resumable agent offers Resume', () => {
-    for (const adapter of ['claude', 'codex', 'pi']) {
-      expect(lifecycleAction(sess({ resumable: true, adapter }))).toEqual({
-        id: 'resume', label: 'Resume session', shortLabel: 'Resume', disabled: false,
-      })
-    }
+  it("dead session offers the daemon's verb, not an adapter guess", () => {
+    // The daemon owns the policy: a shell that the daemon says it will
+    // resume says Resume, and an agent it will only rerun says Rerun.
+    expect(lifecycleAction(sess({ resumable: true, adapter: 'shell', relaunch: 'resume' })))
+      .toEqual({ id: 'relaunch', verb: 'resume', label: 'Resume session', shortLabel: 'Resume', disabled: false })
+    expect(lifecycleAction(sess({ resumable: true, adapter: 'claude', relaunch: 'rerun' })))
+      .toEqual({ id: 'relaunch', verb: 'rerun', label: 'Rerun session', shortLabel: 'Rerun', disabled: false })
   })
 
-  it('dead resumable non-agent offers Rerun', () => {
-    expect(lifecycleAction(sess({ resumable: true, adapter: 'shell' }))).toEqual({
-      id: 'resume', label: 'Rerun session', shortLabel: 'Rerun', disabled: false,
-    })
-    // Unknown adapter kinds default to the safe Rerun label.
-    expect(lifecycleAction(sess({ resumable: true, adapter: 'future-agent' }))!.shortLabel)
-      .toBe('Rerun')
+  it('dead shell with a rerun verdict offers Rerun (the reported bug)', () => {
+    expect(lifecycleAction(sess({ resumable: true, adapter: 'shell', relaunch: 'rerun' })))
+      .toEqual({ id: 'relaunch', verb: 'rerun', label: 'Rerun session', shortLabel: 'Rerun', disabled: false })
   })
 
-  it('dead non-resumable session offers nothing', () => {
+  it('dead session with no relaunch verdict offers nothing, even if resumable is stale', () => {
+    // resumable and relaunch are emitted together by any daemon that knows
+    // the field, so relaunch-absent + resumable-true only happens on the
+    // legacy peer path below.
     expect(lifecycleAction(sess({}))).toBeNull()
+    expect(lifecycleAction(sess({ resumable: false, relaunch: undefined }))).toBeNull()
   })
 
-  it('resuming disables the action and shows busy label per kind', () => {
-    expect(lifecycleAction(sess({ resumable: true, adapter: 'claude' }), true)).toEqual({
-      id: 'resume', label: 'Resuming…', shortLabel: 'Resuming…', disabled: true,
+  it('falls back to the adapter guess for pre-relaunch daemons', () => {
+    for (const adapter of ['claude', 'codex', 'pi']) {
+      expect(lifecycleAction(sess({ resumable: true, adapter }))!.shortLabel).toBe('Resume')
+    }
+    expect(lifecycleAction(sess({ resumable: true, adapter: 'shell' }))!.shortLabel).toBe('Rerun')
+    expect(lifecycleAction(sess({ resumable: true, adapter: 'future-agent' }))!.shortLabel).toBe('Rerun')
+  })
+
+  it('pending disables the action and shows busy label per verb', () => {
+    expect(lifecycleAction(sess({ resumable: true, relaunch: 'resume' }), true)).toEqual({
+      id: 'relaunch', verb: 'resume', label: 'Resuming…', shortLabel: 'Resuming…', disabled: true,
     })
-    expect(lifecycleAction(sess({ resumable: true, adapter: 'shell' }), true)).toEqual({
-      id: 'resume', label: 'Rerunning…', shortLabel: 'Rerunning…', disabled: true,
+    expect(lifecycleAction(sess({ resumable: true, relaunch: 'rerun' }), true)).toEqual({
+      id: 'relaunch', verb: 'rerun', label: 'Rerunning…', shortLabel: 'Rerunning…', disabled: true,
     })
   })
 
-  it('resuming does not affect an alive session', () => {
+  it('pending does not affect an alive session', () => {
     expect(lifecycleAction(sess({ alive: true }), true)!.disabled).toBe(false)
   })
 })
 
+describe('relaunchVerb', () => {
+  it('prefers the wire verdict over both resumable and the adapter name', () => {
+    expect(relaunchVerb({ relaunch: 'rerun', resumable: false, adapter: 'claude' })).toBe('rerun')
+    expect(relaunchVerb({ relaunch: 'resume', resumable: false, adapter: 'shell' })).toBe('resume')
+  })
+
+  it('is null when the daemon offers no relaunch', () => {
+    expect(relaunchVerb({ resumable: false, adapter: 'shell' })).toBeNull()
+  })
+})
+
+describe('relaunchDirectoryNotice', () => {
+  it('is silent when the daemon relaunched where the session lived', () => {
+    expect(relaunchDirectoryNotice('rerun', {})).toBeNull()
+    expect(relaunchDirectoryNotice('rerun', { pid: 42 })).toBeNull()
+    expect(relaunchDirectoryNotice('resume', undefined)).toBeNull()
+  })
+
+  it('names the substituted directory, because a rerun runs a recorded command there', () => {
+    expect(relaunchDirectoryNotice('rerun', {
+      original_cwd: '/gone/project', fallback_cwd: '/home/user',
+    })).toBe('Rerunning in /home/user instead (/gone/project no longer exists)')
+    expect(relaunchDirectoryNotice('resume', { fallback_cwd: '/home/user' }))
+      .toBe('Resumed in /home/user instead')
+  })
+})
+
+describe('unknown relaunch verbs (forward compatibility)', () => {
+  it('a verb this client does not know degrades to the resumable fallback', () => {
+    // A newer daemon may grow a third verb; the row must still render.
+    expect(relaunchVerb({ relaunch: 'teleport', resumable: true, adapter: 'shell' })).toBe('rerun')
+    expect(relaunchVerb({ relaunch: 'teleport', resumable: false, adapter: 'shell' })).toBeNull()
+  })
+})

--- a/apps/gmux-web/src/session-actions.ts
+++ b/apps/gmux-web/src/session-actions.ts
@@ -6,17 +6,27 @@ import type { Session } from './types'
  * (For dead sessions the same action is deliberately mirrored as the
  * primary button in ReplayView's action bar.)
  *
- * Adapter kinds whose runners have an explicit resume protocol
- * (--resume <id> or equivalent). Anything not in this set falls back to
- * "Rerun" because there's no captured agent state to pick up from;
- * re-launching just runs the original command again. Listed explicitly
- * so adding a new agent adapter is a deliberate one-line change here,
- * and unknown kinds default to the safe "Rerun" label.
+ * The verb is the *daemon's* verdict, carried on the wire as
+ * `session.relaunch` ('resume' | 'rerun'), because the daemon is the only
+ * party that knows whether a recorded conversation can actually be picked
+ * up (see services/gmuxd/internal/relaunch). The UI used to guess from the
+ * adapter name and from `resumable` alone, which offered "Rerun" on dead
+ * shell sessions that the daemon then refused with "session is not
+ * resumable" — and, via Restart, killed them on the way.
+ *
+ * Fallback for pre-`relaunch` daemons (a peer-owned row from an older
+ * host): fall back to `resumable` and the adapter-name guess below. It is
+ * a guess, and it is confined to this one legacy path.
  */
-export const RESUMABLE_AGENT_KINDS = new Set(['claude', 'codex', 'pi'])
+const RESUMABLE_AGENT_KINDS = new Set(['claude', 'codex', 'pi'])
+
+export type RelaunchVerb = 'resume' | 'rerun'
 
 export type LifecycleAction = {
-  id: 'restart' | 'resume'
+  id: 'restart' | 'relaunch'
+  /** Which relaunch the daemon will perform; undefined for Restart. Used
+   * for labels and for naming the action in failure toasts. */
+  verb?: RelaunchVerb
   /** Menu-item label ("Resume session") — needs the noun, since the menu
    * also holds non-lifecycle rows. */
   label: string
@@ -26,29 +36,65 @@ export type LifecycleAction = {
   disabled: boolean
 }
 
+/** The relaunch verb the owning daemon will honor, or null when it will
+ * honor none.
+ *
+ * `relaunch` is checked first *and* alone: the daemon emits it and
+ * `resumable` from the same verdict (wire/convert.go sets both from one
+ * `kind`, and clears both together for a dismissed row), so a present verb
+ * already implies `resumable`. `resumable` is only consulted when the verb
+ * is absent, which means a peer on a daemon older than the field. */
+export function relaunchVerb(
+  session: Pick<Session, 'relaunch' | 'resumable' | 'adapter'>,
+): RelaunchVerb | null {
+  if (session.relaunch === 'resume' || session.relaunch === 'rerun') return session.relaunch
+  if (!session.resumable) return null
+  return RESUMABLE_AGENT_KINDS.has(session.adapter) ? 'resume' : 'rerun'
+}
+
+/**
+ * The user-visible notice for a relaunch that did not happen where the
+ * session used to live. The daemon reports `original_cwd`/`fallback_cwd`
+ * only when it substituted a directory (its recorded one is gone); a rerun
+ * runs an arbitrary recorded command, so running it somewhere else is a fact
+ * the user has to be told rather than a detail to drop.
+ *
+ * Returns null when nothing was substituted.
+ */
+export function relaunchDirectoryNotice(
+  verb: RelaunchVerb,
+  data: Record<string, unknown> | null | undefined,
+): string | null {
+  const fallback = data?.fallback_cwd
+  const original = data?.original_cwd
+  if (typeof fallback !== 'string' || !fallback) return null
+  const word = verb === 'resume' ? 'Resumed' : 'Rerunning'
+  const from = typeof original === 'string' && original ? ` (${original} no longer exists)` : ''
+  return `${word} in ${fallback} instead${from}`
+}
+
 /**
  * The one lifecycle action a session offers in its current state, or
- * null when it offers none (dead and not resumable).
+ * null when it offers none (dead and not relaunchable).
  *
  * - alive → Restart
- * - dead + resumable agent (claude/codex/pi) → Resume
- * - dead + resumable non-agent (shell, one-off command) → Rerun
- * - dead + not resumable → none
+ * - dead + relaunch 'resume' → Resume
+ * - dead + relaunch 'rerun' → Rerun
+ * - dead + no relaunch verdict → none
  */
 export function lifecycleAction(
-  session: Pick<Session, 'alive' | 'resumable' | 'adapter'>,
-  resuming = false,
+  session: Pick<Session, 'alive' | 'relaunch' | 'resumable' | 'adapter'>,
+  pending = false,
 ): LifecycleAction | null {
   if (session.alive) {
     return { id: 'restart', label: 'Restart session', shortLabel: 'Restart', disabled: false }
   }
-  if (!session.resumable) return null
-  const isAgent = RESUMABLE_AGENT_KINDS.has(session.adapter)
-  if (resuming) {
-    const busy = isAgent ? 'Resuming…' : 'Rerunning…'
-    return { id: 'resume', label: busy, shortLabel: busy, disabled: true }
+  const verb = relaunchVerb(session)
+  if (!verb) return null
+  if (pending) {
+    const busy = verb === 'resume' ? 'Resuming…' : 'Rerunning…'
+    return { id: 'relaunch', verb, label: busy, shortLabel: busy, disabled: true }
   }
-  const verb = isAgent ? 'Resume' : 'Rerun'
-  return { id: 'resume', label: `${verb} session`, shortLabel: verb, disabled: false }
+  const word = verb === 'resume' ? 'Resume' : 'Rerun'
+  return { id: 'relaunch', verb, label: `${word} session`, shortLabel: word, disabled: false }
 }
-

--- a/apps/gmux-web/src/store.test.ts
+++ b/apps/gmux-web/src/store.test.ts
@@ -83,6 +83,44 @@ describe('postAction surfaces backend failures as error toasts', () => {
     expect(toasts.value[0].message).toBe('Kill failed: Internal Server Error')
   })
 
+  it('labels a failed rerun with the verb the UI showed', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false, status: 400, statusText: 'Bad Request',
+      text: () => Promise.resolve(JSON.stringify({
+        ok: false, error: { code: 'not_resumable', message: 'no recorded command to rerun' },
+      })),
+    }))
+    await resumeSession('s1', 'rerun')
+    expect(toasts.value[0].message).toBe('Rerun failed: no recorded command to rerun')
+  })
+
+  it('tells the user when a rerun was relocated to the fallback directory', async () => {
+    // The daemon substitutes a directory when the recorded one is gone; a
+    // rerun executes an arbitrary recorded command, so this cannot be silent.
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true, status: 200, statusText: 'OK',
+      json: () => Promise.resolve({
+        ok: true,
+        data: { pid: 7, session_id: 's1', original_cwd: '/gone', fallback_cwd: '/home/user' },
+      }),
+    }))
+    await resumeSession('s1', 'rerun')
+    expect(toasts.value).toHaveLength(1)
+    expect(toasts.value[0]).toMatchObject({
+      kind: 'info',
+      message: 'Rerunning in /home/user instead (/gone no longer exists)',
+    })
+  })
+
+  it('stays quiet when the relaunch happened where the session lived', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true, status: 200, statusText: 'OK',
+      json: () => Promise.resolve({ ok: true, data: { pid: 7, session_id: 's1' } }),
+    }))
+    await resumeSession('s1', 'rerun')
+    expect(toasts.value).toHaveLength(0)
+  })
+
   it('does NOT toast a network reject (connectivity is owned by the reconnecting pill)', async () => {
     vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')))
     await resumeSession('s1')

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -30,10 +30,11 @@ import {
 import { referencePresence, removeHostReferenceItems, removeReferenceItems, type UnresolvedHost, unresolvedReferences } from './references'
 import type { View } from './routing'
 import { resolveViewFromPath, viewToPath } from './routing'
+import { relaunchDirectoryNotice } from './session-actions'
 import type { ResolvedTerminalOptions } from './settings-schema'
 import { createSSESupervisor, type SSESource } from './sse-supervisor'
 import { formatFilterParam, parseFilterParam, type Selector, sessionMatchesFilter } from './tab-filter'
-import { pushError } from './toasts'
+import { pushError, pushToast } from './toasts'
 import type { DiscoveredProject, Folder, LauncherDef, PeerInfo, PeerProject, ProjectItem, Session } from './types'
 import { navigateWithReload } from './version-watch'
 
@@ -2005,8 +2006,12 @@ async function postAction(endpoint: string, label = 'Action', opts: {
    * rejection is the outcome the caller asked for anyway. */
   alsoOk?: number
   body?: unknown
+  /** Called with the parsed `data` object of a successful response. Used
+   * by relaunch, where the daemon reports a directory substitution the
+   * user has to know about. */
+  onData?: (data: Record<string, unknown>) => void
 } = {}): Promise<boolean> {
-  const { quiet = false, alsoOk, body } = opts
+  const { quiet = false, alsoOk, body, onData } = opts
   try {
     const resp = await fetch(endpoint, {
       method: 'POST',
@@ -2021,6 +2026,12 @@ async function postAction(endpoint: string, label = 'Action', opts: {
       // take the boolean and report once.
       if (!quiet) pushError(`${label} failed: ${await errorMessageFromResponse(resp)}`)
       return false
+    }
+    if (onData) {
+      try {
+        const parsed = await resp.json() as { data?: Record<string, unknown> }
+        onData(parsed?.data ?? {})
+      } catch { /* a body-less success is still a success */ }
     }
     return true
   } catch {
@@ -2062,8 +2073,23 @@ export function dismissSession(sessionId: string): Promise<void> {
   )
 }
 
-export function resumeSession(sessionId: string): Promise<boolean> {
-  return postAction(`/v1/sessions/${sessionId}/resume`, 'Resume')
+/** Relaunch a dead session. `verb` names the action in the failure toast:
+ * the daemon exposes one endpoint and decides for itself whether that means
+ * resuming a conversation or rerunning the recorded command
+ * (services/gmuxd/internal/relaunch). The caller passes the verb the UI
+ * showed the user (session.relaunch) so the two agree.
+ *
+ * A success can still carry a surprise: when the recorded directory is gone
+ * the daemon relaunches in a fallback directory and says so. That matters
+ * most for `rerun`, which runs an arbitrary recorded command, so the
+ * substitution is toasted rather than swallowed. */
+export function resumeSession(sessionId: string, verb: 'resume' | 'rerun' = 'resume'): Promise<boolean> {
+  return postAction(`/v1/sessions/${sessionId}/resume`, verb === 'rerun' ? 'Rerun' : 'Resume', {
+    onData: data => {
+      const notice = relaunchDirectoryNotice(verb, data)
+      if (notice) pushToast('info', notice)
+    },
+  })
 }
 
 export function restartSession(sessionId: string): Promise<boolean> {

--- a/apps/gmux-web/src/types.ts
+++ b/apps/gmux-web/src/types.ts
@@ -51,6 +51,17 @@ export interface Session {
   unread_token?: string
   resumable?: boolean
   /**
+   * Which relaunch verb the *owning* daemon will honor for this dead
+   * session: 'resume' (continue the recorded agent conversation) or
+   * 'rerun' (launch the recorded command again). Absent means either
+   * "the daemon will refuse" or "this row came from a peer running a
+   * daemon that predates the field", as does a verb this client does not
+   * know (the verb set is daemon-owned and may grow); `lifecycleAction`
+   * degrades to the `resumable` flag there. Never derive the verb from the adapter name:
+   * the daemon owns the policy (see internal/relaunch).
+   */
+  relaunch?: string
+  /**
    * RFC3339 timestamp of the session's most recent noteworthy state
    * transition (exited / unread on / working on / error on). Set by
    * the owning daemon. Drives the home dashboard's "Recent" section

--- a/apps/website/src/content/docs/architecture.md
+++ b/apps/website/src/content/docs/architecture.md
@@ -97,7 +97,7 @@ Served by `gmuxd` on a Unix socket (local IPC) and a TCP listener (default `127.
 | `POST /v1/launch` | Launch a new session |
 | `POST /v1/sessions/{id}/kill` | Kill a session |
 | `POST /v1/sessions/{id}/dismiss` | Stop and dismiss the session and every session it launched |
-| `POST /v1/sessions/{id}/resume` | Resume a resumable session |
+| `POST /v1/sessions/{id}/resume` | Relaunch a dead session: resumes its conversation or reruns its command, whichever the session's `relaunch` field advertises. Peer-owned sessions are forwarded to the owning daemon |
 | `GET /v1/sessions/{id}/scrollback` | Plain-text terminal tail (works for dead sessions) |
 | `POST /v1/sessions/{id}/{input,read,wait,...}` | Other session actions (input injection, mark read, wait-for-idle, …) |
 | `POST /v1/sessions/{id}/prompt` | Semantic agent prompt: mode `prompt`/`follow_up`/`steer`, transparent resume, admission + fused wait (ADR 0027; local sessions only) |

--- a/apps/website/src/content/docs/develop/session-schema.md
+++ b/apps/website/src/content/docs/develop/session-schema.md
@@ -72,6 +72,7 @@ gmuxd exposes aggregated state to the browser via `GET /v1/events?session_stream
 | `unread_token` | ✓ | ✓ | ✓ | ✓ read acknowledgement identity |
 | **Resume & conversations** |
 | `resumable` | — | ✓ derived | ✓ | ✓ sidebar |
+| `relaunch` | — | ✓ derived | ✓ | ✓ Resume/Rerun affordance |
 | `conversation_file` | ✓ (hook) | ✓ | ✓ | ✓ duplicate-conversation warning |
 | **Routing** |
 | `slug` | ✓ opt | ✓ auto-derived | ✓ | ✓ URL routing |
@@ -131,10 +132,19 @@ Internal fields are inputs to derived fields. The API only exposes the derived o
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `resumable` | boolean | Derived, never set manually: the session is dead, has evidence it actually ran, its adapter has not declared the conversation gone, and a resume command can be derived. |
+| `resumable` | boolean | Derived, never set manually: the session is dead, has evidence it actually ran, its adapter has not declared the conversation gone, and a relaunch command can be derived. Equivalent to `relaunch` being present. |
+| `relaunch` | `"resume"` \| `"rerun"`? | Which relaunch the **owning** daemon will perform for `POST /v1/sessions/{id}/resume`: `resume` continues the recorded conversation, `rerun` launches the recorded command again in the recorded directory (or, when that directory is gone, in the fallback directory the response reports as `fallback_cwd`). Absent means the daemon will refuse (or, for a peer row, that the owner runs a daemon older than the field — clients then fall back to `resumable`). Clients must not re-derive the verb from the adapter name: only the owner can resolve its adapters' conversations. |
 | `conversation_file` | string? | The agent's opaque conversation ref (for file-backed adapters, the transcript path), reported authoritatively by the agent hook (ADR 0011). Drives resume-command derivation; duplicate values across live sessions trigger a "conversation open in multiple tabs" warning. |
 
-The stored launch `command` is preserved across exit. Resuming derives a tool-specific resume command from `(adapter, conversation_ref)` at spawn time. Dead conversations can be resolved via `GET /v1/conversations/{adapter}/{slug}`.
+The stored launch `command` is preserved across exit. One policy decides what a
+relaunch runs, and both the wire projection and the runner spawner apply it
+(`services/gmuxd/internal/relaunch`): with a `conversation_file`, a
+tool-specific resume command is derived from `(adapter, conversation_ref)` at
+spawn time, and an unresolvable conversation makes the session non-relaunchable
+rather than silently starting a fresh one; without one — every shell and editor
+session, plus agents that died before their hook bound a conversation — the
+recorded launch command is rerun. Dead conversations can be resolved via `GET
+/v1/conversations/{adapter}/{slug}`.
 
 ### Routing
 

--- a/apps/website/src/content/docs/orchestrating-agents.md
+++ b/apps/website/src/content/docs/orchestrating-agents.md
@@ -40,8 +40,11 @@ gmux agent logs a1b2c3d4                             # re-read the latest exchan
 
 An agent session names a **conversation**, not a process: prompting an
 inactive conversation transparently resumes it, and reading one never starts
-anything. Semantic surfaces report the agent as **active** or **inactive** —
-your script never branches on whether a process happens to be resident.
+anything. (The exception: a session whose agent exited before it ever bound a
+conversation has nothing to resume, so prompting it reruns the recorded
+command and delivers the prompt into a fresh conversation.) Semantic surfaces
+report the agent as **active** or **inactive** — your script never branches on
+whether a process happens to be resident.
 
 `--new` launches a new pi session (from this shell's env and cwd, local daemon
 only) and sends the prompt as its first work. A synchronous run prints the
@@ -148,8 +151,9 @@ everything that entered the loop.
 ordinary work; delivered into **running** work it merges into that activity,
 which settles once for everybody. Flags go before the id; everything after the
 id is the prompt, verbatim. A plain prompt transparently resumes an inactive
-conversation to deliver it; `--steer` and `cancel` fail when no activity is in
-progress and never resume.
+conversation to deliver it — or, when no conversation was ever bound, reruns
+the recorded command and delivers into a fresh one; `--steer` and `cancel`
+fail when no activity is in progress and never resume.
 
 ## Reading a conversation
 

--- a/apps/website/src/content/docs/reference/cli.md
+++ b/apps/website/src/content/docs/reference/cli.md
@@ -474,7 +474,10 @@ each verb also answers `--help`.
 conversation that can always be continued; whether a process currently hosts
 it is gmux's problem. Semantic surfaces report the agent as **active** (work
 in progress) or **inactive** (settled) — never "alive" or "dead". Prompting an
-inactive conversation transparently resumes it; reading one never does.
+inactive conversation transparently resumes it; reading one never does. A
+session whose agent exited before binding a conversation has none to resume:
+prompting it reruns the recorded command, and the prompt lands in a fresh
+conversation.
 
 **Vocabulary.** A **visible exchange** is one user message and everything the
 agent did up to the next user message. An **iteration** is one completed
@@ -540,7 +543,8 @@ git diff | gmux agent prompt a3f20187                        # prompt from stdin
 
 - **no flag** — start fresh work. Requires an inactive agent; an inactive
   conversation with no resident process is resumed transparently to deliver
-  the prompt.
+  the prompt (or, when no conversation was ever bound, the recorded command is
+  rerun and the prompt lands in a fresh conversation).
 - `--follow-up` — submit after the current model response. Delivered to an
   **inactive** agent it starts ordinary work (like a plain prompt); delivered
   into **running** work it **merges into that activity** (pi drains its queue

--- a/apps/website/src/content/docs/using-the-ui.md
+++ b/apps/website/src/content/docs/using-the-ui.md
@@ -23,7 +23,7 @@ Projects match sessions by filesystem path or git remote URL. Projects on other 
 
 Click a session to attach a full interactive terminal. **Cmd/Ctrl+F** opens find-in-terminal; the full default keymap and how to override it is in the [settings reference](/reference/settings/#default-keymap).
 
-The **⋮** menu holds the lifecycle action — **Restart** for a live session, **Resume** or **Rerun** for a dead one. Dead sessions replay their terminal history read-only: resuming continues an agent conversation where it left off, rerunning starts the command fresh in the same directory.
+The **⋮** menu holds the lifecycle action — **Restart** for a live session, **Resume** or **Rerun** for a dead one. Dead sessions replay their terminal history read-only: resuming continues an agent conversation where it left off, rerunning starts the command fresh in the directory the session recorded — and if that directory no longer exists, gmux relaunches in a fallback directory and tells you so in a notification. Which of the two you get is decided by the machine that owns the session, so the button only ever offers what that machine will actually do — shells and other sessions with no recorded conversation say **Rerun**, and a session whose conversation is gone offers neither.
 
 To get rid of a session, hover it in the sidebar and click **×**. This stops the session **and every session it launched**, then removes them from the UI — but it isn't data deletion: agent conversations stay in their own tools, and terminal history is kept until gmux eventually cleans it up.
 

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -25,6 +25,35 @@ export async function apiGet<T = unknown>(urlPath: string): Promise<{ status: nu
 }
 
 /**
+ * Bearer-auth `fetch` with a method + optional JSON body, against the test
+ * gmuxd (or, with `opts.port`/`opts.token`, another daemon a spec started —
+ * peer specs need to drive both ends).
+ */
+export async function apiFetch<T = unknown>(
+  method: string,
+  urlPath: string,
+  opts: { body?: unknown; port?: string | number; token?: string } = {},
+): Promise<{ status: number; body: T }> {
+  const port = String(opts.port ?? process.env.GMUXD_TEST_PORT ?? '')
+  const token = opts.token ?? process.env.GMUX_TEST_TOKEN
+  if (!port) throw new Error('GMUXD_TEST_PORT not set; global-setup did not run')
+  if (!token) throw new Error('GMUX_TEST_TOKEN not set; global-setup did not run')
+  const resp = await fetch(`http://127.0.0.1:${port}${urlPath}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      ...(opts.body === undefined ? {} : { 'Content-Type': 'application/json' }),
+    },
+    body: opts.body === undefined ? undefined : JSON.stringify(opts.body),
+  })
+  let body: T = undefined as unknown as T
+  try {
+    body = await resp.json() as T
+  } catch { /* non-JSON, leave body undefined */ }
+  return { status: resp.status, body }
+}
+
+/**
  * Poll `fn` until it returns a defined, truthy value (or until
  * `timeoutMs` elapses). Returns the resolved value or throws.
  *

--- a/e2e/tests/relaunch-affordance.spec.ts
+++ b/e2e/tests/relaunch-affordance.spec.ts
@@ -1,0 +1,237 @@
+import { test, expect, type Page } from '@playwright/test'
+import { spawn, type ChildProcess } from 'child_process'
+import * as fs from 'fs'
+import * as net from 'net'
+import * as os from 'os'
+import * as path from 'path'
+import { apiFetch, gotoSession, openApp, pollUntil } from '../helpers'
+
+/**
+ * The affordance must be truthful: if the UI offers a relaunch, the daemon
+ * must perform it. This is the regression test for the reported bug, where a
+ * dead shell session was advertised as resumable and the click came back
+ * "sessioncoord: resume spawn for …: runner spawn: session … is not
+ * resumable" — because presentation derived resumability from "dead + has a
+ * command" while the spawner only ever resolved an agent *resume* command.
+ *
+ * Both halves of the bug are covered, because the peer path is the one the
+ * user actually hit:
+ *
+ *  1. a dead shell owned by this daemon, and
+ *  2. a dead shell owned by a peer daemon this spec starts, where the click
+ *     must be forwarded to the owner and executed there.
+ *
+ * The assertion in both cases is the biconditional: the button is shown, it
+ * says "Rerun" (not "Resume" — there is no conversation to resume), and
+ * clicking it brings the session back alive on the daemon that owns it.
+ */
+
+const ROOT = path.resolve(__dirname, '..', '..')
+const GMUX = path.join(ROOT, 'bin', 'gmux')
+const GMUXD = path.join(ROOT, 'bin', 'gmuxd')
+const STATE_FILE = path.join(os.tmpdir(), 'gmux-e2e-state.json')
+
+type WireSession = {
+  id: string
+  alive: boolean
+  cwd?: string
+  peer?: string
+  adapter?: string
+  resumable?: boolean
+  relaunch?: string
+}
+
+async function sessions(port?: string | number, token?: string): Promise<WireSession[]> {
+  const { body } = await apiFetch<{ data: WireSession[] }>('GET', '/v1/sessions', { port, token })
+  return body?.data ?? []
+}
+
+async function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer()
+    srv.listen(0, '127.0.0.1', () => {
+      const port = (srv.address() as net.AddressInfo).port
+      srv.close(() => resolve(port))
+    })
+    srv.on('error', reject)
+  })
+}
+
+/** Fail loudly, with the daemon's own words, the moment a relaunch is
+ * refused — rather than letting the liveness poll time out anonymously. */
+async function expectNoFailureToast(page: Page): Promise<void> {
+  const toast = page.locator('.toast-error .toast-message', { hasText: 'failed' }).first()
+  if (await toast.count() > 0) {
+    throw new Error(`relaunch refused: ${await toast.textContent()}`)
+  }
+}
+
+let env: Record<string, string>
+let workspace = ''
+let localDeadId = ''
+const spawned: ChildProcess[] = []
+
+// The peer daemon: its own state/config/socket dirs and HOME, exactly like
+// the harness's isolation contract (e2e/AGENTS.md) — a second daemon that
+// leaked into the operator's environment would be no better than the first.
+let peerProc: ChildProcess | undefined
+let peerPort = 0
+let peerToken = ''
+let peerName = ''
+let peerWorkspace = ''
+let peerDeadId = ''
+let peerTmp = ''
+
+test.describe.configure({ mode: 'serial' })
+
+test.beforeAll(async () => {
+  test.setTimeout(90_000)
+  const state = JSON.parse(fs.readFileSync(STATE_FILE, 'utf-8')) as { tmpDir: string }
+  workspace = process.env.GMUX_TEST_WORKSPACE!
+  env = {
+    PATH: process.env.PATH || '',
+    HOME: process.env.GMUX_TEST_HOME!,
+    TERM: 'xterm-256color',
+    GMUX_SOCKET_DIR: path.join(state.tmpDir, 'sockets'),
+    GMUXD_TOKEN: process.env.GMUX_TEST_TOKEN || '',
+    XDG_CONFIG_HOME: path.join(state.tmpDir, 'config'),
+    XDG_STATE_HOME: path.join(state.tmpDir, 'state'),
+  }
+
+  // ── a dead shell owned by the harness daemon ──
+  const marker = 'local-relaunch-probe'
+  // Sleeps briefly so both the initial exit and the relaunch are observable:
+  // a command that exits instantly would relaunch and die between polls.
+  const proc = spawn(GMUX, ['--', 'bash', '-c', `echo ${marker}; sleep 5`], {
+    env, cwd: workspace, stdio: ['ignore', 'pipe', 'pipe'], detached: true,
+  })
+  spawned.push(proc)
+  const dead = await pollUntil(async () =>
+    (await sessions()).find(s => !s.alive && s.cwd === workspace && s.adapter === 'shell'),
+  { timeoutMs: 20_000, intervalMs: 200, description: 'local shell session exited' })
+  localDeadId = dead.id
+
+  // ── a dead shell owned by a peer daemon ──
+  peerTmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gmux-e2e-peer-'))
+  peerWorkspace = path.join(peerTmp, 'workspace')
+  const peerHome = path.join(peerTmp, 'home')
+  for (const d of ['sockets', 'config/gmux', 'state', 'home', 'workspace']) {
+    fs.mkdirSync(path.join(peerTmp, d), { recursive: true })
+  }
+  peerPort = await freePort()
+  // Must be 64 hex chars (authtoken.validateFormat), and distinct from the
+  // harness token so a mis-addressed request fails loudly.
+  peerToken = 'beef'.padEnd(64, '0')
+  fs.writeFileSync(
+    path.join(peerTmp, 'config', 'gmux', 'host.toml'),
+    [`port = ${peerPort}`, '', '[discovery]', 'devcontainers = false', ''].join('\n'),
+  )
+  peerProc = spawn(GMUXD, ['run'], {
+    env: {
+      PATH: process.env.PATH || '',
+      HOME: peerHome,
+      TERM: 'xterm-256color',
+      GMUX_SOCKET_DIR: path.join(peerTmp, 'sockets'),
+      GMUXD_TOKEN: peerToken,
+      XDG_CONFIG_HOME: path.join(peerTmp, 'config'),
+      XDG_STATE_HOME: path.join(peerTmp, 'state'),
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+    detached: true,
+  })
+  let peerLog = ''
+  peerProc.stderr?.on('data', (d: Buffer) => { peerLog += String(d) })
+  peerProc.stdout?.on('data', (d: Buffer) => { peerLog += String(d) })
+  await pollUntil(async () => {
+    try {
+      return (await apiFetch('GET', '/v1/health', { port: peerPort, token: peerToken })).status === 200
+    } catch {
+      return false // daemon still binding
+    }
+  }, { timeoutMs: 20_000, intervalMs: 200, description: `peer daemon healthy (log: ${peerLog})` })
+
+  // The peer's session needs a project on the peer for the UI to route to it.
+  await apiFetch('PUT', '/v1/projects', {
+    port: peerPort, token: peerToken,
+    body: { items: [{ slug: 'peer-project', match: [{ path: peerWorkspace }] }] },
+  })
+  await apiFetch('POST', '/v1/launch', {
+    port: peerPort, token: peerToken,
+    body: { cwd: peerWorkspace, command: ['bash', '-c', 'echo peer-relaunch-probe; sleep 5'] },
+  })
+  const peerDead = await pollUntil(async () =>
+    (await sessions(peerPort, peerToken)).find(s => !s.alive && s.cwd === peerWorkspace),
+  { timeoutMs: 20_000, intervalMs: 200, description: 'peer shell session exited' })
+  peerDeadId = peerDead.id
+
+  const registered = await apiFetch<{ peer?: { Name: string } }>('POST', '/v1/peers', {
+    body: { URL: `http://127.0.0.1:${peerPort}`, Token: peerToken },
+  })
+  expect(registered.status, 'peer registration').toBe(200)
+  peerName = registered.body?.peer?.Name ?? ''
+  expect(peerName).not.toBe('')
+})
+
+test.afterAll(async () => {
+  // Restore the shared daemon: no peer, no extra sessions. Later specs
+  // assume the harness's single-session world.
+  for (const id of [localDeadId, peerDeadId ? `${peerDeadId}@${peerName}` : '']) {
+    if (!id) continue
+    await apiFetch('POST', `/v1/sessions/${id}/kill`).catch(() => {})
+  }
+  await new Promise(r => setTimeout(r, 300))
+  if (localDeadId) await apiFetch('POST', `/v1/sessions/${localDeadId}/dismiss`).catch(() => {})
+  if (peerName) await apiFetch('DELETE', `/v1/peers/${peerName}`).catch(() => {})
+  for (const proc of spawned) {
+    if (proc.pid) { try { process.kill(-proc.pid, 'SIGKILL') } catch { /* gone */ } }
+  }
+  if (peerProc?.pid) { try { process.kill(-peerProc.pid, 'SIGKILL') } catch { /* gone */ } }
+  if (peerTmp) fs.rmSync(peerTmp, { recursive: true, force: true })
+})
+
+test('a dead local shell is offered Rerun, and Rerun works', async ({ page }) => {
+  const row = (await sessions()).find(s => s.id === localDeadId)!
+  expect(row.resumable, 'dead shell stays visible in the sidebar').toBe(true)
+  // The daemon names the verb: a shell has no conversation to resume.
+  expect(row.relaunch).toBe('rerun')
+
+  await openApp(page)
+  await gotoSession(page, localDeadId)
+
+  const button = page.locator('.replay-actions .btn-primary')
+  await expect(button).toBeVisible()
+  await expect(button).toHaveText('Rerun')
+
+  await button.click()
+  // The failure mode this replaces is a toast carrying the daemon's refusal.
+  // Watch for it *while* waiting for liveness, so a regression reports the
+  // actual message instead of an anonymous poll timeout.
+  await pollUntil(async () => {
+    await expectNoFailureToast(page)
+    return (await sessions()).find(s => s.id === localDeadId)?.alive
+  }, { timeoutMs: 15_000, intervalMs: 200, description: 'local shell relaunched' })
+})
+
+test('a dead peer shell is offered Rerun, and Rerun runs on the owning daemon', async ({ page }) => {
+  const ref = `${peerDeadId}@${peerName}`
+  const row = await pollUntil(async () => (await sessions()).find(s => s.id === ref),
+    { timeoutMs: 20_000, intervalMs: 200, description: 'peer session projected locally' })
+  expect(row.peer).toBe(peerName)
+  // The verdict is the owner's, carried on the wire — not recomputed here.
+  expect(row.relaunch).toBe('rerun')
+
+  await openApp(page)
+  await gotoSession(page, ref)
+
+  const button = page.locator('.replay-actions .btn-primary')
+  await expect(button).toBeVisible()
+  await expect(button).toHaveText('Rerun')
+
+  await button.click()
+  // Assert on the *owning* daemon: the request must be forwarded, not run
+  // locally against a store row that doesn't exist here.
+  await pollUntil(async () => {
+    await expectNoFailureToast(page)
+    return (await sessions(peerPort, peerToken)).find(s => s.id === peerDeadId)?.alive
+  }, { timeoutMs: 15_000, intervalMs: 200, description: 'peer shell relaunched on its owner' })
+})

--- a/packages/protocol/src/session.ts
+++ b/packages/protocol/src/session.ts
@@ -44,6 +44,20 @@ export const SessionSchema = z.object({
   // completion, including across runner replacement.
   unread_token: z.string().optional().default(''),
   resumable: z.boolean().optional().default(false),
+  // The owning daemon's verdict on which relaunch verb a dead session
+  // offers, and the single source of truth for the affordance: 'resume'
+  // continues the recorded agent conversation, 'rerun' launches the
+  // recorded command again in the recorded directory (the only thing a dead
+  // shell can do). Absent means the daemon will refuse to relaunch — or
+  // that the row came from a peer running a daemon older than this field,
+  // in which case clients fall back to `resumable`.
+  //
+  // Parsed as a plain string, not an enum: the verb set is daemon-owned
+  // policy and may grow, and a newer peer sending a third verb must not
+  // make the whole row fail to parse (the wire covenant is "ignore keys —
+  // and values — you don't understand"). Consumers narrow it themselves
+  // and treat anything unrecognized as absent (see relaunchVerb).
+  relaunch: z.string().optional(),
   // Absolute path of the agent conversation file this session holds, as
   // reported by the agent hook (ADR 0011). Two live sessions sharing one
   // conversation_file means the same conversation is open in multiple tabs;

--- a/services/gmuxd/cmd/gmuxd/agent_actions.go
+++ b/services/gmuxd/cmd/gmuxd/agent_actions.go
@@ -295,8 +295,8 @@ func (d agentDeps) timer(dur time.Duration) <-chan time.Time {
 // POST /v1/sessions/{id}/resume's preconditions on purpose: a transparent
 // resume must not be able to succeed where an explicit one would refuse.
 func agentResumeGuard(ctx context.Context, boot *Bootstrap, gmuxBin string, row centralstore.Session) (int, string, string) {
-	if row.ExitedAt == nil || len(row.Command) == 0 {
-		return http.StatusBadRequest, "not_resumable", "session is not resumable"
+	if status, code, msg := relaunchGuard(row); status != 0 {
+		return status, code, msg
 	}
 	if gmuxBin == "" {
 		return http.StatusInternalServerError, "gmux_not_found", "gmux not found"
@@ -307,6 +307,43 @@ func agentResumeGuard(ctx context.Context, boot *Bootstrap, gmuxBin string, row 
 	}
 	if cwd == "" {
 		return http.StatusUnprocessableEntity, "cwd_missing", "the session's working directory no longer exists and no fallback directory is available"
+	}
+	return 0, "", ""
+}
+
+// relaunchGuard reports why a row cannot be relaunched, as (status, code,
+// message), or a zero status when POST /resume may proceed. It applies the
+// shared relaunch policy (package relaunch) that the wire converter presents
+// and the runner spawner executes, so a client is never refused for a row the
+// UI showed as relaunchable — and when it is refused, the message says which
+// of the two relaunch verbs was unavailable and why.
+func relaunchGuard(row centralstore.Session) (int, string, string) {
+	if row.ExitedAt == nil {
+		// Two shapes reach this, and the message must fit both: a session
+		// that is genuinely running, and one whose runner is gone but whose
+		// exit is not durable yet (the convergence window — the coordinator
+		// refuses those too, ErrConvergencePending). Telling the second one
+		// to "stop it first" would be nonsense advice about a dead process.
+		return http.StatusBadRequest, "not_resumable",
+			"this session has no recorded exit: if it is still running, restart it instead; if it just stopped, retry in a moment"
+	}
+	return relaunchCommandGuard(row)
+}
+
+// relaunchCommandGuard is relaunchGuard without the exit precondition, for
+// restart: restart stops a live session and then spawns it again, so a row
+// the spawner would refuse must be refused *before* the stop. Otherwise
+// "Restart" is a kill with extra steps — exactly what it was for every shell
+// session before the relaunch policy was shared.
+func relaunchCommandGuard(row centralstore.Session) (int, string, string) {
+	if len(productionResolveRelaunchCommand(row)) == 0 {
+		if row.ConversationRef != "" {
+			return http.StatusBadRequest, "not_resumable", fmt.Sprintf(
+				"this session's %s conversation (%s) is missing, empty, or no longer resumable by the adapter; start a new session instead",
+				row.Adapter, row.ConversationRef)
+		}
+		return http.StatusBadRequest, "not_resumable",
+			"this session has no conversation to resume and no recorded command to rerun; start a new session instead"
 	}
 	return 0, "", ""
 }

--- a/services/gmuxd/cmd/gmuxd/bootstrap_runner_adapters.go
+++ b/services/gmuxd/cmd/gmuxd/bootstrap_runner_adapters.go
@@ -415,6 +415,45 @@ type productionRunnerSpawner struct {
 	launched            map[string]runnerLaunchResult
 }
 
+// productionResolveRelaunchCommand is the production relaunch resolution: the
+// shared policy (package relaunch) applied with the live adapter resolver.
+// It is the single value injected as productionRunnerSpawner.ResolveCommand
+// (serve_central.go) and the one the HTTP guards consult, so presentation,
+// admission and execution cannot drift; tests must exercise *this* function
+// rather than re-implementing the lambda that used to live at the call site.
+func productionResolveRelaunchCommand(row centralstore.Session) []string {
+	legacy := centralSessionToLegacy(row)
+	cmd, _ := discovery.ResolveRelaunchLive(legacy.Adapter, legacy.ConversationRef, legacy.Command)
+	return cmd
+}
+
+// resolveCommand applies the injected relaunch resolution, defaulting to the
+// production one so a spawner built without wiring behaves identically.
+func (s *productionRunnerSpawner) resolveCommand(row centralstore.Session) []string {
+	if s.ResolveCommand != nil {
+		return s.ResolveCommand(row)
+	}
+	return productionResolveRelaunchCommand(row)
+}
+
+// CanSpawn answers Restart's pre-stop question (sessioncoord.RunnerSpawnChecker)
+// with exactly the predicate Spawn applies, minus any side effect.
+func (s *productionRunnerSpawner) CanSpawn(row centralstore.Session) error {
+	if len(s.resolveCommand(row)) == 0 {
+		return relaunchRefusal(row)
+	}
+	return nil
+}
+
+// relaunchRefusal is the actionable refusal for a row the relaunch policy
+// declines. The two refusals have different remedies, so they read differently.
+func relaunchRefusal(row centralstore.Session) error {
+	if row.ConversationRef != "" {
+		return fmt.Errorf("session %s cannot be resumed: its %s conversation (%s) is missing, empty, or no longer resumable by the adapter", row.ID, row.Adapter, row.ConversationRef)
+	}
+	return fmt.Errorf("session %s cannot be relaunched: no conversation to resume and no recorded command to rerun", row.ID)
+}
+
 func (s *productionRunnerSpawner) Spawn(ctx context.Context, row centralstore.Session) (string, error) {
 	if err := ctx.Err(); err != nil {
 		return "", err
@@ -433,13 +472,9 @@ func (s *productionRunnerSpawner) Spawn(ctx context.Context, row centralstore.Se
 	if cwd == "" {
 		return "", fmt.Errorf("runner spawn: no usable directory")
 	}
-	if s.ResolveCommand != nil {
-		legacy.Command = s.ResolveCommand(row)
-	} else {
-		legacy.Command = discovery.ResolveResumeCommandFor(legacy.Adapter, legacy.ConversationRef)
-	}
+	legacy.Command = s.resolveCommand(row)
 	if len(legacy.Command) == 0 {
-		return "", fmt.Errorf("runner spawn: session %s is not resumable", row.ID)
+		return "", fmt.Errorf("runner spawn: %w", relaunchRefusal(row))
 	}
 	endpoint := filepath.Join(paths.SessionSocketDir(), legacy.ID+".sock")
 	// A retained session may predate the socket lease protocol and therefore

--- a/services/gmuxd/cmd/gmuxd/relaunch_restart_route_test.go
+++ b/services/gmuxd/cmd/gmuxd/relaunch_restart_route_test.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/centralstore"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/sessioncoord"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/sessionmeta"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/snapshot/wire"
+)
+
+// countingSpawner records whether the lifecycle path was entered at all.
+type countingSpawner struct{ spawns atomic.Int64 }
+
+func (s *countingSpawner) Spawn(context.Context, centralstore.Session) (string, error) {
+	s.spawns.Add(1)
+	return "", context.Canceled // never reached in these tests
+}
+
+type countingControl struct{ kills atomic.Int64 }
+
+// Terminate records the kill and then fails, so a restart that gets this far
+// unwinds immediately instead of waiting out an observed death that this
+// harness's fake runner will never report.
+func (c *countingControl) Terminate(context.Context, string, string) error {
+	c.kills.Add(1)
+	return errors.New("terminate refused by the test control")
+}
+
+func (c *countingControl) Reap(context.Context, string, string) error { return nil }
+
+// restartRouteHarness registers a live runner for a row the relaunch policy
+// refuses (an unresolvable conversation ref) and returns the pieces needed to
+// drive POST /v1/sessions/{id}/restart through the real route dispatch.
+func restartRouteHarness(t *testing.T, ref string) (*Bootstrap, *countingSpawner, *countingControl) {
+	t.Helper()
+	ctx := context.Background()
+	st, err := centralstore.Open(ctx, t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	cwd := t.TempDir()
+	active := true
+	cmd := []string{"claude"}
+	facts := centralstore.RunnerFacts{Active: &active, CWD: &cwd, ConversationRef: &ref, Command: &cmd}
+	runners := &bootstrapRunners{
+		metas: map[string]sessioncoord.RunnerMeta{"ep-restart": {PID: 321, Incarnation: "inc-restart", Registration: centralstore.RunnerRegistration{
+			ID: productionSessionID, Adapter: "claude", Alive: true, CreatedAt: 1, ObservedAt: 1, Facts: facts,
+		}}},
+		blocked: map[string]bool{},
+	}
+	spawner, control := &countingSpawner{}, &countingControl{}
+	reg := sessioncoord.NewRegistry()
+	coord := sessioncoord.New(reg, runners, st, nil, nil,
+		sessioncoord.WithRunnerSpawner(spawner), sessioncoord.WithRunnerControl(control))
+	t.Cleanup(coord.Close)
+	if _, err := coord.Register(ctx, sessioncoord.RegisterRequest{Endpoint: "ep-restart"}); err != nil {
+		t.Fatal(err)
+	}
+	return &Bootstrap{Store: st, Registry: reg, Coordinator: coord}, spawner, control
+}
+
+func postRestart(t *testing.T, boot *Bootstrap) recorded {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/sessions/"+string(productionSessionID)+"/restart", nil)
+	handleCentralSessionAction(rec, req, boot, newSSEFanout(), &wire.Converter{}, nil, sessionmeta.New(t.TempDir()), "/usr/bin/gmux", nil)
+	return parseRecorded(t, rec)
+}
+
+// TestRestartRouteRefusesWithoutEnteringTheLifecycle is the ordering assertion
+// at the level where the ordering is written: the handler must refuse a row
+// the relaunch policy declines *before* handing it to the coordinator, because
+// the coordinator's restart stops the runner first. Moving the guard after
+// boot.Coordinator.Restart(...) makes this fail (the terminate lands and the
+// live entry disappears), which a pure-function guard test cannot see.
+func TestRestartRouteRefusesWithoutEnteringTheLifecycle(t *testing.T) {
+	boot, spawner, control := restartRouteHarness(t, filepath.Join(t.TempDir(), "vanished.jsonl"))
+
+	got := postRestart(t, boot)
+	if got.code != http.StatusBadRequest || got.errCode() != "not_resumable" {
+		t.Fatalf("code=%d body=%v, want 400 not_resumable", got.code, got.body)
+	}
+	if control.kills.Load() != 0 {
+		t.Errorf("terminate issued %d time(s): the session was stopped for a restart that cannot happen", control.kills.Load())
+	}
+	if spawner.spawns.Load() != 0 {
+		t.Errorf("spawn attempted %d time(s) after a refusal", spawner.spawns.Load())
+	}
+	if _, live := registryRuntime(boot.Registry, productionSessionID); !live {
+		t.Error("the live runner must survive a refused restart")
+	}
+}
+
+// The same route, with a relaunchable row, must reach the lifecycle: otherwise
+// the test above would pass for the wrong reason (a handler that refuses
+// everything).
+func TestRestartRouteEntersTheLifecycleForARelaunchableRow(t *testing.T) {
+	boot, _, control := restartRouteHarness(t, "")
+
+	if got := postRestart(t, boot); got.code == http.StatusBadRequest && got.errCode() == "not_resumable" {
+		t.Fatalf("a rerunnable row was refused: %v", got.body)
+	}
+	if control.kills.Load() == 0 {
+		t.Error("the lifecycle was never entered for a relaunchable row")
+	}
+}

--- a/services/gmuxd/cmd/gmuxd/resume_agreement_test.go
+++ b/services/gmuxd/cmd/gmuxd/resume_agreement_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/centralstore"
@@ -34,11 +35,10 @@ func TestResumeDerivationPresentationMatchesSpawn(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Exactly the production wiring from serve_central.go.
-	resolve := func(row centralstore.Session) []string {
-		legacy := centralSessionToLegacy(row)
-		return discovery.ResolveResumeCommandFor(legacy.Adapter, legacy.ConversationRef)
-	}
+	// The production value itself, not a copy of it: serve_central.go injects
+	// exactly this function as productionRunnerSpawner.ResolveCommand, so
+	// reverting the wiring to the resume-only resolver fails here.
+	resolve := productionResolveRelaunchCommand
 	conv := &wire.Converter{ResumeCommand: func(adapterName, ref string) []string {
 		return discovery.ResolveResumeCommandFor(adapterName, ref)
 	}}
@@ -98,3 +98,176 @@ var errSpawnReached = errTestSentinel("spawn reached launcher")
 type errTestSentinel string
 
 func (e errTestSentinel) Error() string { return string(e) }
+
+// TestRelaunchDerivationPresentationMatchesSpawn is the same agreement for
+// rows with NO conversation ref — the shape that shipped broken. Every dead
+// shell session is one (the shell has no hook that binds a conversation), and
+// so is any agent that died before its first hook event. Presentation derived
+// "resumable" from the durable command while the spawner only ever resolved
+// the *resume* command, so the sidebar offered an action the daemon answered
+// with "session is not resumable" (and Restart killed the session first).
+//
+// Sweeping every registered adapter keeps this systemic: a new adapter cannot
+// reintroduce the divergence for its own kind.
+func TestRelaunchDerivationPresentationMatchesSpawn(t *testing.T) {
+	dir := t.TempDir()
+	resolve := productionResolveRelaunchCommand
+	conv := &wire.Converter{ResumeCommand: func(adapterName, ref string) []string {
+		return discovery.ResolveResumeCommandFor(adapterName, ref)
+	}}
+
+	adapterNames := []string{"shell", "editor", "claude", "codex", "pi", "acp-unknown"}
+	for i, name := range adapterNames {
+		for _, tc := range []struct {
+			label   string
+			command []string
+			// A dead row with no conversation ref is rerunnable exactly
+			// when it recorded a command.
+			wantRelaunch string
+		}{
+			{"recorded command", []string{"/root/.local/bin/fish"}, "rerun"},
+			{"no command", nil, ""},
+		} {
+			t.Run(name+"/"+tc.label, func(t *testing.T) {
+				row := centralstore.Session{
+					ID: centralstore.SessionID(fmt.Sprintf("%06dx%d", i, len(tc.label))), Adapter: name,
+					Command: tc.command, CWD: dir, CreatedAt: 1700000000000, StatusReported: true,
+				}
+
+				// Presentation: the composer's own Resumable term (dead ∧
+				// command ∧ verdict ≠ Gone) feeds the converter, exactly
+				// like production.
+				payload := conv.Sessions(&central.SessionsPayload{Sessions: []central.SessionRow{{
+					SessionView: centralstore.SessionView{Session: row},
+					Resumable:   len(tc.command) > 0,
+				}}}, nil, nil)
+				got := payload.Sessions[0]
+				if got.Relaunch != tc.wantRelaunch {
+					t.Errorf("wire relaunch = %q, want %q", got.Relaunch, tc.wantRelaunch)
+				}
+				if got.Resumable != (tc.wantRelaunch != "") {
+					t.Errorf("wire resumable = %v, want %v", got.Resumable, tc.wantRelaunch != "")
+				}
+
+				// Execution: the production spawner must accept exactly the
+				// rows presentation advertised.
+				spawner := &productionRunnerSpawner{
+					GmuxBin:        "/bin/gmux",
+					ResolveDir:     func(centralstore.Session) (string, error) { return dir, nil },
+					ResolveCommand: resolve,
+					Launch: func(context.Context, runnerLaunchRequest) (runnerLaunchResult, error) {
+						return runnerLaunchResult{}, errSpawnReached
+					},
+				}
+				_, err := spawner.Spawn(context.Background(), row)
+				spawnAttempted := err == errSpawnReached
+				if spawnAttempted != got.Resumable {
+					t.Errorf("spawn attempted = %v (err %v), want %v — presentation and execution disagree",
+						spawnAttempted, err, got.Resumable)
+				}
+			})
+		}
+	}
+}
+
+// TestRelaunchSpawnRerunsTheRecordedCommand pins what a rerun actually
+// executes: the recorded command, in the resolved directory, under the same
+// session id (the runner re-registers the same session, as resume does).
+func TestRelaunchSpawnRerunsTheRecordedCommand(t *testing.T) {
+	dir := t.TempDir()
+	var seen runnerLaunchRequest
+	spawner := &productionRunnerSpawner{
+		GmuxBin:        "/bin/gmux",
+		ResolveDir:     func(centralstore.Session) (string, error) { return dir, nil },
+		ResolveCommand: productionResolveRelaunchCommand,
+		Launch: func(_ context.Context, req runnerLaunchRequest) (runnerLaunchResult, error) {
+			seen = req
+			return runnerLaunchResult{}, errSpawnReached
+		},
+	}
+	row := centralstore.Session{
+		ID: "1rerun01", Adapter: "shell", Command: []string{"bash", "-lc", "echo hi"},
+		CWD: dir, CreatedAt: 1700000000000, StatusReported: true,
+	}
+	if _, err := spawner.Spawn(context.Background(), row); err != errSpawnReached {
+		t.Fatalf("Spawn err = %v, want the launcher to be reached", err)
+	}
+	if want := []string{"bash", "-lc", "echo hi"}; !slicesEqual(seen.Command, want) {
+		t.Errorf("launched command = %v, want %v", seen.Command, want)
+	}
+	if seen.CWD != dir {
+		t.Errorf("launched cwd = %q, want %q", seen.CWD, dir)
+	}
+	if seen.ResumeID != "1rerun01" {
+		t.Errorf("launched ResumeID = %q, want the same session id", seen.ResumeID)
+	}
+}
+
+// TestRelaunchGuardMessagesAreActionable pins the two refusals the daemon can
+// still emit and that each says what to do about it.
+func TestRelaunchGuardMessagesAreActionable(t *testing.T) {
+	exited := centralstore.UnixMillis(1700000001000)
+	alive := centralstore.Session{ID: "1alive00", Adapter: "shell", Command: []string{"bash"}}
+	status, code, msg := relaunchGuard(alive)
+	if status == 0 || code != "not_resumable" {
+		t.Errorf("running session: status=%d code=%q, want a not_resumable refusal", status, code)
+	}
+	// The same refusal covers a row whose runner is gone but whose exit is
+	// not durable yet (the convergence window), so it must not order the user
+	// to stop a process that may not exist.
+	if strings.Contains(msg, "stop it first") || !strings.Contains(msg, "retry in a moment") {
+		t.Errorf("exit-less message = %q, want advice valid for both a running and a converging row", msg)
+	}
+	bare := centralstore.Session{ID: "1bare000", Adapter: "shell", ExitedAt: &exited}
+	_, _, msg = relaunchGuard(bare)
+	if !strings.Contains(msg, "no recorded command to rerun") {
+		t.Errorf("bare row message = %q, want it to name the missing command", msg)
+	}
+	goneConv := centralstore.Session{ID: "1gone000", Adapter: "pi", Command: []string{"pi"},
+		ExitedAt: &exited, ConversationRef: filepath.Join(t.TempDir(), "missing.jsonl")}
+	_, _, msg = relaunchGuard(goneConv)
+	if !strings.Contains(msg, "missing.jsonl") || !strings.Contains(msg, "start a new session") {
+		t.Errorf("gone-conversation message = %q, want the ref and a next step", msg)
+	}
+	ok := centralstore.Session{ID: "1okrerun", Adapter: "shell", Command: []string{"bash"}, ExitedAt: &exited}
+	if status, _, msg := relaunchGuard(ok); status != 0 {
+		t.Errorf("rerunnable row refused: status=%d msg=%q", status, msg)
+	}
+}
+
+func slicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// TestRestartGuardRefusesBeforeStopping: restart is stop+spawn, so the check
+// that the spawner will accept the row has to happen while the session is
+// still running. A live shell must pass (it reruns its command); a live agent
+// whose conversation vanished must be refused rather than stopped and lost.
+func TestRestartGuardRefusesBeforeStopping(t *testing.T) {
+	liveShell := centralstore.Session{ID: "1liveshl", Adapter: "shell", Command: []string{"bash"}, CWD: t.TempDir()}
+	if status, _, msg := relaunchCommandGuard(liveShell); status != 0 {
+		t.Errorf("live shell restart refused: status=%d msg=%q", status, msg)
+	}
+	lostConv := centralstore.Session{ID: "1lostcnv", Adapter: "pi", Command: []string{"pi"},
+		CWD: t.TempDir(), ConversationRef: filepath.Join(t.TempDir(), "vanished.jsonl")}
+	status, code, msg := relaunchCommandGuard(lostConv)
+	if status == 0 || code != "not_resumable" {
+		t.Fatalf("lost conversation accepted for restart: status=%d code=%q", status, code)
+	}
+	if !strings.Contains(msg, "vanished.jsonl") {
+		t.Errorf("message = %q, want the unresolvable ref named", msg)
+	}
+	// The exit precondition belongs to resume alone: restart's guard must not
+	// reject a session for still running.
+	if status, _, _ := relaunchGuard(liveShell); status == 0 {
+		t.Error("resume guard accepted a session that has not exited")
+	}
+}

--- a/services/gmuxd/cmd/gmuxd/serve_central.go
+++ b/services/gmuxd/cmd/gmuxd/serve_central.go
@@ -298,10 +298,7 @@ func serveCentral(stderr io.Writer, replace bool) int {
 	spawner := &productionRunnerSpawner{GmuxBin: gmuxBin, ResolveDir: func(row centralstore.Session) (string, error) {
 		dir, _, err := resolveResumeDirCentral(context.Background(), storeHandle, row)
 		return dir, err
-	}, ResolveCommand: func(row centralstore.Session) []string {
-		legacy := centralSessionToLegacy(row)
-		return discovery.ResolveResumeCommandFor(legacy.Adapter, legacy.ConversationRef)
-	}}
+	}, ResolveCommand: productionResolveRelaunchCommand}
 
 	boot, err = newBootstrap(BootstrapConfig{Store: storeHandle, Runners: productionRunnerClient{}, Control: productionRunnerControl{}, Spawner: spawner, Resolver: productionConversationResolver{}, Reconciler: productionAdapterReconciler{}, LocalPeers: peerAdapter.LocalPeerMatchInputs, Peers: peerAdapter, PeerSessions: peerAdapter, Converter: converter, Endpoints: productionEndpointSource{}, MaxSubagentsByDepth: cfg.Agent.MaxSubagentsByDepth.Values, SubagentBudgetDisabled: cfg.Agent.MaxSubagentsByDepth.Disabled, SemanticAgent: func(name string) bool { return converter.SemanticAgents[name] }, Errors: sessioncoord.ErrorSinkFunc(func(_ context.Context, err error) { log.Printf("gmuxd: %v", err) }), Frames: func(_ context.Context, frames wire.Frames) {
 		// The converter builds world.health.launchers but not the top-level
@@ -1271,8 +1268,8 @@ func handleCentralSessionAction(w http.ResponseWriter, r *http.Request, boot *Bo
 			writeError(w, http.StatusNotFound, "not_found", "session not found")
 			return
 		}
-		if row.ExitedAt == nil || len(row.Command) == 0 {
-			writeError(w, http.StatusBadRequest, "not_resumable", "session is not resumable")
+		if status, code, msg := relaunchGuard(row); status != 0 {
+			writeError(w, status, code, msg)
 			return
 		}
 		if gmuxBin == "" {
@@ -1306,6 +1303,12 @@ func handleCentralSessionAction(w http.ResponseWriter, r *http.Request, boot *Bo
 		}
 		if gmuxBin == "" {
 			writeError(w, http.StatusInternalServerError, "gmux_not_found", "gmux not found")
+			return
+		}
+		// Refuse before stopping: restart is stop+spawn, so a row the spawner
+		// would refuse must not lose its running process to a failed respawn.
+		if status, code, msg := relaunchCommandGuard(row); status != 0 {
+			writeError(w, status, code, msg)
 			return
 		}
 		restartCwd, fellBack, err := resolveResumeDirCentral(r.Context(), boot.Store, row)

--- a/services/gmuxd/internal/discovery/resume.go
+++ b/services/gmuxd/internal/discovery/resume.go
@@ -3,6 +3,7 @@ package discovery
 import (
 	"github.com/gmuxapp/gmux/packages/adapter"
 	"github.com/gmuxapp/gmux/packages/adapter/adapters"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/relaunch"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/store"
 )
 
@@ -36,4 +37,11 @@ func ResolveResumeCommandFor(adapterName, conversationRef string) []string {
 		return nil
 	}
 	return resumer.ResumeCommand(info)
+}
+
+// ResolveRelaunchLive applies the shared relaunch policy with the live
+// adapter resolver. It is the execution-side (runner spawn) entry point;
+// presentation applies the same policy through the snapshot wire converter.
+func ResolveRelaunchLive(adapterName, conversationRef string, command []string) ([]string, relaunch.Kind) {
+	return relaunch.Resolve(ResolveResumeCommandFor, adapterName, conversationRef, command)
 }

--- a/services/gmuxd/internal/peering/projection.go
+++ b/services/gmuxd/internal/peering/projection.go
@@ -5,6 +5,12 @@ import "reflect"
 // SessionProjection is the authority-neutral, copyable projection received
 // from a peer's snapshot.sessions stream. It intentionally contains only
 // wire/runtime facts; no durable store type crosses the peering boundary.
+//
+// Relaunch carries the owning peer's relaunch verdict verbatim ("resume" or
+// "rerun"): the owner is the only node that can resolve its own adapters'
+// conversations, and it is the node that will execute the request once we
+// forward it. Empty means the owner refuses — or that it runs a daemon older
+// than the field, which clients degrade to the Resumable-only behavior.
 type SessionProjection struct {
 	ID                    string            `json:"id"`
 	Peer                  string            `json:"peer,omitempty"`
@@ -29,6 +35,7 @@ type SessionProjection struct {
 	Unread                bool              `json:"unread"`
 	UnreadToken           string            `json:"unread_token"`
 	Resumable             bool              `json:"resumable,omitempty"`
+	Relaunch              string            `json:"relaunch,omitempty"` // "resume" | "rerun" | "" (refused / pre-field peer)
 	SocketPath            string            `json:"socket_path,omitempty"`
 	TerminalCols          uint16            `json:"terminal_cols,omitempty"`
 	TerminalRows          uint16            `json:"terminal_rows,omitempty"`

--- a/services/gmuxd/internal/relaunch/relaunch.go
+++ b/services/gmuxd/internal/relaunch/relaunch.go
@@ -1,0 +1,65 @@
+// Package relaunch holds the single relaunch policy shared by presentation
+// and execution. It is deliberately a dependency-free leaf: the snapshot wire
+// converter (which decides whether the UI is offered the affordance) and the
+// runner spawner (which decides whether to spawn) both import it, so neither
+// can drift into advertising a relaunch the other refuses.
+package relaunch
+
+// Kind names the one relaunch action a dead session offers.
+//
+// The two kinds are genuinely different verbs, not labels: "resume" picks a
+// recorded agent conversation back up (the adapter derives a `--resume <id>`
+// style command from it), while "rerun" simply launches the session's recorded
+// command again in the same directory, with no state carried over. A shell has
+// no conversation to resume, so a dead shell can only ever be rerun.
+type Kind string
+
+const (
+	// None means the daemon will refuse to relaunch the session.
+	None Kind = ""
+	// Resume means the adapter resolved a resume command from the
+	// session's recorded conversation.
+	Resume Kind = "resume"
+	// Rerun means there is no conversation to resume, but the recorded
+	// launch command can be run again.
+	Rerun Kind = "rerun"
+)
+
+// Resolve is the single relaunch policy: given a session's adapter,
+// conversation ref and recorded launch command, it returns the command a
+// relaunch would execute and which verb that is.
+//
+// Presentation (the snapshot wire converter, which decides whether the UI
+// offers the affordance) and execution (the runner spawner, which decides
+// whether to spawn) must both go through this function. When they derived
+// their verdicts independently the UI advertised relaunches the daemon then
+// refused: a dead shell session has a recorded command but never a
+// conversation ref, so presentation said "resumable" while the spawner —
+// which only ever resolved the *resume* command — answered "session is not
+// resumable" (and, via restart, killed the session on the way).
+//
+// resume resolves the adapter's resume command for a conversation ref. A nil
+// func means "this caller has no resume policy at all" (a degenerate,
+// test-only shape — production always injects one) and degrades to the rerun
+// path rather than pretending the adapter refused. Rules:
+//
+//   - A conversation ref that resolves to a resume command → Resume.
+//   - A conversation ref that resolves to nothing → None. The adapter is
+//     authoritative for a bound conversation: an empty or unreadable
+//     transcript is not silently downgraded to a fresh rerun, because the
+//     user asked to continue *that* conversation.
+//   - No conversation ref (shell, editor, one-off commands, and agents that
+//     died before their hook bound a conversation) → Rerun of the recorded
+//     command, when there is one.
+func Resolve(resume func(adapterName, conversationRef string) []string, adapterName, conversationRef string, command []string) ([]string, Kind) {
+	if conversationRef != "" && resume != nil {
+		if cmd := resume(adapterName, conversationRef); len(cmd) > 0 {
+			return cmd, Resume
+		}
+		return nil, None
+	}
+	if len(command) > 0 {
+		return append([]string(nil), command...), Rerun
+	}
+	return nil, None
+}

--- a/services/gmuxd/internal/relaunch/relaunch_test.go
+++ b/services/gmuxd/internal/relaunch/relaunch_test.go
@@ -1,0 +1,87 @@
+package relaunch
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestResolve(t *testing.T) {
+	resume := func(adapterName, ref string) []string {
+		if ref == "good" {
+			return []string{adapterName, "--resume", ref}
+		}
+		return nil
+	}
+
+	for _, tc := range []struct {
+		name     string
+		ref      string
+		command  []string
+		resume   func(string, string) []string
+		wantCmd  []string
+		wantKind Kind
+	}{
+		{
+			name: "conversation resolves to a resume command",
+			ref:  "good", command: []string{"pi"}, resume: resume,
+			wantCmd: []string{"pi", "--resume", "good"}, wantKind: Resume,
+		},
+		{
+			// The user asked to continue *that* conversation; silently
+			// starting a fresh one would be a different session.
+			name: "unresolvable conversation is refused, not downgraded to rerun",
+			ref:  "gone", command: []string{"pi"}, resume: resume,
+			wantCmd: nil, wantKind: None,
+		},
+		{
+			// The reported bug: dead shells have a command but never a
+			// conversation ref, and presentation used to call this
+			// "resumable" while execution refused it.
+			name: "no conversation, recorded command reruns",
+			ref:  "", command: []string{"/root/.local/bin/fish"}, resume: resume,
+			wantCmd: []string{"/root/.local/bin/fish"}, wantKind: Rerun,
+		},
+		{
+			name: "agent that died before binding a conversation reruns",
+			ref:  "", command: []string{"claude"}, resume: resume,
+			wantCmd: []string{"claude"}, wantKind: Rerun,
+		},
+		{
+			name: "nothing recorded at all",
+			ref:  "", command: nil, resume: resume,
+			wantCmd: nil, wantKind: None,
+		},
+		{
+			name: "nil resolver has no resume policy and degrades to rerun",
+			ref:  "good", command: []string{"pi"}, resume: nil,
+			wantCmd: []string{"pi"}, wantKind: Rerun,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd, kind := Resolve(tc.resume, "pi", tc.ref, tc.command)
+			if kind != tc.wantKind {
+				t.Errorf("kind = %q, want %q", kind, tc.wantKind)
+			}
+			if !reflect.DeepEqual(cmd, tc.wantCmd) {
+				t.Errorf("cmd = %v, want %v", cmd, tc.wantCmd)
+			}
+			if (len(cmd) > 0) != (kind != None) {
+				t.Errorf("command/kind disagree: %v / %q", cmd, kind)
+			}
+		})
+	}
+}
+
+// TestResolveDoesNotAliasCommand guards the rerun path against handing the
+// caller the durable slice: the spawner rewrites what it gets.
+func TestResolveDoesNotAliasCommand(t *testing.T) {
+	durable := []string{"bash", "-lc", "true"}
+	cmd, kind := Resolve(nil, "shell", "", durable)
+	if kind != Rerun {
+		t.Fatalf("kind = %q, want rerun", kind)
+	}
+	cmd[0] = "mutated"
+	if durable[0] != "bash" {
+		t.Errorf("durable command aliased and mutated: %v", durable)
+	}
+}

--- a/services/gmuxd/internal/sessioncoord/lifecycle.go
+++ b/services/gmuxd/internal/sessioncoord/lifecycle.go
@@ -92,6 +92,15 @@ type RunnerSpawner interface {
 	Spawn(ctx context.Context, session centralstore.Session) (endpoint string, err error)
 }
 
+// RunnerSpawnChecker is an optional extension implemented by spawners that can
+// answer "would you refuse this row?" without launching anything. Restart uses
+// it to refuse *before* stopping: restart is stop+spawn, so a row the spawner
+// would reject must never lose its running process to a doomed respawn.
+// Implementations must be pure and side-effect free.
+type RunnerSpawnChecker interface {
+	CanSpawn(session centralstore.Session) error
+}
+
 // RunnerSpawnCleaner is an optional extension implemented by spawners that
 // retain an exact process handle. It is invoked when replacement registration
 // fails, so a child that never became coordinator-owned cannot leak. Cleanup
@@ -278,10 +287,16 @@ func (c *Coordinator) Resume(ctx context.Context, id centralstore.SessionID) (Ru
 		return Runtime{}, err
 	}
 	defer release()
-	return c.resumeClaimed(ctx, id, cl)
+	return c.resumeClaimed(ctx, id, cl, nil)
 }
 
-func (c *Coordinator) resumeClaimed(ctx context.Context, id centralstore.SessionID, cl *LifecycleClaim) (Runtime, error) {
+// resumeClaimed spawns under an already-held claim. authorized, when non-nil,
+// is the row snapshot the caller's decision was made against (Restart reads it
+// before the stop): the spawn then uses that snapshot instead of re-reading,
+// so a runner fact landing between the decision and the spawn — fact events do
+// not take the lifecycle claim — cannot flip the relaunch verdict under the
+// operation and strand a stopped session.
+func (c *Coordinator) resumeClaimed(ctx context.Context, id centralstore.SessionID, cl *LifecycleClaim, authorized *centralstore.Session) (Runtime, error) {
 	if _, live := c.registry.current(id); live {
 		return Runtime{}, fmt.Errorf("%w: %s", ErrSessionAlive, id)
 	}
@@ -291,6 +306,13 @@ func (c *Coordinator) resumeClaimed(ctx context.Context, id centralstore.Session
 	}
 	if !ok {
 		return Runtime{}, fmt.Errorf("%w: %s", centralstore.ErrSessionNotFound, id)
+	}
+	if authorized != nil {
+		// Keep the fresh row's convergence/liveness facts below, but spawn
+		// exactly what was authorized.
+		session.Adapter = authorized.Adapter
+		session.ConversationRef = authorized.ConversationRef
+		session.Command = append([]string(nil), authorized.Command...)
 	}
 	if session.ExitedAt == nil {
 		c.mu.Lock()
@@ -354,10 +376,25 @@ func (c *Coordinator) Restart(ctx context.Context, id centralstore.SessionID) (R
 		return Runtime{}, err
 	}
 	defer release()
+	// Decide against one snapshot, taken under the claim and *before* the
+	// stop, and carry it into the spawn. Without this, restart is a kill with
+	// extra steps whenever the spawner would refuse the row it re-reads.
+	authorized, ok, err := c.durable.Session(ctx, id)
+	if err != nil {
+		return Runtime{}, err
+	}
+	if !ok {
+		return Runtime{}, fmt.Errorf("%w: %s", centralstore.ErrSessionNotFound, id)
+	}
+	if checker, ok := c.spawner.(RunnerSpawnChecker); ok {
+		if err := checker.CanSpawn(authorized); err != nil {
+			return Runtime{}, fmt.Errorf("sessioncoord: restart refused for %s (session left running): %w", id, err)
+		}
+	}
 	if _, live := c.registry.current(id); live {
 		if err := c.stopClaimed(ctx, id); err != nil {
 			return Runtime{}, err
 		}
 	}
-	return c.resumeClaimed(ctx, id, cl)
+	return c.resumeClaimed(ctx, id, cl, &authorized)
 }

--- a/services/gmuxd/internal/sessioncoord/restart_atomicity_test.go
+++ b/services/gmuxd/internal/sessioncoord/restart_atomicity_test.go
@@ -1,0 +1,131 @@
+package sessioncoord
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/centralstore"
+)
+
+// checkingSpawner is a spawner that answers the pre-stop question the same way
+// it answers the spawn: it refuses any row carrying a conversation ref it
+// cannot resolve. That is the production shape (productionRunnerSpawner.CanSpawn
+// and Spawn share one resolver), reduced to what the ordering tests need.
+type checkingSpawner struct {
+	mu       sync.Mutex
+	calls    []centralstore.Session
+	endpoint string
+	// refuse reports whether the spawner would decline this row.
+	refuse func(centralstore.Session) bool
+}
+
+func (s *checkingSpawner) refuses(row centralstore.Session) bool {
+	return s.refuse != nil && s.refuse(row)
+}
+
+func (s *checkingSpawner) CanSpawn(row centralstore.Session) error {
+	if s.refuses(row) {
+		return errors.New("cannot be resumed: conversation not resolvable")
+	}
+	return nil
+}
+
+func (s *checkingSpawner) Spawn(_ context.Context, row centralstore.Session) (string, error) {
+	s.mu.Lock()
+	s.calls = append(s.calls, row)
+	s.mu.Unlock()
+	if s.refuses(row) {
+		return "", errors.New("cannot be resumed: conversation not resolvable")
+	}
+	return s.endpoint, nil
+}
+
+func (s *checkingSpawner) spawned() []centralstore.Session {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]centralstore.Session(nil), s.calls...)
+}
+
+// TestRestartRefusesBeforeStoppingWhenTheSpawnerWouldRefuse pins the ordering,
+// not the value: a row the spawner declines must keep its running process.
+// Moving the check after the stop (or after Restart's spawn) fails here,
+// because the terminate would have been issued and the live entry lost.
+func TestRestartRefusesBeforeStoppingWhenTheSpawnerWouldRefuse(t *testing.T) {
+	id := sid(360)
+	client := newFakeClient(RunnerMeta{Registration: centralstore.RunnerRegistration{ID: id, Alive: true}})
+	dur := newFakeDurable(0)
+	live := centralstore.Session{ID: id, Version: 2, Adapter: "claude", Command: []string{"claude"}, ConversationRef: "/gone.jsonl"}
+	dur.session = func(centralstore.SessionID) (centralstore.Session, bool, error) { return live, true, nil }
+	// Errors if called at all, so a check moved after the stop surfaces as a
+	// terminate failure instead of blocking on a death this fake never reports.
+	control := &fakeControl{err: errors.New("terminate must not be issued for a refused restart")}
+	spawner := &checkingSpawner{endpoint: "ep360", refuse: func(row centralstore.Session) bool { return row.ConversationRef != "" }}
+	coord := New(nil, client, dur, &fakeDirtySink{}, nil, WithRunnerControl(control), WithRunnerSpawner(spawner))
+
+	registerLive(t, coord, "ep360")
+	_, err := coord.Restart(context.Background(), id)
+	if err == nil {
+		t.Fatal("restart of a row the spawner refuses must fail")
+	}
+	if !strings.Contains(err.Error(), "session left running") {
+		t.Errorf("error %q must say the session was left running", err)
+	}
+	if control.count() != 0 {
+		t.Errorf("terminate issued %d time(s): restart stopped a session it could not respawn", control.count())
+	}
+	if n := len(spawner.spawned()); n != 0 {
+		t.Errorf("spawn attempted %d time(s) after a refusal", n)
+	}
+	if len(coord.Registry().Snapshot()) != 1 {
+		t.Fatal("the live runner must survive a refused restart")
+	}
+}
+
+// TestRestartSpawnsTheRowItAuthorized is the F3 race, made deterministic: a
+// runner fact (a first-bind conversation_file) lands between the pre-stop
+// decision and the spawn. Fact application does not take the lifecycle claim,
+// so the store row genuinely changes underneath the operation. The spawn must
+// use the row the restart was authorized against, or restart becomes a kill
+// that cannot come back.
+func TestRestartSpawnsTheRowItAuthorized(t *testing.T) {
+	id := sid(361)
+	client := newFakeClient(RunnerMeta{Registration: centralstore.RunnerRegistration{ID: id, Alive: true}})
+	dur := newFakeDurable(0)
+	authorized := centralstore.Session{ID: id, Version: 2, Adapter: "claude", Command: []string{"claude"}}
+	var reads int
+	var mu sync.Mutex
+	dur.session = func(centralstore.SessionID) (centralstore.Session, bool, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		reads++
+		if reads == 1 {
+			return authorized, true, nil // pre-stop: no conversation bound yet
+		}
+		// Post-stop re-read: the hook bound a transcript the adapter cannot
+		// parse yet, which flips the policy branch from rerun to resume.
+		rebound := authorized
+		rebound.ConversationRef = "/fresh-unparseable.jsonl"
+		return rebound, true, nil
+	}
+	control := &fakeControl{}
+	spawner := &checkingSpawner{endpoint: "ep361", refuse: func(row centralstore.Session) bool { return row.ConversationRef != "" }}
+	coord := New(nil, client, dur, &fakeDirtySink{}, nil, WithRunnerControl(control), WithRunnerSpawner(spawner))
+
+	if _, err := coord.Restart(context.Background(), id); err != nil {
+		t.Fatalf("Restart: %v", err)
+	}
+	calls := spawner.spawned()
+	if len(calls) != 1 {
+		t.Fatalf("spawns = %d, want 1", len(calls))
+	}
+	if calls[0].ConversationRef != "" {
+		t.Errorf("spawned with the re-read row (ref %q); the authorized row had none",
+			calls[0].ConversationRef)
+	}
+	if reads < 2 {
+		t.Fatalf("the post-stop re-read never happened (reads=%d); the test no longer exercises the race", reads)
+	}
+}

--- a/services/gmuxd/internal/snapshot/wire/convert.go
+++ b/services/gmuxd/internal/snapshot/wire/convert.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/centralstore"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/peering"
+	"github.com/gmuxapp/gmux/services/gmuxd/internal/relaunch"
 	central "github.com/gmuxapp/gmux/services/gmuxd/internal/snapshot/central"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/statetool"
 )
@@ -22,9 +23,9 @@ type Converter struct {
 	// Titlers maps adapter name → command-title derivation.
 	Titlers map[string]func([]string) string
 	// ResumeCommand derives the resume form of a dead session's command
-	// from its adapter + opaque conversation ref. A nil func or a nil
-	// return keeps the recorded launch command (production
-	// subs.OnExit/Scan parity).
+	// from its adapter + opaque conversation ref. It is only the resolver:
+	// the relaunch *policy* around it (resume vs rerun vs refuse) lives in
+	// package relaunch and is shared verbatim with the runner spawner.
 	ResumeCommand func(adapterName, conversationRef string) []string
 	// IsLocalPeer reports whether a peer name is a Local peer (an
 	// extension of this host whose project stamps the parent owns).
@@ -148,32 +149,40 @@ func (c *Converter) session(row central.SessionRow) Session {
 		out.BinaryHash = row.Runtime.BinaryHash
 	}
 	if !row.Alive {
-		// Resume-command rewriting is presentation/spawn policy, never
-		// durable state: the row keeps the launch command, the wire shows
-		// the resume form (design §3.1). RunnerSpawner applies the same
-		// pure function at spawn.
+		// Relaunch resolution is presentation/spawn policy, never durable
+		// state: the row keeps the launch command, the wire shows what a
+		// relaunch would actually run (design §3.1). RunnerSpawner applies
+		// the same pure function at spawn, so the affordance the UI is
+		// offered and the command the daemon executes cannot disagree.
+		//
 		// The adapter is authoritative for a row that has a conversation
 		// ref: an empty derived command means that conversation cannot be
-		// resumed, and RunnerSpawner — which resolves the same way and
-		// ignores the durable command — will refuse to spawn. Falling back
-		// to the durable launch command here would advertise a resume the
-		// daemon cannot execute, so the row shows no command instead.
-		if c.ResumeCommand != nil && v.ConversationRef != "" {
-			out.Command = c.ResumeCommand(v.Adapter, v.ConversationRef)
+		// resumed, and the row is not relaunchable at all. A row with no
+		// conversation ref (every shell and editor session, plus agents
+		// that died before their hook bound one) can still be rerun from
+		// its recorded launch command — a different verb, which the wire
+		// now names instead of leaving clients to guess.
+		cmd, kind := relaunch.Resolve(c.ResumeCommand, v.Adapter, v.ConversationRef, v.Command)
+		if v.ConversationRef != "" {
+			// Adapter-authoritative: an unresolvable conversation shows no
+			// command rather than the stale launch command.
+			out.Command = cmd
 		}
 		// Narrowing: the composer's Resumable already folds in the verdict
-		// (dead ∧ durable command ∧ verdict ≠ Gone). Recompute the command
-		// term against the rewritten command so a row whose durable command
-		// is empty but whose conversation still resolves to a resume form
-		// becomes resumable — production parity, where Resumable derives
-		// from the post-rewrite command.
-		gone := len(v.Command) > 0 && !row.Resumable
-		out.Resumable = len(out.Command) > 0 && !gone
+		// (dead ∧ durable command ∧ verdict ≠ Gone, and never-started rows).
+		// A Gone conversation — or a row that never ran — offers nothing,
+		// whichever verb the policy would otherwise have picked.
+		if gone := len(v.Command) > 0 && !row.Resumable; gone {
+			kind = relaunch.None
+		}
+		out.Relaunch = string(kind)
+		out.Resumable = kind != relaunch.None
 	}
 	if row.Session.DismissedAt != nil {
 		// Defensive: ReadSnapshot filters dismissed rows (FD-2); a row that
 		// slips through must still never reach the wire.
 		out.Resumable = false
+		out.Relaunch = ""
 	}
 	return out
 }

--- a/services/gmuxd/internal/snapshot/wire/convert_test.go
+++ b/services/gmuxd/internal/snapshot/wire/convert_test.go
@@ -248,6 +248,54 @@ func TestResumeCommandRewrite(t *testing.T) {
 	}
 }
 
+// TestRelaunchVerbOnTheWire pins the verb the UI reads. It is the daemon's
+// answer to "what will POST /resume actually do?", and it must never claim
+// a verb the runner spawner would refuse (relaunch.Resolve decides for both).
+func TestRelaunchVerbOnTheWire(t *testing.T) {
+	resolver := func(adapter, ref string) []string {
+		if ref == "known-ref" {
+			return []string{adapter, "resume", ref}
+		}
+		return nil
+	}
+	conv := &Converter{ResumeCommand: resolver}
+
+	for _, tc := range []struct {
+		name string
+		mut  func(*central.SessionRow)
+		want string
+	}{
+		{"agent with a resumable conversation", func(r *central.SessionRow) {
+			r.Session.ConversationRef = "known-ref"
+		}, "resume"},
+		{"shell with no conversation reruns its command", func(*central.SessionRow) {}, "rerun"},
+		{"conversation the adapter cannot resume", func(r *central.SessionRow) {
+			r.Session.ConversationRef = "gone-ref"
+		}, ""},
+		{"verdict-gone row offers nothing", func(r *central.SessionRow) {
+			r.Resumable = false
+		}, ""},
+		{"no command and no conversation", func(r *central.SessionRow) {
+			r.Session.Command = nil
+		}, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := conv.session(localRow("1relaun1", false, tc.mut))
+			if got.Relaunch != tc.want {
+				t.Errorf("relaunch = %q, want %q", got.Relaunch, tc.want)
+			}
+			if got.Resumable != (tc.want != "") {
+				t.Errorf("resumable = %v, want %v (must agree with relaunch)", got.Resumable, tc.want != "")
+			}
+		})
+	}
+
+	// Alive rows carry no relaunch verb: the offered action is Restart.
+	if got := conv.session(localRow("1relaun2", true)); got.Relaunch != "" {
+		t.Errorf("alive row relaunch = %q, want empty", got.Relaunch)
+	}
+}
+
 func lpPlacement(peer, sess, slug, scope string, pos int) central.LocalPeerPlacementRow {
 	return central.LocalPeerPlacementRow{LocalPeerPlacementView: centralstore.LocalPeerPlacementView{
 		PeerKey: centralstore.PeerKey(peer), SessionID: sess, ProjectSlug: slug, SiblingScope: scope, Position: pos,

--- a/services/gmuxd/internal/snapshot/wire/equivalence/equivalence_test.go
+++ b/services/gmuxd/internal/snapshot/wire/equivalence/equivalence_test.go
@@ -20,9 +20,17 @@ import (
 // facts added after the legacy production composer was retired. Those family
 // fields are covered directly by wire converter tests; the legacy store has no
 // promoted bit or adapter capability map with which to produce them.
+//
+// `relaunch` joins that list: it is an additive field naming which relaunch
+// verb the daemon will honor, added after the legacy composer was retired
+// (which is exactly why the legacy `resumable` flag could disagree with the
+// spawner). Its derivation is covered by wire converter tests and by
+// TestRelaunchDerivationPresentationMatchesSpawn.
 func fdExcluded(path string) bool {
 	switch {
 	case strings.HasSuffix(path, ".semantic_agent"):
+		return true
+	case strings.HasSuffix(path, ".relaunch"):
 		return true
 	case strings.HasSuffix(path, ".project_index"):
 		return true

--- a/services/gmuxd/internal/snapshot/wire/wire.go
+++ b/services/gmuxd/internal/snapshot/wire/wire.go
@@ -13,12 +13,15 @@
 //     (internal/store/store.go resolveTitle): adapter title > shell title >
 //     CommandTitler(command) > adapter name.
 //   - Timestamps: durable Unix-ms → RFC3339 at second precision (FD-4).
-//   - Resume-command rewriting for dead rows as a pure function of
-//     (adapter, conversation ref); the durable row keeps the launch
-//     command (design §3.1 — one function, two call sites, zero
-//     persistence).
-//   - Resumable narrowing: dead ∧ command present ∧ verdict ≠ Gone (the
-//     composer's overlay), recomputed against the rewritten command.
+//   - Relaunch resolution for dead rows as a pure function of (adapter,
+//     conversation ref, recorded command) — relaunch.Resolve, the very
+//     function the runner spawner executes (design §3.1 — one function,
+//     two call sites, zero persistence). It yields both the rewritten
+//     command and the verb: "resume" continues a recorded agent
+//     conversation, "rerun" launches the recorded command again (all a
+//     dead shell can do).
+//   - Resumable narrowing: dead ∧ relaunchable ∧ verdict ≠ Gone (the
+//     composer's overlay), recomputed against the resolved command.
 //   - project_index: FD-1 flatten of the durable scoped ordering into the
 //     legacy per-project flat integer.
 package wire
@@ -40,10 +43,19 @@ type Status struct {
 }
 
 // Session is the exact ADR 0001 session wire shape — field-for-field the
-// wire struct inside store.Session.MarshalJSON (internal/store/store.go).
+// wire struct inside store.Session.MarshalJSON (internal/store/store.go),
+// plus the additive Relaunch verdict.
 // It is also the shape of a peer-session projection as received from a
 // peer's own snapshot.sessions feed, which is why the peer overlay
 // (PeerSessionSource) traffics in this type verbatim.
+//
+// Relaunch is the owning daemon's answer to "what will you do if I POST
+// /resume?" — "resume" (continue the recorded conversation), "rerun" (run
+// the recorded command again), or empty for "refuse". Clients must not
+// re-derive it from adapter names: only the owner can resolve its adapters'
+// conversations, and disagreement is how the UI came to offer resumes the
+// daemon then rejected. Empty also covers a peer running a pre-field daemon,
+// where clients fall back to Resumable alone.
 type Session struct {
 	ID                    string            `json:"id"`
 	Peer                  string            `json:"peer,omitempty"`
@@ -68,6 +80,7 @@ type Session struct {
 	Unread                bool              `json:"unread"`
 	UnreadToken           string            `json:"unread_token"`
 	Resumable             bool              `json:"resumable,omitempty"`
+	Relaunch              string            `json:"relaunch,omitempty"` // "resume" | "rerun" | "" (refused / pre-field peer)
 	SocketPath            string            `json:"socket_path,omitempty"`
 	TerminalCols          uint16            `json:"terminal_cols,omitempty"`
 	TerminalRows          uint16            `json:"terminal_rows,omitempty"`


### PR DESCRIPTION
## The bug

A dead shell session in the sidebar offers a relaunch; clicking it fails:

```
Resume failed: sessioncoord: resume spawn for b75zx03g: runner spawn: session b75zx03g is not resumable
```

Two predicates disagreed:

| Side | Predicate (before) |
|---|---|
| Presentation → `resumable` → the button | dead ∧ recorded `command` ∧ verdict ≠ Gone (`snapshot/wire/convert.go:161-171`) |
| Execution → `POST /resume` → runner spawn | `ResolveResumeCommandFor(adapter, conversationRef)` non-empty (`serve_central.go:301`, `bootstrap_runner_adapters.go:437`) |

They agree only when the row has a conversation ref. A shell never has one —
the ref comes solely from the agent hook's `conversation_file` event — so
**every dead shell was advertised as relaunchable and refused at spawn**. Same
for `editor` and for any agent that died before its hook bound a conversation.
The pre-existing agreement test only covered rows that *do* have a ref.

Reproduced on disposable daemons, locally and across a peer. Two extras found:

- **Restart destroyed live shells**: restart is stop + the same spawn, so the
  stop succeeded and the respawn refused.
- The peer path was *not* broken: the request is forwarded and the owning
  daemon produced the error. The peer projection just faithfully relayed the
  owner's own wrong `resumable`.

## The fix

**One policy, both sides.** New dependency-free leaf
`services/gmuxd/internal/relaunch`: a conversation ref that resolves →
`resume`; a ref that resolves to nothing → refuse (the adapter is
authoritative; the user asked for *that* conversation); no ref but a recorded
command → `rerun`. The wire converter and the runner spawner both call it.

**A truthful affordance on the wire.** Additive `relaunch: "resume" | "rerun"`
(omitted = the daemon will refuse) on `wire.Session` and on the peer
projection, so a peer row carries the *owning* daemon's verdict. `resumable`
keeps exactly its old value — sidebar visibility is unchanged.

**The UI reads the verdict instead of guessing it** from an adapter-name
allowlist (kept only as the fallback for peers on older daemons), and routes
the verb into the toast: a failed rerun says "Rerun failed", not "Resume
failed".

**Restart refuses before stopping**, so it can no longer be a kill with extra
steps, and the remaining refusals are actionable:
`… cannot be resumed: its pi conversation (/path.jsonl) is missing, empty, or
no longer resumable by the adapter`.

## Verification

- `go test -race ./...` green across gmuxd/cli/adapter/paths. New: relaunch
  policy table; `TestRelaunchVerbOnTheWire`;
  `TestRelaunchDerivationPresentationMatchesSpawn` (presentation ⇔ spawn for
  ref-less rows across shell/editor/claude/codex/pi/unknown — the systemic
  guard); guard-message and restart-guard tests.
- Web: vitest 870 green, `tsc --noEmit` clean, biome clean.
  `session-actions.test.ts` rewritten around the wire verdict + legacy
  fallback.
- e2e: new `relaunch-affordance.spec.ts` covers a dead **local** shell and a
  dead **peer** shell (the spec starts and tears down a second isolated
  gmuxd): button shown ⇔ says "Rerun" ⇔ click brings the session back alive on
  the *owning* daemon. Full Playwright suite 112 passed. Reverting just the
  spawner wiring makes the new spec fail, so it guards the reported bug.
- Docs: `develop/session-schema.md`, `architecture.md`, `using-the-ui.md`.
