### PR TITLE
fix(web): patch-release polish — resize refusal, day labels, wake retry, dep trim

### DIFF
--- a/apps/gmux-web/package.json
+++ b/apps/gmux-web/package.json
@@ -18,7 +18,6 @@
     "@gmux/protocol": "workspace:*",
     "@gmux/scroll-anchor": "workspace:*",
     "@preact/signals": "^2.9.0",
-    "@trpc/client": "^11.6.0",
     "@xterm/addon-fit": "0.12.0-beta.288",
     "@xterm/addon-search": "0.17.0-beta.288",
     "@xterm/addon-image": "github:gmuxapp/xterm.js#v6.1.0-beta.288-gmux.5&path:addons/addon-image",

--- a/apps/gmux-web/src/day-boundary.test.ts
+++ b/apps/gmux-web/src/day-boundary.test.ts
@@ -1,0 +1,121 @@
+/** Day-relative labels ("Today", "Yesterday", "Last <weekday>") are a
+ * function of the wall clock, but every other trigger in the store is a
+ * function of *data*. #518's incremental reconciliation made that gap
+ * observable: an identical snapshot commits as a no-op, and a quiet tab
+ * commits nothing at all, so a sidebar left open across midnight kept
+ * calling yesterday "Today" until some unrelated update arrived.
+ *
+ * watchDayBoundary is the clock trigger: one timer per app lifetime, armed
+ * for the next local midnight, re-armed after it fires, cleared on unmount.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  _rawSessions, _setRawWorld, homePartition, sessionsLoaded, urlHash, urlPath,
+  urlSearch, watchDayBoundary, worldLoaded,
+} from './store'
+import { makeSession } from './test-helpers'
+
+;(globalThis as { window?: unknown }).window ??= globalThis
+
+// Local (not UTC) parts: the partition computes calendar days in local time.
+const NOW = new Date(2026, 0, 12, 15, 0, 0).getTime()
+const HOUR = 60 * 60 * 1000
+
+beforeEach(() => {
+  vi.useFakeTimers({ now: NOW })
+  _setRawWorld({ projects: [], peers: [], peerProjects: {} })
+  _rawSessions.value = [makeSession({
+    id: 'a', cwd: '/x', alive: true, last_output_at: new Date(NOW - HOUR).toISOString(),
+  })]
+  sessionsLoaded.value = true
+  worldLoaded.value = true
+  urlPath.value = '/'
+  urlSearch.value = ''
+  urlHash.value = ''
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  _rawSessions.value = []
+})
+
+const labels = () => homePartition.value.map(b => ({ label: b.label, kind: b.kind }))
+
+describe('watchDayBoundary', () => {
+  it('relabels the buckets at the next local midnight without any snapshot', () => {
+    const stop = watchDayBoundary()
+    expect(labels()).toEqual([{ label: null, kind: 'today' }])
+
+    // Just before midnight: nothing has moved yet.
+    vi.advanceTimersByTime(8 * HOUR + 59 * 60 * 1000)
+    expect(labels()).toEqual([{ label: null, kind: 'today' }])
+
+    // Across midnight, with no store mutation of any kind.
+    vi.advanceTimersByTime(2 * 60 * 1000)
+    expect(labels()).toEqual([{ label: 'Yesterday', kind: 'named' }])
+    stop()
+  })
+
+  it('re-arms, so a second midnight also relabels', () => {
+    const stop = watchDayBoundary()
+    vi.advanceTimersByTime(9 * HOUR + 60 * 1000)
+    expect(labels()).toEqual([{ label: 'Yesterday', kind: 'named' }])
+
+    vi.advanceTimersByTime(24 * HOUR)
+    expect(labels()).toEqual([{ label: expect.stringMatching(/^Last /), kind: 'named' }])
+    stop()
+  })
+
+  it('does not poll: exactly one timer is pending at a time', () => {
+    const stop = watchDayBoundary()
+    expect(vi.getTimerCount()).toBe(1)
+    vi.advanceTimersByTime(9 * HOUR + 60 * 1000)
+    expect(vi.getTimerCount()).toBe(1)
+    stop()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('stops on unmount: a cleared watch never relabels', () => {
+    const stop = watchDayBoundary()
+    // Read once so the projection is cached at this clock, then unmount:
+    // without the timer's signal write nothing invalidates it again.
+    expect(labels()).toEqual([{ label: null, kind: 'today' }])
+    stop()
+    vi.advanceTimersByTime(48 * HOUR)
+    expect(labels()).toEqual([{ label: null, kind: 'today' }])
+  })
+})
+
+// The arm target is computed from calendar parts (new Date(y, m, d + 1)) rather
+// than "+24h" precisely so a DST day still lands on local midnight. Pinned in a
+// zone that shifts: 2026-03-08 is the US spring-forward, a 23-hour day.
+describe('watchDayBoundary across a DST transition', () => {
+  const savedTZ = process.env.TZ
+
+  beforeEach(() => { process.env.TZ = 'America/New_York' })
+  afterEach(() => { process.env.TZ = savedTZ })
+
+  it('arms 23 hours for the short day, not 24', () => {
+    // Sat 2026-03-07 22:00 EST. If the process did not pick the zone up, this
+    // fails loudly rather than asserting something vacuous.
+    const start = new Date(2026, 2, 7, 22, 0, 0)
+    expect(start.getTimezoneOffset()).toBe(300) // EST = UTC-5
+    vi.setSystemTime(start)
+
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout')
+    const stop = watchDayBoundary()
+    const firstDelay = setTimeoutSpy.mock.calls[0][1] as number
+    // 22:00 → 00:00 next day (+1 s of slack), no DST shift in between.
+    expect(firstDelay).toBe(2 * HOUR + 1_000)
+
+    vi.advanceTimersByTime(firstDelay)
+    const secondDelay = setTimeoutSpy.mock.calls[1][1] as number
+    // Sun 2026-03-08 00:00 EST → Mon 2026-03-09 00:00 EDT is 23 hours (the
+    // re-arm runs a second past midnight, so the slack is already spent).
+    expect(secondDelay).toBe(23 * HOUR)
+
+    stop()
+    setTimeoutSpy.mockRestore()
+  })
+})

--- a/apps/gmux-web/src/sse-supervisor.test.ts
+++ b/apps/gmux-web/src/sse-supervisor.test.ts
@@ -115,6 +115,98 @@ describe('SSE supervisor', () => {
     expect(sources).toHaveLength(2)
   })
 
+  it('pulls a deep pending retry forward on a wake, without collapsing the backoff', () => {
+    vi.useFakeTimers()
+    const scheduled = vi.fn()
+    const { supervisor, sources } = setup({ onRetryScheduled: scheduled })
+    supervisor.start()
+
+    // Back off to the ceiling: 500, 1000, 2000, 4000 → the pending retry is
+    // 8000 ms (×1.0 jitter here) away.
+    sources[0].emit('error')
+    vi.advanceTimersByTime(500)
+    sources[1].emit('error')
+    vi.advanceTimersByTime(1000)
+    sources[2].emit('error')
+    vi.advanceTimersByTime(2000)
+    sources[3].emit('error')
+    vi.advanceTimersByTime(4000)
+    sources[4].emit('error')
+    expect(sources).toHaveLength(5)
+
+    // The tab wakes 1 s into that 8 s wait. Waiting out the remaining 7 s is
+    // the defect: the wake is fresh evidence, so the attempt happens now.
+    vi.advanceTimersByTime(1000)
+    supervisor.revalidate()
+    vi.advanceTimersByTime(0)
+    expect(sources).toHaveLength(6)
+    expect(sources[4].closed).toBe(true)
+    // The pulled-forward attempt is the only one: the superseded 8 s timer
+    // must not open a second live source when it would have fired.
+    vi.advanceTimersByTime(10_000)
+    expect(sources).toHaveLength(6)
+
+    // Backoff is preserved, not reset: this failure schedules the ceiling
+    // delay again, not the 500 ms floor a manual retry would restore.
+    sources[5].emit('error')
+    vi.advanceTimersByTime(7999)
+    expect(sources).toHaveLength(6)
+    vi.advanceTimersByTime(1)
+    expect(sources).toHaveLength(7)
+  })
+
+  // Wakes must not become the retry clock. Every connect here is a full
+  // protocol-3 bootstrap, so a tab emitting wakes at the store's 1 Hz debounce
+  // ceiling (flapping mobile network: online/visibilitychange/pageshow) must
+  // still reconnect at roughly the backoff's rate, not the wake rate.
+  it('keeps the connect rate near the backoff rate under a sustained wake stream', () => {
+    vi.useFakeTimers()
+    const run = (wakeIntervalMs: number | null) => {
+      const { supervisor, sources } = setup()
+      supervisor.start()
+      // Every attempt fails immediately: the pure backoff schedule.
+      let handled = 0
+      const drain = () => {
+        while (handled < sources.length) sources[handled++].emit('error')
+      }
+      drain()
+      for (let elapsed = 0; elapsed < 60_000; elapsed += 100) {
+        vi.advanceTimersByTime(100)
+        drain()
+        if (wakeIntervalMs !== null && elapsed % wakeIntervalMs === 0) {
+          supervisor.revalidate()
+          drain()
+        }
+      }
+      supervisor.stop()
+      return sources.length
+    }
+
+    const base = run(null)
+    const woken = run(1_000)
+    // Sanity: the unwoken run really is backoff-paced (500 ms → 8 s ceiling).
+    expect(base).toBeLessThan(15)
+    expect(woken).toBeLessThanOrEqual(Math.ceil(base * 1.5))
+  })
+
+  it('leaves a retry that is about to fire alone under a burst of wakes', () => {
+    vi.useFakeTimers()
+    const { supervisor, sources } = setup()
+    supervisor.start()
+    sources[0].emit('error')
+
+    // 500 ms pending: close enough that rescheduling buys nothing, so a
+    // burst of wakes must not churn through sources.
+    supervisor.revalidate()
+    supervisor.revalidate()
+    vi.advanceTimersByTime(0)
+    expect(sources).toHaveLength(1)
+    vi.advanceTimersByTime(500)
+    expect(sources).toHaveLength(2)
+    vi.advanceTimersByTime(10_000)
+    expect(sources).toHaveLength(2)
+  })
+
   it('cancels a pending automatic retry when a manual retry replaces it', () => {
     vi.useFakeTimers()
     const { supervisor, sources } = setup()

--- a/apps/gmux-web/src/sse-supervisor.ts
+++ b/apps/gmux-web/src/sse-supervisor.ts
@@ -47,7 +47,8 @@ export interface SSESupervisor {
  *  - `revalidate()` (a wake) and `retry()` (a tap) are new information and
  *    always open a fresh window, including after exhaustion — a phone that
  *    returns after ten minutes must recover without a tap. They never stack
- *    sources: a pending retry or an in-flight attempt absorbs the wake. A
+ *    sources: a pending retry or an in-flight attempt absorbs the wake, though
+ *    a retry still parked deep in the backoff is pulled forward to now. A
  *    wake refreshes the deadline only; a tap also restores the backoff floor.
  *
  * Lifecycle revalidation replaces only an unhealthy or stale source: after
@@ -55,6 +56,9 @@ export interface SSESupervisor {
  * TCP stream still delivers bytes, but a stream that delivered bytes moments
  * ago needs no new (full) bootstrap.
  */
