### PR TITLE
fix(gmuxd,build): patch-release polish — bounded scan guard, diagnostic dev version

### DIFF
--- a/cli/gmux/cmd/gmux/daemon.go
+++ b/cli/gmux/cmd/gmux/daemon.go
@@ -16,6 +16,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/gmuxapp/gmux/packages/buildversion"
 	"github.com/gmuxapp/gmux/packages/paths"
 	"github.com/gmuxapp/gmux/packages/sessionenv"
 )
@@ -91,9 +92,11 @@ func gmuxdNeedsStartContext(ctx context.Context) bool {
 		return true
 	}
 
-	// "dev" builds never replace — avoids churn during development and needs
-	// no identity response once socket ownership is established.
-	if version == "dev" {
+	// Development builds never replace — avoids churn during development and
+	// needs no identity response once socket ownership is established. A source
+	// install stamps "dev+<hash>", which is still a development build: rebuilding
+	// must not start replacing the running daemon on every hash change.
+	if buildversion.IsDev(version) {
 		return false
 	}
 

--- a/cli/gmux/cmd/gmux/main.go
+++ b/cli/gmux/cmd/gmux/main.go
@@ -16,6 +16,8 @@ import (
 // Falls back to "dev" for local builds.
 var version = "dev"
 
+
+
 func main() {
 	if len(os.Args) > 2 && os.Args[1] == "__detached-target" {
 		os.Exit(runDetachedTarget(os.Args[2:]))

--- a/cli/gmux/cmd/gmux/main_test.go
+++ b/cli/gmux/cmd/gmux/main_test.go
@@ -286,3 +286,21 @@ func TestParseHealthField(t *testing.T) {
 		t.Errorf("nonexistent = %q, want empty", got)
 	}
 }
+
+// A source install stamps "dev+<hash>" (see scripts/build.sh). It is still a
+// development build: rebuilding must not make every gmux invocation replace
+// the running daemon because the hash moved.
+func TestGmuxdNeedsStart_StampedDevNeverReplaces(t *testing.T) {
+	old := version
+	version = "dev+1a2b3c4d5e6f-dirty"
+	defer func() { version = old }()
+
+	stateDir, cleanup := startTestSocketDaemon(t, "0.4.3")
+	defer cleanup()
+	t.Setenv("XDG_STATE_HOME", stateDir)
+
+	if gmuxdNeedsStart() {
+		t.Error("a stamped dev build must not replace a healthy daemon")
+	}
+}
+

--- a/go.work
+++ b/go.work
@@ -5,6 +5,7 @@ toolchain go1.26.1
 use (
 	./cli/gmux
 	./packages/adapter
+	./packages/buildversion
 	./packages/paths
 	./packages/scrollback
 	./packages/socklease

--- a/packages/buildversion/buildversion.go
+++ b/packages/buildversion/buildversion.go
@@ -1,0 +1,34 @@
+// Package buildversion answers one question about the version string that
+// -ldflags stamps into gmux and gmuxd: did this binary come from a working
+// tree, or from a release?
+//
+// It lives in a shared package because the answer drives policy in three
+// separate places — the CLI's daemon autostart, gmuxd's incumbent/takeover
+// check, and the update checker — and three copies of the predicate would
+// drift. A drifting copy is not cosmetic: gmuxd decides whether to shut a
+// healthy daemon down by comparing versions.
+package buildversion
+
+import "strings"
+
+// Dev is the version a build carries when nothing stamped it.
+const Dev = "dev"
+
+// IsDev reports whether a version denotes a development build.
+//
+// scripts/build.sh stamps source builds "dev+<short hash>" (optionally
+// "-dirty") so a local install can say which tree it came from. Those hashes
+// move on every rebuild, so anything that treats "dev" as "not a release" —
+// and in particular anything that compares two versions for equality to decide
+// whether to replace a running daemon — must treat every dev+ stamp as the
+// same kind of build.
+func IsDev(v string) bool {
+	return v == Dev || strings.HasPrefix(v, Dev+"+")
+}
+
+// SameBuildClass reports whether two version strings should be treated as the
+// same daemon version for replacement decisions: either they are identical, or
+// both are development builds (whose hashes differ per rebuild).
+func SameBuildClass(a, b string) bool {
+	return a == b || (IsDev(a) && IsDev(b))
+}

--- a/packages/buildversion/buildversion_test.go
+++ b/packages/buildversion/buildversion_test.go
@@ -1,0 +1,42 @@
+package buildversion
+
+import "testing"
+
+func TestIsDev(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want bool
+	}{
+		{"dev", true},
+		{"dev+1a2b3c4d5e6f", true},
+		{"dev+1a2b3c4d5e6f-dirty", true},
+		{"v2.1.1", false},
+		{"2.1.2-snapshot-abcdef", false},
+		{"", false},
+		{"development", false},
+		{"devel", false},
+	} {
+		if got := IsDev(tc.in); got != tc.want {
+			t.Errorf("IsDev(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestSameBuildClass(t *testing.T) {
+	for _, tc := range []struct {
+		a, b string
+		want bool
+	}{
+		{"dev", "dev", true},
+		{"dev+aaaaaaaaaaaa", "dev+bbbbbbbbbbbb", true},   // rebuild, same class
+		{"dev", "dev+aaaaaaaaaaaa-dirty", true},          // stamped vs unstamped
+		{"v2.1.1", "v2.1.1", true},
+		{"v2.1.1", "v2.1.0", false},                      // real upgrade
+		{"dev+aaaaaaaaaaaa", "v2.1.1", false},            // dev vs release
+		{"v2.1.1", "dev", false},
+	} {
+		if got := SameBuildClass(tc.a, tc.b); got != tc.want {
+			t.Errorf("SameBuildClass(%q, %q) = %v, want %v", tc.a, tc.b, got, tc.want)
+		}
+	}
+}

--- a/packages/buildversion/go.mod
+++ b/packages/buildversion/go.mod
@@ -1,0 +1,5 @@
+module github.com/gmuxapp/gmux/packages/buildversion
+
+go 1.26.1
+
+toolchain go1.26.1

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -19,12 +19,72 @@ if ! GO_VERSION="$(go version 2>&1)"; then
 fi
 echo "→ Using $GO_VERSION"
 
+# ── Version stamp ──
+#
+# Real releases come from GoReleaser, which never runs this script and passes
+# the tag through -ldflags itself. Everything this script builds is a source
+# build, and stamping every one of them "dev" makes `gmux --version` and
+# /v1/health useless for the one question they get asked on a local install:
+# *which tree is this binary from?* So derive a cheap, diagnostic stamp from
+# the VCS: dev+<short hash>[-dirty], falling back to plain "dev" outside a
+# checkout. Everything that treats "dev" as "not a release" (the daemon
+# replacement policy, the update checker) recognises the dev+ prefix too.
+#
+# Exported, not just passed to `go build`: vite bakes VERSION into the bundle
+# as __GMUX_VERSION__, and a bundle whose version disagrees with the daemon's
+# makes the tab think it is permanently stale (see version-watch.ts).
+dev_version() {
+  local hash
+  # git first, and not by accident: it is the only read-only source that can
+  # also report *dirtiness*. This repo is colocated (.git and .jj), and jj keeps
+  # git HEAD current, so the git answer is the same commit with a usable marker.
+  # The `-e $ROOT/.git` test matters: inside a secondary jj workspace (a grove)
+  # there is no .git of its own, and git would happily answer with the *parent*
+  # repository's HEAD, which is a different tree.
+  if [ -e "$ROOT/.git" ] && command -v git >/dev/null 2>&1 \
+    && hash="$(git -C "$ROOT" rev-parse --short=12 HEAD 2>/dev/null)" \
+    && [ -n "$hash" ]; then
+    if [ -n "$(git -C "$ROOT" status --porcelain 2>/dev/null)" ]; then
+      echo "dev+$hash-dirty"
+    else
+      echo "dev+$hash"
+    fi
+    return
+  fi
+  # jj-only checkout (e.g. a `jj workspace`/grove with no .git of its own).
+  # --ignore-working-copy keeps the build read-only: it must not take the repo
+  # lock or write a snapshot. The cost is that the stamp names the tree as of
+  # the last jj command and can never say -dirty, so it is marked approximate
+  # with a trailing '~' rather than claiming precision it does not have.
+  if command -v jj >/dev/null 2>&1 \
+    && hash="$(jj --repository "$ROOT" --ignore-working-copy log --no-graph --color never \
+         -r @ -T 'commit_id.short(12)' 2>/dev/null)" \
+    && [ -n "$hash" ]; then
+    echo "dev+$hash~"
+    return
+  fi
+  echo "dev"
+}
+
 skip_frontend=false
 for arg in "$@"; do
   case "$arg" in
     --skip-frontend) skip_frontend=true ;;
   esac
 done
+
+# The stamp the currently embedded bundle was built with. A --skip-frontend
+# build must reuse it: the daemon serves that bundle, and version-watch turns
+# any bundle/daemon disagreement into a forced full page load on the next
+# in-app navigation (one lost SPA state per tab, per daemon-only rebuild).
+EMBED_STAMP="$BIN/.web-version"
+if [ -z "${VERSION:-}" ] && [ "$skip_frontend" = true ] && [ -s "$EMBED_STAMP" ]; then
+  VERSION="$(cat "$EMBED_STAMP")"
+fi
+
+VERSION="${VERSION:-$(dev_version)}"
+export VERSION
+echo "→ Stamping version $VERSION"
 
 mkdir -p "$BIN"
 
@@ -37,12 +97,15 @@ if [ "$skip_frontend" = false ]; then
   # Copy dist into the go:embed directory
   rm -rf "$WEB_EMBED/assets" "$WEB_EMBED/favicon.svg" "$WEB_EMBED/manifest.json"
   cp -r "$ROOT/apps/gmux-web/dist/"* "$WEB_EMBED/"
+  # Record what the embedded bundle reports as its version, so a later
+  # --skip-frontend build can stamp the daemon to match it. Kept next to the
+  # binaries, not inside the embed dir (which is embedded with `all:`).
+  printf '%s' "$VERSION" > "$EMBED_STAMP"
   echo "  Embedded $(du -sh "$WEB_EMBED" | cut -f1) of frontend assets"
 fi
 
 # ── Go binaries ──
 
-VERSION="${VERSION:-dev}"
 LDFLAGS_COMMON="-s -w -X main.version=$VERSION"
 export CGO_ENABLED=0
 

--- a/services/gmuxd/cmd/gmuxd/serve_central.go
+++ b/services/gmuxd/cmd/gmuxd/serve_central.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/gmuxapp/gmux/packages/adapter"
 	"github.com/gmuxapp/gmux/packages/adapter/adapters"
+	"github.com/gmuxapp/gmux/packages/buildversion"
 	"github.com/gmuxapp/gmux/packages/paths"
 	"github.com/gmuxapp/gmux/packages/scrollback"
 	"github.com/gmuxapp/gmux/services/gmuxd/internal/authtoken"
@@ -67,10 +68,22 @@ func implicitIncumbentCheck(sock string) error {
 	if !ok {
 		return fmt.Errorf("%w: socket owner with unavailable identity owns %s", errIncumbentHealthy, sock)
 	}
-	if ident.Version == version {
+	if sameDaemonBuild(ident.Version) {
 		return fmt.Errorf("%w: healthy daemon %s (pid %d) owns %s", errIncumbentHealthy, ident.Version, ident.PID, sock)
 	}
 	return nil
+}
+
+// sameDaemonBuild decides whether an incumbent counts as "same version" for the
+// implicit-replacement policy. Exact equality is not enough since source builds
+// carry a per-tree stamp (dev+<hash>, see scripts/build.sh): two rebuilds of the
+// same working tree would otherwise look like a version upgrade to each other,
+// and `gmuxd run` — the documented systemd/Docker/debug entry point — would
+// silently shut a healthy daemon down without --replace, in either direction.
+// Development builds are therefore one class; only a real version difference
+// earns an implicit takeover.
+func sameDaemonBuild(incumbent string) bool {
+	return buildversion.SameBuildClass(incumbent, version)
 }
 
 // registerGetProjectsRoute installs the production GET /v1/projects handler.
@@ -184,7 +197,7 @@ func serveCentral(stderr io.Writer, replace bool) int {
 			return nil
 		}
 		ident, identityOK := unixipc.HealthIdentity(sock)
-		if !replace && (!identityOK || ident.Version == version) {
+		if !replace && (!identityOK || sameDaemonBuild(ident.Version)) {
 			if !identityOK {
 				return fmt.Errorf("%w: socket owner with unavailable identity owns %s", errIncumbentHealthy, sock)
 			}

--- a/services/gmuxd/cmd/gmuxd/serve_takeover_policy_test.go
+++ b/services/gmuxd/cmd/gmuxd/serve_takeover_policy_test.go
@@ -2,11 +2,13 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -142,5 +144,72 @@ func TestServeRefusesToReplaceHealthySameVersionIncumbent(t *testing.T) {
 	case <-replacer:
 	case <-time.After(10 * time.Second):
 		t.Fatal("replacement daemon did not exit after shutdown")
+	}
+}
+
+// Source builds carry a per-tree stamp (dev+<hash>), so two rebuilds of the
+// same tree are *different strings* while still being the same kind of build.
+// Before the stamp existed, every source daemon said "dev" and implicit
+// replacement was unreachable here; with it, plain string equality would let a
+// bare `gmuxd run` shut a healthy incumbent down without --replace — in either
+// direction, since an older tree can carry the newer hash. Both directions and
+// the mixed stamped/unstamped case must yield instead.
+func TestImplicitIncumbentCheckTreatsDevStampsAsOneVersion(t *testing.T) {
+	cases := []struct {
+		name            string
+		mine, incumbent string
+		wantYield       bool
+	}{
+		{"different dev stamps", "dev+aaaaaaaaaaaa", "dev+bbbbbbbbbbbb", true},
+		{"reverse direction", "dev+bbbbbbbbbbbb", "dev+aaaaaaaaaaaa", true},
+		{"stamped vs unstamped", "dev+aaaaaaaaaaaa", "dev", true},
+		{"dirty stamp", "dev+aaaaaaaaaaaa", "dev+aaaaaaaaaaaa-dirty", true},
+		{"same release", "v2.1.1", "v2.1.1", true},
+		{"real version difference", "v2.1.1", "v2.1.0", false},
+		{"release vs dev", "v2.1.1", "dev+aaaaaaaaaaaa", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			old := version
+			version = tc.mine
+			defer func() { version = old }()
+
+			base := t.TempDir()
+			for _, dir := range []string{"state", "home", "run"} {
+				if err := os.MkdirAll(filepath.Join(base, dir), 0o700); err != nil {
+					t.Fatal(err)
+				}
+			}
+			t.Setenv("HOME", filepath.Join(base, "home"))
+			t.Setenv("XDG_STATE_HOME", filepath.Join(base, "state"))
+			t.Setenv("GMUX_SOCKET_DIR", filepath.Join(base, "run"))
+			sock := paths.SocketPath()
+			if !strings.HasPrefix(sock, base) {
+				t.Fatalf("socket path escaped the test sandbox: %s", sock)
+			}
+			ln, err := unixipc.Listen(sock)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer ln.Close()
+			srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"data": map[string]any{"version": tc.incumbent, "pid": 4242},
+				})
+			})}
+			go srv.Serve(ln)
+			defer srv.Close()
+
+			err = implicitIncumbentCheck(sock)
+			if tc.wantYield && err == nil {
+				t.Fatalf("challenger %s replaced healthy incumbent %s without --replace", tc.mine, tc.incumbent)
+			}
+			if !tc.wantYield && err != nil {
+				t.Fatalf("challenger %s refused to replace incumbent %s: %v", tc.mine, tc.incumbent, err)
+			}
+			if tc.wantYield && !errors.Is(err, errIncumbentHealthy) {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
 	}
 }

--- a/services/gmuxd/internal/conversations/index.go
+++ b/services/gmuxd/internal/conversations/index.go
@@ -21,6 +21,14 @@ import (
 	"github.com/gmuxapp/gmux/packages/adapter"
 )
 
+// refScan is the guard state for a ref with at least one Scan in flight:
+// how many are running, and how many removals landed since the entry was
+// created. A scan commits only if `gen` still matches what it snapshotted.
+type refScan struct {
+	pending int
+	gen     uint64
+}
+
 // Info holds metadata for a single stored conversation.
 type Info struct {
 	ConversationID string    // adapter-native conversation ID (typically a UUID)
@@ -49,13 +57,20 @@ type Index struct {
 	// conversation source is indexing the ref. Rendering the session list is
 	// a hot read path and must not re-read every dead conversation transcript.
 	resumeByRef map[string][]string
-	// removeGen counts Remove/RemoveByRef events per (adapter, ref). Scan
-	// snapshots it before its unlocked DescribeConversation and commits only
-	// if it is unchanged, so a watcher-observed deletion always beats an
-	// in-flight scan of the same ref — otherwise the scan's late Upsert would
-	// resurrect the deleted conversation until restart (zombie). The map only
-	// grows on removal events (manual rm, rotation), which are rare.
-	removeGen map[string]uint64
+	// scanning tracks per-(adapter, ref) in-flight Scans and the removal
+	// generation observed while they run. Scan snapshots the generation before
+	// its unlocked DescribeConversation and commits only if it is unchanged,
+	// so a watcher-observed deletion always beats an in-flight scan of the same
+	// ref — otherwise the scan's late Upsert would resurrect the deleted
+	// conversation until restart (zombie).
+	//
+	// The entry exists only while at least one scan of that ref is in flight,
+	// which is exactly the window the guard covers: a removal with no scan
+	// pending has nothing to invalidate (any later scan starts *after* it and
+	// re-reads the world), and the last scan to settle drops the entry. So the
+	// map is bounded by concurrent scans instead of growing once per removal
+	// event for the daemon's lifetime.
+	scanning map[string]refScan
 	// snapshotDone flips to true once the initial full snapshot of every
 	// adapter ConversationSource has finished (Snapshot or StartSnapshot).
 	// Until then, a lookup miss means "not indexed yet", not "absent".
@@ -68,7 +83,7 @@ func New() *Index {
 		byKey:            make(map[string]Info),
 		byConversationID: make(map[string]string),
 		resumeByRef:      make(map[string][]string),
-		removeGen:        make(map[string]uint64),
+		scanning:         make(map[string]refScan),
 	}
 }
 
@@ -242,16 +257,19 @@ func (idx *Index) Scan(a adapter.Adapter, ref string) string {
 		return ""
 	}
 
-	// Snapshot the ref's removal generation before the unlocked describe:
-	// a Remove event that lands while the file is being read/parsed must
-	// win over this scan's results (commitScanLocked re-checks it).
-	gen := idx.refGeneration(a.Name(), ref)
+	// Register the scan and snapshot the ref's removal generation before the
+	// unlocked describe: a Remove event that lands while the file is being
+	// read/parsed must win over this scan's results (the commit re-checks it).
+	gen := idx.beginScan(a.Name(), ref)
 
 	convInfo, err := desc.DescribeConversation(ref)
 	if err != nil {
 		// Keep stale-good state on transient descriptor failures, matching the
 		// main metadata index. A source Remove event is the authoritative
 		// signal that clears both entries.
+		idx.mu.Lock()
+		idx.endScanLocked(a.Name(), ref)
+		idx.mu.Unlock()
 		return ""
 	}
 
@@ -290,7 +308,10 @@ func (idx *Index) Scan(a adapter.Adapter, ref string) string {
 
 	idx.mu.Lock()
 	defer idx.mu.Unlock()
-	if idx.removeGen[refKey(a.Name(), ref)] != gen {
+	// Settle the scan under the same lock hold as the check it guards, so the
+	// entry survives exactly as long as it can still invalidate something.
+	defer idx.endScanLocked(a.Name(), ref)
+	if idx.scanning[refKey(a.Name(), ref)].gen != gen {
 		// The ref was removed while this scan was describing it; the removal
 		// is authoritative. Committing anyway would resurrect a deleted
 		// conversation with no future event to clear it.
@@ -308,11 +329,46 @@ func (idx *Index) Scan(a adapter.Adapter, ref string) string {
 	return idx.upsertLocked(info)
 }
 
-// refGeneration returns the current removal generation for (adapter, ref).
-func (idx *Index) refGeneration(adapterName, ref string) uint64 {
-	idx.mu.RLock()
-	defer idx.mu.RUnlock()
-	return idx.removeGen[refKey(adapterName, ref)]
+// beginScan registers an in-flight scan of (adapter, ref) and returns the
+// removal generation it must still observe at commit time.
+func (idx *Index) beginScan(adapterName, ref string) uint64 {
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
+	rk := refKey(adapterName, ref)
+	state := idx.scanning[rk]
+	state.pending++
+	idx.scanning[rk] = state
+	return state.gen
+}
+
+// endScanLocked retires one in-flight scan of (adapter, ref), dropping the
+// guard entry once none remain. Must be called with idx.mu held (write).
+func (idx *Index) endScanLocked(adapterName, ref string) {
+	rk := refKey(adapterName, ref)
+	state, ok := idx.scanning[rk]
+	if !ok {
+		return
+	}
+	state.pending--
+	if state.pending <= 0 {
+		delete(idx.scanning, rk)
+		return
+	}
+	idx.scanning[rk] = state
+}
+
+// noteRemovalLocked invalidates any scan of (adapter, ref) that is already in
+// flight. A removal with no scan pending needs no record: a scan starting
+// afterwards re-reads the world and so cannot be stale. Must be called with
+// idx.mu held (write).
+func (idx *Index) noteRemovalLocked(adapterName, ref string) {
+	rk := refKey(adapterName, ref)
+	state, ok := idx.scanning[rk]
+	if !ok {
+		return
+	}
+	state.gen++
+	idx.scanning[rk] = state
 }
 
 // Remove deletes a conversation from the index by conversation ID.
@@ -328,7 +384,7 @@ func (idx *Index) Remove(adapterName, conversationID string) bool {
 	delete(idx.byConversationID, tk)
 	if info, exists := idx.byKey[indexKey(adapterName, key)]; exists {
 		delete(idx.resumeByRef, refKey(adapterName, info.Ref))
-		idx.removeGen[refKey(adapterName, info.Ref)]++
+		idx.noteRemovalLocked(adapterName, info.Ref)
 	}
 	delete(idx.byKey, indexKey(adapterName, key))
 	return true
@@ -350,10 +406,10 @@ func (idx *Index) Remove(adapterName, conversationID string) bool {
 func (idx *Index) RemoveByRef(adapterName, ref string) bool {
 	idx.mu.Lock()
 	defer idx.mu.Unlock()
-	// Bump the removal generation even when nothing is indexed yet: the
-	// entry may be mid-scan (describe in flight), and that scan's commit
-	// must observe this removal and drop its result.
-	idx.removeGen[refKey(adapterName, ref)]++
+	// Invalidate even when nothing is indexed yet: the entry may be mid-scan
+	// (describe in flight), and that scan's commit must observe this removal
+	// and drop its result.
+	idx.noteRemovalLocked(adapterName, ref)
 	delete(idx.resumeByRef, refKey(adapterName, ref))
 	for key, info := range idx.byKey {
 		if info.Adapter != adapterName || info.Ref != ref {

--- a/services/gmuxd/internal/conversations/index_scan_guard_test.go
+++ b/services/gmuxd/internal/conversations/index_scan_guard_test.go
@@ -1,0 +1,163 @@
+package conversations
+
+import (
+	"errors"
+	"strconv"
+	"testing"
+
+	"github.com/gmuxapp/gmux/packages/adapter"
+)
+
+// errAdapter describes nothing: the guard must be retired on the failure path
+// too, or a transiently unreadable ref would leak an entry per attempt.
+type errAdapter struct{ *fakeConvAdapter }
+
+func (errAdapter) DescribeConversation(string) (*adapter.ConversationInfo, error) {
+	return nil, errors.New("boom")
+}
+
+// The scan guard is a *window*, not a ledger: it exists while a Scan of that
+// ref is in flight and disappears once the last one settles. Before this, the
+// per-ref generation map only ever grew — every removal event (manual rm, log
+// rotation, a conversation deleted by its tool) left an entry behind for the
+// daemon's lifetime.
+func TestScanGuardIsPrunedWhenWorkSettles(t *testing.T) {
+	const ref = "conv-1|Some Title|/tmp/x"
+	idx := New()
+	a := &fakeConvAdapter{name: "probe"}
+
+	if key := idx.Scan(a, ref); key == "" {
+		t.Fatal("scan failed")
+	}
+	if n := len(idx.scanning); n != 0 {
+		t.Fatalf("guard entry survived a settled scan: %d entr(ies)", n)
+	}
+
+	// Removals with no scan in flight record nothing: a scan starting after a
+	// removal re-reads the world, so there is nothing to invalidate.
+	for i := 0; i < 100; i++ {
+		idx.RemoveByRef("probe", ref)
+		idx.Remove("probe", "conv-1")
+		if key := idx.Scan(a, ref); key == "" {
+			t.Fatalf("rescan %d refused to index a re-created conversation", i)
+		}
+	}
+	if n := len(idx.scanning); n != 0 {
+		t.Fatalf("guard grew across %d remove/scan cycles: %d entr(ies)", 100, n)
+	}
+
+	// Describe failures keep stale-good state and must not leak a guard entry.
+	failing := errAdapter{&fakeConvAdapter{name: "probe"}}
+	for i := 0; i < 10; i++ {
+		if key := idx.Scan(failing, "missing|x|/tmp/x"); key != "" {
+			t.Fatalf("failed describe indexed key %q", key)
+		}
+	}
+	if n := len(idx.scanning); n != 0 {
+		t.Fatalf("guard grew across failed describes: %d entr(ies)", n)
+	}
+}
+
+// The property the change exists for, isolated: removals *alone* — the actual
+// unbounded-growth workload (log rotation, a tool pruning old conversations,
+// `rm` in a watched directory), where no scan of the ref follows — must leave
+// nothing behind. The settle-based test above cannot see this: every removal
+// there is followed by a Scan whose commit deletes the entry anyway.
+func TestRemovalsWithoutScansRecordNothing(t *testing.T) {
+	idx := New()
+	a := &fakeConvAdapter{name: "probe"}
+
+	// Index one conversation, then delete it by ID and by ref, repeatedly, plus
+	// removals of refs that were never indexed at all.
+	if key := idx.Scan(a, "conv-1|Some Title|/tmp/x"); key == "" {
+		t.Fatal("scan failed")
+	}
+	idx.Remove("probe", "conv-1")
+	for i := 0; i < 500; i++ {
+		ref := "rotated-" + strconv.Itoa(i) + "|Title|/tmp/x"
+		idx.RemoveByRef("probe", ref)
+		idx.Remove("probe", "rotated-"+strconv.Itoa(i))
+	}
+	if n := len(idx.scanning); n != 0 {
+		t.Fatalf("removal-only workload left %d guard entr(ies)", n)
+	}
+}
+
+// A removal landing mid-scan must still invalidate that scan (the #517 zombie
+// guarantee), and the entry must be gone once the scan settles.
+func TestScanGuardPrunedAfterInvalidatingAnInFlightScan(t *testing.T) {
+	const ref = "conv-1|Some Title|/tmp/x"
+	idx := New()
+	gated := &fakeConvAdapter{
+		name:            "probe",
+		describeStarted: make(chan string, 1),
+		describeGate:    make(chan struct{}),
+	}
+	done := make(chan string)
+	go func() { done <- idx.Scan(gated, ref) }()
+	<-gated.describeStarted
+
+	idx.mu.RLock()
+	pending := len(idx.scanning)
+	idx.mu.RUnlock()
+	if pending != 1 {
+		t.Fatalf("in-flight scan is not tracked: %d entr(ies)", pending)
+	}
+
+	idx.RemoveByRef("probe", ref)
+	close(gated.describeGate)
+	if key := <-done; key != "" {
+		t.Fatalf("zombie: scan committed key %q after the ref was removed", key)
+	}
+	if n := len(idx.scanning); n != 0 {
+		t.Fatalf("guard entry survived the invalidated scan: %d entr(ies)", n)
+	}
+
+	// The generation restarts from zero for this ref, which is only sound
+	// because the entry is created fresh per scan window: a later scan snapshots
+	// and re-checks the *same* entry it created.
+	if key := idx.Scan(&fakeConvAdapter{name: "probe"}, ref); key == "" {
+		t.Fatal("post-removal rescan refused to index a re-created conversation")
+	}
+	if n := len(idx.scanning); n != 0 {
+		t.Fatalf("guard entry survived the rescan: %d entr(ies)", n)
+	}
+}
+
+// Two concurrent scans of the same ref share one entry; it is dropped only
+// after the second one settles.
+func TestScanGuardCountsConcurrentScans(t *testing.T) {
+	const ref = "conv-1|Some Title|/tmp/x"
+	idx := New()
+	gates := []*fakeConvAdapter{
+		{name: "probe", describeStarted: make(chan string, 1), describeGate: make(chan struct{})},
+		{name: "probe", describeStarted: make(chan string, 1), describeGate: make(chan struct{})},
+	}
+	done := make(chan string, 2)
+	for _, g := range gates {
+		go func() { done <- idx.Scan(g, ref) }()
+		<-g.describeStarted
+	}
+
+	idx.mu.RLock()
+	state := idx.scanning[refKey("probe", ref)]
+	idx.mu.RUnlock()
+	if state.pending != 2 {
+		t.Fatalf("pending scans = %d, want 2", state.pending)
+	}
+
+	close(gates[0].describeGate)
+	<-done
+	idx.mu.RLock()
+	state = idx.scanning[refKey("probe", ref)]
+	idx.mu.RUnlock()
+	if state.pending != 1 {
+		t.Fatalf("guard retired too early: pending = %d, want 1", state.pending)
+	}
+
+	close(gates[1].describeGate)
+	<-done
+	if n := len(idx.scanning); n != 0 {
+		t.Fatalf("guard entry survived both scans: %d entr(ies)", n)
+	}
+}

--- a/services/gmuxd/internal/update/update.go
+++ b/services/gmuxd/internal/update/update.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/gmuxapp/gmux/packages/buildversion"
 )
 
 const (
@@ -27,13 +29,14 @@ type Checker struct {
 }
 
 // New starts a background checker. current is the running version (e.g. "v0.4.6").
-// If current is "dev", the checker does nothing.
+// If current is a development version the checker does nothing: no goroutine,
+// no network.
 func New(current string) *Checker {
 	c := &Checker{
 		current: current,
 		client:  &http.Client{Timeout: 10 * time.Second},
 	}
-	if current == "dev" {
+	if buildversion.IsDev(current) {
 		return c
 	}
 	go c.loop()

--- a/services/gmuxd/internal/update/update_test.go
+++ b/services/gmuxd/internal/update/update_test.go
@@ -43,3 +43,16 @@ func TestParseSemver(t *testing.T) {
 		}
 	}
 }
+
+// The update checker must stay silent — and offline — for every build that
+// came from a working tree, including the stamped "dev+<hash>" a source
+// install produces (scripts/build.sh).
+func TestDevBuildsNeverCheckForUpdates(t *testing.T) {
+	// The predicate itself lives in packages/buildversion (one copy for the
+	// three policies that key off it); pin the behaviour here.
+	for _, v := range []string{"dev", "dev+1a2b3c4d5e6f", "dev+1a2b3c4d5e6f-dirty"} {
+		if c := New(v); c.Available() != "" {
+			t.Errorf("dev build %q reported an available update: %q", v, c.Available())
+		}
+	}
+}


### PR DESCRIPTION
Two small daemon/scripts fixes for v2.1.1, plus the disposition of a third
reported item that does not reproduce on `main`.

## 1. Bound the conversation scan guard to in-flight work
`conversations.Index` guards a `Scan`'s late commit with a per-`(adapter, ref)`
removal generation (#517's zombie guarantee). The map was only ever written:
every `Remove`/`RemoveByRef` — manual `rm`, log rotation, a tool deleting a
conversation — left an entry behind for the daemon's lifetime.

It is now a *window* rather than a ledger: created when a `Scan` of that ref
starts, carrying the removals seen while that scan runs, dropped when the last
in-flight scan settles (including the describe-failure path). The staleness
guarantee is unchanged, because that window is exactly when a removal has
something to invalidate — a removal with no scan pending needs no record, since
any scan starting afterwards re-reads the world.

Tests: prune-after-settle, prune-after-invalidating-an-in-flight-scan,
concurrent scans share one entry, describe failures leak nothing.

## 2. Stamp source builds with a diagnostic dev version
`scripts/build.sh` defaulted `VERSION=dev` and `scripts/install.sh` never set
it, so a locally installed gmux/gmuxd answered `dev` to `--version` and
`/v1/health` — the one question those surfaces get asked on a source install.

Now: `dev+<short hash>` (`-dirty` on the git path), falling back to plain `dev`
outside a checkout. The jj lookup runs `--ignore-working-copy`, so a build stays
read-only: no repo lock, no snapshot. `VERSION` is exported *before* the vite
build so bundle and daemon agree — otherwise `version-watch` would think the tab
is permanently stale.

GoReleaser's real-version path is untouched (it never runs this script), and the
health/version wire surface is unchanged: still a free-form string.

`dev+…` is still a development build, so the two policies keyed off `"dev"` now
recognise the prefix: `gmux` does not start replacing a healthy daemon because a
rebuild moved the hash, and the update checker stays offline and silent.

## 3. Reported "reparent visibility leak" — not present on `main`
The report was that `case "reparent"` in `serve_central.go` computes
`visibleSession(...)` without consulting `ok`, letting a reparent event reach a
client that cannot see the session. Verified against `main`:

- `case "reparent"` emits no event at all; it validates the body and calls
  `Coordinator.SetSessionParent`, which returns `ErrSessionNotFound` → 404 for a
  session that is not in the store.
- Every per-session emission on `/v1/events` is already filtered for the
  subscriber's class: `snapshot.sessions` encodes through
  `SessionsPayload.FilterOwned` (`sessionEncodeMemo.payloadForLocked`), and
  `session-activity` is gated by `shouldForwardActivity`. There is no third
  per-session event.
- The one `ok` consumer in that switch is `scrollback`, and the reparent
  contract is deliberately snapshot-blind (ADR 0026 §2a): the existing
  `TestSessionReparentHTTPValidation` drives the handler with an *empty* fanout
  and requires 200. Gating reparent on `visibleSession` would regress that.

No code change; recorded here so the item is closed with its evidence.

## Verification
- `go test -race` — `services/gmuxd/internal/conversations`,
  `services/gmuxd/internal/update`, `services/gmuxd/cmd/gmuxd`,
  `cli/gmux/cmd/gmux`: all pass
- Mutation checks: never-pruning, pruning before the guard check, and a removal
  that does not invalidate an in-flight scan each fail the new/existing tests;
  narrowing `isDevVersion`/`IsDevVersion` back to `== "dev"` fails both the
  table test and the daemon-replacement test
- `./scripts/build.sh` (stamped `dev+<hash>`, bundle and daemon agree),
  `VERSION=v9.9.9` override still wins, VCS-less and git-only fallbacks probed
- Playwright on an isolated daemon: `no-external-network`, `harness`,
  `conversation-discovery`
- Drift guard: `TestPiSubcommandsMatchHelp` and
  `TestPiCommandsWithExtensionInjected` against the installed `pi`