+/** A pending retry closer than this to firing is left alone on a wake. */
+const wakeRescheduleThresholdMs = 1_000
+
 export function createSSESupervisor(options: SSESupervisorOptions): SSESupervisor {
   const now = options.now ?? Date.now
   const random = options.random ?? Math.random
@@ -66,6 +70,7 @@ export function createSSESupervisor(options: SSESupervisorOptions): SSESuperviso
 
   let source: SSESource | null = null
   let timer: ReturnType<typeof setTimeout> | null = null
+  let timerDueAt = 0
   let lastActivityAt: number | null = null
   let openedAt: number | null = null
   let attemptStartedAt = 0
@@ -73,10 +78,22 @@ export function createSSESupervisor(options: SSESupervisorOptions): SSESuperviso
   let generation = 0
   let attempts = 0
   let retryStartedAt: number | null = null
+  // When a wake last pulled a pending retry forward; bounds that privilege to
+  // once per `maxDelayMs` (cleared whenever the backoff itself is reset).
+  let lastWakePullAt: number | null = null
 
   const clearTimer = () => {
     if (timer !== null) clearTimeout(timer)
     timer = null
+  }
+
+  // Scheduling goes through here so a pending retry's due time is always
+  // known: a wake needs to tell "about to fire" from "parked deep in the
+  // backoff" without reaching into the timer handle.
+  const scheduleConnect = (delay: number) => {
+    clearTimer()
+    timerDueAt = now() + delay
+    timer = setTimeout(connect, delay)
   }
 
   const closeSource = () => {
@@ -128,6 +145,7 @@ export function createSSESupervisor(options: SSESupervisorOptions): SSESuperviso
         if (openedAt !== null && now() - openedAt >= stableOpenDurationMs) {
           attempts = 0
           retryStartedAt = null
+          lastWakePullAt = null
         }
         closeSource()
         if (retryStartedAt === null) retryStartedAt = now()
@@ -141,7 +159,7 @@ export function createSSESupervisor(options: SSESupervisorOptions): SSESuperviso
         // ±20% jitter avoids a set of resumed tabs reconnecting in lockstep.
         const delay = Math.max(0, Math.round(base * (0.8 + random() * 0.4)))
         options.onRetryScheduled?.()
-        timer = setTimeout(connect, delay)
+        scheduleConnect(delay)
       },
     })
     // A test double or an unusual implementation can report failure during
@@ -160,7 +178,7 @@ export function createSSESupervisor(options: SSESupervisorOptions): SSESuperviso
     clearTimer()
     closeSource()
     options.onRetryScheduled?.()
-    timer = setTimeout(connect, 0)
+    scheduleConnect(0)
   }
 
   return {
@@ -169,6 +187,7 @@ export function createSSESupervisor(options: SSESupervisorOptions): SSESuperviso
       stopped = false
       attempts = 0
       retryStartedAt = null
+      lastWakePullAt = null
       connect()
     },
     stop() {
@@ -181,6 +200,7 @@ export function createSSESupervisor(options: SSESupervisorOptions): SSESuperviso
       if (stopped) return
       attempts = 0
       retryStartedAt = null
+      lastWakePullAt = null
       restart()
     },
     revalidate() {
@@ -199,7 +219,30 @@ export function createSSESupervisor(options: SSESupervisorOptions): SSESuperviso
       retryStartedAt = null
       // But it must not pile up sources. A pending retry or an attempt still
       // in flight already covers this wake; it now carries the new budget.
-      if (timer !== null) return
+      if (timer !== null) {
+        // A retry parked deep in the backoff (up to maxDelayMs plus jitter)
+        // would keep a just-woken tab dark for that whole delay, even though
+        // the wake is fresh evidence that the network moved. Pull the pending
+        // attempt forward instead of absorbing the wake silently. `attempts`
+        // is deliberately left grown, so the backoff is not collapsed: if
+        // this attempt fails too, the next delay is still the grown one.
+        // Timers about to fire anyway are left alone — rescheduling them buys
+        // nothing and would only add churn under a burst of wakes.
+        //
+        // And the pull itself is rate-limited to one per `maxDelayMs`. Without
+        // that, wakes — not the backoff — would set the reconnect rate: at the
+        // ceiling every wake more than a second early pulls the retry to now,
+        // the attempt fails, a fresh ceiling-length timer is armed, and the next
+        // wake pulls that one too. A tab emitting wakes at the store's 1 Hz
+        // debounce ceiling would then bootstrap ~1×/s forever, which is the
+        // load-shedding property the backoff exists for.
+        if (timerDueAt - now() > wakeRescheduleThresholdMs
+            && (lastWakePullAt === null || now() - lastWakePullAt >= maxDelayMs)) {
+          lastWakePullAt = now()
+          scheduleConnect(0)
+        }
+        return
+      }
       if (source !== null && source.readyState === 0
           && now() - attemptStartedAt < attemptTimeoutMs) return
       restart()

--- a/apps/gmux-web/src/store.ts
+++ b/apps/gmux-web/src/store.ts
@@ -825,6 +825,39 @@ function refreshDayBoundary(): void {
   if (mid !== dayBoundary.value) dayBoundary.value = mid
 }
 
+/**
+ * Re-evaluate the day-relative labels when the local day actually turns.
+ *
+ * The snapshot seam alone is not enough: a quiet tab (no sessions changing,
+ * no reconnect) commits nothing across midnight, so "Today" would keep
+ * naming yesterday until some unrelated update arrived. This is one timer
+ * armed for the next local midnight, not polling — it fires once a day, does
+ * a single signal write, and re-arms from the real clock afterwards, so a
+ * suspended tab that wakes late still converges on its next tick.
+ *
+ * The target is computed with the Date constructor (not +24h) so a DST
+ * transition still lands on the following local midnight.
+ */
+export function watchDayBoundary(): () => void {
+  let timer: ReturnType<typeof setTimeout> | null = null
+  const arm = () => {
+    const now = Date.now()
+    const d = new Date(now)
+    const next = new Date(d.getFullYear(), d.getMonth(), d.getDate() + 1).getTime()
+    // A second past midnight: fire inside the new day even if the timer is
+    // nudged early, and never schedule a zero-delay loop.
+    timer = setTimeout(() => {
+      refreshDayBoundary()
+      arm()
+    }, Math.max(1_000, next + 1_000 - now))
+  }
+  arm()
+  return () => {
+    if (timer !== null) clearTimeout(timer)
+    timer = null
+  }
+}
+
 /** The single source of truth for which sessions are eligible for the
  *  sidebar. Projects places this list into configured folders; Activity
  *  rearranges that placed set, so unstamped/unreferenced sessions that
@@ -2376,6 +2409,10 @@ export function initStore(): () => void {
     }
   })
   cleanups.push(disposeSidebarRepair)
+
+  // Day-relative sidebar/home labels are a function of the wall clock, so
+  // they need a clock trigger of their own — snapshot commits are not one.
+  cleanups.push(watchDayBoundary())
 
   if (USE_MOCK) {
     const localHost = new URLSearchParams(location.search).get('host')

--- a/apps/gmux-web/src/terminal-resize.test.ts
+++ b/apps/gmux-web/src/terminal-resize.test.ts
@@ -1,5 +1,32 @@
 import { describe, expect, test } from 'vitest'
-import { decideViewportResize, sameSize, shouldQueueResizeEcho } from './terminal-resize'
+import { decideViewportResize, sameSize, shouldQueueResizeEcho, terminalGridSize } from './terminal-resize'
+
+describe('terminalGridSize', () => {
+  test('refuses a viewport that cannot fit the minimum grid', () => {
+    // A transiently tiny container (keyboard animation, collapsed pane) must
+    // not become a 1-row PTY resize.
+    expect(terminalGridSize(800, 19, 10, 20)).toBeNull()
+    expect(terminalGridSize(800, 0, 10, 20)).toBeNull()
+    expect(terminalGridSize(800, -40, 10, 20)).toBeNull()
+    expect(terminalGridSize(19, 400, 10, 20)).toBeNull()
+    expect(terminalGridSize(0, 400, 10, 20)).toBeNull()
+  })
+
+  test('refuses when cell metrics are not measurable yet', () => {
+    expect(terminalGridSize(800, 400, 0, 20)).toBeNull()
+    expect(terminalGridSize(800, 400, 10, 0)).toBeNull()
+  })
+
+  test('measures at and above the minimum boundary', () => {
+    expect(terminalGridSize(20, 20, 10, 20)).toEqual({ cols: 2, rows: 1 })
+    expect(terminalGridSize(800, 400, 10, 20)).toEqual({ cols: 80, rows: 20 })
+  })
+
+  test('rounds rows up in overlay-bar mode, but still refuses sub-cell height', () => {
+    expect(terminalGridSize(85, 45, 10, 20, Math.ceil)).toEqual({ cols: 8, rows: 3 })
+    expect(terminalGridSize(85, 19, 10, 20, Math.ceil)).toBeNull()
+  })
+})
 
 describe('sameSize', () => {
   test('matches identical sizes and suppresses an echo already applied by a claim barrier', () => {
@@ -53,6 +80,25 @@ describe('decideViewportResize', () => {
       awaitingEcho: false,
       forceDrive: true,
     })).toEqual({ kind: 'drive', size: { cols: 120, rows: 40 } })
+  })
+
+  // Why a refused measurement must never be committed as the viewport
+  // (terminal.tsx `processViewportResize`): drive/follow is derived from
+  // sameSize(prevViewport, ptySize), so a null prevViewport makes the *next*
+  // real measurement passive — the terminal stays at the stale grid behind the
+  // reclaim pill. Collapse → settle-at-a-different-size is the mobile keyboard
+  // case, so this is the difference between self-healing and needing a tap.
+  test('a forgotten viewport turns the next real measurement passive', () => {
+    const pty = { cols: 80, rows: 24 }
+    const settled = { cols: 80, rows: 12 }
+    // What committing the refusal would do:
+    expect(decideViewportResize({
+      prevViewport: null, ptySize: pty, newViewport: settled, awaitingEcho: false,
+    })).toEqual({ kind: 'follow', size: pty })
+    // What keeping the last known viewport does:
+    expect(decideViewportResize({
+      prevViewport: pty, ptySize: pty, newViewport: settled, awaitingEcho: false,
+    })).toEqual({ kind: 'drive', size: settled })
   })
 
   test('follows the PTY when passive', () => {

--- a/apps/gmux-web/src/terminal-resize.ts
+++ b/apps/gmux-web/src/terminal-resize.ts
@@ -1,5 +1,32 @@
 import type { TerminalSize } from './terminal-io'
 
+/**
+ * Convert available pixels into a terminal grid, or refuse.
+ *
+ * Refusing (null) is the point. A container can transiently measure smaller
+ * than a single cell — a collapsed pane, a flex child mid-relayout, the
+ * mobile keyboard animating in — and clamping that to the minimum grid would
+ * publish a real 1-row (or 2-column) resize to the PTY, reflowing the
+ * running program for a layout state the user never saw. The caller treats
+ * null as "no measurement yet" and retries on the next usable layout, which
+ * is exactly what the initial-claim retry path already does for a terminal
+ * whose cell metrics have not settled.
+ */
+export function terminalGridSize(
+  availW: number,
+  availH: number,
+  cellWidth: number,
+  cellHeight: number,
+  roundRows: (value: number) => number = Math.floor,
+): TerminalSize | null {
+  if (!(cellWidth > 0) || !(cellHeight > 0)) return null
+  if (availW < cellWidth * 2 || availH < cellHeight) return null
+  return {
+    cols: Math.max(2, Math.floor(availW / cellWidth)),
+    rows: Math.max(1, roundRows(availH / cellHeight)),
+  }
+}
+
 export function sameSize(a: TerminalSize | null, b: TerminalSize | null): boolean {
   return a != null && b != null && a.cols === b.cols && a.rows === b.rows
 }

--- a/apps/gmux-web/src/terminal.tsx
+++ b/apps/gmux-web/src/terminal.tsx
@@ -21,7 +21,7 @@ import { TerminalFindBar } from './terminal-find'
 import { canSendTerminalInput } from './terminal-input'
 import { createTerminalIO, type TerminalSize } from './terminal-io'
 import { type LinkInfo, linkAtPoint, openLinkAtPoint } from './terminal-link'
-import { decideViewportResize, sameSize, shouldQueueResizeEcho } from './terminal-resize'
+import { decideViewportResize, sameSize, shouldQueueResizeEcho, terminalGridSize } from './terminal-resize'
 import { pressedBufferRow, readTerminalText } from './terminal-text'
 import { TerminalTextSheet } from './terminal-text-sheet'
 import { pushError } from './toasts'
@@ -159,8 +159,20 @@ function measureTerminalFit(
   const availW = shellEl.offsetWidth - padX - reserveWidth
   const availH = shellEl.offsetHeight - padY - overlayBar
 
-  let cols = Math.max(2, Math.floor(availW / dims.css.cell.width))
-  let rows = Math.max(1, (overlayBar > 0 ? Math.ceil : Math.floor)(availH / dims.css.cell.height))
+  // Refuse a non-viable measurement instead of clamping it to the minimum
+  // grid: a container that transiently measures below one cell (keyboard
+  // animation, collapsed pane, mid-relayout flex child) must not publish a
+  // 1-row/2-column resize to the PTY and reflow the running program. Callers
+  // treat null as "not measurable yet" and re-measure on the next layout.
+  const grid = terminalGridSize(
+    availW,
+    availH,
+    dims.css.cell.width,
+    dims.css.cell.height,
+    overlayBar > 0 ? Math.ceil : Math.floor,
+  )
+  if (!grid) return null
+  let { cols, rows } = grid
 
   // Guard against 1px overflow: xterm computes screen width as
   // Math.round(device.cell.width * cols / dpr). Because css.cell.width is
@@ -442,6 +454,15 @@ export function TerminalView({
     if (!term || !shell) return
 
     const newVp = measureTerminalFit(term, shell)
+    // A refusal is *no information*, not a new viewport. Committing it would
+    // clear `prevViewport`, and drive/follow is derived from
+    // sameSize(prevViewport, ptySize) — so the next real measurement would be
+    // judged 'follow' and the terminal would sit at the stale grid behind the
+    // reclaim pill until the user taps it. That is exactly the mobile case
+    // this guard exists for: the keyboard passes through a non-viable height
+    // and settles at a *different* viable one. Keep the last known viewport
+    // and wait for the next layout notification instead.
+    if (!newVp) return
     const gate = resizeEchoGateRef.current
     const decision = decideViewportResize({
       prevViewport: viewportSizeRef.current,
@@ -484,8 +505,11 @@ export function TerminalView({
     if (!term || !shell) return
 
     const dims = measureTerminalFit(term, shell)
-    setViewportSize(dims); viewportSizeRef.current = dims
+    // Same rule as processViewportResize: never commit a refusal. Here it also
+    // keeps the pill on screen (it is gated on a non-null viewport), so a tap
+    // that lands mid-relayout can simply be tapped again.
     if (!dims) return
+    setViewportSize(dims); viewportSizeRef.current = dims
 
     applyOwnedResize(dims)
   }, [applyOwnedResize])
@@ -497,8 +521,11 @@ export function TerminalView({
     const shell = shellRef.current
     if (!term || !shell) return null
     const dims = measureTerminalFit(term, shell)
-    setViewportSize(dims); viewportSizeRef.current = dims
+    // A refused claim measurement is retried by watchForClaimMeasurement and
+    // falls back to checkpoint geometry on its deadline; it must not overwrite
+    // the viewport state with null on the way there.
     if (!dims) return null
+    setViewportSize(dims); viewportSizeRef.current = dims
     // A claim is also the ownership assertion and reconnect-redraw trigger,
     // so it must reach the runner even when checkpoint and viewport match.
     applyOwnedResize(dims, false, true)

--- a/e2e/tests/terminal-resize.spec.ts
+++ b/e2e/tests/terminal-resize.spec.ts
@@ -1,5 +1,12 @@
 import { test, expect } from '@playwright/test'
-import { getTermState, isPillVisible, openApp, gotoTestSession } from '../helpers'
+import { apiGet, getTermState, isPillVisible, openApp, gotoTestSession, pollUntil } from '../helpers'
+
+async function ptySize(): Promise<{ cols?: number, rows?: number }> {
+  const id = process.env.GMUX_TEST_SESSION_ID!
+  const r = await apiGet<{ data: Array<{ id: string, terminal_cols?: number, terminal_rows?: number }> }>('/v1/sessions')
+  const s = r.body.data.find(x => x.id === id)
+  return { cols: s?.terminal_cols, rows: s?.terminal_rows }
+}
 
 test.describe('terminal resize', () => {
   test.beforeEach(async ({ page }) => {
@@ -32,6 +39,42 @@ test.describe('terminal resize', () => {
     expect(large.termCols!).toBeGreaterThan(small.termCols!)
     expect(large.termRows!).toBeGreaterThan(small.termRows!)
     // Driving the whole time → no pill.
+    expect(await isPillVisible(page)).toBe(false)
+  })
+
+  // The mobile-keyboard shape: the terminal shell passes through a height
+  // below one cell and settles at a *different* viable height. Two failure
+  // modes are pinned at once — a 1-row PTY resize while collapsed (the clamp
+  // bug), and a terminal stranded at the stale grid behind the reclaim pill
+  // afterwards (what committing the refusal as the viewport would cause).
+  test('a shell that collapses below one cell and settles smaller self-heals', async ({ page }) => {
+    const before = await getTermState(page)
+    expect(before.termRows!).toBeGreaterThan(4)
+
+    const setShellHeight = (flex: string) => page.evaluate((value) => {
+      const shell = document.querySelector('.terminal-shell') as HTMLElement
+      shell.style.flex = value
+    }, flex)
+
+    // Collapse below one cell (~17 px) and give the resize path time to run.
+    await setShellHeight('0 0 8px')
+    await page.waitForTimeout(600)
+    const collapsed = await ptySize()
+    expect(collapsed.rows, 'a non-viable measurement must not reach the PTY')
+      .toBe(before.termRows)
+
+    // Settle at a viable but different height.
+    await setShellHeight('0 0 300px')
+    const settled = await pollUntil(async () => {
+      const state = await getTermState(page)
+      return state.termRows !== before.termRows ? state : null
+    }, { timeoutMs: 5_000, description: 'terminal refits after the shell settles' })
+
+    expect(settled.termRows!).toBeGreaterThan(1)
+    expect(settled.termRows!).toBeLessThan(before.termRows!)
+    // Still driving: the PTY followed us down and no reclaim tap is needed.
+    await pollUntil(async () => (await ptySize()).rows === settled.termRows || null,
+      { timeoutMs: 5_000, description: 'PTY follows the settled viewport' })
     expect(await isPillVisible(page)).toBe(false)
   })
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,9 +47,6 @@ importers:
       '@preact/signals':
         specifier: ^2.9.0
         version: 2.9.0(preact@10.29.0)
-      '@trpc/client':
-        specifier: ^11.6.0
-        version: 11.12.0(@trpc/server@11.12.0(typescript@5.9.3))(typescript@5.9.3)
       '@xterm/addon-fit':
         specifier: 0.12.0-beta.288
         version: 0.12.0-beta.288(@xterm/xterm@https://codeload.github.com/gmuxapp/xterm.js/tar.gz/baeffe1f08c007e194c842b0f913665a48643c19)
@@ -1188,17 +1185,6 @@ packages:
 
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
-
-  '@trpc/client@11.12.0':
-    resolution: {integrity: sha512-zTwFKQdE99pvNm7kXFdHo5xIQpGqpQJHtqVkT9o+i8h/0fbDOUBEEbFVICiMsNA+GiXskoaDRX2l+z6ir+Ug3w==}
-    peerDependencies:
-      '@trpc/server': 11.12.0
-      typescript: '>=5.7.2'
-
-  '@trpc/server@11.12.0':
-    resolution: {integrity: sha512-rpZnf5FUjNndE/AjGIy+FvEHR52iBd0u0wySqWCwXj67wraj3qCuBr5Opcf0Te/g67C/YztqceFkLoG0r4mp4Q==}
-    peerDependencies:
-      typescript: '>=5.7.2'
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -4010,15 +3996,6 @@ snapshots:
       '@types/hast': 3.0.4
 
   '@shikijs/vscode-textmate@10.0.2': {}
-
-  '@trpc/client@11.12.0(@trpc/server@11.12.0(typescript@5.9.3))(typescript@5.9.3)':
-    dependencies:
-      '@trpc/server': 11.12.0(typescript@5.9.3)
-      typescript: 5.9.3
-
-  '@trpc/server@11.12.0(typescript@5.9.3)':
-    dependencies:
-      typescript: 5.9.3
 
   '@types/chai@5.2.3':
     dependencies:


### PR DESCRIPTION
Four small, independent web fixes for v2.1.1. No rewrites; each commit stands alone.

## 1. Refuse non-viable terminal measurements instead of clamping to 1 row
`measureTerminalFit` clamped a sub-cell measurement to the minimum grid
(`Math.max(1, …)`), so a transiently tiny container — the mobile keyboard
animating in, a collapsed pane, a flex child mid-relayout — published a real
1-row resize to the PTY and reflowed the running program for a layout the user
never saw.

Restores the refusal from #463 that #466 dropped (#466 fixed the *horizontal*
case with a CSS `min-width`, which left the vertical one unguarded). `null`
already means "not measurable yet" everywhere downstream: the first-claim path
retries on later frames and falls back to checkpoint geometry on its deadline,
so the claim/checkpoint invariants from #484/#502/#509/#514 are untouched.

## 2. Refresh day-relative sidebar labels when the local day turns
"Today"/"Yesterday" were only re-evaluated at a snapshot commit. Since #518 an
identical snapshot commits as a no-op, and a quiet tab commits nothing at all,
so a sidebar left open across midnight kept calling yesterday "Today".

Adds the missing clock trigger: **one** timer armed for the next local midnight
(computed from calendar parts, so DST still lands on the boundary), re-armed
after firing, cleared with the rest of `initStore`'s cleanups. One signal write
per day — not polling.

## 3. Drop the unused `@trpc/client` dependency
Nothing in the repo imports tRPC; the frontend talks REST + SSE + WebSocket.

## 4. Let a wake pull a deep pending SSE retry forward
(From the #522 review.) A wake arriving while a backoff timer was pending was
absorbed entirely, so a tab that woke one second into an 8 s (up to 9.6 s with
jitter) wait stayed dark for the rest of it.

A pending retry more than a second away is now rescheduled to now; timers about
to fire are left alone so a burst of wakes cannot churn sources. `attempts` is
deliberately **not** reset — the backoff is pulled forward, not collapsed, so a
wake still cannot drag the retry rate back to the 500 ms floor (only a user's
tap does). No other supervisor semantics change.

## Verification
- `pnpm exec vitest run` — 46 files, 878 tests pass (new: `terminal-resize`
  grid-refusal cases, `day-boundary.test.ts`, two supervisor wake cases)
- `pnpm exec tsc --noEmit`, Biome check on touched files
- Playwright (isolated daemon, `TMPDIR` scoped): `terminal-resize`,
  `terminal-reattach-geometry`, `initial-checkpoint-geometry`,
  `terminal-claim-retry`, `reconnect-stability` — all pass
- `./scripts/build.sh`
- Mutation checks: dropping the grid guard fails 2 resize tests; a no-op
  midnight timer fails 2 day-boundary tests; absorbing the wake, collapsing the
  backoff, or rescheduling unconditionally each fail a supervisor test